### PR TITLE
fix(templates): flush+refresh+commit on PATCH (onupdate lazy-load 500)

### DIFF
--- a/klai-portal/backend/app/api/app_templates.py
+++ b/klai-portal/backend/app/api/app_templates.py
@@ -313,12 +313,19 @@ async def update_template(
         template.is_active = body.is_active
 
     # UPDATE pattern (see .claude/rules/klai/projects/portal-security.md —
-    # "Post-commit db.refresh on RLS tables"): no refresh needed. All fields
-    # above are assigned in Python; AsyncSessionLocal uses expire_on_commit=False
-    # so the ORM instance stays populated after commit. The post-commit refresh
-    # would hit RLS without the tenant GUC (transaction-scoped SET LOCAL) and
-    # raise 500 — skipping it is both safer and cheaper.
+    # "Post-commit db.refresh on RLS tables"). Flush + refresh BEFORE commit,
+    # same as the CREATE path. The generic rule ("drop refresh entirely for
+    # UPDATE") assumes every mutated column stays Python-assigned, but
+    # `PortalTemplate.updated_at` has `onupdate=func.now()` — SQLAlchemy
+    # generates the new timestamp server-side and marks the attribute as
+    # expired after flush. Without a refresh, `_template_out` touches
+    # `template.updated_at` and triggers a lazy SELECT that fires outside the
+    # async greenlet context → `sqlalchemy.exc.MissingGreenlet` → HTTP 500.
+    # The refresh runs inside the tenant-scoped transaction so RLS still sees
+    # the row.
     try:
+        await db.flush()
+        await db.refresh(template)
         await db.commit()
     except IntegrityError as exc:
         await db.rollback()

--- a/klai-portal/backend/tests/test_app_templates.py
+++ b/klai-portal/backend/tests/test_app_templates.py
@@ -259,6 +259,51 @@ async def test_patch_by_non_owner_non_admin_returns_403(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_patch_happy_path_flushes_and_refreshes_before_commit(monkeypatch):
+    """Regression: `PortalTemplate.updated_at` has `onupdate=func.now()`, which
+    SQLAlchemy expires after flush. Without a refresh, `_template_out` later
+    triggers a lazy SELECT that fires outside the greenlet context and raises
+    `MissingGreenlet` (observed in production 2026-04-24 as HTTP 500 on
+    PATCH /api/app/templates/klantenservice2).
+
+    This test locks the flush → refresh → commit ordering so a future cleanup
+    cannot re-introduce the same bug.
+    """
+    from app.api import app_templates
+
+    monkeypatch.setattr(
+        app_templates,
+        "_get_caller_org",
+        AsyncMock(return_value=_mock_caller(role="admin", zitadel_user_id="user-1")),
+    )
+    monkeypatch.setattr(app_templates, "_enforce_rate_limit", AsyncMock())
+    monkeypatch.setattr(app_templates, "invalidate_templates", AsyncMock())
+    template = _mock_template(created_by="user-1", scope="org", slug="klantenservice")
+    monkeypatch.setattr(app_templates, "_get_template_or_404", AsyncMock(return_value=template))
+
+    call_order: list[str] = []
+    db = MagicMock()
+    db.flush = AsyncMock(side_effect=lambda: call_order.append("flush"))
+
+    async def _refresh(obj):
+        call_order.append("refresh")
+        # Simulate server-side updated_at being re-populated.
+        obj.updated_at = datetime(2026, 4, 24, 14, 0, 0)
+
+    db.refresh = AsyncMock(side_effect=_refresh)
+    db.commit = AsyncMock(side_effect=lambda: call_order.append("commit"))
+
+    body = app_templates.TemplatePatch(name="Klantenservice 2")
+    out = await app_templates.update_template(slug="klantenservice", body=body, credentials=MagicMock(), db=db)
+
+    # flush MUST precede refresh MUST precede commit, so the refresh SELECT
+    # runs inside the tenant-scoped transaction.
+    assert call_order == ["flush", "refresh", "commit"], call_order
+    # Response carries the new slug derived from the renamed template.
+    assert out.slug == "klantenservice-2"
+
+
+@pytest.mark.asyncio
 async def test_patch_promoting_personal_to_org_requires_admin(monkeypatch):
     """REQ-TEMPLATES-CRUD-E1 applies on PATCH too: promoting to scope='org' needs admin."""
     from app.api import app_templates


### PR DESCRIPTION
## Production 500 from PR #141 cleanup

Mark reported `PATCH /api/app/templates/klantenservice2` returned 500 with:

\`\`\`
sqlalchemy.exc.MissingGreenlet: greenlet_spawn has not been called;
can't call await_only() here. Was IO attempted in an unexpected place?
\`\`\`

## Root cause

\`PortalTemplate.updated_at\` has \`onupdate=func.now()\`. SQLAlchemy marks that attribute as expired after flush. \`expire_on_commit=False\` only prevents the bulk-expiry-on-commit path; per-column expiry triggered by \`onupdate\` is independent. \`_template_out(template)\` then touches \`template.updated_at\` after commit → lazy SELECT → outside greenlet → 500.

PR #141 followed the generic \`portal-security.md\` rule ("UPDATE: drop refresh entirely") without accounting for server-generated columns.

## Fix

Use the same \`flush → refresh → commit\` pattern as the CREATE path:

\`\`\`python
try:
    await db.flush()
    await db.refresh(template)  # pulls server-side updated_at inside tenant tx
    await db.commit()
except IntegrityError as exc:
    ...
\`\`\`

## Tests

- [x] New regression test \`test_patch_happy_path_flushes_and_refreshes_before_commit\` locks flush → refresh → commit ordering.
- [x] 12/12 in tests/test_app_templates.py.
- [ ] Playwright e2e on getklai tenant after deploy.