### PR TITLE
SPEC-KB-MS-DOCS-001: Microsoft 365 connector — SPEC + runbook + R4.4 + tests

### DIFF
--- a/.claude/rules/klai/pitfalls/process-rules.md
+++ b/.claude/rules/klai/pitfalls/process-rules.md
@@ -165,3 +165,36 @@ its file writes land in that worktree, not the main working tree. After the
 agent completes, manually verify that changes exist in the main directory,
 copy them if needed, and prune with `git worktree prune`. Skipping this
 means reviewing and committing an empty diff.
+
+## spec-work-in-a-worktree (HIGH)
+Before making the first edit for any multi-file SPEC implementation, create a
+dedicated git worktree branched from `main`:
+
+```bash
+git worktree add ../klai-<spec-short-name> -b feature/SPEC-<SPEC-ID> main
+```
+
+Then `cd` there and do all work in that worktree — implementation, tests,
+docs, runbooks, everything. Commit inside the worktree. Open the PR from
+that branch.
+
+**Why:** When work spans 10+ files across multiple services (connector +
+portal + frontend + docs), doing it on whatever feature branch happens to
+be checked out is a recipe for the work getting swept into an unrelated
+commit. SPEC-KB-MS-DOCS-001 suffered exactly this: 17 files of MS-365
+connector work landed in commit `726d81a2` titled "fix(knowledge-ingest):
+seed BFS start_url inside path_prefix subtree" because the implementation
+assistant never created a dedicated worktree. Recovering clean history
+after the fact requires rewriting pushed commits, which is rarely worth
+the risk — the mess ships as-is.
+
+**Prevention:**
+- Every new SPEC implementation starts with `git worktree add` as literal
+  step 0. No exceptions, no "I'll clean up later".
+- If you catch yourself editing on the wrong branch, STOP — stash, create
+  the worktree, replay the edits there.
+- Rule-of-thumb trigger: if the SPEC touches more than 3 files, worktree.
+  Below that, a normal feature branch is fine.
+
+See `.claude/rules/moai/workflow/worktree-integration.md` for the decision
+tree and `worktree add` flags.

--- a/.moai/specs/SPEC-KB-MS-DOCS-001/spec.md
+++ b/.moai/specs/SPEC-KB-MS-DOCS-001/spec.md
@@ -1,0 +1,433 @@
+---
+id: SPEC-KB-MS-DOCS-001
+version: "1.1.0"
+status: draft
+created: 2026-04-23
+updated: 2026-04-23
+author: Mark Vletter
+priority: high
+supersedes_partial: SPEC-KB-025 (MS/SharePoint-half; Google Drive-half is geland)
+---
+
+## HISTORY
+
+| Date | Version | Change |
+|------|---------|--------|
+| 2026-04-23 | 1.0.0 | Initial draft — Microsoft SharePoint / OneDrive connector (`ms_docs`) als OAuth-backed adapter. Spiegel van `GoogleDriveAdapter` op Microsoft Graph. `ms_docs` staat al in `ConnectorType` Literal + CHECK-constraint + `SENSITIVE_FIELDS` — alleen adapter + OAuth provider-registratie + frontend-wizard ontbreken. |
+| 2026-04-23 | 1.1.0 | Open vragen beantwoord na owner-review. (1) App-registratie in klai-eigen M365 tenant (zelfde structuur als social login IDP-registratie). (2) Multi-tenant app — bevestigd. (3) **Één `ms_docs` connector-type met UI-label "Office 365"** — geen split van SharePoint/OneDrive als losse tiles; config-veld `site_url` onderscheidt per-site sync van "mijn OneDrive". (4) Refresh-token rotation support is onderdeel van deze SPEC (R2.2 + PortalClient uitbreiding). (5) **`site_url` tekstveld + optionele `drive_id`, geen picker in v1** — conform SPEC-KB-025 design. D2 toegevoegd: erkenning dat SPEC-KB-025 partial superseded wordt. |
+
+---
+
+# SPEC-KB-MS-DOCS-001: Microsoft SharePoint / OneDrive connector
+
+## Summary
+
+Implementatie van de al-in-de-Literal-staande `ms_docs` connector-type als OAuth-backed adapter in `klai-connector`, met bijbehorende OAuth provider-registratie in portal-api en UI-support in portal-frontend. De adapter is een één-op-één spiegel van `GoogleDriveAdapter` op Microsoft Graph v1.0: zelfde `OAuthAdapterBase`, zelfde `BaseAdapter` interface, zelfde delta-cursor patroon, zelfde credential-writeback flow. Alleen de provider-details (token endpoint, scopes, API shape) verschillen.
+
+**Geen** adapter voor Outlook-mail, Teams-messages, of andere M365-bronnen — dit is uitsluitend document-ingest van OneDrive + SharePoint document libraries, analoog aan hoe `GoogleDriveAdapter` alleen Drive-files behandelt.
+
+### Relatie tot SPEC-KB-025
+
+Dit SPEC vervangt de MS/SharePoint-helft van `SPEC-KB-025` ("OAuth Connectors — Google Drive & SharePoint", april 2026). KB-025 is toen in twee fasen geïmplementeerd: de Google Drive-helft is geland (zie `OAuthAdapterBase` + `GoogleDriveAdapter`), de MS-helft niet. Design-keuzes uit KB-025 die in dit SPEC terugkeren: `site_url` als tekstveld, `delta_link` als cursor, `webUrl` als `source_url`, multi-tenant Azure AD app (`tenant_id=common`). KB-025 stelde `MSAL` + `unstructured-ingest[sharepoint]` voor als dependencies — beide expliciet **afgewezen** in dit SPEC (zie D2).
+
+## Motivation
+
+Drie concrete redenen:
+
+1. **Klanten met M365-tenants** (verreweg de grootste groep Nederlandse SMB's) kunnen hun kennis vandaag niet syncen. Google Drive werkt, SharePoint niet. Dat is een harde GTM-blocker voor elke klant wiens primaire tool SharePoint of OneDrive is.
+2. **Scaffolding is al klaar.** `ms_docs` staat in `ConnectorType` Literal, in de `ck_portal_connectors_type` CHECK constraint, in `SENSITIVE_FIELDS`, en in `CONTENT_TYPE_DEFAULTS`. De frontend heeft al een `ms_docs` type-entry met `available: false`. Het is af-bouwen, geen green-field.
+3. **De abstracties zijn al gemaakt.** `OAuthAdapterBase` noemt letterlijk in zijn docstring "used by Google Drive (and, later, SharePoint)" — de refresh-token cache, expiry-skew, lock, en writeback-naar-portal zijn adapter-agnostisch.
+
+De opportunity-kost om dit niet te doen: elke inbound-klant met een M365-tenant moet "eerst hun kennis naar Google Drive verhuizen" of afhaken.
+
+## Scope
+
+**In scope:**
+- `MsDocsAdapter` in `klai-connector/app/adapters/ms_docs.py` als subclass van `OAuthAdapterBase` + `BaseAdapter`
+- Microsoft Graph OAuth-provider in `klai-portal/backend/app/api/oauth.py` (`_SUPPORTED_PROVIDERS`, authorize + callback)
+- Conditionele registratie in `klai-connector/app/main.py` bij ontbrekende credentials
+- Portal-frontend wizard-step voor `ms_docs`: `available: true` + OAuth-connect button + optionele `site_url` / `drive_id` config
+- Settings: `ms_docs_client_id` + `ms_docs_client_secret` + `ms_docs_tenant_id` (default `common` voor multi-tenant)
+- Azure AD app-registratie als runbook, niet als code (`docs/runbooks/ms-docs-oauth.md`)
+- Unit + integration tests ≥ 85% coverage met gemockte Graph responses (httpx.MockTransport)
+- `sender_email` + `mentioned_emails[]` identifier-capture conform `SPEC-KB-CONNECTORS-001` R2.5
+
+**Buiten scope (toekomstig werk):**
+- **Outlook / Exchange Online mail** — past bij `SPEC-KB-EMAIL-001` pipeline
+- **Teams messages** — communicatie-kanaal, niet knowledge-bron
+- **Application permissions / app-only OAuth flow** — v1 gebruikt delegated (per-user OAuth)
+- **User-facing connector-type split** (`ms_onedrive`, `ms_sharepoint` als losse entries) — wacht op `AdapterRegistry.register_alias` uit `SPEC-KB-CONNECTORS-001`
+- **Real-time sync via Graph webhooks**
+- **SharePoint Pages (aspx / modern pages)** — alleen DriveItems in v1
+- **SharePoint list items als knowledge** — alleen files in document libraries
+- **PDF-conversie van legacy Office-formaten** (.doc, .xls, .ppt, .rtf)
+
+**Niet in scope (expliciet afgewezen):**
+- **`msgraph-sdk`** of **`MSAL`** als dependencies (zie D2)
+- **`unstructured-ingest[sharepoint]`** (SPEC-KB-025 voorstel, afgewezen in D2)
+
+---
+
+## Design Decisions
+
+### D1: Mirror `GoogleDriveAdapter` exact — niet creatief zijn
+
+De `MsDocsAdapter` volgt `GoogleDriveAdapter` methode-voor-methode:
+
+| `GoogleDriveAdapter` | `MsDocsAdapter` | Graph endpoint |
+|---|---|---|
+| `_refresh_oauth_token` via `https://oauth2.googleapis.com/token` | idem via `https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token` | OAuth 2.0 refresh_token grant |
+| `_list_files` → `files.list` | `_drain_delta` → `/drives/{id}/root/delta` | Drive listing |
+| `_list_changes` → `changes.list?pageToken=...` | incremental via persisted `@odata.deltaLink` | Delta |
+| `_fetch_start_page_token` (bootstrap) | `get_cursor_state` bootstrap via delta-call | Delta bootstrap |
+| `_download_file` (`alt=media`) | `_graph_get_bytes` (`/drive/items/{id}/content`) | Binary download |
+| `_export_file` (Google-native → DOCX/XLSX/PPTX) | **n.v.t.** — Office-files zijn al in Office format | — |
+| `get_cursor_state` → `{"page_token": ...}` | `get_cursor_state` → `{"delta_link": ...}` | Persist exact deltaLink URL |
+
+### D2: Direct `httpx` — geen `msgraph-sdk`, geen `MSAL`, geen `unstructured-ingest[sharepoint]`
+
+Drie kandidaten voor provider-SDK, alle drie afgewezen:
+
+| Aanpak | Voordeel | Waarom afgewezen |
+|---|---|---|
+| `msgraph-sdk` (Kiota-based, async-first, MS-aanbevolen) | Type-safe voor alle Graph-endpoints | Grote dep (100+ transitieve imports via Kiota runtime), andere test-ergonomie dan `GoogleDriveAdapter`, overkill voor 6 endpoints |
+| `MSAL` (Microsoft Authentication Library) voor token acquisition + `httpx` voor Graph calls | MS-canonical auth library; sync, wrap via `asyncio.to_thread` | `oauth.py` doet Google-tokens al via directe `/oauth2/token` POST zonder SDK. MSAL voor MS maar niet voor Google is inconsistent. **SPEC-KB-025 stelde MSAL voor; we wijken bewust af.** |
+| `unstructured-ingest[sharepoint]` voor discovery + download | Gratis lib voor 71+ connectors | Conflicts met onze ingest-pipeline (eigen parsing via knowledge-ingest). Non-additive om te introduceren. **SPEC-KB-025 stelde dit voor; we wijken bewust af.** |
+| **Direct `httpx` calls** | 1:1 patroon met `GoogleDriveAdapter`, trivial te mocken met `httpx.MockTransport`, geen extra deps | Zelf paginatie + 429-retry schrijven — maar klein en voorspelbaar |
+
+**Gekozen: direct `httpx`.** Pattern-consistentie met werkende Google Drive adapter weegt zwaarder dan SDK type-safety.
+
+Noot: wijkt bewust af van `SPEC-KB-CONNECTORS-001` R2 ("officiële SDK's zijn verplicht"). Die regel geldt voor Airtable/Confluence/Google-split.
+
+### D3: Delegated permissions, multi-tenant Azure AD app in klai-eigen M365 tenant
+
+OAuth 2.0 authorization code flow met delegated scopes:
+```
+offline_access
+User.Read
+Files.Read.All
+Sites.Read.All
+```
+
+**App-registratie eigenaar:** Klai-team M365 tenant, zelfde structuur als `ZITADEL_IDP_MICROSOFT_ID` (social login). Credentials SOPS-versleuteld.
+
+**Multi-tenant:** `tenant_id = common` — elke M365-tenant van een klant kan connecten.
+
+**Admin-consent:** `Files.Read.All` en `Sites.Read.All` vereisen tenant-wide admin-consent in de meeste klant-tenants. UX-risico: gewone medewerker kan niet zelf activeren zonder IT-admin van klant. Gedocumenteerd in wizard-copy en runbook.
+
+**App-only flow buiten scope v1** — wordt v2 als delegated te hoge drempel blijkt.
+
+### D4: Één connector-type "Office 365", filter via config
+
+Eén `ms_docs` connector-type met UI-label **"Office 365"**. Geen split van SharePoint/OneDrive als losse tiles. Filtering via config:
+
+| Config-veld | Betekenis | Graph-endpoint |
+|---|---|---|
+| (beide leeg) | "Mijn OneDrive" — persoonlijke OneDrive | `/me/drive/root/delta` |
+| `site_url` (optional) | Specifieke SharePoint site | `/sites/{hostname}:/{path}:/drive/root/delta` |
+| `drive_id` (optional) | Specifieke Drive-GUID | `/drives/{drive_id}/root/delta` |
+
+Resolutie-volgorde: `drive_id` > `site_url` > `/me/drive`.
+
+### D5: `site_url` tekstveld, geen site-picker in v1
+
+De wizard vraagt om een `site_url` tekstveld (format `https://{tenant}.sharepoint.com/sites/{site}`) — geen picker.
+
+**Waarom geen picker:** kip/ei probleem — picker vereist Graph-calls vóór de OAuth-flow rond is. Copy/paste van een URL uit de browser is triviaal.
+
+**Server-side resolutie** van `site_url` naar Graph-site-object via `GET /sites/{hostname}:/{path}` → response.id, gecached per connector.
+
+### D6: Delta-sync via `driveItem: delta` — één call, niet per-item
+
+Graph's `/drives/{id}/root/delta` retourneert alle wijzigingen (add/update/delete) in één call, gepaginaliseerd via `@odata.nextLink`, afsluitend met `@odata.deltaLink` voor volgende run.
+
+**Persistentie:** de exacte deltaLink URL opgeslagen als cursor — geen param-reconstructie.
+
+**410 Gone handling:** bij expired deltaLink (>30d inactief) → cursor reset → full re-sync volgende run.
+
+### D7: Office-binaries direct doorzetten, geen PDF-conversie in v1
+
+`.docx`/`.xlsx`/`.pptx`/`.pdf` → `fetch_document` doet `GET /drive/items/{id}/content` → bytes. Geen conversie, geen `?format=pdf`, geen export-mime-mapping. Legacy formats (`.doc`, etc.) gewoon downloaden; conversie pas toevoegen als knowledge-ingest er in productie op faalt.
+
+### D8: `source_url` is `webUrl` uit de DriveItem response
+
+`DocumentRef.source_url = driveItem.webUrl` — klikbaar, user-visible, geauthoriseerd in klant-browser via hun M365-sessie.
+
+### D9: Identifier capture — `sender_email` uit DriveItem's `createdBy`/`lastModifiedBy`
+
+- `sender_email = driveItem.lastModifiedBy.user.email` (fallback `createdBy.user.email`)
+- `mentioned_emails[] = {createdBy.email, lastModifiedBy.email}` gededupliceerd, lege strings eruit
+
+### D10: `FRONTEND_URL` is het redirect-URI anchor
+
+Azure AD app-registratie moet `https://my.getklai.com/api/oauth/ms_docs/callback` als toegestane redirect-URI hebben. Bij domain-wijziging moet Azure AD mee — staat in runbook.
+
+---
+
+## Requirements
+
+### Module 1: Portal OAuth-provider registratie
+
+**R1:** `klai-portal/backend/app/api/oauth.py` voegt `"ms_docs"` toe aan `_SUPPORTED_PROVIDERS`.
+
+**R1.1:** `_provider_enabled("ms_docs")` retourneert `True` wanneer `settings.ms_docs_client_id` niet-leeg is.
+
+**R1.2:** `GET /api/oauth/ms_docs/authorize` zet een signed state-cookie en retourneert een `authorize_url` naar `https://login.microsoftonline.com/{tenant}/oauth2/v2.0/authorize` met:
+- `scope = "offline_access User.Read Files.Read.All Sites.Read.All"`
+- `response_type = code`, `response_mode = query`, `prompt = consent`
+- `redirect_uri = {FRONTEND_URL}/api/oauth/ms_docs/callback`
+
+**R1.3:** `GET /api/oauth/ms_docs/callback` verifieert state, wisselt `code` in op `https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token`, encrypt tokens via `ConnectorCredentialStore`, redirect naar `/app/knowledge/{kb_slug}/connectors?oauth=connected`.
+
+**R1.4:** Tokens worden nooit gelogd (alleen status codes + connector_id).
+
+**R1.5:** `GET /api/oauth/providers` retourneert `ms_docs: {enabled, scopes}`.
+
+### Module 2: klai-connector adapter implementatie
+
+**R2:** `klai-connector/app/adapters/ms_docs.py` bevat een `MsDocsAdapter(OAuthAdapterBase, BaseAdapter)`.
+
+**R2.1:** `_refresh_oauth_token` roept `login.microsoftonline.com/{tenant}/oauth2/v2.0/token` aan met `grant_type=refresh_token` en retourneert raw JSON.
+
+**R2.2:** Wanneer de response een nieuwe `refresh_token` bevat, wordt die via `portal_client.update_credentials(refresh_token=...)` teruggeschreven. Vereist PortalClient uitbreiding (Module 9).
+
+**R2.3:** `list_documents` delta-root-URL resolutie:
+1. `config.drive_id` → `/drives/{drive_id}/root/delta`
+2. `config.site_url` → eerst `GET /sites/{hostname}:/{path}` → `/sites/{site-id}/drive/root/delta`
+3. Beide leeg → `/me/drive/root/delta`
+
+**R2.4:** `list_documents` persisteert `@odata.deltaLink` in `_latest_delta_link[connector_id]`.
+
+**R2.5:** Elke `DocumentRef` bevat:
+- `source_ref = driveItem.id`
+- `source_url = driveItem.webUrl`
+- `last_edited = driveItem.lastModifiedDateTime`
+- `content_type` gemapped via R2.6
+- `size = driveItem.size`
+
+**R2.6:** MIME → `content_type` mapping:
+- `application/vnd.openxmlformats-officedocument.wordprocessingml.document` → `word_document`
+- `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` → `excel_document`
+- `application/vnd.openxmlformats-officedocument.presentationml.presentation` → `powerpoint_document`
+- `application/pdf` → `pdf_document`
+- overige → `kb_article`
+
+**R2.7:** `fetch_document` roept `GET /drive/items/{ref.ref}/content` aan met Bearer-header, volgt 302-redirects naar preauthenticated URLs.
+
+**R2.8:** `get_cursor_state` retourneert `{"delta_link": <url>}` uit `_latest_delta_link`, of bootstrap via enkele delta-call.
+
+**R2.9:** `aclose()` no-op.
+
+**R2.10:** `sender_email` en `mentioned_emails[]` gevuld conform D9.
+
+**R2.11:** 429/503 response → één retry met `Retry-After` header (cap 30s); tweede failure propageert.
+
+**R2.12:** Nooit access_token / refresh_token / Bearer headers loggen.
+
+### Module 3: klai-connector registratie
+
+**R3:** `main.py` registreert `MsDocsAdapter` in `AdapterRegistry` onder key `"ms_docs"`, conditioneel op `settings.ms_docs_client_id`.
+
+**R3.1:** Bij ontbrekende `ms_docs_client_id` logt `main.py` een `warning` zonder te crashen.
+
+### Module 4: Portal-frontend wizard
+
+**R4:** `add-connector.tsx` zet `ms_docs` op `available: true`, label "Office 365", icon `FileText` (fallback voor MS-icon).
+
+**R4.1:** Wizard volgt voor `ms_docs` dezelfde OAuth-dans als `google_drive` (create connector → fetch authorize_url → redirect).
+
+**R4.2:** Optionele config-velden:
+- `site_url` — placeholder `https://contoso.sharepoint.com/sites/marketing`, helper-text "laat leeg voor persoonlijke OneDrive"
+- `drive_id` — advanced, helper-link naar Graph Explorer
+
+**R4.3:** Client-side `site_url` validatie via regex `^https://[a-z0-9-]+\.sharepoint\.com/sites/[^/]+/?$`.
+
+**R4.4:** Edit-connector pagina toont "Opnieuw verbinden" knop voor verlopen refresh_tokens.
+
+**R4.5:** Alle i18n-strings via Paraglide (`admin_connectors_ms_docs_*` en `admin_connectors_type_ms_docs = "Office 365"`) in NL + EN.
+
+### Module 5: Configuratie
+
+**R5:** Portal `config.py` krijgt:
+- `ms_docs_client_id: str = ""`
+- `ms_docs_client_secret: str = ""`
+- `ms_docs_tenant_id: str = "common"`
+
+**R5.1:** Connector `config.py` idem.
+
+**R5.2:** `deploy/docker-compose.yml` mount `MS_DOCS_CLIENT_ID`, `MS_DOCS_CLIENT_SECRET`, `MS_DOCS_TENANT_ID` op `portal-api` + `klai-connector`.
+
+**R5.3:** `klai-infra/core-01/.env.sops` bevat versleutelde waarden na Azure AD app-registratie.
+
+### Module 6: Azure AD registratie — runbook
+
+**R6:** `docs/runbooks/ms-docs-oauth.md` documenteert stap-voor-stap:
+1. App registrations → New (multi-tenant)
+2. Redirect URI: `https://my.getklai.com/api/oauth/ms_docs/callback`
+3. Delegated permissions: `offline_access`, `User.Read`, `Files.Read.All`, `Sites.Read.All`
+4. Client secret → SOPS
+5. Grant tenant-wide admin consent voor dev-tenant
+6. Verify via `/oauth2/v2.0/authorize` curl
+
+### Module 7: Tests
+
+**R7:** `tests/adapters/test_ms_docs.py` coverage ≥ 85%.
+
+**R7.1:** Tests via `httpx.MockTransport` + `pytest-asyncio` + `unittest.mock.patch`.
+
+**R7.2:** Verplichte scenarios: first-sync, incremental-sync, paginatie, token-refresh, refresh-rotation (R9), 429 retry, content-download, MIME mapping, `drive_id`/`site_url` varianten.
+
+**R7.3:** `tests/test_oauth_routes.py` krijgt `ms_docs` variant parallel aan `google_drive`.
+
+**R7.4:** Integration test runt volledige sync-flow via `AdapterRegistry` met mocked Graph responses.
+
+### Module 8: Quality & Observability
+
+**R8:** `ruff check` + `pyright` clean op alle nieuwe bestanden.
+
+**R8.1:** `@MX:ANCHOR` + `@MX:REASON` op methoden met `fan_in >= 3`.
+
+**R8.2:** Structured logs met `connector_id`, `org_id`, `item_count`, `duration_ms`, `status_code` — nooit tokens of bodies.
+
+**R8.3:** Cross-service trace-test via `request_id:<uuid>` in VictoriaLogs.
+
+### Module 9: Refresh-token rotation support (PortalClient uitbreiding)
+
+**R9:** `PortalClient.update_credentials` krijgt optionele `refresh_token: str | None = None` parameter:
+```python
+async def update_credentials(
+    self,
+    connector_id: str,
+    access_token: str,
+    token_expiry: str | None = None,
+    refresh_token: str | None = None,
+) -> None
+```
+
+**R9.1:** `PATCH /internal/connectors/{id}/credentials` accepteert optioneel `refresh_token` in de JSON body.
+
+**R9.2:** `OAuthAdapterBase.ensure_token` parsed nieuwe `refresh_token` uit refresh-response; indien aanwezig én verschillend van input → writeback via `update_credentials(refresh_token=...)` + in-memory mutatie van `connector.config["refresh_token"]`.
+
+**R9.3:** Tests dekken beide paden: (a) geen rotatie → RT writeback skipped, (b) rotatie → beide tokens versleuteld opgeslagen.
+
+**R9.4:** Additief en backward-compatible — Google Drive blijft werken.
+
+---
+
+## Architecture — samenvatting
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ portal-frontend: /app/knowledge/{kb}/add-connector               │
+│   Office 365 tile (was: ms_docs available:false → true)          │
+│     ↓ "Connect with Microsoft"                                   │
+│     POST /api/connectors (with optional site_url / drive_id)     │
+│     GET  /api/oauth/ms_docs/authorize?kb_slug=&connector_id=     │
+│     → navigate to login.microsoftonline.com                      │
+└──────────────────────────┬───────────────────────────────────────┘
+                           │ consent
+                           ▼
+┌──────────────────────────────────────────────────────────────────┐
+│ portal-api: /api/oauth/ms_docs/callback                          │
+│   verify state cookie → exchange code → encrypt tokens           │
+│   via ConnectorCredentialStore (SPEC-KB-020)                     │
+│   → redirect /app/knowledge/{kb}/connectors?oauth=connected      │
+└──────────────────────────┬───────────────────────────────────────┘
+                           │ scheduled sync
+                           ▼
+┌──────────────────────────────────────────────────────────────────┐
+│ klai-connector: MsDocsAdapter (extends OAuthAdapterBase)         │
+│   ensure_token → Graph token endpoint (refresh if expired)       │
+│     ↑ rotates refresh_token if Microsoft issues a new one (R9)   │
+│   list_documents → /drive/root/delta (or /sites/{id}/ or         │
+│                    /drives/{id}/) + paginate                     │
+│   fetch_document → GET /drive/items/{id}/content                 │
+│   get_cursor_state → {"delta_link": <url>}                       │
+│                                                                   │
+│ Chunk metadata:                                                  │
+│   source_ref = item.id                                           │
+│   source_url = item.webUrl                                       │
+│   last_edited = item.lastModifiedDateTime                        │
+│   sender_email = item.lastModifiedBy.user.email                  │
+│   mentioned_emails = [createdBy.email, lastModifiedBy.email]     │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Verification
+
+1. **Adapter:**
+   - `pytest klai-connector/tests/adapters/test_ms_docs.py -v --cov=app.adapters.ms_docs` → coverage ≥ 85%
+   - `uv run ruff check klai-connector/app/adapters/ms_docs.py` → clean
+   - `uv run --with pyright pyright klai-connector/app/adapters/ms_docs.py` → clean
+
+2. **Portal OAuth routes:**
+   - `pytest klai-portal/backend/tests/test_oauth_routes.py -v -k ms_docs` → alle cases groen
+
+3. **End-to-end (staging, na Azure AD app-registratie):**
+   - Configureer ms_docs connector in portal → OAuth redirect → consent → connected
+   - Trigger sync → VictoriaLogs `service:klai-connector AND connector_type:ms_docs` toont item counts
+   - Qdrant: chunks hebben `source_url` met `webUrl` en `sender_email` gevuld
+   - Chat-citatie klikt door naar SharePoint/OneDrive web-view
+
+4. **Incremental sync:**
+   - Na eerste sync: `connector.sync_runs.cursor_state` bevat `{"delta_link": "https://graph.microsoft.com/..."}`
+   - Bewerk één document → volgende sync ingesereert alleen dat document
+
+5. **Credential safety:**
+   - `grep -r "Bearer\|access_token\|refresh_token" klai-connector/app/adapters/ms_docs.py` — alleen metadata-logs
+   - Encrypted-at-rest: `SELECT config FROM portal_connectors WHERE connector_type='ms_docs'` toont `***`
+
+6. **Token refresh + rotation:**
+   - Handmatig `connector.config.token_expiry` op verleden zetten → sync → log `Refreshing OAuth token (provider=MsDocsAdapter)` → sync completes
+   - Na tweede refresh: verifieer in `portal_connectors` dat `encrypted_credentials` is gewijzigd (new refresh_token opgeslagen)
+
+---
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Admin-consent vereist voor `Files.Read.All` / `Sites.Read.All` — gewone gebruiker kan connector niet zelf activeren | High | High | Documenteer in wizard-copy en runbook. Na eerste tenant-wide consent werkt elke user in die tenant. |
+| Graph rate-limits bij grote SharePoint-tenants | Medium | Medium | R2.11 implementeert retry met `Retry-After`. v2: checkpointing binnen een run. |
+| deltaLink expiry (>30d inactief) → 410 Gone | Low | Medium | Catch 410 → reset `cursor_state` → volgende run doet full re-sync. |
+| Refresh-token rotation — oude RT invalid na grace window | High | High | R9 verplicht writeback van nieuwe RT. `update_credentials` uitgebreid met optionele parameter. |
+| `site_url` invoer UX — user plakt verkeerde URL (document i.p.v. site-root) | Medium | Low | R4.3 client-side regex validatie + server-side 404 via Graph resolutie-call. |
+| Wijking van `SPEC-KB-CONNECTORS-001` R2 (SDK verplicht) + `SPEC-KB-025` (MSAL + unstructured-ingest) naar direct httpx | N/A | N/A | Expliciet gedocumenteerd in D2. Consistentie met `GoogleDriveAdapter` + minimale deps. |
+| Azure AD app-registratie blokkeert bij ontbrekende DPIA/AVG-review voor `Files.Read.All` | Low | High | Pre-flight in test-tenant. Runbook documenteert. |
+| `site_url` → `site_id` resolutie 403 (admin-consent ontbreekt) | Medium | Medium | Catch 403 specifiek → helder error-message in portal-frontend. |
+| PortalClient API-signature wijziging (R9) breekt bestaande tests | Low | Low | Optionele parameter met `None` default — bestaande call-sites blijven werken. |
+
+---
+
+## Open vragen
+
+Alle open vragen uit v1.0.0 beantwoord in v1.1.0 na owner-review:
+
+1. ~~**App-registratie eigenaar.**~~ ✅ Klai-team M365 tenant, zelfde structuur als `ZITADEL_IDP_MICROSOFT_ID`. Credentials klai-team-beheerd, SOPS-versleuteld. Zie D3.
+2. ~~**Multi-tenant vs single-tenant.**~~ ✅ Multi-tenant (`tenant_id=common`).
+3. ~~**Naming in UI.**~~ ✅ Eén tile, label **"Office 365"**. Consistent met Google Drive als één tile. Zie D4.
+4. ~~**Refresh-token rotation.**~~ ✅ Onderdeel van dit SPEC — Module 9 (R9 t/m R9.4). Additief, backward-compatible, baat ook Google Drive.
+5. ~~**Site-picker vs tekstveld.**~~ ✅ Tekstveld met `site_url` + optionele `drive_id`. Geen picker in v1. Server-side resolutie via `/sites/{hostname}:/{path}`. Zie D5.
+
+---
+
+## Referenties
+
+### Klai intern
+- [SPEC-KB-025](../../docs/specs/SPEC-KB-025.md) — OAuth adapter framework (`OAuthAdapterBase`), partial predecessor
+- [SPEC-KB-020](../SPEC-KB-020/spec.md) — Connector credential encryption (`ConnectorCredentialStore`)
+- [SPEC-KB-CONNECTORS-001](../SPEC-KB-CONNECTORS-001/spec.md) — Standaard connectors framework
+- [SPEC-AUTH-001](../../docs/specs/SPEC-AUTH-001.md) — Social signup flow (reference)
+- [docs/runbooks/ms-docs-oauth.md](../../docs/runbooks/ms-docs-oauth.md) — Azure AD app-registratie runbook
+
+### Microsoft documentatie
+- [Microsoft Graph permissions reference](https://learn.microsoft.com/en-us/graph/permissions-reference)
+- [Overview of permissions and consent](https://learn.microsoft.com/en-us/entra/identity-platform/permissions-consent-overview)
+- [driveItem: delta](https://learn.microsoft.com/en-us/graph/api/driveitem-delta?view=graph-rest-1.0)
+- [Use delta query to track changes](https://learn.microsoft.com/en-us/graph/delta-query-overview)
+- [Best practices for discovering files at scale](https://learn.microsoft.com/en-us/onedrive/developer/rest-api/concepts/scan-guidance?view=odsp-graph-online)
+- [Get access on behalf of a user (OAuth 2.0)](https://learn.microsoft.com/en-us/graph/auth-v2-user)
+- [Refresh tokens in Microsoft identity platform](https://learn.microsoft.com/en-us/entra/identity-platform/refresh-tokens)
+- [msgraph-sdk-python](https://github.com/microsoftgraph/msgraph-sdk-python) — overwogen en afgewezen in D2

--- a/docs/runbooks/ms-docs-oauth.md
+++ b/docs/runbooks/ms-docs-oauth.md
@@ -1,0 +1,163 @@
+# Runbook: Microsoft 365 OAuth — app registration & rotation
+
+> Setup and operational runbook for the `ms_docs` connector (SPEC-KB-MS-DOCS-001).
+> Covers Azure AD app registration, SOPS secret provisioning, verification and rotation.
+
+## Ownership
+
+The Azure AD app is registered in the **Klai-owned M365 tenant** (same ownership
+model as `ZITADEL_IDP_MICROSOFT_ID` for social login). Klai team manages
+credentials; klai customers grant tenant-wide admin-consent once when they
+enable the connector.
+
+**Credentials (SOPS):**
+- `MS_DOCS_CLIENT_ID` — Application (client) ID from the Azure portal
+- `MS_DOCS_CLIENT_SECRET` — Client secret value (not secret ID)
+- `MS_DOCS_TENANT_ID` — `common` (multi-tenant; do not change without a SPEC)
+
+## First-time app registration (Klai-owned tenant)
+
+Prereq: signed in to [portal.azure.com](https://portal.azure.com) as an admin
+of the Klai M365 tenant.
+
+### 1. Create the App registration
+
+1. **Entra ID → App registrations → New registration**
+2. **Name**: `Klai Knowledge — Office 365 Connector`
+3. **Supported account types**: **Accounts in any organizational directory (Any Microsoft Entra ID tenant — Multitenant)**
+4. **Redirect URI**:
+   - Type: **Web**
+   - URI: `https://my.getklai.com/api/oauth/ms_docs/callback`
+5. Click **Register**. Copy the **Application (client) ID** — this is `MS_DOCS_CLIENT_ID`.
+
+### 2. Add API permissions (delegated, not application)
+
+**API permissions → Add a permission → Microsoft Graph → Delegated permissions**, add:
+
+- `offline_access` — required for refresh_token
+- `User.Read` — identity (populates `sender_email`)
+- `Files.Read.All` — OneDrive + SharePoint files the user can access
+- `Sites.Read.All` — SharePoint site enumeration / site-URL resolution
+
+Do **not** add any `Application` permissions — we use delegated-only (see D3 in the SPEC).
+
+**Grant admin consent for Klai tenant** (for dev/test). Customers will grant
+consent for their own tenants the first time their admin clicks "Connect Office 365".
+
+### 3. Create a client secret
+
+**Certificates & secrets → Client secrets → New client secret**
+
+- Description: `Klai connector (rotated YYYY-MM)`
+- Expires: **6 months** (see Rotation below)
+
+Copy the **Value** immediately — this is `MS_DOCS_CLIENT_SECRET`. The portal
+only shows this once.
+
+### 4. Publisher verification (optional, recommended)
+
+If you want to ship out of beta: complete [publisher verification](https://learn.microsoft.com/en-us/entra/identity-platform/publisher-verification-overview)
+in the tenant. Unverified apps trigger a warning banner during user consent.
+
+## SOPS provisioning
+
+Add the three values to the core-01 encrypted env file:
+
+```bash
+cd klai-infra/core-01
+sops -d .env.sops > .env.decrypted
+# Append / update:
+#   MS_DOCS_CLIENT_ID=<application-client-id>
+#   MS_DOCS_CLIENT_SECRET=<client-secret-value>
+#   MS_DOCS_TENANT_ID=common
+sops -e .env.decrypted > .env.sops.new && mv .env.sops.new .env.sops
+rm .env.decrypted
+git diff .env.sops   # verify only the ciphertext blocks changed
+git add .env.sops && git commit -m "chore(infra): add MS_DOCS_* for SPEC-KB-MS-DOCS-001"
+git push
+```
+
+GitHub Action auto-syncs to `/opt/klai/.env`. Verify after sync:
+
+```bash
+ssh core-01 "sudo grep '^MS_DOCS_' /opt/klai/.env | sed 's/=.*/=***/'"
+# Expected: MS_DOCS_CLIENT_ID=*** / MS_DOCS_CLIENT_SECRET=*** / MS_DOCS_TENANT_ID=***
+```
+
+## Container rollout
+
+```bash
+ssh core-01 "cd /opt/klai && docker compose up -d portal-api klai-connector"
+# Wait ~10s, then verify:
+ssh core-01 "docker logs --tail 30 klai-core-portal-api-1 2>&1 | grep -i ms_docs || true"
+ssh core-01 "docker logs --tail 30 klai-core-klai-connector-1 2>&1 | grep -i ms_docs"
+# Connector should log either: "ms_docs adapter registered" (implicit)
+# or: "ms_docs adapter not registered — MS_DOCS_CLIENT_ID unset" (if env didn't propagate)
+```
+
+If the warning fires, check `docker compose config klai-connector | grep MS_DOCS_` —
+the env var must reach the container.
+
+## End-to-end verification
+
+1. Log in to [my.getklai.com](https://my.getklai.com) as a user in the Klai tenant.
+2. Go to a knowledge base → **Add connector** → **Office 365**.
+3. Leave `SharePoint site URL` empty (personal OneDrive), click **Connect with Microsoft**.
+4. Complete the Microsoft consent page. On first use per-tenant an admin must
+   click through tenant-wide consent once.
+5. Back in the portal: status becomes **Connected**.
+6. Trigger sync → check VictoriaLogs:
+   ```
+   service:klai-connector AND connector_type:ms_docs
+   ```
+   Expect `Listing MS drive items` entries with positive `item_count`, no
+   bearer tokens in the output.
+7. In Qdrant, verify a chunk has `source_url` starting with
+   `https://{tenant}.sharepoint.com/` and non-empty `sender_email`.
+8. Edit a document in OneDrive → wait for the next scheduled sync → only that
+   document should be re-ingested (incremental delta). Verify via
+   `connector.sync_runs.cursor_state`:
+   ```sql
+   SELECT cursor_state FROM connector.sync_runs
+   WHERE connector_id = '<uuid>' ORDER BY created_at DESC LIMIT 2;
+   ```
+   Two different `delta_link` values.
+
+## Rotation
+
+Microsoft client-secret has configurable expiry. Rotate **every 6 months** even
+if not expired, per `runbooks/credential-rotation.md` cadence.
+
+```
+1. Azure Portal → Certificates & secrets → New client secret
+2. Copy the new Value
+3. Update SOPS: MS_DOCS_CLIENT_SECRET=<new-value>
+4. Push; GitHub Action syncs /opt/klai/.env
+5. ssh core-01 "docker compose up -d portal-api klai-connector"
+6. Verify via end-to-end step 6 — new bearer tokens flowing
+7. Delete the OLD secret in Azure AD (Certificates & secrets → Delete)
+```
+
+**Refresh-token rotation** is handled automatically by
+[`OAuthAdapterBase.ensure_token`](../../klai-connector/app/adapters/oauth_base.py):
+Microsoft rotates refresh_tokens on each refresh; the adapter writebacks the new
+one to portal via `PortalClient.update_credentials(refresh_token=...)` (SPEC R9).
+No operator action needed for RT rotation — only client-secret rotation.
+
+## Common issues
+
+| Symptom | Likely cause | Action |
+|---|---|---|
+| `Connect Office 365` button missing in wizard | `MS_DOCS_CLIENT_ID` unset | Verify via `docker exec portal-api printenv MS_DOCS_CLIENT_ID` |
+| 403 on `/sites/{host}:/{path}` resolution | Admin consent missing for `Sites.Read.All` | Ask customer admin to grant tenant-wide consent once |
+| 404 on site resolution | User typed wrong site URL | Surface clean error in portal; no fix needed server-side |
+| 410 Gone on delta call | deltaLink expired (rare, > 30d inactive) | Adapter handles this — catches 410 and resets cursor to trigger full re-sync next run |
+| Sync returns 401 after weeks of working | Refresh token got invalidated (user changed password, revoked consent) | User clicks "Reconnect Microsoft" on the edit-connector page |
+
+## References
+
+- [SPEC-KB-MS-DOCS-001](../../.moai/specs/SPEC-KB-MS-DOCS-001/spec.md)
+- [Microsoft Graph permissions reference](https://learn.microsoft.com/en-us/graph/permissions-reference)
+- [driveItem: delta](https://learn.microsoft.com/en-us/graph/api/driveitem-delta)
+- [Refresh tokens in Microsoft identity platform](https://learn.microsoft.com/en-us/entra/identity-platform/refresh-tokens)
+- Klai runbooks: [credential-rotation.md](./credential-rotation.md), [platform-recovery.md](./platform-recovery.md)

--- a/klai-connector/app/adapters/ms_docs.py
+++ b/klai-connector/app/adapters/ms_docs.py
@@ -158,7 +158,11 @@ class MsDocsAdapter(OAuthAdapterBase, BaseAdapter):
             response = await client.post(token_url, data=payload)
             response.raise_for_status()
             data = response.json()
-        return data if isinstance(data, dict) else {}
+        if not isinstance(data, dict):
+            return {}
+        # data is a genuinely untyped JSON dict; the caller treats keys as Any.
+        result: dict[str, Any] = dict(data)  # pyright: ignore[reportUnknownArgumentType]
+        return result
 
     # -- BaseAdapter interface ------------------------------------------------
 
@@ -413,7 +417,11 @@ class MsDocsAdapter(OAuthAdapterBase, BaseAdapter):
                 response = await client.get(url, headers=headers)
             response.raise_for_status()
             data = response.json()
-        return data if isinstance(data, dict) else {}
+        if not isinstance(data, dict):
+            return {}
+        # data is a genuinely untyped JSON dict; the caller treats keys as Any.
+        result: dict[str, Any] = dict(data)  # pyright: ignore[reportUnknownArgumentType]
+        return result
 
     async def _graph_get_bytes(
         self, url: str, connector: Any | None = None,

--- a/klai-connector/app/adapters/oauth_base.py
+++ b/klai-connector/app/adapters/oauth_base.py
@@ -28,7 +28,7 @@ import asyncio
 import time
 from abc import ABC, abstractmethod
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import Any, cast
 
 from app.core.config import Settings
 from app.core.logging import get_logger
@@ -113,7 +113,9 @@ class OAuthAdapterBase(ABC):
             if cached is not None and cached[1] - now > _EXPIRY_SKEW_SECONDS:
                 return cached[0]
 
-            refresh_token = (connector.config or {}).get("refresh_token", "")
+            current_config: dict[str, Any] = connector.config or {}
+            refresh_token_value = current_config.get("refresh_token", "")
+            refresh_token: str = refresh_token_value if isinstance(refresh_token_value, str) else ""
             if not refresh_token:
                 raise ValueError(
                     "OAuth connector missing refresh_token — reconnect required "
@@ -146,14 +148,16 @@ class OAuthAdapterBase(ABC):
             # is invalidated after a grace window. We must (a) writeback the
             # new one so it survives restart, and (b) mutate connector.config
             # so subsequent refreshes within the same process use the new RT.
-            rotated_refresh_token: str | None = payload.get("refresh_token")
+            rotated_raw = payload.get("refresh_token")
+            rotated_refresh_token: str | None = rotated_raw if isinstance(rotated_raw, str) else None
             if rotated_refresh_token is not None and rotated_refresh_token == refresh_token:
                 # Provider echoed the same RT — treat as no-rotation.
                 rotated_refresh_token = None
             if rotated_refresh_token:
                 if connector.config is None:
                     connector.config = {}
-                connector.config["refresh_token"] = rotated_refresh_token
+                # connector.config is typed Any at the ABC boundary; cast narrows for the write.
+                cast("dict[str, Any]", connector.config)["refresh_token"] = rotated_refresh_token  # pyright: ignore[reportUnknownMemberType]
 
             token_expiry = (datetime.now(UTC) + timedelta(seconds=expires_in)).isoformat()
             try:

--- a/klai-connector/tests/test_integration_ms_docs.py
+++ b/klai-connector/tests/test_integration_ms_docs.py
@@ -1,0 +1,277 @@
+"""End-to-end integration test for MsDocsAdapter via AdapterRegistry.
+
+SPEC-KB-MS-DOCS-001 — verifies that a connector registered under the
+``ms_docs`` key produces the right DocumentRef shape, adapter-owned
+metadata, and cursor state on a full list → fetch → cursor roundtrip
+against mocked Microsoft Graph responses.
+
+Distinct from ``tests/adapters/test_ms_docs.py`` which unit-tests the
+adapter in isolation. This test exercises the registration path used
+by ``main.py``.
+"""
+
+# ruff: noqa: S106  -- test-only placeholder token strings
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.adapters.base import DocumentRef
+from app.adapters.ms_docs import MsDocsAdapter
+from app.adapters.registry import AdapterRegistry
+
+
+@pytest.fixture
+def settings() -> MagicMock:
+    s = MagicMock()
+    s.ms_docs_client_id = "placeholder-client-id"
+    s.ms_docs_client_secret = "placeholder-client-secret"
+    s.ms_docs_tenant_id = "common"
+    return s
+
+
+@pytest.fixture
+def portal_client() -> MagicMock:
+    pc = MagicMock()
+    pc.update_credentials = AsyncMock()
+    return pc
+
+
+@pytest.fixture
+def registry_with_ms_docs(
+    settings: MagicMock, portal_client: MagicMock,
+) -> tuple[AdapterRegistry, MsDocsAdapter]:
+    """AdapterRegistry with ms_docs registered exactly as main.py does it."""
+    registry = AdapterRegistry()
+    adapter = MsDocsAdapter(settings=settings, portal_client=portal_client)
+    registry.register("ms_docs", adapter)
+    # Seed token cache so tests don't hit HTTP
+    adapter._cache_token("msdocs-integration", "placeholder-access-value", expires_in_seconds=3600.0)
+    return registry, adapter
+
+
+def _make_connector(config: dict[str, Any] | None = None) -> SimpleNamespace:
+    cfg: dict[str, Any] = {
+        "access_token": "placeholder-access-value",
+        "refresh_token": "placeholder-refresh-value",
+    }
+    if config:
+        cfg.update(config)
+    return SimpleNamespace(id="msdocs-integration", org_id="org-integration", config=cfg)
+
+
+@pytest.mark.asyncio
+async def test_registry_returns_ms_docs_adapter_for_connector_type(
+    registry_with_ms_docs: tuple[AdapterRegistry, MsDocsAdapter],
+) -> None:
+    """registry.get("ms_docs") returns the registered MsDocsAdapter instance."""
+    registry, adapter = registry_with_ms_docs
+
+    result = registry.get("ms_docs")
+
+    assert result is adapter
+    assert isinstance(result, MsDocsAdapter)
+
+
+@pytest.mark.asyncio
+async def test_full_sync_roundtrip_produces_document_refs_with_metadata(
+    registry_with_ms_docs: tuple[AdapterRegistry, MsDocsAdapter],
+) -> None:
+    """Full list → fetch → cursor flow via the registry.
+
+    Verifies the sync-engine contract end-to-end:
+      1. registry.get("ms_docs").list_documents(connector) returns DocumentRefs
+      2. Each DocumentRef carries source_url, source_ref, last_edited from Graph
+      3. adapter._get_metadata_for_ref surfaces sender_email + mentioned_emails
+      4. fetch_document returns the binary content
+      5. get_cursor_state returns a delta_link suitable for the next run
+    """
+    registry, adapter = registry_with_ms_docs
+    connector = _make_connector()
+
+    # Mock Graph responses:
+    # - list_documents: one delta response with two items + deltaLink
+    # - fetch_document: content bytes
+    delta_response = {
+        "value": [
+            {
+                "id": "item-docx-1",
+                "name": "Q2 Report.docx",
+                "webUrl": "https://contoso.sharepoint.com/personal/alice/Documents/Q2%20Report.docx",
+                "size": 45678,
+                "lastModifiedDateTime": "2026-04-20T10:00:00Z",
+                "file": {"mimeType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"},
+                "createdBy": {"user": {"email": "alice@contoso.com"}},
+                "lastModifiedBy": {"user": {"email": "bob@contoso.com"}},
+            },
+            {
+                "id": "item-pdf-1",
+                "name": "Policy.pdf",
+                "webUrl": "https://contoso.sharepoint.com/personal/alice/Documents/Policy.pdf",
+                "size": 123456,
+                "lastModifiedDateTime": "2026-04-19T14:30:00Z",
+                "file": {"mimeType": "application/pdf"},
+                "createdBy": {"user": {"email": "carol@contoso.com"}},
+                "lastModifiedBy": {"user": {"email": "carol@contoso.com"}},
+            },
+        ],
+        "@odata.deltaLink": "https://graph.microsoft.com/v1.0/me/drive/root/delta?token=final-cursor",
+    }
+
+    async def fake_get_json(url: str, connector: Any = None) -> dict[str, Any]:
+        return delta_response
+
+    async def fake_get_bytes(url: str, connector: Any = None) -> bytes:
+        assert "/drive/items/item-docx-1/content" in url
+        return b"FAKE_DOCX_CONTENT"
+
+    with (
+        patch.object(adapter, "_graph_get_json", side_effect=fake_get_json),
+        patch.object(adapter, "_graph_get_bytes", side_effect=fake_get_bytes),
+    ):
+        # 1. Resolve adapter via registry
+        resolved_adapter = registry.get("ms_docs")
+
+        # 2. List documents
+        refs = await resolved_adapter.list_documents(connector, cursor_context=None)
+        assert len(refs) == 2
+        assert all(isinstance(r, DocumentRef) for r in refs)
+
+        docx_ref = next(r for r in refs if r.ref == "item-docx-1")
+        pdf_ref = next(r for r in refs if r.ref == "item-pdf-1")
+
+        # DocumentRef contract (R2.5, R2.6)
+        assert docx_ref.content_type == "word_document"
+        assert docx_ref.source_url == "https://contoso.sharepoint.com/personal/alice/Documents/Q2%20Report.docx"
+        assert docx_ref.source_ref == "item-docx-1"
+        assert docx_ref.last_edited == "2026-04-20T10:00:00Z"
+        assert docx_ref.size == 45678
+        assert pdf_ref.content_type == "pdf_document"
+
+        # 3. Adapter-owned metadata (R2.10 identifier capture)
+        # Cast so pyright knows we have the MsDocsAdapter methods.
+        assert isinstance(resolved_adapter, MsDocsAdapter)
+        docx_meta = resolved_adapter._get_metadata_for_ref(docx_ref)
+        assert docx_meta["sender_email"] == "bob@contoso.com"
+        assert set(docx_meta["mentioned_emails"]) == {"alice@contoso.com", "bob@contoso.com"}
+
+        pdf_meta = resolved_adapter._get_metadata_for_ref(pdf_ref)
+        assert pdf_meta["sender_email"] == "carol@contoso.com"
+        # createdBy and lastModifiedBy are the same → single entry after dedup
+        assert pdf_meta["mentioned_emails"] == ["carol@contoso.com"]
+
+        # 4. Fetch document content
+        content = await resolved_adapter.fetch_document(docx_ref, connector)
+        assert content == b"FAKE_DOCX_CONTENT"
+
+        # 5. Cursor state after list ready for next run
+        cursor = await resolved_adapter.get_cursor_state(connector)
+        assert cursor == {"delta_link": "https://graph.microsoft.com/v1.0/me/drive/root/delta?token=final-cursor"}
+
+
+@pytest.mark.asyncio
+async def test_incremental_sync_uses_persisted_delta_link(
+    registry_with_ms_docs: tuple[AdapterRegistry, MsDocsAdapter],
+) -> None:
+    """Second sync reads cursor from get_cursor_state and calls that URL verbatim."""
+    registry, adapter = registry_with_ms_docs
+    connector = _make_connector()
+
+    stored_cursor = "https://graph.microsoft.com/v1.0/me/drive/root/delta?token=stored"
+    new_cursor = "https://graph.microsoft.com/v1.0/me/drive/root/delta?token=new"
+
+    incremental_response = {
+        "value": [
+            {
+                "id": "item-changed",
+                "name": "Updated.xlsx",
+                "webUrl": "https://contoso.sharepoint.com/personal/alice/Documents/Updated.xlsx",
+                "size": 9999,
+                "lastModifiedDateTime": "2026-04-21T09:00:00Z",
+                "file": {"mimeType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"},
+                "createdBy": {"user": {"email": "alice@contoso.com"}},
+                "lastModifiedBy": {"user": {"email": "alice@contoso.com"}},
+            },
+        ],
+        "@odata.deltaLink": new_cursor,
+    }
+    call_urls: list[str] = []
+
+    async def fake_get_json(url: str, connector: Any = None) -> dict[str, Any]:
+        call_urls.append(url)
+        return incremental_response
+
+    with patch.object(adapter, "_graph_get_json", side_effect=fake_get_json):
+        resolved = registry.get("ms_docs")
+        assert isinstance(resolved, MsDocsAdapter)
+        refs = await resolved.list_documents(
+            connector, cursor_context={"delta_link": stored_cursor}
+        )
+
+    # The persisted delta_link is called verbatim, no reconstruction
+    assert call_urls == [stored_cursor]
+    assert len(refs) == 1
+    assert refs[0].content_type == "excel_document"
+    # New cursor is persisted for next run
+    assert adapter._latest_delta_link["msdocs-integration"] == new_cursor
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_rotation_propagates_through_portal_client(
+    settings: MagicMock, portal_client: MagicMock,
+) -> None:
+    """SPEC-KB-MS-DOCS-001 R9.2: rotated refresh_token flows from adapter → portal_client.
+
+    This exercises the OAuthAdapterBase path via the concrete MsDocsAdapter.
+    """
+    adapter = MsDocsAdapter(settings=settings, portal_client=portal_client)
+    registry = AdapterRegistry()
+    registry.register("ms_docs", adapter)
+
+    connector = _make_connector()
+
+    # Mock the raw token-endpoint call inside _refresh_oauth_token
+    token_response = MagicMock()
+    token_response.json = MagicMock(
+        return_value={
+            "access_token": "placeholder-new-access",
+            "expires_in": 3600,
+            "refresh_token": "placeholder-rotated-refresh",
+        }
+    )
+    token_response.raise_for_status = MagicMock(return_value=None)
+
+    http_client = MagicMock()
+    http_client.post = AsyncMock(return_value=token_response)
+    http_client.__aenter__ = AsyncMock(return_value=http_client)
+    http_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("app.adapters.ms_docs.httpx.AsyncClient", MagicMock(return_value=http_client)):
+        # First ensure_token triggers refresh (cache is empty → hits token endpoint)
+        resolved = registry.get("ms_docs")
+        assert isinstance(resolved, MsDocsAdapter)
+        access_token = await resolved.ensure_token(connector)
+
+    # Adapter returns the new access_token
+    assert access_token == "placeholder-new-access"
+    # Portal writeback includes the rotated refresh_token (R9)
+    portal_client.update_credentials.assert_awaited_once()
+    kwargs = portal_client.update_credentials.await_args.kwargs
+    assert kwargs["access_token"] == "placeholder-new-access"
+    assert kwargs["refresh_token"] == "placeholder-rotated-refresh"
+    # connector.config is mutated in-memory so subsequent refreshes use the new RT
+    assert connector.config["refresh_token"] == "placeholder-rotated-refresh"
+
+
+@pytest.mark.asyncio
+async def test_registry_aclose_closes_ms_docs_adapter(
+    registry_with_ms_docs: tuple[AdapterRegistry, MsDocsAdapter],
+) -> None:
+    """Registry shutdown calls aclose on the MsDocsAdapter (no exception)."""
+    registry, _adapter = registry_with_ms_docs
+    # MsDocsAdapter.aclose is a no-op but must be callable
+    await registry.aclose()

--- a/klai-portal/frontend/messages/en.json
+++ b/klai-portal/frontend/messages/en.json
@@ -1086,7 +1086,7 @@
   "admin_connectors_ms_docs_reconnect": "Reconnect Microsoft",
   "admin_connectors_ms_docs_site_url": "SharePoint site URL (optional)",
   "admin_connectors_ms_docs_site_url_help": "Leave empty to sync your personal OneDrive. Example: https://contoso.sharepoint.com/sites/marketing",
-  "admin_connectors_ms_docs_site_url_invalid": "Invalid SharePoint site URL. Expected: https://{tenant}.sharepoint.com/sites/{site}",
+  "admin_connectors_ms_docs_site_url_invalid": "Invalid SharePoint site URL. Expected format: https://<tenant>.sharepoint.com/sites/<site>",
   "admin_connectors_ms_docs_drive_id": "Specific Drive ID (advanced)",
   "admin_connectors_ms_docs_drive_id_help": "Only set if you want to target a specific Drive GUID (from Microsoft Graph Explorer).",
   "admin_connectors_ms_docs_oauth_success": "Office 365 connected successfully.",

--- a/klai-portal/frontend/messages/nl.json
+++ b/klai-portal/frontend/messages/nl.json
@@ -1086,7 +1086,7 @@
   "admin_connectors_ms_docs_reconnect": "Microsoft opnieuw verbinden",
   "admin_connectors_ms_docs_site_url": "SharePoint site-URL (optioneel)",
   "admin_connectors_ms_docs_site_url_help": "Laat leeg om je persoonlijke OneDrive te syncen. Voorbeeld: https://contoso.sharepoint.com/sites/marketing",
-  "admin_connectors_ms_docs_site_url_invalid": "Ongeldige SharePoint site-URL. Verwacht: https://{tenant}.sharepoint.com/sites/{site}",
+  "admin_connectors_ms_docs_site_url_invalid": "Ongeldige SharePoint site-URL. Verwacht formaat: https://<tenant>.sharepoint.com/sites/<site>",
   "admin_connectors_ms_docs_drive_id": "Specifiek Drive ID (geavanceerd)",
   "admin_connectors_ms_docs_drive_id_help": "Alleen invullen als je een specifieke Drive-GUID wilt gebruiken (uit Microsoft Graph Explorer).",
   "admin_connectors_ms_docs_oauth_success": "Office 365 succesvol verbonden.",

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
@@ -79,6 +79,10 @@ function EditConnectorPage() {
   })
   const [folderId, setFolderId] = useState('')
   const [isReconnecting, setIsReconnecting] = useState(false)
+  // ms_docs (SPEC-KB-MS-DOCS-001 R4.4): optional site_url + drive_id
+  const [msSiteUrl, setMsSiteUrl] = useState('')
+  const [msDriveId, setMsDriveId] = useState('')
+  const [msSiteUrlError, setMsSiteUrlError] = useState<string | null>(null)
 
   // Web crawler preview state
   const [showAdvancedSelector, setShowAdvancedSelector] = useState(false)
@@ -99,6 +103,20 @@ function EditConnectorPage() {
       setIsReconnecting(false)
     }
   }
+
+  // SPEC-KB-MS-DOCS-001 R4.4 — trigger a fresh OAuth flow when refresh_token is invalid.
+  async function handleMsDocsReconnect() {
+    setIsReconnecting(true)
+    try {
+      const { authorize_url } = await apiFetch<{ authorize_url: string }>(`/api/oauth/ms_docs/authorize?kb_slug=${encodeURIComponent(kbSlug)}&connector_id=${encodeURIComponent(connectorId)}`, )
+      window.location.href = authorize_url
+    } finally {
+      setIsReconnecting(false)
+    }
+  }
+
+  // Keep in sync with add-connector.tsx MS_SITE_URL_PATTERN.
+  const MS_SITE_URL_PATTERN = /^https:\/\/[a-z0-9-]+\.sharepoint\.com\/sites\/[^/]+\/?$/
 
   function parseCookies(): unknown[] | undefined {
     const raw = wcCookies.trim()
@@ -154,6 +172,12 @@ function EditConnectorPage() {
       const cfg = connector.config as { folder_id?: string }
       setFolderId(cfg.folder_id ?? '')
     }
+    if (connector.connector_type === 'ms_docs') {
+      const cfg = connector.config as { site_url?: string; drive_id?: string }
+      setMsSiteUrl(cfg.site_url ?? '')
+      setMsDriveId(cfg.drive_id ?? '')
+      setMsSiteUrlError(null)
+    }
   }, [connector?.id]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const updateMutation = useMutation({
@@ -189,6 +213,16 @@ function EditConnectorPage() {
       }
       if (connector.connector_type === 'google_drive') {
         if (folderId.trim()) config.folder_id = folderId.trim()
+      }
+      if (connector.connector_type === 'ms_docs') {
+        const siteUrl = msSiteUrl.trim()
+        if (siteUrl && !MS_SITE_URL_PATTERN.test(siteUrl)) {
+          setMsSiteUrlError(m.admin_connectors_ms_docs_site_url_invalid())
+          throw new Error('invalid_site_url')
+        }
+        setMsSiteUrlError(null)
+        if (siteUrl) config.site_url = siteUrl
+        if (msDriveId.trim()) config.drive_id = msDriveId.trim()
       }
       await apiFetch(`/api/app/knowledge-bases/${kbSlug}/connectors/${connectorId}`, {
         method: 'PATCH',
@@ -577,8 +611,53 @@ function EditConnectorPage() {
             </form>
           )}
 
+          {/* Microsoft 365 (SPEC-KB-MS-DOCS-001 R4.4) */}
+          {connector?.connector_type === 'ms_docs' && (
+            <form onSubmit={(e) => { e.preventDefault(); updateMutation.mutate() }} className="space-y-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="edit-conn-name">{m.admin_connectors_field_name()}</Label>
+                <Input id="edit-conn-name" required value={name} onChange={(e) => setName(e.target.value)} />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="edit-ms-site-url">{m.admin_connectors_ms_docs_site_url()}</Label>
+                <Input
+                  id="edit-ms-site-url"
+                  placeholder="https://contoso.sharepoint.com/sites/marketing"
+                  value={msSiteUrl}
+                  onChange={(e) => { setMsSiteUrl(e.target.value); setMsSiteUrlError(null) }}
+                />
+                <p className="text-xs text-[var(--color-muted-foreground)]">{m.admin_connectors_ms_docs_site_url_help()}</p>
+                {msSiteUrlError && (
+                  <p className="text-xs text-[var(--color-destructive)]">{msSiteUrlError}</p>
+                )}
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="edit-ms-drive-id">{m.admin_connectors_ms_docs_drive_id()}</Label>
+                <Input id="edit-ms-drive-id" placeholder="b!xyz..." value={msDriveId} onChange={(e) => setMsDriveId(e.target.value)} />
+                <p className="text-xs text-[var(--color-muted-foreground)]">{m.admin_connectors_ms_docs_drive_id_help()}</p>
+              </div>
+              <div className="space-y-1.5">
+                <Label>{m.admin_connectors_assertion_modes_label()}</Label>
+                <MultiSelect options={ASSERTION_MODE_OPTIONS} value={allowedAssertionModes} onChange={setAllowedAssertionModes} placeholder={m.admin_connectors_assertion_modes_placeholder()} />
+              </div>
+              {renderError()}
+              <div className="flex gap-2 pt-2">
+                <Button type="submit" size="sm" disabled={updateMutation.isPending}>{m.admin_connectors_save()}</Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  disabled={isReconnecting}
+                  onClick={() => { void handleMsDocsReconnect() }}
+                >
+                  {m.admin_connectors_ms_docs_reconnect()}
+                </Button>
+              </div>
+            </form>
+          )}
+
           {/* Generic fallback for unsupported connector types */}
-          {connector && !['web_crawler', 'github', 'notion', 'google_drive'].includes(connector.connector_type) && (
+          {connector && !['web_crawler', 'github', 'notion', 'google_drive', 'ms_docs'].includes(connector.connector_type) && (
             <form onSubmit={(e) => { e.preventDefault(); updateMutation.mutate() }} className="space-y-3">
               <div className="space-y-1.5">
                 <Label htmlFor="edit-conn-name">{m.admin_connectors_field_name()}</Label>


### PR DESCRIPTION
## Summary

Finalizes SPEC-KB-MS-DOCS-001 (Microsoft SharePoint / OneDrive connector). The
adapter implementation + tests + frontend wizard + OAuth routes already shipped
to main via commit 726d81a2 (mislabeled as a knowledge-ingest fix — see retro
entry in process-rules.md). This PR adds the missing paper trail + finishing
work.

## Changes

- **\`5319870f docs\`** — SPEC-KB-MS-DOCS-001 v1.1.0 document + Azure AD app registration runbook (\`docs/runbooks/ms-docs-oauth.md\`)
- **\`7b634cfa feat\`** — R4.4 edit-connector UI: site_url/drive_id form fields + "Reconnect Microsoft" button (was missing — add-connector path shipped, edit-connector path did not)
- **\`abb3e542 chore\`** — Pyright cleanup (0 errors, was 6) + worktree-discipline retro entry so this SPEC-in-unrelated-commit disaster doesn't repeat
- **\`313881eb test\`** — Phase 9 integration test via AdapterRegistry: 5 tests covering full list → fetch → cursor → rotation roundtrip
- **\`cf33710a fix\`** — i18n: escape \`{tenant}\` / \`{site}\` Paraglide placeholders in the site-URL validation message (broke \`npm run build\`)

## Test plan

- [x] 31/31 connector unit tests pass (adapters/test_ms_docs.py, test_oauth_base.py, services/test_portal_client_writeback.py, adapters/test_google_drive.py — no regression)
- [x] 15/15 portal oauth route tests pass (including 4 new TestMsDocsProvider cases + 2 R9 rotation writeback tests)
- [x] 5/5 integration tests via AdapterRegistry (test_integration_ms_docs.py)
- [x] Coverage 88% on ms_docs.py (target 85%)
- [x] \`ruff check\` clean on all modified files
- [x] \`pyright\` 0 errors on ms_docs.py + oauth_base.py + portal_client.py
- [x] \`npm run build\` clean — production bundle contains "Office 365" + "Connect with Microsoft" + sharepoint.com regex + site_url config

## Operational

**Blocked on Azure AD app registration** (follows this PR). Until then the
provider is inert — \`ms_docs_client_id = ""\` → \`_provider_enabled("ms_docs")\`
returns False → wizard tile stays clickable but authorize returns 404. No
breakage risk.

Next steps after merge:
1. Azure AD app registration in Klai M365 tenant (see \`docs/runbooks/ms-docs-oauth.md\` §1)
2. SOPS populate \`MS_DOCS_CLIENT_ID\` / \`MS_DOCS_CLIENT_SECRET\` / \`MS_DOCS_TENANT_ID\`
3. \`docker compose up -d portal-api klai-connector\` on core-01
4. End-to-end smoketest

🤖 Generated with [Claude Code](https://claude.com/claude-code)