### PR TITLE
docs(sec): SPEC-SEC-ENVFILE-SCOPE-001 close-out — status done + retro

### DIFF
--- a/.claude/rules/klai/pitfalls/process-rules.md
+++ b/.claude/rules/klai/pitfalls/process-rules.md
@@ -245,3 +245,49 @@ window.
    reviewers stop and think about prod env parity.
 
 See `klai-infra/core-01/.env.sops` for the canonical prod env inventory.
+
+## env-file-migration-reverse-check (HIGH)
+When replacing `env_file: .env` on a service with an explicit
+`environment:` block, the obvious audit is forward: "what env vars does
+the service's code read, and is each one declared in the new block?"
+That audit is necessary but NOT sufficient. It misses the case where
+a pydantic-settings field has an in-code default AND `/opt/klai/.env`
+overrides it with a different value. Pre-migration the override was
+inherited silently via `env_file: .env`; post-migration the field falls
+back to the code default and behaviour changes.
+
+SPEC-SEC-ENVFILE-SCOPE-001 shipped with three such regressions that
+survived the forward audit:
+
+- `VEXA_MEETING_API_URL` on portal-api: prod set `http://api-gateway:8000`,
+  code default was `http://vexa-meeting-api:8080`. Would have routed
+  meeting-bot traffic past the api-gateway layer.
+- `GRAPHITI_LLM_MODEL` on retrieval-api: prod set `klai-pipeline`,
+  code default was `klai-fast`. Different quality/cost on graph
+  extraction.
+- `VEXA_ADMIN_TOKEN` on portal-api: prod set a real token, code default
+  was `""`. No current runtime reader, but future callers would have
+  silently gotten an empty token.
+
+**Prevention:** For every service migrated off `env_file: .env`, run
+the reverse check explicitly:
+
+```bash
+# For each pydantic field with a default, compare /opt/klai/.env to the container env
+for var in $FIELD_NAMES; do
+  VAL_ENV=$(grep -E "^${var}=" /opt/klai/.env | cut -d= -f2-)
+  VAL_CTR=$(docker exec klai-core-<svc>-1 printenv $var 2>/dev/null)
+  [ -n "$VAL_ENV" ] && [ "$VAL_ENV" != "$VAL_CTR" ] && \
+    echo "DIVERGENCE: $var — .env='$VAL_ENV' vs container='$VAL_CTR'"
+done
+```
+
+Run both BEFORE the migration (to build the override inventory) and
+AFTER the deploy (to confirm zero divergence). Any DIVERGENCE line is
+a behaviour regression. Fix by declaring the var in the explicit block
+with `${VAR:-<code-default>}` interpolation so the compose file is also
+self-documenting about the expected prod value if SOPS drift occurs.
+
+The same-shape generalisation: **trust the container env, not the
+config source.** Any "silent fallback to a code default" in a migration
+off a blanket-inherit pattern is a latent bug.

--- a/.moai/specs/SPEC-SEC-ENVFILE-SCOPE-001/spec.md
+++ b/.moai/specs/SPEC-SEC-ENVFILE-SCOPE-001/spec.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-SEC-ENVFILE-SCOPE-001
-version: 0.2.0
-status: draft
+version: 0.3.0
+status: done
 created: 2026-04-24
 updated: 2026-04-24
 author: Mark Vletter
@@ -12,6 +12,27 @@ tracker: SPEC-SEC-AUDIT-2026-04
 # SPEC-SEC-ENVFILE-SCOPE-001: Replace `env_file: .env` with Explicit Per-Service Environment
 
 ## HISTORY
+
+### v0.3.0 (2026-04-24) — Landed
+
+Staged rollout complete on core-01. All four migrations deployed +
+runtime-verified, CI guard active on main, SECRETS_MATRIX.md published,
+adversarial reverse-check revealed and fixed 3 missed vars
+(`VEXA_MEETING_API_URL`, `VEXA_ADMIN_TOKEN`, `GRAPHITI_LLM_MODEL`) in a
+follow-up hotfix. Final env-var counts: scribe 163→15, retrieval 179→29,
+victorialogs 155→5, portal 177→55. Smoking-gun filters empty on all
+four. PRs: [#163](https://github.com/GetKlai/klai/pull/163) (initial
+migration, 5 commits staged per REQ-5.1) +
+[#170](https://github.com/GetKlai/klai/pull/170) (hotfix for missed
+vars).
+
+Retro pitfall captured in
+[.claude/rules/klai/pitfalls/process-rules.md](../../../.claude/rules/klai/pitfalls/process-rules.md)
+as `env-file-migration-reverse-check` — the initial audit methodology
+was asymmetric (code-reads → compose) and missed pydantic-settings
+fields where the prod override in `/opt/klai/.env` differed from the
+in-code default. Future `env_file` migrations must do the reverse check
+explicitly.
 
 ### v0.2.0 (2026-04-24)
 - Expanded stub to full EARS SPEC after repo-wide audit of


### PR DESCRIPTION
## Summary

Documentation-only close-out for SPEC-SEC-ENVFILE-SCOPE-001. No compose change, no production change.

- Flip SPEC \`status: draft\` → \`done\`, bump to v0.3.0 with landed summary (env-var counts, PR refs, follow-up hotfix).
- Capture the pitfall as \`env-file-migration-reverse-check (HIGH)\` in \`.claude/rules/klai/pitfalls/process-rules.md\` per the SPEC's Rule coupling (Environment §). Includes the exact shell snippet that catches the in-code-default vs prod-override divergence that leaked three vars past the initial forward audit — same pattern applies to any future \`env_file\` migration.

## Test plan

- [x] SPEC file parses (valid YAML frontmatter).
- [x] New pitfall section renders correctly (markdown).
- [x] No files under \`deploy/\` or \`.github/workflows/\` touched — env-scope-guard workflow does not fire.

Refs: .moai/specs/SPEC-SEC-ENVFILE-SCOPE-001