### PR TITLE
security(portal-api+compose): wire Vexa POST_MEETING_HOOKS auth via Basic (SPEC-SEC-WEBHOOK-001 completion)

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -883,7 +883,14 @@ services:
       CAPTURE_MODES: "audio"
       TRANSCRIPTION_SERVICE_URL: http://172.18.0.1:8000/v1/audio/transcriptions
       TRANSCRIPTION_SERVICE_TOKEN: ${WHISPER_SERVICE_TOKEN:-internal}  # SEC-013 F-035 — prefer SOPS secret, fallback to legacy placeholder
-      POST_MEETING_HOOKS: http://portal-api:8010/api/bots/internal/webhook
+      # SPEC-SEC-WEBHOOK-001 REQ-2 forcing function: portal-api's webhook requires
+      # an Authorization header now. Vexa's meeting-api does not natively inject a
+      # Bearer header (fire_post_meeting_hooks does not pass webhook_secret to
+      # deliver()), but its httpx client auto-adds `Authorization: Basic <b64>`
+      # when the URL contains userinfo. The "vexa" user component is ignored by
+      # portal-api; the password half carries VEXA_WEBHOOK_SECRET. If the secret
+      # is rotated, update this value in the same deploy. Do not log this value.
+      POST_MEETING_HOOKS: http://vexa:${VEXA_WEBHOOK_SECRET}@portal-api:8010/api/bots/internal/webhook
       LOG_LEVEL: INFO
     init: true
     depends_on:

--- a/klai-portal/backend/app/api/meetings.py
+++ b/klai-portal/backend/app/api/meetings.py
@@ -4,6 +4,8 @@ Route prefix: /api/bots
 """
 
 import asyncio
+import base64
+import binascii
 import hmac
 import io
 from datetime import UTC, datetime
@@ -45,19 +47,46 @@ MAX_CONCURRENT_BOTS = 2
 
 def _require_webhook_secret(request: Request) -> None:
     # SPEC-SEC-WEBHOOK-001 REQ-2: fail-closed auth on /api/bots/internal/webhook.
-    # Authentication is the Bearer-token compare alone — NO IP-range short-circuit.
-    # The previous "internal Docker network callers are trusted" path (172.x / 10.x
-    # / 192.168.x) was effectively an auth bypass: Caddy's container IP always sat
-    # in those ranges, so every external request was implicitly authenticated.
-    # Vexa's POST_MEETING_HOOKS MUST supply `Authorization: Bearer <secret>` now.
+    # Authentication is the Authorization-header compare alone — NO IP-range
+    # short-circuit. Two accepted forms:
     #
-    # Startup validator _require_vexa_webhook_secret in app.core.config guarantees
+    # 1. `Authorization: Bearer <vexa_webhook_secret>` — canonical form, used by any
+    #    caller that can add a custom header (e.g. a proxy shim or a future Vexa
+    #    release that wires `webhook_secret` into `fire_post_meeting_hooks`).
+    #
+    # 2. `Authorization: Basic <base64(user:vexa_webhook_secret)>` — derived
+    #    automatically by httpx when the POST URL contains userinfo
+    #    (`http://u:secret@portal-api:8010/...`). This is the path used today by
+    #    Vexa's `POST_MEETING_HOOKS` — Vexa's `fire_post_meeting_hooks` does not
+    #    expose a header-injection hook, but it passes the URL verbatim to
+    #    httpx.AsyncClient.post which auto-adds Basic auth from userinfo. The
+    #    `user` component is ignored by this guard; the secret lives in the
+    #    password half. See SPEC-SEC-WEBHOOK-001 Assumptions ("URL variant that
+    #    embeds the secret").
+    #
+    # The IP-range "trusted Docker networks" shortcut has been permanently removed;
+    # every caller MUST present one of the two valid Authorization forms.
+    # Startup validator `_require_vexa_webhook_secret` in app.core.config guarantees
     # settings.vexa_webhook_secret is non-empty, so an empty expected value cannot
-    # lead to compare_digest returning True against an empty attacker header.
+    # lead to a compare_digest false-positive.
     auth_header = request.headers.get("Authorization", "")
-    expected = f"Bearer {settings.vexa_webhook_secret}"
-    if not hmac.compare_digest(auth_header.encode("utf-8"), expected.encode("utf-8")):
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
+    expected_secret = settings.vexa_webhook_secret.encode("utf-8")
+
+    if auth_header.startswith("Bearer "):
+        expected = f"Bearer {settings.vexa_webhook_secret}".encode()
+        if hmac.compare_digest(auth_header.encode("utf-8"), expected):
+            return
+    elif auth_header.startswith("Basic "):
+        try:
+            decoded = base64.b64decode(auth_header[len("Basic ") :], validate=True).decode("utf-8")
+        except (binascii.Error, UnicodeDecodeError):
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized") from None
+        # Basic auth format is "user:password"; only the password carries the secret.
+        _, sep, password = decoded.partition(":")
+        if sep and hmac.compare_digest(password.encode("utf-8"), expected_secret):
+            return
+
+    raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
 
 
 # -- Request / Response models -----------------------------------------------

--- a/klai-portal/backend/tests/test_meetings_webhook_auth.py
+++ b/klai-portal/backend/tests/test_meetings_webhook_auth.py
@@ -15,6 +15,7 @@ Covers:
 
 from __future__ import annotations
 
+import base64
 import hmac
 import os
 from unittest.mock import MagicMock, patch
@@ -25,6 +26,13 @@ from pydantic import ValidationError
 
 from app.api.meetings import _require_webhook_secret
 from app.core.config import Settings
+
+
+def _basic_auth_header(user: str, password: str) -> str:
+    """Build the `Authorization: Basic <base64>` header httpx would produce for
+    a URL with userinfo (`http://user:password@host/path`)."""
+    raw = f"{user}:{password}".encode()
+    return f"Basic {base64.b64encode(raw).decode('ascii')}"
 
 
 def _make_request(client_host: str | None, auth_header: str | None) -> MagicMock:
@@ -172,3 +180,90 @@ def test_require_webhook_secret_uses_constant_time_compare() -> None:
     assert isinstance(args[1], bytes)
     assert args[0] == b"Bearer correct-secret"
     assert args[1] == b"Bearer correct-secret"
+
+
+# ---------------------------------------------------------------------------
+# Basic-auth branch (SPEC Assumption "URL variant that embeds the secret")
+#
+# Vexa's POST_MEETING_HOOKS currently cannot inject a Bearer header — but httpx
+# converts URL userinfo into `Authorization: Basic <b64(user:password)>`. The
+# guard accepts Basic as an alternative form; the password half MUST match
+# settings.vexa_webhook_secret.
+# ---------------------------------------------------------------------------
+
+
+def test_require_webhook_secret_accepts_basic_auth_with_correct_password() -> None:
+    """URL userinfo => httpx sends `Authorization: Basic <b64(user:secret)>`.
+
+    The user component is ignored; any non-empty user is accepted. This mirrors
+    what Vexa produces with `POST_MEETING_HOOKS=http://vexa:<secret>@portal-api/...`.
+    """
+    req = _make_request(
+        client_host="172.18.0.5",  # Docker-internal, like real Vexa callback
+        auth_header=_basic_auth_header("vexa", "correct-secret"),
+    )
+    with patch("app.api.meetings.settings") as mock_settings:
+        mock_settings.vexa_webhook_secret = "correct-secret"
+        _require_webhook_secret(req)  # no exception
+
+
+def test_require_webhook_secret_rejects_basic_auth_with_wrong_password() -> None:
+    """Wrong password in Basic header is rejected — matches the Bearer path."""
+    req = _make_request(
+        client_host="172.18.0.5",
+        auth_header=_basic_auth_header("vexa", "wrong-secret"),
+    )
+    with patch("app.api.meetings.settings") as mock_settings:
+        mock_settings.vexa_webhook_secret = "correct-secret"
+        with pytest.raises(HTTPException) as excinfo:
+            _require_webhook_secret(req)
+    assert excinfo.value.status_code == 401
+
+
+def test_require_webhook_secret_basic_auth_ignores_user_component() -> None:
+    """User component of Basic auth MUST NOT influence the decision. The guard
+    only reads the password half after the first colon. Per RFC 7617 the user
+    component cannot contain a colon, so `partition(":")` splits unambiguously.
+    """
+    for user in ("vexa", "", "any-random-user"):
+        req = _make_request(
+            client_host="172.18.0.5",
+            auth_header=_basic_auth_header(user, "correct-secret"),
+        )
+        with patch("app.api.meetings.settings") as mock_settings:
+            mock_settings.vexa_webhook_secret = "correct-secret"
+            _require_webhook_secret(req)  # no exception
+
+
+def test_require_webhook_secret_rejects_malformed_basic_auth() -> None:
+    """Non-base64 payload in Basic header → 401, not 500. Prevents DoS via
+    malformed auth."""
+    req = _make_request(client_host="203.0.113.5", auth_header="Basic !!!not-valid-base64!!!")
+    with patch("app.api.meetings.settings") as mock_settings:
+        mock_settings.vexa_webhook_secret = "correct-secret"
+        with pytest.raises(HTTPException) as excinfo:
+            _require_webhook_secret(req)
+    assert excinfo.value.status_code == 401
+
+
+def test_require_webhook_secret_rejects_basic_auth_without_colon() -> None:
+    """Decoded Basic payload missing a colon is invalid per RFC 7617 → 401."""
+    # `notacolon` base64 → "bm90YWNvbG9u"
+    payload = base64.b64encode(b"notacolon").decode("ascii")
+    req = _make_request(client_host="203.0.113.5", auth_header=f"Basic {payload}")
+    with patch("app.api.meetings.settings") as mock_settings:
+        mock_settings.vexa_webhook_secret = "correct-secret"
+        with pytest.raises(HTTPException) as excinfo:
+            _require_webhook_secret(req)
+    assert excinfo.value.status_code == 401
+
+
+def test_require_webhook_secret_rejects_unknown_auth_scheme() -> None:
+    """Digest, JWT-in-Authorization, etc. are not accepted — 401."""
+    for header in ("Digest stuff", "JWT abc.def.ghi", "Token foo", "correct-secret"):
+        req = _make_request(client_host="203.0.113.5", auth_header=header)
+        with patch("app.api.meetings.settings") as mock_settings:
+            mock_settings.vexa_webhook_secret = "correct-secret"
+            with pytest.raises(HTTPException) as excinfo:
+                _require_webhook_secret(req)
+        assert excinfo.value.status_code == 401, f"scheme {header!r} was unexpectedly accepted"


### PR DESCRIPTION
## Summary

Completes the forcing-function half of SPEC-SEC-WEBHOOK-001 REQ-2 (merged as #155). Since PR #155 removed the Vexa IP-range bypass, Vexa's post-meeting callbacks have been failing with 401. This PR wires the secret through Vexa's config so callbacks work again.

## Design choice: Basic, not Bearer

Upstream `vexaai/meeting-api:0.10.0` does NOT expose a way to inject a Bearer header — `fire_post_meeting_hooks()` calls `deliver(url, payload)` without passing `webhook_secret` (which `deliver` supports but only if invoked with it). No companion env var like `POST_MEETING_HOOK_SECRETS` exists upstream. Fork is out of scope.

Vexa's `deliver()` uses `httpx.AsyncClient.post(url, ...)`, and **httpx auto-converts URL userinfo into `Authorization: Basic <b64>`**. So the clean config-only path is:

- `POST_MEETING_HOOKS=http://vexa:${VEXA_WEBHOOK_SECRET}@portal-api:8010/...`
- Portal-api accepts Basic in addition to Bearer, with the password half being the secret

SPEC-SEC-WEBHOOK-001 Assumptions explicitly listed this as a valid path ("URL variant that embeds the secret"), so no SPEC amendment needed.

## Changes

- `klai-portal/backend/app/api/meetings.py`: `_require_webhook_secret` now accepts both `Authorization: Bearer <secret>` (unchanged, forward-compatible) and `Authorization: Basic <b64(user:secret)>` (new). Both use `hmac.compare_digest`. User component ignored (RFC 7617).
- `deploy/docker-compose.yml:886`: POST_MEETING_HOOKS now embeds the secret in userinfo. Interpolated by docker-compose at deploy time from /opt/klai/.env.
- `klai-portal/backend/tests/test_meetings_webhook_auth.py`: 6 new Basic-auth tests (correct-pass, wrong-pass, user-ignored parametrised, malformed-base64, missing-colon, unknown-scheme). 14/14 webhook-auth tests pass.

## Verified locally

- VEXA_WEBHOOK_SECRET is 64 URL-safe hex chars (verified on core-01) — no URL-encoding edge cases
- `ruff check` clean, `pyright` 0 errors on changed files
- Full Vexa webhook auth suite: 14/14 pass

## Test plan

- [ ] CI green (quality / semgrep / rls-smoke)
- [ ] Post-deploy: `docker exec klai-core-meeting-api-1 printenv POST_MEETING_HOOKS` shows interpolated URL
- [ ] Post-deploy: next real Vexa post-meeting callback lands with HTTP 200 (VictoriaLogs: `service:portal-api AND path:/api/bots/internal/webhook AND status:200`)
- [ ] Post-deploy: curl direct without auth still returns 401 (regression check)

## Not in this PR

- REQ-1 uvicorn --proxy-headers service-wide
- REQ-5.4 timing microbenchmark
- REQ-5.6 retrieval-api XFF-spoof bucket-identity test
- REQ-6 shared uvicorn launch wrapper

🤖 Generated with [Claude Code](https://claude.com/claude-code)