### PR TITLE
feat(connectors): emit connector.reconnect_failed on OAuth failure paths

### DIFF
--- a/klai-portal/backend/app/api/oauth.py
+++ b/klai-portal/backend/app/api/oauth.py
@@ -101,6 +101,65 @@ def _provider_enabled(provider: str) -> bool:
     return False
 
 
+def _emit_reconnect_failed(
+    *,
+    was_reconnect: bool,
+    connector: PortalConnector,
+    user_id: str,
+    provider: str,
+    reason: str,
+    **extra: Any,
+) -> None:
+    """Emit connector.reconnect_failed when the flow was a reconnect.
+
+    First-time OAuth failures (no prior credentials) are silent — they're
+    setup abandonments, not reconnect signals. Only actual reconnect attempts
+    generate the event so the dashboard shows true recovery-attempt failures.
+    """
+    if not was_reconnect:
+        return
+    emit_event(
+        "connector.reconnect_failed",
+        org_id=connector.org_id,
+        user_id=user_id,
+        properties={
+            "provider": provider,
+            "connector_id": str(connector.id),
+            "reason": reason,
+            **extra,
+        },
+    )
+
+
+def _build_token_exchange(provider: str, code: str) -> tuple[str, dict[str, Any]]:
+    """Build (token_url, token_payload) for the authorization_code grant.
+
+    Providers differ in scope handling (Google infers from authorize, MS
+    requires scope on exchange too) and in tenant-scoped endpoint URLs.
+    """
+    redirect_uri = _frontend_redirect_url(f"/api/oauth/{provider}/callback")
+    if provider == "google_drive":
+        return _GOOGLE_TOKEN_URL, {
+            "code": code,
+            "client_id": settings.google_drive_client_id,
+            "client_secret": settings.google_drive_client_secret,
+            "redirect_uri": redirect_uri,
+            "grant_type": "authorization_code",
+        }
+    if provider == "ms_docs":
+        tenant = settings.ms_docs_tenant_id or "common"
+        return _MS_TOKEN_URL_TMPL.format(tenant=tenant), {
+            "code": code,
+            "client_id": settings.ms_docs_client_id,
+            "client_secret": settings.ms_docs_client_secret,
+            "redirect_uri": redirect_uri,
+            "grant_type": "authorization_code",
+            "scope": _MS_SCOPES,
+        }
+    # Guarded by _SUPPORTED_PROVIDERS check in the caller.
+    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Unknown provider")
+
+
 def _frontend_redirect_url(path: str) -> str:
     """Build the browser redirect URL for post-callback navigation."""
     return f"{settings.portal_url.rstrip('/')}{path}"
@@ -224,13 +283,25 @@ async def authorize_provider(
 @router.get("/{provider}/callback")
 async def callback_provider(
     provider: str,
-    code: str = Query(...),
     state: str = Query(...),
+    code: str | None = Query(None, description="Authorization code from provider (absent if user denied consent)"),
+    error: str | None = Query(None, description="OAuth error code (e.g. 'access_denied' when user denies consent)"),
+    error_description: str | None = Query(None, description="Human-readable error detail from provider"),
     klai_oauth_state: str | None = Cookie(default=None),
     user_id: str = Depends(get_current_user_id),
     db: AsyncSession = Depends(get_db),
 ) -> RedirectResponse:
-    """Validate state, exchange code for tokens, encrypt and store on the connector row."""
+    """Validate state, exchange code for tokens, encrypt and store on the connector row.
+
+    Error handling branches (in order):
+      1. Invalid state (CSRF) → 400
+      2. User denied consent (provider redirected with ?error=) → emit
+         connector.reconnect_failed if reconnect-flow, then redirect to portal
+         with ?oauth=failed
+      3. Missing code with no error (malformed redirect) → 400
+      4. Token exchange failure → emit connector.reconnect_failed if
+         reconnect-flow, then 502
+    """
     if provider not in _SUPPORTED_PROVIDERS:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Provider not enabled")
 
@@ -260,38 +331,47 @@ async def callback_provider(
     await set_tenant(db, connector.org_id)
 
     # Detect reconnect-flow: connector already had encrypted credentials AND
-    # was in auth_error. Used below to emit connector.reconnected for
-    # observability (distinguish successful recoveries from initial setups).
+    # was in auth_error. Used below to emit connector.reconnected /
+    # connector.reconnect_failed for observability (distinguishes successful
+    # recoveries + failure modes from first-time setups).
+    kb_slug = payload.get("kb_slug", "")
     was_reconnect = (
         connector.encrypted_credentials is not None and (connector.last_sync_status or "").lower() == "auth_error"
     )
 
-    # 3. Exchange authorization code for tokens. NEVER log the response body.
-    token_url: str
-    token_payload: dict[str, Any]
-    if provider == "google_drive":
-        token_url = _GOOGLE_TOKEN_URL
-        token_payload = {
-            "code": code,
-            "client_id": settings.google_drive_client_id,
-            "client_secret": settings.google_drive_client_secret,
-            "redirect_uri": _frontend_redirect_url(f"/api/oauth/{provider}/callback"),
-            "grant_type": "authorization_code",
-        }
-    elif provider == "ms_docs":
-        tenant = settings.ms_docs_tenant_id or "common"
-        token_url = _MS_TOKEN_URL_TMPL.format(tenant=tenant)
-        token_payload = {
-            "code": code,
-            "client_id": settings.ms_docs_client_id,
-            "client_secret": settings.ms_docs_client_secret,
-            "redirect_uri": _frontend_redirect_url(f"/api/oauth/{provider}/callback"),
-            "grant_type": "authorization_code",
-            "scope": _MS_SCOPES,
-        }
-    else:  # pragma: no cover -- guarded by _SUPPORTED_PROVIDERS above
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Unknown provider")
+    # 2a. Provider-reported error (most commonly: user denied consent on the
+    # provider's page). No code will be present. Emit the failure event with
+    # the provider-supplied reason, then redirect back to the portal with a
+    # failed-banner flag so the frontend can acknowledge it.
+    if error:
+        logger.info(
+            "oauth_callback_provider_error: provider=%s error=%s connector_id=%s",
+            provider,
+            error,
+            connector_id,
+        )
+        _emit_reconnect_failed(
+            was_reconnect=was_reconnect,
+            connector=connector,
+            user_id=user_id,
+            provider=provider,
+            reason="consent_denied",
+            provider_error=error,
+        )
+        return RedirectResponse(
+            url=_frontend_redirect_url(f"/app/knowledge/{kb_slug}/connectors?oauth=failed"),
+            status_code=status.HTTP_302_FOUND,
+        )
 
+    # 2b. No code AND no error: malformed redirect.
+    if not code:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Missing authorization code",
+        )
+
+    # 3. Exchange authorization code for tokens. NEVER log the response body.
+    token_url, token_payload = _build_token_exchange(provider, code)
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
             token_response = await client.post(token_url, data=token_payload)
@@ -303,6 +383,14 @@ async def callback_provider(
             "oauth_callback_token_exchange_failed: provider=%s status=%s",
             provider,
             exc.response.status_code,
+        )
+        _emit_reconnect_failed(
+            was_reconnect=was_reconnect,
+            connector=connector,
+            user_id=user_id,
+            provider=provider,
+            reason="token_exchange_failed",
+            provider_status=exc.response.status_code,
         )
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,

--- a/klai-portal/backend/tests/test_oauth_routes.py
+++ b/klai-portal/backend/tests/test_oauth_routes.py
@@ -254,6 +254,8 @@ class TestCallbackEndpoint:
                 provider="google_drive",
                 code="auth-code-xyz",
                 state=state_token,
+                error=None,
+                error_description=None,
                 klai_oauth_state=state_token,
                 user_id="zitadel-user-1",
                 db=db,
@@ -610,6 +612,8 @@ class TestMsDocsProvider:
                 provider="ms_docs",
                 code="auth-code-ms",
                 state=state_token,
+                error=None,
+                error_description=None,
                 klai_oauth_state=state_token,
                 user_id="zitadel-user-1",
                 db=db,
@@ -622,3 +626,292 @@ class TestMsDocsProvider:
             # Scope is forwarded
             assert post_call.kwargs["data"]["scope"] == "offline_access User.Read Files.Read.All Sites.Read.All"
             mock_store.encrypt_credentials.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# SPEC-KB-MS-DOCS-001 — connector.reconnect_failed emission
+# ---------------------------------------------------------------------------
+
+
+class TestCallbackReconnectFailed:
+    """Callback emits connector.reconnect_failed on consent-denied and token-exchange failure.
+
+    was_reconnect flag is true when the connector already had encrypted_credentials
+    AND last_sync_status == "auth_error" (i.e. the user is recovering from a failed
+    sync). Only reconnect-flow failures emit the event — first-time failures don't.
+    """
+
+    @pytest.mark.asyncio
+    async def test_callback_consent_denied_emits_reconnect_failed_and_redirects(self) -> None:
+        """Provider redirects with ?error=access_denied (user refused consent).
+
+        Expected: emit connector.reconnect_failed with reason=consent_denied,
+        then 302 redirect to portal with ?oauth=failed. No token exchange.
+        """
+        from app.api.oauth import _sign_state, callback_provider
+
+        db = AsyncMock()
+
+        mock_portal_user = MagicMock()
+        mock_portal_user.org_id = 77
+
+        mock_connector = MagicMock()
+        mock_connector.id = "conn-uuid-reconnect-denied"
+        mock_connector.org_id = 77
+        mock_connector.connector_type = "ms_docs"
+        mock_connector.config = {}
+        # was_reconnect=True requires BOTH of these
+        mock_connector.encrypted_credentials = b"EXISTING_ENCRYPTED_BLOB"
+        mock_connector.last_sync_status = "auth_error"
+
+        with (
+            patch("app.api.oauth.settings") as mock_settings,
+            patch("app.api.oauth.emit_event") as mock_emit_event,
+        ):
+            mock_settings.ms_docs_client_id = _PLACEHOLDER_CLIENT_ID
+            mock_settings.ms_docs_client_secret = _PLACEHOLDER_CLIENT_SECRET
+            mock_settings.ms_docs_tenant_id = "common"
+            mock_settings.google_drive_client_id = ""
+            mock_settings.sso_cookie_key = _PLACEHOLDER_COOKIE_KEY
+            mock_settings.portal_url = "https://my.getklai.com"
+            mock_settings.domain = "getklai.com"
+
+            state_token = _sign_state(
+                {
+                    "provider": "ms_docs",
+                    "user_id": "zitadel-user-1",
+                    "kb_slug": "main",
+                    "connector_id": "conn-uuid-reconnect-denied",
+                    "nonce": "nonce",
+                }
+            )
+
+            db.scalar = AsyncMock(return_value=mock_portal_user)
+            db.get = AsyncMock(return_value=mock_connector)
+
+            response = await callback_provider(
+                provider="ms_docs",
+                code=None,
+                state=state_token,
+                error="access_denied",
+                error_description="The user denied the request.",
+                klai_oauth_state=state_token,
+                user_id="zitadel-user-1",
+                db=db,
+            )
+
+            # 302 redirect with ?oauth=failed on the connectors page
+            assert response.status_code == 302
+            assert "oauth=failed" in response.headers["location"]
+            assert "/app/knowledge/main/connectors" in response.headers["location"]
+
+            # Exactly one reconnect_failed event with the expected shape
+            mock_emit_event.assert_called_once()
+            call = mock_emit_event.call_args
+            assert call.args[0] == "connector.reconnect_failed"
+            assert call.kwargs["org_id"] == 77
+            assert call.kwargs["user_id"] == "zitadel-user-1"
+            assert call.kwargs["properties"]["provider"] == "ms_docs"
+            assert call.kwargs["properties"]["reason"] == "consent_denied"
+            assert call.kwargs["properties"]["provider_error"] == "access_denied"
+
+            # No token exchange happened — no commit, no re-encrypt
+            db.commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_callback_consent_denied_first_time_does_not_emit_reconnect_failed(
+        self,
+    ) -> None:
+        """First-time connection refused (no prior credentials) must NOT emit the
+        reconnect_failed event — it's a first-setup abandonment, not a reconnect.
+        Still redirects to ?oauth=failed for UX.
+        """
+        from app.api.oauth import _sign_state, callback_provider
+
+        db = AsyncMock()
+
+        mock_portal_user = MagicMock()
+        mock_portal_user.org_id = 77
+
+        mock_connector = MagicMock()
+        mock_connector.id = "conn-uuid-first-time"
+        mock_connector.org_id = 77
+        mock_connector.connector_type = "ms_docs"
+        mock_connector.config = {}
+        # was_reconnect=False: no prior credentials
+        mock_connector.encrypted_credentials = None
+        mock_connector.last_sync_status = None
+
+        with (
+            patch("app.api.oauth.settings") as mock_settings,
+            patch("app.api.oauth.emit_event") as mock_emit_event,
+        ):
+            mock_settings.ms_docs_client_id = _PLACEHOLDER_CLIENT_ID
+            mock_settings.ms_docs_client_secret = _PLACEHOLDER_CLIENT_SECRET
+            mock_settings.ms_docs_tenant_id = "common"
+            mock_settings.google_drive_client_id = ""
+            mock_settings.sso_cookie_key = _PLACEHOLDER_COOKIE_KEY
+            mock_settings.portal_url = "https://my.getklai.com"
+            mock_settings.domain = "getklai.com"
+
+            state_token = _sign_state(
+                {
+                    "provider": "ms_docs",
+                    "user_id": "zitadel-user-1",
+                    "kb_slug": "main",
+                    "connector_id": "conn-uuid-first-time",
+                    "nonce": "nonce",
+                }
+            )
+
+            db.scalar = AsyncMock(return_value=mock_portal_user)
+            db.get = AsyncMock(return_value=mock_connector)
+
+            response = await callback_provider(
+                provider="ms_docs",
+                code=None,
+                state=state_token,
+                error="access_denied",
+                klai_oauth_state=state_token,
+                user_id="zitadel-user-1",
+                db=db,
+            )
+
+            assert response.status_code == 302
+            assert "oauth=failed" in response.headers["location"]
+            # No event — this was a first-time setup, not a reconnect
+            mock_emit_event.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_callback_token_exchange_failure_emits_reconnect_failed(self) -> None:
+        """Token endpoint returns non-2xx while in a reconnect flow.
+
+        Expected: emit connector.reconnect_failed with reason=token_exchange_failed,
+        then raise HTTPException(502).
+        """
+        from app.api.oauth import _sign_state, callback_provider
+
+        db = AsyncMock()
+
+        mock_portal_user = MagicMock()
+        mock_portal_user.org_id = 77
+
+        mock_connector = MagicMock()
+        mock_connector.id = "conn-uuid-reconnect-tx-fail"
+        mock_connector.org_id = 77
+        mock_connector.connector_type = "google_drive"
+        mock_connector.config = {}
+        # was_reconnect=True
+        mock_connector.encrypted_credentials = b"EXISTING_ENCRYPTED_BLOB"
+        mock_connector.last_sync_status = "auth_error"
+
+        # Token endpoint returns 400 -> raise_for_status triggers HTTPStatusError
+        token_response = _make_http_response(400, {"error": "invalid_grant"})
+
+        with (
+            patch("app.api.oauth.settings") as mock_settings,
+            patch("app.api.oauth.httpx.AsyncClient", _mock_httpx_client(token_response)),
+            patch("app.api.oauth.emit_event") as mock_emit_event,
+        ):
+            mock_settings.google_drive_client_id = _PLACEHOLDER_CLIENT_ID
+            mock_settings.google_drive_client_secret = _PLACEHOLDER_CLIENT_SECRET
+            mock_settings.sso_cookie_key = _PLACEHOLDER_COOKIE_KEY
+            mock_settings.portal_url = "https://portal.getklai.com"
+            mock_settings.domain = "getklai.com"
+
+            state_token = _sign_state(
+                {
+                    "provider": "google_drive",
+                    "user_id": "zitadel-user-1",
+                    "connector_id": "conn-uuid-reconnect-tx-fail",
+                }
+            )
+
+            db.scalar = AsyncMock(return_value=mock_portal_user)
+            db.get = AsyncMock(return_value=mock_connector)
+
+            with pytest.raises(HTTPException) as exc_info:
+                await callback_provider(
+                    provider="google_drive",
+                    code="auth-code-xyz",
+                    state=state_token,
+                    error=None,
+                    error_description=None,
+                    klai_oauth_state=state_token,
+                    user_id="zitadel-user-1",
+                    db=db,
+                )
+
+            assert exc_info.value.status_code == 502
+
+            mock_emit_event.assert_called_once()
+            call = mock_emit_event.call_args
+            assert call.args[0] == "connector.reconnect_failed"
+            assert call.kwargs["org_id"] == 77
+            assert call.kwargs["user_id"] == "zitadel-user-1"
+            assert call.kwargs["properties"]["provider"] == "google_drive"
+            assert call.kwargs["properties"]["reason"] == "token_exchange_failed"
+            assert call.kwargs["properties"]["provider_status"] == 400
+
+            # No commit on failure
+            db.commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_callback_token_exchange_failure_first_time_does_not_emit(self) -> None:
+        """First-time token exchange failure must NOT emit reconnect_failed.
+
+        Still raises 502 — only the event emission is conditional on was_reconnect.
+        """
+        from app.api.oauth import _sign_state, callback_provider
+
+        db = AsyncMock()
+
+        mock_portal_user = MagicMock()
+        mock_portal_user.org_id = 77
+
+        mock_connector = MagicMock()
+        mock_connector.id = "conn-uuid-first-time-tx-fail"
+        mock_connector.org_id = 77
+        mock_connector.connector_type = "google_drive"
+        mock_connector.config = {}
+        mock_connector.encrypted_credentials = None
+        mock_connector.last_sync_status = None
+
+        token_response = _make_http_response(400, {"error": "invalid_grant"})
+
+        with (
+            patch("app.api.oauth.settings") as mock_settings,
+            patch("app.api.oauth.httpx.AsyncClient", _mock_httpx_client(token_response)),
+            patch("app.api.oauth.emit_event") as mock_emit_event,
+        ):
+            mock_settings.google_drive_client_id = _PLACEHOLDER_CLIENT_ID
+            mock_settings.google_drive_client_secret = _PLACEHOLDER_CLIENT_SECRET
+            mock_settings.sso_cookie_key = _PLACEHOLDER_COOKIE_KEY
+            mock_settings.portal_url = "https://portal.getklai.com"
+            mock_settings.domain = "getklai.com"
+
+            state_token = _sign_state(
+                {
+                    "provider": "google_drive",
+                    "user_id": "zitadel-user-1",
+                    "connector_id": "conn-uuid-first-time-tx-fail",
+                }
+            )
+
+            db.scalar = AsyncMock(return_value=mock_portal_user)
+            db.get = AsyncMock(return_value=mock_connector)
+
+            with pytest.raises(HTTPException) as exc_info:
+                await callback_provider(
+                    provider="google_drive",
+                    code="auth-code-xyz",
+                    state=state_token,
+                    error=None,
+                    error_description=None,
+                    klai_oauth_state=state_token,
+                    user_id="zitadel-user-1",
+                    db=db,
+                )
+
+            assert exc_info.value.status_code == 502
+            mock_emit_event.assert_not_called()

--- a/klai-portal/frontend/messages/en.json
+++ b/klai-portal/frontend/messages/en.json
@@ -999,6 +999,7 @@
   "admin_connectors_google_drive_folder_id_help": "Limit the sync to a specific folder. Find the folder ID in the URL when opening a folder in Google Drive.",
   "admin_connectors_google_drive_reconnect": "Reconnect Google",
   "admin_connectors_oauth_success": "Google Drive connected successfully.",
+  "admin_connectors_oauth_failed": "Connection failed. Please try again, or contact support if this keeps happening.",
   "admin_connectors_type_notion": "Notion",
   "admin_connectors_notion_access_token": "Notion integration token",
   "admin_connectors_notion_access_token_placeholder": "secret_...",

--- a/klai-portal/frontend/messages/nl.json
+++ b/klai-portal/frontend/messages/nl.json
@@ -999,6 +999,7 @@
   "admin_connectors_google_drive_folder_id_help": "Beperk de sync tot een specifieke map. Vind het map ID in de URL van een geopende map in Google Drive.",
   "admin_connectors_google_drive_reconnect": "Google opnieuw verbinden",
   "admin_connectors_oauth_success": "Google Drive succesvol verbonden.",
+  "admin_connectors_oauth_failed": "Verbinden mislukt. Probeer het nog eens of neem contact op met support als het blijft fout gaan.",
   "admin_connectors_type_notion": "Notion",
   "admin_connectors_notion_access_token": "Notion integratie-token",
   "admin_connectors_notion_access_token_placeholder": "secret_...",

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/connectors.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/connectors.tsx
@@ -3,7 +3,7 @@ import { useAuth } from '@/lib/auth'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useState, useEffect } from 'react'
 import {
-  RefreshCw, Trash2, Loader2, Plus, Pencil, Globe, FileText, CheckCircle2, X,
+  RefreshCw, Trash2, Loader2, Plus, Pencil, Globe, FileText, CheckCircle2, AlertTriangle, X,
 } from 'lucide-react'
 import { SiGithub, SiNotion, SiGoogledrive } from '@icons-pack/react-simple-icons'
 import { Button } from '@/components/ui/button'
@@ -53,11 +53,12 @@ function ConnectorsTab() {
   const queryClient = useQueryClient()
   const { oauth } = Route.useSearch()
   const [showOAuthBanner, setShowOAuthBanner] = useState(oauth === 'connected')
+  const [showOAuthFailedBanner, setShowOAuthFailedBanner] = useState(oauth === 'failed')
   const [confirmingDeleteId, setConfirmingDeleteId] = useState<string | null>(null)
 
   // Clean up the ?oauth= param from the URL after mounting so a reload doesn't re-show the banner.
   useEffect(() => {
-    if (oauth === 'connected') {
+    if (oauth === 'connected' || oauth === 'failed') {
       window.history.replaceState({}, '', window.location.pathname)
     }
   }, [oauth])
@@ -152,6 +153,15 @@ function ConnectorsTab() {
           <CheckCircle2 className="h-3.5 w-3.5 shrink-0" />
           <span className="flex-1">{m.admin_connectors_oauth_success()}</span>
           <button onClick={() => setShowOAuthBanner(false)} aria-label="Dismiss" className="hover:opacity-70 transition-opacity">
+            <X className="h-3 w-3" />
+          </button>
+        </div>
+      )}
+      {showOAuthFailedBanner && (
+        <div className="flex gap-2 items-center rounded-lg border border-[var(--color-destructive)]/30 bg-[var(--color-destructive)]/5 p-3 text-xs text-[var(--color-destructive)]">
+          <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+          <span className="flex-1">{m.admin_connectors_oauth_failed()}</span>
+          <button onClick={() => setShowOAuthFailedBanner(false)} aria-label="Dismiss" className="hover:opacity-70 transition-opacity">
             <X className="h-3 w-3" />
           </button>
         </div>


### PR DESCRIPTION
## Summary
- Adds `connector.reconnect_failed` event emission on the two callback failure paths:
  - `reason=consent_denied` — provider redirected with `?error=access_denied` (user cancelled consent)
  - `reason=token_exchange_failed` — code-for-token POST returned non-2xx
- Only fires when the connector was in a reconnect flow (prior credentials + `auth_error`); first-time setup abandonments remain silent.
- Frontend shows a destructive banner on `?oauth=failed` (NL + EN via `admin_connectors_oauth_failed`).
- Extracted `_emit_reconnect_failed` + `_build_token_exchange` helpers to keep `callback_provider` complexity below the ruff C901 threshold.

## Test plan
- [x] pytest `tests/test_oauth_routes.py` — 19 passing (4 new)
- [x] ruff check + ruff format on `app/api/oauth.py` + `tests/test_oauth_routes.py`
- [x] pyright clean on both files (2 remaining errors are pre-existing in existing tests on `main`)
- [x] frontend `npm run build` — succeeds
- [x] eslint on `connectors.tsx` — clean
- [ ] CI passes
- [ ] Post-merge smoke: trigger a consent-denied flow via `/oauth=failed` URL in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)