### PR TITLE
security(portal-api): SPEC-SEC-WEBHOOK-001 REQ-3+REQ-4 — Moneybird webhook auth hardening

### DIFF
--- a/klai-portal/backend/app/api/webhooks.py
+++ b/klai-portal/backend/app/api/webhooks.py
@@ -1,6 +1,8 @@
+import hmac
 import logging
 
-from fastapi import APIRouter, Depends, Request, Response
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -10,6 +12,7 @@ from app.models.portal import PortalOrg
 from app.services.moneybird import MoneybirdService
 
 logger = logging.getLogger(__name__)
+_structlog_logger = structlog.get_logger()
 
 router = APIRouter(prefix="/api/webhooks", tags=["webhooks"])
 
@@ -19,13 +22,24 @@ async def moneybird_webhook(
     request: Request,
     db: AsyncSession = Depends(get_db),
 ) -> Response:
+    # SPEC-SEC-WEBHOOK-001 REQ-3 + REQ-4:
+    # - Startup validator `_require_moneybird_webhook_token` guarantees the
+    #   secret is non-empty, so no `if settings.moneybird_webhook_token:` guard
+    #   is required or permitted here (REQ-3.2).
+    # - Token comparison uses hmac.compare_digest against byte-encoded operands
+    #   (REQ-4.1) and auth failure returns HTTP 401, never 200 (REQ-4.2).
     payload: dict = await request.json()
-
-    if settings.moneybird_webhook_token:
-        token = payload.get("webhook_token", "")
-        if token != settings.moneybird_webhook_token:
-            logger.warning("Moneybird webhook: invalid token")
-            return Response(status_code=200)
+    token = payload.get("webhook_token", "")
+    if not hmac.compare_digest(
+        token.encode("utf-8"),
+        settings.moneybird_webhook_token.encode("utf-8"),
+    ):
+        _structlog_logger.warning(
+            "moneybird_webhook_auth_failed",
+            event_type=payload.get("event", ""),
+            entity_type=payload.get("entity_type", ""),
+        )
+        raise HTTPException(status_code=401, detail="Unauthorized")
 
     entity_type: str = payload.get("entity_type", "")
     event: str = payload.get("event", "")

--- a/klai-portal/backend/app/core/config.py
+++ b/klai-portal/backend/app/core/config.py
@@ -247,5 +247,30 @@ class Settings(BaseSettings):
             )
         return self
 
+    @model_validator(mode="after")
+    def _require_moneybird_webhook_token(self) -> "Settings":
+        """SPEC-SEC-WEBHOOK-001 REQ-3: fail-closed on missing moneybird_webhook_token.
+
+        Moneybird webhooks flip `PortalOrg.billing_status` between active, cancelled
+        and payment_failed. Before this validator, an empty/whitespace-only token
+        made the signature check at /api/webhooks/moneybird optional (guarded by
+        `if settings.moneybird_webhook_token:`) — any unauthenticated POST could
+        mutate billing state. Fail fast at startup rather than ship a silent
+        fail-open. Same pattern as _require_vexa_webhook_secret above.
+
+        If Moneybird webhook processing must be disabled, unregister the router
+        instead of emptying the secret (see SPEC-SEC-WEBHOOK-001 REQ-3.3).
+
+        Env-parity: MONEYBIRD_WEBHOOK_TOKEN must exist in
+        klai-infra/core-01/.env.sops BEFORE this validator lands (see pitfall
+        `validator-env-parity` in .claude/rules/klai/pitfalls/process-rules.md).
+        """
+        if not self.moneybird_webhook_token or not self.moneybird_webhook_token.strip():
+            raise ValueError(
+                "Missing required: MONEYBIRD_WEBHOOK_TOKEN (SPEC-SEC-WEBHOOK-001 REQ-3). "
+                "Set it in SOPS before starting portal-api, or unregister the Moneybird router."
+            )
+        return self
+
 
 settings = Settings()  # type: ignore[call-arg]  # pydantic-settings reads required fields from env

--- a/klai-portal/backend/tests/conftest.py
+++ b/klai-portal/backend/tests/conftest.py
@@ -40,3 +40,4 @@ os.environ.setdefault("SSO_COOKIE_KEY", "R1c1-s96uO9Yz7k1E0kN6qz52gzd9PwNbAeZaks
 os.environ.setdefault("PORTAL_SECRETS_KEY", "0" * 64)  # 64-char hex; test placeholder only
 os.environ.setdefault("ENCRYPTION_KEY", "1" * 64)  # 64-char hex; test placeholder only
 os.environ.setdefault("VEXA_WEBHOOK_SECRET", "test-vexa-webhook-secret")  # SEC-013 F-033
+os.environ.setdefault("MONEYBIRD_WEBHOOK_TOKEN", "test-moneybird-webhook-token")  # SPEC-SEC-WEBHOOK-001 REQ-3

--- a/klai-portal/backend/tests/test_moneybird_webhook_auth.py
+++ b/klai-portal/backend/tests/test_moneybird_webhook_auth.py
@@ -1,0 +1,181 @@
+"""
+SPEC-SEC-WEBHOOK-001 REQ-3 / REQ-4 — Moneybird webhook auth hardening.
+
+Pre-SPEC defects closed:
+- `if settings.moneybird_webhook_token:` made the check optional when the env
+  var was empty → any unauthenticated POST could flip PortalOrg.billing_status
+  to active, cancelled, or payment_failed.
+- Token comparison used Python `!=`, a non-constant-time primitive.
+- Auth failure returned HTTP 200, hiding the rejection from upstream monitoring.
+
+After this SPEC:
+- Empty/whitespace `MONEYBIRD_WEBHOOK_TOKEN` aborts app startup (REQ-3.1).
+- Token compared with `hmac.compare_digest` on byte-encoded operands (REQ-4.1).
+- Auth failure returns HTTP 401 and emits `moneybird_webhook_auth_failed`
+  structlog event (REQ-4.2, REQ-4.3).
+
+NOTE on env-parity: this test file pairs with the
+`_require_moneybird_webhook_token` pydantic validator. The var MUST be
+present in klai-infra/core-01/.env.sops before this code lands in prod —
+see pitfall `validator-env-parity` in .claude/rules/klai/pitfalls/process-rules.md.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from pydantic import ValidationError
+
+from app.core.config import Settings
+
+# ---------------------------------------------------------------------------
+# REQ-3: Startup validator rejects empty / whitespace-only secret
+# ---------------------------------------------------------------------------
+
+
+def test_settings_startup_fails_without_moneybird_webhook_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty MONEYBIRD_WEBHOOK_TOKEN at Settings() construction aborts startup."""
+    monkeypatch.setenv("DATABASE_URL", os.environ["DATABASE_URL"])
+    monkeypatch.setenv("ZITADEL_PAT", os.environ["ZITADEL_PAT"])
+    monkeypatch.setenv("SSO_COOKIE_KEY", os.environ["SSO_COOKIE_KEY"])
+    monkeypatch.setenv("PORTAL_SECRETS_KEY", os.environ["PORTAL_SECRETS_KEY"])
+    monkeypatch.setenv("ENCRYPTION_KEY", os.environ["ENCRYPTION_KEY"])
+    monkeypatch.setenv("VEXA_WEBHOOK_SECRET", os.environ["VEXA_WEBHOOK_SECRET"])
+    monkeypatch.setenv("MONEYBIRD_WEBHOOK_TOKEN", "")
+
+    with pytest.raises(ValidationError) as excinfo:
+        Settings(_env_file=None)  # type: ignore[call-arg]
+
+    assert "MONEYBIRD_WEBHOOK_TOKEN" in str(excinfo.value)
+
+
+def test_settings_startup_fails_with_whitespace_only_moneybird_webhook_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Whitespace-only value is equivalent to empty — same rejection."""
+    monkeypatch.setenv("MONEYBIRD_WEBHOOK_TOKEN", "   ")
+
+    with pytest.raises(ValidationError) as excinfo:
+        Settings(_env_file=None)  # type: ignore[call-arg]
+
+    assert "MONEYBIRD_WEBHOOK_TOKEN" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# REQ-4: hmac.compare_digest + HTTP 401 on failure + structlog event
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def moneybird_client():
+    """TestClient bound to a throwaway app that mounts ONLY the webhooks router.
+
+    The DB dependency is overridden with a stub because auth failures reject
+    before touching the DB.
+    """
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from app.api.webhooks import router as webhooks_router
+    from app.core.database import get_db
+
+    app = FastAPI()
+    app.include_router(webhooks_router)
+
+    async def _fake_db():
+        class _Stub:
+            async def execute(self, *_args, **_kwargs):  # pragma: no cover - unreached
+                raise AssertionError("DB must not be touched on auth failure")
+
+            async def commit(self):  # pragma: no cover - unreached
+                raise AssertionError("DB must not be touched on auth failure")
+
+        yield _Stub()
+
+    app.dependency_overrides[get_db] = _fake_db
+
+    with TestClient(app) as client:
+        yield client
+
+
+def test_moneybird_webhook_wrong_token_returns_401(moneybird_client) -> None:
+    """REQ-4.2: wrong token → HTTP 401, not 200."""
+    response = moneybird_client.post(
+        "/api/webhooks/moneybird",
+        json={
+            "webhook_token": "wrong-token",
+            "entity_type": "Contact",
+            "event": "contact_mandate_request_succeeded",
+            "entity": {"id": "123"},
+        },
+    )
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Unauthorized"}
+
+
+def test_moneybird_webhook_missing_token_returns_401(moneybird_client) -> None:
+    """Payload without a webhook_token field is rejected — empty string does not
+    match the configured secret because compare_digest is constant-time against
+    any non-matching operand, not lenient on length."""
+    response = moneybird_client.post(
+        "/api/webhooks/moneybird",
+        json={"entity_type": "Contact", "event": "whatever"},
+    )
+    assert response.status_code == 401
+
+
+def test_moneybird_webhook_correct_token_does_not_401(moneybird_client) -> None:
+    """REQ-4.2 positive path: a matching token passes the auth gate.
+
+    Conftest default `MONEYBIRD_WEBHOOK_TOKEN=test-moneybird-webhook-token`
+    is the expected token value.
+    """
+    response = moneybird_client.post(
+        "/api/webhooks/moneybird",
+        json={
+            "webhook_token": "test-moneybird-webhook-token",
+            "entity_type": "Unknown",
+            "event": "ignored",
+        },
+    )
+    assert response.status_code == 200
+
+
+def test_moneybird_webhook_uses_constant_time_compare(moneybird_client) -> None:
+    """REQ-4.1: hmac.compare_digest must be used. We spy on the symbol imported
+    into the webhooks module and verify byte-encoded operands."""
+    import hmac
+    from unittest.mock import patch
+
+    with patch("app.api.webhooks.hmac.compare_digest", wraps=hmac.compare_digest) as spy:
+        moneybird_client.post(
+            "/api/webhooks/moneybird",
+            json={"webhook_token": "test-moneybird-webhook-token", "entity_type": "X", "event": "y"},
+        )
+
+    assert spy.called
+    args, _kwargs = spy.call_args
+    assert isinstance(args[0], bytes)
+    assert isinstance(args[1], bytes)
+
+
+def test_moneybird_webhook_auth_failure_emits_structlog_event(moneybird_client) -> None:
+    """REQ-4.3: auth failure emits `moneybird_webhook_auth_failed` with
+    correlation fields. Patch the module-level structlog logger and assert on
+    its `warning()` call — robust regardless of the process-wide structlog
+    renderer configuration."""
+    from unittest.mock import MagicMock, patch
+
+    fake_logger = MagicMock()
+    with patch("app.api.webhooks._structlog_logger", fake_logger):
+        moneybird_client.post(
+            "/api/webhooks/moneybird",
+            json={"webhook_token": "wrong", "entity_type": "Contact", "event": "the_event"},
+        )
+
+    fake_logger.warning.assert_called_once()
+    args, kwargs = fake_logger.warning.call_args
+    assert args[0] == "moneybird_webhook_auth_failed"
+    assert kwargs.get("event_type") == "the_event"
+    assert kwargs.get("entity_type") == "Contact"


### PR DESCRIPTION
## Summary

Closes REQ-3 (fail-closed startup validator) and REQ-4 (hmac.compare_digest + 401 + structlog) of SPEC-SEC-WEBHOOK-001 for the Moneybird webhook.

## Env-parity precondition satisfied this time ✅

Unlike #150 (reverted in `6ee5315d` after causing prod 502), this PR lands AFTER `MONEYBIRD_WEBHOOK_TOKEN` was added to `klai-infra/core-01/.env.sops` in klai-infra commit `7170003`. Verified via:

```
ssh core-01 grep MONEYBIRD_WEBHOOK_TOKEN /opt/klai/.env  # → present, 65 chars
```

So `_require_moneybird_webhook_token` will pass at startup. No 502 loop.

## Changes

- `app/core/config.py`: new `_require_moneybird_webhook_token` pydantic @model_validator mirroring `_require_vexa_webhook_secret`
- `app/api/webhooks.py`: replaced `if settings.X:` + `!=` + `Response(200)` with unconditional `hmac.compare_digest` + `HTTPException(401)` + structlog `moneybird_webhook_auth_failed` event
- `tests/conftest.py`: add `MONEYBIRD_WEBHOOK_TOKEN` default so other tests continue to construct Settings()
- `tests/test_moneybird_webhook_auth.py`: 7 new tests covering startup-fail-on-empty, 401 on wrong/missing token, compare_digest byte-encoded operands, structlog event emission

## Deploy forcing function (dashboard-side)

The token generated into SOPS (`openssl rand -hex 32`) MUST be mirrored in the Moneybird dashboard's webhook settings — **you (human) do this part**. Any Moneybird webhook events posted with the OLD value (or no value) will receive 401 after this PR merges. Klai is in dev per your earlier note; this window is accepted.

Generated token value is in the SOPS file committed to klai-infra. Retrieve via `ssh core-01 'grep MONEYBIRD_WEBHOOK_TOKEN /opt/klai/.env'` when configuring Moneybird.

## Test plan

- [ ] CI green (quality, semgrep, rls-smoke-test)
- [ ] Post-merge: portal-api stays up (502 check immediately after deploy)
- [ ] Post-merge: `curl -X POST -d '{}' https://my.getklai.com/api/webhooks/moneybird` returns 401 (previously 200)
- [ ] Post-merge: Moneybird dashboard token updated to match SOPS value

## Precedents

- #149 — SPEC docs + klai-security-audit agent (merged)
- #155 — Vexa slice REQ-2 (merged)
- #150 — previous attempt that bundled this with REQ-2 (reverted; incident captured as pitfall `validator-env-parity`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)