### PR TITLE
feat: Partner API for external chat integration (SPEC-API-001)

### DIFF
--- a/deploy/caddy/Caddyfile
+++ b/deploy/caddy/Caddyfile
@@ -163,6 +163,18 @@
         }
     }
 
+    # Partner API — external integration surface with per-IP rate limiting
+    handle /partner/* {
+        rate_limit {
+            zone partner_per_ip {
+                key {remote_host}
+                events 120
+                window 1m
+            }
+        }
+        reverse_proxy portal-api:8010
+    }
+
     handle /api/* {
         reverse_proxy portal-api:8010
     }

--- a/klai-portal/backend/app/api/admin_integrations.py
+++ b/klai-portal/backend/app/api/admin_integrations.py
@@ -1,0 +1,466 @@
+"""Admin integration management endpoints.
+
+SPEC-API-001 REQ-6.1 through REQ-6.7:
+- CRUD for partner API keys ("integrations") scoped to caller's org
+- Auth: Zitadel OIDC session with admin role check
+- Product events for create, update, revoke actions
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Literal
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from pydantic import BaseModel, Field
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.admin import _get_caller_org, _require_admin
+from app.core.database import get_db
+from app.models.knowledge_bases import PortalKnowledgeBase
+from app.models.partner_api_keys import PartnerAPIKey, PartnerApiKeyKbAccess
+from app.services.events import emit_event
+from app.services.partner_keys import generate_partner_key
+
+logger = structlog.get_logger()
+bearer = HTTPBearer()
+
+router = APIRouter(prefix="/api/integrations", tags=["Integrations Admin"])
+
+
+# ---------------------------------------------------------------------------
+# Pydantic schemas
+# ---------------------------------------------------------------------------
+
+
+class KbAccessEntry(BaseModel):
+    kb_id: int
+    access_level: Literal["read", "read_write"]
+
+
+class CreateIntegrationRequest(BaseModel):
+    name: str = Field(min_length=3, max_length=128)
+    description: str | None = None
+    permissions: dict  # {"chat": bool, "feedback": bool, "knowledge_append": bool}
+    kb_access: list[KbAccessEntry]
+    rate_limit_rpm: int = Field(default=60, ge=10, le=600)
+
+
+class IntegrationResponse(BaseModel):
+    id: str
+    name: str
+    description: str | None
+    key_prefix: str
+    permissions: dict
+    active: bool
+    kb_access_count: int
+    rate_limit_rpm: int
+    last_used_at: str | None
+    created_at: str
+    created_by: str
+
+
+class CreateIntegrationResponse(IntegrationResponse):
+    api_key: str  # Full plaintext key — only in create response
+
+
+class IntegrationDetailResponse(IntegrationResponse):
+    kb_access: list[dict]  # [{kb_id, kb_name, kb_slug, access_level}]
+
+
+class UpdateIntegrationRequest(BaseModel):
+    name: str | None = None
+    description: str | None = None
+    permissions: dict | None = None
+    kb_access: list[KbAccessEntry] | None = None
+    rate_limit_rpm: int | None = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _key_to_response(key: PartnerAPIKey, kb_access_count: int) -> IntegrationResponse:
+    """Map a PartnerAPIKey row to IntegrationResponse."""
+    return IntegrationResponse(
+        id=key.id,
+        name=key.name,
+        description=key.description,
+        key_prefix=key.key_prefix,
+        permissions=key.permissions,
+        active=key.active,
+        kb_access_count=kb_access_count,
+        rate_limit_rpm=key.rate_limit_rpm,
+        last_used_at=str(key.last_used_at) if key.last_used_at else None,
+        created_at=str(key.created_at),
+        created_by=key.created_by,
+    )
+
+
+async def _get_integration_or_404(
+    integration_id: str, org_id: int, db: AsyncSession
+) -> PartnerAPIKey:
+    """Fetch integration scoped to org, raise 404 if not found."""
+    result = await db.execute(
+        select(PartnerAPIKey).where(
+            PartnerAPIKey.id == integration_id,
+            PartnerAPIKey.org_id == org_id,
+        )
+    )
+    key = result.scalar_one_or_none()
+    if key is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Integration not found",
+        )
+    return key
+
+
+async def _validate_kb_ids(
+    kb_ids: list[int], org_id: int, db: AsyncSession
+) -> list[PortalKnowledgeBase]:
+    """Validate that all kb_ids belong to the org. Returns matching KB rows."""
+    if not kb_ids:
+        return []
+    result = await db.execute(
+        select(PortalKnowledgeBase).where(
+            PortalKnowledgeBase.id.in_(kb_ids),
+            PortalKnowledgeBase.org_id == org_id,
+        )
+    )
+    found_kbs = result.scalars().all()
+    found_ids = {kb.id for kb in found_kbs}
+    missing = set(kb_ids) - found_ids
+    if missing:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Knowledge base IDs not found in your organisation: {sorted(missing)}",
+        )
+    return list(found_kbs)
+
+
+# ---------------------------------------------------------------------------
+# TASK-012: POST /api/integrations
+# ---------------------------------------------------------------------------
+
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+async def create_integration(
+    body: CreateIntegrationRequest,
+    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    db: AsyncSession = Depends(get_db),
+) -> CreateIntegrationResponse:
+    """Create a new partner API key integration. REQ-6.2."""
+    caller_user_id, org, caller_user = await _get_caller_org(credentials, db)
+    _require_admin(caller_user)
+
+    # Validate KB IDs belong to org
+    kb_ids = [entry.kb_id for entry in body.kb_access]
+    await _validate_kb_ids(kb_ids, org.id, db)
+
+    # Validate: knowledge_append requires at least one read_write KB
+    if body.permissions.get("knowledge_append"):
+        has_rw = any(entry.access_level == "read_write" for entry in body.kb_access)
+        if not has_rw:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="knowledge_append permission requires at least one KB with read_write access",
+            )
+
+    # Generate key
+    plaintext_key, key_hash = generate_partner_key()
+    key_prefix = plaintext_key[:12]
+
+    # Create PartnerAPIKey row
+    key_id = str(uuid.uuid4())
+    key_row = PartnerAPIKey(
+        id=key_id,
+        org_id=org.id,
+        name=body.name,
+        description=body.description,
+        key_prefix=key_prefix,
+        key_hash=key_hash,
+        permissions=body.permissions,
+        rate_limit_rpm=body.rate_limit_rpm,
+        created_by=caller_user_id,
+    )
+    db.add(key_row)
+    await db.flush()  # Get the generated ID
+
+    # Create KB access rows
+    for entry in body.kb_access:
+        db.add(
+            PartnerApiKeyKbAccess(
+                partner_api_key_id=key_row.id,
+                kb_id=entry.kb_id,
+                access_level=entry.access_level,
+            )
+        )
+
+    await db.commit()
+
+    # Emit product event (REQ-6.7)
+    emit_event(
+        "integration.created",
+        org_id=org.id,
+        user_id=caller_user_id,
+        properties={"integration_id": key_row.id, "name": body.name},
+    )
+
+    logger.info(
+        "Integration created",
+        integration_id=key_row.id,
+        org_id=org.id,
+    )
+
+    return CreateIntegrationResponse(
+        id=key_row.id,
+        name=key_row.name,
+        description=key_row.description,
+        key_prefix=key_prefix,
+        permissions=key_row.permissions,
+        active=True,
+        kb_access_count=len(body.kb_access),
+        rate_limit_rpm=key_row.rate_limit_rpm,
+        last_used_at=None,
+        created_at=str(key_row.created_at),
+        created_by=key_row.created_by,
+        api_key=plaintext_key,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TASK-012: GET /api/integrations
+# ---------------------------------------------------------------------------
+
+
+@router.get("")
+async def list_integrations(
+    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    db: AsyncSession = Depends(get_db),
+) -> list[IntegrationResponse]:
+    """List all integrations for the caller's org. REQ-6.3."""
+    _caller_user_id, org, caller_user = await _get_caller_org(credentials, db)
+    _require_admin(caller_user)
+
+    result = await db.execute(
+        select(PartnerAPIKey).where(PartnerAPIKey.org_id == org.id)
+    )
+    keys = result.scalars().all()
+
+    if not keys:
+        return []
+
+    # Load KB access counts for all keys in one query
+    key_ids = [k.id for k in keys]
+    kb_result = await db.execute(
+        select(PartnerApiKeyKbAccess).where(
+            PartnerApiKeyKbAccess.partner_api_key_id.in_(key_ids)
+        )
+    )
+    kb_rows = kb_result.scalars().all()
+
+    # Count per key
+    kb_counts: dict[str, int] = {}
+    for row in kb_rows:
+        kb_counts[row.partner_api_key_id] = kb_counts.get(row.partner_api_key_id, 0) + 1
+
+    return [_key_to_response(k, kb_counts.get(k.id, 0)) for k in keys]
+
+
+# ---------------------------------------------------------------------------
+# TASK-013: GET /api/integrations/{id}
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{integration_id}")
+async def get_integration_detail(
+    integration_id: str,
+    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    db: AsyncSession = Depends(get_db),
+) -> IntegrationDetailResponse:
+    """Get full detail for a single integration. REQ-6.4."""
+    _caller_user_id, org, caller_user = await _get_caller_org(credentials, db)
+    _require_admin(caller_user)
+
+    key = await _get_integration_or_404(integration_id, org.id, db)
+
+    # Load KB access entries
+    kb_access_result = await db.execute(
+        select(PartnerApiKeyKbAccess).where(
+            PartnerApiKeyKbAccess.partner_api_key_id == key.id
+        )
+    )
+    kb_access_rows = kb_access_result.scalars().all()
+
+    # Load KB names
+    kb_ids = [row.kb_id for row in kb_access_rows]
+    kb_details: dict[int, PortalKnowledgeBase] = {}
+    if kb_ids:
+        kb_result = await db.execute(
+            select(PortalKnowledgeBase).where(PortalKnowledgeBase.id.in_(kb_ids))
+        )
+        for kb in kb_result.scalars().all():
+            kb_details[kb.id] = kb
+
+    kb_access_list = [
+        {
+            "kb_id": row.kb_id,
+            "kb_name": kb_details[row.kb_id].name if row.kb_id in kb_details else "Unknown",
+            "kb_slug": kb_details[row.kb_id].slug if row.kb_id in kb_details else "",
+            "access_level": row.access_level,
+        }
+        for row in kb_access_rows
+    ]
+
+    return IntegrationDetailResponse(
+        id=key.id,
+        name=key.name,
+        description=key.description,
+        key_prefix=key.key_prefix,
+        permissions=key.permissions,
+        active=key.active,
+        kb_access_count=len(kb_access_rows),
+        rate_limit_rpm=key.rate_limit_rpm,
+        last_used_at=str(key.last_used_at) if key.last_used_at else None,
+        created_at=str(key.created_at),
+        created_by=key.created_by,
+        kb_access=kb_access_list,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TASK-013: PATCH /api/integrations/{id}
+# ---------------------------------------------------------------------------
+
+
+@router.patch("/{integration_id}")
+async def update_integration(
+    integration_id: str,
+    body: UpdateIntegrationRequest,
+    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    db: AsyncSession = Depends(get_db),
+) -> IntegrationResponse:
+    """Partial update of an integration. REQ-6.5."""
+    caller_user_id, org, caller_user = await _get_caller_org(credentials, db)
+    _require_admin(caller_user)
+
+    key = await _get_integration_or_404(integration_id, org.id, db)
+
+    # Cannot update a revoked key
+    if not key.active:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot update a revoked integration",
+        )
+
+    # Apply partial updates
+    if body.name is not None:
+        key.name = body.name
+    if body.description is not None:
+        key.description = body.description
+    if body.permissions is not None:
+        key.permissions = body.permissions
+    if body.rate_limit_rpm is not None:
+        key.rate_limit_rpm = body.rate_limit_rpm
+
+    kb_access_count: int | None = None
+
+    # Atomic KB access replacement (REQ-6.5)
+    if body.kb_access is not None:
+        kb_ids = [entry.kb_id for entry in body.kb_access]
+        await _validate_kb_ids(kb_ids, org.id, db)
+
+        # Delete existing rows
+        await db.execute(
+            delete(PartnerApiKeyKbAccess).where(
+                PartnerApiKeyKbAccess.partner_api_key_id == key.id
+            )
+        )
+
+        # Insert new rows
+        for entry in body.kb_access:
+            db.add(
+                PartnerApiKeyKbAccess(
+                    partner_api_key_id=key.id,
+                    kb_id=entry.kb_id,
+                    access_level=entry.access_level,
+                )
+            )
+        kb_access_count = len(body.kb_access)
+
+    await db.commit()
+
+    # If we didn't update kb_access, count the existing ones
+    if kb_access_count is None:
+        count_result = await db.execute(
+            select(PartnerApiKeyKbAccess).where(
+                PartnerApiKeyKbAccess.partner_api_key_id == key.id
+            )
+        )
+        kb_access_count = len(count_result.scalars().all())
+
+    # Emit product event (REQ-6.7)
+    emit_event(
+        "integration.updated",
+        org_id=org.id,
+        user_id=caller_user_id,
+        properties={"integration_id": key.id, "name": key.name},
+    )
+
+    return _key_to_response(key, kb_access_count)
+
+
+# ---------------------------------------------------------------------------
+# TASK-013: POST /api/integrations/{id}/revoke
+# ---------------------------------------------------------------------------
+
+
+@router.post("/{integration_id}/revoke")
+async def revoke_integration(
+    integration_id: str,
+    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    db: AsyncSession = Depends(get_db),
+) -> IntegrationResponse:
+    """Revoke an integration (irreversible). REQ-6.6."""
+    caller_user_id, org, caller_user = await _get_caller_org(credentials, db)
+    _require_admin(caller_user)
+
+    key = await _get_integration_or_404(integration_id, org.id, db)
+
+    if not key.active:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Integration is already revoked",
+        )
+
+    key.active = False
+    await db.commit()
+
+    # Emit product event (REQ-6.7)
+    emit_event(
+        "integration.revoked",
+        org_id=org.id,
+        user_id=caller_user_id,
+        properties={"integration_id": key.id, "name": key.name},
+    )
+
+    logger.info(
+        "Integration revoked",
+        integration_id=key.id,
+        org_id=org.id,
+    )
+
+    # Count KB access for response
+    count_result = await db.execute(
+        select(PartnerApiKeyKbAccess).where(
+            PartnerApiKeyKbAccess.partner_api_key_id == key.id
+        )
+    )
+    kb_access_count = len(count_result.scalars().all())
+
+    return _key_to_response(key, kb_access_count)

--- a/klai-portal/backend/app/api/partner.py
+++ b/klai-portal/backend/app/api/partner.py
@@ -4,19 +4,80 @@ SPEC-API-001: External partner endpoints under /partner/v1/*.
 Authenticated via partner API keys (Bearer pk_live_...).
 """
 
-from fastapi import APIRouter, Depends
-from sqlalchemy import select
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import Literal
+
+import httpx
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.responses import Response, StreamingResponse
 
 from app.api.partner_dependencies import (
     PartnerAuthContext,
     get_partner_key,
     require_permission,
+    validate_kb_access,
 )
+from app.core.config import settings
 from app.core.database import get_db
 from app.models.knowledge_bases import PortalKnowledgeBase
+from app.services.events import emit_event
+from app.services.partner_chat import (
+    chat_completion_non_streaming,
+    chat_completion_streaming,
+    retrieve_context,
+)
+from app.services.quality_scorer import schedule_quality_update
+from app.services.redis_client import get_redis_pool
+from app.services.retrieval_log import find_correlated_log, write_retrieval_log
+
+logger = structlog.get_logger()
+
+# Hold references to fire-and-forget tasks to prevent GC (same pattern as partner_dependencies)
+_pending: set[asyncio.Task] = set()  # type: ignore[type-arg]
 
 router = APIRouter(prefix="/partner/v1", tags=["Partner API"])
+
+_ALLOWED_MODELS = {"klai-primary", "klai-fast"}
+
+
+# ---------------------------------------------------------------------------
+# Pydantic request models
+# ---------------------------------------------------------------------------
+
+
+class ChatCompletionsRequest(BaseModel):
+    messages: list[dict] = Field(..., min_length=1)
+    model: str = "klai-primary"
+    stream: bool = True
+    temperature: float = 0.7
+    knowledge_base_ids: list[int] | None = None
+
+
+class PartnerFeedbackRequest(BaseModel):
+    message_id: str
+    rating: Literal["thumbsUp", "thumbsDown"]
+    text: str | None = None
+    tag: str | None = None
+
+
+class PartnerKnowledgeRequest(BaseModel):
+    kb_id: int
+    title: str | None = None
+    content: str = Field(..., max_length=10_485_760)
+    source_type: str = "partner_api"
+    content_type: str = "text/plain"
+
+
+# ---------------------------------------------------------------------------
+# GET /partner/v1/knowledge-bases
+# ---------------------------------------------------------------------------
 
 
 @router.get("/knowledge-bases")
@@ -56,3 +117,256 @@ async def list_knowledge_bases(
         for kb in kbs
         if kb.id in auth.kb_access
     ]
+
+
+# ---------------------------------------------------------------------------
+# POST /partner/v1/chat/completions  (TASK-008 + TASK-009)
+# ---------------------------------------------------------------------------
+
+
+async def _resolve_kb_slugs(
+    kb_ids: list[int], org_id: int, db: AsyncSession
+) -> list[str]:
+    """Translate integer KB IDs to slug strings via DB lookup."""
+    result = await db.execute(
+        select(PortalKnowledgeBase).where(
+            PortalKnowledgeBase.id.in_(kb_ids),
+            PortalKnowledgeBase.org_id == org_id,
+        )
+    )
+    kbs = result.scalars().all()
+    return [kb.slug for kb in kbs]
+
+
+@router.post("/chat/completions")
+async def chat_completions(
+    request: ChatCompletionsRequest,
+    auth: PartnerAuthContext = Depends(get_partner_key),
+    db: AsyncSession = Depends(get_db),
+):
+    """Chat completions with RAG context from knowledge bases.
+
+    TASK-008: Non-streaming path.
+    TASK-009: Streaming SSE path.
+    """
+    # 1. Permission check
+    require_permission(auth, "chat")
+
+    # 2. Model validation
+    if request.model not in _ALLOWED_MODELS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"error": {"type": "invalid_request", "message": f"Model must be one of: {', '.join(sorted(_ALLOWED_MODELS))}"}},
+        )
+
+    # 3. Messages validation: at least one user message
+    has_user_msg = any(m.get("role") == "user" for m in request.messages)
+    if not has_user_msg:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"error": {"type": "invalid_request", "message": "Messages must contain at least one user message"}},
+        )
+
+    # 4. Validate KB access
+    kb_ids = validate_kb_access(auth, request.knowledge_base_ids)
+
+    # 5. Translate kb_ids -> kb_slugs
+    kb_slugs = await _resolve_kb_slugs(kb_ids, auth.org_id, db)
+
+    # 6. Retrieve context
+    try:
+        chunks, system_prompt = await retrieve_context(
+            org_id=auth.org_id,
+            zitadel_org_id=auth.zitadel_org_id,
+            kb_slugs=kb_slugs,
+            messages=request.messages,
+            settings=settings,
+        )
+    except (httpx.TimeoutException, httpx.ReadTimeout) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail={"error": {"type": "upstream_error", "message": "Retrieval service timeout"}},
+        ) from exc
+
+    # 7. Fire retrieval log async
+    chunk_ids = [c.get("chunk_id", "") for c in chunks if c.get("chunk_id")]
+    reranker_scores = [c.get("reranker_score", 0.0) for c in chunks if c.get("reranker_score") is not None]
+
+    task = asyncio.create_task(
+        write_retrieval_log(
+            org_id=auth.org_id,
+            user_id=f"partner:{auth.key_id}",
+            chunk_ids=chunk_ids,
+            reranker_scores=reranker_scores,
+            query_resolved="",
+            embedding_model_version="",
+            retrieved_at=datetime.now(UTC),
+        )
+    )
+    _pending.add(task)
+    task.add_done_callback(_pending.discard)
+
+    # 8. Streaming or non-streaming
+    if request.stream:
+        streaming_gen = chat_completion_streaming(
+            messages=request.messages,
+            model=request.model,
+            temperature=request.temperature,
+            system_prompt=system_prompt,
+            settings=settings,
+        )
+        return StreamingResponse(
+            content=streaming_gen,
+            media_type="text/event-stream",
+        )
+
+    # Non-streaming
+    result = await chat_completion_non_streaming(
+        messages=request.messages,
+        model=request.model,
+        temperature=request.temperature,
+        system_prompt=system_prompt,
+        settings=settings,
+    )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# POST /partner/v1/feedback  (TASK-010)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/feedback", status_code=201)
+async def submit_feedback(
+    request: PartnerFeedbackRequest,
+    auth: PartnerAuthContext = Depends(get_partner_key),
+    db: AsyncSession = Depends(get_db),
+):
+    """Process feedback from partner API.
+
+    Follows the pattern from app/api/internal.py:post_kb_feedback
+    but adapted for partner auth (no librechat_tenant_id).
+    """
+    # 1. Permission check
+    require_permission(auth, "feedback")
+
+    # 2. Idempotency check
+    redis_pool = await get_redis_pool()
+    idem_key = f"partner_fb:{request.message_id}"
+    if redis_pool:
+        existing = await redis_pool.get(idem_key)
+        if existing:
+            return Response(status_code=200)
+
+    # 3. Time-window correlation with retrieval log
+    correlated_log = await find_correlated_log(
+        org_id=auth.org_id,
+        user_id=f"partner:{auth.key_id}",
+        message_created_at=datetime.now(UTC),
+    )
+
+    chunk_ids = correlated_log["chunk_ids"] if correlated_log else []
+    correlated = correlated_log is not None
+
+    # 4. Insert feedback event via raw SQL (RLS table)
+    await db.execute(
+        text("""
+            INSERT INTO portal_feedback_events
+            (org_id, message_id, rating, tag, feedback_text,
+             chunk_ids, correlated, occurred_at)
+            VALUES (:org_id, :message_id, :rating, :tag,
+                    :feedback_text, :chunk_ids, :correlated, NOW())
+        """),
+        {
+            "org_id": auth.org_id,
+            "message_id": request.message_id,
+            "rating": request.rating,
+            "tag": request.tag,
+            "feedback_text": request.text,
+            "chunk_ids": chunk_ids or None,
+            "correlated": correlated,
+        },
+    )
+    await db.commit()
+
+    # 5. Set idempotency key
+    if redis_pool:
+        try:
+            await redis_pool.set(idem_key, "1", ex=3600)
+        except Exception:
+            logger.warning("partner_feedback_idem_key_set_failed", exc_info=True)
+
+    # 6. Schedule Qdrant quality update if correlated
+    if correlated and chunk_ids:
+        schedule_quality_update(chunk_ids, request.rating, auth.org_id)
+
+    # 7. Emit product event
+    emit_event(
+        "knowledge.feedback",
+        org_id=auth.org_id,
+        properties={
+            "rating": request.rating,
+            "correlated": correlated,
+            "chunk_count": len(chunk_ids),
+            "source": "partner_api",
+        },
+    )
+
+    return {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# POST /partner/v1/knowledge  (TASK-011)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/knowledge", status_code=201)
+async def append_knowledge(
+    request: PartnerKnowledgeRequest,
+    auth: PartnerAuthContext = Depends(get_partner_key),
+    db: AsyncSession = Depends(get_db),
+):
+    """Append content to a knowledge base via ingest-api.
+
+    Append-only: no update or delete operations.
+    """
+    from app.services.partner_knowledge import ingest_knowledge
+
+    # 1. Permission check
+    require_permission(auth, "knowledge_append")
+
+    # 2. Validate KB access with read_write level
+    validate_kb_access(auth, [request.kb_id], required_level="read_write")
+
+    # 3. Translate kb_id -> kb_slug
+    result = await db.execute(
+        select(PortalKnowledgeBase).where(
+            PortalKnowledgeBase.id == request.kb_id,
+            PortalKnowledgeBase.org_id == auth.org_id,
+        )
+    )
+    kb = result.scalar_one_or_none()
+    if kb is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={"error": {"type": "permission_error", "message": "Insufficient permissions"}},
+        )
+
+    # 4. Call ingest service
+    ingest_result = await ingest_knowledge(
+        org_id=auth.org_id,
+        zitadel_org_id=auth.zitadel_org_id,
+        kb_slug=kb.slug,
+        title=request.title,
+        content=request.content,
+        source_type=request.source_type,
+        content_type=request.content_type,
+        settings=settings,
+    )
+
+    # 5. Return mapped response
+    return {
+        "knowledge_id": ingest_result.get("artifact_id"),
+        "chunks_created": ingest_result.get("chunks_created"),
+        "status": ingest_result.get("status", "ingested"),
+    }

--- a/klai-portal/backend/app/main.py
+++ b/klai-portal/backend/app/main.py
@@ -21,6 +21,7 @@ from app.api.knowledge import router as knowledge_router
 from app.api.knowledge_bases import router as knowledge_bases_router
 from app.api.mcp_servers import router as mcp_servers_router
 from app.api.meetings import router as meetings_router
+from app.api.admin_integrations import router as admin_integrations_router
 from app.api.partner import router as partner_router
 from app.api.taxonomy import router as taxonomy_router
 from app.api.vitals import router as vitals_router
@@ -177,6 +178,7 @@ app.include_router(connectors_router)
 app.include_router(taxonomy_router)
 app.include_router(vitals_router)
 app.include_router(mcp_servers_router)
+app.include_router(admin_integrations_router)
 app.include_router(partner_router)
 
 

--- a/klai-portal/backend/app/services/partner_chat.py
+++ b/klai-portal/backend/app/services/partner_chat.py
@@ -1,0 +1,196 @@
+"""Partner chat completions service.
+
+SPEC-API-001 TASK-008/009:
+- Retrieve context from retrieval-api
+- Forward to LiteLLM for non-streaming and streaming completions
+- Build augmented system prompt with retrieved chunks
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+import httpx
+import structlog
+
+from app.core.config import Settings
+from app.trace import get_trace_headers
+
+logger = structlog.get_logger()
+
+
+def _last_user_message(messages: list[dict]) -> str | None:
+    """Extract the last user message from the messages array."""
+    for msg in reversed(messages):
+        if msg.get("role") == "user":
+            content = msg.get("content", "")
+            if isinstance(content, str):
+                return content
+            if isinstance(content, list):
+                return " ".join(
+                    p.get("text", "") for p in content if p.get("type") == "text"
+                )
+    return None
+
+
+def _build_conversation_history(messages: list[dict]) -> list[dict]:
+    """Return up to the last 6 turns (3 exchanges), excluding the last user message."""
+    history = [
+        {"role": m["role"], "content": m["content"]}
+        for m in messages[:-1]
+        if m.get("role") in ("user", "assistant")
+        and isinstance(m.get("content"), str)
+    ]
+    return history[-6:]
+
+
+def _build_system_prompt(chunks: list[dict], original_system: str | None = None) -> str:
+    """Build a system prompt augmented with retrieved context chunks."""
+    base = original_system or "You are a helpful assistant."
+
+    if not chunks:
+        return base
+
+    context_parts = []
+    for chunk in chunks:
+        text = chunk.get("text", "")
+        if text:
+            context_parts.append(text)
+
+    if not context_parts:
+        return base
+
+    context_block = "\n\n---\n\n".join(context_parts)
+    return f"{base}\n\nContext:\n{context_block}"
+
+
+async def retrieve_context(
+    org_id: int,
+    zitadel_org_id: str,
+    kb_slugs: list[str],
+    messages: list[dict],
+    settings: Settings,
+) -> tuple[list[dict], str]:
+    """Call retrieval-api and return (chunks, augmented_system_prompt).
+
+    Follows the pattern from deploy/litellm/klai_knowledge.py.
+    """
+    query = _last_user_message(messages)
+    if not query:
+        return [], _build_system_prompt([])
+
+    conversation_history = _build_conversation_history(messages)
+
+    # Extract original system message if present
+    original_system = None
+    for msg in messages:
+        if msg.get("role") == "system":
+            original_system = msg.get("content", "")
+            break
+
+    retrieve_body: dict = {
+        "query": query,
+        "org_id": zitadel_org_id,  # retrieval-api expects string org_id
+        "scope": "org",
+        "top_k": 8,
+        "conversation_history": conversation_history,
+    }
+    if kb_slugs:
+        retrieve_body["kb_slugs"] = kb_slugs
+
+    retrieval_url = settings.knowledge_retrieve_url
+    if not retrieval_url:
+        logger.warning("partner_chat_no_retrieval_url")
+        return [], _build_system_prompt([], original_system)
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await client.post(
+            f"{retrieval_url}/retrieve/v1/query",
+            json=retrieve_body,
+            headers={
+                "X-Internal-Secret": settings.internal_secret,
+                **get_trace_headers(),
+            },
+        )
+        resp.raise_for_status()
+        result = resp.json()
+
+    chunks = result.get("chunks", [])
+    system_prompt = _build_system_prompt(chunks, original_system)
+
+    return chunks, system_prompt
+
+
+async def chat_completion_non_streaming(
+    messages: list[dict],
+    model: str,
+    temperature: float,
+    system_prompt: str,
+    settings: Settings,
+) -> dict:
+    """Forward to LiteLLM and return complete response as dict.
+
+    POST to litellm with stream=false.
+    """
+    # Replace/prepend system message
+    augmented_messages = [{"role": "system", "content": system_prompt}]
+    for msg in messages:
+        if msg.get("role") != "system":
+            augmented_messages.append(msg)
+
+    litellm_url = settings.litellm_base_url
+
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        resp = await client.post(
+            f"{litellm_url}/v1/chat/completions",
+            json={
+                "model": model,
+                "messages": augmented_messages,
+                "temperature": temperature,
+                "stream": False,
+            },
+            headers={
+                "Authorization": f"Bearer {settings.litellm_master_key}",
+                **get_trace_headers(),
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def chat_completion_streaming(
+    messages: list[dict],
+    model: str,
+    temperature: float,
+    system_prompt: str,
+    settings: Settings,
+) -> AsyncGenerator[bytes, None]:
+    """Stream LiteLLM SSE response byte-for-byte.
+
+    POST to LiteLLM with stream=true, yield each chunk as-is.
+    """
+    augmented_messages = [{"role": "system", "content": system_prompt}]
+    for msg in messages:
+        if msg.get("role") != "system":
+            augmented_messages.append(msg)
+
+    litellm_url = settings.litellm_base_url
+
+    async with httpx.AsyncClient(timeout=120.0) as client:
+        async with client.stream(
+            "POST",
+            f"{litellm_url}/v1/chat/completions",
+            json={
+                "model": model,
+                "messages": augmented_messages,
+                "temperature": temperature,
+                "stream": True,
+            },
+            headers={
+                "Authorization": f"Bearer {settings.litellm_master_key}",
+                **get_trace_headers(),
+            },
+        ) as resp:
+            resp.raise_for_status()
+            async for chunk in resp.aiter_bytes():
+                yield chunk

--- a/klai-portal/backend/app/services/partner_knowledge.py
+++ b/klai-portal/backend/app/services/partner_knowledge.py
@@ -1,0 +1,53 @@
+"""Partner knowledge ingest service.
+
+SPEC-API-001 TASK-011:
+- Proxy content to knowledge-ingest service for append-only ingestion.
+"""
+
+from __future__ import annotations
+
+import httpx
+import structlog
+
+from app.core.config import Settings
+from app.trace import get_trace_headers
+
+logger = structlog.get_logger()
+
+
+async def ingest_knowledge(
+    org_id: int,
+    zitadel_org_id: str,
+    kb_slug: str,
+    title: str | None,
+    content: str,
+    source_type: str,
+    content_type: str,
+    settings: Settings,
+) -> dict:
+    """Proxy to POST /ingest/v1/document on knowledge-ingest service.
+
+    Returns {artifact_id, chunks_created, status} from ingest response.
+    """
+    ingest_url = settings.knowledge_ingest_url
+
+    body = {
+        "org_id": zitadel_org_id,
+        "kb_slug": kb_slug,
+        "path": title or "partner-upload",
+        "content": content,
+        "source_type": source_type,
+        "content_type": content_type,
+    }
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(
+            f"{ingest_url}/ingest/v1/document",
+            json=body,
+            headers={
+                "X-Internal-Secret": settings.knowledge_ingest_secret,
+                **get_trace_headers(),
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()

--- a/klai-portal/backend/tests/test_admin_integrations.py
+++ b/klai-portal/backend/tests/test_admin_integrations.py
@@ -1,0 +1,605 @@
+"""RED: Verify admin integration endpoints (SPEC-API-001 REQ-6).
+
+TASK-012: POST /api/integrations, GET /api/integrations
+TASK-013: GET /api/integrations/{id}, PATCH /api/integrations/{id}, POST /api/integrations/{id}/revoke
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_db():
+    """Mock async DB session with transaction support."""
+    db = AsyncMock()
+    db.execute = AsyncMock()
+    db.commit = AsyncMock()
+    db.add = MagicMock()
+    db.delete = AsyncMock()
+    return db
+
+
+@pytest.fixture
+def mock_credentials():
+    """Mock OIDC credentials."""
+    creds = MagicMock()
+    creds.credentials = "fake-oidc-token"
+    return creds
+
+
+@pytest.fixture
+def admin_user():
+    """Mock admin PortalUser."""
+    user = MagicMock()
+    user.role = "admin"
+    user.zitadel_user_id = "admin-user-123"
+    return user
+
+
+@pytest.fixture
+def member_user():
+    """Mock non-admin PortalUser."""
+    user = MagicMock()
+    user.role = "member"
+    user.zitadel_user_id = "member-user-456"
+    return user
+
+
+@pytest.fixture
+def mock_org():
+    """Mock PortalOrg."""
+    org = MagicMock()
+    org.id = 42
+    org.zitadel_org_id = "zit-org-1"
+    return org
+
+
+@pytest.fixture
+def valid_create_body():
+    """Valid CreateIntegrationRequest data."""
+    from app.api.admin_integrations import CreateIntegrationRequest
+
+    return CreateIntegrationRequest(
+        name="Test Partner",
+        description="A test integration",
+        permissions={"chat": True, "feedback": True, "knowledge_append": False},
+        kb_access=[{"kb_id": 1, "access_level": "read"}],
+        rate_limit_rpm=60,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_scalar_result(value):
+    """Create a mock result that returns value from scalar_one_or_none."""
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = value
+    return result
+
+
+def _mock_scalars_result(values):
+    """Create a mock result that returns values from scalars().all()."""
+    result = MagicMock()
+    scalars_mock = MagicMock()
+    scalars_mock.all.return_value = values
+    result.scalars.return_value = scalars_mock
+    return result
+
+
+# ===========================================================================
+# TASK-012: POST /api/integrations
+# ===========================================================================
+
+
+class TestCreateIntegration:
+    """POST /api/integrations — REQ-6.2."""
+
+    @pytest.mark.asyncio
+    async def test_non_admin_returns_403(self, mock_db, mock_credentials, member_user, mock_org):
+        """REQ-6.1: Non-admin user gets 403."""
+        from app.api.admin_integrations import CreateIntegrationRequest, create_integration
+
+        body = CreateIntegrationRequest(
+            name="Test",
+            permissions={"chat": True, "feedback": False, "knowledge_append": False},
+            kb_access=[],
+            rate_limit_rpm=60,
+        )
+
+        with patch("app.api.admin_integrations._get_caller_org", return_value=("user-id", mock_org, member_user)):
+            with pytest.raises(HTTPException) as exc_info:
+                await create_integration(body=body, credentials=mock_credentials, db=mock_db)
+            assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_create_happy_path_returns_plaintext_key(
+        self, mock_db, mock_credentials, admin_user, mock_org
+    ):
+        """REQ-6.2: Create returns plaintext key + metadata."""
+        from app.api.admin_integrations import CreateIntegrationRequest, create_integration
+
+        # Mock KB validation: kb_id=1 belongs to org
+        mock_kb = MagicMock()
+        mock_kb.id = 1
+        mock_kb.name = "Test KB"
+
+        mock_db.execute = AsyncMock(
+            side_effect=[
+                # First call: KB validation query
+                _mock_scalars_result([mock_kb]),
+                # Remaining calls for inserts
+                MagicMock(),
+                MagicMock(),
+            ]
+        )
+
+        body = CreateIntegrationRequest(
+            name="Test Partner",
+            permissions={"chat": True, "feedback": True, "knowledge_append": False},
+            kb_access=[{"kb_id": 1, "access_level": "read"}],
+            rate_limit_rpm=60,
+        )
+
+        with (
+            patch("app.api.admin_integrations._get_caller_org", return_value=("admin-user-123", mock_org, admin_user)),
+            patch("app.api.admin_integrations.emit_event"),
+        ):
+            result = await create_integration(body=body, credentials=mock_credentials, db=mock_db)
+
+        # Must return plaintext key starting with pk_live_
+        assert hasattr(result, "api_key")
+        assert result.api_key.startswith("pk_live_")
+        assert result.name == "Test Partner"
+        assert result.active is True
+        assert result.key_prefix.startswith("pk_live_")
+        assert len(result.key_prefix) == 12
+
+    @pytest.mark.asyncio
+    async def test_create_with_out_of_org_kb_returns_400(
+        self, mock_db, mock_credentials, admin_user, mock_org
+    ):
+        """REQ-6.2: KB not in org -> 400."""
+        from app.api.admin_integrations import CreateIntegrationRequest, create_integration
+
+        # Mock: no KBs found for org (kb_id=999 doesn't belong)
+        mock_db.execute = AsyncMock(return_value=_mock_scalars_result([]))
+
+        body = CreateIntegrationRequest(
+            name="Test Partner",
+            permissions={"chat": True, "feedback": False, "knowledge_append": False},
+            kb_access=[{"kb_id": 999, "access_level": "read"}],
+            rate_limit_rpm=60,
+        )
+
+        with patch("app.api.admin_integrations._get_caller_org", return_value=("admin-user-123", mock_org, admin_user)):
+            with pytest.raises(HTTPException) as exc_info:
+                await create_integration(body=body, credentials=mock_credentials, db=mock_db)
+            assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_create_knowledge_append_without_read_write_returns_400(
+        self, mock_db, mock_credentials, admin_user, mock_org
+    ):
+        """knowledge_append=true but no KBs with read_write -> 400."""
+        from app.api.admin_integrations import CreateIntegrationRequest, create_integration
+
+        mock_kb = MagicMock()
+        mock_kb.id = 1
+        mock_db.execute = AsyncMock(return_value=_mock_scalars_result([mock_kb]))
+
+        body = CreateIntegrationRequest(
+            name="Test Partner",
+            permissions={"chat": True, "feedback": False, "knowledge_append": True},
+            kb_access=[{"kb_id": 1, "access_level": "read"}],  # only read, not read_write
+            rate_limit_rpm=60,
+        )
+
+        with patch("app.api.admin_integrations._get_caller_org", return_value=("admin-user-123", mock_org, admin_user)):
+            with pytest.raises(HTTPException) as exc_info:
+                await create_integration(body=body, credentials=mock_credentials, db=mock_db)
+            assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_create_emits_product_event(
+        self, mock_db, mock_credentials, admin_user, mock_org
+    ):
+        """REQ-6.7: integration.created event emitted."""
+        from app.api.admin_integrations import CreateIntegrationRequest, create_integration
+
+        mock_kb = MagicMock()
+        mock_kb.id = 1
+        mock_db.execute = AsyncMock(
+            side_effect=[
+                _mock_scalars_result([mock_kb]),
+                MagicMock(),
+                MagicMock(),
+            ]
+        )
+
+        body = CreateIntegrationRequest(
+            name="Event Test",
+            permissions={"chat": True, "feedback": False, "knowledge_append": False},
+            kb_access=[{"kb_id": 1, "access_level": "read"}],
+            rate_limit_rpm=60,
+        )
+
+        with (
+            patch("app.api.admin_integrations._get_caller_org", return_value=("admin-user-123", mock_org, admin_user)),
+            patch("app.api.admin_integrations.emit_event") as mock_emit,
+        ):
+            await create_integration(body=body, credentials=mock_credentials, db=mock_db)
+
+        mock_emit.assert_called_once()
+        call_args = mock_emit.call_args
+        assert call_args[0][0] == "integration.created"
+        assert call_args[1]["org_id"] == 42
+        assert call_args[1]["user_id"] == "admin-user-123"
+
+
+# ===========================================================================
+# TASK-012: GET /api/integrations
+# ===========================================================================
+
+
+class TestListIntegrations:
+    """GET /api/integrations — REQ-6.3."""
+
+    @pytest.mark.asyncio
+    async def test_non_admin_returns_403(self, mock_db, mock_credentials, member_user, mock_org):
+        """REQ-6.1: Non-admin user gets 403."""
+        from app.api.admin_integrations import list_integrations
+
+        with patch("app.api.admin_integrations._get_caller_org", return_value=("user-id", mock_org, member_user)):
+            with pytest.raises(HTTPException) as exc_info:
+                await list_integrations(credentials=mock_credentials, db=mock_db)
+            assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_list_returns_entries_without_plaintext_key(
+        self, mock_db, mock_credentials, admin_user, mock_org
+    ):
+        """REQ-6.3: List returns metadata without plaintext key."""
+        from app.api.admin_integrations import list_integrations
+
+        # Mock a partner key row
+        key_row = MagicMock()
+        key_row.id = "uuid-1"
+        key_row.name = "Partner A"
+        key_row.description = "Desc"
+        key_row.key_prefix = "pk_live_abcd"
+        key_row.permissions = {"chat": True, "feedback": False, "knowledge_append": False}
+        key_row.active = True
+        key_row.rate_limit_rpm = 60
+        key_row.last_used_at = None
+        key_row.created_at = "2026-01-01T00:00:00Z"
+        key_row.created_by = "admin-user-123"
+
+        # Mock KB access count
+        kb_access_row = MagicMock()
+        kb_access_row.partner_api_key_id = "uuid-1"
+        kb_access_row.kb_id = 1
+        kb_access_row.access_level = "read"
+
+        mock_db.execute = AsyncMock(
+            side_effect=[
+                # First: list keys
+                _mock_scalars_result([key_row]),
+                # Second: KB access entries
+                _mock_scalars_result([kb_access_row]),
+            ]
+        )
+
+        with patch("app.api.admin_integrations._get_caller_org", return_value=("admin-user-123", mock_org, admin_user)):
+            result = await list_integrations(credentials=mock_credentials, db=mock_db)
+
+        assert len(result) == 1
+        entry = result[0]
+        assert entry.name == "Partner A"
+        assert entry.key_prefix == "pk_live_abcd"
+        # Must NOT have api_key attribute with plaintext
+        assert not hasattr(entry, "api_key")
+        assert entry.kb_access_count == 1
+
+
+# ===========================================================================
+# TASK-013: GET /api/integrations/{id}
+# ===========================================================================
+
+
+class TestGetIntegrationDetail:
+    """GET /api/integrations/{id} — REQ-6.4."""
+
+    @pytest.mark.asyncio
+    async def test_detail_returns_full_kb_list_with_names(
+        self, mock_db, mock_credentials, admin_user, mock_org
+    ):
+        """REQ-6.4: Detail returns per-KB access list with KB names."""
+        from app.api.admin_integrations import get_integration_detail
+
+        key_row = MagicMock()
+        key_row.id = "uuid-1"
+        key_row.org_id = 42
+        key_row.name = "Partner A"
+        key_row.description = "Desc"
+        key_row.key_prefix = "pk_live_abcd"
+        key_row.permissions = {"chat": True, "feedback": False, "knowledge_append": False}
+        key_row.active = True
+        key_row.rate_limit_rpm = 60
+        key_row.last_used_at = None
+        key_row.created_at = "2026-01-01T00:00:00Z"
+        key_row.created_by = "admin-user-123"
+
+        kb_access_entry = MagicMock()
+        kb_access_entry.kb_id = 1
+        kb_access_entry.access_level = "read"
+
+        kb_model = MagicMock()
+        kb_model.id = 1
+        kb_model.name = "Sales KB"
+        kb_model.slug = "sales"
+
+        mock_db.execute = AsyncMock(
+            side_effect=[
+                # Key lookup
+                _mock_scalar_result(key_row),
+                # KB access entries
+                _mock_scalars_result([kb_access_entry]),
+                # KB details lookup
+                _mock_scalars_result([kb_model]),
+            ]
+        )
+
+        with patch("app.api.admin_integrations._get_caller_org", return_value=("admin-user-123", mock_org, admin_user)):
+            result = await get_integration_detail(
+                integration_id="uuid-1", credentials=mock_credentials, db=mock_db
+            )
+
+        assert result.name == "Partner A"
+        assert len(result.kb_access) == 1
+        assert result.kb_access[0]["kb_id"] == 1
+        assert result.kb_access[0]["kb_name"] == "Sales KB"
+        assert result.kb_access[0]["access_level"] == "read"
+
+    @pytest.mark.asyncio
+    async def test_detail_not_found_returns_404(
+        self, mock_db, mock_credentials, admin_user, mock_org
+    ):
+        """Integration not in org -> 404."""
+        from app.api.admin_integrations import get_integration_detail
+
+        mock_db.execute = AsyncMock(return_value=_mock_scalar_result(None))
+
+        with patch("app.api.admin_integrations._get_caller_org", return_value=("admin-user-123", mock_org, admin_user)):
+            with pytest.raises(HTTPException) as exc_info:
+                await get_integration_detail(
+                    integration_id="nonexistent", credentials=mock_credentials, db=mock_db
+                )
+            assert exc_info.value.status_code == 404
+
+
+# ===========================================================================
+# TASK-013: PATCH /api/integrations/{id}
+# ===========================================================================
+
+
+class TestUpdateIntegration:
+    """PATCH /api/integrations/{id} — REQ-6.5."""
+
+    @pytest.mark.asyncio
+    async def test_patch_partial_fields_works(
+        self, mock_db, mock_credentials, admin_user, mock_org
+    ):
+        """REQ-6.5: Partial update of name/description."""
+        from app.api.admin_integrations import UpdateIntegrationRequest, update_integration
+
+        key_row = MagicMock()
+        key_row.id = "uuid-1"
+        key_row.org_id = 42
+        key_row.name = "Old Name"
+        key_row.description = "Old Desc"
+        key_row.key_prefix = "pk_live_abcd"
+        key_row.permissions = {"chat": True, "feedback": False, "knowledge_append": False}
+        key_row.active = True
+        key_row.rate_limit_rpm = 60
+        key_row.last_used_at = None
+        key_row.created_at = "2026-01-01T00:00:00Z"
+        key_row.created_by = "admin-user-123"
+
+        mock_db.execute = AsyncMock(return_value=_mock_scalar_result(key_row))
+
+        body = UpdateIntegrationRequest(name="New Name")
+
+        with (
+            patch("app.api.admin_integrations._get_caller_org", return_value=("admin-user-123", mock_org, admin_user)),
+            patch("app.api.admin_integrations.emit_event") as mock_emit,
+        ):
+            await update_integration(
+                integration_id="uuid-1", body=body, credentials=mock_credentials, db=mock_db
+            )
+
+        assert key_row.name == "New Name"
+        mock_emit.assert_called_once()
+        assert mock_emit.call_args[0][0] == "integration.updated"
+
+    @pytest.mark.asyncio
+    async def test_patch_kb_access_replaces_rows_atomically(
+        self, mock_db, mock_credentials, admin_user, mock_org
+    ):
+        """REQ-6.5: kb_access update deletes old rows and inserts new ones."""
+        from app.api.admin_integrations import UpdateIntegrationRequest, update_integration
+
+        key_row = MagicMock()
+        key_row.id = "uuid-1"
+        key_row.org_id = 42
+        key_row.name = "Partner"
+        key_row.description = None
+        key_row.key_prefix = "pk_live_abcd"
+        key_row.permissions = {"chat": True, "feedback": False, "knowledge_append": False}
+        key_row.active = True
+        key_row.rate_limit_rpm = 60
+        key_row.last_used_at = None
+        key_row.created_at = "2026-01-01T00:00:00Z"
+        key_row.created_by = "admin-user-123"
+
+        mock_kb = MagicMock()
+        mock_kb.id = 2
+
+        mock_db.execute = AsyncMock(
+            side_effect=[
+                # Key lookup
+                _mock_scalar_result(key_row),
+                # KB validation
+                _mock_scalars_result([mock_kb]),
+                # DELETE old kb_access
+                MagicMock(),
+                # (inserts happen via db.add)
+            ]
+        )
+
+        body = UpdateIntegrationRequest(
+            kb_access=[{"kb_id": 2, "access_level": "read_write"}]
+        )
+
+        with (
+            patch("app.api.admin_integrations._get_caller_org", return_value=("admin-user-123", mock_org, admin_user)),
+            patch("app.api.admin_integrations.emit_event"),
+        ):
+            await update_integration(
+                integration_id="uuid-1", body=body, credentials=mock_credentials, db=mock_db
+            )
+
+        # db.add should have been called for the new kb_access row
+        mock_db.add.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_patch_revoked_key_active_true_returns_400(
+        self, mock_db, mock_credentials, admin_user, mock_org
+    ):
+        """Cannot set active=true on a revoked key -> 400."""
+        from app.api.admin_integrations import UpdateIntegrationRequest, update_integration
+
+        key_row = MagicMock()
+        key_row.id = "uuid-1"
+        key_row.org_id = 42
+        key_row.active = False  # revoked
+
+        mock_db.execute = AsyncMock(return_value=_mock_scalar_result(key_row))
+
+        # The SPEC says no setting active=true on revoked key
+        # UpdateIntegrationRequest should not even support active field,
+        # but we test that revoked keys cannot be reactivated via PATCH
+        body = UpdateIntegrationRequest(name="Try Reactivate")
+
+        with patch("app.api.admin_integrations._get_caller_org", return_value=("admin-user-123", mock_org, admin_user)):
+            with pytest.raises(HTTPException) as exc_info:
+                await update_integration(
+                    integration_id="uuid-1", body=body, credentials=mock_credentials, db=mock_db
+                )
+            assert exc_info.value.status_code == 400
+
+
+# ===========================================================================
+# TASK-013: POST /api/integrations/{id}/revoke
+# ===========================================================================
+
+
+class TestRevokeIntegration:
+    """POST /api/integrations/{id}/revoke — REQ-6.6."""
+
+    @pytest.mark.asyncio
+    async def test_revoke_sets_active_false(
+        self, mock_db, mock_credentials, admin_user, mock_org
+    ):
+        """REQ-6.6: Revoke sets active=false."""
+        from app.api.admin_integrations import revoke_integration
+
+        key_row = MagicMock()
+        key_row.id = "uuid-1"
+        key_row.org_id = 42
+        key_row.name = "Partner"
+        key_row.description = None
+        key_row.key_prefix = "pk_live_abcd"
+        key_row.permissions = {"chat": True, "feedback": False, "knowledge_append": False}
+        key_row.active = True
+        key_row.rate_limit_rpm = 60
+        key_row.last_used_at = None
+        key_row.created_at = "2026-01-01T00:00:00Z"
+        key_row.created_by = "admin-user-123"
+
+        mock_db.execute = AsyncMock(return_value=_mock_scalar_result(key_row))
+
+        with (
+            patch("app.api.admin_integrations._get_caller_org", return_value=("admin-user-123", mock_org, admin_user)),
+            patch("app.api.admin_integrations.emit_event") as mock_emit,
+        ):
+            await revoke_integration(
+                integration_id="uuid-1", credentials=mock_credentials, db=mock_db
+            )
+
+        assert key_row.active is False
+        mock_emit.assert_called_once()
+        assert mock_emit.call_args[0][0] == "integration.revoked"
+
+    @pytest.mark.asyncio
+    async def test_revoke_already_revoked_returns_400(
+        self, mock_db, mock_credentials, admin_user, mock_org
+    ):
+        """Revoking an already-revoked key -> 400."""
+        from app.api.admin_integrations import revoke_integration
+
+        key_row = MagicMock()
+        key_row.id = "uuid-1"
+        key_row.org_id = 42
+        key_row.active = False  # already revoked
+
+        mock_db.execute = AsyncMock(return_value=_mock_scalar_result(key_row))
+
+        with patch("app.api.admin_integrations._get_caller_org", return_value=("admin-user-123", mock_org, admin_user)):
+            with pytest.raises(HTTPException) as exc_info:
+                await revoke_integration(
+                    integration_id="uuid-1", credentials=mock_credentials, db=mock_db
+                )
+            assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_revoke_emits_product_event(
+        self, mock_db, mock_credentials, admin_user, mock_org
+    ):
+        """REQ-6.7: integration.revoked event emitted."""
+        from app.api.admin_integrations import revoke_integration
+
+        key_row = MagicMock()
+        key_row.id = "uuid-1"
+        key_row.org_id = 42
+        key_row.name = "Partner"
+        key_row.description = None
+        key_row.key_prefix = "pk_live_abcd"
+        key_row.permissions = {"chat": True, "feedback": False, "knowledge_append": False}
+        key_row.active = True
+        key_row.rate_limit_rpm = 60
+        key_row.last_used_at = None
+        key_row.created_at = "2026-01-01T00:00:00Z"
+        key_row.created_by = "admin-user-123"
+
+        mock_db.execute = AsyncMock(return_value=_mock_scalar_result(key_row))
+
+        with (
+            patch("app.api.admin_integrations._get_caller_org", return_value=("admin-user-123", mock_org, admin_user)),
+            patch("app.api.admin_integrations.emit_event") as mock_emit,
+        ):
+            await revoke_integration(
+                integration_id="uuid-1", credentials=mock_credentials, db=mock_db
+            )
+
+        mock_emit.assert_called_once()
+        assert mock_emit.call_args[0][0] == "integration.revoked"
+        assert mock_emit.call_args[1]["org_id"] == 42

--- a/klai-portal/backend/tests/test_partner_chat.py
+++ b/klai-portal/backend/tests/test_partner_chat.py
@@ -1,0 +1,468 @@
+"""RED: Verify POST /partner/v1/chat/completions.
+
+SPEC-API-001 TASK-008 + TASK-009:
+- Model validation (only klai-primary, klai-fast allowed)
+- Messages validation (non-empty, at least one user message)
+- KB out-of-scope -> 403
+- Retrieval timeout -> 502
+- Happy path non-streaming returns OpenAI-shaped JSON
+- Retrieval log scheduled as async task
+- kb_id -> kb_slug translation
+- Streaming returns text/event-stream with SSE chunks
+"""
+
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from fastapi import HTTPException
+
+
+@dataclass
+class FakeKB:
+    """Mimics a PortalKnowledgeBase row."""
+
+    id: int
+    name: str
+    slug: str
+    org_id: int
+
+
+def _make_auth(permissions: dict | None = None, kb_access: dict | None = None):
+    """Create a PartnerAuthContext for testing."""
+    from app.api.partner_dependencies import PartnerAuthContext
+
+    return PartnerAuthContext(
+        key_id="key-uuid-1",
+        org_id=42,
+        zitadel_org_id="zit-org-42",
+        permissions=permissions or {"chat": True, "feedback": True, "knowledge_append": False},
+        kb_access=kb_access or {10: "read", 20: "read_write"},
+        rate_limit_rpm=60,
+    )
+
+
+def _mock_scalars_all(values):
+    result = MagicMock()
+    scalars = MagicMock()
+    scalars.all.return_value = values
+    result.scalars.return_value = scalars
+    return result
+
+
+# ---------------------------------------------------------------------------
+# TASK-008: Non-streaming chat completions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invalid_model_returns_400():
+    """Model must be klai-primary or klai-fast; anything else -> 400."""
+    from app.api.partner import ChatCompletionsRequest, chat_completions
+
+    auth = _make_auth()
+    db = AsyncMock()
+
+    req = ChatCompletionsRequest(
+        messages=[{"role": "user", "content": "Hello"}],
+        model="gpt-4",
+        stream=False,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await chat_completions(request=req, auth=auth, db=db)
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_empty_messages_returns_400():
+    """Empty messages list -> rejected by Pydantic (min_length=1)."""
+    from pydantic import ValidationError
+
+    from app.api.partner import ChatCompletionsRequest
+
+    with pytest.raises(ValidationError):
+        ChatCompletionsRequest(
+            messages=[],
+            model="klai-primary",
+            stream=False,
+        )
+
+
+@pytest.mark.asyncio
+async def test_messages_only_system_role_returns_400():
+    """Messages with only system role and no user message -> 400."""
+    from app.api.partner import ChatCompletionsRequest, chat_completions
+
+    auth = _make_auth()
+    db = AsyncMock()
+
+    req = ChatCompletionsRequest(
+        messages=[{"role": "system", "content": "You are helpful"}],
+        model="klai-primary",
+        stream=False,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await chat_completions(request=req, auth=auth, db=db)
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_kb_out_of_scope_returns_403():
+    """Requesting a KB not in key scope -> 403."""
+    from app.api.partner import ChatCompletionsRequest, chat_completions
+
+    auth = _make_auth(kb_access={10: "read"})
+    db = AsyncMock()
+
+    req = ChatCompletionsRequest(
+        messages=[{"role": "user", "content": "Hello"}],
+        model="klai-primary",
+        stream=False,
+        knowledge_base_ids=[99],  # not in scope
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await chat_completions(request=req, auth=auth, db=db)
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_retrieval_timeout_returns_502():
+    """Retrieval-api timeout -> 502 Bad Gateway."""
+    from app.api.partner import ChatCompletionsRequest, chat_completions
+
+    auth = _make_auth(kb_access={10: "read"})
+    fake_kbs = [FakeKB(id=10, name="KB Alpha", slug="kb-alpha", org_id=42)]
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_mock_scalars_all(fake_kbs))
+
+    req = ChatCompletionsRequest(
+        messages=[{"role": "user", "content": "Hello"}],
+        model="klai-primary",
+        stream=False,
+    )
+
+    with (
+        patch(
+            "app.api.partner.retrieve_context",
+            side_effect=httpx.ReadTimeout("timeout"),
+        ),
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await chat_completions(request=req, auth=auth, db=db)
+    assert exc_info.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_happy_path_non_streaming():
+    """Non-streaming: returns OpenAI-shaped JSON with choices."""
+    from app.api.partner import ChatCompletionsRequest, chat_completions
+
+    auth = _make_auth(kb_access={10: "read"})
+    fake_kbs = [FakeKB(id=10, name="KB Alpha", slug="kb-alpha", org_id=42)]
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_mock_scalars_all(fake_kbs))
+
+    req = ChatCompletionsRequest(
+        messages=[{"role": "user", "content": "Hello"}],
+        model="klai-primary",
+        stream=False,
+    )
+
+    mock_chunks = [{"chunk_id": "c1", "text": "context"}]
+    mock_system_prompt = "You are a helpful assistant.\n\nContext:\ncontext"
+
+    litellm_response = {
+        "id": "chatcmpl-123",
+        "object": "chat.completion",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "Hi there!"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+
+    with (
+        patch(
+            "app.api.partner.retrieve_context",
+            return_value=(mock_chunks, mock_system_prompt),
+        ),
+        patch(
+            "app.api.partner.chat_completion_non_streaming",
+            return_value=litellm_response,
+        ),
+        patch("app.api.partner.asyncio") as mock_asyncio,
+    ):
+        result = await chat_completions(request=req, auth=auth, db=db)
+
+    assert result["id"] == "chatcmpl-123"
+    assert result["choices"][0]["message"]["content"] == "Hi there!"
+
+
+@pytest.mark.asyncio
+async def test_retrieval_log_scheduled():
+    """Retrieval log is scheduled as fire-and-forget asyncio.create_task."""
+    from app.api.partner import ChatCompletionsRequest, chat_completions
+
+    auth = _make_auth(kb_access={10: "read"})
+    fake_kbs = [FakeKB(id=10, name="KB Alpha", slug="kb-alpha", org_id=42)]
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_mock_scalars_all(fake_kbs))
+
+    req = ChatCompletionsRequest(
+        messages=[{"role": "user", "content": "Hello"}],
+        model="klai-primary",
+        stream=False,
+    )
+
+    mock_chunks = [{"chunk_id": "c1", "text": "context", "reranker_score": 0.9}]
+    mock_system_prompt = "system prompt"
+
+    litellm_response = {
+        "id": "chatcmpl-123",
+        "object": "chat.completion",
+        "choices": [{"index": 0, "message": {"role": "assistant", "content": "Hi"}, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+
+    with (
+        patch(
+            "app.api.partner.retrieve_context",
+            return_value=(mock_chunks, mock_system_prompt),
+        ),
+        patch(
+            "app.api.partner.chat_completion_non_streaming",
+            return_value=litellm_response,
+        ),
+        patch("app.api.partner.asyncio") as mock_asyncio,
+    ):
+        await chat_completions(request=req, auth=auth, db=db)
+
+    # create_task was called to schedule the retrieval log
+    mock_asyncio.create_task.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_kb_id_to_slug_translation():
+    """kb_ids are translated to kb_slugs via DB lookup before retrieval."""
+    from app.api.partner import ChatCompletionsRequest, chat_completions
+
+    auth = _make_auth(kb_access={10: "read", 20: "read_write"})
+    fake_kbs = [
+        FakeKB(id=10, name="KB Alpha", slug="kb-alpha", org_id=42),
+        FakeKB(id=20, name="KB Beta", slug="kb-beta", org_id=42),
+    ]
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_mock_scalars_all(fake_kbs))
+
+    req = ChatCompletionsRequest(
+        messages=[{"role": "user", "content": "Hello"}],
+        model="klai-primary",
+        stream=False,
+        knowledge_base_ids=[10, 20],
+    )
+
+    mock_chunks = []
+    mock_system_prompt = "system prompt"
+
+    litellm_response = {
+        "id": "chatcmpl-123",
+        "object": "chat.completion",
+        "choices": [{"index": 0, "message": {"role": "assistant", "content": "Hi"}, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+
+    with (
+        patch(
+            "app.api.partner.retrieve_context",
+            return_value=(mock_chunks, mock_system_prompt),
+        ) as mock_retrieve,
+        patch(
+            "app.api.partner.chat_completion_non_streaming",
+            return_value=litellm_response,
+        ),
+        patch("app.api.partner.asyncio"),
+    ):
+        await chat_completions(request=req, auth=auth, db=db)
+
+    # Verify retrieve_context was called with slugs, not IDs
+    call_kwargs = mock_retrieve.call_args
+    kb_slugs_arg = call_kwargs[1].get("kb_slugs") or call_kwargs[0][2]
+    assert set(kb_slugs_arg) == {"kb-alpha", "kb-beta"}
+
+
+# ---------------------------------------------------------------------------
+# TASK-009: Streaming chat completions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_streaming_returns_event_stream_content_type():
+    """Streaming response has content-type text/event-stream."""
+    from app.api.partner import ChatCompletionsRequest, chat_completions
+
+    auth = _make_auth(kb_access={10: "read"})
+    fake_kbs = [FakeKB(id=10, name="KB Alpha", slug="kb-alpha", org_id=42)]
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_mock_scalars_all(fake_kbs))
+
+    req = ChatCompletionsRequest(
+        messages=[{"role": "user", "content": "Hello"}],
+        model="klai-primary",
+        stream=True,
+    )
+
+    mock_chunks = [{"chunk_id": "c1", "text": "context"}]
+    mock_system_prompt = "system prompt"
+
+    async def mock_streaming_gen():
+        yield b"data: {}\n\n"
+        yield b"data: [DONE]\n\n"
+
+    with (
+        patch(
+            "app.api.partner.retrieve_context",
+            return_value=(mock_chunks, mock_system_prompt),
+        ),
+        patch(
+            "app.api.partner.chat_completion_streaming",
+            return_value=mock_streaming_gen(),
+        ),
+        patch("app.api.partner.asyncio"),
+    ):
+        from starlette.responses import StreamingResponse
+
+        result = await chat_completions(request=req, auth=auth, db=db)
+        assert isinstance(result, StreamingResponse)
+        assert result.media_type == "text/event-stream"
+
+
+@pytest.mark.asyncio
+async def test_streaming_chunks_forwarded():
+    """Mock LiteLLM streaming chunks are forwarded byte-for-byte."""
+    from app.api.partner import ChatCompletionsRequest, chat_completions
+
+    auth = _make_auth(kb_access={10: "read"})
+    fake_kbs = [FakeKB(id=10, name="KB Alpha", slug="kb-alpha", org_id=42)]
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_mock_scalars_all(fake_kbs))
+
+    req = ChatCompletionsRequest(
+        messages=[{"role": "user", "content": "Hello"}],
+        model="klai-primary",
+        stream=True,
+    )
+
+    mock_chunks_data = [{"chunk_id": "c1", "text": "context"}]
+    mock_system_prompt = "system prompt"
+
+    expected_bytes = [
+        b'data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n',
+        b"data: [DONE]\n\n",
+    ]
+
+    async def mock_streaming_gen():
+        for chunk in expected_bytes:
+            yield chunk
+
+    with (
+        patch(
+            "app.api.partner.retrieve_context",
+            return_value=(mock_chunks_data, mock_system_prompt),
+        ),
+        patch(
+            "app.api.partner.chat_completion_streaming",
+            return_value=mock_streaming_gen(),
+        ),
+        patch("app.api.partner.asyncio"),
+    ):
+        result = await chat_completions(request=req, auth=auth, db=db)
+
+        # Collect streamed bytes
+        received = []
+        async for chunk in result.body_iterator:
+            received.append(chunk)
+
+        assert len(received) == 2
+        assert b"[DONE]" in received[-1]
+
+
+@pytest.mark.asyncio
+async def test_streaming_done_terminator():
+    """[DONE] terminator is present in streaming output."""
+    from app.api.partner import ChatCompletionsRequest, chat_completions
+
+    auth = _make_auth(kb_access={10: "read"})
+    fake_kbs = [FakeKB(id=10, name="KB Alpha", slug="kb-alpha", org_id=42)]
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_mock_scalars_all(fake_kbs))
+
+    req = ChatCompletionsRequest(
+        messages=[{"role": "user", "content": "Hello"}],
+        model="klai-primary",
+        stream=True,
+    )
+
+    async def mock_streaming_gen():
+        yield b'data: {"choices":[{"delta":{"content":"Hi"}}]}\n\n'
+        yield b"data: [DONE]\n\n"
+
+    with (
+        patch(
+            "app.api.partner.retrieve_context",
+            return_value=([], "prompt"),
+        ),
+        patch(
+            "app.api.partner.chat_completion_streaming",
+            return_value=mock_streaming_gen(),
+        ),
+        patch("app.api.partner.asyncio"),
+    ):
+        result = await chat_completions(request=req, auth=auth, db=db)
+
+        all_bytes = b""
+        async for chunk in result.body_iterator:
+            all_bytes += chunk
+
+        assert b"[DONE]" in all_bytes
+
+
+@pytest.mark.asyncio
+async def test_streaming_retrieval_log_fires():
+    """Retrieval log fires even on streaming path."""
+    from app.api.partner import ChatCompletionsRequest, chat_completions
+
+    auth = _make_auth(kb_access={10: "read"})
+    fake_kbs = [FakeKB(id=10, name="KB Alpha", slug="kb-alpha", org_id=42)]
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_mock_scalars_all(fake_kbs))
+
+    req = ChatCompletionsRequest(
+        messages=[{"role": "user", "content": "Hello"}],
+        model="klai-primary",
+        stream=True,
+    )
+
+    async def mock_streaming_gen():
+        yield b"data: [DONE]\n\n"
+
+    with (
+        patch(
+            "app.api.partner.retrieve_context",
+            return_value=([{"chunk_id": "c1"}], "prompt"),
+        ),
+        patch(
+            "app.api.partner.chat_completion_streaming",
+            return_value=mock_streaming_gen(),
+        ),
+        patch("app.api.partner.asyncio") as mock_asyncio,
+    ):
+        await chat_completions(request=req, auth=auth, db=db)
+
+    mock_asyncio.create_task.assert_called_once()

--- a/klai-portal/backend/tests/test_partner_feedback.py
+++ b/klai-portal/backend/tests/test_partner_feedback.py
@@ -1,0 +1,164 @@
+"""RED: Verify POST /partner/v1/feedback.
+
+SPEC-API-001 TASK-010:
+- Rating validation (only thumbsUp/thumbsDown)
+- Feedback permission denied -> 403
+- Correlated case -> quality update scheduled
+- Uncorrelated case -> no quality update
+- Idempotent duplicate -> 200 without new row
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+
+def _make_auth(permissions: dict | None = None, kb_access: dict | None = None):
+    """Create a PartnerAuthContext for testing."""
+    from app.api.partner_dependencies import PartnerAuthContext
+
+    return PartnerAuthContext(
+        key_id="key-uuid-1",
+        org_id=42,
+        zitadel_org_id="zit-org-42",
+        permissions=permissions or {"chat": True, "feedback": True, "knowledge_append": False},
+        kb_access=kb_access or {10: "read"},
+        rate_limit_rpm=60,
+    )
+
+
+@pytest.mark.asyncio
+async def test_rating_validation():
+    """Rating must be thumbsUp or thumbsDown — Pydantic rejects other values."""
+    from pydantic import ValidationError
+
+    from app.api.partner import PartnerFeedbackRequest
+
+    with pytest.raises(ValidationError):
+        PartnerFeedbackRequest(
+            message_id="msg-1",
+            rating="invalid",
+        )
+
+
+@pytest.mark.asyncio
+async def test_feedback_permission_denied():
+    """No feedback permission -> 403."""
+    from app.api.partner import PartnerFeedbackRequest, submit_feedback
+
+    auth = _make_auth(permissions={"chat": True, "feedback": False, "knowledge_append": False})
+    db = AsyncMock()
+
+    req = PartnerFeedbackRequest(
+        message_id="msg-1",
+        rating="thumbsUp",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await submit_feedback(request=req, auth=auth, db=db)
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_correlated_feedback_schedules_quality_update():
+    """Correlated feedback: retrieval log found -> quality update scheduled."""
+    from app.api.partner import PartnerFeedbackRequest, submit_feedback
+
+    auth = _make_auth()
+    mock_redis = AsyncMock()
+    mock_redis.get = AsyncMock(return_value=None)  # no idempotency key
+    mock_redis.set = AsyncMock()
+
+    db = AsyncMock()
+    db.execute = AsyncMock()
+    db.commit = AsyncMock()
+
+    correlated_log = {
+        "chunk_ids": ["c1", "c2"],
+        "reranker_scores": [0.9, 0.8],
+        "query_resolved": "test",
+        "embedding_model_version": "bge-m3-v1",
+    }
+
+    req = PartnerFeedbackRequest(
+        message_id="msg-1",
+        rating="thumbsUp",
+    )
+
+    with (
+        patch("app.api.partner.get_redis_pool", return_value=mock_redis),
+        patch("app.api.partner.find_correlated_log", return_value=correlated_log),
+        patch("app.api.partner.schedule_quality_update") as mock_schedule,
+        patch("app.api.partner.emit_event") as mock_emit,
+    ):
+        result = await submit_feedback(request=req, auth=auth, db=db)
+
+    assert result == {"ok": True}
+    mock_schedule.assert_called_once_with(["c1", "c2"], "thumbsUp", 42)
+    mock_emit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_uncorrelated_feedback_no_quality_update():
+    """Uncorrelated: no retrieval log -> no quality update, event still emitted."""
+    from app.api.partner import PartnerFeedbackRequest, submit_feedback
+
+    auth = _make_auth()
+    mock_redis = AsyncMock()
+    mock_redis.get = AsyncMock(return_value=None)
+    mock_redis.set = AsyncMock()
+
+    db = AsyncMock()
+    db.execute = AsyncMock()
+    db.commit = AsyncMock()
+
+    req = PartnerFeedbackRequest(
+        message_id="msg-2",
+        rating="thumbsDown",
+    )
+
+    with (
+        patch("app.api.partner.get_redis_pool", return_value=mock_redis),
+        patch("app.api.partner.find_correlated_log", return_value=None),
+        patch("app.api.partner.schedule_quality_update") as mock_schedule,
+        patch("app.api.partner.emit_event") as mock_emit,
+    ):
+        result = await submit_feedback(request=req, auth=auth, db=db)
+
+    assert result == {"ok": True}
+    mock_schedule.assert_not_called()
+    mock_emit.assert_called_once()
+    emit_kwargs = mock_emit.call_args[1]
+    assert emit_kwargs["properties"]["correlated"] is False
+
+
+@pytest.mark.asyncio
+async def test_idempotent_duplicate_returns_200():
+    """Duplicate message_id -> 200 without inserting new row."""
+    from app.api.partner import PartnerFeedbackRequest, submit_feedback
+
+    auth = _make_auth()
+    mock_redis = AsyncMock()
+    mock_redis.get = AsyncMock(return_value="1")  # idempotency key exists
+
+    db = AsyncMock()
+    db.execute = AsyncMock()
+    db.commit = AsyncMock()
+
+    req = PartnerFeedbackRequest(
+        message_id="msg-1",
+        rating="thumbsUp",
+    )
+
+    with (
+        patch("app.api.partner.get_redis_pool", return_value=mock_redis),
+    ):
+        from starlette.responses import Response as StarletteResponse
+
+        result = await submit_feedback(request=req, auth=auth, db=db)
+        assert isinstance(result, StarletteResponse)
+        assert result.status_code == 200
+
+    # No DB write
+    db.commit.assert_not_called()

--- a/klai-portal/backend/tests/test_partner_knowledge.py
+++ b/klai-portal/backend/tests/test_partner_knowledge.py
@@ -1,0 +1,167 @@
+"""RED: Verify POST /partner/v1/knowledge.
+
+SPEC-API-001 TASK-011:
+- knowledge_append permission missing -> 403
+- KB not in scope -> 403
+- KB in scope but only read level -> 403
+- Content > 10MB -> 413
+- Happy path proxies to ingest-api and returns mapped response
+"""
+
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+
+@dataclass
+class FakeKB:
+    """Mimics a PortalKnowledgeBase row."""
+
+    id: int
+    name: str
+    slug: str
+    org_id: int
+
+
+def _make_auth(permissions: dict | None = None, kb_access: dict | None = None):
+    """Create a PartnerAuthContext for testing."""
+    from app.api.partner_dependencies import PartnerAuthContext
+
+    return PartnerAuthContext(
+        key_id="key-uuid-1",
+        org_id=42,
+        zitadel_org_id="zit-org-42",
+        permissions=permissions or {"chat": True, "feedback": True, "knowledge_append": True},
+        kb_access=kb_access or {10: "read_write"},
+        rate_limit_rpm=60,
+    )
+
+
+def _mock_scalars_all(values):
+    result = MagicMock()
+    scalars = MagicMock()
+    scalars.all.return_value = values
+    result.scalars.return_value = scalars
+    return result
+
+
+def _mock_scalar_one_or_none(value):
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = value
+    return result
+
+
+@pytest.mark.asyncio
+async def test_knowledge_append_permission_missing():
+    """knowledge_append permission not set -> 403."""
+    from app.api.partner import PartnerKnowledgeRequest, append_knowledge
+
+    auth = _make_auth(
+        permissions={"chat": True, "feedback": True, "knowledge_append": False},
+        kb_access={10: "read_write"},
+    )
+    db = AsyncMock()
+
+    req = PartnerKnowledgeRequest(
+        kb_id=10,
+        content="Some content",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await append_knowledge(request=req, auth=auth, db=db)
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_kb_not_in_scope():
+    """KB not in key's scope -> 403."""
+    from app.api.partner import PartnerKnowledgeRequest, append_knowledge
+
+    auth = _make_auth(kb_access={10: "read_write"})
+    db = AsyncMock()
+
+    req = PartnerKnowledgeRequest(
+        kb_id=99,  # not in scope
+        content="Some content",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await append_knowledge(request=req, auth=auth, db=db)
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_kb_read_only_returns_403():
+    """KB in scope but only read level -> 403."""
+    from app.api.partner import PartnerKnowledgeRequest, append_knowledge
+
+    auth = _make_auth(kb_access={10: "read"})  # only read, not read_write
+    db = AsyncMock()
+
+    req = PartnerKnowledgeRequest(
+        kb_id=10,
+        content="Some content",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await append_knowledge(request=req, auth=auth, db=db)
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_content_too_large_returns_413():
+    """Content > 10MB -> 413 (validated by Pydantic max_length on the request model)."""
+    from pydantic import ValidationError
+
+    from app.api.partner import PartnerKnowledgeRequest
+
+    # 10MB + 1 byte
+    with pytest.raises(ValidationError):
+        PartnerKnowledgeRequest(
+            kb_id=10,
+            content="x" * (10_485_760 + 1),
+        )
+
+
+@pytest.mark.asyncio
+async def test_happy_path_proxies_to_ingest():
+    """Happy path: proxies to ingest-api and returns mapped response."""
+    from app.api.partner import PartnerKnowledgeRequest, append_knowledge
+
+    auth = _make_auth(kb_access={10: "read_write"})
+    fake_kb = FakeKB(id=10, name="KB Alpha", slug="kb-alpha", org_id=42)
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_mock_scalar_one_or_none(fake_kb))
+
+    req = PartnerKnowledgeRequest(
+        kb_id=10,
+        title="My Document",
+        content="Document content here",
+        source_type="partner_api",
+        content_type="text/plain",
+    )
+
+    ingest_response = {
+        "artifact_id": "art-123",
+        "chunks_created": 3,
+        "status": "ingested",
+    }
+
+    with patch(
+        "app.services.partner_knowledge.ingest_knowledge",
+        return_value=ingest_response,
+    ) as mock_ingest:
+        result = await append_knowledge(request=req, auth=auth, db=db)
+
+    assert result["knowledge_id"] == "art-123"
+    assert result["chunks_created"] == 3
+    assert result["status"] == "ingested"
+
+    # Verify ingest was called with correct slug
+    mock_ingest.assert_called_once()
+    call_kwargs = mock_ingest.call_args[1]
+    assert call_kwargs["kb_slug"] == "kb-alpha"
+    assert call_kwargs["zitadel_org_id"] == "zit-org-42"

--- a/klai-portal/frontend/messages/en.json
+++ b/klai-portal/frontend/messages/en.json
@@ -1367,5 +1367,66 @@
   "admin_billing_placeholder_zipcode": "1234 AB",
   "admin_billing_placeholder_city": "Amsterdam",
   "admin_billing_placeholder_tax_number": "NL123456789B01",
-  "session_token_expiring": "Session is being renewed..."
+  "session_token_expiring": "Session is being renewed...",
+
+  "admin_nav_integrations": "Integrations",
+  "admin_section_integrations_title": "Integrations",
+  "admin_section_integrations_description": "Manage partner API keys and external integrations.",
+
+  "admin_integrations_title": "Integrations",
+  "admin_integrations_create": "New integration",
+  "admin_integrations_create_submit": "Create integration",
+  "admin_integrations_loading": "Loading...",
+  "admin_integrations_empty": "No integrations yet",
+  "admin_integrations_empty_description": "Create an integration to let external partners access your knowledge bases via API.",
+  "admin_integrations_error_generic": "Something went wrong. Please try again.",
+
+  "admin_integrations_col_name": "Name",
+  "admin_integrations_col_key_prefix": "Key prefix",
+  "admin_integrations_col_status": "Status",
+  "admin_integrations_col_kb_access": "KB access",
+  "admin_integrations_col_last_used": "Last used",
+  "admin_integrations_view_detail": "View",
+
+  "admin_integrations_status_active": "Active",
+  "admin_integrations_status_revoked": "Revoked",
+
+  "admin_integrations_section_basics": "Basics",
+  "admin_integrations_section_permissions": "Permissions",
+  "admin_integrations_section_kb_access": "Knowledge base access",
+  "admin_integrations_section_rate_limit": "Rate limit",
+
+  "admin_integrations_field_name": "Name",
+  "admin_integrations_field_description": "Description",
+  "admin_integrations_field_rate_limit": "Requests per minute",
+  "admin_integrations_rate_limit_unit": "requests/min",
+
+  "admin_integrations_perm_chat": "Chat completions",
+  "admin_integrations_perm_feedback": "Feedback",
+  "admin_integrations_perm_knowledge_append": "Knowledge append",
+
+  "admin_integrations_kb_name": "Knowledge base",
+  "admin_integrations_kb_none": "None",
+  "admin_integrations_kb_read": "Read",
+  "admin_integrations_kb_read_write": "Read + Write",
+  "admin_integrations_kb_read_write_disabled_hint": "Enable the Knowledge append permission to allow write access",
+  "admin_integrations_kb_empty": "No knowledge bases found in this organisation.",
+
+  "admin_integrations_key_modal_title": "API key created",
+  "admin_integrations_key_modal_warning": "This key will only be shown once. Copy it now.",
+  "admin_integrations_key_modal_description": "Store this key in a safe place. You will not be able to view it again after closing this dialog.",
+  "admin_integrations_key_modal_confirm": "I have saved the key",
+
+  "admin_integrations_save": "Save changes",
+  "admin_integrations_success_updated": "Integration updated",
+  "admin_integrations_success_revoked": "Integration revoked",
+
+  "admin_integrations_revoke_section_title": "Danger zone",
+  "admin_integrations_revoke_section_description": "Revoking this integration will immediately invalidate the API key. This cannot be undone.",
+  "admin_integrations_revoke_button": "Revoke integration",
+  "admin_integrations_revoke_title": "Revoke integration",
+  "admin_integrations_revoke_description": "Are you sure? The API key will stop working immediately. This action cannot be undone.",
+  "admin_integrations_revoke_confirm": "Revoke",
+
+  "admin_integrations_view_logs": "View logs in Grafana"
 }

--- a/klai-portal/frontend/messages/nl.json
+++ b/klai-portal/frontend/messages/nl.json
@@ -1367,5 +1367,66 @@
   "admin_billing_placeholder_zipcode": "1234 AB",
   "admin_billing_placeholder_city": "Amsterdam",
   "admin_billing_placeholder_tax_number": "NL123456789B01",
-  "session_token_expiring": "Sessie wordt verlengd..."
+  "session_token_expiring": "Sessie wordt verlengd...",
+
+  "admin_nav_integrations": "Integraties",
+  "admin_section_integrations_title": "Integraties",
+  "admin_section_integrations_description": "Beheer partner API-sleutels en externe integraties.",
+
+  "admin_integrations_title": "Integraties",
+  "admin_integrations_create": "Nieuwe integratie",
+  "admin_integrations_create_submit": "Integratie aanmaken",
+  "admin_integrations_loading": "Laden...",
+  "admin_integrations_empty": "Nog geen integraties",
+  "admin_integrations_empty_description": "Maak een integratie aan zodat externe partners via API toegang krijgen tot je kennisbanken.",
+  "admin_integrations_error_generic": "Er is iets misgegaan. Probeer het opnieuw.",
+
+  "admin_integrations_col_name": "Naam",
+  "admin_integrations_col_key_prefix": "Sleutelprefix",
+  "admin_integrations_col_status": "Status",
+  "admin_integrations_col_kb_access": "KB-toegang",
+  "admin_integrations_col_last_used": "Laatst gebruikt",
+  "admin_integrations_view_detail": "Bekijk",
+
+  "admin_integrations_status_active": "Actief",
+  "admin_integrations_status_revoked": "Ingetrokken",
+
+  "admin_integrations_section_basics": "Basisgegevens",
+  "admin_integrations_section_permissions": "Rechten",
+  "admin_integrations_section_kb_access": "Kennisbanktoegang",
+  "admin_integrations_section_rate_limit": "Limiet",
+
+  "admin_integrations_field_name": "Naam",
+  "admin_integrations_field_description": "Beschrijving",
+  "admin_integrations_field_rate_limit": "Verzoeken per minuut",
+  "admin_integrations_rate_limit_unit": "verzoeken/min",
+
+  "admin_integrations_perm_chat": "Chatvervolledigingen",
+  "admin_integrations_perm_feedback": "Feedback",
+  "admin_integrations_perm_knowledge_append": "Kennis toevoegen",
+
+  "admin_integrations_kb_name": "Kennisbank",
+  "admin_integrations_kb_none": "Geen",
+  "admin_integrations_kb_read": "Lezen",
+  "admin_integrations_kb_read_write": "Lezen + Schrijven",
+  "admin_integrations_kb_read_write_disabled_hint": "Schakel de toestemming Kennis toevoegen in om schrijftoegang toe te staan",
+  "admin_integrations_kb_empty": "Geen kennisbanken gevonden in deze organisatie.",
+
+  "admin_integrations_key_modal_title": "API-sleutel aangemaakt",
+  "admin_integrations_key_modal_warning": "Deze sleutel wordt slechts eenmaal getoond. Kopieer hem nu.",
+  "admin_integrations_key_modal_description": "Bewaar deze sleutel op een veilige plek. Je kunt hem niet meer bekijken na het sluiten van dit venster.",
+  "admin_integrations_key_modal_confirm": "Ik heb de sleutel opgeslagen",
+
+  "admin_integrations_save": "Wijzigingen opslaan",
+  "admin_integrations_success_updated": "Integratie bijgewerkt",
+  "admin_integrations_success_revoked": "Integratie ingetrokken",
+
+  "admin_integrations_revoke_section_title": "Gevarenzone",
+  "admin_integrations_revoke_section_description": "Het intrekken van deze integratie maakt de API-sleutel onmiddellijk ongeldig. Dit kan niet ongedaan worden gemaakt.",
+  "admin_integrations_revoke_button": "Integratie intrekken",
+  "admin_integrations_revoke_title": "Integratie intrekken",
+  "admin_integrations_revoke_description": "Weet je het zeker? De API-sleutel stopt onmiddellijk met werken. Deze actie kan niet ongedaan worden gemaakt.",
+  "admin_integrations_revoke_confirm": "Intrekken",
+
+  "admin_integrations_view_logs": "Logs bekijken in Grafana"
 }

--- a/klai-portal/frontend/src/routeTree.gen.ts
+++ b/klai-portal/frontend/src/routeTree.gen.ts
@@ -38,6 +38,7 @@ import { Route as AppFocusIndexRouteImport } from './routes/app/focus/index'
 import { Route as AppDocsIndexRouteImport } from './routes/app/docs/index'
 import { Route as AdminUsersIndexRouteImport } from './routes/admin/users/index'
 import { Route as AdminMcpsIndexRouteImport } from './routes/admin/mcps/index'
+import { Route as AdminIntegrationsIndexRouteImport } from './routes/admin/integrations/index'
 import { Route as AdminGroupsIndexRouteImport } from './routes/admin/groups/index'
 import { Route as AppTranscribeAddRouteImport } from './routes/app/transcribe/add'
 import { Route as AppTranscribeTranscriptionIdRouteImport } from './routes/app/transcribe/$transcriptionId'
@@ -51,6 +52,8 @@ import { Route as AppDocsKbSlugRouteImport } from './routes/app/docs/$kbSlug'
 import { Route as AdminUsersInviteRouteImport } from './routes/admin/users/invite'
 import { Route as AdminMcpsNewRouteImport } from './routes/admin/mcps/new'
 import { Route as AdminMcpsServerIdRouteImport } from './routes/admin/mcps/$serverId'
+import { Route as AdminIntegrationsNewRouteImport } from './routes/admin/integrations/new'
+import { Route as AdminIntegrationsIdRouteImport } from './routes/admin/integrations/$id'
 import { Route as AdminGroupsNewRouteImport } from './routes/admin/groups/new'
 import { Route as LocalePasswordForgotRouteImport } from './routes/$locale/password/forgot'
 import { Route as AppKnowledgeKbSlugRouteRouteImport } from './routes/app/knowledge/$kbSlug/route'
@@ -217,6 +220,11 @@ const AdminMcpsIndexRoute = AdminMcpsIndexRouteImport.update({
   path: '/mcps/',
   getParentRoute: () => AdminRouteRoute,
 } as any)
+const AdminIntegrationsIndexRoute = AdminIntegrationsIndexRouteImport.update({
+  id: '/integrations/',
+  path: '/integrations/',
+  getParentRoute: () => AdminRouteRoute,
+} as any)
 const AdminGroupsIndexRoute = AdminGroupsIndexRouteImport.update({
   id: '/groups/',
   path: '/groups/',
@@ -285,6 +293,16 @@ const AdminMcpsNewRoute = AdminMcpsNewRouteImport.update({
 const AdminMcpsServerIdRoute = AdminMcpsServerIdRouteImport.update({
   id: '/mcps/$serverId',
   path: '/mcps/$serverId',
+  getParentRoute: () => AdminRouteRoute,
+} as any)
+const AdminIntegrationsNewRoute = AdminIntegrationsNewRouteImport.update({
+  id: '/integrations/new',
+  path: '/integrations/new',
+  getParentRoute: () => AdminRouteRoute,
+} as any)
+const AdminIntegrationsIdRoute = AdminIntegrationsIdRouteImport.update({
+  id: '/integrations/$id',
+  path: '/integrations/$id',
   getParentRoute: () => AdminRouteRoute,
 } as any)
 const AdminGroupsNewRoute = AdminGroupsNewRouteImport.update({
@@ -424,6 +442,8 @@ export interface FileRoutesByFullPath {
   '/app/knowledge/$kbSlug': typeof AppKnowledgeKbSlugRouteRouteWithChildren
   '/$locale/password/forgot': typeof LocalePasswordForgotRoute
   '/admin/groups/new': typeof AdminGroupsNewRoute
+  '/admin/integrations/$id': typeof AdminIntegrationsIdRoute
+  '/admin/integrations/new': typeof AdminIntegrationsNewRoute
   '/admin/mcps/$serverId': typeof AdminMcpsServerIdRoute
   '/admin/mcps/new': typeof AdminMcpsNewRoute
   '/admin/users/invite': typeof AdminUsersInviteRoute
@@ -437,6 +457,7 @@ export interface FileRoutesByFullPath {
   '/app/transcribe/$transcriptionId': typeof AppTranscribeTranscriptionIdRoute
   '/app/transcribe/add': typeof AppTranscribeAddRoute
   '/admin/groups/': typeof AdminGroupsIndexRoute
+  '/admin/integrations/': typeof AdminIntegrationsIndexRoute
   '/admin/mcps/': typeof AdminMcpsIndexRoute
   '/admin/users/': typeof AdminUsersIndexRoute
   '/app/docs/': typeof AppDocsIndexRoute
@@ -485,6 +506,8 @@ export interface FileRoutesByTo {
   '/app': typeof AppIndexRoute
   '/$locale/password/forgot': typeof LocalePasswordForgotRoute
   '/admin/groups/new': typeof AdminGroupsNewRoute
+  '/admin/integrations/$id': typeof AdminIntegrationsIdRoute
+  '/admin/integrations/new': typeof AdminIntegrationsNewRoute
   '/admin/mcps/$serverId': typeof AdminMcpsServerIdRoute
   '/admin/mcps/new': typeof AdminMcpsNewRoute
   '/admin/users/invite': typeof AdminUsersInviteRoute
@@ -498,6 +521,7 @@ export interface FileRoutesByTo {
   '/app/transcribe/$transcriptionId': typeof AppTranscribeTranscriptionIdRoute
   '/app/transcribe/add': typeof AppTranscribeAddRoute
   '/admin/groups': typeof AdminGroupsIndexRoute
+  '/admin/integrations': typeof AdminIntegrationsIndexRoute
   '/admin/mcps': typeof AdminMcpsIndexRoute
   '/admin/users': typeof AdminUsersIndexRoute
   '/app/docs': typeof AppDocsIndexRoute
@@ -550,6 +574,8 @@ export interface FileRoutesById {
   '/app/knowledge/$kbSlug': typeof AppKnowledgeKbSlugRouteRouteWithChildren
   '/$locale/password/forgot': typeof LocalePasswordForgotRoute
   '/admin/groups/new': typeof AdminGroupsNewRoute
+  '/admin/integrations/$id': typeof AdminIntegrationsIdRoute
+  '/admin/integrations/new': typeof AdminIntegrationsNewRoute
   '/admin/mcps/$serverId': typeof AdminMcpsServerIdRoute
   '/admin/mcps/new': typeof AdminMcpsNewRoute
   '/admin/users/invite': typeof AdminUsersInviteRoute
@@ -563,6 +589,7 @@ export interface FileRoutesById {
   '/app/transcribe/$transcriptionId': typeof AppTranscribeTranscriptionIdRoute
   '/app/transcribe/add': typeof AppTranscribeAddRoute
   '/admin/groups/': typeof AdminGroupsIndexRoute
+  '/admin/integrations/': typeof AdminIntegrationsIndexRoute
   '/admin/mcps/': typeof AdminMcpsIndexRoute
   '/admin/users/': typeof AdminUsersIndexRoute
   '/app/docs/': typeof AppDocsIndexRoute
@@ -616,6 +643,8 @@ export interface FileRouteTypes {
     | '/app/knowledge/$kbSlug'
     | '/$locale/password/forgot'
     | '/admin/groups/new'
+    | '/admin/integrations/$id'
+    | '/admin/integrations/new'
     | '/admin/mcps/$serverId'
     | '/admin/mcps/new'
     | '/admin/users/invite'
@@ -629,6 +658,7 @@ export interface FileRouteTypes {
     | '/app/transcribe/$transcriptionId'
     | '/app/transcribe/add'
     | '/admin/groups/'
+    | '/admin/integrations/'
     | '/admin/mcps/'
     | '/admin/users/'
     | '/app/docs/'
@@ -677,6 +707,8 @@ export interface FileRouteTypes {
     | '/app'
     | '/$locale/password/forgot'
     | '/admin/groups/new'
+    | '/admin/integrations/$id'
+    | '/admin/integrations/new'
     | '/admin/mcps/$serverId'
     | '/admin/mcps/new'
     | '/admin/users/invite'
@@ -690,6 +722,7 @@ export interface FileRouteTypes {
     | '/app/transcribe/$transcriptionId'
     | '/app/transcribe/add'
     | '/admin/groups'
+    | '/admin/integrations'
     | '/admin/mcps'
     | '/admin/users'
     | '/app/docs'
@@ -741,6 +774,8 @@ export interface FileRouteTypes {
     | '/app/knowledge/$kbSlug'
     | '/$locale/password/forgot'
     | '/admin/groups/new'
+    | '/admin/integrations/$id'
+    | '/admin/integrations/new'
     | '/admin/mcps/$serverId'
     | '/admin/mcps/new'
     | '/admin/users/invite'
@@ -754,6 +789,7 @@ export interface FileRouteTypes {
     | '/app/transcribe/$transcriptionId'
     | '/app/transcribe/add'
     | '/admin/groups/'
+    | '/admin/integrations/'
     | '/admin/mcps/'
     | '/admin/users/'
     | '/app/docs/'
@@ -1002,6 +1038,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AdminMcpsIndexRouteImport
       parentRoute: typeof AdminRouteRoute
     }
+    '/admin/integrations/': {
+      id: '/admin/integrations/'
+      path: '/integrations'
+      fullPath: '/admin/integrations/'
+      preLoaderRoute: typeof AdminIntegrationsIndexRouteImport
+      parentRoute: typeof AdminRouteRoute
+    }
     '/admin/groups/': {
       id: '/admin/groups/'
       path: '/groups'
@@ -1091,6 +1134,20 @@ declare module '@tanstack/react-router' {
       path: '/mcps/$serverId'
       fullPath: '/admin/mcps/$serverId'
       preLoaderRoute: typeof AdminMcpsServerIdRouteImport
+      parentRoute: typeof AdminRouteRoute
+    }
+    '/admin/integrations/new': {
+      id: '/admin/integrations/new'
+      path: '/integrations/new'
+      fullPath: '/admin/integrations/new'
+      preLoaderRoute: typeof AdminIntegrationsNewRouteImport
+      parentRoute: typeof AdminRouteRoute
+    }
+    '/admin/integrations/$id': {
+      id: '/admin/integrations/$id'
+      path: '/integrations/$id'
+      fullPath: '/admin/integrations/$id'
+      preLoaderRoute: typeof AdminIntegrationsIdRouteImport
       parentRoute: typeof AdminRouteRoute
     }
     '/admin/groups/new': {
@@ -1255,10 +1312,13 @@ interface AdminRouteRouteChildren {
   AdminSettingsRoute: typeof AdminSettingsRoute
   AdminIndexRoute: typeof AdminIndexRoute
   AdminGroupsNewRoute: typeof AdminGroupsNewRoute
+  AdminIntegrationsIdRoute: typeof AdminIntegrationsIdRoute
+  AdminIntegrationsNewRoute: typeof AdminIntegrationsNewRoute
   AdminMcpsServerIdRoute: typeof AdminMcpsServerIdRoute
   AdminMcpsNewRoute: typeof AdminMcpsNewRoute
   AdminUsersInviteRoute: typeof AdminUsersInviteRoute
   AdminGroupsIndexRoute: typeof AdminGroupsIndexRoute
+  AdminIntegrationsIndexRoute: typeof AdminIntegrationsIndexRoute
   AdminMcpsIndexRoute: typeof AdminMcpsIndexRoute
   AdminUsersIndexRoute: typeof AdminUsersIndexRoute
   AdminGroupsGroupIdAddMemberRoute: typeof AdminGroupsGroupIdAddMemberRoute
@@ -1272,10 +1332,13 @@ const AdminRouteRouteChildren: AdminRouteRouteChildren = {
   AdminSettingsRoute: AdminSettingsRoute,
   AdminIndexRoute: AdminIndexRoute,
   AdminGroupsNewRoute: AdminGroupsNewRoute,
+  AdminIntegrationsIdRoute: AdminIntegrationsIdRoute,
+  AdminIntegrationsNewRoute: AdminIntegrationsNewRoute,
   AdminMcpsServerIdRoute: AdminMcpsServerIdRoute,
   AdminMcpsNewRoute: AdminMcpsNewRoute,
   AdminUsersInviteRoute: AdminUsersInviteRoute,
   AdminGroupsIndexRoute: AdminGroupsIndexRoute,
+  AdminIntegrationsIndexRoute: AdminIntegrationsIndexRoute,
   AdminMcpsIndexRoute: AdminMcpsIndexRoute,
   AdminUsersIndexRoute: AdminUsersIndexRoute,
   AdminGroupsGroupIdAddMemberRoute: AdminGroupsGroupIdAddMemberRoute,

--- a/klai-portal/frontend/src/routes/admin/index.tsx
+++ b/klai-portal/frontend/src/routes/admin/index.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { Users, FolderKanban, CreditCard, Settings } from 'lucide-react'
+import { Users, FolderKanban, CreditCard, Settings, Cable } from 'lucide-react'
 import * as m from '@/paraglide/messages'
 
 export const Route = createFileRoute('/admin/')({
@@ -19,6 +19,12 @@ function AdminHome() {
       description: m.admin_section_groups_description(),
       icon: FolderKanban,
       href: '/admin/groups',
+    },
+    {
+      title: m.admin_section_integrations_title(),
+      description: m.admin_section_integrations_description(),
+      icon: Cable,
+      href: '/admin/integrations',
     },
     {
       title: m.admin_section_billing_title(),

--- a/klai-portal/frontend/src/routes/admin/integrations/$id.tsx
+++ b/klai-portal/frontend/src/routes/admin/integrations/$id.tsx
@@ -1,0 +1,352 @@
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { useState, useEffect } from 'react'
+import { ArrowLeft, Loader2, ExternalLink } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Badge } from '@/components/ui/badge'
+import { QueryErrorState } from '@/components/ui/query-error-state'
+import * as m from '@/paraglide/messages'
+import { useIntegration, useUpdateIntegration, useRevokeIntegration } from './-hooks'
+import type { AccessLevel } from './-types'
+import { KbAccessEditor } from './_components/KbAccessEditor'
+import { RevokeConfirmDialog } from './_components/RevokeConfirmDialog'
+
+export const Route = createFileRoute('/admin/integrations/$id')({
+  component: IntegrationDetailPage,
+})
+
+interface FormState {
+  name: string
+  description: string
+  chat: boolean
+  feedback: boolean
+  knowledge_append: boolean
+  rate_limit_rpm: number
+  kb_access: { kb_id: number; access_level: AccessLevel }[]
+}
+
+function IntegrationDetailPage() {
+  const { id } = Route.useParams()
+  const navigate = useNavigate()
+
+  const { data: integration, isLoading, error, refetch } = useIntegration(id)
+  const updateMutation = useUpdateIntegration(id)
+  const revokeMutation = useRevokeIntegration(id)
+
+  const [form, setForm] = useState<FormState | null>(null)
+  const [showRevokeDialog, setShowRevokeDialog] = useState(false)
+
+  // Populate form when integration data loads
+  useEffect(() => {
+    if (integration && !form) {
+      setForm({
+        name: integration.name,
+        description: integration.description ?? '',
+        chat: integration.permissions.chat,
+        feedback: integration.permissions.feedback,
+        knowledge_append: integration.permissions.knowledge_append,
+        rate_limit_rpm: integration.rate_limit_rpm,
+        kb_access: integration.kb_access.map((ka) => ({
+          kb_id: ka.kb_id,
+          access_level: ka.access_level,
+        })),
+      })
+    }
+  }, [integration, form])
+
+  const isRevoked = integration?.active === false
+  const isDisabled = isRevoked || updateMutation.isPending
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!form) return
+    updateMutation.mutate(
+      {
+        name: form.name.trim(),
+        description: form.description.trim() || null,
+        permissions: {
+          chat: form.chat,
+          feedback: form.feedback,
+          knowledge_append: form.knowledge_append,
+        },
+        rate_limit_rpm: form.rate_limit_rpm,
+        kb_access: form.kb_access,
+      },
+      {
+        onSuccess: () => {
+          toast.success(m.admin_integrations_success_updated())
+        },
+      },
+    )
+  }
+
+  function handleRevoke() {
+    revokeMutation.mutate(undefined, {
+      onSuccess: () => {
+        setShowRevokeDialog(false)
+        toast.success(m.admin_integrations_success_revoked())
+        // Reset form to reflect revoked state
+        setForm(null)
+      },
+    })
+  }
+
+  // When knowledge_append is toggled off, downgrade any read_write to read
+  function handleKnowledgeAppendChange(checked: boolean) {
+    if (!form) return
+    setForm({
+      ...form,
+      knowledge_append: checked,
+      kb_access: checked
+        ? form.kb_access
+        : form.kb_access.map((row) =>
+            row.access_level === 'read_write'
+              ? { ...row, access_level: 'read' as AccessLevel }
+              : row,
+          ),
+    })
+  }
+
+  const grafanaUrl = `https://grafana.getklai.com/explore?left={"queries":[{"expr":"partner_key_id:${id}"}]}`
+
+  if (isLoading) {
+    return (
+      <div className="p-6">
+        <p className="py-8 text-sm text-[var(--color-muted-foreground)]">
+          <Loader2 className="inline h-4 w-4 animate-spin mr-2" />
+          {m.admin_integrations_loading()}
+        </p>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="p-6 max-w-lg">
+        <QueryErrorState
+          error={error instanceof Error ? error : new Error(String(error))}
+          onRetry={() => void refetch()}
+        />
+      </div>
+    )
+  }
+
+  if (!integration || !form) return null
+
+  return (
+    <div className="p-6 max-w-lg">
+      <div className="flex items-start justify-between mb-6">
+        <div className="flex items-center gap-3">
+          <h1 className="page-title text-xl/none font-semibold text-[var(--color-foreground)]">
+            {integration.name}
+          </h1>
+          {isRevoked ? (
+            <Badge variant="destructive">
+              {m.admin_integrations_status_revoked()}
+            </Badge>
+          ) : (
+            <Badge variant="success">
+              {m.admin_integrations_status_active()}
+            </Badge>
+          )}
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => navigate({ to: '/admin/integrations' })}
+        >
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          {m.admin_users_cancel()}
+        </Button>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        {/* Basics */}
+        <section className="space-y-4">
+          <h2 className="text-sm font-medium text-[var(--color-foreground)]">
+            {m.admin_integrations_section_basics()}
+          </h2>
+          <div className="space-y-1.5">
+            <Label htmlFor="integration-name">
+              {m.admin_integrations_field_name()}
+            </Label>
+            <Input
+              id="integration-name"
+              value={form.name}
+              onChange={(e) => setForm({ ...form, name: e.target.value })}
+              required
+              disabled={isDisabled}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="integration-description">
+              {m.admin_integrations_field_description()}
+            </Label>
+            <textarea
+              id="integration-description"
+              value={form.description}
+              onChange={(e) => setForm({ ...form, description: e.target.value })}
+              rows={3}
+              disabled={isDisabled}
+              className="w-full rounded-md border border-[var(--color-border)] bg-transparent px-3 py-2 text-sm text-[var(--color-foreground)] outline-none transition-colors placeholder:text-[var(--color-muted-foreground)] focus:ring-2 focus:ring-[var(--color-ring)] disabled:cursor-not-allowed disabled:opacity-50"
+            />
+          </div>
+
+          {/* Key prefix (read-only) */}
+          <div className="space-y-1.5">
+            <Label>{m.admin_integrations_col_key_prefix()}</Label>
+            <code className="block text-xs font-mono text-[var(--color-muted-foreground)] py-2">
+              {integration.key_prefix}...
+            </code>
+          </div>
+        </section>
+
+        {/* Permissions */}
+        <section className="space-y-4">
+          <h2 className="text-sm font-medium text-[var(--color-foreground)]">
+            {m.admin_integrations_section_permissions()}
+          </h2>
+          <div className="space-y-3">
+            <label className="flex items-center gap-2 text-sm text-[var(--color-foreground)]">
+              <input
+                type="checkbox"
+                checked={form.chat}
+                onChange={(e) => setForm({ ...form, chat: e.target.checked })}
+                disabled={isDisabled}
+                className="accent-[var(--color-accent)]"
+              />
+              {m.admin_integrations_perm_chat()}
+            </label>
+            <label className="flex items-center gap-2 text-sm text-[var(--color-foreground)]">
+              <input
+                type="checkbox"
+                checked={form.feedback}
+                onChange={(e) => setForm({ ...form, feedback: e.target.checked })}
+                disabled={isDisabled}
+                className="accent-[var(--color-accent)]"
+              />
+              {m.admin_integrations_perm_feedback()}
+            </label>
+            <label className="flex items-center gap-2 text-sm text-[var(--color-foreground)]">
+              <input
+                type="checkbox"
+                checked={form.knowledge_append}
+                onChange={(e) => handleKnowledgeAppendChange(e.target.checked)}
+                disabled={isDisabled}
+                className="accent-[var(--color-accent)]"
+              />
+              {m.admin_integrations_perm_knowledge_append()}
+            </label>
+          </div>
+        </section>
+
+        {/* KB Access */}
+        <section className="space-y-4">
+          <h2 className="text-sm font-medium text-[var(--color-foreground)]">
+            {m.admin_integrations_section_kb_access()}
+          </h2>
+          <KbAccessEditor
+            value={form.kb_access}
+            onChange={(kb_access) => setForm({ ...form, kb_access })}
+            knowledgeAppendEnabled={form.knowledge_append}
+            disabled={isDisabled}
+          />
+        </section>
+
+        {/* Rate limit */}
+        <section className="space-y-4">
+          <h2 className="text-sm font-medium text-[var(--color-foreground)]">
+            {m.admin_integrations_section_rate_limit()}
+          </h2>
+          <div className="space-y-1.5">
+            <Label htmlFor="rate-limit">
+              {m.admin_integrations_field_rate_limit()}
+            </Label>
+            <div className="flex items-center gap-2">
+              <Input
+                id="rate-limit"
+                type="number"
+                min={10}
+                max={600}
+                value={form.rate_limit_rpm}
+                onChange={(e) =>
+                  setForm({ ...form, rate_limit_rpm: Number(e.target.value) })
+                }
+                disabled={isDisabled}
+                className="max-w-[8rem]"
+              />
+              <span className="text-sm text-[var(--color-muted-foreground)]">
+                {m.admin_integrations_rate_limit_unit()}
+              </span>
+            </div>
+          </div>
+        </section>
+
+        {updateMutation.error && (
+          <p className="text-sm text-[var(--color-destructive)]">
+            {updateMutation.error instanceof Error
+              ? updateMutation.error.message
+              : m.admin_integrations_error_generic()}
+          </p>
+        )}
+
+        {!isRevoked && (
+          <div className="pt-2">
+            <Button
+              type="submit"
+              disabled={updateMutation.isPending || !form.name.trim()}
+            >
+              {updateMutation.isPending && (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              )}
+              {m.admin_integrations_save()}
+            </Button>
+          </div>
+        )}
+      </form>
+
+      {/* View logs link */}
+      <div className="mt-8 pt-6 border-t border-[var(--color-border)]">
+        <a
+          href={grafanaUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1.5 text-sm text-[var(--color-accent)] hover:opacity-70 transition-opacity"
+        >
+          {m.admin_integrations_view_logs()}
+          <ExternalLink className="h-3.5 w-3.5" />
+        </a>
+      </div>
+
+      {/* Revoke section */}
+      {!isRevoked && (
+        <div className="mt-6 pt-6 border-t border-[var(--color-border)]">
+          <h2 className="text-sm font-medium text-[var(--color-destructive)] mb-2">
+            {m.admin_integrations_revoke_section_title()}
+          </h2>
+          <p className="text-sm text-[var(--color-muted-foreground)] mb-4">
+            {m.admin_integrations_revoke_section_description()}
+          </p>
+          <Button
+            type="button"
+            variant="destructive"
+            size="sm"
+            onClick={() => setShowRevokeDialog(true)}
+          >
+            {m.admin_integrations_revoke_button()}
+          </Button>
+        </div>
+      )}
+
+      <RevokeConfirmDialog
+        open={showRevokeDialog}
+        isPending={revokeMutation.isPending}
+        onConfirm={handleRevoke}
+        onCancel={() => setShowRevokeDialog(false)}
+      />
+    </div>
+  )
+}

--- a/klai-portal/frontend/src/routes/admin/integrations/-hooks.ts
+++ b/klai-portal/frontend/src/routes/admin/integrations/-hooks.ts
@@ -1,0 +1,103 @@
+// TanStack Query hooks for admin integrations
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useAuth } from 'react-oidc-context'
+import { apiFetch } from '@/lib/apiFetch'
+import type {
+  IntegrationResponse,
+  IntegrationDetailResponse,
+  CreateIntegrationRequest,
+  CreateIntegrationResponse,
+  UpdateIntegrationRequest,
+  OrgKnowledgeBase,
+} from './-types'
+
+export function useIntegrations() {
+  const auth = useAuth()
+  const token = auth.user?.access_token
+
+  return useQuery({
+    queryKey: ['admin-integrations'],
+    queryFn: async () =>
+      apiFetch<{ integrations: IntegrationResponse[] }>('/api/integrations', token),
+    enabled: !!token,
+  })
+}
+
+export function useIntegration(id: string) {
+  const auth = useAuth()
+  const token = auth.user?.access_token
+
+  return useQuery({
+    queryKey: ['admin-integration', id],
+    queryFn: async () =>
+      apiFetch<IntegrationDetailResponse>(`/api/integrations/${id}`, token),
+    enabled: !!token && !!id,
+  })
+}
+
+export function useCreateIntegration() {
+  const auth = useAuth()
+  const token = auth.user?.access_token
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (data: CreateIntegrationRequest) =>
+      apiFetch<CreateIntegrationResponse>('/api/integrations', token, {
+        method: 'POST',
+        body: JSON.stringify(data),
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['admin-integrations'] })
+    },
+  })
+}
+
+export function useUpdateIntegration(id: string) {
+  const auth = useAuth()
+  const token = auth.user?.access_token
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (data: UpdateIntegrationRequest) =>
+      apiFetch<IntegrationDetailResponse>(`/api/integrations/${id}`, token, {
+        method: 'PATCH',
+        body: JSON.stringify(data),
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['admin-integrations'] })
+      void queryClient.invalidateQueries({ queryKey: ['admin-integration', id] })
+    },
+  })
+}
+
+export function useRevokeIntegration(id: string) {
+  const auth = useAuth()
+  const token = auth.user?.access_token
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async () =>
+      apiFetch<IntegrationDetailResponse>(`/api/integrations/${id}/revoke`, token, {
+        method: 'POST',
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['admin-integrations'] })
+      void queryClient.invalidateQueries({ queryKey: ['admin-integration', id] })
+    },
+  })
+}
+
+export function useOrgKnowledgeBases() {
+  const auth = useAuth()
+  const token = auth.user?.access_token
+
+  return useQuery({
+    queryKey: ['app-knowledge-bases-for-integrations'],
+    queryFn: async () =>
+      apiFetch<{ knowledge_bases: OrgKnowledgeBase[] }>(
+        '/api/app/knowledge-bases?owner_type=org',
+        token,
+      ),
+    enabled: !!token,
+  })
+}

--- a/klai-portal/frontend/src/routes/admin/integrations/-types.ts
+++ b/klai-portal/frontend/src/routes/admin/integrations/-types.ts
@@ -1,0 +1,67 @@
+// Shared types for admin integrations routes
+
+export type AccessLevel = 'none' | 'read' | 'read_write'
+
+export interface KbAccess {
+  kb_id: number
+  kb_name: string
+  kb_slug: string
+  access_level: AccessLevel
+}
+
+export interface IntegrationResponse {
+  id: number
+  name: string
+  description: string | null
+  key_prefix: string
+  active: boolean
+  permissions: {
+    chat: boolean
+    feedback: boolean
+    knowledge_append: boolean
+  }
+  rate_limit_rpm: number
+  kb_access_count: number
+  last_used_at: string | null
+  created_at: string
+  created_by: string
+}
+
+export interface IntegrationDetailResponse extends IntegrationResponse {
+  kb_access: KbAccess[]
+}
+
+export interface CreateIntegrationRequest {
+  name: string
+  description: string | null
+  permissions: {
+    chat: boolean
+    feedback: boolean
+    knowledge_append: boolean
+  }
+  rate_limit_rpm: number
+  kb_access: { kb_id: number; access_level: AccessLevel }[]
+}
+
+export interface CreateIntegrationResponse extends IntegrationDetailResponse {
+  api_key: string
+}
+
+export interface UpdateIntegrationRequest {
+  name?: string
+  description?: string | null
+  permissions?: {
+    chat: boolean
+    feedback: boolean
+    knowledge_append: boolean
+  }
+  rate_limit_rpm?: number
+  kb_access?: { kb_id: number; access_level: AccessLevel }[]
+}
+
+export interface OrgKnowledgeBase {
+  id: number
+  name: string
+  slug: string
+  owner_type: string
+}

--- a/klai-portal/frontend/src/routes/admin/integrations/_components/CreatedKeyModal.tsx
+++ b/klai-portal/frontend/src/routes/admin/integrations/_components/CreatedKeyModal.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react'
+import { Copy, Check, AlertTriangle } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+} from '@/components/ui/alert-dialog'
+import * as m from '@/paraglide/messages'
+
+interface CreatedKeyModalProps {
+  apiKey: string
+  open: boolean
+  onConfirm: () => void
+}
+
+export function CreatedKeyModal({ apiKey, open, onConfirm }: CreatedKeyModalProps) {
+  const [copied, setCopied] = useState(false)
+
+  async function handleCopy() {
+    await navigator.clipboard.writeText(apiKey)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <AlertDialog open={open}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{m.admin_integrations_key_modal_title()}</AlertDialogTitle>
+          <AlertDialogDescription className="space-y-3">
+            <span className="flex items-center gap-2 text-[var(--color-destructive)] font-medium">
+              <AlertTriangle className="h-4 w-4 shrink-0" />
+              {m.admin_integrations_key_modal_warning()}
+            </span>
+            <span className="block">
+              {m.admin_integrations_key_modal_description()}
+            </span>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <div className="my-4 flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-card)] p-3">
+          <code className="flex-1 break-all text-xs font-mono text-[var(--color-foreground)]">
+            {apiKey}
+          </code>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => void handleCopy()}
+            className="shrink-0"
+          >
+            {copied ? (
+              <Check className="h-4 w-4 text-[var(--color-success)]" />
+            ) : (
+              <Copy className="h-4 w-4" />
+            )}
+          </Button>
+        </div>
+
+        <AlertDialogFooter>
+          <Button onClick={onConfirm}>
+            {m.admin_integrations_key_modal_confirm()}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/klai-portal/frontend/src/routes/admin/integrations/_components/KbAccessEditor.tsx
+++ b/klai-portal/frontend/src/routes/admin/integrations/_components/KbAccessEditor.tsx
@@ -1,0 +1,143 @@
+import { Loader2 } from 'lucide-react'
+import * as m from '@/paraglide/messages'
+import { useOrgKnowledgeBases } from '../-hooks'
+import type { AccessLevel, OrgKnowledgeBase } from '../-types'
+
+interface KbAccessRow {
+  kb_id: number
+  access_level: AccessLevel
+}
+
+interface KbAccessEditorProps {
+  value: KbAccessRow[]
+  onChange: (value: KbAccessRow[]) => void
+  knowledgeAppendEnabled: boolean
+  disabled?: boolean
+}
+
+function getAccessLevel(
+  rows: KbAccessRow[],
+  kbId: number,
+): AccessLevel {
+  const found = rows.find((r) => r.kb_id === kbId)
+  return found?.access_level ?? 'none'
+}
+
+function setAccessLevel(
+  rows: KbAccessRow[],
+  kbId: number,
+  level: AccessLevel,
+): KbAccessRow[] {
+  if (level === 'none') {
+    return rows.filter((r) => r.kb_id !== kbId)
+  }
+  const existing = rows.find((r) => r.kb_id === kbId)
+  if (existing) {
+    return rows.map((r) => (r.kb_id === kbId ? { ...r, access_level: level } : r))
+  }
+  return [...rows, { kb_id: kbId, access_level: level }]
+}
+
+export function KbAccessEditor({
+  value,
+  onChange,
+  knowledgeAppendEnabled,
+  disabled = false,
+}: KbAccessEditorProps) {
+  const { data: kbsData, isLoading } = useOrgKnowledgeBases()
+  const kbs: OrgKnowledgeBase[] = (kbsData?.knowledge_bases ?? []).filter(
+    (kb) => kb.owner_type === 'org',
+  )
+
+  if (isLoading) {
+    return (
+      <p className="py-4 text-sm text-[var(--color-muted-foreground)]">
+        <Loader2 className="inline h-4 w-4 animate-spin mr-2" />
+        {m.admin_integrations_loading()}
+      </p>
+    )
+  }
+
+  if (kbs.length === 0) {
+    return (
+      <p className="py-4 text-sm text-[var(--color-muted-foreground)]">
+        {m.admin_integrations_kb_empty()}
+      </p>
+    )
+  }
+
+  function handleChange(kbId: number, level: AccessLevel) {
+    onChange(setAccessLevel(value, kbId, level))
+  }
+
+  return (
+    <table className="w-full text-sm border-t border-b border-[var(--color-border)]">
+      <thead>
+        <tr className="border-b border-[var(--color-border)]">
+          <th className="py-3 pr-4 text-left text-xs font-medium text-[var(--color-rl-dark-30)] uppercase tracking-[0.04em]">
+            {m.admin_integrations_kb_name()}
+          </th>
+          <th className="py-3 pr-4 text-center text-xs font-medium text-[var(--color-rl-dark-30)] uppercase tracking-[0.04em] w-24">
+            {m.admin_integrations_kb_none()}
+          </th>
+          <th className="py-3 pr-4 text-center text-xs font-medium text-[var(--color-rl-dark-30)] uppercase tracking-[0.04em] w-24">
+            {m.admin_integrations_kb_read()}
+          </th>
+          <th className="py-3 text-center text-xs font-medium text-[var(--color-rl-dark-30)] uppercase tracking-[0.04em] w-28">
+            {m.admin_integrations_kb_read_write()}
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {kbs.map((kb) => {
+          const currentLevel = getAccessLevel(value, kb.id)
+          return (
+            <tr
+              key={kb.id}
+              className="border-b border-[var(--color-border)] last:border-b-0"
+            >
+              <td className="py-3 pr-4 align-middle text-[var(--color-foreground)]">
+                {kb.name}
+              </td>
+              <td className="py-3 pr-4 text-center align-middle">
+                <input
+                  type="radio"
+                  name={`kb-access-${kb.id}`}
+                  checked={currentLevel === 'none'}
+                  onChange={() => handleChange(kb.id, 'none')}
+                  disabled={disabled}
+                  className="accent-[var(--color-accent)]"
+                />
+              </td>
+              <td className="py-3 pr-4 text-center align-middle">
+                <input
+                  type="radio"
+                  name={`kb-access-${kb.id}`}
+                  checked={currentLevel === 'read'}
+                  onChange={() => handleChange(kb.id, 'read')}
+                  disabled={disabled}
+                  className="accent-[var(--color-accent)]"
+                />
+              </td>
+              <td className="py-3 text-center align-middle">
+                <input
+                  type="radio"
+                  name={`kb-access-${kb.id}`}
+                  checked={currentLevel === 'read_write'}
+                  onChange={() => handleChange(kb.id, 'read_write')}
+                  disabled={disabled || !knowledgeAppendEnabled}
+                  className="accent-[var(--color-accent)]"
+                  title={
+                    !knowledgeAppendEnabled
+                      ? m.admin_integrations_kb_read_write_disabled_hint()
+                      : undefined
+                  }
+                />
+              </td>
+            </tr>
+          )
+        })}
+      </tbody>
+    </table>
+  )
+}

--- a/klai-portal/frontend/src/routes/admin/integrations/_components/RevokeConfirmDialog.tsx
+++ b/klai-portal/frontend/src/routes/admin/integrations/_components/RevokeConfirmDialog.tsx
@@ -1,0 +1,57 @@
+import { Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import * as m from '@/paraglide/messages'
+
+interface RevokeConfirmDialogProps {
+  open: boolean
+  isPending: boolean
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export function RevokeConfirmDialog({
+  open,
+  isPending,
+  onConfirm,
+  onCancel,
+}: RevokeConfirmDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={(o) => { if (!o) onCancel() }}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {m.admin_integrations_revoke_title()}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {m.admin_integrations_revoke_description()}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>
+            {m.admin_users_cancel()}
+          </AlertDialogCancel>
+          <AlertDialogAction asChild>
+            <Button
+              className="bg-[var(--color-destructive)] text-white hover:bg-[var(--color-destructive)]/90"
+              onClick={onConfirm}
+              disabled={isPending}
+            >
+              {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {m.admin_integrations_revoke_confirm()}
+            </Button>
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/klai-portal/frontend/src/routes/admin/integrations/index.tsx
+++ b/klai-portal/frontend/src/routes/admin/integrations/index.tsx
@@ -1,0 +1,197 @@
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import {
+  useReactTable,
+  getCoreRowModel,
+  flexRender,
+  createColumnHelper,
+} from '@tanstack/react-table'
+import { Plus, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { QueryErrorState } from '@/components/ui/query-error-state'
+import * as m from '@/paraglide/messages'
+import { getLocale } from '@/paraglide/runtime'
+import { datetime } from '@/paraglide/registry'
+import { useIntegrations } from './-hooks'
+import type { IntegrationResponse } from './-types'
+
+export const Route = createFileRoute('/admin/integrations/')({
+  component: IntegrationsPage,
+})
+
+function formatRelativeTime(isoString: string | null): string {
+  if (!isoString) return '\u2014'
+  return datetime(getLocale(), isoString, {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function StatusBadge({ active }: { active: boolean }) {
+  return active ? (
+    <Badge variant="success">{m.admin_integrations_status_active()}</Badge>
+  ) : (
+    <Badge variant="destructive">{m.admin_integrations_status_revoked()}</Badge>
+  )
+}
+
+const columnHelper = createColumnHelper<IntegrationResponse>()
+
+function IntegrationsPage() {
+  const navigate = useNavigate()
+  const { data, isLoading, error, refetch } = useIntegrations()
+
+  const integrations = data?.integrations ?? []
+
+  const columns = [
+    columnHelper.accessor('name', {
+      header: () => m.admin_integrations_col_name(),
+      cell: (info) => (
+        <button
+          onClick={() =>
+            navigate({
+              to: '/admin/integrations/$id',
+              params: { id: String(info.row.original.id) },
+            })
+          }
+          className="font-medium text-[var(--color-foreground)] hover:text-[var(--color-accent)] transition-colors text-left"
+        >
+          {info.getValue()}
+        </button>
+      ),
+    }),
+    columnHelper.accessor('key_prefix', {
+      header: () => m.admin_integrations_col_key_prefix(),
+      cell: (info) => (
+        <code className="text-xs font-mono text-[var(--color-muted-foreground)]">
+          {info.getValue()}...
+        </code>
+      ),
+    }),
+    columnHelper.accessor('active', {
+      header: () => m.admin_integrations_col_status(),
+      cell: (info) => <StatusBadge active={info.getValue()} />,
+    }),
+    columnHelper.accessor('kb_access_count', {
+      header: () => m.admin_integrations_col_kb_access(),
+      cell: (info) => (
+        <span className="text-sm tabular-nums">{info.getValue()}</span>
+      ),
+    }),
+    columnHelper.accessor('last_used_at', {
+      header: () => m.admin_integrations_col_last_used(),
+      cell: (info) => (
+        <span className="text-sm text-[var(--color-muted-foreground)] whitespace-nowrap tabular-nums">
+          {formatRelativeTime(info.getValue())}
+        </span>
+      ),
+    }),
+    columnHelper.display({
+      id: 'actions',
+      header: () => '',
+      cell: ({ row }) => (
+        <div className="flex items-start justify-end mt-px">
+          <button
+            onClick={() =>
+              navigate({
+                to: '/admin/integrations/$id',
+                params: { id: String(row.original.id) },
+              })
+            }
+            className="text-sm text-[var(--color-accent)] hover:opacity-70 transition-opacity"
+          >
+            {m.admin_integrations_view_detail()}
+          </button>
+        </div>
+      ),
+    }),
+  ]
+
+  // eslint-disable-next-line react-hooks/incompatible-library -- useReactTable returns functions that React Compiler cannot memoize safely; this is expected TanStack Table behaviour
+  const table = useReactTable({
+    data: integrations,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  })
+
+  return (
+    <div className="p-6 space-y-6 max-w-5xl">
+      <div className="flex items-start justify-between">
+        <h1 className="page-title text-xl/none font-semibold text-[var(--color-foreground)]">
+          {m.admin_integrations_title()}
+        </h1>
+        <Button
+          size="sm"
+          onClick={() => void navigate({ to: '/admin/integrations/new' })}
+        >
+          <Plus className="h-4 w-4 mr-2" />
+          {m.admin_integrations_create()}
+        </Button>
+      </div>
+
+      {error ? (
+        <QueryErrorState
+          error={error instanceof Error ? error : new Error(String(error))}
+          onRetry={() => void refetch()}
+        />
+      ) : isLoading ? (
+        <p className="py-8 text-sm text-[var(--color-muted-foreground)]">
+          <Loader2 className="inline h-4 w-4 animate-spin mr-2" />
+          {m.admin_integrations_loading()}
+        </p>
+      ) : integrations.length === 0 ? (
+        <div className="py-12 text-center space-y-3">
+          <p className="text-sm font-medium text-[var(--color-foreground)]">
+            {m.admin_integrations_empty()}
+          </p>
+          <p className="text-sm text-[var(--color-muted-foreground)]">
+            {m.admin_integrations_empty_description()}
+          </p>
+        </div>
+      ) : (
+        <table className="w-full text-sm border-t border-b border-[var(--color-border)]">
+          <thead>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr
+                key={headerGroup.id}
+                className="border-b border-[var(--color-border)]"
+              >
+                {headerGroup.headers.map((header) => (
+                  <th
+                    key={header.id}
+                    className="py-3 pr-4 text-left text-xs font-medium text-[var(--color-rl-dark-30)] uppercase tracking-[0.04em]"
+                  >
+                    {flexRender(
+                      header.column.columnDef.header,
+                      header.getContext(),
+                    )}
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {table.getRowModel().rows.map((row) => (
+              <tr
+                key={row.id}
+                className="border-b border-[var(--color-border)] last:border-b-0"
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <td
+                    key={cell.id}
+                    className="py-4 pr-4 align-top text-[var(--color-foreground)]"
+                  >
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  )
+}

--- a/klai-portal/frontend/src/routes/admin/integrations/new.tsx
+++ b/klai-portal/frontend/src/routes/admin/integrations/new.tsx
@@ -1,0 +1,249 @@
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { useState } from 'react'
+import { ArrowLeft, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import * as m from '@/paraglide/messages'
+import { useCreateIntegration } from './-hooks'
+import type { AccessLevel } from './-types'
+import { KbAccessEditor } from './_components/KbAccessEditor'
+import { CreatedKeyModal } from './_components/CreatedKeyModal'
+
+export const Route = createFileRoute('/admin/integrations/new')({
+  component: NewIntegrationPage,
+})
+
+interface FormState {
+  name: string
+  description: string
+  chat: boolean
+  feedback: boolean
+  knowledge_append: boolean
+  rate_limit_rpm: number
+  kb_access: { kb_id: number; access_level: AccessLevel }[]
+}
+
+function NewIntegrationPage() {
+  const navigate = useNavigate()
+  const createMutation = useCreateIntegration()
+
+  const [form, setForm] = useState<FormState>({
+    name: '',
+    description: '',
+    chat: true,
+    feedback: true,
+    knowledge_append: false,
+    rate_limit_rpm: 60,
+    kb_access: [],
+  })
+
+  const [createdKey, setCreatedKey] = useState<string | null>(null)
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    createMutation.mutate(
+      {
+        name: form.name.trim(),
+        description: form.description.trim() || null,
+        permissions: {
+          chat: form.chat,
+          feedback: form.feedback,
+          knowledge_append: form.knowledge_append,
+        },
+        rate_limit_rpm: form.rate_limit_rpm,
+        kb_access: form.kb_access,
+      },
+      {
+        onSuccess: (data) => {
+          setCreatedKey(data.api_key)
+        },
+      },
+    )
+  }
+
+  function handleKeyModalConfirm() {
+    setCreatedKey(null)
+    void navigate({ to: '/admin/integrations' })
+  }
+
+  // When knowledge_append is toggled off, downgrade any read_write to read
+  function handleKnowledgeAppendChange(checked: boolean) {
+    setForm((prev) => ({
+      ...prev,
+      knowledge_append: checked,
+      kb_access: checked
+        ? prev.kb_access
+        : prev.kb_access.map((row) =>
+            row.access_level === 'read_write'
+              ? { ...row, access_level: 'read' as AccessLevel }
+              : row,
+          ),
+    }))
+  }
+
+  return (
+    <div className="p-6 max-w-lg">
+      <div className="flex items-start justify-between mb-6">
+        <h1 className="page-title text-xl/none font-semibold text-[var(--color-foreground)]">
+          {m.admin_integrations_create()}
+        </h1>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => navigate({ to: '/admin/integrations' })}
+        >
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          {m.admin_users_cancel()}
+        </Button>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        {/* Basics */}
+        <section className="space-y-4">
+          <h2 className="text-sm font-medium text-[var(--color-foreground)]">
+            {m.admin_integrations_section_basics()}
+          </h2>
+          <div className="space-y-1.5">
+            <Label htmlFor="integration-name">
+              {m.admin_integrations_field_name()}
+            </Label>
+            <Input
+              id="integration-name"
+              value={form.name}
+              onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))}
+              required
+              autoFocus
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="integration-description">
+              {m.admin_integrations_field_description()}
+            </Label>
+            <textarea
+              id="integration-description"
+              value={form.description}
+              onChange={(e) =>
+                setForm((prev) => ({ ...prev, description: e.target.value }))
+              }
+              rows={3}
+              className="w-full rounded-md border border-[var(--color-border)] bg-transparent px-3 py-2 text-sm text-[var(--color-foreground)] outline-none transition-colors placeholder:text-[var(--color-muted-foreground)] focus:ring-2 focus:ring-[var(--color-ring)] disabled:cursor-not-allowed disabled:opacity-50"
+            />
+          </div>
+        </section>
+
+        {/* Permissions */}
+        <section className="space-y-4">
+          <h2 className="text-sm font-medium text-[var(--color-foreground)]">
+            {m.admin_integrations_section_permissions()}
+          </h2>
+          <div className="space-y-3">
+            <label className="flex items-center gap-2 text-sm text-[var(--color-foreground)]">
+              <input
+                type="checkbox"
+                checked={form.chat}
+                onChange={(e) =>
+                  setForm((prev) => ({ ...prev, chat: e.target.checked }))
+                }
+                className="accent-[var(--color-accent)]"
+              />
+              {m.admin_integrations_perm_chat()}
+            </label>
+            <label className="flex items-center gap-2 text-sm text-[var(--color-foreground)]">
+              <input
+                type="checkbox"
+                checked={form.feedback}
+                onChange={(e) =>
+                  setForm((prev) => ({ ...prev, feedback: e.target.checked }))
+                }
+                className="accent-[var(--color-accent)]"
+              />
+              {m.admin_integrations_perm_feedback()}
+            </label>
+            <label className="flex items-center gap-2 text-sm text-[var(--color-foreground)]">
+              <input
+                type="checkbox"
+                checked={form.knowledge_append}
+                onChange={(e) => handleKnowledgeAppendChange(e.target.checked)}
+                className="accent-[var(--color-accent)]"
+              />
+              {m.admin_integrations_perm_knowledge_append()}
+            </label>
+          </div>
+        </section>
+
+        {/* KB Access */}
+        <section className="space-y-4">
+          <h2 className="text-sm font-medium text-[var(--color-foreground)]">
+            {m.admin_integrations_section_kb_access()}
+          </h2>
+          <KbAccessEditor
+            value={form.kb_access}
+            onChange={(kb_access) => setForm((prev) => ({ ...prev, kb_access }))}
+            knowledgeAppendEnabled={form.knowledge_append}
+          />
+        </section>
+
+        {/* Rate limit */}
+        <section className="space-y-4">
+          <h2 className="text-sm font-medium text-[var(--color-foreground)]">
+            {m.admin_integrations_section_rate_limit()}
+          </h2>
+          <div className="space-y-1.5">
+            <Label htmlFor="rate-limit">
+              {m.admin_integrations_field_rate_limit()}
+            </Label>
+            <div className="flex items-center gap-2">
+              <Input
+                id="rate-limit"
+                type="number"
+                min={10}
+                max={600}
+                value={form.rate_limit_rpm}
+                onChange={(e) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    rate_limit_rpm: Number(e.target.value),
+                  }))
+                }
+                className="max-w-[8rem]"
+              />
+              <span className="text-sm text-[var(--color-muted-foreground)]">
+                {m.admin_integrations_rate_limit_unit()}
+              </span>
+            </div>
+          </div>
+        </section>
+
+        {createMutation.error && (
+          <p className="text-sm text-[var(--color-destructive)]">
+            {createMutation.error instanceof Error
+              ? createMutation.error.message
+              : m.admin_integrations_error_generic()}
+          </p>
+        )}
+
+        <div className="pt-2">
+          <Button
+            type="submit"
+            disabled={createMutation.isPending || !form.name.trim()}
+          >
+            {createMutation.isPending && (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            )}
+            {m.admin_integrations_create_submit()}
+          </Button>
+        </div>
+      </form>
+
+      {createdKey && (
+        <CreatedKeyModal
+          apiKey={createdKey}
+          open={!!createdKey}
+          onConfirm={handleKeyModalConfirm}
+        />
+      )}
+    </div>
+  )
+}

--- a/klai-portal/frontend/src/routes/admin/route.tsx
+++ b/klai-portal/frontend/src/routes/admin/route.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, Outlet, useNavigate } from '@tanstack/react-router'
 import { useEffect } from 'react'
 import { useAuth } from 'react-oidc-context'
-import { LayoutDashboard, Users, FolderKanban, Settings, CreditCard, Puzzle } from 'lucide-react'
+import { LayoutDashboard, Users, FolderKanban, Settings, CreditCard, Puzzle, Cable } from 'lucide-react'
 import { Sidebar } from '@/components/layout/Sidebar'
 import { HelpButton } from '@/components/help/HelpButton'
 import * as m from '@/paraglide/messages'
@@ -23,6 +23,7 @@ function AdminLayout() {
     { to: '/admin/users', label: m.admin_nav_users(), icon: Users },
     { to: '/admin/groups', label: m.admin_nav_groups(), icon: FolderKanban },
     { to: '/admin/billing', label: m.admin_nav_billing(), icon: CreditCard },
+    { to: '/admin/integrations', label: m.admin_nav_integrations(), icon: Cable },
     { to: '/admin/mcps', label: m.admin_nav_mcps(), icon: Puzzle },
     { to: '/admin/settings', label: m.admin_nav_settings(), icon: Settings },
   ]


### PR DESCRIPTION
## Summary

- New Partner API (`/partner/v1/*`) enabling external parties to integrate their own chat clients with Klai's knowledge layer
- OpenAI-compatible chat completions with RAG under the hood (streaming + non-streaming)
- Append-only knowledge ingestion (direct to knowledge layer, not via docs)
- Feedback endpoint integrated with existing quality boost pipeline
- API key auth with SHA-256 hashing, per-KB access levels (read/read_write), Redis rate limiting
- Admin Integrations UI (`/admin/integrations`) for key management: create, edit, revoke
- Caddy routing for `/partner/*` with 120rpm per-IP rate limit
- Full NL + EN i18n for admin UI

## Files changed

- **23 files**, +3885 lines
- 73 backend tests (all passing), TypeScript clean, Vite build succeeds

## Post-merge steps

1. Run Alembic migration: `docker compose exec portal-api alembic upgrade head`
2. Enable RLS as `klai` superuser on core-01:
   ```sql
   ALTER TABLE partner_api_keys ENABLE ROW LEVEL SECURITY;
   ALTER TABLE partner_api_key_kb_access ENABLE ROW LEVEL SECURITY;
   ```
3. Restart Caddy: `docker compose restart caddy`
4. Create first integration via `/admin/integrations` in the portal

## Test plan

- [ ] Alembic migration runs cleanly (upgrade + downgrade)
- [ ] RLS policies active on both tables
- [ ] Admin can create integration via portal UI, key shown once
- [ ] Partner client authenticates with `Bearer pk_live_...`
- [ ] Chat completions stream with KB-scoped retrieval
- [ ] Knowledge append lands in Qdrant (not via docs)
- [ ] Feedback correlates with retrieval log
- [ ] Rate limit triggers at configured RPM
- [ ] Revoked key returns 401
- [ ] Non-admin cannot access `/admin/integrations`

🤖 Generated with [Claude Code](https://claude.com/claude-code)