### PR TITLE
docs(sync): tech.md adds yt-dlp (SPEC-KB-SOURCES-001 sync)

### DIFF
--- a/.moai/project/tech.md
+++ b/.moai/project/tech.md
@@ -26,6 +26,7 @@ Klai is a multi-service TypeScript/Python monorepo. The frontend stack is TypeSc
 | Crypto | cryptography | >=43.0 |
 | Calendar | icalendar | >=6.1, <7.0 |
 | MongoDB Driver | motor | >=3.6 |
+| YouTube extractor | yt-dlp | >=2026.3 |
 | Linting | ruff | >=0.8 |
 | Type Checking | pyright | >=1.1 |
 | Testing | pytest + pytest-asyncio | >=8 / >=0.24 |


### PR DESCRIPTION
Sync-phase doc update for SPEC-KB-SOURCES-001. One-line addition to tech.md: `yt-dlp >=2026.3` under the Portal Backend stack. Closes the dependency-delta loop — the backend yt-dlp extractor stays live after the frontend tile was pulled, so the stack doc reflects reality.

No code changes. No migrations. No tests impacted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)