### PR TITLE
refactor(connectors): reconnect flow polish — DRY helper, tests, proper CTA, events, feedback

### DIFF
--- a/klai-connector/app/adapters/google_drive.py
+++ b/klai-connector/app/adapters/google_drive.py
@@ -39,7 +39,7 @@ from typing import Any
 import httpx
 
 from app.adapters.base import BaseAdapter, DocumentRef
-from app.adapters.oauth_base import ConnectorLike, OAuthAdapterBase, OAuthReconnectRequiredError
+from app.adapters.oauth_base import ConnectorLike, OAuthAdapterBase, check_invalid_grant_and_raise
 from app.core.config import Settings
 from app.core.logging import get_logger
 from app.services.portal_client import PortalClient
@@ -217,25 +217,12 @@ class GoogleDriveAdapter(OAuthAdapterBase, BaseAdapter):
         }
         async with httpx.AsyncClient(timeout=10.0) as client:
             response = await client.post(_GOOGLE_TOKEN_URL, data=payload)
-            # Google returns 400 + JSON body with error=invalid_grant when the
-            # refresh_token is permanently invalid. Translate to a typed
-            # signal so sync_engine can catch it specifically and mark the
-            # connector AUTH_ERROR instead of the generic FAILED. See:
-            # https://developers.google.com/identity/protocols/oauth2#expiration
-            if response.status_code == 400:
-                try:
-                    body = response.json()
-                except ValueError:
-                    body = {}
-                if isinstance(body, dict) and body.get("error") == "invalid_grant":
-                    logger.warning(
-                        "Google invalid_grant for connector=%s — reconnect required",
-                        str(connector.id),
-                    )
-                    raise OAuthReconnectRequiredError(
-                        f"Google refresh_token rejected (connector_id={connector.id}): "
-                        f"{body.get('error_description', 'invalid_grant')}"
-                    )
+            # Shared helper translates 400 + error=invalid_grant to a typed
+            # OAuthReconnectRequiredError; other 400s fall through to
+            # raise_for_status (generic HTTPStatusError).
+            check_invalid_grant_and_raise(
+                response, provider="Google", connector_id=connector.id,
+            )
             response.raise_for_status()
             data = response.json()
         return data if isinstance(data, dict) else {}

--- a/klai-connector/app/adapters/ms_docs.py
+++ b/klai-connector/app/adapters/ms_docs.py
@@ -46,7 +46,11 @@ from urllib.parse import quote, urlparse
 import httpx
 
 from app.adapters.base import BaseAdapter, DocumentRef
-from app.adapters.oauth_base import ConnectorLike, OAuthAdapterBase, OAuthReconnectRequiredError
+from app.adapters.oauth_base import (
+    ConnectorLike,
+    OAuthAdapterBase,
+    check_invalid_grant_and_raise,
+)
 from app.core.config import Settings
 from app.core.logging import get_logger
 from app.services.portal_client import PortalClient
@@ -165,24 +169,12 @@ class MsDocsAdapter(OAuthAdapterBase, BaseAdapter):
         token_url = _ms_token_url(self._settings.ms_docs_tenant_id)
         async with httpx.AsyncClient(timeout=10.0) as client:
             response = await client.post(token_url, data=payload)
-            # Microsoft returns 400 + JSON body with error=invalid_grant when
-            # the refresh_token is permanently invalid. Translate to a clean
-            # signal before raising a generic HTTPStatusError. See MS docs:
-            # https://learn.microsoft.com/en-us/entra/identity-platform/reference-error-codes
-            if response.status_code == 400:
-                try:
-                    body = response.json()
-                except ValueError:
-                    body = {}
-                if isinstance(body, dict) and body.get("error") == "invalid_grant":
-                    logger.warning(
-                        "Microsoft invalid_grant for connector=%s — reconnect required",
-                        str(connector.id),
-                    )
-                    raise OAuthReconnectRequiredError(
-                        f"Microsoft refresh_token rejected (connector_id={connector.id}): "
-                        f"{body.get('error_description', 'invalid_grant')}"
-                    )
+            # Shared helper translates 400 + error=invalid_grant to a typed
+            # OAuthReconnectRequiredError; other 400s fall through to
+            # raise_for_status (generic HTTPStatusError).
+            check_invalid_grant_and_raise(
+                response, provider="Microsoft", connector_id=connector.id,
+            )
             response.raise_for_status()
             data = response.json()
         if not isinstance(data, dict):

--- a/klai-connector/app/adapters/oauth_base.py
+++ b/klai-connector/app/adapters/oauth_base.py
@@ -74,6 +74,53 @@ class OAuthReconnectRequiredError(RuntimeError):
     """
 
 
+def check_invalid_grant_and_raise(
+    response: Any,  # httpx.Response; Any here to avoid circular imports in type-only usage.
+    *,
+    provider: str,
+    connector_id: Any,
+) -> None:
+    """Translate a provider ``invalid_grant`` response to ``OAuthReconnectRequiredError``.
+
+    Both Microsoft Graph and Google Identity return HTTP 400 with a JSON body
+    ``{"error": "invalid_grant", "error_description": "..."}`` when the stored
+    refresh_token is permanently invalid (password change, consent revoke,
+    extended inactivity, post-grace rotation). All OAuth adapters translate
+    that specific response into the typed ``OAuthReconnectRequiredError`` so
+    the sync engine can mark the connector ``AUTH_ERROR`` and the portal can
+    surface a "Reconnect <provider>" affordance.
+
+    Args:
+        response: The ``httpx.Response`` from the provider token endpoint.
+            Must have ``status_code`` and ``json()``.
+        provider: Human-readable provider name for logs + error message
+            (e.g. ``"Microsoft"``, ``"Google"``).
+        connector_id: Used in the exception message only; never logged alone.
+
+    Raises:
+        OAuthReconnectRequiredError: When the response is a 400 +
+            ``error=invalid_grant``. Other responses are left for the caller
+            to handle (typically via ``response.raise_for_status()``).
+    """
+    if response.status_code != 400:
+        return
+    try:
+        body = response.json()
+    except ValueError:
+        body = {}
+    if not isinstance(body, dict) or body.get("error") != "invalid_grant":
+        return
+    logger.warning(
+        "%s invalid_grant for connector=%s — reconnect required",
+        provider,
+        str(connector_id),
+    )
+    raise OAuthReconnectRequiredError(
+        f"{provider} refresh_token rejected (connector_id={connector_id}): "
+        f"{body.get('error_description', 'invalid_grant')}"
+    )
+
+
 class OAuthAdapterBase(ABC):
     """Base class contributing OAuth token management to adapters.
 

--- a/klai-connector/tests/test_sync_engine_reconnect.py
+++ b/klai-connector/tests/test_sync_engine_reconnect.py
@@ -1,0 +1,185 @@
+"""Integration test for SyncEngine's OAuthReconnectRequiredError handling.
+
+SPEC-KB-MS-DOCS-001 reconnect-signal: when an OAuth adapter raises
+``OAuthReconnectRequiredError`` during a sync run, the engine must
+report ``sync_status=AUTH_ERROR`` to the portal so the UI can surface
+the Reconnect affordance.
+
+This test mocks the heavy dependencies (portal client, session maker,
+registry) and exercises only the catch path that translates the typed
+exception into ``SyncStatus.AUTH_ERROR``.
+"""
+
+# ruff: noqa: S106  -- test-only placeholder token strings
+
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.adapters.oauth_base import OAuthReconnectRequiredError
+from app.core.enums import SyncStatus
+from app.services.portal_client import PortalConnectorConfig
+from app.services.sync_engine import SyncEngine
+
+
+def _portal_config(connector_type: str = "ms_docs") -> PortalConnectorConfig:
+    """Minimal PortalConnectorConfig for a sync run."""
+    return PortalConnectorConfig(
+        connector_id="conn-uuid-reconnect",
+        kb_id=1,
+        kb_slug="test-kb",
+        zitadel_org_id="org-123",
+        connector_type=connector_type,
+        config={"refresh_token": "placeholder-dead-refresh"},
+        schedule=None,
+        is_enabled=True,
+    )
+
+
+def _mock_session_maker(sync_run: MagicMock) -> Any:
+    """Build a mock async_sessionmaker() that yields a session with
+    ``.get(SyncRun, id)`` returning the provided sync_run.
+
+    SyncEngine uses ``async with self._session_maker() as session`` and
+    inside that reads ``sync_run = await session.get(SyncRun, sync_run_id)``.
+    """
+    session = AsyncMock()
+    session.get = AsyncMock(return_value=sync_run)
+    session.commit = AsyncMock()
+    # _get_last_successful_run / _get_last_pending_run call session.execute
+    scalars = MagicMock()
+    scalars.scalar_one_or_none = MagicMock(return_value=None)
+    exec_result = MagicMock()
+    exec_result.scalars = MagicMock(return_value=scalars)
+    session.execute = AsyncMock(return_value=exec_result)
+
+    @asynccontextmanager
+    async def _ctx() -> Any:
+        yield session
+
+    return MagicMock(side_effect=_ctx), session
+
+
+@pytest.mark.asyncio
+async def test_oauth_reconnect_required_marks_run_auth_error() -> None:
+    """Adapter raises OAuthReconnectRequiredError → sync_run + report_sync_status use AUTH_ERROR.
+
+    Guards the sole wiring contract between the OAuth-adapter layer and
+    the portal connector-status surface: without this translation the
+    UI never sees the reconnect affordance and users are stuck.
+    """
+    sync_run = MagicMock()
+    sync_run.status = SyncStatus.PENDING
+    sync_run.cursor_state = None
+    sync_run.error_details = None
+    sync_run.quality_status = None
+
+    session_maker_mock, _session = _mock_session_maker(sync_run)
+
+    portal_client = MagicMock()
+    portal_client.get_connector_config = AsyncMock(return_value=_portal_config())
+    portal_client.report_sync_status = AsyncMock()
+
+    # Adapter whose first call inside the try-block raises the typed error.
+    # run_sync calls get_cursor_state first (line ~195 in sync_engine.py).
+    adapter = MagicMock()
+    adapter.get_cursor_state = AsyncMock(
+        side_effect=OAuthReconnectRequiredError(
+            "Microsoft refresh_token rejected (connector_id=conn-uuid-reconnect): "
+            "AADSTS700082: refresh token expired"
+        ),
+    )
+
+    registry = MagicMock()
+    registry.get = MagicMock(return_value=adapter)
+
+    ingest_client = MagicMock()
+    ingest_client.ingest = AsyncMock()
+    crawl_sync_client = MagicMock()
+
+    engine = SyncEngine(
+        session_maker=session_maker_mock,
+        registry=registry,
+        ingest_client=ingest_client,
+        portal_client=portal_client,
+        image_store=None,
+        crawl_sync_client=crawl_sync_client,
+    )
+
+    # Act: run a sync that will hit the OAuthReconnectRequiredError path.
+    connector_id = uuid.UUID("12345678-1234-5678-1234-567812345678")
+    sync_run_id = uuid.UUID("87654321-4321-8765-4321-876543218765")
+    await engine.run_sync(connector_id, sync_run_id)
+
+    # Assert: the sync_run object gets AUTH_ERROR status
+    assert sync_run.status == SyncStatus.AUTH_ERROR, (
+        f"expected AUTH_ERROR status on sync_run, got {sync_run.status}"
+    )
+
+    # Assert: report_sync_status is called with AUTH_ERROR
+    portal_client.report_sync_status.assert_awaited_once()
+    kwargs = portal_client.report_sync_status.await_args.kwargs
+    assert kwargs["sync_status"] == SyncStatus.AUTH_ERROR
+    assert kwargs["connector_id"] == connector_id
+    assert kwargs["sync_run_id"] == sync_run_id
+
+    # Assert: error_details carries the reconnect_required reason so downstream
+    # consumers can distinguish this from a generic auth failure.
+    error_details = kwargs.get("error_details") or []
+    assert any(
+        isinstance(e, dict) and e.get("reason") == "reconnect_required"
+        for e in error_details
+    ), f"expected reason=reconnect_required in error_details, got {error_details!r}"
+
+
+@pytest.mark.asyncio
+async def test_generic_exception_falls_through_to_failed_not_auth_error() -> None:
+    """A non-OAuth exception still ends up as FAILED, not AUTH_ERROR.
+
+    Regression guard: the except-clause ordering matters. If someone
+    accidentally moves ``except OAuthReconnectRequiredError`` *after*
+    ``except Exception``, every OAuth reconnect would silently become
+    FAILED and the Reconnect UI never surfaces.
+    """
+    sync_run = MagicMock()
+    sync_run.status = SyncStatus.PENDING
+    sync_run.cursor_state = None
+    sync_run.error_details = None
+    sync_run.quality_status = None
+
+    session_maker_mock, _session = _mock_session_maker(sync_run)
+
+    portal_client = MagicMock()
+    portal_client.get_connector_config = AsyncMock(return_value=_portal_config())
+    portal_client.report_sync_status = AsyncMock()
+
+    adapter = MagicMock()
+    adapter.get_cursor_state = AsyncMock(side_effect=RuntimeError("unrelated boom"))
+
+    registry = MagicMock()
+    registry.get = MagicMock(return_value=adapter)
+
+    engine = SyncEngine(
+        session_maker=session_maker_mock,
+        registry=registry,
+        ingest_client=MagicMock(ingest=AsyncMock()),
+        portal_client=portal_client,
+        image_store=None,
+        crawl_sync_client=MagicMock(),
+    )
+
+    await engine.run_sync(
+        uuid.UUID("12345678-1234-5678-1234-567812345678"),
+        uuid.UUID("87654321-4321-8765-4321-876543218765"),
+    )
+
+    portal_client.report_sync_status.assert_awaited_once()
+    kwargs = portal_client.report_sync_status.await_args.kwargs
+    assert kwargs["sync_status"] == SyncStatus.FAILED, (
+        "generic exception must not be treated as AUTH_ERROR — except ordering matters"
+    )

--- a/klai-portal/backend/app/api/oauth.py
+++ b/klai-portal/backend/app/api/oauth.py
@@ -36,6 +36,7 @@ from app.core.database import get_db, set_tenant
 from app.models.connectors import PortalConnector
 from app.models.portal import PortalUser
 from app.services.connector_credentials import credential_store
+from app.services.events import emit_event
 
 logger = logging.getLogger(__name__)
 
@@ -258,6 +259,14 @@ async def callback_provider(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Connector not found")
     await set_tenant(db, connector.org_id)
 
+    # Detect reconnect-flow: connector already had encrypted credentials AND
+    # was in auth_error. Used below to emit connector.reconnected for
+    # observability (distinguish successful recoveries from initial setups).
+    was_reconnect = (
+        connector.encrypted_credentials is not None
+        and (connector.last_sync_status or "").lower() == "auth_error"
+    )
+
     # 3. Exchange authorization code for tokens. NEVER log the response body.
     token_url: str
     token_payload: dict[str, Any]
@@ -323,7 +332,22 @@ async def callback_provider(
     )
     connector.encrypted_credentials = encrypted_blob
     connector.config = redacted_config
+    # Clear auth_error so the badge + Reconnect CTA disappear on the next list
+    # query. sync_engine will overwrite this again on the next run; clearing
+    # here is a best-effort UX improvement so users aren't left staring at a
+    # red badge immediately after a successful reconnect.
+    if was_reconnect:
+        connector.last_sync_status = None
     await db.commit()
+
+    # Observability: successful re-consent recovery from auth_error is a
+    # different signal from first-time connector setup. emit both separately.
+    emit_event(
+        "connector.reconnected" if was_reconnect else "connector.connected",
+        org_id=connector.org_id,
+        user_id=user_id,
+        properties={"provider": provider, "connector_id": str(connector.id)},
+    )
 
     logger.info(
         "oauth_callback_success: provider=%s connector_id=%s",

--- a/klai-portal/backend/app/api/oauth.py
+++ b/klai-portal/backend/app/api/oauth.py
@@ -263,8 +263,7 @@ async def callback_provider(
     # was in auth_error. Used below to emit connector.reconnected for
     # observability (distinguish successful recoveries from initial setups).
     was_reconnect = (
-        connector.encrypted_credentials is not None
-        and (connector.last_sync_status or "").lower() == "auth_error"
+        connector.encrypted_credentials is not None and (connector.last_sync_status or "").lower() == "auth_error"
     )
 
     # 3. Exchange authorization code for tokens. NEVER log the response body.

--- a/klai-portal/frontend/messages/en.json
+++ b/klai-portal/frontend/messages/en.json
@@ -988,6 +988,7 @@
   "admin_connectors_status_failed": "Failed",
   "admin_connectors_status_auth_error": "Auth error",
   "admin_connectors_reconnect_action": "Reconnect",
+  "admin_connectors_reconnect_error": "Reconnect failed. Please try again.",
   "admin_connectors_status_never": "Never synced",
   "admin_connectors_type_github": "GitHub",
   "admin_connectors_type_google_drive": "Google Drive",

--- a/klai-portal/frontend/messages/nl.json
+++ b/klai-portal/frontend/messages/nl.json
@@ -988,6 +988,7 @@
   "admin_connectors_status_failed": "Mislukt",
   "admin_connectors_status_auth_error": "Authenticatiefout",
   "admin_connectors_reconnect_action": "Opnieuw verbinden",
+  "admin_connectors_reconnect_error": "Opnieuw verbinden mislukt. Probeer het nog eens.",
   "admin_connectors_status_never": "Nooit gesynchroniseerd",
   "admin_connectors_type_github": "GitHub",
   "admin_connectors_type_google_drive": "Google Drive",

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/connectors.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/connectors.tsx
@@ -30,14 +30,17 @@ export const Route = createFileRoute('/app/knowledge/$kbSlug/connectors')({
   component: ConnectorsTab,
 })
 
-type ConnectorTypeInfo = { label: string; IconComponent: React.ComponentType<{ className?: string }> }
+type ConnectorTypeInfo = { label: () => string; IconComponent: React.ComponentType<{ className?: string }> }
 
+// Paraglide message functions — keeps the type labels i18n-driven instead of
+// hard-coded strings. The key on the right is the Paraglide-generated function
+// (see klai-portal/frontend/messages/*.json).
 const CONNECTOR_TYPE_MAP: Record<string, ConnectorTypeInfo> = {
-  github:       { label: 'GitHub',       IconComponent: SiGithub },
-  web_crawler:  { label: 'Web',          IconComponent: Globe },
-  notion:       { label: 'Notion',       IconComponent: SiNotion },
-  google_drive: { label: 'Google Drive', IconComponent: SiGoogledrive },
-  ms_docs:      { label: 'Office 365',   IconComponent: FileText },
+  github:       { label: m.admin_connectors_type_github,       IconComponent: SiGithub },
+  web_crawler:  { label: m.admin_connectors_type_website,      IconComponent: Globe },
+  notion:       { label: m.admin_connectors_type_notion,       IconComponent: SiNotion },
+  google_drive: { label: m.admin_connectors_type_google_drive, IconComponent: SiGoogledrive },
+  ms_docs:      { label: m.admin_connectors_type_ms_docs,      IconComponent: FileText },
 }
 
 /** OAuth-backed connector types that support the /api/oauth/{provider}/authorize reconnect flow. */
@@ -59,6 +62,11 @@ function ConnectorsTab() {
     }
   }, [oauth])
   const [syncingIds, setSyncingIds] = useState<Set<string>>(new Set())
+  // Per-connector reconnect state: tracks which connector is mid-redirect and
+  // which failed so the UI can show a spinner / error message without stale
+  // state bleeding to other rows.
+  const [reconnectingId, setReconnectingId] = useState<string | null>(null)
+  const [reconnectErrorId, setReconnectErrorId] = useState<string | null>(null)
 
   const { data: kb } = useQuery<KnowledgeBase>({
     queryKey: ['app-knowledge-base', kbSlug],
@@ -114,16 +122,21 @@ function ConnectorsTab() {
   // recovers by triggering a fresh OAuth authorize flow — same endpoint
   // the add-connector and edit-connector pages use.
   async function handleReconnect(connectorType: string, connectorId: string) {
+    setReconnectErrorId(null)
+    setReconnectingId(connectorId)
     try {
       const { authorize_url } = await apiFetch<{ authorize_url: string }>(
         `/api/oauth/${encodeURIComponent(connectorType)}/authorize?kb_slug=${encodeURIComponent(kbSlug)}&connector_id=${encodeURIComponent(connectorId)}`,
       )
-      // Use .assign() not `.href =` — react-hooks/immutability flags the
-      // assignment as a modification of a component-external variable.
-      // Functionally equivalent (both navigate + push history entry).
       window.location.assign(authorize_url)
+      // Intentionally don't clear `reconnectingId` on success: the navigation
+      // unmounts this tree, so the spinner stays visible until the redirect
+      // completes (vs. briefly flashing back to the Reconnect button).
     } catch {
-      // Surface stale status via refetch; user sees the badge unchanged.
+      setReconnectingId(null)
+      setReconnectErrorId(connectorId)
+      // Also refetch in case the error was a stale-session 401 — the
+      // connectors list will refresh with up-to-date status.
       void queryClient.invalidateQueries({ queryKey: ['kb-connectors-portal', kbSlug] })
     }
   }
@@ -164,7 +177,7 @@ function ConnectorsTab() {
             {connectors.map((c) => {
               const info = CONNECTOR_TYPE_MAP[c.connector_type]
               const Icon = info?.IconComponent ?? FileText
-              const typeLabel = info?.label ?? c.connector_type
+              const typeLabel = info?.label() ?? c.connector_type
               const isSyncing = syncingIds.has(c.id)
               const isRunning = c.last_sync_status?.toUpperCase() === 'RUNNING'
               return (
@@ -185,13 +198,25 @@ function ConnectorsTab() {
                     {isOwner
                       && c.last_sync_status?.toUpperCase() === 'AUTH_ERROR'
                       && OAUTH_RECONNECTABLE.has(c.connector_type) && (
-                      <button
-                        type="button"
-                        onClick={() => void handleReconnect(c.connector_type, c.id)}
-                        className="mt-1 block text-xs text-[var(--color-rl-accent-dark)] underline underline-offset-2 hover:opacity-70"
-                      >
-                        {m.admin_connectors_reconnect_action()}
-                      </button>
+                      <div className="mt-1.5 space-y-1">
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          disabled={reconnectingId === c.id}
+                          onClick={() => void handleReconnect(c.connector_type, c.id)}
+                          className="h-7 text-xs"
+                        >
+                          {reconnectingId === c.id ? (
+                            <Loader2 className="h-3 w-3 animate-spin" />
+                          ) : null}
+                          {m.admin_connectors_reconnect_action()}
+                        </Button>
+                        {reconnectErrorId === c.id && (
+                          <p className="text-xs text-[var(--color-destructive)]">
+                            {m.admin_connectors_reconnect_error()}
+                          </p>
+                        )}
+                      </div>
                     )}
                     {c.last_sync_documents_ok != null && c.last_sync_documents_ok > 0 && (
                       <p className="mt-0.5 text-xs text-[var(--color-muted-foreground)] tabular-nums">

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
@@ -269,7 +269,9 @@ function AddConnectorPage() {
     },
     onSuccess: ({ authorizeUrl }) => {
       void queryClient.invalidateQueries({ queryKey: ['kb-connectors-portal', kbSlug] })
-      window.location.href = authorizeUrl
+      // .assign() over `.href =` — consistent with connectors.tsx reconnect flow;
+      // react-hooks/immutability flags the property-assignment form.
+      window.location.assign(authorizeUrl)
     },
   })
 
@@ -302,7 +304,9 @@ function AddConnectorPage() {
     },
     onSuccess: ({ authorizeUrl }) => {
       void queryClient.invalidateQueries({ queryKey: ['kb-connectors-portal', kbSlug] })
-      window.location.href = authorizeUrl
+      // .assign() over `.href =` — consistent with connectors.tsx reconnect flow;
+      // react-hooks/immutability flags the property-assignment form.
+      window.location.assign(authorizeUrl)
     },
   })
 

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
@@ -121,7 +121,9 @@ function EditConnectorPage() {
     setIsReconnecting(true)
     try {
       const { authorize_url } = await apiFetch<{ authorize_url: string }>(`/api/oauth/google_drive/authorize?kb_slug=${encodeURIComponent(kbSlug)}&connector_id=${encodeURIComponent(connectorId)}`, )
-      window.location.href = authorize_url
+      // .assign() over `.href =` — consistent with connectors.tsx + add-connector;
+      // react-hooks/immutability flags the property-assignment form.
+      window.location.assign(authorize_url)
     } finally {
       setIsReconnecting(false)
     }
@@ -132,7 +134,7 @@ function EditConnectorPage() {
     setIsReconnecting(true)
     try {
       const { authorize_url } = await apiFetch<{ authorize_url: string }>(`/api/oauth/ms_docs/authorize?kb_slug=${encodeURIComponent(kbSlug)}&connector_id=${encodeURIComponent(connectorId)}`, )
-      window.location.href = authorize_url
+      window.location.assign(authorize_url)
     } finally {
       setIsReconnecting(false)
     }


### PR DESCRIPTION
## Summary

Addresses review comments from PR #145 (reconnect-signal). Seven small
clean-ups that together make the reconnect flow production-grade.

## Changes

**Backend — DRY + observability + regression guard**

1. \`oauth_base.py\`: extract \`check_invalid_grant_and_raise(response, provider, connector_id)\` helper. Both adapters now call it instead of duplicating the 400+invalid_grant translation logic
2. \`test_sync_engine_reconnect.py\` (NEW): sync_engine integration test. 2 cases — adapter raises OAuthReconnectRequiredError → AUTH_ERROR propagates to portal; generic exception → still FAILED (regression guard for except-clause ordering)
3. \`oauth.py\` callback: emits \`connector.reconnected\` event when recovering from auth_error, \`connector.connected\` for first-time setup. Clears \`last_sync_status\` on successful reconnect so the badge disappears

**Frontend — UX polish**

4. \`connectors.tsx\`: Reconnect link → proper \`<Button size="sm" variant="outline">\` with spinner; per-connector loading/error state; destructive error message when authorize-url fetch fails
5. \`CONNECTOR_TYPE_MAP\` labels now via paraglide i18n functions (was hardcoded strings)
6. \`window.location.href = X\` → \`.assign(X)\` across add-connector / edit-connector / connectors (consistent method call, no more react-hooks/immutability hit depending on scope)
7. i18n: new \`admin_connectors_reconnect_error\` string (NL + EN)

## Test plan

- [x] 63/63 connector tests pass (2 new sync_engine tests)
- [x] 15/15 portal oauth tests pass (no regression on callback changes)
- [x] Frontend \`tsc --noEmit\` clean
- [x] Frontend \`eslint\` clean on \`src/routes/app/knowledge/\`
- [x] Frontend \`npm run build\` succeeds
- [x] Ruff + pyright clean on modified adapter files

🤖 Generated with [Claude Code](https://claude.com/claude-code)