### PR TITLE
feat(portal): surface add-source entry from every KB view

### DIFF
--- a/klai-portal/frontend/messages/en.json
+++ b/klai-portal/frontend/messages/en.json
@@ -631,6 +631,7 @@
   "knowledge_detail_delete_confirm_title": "Delete knowledge base?",
   "knowledge_detail_delete_confirm_body": "This will permanently delete \"{name}\" and all its documents and connectors. This cannot be undone.",
   "knowledge_detail_delete_confirm_action": "Yes, delete",
+  "knowledge_detail_add_source": "Add",
   "knowledge_detail_tab_overview": "Overview",
   "knowledge_detail_tab_connectors": "Connectors",
   "knowledge_detail_tab_members": "Access",

--- a/klai-portal/frontend/messages/nl.json
+++ b/klai-portal/frontend/messages/nl.json
@@ -631,6 +631,7 @@
   "knowledge_detail_delete_confirm_title": "Kennisbank verwijderen?",
   "knowledge_detail_delete_confirm_body": "Dit verwijdert \"{name}\" permanent, inclusief alle documenten en connectoren. Dit kan niet ongedaan worden gemaakt.",
   "knowledge_detail_delete_confirm_action": "Ja, verwijderen",
+  "knowledge_detail_add_source": "Toevoegen",
   "knowledge_detail_tab_overview": "Overzicht",
   "knowledge_detail_tab_connectors": "Connectoren",
   "knowledge_detail_tab_members": "Toegang",

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/connectors.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/connectors.tsx
@@ -212,7 +212,7 @@ function ConnectorsTab() {
       )}
 
       {isOwner && (
-        <Button size="sm" variant="outline" onClick={() => void navigate({ to: '/app/knowledge/$kbSlug/add-connector', params: { kbSlug } })}>
+        <Button size="sm" variant="outline" onClick={() => void navigate({ to: '/app/knowledge/$kbSlug/add-source', params: { kbSlug } })}>
           <Plus className="h-4 w-4 mr-1" />
           {m.admin_connectors_add_button()}
         </Button>

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/route.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/route.tsx
@@ -2,7 +2,7 @@ import { createFileRoute, Link, Outlet, redirect } from '@tanstack/react-router'
 import { useAuth } from '@/lib/auth'
 import { useQuery } from '@tanstack/react-query'
 import {
-  Globe, Lock, Shield, BarChart2, Zap, List, FolderTree, Settings, SlidersHorizontal, ArrowLeft
+  Globe, Lock, Shield, BarChart2, Zap, List, FolderTree, Settings, SlidersHorizontal, ArrowLeft, Plus
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -154,6 +154,12 @@ function KbLayout() {
           </div>
         </div>
         <div className="flex items-center gap-2">
+          <Button size="sm" asChild>
+            <Link to="/app/knowledge/$kbSlug/add-source" params={{ kbSlug }}>
+              <Plus className="h-4 w-4 mr-2" />
+              {m.knowledge_detail_add_source()}
+            </Link>
+          </Button>
           <Button variant="ghost" size="sm" asChild>
             <Link to="/app/knowledge">
               <ArrowLeft className="h-4 w-4 mr-2" />


### PR DESCRIPTION
## Summary

The unified add-source grid was reachable only via the Items tab. Fix:

- KB header: new primary Add button (visible on every sub-tab) → /add-source
- Connectors tab Add button → /add-source (was going directly to /add-connector)

## Test plan
- [x] ESLint clean
- [x] tsc -b --noEmit clean
- [x] Paraglide recompiled
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)