### PR TITLE
security(portal-api): SPEC-SEC-WEBHOOK-001 REQ-1 — uvicorn --proxy-headers + dynamic Caddy trust

### DIFF
--- a/klai-portal/backend/entrypoint.sh
+++ b/klai-portal/backend/entrypoint.sh
@@ -11,6 +11,38 @@ set -eu
 
 echo "[entrypoint] Running alembic upgrade head…"
 alembic upgrade head
-echo "[entrypoint] Migrations applied. Starting uvicorn."
+echo "[entrypoint] Migrations applied."
 
-exec uvicorn app.main:app --host 0.0.0.0 --port 8010 "$@"
+# SPEC-SEC-WEBHOOK-001 REQ-1: uvicorn --proxy-headers trust-boundary.
+#
+# Without --proxy-headers, `request.client.host` equals the TCP peer — that
+# is Caddy's klai-net container IP (172.x.y.z) for every external request.
+# Cornelis audit #2 exploited exactly that to bypass the Vexa webhook auth
+# check (the now-deleted "internal Docker network = trusted" shortcut
+# short-circuited on Caddy's own IP). REQ-2 removed the shortcut in #155;
+# this step adds the proper proxy-headers handling so future rate-limiting,
+# CSRF-exempt audits, and log correlation see the REAL external client IP.
+#
+# `--forwarded-allow-ips` must NOT be `*` (REQ-1.2) and must NOT be a
+# hardcoded IP (container IPs change per restart —
+# .claude/rules/klai/infra/servers.md). We resolve `caddy` at container
+# start time via Docker's embedded DNS. If caddy is unresolvable (bootstrap
+# race, compose network misconfig), we fall back to 127.0.0.1 which means
+# "trust nobody's X-Forwarded-For" — safe default that keeps the service
+# up and surfaces the misconfiguration via `request.client.host` showing
+# the TCP peer instead of a real client.
+CADDY_IP="$(getent hosts caddy 2>/dev/null | awk '{print $1}' | head -n1)"
+if [ -z "$CADDY_IP" ]; then
+    echo "[entrypoint] WARN: cannot resolve caddy via Docker DNS — falling back to --forwarded-allow-ips=127.0.0.1 (X-Forwarded-For ignored)."
+    CADDY_IP="127.0.0.1"
+else
+    echo "[entrypoint] Resolved caddy → $CADDY_IP (trusted source for X-Forwarded-For / X-Forwarded-Proto)."
+fi
+
+echo "[entrypoint] Starting uvicorn with --proxy-headers --forwarded-allow-ips=$CADDY_IP"
+exec uvicorn app.main:app \
+    --host 0.0.0.0 \
+    --port 8010 \
+    --proxy-headers \
+    --forwarded-allow-ips="$CADDY_IP" \
+    "$@"


### PR DESCRIPTION
## Summary

Closes REQ-1 of SPEC-SEC-WEBHOOK-001 for **portal-api only**. Adds `--proxy-headers` with `--forwarded-allow-ips` scoped to Caddy's container IP (resolved at container start via Docker's embedded DNS).

## Before / after

| State | `request.client.host` on external request |
|---|---|
| Before | `172.18.0.x` (Caddy's klai-net container IP) |
| After | the real external client IP, as Caddy puts in `X-Forwarded-For` |

## Why dynamic resolution

Two constraints conflict: `.claude/rules/klai/infra/servers.md` bans hardcoded container IPs, and SPEC REQ-1.2 bans `--forwarded-allow-ips=*`. The resolution: entrypoint.sh resolves `caddy` via `getent hosts` at container start, passes the current IP to uvicorn.

Fallback on resolution failure: `127.0.0.1` (trust nobody) — safe default, service stays up, misconfiguration surfaces in logs instead of breaking auth.

## Verification

- `sh -n entrypoint.sh` clean
- Dry-run with mocked `getent` → `uvicorn --proxy-headers --forwarded-allow-ips=172.18.0.6`
- Dry-run with error'd `getent` → fallback to `--forwarded-allow-ips=127.0.0.1`
- `getent` confirmed present in the portal-api image (python:3.12-slim base, libc-bin)

## Scope note

Portal-api only. retrieval-api / knowledge-ingest / scribe-api also need the same treatment per REQ-1 v0.3.0 amendments but belong in separate PRs alongside their own auth-hardening work.

## Test plan

- [ ] CI green
- [ ] Post-deploy: `docker logs klai-core-portal-api-1 | grep entrypoint` shows `Resolved caddy → <ip>` line
- [ ] Post-deploy: access log / structlog shows real client IP on external requests (e.g. my own curl will appear as my ISP IP, not 172.18.0.6)
- [ ] Post-deploy: Vexa + Moneybird webhook auth paths still work (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)