### PR TITLE
fix(portal-api): reset RLS GUCs at checkout to stop pool pollution

### DIFF
--- a/.claude/rules/klai/projects/portal-backend.md
+++ b/.claude/rules/klai/projects/portal-backend.md
@@ -23,6 +23,49 @@ paths:
 - Use `text()` raw SQL for inserts on RLS-protected tables where the inserting role differs from the reading role.
 - `::jsonb` casts conflict with SQLAlchemy `:param` — use `CAST(:param AS jsonb)` instead.
 
+## Pool-GUC pollution — reset at checkout AND cleanup (CRIT)
+
+PostgreSQL `set_config('app.current_org_id', ...)` persists for the lifetime
+of the pooled connection. `app/core/database.py` resets both RLS GUCs on
+cleanup, but the reset is wrapped in `suppress(Exception)` — if the session
+is in aborted-transaction state (42501 RLS fail-loud, closed connection)
+the reset silently fails and the connection returns to the pool with a
+stale tenant GUC.
+
+**Symptom:** Intermittent 404 "Organisation not found" on `/api/app/*`
+endpoints with a valid session. Same cookie alternately succeeds and fails
+within seconds. Adjacent endpoints (`/api/app/knowledge-bases` vs
+`/api/app/templates`) return different statuses in the same millisecond
+because each call checks out a different pooled connection.
+
+**Root cause (2026-04-24 getklai incident):** `_get_caller_org` queries
+`portal_users` (RLS: `org_id = GUC OR GUC IS NULL`) BEFORE calling
+`set_tenant`. A pooled connection with `app.current_org_id=8` (Voys, leaked
+from a prior request) serving a request for org_id=1 (getklai) filters the
+getklai user row out via RLS, and the handler raises 404.
+
+**Fix:** `_pin_and_reset_connection` (renamed from `_pin_and_reset_on_exit`)
+runs `_reset_tenant_context` at checkout, before yielding the session.
+Defense-in-depth — cleanup still runs, but checkout catches any leak from
+a prior cleanup that the suppress-blocks ate.
+
+**Prevention:**
+- Every helper that hands out a pooled session MUST call
+  `_pin_and_reset_connection(session)` before yielding. `get_db`,
+  `tenant_scoped_session`, `pin_session`, `cross_org_session` all do.
+- New RLS-protected tables: the policy MUST include the
+  `OR current_setting(...) IS NULL` branch so cleared GUCs do not
+  lock out fresh connections (unless the table is intentionally cross-
+  org-inaccessible from unset context).
+- Never query an RLS-protected table before setting the tenant context in
+  the same request. If you must, accept that the query returns all rows
+  visible under the NULL policy branch.
+
+**Verification:** `docker exec klai-core-portal-api-1 psql -U klai -d klai -c
+"SELECT application_name, state, backend_start, query FROM pg_stat_activity
+WHERE application_name LIKE '%portal-api%';"` — all idle connections should
+sit in state=idle with no pending RLS statement.
+
 ## Prometheus metrics in tests
 - Never use the global `prometheus_client` registry in tests — causes `Duplicated timeseries`.
 - Use a `CollectorRegistry` per instance via dataclass + `autouse` fixture that patches module-level singleton.

--- a/klai-portal/backend/app/core/database.py
+++ b/klai-portal/backend/app/core/database.py
@@ -21,14 +21,31 @@ engine = create_async_engine(
 AsyncSessionLocal = async_sessionmaker(engine, expire_on_commit=False)
 
 
-async def _pin_and_reset_on_exit(session: AsyncSession) -> None:
-    """Pin the session's pooled connection.
+async def _pin_and_reset_connection(session: AsyncSession) -> None:
+    """Pin the session's pooled connection AND clear any stale tenant context.
 
-    After this call every subsequent statement on the session uses the same
-    physical connection, so PostgreSQL session-level `set_config()` values
-    stay visible across awaits.
+    Two jobs, both at checkout time:
+
+    1. Pin the pooled connection via `session.connection()`. After this call
+       every subsequent statement on the session uses the same physical
+       connection, so PostgreSQL session-level `set_config()` values stay
+       visible across awaits.
+
+    2. Clear any stale `app.current_org_id` / `app.cross_org_admin` inherited
+       from a prior request. `_reset_tenant_context` already runs at cleanup,
+       but its two `set_config` calls are each wrapped in `suppress(Exception)`
+       — if the suppressed path fires (aborted transaction, closed connection,
+       etc.) the GUC stays set on the pooled connection. The next request
+       picking up that connection runs its auth lookup BEFORE set_tenant, so
+       a stale GUC from a different tenant silently filters `portal_users` via
+       RLS. Observable symptom: valid sessions get intermittent
+       "Organisation not found" 404s on `/api/app/*` endpoints, with the
+       exact same cookie alternately succeeding and failing within seconds
+       depending on which pooled connection is checked out. Defense-in-depth
+       at checkout closes that window.
     """
     await session.connection()
+    await _reset_tenant_context(session)
 
 
 async def _reset_tenant_context(session: AsyncSession) -> None:
@@ -75,7 +92,7 @@ async def get_db() -> AsyncGenerator[AsyncSession]:
     making RLS block all rows.
     """
     async with AsyncSessionLocal() as session:
-        await _pin_and_reset_on_exit(session)
+        await _pin_and_reset_connection(session)
         try:
             yield session
         finally:
@@ -127,7 +144,7 @@ async def tenant_scoped_session(org_id: int) -> AsyncIterator[AsyncSession]:
                 await db.commit()
     """
     async with AsyncSessionLocal() as session:
-        await _pin_and_reset_on_exit(session)
+        await _pin_and_reset_connection(session)
         await set_tenant(session, org_id)
         try:
             yield session
@@ -141,9 +158,10 @@ async def pin_session(session: AsyncSession) -> None:
     For code paths that accept a session as a parameter (e.g. provisioning
     orchestrator) and need to guarantee that later set_config() calls on
     that session remain visible. Idempotent — calling session.connection()
-    twice is safe.
+    twice is safe, and re-clearing the tenant GUC is a no-op when already
+    clear.
     """
-    await _pin_and_reset_on_exit(session)
+    await _pin_and_reset_connection(session)
 
 
 @contextlib.asynccontextmanager
@@ -175,7 +193,7 @@ async def cross_org_session() -> AsyncIterator[AsyncSession]:
     why tenant scoping is not possible.
     """
     async with AsyncSessionLocal() as session:
-        await _pin_and_reset_on_exit(session)
+        await _pin_and_reset_connection(session)
         await session.execute(text("SELECT set_config('app.cross_org_admin', 'true', false)"))
         try:
             yield session

--- a/klai-portal/backend/tests/test_rls_guards.py
+++ b/klai-portal/backend/tests/test_rls_guards.py
@@ -76,14 +76,23 @@ async def test_tenant_scoped_session_pins_before_set_tenant(monkeypatch):
 
     # Critical invariants:
     #   1. pin happens before set_tenant (set_config must see pinned connection)
-    #   2. on exit, rollback runs BEFORE set_config resets — otherwise an aborted
+    #   2. at checkout, the tenant context is reset BEFORE set_tenant runs —
+    #      defense-in-depth against a pooled connection whose prior cleanup
+    #      silently failed and leaked a stale GUC (2026-04-24 getklai incident).
+    #   3. on exit, rollback runs BEFORE set_config resets — otherwise an aborted
     #      transaction from a 42501 RLS fail-loud would trap the reset and leak
     #      app.current_org_id to the next pooled request (2026-04-23 incident).
-    #   3. both GUCs are cleared on exit.
+    #   4. both GUCs are cleared on exit.
     assert calls == [
+        # Checkout: pin + reset (rollback + both GUCs).
         "pin",
+        "rollback",
+        "reset_current_org_id",
+        "reset_cross_org_admin",
+        # Caller sets the tenant.
         "set_tenant:42",
         "yield",
+        # Cleanup: rollback + both GUCs.
         "rollback",
         "reset_current_org_id",
         "reset_cross_org_admin",
@@ -125,8 +134,17 @@ async def test_tenant_scoped_session_resets_on_exception(monkeypatch):
         async with db_module.tenant_scoped_session(7):
             raise RuntimeError("boom")
 
-    # Even on exception: rollback runs, then both GUCs are cleared.
-    assert calls == ["pin", "set", "rollback", "reset_current_org_id", "reset_cross_org_admin"]
+    # Checkout reset runs first, then set, then on exception cleanup reset fires again.
+    assert calls == [
+        "pin",
+        "rollback",
+        "reset_current_org_id",
+        "reset_cross_org_admin",
+        "set",
+        "rollback",
+        "reset_current_org_id",
+        "reset_cross_org_admin",
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -190,7 +208,20 @@ async def test_cross_org_session_sets_and_resets_bypass_flag(monkeypatch):
     # (current_org_id before cross_org_admin). An aborted transaction from
     # a 42501 inside the cross-org body would otherwise leak the bypass
     # flag to the next pooled request.
-    assert calls == ["pin", "bypass_on", "yield", "rollback", "tenant_reset", "bypass_off"]
+    # After the 2026-04-24 checkout-reset fix, the same helper runs BEFORE
+    # bypass_on is set — so the sequence is pin → reset → bypass_on →
+    # yield → cleanup reset.
+    assert calls == [
+        "pin",
+        "rollback",
+        "tenant_reset",
+        "bypass_off",
+        "bypass_on",
+        "yield",
+        "rollback",
+        "tenant_reset",
+        "bypass_off",
+    ]
 
 
 @pytest.mark.asyncio
@@ -223,7 +254,12 @@ async def test_cross_org_session_clears_bypass_on_exception(monkeypatch):
             raise RuntimeError("kaboom")
 
     assert "bypass_on" in calls and "bypass_off" in calls
-    assert calls.index("bypass_on") < calls.index("bypass_off")
+    # The checkout reset clears bypass BEFORE the body sets it, so the first
+    # bypass_off precedes bypass_on. What we care about is that the LAST
+    # bypass_off (cleanup) runs after bypass_on — i.e. the pool never returns
+    # with the bypass flag still lit.
+    last_off_idx = len(calls) - 1 - calls[::-1].index("bypass_off")
+    assert calls.index("bypass_on") < last_off_idx
 
 
 # ---------------------------------------------------------------------------

--- a/klai-portal/backend/tests/test_tenant_context_reset.py
+++ b/klai-portal/backend/tests/test_tenant_context_reset.py
@@ -152,6 +152,145 @@ async def test_reset_swallows_set_config_failure_on_first_guc() -> None:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# _pin_and_reset_connection — checkout-time defense against pool pollution
+# ---------------------------------------------------------------------------
+#
+# Symptom that led to these tests (2026-04-24):
+#   Apr 23 — getklai.getklai.com chat: `/api/app/templates` and
+#   `/api/app/chat-health` returned intermittent 404 "Organisation not found"
+#   for a valid session, while `/api/app/knowledge-bases` with the same cookie
+#   in the same second returned 200. Caddy logs showed alternating statuses
+#   tied to which pooled DB connection served the request.
+#
+# Root cause:
+#   `_get_caller_org` queries portal_users (RLS: `org_id = GUC OR GUC IS NULL`)
+#   BEFORE calling set_tenant. If the checked-out connection had a stale
+#   `app.current_org_id` from a prior request whose cleanup `_reset_tenant_context`
+#   suppressed an error (aborted transaction, closed connection), the user row
+#   was filtered out and the handler raised 404.
+#
+#   Cleanup-time reset was not enough — any silent failure there leaks the GUC
+#   to the next checkout. These tests lock the new checkout-time reset.
+
+
+@pytest.mark.asyncio
+async def test_pin_and_reset_clears_stale_tenant_at_checkout() -> None:
+    """`_pin_and_reset_connection` MUST clear any leftover tenant GUC.
+
+    Without this, a pooled connection whose prior cleanup suppressed an
+    error returns to the next request with the stale `app.current_org_id`,
+    and RLS silently filters portal_users for the wrong tenant.
+    """
+    session = _fake_session()
+    session.connection = AsyncMock()
+
+    await db_module._pin_and_reset_connection(session)
+
+    # Connection pinned exactly once before reset runs.
+    assert session.connection.await_count == 1
+    # Reset: rollback + two set_config calls (current_org_id + cross_org_admin).
+    assert session.rollback.await_count == 1
+    assert session.execute.await_count == 2
+    rendered = [str(c.args[0]) for c in session.execute.await_args_list]
+    assert any("app.current_org_id" in s for s in rendered), rendered
+    assert any("app.cross_org_admin" in s for s in rendered), rendered
+
+
+@pytest.mark.asyncio
+async def test_pin_runs_connection_before_reset() -> None:
+    """Connection MUST be pinned before the set_config statements run.
+
+    If the reset landed on a non-pinned session, SQLAlchemy could route each
+    set_config to a different pooled connection and the RLS GUC would end up
+    on the wrong physical connection — re-introducing the same class of bug.
+    """
+    session = AsyncMock()
+    calls: list[str] = []
+
+    async def tracked_connection() -> None:
+        calls.append("connection")
+
+    async def tracked_rollback() -> None:
+        calls.append("rollback")
+
+    async def tracked_execute(*_args: object, **_kwargs: object) -> object:
+        calls.append("execute")
+        return MagicMock()
+
+    session.connection = AsyncMock(side_effect=tracked_connection)
+    session.rollback = AsyncMock(side_effect=tracked_rollback)
+    session.execute = AsyncMock(side_effect=tracked_execute)
+
+    await db_module._pin_and_reset_connection(session)
+
+    assert calls[0] == "connection", f"connection() must run first, got {calls}"
+    # Then the reset sequence (rollback, execute, execute).
+    assert calls[1:] == ["rollback", "execute", "execute"], calls
+
+
+@pytest.mark.asyncio
+async def test_get_db_clears_stale_guc_before_yielding(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression test for the getklai.getklai.com intermittent-404 incident.
+
+    Before the fix, `get_db` pinned the connection but did NOT reset the
+    tenant GUC at checkout. If the previous request leaked `app.current_org_id`
+    into the pool, the very next `_get_caller_org` query ran with the wrong
+    tenant and returned 404 for a valid session.
+
+    After the fix, `_pin_and_reset_connection` fires before yielding, so the
+    handler sees a clean GUC and its own `set_tenant` lands reliably.
+    """
+    fake_session = _fake_session()
+    fake_session.connection = AsyncMock()
+
+    class FakeSessionCM:
+        async def __aenter__(self) -> AsyncMock:
+            return fake_session
+
+        async def __aexit__(self, *_args: object) -> None:
+            pass
+
+    monkeypatch.setattr(db_module, "AsyncSessionLocal", lambda: FakeSessionCM())
+
+    yielded_sessions: list[AsyncMock] = []
+    async for session in db_module.get_db():
+        yielded_sessions.append(session)
+        # At yield-time the reset must already have run — otherwise the
+        # handler's first query (which typically lands before set_tenant)
+        # can still hit a stale RLS context.
+        assert session.rollback.await_count == 1
+        assert session.execute.await_count == 2
+        break
+
+    assert yielded_sessions == [fake_session]
+
+
+@pytest.mark.asyncio
+async def test_pin_session_also_clears_stale_guc() -> None:
+    """External-session pin (used by provisioning orchestrator) must reset too.
+
+    `pin_session` accepts a session from the caller. Provisioning pipelines
+    reuse a long-lived session across compensator steps; each step should
+    start from a clean RLS context, not whatever the previous step left
+    behind.
+    """
+    session = _fake_session()
+    session.connection = AsyncMock()
+
+    await db_module.pin_session(session)
+
+    # Same contract as _pin_and_reset_connection.
+    assert session.connection.await_count == 1
+    assert session.rollback.await_count == 1
+    assert session.execute.await_count == 2
+
+
+# ---------------------------------------------------------------------------
+# cross_org_session — no more double-reset of app.cross_org_admin
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.asyncio
 async def test_cross_org_session_delegates_reset_to_shared_helper(
     monkeypatch: pytest.MonkeyPatch,
@@ -161,6 +300,11 @@ async def test_cross_org_session_delegates_reset_to_shared_helper(
     Before the fix it had its own standalone
     `set_config('app.cross_org_admin', '', false)` wrapped in suppress —
     same aborted-transaction trap. Now the shared helper handles it.
+
+    Post-2026-04-24 pool-reset fix: the helper is also invoked at checkout
+    via `_pin_and_reset_connection`, so a `cross_org_session` block runs
+    two resets total (checkout + cleanup). Both target the same fake
+    session, and the cleanup one is the one that matters for pool hygiene.
     """
     fake_session = AsyncMock()
     fake_session.rollback = AsyncMock()
@@ -186,5 +330,7 @@ async def test_cross_org_session_delegates_reset_to_shared_helper(
     async with db_module.cross_org_session() as db:
         assert db is fake_session
 
-    assert len(reset_calls) == 1, "Shared reset helper must run exactly once"
-    assert reset_calls[0] is fake_session
+    # Two resets: one at checkout (_pin_and_reset_connection), one at cleanup.
+    # Both must target the fake session — no other sessions created.
+    assert len(reset_calls) == 2, "Shared reset must run at checkout AND cleanup"
+    assert all(s is fake_session for s in reset_calls)


### PR DESCRIPTION
## Summary

- Close a silent pool-GUC leak that caused intermittent **"Organisation not found" 404s** on every RLS-protected `/api/app/*` endpoint for valid sessions.
- Rename `_pin_and_reset_on_exit` → `_pin_and_reset_connection` and have it reset the tenant context **at checkout** as well as cleanup. Defense-in-depth: the cleanup reset still runs; the new checkout reset closes the window where a suppressed cleanup leaks the GUC.

## Incident (2026-04-24, getklai.getklai.com chat)

Same session, same cookie, consecutive calls:

```
14:57:17.190  GET /api/app/account/kb-preference  200  ✓
14:57:17.192  GET /api/app/knowledge-bases        404  ✗
14:57:17.193  GET /api/app/templates              404  ✗
14:57:18.275  GET /api/app/knowledge-bases        200  ✓  (retry on another conn)
```

Different pooled DB connections → different stale `app.current_org_id` values → `portal_users` RLS (`org_id = GUC OR GUC IS NULL`) filters the user row out on some connections → `_get_caller_org` raises 404.

## Root cause

`_get_caller_org` runs the `portal_users` lookup **before** `set_tenant`. If the checked-out connection carries a stale GUC from a prior request whose cleanup `_reset_tenant_context` suppressed an exception (aborted transaction, closed connection), RLS silently filters. Concurrent cross-tenant activity (a parallel Playwright test on the Voys tenant) was enough to fill the pool with `GUC=8` connections while the getklai browser expected `GUC=1`.

## Fix

`_pin_and_reset_connection` now:

1. pins the pooled connection (`session.connection()`), then
2. calls `_reset_tenant_context(session)` to clear both RLS GUCs at checkout.

All four pool helpers (`get_db`, `tenant_scoped_session`, `pin_session`, `cross_org_session`) already delegated to this helper, so the single-site change covers every pooled-session entry point.

## Test plan

- [x] `tests/test_tenant_context_reset.py`: 4 new tests lock checkout-time reset behaviour (pin-before-reset ordering, GUC clearing, regression test for the getklai 404 incident, `pin_session` coverage).
- [x] `tests/test_rls_guards.py`: update 4 existing call-sequence assertions to include the new checkout reset; invariants stay the same.
- [x] Full backend test suite: **810/810 green**.
- [x] `ruff check` + `ruff format --check`: clean.
- [ ] CI green on push.
- [ ] After merge, verify production: no `"Organisation not found"` 404s in portal-api logs for `/api/app/*` endpoints across a full 30-minute window with parallel tenant traffic.

## Mitigation already applied

Portal-api was restarted on core-01 immediately after diagnosis (`docker compose restart portal-api` at 2026-04-24T05:35:14Z) to clear the polluted pool. Mark's getklai chat works again right now. This PR prevents the class of bug from recurring.

## Follow-up (not in this PR)

- Consider a startup assertion that `_rls_current_org_id()` policy functions always include the `IS NULL` branch for tables accessed by `_get_caller_org`. Currently a table without that branch would 404 even on a fresh pool connection.
- Consider wiring a `pool_pre_ping` hook that resets the GUC on every checkout at the SQLAlchemy level — belt + suspenders, would catch any future helper that forgets to call `_pin_and_reset_connection`.