### PR TITLE
fix(templates): 500 on PATCH/POST — re-apply tenant GUC before post-commit refresh

### DIFF
--- a/klai-portal/backend/app/api/app_templates.py
+++ b/klai-portal/backend/app/api/app_templates.py
@@ -30,7 +30,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.dependencies import _get_caller_org, bearer
-from app.core.database import get_db
+from app.core.database import get_db, set_tenant
 from app.models.templates import PortalTemplate
 from app.services.default_templates import ensure_default_templates
 from app.services.litellm_cache import invalidate_templates
@@ -213,13 +213,18 @@ async def create_template(
     db.add(template)
     try:
         await db.commit()
-        await db.refresh(template)
     except IntegrityError as exc:
         await db.rollback()
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=f"Er bestaat al een template met slug '{slug}' in deze organisatie",
         ) from exc
+    # SQLAlchemy expires attributes on commit. Any attribute access below
+    # (inside _template_out) triggers a lazy reload query; with RLS enabled
+    # on portal_templates the reload needs the tenant GUC re-applied after
+    # the commit released the transaction's session-level config.
+    await set_tenant(db, org.id)
+    await db.refresh(template)
 
     logger.info(
         "template_created",
@@ -308,13 +313,16 @@ async def update_template(
 
     try:
         await db.commit()
-        await db.refresh(template)
     except IntegrityError as exc:
         await db.rollback()
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail="Er bestaat al een template met deze slug in deze organisatie",
         ) from exc
+    # Same RLS-after-commit reason as in create_template — re-set tenant
+    # GUC so the post-commit refresh query can see the row.
+    await set_tenant(db, org.id)
+    await db.refresh(template)
 
     logger.info(
         "template_updated",

--- a/klai-portal/backend/tests/test_app_templates.py
+++ b/klai-portal/backend/tests/test_app_templates.py
@@ -94,6 +94,9 @@ async def test_post_scope_personal_as_non_admin_allowed(monkeypatch):
     )
     monkeypatch.setattr(app_templates, "_enforce_rate_limit", AsyncMock())
     monkeypatch.setattr(app_templates, "invalidate_templates", AsyncMock())
+    # Hotfix: create/update re-apply tenant GUC before post-commit refresh.
+    # Mock it out in unit tests since the DB is a MagicMock.
+    monkeypatch.setattr(app_templates, "set_tenant", AsyncMock())
 
     db = MagicMock()
     db.add = MagicMock()
@@ -131,6 +134,9 @@ async def test_post_scope_org_as_admin_triggers_org_wide_invalidate(monkeypatch)
     )
     monkeypatch.setattr(app_templates, "_enforce_rate_limit", AsyncMock())
     monkeypatch.setattr(app_templates, "invalidate_templates", AsyncMock())
+    # Hotfix: create/update re-apply tenant GUC before post-commit refresh.
+    # Mock it out in unit tests since the DB is a MagicMock.
+    monkeypatch.setattr(app_templates, "set_tenant", AsyncMock())
 
     db = MagicMock()
     db.add = MagicMock()


### PR DESCRIPTION
## Summary

Hotfix for production 500 error on \`PATCH /api/app/templates/{slug}\` and \`POST /api/app/templates\`. Trace:

\`\`\`
sqlalchemy.exc.InvalidRequestError: Could not refresh instance '<PortalTemplate at ...>'
  File app/api/app_templates.py:311 in update_template
    await db.refresh(template)
\`\`\`

## Root cause

SQLAlchemy AsyncSession expires all attributes on \`db.commit()\`. The subsequent \`_template_out(template)\` serialisation accesses attributes → triggers lazy reload query. After commit, the transaction is released and the session-level \`app.current_org_id\` GUC (set by \`_get_caller_org → set_tenant\`) is no longer applied to the reload query's connection. The strict RLS policy on \`portal_templates\` (\`USING (org_id = current_setting('app.current_org_id')::int)\`) then filters the row out, and SQLAlchemy raises InvalidRequestError because the refresh returned zero rows.

## Fix

Explicitly re-call \`set_tenant(db, org.id)\` between \`await db.commit()\` and \`await db.refresh(template)\` in both \`create_template\` and \`update_template\`.

## Test plan

- [x] Backend ruff check + format: clean
- [x] \`tests/test_app_templates.py\` — 11/11 pass (monkeypatch added for new \`set_tenant\` import)
- [ ] CI green (awaiting)
- [ ] Post-deploy smoke: PATCH a template via \`/admin/templates\` edit flow returns 200 + new \`updated_at\`

## Reproduction

User edited \`Klantenservice\` → \`Klantenservice2\` on \`getklai.getklai.com/admin/templates\`. Save returned 500. Log excerpt included in commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)