### PR TITLE
chore(portal-api): real-crypto ARC tests + fail-loud authserv-id + SPEC HISTORY (SPEC-SEC-IMAP-001)

### DIFF
--- a/.moai/specs/SPEC-SEC-IMAP-001/spec.md
+++ b/.moai/specs/SPEC-SEC-IMAP-001/spec.md
@@ -1,9 +1,9 @@
 ---
 id: SPEC-SEC-IMAP-001
-version: 0.2.0
-status: draft
+version: 0.3.0
+status: shipped
 created: 2026-04-24
-updated: 2026-04-24
+updated: 2026-04-25
 author: Mark Vletter
 priority: high
 tracker: SPEC-SEC-AUDIT-2026-04
@@ -12,6 +12,47 @@ tracker: SPEC-SEC-AUDIT-2026-04
 # SPEC-SEC-IMAP-001: IMAP Listener DKIM/SPF/ARC Enforcement
 
 ## HISTORY
+
+### v0.3.0 (2026-04-25) — POST-SHIP CORRECTIONS
+
+The implementation shipped in PRs #165, #172, #174, #175. Live verification on
+core-01 against a real captured invite uncovered three corrections to the
+research.md mental model — recorded here so the SPEC matches reality:
+
+- **The trusted upstream relay is `shared199.cloud86-host.io`, NOT
+  `mail.getklai.com`.** Klai's mailbox is hosted on cloud86; their MX
+  stamps `Authentication-Results` under that authserv-id. REQ-2.4's
+  trust-boundary filter targets that string. The default for
+  `imap_authserv_id` is the cloud86 hostname; the SPEC's references to
+  `mail.getklai.com` below are the operator-facing alias and remain
+  conceptually correct, but the wire-level authserv-id is cloud86's.
+- **ARC fallback is the hot path, not a cold one.** Cloud86's amavis
+  layer modifies the message body on forward, breaking the original
+  upstream DKIM crypto for every inbound invite. Direct DKIM=pass
+  alignment (REQ-1.2) is therefore rare in production; ARC fallback
+  (REQ-3) carries every legitimate accept. `imap_trusted_arc_sealers`
+  must include `getklai.com` because cloud86 ARC-seals every inbound
+  message under our domain — that seal is the trust boundary at the
+  IMAP boundary.
+- **`dkim.ARC.verify()` does NOT populate ``ARC.domain``** for
+  verification flows; the sealing domain lives in
+  ``results[*]['as-domain']``. Implementation reads the latter via the
+  `_outermost_arc_sealer` helper. A naive read of `ARC.domain` returns
+  `None` for every legitimately forwarded invite — silent
+  `arc_untrusted_sealer` rejection. Caught only by live verification;
+  synthetic test mocks agreed with the wrong assumption.
+
+Companion changes:
+- `Settings._require_imap_authserv_id_when_listener_enabled` model_validator
+  fails-loud at startup if IMAP is enabled and the authserv-id is empty.
+- `TestAC5_RealArcCrypto` integration tests exercise `dkim.arc_sign` and
+  `dkim.arc_verify` end-to-end (no mocks) so a future regression on the
+  ARC.domain / results-list contract is caught locally.
+
+Operator note: any time the upstream mail-host changes, both
+`imap_authserv_id` and (potentially) `imap_trusted_arc_sealers` must
+be reviewed. There is no automatic detection — the model_validator only
+catches an explicit-empty value, not silent rot of a stale default.
 
 ### v0.2.0 (2026-04-24)
 - Expanded from stub via `/moai plan SPEC-SEC-IMAP-001`

--- a/klai-portal/backend/app/core/config.py
+++ b/klai-portal/backend/app/core/config.py
@@ -308,5 +308,31 @@ class Settings(BaseSettings):
             )
         return self
 
+    @model_validator(mode="after")
+    def _require_imap_authserv_id_when_listener_enabled(self) -> "Settings":
+        """SPEC-SEC-IMAP-001: when the IMAP listener is enabled, the upstream
+        relay's authserv-id MUST be explicitly set.
+
+        An empty value silently breaks SPF observability (REQ-2.1), and a
+        wrong default (e.g. left over from an earlier hosting provider after
+        a migration) leaves the SPF check searching for a header that the
+        new relay never stamps. This validator catches the explicit-empty
+        case at startup; operators must still review the default after any
+        mail-host change to avoid silent default rot.
+
+        IMAP is considered enabled iff both ``imap_host`` and ``imap_username``
+        are set — matches the assertion in
+        :func:`app.services.imap_listener._poll_once`.
+        """
+        listener_enabled = bool(self.imap_host) and bool(self.imap_username)
+        if listener_enabled and not (self.imap_authserv_id and self.imap_authserv_id.strip()):
+            raise ValueError(
+                "Missing required: PORTAL_API_IMAP_AUTHSERV_ID (SPEC-SEC-IMAP-001). "
+                "Set it to the authserv-id stamped by your trusted upstream mail relay; "
+                "inspect Authentication-Results headers in a recent message at "
+                "meet@getklai.com to find the correct value."
+            )
+        return self
+
 
 settings = Settings()  # type: ignore[call-arg]  # pydantic-settings reads required fields from env

--- a/klai-portal/backend/tests/services/fixtures/imap/builders.py
+++ b/klai-portal/backend/tests/services/fixtures/imap/builders.py
@@ -122,3 +122,29 @@ def dkim_sign(raw: bytes, signing_domain: str, selector: str = "test") -> bytes:
         include_headers=[b"From", b"To", b"Subject", b"Date", b"Message-ID"],
     )
     return sig + raw
+
+
+def arc_sign(
+    raw: bytes,
+    sealer_domain: str,
+    authserv_id: str,
+    selector: str = "test",
+) -> bytes:
+    """Prepend a real ARC-Seal + ARC-Message-Signature + ARC-Authentication-Results.
+
+    Uses the same throwaway RSA key that ``dkim_sign`` uses for the sealing
+    domain. The inner ``ARC-Authentication-Results`` is built by
+    ``dkim.arc_sign`` from any pre-existing ``Authentication-Results``
+    headers in ``raw`` whose authserv-id matches ``authserv_id`` — caller
+    should include such a header to model an upstream-authenticated forward.
+    """
+    k = key_for(sealer_domain, selector)
+    arc_headers = dkim.arc_sign(
+        message=raw,
+        selector=k.selector,
+        domain=k.domain,
+        privkey=k.private_pem,
+        srv_id=authserv_id.encode(),
+        include_headers=[b"From", b"To", b"Subject", b"Date", b"Message-ID"],
+    )
+    return b"".join(arc_headers) + raw

--- a/klai-portal/backend/tests/services/test_mail_auth.py
+++ b/klai-portal/backend/tests/services/test_mail_auth.py
@@ -29,6 +29,7 @@ from app.services.mail_auth import (
     verify_mail_auth,
 )
 from tests.services.fixtures.imap.builders import (
+    arc_sign,
     build_email,
     dkim_sign,
     key_for,
@@ -82,6 +83,59 @@ class TestAlignmentHelpers:
     )
     def test_distinct_slds_under_public_suffix_do_not_align(self, a: str, b: str) -> None:
         assert _aligned(a, b) is False
+
+
+class TestSettingsImapAuthservIdValidator:
+    """SPEC-SEC-IMAP-001: the Settings model_validator that catches empty
+    ``imap_authserv_id`` when the IMAP listener is enabled.
+
+    Lives here (not in a config-specific suite) because the validator is
+    SPEC-SEC-IMAP-001 scope and the doc-string references this file.
+    """
+
+    def test_listener_disabled_does_not_require_authserv_id(self) -> None:
+        from app.core.config import Settings
+
+        # No imap_host / imap_username → listener inactive → validator skipped.
+        s = Settings(imap_host=None, imap_username=None, imap_authserv_id="")
+        assert s.imap_host is None
+
+    def test_listener_enabled_with_empty_authserv_id_fails_loud(self) -> None:
+        from pydantic import ValidationError
+
+        from app.core.config import Settings
+
+        with pytest.raises(ValidationError, match="PORTAL_API_IMAP_AUTHSERV_ID"):
+            Settings(
+                imap_host="imap.example.com",
+                imap_username="meet@example.com",
+                imap_password="secret",
+                imap_authserv_id="",
+            )
+
+    def test_listener_enabled_with_whitespace_authserv_id_fails_loud(self) -> None:
+        from pydantic import ValidationError
+
+        from app.core.config import Settings
+
+        with pytest.raises(ValidationError, match="PORTAL_API_IMAP_AUTHSERV_ID"):
+            Settings(
+                imap_host="imap.example.com",
+                imap_username="meet@example.com",
+                imap_password="secret",
+                imap_authserv_id="   ",
+            )
+
+    def test_listener_enabled_with_authserv_id_succeeds(self) -> None:
+        from app.core.config import Settings
+
+        s = Settings(
+            imap_host="imap.example.com",
+            imap_username="meet@example.com",
+            imap_password="secret",
+            imap_authserv_id="my-relay.example",
+        )
+        assert s.imap_authserv_id == "my-relay.example"
 
 
 class TestArcSealerExtraction:
@@ -217,6 +271,81 @@ class TestAC3AC4_DkimValidAligned:
 
         assert result.verified_from == "user@mail.customer.nl"
         assert result.dkim_result.aligned is True
+
+
+# ---------- AC-5 (real crypto): integration test for the ARC accept path -
+
+
+class TestAC5_RealArcCrypto:
+    """End-to-end ARC validation with no mocks — exercises ``dkim.arc_sign``
+    plus ``dkim.arc_verify`` and the real ``_outermost_arc_sealer`` extraction.
+
+    Catches the April 2026 production regression where mocked tests agreed
+    with a wrong assumption about ``dkim.ARC.verify()``'s API surface
+    (sealer was being read from ``ARC.domain`` instead of from the results
+    list, returning ``None`` for every legitimately forwarded invite).
+    """
+
+    @pytest.mark.asyncio
+    async def test_real_arc_chain_validates_and_accepts(self) -> None:
+        sealer_key = key_for("getklai.com")
+        raw = build_email(
+            from_addr="boss@customer.nl",
+            extra_headers=[
+                # Upstream MX authenticated and stamped — arc_sign will
+                # copy this into the ARC-Authentication-Results header.
+                (
+                    "Authentication-Results",
+                    "upstream-relay.test; dkim=pass header.d=customer.nl; spf=pass smtp.mailfrom=boss@customer.nl",
+                ),
+            ],
+        )
+        # No DKIM-Signature on the raw bytes → force ARC-only acceptance,
+        # which is the production hot path (cloud86 strips DKIM on forward).
+        signed = arc_sign(raw, sealer_domain="getklai.com", authserv_id="upstream-relay.test")
+
+        result = await verify_mail_auth(
+            signed,
+            dnsfunc=make_dnsfunc(sealer_key),
+            trusted_arc_sealers=["getklai.com"],
+            authserv_id="upstream-relay.test",
+        )
+
+        assert result.verified_from == "boss@customer.nl"
+        assert result.reason == ""
+        assert result.arc_result.present is True
+        assert result.arc_result.valid is True
+        # The bug-bearing line: this assertion fails with sealer=None when
+        # the wrapper reads from ``ARC.domain`` instead of results list.
+        assert result.arc_result.sealer == "getklai.com"
+        assert result.arc_result.trusted is True
+        assert result.arc_result.aligned_from_domain is True
+
+    @pytest.mark.asyncio
+    async def test_real_arc_untrusted_sealer_rejects(self) -> None:
+        sealer_key = key_for("weird-provider.example")
+        raw = build_email(
+            from_addr="boss@customer.nl",
+            extra_headers=[
+                (
+                    "Authentication-Results",
+                    "upstream-relay.test; dkim=pass header.d=customer.nl",
+                ),
+            ],
+        )
+        signed = arc_sign(raw, sealer_domain="weird-provider.example", authserv_id="upstream-relay.test")
+
+        result = await verify_mail_auth(
+            signed,
+            dnsfunc=make_dnsfunc(sealer_key),
+            trusted_arc_sealers=["getklai.com", "google.com"],  # weird-provider NOT in list
+            authserv_id="upstream-relay.test",
+        )
+
+        assert result.verified_from is None
+        assert result.reason == "arc_untrusted_sealer"
+        assert result.arc_result.sealer == "weird-provider.example"
+        assert result.arc_result.trusted is False
 
 
 # ---------- AC-5: Valid ARC from trusted sealer (forwarded) ---------------


### PR DESCRIPTION
Three loose ends from the post-mortem on the April 2026 production incident with SPEC-SEC-IMAP-001, closed in one pass.

## What

### 1. Real-crypto ARC integration tests (no mocks)

The original AC-5 / AC-6 tests mocked `dkim.ARC.verify()` with `mock_arc.domain = b"google.com"` — but dkimpy never reads `ARC.domain` in verification flows. The test "agreed with the bug" until live verification on core-01 caught it. New `TestAC5_RealArcCrypto` (2 tests) calls `dkim.arc_sign` and the real `dkim.arc_verify` end-to-end and asserts directly on `result.arc_result.sealer == "getklai.com"`. A future regression on the `ARC.domain` vs `results[*]['as-domain']` contract gets caught locally, not at midnight in prod.

New `arc_sign` helper in `tests/services/fixtures/imap/builders.py` so future ARC-related tests can build a real cryptographically-valid chain in one line.

### 2. Fail-loud `imap_authserv_id` validator

`Settings._require_imap_authserv_id_when_listener_enabled` model_validator: fails-loud at startup if IMAP is enabled (`imap_host` and `imap_username` set) but `imap_authserv_id` is empty / whitespace. Same shape as the existing `_require_vexa_webhook_secret` / `_require_moneybird_webhook_token` validators.

This catches the explicit-empty failure mode. It does NOT detect silent rot of a stale hosting default — that needs a different mechanism (runtime check against a live message header, out of scope here). The doc-string spells this out for the next operator.

(+4 tests: listener disabled, empty, whitespace, set.)

### 3. SPEC doc HISTORY entry (v0.3.0)

`.moai/specs/SPEC-SEC-IMAP-001/spec.md` documents:
- Cloud86 (`shared199.cloud86-host.io`) is the real upstream relay, not `mail.getklai.com`
- ARC fallback is the **hot path** — cloud86's amavis layer breaks upstream DKIM crypto on every forward
- `dkim.ARC.verify()` populates `ARC.domain` only for signing flows; verification reads from `results[*]['as-domain']`
- Operator review obligation: any hosting-provider change demands a fresh look at `imap_authserv_id` and `imap_trusted_arc_sealers`

Status flipped from `draft` to `shipped`.

## What's NOT in this PR

Two operational items I deliberately scoped out:

- **Grafana alert on broken main `build-push` runs.** Without this, the kind of failure that masked PR #167's broken Dockerfile for ~24h can recur. Belongs on the infra team's side.
- **Recurring `verify_mail_auth` smoke check against `meet@getklai.com`.** Detects silent rot if cloud86 changes their MX setup. Best as a `/schedule`d agent or a cron — needs an explicit owner for the alert routing.

## Tests

- 1154 passed (was 1136)
- Coverage on `mail_auth.py`: 95% (unchanged)
- ruff + pyright clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)