### PR TITLE
fix(portal): page-title margin-top -16px for logo alignment

### DIFF
--- a/klai-portal/frontend/src/index.css
+++ b/klai-portal/frontend/src/index.css
@@ -115,7 +115,7 @@ body {
    Apply via `page-title` utility class on any h1 used as a page heading.
    ─────────────────────────────────────────────────────────────────────── */
 @utility page-title {
-  margin-top: -2px;
+  margin-top: -16px;
 }
 
 /* ─── BlockNote editor: calibrate heading scale to portal context ──────────


### PR DESCRIPTION
Brings h1.page-title box-top to y=24 (aligning with sidebar klai logo). Container py-10 (40px) + margin-top -16 = 24. One line, applies to all 42 page headings.

Test: after deploy, verify on /app/scribe and /admin/groups that title top-edge aligns with sidebar logo.