### PR TITLE
chore(connector): fix ruff E402 in sync_engine.py

### DIFF
--- a/klai-connector/app/services/sync_engine.py
+++ b/klai-connector/app/services/sync_engine.py
@@ -7,22 +7,6 @@ import uuid
 from datetime import UTC, datetime
 from typing import Any
 
-# MIME → filename extension map for Unstructured parser output. Kept
-# local to the connector because the shared lib intentionally does not
-# know the parser's envelope format.
-_PARSER_MIME_EXT: dict[str, str] = {
-    "image/jpeg": "jpg",
-    "image/png": "png",
-    "image/gif": "gif",
-    "image/webp": "webp",
-    "image/svg+xml": "svg",
-}
-
-
-def _ext_from_parser_mime(mime: str) -> str:
-    """Return the extension for a parser-provided MIME type, default ``png``."""
-    return _PARSER_MIME_EXT.get(mime, "png")
-
 import httpx
 from gidgethub import BadRequest
 from klai_image_storage import (
@@ -42,6 +26,23 @@ from app.core.logging import get_logger
 from app.models.sync_run import SyncRun
 from app.services.parser import parse_document_with_images
 from app.services.portal_client import PortalClient
+
+# MIME → filename extension map for Unstructured parser output. Kept
+# local to the connector because the shared lib intentionally does not
+# know the parser's envelope format.
+_PARSER_MIME_EXT: dict[str, str] = {
+    "image/jpeg": "jpg",
+    "image/png": "png",
+    "image/gif": "gif",
+    "image/webp": "webp",
+    "image/svg+xml": "svg",
+}
+
+
+def _ext_from_parser_mime(mime: str) -> str:
+    """Return the extension for a parser-provided MIME type, default ``png``."""
+    return _PARSER_MIME_EXT.get(mime, "png")
+
 
 logger = get_logger(__name__)
 


### PR DESCRIPTION
## Summary

- Moves `_PARSER_MIME_EXT` dict + `_ext_from_parser_mime` helper below the import block in `klai-connector/app/services/sync_engine.py`
- Resolves 13 pre-existing ruff `E402` (module-level import not at top of file) violations — the helpers were sandwiched between stdlib and third-party imports
- No behavior change: helpers stay at module scope and are defined before any code references them

## Why a separate PR

Spotted while working on a different branch (`feature/klai-security-audit-agent`); these are pre-existing lint errors with no connection to the security-audit work, so keeping them out of that diff for clean review.

## Test plan

- [x] `python -m ruff check app/services/sync_engine.py --select E402` → All checks passed
- [x] `python -m py_compile app/services/sync_engine.py` → syntax OK
- [ ] CI ruff + pyright pass