### PR TITLE
feat: SSO self-service domain allowlist and join requests (SPEC-AUTH-006)

### DIFF
--- a/.moai/specs/SPEC-AUTH-006/spec.md
+++ b/.moai/specs/SPEC-AUTH-006/spec.md
@@ -1,0 +1,444 @@
+---
+id: SPEC-AUTH-006
+version: "1.1.0"
+status: draft
+created: "2026-04-16"
+updated: "2026-04-16"
+author: MoAI
+priority: P1
+---
+
+## HISTORY
+
+| Date       | Version | Change                                                            |
+|------------|---------|-------------------------------------------------------------------|
+| 2026-04-16 | 1.0.0   | Initial SPEC creation                                             |
+| 2026-04-16 | 1.1.0   | Add R9 (multi-org workspace selection); relax domain uniqueness   |
+| 2026-04-16 | 1.2.0   | Fix three design issues: restore domain uniqueness for auto-join; fix join-request auth; replace URL token with Redis pending-session |
+
+# SPEC-AUTH-006: SSO Self-Service — Domain Allowlist & Join Requests
+
+## Context
+
+Social login (Google, Microsoft) is live since SPEC-AUTH-006 precursor work (2026-04-16). When a
+user authenticates via SSO but has no `portal_users` record, the portal sends them to the
+`/provisioning` page which polls forever and never resolves. Two things are needed:
+
+1. **Fase 2 — Domain allowlist**: Org admins configure trusted email domains
+   (e.g. `bedrijf.nl`). Any SSO user whose email matches is automatically provisioned as a
+   member of that org on first login — no invite required.
+
+2. **Fase 3 — Join requests**: When SSO authentication succeeds but neither a direct invite
+   nor a domain match exists, the user can submit a join request. The org admin receives an
+   email with an approve/deny link.
+
+A third prerequisite is out of scope for implementation here but is a dependency:
+
+> **Fase 1 (prerequisite, implement first):** Detect "authenticated but no org" in the
+> `callback.tsx` → `provisioning.tsx` flow and show a clear error page ("Je hebt geen Klai
+> account. Vraag je beheerder om je uit te nodigen.") instead of the infinite spinner.
+> This is a single frontend change with no backend work.
+
+---
+
+## Scope
+
+| Layer          | Changes                                                          |
+|----------------|------------------------------------------------------------------|
+| DB             | Two new tables: `portal_org_allowed_domains`, `portal_join_requests` |
+| Backend        | Auto-provision in `idp_callback`; new admin endpoints; klai-mailer extension |
+| Frontend       | Admin domain settings page; join request page; admin request management |
+| klai-mailer    | New `/internal/send` endpoint for platform-initiated transactional emails |
+
+## Out of Scope
+
+- SAML / enterprise SSO (Okta, Azure AD SSO at org level) — separate SPEC
+- Automatic domain detection from the user's existing email at account creation
+- Deprovisioning users when a domain is removed from the allowlist
+- Rate-limiting join requests per email address (low priority, can add later)
+
+---
+
+## Requirements
+
+### R1: Fase 1 — No-account error page (prerequisite)
+
+**WHEN** a user completes SSO authentication AND `GET /api/me` returns `workspace_url: null`
+AND `provisioning_status: "pending"` AND there is no `portal_users` row for this user,
+**THEN** the portal SHALL display a clear error page instead of the provisioning spinner.
+
+The page MUST communicate:
+- Authentication succeeded (Zitadel user exists)
+- No Klai workspace is linked to this account
+- Actionable next step: contact the org admin or sign up
+
+**Constraints:**
+- C1.1: The error page must distinguish from a real provisioning job in progress. Use
+  a new `me` field `org_found: bool` — `true` when a `portal_users` row exists, `false`
+  when authenticated but unlinked.
+- C1.2: The error page must not show the provisioning spinner at any point.
+- C1.3: The Zitadel user created by the first SSO attempt remains in Zitadel. The
+  backend does not delete it.
+
+### R2: Domain allowlist — data model
+
+**WHEN** an admin configures a trusted email domain for their org,
+**THEN** the system SHALL persist it in `portal_org_allowed_domains`:
+
+```sql
+CREATE TABLE portal_org_allowed_domains (
+    id          SERIAL PRIMARY KEY,
+    org_id      INTEGER NOT NULL REFERENCES portal_orgs(id) ON DELETE CASCADE,
+    domain      VARCHAR(253) NOT NULL,  -- e.g. "bedrijf.nl"
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    created_by  VARCHAR(64) NOT NULL,   -- zitadel_user_id of admin who added it
+    UNIQUE (org_id, domain)
+);
+```
+
+**Constraints:**
+- C2.1: `domain` is stored lowercase, leading/trailing whitespace stripped.
+- C2.2: A domain may be registered for at most ONE org (global unique constraint).
+  If a domain is already claimed, the API returns 409 Conflict.
+- C2.3: Only org admins (role = `admin`) may add or remove domains.
+- C2.4: RLS policy: org members can read, org admins can insert/delete, others see nothing.
+
+### R3: Domain allowlist — admin UI
+
+**WHEN** an admin navigates to Settings → Toegang (or equivalent),
+**THEN** they SHALL see a list of configured trusted domains with the ability to add or remove them.
+
+**Constraints:**
+- C3.1: Add form: single text field for the domain. Validation: valid domain format, not a
+  free email provider (block `gmail.com`, `hotmail.com`, `outlook.com`, `yahoo.com`, etc.).
+- C3.2: Remove: inline delete with confirmation (use `InlineDeleteConfirm` pattern).
+- C3.3: If the domain is already claimed by another org, show: "Dit domein is al gekoppeld
+  aan een andere organisatie."
+- C3.4: Route: `/admin/settings/domains` (new route, separate from existing settings pages).
+
+### R4: Domain allowlist — auto-provisioning on SSO login
+
+**WHEN** `GET /api/auth/idp-callback` is called (SSO flow completes),
+AND `create_session_with_idp_intent` succeeds,
+AND no `portal_users` row exists for the resulting `zitadel_user_id`,
+**THEN** the backend SHALL:
+
+1. Fetch the session details from Zitadel to get the user's `zitadel_user_id` and `email`.
+2. Extract the email domain (part after `@`, lowercased).
+3. Query `portal_org_allowed_domains` for a row matching that domain.
+4. If found: create a `portal_users` row with `role = "member"`, `status = "active"`.
+5. Continue with the normal `finalize_auth_request` + cookie + redirect flow.
+6. If not found: fall through to R5 (join request) or the no-account error page.
+
+**Constraints:**
+- C4.1: The Zitadel session details call is `GET /v2/sessions/{sessionId}` — the user ID
+  is in `session.factors.user.id`.
+- C4.2: Auto-provisioned users get `role = "member"`. Admins can promote later.
+- C4.3: The provisioning is synchronous — no background job. The redirect must complete
+  after the `portal_users` row is committed.
+- C4.4: If the DB insert fails (e.g. race with another request), log the error and fall
+  through to the join request flow rather than returning 500 to the user.
+- C4.5: Auto-provisioning does NOT create a personal knowledge base. That remains an
+  explicit invite-only step.
+
+### R5: Join requests — data model
+
+**WHEN** an SSO-authenticated user has no org and no domain match,
+**THEN** the system SHALL allow them to submit a join request, persisted in `portal_join_requests`:
+
+```sql
+CREATE TABLE portal_join_requests (
+    id              SERIAL PRIMARY KEY,
+    zitadel_user_id VARCHAR(64) NOT NULL,
+    email           VARCHAR(320) NOT NULL,
+    display_name    VARCHAR(128),
+    org_id          INTEGER REFERENCES portal_orgs(id) ON DELETE SET NULL,
+    status          VARCHAR(16) NOT NULL DEFAULT 'pending',
+       -- pending | approved | denied | expired
+    requested_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    reviewed_at     TIMESTAMPTZ,
+    reviewed_by     VARCHAR(64),   -- zitadel_user_id of admin who reviewed
+    approval_token  VARCHAR(128) UNIQUE NOT NULL,
+       -- HMAC-signed token for one-click email approval
+    expires_at      TIMESTAMPTZ NOT NULL DEFAULT now() + INTERVAL '7 days'
+);
+CREATE INDEX ON portal_join_requests (org_id, status);
+CREATE INDEX ON portal_join_requests (zitadel_user_id);
+```
+
+**Constraints:**
+- C5.1: `org_id` is derived from the email domain: if a domain match exists in
+  `portal_org_allowed_domains` but auto-provisioning was disabled, use that org. If no
+  domain match at all, `org_id = NULL` (platform-level request, reviewed by Klai team).
+- C5.2: One pending request per `zitadel_user_id`. Duplicate submissions return 200
+  (idempotent) without creating a second row.
+- C5.3: `approval_token` is an HMAC-SHA256 of `(request_id + zitadel_user_id)` using the
+  Fernet key. Tokens older than 7 days are expired automatically.
+- C5.4: RLS: no public access. Only admin role can read/update for their org. Platform
+  admin (internal service) can read/insert all.
+
+### R6: Join request — user flow
+
+**WHEN** SSO authentication succeeds but no org is found (R4 step 6),
+**THEN** the portal SHALL redirect to `/join-request` and display a form:
+- Pre-filled email (read-only, from Zitadel token)
+- Editable display name
+- Optional message to the admin (max 500 chars)
+- Submit button
+
+**WHEN** the user submits the form,
+**THEN** the backend SHALL:
+1. Create a `portal_join_requests` row.
+2. Send a notification email to all admins of the matched org (or to the Klai platform
+   address `access@getklai.com` if `org_id = NULL`).
+3. Show the user a confirmation: "Je verzoek is ingediend. De beheerder van de werkruimte
+   ontvangt een e-mail."
+
+**Constraints:**
+- C6.1: The join-request page is only reachable after SSO authentication — it reads
+  the email from the OIDC token, not from user input.
+- C6.2: If the user already has a pending request, show: "Er is al een verzoek ingediend
+  op [datum]. Neem contact op met je beheerder als je nog geen reactie hebt ontvangen."
+- C6.3: The submit endpoint is `POST /api/auth/join-request` (Bearer-authenticated —
+  the user has a valid OIDC token after completing SSO). The email is taken exclusively
+  from the verified OIDC token, never from the request body. Rate-limited: 3 requests
+  per `zitadel_user_id` per day (not per IP, since the user is authenticated).
+
+### R7: Join request — admin notification email
+
+**WHEN** a join request is created,
+**THEN** klai-mailer SHALL send an email to all active admins of the matched org
+containing:
+- Requester name and email
+- Approve button (links to `POST /api/admin/join-requests/{id}/approve?token={approval_token}`)
+- Deny button (links to `POST /api/admin/join-requests/{id}/deny?token={approval_token}`)
+- Expiry date (7 days from request)
+
+**Constraints:**
+- C7.1: Portal-api calls klai-mailer via a new internal endpoint
+  `POST /internal/send` (protected by `X-Internal-Secret` header, same secret as other
+  internal endpoints). Payload: `{ template, to, locale, variables }`.
+- C7.2: klai-mailer adds two new templates: `join_request_admin_nl` and `join_request_admin_en`.
+- C7.3: If email delivery fails, the join request is still persisted. Log the error at
+  `warn` level. The admin can still approve via the portal UI (R8).
+- C7.4: Subject: `[Klai] Toegangsverzoek van {name} ({email})`.
+
+### R8: Join request — admin management UI
+
+**WHEN** an admin navigates to Settings → Toegangsverzoeken (or equivalent),
+**THEN** they SHALL see a table of all pending join requests for their org with:
+- Requester name and email
+- Request date
+- Optional message
+- Approve / Deny action buttons
+
+**WHEN** the admin approves a request,
+**THEN** the backend SHALL:
+1. Create a `portal_users` row (role = "member").
+2. Mark the join request as `approved`.
+3. Send the newly provisioned user a confirmation email ("Je hebt toegang tot de Klai
+   werkruimte van {org_name}. Log in via {portal_url}") via klai-mailer.
+
+**WHEN** the admin denies a request,
+**THEN** the backend SHALL mark the request `denied` and optionally send a denial email.
+
+**Constraints:**
+- C8.1: Approve/deny via one-click email link (using `approval_token`) also works — no
+  portal login required for the admin action if they have the token.
+- C8.2: Route: `/admin/settings/join-requests`.
+- C8.3: Approved users do NOT automatically get a personal KB (same as R4-C4.5).
+- C8.4: After approval, the Zitadel user already exists — only `portal_users` is created.
+  No new Zitadel invite is sent.
+
+---
+
+## Data flow
+
+```
+SSO login flow (idp_callback)
+  └─ create_session_with_idp_intent → session
+  └─ GET /v2/sessions/{id} → zitadel_user_id, email
+  └─ portal_users lookup
+       ├─ found → normal login ✓
+       └─ not found
+             └─ domain match in portal_org_allowed_domains?
+                  ├─ yes → INSERT portal_users (auto-provision) → normal login ✓
+                  └─ no  → redirect to /join-request
+                              └─ POST /api/auth/join-request
+                                   └─ INSERT portal_join_requests
+                                   └─ notify admins via klai-mailer
+                                   └─ show confirmation page
+
+Admin approval flow
+  ├─ via email link: GET /api/admin/join-requests/{id}/approve?token=...
+  └─ via portal UI: POST /api/admin/join-requests/{id}/approve (Bearer auth)
+       └─ INSERT portal_users → notify user → mark approved
+```
+
+---
+
+## Dependencies
+
+| Dependency                  | Type     | Notes                                             |
+|-----------------------------|----------|---------------------------------------------------|
+| `GET /v2/sessions/{id}`     | Zitadel  | Needed to resolve user ID + email from session    |
+| `portal_org_allowed_domains`| New DB   | Alembic migration required                        |
+| `portal_join_requests`      | New DB   | Alembic migration required                        |
+| klai-mailer `/internal/send`| New API  | Shared `X-Internal-Secret` from existing config   |
+| `portal_users` INSERT       | Existing | Reuse pattern from `admin/users.py` invite flow   |
+
+---
+
+## Assumptions
+
+- A-001: A domain may only be claimed by one org globally for **auto-join**. This is
+  the industry-standard approach (Notion, Linear both enforce 1:1 for domain auto-join).
+  The workspace-picker (R9) handles users who are members of multiple orgs via invites —
+  a separate and distinct case. The global `UNIQUE(domain)` constraint is restored.
+- A-002: Free email provider blocklist is a static list in code, not configurable per org.
+- A-003: The Klai-mailer `/internal/send` endpoint can reuse the existing
+  `X-Internal-Secret` from `settings.internal_secret`.
+- A-004: Auto-provisioned and join-request-approved users are treated identically to
+  invited users after their `portal_users` row is created. No separate onboarding flow.
+
+---
+
+## Risks
+
+| Risk                                                        | Impact | Mitigation                               |
+|-------------------------------------------------------------|--------|------------------------------------------|
+| `GET /v2/sessions/{id}` adds latency to every IDP callback  | Low    | Only called when no existing portal_user; cache is negligible since this is a one-time path |
+| Domain squatting (attacker claims competitor's domain)       | High   | Manual review on add; C2.2 global unique; block free email providers |
+| Approval token leakage via email forwarding                  | Medium | HMAC token scoped to request ID + user ID; 7-day expiry; single-use (mark used on first call) |
+| Admin approves stale request (user already provisioned)      | Low    | Idempotent INSERT; unique constraint on (org_id, zitadel_user_id) prevents duplicate rows |
+| klai-mailer `/internal/send` call fails silently            | Medium | C7.3: join request persisted regardless; admin sees it in portal UI |
+
+---
+
+### R9: Multi-org workspace selection
+
+**Context:** A user may be a member of multiple Klai orgs — invited to each separately
+(e.g. an employee who also has admin access to a second workspace, or a consultant working
+across client accounts). Research shows Slack, Notion, and Linear all solve this with a
+workspace-picker screen after authentication — the dominant B2B SaaS pattern. This is
+distinct from the domain auto-join case: domains remain 1:1 (one domain → one org).
+The multi-org case arises from **invitations**, not from multiple orgs claiming the same domain.
+
+**WHEN** `idp_callback` resolves a `zitadel_user_id` that maps to `portal_users` rows in
+**multiple** orgs (user was invited to several),
+**THEN** the backend SHALL NOT redirect directly to a workspace. Instead it SHALL store a
+pending-session record in Redis (TTL 10 min) keyed by a random UUID, containing
+`{ zitadel_user_id, session_id, session_token, org_ids[] }`. The UUID is passed as a query
+parameter to the frontend `/select-workspace?ref={uuid}` — no sensitive data in the URL.
+
+**WHEN** the `/select-workspace` page renders,
+**THEN** it SHALL display all eligible workspaces (org name, logo if available) and allow
+the user to click one.
+
+**WHEN** the user selects a workspace,
+**THEN** the frontend calls `POST /api/auth/select-workspace` with `{ ref, org_id }`.
+The backend retrieves the pending-session from Redis, validates `org_id` is in the allowed
+list, sets the SSO cookie, deletes the Redis key (single-use), and returns the workspace URL.
+
+**Constraints:**
+- C9.1: Domain auto-join remains 1:1 (global `UNIQUE(domain)` constraint preserved in
+  `portal_org_allowed_domains`). Multi-org selection only applies to users with multiple
+  `portal_users` rows from invitations.
+- C9.2: The pending-session is stored in Redis (existing Redis instance), not in a URL
+  parameter. The URL contains only an opaque UUID. Session tokens never appear in URLs,
+  logs, or referer headers.
+- C9.3: If only one eligible org exists, skip the selection screen and go directly to
+  that workspace (no unnecessary extra step for the common case).
+- C9.4: The `/select-workspace` frontend route requires no Bearer token — the `ref` UUID
+  IS the short-lived credential at that point.
+- C9.5: Redis TTL: 10 minutes. Expired or missing ref → redirect to login.
+- C9.6: Auto-provisioning (R4) provisions the user into the one matched org (domain is
+  1:1). If after auto-provisioning the user is in multiple orgs, R9 applies.
+- C9.7: The workspace-picker page is part of the portal frontend (not a separate service),
+  served at `portal.getklai.com/select-workspace`.
+
+**Note on phasing:** R9 can be implemented after R2-R4 without breaking the earlier work.
+When only one org matches (the most common case today), the behaviour is identical to v1.0.
+The selection screen activates only when `org_ids` contains more than one entry.
+
+---
+
+## Acceptance Criteria
+
+### AC-1: Domain allowlist — happy path
+
+**Given** an admin has added `bedrijf.nl` as a trusted domain for org A
+**When** a new user authenticates via Google with email `jan@bedrijf.nl` for the first time
+**Then** a `portal_users` row is created for that user in org A with `role = "member"`
+**And** the user is redirected to their workspace without seeing the join request page
+**And** a second login by `jan@bedrijf.nl` goes through the normal session flow (no duplicate insert)
+
+### AC-2: Domain claim uniqueness
+
+**Given** org A has claimed domain `bedrijf.nl`
+**When** an admin of org B tries to add `bedrijf.nl`
+**Then** the API returns 409 Conflict with detail "Dit domein is al gekoppeld aan een andere organisatie"
+
+### AC-3: Free email provider blocked
+
+**Given** an admin of any org
+**When** they try to add `gmail.com` as a trusted domain
+**Then** the API returns 400 with detail "Gratis e-mailproviders kunnen niet als vertrouwd domein worden toegevoegd"
+
+### AC-4: Join request — new user, no domain match
+
+**Given** no org has claimed domain `freelancer.nl`
+**When** a new user authenticates via Google with email `jan@freelancer.nl`
+**Then** they are redirected to `/join-request`
+**And** submitting the form creates a `portal_join_requests` row
+**And** admins of the closest matching org (or `access@getklai.com` if no match) receive an email
+
+### AC-5: One-click approval from email
+
+**Given** an admin receives a join request email with an approval link
+**When** they click the approval link (no portal login required)
+**Then** the `portal_users` row is created
+**And** the join request is marked `approved`
+**And** the requester receives a confirmation email
+
+### AC-6: No duplicate join requests
+
+**Given** user has a pending join request
+**When** they submit the join request form again
+**Then** the API returns 200 with the existing request's status (idempotent, no new row)
+
+### AC-8: Multi-org workspace selection
+
+**Given** user `jan@acme.nl` is a member of org A and org B (both claimed `acme.nl`)
+**When** Jan authenticates via Google SSO
+**Then** he sees the workspace-picker page listing both workspaces
+**And** clicking org A redirects to `acme-a.getklai.com`
+
+**Given** user `jan@acme.nl` is a member of only one org
+**When** Jan authenticates via Google SSO
+**Then** the workspace-picker page is skipped and Jan lands directly in his workspace
+
+**Given** a workspace-selection token older than 10 minutes
+**When** a user visits `/select-workspace?token=...`
+**Then** they are redirected to the login page with an appropriate error
+
+### AC-9: Fase 1 — no-account error page
+
+**Given** an SSO-authenticated user has no `portal_users` row and no domain match
+**When** the portal's `/callback` route resolves
+**Then** the user sees a clear error page — NOT the provisioning spinner
+**And** the page includes a call to action (contact admin or request access via R6)
+
+---
+
+## Quality Gates
+
+- [ ] `uv run ruff format .` + `uv run ruff check .` — no new errors
+- [ ] `tsc --noEmit` — no new type errors
+- [ ] `npm run lint` — no new errors
+- [ ] Alembic migration is reversible (`downgrade` tested locally)
+- [ ] All user-facing strings in both `messages/en.json` and `messages/nl.json`
+- [ ] Free email provider blocklist covers at minimum: gmail.com, hotmail.com, outlook.com, yahoo.com, live.com, icloud.com, proton.me, gmx.com
+- [ ] CI green: portal-api + portal-frontend + SAST/Semgrep
+- [ ] Browser-verified: full auto-provision flow (Google login → auto member → workspace)
+- [ ] Browser-verified: full join request flow (no match → form → admin email → approve link → user access)

--- a/klai-mailer/app/config.py
+++ b/klai-mailer/app/config.py
@@ -31,6 +31,9 @@ class Settings(BaseSettings):
     # Shared secret — must match INTERNAL_SECRET in the portal .env
     portal_internal_secret: str = ""
 
+    # Internal service-to-service secret for /internal/send (portal-api → mailer)
+    internal_secret: str = ""
+
     # Set DEBUG=true to enable /debug endpoint (logs raw Zitadel payloads)
     debug: bool = False
 

--- a/klai-mailer/app/main.py
+++ b/klai-mailer/app/main.py
@@ -128,6 +128,93 @@ async def notify(request: Request) -> JSONResponse:
     return JSONResponse(status_code=200, content={"sent": True})
 
 
+# ---------------------------------------------------------------------------
+# Internal send endpoint (portal-api → mailer, SPEC-AUTH-006 R7)
+# ---------------------------------------------------------------------------
+
+# Simple templates for internal transactional emails
+_INTERNAL_TEMPLATES: dict[str, dict[str, dict[str, str]]] = {
+    "join_request_admin": {
+        "nl": {
+            "subject": "[Klai] Toegangsverzoek van {name} ({email})",
+            "body": (
+                "<p>Hallo,</p>"
+                "<p><strong>{name}</strong> ({email}) heeft een toegangsverzoek ingediend voor je Klai-werkruimte.</p>"
+                "<p>Je kunt het verzoek goedkeuren of afwijzen in de <a href='{brand_url}/admin/settings/join-requests'>beheeromgeving</a>.</p>"
+            ),
+        },
+        "en": {
+            "subject": "[Klai] Access request from {name} ({email})",
+            "body": (
+                "<p>Hello,</p>"
+                "<p><strong>{name}</strong> ({email}) has submitted an access request for your Klai workspace.</p>"
+                "<p>You can approve or deny the request in the <a href='{brand_url}/admin/settings/join-requests'>admin settings</a>.</p>"
+            ),
+        },
+    },
+    "join_request_approved": {
+        "nl": {
+            "subject": "[Klai] Je toegangsverzoek is goedgekeurd",
+            "body": (
+                "<p>Hallo {name},</p>"
+                "<p>Je toegangsverzoek voor Klai is goedgekeurd. Je kunt nu inloggen op je werkruimte:</p>"
+                "<p><a href='{workspace_url}'>{workspace_url}</a></p>"
+            ),
+        },
+        "en": {
+            "subject": "[Klai] Your access request has been approved",
+            "body": (
+                "<p>Hello {name},</p>"
+                "<p>Your access request for Klai has been approved. You can now log in to your workspace:</p>"
+                "<p><a href='{workspace_url}'>{workspace_url}</a></p>"
+            ),
+        },
+    },
+}
+
+
+@app.post("/internal/send")
+async def internal_send(request: Request) -> JSONResponse:
+    """Send a transactional email using a predefined template.
+
+    Authenticated via X-Internal-Secret header (same as portal-api internal endpoints).
+    """
+    if not settings.internal_secret or request.headers.get("X-Internal-Secret") != settings.internal_secret:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+    body = json.loads(await request.body())
+    template_name = body.get("template", "")
+    to_address = body.get("to", "")
+    locale = body.get("locale", "nl")
+    variables = body.get("variables", {})
+
+    template = _INTERNAL_TEMPLATES.get(template_name)
+    if not template:
+        raise HTTPException(status_code=400, detail=f"Unknown template: {template_name}")
+
+    lang_template = template.get(locale, template.get("nl", {}))
+
+    # Add branding vars
+    variables["brand_url"] = settings.brand_url
+
+    subject = lang_template["subject"].format(**variables)
+    body_html = lang_template["body"].format(**variables)
+
+    # Wrap in the Klai email template
+    html_email = renderer.wrap(
+        {"subject": subject, "body": body_html, "button_url": "", "button_text": ""},
+        _branding,
+    )
+
+    if to_address:
+        await send_email(to_address=to_address, subject=subject, html_body=html_email)
+        logger.info("Internal email sent template=%s to=%s", template_name, to_address)
+    else:
+        logger.warning("No to_address for internal email template=%s", template_name)
+
+    return JSONResponse(status_code=200, content={"sent": True})
+
+
 @app.post("/debug")
 async def debug(request: Request) -> JSONResponse:
     """

--- a/klai-portal/backend/alembic/versions/a1b2c3d4e5f6_add_portal_org_allowed_domains.py
+++ b/klai-portal/backend/alembic/versions/a1b2c3d4e5f6_add_portal_org_allowed_domains.py
@@ -1,0 +1,34 @@
+"""add portal_org_allowed_domains table
+
+Revision ID: a1b2c3d4e5f6
+Revises: z3a4b5c6d7e8
+Create Date: 2026-04-16
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "a1b2c3d4e5f6"
+down_revision = "z3a4b5c6d7e8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "portal_org_allowed_domains",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("org_id", sa.Integer(), sa.ForeignKey("portal_orgs.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("domain", sa.String(253), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("created_by", sa.String(64), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("org_id", "domain", name="uq_org_allowed_domains_org_domain"),
+        sa.UniqueConstraint("domain", name="uq_org_allowed_domains_domain_global"),
+    )
+    op.create_index("ix_portal_org_allowed_domains_domain", "portal_org_allowed_domains", ["domain"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_portal_org_allowed_domains_domain", table_name="portal_org_allowed_domains")
+    op.drop_table("portal_org_allowed_domains")

--- a/klai-portal/backend/alembic/versions/b2c3d4e5f6g7_add_portal_join_requests.py
+++ b/klai-portal/backend/alembic/versions/b2c3d4e5f6g7_add_portal_join_requests.py
@@ -1,0 +1,40 @@
+"""add portal_join_requests table
+
+Revision ID: b2c3d4e5f6g7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-04-16
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "b2c3d4e5f6g7"
+down_revision = "a1b2c3d4e5f6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "portal_join_requests",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("zitadel_user_id", sa.String(64), nullable=False),
+        sa.Column("email", sa.String(320), nullable=False),
+        sa.Column("display_name", sa.String(128), nullable=True),
+        sa.Column("org_id", sa.Integer(), sa.ForeignKey("portal_orgs.id", ondelete="SET NULL"), nullable=True),
+        sa.Column("status", sa.String(16), nullable=False, server_default="pending"),
+        sa.Column("requested_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("reviewed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("reviewed_by", sa.String(64), nullable=True),
+        sa.Column("approval_token", sa.String(128), unique=True, nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_portal_join_requests_org_status", "portal_join_requests", ["org_id", "status"])
+    op.create_index("ix_portal_join_requests_zitadel_user_id", "portal_join_requests", ["zitadel_user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_portal_join_requests_zitadel_user_id", table_name="portal_join_requests")
+    op.drop_index("ix_portal_join_requests_org_status", table_name="portal_join_requests")
+    op.drop_table("portal_join_requests")

--- a/klai-portal/backend/alembic/versions/c3d4e5f6g7h8_portal_users_multi_org.py
+++ b/klai-portal/backend/alembic/versions/c3d4e5f6g7h8_portal_users_multi_org.py
@@ -1,0 +1,34 @@
+"""change portal_users unique constraint for multi-org support
+
+Revision ID: c3d4e5f6g7h8
+Revises: b2c3d4e5f6g7
+Create Date: 2026-04-16
+"""
+
+from alembic import op
+
+revision = "c3d4e5f6g7h8"
+down_revision = "b2c3d4e5f6g7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Drop the old global unique constraint on zitadel_user_id
+    op.drop_index("ix_portal_users_zitadel_user_id", table_name="portal_users")
+    op.drop_constraint("portal_users_zitadel_user_id_key", table_name="portal_users", type_="unique")
+
+    # Add composite unique constraint: one user per org
+    op.create_unique_constraint(
+        "uq_portal_users_zitadel_user_org",
+        "portal_users",
+        ["zitadel_user_id", "org_id"],
+    )
+    # Re-create index (non-unique now)
+    op.create_index("ix_portal_users_zitadel_user_id", "portal_users", ["zitadel_user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_portal_users_zitadel_user_id", table_name="portal_users")
+    op.drop_constraint("uq_portal_users_zitadel_user_org", table_name="portal_users", type_="unique")
+    op.create_index("ix_portal_users_zitadel_user_id", "portal_users", ["zitadel_user_id"], unique=True)

--- a/klai-portal/backend/app/api/admin/__init__.py
+++ b/klai-portal/backend/app/api/admin/__init__.py
@@ -60,6 +60,8 @@ def _require_admin(caller_user: "PortalUser") -> None:
 
 # --- Sub-router inclusion (no prefix on sub-routers!) ---
 from .audit import router as audit_router  # noqa: E402
+from .domains import router as domains_router  # noqa: E402
+from .join_requests import router as join_requests_router  # noqa: E402
 from .products import router as products_router  # noqa: E402
 from .settings import router as settings_router  # noqa: E402
 from .users import router as users_router  # noqa: E402
@@ -68,6 +70,8 @@ router.include_router(users_router)
 router.include_router(products_router)
 router.include_router(settings_router)
 router.include_router(audit_router)
+router.include_router(domains_router)
+router.include_router(join_requests_router)
 
 __all__ = [
     "_get_caller_org",

--- a/klai-portal/backend/app/api/admin/domains.py
+++ b/klai-portal/backend/app/api/admin/domains.py
@@ -1,0 +1,159 @@
+"""
+Admin endpoints for managing allowed email domains (SPEC-AUTH-006 R3).
+
+GET    /api/admin/domains         -- list org's allowed domains
+POST   /api/admin/domains         -- add a new allowed domain
+DELETE /api/admin/domains/{id}    -- remove an allowed domain
+"""
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.admin import _get_caller_org, _require_admin, bearer
+from app.core.database import get_db
+from app.models.portal import PortalOrgAllowedDomain
+from app.services.domain_validation import is_free_email_provider, is_valid_domain, normalize_domain
+
+logger = structlog.get_logger()
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Request / Response models
+# ---------------------------------------------------------------------------
+
+
+class DomainItem(BaseModel):
+    id: int
+    domain: str
+    created_at: str
+    created_by: str
+
+
+class DomainsResponse(BaseModel):
+    domains: list[DomainItem]
+
+
+class AddDomainRequest(BaseModel):
+    domain: str
+
+
+class AddDomainResponse(BaseModel):
+    id: int
+    domain: str
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/domains", response_model=DomainsResponse)
+async def list_domains(
+    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    db: AsyncSession = Depends(get_db),
+) -> DomainsResponse:
+    """List all allowed email domains for the caller's org."""
+    _zitadel_user_id, org, caller_user = await _get_caller_org(credentials, db)
+    _require_admin(caller_user)
+
+    result = await db.execute(
+        select(PortalOrgAllowedDomain)
+        .where(PortalOrgAllowedDomain.org_id == org.id)
+        .order_by(PortalOrgAllowedDomain.created_at.desc())
+    )
+    rows = result.scalars().all()
+
+    return DomainsResponse(
+        domains=[
+            DomainItem(
+                id=row.id,
+                domain=row.domain,
+                created_at=str(row.created_at),
+                created_by=row.created_by,
+            )
+            for row in rows
+        ]
+    )
+
+
+@router.post("/domains", response_model=AddDomainResponse, status_code=status.HTTP_201_CREATED)
+async def add_domain(
+    body: AddDomainRequest,
+    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    db: AsyncSession = Depends(get_db),
+) -> AddDomainResponse:
+    """Add a new allowed email domain for the caller's org."""
+    zitadel_user_id, org, caller_user = await _get_caller_org(credentials, db)
+    _require_admin(caller_user)
+
+    domain = normalize_domain(body.domain)
+
+    if not is_valid_domain(domain):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid domain format",
+        )
+
+    if is_free_email_provider(domain):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Free email providers cannot be used as allowed domains",
+        )
+
+    new_domain = PortalOrgAllowedDomain(
+        org_id=org.id,
+        domain=domain,
+        created_by=zitadel_user_id,
+    )
+    db.add(new_domain)
+
+    try:
+        await db.flush()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Domain already exists",
+        ) from exc
+
+    await db.commit()
+    await db.refresh(new_domain)
+
+    logger.info("Domain added", org_id=org.id, domain=domain, added_by=zitadel_user_id)
+    return AddDomainResponse(id=new_domain.id, domain=new_domain.domain)
+
+
+@router.delete("/domains/{domain_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_domain(
+    domain_id: int,
+    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Remove an allowed email domain (org-scoped)."""
+    zitadel_user_id, org, caller_user = await _get_caller_org(credentials, db)
+    _require_admin(caller_user)
+
+    result = await db.execute(
+        select(PortalOrgAllowedDomain).where(
+            PortalOrgAllowedDomain.id == domain_id,
+            PortalOrgAllowedDomain.org_id == org.id,
+        )
+    )
+    domain = result.scalar_one_or_none()
+    if not domain:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Domain not found",
+        )
+
+    await db.delete(domain)
+    await db.commit()
+
+    logger.info("Domain removed", org_id=org.id, domain=domain.domain, removed_by=zitadel_user_id)

--- a/klai-portal/backend/app/api/admin/join_requests.py
+++ b/klai-portal/backend/app/api/admin/join_requests.py
@@ -1,0 +1,217 @@
+"""
+Admin endpoints for managing join requests (SPEC-AUTH-006 R8).
+
+GET    /api/admin/join-requests            -- list pending requests for org
+POST   /api/admin/join-requests/{id}/approve -- approve and create portal_users row
+POST   /api/admin/join-requests/{id}/deny    -- deny request
+"""
+
+from datetime import UTC, datetime
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.security import HTTPAuthorizationCredentials
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.admin import _get_caller_org, _require_admin, bearer
+from app.core.config import settings
+from app.core.database import get_db
+from app.models.portal import PortalJoinRequest, PortalUser
+from app.services.join_request_token import verify_approval_token
+from app.services.notifications import notify_user_join_approved
+
+logger = structlog.get_logger()
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+
+
+class JoinRequestItem(BaseModel):
+    id: int
+    zitadel_user_id: str
+    email: str
+    display_name: str | None
+    status: str
+    requested_at: str
+    approval_token: str
+
+
+class JoinRequestsResponse(BaseModel):
+    requests: list[JoinRequestItem]
+
+
+class ApproveResponse(BaseModel):
+    message: str
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/join-requests", response_model=JoinRequestsResponse)
+async def list_join_requests(
+    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    db: AsyncSession = Depends(get_db),
+) -> JoinRequestsResponse:
+    """List pending join requests for the caller's org."""
+    _zitadel_user_id, org, caller_user = await _get_caller_org(credentials, db)
+    _require_admin(caller_user)
+
+    result = await db.execute(
+        select(PortalJoinRequest)
+        .where(
+            PortalJoinRequest.org_id == org.id,
+            PortalJoinRequest.status == "pending",
+        )
+        .order_by(PortalJoinRequest.requested_at.desc())
+    )
+    rows = result.scalars().all()
+
+    return JoinRequestsResponse(
+        requests=[
+            JoinRequestItem(
+                id=row.id,
+                zitadel_user_id=row.zitadel_user_id,
+                email=row.email,
+                display_name=row.display_name,
+                status=row.status,
+                requested_at=str(row.requested_at),
+                approval_token=row.approval_token,
+            )
+            for row in rows
+        ]
+    )
+
+
+@router.post("/join-requests/{request_id}/approve", response_model=ApproveResponse)
+async def approve_join_request(
+    request_id: int,
+    credentials: HTTPAuthorizationCredentials | None = Depends(bearer),
+    db: AsyncSession = Depends(get_db),
+    token: str | None = Query(default=None),
+) -> ApproveResponse:
+    """Approve a join request — creates a portal_users row.
+
+    Can be called with:
+    - Bearer token (admin UI) — requires admin role
+    - ?token= query param (email one-click link) — no Bearer required
+    """
+    # Token-based approval (email link)
+    if token:
+        jr_result = await db.execute(
+            select(PortalJoinRequest).where(
+                PortalJoinRequest.id == request_id,
+                PortalJoinRequest.status == "pending",
+            )
+        )
+        jr = jr_result.scalar_one_or_none()
+        if not jr:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Request not found")
+
+        if not verify_approval_token(token, jr.id, jr.zitadel_user_id):
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid approval token")
+
+        if jr.expires_at and jr.expires_at < datetime.now(tz=UTC):
+            raise HTTPException(status_code=status.HTTP_410_GONE, detail="Request has expired")
+
+        reviewer = "email-link"
+        org_id = jr.org_id
+    else:
+        # Bearer-based approval (admin UI)
+        zitadel_user_id, org, caller_user = await _get_caller_org(credentials, db)
+        _require_admin(caller_user)
+
+        jr_result = await db.execute(
+            select(PortalJoinRequest).where(
+                PortalJoinRequest.id == request_id,
+                PortalJoinRequest.org_id == org.id,
+                PortalJoinRequest.status == "pending",
+            )
+        )
+        jr = jr_result.scalar_one_or_none()
+        if not jr:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Request not found")
+
+        reviewer = zitadel_user_id
+        org_id = org.id
+
+    # Create portal_users row
+    new_user = PortalUser(
+        zitadel_user_id=jr.zitadel_user_id,
+        org_id=org_id,
+        role="member",
+        status="active",
+        display_name=jr.display_name,
+        email=jr.email,
+    )
+    db.add(new_user)
+
+    # Mark request as approved
+    jr.status = "approved"
+    jr.reviewed_at = datetime.now(tz=UTC)
+    jr.reviewed_by = reviewer
+
+    await db.commit()
+
+    logger.info(
+        "Join request approved",
+        request_id=request_id,
+        zitadel_user_id=jr.zitadel_user_id,
+        org_id=org_id,
+        reviewer=reviewer,
+    )
+
+    # Send approval notification email (non-blocking)
+    workspace_url = f"https://{settings.domain}"
+    try:
+        await notify_user_join_approved(
+            email=jr.email,
+            display_name=jr.display_name or jr.email,
+            workspace_url=workspace_url,
+        )
+    except Exception:
+        logger.warning("Approval notification email failed", request_id=request_id)
+
+    return ApproveResponse(message="Request approved")
+
+
+@router.post("/join-requests/{request_id}/deny", status_code=status.HTTP_204_NO_CONTENT)
+async def deny_join_request(
+    request_id: int,
+    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Deny a join request."""
+    zitadel_user_id, org, caller_user = await _get_caller_org(credentials, db)
+    _require_admin(caller_user)
+
+    jr_result = await db.execute(
+        select(PortalJoinRequest).where(
+            PortalJoinRequest.id == request_id,
+            PortalJoinRequest.org_id == org.id,
+            PortalJoinRequest.status == "pending",
+        )
+    )
+    jr = jr_result.scalar_one_or_none()
+    if not jr:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Request not found")
+
+    jr.status = "denied"
+    jr.reviewed_at = datetime.now(tz=UTC)
+    jr.reviewed_by = zitadel_user_id
+    await db.commit()
+
+    logger.info(
+        "Join request denied",
+        request_id=request_id,
+        zitadel_user_id=jr.zitadel_user_id,
+        org_id=org.id,
+        reviewer=zitadel_user_id,
+    )

--- a/klai-portal/backend/app/api/admin/join_requests.py
+++ b/klai-portal/backend/app/api/admin/join_requests.py
@@ -39,7 +39,6 @@ class JoinRequestItem(BaseModel):
     display_name: str | None
     status: str
     requested_at: str
-    approval_token: str
 
 
 class JoinRequestsResponse(BaseModel):
@@ -83,7 +82,6 @@ async def list_join_requests(
                 display_name=row.display_name,
                 status=row.status,
                 requested_at=str(row.requested_at),
-                approval_token=row.approval_token,
             )
             for row in rows
         ]
@@ -123,6 +121,11 @@ async def approve_join_request(
 
         reviewer = "email-link"
         org_id = jr.org_id
+        if not org_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="This request has no organisation assigned. Approve it from the admin panel.",
+            )
     else:
         # Bearer-based approval (admin UI)
         zitadel_user_id, org, caller_user = await _get_caller_org(credentials, db)

--- a/klai-portal/backend/app/api/auth.py
+++ b/klai-portal/backend/app/api/auth.py
@@ -37,6 +37,7 @@ import time
 from urllib.parse import quote, urlparse
 
 import httpx
+import structlog
 from cryptography.fernet import Fernet
 from fastapi import APIRouter, Cookie, Depends, HTTPException, Query, Request, Response, status
 from fastapi.responses import RedirectResponse
@@ -47,12 +48,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.core.database import get_db
-from app.models.portal import PortalOrg, PortalUser
+from app.models.portal import PortalOrg, PortalOrgAllowedDomain, PortalUser
 from app.services import audit
 from app.services.events import emit_event
 from app.services.zitadel import zitadel
 
 logger = logging.getLogger(__name__)
+_slog = structlog.get_logger()
 
 router = APIRouter(prefix="/api", tags=["auth"])
 bearer = HTTPBearer()
@@ -784,12 +786,14 @@ async def idp_callback(
     id: str,
     token: str,
     auth_request_id: str,
+    db: AsyncSession = Depends(get_db),
 ) -> RedirectResponse:
     """Handle the redirect back from a social IDP after authentication.
 
     Zitadel appends ?id=<intentId>&token=<intentToken> to the success_url.
-    We create a session from the intent, finalize the auth request, set the SSO
-    cookie, and redirect to the OIDC callback URL — identical to the password flow.
+    We create a session from the intent, look up portal_users, auto-provision
+    if an allowed domain matches, finalize the auth request, set the SSO cookie,
+    and redirect to the OIDC callback URL.
     """
     failure_url = f"/login?authRequest={auth_request_id}"
 
@@ -806,6 +810,78 @@ async def idp_callback(
         logger.error("create_session_with_idp_intent returned no session: %s", session)
         return RedirectResponse(url=failure_url, status_code=302)
 
+    # Fetch user identity from the session
+    try:
+        details = await zitadel.get_session_details(session_id, session_token)
+    except Exception:
+        logger.exception("get_session_details failed — continuing without auto-provision")
+        details = {"zitadel_user_id": "", "email": ""}
+
+    zitadel_user_id = details.get("zitadel_user_id", "")
+    email = details.get("email", "")
+
+    # Look up existing portal_users rows for this zitadel_user_id
+    if zitadel_user_id:
+        user_result = await db.execute(select(PortalUser).where(PortalUser.zitadel_user_id == zitadel_user_id))
+        existing_users = user_result.scalars().all()
+    else:
+        existing_users = []
+
+    # C9.3: Multiple orgs → Redis pending-session, redirect to /select-workspace
+    if len(existing_users) > 1:
+        from app.services.pending_session import PendingSessionService
+
+        try:
+            svc = PendingSessionService()
+            ref = await svc.store(
+                session_id=session_id,
+                session_token=session_token,
+                zitadel_user_id=zitadel_user_id,
+                email=email,
+                auth_request_id=auth_request_id,
+                org_ids=[u.org_id for u in existing_users],
+            )
+            return RedirectResponse(url=f"/select-workspace?ref={ref}", status_code=302)
+        except Exception:
+            _slog.exception("Failed to store pending session — falling through to first org")
+
+    if not existing_users and zitadel_user_id and email:
+        # No portal_users row — check allowed domains for auto-provision
+        email_domain = email.rsplit("@", 1)[-1].lower() if "@" in email else ""
+        if email_domain:
+            domain_result = await db.execute(
+                select(PortalOrgAllowedDomain).where(PortalOrgAllowedDomain.domain == email_domain)
+            )
+            matched_domain = domain_result.scalar_one_or_none()
+
+            if matched_domain:
+                # C4.4: DB error → log + fall through, never 500
+                try:
+                    new_user = PortalUser(
+                        zitadel_user_id=zitadel_user_id,
+                        org_id=matched_domain.org_id,
+                        role="member",
+                        status="active",
+                        display_name=email.split("@")[0],
+                        email=email,
+                    )
+                    db.add(new_user)
+                    await db.commit()
+                    _slog.info(
+                        "Auto-provisioned SSO user",
+                        zitadel_user_id=zitadel_user_id,
+                        org_id=matched_domain.org_id,
+                        domain=email_domain,
+                    )
+                except Exception:
+                    _slog.exception(
+                        "Auto-provision failed — user will see no-account page",
+                        zitadel_user_id=zitadel_user_id,
+                    )
+                    await db.rollback()
+
+    # Finalize the auth request (always, even if no portal_users row)
+    # The callback.tsx will check org_found and redirect to /no-account if needed
     try:
         callback_url = await zitadel.finalize_auth_request(
             auth_request_id=auth_request_id,
@@ -826,7 +902,7 @@ async def idp_callback(
         samesite="lax",
         max_age=settings.sso_cookie_max_age,
     )
-    emit_event("login", user_id=None, properties={"method": "idp"})
+    emit_event("login", user_id=zitadel_user_id or None, properties={"method": "idp"})
     return redirect
 
 

--- a/klai-portal/backend/app/api/auth_join.py
+++ b/klai-portal/backend/app/api/auth_join.py
@@ -1,0 +1,123 @@
+"""
+Join request endpoint for SSO users without an org (SPEC-AUTH-006 R6).
+
+POST /api/auth/join-request  -- Bearer auth required (OIDC token)
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from pydantic import BaseModel
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.auth import get_current_user_id
+from app.core.database import get_db
+from app.models.portal import PortalJoinRequest
+from app.services.join_request_token import generate_approval_token
+from app.services.notifications import notify_admin_join_request
+from app.services.zitadel import zitadel
+
+logger = structlog.get_logger()
+
+router = APIRouter(prefix="/api", tags=["auth"])
+bearer = HTTPBearer()
+
+# C6.3: rate limit 3/day per zitadel_user_id
+_RATE_LIMIT_PER_DAY = 3
+_REQUEST_EXPIRY_DAYS = 7
+
+
+class JoinRequestResponse(BaseModel):
+    id: int
+    status: str
+    requested_at: str
+
+
+@router.post("/auth/join-request", response_model=JoinRequestResponse)
+async def create_join_request(
+    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    user_id: str = Depends(get_current_user_id),
+    db: AsyncSession = Depends(get_db),
+) -> JoinRequestResponse:
+    """Create a join request for an SSO user with no portal_users row.
+
+    Email is extracted from OIDC token only (never from request body).
+    Idempotent: returns existing pending request if one exists.
+    Rate-limited: 3 requests per day per zitadel_user_id.
+    """
+    # Get email from OIDC token
+    info = await zitadel.get_userinfo(credentials.credentials)
+    email = info.get("email", "")
+    display_name = info.get("name", info.get("preferred_username", ""))
+
+    # C5.2: one pending per zitadel_user_id (idempotent)
+    pending_result = await db.execute(
+        select(PortalJoinRequest).where(
+            PortalJoinRequest.zitadel_user_id == user_id,
+            PortalJoinRequest.status == "pending",
+        )
+    )
+    existing = pending_result.scalar_one_or_none()
+    if existing:
+        return JoinRequestResponse(
+            id=existing.id,
+            status=existing.status,
+            requested_at=str(existing.requested_at),
+        )
+
+    # C6.3: rate limit 3/day per zitadel_user_id
+    today_start = datetime.now(tz=UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+    count_result = await db.execute(
+        select(func.count())
+        .select_from(PortalJoinRequest)
+        .where(
+            PortalJoinRequest.zitadel_user_id == user_id,
+            PortalJoinRequest.requested_at >= today_start,
+        )
+    )
+    count = count_result.scalar_one()
+    if count >= _RATE_LIMIT_PER_DAY:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many join requests today. Please try again tomorrow.",
+        )
+
+    # Create the join request (approval_token needs id, so we use a placeholder first)
+    new_request = PortalJoinRequest(
+        zitadel_user_id=user_id,
+        email=email,
+        display_name=display_name,
+        org_id=None,  # No org yet
+        status="pending",
+        approval_token="placeholder",  # noqa: S106  # Will be updated after flush
+        expires_at=datetime.now(tz=UTC) + timedelta(days=_REQUEST_EXPIRY_DAYS),
+    )
+    db.add(new_request)
+    await db.flush()
+
+    # Generate deterministic HMAC token using the assigned id
+    new_request.approval_token = generate_approval_token(new_request.id, user_id)
+    await db.commit()
+    await db.refresh(new_request)
+
+    logger.info(
+        "Join request created",
+        request_id=new_request.id,
+        zitadel_user_id=user_id,
+        email=email,
+    )
+
+    # C7.3: email failure never blocks join request creation
+    try:
+        await notify_admin_join_request(email=email, display_name=display_name)
+    except Exception:
+        logger.warning("Admin notification failed for join request", request_id=new_request.id)
+
+    return JoinRequestResponse(
+        id=new_request.id,
+        status=new_request.status,
+        requested_at=str(new_request.requested_at),
+    )

--- a/klai-portal/backend/app/api/auth_join.py
+++ b/klai-portal/backend/app/api/auth_join.py
@@ -54,11 +54,14 @@ async def create_join_request(
     display_name = info.get("name", info.get("preferred_username", ""))
 
     # C5.2: one pending per zitadel_user_id (idempotent)
+    # with_for_update prevents two concurrent requests from both inserting a duplicate
     pending_result = await db.execute(
-        select(PortalJoinRequest).where(
+        select(PortalJoinRequest)
+        .where(
             PortalJoinRequest.zitadel_user_id == user_id,
             PortalJoinRequest.status == "pending",
         )
+        .with_for_update()
     )
     existing = pending_result.scalar_one_or_none()
     if existing:

--- a/klai-portal/backend/app/api/auth_select.py
+++ b/klai-portal/backend/app/api/auth_select.py
@@ -1,0 +1,106 @@
+"""
+Workspace selection endpoint for multi-org SSO users (SPEC-AUTH-006 R9).
+
+POST /api/auth/select-workspace  -- no Bearer required, uses ref from Redis
+"""
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.database import get_db
+from app.models.portal import PortalOrg
+from app.services.events import emit_event
+from app.services.pending_session import PendingSessionService
+from app.services.zitadel import zitadel
+
+logger = structlog.get_logger()
+
+router = APIRouter(prefix="/api", tags=["auth"])
+
+pending_session_svc = PendingSessionService()
+
+
+class SelectWorkspaceRequest(BaseModel):
+    ref: str
+    org_id: int
+
+
+class SelectWorkspaceResponse(BaseModel):
+    workspace_url: str
+
+
+@router.post("/auth/select-workspace", response_model=SelectWorkspaceResponse)
+async def select_workspace(
+    body: SelectWorkspaceRequest,
+    db: AsyncSession = Depends(get_db),
+) -> SelectWorkspaceResponse:
+    """Select a workspace from a pending multi-org SSO session.
+
+    The ref is a UUID stored in Redis by idp_callback when the user
+    has multiple portal_users rows. This endpoint consumes (one-time use)
+    the pending session, finalizes the auth request for the selected org,
+    and returns the workspace URL.
+    """
+    # Consume pending session (one-time use)
+    session_data = await pending_session_svc.consume(body.ref)
+    if not session_data:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Session not found or expired",
+        )
+
+    # Validate that the selected org_id is in the allowed list
+    allowed_org_ids = session_data.get("org_ids", [])
+    if body.org_id not in allowed_org_ids:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Organisation not available for this user",
+        )
+
+    # Look up the org to get slug for workspace URL
+    result = await db.execute(select(PortalOrg).where(PortalOrg.id == body.org_id))
+    org = result.scalar_one_or_none()
+    if not org:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Organisation not found",
+        )
+
+    # Finalize the auth request
+    session_id = session_data["session_id"]
+    session_token = session_data["session_token"]
+    auth_request_id = session_data["auth_request_id"]
+
+    try:
+        await zitadel.finalize_auth_request(
+            auth_request_id=auth_request_id,
+            session_id=session_id,
+            session_token=session_token,
+        )
+    except Exception as exc:
+        logger.exception("finalize_auth_request failed in select-workspace")
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Login failed, please try again",
+        ) from exc
+
+    workspace_url = f"https://{org.slug}.{settings.domain}"
+
+    emit_event(
+        "login",
+        user_id=session_data.get("zitadel_user_id"),
+        properties={"method": "idp", "multi_org": True, "org_id": body.org_id},
+    )
+
+    logger.info(
+        "Workspace selected",
+        zitadel_user_id=session_data.get("zitadel_user_id"),
+        org_id=body.org_id,
+        workspace_url=workspace_url,
+    )
+
+    return SelectWorkspaceResponse(workspace_url=workspace_url)

--- a/klai-portal/backend/app/api/auth_select.py
+++ b/klai-portal/backend/app/api/auth_select.py
@@ -5,7 +5,7 @@ POST /api/auth/select-workspace  -- no Bearer required, uses ref from Redis
 """
 
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -24,6 +24,16 @@ router = APIRouter(prefix="/api", tags=["auth"])
 pending_session_svc = PendingSessionService()
 
 
+class PendingSessionOrg(BaseModel):
+    id: int
+    name: str
+    slug: str
+
+
+class PendingSessionResponse(BaseModel):
+    orgs: list[PendingSessionOrg]
+
+
 class SelectWorkspaceRequest(BaseModel):
     ref: str
     org_id: int
@@ -31,6 +41,36 @@ class SelectWorkspaceRequest(BaseModel):
 
 class SelectWorkspaceResponse(BaseModel):
     workspace_url: str
+
+
+@router.get("/auth/pending-session", response_model=PendingSessionResponse)
+async def get_pending_session(
+    ref: str = Query(...),
+    db: AsyncSession = Depends(get_db),
+) -> PendingSessionResponse:
+    """Return the orgs available for a pending multi-org session (non-consuming).
+
+    Used by the select-workspace page to show workspace names before the user
+    submits their choice.
+    """
+    session_data = await pending_session_svc.retrieve(ref)
+    if not session_data:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Session not found or expired",
+        )
+
+    org_ids: list[int] = session_data.get("org_ids", [])
+    result = await db.execute(select(PortalOrg).where(PortalOrg.id.in_(org_ids)))
+    orgs_by_id = {org.id: org for org in result.scalars().all()}
+
+    return PendingSessionResponse(
+        orgs=[
+            PendingSessionOrg(id=oid, name=orgs_by_id[oid].name, slug=orgs_by_id[oid].slug)
+            for oid in org_ids
+            if oid in orgs_by_id
+        ]
+    )
 
 
 @router.post("/auth/select-workspace", response_model=SelectWorkspaceResponse)

--- a/klai-portal/backend/app/api/me.py
+++ b/klai-portal/backend/app/api/me.py
@@ -53,6 +53,7 @@ class MeResponse(BaseModel):
     preferred_language: Literal["nl", "en"] = "nl"
     portal_role: str = "member"
     products: list[str] = []
+    org_found: bool = False
 
 
 def _extract_roles(info: dict) -> list[str]:
@@ -89,6 +90,7 @@ async def me(
     mfa_policy: str = "optional"
     preferred_language: Literal["nl", "en"] = "nl"
     portal_role: str = "member"
+    org_found: bool = False
     if zitadel_user_id:
         result = await db.execute(
             select(PortalOrg, PortalUser)
@@ -98,6 +100,7 @@ async def me(
         row = result.one_or_none()
         if row:
             org, portal_user = row
+            org_found = True
             provisioning_status = org.provisioning_status
             mfa_policy = org.mfa_policy
             preferred_language = portal_user.preferred_language
@@ -135,6 +138,7 @@ async def me(
         preferred_language=preferred_language,
         portal_role=portal_role,
         products=products,
+        org_found=org_found,
     )
 
 

--- a/klai-portal/backend/app/core/config.py
+++ b/klai-portal/backend/app/core/config.py
@@ -84,6 +84,9 @@ class Settings(BaseSettings):
     # Generate with: openssl rand -hex 32
     internal_secret: str = ""
 
+    # klai-mailer service URL (for sending transactional emails)
+    mailer_url: str = ""  # e.g. http://klai-mailer:8300
+
     # klai-docs internal secret (used by portal → klai-docs for KB provisioning)
     docs_internal_secret: str = ""
 

--- a/klai-portal/backend/app/main.py
+++ b/klai-portal/backend/app/main.py
@@ -163,6 +163,11 @@ app.add_middleware(LoggingContextMiddleware)
 app.include_router(signup.router)
 app.include_router(me.router)
 app.include_router(auth_router)
+from app.api.auth_join import router as auth_join_router  # noqa: E402
+from app.api.auth_select import router as auth_select_router  # noqa: E402
+
+app.include_router(auth_join_router)
+app.include_router(auth_select_router)
 app.include_router(admin_router)
 app.include_router(groups_router)
 app.include_router(billing_router)

--- a/klai-portal/backend/app/models/portal.py
+++ b/klai-portal/backend/app/models/portal.py
@@ -1,7 +1,18 @@
 from datetime import datetime
 from typing import Literal
 
-from sqlalchemy import ARRAY, JSON, CheckConstraint, DateTime, ForeignKey, LargeBinary, String, Text, func
+from sqlalchemy import (
+    ARRAY,
+    JSON,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    LargeBinary,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base
@@ -44,10 +55,11 @@ class PortalUser(Base):
     __tablename__ = "portal_users"
     __table_args__ = (
         CheckConstraint("status IN ('active', 'suspended', 'offboarded')", name="ck_portal_users_status"),
+        UniqueConstraint("zitadel_user_id", "org_id", name="uq_portal_users_zitadel_user_org"),
     )
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    zitadel_user_id: Mapped[str] = mapped_column(String(64), unique=True, index=True)
+    zitadel_user_id: Mapped[str] = mapped_column(String(64), index=True)
     org_id: Mapped[int] = mapped_column(ForeignKey("portal_orgs.id"))
     role: Mapped[Literal["admin", "group-admin", "member"]] = mapped_column(
         String(20), nullable=False, default="member", server_default="member"
@@ -74,3 +86,33 @@ class PortalUser(Base):
     kb_pref_version: Mapped[int] = mapped_column(nullable=False, default=0, server_default="0")
 
     org: Mapped["PortalOrg"] = relationship(back_populates="users")
+
+
+class PortalOrgAllowedDomain(Base):
+    __tablename__ = "portal_org_allowed_domains"
+    __table_args__ = (
+        UniqueConstraint("org_id", "domain", name="uq_org_allowed_domains_org_domain"),
+        UniqueConstraint("domain", name="uq_org_allowed_domains_domain_global"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    org_id: Mapped[int] = mapped_column(ForeignKey("portal_orgs.id", ondelete="CASCADE"))
+    domain: Mapped[str] = mapped_column(String(253), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created_by: Mapped[str] = mapped_column(String(64), nullable=False)
+
+
+class PortalJoinRequest(Base):
+    __tablename__ = "portal_join_requests"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    zitadel_user_id: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    email: Mapped[str] = mapped_column(String(320), nullable=False)
+    display_name: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    org_id: Mapped[int | None] = mapped_column(ForeignKey("portal_orgs.id", ondelete="SET NULL"), nullable=True)
+    status: Mapped[str] = mapped_column(String(16), nullable=False, default="pending", server_default="pending")
+    requested_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    reviewed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    reviewed_by: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    approval_token: Mapped[str] = mapped_column(String(128), unique=True, nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)

--- a/klai-portal/backend/app/services/domain_validation.py
+++ b/klai-portal/backend/app/services/domain_validation.py
@@ -1,0 +1,39 @@
+"""Domain validation utilities for the allowed-domains feature (SPEC-AUTH-006 R3)."""
+
+import re
+
+# Free email providers that cannot be used as org-wide allowed domains.
+# An attacker could register gmail.com and auto-provision into any org.
+FREE_EMAIL_PROVIDERS: frozenset[str] = frozenset(
+    {
+        "gmail.com",
+        "hotmail.com",
+        "outlook.com",
+        "yahoo.com",
+        "live.com",
+        "icloud.com",
+        "proton.me",
+        "gmx.com",
+    }
+)
+
+# RFC-compliant domain regex: labels separated by dots, 2+ char TLD
+_DOMAIN_RE = re.compile(r"^(?!-)[a-z0-9-]{1,63}(?<!-)(\.[a-z0-9-]{1,63})*\.[a-z]{2,}$")
+
+
+def normalize_domain(domain: str) -> str:
+    """Normalize a domain: lowercase + strip whitespace (C2.1)."""
+    return domain.strip().lower()
+
+
+def is_free_email_provider(domain: str) -> bool:
+    """Return True if the domain is a free email provider (C3.3)."""
+    return normalize_domain(domain) in FREE_EMAIL_PROVIDERS
+
+
+def is_valid_domain(domain: str) -> bool:
+    """Return True if the domain has a valid format (no protocol, no path, has TLD)."""
+    if not domain:
+        return False
+    normalized = normalize_domain(domain)
+    return bool(_DOMAIN_RE.match(normalized))

--- a/klai-portal/backend/app/services/join_request_token.py
+++ b/klai-portal/backend/app/services/join_request_token.py
@@ -1,0 +1,23 @@
+"""HMAC-SHA256 approval token for join requests (SPEC-AUTH-006 R5)."""
+
+import hashlib
+import hmac
+
+from app.core.config import settings
+
+
+def _get_key() -> bytes:
+    """Return the HMAC key from the SSO cookie key (shared secret)."""
+    return settings.sso_cookie_key.encode()
+
+
+def generate_approval_token(request_id: int, zitadel_user_id: str) -> str:
+    """Generate HMAC-SHA256 of (id + zitadel_user_id) using the SSO cookie key."""
+    message = f"{request_id}:{zitadel_user_id}".encode()
+    return hmac.new(_get_key(), message, hashlib.sha256).hexdigest()
+
+
+def verify_approval_token(token: str, request_id: int, zitadel_user_id: str) -> bool:
+    """Verify an approval token against the expected HMAC."""
+    expected = generate_approval_token(request_id, zitadel_user_id)
+    return hmac.compare_digest(token, expected)

--- a/klai-portal/backend/app/services/notifications.py
+++ b/klai-portal/backend/app/services/notifications.py
@@ -1,0 +1,73 @@
+"""Notification helpers for sending emails via klai-mailer (SPEC-AUTH-006 R7/R16)."""
+
+import structlog
+
+from app.core.config import settings
+
+logger = structlog.get_logger()
+
+try:
+    import httpx
+except ImportError:
+    httpx = None  # type: ignore[assignment]
+
+
+async def notify_admin_join_request(
+    email: str,
+    display_name: str,
+    admin_email: str | None = None,
+) -> None:
+    """Send join request notification email to org admins via klai-mailer.
+
+    C7.3: Never fail the main flow — exceptions are caught by the caller.
+    """
+    if not settings.mailer_url:
+        logger.warning("mailer_url not configured — skipping join request notification")
+        return
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            await client.post(
+                f"{settings.mailer_url}/internal/send",
+                headers={"X-Internal-Secret": settings.internal_secret},
+                json={
+                    "template": "join_request_admin",
+                    "to": admin_email or "",
+                    "locale": "nl",
+                    "variables": {
+                        "name": display_name,
+                        "email": email,
+                    },
+                },
+            )
+    except Exception:
+        logger.warning("klai-mailer notification failed", email=email)
+
+
+async def notify_user_join_approved(
+    email: str,
+    display_name: str,
+    workspace_url: str,
+) -> None:
+    """Send approval confirmation email to the user via klai-mailer."""
+    if not settings.mailer_url:
+        logger.warning("mailer_url not configured — skipping approval notification")
+        return
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            await client.post(
+                f"{settings.mailer_url}/internal/send",
+                headers={"X-Internal-Secret": settings.internal_secret},
+                json={
+                    "template": "join_request_approved",
+                    "to": email,
+                    "locale": "nl",
+                    "variables": {
+                        "name": display_name,
+                        "workspace_url": workspace_url,
+                    },
+                },
+            )
+    except Exception:
+        logger.warning("klai-mailer approval notification failed", email=email)

--- a/klai-portal/backend/app/services/pending_session.py
+++ b/klai-portal/backend/app/services/pending_session.py
@@ -1,0 +1,79 @@
+"""Redis-backed pending session for multi-org workspace selection (SPEC-AUTH-006 R9).
+
+When an SSO user belongs to multiple orgs, the idp_callback stores session details
+in Redis with a short TTL and redirects to /select-workspace?ref={uuid}.
+The user then selects an org, and POST /api/auth/select-workspace consumes the
+pending session to finalize.
+"""
+
+import json
+import uuid
+
+import structlog
+
+from app.services.redis_client import get_redis_pool
+
+logger = structlog.get_logger()
+
+_PENDING_SESSION_TTL = 600  # 10 minutes
+_KEY_PREFIX = "pending_session:"
+
+
+class PendingSessionService:
+    """Store and retrieve pending SSO sessions in Redis."""
+
+    async def store(
+        self,
+        session_id: str,
+        session_token: str,
+        zitadel_user_id: str,
+        email: str,
+        auth_request_id: str,
+        org_ids: list[int],
+    ) -> str:
+        """Store pending session data and return a reference UUID."""
+        ref = str(uuid.uuid4())
+        data = json.dumps(
+            {
+                "session_id": session_id,
+                "session_token": session_token,
+                "zitadel_user_id": zitadel_user_id,
+                "email": email,
+                "auth_request_id": auth_request_id,
+                "org_ids": org_ids,
+            }
+        )
+
+        pool = await get_redis_pool()
+        if pool:
+            await pool.set(f"{_KEY_PREFIX}{ref}", data, ex=_PENDING_SESSION_TTL)
+        else:
+            logger.warning("Redis not available — pending session cannot be stored")
+
+        return ref
+
+    async def retrieve(self, ref: str) -> dict | None:
+        """Retrieve pending session data without consuming it."""
+        pool = await get_redis_pool()
+        if not pool:
+            return None
+
+        raw = await pool.get(f"{_KEY_PREFIX}{ref}")
+        if not raw:
+            return None
+
+        return json.loads(raw)
+
+    async def consume(self, ref: str) -> dict | None:
+        """Retrieve and delete pending session data (one-time use)."""
+        pool = await get_redis_pool()
+        if not pool:
+            return None
+
+        key = f"{_KEY_PREFIX}{ref}"
+        raw = await pool.get(key)
+        if not raw:
+            return None
+
+        await pool.delete(key)
+        return json.loads(raw)

--- a/klai-portal/backend/app/services/zitadel.py
+++ b/klai-portal/backend/app/services/zitadel.py
@@ -527,6 +527,24 @@ class ZitadelClient:
         resp.raise_for_status()
         return resp.json()
 
+    async def get_session_details(self, session_id: str, session_token: str) -> dict:
+        """Fetch session details to extract user_id and email after IDP login.
+
+        Returns {"zitadel_user_id": ..., "email": ...}.
+        Used in idp_callback to identify the SSO user for auto-provisioning.
+        """
+        resp = await self._http.get(
+            f"/v2/sessions/{session_id}",
+            headers={"x-zitadel-session-token": session_token},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        user_info = data.get("session", {}).get("factors", {}).get("user", {})
+        return {
+            "zitadel_user_id": user_info.get("id", ""),
+            "email": user_info.get("loginName", ""),
+        }
+
 
 # Singleton — reused across requests
 zitadel = ZitadelClient()

--- a/klai-portal/backend/tests/test_admin_domains.py
+++ b/klai-portal/backend/tests/test_admin_domains.py
@@ -1,0 +1,138 @@
+"""
+Tests for admin domain CRUD endpoints (SPEC-AUTH-006 R3).
+
+Covers:
+- GET /api/admin/domains
+- POST /api/admin/domains
+- DELETE /api/admin/domains/{id}
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+
+def _mock_org(org_id: int = 1) -> MagicMock:
+    org = MagicMock()
+    org.id = org_id
+    return org
+
+
+def _mock_admin_user() -> MagicMock:
+    user = MagicMock()
+    user.role = "admin"
+    return user
+
+
+def _mock_member_user() -> MagicMock:
+    user = MagicMock()
+    user.role = "member"
+    return user
+
+
+class TestListDomains:
+    """GET /api/admin/domains returns org's allowed domains."""
+
+    @pytest.mark.asyncio
+    async def test_returns_domains_for_org(self) -> None:
+        from app.api.admin.domains import list_domains
+
+        domain_mock = MagicMock()
+        domain_mock.id = 1
+        domain_mock.domain = "acme.nl"
+        domain_mock.created_at = "2026-04-16"
+        domain_mock.created_by = "user-123"
+
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [domain_mock]
+
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        mock_credentials = MagicMock()
+
+        with patch("app.api.admin.domains._get_caller_org") as mock_get_org:
+            mock_get_org.return_value = ("user-123", _mock_org(), _mock_admin_user())
+            response = await list_domains(credentials=mock_credentials, db=mock_db)
+
+        assert len(response.domains) == 1
+        assert response.domains[0].domain == "acme.nl"
+
+
+class TestAddDomain:
+    """POST /api/admin/domains adds a new allowed domain."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_free_email_provider(self) -> None:
+        from app.api.admin.domains import AddDomainRequest, add_domain
+
+        mock_db = AsyncMock()
+        mock_credentials = MagicMock()
+
+        body = AddDomainRequest(domain="gmail.com")
+
+        with (
+            patch("app.api.admin.domains._get_caller_org") as mock_get_org,
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            mock_get_org.return_value = ("user-123", _mock_org(), _mock_admin_user())
+            await add_domain(body=body, credentials=mock_credentials, db=mock_db)
+
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_domain_format(self) -> None:
+        from app.api.admin.domains import AddDomainRequest, add_domain
+
+        mock_db = AsyncMock()
+        mock_credentials = MagicMock()
+
+        body = AddDomainRequest(domain="not-a-domain")
+
+        with (
+            patch("app.api.admin.domains._get_caller_org") as mock_get_org,
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            mock_get_org.return_value = ("user-123", _mock_org(), _mock_admin_user())
+            await add_domain(body=body, credentials=mock_credentials, db=mock_db)
+
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_non_admin_rejected(self) -> None:
+        from app.api.admin.domains import AddDomainRequest, add_domain
+
+        mock_db = AsyncMock()
+        mock_credentials = MagicMock()
+
+        body = AddDomainRequest(domain="acme.nl")
+
+        with (
+            patch("app.api.admin.domains._get_caller_org") as mock_get_org,
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            mock_get_org.return_value = ("user-123", _mock_org(), _mock_member_user())
+            await add_domain(body=body, credentials=mock_credentials, db=mock_db)
+
+        assert exc_info.value.status_code == 403
+
+
+class TestDeleteDomain:
+    """DELETE /api/admin/domains/{id} removes domain."""
+
+    @pytest.mark.asyncio
+    async def test_non_admin_rejected(self) -> None:
+        from app.api.admin.domains import delete_domain
+
+        mock_db = AsyncMock()
+        mock_credentials = MagicMock()
+
+        with (
+            patch("app.api.admin.domains._get_caller_org") as mock_get_org,
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            mock_get_org.return_value = ("user-123", _mock_org(), _mock_member_user())
+            await delete_domain(domain_id=1, credentials=mock_credentials, db=mock_db)
+
+        assert exc_info.value.status_code == 403

--- a/klai-portal/backend/tests/test_admin_join_requests.py
+++ b/klai-portal/backend/tests/test_admin_join_requests.py
@@ -1,0 +1,111 @@
+"""
+Tests for admin join request management endpoints (SPEC-AUTH-006 R8).
+
+Covers:
+- GET /api/admin/join-requests (list pending)
+- POST /api/admin/join-requests/{id}/approve
+- POST /api/admin/join-requests/{id}/deny
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+
+def _mock_org(org_id: int = 1) -> MagicMock:
+    org = MagicMock()
+    org.id = org_id
+    org.slug = "acme"
+    return org
+
+
+def _mock_admin_user() -> MagicMock:
+    user = MagicMock()
+    user.role = "admin"
+    return user
+
+
+def _mock_join_request(request_id: int = 1, status: str = "pending") -> MagicMock:
+    jr = MagicMock()
+    jr.id = request_id
+    jr.zitadel_user_id = "user-sso-1"
+    jr.email = "test@company.com"
+    jr.display_name = "Test User"
+    jr.org_id = 1
+    jr.status = status
+    jr.requested_at = datetime(2026, 4, 16, tzinfo=UTC)
+    jr.reviewed_at = None
+    jr.reviewed_by = None
+    jr.approval_token = "a" * 64
+    jr.expires_at = datetime(2026, 4, 23, tzinfo=UTC)
+    return jr
+
+
+class TestListJoinRequests:
+    """GET /api/admin/join-requests returns pending requests for org."""
+
+    @pytest.mark.asyncio
+    async def test_returns_pending_requests(self) -> None:
+        from app.api.admin.join_requests import list_join_requests
+
+        jr = _mock_join_request()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [jr]
+
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        mock_credentials = MagicMock()
+
+        with patch("app.api.admin.join_requests._get_caller_org") as mock_get_org:
+            mock_get_org.return_value = ("admin-1", _mock_org(), _mock_admin_user())
+            response = await list_join_requests(credentials=mock_credentials, db=mock_db)
+
+        assert len(response.requests) == 1
+        assert response.requests[0].email == "test@company.com"
+
+
+class TestApproveJoinRequest:
+    """POST /api/admin/join-requests/{id}/approve creates portal_users row."""
+
+    @pytest.mark.asyncio
+    async def test_non_admin_rejected(self) -> None:
+        from app.api.admin.join_requests import approve_join_request
+
+        mock_db = AsyncMock()
+        mock_credentials = MagicMock()
+        member = MagicMock()
+        member.role = "member"
+
+        with (
+            patch("app.api.admin.join_requests._get_caller_org") as mock_get_org,
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            mock_get_org.return_value = ("admin-1", _mock_org(), member)
+            await approve_join_request(request_id=1, credentials=mock_credentials, db=mock_db, token=None)
+
+        assert exc_info.value.status_code == 403
+
+
+class TestDenyJoinRequest:
+    """POST /api/admin/join-requests/{id}/deny marks request as denied."""
+
+    @pytest.mark.asyncio
+    async def test_non_admin_rejected(self) -> None:
+        from app.api.admin.join_requests import deny_join_request
+
+        mock_db = AsyncMock()
+        mock_credentials = MagicMock()
+        member = MagicMock()
+        member.role = "member"
+
+        with (
+            patch("app.api.admin.join_requests._get_caller_org") as mock_get_org,
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            mock_get_org.return_value = ("admin-1", _mock_org(), member)
+            await deny_join_request(request_id=1, credentials=mock_credentials, db=mock_db)
+
+        assert exc_info.value.status_code == 403

--- a/klai-portal/backend/tests/test_allowed_domains.py
+++ b/klai-portal/backend/tests/test_allowed_domains.py
@@ -1,0 +1,32 @@
+"""
+Tests for PortalOrgAllowedDomain model and domain validation utilities (SPEC-AUTH-006 R2-R3).
+"""
+
+
+class TestPortalOrgAllowedDomainModel:
+    """Verify the SQLAlchemy model is correctly defined."""
+
+    def test_model_has_expected_columns(self) -> None:
+        from app.models.portal import PortalOrgAllowedDomain
+
+        mapper = PortalOrgAllowedDomain.__table__
+        column_names = {c.name for c in mapper.columns}
+        assert "id" in column_names
+        assert "org_id" in column_names
+        assert "domain" in column_names
+        assert "created_at" in column_names
+        assert "created_by" in column_names
+
+    def test_model_has_unique_constraints(self) -> None:
+        from app.models.portal import PortalOrgAllowedDomain
+
+        table = PortalOrgAllowedDomain.__table__
+        constraint_names = {c.name for c in table.constraints if hasattr(c, "name") and c.name}
+        assert "uq_org_allowed_domains_org_domain" in constraint_names
+        assert "uq_org_allowed_domains_domain_global" in constraint_names
+
+    def test_domain_column_max_length(self) -> None:
+        from app.models.portal import PortalOrgAllowedDomain
+
+        domain_col = PortalOrgAllowedDomain.__table__.columns["domain"]
+        assert domain_col.type.length == 253

--- a/klai-portal/backend/tests/test_domain_validation.py
+++ b/klai-portal/backend/tests/test_domain_validation.py
@@ -1,0 +1,105 @@
+"""
+Tests for domain validation utilities (SPEC-AUTH-006 R3).
+
+Covers:
+- Free email provider blocklist
+- Domain format validation
+- Domain normalization (lowercase, strip)
+"""
+
+
+class TestFreeEmailBlocklist:
+    """Free email providers must be rejected when adding allowed domains."""
+
+    def test_gmail_is_blocked(self) -> None:
+        from app.services.domain_validation import is_free_email_provider
+
+        assert is_free_email_provider("gmail.com") is True
+
+    def test_hotmail_is_blocked(self) -> None:
+        from app.services.domain_validation import is_free_email_provider
+
+        assert is_free_email_provider("hotmail.com") is True
+
+    def test_outlook_is_blocked(self) -> None:
+        from app.services.domain_validation import is_free_email_provider
+
+        assert is_free_email_provider("outlook.com") is True
+
+    def test_yahoo_is_blocked(self) -> None:
+        from app.services.domain_validation import is_free_email_provider
+
+        assert is_free_email_provider("yahoo.com") is True
+
+    def test_proton_is_blocked(self) -> None:
+        from app.services.domain_validation import is_free_email_provider
+
+        assert is_free_email_provider("proton.me") is True
+
+    def test_corporate_domain_is_allowed(self) -> None:
+        from app.services.domain_validation import is_free_email_provider
+
+        assert is_free_email_provider("acme.nl") is False
+
+    def test_case_insensitive(self) -> None:
+        from app.services.domain_validation import is_free_email_provider
+
+        assert is_free_email_provider("Gmail.COM") is True
+
+
+class TestDomainNormalization:
+    """Domain must be stored lowercase, stripped."""
+
+    def test_lowercase(self) -> None:
+        from app.services.domain_validation import normalize_domain
+
+        assert normalize_domain("ACME.NL") == "acme.nl"
+
+    def test_strip_whitespace(self) -> None:
+        from app.services.domain_validation import normalize_domain
+
+        assert normalize_domain("  acme.nl  ") == "acme.nl"
+
+    def test_combined(self) -> None:
+        from app.services.domain_validation import normalize_domain
+
+        assert normalize_domain("  ACME.NL  ") == "acme.nl"
+
+
+class TestDomainFormatValidation:
+    """Domain format must be validated before storage."""
+
+    def test_valid_domain(self) -> None:
+        from app.services.domain_validation import is_valid_domain
+
+        assert is_valid_domain("acme.nl") is True
+
+    def test_valid_subdomain(self) -> None:
+        from app.services.domain_validation import is_valid_domain
+
+        assert is_valid_domain("mail.acme.nl") is True
+
+    def test_invalid_no_tld(self) -> None:
+        from app.services.domain_validation import is_valid_domain
+
+        assert is_valid_domain("localhost") is False
+
+    def test_invalid_with_protocol(self) -> None:
+        from app.services.domain_validation import is_valid_domain
+
+        assert is_valid_domain("https://acme.nl") is False
+
+    def test_invalid_with_path(self) -> None:
+        from app.services.domain_validation import is_valid_domain
+
+        assert is_valid_domain("acme.nl/page") is False
+
+    def test_invalid_empty(self) -> None:
+        from app.services.domain_validation import is_valid_domain
+
+        assert is_valid_domain("") is False
+
+    def test_invalid_with_at(self) -> None:
+        from app.services.domain_validation import is_valid_domain
+
+        assert is_valid_domain("user@acme.nl") is False

--- a/klai-portal/backend/tests/test_idp_callback_provision.py
+++ b/klai-portal/backend/tests/test_idp_callback_provision.py
@@ -1,0 +1,135 @@
+"""
+Tests for auto-provision logic in idp_callback (SPEC-AUTH-006 R4).
+
+Covers:
+- Existing user: normal finalize flow
+- New user with matching domain: auto-provision + finalize
+- New user without matching domain: redirect to /no-account (join-request TBD)
+- DB error during auto-provision: fall through to /no-account
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestIdpCallbackAutoProvision:
+    """idp_callback must auto-provision SSO users with matching allowed domains."""
+
+    @pytest.mark.asyncio
+    async def test_existing_user_gets_normal_flow(self) -> None:
+        """When portal_users row exists, finalize and set cookie normally."""
+        from app.api.auth import idp_callback
+
+        mock_portal_user = MagicMock()
+        mock_portal_user.org_id = 1
+
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [mock_portal_user]
+
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        with (
+            patch("app.api.auth.zitadel") as mock_zitadel,
+            patch("app.api.auth.emit_event"),
+        ):
+            mock_zitadel.create_session_with_idp_intent = AsyncMock(
+                return_value={"sessionId": "sid", "sessionToken": "stk"}
+            )
+            mock_zitadel.get_session_details = AsyncMock(
+                return_value={"zitadel_user_id": "user-1", "email": "test@acme.nl"}
+            )
+            mock_zitadel.finalize_auth_request = AsyncMock(return_value="https://acme.getklai.com/callback")
+
+            response = await idp_callback(
+                id="intent-1",
+                token="tok-1",  # noqa: S106
+                auth_request_id="ar-1",
+                db=mock_db,
+            )
+
+        assert response.status_code == 302
+        assert "acme.getklai.com" in response.headers.get("location", "")
+
+    @pytest.mark.asyncio
+    async def test_new_user_matching_domain_gets_auto_provisioned(self) -> None:
+        """When no portal_users row but domain matches, user is auto-provisioned."""
+        from app.api.auth import idp_callback
+
+        # First query: no portal_users rows
+        mock_user_result = MagicMock()
+        mock_user_result.scalars.return_value.all.return_value = []
+
+        # Second query: domain match
+        mock_domain = MagicMock()
+        mock_domain.org_id = 42
+
+        mock_domain_result = MagicMock()
+        mock_domain_result.scalar_one_or_none.return_value = mock_domain
+
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock(side_effect=[mock_user_result, mock_domain_result])
+        mock_db.add = MagicMock()
+        mock_db.commit = AsyncMock()
+
+        with (
+            patch("app.api.auth.zitadel") as mock_zitadel,
+            patch("app.api.auth.emit_event"),
+        ):
+            mock_zitadel.create_session_with_idp_intent = AsyncMock(
+                return_value={"sessionId": "sid", "sessionToken": "stk"}
+            )
+            mock_zitadel.get_session_details = AsyncMock(
+                return_value={"zitadel_user_id": "user-new", "email": "test@acme.nl"}
+            )
+            mock_zitadel.finalize_auth_request = AsyncMock(return_value="https://acme.getklai.com/callback")
+
+            response = await idp_callback(
+                id="intent-1",
+                token="tok-1",  # noqa: S106
+                auth_request_id="ar-1",
+                db=mock_db,
+            )
+
+        # User was auto-provisioned
+        assert mock_db.add.called
+        assert response.status_code == 302
+
+    @pytest.mark.asyncio
+    async def test_new_user_no_domain_match_redirects_to_no_account(self) -> None:
+        """When no portal_users row and no domain match, redirect to /no-account."""
+        from app.api.auth import idp_callback
+
+        # First query: no portal_users rows
+        mock_user_result = MagicMock()
+        mock_user_result.scalars.return_value.all.return_value = []
+
+        # Second query: no domain match
+        mock_domain_result = MagicMock()
+        mock_domain_result.scalar_one_or_none.return_value = None
+
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock(side_effect=[mock_user_result, mock_domain_result])
+
+        with (
+            patch("app.api.auth.zitadel") as mock_zitadel,
+            patch("app.api.auth.emit_event"),
+        ):
+            mock_zitadel.create_session_with_idp_intent = AsyncMock(
+                return_value={"sessionId": "sid", "sessionToken": "stk"}
+            )
+            mock_zitadel.get_session_details = AsyncMock(
+                return_value={"zitadel_user_id": "user-orphan", "email": "orphan@unknown.com"}
+            )
+            mock_zitadel.finalize_auth_request = AsyncMock(return_value="https://portal.getklai.com/callback")
+
+            response = await idp_callback(
+                id="intent-1",
+                token="tok-1",  # noqa: S106
+                auth_request_id="ar-1",
+                db=mock_db,
+            )
+
+        # Redirected to callback with finalized auth, but will hit /no-account via callback.tsx
+        assert response.status_code == 302

--- a/klai-portal/backend/tests/test_join_request_endpoint.py
+++ b/klai-portal/backend/tests/test_join_request_endpoint.py
@@ -1,0 +1,102 @@
+"""
+Tests for POST /api/auth/join-request endpoint (SPEC-AUTH-006 R6).
+
+Covers:
+- Creating a new join request
+- Idempotent: returns existing pending request
+- Rate limit: 3/day per zitadel_user_id
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestJoinRequestEndpoint:
+    """POST /api/auth/join-request creates a join request for SSO users."""
+
+    @pytest.mark.asyncio
+    async def test_creates_join_request(self) -> None:
+        from app.api.auth_join import create_join_request
+
+        mock_credentials = MagicMock()
+        mock_credentials.credentials = "test-token"
+
+        # No existing pending request
+        mock_pending_result = MagicMock()
+        mock_pending_result.scalar_one_or_none.return_value = None
+
+        # Rate limit count = 0
+        mock_count_result = MagicMock()
+        mock_count_result.scalar_one.return_value = 0
+
+        captured_request = {}
+
+        def capture_add(obj: object) -> None:
+            captured_request["obj"] = obj
+
+        async def simulate_flush() -> None:
+            captured_request["obj"].id = 1
+            captured_request["obj"].requested_at = datetime(2026, 4, 16, tzinfo=UTC)
+
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock(side_effect=[mock_pending_result, mock_count_result])
+        mock_db.add = MagicMock(side_effect=capture_add)
+        mock_db.flush = AsyncMock(side_effect=simulate_flush)
+        mock_db.commit = AsyncMock()
+        mock_db.refresh = AsyncMock()
+
+        with (
+            patch("app.api.auth_join.get_current_user_id", return_value="user-sso-1"),
+            patch("app.api.auth_join.zitadel") as mock_zitadel,
+            patch("app.api.auth_join.generate_approval_token", return_value="a" * 64),
+            patch("app.api.auth_join.notify_admin_join_request"),
+        ):
+            mock_zitadel.get_userinfo = AsyncMock(
+                return_value={"sub": "user-sso-1", "email": "test@company.com", "name": "Test User"}
+            )
+            response = await create_join_request(
+                credentials=mock_credentials,
+                user_id="user-sso-1",
+                db=mock_db,
+            )
+
+        assert response.status == "pending"
+        assert mock_db.add.called
+
+    @pytest.mark.asyncio
+    async def test_returns_existing_pending_request(self) -> None:
+        from app.api.auth_join import create_join_request
+
+        mock_credentials = MagicMock()
+        mock_credentials.credentials = "test-token"
+
+        existing_request = MagicMock()
+        existing_request.id = 99
+        existing_request.status = "pending"
+        existing_request.requested_at = datetime(2026, 4, 16, tzinfo=UTC)
+
+        mock_pending_result = MagicMock()
+        mock_pending_result.scalar_one_or_none.return_value = existing_request
+
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock(return_value=mock_pending_result)
+
+        with (
+            patch("app.api.auth_join.get_current_user_id", return_value="user-sso-1"),
+            patch("app.api.auth_join.zitadel") as mock_zitadel,
+        ):
+            mock_zitadel.get_userinfo = AsyncMock(
+                return_value={"sub": "user-sso-1", "email": "test@company.com", "name": "Test User"}
+            )
+            response = await create_join_request(
+                credentials=mock_credentials,
+                user_id="user-sso-1",
+                db=mock_db,
+            )
+
+        assert response.status == "pending"
+        assert response.id == 99
+        # Should NOT create a new one
+        assert not mock_db.add.called

--- a/klai-portal/backend/tests/test_join_requests.py
+++ b/klai-portal/backend/tests/test_join_requests.py
@@ -1,0 +1,71 @@
+"""
+Tests for PortalJoinRequest model and HMAC token generation (SPEC-AUTH-006 R5).
+"""
+
+
+class TestPortalJoinRequestModel:
+    """Verify the SQLAlchemy model is correctly defined."""
+
+    def test_model_has_expected_columns(self) -> None:
+        from app.models.portal import PortalJoinRequest
+
+        mapper = PortalJoinRequest.__table__
+        column_names = {c.name for c in mapper.columns}
+        expected = {
+            "id",
+            "zitadel_user_id",
+            "email",
+            "display_name",
+            "org_id",
+            "status",
+            "requested_at",
+            "reviewed_at",
+            "reviewed_by",
+            "approval_token",
+            "expires_at",
+        }
+        assert expected.issubset(column_names)
+
+    def test_approval_token_is_unique(self) -> None:
+        from app.models.portal import PortalJoinRequest
+
+        table = PortalJoinRequest.__table__
+        approval_col = table.columns["approval_token"]
+        assert approval_col.unique is True
+
+
+class TestApprovalTokenGeneration:
+    """Approval token must be HMAC-SHA256 of (id + zitadel_user_id)."""
+
+    def test_generates_deterministic_token(self) -> None:
+        from app.services.join_request_token import generate_approval_token
+
+        token1 = generate_approval_token(1, "user-abc")
+        token2 = generate_approval_token(1, "user-abc")
+        assert token1 == token2
+
+    def test_different_inputs_give_different_tokens(self) -> None:
+        from app.services.join_request_token import generate_approval_token
+
+        token1 = generate_approval_token(1, "user-abc")
+        token2 = generate_approval_token(2, "user-abc")
+        assert token1 != token2
+
+    def test_token_is_hex_string(self) -> None:
+        from app.services.join_request_token import generate_approval_token
+
+        token = generate_approval_token(1, "user-abc")
+        # HMAC-SHA256 produces 64 hex chars
+        assert len(token) == 64
+        int(token, 16)  # should not raise
+
+    def test_validates_correct_token(self) -> None:
+        from app.services.join_request_token import generate_approval_token, verify_approval_token
+
+        token = generate_approval_token(42, "user-xyz")
+        assert verify_approval_token(token, 42, "user-xyz") is True
+
+    def test_rejects_wrong_token(self) -> None:
+        from app.services.join_request_token import verify_approval_token
+
+        assert verify_approval_token("deadbeef" * 8, 42, "user-xyz") is False

--- a/klai-portal/backend/tests/test_me_org_found.py
+++ b/klai-portal/backend/tests/test_me_org_found.py
@@ -1,0 +1,114 @@
+"""
+Tests for the org_found field in MeResponse (SPEC-AUTH-006 R1).
+
+Verifies that /api/me returns org_found=True when a portal_users row exists
+for the authenticated user, and org_found=False when no row exists.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _mock_org() -> MagicMock:
+    org = MagicMock()
+    org.slug = "acme"
+    org.provisioning_status = "active"
+    org.mfa_policy = "optional"
+    org.moneybird_contact_id = "mb-1"
+    return org
+
+
+def _mock_portal_user() -> MagicMock:
+    user = MagicMock()
+    user.role = "member"
+    user.preferred_language = "nl"
+    user.display_name = "Test User"
+    user.email = "test@acme.nl"
+    return user
+
+
+class TestMeOrgFound:
+    """org_found field must be True when a portal_users row exists, False otherwise."""
+
+    @pytest.mark.asyncio
+    async def test_org_found_true_when_portal_user_exists(self) -> None:
+        """When portal_users row exists for zitadel_user_id, org_found should be True."""
+        from app.api.me import me
+
+        org = _mock_org()
+        portal_user = _mock_portal_user()
+
+        mock_row = MagicMock()
+        mock_row.__iter__ = lambda self: iter((org, portal_user))
+
+        mock_result = MagicMock()
+        mock_result.one_or_none.return_value = mock_row
+
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock(return_value=mock_result)
+        mock_db.commit = AsyncMock()
+
+        mock_credentials = MagicMock()
+        mock_credentials.credentials = "test-token"
+
+        userinfo = {
+            "sub": "user-123",
+            "email": "test@acme.nl",
+            "name": "Test User",
+        }
+
+        with (
+            patch("app.api.me.zitadel") as mock_zitadel,
+            patch("app.api.me.get_effective_products", return_value=[]),
+        ):
+            mock_zitadel.get_userinfo = AsyncMock(return_value=userinfo)
+            mock_zitadel.has_any_mfa = AsyncMock(return_value=False)
+
+            response = await me(credentials=mock_credentials, db=mock_db)
+
+        assert response.org_found is True
+
+    @pytest.mark.asyncio
+    async def test_org_found_false_when_no_portal_user(self) -> None:
+        """When no portal_users row exists for zitadel_user_id, org_found should be False."""
+        from app.api.me import me
+
+        mock_result = MagicMock()
+        mock_result.one_or_none.return_value = None
+
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        mock_credentials = MagicMock()
+        mock_credentials.credentials = "test-token"
+
+        userinfo = {
+            "sub": "user-456",
+            "email": "nobody@example.com",
+            "name": "Nobody",
+        }
+
+        with (
+            patch("app.api.me.zitadel") as mock_zitadel,
+            patch("app.api.me.get_effective_products", return_value=[]),
+        ):
+            mock_zitadel.get_userinfo = AsyncMock(return_value=userinfo)
+            mock_zitadel.has_any_mfa = AsyncMock(return_value=False)
+
+            response = await me(credentials=mock_credentials, db=mock_db)
+
+        assert response.org_found is False
+
+    @pytest.mark.asyncio
+    async def test_org_found_in_response_model(self) -> None:
+        """MeResponse model should include org_found field with default False."""
+        from app.api.me import MeResponse
+
+        # Default should be False
+        resp = MeResponse(user_id="u1", email="a@b.com", name="A")
+        assert resp.org_found is False
+
+        # Can be set to True
+        resp2 = MeResponse(user_id="u1", email="a@b.com", name="A", org_found=True)
+        assert resp2.org_found is True

--- a/klai-portal/backend/tests/test_pending_session.py
+++ b/klai-portal/backend/tests/test_pending_session.py
@@ -1,0 +1,66 @@
+"""
+Tests for Redis pending-session service (SPEC-AUTH-006 R9).
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+class TestPendingSessionService:
+    """Redis-backed pending session for multi-org workspace selection."""
+
+    @pytest.mark.asyncio
+    async def test_store_and_retrieve_session(self) -> None:
+        from app.services.pending_session import PendingSessionService
+
+        mock_pool = AsyncMock()
+        mock_pool.set = AsyncMock()
+        mock_pool.get = AsyncMock(
+            return_value='{"session_id":"sid","session_token":"stk","zitadel_user_id":"u1","email":"a@b.com","auth_request_id":"ar1","org_ids":[1,2]}'
+        )
+
+        with patch("app.services.pending_session.get_redis_pool", return_value=mock_pool):
+            svc = PendingSessionService()
+            ref = await svc.store(
+                session_id="sid",
+                session_token="stk",  # noqa: S106
+                zitadel_user_id="u1",
+                email="a@b.com",
+                auth_request_id="ar1",
+                org_ids=[1, 2],
+            )
+            assert ref  # UUID string
+
+            data = await svc.retrieve(ref)
+            assert data is not None
+            assert data["session_id"] == "sid"
+            assert data["org_ids"] == [1, 2]
+
+    @pytest.mark.asyncio
+    async def test_retrieve_missing_returns_none(self) -> None:
+        from app.services.pending_session import PendingSessionService
+
+        mock_pool = AsyncMock()
+        mock_pool.get = AsyncMock(return_value=None)
+
+        with patch("app.services.pending_session.get_redis_pool", return_value=mock_pool):
+            svc = PendingSessionService()
+            data = await svc.retrieve("nonexistent-ref")
+            assert data is None
+
+    @pytest.mark.asyncio
+    async def test_consume_deletes_after_read(self) -> None:
+        from app.services.pending_session import PendingSessionService
+
+        mock_pool = AsyncMock()
+        mock_pool.get = AsyncMock(
+            return_value='{"session_id":"sid","session_token":"stk","zitadel_user_id":"u1","email":"a@b.com","auth_request_id":"ar1","org_ids":[1]}'
+        )
+        mock_pool.delete = AsyncMock()
+
+        with patch("app.services.pending_session.get_redis_pool", return_value=mock_pool):
+            svc = PendingSessionService()
+            data = await svc.consume("some-ref")
+            assert data is not None
+            mock_pool.delete.assert_called_once()

--- a/klai-portal/backend/tests/test_select_workspace.py
+++ b/klai-portal/backend/tests/test_select_workspace.py
@@ -1,0 +1,90 @@
+"""
+Tests for POST /api/auth/select-workspace (SPEC-AUTH-006 R9).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+
+class TestSelectWorkspace:
+    """POST /api/auth/select-workspace validates ref and org, then finalizes."""
+
+    @pytest.mark.asyncio
+    async def test_valid_ref_and_org_finalizes(self) -> None:
+        from app.api.auth_select import SelectWorkspaceRequest, select_workspace
+
+        mock_org = MagicMock()
+        mock_org.slug = "acme"
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = mock_org
+
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        body = SelectWorkspaceRequest(ref="test-ref-uuid", org_id=1)
+
+        with (
+            patch("app.api.auth_select.pending_session_svc") as mock_svc,
+            patch("app.api.auth_select.zitadel") as mock_zitadel,
+            patch("app.api.auth_select.emit_event"),
+        ):
+            mock_svc.consume = AsyncMock(
+                return_value={
+                    "session_id": "sid",
+                    "session_token": "stk",
+                    "zitadel_user_id": "u1",
+                    "email": "a@b.com",
+                    "auth_request_id": "ar1",
+                    "org_ids": [1, 2],
+                }
+            )
+            mock_zitadel.finalize_auth_request = AsyncMock(return_value="https://acme.getklai.com/callback")
+
+            response = await select_workspace(body=body, db=mock_db)
+
+        assert response.workspace_url is not None
+        assert "acme" in response.workspace_url
+
+    @pytest.mark.asyncio
+    async def test_invalid_ref_returns_404(self) -> None:
+        from app.api.auth_select import SelectWorkspaceRequest, select_workspace
+
+        mock_db = AsyncMock()
+        body = SelectWorkspaceRequest(ref="invalid-ref", org_id=1)
+
+        with (
+            patch("app.api.auth_select.pending_session_svc") as mock_svc,
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            mock_svc.consume = AsyncMock(return_value=None)
+            await select_workspace(body=body, db=mock_db)
+
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_org_not_in_allowed_list_returns_403(self) -> None:
+        from app.api.auth_select import SelectWorkspaceRequest, select_workspace
+
+        mock_db = AsyncMock()
+        body = SelectWorkspaceRequest(ref="test-ref", org_id=99)
+
+        with (
+            patch("app.api.auth_select.pending_session_svc") as mock_svc,
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            mock_svc.consume = AsyncMock(
+                return_value={
+                    "session_id": "sid",
+                    "session_token": "stk",
+                    "zitadel_user_id": "u1",
+                    "email": "a@b.com",
+                    "auth_request_id": "ar1",
+                    "org_ids": [1, 2],
+                }
+            )
+            await select_workspace(body=body, db=mock_db)
+
+        assert exc_info.value.status_code == 403

--- a/klai-portal/backend/tests/test_zitadel_session_details.py
+++ b/klai-portal/backend/tests/test_zitadel_session_details.py
@@ -1,0 +1,66 @@
+"""
+Tests for Zitadel get_session_details helper (SPEC-AUTH-006 R4).
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+class TestGetSessionDetails:
+    """get_session_details must return zitadel_user_id and email from session."""
+
+    @pytest.mark.asyncio
+    async def test_returns_user_id_and_email(self) -> None:
+        from app.services.zitadel import ZitadelClient
+
+        client = ZitadelClient.__new__(ZitadelClient)
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "session": {
+                "factors": {
+                    "user": {
+                        "id": "user-abc-123",
+                        "loginName": "test@acme.nl",
+                    }
+                }
+            }
+        }
+        mock_resp.raise_for_status = MagicMock()
+
+        mock_http = AsyncMock()
+        mock_http.get = AsyncMock(return_value=mock_resp)
+        client._http = mock_http
+
+        result = await client.get_session_details("session-id-1", "session-token-1")
+
+        assert result["zitadel_user_id"] == "user-abc-123"
+        assert result["email"] == "test@acme.nl"
+
+    @pytest.mark.asyncio
+    async def test_passes_session_token_header(self) -> None:
+        from app.services.zitadel import ZitadelClient
+
+        client = ZitadelClient.__new__(ZitadelClient)
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "session": {
+                "factors": {
+                    "user": {
+                        "id": "user-1",
+                        "loginName": "a@b.com",
+                    }
+                }
+            }
+        }
+        mock_resp.raise_for_status = MagicMock()
+
+        mock_http = AsyncMock()
+        mock_http.get = AsyncMock(return_value=mock_resp)
+        client._http = mock_http
+
+        await client.get_session_details("sid", "stoken")
+
+        mock_http.get.assert_called_once()
+        call_kwargs = mock_http.get.call_args
+        assert "x-zitadel-session-token" in call_kwargs.kwargs.get("headers", {})

--- a/klai-portal/frontend/messages/en.json
+++ b/klai-portal/frontend/messages/en.json
@@ -1464,5 +1464,38 @@
 
   "docs_page_not_found": "Page not found",
   "docs_page_not_found_desc": "This page does not exist or has been removed.",
-  "docs_back_to_kb": "Back to knowledge base"
+  "docs_back_to_kb": "Back to knowledge base",
+
+  "no_account_hero_heading": "Your workspace",
+  "no_account_hero_highlight": "awaits",
+  "no_account_hero_body": "Ask your admin to invite you or sign up for a new workspace.",
+  "no_account_heading": "No Klai workspace linked",
+  "no_account_body": "You signed in successfully, but no workspace is connected to your account. Contact your organisation admin to get access, or create a new workspace.",
+  "no_account_cta": "Back to login",
+  "no_account_request_access": "Request access",
+
+  "admin_domains_title": "Allowed domains",
+  "admin_domains_description": "Users with an email address from these domains can join your workspace automatically via SSO.",
+  "admin_domains_add": "Add domain",
+  "admin_domains_add_placeholder": "e.g. company.com",
+  "admin_domains_empty": "No allowed domains configured yet.",
+  "admin_domains_delete_confirm": "Remove this domain?",
+  "admin_domains_error_free": "Free email providers cannot be used as allowed domains.",
+  "admin_domains_error_invalid": "Invalid domain format.",
+  "admin_domains_error_duplicate": "This domain is already configured.",
+
+  "join_request_heading": "Request access",
+  "join_request_body": "Your email domain is not linked to any workspace. You can submit a request to join. An admin will review your request.",
+  "join_request_submit": "Submit request",
+  "join_request_success": "Your request has been submitted. You will receive an email when an admin has reviewed it.",
+
+  "admin_join_requests_title": "Join requests",
+  "admin_join_requests_empty": "No pending join requests.",
+  "admin_join_requests_approve": "Approve",
+  "admin_join_requests_deny": "Deny",
+
+  "select_workspace_heading": "Select workspace",
+  "select_workspace_body": "Your account is linked to multiple workspaces. Select which one to open.",
+  "select_workspace_continue": "Continue",
+  "select_workspace_session_expired": "Your session has expired. Please log in again."
 }

--- a/klai-portal/frontend/messages/nl.json
+++ b/klai-portal/frontend/messages/nl.json
@@ -1462,5 +1462,38 @@
 
   "docs_page_not_found": "Pagina niet gevonden",
   "docs_page_not_found_desc": "Deze pagina bestaat niet of is verwijderd.",
-  "docs_back_to_kb": "Terug naar kennisbank"
+  "docs_back_to_kb": "Terug naar kennisbank",
+
+  "no_account_hero_heading": "Je werkruimte",
+  "no_account_hero_highlight": "wacht",
+  "no_account_hero_body": "Vraag je beheerder om je uit te nodigen of maak een nieuwe werkruimte aan.",
+  "no_account_heading": "Geen Klai-werkruimte gekoppeld",
+  "no_account_body": "Je bent succesvol ingelogd, maar er is geen werkruimte verbonden aan je account. Neem contact op met je organisatiebeheerder voor toegang, of maak een nieuwe werkruimte aan.",
+  "no_account_cta": "Terug naar inloggen",
+  "no_account_request_access": "Toegang aanvragen",
+
+  "admin_domains_title": "Toegestane domeinen",
+  "admin_domains_description": "Gebruikers met een e-mailadres van deze domeinen kunnen automatisch lid worden van je werkruimte via SSO.",
+  "admin_domains_add": "Domein toevoegen",
+  "admin_domains_add_placeholder": "bijv. bedrijf.nl",
+  "admin_domains_empty": "Nog geen toegestane domeinen geconfigureerd.",
+  "admin_domains_delete_confirm": "Dit domein verwijderen?",
+  "admin_domains_error_free": "Gratis e-mailproviders kunnen niet worden gebruikt als toegestane domeinen.",
+  "admin_domains_error_invalid": "Ongeldig domeinformaat.",
+  "admin_domains_error_duplicate": "Dit domein is al geconfigureerd.",
+
+  "join_request_heading": "Toegang aanvragen",
+  "join_request_body": "Je e-maildomein is niet gekoppeld aan een werkruimte. Je kunt een verzoek indienen om lid te worden. Een beheerder zal je verzoek beoordelen.",
+  "join_request_submit": "Verzoek indienen",
+  "join_request_success": "Je verzoek is ingediend. Je ontvangt een e-mail zodra een beheerder het heeft beoordeeld.",
+
+  "admin_join_requests_title": "Toegangsverzoeken",
+  "admin_join_requests_empty": "Geen openstaande toegangsverzoeken.",
+  "admin_join_requests_approve": "Goedkeuren",
+  "admin_join_requests_deny": "Afwijzen",
+
+  "select_workspace_heading": "Werkruimte selecteren",
+  "select_workspace_body": "Je account is gekoppeld aan meerdere werkruimtes. Selecteer welke je wilt openen.",
+  "select_workspace_continue": "Doorgaan",
+  "select_workspace_session_expired": "Je sessie is verlopen. Log opnieuw in."
 }

--- a/klai-portal/frontend/src/routeTree.gen.ts
+++ b/klai-portal/frontend/src/routeTree.gen.ts
@@ -11,9 +11,12 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as VerifyRouteImport } from './routes/verify'
 import { Route as SignupRouteImport } from './routes/signup'
+import { Route as SelectWorkspaceRouteImport } from './routes/select-workspace'
 import { Route as ProvisioningRouteImport } from './routes/provisioning'
+import { Route as NoAccountRouteImport } from './routes/no-account'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as LoggedOutRouteImport } from './routes/logged-out'
+import { Route as JoinRequestRouteImport } from './routes/join-request'
 import { Route as CallbackRouteImport } from './routes/callback'
 import { Route as AppRouteRouteImport } from './routes/app/route'
 import { Route as AdminRouteRouteImport } from './routes/admin/route'
@@ -29,6 +32,8 @@ import { Route as AppScribeRouteImport } from './routes/app/scribe'
 import { Route as AppChatRouteImport } from './routes/app/chat'
 import { Route as AppAccountRouteImport } from './routes/app/account'
 import { Route as AdminSettingsRouteImport } from './routes/admin/settings'
+import { Route as AdminJoinRequestsRouteImport } from './routes/admin/join-requests'
+import { Route as AdminDomainsRouteImport } from './routes/admin/domains'
 import { Route as AdminBillingRouteImport } from './routes/admin/billing'
 import { Route as LocaleSignupRouteImport } from './routes/$locale/signup'
 import { Route as AppTranscribeIndexRouteImport } from './routes/app/transcribe/index'
@@ -89,9 +94,19 @@ const SignupRoute = SignupRouteImport.update({
   path: '/signup',
   getParentRoute: () => rootRouteImport,
 } as any)
+const SelectWorkspaceRoute = SelectWorkspaceRouteImport.update({
+  id: '/select-workspace',
+  path: '/select-workspace',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ProvisioningRoute = ProvisioningRouteImport.update({
   id: '/provisioning',
   path: '/provisioning',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const NoAccountRoute = NoAccountRouteImport.update({
+  id: '/no-account',
+  path: '/no-account',
   getParentRoute: () => rootRouteImport,
 } as any)
 const LoginRoute = LoginRouteImport.update({
@@ -102,6 +117,11 @@ const LoginRoute = LoginRouteImport.update({
 const LoggedOutRoute = LoggedOutRouteImport.update({
   id: '/logged-out',
   path: '/logged-out',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const JoinRequestRoute = JoinRequestRouteImport.update({
+  id: '/join-request',
+  path: '/join-request',
   getParentRoute: () => rootRouteImport,
 } as any)
 const CallbackRoute = CallbackRouteImport.update({
@@ -177,6 +197,16 @@ const AppAccountRoute = AppAccountRouteImport.update({
 const AdminSettingsRoute = AdminSettingsRouteImport.update({
   id: '/settings',
   path: '/settings',
+  getParentRoute: () => AdminRouteRoute,
+} as any)
+const AdminJoinRequestsRoute = AdminJoinRequestsRouteImport.update({
+  id: '/join-requests',
+  path: '/join-requests',
+  getParentRoute: () => AdminRouteRoute,
+} as any)
+const AdminDomainsRoute = AdminDomainsRouteImport.update({
+  id: '/domains',
+  path: '/domains',
   getParentRoute: () => AdminRouteRoute,
 } as any)
 const AdminBillingRoute = AdminBillingRouteImport.update({
@@ -446,13 +476,18 @@ export interface FileRoutesByFullPath {
   '/admin': typeof AdminRouteRouteWithChildren
   '/app': typeof AppRouteRouteWithChildren
   '/callback': typeof CallbackRoute
+  '/join-request': typeof JoinRequestRoute
   '/logged-out': typeof LoggedOutRoute
   '/login': typeof LoginRoute
+  '/no-account': typeof NoAccountRoute
   '/provisioning': typeof ProvisioningRoute
+  '/select-workspace': typeof SelectWorkspaceRoute
   '/signup': typeof SignupRoute
   '/verify': typeof VerifyRoute
   '/$locale/signup': typeof LocaleSignupRouteWithChildren
   '/admin/billing': typeof AdminBillingRoute
+  '/admin/domains': typeof AdminDomainsRoute
+  '/admin/join-requests': typeof AdminJoinRequestsRoute
   '/admin/settings': typeof AdminSettingsRoute
   '/app/account': typeof AppAccountRoute
   '/app/chat': typeof AppChatRoute
@@ -515,12 +550,17 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/$locale': typeof LocaleRouteRouteWithChildren
   '/callback': typeof CallbackRoute
+  '/join-request': typeof JoinRequestRoute
   '/logged-out': typeof LoggedOutRoute
   '/login': typeof LoginRoute
+  '/no-account': typeof NoAccountRoute
   '/provisioning': typeof ProvisioningRoute
+  '/select-workspace': typeof SelectWorkspaceRoute
   '/signup': typeof SignupRoute
   '/verify': typeof VerifyRoute
   '/admin/billing': typeof AdminBillingRoute
+  '/admin/domains': typeof AdminDomainsRoute
+  '/admin/join-requests': typeof AdminJoinRequestsRoute
   '/admin/settings': typeof AdminSettingsRoute
   '/app/account': typeof AppAccountRoute
   '/app/chat': typeof AppChatRoute
@@ -584,13 +624,18 @@ export interface FileRoutesById {
   '/admin': typeof AdminRouteRouteWithChildren
   '/app': typeof AppRouteRouteWithChildren
   '/callback': typeof CallbackRoute
+  '/join-request': typeof JoinRequestRoute
   '/logged-out': typeof LoggedOutRoute
   '/login': typeof LoginRoute
+  '/no-account': typeof NoAccountRoute
   '/provisioning': typeof ProvisioningRoute
+  '/select-workspace': typeof SelectWorkspaceRoute
   '/signup': typeof SignupRoute
   '/verify': typeof VerifyRoute
   '/$locale/signup': typeof LocaleSignupRouteWithChildren
   '/admin/billing': typeof AdminBillingRoute
+  '/admin/domains': typeof AdminDomainsRoute
+  '/admin/join-requests': typeof AdminJoinRequestsRoute
   '/admin/settings': typeof AdminSettingsRoute
   '/app/account': typeof AppAccountRoute
   '/app/chat': typeof AppChatRoute
@@ -657,13 +702,18 @@ export interface FileRouteTypes {
     | '/admin'
     | '/app'
     | '/callback'
+    | '/join-request'
     | '/logged-out'
     | '/login'
+    | '/no-account'
     | '/provisioning'
+    | '/select-workspace'
     | '/signup'
     | '/verify'
     | '/$locale/signup'
     | '/admin/billing'
+    | '/admin/domains'
+    | '/admin/join-requests'
     | '/admin/settings'
     | '/app/account'
     | '/app/chat'
@@ -726,12 +776,17 @@ export interface FileRouteTypes {
     | '/'
     | '/$locale'
     | '/callback'
+    | '/join-request'
     | '/logged-out'
     | '/login'
+    | '/no-account'
     | '/provisioning'
+    | '/select-workspace'
     | '/signup'
     | '/verify'
     | '/admin/billing'
+    | '/admin/domains'
+    | '/admin/join-requests'
     | '/admin/settings'
     | '/app/account'
     | '/app/chat'
@@ -794,13 +849,18 @@ export interface FileRouteTypes {
     | '/admin'
     | '/app'
     | '/callback'
+    | '/join-request'
     | '/logged-out'
     | '/login'
+    | '/no-account'
     | '/provisioning'
+    | '/select-workspace'
     | '/signup'
     | '/verify'
     | '/$locale/signup'
     | '/admin/billing'
+    | '/admin/domains'
+    | '/admin/join-requests'
     | '/admin/settings'
     | '/app/account'
     | '/app/chat'
@@ -866,9 +926,12 @@ export interface RootRouteChildren {
   AdminRouteRoute: typeof AdminRouteRouteWithChildren
   AppRouteRoute: typeof AppRouteRouteWithChildren
   CallbackRoute: typeof CallbackRoute
+  JoinRequestRoute: typeof JoinRequestRoute
   LoggedOutRoute: typeof LoggedOutRoute
   LoginRoute: typeof LoginRoute
+  NoAccountRoute: typeof NoAccountRoute
   ProvisioningRoute: typeof ProvisioningRoute
+  SelectWorkspaceRoute: typeof SelectWorkspaceRoute
   SignupRoute: typeof SignupRoute
   VerifyRoute: typeof VerifyRoute
   PasswordForgotRoute: typeof PasswordForgotRoute
@@ -893,11 +956,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SignupRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/select-workspace': {
+      id: '/select-workspace'
+      path: '/select-workspace'
+      fullPath: '/select-workspace'
+      preLoaderRoute: typeof SelectWorkspaceRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/provisioning': {
       id: '/provisioning'
       path: '/provisioning'
       fullPath: '/provisioning'
       preLoaderRoute: typeof ProvisioningRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/no-account': {
+      id: '/no-account'
+      path: '/no-account'
+      fullPath: '/no-account'
+      preLoaderRoute: typeof NoAccountRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/login': {
@@ -912,6 +989,13 @@ declare module '@tanstack/react-router' {
       path: '/logged-out'
       fullPath: '/logged-out'
       preLoaderRoute: typeof LoggedOutRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/join-request': {
+      id: '/join-request'
+      path: '/join-request'
+      fullPath: '/join-request'
+      preLoaderRoute: typeof JoinRequestRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/callback': {
@@ -1017,6 +1101,20 @@ declare module '@tanstack/react-router' {
       path: '/settings'
       fullPath: '/admin/settings'
       preLoaderRoute: typeof AdminSettingsRouteImport
+      parentRoute: typeof AdminRouteRoute
+    }
+    '/admin/join-requests': {
+      id: '/admin/join-requests'
+      path: '/join-requests'
+      fullPath: '/admin/join-requests'
+      preLoaderRoute: typeof AdminJoinRequestsRouteImport
+      parentRoute: typeof AdminRouteRoute
+    }
+    '/admin/domains': {
+      id: '/admin/domains'
+      path: '/domains'
+      fullPath: '/admin/domains'
+      preLoaderRoute: typeof AdminDomainsRouteImport
       parentRoute: typeof AdminRouteRoute
     }
     '/admin/billing': {
@@ -1395,6 +1493,8 @@ const LocaleRouteRouteWithChildren = LocaleRouteRoute._addFileChildren(
 
 interface AdminRouteRouteChildren {
   AdminBillingRoute: typeof AdminBillingRoute
+  AdminDomainsRoute: typeof AdminDomainsRoute
+  AdminJoinRequestsRoute: typeof AdminJoinRequestsRoute
   AdminSettingsRoute: typeof AdminSettingsRoute
   AdminIndexRoute: typeof AdminIndexRoute
   AdminGroupsNewRoute: typeof AdminGroupsNewRoute
@@ -1415,6 +1515,8 @@ interface AdminRouteRouteChildren {
 
 const AdminRouteRouteChildren: AdminRouteRouteChildren = {
   AdminBillingRoute: AdminBillingRoute,
+  AdminDomainsRoute: AdminDomainsRoute,
+  AdminJoinRequestsRoute: AdminJoinRequestsRoute,
   AdminSettingsRoute: AdminSettingsRoute,
   AdminIndexRoute: AdminIndexRoute,
   AdminGroupsNewRoute: AdminGroupsNewRoute,
@@ -1543,9 +1645,12 @@ const rootRouteChildren: RootRouteChildren = {
   AdminRouteRoute: AdminRouteRouteWithChildren,
   AppRouteRoute: AppRouteRouteWithChildren,
   CallbackRoute: CallbackRoute,
+  JoinRequestRoute: JoinRequestRoute,
   LoggedOutRoute: LoggedOutRoute,
   LoginRoute: LoginRoute,
+  NoAccountRoute: NoAccountRoute,
   ProvisioningRoute: ProvisioningRoute,
+  SelectWorkspaceRoute: SelectWorkspaceRoute,
   SignupRoute: SignupRoute,
   VerifyRoute: VerifyRoute,
   PasswordForgotRoute: PasswordForgotRoute,

--- a/klai-portal/frontend/src/routes/admin/domains.tsx
+++ b/klai-portal/frontend/src/routes/admin/domains.tsx
@@ -1,0 +1,131 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { useState } from 'react'
+import { useAuth } from 'react-oidc-context'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Plus, Trash2 } from 'lucide-react'
+import { apiFetch } from '@/lib/apiFetch'
+import * as m from '@/paraglide/messages'
+import { adminLogger } from '@/lib/logger'
+
+export const Route = createFileRoute('/admin/domains')({
+  component: AdminDomainsPage,
+})
+
+interface Domain {
+  id: number
+  domain: string
+  created_at: string
+  created_by: string
+}
+
+function AdminDomainsPage() {
+  const auth = useAuth()
+  const token = auth.user?.access_token
+  const queryClient = useQueryClient()
+  const [newDomain, setNewDomain] = useState('')
+  const [error, setError] = useState('')
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['admin-domains'],
+    queryFn: async () => apiFetch<{ domains: Domain[] }>('/api/admin/domains', token),
+    enabled: !!token,
+  })
+
+  const addMutation = useMutation({
+    mutationFn: async (domain: string) =>
+      apiFetch('/api/admin/domains', token, {
+        method: 'POST',
+        body: JSON.stringify({ domain }),
+      }),
+    onSuccess: () => {
+      setNewDomain('')
+      setError('')
+      void queryClient.invalidateQueries({ queryKey: ['admin-domains'] })
+      adminLogger.info('Domain added', { domain: newDomain })
+    },
+    onError: (err: Error) => {
+      if (err.message.includes('Free email')) setError(m.admin_domains_error_free())
+      else if (err.message.includes('Invalid')) setError(m.admin_domains_error_invalid())
+      else if (err.message.includes('already')) setError(m.admin_domains_error_duplicate())
+      else setError(err.message)
+    },
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: async (id: number) =>
+      apiFetch(`/api/admin/domains/${id}`, token, { method: 'DELETE' }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['admin-domains'] })
+    },
+  })
+
+  const domains = data?.domains ?? []
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">{m.admin_domains_title()}</h1>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{m.admin_domains_title()}</CardTitle>
+          <CardDescription>{m.admin_domains_description()}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <form
+            onSubmit={(e) => {
+              e.preventDefault()
+              if (newDomain.trim()) addMutation.mutate(newDomain.trim())
+            }}
+            className="flex gap-2"
+          >
+            <Input
+              value={newDomain}
+              onChange={(e) => { setNewDomain(e.target.value); setError('') }}
+              placeholder={m.admin_domains_add_placeholder()}
+              className="flex-1"
+            />
+            <Button type="submit" disabled={!newDomain.trim() || addMutation.isPending}>
+              <Plus className="mr-1 h-4 w-4" />
+              {m.admin_domains_add()}
+            </Button>
+          </form>
+
+          {error && (
+            <p className="text-sm text-[var(--color-destructive)]">{error}</p>
+          )}
+
+          {isLoading ? (
+            <p className="text-sm text-[var(--color-muted-foreground)]">...</p>
+          ) : domains.length === 0 ? (
+            <p className="text-sm text-[var(--color-muted-foreground)]">{m.admin_domains_empty()}</p>
+          ) : (
+            <table className="w-full text-sm border-t border-b border-[var(--color-border)]">
+              <tbody>
+                {domains.map((d) => (
+                  <tr key={d.id} className="border-b border-[var(--color-border)] last:border-b-0">
+                    <td className="py-3 font-medium">{d.domain}</td>
+                    <td className="py-3 text-right">
+                      <button
+                        onClick={() => deleteMutation.mutate(d.id)}
+                        disabled={deleteMutation.isPending}
+                        className="inline-flex items-center justify-center text-[var(--color-destructive)] transition-opacity hover:opacity-70"
+                        aria-label={m.admin_domains_delete_confirm()}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/klai-portal/frontend/src/routes/admin/join-requests.tsx
+++ b/klai-portal/frontend/src/routes/admin/join-requests.tsx
@@ -1,0 +1,118 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { useAuth } from 'react-oidc-context'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Check, X } from 'lucide-react'
+import { apiFetch } from '@/lib/apiFetch'
+import * as m from '@/paraglide/messages'
+import { adminLogger } from '@/lib/logger'
+
+export const Route = createFileRoute('/admin/join-requests')({
+  component: AdminJoinRequestsPage,
+})
+
+interface JoinRequest {
+  id: number
+  zitadel_user_id: string
+  email: string
+  display_name: string | null
+  status: string
+  requested_at: string
+}
+
+function AdminJoinRequestsPage() {
+  const auth = useAuth()
+  const token = auth.user?.access_token
+  const queryClient = useQueryClient()
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['admin-join-requests'],
+    queryFn: async () => apiFetch<{ requests: JoinRequest[] }>('/api/admin/join-requests', token),
+    enabled: !!token,
+  })
+
+  const approveMutation = useMutation({
+    mutationFn: async (id: number) =>
+      apiFetch(`/api/admin/join-requests/${id}/approve`, token, { method: 'POST' }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['admin-join-requests'] })
+      adminLogger.info('Join request approved')
+    },
+  })
+
+  const denyMutation = useMutation({
+    mutationFn: async (id: number) =>
+      apiFetch(`/api/admin/join-requests/${id}/deny`, token, { method: 'POST' }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['admin-join-requests'] })
+      adminLogger.info('Join request denied')
+    },
+  })
+
+  const requests = data?.requests ?? []
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">{m.admin_join_requests_title()}</h1>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{m.admin_join_requests_title()}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <p className="text-sm text-[var(--color-muted-foreground)]">...</p>
+          ) : requests.length === 0 ? (
+            <p className="text-sm text-[var(--color-muted-foreground)]">{m.admin_join_requests_empty()}</p>
+          ) : (
+            <table className="w-full text-sm border-t border-b border-[var(--color-border)]">
+              <thead>
+                <tr className="border-b border-[var(--color-border)]">
+                  <th className="py-3 pr-4 text-left text-xs font-medium text-[var(--color-rl-dark-30)] uppercase tracking-[0.04em]">
+                    Name
+                  </th>
+                  <th className="py-3 pr-4 text-left text-xs font-medium text-[var(--color-rl-dark-30)] uppercase tracking-[0.04em]">
+                    Email
+                  </th>
+                  <th className="py-3 text-right w-36" />
+                </tr>
+              </thead>
+              <tbody>
+                {requests.map((req) => (
+                  <tr key={req.id} className="border-b border-[var(--color-border)] last:border-b-0">
+                    <td className="py-4 pr-4 align-top">{req.display_name || '-'}</td>
+                    <td className="py-4 pr-4 align-top">{req.email}</td>
+                    <td className="py-4 align-top text-right w-36">
+                      <div className="flex items-center justify-end gap-1">
+                        <Button
+                          size="sm"
+                          className="h-6 text-[10px] px-2 gap-1 [&_svg]:size-2.5 bg-[var(--color-success)] text-white hover:opacity-70"
+                          onClick={() => approveMutation.mutate(req.id)}
+                          disabled={approveMutation.isPending}
+                        >
+                          <Check /> {m.admin_join_requests_approve()}
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          className="h-6 text-[10px] px-2 gap-1 [&_svg]:size-2.5"
+                          onClick={() => denyMutation.mutate(req.id)}
+                          disabled={denyMutation.isPending}
+                        >
+                          <X /> {m.admin_join_requests_deny()}
+                        </Button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/klai-portal/frontend/src/routes/callback.tsx
+++ b/klai-portal/frontend/src/routes/callback.tsx
@@ -29,6 +29,12 @@ function CallbackPage() {
         if (res.ok) {
           const me = await res.json()
 
+          // SSO user with no org — show no-account page
+          if (me.org_found === false) {
+            window.location.replace('/no-account')
+            return
+          }
+
           // Provisioning still running — send to loading screen
           if (me.provisioning_status === 'pending' || me.provisioning_status === 'failed') {
             window.location.replace('/provisioning')

--- a/klai-portal/frontend/src/routes/join-request.tsx
+++ b/klai-portal/frontend/src/routes/join-request.tsx
@@ -39,9 +39,10 @@ function JoinRequestPage() {
 
   const submitMutation = useMutation({
     mutationFn: async () => {
+      if (!auth.user) throw new Error('Not authenticated')
       const res = await fetch('/api/auth/join-request', {
         method: 'POST',
-        headers: { Authorization: `Bearer ${auth.user!.access_token}` },
+        headers: { Authorization: `Bearer ${auth.user.access_token}` },
       })
       if (!res.ok) {
         const data = await res.json().catch(() => ({}))
@@ -123,7 +124,7 @@ function JoinRequestPage() {
 
       {submitMutation.error && (
         <p className="text-sm text-[var(--color-destructive)]">
-          {String(submitMutation.error)}
+          {submitMutation.error instanceof Error ? submitMutation.error.message : String(submitMutation.error)}
         </p>
       )}
 

--- a/klai-portal/frontend/src/routes/join-request.tsx
+++ b/klai-portal/frontend/src/routes/join-request.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
 import { useAuth } from 'react-oidc-context'
 import { useQuery, useMutation } from '@tanstack/react-query'
@@ -34,8 +34,12 @@ function JoinRequestPage() {
     enabled: !!auth.user,
   })
 
-  // Pre-fill display name from /api/me once loaded
-  const prefillName = me?.display_name ?? me?.email?.split('@')[0] ?? ''
+  // Pre-fill display name from /api/me once loaded (only if the user hasn't typed anything)
+  useEffect(() => {
+    if (me && !displayName) {
+      setDisplayName(me.display_name ?? me.email?.split('@')[0] ?? '')
+    }
+  }, [me]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const submitMutation = useMutation({
     mutationFn: async () => {
@@ -115,7 +119,7 @@ function JoinRequestPage() {
           <Input
             id="jr-name"
             type="text"
-            value={displayName || prefillName}
+            value={displayName}
             onChange={(e) => setDisplayName(e.target.value)}
             maxLength={100}
           />

--- a/klai-portal/frontend/src/routes/join-request.tsx
+++ b/klai-portal/frontend/src/routes/join-request.tsx
@@ -1,0 +1,140 @@
+import { useState } from 'react'
+import { createFileRoute } from '@tanstack/react-router'
+import { useAuth } from 'react-oidc-context'
+import { useQuery, useMutation } from '@tanstack/react-query'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { CheckCircle2 } from 'lucide-react'
+import * as m from '@/paraglide/messages'
+import { useLocale } from '@/lib/locale'
+import { AuthPageLayout } from '@/components/layout/AuthPageLayout'
+import { authLogger } from '@/lib/logger'
+
+export const Route = createFileRoute('/join-request')({
+  component: JoinRequestPage,
+})
+
+function JoinRequestPage() {
+  useLocale()
+  const auth = useAuth()
+  const [displayName, setDisplayName] = useState('')
+  const [submitted, setSubmitted] = useState(false)
+
+  // Prefetch email from /api/me to pre-fill display name
+  const { data: me } = useQuery({
+    queryKey: ['me'],
+    queryFn: async () => {
+      const res = await fetch('/api/me', {
+        headers: { Authorization: `Bearer ${auth.user!.access_token}` },
+      })
+      if (!res.ok) return null
+      return res.json() as Promise<{ email?: string; display_name?: string }>
+    },
+    enabled: !!auth.user,
+  })
+
+  // Pre-fill display name from /api/me once loaded
+  const prefillName = me?.display_name ?? me?.email?.split('@')[0] ?? ''
+
+  const submitMutation = useMutation({
+    mutationFn: async () => {
+      const res = await fetch('/api/auth/join-request', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${auth.user!.access_token}` },
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error((data as { detail?: string }).detail ?? `HTTP ${res.status}`)
+      }
+      return res.json()
+    },
+    onSuccess: () => {
+      setSubmitted(true)
+    },
+    onError: (err) => {
+      authLogger.error('Join request failed', { error: String(err) })
+    },
+  })
+
+  const leftContent = (
+    <>
+      <h1 className="text-2xl font-semibold leading-tight">
+        {m.no_account_hero_heading()}
+        <br />
+        <span className="text-[var(--color-rl-accent)]">{m.no_account_hero_highlight()}</span>
+      </h1>
+      <p className="text-base leading-relaxed text-[var(--color-rl-cream)]">
+        {m.no_account_hero_body()}
+      </p>
+    </>
+  )
+
+  if (submitted) {
+    return (
+      <AuthPageLayout leftContent={leftContent} showLocale>
+        <div className="flex flex-col items-center gap-4 text-center">
+          <CheckCircle2 className="h-10 w-10 text-[var(--color-success)]" />
+          <p className="text-sm text-[var(--color-muted-foreground)]">
+            {m.join_request_success()}
+          </p>
+        </div>
+      </AuthPageLayout>
+    )
+  }
+
+  return (
+    <AuthPageLayout leftContent={leftContent} showLocale>
+      <div className="space-y-2">
+        <h2 className="text-xl font-semibold text-[var(--color-foreground)]">
+          {m.join_request_heading()}
+        </h2>
+        <p className="text-sm text-[var(--color-muted-foreground)]">
+          {m.join_request_body()}
+        </p>
+      </div>
+
+      <div className="space-y-4">
+        {me?.email && (
+          <div className="space-y-1.5">
+            <Label htmlFor="jr-email">Email</Label>
+            <Input
+              id="jr-email"
+              type="email"
+              value={me.email}
+              disabled
+              readOnly
+              className="opacity-60"
+            />
+          </div>
+        )}
+
+        <div className="space-y-1.5">
+          <Label htmlFor="jr-name">Name</Label>
+          <Input
+            id="jr-name"
+            type="text"
+            value={displayName || prefillName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            maxLength={100}
+          />
+        </div>
+      </div>
+
+      {submitMutation.error && (
+        <p className="text-sm text-[var(--color-destructive)]">
+          {String(submitMutation.error)}
+        </p>
+      )}
+
+      <Button
+        onClick={() => submitMutation.mutate()}
+        disabled={submitMutation.isPending}
+        size="lg"
+        className="w-full"
+      >
+        {m.join_request_submit()}
+      </Button>
+    </AuthPageLayout>
+  )
+}

--- a/klai-portal/frontend/src/routes/no-account.tsx
+++ b/klai-portal/frontend/src/routes/no-account.tsx
@@ -1,0 +1,59 @@
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { Button } from '@/components/ui/button'
+import { ArrowRight } from 'lucide-react'
+import * as m from '@/paraglide/messages'
+import { useLocale } from '@/lib/locale'
+import { AuthPageLayout } from '@/components/layout/AuthPageLayout'
+
+export const Route = createFileRoute('/no-account')({
+  component: NoAccountPage,
+})
+
+function NoAccountPage() {
+  useLocale()
+  const navigate = useNavigate()
+
+  const leftContent = (
+    <>
+      <h1 className="text-2xl font-semibold leading-tight">
+        {m.no_account_hero_heading()}
+        <br />
+        <span className="text-[var(--color-rl-accent)]">{m.no_account_hero_highlight()}</span>
+      </h1>
+      <p className="text-base leading-relaxed text-[var(--color-rl-cream)]">
+        {m.no_account_hero_body()}
+      </p>
+    </>
+  )
+
+  return (
+    <AuthPageLayout leftContent={leftContent} showLocale>
+      <div className="space-y-2">
+        <h2 className="text-xl font-semibold text-[var(--color-foreground)]">
+          {m.no_account_heading()}
+        </h2>
+        <p className="text-sm text-[var(--color-muted-foreground)]">
+          {m.no_account_body()}
+        </p>
+      </div>
+
+      <Button
+        onClick={() => { void navigate({ to: '/join-request' }) }}
+        size="lg"
+        className="w-full gap-3"
+      >
+        {m.no_account_request_access()}
+        <ArrowRight size={16} />
+      </Button>
+
+      <Button
+        variant="ghost"
+        onClick={() => { window.location.replace('/') }}
+        size="lg"
+        className="w-full"
+      >
+        {m.no_account_cta()}
+      </Button>
+    </AuthPageLayout>
+  )
+}

--- a/klai-portal/frontend/src/routes/select-workspace.tsx
+++ b/klai-portal/frontend/src/routes/select-workspace.tsx
@@ -2,7 +2,6 @@ import { createFileRoute, useSearch } from '@tanstack/react-router'
 import { useState } from 'react'
 import { useQuery, useMutation } from '@tanstack/react-query'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import * as m from '@/paraglide/messages'
 import { useLocale } from '@/lib/locale'
 import { AuthPageLayout } from '@/components/layout/AuthPageLayout'
@@ -17,7 +16,7 @@ export const Route = createFileRoute('/select-workspace')({
 })
 
 interface Workspace {
-  org_id: number
+  id: number
   name: string
   slug: string
 }
@@ -27,6 +26,22 @@ function SelectWorkspacePage() {
   const { ref } = useSearch({ from: '/select-workspace' })
   const [selectedOrg, setSelectedOrg] = useState<number | null>(null)
 
+  const { data, isLoading, error: fetchError } = useQuery({
+    queryKey: ['pending-session', ref],
+    queryFn: async () => {
+      const res = await fetch(
+        `${API_BASE}/api/auth/pending-session?ref=${encodeURIComponent(ref)}`,
+      )
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error((body as { detail?: string }).detail ?? `HTTP ${res.status}`)
+      }
+      return res.json() as Promise<{ orgs: Workspace[] }>
+    },
+    enabled: !!ref,
+    retry: false,
+  })
+
   const selectMutation = useMutation({
     mutationFn: async (orgId: number) => {
       const res = await fetch(`${API_BASE}/api/auth/select-workspace`, {
@@ -34,14 +49,17 @@ function SelectWorkspacePage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ ref, org_id: orgId }),
       })
-      if (!res.ok) throw new Error('Selection failed')
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error((body as { detail?: string }).detail ?? `HTTP ${res.status}`)
+      }
       return res.json() as Promise<{ workspace_url: string }>
     },
-    onSuccess: (data) => {
-      window.location.replace(data.workspace_url)
+    onSuccess: (result) => {
+      window.location.replace(result.workspace_url)
     },
     onError: (err) => {
-      authLogger.error('Workspace selection failed', err)
+      authLogger.error('Workspace selection failed', { error: String(err) })
     },
   })
 
@@ -51,30 +69,88 @@ function SelectWorkspacePage() {
     </h1>
   )
 
-  return (
-    <AuthPageLayout leftContent={leftContent} showLocale>
-      <div className="space-y-4">
-        <div className="space-y-2">
-          <h2 className="text-xl font-semibold text-[var(--color-foreground)]">
-            {m.select_workspace_heading()}
-          </h2>
-          <p className="text-sm text-[var(--color-muted-foreground)]">
-            {m.select_workspace_body()}
-          </p>
+  if (isLoading) {
+    return (
+      <AuthPageLayout leftContent={leftContent} showLocale>
+        <div className="flex items-center justify-center py-8">
+          <span className="text-sm text-[var(--color-muted-foreground)]">…</span>
         </div>
+      </AuthPageLayout>
+    )
+  }
 
-        {/* Workspaces will be populated from the pending session data */}
-        <div className="space-y-2">
+  if (fetchError || !data) {
+    return (
+      <AuthPageLayout leftContent={leftContent} showLocale>
+        <div className="space-y-4">
+          <p className="text-sm text-[var(--color-destructive)]">
+            {fetchError instanceof Error
+              ? fetchError.message
+              : m.select_workspace_session_expired()}
+          </p>
           <Button
-            onClick={() => selectMutation.mutate(selectedOrg ?? 0)}
-            disabled={!selectedOrg || selectMutation.isPending}
+            variant="ghost"
             size="lg"
             className="w-full"
+            onClick={() => window.location.replace('/')}
           >
-            {selectMutation.isPending ? '...' : m.select_workspace_heading()}
+            {m.forgot_back()}
           </Button>
         </div>
+      </AuthPageLayout>
+    )
+  }
+
+  return (
+    <AuthPageLayout leftContent={leftContent} showLocale>
+      <div className="space-y-2">
+        <h2 className="text-xl font-semibold text-[var(--color-foreground)]">
+          {m.select_workspace_heading()}
+        </h2>
+        <p className="text-sm text-[var(--color-muted-foreground)]">
+          {m.select_workspace_body()}
+        </p>
       </div>
+
+      <div className="space-y-2">
+        {data.orgs.map((org) => (
+          <button
+            key={org.id}
+            type="button"
+            onClick={() => setSelectedOrg(org.id)}
+            className={[
+              'w-full rounded-xl border p-4 text-left transition-colors',
+              selectedOrg === org.id
+                ? 'border-[var(--color-rl-accent)] bg-[var(--color-rl-accent)]/10'
+                : 'border-[var(--color-border)] bg-[var(--color-card)] hover:border-[var(--color-rl-accent)]/50',
+            ].join(' ')}
+          >
+            <span className="block font-medium text-[var(--color-foreground)]">
+              {org.name}
+            </span>
+            <span className="block text-xs text-[var(--color-muted-foreground)]">
+              {org.slug}
+            </span>
+          </button>
+        ))}
+      </div>
+
+      {selectMutation.error && (
+        <p className="text-sm text-[var(--color-destructive)]">
+          {selectMutation.error instanceof Error
+            ? selectMutation.error.message
+            : String(selectMutation.error)}
+        </p>
+      )}
+
+      <Button
+        onClick={() => selectedOrg !== null && selectMutation.mutate(selectedOrg)}
+        disabled={selectedOrg === null || selectMutation.isPending}
+        size="lg"
+        className="w-full"
+      >
+        {selectMutation.isPending ? '…' : m.select_workspace_continue()}
+      </Button>
     </AuthPageLayout>
   )
 }

--- a/klai-portal/frontend/src/routes/select-workspace.tsx
+++ b/klai-portal/frontend/src/routes/select-workspace.tsx
@@ -1,0 +1,80 @@
+import { createFileRoute, useSearch } from '@tanstack/react-router'
+import { useState } from 'react'
+import { useQuery, useMutation } from '@tanstack/react-query'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import * as m from '@/paraglide/messages'
+import { useLocale } from '@/lib/locale'
+import { AuthPageLayout } from '@/components/layout/AuthPageLayout'
+import { API_BASE } from '@/lib/api'
+import { authLogger } from '@/lib/logger'
+
+export const Route = createFileRoute('/select-workspace')({
+  component: SelectWorkspacePage,
+  validateSearch: (search: Record<string, unknown>) => ({
+    ref: (search.ref as string) || '',
+  }),
+})
+
+interface Workspace {
+  org_id: number
+  name: string
+  slug: string
+}
+
+function SelectWorkspacePage() {
+  useLocale()
+  const { ref } = useSearch({ from: '/select-workspace' })
+  const [selectedOrg, setSelectedOrg] = useState<number | null>(null)
+
+  const selectMutation = useMutation({
+    mutationFn: async (orgId: number) => {
+      const res = await fetch(`${API_BASE}/api/auth/select-workspace`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ref, org_id: orgId }),
+      })
+      if (!res.ok) throw new Error('Selection failed')
+      return res.json() as Promise<{ workspace_url: string }>
+    },
+    onSuccess: (data) => {
+      window.location.replace(data.workspace_url)
+    },
+    onError: (err) => {
+      authLogger.error('Workspace selection failed', err)
+    },
+  })
+
+  const leftContent = (
+    <h1 className="text-2xl font-semibold leading-tight">
+      {m.select_workspace_heading()}
+    </h1>
+  )
+
+  return (
+    <AuthPageLayout leftContent={leftContent} showLocale>
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold text-[var(--color-foreground)]">
+            {m.select_workspace_heading()}
+          </h2>
+          <p className="text-sm text-[var(--color-muted-foreground)]">
+            {m.select_workspace_body()}
+          </p>
+        </div>
+
+        {/* Workspaces will be populated from the pending session data */}
+        <div className="space-y-2">
+          <Button
+            onClick={() => selectMutation.mutate(selectedOrg ?? 0)}
+            disabled={!selectedOrg || selectMutation.isPending}
+            size="lg"
+            className="w-full"
+          >
+            {selectMutation.isPending ? '...' : m.select_workspace_heading()}
+          </Button>
+        </div>
+      </div>
+    </AuthPageLayout>
+  )
+}


### PR DESCRIPTION
## Summary

- **Domain allowlist** (R1-R4): Admins add/remove email domains; SSO users on matching domains are auto-provisioned on first login
- **Join request flow** (R5-R7): SSO users with no workspace see `/no-account` → `/join-request` form → admin email notification → approve/deny via admin UI or approval token link
- **Multi-org workspace selection** (R8-R9): Users linked to multiple orgs are redirected to `/select-workspace` via Redis pending session (single-use, 10-min TTL)

## Key changes

**Backend (portal-api)**
- 3 Alembic migrations: `portal_org_allowed_domains`, `portal_join_requests`, composite unique on `portal_users(zitadel_user_id, org_id)`
- `idp_callback` extended: auto-provision on domain match, multi-org Redis redirect, `org_found` flag propagated via `/api/me`
- New endpoints: `POST /api/auth/join-request`, `POST /api/auth/select-workspace`, `GET/POST/DELETE /api/admin/domains`, `GET/POST /api/admin/join-requests`
- Services: `domain_validation`, `pending_session` (Redis), `join_request_token` (HMAC), `notifications` (mailer)

**Frontend (portal)**
- `no-account.tsx`: new page with primary "Request access" CTA + ghost back button
- `join-request.tsx`: email pre-filled (read-only), name editable, submit → confirmation
- `select-workspace.tsx`: workspace picker for multi-org users
- `admin/domains.tsx`, `admin/join-requests.tsx`: admin management pages
- 28 new i18n messages in `en.json` + `nl.json`

**Mailer**
- `POST /internal/send` endpoint with `X-Internal-Secret` auth for join request notifications

## Test plan
- [ ] 51 backend tests pass (`uv run pytest`)
- [ ] TypeScript compiles clean (`tsc --noEmit`)
- [ ] SSO login with no matching domain → `/no-account` → `/join-request` → confirmation
- [ ] Admin approves/denies join request via UI
- [ ] Domain allowlist auto-provisions user on match
- [ ] Multi-org user redirected to workspace selector

🤖 Generated with [Claude Code](https://claude.com/claude-code)