### PR TITLE
docs(sync): SPEC-SEC-IMAP-001 — project docs reflect mail-auth (DKIM/SPF/ARC) gating

### DIFF
--- a/.moai/project/product.md
+++ b/.moai/project/product.md
@@ -52,7 +52,7 @@ Bot-assisted meeting transcription via Vexa integration. A Vexa bot joins Google
 - Post-meeting batch transcription via Whisper Server (no real-time overhead)
 - Speaker attribution via Vexa's DOM-based speaking-indicator detection
 - EU-only audio processing -- audio never leaves Klai infrastructure
-- Calendar invite parsing via IMAP listener (meet@getklai.com)
+- Calendar invite parsing via IMAP listener (meet@getklai.com), DKIM/SPF/ARC-verified per SPEC-SEC-IMAP-001 — only invites whose RFC-5322 From identity is cryptographically verified can schedule a bot, preventing spoofed-organizer attacks against a customer's tenant budget
 - Consent notice displayed and recorded before any bot is dispatched
 
 ### Product Entitlements & Plans

--- a/.moai/project/structure.md
+++ b/.moai/project/structure.md
@@ -68,7 +68,9 @@ klai-portal/
 │   │   ├── services/          # Business logic
 │   │   │   ├── zitadel.py     # Zitadel API client
 │   │   │   ├── vexa.py        # Vexa meeting bot client
-│   │   │   └── bot_poller.py  # Background meeting bot polling
+│   │   │   ├── bot_poller.py  # Background meeting bot polling
+│   │   │   ├── imap_listener.py # Calendar-invite IMAP listener (gates on mail-auth)
+│   │   │   └── mail_auth.py   # DKIM/SPF/ARC verification (SPEC-SEC-IMAP-001)
 │   │   └── core/
 │   │       └── config.py      # Pydantic settings
 │   ├── alembic/               # Database migrations

--- a/.moai/project/tech.md
+++ b/.moai/project/tech.md
@@ -25,6 +25,8 @@ Klai is a multi-service TypeScript/Python monorepo. The frontend stack is TypeSc
 | Docker API | docker (Python SDK) | >=7.0 |
 | Crypto | cryptography | >=43.0 |
 | Calendar | icalendar | >=6.1, <7.0 |
+| Mail authentication (DKIM/SPF/ARC) | authheaders + dkimpy + authres | >=0.16 |
+| Public Suffix List (RFC 7489 alignment) | publicsuffix2 | >=2.2, <3.0 |
 | MongoDB Driver | motor | >=3.6 |
 | YouTube extractor | yt-dlp | >=2026.3 |
 | Linting | ruff | >=0.8 |


### PR DESCRIPTION
## Sync scope

Closes the documentation loop on SPEC-SEC-IMAP-001 (PRs #165, #172, #174, #175, #176). The SPEC + implementation + tests are merged and deployed; this PR catches up the project-level reference docs so anyone reading `.moai/project/` sees the new dependencies and the security boundary.

No code changes. SPEC document at `.moai/specs/SPEC-SEC-IMAP-001/spec.md` is already at v0.3.0 (status: shipped) from PR #176.

## What's updated

| File | Change |
|---|---|
| `.moai/project/tech.md` | Portal Backend dep table: adds `authheaders + dkimpy + authres` and `publicsuffix2` |
| `.moai/project/product.md` | Meeting Transcription section: invites are DKIM/SPF/ARC-verified per SPEC-SEC-IMAP-001 |
| `.moai/project/structure.md` | Portal Backend `services/` listing: `imap_listener.py` + `mail_auth.py` now visible |

## What's NOT in this PR

- Codemap regeneration — no architectural change (one new service file in an existing dir)
- README — no surface relevant to a top-level reader changed
- Operational follow-ups (Grafana alert on broken main builds, weekly `verify_mail_auth` smoke check) — out of doc-sync scope, owned by infra/ops

🤖 Generated with [Claude Code](https://claude.com/claude-code)