### PR TITLE
refactor(portal-api): typed mail-auth sub-results + eliminate double-parse (SPEC-SEC-IMAP-001 polish)

### DIFF
--- a/klai-portal/backend/app/services/imap_listener.py
+++ b/klai-portal/backend/app/services/imap_listener.py
@@ -1,5 +1,4 @@
-"""
-IMAP listener -- poll an IMAP mailbox for calendar invites.
+"""IMAP listener — poll an IMAP mailbox for calendar invites.
 
 Connects to IMAP4_SSL, polls for UNSEEN emails, verifies sender identity
 via DKIM/SPF/ARC (SPEC-SEC-IMAP-001), extracts .ics data, parses invites,
@@ -7,9 +6,7 @@ resolves tenants, and schedules bot joins.
 """
 
 import asyncio
-import email
 import imaplib
-import logging
 from email.message import Message
 
 import structlog
@@ -17,14 +14,10 @@ import structlog
 from app.core.config import settings
 from app.services.ical_parser import parse_ics
 from app.services.invite_scheduler import schedule_invite
-from app.services.mail_auth import verify_mail_auth
+from app.services.mail_auth import result_log_fields, verify_mail_auth
 from app.services.tenant_matcher import find_tenant
 
-# Stdlib logger kept for existing operational messages (poll errors, startup
-# noise). SPEC-SEC-IMAP-001 events (imap_auth_*) use structlog so their fields
-# land as queryable keys in VictoriaLogs.
-logger = logging.getLogger(__name__)
-struct_logger = structlog.get_logger()
+logger = structlog.get_logger()
 
 # Exponential backoff limits
 _BACKOFF_BASE = 1.0
@@ -43,7 +36,7 @@ async def start_imap_listener() -> None:
         except asyncio.CancelledError:
             break
         except Exception:
-            logger.exception("IMAP poll error (retrying in %.0fs)", backoff)
+            logger.exception("imap_poll_error", backoff_seconds=backoff)
             await asyncio.sleep(backoff)
             backoff = min(backoff * 2, _BACKOFF_MAX)
             continue
@@ -66,13 +59,13 @@ async def _poll_once() -> None:
             return
 
         msg_ids = data[0].split()
-        logger.info("IMAP: found %d unseen emails", len(msg_ids))
+        logger.info("imap_poll_found_unseen", count=len(msg_ids))
 
         for msg_id in msg_ids:
             try:
                 await _process_email(imap, msg_id)
             except Exception:
-                logger.exception("Failed to process email %s", msg_id)
+                logger.exception("imap_process_email_failed", imap_msg_id=msg_id.decode(errors="replace"))
             # Mark as SEEN regardless (avoid reprocessing). REQ-5.4: rejected
             # messages also get the \Seen flag so they do not loop.
             await asyncio.to_thread(imap.store, msg_id, "+FLAGS", "\\Seen")
@@ -80,7 +73,7 @@ async def _poll_once() -> None:
         try:
             await asyncio.to_thread(imap.logout)
         except Exception:
-            logger.debug("IMAP logout failed (connection may already be closed)")
+            logger.debug("imap_logout_failed", exc_info=True)
 
 
 async def _process_email(imap: imaplib.IMAP4_SSL, msg_id: bytes) -> None:
@@ -96,45 +89,41 @@ async def _process_email(imap: imaplib.IMAP4_SSL, msg_id: bytes) -> None:
         return
 
     raw_email = msg_data[0]
-    if isinstance(raw_email, tuple):
-        raw_bytes = raw_email[1]
-    else:
+    if not isinstance(raw_email, tuple):
         return
+    raw_bytes = raw_email[1]
 
-    # REQ-1..REQ-5: verify mail-auth. Structured result drives both the
-    # accept/reject gate and the observability event.
+    # REQ-1..REQ-5: verify mail-auth. The result carries the parsed Message
+    # so we don't re-parse raw_bytes downstream.
     auth = await verify_mail_auth(raw_bytes)
-    msg = email.message_from_bytes(raw_bytes)
-    message_id = msg.get("Message-ID") or "<unknown>"
 
     if auth.verified_from is None:
         # REQ-4.1 + REQ-4.2: stable log keys; no body, no ICS payload.
-        struct_logger.warning(
+        logger.warning(
             "imap_auth_failed",
             reason=auth.reason,
             from_header=auth.from_header,
             from_domain=auth.from_domain,
-            dkim_result=auth.dkim_result,
-            spf_result=auth.spf_result,
-            arc_result=auth.arc_result,
-            message_id=message_id,
+            message_id=auth.message_id,
+            **result_log_fields(auth),
         )
         return
 
     # REQ-4.3: positive trail for post-incident forensics.
-    struct_logger.info(
+    logger.info(
         "imap_auth_passed",
         verified_from=auth.verified_from,
         from_domain=auth.from_domain,
-        dkim_result=auth.dkim_result,
-        spf_result=auth.spf_result,
-        arc_result=auth.arc_result,
-        message_id=message_id,
+        message_id=auth.message_id,
+        **result_log_fields(auth),
     )
 
-    ics_parts = _extract_ics_parts(msg)
+    # verified_from is not None implies the raw bytes were parseable; the
+    # invariant is documented on MailAuthResult.
+    assert auth.parsed_message is not None
+    ics_parts = _extract_ics_parts(auth.parsed_message)
     if not ics_parts:
-        logger.debug("No iCal content in email %s", msg_id)
+        logger.debug("imap_no_ics_content", message_id=auth.message_id)
         return
 
     for ics_bytes in ics_parts:
@@ -148,11 +137,11 @@ async def _process_email(imap: imaplib.IMAP4_SSL, msg_id: bytes) -> None:
         # must see these but not break them. mail-auth is authoritative,
         # the ICS field is informational.
         if invite.organizer_email and invite.organizer_email.lower() != auth.verified_from:
-            struct_logger.warning(
+            logger.warning(
                 "imap_organizer_mismatch",
                 verified_from=auth.verified_from,
                 ics_organizer=invite.organizer_email,
-                message_id=message_id,
+                message_id=auth.message_id,
             )
 
         # REQ-5.2: find_tenant is called with verified_from, NOT

--- a/klai-portal/backend/app/services/mail_auth.py
+++ b/klai-portal/backend/app/services/mail_auth.py
@@ -3,18 +3,19 @@
 SPEC-SEC-IMAP-001. Verifies DKIM (aligned to RFC-5322 From domain), reads
 SPF from the trusted upstream Authentication-Results header, and accepts a
 valid ARC chain from a trusted sealer as a substitute for direct DKIM
-alignment on forwarded mail. Returns a structured MailAuthResult; callers
-gate on ``verified_from is not None``.
+alignment on forwarded mail. Returns a structured :class:`MailAuthResult`;
+callers gate on ``verified_from is not None``.
 
-Call site: ``app.services.imap_listener._process_email``.
+Call site: :func:`app.services.imap_listener._process_email`.
 """
 
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import email
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from email.message import Message
 from email.utils import getaddresses
 from typing import Any, Literal
@@ -23,7 +24,6 @@ import authres
 import dkim
 import publicsuffix2
 import structlog
-from authres.core import AuthenticationResultsHeader
 
 from app.core.config import settings
 
@@ -31,9 +31,9 @@ logger = structlog.get_logger()
 
 DnsFunc = Callable[[str], bytes]
 
-# REQ-4.1: every possible value of `MailAuthResult.reason`. Empty string means
-# "pass". A Literal type means a typo here is caught by pyright, not by a
-# missed test assertion.
+# REQ-4.1: every possible value of :attr:`MailAuthResult.reason`. Empty string
+# means "pass". A ``Literal`` type means a typo here is caught by pyright, not
+# by a missed test assertion.
 RejectReason = Literal[
     "",
     "no_dkim_signature",
@@ -46,50 +46,84 @@ RejectReason = Literal[
     "malformed_headers",
 ]
 
-# Empty result sentinels — used when a signal is absent or unreachable.
-_EMPTY_DKIM: dict[str, Any] = {"present": False, "valid": False, "d": None, "aligned": False}
-_EMPTY_SPF: dict[str, Any] = {"result": "absent", "smtp_mailfrom_domain": "", "aligned": False}
-_EMPTY_ARC: dict[str, Any] = {
-    "present": False,
-    "valid": False,
-    "sealer": None,
-    "trusted": False,
-    "aligned_from_domain": False,
-}
+
+@dataclass(frozen=True)
+class DkimResult:
+    """REQ-1: verdict of the first DKIM-Signature header.
+
+    ``present`` is True iff a DKIM-Signature header is in the message;
+    ``valid`` is True iff crypto-verify passed; ``d`` is the signing domain
+    from the verifying signature; ``aligned`` is True iff ``d`` aligns with
+    the RFC-5322 From domain per RFC 7489 §3.1.1.
+    """
+
+    present: bool = False
+    valid: bool = False
+    d: str | None = None
+    aligned: bool = False
+
+
+@dataclass(frozen=True)
+class SpfResult:
+    """REQ-2: SPF verdict read from the trusted upstream Authentication-Results."""
+
+    result: str = "absent"
+    smtp_mailfrom_domain: str = ""
+    aligned: bool = False
+
+
+@dataclass(frozen=True)
+class ArcResult:
+    """REQ-3: verdict of the ARC chain, with sealer-allowlist resolution."""
+
+    present: bool = False
+    valid: bool = False
+    sealer: str | None = None
+    trusted: bool = False
+    aligned_from_domain: bool = False
 
 
 @dataclass(frozen=True)
 class MailAuthResult:
     """REQ-1.5: structured mail-auth verdict.
 
+    Invariants:
+
+    - ``verified_from is not None`` iff the message passed
+    - On pass, ``reason == ""``; on reject, ``reason`` is a REQ-4.1 code
+    - ``parsed_message is not None`` iff the raw bytes were parseable as
+      RFC-822 (so the accept path can always use it; the very rare
+      ``malformed_headers`` branch from a raise inside ``message_from_bytes``
+      is the only case where it is None)
+
     Downstream callers MUST gate on ``verified_from is not None``. The
-    individual result dicts are for logging only; combining them outside this
-    module is a footgun (e.g. DKIM valid-but-misaligned is NOT acceptance).
+    individual :class:`DkimResult` / :class:`SpfResult` / :class:`ArcResult`
+    fields are for logging only; combining them outside this module is a
+    footgun (e.g. DKIM valid-but-misaligned is NOT acceptance).
     """
 
-    dkim_result: dict[str, Any]
-    spf_result: dict[str, Any]
-    arc_result: dict[str, Any]
+    dkim_result: DkimResult
+    spf_result: SpfResult
+    arc_result: ArcResult
     from_header: str
     from_domain: str
+    message_id: str
     verified_from: str | None
     reason: RejectReason
+    parsed_message: Message | None = field(default=None, repr=False, compare=False)
 
 
 def _organizational_domain(domain: str) -> str:
     """RFC 7489 §3.1.1 organizational domain via the Public Suffix List.
 
-    A naive two-label heuristic misaligns on ccTLDs with public suffixes — e.g.
-    ``evil.co.uk`` and ``target.co.uk`` both yield ``co.uk`` and therefore
-    would "align". ``publicsuffix2`` consults the IANA-maintained PSL and
-    returns the correct organizational domain (``evil.co.uk`` → ``evil.co.uk``,
-    ``mail.customer.nl`` → ``customer.nl``).
+    A naive two-label heuristic misaligns on ccTLDs with multi-label public
+    suffixes: ``evil.co.uk`` and ``target.co.uk`` both yield ``co.uk`` and
+    therefore would "align". :func:`publicsuffix2.get_sld` consults the
+    IANA-maintained PSL and returns the correct organizational domain
+    (``evil.co.uk`` → ``evil.co.uk``, ``mail.customer.nl`` → ``customer.nl``).
     """
-    sld = publicsuffix2.get_sld(domain.lower().strip("."))
-    # get_sld returns None for pure public suffixes or unknown TLDs — fall
-    # back to the input so alignment still produces a defensible answer
-    # (callers then compare two strings, one of which is the original domain).
-    return sld or domain.lower().strip(".")
+    normalized = domain.lower().strip(".")
+    return publicsuffix2.get_sld(normalized) or normalized
 
 
 def _aligned(signing_domain: str, from_domain: str) -> bool:
@@ -115,22 +149,26 @@ def _extract_from(msg: Message) -> tuple[str, str, str | None]:
     return raw, domain, addr
 
 
-def _dkim_verify_sync(raw: bytes, dnsfunc: DnsFunc | None, timeout: float) -> dict[str, Any]:
-    """REQ-1.2: crypto-verify the first DKIM-Signature. Returns structured result.
+def _dkim_verify_sync(raw: bytes, dnsfunc: DnsFunc | None, timeout: float, from_domain: str) -> DkimResult:
+    """REQ-1.2: crypto-verify the first DKIM-Signature and check alignment.
 
-    ``aligned`` is set to False here — the caller computes alignment against
-    the RFC-5322 From domain once both values are known.
+    Alignment is folded into this function so the returned :class:`DkimResult`
+    is complete — no post-hoc field mutation required at the call site.
     """
-    has_header = b"dkim-signature:" in raw.lower()
-    if not has_header:
-        return dict(_EMPTY_DKIM)
+    if b"dkim-signature:" not in raw.lower():
+        return DkimResult()
     d = dkim.DKIM(raw, timeout=int(timeout))
     try:
-        valid = d.verify(dnsfunc=dnsfunc) if dnsfunc is not None else d.verify()
+        valid = bool(d.verify(dnsfunc=dnsfunc) if dnsfunc is not None else d.verify())
     except dkim.DKIMException:
-        return {"present": True, "valid": False, "d": None, "aligned": False}
+        return DkimResult(present=True)
     signing = d.domain.decode().lower() if d.domain else None
-    return {"present": True, "valid": bool(valid), "d": signing, "aligned": False}
+    return DkimResult(
+        present=True,
+        valid=valid,
+        d=signing,
+        aligned=valid and signing is not None and _aligned(signing, from_domain),
+    )
 
 
 def _arc_verify_sync(
@@ -140,28 +178,27 @@ def _arc_verify_sync(
     timeout: float,
     trusted_sealers: set[str],
     from_domain: str,
-) -> dict[str, Any]:
+) -> ArcResult:
     """REQ-3: verify ARC chain and check innermost Auth-Results for aligned DKIM."""
-    has_header = b"arc-seal:" in raw.lower()
-    if not has_header:
-        return dict(_EMPTY_ARC)
+    if b"arc-seal:" not in raw.lower():
+        return ArcResult()
     a = dkim.ARC(raw, timeout=int(timeout))
     try:
         cv, _results, _reason = a.verify(dnsfunc=dnsfunc) if dnsfunc is not None else a.verify()
     except dkim.DKIMException:
-        return {**_EMPTY_ARC, "present": True, "valid": False}
+        return ArcResult(present=True)
 
     valid = cv == dkim.CV_Pass
     sealer = a.domain.decode().lower() if a.domain else None
     trusted = sealer in trusted_sealers if sealer else False
     aligned_from = valid and trusted and _arc_inner_dkim_aligned(msg, from_domain)
-    return {
-        "present": True,
-        "valid": valid,
-        "sealer": sealer,
-        "trusted": trusted,
-        "aligned_from_domain": aligned_from,
-    }
+    return ArcResult(
+        present=True,
+        valid=valid,
+        sealer=sealer,
+        trusted=trusted,
+        aligned_from_domain=aligned_from,
+    )
 
 
 def _arc_inner_dkim_aligned(msg: Message, from_domain: str) -> bool:
@@ -171,7 +208,7 @@ def _arc_inner_dkim_aligned(msg: Message, from_domain: str) -> bool:
     ARC-Authentication-Results header is prefixed with ``i=N;`` followed by
     an ordinary Authentication-Results body.
     """
-    parsed: list[tuple[int, AuthenticationResultsHeader]] = []
+    parsed: list[tuple[int, Any]] = []
     for raw in msg.get_all("ARC-Authentication-Results", []) or []:
         try:
             prefix, _, rest = raw.partition(";")
@@ -203,13 +240,13 @@ def _arc_inner_dkim_aligned(msg: Message, from_domain: str) -> bool:
     return False
 
 
-def _trusted_auth_results(msg: Message, authserv_id: str) -> list[AuthenticationResultsHeader]:
+def _trusted_auth_results(msg: Message, authserv_id: str) -> list[Any]:
     """Return only Authentication-Results stamped by the configured authserv-id.
 
     REQ-2.4 trust boundary: a sender-injected Authentication-Results header is
     attacker-controlled and MUST be ignored.
     """
-    out: list[AuthenticationResultsHeader] = []
+    out: list[Any] = []
     wanted = authserv_id.lower()
     for raw in msg.get_all("Authentication-Results", []) or []:
         try:
@@ -223,7 +260,7 @@ def _trusted_auth_results(msg: Message, authserv_id: str) -> list[Authentication
     return out
 
 
-def _spf_from_auth_results(ars: list[AuthenticationResultsHeader], from_domain: str) -> dict[str, Any]:
+def _spf_from_auth_results(ars: list[Any], from_domain: str) -> SpfResult:
     """REQ-2.1: pull SPF verdict + alignment from trusted Authentication-Results."""
     for ar in ars:
         for r in ar.results:
@@ -236,12 +273,39 @@ def _spf_from_auth_results(ars: list[AuthenticationResultsHeader], from_domain: 
                     _, _, mailfrom_domain = p.value.rpartition("@")
                     mailfrom_domain = mailfrom_domain.lower()
                     break
-            return {
-                "result": result or "absent",
-                "smtp_mailfrom_domain": mailfrom_domain,
-                "aligned": result == "pass" and _aligned(mailfrom_domain, from_domain),
-            }
-    return dict(_EMPTY_SPF)
+            return SpfResult(
+                result=result or "absent",
+                smtp_mailfrom_domain=mailfrom_domain,
+                aligned=result == "pass" and _aligned(mailfrom_domain, from_domain),
+            )
+    return SpfResult()
+
+
+def _verdict(dkim_r: DkimResult, arc_r: ArcResult) -> RejectReason:
+    """Return empty string on accept, REQ-4.1 reason code on reject.
+
+    Accept iff one of:
+
+    - DKIM valid AND aligned to From domain (REQ-1.2)
+    - ARC valid AND sealer trusted AND inner DKIM aligned to From (REQ-3.2)
+    """
+    if dkim_r.valid and dkim_r.aligned:
+        return ""
+    if arc_r.valid and arc_r.trusted and arc_r.aligned_from_domain:
+        return ""
+
+    # Ordered most-specific-first so log `reason` codes are actionable.
+    if arc_r.present and arc_r.valid and not arc_r.trusted:
+        return "arc_untrusted_sealer"
+    if arc_r.present and not arc_r.valid:
+        return "arc_invalid"
+    if dkim_r.present and dkim_r.valid and not dkim_r.aligned:
+        return "dkim_misaligned"
+    if dkim_r.present and not dkim_r.valid:
+        return "dkim_invalid"
+    if not dkim_r.present and not arc_r.present:
+        return "no_dkim_signature"
+    return "no_auth_signal"
 
 
 async def verify_mail_auth(
@@ -257,6 +321,10 @@ async def verify_mail_auth(
     Runs synchronous DKIM/ARC verification in a thread with a hard wall-clock
     ceiling (REQ-1.4). Any unhandled exception from the verify libraries is
     caught and mapped to ``reason="malformed_headers"`` (REQ-9, fail-closed).
+
+    The returned :class:`MailAuthResult` carries the parsed ``Message`` so
+    callers don't re-parse the raw bytes; ``message_id`` is extracted once
+    here for the same reason.
     """
     authserv = authserv_id or settings.imap_authserv_id
     trusted_sealers = {s.lower() for s in (trusted_arc_sealers or settings.imap_trusted_arc_sealers)}
@@ -265,13 +333,14 @@ async def verify_mail_auth(
     try:
         msg = email.message_from_bytes(raw_message)
     except Exception:
-        # REQ-9 fail-closed: any parse error means we cannot trust the envelope.
         logger.debug("mail_auth_parse_failed", exc_info=True)
-        return _reject("", "", "malformed_headers")
+        return _reject("", "", "<unknown>", "malformed_headers", parsed_message=None)
 
     from_header, from_domain, verified_from_addr = _extract_from(msg)
+    message_id = msg.get("Message-ID") or "<unknown>"
+
     if not from_domain or not verified_from_addr:
-        return _reject(from_header, "", "malformed_headers")
+        return _reject(from_header, "", message_id, "malformed_headers", parsed_message=msg)
 
     try:
         dkim_r, arc_r = await asyncio.wait_for(
@@ -287,37 +356,24 @@ async def verify_mail_auth(
             timeout=timeout,
         )
     except TimeoutError:
-        return _reject(from_header, from_domain, "dkim_timeout")
+        return _reject(from_header, from_domain, message_id, "dkim_timeout", parsed_message=msg)
     except Exception:
-        # REQ-9 fail-closed: any unhandled verify error → reject as malformed.
         logger.debug("mail_auth_verify_unexpected_error", exc_info=True)
-        return _reject(from_header, from_domain, "malformed_headers")
-
-    # Alignment check: cheap string-compare; kept out of the threaded block.
-    if dkim_r["valid"] and dkim_r["d"]:
-        dkim_r["aligned"] = _aligned(dkim_r["d"], from_domain)
+        return _reject(from_header, from_domain, message_id, "malformed_headers", parsed_message=msg)
 
     spf_r = _spf_from_auth_results(_trusted_auth_results(msg, authserv), from_domain)
 
     reason = _verdict(dkim_r, arc_r)
-    if not reason:
-        return MailAuthResult(
-            dkim_result=dkim_r,
-            spf_result=spf_r,
-            arc_result=arc_r,
-            from_header=from_header,
-            from_domain=from_domain,
-            verified_from=verified_from_addr,
-            reason="",
-        )
     return MailAuthResult(
         dkim_result=dkim_r,
         spf_result=spf_r,
         arc_result=arc_r,
         from_header=from_header,
         from_domain=from_domain,
-        verified_from=None,
+        message_id=message_id,
+        verified_from=verified_from_addr if reason == "" else None,
         reason=reason,
+        parsed_message=msg,
     )
 
 
@@ -328,48 +384,46 @@ def _verify_crypto_sync(
     timeout: float,
     trusted_sealers: set[str],
     from_domain: str,
-) -> tuple[dict[str, Any], dict[str, Any]]:
+) -> tuple[DkimResult, ArcResult]:
     """Run DKIM + ARC verify inside one thread offload. Must not raise."""
     return (
-        _dkim_verify_sync(raw, dnsfunc, timeout),
+        _dkim_verify_sync(raw, dnsfunc, timeout, from_domain),
         _arc_verify_sync(raw, msg, dnsfunc, timeout, trusted_sealers, from_domain),
     )
 
 
-def _verdict(dkim_r: dict[str, Any], arc_r: dict[str, Any]) -> RejectReason:
-    """Return empty string on accept, REQ-4.1 reason code on reject.
-
-    Accept iff one of:
-    - DKIM valid AND aligned to From domain (REQ-1.2)
-    - ARC valid AND sealer trusted AND inner DKIM aligned to From (REQ-3.2)
-    """
-    if dkim_r["valid"] and dkim_r["aligned"]:
-        return ""
-    if arc_r["valid"] and arc_r["trusted"] and arc_r["aligned_from_domain"]:
-        return ""
-
-    # Ordered most-specific-first so log `reason` codes are actionable.
-    if arc_r["present"] and arc_r["valid"] and not arc_r["trusted"]:
-        return "arc_untrusted_sealer"
-    if arc_r["present"] and not arc_r["valid"]:
-        return "arc_invalid"
-    if dkim_r["present"] and dkim_r["valid"] and not dkim_r["aligned"]:
-        return "dkim_misaligned"
-    if dkim_r["present"] and not dkim_r["valid"]:
-        return "dkim_invalid"
-    if not dkim_r["present"] and not arc_r["present"]:
-        return "no_dkim_signature"
-    return "no_auth_signal"
-
-
-def _reject(from_header: str, from_domain: str, reason: RejectReason) -> MailAuthResult:
+def _reject(
+    from_header: str,
+    from_domain: str,
+    message_id: str,
+    reason: RejectReason,
+    *,
+    parsed_message: Message | None,
+) -> MailAuthResult:
     """Shortcut for constructing a rejected MailAuthResult with empty sub-results."""
     return MailAuthResult(
-        dkim_result=dict(_EMPTY_DKIM),
-        spf_result=dict(_EMPTY_SPF),
-        arc_result=dict(_EMPTY_ARC),
+        dkim_result=DkimResult(),
+        spf_result=SpfResult(),
+        arc_result=ArcResult(),
         from_header=from_header,
         from_domain=from_domain,
+        message_id=message_id,
         verified_from=None,
         reason=reason,
+        parsed_message=parsed_message,
     )
+
+
+def result_log_fields(auth: MailAuthResult) -> dict[str, Any]:
+    """Flatten sub-results to a queryable log-field dict.
+
+    Used by :mod:`app.services.imap_listener` to build the
+    ``imap_auth_passed`` / ``imap_auth_failed`` structlog entries without
+    callers ever touching :class:`DkimResult` / :class:`SpfResult` /
+    :class:`ArcResult` internals directly.
+    """
+    return {
+        "dkim_result": dataclasses.asdict(auth.dkim_result),
+        "spf_result": dataclasses.asdict(auth.spf_result),
+        "arc_result": dataclasses.asdict(auth.arc_result),
+    }

--- a/klai-portal/backend/tests/services/test_mail_auth.py
+++ b/klai-portal/backend/tests/services/test_mail_auth.py
@@ -14,6 +14,7 @@ Strategy:
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 from typing import Any
 from unittest.mock import patch
 
@@ -102,8 +103,8 @@ class TestAC1_NoDkim:
         assert result.reason == "no_dkim_signature"
         assert result.from_header.strip() == "ceo@customer.nl"
         assert result.from_domain == "customer.nl"
-        assert result.dkim_result["present"] is False
-        assert result.arc_result["present"] is False
+        assert result.dkim_result.present is False
+        assert result.arc_result.present is False
 
 
 # ---------- AC-2: DKIM valid but misaligned -------------------------------
@@ -126,9 +127,9 @@ class TestAC2_DkimMisaligned:
 
         assert result.verified_from is None
         assert result.reason == "dkim_misaligned"
-        assert result.dkim_result["valid"] is True
-        assert result.dkim_result["d"] == "spammer.net"
-        assert result.dkim_result["aligned"] is False
+        assert result.dkim_result.valid is True
+        assert result.dkim_result.d == "spammer.net"
+        assert result.dkim_result.aligned is False
         assert result.from_domain == "customer.nl"
 
 
@@ -152,8 +153,8 @@ class TestAC3AC4_DkimValidAligned:
 
         assert result.verified_from == "boss@customer.nl"
         assert result.reason == ""
-        assert result.dkim_result["valid"] is True
-        assert result.dkim_result["aligned"] is True
+        assert result.dkim_result.valid is True
+        assert result.dkim_result.aligned is True
         assert result.from_domain == "customer.nl"
 
     @pytest.mark.asyncio
@@ -170,8 +171,8 @@ class TestAC3AC4_DkimValidAligned:
 
         assert result.verified_from == "someone@gmail.com"
         assert result.reason == ""
-        assert result.dkim_result["valid"] is True
-        assert result.dkim_result["aligned"] is True
+        assert result.dkim_result.valid is True
+        assert result.dkim_result.aligned is True
 
     @pytest.mark.asyncio
     async def test_dkim_valid_org_domain_alignment(self) -> None:
@@ -187,7 +188,7 @@ class TestAC3AC4_DkimValidAligned:
         )
 
         assert result.verified_from == "user@mail.customer.nl"
-        assert result.dkim_result["aligned"] is True
+        assert result.dkim_result.aligned is True
 
 
 # ---------- AC-5: Valid ARC from trusted sealer (forwarded) ---------------
@@ -238,10 +239,10 @@ class TestAC5_ArcTrustedForwarded:
 
         assert result.verified_from == "boss@customer.nl"
         assert result.reason == ""
-        assert result.arc_result["valid"] is True
-        assert result.arc_result["sealer"] == "google.com"
-        assert result.arc_result["trusted"] is True
-        assert result.arc_result["aligned_from_domain"] is True
+        assert result.arc_result.valid is True
+        assert result.arc_result.sealer == "google.com"
+        assert result.arc_result.trusted is True
+        assert result.arc_result.aligned_from_domain is True
 
 
 # ---------- AC-6: ARC from untrusted sealer -------------------------------
@@ -286,9 +287,9 @@ class TestAC6_ArcUntrustedSealer:
 
         assert result.verified_from is None
         assert result.reason == "arc_untrusted_sealer"
-        assert result.arc_result["valid"] is True
-        assert result.arc_result["sealer"] == "weird-provider.example"
-        assert result.arc_result["trusted"] is False
+        assert result.arc_result.valid is True
+        assert result.arc_result.sealer == "weird-provider.example"
+        assert result.arc_result.trusted is False
 
 
 # ---------- AC-8: Verification timeout ------------------------------------
@@ -361,18 +362,31 @@ class TestAC9_Malformed:
 
 
 class TestAC11_ResultSchema:
-    """Every MailAuthResult contains the same top-level keys regardless of verdict."""
+    """Every MailAuthResult carries the same typed sub-results regardless of verdict.
+
+    The :class:`DkimResult` / :class:`SpfResult` / :class:`ArcResult` frozen
+    dataclasses replace the previous ``dict[str, Any]`` shape, so a typo in
+    a field access is now a pyright / runtime error rather than a silent
+    KeyError-or-None in prod.
+    """
 
     @pytest.mark.asyncio
     async def test_reject_result_has_stable_shape(self) -> None:
         raw = build_email(from_addr="ceo@customer.nl")
         result = await verify_mail_auth(raw)
 
-        # MailAuthResult is a frozen dataclass with a fixed shape; the
-        # listener will pull these into the imap_auth_failed log.
-        assert set(result.dkim_result.keys()) == {"present", "valid", "d", "aligned"}
-        assert set(result.spf_result.keys()) == {"result", "smtp_mailfrom_domain", "aligned"}
-        assert set(result.arc_result.keys()) == {
+        assert {f.name for f in dataclasses.fields(result.dkim_result)} == {
+            "present",
+            "valid",
+            "d",
+            "aligned",
+        }
+        assert {f.name for f in dataclasses.fields(result.spf_result)} == {
+            "result",
+            "smtp_mailfrom_domain",
+            "aligned",
+        }
+        assert {f.name for f in dataclasses.fields(result.arc_result)} == {
             "present",
             "valid",
             "sealer",
@@ -403,14 +417,8 @@ class TestAC11_ResultSchema:
 
         assert result.verified_from == "user@accept-shape.test"
         assert result.reason == ""
-        assert set(result.dkim_result.keys()) == {"present", "valid", "d", "aligned"}
-        assert set(result.arc_result.keys()) == {
-            "present",
-            "valid",
-            "sealer",
-            "trusted",
-            "aligned_from_domain",
-        }
+        assert result.parsed_message is not None
+        assert result.message_id  # non-empty; either real or "<unknown>"
 
 
 # ---------- REQ-2.1: SPF alignment pulled from trusted Auth-Results --------
@@ -436,9 +444,9 @@ class TestSPFFromAuthResults:
         result = await verify_mail_auth(raw, dnsfunc=make_dnsfunc(k), authserv_id="mail.getklai.com")
 
         assert result.verified_from == "boss@spf-aligned.test"
-        assert result.spf_result["result"] == "pass"
-        assert result.spf_result["smtp_mailfrom_domain"] == "spf-aligned.test"
-        assert result.spf_result["aligned"] is True
+        assert result.spf_result.result == "pass"
+        assert result.spf_result.smtp_mailfrom_domain == "spf-aligned.test"
+        assert result.spf_result.aligned is True
 
     @pytest.mark.asyncio
     async def test_spf_misaligned_not_marked_aligned(self) -> None:
@@ -459,9 +467,9 @@ class TestSPFFromAuthResults:
 
         # DKIM-aligned accept still happens; SPF is a soft signal per REQ-2.2.
         assert result.verified_from == "boss@dkim-only.com"
-        assert result.spf_result["result"] == "pass"
-        assert result.spf_result["aligned"] is False
-        assert result.spf_result["smtp_mailfrom_domain"] == "mail-relay.com"
+        assert result.spf_result.result == "pass"
+        assert result.spf_result.aligned is False
+        assert result.spf_result.smtp_mailfrom_domain == "mail-relay.com"
 
     @pytest.mark.asyncio
     async def test_authserv_id_filter_ignores_sender_injected_auth_results(self) -> None:
@@ -488,8 +496,8 @@ class TestSPFFromAuthResults:
         # DKIM alignment still carries the accept; SPF signal from untrusted
         # header is discarded (result stays "absent").
         assert result.verified_from == "boss@dkim-only-again.test"
-        assert result.spf_result["result"] == "absent"
-        assert result.spf_result["aligned"] is False
+        assert result.spf_result.result == "absent"
+        assert result.spf_result.aligned is False
 
 
 # ---------- REQ-3: ARC edge cases -----------------------------------------
@@ -533,8 +541,8 @@ class TestARCEdgeCases:
         # signal remains → no_auth_signal.
         assert result.verified_from is None
         assert result.reason == "no_auth_signal"
-        assert result.arc_result["aligned_from_domain"] is False
-        assert result.arc_result["trusted"] is True
+        assert result.arc_result.aligned_from_domain is False
+        assert result.arc_result.trusted is True
 
     @pytest.mark.asyncio
     async def test_arc_inner_dkim_fail_does_not_align(self) -> None:
@@ -562,7 +570,7 @@ class TestARCEdgeCases:
             result = await verify_mail_auth(raw, trusted_arc_sealers=["google.com"], timeout_seconds=5.0)
 
         assert result.verified_from is None
-        assert result.arc_result["aligned_from_domain"] is False
+        assert result.arc_result.aligned_from_domain is False
 
     @pytest.mark.asyncio
     async def test_arc_cv_fail_yields_arc_invalid(self) -> None:
@@ -607,8 +615,8 @@ class TestARCEdgeCases:
             result = await verify_mail_auth(raw, trusted_arc_sealers=["google.com"], timeout_seconds=5.0)
 
         assert result.verified_from is None
-        assert result.arc_result["valid"] is False
-        assert result.arc_result["present"] is True
+        assert result.arc_result.valid is False
+        assert result.arc_result.present is True
 
 
 # ---------- REQ-1: DKIM exception + invalid sig variants ------------------
@@ -631,8 +639,8 @@ class TestDkimInvalidBranches:
 
         assert result.verified_from is None
         assert result.reason == "dkim_invalid"
-        assert result.dkim_result["present"] is True
-        assert result.dkim_result["valid"] is False
+        assert result.dkim_result.present is True
+        assert result.dkim_result.valid is False
 
     @pytest.mark.asyncio
     async def test_arc_with_dkim_invalid_and_no_arc_header_yields_dkim_invalid(

--- a/klai-portal/backend/tests/test_imap_listener.py
+++ b/klai-portal/backend/tests/test_imap_listener.py
@@ -77,6 +77,23 @@ def test_no_ics_in_email() -> None:
     assert parts == []
 
 
+def _make_verified_result(raw_email: bytes, from_addr: str):
+    """Build a passing MailAuthResult for tests that isolate the post-auth flow."""
+    from app.services.mail_auth import ArcResult, DkimResult, MailAuthResult, SpfResult
+
+    return MailAuthResult(
+        dkim_result=DkimResult(present=True, valid=True, d="example.com", aligned=True),
+        spf_result=SpfResult(result="pass", smtp_mailfrom_domain="example.com", aligned=True),
+        arc_result=ArcResult(),
+        from_header=from_addr,
+        from_domain="example.com",
+        message_id="<test@example.com>",
+        verified_from=from_addr,
+        reason="",
+        parsed_message=email.message_from_bytes(raw_email),
+    )
+
+
 @pytest.mark.asyncio
 async def test_process_email_with_valid_invite() -> None:
     """A mail-auth-verified .ics email triggers tenant lookup and scheduling.
@@ -89,24 +106,7 @@ async def test_process_email_with_valid_invite() -> None:
     """
     ics_bytes = (FIXTURES / "google_meet.ics").read_bytes()
     raw_email = _make_email_with_ics(ics_bytes)
-
-    from app.services.mail_auth import MailAuthResult
-
-    verified = MailAuthResult(
-        dkim_result={"present": True, "valid": True, "d": "example.com", "aligned": True},
-        spf_result={"result": "pass", "smtp_mailfrom_domain": "example.com", "aligned": True},
-        arc_result={
-            "present": False,
-            "valid": False,
-            "sealer": None,
-            "trusted": False,
-            "aligned_from_domain": False,
-        },
-        from_header="calendar@example.com",
-        from_domain="example.com",
-        verified_from="calendar@example.com",
-        reason="",
-    )
+    verified = _make_verified_result(raw_email, "calendar@example.com")
 
     mock_imap = MagicMock()
     mock_imap.fetch = MagicMock(return_value=("OK", [(b"1", raw_email)]))
@@ -180,24 +180,7 @@ async def test_graceful_when_no_ics() -> None:
     This test mocks verify_mail_auth to isolate the "no ICS" branch.
     """
     raw_email = MIMEText("Just a plain email").as_bytes()
-
-    from app.services.mail_auth import MailAuthResult
-
-    verified = MailAuthResult(
-        dkim_result={"present": True, "valid": True, "d": "example.com", "aligned": True},
-        spf_result={"result": "pass", "smtp_mailfrom_domain": "example.com", "aligned": True},
-        arc_result={
-            "present": False,
-            "valid": False,
-            "sealer": None,
-            "trusted": False,
-            "aligned_from_domain": False,
-        },
-        from_header="sender@example.com",
-        from_domain="example.com",
-        verified_from="sender@example.com",
-        reason="",
-    )
+    verified = _make_verified_result(raw_email, "sender@example.com")
 
     mock_imap = MagicMock()
     mock_imap.fetch = MagicMock(return_value=("OK", [(b"1", raw_email)]))


### PR DESCRIPTION
## Summary

Follow-up to [PR #165](https://github.com/GetKlai/klai/pull/165) — cleans up the tech debt identified in the post-merge self-review. **No behavioural change** — every reason code, log key, and reject decision is identical to what shipped.

The SPEC-SEC-IMAP-001 caller contract is unchanged: gate on `verified_from is not None`.

## What's removed (tech debt)

- `dict[str, Any]` sub-results. A typo in `auth.dkim_result["valid_typo"]` previously failed silently with `KeyError` at runtime. Now it's a pyright error.
- Double `email.message_from_bytes(raw_bytes)` per invite — once in `verify_mail_auth`, once in the listener. Now parsed once, reused via `MailAuthResult.parsed_message`.
- `_EMPTY_DKIM["aligned"]=False` placeholder that was mutated post-hoc at the call site (`dkim_r["aligned"] = _aligned(...)`). Alignment now computed inside `_dkim_verify_sync` so the returned `DkimResult` is complete on construction.
- Mixed stdlib `logger` + `struct_logger` pair in `imap_listener.py`. Every event goes through `structlog.get_logger()` now with stable queryable keys.

## What's added (correctness stronger, API cleaner)

- `DkimResult` / `SpfResult` / `ArcResult` — frozen dataclasses with `dataclasses.fields()`-verifiable shape.
- `MailAuthResult.parsed_message: Message | None` — the parsed RFC-822 message. `None` only on the rare `malformed_headers` branch from a raise inside `message_from_bytes`; documented invariant in the docstring.
- `MailAuthResult.message_id: str` — extracted once; surfaced directly to the log site.
- `result_log_fields(auth)` — flattens sub-results via `dataclasses.asdict` for structlog kwargs. Log-boundary logic lives in one place.
- `imap_listener.py` structlog events with stable keys: `imap_poll_error`, `imap_poll_found_unseen`, `imap_process_email_failed`, `imap_logout_failed`, `imap_no_ics_content`.

## Test impact

- 1132 tests passed (was 1117 baseline; other PRs added 15)
- Coverage on `mail_auth.py`: **95%** (up from 94%)
- ruff (check + format) + pyright: clean
- Structural `TestAC11_ResultSchema` uses `dataclasses.fields()` instead of `dict.keys()`
- `_make_verified_result()` helper in `tests/test_imap_listener.py` for the pre-existing tests

## Risk assessment

Zero behaviour change. The refactor is internal API restructuring. The same log-output shape is preserved at the VictoriaLogs boundary (structlog kwargs flatten to identical keys), so any alerting/dashboard query on `event:imap_auth_passed OR event:imap_auth_failed` keeps working.

## Test plan

- [ ] CI `quality` green (ruff format + ruff check + pyright + pytest)
- [ ] Post-merge: smoke-test the production container the same way PR #165 verified — force a reject with a forged-From email; confirm `reason="no_dkim_signature"`
- [ ] Post-merge: **also verify the accept path** — pull one real message from `meet@getklai.com` via `imap.fetch(..., '(RFC822)')` and run `verify_mail_auth` on it; confirm `verified_from` is set and `dkim_result.aligned is True`. This is the research.md prerequisite that PR #165 deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)