### PR TITLE
chore(infra): klai-mailer INTERNAL_SECRET via compose environment

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -312,6 +312,13 @@ services:
     ports:
       - "127.0.0.1:8001:8000"
     env_file: ./klai-mailer/.env
+    environment:
+      # Cross-service shared secret — single source of truth in /opt/klai/.env.
+      # Portal-api sends `X-Internal-Secret: ${PORTAL_API_INTERNAL_SECRET}` when
+      # calling /internal/send; mailer compares via hmac.compare_digest
+      # (SPEC-SEC-MAILER-INJECTION-001 REQ-8). Wiring via `environment:` instead
+      # of duplicating into klai-mailer/.env keeps rotation atomic.
+      INTERNAL_SECRET: ${PORTAL_API_INTERNAL_SECRET}
     networks:
       - klai-net
 


### PR DESCRIPTION
## Summary

SPEC-SEC-MAILER-INJECTION-001 follow-up cleanup.

Wire `INTERNAL_SECRET` from `\${PORTAL_API_INTERNAL_SECRET}` (single source of truth in `/opt/klai/.env`) into klai-mailer via the compose `environment:` block, instead of duplicating the value into `/opt/klai/klai-mailer/.env`.

Mirrors how portal-api already wires it (compose.yml:331) — same pattern across both ends of the `X-Internal-Secret` call.

## Background

After SPEC-SEC-MAILER-INJECTION-001 deployed, the mailer crash-looped because `INTERNAL_SECRET` was missing from its env (REQ-9.2 made it required). Hotfix on 2026-04-24 appended `INTERNAL_SECRET=<value>` to `/opt/klai/klai-mailer/.env` — but that duplicated the secret already in `/opt/klai/.env` as `PORTAL_API_INTERNAL_SECRET`. Rotating the canonical value would silently desync mailer auth.

This PR removes the dupe by wiring through compose, which is the same pattern portal-api uses.

## Test plan

- [ ] CI green (deploy-compose.yml will auto-sync compose to core-01)
- [ ] After merge: `ssh core-01 'cd /opt/klai && docker compose up -d klai-mailer'` — picks up new env layer
- [ ] `ssh core-01 'curl -fsS http://127.0.0.1:8001/health'` returns `{"status":"ok"}`
- [ ] `docker exec klai-core-klai-mailer-1 printenv INTERNAL_SECRET` matches portal-api's value
- [ ] Cleanup commit (separate, after verification): remove `INTERNAL_SECRET=...` from `/opt/klai/klai-mailer/.env` + remove backup file

🤖 Generated with [Claude Code](https://claude.com/claude-code)