### PR TITLE
fix(sec): SPEC-SEC-ENVFILE-SCOPE-001 — restore 3 vars dropped by migration

### DIFF
--- a/deploy/SECRETS_MATRIX.md
+++ b/deploy/SECRETS_MATRIX.md
@@ -39,6 +39,7 @@ from SOPS `klai-infra/core-01/.env.sops`) unless noted otherwise.
 | Secret | Service | Purpose |
 |---|---|---|
 | `DOCS_INTERNAL_SECRET` | portal-api | Shared secret portal-api → klai-docs for KB provisioning calls. |
+| `GRAPHITI_LLM_MODEL` | retrieval-api | LLM model name used by Graphiti for knowledge-graph extraction. Prod uses `klai-pipeline`; config.py default is `klai-fast`. Not a secret — declared here because the prod value differs from the code default. |
 | `FIRECRAWL_INTERNAL_KEY` | portal-api | Shared web-search API key (portal re-uses the Firecrawl internal key for URL extraction). |
 | `GITHUB_ADMIN_PAT` | portal-api | GitHub PAT with `admin:org` scope — used during offboarding to remove members from the GetKlai org. |
 | `KLAI_CONNECTOR_SECRET` | portal-api | Shared secret for portal → klai-connector orchestration calls (SOPS key: `PORTAL_API_KLAI_CONNECTOR_SECRET`, mapped inline). |
@@ -73,7 +74,9 @@ from SOPS `klai-infra/core-01/.env.sops`) unless noted otherwise.
 | `RETRIEVAL_API_INTERNAL_SECRET` | retrieval-api | Shared secret for internal callers (portal-api, LiteLLM hook). Mapped to `INTERNAL_SECRET` in-container (SPEC-SEC-010). |
 | `RETRIEVAL_API_RATE_LIMIT_RPM` | retrieval-api | Sliding-window rate-limit threshold per caller identity (SPEC-SEC-010). |
 | `RETRIEVAL_API_ZITADEL_AUDIENCE` | retrieval-api | Zitadel audience for JWT validation. Mapped to `ZITADEL_API_AUDIENCE` in-container. |
+| `VEXA_ADMIN_TOKEN` | portal-api | Reserved for Vexa admin-API calls (tenant provisioning, quota inspection). @MX:NOTE in config.py — no runtime reader yet; declared to preserve pre-migration env-shape. |
 | `VEXA_BOT_MANAGER_API_KEY` | portal-api | Vexa bot-manager API key. Mapped to `VEXA_API_KEY` in-container. |
+| `VEXA_MEETING_API_URL` | portal-api | Base URL for Vexa meeting-api (prod routes through `api-gateway:8000`, not the raw meeting-api). Overrides the config.py default. |
 | `VEXA_WEBHOOK_SECRET` | portal-api | Signs Vexa webhook deliveries to portal; config.py validator fails closed on empty/whitespace (SEC-013 F-033). |
 | `VICTORIALOGS_AUTH_PASSWORD` | victorialogs | HTTP basic-auth password (set via `-httpAuth.password` cmdline flag). Also needed inside the container so the busybox-wget healthcheck can build the auth header. |
 | `VICTORIALOGS_AUTH_USER` | victorialogs | HTTP basic-auth username (set via `-httpAuth.username` cmdline flag). Also needed inside the container for the healthcheck. |

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -363,6 +363,15 @@ services:
       # ─── Vexa (meeting bot) ─────────────────────────────────────
       VEXA_API_KEY: ${VEXA_BOT_MANAGER_API_KEY}
       VEXA_WEBHOOK_SECRET: ${VEXA_WEBHOOK_SECRET}
+      # Vexa meeting-api base URL. Prod routes through the api-gateway
+      # (:8000) — NOT the raw meeting-api (:8080). Overrides the
+      # config.py default to match pre-SPEC-SEC-ENVFILE-SCOPE-001 behaviour.
+      VEXA_MEETING_API_URL: ${VEXA_MEETING_API_URL:-http://api-gateway:8000}
+      # Reserved for Vexa admin-API calls (tenant provisioning, quota).
+      # @MX:NOTE in config.py — no runtime reader yet; kept declared so
+      # a future admin-api caller picks up the real token, matching the
+      # pre-migration env-shape.
+      VEXA_ADMIN_TOKEN: ${VEXA_ADMIN_TOKEN}
       # ─── Billing — Moneybird ────────────────────────────────────
       # Validator in config.py requires MONEYBIRD_WEBHOOK_TOKEN at boot.
       MONEYBIRD_WEBHOOK_TOKEN: ${MONEYBIRD_WEBHOOK_TOKEN}
@@ -697,6 +706,11 @@ services:
       FALKORDB_PORT: "6379"
       GRAPHITI_ENABLED: "true"
       GRAPH_SEARCH_TIMEOUT: "60.0"
+      # Graphiti LLM model for knowledge-graph extraction. Prod uses
+      # the heavier pipeline model; config.py defaults to klai-fast
+      # which is not suitable for graph extraction. Overrides the
+      # default to match pre-SPEC-SEC-ENVFILE-SCOPE-001 behaviour.
+      GRAPHITI_LLM_MODEL: ${GRAPHITI_LLM_MODEL:-klai-pipeline}
       RERANKER_ENABLED: "true"
       RERANKER_TIMEOUT: "60.0"
       OPENAI_API_KEY: "dummy"


### PR DESCRIPTION
## Summary

Post-merge adversarial audit of PR #163 found three environment variables that were set in \`/opt/klai/.env\` with a value differing from the in-code pydantic-settings default. The initial migration audit checked vars that the running container had → code references, but did NOT reverse-check every config.py field with a default against \`/opt/klai/.env\` for non-default overrides. Three fell through:

| Var | Service | Pre-migration value (from .env) | Post-migration fallback (code default) | Impact |
|---|---|---|---|---|
| \`VEXA_MEETING_API_URL\` | portal-api | \`http://api-gateway:8000\` | \`http://vexa-meeting-api:8080\` | Portal calls to Vexa meeting-api would skip the api-gateway layer — different service entrypoint. |
| \`GRAPHITI_LLM_MODEL\` | retrieval-api | \`klai-pipeline\` | \`klai-fast\` | Graphiti graph-extraction would switch to a lighter model with different quality/cost. |
| \`VEXA_ADMIN_TOKEN\` | portal-api | (real token from SOPS) | \`""\` | No runtime reader today (@MX:NOTE in config.py), but future admin-api caller would get empty string instead of the real token — restored to preserve exact pre-migration env-shape. |

## Fix

Declare the three vars on the respective service in \`deploy/docker-compose.yml\` with \`\${VAR:-<default>}\` interpolation:

- portal-api gets \`VEXA_MEETING_API_URL\`, \`VEXA_ADMIN_TOKEN\`.
- retrieval-api gets \`GRAPHITI_LLM_MODEL\`.
- \`deploy/SECRETS_MATRIX.md\` gets a row per new var.

## Verification (deployed on core-01, live)

\`\`\`
portal-api:    VEXA_MEETING_API_URL=http://api-gateway:8000
               VEXA_ADMIN_TOKEN=<token set>
retrieval-api: GRAPHITI_LLM_MODEL=klai-pipeline

Env-var counts:   portal 53→55, retrieval 28→29  (+3 total)
Smoking-gun:      still empty on both services
Health:           portal /health 200, retrieval /health 200 (tei+qdrant+litellm+falkordb all ok)
Logs since reboot: 0 errors on either service
\`\`\`

## Why this pattern matters going forward

The correct audit method for future \`env_file\` → explicit migrations:

1. Extract every pydantic-settings field with a default.
2. For each, check \`/opt/klai/.env\`: is it set, and does the value differ from the in-code default?
3. If yes, declare explicitly in the \`environment:\` block with \`\${VAR:-<code-default>}\`.

PR #163 only did step 1 + a forward-check (code reads → compose). The reverse-check (SOPS-set non-default values) was spot-check only — which is how these three leaked through.

## Rollback

Single commit. Revert if it breaks something:

\`\`\`
git revert <sha>
scp deploy/docker-compose.yml core-01:/opt/klai/docker-compose.yml
ssh core-01 "cd /opt/klai && docker compose up -d portal-api retrieval-api"
\`\`\`

Server-side backup at \`/opt/klai/docker-compose.yml.pre-envfile-hotfix.bak\`.

## Confidence: 85 — evidence summary

- Three missing vars confirmed via reverse-check script on core-01 (full list of pydantic fields × /opt/klai/.env \`grep\`).
- Post-hotfix printenv on both services shows the expected values.
- Both services \`/health\` 200 with all downstream deps reporting OK.
- No errors in logs for either service in the first minute after recreate.
- Env-var counts remain small (55 and 29) — scope of the migration preserved.
- Smoking-gun filter still empty on portal — this hotfix does not re-introduce cross-service leakage.

Not 95+ for the same reason as #163: end-to-end browser flows (portal login + knowledge chat + actual Vexa meeting-bot spawn) not exercised by the agent.

Refs: .moai/specs/SPEC-SEC-ENVFILE-SCOPE-001 REQ-1.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)