### PR TITLE
fix(portal-api): rollback before RLS context reset to prevent pool leak

### DIFF
--- a/klai-portal/backend/app/core/database.py
+++ b/klai-portal/backend/app/core/database.py
@@ -32,13 +32,32 @@ async def _pin_and_reset_on_exit(session: AsyncSession) -> None:
 
 
 async def _reset_tenant_context(session: AsyncSession) -> None:
-    """Clear app.current_org_id on the session's connection.
+    """Clear app.current_org_id and app.cross_org_admin on the session's connection.
 
     Called before the connection returns to the pool so the next request /
     task that picks it up starts with a clean RLS context.
+
+    Rolls back FIRST. If the session is in an aborted-transaction state (e.g.
+    after a 42501 RLS failure from the fail-loud policy), PostgreSQL rejects
+    every subsequent command with "current transaction is aborted" — including
+    our set_config reset. Without the rollback the suppressed exception path
+    would silently leave the leftover tenant context on the pooled connection,
+    and the next request picking up that connection would see it and silently
+    filter rows by the wrong tenant.
+
+    Both GUCs are reset so this helper can be shared between get_db(),
+    tenant_scoped_session() and cross_org_session() without duplicating the
+    pool-leak guard.
     """
+    # Step 1: clear any aborted-transaction state so set_config can run.
+    with contextlib.suppress(Exception):
+        await session.rollback()
+    # Step 2: clear both RLS GUCs. Each in its own suppress so one failure
+    # does not skip the other.
     with contextlib.suppress(Exception):
         await session.execute(text("SELECT set_config('app.current_org_id', '', false)"))
+    with contextlib.suppress(Exception):
+        await session.execute(text("SELECT set_config('app.cross_org_admin', '', false)"))
 
 
 async def get_db() -> AsyncGenerator[AsyncSession]:
@@ -161,6 +180,8 @@ async def cross_org_session() -> AsyncIterator[AsyncSession]:
         try:
             yield session
         finally:
-            with contextlib.suppress(Exception):
-                await session.execute(text("SELECT set_config('app.cross_org_admin', '', false)"))
+            # _reset_tenant_context rolls back first, then clears BOTH
+            # app.current_org_id and app.cross_org_admin in suppressed blocks —
+            # so the pool cannot inherit the cross-org bypass flag from a
+            # session that aborted before reaching this finally.
             await _reset_tenant_context(session)

--- a/klai-portal/backend/tests/test_rls_guards.py
+++ b/klai-portal/backend/tests/test_rls_guards.py
@@ -48,14 +48,18 @@ async def test_tenant_scoped_session_pins_before_set_tenant(monkeypatch):
         async def connection(self):
             calls.append("pin")
 
+        async def rollback(self):
+            calls.append("rollback")
+
         async def execute(self, stmt, params=None):
             sql = str(stmt)
             if "set_config" in sql:
-                # distinguish set vs reset by the bound value
                 if params and params.get("org_id") == "42":
                     calls.append("set_tenant:42")
-                else:
-                    calls.append("reset_tenant")
+                elif "current_org_id" in sql:
+                    calls.append("reset_current_org_id")
+                elif "cross_org_admin" in sql:
+                    calls.append("reset_cross_org_admin")
             return SimpleNamespace(rowcount=-1)
 
         async def __aenter__(self):
@@ -70,8 +74,20 @@ async def test_tenant_scoped_session_pins_before_set_tenant(monkeypatch):
         assert session is not None
         calls.append("yield")
 
-    # The critical invariant: pin happens before set_tenant, reset happens on exit.
-    assert calls == ["pin", "set_tenant:42", "yield", "reset_tenant"]
+    # Critical invariants:
+    #   1. pin happens before set_tenant (set_config must see pinned connection)
+    #   2. on exit, rollback runs BEFORE set_config resets — otherwise an aborted
+    #      transaction from a 42501 RLS fail-loud would trap the reset and leak
+    #      app.current_org_id to the next pooled request (2026-04-23 incident).
+    #   3. both GUCs are cleared on exit.
+    assert calls == [
+        "pin",
+        "set_tenant:42",
+        "yield",
+        "rollback",
+        "reset_current_org_id",
+        "reset_cross_org_admin",
+    ]
 
 
 @pytest.mark.asyncio
@@ -83,10 +99,18 @@ async def test_tenant_scoped_session_resets_on_exception(monkeypatch):
         async def connection(self):
             calls.append("pin")
 
+        async def rollback(self):
+            calls.append("rollback")
+
         async def execute(self, stmt, params=None):
             sql = str(stmt)
             if "set_config" in sql:
-                calls.append("set" if params and params.get("org_id") == "7" else "reset")
+                if params and params.get("org_id") == "7":
+                    calls.append("set")
+                elif "current_org_id" in sql:
+                    calls.append("reset_current_org_id")
+                elif "cross_org_admin" in sql:
+                    calls.append("reset_cross_org_admin")
             return SimpleNamespace(rowcount=-1)
 
         async def __aenter__(self):
@@ -101,7 +125,8 @@ async def test_tenant_scoped_session_resets_on_exception(monkeypatch):
         async with db_module.tenant_scoped_session(7):
             raise RuntimeError("boom")
 
-    assert calls == ["pin", "set", "reset"]
+    # Even on exception: rollback runs, then both GUCs are cleared.
+    assert calls == ["pin", "set", "rollback", "reset_current_org_id", "reset_cross_org_admin"]
 
 
 # ---------------------------------------------------------------------------
@@ -137,6 +162,9 @@ async def test_cross_org_session_sets_and_resets_bypass_flag(monkeypatch):
         async def connection(self):
             calls.append("pin")
 
+        async def rollback(self):
+            calls.append("rollback")
+
         async def execute(self, stmt, params=None):
             sql = str(stmt)
             if "set_config" in sql and "cross_org_admin" in sql:
@@ -157,7 +185,12 @@ async def test_cross_org_session_sets_and_resets_bypass_flag(monkeypatch):
         assert session is not None
         calls.append("yield")
 
-    assert calls == ["pin", "bypass_on", "yield", "bypass_off", "tenant_reset"]
+    # After the 2026-04-23 pool-leak fix, cleanup delegates to
+    # _reset_tenant_context which rolls back first, then clears both GUCs
+    # (current_org_id before cross_org_admin). An aborted transaction from
+    # a 42501 inside the cross-org body would otherwise leak the bypass
+    # flag to the next pooled request.
+    assert calls == ["pin", "bypass_on", "yield", "rollback", "tenant_reset", "bypass_off"]
 
 
 @pytest.mark.asyncio

--- a/klai-portal/backend/tests/test_tenant_context_reset.py
+++ b/klai-portal/backend/tests/test_tenant_context_reset.py
@@ -1,0 +1,190 @@
+"""Regression tests for the tenant-context reset pool-leak fix (2026-04-23).
+
+Symptom that led to this test:
+  - Apr 22: `post_deploy_rls_raise_on_missing_context.sql` flipped portal_users-
+    adjacent RLS policies to fail-loud (raise 42501 instead of silent filter).
+  - Apr 23: admin login landed on `/no-account` and `/app/chat` inception.
+
+Root cause:
+  Any request that ran `set_tenant(org_X)` and then hit a 42501 RLS error left
+  the SQLAlchemy transaction in aborted state. The old
+  `_reset_tenant_context` ran `SELECT set_config(...)` on the aborted session —
+  PostgreSQL rejects every command on an aborted transaction — so the reset
+  silently failed via `suppress(Exception)`. The connection returned to the
+  pool with `app.current_org_id='X'` still set. The next request (e.g. the
+  admin's BFF callback or `/api/me`) picked up that connection, queried
+  `portal_users`, and RLS filtered out the admin's row because their org did
+  not match `X`. Result: `org_found=false`, `workspace_url=null`, wrong
+  redirect.
+
+The fix: `_reset_tenant_context` MUST roll back first so subsequent
+`set_config` statements can run on a clean session. It also now clears BOTH
+GUCs (`app.current_org_id` and `app.cross_org_admin`) so `cross_org_session`
+cannot leak its bypass flag via the same aborted-transaction path.
+
+These tests lock the ordering and the GUC coverage. They do not exercise
+PostgreSQL itself — that lives in `scripts/rls-smoke-test.sql` / the
+`rls-policy-smoke-test` CI job.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.core import database as db_module
+
+
+def _fake_session() -> AsyncMock:
+    session = AsyncMock()
+    session.rollback = AsyncMock()
+    session.execute = AsyncMock()
+    return session
+
+
+# ---------------------------------------------------------------------------
+# _reset_tenant_context — ordering and GUC coverage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reset_rolls_back_before_set_config() -> None:
+    """rollback() MUST fire before the first set_config.
+
+    If set_config runs first on an aborted session it raises
+    ``InFailedSqlTransactionError`` and the suppress swallows it — the pool
+    leaks the leftover tenant GUC to the next request.
+    """
+    calls: list[str] = []
+    session = _fake_session()
+
+    async def tracked_rollback() -> None:
+        calls.append("rollback")
+
+    async def tracked_execute(stmt: object, *args: object, **kwargs: object) -> object:
+        # Record the set_config target rather than the whole text clause.
+        text_str = str(stmt)
+        if "app.current_org_id" in text_str:
+            calls.append("reset_current_org_id")
+        elif "app.cross_org_admin" in text_str:
+            calls.append("reset_cross_org_admin")
+        else:
+            calls.append(f"unexpected:{text_str}")
+        return MagicMock()
+
+    session.rollback = AsyncMock(side_effect=tracked_rollback)
+    session.execute = AsyncMock(side_effect=tracked_execute)
+
+    await db_module._reset_tenant_context(session)
+
+    assert calls[0] == "rollback", f"rollback must run first, got {calls}"
+    assert "reset_current_org_id" in calls, calls
+    assert "reset_cross_org_admin" in calls, calls
+
+
+@pytest.mark.asyncio
+async def test_reset_clears_both_rls_gucs() -> None:
+    """Both current_org_id AND cross_org_admin must be cleared.
+
+    Without this `cross_org_session` could leak the bypass flag to the next
+    request — same class of bug but worse because the bypass makes the
+    connection see ALL tenants' rows.
+    """
+    session = _fake_session()
+
+    await db_module._reset_tenant_context(session)
+
+    # rollback + 2 set_config calls
+    assert session.rollback.await_count == 1
+    assert session.execute.await_count == 2
+
+    rendered = [str(c.args[0]) for c in session.execute.await_args_list]
+    assert any("app.current_org_id" in s for s in rendered), rendered
+    assert any("app.cross_org_admin" in s for s in rendered), rendered
+
+
+@pytest.mark.asyncio
+async def test_reset_swallows_rollback_failure_and_still_tries_to_clear() -> None:
+    """A raised rollback (closed session) must not skip the set_config attempts.
+
+    Defense-in-depth: even if rollback itself fails we still try to clear
+    the GUCs. If those also fail the suppress lets the connection return to
+    the pool — the next request will either hit a live GUC (and fail safely)
+    or a recycled connection from pool_pre_ping.
+    """
+    session = _fake_session()
+    session.rollback = AsyncMock(side_effect=RuntimeError("session already closed"))
+
+    # Should not raise.
+    await db_module._reset_tenant_context(session)
+
+    # Still attempted both GUC resets.
+    assert session.execute.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_reset_swallows_set_config_failure_on_first_guc() -> None:
+    """A failure clearing current_org_id must not skip clearing cross_org_admin.
+
+    Each set_config is wrapped in its own suppress block for exactly this.
+    """
+    session = _fake_session()
+
+    call_counter = {"n": 0}
+
+    async def execute_side_effect(*_args: object, **_kwargs: object) -> object:
+        call_counter["n"] += 1
+        if call_counter["n"] == 1:
+            raise RuntimeError("set_config failed on current_org_id")
+        return MagicMock()
+
+    session.execute = AsyncMock(side_effect=execute_side_effect)
+
+    await db_module._reset_tenant_context(session)
+
+    # Both set_config calls attempted despite the first one raising.
+    assert session.execute.await_count == 2
+
+
+# ---------------------------------------------------------------------------
+# cross_org_session — no more double-reset of app.cross_org_admin
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cross_org_session_delegates_reset_to_shared_helper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The cross_org_session finally block must use `_reset_tenant_context`.
+
+    Before the fix it had its own standalone
+    `set_config('app.cross_org_admin', '', false)` wrapped in suppress —
+    same aborted-transaction trap. Now the shared helper handles it.
+    """
+    fake_session = AsyncMock()
+    fake_session.rollback = AsyncMock()
+    fake_session.execute = AsyncMock(return_value=MagicMock())
+    fake_session.connection = AsyncMock()
+
+    class FakeSessionCM:
+        async def __aenter__(self) -> AsyncMock:
+            return fake_session
+
+        async def __aexit__(self, *_args: object) -> None:
+            pass
+
+    monkeypatch.setattr(db_module, "AsyncSessionLocal", lambda: FakeSessionCM())
+
+    reset_calls: list[AsyncMock] = []
+
+    async def fake_reset(session: AsyncMock) -> None:
+        reset_calls.append(session)
+
+    monkeypatch.setattr(db_module, "_reset_tenant_context", fake_reset)
+
+    async with db_module.cross_org_session() as db:
+        assert db is fake_session
+
+    assert len(reset_calls) == 1, "Shared reset helper must run exactly once"
+    assert reset_calls[0] is fake_session


### PR DESCRIPTION
## Summary

- Admin login landed on `/no-account` (or `chat-my.getklai.com` inception) starting Apr 23, 2026.
- Root cause: pooled DB connections leaked `app.current_org_id` after a 42501 RLS error aborted the SQLAlchemy transaction. `_reset_tenant_context` tried to `SELECT set_config(...)` on the aborted session — Postgres rejected it, `suppress(Exception)` swallowed the failure, and the GUC stayed set when the connection returned to the pool.
- Fix: `_reset_tenant_context` now rolls back FIRST (own `suppress` block), then clears both `app.current_org_id` and `app.cross_org_admin`. `cross_org_session` delegates its finally to the shared helper.

See commit message for full chain + reproduction.

## Test plan

- [x] `tests/test_tenant_context_reset.py` — 5 new cases locking rollback-first ordering, dual-GUC coverage, and suppress isolation between the two `set_config` calls.
- [x] `tests/test_rls_guards.py` — 3 existing tests updated to assert the new safer cleanup ordering with inline incident reference.
- [x] `uv run pytest tests/test_tenant_context_reset.py tests/test_rls_guards.py` — 25/25 pass.
- [x] `uv run ruff check` on modified files — clean.
- [ ] CI green on this PR.
- [ ] Post-merge: admin login (admin@getklai.com) lands on `getklai.getklai.com/app` with `org_found=true` and `workspace_url` populated in `/api/me`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)