### PR TITLE
fix(portal-api): exempt /api/perf from CSRF for sendBeacon

### DIFF
--- a/klai-portal/backend/app/middleware/session.py
+++ b/klai-portal/backend/app/middleware/session.py
@@ -46,6 +46,8 @@ _CSRF_EXEMPT_PREFIXES: tuple[str, ...] = (
     "/api/signup",
     "/api/health",
     "/api/public/",
+    # Web-vitals beacon: navigator.sendBeacon cannot set X-CSRF-Token.
+    "/api/perf",
     "/internal/",
     "/partner/",
     "/widget/",

--- a/klai-portal/backend/tests/test_bff_session_middleware.py
+++ b/klai-portal/backend/tests/test_bff_session_middleware.py
@@ -258,3 +258,19 @@ class TestCsrfEnforcement:
         client = TestClient(app)
         resp = client.post("/internal/webhook", cookies={SESSION_COOKIE_NAME: sid})
         assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_perf_beacon_is_csrf_exempt(self, app: FastAPI, wire_redis: AsyncMock) -> None:
+        # /api/perf receives navigator.sendBeacon payloads, which cannot set
+        # X-CSRF-Token. Must bypass CSRF even with an active session.
+        sid, _csrf = await _create_session(wire_redis)
+        app = FastAPI()
+        app.add_middleware(SessionMiddleware)
+
+        @app.post("/api/perf")
+        async def perf():  # type: ignore[no-untyped-def]
+            return {"ok": True}
+
+        client = TestClient(app)
+        resp = client.post("/api/perf", cookies={SESSION_COOKIE_NAME: sid})
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- `/api/perf` receives web-vitals via `navigator.sendBeacon`, which cannot set `X-CSRF-Token`
- Authenticated users were getting 403 on every vitals flush
- Added `/api/perf` to `_CSRF_EXEMPT_PREFIXES` alongside other analytics/webhook paths
- Regression test in `test_bff_session_middleware.py` locks in the exempt behaviour

## Test plan
- [x] `uv run pytest tests/test_bff_session_middleware.py` (12/12 green locally)
- [ ] CI green
- [ ] Verify no 403 on `/api/perf` after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)