### PR TITLE
feat(taxonomy): SPEC-KB-027 — taxonomy-aware retrieval + completeness fixes

### DIFF
--- a/.claude/rules/klai/lang/testing.md
+++ b/.claude/rules/klai/lang/testing.md
@@ -9,19 +9,22 @@ paths:
 # Testing Rules
 
 ## [HARD] Close browser when done
-After ANY Playwright testing, close all tabs then `browser_close()`. Brave locks `userDataDir` with `SingletonLock` — leaving it open blocks the next session.
+After ANY Playwright testing, call `browser_close()` explicitly. Even in isolated mode (which
+auto-closes on session disconnect), closing explicitly is required — do not leave it for the
+disconnect event.
 
 ## Playwright MCP workflow
-1. Kill Brave before starting: `pkill -x "Brave Browser"`
-2. Navigate: `browser_navigate({ url: '...' })`
-3. Inspect: `browser_snapshot()` (prefer over screenshots for assertions)
-4. Interact via `ref` from snapshot, never CSS selectors: `browser_click({ ref: 'e66' })`
-5. Close browser when done (see rule above)
+1. Navigate: `browser_navigate({ url: '...' })`
+2. Inspect: `browser_snapshot()` (prefer over screenshots for assertions)
+3. Interact via `ref` from snapshot, never CSS selectors: `browser_click({ ref: 'e66' })`
+4. **Always call `browser_close()` as the final step**
 
 ## Playwright session management
-- Persistent profile at `~/.claude/mcp-brave-profile` — login sessions survive across runs.
-- Brave locks `userDataDir` with `SingletonLock` — only one session at a time.
-- If "Profile already in use": `pkill -x "Brave Browser"`
+- **Isolated mode**: each Claude Code session gets a fresh browser context. Auto-closes on
+  disconnect. No profile locking — multiple sessions can run in parallel.
+- **Login persistence**: stored in `~/.claude/mcp-brave-storageState.json` (cookies + localStorage).
+  Load fresh with `node scripts/export-mcp-session.mjs` if session expires.
+- If login is gone after a session: re-log in, then re-run the export script.
 - Grant permissions programmatically: `context.grantPermissions(['microphone'], { origin: '...' })`
 
 ## Browser console + GlitchTip
@@ -40,6 +43,22 @@ After ANY Playwright testing, close all tabs then `browser_close()`. Brave locks
 - MagicMock is truthy for `.headers.get()` — set `request.headers = {}` explicitly when
   testing middleware that reads optional headers. Otherwise the mock returns a MagicMock
   object that passes truthiness checks.
+
+## Inner-function import patching (HIGH)
+
+When a function imports all its dependencies inside the function body (common in task workers), patching the module-level name fails.
+
+**Why:** `patch("my_module.AsyncQdrantClient")` fails with AttributeError when `AsyncQdrantClient` is only imported inside `_run_backfill()`, not at module level.
+
+**Prevention:** Patch at the source module: `patch("qdrant_client.AsyncQdrantClient")`. When in doubt, look at the actual `import` statement inside the function to find the correct patch target.
+
+## asyncio.gather + AsyncMock produces coroutine-never-awaited warnings (MED)
+
+Patching `asyncio.gather` with `AsyncMock` when the gather call wraps `asyncio.wait_for(inner_fn(), ...)` creates coroutines for the inner calls that are never awaited.
+
+**Why:** `asyncio.wait_for(inner_fn(), ...)` creates a coroutine object before the mocked `gather` discards it, producing `RuntimeWarning: coroutine was never awaited`.
+
+**Prevention:** Extract inner functions as module-level helpers so they can be patched individually. The caller then calls the helper directly, and tests patch the helper — no orphaned coroutines.
 
 ## Frontend test patterns
 - UI bugfixes require browser verification — code reading scores zero.

--- a/.claude/rules/klai/projects/portal-backend.md
+++ b/.claude/rules/klai/projects/portal-backend.md
@@ -42,6 +42,14 @@ result = await db.execute(
 org = result.scalar_one_or_none()
 ```
 
+## FastAPI Depends() triggers ruff B008 (MED)
+
+`Depends(get_current_user)` in function default args is the correct FastAPI pattern, but ruff B008 ("do not perform function call in default arguments") flags it as an error.
+
+**Why:** ruff B008 fires on any function call in a default argument. FastAPI uses this pattern intentionally for dependency injection.
+
+**Prevention:** Add `"B008"` to the `[tool.ruff.lint] ignore` list in `pyproject.toml`. Do not suppress per-line — it appears across every route file.
+
 ## portal-api scripts/ not in Docker image (MED)
 `klai-portal/backend/scripts/` is NOT copied into the container (no `COPY scripts/` in Dockerfile).
 Data migration scripts in `scripts/` cannot be run via `docker exec portal-api python scripts/foo.py`.

--- a/.claude/rules/klai/projects/python-services.md
+++ b/.claude/rules/klai/projects/python-services.md
@@ -24,3 +24,29 @@ paths:
 ## New field on existing request models
 - Always `Optional` with safe default — required fields break existing callers with 422.
 - Guard with explicit check when empty string is valid: `if body.field:`.
+
+## pydantic-settings validates env vars at import time (HIGH)
+
+Services that instantiate `Settings()` at module level fail test imports with `ValidationError: field required` if required env vars are absent.
+
+**Why:** `pydantic-settings` reads and validates environment variables when `Settings()` is constructed — not lazily. Any test file that imports from such a module triggers this before any fixture runs.
+
+**Prevention:** Add a `conftest.py` at the test root that sets required env vars with `os.environ.setdefault(...)` before any imports. This runs before pytest collects test modules.
+
+## Stored config beats per-request plumbing
+
+**When:** A downstream call needs a piece of configuration that originates from a user-created entity (e.g., which knowledge base to query for a notebook).
+
+Store the config on the entity itself (e.g., `kb_slug` column on `Notebook`) and read it at call time. Do not pass it as a field in each request from the frontend.
+
+**Why:** Per-request fields create an API contract that must be maintained by every caller (frontend, integrations, tests). Storing it once on the entity gives a single update point and eliminates the field from every request payload.
+
+**Rule:** Entity-scoped config belongs on the entity, not in every request.
+
+## Return bool from functions that may early-exit (MED)
+
+**When:** A helper function can early-exit without performing its primary action (e.g., threshold not met, token missing, name clash).
+
+Return `bool` — `True` only when the action was actually taken. Never `None` from a function that callers treat as "did it run?".
+
+**Why:** Callers that set a counter/flag unconditionally after calling a void function will count no-ops as successes. `maybe_generate_proposal()` returned `None` on early-exit; the caller incremented `proposals_submitted = 1` regardless.

--- a/.mcp.json
+++ b/.mcp.json
@@ -16,7 +16,7 @@
       "env": {}
     },
     "playwright": {
-      "$comment": "Browser automation for E2E spot-checks. Uses persistent Brave profile. Stop hook auto-enforces browser_close. Supports localhost (dev) and *.getklai.com (prod).",
+      "$comment": "Browser automation for E2E spot-checks. Uses Brave in isolated mode — browser closes automatically on session disconnect. Login state persists via storageState.json (~/.claude/mcp-brave-storageState.json). Multiple Claude Code sessions can run in parallel. Setup: node scripts/export-mcp-session.mjs",
       "type": "stdio",
       "command": "npx",
       "args": ["@playwright/mcp@0.0.70", "--config", ".playwright-mcp/config.json"],

--- a/.moai/specs/SPEC-KB-021/acceptance.md
+++ b/.moai/specs/SPEC-KB-021/acceptance.md
@@ -1,0 +1,144 @@
+---
+id: SPEC-KB-021
+phase: acceptance
+---
+
+# Acceptance Criteria — SPEC-KB-021
+
+## AC-1: Chunk tagging at ingest
+
+**Given** a KB with taxonomy nodes `["Billing", "Technical Support"]`
+**When** a document titled "How to pay your invoice" is ingested
+**Then** all Qdrant chunks for that document have `taxonomy_node_id = <id of Billing node>`
+
+---
+
+**Given** a KB with taxonomy nodes `["Billing", "Technical Support"]`
+**When** a document is ingested whose content does not match any node with confidence ≥ 0.5
+**Then** all chunks for that document have `taxonomy_node_id = null`
+
+---
+
+**Given** a KB with NO taxonomy nodes
+**When** any document is ingested
+**Then** the Qdrant chunk payloads do NOT contain a `taxonomy_node_id` field
+**And** the document IS added to the unmatched batch for proposal generation
+
+---
+
+**Given** the classification LLM call times out (> 5 seconds)
+**When** a document is being ingested
+**Then** ingest completes successfully and chunks have `taxonomy_node_id = null` (no crash, no retry)
+
+## AC-2: Qdrant payload index
+
+**Given** the application starts up
+**When** `_ensure_payload_indexes()` runs
+**Then** a keyword index exists on `taxonomy_node_id` in the `klai_knowledge` collection
+
+## AC-3: Retrieval filter
+
+**Given** a KB with chunks tagged `taxonomy_node_id = 5` (Billing) and `taxonomy_node_id = 7` (Technical)
+**When** a retrieve request includes `{ "taxonomy_node_ids": [5] }`
+**Then** only chunks with `taxonomy_node_id = 5` are returned (Technical chunks excluded)
+
+---
+
+**Given** a retrieve request with no `taxonomy_node_ids` field
+**When** the retrieval pipeline runs
+**Then** no taxonomy filter is applied and all chunks are eligible (existing behavior)
+
+---
+
+**Given** a retrieve request with `taxonomy_node_ids: []` (empty list)
+**When** the retrieval pipeline runs
+**Then** no taxonomy filter is applied (empty = all, same as absent)
+
+## AC-4: Proposal generation
+
+**Given** a batch of 5 documents ingested into a KB with 0 existing taxonomy nodes (self-bootstrap scenario)
+**And** `PORTAL_INTERNAL_TOKEN` is configured
+**When** the batch ingest completes
+**Then** proposals are generated for the clustered documents
+**And** the proposals appear in the portal review queue with status `pending`
+
+---
+
+**Given** a batch of 5 documents ingested into a KB where 4 have `taxonomy_node_id = null`
+**And** `PORTAL_INTERNAL_TOKEN` is configured
+**And** no pending proposal with the same suggested name exists
+**When** the batch ingest completes
+**Then** exactly 1 proposal is submitted to the portal with `proposal_type = "new_node"`
+**And** the proposal appears in the portal's review queue with status `pending`
+
+---
+
+**Given** `PORTAL_INTERNAL_TOKEN` is NOT set
+**When** a batch ingest with ≥3 unmatched documents completes
+**Then** no proposal is submitted
+**And** a warning is logged: `taxonomy_proposal_skipped: missing PORTAL_INTERNAL_TOKEN`
+**And** ingest does NOT fail
+
+---
+
+**Given** a proposal with name "API Documentation" was submitted < 24 hours ago for the same KB
+**When** another batch ingest would generate the same proposal name
+**Then** the proposal is NOT resubmitted (deduplication)
+
+## AC-5: Backfill endpoint
+
+**Given** a KB with 100 existing chunks, all without `taxonomy_node_id`
+**And** the KB has 2 taxonomy nodes
+**When** `POST /ingest/v1/taxonomy/backfill` is called with `{ "org_id": "...", "kb_slug": "..." }`
+**Then** the response contains `{ "processed": N, "tagged": M, "skipped": 0 }` where M ≤ N
+**And** chunks that matched a node have `taxonomy_node_id` set in Qdrant
+**And** chunks with confidence < 0.5 have `taxonomy_node_id = null`
+
+---
+
+**Given** backfill is run a second time on the same KB (already-tagged chunks)
+**When** `POST /ingest/v1/taxonomy/backfill` is called again
+**Then** the response contains `{ "processed": 0, "tagged": 0, "skipped": N }` (idempotent)
+
+---
+
+**Given** the endpoint is called without `X-Internal-Token` header
+**When** the request hits the endpoint
+**Then** the response is `401 Unauthorized`
+
+## AC-6: Gap event taxonomy signal
+
+**Given** a retrieve request includes `taxonomy_node_ids: [5]`
+**And** retrieval returns no results (hard gap)
+**When** the gap event is fired
+**Then** the gap event payload includes `taxonomy_node_ids: [5]`
+
+---
+
+**Given** a retrieve request has NO `taxonomy_node_ids`
+**And** a gap is detected
+**When** the gap event is fired
+**Then** the gap event payload does NOT include `taxonomy_node_ids` (no change to existing behavior)
+
+## AC-7: No regression
+
+**Given** all existing unit and integration tests
+**When** this feature is deployed
+**Then** all existing tests pass (zero regressions)
+
+---
+
+**Given** production retrieval latency baseline (P95 ~400ms)
+**When** taxonomy filter is active in a retrieve request
+**Then** P95 latency does NOT increase by more than 20ms
+
+## Test Coverage Targets
+
+| Component | Target |
+|---|---|
+| `taxonomy_classifier.py` | 90%+ (mock LLM calls) |
+| `portal_client.py` | 85%+ |
+| `qdrant_store.py` additions | 85%+ |
+| Retrieval filter | 90%+ |
+| Backfill endpoint | 80%+ |
+| Proposal generation | 85%+ |

--- a/.moai/specs/SPEC-KB-021/plan.md
+++ b/.moai/specs/SPEC-KB-021/plan.md
@@ -1,0 +1,134 @@
+---
+id: SPEC-KB-021
+phase: plan
+---
+
+# Implementation Plan — SPEC-KB-021
+
+## Phase 1: Qdrant infrastructure (Day 1)
+
+**File:** `klai-knowledge-ingest/knowledge_ingest/qdrant_store.py`
+
+1. Add `taxonomy_node_id` to `_ensure_payload_indexes()` — create keyword index alongside existing ones
+2. Add `taxonomy_node_id: int | None` parameter to `upsert_chunks()` and `upsert_full_document()` — store in `base_payload` when provided
+3. No migration needed — Qdrant schema is additive
+
+## Phase 2: Classification service (Day 1–2)
+
+**New file:** `klai-knowledge-ingest/knowledge_ingest/taxonomy_classifier.py`
+
+```python
+async def classify_document(
+    title: str,
+    content_preview: str,  # first 500 chars
+    taxonomy_nodes: list[TaxonomyNode],  # id + name
+) -> tuple[int | None, float]:
+    """Returns (node_id, confidence). node_id=None if confidence < 0.5 or no nodes."""
+```
+
+- Uses `klai-fast` via LiteLLM
+- Structured output: `{ "node_id": int | null, "confidence": float, "reasoning": str }`
+- 5-second timeout, falls back to `(None, 0.0)` on error
+- Unit-testable without LLM (mock the LiteLLM call)
+
+**New file:** `klai-knowledge-ingest/knowledge_ingest/portal_client.py`
+
+```python
+async def fetch_taxonomy_nodes(kb_slug: str, org_id: str) -> list[TaxonomyNode]
+async def submit_taxonomy_proposal(kb_slug: str, proposal: TaxonomyProposal) -> None
+```
+
+- Reads `PORTAL_URL` + `PORTAL_INTERNAL_TOKEN` from settings
+- `fetch_taxonomy_nodes` result is cached per (org_id, kb_slug) for 5 minutes
+- Missing token → returns empty list / skips submission with warning log
+
+## Phase 3: Ingest pipeline integration (Day 2)
+
+**File:** `klai-knowledge-ingest/knowledge_ingest/tasks.py` (or wherever document ingest is orchestrated)
+
+In the document ingest task, after chunking and before embedding:
+
+```python
+taxonomy_nodes = await portal_client.fetch_taxonomy_nodes(kb_slug, org_id)
+if taxonomy_nodes:
+    node_id, confidence = await classify_document(title, content[:500], taxonomy_nodes)
+else:
+    node_id = None
+# pass node_id to upsert_chunks(...)
+```
+
+Track documents with `node_id = None` per batch. After batch completes, run proposal generation if ≥3 unmatched.
+
+## Phase 4: Proposal generation (Day 2–3)
+
+**File:** `klai-knowledge-ingest/knowledge_ingest/proposal_generator.py`
+
+```python
+async def maybe_generate_proposal(
+    org_id: str,
+    kb_slug: str,
+    unmatched_documents: list[DocumentSummary],
+    existing_nodes: list[TaxonomyNode],
+) -> None
+```
+
+- Uses `klai-fast` to suggest a category name for the cluster of unmatched documents
+- Deduplication: query portal for existing pending proposals with same name before submitting
+- Submits via `portal_client.submit_taxonomy_proposal()`
+
+## Phase 5: Retrieval filter (Day 3)
+
+**File:** `klai-retrieval-api/retrieval_api/api/retrieve.py`
+
+Add `taxonomy_node_ids: list[int] | None = None` to `RetrieveRequest`.
+
+**File:** `klai-retrieval-api/retrieval_api/services/search.py`
+
+In the Qdrant prefetch builder, if `taxonomy_node_ids` is non-empty, add:
+```python
+FieldCondition(key="taxonomy_node_id", match=MatchAny(any=taxonomy_node_ids))
+```
+alongside existing org_id/kb_slug conditions.
+
+## Phase 6: Backfill endpoint (Day 3–4)
+
+**File:** `klai-knowledge-ingest/knowledge_ingest/routes/backfill.py` (or add to existing routes)
+
+`POST /ingest/v1/taxonomy/backfill`
+- Protected by `X-Internal-Token` header
+- Scrolls Qdrant with filter `{ must_not: [{ key: "taxonomy_node_id", is_empty: false }] }` per org/kb
+- Classifies each unique (path, artifact_id) document once, updates all its chunks with `set_payload`
+- Returns progress stats
+
+## Phase 7: Gap event tagging (Day 4)
+
+**File:** `deploy/litellm/klai_knowledge.py` (the LiteLLM hook)
+
+When firing gap event and `taxonomy_node_ids` was in the retrieve request, include them in the event payload.
+
+---
+
+## Milestone Summary
+
+| Milestone | Deliverable | Day |
+|---|---|---|
+| M1 | Qdrant index + upsert with taxonomy_node_id | 1 |
+| M2 | TaxonomyClassifier + PortalClient | 1–2 |
+| M3 | Ingest pipeline tags chunks at ingest time | 2 |
+| M4 | Proposal generation when ≥3 docs unmatched | 2–3 |
+| M5 | Retrieval API accepts taxonomy_node_ids filter | 3 |
+| M6 | Backfill endpoint for existing chunks | 3–4 |
+| M7 | Gap events include taxonomy signal | 4 |
+
+Total estimated effort: 3–4 days single developer.
+
+---
+
+## Risk Register
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| klai-fast classification quality is too low | Medium | Start with confidence threshold 0.5, monitor hit rate; lower to 0.3 if needed |
+| Portal fetch_taxonomy_nodes adds latency to ingest | Low | Cache result 5 min; skip gracefully if portal unreachable |
+| Backfill runs too slowly on large KBs | Medium | batch_size param + configurable sleep between batches |
+| Duplicate proposals spam the review queue | Low | Deduplication query before submit + 24h window |

--- a/.moai/specs/SPEC-KB-021/spec.md
+++ b/.moai/specs/SPEC-KB-021/spec.md
@@ -1,0 +1,168 @@
+---
+id: SPEC-KB-021
+version: "1.0"
+status: draft
+created: "2026-04-05"
+updated: "2026-04-05"
+author: Mark Vletter
+priority: medium
+tags: [taxonomy, retrieval, knowledge-ingest, qdrant, proposals]
+related: [SPEC-TAXONOMY-001, SPEC-KB-015, SPEC-KB-020]
+---
+
+# SPEC-KB-021: Taxonomy Integration — Chunk Tagging, Retrieval Filtering & Proposal Generation
+
+## Context
+
+The portal has a complete taxonomy infrastructure (nodes, proposals, review queue UI, API) but no producer. Taxonomy nodes exist in PostgreSQL only — they have zero effect on retrieval because Qdrant chunks carry no category information. The result: taxonomy is a standalone editorial tool with no downstream impact on what the AI retrieves or how gap detection works.
+
+Research confirms that taxonomy-guided retrieval yields 35–48% higher precision over flat vector search. The missing integration has three parts:
+
+1. **Chunk tagging at ingest** — store `taxonomy_node_id` on Qdrant chunks so retrieval can filter by category
+2. **Proposal generation** — knowledge-ingest suggests new taxonomy categories based on document clustering
+3. **Retroactive backfill** — classify existing chunks that predate this feature
+
+A fourth integration (gap detection × taxonomy) is included as an additive signal.
+
+---
+
+## Scope
+
+**In scope:**
+- `klai-knowledge-ingest`: classify documents at ingest time, store taxonomy_node_id in Qdrant payload, generate proposals to portal, expose backfill endpoint
+- `klai-retrieval-api`: add optional `taxonomy_node_ids` filter to RetrieveRequest
+- `klai-portal/backend`: internal taxonomy proposals endpoint (already exists — verify it works end-to-end)
+
+**Out of scope:**
+- klai-docs publication structure with taxonomy navigation (separate SPEC)
+- User-facing taxonomy selector in the KBScopeBar (separate SPEC, depends on this)
+- Graph-based taxonomy traversal or ontology expansion
+
+---
+
+## Requirements
+
+### R1 — Chunk Tagging at Ingest
+
+WHEN a document is ingested into a knowledge base that has at least one taxonomy node,
+THEN the ingest pipeline SHALL classify the document into the best matching taxonomy node
+and store `taxonomy_node_id` (integer | null) on all resulting Qdrant chunks.
+
+WHEN no taxonomy node matches with sufficient confidence (< 0.5),
+THEN `taxonomy_node_id` SHALL be stored as `null` on the chunks.
+
+WHEN a knowledge base has NO taxonomy nodes,
+THEN classification SHALL be skipped (no LLM call), `taxonomy_node_id` SHALL be omitted from chunks,
+AND the document SHALL be added to the "unmatched" batch for proposal generation (see R4).
+
+The classification SHALL use `klai-fast` with:
+- Input: document title + first 500 characters of content
+- Context: list of existing taxonomy node names (id + name)
+- Output: `{ node_id: int | null, confidence: float }`
+- Timeout: 5 seconds; on timeout, store `null` without failing the ingest
+
+### R2 — Qdrant Payload Index
+
+The system SHALL create a `keyword`-type payload index on `taxonomy_node_id` in the `klai_knowledge` collection,
+alongside existing indexes for `org_id`, `kb_slug`, `artifact_id`, etc.
+
+### R3 — Retrieval Filter
+
+WHEN a retrieve request includes `taxonomy_node_ids: list[int]` (non-empty),
+THEN the Qdrant query SHALL add a `MatchAny` filter on `taxonomy_node_id`
+in addition to existing `org_id` and `kb_slug` filters.
+
+IF `taxonomy_node_ids` is absent or empty,
+THEN no taxonomy filter SHALL be applied (existing behavior preserved).
+
+The `taxonomy_node_ids` field SHALL be optional in `RetrieveRequest` with default `None`.
+
+### R4 — Proposal Generation (self-bootstrapping)
+
+WHEN knowledge-ingest finishes ingesting a batch of documents for a KB,
+AND at least one document in the batch is "unmatched" (either `taxonomy_node_id = null` OR the KB has no nodes),
+THEN the ingest service SHALL cluster the unmatched documents and call
+`POST /api/app/knowledge-bases/{kb_slug}/taxonomy/proposals` for each detected cluster,
+using `klai-fast` to generate a suggested category name per cluster.
+
+This means the system is self-bootstrapping:
+- KB with 0 nodes: all documents are unmatched → proposals are generated from scratch
+- KB with existing nodes: only truly unmatched documents (confidence < 0.5) trigger proposals
+
+The proposal SHALL only be submitted when:
+- At least 3 documents are in the unmatched batch
+- The suggested category name does not already exist among the KB's taxonomy nodes or pending proposals
+- The portal internal token is configured (`PORTAL_INTERNAL_TOKEN` env var)
+
+IF `PORTAL_INTERNAL_TOKEN` is not configured,
+THEN proposal submission SHALL be skipped silently (log a warning, do not fail ingest).
+
+### R5 — Backfill Endpoint
+
+The system SHALL expose `POST /ingest/v1/taxonomy/backfill` (internal endpoint, requires `X-Internal-Token`).
+
+Request body:
+```json
+{ "org_id": "string", "kb_slug": "string", "batch_size": 100 }
+```
+
+WHEN called, the endpoint SHALL:
+1. Fetch taxonomy nodes for the given KB from the portal
+2. Iterate Qdrant chunks for that org/KB that have no `taxonomy_node_id` payload field
+3. For each chunk, classify using `klai-fast` and update the Qdrant payload via `set_payload`
+4. Return `{ "processed": int, "tagged": int, "skipped": int }`
+
+The endpoint SHALL be idempotent: re-running on already-tagged chunks SHALL be a no-op.
+
+### R6 — Gap Event Taxonomy Signal
+
+WHEN a gap event is fired (hard gap or soft gap),
+AND the retrieval request included a `taxonomy_node_ids` filter,
+THEN the gap event payload SHALL include `taxonomy_node_ids` so editorial tooling can correlate unmet queries to specific knowledge areas.
+
+This is additive — gap events without taxonomy context continue to fire unchanged.
+
+### R7 — Constraints
+
+The system SHALL NOT break existing retrieval behavior when taxonomy_node_id is absent from a chunk payload.
+The system SHALL NOT increase P95 retrieval latency by more than 20ms.
+The system SHALL NOT call the taxonomy classification LLM more than once per document (not per chunk).
+The system SHALL NOT submit duplicate proposals (same name, same KB) within a 24-hour window.
+
+---
+
+## Data Model Changes
+
+### Qdrant chunk payload (additions)
+
+```
+taxonomy_node_id: int | null   (new, optional field)
+                               null  = classified, no match
+                               <int> = matched to portal taxonomy node ID
+                               absent = KB has no taxonomy nodes
+```
+
+### RetrieveRequest (additions)
+
+```python
+taxonomy_node_ids: list[int] | None = None
+```
+
+### knowledge-ingest environment variables (additions)
+
+```
+PORTAL_URL               # already used for other internal calls (or new)
+PORTAL_INTERNAL_TOKEN    # shared secret for internal portal endpoints
+```
+
+---
+
+## Assumptions
+
+| Assumption | Confidence | Risk if wrong |
+|---|---|---|
+| `klai-fast` can classify a document into a taxonomy node from title + 500 chars | High | Classification quality drops; mitigation: lower confidence threshold → more nulls |
+| Portal taxonomy endpoint authentication uses X-Internal-Token header | High | Check existing implementation in portal backend |
+| Qdrant set_payload is safe to call on existing points | High | Standard Qdrant operation |
+| Backfill can run without blocking production traffic | Medium | Add rate limiting (batch_size + sleep between batches) |
+| LLM cost for classification is acceptable (1 call per document) | High | klai-fast is the cheapest tier; classification is a tiny call |

--- a/.moai/specs/SPEC-KB-026/spec.md
+++ b/.moai/specs/SPEC-KB-026/spec.md
@@ -1,0 +1,250 @@
+---
+id: SPEC-KB-026
+version: "1.1.0"
+status: approved
+created: "2026-04-06"
+updated: "2026-04-06"
+author: Mark Vletter
+priority: high
+tags: [taxonomy, hardening, gap-classification, clustering, auto-categorise]
+related: [SPEC-KB-021, SPEC-KB-022, SPEC-KB-023, SPEC-KB-024, SPEC-KB-027]
+---
+
+# SPEC-KB-026: Taxonomy Integration Hardening
+
+## HISTORY
+
+| Versie | Datum | Auteur | Wijziging |
+|---|---|---|---|
+| 1.0.0 | 2026-04-06 | Mark Vletter | Initiele versie na holistische code review KB-021 t/m KB-025 |
+| 1.1.0 | 2026-04-06 | Mark Vletter | Tag governance (R7+R8) verplaatst naar SPEC-KB-027; R5 Procrastinate bevestigd aanwezig in portal |
+
+---
+
+## Context
+
+Na de implementatie van KB-021 t/m KB-025 is een holistische code review uitgevoerd. De architectuur is solide en de happy path werkt, maar een aantal integratiepunten zijn onafgemaakt, fout gekoppeld, of bevatten stille failures.
+
+De meest kritieke bug: `clustering_tasks.py` roept `submit_taxonomy_proposal()` aan met een verkeerde functie-signature. Dit veroorzaakt een `TypeError` bij elke clustering run — **de clustering job heeft nog nooit een voorstel ingediend**. Als gevolg hiervan vuurt auto-categorise ook nooit, want het centroid bereikt de portal nooit.
+
+Dit SPEC richt de zes gevonden problemen op prioriteitsvolgorde. Tag governance (KB-022 R5) is bewust buiten scope gehouden en komt in SPEC-KB-027.
+
+---
+
+## Scope
+
+**In scope:**
+- `klai-knowledge-ingest`: fix `submit_taxonomy_proposal` signature mismatch in `clustering_tasks.py`
+- `klai-knowledge-ingest`: voeg `cluster_centroid` toe aan `TaxonomyProposal` + `portal_client.py`
+- `klai-knowledge-ingest`: genereer description in `maybe_generate_proposal()`
+- `klai-knowledge-ingest`: voeg max-age check toe aan `load_centroids()`
+- `klai-knowledge-ingest`: nieuw intern classify endpoint voor gap classificatie
+- `klai-portal/backend`: implementeer gap taxonomy classificatie (stub afmaken in `internal.py`)
+- `klai-portal/backend`: maak auto-categorise betrouwbaar via Procrastinate
+
+**Buiten scope:**
+- Tag governance (→ SPEC-KB-027)
+- Clustering merge/split UI
+- Cross-KB taxonomy coherentie
+- Float precision optimalisatie van centroid opslag
+
+---
+
+## Requirements
+
+### R1 — Fix: `submit_taxonomy_proposal` API mismatch (KRITIEK — runtime crash)
+
+WHEN de clustering job (`clustering_tasks.py`) een voorstel indient,
+THEN SHALL de aanroep naar `submit_taxonomy_proposal` de correcte signature gebruiken van `portal_client.py`.
+
+**Huidig probleem:**
+`clustering_tasks.py` roept `submit_taxonomy_proposal()` aan met keyword arguments (`proposal_type`, `title`, `description`, `payload`) die niet bestaan in de functie-signature van `portal_client.py` (die accepteert alleen `(kb_slug, org_id, proposal: TaxonomyProposal)`).
+Dit veroorzaakt een `TypeError` bij iedere clustering run — **de clustering job submit nooit proposals**.
+
+**Fix:** pas `clustering_tasks.py` aan zodat het een `TaxonomyProposal` object aanmaakt en dat meegeeft. De `portal_client` API blijft ongewijzigd — die wordt al correct gebruikt door `proposal_generator.py`.
+
+Schrijf een unit test die bewijst dat de `clustering_tasks.py` → `portal_client.py` koppeling werkt zonder `TypeError`.
+
+### R2 — Fix: `cluster_centroid` ontbreekt in proposal payload (KRITIEK — auto-categorise vuurt nooit)
+
+WHEN de clustering job een nieuw cluster proposal indient,
+THEN SHALL `cluster_centroid: list[float]` aanwezig zijn in het `payload` dict van het proposal.
+
+**Huidig probleem:**
+`portal_client.py`'s `TaxonomyProposal` dataclass heeft geen `cluster_centroid` veld.
+`portal/api/taxonomy.py` leest `payload.get("cluster_centroid")` bij approval — dit is altijd `None` → auto-categorise vuurt nooit.
+
+**Oplossing:**
+1. Voeg `cluster_centroid: list[float] | None = None` toe aan `TaxonomyProposal` dataclass
+2. Pas `submit_taxonomy_proposal` aan zodat `cluster_centroid` in de `payload` dict wordt meegezonden:
+   ```json
+   {
+     "proposal_type": "new_node",
+     "title": "<name>",
+     "payload": {
+       "suggested_name": "<name>",
+       "document_count": N,
+       "sample_titles": [...],
+       "description": "<desc>",
+       "cluster_centroid": [0.123, ...]
+     }
+   }
+   ```
+3. `clustering_tasks.py` vult `proposal.cluster_centroid` vanuit `cluster.centroid`
+
+WHEN het cluster geen centroid heeft (bijv. bij `maybe_generate_proposal` vanuit reguliere ingest),
+THEN SHALL `cluster_centroid` `null` zijn in de payload — auto-categorise wordt dan overgeslagen.
+
+R1 en R2 worden samen geïmplementeerd in één PR.
+
+### R3 — Fix: descriptions ontbreken bij incrementele proposals (MAJOR — classificatiekwaliteit)
+
+WHEN `maybe_generate_proposal()` een voorstel indient vanuit reguliere ingest (niet bootstrap),
+THEN SHALL het systeem `generate_node_description()` aanroepen voor de suggested_name
+AND de gegenereerde description opslaan in `proposal.description`.
+
+**Huidig probleem:**
+`generate_bootstrap_proposals()` genereert descriptions correct.
+`maybe_generate_proposal()` maakt een `TaxonomyProposal` aan zonder `generate_node_description()` aan te roepen — description blijft altijd `""`. Oversight.
+
+**Fix:** voeg één `await generate_node_description(suggested_name, None, sample_titles)` aanroep toe in `maybe_generate_proposal()` na het bepalen van `suggested_name`. Gebruik dezelfde error-handling als `generate_bootstrap_proposals()` (exception → `""`).
+
+### R4 — Fix: gap taxonomy classificatie niet gekoppeld (MAJOR — KB-022 R6 onafgemaakt)
+
+**Huidig probleem:**
+`internal.py` → `create_gap_event()` heeft een skeleton voor async gap classificatie (regels 553–594), maar logt `"gap_classification_skipped: reason=async classification not yet connected to ingest service"` en doet verder niks.
+
+WHEN een gap event binnenkomt zonder `taxonomy_node_ids`
+AND de gap heeft een `nearest_kb_slug`,
+THEN SHALL het portal de gap query asynchroon classificeren via een nieuw intern endpoint in knowledge-ingest
+AND het resultaat (`taxonomy_node_ids: list[int]`) opslaan op de gap record.
+
+Het nieuwe classify endpoint (`POST /ingest/v1/taxonomy/classify`) ontvangt:
+```json
+{"org_id": "<str>", "kb_slug": "<str>", "text": "<gap query>"}
+```
+En retourneert:
+```json
+{"taxonomy_node_ids": [5, 7]}
+```
+
+Het endpoint gebruikt de bestaande `classify_document()` functie uit `taxonomy_classifier.py`.
+
+De classificatie is best-effort: timeout of service unavailable → gap opgeslagen zonder `taxonomy_node_ids`. De gap-opslag wordt nooit geblokkeerd.
+
+Na succesvolle classificatie: `UPDATE portal_retrieval_gaps SET taxonomy_node_ids = ? WHERE id = ?`.
+
+### R5 — Fix: auto-categorise fire-and-forget vervangen door Procrastinate job (MAJOR — stille failures)
+
+**Huidig probleem:**
+`portal/api/taxonomy.py` gebruikt `asyncio.create_task()` voor de auto-categorise call naar knowledge-ingest. Bij herstart of tijdelijke unavailability van knowledge-ingest wordt de categorisatie stilletjes gemist — geen retry, geen foutmelding.
+
+WHEN een taxonomy node wordt goedgekeurd (proposal approved),
+THEN SHALL het portal een Procrastinate background job inplannen voor auto-categorise.
+
+Het Procrastinate job ontvangt: `org_id`, `kb_slug`, `node_id`, `cluster_centroid`.
+
+WHEN de knowledge-ingest service niet bereikbaar is,
+THEN SHALL Procrastinate de job maximaal 3 keer herproberen met exponential backoff (30s, 5m, 30m).
+
+WHEN alle retries mislukken,
+THEN SHALL `log.error("auto_categorise_exhausted", ...)` worden gelogd.
+
+Na goedkeuring toont de portal een melding: "Categorie aangemaakt, documenten worden op de achtergrond gecategoriseerd."
+
+### R6 — Fix: centroid store max-age check ontbreekt (MEDIUM — stille classificatiefout)
+
+WHEN `load_centroids()` wordt aangeroepen,
+THEN SHALL het systeem controleren of `computed_at` in het centroid bestand niet ouder is dan `TAXONOMY_CENTROID_MAX_AGE_HOURS` (default: 48u).
+
+IF het bestand ouder is,
+THEN SHALL `load_centroids()` `None` retourneren (LLM-classificatie wordt gebruikt)
+AND `log.warning("centroid_store_stale", age_hours=..., path=...)` worden gelogd.
+
+Rationale voor 48u: de clustering job draait elke 24u — dit geeft één marge-dag voordat het een zichtbaar probleem wordt.
+
+Voeg `taxonomy_centroid_max_age_hours: int = 48` toe aan `config.py`.
+
+---
+
+## Data Model Wijzigingen
+
+### `TaxonomyProposal` dataclass (klai-knowledge-ingest)
+
+```python
+@dataclass
+class TaxonomyProposal:
+    proposal_type: str                              # "new_node"
+    suggested_name: str
+    document_count: int
+    sample_titles: list[str]
+    description: str = ""
+    cluster_centroid: list[float] | None = None     # NIEUW (R2)
+```
+
+### `portal_client.submit_taxonomy_proposal` payload
+
+```json
+{
+  "proposal_type": "new_node",
+  "title": "<name>",
+  "payload": {
+    "suggested_name": "<name>",
+    "document_count": N,
+    "sample_titles": [...],
+    "description": "<desc>",
+    "cluster_centroid": [<float>, ...] | null
+  }
+}
+```
+
+### `config.py` (klai-knowledge-ingest) — nieuwe env var
+
+```python
+taxonomy_centroid_max_age_hours: int = 48
+```
+
+### Nieuw classify endpoint (klai-knowledge-ingest)
+
+`POST /ingest/v1/taxonomy/classify`
+
+Request: `{"org_id": "<str>", "kb_slug": "<str>", "text": "<str>"}`
+Response: `{"taxonomy_node_ids": [<int>, ...]}`
+
+---
+
+## Volgorde van implementatie
+
+| Stap | Requirements | Reden |
+|------|-------------|-------|
+| 1 | R1 + R2 | Hangen samen; samen één PR |
+| 2 | R3 | Klein, één file, onafhankelijk |
+| 3 | R4 | Nieuw endpoint + portal wiring |
+| 4 | R5 | Portal backend, Procrastinate job |
+| 5 | R6 | Klein, één file, onafhankelijk |
+
+---
+
+## Acceptatiecriteria
+
+| # | Criterium | Verificatie |
+|---|-----------|-------------|
+| AC1 | `clustering_tasks.py` gooit geen `TypeError` bij proposal submission | Unit test: mock `submit_taxonomy_proposal`, verify call arguments matchen `TaxonomyProposal` signature |
+| AC2 | `cluster_centroid` is aanwezig in portal na clustering run | Check DB: `SELECT payload->>'cluster_centroid' FROM taxonomy_proposals WHERE proposal_type='new_node' LIMIT 5` |
+| AC3 | Auto-categorise vuurt na approval van een cluster-proposal | Approve voorstel, wacht 10s, check Qdrant payloads + logs `auto_categorise_triggered` |
+| AC4 | Incrementele proposals hebben een description niet leeg | Trigger `maybe_generate_proposal`, inspect ingediend voorstel in portal |
+| AC5 | Gap events zonder taxonomy_node_ids krijgen ze asynchroon | POST gap event zonder taxonomy_node_ids, wacht 5s, check DB: `taxonomy_node_ids IS NOT NULL` |
+| AC6 | Classify endpoint retourneert correcte nodes | `POST /ingest/v1/taxonomy/classify` met bekende query, verify geretourneerde node IDs kloppen |
+| AC7 | Verouderd centroid bestand wordt niet gebruikt | Zet `computed_at` naar 49u geleden, ingest doc, check logs voor `centroid_store_stale` |
+| AC8 | Auto-categorise job retry na tijdelijke failure | Stop knowledge-ingest, keur voorstel goed, herstart service, verify Procrastinate job slaagt alsnog |
+
+---
+
+## Aannames
+
+| Aanname | Confidence | Risico als fout |
+|---|---|---|
+| `classify_document()` in `taxonomy_classifier.py` is bruikbaar als backend voor classify endpoint | Hoog | Minimale aanpassing nodig |
+| Procrastinate is geconfigureerd in portal-api (bevestigd door Mark) | Hoog | Geen fallback nodig |
+| Qdrant `set_payload` is safe voor concurrent updates | Hoog | Race conditions bij extreem hoog volume; acceptabel |
+| Centroid opslaan als JSONB (~10KB per voorstel) is performant genoeg | Hoog | PostgreSQL comprimeert JSONB; volumes zijn laag |

--- a/.moai/specs/SPEC-KB-027/acceptance.md
+++ b/.moai/specs/SPEC-KB-027/acceptance.md
@@ -1,0 +1,70 @@
+# SPEC-KB-027 — Acceptance Criteria
+
+## Scenario 1: Taxonomy-aware retrieval bij voldoende coverage
+
+**Given** een KB met 10 chunks waarvan 8 gecategoriseerd (80% coverage)
+**And** de query "Hoe stel ik SSO in?" classificeert naar node_id=5 ("Setup > SSO")
+**When** de research-api een retrieval request uitvoert
+**Then** de retrieval-api ontvangt `taxonomy_node_ids=[5]` in het request
+**And** de retrieval-api logt `taxonomy_filter_applied=true, node_ids=[5]`
+**And** alleen chunks met `taxonomy_node_ids` containing 5 worden opgehaald
+
+## Scenario 2: Taxonomy filter overgeslagen bij lage coverage
+
+**Given** een KB met 10 chunks waarvan 2 gecategoriseerd (20% coverage < 30% drempel)
+**When** de research-api een retrieval request uitvoert
+**Then** de retrieval-api ontvangt `taxonomy_node_ids=None` (geen filter)
+**And** de research-api logt `taxonomy_filter_skipped=true, reason=low_coverage, coverage=0.20`
+**And** retrieval werkt identiek aan het huidige gedrag
+
+## Scenario 3: Taxonomy filter overgeslagen bij classify timeout
+
+**Given** het knowledge-ingest classify endpoint reageert niet binnen 3 seconden
+**When** de research-api een retrieval request uitvoert
+**Then** de retrieval-api ontvangt `taxonomy_node_ids=None`
+**And** de research-api logt `taxonomy_classify_timeout=true`
+**And** de gebruiker merkt geen vertraging >3s extra ten opzichte van normale retrieval
+
+## Scenario 4: Backfill genereert proposal voor cluster van ongematchde documenten
+
+**Given** een KB met 6 ongeclassificeerde documenten
+**And** de taxonomy heeft 2 nodes maar geen van de 6 docs match (confidence < 0.5)
+**When** een backfill job wordt gestart voor deze KB
+**Then** na Phase 2 wordt `maybe_generate_proposal` aangeroepen met 6 `DocumentSummary` objecten
+**And** er verschijnt 1 nieuw voorstel in de portal review queue
+**And** het voorstel heeft een niet-lege `title` en `description`
+
+## Scenario 5: Dead code verwijderd uit ingest route
+
+**Given** een ingest request voor een document dat niet classificeert
+**When** de ingest endpoint het document verwerkt
+**Then** er wordt GEEN `asyncio.create_task` aangemaakt voor `maybe_generate_proposal`
+**And** `grep -r "maybe_generate_proposal" klai-knowledge-ingest/knowledge_ingest/routes/` geeft geen resultaat
+
+## Scenario 6: doc_count kolom niet meer aanwezig
+
+**Given** de migratie is uitgevoerd
+**When** `\d portal_taxonomy_nodes` wordt uitgevoerd
+**Then** is `doc_count` niet aanwezig in de kolomlijst
+**And** `GET /api/app/knowledge-bases/{slug}/taxonomy/nodes` bevat geen `doc_count` veld in de response items
+
+## Scenario 7: Coverage dashboard nog correct na doc_count verwijdering
+
+**Given** een KB met taxonomy nodes en 50 gecategoriseerde chunks
+**When** de coverage dashboard wordt geladen
+**Then** toont elke node een chunk count groter dan 0 (opgehaald uit Qdrant)
+**And** de totale chunk count klopt met de werkelijke Qdrant count
+**And** er is geen NullPointerException of leeg veld waar een count verwacht wordt
+
+## Edge cases
+
+- **Lege taxonomy:** KB heeft 0 taxonomy nodes → classify stap overgeslagen, retrieval normaal
+- **Alle chunks ongeclassificeerd:** coverage = 0% → filter overgeslagen, retrieval normaal
+- **Classify retourneert ongeldige node IDs:** node IDs die niet in KB's taxonomy zitten → filter overgeslagen (veiligheidscheck)
+- **Backfill met alle gematchde docs:** `unmatched_summaries = []` → `maybe_generate_proposal` niet gecalled
+
+## Performance criteria
+
+- Taxonomy classify + coverage parallel call: max 3 seconden extra latency, P95
+- Bij timeout: retrieval niet geblokkeerd — gaat door zonder filter
+- Geen merkbare latency impact wanneer taxonomy filter overgeslagen wordt (< 5ms overhead)

--- a/.moai/specs/SPEC-KB-027/plan.md
+++ b/.moai/specs/SPEC-KB-027/plan.md
@@ -1,0 +1,82 @@
+# SPEC-KB-027 — Implementation Plan
+
+## Task decomposition
+
+### Stap 1: R2 — Verwijder dead code + fix backfill proposals
+
+**Files:**
+- `klai-knowledge-ingest/knowledge_ingest/routes/ingest.py`
+- `klai-knowledge-ingest/knowledge_ingest/taxonomy_tasks.py`
+- `klai-knowledge-ingest/tests/test_taxonomy_classifier.py` (of nieuw test file)
+
+**Wijzigingen:**
+1. Verwijder het `asyncio.create_task(maybe_generate_proposal(...))` blok in `ingest.py`
+2. Verwijder de `_background_tasks` set en `maybe_generate_proposal` import uit `ingest.py` (als niet elders gebruikt — controleer)
+3. In `taxonomy_tasks.py` `_run_backfill()` Phase 2: voeg `unmatched_summaries: list[DocumentSummary] = []` toe, vul bij elke batch waar `node_ids = []`
+4. Aan het einde van Phase 2: `await maybe_generate_proposal(org_id, kb_slug, unmatched_summaries, taxonomy_nodes)`
+5. Update return dict om `proposals_submitted: int` toe te voegen
+
+**Testbaar via:**
+- Unit test: `_run_backfill` met 5 unmatched docs → `maybe_generate_proposal` gecalled met 5 docs
+- Unit test: `_run_backfill` met 0 unmatched docs → `maybe_generate_proposal` niet gecalled
+
+---
+
+### Stap 2: R3 — doc_count verwijdering
+
+**Files:**
+- `klai-portal/backend/app/models/taxonomy.py`
+- `klai-portal/backend/app/api/taxonomy.py`
+- `klai-portal/backend/alembic/versions/<new_migration>.py`
+- Frontend: zoek naar `doc_count` in `klai-portal/frontend/src/`
+
+**Wijzigingen:**
+1. Verwijder `doc_count` uit `PortalTaxonomyNode` SQLAlchemy model
+2. Verwijder `doc_count` uit `TaxonomyNodeOut` Pydantic schema
+3. Verwijder alle `doc_count` mutaties in `delete_taxonomy_node()` en `_execute_merge()`
+4. Nieuwe Alembic migratie: `op.drop_column("portal_taxonomy_nodes", "doc_count")`
+5. Frontend: vervang `node.doc_count` door coverage-stats data of verberg het veld
+
+**Volgorde:** model → API → migratie → frontend
+
+---
+
+### Stap 3: R1 — Query classificatie in research-api
+
+**Files:**
+- `klai-focus/research-api/app/services/retrieval_client.py`
+- `klai-focus/research-api/app/services/retrieval.py`
+- `klai-focus/research-api/app/core/config.py`
+
+**Wijzigingen:**
+1. Voeg `taxonomy_retrieval_min_coverage: float = 0.3` en `knowledge_ingest_url: str` toe aan config
+2. Maak nieuwe functie `get_taxonomy_filter(query: str, kb_slug: str, org_id: str) -> list[int] | None`:
+   - Parallel: `classify_query(...)` + `get_coverage(...)` via `asyncio.gather()`
+   - Coverage check: `(total - untagged) / total >= min_coverage`
+   - Retourneert `None` bij failure of lage coverage
+3. In `retrieval_client.py` `retrieve()`: roep `get_taxonomy_filter()` aan, voeg taxonomy_node_ids toe aan request body
+
+**Error handling:**
+- `asyncio.wait_for(..., timeout=3.0)` per call
+- Alle exceptions → log warning, return `None` (retrieval gaat door zonder filter)
+
+**Testbaar via:**
+- Unit test `get_taxonomy_filter`: mock classify + coverage endpoints
+- Integration test: retrieval met taxonomy filter vs zonder → andere chunk subset
+
+---
+
+## Risico's
+
+| Risico | Kans | Impact | Mitigatie |
+|---|---|---|---|
+| Frontend toont lege `doc_count` kolom na R3 | Hoog | Laag (visueel) | Frontend check vóór merge |
+| Research-api heeft geen directe toegang tot knowledge-ingest | Laag | Hoog | Controleer docker-compose networking |
+| Taxonomy filter sluit te veel chunks uit (coverage check te laat) | Gemiddeld | Gemiddeld | Default 30% is conservatief; logging bij gefilterde retrieval |
+| Backfill proposal vuurt dubbel als backfill meerdere keren loopt | Laag | Laag | Portal dedupliceert proposals per naam (24h window) |
+
+## Dependencies
+
+- SPEC-KB-026 R4: `/ingest/v1/taxonomy/classify` endpoint — **aanwezig** (geïmplementeerd)
+- SPEC-KB-026 R5: auto-categorise via Procrastinate — **aanwezig**
+- `klai-retrieval-api` `taxonomy_node_ids` filter — **aanwezig** (search.py regel 182–190)

--- a/.moai/specs/SPEC-KB-027/spec.md
+++ b/.moai/specs/SPEC-KB-027/spec.md
@@ -1,0 +1,259 @@
+---
+id: SPEC-KB-027
+version: "1.0.0"
+status: completed
+created: "2026-04-07"
+updated: "2026-04-07"
+author: Mark Vletter
+priority: high
+tags: [taxonomy, retrieval, query-classification, maybe_generate_proposal, doc_count]
+related: [SPEC-KB-021, SPEC-KB-022, SPEC-KB-024, SPEC-KB-026]
+---
+
+# SPEC-KB-027: Taxonomy-Aware Retrieval + Taxonomy Completeness Fixes
+
+## HISTORY
+
+| Versie | Datum | Auteur | Wijziging |
+|---|---|---|---|
+| 1.0.0 | 2026-04-07 | Mark Vletter | Initiële versie na analyse van taxonomy pipeline completeness |
+
+---
+
+## Context
+
+Na KB-021 t/m KB-026 staat de volledige taxonomy pipeline overeind: ingest classificeert documenten, Qdrant slaat `taxonomy_node_ids` op, de retrieval-api heeft een `taxonomy_node_ids` filter in `search.py`. Maar **de filter wordt nooit gebruikt**. De research-api (chat) stuurt nooit `taxonomy_node_ids` mee naar de retrieval-api — dus werkt het als identieke fallback op het pad zónder filter.
+
+Dit SPEC lost drie resterende gaten op, in volgorde van impact:
+
+**R1 — Query classificatie in research-api (biggest gap):**
+De chat-flow moet de query classificeren naar taxonomy nodes vóór retrieval, zodat de bestaande filter in `klai-retrieval-api/retrieval_api/services/search.py` eindelijk actief wordt. Dit is de overgang van metadata-opslag naar daadwerkelijk taxonomy-guided retrieval.
+
+**R2 — Fix dead code in `maybe_generate_proposal`:**
+De aanroep van `maybe_generate_proposal()` in `routes/ingest.py` stuurt altijd precies 1 document mee. De functie heeft een `_MIN_UNMATCHED_FOR_PROPOSAL = 3` drempel. Resultaat: de functie returnt altijd direct zonder actie — het is dead code. De clustering job genereert proposals correct; de per-document aanroep is dus niet alleen nutteloos maar misleidend.
+
+**R3 — Verwijder `doc_count` denormalisatie:**
+`PortalTaxonomyNode.doc_count` wordt handmatig bijgehouden bij node-delete. Bij elke andere mutatie (re-ingest, connector cleanup, backfill) loopt het uit de pas. De coverage dashboard haalt de echte count al live uit Qdrant. De PostgreSQL kolom is misleidende denormalisatie zonder waarde.
+
+---
+
+## Scope
+
+**In scope:**
+- `klai-focus/research-api`: query classificatie vóór retrieval (R1)
+- `klai-knowledge-ingest/routes/ingest.py`: verwijder dode `maybe_generate_proposal` aanroep (R2)
+- `klai-knowledge-ingest/taxonomy_tasks.py`: voeg proposal generatie toe aan einde van backfill Phase 2 (R2)
+- `klai-portal/backend/app/models/taxonomy.py`: verwijder `doc_count` kolom (R3)
+- `klai-portal/backend/app/api/taxonomy.py`: verwijder alle `doc_count` mutaties (R3)
+- Alembic migratie voor `doc_count` verwijdering (R3)
+
+**Buiten scope:**
+- Browse interface (navigate-by-topic)
+- Cross-KB taxonomy coherentie
+- Tag-gebaseerde retrieval filters
+- Taxonomy governance UI verbeteringen
+- Centroid store naar database verplaatsen
+
+---
+
+## Requirements
+
+### R1 — Query classificatie in research-api voor taxonomy-aware retrieval
+
+**Context:**
+`klai-retrieval-api/retrieval_api/services/search.py` bevat al een werkende `MatchAny` filter op `taxonomy_node_ids`. `klai-retrieval-api/retrieval_api/models.py` heeft al `taxonomy_node_ids: list[int] | None = None` in `RetrieveRequest`. De filter ligt klaar maar wordt nooit gevuld.
+
+**EARS:**
+
+WHEN de research-api een retrieval request uitvoert voor een KB
+AND die KB heeft taxonomy nodes geconfigureerd in de portal,
+THEN SHALL de research-api de query tekst eerst classificeren naar taxonomy node IDs via het knowledge-ingest classify endpoint,
+AND de geretourneerde node IDs meesturen als `taxonomy_node_ids` in de retrieval request naar de retrieval-api.
+
+WHEN de taxonomie-classificatie faalt (timeout, service unavailable, lege response),
+THEN SHALL de retrieval request worden uitgevoerd zonder `taxonomy_node_ids` (bestaand gedrag behouden).
+
+WHEN de taxonomy coverage voor een KB lager is dan `TAXONOMY_RETRIEVAL_MIN_COVERAGE` (default: 0.3 — 30% van chunks gecategoriseerd),
+THEN SHALL de taxonomy filter NIET worden toegepast, ook niet als classificatie slaagt.
+RATIONALE: bij lage coverage sluit een harde filter te veel relevante maar ongeclassificeerde chunks uit.
+
+WHEN de query classificeert naar node IDs die niet overeenkomen met de beschikbare taxonomy nodes van de KB,
+THEN SHALL de filter worden overgeslagen (stale classificatie resultaat).
+
+**Implementatiedetails:**
+
+De research-api roept het bestaande endpoint aan:
+```
+POST /ingest/v1/taxonomy/classify
+{"org_id": "<str>", "kb_slug": "<str>", "text": "<query>"}
+→ {"taxonomy_node_ids": [5, 7]}
+```
+
+Coverage check: de research-api vraagt de coverage stats op via:
+```
+GET /ingest/v1/taxonomy/coverage-stats?kb_slug=<str>&org_id=<str>
+→ {"total_chunks": N, "untagged_count": M, ...}
+```
+Coverage = `(total_chunks - untagged_count) / total_chunks`. Beide endpoints bestaan al.
+
+De coverage check + classify aanroep lopen parallel met `asyncio.gather()`. Totale overhead: max 3 seconden (timeout). Retrieval wordt niet geblokkeerd bij failure.
+
+Voeg `TAXONOMY_RETRIEVAL_MIN_COVERAGE: float = 0.3` toe aan research-api config.
+Voeg `KNOWLEDGE_INGEST_URL` toe aan research-api config (als die er nog niet is).
+
+**Testbare grens:**
+Unit test: `_get_taxonomy_filter(query, kb_slug, org_id)` → returnt `list[int] | None`.
+
+---
+
+### R2 — Fix dead code: `maybe_generate_proposal` per document
+
+**Context:**
+In `klai-knowledge-ingest/knowledge_ingest/routes/ingest.py`:
+```python
+if has_taxonomy and not taxonomy_node_ids:
+    _t = _asyncio.create_task(
+        maybe_generate_proposal(
+            unmatched_documents=[DocumentSummary(title=title, content_preview=...)],
+            existing_nodes=taxonomy_nodes,
+        )
+    )
+```
+`maybe_generate_proposal` heeft `_MIN_UNMATCHED_FOR_PROPOSAL = 3`. Er wordt altijd 1 document meegegeven. De check `len(unmatched_documents) < 3` is altijd True → de functie returnt altijd direct. De aanroep is dead code en genereert nutteloze asyncio tasks.
+
+**EARS:**
+
+WHEN een ingest batch eindigt (backfill Phase 2 `_run_backfill`),
+AND er zijn documents die na classificatie `taxonomy_node_ids = []` hebben (unmatched),
+THEN SHALL `maybe_generate_proposal()` worden aangeroepen met alle unmatched documents uit die batch.
+
+WHEN `len(unmatched_documents) >= 3`,
+THEN SHALL `maybe_generate_proposal()` een taxonomy voorstel genereren en indienen.
+
+WHEN `len(unmatched_documents) < 3`,
+THEN SHALL `maybe_generate_proposal()` direct returnen zonder LLM aanroep.
+
+De aanroep van `maybe_generate_proposal()` in `routes/ingest.py` (per-document, per-ingest) SHALL worden verwijderd.
+
+**Implementatie:**
+
+In `taxonomy_tasks.py` `_run_backfill()`, aan het einde van Phase 2:
+```python
+# Collect unmatched docs from Phase 2 for batch proposal
+if unmatched_summaries:  # DocumentSummary list, populated during Phase 2
+    await maybe_generate_proposal(
+        org_id=org_id,
+        kb_slug=kb_slug,
+        unmatched_documents=unmatched_summaries,
+        existing_nodes=taxonomy_nodes,
+    )
+```
+
+De backfill slaat `DocumentSummary(title=..., content_preview=...)` op voor elk document dat na classificatie `node_ids = []` heeft.
+
+---
+
+### R3 — Verwijder `doc_count` denormalisatie
+
+**Context:**
+`portal_taxonomy_nodes.doc_count` wordt bijgehouden in:
+- `delete_taxonomy_node()`: handmatig optellen bij parent
+- Nergens anders (re-ingest, backfill, connector cleanup updaten het NIET)
+
+De coverage dashboard (`GET /taxonomy/{kb_slug}/coverage`) haalt chunk counts al live uit Qdrant. `doc_count` in PostgreSQL is structureel onjuist en wordt nooit correct gehouden.
+
+**EARS:**
+
+WHEN de coverage dashboard wordt geladen,
+THEN SHALL chunk counts exclusief worden opgehaald uit Qdrant via het bestaande coverage-stats endpoint.
+
+WHEN een taxonomy node wordt verwijderd,
+THEN SHALL er geen `doc_count` mutatie plaatsvinden op de parent node.
+
+Het veld `portal_taxonomy_nodes.doc_count` SHALL worden verwijderd uit het datamodel en de API responses.
+
+**Implementatie:**
+
+1. Verwijder `doc_count: Mapped[int]` uit `PortalTaxonomyNode` model
+2. Verwijder `doc_count` uit `TaxonomyNodeOut` Pydantic schema
+3. Verwijder alle `doc_count` mutaties in `taxonomy.py` API
+4. Alembic migratie: `ALTER TABLE portal_taxonomy_nodes DROP COLUMN doc_count`
+5. Controleer frontend: als `doc_count` wordt getoond in de UI → vervangen door live Qdrant count via coverage-stats (of weglaten)
+
+**Backward compatibility:**
+De `TaxonomyNodeOut` response verliest `doc_count`. Check frontend-componenten die dit veld uitlezen.
+
+---
+
+## Volgorde van implementatie
+
+| Stap | Requirement | Reden |
+|---|---|---|
+| 1 | R2 | Kleinste wijziging, geen datamodel impact, verwijdert dead code |
+| 2 | R3 | Alembic migratie + API cleanup, onafhankelijk van R1 |
+| 3 | R1 | Research-api wijziging, bouwt op R2+R3 maar is onafhankelijk |
+
+---
+
+## Data model wijzigingen
+
+### `PortalTaxonomyNode` (verwijdering)
+
+```python
+# VERWIJDERD:
+doc_count: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+```
+
+### `TaxonomyNodeOut` (verwijdering)
+
+```python
+# VERWIJDERD:
+doc_count: int
+```
+
+### Research-api config (toevoeging)
+
+```python
+taxonomy_retrieval_min_coverage: float = 0.3
+knowledge_ingest_url: str = "http://knowledge-ingest:8000"
+```
+
+### `_run_backfill` return dict (toevoeging)
+
+```python
+{
+    "labelled": int,
+    "migrated": int,
+    "classified": int,
+    "tagged": int,
+    "skipped": int,
+    "proposals_submitted": int  # NIEUW
+}
+```
+
+---
+
+## Acceptatiecriteria
+
+| # | Criterium | Verificatie |
+|---|-----------|-------------|
+| AC1 | Chat retrieval gebruikt taxonomy filter als coverage >= 30% | Stel KB in met 5 gecategoriseerde chunks, stuur query, check retrieval-api logs: `taxonomy_node_ids=[N]` aanwezig in request |
+| AC2 | Taxonomy filter wordt overgeslagen bij coverage < 30% | Stel KB in met 1 gecategoriseerde van 10 chunks, check dat `taxonomy_node_ids=None` in retrieval request |
+| AC3 | Taxonomy filter wordt overgeslagen bij classify timeout | Mock classify endpoint om te time-outen, check dat retrieval toch slaagt |
+| AC4 | Backfill genereert een proposal als >= 3 docs ongematchd zijn | Start backfill op KB met 5 ongeclassificeerde docs, geen taxonomy nodes beschikbaar → 1 proposal in portal review queue |
+| AC5 | Geen `asyncio.create_task(maybe_generate_proposal(...))` meer in ingest route | `grep -r "maybe_generate_proposal" klai-knowledge-ingest/knowledge_ingest/routes/` → geen resultaat |
+| AC6 | `doc_count` kolom bestaat niet meer in database | `\d portal_taxonomy_nodes` → geen `doc_count` kolom |
+| AC7 | Taxonomy API responses bevatten geen `doc_count` veld meer | `GET /api/app/knowledge-bases/{slug}/taxonomy/nodes` → geen `doc_count` in items |
+| AC8 | Coverage dashboard toont nog steeds correcte chunk counts | Coverage dashboard openen → per-node chunk counts gelijk aan Qdrant live count |
+
+---
+
+## Aannames
+
+| Aanname | Confidence | Risico als fout |
+|---|---|---|
+| Research-api heeft al een httpx client voor knowledge-ingest calls | Gemiddeld | Kleine extra setup, geen blocker |
+| Frontend gebruikt `doc_count` niet voor kritische functionaliteit | Gemiddeld | Visuele regressie in taxonomy node list; oplossing: toon coverage count live |
+| 30% coverage als minimum is conservatief genoeg voor productie KBs | Gemiddeld | Te restrictief → coverage setting aanpassen per KB; te soepel → retrieval precision daalt |
+| `classify_document()` latency < 2s voor korte queries (< 50 woorden) | Hoog | Retrieval latency stijgt; oplossing: striktere timeout + parallel met coverage check |
+| Backfill batch grootte van 100 is voldoende om >= 3 unmatched docs per batch te hebben | Gemiddeld | Bij KBs met hoge classificatiegraad kan een batch allemaal matched zijn → `maybe_generate_proposal` vuurt dan niet vanuit backfill, maar dat is correct gedrag |

--- a/.serena/memories/backend-patterns.md
+++ b/.serena/memories/backend-patterns.md
@@ -49,3 +49,28 @@ pyproject.toml
 - `services/vexa.py` — meeting bot lifecycle
 - `services/moneybird.py` — invoicing + subscriptions
 - `services/provisioning.py` — tenant container spin-up (Docker + Caddy + LibreChat)
+
+## Qdrant org_id vs PostgreSQL org_id are different types (CRIT)
+Qdrant payload stores `org_id` as the **Zitadel string ID** (e.g. `"362757920133283846"`).
+PostgreSQL portal DB uses the **integer surrogate key** (e.g. `1`).
+Never use the integer PG `org_id` to filter or delete Qdrant records — it will silently match nothing or the wrong tenant.
+Always verify which ID scope you are in before any cross-store delete or lookup.
+
+## PostgreSQL artifact cascade delete order (CRIT)
+When deleting artifacts by connector, this order is required to avoid FK violations:
+1. Nullify `superseded_by` self-references in `artifacts` (self-referential FK)
+2. Delete from `embedding_queue`
+3. Delete from `artifact_entities`
+4. Delete from `derivations` — join column is `child_id` / `parent_id`, NOT `source_artifact_id`
+5. Delete from `artifacts`
+
+Skipping step 1 or using the wrong column name on `derivations` causes FK constraint failures.
+
+## structlog vs stdlib logging — keyword arguments (HIGH)
+Services that use `structlog` must call logger methods with positional arguments only for the message, then keyword args for context. Stdlib `logging.Logger._log()` does NOT accept arbitrary keyword arguments — passing structlog-style kwargs (e.g. `logger.info("msg", path=x)`) raises `TypeError: _log() got unexpected keyword argument`.
+
+Fix: use positional string interpolation for stdlib loggers:
+```python
+logger.info("msg (path=%s)", ref.path)
+```
+Or switch the module to use `structlog.get_logger()` throughout.

--- a/.serena/memories/services-overview.md
+++ b/.serena/memories/services-overview.md
@@ -16,12 +16,13 @@
 - **Deploy:** Coolify on public-01
 
 ## klai-connector (in deploy/ or separate service)
-- **Purpose:** Syncs external sources (currently GitHub) to the Klai knowledge base (Qdrant)
+- **Purpose:** Syncs external sources (currently GitHub, Notion) to the Klai knowledge base (Qdrant)
 - **Port:** 8200
 - **Auth:** Internal service-to-service via AuthMiddleware
 - **Key components:**
   - `adapters/github.py` — GitHub API adapter
-  - `clients/knowledge_ingest.py` — Pushes docs to knowledge ingest endpoint
+  - `adapters/notion.py` — Notion API adapter (uses notion_client v2 + notion-sync-lib)
+  - `clients/knowledge_ingest.py` — Pushes docs to knowledge ingest endpoint; includes `delete_connector()` for per-connector cleanup
   - `services/sync_engine.py` — Orchestrates sync runs
   - `services/scheduler.py` — APScheduler-based periodic sync
   - `services/crypto.py` — AES-GCM encryption for stored OAuth secrets
@@ -53,3 +54,24 @@ All accessed from core-01 containers via 172.18.0.1 (Docker host gateway):
 | Redis | Cache/queues | internal |
 | Meilisearch | Search (shared across tenants) | internal |
 | VictoriaMetrics | Metrics/monitoring | internal |
+
+## Notion adapter (klai-connector) — key behaviors
+- **notion_client v2:** `databases.query()` is removed. All pages retrieved via `client.search()`. `database_ids` filtering is post-fetch in Python (compare `parent.database_id`).
+- **notion_client timeout:** Pass `client=httpx.Client(timeout=httpx.Timeout(30.0))` as a separate constructor param — `ClientOptions` does not accept `timeout`.
+- **`page_ids` config:** When set, fetches specific pages via `pages.retrieve()` — skips search entirely. Use for targeted ingestion.
+- **`max_pages`:** Real page count limit (not API pagination call limit).
+- **`fetch_blocks_recursive`** (notion-sync-lib): fetches ALL nested blocks for one Notion page → produces 1 artifact.
+- **Incremental cursor reset:** If data was cleaned and 0 docs are fetched, the cursor `last_synced_at` may still be set. Reset via: `UPDATE connector.sync_runs SET cursor_state = NULL WHERE connector_id = ?`
+- **FileType detection on Notion titles:** `Path("3.011 Opzeggingen...").suffix` returns `".011 Opzeggingen..."` (non-empty, has space, long). Guard: `if not suffix or " " in suffix or len(suffix) > 10` before trusting the suffix.
+
+## DELETE /ingest/v1/connector endpoint (knowledge-ingest)
+Performs per-connector recursive cleanup: Qdrant points + PG artifacts + FalkorDB episodes.
+Called by portal-api connector delete flow via `knowledge_ingest_client.delete_connector()` before the DB record is removed.
+FalkorDB cleanup uses `delete_kb_episodes(org_id, episode_ids)` from `knowledge_ingest/graph.py`.
+
+## Source citation pipeline — known gap
+`source_ref` (Notion UUID / source URL) is stored in Qdrant payload and PG `artifacts.extra` but is NOT propagated to the chat/research UI. The break points are:
+1. `retrieval-api ChunkResult` — no `source_ref`, `source_connector_id`, or `source_url` fields
+2. `research-api _to_chunk()` — always sets `metadata = {}`, discards all source context
+3. Frontend `Citation` type — no `url` or `source_ref` field
+Fix requires changes at all 5 layers to enable clickable source links in citations.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+<!-- codeindex:start -->
+# CodeIndex MCP
+
+This project is indexed by CodeIndex as **klai** (7950 symbols, 17306 relationships, 300 execution flows).
+
+## Rules (MUST follow)
+
+- **Before ANY code modification**: call `impact` on the symbol(s) you will change
+- **Before searching code**: try `query` first — only use Grep/Glob if CodeIndex returns nothing useful
+- **"How does X work?" questions**: use `query` or `context` — do NOT start with Grep
+- **Skip CodeIndex only for**: non-code conversations, config edits, or single known-file changes
+
+## Always Start Here
+
+1. **Read `codeindex://repo/{name}/context`** — codebase overview + check index freshness
+2. **Match your task to a skill below** and **read that skill file**
+3. **Follow the skill's workflow and checklist**
+
+> If step 1 warns the index is stale, run `codeindex update` in the terminal first.
+
+## Skills
+
+| Task | Read this skill file |
+|------|---------------------|
+| Understand architecture / "How does X work?" | `.claude/skills/codeindex/codeindex-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/codeindex/codeindex-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/codeindex/codeindex-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/codeindex/codeindex-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/codeindex/codeindex-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/codeindex/codeindex-cli/SKILL.md` |
+
+<!-- codeindex:end -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## [Unreleased] — 2026-04-07 — SPEC-KB-027: Taxonomy-Aware Retrieval + Completeness Fixes
+
+### Added — SPEC-KB-027 R1: Query classification before retrieval (research-api)
+
+- **`_get_taxonomy_filter()`** (`klai-focus/research-api/app/services/retrieval_client.py`): New function that classifies a query against the KB taxonomy before retrieval. Calls `/ingest/v1/taxonomy/classify` and `/ingest/v1/taxonomy/coverage-stats` in parallel with a 3 s timeout. Returns node IDs when coverage ≥ 30% (configurable), `None` on any failure.
+- **`_classify_query()` / `_get_coverage_ratio()`**: Extracted as module-level helpers for clean testability.
+- **`retrieve_broad()`** extended with `kb_slug` parameter — when set, applies taxonomy filter as `taxonomy_node_ids` in the retrieval-api request body.
+- **`Notebook.kb_slug`** (`klai-focus/research-api`): New nullable column on `research.notebooks`. Notebooks linked to a KB automatically apply taxonomy filtering in broad mode — no per-request plumbing needed.
+- **Alembic migration** `0004_add_kb_slug_to_notebooks` — adds `kb_slug VARCHAR(128)` to `research.notebooks`.
+- **Config**: `knowledge_ingest_url` and `taxonomy_retrieval_min_coverage` (default: `0.3`) in `research-api/app/core/config.py`.
+- **7 unit tests** in `tests/test_taxonomy_filter.py` covering: sufficient coverage, low coverage, timeout, exception, empty URL, empty node list, exact threshold boundary.
+
+### Fixed — SPEC-KB-027 R2: Proposal generation moved to batch end (knowledge-ingest)
+
+- **Removed dead code**: `maybe_generate_proposal()` call in `routes/ingest.py` always passed exactly 1 document but the function requires ≥ 3 (`_MIN_UNMATCHED_FOR_PROPOSAL`). It was always a no-op. Call removed entirely.
+- **Batch proposal generation**: `_run_backfill()` now collects unmatched documents during Phase 2 and calls `maybe_generate_proposal()` once at the end with the full batch — the first real chance for proposals to fire during backfill.
+- **`maybe_generate_proposal()` returns `bool`** — `True` when a proposal was actually submitted, `False` on all early-exit paths (< 3 docs, missing token, name clash, LLM failure). `proposals_submitted` counter in backfill result now reflects actual outcome.
+- **Fixed `except (TimeoutError, Exception)`** → `except Exception` in `proposal_generator.py` (TimeoutError is a subclass of Exception — dead code pattern).
+- **3 unit tests** in `tests/test_taxonomy_backfill_proposals.py` covering: unmatched batch → called, all matched → not called, no nodes → proposals_submitted=0.
+
+### Removed — SPEC-KB-027 R3: `doc_count` denormalization (portal)
+
+- **`PortalTaxonomyNode.doc_count`** column removed from `portal_taxonomy_nodes`. It was only updated on node-delete; every re-ingest, backfill, and connector cleanup left it stale. Coverage dashboard already uses live Qdrant counts.
+- **Alembic migration** `d3e4f5a6b7c8_drop_doc_count_from_taxonomy_nodes` — drops the column with downgrade support.
+- **`TaxonomyNodeOut.doc_count`** removed from portal API response schema.
+- **Frontend**: `doc_count` removed from `TaxonomyNode` TypeScript interface and taxonomy tree UI.
+
+### Deployment notes
+
+- Run migrations on `klai-portal` (`d3e4f5a6b7c8`) and `research-api` (`0004`) before deploying.
+- New env vars for research-api: `KNOWLEDGE_INGEST_URL` (default: `http://knowledge-ingest:8000`), `TAXONOMY_RETRIEVAL_MIN_COVERAGE` (default: `0.3`).
+- To activate taxonomy-filtered retrieval: set `kb_slug` on an existing notebook via `PATCH /v1/notebooks/{nb_id}`.
+
 ## [Unreleased] — 2026-04-06 — SPEC-KB-026: Taxonomy Integration Hardening
 
 ### Fixed — SPEC-KB-026: Taxonomy Integration Hardening (6 bugs)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ Graph-powered code intelligence (call graphs, communities, execution flows). Enr
 <!-- codeindex:start -->
 # CodeIndex MCP
 
-This project is indexed by CodeIndex as **klai** (8122 symbols, 19567 relationships, 300 execution flows).
+This project is indexed by CodeIndex as **klai** (7950 symbols, 17306 relationships, 300 execution flows).
 
 ## Rules (MUST follow)
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -455,6 +455,32 @@ services:
     networks:
       - net-postgres
 
+  glitchtip-oidc-setup:
+    image: glitchtip/glitchtip:latest
+    # Run: docker compose run --rm glitchtip-oidc-setup
+    # Idempotent — safe to re-run after credential rotation.
+    command: python /setup/setup_oidc.py
+    restart: "no"
+    profiles:
+      - setup
+    depends_on:
+      postgres:
+        condition: service_healthy
+      glitchtip-web:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://glitchtip:${GLITCHTIP_DB_PASSWORD}@postgres:5432/glitchtip
+      SECRET_KEY: ${GLITCHTIP_SECRET_KEY}
+      GLITCHTIP_DOMAIN: https://errors.${DOMAIN}
+      GLITCHTIP_OIDC_CLIENT_ID: ${GLITCHTIP_OIDC_CLIENT_ID}
+      GLITCHTIP_OIDC_CLIENT_SECRET: ${GLITCHTIP_OIDC_CLIENT_SECRET}
+      GLITCHTIP_OIDC_SERVER_URL: https://auth.${DOMAIN}
+    volumes:
+      - ./glitchtip/setup_oidc.py:/setup/setup_oidc.py:ro
+    networks:
+      - klai-net
+      - net-postgres
+
   # ─── Monitoring stack ─────────────────────────────────────────────────────
   # Note: runs on core-01 until monitor-01 is provisioned.
   # To migrate: update Alloy endpoint URLs to point to monitor-01.

--- a/deploy/glitchtip/setup_oidc.py
+++ b/deploy/glitchtip/setup_oidc.py
@@ -1,0 +1,66 @@
+"""
+GlitchTip OIDC setup — configures Zitadel as the OpenID Connect provider.
+
+Run via:  docker compose run --rm glitchtip-oidc-setup
+Idempotent: safe to re-run after credentials rotate or on a fresh DB.
+
+What it does:
+- Creates (or updates) a django-allauth SocialApp for Zitadel OIDC
+- Attaches it to the default Django site
+- Prints the callback URL to register in Zitadel
+"""
+import os
+import sys
+import django
+
+django.setup()
+
+from allauth.socialaccount.models import SocialApp  # noqa: E402 (after setup)
+from django.contrib.sites.models import Site  # noqa: E402
+
+PROVIDER_ID = "zitadel"
+CLIENT_ID = os.environ.get("GLITCHTIP_OIDC_CLIENT_ID", "").strip()
+CLIENT_SECRET = os.environ.get("GLITCHTIP_OIDC_CLIENT_SECRET", "").strip()
+SERVER_URL = os.environ.get("GLITCHTIP_OIDC_SERVER_URL", "").strip()
+
+# Validate
+missing = [k for k, v in {
+    "GLITCHTIP_OIDC_CLIENT_ID": CLIENT_ID,
+    "GLITCHTIP_OIDC_CLIENT_SECRET": CLIENT_SECRET,
+    "GLITCHTIP_OIDC_SERVER_URL": SERVER_URL,
+}.items() if not v]
+
+if missing:
+    print(f"ERROR: missing env vars: {', '.join(missing)}", file=sys.stderr)
+    sys.exit(1)
+
+# Create or update the SocialApp
+app, created = SocialApp.objects.update_or_create(
+    provider="openid_connect",
+    provider_id=PROVIDER_ID,
+    defaults={
+        "name": "Klai (Zitadel)",
+        "client_id": CLIENT_ID,
+        "secret": CLIENT_SECRET,
+        "settings": {
+            "server_url": SERVER_URL,
+            "token_auth_method": "client_secret_basic",
+            "scope": ["openid", "email", "profile"],
+        },
+    },
+)
+
+# Attach to the current site (required by django-allauth)
+site = Site.objects.get_current()
+app.sites.add(site)
+
+action = "Created" if created else "Updated"
+domain = os.environ.get("GLITCHTIP_DOMAIN", "https://errors.example.com")
+callback_url = f"{domain}/accounts/oidc/{PROVIDER_ID}/login/callback/"
+
+print(f"  {action} OIDC social app: {app.name}")
+print(f"  Server URL:   {SERVER_URL}")
+print(f"  Client ID:    {CLIENT_ID}")
+print(f"  Callback URL: {callback_url}")
+print()
+print("Register this callback URL in Zitadel → GlitchTip app → Redirect URIs")

--- a/docs/research/klai-taxonomy-how-it-works.md
+++ b/docs/research/klai-taxonomy-how-it-works.md
@@ -1,0 +1,371 @@
+# Klai Taxonomy & Tagging: How It Actually Works
+
+> Written: 2026-04-07
+> Updated: 2026-04-07 — SPEC-KB-027 gaps added
+> Based on: SPEC-KB-021 through SPEC-KB-027 + code trace
+> Scope: The complete categorisation and tagging pipeline as implemented + known gaps
+
+---
+
+## Overview
+
+Klai's taxonomy system classifies knowledge base chunks into editorial categories and tags them with free-form keywords. It is a **per-KB, user-governed system** with two parallel classification signals and a self-improving proposal loop.
+
+The system spans three services:
+- **portal-api** — taxonomy node/proposal CRUD, gap classification, coverage dashboard
+- **knowledge-ingest** — LLM classification at ingest, backfill, HDBSCAN clustering, auto-categorise
+- **Qdrant** — stores `taxonomy_node_ids`, `tags`, `content_label` as chunk payload fields
+
+---
+
+## Data model
+
+### PostgreSQL (portal-api)
+
+**`portal_taxonomy_nodes`** — the taxonomy itself, per KB.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | int PK | |
+| `kb_id` | FK → knowledge_bases | per-KB isolation |
+| `parent_id` | FK → self (nullable) | max 2 levels in practice (no enforcement) |
+| `name` | varchar(128) | unique among siblings |
+| `slug` | varchar(128) | URL-safe, auto-generated from name |
+| `description` | text (nullable) | used by classifier as context |
+| `doc_count` | int | maintained manually (not live count) |
+| `sort_order` | int | |
+| `created_by` | varchar(64) | user_id |
+
+Uniqueness is enforced by two partial indexes: one for root nodes (parent_id IS NULL), one for siblings (parent_id IS NOT NULL).
+
+**`portal_taxonomy_proposals`** — AI-generated or user-submitted change proposals.
+
+| Column | Type | Notes |
+|---|---|---|
+| `proposal_type` | enum | `new_node | merge | split | rename | tag` |
+| `status` | enum | `pending | approved | rejected` |
+| `payload` | JSONB | type-specific data |
+| `confidence_score` | float (nullable) | LLM confidence |
+
+The `payload` for a `new_node` proposal from clustering includes: `suggested_name`, `document_count`, `sample_titles`, `description`, `cluster_centroid` (the HDBSCAN centroid vector).
+
+### Qdrant (per chunk payload)
+
+Three fields are written to every chunk:
+
+| Field | Type | Set by |
+|---|---|---|
+| `taxonomy_node_ids` | `list[int]` | LLM classifier or centroid lookup at ingest / backfill |
+| `tags` | `list[str]` | Frontmatter + LLM suggestions, merged at ingest |
+| `content_label` | `list[str]` | Blind keyword extractor (3-5 words, no taxonomy context) |
+
+`taxonomy_node_ids` is multi-label (a chunk can belong to multiple nodes). `tags` are free-form lowercase keywords. `content_label` is the raw content fingerprint, used as HDBSCAN clustering input.
+
+---
+
+## Pipeline 1: Classification at ingest time
+
+This runs synchronously inside every `POST /ingest/v1/ingest` call, before the enrichment Procrastinate job is enqueued.
+
+### Step 1 — Blind label generation (`content_labeler.py`)
+
+Called **before** any taxonomy context is fetched. Prevents confirmation bias.
+
+```
+title + content[:500]
+  → klai-fast (LLM, temp=0, max_tokens=100, json_object)
+  → {"keywords": ["keyword1", "keyword2", ...]}
+  → 3-5 lowercase keywords stored as content_label
+```
+
+The `content_label` is the raw, taxonomy-agnostic description of the document. It is used later by HDBSCAN clustering to identify semantic groups.
+
+Non-fatal: returns `[]` on timeout (15s) or failure. Ingest continues.
+
+### Step 2 — Taxonomy node fetch (`portal_client.py`)
+
+```
+fetch_taxonomy_nodes(kb_slug, org_id)
+  → GET /api/app/knowledge-bases/{kb_slug}/taxonomy/nodes/internal?zitadel_org_id=...
+  → portal-api (RLS-scoped query on portal_taxonomy_nodes)
+  → list[TaxonomyNode(id, name, description)]
+```
+
+Result is **cached in-memory for 5 minutes** per (org_id, kb_slug). If no nodes exist, classification is skipped entirely (has_taxonomy = False).
+
+### Step 3 — Centroid lookup (fast path, `clustering.py`)
+
+If a centroid store exists for this KB (JSON sidecar at `~/.klai/taxonomy_centroids/{org_id}_{kb_slug}.json`) and is not stale (configurable max age, default 24h):
+
+```
+doc content[:512] → embed (dense vector)
+  → cosine similarity against all cluster centroids
+  → if best_sim >= taxonomy_centroid_match_threshold AND centroid has taxonomy_node_id
+  → return [taxonomy_node_id] (skip LLM call)
+```
+
+The centroid path is the **fast path**: no LLM call, O(k) similarity check where k = number of clusters.
+
+### Step 4 — LLM classification (slow path, `taxonomy_classifier.py`)
+
+If centroid lookup misses (no store, stale, or no match above threshold):
+
+```
+title + content[:500] + taxonomy_node_ids formatted list (name + description)
+  → klai-fast (temp=0, max_tokens=300, json_object, rate-limited to 1 req/s)
+  → {"nodes": [{"node_id": int, "confidence": float}], "tags": [str], "reasoning": str}
+  → matched_nodes: list[(node_id, confidence)] where confidence >= 0.5, max 5
+  → llm_tags: list[str], max 5
+```
+
+Model is `settings.taxonomy_classification_model` (defaults to `klai-fast`).
+
+### Step 5 — Tag merge
+
+Frontmatter tags (from YAML frontmatter in the document) take priority. LLM tags are appended, deduped:
+
+```python
+merged_tags = [*frontmatter_tags, *llm_tags]  # deduped, lowercase
+```
+
+### Step 6 — Write to Qdrant
+
+All three fields go into `extra_payload` which is passed through to every chunk:
+
+```python
+extra_payload["taxonomy_node_ids"] = taxonomy_node_ids   # list[int]
+extra_payload["tags"]              = merged_tags          # list[str]
+extra_payload["content_label"]     = content_label        # list[str]
+```
+
+**Critical:** these fields must be in `extra_payload` (not just local variables) or they are silently dropped by the enrichment pipeline passthrough.
+
+### Step 7 — Self-bootstrapping proposal (dead code — fixed in SPEC-KB-027)
+
+If the KB has taxonomy nodes but the document was **not classified** (taxonomy_node_ids is empty), the ingest route calls `maybe_generate_proposal` with a single-document list. However, the function has a `_MIN_UNMATCHED_FOR_PROPOSAL = 3` threshold — a list of 1 document always fails this check and the function returns immediately. **This code path never submits a proposal.**
+
+The fix (SPEC-KB-027 R2): remove the per-document call from the ingest route. Instead, the backfill job (`_run_backfill` Phase 2) accumulates all unmatched documents across the batch and calls `maybe_generate_proposal` once at the end with the full list. Proposals are generated only when a batch of real documents genuinely fails classification.
+
+---
+
+## Pipeline 2: Backfill (4-phase background job)
+
+Triggered by a user action in the portal ("Re-tag" button → `POST /api/app/.../taxonomy/backfill-trigger`). Enqueues a Procrastinate job in the `taxonomy-backfill` queue.
+
+### Phase 0 — Blind label generation
+
+Scrolls all Qdrant chunks for this KB with `IsEmptyCondition(content_label)`. Groups by `artifact_id` (one LLM call per document, not per chunk). Writes `content_label` via `client.set_payload()`.
+
+### Phase 1 — Schema migration
+
+Migrates old `taxonomy_node_id` (singular, SPEC-KB-021) to `taxonomy_node_ids` (plural list, SPEC-KB-022). Scrolls chunks with `taxonomy_node_id` set but `taxonomy_node_ids` absent. Writes `[old_id]` → `taxonomy_node_ids`.
+
+### Phase 2 — Re-classify unclassified chunks
+
+Scrolls chunks with neither `taxonomy_node_id` nor `taxonomy_node_ids`. Same grouping by `artifact_id`, same LLM classification call as at ingest time.
+
+### Phase 3 — Generate tags for classified-but-untagged chunks
+
+Scrolls chunks with `taxonomy_node_ids` set but `tags` absent. Runs LLM classification again (only tag output used).
+
+**Deduplication:** the Procrastinate `queueing_lock` pattern ensures at most one pending/running backfill per (org_id, kb_slug). A second trigger returns the existing job_id.
+
+---
+
+## Taxonomy governance: proposals
+
+### Proposal lifecycle
+
+```
+new_node proposal
+  → status=pending (visible in portal review queue)
+  → contributor approves
+    → PortalTaxonomyNode created in PostgreSQL
+    → auto-categorise triggered (if cluster_centroid in payload)
+  → contributor rejects
+    → status=rejected, rejection_reason stored
+```
+
+### Proposal sources
+
+1. **Self-bootstrapping** — ingest creates `new_node` proposals when unmatched documents accumulate
+2. **Bootstrap endpoint** — `POST /taxonomy/bootstrap` scans up to 50 existing chunks, asks klai-fast for 3-8 category names, submits one proposal per category. Use this to cold-start a taxonomy from scratch.
+3. **Manual** — users create nodes directly via `POST /taxonomy/nodes` (no proposal needed, instant)
+
+### Auto-categorise (on proposal approval)
+
+When a `new_node` proposal with a `cluster_centroid` is approved:
+
+```
+approve_proposal()
+  → PortalTaxonomyNode created
+  → enqueue_auto_categorise(org_id, kb_slug, node_id, cluster_centroid)
+    → POST /ingest/v1/taxonomy/auto-categorise-job (Procrastinate)
+      → _auto_categorise_impl():
+          Pass 1: scroll all chunks, compute cosine_similarity(vec, centroid)
+                  collect matched artifact_ids (sim >= threshold)
+          Pass 2: scroll all chunks of matched artifact_ids
+                  set_payload(taxonomy_node_ids = [*current, node_id])
+```
+
+This is **pure cosine similarity** — no LLM calls. All chunks belonging to documents that match the centroid get tagged with the new node_id, including all chunks of a document (not just the representative chunk).
+
+---
+
+## HDBSCAN clustering (taxonomy discovery)
+
+Runs separately from ingest. Used to discover emergent clusters in the embedding space.
+
+```
+run_clustering_for_kb(org_id, kb_slug, qdrant_client, taxonomy_nodes)
+  → scroll all chunks, deduplicate to one embedding per artifact_id
+  → requires >= 10 documents
+  → HDBSCAN(min_cluster_size=settings.taxonomy_cluster_min_size, metric="cosine")
+  → for each cluster:
+      centroid = mean(cluster_embeddings)
+      content_label_summary = top-5 unique keywords from cluster docs
+      taxonomy_node_id = carried from previous store if centroid sim > 0.95
+  → save to ~/.klai/taxonomy_centroids/{org_id}_{kb_slug}.json
+```
+
+The centroid store is versioned and has a configurable max age (default 24h, rejected as stale after that). Previous `taxonomy_node_id` assignments carry over when a new cluster's centroid matches a previous centroid with > 0.95 cosine similarity (stable cluster).
+
+---
+
+## Gap classification
+
+Every failed retrieval (hard gap: 0 chunks, soft gap: top score < 0.4) creates a `PortalRetrievalGap` record.
+
+After the gap is stored, an async task calls the knowledge-ingest classify endpoint:
+
+```
+_classify_gap(gap_id, org_zitadel_id, query_text, kb_slug)
+  → POST /ingest/v1/taxonomy/classify {org_id, kb_slug, text=query_text}
+    → fetch_taxonomy_nodes() → classify_document()
+    → returns taxonomy_node_ids
+  → UPDATE portal_retrieval_gaps SET taxonomy_node_ids = [...] WHERE id = gap_id
+```
+
+This is best-effort (fire-and-forget task, non-fatal on failure).
+
+---
+
+## Coverage dashboard
+
+The coverage dashboard (`GET /taxonomy/{kb_slug}/coverage`) combines:
+
+1. **Chunk counts per taxonomy node** — from Qdrant via knowledge-ingest `/ingest/v1/taxonomy/coverage-stats`
+2. **Gap counts per taxonomy node** — from PostgreSQL: `COUNT(gaps) WHERE taxonomy_node_ids @> [node_id] AND last 30 days AND unresolved`
+
+Together they show which nodes have good coverage (many chunks, few gaps) vs. which are thin (few chunks, many gaps). Cached for 5 minutes.
+
+---
+
+## Tag visibility
+
+Tags are queryable via `/ingest/v1/taxonomy/top-tags`, which scrolls up to 2,000 Qdrant chunks and counts tag frequency. Can be scoped to a specific `taxonomy_node_id`. Used to populate the tag cloud in the portal.
+
+---
+
+## Full flow diagram
+
+```
+Document ingest
+│
+├─ generate_content_label()          klai-fast, blind (no taxonomy context)
+│   → content_label: ["keyword1", ...]
+│
+├─ fetch_taxonomy_nodes()            portal-api internal endpoint (5-min cache)
+│   → taxonomy nodes with id, name, description
+│   └─ if no nodes: skip classification
+│
+├─ [fast path] classify_by_centroid()
+│   → cosine_similarity(doc_embedding, centroids)
+│   → if match: taxonomy_node_ids = [node_id]  (no LLM)
+│
+├─ [slow path] classify_document()   klai-fast, multi-label
+│   → taxonomy_node_ids: [id, id]
+│   → llm_tags: ["tag1", "tag2"]
+│
+├─ merge_tags(frontmatter_tags, llm_tags)
+│   → merged_tags: ["tag1", ...]  (frontmatter priority)
+│
+├─ upsert_chunks(Qdrant)
+│   payload: {taxonomy_node_ids, tags, content_label, ...}
+│
+└─ [if unmatched] ⚠️ dead code — never fires (threshold=3, always 1 doc passed)
+    See SPEC-KB-027 R2 for fix (move to backfill batch accumulation)
+
+User approves proposal
+│
+├─ PortalTaxonomyNode created (PostgreSQL)
+└─ auto_categorise_job (Procrastinate)
+    → cosine_similarity(all_chunks, centroid) > threshold
+    → set_payload(taxonomy_node_ids = [*existing, new_id])
+
+Failed retrieval (gap event)
+│
+└─ classify_gap (async task)
+    → /ingest/v1/taxonomy/classify
+    → UPDATE portal_retrieval_gaps SET taxonomy_node_ids
+```
+
+---
+
+## Known gaps and roadmap
+
+### Addressed in SPEC-KB-027
+
+| Gap | Fix |
+|---|---|
+| **Retrieval filter nooit actief** — `taxonomy_node_ids` zit in Qdrant en retrieval-api heeft de filter al (`search.py:182`), maar research-api stuurt nooit node IDs mee | R1: research-api classificeert query voor retrieval, stuurt node IDs mee als coverage ≥ 30% |
+| **`maybe_generate_proposal` is dead code** — altijd 1 doc meegestuurd, drempel is 3, functie returnt altijd direct | R2: call verwijderd uit ingest route, backfill accumuleert unmatched docs en triggert batch-gewijs |
+| **`doc_count` denormalisatie** — handmatig bijgehouden bij node-delete, maar nooit bij re-ingest/backfill/connector cleanup; structureel onjuist | R3: kolom verwijderd, coverage dashboard haalt counts altijd live uit Qdrant |
+
+### Taxonomy-aware retrieval flow (na SPEC-KB-027 R1)
+
+```
+Chat query
+│
+├─ [parallel, max 3s]
+│   ├─ GET /ingest/v1/taxonomy/coverage-stats
+│   │   → coverage = (total - untagged) / total
+│   └─ POST /ingest/v1/taxonomy/classify {text=query}
+│       → taxonomy_node_ids: [5, 7]
+│
+├─ if coverage >= 0.30 AND node_ids not empty:
+│   → retrieval request met taxonomy_node_ids=[5, 7]  ← filter actief
+└─ else:
+    → retrieval request zonder filter  ← huidig gedrag
+```
+
+### Nog niet opgepakt
+
+| Feature | Status |
+|---|---|
+| Browse interface (navigate-by-topic) | Niet geïmplementeerd |
+| Cross-KB taxonomy coherentie | Niet geïmplementeerd — elk KB heeft eigen geïsoleerde node set |
+| Synonym mapping / alias handling | Niet geïmplementeerd |
+| Tag-gebaseerde retrieval filter | Niet geïmplementeerd — tags opgeslagen maar niet als filter gebruikt |
+| Centroid store in PostgreSQL/Redis | Huidig: JSON sidecar op disk van ingest container |
+| Automatic taxonomy evolution (split/merge signalen) | Gedeeltelijk — proposals kunnen worden ingediend, geen automatische signaalberekening |
+
+The coverage dashboard and gap classification per taxonomy node are implemented. The editorial "prioritised writing agenda" (gaps grouped by node) exists but requires the coverage dashboard UI to surface it.
+
+---
+
+## Configuration reference
+
+Relevant settings in `knowledge-ingest/knowledge_ingest/config.py`:
+
+| Setting | Default | Purpose |
+|---|---|---|
+| `taxonomy_classification_model` | `klai-fast` | Model for LLM classification |
+| `taxonomy_classification_timeout` | `30s` | Timeout for classification call |
+| `content_label_timeout` | `15s` | Timeout for blind label generation |
+| `taxonomy_centroid_match_threshold` | configurable | Min cosine sim for centroid fast path |
+| `taxonomy_centroid_max_age_hours` | `24` | Max age of centroid store before stale |
+| `taxonomy_centroids_dir` | `~/.klai/taxonomy_centroids` | JSON sidecar location |
+| `taxonomy_cluster_min_size` | configurable | HDBSCAN min_cluster_size |
+| `taxonomy_auto_categorise_threshold` | configurable | Min sim for auto-categorise pass 1 |
+| `graphiti_llm_rps` | `1` | Rate limit shared by labeler + classifier |

--- a/docs/research/knowledge-taxonomy-design.md
+++ b/docs/research/knowledge-taxonomy-design.md
@@ -1,0 +1,531 @@
+# Knowledge Taxonomy Design: Structure, Value, and Best Practices
+
+> Research date: 2026-04-05
+> Status: Background research — informs Klai knowledge architecture decisions
+> Scope: What taxonomies are, why they matter, how to design them well, and what they would add to Klai specifically
+
+---
+
+## Summary
+
+A taxonomy is a hierarchical classification system that organises information into categories and subcategories. In knowledge systems, taxonomies are the structural layer that determines whether information is findable, whether AI retrieval is accurate, and whether knowledge silos form.
+
+The key finding: **neither a pure hierarchy nor flat tags alone are sufficient**. Best-practice knowledge systems use a three-layer hybrid — hierarchy for navigation, facets for filtering, tags for the long tail.
+
+---
+
+## 1. Why taxonomies matter
+
+### Findability impact
+
+- Teams implementing effective taxonomy see search success rates improve by **20–40%** within the first month
+- Effective taxonomy reduces employee search time by **60%**
+- McKinsey: robust knowledge management reduces time spent searching by **35%** and measurably boosts productivity
+
+### The cost of not having a taxonomy
+
+- IDC estimates Fortune 500 companies lose **$31.5 billion per year** from failing to share relevant information
+- The average knowledge worker spends **2 hours per week recreating information that already exists**
+- **67% of collaboration failures** trace directly to organisational silos, not lack of effort or tools (Harvard Business)
+- Without shared structure, users must alter their search behaviour per system — compounding the loss
+
+### Concrete ROI example
+
+For a 200-employee company: 160 hours of reduced search time per team per month × 5 teams × 12 months = **9,600 hours recovered annually** ≈ $480K in productivity gains from taxonomy alone.
+
+---
+
+## 2. The three taxonomy structures
+
+### 2.1 Hierarchical tree
+
+A parent-child structure. Each category contains subcategories.
+
+```
+Products
+├── Hardware
+│   ├── Laptops
+│   └── Servers
+└── Software
+    ├── Licences
+    └── Updates
+```
+
+**Strengths:** intuitive navigation, clear overview, good for onboarding
+**Weaknesses:** rigid — content that belongs in multiple categories breaks the model; becomes unwieldy at depth
+
+**Hard limit: 3 levels maximum.** Each additional level reduces discoverability by approximately 50%. At level 5, over 90% of users have abandoned the search. The rule of thumb: Category → Subcategory → Content. If a 4th level is needed, use a facet instead.
+
+---
+
+### 2.2 Faceted taxonomy
+
+Multiple independent classification dimensions applied simultaneously. Instead of one tree, each dimension is a separate axis.
+
+```
+Dimension: Audience    → [Developer] [Sales] [Support] [Management]
+Dimension: Content type → [How-to] [Reference] [Policy] [Template]
+Dimension: Product     → [Portal] [API] [Mobile] [Integrations]
+Dimension: Region      → [NL] [DE] [EU] [Global]
+```
+
+A document is tagged across all relevant dimensions: `Developer × How-to × API × EU`
+
+**Strengths:** precise, flexible filtering; scales to heterogeneous, broad knowledge bases; much shallower than trees; supports multiple audiences
+**Weaknesses:** complex to design — requires content analysis upfront; cannot be designed without understanding the content domain
+
+**Design limits:** no more than 10–15 top-level facets; no more than 2–4 levels per facet.
+
+---
+
+### 2.3 Flat tags
+
+Free-form keywords with no hierarchy. Fast to assign, minimal governance overhead.
+
+**Strengths:** captures long-tail concepts; user-driven categorisation; good for niche topics
+**Weaknesses:** inconsistency at scale (synonyms, typos, drift); does not scale without curation
+
+---
+
+## 3. The hybrid approach — best practice
+
+Systems achieving 85%+ search success rates use all three layers:
+
+| Layer | Type | Purpose |
+|---|---|---|
+| Main navigation | Hierarchy (max 3 levels) | Browsing, onboarding, overview |
+| Search refinement | Facets | Multi-dimensional filtering |
+| Annotation | Tags | Flexible long-tail coverage |
+
+**Practical result:** support teams answer questions 3× faster; average search time drops from 8 minutes to under 3 minutes per query.
+
+---
+
+## 4. Taxonomy design principles
+
+### 4.1 Start with the user, not the org chart
+
+The most common mistake: using the internal department structure as the taxonomy. Users search by task or problem — not by which team owns the content. A taxonomy that mirrors HR org charts is optimised for the organisation, not the user.
+
+### 4.2 Terms must be unambiguous and mutually exclusive
+
+"Customers" and "Accounts" as separate categories create confusion. Choose one canonical term; make the other a synonym or alias. Every term should have a single, clear meaning.
+
+### 4.3 Avoid polyhierarchy
+
+Polyhierarchy is when the same concept appears in multiple locations in the tree (e.g., "GDPR" under both "Legal" and "Security"). This breaks the assumption that terms are mutually exclusive. If a concept genuinely spans multiple parents, use a facet or tag instead of duplicating the node.
+
+### 4.4 Taxonomy determines search quality more than the algorithm
+
+The search algorithm ranks results using the contextual relationships that the taxonomy provides — parent categories, related topics, audience associations, product hierarchies. A weak taxonomy produces poor search results regardless of the algorithm. Fixing the algorithm without fixing the taxonomy is wasted effort.
+
+### 4.5 Every taxonomy decision starts with three questions
+
+1. **Who is the audience?** (and how do they search?)
+2. **What are we taxonomising?** (content type, domain, volume)
+3. **Why are we doing it?** (navigation, search, AI retrieval, governance?)
+
+---
+
+## 5. Taxonomy vs. ontology vs. knowledge graph
+
+These are often confused. They exist on a spectrum of semantic richness:
+
+```
+Term list → Taxonomy → Thesaurus → Ontology → Knowledge Graph
+                        ↑ each step adds more relationships and rules ↑
+```
+
+| Feature | Taxonomy | Ontology | Knowledge Graph |
+|---|---|---|---|
+| Structure | Hierarchy (tree) | Network of relationships | Nodes + edges (instances) |
+| Complexity | Low–medium | High | Very high |
+| Primary use | Classification, navigation, filtering | Reasoning, inference | AI, cross-domain queries |
+| Example | Product category tree | Medical knowledge model | Google Knowledge Graph |
+
+For practical knowledge systems, **taxonomy is the starting point** with immediate ROI. Ontologies and knowledge graphs build on top of it for advanced AI applications.
+
+---
+
+## 6. Taxonomy and AI retrieval
+
+This is the most critical dimension for modern AI-powered knowledge systems.
+
+### The problem with pure vector search
+
+LLMs are only as reliable as the structure behind the data they draw from. Without a semantic foundation, even advanced models can:
+- Misclassify content
+- Surface irrelevant results
+- Generate factually incorrect answers (hallucinations)
+
+Hallucinations occur primarily because a model lacks grounded, authoritative knowledge about a domain.
+
+### What taxonomy adds to RAG
+
+**GraphRAG** (vector search + taxonomy/ontology) combines semantic similarity with logical structure:
+
+- Taxonomy-enhanced retrievers identify both thematically and semantically relevant documents
+- KG-RAG (Knowledge Graph-based RAG) reduces hallucinations by traversing a structured knowledge graph
+- Search precision can reach **99%** with deterministic knowledge graph approaches, vs. ~70–80% with pure vector search
+
+**Core principle:** taxonomies and ontologies *constrain* what an AI system can assert — they anchor output in authoritative domain knowledge.
+
+### GraphRAG vs. naive RAG
+
+| Approach | Mechanism | Typical precision |
+|---|---|---|
+| Naive RAG | Vector similarity only | ~70–80% |
+| Metadata-filtered RAG | Vector + taxonomy filters | ~85–90% |
+| GraphRAG | Vector + taxonomy + relationship traversal | Up to 99% |
+
+---
+
+## 7. When is a taxonomy most valuable?
+
+From the research, four scenarios show the largest impact:
+
+1. **Large, growing knowledge bases** — without structure, chaos grows exponentially with content volume
+2. **Multiple data sources or silos** — a shared taxonomy provides cross-system consistency; users can search once across all sources
+3. **AI-driven retrieval (RAG)** — taxonomy raises precision and reduces hallucinations
+4. **External-facing navigation** (search, browse, filter for end users) — hierarchical browsing outperforms free search alone for users who don't know exact terminology
+
+---
+
+## 8. Practical example — SaaS knowledge system
+
+```
+HIERARCHY (navigation, max 3 levels):
+├── Getting started
+├── Product documentation
+│   ├── Connectors
+│   ├── Knowledge base
+│   └── Settings
+├── Guides
+└── Troubleshooting
+
+FACETS (search filters):
+├── Audience:      [Admin] [End user] [Developer]
+├── Content type:  [Tutorial] [Reference] [FAQ] [Release note]
+└── Skill level:   [Beginner] [Advanced]
+
+TAGS (free-form, long tail):
+  notion-integration, SSO, bulk-upload, GDPR, rate-limit, ...
+```
+
+---
+
+## 9. Common failure modes
+
+| Failure | Symptom | Fix |
+|---|---|---|
+| Org-chart taxonomy | Users can't find anything; search fails | Redesign around user tasks |
+| Too deep (>3 levels) | >90% drop-off before reaching content | Cap at 3 levels; use facets for depth |
+| No governance | Tags proliferate with synonyms and typos | Assign taxonomy owner; add synonym mapping |
+| Polyhierarchy | Same concept in multiple tree locations | Move to facet or tag |
+| Ad hoc taxonomy | Inconsistent, gaps, not extensible | Design upfront with documented principles |
+| Taxonomy mirrors search algorithm | Good search algorithm, poor results | Fix taxonomy first |
+
+---
+
+## Conclusion
+
+The value of a taxonomy in a knowledge system is threefold:
+
+1. **Operational:** less search time, less duplicated work, lower support load
+2. **Organisational:** break down silos, shared vocabulary, content governance
+3. **Technical (AI):** higher retrieval precision, fewer hallucinations, richer contextual answers
+
+The biggest risk is an ad-hoc approach: taxonomies that are not consistent, extensible, or complete deliver none of these benefits. The biggest design mistake is optimising for the organisation rather than the user.
+
+**The recommended starting structure:** hierarchy (max 3 levels) for navigation + facets (max 10–15 top-level) for filtering + free tags for the long tail. Design all three from the user's search behaviour, not from internal structure.
+
+---
+
+## 10. Klai: current state and taxonomy gaps
+
+This section applies the research above to the Klai knowledge architecture as of April 2026. Source documents: `docs/architecture/klai-knowledge-architecture.md` and `docs/architecture/knowledge-ingest-flow.md`.
+
+### 10.1 What Klai already has (taxonomy-relevant)
+
+The Klai system contains multiple implicit taxonomies — classification layers that are used internally but not yet assembled into a coherent, navigable structure.
+
+**Content type — flat taxonomy, internal only**
+
+`kb_article | pdf_document | meeting_transcript | 1on1_transcript | email_thread | web_crawl | faq | api_doc | changelog | unknown`
+
+Drives the content profile (chunk size, HyPE strategy, context window approach) and the evidence-scoring tier in §7.4 of the architecture. Not user-facing; users cannot filter by content type at retrieval time.
+
+**Assertion mode — flat epistemic taxonomy**
+
+`factual | procedural | quoted | belief | hypothesis`
+
+Classifies what kind of claim a piece of content makes. Stored in YAML frontmatter and Qdrant payload. Currently all flat weights (1.00) in evidence scoring. Not exposed for navigation or filtering.
+
+**Provenance type + synthesis depth — two orthogonal axes**
+
+`observed | extracted | synthesized | revised` × `0–4`. Good internal metadata; not used for navigation.
+
+**Entity extraction — embryonic domain facets**
+
+Graphiti/FalkorDB extracts named entities with types `product_area | feature | concept | person`. The PostgreSQL `knowledge.entities` table stores them. This is the beginning of a domain-facet layer — but it is feature-flagged off in production, not used as a retrieval filter, and not exposed for browsing or navigation.
+
+**KB structure — file system as implicit hierarchy**
+
+Each org has one or more KBs (`kb_slug`). Within a KB, pages are organised by the Gitea file structure. This provides a hierarchy, but not a semantic one — it reflects the accidental folder structure of the content, not a deliberately designed taxonomy.
+
+**Gap detection — topic-blind**
+
+Gap events fire when retrieval fails (hard gap: no chunks; soft gap: scores < 0.4). Gaps are stored per query but not classified by topic or taxonomy node. The editorial inbox UI does not yet exist (tracked in §0 of the architecture as an open item).
+
+**KBScopeBar — scope at KB level, not topic level**
+
+Users can restrict retrieval to specific `kb_slugs`. This is a scope filter at the entire-KB level — not at a semantic topic or taxonomy node within a KB.
+
+---
+
+### 10.2 What is missing
+
+| What the research recommends | Current state | Gap |
+|---|---|---|
+| **Hierarchy** (max 3 levels) for navigation/browsing | File-system hierarchy in Gitea only | No semantic topic hierarchy |
+| **Facets** for multi-dimensional filtering | Internal: content_type + assertion_mode + entities (off) | Not user-facing; not combinable at retrieval time |
+| **Tags** as first-class retrieval signal | MCP tool accepts tags; not indexed in Qdrant payload | Tags do not influence retrieval |
+| **Taxonomy-aware gap detection** | Gaps are per query, not per topic cluster | Editors cannot see where to write |
+| **Browse interface** | Chat-only; klai-docs shows per-KB page list | No navigate-by-topic interface |
+| **Cross-KB coherence** | KBs are fully isolated silos per slug | No shared taxonomic frame across KBs |
+| **Governance workflow** | No taxonomy review UI built | Taxonomy proposal queue does not exist |
+
+---
+
+### 10.3 What adding taxonomy would produce
+
+Each gap filled produces a concrete change in system behaviour. These are not improvements in degree — they are qualitative shifts in what the system can do.
+
+#### Gap 1 + 2: Semantic hierarchy + user-facing facets
+
+**Before:** retrieval = hybrid vector search over all org chunks. Filter = `org_id` + optional `kb_slug`.
+
+**After:** query is first classified to a taxonomy node. Qdrant search runs with a hard filter on that node, reducing the search space from e.g. 12,000 chunks to 800 relevant ones.
+
+```
+User asks: "How do I configure SSO?"
+  → query classification → node: "Setup > SSO"
+  → Qdrant search: org_id=X AND taxonomy_node="setup.sso"
+  → searches 800 chunks instead of 12,000
+  → higher precision, less noise
+```
+
+The KBScopeBar (currently: filter on kb_slug) becomes a topic scope: "answer only from Billing topics" rather than "answer only from KB slug X."
+
+This is the move from metadata-filtered RAG (~85–90% precision) to taxonomy-constrained retrieval — approaching the GraphRAG precision range.
+
+#### Gap 3: Tags as first-class concept
+
+Tags in the Qdrant payload become a retrieval filter. They cover the long-tail: terms like `iDEAL`, `rate-limit`, `GDPR-export` that do not belong in the hierarchy but should be findable. The hierarchy handles 80% of cases; tags handle the rest without requiring taxonomy changes.
+
+#### Gap 4: Taxonomy-aware gap detection
+
+This is the gap with the highest immediate editorial value.
+
+**Before — editorial inbox today:**
+
+| Query | Type | KB |
+|---|---|---|
+| "how do I cancel my subscription" | hard | — |
+| "VAT on invoice" | soft | billing-kb |
+| "SSO setup Okta" | hard | — |
+| ... 147 more | | |
+
+An editor sees 150 failed search queries. No indication of where to start.
+
+**After — editorial inbox with taxonomy:**
+
+| Topic node | Open gaps | Frequency | Priority |
+|---|---|---|---|
+| Billing > Subscriptions | 47 | 3.2/day | 🔴 High |
+| Setup > SSO | 31 | 1.8/day | 🔴 High |
+| AI Features > Chat | 18 | 0.9/day | 🟡 Medium |
+| Troubleshooting | 12 | 0.4/day | 🟢 Low |
+
+Clicking "Billing > Subscriptions" shows the 47 specific queries, which sub-topics are most requested, which articles already exist in this node, and a suggested title for the missing article.
+
+Gap detection becomes a **prioritised editorial work programme** — not "here are your problems" but "here are your writing assignments for this week, sorted by impact."
+
+#### Gap 5: Browse interface
+
+**Before:** Klai is search-first only. You can only find knowledge if you know what to search for.
+
+**After:** A new employee opens the knowledge base and sees:
+
+```
+📁 Billing (43 articles)
+   📁 Invoices (12)
+   📁 Subscriptions (8)
+   📁 Payment methods (5)
+
+📁 Setup & Configuration (29 articles)
+   📁 SSO (7)
+   📁 Connectors (11)
+```
+
+The knowledge base becomes self-navigable for people who do not yet know what they do not know. This is the onboarding use case — new employees exploring the knowledge base without a specific question.
+
+#### Gap 6: Cross-KB coherence
+
+**Before:** KB A and KB B are fully isolated. A gap in KB A is never related to existing content in KB B, even if they cover the same topic.
+
+**After:** A shared taxonomy over KBs enables:
+- Linking a gap in the external KB to an existing internal article on the same node
+- Retrieving content from both KBs for a question, weighted by `synthesis_depth` + `visibility`
+- Showing editors: "This article already exists internally — do you want to publish or adapt it?"
+
+#### Gap 7: Governance workflow
+
+A taxonomy without governance degrades within months. The minimum viable process (PR-style workflow as described in §6.5 of the architecture):
+
+```
+System detects: "47 chunks unclassified after ingestion"
+  → Generates suggestion: "New node: 'Billing > VAT questions'"
+  → Sent to taxonomy owner's review queue
+  → Reviewer approves (or renames)
+  → Node is active; classifier retroactively tags existing content
+```
+
+Research estimate: 2–4 hours per quarter for an experienced reviewer covers a corpus of thousands of documents using active learning to surface only uncertain edge cases.
+
+---
+
+### 10.4 The honest trade-off
+
+Taxonomy adds structure, and structure costs maintenance. It only works well if someone holds the taxonomy-owner role explicitly. That does not need to be much time (2–4 hours/quarter per large tenant), but it must be intentional. Without that role, a taxonomy degrades faster than it was built.
+
+**What this means for Klai as a product:**
+
+Without taxonomy, Klai Knowledge is a sophisticated search engine with knowledge storage. You put content in; you pull content out via vector search.
+
+With the taxonomy layer, it becomes a **knowledge management platform with editorial intelligence**:
+
+| Dimension | Without taxonomy | With taxonomy |
+|---|---|---|
+| Search | "Find something" | "Find something within this domain" |
+| Gaps | "Here are 150 failed queries" | "Here are your writing assignments" |
+| Browse | Not possible | Hierarchy navigable |
+| Coverage | Invisible | Visible per topic node |
+| Editors | Reactive | Proactively guided agenda |
+| KB silos | Fully isolated | Shared taxonomic frame |
+
+**The priority recommendation:** taxonomy-aware gap detection has the highest immediate value for editors and requires the least infrastructure to build first. It requires: (1) a taxonomy definition, (2) classification of existing gaps to taxonomy nodes, (3) aggregation in the editorial inbox per node. A browse interface and faceted retrieval can follow once the taxonomy is stable.
+
+---
+
+## 11. Bootstrapping a taxonomy: main categories with stub subcategories
+
+### 11.1 Why a pre-defined taxonomy beats auto-discovery for V1
+
+Auto-discovery (BERTopic, FASTopic) requires a minimum viable corpus of ~1,000 documents to produce stable clusters. Most tenants onboard with far fewer articles. A pre-defined taxonomy with stub subcategories solves the cold-start problem and unlocks the three highest-value features (gap classification, retrieval filtering, coverage dashboard) immediately — without a discovery pipeline.
+
+Once a pre-defined taxonomy exists, every gap event can be matched against taxonomy nodes by embedding similarity. That is sufficient to produce an aggregated editorial inbox and a coverage view. No BERTopic needed until the corpus is large enough to validate and refine the taxonomy empirically.
+
+### 11.2 The minimum viable taxonomy structure
+
+**Main categories: 5–10**
+
+Broad enough that every user query maps to at least one. Narrow enough that gaps can be meaningfully prioritised. For a B2B SaaS knowledge base, a realistic starting set:
+
+```
+1. Getting started & onboarding
+2. Product features
+3. Billing & subscriptions
+4. Setup & configuration
+5. Integrations & connectors
+6. Security & compliance
+7. Troubleshooting
+8. API & developer docs
+9. Release notes & changelog
+10. Policies & legal
+```
+
+**Stub subcategories: 3–8 per main category**
+
+Placeholders — name + ID only, not fully elaborated. Examples under "Setup & Configuration":
+
+```
+Setup & Configuration
+├── SSO & authentication
+├── Permissions & roles
+├── Notifications
+├── Data import & export
+└── [stub: other]
+```
+
+The `[stub: other]` catchall is important: it captures gaps that belong in this main category but don't yet have a named subcategory. When the stub accumulates enough gaps, that signals a node should be split off.
+
+**Node description: 1–2 sentences per node**
+
+This is non-optional. A classifier matching queries against node names alone will miss edge cases. Each node needs a brief description of what kinds of questions and content belong there. Example:
+
+> **SSO & authentication** — questions and articles about single sign-on setup, SAML/OIDC configuration, login problems, session management, and multi-factor authentication.
+
+Without this, "I can't log in" may be classified to Troubleshooting instead of SSO & authentication — both are plausible, but only one is editorially actionable.
+
+### 11.3 What this enables immediately
+
+With main categories + stubs + descriptions in place:
+
+**Gap classification** — every incoming gap query is embedded and matched against node descriptions. The gap registry gains a `taxonomy_node_id` field. The editorial inbox can immediately aggregate: "47 gaps in Billing & subscriptions, 31 in Setup & configuration."
+
+**Retrieval filtering** — chunks at ingest time get classified to a taxonomy node. The Qdrant payload gains `taxonomy_nodes: ["setup", "setup.sso"]`. The retrieval-api can filter on this before vector search runs.
+
+**Coverage dashboard** — `COUNT(chunks) GROUP BY taxonomy_node` shows immediately which nodes are thin (<3 articles) vs. well-covered.
+
+### 11.4 What to leave out of V1
+
+Do not build in V1:
+- Synonym lists (add these after seeing real classification failures)
+- More than 3 levels of depth (stubs are level 2; level 3 emerges from gap data)
+- Automatic taxonomy evolution (nodes are only added/renamed via the governance queue)
+- Tenant-customised taxonomy structures (a shared base taxonomy is sufficient for V1; tenant overrides are V2)
+
+### 11.5 How the taxonomy grows
+
+The taxonomy is not designed once and frozen. The gap data drives it forward:
+
+1. A taxonomy node accumulates gaps that are semantically diverse → signal to split it into two nodes
+2. Two taxonomy nodes consistently share the same gaps → signal to merge them
+3. The `[stub: other]` catchall in a main category grows past a threshold (e.g. 20 gaps) → signal to name and formalise a new subcategory
+
+All three signals go to the governance queue (§6.5 of the architecture). A reviewer approves or rejects. The taxonomy evolves from real usage, not from upfront speculation.
+
+### 11.6 Effort estimate
+
+| Task | Effort |
+|---|---|
+| Define 5–10 main categories | 1–2 hours |
+| Write 3–8 stub subcategories per main category | 2–4 hours |
+| Write node descriptions (1–2 sentences each) | 2–3 hours |
+| **Total: initial taxonomy definition** | **~1 day** |
+| Classify existing gaps to taxonomy nodes (retroactive) | Automated once descriptions exist |
+| First quarterly review | 2–4 hours |
+
+The description-writing step is the one that cannot be skipped. It is also the step that requires domain knowledge — it cannot be delegated to a classifier or generated by LLM without human review, because these descriptions define what the system considers in-scope for each node.
+
+---
+
+## Sources
+
+- [Taxonomy 101: Definition, Best Practices — Nielsen Norman Group](https://www.nngroup.com/articles/taxonomy-101/)
+- [Knowledge Base Taxonomy: 10 Proven Design Principles — Matrixflows](https://www.matrixflows.com/blog/10-best-practices-for-creating-taxonomy-for-your-company-knowledge-base)
+- [Taxonomy Design Best Practices — Enterprise Knowledge](https://enterprise-knowledge.com/taxonomy-design-best-practices/)
+- [Taxonomy Implementation Best Practices — Enterprise Knowledge](https://enterprise-knowledge.com/taxonomy-implementation-best-practices/)
+- [The Case for Enterprise Taxonomy — Strategic Content](https://strategiccontent.com/resources/enterprise-taxonomy)
+- [Faceted vs Hierarchical Taxonomies — LinkedIn](https://www.linkedin.com/advice/0/what-differences-between-hierarchical-56r2f)
+- [When a Taxonomy Should Not Be Hierarchical — Hedden Information Management](https://www.hedden-information.com/when-a-taxonomy-should-not-be-hierarchical/)
+- [Polyhierarchy in Taxonomies — Hedden Information Management](https://www.hedden-information.com/polyhierarchy-in-taxonomies/)
+- [Why a Knowledge Graph is the Best Way to Upgrade Your Taxonomy — Enterprise Knowledge](https://enterprise-knowledge.com/why-a-knowledge-graph-is-the-best-way-to-upgrade-your-taxonomy/)
+- [From Data Chaos to Clarity: GenAI Needs Taxonomy & Ontology — Squirro](https://squirro.com/squirro-blog/genai-taxonomy-ontology)
+- [A Survey on Knowledge-Oriented RAG — arXiv](https://arxiv.org/html/2503.10677v1)
+- [Knowledge Graph-Based RAG — Nature Scientific Reports](https://www.nature.com/articles/s41598-025-21222-z)
+- [Enhancing Taxonomy Management Through Knowledge Intelligence — Enterprise Knowledge](https://enterprise-knowledge.com/enhancing-taxonomy-management-through-knowledge-intelligence/)
+- [The Role of Taxonomies in Effective Knowledge Management — Taxodiary](https://taxodiary.com/2025/09/the-role-of-taxonomies-in-effective-knowledge-management/)
+- [Knowledge Management Taxonomy — KM Insider](https://kminsider.com/topic/knowledge-management-taxonomy/)
+- [Hidden Costs of Inefficient Knowledge Management — Assima](https://assimasolutions.com/resources/blog/hidden-costs-of-inefficient-knowledge-management/)

--- a/klai-connector/uv.lock
+++ b/klai-connector/uv.lock
@@ -109,15 +109,6 @@ wheels = [
 ]
 
 [[package]]
-name = "backoff"
-version = "2.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148 },
-]
-
-[[package]]
 name = "beautifulsoup4"
 version = "4.14.3"
 source = { registry = "https://pypi.org/simple" }
@@ -594,15 +585,6 @@ wheels = [
 ]
 
 [[package]]
-name = "htmlbuilder"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/45/a1/da87d642b31831fb6731cbec6c5dceb3f770dd0b147beefbb1426eb8f0c6/htmlBuilder-1.0.0.tar.gz", hash = "sha256:4eae01d8acc77213328659b6be32e357f47ae10939959fcdcce8afb9393de564", size = 15967 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/73/eb44d24c8554c7093f5b4cacd7a258c8012601727f053ea88e131888febf/htmlBuilder-1.0.0-py2.py3-none-any.whl", hash = "sha256:d023c1be4e1f8b0df31a3414ab27be2d44defc1ff96c242962c1d67e38091701", size = 14926 },
-]
-
-[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -654,18 +636,6 @@ wheels = [
 ]
 
 [[package]]
-name = "importlib-metadata"
-version = "8.7.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "zipp" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865 },
-]
-
-[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -707,13 +677,13 @@ dependencies = [
     { name = "fastapi" },
     { name = "gidgethub" },
     { name = "httpx", extra = ["http2"] },
+    { name = "notion-sync-lib" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "structlog" },
     { name = "unstructured" },
-    { name = "unstructured-ingest", extra = ["notion"] },
     { name = "uvicorn" },
 ]
 
@@ -734,6 +704,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "gidgethub", specifier = ">=5.3.0" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.28.0" },
+    { name = "notion-sync-lib", git = "https://github.com/mvletter/notion-sync-lib.git" },
     { name = "pydantic", specifier = ">=2.9.0" },
     { name = "pydantic-settings", specifier = ">=2.7.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.9.0" },
@@ -744,7 +715,6 @@ requires-dist = [
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.36" },
     { name = "structlog", specifier = ">=25.0" },
     { name = "unstructured", specifier = ">=0.16.0" },
-    { name = "unstructured-ingest", extras = ["notion"], specifier = ">=1.4.18" },
     { name = "uvicorn", specifier = ">=0.34.0" },
 ]
 provides-extras = ["dev"]
@@ -1028,6 +998,16 @@ wheels = [
 ]
 
 [[package]]
+name = "notion-sync-lib"
+version = "1.2.7"
+source = { git = "https://github.com/mvletter/notion-sync-lib.git#c992f5314b4c1b2c94ff019f6de7260a59f558b1" }
+dependencies = [
+    { name = "notion-client" },
+    { name = "python-dotenv" },
+    { name = "requests" },
+]
+
+[[package]]
 name = "numba"
 version = "0.65.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1123,46 +1103,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/69/1b/077b508e3e500e1629d366249c3ccb32f95e50258b231705c09e3c7a4366/olefile-0.47.zip", hash = "sha256:599383381a0bf3dfbd932ca0ca6515acd174ed48870cbf7fee123d698c192c1c", size = 112240 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/d3/b64c356a907242d719fc668b71befd73324e47ab46c8ebbbede252c154b2/olefile-0.47-py2.py3-none-any.whl", hash = "sha256:543c7da2a7adadf21214938bb79c83ea12b473a4b6ee4ad4bf854e7715e13d1f", size = 114565 },
-]
-
-[[package]]
-name = "opentelemetry-api"
-version = "1.40.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "importlib-metadata" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/1d/4049a9e8698361cc1a1aa03a6c59e4fa4c71e0c0f94a30f988a6876a2ae6/opentelemetry_api-1.40.0.tar.gz", hash = "sha256:159be641c0b04d11e9ecd576906462773eb97ae1b657730f0ecf64d32071569f", size = 70851 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/bf/93795954016c522008da367da292adceed71cca6ee1717e1d64c83089099/opentelemetry_api-1.40.0-py3-none-any.whl", hash = "sha256:82dd69331ae74b06f6a874704be0cfaa49a1650e1537d4a813b86ecef7d0ecf9", size = 68676 },
-]
-
-[[package]]
-name = "opentelemetry-sdk"
-version = "1.40.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/58/fd/3c3125b20ba18ce2155ba9ea74acb0ae5d25f8cd39cfd37455601b7955cc/opentelemetry_sdk-1.40.0.tar.gz", hash = "sha256:18e9f5ec20d859d268c7cb3c5198c8d105d073714db3de50b593b8c1345a48f2", size = 184252 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/c5/6a852903d8bfac758c6dc6e9a68b015d3c33f2f1be5e9591e0f4b69c7e0a/opentelemetry_sdk-1.40.0-py3-none-any.whl", hash = "sha256:787d2154a71f4b3d81f20524a8ce061b7db667d24e46753f32a7bc48f1c1f3f1", size = 141951 },
-]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.61b0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/c0/4ae7973f3c2cfd2b6e321f1675626f0dab0a97027cc7a297474c9c8f3d04/opentelemetry_semantic_conventions-0.61b0.tar.gz", hash = "sha256:072f65473c5d7c6dc0355b27d6c9d1a679d63b6d4b4b16a9773062cb7e31192a", size = 145755 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/37/cc6a55e448deaa9b27377d087da8615a3416d8ad523d5960b78dbeadd02a/opentelemetry_semantic_conventions-0.61b0-py3-none-any.whl", hash = "sha256:fa530a96be229795f8cef353739b618148b0fe2b4b3f005e60e262926c4d38e2", size = 231621 },
 ]
 
 [[package]]
@@ -1465,18 +1405,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075 },
-]
-
-[[package]]
-name = "python-dateutil"
-version = "2.9.0.post0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892 },
 ]
 
 [[package]]
@@ -2130,31 +2058,6 @@ wheels = [
 ]
 
 [[package]]
-name = "unstructured-ingest"
-version = "1.4.18"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "click" },
-    { name = "opentelemetry-sdk" },
-    { name = "pydantic" },
-    { name = "python-dateutil" },
-    { name = "tqdm" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3f/ed/081631fc6f0914e3ea4cc745618c641bdb272baeb82487f3b9c8f9b27994/unstructured_ingest-1.4.18.tar.gz", hash = "sha256:ac66a8e4fb1aa770e4aceb142c62945bc029a7f297358e6c722745a0c51235c5", size = 216007 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/bb/fe83be9fd1daa07989fea28d7af62897f14ed97cc68b5c54ff97556ec15b/unstructured_ingest-1.4.18-py3-none-any.whl", hash = "sha256:d4a05f5fe85aafc2f8271042f578650d4effd45a5db0e85f1987b69395a625f7", size = 361833 },
-]
-
-[package.optional-dependencies]
-notion = [
-    { name = "backoff" },
-    { name = "htmlbuilder" },
-    { name = "httpx" },
-    { name = "notion-client" },
-]
-
-[[package]]
 name = "uritemplate"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2288,13 +2191,4 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969 },
     { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554 },
     { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993 },
-]
-
-[[package]]
-name = "zipp"
-version = "3.23.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276 },
 ]

--- a/klai-focus/research-api/alembic/versions/0004_add_kb_slug_to_notebooks.py
+++ b/klai-focus/research-api/alembic/versions/0004_add_kb_slug_to_notebooks.py
@@ -1,0 +1,25 @@
+"""Add kb_slug to research.notebooks for taxonomy-aware retrieval
+
+Revision ID: 0004_add_kb_slug
+Revises: 0003_drop_embedding
+Create Date: 2026-04-07
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0004_add_kb_slug"
+down_revision = "0003_drop_embedding"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "notebooks",
+        sa.Column("kb_slug", sa.VARCHAR(128), nullable=True),
+        schema="research",
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("notebooks", "kb_slug", schema="research")

--- a/klai-focus/research-api/app/api/chat.py
+++ b/klai-focus/research-api/app/api/chat.py
@@ -36,6 +36,7 @@ class ChatRequest(BaseModel):
     question: str
     mode: str | None = None
     history: list[dict] | None = None
+    kb_slug: str | None = None  # When set, enables taxonomy-aware retrieval in broad mode
 
 
 @router.post("/notebooks/{nb_id}/chat")
@@ -67,7 +68,7 @@ async def chat(
     history = body.history or []
 
     return StreamingResponse(
-        _generate(db, question, mode, nb_id, user.tenant_id, history, nb.save_history),
+        _generate(db, question, mode, nb_id, user.tenant_id, history, nb.save_history, body.kb_slug),
         media_type="text/event-stream",
         headers={
             "Cache-Control": "no-cache",
@@ -84,13 +85,14 @@ async def _generate(
     tenant_id: str,
     history: list[dict],
     save_history: bool,
+    kb_slug: str | None = None,
 ):
     """Async generator that yields SSE lines."""
     full_response = ""
     try:
         # 1. Retrieve chunks based on mode
         if mode == "broad":
-            doc_chunks = await retrieve_broad(question, notebook_id, tenant_id)
+            doc_chunks = await retrieve_broad(question, notebook_id, tenant_id, kb_slug=kb_slug)
             web_chunks: list[dict] = []
         elif mode == "web":
             doc_chunks = await retrieve_narrow(question, notebook_id, tenant_id)

--- a/klai-focus/research-api/app/api/chat.py
+++ b/klai-focus/research-api/app/api/chat.py
@@ -36,7 +36,6 @@ class ChatRequest(BaseModel):
     question: str
     mode: str | None = None
     history: list[dict] | None = None
-    kb_slug: str | None = None  # When set, enables taxonomy-aware retrieval in broad mode
 
 
 @router.post("/notebooks/{nb_id}/chat")
@@ -68,7 +67,7 @@ async def chat(
     history = body.history or []
 
     return StreamingResponse(
-        _generate(db, question, mode, nb_id, user.tenant_id, history, nb.save_history, body.kb_slug),
+        _generate(db, question, mode, nb_id, user.tenant_id, history, nb.save_history, nb.kb_slug),
         media_type="text/event-stream",
         headers={
             "Cache-Control": "no-cache",

--- a/klai-focus/research-api/app/api/notebooks.py
+++ b/klai-focus/research-api/app/api/notebooks.py
@@ -30,6 +30,7 @@ class NotebookCreate(BaseModel):
     description: str | None = None
     scope: Literal["personal", "org"] = "personal"
     default_mode: Literal["narrow", "broad", "web"] = "narrow"
+    kb_slug: str | None = None
 
 
 class NotebookUpdate(BaseModel):
@@ -38,6 +39,7 @@ class NotebookUpdate(BaseModel):
     scope: Literal["personal", "org"] | None = None
     default_mode: Literal["narrow", "broad", "web"] | None = None
     save_history: bool | None = None
+    kb_slug: str | None = None
 
 
 class NotebookResponse(BaseModel):
@@ -47,6 +49,7 @@ class NotebookResponse(BaseModel):
     scope: str
     default_mode: str
     save_history: bool
+    kb_slug: str | None
     owner_user_id: str
     sources_count: int
     created_at: datetime
@@ -110,6 +113,7 @@ async def create_notebook(
         name=body.name,
         description=body.description,
         default_mode=body.default_mode,
+        kb_slug=body.kb_slug,
     )
     db.add(nb)
     await db.commit()
@@ -125,6 +129,7 @@ async def create_notebook(
         scope=nb.scope,
         default_mode=nb.default_mode,
         save_history=nb.save_history,
+        kb_slug=nb.kb_slug,
         owner_user_id=nb.owner_user_id,
         sources_count=0,
         created_at=nb.created_at,
@@ -173,6 +178,7 @@ async def list_notebooks(
                 scope=nb.scope,
                 default_mode=nb.default_mode,
                 save_history=nb.save_history,
+                kb_slug=nb.kb_slug,
                 owner_user_id=nb.owner_user_id,
                 sources_count=count,
                 created_at=nb.created_at,
@@ -202,6 +208,7 @@ async def get_notebook(
         scope=nb.scope,
         default_mode=nb.default_mode,
         save_history=nb.save_history,
+        kb_slug=nb.kb_slug,
         owner_user_id=nb.owner_user_id,
         sources_count=count,
         created_at=nb.created_at,
@@ -233,6 +240,8 @@ async def update_notebook(
         nb.default_mode = body.default_mode
     if body.save_history is not None:
         nb.save_history = body.save_history
+    if body.kb_slug is not None:
+        nb.kb_slug = body.kb_slug
     nb.updated_at = datetime.utcnow()
 
     await db.commit()
@@ -246,6 +255,7 @@ async def update_notebook(
         scope=nb.scope,
         default_mode=nb.default_mode,
         save_history=nb.save_history,
+        kb_slug=nb.kb_slug,
         owner_user_id=nb.owner_user_id,
         sources_count=count,
         created_at=nb.created_at,

--- a/klai-focus/research-api/app/core/config.py
+++ b/klai-focus/research-api/app/core/config.py
@@ -26,10 +26,14 @@ class Settings(BaseSettings):
     # Internal service URLs
     docling_url: str = "http://docling-serve:5001"
     retrieval_api_url: str = ""
+    knowledge_ingest_url: str = "http://knowledge-ingest:8000"
     tei_url: str = "http://172.18.0.1:7997"
     litellm_url: str = "http://litellm:4000"
     litellm_api_key: str = ""
     searxng_url: str = "http://searxng:8080"
+
+    # Taxonomy-aware retrieval
+    taxonomy_retrieval_min_coverage: float = 0.3
 
     # YouTube — optional residential proxy, used as fallback when YouTube blocks server IP
     # Format: https://user:pass@host:port

--- a/klai-focus/research-api/app/models/notebook.py
+++ b/klai-focus/research-api/app/models/notebook.py
@@ -10,7 +10,7 @@ class Base(DeclarativeBase):
 
 class Notebook(Base):
     __tablename__ = "notebooks"
-    __table_args__ = {"schema": "research"}
+    __table_args__ = {"schema": "research"}  # noqa: RUF012
 
     id = Column(VARCHAR(32), primary_key=True)
     tenant_id = Column(VARCHAR(64), nullable=False, index=True)

--- a/klai-focus/research-api/app/models/notebook.py
+++ b/klai-focus/research-api/app/models/notebook.py
@@ -20,6 +20,7 @@ class Notebook(Base):
     description = Column(Text, nullable=True)
     default_mode = Column(VARCHAR(16), nullable=False, default="narrow")
     save_history = Column(Boolean, nullable=False, default=True, server_default="true")
+    kb_slug = Column(VARCHAR(128), nullable=True)
     created_at = Column(TIMESTAMP(timezone=True), nullable=False, default=datetime.utcnow)
     updated_at = Column(
         TIMESTAMP(timezone=True), nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow

--- a/klai-focus/research-api/app/services/retrieval_client.py
+++ b/klai-focus/research-api/app/services/retrieval_client.py
@@ -61,8 +61,12 @@ async def _get_taxonomy_filter(
 
     try:
         node_ids, coverage = await asyncio.gather(
-            asyncio.wait_for(_classify_query(base, query, kb_slug, org_id), timeout=_TAXONOMY_TIMEOUT),
-            asyncio.wait_for(_get_coverage_ratio(base, kb_slug, org_id), timeout=_TAXONOMY_TIMEOUT),
+            asyncio.wait_for(
+                _classify_query(base, query, kb_slug, org_id), timeout=_TAXONOMY_TIMEOUT
+            ),
+            asyncio.wait_for(
+                _get_coverage_ratio(base, kb_slug, org_id), timeout=_TAXONOMY_TIMEOUT
+            ),
         )
     except Exception:
         logger.warning("taxonomy_filter_skipped", kb_slug=kb_slug, org_id=org_id)

--- a/klai-focus/research-api/app/services/retrieval_client.py
+++ b/klai-focus/research-api/app/services/retrieval_client.py
@@ -2,6 +2,7 @@
 HTTP client for retrieval-api service.
 Replaces direct Qdrant queries (narrow) and knowledge_client.py (broad).
 """
+import asyncio
 import logging
 
 import httpx
@@ -11,6 +12,66 @@ from app.core.config import settings
 logger = logging.getLogger(__name__)
 
 _TIMEOUT = 10.0
+_TAXONOMY_TIMEOUT = 3.0
+
+
+async def _get_taxonomy_filter(
+    query: str,
+    kb_slug: str,
+    org_id: str,
+) -> list[int] | None:
+    """Classify query against KB taxonomy and return node IDs to filter by.
+
+    Runs coverage check and classification in parallel. Returns None when:
+    - Either call fails or times out
+    - Coverage is below TAXONOMY_RETRIEVAL_MIN_COVERAGE (default 30%)
+    - No node IDs returned
+    """
+    if not settings.knowledge_ingest_url:
+        return None
+
+    base = settings.knowledge_ingest_url.rstrip("/")
+
+    async def _classify() -> list[int]:
+        async with httpx.AsyncClient(timeout=_TAXONOMY_TIMEOUT) as client:
+            resp = await client.post(
+                f"{base}/ingest/v1/taxonomy/classify",
+                json={"org_id": org_id, "kb_slug": kb_slug, "text": query},
+            )
+            resp.raise_for_status()
+            return resp.json().get("taxonomy_node_ids", [])
+
+    async def _coverage() -> float:
+        async with httpx.AsyncClient(timeout=_TAXONOMY_TIMEOUT) as client:
+            resp = await client.get(
+                f"{base}/ingest/v1/taxonomy/coverage-stats",
+                params={"kb_slug": kb_slug, "org_id": org_id},
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            total = data.get("total_chunks", 0)
+            if total == 0:
+                return 0.0
+            untagged = data.get("untagged_count", total)
+            return (total - untagged) / total
+
+    try:
+        node_ids, coverage = await asyncio.gather(
+            asyncio.wait_for(_classify(), timeout=_TAXONOMY_TIMEOUT),
+            asyncio.wait_for(_coverage(), timeout=_TAXONOMY_TIMEOUT),
+        )
+    except Exception:
+        logger.warning("taxonomy_filter_skipped", extra={"kb_slug": kb_slug, "org_id": org_id})
+        return None
+
+    if coverage < settings.taxonomy_retrieval_min_coverage:
+        logger.debug(
+            "taxonomy_filter_skipped_low_coverage",
+            extra={"kb_slug": kb_slug, "coverage": coverage},
+        )
+        return None
+
+    return node_ids if node_ids else None
 
 
 async def retrieve_narrow(
@@ -52,26 +113,43 @@ async def retrieve_broad(
     notebook_id: str,
     tenant_id: str,
     top_k: int = 8,
+    kb_slug: str | None = None,
 ) -> list[dict]:
     """
     Broad retrieval: Focus + KB chunks via retrieval-api broad scope.
     Returns list of {chunk_id, content, score, source_name, origin, metadata}.
+
+    When kb_slug is provided, applies taxonomy-aware filtering: classifies the query
+    against the KB's taxonomy and passes matching node IDs to the retrieval-api.
+    Falls back to unfiltered retrieval on any classification error.
     """
     if not settings.retrieval_api_url:
         logger.warning("RETRIEVAL_API_URL not set, broad retrieval returns empty")
         return []
 
+    taxonomy_node_ids: list[int] | None = None
+    if kb_slug:
+        taxonomy_node_ids = await _get_taxonomy_filter(
+            query=question,
+            kb_slug=kb_slug,
+            org_id=tenant_id,
+        )
+
     try:
+        request_body: dict = {
+            "query": question,
+            "org_id": tenant_id,
+            "scope": "broad",
+            "notebook_id": notebook_id,
+            "top_k": top_k,
+        }
+        if taxonomy_node_ids is not None:
+            request_body["taxonomy_node_ids"] = taxonomy_node_ids
+
         async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
             resp = await client.post(
                 f"{settings.retrieval_api_url}/retrieve",
-                json={
-                    "query": question,
-                    "org_id": tenant_id,
-                    "scope": "broad",
-                    "notebook_id": notebook_id,
-                    "top_k": top_k,
-                },
+                json=request_body,
             )
             resp.raise_for_status()
             data = resp.json()

--- a/klai-focus/research-api/app/services/retrieval_client.py
+++ b/klai-focus/research-api/app/services/retrieval_client.py
@@ -3,16 +3,43 @@ HTTP client for retrieval-api service.
 Replaces direct Qdrant queries (narrow) and knowledge_client.py (broad).
 """
 import asyncio
-import logging
 
 import httpx
+import structlog
 
 from app.core.config import settings
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger()
 
 _TIMEOUT = 10.0
 _TAXONOMY_TIMEOUT = 3.0
+
+
+async def _classify_query(base: str, query: str, kb_slug: str, org_id: str) -> list[int]:
+    """POST to knowledge-ingest classify endpoint; returns matched taxonomy node IDs."""
+    async with httpx.AsyncClient(timeout=_TAXONOMY_TIMEOUT) as client:
+        resp = await client.post(
+            f"{base}/ingest/v1/taxonomy/classify",
+            json={"org_id": org_id, "kb_slug": kb_slug, "text": query},
+        )
+        resp.raise_for_status()
+        return resp.json().get("taxonomy_node_ids", [])
+
+
+async def _get_coverage_ratio(base: str, kb_slug: str, org_id: str) -> float:
+    """GET coverage-stats from knowledge-ingest; returns fraction of tagged chunks."""
+    async with httpx.AsyncClient(timeout=_TAXONOMY_TIMEOUT) as client:
+        resp = await client.get(
+            f"{base}/ingest/v1/taxonomy/coverage-stats",
+            params={"kb_slug": kb_slug, "org_id": org_id},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        total = data.get("total_chunks", 0)
+        if total == 0:
+            return 0.0
+        untagged = data.get("untagged_count", total)
+        return (total - untagged) / total
 
 
 async def _get_taxonomy_filter(
@@ -32,43 +59,17 @@ async def _get_taxonomy_filter(
 
     base = settings.knowledge_ingest_url.rstrip("/")
 
-    async def _classify() -> list[int]:
-        async with httpx.AsyncClient(timeout=_TAXONOMY_TIMEOUT) as client:
-            resp = await client.post(
-                f"{base}/ingest/v1/taxonomy/classify",
-                json={"org_id": org_id, "kb_slug": kb_slug, "text": query},
-            )
-            resp.raise_for_status()
-            return resp.json().get("taxonomy_node_ids", [])
-
-    async def _coverage() -> float:
-        async with httpx.AsyncClient(timeout=_TAXONOMY_TIMEOUT) as client:
-            resp = await client.get(
-                f"{base}/ingest/v1/taxonomy/coverage-stats",
-                params={"kb_slug": kb_slug, "org_id": org_id},
-            )
-            resp.raise_for_status()
-            data = resp.json()
-            total = data.get("total_chunks", 0)
-            if total == 0:
-                return 0.0
-            untagged = data.get("untagged_count", total)
-            return (total - untagged) / total
-
     try:
         node_ids, coverage = await asyncio.gather(
-            asyncio.wait_for(_classify(), timeout=_TAXONOMY_TIMEOUT),
-            asyncio.wait_for(_coverage(), timeout=_TAXONOMY_TIMEOUT),
+            asyncio.wait_for(_classify_query(base, query, kb_slug, org_id), timeout=_TAXONOMY_TIMEOUT),
+            asyncio.wait_for(_get_coverage_ratio(base, kb_slug, org_id), timeout=_TAXONOMY_TIMEOUT),
         )
     except Exception:
-        logger.warning("taxonomy_filter_skipped", extra={"kb_slug": kb_slug, "org_id": org_id})
+        logger.warning("taxonomy_filter_skipped", kb_slug=kb_slug, org_id=org_id)
         return None
 
     if coverage < settings.taxonomy_retrieval_min_coverage:
-        logger.debug(
-            "taxonomy_filter_skipped_low_coverage",
-            extra={"kb_slug": kb_slug, "coverage": coverage},
-        )
+        logger.debug("taxonomy_filter_skipped_low_coverage", kb_slug=kb_slug, coverage=coverage)
         return None
 
     return node_ids if node_ids else None

--- a/klai-focus/research-api/app/services/retrieval_client.py
+++ b/klai-focus/research-api/app/services/retrieval_client.py
@@ -76,6 +76,12 @@ async def _get_taxonomy_filter(
         logger.debug("taxonomy_filter_skipped_low_coverage", kb_slug=kb_slug, coverage=coverage)
         return None
 
+    # Node IDs come from the classify endpoint, which fetches the current taxonomy
+    # immediately before classifying. It can only return IDs that exist at call time.
+    # Stale IDs are not possible without a sub-second race condition (node deleted
+    # between classify response and this line). Even then, Qdrant chunks retain their
+    # taxonomy_node_ids after portal node deletion — MatchAny([stale_id]) still
+    # returns the correctly tagged content.
     return node_ids if node_ids else None
 
 

--- a/klai-focus/research-api/pyproject.toml
+++ b/klai-focus/research-api/pyproject.toml
@@ -36,8 +36,9 @@ target-version = "py312"
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "S", "RUF", "G", "LOG"]
 ignore = [
-    "S101",  # assert is fine in tests
-    "S105",  # hardcoded passwords — too many false positives on config defaults
+    "S101",   # assert is fine in tests
+    "S105",   # hardcoded passwords — too many false positives on config defaults
+    "B008",   # FastAPI Depends() in function defaults is the intended pattern
 ]
 
 [tool.pytest.ini_options]

--- a/klai-focus/research-api/pyproject.toml
+++ b/klai-focus/research-api/pyproject.toml
@@ -39,3 +39,7 @@ ignore = [
     "S101",  # assert is fine in tests
     "S105",  # hardcoded passwords — too many false positives on config defaults
 ]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/klai-focus/research-api/tests/conftest.py
+++ b/klai-focus/research-api/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Conftest for research-api tests.
+
+Sets required environment variables before any module import so pydantic-settings
+can instantiate Settings without a real .env file.
+"""
+import os
+
+os.environ.setdefault("POSTGRES_DSN", "postgresql+asyncpg://test:test@localhost/test")

--- a/klai-focus/research-api/tests/test_taxonomy_filter.py
+++ b/klai-focus/research-api/tests/test_taxonomy_filter.py
@@ -1,0 +1,118 @@
+"""Tests for _get_taxonomy_filter — taxonomy-aware retrieval (SPEC-KB-027 R1).
+
+We patch asyncio.gather directly to control what the parallel calls return,
+bypassing HTTP entirely. This tests the logic of _get_taxonomy_filter (coverage
+check, empty-list handling) without requiring a live HTTP stack.
+
+Verifies:
+- Returns node IDs when coverage >= 30% and classify returns IDs
+- Returns None when coverage < 30%
+- Returns None when asyncio.gather raises (timeout, network error)
+- Returns None when knowledge_ingest_url is empty
+- Returns None when node_ids is empty list despite sufficient coverage
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _mock_settings(
+    knowledge_ingest_url: str = "http://knowledge-ingest:8000",
+    taxonomy_retrieval_min_coverage: float = 0.3,
+) -> MagicMock:
+    s = MagicMock()
+    s.knowledge_ingest_url = knowledge_ingest_url
+    s.taxonomy_retrieval_min_coverage = taxonomy_retrieval_min_coverage
+    return s
+
+
+class TestGetTaxonomyFilter:
+    @pytest.mark.asyncio
+    async def test_returns_node_ids_when_coverage_sufficient(self):
+        """Returns [5, 7] when classify returns those IDs and coverage = 60% (>= 30%)."""
+        with patch("app.services.retrieval_client.settings", _mock_settings()):
+            with patch(
+                "app.services.retrieval_client.asyncio.gather",
+                new=AsyncMock(return_value=([5, 7], 0.6)),
+            ):
+                from app.services.retrieval_client import _get_taxonomy_filter
+                result = await _get_taxonomy_filter("test query", "my-kb", "org1")
+
+        assert result == [5, 7]
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_coverage_too_low(self):
+        """Returns None when coverage = 10% (< 30% threshold)."""
+        with patch("app.services.retrieval_client.settings", _mock_settings()):
+            with patch(
+                "app.services.retrieval_client.asyncio.gather",
+                new=AsyncMock(return_value=([5], 0.1)),
+            ):
+                from app.services.retrieval_client import _get_taxonomy_filter
+                result = await _get_taxonomy_filter("test query", "my-kb", "org1")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_timeout(self):
+        """Returns None when calls time out — retrieval continues without filter."""
+        with patch("app.services.retrieval_client.settings", _mock_settings()):
+            with patch(
+                "app.services.retrieval_client.asyncio.gather",
+                side_effect=asyncio.TimeoutError,
+            ):
+                from app.services.retrieval_client import _get_taxonomy_filter
+                result = await _get_taxonomy_filter("test query", "my-kb", "org1")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_exception(self):
+        """Returns None when classify/coverage raise any exception."""
+        with patch("app.services.retrieval_client.settings", _mock_settings()):
+            with patch(
+                "app.services.retrieval_client.asyncio.gather",
+                side_effect=Exception("connection refused"),
+            ):
+                from app.services.retrieval_client import _get_taxonomy_filter
+                result = await _get_taxonomy_filter("test query", "my-kb", "org1")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_knowledge_ingest_url_empty(self):
+        """Returns None immediately when knowledge_ingest_url is not configured."""
+        with patch("app.services.retrieval_client.settings", _mock_settings(knowledge_ingest_url="")):
+            from app.services.retrieval_client import _get_taxonomy_filter
+            result = await _get_taxonomy_filter("test query", "my-kb", "org1")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_classify_returns_empty(self):
+        """Returns None when classify returns empty list despite sufficient coverage."""
+        with patch("app.services.retrieval_client.settings", _mock_settings()):
+            with patch(
+                "app.services.retrieval_client.asyncio.gather",
+                new=AsyncMock(return_value=([], 0.7)),
+            ):
+                from app.services.retrieval_client import _get_taxonomy_filter
+                result = await _get_taxonomy_filter("test query", "my-kb", "org1")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_exact_coverage_threshold_passes(self):
+        """Returns node IDs when coverage exactly equals the minimum threshold (30%)."""
+        with patch("app.services.retrieval_client.settings", _mock_settings()):
+            with patch(
+                "app.services.retrieval_client.asyncio.gather",
+                new=AsyncMock(return_value=([3], 0.3)),
+            ):
+                from app.services.retrieval_client import _get_taxonomy_filter
+                result = await _get_taxonomy_filter("test query", "my-kb", "org1")
+
+        assert result == [3]

--- a/klai-focus/research-api/tests/test_taxonomy_filter.py
+++ b/klai-focus/research-api/tests/test_taxonomy_filter.py
@@ -1,8 +1,8 @@
 """Tests for _get_taxonomy_filter — taxonomy-aware retrieval (SPEC-KB-027 R1).
 
-We patch asyncio.gather directly to control what the parallel calls return,
-bypassing HTTP entirely. This tests the logic of _get_taxonomy_filter (coverage
-check, empty-list handling) without requiring a live HTTP stack.
+We patch the two helper coroutines (_classify_query, _get_coverage_ratio) that
+_get_taxonomy_filter calls via asyncio.gather. This avoids HTTP entirely and tests
+the orchestration logic cleanly: coverage gating, empty-list handling, error fallback.
 
 Verifies:
 - Returns node IDs when coverage >= 30% and classify returns IDs
@@ -10,6 +10,7 @@ Verifies:
 - Returns None when asyncio.gather raises (timeout, network error)
 - Returns None when knowledge_ingest_url is empty
 - Returns None when node_ids is empty list despite sufficient coverage
+- Returns node IDs at exact coverage threshold (30%)
 """
 from __future__ import annotations
 
@@ -34,12 +35,10 @@ class TestGetTaxonomyFilter:
     async def test_returns_node_ids_when_coverage_sufficient(self):
         """Returns [5, 7] when classify returns those IDs and coverage = 60% (>= 30%)."""
         with patch("app.services.retrieval_client.settings", _mock_settings()):
-            with patch(
-                "app.services.retrieval_client.asyncio.gather",
-                new=AsyncMock(return_value=([5, 7], 0.6)),
-            ):
-                from app.services.retrieval_client import _get_taxonomy_filter
-                result = await _get_taxonomy_filter("test query", "my-kb", "org1")
+            with patch("app.services.retrieval_client._classify_query", new=AsyncMock(return_value=[5, 7])):
+                with patch("app.services.retrieval_client._get_coverage_ratio", new=AsyncMock(return_value=0.6)):
+                    from app.services.retrieval_client import _get_taxonomy_filter
+                    result = await _get_taxonomy_filter("test query", "my-kb", "org1")
 
         assert result == [5, 7]
 
@@ -47,12 +46,10 @@ class TestGetTaxonomyFilter:
     async def test_returns_none_when_coverage_too_low(self):
         """Returns None when coverage = 10% (< 30% threshold)."""
         with patch("app.services.retrieval_client.settings", _mock_settings()):
-            with patch(
-                "app.services.retrieval_client.asyncio.gather",
-                new=AsyncMock(return_value=([5], 0.1)),
-            ):
-                from app.services.retrieval_client import _get_taxonomy_filter
-                result = await _get_taxonomy_filter("test query", "my-kb", "org1")
+            with patch("app.services.retrieval_client._classify_query", new=AsyncMock(return_value=[5])):
+                with patch("app.services.retrieval_client._get_coverage_ratio", new=AsyncMock(return_value=0.1)):
+                    from app.services.retrieval_client import _get_taxonomy_filter
+                    result = await _get_taxonomy_filter("test query", "my-kb", "org1")
 
         assert result is None
 
@@ -60,12 +57,10 @@ class TestGetTaxonomyFilter:
     async def test_returns_none_on_timeout(self):
         """Returns None when calls time out — retrieval continues without filter."""
         with patch("app.services.retrieval_client.settings", _mock_settings()):
-            with patch(
-                "app.services.retrieval_client.asyncio.gather",
-                side_effect=asyncio.TimeoutError,
-            ):
-                from app.services.retrieval_client import _get_taxonomy_filter
-                result = await _get_taxonomy_filter("test query", "my-kb", "org1")
+            with patch("app.services.retrieval_client._classify_query", side_effect=asyncio.TimeoutError):
+                with patch("app.services.retrieval_client._get_coverage_ratio", new=AsyncMock(return_value=0.6)):
+                    from app.services.retrieval_client import _get_taxonomy_filter
+                    result = await _get_taxonomy_filter("test query", "my-kb", "org1")
 
         assert result is None
 
@@ -73,12 +68,10 @@ class TestGetTaxonomyFilter:
     async def test_returns_none_on_exception(self):
         """Returns None when classify/coverage raise any exception."""
         with patch("app.services.retrieval_client.settings", _mock_settings()):
-            with patch(
-                "app.services.retrieval_client.asyncio.gather",
-                side_effect=Exception("connection refused"),
-            ):
-                from app.services.retrieval_client import _get_taxonomy_filter
-                result = await _get_taxonomy_filter("test query", "my-kb", "org1")
+            with patch("app.services.retrieval_client._classify_query", side_effect=Exception("connection refused")):
+                with patch("app.services.retrieval_client._get_coverage_ratio", new=AsyncMock(return_value=0.6)):
+                    from app.services.retrieval_client import _get_taxonomy_filter
+                    result = await _get_taxonomy_filter("test query", "my-kb", "org1")
 
         assert result is None
 
@@ -95,12 +88,10 @@ class TestGetTaxonomyFilter:
     async def test_returns_none_when_classify_returns_empty(self):
         """Returns None when classify returns empty list despite sufficient coverage."""
         with patch("app.services.retrieval_client.settings", _mock_settings()):
-            with patch(
-                "app.services.retrieval_client.asyncio.gather",
-                new=AsyncMock(return_value=([], 0.7)),
-            ):
-                from app.services.retrieval_client import _get_taxonomy_filter
-                result = await _get_taxonomy_filter("test query", "my-kb", "org1")
+            with patch("app.services.retrieval_client._classify_query", new=AsyncMock(return_value=[])):
+                with patch("app.services.retrieval_client._get_coverage_ratio", new=AsyncMock(return_value=0.7)):
+                    from app.services.retrieval_client import _get_taxonomy_filter
+                    result = await _get_taxonomy_filter("test query", "my-kb", "org1")
 
         assert result is None
 
@@ -108,11 +99,9 @@ class TestGetTaxonomyFilter:
     async def test_exact_coverage_threshold_passes(self):
         """Returns node IDs when coverage exactly equals the minimum threshold (30%)."""
         with patch("app.services.retrieval_client.settings", _mock_settings()):
-            with patch(
-                "app.services.retrieval_client.asyncio.gather",
-                new=AsyncMock(return_value=([3], 0.3)),
-            ):
-                from app.services.retrieval_client import _get_taxonomy_filter
-                result = await _get_taxonomy_filter("test query", "my-kb", "org1")
+            with patch("app.services.retrieval_client._classify_query", new=AsyncMock(return_value=[3])):
+                with patch("app.services.retrieval_client._get_coverage_ratio", new=AsyncMock(return_value=0.3)):
+                    from app.services.retrieval_client import _get_taxonomy_filter
+                    result = await _get_taxonomy_filter("test query", "my-kb", "org1")
 
         assert result == [3]

--- a/klai-focus/research-api/tests/test_taxonomy_filter.py
+++ b/klai-focus/research-api/tests/test_taxonomy_filter.py
@@ -19,6 +19,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+_MOD = "app.services.retrieval_client"
+
 
 def _mock_settings(
     knowledge_ingest_url: str = "http://knowledge-ingest:8000",
@@ -34,9 +36,9 @@ class TestGetTaxonomyFilter:
     @pytest.mark.asyncio
     async def test_returns_node_ids_when_coverage_sufficient(self):
         """Returns [5, 7] when classify returns those IDs and coverage = 60% (>= 30%)."""
-        with patch("app.services.retrieval_client.settings", _mock_settings()):
-            with patch("app.services.retrieval_client._classify_query", new=AsyncMock(return_value=[5, 7])):
-                with patch("app.services.retrieval_client._get_coverage_ratio", new=AsyncMock(return_value=0.6)):
+        with patch(f"{_MOD}.settings", _mock_settings()):
+            with patch(f"{_MOD}._classify_query", new=AsyncMock(return_value=[5, 7])):
+                with patch(f"{_MOD}._get_coverage_ratio", new=AsyncMock(return_value=0.6)):
                     from app.services.retrieval_client import _get_taxonomy_filter
                     result = await _get_taxonomy_filter("test query", "my-kb", "org1")
 
@@ -45,9 +47,9 @@ class TestGetTaxonomyFilter:
     @pytest.mark.asyncio
     async def test_returns_none_when_coverage_too_low(self):
         """Returns None when coverage = 10% (< 30% threshold)."""
-        with patch("app.services.retrieval_client.settings", _mock_settings()):
-            with patch("app.services.retrieval_client._classify_query", new=AsyncMock(return_value=[5])):
-                with patch("app.services.retrieval_client._get_coverage_ratio", new=AsyncMock(return_value=0.1)):
+        with patch(f"{_MOD}.settings", _mock_settings()):
+            with patch(f"{_MOD}._classify_query", new=AsyncMock(return_value=[5])):
+                with patch(f"{_MOD}._get_coverage_ratio", new=AsyncMock(return_value=0.1)):
                     from app.services.retrieval_client import _get_taxonomy_filter
                     result = await _get_taxonomy_filter("test query", "my-kb", "org1")
 
@@ -56,9 +58,9 @@ class TestGetTaxonomyFilter:
     @pytest.mark.asyncio
     async def test_returns_none_on_timeout(self):
         """Returns None when calls time out — retrieval continues without filter."""
-        with patch("app.services.retrieval_client.settings", _mock_settings()):
-            with patch("app.services.retrieval_client._classify_query", side_effect=asyncio.TimeoutError):
-                with patch("app.services.retrieval_client._get_coverage_ratio", new=AsyncMock(return_value=0.6)):
+        with patch(f"{_MOD}.settings", _mock_settings()):
+            with patch(f"{_MOD}._classify_query", side_effect=asyncio.TimeoutError):
+                with patch(f"{_MOD}._get_coverage_ratio", new=AsyncMock(return_value=0.6)):
                     from app.services.retrieval_client import _get_taxonomy_filter
                     result = await _get_taxonomy_filter("test query", "my-kb", "org1")
 
@@ -67,9 +69,12 @@ class TestGetTaxonomyFilter:
     @pytest.mark.asyncio
     async def test_returns_none_on_exception(self):
         """Returns None when classify/coverage raise any exception."""
-        with patch("app.services.retrieval_client.settings", _mock_settings()):
-            with patch("app.services.retrieval_client._classify_query", side_effect=Exception("connection refused")):
-                with patch("app.services.retrieval_client._get_coverage_ratio", new=AsyncMock(return_value=0.6)):
+        with patch(f"{_MOD}.settings", _mock_settings()):
+            with patch(
+                f"{_MOD}._classify_query",
+                side_effect=Exception("connection refused"),
+            ):
+                with patch(f"{_MOD}._get_coverage_ratio", new=AsyncMock(return_value=0.6)):
                     from app.services.retrieval_client import _get_taxonomy_filter
                     result = await _get_taxonomy_filter("test query", "my-kb", "org1")
 
@@ -78,7 +83,7 @@ class TestGetTaxonomyFilter:
     @pytest.mark.asyncio
     async def test_returns_none_when_knowledge_ingest_url_empty(self):
         """Returns None immediately when knowledge_ingest_url is not configured."""
-        with patch("app.services.retrieval_client.settings", _mock_settings(knowledge_ingest_url="")):
+        with patch(f"{_MOD}.settings", _mock_settings(knowledge_ingest_url="")):
             from app.services.retrieval_client import _get_taxonomy_filter
             result = await _get_taxonomy_filter("test query", "my-kb", "org1")
 
@@ -87,9 +92,9 @@ class TestGetTaxonomyFilter:
     @pytest.mark.asyncio
     async def test_returns_none_when_classify_returns_empty(self):
         """Returns None when classify returns empty list despite sufficient coverage."""
-        with patch("app.services.retrieval_client.settings", _mock_settings()):
-            with patch("app.services.retrieval_client._classify_query", new=AsyncMock(return_value=[])):
-                with patch("app.services.retrieval_client._get_coverage_ratio", new=AsyncMock(return_value=0.7)):
+        with patch(f"{_MOD}.settings", _mock_settings()):
+            with patch(f"{_MOD}._classify_query", new=AsyncMock(return_value=[])):
+                with patch(f"{_MOD}._get_coverage_ratio", new=AsyncMock(return_value=0.7)):
                     from app.services.retrieval_client import _get_taxonomy_filter
                     result = await _get_taxonomy_filter("test query", "my-kb", "org1")
 
@@ -98,9 +103,9 @@ class TestGetTaxonomyFilter:
     @pytest.mark.asyncio
     async def test_exact_coverage_threshold_passes(self):
         """Returns node IDs when coverage exactly equals the minimum threshold (30%)."""
-        with patch("app.services.retrieval_client.settings", _mock_settings()):
-            with patch("app.services.retrieval_client._classify_query", new=AsyncMock(return_value=[3])):
-                with patch("app.services.retrieval_client._get_coverage_ratio", new=AsyncMock(return_value=0.3)):
+        with patch(f"{_MOD}.settings", _mock_settings()):
+            with patch(f"{_MOD}._classify_query", new=AsyncMock(return_value=[3])):
+                with patch(f"{_MOD}._get_coverage_ratio", new=AsyncMock(return_value=0.3)):
                     from app.services.retrieval_client import _get_taxonomy_filter
                     result = await _get_taxonomy_filter("test query", "my-kb", "org1")
 

--- a/klai-knowledge-ingest/knowledge_ingest/proposal_generator.py
+++ b/klai-knowledge-ingest/knowledge_ingest/proposal_generator.py
@@ -43,8 +43,10 @@ async def maybe_generate_proposal(
     kb_slug: str,
     unmatched_documents: list[DocumentSummary],
     existing_nodes: list[TaxonomyNode],
-) -> None:
+) -> bool:
     """Generate and submit a taxonomy proposal if conditions are met.
+
+    Returns True when a proposal was submitted, False in all other cases.
 
     Conditions:
     - At least 3 unmatched documents in the batch
@@ -52,7 +54,7 @@ async def maybe_generate_proposal(
     - Suggested name doesn't already exist among KB's taxonomy nodes
     """
     if len(unmatched_documents) < _MIN_UNMATCHED_FOR_PROPOSAL:
-        return
+        return False
 
     if not settings.portal_internal_token:
         logger.warning(
@@ -60,7 +62,7 @@ async def maybe_generate_proposal(
             reason="missing PORTAL_INTERNAL_TOKEN",
             kb_slug=kb_slug,
         )
-        return
+        return False
 
     # Generate suggested category name
     try:
@@ -68,16 +70,16 @@ async def maybe_generate_proposal(
             _suggest_category_name(unmatched_documents),
             timeout=settings.taxonomy_classification_timeout,
         )
-    except (TimeoutError, Exception) as exc:
+    except Exception as exc:
         logger.warning(
             "taxonomy_proposal_generation_failed",
             kb_slug=kb_slug,
             error=str(exc),
         )
-        return
+        return False
 
     if not suggested_name:
-        return
+        return False
 
     # Check that suggested name doesn't already exist
     existing_names = {node.name.lower() for node in existing_nodes}
@@ -88,7 +90,7 @@ async def maybe_generate_proposal(
             suggested_name=suggested_name,
             kb_slug=kb_slug,
         )
-        return
+        return False
 
     # Generate description (same pattern as generate_bootstrap_proposals)
     sample_titles = [doc.title for doc in unmatched_documents[:5]]
@@ -117,6 +119,7 @@ async def maybe_generate_proposal(
         suggested_name=suggested_name,
         unmatched_count=len(unmatched_documents),
     )
+    return True
 
 
 _BOOTSTRAP_SYSTEM_PROMPT = (
@@ -156,7 +159,7 @@ async def generate_bootstrap_proposals(
             _suggest_multiple_categories(documents[:50]),
             timeout=30.0,
         )
-    except (TimeoutError, Exception) as exc:
+    except Exception as exc:
         logger.warning(
             "bootstrap_proposals_generation_failed",
             kb_slug=kb_slug,

--- a/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
@@ -41,11 +41,9 @@ from knowledge_ingest.models import (
     UpdateKBVisibilityRequest,
 )
 from knowledge_ingest.portal_client import fetch_taxonomy_nodes
-from knowledge_ingest.proposal_generator import DocumentSummary, maybe_generate_proposal
 from knowledge_ingest.taxonomy_classifier import classify_document
 
 _SENTINEL = 253402300800  # 9999-12-31
-_background_tasks: set = set()  # Prevents fire-and-forget tasks from being GC'd
 
 logger = structlog.get_logger()
 router = APIRouter()
@@ -388,27 +386,6 @@ async def ingest_document(req: IngestRequest) -> dict:
         tags=merged_tags if merged_tags else None,
         has_taxonomy=has_taxonomy,
     )
-
-    # Taxonomy proposal generation (SPEC-KB-022 R4) — fire-and-forget, non-blocking.
-    # Self-bootstrapping: fires when taxonomy_node_ids is empty regardless of whether the KB
-    # already has nodes. This covers both:
-    #   - KB with 0 nodes: all documents are unmatched -> proposals generated from scratch
-    #   - KB with nodes: only truly unmatched documents (confidence < 0.5) trigger proposals
-    # The >= 3 threshold in maybe_generate_proposal prevents noise from single documents.
-    if has_taxonomy and not taxonomy_node_ids:
-        import asyncio as _asyncio
-        _t = _asyncio.create_task(
-            maybe_generate_proposal(
-                org_id=req.org_id,
-                kb_slug=req.kb_slug,
-                unmatched_documents=[
-                    DocumentSummary(title=title, content_preview=req.content[:500])
-                ],
-                existing_nodes=taxonomy_nodes,
-            )
-        )
-        _background_tasks.add(_t)
-        _t.add_done_callback(_background_tasks.discard)
 
     # Enqueue enrichment as async Procrastinate task (non-blocking)
     if await org_config.is_enrichment_enabled(req.org_id, pool):

--- a/klai-knowledge-ingest/knowledge_ingest/taxonomy_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/taxonomy_tasks.py
@@ -278,13 +278,13 @@ async def _run_backfill(org_id: str, kb_slug: str, batch_size: int) -> dict:
 
     # Phase 2 post-processing: generate taxonomy proposal if enough unmatched docs accumulated.
     if unmatched_summaries:
-        await maybe_generate_proposal(
+        submitted = await maybe_generate_proposal(
             org_id=org_id,
             kb_slug=kb_slug,
             unmatched_documents=unmatched_summaries,
             existing_nodes=taxonomy_nodes,
         )
-        proposals_submitted = 1
+        proposals_submitted = 1 if submitted else 0
 
     # Phase 3: Generate tags for chunks with taxonomy_node_ids but no tags
     offset = None

--- a/klai-knowledge-ingest/knowledge_ingest/taxonomy_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/taxonomy_tasks.py
@@ -17,6 +17,8 @@ from typing import Any
 
 import structlog
 
+from knowledge_ingest.proposal_generator import DocumentSummary, maybe_generate_proposal
+
 logger = structlog.get_logger()
 
 
@@ -78,6 +80,7 @@ async def _run_backfill(org_id: str, kb_slug: str, batch_size: int) -> dict:
     classified = 0
     tagged = 0
     skipped = 0
+    proposals_submitted = 0
 
     # Phase 0: Blind content_label generation (SPEC-KB-023)
     # Runs before taxonomy phases so labels are taxonomy-independent.
@@ -155,6 +158,7 @@ async def _run_backfill(org_id: str, kb_slug: str, batch_size: int) -> dict:
             "classified": 0,
             "tagged": 0,
             "skipped": 0,
+            "proposals_submitted": 0,
         }
 
     # Phase 1: Migrate old taxonomy_node_id -> taxonomy_node_ids
@@ -202,6 +206,8 @@ async def _run_backfill(org_id: str, kb_slug: str, batch_size: int) -> dict:
         offset = next_offset
 
     # Phase 2: Re-classify unclassified chunks
+    # Collect unmatched documents for batch proposal generation at the end.
+    unmatched_summaries: list[DocumentSummary] = []
     offset = None
     while True:
         phase2_filter = Filter(
@@ -248,6 +254,11 @@ async def _run_backfill(org_id: str, kb_slug: str, batch_size: int) -> dict:
             )
             node_ids = [nid for nid, _conf in matched_nodes]
 
+            if not node_ids:
+                unmatched_summaries.append(
+                    DocumentSummary(title=title, content_preview=content_preview)
+                )
+
             point_ids = [p.id for p in doc_points]
             update_payload: dict = {"taxonomy_node_ids": node_ids}
             if suggested_tags:
@@ -264,6 +275,16 @@ async def _run_backfill(org_id: str, kb_slug: str, batch_size: int) -> dict:
         if next_offset is None:
             break
         offset = next_offset
+
+    # Phase 2 post-processing: generate taxonomy proposal if enough unmatched docs accumulated.
+    if unmatched_summaries:
+        await maybe_generate_proposal(
+            org_id=org_id,
+            kb_slug=kb_slug,
+            unmatched_documents=unmatched_summaries,
+            existing_nodes=taxonomy_nodes,
+        )
+        proposals_submitted = 1
 
     # Phase 3: Generate tags for chunks with taxonomy_node_ids but no tags
     offset = None
@@ -342,4 +363,5 @@ async def _run_backfill(org_id: str, kb_slug: str, batch_size: int) -> dict:
         "classified": classified,
         "tagged": tagged,
         "skipped": skipped,
+        "proposals_submitted": proposals_submitted,
     }

--- a/klai-knowledge-ingest/tests/test_taxonomy_backfill_proposals.py
+++ b/klai-knowledge-ingest/tests/test_taxonomy_backfill_proposals.py
@@ -1,0 +1,164 @@
+"""Tests for _run_backfill batch proposal generation (SPEC-KB-027 R2).
+
+All Qdrant / portal / LLM calls are mocked. The tests verify:
+- maybe_generate_proposal is called with all unmatched docs after Phase 2
+- maybe_generate_proposal is NOT called when all docs are matched
+- proposals_submitted == 0 when no taxonomy nodes exist
+
+Note: _run_backfill imports all dependencies inside the function body, so we patch
+at their source modules (knowledge_ingest.config, knowledge_ingest.portal_client, etc.)
+and use qdrant_client.AsyncQdrantClient for the Qdrant client constructor.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _make_qdrant_point(doc_key: str, title: str, text: str = "content") -> MagicMock:
+    point = MagicMock()
+    point.id = doc_key
+    point.payload = {
+        "artifact_id": doc_key,
+        "title": title,
+        "text": text,
+    }
+    return point
+
+
+def _make_taxonomy_node(node_id: int, name: str) -> MagicMock:
+    node = MagicMock()
+    node.id = node_id
+    node.name = name
+    return node
+
+
+def _make_scroll_client(phase2_points: list) -> AsyncMock:
+    """Return an AsyncQdrantClient mock whose scroll() returns empty for phases 0/1/3
+    and `phase2_points` for phase 2's first page."""
+    call_count = 0
+
+    async def scroll_side_effect(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        # Phase 0 → call 1, Phase 1 → call 2, Phase 2 → call 3, Phase 3 → call 4+
+        if call_count == 3:
+            return (phase2_points, None)
+        return ([], None)
+
+    client = AsyncMock()
+    client.scroll = scroll_side_effect
+    client.set_payload = AsyncMock()
+    return client
+
+
+def _common_patches(client, taxonomy_nodes, classify_return):
+    """Return a list of context managers for the common patches shared across tests."""
+    mock_settings = MagicMock()
+    mock_settings.qdrant_url = "http://qdrant:6333"
+    mock_settings.qdrant_api_key = ""
+
+    return [
+        patch("qdrant_client.AsyncQdrantClient", return_value=client),
+        patch("knowledge_ingest.config.settings", mock_settings),
+        patch(
+            "knowledge_ingest.portal_client.fetch_taxonomy_nodes",
+            new=AsyncMock(return_value=taxonomy_nodes),
+        ),
+        patch("knowledge_ingest.portal_client.invalidate_cache"),
+        patch(
+            "knowledge_ingest.taxonomy_classifier.classify_document",
+            new=AsyncMock(return_value=classify_return),
+        ),
+        patch(
+            "knowledge_ingest.content_labeler.generate_content_label",
+            new=AsyncMock(return_value="label"),
+        ),
+    ]
+
+
+class TestRunBackfillProposals:
+    @pytest.mark.asyncio
+    async def test_maybe_generate_proposal_called_with_unmatched_docs(self):
+        """When Phase 2 finds 5 unmatched docs, maybe_generate_proposal is called with all 5."""
+        taxonomy_nodes = [_make_taxonomy_node(1, "Node A")]
+        phase2_points = [_make_qdrant_point(f"doc{i}", f"Doc {i}") for i in range(5)]
+        client = _make_scroll_client(phase2_points)
+
+        mock_proposal = AsyncMock()
+
+        patches = _common_patches(client, taxonomy_nodes, classify_return=([], []))
+        patches.append(
+            patch(
+                "knowledge_ingest.proposal_generator.maybe_generate_proposal",
+                new=mock_proposal,
+            )
+        )
+
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
+            from knowledge_ingest.taxonomy_tasks import _run_backfill
+            result = await _run_backfill(org_id="org1", kb_slug="kb1", batch_size=100)
+
+        mock_proposal.assert_called_once()
+        call_kwargs = mock_proposal.call_args.kwargs
+        assert call_kwargs["org_id"] == "org1"
+        assert call_kwargs["kb_slug"] == "kb1"
+        assert len(call_kwargs["unmatched_documents"]) == 5
+        assert call_kwargs["existing_nodes"] == taxonomy_nodes
+        assert result["proposals_submitted"] == 1
+
+    @pytest.mark.asyncio
+    async def test_maybe_generate_proposal_not_called_when_all_matched(self):
+        """When all docs in Phase 2 are matched, maybe_generate_proposal is NOT called."""
+        taxonomy_nodes = [_make_taxonomy_node(1, "Node A")]
+        phase2_points = [_make_qdrant_point(f"doc{i}", f"Doc {i}") for i in range(3)]
+        client = _make_scroll_client(phase2_points)
+
+        mock_proposal = AsyncMock()
+
+        patches = _common_patches(
+            client, taxonomy_nodes, classify_return=([(1, 0.9)], ["tag1"])
+        )
+        patches.append(
+            patch(
+                "knowledge_ingest.proposal_generator.maybe_generate_proposal",
+                new=mock_proposal,
+            )
+        )
+
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
+            from knowledge_ingest.taxonomy_tasks import _run_backfill
+            result = await _run_backfill(org_id="org1", kb_slug="kb1", batch_size=100)
+
+        mock_proposal.assert_not_called()
+        assert result["proposals_submitted"] == 0
+
+    @pytest.mark.asyncio
+    async def test_proposals_submitted_zero_when_no_taxonomy_nodes(self):
+        """When no taxonomy nodes exist, proposals_submitted is 0 and Phase 2 never runs."""
+        client = AsyncMock()
+        client.scroll = AsyncMock(return_value=([], None))
+        client.set_payload = AsyncMock()
+
+        mock_settings = MagicMock()
+        mock_settings.qdrant_url = "http://qdrant:6333"
+        mock_settings.qdrant_api_key = ""
+
+        with (
+            patch("qdrant_client.AsyncQdrantClient", return_value=client),
+            patch("knowledge_ingest.config.settings", mock_settings),
+            patch(
+                "knowledge_ingest.portal_client.fetch_taxonomy_nodes",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch("knowledge_ingest.portal_client.invalidate_cache"),
+            patch(
+                "knowledge_ingest.content_labeler.generate_content_label",
+                new=AsyncMock(return_value="label"),
+            ),
+        ):
+            from knowledge_ingest.taxonomy_tasks import _run_backfill
+            result = await _run_backfill(org_id="org1", kb_slug="kb1", batch_size=100)
+
+        assert result["proposals_submitted"] == 0

--- a/klai-knowledge-ingest/tests/test_taxonomy_backfill_proposals.py
+++ b/klai-knowledge-ingest/tests/test_taxonomy_backfill_proposals.py
@@ -86,7 +86,7 @@ class TestRunBackfillProposals:
         phase2_points = [_make_qdrant_point(f"doc{i}", f"Doc {i}") for i in range(5)]
         client = _make_scroll_client(phase2_points)
 
-        mock_proposal = AsyncMock()
+        mock_proposal = AsyncMock(return_value=True)
 
         patches = _common_patches(client, taxonomy_nodes, classify_return=([], []))
         patches.append(

--- a/klai-knowledge-ingest/uv.lock
+++ b/klai-knowledge-ingest/uv.lock
@@ -563,6 +563,15 @@ wheels = [
 ]
 
 [[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071 },
+]
+
+[[package]]
 name = "knowledge-ingest"
 version = "1.0.0"
 source = { virtual = "." }
@@ -577,6 +586,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pyyaml" },
     { name = "qdrant-client" },
+    { name = "scikit-learn" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "structlog" },
     { name = "uvicorn", extra = ["standard"] },
@@ -612,6 +622,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "qdrant-client", specifier = ">=1.12" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8" },
+    { name = "scikit-learn", specifier = ">=1.3.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
     { name = "structlog", specifier = ">=25.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32" },
@@ -1124,6 +1135,111 @@ wheels = [
 ]
 
 [[package]]
+name = "scikit-learn"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/74/e6a7cc4b820e95cc38cf36cd74d5aa2b42e8ffc2d21fe5a9a9c45c1c7630/scikit_learn-1.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5fb63362b5a7ddab88e52b6dbb47dac3fd7dafeee740dc6c8d8a446ddedade8e", size = 8548242 },
+    { url = "https://files.pythonhosted.org/packages/49/d8/9be608c6024d021041c7f0b3928d4749a706f4e2c3832bbede4fb4f58c95/scikit_learn-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5025ce924beccb28298246e589c691fe1b8c1c96507e6d27d12c5fadd85bfd76", size = 8079075 },
+    { url = "https://files.pythonhosted.org/packages/dd/47/f187b4636ff80cc63f21cd40b7b2d177134acaa10f6bb73746130ee8c2e5/scikit_learn-1.8.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4496bb2cf7a43ce1a2d7524a79e40bc5da45cf598dbf9545b7e8316ccba47bb4", size = 8660492 },
+    { url = "https://files.pythonhosted.org/packages/97/74/b7a304feb2b49df9fafa9382d4d09061a96ee9a9449a7cbea7988dda0828/scikit_learn-1.8.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a0bcfe4d0d14aec44921545fd2af2338c7471de9cb701f1da4c9d85906ab847a", size = 8931904 },
+    { url = "https://files.pythonhosted.org/packages/9f/c4/0ab22726a04ede56f689476b760f98f8f46607caecff993017ac1b64aa5d/scikit_learn-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:35c007dedb2ffe38fe3ee7d201ebac4a2deccd2408e8621d53067733e3c74809", size = 8019359 },
+    { url = "https://files.pythonhosted.org/packages/24/90/344a67811cfd561d7335c1b96ca21455e7e472d281c3c279c4d3f2300236/scikit_learn-1.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:8c497fff237d7b4e07e9ef1a640887fa4fb765647f86fbe00f969ff6280ce2bb", size = 7641898 },
+    { url = "https://files.pythonhosted.org/packages/03/aa/e22e0768512ce9255eba34775be2e85c2048da73da1193e841707f8f039c/scikit_learn-1.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0d6ae97234d5d7079dc0040990a6f7aeb97cb7fa7e8945f1999a429b23569e0a", size = 8513770 },
+    { url = "https://files.pythonhosted.org/packages/58/37/31b83b2594105f61a381fc74ca19e8780ee923be2d496fcd8d2e1147bd99/scikit_learn-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:edec98c5e7c128328124a029bceb09eda2d526997780fef8d65e9a69eead963e", size = 8044458 },
+    { url = "https://files.pythonhosted.org/packages/2d/5a/3f1caed8765f33eabb723596666da4ebbf43d11e96550fb18bdec42b467b/scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74b66d8689d52ed04c271e1329f0c61635bcaf5b926db9b12d58914cdc01fe57", size = 8610341 },
+    { url = "https://files.pythonhosted.org/packages/38/cf/06896db3f71c75902a8e9943b444a56e727418f6b4b4a90c98c934f51ed4/scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8fdf95767f989b0cfedb85f7ed8ca215d4be728031f56ff5a519ee1e3276dc2e", size = 8900022 },
+    { url = "https://files.pythonhosted.org/packages/1c/f9/9b7563caf3ec8873e17a31401858efab6b39a882daf6c1bfa88879c0aa11/scikit_learn-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:2de443b9373b3b615aec1bb57f9baa6bb3a9bd093f1269ba95c17d870422b271", size = 7989409 },
+    { url = "https://files.pythonhosted.org/packages/49/bd/1f4001503650e72c4f6009ac0c4413cb17d2d601cef6f71c0453da2732fc/scikit_learn-1.8.0-cp313-cp313-win_arm64.whl", hash = "sha256:eddde82a035681427cbedded4e6eff5e57fa59216c2e3e90b10b19ab1d0a65c3", size = 7619760 },
+    { url = "https://files.pythonhosted.org/packages/d2/7d/a630359fc9dcc95496588c8d8e3245cc8fd81980251079bc09c70d41d951/scikit_learn-1.8.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:7cc267b6108f0a1499a734167282c00c4ebf61328566b55ef262d48e9849c735", size = 8826045 },
+    { url = "https://files.pythonhosted.org/packages/cc/56/a0c86f6930cfcd1c7054a2bc417e26960bb88d32444fe7f71d5c2cfae891/scikit_learn-1.8.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:fe1c011a640a9f0791146011dfd3c7d9669785f9fed2b2a5f9e207536cf5c2fd", size = 8420324 },
+    { url = "https://files.pythonhosted.org/packages/46/1e/05962ea1cebc1cf3876667ecb14c283ef755bf409993c5946ade3b77e303/scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72358cce49465d140cc4e7792015bb1f0296a9742d5622c67e31399b75468b9e", size = 8680651 },
+    { url = "https://files.pythonhosted.org/packages/fe/56/a85473cd75f200c9759e3a5f0bcab2d116c92a8a02ee08ccd73b870f8bb4/scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:80832434a6cc114f5219211eec13dcbc16c2bac0e31ef64c6d346cde3cf054cb", size = 8925045 },
+    { url = "https://files.pythonhosted.org/packages/cc/b7/64d8cfa896c64435ae57f4917a548d7ac7a44762ff9802f75a79b77cb633/scikit_learn-1.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ee787491dbfe082d9c3013f01f5991658b0f38aa8177e4cd4bf434c58f551702", size = 8507994 },
+    { url = "https://files.pythonhosted.org/packages/5e/37/e192ea709551799379958b4c4771ec507347027bb7c942662c7fbeba31cb/scikit_learn-1.8.0-cp313-cp313t-win_arm64.whl", hash = "sha256:bf97c10a3f5a7543f9b88cbf488d33d175e9146115a451ae34568597ba33dcde", size = 7869518 },
+    { url = "https://files.pythonhosted.org/packages/24/05/1af2c186174cc92dcab2233f327336058c077d38f6fe2aceb08e6ab4d509/scikit_learn-1.8.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c22a2da7a198c28dd1a6e1136f19c830beab7fdca5b3e5c8bba8394f8a5c45b3", size = 8528667 },
+    { url = "https://files.pythonhosted.org/packages/a8/25/01c0af38fe969473fb292bba9dc2b8f9b451f3112ff242c647fee3d0dfe7/scikit_learn-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:6b595b07a03069a2b1740dc08c2299993850ea81cce4fe19b2421e0c970de6b7", size = 8066524 },
+    { url = "https://files.pythonhosted.org/packages/be/ce/a0623350aa0b68647333940ee46fe45086c6060ec604874e38e9ab7d8e6c/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:29ffc74089f3d5e87dfca4c2c8450f88bdc61b0fc6ed5d267f3988f19a1309f6", size = 8657133 },
+    { url = "https://files.pythonhosted.org/packages/b8/cb/861b41341d6f1245e6ca80b1c1a8c4dfce43255b03df034429089ca2a2c5/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fb65db5d7531bccf3a4f6bec3462223bea71384e2cda41da0f10b7c292b9e7c4", size = 8923223 },
+    { url = "https://files.pythonhosted.org/packages/76/18/a8def8f91b18cd1ba6e05dbe02540168cb24d47e8dcf69e8d00b7da42a08/scikit_learn-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:56079a99c20d230e873ea40753102102734c5953366972a71d5cb39a32bc40c6", size = 8096518 },
+    { url = "https://files.pythonhosted.org/packages/d1/77/482076a678458307f0deb44e29891d6022617b2a64c840c725495bee343f/scikit_learn-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:3bad7565bc9cf37ce19a7c0d107742b320c1285df7aab1a6e2d28780df167242", size = 7754546 },
+    { url = "https://files.pythonhosted.org/packages/2d/d1/ef294ca754826daa043b2a104e59960abfab4cf653891037d19dd5b6f3cf/scikit_learn-1.8.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4511be56637e46c25721e83d1a9cea9614e7badc7040c4d573d75fbe257d6fd7", size = 8848305 },
+    { url = "https://files.pythonhosted.org/packages/5b/e2/b1f8b05138ee813b8e1a4149f2f0d289547e60851fd1bb268886915adbda/scikit_learn-1.8.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:a69525355a641bf8ef136a7fa447672fb54fe8d60cab5538d9eb7c6438543fb9", size = 8432257 },
+    { url = "https://files.pythonhosted.org/packages/26/11/c32b2138a85dcb0c99f6afd13a70a951bfdff8a6ab42d8160522542fb647/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2656924ec73e5939c76ac4c8b026fc203b83d8900362eb2599d8aee80e4880f", size = 8678673 },
+    { url = "https://files.pythonhosted.org/packages/c7/57/51f2384575bdec454f4fe4e7a919d696c9ebce914590abf3e52d47607ab8/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15fc3b5d19cc2be65404786857f2e13c70c83dd4782676dd6814e3b89dc8f5b9", size = 8922467 },
+    { url = "https://files.pythonhosted.org/packages/35/4d/748c9e2872637a57981a04adc038dacaa16ba8ca887b23e34953f0b3f742/scikit_learn-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:00d6f1d66fbcf4eba6e356e1420d33cc06c70a45bb1363cd6f6a8e4ebbbdece2", size = 8774395 },
+    { url = "https://files.pythonhosted.org/packages/60/22/d7b2ebe4704a5e50790ba089d5c2ae308ab6bb852719e6c3bd4f04c3a363/scikit_learn-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:f28dd15c6bb0b66ba09728cf09fd8736c304be29409bd8445a080c1280619e8c", size = 8002647 },
+]
+
+[[package]]
+name = "scipy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/48/b992b488d6f299dbe3f11a20b24d3dda3d46f1a635ede1c46b5b17a7b163/scipy-1.17.1-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:35c3a56d2ef83efc372eaec584314bd0ef2e2f0d2adb21c55e6ad5b344c0dcb8", size = 31610954 },
+    { url = "https://files.pythonhosted.org/packages/b2/02/cf107b01494c19dc100f1d0b7ac3cc08666e96ba2d64db7626066cee895e/scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:fcb310ddb270a06114bb64bbe53c94926b943f5b7f0842194d585c65eb4edd76", size = 28172662 },
+    { url = "https://files.pythonhosted.org/packages/cf/a9/599c28631bad314d219cf9ffd40e985b24d603fc8a2f4ccc5ae8419a535b/scipy-1.17.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cc90d2e9c7e5c7f1a482c9875007c095c3194b1cfedca3c2f3291cdc2bc7c086", size = 20344366 },
+    { url = "https://files.pythonhosted.org/packages/35/f5/906eda513271c8deb5af284e5ef0206d17a96239af79f9fa0aebfe0e36b4/scipy-1.17.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:c80be5ede8f3f8eded4eff73cc99a25c388ce98e555b17d31da05287015ffa5b", size = 22704017 },
+    { url = "https://files.pythonhosted.org/packages/da/34/16f10e3042d2f1d6b66e0428308ab52224b6a23049cb2f5c1756f713815f/scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e19ebea31758fac5893a2ac360fedd00116cbb7628e650842a6691ba7ca28a21", size = 32927842 },
+    { url = "https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02ae3b274fde71c5e92ac4d54bc06c42d80e399fec704383dcd99b301df37458", size = 35235890 },
+    { url = "https://files.pythonhosted.org/packages/c5/5c/9d7f4c88bea6e0d5a4f1bc0506a53a00e9fcb198de372bfe4d3652cef482/scipy-1.17.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8a604bae87c6195d8b1045eddece0514d041604b14f2727bbc2b3020172045eb", size = 35003557 },
+    { url = "https://files.pythonhosted.org/packages/65/94/7698add8f276dbab7a9de9fb6b0e02fc13ee61d51c7c3f85ac28b65e1239/scipy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f590cd684941912d10becc07325a3eeb77886fe981415660d9265c4c418d0bea", size = 37625856 },
+    { url = "https://files.pythonhosted.org/packages/a2/84/dc08d77fbf3d87d3ee27f6a0c6dcce1de5829a64f2eae85a0ecc1f0daa73/scipy-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:41b71f4a3a4cab9d366cd9065b288efc4d4f3c0b37a91a8e0947fb5bd7f31d87", size = 36549682 },
+    { url = "https://files.pythonhosted.org/packages/bc/98/fe9ae9ffb3b54b62559f52dedaebe204b408db8109a8c66fdd04869e6424/scipy-1.17.1-cp312-cp312-win_arm64.whl", hash = "sha256:f4115102802df98b2b0db3cce5cb9b92572633a1197c77b7553e5203f284a5b3", size = 24547340 },
+    { url = "https://files.pythonhosted.org/packages/76/27/07ee1b57b65e92645f219b37148a7e7928b82e2b5dbeccecb4dff7c64f0b/scipy-1.17.1-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:5e3c5c011904115f88a39308379c17f91546f77c1667cea98739fe0fccea804c", size = 31590199 },
+    { url = "https://files.pythonhosted.org/packages/ec/ae/db19f8ab842e9b724bf5dbb7db29302a91f1e55bc4d04b1025d6d605a2c5/scipy-1.17.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6fac755ca3d2c3edcb22f479fceaa241704111414831ddd3bc6056e18516892f", size = 28154001 },
+    { url = "https://files.pythonhosted.org/packages/5b/58/3ce96251560107b381cbd6e8413c483bbb1228a6b919fa8652b0d4090e7f/scipy-1.17.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:7ff200bf9d24f2e4d5dc6ee8c3ac64d739d3a89e2326ba68aaf6c4a2b838fd7d", size = 20325719 },
+    { url = "https://files.pythonhosted.org/packages/b2/83/15087d945e0e4d48ce2377498abf5ad171ae013232ae31d06f336e64c999/scipy-1.17.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4b400bdc6f79fa02a4d86640310dde87a21fba0c979efff5248908c6f15fad1b", size = 22683595 },
+    { url = "https://files.pythonhosted.org/packages/b4/e0/e58fbde4a1a594c8be8114eb4aac1a55bcd6587047efc18a61eb1f5c0d30/scipy-1.17.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b64ca7d4aee0102a97f3ba22124052b4bd2152522355073580bf4845e2550b6", size = 32896429 },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:581b2264fc0aa555f3f435a5944da7504ea3a065d7029ad60e7c3d1ae09c5464", size = 35203952 },
+    { url = "https://files.pythonhosted.org/packages/8d/a5/9afd17de24f657fdfe4df9a3f1ea049b39aef7c06000c13db1530d81ccca/scipy-1.17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:beeda3d4ae615106d7094f7e7cef6218392e4465cc95d25f900bebabfded0950", size = 34979063 },
+    { url = "https://files.pythonhosted.org/packages/8b/13/88b1d2384b424bf7c924f2038c1c409f8d88bb2a8d49d097861dd64a57b2/scipy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6609bc224e9568f65064cfa72edc0f24ee6655b47575954ec6339534b2798369", size = 37598449 },
+    { url = "https://files.pythonhosted.org/packages/35/e5/d6d0e51fc888f692a35134336866341c08655d92614f492c6860dc45bb2c/scipy-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:37425bc9175607b0268f493d79a292c39f9d001a357bebb6b88fdfaff13f6448", size = 36510943 },
+    { url = "https://files.pythonhosted.org/packages/2a/fd/3be73c564e2a01e690e19cc618811540ba5354c67c8680dce3281123fb79/scipy-1.17.1-cp313-cp313-win_arm64.whl", hash = "sha256:5cf36e801231b6a2059bf354720274b7558746f3b1a4efb43fcf557ccd484a87", size = 24545621 },
+    { url = "https://files.pythonhosted.org/packages/6f/6b/17787db8b8114933a66f9dcc479a8272e4b4da75fe03b0c282f7b0ade8cd/scipy-1.17.1-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:d59c30000a16d8edc7e64152e30220bfbd724c9bbb08368c054e24c651314f0a", size = 31936708 },
+    { url = "https://files.pythonhosted.org/packages/38/2e/524405c2b6392765ab1e2b722a41d5da33dc5c7b7278184a8ad29b6cb206/scipy-1.17.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:010f4333c96c9bb1a4516269e33cb5917b08ef2166d5556ca2fd9f082a9e6ea0", size = 28570135 },
+    { url = "https://files.pythonhosted.org/packages/fd/c3/5bd7199f4ea8556c0c8e39f04ccb014ac37d1468e6cfa6a95c6b3562b76e/scipy-1.17.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:2ceb2d3e01c5f1d83c4189737a42d9cb2fc38a6eeed225e7515eef71ad301dce", size = 20741977 },
+    { url = "https://files.pythonhosted.org/packages/d9/b8/8ccd9b766ad14c78386599708eb745f6b44f08400a5fd0ade7cf89b6fc93/scipy-1.17.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:844e165636711ef41f80b4103ed234181646b98a53c8f05da12ca5ca289134f6", size = 23029601 },
+    { url = "https://files.pythonhosted.org/packages/6d/a0/3cb6f4d2fb3e17428ad2880333cac878909ad1a89f678527b5328b93c1d4/scipy-1.17.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:158dd96d2207e21c966063e1635b1063cd7787b627b6f07305315dd73d9c679e", size = 33019667 },
+    { url = "https://files.pythonhosted.org/packages/f3/c3/2d834a5ac7bf3a0c806ad1508efc02dda3c8c61472a56132d7894c312dea/scipy-1.17.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74cbb80d93260fe2ffa334efa24cb8f2f0f622a9b9febf8b483c0b865bfb3475", size = 35264159 },
+    { url = "https://files.pythonhosted.org/packages/4d/77/d3ed4becfdbd217c52062fafe35a72388d1bd82c2d0ba5ca19d6fcc93e11/scipy-1.17.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:dbc12c9f3d185f5c737d801da555fb74b3dcfa1a50b66a1a93e09190f41fab50", size = 35102771 },
+    { url = "https://files.pythonhosted.org/packages/bd/12/d19da97efde68ca1ee5538bb261d5d2c062f0c055575128f11a2730e3ac1/scipy-1.17.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94055a11dfebe37c656e70317e1996dc197e1a15bbcc351bcdd4610e128fe1ca", size = 37665910 },
+    { url = "https://files.pythonhosted.org/packages/06/1c/1172a88d507a4baaf72c5a09bb6c018fe2ae0ab622e5830b703a46cc9e44/scipy-1.17.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e30bdeaa5deed6bc27b4cc490823cd0347d7dae09119b8803ae576ea0ce52e4c", size = 36562980 },
+    { url = "https://files.pythonhosted.org/packages/70/b0/eb757336e5a76dfa7911f63252e3b7d1de00935d7705cf772db5b45ec238/scipy-1.17.1-cp313-cp313t-win_arm64.whl", hash = "sha256:a720477885a9d2411f94a93d16f9d89bad0f28ca23c3f8daa521e2dcc3f44d49", size = 24856543 },
+    { url = "https://files.pythonhosted.org/packages/cf/83/333afb452af6f0fd70414dc04f898647ee1423979ce02efa75c3b0f2c28e/scipy-1.17.1-cp314-cp314-macosx_10_14_x86_64.whl", hash = "sha256:a48a72c77a310327f6a3a920092fa2b8fd03d7deaa60f093038f22d98e096717", size = 31584510 },
+    { url = "https://files.pythonhosted.org/packages/ed/a6/d05a85fd51daeb2e4ea71d102f15b34fedca8e931af02594193ae4fd25f7/scipy-1.17.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:45abad819184f07240d8a696117a7aacd39787af9e0b719d00285549ed19a1e9", size = 28170131 },
+    { url = "https://files.pythonhosted.org/packages/db/7b/8624a203326675d7746a254083a187398090a179335b2e4a20e2ddc46e83/scipy-1.17.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:3fd1fcdab3ea951b610dc4cef356d416d5802991e7e32b5254828d342f7b7e0b", size = 20342032 },
+    { url = "https://files.pythonhosted.org/packages/c9/35/2c342897c00775d688d8ff3987aced3426858fd89d5a0e26e020b660b301/scipy-1.17.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:7bdf2da170b67fdf10bca777614b1c7d96ae3ca5794fd9587dce41eb2966e866", size = 22678766 },
+    { url = "https://files.pythonhosted.org/packages/ef/f2/7cdb8eb308a1a6ae1e19f945913c82c23c0c442a462a46480ce487fdc0ac/scipy-1.17.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:adb2642e060a6549c343603a3851ba76ef0b74cc8c079a9a58121c7ec9fe2350", size = 32957007 },
+    { url = "https://files.pythonhosted.org/packages/0b/2e/7eea398450457ecb54e18e9d10110993fa65561c4f3add5e8eccd2b9cd41/scipy-1.17.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eee2cfda04c00a857206a4330f0c5e3e56535494e30ca445eb19ec624ae75118", size = 35221333 },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5b8509d03b77f093a0d52e606d3c4f79e8b06d1d38c441dacb1e26cacf46/scipy-1.17.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d2650c1fb97e184d12d8ba010493ee7b322864f7d3d00d3f9bb97d9c21de4068", size = 35042066 },
+    { url = "https://files.pythonhosted.org/packages/f9/df/18f80fb99df40b4070328d5ae5c596f2f00fffb50167e31439e932f29e7d/scipy-1.17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:08b900519463543aa604a06bec02461558a6e1cef8fdbb8098f77a48a83c8118", size = 37612763 },
+    { url = "https://files.pythonhosted.org/packages/4b/39/f0e8ea762a764a9dc52aa7dabcfad51a354819de1f0d4652b6a1122424d6/scipy-1.17.1-cp314-cp314-win_amd64.whl", hash = "sha256:3877ac408e14da24a6196de0ddcace62092bfc12a83823e92e49e40747e52c19", size = 37290984 },
+    { url = "https://files.pythonhosted.org/packages/7c/56/fe201e3b0f93d1a8bcf75d3379affd228a63d7e2d80ab45467a74b494947/scipy-1.17.1-cp314-cp314-win_arm64.whl", hash = "sha256:f8885db0bc2bffa59d5c1b72fad7a6a92d3e80e7257f967dd81abb553a90d293", size = 25192877 },
+    { url = "https://files.pythonhosted.org/packages/96/ad/f8c414e121f82e02d76f310f16db9899c4fcde36710329502a6b2a3c0392/scipy-1.17.1-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:1cc682cea2ae55524432f3cdff9e9a3be743d52a7443d0cba9017c23c87ae2f6", size = 31949750 },
+    { url = "https://files.pythonhosted.org/packages/7c/b0/c741e8865d61b67c81e255f4f0a832846c064e426636cd7de84e74d209be/scipy-1.17.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:2040ad4d1795a0ae89bfc7e8429677f365d45aa9fd5e4587cf1ea737f927b4a1", size = 28585858 },
+    { url = "https://files.pythonhosted.org/packages/ed/1b/3985219c6177866628fa7c2595bfd23f193ceebbe472c98a08824b9466ff/scipy-1.17.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:131f5aaea57602008f9822e2115029b55d4b5f7c070287699fe45c661d051e39", size = 20757723 },
+    { url = "https://files.pythonhosted.org/packages/c0/19/2a04aa25050d656d6f7b9e7b685cc83d6957fb101665bfd9369ca6534563/scipy-1.17.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:9cdc1a2fcfd5c52cfb3045feb399f7b3ce822abdde3a193a6b9a60b3cb5854ca", size = 23043098 },
+    { url = "https://files.pythonhosted.org/packages/86/f1/3383beb9b5d0dbddd030335bf8a8b32d4317185efe495374f134d8be6cce/scipy-1.17.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e3dcd57ab780c741fde8dc68619de988b966db759a3c3152e8e9142c26295ad", size = 33030397 },
+    { url = "https://files.pythonhosted.org/packages/41/68/8f21e8a65a5a03f25a79165ec9d2b28c00e66dc80546cf5eb803aeeff35b/scipy-1.17.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9956e4d4f4a301ebf6cde39850333a6b6110799d470dbbb1e25326ac447f52a", size = 35281163 },
+    { url = "https://files.pythonhosted.org/packages/84/8d/c8a5e19479554007a5632ed7529e665c315ae7492b4f946b0deb39870e39/scipy-1.17.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a4328d245944d09fd639771de275701ccadf5f781ba0ff092ad141e017eccda4", size = 35116291 },
+    { url = "https://files.pythonhosted.org/packages/52/52/e57eceff0e342a1f50e274264ed47497b59e6a4e3118808ee58ddda7b74a/scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2", size = 37682317 },
+    { url = "https://files.pythonhosted.org/packages/11/2f/b29eafe4a3fbc3d6de9662b36e028d5f039e72d345e05c250e121a230dd4/scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484", size = 37345327 },
+    { url = "https://files.pythonhosted.org/packages/07/39/338d9219c4e87f3e708f18857ecd24d22a0c3094752393319553096b98af/scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21", size = 25489165 },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1221,6 +1337,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926 },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638 },
 ]
 
 [[package]]

--- a/klai-portal/backend/alembic/versions/d3e4f5a6b7c8_drop_doc_count_from_taxonomy_nodes.py
+++ b/klai-portal/backend/alembic/versions/d3e4f5a6b7c8_drop_doc_count_from_taxonomy_nodes.py
@@ -1,0 +1,35 @@
+"""Drop doc_count column from portal_taxonomy_nodes (SPEC-KB-027 R3).
+
+doc_count was a denormalized counter that was only updated on node deletion
+and never on re-ingest, backfill, or connector cleanup. The coverage dashboard
+already fetches live chunk counts from Qdrant via the coverage-stats endpoint,
+making this column misleading and unnecessary.
+
+Revision ID: d3e4f5a6b7c8
+Revises: c3d4e5f6a7b9
+Create Date: 2026-04-07
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "d3e4f5a6b7c8"
+down_revision = "c3d4e5f6a7b9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_column("portal_taxonomy_nodes", "doc_count")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "portal_taxonomy_nodes",
+        sa.Column(
+            "doc_count",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )

--- a/klai-portal/backend/app/api/taxonomy.py
+++ b/klai-portal/backend/app/api/taxonomy.py
@@ -37,7 +37,6 @@ class TaxonomyNodeOut(BaseModel):
     name: str
     slug: str
     description: str | None = None
-    doc_count: int
     sort_order: int
     created_at: datetime
     created_by: str
@@ -105,7 +104,6 @@ def _node_out(node: PortalTaxonomyNode) -> TaxonomyNodeOut:
         name=node.name,
         slug=node.slug,
         description=node.description,
-        doc_count=node.doc_count,
         sort_order=node.sort_order,
         created_at=node.created_at,
         created_by=node.created_by,
@@ -342,17 +340,9 @@ async def delete_taxonomy_node(
         .values(parent_id=node.parent_id)
     )
 
-    # Update parent doc_count if parent exists
-    reassigned_docs = node.doc_count
-    if node.parent_id is not None and reassigned_docs > 0:
-        parent_result = await db.execute(select(PortalTaxonomyNode).where(PortalTaxonomyNode.id == node.parent_id))
-        parent = parent_result.scalar_one_or_none()
-        if parent:
-            parent.doc_count += reassigned_docs
-
     await db.delete(node)
     await db.commit()
-    return {"reassigned_docs": reassigned_docs}
+    return {}
 
 
 # -- Taxonomy proposals -------------------------------------------------------
@@ -551,7 +541,6 @@ async def _execute_merge(
     await db.execute(
         update(PortalTaxonomyNode).where(PortalTaxonomyNode.parent_id == source_id).values(parent_id=target_id)
     )
-    target_node.doc_count += source_node.doc_count
     await db.delete(source_node)
 
 

--- a/klai-portal/backend/app/models/taxonomy.py
+++ b/klai-portal/backend/app/models/taxonomy.py
@@ -42,7 +42,6 @@ class PortalTaxonomyNode(Base):
     )
     name: Mapped[str] = mapped_column(String(128), nullable=False)
     slug: Mapped[str] = mapped_column(String(128), nullable=False)
-    doc_count: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
     sort_order: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/klai-portal/frontend/src/components/layout/Sidebar.tsx
+++ b/klai-portal/frontend/src/components/layout/Sidebar.tsx
@@ -50,9 +50,12 @@ export function Sidebar({ navItems }: SidebarProps) {
       )}
     >
       {/* Logo + toggle */}
-      <div className="flex h-16 items-center border-b border-[var(--color-sidebar-border)] px-3">
+      <div className={cn(
+        'flex h-16 items-center border-b border-[var(--color-sidebar-border)]',
+        collapsed ? 'px-0' : 'pl-12 pr-12'
+      )}>
         {!collapsed && (
-          <div className="flex-1 px-3">
+          <div className="flex-1">
             <img src="/klai-logo-white.svg" alt="Klai" className="h-5 w-auto block" />
           </div>
         )}
@@ -73,7 +76,7 @@ export function Sidebar({ navItems }: SidebarProps) {
       </div>
 
       {/* Navigation */}
-      <nav className="flex-1 overflow-y-auto px-2 py-4">
+      <nav className="flex-1 overflow-y-auto py-4">
         <ul className="space-y-1">
           {navItems.map((item) => (
             <li key={item.href ?? item.to}>
@@ -83,9 +86,9 @@ export function Sidebar({ navItems }: SidebarProps) {
                   rel="noopener noreferrer"
                   title={collapsed ? item.label : undefined}
                   className={cn(
-                    'flex items-center rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+                    'flex items-center rounded-lg py-2 text-sm font-medium transition-colors',
                     'text-[var(--color-sidebar-muted-foreground)] hover:bg-[var(--color-sidebar-accent)] hover:text-[var(--color-sidebar-foreground)]',
-                    collapsed ? 'justify-center' : 'gap-3'
+                    collapsed ? 'justify-center px-0 w-full' : 'gap-3 px-6'
                   )}
                 >
                   <item.icon size={16} strokeWidth={1.75} />
@@ -97,9 +100,9 @@ export function Sidebar({ navItems }: SidebarProps) {
                   activeOptions={item.end ? { exact: true } : undefined}
                   title={collapsed ? item.label : undefined}
                   className={cn(
-                    'flex items-center rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+                    'flex items-center rounded-lg py-2 text-sm font-medium transition-colors',
                     'text-[var(--color-sidebar-muted-foreground)] hover:bg-[var(--color-sidebar-accent)] hover:text-[var(--color-sidebar-foreground)]',
-                    collapsed ? 'justify-center' : 'gap-3'
+                    collapsed ? 'justify-center px-0 w-full' : 'gap-3 px-6'
                   )}
                   activeProps={{
                     className: 'bg-[var(--color-sidebar-accent)] text-[var(--color-sidebar-foreground)]',
@@ -139,14 +142,14 @@ export function Sidebar({ navItems }: SidebarProps) {
 
       {/* Admin/App switcher */}
       {isAdmin && (
-        <div className="border-t border-[var(--color-sidebar-border)] px-2 py-3">
+        <div className="border-t border-[var(--color-sidebar-border)] py-3">
           <Link
             to={inAdmin ? '/app' : '/admin'}
             title={collapsed ? (inAdmin ? m.sidebar_go_to_app() : m.sidebar_go_to_admin()) : undefined}
             className={cn(
-              'flex items-center rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+              'flex items-center rounded-lg py-2 text-sm font-medium transition-colors',
               'text-[var(--color-sidebar-muted-foreground)] hover:bg-[var(--color-sidebar-accent)] hover:text-[var(--color-sidebar-foreground)]',
-              collapsed ? 'justify-center' : 'gap-3'
+              collapsed ? 'justify-center px-0 w-full' : 'gap-3 px-6'
             )}
           >
             {inAdmin
@@ -160,8 +163,8 @@ export function Sidebar({ navItems }: SidebarProps) {
 
       {/* Locale switcher */}
       <div className={cn(
-        'border-t border-[var(--color-sidebar-border)] px-2 py-2',
-        collapsed ? 'flex justify-center' : 'flex items-center gap-1 px-5'
+        'border-t border-[var(--color-sidebar-border)] py-2',
+        collapsed ? 'flex justify-center' : 'flex items-center gap-1 px-6'
       )}>
         {collapsed ? (
           <button
@@ -201,9 +204,9 @@ export function Sidebar({ navItems }: SidebarProps) {
       </div>
 
       {/* User + logout */}
-      <div className="border-t border-[var(--color-sidebar-border)] p-2">
+      <div className="border-t border-[var(--color-sidebar-border)] py-2">
         {auth.user && !collapsed && (
-          <div className="mb-2 px-3 py-2">
+          <div className="mb-1 px-6 py-2">
             <p className="truncate text-xs font-medium text-[var(--color-sidebar-foreground)]">
               {auth.user.profile.name ?? auth.user.profile.preferred_username}
             </p>
@@ -216,9 +219,9 @@ export function Sidebar({ navItems }: SidebarProps) {
           to="/app/account"
           title={collapsed ? m.sidebar_account() : undefined}
           className={cn(
-            'flex items-center rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+            'flex items-center rounded-lg py-2 text-sm font-medium transition-colors',
             'text-[var(--color-sidebar-muted-foreground)] hover:bg-[var(--color-sidebar-accent)] hover:text-[var(--color-sidebar-foreground)]',
-            collapsed ? 'justify-center' : 'gap-3'
+            collapsed ? 'justify-center px-0 w-full' : 'gap-3 px-6'
           )}
           activeProps={{
             className: 'bg-[var(--color-sidebar-accent)] text-[var(--color-sidebar-foreground)]',
@@ -236,9 +239,9 @@ export function Sidebar({ navItems }: SidebarProps) {
           }}
           title={collapsed ? m.sidebar_logout() : undefined}
           className={cn(
-            'flex w-full items-center rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+            'flex w-full items-center rounded-lg py-2 text-sm font-medium transition-colors',
             'text-[var(--color-sidebar-muted-foreground)] hover:bg-[var(--color-sidebar-accent)] hover:text-[var(--color-sidebar-foreground)]',
-            collapsed ? 'justify-center' : 'gap-3'
+            collapsed ? 'justify-center px-0' : 'gap-3 px-6'
           )}
         >
           <LogOut size={16} strokeWidth={1.75} />

--- a/klai-portal/frontend/src/routes/admin/billing.lazy.tsx
+++ b/klai-portal/frontend/src/routes/admin/billing.lazy.tsx
@@ -145,14 +145,14 @@ function BillingPage() {
 
   if (loadingStatus) {
     return (
-      <div className="p-8">
+      <div className="p-12">
         <div className="h-6 w-6 animate-spin rounded-full border-2 border-[var(--color-purple-accent)] border-t-transparent" />
       </div>
     )
   }
 
   return (
-    <div className="p-8 space-y-6 max-w-3xl" data-help-id="admin-billing-overview">
+    <div className="p-12 space-y-6 max-w-3xl" data-help-id="admin-billing-overview">
       <div className="space-y-1">
         <h1 className="font-serif text-2xl font-bold text-[var(--color-purple-deep)]">{m.admin_billing_heading()}</h1>
         <p className="text-sm text-[var(--color-muted-foreground)]">

--- a/klai-portal/frontend/src/routes/admin/groups/$groupId/add-member.tsx
+++ b/klai-portal/frontend/src/routes/admin/groups/$groupId/add-member.tsx
@@ -99,7 +99,7 @@ function AddMemberPage() {
   }
 
   return (
-    <div className="p-8 max-w-lg">
+    <div className="p-12 max-w-lg">
       <div className="flex items-center justify-between mb-6">
         <h1 className="font-serif text-2xl font-bold text-[var(--color-purple-deep)]">
           {m.admin_groups_members_add()}

--- a/klai-portal/frontend/src/routes/admin/groups/$groupId/edit.tsx
+++ b/klai-portal/frontend/src/routes/admin/groups/$groupId/edit.tsx
@@ -153,7 +153,7 @@ function EditGroupPage() {
 
   if (groupLoading) {
     return (
-      <div className="p-8">
+      <div className="p-12">
         <p className="text-sm text-[var(--color-muted-foreground)]">
           <Loader2 className="inline h-4 w-4 animate-spin mr-2" />
           Loading...
@@ -164,14 +164,14 @@ function EditGroupPage() {
 
   if (!group) {
     return (
-      <div className="p-8">
+      <div className="p-12">
         <p className="text-sm text-[var(--color-destructive)]">Group not found</p>
       </div>
     )
   }
 
   return (
-    <div className="p-8 max-w-lg">
+    <div className="p-12 max-w-lg">
       <div className="flex items-center justify-between mb-6">
         <h1 className="font-serif text-2xl font-bold text-[var(--color-purple-deep)]">
           {m.admin_groups_edit()}

--- a/klai-portal/frontend/src/routes/admin/groups/$groupId/index.tsx
+++ b/klai-portal/frontend/src/routes/admin/groups/$groupId/index.tsx
@@ -130,7 +130,7 @@ function AdminGroupDetail() {
 
   if (groupLoading) {
     return (
-      <div className="p-8">
+      <div className="p-12">
         <p className="text-sm text-[var(--color-muted-foreground)]">
           <Loader2 className="inline h-4 w-4 animate-spin mr-2" />
           Loading...
@@ -141,14 +141,14 @@ function AdminGroupDetail() {
 
   if (!groupData) {
     return (
-      <div className="p-8">
+      <div className="p-12">
         <p className="text-sm text-[var(--color-destructive)]">Group not found</p>
       </div>
     )
   }
 
   return (
-    <div className="p-8 space-y-6 max-w-2xl">
+    <div className="p-12 space-y-6 max-w-2xl">
       {/* Header */}
       <div className="flex items-start justify-between">
         <div className="space-y-2">

--- a/klai-portal/frontend/src/routes/admin/groups/index.tsx
+++ b/klai-portal/frontend/src/routes/admin/groups/index.tsx
@@ -299,7 +299,7 @@ function AdminGroups() {
   })
 
   return (
-    <div className="p-8 space-y-6">
+    <div className="p-12 space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="font-serif text-2xl font-bold text-[var(--color-purple-deep)]">
           {m.admin_groups_title()}

--- a/klai-portal/frontend/src/routes/admin/groups/new.tsx
+++ b/klai-portal/frontend/src/routes/admin/groups/new.tsx
@@ -61,7 +61,7 @@ function NewGroupPage() {
   }
 
   return (
-    <div className="p-8 max-w-lg">
+    <div className="p-12 max-w-lg">
       <div className="flex items-center justify-between mb-6">
         <h1 className="font-serif text-2xl font-bold text-[var(--color-purple-deep)]">
           {m.admin_groups_create()}

--- a/klai-portal/frontend/src/routes/admin/index.tsx
+++ b/klai-portal/frontend/src/routes/admin/index.tsx
@@ -35,7 +35,7 @@ function AdminHome() {
   ]
 
   return (
-    <div className="p-8 space-y-8 max-w-3xl">
+    <div className="p-12 space-y-8 max-w-3xl">
       <div className="space-y-1">
         <h1 className="font-serif text-2xl font-bold text-[var(--color-purple-deep)]">
           {m.admin_home_heading()}

--- a/klai-portal/frontend/src/routes/admin/integrations/index.tsx
+++ b/klai-portal/frontend/src/routes/admin/integrations/index.tsx
@@ -253,7 +253,7 @@ function IntegrationsPage() {
   }
 
   return (
-    <div className="p-8 max-w-2xl">
+    <div className="p-12 max-w-2xl">
       <div className="mb-6">
         <h1 className="font-serif text-2xl font-bold text-[var(--color-purple-deep)]">
           {m.admin_integrations_title()}

--- a/klai-portal/frontend/src/routes/admin/settings.tsx
+++ b/klai-portal/frontend/src/routes/admin/settings.tsx
@@ -55,7 +55,7 @@ function AdminSettingsPage() {
   }, [settings])
 
   return (
-    <div className="p-8 space-y-6 max-w-3xl" data-help-id="admin-settings-general">
+    <div className="p-12 space-y-6 max-w-3xl" data-help-id="admin-settings-general">
       <div className="space-y-1">
         <h1 className="font-serif text-2xl font-bold text-[var(--color-purple-deep)]">
           {m.admin_settings_heading()}

--- a/klai-portal/frontend/src/routes/admin/users/$userId/edit.tsx
+++ b/klai-portal/frontend/src/routes/admin/users/$userId/edit.tsx
@@ -172,7 +172,7 @@ function EditUserPage() {
   const offboardMutation = useOffboardUser()
 
   return (
-    <div className="p-8 max-w-lg">
+    <div className="p-12 max-w-lg">
       <div className="flex items-center justify-between mb-6">
         <h1 className="font-serif text-2xl font-bold text-[var(--color-purple-deep)]">
           {m.admin_users_edit_heading()}

--- a/klai-portal/frontend/src/routes/admin/users/index.tsx
+++ b/klai-portal/frontend/src/routes/admin/users/index.tsx
@@ -316,7 +316,7 @@ function UsersPage() {
   })
 
   return (
-    <div className="p-8 space-y-6">
+    <div className="p-12 space-y-6">
       <div className="flex items-start justify-between">
         <div className="space-y-1">
           <h1 className="font-serif text-2xl font-bold text-[var(--color-purple-deep)]">

--- a/klai-portal/frontend/src/routes/admin/users/invite.tsx
+++ b/klai-portal/frontend/src/routes/admin/users/invite.tsx
@@ -82,7 +82,7 @@ function InviteUserPage() {
   }
 
   return (
-    <div className="p-8 max-w-lg">
+    <div className="p-12 max-w-lg">
       <div className="flex items-center justify-between mb-6">
         <h1 className="font-serif text-2xl font-bold text-[var(--color-purple-deep)]">
           {m.admin_users_invite_button()}

--- a/klai-portal/frontend/src/routes/app/account.tsx
+++ b/klai-portal/frontend/src/routes/app/account.tsx
@@ -78,7 +78,7 @@ function AccountPage() {
   const email = auth.user?.profile?.email ?? ''
 
   return (
-    <div className="p-8 space-y-6 max-w-2xl">
+    <div className="p-12 space-y-6 max-w-2xl">
       <div className="space-y-1">
         <h1 className="font-serif text-2xl font-bold text-[var(--color-purple-deep)]">
           {m.account_heading()}

--- a/klai-portal/frontend/src/routes/app/docs/$kbSlug_.edit.tsx
+++ b/klai-portal/frontend/src/routes/app/docs/$kbSlug_.edit.tsx
@@ -82,7 +82,7 @@ function EditKBPage() {
   }
 
   return (
-    <div className="p-8 max-w-lg">
+    <div className="p-12 max-w-lg">
       <div className="flex items-center justify-between mb-6">
         <h1 className="font-serif text-2xl font-bold text-[var(--color-purple-deep)]">
           {m.docs_kb_edit_modal_title()}

--- a/klai-portal/frontend/src/routes/app/docs/index.tsx
+++ b/klai-portal/frontend/src/routes/app/docs/index.tsx
@@ -47,7 +47,7 @@ function DocsPage() {
       : m.docs_kbs_count({ count: String(accessibleKbs.length) })
 
   return (
-    <div className="p-8 space-y-6">
+    <div className="p-12 space-y-6">
       <div className="flex items-start justify-between">
         <div className="space-y-1">
           <h1 className="font-serif text-2xl font-bold text-[var(--color-purple-deep)]">

--- a/klai-portal/frontend/src/routes/app/docs/new.tsx
+++ b/klai-portal/frontend/src/routes/app/docs/new.tsx
@@ -51,7 +51,7 @@ function NewKBPage() {
   }
 
   return (
-    <div className="p-8 max-w-lg">
+    <div className="p-12 max-w-lg">
       <div className="flex items-center justify-between mb-6">
         <h1 className="font-serif text-2xl font-bold text-[var(--color-purple-deep)]">
           {m.docs_kbs_new()}

--- a/klai-portal/frontend/src/routes/app/focus/$notebookId.lazy.tsx
+++ b/klai-portal/frontend/src/routes/app/focus/$notebookId.lazy.tsx
@@ -289,7 +289,7 @@ function NotebookDetailPage() {
   // ── Render ────────────────────────────────────────────────────────────────────
 
   return (
-    <div className="p-8 space-y-6">
+    <div className="p-12 space-y-6">
       {/* Header */}
       <div>
         <div className="flex items-center justify-between mb-1">

--- a/klai-portal/frontend/src/routes/app/focus/$notebookId_.add-source.tsx
+++ b/klai-portal/frontend/src/routes/app/focus/$notebookId_.add-source.tsx
@@ -90,7 +90,7 @@ function AddSourcePage() {
   })
 
   return (
-    <div className="p-8 max-w-lg">
+    <div className="p-12 max-w-lg">
       <div className="flex items-center justify-between mb-6">
         <h1 className="font-serif text-2xl font-bold text-[var(--color-purple-deep)]">
           {m.app_focus_add_source()}

--- a/klai-portal/frontend/src/routes/app/focus/$notebookId_.edit.tsx
+++ b/klai-portal/frontend/src/routes/app/focus/$notebookId_.edit.tsx
@@ -100,7 +100,7 @@ function EditFocusPage() {
   }
 
   return (
-    <div className="p-8 max-w-lg">
+    <div className="p-12 max-w-lg">
       <div className="flex items-center justify-between mb-6">
         <h1 className="font-serif text-2xl font-bold text-[var(--color-purple-deep)]">
           {m.app_focus_edit_title()}

--- a/klai-portal/frontend/src/routes/app/focus/index.tsx
+++ b/klai-portal/frontend/src/routes/app/focus/index.tsx
@@ -113,7 +113,7 @@ function FocusPage() {
         : null
 
   return (
-    <div className="p-8 space-y-6">
+    <div className="p-12 space-y-6">
       <div className="flex items-start justify-between">
         <div className="space-y-1">
           <h1 className="font-serif text-2xl font-bold text-[var(--color-purple-deep)]">

--- a/klai-portal/frontend/src/routes/app/focus/new.tsx
+++ b/klai-portal/frontend/src/routes/app/focus/new.tsx
@@ -77,7 +77,7 @@ function NewFocusPage() {
   }
 
   return (
-    <div className="p-8 max-w-lg">
+    <div className="p-12 max-w-lg">
       <div className="flex items-center justify-between mb-6">
         <h1 className="font-serif text-2xl font-bold text-[var(--color-purple-deep)]">
           {m.app_focus_new_title()}

--- a/klai-portal/frontend/src/routes/app/gaps/index.tsx
+++ b/klai-portal/frontend/src/routes/app/gaps/index.tsx
@@ -97,7 +97,7 @@ function GapsPage() {
 
   if (!isAdmin) {
     return (
-      <div className="p-8 max-w-2xl">
+      <div className="p-12 max-w-2xl">
         <p className="text-[var(--color-muted-foreground)]">Admin access required.</p>
       </div>
     )
@@ -106,7 +106,7 @@ function GapsPage() {
   const gaps = data?.gaps ?? []
 
   return (
-    <div className="p-8 max-w-4xl">
+    <div className="p-12 max-w-4xl">
       <div className="flex items-center justify-between mb-6">
         <div className="flex items-center gap-3">
           <AlertTriangle className="h-7 w-7 text-[var(--color-purple-deep)]" />

--- a/klai-portal/frontend/src/routes/app/index.tsx
+++ b/klai-portal/frontend/src/routes/app/index.tsx
@@ -57,7 +57,7 @@ function AppHome() {
   ]
 
   return (
-    <div className="p-8 space-y-8 max-w-3xl">
+    <div className="p-12 space-y-8 max-w-3xl">
       <div className="space-y-1" data-help-id="home-greeting">
         <h1 className="font-serif text-2xl font-bold text-[var(--color-purple-deep)]">
           {getGreeting(userName)}

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-kb-types.ts
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-kb-types.ts
@@ -71,7 +71,6 @@ export interface TaxonomyNode {
   parent_id: number | null
   name: string
   slug: string
-  doc_count: number
   sort_order: number
   created_at: string
   created_by: string

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/items.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/items.tsx
@@ -45,7 +45,7 @@ function ItemsTab() {
 
   if (!data?.items?.length) {
     return (
-      <div className="rounded-lg border border-dashed border-[var(--color-border)] p-8 text-center">
+      <div className="rounded-lg border border-dashed border-[var(--color-border)] p-12 text-center">
         <List className="mx-auto h-8 w-8 text-[var(--color-muted-foreground)] mb-3" />
         <p className="text-sm text-[var(--color-muted-foreground)]">{m.knowledge_items_empty_state()}</p>
       </div>

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/route.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/route.tsx
@@ -100,7 +100,7 @@ function KbLayout() {
 
   if (isLoading) {
     return (
-      <div className="p-8">
+      <div className="p-12">
         <div className="h-8 w-48 rounded bg-[var(--color-secondary)] animate-pulse mb-4" />
         <div className="h-4 w-96 rounded bg-[var(--color-secondary)] animate-pulse" />
       </div>
@@ -109,7 +109,7 @@ function KbLayout() {
 
   if (isError || !kb) {
     return (
-      <div className="p-8 text-[var(--color-muted-foreground)]">
+      <div className="p-12 text-[var(--color-muted-foreground)]">
         {m.knowledge_detail_not_found()}
       </div>
     )
@@ -128,7 +128,7 @@ function KbLayout() {
   void stats // keep query alive for child routes
 
   return (
-    <div className="p-8 max-w-2xl space-y-8">
+    <div className="p-12 max-w-2xl space-y-8">
       {/* Header */}
       <div className="flex items-start gap-3">
         <div className="flex-1">

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/taxonomy.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/taxonomy.tsx
@@ -278,9 +278,6 @@ function TaxonomyTree({
               ) : (
                 <>
                   <span className="text-sm text-[var(--color-foreground)] truncate flex-1">{node.name}</span>
-                  <span className="text-xs text-[var(--color-muted-foreground)] tabular-nums shrink-0">
-                    {node.doc_count > 0 && m.knowledge_taxonomy_node_doc_count({ count: String(node.doc_count) })}
-                  </span>
 
                   {canEdit && (
                     <div className="hidden group-hover:flex items-center gap-0.5 ml-1">

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
@@ -169,7 +169,7 @@ function AddConnectorPage() {
   })
 
   return (
-    <div className="p-8 max-w-lg">
+    <div className="p-12 max-w-lg">
       {/* Page header */}
       <div className="flex items-center justify-between mb-6">
         <h1 className="font-serif text-2xl font-bold text-[var(--color-purple-deep)]">

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
@@ -157,7 +157,7 @@ function EditConnectorPage() {
   }
 
   return (
-    <div className="p-8 max-w-lg">
+    <div className="p-12 max-w-lg">
       <div className="flex items-center justify-between mb-6">
         <h1 className="font-serif text-2xl font-bold text-[var(--color-purple-deep)]">
           {m.admin_connectors_edit_title()}

--- a/klai-portal/frontend/src/routes/app/knowledge/index.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/index.tsx
@@ -131,7 +131,7 @@ function KnowledgePage() {
   )
 
   return (
-    <div className="p-8 max-w-2xl">
+    <div className="p-12 max-w-2xl">
       <div className="flex items-center justify-between mb-2">
         <div className="flex items-center gap-3">
           <h1 className="font-serif text-2xl font-bold text-[var(--color-purple-deep)]">

--- a/klai-portal/frontend/src/routes/app/knowledge/new.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/new.tsx
@@ -179,7 +179,7 @@ function NewKnowledgeBasePage() {
   }
 
   return (
-    <div className="p-8 max-w-lg">
+    <div className="p-12 max-w-lg">
       {/* Header with back/cancel */}
       <div className="flex items-center justify-between mb-6">
         <h1 className="font-serif text-2xl font-bold text-[var(--color-purple-deep)]">

--- a/klai-portal/frontend/src/routes/app/meetings/$meetingId.tsx
+++ b/klai-portal/frontend/src/routes/app/meetings/$meetingId.tsx
@@ -229,7 +229,7 @@ function MeetingDetailPage() {
   const hasTranscript = meeting.status === 'done' && !!(meeting.transcript_text || meeting.transcript_segments?.length)
 
   return (
-    <div className="p-8 max-w-3xl">
+    <div className="p-12 max-w-3xl">
       <Button
         variant="ghost"
         size="sm"

--- a/klai-portal/frontend/src/routes/app/meetings/start.tsx
+++ b/klai-portal/frontend/src/routes/app/meetings/start.tsx
@@ -80,7 +80,7 @@ function StartMeetingPage() {
   }
 
   return (
-    <div className="p-8 max-w-3xl">
+    <div className="p-12 max-w-3xl">
       <div className="flex items-center justify-between mb-6">
         <h1 className="font-serif text-2xl font-bold text-[var(--color-purple-deep)]">
           {m.app_meetings_start_title()}

--- a/klai-portal/frontend/src/routes/app/scribe.tsx
+++ b/klai-portal/frontend/src/routes/app/scribe.tsx
@@ -9,7 +9,7 @@ export const Route = createFileRoute('/app/scribe')({
 function ScribePage() {
   return (
     <ProductGuard product="scribe">
-    <div className="p-8 space-y-6 max-w-3xl">
+    <div className="p-12 space-y-6 max-w-3xl">
       <div className="space-y-1">
         <h1 className="font-serif text-2xl font-bold text-[var(--color-purple-deep)]">{m.app_tool_scribe_title()}</h1>
         <p className="text-sm text-[var(--color-muted-foreground)]">

--- a/klai-portal/frontend/src/routes/app/transcribe/$transcriptionId.tsx
+++ b/klai-portal/frontend/src/routes/app/transcribe/$transcriptionId.tsx
@@ -123,7 +123,7 @@ function TranscriptionDetailPage() {
   )
 
   return (
-    <div className="p-8 max-w-3xl">
+    <div className="p-12 max-w-3xl">
       <div className="flex items-center justify-between mb-6">
         <h1 className="font-serif text-2xl font-bold text-[var(--color-purple-deep)]">
           {displayTitle}

--- a/klai-portal/frontend/src/routes/app/transcribe/add.tsx
+++ b/klai-portal/frontend/src/routes/app/transcribe/add.tsx
@@ -264,7 +264,7 @@ function AddTranscribePage() {
   const isTranscribing = transcribeMutation.isPending || retryMutation.isPending
 
   return (
-    <div className="p-8 max-w-lg">
+    <div className="p-12 max-w-lg">
       <div className="flex items-center justify-between mb-6">
         <h1 className="font-serif text-2xl font-bold text-[var(--color-purple-deep)]">
           {m.app_transcribe_add_title()}
@@ -395,7 +395,7 @@ function AddTranscribePage() {
             {/* Upload tab */}
             {activeTab === 'upload' && (
               <div
-                className={`border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-colors ${
+                className={`border-2 border-dashed rounded-lg p-12 text-center cursor-pointer transition-colors ${
                   dragging
                     ? 'border-[var(--color-purple-accent)] bg-[var(--color-purple-accent)]/5'
                     : 'border-[var(--color-border)] hover:border-[var(--color-purple-accent)]/50'

--- a/klai-portal/frontend/src/routes/app/transcribe/index.tsx
+++ b/klai-portal/frontend/src/routes/app/transcribe/index.tsx
@@ -162,7 +162,7 @@ function TranscribePage() {
   const totalCount = (transcriptionsData?.total ?? 0) + (meetingsData?.total ?? 0)
 
   return (
-    <div className="p-8 space-y-6">
+    <div className="p-12 space-y-6">
       <div className="flex items-start justify-between">
         <div className="space-y-1">
           <h1 className="font-serif text-2xl font-bold text-[var(--color-purple-deep)]">

--- a/scripts/export-mcp-session.mjs
+++ b/scripts/export-mcp-session.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/**
+ * One-time setup: exports the persistent Brave/Chromium MCP profile to storageState.json.
+ *
+ * Run this:
+ *   - After first-time setup (creates an empty storageState.json)
+ *   - After migrating from persistent-profile to isolated mode (copies existing cookies)
+ *   - After your login session expires and you need to re-export
+ *
+ * Usage:
+ *   node scripts/export-mcp-session.mjs
+ *
+ * Requires: npm install -g playwright  (or use the globally installed playwright-mcp's playwright)
+ */
+import { chromium } from 'playwright';
+import { readFileSync, existsSync, mkdirSync, writeFileSync } from 'fs';
+import { resolve, dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import os from 'os';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const configPath = resolve(__dirname, '..', '.playwright-mcp', 'config.json');
+
+// --- Read config.json ---
+if (!existsSync(configPath)) {
+  console.error('ERROR: .playwright-mcp/config.json not found.');
+  console.error('Copy .playwright-mcp/config.example.json to config.json and fill in your paths.');
+  process.exit(1);
+}
+
+const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+const executablePath = config.executablePath;
+const storageStatePath = (config.contextOptions?.storageState || '')
+  .replace('~', os.homedir())
+  .replace(/\\/g, '/');
+
+if (!storageStatePath) {
+  console.error('ERROR: config.json missing contextOptions.storageState path.');
+  console.error('Make sure your config.json uses isolated mode with a storageState path.');
+  process.exit(1);
+}
+
+if (!executablePath || !existsSync(executablePath)) {
+  console.error(`ERROR: Browser executable not found: ${executablePath}`);
+  console.error('Set executablePath in .playwright-mcp/config.json to your Brave/Chrome path.');
+  process.exit(1);
+}
+
+// --- Resolve source profile dir (old persistent profile location) ---
+const defaultProfileDir = join(os.homedir(), '.claude', 'mcp-brave-profile').replace(/\\/g, '/');
+const sourceProfileDir = (config.userDataDir || defaultProfileDir)
+  .replace('~', os.homedir())
+  .replace(/\\/g, '/');
+
+const hasExistingProfile = existsSync(sourceProfileDir);
+
+console.log('Playwright MCP — session export');
+console.log('================================');
+console.log(`Executable:   ${executablePath}`);
+console.log(`Source:       ${sourceProfileDir} ${hasExistingProfile ? '(found)' : '(not found — will create empty state)'}`);
+console.log(`Output:       ${storageStatePath}`);
+console.log('');
+
+// Ensure output directory exists
+const outputDir = dirname(storageStatePath);
+if (!existsSync(outputDir)) {
+  mkdirSync(outputDir, { recursive: true });
+}
+
+if (!hasExistingProfile) {
+  // No existing profile — create empty storageState so Playwright MCP can start
+  writeFileSync(storageStatePath, JSON.stringify({ cookies: [], origins: [] }, null, 2));
+  console.log('Created empty storageState.json (no existing profile found).');
+  console.log('');
+  console.log('Next: restart Claude Code, then log in via the browser in your first test session.');
+  console.log('After logging in, re-run this script to save the session for future sessions.');
+  process.exit(0);
+}
+
+// Export from existing persistent profile
+console.log('Launching headless browser to read profile cookies...');
+let browser;
+try {
+  browser = await chromium.launchPersistentContext(sourceProfileDir, {
+    executablePath,
+    headless: true,
+    args: ['--no-sandbox', '--disable-dev-shm-usage'],
+  });
+
+  await browser.storageState({ path: storageStatePath });
+  console.log('');
+  console.log(`storageState.json exported to: ${storageStatePath}`);
+  console.log('');
+  console.log('Done. Restart Claude Code to apply isolated mode with your saved session.');
+} catch (err) {
+  console.error('');
+  console.error('Export failed:', err.message);
+  console.error('');
+  console.error('If the profile is locked (Brave still open), close all Brave windows first.');
+  console.error('Or delete the lock file:');
+  console.error(`  del "${sourceProfileDir}\\SingletonLock"   (Windows)`);
+  console.error(`  rm "${sourceProfileDir}/SingletonLock"    (Mac/Linux)`);
+  process.exit(1);
+} finally {
+  await browser?.close();
+}


### PR DESCRIPTION
## Summary

- **R1**: Taxonomy-filtered retrieval in research-api — queries are now classified against the KB taxonomy before `retrieve_broad` calls the retrieval-api. Parallel classify + coverage-stats with 3 s timeout; falls back to unfiltered retrieval on any failure. `Notebook.kb_slug` column stores the KB link permanently so the frontend doesn't need to pass it per-chat.
- **R2**: Removed dead `maybe_generate_proposal()` call from `ingest.py` (always 1 doc, threshold is 3 — always a no-op). Moved to batch end of `_run_backfill` Phase 2. `maybe_generate_proposal` now returns `bool` so callers know if a proposal actually fired.
- **R3**: Dropped `doc_count` denormalization column from `portal_taxonomy_nodes`. Only updated on delete; stale on every re-ingest/backfill. Coverage dashboard uses live Qdrant counts.

## Migrations required (run before deploy)

| Service | Migration |
|---|---|
| klai-portal | `d3e4f5a6b7c8_drop_doc_count_from_taxonomy_nodes` |
| research-api | `0004_add_kb_slug_to_notebooks` |

## New env vars (research-api)

| Variable | Default | Notes |
|---|---|---|
| `KNOWLEDGE_INGEST_URL` | `http://knowledge-ingest:8000` | Already set in production |
| `TAXONOMY_RETRIEVAL_MIN_COVERAGE` | `0.3` | 30% coverage threshold to enable filter |

## Activate taxonomy filtering

```bash
PATCH /v1/notebooks/{nb_id}
{ "kb_slug": "my-kb" }
```

## Test plan

- [x] `klai-focus/research-api`: 7 tests in `test_taxonomy_filter.py` — all pass
- [x] `klai-knowledge-ingest`: 3 tests in `test_taxonomy_backfill_proposals.py` — all pass
- [x] `klai-portal/backend`: ruff check clean on changed files
- [x] All pre-existing tests unaffected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)