### PR TITLE
refactor(templates): canonical refresh pattern + docs consolidation

### DIFF
--- a/.claude/rules/klai/projects/portal-backend.md
+++ b/.claude/rules/klai/projects/portal-backend.md
@@ -44,27 +44,42 @@ because each call checks out a different pooled connection.
 from a prior request) serving a request for org_id=1 (getklai) filters the
 getklai user row out via RLS, and the handler raises 404.
 
-**Fix:** `_pin_and_reset_connection` (renamed from `_pin_and_reset_on_exit`)
-runs `_reset_tenant_context` at checkout, before yielding the session.
-Defense-in-depth — cleanup still runs, but checkout catches any leak from
-a prior cleanup that the suppress-blocks ate.
+**Fix (three independent layers):**
+
+1. `_pin_and_reset_connection` (renamed from `_pin_and_reset_on_exit`) runs
+   `_reset_tenant_context` at checkout, before yielding the session.
+   Cleanup-time reset still runs; checkout-time reset catches any leak from
+   a prior cleanup that the suppress-blocks ate.
+2. `PooledTenantSession` — an `AsyncSession` subclass wired into
+   `async_sessionmaker(class_=PooledTenantSession)`. Every
+   `async with AsyncSessionLocal() as s:` block auto-pins + resets on
+   `__aenter__`, so a future helper that forgets the explicit
+   `_pin_and_reset_connection` call cannot re-introduce the bug.
+3. `assert_portal_users_rls_ready()` runs in the `main.py` lifespan after
+   `install_rls_guard`. It fails loud at startup if the `portal_users`
+   `tenant_isolation` policy drops its `IS NULL` branch — without that
+   branch, every authenticated request 404s after deploy (because the
+   freshly-reset GUC makes `_get_caller_org`'s user lookup return zero rows).
 
 **Prevention:**
 - Every helper that hands out a pooled session MUST call
   `_pin_and_reset_connection(session)` before yielding. `get_db`,
-  `tenant_scoped_session`, `pin_session`, `cross_org_session` all do.
-- New RLS-protected tables: the policy MUST include the
-  `OR current_setting(...) IS NULL` branch so cleared GUCs do not
-  lock out fresh connections (unless the table is intentionally cross-
-  org-inaccessible from unset context).
-- Never query an RLS-protected table before setting the tenant context in
-  the same request. If you must, accept that the query returns all rows
-  visible under the NULL policy branch.
+  `tenant_scoped_session`, `pin_session`, `cross_org_session` all do. This
+  layers on top of the `PooledTenantSession` auto-reset — belt + braces.
+- Category-A tables (`portal_users`, `portal_connectors` — see the 4-category
+  framework in `portal-security.md`) MUST keep the `OR current_setting(...)
+  IS NULL` branch. The startup assertion guards `portal_users`; extend it
+  if a new Category-A table joins the auth path before `set_tenant` fires.
+- Never query an RLS-protected table before `_get_caller_org` / `set_tenant`
+  in the same request. With the pool reset, empty GUC = Category-A permissive
+  only; Category-D raises 42501, Category-C SELECT returns zero rows.
 
-**Verification:** `docker exec klai-core-portal-api-1 psql -U klai -d klai -c
-"SELECT application_name, state, backend_start, query FROM pg_stat_activity
-WHERE application_name LIKE '%portal-api%';"` — all idle connections should
-sit in state=idle with no pending RLS statement.
+**Verification:**
+- `docker logs klai-core-portal-api-1 | grep "RLS policy checked"` — must
+  appear once per startup. Absence means the assertion regressed.
+- Reproduce the original bug: inject a stale GUC into the pool and fire a
+  cross-tenant burst. Before the fix: mixed 200/404. After: 100% 200.
+  Repro script lives in PR #133 description.
 
 ## Prometheus metrics in tests
 - Never use the global `prometheus_client` registry in tests — causes `Duplicated timeseries`.

--- a/klai-portal/backend/app/api/app_templates.py
+++ b/klai-portal/backend/app/api/app_templates.py
@@ -30,7 +30,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.dependencies import _get_caller_org, bearer
-from app.core.database import get_db, set_tenant
+from app.core.database import get_db
 from app.models.templates import PortalTemplate
 from app.services.default_templates import ensure_default_templates
 from app.services.litellm_cache import invalidate_templates
@@ -210,8 +210,15 @@ async def create_template(
         scope=body.scope,
         created_by=zitadel_user_id,
     )
+    # CREATE pattern (see .claude/rules/klai/projects/portal-security.md —
+    # "Post-commit db.refresh on RLS tables"): flush + refresh BEFORE commit
+    # so the server-default timestamps/is_active fields are loaded while the
+    # tenant GUC is still active on the transaction. After commit, attributes
+    # persist in memory because AsyncSessionLocal uses expire_on_commit=False.
     db.add(template)
     try:
+        await db.flush()
+        await db.refresh(template)
         await db.commit()
     except IntegrityError as exc:
         await db.rollback()
@@ -219,12 +226,6 @@ async def create_template(
             status_code=status.HTTP_409_CONFLICT,
             detail=f"Er bestaat al een template met slug '{slug}' in deze organisatie",
         ) from exc
-    # SQLAlchemy expires attributes on commit. Any attribute access below
-    # (inside _template_out) triggers a lazy reload query; with RLS enabled
-    # on portal_templates the reload needs the tenant GUC re-applied after
-    # the commit released the transaction's session-level config.
-    await set_tenant(db, org.id)
-    await db.refresh(template)
 
     logger.info(
         "template_created",
@@ -311,6 +312,12 @@ async def update_template(
     if body.is_active is not None:
         template.is_active = body.is_active
 
+    # UPDATE pattern (see .claude/rules/klai/projects/portal-security.md —
+    # "Post-commit db.refresh on RLS tables"): no refresh needed. All fields
+    # above are assigned in Python; AsyncSessionLocal uses expire_on_commit=False
+    # so the ORM instance stays populated after commit. The post-commit refresh
+    # would hit RLS without the tenant GUC (transaction-scoped SET LOCAL) and
+    # raise 500 — skipping it is both safer and cheaper.
     try:
         await db.commit()
     except IntegrityError as exc:
@@ -319,10 +326,6 @@ async def update_template(
             status_code=status.HTTP_409_CONFLICT,
             detail="Er bestaat al een template met deze slug in deze organisatie",
         ) from exc
-    # Same RLS-after-commit reason as in create_template — re-set tenant
-    # GUC so the post-commit refresh query can see the row.
-    await set_tenant(db, org.id)
-    await db.refresh(template)
 
     logger.info(
         "template_updated",

--- a/klai-portal/backend/app/core/database.py
+++ b/klai-portal/backend/app/core/database.py
@@ -121,6 +121,15 @@ async def get_db() -> AsyncGenerator[AsyncSession]:
     awaits. This caused set_tenant() to set app.current_org_id on connection A
     while the next query ran on connection B (where the setting was empty),
     making RLS block all rows.
+
+    The explicit `_pin_and_reset_connection` below is intentionally double work
+    with `PooledTenantSession.__aenter__`. Rationale:
+      * Tests monkeypatch `AsyncSessionLocal` with a FakeSession that bypasses
+        `PooledTenantSession` entirely, so the explicit call is the only way
+        checkout behaviour stays covered in unit tests.
+      * The three extra SQL statements per checkout are sub-millisecond and
+        the call site makes the invariant readable without chasing a subclass.
+      * `_reset_tenant_context` is idempotent — repeating it is cheap and safe.
     """
     async with AsyncSessionLocal() as session:
         await _pin_and_reset_connection(session)

--- a/klai-portal/backend/tests/test_app_templates.py
+++ b/klai-portal/backend/tests/test_app_templates.py
@@ -94,15 +94,14 @@ async def test_post_scope_personal_as_non_admin_allowed(monkeypatch):
     )
     monkeypatch.setattr(app_templates, "_enforce_rate_limit", AsyncMock())
     monkeypatch.setattr(app_templates, "invalidate_templates", AsyncMock())
-    # Hotfix: create/update re-apply tenant GUC before post-commit refresh.
-    # Mock it out in unit tests since the DB is a MagicMock.
-    monkeypatch.setattr(app_templates, "set_tenant", AsyncMock())
 
     db = MagicMock()
     db.add = MagicMock()
+    db.flush = AsyncMock()
     db.commit = AsyncMock()
 
-    # Simulate db.refresh populating id + timestamps after the flush/commit
+    # Canonical CREATE pattern: flush + refresh run BEFORE commit, while the
+    # tenant GUC is still active on the transaction.
     async def _refresh(obj):
         obj.id = 123
         obj.slug = "x"
@@ -118,6 +117,10 @@ async def test_post_scope_personal_as_non_admin_allowed(monkeypatch):
     out = await app_templates.create_template(body=body, credentials=MagicMock(), db=db)
 
     assert out.scope == "personal"
+    # flush → refresh → commit ordering is part of the contract.
+    assert db.flush.await_count == 1
+    assert db.refresh.await_count == 1
+    assert db.commit.await_count == 1
     # Personal write → single-user invalidation, not org-wide.
     app_templates.invalidate_templates.assert_awaited_once_with(42, "lc-1")
 
@@ -134,12 +137,10 @@ async def test_post_scope_org_as_admin_triggers_org_wide_invalidate(monkeypatch)
     )
     monkeypatch.setattr(app_templates, "_enforce_rate_limit", AsyncMock())
     monkeypatch.setattr(app_templates, "invalidate_templates", AsyncMock())
-    # Hotfix: create/update re-apply tenant GUC before post-commit refresh.
-    # Mock it out in unit tests since the DB is a MagicMock.
-    monkeypatch.setattr(app_templates, "set_tenant", AsyncMock())
 
     db = MagicMock()
     db.add = MagicMock()
+    db.flush = AsyncMock()
     db.commit = AsyncMock()
 
     async def _refresh(obj):


### PR DESCRIPTION
## Summary

Cleanup pass following PRs #133 and #137. Three small things, zero behaviour change in happy path:

### 1. `create_template` / `update_template` — canonical refresh pattern

The 2026-04-23 hotfix re-applied `set_tenant(db, org.id)` between commit and refresh so the post-commit refresh could see the row through RLS. That worked but diverged from the canonical pattern documented in [`portal-security.md`](.claude/rules/klai/projects/portal-security.md):

- **CREATE**: `flush + refresh` **before** commit → server-default columns (`created_at`, `updated_at`, `is_active`, `scope`) load while the tenant GUC is still active on the transaction.
- **UPDATE**: drop the refresh entirely → `AsyncSessionLocal` uses `expire_on_commit=False`, so attributes set in Python before commit persist in memory. The post-commit refresh was pure cost **and** the exact trigger for the 500 Mark saw before the pool fix.

Drop the now-unused `set_tenant` import from `app_templates.py`.

### 2. `get_db` docstring — document intentional duplication

`_pin_and_reset_connection` in `get_db` is double work with `PooledTenantSession.__aenter__`. That's intentional:

- Unit tests monkeypatch `AsyncSessionLocal` with a FakeSession that bypasses the subclass, so the explicit call is the only way checkout behaviour stays covered in tests.
- Three extra SQL statements per checkout are sub-millisecond.
- `_reset_tenant_context` is idempotent.

Adding a docstring paragraph so a future reader doesn't "clean up" the duplication and break test coverage.

### 3. `portal-backend.md` pitfall entry

Expand the *Pool-GUC pollution* section to cover all three defense layers (checkout reset, `PooledTenantSession` subclass, startup assertion) and add a new *Post-commit db.refresh on RLS tables* section that points at the canonical pattern and explicitly calls out the \`set_tenant\`-between-commit-and-refresh anti-pattern this PR removes.

## Test plan

- [x] `tests/test_app_templates.py`: 11/11 passing. Updated CREATE tests to assert `flush → refresh → commit` ordering and removed the obsolete `set_tenant` monkeypatch.
- [x] Full backend suite: **816/816 green** (unchanged baseline).
- [x] `ruff check` + `ruff format --check`: clean.
- [ ] CI green on push.
- [ ] After deploy, exercise `/api/app/templates` PATCH — must return 200 with the updated fields in-memory (no post-commit refresh round-trip).

## Not in this PR

Mentioned during analysis, deliberately skipped:

- `portal_feedback_events` / `portal_audit_log` / `product_events` RLS policies missing `IS NULL`: these are **Category C** (INSERT permissive, SELECT scoped) per the 4-category framework in `portal-security.md`. No Python SELECT paths hit them without a tenant context active. Not a bug.
- Removing explicit `_pin_and_reset_connection` from other helpers (`tenant_scoped_session`, `cross_org_session`): same test-coverage reason as `get_db`.