### PR TITLE
docs(spec): SPEC-CRAWLER-004 Fase G — close SPEC + HISTORY + pitfall

### DIFF
--- a/.claude/rules/klai/pitfalls/process-rules.md
+++ b/.claude/rules/klai/pitfalls/process-rules.md
@@ -1,5 +1,25 @@
 # Process Rules
 
+## adapter-framework-bleed (HIGH)
+When a service is declared "a pure X adapter framework" but you find
+infrastructure concepts leaking into its public contract (S3 clients,
+persistence primitives, MIME-validation helpers, content-fingerprint
+fields) — stop before deleting them. Audit every consumer of those
+concepts first. SPEC-CRAWLER-004 planned to delete `ImageRef` +
+`DocumentRef.images` + `DocumentRef.content_fingerprint` from
+klai-connector's BaseAdapter as "obviously crawl-only leakage". Only
+`content_fingerprint` was actually crawl-only; github and notion
+adapters were silently relying on `ImageRef` + `DocumentRef.images` to
+drive sync_engine's S3 upload path. Deleting them would have broken
+every live github/notion sync.
+
+**Prevention:** Before any SPEC calls for deletion of a shared
+datastructure, grep every caller across all services in the repo.
+If non-trivially-adjacent callers exist, either broaden the SPEC
+scope to move them or narrow the SPEC scope to leave the structure
+in place. Never assume "originally added for X, therefore only used
+by X". Shared contracts spread.
+
 ## data-before-code
 Before fixing a bug: check the logs and follow the actual code path.
 No guessing. No stacking patches. Trace what happens at runtime — logs,

--- a/.moai/specs/SPEC-CRAWLER-004/spec.md
+++ b/.moai/specs/SPEC-CRAWLER-004/spec.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-CRAWLER-004
-version: "1.0"
-status: draft
+version: "1.1"
+status: completed
 created: 2026-04-22
 updated: 2026-04-22
 author: Mark Vletter
@@ -14,6 +14,7 @@ issue_number: 108
 | Version | Date | Author | Change |
 |---------|------|--------|--------|
 | 1.0 | 2026-04-22 | Mark Vletter | Initial draft na E2E test op Voys/support KB |
+| 1.1 | 2026-04-22 | Mark Vletter | Fase F amendment: `ImageRef` + `DocumentRef.images` retained (used by github + notion adapters). REQ-04.2 scope narrowed to `DocumentRef.content_fingerprint`. Full consolidation tracked under SPEC-KB-IMAGE-002 (#111) and possible SPEC-KB-IMAGE-003. Status: `completed`. |
 
 ---
 
@@ -204,9 +205,12 @@ automatically within the same sync cycle.
 named `webcrawler.py` or `content_fingerprint.py` under `klai-connector/app/`, and
 no class named `WebCrawlerAdapter` anywhere under `klai-connector/`.
 
-**REQ-04.2 (Ubiquitous).** `klai-connector/app/adapters/base.py` shall not contain
-`ImageRef`, `DocumentRef.images`, or `DocumentRef.content_fingerprint` after Fase F;
-`DocumentRef` shall be the minimal document-of-a-managed-source dataclass.
+**REQ-04.2 (Ubiquitous).** [AMENDED v1.1] `klai-connector/app/adapters/base.py` shall not
+contain `DocumentRef.content_fingerprint` after Fase F. `ImageRef` + `DocumentRef.images`
+are RETAINED — github and notion adapters actively populate them to drive sync_engine's
+`_upload_images` path. Full removal + consolidation of the klai-connector image stack is
+tracked under SPEC-KB-IMAGE-002 (#111 — shared `klai-libs/image-storage/` package) and
+possible SPEC-KB-IMAGE-003 (adapter contract rework to surface images as inline markdown).
 
 **REQ-04.3 (Ubiquitous).** `klai-connector/app/adapters/registry.py` shall route
 `web_crawler` connector_type directly to the delegation path added in REQ-03.3,

--- a/docs/architecture/knowledge-ingest-flow.md
+++ b/docs/architecture/knowledge-ingest-flow.md
@@ -140,7 +140,7 @@ On page delete: all Qdrant vectors for that document path are removed.
 ### 1.2 External sources via klai-connector
 
 klai-connector is a separate service that syncs external content into the knowledge pipeline
-on a schedule or on-demand.
+on a schedule or on-demand. Since SPEC-CRAWLER-004 it is a **pure adapter framework for Klasse-1 managed sources** (GitHub, Notion, Drive, MS Docs). Web crawling (Klasse-3 unmanaged-source ingress) was consolidated into knowledge-ingest; klai-connector's sync_engine delegates `connector_type=="web_crawler"` syncs to knowledge-ingest's `/ingest/v1/crawl/sync` endpoint and polls the returned `job_id` for completion. Cookies are loaded + decrypted in-process by knowledge-ingest via the shared `klai-libs/connector-credentials` library so plaintext cookies never cross a service boundary.
 
 **GitHub repos (live):** klai-connector authenticates as a GitHub App installation, lists
 all files, and skips syncs when the repository tree SHA hasn't changed since the last run.
@@ -153,12 +153,22 @@ This means a large repo with no changes costs almost nothing. Supported files: `
 parser.py`. The parsed plain text is then forwarded to `knowledge-ingest` via
 `POST /ingest/v1/document`. Maximum file size: 50 MB.
 
-**Web crawls (live) — two-phase pipeline (SPEC-CRAWL-002):** the crawler splits **URL discovery** from **content extraction**, so auth failures and selector issues surface before the full crawl runs:
+**Web crawls (live) — delegation pipeline (SPEC-CRAWLER-004):**
 
-- **Phase 1 — BFS discovery.** Traverses internal links from `base_url`, bounded by `max_pages` and `path_prefix`. The full DOM is preserved during discovery (no premature pruning) so the link graph is complete. Output: deduplicated URL list.
-- **Phase 2 — Extraction.** For each URL, applies the `css_selector` (user-provided, stored, or AI-detected) and runs the same enrichment as documents.
+```
+portal-api ─▶ klai-connector sync_engine ─▶ POST /ingest/v1/crawl/sync ─▶ knowledge-ingest
+   (Sync now)   (connector_type=="web_crawler"        (connector_id only,                   (decrypts cookies,
+                 → delegation path)                     never plaintext cookies)              enqueues Procrastinate run_crawl)
+                                                                                                   │
+                                                                                                   ▼
+                                                                                        crawl4ai REST + image pipeline
+                                                                                        (SPEC-CRAWLER-004 Fase A/B/C)
+                                                                                                   │
+   klai-connector ◀─ GET /ingest/v1/crawl/sync/{job_id}/status (polled every 5 s, timeout 30 min) ─┘
+   closes sync_run.status=completed + documents_ok=pages_total
+```
 
-Both phases use the shared Crawl4AI container via REST API (`http://crawl4ai:11235`).
+The actual crawl happens inside **knowledge-ingest's** crawler adapter, which uses the same Crawl4AI REST container (`http://crawl4ai:11235`) as the old in-connector path. The two-phase "discover → extract" semantics (SPEC-CRAWL-002) now live in `knowledge_ingest/adapters/crawler.py`. klai-connector keeps ownership of `connector.sync_runs` + `product_events` so scheduler, analytics, and UI stay untouched.
 
 **Wizard endpoints:**
 
@@ -288,9 +298,18 @@ If no `content_type` is set, the pipeline uses `unknown` — no enrichment, basi
 ### Phase 1: Immediate (synchronous)
 
 **Step 1 — Parse and chunk.** The content arrives as plain text (already decoded by the
-caller for Gitea pages and connector text files). Binary files (PDF, DOCX, HTML) are
-parsed upstream in **klai-connector** via Unstructured.io's `partition.auto` — not in
-knowledge-ingest itself.
+caller for Gitea pages and connector text files). Binary files (PDF, DOCX, HTML) arriving
+via klai-connector's github/notion/drive adapters are parsed upstream in **klai-connector**
+via Unstructured.io's `partition.auto` — not in knowledge-ingest itself.
+
+**Web-crawl content** follows a different path: since SPEC-CRAWLER-004 the bulk crawl
+runs inside knowledge-ingest itself (`POST /ingest/v1/crawl/sync` + Procrastinate
+`run_crawl` task + `knowledge_ingest/adapters/crawler.py`). Inline images in the
+`result.media.images` field from crawl4ai are downloaded + uploaded to Garage S3 by
+`knowledge_ingest/sync_images.py::download_and_upload_crawl_images` and surface in the
+Qdrant payload as `image_urls: ["/kb-images/{org_id}/images/{kb_slug}/{sha256}.{ext}"]`.
+The github + notion adapters in klai-connector keep using their own
+`sync_engine._upload_images` path for now — consolidation tracked in SPEC-KB-IMAGE-002.
 
 Chunking is done by a custom `chunker.py` inside knowledge-ingest:
 1. **Heading split** — the document is first split at H1/H2/H3 headings
@@ -704,6 +723,21 @@ When a new tenant is provisioned:
 
 The team key is the thread that connects provisioning to retrieval: it carries `org_id`,
 which scopes every Qdrant search to the correct tenant's content.
+
+### Shared libraries (klai-libs/)
+
+Two Python packages live under `klai-libs/` and are consumed by multiple services via
+`[tool.uv.sources]` path-deps:
+
+- **`klai-libs/connector-credentials/`** (SPEC-CRAWLER-004 Fase 0) — `ConnectorCredentialStore`
+  with AES-256-GCM KEK/DEK hierarchy. Consumed by `klai-portal/backend`, `klai-connector`,
+  and `klai-knowledge-ingest`. When knowledge-ingest receives a `POST /ingest/v1/crawl/sync`
+  request, it loads cookies for the `connector_id` via this library and decrypts in-process —
+  plaintext cookies never cross a service boundary (REQ-01.3, REQ-05.4).
+
+- **`klai-libs/image-storage/`** (SPEC-KB-IMAGE-002, planned) — `ImageStore` + image URL
+  helpers + `download_and_upload_*` orchestrators. Will be consumed by klai-connector and
+  knowledge-ingest once the SPEC lands; today both services still carry local copies.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes SPEC-CRAWLER-004. Delegation is live (Fase 0-D), dead code is gone (Fase F, PR #112). This PR updates the docs, amends REQ-04.2 to match the real deployed reality, and captures the lessons learned.

## What this PR does

**`docs/architecture/knowledge-ingest-flow.md`:**
- § 1.2 rewritten with the delegation flow diagram (portal-api → klai-connector → /ingest/v1/crawl/sync → knowledge-ingest → Procrastinate → crawl4ai; polled /status every 5s for 30 min)
- § 2 Phase 1 Step 1 notes web-crawl images now handled inside knowledge-ingest's crawler adapter
- § 4 gains a "Shared libraries" subsection covering `klai-libs/connector-credentials` (live) and `klai-libs/image-storage` (planned under SPEC-KB-IMAGE-002)

**`.moai/specs/SPEC-CRAWLER-004/spec.md`:**
- frontmatter → status=completed, version=1.1
- HISTORY row 1.1 capturing Fase F scope amendment
- REQ-04.2 [AMENDED]: `DocumentRef.content_fingerprint` removed; `ImageRef` + `DocumentRef.images` retained pending SPEC-KB-IMAGE-002 (#111) and possible SPEC-KB-IMAGE-003

**`.claude/rules/klai/pitfalls/process-rules.md`:**
- New "adapter-framework-bleed (HIGH)" entry documenting the Fase F miss: grep every caller of a to-be-deleted shared contract before the SPEC lands.

## Test plan

- [x] `docs/architecture/knowledge-ingest-flow.md` renders correctly (markdown)
- [x] SPEC-CRAWLER-004 frontmatter parses (status=completed)
- [ ] CI green

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)