### PR TITLE
fix(portal-api): bot_poller DetachedInstanceError

### DIFF
--- a/klai-portal/backend/app/services/bot_poller.py
+++ b/klai-portal/backend/app/services/bot_poller.py
@@ -8,9 +8,19 @@ Two responsibilities:
 2. Recover meetings stuck in "stopping" — if the "completed" webhook from Vexa
    never arrives after stop_bot(), the meeting would stay in "stopping" forever.
    After PROCESSING_TIMEOUT_MINUTES, the poller tries to transcribe directly.
+
+Session lifecycle rule (2026-04-24):
+  Cross-org rows are read once per cycle inside `cross_org_session()` and
+  SNAPSHOTTED into `_ActiveMeetingSnapshot` dataclasses. The rest of the loop
+  operates on those primitives. Never touch an ORM attribute outside the
+  owning session — rollback-on-exit expires all attributes and lazy access
+  raises DetachedInstanceError (regression observed in production flooding
+  portal-api logs every 10s).
 """
 
 import asyncio
+import uuid
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 
 import structlog
@@ -28,11 +38,27 @@ POLL_INTERVAL = 10  # seconds — Vexa's own documented polling interval
 PROCESSING_TIMEOUT_MINUTES = 10  # retry transcription after this many minutes stuck in "processing"
 
 
-async def _upgrade_joining_to_recording(meeting_id: object, org_id: int) -> None:
+@dataclass(frozen=True)
+class _ActiveMeetingSnapshot:
+    """Immutable primitives captured from a VexaMeeting row inside the
+    cross-org session. Safe to pass around after the session has closed.
+    """
+
+    id: uuid.UUID
+    org_id: int | None
+    meeting_url: str
+    status: str
+
+
+def _snapshot(m: VexaMeeting) -> _ActiveMeetingSnapshot:
+    return _ActiveMeetingSnapshot(id=m.id, org_id=m.org_id, meeting_url=m.meeting_url, status=m.status)
+
+
+async def _upgrade_joining_to_recording(meeting_id: uuid.UUID, org_id: int) -> None:
     """Set meeting status joining→recording when the bot is confirmed active.
 
     Runs in a tenant-scoped session so vexa_meetings' UPDATE RLS policy
-    accepts the write. Caller holds the meeting object and provides org_id.
+    accepts the write. Caller holds the meeting id and provides org_id.
     """
     async with tenant_scoped_session(org_id) as db:
         m = await db.scalar(
@@ -47,19 +73,19 @@ async def _upgrade_joining_to_recording(meeting_id: object, org_id: int) -> None
             logger.info("Bot poll: bot active, updated status joining→recording", meeting_id=str(meeting_id))
 
 
-async def _handle_meeting_ended(meeting: VexaMeeting) -> None:
+async def _handle_meeting_ended(snap: _ActiveMeetingSnapshot) -> None:
     """Bot is gone from Vexa — transition meeting to stopping and run transcription.
 
-    Tenant-scoped: uses meeting.org_id to satisfy vexa_meetings UPDATE RLS.
+    Tenant-scoped: uses snap.org_id to satisfy vexa_meetings UPDATE RLS.
     """
-    logger.info("Bot poll: meeting ended, triggering transcription", meeting_id=str(meeting.id))
-    if meeting.org_id is None:
-        logger.warning("bot_poll_skipped_missing_org_id", meeting_id=str(meeting.id))
+    logger.info("Bot poll: meeting ended, triggering transcription", meeting_id=str(snap.id))
+    if snap.org_id is None:
+        logger.warning("bot_poll_skipped_missing_org_id", meeting_id=str(snap.id))
         return
-    async with tenant_scoped_session(meeting.org_id) as db:
+    async with tenant_scoped_session(snap.org_id) as db:
         m = await db.scalar(
             select(VexaMeeting).where(
-                VexaMeeting.id == meeting.id,
+                VexaMeeting.id == snap.id,
                 VexaMeeting.status.in_(ACTIVE_STATUSES),
             )
         )
@@ -76,7 +102,9 @@ async def _handle_meeting_ended(meeting: VexaMeeting) -> None:
             await cleanup_recording(m, db)
 
 
-async def _fetch_running_keys_safe(active: list[VexaMeeting]) -> set[tuple[str, str]] | None:
+async def _fetch_running_keys_safe(
+    active: list[_ActiveMeetingSnapshot],
+) -> set[tuple[str, str]] | None:
     """Return the set of (platform, native_meeting_id) for all running Vexa bots.
 
     Returns None if the Vexa API call fails (caller must skip end-detection that cycle).
@@ -86,29 +114,28 @@ async def _fetch_running_keys_safe(active: list[VexaMeeting]) -> set[tuple[str, 
     try:
         running_bots = await vexa.get_running_bots()
         return {(b["platform"], b["native_meeting_id"]) for b in running_bots}
-    except Exception as exc:
+    except Exception:
         logger.warning(
             "Bot status poll failed — skipping end detection this cycle",
-            error=str(exc),
             exc_info=True,
         )
         return None
 
 
-async def _recover_stuck_meeting(meeting: VexaMeeting) -> None:
+async def _recover_stuck_meeting(snap: _ActiveMeetingSnapshot) -> None:
     """Force-transcribe a meeting that has been stuck in 'stopping' too long."""
     logger.warning(
         "Bot poll: meeting stuck in stopping",
-        meeting_id=str(meeting.id),
+        meeting_id=str(snap.id),
         timeout_minutes=PROCESSING_TIMEOUT_MINUTES,
     )
-    if meeting.org_id is None:
-        logger.warning("stuck_meeting_skipped_missing_org_id", meeting_id=str(meeting.id))
+    if snap.org_id is None:
+        logger.warning("stuck_meeting_skipped_missing_org_id", meeting_id=str(snap.id))
         return
-    async with tenant_scoped_session(meeting.org_id) as db:
+    async with tenant_scoped_session(snap.org_id) as db:
         m = await db.scalar(
             select(VexaMeeting).where(
-                VexaMeeting.id == meeting.id,
+                VexaMeeting.id == snap.id,
                 VexaMeeting.status == "stopping",
             )
         )
@@ -120,54 +147,72 @@ async def _recover_stuck_meeting(meeting: VexaMeeting) -> None:
             await cleanup_recording(m, db)
 
 
+async def _load_cycle_snapshots() -> tuple[list[_ActiveMeetingSnapshot], list[_ActiveMeetingSnapshot]]:
+    """Load active + stuck meetings in a cross-org pass and return primitives.
+
+    Snapshotting happens INSIDE the session context so that rollback-on-exit
+    (see `_reset_tenant_context` in `cross_org_session()`) cannot strip
+    attributes out from under us.
+
+    Platform-level poll: scans across every tenant via `cross_org_session`
+    which sets `app.cross_org_admin=true`. The upgraded RLS policies on
+    vexa_meetings honour that flag as an opt-in bypass. Per-meeting WRITES
+    still run in `tenant_scoped_session(meeting.org_id)` so RLS enforces
+    isolation on the mutations themselves.
+    """
+    # @MX:SPEC: SPEC-SEC-007
+    async with cross_org_session() as db:
+        active_result = await db.execute(select(VexaMeeting).where(VexaMeeting.status.in_(ACTIVE_STATUSES)))
+        active = [_snapshot(m) for m in active_result.scalars().all()]
+
+        timeout_cutoff = datetime.now(UTC) - timedelta(minutes=PROCESSING_TIMEOUT_MINUTES)
+        stuck_result = await db.execute(
+            select(VexaMeeting).where(
+                VexaMeeting.status == "stopping",
+                VexaMeeting.ended_at < timeout_cutoff,
+                VexaMeeting.vexa_meeting_id.is_not(None),
+            )
+        )
+        stuck = [_snapshot(m) for m in stuck_result.scalars().all()]
+
+    return active, stuck
+
+
+async def _poll_once() -> None:
+    """Execute a single poll cycle. Extracted for testability — `poll_loop`
+    is just this function wrapped in an infinite retry loop.
+    """
+    active, stuck = await _load_cycle_snapshots()
+
+    # Fetch running bots once per cycle — a meeting has ended when its
+    # (platform, native_meeting_id) is absent from this list.
+    running_keys = await _fetch_running_keys_safe(active)
+
+    for snap in active:
+        if running_keys is None:
+            continue  # poll failed; don't trigger transcription based on missing data
+
+        ref = parse_meeting_url(snap.meeting_url)
+        if ref is None:
+            continue
+
+        if (ref.platform, ref.native_meeting_id) in running_keys:
+            if snap.status == "joining" and snap.org_id is not None:
+                await _upgrade_joining_to_recording(snap.id, snap.org_id)
+            continue  # bot is still running
+
+        await _handle_meeting_ended(snap)
+
+    for snap in stuck:
+        await _recover_stuck_meeting(snap)
+
+
 async def poll_loop() -> None:
     """Async task: run forever, polling Vexa for active meetings."""
     await asyncio.sleep(15)  # let the app finish starting up
     while True:
         try:
-            # Platform-level poll: scan active and stuck meetings across every
-            # tenant. Uses `cross_org_session` which explicitly sets
-            # `app.cross_org_admin=true` — the upgraded RLS policies on
-            # vexa_meetings honour that flag as an opt-in bypass. Per-meeting
-            # WRITES below run in `tenant_scoped_session(meeting.org_id)` so
-            # RLS still enforces isolation on the mutations themselves.
-            # @MX:SPEC: SPEC-SEC-007
-            async with cross_org_session() as db:
-                result = await db.execute(select(VexaMeeting).where(VexaMeeting.status.in_(ACTIVE_STATUSES)))
-                active = list(result.scalars().all())
-
-                timeout_cutoff = datetime.now(UTC) - timedelta(minutes=PROCESSING_TIMEOUT_MINUTES)
-                stuck_result = await db.execute(
-                    select(VexaMeeting).where(
-                        VexaMeeting.status == "stopping",
-                        VexaMeeting.ended_at < timeout_cutoff,
-                        VexaMeeting.vexa_meeting_id.is_not(None),
-                    )
-                )
-                stuck = list(stuck_result.scalars().all())
-
-            # Fetch running bots once per cycle — a meeting has ended when its
-            # (platform, native_meeting_id) is absent from this list.
-            running_keys = await _fetch_running_keys_safe(active)
-
-            for meeting in active:
-                if running_keys is None:
-                    continue  # poll failed; don't trigger transcription based on missing data
-
-                ref = parse_meeting_url(meeting.meeting_url)
-                if ref is None:
-                    continue
-
-                if (ref.platform, ref.native_meeting_id) in running_keys:
-                    if meeting.status == "joining" and meeting.org_id is not None:
-                        await _upgrade_joining_to_recording(meeting.id, meeting.org_id)
-                    continue  # bot is still running
-
-                await _handle_meeting_ended(meeting)
-
-            for meeting in stuck:
-                await _recover_stuck_meeting(meeting)
-
+            await _poll_once()
         except asyncio.CancelledError:
             break
         except Exception:

--- a/klai-portal/backend/tests/test_bot_poller.py
+++ b/klai-portal/backend/tests/test_bot_poller.py
@@ -1,0 +1,311 @@
+"""
+Unit tests for bot_poller.
+
+Regression coverage for the 2026-04-24 DetachedInstanceError bug where
+poll_loop iterated VexaMeeting ORM instances OUTSIDE the cross_org_session
+context — triggering DetachedInstanceError on rollback-expired attributes.
+
+The fix: snapshot primitives (id, org_id, meeting_url, status) inside the
+session, iterate on those afterwards.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import uuid
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.orm.exc import DetachedInstanceError
+
+from app.services import bot_poller
+
+# ---------------------------------------------------------------------------
+# Tracked ORM-instance stand-in
+# ---------------------------------------------------------------------------
+
+
+class _TrackedMeeting:
+    """VexaMeeting stand-in that raises DetachedInstanceError if an ORM-column
+    attribute is read AFTER the owning session has exited.
+
+    This mirrors the real SQLAlchemy behaviour: rollback expires attributes,
+    and any subsequent lazy load raises DetachedInstanceError because the
+    session is gone.
+    """
+
+    _COLUMN_ATTRS = frozenset({"id", "org_id", "meeting_url", "status", "ended_at", "vexa_meeting_id"})
+
+    def __init__(self, *, post_exit_flag: list[bool], **columns: object) -> None:
+        # Use object.__setattr__ so __getattr__ doesn't trip on our init.
+        object.__setattr__(self, "_post_exit_flag", post_exit_flag)
+        object.__setattr__(self, "_columns", columns)
+
+    def __getattr__(self, name: str) -> object:
+        if name in self._COLUMN_ATTRS:
+            if self._post_exit_flag[0]:
+                raise DetachedInstanceError(
+                    f"Instance is not bound to a Session; refused access to {name!r} "
+                    "after cross_org_session exit (regression probe for 2026-04-24 bug)"
+                )
+            return self._columns[name]
+        raise AttributeError(name)
+
+
+def _mk_meeting(
+    *,
+    post_exit_flag: list[bool],
+    meeting_id: uuid.UUID | None = None,
+    org_id: int | None = 1,
+    platform: str = "google_meet",
+    native_id: str = "abc-def-ghi",
+    status: str = "recording",
+) -> _TrackedMeeting:
+    return _TrackedMeeting(
+        post_exit_flag=post_exit_flag,
+        id=meeting_id or uuid.uuid4(),
+        org_id=org_id,
+        meeting_url=f"https://meet.google.com/{native_id}",
+        status=status,
+        ended_at=None,
+        vexa_meeting_id=42,
+    )
+
+
+def _mk_cross_org_session(active_rows, stuck_rows, post_exit_flag: list[bool]):
+    """Build an @asynccontextmanager that mimics cross_org_session().
+
+    Yields a mock session whose execute() returns active rows first, then stuck
+    rows. Flips post_exit_flag[0] = True on exit — so any ORM-column access
+    afterwards raises DetachedInstanceError.
+    """
+
+    @asynccontextmanager
+    async def _ctx():
+        session = AsyncMock()
+        active_result = MagicMock()
+        active_result.scalars.return_value.all.return_value = active_rows
+        stuck_result = MagicMock()
+        stuck_result.scalars.return_value.all.return_value = stuck_rows
+        session.execute = AsyncMock(side_effect=[active_result, stuck_result])
+        try:
+            yield session
+        finally:
+            post_exit_flag[0] = True
+
+    return _ctx
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_poll_once_does_not_access_orm_after_session_exit(monkeypatch):
+    """Regression for 2026-04-24 DetachedInstanceError bug.
+
+    poll_loop iterated VexaMeeting instances AFTER cross_org_session() exited.
+    Rollback on exit expires all attributes; first access to meeting.meeting_url
+    raised DetachedInstanceError ~every 10s in production.
+
+    The fix snapshots primitives inside the session so the post-session loop
+    works on a plain dataclass.
+    """
+    post_exit = [False]
+    meeting = _mk_meeting(post_exit_flag=post_exit, status="recording")
+
+    monkeypatch.setattr(
+        bot_poller,
+        "cross_org_session",
+        _mk_cross_org_session([meeting], [], post_exit),
+    )
+    monkeypatch.setattr(
+        bot_poller,
+        "_fetch_running_keys_safe",
+        AsyncMock(return_value={("google_meet", "abc-def-ghi")}),
+    )
+    upgrade = AsyncMock()
+    handle_ended = AsyncMock()
+    recover_stuck = AsyncMock()
+    monkeypatch.setattr(bot_poller, "_upgrade_joining_to_recording", upgrade)
+    monkeypatch.setattr(bot_poller, "_handle_meeting_ended", handle_ended)
+    monkeypatch.setattr(bot_poller, "_recover_stuck_meeting", recover_stuck)
+
+    # Real bug would raise DetachedInstanceError here.
+    await bot_poller._poll_once()
+
+    # Bot is still running (platform/native_id in running_keys) and status is
+    # "recording" — so no helper should fire.
+    upgrade.assert_not_awaited()
+    handle_ended.assert_not_awaited()
+    recover_stuck.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_poll_once_upgrades_joining_to_recording(monkeypatch):
+    """When the bot is running and status is 'joining', upgrade to 'recording'
+    — and pass primitives, not ORM instances, to the helper."""
+    post_exit = [False]
+    mid = uuid.uuid4()
+    meeting = _mk_meeting(post_exit_flag=post_exit, meeting_id=mid, status="joining", org_id=7)
+
+    monkeypatch.setattr(
+        bot_poller,
+        "cross_org_session",
+        _mk_cross_org_session([meeting], [], post_exit),
+    )
+    monkeypatch.setattr(
+        bot_poller,
+        "_fetch_running_keys_safe",
+        AsyncMock(return_value={("google_meet", "abc-def-ghi")}),
+    )
+    upgrade = AsyncMock()
+    monkeypatch.setattr(bot_poller, "_upgrade_joining_to_recording", upgrade)
+    monkeypatch.setattr(bot_poller, "_handle_meeting_ended", AsyncMock())
+    monkeypatch.setattr(bot_poller, "_recover_stuck_meeting", AsyncMock())
+
+    await bot_poller._poll_once()
+
+    upgrade.assert_awaited_once_with(mid, 7)
+
+
+@pytest.mark.asyncio
+async def test_poll_once_handles_meeting_ended_when_bot_gone(monkeypatch):
+    """Bot not in running_keys → trigger _handle_meeting_ended with a snapshot
+    containing id and org_id so the helper can open its own tenant session."""
+    post_exit = [False]
+    mid = uuid.uuid4()
+    meeting = _mk_meeting(post_exit_flag=post_exit, meeting_id=mid, org_id=9, native_id="gone-meeting")
+
+    monkeypatch.setattr(
+        bot_poller,
+        "cross_org_session",
+        _mk_cross_org_session([meeting], [], post_exit),
+    )
+    monkeypatch.setattr(
+        bot_poller,
+        "_fetch_running_keys_safe",
+        AsyncMock(return_value=set()),  # empty → bot has ended
+    )
+    handle_ended = AsyncMock()
+    monkeypatch.setattr(bot_poller, "_handle_meeting_ended", handle_ended)
+    monkeypatch.setattr(bot_poller, "_upgrade_joining_to_recording", AsyncMock())
+    monkeypatch.setattr(bot_poller, "_recover_stuck_meeting", AsyncMock())
+
+    await bot_poller._poll_once()
+
+    assert handle_ended.await_count == 1
+    (snap,) = handle_ended.await_args.args
+    assert snap.id == mid
+    assert snap.org_id == 9
+    assert snap.meeting_url == "https://meet.google.com/gone-meeting"
+
+
+@pytest.mark.asyncio
+async def test_poll_once_recovers_stuck_meetings(monkeypatch):
+    """Stuck meetings are passed as snapshots to _recover_stuck_meeting."""
+    post_exit = [False]
+    stuck_mid = uuid.uuid4()
+    stuck_meeting = _mk_meeting(post_exit_flag=post_exit, meeting_id=stuck_mid, org_id=42, status="stopping")
+
+    monkeypatch.setattr(
+        bot_poller,
+        "cross_org_session",
+        _mk_cross_org_session([], [stuck_meeting], post_exit),
+    )
+    monkeypatch.setattr(bot_poller, "_fetch_running_keys_safe", AsyncMock(return_value=None))
+    recover_stuck = AsyncMock()
+    monkeypatch.setattr(bot_poller, "_recover_stuck_meeting", recover_stuck)
+    monkeypatch.setattr(bot_poller, "_handle_meeting_ended", AsyncMock())
+    monkeypatch.setattr(bot_poller, "_upgrade_joining_to_recording", AsyncMock())
+
+    await bot_poller._poll_once()
+
+    assert recover_stuck.await_count == 1
+    (snap,) = recover_stuck.await_args.args
+    assert snap.id == stuck_mid
+    assert snap.org_id == 42
+
+
+@pytest.mark.asyncio
+async def test_poll_once_skips_end_detection_when_running_keys_none(monkeypatch):
+    """If Vexa's running-bots call fails (running_keys is None), end-detection
+    is skipped for active meetings but stuck recovery still runs."""
+    post_exit = [False]
+    active = _mk_meeting(post_exit_flag=post_exit, status="recording")
+    stuck_post_exit = post_exit  # share — only one session per iteration
+    stuck = _mk_meeting(post_exit_flag=stuck_post_exit, status="stopping")
+
+    monkeypatch.setattr(
+        bot_poller,
+        "cross_org_session",
+        _mk_cross_org_session([active], [stuck], post_exit),
+    )
+    monkeypatch.setattr(bot_poller, "_fetch_running_keys_safe", AsyncMock(return_value=None))
+    handle_ended = AsyncMock()
+    recover_stuck = AsyncMock()
+    monkeypatch.setattr(bot_poller, "_handle_meeting_ended", handle_ended)
+    monkeypatch.setattr(bot_poller, "_recover_stuck_meeting", recover_stuck)
+    monkeypatch.setattr(bot_poller, "_upgrade_joining_to_recording", AsyncMock())
+
+    await bot_poller._poll_once()
+
+    handle_ended.assert_not_awaited()
+    assert recover_stuck.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_poll_once_skips_meeting_with_unparseable_url(monkeypatch):
+    """parse_meeting_url returning None must short-circuit that meeting — no
+    end-detection, no upgrade, no crash."""
+    post_exit = [False]
+    meeting = _TrackedMeeting(
+        post_exit_flag=post_exit,
+        id=uuid.uuid4(),
+        org_id=1,
+        meeting_url="not-a-valid-meeting-url",
+        status="recording",
+        ended_at=None,
+        vexa_meeting_id=None,
+    )
+
+    monkeypatch.setattr(
+        bot_poller,
+        "cross_org_session",
+        _mk_cross_org_session([meeting], [], post_exit),
+    )
+    monkeypatch.setattr(bot_poller, "_fetch_running_keys_safe", AsyncMock(return_value=set()))
+    handle_ended = AsyncMock()
+    monkeypatch.setattr(bot_poller, "_handle_meeting_ended", handle_ended)
+    monkeypatch.setattr(bot_poller, "_upgrade_joining_to_recording", AsyncMock())
+    monkeypatch.setattr(bot_poller, "_recover_stuck_meeting", AsyncMock())
+
+    await bot_poller._poll_once()
+
+    handle_ended.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Snapshot dataclass contract
+# ---------------------------------------------------------------------------
+
+
+def test_active_meeting_snapshot_is_frozen_dataclass():
+    """_ActiveMeetingSnapshot must be an immutable value — no accidental
+    sharing of mutable state across poll cycles."""
+    snap = bot_poller._ActiveMeetingSnapshot(id=uuid.uuid4(), org_id=1, meeting_url="https://x", status="recording")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        snap.status = "other"  # type: ignore[misc]
+
+
+def test_stuck_meeting_timeout_cutoff_uses_processing_timeout_minutes():
+    """Sanity: POLL_INTERVAL and PROCESSING_TIMEOUT_MINUTES are preserved
+    after refactor — they're tuning knobs and should not silently shift."""
+    assert bot_poller.POLL_INTERVAL == 10
+    assert bot_poller.PROCESSING_TIMEOUT_MINUTES == 10
+    # Cutoff is derived, not stored — verify the math is consistent.
+    cutoff = datetime.now(UTC) - timedelta(minutes=bot_poller.PROCESSING_TIMEOUT_MINUTES)
+    assert (datetime.now(UTC) - cutoff) >= timedelta(minutes=9, seconds=59)


### PR DESCRIPTION
## Summary
- Bot poller has been logging `sqlalchemy.orm.exc.DetachedInstanceError` every ~10s since 2026-04-24 09:07 (30 errors per 5 min in production).
- Root cause: `poll_loop` iterated VexaMeeting ORM instances **outside** the `cross_org_session()` context. Rollback on exit expires all attributes (ignoring `expire_on_commit=False`), so post-exit `meeting.meeting_url` triggers a lazy load against a closed session.
- Fix: `_ActiveMeetingSnapshot` frozen dataclass; primitives are snapshotted **inside** the session. `_poll_once` extracted from `poll_loop` for testability.

## Test plan
- [x] 8 new unit tests in `tests/test_bot_poller.py` (happy paths, joining→recording upgrade, end-detection, stuck recovery, unparseable URL skip, snapshot immutability)
- [x] RED probe verified: inlining the old iteration pattern triggers `DetachedInstanceError` via the same test harness
- [x] Adjacent test modules green: `test_recording_cleanup`, `test_meetings`, `test_meetings_webhook_auth`, `test_invite_scheduler` (42 tests, all pass)
- [x] `uv run ruff check` clean
- [x] `uv run --with pyright pyright` clean
- [ ] Post-merge: verify `service:portal-api event:"Bot poll loop: unexpected error"` drops to 0 in VictoriaLogs