### PR TITLE
chore(portal-api): retrigger deploy for /api/perf CSRF fix

### DIFF
--- a/klai-portal/backend/app/middleware/session.py
+++ b/klai-portal/backend/app/middleware/session.py
@@ -46,7 +46,8 @@ _CSRF_EXEMPT_PREFIXES: tuple[str, ...] = (
     "/api/signup",
     "/api/health",
     "/api/public/",
-    # Web-vitals beacon: navigator.sendBeacon cannot set X-CSRF-Token.
+    # Web-vitals beacon: navigator.sendBeacon cannot set X-CSRF-Token, so the
+    # endpoint is intentionally unauthenticated and CSRF-exempt.
     "/api/perf",
     "/internal/",
     "/partner/",


### PR DESCRIPTION
Trigger workflow that did not fire on PR #134 squash-merge so portal-api gets redeployed with the /api/perf CSRF-exempt fix.