### PR TITLE
style(retrieval-api): clear 7 ruff violations in services/search.py

### DIFF
--- a/klai-retrieval-api/retrieval_api/services/search.py
+++ b/klai-retrieval-api/retrieval_api/services/search.py
@@ -11,9 +11,6 @@ import asyncio
 import warnings
 from datetime import UTC, datetime
 
-# Qdrant client warns about API key over HTTP; safe inside Docker network
-warnings.filterwarnings("ignore", message="Api key is used with an insecure connection")
-
 import structlog
 from qdrant_client import AsyncQdrantClient
 from qdrant_client.models import (
@@ -30,6 +27,10 @@ from qdrant_client.models import (
 from retrieval_api.config import settings
 from retrieval_api.models import RetrieveRequest
 from retrieval_api.util.payload import payload_list
+
+# Qdrant client warns at call-time when an api_key is used over plain HTTP;
+# safe inside the Docker network, so silence that specific warning.
+warnings.filterwarnings("ignore", message="Api key is used with an insecure connection")
 
 logger = structlog.get_logger()
 
@@ -140,7 +141,11 @@ async def _search_notebook(
             timeout=5.0,
         )
     except (TimeoutError, Exception) as exc:
-        logger.error("qdrant_search_failed", collection=settings.qdrant_focus_collection, error=str(exc))
+        logger.error(
+            "qdrant_search_failed",
+            collection=settings.qdrant_focus_collection,
+            error=str(exc),
+        )
         raise
 
     return [

--- a/klai-retrieval-api/retrieval_api/services/search.py
+++ b/klai-retrieval-api/retrieval_api/services/search.py
@@ -11,9 +11,6 @@ import asyncio
 import warnings
 from datetime import UTC, datetime
 
-# Qdrant client warns about API key over HTTP; safe inside Docker network
-warnings.filterwarnings("ignore", message="Api key is used with an insecure connection")
-
 import structlog
 from qdrant_client import AsyncQdrantClient
 from qdrant_client.models import (
@@ -30,6 +27,10 @@ from qdrant_client.models import (
 from retrieval_api.config import settings
 from retrieval_api.models import RetrieveRequest
 from retrieval_api.util.payload import payload_list
+
+# Qdrant client warns at call-time when an api_key is used over plain HTTP;
+# safe inside the Docker network, so silence that specific warning.
+warnings.filterwarnings("ignore", message="Api key is used with an insecure connection")
 
 logger = structlog.get_logger()
 
@@ -195,7 +196,8 @@ async def _search_notebook(
         # SPEC-SEC-HYGIENE-001 REQ-43: logger.exception preserves the
         # traceback (TRY400/TRY401); the previous `error=str(exc)` discarded it.
         logger.exception(
-            "qdrant_search_failed", collection=settings.qdrant_focus_collection
+            "qdrant_search_failed",
+            collection=settings.qdrant_focus_collection,
         )
         raise
 


### PR DESCRIPTION
## Summary

Clears the 7 pre-existing ruff violations in `klai-retrieval-api/retrieval_api/services/search.py` so `ruff check` runs clean on that file.

## Changes

| Count | Rule | Fix |
|---|---|---|
| 6 | `E402` | Moved `warnings.filterwarnings(...)` from between the stdlib and third-party import blocks to after all imports. The filter targets a qdrant_client **call-time** warning (`Api key is used with an insecure connection`), not an import-time one, so ordering after imports is safe. |
| 1 | `E501` | Broke the long `logger.error("qdrant_search_failed", ...)` call across multiple lines. |

No behavior change.

## Verification

- `ruff check retrieval_api/services/search.py` → **All checks passed** (was: 7 errors)
- Search/qdrant-scoped tests → **20 passed, 1 pre-existing failure in `test_graph_search`** (unrelated; graphiti/Neo4j, not qdrant)
- Full `klai-retrieval-api` suite → 237 passed, 1 skipped, 7 failed. All 7 failures are **pre-existing on main** (verified by stashing these changes and re-running): `test_tei.py` (4x), `test_api::test_health_all_ok`, `test_auth::test_missing_zitadel_audience_fails_import`, `test_graph_search::test_search_success`.

## Test plan

- [ ] After merge, `ruff check` on retrieval-api reports 7 fewer errors in the repo baseline.

## Notes

- Pyright shows 53 errors on this file, all pre-existing and unrelated to this change (mostly `Payload | None` typing from qdrant_client). Out of scope for a ruff-only chore PR.
- The 7 other test failures in retrieval-api (`test_tei.py`, `test_api`, `test_auth`, `test_graph_search`) are pre-existing on `main` and out of scope.