### PR TITLE
fix(portal-api): close session on PooledTenantSession checkout failure

### DIFF
--- a/klai-portal/backend/app/core/database.py
+++ b/klai-portal/backend/app/core/database.py
@@ -41,7 +41,17 @@ class PooledTenantSession(AsyncSession):
 
     async def __aenter__(self) -> AsyncSession:  # type: ignore[override]
         session = await super().__aenter__()
-        await _pin_and_reset_connection(session)
+        try:
+            await _pin_and_reset_connection(session)
+        except BaseException:
+            # Pin/reset raised (e.g. asyncpg connection error during pin, or an
+            # unsuppressed failure in _reset_tenant_context). The caller never
+            # enters the `async with` body, so `__aexit__` does not fire. Close
+            # the session explicitly so its pooled connection returns to the
+            # pool instead of leaking with indeterminate GUC state. Using
+            # BaseException also covers KeyboardInterrupt / SystemExit.
+            await session.close()
+            raise
         return session
 
 

--- a/klai-portal/backend/tests/test_tenant_context_reset.py
+++ b/klai-portal/backend/tests/test_tenant_context_reset.py
@@ -326,6 +326,41 @@ def test_pooled_tenant_session_is_the_configured_class() -> None:
     assert db_module.AsyncSessionLocal.class_ is db_module.PooledTenantSession
 
 
+@pytest.mark.asyncio
+async def test_pooled_tenant_session_closes_on_checkout_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If `_pin_and_reset_connection` raises in `__aenter__`, the session MUST
+    be closed before the exception propagates. Otherwise the caller never
+    enters the `async with` body, `__aexit__` never fires, and the pooled
+    connection leaks back to the pool with indeterminate GUC state.
+    """
+
+    async def boom(_session: object) -> None:
+        raise RuntimeError("simulated pin/reset failure at checkout")
+
+    monkeypatch.setattr(db_module, "_pin_and_reset_connection", boom)
+
+    close_calls: list[object] = []
+    orig_close = db_module.AsyncSession.close
+
+    async def tracking_close(self: db_module.AsyncSession) -> None:
+        close_calls.append(self)
+        await orig_close(self)
+
+    monkeypatch.setattr(db_module.AsyncSession, "close", tracking_close)
+
+    with pytest.raises(RuntimeError, match="simulated pin/reset failure"):
+        async with db_module.AsyncSessionLocal() as _:
+            # Never reached — checkout raises.
+            pass
+
+    # Exactly one session was opened (by super().__aenter__) and it must have
+    # been closed by our error-path cleanup. Zero close calls means the
+    # connection is leaked with whatever GUC state it had on checkout.
+    assert len(close_calls) == 1, f"session must be closed on checkout failure; got {len(close_calls)} close() calls"
+
+
 # ---------------------------------------------------------------------------
 # assert_portal_users_rls_ready — startup fail-loud on broken policy
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Found while re-reviewing the recent pool-reset work through the lens 6 ("Middleware Order & Exception Paths") of the `klai-security-audit` agent: `PooledTenantSession.__aenter__` leaks the pooled connection if `_pin_and_reset_connection` raises during checkout.

## The leak

```python
async def __aenter__(self):
    session = await super().__aenter__()   # opens session
    await _pin_and_reset_connection(session)  # if this raises, we return without closing
    return session
```

If `_pin_and_reset_connection` raises (e.g. asyncpg connection error during the `session.connection()` pin, or any future unsuppressed failure in `_reset_tenant_context`), the exception propagates before `__aenter__` returns. The caller's `async with` body never enters, so `__aexit__` never fires. The session stays open and its pooled connection is checked out forever.

Under repeated checkout failures this drains `pool_size + max_overflow` and the process eventually deadlocks. No production incident has triggered this yet — found post-hoc during adversarial review.

## Reproduction (verified on the live container)

```
$ docker exec klai-core-portal-api-1 python -c 'reproducer...'
exception propagated: simulated checkout failure
session.close() called: 0 times
```

Expected: `close() called: 1 times`.

## Fix

```python
async def __aenter__(self):
    session = await super().__aenter__()
    try:
        await _pin_and_reset_connection(session)
    except BaseException:
        await session.close()
        raise
    return session
```

`BaseException` catches KeyboardInterrupt / SystemExit too, which is what we want for pool hygiene.

## Test plan

- [x] New regression test `test_pooled_tenant_session_closes_on_checkout_failure` patches both `_pin_and_reset_connection` (to raise) and `AsyncSession.close` (to count calls) and asserts exactly one close call fires on the error path.
- [x] 15/15 in `tests/test_tenant_context_reset.py` (was 14).
- [x] Full backend suite: **817/817 green** (was 816).
- [x] `ruff check` + `ruff format --check`: clean.
- [ ] CI green on push.

## Companion to

PR #133 (checkout reset), PR #137 (defense-in-depth), PR #141 (refresh pattern cleanup). Completes the hardening pass started by the 2026-04-24 getklai incident.