### PR TITLE
fix(infra): SPEC-DEVOPS-002 — TEI/Infinity split herstel + monitoring fix

### DIFF
--- a/.claude/rules/klai/pitfalls/process.md
+++ b/.claude/rules/klai/pitfalls/process.md
@@ -24,6 +24,7 @@
 | [process-no-prompt-files](#process-no-prompt-files) | HIGH | Output prompts in chat, never write to markdown files |
 | [process-spec-stub-deps-premature](#process-spec-stub-deps-premature) | HIGH | Comment out new deps at stub time; enable in `/run` |
 | [process-test-cache-two-level-dispatch](#process-test-cache-two-level-dispatch) | MED | Dispatch by key prefix in multi-key cache mocks |
+| [process-no-architecture-change-in-migration](#process-no-architecture-change-in-migration) | CRIT | During migrations, move services as-is — never consolidate or replace without explicit approval |
 
 ---
 
@@ -384,6 +385,30 @@ cache.async_get_cache = AsyncMock(side_effect=_get)
 **Rule:** When testing two-level caches, always dispatch by key prefix in the mock, not by a single return value.
 
 **Source:** SPEC-KB-013 (two-level version cache: `kb_ver:` + `kb_feature:`)
+
+---
+
+## process-no-architecture-change-in-migration
+
+**Severity:** CRIT
+
+**Trigger:** Migrating services from one server to another (e.g. moving GPU workloads from core-01 to gpu-01)
+
+During a migration, move services **exactly as they are**. Never consolidate, replace, or redesign services as part of the same task — even if it seems like an obvious improvement.
+
+**What happened:** During SPEC-GPU-001, an agent replaced two separate services (TEI for embeddings + Infinity for reranking) with a single consolidated Infinity instance. This was done without explicit user approval and turned out to be architecturally wrong: Infinity has a known GPU memory leak (issue #517) and no Prometheus metrics, making it unsuitable as the sole embedding service. The decision was discovered by the user only after the fact.
+
+**What NOT to do:**
+- Replace `tei` + `infinity-reranker` with a single `infinity` instance during a move
+- Change API formats, consolidate services, or swap implementations mid-migration
+- Mark a migration SPEC as complete when architectural decisions were made unilaterally
+
+**What to do:**
+1. Move services to the new server with identical configuration
+2. Verify everything works identically on the new server
+3. Only then propose architectural improvements as a **separate, explicitly approved task**
+
+**Rule:** A migration task has one goal — same services, different server. Any architectural change requires its own SPEC and explicit user approval.
 
 ---
 

--- a/.moai/specs/SPEC-DEVOPS-002/acceptance.md
+++ b/.moai/specs/SPEC-DEVOPS-002/acceptance.md
@@ -1,0 +1,229 @@
+---
+id: SPEC-DEVOPS-002
+version: 1.0.0
+status: draft
+created: 2026-03-30
+updated: 2026-03-30
+author: MoAI
+priority: high
+---
+
+# Acceptatiecriteria: SPEC-DEVOPS-002 -- GPU-01 TEI + Infinity Split Herstellen
+
+## HISTORY
+
+| Versie | Datum      | Auteur | Wijziging                |
+|--------|------------|--------|--------------------------|
+| 1.0.0  | 2026-03-30 | MoAI   | Initieel document        |
+
+---
+
+## Module 1: GPU-01 Service Herconfiguratie
+
+### AC-GPU-001: TEI service draait op poort 7997
+
+**Given** gpu-01 Docker Compose stack is geconfigureerd met een `tei` service
+**And** de `tei` service gebruikt image `ghcr.io/huggingface/text-embeddings-inference:1.5`
+**And** het model is ingesteld op `BAAI/bge-m3`
+**When** de Docker Compose stack wordt gestart op gpu-01
+**Then** de `tei` container start succesvol op
+**And** `curl http://localhost:7997/health` retourneert HTTP 200
+**And** `docker logs tei` toont dat het BAAI/bge-m3 model is geladen
+
+### AC-GPU-002: Infinity service draait op poort 7998 (alleen reranking)
+
+**Given** gpu-01 Docker Compose stack is geconfigureerd met een `infinity` service op poort 7998
+**And** de `infinity` service is geconfigureerd met uitsluitend het model `BAAI/bge-reranker-v2-m3`
+**When** de Docker Compose stack wordt gestart op gpu-01
+**Then** de `infinity` container start succesvol op
+**And** `curl http://localhost:7998/health` retourneert HTTP 200
+**And** `docker logs infinity` toont dat alleen het reranker model is geladen
+**And** Infinity bedient GEEN embedding requests (geen bge-m3 model geladen)
+
+### AC-GPU-003: Bestaande services ongewijzigd
+
+**Given** gpu-01 Docker Compose stack bevat `bge-m3-sparse` (poort 8001) en `whisper-server` (poort 8000)
+**When** de Docker Compose stack wordt herstart na de TEI/Infinity wijzigingen
+**Then** `curl http://localhost:8001/health` retourneert HTTP 200
+**And** `curl http://localhost:8000/health` retourneert HTTP 200
+**And** de configuratie van `bge-m3-sparse` en `whisper-server` is ongewijzigd ten opzichte van de vorige versie
+
+### AC-GPU-004: SSH-tunnel forwardt poort 7998
+
+**Given** de SSH-tunnel van core-01 naar gpu-01 is geconfigureerd
+**And** de tunnel-configuratie bevat `-L 172.18.0.1:7998:127.0.0.1:7998`
+**When** de SSH-tunnel actief is
+**Then** `curl http://172.18.0.1:7997/health` retourneert HTTP 200 (TEI)
+**And** `curl http://172.18.0.1:7998/health` retourneert HTTP 200 (Infinity reranker)
+**And** `curl http://172.18.0.1:8001/health` retourneert HTTP 200 (sparse)
+**And** `curl http://172.18.0.1:8000/health` retourneert HTTP 200 (whisper)
+
+---
+
+## Module 2: Core-01 docker-compose.yml Update
+
+### AC-CORE-001: Consumer-services gebruiken correcte endpoints
+
+**Given** `deploy/docker-compose.yml` is bijgewerkt met de nieuwe environment variabelen
+**When** de docker-compose configuratie wordt gevalideerd met `docker compose config`
+**Then** de volgende environment variabelen zijn correct ingesteld:
+
+| Service | Variable | Verwachte waarde |
+|---------|----------|-----------------|
+| `knowledge-ingest` | `TEI_URL` | `http://172.18.0.1:7997` |
+| `knowledge-ingest` | `SPARSE_SIDECAR_URL` | `http://172.18.0.1:8001` |
+| `retrieval-api` | `TEI_URL` | `http://172.18.0.1:7997` |
+| `retrieval-api` | `TEI_RERANKER_URL` | `http://172.18.0.1:7998` |
+| `retrieval-api` | `SPARSE_SIDECAR_URL` | `http://172.18.0.1:8001` |
+| `scribe-api` | `WHISPER_SERVER_URL` | `http://172.18.0.1:8000` |
+| `vexa-bot-manager` | `TRANSCRIBER_URL` | begint met `http://172.18.0.1:8000` |
+| `librechat-klai` | `JINA_API_URL` | `http://172.18.0.1:7998/v1/rerank` |
+| `research-api` | `TEI_URL` | `http://172.18.0.1:7997` |
+
+### AC-CORE-002: Oude GPU service-definities verwijderd
+
+**Given** `deploy/docker-compose.yml` is bijgewerkt
+**When** het bestand wordt doorzocht op service-namen
+**Then** de volgende services komen NIET voor als service-definitie:
+- `tei:` (als top-level service key)
+- `bge-m3-sparse:` (als top-level service key)
+- `whisper-server:` (als top-level service key)
+- `infinity-reranker:` (als top-level service key)
+
+**Verificatie:**
+```bash
+grep -E '^\s{2}(tei|bge-m3-sparse|whisper-server|infinity-reranker):' deploy/docker-compose.yml
+# Verwacht: geen output
+```
+
+### AC-CORE-003: depends_on referenties verwijderd
+
+**Given** `deploy/docker-compose.yml` is bijgewerkt
+**When** de `depends_on` secties van consumer-services worden geinspecteerd
+**Then** `research-api.depends_on` bevat NIET `tei`
+**And** `knowledge-ingest.depends_on` bevat NIET `tei` en NIET `bge-m3-sparse`
+**And** `scribe-api.depends_on` bevat NIET `whisper-server`
+
+### AC-CORE-004: Ongebruikte volumes verwijderd
+
+**Given** `deploy/docker-compose.yml` is bijgewerkt
+**When** de `volumes:` sectie wordt geinspecteerd
+**Then** de volgende volumes komen NIET voor:
+- `tei-models`
+- `whisper-models`
+- `infinity-models` (tenzij nog in gebruik door een andere service)
+
+---
+
+## Module 3: Python Config Defaults
+
+### AC-PY-001: Config defaults verwijzen naar 172.18.0.1
+
+**Given** de Python config-bestanden zijn bijgewerkt
+**When** de default-waarden worden uitgelezen
+**Then** de volgende bestanden bevatten de correcte defaults:
+
+| Bestand | Veld | Verwachte default |
+|---------|------|------------------|
+| `klai-knowledge-ingest/knowledge_ingest/config.py` | `tei_url` | `http://172.18.0.1:7997` |
+| `klai-knowledge-ingest/knowledge_ingest/config.py` | `sparse_sidecar_url` | `http://172.18.0.1:8001` |
+| `klai-retrieval-api/retrieval_api/config.py` | `tei_url` | `http://172.18.0.1:7997` |
+| `klai-retrieval-api/retrieval_api/config.py` | `tei_reranker_url` | `http://172.18.0.1:7998` |
+| `klai-retrieval-api/retrieval_api/config.py` | `sparse_sidecar_url` | `http://172.18.0.1:8001` |
+| `klai-scribe/scribe-api/app/core/config.py` | `whisper_server_url` | `http://172.18.0.1:8000` |
+
+**Verificatie:**
+```bash
+grep -n "172.18.0.1" klai-knowledge-ingest/knowledge_ingest/config.py
+grep -n "172.18.0.1" klai-retrieval-api/retrieval_api/config.py
+grep -n "172.18.0.1" klai-scribe/scribe-api/app/core/config.py
+# Verwacht: alle relevante regels tonen 172.18.0.1 adressen
+```
+
+### AC-PY-002: Geen referenties naar oude Docker service-namen
+
+**Given** de Python config-bestanden zijn bijgewerkt
+**When** de bestanden worden doorzocht op oude service-namen
+**Then** de volgende strings komen NIET voor als default-waarden:
+- `http://tei:8080`
+- `http://bge-m3-sparse:8001`
+- `http://whisper-server:8000`
+- `http://tei-reranker:8080`
+- `http://infinity-reranker:7997`
+
+**Verificatie:**
+```bash
+grep -rn "tei:8080\|bge-m3-sparse:8001\|whisper-server:8000\|tei-reranker:8080\|infinity-reranker:7997" \
+  klai-knowledge-ingest/knowledge_ingest/config.py \
+  klai-retrieval-api/retrieval_api/config.py \
+  klai-scribe/scribe-api/app/core/config.py
+# Verwacht: geen output
+```
+
+---
+
+## Module 4: Verificatie
+
+### AC-VER-001: Alle gpu-01 endpoints bereikbaar via SSH-tunnel
+
+**Given** alle wijzigingen uit Fase 1-3 zijn doorgevoerd
+**And** de SSH-tunnel van core-01 naar gpu-01 is actief
+**When** health checks worden uitgevoerd vanuit core-01
+**Then** alle volgende endpoints retourneren HTTP 200:
+- `http://172.18.0.1:7997/health` (TEI dense embeddings)
+- `http://172.18.0.1:7998/health` (Infinity reranker)
+- `http://172.18.0.1:8001/health` (BGE-M3 sparse)
+- `http://172.18.0.1:8000/health` (Whisper STT)
+
+### AC-VER-002: Test embedding-aanroep succesvol
+
+**Given** TEI draait op poort 7997 met BAAI/bge-m3
+**When** een embedding request wordt verstuurd:
+```bash
+curl -s -X POST http://172.18.0.1:7997/v1/embeddings \
+  -H "Content-Type: application/json" \
+  -d '{"input": "test embedding", "model": "BAAI/bge-m3"}'
+```
+**Then** de response bevat een `data` array met een `embedding` van dimensie 1024
+**And** de HTTP status code is 200
+
+### AC-VER-003: Test rerank-aanroep succesvol
+
+**Given** Infinity draait op poort 7998 met BAAI/bge-reranker-v2-m3
+**When** een rerank request wordt verstuurd:
+```bash
+curl -s -X POST http://172.18.0.1:7998/v1/rerank \
+  -H "Content-Type: application/json" \
+  -d '{"model": "BAAI/bge-reranker-v2-m3", "query": "test query", "documents": ["relevant document", "irrelevant document"]}'
+```
+**Then** de response bevat een `results` array met relevancy scores
+**And** de HTTP status code is 200
+**And** het eerste document scoort hoger dan het tweede
+
+### AC-VER-004: Geen oude GPU-containers op core-01
+
+**Given** alle wijzigingen zijn doorgevoerd en consumer-services zijn herstart
+**When** de draaiende containers op core-01 worden geinspecteerd
+**Then** de volgende containers bestaan NIET:
+```bash
+docker ps --format '{{.Names}}' | grep -E '(klai-core-tei|klai-core-bge-m3-sparse|klai-core-whisper-server|klai-core-infinity-reranker)'
+# Verwacht: geen output
+```
+**And** `docker volume ls` toont geen actieve mounts voor `tei-models`, `whisper-models`, of `infinity-models`
+
+---
+
+## Definition of Done
+
+De SPEC-DEVOPS-002 is voltooid wanneer:
+
+1. **GPU-01 architectuur correct**: TEI op poort 7997 (embeddings), Infinity op poort 7998 (reranking), beide apart draaiend
+2. **SSH-tunnel compleet**: Alle 4 poorten (7997, 7998, 8000, 8001) doorgestuurd naar 172.18.0.1 op core-01
+3. **Core-01 consumers correct**: Alle 9 environment variabelen wijzen naar 172.18.0.1 endpoints
+4. **Oude services verwijderd**: Geen GPU service-definities meer in core-01 docker-compose.yml
+5. **Python defaults correct**: Alle 6 config defaults wijzen naar 172.18.0.1
+6. **Latente bug gefixt**: `tei_reranker_url` in retrieval-api verwijst niet meer naar het niet-bestaande `tei-reranker:8080`
+7. **Health checks groen**: Alle 4 inference endpoints bereikbaar via SSH-tunnel
+8. **Functionele tests groen**: Embedding (1024 dims) en reranking scores werken end-to-end
+9. **Geen oude containers**: Geen GPU-gerelateerde containers meer op core-01
+10. **Consumer-logs schoon**: Geen connection errors in knowledge-ingest, retrieval-api, scribe-api, research-api

--- a/.moai/specs/SPEC-DEVOPS-002/plan.md
+++ b/.moai/specs/SPEC-DEVOPS-002/plan.md
@@ -1,0 +1,340 @@
+---
+id: SPEC-DEVOPS-002
+version: 1.0.0
+status: draft
+created: 2026-03-30
+updated: 2026-03-30
+author: MoAI
+priority: high
+---
+
+# Implementatieplan: SPEC-DEVOPS-002 -- GPU-01 TEI + Infinity Split Herstellen
+
+## HISTORY
+
+| Versie | Datum      | Auteur | Wijziging                |
+|--------|------------|--------|--------------------------|
+| 1.0.0  | 2026-03-30 | MoAI   | Initieel plan            |
+
+---
+
+## Overzicht
+
+Dit plan beschrijft de stapsgewijze uitvoering van de TEI/Infinity split-herstel op gpu-01 en de bijbehorende configuratie-updates op core-01. De volgorde is kritisch: gpu-01 wordt eerst gecorrigeerd, daarna de SSH-tunnel, dan core-01 consumers, en als laatste verificatie.
+
+---
+
+## Fase 1: GPU-01 Service Herconfiguratie
+
+**Prioriteit:** Primair doel
+**Risico:** Medium -- gpu-01 is een dedicated server met directe SSH-toegang
+**Referenties:** REQ-GPU-001, REQ-GPU-002, REQ-GPU-003, REQ-GPU-004
+
+### Stap 1: TEI service toevoegen aan gpu-01 docker-compose.yml
+
+**Actie:** Bewerk `/opt/klai-gpu/docker-compose.yml` op gpu-01:
+- Wijzig de huidige `infinity` service van poort 7997 naar poort 7998
+- Verwijder het bge-m3 model uit de Infinity configuratie (laat alleen bge-reranker-v2-m3)
+- Voeg een nieuwe `tei` service toe op poort 7997 met:
+  - Image: `ghcr.io/huggingface/text-embeddings-inference:1.5`
+  - Model: `BAAI/bge-m3`
+  - GPU: NVIDIA runtime toewijzing
+  - Volume mount voor model cache
+
+**Pre-flight checks (CON-004):**
+- Inspecteer huidige `docker compose config` op gpu-01
+- Noteer huidige volumes en netwerkconfiguratie
+- Maak backup: `cp docker-compose.yml docker-compose.yml.bak`
+
+### Stap 2: Services herstarten op gpu-01
+
+**Actie:**
+```bash
+ssh gpu-01
+cd /opt/klai-gpu
+docker compose down
+docker compose up -d
+```
+
+**Post-flight checks:**
+- `docker compose ps` -- alle services moeten "running" zijn
+- `docker logs --tail 30 tei` -- geen errors, model geladen
+- `docker logs --tail 30 infinity` -- geen errors, reranker model geladen
+- `curl http://localhost:7997/health` -- TEI gezond
+- `curl http://localhost:7998/health` -- Infinity gezond
+- `curl http://localhost:8001/health` -- bge-m3-sparse gezond (ongewijzigd)
+- `curl http://localhost:8000/health` -- whisper-server gezond (ongewijzigd)
+
+### Stap 3: SSH-tunnel uitbreiden met poort 7998
+
+**Actie:** Voeg poort 7998 toe aan de autossh systemd service op core-01:
+
+```bash
+# Bewerk de tunnel service op core-01
+ssh core-01 "sudo nano /etc/systemd/system/gpu-tunnel.service"
+```
+
+Voeg `-L 172.18.0.1:7998:127.0.0.1:7998` toe aan de `ExecStart` regel, naast de bestaande forwardings:
+```
+# Bestaand (niet wijzigen):
+-L 172.18.0.1:7997:127.0.0.1:7997
+-L 172.18.0.1:8001:127.0.0.1:8001
+-L 172.18.0.1:8000:127.0.0.1:8000
+# Toevoegen:
+-L 172.18.0.1:7998:127.0.0.1:7998
+```
+
+Daarna herladen en herstarten:
+```bash
+ssh core-01 "sudo systemctl daemon-reload && sudo systemctl restart gpu-tunnel.service"
+ssh core-01 "sudo systemctl status gpu-tunnel.service"
+```
+
+**Verificatie:**
+```bash
+# Alle 4 tunnelpoorten bereikbaar vanuit core-01:
+ssh core-01 "sudo ss -tlnp | grep 172.18.0.1"
+curl -sf http://172.18.0.1:7997/health  # TEI (embeddings)
+curl -sf http://172.18.0.1:7998/health  # Infinity (reranker)
+curl -sf http://172.18.0.1:8001/health  # sparse
+curl -sf http://172.18.0.1:8000/health  # whisper
+```
+
+### Rollback Fase 1
+
+Als de herconfiguratie op gpu-01 faalt:
+1. `ssh gpu-01 && cd /opt/klai-gpu`
+2. `cp docker-compose.yml.bak docker-compose.yml`
+3. `docker compose down && docker compose up -d`
+4. Verifieer dat de oude configuratie weer draait
+
+---
+
+## Fase 2: Core-01 docker-compose.yml Update
+
+**Prioriteit:** Primair doel
+**Risico:** Hoog -- productie-impact op 6 consumer-services
+**Referenties:** REQ-CORE-001, REQ-CORE-002, REQ-CORE-003, REQ-CORE-004
+**Afhankelijkheid:** Fase 1 moet volledig voltooid en geverifieerd zijn
+
+### Stap 1: Environment variabelen updaten
+
+**Actie:** Bewerk `deploy/docker-compose.yml` in de repo:
+
+Wijzig de 9 environment variabelen conform de mapping in REQ-CORE-001:
+
+| Service | Variable | Oud | Nieuw |
+|---------|----------|-----|-------|
+| `knowledge-ingest` | `TEI_URL` | `http://tei:8080` | `http://172.18.0.1:7997` |
+| `knowledge-ingest` | `SPARSE_SIDECAR_URL` | `http://bge-m3-sparse:8001` | `http://172.18.0.1:8001` |
+| `retrieval-api` | `TEI_URL` | `http://tei:8080` | `http://172.18.0.1:7997` |
+| `retrieval-api` | `TEI_RERANKER_URL` | `http://infinity-reranker:7997` | `http://172.18.0.1:7998` |
+| `retrieval-api` | `SPARSE_SIDECAR_URL` | `http://bge-m3-sparse:8001` | `http://172.18.0.1:8001` |
+| `scribe-api` | `WHISPER_SERVER_URL` | `http://whisper-server:8000` | `http://172.18.0.1:8000` |
+| `vexa-bot-manager` | `TRANSCRIBER_URL` | `http://whisper-server:8000/...` | `http://172.18.0.1:8000/...` |
+| `librechat-klai` | `JINA_API_URL` | `http://infinity-reranker:7997/v1/rerank` | `http://172.18.0.1:7998/v1/rerank` |
+| `research-api` | `TEI_URL` | `http://tei:8080` | `http://172.18.0.1:7997` |
+
+### Stap 2: Oude GPU service-definities verwijderen
+
+**Actie:** Verwijder de volgende service-blokken uit `deploy/docker-compose.yml`:
+- `tei` service-definitie (regels ~564-572)
+- `bge-m3-sparse` service-definitie (regels ~574-595)
+- `whisper-server` service-definitie (regels ~744-756)
+- `infinity-reranker` service-definitie (regels ~925-945)
+
+### Stap 3: depends_on entries verwijderen
+
+**Actie:** Verwijder stale `depends_on` referenties:
+- `research-api.depends_on`: verwijder `- tei`
+- `knowledge-ingest.depends_on`: verwijder `- tei` en `- bge-m3-sparse`
+- `scribe-api.depends_on`: verwijder `- whisper-server`
+
+### Stap 4: Ongebruikte volumes verwijderen
+
+**Actie:** Verwijder de volgende volume-definities uit de `volumes:` sectie:
+- `tei-models`
+- `whisper-models`
+- `infinity-models` (indien niet meer in gebruik na de Infinity poortwijziging)
+
+### Stap 5: Deployen naar core-01
+
+**Actie:**
+1. Commit en push de docker-compose.yml wijzigingen
+2. Kopieer naar core-01: `scp deploy/docker-compose.yml core-01:/opt/klai/docker-compose.yml`
+   (of via het gebruikelijke deploy-mechanisme)
+3. Herstart de betreffende services:
+
+```bash
+ssh core-01
+cd /opt/klai
+# Pre-flight check (CON-004):
+docker compose config knowledge-ingest | grep -A 10 'environment:'
+docker compose config retrieval-api | grep -A 10 'environment:'
+
+# Herstart consumer-services (niet de hele stack):
+docker compose up -d knowledge-ingest retrieval-api scribe-api vexa-bot-manager research-api
+```
+
+**Post-flight checks:**
+- `docker compose ps` -- alle services "running"
+- `docker logs --tail 30 klai-core-knowledge-ingest-1` -- geen connection errors
+- `docker logs --tail 30 klai-core-retrieval-api-1` -- geen connection errors
+- `docker logs --tail 30 klai-core-scribe-api-1` -- geen connection errors
+
+### Rollback Fase 2
+
+Als de consumer-services op core-01 falen:
+1. Herstel de vorige docker-compose.yml: `git checkout HEAD~1 -- deploy/docker-compose.yml`
+2. Kopieer naar core-01 en herstart
+3. Oude GPU services op core-01 zijn al verwijderd -- als rollback nodig is naar de volledig oude situatie, moeten de service-definities handmatig worden teruggezet
+
+**Belangrijk:** Zolang de SSH-tunnel naar gpu-01 werkt en de services op gpu-01 draaien, zijn de 172.18.0.1 endpoints beschikbaar. Rollback is alleen nodig als de tunnel of gpu-01 services falen.
+
+---
+
+## Fase 3: Python Config Defaults
+
+**Prioriteit:** Secundair doel
+**Risico:** Laag -- defaults worden overschreven door env vars; dit is een defensieve verbetering
+**Referenties:** REQ-PY-001, REQ-PY-002
+
+### Stap 1: Config defaults updaten
+
+**Actie:** Bewerk de volgende 4 bestanden in de repo:
+
+1. `klai-knowledge-ingest/knowledge_ingest/config.py`
+   - Regel 8: `tei_url` default `"http://tei:8080"` --> `"http://172.18.0.1:7997"`
+   - Regel 33: `sparse_sidecar_url` default `"http://bge-m3-sparse:8001"` --> `"http://172.18.0.1:8001"`
+
+2. `klai-retrieval-api/retrieval_api/config.py`
+   - Regel 12: `tei_url` default `"http://tei:8080"` --> `"http://172.18.0.1:7997"`
+   - Regel 13: `tei_reranker_url` default `"http://tei-reranker:8080"` --> `"http://172.18.0.1:7998"` (latente bug fix)
+   - Regel 23: `sparse_sidecar_url` default `""` --> `"http://172.18.0.1:8001"`
+
+3. `klai-scribe/scribe-api/app/core/config.py`
+   - Regel 18: `whisper_server_url` default `"http://whisper-server:8000"` --> `"http://172.18.0.1:8000"`
+
+**Opmerking:** Deze wijzigingen worden meegenomen in dezelfde commit als de docker-compose.yml updates.
+
+### Rollback Fase 3
+
+Niet nodig -- de env vars in docker-compose.yml overschrijven deze defaults altijd. Een revert van de config-bestanden is eenvoudig via git.
+
+---
+
+## Fase 4: Verificatie
+
+**Prioriteit:** Primair doel (verplicht voor voltooiing)
+**Risico:** Geen -- alleen lezen/testen
+**Referenties:** REQ-VER-001, REQ-VER-002, REQ-VER-003, REQ-VER-004
+**Afhankelijkheid:** Fase 1, 2 en 3 moeten volledig voltooid zijn
+
+### Stap 1: Health checks via SSH-tunnel
+
+```bash
+# Vanuit core-01:
+curl -s http://172.18.0.1:7997/health   # TEI (embeddings)
+curl -s http://172.18.0.1:7998/health   # Infinity (reranker)
+curl -s http://172.18.0.1:8001/health   # BGE-M3 sparse
+curl -s http://172.18.0.1:8000/health   # Whisper
+```
+
+Alle 4 endpoints moeten een 200 OK response geven.
+
+### Stap 2: Test embedding-aanroep
+
+```bash
+# Test embedding via TEI:
+curl -s -X POST http://172.18.0.1:7997/v1/embeddings \
+  -H "Content-Type: application/json" \
+  -d '{"input": "test embedding", "model": "BAAI/bge-m3"}' \
+  | python3 -c "import sys,json; d=json.load(sys.stdin); print(f'dims={len(d[\"data\"][0][\"embedding\"])}')"
+```
+
+Verwacht resultaat: `dims=1024` (bge-m3 dimensionaliteit).
+
+### Stap 3: Test rerank-aanroep
+
+```bash
+# Test reranking via Infinity:
+curl -s -X POST http://172.18.0.1:7998/v1/rerank \
+  -H "Content-Type: application/json" \
+  -d '{"model": "BAAI/bge-reranker-v2-m3", "query": "test", "documents": ["doc1", "doc2"]}'
+```
+
+Verwacht resultaat: JSON met `results` array en relevancy scores.
+
+### Stap 4: Verifieer geen oude GPU-containers op core-01
+
+```bash
+# Op core-01:
+docker ps --format '{{.Names}}' | grep -E '(tei|bge-m3-sparse|whisper-server|infinity-reranker)'
+```
+
+Verwacht resultaat: lege output (geen matches).
+
+### Stap 5: End-to-end controle consumer-services
+
+```bash
+# Controleer logs op connection errors:
+docker logs --tail 50 klai-core-knowledge-ingest-1 2>&1 | grep -i error
+docker logs --tail 50 klai-core-retrieval-api-1 2>&1 | grep -i error
+docker logs --tail 50 klai-core-scribe-api-1 2>&1 | grep -i error
+docker logs --tail 50 klai-core-research-api-1 2>&1 | grep -i error
+```
+
+Verwacht resultaat: geen connection errors naar de inference endpoints.
+
+---
+
+## Technische Aanpak
+
+### Waarom TEI voor embeddings in plaats van Infinity
+
+| Criterium | TEI | Infinity |
+|-----------|-----|----------|
+| Architectuur | Rust + cuBLASLt (HuggingFace native) | Python + PyTorch |
+| GPU memory | Stabiel, geen bekende leaks | Bekende leak (issue #517, open) |
+| bge-m3 ondersteuning | Aanbevolen op model card | Ondersteund maar niet aanbevolen |
+| Prometheus metrics | Native beschikbaar | Beperkt |
+| Batching | Token-based dynamic batching | Request-based batching |
+
+### Waarom Infinity voor reranking in plaats van TEI
+
+| Criterium | TEI | Infinity |
+|-----------|-----|----------|
+| LiteLLM integratie | Geen native rerank support | Cohere-compatible `/rerank` endpoint |
+| bge-reranker-v2-m3 | Werkt maar geen native rerank API | Native rerank ondersteuning |
+| Operationeel | Tweede TEI instantie nodig met ander model | Eenvoudige configuratie |
+
+### Poortschema
+
+```
+gpu-01 (intern)        SSH-tunnel         core-01 (172.18.0.1)
+-----------------     ------------>       ----------------------
+:7997 (TEI)           -L 7997            :7997 (dense embeddings)
+:7998 (Infinity)      -L 7998            :7998 (reranking)
+:8000 (Whisper)       -L 8000            :8000 (STT)
+:8001 (Sparse)        -L 8001            :8001 (sparse embeddings)
+```
+
+---
+
+## Risico's en Mitigatie
+
+| Risico | Impact | Kans | Mitigatie |
+|--------|--------|------|-----------|
+| TEI start niet op gpu-01 | Embeddings onbeschikbaar | Laag | Rollback naar Infinity op poort 7997; model werkt bewezen op TEI |
+| SSH-tunnel poort 7998 faalt | Reranking onbeschikbaar | Laag | Debug tunnel; poort forwarding is standaard SSH functionaliteit |
+| Consumer-services vinden endpoints niet | Embedding/rerank/STT uitval | Medium | Pre-flight check env vars; rollback docker-compose.yml via git |
+| VRAM te krap voor TEI + Infinity naast elkaar | OOM op gpu-01 | Laag | RTX 4000 Ada heeft 20GB; TEI (bge-m3) ~2GB + Infinity (reranker) ~1GB = ruim voldoende |
+| embedder.py incompatibel met TEI | Embedding calls falen | Zeer laag | Commit 235a259 schakelde al naar `/v1/embeddings` (OpenAI-compatible), wat TEI ondersteunt |
+
+---
+
+## Scope-beperkingen
+
+- LibreChat (`librechat-klai`) env var update is opgenomen maar de service wordt niet actief getest (LibreChat is een third-party service)
+- embedder.py wordt NIET gewijzigd (reeds compatible, zie CON-007)
+- Geen wijzigingen aan de modellen zelf -- alleen de serving-infrastructuur verandert

--- a/.moai/specs/SPEC-DEVOPS-002/spec.md
+++ b/.moai/specs/SPEC-DEVOPS-002/spec.md
@@ -1,0 +1,205 @@
+---
+id: SPEC-DEVOPS-002
+version: 1.0.0
+status: draft
+created: 2026-03-30
+updated: 2026-03-30
+author: MoAI
+priority: high
+---
+
+# SPEC-DEVOPS-002: GPU-01 Inference Migration Fix -- TEI + Infinity Split Herstellen
+
+## HISTORY
+
+| Versie | Datum      | Auteur | Wijziging                |
+|--------|------------|--------|--------------------------|
+| 1.0.0  | 2026-03-30 | MoAI   | Initieel SPEC-document   |
+
+---
+
+## Samenvatting
+
+Tijdens de uitvoering van SPEC-GPU-001 is een ongeautoriseerde architectuurwijziging doorgevoerd: TEI (text-embeddings-inference) en de aparte infinity-reranker zijn samengevoegd tot een enkele Infinity-instantie op gpu-01. Dit is architectureel onjuist en brengt productierisico's met zich mee (bekende GPU memory leak in Infinity, issue #517). Deze SPEC herstelt de correcte split-architectuur en repareert alle verbroken service-referenties op core-01.
+
+---
+
+## Module 1: GPU-01 Service Herconfiguratie
+
+### Omgeving
+
+- gpu-01 (Hetzner GEX44, RTX 4000 Ada 20GB GDDR6, IP 5.9.10.215, FSN1-DC13)
+- Docker Compose configuratie: `/opt/klai-gpu/docker-compose.yml` op gpu-01
+- Huidige (foutieve) situatie: enkele Infinity-instantie op poort 7997 bedient zowel bge-m3 dense embeddings als bge-reranker-v2-m3 reranking
+- bge-m3-sparse op poort 8001 en whisper-server op poort 8000 zijn correct en worden niet gewijzigd
+- SSH-tunnel van core-01 naar gpu-01 bindt inference-poorten aan 172.18.0.1 (Docker host gateway op core-01)
+
+### Aannames
+
+- **ASM-001**: TEI Docker image `ghcr.io/huggingface/text-embeddings-inference:1.5` ondersteunt BAAI/bge-m3 correct (bevestigd door model card)
+- **ASM-002**: TEI ondersteunt het `/v1/embeddings` OpenAI-compatible endpoint, waardoor geen code-aanpassing in embedder.py nodig is (reeds gevalideerd in commit 235a259)
+- **ASM-003**: Infinity heeft een bekende GPU memory leak (GitHub issue #517, open sinds jan 2025) die het ongeschikt maakt als sole embedding service onder productielast
+- **ASM-004**: De SSH-tunnel op core-01 kan uitgebreid worden met een extra poortforwarding (7998) zonder impact op bestaande tunnels
+- **ASM-005**: gpu-01 heeft voldoende VRAM (20GB) voor TEI (bge-m3) + Infinity (bge-reranker-v2-m3) + bge-m3-sparse + whisper-server naast elkaar
+
+### Requirements
+
+**REQ-GPU-001** (Event-Driven):
+WHEN de gpu-01 Docker Compose stack wordt gestart, THEN SHALL de `tei` service opstarten op poort 7997 met het model BAAI/bge-m3 voor dense embeddings, gebruikmakend van het Docker image `ghcr.io/huggingface/text-embeddings-inference:1.5`.
+
+**REQ-GPU-002** (Event-Driven):
+WHEN de gpu-01 Docker Compose stack wordt gestart, THEN SHALL de `infinity` service opstarten op poort 7998 met uitsluitend het model BAAI/bge-reranker-v2-m3 voor reranking.
+
+**REQ-GPU-003** (Ubiquitous):
+De services `bge-m3-sparse` (poort 8001) en `whisper-server` (poort 8000) op gpu-01 SHALL ongewijzigd blijven.
+
+**REQ-GPU-004** (Event-Driven):
+WHEN de SSH-tunnel van core-01 naar gpu-01 wordt opgezet, THEN SHALL poort 7998 (Infinity reranker) worden doorgestuurd via `/etc/systemd/system/gpu-tunnel.service` op core-01, naast de bestaande poorten 7997, 8000 en 8001, gebonden aan 172.18.0.1 op core-01. De service wordt herladen via `systemctl daemon-reload && systemctl restart gpu-tunnel.service`.
+
+### Specificaties
+
+| Service | Poort | Model | Docker Image | Functie |
+|---------|-------|-------|-------------|---------|
+| `tei` | 7997 | BAAI/bge-m3 | `ghcr.io/huggingface/text-embeddings-inference:1.5` | Dense embeddings |
+| `infinity` | 7998 | BAAI/bge-reranker-v2-m3 | `michaelf34/infinity:latest` | Reranking |
+| `bge-m3-sparse` | 8001 | BAAI/bge-m3 | custom | Sparse embeddings (ongewijzigd) |
+| `whisper-server` | 8000 | large-v3 | custom | STT (ongewijzigd) |
+
+---
+
+## Module 2: Core-01 docker-compose.yml Update
+
+### Omgeving
+
+- core-01 Docker Compose: `deploy/docker-compose.yml` in deze repo, deployed naar `/opt/klai/docker-compose.yml`
+- 6 consumer-services refereren nog naar oude Docker service-namen (intra-compose netwerk) in plaats van naar de SSH-tunnel endpoints op 172.18.0.1
+- 4 oude GPU service-definities staan nog in docker-compose.yml en moeten verwijderd worden
+- Bijbehorende `depends_on` entries en volumes zijn stale
+
+### Aannames
+
+- **ASM-006**: De 172.18.0.1 adressen zijn bereikbaar vanuit alle Docker-containers op core-01 via het Docker host gateway
+- **ASM-007**: Environment variabelen in docker-compose.yml overschrijven Python config defaults (env vars hebben voorrang)
+- **ASM-008**: Verwijdering van de oude service-definities heeft geen neveneffecten op andere services
+
+### Requirements
+
+**REQ-CORE-001** (Event-Driven):
+WHEN de core-01 Docker Compose stack wordt gestart, THEN SHALL elke consumer-service de correcte inference endpoints gebruiken via 172.18.0.1, conform de volgende mapping:
+
+| Service | Variable | Nieuwe waarde |
+|---------|----------|---------------|
+| `knowledge-ingest` | `TEI_URL` | `http://172.18.0.1:7997` |
+| `knowledge-ingest` | `SPARSE_SIDECAR_URL` | `http://172.18.0.1:8001` |
+| `retrieval-api` | `TEI_URL` | `http://172.18.0.1:7997` |
+| `retrieval-api` | `TEI_RERANKER_URL` | `http://172.18.0.1:7998` |
+| `retrieval-api` | `SPARSE_SIDECAR_URL` | `http://172.18.0.1:8001` |
+| `scribe-api` | `WHISPER_SERVER_URL` | `http://172.18.0.1:8000` |
+| `vexa-bot-manager` | `TRANSCRIBER_URL` | `http://172.18.0.1:8000/...` |
+| `librechat-klai` | `JINA_API_URL` | `http://172.18.0.1:7998/v1/rerank` |
+| `research-api` | `TEI_URL` | `http://172.18.0.1:7997` |
+
+**REQ-CORE-002** (Unwanted):
+De docker-compose.yml SHALL NIET de volgende service-definities bevatten na de wijziging: `tei`, `bge-m3-sparse`, `whisper-server`, `infinity-reranker`. Deze services draaien nu op gpu-01.
+
+**REQ-CORE-003** (Event-Driven):
+WHEN de oude GPU service-definities worden verwijderd, THEN SHALL alle bijbehorende `depends_on` referenties ook worden verwijderd:
+- `research-api`: verwijder `- tei`
+- `knowledge-ingest`: verwijder `- tei` en `- bge-m3-sparse`
+- `scribe-api`: verwijder `- whisper-server`
+
+**REQ-CORE-004** (Event-Driven):
+WHEN de oude GPU service-definities worden verwijderd, THEN SHALL de bijbehorende ongebruikte volumes worden verwijderd: `tei-models`, `whisper-models`, en `infinity-models` (indien niet meer in gebruik).
+
+---
+
+## Module 3: Python Config Defaults
+
+### Omgeving
+
+- 4 Python config-bestanden bevatten hardcoded defaults die verwijzen naar oude Docker service-namen
+- Deze defaults worden overschreven door environment variabelen maar vormen een risico als de env vars ontbreken
+- Er is een latente bug: `retrieval-api` config verwijst naar `tei-reranker:8080` dat nooit bestond
+
+### Aannames
+
+- **ASM-009**: De Python config defaults worden alleen als fallback gebruikt; de docker-compose environment variabelen hebben voorrang
+- **ASM-010**: Het updaten van de defaults naar 172.18.0.1 adressen is veilig voor zowel productie als lokale ontwikkeling (lokale dev kan alsnog overschrijven via env vars)
+
+### Requirements
+
+**REQ-PY-001** (Ubiquitous):
+De Python config defaults SHALL de correcte 172.18.0.1 adressen bevatten als fallback-waarden:
+
+| Bestand | Veld | Huidige waarde (fout) | Nieuwe waarde |
+|---------|------|----------------------|---------------|
+| `klai-knowledge-ingest/knowledge_ingest/config.py:8` | `tei_url` | `http://tei:8080` | `http://172.18.0.1:7997` |
+| `klai-knowledge-ingest/knowledge_ingest/config.py:33` | `sparse_sidecar_url` | `http://bge-m3-sparse:8001` | `http://172.18.0.1:8001` |
+| `klai-retrieval-api/retrieval_api/config.py:12` | `tei_url` | `http://tei:8080` | `http://172.18.0.1:7997` |
+| `klai-retrieval-api/retrieval_api/config.py:13` | `tei_reranker_url` | `http://tei-reranker:8080` | `http://172.18.0.1:7998` |
+| `klai-retrieval-api/retrieval_api/config.py:23` | `sparse_sidecar_url` | `""` | `http://172.18.0.1:8001` |
+| `klai-scribe/scribe-api/app/core/config.py:18` | `whisper_server_url` | `http://whisper-server:8000` | `http://172.18.0.1:8000` |
+
+**REQ-PY-002** (Unwanted):
+De Python config defaults SHALL NIET verwijzen naar Docker service-namen (`tei`, `bge-m3-sparse`, `whisper-server`, `tei-reranker`, `infinity-reranker`) die niet meer bestaan op core-01.
+
+---
+
+## Module 4: Verificatie
+
+### Omgeving
+
+- Na alle wijzigingen moeten alle inference-paden end-to-end gevalideerd worden
+- Health checks moeten via de SSH-tunnel lopen (172.18.0.1 op core-01)
+- Oude GPU-containers op core-01 mogen niet meer draaien
+
+### Requirements
+
+**REQ-VER-001** (Event-Driven):
+WHEN alle wijzigingen zijn doorgevoerd, THEN SHALL elk gpu-01 service-endpoint bereikbaar zijn via de SSH-tunnel:
+- TEI health: `http://172.18.0.1:7997/health`
+- Infinity health: `http://172.18.0.1:7998/health`
+- BGE-M3 sparse health: `http://172.18.0.1:8001/health`
+- Whisper health: `http://172.18.0.1:8000/health`
+
+**REQ-VER-002** (Event-Driven):
+WHEN de TEI service draait, THEN SHALL een test embedding-aanroep via `knowledge-ingest` een geldig dense embedding-vector opleveren (dimensie 1024 voor bge-m3).
+
+**REQ-VER-003** (Event-Driven):
+WHEN de Infinity service draait op poort 7998, THEN SHALL een test rerank-aanroep via `retrieval-api` een geldige reranking-score opleveren.
+
+**REQ-VER-004** (Unwanted):
+Er SHALL GEEN oude GPU-gerelateerde containers (tei, bge-m3-sparse, whisper-server, infinity-reranker) meer draaien op core-01 na de migratie.
+
+---
+
+## Beperkingen
+
+- **CON-001**: De migratie moet in een specifieke veilige volgorde worden uitgevoerd (gpu-01 eerst, daarna core-01 consumers) om downtime te minimaliseren
+- **CON-002**: Elke stap moet een rollback-procedure hebben
+- **CON-003**: Alle service health checks moeten slagen voordat de migratie als voltooid wordt verklaard
+- **CON-004**: Volg `.claude/rules/klai/container-preflight.md` voor alle docker compose operaties
+- **CON-005**: Volg `.claude/rules/klai/pitfalls/infrastructure.md` voor environment variabele wijzigingen
+- **CON-006**: Gebruik GEEN `sed` of `echo` om `/opt/klai/.env` te wijzigen -- env wijzigingen gaan in docker-compose.yml
+- **CON-007**: embedder.py (commit 235a259) is reeds compatible met TEI's `/v1/embeddings` endpoint -- geen revert nodig
+
+---
+
+## Traceerbaarheid
+
+| Requirement | Plan Referentie | Acceptatie Referentie |
+|-------------|----------------|----------------------|
+| REQ-GPU-001 | Fase 1, Stap 1 | AC-GPU-001 |
+| REQ-GPU-002 | Fase 1, Stap 2 | AC-GPU-002 |
+| REQ-GPU-003 | Fase 1 (geen actie) | AC-GPU-003 |
+| REQ-GPU-004 | Fase 1, Stap 3 | AC-GPU-004 |
+| REQ-CORE-001 | Fase 2, Stap 1 | AC-CORE-001 |
+| REQ-CORE-002 | Fase 2, Stap 2 | AC-CORE-002 |
+| REQ-CORE-003 | Fase 2, Stap 3 | AC-CORE-003 |
+| REQ-CORE-004 | Fase 2, Stap 4 | AC-CORE-004 |
+| REQ-PY-001 | Fase 3, Stap 1 | AC-PY-001 |
+| REQ-PY-002 | Fase 3 (impliciete verificatie) | AC-PY-002 |
+| REQ-VER-001 | Fase 4, Stap 1 | AC-VER-001 |
+| REQ-VER-002 | Fase 4, Stap 2 | AC-VER-002 |
+| REQ-VER-003 | Fase 4, Stap 3 | AC-VER-003 |
+| REQ-VER-004 | Fase 4, Stap 4 | AC-VER-004 |

--- a/deploy/librechat/librechat.yaml
+++ b/deploy/librechat/librechat.yaml
@@ -11,7 +11,7 @@ balance:
 # ── Web search ────────────────────────────────────────────────────────────────
 # Search:   SearXNG (self-hosted, klai-net) — Startpage + DuckDuckGo engines
 # Scraper:  firecrawl-api (self-hosted, klai-net) — full-page content extraction
-# Reranker: infinity-reranker (self-hosted, klai-net) — bge-reranker-v2-m3 (CPU)
+# Reranker: Infinity (gpu-01 via SSH tunnel at 172.18.0.1:7998) — bge-reranker-v2-m3 (GPU)
 #           Exposed as Jina-compatible /v1/rerank; no auth needed (network-isolated)
 webSearch:
   searchProvider: "searxng"

--- a/docs/runbooks/gpu-01-setup.md
+++ b/docs/runbooks/gpu-01-setup.md
@@ -5,7 +5,7 @@
 **Disks:** 2× 1.7 TB NVMe (RAID1 via mdadm)
 **OS:** Ubuntu 24.04 LTS + LUKS full-disk encryption
 
-**SPEC:** SPEC-GPU-001 v2.0
+**SPEC:** SPEC-GPU-001 v2.0 → SPEC-DEVOPS-002 v1.0 (TEI/Infinity split herstel)
 
 ---
 
@@ -378,20 +378,28 @@ docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'
 
 ```bash
 # Health checks vanuit gpu-01
-curl -sf http://127.0.0.1:7997/health   # Infinity (embeddings + reranker)
+curl -sf http://127.0.0.1:7997/health   # TEI (dense embeddings — BAAI/bge-m3)
+curl -sf http://127.0.0.1:7998/health   # Infinity (reranker — BAAI/bge-reranker-v2-m3)
 curl -sf http://127.0.0.1:8001/health   # BGE-M3 sparse
 curl -sf http://127.0.0.1:8000/health   # Whisper
 
-# Embedding test
+# Embedding test via TEI
 curl -s -X POST http://127.0.0.1:7997/v1/embeddings \
   -H 'Content-Type: application/json' \
   -d '{"model":"BAAI/bge-m3","input":"test"}' \
   | python3 -c "import json,sys; r=json.load(sys.stdin); print(len(r['data'][0]['embedding']), 'dims')"
 # Verwacht: 1024 dims
 
+# Rerank test via Infinity
+curl -s -X POST http://127.0.0.1:7998/v1/rerank \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"BAAI/bge-reranker-v2-m3","query":"test","documents":["relevant","irrelevant"]}' \
+  | python3 -c "import json,sys; r=json.load(sys.stdin); print('scores:', [x['relevance_score'] for x in r['results']])"
+# Verwacht: eerste score >> tweede score
+
 # VRAM gebruik
 nvidia-smi --query-gpu=memory.used,memory.total --format=csv,noheader,nounits
-# Verwacht: ~5400 van 20475 MB (~27%)
+# Verwacht: ~3000 van 20475 MB (~15%) — TEI (bge-m3) ~2 GB + Infinity (reranker) ~1 GB
 ```
 
 ---
@@ -455,6 +463,7 @@ ExecStart=/usr/bin/autossh -M 0 \
   -i /opt/klai/gpu-tunnel-key \
   -N \
   -L 172.18.0.1:7997:127.0.0.1:7997 \
+  -L 172.18.0.1:7998:127.0.0.1:7998 \
   -L 172.18.0.1:8001:127.0.0.1:8001 \
   -L 172.18.0.1:8000:127.0.0.1:8000 \
   root@5.9.10.215
@@ -491,8 +500,9 @@ ssh core-01 "
 # Tunnel ports gebonden op 172.18.0.1?
 sudo ss -tlnp | grep 172.18.0.1
 
-# Alle drie services bereikbaar?
-curl -sf http://172.18.0.1:7997/health   # Infinity
+# Alle vier services bereikbaar?
+curl -sf http://172.18.0.1:7997/health   # TEI (dense embeddings)
+curl -sf http://172.18.0.1:7998/health   # Infinity (reranker)
 curl -sf http://172.18.0.1:8001/health   # BGE-M3 sparse
 curl -sf http://172.18.0.1:8000/health   # Whisper
 "
@@ -506,22 +516,18 @@ curl -sf http://172.18.0.1:8000/health   # Whisper
 
 #### URL mapping
 
-| Variabele | Oud | Nieuw |
+| Variabele | Service | Waarde |
 |---|---|---|
-| `TEI_URL` | `http://tei:8080` | `http://172.18.0.1:7997` |
-| `TEI_RERANKER_URL` | `http://infinity-reranker:7997` | `http://172.18.0.1:7997` |
-| `SPARSE_SIDECAR_URL` | `http://bge-m3-sparse:8001` | `http://172.18.0.1:8001` |
-| `WHISPER_SERVER_URL` | `http://whisper-server:8000` | `http://172.18.0.1:8000` |
-| `TRANSCRIBER_URL` | `http://whisper-server:8000/...` | `http://172.18.0.1:8000/...` |
-| `JINA_API_URL` | `http://infinity-reranker:7997/v1/rerank` | `http://172.18.0.1:7997/v1/rerank` |
+| `TEI_URL` | knowledge-ingest, retrieval-api, research-api | `http://172.18.0.1:7997` |
+| `TEI_RERANKER_URL` | retrieval-api | `http://172.18.0.1:7998` |
+| `SPARSE_SIDECAR_URL` | knowledge-ingest, retrieval-api | `http://172.18.0.1:8001` |
+| `WHISPER_SERVER_URL` | scribe-api | `http://172.18.0.1:8000` |
+| `TRANSCRIBER_URL` | vexa-bot-manager | `http://172.18.0.1:8000/...` |
+| `JINA_API_URL` | librechat-klai | `http://172.18.0.1:7998/v1/rerank` |
 
 #### Stap 3.1 — Consumer code deployen
 
-De volgende bestanden zijn al bijgewerkt voor de Infinity OpenAI API (`/v1/embeddings`) in plaats van de TEI API (`/embed`):
-
-- `klai-retrieval-api/retrieval_api/services/tei.py`
-- `klai-knowledge-ingest/knowledge_ingest/embedder.py`
-- `klai-focus/research-api/app/services/tei.py`
+Consumer-services gebruiken de OpenAI-compatible embedding API (`POST /v1/embeddings`), die zowel TEI als Infinity ondersteunt. Geen code-wijzigingen nodig — alleen de URL env vars hoeven bijgewerkt te worden (zie stap 3.2).
 
 Build en push de images via de normale CI workflows.
 
@@ -535,21 +541,17 @@ ssh core-01 "cp /opt/klai/docker-compose.yml /opt/klai/docker-compose.yml.bak-$(
 scp deploy/docker-compose.yml core-01:/opt/klai/docker-compose.yml
 ```
 
-De compose file heeft de oude GPU services op `profiles: [gpu-disabled]` staan (ze draaien niet meer).
-De URL env vars zijn bijgewerkt naar 172.18.0.1.
+De oude GPU service-definities (`tei`, `bge-m3-sparse`, `whisper-server`, `infinity-reranker`) zijn verwijderd uit de compose file.
+De URL env vars verwijzen naar 172.18.0.1 (SSH tunnel naar gpu-01).
 
-#### Stap 3.3 — Oude GPU services stoppen + consumers herstarten
+#### Stap 3.3 — Consumers herstarten
 
 ```bash
 ssh core-01 "
 cd /opt/klai
 
-# Oude CPU GPU containers verwijderen (staan al op gpu-disabled, maar voor zekerheid)
-docker compose stop tei bge-m3-sparse whisper-server infinity-reranker 2>/dev/null || true
-docker compose rm -f tei bge-m3-sparse whisper-server infinity-reranker 2>/dev/null || true
-
 # Consumer services herstarten met nieuwe config
-docker compose up -d retrieval-api knowledge-ingest scribe-api vexa-bot-manager librechat-klai
+docker compose up -d retrieval-api knowledge-ingest scribe-api vexa-bot-manager librechat-klai research-api
 "
 ```
 
@@ -665,26 +667,25 @@ ssh -i ~/.ssh/klai_ed25519 root@65.109.237.64 \
 
 ## Rollback Procedure
 
-Als de migratie ongedaan gemaakt moet worden (terugvallen op core-01 CPU containers):
+Bij een volledige gpu-01 uitval (hardware, tunnel, of service crash) waarbij terugvallen op CPU tijdelijk nodig is:
+
+> De oude CPU service-definities (`tei`, `bge-m3-sparse`, `whisper-server`, `infinity-reranker`) zijn verwijderd uit `deploy/docker-compose.yml` (SPEC-DEVOPS-002). Rollback vereist het handmatig terugzetten van de compose file via git.
 
 ```bash
 # Stap 1: Stop tunnel
 ssh core-01 "sudo systemctl stop gpu-tunnel.service"
 
-# Stap 2: Herstel backup compose
-BACKUP=$(ssh core-01 "ls -t /opt/klai/docker-compose.yml.bak-* | head -1")
-ssh core-01 "cp $BACKUP /opt/klai/docker-compose.yml"
+# Stap 2: Herstel docker-compose.yml vóór SPEC-DEVOPS-002
+# Commit vóór de wijziging: e3c1697 (refactor: promote klai-knowledge-mcp)
+ssh core-01 "cp /opt/klai/docker-compose.yml.bak-<timestamp> /opt/klai/docker-compose.yml"
+# Of via git: git show e3c1697:deploy/docker-compose.yml > deploy/docker-compose.yml
 
-# Stap 3: Start oude GPU services opnieuw
-ssh core-01 "cd /opt/klai && docker compose --profile gpu-disabled up -d \
-  tei bge-m3-sparse whisper-server infinity-reranker"
-
-# Stap 4: Herstart consumers
+# Stap 3: Herstart consumers
 ssh core-01 "cd /opt/klai && docker compose up -d \
-  retrieval-api knowledge-ingest scribe-api vexa-bot-manager"
+  retrieval-api knowledge-ingest scribe-api vexa-bot-manager research-api"
 ```
 
-Rollback tijd: ~5-10 minuten (model warmup 2-3 min).
+> **Opmerking:** Na gpu-01 herstel: `sudo systemctl start gpu-tunnel.service` en verifieer health checks. Geen rollback van docker-compose nodig als de tunnel gewoon weer werkt.
 
 ---
 
@@ -726,9 +727,10 @@ ssh root@5.9.10.215 "cd /opt/klai-gpu && docker compose restart"
 
 # Wacht op warmup (~2 min), dan verificeer
 ssh root@5.9.10.215 "
-  curl -sf http://127.0.0.1:7997/health
-  curl -sf http://127.0.0.1:8001/health
-  curl -sf http://127.0.0.1:8000/health
+  curl -sf http://127.0.0.1:7997/health   # TEI
+  curl -sf http://127.0.0.1:7998/health   # Infinity reranker
+  curl -sf http://127.0.0.1:8001/health   # BGE-M3 sparse
+  curl -sf http://127.0.0.1:8000/health   # Whisper
 "
 ```
 
@@ -808,13 +810,17 @@ ssh -i ~/.ssh/klai_ed25519 root@65.109.237.64 \
 
 ### Docker + GPU valkuilen
 
-**Infinity API ≠ TEI API:** Infinity (v2) ondersteunt alleen de OpenAI-compatible API (`POST /v1/embeddings` met `{"input": ..., "model": ...}`). De TEI API (`POST /embed` met `{"inputs": ...}`) werkt niet op Infinity. Let ook op het response formaat:
-- TEI: `[[0.1, 0.2, ...]]` (array of arrays)
-- Infinity: `{"data": [{"embedding": [0.1, ...], "index": 0}]}` — sorteer op `index`, resultaten kunnen out-of-order zijn.
+**TEI en Infinity draaien nu op aparte poorten (SPEC-DEVOPS-002):** TEI (HuggingFace text-embeddings-inference) draait op poort 7997 voor dense embeddings; Infinity draait op poort 7998 uitsluitend voor reranking. Beide ondersteunen de OpenAI-compatible API:
+- Embeddings via TEI: `POST http://172.18.0.1:7997/v1/embeddings` — response: `{"data": [{"embedding": [...]}]}`
+- Reranking via Infinity: `POST http://172.18.0.1:7998/v1/rerank` — response: `{"results": [{"relevance_score": ...}]}`
+
+**Waarom TEI voor embeddings, Infinity voor reranking:**
+- TEI: Rust + cuBLASLt, native HuggingFace support voor bge-m3, stabiel VRAM gebruik, Prometheus metrics
+- Infinity: Python + PyTorch, native `/v1/rerank` endpoint (Cohere-compatible), benodigd voor LiteLLM/LibreChat jinaApiUrl integratie. Niet geschikt voor embeddings vanwege bekende GPU memory leak (issue #517).
 
 **GHCR auth op gpu-01:** `ghcr.io/getklai/*` images zijn private. Credentials ophalen via `core-01:~/.docker/config.json` en dan `docker login ghcr.io`.
 
-**VRAM verdeling:** Infinity met bge-m3 + bge-reranker-v2-m3 + Whisper large-v3-turbo = ~5.4 GB van 20 GB VRAM. BGE-M3 sparse draait op CPU (spaart ~1 GB VRAM, doet het goed op CPU).
+**VRAM verdeling:** TEI (bge-m3) ~2 GB + Infinity (bge-reranker-v2-m3) ~1 GB + Whisper large-v3-turbo ~3 GB = ~6 GB van 20 GB VRAM. BGE-M3 sparse draait op CPU (spaart ~1 GB VRAM, doet het goed op CPU).
 
 ### Monitoring valkuilen
 


### PR DESCRIPTION
## Overzicht

Implementatie van SPEC-DEVOPS-002: herstel van de TEI/Infinity split-architectuur op gpu-01, inclusief alle opruimwerk en monitoring fixes.

## Wijzigingen

### Kernimplementatie (commit `1ec8547` — al op main)
- **deploy/docker-compose.yml**: 9 env vars bijgewerkt naar `172.18.0.1` endpoints; 4 GPU service-definities verwijderd (`tei`, `bge-m3-sparse`, `whisper-server`, `infinity-reranker`); stale `depends_on` en volumes opgeruimd
- **klai-knowledge-ingest/knowledge_ingest/config.py**: defaults bijgewerkt naar `172.18.0.1`
- **klai-retrieval-api/retrieval_api/config.py**: defaults bijgewerkt + latente bug fix (`tei-reranker:8080` → `172.18.0.1:7998`)
- **klai-scribe/scribe-api/app/core/config.py**: `whisper_server_url` default bijgewerkt

### Opruimwerk (deze PR)
- **deploy/librechat/librechat.yaml**: stale comment bijgewerkt (`infinity-reranker CPU` → `Infinity gpu-01 GPU :7998`)
- **docs/runbooks/gpu-01-setup.md**: volledige update voor nieuwe architectuur (TEI:7997 + Infinity:7998 split)
- **.moai/specs/SPEC-DEVOPS-002/**: spec, plan en acceptatiecriteria toegevoegd aan repo
- **.claude/rules/klai/pitfalls/process.md**: `process-no-architecture-change-in-migration` pitfall toegevoegd

### Monitoring fix (klai-infra commit `83f0347`)
- **push-health.sh**: Reranker monitor bugfix — port `7997` → `7998`
- **gpu-health.sh**: 3 → 4 endpoints bewaakt (TEI:7997 + Infinity:7998 + sparse:8001 + Whisper:8000)

## Verificatie (uitgevoerd op productie)

| Check | Resultaat |
|---|---|
| `curl http://172.18.0.1:7997/health` (TEI embeddings) | ✅ HTTP 200 |
| `curl http://172.18.0.1:7998/health` (Infinity reranker) | ✅ HTTP 200 |
| `curl http://172.18.0.1:8001/health` (BGE-M3 sparse) | ✅ HTTP 200 |
| `curl http://172.18.0.1:8000/health` (Whisper STT) | ✅ HTTP 200 |
| Embedding test (dims) | ✅ 1024 dims |
| Rerank test (scores) | ✅ score1≈1.0, score2≈0.0 |
| gpu-health.sh handmatig | ✅ GPU_HEALTH_OK |

## SPEC referentie

SPEC-DEVOPS-002 — Definition of Done: alle 10 punten voldaan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)