### PR TITLE
fix(portal-api): COPY klai-libs/image-storage into Docker build context

### DIFF
--- a/klai-portal/backend/Dockerfile
+++ b/klai-portal/backend/Dockerfile
@@ -13,6 +13,7 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 # Repo-mirror layout: /repo/klai-libs/..., /repo/klai-portal/backend/...
 WORKDIR /repo
 COPY klai-libs/connector-credentials klai-libs/connector-credentials
+COPY klai-libs/image-storage klai-libs/image-storage
 COPY klai-portal/backend/pyproject.toml klai-portal/backend/pyproject.toml
 COPY klai-portal/backend/uv.lock klai-portal/backend/uv.lock
 


### PR DESCRIPTION
PR #167 (SPEC-SEC-SSRF-001) added klai-libs/image-storage as an editable path dep in klai-portal/backend/pyproject.toml but did not update klai-portal/backend/Dockerfile to copy that directory into the build context. Every portal-api Docker build on main since #167 has failed at `uv sync --frozen` with `Distribution not found at: file:///repo/klai-libs/image-storage`. The deploy pipeline silently halts (build-push fail → deploy skipped), so production is stuck on the pre-#167 image — in particular the SPEC-SEC-IMAP-001 ARC sealer fix from #174 is on main but not on core-01. One-line Dockerfile change mirroring the existing connector-credentials pattern.