### PR TITLE
security(portal-api): SPEC-SEC-WEBHOOK-001 REQ-2 — remove Vexa IP-range bypass (Vexa slice)

### DIFF
--- a/.claude/rules/klai/pitfalls/process-rules.md
+++ b/.claude/rules/klai/pitfalls/process-rules.md
@@ -198,3 +198,50 @@ the risk — the mess ships as-is.
 
 See `.claude/rules/moai/workflow/worktree-integration.md` for the decision
 tree and `worktree add` flags.
+
+## validator-env-parity (HIGH)
+When a pydantic `@model_validator` is added that REJECTS an empty /
+whitespace-only env var at app startup, verify the env var already exists
+in production BEFORE landing the code change. Local tests pass because the
+conftest sets a default; prod doesn't have a conftest, only SOPS. Shipping
+the validator without the env var causes the service to refuse to start
+and returns HTTP 502 until reverted.
+
+**Why this happened:** SPEC-SEC-WEBHOOK-001 REQ-3 added
+`_require_moneybird_webhook_token` to `klai-portal/backend/app/core/config.py`.
+Tests passed (conftest sets the var), CI green, PR merged → auto-deploy to
+core-01 → portal-api startup raised `ValidationError: Missing required:
+MONEYBIRD_WEBHOOK_TOKEN` because the var was never in
+`klai-infra/core-01/.env.sops`. Prod 502 for ~4 minutes until the merge was
+reverted. The Moneybird finding (Cornelis #3) was the CAUSE: the token had
+never been configured, so webhooks ran fail-open. The validator correctly
+closed that bypass but required the env var to ship in the same deploy
+window.
+
+**Prevention:**
+
+1. Before committing any `_require_<X>_secret` validator, run:
+   ```bash
+   grep -c "^ *<X>_SECRET\|^ *<X>_TOKEN" klai-infra/core-01/.env.sops
+   grep -c "<X>_SECRET\|<X>_TOKEN" deploy/docker-compose.yml
+   ```
+   If either returns `0`, add the env var to SOPS first (and to the compose
+   environment block if applicable), commit to klai-infra, verify decrypt
+   works, THEN land the validator.
+
+2. Deploy order is **env var first, validator second** — never the other
+   way around. Even a same-day gap is acceptable; a same-deploy gap is
+   catastrophic because validator-fails-at-startup triggers Docker restart
+   loop and 502 cascade.
+
+3. For audit-finding fixes that make a previously-optional config
+   mandatory, list "env var pre-flight in klai-infra/core-01/.env.sops"
+   as an explicit checkbox in the SPEC's Success Criteria AND in the PR
+   body — not only in the forcing-function prose.
+
+4. Conftest-sets-a-default is the classic trap that hides this regression.
+   When writing the fail-closed test (`test_settings_startup_fails_without_X`),
+   add a comment on the pydantic validator linking to this pitfall so
+   reviewers stop and think about prod env parity.
+
+See `klai-infra/core-01/.env.sops` for the canonical prod env inventory.

--- a/klai-portal/backend/app/api/meetings.py
+++ b/klai-portal/backend/app/api/meetings.py
@@ -44,14 +44,16 @@ MAX_CONCURRENT_BOTS = 2
 
 
 def _require_webhook_secret(request: Request) -> None:
-    # SEC-013 F-033: fail-closed + constant-time compare. Startup validator in
-    # app.core.config guarantees vexa_webhook_secret is non-empty.
+    # SPEC-SEC-WEBHOOK-001 REQ-2: fail-closed auth on /api/bots/internal/webhook.
+    # Authentication is the Bearer-token compare alone — NO IP-range short-circuit.
+    # The previous "internal Docker network callers are trusted" path (172.x / 10.x
+    # / 192.168.x) was effectively an auth bypass: Caddy's container IP always sat
+    # in those ranges, so every external request was implicitly authenticated.
+    # Vexa's POST_MEETING_HOOKS MUST supply `Authorization: Bearer <secret>` now.
     #
-    # Internal Docker network callers (172.x, 10.x, 192.168.x) are trusted without a token.
-    # This avoids embedding secrets in POST_MEETING_HOOKS URLs where they appear in container logs.
-    client_host = request.client.host if request.client else ""
-    if client_host.startswith(("172.", "10.", "192.168.")):
-        return
+    # Startup validator _require_vexa_webhook_secret in app.core.config guarantees
+    # settings.vexa_webhook_secret is non-empty, so an empty expected value cannot
+    # lead to compare_digest returning True against an empty attacker header.
     auth_header = request.headers.get("Authorization", "")
     expected = f"Bearer {settings.vexa_webhook_secret}"
     if not hmac.compare_digest(auth_header.encode("utf-8"), expected.encode("utf-8")):

--- a/klai-portal/backend/tests/test_meetings_webhook_auth.py
+++ b/klai-portal/backend/tests/test_meetings_webhook_auth.py
@@ -1,12 +1,16 @@
 """
-SPEC-SEC-F033: Vexa webhook auth — fail-closed + constant-time compare.
+SPEC-SEC-WEBHOOK-001 REQ-2 — Vexa webhook auth hardening.
+
+Supersedes the SEC-013 F-033 test suite. The IP-range bypass
+(172.x / 10.x / 192.168.x short-circuit) is REMOVED — every caller,
+including Docker-internal peers, MUST present a valid Bearer token.
 
 Covers:
-- startup fails when VEXA_WEBHOOK_SECRET is empty (pydantic model_validator)
+- startup fails when VEXA_WEBHOOK_SECRET is empty (pydantic model_validator, unchanged)
 - _require_webhook_secret uses hmac.compare_digest for the Bearer comparison
 - 401 on wrong Bearer
-- 200 (pass) on correct Bearer
-- Docker-network IP is still trusted without a Bearer
+- 401 on Docker-network source IP with no Bearer (inverted legacy case)
+- Pass on correct Bearer regardless of source IP
 """
 
 from __future__ import annotations
@@ -114,15 +118,33 @@ def test_require_webhook_secret_missing_authorization_header_rejects() -> None:
     assert excinfo.value.status_code == 401
 
 
-def test_require_webhook_secret_docker_network_trusted_without_bearer() -> None:
-    """Callers on the internal Docker networks (172.x/10.x/192.168.x) are trusted.
+def test_require_webhook_secret_docker_network_IP_no_bearer_rejects_401() -> None:
+    """SPEC-SEC-WEBHOOK-001 REQ-2.2: source IP alone NEVER authenticates.
 
-    This preserves pre-existing behaviour: meeting-api reaches portal-api via
-    klai-net and must not be forced to embed the secret in POST_MEETING_HOOKS.
-    Further hardening tracked in SEC-013.
+    Inverted from the legacy `test_require_webhook_secret_docker_network_trusted_without_bearer`
+    test. Docker-internal source IPs (172.x / 10.x / 192.168.x) previously short-
+    circuited the auth check — that was an auth bypass because Caddy's container
+    IP always sat in those ranges for every external request. The IP-range
+    early-return is deleted in REQ-2.1; every caller now MUST present a valid
+    Bearer, full stop.
     """
     for host in ("172.18.0.5", "10.0.0.2", "192.168.1.10"):
         req = _make_request(client_host=host, auth_header=None)
+        with patch("app.api.meetings.settings") as mock_settings:
+            mock_settings.vexa_webhook_secret = "correct-secret"
+            with pytest.raises(HTTPException) as excinfo:
+                _require_webhook_secret(req)
+            assert excinfo.value.status_code == 401, f"Docker-internal host {host} was accepted without a Bearer"
+
+
+def test_require_webhook_secret_docker_network_IP_with_valid_bearer_passes() -> None:
+    """Legitimate callers on klai-net (Vexa api-gateway) continue to work provided
+    they present the Bearer — this covers the forcing function documented in the
+    SPEC Assumptions: POST_MEETING_HOOKS must be (re)configured with
+    `Authorization: Bearer <secret>` for the Vexa webhook flow to keep working.
+    """
+    for host in ("172.18.0.5", "10.0.0.2", "192.168.1.10"):
+        req = _make_request(client_host=host, auth_header="Bearer correct-secret")
         with patch("app.api.meetings.settings") as mock_settings:
             mock_settings.vexa_webhook_secret = "correct-secret"
             _require_webhook_secret(req)  # no exception


### PR DESCRIPTION
## Summary

Re-applies the Vexa slice of SPEC-SEC-WEBHOOK-001 after #150's Moneybird
validator caused a prod incident. This PR closes REQ-2 (Vexa IP-range
bypass) AND adds a new pitfall rule capturing the lesson learned.

Deliberately **narrower** than #150 — Moneybird (REQ-3/REQ-4) is deferred
to a follow-up PR that can only land after `MONEYBIRD_WEBHOOK_TOKEN` is
added to `klai-infra/core-01/.env.sops` AND configured in the Moneybird
dashboard.

## Commits

1. `feat(security): ... REQ-2 — remove Vexa IP-range auth bypass` — the actual fix + test updates
2. `docs(pitfalls): capture validator-env-parity after #150 prod incident` — a new pitfall rule preventing recurrence

## REQ-2 closes the Vexa auth bypass

The 172./10./192.168. short-circuit in `_require_webhook_secret` was an auth
bypass — Caddy's klai-net container IP always matched those ranges, so every
external request was implicitly authenticated. Deleted. Every caller MUST
present `Authorization: Bearer <VEXA_WEBHOOK_SECRET>`.

`VEXA_WEBHOOK_SECRET` IS already in `klai-infra/core-01/.env.sops` (verified
via grep). So unlike #150, this PR will not cause a startup failure.

## ⚠️ Deploy forcing function

Vexa's `POST_MEETING_HOOKS` (`deploy/docker-compose.yml:886`, currently a
plain URL with no Bearer) MUST be reconfigured to send
`Authorization: Bearer $VEXA_WEBHOOK_SECRET` in the same deploy. Otherwise
Vexa callbacks start returning 401 after merge — which is the intentional
observable break replacing the silent auth bypass. 401 is strictly better
than fail-open; confirm the header is set before merging.

## Pre-flight checks performed this time

- [x] `grep -c VEXA_WEBHOOK_SECRET klai-infra/core-01/.env.sops` → 1 (validator will not trip)
- [x] 8/8 Vexa auth tests green locally
- [x] ruff + pyright clean
- [x] No code change to Moneybird handler/validator — Moneybird endpoint continues to run with its existing (known-bypassed) auth; this PR does not improve it but also does not break startup

## What's NOT in this PR

- REQ-3 Moneybird fail-closed startup validator — needs MONEYBIRD_WEBHOOK_TOKEN in SOPS first
- REQ-4 Moneybird hmac.compare_digest + 401 — same dependency
- REQ-1 uvicorn --proxy-headers service-wide
- REQ-5.4 / 5.6 / REQ-6 — later PRs

## Incident context

This PR exists because #150 was merged then reverted (6ee5315d) after the
Moneybird validator refused startup due to missing SOPS env var. That
incident's forensic trail is captured both in the new pitfall rule and
in the #150 PR discussion.

## Test plan

- [ ] CI green (quality, semgrep, rls-smoke-test)
- [ ] Manual pre-merge: confirm `POST_MEETING_HOOKS` in `deploy/docker-compose.yml:886` has the Bearer header configured before merging
- [ ] Manual post-merge: POST to `/api/bots/internal/webhook` from curl with no Bearer → 401 (previously 200)
- [ ] Post-deploy: verify Vexa meetings still trigger portal callbacks successfully (check `meeting.*` product_events for fresh entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)