### PR TITLE
SPEC-WIDGET-002: split API keys and widgets into independent domains

### DIFF
--- a/.moai/specs/SPEC-KB-IMAGE-001/spec.md
+++ b/.moai/specs/SPEC-KB-IMAGE-001/spec.md
@@ -1,9 +1,9 @@
 ---
 id: SPEC-KB-IMAGE-001
-version: "1.0.0"
+version: "1.3.0"
 status: implemented
 created: 2026-04-08
-updated: 2026-04-08
+updated: 2026-04-16
 author: Mark Vletter
 priority: high
 ---
@@ -15,6 +15,7 @@ priority: high
 | 2026-04-08 | 1.0.0 | Initial SPEC creation |
 | 2026-04-08 | 1.1.0 | Component correcties: Garage v2.2.0, minio SDK, filetype validatie, init-script |
 | 2026-04-08 | 1.2.0 | Implemented and deployed: Caddy website mode, env var secrets, E2E verified on production |
+| 2026-04-16 | 1.3.0 | Refactor: adapter-owned image URL resolution (DRY, typed, tested). No behavioural change. |
 
 ---
 
@@ -141,3 +142,50 @@ Het systeem **zal** maximaal 20 images per document verwerken.
 - **Garage region:** S3 client MOET `region="garage"` configureren, anders falen auth signatures
 - **Garage bootstrap:** Vereist post-start CLI interactie (layout assign + bucket create) via init-script
 - **S3 client:** `minio` SDK (sync) met `asyncio.to_thread()` — consistent met codebase die httpx gebruikt (geen aiohttp dependency)
+
+---
+
+## Implementation Notes — 2026-04-16 Refactor
+
+### What was refactored
+
+URL resolution voor afbeeldingen is verplaatst van `sync_engine.py` naar elke adapter afzonderlijk. Vóór de refactor bevatte `sync_engine` connector-type dispatch (`isinstance` checks) om relatieve URLs te resolven voor de webcrawler en om markdown image URLs te extraheren voor GitHub. Na de refactor doet elke adapter dit zelf als onderdeel van zijn `fetch_document()` of `_process_results()` logica.
+
+Concreet:
+- De `_extract_and_upload_images()` functie in `sync_engine` werd vereenvoudigd naar `_upload_images()` zonder `text`-parameter en zonder connector-type dispatch.
+- `extract_markdown_image_urls()` en `resolve_relative_url` imports zijn verwijderd uit `sync_engine`.
+- De `_image_cache` side-channel en de bijbehorende `get_cached_images()` methode zijn verwijderd uit de Notion adapter.
+
+### Why
+
+- Elimineer connector-type dispatch in `sync_engine` (violation of open/closed principle).
+- Maak het contract expliciet: elke adapter is verantwoordelijk voor zijn eigen `DocumentRef.images` met absolute URLs.
+- Maakt per-adapter testing mogelijk zonder `sync_engine` te instantiëren.
+
+### Files touched
+
+- `klai-connector/app/adapters/webcrawler.py` — `_process_results()` resolveert relatieve image URLs naar absoluut t.o.v. de pagina-URL.
+- `klai-connector/app/adapters/notion.py` — verwijderd `_image_cache` en `get_cached_images()`; `fetch_document()` zet `ref.images` direct.
+- `klai-connector/app/adapters/github.py` — `source_url` is nu de blob-view URL (`github.com/{owner}/{repo}/blob/{branch}/{path}`); nieuwe statische helper `_extract_markdown_images()` vult `ref.images` met absolute URLs voor `.md`/`.rst` bestanden.
+- `klai-connector/app/services/sync_engine.py` — `_extract_and_upload_images()` hernoemd naar `_upload_images()`; alle connector-type dispatch verwijderd; `ref` parameter getypt als `DocumentRef`.
+- `klai-connector/app/adapters/base.py` — docstrings documenteren nu het contract: `ImageRef.url` MUST be absolute HTTP(S); `DocumentRef.images` is URL-based only.
+
+### Tests added
+
+18 nieuwe unit tests verdeeld over 4 testbestanden:
+
+- `tests/adapters/test_github_images.py` (NIEUW) — 9 tests: relatieve URL, absolute URL, dot-slash, branch handling, data URI skipping, leading-slash urljoin semantics.
+- `tests/adapters/test_webcrawler.py::TestImageUrlResolution` — 4 tests: `_process_results()` absolute URL conversie.
+- `tests/adapters/test_notion.py` — 3 tests: `ref.images` populatie + afwezigheid van legacy `_image_cache`.
+- `tests/test_sync_engine_images.py::TestUploadImagesIsConnectorAgnostic` — 2 tests: connector-agnostic upload.
+
+### Contract clarified
+
+- `ImageRef.url` MUST be an absolute HTTP(S) URL. Adapters zijn verantwoordelijk voor het resolven van relatieve URLs vóór het zetten van `ref.images`.
+- `DocumentRef.images` is URL-based only. Embedded binary images (DOCX/PDF embeds) gaan via de parser pipeline (Unstructured.io `Image` elements), niet via dit veld.
+
+### Commits
+
+- `ddfac8c1` — `refactor(connector): each adapter owns its own image URL resolution`
+- `363441be` — `refactor(connector): complete adapter-owned image URL resolution`
+- `51b7150b` — `refactor(connector): tighten types and document image contract`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [Unreleased] — 2026-04-16 — SPEC-KB-IMAGE-001: Adapter-owned image URL resolution (refactor)
+
+### Changed
+
+- **`klai-connector/app/adapters/webcrawler.py`**: `_process_results()` resolveert nu relatieve image URLs naar absoluut t.o.v. de pagina-URL, direct bij het ophalen van resultaten. Geen connector-type dispatch meer in `sync_engine` voor webcrawler URLs.
+- **`klai-connector/app/adapters/notion.py`**: Verwijderd `_image_cache` side-channel en `get_cached_images()` methode. `fetch_document()` zet `ref.images` nu direct (conform het BaseAdapter contract).
+- **`klai-connector/app/adapters/github.py`**: `source_url` is nu de GitHub blob-view URL (`https://github.com/{owner}/{repo}/blob/{branch}/{path}`) voor gebruikerszichtbare citaties. De raw URL (`raw.githubusercontent.com`) wordt alleen intern gebruikt in `fetch_document()` als basis voor het resolven van markdown image URLs. Nieuwe statische helper `_extract_markdown_images()` vult `ref.images` met absolute URLs voor `.md` en `.rst` bestanden.
+- **`klai-connector/app/services/sync_engine.py`**: `_extract_and_upload_images()` hernoemd naar `_upload_images()`. Alle connector-type dispatch verwijderd. `text` parameter verwijderd. `extract_markdown_image_urls()` en `resolve_relative_url` imports verwijderd. Parameter `ref` getypt als `DocumentRef` in plaats van `Any`.
+- **`klai-connector/app/adapters/base.py`**: Docstrings documenteren nu expliciet het contract: `ImageRef.url` MUST be absolute HTTP(S); `DocumentRef.images` is URL-based only (DOCX/PDF embeds gaan via de parser pipeline, niet via dit veld). Docstrings toegevoegd voor `source_url` en `last_edited` velden op `DocumentRef`.
+
+### Added
+
+- **18 nieuwe unit tests** verdeeld over 4 testbestanden:
+  - `tests/adapters/test_github_images.py` (NIEUW) — 9 tests voor markdown URL resolution (relatief, absoluut, dot-slash, branch handling, data URI skipping, leading-slash urljoin semantics)
+  - `tests/adapters/test_webcrawler.py::TestImageUrlResolution` — 4 tests voor `_process_results()` absolute URL conversie
+  - `tests/adapters/test_notion.py` — 3 tests voor `ref.images` populatie + afwezigheid van legacy `_image_cache`
+  - `tests/test_sync_engine_images.py::TestUploadImagesIsConnectorAgnostic` — 2 tests voor connector-agnostic upload
+
+> Dit is een refactor. Er zijn geen nieuwe gebruikerszichtbare features. Extern gedrag is ongewijzigd.
+
 ## [Unreleased] — 2026-04-06 — SPEC-KB-026: Taxonomy Integration Hardening
 
 ### Fixed — SPEC-KB-026: Taxonomy Integration Hardening (6 bugs)


### PR DESCRIPTION
## Summary

Splits the combined \`partner_api_keys\` table and \`/admin/integrations\` surface into two independent first-class domains (see SPEC-WIDGET-002 v0.3.0).

### Backend
- New \`widgets\` + \`widget_kb_access\` tables (no auth-secret columns — widget auth is 100% JWT via WIDGET_JWT_SECRET)
- New endpoints: \`/api/api-keys/*\` and \`/api/widgets/*\`
- Removed \`/api/integrations/*\` entirely, removed revoke endpoint, removed \`active\` column
- \`/partner/v1/widget-config\` now queries the \`widgets\` table
- Alembic migration \`f0a1b2c3d4e5\` handles data move + column drops (with DO block for non-owner DDL)
- Post-deploy SQL (\`post_deploy_f0a1b2c3d4e5.sql\`) must run as klai superuser to ENABLE RLS + CREATE POLICY on the new tables + finalise column drops on partner_api_keys

### Frontend
- Two new route trees: \`/admin/api-keys/\` and \`/admin/widgets/\`
- Each has its own wizard (4 steps, matching tabs 1-to-1) and detail view (5 tabs)
- Widget KB selector is a simple checkbox list (no read_write option)
- Danger zone: delete only, no revoke, no status badges
- Sidebar: \"API keys\" + \"Chat widgets\" menu items
- Removed \`/admin/integrations\` route tree entirely

### Deployment
1. CI builds + deploys backend and frontend together
2. Operator runs post-deploy SQL on core-01 as klai superuser:
   \`\`\`
   ssh core-01 \"docker exec -i klai-core-postgres-1 psql -U klai -d klai\" < klai-portal/backend/alembic/versions/post_deploy_f0a1b2c3d4e5.sql
   \`\`\`
3. \`alembic upgrade f0a1b2c3d4e5\` on portal-api

## Test plan
- [ ] Backend: \`pytest tests/test_widget_config.py tests/test_partner_dependencies.py tests/test_partner_api_keys_model.py\` green
- [ ] Frontend: \`tsc --noEmit\` + \`npm run lint\` + \`npm run build\` green
- [ ] Playwright smoke: /admin/api-keys wizard + detail + delete
- [ ] Playwright smoke: /admin/widgets wizard + detail + delete
- [ ] Widget embed snippet works on test domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)