### PR TITLE
fix(portal-api): real ARC sealer extraction + production-correct defaults (SPEC-SEC-IMAP-001)

### DIFF
--- a/klai-portal/backend/app/core/config.py
+++ b/klai-portal/backend/app/core/config.py
@@ -216,18 +216,22 @@ class Settings(BaseSettings):
     invite_bot_rate_limit_per_user_per_day: int = 10
 
     # SPEC-SEC-IMAP-001: mail-auth (DKIM/SPF/ARC) enforcement on the listener.
-    # `imap_authserv_id` is the authserv-id written into Authentication-Results
-    # by the trusted upstream relay (`mail.getklai.com`). Only auth-results
-    # stamped by that authserv-id are consulted; sender-injected headers are
-    # ignored.
-    imap_authserv_id: str = "mail.getklai.com"
+    # `imap_authserv_id` is the authserv-id stamped into Authentication-Results
+    # by the trusted upstream relay. Only auth-results from that authserv-id
+    # are consulted; sender-injected headers are ignored. The default matches
+    # the cloud86 hosting relay observed in production headers (April 2026);
+    # override via PORTAL_API_IMAP_AUTHSERV_ID after a hosting-provider change.
+    imap_authserv_id: str = "shared199.cloud86-host.io"
     # Per-message wall-clock timeout for the synchronous DKIM/ARC verify call
     # (runs in `asyncio.to_thread` with `asyncio.wait_for`).
     imap_auth_timeout_seconds: float = 5.0
     # Allowlist of ARC sealing domains (`d=` of the outermost valid ARC-Seal)
-    # whose `ARC-Authentication-Results` we accept when DKIM direct alignment
-    # is broken (legitimate mailing-list / forwarded mail).
+    # whose `ARC-Authentication-Results` we accept when direct DKIM alignment
+    # is broken — legitimate forwarded mail. `getklai.com` is in this list
+    # because the operator-controlled mail.getklai.com MX seals every inbound
+    # invite, and that seal is the trusted boundary for our IMAP ingress.
     imap_trusted_arc_sealers: list[str] = [
+        "getklai.com",
         "google.com",
         "outlook.com",
         "icloud.com",

--- a/klai-portal/backend/app/services/mail_auth.py
+++ b/klai-portal/backend/app/services/mail_auth.py
@@ -184,12 +184,12 @@ def _arc_verify_sync(
         return ArcResult()
     a = dkim.ARC(raw, timeout=int(timeout))
     try:
-        cv, _results, _reason = a.verify(dnsfunc=dnsfunc) if dnsfunc is not None else a.verify()
+        cv, results, _reason = a.verify(dnsfunc=dnsfunc) if dnsfunc is not None else a.verify()
     except dkim.DKIMException:
         return ArcResult(present=True)
 
     valid = cv == dkim.CV_Pass
-    sealer = a.domain.decode().lower() if a.domain else None
+    sealer = _outermost_arc_sealer(results)
     trusted = sealer in trusted_sealers if sealer else False
     aligned_from = valid and trusted and _arc_inner_dkim_aligned(msg, from_domain)
     return ArcResult(
@@ -199,6 +199,24 @@ def _arc_verify_sync(
         trusted=trusted,
         aligned_from_domain=aligned_from,
     )
+
+
+def _outermost_arc_sealer(results: list[dict[str, Any]] | None) -> str | None:
+    """Return the ``d=`` of the outermost ARC-Seal (highest ``instance``).
+
+    ``dkim.ARC.verify`` returns the sealing domain inside its results list as
+    ``as-domain``; the ``ARC.domain`` attribute is only populated for signing
+    flows, not verification, so we cannot read it from there.
+    """
+    if not results:
+        return None
+    outermost = max(results, key=lambda r: r.get("instance", 0))
+    as_domain = outermost.get("as-domain")
+    if isinstance(as_domain, (bytes, bytearray)):
+        return as_domain.decode(errors="replace").lower()
+    if isinstance(as_domain, str):
+        return as_domain.lower()
+    return None
 
 
 def _arc_inner_dkim_aligned(msg: Message, from_domain: str) -> bool:

--- a/klai-portal/backend/tests/services/test_mail_auth.py
+++ b/klai-portal/backend/tests/services/test_mail_auth.py
@@ -25,6 +25,7 @@ from app.services.mail_auth import (
     MailAuthResult,
     _aligned,
     _organizational_domain,
+    _outermost_arc_sealer,
     verify_mail_auth,
 )
 from tests.services.fixtures.imap.builders import (
@@ -81,6 +82,33 @@ class TestAlignmentHelpers:
     )
     def test_distinct_slds_under_public_suffix_do_not_align(self, a: str, b: str) -> None:
         assert _aligned(a, b) is False
+
+
+class TestArcSealerExtraction:
+    """Regression for an April 2026 production incident: ``dkim.ARC.verify()``
+    does NOT populate ``ARC.domain`` for verification flows; the sealing
+    domain is in ``results[*]['as-domain']``. The original implementation
+    read ``a.domain``, which silently returned ``sealer=None`` for every
+    legitimately-forwarded invite — every real customer message rejected.
+    """
+
+    def test_extracts_outermost_seal_domain_from_results(self) -> None:
+        results = [
+            {"instance": 1, "as-domain": b"google.com"},
+            {"instance": 2, "as-domain": b"getklai.com"},  # outermost
+        ]
+        assert _outermost_arc_sealer(results) == "getklai.com"
+
+    def test_lowercases_domain(self) -> None:
+        assert _outermost_arc_sealer([{"instance": 1, "as-domain": b"Google.COM"}]) == "google.com"
+
+    def test_accepts_str_value(self) -> None:
+        assert _outermost_arc_sealer([{"instance": 1, "as-domain": "fastmail.com"}]) == "fastmail.com"
+
+    def test_returns_none_on_missing_or_empty(self) -> None:
+        assert _outermost_arc_sealer(None) is None
+        assert _outermost_arc_sealer([]) is None
+        assert _outermost_arc_sealer([{"instance": 1}]) is None  # missing as-domain
 
 
 # ---------- AC-1: forged From, no DKIM -------------------------------------
@@ -228,8 +256,13 @@ class TestAC5_ArcTrustedForwarded:
             mock_dkim.domain = None
 
             mock_arc = mock_arc_cls.return_value
-            mock_arc.verify.return_value = (dkim.CV_Pass, [], "")
-            mock_arc.domain = b"google.com"
+            # dkim.ARC.verify returns (cv, results, reason); the sealing
+            # domain is in results[*]['as-domain'] (NOT in `a.domain`).
+            mock_arc.verify.return_value = (
+                dkim.CV_Pass,
+                [{"instance": 1, "as-domain": b"google.com"}],
+                "",
+            )
 
             result = await verify_mail_auth(
                 raw,
@@ -276,8 +309,11 @@ class TestAC6_ArcUntrustedSealer:
             mock_dkim.domain = None
 
             mock_arc = mock_arc_cls.return_value
-            mock_arc.verify.return_value = (dkim.CV_Pass, [], "")
-            mock_arc.domain = b"weird-provider.example"
+            mock_arc.verify.return_value = (
+                dkim.CV_Pass,
+                [{"instance": 1, "as-domain": b"weird-provider.example"}],
+                "",
+            )
 
             result = await verify_mail_auth(
                 raw,
@@ -531,8 +567,11 @@ class TestARCEdgeCases:
         ):
             mock_dkim_cls.return_value.verify.side_effect = dkim.DKIMException("broken")
             mock_dkim_cls.return_value.domain = None
-            mock_arc_cls.return_value.verify.return_value = (dkim.CV_Pass, [], "")
-            mock_arc_cls.return_value.domain = b"google.com"
+            mock_arc_cls.return_value.verify.return_value = (
+                dkim.CV_Pass,
+                [{"instance": 1, "as-domain": b"google.com"}],
+                "",
+            )
 
             result = await verify_mail_auth(raw, trusted_arc_sealers=["google.com"], timeout_seconds=5.0)
 
@@ -564,8 +603,11 @@ class TestARCEdgeCases:
         ):
             mock_dkim_cls.return_value.verify.side_effect = dkim.DKIMException("broken")
             mock_dkim_cls.return_value.domain = None
-            mock_arc_cls.return_value.verify.return_value = (dkim.CV_Pass, [], "")
-            mock_arc_cls.return_value.domain = b"google.com"
+            mock_arc_cls.return_value.verify.return_value = (
+                dkim.CV_Pass,
+                [{"instance": 1, "as-domain": b"google.com"}],
+                "",
+            )
 
             result = await verify_mail_auth(raw, trusted_arc_sealers=["google.com"], timeout_seconds=5.0)
 
@@ -587,8 +629,11 @@ class TestARCEdgeCases:
         ):
             mock_dkim_cls.return_value.verify.side_effect = dkim.DKIMException("broken")
             mock_dkim_cls.return_value.domain = None
-            mock_arc_cls.return_value.verify.return_value = (dkim.CV_Fail, [], "")
-            mock_arc_cls.return_value.domain = b"google.com"
+            mock_arc_cls.return_value.verify.return_value = (
+                dkim.CV_Fail,
+                [{"instance": 1, "as-domain": b"google.com"}],
+                "",
+            )
 
             result = await verify_mail_auth(raw, trusted_arc_sealers=["google.com"], timeout_seconds=5.0)
 


### PR DESCRIPTION
## Production-blocker found in live verification

After PR #172 deployed, I ran the research.md prerequisite check that PR #165 had deferred — pulling a real meeting invite from `meet@getklai.com` and running it through `verify_mail_auth` on the production container. **Result: rejected.** Two bugs that the synthetic test suite missed.

## Bug 1 — sealer always read as None

`dkim.ARC.verify()` does NOT populate `ARC.domain` for verification flows; the attribute is only set on signing. The sealing domain on a verified chain lives in `results[*]['as-domain']` (bytes). The original implementation read `a.domain`, got `None` back, and consequently:

```
arc_result.sealer:  None
arc_result.trusted: False
arc_result.aligned_from_domain: False
verdict:            arc_untrusted_sealer
```

…on **every** legitimately-forwarded invite.

## Bug 2 — defaults targeted the wrong relay

The actual production mail path is `shared199.cloud86-host.io` (the cloud86 hosting MX), not `mail.getklai.com`. Authentication-Results from the real relay carry the cloud86 authserv-id, and the ARC seal that wraps every inbound invite is `d=getklai.com s=cloud86`. Fixed:

| Setting | Was | Now |
|---|---|---|
| `imap_authserv_id` | `mail.getklai.com` | `shared199.cloud86-host.io` |
| `imap_trusted_arc_sealers` | `[google, outlook, icloud, fastmail, protonmail]` | `[**getklai.com**, google, outlook, icloud, fastmail, protonmail]` |

`getklai.com` belongs in the allowlist because the operator-controlled `mail.getklai.com` MX seals every inbound invite, and that seal is the trust boundary for our IMAP ingress.

## Why the test suite missed this

My synthetic test mocks did `mock_arc.verify.return_value = (CV_Pass, [], "")` and `mock_arc.domain = b"google.com"` — they tested the wrong attribute the same way the real code did. Both pieces of code agreed on a wrong assumption. The new `TestArcSealerExtraction` regression suite (4 tests) targets `_outermost_arc_sealer` directly with the real `as-domain` shape so a future contributor cannot reintroduce the `a.domain` read pattern.

## Verified live on core-01 with a real captured Voys-sent invite

Before this PR (production):
```
verified_from: None
reason:        'arc_untrusted_sealer'
arc.sealer:    None        ← bug
arc.trusted:   False
spf.result:    'absent'    ← wrong authserv-id
```

After this PR (re-run on the same message with the new defaults):
- ARC chain validates, sealer extracted as `getklai.com`, trusted
- Inner `ARC-Authentication-Results` records `dkim=pass header.d=voys.nl` aligns with From `mark.vletter@voys.nl`
- SPF read correctly with the cloud86 authserv-id
- Result: **accept**

## Test plan

- [ ] CI quality green
- [ ] Deploy to main; rerun the same `verify_mail_auth` smoke test on core-01 to confirm the live behaviour matches local

## Severity

**Without this fix, every real customer invite would have been silently rejected in production.** The original SPEC reject-path smoke test on core-01 (PR #165 close-out) verified the negative path but did not exercise a real positive path; this PR closes that gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)