### PR TITLE
fix(alerting): execErrState OK for broken LogsQL Caddy rules

### DIFF
--- a/deploy/grafana/provisioning/alerting/caddy-rules.yaml
+++ b/deploy/grafana/provisioning/alerting/caddy-rules.yaml
@@ -87,7 +87,13 @@ groups:
                   reducer: { params: [], type: last }
                   type: query
         noDataState: OK
-        execErrState: Alerting
+        # execErrState: OK — the VictoriaLogs plugin + Grafana SSE combo
+        # intermittently trips "input data must be a wide series but got
+        # type long" on LogsQL reduce chains. Observed since 2026-04-22
+        # across all three LogsQL-based caddy/portal rules. We'd rather
+        # miss a fire on plugin hiccup than page on plugin error — matches
+        # the intent documented in the portal-api-rules.yaml header.
+        execErrState: OK
         for: 5m
         keepFiringFor: 10m
         isPaused: false

--- a/deploy/grafana/provisioning/alerting/portal-api-rules.yaml
+++ b/deploy/grafana/provisioning/alerting/portal-api-rules.yaml
@@ -78,7 +78,12 @@ groups:
                   reducer: { params: [], type: last }
                   type: query
         noDataState: OK
-        execErrState: Alerting
+        # execErrState: OK — matches the intent documented in the header
+        # comment of this file. The VictoriaLogs plugin + Grafana SSE combo
+        # trips "input data must be a wide series but got type long" on
+        # LogsQL reduce chains (observed since 2026-04-22). Miss-on-hiccup
+        # beats false-page-on-plugin-error.
+        execErrState: OK
         for: 5m
         keepFiringFor: 10m
         isPaused: false
@@ -191,7 +196,10 @@ groups:
                   reducer: { params: [], type: last }
                   type: query
         noDataState: OK
-        execErrState: Alerting
+        # execErrState: OK — see header comment + p95 rule above. LogsQL
+        # reduce chains intermittently fail with "long vs wide" plugin
+        # errors; suppress false-fires on eval failure.
+        execErrState: OK
         for: 10m
         keepFiringFor: 15m
         isPaused: false


### PR DESCRIPTION
## Summary
- Three Grafana alerts (`caddy_5xx_count_high`, `caddy_p95_latency_high`, `caddy_traffic_drop`) are false-firing on plugin eval errors since 2026-04-22: `[sse.readDataError] input data must be a wide series but got type long`.
- They currently page on plugin hiccups, not on real Caddy slowness — because `execErrState: Alerting` makes eval failure = fire.
- Fix: flip `execErrState: OK` on the 3 LogsQL rules. Matches the intent already documented in `portal-api-rules.yaml` header comment ("we'd rather miss a fire than create one falsely").
- Scope-bounded: other alerts (PromQL-based) keep `Alerting` — correct for them.

## Follow-up (not in this PR)
- Rewrite the LogsQL queries so Grafana sees wide-series output (`| fields _value` or migrate to VictoriaMetrics via Caddy prom exporter). Needs live plugin testing.

## Test plan
- [x] YAML syntax validation passes
- [x] `audit-alert-secrets.sh` clean
- [ ] `alerting-check` workflow green in CI
- [ ] Post-merge: check Grafana alerts leave `exec_err_state=Alerting` and go to `OK` state