### PR TITLE
fix(portal): split YouTube IP-block from no-transcript (SPEC-KB-SOURCES-001)

### DIFF
--- a/klai-portal/backend/app/api/app_knowledge_sources.py
+++ b/klai-portal/backend/app/api/app_knowledge_sources.py
@@ -251,6 +251,14 @@ async def add_youtube_source(
             status_code=422,
             detail="This video has no transcript available",
         ) from exc
+    except SourceFetchError as exc:
+        # YouTube refused our request (IP block / rate limit / transient
+        # failure). Distinct from UnsupportedSource — this is retryable
+        # and NOT the user's fault.
+        raise HTTPException(
+            status_code=502,
+            detail="Could not reach YouTube — try again",
+        ) from exc
 
     # video_id is the portion after "youtube:" in source_ref (R3.5).
     video_id = source_ref.removeprefix("youtube:")

--- a/klai-portal/backend/app/core/config.py
+++ b/klai-portal/backend/app/core/config.py
@@ -154,6 +154,14 @@ class Settings(BaseSettings):
     # Same endpoint that klai-knowledge-ingest and klai-connector already target.
     crawl4ai_api_url: str = "http://crawl4ai:11235"
 
+    # Optional residential proxy for YouTube transcript fetches (SPEC-KB-SOURCES-001
+    # D5 follow-up). When set, the YouTube extractor retries via this proxy when
+    # YouTube refuses the datacenter IP (RequestBlocked / IpBlocked). Empty = direct
+    # fetch only, and an IP-block surfaces as a 502 "could not reach YouTube".
+    # Format: full proxy URL including scheme + credentials, e.g.
+    # "http://user:pass@p.webshare.io:9999".
+    youtube_proxy_url: str = ""
+
     # Redis (used for retrieval logs and feedback idempotency -- SPEC-KB-015)
     redis_url: str = ""
 

--- a/klai-portal/backend/app/services/source_extractors/youtube.py
+++ b/klai-portal/backend/app/services/source_extractors/youtube.py
@@ -6,6 +6,21 @@ Extracts the video ID from a YouTube URL, fetches the transcript via
 oembed endpoint. Failure in the oembed call is best-effort — transcript
 is the primary payload and must drive success / failure, per SPEC R3.4.
 
+Error mapping (1.3):
+- ``NoTranscriptFound`` / ``TranscriptsDisabled`` / ``VideoUnavailable``
+  → ``UnsupportedSourceError`` → 422 ("no transcript available"). This is
+  a user-facing truth: the video genuinely cannot be ingested.
+- ``RequestBlocked`` / ``IpBlocked`` / ``YouTubeRequestFailed`` /
+  ``CouldNotRetrieveTranscript`` → ``SourceFetchError`` → 502 ("could not
+  reach YouTube"). These are infrastructure signals — typically YouTube
+  rate-limiting the datacenter IP. Telling the user "no transcript" here
+  is a lie; "try again" / "temporarily unavailable" is the truth.
+
+Optional proxy fallback: when ``settings.youtube_proxy_url`` is set,
+infrastructure-level errors trigger one retry via
+``GenericProxyConfig(http_url, https_url)``. Ported from
+``klai-focus/research-api/app/services/youtube.py`` (SPEC D5 follow-up).
+
 Video-ID extraction is ported from klai-focus (no verbatim re-use — same
 regex shape, broader host coverage).
 """
@@ -18,15 +33,21 @@ import re
 import httpx
 import structlog
 from youtube_transcript_api import (
+    CouldNotRetrieveTranscript,
+    IpBlocked,
     NoTranscriptFound,
     RequestBlocked,
     TranscriptsDisabled,
     VideoUnavailable,
+    YouTubeRequestFailed,
     YouTubeTranscriptApi,
 )
+from youtube_transcript_api.proxies import GenericProxyConfig
 
+from app.core.config import settings
 from app.services.source_extractors.exceptions import (
     InvalidUrlError,
+    SourceFetchError,
     UnsupportedSourceError,
 )
 
@@ -59,6 +80,28 @@ _YOUTUBE_URL_RE = re.compile(
 _OEMBED_URL = "https://www.youtube.com/oembed"
 _OEMBED_TIMEOUT = 5.0
 
+# Language preference order: English then Dutch, with youtube-transcript-api's
+# own fallback behaviour handling everything else (find_transcript returns
+# whatever language is available after those two).
+_TRANSCRIPT_LANGUAGES: tuple[str, ...] = ("en", "nl")
+
+# These exceptions mean the video HAS no accessible transcript — truthful
+# "no transcript" banner to the user.
+_NO_TRANSCRIPT_EXCEPTIONS = (
+    TranscriptsDisabled,
+    NoTranscriptFound,
+    VideoUnavailable,
+)
+
+# These exceptions mean YouTube refused OUR request — infrastructure issue,
+# unrelated to whether the video has a transcript. User gets a retry banner.
+_UPSTREAM_BLOCKED_EXCEPTIONS = (
+    RequestBlocked,
+    IpBlocked,
+    YouTubeRequestFailed,
+    CouldNotRetrieveTranscript,
+)
+
 
 def _extract_video_id(url: str) -> str:
     """Parse ``url`` and return the 11-character YouTube video ID.
@@ -74,15 +117,24 @@ def _extract_video_id(url: str) -> str:
     return match.group(1)
 
 
-def _fetch_transcript_sync(video_id: str) -> list[str]:
+def _make_api(proxy_url: str | None) -> YouTubeTranscriptApi:
+    """Instantiate ``YouTubeTranscriptApi`` with an optional residential proxy."""
+    if proxy_url:
+        proxy = GenericProxyConfig(http_url=proxy_url, https_url=proxy_url)
+        return YouTubeTranscriptApi(proxy_config=proxy)
+    return YouTubeTranscriptApi()
+
+
+def _fetch_transcript_sync(video_id: str, proxy_url: str | None) -> list[str]:
     """Blocking transcript fetch — runs in a worker thread.
 
-    Returns the list of snippet texts; caller joins them. Language
-    preference is English then Dutch, then youtube-transcript-api's
-    default fallback (any available).
+    Returns a list of snippet text strings. ``api.fetch`` internally calls
+    ``list(video_id).find_transcript(languages).fetch()``, and
+    ``find_transcript`` already falls back from manual to auto-generated
+    captions, so we only need one call here.
     """
-    api = YouTubeTranscriptApi()
-    fetched = api.fetch(video_id, languages=["en", "nl"])
+    api = _make_api(proxy_url)
+    fetched = api.fetch(video_id, languages=list(_TRANSCRIPT_LANGUAGES))
     return [getattr(snippet, "text", "") for snippet in fetched]
 
 
@@ -91,16 +143,61 @@ async def _fetch_transcript(video_id: str) -> str:
 
     Joins segments with a single space; timestamps are deliberately
     discarded (R3.3 — not stored in retrieved text).
+
+    Tries a direct connection first. If YouTube blocks the request AND
+    ``settings.youtube_proxy_url`` is configured, retries once via the
+    proxy. No proxy → the upstream block propagates as SourceFetchError.
+
+    Raises:
+        UnsupportedSourceError: the video genuinely has no transcript.
+        SourceFetchError: YouTube refused the request (IP block, rate
+            limit, transient failure). The user sees a retry banner, not
+            a misleading "no transcript" message.
     """
+    proxy_url: str | None = None
     try:
-        snippets = await asyncio.to_thread(_fetch_transcript_sync, video_id)
-    except (
-        TranscriptsDisabled,
-        NoTranscriptFound,
-        VideoUnavailable,
-        RequestBlocked,
-    ) as exc:
+        snippets = await asyncio.to_thread(_fetch_transcript_sync, video_id, proxy_url)
+    except _NO_TRANSCRIPT_EXCEPTIONS as exc:
+        logger.info(
+            "youtube_transcript_unavailable",
+            video_id=video_id,
+            error_class=exc.__class__.__name__,
+        )
         raise UnsupportedSourceError(f"No transcript available for {video_id}: {exc.__class__.__name__}") from exc
+    except _UPSTREAM_BLOCKED_EXCEPTIONS as exc:
+        proxy_url = settings.youtube_proxy_url or None
+        if not proxy_url:
+            logger.warning(
+                "youtube_upstream_blocked_no_proxy",
+                video_id=video_id,
+                error_class=exc.__class__.__name__,
+            )
+            raise SourceFetchError(f"YouTube refused the request for {video_id}: {exc.__class__.__name__}") from exc
+
+        logger.warning(
+            "youtube_upstream_blocked_retry_via_proxy",
+            video_id=video_id,
+            error_class=exc.__class__.__name__,
+        )
+        try:
+            snippets = await asyncio.to_thread(_fetch_transcript_sync, video_id, proxy_url)
+        except _NO_TRANSCRIPT_EXCEPTIONS as proxy_exc:
+            # Proxy got through but the video really has no transcript.
+            logger.info(
+                "youtube_transcript_unavailable_via_proxy",
+                video_id=video_id,
+                error_class=proxy_exc.__class__.__name__,
+            )
+            raise UnsupportedSourceError(
+                f"No transcript available for {video_id}: {proxy_exc.__class__.__name__}"
+            ) from proxy_exc
+        except _UPSTREAM_BLOCKED_EXCEPTIONS as proxy_exc:
+            logger.exception(
+                "youtube_upstream_blocked_via_proxy",
+                video_id=video_id,
+                error_class=proxy_exc.__class__.__name__,
+            )
+            raise SourceFetchError(f"YouTube refused the request even via proxy for {video_id}") from proxy_exc
 
     joined = " ".join(text.strip() for text in snippets if text and text.strip())
     if not joined:
@@ -146,7 +243,10 @@ async def extract_youtube(url: str) -> tuple[str, str, str]:
 
     Raises:
         InvalidUrlError: URL does not parse as a YouTube video.
-        UnsupportedSourceError: no transcript available in any language.
+        UnsupportedSourceError: the video genuinely has no transcript.
+        SourceFetchError: YouTube refused the request (IP block, rate
+            limit, transient failure) — retry-friendly banner, not the
+            "no transcript" banner.
     """
     video_id = _extract_video_id(url)
     transcript = await _fetch_transcript(video_id)

--- a/klai-portal/backend/tests/test_app_knowledge_sources.py
+++ b/klai-portal/backend/tests/test_app_knowledge_sources.py
@@ -468,6 +468,30 @@ class TestYoutubeRoute:
         assert exc.value.status_code == 422
 
     @pytest.mark.asyncio
+    async def test_returns_502_on_source_fetch_error(self) -> None:
+        """IP block / rate-limit on YouTube → 502, NOT 422 (SPEC-KB-SOURCES-001 v1.3)."""
+        from app.api.app_knowledge_sources import YouTubeSourceRequest, add_youtube_source
+
+        kb = _make_kb()
+        db = _make_db_mock(kb)
+
+        with (
+            _CommonPatches(
+                extract_target="youtube",
+                extract_side_effect=SourceFetchError("YouTube refused the request"),
+            ),
+            pytest.raises(HTTPException) as exc,
+        ):
+            await add_youtube_source(
+                kb_slug="personal",
+                body=YouTubeSourceRequest(url="https://youtu.be/dQw4w9WgXcQ"),
+                credentials=MagicMock(),
+                db=db,
+            )
+        assert exc.value.status_code == 502
+        assert "youtube" in exc.value.detail.lower()
+
+    @pytest.mark.asyncio
     async def test_source_ref_dedup_across_url_variants(self) -> None:
         """R3.5: same video via different URL shapes hits the same source_ref."""
         from app.api.app_knowledge_sources import YouTubeSourceRequest, add_youtube_source

--- a/klai-portal/backend/tests/test_source_extractors_youtube.py
+++ b/klai-portal/backend/tests/test_source_extractors_youtube.py
@@ -3,6 +3,15 @@
 Covers video-ID extraction across URL variants, transcript fetching via
 youtube-transcript-api (mocked), and oembed title resolution with
 best-effort fallback.
+
+Error-mapping invariants (SPEC-KB-SOURCES-001 v1.3):
+- NoTranscriptFound / TranscriptsDisabled / VideoUnavailable
+  → UnsupportedSourceError (route → 422, "no transcript").
+- RequestBlocked / IpBlocked / YouTubeRequestFailed /
+  CouldNotRetrieveTranscript
+  → SourceFetchError (route → 502, "could not reach YouTube").
+  With ``settings.youtube_proxy_url`` configured, a retry is attempted
+  via the proxy before the SourceFetchError is raised.
 """
 
 from __future__ import annotations
@@ -13,13 +22,18 @@ from typing import Any
 import httpx
 import pytest
 from youtube_transcript_api import (
+    CouldNotRetrieveTranscript,
+    IpBlocked,
     NoTranscriptFound,
+    RequestBlocked,
     TranscriptsDisabled,
     VideoUnavailable,
+    YouTubeRequestFailed,
 )
 
 from app.services.source_extractors.exceptions import (
     InvalidUrlError,
+    SourceFetchError,
     UnsupportedSourceError,
 )
 from app.services.source_extractors.youtube import (
@@ -55,22 +69,61 @@ class _FakeApi:
         return _FakeTranscript(self._result)
 
 
+def _make_factory(results: list[list[_Snippet] | Exception]):
+    """Build a ``YouTubeTranscriptApi(proxy_config=...)`` factory.
+
+    ``results`` is the queue of outcomes for successive instantiations:
+    index 0 is returned on the first ``YouTubeTranscriptApi(...)`` call,
+    index 1 on the second, etc. Each entry is either snippet list or an
+    exception to raise from ``.fetch``. Matches the production retry
+    flow: direct call first, optional proxy-retry on upstream block.
+    """
+    calls: list[dict[str, Any]] = []
+
+    def _factory(*, proxy_config: Any = None) -> _FakeApi:
+        calls.append({"proxy_config": proxy_config})
+        result = results[min(len(calls) - 1, len(results) - 1)]
+        return _FakeApi(result)
+
+    _factory.calls = calls  # type: ignore[attr-defined]
+    return _factory
+
+
 @pytest.fixture
 def mock_transcript(monkeypatch: pytest.MonkeyPatch):
-    """Return a callable that installs a transcript or exception into the extractor."""
+    """Install a one-shot transcript result (no retry)."""
 
     def _install(result: list[_Snippet] | Exception) -> None:
         monkeypatch.setattr(
             "app.services.source_extractors.youtube.YouTubeTranscriptApi",
-            lambda: _FakeApi(result),
+            _make_factory([result]),
         )
 
     return _install
 
 
 @pytest.fixture
+def mock_transcript_sequence(monkeypatch: pytest.MonkeyPatch):
+    """Install an ordered sequence of results for successive API instantiations.
+
+    Returns the factory object so tests can inspect ``.calls`` to assert
+    how many times (and with which proxy_config) the API was instantiated.
+    """
+
+    def _install(results: list[list[_Snippet] | Exception]):
+        factory = _make_factory(results)
+        monkeypatch.setattr(
+            "app.services.source_extractors.youtube.YouTubeTranscriptApi",
+            factory,
+        )
+        return factory
+
+    return _install
+
+
+@pytest.fixture
 def mock_oembed(monkeypatch: pytest.MonkeyPatch):
-    """Replace the oembed AsyncClient with a MockTransport that returns the given response."""
+    """Replace the oembed AsyncClient with a MockTransport."""
 
     def _install(response: httpx.Response) -> None:
         def handler(_request: httpx.Request) -> httpx.Response:
@@ -186,6 +239,127 @@ class TestTranscriptFetching:
         mock_oembed(httpx.Response(200, json={"title": "T"}))
         with pytest.raises(UnsupportedSourceError):
             await extract_youtube("https://youtu.be/dQw4w9WgXcQ")
+
+
+class TestUpstreamBlocked:
+    """RequestBlocked / IpBlocked / YouTubeRequestFailed / CouldNotRetrieveTranscript
+    must NOT leak as "no transcript" — they're infrastructure, not user input."""
+
+    async def test_request_blocked_no_proxy_raises_source_fetch(
+        self, mock_transcript, mock_oembed, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("app.services.source_extractors.youtube.settings.youtube_proxy_url", "")
+        mock_transcript(RequestBlocked("dQw4w9WgXcQ"))
+        mock_oembed(httpx.Response(200, json={"title": "T"}))
+        with pytest.raises(SourceFetchError):
+            await extract_youtube("https://youtu.be/dQw4w9WgXcQ")
+
+    async def test_ip_blocked_no_proxy_raises_source_fetch(
+        self, mock_transcript, mock_oembed, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("app.services.source_extractors.youtube.settings.youtube_proxy_url", "")
+        mock_transcript(IpBlocked("dQw4w9WgXcQ"))
+        mock_oembed(httpx.Response(200, json={"title": "T"}))
+        with pytest.raises(SourceFetchError):
+            await extract_youtube("https://youtu.be/dQw4w9WgXcQ")
+
+    async def test_youtube_request_failed_no_proxy_raises_source_fetch(
+        self, mock_transcript, mock_oembed, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("app.services.source_extractors.youtube.settings.youtube_proxy_url", "")
+        mock_transcript(YouTubeRequestFailed("dQw4w9WgXcQ", "network error"))
+        mock_oembed(httpx.Response(200, json={"title": "T"}))
+        with pytest.raises(SourceFetchError):
+            await extract_youtube("https://youtu.be/dQw4w9WgXcQ")
+
+    async def test_could_not_retrieve_transcript_raises_source_fetch(
+        self, mock_transcript, mock_oembed, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("app.services.source_extractors.youtube.settings.youtube_proxy_url", "")
+        mock_transcript(CouldNotRetrieveTranscript("dQw4w9WgXcQ"))
+        mock_oembed(httpx.Response(200, json={"title": "T"}))
+        with pytest.raises(SourceFetchError):
+            await extract_youtube("https://youtu.be/dQw4w9WgXcQ")
+
+
+class TestProxyFallback:
+    """When YOUTUBE_PROXY_URL is set, upstream blocks trigger one retry."""
+
+    async def test_proxy_retry_recovers(
+        self, mock_transcript_sequence, mock_oembed, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """First call blocked, proxy retry succeeds → happy-path transcript."""
+        monkeypatch.setattr(
+            "app.services.source_extractors.youtube.settings.youtube_proxy_url",
+            "http://user:pass@proxy.example:9999",
+        )
+        factory = mock_transcript_sequence(
+            [
+                RequestBlocked("dQw4w9WgXcQ"),  # direct call
+                [_Snippet(text="works"), _Snippet(text="via"), _Snippet(text="proxy")],  # proxy call
+            ]
+        )
+        mock_oembed(httpx.Response(200, json={"title": "T"}))
+
+        _, content, _ = await extract_youtube("https://youtu.be/dQw4w9WgXcQ")
+
+        assert content == "works via proxy"
+        # Two instantiations: first direct (no proxy), second with proxy_config.
+        assert len(factory.calls) == 2
+        assert factory.calls[0]["proxy_config"] is None
+        assert factory.calls[1]["proxy_config"] is not None
+
+    async def test_proxy_retry_still_no_transcript_raises_unsupported(
+        self, mock_transcript_sequence, mock_oembed, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Proxy got through but the video really has no transcript."""
+        monkeypatch.setattr(
+            "app.services.source_extractors.youtube.settings.youtube_proxy_url",
+            "http://user:pass@proxy.example:9999",
+        )
+        mock_transcript_sequence(
+            [
+                RequestBlocked("dQw4w9WgXcQ"),
+                NoTranscriptFound("dQw4w9WgXcQ", ["en"], None),
+            ]
+        )
+        mock_oembed(httpx.Response(200, json={"title": "T"}))
+
+        with pytest.raises(UnsupportedSourceError):
+            await extract_youtube("https://youtu.be/dQw4w9WgXcQ")
+
+    async def test_proxy_retry_also_blocked_raises_source_fetch(
+        self, mock_transcript_sequence, mock_oembed, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If proxy is ALSO blocked (rare but possible), surface 502."""
+        monkeypatch.setattr(
+            "app.services.source_extractors.youtube.settings.youtube_proxy_url",
+            "http://user:pass@proxy.example:9999",
+        )
+        mock_transcript_sequence(
+            [
+                RequestBlocked("dQw4w9WgXcQ"),
+                IpBlocked("dQw4w9WgXcQ"),
+            ]
+        )
+        mock_oembed(httpx.Response(200, json={"title": "T"}))
+
+        with pytest.raises(SourceFetchError):
+            await extract_youtube("https://youtu.be/dQw4w9WgXcQ")
+
+    async def test_no_proxy_config_no_retry(
+        self, mock_transcript_sequence, mock_oembed, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without proxy URL, the direct call is the only attempt."""
+        monkeypatch.setattr("app.services.source_extractors.youtube.settings.youtube_proxy_url", "")
+        factory = mock_transcript_sequence([RequestBlocked("dQw4w9WgXcQ")])
+        mock_oembed(httpx.Response(200, json={"title": "T"}))
+
+        with pytest.raises(SourceFetchError):
+            await extract_youtube("https://youtu.be/dQw4w9WgXcQ")
+
+        assert len(factory.calls) == 1
+        assert factory.calls[0]["proxy_config"] is None
 
 
 class TestOembedTitle:

--- a/klai-portal/frontend/messages/en.json
+++ b/klai-portal/frontend/messages/en.json
@@ -681,6 +681,7 @@
   "knowledge_add_source_error_invalid_url": "Not a valid URL",
   "knowledge_add_source_error_blocked_url": "This URL is not allowed",
   "knowledge_add_source_error_fetch_failed": "Could not reach the page — try again",
+  "knowledge_add_source_error_youtube_unreachable": "Could not reach YouTube — try again",
   "knowledge_add_source_error_no_transcript": "This video has no transcript available",
   "knowledge_add_source_error_kb_full": "This knowledge base has reached its document limit",
   "knowledge_add_source_error_generic": "Something went wrong. Try again.",

--- a/klai-portal/frontend/messages/nl.json
+++ b/klai-portal/frontend/messages/nl.json
@@ -681,6 +681,7 @@
   "knowledge_add_source_error_invalid_url": "Geen geldige URL",
   "knowledge_add_source_error_blocked_url": "Deze URL is niet toegestaan",
   "knowledge_add_source_error_fetch_failed": "Pagina onbereikbaar — probeer opnieuw",
+  "knowledge_add_source_error_youtube_unreachable": "YouTube onbereikbaar — probeer opnieuw",
   "knowledge_add_source_error_no_transcript": "Deze video heeft geen transcript",
   "knowledge_add_source_error_kb_full": "Deze kennisbank heeft de documentlimiet bereikt",
   "knowledge_add_source_error_generic": "Er ging iets mis. Probeer opnieuw.",

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source._components/__tests__/useSourceSubmit.test.ts
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source._components/__tests__/useSourceSubmit.test.ts
@@ -86,9 +86,27 @@ describe('errorMessageFor — SPEC D8 mapping', () => {
     expect(errorMessageFor('url', err)).toBe(keyOf('Something went wrong. Try again.'))
   })
 
-  it('ApiError 502 on any kind → fetch-failed banner', () => {
+  it('ApiError 502 on URL kind → fetch-failed banner', () => {
     const err = new ApiError(502, 'crawl4ai unreachable')
     expect(errorMessageFor('url', err)).toBe(
+      keyOf('Could not reach the page — try again'),
+    )
+  })
+
+  it('ApiError 502 on YouTube kind → YouTube-specific unreachable banner', () => {
+    // IP block / rate-limit on core-01 surfaces here — user needs to know
+    // it's a transient upstream issue, not "no transcript".
+    const err = new ApiError(502, 'Could not reach YouTube — try again')
+    expect(errorMessageFor('youtube', err)).toBe(
+      keyOf('Could not reach YouTube — try again'),
+    )
+  })
+
+  it('ApiError 502 on Text kind → generic fetch-failed (no upstream for text)', () => {
+    // Text never calls crawl4ai or YouTube — a 502 here is from the
+    // knowledge-ingest forwarding step. Generic fetch-failed copy is fine.
+    const err = new ApiError(502, 'Knowledge ingest unreachable')
+    expect(errorMessageFor('text', err)).toBe(
       keyOf('Could not reach the page — try again'),
     )
   })

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source._components/useSourceSubmit.ts
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source._components/useSourceSubmit.ts
@@ -77,7 +77,9 @@ export function errorMessageFor(kind: SourceKind, err: unknown): string {
         ? m.knowledge_add_source_error_no_transcript()
         : m.knowledge_add_source_error_generic()
     case 502:
-      return m.knowledge_add_source_error_fetch_failed()
+      return kind === 'youtube'
+        ? m.knowledge_add_source_error_youtube_unreachable()
+        : m.knowledge_add_source_error_fetch_failed()
     default:
       return m.knowledge_add_source_error_generic()
   }


### PR DESCRIPTION
Follow-up fix surfaced during prod smoke of PR #154. Voys tenant tested two popular YouTube videos, both returned '\''no transcript'\'' — but both have transcripts. Root cause: core-01's datacenter IP is rate-limited by YouTube (RequestBlocked), and my error mapping conflated that with NoTranscriptFound.

## Changes
- Split exception mapping: NoTranscriptFound/TranscriptsDisabled/VideoUnavailable → 422 "no transcript"; RequestBlocked/IpBlocked/YouTubeRequestFailed/CouldNotRetrieveTranscript → 502 "could not reach YouTube".
- Port Focus'\''s proxy fallback: `settings.youtube_proxy_url`. Set it in SOPS → upstream blocks retry via residential proxy. Empty → 502 surfaces direct.
- Observability: every branch logs exception class before raising.
- Frontend: new `error_youtube_unreachable` i18n key + distinct banner.
- 136 backend tests / 126 frontend tests — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)