### PR TITLE
refactor(ms-docs): cleanup — Protocol, shared helper, stable keys, reconnect signal

### DIFF
--- a/klai-connector/app/adapters/google_drive.py
+++ b/klai-connector/app/adapters/google_drive.py
@@ -39,7 +39,7 @@ from typing import Any
 import httpx
 
 from app.adapters.base import BaseAdapter, DocumentRef
-from app.adapters.oauth_base import OAuthAdapterBase
+from app.adapters.oauth_base import ConnectorLike, OAuthAdapterBase
 from app.core.config import Settings
 from app.core.logging import get_logger
 from app.services.portal_client import PortalClient
@@ -190,7 +190,7 @@ class GoogleDriveAdapter(OAuthAdapterBase, BaseAdapter):
     # -- OAuth refresh --------------------------------------------------------
 
     async def _refresh_oauth_token(
-        self, connector: Any, refresh_token: str,
+        self, connector: ConnectorLike, refresh_token: str,
     ) -> dict[str, Any]:
         """Exchange a refresh_token for a new access_token against Google.
 

--- a/klai-connector/app/adapters/ms_docs.py
+++ b/klai-connector/app/adapters/ms_docs.py
@@ -46,7 +46,7 @@ from urllib.parse import quote, urlparse
 import httpx
 
 from app.adapters.base import BaseAdapter, DocumentRef
-from app.adapters.oauth_base import OAuthAdapterBase
+from app.adapters.oauth_base import ConnectorLike, OAuthAdapterBase, OAuthReconnectRequiredError
 from app.core.config import Settings
 from app.core.logging import get_logger
 from app.services.portal_client import PortalClient
@@ -109,9 +109,11 @@ class MsDocsAdapter(OAuthAdapterBase, BaseAdapter):
         self._latest_delta_link: dict[str, str] = {}
         # connector_id -> resolved SharePoint site id (from site_url lookup).
         self._resolved_sites: dict[str, str] = {}
-        # DocumentRef identity -> adapter-owned metadata (sender_email, mentioned_emails).
-        # Keyed by object id since DocumentRef is frozen.
-        self._ref_metadata: dict[int, dict[str, Any]] = {}
+        # DocumentRef.ref (Graph driveItem id, stable) -> adapter-owned metadata
+        # (sender_email, mentioned_emails). Keyed by the Graph id rather than
+        # Python id() so entries survive GC and can be looked up safely even
+        # if a caller rebuilds DocumentRef instances.
+        self._ref_metadata: dict[str, dict[str, Any]] = {}
 
     async def aclose(self) -> None:
         """No persistent resources to close."""
@@ -130,7 +132,7 @@ class MsDocsAdapter(OAuthAdapterBase, BaseAdapter):
     # -- OAuth refresh (SPEC-KB-MS-DOCS-001 R2.1) -----------------------------
 
     async def _refresh_oauth_token(
-        self, connector: Any, refresh_token: str,
+        self, connector: ConnectorLike, refresh_token: str,
     ) -> dict[str, Any]:
         """Exchange a refresh_token for a new access_token against Microsoft.
 
@@ -139,11 +141,18 @@ class MsDocsAdapter(OAuthAdapterBase, BaseAdapter):
         handles the writeback + in-memory rotation (see R9.2).
 
         Args:
-            connector: Connector model (unused — kept for the OAuth base contract).
+            connector: Connector model (used for connector_id in error messages).
             refresh_token: Long-lived refresh token from the encrypted config.
 
         Returns:
             Raw JSON dict from Microsoft's token endpoint.
+
+        Raises:
+            OAuthReconnectRequiredError: Microsoft returned ``invalid_grant``
+                (refresh_token revoked by user password change, admin consent
+                revoke, or past grace window after rotation). The caller
+                (sync engine) should mark the connector as auth_error so the
+                portal can surface a "Reconnect Microsoft" affordance.
         """
         # @MX:NOTE: [AUTO] NEVER log the refresh_token or the returned access_token.
         payload = {
@@ -156,6 +165,24 @@ class MsDocsAdapter(OAuthAdapterBase, BaseAdapter):
         token_url = _ms_token_url(self._settings.ms_docs_tenant_id)
         async with httpx.AsyncClient(timeout=10.0) as client:
             response = await client.post(token_url, data=payload)
+            # Microsoft returns 400 + JSON body with error=invalid_grant when
+            # the refresh_token is permanently invalid. Translate to a clean
+            # signal before raising a generic HTTPStatusError. See MS docs:
+            # https://learn.microsoft.com/en-us/entra/identity-platform/reference-error-codes
+            if response.status_code == 400:
+                try:
+                    body = response.json()
+                except ValueError:
+                    body = {}
+                if isinstance(body, dict) and body.get("error") == "invalid_grant":
+                    logger.warning(
+                        "Microsoft invalid_grant for connector=%s — reconnect required",
+                        str(connector.id),
+                    )
+                    raise OAuthReconnectRequiredError(
+                        f"Microsoft refresh_token rejected (connector_id={connector.id}): "
+                        f"{body.get('error_description', 'invalid_grant')}"
+                    )
             response.raise_for_status()
             data = response.json()
         if not isinstance(data, dict):
@@ -216,7 +243,7 @@ class MsDocsAdapter(OAuthAdapterBase, BaseAdapter):
                 continue
             # Adapter-owned metadata (identifier capture, R2.5)
             meta = self._extract_metadata(item)
-            self._ref_metadata[id(ref)] = meta
+            self._ref_metadata[ref.ref] = meta
             refs.append(ref)
 
         logger.info(
@@ -265,7 +292,7 @@ class MsDocsAdapter(OAuthAdapterBase, BaseAdapter):
         The sync engine reads this after ``list_documents`` to populate the
         ``extra`` JSONB passthrough into knowledge-ingest (R2.10).
         """
-        return self._ref_metadata.get(id(ref), {"sender_email": "", "mentioned_emails": []})
+        return self._ref_metadata.get(ref.ref, {"sender_email": "", "mentioned_emails": []})
 
     # -- Delta URL construction + pagination ---------------------------------
 
@@ -387,25 +414,40 @@ class MsDocsAdapter(OAuthAdapterBase, BaseAdapter):
     # -- Graph HTTP helpers (auth + retry) -----------------------------------
 
     # @MX:ANCHOR: Single HTTP request codepath for all Graph calls.
-    # @MX:REASON: fan_in >= 3 (list, resolve, get_cursor_state).
+    # @MX:REASON: fan_in >= 3 (list, resolve, get_cursor_state, fetch_document).
     #             Auth header + Retry-After + 429 handling must stay identical.
-    async def _graph_get_json(
-        self, url: str, connector: Any | None = None,
-    ) -> dict[str, Any]:
-        """GET a JSON response from the Graph API with auth + 429 retry.
+    async def _graph_request(
+        self,
+        url: str,
+        *,
+        connector: ConnectorLike | None = None,
+        timeout: float = 30.0,
+        follow_redirects: bool = False,
+    ) -> httpx.Response:
+        """Issue a GET against the Graph API with auth + one 429/503 retry.
 
-        One retry on 429/503 using ``Retry-After`` (capped at
-        ``_RETRY_AFTER_CAP_SECONDS``); after a second failure, the exception
-        propagates and the scheduler does exponential backoff (R2.11).
+        Single codepath used by both JSON and byte-stream consumers. One
+        retry on 429/503 using ``Retry-After`` (capped at
+        ``_RETRY_AFTER_CAP_SECONDS``); after a second failure the exception
+        propagates so the scheduler does exponential backoff (R2.11).
 
         Args:
             url: Fully-qualified Graph URL (or a deltaLink echoed from Graph).
             connector: Optional — needed for token refresh when called outside
                 list_documents. In practice ensure_token uses the last-seen
                 connector via the cache.
+            timeout: httpx timeout; callers raise it for content downloads.
+            follow_redirects: Graph may 302 content requests to
+                preauthenticated URLs; set True for binary fetches.
+
+        Returns:
+            The raised-for-status httpx Response. Caller decides ``.json()``
+            vs ``.content`` shape.
         """
         headers = await self._auth_headers(connector)
-        async with httpx.AsyncClient(timeout=30.0) as client:
+        async with httpx.AsyncClient(
+            timeout=timeout, follow_redirects=follow_redirects,
+        ) as client:
             response = await client.get(url, headers=headers)
             if response.status_code in (429, 503):
                 retry_after = self._parse_retry_after(response)
@@ -416,7 +458,14 @@ class MsDocsAdapter(OAuthAdapterBase, BaseAdapter):
                 await asyncio.sleep(retry_after)
                 response = await client.get(url, headers=headers)
             response.raise_for_status()
-            data = response.json()
+            return response
+
+    async def _graph_get_json(
+        self, url: str, connector: ConnectorLike | None = None,
+    ) -> dict[str, Any]:
+        """Thin wrapper over ``_graph_request`` returning a JSON dict."""
+        response = await self._graph_request(url, connector=connector)
+        data = response.json()
         if not isinstance(data, dict):
             return {}
         # data is a genuinely untyped JSON dict; the caller treats keys as Any.
@@ -424,28 +473,19 @@ class MsDocsAdapter(OAuthAdapterBase, BaseAdapter):
         return result
 
     async def _graph_get_bytes(
-        self, url: str, connector: Any | None = None,
+        self, url: str, connector: ConnectorLike | None = None,
     ) -> bytes:
-        """GET binary content from the Graph API (used by fetch_document).
+        """Thin wrapper over ``_graph_request`` returning raw bytes.
 
-        Follows 302 redirects to preauthenticated download URLs that Graph may
-        return for large files.
+        Uses a longer timeout + follow_redirects since Graph can 302 binary
+        downloads to preauthenticated blob URLs for large files.
         """
-        headers = await self._auth_headers(connector)
-        async with httpx.AsyncClient(timeout=60.0, follow_redirects=True) as client:
-            response = await client.get(url, headers=headers)
-            if response.status_code in (429, 503):
-                retry_after = self._parse_retry_after(response)
-                logger.warning(
-                    "Graph throttled on content fetch (status=%s, retry_after=%.1fs)",
-                    response.status_code, retry_after,
-                )
-                await asyncio.sleep(retry_after)
-                response = await client.get(url, headers=headers)
-            response.raise_for_status()
-            return response.content
+        response = await self._graph_request(
+            url, connector=connector, timeout=60.0, follow_redirects=True,
+        )
+        return response.content
 
-    async def _auth_headers(self, connector: Any | None) -> dict[str, str]:
+    async def _auth_headers(self, connector: ConnectorLike | None) -> dict[str, str]:
         """Return an ``Authorization: Bearer <token>`` header for Graph calls.
 
         Uses the most-recently cached access token. If ``connector`` is given

--- a/klai-connector/app/adapters/oauth_base.py
+++ b/klai-connector/app/adapters/oauth_base.py
@@ -1,9 +1,9 @@
 """Shared base class for OAuth-backed connector adapters (SPEC-KB-025).
 
 This module centralises the OAuth token refresh + in-memory caching logic
-used by Google Drive (and, later, SharePoint). Adapters subclass
-``OAuthAdapterBase`` and implement ``_refresh_oauth_token`` with the
-provider-specific token endpoint call.
+used by Google Drive and Microsoft 365 (SharePoint/OneDrive). Adapters
+subclass ``OAuthAdapterBase`` and implement ``_refresh_oauth_token`` with
+the provider-specific token endpoint call.
 
 Design decisions:
 - Token cache is keyed by ``connector.id`` and uses ``time.monotonic()`` for
@@ -15,12 +15,15 @@ Design decisions:
   This is best-effort: a callback failure is logged but never propagates,
   since the next sync can always refresh again.
 - NEVER log access_token / refresh_token values — only metadata.
+- Connector shape is expressed as a ``ConnectorLike`` Protocol so both
+  SQLAlchemy models (production) and ``SimpleNamespace`` stubs (tests)
+  type-check cleanly without ``Any``.
 """
 
 # @MX:ANCHOR: [AUTO] Shared OAuth refresh path for all OAuth-backed adapters.
-# @MX:REASON: fan_in>=2 now (google_drive) and grows with every new OAuth provider.
+# @MX:REASON: fan_in>=2 (google_drive, ms_docs) and grows with every new OAuth provider.
 #             Cache + writeback invariants must stay identical across providers.
-# @MX:SPEC: SPEC-KB-025
+# @MX:SPEC: SPEC-KB-025, SPEC-KB-MS-DOCS-001
 
 from __future__ import annotations
 
@@ -28,7 +31,7 @@ import asyncio
 import time
 from abc import ABC, abstractmethod
 from datetime import UTC, datetime, timedelta
-from typing import Any, cast
+from typing import Any, Protocol, runtime_checkable
 
 from app.core.config import Settings
 from app.core.logging import get_logger
@@ -40,6 +43,35 @@ logger = get_logger(__name__)
 # How many seconds before actual expiry we consider a token "expired" and
 # trigger a refresh. Avoids racing API calls against wall-clock expiry.
 _EXPIRY_SKEW_SECONDS = 60.0
+
+
+@runtime_checkable
+class ConnectorLike(Protocol):
+    """Structural Protocol for a connector model passed to OAuthAdapterBase.
+
+    Both SQLAlchemy ``PortalConnector`` instances (production) and
+    ``SimpleNamespace(id=..., config=...)`` stubs (tests) match this shape.
+    The Protocol lets pyright narrow ``config`` without ``Any`` / cast
+    workarounds and catches missing-attribute typos at type-check time.
+
+    ``id`` is typed as ``Any`` because different callers pass different
+    shapes: SQLAlchemy ``Column[UUID]``, ``uuid.UUID``, or ``str``. The
+    adapter always stringifies via ``str(connector.id)``.
+    """
+
+    id: Any
+    config: dict[str, Any] | None
+
+
+class OAuthReconnectRequiredError(RuntimeError):
+    """Raised when the provider indicates the refresh_token is no longer valid.
+
+    Signals that the connector needs a fresh OAuth consent from the user
+    (e.g. Microsoft ``invalid_grant`` after password change, consent revoke,
+    or refresh-token-past-grace-window). Sync engines should catch this and
+    mark the connector as ``auth_error`` so the portal can surface a
+    "Reconnect Microsoft" / "Reconnect Google" affordance.
+    """
 
 
 class OAuthAdapterBase(ABC):
@@ -67,22 +99,30 @@ class OAuthAdapterBase(ABC):
 
     @abstractmethod
     async def _refresh_oauth_token(
-        self, connector: Any, refresh_token: str,
+        self, connector: ConnectorLike, refresh_token: str,
     ) -> dict[str, Any]:
         """Call the provider's token endpoint with the refresh_token.
 
+        Implementations MAY raise ``OAuthReconnectRequiredError`` when the
+        provider returns ``invalid_grant`` so the sync engine can mark the
+        connector as needing user-driven re-consent.
+
         Args:
-            connector: The connector model (provides org_id + config context).
+            connector: The connector model (provides id + config context).
             refresh_token: The long-lived OAuth refresh token.
 
         Returns:
             Raw JSON dict from the token endpoint. MUST contain ``access_token``
             and ``expires_in`` keys. Provider-specific extras are ignored here.
+
+        Raises:
+            OAuthReconnectRequiredError: Provider signalled the refresh_token is
+                permanently invalid.
         """
 
     # -- Public API ----------------------------------------------------------
 
-    async def ensure_token(self, connector: Any) -> str:
+    async def ensure_token(self, connector: ConnectorLike) -> str:
         """Return a valid access_token, refreshing if the cached one has expired.
 
         Args:
@@ -94,6 +134,8 @@ class OAuthAdapterBase(ABC):
         Raises:
             ValueError: If the connector config lacks a refresh_token AND the
                 cached access_token is expired (or absent).
+            OAuthReconnectRequiredError: Provider rejected the refresh_token as
+                permanently invalid (propagated from ``_refresh_oauth_token``).
         """
         connector_id = str(connector.id)
         cached = self._token_cache.get(connector_id)
@@ -104,7 +146,7 @@ class OAuthAdapterBase(ABC):
                 return token
 
         # Serialise refreshes for the same connector so we don't burn through
-        # Google's refresh quota with a thundering-herd at startup.
+        # the provider's refresh quota with a thundering-herd at startup.
         lock = self._refresh_locks.setdefault(connector_id, asyncio.Lock())
         async with lock:
             # Re-check under the lock in case another coroutine just refreshed.
@@ -114,8 +156,10 @@ class OAuthAdapterBase(ABC):
                 return cached[0]
 
             current_config: dict[str, Any] = connector.config or {}
-            refresh_token_value = current_config.get("refresh_token", "")
-            refresh_token: str = refresh_token_value if isinstance(refresh_token_value, str) else ""
+            refresh_token_raw = current_config.get("refresh_token", "")
+            refresh_token: str = (
+                refresh_token_raw if isinstance(refresh_token_raw, str) else ""
+            )
             if not refresh_token:
                 raise ValueError(
                     "OAuth connector missing refresh_token — reconnect required "
@@ -130,7 +174,10 @@ class OAuthAdapterBase(ABC):
                 type(self).__name__,
             )
             payload = await self._refresh_oauth_token(connector, refresh_token)
-            access_token = payload.get("access_token", "")
+            access_token_raw = payload.get("access_token", "")
+            access_token: str = (
+                access_token_raw if isinstance(access_token_raw, str) else ""
+            )
             expires_in = int(payload.get("expires_in", 3600))
             if not access_token:
                 raise ValueError(
@@ -149,15 +196,18 @@ class OAuthAdapterBase(ABC):
             # new one so it survives restart, and (b) mutate connector.config
             # so subsequent refreshes within the same process use the new RT.
             rotated_raw = payload.get("refresh_token")
-            rotated_refresh_token: str | None = rotated_raw if isinstance(rotated_raw, str) else None
+            rotated_refresh_token: str | None = (
+                rotated_raw if isinstance(rotated_raw, str) else None
+            )
             if rotated_refresh_token is not None and rotated_refresh_token == refresh_token:
                 # Provider echoed the same RT — treat as no-rotation.
                 rotated_refresh_token = None
             if rotated_refresh_token:
-                if connector.config is None:
-                    connector.config = {}
-                # connector.config is typed Any at the ABC boundary; cast narrows for the write.
-                cast("dict[str, Any]", connector.config)["refresh_token"] = rotated_refresh_token  # pyright: ignore[reportUnknownMemberType]
+                config_dict: dict[str, Any] = (
+                    connector.config if connector.config is not None else {}
+                )
+                config_dict["refresh_token"] = rotated_refresh_token
+                connector.config = config_dict
 
             token_expiry = (datetime.now(UTC) + timedelta(seconds=expires_in)).isoformat()
             try:

--- a/klai-connector/tests/adapters/test_ms_docs.py
+++ b/klai-connector/tests/adapters/test_ms_docs.py
@@ -401,6 +401,112 @@ async def test_refresh_oauth_token_posts_to_microsoft_endpoint(
 
 
 @pytest.mark.asyncio
+async def test_refresh_oauth_token_invalid_grant_raises_reconnect_required(
+    ms_adapter: Any, ms_connector: SimpleNamespace,
+) -> None:
+    """Microsoft returns 400 + invalid_grant → OAuthReconnectRequiredError, not HTTPStatusError."""
+    from app.adapters.oauth_base import OAuthReconnectRequiredError
+
+    mock_response = MagicMock()
+    mock_response.status_code = 400
+    mock_response.json = MagicMock(
+        return_value={
+            "error": "invalid_grant",
+            "error_description": "AADSTS700082: refresh token expired",
+        }
+    )
+    # raise_for_status won't be called on the 400 path (our code raises before)
+    mock_response.raise_for_status = MagicMock(return_value=None)
+
+    http_client = MagicMock()
+    http_client.post = AsyncMock(return_value=mock_response)
+    http_client.__aenter__ = AsyncMock(return_value=http_client)
+    http_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch(
+        "app.adapters.ms_docs.httpx.AsyncClient",
+        MagicMock(return_value=http_client),
+    ), pytest.raises(OAuthReconnectRequiredError, match="refresh token expired"):
+        await ms_adapter._refresh_oauth_token(
+            ms_connector, refresh_token="placeholder-dead-refresh"
+        )
+
+
+@pytest.mark.asyncio
+async def test_refresh_oauth_token_other_400_propagates_as_http_error(
+    ms_adapter: Any, ms_connector: SimpleNamespace,
+) -> None:
+    """A 400 that is NOT invalid_grant still bubbles up via raise_for_status."""
+    import httpx
+
+    mock_response = MagicMock()
+    mock_response.status_code = 400
+    mock_response.json = MagicMock(
+        return_value={"error": "invalid_client", "error_description": "Unknown client"}
+    )
+    http_err = httpx.HTTPStatusError(
+        "bad request", request=MagicMock(), response=mock_response,
+    )
+    mock_response.raise_for_status = MagicMock(side_effect=http_err)
+
+    http_client = MagicMock()
+    http_client.post = AsyncMock(return_value=mock_response)
+    http_client.__aenter__ = AsyncMock(return_value=http_client)
+    http_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch(
+        "app.adapters.ms_docs.httpx.AsyncClient",
+        MagicMock(return_value=http_client),
+    ), pytest.raises(httpx.HTTPStatusError):
+        await ms_adapter._refresh_oauth_token(
+            ms_connector, refresh_token="placeholder-rt"
+        )
+
+
+@pytest.mark.asyncio
+async def test_metadata_keyed_by_stable_graph_id_not_python_id(
+    ms_adapter: Any, ms_connector: SimpleNamespace,
+) -> None:
+    """SPEC-KB-MS-DOCS-001 cleanup: metadata survives rebuilding the DocumentRef.
+
+    Regression guard for the previous id(ref) keying that would break if a
+    caller reconstructs a DocumentRef with the same Graph id but a different
+    Python object identity (e.g. after DB round-trip).
+    """
+    delta_response = {
+        "value": [_drive_item(
+            "item-stable-id",
+            "Stable.docx",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        )],
+        "@odata.deltaLink": "https://graph/.../delta?t=x",
+    }
+
+    async def _fake_get(url: str) -> dict[str, Any]:
+        return delta_response
+
+    with patch.object(ms_adapter, "_graph_get_json", side_effect=_fake_get):
+        refs_first = await ms_adapter.list_documents(ms_connector, cursor_context=None)
+
+    # Look up via a FRESH DocumentRef with the same .ref — different Python id
+    fresh_ref = DocumentRef(
+        path="Stable.docx",
+        ref="item-stable-id",
+        size=1024,
+        content_type="word_document",
+        source_ref="item-stable-id",
+        source_url="https://contoso.sharepoint.com/x",
+        last_edited="2026-04-20T10:00:00Z",
+    )
+    assert id(fresh_ref) != id(refs_first[0]), "test needs distinct Python objects"
+
+    # Old code (id(ref)) would return default empty metadata here; new code returns real metadata.
+    meta = ms_adapter._get_metadata_for_ref(fresh_ref)
+    assert meta["sender_email"] == "bob@example.com"
+    assert set(meta["mentioned_emails"]) == {"alice@example.com", "bob@example.com"}
+
+
+@pytest.mark.asyncio
 async def test_graph_get_json_retries_on_429(
     ms_adapter: Any, ms_connector: SimpleNamespace,
 ) -> None:

--- a/klai-portal/frontend/src/lib/ms-docs.ts
+++ b/klai-portal/frontend/src/lib/ms-docs.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared helpers for the Microsoft 365 (ms_docs) connector wizard.
+ *
+ * SPEC-KB-MS-DOCS-001: a SharePoint site URL must be of the form
+ *   https://{tenant}.sharepoint.com/sites/{site}
+ * so the server can resolve it to a Graph site-id via
+ *   GET /sites/{hostname}:/sites/{site}
+ */
+
+/**
+ * Client-side validation regex for the SharePoint site URL field.
+ *
+ * Tenant names: lowercase letters, digits, hyphens (Microsoft allows `-` but not
+ * subdomains-of-subdomains on the sharepoint.com apex). The site segment may
+ * contain anything that is URL-safe except `/`. A trailing slash is tolerated.
+ *
+ * Keep in sync with the server-side `_parse_site_url` split in
+ * `klai-connector/app/adapters/ms_docs.py` — that function expects exactly the
+ * `hostname` + `/sites/{site}` shape this regex accepts.
+ */
+export const MS_SITE_URL_PATTERN =
+  /^https:\/\/[a-z0-9-]+\.sharepoint\.com\/sites\/[^/]+\/?$/

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
@@ -14,6 +14,7 @@ import { Label } from '@/components/ui/label'
 import { MultiSelect, type MultiSelectOption } from '@/components/ui/multi-select'
 import * as m from '@/paraglide/messages'
 import { apiFetch } from '@/lib/apiFetch'
+import { MS_SITE_URL_PATTERN } from '@/lib/ms-docs'
 
 // -- Types -------------------------------------------------------------------
 
@@ -261,9 +262,7 @@ function AddConnectorPage() {
   })
 
   // SPEC-KB-MS-DOCS-001 R4: Microsoft 365 OAuth flow, mirrors Google Drive.
-  // SharePoint site URL format. Keep this in sync with the server-side parse in ms_docs.py.
-  const MS_SITE_URL_PATTERN = /^https:\/\/[a-z0-9-]+\.sharepoint\.com\/sites\/[^/]+\/?$/
-
+  // MS_SITE_URL_PATTERN imported from @/lib/ms-docs (shared with edit-connector).
   const createMsDocsMutation = useMutation({
     mutationFn: async () => {
       // Client-side validation (R4.3) before posting.

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
@@ -13,6 +13,7 @@ import { Label } from '@/components/ui/label'
 import { MultiSelect } from '@/components/ui/multi-select'
 import * as m from '@/paraglide/messages'
 import { apiFetch } from '@/lib/apiFetch'
+import { MS_SITE_URL_PATTERN } from '@/lib/ms-docs'
 import { ASSERTION_MODE_OPTIONS } from './$kbSlug/-kb-helpers'
 import type { ConnectorSummary, GitHubConfig, WebCrawlerConfig } from './$kbSlug/-kb-types'
 
@@ -136,9 +137,6 @@ function EditConnectorPage() {
       setIsReconnecting(false)
     }
   }
-
-  // Keep in sync with add-connector.tsx MS_SITE_URL_PATTERN.
-  const MS_SITE_URL_PATTERN = /^https:\/\/[a-z0-9-]+\.sharepoint\.com\/sites\/[^/]+\/?$/
 
   function parseCookies(): unknown[] | undefined {
     const raw = wcCookies.trim()


### PR DESCRIPTION
## Summary

Follow-up cleanup pass after PR #119 shipped SPEC-KB-MS-DOCS-001. Addresses
points 2, 4, 5, 6, 8 from the post-merge review.

## Changes

- **#2** Extract \`MS_SITE_URL_PATTERN\` to \`klai-portal/frontend/src/lib/ms-docs.ts\`. Was duplicated in add-connector.tsx and edit-connector.tsx with a "keep in sync" comment
- **#4** \`ConnectorLike\` Protocol in \`oauth_base.py\` — drops \`connector: Any\` on abstract + \`ensure_token\`. Adapters override with \`ConnectorLike\`. Removes the \`cast(...)\` + \`pyright: ignore\` workaround on the rotated-refresh write
- **#5** Rekey \`MsDocsAdapter._ref_metadata\` from \`id(ref)\` (Python object id) → \`ref.ref\` (Graph driveItem id, stable). Regression test added: look up via a freshly-built DocumentRef with matching .ref but different object id
- **#6** Translate Microsoft \`invalid_grant\` → \`OAuthReconnectRequiredError\` in \`MsDocsAdapter._refresh_oauth_token\`. Typed exception for sync engines to catch and mark \`auth_error\`
- **#8** Extract \`_graph_request\` — \`_graph_get_json\` and \`_graph_get_bytes\` now share one auth + 429 retry codepath

## Skipped intentionally

- **#1** Original commit hygiene (main already pushed, not worth force-push)
- **#3** Provider-strategy-map in oauth.py (YAGNI until a 3rd provider)
- **#7** Client-secret expiry 6mo vs 24mo (user call, documented in runbook)

## Test plan

- [x] 59/59 connector tests pass (3 new regression tests for #5 + #6)
- [x] Ruff clean on all modified files
- [x] Pyright 0 errors on \`oauth_base.py\`, \`ms_docs.py\`, \`google_drive.py\`
- [x] Frontend \`tsc --noEmit\` clean

## Deployment

No runtime behavior change for the happy path. New \`OAuthReconnectRequiredError\`
is raised for Microsoft \`invalid_grant\` but no sync-engine handler consumes it
yet — propagates as an uncaught error with a clean message. Portal-side handler
wiring is a separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)