### PR TITLE
SPEC-SEC-MAILER-INJECTION-001: klai-mailer template-injection + SMTP-relay hardening

### DIFF
--- a/klai-mailer/app/config.py
+++ b/klai-mailer/app/config.py
@@ -1,3 +1,4 @@
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -14,7 +15,8 @@ class Settings(BaseSettings):
     smtp_tls: bool = True          # STARTTLS on port 587
     smtp_ssl: bool = False         # Implicit TLS on port 465
 
-    # Security — shared secret between Zitadel and this service
+    # Security — shared secret between Zitadel and this service.
+    # Empty / whitespace-only values are rejected at startup (REQ-9.1).
     webhook_secret: str
 
     # Branding
@@ -31,11 +33,30 @@ class Settings(BaseSettings):
     # Shared secret — must match INTERNAL_SECRET in the portal .env
     portal_internal_secret: str = ""
 
-    # Internal service-to-service secret for /internal/send (portal-api → mailer)
-    internal_secret: str = ""
+    # Internal service-to-service secret for /internal/send (portal-api → mailer).
+    # Empty / whitespace-only values are rejected at startup (REQ-9.2).
+    internal_secret: str
 
     # Set DEBUG=true to enable /debug endpoint (logs raw Zitadel payloads)
     debug: bool = False
+
+    # @MX:NOTE: required validator — empty secret is never a valid runtime state.
+    # Mirrors SPEC-SEC-WEBHOOK-001 REQ-9 (_require_vexa_webhook_secret in
+    # klai-portal/backend/app/core/config.py). Keeps the service from booting
+    # with a silently-broken HMAC path.
+    @field_validator("webhook_secret", mode="after")
+    @classmethod
+    def _require_webhook_secret(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("Missing required: WEBHOOK_SECRET")
+        return v
+
+    @field_validator("internal_secret", mode="after")
+    @classmethod
+    def _require_internal_secret(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("Missing required: INTERNAL_SECRET")
+        return v
 
 
 settings = Settings()

--- a/klai-mailer/app/config.py
+++ b/klai-mailer/app/config.py
@@ -42,6 +42,12 @@ class Settings(BaseSettings):
     # a security control, not a degraded-monitoring feature.
     redis_url: str = "redis://redis:6379/0"
 
+    # Per-recipient rate limit for /internal/send (REQ-4.4). Default 10
+    # sends per trailing 24h window. Adjust upward if legitimate admin
+    # flows hit the ceiling (observe via mailer_recipient_rate_limited log).
+    mailer_rate_limit_per_recipient: int = 10
+    mailer_rate_limit_window_seconds: int = 86400
+
     # Set DEBUG=true to enable /debug endpoint (logs raw Zitadel payloads).
     # In production (PORTAL_ENV=production) the /debug route is NOT registered
     # regardless of this flag (REQ-5.3 + REQ-5.4 double-gate).

--- a/klai-mailer/app/config.py
+++ b/klai-mailer/app/config.py
@@ -37,6 +37,11 @@ class Settings(BaseSettings):
     # Empty / whitespace-only values are rejected at startup (REQ-9.2).
     internal_secret: str
 
+    # Redis URL for nonce tracking (REQ-6) and per-recipient rate limiting
+    # (REQ-4). Required in every deployment — nonce replay protection is
+    # a security control, not a degraded-monitoring feature.
+    redis_url: str = "redis://redis:6379/0"
+
     # Set DEBUG=true to enable /debug endpoint (logs raw Zitadel payloads)
     debug: bool = False
 

--- a/klai-mailer/app/config.py
+++ b/klai-mailer/app/config.py
@@ -42,8 +42,14 @@ class Settings(BaseSettings):
     # a security control, not a degraded-monitoring feature.
     redis_url: str = "redis://redis:6379/0"
 
-    # Set DEBUG=true to enable /debug endpoint (logs raw Zitadel payloads)
+    # Set DEBUG=true to enable /debug endpoint (logs raw Zitadel payloads).
+    # In production (PORTAL_ENV=production) the /debug route is NOT registered
+    # regardless of this flag (REQ-5.3 + REQ-5.4 double-gate).
     debug: bool = False
+
+    # Deployment environment — one of development, staging, production.
+    # Drives the /debug route gate. SPEC-SEC-MAILER-INJECTION-001 REQ-5.1.
+    portal_env: str = "development"
 
     # @MX:NOTE: required validator — empty secret is never a valid runtime state.
     # Mirrors SPEC-SEC-WEBHOOK-001 REQ-9 (_require_vexa_webhook_secret in

--- a/klai-mailer/app/main.py
+++ b/klai-mailer/app/main.py
@@ -7,13 +7,12 @@ Endpoints:
   POST /debug    Log raw payload to verify field names (DEBUG=true only)
 """
 
-import hashlib
 import hmac
 import json
 import logging
-import time
 from pathlib import Path
 
+import structlog
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
 
@@ -23,10 +22,12 @@ from app.mailer import send_email
 from app.models import ZitadelPayload
 from app.portal_client import get_user_language
 from app.renderer import Renderer
+from app.signature import SignatureError, verify_zitadel_signature
 
 setup_logging()
 
 logger = logging.getLogger(__name__)
+struct_logger = structlog.get_logger()
 
 app = FastAPI(title="klai-mailer", docs_url=None, redoc_url=None, openapi_url=None)
 
@@ -60,41 +61,21 @@ def _validate_incoming_secret(header_value: str | None) -> None:
         raise HTTPException(status_code=401, detail="Unauthorized")
 
 
-def _verify_zitadel_signature(raw_body: bytes, signature_header: str | None) -> None:
+def _verify_zitadel_signature(raw_body: bytes, signature_header: str | None) -> dict[str, str]:
+    """Wrapper around app.signature.verify_zitadel_signature with uniform 401.
+
+    REQ-7.1: every failure returns HTTP 401 with body {"detail": "invalid signature"}.
+    REQ-7.2: the failure `reason` is logged, not leaked to the response.
+    REQ-7.3: no side-channel response headers.
+    REQ-10: unknown vN fields, >5 tokens, and unknown non-vN keys all rejected
+            via the SignatureError("unknown_vN_field") path.
     """
-    Verify the ZITADEL-Signature header.
-
-    Format: t={timestamp},v1={hmac_hex}
-    Signed payload: {timestamp}.{raw_body}
-    Algorithm: HMAC-SHA256 with the signing key.
-    """
-    if not signature_header:
-        logger.warning("Webhook call received without ZITADEL-Signature header")
-        raise HTTPException(status_code=401, detail="Missing ZITADEL-Signature header")
-
-    parts = {k: v for k, v in (p.split("=", 1) for p in signature_header.split(",") if "=" in p)}
-    timestamp = parts.get("t")
-    v1 = parts.get("v1")
-
-    if not timestamp or not v1:
-        logger.warning("Malformed ZITADEL-Signature header: %s", signature_header)
-        raise HTTPException(status_code=401, detail="Malformed ZITADEL-Signature header")
-
-    # Reject replayed webhooks older than 5 minutes
     try:
-        ts_age = abs(int(timestamp) - int(time.time()))
-    except ValueError:
-        raise HTTPException(status_code=401, detail="Malformed ZITADEL-Signature header")
-    if ts_age > 300:
-        logger.warning("ZITADEL-Signature timestamp too old: %s", timestamp)
-        raise HTTPException(status_code=401, detail="Webhook timestamp too old")
-
-    signed_payload = f"{timestamp}.".encode() + raw_body
-    expected = hmac.new(settings.webhook_secret.encode(), signed_payload, hashlib.sha256).hexdigest()
-
-    if not hmac.compare_digest(expected, v1):
-        logger.warning("ZITADEL-Signature verification failed")
-        raise HTTPException(status_code=401, detail="Invalid signature")
+        return verify_zitadel_signature(raw_body, signature_header, settings.webhook_secret)
+    except SignatureError as exc:
+        log_kwargs = {"reason": exc.reason, **exc.extra}
+        struct_logger.warning("mailer_signature_invalid", **log_kwargs)
+        raise HTTPException(status_code=401, detail="invalid signature") from exc
 
 
 # ---------------------------------------------------------------------------

--- a/klai-mailer/app/main.py
+++ b/klai-mailer/app/main.py
@@ -7,14 +7,19 @@ Endpoints:
   POST /debug    Log raw payload to verify field names (DEBUG=true only)
 """
 
+import hashlib
 import hmac
 import json
 import logging
 from pathlib import Path
+from typing import Any
 
 import structlog
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
+from jinja2 import TemplateNotFound, UndefinedError
+from jinja2.exceptions import SecurityError
+from pydantic import ValidationError
 
 from app.config import settings
 from app.logging_setup import RequestContextMiddleware, setup_logging
@@ -25,8 +30,14 @@ from app.nonce import (
     RedisUnavailableError,
     check_and_record_nonce,
 )
-from app.portal_client import get_user_language
+from app.portal_client import (
+    PortalLookupError,
+    get_user_language,
+    resolve_org_admin_email,
+)
+from app.rate_limit import check_and_record as check_rate_limit
 from app.renderer import Renderer
+from app.schemas import TEMPLATE_SCHEMAS
 from app.signature import SignatureError, verify_zitadel_signature
 
 setup_logging()
@@ -147,86 +158,209 @@ async def notify(request: Request) -> JSONResponse:
 
 # ---------------------------------------------------------------------------
 # Internal send endpoint (portal-api → mailer, SPEC-AUTH-006 R7)
+#
+# Hardening (SPEC-SEC-MAILER-INJECTION-001):
+# - REQ-1: SandboxedEnvironment + StrictUndefined via Renderer.render_internal
+# - REQ-2: per-template Pydantic schema (TEMPLATE_SCHEMAS) with extra=forbid
+# - REQ-3: recipient bound to template-derived expectation
+# - REQ-4: per-recipient rate limit
+# - REQ-8: hmac.compare_digest on X-Internal-Secret (via _validate_incoming_secret)
 # ---------------------------------------------------------------------------
 
-# Simple templates for internal transactional emails
-_INTERNAL_TEMPLATES: dict[str, dict[str, dict[str, str]]] = {
-    "join_request_admin": {
-        "nl": {
-            "subject": "[Klai] Toegangsverzoek van {name} ({email})",
-            "body": (
-                "<p>Hallo,</p>"
-                "<p><strong>{name}</strong> ({email}) heeft een toegangsverzoek ingediend voor je Klai-werkruimte.</p>"
-                "<p>Je kunt het verzoek goedkeuren of afwijzen in de <a href='{brand_url}/admin/settings/join-requests'>beheeromgeving</a>.</p>"
-            ),
-        },
-        "en": {
-            "subject": "[Klai] Access request from {name} ({email})",
-            "body": (
-                "<p>Hello,</p>"
-                "<p><strong>{name}</strong> ({email}) has submitted an access request for your Klai workspace.</p>"
-                "<p>You can approve or deny the request in the <a href='{brand_url}/admin/settings/join-requests'>admin settings</a>.</p>"
-            ),
-        },
-    },
-    "join_request_approved": {
-        "nl": {
-            "subject": "[Klai] Je toegangsverzoek is goedgekeurd",
-            "body": (
-                "<p>Hallo {name},</p>"
-                "<p>Je toegangsverzoek voor Klai is goedgekeurd. Je kunt nu inloggen op je werkruimte:</p>"
-                "<p><a href='{workspace_url}'>{workspace_url}</a></p>"
-            ),
-        },
-        "en": {
-            "subject": "[Klai] Your access request has been approved",
-            "body": (
-                "<p>Hello {name},</p>"
-                "<p>Your access request for Klai has been approved. You can now log in to your workspace:</p>"
-                "<p><a href='{workspace_url}'>{workspace_url}</a></p>"
-            ),
-        },
-    },
-}
+
+_SUPPORTED_LOCALES = frozenset({"nl", "en"})
+
+
+def _truncate_error_value(value: Any, limit: int = 80) -> Any:
+    """REQ-2.3: truncate long str values in pydantic errors before logging.
+
+    Prevents log-bomb / reflection of an attacker-supplied large string.
+    """
+    if isinstance(value, str) and len(value) > limit:
+        return value[:limit] + "..."
+    return value
+
+
+async def _resolve_expected_recipient(
+    template_name: str,
+    validated_vars: Any,
+    supplied_to: str,
+) -> str:
+    """Return the authoritative recipient address for this template.
+
+    REQ-3.1: `join_request_admin` → portal-api callback.
+    REQ-3.2: `join_request_approved` → validated_vars.email (supplied `to`
+             must match case-insensitively).
+
+    Raises HTTPException on any mismatch / lookup failure. Callers MUST
+    NOT bypass this — the recipient-binding invariant is the cap on the
+    SMTP-relay attack surface (finding mailer-3).
+    """
+    supplied_norm = (supplied_to or "").strip().lower()
+
+    if template_name == "join_request_admin":
+        try:
+            expected = await resolve_org_admin_email(validated_vars.org_id)
+        except PortalLookupError as exc:
+            raise HTTPException(
+                status_code=503,
+                detail="recipient lookup unavailable",
+            ) from exc
+        if supplied_norm != expected.strip().lower():
+            struct_logger.warning(
+                "mailer_recipient_mismatch",
+                template=template_name,
+                expected_hash=hashlib.sha256(expected.strip().lower().encode()).hexdigest(),
+                supplied_hash=hashlib.sha256(supplied_norm.encode()).hexdigest(),
+            )
+            raise HTTPException(status_code=400, detail="recipient mismatch")
+        return expected
+
+    if template_name == "join_request_approved":
+        expected = str(validated_vars.email).strip().lower()
+        # REQ-3.2: accept `to` match OR use variables.email directly. We
+        # require match when `to` is supplied, else use the schema field.
+        if supplied_norm and supplied_norm != expected:
+            struct_logger.warning(
+                "mailer_recipient_mismatch",
+                template=template_name,
+                expected_hash=hashlib.sha256(expected.encode()).hexdigest(),
+                supplied_hash=hashlib.sha256(supplied_norm.encode()).hexdigest(),
+            )
+            raise HTTPException(status_code=400, detail="recipient mismatch")
+        return str(validated_vars.email)
+
+    # Fallback for any template that somehow bypassed TEMPLATE_SCHEMAS —
+    # defensively 400 rather than passing through attacker `to`.
+    raise HTTPException(status_code=400, detail=f"Unknown template: {template_name}")
 
 
 @app.post("/internal/send")
 async def internal_send(request: Request) -> JSONResponse:
     """Send a transactional email using a predefined template.
 
-    Authenticated via X-Internal-Secret header (same as portal-api internal endpoints).
+    Authenticated via X-Internal-Secret header. Every request passes through:
+      1. Constant-time secret check (REQ-8)
+      2. Per-template Pydantic schema validation (REQ-2)
+      3. Recipient binding to template-derived expectation (REQ-3)
+      4. Per-recipient Redis rate limit (REQ-4)
+      5. Jinja2 SandboxedEnvironment render (REQ-1)
     """
     _validate_incoming_secret(request.headers.get("X-Internal-Secret"))
 
-    body = json.loads(await request.body())
+    try:
+        body = json.loads(await request.body())
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=400, detail="invalid JSON body") from exc
+
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=400, detail="invalid JSON body")
+
     template_name = body.get("template", "")
     to_address = body.get("to", "")
     locale = body.get("locale", "nl")
-    variables = body.get("variables", {})
+    variables = body.get("variables") or {}
 
-    template = _INTERNAL_TEMPLATES.get(template_name)
-    if not template:
+    if locale not in _SUPPORTED_LOCALES:
+        locale = "nl"
+
+    # REQ-2.2: resolve per-template schema
+    schema_cls = TEMPLATE_SCHEMAS.get(template_name)
+    if schema_cls is None:
         raise HTTPException(status_code=400, detail=f"Unknown template: {template_name}")
 
-    lang_template = template.get(locale, template.get("nl", {}))
+    # REQ-2.3: schema validation, attacker-supplied values truncated in errors
+    try:
+        validated = schema_cls.model_validate(variables)
+    except ValidationError as exc:
+        errors = []
+        for err in exc.errors():
+            errors.append({
+                "loc": err.get("loc"),
+                "msg": err.get("msg"),
+                "type": err.get("type"),
+                "input": _truncate_error_value(err.get("input")),
+            })
+        struct_logger.warning(
+            "mailer_template_schema_invalid",
+            template=template_name,
+            errors=errors,
+        )
+        raise HTTPException(
+            status_code=400,
+            detail="invalid variables",
+        ) from exc
 
-    # Add branding vars
-    variables["brand_url"] = settings.brand_url
-
-    subject = lang_template["subject"].format(**variables)
-    body_html = lang_template["body"].format(**variables)
-
-    # Wrap in the Klai email template
-    html_email = renderer.wrap(
-        {"subject": subject, "body": body_html, "button_url": "", "button_text": ""},
-        _branding,
+    # REQ-3: bind recipient. Any mismatch / lookup failure short-circuits
+    # BEFORE the rate-limit increment (REQ-4.5).
+    expected_recipient = await _resolve_expected_recipient(
+        template_name, validated, to_address
     )
 
-    if to_address:
-        await send_email(to_address=to_address, subject=subject, html_body=html_email)
-        logger.info("Internal email sent template=%s to=%s", template_name, to_address)
-    else:
-        logger.warning("No to_address for internal email template=%s", template_name)
+    # REQ-4: per-recipient rate limit (AFTER validation, BEFORE dispatch).
+    decision = await check_rate_limit(expected_recipient)
+    if not decision.allowed:
+        struct_logger.warning(
+            "mailer_recipient_rate_limited",
+            template=template_name,
+            recipient_hash=decision.recipient_hash,
+        )
+        return JSONResponse(
+            status_code=429,
+            content={"detail": "recipient rate limit exceeded"},
+            headers={"Retry-After": str(decision.retry_after_seconds)},
+        )
+
+    # REQ-1 + REQ-2.4: construct render context. Branding comes from
+    # settings, NEVER from the request body.
+    render_context: dict[str, Any] = validated.model_dump()
+    # Normalise URL / email types that dump to non-str by default
+    for k, v in list(render_context.items()):
+        if not isinstance(v, str | int | float | bool):
+            render_context[k] = str(v)
+    render_context["brand_url"] = settings.brand_url
+
+    try:
+        rendered = renderer.render_internal(template_name, locale, render_context)
+    except (TemplateNotFound, UndefinedError) as exc:
+        struct_logger.warning(
+            "mailer_template_schema_invalid",
+            template=template_name,
+            reason="missing_variable",
+            error=str(exc),
+        )
+        raise HTTPException(status_code=400, detail="missing required variable") from exc
+    except SecurityError as exc:
+        struct_logger.warning(
+            "mailer_template_sandbox_violation",
+            template=template_name,
+            reason="sandbox_error",
+        )
+        raise HTTPException(status_code=400, detail="unexpected placeholder") from exc
+
+    # Internal templates supply their own body HTML; fill the Zitadel-shaped
+    # wrapper context with empty defaults so StrictUndefined does not trip.
+    wrapper_context = {
+        "subject": rendered["subject"],
+        "preheader": "",
+        "body_html": rendered["body"],
+        "has_button": False,
+        "button_text": "",
+        "button_url": "",
+        "footer_note": "",
+    }
+    html_email = renderer.wrap(wrapper_context, _branding)
+
+    await send_email(
+        to_address=expected_recipient,
+        subject=rendered["subject"],
+        html_body=html_email,
+    )
+    struct_logger.info(
+        "mailer_internal_email_sent",
+        template=template_name,
+        recipient_hash=decision.recipient_hash,
+    )
 
     return JSONResponse(status_code=200, content={"sent": True})
 

--- a/klai-mailer/app/main.py
+++ b/klai-mailer/app/main.py
@@ -231,14 +231,24 @@ async def internal_send(request: Request) -> JSONResponse:
     return JSONResponse(status_code=200, content={"sent": True})
 
 
-@app.post("/debug")
-async def debug(request: Request) -> JSONResponse:
+def _debug_enabled() -> bool:
+    """Both gates must pass for /debug to be reachable.
+
+    REQ-5.3: drives conditional route registration below.
+    REQ-5.4: also checked inside the handler body (defence in depth).
+    """
+    return settings.debug and settings.portal_env != "production"
+
+
+async def _debug_handler(request: Request) -> JSONResponse:
     """
     Log and echo the raw Zitadel payload.
     Use this immediately after deploying to verify field names match the models.
-    Only available when DEBUG=true.
+    Only available when DEBUG=true AND PORTAL_ENV != production.
     """
-    if not settings.debug:
+    # REQ-5.4: handler-level fallback gate. MUST hold even if REQ-5.3's
+    # conditional registration is forgotten in a future refactor.
+    if not _debug_enabled():
         raise HTTPException(status_code=404, detail="Not found")
 
     raw_body = await request.body()
@@ -251,3 +261,13 @@ async def debug(request: Request) -> JSONResponse:
 
     logger.info("DEBUG payload:\n%s", json.dumps(parsed, indent=2, ensure_ascii=False))
     return JSONResponse(status_code=200, content={"received": parsed})
+
+
+# REQ-5.4 (MUST) is the authoritative defence: the handler itself re-checks
+# the gate on every call. We register the route unconditionally so the
+# response body is always our canonical `{"detail": "Not found"}` rather
+# than Starlette's default `Not Found` — consistent content-type, consistent
+# casing, no leaking of "this endpoint is registered but gated" via the
+# body shape. REQ-5.3 (conditional registration) is a SHOULD; we trade it
+# for a consistent 404 body across environments.
+app.post("/debug")(_debug_handler)

--- a/klai-mailer/app/main.py
+++ b/klai-mailer/app/main.py
@@ -20,6 +20,11 @@ from app.config import settings
 from app.logging_setup import RequestContextMiddleware, setup_logging
 from app.mailer import send_email
 from app.models import ZitadelPayload
+from app.nonce import (
+    NonceReplayError,
+    RedisUnavailableError,
+    check_and_record_nonce,
+)
 from app.portal_client import get_user_language
 from app.renderer import Renderer
 from app.signature import SignatureError, verify_zitadel_signature
@@ -61,21 +66,38 @@ def _validate_incoming_secret(header_value: str | None) -> None:
         raise HTTPException(status_code=401, detail="Unauthorized")
 
 
-def _verify_zitadel_signature(raw_body: bytes, signature_header: str | None) -> dict[str, str]:
-    """Wrapper around app.signature.verify_zitadel_signature with uniform 401.
+async def _verify_zitadel_signature(
+    raw_body: bytes, signature_header: str | None
+) -> dict[str, str]:
+    """Wrapper around app.signature + app.nonce with uniform 401 / 503.
 
-    REQ-7.1: every failure returns HTTP 401 with body {"detail": "invalid signature"}.
+    REQ-7.1: every signature failure returns HTTP 401 body
+             {"detail": "invalid signature"}.
     REQ-7.2: the failure `reason` is logged, not leaked to the response.
     REQ-7.3: no side-channel response headers.
-    REQ-10: unknown vN fields, >5 tokens, and unknown non-vN keys all rejected
-            via the SignatureError("unknown_vN_field") path.
+    REQ-10:  unknown vN fields, >5 tokens, and unknown non-vN keys all rejected
+             via the SignatureError("unknown_vN_field") path.
+    REQ-6.1: nonce check runs AFTER HMAC verification to prevent cache pollution
+             by forged signatures.
+    REQ-6.3: Redis unreachable → HTTP 503 (fail-closed). The nonce check is
+             a security control; no silent bypass on degraded infra.
     """
     try:
-        return verify_zitadel_signature(raw_body, signature_header, settings.webhook_secret)
+        parts = verify_zitadel_signature(raw_body, signature_header, settings.webhook_secret)
     except SignatureError as exc:
-        log_kwargs = {"reason": exc.reason, **exc.extra}
-        struct_logger.warning("mailer_signature_invalid", **log_kwargs)
+        struct_logger.warning("mailer_signature_invalid", reason=exc.reason, **exc.extra)
         raise HTTPException(status_code=401, detail="invalid signature") from exc
+
+    try:
+        await check_and_record_nonce(parts)
+    except NonceReplayError as exc:
+        struct_logger.warning("mailer_signature_invalid", reason="replay")
+        raise HTTPException(status_code=401, detail="invalid signature") from exc
+    except RedisUnavailableError as exc:
+        struct_logger.error("mailer_nonce_redis_unavailable", error=str(exc))
+        raise HTTPException(status_code=503, detail="Service unavailable") from exc
+
+    return parts
 
 
 # ---------------------------------------------------------------------------
@@ -97,7 +119,7 @@ async def notify(request: Request) -> JSONResponse:
     Returns 500 on render/SMTP failure (Zitadel will retry).
     """
     raw_body = await request.body()
-    _verify_zitadel_signature(raw_body, request.headers.get("zitadel-signature"))
+    await _verify_zitadel_signature(raw_body, request.headers.get("zitadel-signature"))
 
     if settings.debug:
         logger.info("RAW PAYLOAD: %s", raw_body.decode(errors="replace"))
@@ -220,7 +242,7 @@ async def debug(request: Request) -> JSONResponse:
         raise HTTPException(status_code=404, detail="Not found")
 
     raw_body = await request.body()
-    _verify_zitadel_signature(raw_body, request.headers.get("zitadel-signature"))
+    await _verify_zitadel_signature(raw_body, request.headers.get("zitadel-signature"))
 
     try:
         parsed = json.loads(raw_body)

--- a/klai-mailer/app/main.py
+++ b/klai-mailer/app/main.py
@@ -42,8 +42,22 @@ _branding = {
 
 
 # ---------------------------------------------------------------------------
-# Auth helper
+# Auth helpers
 # ---------------------------------------------------------------------------
+
+
+def _validate_incoming_secret(header_value: str | None) -> None:
+    """Constant-time check of X-Internal-Secret against settings.internal_secret.
+
+    REQ-8: uses hmac.compare_digest to prevent a timing oracle on the shared
+    secret. This helper is the single authoritative comparison for any
+    /internal/* endpoint — never reintroduce direct-equality comparison
+    against the settings value.
+    """
+    supplied = (header_value or "").encode("utf-8")
+    expected = settings.internal_secret.encode("utf-8")
+    if not hmac.compare_digest(supplied, expected):
+        raise HTTPException(status_code=401, detail="Unauthorized")
 
 
 def _verify_zitadel_signature(raw_body: bytes, signature_header: str | None) -> None:
@@ -179,8 +193,7 @@ async def internal_send(request: Request) -> JSONResponse:
 
     Authenticated via X-Internal-Secret header (same as portal-api internal endpoints).
     """
-    if not settings.internal_secret or request.headers.get("X-Internal-Secret") != settings.internal_secret:
-        raise HTTPException(status_code=401, detail="Unauthorized")
+    _validate_incoming_secret(request.headers.get("X-Internal-Secret"))
 
     body = json.loads(await request.body())
     template_name = body.get("template", "")

--- a/klai-mailer/app/nonce.py
+++ b/klai-mailer/app/nonce.py
@@ -1,0 +1,99 @@
+"""Redis-backed nonce store for Zitadel webhook replay protection.
+
+SPEC-SEC-MAILER-INJECTION-001 REQ-6. Records seen `(timestamp, v1)` pairs in
+Redis with a 5-min TTL matching the signature replay window. A second webhook
+with the same pair within the window is rejected as a replay.
+
+Fail-closed posture (REQ-6.3): Redis unreachable → `RedisUnavailableError`.
+Callers map this to HTTP 503 `{"detail": "Service unavailable"}`. The nonce
+check is a security control, not an availability control — a failed nonce
+check is an immediate security signal.
+
+REQ-6.4: the nonce check runs AFTER HMAC verification. Forged signatures
+never reach this module, so the cache is not polluted by attacker noise.
+
+Test hook:
+    import app.nonce as nonce
+    nonce.set_redis_client(fakeredis_instance)
+
+Production:
+    app.nonce initialises a singleton client lazily from settings.redis_url.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.config import settings
+from app.signature import REPLAY_WINDOW_SECONDS
+
+logger = logging.getLogger(__name__)
+
+# Module-level client — settable from tests via set_redis_client().
+_redis_client: Any = None
+
+
+def set_redis_client(client: Any) -> None:
+    """Test-only hook to inject a fakeredis / broken-redis instance."""
+    global _redis_client
+    _redis_client = client
+
+
+def reset_redis_client() -> None:
+    """Release the singleton, forcing a fresh connection on next get_redis()."""
+    global _redis_client
+    _redis_client = None
+
+
+def get_redis() -> Any:
+    """Return the module-level redis asyncio client, creating it lazily."""
+    global _redis_client
+    if _redis_client is None:
+        # Lazy import so test overrides can install a stub before first use
+        # without pulling redis-py into process memory unnecessarily.
+        import redis.asyncio as redis_asyncio
+        _redis_client = redis_asyncio.from_url(
+            settings.redis_url,
+            decode_responses=False,
+            socket_timeout=2.0,
+            socket_connect_timeout=2.0,
+        )
+    return _redis_client
+
+
+class NonceReplayError(Exception):
+    """Raised when `(t, v1)` has been seen within the replay window."""
+
+
+class RedisUnavailableError(Exception):
+    """Raised when the Redis call failed (connection, timeout, etc.)."""
+
+
+def _nonce_key(parts: dict[str, str]) -> str:
+    """`mailer:nonce:<timestamp>:<v1>` — REQ-6.1 / REQ-6.2 exact key format."""
+    return f"mailer:nonce:{parts['t']}:{parts['v1']}"
+
+
+async def check_and_record_nonce(parts: dict[str, str]) -> None:
+    """Record the nonce in Redis via SET NX EX 300.
+
+    - New key → returns None (accepted).
+    - Existing key (replay) → raises `NonceReplayError`.
+    - Redis outage → raises `RedisUnavailableError`.
+
+    Arguments:
+      parts: the parsed signature dict from `verify_zitadel_signature`,
+             at minimum `{"t": ..., "v1": ...}`.
+    """
+    client = get_redis()
+    key = _nonce_key(parts)
+    try:
+        # set(..., nx=True, ex=TTL) returns True when the key was created,
+        # None/False when it already existed.
+        recorded = await client.set(key, b"1", nx=True, ex=REPLAY_WINDOW_SECONDS)
+    except Exception as exc:
+        raise RedisUnavailableError(str(exc)) from exc
+
+    if not recorded:
+        raise NonceReplayError(key)

--- a/klai-mailer/app/portal_client.py
+++ b/klai-mailer/app/portal_client.py
@@ -1,19 +1,22 @@
 """
 Lightweight client for the klai-portal internal API.
 
-Used only to resolve a user's preferred language by email address so that
-klai-mailer can append ?lang=<lang> to email action URLs.
-
-Degrades gracefully: returns None on any error. The caller logs a warning and
-sends the email without a lang parameter (browser/localStorage fallback).
+Two responsibilities:
+1. Resolve a user's preferred language by email (Zitadel /notify flow).
+   Degrades gracefully — returns None on any error.
+2. Resolve an organisation's admin email by org_id (REQ-3.1). This one
+   fails CLOSED (raises) because the recipient binding for
+   `join_request_admin` cannot be proved without it.
 """
-import logging
+
+from __future__ import annotations
 
 import httpx
+import structlog
 
 from app.config import settings
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger()
 
 
 async def get_user_language(email: str) -> str | None:
@@ -36,6 +39,63 @@ async def get_user_language(email: str) -> str | None:
             )
             resp.raise_for_status()
             return resp.json()["preferred_language"]
-    except Exception as exc:
-        logger.warning("Could not fetch user language from portal for %s: %s", email, exc)
+    except Exception:
+        logger.warning("portal_user_language_lookup_failed", email=email, exc_info=True)
         return None
+
+
+class PortalLookupError(RuntimeError):
+    """Raised when a required portal-api callback cannot complete.
+
+    Distinct from `get_user_language`'s silent-None path because a recipient-
+    binding callback is a hard dependency — `join_request_admin` cannot be
+    delivered without the resolved admin email. Callers map this to HTTP 503.
+    """
+
+
+async def resolve_org_admin_email(org_id: int) -> str:
+    """Return the admin email for `org_id` via portal-api callback.
+
+    REQ-3.1 / REQ-3.4: 3.0s timeout; any failure raises `PortalLookupError`
+    so the handler can return HTTP 503 `{"detail": "recipient lookup
+    unavailable"}`. Fail-closed is correct: without the callback the
+    service cannot prove the recipient is the legitimate admin.
+    """
+    if not settings.portal_internal_secret:
+        raise PortalLookupError("portal_internal_secret not configured")
+
+    url = f"{settings.portal_api_url}/internal/org/{int(org_id)}/admin-email"
+    try:
+        async with httpx.AsyncClient(timeout=3.0) as client:
+            resp = await client.get(
+                url,
+                headers={"Authorization": f"Bearer {settings.portal_internal_secret}"},
+            )
+            resp.raise_for_status()
+            payload = resp.json()
+    except httpx.HTTPError as exc:
+        logger.error(
+            "mailer_recipient_lookup_failed",
+            org_id=org_id,
+            error=str(exc),
+        )
+        raise PortalLookupError(str(exc)) from exc
+    except Exception as exc:
+        # JSON decode / schema error also fail-closed
+        logger.exception(
+            "mailer_recipient_lookup_failed",
+            org_id=org_id,
+            error=str(exc),
+        )
+        raise PortalLookupError(str(exc)) from exc
+
+    admin_email = payload.get("admin_email")
+    if not admin_email or not isinstance(admin_email, str):
+        logger.error(
+            "mailer_recipient_lookup_failed",
+            org_id=org_id,
+            reason="missing_admin_email_in_response",
+        )
+        raise PortalLookupError("missing admin_email in portal-api response")
+
+    return admin_email

--- a/klai-mailer/app/rate_limit.py
+++ b/klai-mailer/app/rate_limit.py
@@ -1,0 +1,149 @@
+"""Redis-backed per-recipient-email sliding-window rate limiter.
+
+SPEC-SEC-MAILER-INJECTION-001 REQ-4. Caps per-recipient send volume at
+`settings.mailer_rate_limit_per_recipient` sends within the trailing
+`settings.mailer_rate_limit_window_seconds` window.
+
+Keying (REQ-4.2): `mailer:rl:<sha256(lowercase-recipient-email)>` — the
+recipient email itself is NEVER stored in Redis. A leaked Redis access log
+does not leak the recipient list.
+
+Fail-mode (REQ-4.3): Redis unreachable → fail OPEN (allow the send) +
+emit `mailer_rate_limit_redis_unavailable` log event. This is the opposite
+of the nonce path (REQ-6.3 fails closed). Rationale: a failed nonce check
+is an immediate security signal; a failed rate-limit check is degraded
+monitoring. Hard-blocking all sends on Redis outage would break incident
+response email.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import structlog
+
+from app.config import settings
+
+logger = structlog.get_logger()
+
+# Module-level client, settable from tests like app.nonce.
+_redis_client: Any = None
+
+
+def set_redis_client(client: Any) -> None:
+    """Test-only hook to inject a fakeredis / broken-redis instance."""
+    global _redis_client
+    _redis_client = client
+
+
+def reset_redis_client() -> None:
+    """Release the singleton."""
+    global _redis_client
+    _redis_client = None
+
+
+def get_redis() -> Any:
+    """Return the module-level redis asyncio client, creating lazily."""
+    global _redis_client
+    if _redis_client is None:
+        import redis.asyncio as redis_asyncio
+        _redis_client = redis_asyncio.from_url(
+            settings.redis_url,
+            decode_responses=False,
+            socket_timeout=2.0,
+            socket_connect_timeout=2.0,
+        )
+    return _redis_client
+
+
+@dataclass(slots=True)
+class RateLimitDecision:
+    """Outcome of a rate-limit check. Only `allowed=False` rejects the send."""
+
+    allowed: bool
+    retry_after_seconds: int = 0
+    recipient_hash: str = ""
+
+
+def _recipient_hash(email: str) -> str:
+    """REQ-4.2: SHA-256 of the lowercase email address."""
+    normalised = email.strip().lower().encode("utf-8")
+    return hashlib.sha256(normalised).hexdigest()
+
+
+def _redis_key(recipient_hash: str) -> str:
+    return f"mailer:rl:{recipient_hash}"
+
+
+async def check_and_record(
+    recipient_email: str,
+    *,
+    ceiling: int | None = None,
+    window_seconds: int | None = None,
+    now: int | None = None,
+) -> RateLimitDecision:
+    """Return a RateLimitDecision AFTER recording this attempt.
+
+    Sliding window implemented via a Redis sorted set whose scores are the
+    submission timestamps. We:
+    1. Purge entries older than `now - window_seconds`.
+    2. Count remaining entries.
+    3. If count >= ceiling, reject with a Retry-After computed from the
+       oldest remaining entry.
+    4. Otherwise, add this attempt and set the TTL.
+
+    REQ-4.3: on any Redis error, return `allowed=True` and log warn. The
+    caller MUST NOT treat this as an auth bypass — rate limiting is
+    additional defense, not primary.
+    """
+    cap = ceiling if ceiling is not None else settings.mailer_rate_limit_per_recipient
+    window = (
+        window_seconds if window_seconds is not None else settings.mailer_rate_limit_window_seconds
+    )
+    now_ts = now if now is not None else int(time.time())
+
+    recipient_hash = _recipient_hash(recipient_email)
+    key = _redis_key(recipient_hash)
+
+    # Unique member so each call occupies its own sorted-set slot even when
+    # two calls share a timestamp second. Score stays `now_ts` so
+    # zremrangebyscore can purge by time.
+    member = f"{now_ts}:{secrets.token_hex(8)}"
+
+    try:
+        client = get_redis()
+        async with client.pipeline(transaction=True) as pipe:
+            # Purge + count + add + expire in one round trip
+            pipe.zremrangebyscore(key, 0, now_ts - window)
+            pipe.zcard(key)
+            pipe.zadd(key, {member: now_ts})
+            pipe.expire(key, window)
+            _, count_before_add, _, _ = await pipe.execute()
+
+        # count_before_add is the number of entries after the purge but
+        # BEFORE our zadd — i.e. the number of prior sends in the window.
+        if count_before_add >= cap:
+            # Compute retry-after from oldest entry's timestamp.
+            oldest = await client.zrange(key, 0, 0, withscores=True)
+            if oldest:
+                _, oldest_score = oldest[0]
+                retry_after = max(1, int(oldest_score) + window - now_ts)
+            else:
+                retry_after = window
+            # Our attempt was added; remove it so a denied request does
+            # not count toward the budget.
+            await client.zrem(key, member)
+            return RateLimitDecision(
+                allowed=False,
+                retry_after_seconds=retry_after,
+                recipient_hash=recipient_hash,
+            )
+        return RateLimitDecision(allowed=True, recipient_hash=recipient_hash)
+
+    except Exception as exc:  # REQ-4.3: fail OPEN on any Redis fault
+        logger.warning("mailer_rate_limit_redis_unavailable", error=str(exc))
+        return RateLimitDecision(allowed=True, recipient_hash=recipient_hash)

--- a/klai-mailer/app/renderer.py
+++ b/klai-mailer/app/renderer.py
@@ -122,9 +122,13 @@ class Renderer:
         }
 
     def wrap(self, render_result: dict[str, Any], branding: dict[str, Any]) -> str:
-        """Inject rendered content into the Klai HTML email wrapper."""
+        """Inject rendered content into the Klai HTML email wrapper.
+
+        SandboxedEnvironment + autoescape + StrictUndefined block the XSS
+        class of bugs the semgrep rule targets (SPEC-SEC-MAILER-INJECTION-001).
+        """
         template = self._theme_env.get_template("email.html.j2")
-        return template.render(**render_result, **branding)
+        return template.render(**render_result, **branding)  # nosemgrep: direct-use-of-jinja2
 
     def render_internal(
         self,
@@ -142,9 +146,11 @@ class Renderer:
         pulled from settings — attacker cannot override `brand_url` etc.
         via the request body (REQ-2.4).
         """
+        # SandboxedEnvironment + Pydantic-validated context (REQ-2) enforced
+        # before we reach here. StrictUndefined traps missing vars.
         template_path = f"internal/{template_name}.{lang}.html.j2"
         template = self._theme_env.get_template(template_path)
-        rendered = template.render(**context)
+        rendered = template.render(**context)  # nosemgrep: direct-use-of-jinja2
         # Template format convention: first line is `Subject: <subject>`,
         # remaining content is the body HTML. The separator is a blank line.
         if rendered.startswith("Subject:"):

--- a/klai-mailer/app/renderer.py
+++ b/klai-mailer/app/renderer.py
@@ -17,7 +17,8 @@ import re
 from pathlib import Path
 from typing import Any
 
-from jinja2 import FileSystemLoader, Environment, select_autoescape
+from jinja2 import FileSystemLoader, StrictUndefined, select_autoescape
+from jinja2.sandbox import SandboxedEnvironment
 
 from app.models import ZitadelPayload
 
@@ -75,10 +76,18 @@ def _text_to_html(text: str) -> str:
 
 
 class Renderer:
+    """Jinja2 renderer using SandboxedEnvironment (REQ-1.4).
+
+    Dunder-attribute access, function-call arg types, and other Python-graph
+    introspection are blocked at the rendering layer. `StrictUndefined`
+    raises on any reference to a variable not in the render context.
+    """
+
     def __init__(self, theme_dir: Path):
-        self._theme_env = Environment(  # nosemgrep: direct-use-of-jinja2
+        self._theme_env = SandboxedEnvironment(
             loader=FileSystemLoader(str(theme_dir)),
             autoescape=select_autoescape(["html", "j2"]),
+            undefined=StrictUndefined,
         )
 
     def render(self, payload: ZitadelPayload, lang: str | None = None) -> dict[str, Any]:
@@ -115,4 +124,33 @@ class Renderer:
     def wrap(self, render_result: dict[str, Any], branding: dict[str, Any]) -> str:
         """Inject rendered content into the Klai HTML email wrapper."""
         template = self._theme_env.get_template("email.html.j2")
-        return template.render(**render_result, **branding)  # nosemgrep: direct-use-of-jinja2
+        return template.render(**render_result, **branding)
+
+    def render_internal(
+        self,
+        template_name: str,
+        lang: str,
+        context: dict[str, Any],
+    ) -> dict[str, str]:
+        """Render an internal transactional template.
+
+        SPEC-SEC-MAILER-INJECTION-001 REQ-1.5: each template lives in
+        `theme/internal/<name>.<lang>.html.j2` and produces a dict with
+        `subject` (first non-empty paragraph) and `body` (full HTML).
+
+        The Pydantic-validated variable context is merged with branding
+        pulled from settings — attacker cannot override `brand_url` etc.
+        via the request body (REQ-2.4).
+        """
+        template_path = f"internal/{template_name}.{lang}.html.j2"
+        template = self._theme_env.get_template(template_path)
+        rendered = template.render(**context)
+        # Template format convention: first line is `Subject: <subject>`,
+        # remaining content is the body HTML. The separator is a blank line.
+        if rendered.startswith("Subject:"):
+            first_line, _, body = rendered.partition("\n")
+            subject = first_line[len("Subject:"):].strip()
+            return {"subject": subject, "body": body.lstrip()}
+        raise ValueError(
+            f"internal template {template_path} must start with `Subject: <line>\\n`"
+        )

--- a/klai-mailer/app/schemas.py
+++ b/klai-mailer/app/schemas.py
@@ -1,0 +1,64 @@
+"""Per-template Pydantic v2 schemas for `/internal/send`.
+
+SPEC-SEC-MAILER-INJECTION-001 REQ-2. The schema registry is the single
+authoritative list of accepted variables per internal template. Adding a
+variable to a template MUST include a schema change in the same commit
+(REQ-2.5).
+
+All models use `extra="forbid"` — unknown keys raise ValidationError. This
+is the first layer of the defence-in-depth that REQ-1 (Jinja2 sandbox) and
+REQ-1.3 (StrictUndefined) then reinforce.
+
+@MX:NOTE: TEMPLATE_SCHEMAS is the single source of truth for the accepted
+variable surface. Do NOT thread attacker-controlled values around this
+registry.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, EmailStr, HttpUrl
+
+
+class _BaseVars(BaseModel):
+    """Shared config: forbid unknowns, strip whitespace on str fields."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        str_strip_whitespace=True,
+    )
+
+
+class JoinRequestAdminVars(_BaseVars):
+    """Variables for the `join_request_admin` email.
+
+    REQ-3.1: `org_id` is REQUIRED so klai-mailer can resolve the expected
+    recipient via portal-api. The portal-api caller at
+    `klai-portal/backend/app/services/notifications.py:notify_admin_join_request`
+    MUST pass `org_id` in the same PR as REQ-1..4 landing.
+    """
+
+    name: str
+    email: EmailStr
+    org_id: int
+
+
+class JoinRequestApprovedVars(_BaseVars):
+    """Variables for the `join_request_approved` email.
+
+    REQ-3.2 design choice: `email` is an explicit schema field. The
+    handler asserts `to == variables.email` before dispatch, making the
+    recipient binding explicit and testable rather than an implicit
+    derivation.
+    """
+
+    name: str
+    email: EmailStr
+    workspace_url: HttpUrl
+
+
+# REQ-2.2: registry keyed on template_name. Handler resolves schema via
+# TEMPLATE_SCHEMAS[template_name]; unknown key -> HTTP 400.
+TEMPLATE_SCHEMAS: dict[str, type[_BaseVars]] = {
+    "join_request_admin": JoinRequestAdminVars,
+    "join_request_approved": JoinRequestApprovedVars,
+}

--- a/klai-mailer/app/signature.py
+++ b/klai-mailer/app/signature.py
@@ -1,0 +1,131 @@
+"""Zitadel webhook signature verification.
+
+Factored out of app/main.py for SPEC-SEC-MAILER-INJECTION-001 REQ-7 (uniform
+401 body across failure modes) and REQ-10 (strict parser rejecting unknown
+vN fields).
+
+Public surface:
+- `verify_zitadel_signature(raw_body, header_value, secret)` — the canonical
+  verifier. Raises `SignatureError` on any failure; the exception carries a
+  distinct `reason` for observability without leaking it to the HTTP response.
+- `SignatureError` — internal-only exception. Callers must catch it and emit
+  a single uniform `{"detail": "invalid signature"}` 401 (REQ-7.1).
+
+@MX:ANCHOR: every /notify and /debug caller funnels through this module.
+@MX:REASON: centralising the parser + verifier ensures REQ-7 / REQ-10
+invariants hold regardless of call site.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import time
+from typing import Any
+
+# Zitadel currently emits exactly two fields: t (timestamp) and v1 (HMAC hex).
+# Any other key is a parser rejection per REQ-10.1. If Zitadel ships a v2 /
+# v3 scheme, this set MUST be updated explicitly in a versioned change.
+ALLOWED_SIG_KEYS: frozenset[str] = frozenset({"t", "v1"})
+
+# REQ-10.3: defence against header-splitting / padding attacks. Current Zitadel
+# headers are 2 tokens; 5 leaves headroom for future versions.
+MAX_SIG_TOKENS: int = 5
+
+# Zitadel replay window.
+REPLAY_WINDOW_SECONDS: int = 300
+
+
+class SignatureError(Exception):
+    """Raised when a Zitadel webhook signature fails verification.
+
+    The `reason` attribute MUST be one of the sentinels below. It is logged,
+    not returned — see REQ-7.2.
+    """
+
+    REASONS = frozenset({
+        "missing_header",
+        "malformed_header",
+        "timestamp_out_of_window",
+        "hmac_mismatch",
+        "unknown_vN_field",
+        "replay",
+    })
+
+    def __init__(self, reason: str, *, extra: dict[str, Any] | None = None) -> None:
+        if reason not in self.REASONS:
+            raise AssertionError(f"unknown signature reason: {reason!r}")
+        super().__init__(reason)
+        self.reason = reason
+        self.extra: dict[str, Any] = extra or {}
+
+
+def _parse_signature_header(header: str) -> dict[str, str]:
+    """Strict parser. Rejects unknown keys and over-long headers.
+
+    Raises `SignatureError` with the appropriate reason.
+    """
+    tokens = header.split(",")
+    if len(tokens) > MAX_SIG_TOKENS:
+        raise SignatureError("unknown_vN_field", extra={"unknown_fields": tokens})
+
+    parts: dict[str, str] = {}
+    unknown: list[str] = []
+    for raw_token in tokens:
+        token = raw_token.strip()
+        if not token:
+            raise SignatureError("malformed_header")
+        if "=" not in token:
+            raise SignatureError("malformed_header")
+        k, v = token.split("=", 1)
+        k = k.strip()
+        if k not in ALLOWED_SIG_KEYS:
+            unknown.append(k)
+            continue
+        parts[k] = v
+
+    if unknown:
+        raise SignatureError("unknown_vN_field", extra={"unknown_fields": unknown})
+    if "t" not in parts or "v1" not in parts:
+        raise SignatureError("malformed_header")
+    return parts
+
+
+def verify_zitadel_signature(
+    raw_body: bytes,
+    header_value: str | None,
+    secret: str,
+    *,
+    now: int | None = None,
+) -> dict[str, str]:
+    """Verify the Zitadel signature header against the raw body.
+
+    Returns the parsed `{"t": ..., "v1": ...}` dict on success (useful for
+    nonce tracking in REQ-6). Raises `SignatureError` on any failure.
+
+    `now` override exists for deterministic tests.
+    """
+    if not header_value:
+        raise SignatureError("missing_header")
+
+    parts = _parse_signature_header(header_value)
+    timestamp = parts["t"]
+    v1 = parts["v1"]
+
+    # Timestamp must be an integer within the replay window.
+    try:
+        ts_int = int(timestamp)
+    except ValueError as exc:
+        raise SignatureError("malformed_header") from exc
+
+    current = now if now is not None else int(time.time())
+    if abs(current - ts_int) > REPLAY_WINDOW_SECONDS:
+        raise SignatureError("timestamp_out_of_window")
+
+    signed_payload = f"{timestamp}.".encode() + raw_body
+    expected = hmac.new(secret.encode("utf-8"), signed_payload, hashlib.sha256).hexdigest()
+
+    if not hmac.compare_digest(expected, v1):
+        raise SignatureError("hmac_mismatch")
+
+    return parts

--- a/klai-mailer/pyproject.toml
+++ b/klai-mailer/pyproject.toml
@@ -11,12 +11,20 @@ dependencies = [
     "pydantic-settings>=2.6",
     "httpx>=0.27",
     "structlog>=25.0",
+    "redis>=5.0",
+    "email-validator>=2.0",
 ]
 
 [project.optional-dependencies]
 dev = [
     "ruff>=0.8",
     "pyright>=1.1",
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24",
+    "pytest-cov>=5.0",
+    "fakeredis>=2.24",
+    "respx>=0.21",
+    "lxml>=5.0",
 ]
 
 [tool.ruff]
@@ -28,4 +36,15 @@ select = ["E", "F", "I", "UP", "B", "S", "RUF", "G", "LOG"]
 ignore = [
     "S101",  # assert is fine in tests
     "S105",  # hardcoded passwords — too many false positives on config defaults
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["S106", "S311"]  # test secrets + non-crypto random are fine
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+pythonpath = ["."]
+filterwarnings = [
+    "ignore::DeprecationWarning:pydantic.*",
 ]

--- a/klai-mailer/tests/_signing.py
+++ b/klai-mailer/tests/_signing.py
@@ -1,0 +1,28 @@
+"""Test helper: build a valid Zitadel-signed webhook header.
+
+Used by test_notify_*.py to construct legitimate AND forged signatures
+without duplicating the HMAC plumbing.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import time
+
+
+def sign(body: bytes, secret: str, timestamp: int | None = None) -> tuple[str, int]:
+    """Return (header_value, timestamp). Header format: `t=<ts>,v1=<hex>`."""
+    ts = timestamp if timestamp is not None else int(time.time())
+    payload = f"{ts}.".encode() + body
+    digest = hmac.new(secret.encode("utf-8"), payload, hashlib.sha256).hexdigest()
+    return f"t={ts},v1={digest}", ts
+
+
+def sign_with_extra(body: bytes, secret: str, extra: str, timestamp: int | None = None) -> str:
+    """Valid t/v1 pair plus an attacker-supplied extra field (e.g. `v2=x`).
+
+    REQ-10.1 says this MUST be rejected.
+    """
+    base, _ = sign(body, secret, timestamp=timestamp)
+    return f"{base},{extra}"

--- a/klai-mailer/tests/conftest.py
+++ b/klai-mailer/tests/conftest.py
@@ -1,0 +1,217 @@
+"""Shared pytest fixtures for klai-mailer tests.
+
+Provides:
+- `settings_env`: minimal valid env vars for constructing `Settings`
+- `fake_redis`: fakeredis.aioredis client
+- `stub_smtp`: captures outbound SMTP calls without hitting the network
+- `portal_api_mock`: respx router pre-seeded with common portal-api responses
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator, Iterator
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    pass
+
+import pytest
+
+# Minimal env vars required by Settings() — applied via monkeypatch per test that
+# constructs Settings. Do NOT leak into os.environ unconditionally (other tests
+# may want the absence-case).
+DEFAULT_TEST_ENV: dict[str, str] = {
+    "SMTP_HOST": "smtp.test.local",
+    "SMTP_USERNAME": "mailer@test",
+    "SMTP_PASSWORD": "smtp-test-secret",
+    "SMTP_FROM": "noreply@test.local",
+    "WEBHOOK_SECRET": "webhook-test-secret",
+    "INTERNAL_SECRET": "internal-test-secret",
+    "BRAND_URL": "https://test.klai.example",
+    "LOGO_URL": "https://test.klai.example/logo.png",
+    "PORTAL_API_URL": "http://portal-api.test.local:8010",
+    "PORTAL_INTERNAL_SECRET": "portal-internal-test-secret",
+    "PORTAL_ENV": "development",
+    "REDIS_URL": "redis://redis-test.local:6379/0",
+    "DEBUG": "false",
+}
+
+
+@pytest.fixture
+def settings_env(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
+    """Apply the default valid env vars so `Settings()` succeeds."""
+    for k, v in DEFAULT_TEST_ENV.items():
+        monkeypatch.setenv(k, v)
+    return dict(DEFAULT_TEST_ENV)
+
+
+@pytest.fixture
+def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Start from an empty env so per-test monkeypatch.setenv is deterministic."""
+    for key in list(os.environ):
+        if key in DEFAULT_TEST_ENV or key.startswith((
+            "SMTP_", "WEBHOOK_", "INTERNAL_", "BRAND_", "LOGO_",
+            "PORTAL_", "REDIS_", "DEBUG", "MAILER_",
+        )):
+            monkeypatch.delenv(key, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# StubSMTPSender — captures send_email() calls in-process
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StubSMTPSender:
+    """Captures outbound email calls made via app.mailer.send_email."""
+
+    sent: list[dict[str, Any]] = field(default_factory=list)
+
+    async def __call__(
+        self,
+        *,
+        to_address: str,
+        subject: str,
+        html_body: str,
+    ) -> None:
+        self.sent.append({
+            "to_address": to_address,
+            "subject": subject,
+            "html_body": html_body,
+        })
+
+    def reset(self) -> None:
+        self.sent.clear()
+
+
+@pytest.fixture
+def stub_smtp(monkeypatch: pytest.MonkeyPatch) -> StubSMTPSender:
+    """Install a stub SMTP sender that captures calls in-process.
+
+    Both `app.mailer.send_email` AND any module that has already imported it as
+    `from app.mailer import send_email` must be patched. We patch both the
+    source module and main.py (which is where the import lands at runtime).
+    """
+    stub = StubSMTPSender()
+    # Patch source module
+    import app.mailer as mailer_module
+    monkeypatch.setattr(mailer_module, "send_email", stub, raising=True)
+    # Patch the re-export used by main.py (only if main is already imported)
+    try:
+        import app.main as main_module
+        if hasattr(main_module, "send_email"):
+            monkeypatch.setattr(main_module, "send_email", stub, raising=False)
+    except ImportError:
+        pass
+    return stub
+
+
+# ---------------------------------------------------------------------------
+# fakeredis fixture — in-memory Redis for nonce + rate-limit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def fake_redis() -> AsyncIterator[Any]:
+    """Async fakeredis client shared across a single test."""
+    import fakeredis.aioredis
+
+    client = fakeredis.aioredis.FakeRedis(decode_responses=False)
+    try:
+        yield client
+    finally:
+        await client.aclose()
+
+
+@pytest.fixture
+def broken_redis() -> Any:
+    """A Redis-shaped object whose every operation raises ConnectionError.
+
+    Used to exercise REQ-4.3 (fail-open on rate-limit Redis outage) and REQ-6.3
+    (fail-closed on nonce Redis outage).
+    """
+
+    class _BrokenRedis:
+        async def set(self, *args: Any, **kwargs: Any) -> None:
+            raise ConnectionError("fake redis unavailable")
+
+        async def get(self, *args: Any, **kwargs: Any) -> None:
+            raise ConnectionError("fake redis unavailable")
+
+        async def zadd(self, *args: Any, **kwargs: Any) -> None:
+            raise ConnectionError("fake redis unavailable")
+
+        async def zremrangebyscore(self, *args: Any, **kwargs: Any) -> None:
+            raise ConnectionError("fake redis unavailable")
+
+        async def zcard(self, *args: Any, **kwargs: Any) -> None:
+            raise ConnectionError("fake redis unavailable")
+
+        async def zrange(self, *args: Any, **kwargs: Any) -> None:
+            raise ConnectionError("fake redis unavailable")
+
+        async def expire(self, *args: Any, **kwargs: Any) -> None:
+            raise ConnectionError("fake redis unavailable")
+
+        async def aclose(self) -> None:
+            return None
+
+        def pipeline(self, *args: Any, **kwargs: Any) -> _BrokenRedis:
+            return self
+
+        async def execute(self) -> None:
+            raise ConnectionError("fake redis unavailable")
+
+        async def __aenter__(self) -> _BrokenRedis:
+            return self
+
+        async def __aexit__(self, *args: Any) -> None:
+            return None
+
+    return _BrokenRedis()
+
+
+# ---------------------------------------------------------------------------
+# App factory — yields a fresh FastAPI app with isolated deps
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app_factory(monkeypatch: pytest.MonkeyPatch, settings_env: dict[str, str]) -> Iterator[Any]:
+    """Factory that yields a fresh `app.main` module on demand.
+
+    Re-imports app.main after env changes so module-level state (settings,
+    conditional route registration) reflects the test configuration.
+    """
+    import importlib
+    import sys
+
+    # Ensure clean module graph; drop cached config + main
+    for mod in ("app.main", "app.config", "app.renderer", "app.nonce", "app.rate_limit"):
+        sys.modules.pop(mod, None)
+
+    created_modules: list[str] = []
+
+    def _factory(**env_overrides: str) -> Any:
+        for k, v in env_overrides.items():
+            monkeypatch.setenv(k.upper(), v)
+        # Drop cached modules again so new env takes effect
+        for mod in ("app.main", "app.config", "app.renderer", "app.nonce", "app.rate_limit"):
+            sys.modules.pop(mod, None)
+        module = importlib.import_module("app.main")
+        created_modules.append("app.main")
+        return module
+
+    yield _factory
+
+    for mod in (
+        *created_modules,
+        "app.main",
+        "app.config",
+        "app.renderer",
+        "app.nonce",
+        "app.rate_limit",
+    ):
+        sys.modules.pop(mod, None)

--- a/klai-mailer/tests/conftest.py
+++ b/klai-mailer/tests/conftest.py
@@ -26,7 +26,7 @@ DEFAULT_TEST_ENV: dict[str, str] = {
     "SMTP_HOST": "smtp.test.local",
     "SMTP_USERNAME": "mailer@test",
     "SMTP_PASSWORD": "smtp-test-secret",
-    "SMTP_FROM": "noreply@test.local",
+    "SMTP_FROM": "noreply@test.example",
     "WEBHOOK_SECRET": "webhook-test-secret",
     "INTERNAL_SECRET": "internal-test-secret",
     "BRAND_URL": "https://test.klai.example",
@@ -133,6 +133,44 @@ def broken_redis() -> Any:
     (fail-closed on nonce Redis outage).
     """
 
+    class _BrokenPipeline:
+        """Sync-queue pipeline whose execute() raises ConnectionError.
+
+        Real redis-py pipelines queue commands synchronously; only `execute`
+        is async. We mirror that so rate_limit.py's pipeline use doesn't
+        produce un-awaited-coroutine warnings.
+        """
+
+        def zadd(self, *args: Any, **kwargs: Any) -> _BrokenPipeline:
+            return self
+
+        def zremrangebyscore(self, *args: Any, **kwargs: Any) -> _BrokenPipeline:
+            return self
+
+        def zcard(self, *args: Any, **kwargs: Any) -> _BrokenPipeline:
+            return self
+
+        def zrange(self, *args: Any, **kwargs: Any) -> _BrokenPipeline:
+            return self
+
+        def zrem(self, *args: Any, **kwargs: Any) -> _BrokenPipeline:
+            return self
+
+        def expire(self, *args: Any, **kwargs: Any) -> _BrokenPipeline:
+            return self
+
+        def set(self, *args: Any, **kwargs: Any) -> _BrokenPipeline:
+            return self
+
+        async def execute(self) -> None:
+            raise ConnectionError("fake redis unavailable")
+
+        async def __aenter__(self) -> _BrokenPipeline:
+            return self
+
+        async def __aexit__(self, *args: Any) -> None:
+            return None
+
     class _BrokenRedis:
         async def set(self, *args: Any, **kwargs: Any) -> None:
             raise ConnectionError("fake redis unavailable")
@@ -152,23 +190,17 @@ def broken_redis() -> Any:
         async def zrange(self, *args: Any, **kwargs: Any) -> None:
             raise ConnectionError("fake redis unavailable")
 
+        async def zrem(self, *args: Any, **kwargs: Any) -> None:
+            raise ConnectionError("fake redis unavailable")
+
         async def expire(self, *args: Any, **kwargs: Any) -> None:
             raise ConnectionError("fake redis unavailable")
 
         async def aclose(self) -> None:
             return None
 
-        def pipeline(self, *args: Any, **kwargs: Any) -> _BrokenRedis:
-            return self
-
-        async def execute(self) -> None:
-            raise ConnectionError("fake redis unavailable")
-
-        async def __aenter__(self) -> _BrokenRedis:
-            return self
-
-        async def __aexit__(self, *args: Any) -> None:
-            return None
+        def pipeline(self, *args: Any, **kwargs: Any) -> _BrokenPipeline:
+            return _BrokenPipeline()
 
     return _BrokenRedis()
 

--- a/klai-mailer/tests/fixtures/golden/join_request_admin.en.html
+++ b/klai-mailer/tests/fixtures/golden/join_request_admin.en.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="nl" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="x-apple-disable-message-reformatting">
+  <meta name="format-detection" content="telephone=no,address=no,email=no,date=no,url=no">
+  <title>[Klai] Access request from Alice Example (alice@example.com)</title>
+  <!--[if mso]>
+  <noscript><xml><o:OfficeDocumentSettings>
+    <o:PixelsPerInch>96</o:PixelsPerInch>
+  </o:OfficeDocumentSettings></xml></noscript>
+  <![endif]-->
+  <style>
+    /* Client-specific resets */
+    body, table, td, a { -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }
+    table, td { mso-table-lspace: 0pt; mso-table-rspace: 0pt; }
+    img { -ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none; }
+
+    /* Base — Sand light (#F5F0E8) is the official Klai brand background for sections/cards */
+    body { margin: 0 !important; padding: 0 !important; background-color: #F5F0E8; width: 100% !important; }
+
+    /* Responsive */
+    @media only screen and (max-width: 640px) {
+      .email-card { width: 100% !important; border-radius: 0 !important; }
+      .email-body { padding: 24px 20px !important; }
+      .email-header { padding: 24px 20px 20px !important; }
+      .email-footer { padding: 20px !important; }
+    }
+  </style>
+</head>
+<body style="margin:0;padding:0;background-color:#F5F0E8;font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">
+
+  
+  <div style="display:none;max-height:0;overflow:hidden;mso-hide:all;font-size:1px;color:#F5F0E8;line-height:1px;">
+    
+    
+    &zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;
+  </div>
+
+  
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"
+         style="background-color:#F5F0E8;width:100%;">
+    <tr>
+      <td align="center" style="padding:40px 16px;">
+
+        
+        <table role="presentation" class="email-card" cellpadding="0" cellspacing="0" border="0"
+               style="width:100%;max-width:600px;background-color:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(28,15,64,0.08);">
+
+          
+          <tr>
+            <td class="email-header" align="center"
+                style="padding:32px 40px 24px;border-bottom:1px solid #EEECF3;background-color:#ffffff;">
+              <a href="https://test.klai.example" style="text-decoration:none;">
+                <img src="https://test.klai.example/logo.png" alt="Klai" width="61"
+                     style="display:block;max-width:61px;height:auto;border:0;">
+              </a>
+            </td>
+          </tr>
+
+          
+          <tr>
+            <td class="email-body"
+                style="padding:32px 40px;color:#1a0f40;font-size:16px;line-height:1.625;">
+              <p>Hello,</p><p><strong>Alice Example</strong> (alice@example.com) has submitted an access request for your Klai workspace.</p><p>You can approve or deny the request in the <a href='https://test.klai.example/admin/settings/join-requests'>admin settings</a>.</p>
+            </td>
+          </tr>
+
+          
+          
+
+          
+          <tr>
+            <td class="email-footer"
+                style="padding:24px 40px;border-top:1px solid #EEECF3;background-color:#FAFAF8;">
+              <p style="margin:0;color:#6b7280;font-size:13px;line-height:1.5;text-align:center;">
+                Klai &bull;
+                <a href="https://test.klai.example" style="color:#4A3A8A;text-decoration:none;">https://test.klai.example</a>
+              </p>
+              
+            </td>
+          </tr>
+
+        </table>
+
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>

--- a/klai-mailer/tests/fixtures/golden/join_request_admin.nl.html
+++ b/klai-mailer/tests/fixtures/golden/join_request_admin.nl.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="nl" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="x-apple-disable-message-reformatting">
+  <meta name="format-detection" content="telephone=no,address=no,email=no,date=no,url=no">
+  <title>[Klai] Toegangsverzoek van Alice Example (alice@example.com)</title>
+  <!--[if mso]>
+  <noscript><xml><o:OfficeDocumentSettings>
+    <o:PixelsPerInch>96</o:PixelsPerInch>
+  </o:OfficeDocumentSettings></xml></noscript>
+  <![endif]-->
+  <style>
+    /* Client-specific resets */
+    body, table, td, a { -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }
+    table, td { mso-table-lspace: 0pt; mso-table-rspace: 0pt; }
+    img { -ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none; }
+
+    /* Base — Sand light (#F5F0E8) is the official Klai brand background for sections/cards */
+    body { margin: 0 !important; padding: 0 !important; background-color: #F5F0E8; width: 100% !important; }
+
+    /* Responsive */
+    @media only screen and (max-width: 640px) {
+      .email-card { width: 100% !important; border-radius: 0 !important; }
+      .email-body { padding: 24px 20px !important; }
+      .email-header { padding: 24px 20px 20px !important; }
+      .email-footer { padding: 20px !important; }
+    }
+  </style>
+</head>
+<body style="margin:0;padding:0;background-color:#F5F0E8;font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">
+
+  
+  <div style="display:none;max-height:0;overflow:hidden;mso-hide:all;font-size:1px;color:#F5F0E8;line-height:1px;">
+    
+    
+    &zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;
+  </div>
+
+  
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"
+         style="background-color:#F5F0E8;width:100%;">
+    <tr>
+      <td align="center" style="padding:40px 16px;">
+
+        
+        <table role="presentation" class="email-card" cellpadding="0" cellspacing="0" border="0"
+               style="width:100%;max-width:600px;background-color:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(28,15,64,0.08);">
+
+          
+          <tr>
+            <td class="email-header" align="center"
+                style="padding:32px 40px 24px;border-bottom:1px solid #EEECF3;background-color:#ffffff;">
+              <a href="https://test.klai.example" style="text-decoration:none;">
+                <img src="https://test.klai.example/logo.png" alt="Klai" width="61"
+                     style="display:block;max-width:61px;height:auto;border:0;">
+              </a>
+            </td>
+          </tr>
+
+          
+          <tr>
+            <td class="email-body"
+                style="padding:32px 40px;color:#1a0f40;font-size:16px;line-height:1.625;">
+              <p>Hallo,</p><p><strong>Alice Example</strong> (alice@example.com) heeft een toegangsverzoek ingediend voor je Klai-werkruimte.</p><p>Je kunt het verzoek goedkeuren of afwijzen in de <a href='https://test.klai.example/admin/settings/join-requests'>beheeromgeving</a>.</p>
+            </td>
+          </tr>
+
+          
+          
+
+          
+          <tr>
+            <td class="email-footer"
+                style="padding:24px 40px;border-top:1px solid #EEECF3;background-color:#FAFAF8;">
+              <p style="margin:0;color:#6b7280;font-size:13px;line-height:1.5;text-align:center;">
+                Klai &bull;
+                <a href="https://test.klai.example" style="color:#4A3A8A;text-decoration:none;">https://test.klai.example</a>
+              </p>
+              
+            </td>
+          </tr>
+
+        </table>
+
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>

--- a/klai-mailer/tests/fixtures/golden/join_request_approved.en.html
+++ b/klai-mailer/tests/fixtures/golden/join_request_approved.en.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="nl" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="x-apple-disable-message-reformatting">
+  <meta name="format-detection" content="telephone=no,address=no,email=no,date=no,url=no">
+  <title>[Klai] Your access request has been approved</title>
+  <!--[if mso]>
+  <noscript><xml><o:OfficeDocumentSettings>
+    <o:PixelsPerInch>96</o:PixelsPerInch>
+  </o:OfficeDocumentSettings></xml></noscript>
+  <![endif]-->
+  <style>
+    /* Client-specific resets */
+    body, table, td, a { -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }
+    table, td { mso-table-lspace: 0pt; mso-table-rspace: 0pt; }
+    img { -ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none; }
+
+    /* Base — Sand light (#F5F0E8) is the official Klai brand background for sections/cards */
+    body { margin: 0 !important; padding: 0 !important; background-color: #F5F0E8; width: 100% !important; }
+
+    /* Responsive */
+    @media only screen and (max-width: 640px) {
+      .email-card { width: 100% !important; border-radius: 0 !important; }
+      .email-body { padding: 24px 20px !important; }
+      .email-header { padding: 24px 20px 20px !important; }
+      .email-footer { padding: 20px !important; }
+    }
+  </style>
+</head>
+<body style="margin:0;padding:0;background-color:#F5F0E8;font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">
+
+  
+  <div style="display:none;max-height:0;overflow:hidden;mso-hide:all;font-size:1px;color:#F5F0E8;line-height:1px;">
+    
+    
+    &zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;
+  </div>
+
+  
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"
+         style="background-color:#F5F0E8;width:100%;">
+    <tr>
+      <td align="center" style="padding:40px 16px;">
+
+        
+        <table role="presentation" class="email-card" cellpadding="0" cellspacing="0" border="0"
+               style="width:100%;max-width:600px;background-color:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(28,15,64,0.08);">
+
+          
+          <tr>
+            <td class="email-header" align="center"
+                style="padding:32px 40px 24px;border-bottom:1px solid #EEECF3;background-color:#ffffff;">
+              <a href="https://test.klai.example" style="text-decoration:none;">
+                <img src="https://test.klai.example/logo.png" alt="Klai" width="61"
+                     style="display:block;max-width:61px;height:auto;border:0;">
+              </a>
+            </td>
+          </tr>
+
+          
+          <tr>
+            <td class="email-body"
+                style="padding:32px 40px;color:#1a0f40;font-size:16px;line-height:1.625;">
+              <p>Hello Bob Requester,</p><p>Your access request for Klai has been approved. You can now log in to your workspace:</p><p><a href='https://app.klai.example/'>https://app.klai.example/</a></p>
+            </td>
+          </tr>
+
+          
+          
+
+          
+          <tr>
+            <td class="email-footer"
+                style="padding:24px 40px;border-top:1px solid #EEECF3;background-color:#FAFAF8;">
+              <p style="margin:0;color:#6b7280;font-size:13px;line-height:1.5;text-align:center;">
+                Klai &bull;
+                <a href="https://test.klai.example" style="color:#4A3A8A;text-decoration:none;">https://test.klai.example</a>
+              </p>
+              
+            </td>
+          </tr>
+
+        </table>
+
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>

--- a/klai-mailer/tests/fixtures/golden/join_request_approved.nl.html
+++ b/klai-mailer/tests/fixtures/golden/join_request_approved.nl.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="nl" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="x-apple-disable-message-reformatting">
+  <meta name="format-detection" content="telephone=no,address=no,email=no,date=no,url=no">
+  <title>[Klai] Je toegangsverzoek is goedgekeurd</title>
+  <!--[if mso]>
+  <noscript><xml><o:OfficeDocumentSettings>
+    <o:PixelsPerInch>96</o:PixelsPerInch>
+  </o:OfficeDocumentSettings></xml></noscript>
+  <![endif]-->
+  <style>
+    /* Client-specific resets */
+    body, table, td, a { -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }
+    table, td { mso-table-lspace: 0pt; mso-table-rspace: 0pt; }
+    img { -ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none; }
+
+    /* Base — Sand light (#F5F0E8) is the official Klai brand background for sections/cards */
+    body { margin: 0 !important; padding: 0 !important; background-color: #F5F0E8; width: 100% !important; }
+
+    /* Responsive */
+    @media only screen and (max-width: 640px) {
+      .email-card { width: 100% !important; border-radius: 0 !important; }
+      .email-body { padding: 24px 20px !important; }
+      .email-header { padding: 24px 20px 20px !important; }
+      .email-footer { padding: 20px !important; }
+    }
+  </style>
+</head>
+<body style="margin:0;padding:0;background-color:#F5F0E8;font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">
+
+  
+  <div style="display:none;max-height:0;overflow:hidden;mso-hide:all;font-size:1px;color:#F5F0E8;line-height:1px;">
+    
+    
+    &zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;
+  </div>
+
+  
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"
+         style="background-color:#F5F0E8;width:100%;">
+    <tr>
+      <td align="center" style="padding:40px 16px;">
+
+        
+        <table role="presentation" class="email-card" cellpadding="0" cellspacing="0" border="0"
+               style="width:100%;max-width:600px;background-color:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(28,15,64,0.08);">
+
+          
+          <tr>
+            <td class="email-header" align="center"
+                style="padding:32px 40px 24px;border-bottom:1px solid #EEECF3;background-color:#ffffff;">
+              <a href="https://test.klai.example" style="text-decoration:none;">
+                <img src="https://test.klai.example/logo.png" alt="Klai" width="61"
+                     style="display:block;max-width:61px;height:auto;border:0;">
+              </a>
+            </td>
+          </tr>
+
+          
+          <tr>
+            <td class="email-body"
+                style="padding:32px 40px;color:#1a0f40;font-size:16px;line-height:1.625;">
+              <p>Hallo Bob Requester,</p><p>Je toegangsverzoek voor Klai is goedgekeurd. Je kunt nu inloggen op je werkruimte:</p><p><a href='https://app.klai.example/'>https://app.klai.example/</a></p>
+            </td>
+          </tr>
+
+          
+          
+
+          
+          <tr>
+            <td class="email-footer"
+                style="padding:24px 40px;border-top:1px solid #EEECF3;background-color:#FAFAF8;">
+              <p style="margin:0;color:#6b7280;font-size:13px;line-height:1.5;text-align:center;">
+                Klai &bull;
+                <a href="https://test.klai.example" style="color:#4A3A8A;text-decoration:none;">https://test.klai.example</a>
+              </p>
+              
+            </td>
+          </tr>
+
+        </table>
+
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>

--- a/klai-mailer/tests/test_config_fail_closed.py
+++ b/klai-mailer/tests/test_config_fail_closed.py
@@ -1,0 +1,97 @@
+"""AC-7: Empty or whitespace-only required secrets refuse startup.
+
+Covers REQ-9.1 (WEBHOOK_SECRET) and REQ-9.2 (INTERNAL_SECRET). Fail-closed
+at `Settings()` construction via pydantic-settings field_validator(mode="after").
+
+The module-level `settings = Settings()` in app/config.py means the failure
+manifests at import-time. We construct `Settings()` directly from the class
+so the assertion can be scoped precisely.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+from pydantic import ValidationError
+
+
+def _fresh_settings_class():
+    """Import `Settings` without triggering the module-level singleton."""
+    sys.modules.pop("app.config", None)
+    # Import the class only; reference `Settings()` inline so the singleton
+    # failure path is exercised AT the construction site of the test body.
+    # But app.config runs `settings = Settings()` at module load, which is
+    # exactly the startup behaviour we want to test. So instead we re-import
+    # via a guarded reload and capture the exception.
+    from app.config import Settings
+    return Settings
+
+
+def test_valid_secrets_construct(settings_env, monkeypatch):
+    """Sanity: valid env → Settings() succeeds."""
+    SettingsCls = _fresh_settings_class()
+    settings = SettingsCls()
+    assert settings.webhook_secret == "webhook-test-secret"
+    assert settings.internal_secret == "internal-test-secret"
+
+
+@pytest.mark.parametrize("value", ["", "   ", "\t\n "], ids=["empty", "spaces", "whitespace"])
+def test_empty_webhook_secret_refuses_startup(settings_env, monkeypatch, value):
+    """REQ-9.1: empty / whitespace-only WEBHOOK_SECRET raises ValidationError."""
+    monkeypatch.setenv("WEBHOOK_SECRET", value)
+    # Drop cached module so re-import triggers the module-level Settings()
+    sys.modules.pop("app.config", None)
+    with pytest.raises(ValidationError) as exc_info:
+        importlib.import_module("app.config")
+    assert "Missing required: WEBHOOK_SECRET" in str(exc_info.value)
+
+
+@pytest.mark.parametrize("value", ["", "   ", "\t\n "], ids=["empty", "spaces", "whitespace"])
+def test_empty_internal_secret_refuses_startup(settings_env, monkeypatch, value):
+    """REQ-9.2: empty / whitespace-only INTERNAL_SECRET raises ValidationError."""
+    monkeypatch.setenv("INTERNAL_SECRET", value)
+    sys.modules.pop("app.config", None)
+    with pytest.raises(ValidationError) as exc_info:
+        importlib.import_module("app.config")
+    assert "Missing required: INTERNAL_SECRET" in str(exc_info.value)
+
+
+def test_both_empty_raises(settings_env, monkeypatch):
+    """Both secrets empty → import fails with at least one missing error."""
+    monkeypatch.setenv("WEBHOOK_SECRET", "")
+    monkeypatch.setenv("INTERNAL_SECRET", "")
+    sys.modules.pop("app.config", None)
+    with pytest.raises(ValidationError) as exc_info:
+        importlib.import_module("app.config")
+    msg = str(exc_info.value)
+    assert "Missing required: WEBHOOK_SECRET" in msg
+    assert "Missing required: INTERNAL_SECRET" in msg
+
+
+def test_startup_exits_nonzero(settings_env, monkeypatch):
+    """REQ-9 operational claim: uvicorn entrypoint cannot bind with empty secret.
+
+    Spawn a subprocess that imports `app.config`; assert non-zero exit and
+    the expected error on stderr. Documents the fail-closed property at the
+    OS level — a container with empty WEBHOOK_SECRET refuses to boot.
+    """
+    import os
+    import subprocess
+    import sys as _sys
+    from pathlib import Path
+
+    env = dict(os.environ)
+    env["WEBHOOK_SECRET"] = ""
+
+    result = subprocess.run(
+        [_sys.executable, "-c", "import app.config"],
+        cwd=str(Path(__file__).resolve().parent.parent),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode != 0, f"expected non-zero exit, stderr: {result.stderr}"
+    assert "Missing required: WEBHOOK_SECRET" in result.stderr

--- a/klai-mailer/tests/test_debug_gate.py
+++ b/klai-mailer/tests/test_debug_gate.py
@@ -1,0 +1,123 @@
+"""AC-4: /debug returns 404 when PORTAL_ENV=production (double-gate).
+
+Covers REQ-5.1 (portal_env field), REQ-5.2 (404 in production regardless
+of DEBUG), REQ-5.3 (preferred: conditional route registration), REQ-5.4
+(handler-level fallback gate), REQ-5.5 (no log event on 404).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+from structlog.testing import capture_logs
+
+from tests._signing import sign
+
+VALID_BODY = b'{"contextInfo":{"eventType":"x"},"templateData":{"text":"hi"}}'
+
+
+def _fresh_app(monkeypatch, **env_overrides: str):
+    """Re-import app.main with env overrides applied."""
+    for k, v in env_overrides.items():
+        monkeypatch.setenv(k, v)
+    for mod in ("app.main", "app.config", "app.nonce", "app.signature"):
+        sys.modules.pop(mod, None)
+    # fresh fakeredis per instance so nonce state isolated
+    import fakeredis.aioredis
+
+    import app.nonce as nonce_mod
+    client = fakeredis.aioredis.FakeRedis(decode_responses=False)
+    nonce_mod.set_redis_client(client)
+    main = importlib.import_module("app.main")
+    # re-apply (main re-imports nonce)
+    import app.nonce as nonce_after
+    nonce_after.set_redis_client(client)
+    return main
+
+
+@pytest.fixture
+def in_env(monkeypatch, settings_env, stub_smtp):
+    """Yield a factory that produces a TestClient with `portal_env` + `debug` overridden."""
+    def _build(portal_env: str, debug: str) -> tuple[TestClient, object]:
+        main = _fresh_app(monkeypatch, PORTAL_ENV=portal_env, DEBUG=debug)
+        return TestClient(main.app), main
+    return _build
+
+
+# ---------------------------------------------------------------------------
+# AC-4 headline: production env → 404 regardless of DEBUG
+# ---------------------------------------------------------------------------
+
+
+def test_production_env_returns_404_even_with_debug_true(in_env, settings_env):
+    """REQ-5.2: PORTAL_ENV=production AND DEBUG=true → 404."""
+    client, _ = in_env(portal_env="production", debug="true")
+
+    header, _ = sign(VALID_BODY, settings_env["WEBHOOK_SECRET"])
+    with capture_logs() as events:
+        resp = client.post(
+            "/debug", content=VALID_BODY, headers={"ZITADEL-Signature": header}
+        )
+
+    assert resp.status_code == 404
+    assert resp.json() == {"detail": "Not found"}
+
+    # REQ-5.5: NO structured log event for the production 404 (no
+    # mailer_debug_* or signature events). FastAPI's default 404 is a plain
+    # HTTP response, not an application event.
+    relevant_events = [
+        e for e in events
+        if (e.get("event") or "").startswith(("mailer_debug", "mailer_signature"))
+    ]
+    assert relevant_events == [], f"unexpected app events: {relevant_events}"
+
+
+def test_development_debug_true_works(in_env, settings_env):
+    """Sanity: PORTAL_ENV=development, DEBUG=true → /debug returns 200."""
+    client, _ = in_env(portal_env="development", debug="true")
+    header, _ = sign(VALID_BODY, settings_env["WEBHOOK_SECRET"])
+    resp = client.post(
+        "/debug", content=VALID_BODY, headers={"ZITADEL-Signature": header}
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def test_development_debug_false_returns_404(in_env, settings_env):
+    """REQ-5.2 legacy: PORTAL_ENV=development, DEBUG=false → 404."""
+    client, _ = in_env(portal_env="development", debug="false")
+    header, _ = sign(VALID_BODY, settings_env["WEBHOOK_SECRET"])
+    resp = client.post(
+        "/debug", content=VALID_BODY, headers={"ZITADEL-Signature": header}
+    )
+    assert resp.status_code == 404
+
+
+def test_staging_debug_true_works(in_env, settings_env):
+    """Staging is NOT production — the gate only blocks the production value."""
+    client, _ = in_env(portal_env="staging", debug="true")
+    header, _ = sign(VALID_BODY, settings_env["WEBHOOK_SECRET"])
+    resp = client.post(
+        "/debug", content=VALID_BODY, headers={"ZITADEL-Signature": header}
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def test_signature_verify_not_called_in_production(in_env, settings_env):
+    """REQ-5.2: the 404 short-circuits before signature work is attempted.
+
+    We assert the StubSMTPSender receives no message and that no
+    mailer_signature_invalid log fires — proving _verify_zitadel_signature
+    was not reached even with a forged signature.
+    """
+    client, _ = in_env(portal_env="production", debug="true")
+    bad_header = "t=1,v1=deadbeef"
+    with capture_logs() as events:
+        resp = client.post(
+            "/debug", content=VALID_BODY, headers={"ZITADEL-Signature": bad_header}
+        )
+    assert resp.status_code == 404
+    sig_events = [e for e in events if (e.get("event") or "").startswith("mailer_signature")]
+    assert sig_events == [], f"signature check ran in production: {sig_events}"

--- a/klai-mailer/tests/test_internal_send_auth.py
+++ b/klai-mailer/tests/test_internal_send_auth.py
@@ -1,0 +1,106 @@
+"""AC-10: /internal/send uses hmac.compare_digest for X-Internal-Secret.
+
+REQ-8.1: Replaces `!=` with hmac.compare_digest in the auth helper.
+REQ-8.2: The check is factored into a helper (_validate_incoming_secret)
+         so future routes cannot regress to `!=`.
+
+The constant-time property is asserted by inspecting that the helper
+contains an `hmac.compare_digest` call (textually), and the functional
+behaviour is asserted via HTTP 401 for a range of wrong secrets.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from fastapi.testclient import TestClient
+
+
+def _get_client(settings_env, stub_smtp):
+    # Fresh import so REQ-9 validator and REQ-8 compare_digest land in the module
+    import importlib
+    import sys
+    for mod in ("app.main", "app.config"):
+        sys.modules.pop(mod, None)
+    main = importlib.import_module("app.main")
+    return TestClient(main.app), main
+
+
+def _send(client, secret_header: str | None = None, body=None):
+    headers = {}
+    if secret_header is not None:
+        headers["X-Internal-Secret"] = secret_header
+    payload = body or {
+        "template": "join_request_admin",
+        "to": "admin@test.local",
+        "locale": "nl",
+        "variables": {"name": "Alice", "email": "a@test.local"},
+    }
+    return client.post("/internal/send", json=payload, headers=headers)
+
+
+def test_correct_secret_is_accepted(settings_env, stub_smtp):
+    """Sanity: the correct secret passes the auth gate."""
+    client, _ = _get_client(settings_env, stub_smtp)
+    resp = _send(client, secret_header="internal-test-secret")
+    # May still fail downstream once REQ-1..4 land; for REQ-8 we only check auth
+    # returns a non-401 status.
+    assert resp.status_code != 401, f"got {resp.status_code} with correct secret: {resp.text}"
+
+
+def test_wrong_secret_same_length_returns_401(settings_env, stub_smtp):
+    client, _ = _get_client(settings_env, stub_smtp)
+    resp = _send(client, secret_header="x" * len("internal-test-secret"))
+    assert resp.status_code == 401
+    assert resp.json() == {"detail": "Unauthorized"}
+
+
+def test_wrong_secret_short_returns_401(settings_env, stub_smtp):
+    client, _ = _get_client(settings_env, stub_smtp)
+    resp = _send(client, secret_header="x")
+    assert resp.status_code == 401
+
+
+def test_wrong_secret_long_returns_401(settings_env, stub_smtp):
+    client, _ = _get_client(settings_env, stub_smtp)
+    resp = _send(client, secret_header="y" * 128)
+    assert resp.status_code == 401
+
+
+def test_empty_secret_returns_401(settings_env, stub_smtp):
+    client, _ = _get_client(settings_env, stub_smtp)
+    resp = _send(client, secret_header="")
+    assert resp.status_code == 401
+
+
+def test_missing_secret_header_returns_401(settings_env, stub_smtp):
+    client, _ = _get_client(settings_env, stub_smtp)
+    resp = _send(client, secret_header=None)
+    assert resp.status_code == 401
+
+
+def test_auth_helper_uses_compare_digest(settings_env, stub_smtp):
+    """REQ-8.2: the factored helper calls hmac.compare_digest.
+
+    Sources are inspected to ensure the `!=` antipattern is not reintroduced.
+    """
+    _, main = _get_client(settings_env, stub_smtp)
+    helper = getattr(main, "_validate_incoming_secret", None)
+    assert helper is not None, "expected _validate_incoming_secret helper"
+    source = inspect.getsource(helper)
+    assert "hmac.compare_digest" in source, (
+        f"_validate_incoming_secret must use hmac.compare_digest; got:\n{source}"
+    )
+    assert "!=" not in source.split("\n", 1)[1], (
+        "`!=` comparison against the shared secret is forbidden — use compare_digest"
+    )
+
+
+def test_no_rawless_comparison_on_internal_secret(settings_env, stub_smtp):
+    """REQ-8.3: the `!= settings.internal_secret` antipattern is removed from main.py."""
+    _, main = _get_client(settings_env, stub_smtp)
+    source = inspect.getsource(main)
+    # The bug pattern: direct `!=` comparison on the settings attribute
+    assert "!= settings.internal_secret" not in source, (
+        "main.py still contains the `!=` compare on internal_secret — use hmac.compare_digest"
+    )

--- a/klai-mailer/tests/test_internal_send_auth.py
+++ b/klai-mailer/tests/test_internal_send_auth.py
@@ -32,9 +32,9 @@ def _send(client, secret_header: str | None = None, body=None):
         headers["X-Internal-Secret"] = secret_header
     payload = body or {
         "template": "join_request_admin",
-        "to": "admin@test.local",
+        "to": "admin@test.example",
         "locale": "nl",
-        "variables": {"name": "Alice", "email": "a@test.local"},
+        "variables": {"name": "Alice", "email": "a@test.example"},
     }
     return client.post("/internal/send", json=payload, headers=headers)
 

--- a/klai-mailer/tests/test_internal_send_golden.py
+++ b/klai-mailer/tests/test_internal_send_golden.py
@@ -1,0 +1,139 @@
+"""AC-9: Golden-output regression for legitimate internal emails.
+
+Covers REQ-1.5 (template files), REQ-2.1 (schema validation passes),
+REQ-2.4 (branding from settings), REQ-3.1/3.2 (recipient binding).
+
+Legitimate admin / approved flows produce emails that match the committed
+golden fixtures semantically. Whitespace-only differences inside HTML tags
+are normalised via lxml before comparison.
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+import respx
+from fastapi.testclient import TestClient
+
+GOLDEN_DIR = Path(__file__).parent / "fixtures" / "golden"
+
+CANONICAL_INPUTS = {
+    ("join_request_admin", "nl"): {
+        "name": "Alice Example",
+        "email": "alice@example.com",
+        "org_id": 42,
+    },
+    ("join_request_admin", "en"): {
+        "name": "Alice Example",
+        "email": "alice@example.com",
+        "org_id": 42,
+    },
+    ("join_request_approved", "nl"): {
+        "name": "Bob Requester",
+        "email": "bob@example.com",
+        "workspace_url": "https://app.klai.example",
+    },
+    ("join_request_approved", "en"): {
+        "name": "Bob Requester",
+        "email": "bob@example.com",
+        "workspace_url": "https://app.klai.example",
+    },
+}
+
+
+def _normalise(html: str) -> str:
+    """Collapse whitespace between / inside tags for a forgiving byte compare."""
+    html = re.sub(r"\s+", " ", html)
+    html = re.sub(r">\s+<", "><", html)
+    return html.strip()
+
+
+def _load_main(fake_redis):
+    for mod in ("app.main", "app.config", "app.nonce", "app.rate_limit", "app.signature"):
+        sys.modules.pop(mod, None)
+    import app.nonce as nonce_mod
+    import app.rate_limit as rl_mod
+    nonce_mod.set_redis_client(fake_redis)
+    rl_mod.set_redis_client(fake_redis)
+    main = importlib.import_module("app.main")
+    import app.nonce as n
+    import app.rate_limit as r
+    n.set_redis_client(fake_redis)
+    r.set_redis_client(fake_redis)
+    return main
+
+
+@pytest.fixture
+def client(settings_env, fake_redis, stub_smtp):
+    main = _load_main(fake_redis)
+    return TestClient(main.app)
+
+
+@pytest.mark.parametrize(
+    "template,locale",
+    [
+        ("join_request_admin", "nl"),
+        ("join_request_admin", "en"),
+        ("join_request_approved", "nl"),
+        ("join_request_approved", "en"),
+    ],
+)
+def test_golden_output(client, stub_smtp, template, locale, settings_env):
+    """Rendered (template, locale) matches the committed golden fixture."""
+    inputs = CANONICAL_INPUTS[(template, locale)]
+
+    if template == "join_request_admin":
+        expected_to = "admin@example.com"
+        with respx.mock(assert_all_called=False) as mock:
+            mock.get(url__regex=rf"^.+/internal/org/{inputs['org_id']}/admin-email$").mock(
+                return_value=httpx.Response(200, json={"admin_email": expected_to})
+            )
+            resp = client.post(
+                "/internal/send",
+                headers={"X-Internal-Secret": "internal-test-secret"},
+                json={
+                    "template": template,
+                    "to": expected_to,
+                    "locale": locale,
+                    "variables": inputs,
+                },
+            )
+    else:
+        expected_to = inputs["email"]
+        resp = client.post(
+            "/internal/send",
+            headers={"X-Internal-Secret": "internal-test-secret"},
+            json={
+                "template": template,
+                "to": expected_to,
+                "locale": locale,
+                "variables": inputs,
+            },
+        )
+
+    assert resp.status_code == 200, resp.text
+
+    fixture_path = GOLDEN_DIR / f"{template}.{locale}.html"
+    rendered_html = stub_smtp.sent[0]["html_body"]
+    assert stub_smtp.sent[0]["to_address"] == expected_to
+
+    if not fixture_path.exists():
+        # First-run capture: persist the current output so future changes
+        # are regressions. This keeps the fixture honest to whatever the
+        # Jinja2 sandbox produces from the committed templates + wrapper.
+        fixture_path.parent.mkdir(parents=True, exist_ok=True)
+        fixture_path.write_text(rendered_html, encoding="utf-8")
+        pytest.skip(
+            f"golden fixture {fixture_path.name} captured on first run — "
+            "commit it and re-run the suite"
+        )
+
+    expected = fixture_path.read_text(encoding="utf-8")
+    assert _normalise(rendered_html) == _normalise(expected), (
+        f"golden mismatch for {template}.{locale}"
+    )

--- a/klai-mailer/tests/test_internal_send_rate_limit.py
+++ b/klai-mailer/tests/test_internal_send_rate_limit.py
@@ -1,0 +1,205 @@
+"""AC-3: per-recipient rate limit (10 sends / 24h).
+
+Covers REQ-4.1 (ceiling + Retry-After), REQ-4.2 (sha256 hash keying),
+REQ-4.3 (fail-open on Redis outage), REQ-4.4 (configurable), REQ-4.5
+(failed validation doesn't deplete budget), REQ-4.6 (no cleartext email
+in logs).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import httpx
+import pytest
+import respx
+from fastapi.testclient import TestClient
+from structlog.testing import capture_logs
+
+
+def _load_main(redis_client):
+    for mod in ("app.main", "app.config", "app.nonce", "app.rate_limit", "app.signature"):
+        sys.modules.pop(mod, None)
+    import app.nonce as nonce_mod
+    import app.rate_limit as rl_mod
+    nonce_mod.set_redis_client(redis_client)
+    rl_mod.set_redis_client(redis_client)
+    main = importlib.import_module("app.main")
+    import app.nonce as n
+    import app.rate_limit as r
+    n.set_redis_client(redis_client)
+    r.set_redis_client(redis_client)
+    return main
+
+
+@pytest.fixture
+def client_fakeredis(settings_env, fake_redis, stub_smtp):
+    main = _load_main(fake_redis)
+    return TestClient(main.app)
+
+
+@pytest.fixture
+def client_brokenredis(settings_env, broken_redis, stub_smtp):
+    main = _load_main(broken_redis)
+    return TestClient(main.app)
+
+
+BASE_PAYLOAD = {
+    "template": "join_request_admin",
+    "to": "admin@test.example",
+    "locale": "nl",
+    "variables": {
+        "name": "Alice",
+        "email": "alice@test.example",
+        "org_id": 42,
+    },
+}
+
+
+@pytest.fixture
+def portal_ok():
+    with respx.mock(assert_all_called=False) as mock:
+        mock.get(url__regex=r"^.+/internal/org/\d+/admin-email$").mock(
+            return_value=httpx.Response(200, json={"admin_email": "admin@test.example"})
+        )
+        yield mock
+
+
+# ---------------------------------------------------------------------------
+# AC-3 headline: 11th send returns 429
+# ---------------------------------------------------------------------------
+
+
+def test_eleventh_send_returns_429(client_fakeredis, stub_smtp, portal_ok):
+    """REQ-4.1: 10 sends pass, 11th returns 429 + Retry-After."""
+    for _ in range(10):
+        resp = client_fakeredis.post(
+            "/internal/send",
+            headers={"X-Internal-Secret": "internal-test-secret"},
+            json=BASE_PAYLOAD,
+        )
+        assert resp.status_code == 200, resp.text
+
+    # 11th
+    with capture_logs() as events:
+        resp = client_fakeredis.post(
+            "/internal/send",
+            headers={"X-Internal-Secret": "internal-test-secret"},
+            json=BASE_PAYLOAD,
+        )
+    assert resp.status_code == 429
+    assert resp.json() == {"detail": "recipient rate limit exceeded"}
+    retry_after = resp.headers.get("Retry-After")
+    assert retry_after and int(retry_after) > 0
+
+    assert len(stub_smtp.sent) == 10, "11th send must be blocked before SMTP dispatch"
+
+    rl_events = [e for e in events if e.get("event") == "mailer_recipient_rate_limited"]
+    assert rl_events
+    # REQ-4.6: recipient cleartext MUST NOT appear in the log event
+    for e in rl_events:
+        assert "admin@test.example" not in str(e)
+        assert "recipient_hash" in e
+
+
+def test_different_recipients_have_separate_budgets(client_fakeredis, stub_smtp):
+    """Budgets are per-recipient — another org's admin is unaffected."""
+    with respx.mock(assert_all_called=False) as mock:
+        mock.get(url__regex=r"^.+/internal/org/42/admin-email$").mock(
+            return_value=httpx.Response(200, json={"admin_email": "admin@test.example"})
+        )
+        mock.get(url__regex=r"^.+/internal/org/99/admin-email$").mock(
+            return_value=httpx.Response(200, json={"admin_email": "other@test.example"})
+        )
+
+        # Exhaust org 42's budget
+        for _ in range(10):
+            client_fakeredis.post(
+                "/internal/send",
+                headers={"X-Internal-Secret": "internal-test-secret"},
+                json=BASE_PAYLOAD,
+            )
+
+        other_payload = {
+            **BASE_PAYLOAD,
+            "to": "other@test.example",
+            "variables": {**BASE_PAYLOAD["variables"], "org_id": 99},
+        }
+        # org 99's first send should still succeed
+        resp = client_fakeredis.post(
+            "/internal/send",
+            headers={"X-Internal-Secret": "internal-test-secret"},
+            json=other_payload,
+        )
+        assert resp.status_code == 200
+
+
+def test_case_insensitive_collision(client_fakeredis, stub_smtp):
+    """REQ-4.2: Admin@.. and admin@.. share a budget (sha256 of lowercase)."""
+    with respx.mock(assert_all_called=False) as mock:
+        mock.get(url__regex=r"^.+/internal/org/\d+/admin-email$").mock(
+            return_value=httpx.Response(200, json={"admin_email": "Admin@test.example"})
+        )
+        for i in range(10):
+            to_value = "Admin@test.example" if i % 2 == 0 else "admin@test.example"
+            resp = client_fakeredis.post(
+                "/internal/send",
+                headers={"X-Internal-Secret": "internal-test-secret"},
+                json={**BASE_PAYLOAD, "to": to_value},
+            )
+            assert resp.status_code == 200, f"iter {i}: {resp.text}"
+        # 11th with the other casing collides with the same hash bucket
+        resp = client_fakeredis.post(
+            "/internal/send",
+            headers={"X-Internal-Secret": "internal-test-secret"},
+            json={**BASE_PAYLOAD, "to": "ADMIN@test.example"},
+        )
+        assert resp.status_code == 429
+
+
+def test_redis_unavailable_fails_open(
+    client_brokenredis, stub_smtp, portal_ok, broken_redis
+):
+    """REQ-4.3: Redis down → allow sends, log mailer_rate_limit_redis_unavailable."""
+    with capture_logs() as events:
+        # Go past the normal ceiling — must all succeed
+        for _ in range(15):
+            resp = client_brokenredis.post(
+                "/internal/send",
+                headers={"X-Internal-Secret": "internal-test-secret"},
+                json=BASE_PAYLOAD,
+            )
+            assert resp.status_code == 200, resp.text
+
+    unavail_events = [
+        e for e in events if e.get("event") == "mailer_rate_limit_redis_unavailable"
+    ]
+    assert unavail_events, "expected fail-open warning log"
+
+
+def test_failed_validation_does_not_deplete_budget(
+    client_fakeredis, stub_smtp, portal_ok
+):
+    """REQ-4.5: schema-invalid requests MUST NOT count toward the budget."""
+    # 10 invalid requests (missing org_id)
+    bad_payload = {
+        **BASE_PAYLOAD,
+        "variables": {"name": "Alice", "email": "alice@test.example"},
+    }
+    for _ in range(10):
+        resp = client_fakeredis.post(
+            "/internal/send",
+            headers={"X-Internal-Secret": "internal-test-secret"},
+            json=bad_payload,
+        )
+        assert resp.status_code == 400
+
+    # Now 10 valid requests — all should succeed (budget untouched)
+    for _ in range(10):
+        resp = client_fakeredis.post(
+            "/internal/send",
+            headers={"X-Internal-Secret": "internal-test-secret"},
+            json=BASE_PAYLOAD,
+        )
+        assert resp.status_code == 200, resp.text

--- a/klai-mailer/tests/test_internal_send_recipient.py
+++ b/klai-mailer/tests/test_internal_send_recipient.py
@@ -1,0 +1,218 @@
+"""AC-2: recipient binding to template-derived expectation.
+
+Covers REQ-3.1 (join_request_admin → portal-api admin-email),
+REQ-3.2 (join_request_approved → variables.email), REQ-3.4 (fail-closed
+on portal-api outage).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import httpx
+import pytest
+import respx
+from fastapi.testclient import TestClient
+from structlog.testing import capture_logs
+
+
+def _load_main(fake_redis):
+    for mod in ("app.main", "app.config", "app.nonce", "app.rate_limit", "app.signature"):
+        sys.modules.pop(mod, None)
+    import app.nonce as nonce_mod
+    import app.rate_limit as rl_mod
+    nonce_mod.set_redis_client(fake_redis)
+    rl_mod.set_redis_client(fake_redis)
+    main = importlib.import_module("app.main")
+    import app.nonce as n
+    import app.rate_limit as r
+    n.set_redis_client(fake_redis)
+    r.set_redis_client(fake_redis)
+    return main
+
+
+@pytest.fixture
+def client(settings_env, fake_redis, stub_smtp):
+    main = _load_main(fake_redis)
+    return TestClient(main.app)
+
+
+# ---------------------------------------------------------------------------
+# REQ-3.1: join_request_admin recipient binding
+# ---------------------------------------------------------------------------
+
+
+def test_recipient_mismatch_rejected(client, stub_smtp):
+    """Caller-supplied `to` != portal-api admin_email → 400."""
+    with respx.mock(assert_all_called=False) as mock:
+        mock.get(url__regex=r"^.+/internal/org/42/admin-email$").mock(
+            return_value=httpx.Response(200, json={"admin_email": "admin@test.example"})
+        )
+        with capture_logs() as events:
+            resp = client.post(
+                "/internal/send",
+                headers={"X-Internal-Secret": "internal-test-secret"},
+                json={
+                    "template": "join_request_admin",
+                    "to": "attacker@evil.example",
+                    "locale": "nl",
+                    "variables": {
+                        "name": "Alice",
+                        "email": "alice@test.example",
+                        "org_id": 42,
+                    },
+                },
+            )
+    assert resp.status_code == 400
+    assert resp.json() == {"detail": "recipient mismatch"}
+    assert stub_smtp.sent == []
+
+    mismatch_events = [e for e in events if e.get("event") == "mailer_recipient_mismatch"]
+    assert mismatch_events, f"expected mailer_recipient_mismatch event; got {events}"
+    # Privacy: cleartext email MUST NOT appear in logs
+    for e in mismatch_events:
+        assert "attacker@evil.example" not in str(e)
+        assert "admin@test.example" not in str(e)
+
+
+def test_recipient_match_accepted_uses_resolved_email(client, stub_smtp):
+    """Correct match → email sent to the resolved admin email."""
+    with respx.mock(assert_all_called=False) as mock:
+        mock.get(url__regex=r"^.+/internal/org/42/admin-email$").mock(
+            return_value=httpx.Response(200, json={"admin_email": "admin@test.example"})
+        )
+        resp = client.post(
+            "/internal/send",
+            headers={"X-Internal-Secret": "internal-test-secret"},
+            json={
+                "template": "join_request_admin",
+                "to": "admin@test.example",
+                "locale": "nl",
+                "variables": {
+                    "name": "Alice",
+                    "email": "alice@test.example",
+                    "org_id": 42,
+                },
+            },
+        )
+    assert resp.status_code == 200, resp.text
+    assert len(stub_smtp.sent) == 1
+    assert stub_smtp.sent[0]["to_address"] == "admin@test.example"
+
+
+def test_recipient_match_case_insensitive(client, stub_smtp):
+    """REQ-3.1: `to` comparison is case-insensitive."""
+    with respx.mock(assert_all_called=False) as mock:
+        mock.get(url__regex=r"^.+/internal/org/\d+/admin-email$").mock(
+            return_value=httpx.Response(200, json={"admin_email": "Admin@Test.Example"})
+        )
+        resp = client.post(
+            "/internal/send",
+            headers={"X-Internal-Secret": "internal-test-secret"},
+            json={
+                "template": "join_request_admin",
+                "to": "ADMIN@test.example",
+                "locale": "nl",
+                "variables": {
+                    "name": "Alice",
+                    "email": "alice@test.example",
+                    "org_id": 42,
+                },
+            },
+        )
+    assert resp.status_code == 200, resp.text
+
+
+def test_portal_api_unreachable_returns_503(client, stub_smtp):
+    """REQ-3.4: fail-closed when portal-api is unreachable."""
+    with respx.mock(assert_all_called=False) as mock:
+        mock.get(url__regex=r"^.+/internal/org/\d+/admin-email$").mock(
+            side_effect=httpx.ConnectError("nope")
+        )
+        with capture_logs() as events:
+            resp = client.post(
+                "/internal/send",
+                headers={"X-Internal-Secret": "internal-test-secret"},
+                json={
+                    "template": "join_request_admin",
+                    "to": "admin@test.example",
+                    "locale": "nl",
+                    "variables": {
+                        "name": "Alice",
+                        "email": "alice@test.example",
+                        "org_id": 42,
+                    },
+                },
+            )
+    assert resp.status_code == 503
+    assert resp.json() == {"detail": "recipient lookup unavailable"}
+    assert stub_smtp.sent == []
+    lookup_events = [e for e in events if e.get("event") == "mailer_recipient_lookup_failed"]
+    assert lookup_events
+
+
+# ---------------------------------------------------------------------------
+# REQ-3.2: join_request_approved recipient binding (variables.email)
+# ---------------------------------------------------------------------------
+
+
+def test_approved_recipient_from_variables_email(client, stub_smtp):
+    """REQ-3.2: recipient is validated_vars.email."""
+    resp = client.post(
+        "/internal/send",
+        headers={"X-Internal-Secret": "internal-test-secret"},
+        json={
+            "template": "join_request_approved",
+            "to": "bob@test.example",
+            "locale": "nl",
+            "variables": {
+                "name": "Bob",
+                "email": "bob@test.example",
+                "workspace_url": "https://app.klai.example",
+            },
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert stub_smtp.sent[0]["to_address"] == "bob@test.example"
+
+
+def test_approved_to_mismatch_rejected(client, stub_smtp):
+    """REQ-3.2: `to` != variables.email → 400 recipient mismatch."""
+    resp = client.post(
+        "/internal/send",
+        headers={"X-Internal-Secret": "internal-test-secret"},
+        json={
+            "template": "join_request_approved",
+            "to": "attacker@evil.example",
+            "locale": "nl",
+            "variables": {
+                "name": "Bob",
+                "email": "bob@test.example",
+                "workspace_url": "https://app.klai.example",
+            },
+        },
+    )
+    assert resp.status_code == 400
+    assert resp.json() == {"detail": "recipient mismatch"}
+    assert stub_smtp.sent == []
+
+
+def test_approved_missing_to_falls_back_to_email(client, stub_smtp):
+    """REQ-3.2 alternative: empty `to` → use variables.email."""
+    resp = client.post(
+        "/internal/send",
+        headers={"X-Internal-Secret": "internal-test-secret"},
+        json={
+            "template": "join_request_approved",
+            "to": "",
+            "locale": "nl",
+            "variables": {
+                "name": "Bob",
+                "email": "bob@test.example",
+                "workspace_url": "https://app.klai.example",
+            },
+        },
+    )
+    assert resp.status_code == 200
+    assert stub_smtp.sent[0]["to_address"] == "bob@test.example"

--- a/klai-mailer/tests/test_internal_send_sandbox.py
+++ b/klai-mailer/tests/test_internal_send_sandbox.py
@@ -1,0 +1,234 @@
+"""AC-1 + unit: Jinja2 sandbox + StrictUndefined + Pydantic schema.
+
+Covers REQ-1.1 (sandbox render), REQ-1.2 (dunder access blocked),
+REQ-1.3 (StrictUndefined), REQ-2.1/2.3 (per-template schema rejects
+unknown + invalid values), REQ-2.4 (branding injected from settings,
+not caller).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import httpx
+import pytest
+import respx
+from fastapi.testclient import TestClient
+
+
+def _load_main(settings_env, fake_redis, stub_smtp):
+    for mod in ("app.main", "app.config", "app.nonce", "app.rate_limit", "app.signature"):
+        sys.modules.pop(mod, None)
+    import app.nonce as nonce_mod
+    import app.rate_limit as rl_mod
+    nonce_mod.set_redis_client(fake_redis)
+    rl_mod.set_redis_client(fake_redis)
+    main = importlib.import_module("app.main")
+    import app.nonce as n
+    import app.rate_limit as r
+    n.set_redis_client(fake_redis)
+    r.set_redis_client(fake_redis)
+    return main
+
+
+@pytest.fixture
+def client(settings_env, fake_redis, stub_smtp):
+    main = _load_main(settings_env, fake_redis, stub_smtp)
+    return TestClient(main.app)
+
+
+@pytest.fixture
+def respx_mock_portal(settings_env):
+    """Mock portal-api admin-email lookup."""
+    with respx.mock(assert_all_called=False) as router:
+        router.get(
+            url__regex=r"^.+/internal/org/\d+/admin-email$"
+        ).mock(return_value=httpx.Response(200, json={"admin_email": "admin@test.example"}))
+        yield router
+
+
+# ---------------------------------------------------------------------------
+# AC-1: str.format introspection payload is rejected
+# ---------------------------------------------------------------------------
+
+
+def test_str_format_payload_rejected(client, respx_mock_portal, stub_smtp):
+    """REQ-1.1 + REQ-2.1: attacker string in variables is either rejected
+    (schema/sandbox) or rendered literally — never executed as Python."""
+    resp = client.post(
+        "/internal/send",
+        headers={"X-Internal-Secret": "internal-test-secret"},
+        json={
+            "template": "join_request_admin",
+            "to": "admin@test.example",
+            "locale": "nl",
+            "variables": {
+                "name": "{__class__.__mro__[1].__subclasses__}",
+                "email": "alice@test.example",
+                "org_id": 42,
+            },
+        },
+    )
+
+    if resp.status_code == 200:
+        # Literal-string render path: the attacker string appears LITERALLY
+        # in the body as plain text. That is safe — the test's sole job is
+        # to prove no Python-object graph content leaked into the email.
+        assert len(stub_smtp.sent) == 1
+        body_html = stub_smtp.sent[0]["html_body"]
+        # No secrets, no class objects from actual introspection
+        assert "smtp_password" not in body_html
+        assert "webhook_secret" not in body_html
+        assert "internal-test-secret" not in body_html
+        assert "Settings object at" not in body_html
+        assert "<class '" not in body_html
+        assert "built-in method" not in body_html
+    else:
+        # Rejected path: 400 is the other acceptable outcome.
+        assert resp.status_code == 400
+        assert stub_smtp.sent == []
+
+
+def test_unknown_keys_rejected(client, respx_mock_portal, stub_smtp):
+    """REQ-2.1: `extra="forbid"` rejects unknown variables."""
+    resp = client.post(
+        "/internal/send",
+        headers={"X-Internal-Secret": "internal-test-secret"},
+        json={
+            "template": "join_request_admin",
+            "to": "admin@test.example",
+            "locale": "nl",
+            "variables": {
+                "name": "Alice",
+                "email": "alice@test.example",
+                "org_id": 42,
+                "injected_extra": "evil",  # unknown key
+            },
+        },
+    )
+    assert resp.status_code == 400
+    assert stub_smtp.sent == []
+
+
+def test_missing_required_key_returns_400(client, respx_mock_portal, stub_smtp):
+    """REQ-2.3: missing `org_id` → ValidationError → 400."""
+    resp = client.post(
+        "/internal/send",
+        headers={"X-Internal-Secret": "internal-test-secret"},
+        json={
+            "template": "join_request_admin",
+            "to": "admin@test.example",
+            "locale": "nl",
+            "variables": {"name": "Alice", "email": "alice@test.example"},
+        },
+    )
+    assert resp.status_code == 400
+    assert resp.json() == {"detail": "invalid variables"}
+
+
+def test_malformed_email_rejected(client, respx_mock_portal, stub_smtp):
+    """REQ-2.1: EmailStr refuses non-email strings."""
+    resp = client.post(
+        "/internal/send",
+        headers={"X-Internal-Secret": "internal-test-secret"},
+        json={
+            "template": "join_request_admin",
+            "to": "admin@test.example",
+            "locale": "nl",
+            "variables": {
+                "name": "Alice",
+                "email": "not-an-email",
+                "org_id": 42,
+            },
+        },
+    )
+    assert resp.status_code == 400
+
+
+def test_unknown_template_returns_400(client, respx_mock_portal, stub_smtp):
+    """REQ-2.2: unknown template name is rejected before schema resolve."""
+    resp = client.post(
+        "/internal/send",
+        headers={"X-Internal-Secret": "internal-test-secret"},
+        json={
+            "template": "does_not_exist",
+            "to": "admin@test.example",
+            "locale": "nl",
+            "variables": {},
+        },
+    )
+    assert resp.status_code == 400
+    assert "Unknown template" in resp.json()["detail"]
+
+
+def test_branding_not_overridable_by_caller(
+    client, respx_mock_portal, stub_smtp, settings_env
+):
+    """REQ-2.4: `brand_url` comes from settings even if caller tries to
+    inject it via `variables`. The extra key is rejected outright by
+    extra=forbid."""
+    resp = client.post(
+        "/internal/send",
+        headers={"X-Internal-Secret": "internal-test-secret"},
+        json={
+            "template": "join_request_admin",
+            "to": "admin@test.example",
+            "locale": "nl",
+            "variables": {
+                "name": "Alice",
+                "email": "alice@test.example",
+                "org_id": 42,
+                "brand_url": "https://phisher.evil",
+            },
+        },
+    )
+    # Rejected because `brand_url` is not in the schema (extra=forbid)
+    assert resp.status_code == 400
+
+
+def test_validation_failure_does_not_leak_long_attacker_strings(
+    client, respx_mock_portal, stub_smtp
+):
+    """REQ-2.3: long attacker values are truncated in the error response."""
+    long_value = "A" * 500
+    resp = client.post(
+        "/internal/send",
+        headers={"X-Internal-Secret": "internal-test-secret"},
+        json={
+            "template": "join_request_admin",
+            "to": "admin@test.example",
+            "locale": "nl",
+            "variables": {
+                "name": "Alice",
+                "email": long_value,  # clearly not EmailStr
+                "org_id": 42,
+            },
+        },
+    )
+    assert resp.status_code == 400
+    # The response body is the canonical "invalid variables" message.
+    # Attacker value is NOT echoed.
+    assert resp.json() == {"detail": "invalid variables"}
+    assert long_value not in resp.text
+
+
+def test_sandbox_blocks_dunder_via_template_context(client, respx_mock_portal):
+    """REQ-1.2: even if the schema allowed a dotted attribute string,
+    the sandbox would refuse to resolve it. Unit-level: verify the
+    renderer itself blocks dunder access."""
+    import importlib as _il
+    import sys as _sys
+    for mod in ("app.renderer", "app.config"):
+        _sys.modules.pop(mod, None)
+    renderer_mod = _il.import_module("app.renderer")
+    from pathlib import Path
+    r = renderer_mod.Renderer(
+        theme_dir=Path("theme")
+    )
+    # Write a tiny template that tries dunder access — use Renderer's
+    # env directly
+    template = r._theme_env.from_string("{{ x.__class__ }}")
+    from jinja2.exceptions import SecurityError
+    with pytest.raises(SecurityError):
+        template.render(x="test")

--- a/klai-mailer/tests/test_notify_error_taxonomy.py
+++ b/klai-mailer/tests/test_notify_error_taxonomy.py
@@ -1,0 +1,160 @@
+"""AC-6: Uniform 401 body for every signature-verification failure.
+
+Covers REQ-7.1 (identical response body), REQ-7.2 (distinct log reason),
+REQ-7.3 (no side-channel headers), REQ-10.1 (unknown vN fields rejected).
+
+Every failure mode MUST produce:
+- HTTP 401
+- body EXACTLY == {"detail": "invalid signature"} (byte-identical across modes)
+- no WWW-Authenticate (or other phase-revealing) header
+- a structured log event with a distinct `reason` sub-field.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+from structlog.testing import capture_logs
+
+from tests._signing import sign, sign_with_extra
+
+VALID_BODY = b'{"contextInfo":{"eventType":"x"},"templateData":{"text":"hi"}}'
+
+
+@pytest.fixture
+def client(settings_env, stub_smtp):
+    for mod in ("app.main", "app.config", "app.signature"):
+        sys.modules.pop(mod, None)
+    main = importlib.import_module("app.main")
+    return TestClient(main.app)
+
+
+@pytest.fixture
+def captured_logs():
+    """Capture structlog events emitted during a test via capture_logs()."""
+    with capture_logs() as events:
+        yield events
+
+
+# ---------------------------------------------------------------------------
+# AC-6 headline: byte-identical 401 body across every failure mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def failure_cases(settings_env):
+    """Build the 5 failure modes from AC-6's table."""
+    secret = settings_env["WEBHOOK_SECRET"]
+    _, valid_ts = sign(VALID_BODY, secret)
+    old_header, _ = sign(VALID_BODY, secret, timestamp=valid_ts - 400)
+
+    return [
+        ("missing_header", {}),
+        ("malformed_header", {"ZITADEL-Signature": "garbage"}),
+        ("timestamp_out_of_window", {"ZITADEL-Signature": old_header}),
+        ("hmac_mismatch", {"ZITADEL-Signature": f"t={int(time.time())},v1=deadbeef"}),
+        (
+            "unknown_vN_field",
+            {"ZITADEL-Signature": sign_with_extra(VALID_BODY, secret, "v2=x")},
+        ),
+    ]
+
+
+def test_uniform_401_body_across_failure_modes(client, failure_cases):
+    """REQ-7.1: response body byte-identical for every failure."""
+    bodies = []
+    for _, headers in failure_cases:
+        resp = client.post("/notify", content=VALID_BODY, headers=headers)
+        assert resp.status_code == 401, f"expected 401, got {resp.status_code} for {headers}"
+        bodies.append(resp.content)
+
+    first = bodies[0]
+    for i, b in enumerate(bodies[1:], start=1):
+        assert b == first, (
+            f"body-{i} differs from body-0: {b!r} vs {first!r}"
+        )
+    assert json.loads(first) == {"detail": "invalid signature"}
+
+
+def test_no_side_channel_headers(client, failure_cases):
+    """REQ-7.3: no WWW-Authenticate / phase-revealing response header."""
+    forbidden = {"www-authenticate", "x-signature-phase", "x-auth-error-kind"}
+    for _, headers in failure_cases:
+        resp = client.post("/notify", content=VALID_BODY, headers=headers)
+        lowered = {k.lower() for k in resp.headers}
+        leaked = forbidden & lowered
+        assert not leaked, f"forbidden response headers: {leaked}"
+
+
+def test_log_reason_distinct_per_mode(client, failure_cases, captured_logs):
+    """REQ-7.2: each failure emits a distinct log `reason`."""
+    reasons_seen: list[str] = []
+    for expected_reason, headers in failure_cases:
+        captured_logs.clear()
+        resp = client.post("/notify", content=VALID_BODY, headers=headers)
+        assert resp.status_code == 401
+        sig_events = [
+            e for e in captured_logs
+            if e.get("event") == "mailer_signature_invalid"
+        ]
+        assert sig_events, (
+            f"no mailer_signature_invalid event for {expected_reason}; "
+            f"captured: {captured_logs}"
+        )
+        reasons = [e.get("reason") for e in sig_events]
+        assert expected_reason in reasons, (
+            f"expected reason={expected_reason!r} for headers={headers}, "
+            f"got reasons={reasons}"
+        )
+        reasons_seen.append(expected_reason)
+
+    # All 5 distinct
+    assert len(set(reasons_seen)) == 5
+
+
+# ---------------------------------------------------------------------------
+# AC-8 headline: extra v2 field is rejected
+# ---------------------------------------------------------------------------
+
+
+def test_extra_v2_field_rejected(client, settings_env, stub_smtp, captured_logs):
+    """REQ-10.1: unknown vN field → 401 + reason=unknown_vN_field."""
+    header = sign_with_extra(VALID_BODY, settings_env["WEBHOOK_SECRET"], "v2=unexpected")
+    resp = client.post("/notify", content=VALID_BODY, headers={"ZITADEL-Signature": header})
+    assert resp.status_code == 401
+    assert resp.json() == {"detail": "invalid signature"}
+    assert stub_smtp.sent == []
+
+    sig_events = [e for e in captured_logs if e.get("event") == "mailer_signature_invalid"]
+    assert any(e.get("reason") == "unknown_vN_field" for e in sig_events)
+    # The unknown field MUST be enumerated for operator visibility
+    assert any("v2" in (e.get("unknown_fields") or []) for e in sig_events)
+
+
+def test_six_token_header_rejected(client, settings_env):
+    """REQ-10.3: more than 5 tokens → reject."""
+    base, _ = sign(VALID_BODY, settings_env["WEBHOOK_SECRET"])
+    header = base + ",a=1,b=2,c=3,d=4"  # 5 extra → total 6 tokens
+    resp = client.post("/notify", content=VALID_BODY, headers={"ZITADEL-Signature": header})
+    assert resp.status_code == 401
+
+
+def test_non_v_prefixed_unknown_key_rejected(client, settings_env):
+    """REQ-10.1: any key outside {t, v1} is rejected — not only vN siblings."""
+    header = sign_with_extra(VALID_BODY, settings_env["WEBHOOK_SECRET"], "ver=1")
+    resp = client.post("/notify", content=VALID_BODY, headers={"ZITADEL-Signature": header})
+    assert resp.status_code == 401
+
+
+def test_valid_signature_succeeds(client, settings_env, stub_smtp):
+    """Regression: a well-formed header (t + v1 only) still works."""
+    header, _ = sign(VALID_BODY, settings_env["WEBHOOK_SECRET"])
+    resp = client.post("/notify", content=VALID_BODY, headers={"ZITADEL-Signature": header})
+    # May be 422 (payload validation) or 200 (full render); both prove
+    # signature passed. Critically NOT 401.
+    assert resp.status_code != 401, resp.text

--- a/klai-mailer/tests/test_notify_replay.py
+++ b/klai-mailer/tests/test_notify_replay.py
@@ -1,0 +1,137 @@
+"""AC-5: Zitadel webhook replay within the 5-min window is rejected.
+
+Covers REQ-6.1 (nonce key format + SET NX EX 300), REQ-6.2 (ts+v1 namespace),
+REQ-6.3 (fail-closed 503 on Redis outage), REQ-6.4 (nonce AFTER HMAC).
+
+Every nonce-layer failure funnels through the same uniform 401 body
+(`{"detail": "invalid signature"}`) established by REQ-7.1 — "replay"
+is NOT leaked to the response, only to logs.
+
+Redis-unavailable is a distinct failure — HTTP 503 with
+`{"detail": "Service unavailable"}` and log event
+`mailer_nonce_redis_unavailable`.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+from structlog.testing import capture_logs
+
+from tests._signing import sign
+
+VALID_BODY = b'{"contextInfo":{"eventType":"x"},"templateData":{"text":"hi"}}'
+
+
+def _load_main_with_redis(redis_client):
+    """Re-import app.main with the given redis client injected into app.nonce."""
+    for mod in ("app.main", "app.nonce", "app.signature"):
+        sys.modules.pop(mod, None)
+    import app.nonce as nonce_mod
+    nonce_mod.set_redis_client(redis_client)
+    main = importlib.import_module("app.main")
+    # main.py imports nonce; ensure its reference is also patched
+    import app.nonce as nonce_after
+    nonce_after.set_redis_client(redis_client)
+    return main
+
+
+@pytest.fixture
+async def client_with_fakeredis(settings_env, fake_redis, stub_smtp):
+    main = _load_main_with_redis(fake_redis)
+    return TestClient(main.app), main
+
+
+@pytest.fixture
+async def client_with_broken_redis(settings_env, broken_redis, stub_smtp):
+    main = _load_main_with_redis(broken_redis)
+    return TestClient(main.app), main
+
+
+async def test_first_call_accepted_second_is_replay(client_with_fakeredis, settings_env, stub_smtp):
+    """REQ-6.1: identical (ts, v1) within 5 min → second call rejected 401."""
+    client, _ = client_with_fakeredis
+    header, _ = sign(VALID_BODY, settings_env["WEBHOOK_SECRET"])
+
+    # First call — passes signature + nonce. May return 422 (payload has no
+    # recipient) but critically NOT 401.
+    resp1 = client.post("/notify", content=VALID_BODY, headers={"ZITADEL-Signature": header})
+    assert resp1.status_code != 401, f"first call should pass signature: {resp1.text}"
+
+    # Second identical call — replay
+    with capture_logs() as events:
+        resp2 = client.post("/notify", content=VALID_BODY, headers={"ZITADEL-Signature": header})
+    assert resp2.status_code == 401
+    assert resp2.json() == {"detail": "invalid signature"}
+    replay_events = [
+        e for e in events
+        if e.get("event") == "mailer_signature_invalid" and e.get("reason") == "replay"
+    ]
+    assert replay_events, f"expected reason=replay log event; got {events}"
+
+
+async def test_different_bodies_have_independent_nonces(
+    client_with_fakeredis, settings_env, stub_smtp
+):
+    """REQ-6.2: distinct v1 → distinct nonce slot → both first-seen."""
+    client, _ = client_with_fakeredis
+    secret = settings_env["WEBHOOK_SECRET"]
+    body_a = b'{"contextInfo":{"eventType":"a"},"templateData":{"text":"A"}}'
+    body_b = b'{"contextInfo":{"eventType":"b"},"templateData":{"text":"B"}}'
+    header_a, _ = sign(body_a, secret)
+    header_b, _ = sign(body_b, secret)
+
+    resp_a = client.post("/notify", content=body_a, headers={"ZITADEL-Signature": header_a})
+    resp_b = client.post("/notify", content=body_b, headers={"ZITADEL-Signature": header_b})
+    assert resp_a.status_code != 401
+    assert resp_b.status_code != 401
+
+
+async def test_redis_unavailable_fails_closed_503(
+    client_with_broken_redis, settings_env, stub_smtp
+):
+    """REQ-6.3: Redis down → 503 Service unavailable + mailer_nonce_redis_unavailable."""
+    client, _ = client_with_broken_redis
+    header, _ = sign(VALID_BODY, settings_env["WEBHOOK_SECRET"])
+
+    with capture_logs() as events:
+        resp = client.post("/notify", content=VALID_BODY, headers={"ZITADEL-Signature": header})
+
+    assert resp.status_code == 503
+    assert resp.json() == {"detail": "Service unavailable"}
+    assert stub_smtp.sent == []
+
+    nonce_events = [e for e in events if e.get("event") == "mailer_nonce_redis_unavailable"]
+    assert nonce_events, f"expected mailer_nonce_redis_unavailable event; got {events}"
+
+
+async def test_nonce_not_polluted_by_forged_signatures(
+    client_with_fakeredis, settings_env, stub_smtp, fake_redis
+):
+    """REQ-6.4: forged signature MUST NOT record a nonce entry.
+
+    We send a request with an HMAC-invalid header. Then we send a legitimate
+    request that happens to use the same timestamp + a valid v1. The second
+    call MUST succeed — proving the forged attempt did not pollute the nonce
+    cache (which would otherwise cause the legitimate signature to 401 as a
+    'replay').
+    """
+    client, _ = client_with_fakeredis
+    secret = settings_env["WEBHOOK_SECRET"]
+    header_valid, ts = sign(VALID_BODY, secret)
+
+    # Forged: same timestamp, bogus v1
+    forged = f"t={ts},v1=deadbeef"
+    resp_forged = client.post(
+        "/notify", content=VALID_BODY, headers={"ZITADEL-Signature": forged}
+    )
+    assert resp_forged.status_code == 401
+
+    # Legitimate: real v1 for same body+timestamp — must be accepted
+    resp_real = client.post(
+        "/notify", content=VALID_BODY, headers={"ZITADEL-Signature": header_valid}
+    )
+    assert resp_real.status_code != 401, f"forged attempt polluted the nonce: {resp_real.text}"

--- a/klai-mailer/theme/internal/join_request_admin.en.html.j2
+++ b/klai-mailer/theme/internal/join_request_admin.en.html.j2
@@ -1,0 +1,2 @@
+Subject: [Klai] Access request from {{ name }} ({{ email }})
+<p>Hello,</p><p><strong>{{ name }}</strong> ({{ email }}) has submitted an access request for your Klai workspace.</p><p>You can approve or deny the request in the <a href='{{ brand_url }}/admin/settings/join-requests'>admin settings</a>.</p>

--- a/klai-mailer/theme/internal/join_request_admin.nl.html.j2
+++ b/klai-mailer/theme/internal/join_request_admin.nl.html.j2
@@ -1,0 +1,2 @@
+Subject: [Klai] Toegangsverzoek van {{ name }} ({{ email }})
+<p>Hallo,</p><p><strong>{{ name }}</strong> ({{ email }}) heeft een toegangsverzoek ingediend voor je Klai-werkruimte.</p><p>Je kunt het verzoek goedkeuren of afwijzen in de <a href='{{ brand_url }}/admin/settings/join-requests'>beheeromgeving</a>.</p>

--- a/klai-mailer/theme/internal/join_request_approved.en.html.j2
+++ b/klai-mailer/theme/internal/join_request_approved.en.html.j2
@@ -1,0 +1,2 @@
+Subject: [Klai] Your access request has been approved
+<p>Hello {{ name }},</p><p>Your access request for Klai has been approved. You can now log in to your workspace:</p><p><a href='{{ workspace_url }}'>{{ workspace_url }}</a></p>

--- a/klai-mailer/theme/internal/join_request_approved.nl.html.j2
+++ b/klai-mailer/theme/internal/join_request_approved.nl.html.j2
@@ -1,0 +1,2 @@
+Subject: [Klai] Je toegangsverzoek is goedgekeurd
+<p>Hallo {{ name }},</p><p>Je toegangsverzoek voor Klai is goedgekeurd. Je kunt nu inloggen op je werkruimte:</p><p><a href='{{ workspace_url }}'>{{ workspace_url }}</a></p>

--- a/klai-mailer/uv.lock
+++ b/klai-mailer/uv.lock
@@ -1,0 +1,1019 @@
+version = 1
+revision = 1
+requires-python = ">=3.12"
+
+[[package]]
+name = "aiosmtplib"
+version = "5.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/ad/240a7ce4e50713b111dff8b781a898d8d4770e5d6ad4899103f84c86005c/aiosmtplib-5.1.0.tar.gz", hash = "sha256:2504a23b2b63c9de6bc4ea719559a38996dba68f73f6af4eb97be20ee4c5e6c4", size = 66176 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/82/70f2c452acd7ed18c558c8ace9a8cf4fdcc70eae9a41749b5bdc53eb6f45/aiosmtplib-5.1.0-py3-none-any.whl", hash = "sha256:368029440645b486b69db7029208a7a78c6691b90d24a5332ddba35d9109d55b", size = 27778 },
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303 },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643 },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353 },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.4.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707 },
+]
+
+[[package]]
+name = "click"
+version = "8.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502 },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
+name = "coverage"
+version = "7.13.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e0/70553e3000e345daff267cec284ce4cbf3fc141b6da229ac52775b5428f1/coverage-7.13.5.tar.gz", hash = "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179", size = 915967 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c3/a396306ba7db865bf96fc1fb3b7fd29bcbf3d829df642e77b13555163cd6/coverage-7.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:460cf0114c5016fa841214ff5564aa4864f11948da9440bc97e21ad1f4ba1e01", size = 219554 },
+    { url = "https://files.pythonhosted.org/packages/a6/16/a68a19e5384e93f811dccc51034b1fd0b865841c390e3c931dcc4699e035/coverage-7.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e223ce4b4ed47f065bfb123687686512e37629be25cc63728557ae7db261422", size = 219908 },
+    { url = "https://files.pythonhosted.org/packages/29/72/20b917c6793af3a5ceb7fb9c50033f3ec7865f2911a1416b34a7cfa0813b/coverage-7.13.5-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6e3370441f4513c6252bf042b9c36d22491142385049243253c7e48398a15a9f", size = 251419 },
+    { url = "https://files.pythonhosted.org/packages/8c/49/cd14b789536ac6a4778c453c6a2338bc0a2fb60c5a5a41b4008328b9acc1/coverage-7.13.5-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:03ccc709a17a1de074fb1d11f217342fb0d2b1582ed544f554fc9fc3f07e95f5", size = 254159 },
+    { url = "https://files.pythonhosted.org/packages/9d/00/7b0edcfe64e2ed4c0340dac14a52ad0f4c9bd0b8b5e531af7d55b703db7c/coverage-7.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3f4818d065964db3c1c66dc0fbdac5ac692ecbc875555e13374fdbe7eedb4376", size = 255270 },
+    { url = "https://files.pythonhosted.org/packages/93/89/7ffc4ba0f5d0a55c1e84ea7cee39c9fc06af7b170513d83fbf3bbefce280/coverage-7.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:012d5319e66e9d5a218834642d6c35d265515a62f01157a45bcc036ecf947256", size = 257538 },
+    { url = "https://files.pythonhosted.org/packages/81/bd/73ddf85f93f7e6fa83e77ccecb6162d9415c79007b4bc124008a4995e4a7/coverage-7.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8dd02af98971bdb956363e4827d34425cb3df19ee550ef92855b0acb9c7ce51c", size = 251821 },
+    { url = "https://files.pythonhosted.org/packages/a0/81/278aff4e8dec4926a0bcb9486320752811f543a3ce5b602cc7a29978d073/coverage-7.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f08fd75c50a760c7eb068ae823777268daaf16a80b918fa58eea888f8e3919f5", size = 253191 },
+    { url = "https://files.pythonhosted.org/packages/70/ee/fe1621488e2e0a58d7e94c4800f0d96f79671553488d401a612bebae324b/coverage-7.13.5-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:843ea8643cf967d1ac7e8ecd4bb00c99135adf4816c0c0593fdcc47b597fcf09", size = 251337 },
+    { url = "https://files.pythonhosted.org/packages/37/a6/f79fb37aa104b562207cc23cb5711ab6793608e246cae1e93f26b2236ed9/coverage-7.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:9d44d7aa963820b1b971dbecd90bfe5fe8f81cff79787eb6cca15750bd2f79b9", size = 255404 },
+    { url = "https://files.pythonhosted.org/packages/75/f0/ed15262a58ec81ce457ceb717b7f78752a1713556b19081b76e90896e8d4/coverage-7.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7132bed4bd7b836200c591410ae7d97bf7ae8be6fc87d160b2bd881df929e7bf", size = 250903 },
+    { url = "https://files.pythonhosted.org/packages/0f/e9/9129958f20e7e9d4d56d51d42ccf708d15cac355ff4ac6e736e97a9393d2/coverage-7.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a698e363641b98843c517817db75373c83254781426e94ada3197cabbc2c919c", size = 252780 },
+    { url = "https://files.pythonhosted.org/packages/a4/d7/0ad9b15812d81272db94379fe4c6df8fd17781cc7671fdfa30c76ba5ff7b/coverage-7.13.5-cp312-cp312-win32.whl", hash = "sha256:bdba0a6b8812e8c7df002d908a9a2ea3c36e92611b5708633c50869e6d922fdf", size = 222093 },
+    { url = "https://files.pythonhosted.org/packages/29/3d/821a9a5799fac2556bcf0bd37a70d1d11fa9e49784b6d22e92e8b2f85f18/coverage-7.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:d2c87e0c473a10bffe991502eac389220533024c8082ec1ce849f4218dded810", size = 222900 },
+    { url = "https://files.pythonhosted.org/packages/d4/fa/2238c2ad08e35cf4f020ea721f717e09ec3152aea75d191a7faf3ef009a8/coverage-7.13.5-cp312-cp312-win_arm64.whl", hash = "sha256:bf69236a9a81bdca3bff53796237aab096cdbf8d78a66ad61e992d9dac7eb2de", size = 221515 },
+    { url = "https://files.pythonhosted.org/packages/74/8c/74fedc9663dcf168b0a059d4ea756ecae4da77a489048f94b5f512a8d0b3/coverage-7.13.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5ec4af212df513e399cf11610cc27063f1586419e814755ab362e50a85ea69c1", size = 219576 },
+    { url = "https://files.pythonhosted.org/packages/0c/c9/44fb661c55062f0818a6ffd2685c67aa30816200d5f2817543717d4b92eb/coverage-7.13.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:941617e518602e2d64942c88ec8499f7fbd49d3f6c4327d3a71d43a1973032f3", size = 219942 },
+    { url = "https://files.pythonhosted.org/packages/5f/13/93419671cee82b780bab7ea96b67c8ef448f5f295f36bf5031154ec9a790/coverage-7.13.5-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:da305e9937617ee95c2e39d8ff9f040e0487cbf1ac174f777ed5eddd7a7c1f26", size = 250935 },
+    { url = "https://files.pythonhosted.org/packages/ac/68/1666e3a4462f8202d836920114fa7a5ee9275d1fa45366d336c551a162dd/coverage-7.13.5-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:78e696e1cc714e57e8b25760b33a8b1026b7048d270140d25dafe1b0a1ee05a3", size = 253541 },
+    { url = "https://files.pythonhosted.org/packages/4e/5e/3ee3b835647be646dcf3c65a7c6c18f87c27326a858f72ab22c12730773d/coverage-7.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02ca0eed225b2ff301c474aeeeae27d26e2537942aa0f87491d3e147e784a82b", size = 254780 },
+    { url = "https://files.pythonhosted.org/packages/44/b3/cb5bd1a04cfcc49ede6cd8409d80bee17661167686741e041abc7ee1b9a9/coverage-7.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:04690832cbea4e4663d9149e05dba142546ca05cb1848816760e7f58285c970a", size = 256912 },
+    { url = "https://files.pythonhosted.org/packages/1b/66/c1dceb7b9714473800b075f5c8a84f4588f887a90eb8645282031676e242/coverage-7.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0590e44dd2745c696a778f7bab6aa95256de2cbc8b8cff4f7db8ff09813d6969", size = 251165 },
+    { url = "https://files.pythonhosted.org/packages/b7/62/5502b73b97aa2e53ea22a39cf8649ff44827bef76d90bf638777daa27a9d/coverage-7.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d7cfad2d6d81dd298ab6b89fe72c3b7b05ec7544bdda3b707ddaecff8d25c161", size = 252908 },
+    { url = "https://files.pythonhosted.org/packages/7d/37/7792c2d69854397ca77a55c4646e5897c467928b0e27f2d235d83b5d08c6/coverage-7.13.5-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e092b9499de38ae0fbfbc603a74660eb6ff3e869e507b50d85a13b6db9863e15", size = 250873 },
+    { url = "https://files.pythonhosted.org/packages/a3/23/bc866fb6163be52a8a9e5d708ba0d3b1283c12158cefca0a8bbb6e247a43/coverage-7.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:48c39bc4a04d983a54a705a6389512883d4a3b9862991b3617d547940e9f52b1", size = 255030 },
+    { url = "https://files.pythonhosted.org/packages/7d/8b/ef67e1c222ef49860701d346b8bbb70881bef283bd5f6cbba68a39a086c7/coverage-7.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2d3807015f138ffea1ed9afeeb8624fd781703f2858b62a8dd8da5a0994c57b6", size = 250694 },
+    { url = "https://files.pythonhosted.org/packages/46/0d/866d1f74f0acddbb906db212e096dee77a8e2158ca5e6bb44729f9d93298/coverage-7.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ee2aa19e03161671ec964004fb74b2257805d9710bf14a5c704558b9d8dbaf17", size = 252469 },
+    { url = "https://files.pythonhosted.org/packages/7a/f5/be742fec31118f02ce42b21c6af187ad6a344fed546b56ca60caacc6a9a0/coverage-7.13.5-cp313-cp313-win32.whl", hash = "sha256:ce1998c0483007608c8382f4ff50164bfc5bd07a2246dd272aa4043b75e61e85", size = 222112 },
+    { url = "https://files.pythonhosted.org/packages/66/40/7732d648ab9d069a46e686043241f01206348e2bbf128daea85be4d6414b/coverage-7.13.5-cp313-cp313-win_amd64.whl", hash = "sha256:631efb83f01569670a5e866ceb80fe483e7c159fac6f167e6571522636104a0b", size = 222923 },
+    { url = "https://files.pythonhosted.org/packages/48/af/fea819c12a095781f6ccd504890aaddaf88b8fab263c4940e82c7b770124/coverage-7.13.5-cp313-cp313-win_arm64.whl", hash = "sha256:f4cd16206ad171cbc2470dbea9103cf9a7607d5fe8c242fdf1edf36174020664", size = 221540 },
+    { url = "https://files.pythonhosted.org/packages/23/d2/17879af479df7fbbd44bd528a31692a48f6b25055d16482fdf5cdb633805/coverage-7.13.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0428cbef5783ad91fe240f673cc1f76b25e74bbfe1a13115e4aa30d3f538162d", size = 220262 },
+    { url = "https://files.pythonhosted.org/packages/5b/4c/d20e554f988c8f91d6a02c5118f9abbbf73a8768a3048cb4962230d5743f/coverage-7.13.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e0b216a19534b2427cc201a26c25da4a48633f29a487c61258643e89d28200c0", size = 220617 },
+    { url = "https://files.pythonhosted.org/packages/29/9c/f9f5277b95184f764b24e7231e166dfdb5780a46d408a2ac665969416d61/coverage-7.13.5-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:972a9cd27894afe4bc2b1480107054e062df08e671df7c2f18c205e805ccd806", size = 261912 },
+    { url = "https://files.pythonhosted.org/packages/d5/f6/7f1ab39393eeb50cfe4747ae8ef0e4fc564b989225aa1152e13a180d74f8/coverage-7.13.5-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4b59148601efcd2bac8c4dbf1f0ad6391693ccf7a74b8205781751637076aee3", size = 263987 },
+    { url = "https://files.pythonhosted.org/packages/a0/d7/62c084fb489ed9c6fbdf57e006752e7c516ea46fd690e5ed8b8617c7d52e/coverage-7.13.5-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:505d7083c8b0c87a8fa8c07370c285847c1f77739b22e299ad75a6af6c32c5c9", size = 266416 },
+    { url = "https://files.pythonhosted.org/packages/a9/f6/df63d8660e1a0bff6125947afda112a0502736f470d62ca68b288ea762d8/coverage-7.13.5-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:60365289c3741e4db327e7baff2a4aaacf22f788e80fa4683393891b70a89fbd", size = 267558 },
+    { url = "https://files.pythonhosted.org/packages/5b/02/353ca81d36779bd108f6d384425f7139ac3c58c750dcfaafe5d0bee6436b/coverage-7.13.5-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1b88c69c8ef5d4b6fe7dea66d6636056a0f6a7527c440e890cf9259011f5e606", size = 261163 },
+    { url = "https://files.pythonhosted.org/packages/2c/16/2e79106d5749bcaf3aee6d309123548e3276517cd7851faa8da213bc61bf/coverage-7.13.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5b13955d31d1633cf9376908089b7cebe7d15ddad7aeaabcbe969a595a97e95e", size = 263981 },
+    { url = "https://files.pythonhosted.org/packages/29/c7/c29e0c59ffa6942030ae6f50b88ae49988e7e8da06de7ecdbf49c6d4feae/coverage-7.13.5-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:f70c9ab2595c56f81a89620e22899eea8b212a4041bd728ac6f4a28bf5d3ddd0", size = 261604 },
+    { url = "https://files.pythonhosted.org/packages/40/48/097cdc3db342f34006a308ab41c3a7c11c3f0d84750d340f45d88a782e00/coverage-7.13.5-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:084b84a8c63e8d6fc7e3931b316a9bcafca1458d753c539db82d31ed20091a87", size = 265321 },
+    { url = "https://files.pythonhosted.org/packages/bb/1f/4994af354689e14fd03a75f8ec85a9a68d94e0188bbdab3fc1516b55e512/coverage-7.13.5-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ad14385487393e386e2ea988b09d62dd42c397662ac2dabc3832d71253eee479", size = 260502 },
+    { url = "https://files.pythonhosted.org/packages/22/c6/9bb9ef55903e628033560885f5c31aa227e46878118b63ab15dc7ba87797/coverage-7.13.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7f2c47b36fe7709a6e83bfadf4eefb90bd25fbe4014d715224c4316f808e59a2", size = 262688 },
+    { url = "https://files.pythonhosted.org/packages/14/4f/f5df9007e50b15e53e01edea486814783a7f019893733d9e4d6caad75557/coverage-7.13.5-cp313-cp313t-win32.whl", hash = "sha256:67e9bc5449801fad0e5dff329499fb090ba4c5800b86805c80617b4e29809b2a", size = 222788 },
+    { url = "https://files.pythonhosted.org/packages/e1/98/aa7fccaa97d0f3192bec013c4e6fd6d294a6ed44b640e6bb61f479e00ed5/coverage-7.13.5-cp313-cp313t-win_amd64.whl", hash = "sha256:da86cdcf10d2519e10cabb8ac2de03da1bcb6e4853790b7fbd48523332e3a819", size = 223851 },
+    { url = "https://files.pythonhosted.org/packages/3d/8b/e5c469f7352651e5f013198e9e21f97510b23de957dd06a84071683b4b60/coverage-7.13.5-cp313-cp313t-win_arm64.whl", hash = "sha256:0ecf12ecb326fe2c339d93fc131816f3a7367d223db37817208905c89bded911", size = 222104 },
+    { url = "https://files.pythonhosted.org/packages/8e/77/39703f0d1d4b478bfd30191d3c14f53caf596fac00efb3f8f6ee23646439/coverage-7.13.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fbabfaceaeb587e16f7008f7795cd80d20ec548dc7f94fbb0d4ec2e038ce563f", size = 219621 },
+    { url = "https://files.pythonhosted.org/packages/e2/3e/51dff36d99ae14639a133d9b164d63e628532e2974d8b1edb99dd1ebc733/coverage-7.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9bb2a28101a443669a423b665939381084412b81c3f8c0fcfbac57f4e30b5b8e", size = 219953 },
+    { url = "https://files.pythonhosted.org/packages/6a/6c/1f1917b01eb647c2f2adc9962bd66c79eb978951cab61bdc1acab3290c07/coverage-7.13.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bd3a2fbc1c6cccb3c5106140d87cc6a8715110373ef42b63cf5aea29df8c217a", size = 250992 },
+    { url = "https://files.pythonhosted.org/packages/22/e5/06b1f88f42a5a99df42ce61208bdec3bddb3d261412874280a19796fc09c/coverage-7.13.5-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6c36ddb64ed9d7e496028d1d00dfec3e428e0aabf4006583bb1839958d280510", size = 253503 },
+    { url = "https://files.pythonhosted.org/packages/80/28/2a148a51e5907e504fa7b85490277734e6771d8844ebcc48764a15e28155/coverage-7.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:380e8e9084d8eb38db3a9176a1a4f3c0082c3806fa0dc882d1d87abc3c789247", size = 254852 },
+    { url = "https://files.pythonhosted.org/packages/61/77/50e8d3d85cc0b7ebe09f30f151d670e302c7ff4a1bf6243f71dd8b0981fa/coverage-7.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e808af52a0513762df4d945ea164a24b37f2f518cbe97e03deaa0ee66139b4d6", size = 257161 },
+    { url = "https://files.pythonhosted.org/packages/3b/c4/b5fd1d4b7bf8d0e75d997afd3925c59ba629fc8616f1b3aae7605132e256/coverage-7.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e301d30dd7e95ae068671d746ba8c34e945a82682e62918e41b2679acd2051a0", size = 251021 },
+    { url = "https://files.pythonhosted.org/packages/f8/66/6ea21f910e92d69ef0b1c3346ea5922a51bad4446c9126db2ae96ee24c4c/coverage-7.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:800bc829053c80d240a687ceeb927a94fd108bbdc68dfbe505d0d75ab578a882", size = 252858 },
+    { url = "https://files.pythonhosted.org/packages/9e/ea/879c83cb5d61aa2a35fb80e72715e92672daef8191b84911a643f533840c/coverage-7.13.5-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:0b67af5492adb31940ee418a5a655c28e48165da5afab8c7fa6fd72a142f8740", size = 250823 },
+    { url = "https://files.pythonhosted.org/packages/8a/fb/616d95d3adb88b9803b275580bdeee8bd1b69a886d057652521f83d7322f/coverage-7.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c9136ff29c3a91e25b1d1552b5308e53a1e0653a23e53b6366d7c2dcbbaf8a16", size = 255099 },
+    { url = "https://files.pythonhosted.org/packages/1c/93/25e6917c90ec1c9a56b0b26f6cad6408e5f13bb6b35d484a0d75c9cf000d/coverage-7.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:cff784eef7f0b8f6cb28804fbddcfa99f89efe4cc35fb5627e3ac58f91ed3ac0", size = 250638 },
+    { url = "https://files.pythonhosted.org/packages/fc/7b/dc1776b0464145a929deed214aef9fb1493f159b59ff3c7eeeedf91eddd0/coverage-7.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:68a4953be99b17ac3c23b6efbc8a38330d99680c9458927491d18700ef23ded0", size = 252295 },
+    { url = "https://files.pythonhosted.org/packages/ea/fb/99cbbc56a26e07762a2740713f3c8f9f3f3106e3a3dd8cc4474954bccd34/coverage-7.13.5-cp314-cp314-win32.whl", hash = "sha256:35a31f2b1578185fbe6aa2e74cea1b1d0bbf4c552774247d9160d29b80ed56cc", size = 222360 },
+    { url = "https://files.pythonhosted.org/packages/8d/b7/4758d4f73fb536347cc5e4ad63662f9d60ba9118cb6785e9616b2ce5d7fa/coverage-7.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:2aa055ae1857258f9e0045be26a6d62bdb47a72448b62d7b55f4820f361a2633", size = 223174 },
+    { url = "https://files.pythonhosted.org/packages/2c/f2/24d84e1dfe70f8ac9fdf30d338239860d0d1d5da0bda528959d0ebc9da28/coverage-7.13.5-cp314-cp314-win_arm64.whl", hash = "sha256:1b11eef33edeae9d142f9b4358edb76273b3bfd30bc3df9a4f95d0e49caf94e8", size = 221739 },
+    { url = "https://files.pythonhosted.org/packages/60/5b/4a168591057b3668c2428bff25dd3ebc21b629d666d90bcdfa0217940e84/coverage-7.13.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:10a0c37f0b646eaff7cce1874c31d1f1ccb297688d4c747291f4f4c70741cc8b", size = 220351 },
+    { url = "https://files.pythonhosted.org/packages/f5/21/1fd5c4dbfe4a58b6b99649125635df46decdfd4a784c3cd6d410d303e370/coverage-7.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b5db73ba3c41c7008037fa731ad5459fc3944cb7452fc0aa9f822ad3533c583c", size = 220612 },
+    { url = "https://files.pythonhosted.org/packages/d6/fe/2a924b3055a5e7e4512655a9d4609781b0d62334fa0140c3e742926834e2/coverage-7.13.5-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:750db93a81e3e5a9831b534be7b1229df848b2e125a604fe6651e48aa070e5f9", size = 261985 },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/c8928f2bd518c45990fe1a2ab8db42e914ef9b726c975facc4282578c3eb/coverage-7.13.5-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9ddb4f4a5479f2539644be484da179b653273bca1a323947d48ab107b3ed1f29", size = 264107 },
+    { url = "https://files.pythonhosted.org/packages/ef/ae/4ae35bbd9a0af9d820362751f0766582833c211224b38665c0f8de3d487f/coverage-7.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8a7a2049c14f413163e2bdabd37e41179b1d1ccb10ffc6ccc4b7a718429c607", size = 266513 },
+    { url = "https://files.pythonhosted.org/packages/9c/20/d326174c55af36f74eac6ae781612d9492f060ce8244b570bb9d50d9d609/coverage-7.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1c85e0b6c05c592ea6d8768a66a254bfb3874b53774b12d4c89c481eb78cb90", size = 267650 },
+    { url = "https://files.pythonhosted.org/packages/7a/5e/31484d62cbd0eabd3412e30d74386ece4a0837d4f6c3040a653878bfc019/coverage-7.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:777c4d1eff1b67876139d24288aaf1817f6c03d6bae9c5cc8d27b83bcfe38fe3", size = 261089 },
+    { url = "https://files.pythonhosted.org/packages/e9/d8/49a72d6de146eebb0b7e48cc0f4bc2c0dd858e3d4790ab2b39a2872b62bd/coverage-7.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6697e29b93707167687543480a40f0db8f356e86d9f67ddf2e37e2dfd91a9dab", size = 263982 },
+    { url = "https://files.pythonhosted.org/packages/06/3b/0351f1bd566e6e4dd39e978efe7958bde1d32f879e85589de147654f57bb/coverage-7.13.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8fdf453a942c3e4d99bd80088141c4c6960bb232c409d9c3558e2dbaa3998562", size = 261579 },
+    { url = "https://files.pythonhosted.org/packages/5d/ce/796a2a2f4017f554d7810f5c573449b35b1e46788424a548d4d19201b222/coverage-7.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:32ca0c0114c9834a43f045a87dcebd69d108d8ffb666957ea65aa132f50332e2", size = 265316 },
+    { url = "https://files.pythonhosted.org/packages/3d/16/d5ae91455541d1a78bc90abf495be600588aff8f6db5c8b0dae739fa39c9/coverage-7.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8769751c10f339021e2638cd354e13adeac54004d1941119b2c96fe5276d45ea", size = 260427 },
+    { url = "https://files.pythonhosted.org/packages/48/11/07f413dba62db21fb3fad5d0de013a50e073cc4e2dc4306e770360f6dfc8/coverage-7.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cec2d83125531bd153175354055cdb7a09987af08a9430bd173c937c6d0fba2a", size = 262745 },
+    { url = "https://files.pythonhosted.org/packages/91/15/d792371332eb4663115becf4bad47e047d16234b1aff687b1b18c58d60ae/coverage-7.13.5-cp314-cp314t-win32.whl", hash = "sha256:0cd9ed7a8b181775459296e402ca4fb27db1279740a24e93b3b41942ebe4b215", size = 223146 },
+    { url = "https://files.pythonhosted.org/packages/db/51/37221f59a111dca5e85be7dbf09696323b5b9f13ff65e0641d535ed06ea8/coverage-7.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:301e3b7dfefecaca37c9f1aa6f0049b7d4ab8dd933742b607765d757aca77d43", size = 224254 },
+    { url = "https://files.pythonhosted.org/packages/54/83/6acacc889de8987441aa7d5adfbdbf33d288dad28704a67e574f1df9bcbb/coverage-7.13.5-cp314-cp314t-win_arm64.whl", hash = "sha256:9dacc2ad679b292709e0f5fc1ac74a6d4d5562e424058962c7bb0c658ad25e45", size = 222276 },
+    { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346 },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094 },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604 },
+]
+
+[[package]]
+name = "fakeredis"
+version = "2.35.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "redis" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/50/b748233c02fa77e5105238190cc9bb58b852eb1c8b1d0763230d3a5b745a/fakeredis-2.35.1.tar.gz", hash = "sha256:5bae5eba7b9d93cb968944ac40936373cf2397ff71667d4b595df65c3d2e413f", size = 189118 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/27/b8b057a23f7777177e92d3a602fd866751b6b45014964548997e92e048fd/fakeredis-2.35.1-py3-none-any.whl", hash = "sha256:67d97e11f562b7870e11e5c30cf182270bfb2dd37f6707dba47cc6d91628d1b9", size = 129678 },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.136.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683 },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515 },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784 },
+]
+
+[[package]]
+name = "httptools"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/46/120a669232c7bdedb9d52d4aeae7e6c7dfe151e99dc70802e2fc7a5e1993/httptools-0.7.1.tar.gz", hash = "sha256:abd72556974f8e7c74a259655924a717a2365b236c882c3f6f8a45fe94703ac9", size = 258961 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/7f/403e5d787dc4942316e515e949b0c8a013d84078a915910e9f391ba9b3ed/httptools-0.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:38e0c83a2ea9746ebbd643bdfb521b9aa4a91703e2cd705c20443405d2fd16a5", size = 206280 },
+    { url = "https://files.pythonhosted.org/packages/2a/0d/7f3fd28e2ce311ccc998c388dd1c53b18120fda3b70ebb022b135dc9839b/httptools-0.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f25bbaf1235e27704f1a7b86cd3304eabc04f569c828101d94a0e605ef7205a5", size = 110004 },
+    { url = "https://files.pythonhosted.org/packages/84/a6/b3965e1e146ef5762870bbe76117876ceba51a201e18cc31f5703e454596/httptools-0.7.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2c15f37ef679ab9ecc06bfc4e6e8628c32a8e4b305459de7cf6785acd57e4d03", size = 517655 },
+    { url = "https://files.pythonhosted.org/packages/11/7d/71fee6f1844e6fa378f2eddde6c3e41ce3a1fb4b2d81118dd544e3441ec0/httptools-0.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fe6e96090df46b36ccfaf746f03034e5ab723162bc51b0a4cf58305324036f2", size = 511440 },
+    { url = "https://files.pythonhosted.org/packages/22/a5/079d216712a4f3ffa24af4a0381b108aa9c45b7a5cc6eb141f81726b1823/httptools-0.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f72fdbae2dbc6e68b8239defb48e6a5937b12218e6ffc2c7846cc37befa84362", size = 495186 },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/025ad7b65278745dee3bd0ebf9314934c4592560878308a6121f7f812084/httptools-0.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e99c7b90a29fd82fea9ef57943d501a16f3404d7b9ee81799d41639bdaae412c", size = 499192 },
+    { url = "https://files.pythonhosted.org/packages/6d/de/40a8f202b987d43afc4d54689600ff03ce65680ede2f31df348d7f368b8f/httptools-0.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:3e14f530fefa7499334a79b0cf7e7cd2992870eb893526fb097d51b4f2d0f321", size = 86694 },
+    { url = "https://files.pythonhosted.org/packages/09/8f/c77b1fcbfd262d422f12da02feb0d218fa228d52485b77b953832105bb90/httptools-0.7.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6babce6cfa2a99545c60bfef8bee0cc0545413cb0018f617c8059a30ad985de3", size = 202889 },
+    { url = "https://files.pythonhosted.org/packages/0a/1a/22887f53602feaa066354867bc49a68fc295c2293433177ee90870a7d517/httptools-0.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:601b7628de7504077dd3dcb3791c6b8694bbd967148a6d1f01806509254fb1ca", size = 108180 },
+    { url = "https://files.pythonhosted.org/packages/32/6a/6aaa91937f0010d288d3d124ca2946d48d60c3a5ee7ca62afe870e3ea011/httptools-0.7.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:04c6c0e6c5fb0739c5b8a9eb046d298650a0ff38cf42537fc372b28dc7e4472c", size = 478596 },
+    { url = "https://files.pythonhosted.org/packages/6d/70/023d7ce117993107be88d2cbca566a7c1323ccbaf0af7eabf2064fe356f6/httptools-0.7.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69d4f9705c405ae3ee83d6a12283dc9feba8cc6aaec671b412917e644ab4fa66", size = 473268 },
+    { url = "https://files.pythonhosted.org/packages/32/4d/9dd616c38da088e3f436e9a616e1d0cc66544b8cdac405cc4e81c8679fc7/httptools-0.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:44c8f4347d4b31269c8a9205d8a5ee2df5322b09bbbd30f8f862185bb6b05346", size = 455517 },
+    { url = "https://files.pythonhosted.org/packages/1d/3a/a6c595c310b7df958e739aae88724e24f9246a514d909547778d776799be/httptools-0.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:465275d76db4d554918aba40bf1cbebe324670f3dfc979eaffaa5d108e2ed650", size = 458337 },
+    { url = "https://files.pythonhosted.org/packages/fd/82/88e8d6d2c51edc1cc391b6e044c6c435b6aebe97b1abc33db1b0b24cd582/httptools-0.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:322d00c2068d125bd570f7bf78b2d367dad02b919d8581d7476d8b75b294e3e6", size = 85743 },
+    { url = "https://files.pythonhosted.org/packages/34/50/9d095fcbb6de2d523e027a2f304d4551855c2f46e0b82befd718b8b20056/httptools-0.7.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:c08fe65728b8d70b6923ce31e3956f859d5e1e8548e6f22ec520a962c6757270", size = 203619 },
+    { url = "https://files.pythonhosted.org/packages/07/f0/89720dc5139ae54b03f861b5e2c55a37dba9a5da7d51e1e824a1f343627f/httptools-0.7.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7aea2e3c3953521c3c51106ee11487a910d45586e351202474d45472db7d72d3", size = 108714 },
+    { url = "https://files.pythonhosted.org/packages/b3/cb/eea88506f191fb552c11787c23f9a405f4c7b0c5799bf73f2249cd4f5228/httptools-0.7.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0e68b8582f4ea9166be62926077a3334064d422cf08ab87d8b74664f8e9058e1", size = 472909 },
+    { url = "https://files.pythonhosted.org/packages/e0/4a/a548bdfae6369c0d078bab5769f7b66f17f1bfaa6fa28f81d6be6959066b/httptools-0.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df091cf961a3be783d6aebae963cc9b71e00d57fa6f149025075217bc6a55a7b", size = 470831 },
+    { url = "https://files.pythonhosted.org/packages/4d/31/14df99e1c43bd132eec921c2e7e11cda7852f65619bc0fc5bdc2d0cb126c/httptools-0.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f084813239e1eb403ddacd06a30de3d3e09a9b76e7894dcda2b22f8a726e9c60", size = 452631 },
+    { url = "https://files.pythonhosted.org/packages/22/d2/b7e131f7be8d854d48cb6d048113c30f9a46dca0c9a8b08fcb3fcd588cdc/httptools-0.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7347714368fb2b335e9063bc2b96f2f87a9ceffcd9758ac295f8bbcd3ffbc0ca", size = 452910 },
+    { url = "https://files.pythonhosted.org/packages/53/cf/878f3b91e4e6e011eff6d1fa9ca39f7eb17d19c9d7971b04873734112f30/httptools-0.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:cfabda2a5bb85aa2a904ce06d974a3f30fb36cc63d7feaddec05d2050acede96", size = 88205 },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517 },
+]
+
+[[package]]
+name = "idna"
+version = "3.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629 },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484 },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899 },
+]
+
+[[package]]
+name = "klai-mailer"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "aiosmtplib" },
+    { name = "email-validator" },
+    { name = "fastapi" },
+    { name = "httpx" },
+    { name = "jinja2" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "redis" },
+    { name = "structlog" },
+    { name = "uvicorn", extra = ["standard"] },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "fakeredis" },
+    { name = "lxml" },
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "respx" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiosmtplib", specifier = ">=3.0" },
+    { name = "email-validator", specifier = ">=2.0" },
+    { name = "fakeredis", marker = "extra == 'dev'", specifier = ">=2.24" },
+    { name = "fastapi", specifier = ">=0.115" },
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "jinja2", specifier = ">=3.1" },
+    { name = "lxml", marker = "extra == 'dev'", specifier = ">=5.0" },
+    { name = "pydantic", specifier = ">=2.9" },
+    { name = "pydantic-settings", specifier = ">=2.6" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
+    { name = "redis", specifier = ">=5.0" },
+    { name = "respx", marker = "extra == 'dev'", specifier = ">=0.21" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8" },
+    { name = "structlog", specifier = ">=25.0" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.32" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "lxml"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/30/9abc9e34c657c33834eaf6cd02124c61bdf5944d802aa48e69be8da3585d/lxml-6.1.0.tar.gz", hash = "sha256:bfd57d8008c4965709a919c3e9a98f76c2c7cb319086b3d26858250620023b13", size = 4197006 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/d4/9326838b59dc36dfae42eec9656b97520f9997eee1de47b8316aaeed169c/lxml-6.1.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d2f17a16cd8751e8eb233a7e41aecdf8e511712e00088bf9be455f604cd0d28d", size = 8570663 },
+    { url = "https://files.pythonhosted.org/packages/d8/a4/053745ce1f8303ccbb788b86c0db3a91b973675cefc42566a188637b7c40/lxml-6.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f0cea5b1d3e6e77d71bd2b9972eb2446221a69dc52bb0b9c3c6f6e5700592d93", size = 4624024 },
+    { url = "https://files.pythonhosted.org/packages/90/97/a517944b20f8fd0932ad2109482bee4e29fe721416387a363306667941f6/lxml-6.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fc46da94826188ed45cb53bd8e3fc076ae22675aea2087843d4735627f867c6d", size = 4930895 },
+    { url = "https://files.pythonhosted.org/packages/94/7c/e08a970727d556caa040a44773c7b7e3ad0f0d73dedc863543e9a8b931f2/lxml-6.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9147d8e386ec3b82c3b15d88927f734f565b0aaadef7def562b853adca45784a", size = 5093820 },
+    { url = "https://files.pythonhosted.org/packages/88/ee/2a5c2aa2c32016a226ca25d3e1056a8102ea6e1fe308bf50213586635400/lxml-6.1.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5715e0e28736a070f3f34a7ccc09e2fdcba0e3060abbcf61a1a5718ff6d6b105", size = 5005790 },
+    { url = "https://files.pythonhosted.org/packages/e3/38/a0db9be8f38ad6043ab9429487c128dd1d30f07956ef43040402f8da49e8/lxml-6.1.0-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4937460dc5df0cdd2f06a86c285c28afda06aefa3af949f9477d3e8df430c485", size = 5630827 },
+    { url = "https://files.pythonhosted.org/packages/31/ba/3c13d3fc24b7cacf675f808a3a1baabf43a30d0cd24c98f94548e9aa58eb/lxml-6.1.0-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bc783ee3147e60a25aa0445ea82b3e8aabb83b240f2b95d32cb75587ff781814", size = 5240445 },
+    { url = "https://files.pythonhosted.org/packages/55/ba/eeef4ccba09b2212fe239f46c1692a98db1878e0872ae320756488878a94/lxml-6.1.0-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:40d9189f80075f2e1f88db21ef815a2b17b28adf8e50aaf5c789bfe737027f32", size = 5350121 },
+    { url = "https://files.pythonhosted.org/packages/7e/01/1da87c7b587c38d0cbe77a01aae3b9c1c49ed47d76918ef3db8fc151b1ca/lxml-6.1.0-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:05b9b8787e35bec69e68daf4952b2e6dfcfb0db7ecf1a06f8cdfbbac4eb71aad", size = 4694949 },
+    { url = "https://files.pythonhosted.org/packages/a1/88/7db0fe66d5aaf128443ee1623dec3db1576f3e4c17751ec0ef5866468590/lxml-6.1.0-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0f0f08beb0182e3e9a86fae124b3c47a7b41b7b69b225e1377db983802404e54", size = 5243901 },
+    { url = "https://files.pythonhosted.org/packages/00/a8/1346726af7d1f6fca1f11223ba34001462b0a3660416986d37641708d57c/lxml-6.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73becf6d8c81d4c76b1014dbd3584cb26d904492dcf73ca85dc8bff08dcd6d2d", size = 5048054 },
+    { url = "https://files.pythonhosted.org/packages/2e/b7/85057012f035d1a0c87e02f8c723ca3c3e6e0728bcf4cb62080b21b1c1e3/lxml-6.1.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:1ae225f66e5938f4fa29d37e009a3bb3b13032ac57eb4eb42afa44f6e4054e69", size = 4777324 },
+    { url = "https://files.pythonhosted.org/packages/75/6c/ad2f94a91073ef570f33718040e8e160d5fb93331cf1ab3ca1323f939e2d/lxml-6.1.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:690022c7fae793b0489aa68a658822cea83e0d5933781811cabbf5ea3bcfe73d", size = 5645702 },
+    { url = "https://files.pythonhosted.org/packages/3b/89/0bb6c0bd549c19004c60eea9dc554dd78fd647b72314ef25d460e0d208c6/lxml-6.1.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:63aeafc26aac0be8aff14af7871249e87ea1319be92090bfd632ec68e03b16a5", size = 5232901 },
+    { url = "https://files.pythonhosted.org/packages/a1/d9/d609a11fb567da9399f525193e2b49847b5a409cdebe737f06a8b7126bdc/lxml-6.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:264c605ab9c0e4aa1a679636f4582c4d3313700009fac3ec9c3412ed0d8f3e1d", size = 5261333 },
+    { url = "https://files.pythonhosted.org/packages/a6/3a/ac3f99ec8ac93089e7dd556f279e0d14c24de0a74a507e143a2e4b496e7c/lxml-6.1.0-cp312-cp312-win32.whl", hash = "sha256:56971379bc5ee8037c5a0f09fa88f66cdb7d37c3e38af3e45cf539f41131ac1f", size = 3596289 },
+    { url = "https://files.pythonhosted.org/packages/f2/a7/0a915557538593cb1bbeedcd40e13c7a261822c26fecbbdb71dad0c2f540/lxml-6.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:bba078de0031c219e5dd06cf3e6bf8fb8e6e64a77819b358f53bb132e3e03366", size = 3997059 },
+    { url = "https://files.pythonhosted.org/packages/92/96/a5dc078cf0126fbfbc35611d77ecd5da80054b5893e28fb213a5613b9e1d/lxml-6.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:c3592631e652afa34999a088f98ba7dfc7d6aff0d535c410bea77a71743f3819", size = 3659552 },
+    { url = "https://files.pythonhosted.org/packages/08/03/69347590f1cf4a6d5a4944bb6099e6d37f334784f16062234e1f892fdb1d/lxml-6.1.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a0092f2b107b69601adf562a57c956fbb596e05e3e6651cabd3054113b007e45", size = 8559689 },
+    { url = "https://files.pythonhosted.org/packages/3f/58/25e00bb40b185c974cfe156c110474d9a8a8390d5f7c92a4e328189bb60e/lxml-6.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fc7140d7a7386e6b545d41b7358f4d02b656d4053f5fa6859f92f4b9c2572c4d", size = 4617892 },
+    { url = "https://files.pythonhosted.org/packages/f5/54/92ad98a94ac318dc4f97aaac22ff8d1b94212b2ae8af5b6e9b354bf825f7/lxml-6.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:419c58fc92cc3a2c3fa5f78c63dbf5da70c1fa9c1b25f25727ecee89a96c7de2", size = 4923489 },
+    { url = "https://files.pythonhosted.org/packages/15/3b/a20aecfab42bdf4f9b390590d345857ad3ffd7c51988d1c89c53a0c73faf/lxml-6.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:37fabd1452852636cf38ecdcc9dd5ca4bba7a35d6c53fa09725deeb894a87491", size = 5082162 },
+    { url = "https://files.pythonhosted.org/packages/45/26/2cdb3d281ac1bd175603e290cbe4bad6eff127c0f8de90bafd6f8548f0fd/lxml-6.1.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2853c8b2170cc6cd54a6b4d50d2c1a8a7aeca201f23804b4898525c7a152cfc", size = 4993247 },
+    { url = "https://files.pythonhosted.org/packages/f6/05/d735aef963740022a08185c84821f689fc903acb3d50326e6b1e9886cc22/lxml-6.1.0-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8e369cbd690e788c8d15e56222d91a09c6a417f49cbc543040cba0fe2e25a79e", size = 5613042 },
+    { url = "https://files.pythonhosted.org/packages/ee/b8/ead7c10efff731738c72e59ed6eb5791854879fbed7ae98781a12006263a/lxml-6.1.0-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e69aa6805905807186eb00e66c6d97a935c928275182eb02ee40ba00da9623b2", size = 5228304 },
+    { url = "https://files.pythonhosted.org/packages/6b/10/e9842d2ec322ea65f0a7270aa0315a53abed06058b88ef1b027f620e7a5f/lxml-6.1.0-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:4bd1bdb8a9e0e2dd229de19b5f8aebac80e916921b4b2c6ef8a52bc131d0c1f9", size = 5341578 },
+    { url = "https://files.pythonhosted.org/packages/89/54/40d9403d7c2775fa7301d3ddd3464689bfe9ba71acc17dfff777071b4fdc/lxml-6.1.0-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:cbd7b79cdcb4986ad78a2662625882747f09db5e4cd7b2ae178a88c9c51b3dfe", size = 4700209 },
+    { url = "https://files.pythonhosted.org/packages/85/b2/bbdcc2cf45dfc7dfffef4fd97e5c47b15919b6a365247d95d6f684ef5e82/lxml-6.1.0-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:43e4d297f11080ec9d64a4b1ad7ac02b4484c9f0e2179d9c4ef78e886e747b88", size = 5232365 },
+    { url = "https://files.pythonhosted.org/packages/48/5a/b06875665e53aaba7127611a7bed3b7b9658e20b22bc2dd217a0b7ab0091/lxml-6.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cc16682cc987a3da00aa56a3aa3075b08edb10d9b1e476938cfdbee8f3b67181", size = 5043654 },
+    { url = "https://files.pythonhosted.org/packages/e9/9c/e71a069d09641c1a7abeb30e693f828c7c90a41cbe3d650b2d734d876f85/lxml-6.1.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:d6d8efe71429635f0559579092bb5e60560d7b9115ee38c4adbea35632e7fa24", size = 4769326 },
+    { url = "https://files.pythonhosted.org/packages/cc/06/7a9cd84b3d4ed79adf35f874750abb697dec0b4a81a836037b36e47c091a/lxml-6.1.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:7e39ab3a28af7784e206d8606ec0e4bcad0190f63a492bca95e94e5a4aef7f6e", size = 5635879 },
+    { url = "https://files.pythonhosted.org/packages/cc/f0/9d57916befc1e54c451712c7ee48e9e74e80ae4d03bdce49914e0aee42cd/lxml-6.1.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:9eb667bf50856c4a58145f8ca2d5e5be160191e79eb9e30855a476191b3c3495", size = 5224048 },
+    { url = "https://files.pythonhosted.org/packages/99/75/90c4eefda0c08c92221fe0753db2d6699a4c628f76ff4465ec20dea84cc1/lxml-6.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7f4a77d6f7edf9230cee3e1f7f6764722a41604ee5681844f18db9a81ea0ec33", size = 5250241 },
+    { url = "https://files.pythonhosted.org/packages/5e/73/16596f7e4e38fa33084b9ccbccc22a15f82a290a055126f2c1541236d2ff/lxml-6.1.0-cp313-cp313-win32.whl", hash = "sha256:28902146ffbe5222df411c5d19e5352490122e14447e98cd118907ee3fd6ee62", size = 3596938 },
+    { url = "https://files.pythonhosted.org/packages/8e/63/981401c5680c1eb30893f00a19641ac80db5d1e7086c62cb4b13ed813038/lxml-6.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:4a1503c56e4e2b38dc76f2f2da7bae69670c0f1933e27cfa34b2fa5876410b16", size = 3995728 },
+    { url = "https://files.pythonhosted.org/packages/e7/e8/c358a38ac3e541d16a1b527e4e9cb78c0419b0506a070ace11777e5e8404/lxml-6.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:e0af85773850417d994d019741239b901b22c6680206f46a34766926e466141d", size = 3658372 },
+    { url = "https://files.pythonhosted.org/packages/eb/45/cee4cf203ef0bab5c52afc118da61d6b460c928f2893d40023cfa27e0b80/lxml-6.1.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ab863fd37458fed6456525f297d21239d987800c46e67da5ef04fc6b3dd93ac8", size = 8576713 },
+    { url = "https://files.pythonhosted.org/packages/8a/a7/eda05babeb7e046839204eaf254cd4d7c9130ce2bbf0d9e90ea41af5654d/lxml-6.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6fd8b1df8254ff4fd93fd31da1fc15770bde23ac045be9bb1f87425702f61cc9", size = 4623874 },
+    { url = "https://files.pythonhosted.org/packages/e7/e9/db5846de9b436b91890a62f29d80cd849ea17948a49bf532d5278ee69a9e/lxml-6.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:47024feaae386a92a146af0d2aeed65229bf6fff738e6a11dda6b0015fb8fd03", size = 4949535 },
+    { url = "https://files.pythonhosted.org/packages/5a/ba/0d3593373dcae1d68f40dc3c41a5a92f2544e68115eb2f62319a4c2a6500/lxml-6.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3f00972f84450204cd5d93a5395965e348956aaceaadec693a22ec743f8ae3eb", size = 5086881 },
+    { url = "https://files.pythonhosted.org/packages/43/76/759a7484539ad1af0d125a9afe9c3fb5f82a8779fd1f5f56319d9e4ea2fd/lxml-6.1.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97faa0860e13b05b15a51fb4986421ef7a30f0b3334061c416e0981e9450ca4c", size = 5031305 },
+    { url = "https://files.pythonhosted.org/packages/dc/b9/c1f0daf981a11e47636126901fd4ab82429e18c57aeb0fc3ad2940b42d8b/lxml-6.1.0-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:972a6451204798675407beaad97b868d0c733d9a74dafefc63120b81b8c2de28", size = 5647522 },
+    { url = "https://files.pythonhosted.org/packages/31/e6/1f533dcd205275363d9ba3511bcec52fa2df86abf8abe6a5f2c599f0dc31/lxml-6.1.0-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fe022f20bc4569ec66b63b3fb275a3d628d9d32da6326b2982584104db6d3086", size = 5239310 },
+    { url = "https://files.pythonhosted.org/packages/c3/8c/4175fb709c78a6e315ed814ed33be3defd8b8721067e70419a6cf6f971da/lxml-6.1.0-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:75c4c7c619a744f972f4451bf5adf6d0fb00992a1ffc9fd78e13b0bc817cc99f", size = 5350799 },
+    { url = "https://files.pythonhosted.org/packages/fd/77/6ffdebc5994975f0dde4acb59761902bd9d9bb84422b9a0bd239a7da9ca8/lxml-6.1.0-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3648f20d25102a22b6061c688beb3a805099ea4beb0a01ce62975d926944d292", size = 4697693 },
+    { url = "https://files.pythonhosted.org/packages/f8/f1/565f36bd5c73294602d48e04d23f81ff4c8736be6ba5e1d1ec670ac9be80/lxml-6.1.0-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:77b9f99b17cbf14026d1e618035077060fc7195dd940d025149f3e2e830fbfcb", size = 5250708 },
+    { url = "https://files.pythonhosted.org/packages/5a/11/a68ab9dd18c5c499404deb4005f4bc4e0e88e5b72cd755ad96efec81d18d/lxml-6.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32662519149fd7a9db354175aa5e417d83485a8039b8aaa62f873ceee7ea4cad", size = 5084737 },
+    { url = "https://files.pythonhosted.org/packages/ab/78/e8f41e2c74f4af564e6a0348aea69fb6daaefa64bc071ef469823d22cc18/lxml-6.1.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:73d658216fc173cf2c939e90e07b941c5e12736b0bf6a99e7af95459cfe8eabb", size = 4737817 },
+    { url = "https://files.pythonhosted.org/packages/06/2d/aa4e117aa2ce2f3b35d9ff246be74a2f8e853baba5d2a92c64744474603a/lxml-6.1.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:ac4db068889f8772a4a698c5980ec302771bb545e10c4b095d4c8be26749616f", size = 5670753 },
+    { url = "https://files.pythonhosted.org/packages/08/f5/dd745d50c0409031dbfcc4881740542a01e54d6f0110bd420fa7782110b8/lxml-6.1.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:45e9dfbd1b661eb64ba0d4dbe762bd210c42d86dd1e5bd2bdf89d634231beb43", size = 5238071 },
+    { url = "https://files.pythonhosted.org/packages/3e/74/ad424f36d0340a904665867dab310a3f1f4c96ff4039698de83b77f44c1f/lxml-6.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:89e8d73d09ac696a5ba42ec69787913d53284f12092f651506779314f10ba585", size = 5264319 },
+    { url = "https://files.pythonhosted.org/packages/53/36/a15d8b3514ec889bfd6aa3609107fcb6c9189f8dc347f1c0b81eded8d87c/lxml-6.1.0-cp314-cp314-win32.whl", hash = "sha256:ebe33f4ec1b2de38ceb225a1749a2965855bffeef435ba93cd2d5d540783bf2f", size = 3657139 },
+    { url = "https://files.pythonhosted.org/packages/1a/a4/263ebb0710851a3c6c937180a9a86df1206fdfe53cc43005aa2237fd7736/lxml-6.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:398443df51c538bd578529aa7e5f7afc6c292644174b47961f3bf87fe5741120", size = 4064195 },
+    { url = "https://files.pythonhosted.org/packages/80/68/2000f29d323b6c286de077ad20b429fc52272e44eae6d295467043e56012/lxml-6.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:8c8984e1d8c4b3949e419158fda14d921ff703a9ed8a47236c6eb7a2b6cb4946", size = 3741870 },
+    { url = "https://files.pythonhosted.org/packages/30/e9/21383c7c8d43799f0da90224c0d7c921870d476ec9b3e01e1b2c0b8237c5/lxml-6.1.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1081dd10bc6fa437db2500e13993abf7cc30716d0a2f40e65abb935f02ec559c", size = 8827548 },
+    { url = "https://files.pythonhosted.org/packages/a5/01/c6bc11cd587030dd4f719f65c5657960649fe3e19196c844c75bf32cd0d6/lxml-6.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:dabecc48db5f42ba348d1f5d5afdc54c6c4cc758e676926c7cd327045749517d", size = 4735866 },
+    { url = "https://files.pythonhosted.org/packages/f3/01/757132fff5f4acf25463b5298f1a46099f3a94480b806547b29ce5e385de/lxml-6.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e3dd5fe19c9e0ac818a9c7f132a5e43c1339ec1cbbfecb1a938bd3a47875b7c9", size = 4969476 },
+    { url = "https://files.pythonhosted.org/packages/fd/fb/1bc8b9d27ed64be7c8903db6c89e74dc8c2cd9ec630a7462e4654316dc5b/lxml-6.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9e7b0a4ca6dcc007a4cef00a761bba2dea959de4bd2df98f926b33c92ca5dfb9", size = 5103719 },
+    { url = "https://files.pythonhosted.org/packages/d5/e7/5bf82fa28133536a54601aae633b14988e89ed61d4c1eb6b899b023233aa/lxml-6.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d27bbe326c6b539c64b42638b18bc6003a8d88f76213a97ac9ed4f885efeab7", size = 5027890 },
+    { url = "https://files.pythonhosted.org/packages/2d/20/e048db5d4b4ea0366648aa595f26bb764b2670903fc585b87436d0a5032c/lxml-6.1.0-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c4e425db0c5445ef0ad56b0eec54f89b88b2d884656e536a90b2f52aecb4ca86", size = 5596008 },
+    { url = "https://files.pythonhosted.org/packages/9a/c2/d10807bc8da4824b39e5bd01b5d05c077b6fd01bd91584167edf6b269d22/lxml-6.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b89b098105b8599dc57adac95d1813409ac476d3c948a498775d3d0c6124bfb", size = 5224451 },
+    { url = "https://files.pythonhosted.org/packages/3c/15/2ebea45bea427e7f0057e9ce7b2d62c5aba20c6b001cca89ed0aadb3ad41/lxml-6.1.0-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:c4a699432846df86cc3de502ee85f445ebad748a1c6021d445f3e514d2cd4b1c", size = 5312135 },
+    { url = "https://files.pythonhosted.org/packages/31/e2/87eeae151b0be2a308d49a7ec444ff3eb192b14251e62addb29d0bf3778f/lxml-6.1.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:30e7b2ed63b6c8e97cca8af048589a788ab5c9c905f36d9cf1c2bb549f450d2f", size = 4639126 },
+    { url = "https://files.pythonhosted.org/packages/a3/51/8a3f6a20902ad604dd746ec7b4000311b240d389dac5e9d95adefd349e0c/lxml-6.1.0-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:022981127642fe19866d2907d76241bb07ed21749601f727d5d5dd1ce5d1b773", size = 5232579 },
+    { url = "https://files.pythonhosted.org/packages/6d/d2/650d619bdbe048d2c3f2c31edb00e35670a5e2d65b4fe3b61bce37b19121/lxml-6.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:23cad0cc86046d4222f7f418910e46b89971c5a45d3c8abfad0f64b7b05e4a9b", size = 5084206 },
+    { url = "https://files.pythonhosted.org/packages/dd/8a/672ca1a3cbeabd1f511ca275a916c0514b747f4b85bdaae103b8fa92f307/lxml-6.1.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:21c3302068f50d1e8728c67c87ba92aa87043abee517aa2576cca1855326b405", size = 4758906 },
+    { url = "https://files.pythonhosted.org/packages/be/f1/ef4b691da85c916cb2feb1eec7414f678162798ac85e042fa164419ac05c/lxml-6.1.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:be10838781cb3be19251e276910cd508fe127e27c3242e50521521a0f3781690", size = 5620553 },
+    { url = "https://files.pythonhosted.org/packages/59/17/94e81def74107809755ac2782fdad4404420f1c92ca83433d117a6d5acf0/lxml-6.1.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:2173a7bffe97667bbf0767f8a99e587740a8c56fdf3befac4b09cb29a80276fd", size = 5229458 },
+    { url = "https://files.pythonhosted.org/packages/21/55/c4be91b0f830a871fc1b0d730943d56013b683d4671d5198260e2eae722b/lxml-6.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c6854e9cf99c84beb004eecd7d3a3868ef1109bf2b1df92d7bc11e96a36c2180", size = 5247861 },
+    { url = "https://files.pythonhosted.org/packages/c2/ca/77123e4d77df3cb1e968ade7b1f808f5d3a5c1c96b18a33895397de292c1/lxml-6.1.0-cp314-cp314t-win32.whl", hash = "sha256:00750d63ef0031a05331b9223463b1c7c02b9004cef2346a5b2877f0f9494dd2", size = 3897377 },
+    { url = "https://files.pythonhosted.org/packages/64/ce/3554833989d074267c063209bae8b09815e5656456a2d332b947806b05ff/lxml-6.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:80410c3a7e3c617af04de17caa9f9f20adaa817093293d69eae7d7d0522836f5", size = 4392701 },
+    { url = "https://files.pythonhosted.org/packages/2b/a0/9b916c68c0e57752c07f8f64b30138d9d4059dbeb27b90274dedbea128ff/lxml-6.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:26dd9f57ee3bd41e7d35b4c98a2ffd89ed11591649f421f0ec19f67d50ec67ac", size = 3817120 },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615 },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020 },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332 },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947 },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962 },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760 },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529 },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015 },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540 },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105 },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906 },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622 },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029 },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374 },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980 },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990 },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784 },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588 },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041 },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543 },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113 },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911 },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658 },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066 },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639 },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569 },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284 },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801 },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769 },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642 },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612 },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200 },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973 },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619 },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029 },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408 },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005 },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048 },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821 },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606 },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043 },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747 },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341 },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073 },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661 },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069 },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670 },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598 },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261 },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835 },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733 },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672 },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819 },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426 },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146 },
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438 },
+]
+
+[[package]]
+name = "packaging"
+version = "26.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831 },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538 },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/e4/40d09941a2cebcb20609b86a559817d5b9291c49dd6f8c87e5feffbe703a/pydantic-2.13.3.tar.gz", hash = "sha256:af09e9d1d09f4e7fe37145c1f577e1d61ceb9a41924bf0094a36506285d0a84d", size = 844068 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/0a/fd7d723f8f8153418fb40cf9c940e82004fce7e987026b08a68a36dd3fe7/pydantic-2.13.3-py3-none-any.whl", hash = "sha256:6db14ac8dfc9a1e57f87ea2c0de670c251240f43cb0c30a5130e9720dc612927", size = 471981 },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/ef/f7abb56c49382a246fd2ce9c799691e3c3e7175ec74b14d99e798bcddb1a/pydantic_core-2.46.3.tar.gz", hash = "sha256:41c178f65b8c29807239d47e6050262eb6bf84eb695e41101e62e38df4a5bc2c", size = 471412 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/cb/5b47425556ecc1f3fe18ed2a0083188aa46e1dd812b06e406475b3a5d536/pydantic_core-2.46.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:b11b59b3eee90a80a36701ddb4576d9ae31f93f05cb9e277ceaa09e6bf074a67", size = 2101946 },
+    { url = "https://files.pythonhosted.org/packages/a1/4f/2fb62c2267cae99b815bbf4a7b9283812c88ca3153ef29f7707200f1d4e5/pydantic_core-2.46.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:af8653713055ea18a3abc1537fe2ebc42f5b0bbb768d1eb79fd74eb47c0ac089", size = 1951612 },
+    { url = "https://files.pythonhosted.org/packages/50/6e/b7348fd30d6556d132cddd5bd79f37f96f2601fe0608afac4f5fb01ec0b3/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:75a519dab6d63c514f3a81053e5266c549679e4aa88f6ec57f2b7b854aceb1b0", size = 1977027 },
+    { url = "https://files.pythonhosted.org/packages/82/11/31d60ee2b45540d3fb0b29302a393dbc01cd771c473f5b5147bcd353e593/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a6cd87cb1575b1ad05ba98894c5b5c96411ef678fa2f6ed2576607095b8d9789", size = 2063008 },
+    { url = "https://files.pythonhosted.org/packages/8a/db/3a9d1957181b59258f44a2300ab0f0be9d1e12d662a4f57bb31250455c52/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f80a55484b8d843c8ada81ebf70a682f3f00a3d40e378c06cf17ecb44d280d7d", size = 2233082 },
+    { url = "https://files.pythonhosted.org/packages/9c/e1/3277c38792aeb5cfb18c2f0c5785a221d9ff4e149abbe1184d53d5f72273/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3861f1731b90c50a3266316b9044f5c9b405eecb8e299b0a7120596334e4fe9c", size = 2304615 },
+    { url = "https://files.pythonhosted.org/packages/5e/d5/e3d9717c9eba10855325650afd2a9cba8e607321697f18953af9d562da2f/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb528e295ed31570ac3dcc9bfdd6e0150bc11ce6168ac87a8082055cf1a67395", size = 2094380 },
+    { url = "https://files.pythonhosted.org/packages/a1/20/abac35dedcbfd66c6f0b03e4e3564511771d6c9b7ede10a362d03e110d9b/pydantic_core-2.46.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:367508faa4973b992b271ba1494acaab36eb7e8739d1e47be5035fb1ea225396", size = 2135429 },
+    { url = "https://files.pythonhosted.org/packages/6c/a5/41bfd1df69afad71b5cf0535055bccc73022715ad362edbc124bc1e021d7/pydantic_core-2.46.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5ad3c826fe523e4becf4fe39baa44286cff85ef137c729a2c5e269afbfd0905d", size = 2174582 },
+    { url = "https://files.pythonhosted.org/packages/79/65/38d86ea056b29b2b10734eb23329b7a7672ca604df4f2b6e9c02d4ee22fe/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ec638c5d194ef8af27db69f16c954a09797c0dc25015ad6123eb2c73a4d271ca", size = 2187533 },
+    { url = "https://files.pythonhosted.org/packages/b6/55/a1129141678a2026badc539ad1dee0a71d06f54c2f06a4bd68c030ac781b/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:28ed528c45446062ee66edb1d33df5d88828ae167de76e773a3c7f64bd14e976", size = 2332985 },
+    { url = "https://files.pythonhosted.org/packages/d7/60/cb26f4077719f709e54819f4e8e1d43f4091f94e285eb6bd21e1190a7b7c/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aed19d0c783886d5bd86d80ae5030006b45e28464218747dcf83dabfdd092c7b", size = 2373670 },
+    { url = "https://files.pythonhosted.org/packages/6b/7e/c3f21882bdf1d8d086876f81b5e296206c69c6082551d776895de7801fa0/pydantic_core-2.46.3-cp312-cp312-win32.whl", hash = "sha256:06d5d8820cbbdb4147578c1fe7ffcd5b83f34508cb9f9ab76e807be7db6ff0a4", size = 1966722 },
+    { url = "https://files.pythonhosted.org/packages/57/be/6b5e757b859013ebfbd7adba02f23b428f37c86dcbf78b5bb0b4ffd36e99/pydantic_core-2.46.3-cp312-cp312-win_amd64.whl", hash = "sha256:c3212fda0ee959c1dd04c60b601ec31097aaa893573a3a1abd0a47bcac2968c1", size = 2072970 },
+    { url = "https://files.pythonhosted.org/packages/bf/f8/a989b21cc75e9a32d24192ef700eea606521221a89faa40c919ce884f2b1/pydantic_core-2.46.3-cp312-cp312-win_arm64.whl", hash = "sha256:f1f8338dd7a7f31761f1f1a3c47503a9a3b34eea3c8b01fa6ee96408affb5e72", size = 2035963 },
+    { url = "https://files.pythonhosted.org/packages/9b/3c/9b5e8eb9821936d065439c3b0fb1490ffa64163bfe7e1595985a47896073/pydantic_core-2.46.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:12bc98de041458b80c86c56b24df1d23832f3e166cbaff011f25d187f5c62c37", size = 2102109 },
+    { url = "https://files.pythonhosted.org/packages/91/97/1c41d1f5a19f241d8069f1e249853bcce378cdb76eec8ab636d7bc426280/pydantic_core-2.46.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:85348b8f89d2c3508b65b16c3c33a4da22b8215138d8b996912bb1532868885f", size = 1951820 },
+    { url = "https://files.pythonhosted.org/packages/30/b4/d03a7ae14571bc2b6b3c7b122441154720619afe9a336fa3a95434df5e2f/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1105677a6df914b1fb71a81b96c8cce7726857e1717d86001f29be06a25ee6f8", size = 1977785 },
+    { url = "https://files.pythonhosted.org/packages/ae/0c/4086f808834b59e3c8f1aa26df8f4b6d998cdcf354a143d18ef41529d1fe/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:87082cd65669a33adeba5470769e9704c7cf026cc30afb9cc77fd865578ebaad", size = 2062761 },
+    { url = "https://files.pythonhosted.org/packages/fa/71/a649be5a5064c2df0db06e0a512c2281134ed2fcc981f52a657936a7527c/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:60e5f66e12c4f5212d08522963380eaaeac5ebd795826cfd19b2dfb0c7a52b9c", size = 2232989 },
+    { url = "https://files.pythonhosted.org/packages/a2/84/7756e75763e810b3a710f4724441d1ecc5883b94aacb07ca71c5fb5cfb69/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b6cdf19bf84128d5e7c37e8a73a0c5c10d51103a650ac585d42dd6ae233f2b7f", size = 2303975 },
+    { url = "https://files.pythonhosted.org/packages/6c/35/68a762e0c1e31f35fa0dac733cbd9f5b118042853698de9509c8e5bf128b/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:031bb17f4885a43773c8c763089499f242aee2ea85cf17154168775dccdecf35", size = 2095325 },
+    { url = "https://files.pythonhosted.org/packages/77/bf/1bf8c9a8e91836c926eae5e3e51dce009bf495a60ca56060689d3df3f340/pydantic_core-2.46.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:bcf2a8b2982a6673693eae7348ef3d8cf3979c1d63b54fca7c397a635cc68687", size = 2133368 },
+    { url = "https://files.pythonhosted.org/packages/e5/50/87d818d6bab915984995157ceb2380f5aac4e563dddbed6b56f0ed057aba/pydantic_core-2.46.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:28e8cf2f52d72ced402a137145923a762cbb5081e48b34312f7a0c8f55928ec3", size = 2173908 },
+    { url = "https://files.pythonhosted.org/packages/91/88/a311fb306d0bd6185db41fa14ae888fb81d0baf648a761ae760d30819d33/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:17eaface65d9fc5abb940003020309c1bf7a211f5f608d7870297c367e6f9022", size = 2186422 },
+    { url = "https://files.pythonhosted.org/packages/8f/79/28fd0d81508525ab2054fef7c77a638c8b5b0afcbbaeee493cf7c3fef7e1/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:93fd339f23408a07e98950a89644f92c54d8729719a40b30c0a30bb9ebc55d23", size = 2332709 },
+    { url = "https://files.pythonhosted.org/packages/b3/21/795bf5fe5c0f379308b8ef19c50dedab2e7711dbc8d0c2acf08f1c7daa05/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:23cbdb3aaa74dfe0837975dbf69b469753bbde8eacace524519ffdb6b6e89eb7", size = 2372428 },
+    { url = "https://files.pythonhosted.org/packages/45/b3/ed14c659cbe7605e3ef063077680a64680aec81eb1a04763a05190d49b7f/pydantic_core-2.46.3-cp313-cp313-win32.whl", hash = "sha256:610eda2e3838f401105e6326ca304f5da1e15393ae25dacae5c5c63f2c275b13", size = 1965601 },
+    { url = "https://files.pythonhosted.org/packages/ef/bb/adb70d9a762ddd002d723fbf1bd492244d37da41e3af7b74ad212609027e/pydantic_core-2.46.3-cp313-cp313-win_amd64.whl", hash = "sha256:68cc7866ed863db34351294187f9b729964c371ba33e31c26f478471c52e1ed0", size = 2071517 },
+    { url = "https://files.pythonhosted.org/packages/52/eb/66faefabebfe68bd7788339c9c9127231e680b11906368c67ce112fdb47f/pydantic_core-2.46.3-cp313-cp313-win_arm64.whl", hash = "sha256:f64b5537ac62b231572879cd08ec05600308636a5d63bcbdb15063a466977bec", size = 2035802 },
+    { url = "https://files.pythonhosted.org/packages/7f/db/a7bcb4940183fda36022cd18ba8dd12f2dff40740ec7b58ce7457befa416/pydantic_core-2.46.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:afa3aa644f74e290cdede48a7b0bee37d1c35e71b05105f6b340d484af536d9b", size = 2097614 },
+    { url = "https://files.pythonhosted.org/packages/24/35/e4066358a22e3e99519db370494c7528f5a2aa1367370e80e27e20283543/pydantic_core-2.46.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ced3310e51aa425f7f77da8bbbb5212616655bedbe82c70944320bc1dbe5e018", size = 1951896 },
+    { url = "https://files.pythonhosted.org/packages/87/92/37cf4049d1636996e4b888c05a501f40a43ff218983a551d57f9d5e14f0d/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e29908922ce9da1a30b4da490bd1d3d82c01dcfdf864d2a74aacee674d0bfa34", size = 1979314 },
+    { url = "https://files.pythonhosted.org/packages/d8/36/9ff4d676dfbdfb2d591cf43f3d90ded01e15b1404fd101180ed2d62a2fd3/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0c9ff69140423eea8ed2d5477df3ba037f671f5e897d206d921bc9fdc39613e7", size = 2056133 },
+    { url = "https://files.pythonhosted.org/packages/bc/f0/405b442a4d7ba855b06eec8b2bf9c617d43b8432d099dfdc7bf999293495/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b675ab0a0d5b1c8fdb81195dc5bcefea3f3c240871cdd7ff9a2de8aa50772eb2", size = 2228726 },
+    { url = "https://files.pythonhosted.org/packages/e7/f8/65cd92dd5a0bd89ba277a98ecbfaf6fc36bbd3300973c7a4b826d6ab1391/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0087084960f209a9a4af50ecd1fb063d9ad3658c07bb81a7a53f452dacbfb2ba", size = 2301214 },
+    { url = "https://files.pythonhosted.org/packages/fd/86/ef96a4c6e79e7a2d0410826a68fbc0eccc0fd44aa733be199d5fcac3bb87/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ed42e6cc8e1b0e2b9b96e2276bad70ae625d10d6d524aed0c93de974ae029f9f", size = 2099927 },
+    { url = "https://files.pythonhosted.org/packages/6d/53/269caf30e0096e0a8a8f929d1982a27b3879872cca2d917d17c2f9fdf4fe/pydantic_core-2.46.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:f1771ce258afb3e4201e67d154edbbae712a76a6081079fe247c2f53c6322c22", size = 2128789 },
+    { url = "https://files.pythonhosted.org/packages/00/b0/1a6d9b6a587e118482910c244a1c5acf4d192604174132efd12bf0ac486f/pydantic_core-2.46.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a7610b6a5242a6c736d8ad47fd5fff87fcfe8f833b281b1c409c3d6835d9227f", size = 2173815 },
+    { url = "https://files.pythonhosted.org/packages/87/56/e7e00d4041a7e62b5a40815590114db3b535bf3ca0bf4dca9f16cef25246/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:ff5e7783bcc5476e1db448bf268f11cb257b1c276d3e89f00b5727be86dd0127", size = 2181608 },
+    { url = "https://files.pythonhosted.org/packages/e8/22/4bd23c3d41f7c185d60808a1de83c76cf5aeabf792f6c636a55c3b1ec7f9/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:9d2e32edcc143bc01e95300671915d9ca052d4f745aa0a49c48d4803f8a85f2c", size = 2326968 },
+    { url = "https://files.pythonhosted.org/packages/24/ac/66cd45129e3915e5ade3b292cb3bc7fd537f58f8f8dbdaba6170f7cabb74/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:6e42d83d1c6b87fa56b521479cff237e626a292f3b31b6345c15a99121b454c1", size = 2369842 },
+    { url = "https://files.pythonhosted.org/packages/a2/51/dd4248abb84113615473aa20d5545b7c4cd73c8644003b5259686f93996c/pydantic_core-2.46.3-cp314-cp314-win32.whl", hash = "sha256:07bc6d2a28c3adb4f7c6ae46aa4f2d2929af127f587ed44057af50bf1ce0f505", size = 1959661 },
+    { url = "https://files.pythonhosted.org/packages/20/eb/59980e5f1ae54a3b86372bd9f0fa373ea2d402e8cdcd3459334430f91e91/pydantic_core-2.46.3-cp314-cp314-win_amd64.whl", hash = "sha256:8940562319bc621da30714617e6a7eaa6b98c84e8c685bcdc02d7ed5e7c7c44e", size = 2071686 },
+    { url = "https://files.pythonhosted.org/packages/8c/db/1cf77e5247047dfee34bc01fa9bca134854f528c8eb053e144298893d370/pydantic_core-2.46.3-cp314-cp314-win_arm64.whl", hash = "sha256:5dcbbcf4d22210ced8f837c96db941bdb078f419543472aca5d9a0bb7cddc7df", size = 2026907 },
+    { url = "https://files.pythonhosted.org/packages/57/c0/b3df9f6a543276eadba0a48487b082ca1f201745329d97dbfa287034a230/pydantic_core-2.46.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d0fe3dce1e836e418f912c1ad91c73357d03e556a4d286f441bf34fed2dbeecf", size = 2095047 },
+    { url = "https://files.pythonhosted.org/packages/66/57/886a938073b97556c168fd99e1a7305bb363cd30a6d2c76086bf0587b32a/pydantic_core-2.46.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9ce92e58abc722dac1bf835a6798a60b294e48eb0e625ec9fd994b932ac5feee", size = 1934329 },
+    { url = "https://files.pythonhosted.org/packages/0b/7c/b42eaa5c34b13b07ecb51da21761297a9b8eb43044c864a035999998f328/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a03e6467f0f5ab796a486146d1b887b2dc5e5f9b3288898c1b1c3ad974e53e4a", size = 1974847 },
+    { url = "https://files.pythonhosted.org/packages/e6/9b/92b42db6543e7de4f99ae977101a2967b63122d4b6cf7773812da2d7d5b5/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2798b6ba041b9d70acfb9071a2ea13c8456dd1e6a5555798e41ba7b0790e329c", size = 2041742 },
+    { url = "https://files.pythonhosted.org/packages/0f/19/46fbe1efabb5aa2834b43b9454e70f9a83ad9c338c1291e48bdc4fecf167/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9be3e221bdc6d69abf294dcf7aff6af19c31a5cdcc8f0aa3b14be29df4bd03b1", size = 2236235 },
+    { url = "https://files.pythonhosted.org/packages/77/da/b3f95bc009ad60ec53120f5d16c6faa8cabdbe8a20d83849a1f2b8728148/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f13936129ce841f2a5ddf6f126fea3c43cd128807b5a59588c37cf10178c2e64", size = 2282633 },
+    { url = "https://files.pythonhosted.org/packages/cc/6e/401336117722e28f32fb8220df676769d28ebdf08f2f4469646d404c43a3/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28b5f2ef03416facccb1c6ef744c69793175fd27e44ef15669201601cf423acb", size = 2109679 },
+    { url = "https://files.pythonhosted.org/packages/fc/53/b289f9bc8756a32fe718c46f55afaeaf8d489ee18d1a1e7be1db73f42cc4/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:830d1247d77ad23852314f069e9d7ddafeec5f684baf9d7e7065ed46a049c4e6", size = 2108342 },
+    { url = "https://files.pythonhosted.org/packages/10/5b/8292fc7c1f9111f1b2b7c1b0dcf1179edcd014fc3ea4517499f50b829d71/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0793c90c1a3c74966e7975eaef3ed30ebdff3260a0f815a62a22adc17e4c01c", size = 2157208 },
+    { url = "https://files.pythonhosted.org/packages/2b/9e/f80044e9ec07580f057a89fc131f78dda7a58751ddf52bbe05eaf31db50f/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:d2d0aead851b66f5245ec0c4fb2612ef457f8bbafefdf65a2bf9d6bac6140f47", size = 2167237 },
+    { url = "https://files.pythonhosted.org/packages/f8/84/6781a1b037f3b96be9227edbd1101f6d3946746056231bf4ac48cdff1a8d/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:2f40e4246676beb31c5ce77c38a55ca4e465c6b38d11ea1bd935420568e0b1ab", size = 2312540 },
+    { url = "https://files.pythonhosted.org/packages/3e/db/19c0839feeb728e7df03255581f198dfdf1c2aeb1e174a8420b63c5252e5/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:cf489cf8986c543939aeee17a09c04d6ffb43bfef8ca16fcbcc5cfdcbed24dba", size = 2369556 },
+    { url = "https://files.pythonhosted.org/packages/e0/15/3228774cb7cd45f5f721ddf1b2242747f4eb834d0c491f0c02d606f09fed/pydantic_core-2.46.3-cp314-cp314t-win32.whl", hash = "sha256:ffe0883b56cfc05798bf994164d2b2ff03efe2d22022a2bb080f3b626176dd56", size = 1949756 },
+    { url = "https://files.pythonhosted.org/packages/b8/2a/c79cf53fd91e5a87e30d481809f52f9a60dd221e39de66455cf04deaad37/pydantic_core-2.46.3-cp314-cp314t-win_amd64.whl", hash = "sha256:706d9d0ce9cf4593d07270d8e9f53b161f90c57d315aeec4fb4fd7a8b10240d8", size = 2051305 },
+    { url = "https://files.pythonhosted.org/packages/0b/db/d8182a7f1d9343a032265aae186eb063fe26ca4c40f256b21e8da4498e89/pydantic_core-2.46.3-cp314-cp314t-win_arm64.whl", hash = "sha256:77706aeb41df6a76568434701e0917da10692da28cb69d5fb6919ce5fdb07374", size = 2026310 },
+    { url = "https://files.pythonhosted.org/packages/34/42/f426db557e8ab2791bc7562052299944a118655496fbff99914e564c0a94/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:b12dd51f1187c2eb489af8e20f880362db98e954b54ab792fa5d92e8bcc6b803", size = 2091877 },
+    { url = "https://files.pythonhosted.org/packages/5c/4f/86a832a9d14df58e663bfdf4627dc00d3317c2bd583c4fb23390b0f04b8e/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f00a0961b125f1a47af7bcc17f00782e12f4cd056f83416006b30111d941dfa3", size = 1932428 },
+    { url = "https://files.pythonhosted.org/packages/11/1a/fe857968954d93fb78e0d4b6df5c988c74c4aaa67181c60be7cfe327c0ca/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:57697d7c056aca4bbb680200f96563e841a6386ac1129370a0102592f4dddff5", size = 1997550 },
+    { url = "https://files.pythonhosted.org/packages/17/eb/9d89ad2d9b0ba8cd65393d434471621b98912abb10fbe1df08e480ba57b5/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd35aa21299def8db7ef4fe5c4ff862941a9a158ca7b63d61e66fe67d30416b4", size = 2137657 },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/98/c8345dccdc31de4228c039a98f6467a941e39558da41c1744fbe29fa5666/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d", size = 235709 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/dd/bebff3040138f00ae8a102d426b27349b9a49acc310fcae7f92112d867e3/pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e", size = 60940 },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151 },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.409"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/4e/3aa27f74211522dba7e9cbc3e74de779c6d4b654c54e50a4840623be8014/pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93", size = 4430434 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/6b/330d8ebae582b30c2959a1ef4c3bc344ebde48c2ff0c3f113c4710735e11/pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3", size = 6438161 },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249 },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075 },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876 },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101 },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063 },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973 },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116 },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011 },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870 },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089 },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181 },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658 },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003 },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344 },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669 },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252 },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081 },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159 },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626 },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613 },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115 },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427 },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090 },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246 },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814 },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809 },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454 },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355 },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175 },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228 },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194 },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429 },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912 },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108 },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641 },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901 },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132 },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261 },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272 },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923 },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062 },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341 },
+]
+
+[[package]]
+name = "redis"
+version = "7.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/7f/3759b1d0d72b7c92f0d70ffd9dc962b7b7b5ee74e135f9d7d8ab06b8a318/redis-7.4.0.tar.gz", hash = "sha256:64a6ea7bf567ad43c964d2c30d82853f8df927c5c9017766c55a1d1ed95d18ad", size = 4943913 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/3a/95deec7db1eb53979973ebd156f3369a72732208d1391cd2e5d127062a32/redis-7.4.0-py3-none-any.whl", hash = "sha256:a9c74a5c893a5ef8455a5adb793a31bb70feb821c86eccb62eebef5a19c429ec", size = 409772 },
+]
+
+[[package]]
+name = "respx"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557 },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/8d/192f3d7103816158dfd5ea50d098ef2aec19194e6cbccd4b3485bdb2eb2d/ruff-0.15.11.tar.gz", hash = "sha256:f092b21708bf0e7437ce9ada249dfe688ff9a0954fc94abab05dcea7dcd29c33", size = 4637264 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/1e/6aca3427f751295ab011828e15e9bf452200ac74484f1db4be0197b8170b/ruff-0.15.11-py3-none-linux_armv6l.whl", hash = "sha256:e927cfff503135c558eb581a0c9792264aae9507904eb27809cdcff2f2c847b7", size = 10607943 },
+    { url = "https://files.pythonhosted.org/packages/e7/26/1341c262e74f36d4e84f3d6f4df0ac68cd53331a66bfc5080daa17c84c0b/ruff-0.15.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7a1b5b2938d8f890b76084d4fa843604d787a912541eae85fd7e233398bbb73e", size = 10988592 },
+    { url = "https://files.pythonhosted.org/packages/03/71/850b1d6ffa9564fbb6740429bad53df1094082fe515c8c1e74b6d8d05f18/ruff-0.15.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d4176f3d194afbdaee6e41b9ccb1a2c287dba8700047df474abfbe773825d1cb", size = 10338501 },
+    { url = "https://files.pythonhosted.org/packages/f2/11/cc1284d3e298c45a817a6aadb6c3e1d70b45c9b36d8d9cce3387b495a03a/ruff-0.15.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b17c886fb88203ced3afe7f14e8d5ae96e9d2f4ccc0ee66aa19f2c2675a27e4", size = 10670693 },
+    { url = "https://files.pythonhosted.org/packages/ce/9e/f8288b034ab72b371513c13f9a41d9ba3effac54e24bfb467b007daee2ca/ruff-0.15.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:49fafa220220afe7758a487b048de4c8f9f767f37dfefad46b9dd06759d003eb", size = 10416177 },
+    { url = "https://files.pythonhosted.org/packages/85/71/504d79abfd3d92532ba6bbe3d1c19fada03e494332a59e37c7c2dabae427/ruff-0.15.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f2ab8427e74a00d93b8bda1307b1e60970d40f304af38bccb218e056c220120d", size = 11221886 },
+    { url = "https://files.pythonhosted.org/packages/43/5a/947e6ab7a5ad603d65b474be15a4cbc6d29832db5d762cd142e4e3a74164/ruff-0.15.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:195072c0c8e1fc8f940652073df082e37a5d9cb43b4ab1e4d0566ab8977a13b7", size = 12075183 },
+    { url = "https://files.pythonhosted.org/packages/9f/a1/0b7bb6268775fdd3a0818aee8efd8f5b4e231d24dd4d528ced2534023182/ruff-0.15.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a3a0996d486af3920dec930a2e7daed4847dfc12649b537a9335585ada163e9e", size = 11516575 },
+    { url = "https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bef2cb556d509259f1fe440bb9cd33c756222cf0a7afe90d15edf0866702431", size = 11306537 },
+    { url = "https://files.pythonhosted.org/packages/e4/92/4cfae6441f3967317946f3b788136eecf093729b94d6561f963ed810c82e/ruff-0.15.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:030d921a836d7d4a12cf6e8d984a88b66094ccb0e0f17ddd55067c331191bf19", size = 11296813 },
+    { url = "https://files.pythonhosted.org/packages/43/26/972784c5dde8313acde8ac71ba8ac65475b85db4a2352a76c9934361f9bc/ruff-0.15.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0e783b599b4577788dbbb66b9addcef87e9a8832f4ce0c19e34bf55543a2f890", size = 10633136 },
+    { url = "https://files.pythonhosted.org/packages/5b/53/3985a4f185020c2f367f2e08a103032e12564829742a1b417980ce1514a0/ruff-0.15.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ae90592246625ba4a34349d68ec28d4400d75182b71baa196ddb9f82db025ef5", size = 10424701 },
+    { url = "https://files.pythonhosted.org/packages/d3/57/bf0dfb32241b56c83bb663a826133da4bf17f682ba8c096973065f6e6a68/ruff-0.15.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1f111d62e3c983ed20e0ca2e800f8d77433a5b1161947df99a5c2a3fb60514f0", size = 10873887 },
+    { url = "https://files.pythonhosted.org/packages/02/05/e48076b2a57dc33ee8c7a957296f97c744ca891a8ffb4ffb1aaa3b3f517d/ruff-0.15.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:06f483d6646f59eaffba9ae30956370d3a886625f511a3108994000480621d1c", size = 11404316 },
+    { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535 },
+    { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692 },
+    { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614 },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575 },
+]
+
+[[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651 },
+]
+
+[[package]]
+name = "structlog"
+version = "25.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510 },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614 },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611 },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.46.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926 },
+]
+
+[package.optional-dependencies]
+standard = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "httptools" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/ff/7f72e8170be527b4977b033239a83a68d5c881cc4775fca255c677f7ac5d/uvloop-0.22.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fe94b4564e865d968414598eea1a6de60adba0c040ba4ed05ac1300de402cd42", size = 1359936 },
+    { url = "https://files.pythonhosted.org/packages/c3/c6/e5d433f88fd54d81ef4be58b2b7b0cea13c442454a1db703a1eea0db1a59/uvloop-0.22.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:51eb9bd88391483410daad430813d982010f9c9c89512321f5b60e2cddbdddd6", size = 752769 },
+    { url = "https://files.pythonhosted.org/packages/24/68/a6ac446820273e71aa762fa21cdcc09861edd3536ff47c5cd3b7afb10eeb/uvloop-0.22.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:700e674a166ca5778255e0e1dc4e9d79ab2acc57b9171b79e65feba7184b3370", size = 4317413 },
+    { url = "https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b5b1ac819a3f946d3b2ee07f09149578ae76066d70b44df3fa990add49a82e4", size = 4426307 },
+    { url = "https://files.pythonhosted.org/packages/90/60/97362554ac21e20e81bcef1150cb2a7e4ffdaf8ea1e5b2e8bf7a053caa18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e047cc068570bac9866237739607d1313b9253c3051ad84738cbb095be0537b2", size = 4131970 },
+    { url = "https://files.pythonhosted.org/packages/99/39/6b3f7d234ba3964c428a6e40006340f53ba37993f46ed6e111c6e9141d18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:512fec6815e2dd45161054592441ef76c830eddaad55c8aa30952e6fe1ed07c0", size = 4296343 },
+    { url = "https://files.pythonhosted.org/packages/89/8c/182a2a593195bfd39842ea68ebc084e20c850806117213f5a299dfc513d9/uvloop-0.22.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:561577354eb94200d75aca23fbde86ee11be36b00e52a4eaf8f50fb0c86b7705", size = 1358611 },
+    { url = "https://files.pythonhosted.org/packages/d2/14/e301ee96a6dc95224b6f1162cd3312f6d1217be3907b79173b06785f2fe7/uvloop-0.22.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cdf5192ab3e674ca26da2eada35b288d2fa49fdd0f357a19f0e7c4e7d5077c8", size = 751811 },
+    { url = "https://files.pythonhosted.org/packages/b7/02/654426ce265ac19e2980bfd9ea6590ca96a56f10c76e63801a2df01c0486/uvloop-0.22.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e2ea3d6190a2968f4a14a23019d3b16870dd2190cd69c8180f7c632d21de68d", size = 4288562 },
+    { url = "https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e", size = 4366890 },
+    { url = "https://files.pythonhosted.org/packages/d2/53/8369e5219a5855869bcee5f4d317f6da0e2c669aecf0ef7d371e3d084449/uvloop-0.22.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc5ef13bbc10b5335792360623cc378d52d7e62c2de64660616478c32cd0598e", size = 4119472 },
+    { url = "https://files.pythonhosted.org/packages/f8/ba/d69adbe699b768f6b29a5eec7b47dd610bd17a69de51b251126a801369ea/uvloop-0.22.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1f38ec5e3f18c8a10ded09742f7fb8de0108796eb673f30ce7762ce1b8550cad", size = 4239051 },
+    { url = "https://files.pythonhosted.org/packages/90/cd/b62bdeaa429758aee8de8b00ac0dd26593a9de93d302bff3d21439e9791d/uvloop-0.22.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3879b88423ec7e97cd4eba2a443aa26ed4e59b45e6b76aabf13fe2f27023a142", size = 1362067 },
+    { url = "https://files.pythonhosted.org/packages/0d/f8/a132124dfda0777e489ca86732e85e69afcd1ff7686647000050ba670689/uvloop-0.22.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4baa86acedf1d62115c1dc6ad1e17134476688f08c6efd8a2ab076e815665c74", size = 752423 },
+    { url = "https://files.pythonhosted.org/packages/a3/94/94af78c156f88da4b3a733773ad5ba0b164393e357cc4bd0ab2e2677a7d6/uvloop-0.22.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:297c27d8003520596236bdb2335e6b3f649480bd09e00d1e3a99144b691d2a35", size = 4272437 },
+    { url = "https://files.pythonhosted.org/packages/b5/35/60249e9fd07b32c665192cec7af29e06c7cd96fa1d08b84f012a56a0b38e/uvloop-0.22.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1955d5a1dd43198244d47664a5858082a3239766a839b2102a269aaff7a4e25", size = 4292101 },
+    { url = "https://files.pythonhosted.org/packages/02/62/67d382dfcb25d0a98ce73c11ed1a6fba5037a1a1d533dcbb7cab033a2636/uvloop-0.22.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b31dc2fccbd42adc73bc4e7cdbae4fc5086cf378979e53ca5d0301838c5682c6", size = 4114158 },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/f1171b4a882a5d13c8b7576f348acfe6074d72eaf52cccef752f748d4a9f/uvloop-0.22.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:93f617675b2d03af4e72a5333ef89450dfaa5321303ede6e67ba9c9d26878079", size = 4177360 },
+    { url = "https://files.pythonhosted.org/packages/79/7b/b01414f31546caf0919da80ad57cbfe24c56b151d12af68cee1b04922ca8/uvloop-0.22.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:37554f70528f60cad66945b885eb01f1bb514f132d92b6eeed1c90fd54ed6289", size = 1454790 },
+    { url = "https://files.pythonhosted.org/packages/d4/31/0bb232318dd838cad3fa8fb0c68c8b40e1145b32025581975e18b11fab40/uvloop-0.22.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:b76324e2dc033a0b2f435f33eb88ff9913c156ef78e153fb210e03c13da746b3", size = 796783 },
+    { url = "https://files.pythonhosted.org/packages/42/38/c9b09f3271a7a723a5de69f8e237ab8e7803183131bc57c890db0b6bb872/uvloop-0.22.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:badb4d8e58ee08dad957002027830d5c3b06aea446a6a3744483c2b3b745345c", size = 4647548 },
+    { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065 },
+    { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384 },
+    { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730 },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/d5/f039e7e3c639d9b1d09b07ea412a6806d38123f0508e5f9b48a87b0a76cc/watchfiles-1.1.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:8c89f9f2f740a6b7dcc753140dd5e1ab9215966f7a3530d0c0705c83b401bd7d", size = 404745 },
+    { url = "https://files.pythonhosted.org/packages/a5/96/a881a13aa1349827490dab2d363c8039527060cfcc2c92cc6d13d1b1049e/watchfiles-1.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bd404be08018c37350f0d6e34676bd1e2889990117a2b90070b3007f172d0610", size = 391769 },
+    { url = "https://files.pythonhosted.org/packages/4b/5b/d3b460364aeb8da471c1989238ea0e56bec24b6042a68046adf3d9ddb01c/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8526e8f916bb5b9a0a777c8317c23ce65de259422bba5b31325a6fa6029d33af", size = 449374 },
+    { url = "https://files.pythonhosted.org/packages/b9/44/5769cb62d4ed055cb17417c0a109a92f007114a4e07f30812a73a4efdb11/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2edc3553362b1c38d9f06242416a5d8e9fe235c204a4072e988ce2e5bb1f69f6", size = 459485 },
+    { url = "https://files.pythonhosted.org/packages/19/0c/286b6301ded2eccd4ffd0041a1b726afda999926cf720aab63adb68a1e36/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30f7da3fb3f2844259cba4720c3fc7138eb0f7b659c38f3bfa65084c7fc7abce", size = 488813 },
+    { url = "https://files.pythonhosted.org/packages/c7/2b/8530ed41112dd4a22f4dcfdb5ccf6a1baad1ff6eed8dc5a5f09e7e8c41c7/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8979280bdafff686ba5e4d8f97840f929a87ed9cdf133cbbd42f7766774d2aa", size = 594816 },
+    { url = "https://files.pythonhosted.org/packages/ce/d2/f5f9fb49489f184f18470d4f99f4e862a4b3e9ac2865688eb2099e3d837a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dcc5c24523771db3a294c77d94771abcfcb82a0e0ee8efd910c37c59ec1b31bb", size = 475186 },
+    { url = "https://files.pythonhosted.org/packages/cf/68/5707da262a119fb06fbe214d82dd1fe4a6f4af32d2d14de368d0349eb52a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db5d7ae38ff20153d542460752ff397fcf5c96090c1230803713cf3147a6803", size = 456812 },
+    { url = "https://files.pythonhosted.org/packages/66/ab/3cbb8756323e8f9b6f9acb9ef4ec26d42b2109bce830cc1f3468df20511d/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:28475ddbde92df1874b6c5c8aaeb24ad5be47a11f87cde5a28ef3835932e3e94", size = 630196 },
+    { url = "https://files.pythonhosted.org/packages/78/46/7152ec29b8335f80167928944a94955015a345440f524d2dfe63fc2f437b/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:36193ed342f5b9842edd3532729a2ad55c4160ffcfa3700e0d54be496b70dd43", size = 622657 },
+    { url = "https://files.pythonhosted.org/packages/0a/bf/95895e78dd75efe9a7f31733607f384b42eb5feb54bd2eb6ed57cc2e94f4/watchfiles-1.1.1-cp312-cp312-win32.whl", hash = "sha256:859e43a1951717cc8de7f4c77674a6d389b106361585951d9e69572823f311d9", size = 272042 },
+    { url = "https://files.pythonhosted.org/packages/87/0a/90eb755f568de2688cb220171c4191df932232c20946966c27a59c400850/watchfiles-1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:91d4c9a823a8c987cce8fa2690923b069966dabb196dd8d137ea2cede885fde9", size = 288410 },
+    { url = "https://files.pythonhosted.org/packages/36/76/f322701530586922fbd6723c4f91ace21364924822a8772c549483abed13/watchfiles-1.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:a625815d4a2bdca61953dbba5a39d60164451ef34c88d751f6c368c3ea73d404", size = 278209 },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/f750b29225fe77139f7ae5de89d4949f5a99f934c65a1f1c0b248f26f747/watchfiles-1.1.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:130e4876309e8686a5e37dba7d5e9bc77e6ed908266996ca26572437a5271e18", size = 404321 },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/f07a295cde762644aa4c4bb0f88921d2d141af45e735b965fb2e87858328/watchfiles-1.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5f3bde70f157f84ece3765b42b4a52c6ac1a50334903c6eaf765362f6ccca88a", size = 391783 },
+    { url = "https://files.pythonhosted.org/packages/bc/11/fc2502457e0bea39a5c958d86d2cb69e407a4d00b85735ca724bfa6e0d1a/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14e0b1fe858430fc0251737ef3824c54027bedb8c37c38114488b8e131cf8219", size = 449279 },
+    { url = "https://files.pythonhosted.org/packages/e3/1f/d66bc15ea0b728df3ed96a539c777acfcad0eb78555ad9efcaa1274688f0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f27db948078f3823a6bb3b465180db8ebecf26dd5dae6f6180bd87383b6b4428", size = 459405 },
+    { url = "https://files.pythonhosted.org/packages/be/90/9f4a65c0aec3ccf032703e6db02d89a157462fbb2cf20dd415128251cac0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:059098c3a429f62fc98e8ec62b982230ef2c8df68c79e826e37b895bc359a9c0", size = 488976 },
+    { url = "https://files.pythonhosted.org/packages/37/57/ee347af605d867f712be7029bb94c8c071732a4b44792e3176fa3c612d39/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfb5862016acc9b869bb57284e6cb35fdf8e22fe59f7548858e2f971d045f150", size = 595506 },
+    { url = "https://files.pythonhosted.org/packages/a8/78/cc5ab0b86c122047f75e8fc471c67a04dee395daf847d3e59381996c8707/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:319b27255aacd9923b8a276bb14d21a5f7ff82564c744235fc5eae58d95422ae", size = 474936 },
+    { url = "https://files.pythonhosted.org/packages/62/da/def65b170a3815af7bd40a3e7010bf6ab53089ef1b75d05dd5385b87cf08/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c755367e51db90e75b19454b680903631d41f9e3607fbd941d296a020c2d752d", size = 456147 },
+    { url = "https://files.pythonhosted.org/packages/57/99/da6573ba71166e82d288d4df0839128004c67d2778d3b566c138695f5c0b/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c22c776292a23bfc7237a98f791b9ad3144b02116ff10d820829ce62dff46d0b", size = 630007 },
+    { url = "https://files.pythonhosted.org/packages/a8/51/7439c4dd39511368849eb1e53279cd3454b4a4dbace80bab88feeb83c6b5/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:3a476189be23c3686bc2f4321dd501cb329c0a0469e77b7b534ee10129ae6374", size = 622280 },
+    { url = "https://files.pythonhosted.org/packages/95/9c/8ed97d4bba5db6fdcdb2b298d3898f2dd5c20f6b73aee04eabe56c59677e/watchfiles-1.1.1-cp313-cp313-win32.whl", hash = "sha256:bf0a91bfb5574a2f7fc223cf95eeea79abfefa404bf1ea5e339c0c1560ae99a0", size = 272056 },
+    { url = "https://files.pythonhosted.org/packages/1f/f3/c14e28429f744a260d8ceae18bf58c1d5fa56b50d006a7a9f80e1882cb0d/watchfiles-1.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:52e06553899e11e8074503c8e716d574adeeb7e68913115c4b3653c53f9bae42", size = 288162 },
+    { url = "https://files.pythonhosted.org/packages/dc/61/fe0e56c40d5cd29523e398d31153218718c5786b5e636d9ae8ae79453d27/watchfiles-1.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:ac3cc5759570cd02662b15fbcd9d917f7ecd47efe0d6b40474eafd246f91ea18", size = 277909 },
+    { url = "https://files.pythonhosted.org/packages/79/42/e0a7d749626f1e28c7108a99fb9bf524b501bbbeb9b261ceecde644d5a07/watchfiles-1.1.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:563b116874a9a7ce6f96f87cd0b94f7faf92d08d0021e837796f0a14318ef8da", size = 403389 },
+    { url = "https://files.pythonhosted.org/packages/15/49/08732f90ce0fbbc13913f9f215c689cfc9ced345fb1bcd8829a50007cc8d/watchfiles-1.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3ad9fe1dae4ab4212d8c91e80b832425e24f421703b5a42ef2e4a1e215aff051", size = 389964 },
+    { url = "https://files.pythonhosted.org/packages/27/0d/7c315d4bd5f2538910491a0393c56bf70d333d51bc5b34bee8e68e8cea19/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce70f96a46b894b36eba678f153f052967a0d06d5b5a19b336ab0dbbd029f73e", size = 448114 },
+    { url = "https://files.pythonhosted.org/packages/c3/24/9e096de47a4d11bc4df41e9d1e61776393eac4cb6eb11b3e23315b78b2cc/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cb467c999c2eff23a6417e58d75e5828716f42ed8289fe6b77a7e5a91036ca70", size = 460264 },
+    { url = "https://files.pythonhosted.org/packages/cc/0f/e8dea6375f1d3ba5fcb0b3583e2b493e77379834c74fd5a22d66d85d6540/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:836398932192dae4146c8f6f737d74baeac8b70ce14831a239bdb1ca882fc261", size = 487877 },
+    { url = "https://files.pythonhosted.org/packages/ac/5b/df24cfc6424a12deb41503b64d42fbea6b8cb357ec62ca84a5a3476f654a/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:743185e7372b7bc7c389e1badcc606931a827112fbbd37f14c537320fca08620", size = 595176 },
+    { url = "https://files.pythonhosted.org/packages/8f/b5/853b6757f7347de4e9b37e8cc3289283fb983cba1ab4d2d7144694871d9c/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:afaeff7696e0ad9f02cbb8f56365ff4686ab205fcf9c4c5b6fdfaaa16549dd04", size = 473577 },
+    { url = "https://files.pythonhosted.org/packages/e1/f7/0a4467be0a56e80447c8529c9fce5b38eab4f513cb3d9bf82e7392a5696b/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f7eb7da0eb23aa2ba036d4f616d46906013a68caf61b7fdbe42fc8b25132e77", size = 455425 },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/82583485ea00137ddf69bc84a2db88bd92ab4a6e3c405e5fb878ead8d0e7/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:831a62658609f0e5c64178211c942ace999517f5770fe9436be4c2faeba0c0ef", size = 628826 },
+    { url = "https://files.pythonhosted.org/packages/28/9a/a785356fccf9fae84c0cc90570f11702ae9571036fb25932f1242c82191c/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f9a2ae5c91cecc9edd47e041a930490c31c3afb1f5e6d71de3dc671bfaca02bf", size = 622208 },
+    { url = "https://files.pythonhosted.org/packages/c3/f4/0872229324ef69b2c3edec35e84bd57a1289e7d3fe74588048ed8947a323/watchfiles-1.1.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d1715143123baeeaeadec0528bb7441103979a1d5f6fd0e1f915383fea7ea6d5", size = 404315 },
+    { url = "https://files.pythonhosted.org/packages/7b/22/16d5331eaed1cb107b873f6ae1b69e9ced582fcf0c59a50cd84f403b1c32/watchfiles-1.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:39574d6370c4579d7f5d0ad940ce5b20db0e4117444e39b6d8f99db5676c52fd", size = 390869 },
+    { url = "https://files.pythonhosted.org/packages/b2/7e/5643bfff5acb6539b18483128fdc0ef2cccc94a5b8fbda130c823e8ed636/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7365b92c2e69ee952902e8f70f3ba6360d0d596d9299d55d7d386df84b6941fb", size = 449919 },
+    { url = "https://files.pythonhosted.org/packages/51/2e/c410993ba5025a9f9357c376f48976ef0e1b1aefb73b97a5ae01a5972755/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bfff9740c69c0e4ed32416f013f3c45e2ae42ccedd1167ef2d805c000b6c71a5", size = 460845 },
+    { url = "https://files.pythonhosted.org/packages/8e/a4/2df3b404469122e8680f0fcd06079317e48db58a2da2950fb45020947734/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b27cf2eb1dda37b2089e3907d8ea92922b673c0c427886d4edc6b94d8dfe5db3", size = 489027 },
+    { url = "https://files.pythonhosted.org/packages/ea/84/4587ba5b1f267167ee715b7f66e6382cca6938e0a4b870adad93e44747e6/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:526e86aced14a65a5b0ec50827c745597c782ff46b571dbfe46192ab9e0b3c33", size = 595615 },
+    { url = "https://files.pythonhosted.org/packages/6a/0f/c6988c91d06e93cd0bb3d4a808bcf32375ca1904609835c3031799e3ecae/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:04e78dd0b6352db95507fd8cb46f39d185cf8c74e4cf1e4fbad1d3df96faf510", size = 474836 },
+    { url = "https://files.pythonhosted.org/packages/b4/36/ded8aebea91919485b7bbabbd14f5f359326cb5ec218cd67074d1e426d74/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c85794a4cfa094714fb9c08d4a218375b2b95b8ed1666e8677c349906246c05", size = 455099 },
+    { url = "https://files.pythonhosted.org/packages/98/e0/8c9bdba88af756a2fce230dd365fab2baf927ba42cd47521ee7498fd5211/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:74d5012b7630714b66be7b7b7a78855ef7ad58e8650c73afc4c076a1f480a8d6", size = 630626 },
+    { url = "https://files.pythonhosted.org/packages/2a/84/a95db05354bf2d19e438520d92a8ca475e578c647f78f53197f5a2f17aaf/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:8fbe85cb3201c7d380d3d0b90e63d520f15d6afe217165d7f98c9c649654db81", size = 622519 },
+    { url = "https://files.pythonhosted.org/packages/1d/ce/d8acdc8de545de995c339be67711e474c77d643555a9bb74a9334252bd55/watchfiles-1.1.1-cp314-cp314-win32.whl", hash = "sha256:3fa0b59c92278b5a7800d3ee7733da9d096d4aabcfabb9a928918bd276ef9b9b", size = 272078 },
+    { url = "https://files.pythonhosted.org/packages/c4/c9/a74487f72d0451524be827e8edec251da0cc1fcf111646a511ae752e1a3d/watchfiles-1.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:c2047d0b6cea13b3316bdbafbfa0c4228ae593d995030fda39089d36e64fc03a", size = 287664 },
+    { url = "https://files.pythonhosted.org/packages/df/b8/8ac000702cdd496cdce998c6f4ee0ca1f15977bba51bdf07d872ebdfc34c/watchfiles-1.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:842178b126593addc05acf6fce960d28bc5fae7afbaa2c6c1b3a7b9460e5be02", size = 277154 },
+    { url = "https://files.pythonhosted.org/packages/47/a8/e3af2184707c29f0f14b1963c0aace6529f9d1b8582d5b99f31bbf42f59e/watchfiles-1.1.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:88863fbbc1a7312972f1c511f202eb30866370ebb8493aef2812b9ff28156a21", size = 403820 },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/e47e307c2f4bd75f9f9e8afbe3876679b18e1bcec449beca132a1c5ffb2d/watchfiles-1.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:55c7475190662e202c08c6c0f4d9e345a29367438cf8e8037f3155e10a88d5a5", size = 390510 },
+    { url = "https://files.pythonhosted.org/packages/d5/a0/ad235642118090f66e7b2f18fd5c42082418404a79205cdfca50b6309c13/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f53fa183d53a1d7a8852277c92b967ae99c2d4dcee2bfacff8868e6e30b15f7", size = 448408 },
+    { url = "https://files.pythonhosted.org/packages/df/85/97fa10fd5ff3332ae17e7e40e20784e419e28521549780869f1413742e9d/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6aae418a8b323732fa89721d86f39ec8f092fc2af67f4217a2b07fd3e93c6101", size = 458968 },
+    { url = "https://files.pythonhosted.org/packages/47/c2/9059c2e8966ea5ce678166617a7f75ecba6164375f3b288e50a40dc6d489/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f096076119da54a6080e8920cbdaac3dbee667eb91dcc5e5b78840b87415bd44", size = 488096 },
+    { url = "https://files.pythonhosted.org/packages/94/44/d90a9ec8ac309bc26db808a13e7bfc0e4e78b6fc051078a554e132e80160/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00485f441d183717038ed2e887a7c868154f216877653121068107b227a2f64c", size = 596040 },
+    { url = "https://files.pythonhosted.org/packages/95/68/4e3479b20ca305cfc561db3ed207a8a1c745ee32bf24f2026a129d0ddb6e/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a55f3e9e493158d7bfdb60a1165035f1cf7d320914e7b7ea83fe22c6023b58fc", size = 473847 },
+    { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072 },
+    { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104 },
+    { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112 },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365 },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038 },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328 },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915 },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152 },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583 },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880 },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261 },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693 },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364 },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039 },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323 },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975 },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203 },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653 },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920 },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255 },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689 },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406 },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085 },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328 },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044 },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279 },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711 },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982 },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915 },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381 },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737 },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268 },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486 },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331 },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501 },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062 },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356 },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085 },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531 },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598 },
+]

--- a/klai-portal/backend/app/api/auth_join.py
+++ b/klai-portal/backend/app/api/auth_join.py
@@ -18,7 +18,6 @@ from app.api.bearer import bearer
 from app.core.database import get_db
 from app.models.portal import PortalJoinRequest
 from app.services.join_request_token import generate_approval_token
-from app.services.notifications import notify_admin_join_request
 from app.services.zitadel import zitadel
 
 logger = structlog.get_logger()
@@ -113,11 +112,19 @@ async def create_join_request(
         email=email,
     )
 
-    # C7.3: email failure never blocks join request creation
-    try:
-        await notify_admin_join_request(email=email, display_name=display_name)
-    except Exception:
-        logger.warning("Admin notification failed for join request", request_id=new_request.id, exc_info=True)
+    # Admin notification is a no-op at this call site: the join request is
+    # created BEFORE an org is assigned (org_id=None above). With the
+    # SPEC-SEC-MAILER-INJECTION-001 recipient-binding contract, the
+    # notification requires a known `org_id` + `admin_email` pair so
+    # klai-mailer can prove the recipient via portal-api callback. Once a
+    # per-target-org assignment flow lands, re-enable the call:
+    #   await notify_admin_join_request(
+    #       email=email, display_name=display_name,
+    #       org_id=target_org_id, admin_email=target_admin_email,
+    #   )
+    # Until then we rely on the admin approval flow to surface pending
+    # requests in the UI.
+    logger.info("join_request_pending_admin_review", request_id=new_request.id)
 
     return JoinRequestResponse(
         id=new_request.id,

--- a/klai-portal/backend/app/api/internal.py
+++ b/klai-portal/backend/app/api/internal.py
@@ -275,6 +275,48 @@ class UserLanguageResponse(BaseModel):
     preferred_language: str
 
 
+class OrgAdminEmailResponse(BaseModel):
+    admin_email: str
+
+
+@router.get("/org/{org_id}/admin-email", response_model=OrgAdminEmailResponse)
+async def get_org_admin_email(
+    org_id: int,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> OrgAdminEmailResponse:
+    """Return the primary admin email for an organisation.
+
+    SPEC-SEC-MAILER-INJECTION-001 REQ-3.1 callback: klai-mailer resolves
+    the expected recipient for `join_request_admin` via this endpoint
+    rather than trusting an attacker-supplied `to` address.
+
+    Returns the earliest-created `role='admin'` user with a populated
+    email for the org. 404 if no such user exists.
+    """
+    await _require_internal_token(request)
+    await set_tenant(db, org_id)
+
+    result = await db.execute(
+        select(PortalUser.email)
+        .where(
+            PortalUser.org_id == org_id,
+            PortalUser.role == "admin",
+            PortalUser.status == "active",
+            PortalUser.email.isnot(None),
+        )
+        .order_by(PortalUser.created_at.asc())
+        .limit(1)
+    )
+    admin_email = result.scalar_one_or_none()
+    if not admin_email:
+        await _audit_internal_call(request, org_id=org_id)
+        raise HTTPException(status_code=404, detail="No admin user for org")
+
+    await _audit_internal_call(request, org_id=org_id)
+    return OrgAdminEmailResponse(admin_email=admin_email)
+
+
 @router.get("/user-language", response_model=UserLanguageResponse)
 async def get_user_language(
     email: str,

--- a/klai-portal/backend/app/services/notifications.py
+++ b/klai-portal/backend/app/services/notifications.py
@@ -1,4 +1,14 @@
-"""Notification helpers for sending emails via klai-mailer (SPEC-AUTH-006 R7/R16)."""
+"""Notification helpers for sending emails via klai-mailer (SPEC-AUTH-006 R7/R16).
+
+SPEC-SEC-MAILER-INJECTION-001 contract changes (landing with REQ-1..4):
+- `notify_admin_join_request` now passes `org_id` so klai-mailer can
+  resolve the expected admin recipient via
+  `GET /internal/org/<id>/admin-email`. The caller MUST supply `org_id`
+  and the pre-resolved `admin_email`; klai-mailer validates them against
+  each other and rejects a mismatch with 400.
+- `notify_user_join_approved` passes `email` inside variables so
+  klai-mailer can bind the recipient against the schema field.
+"""
 
 import httpx
 import structlog
@@ -9,16 +19,20 @@ logger = structlog.get_logger()
 
 
 async def notify_admin_join_request(
+    *,
     email: str,
     display_name: str,
-    admin_email: str | None = None,
+    org_id: int,
+    admin_email: str,
 ) -> None:
     """Send join request notification email to org admins via klai-mailer.
 
-    C7.3: Never fail the main flow — exceptions are caught by the caller.
+    Caller MUST pass `org_id` AND `admin_email`. Klai-mailer resolves the
+    expected admin via portal-api and rejects a mismatch with 400.
+    C7.3 — never fail the main flow; exceptions are caught here.
     """
     if not settings.mailer_url:
-        logger.warning("mailer_url not configured — skipping join request notification")
+        logger.warning("mailer_url_not_configured_admin_join", org_id=org_id)
         return
 
     try:
@@ -28,26 +42,32 @@ async def notify_admin_join_request(
                 headers={"X-Internal-Secret": settings.internal_secret},
                 json={
                     "template": "join_request_admin",
-                    "to": admin_email or "",
+                    "to": admin_email,
                     "locale": "nl",
                     "variables": {
                         "name": display_name,
                         "email": email,
+                        "org_id": org_id,
                     },
                 },
             )
     except Exception:
-        logger.warning("klai-mailer notification failed", email=email, exc_info=True)
+        logger.warning("mailer_notify_admin_failed", org_id=org_id, exc_info=True)
 
 
 async def notify_user_join_approved(
+    *,
     email: str,
     display_name: str,
     workspace_url: str,
 ) -> None:
-    """Send approval confirmation email to the user via klai-mailer."""
+    """Send approval confirmation email to the user via klai-mailer.
+
+    Klai-mailer binds the recipient to `variables.email`; the handler
+    returns 400 if `to` differs from it.
+    """
     if not settings.mailer_url:
-        logger.warning("mailer_url not configured — skipping approval notification")
+        logger.warning("mailer_url_not_configured_approved")
         return
 
     try:
@@ -61,9 +81,10 @@ async def notify_user_join_approved(
                     "locale": "nl",
                     "variables": {
                         "name": display_name,
+                        "email": email,
                         "workspace_url": workspace_url,
                     },
                 },
             )
     except Exception:
-        logger.warning("klai-mailer approval notification failed", email=email, exc_info=True)
+        logger.warning("mailer_notify_approved_failed", exc_info=True)

--- a/klai-portal/backend/tests/test_join_request_endpoint.py
+++ b/klai-portal/backend/tests/test_join_request_endpoint.py
@@ -51,7 +51,6 @@ class TestJoinRequestEndpoint:
             patch("app.api.auth_join.get_current_user_id", return_value="user-sso-1"),
             patch("app.api.auth_join.zitadel") as mock_zitadel,
             patch("app.api.auth_join.generate_approval_token", return_value="a" * 64),
-            patch("app.api.auth_join.notify_admin_join_request"),
         ):
             mock_zitadel.get_userinfo = AsyncMock(
                 return_value={"sub": "user-sso-1", "email": "test@company.com", "name": "Test User"}


### PR DESCRIPTION
## Summary

SPEC-SEC-MAILER-INJECTION-001 — klai-mailer audit wave landing. Closes findings mailer-2..mailer-9 (CRITICAL `str.format` introspection chain + open-relay risk) via 10 REQs:

- **REQ-1**: Jinja2 `SandboxedEnvironment` + `StrictUndefined` replaces `str.format(**variables)` on `/internal/send`.
- **REQ-2**: Per-template Pydantic v2 schemas with `extra="forbid"`. `JoinRequestAdminVars` + `JoinRequestApprovedVars`.
- **REQ-3**: Recipient bound to template-derived expectation. `join_request_admin` resolves admin via new portal-api callback `GET /internal/org/{id}/admin-email`; `join_request_approved` binds to `variables.email`. Mismatch → 400.
- **REQ-4**: Redis sliding-window rate limit, 10 sends / 24h / recipient. SHA-256 hashed key. Fail-OPEN on Redis outage (degraded monitoring).
- **REQ-5**: `/debug` double-gated on `PORTAL_ENV != production` AND `DEBUG=true`.
- **REQ-6**: Zitadel webhook nonce tracking in Redis (`SET NX EX 300`). Fail-CLOSED on Redis outage.
- **REQ-7**: Every signature-verification failure returns byte-identical `{"detail": "invalid signature"}` 401. Phase distinction only in structured logs.
- **REQ-8**: `hmac.compare_digest` replaces `!=` on `X-Internal-Secret` via factored helper.
- **REQ-9**: Fail-closed startup if `WEBHOOK_SECRET` / `INTERNAL_SECRET` empty or whitespace-only.
- **REQ-10**: Strict `ZITADEL-Signature` parser — rejects any field outside `{t, v1}` and headers with > 5 tokens.

## Portal-api contract change (same PR)

- New endpoint `GET /internal/org/{org_id}/admin-email` (internal-secret gated).
- `notify_admin_join_request` now requires `org_id` and `admin_email` (keyword-only).
- `notify_user_join_approved` now passes `email` in variables so mailer can bind the recipient.
- `auth_join.py`: admin-notification call disabled (was already no-op — no org_id at that phase). Documented inline for future re-enable.

## Test plan

Mailer suite — 57 tests, all green:

- [x] AC-1: `str.format` introspection payload rejected or rendered literally (no Python-graph leakage)
- [x] AC-2: `to_address` outside template allowlist → 400
- [x] AC-3: 11th send to same recipient in 24h → 429 + Retry-After header
- [x] AC-4: `/debug` returns 404 when `PORTAL_ENV=production` (no log, no signature-verify call)
- [x] AC-5: Zitadel webhook replay within 5-min window → 401 "replay" log event
- [x] AC-6: Every signature-failure mode returns byte-identical 401 body
- [x] AC-7: Empty `WEBHOOK_SECRET` refuses startup (subprocess exit non-zero)
- [x] AC-8: `ZITADEL-Signature` with extra `v2=` / 6-token / non-v key → 401 + `reason=unknown_vN_field`
- [x] AC-9: Golden-output regression for all four `(template, locale)` legitimate flows
- [x] AC-10: Wrong internal secret (various lengths) → 401 via `hmac.compare_digest`

Portal-api side:
- [x] Existing `test_join_request_endpoint.py` passes after signature change
- [ ] TODO: pytest for new `GET /internal/org/{id}/admin-email` endpoint (follow-up)

## Deploy notes (HIGH — coordinate)

1. **`REDIS_URL` env var** must be set on the mailer container before deploy — defaults to `redis://redis:6379/0` which matches klai-net Redis.
2. **Mailer + portal-api must deploy together.** Old portal-api doesn't send `org_id`; new mailer requires it → `400 invalid variables` until both land.
3. **`WEBHOOK_SECRET` / `INTERNAL_SECRET`** both gated on startup. They're already set in prod per audit — verify before rolling.
4. **Rate limit ceiling** (10/24h/recipient) is low-by-design. Observe `mailer_recipient_rate_limited` in VictoriaLogs post-deploy; adjust `MAILER_RATE_LIMIT_PER_RECIPIENT` upward if legitimate admin flows hit the cap.

## Observability

Every reject path emits a structured log with a stable `event` key — queryable in VictoriaLogs:

`mailer_template_sandbox_violation`, `mailer_template_schema_invalid`,
`mailer_recipient_mismatch`, `mailer_recipient_lookup_failed`,
`mailer_recipient_rate_limited`, `mailer_rate_limit_redis_unavailable`,
`mailer_nonce_redis_unavailable`, `mailer_signature_invalid` (with `reason` sub-field).

Follow-up: Grafana alerts on these events.

---

SPEC: `.moai/specs/SPEC-SEC-MAILER-INJECTION-001/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)