### PR TITLE
feat(sec): identity-assert library + portal endpoint + notebook visibility filter (SPEC-SEC-IDENTITY-ASSERT-001 Phase A + REQ-5)

### DIFF
--- a/.moai/specs/SPEC-SEC-IDENTITY-ASSERT-001/progress.md
+++ b/.moai/specs/SPEC-SEC-IDENTITY-ASSERT-001/progress.md
@@ -1,0 +1,54 @@
+# SPEC-SEC-IDENTITY-ASSERT-001 Progress
+
+## Phase A — Foundation (this branch)
+
+- Started: 2026-04-25
+- Branch: `feature/SPEC-SEC-IDENTITY-ASSERT-001` (from `origin/main`)
+- Worktree: `~/.moai/worktrees/klai/SPEC-SEC-IDENTITY-ASSERT-001`
+
+### Plan-phase architectural decisions
+
+1. **End-user JWT header (REQ-2.1 design choice)**: `Authorization: Bearer <user_jwt>`.
+   Mirrors `klai-retrieval-api/retrieval_api/middleware/auth.py:266-327` which
+   already accepts both `X-Internal-Secret` (service auth) and
+   `Authorization: Bearer <jwt>` (end-user JWT) on the same route. RFC-standard,
+   no conflict in `klai-knowledge-mcp/main.py` (which doesn't currently read
+   `Authorization`).
+2. **REQ-4 split-vs-global verify**: REQ-4.2 (global verify) for now;
+   `/admin/retrieve` mount point is YAGNI until an admin/diagnostic caller
+   exists. REQ-4.5 forbids the "admin role on internal-secret" hybrid.
+3. **`notebook_visibility` storage**: Qdrant payload field
+   (`notebook_visibility` + `owner_user_id`) written at ingest time. Mirrors
+   `Notebook.scope` ∈ {"personal", "org"} — no translation layer.
+
+### Delivered
+
+| REQ | Status | Tests | Notes |
+|---|---|---|---|
+| REQ-1 | ✅ | 20 | `/internal/identity/verify` endpoint; service + Redis cache + structlog |
+| REQ-5 | ✅ | 17 | `_notebook_filter` + ingest payload + retrieval guard |
+| REQ-7 | ✅ | 39 | `klai-libs/identity-assert/` shared library |
+
+Total: **76 tests passing** for SPEC-SEC-IDENTITY-ASSERT-001 in this branch.
+
+### Out of scope for this branch (deferred to Phase B / C / D)
+
+- REQ-2 (knowledge-mcp): consume `klai-libs/identity-assert/`, drop
+  caller-asserted header forwarding. Separate `/moai run` invocation.
+- REQ-3 (scribe): derive `org_id` from JWT `resourceowner` + verify.
+- REQ-4 (retrieval-api internal-secret): apply `verify_body_identity` to
+  internal-secret callers, require `X-Caller-Service` header.
+- REQ-6 (`emit_event`): switch to `request.state.auth` after REQ-4 lands.
+- REQ-7.4: editable installs of `klai-libs/identity-assert/` in
+  knowledge-mcp / scribe / retrieval-api `pyproject.toml` (Phase B work).
+
+### Migration sequence (per spec.md Risks & Mitigations)
+
+1. ✅ This branch: REQ-1 + REQ-7 + REQ-5
+2. Next: REQ-2 (knowledge-mcp) — consumer of REQ-1
+3. Then: REQ-3 (scribe) — independent consumer
+4. Then: REQ-4 (retrieval-api) — independent consumer; unblocks REQ-6
+5. Last: REQ-6 (emit_event identity) — depends on REQ-4
+
+Each phase is independently revertable via the `IDENTITY_VERIFY_MODE` flag
+documented in `research.md` §5.1.

--- a/.moai/specs/SPEC-SEC-IDENTITY-ASSERT-001/progress.md
+++ b/.moai/specs/SPEC-SEC-IDENTITY-ASSERT-001/progress.md
@@ -25,11 +25,38 @@
 
 | REQ | Status | Tests | Notes |
 |---|---|---|---|
-| REQ-1 | ✅ | 20 | `/internal/identity/verify` endpoint; service + Redis cache + structlog |
-| REQ-5 | ✅ | 17 | `_notebook_filter` + ingest payload + retrieval guard |
+| REQ-1 | ✅ | 22 | `/internal/identity/verify` endpoint; service + Redis cache (REQ-1.5 strict, evidence in key) + structlog |
+| REQ-5 | ✅ | 17 | `_notebook_filter` + ingest payload + retrieval guard + backfill script |
 | REQ-7 | ✅ | 39 | `klai-libs/identity-assert/` shared library |
+| Contract | ✅ | 5 | End-to-end library↔endpoint via in-process ASGI; allowlist drift guard |
 
-Total: **76 tests passing** for SPEC-SEC-IDENTITY-ASSERT-001 in this branch.
+Total: **83 tests passing** for SPEC-SEC-IDENTITY-ASSERT-001 in this branch.
+
+### Cleanup pass (2026-04-27)
+
+After the initial Phase A landing, a self-review uncovered:
+
+- **Cache-key looseness**: portal cache keyed on `(caller_service, user_id, org_id)`
+  without the SPEC-mandated `evidence` dimension. Fixed: cache key now
+  follows REQ-1.5 strictly. Two new tests verify a JWT-evidence cache
+  entry does NOT serve a membership-evidence lookup (and vice versa) so
+  the `evidence` field in each response honestly reflects what was
+  verified.
+- **`PyJWKClient` typing punt**: the JWKS resolver was annotated `-> "object"`
+  with a local `from jwt import PyJWKClient` and a `# type: ignore[arg-type]`
+  at the call site. Cleaned: top-level import, proper `PyJWKClient` type
+  annotation, `JwksResolver` protocol made `runtime_checkable`.
+- **Missing end-to-end contract test**: the library and endpoint tests
+  used independent mocks. A new `test_identity_verify_contract.py` runs
+  the real library against the real endpoint via `httpx.ASGITransport`.
+  The test caught a real bug — the library sent `X-Internal-Secret` but
+  portal-api's `/internal/*` surface expects `Authorization: Bearer
+  <secret>`. Library fixed; tests updated to assert the correct header.
+- **`# noqa: S107` cleanup**: replaced inline ignores with a per-file
+  rule in `tool.ruff.lint.per-file-ignores` for `tests/*`.
+- **Backfill script**: `klai-focus/research-api/scripts/backfill_notebook_visibility.py`
+  added — idempotent, dry-run/execute modes, uses Qdrant `IsEmptyCondition`
+  to skip already-backfilled chunks.
 
 ### Out of scope for this branch (deferred to Phase B / C / D)
 

--- a/.moai/specs/SPEC-SEC-IDENTITY-ASSERT-001/spec.md
+++ b/.moai/specs/SPEC-SEC-IDENTITY-ASSERT-001/spec.md
@@ -1,9 +1,9 @@
 ---
 id: SPEC-SEC-IDENTITY-ASSERT-001
-version: 0.2.0
-status: draft
+version: 0.3.0
+status: in-progress
 created: 2026-04-24
-updated: 2026-04-24
+updated: 2026-04-27
 author: Mark Vletter
 priority: critical
 tracker: SPEC-SEC-AUDIT-2026-04
@@ -12,6 +12,45 @@ tracker: SPEC-SEC-AUDIT-2026-04
 # SPEC-SEC-IDENTITY-ASSERT-001: Verify Caller-Asserted Identity on Service-to-Service Calls
 
 ## HISTORY
+
+### v0.3.0 (2026-04-27) — Phase A landed
+
+Phase A delivered via PR #178 on `feature/SPEC-SEC-IDENTITY-ASSERT-001`:
+
+- **REQ-1** — `POST /internal/identity/verify` endpoint shipped on portal-api.
+  Service layer (`app/services/identity_verifier.py`) and Redis cache layer
+  (`app/services/identity_verify_cache.py`) split for unit-testability. JWT
+  validation reuses Zitadel JWKS via an independent `PyJWKClient`. 27 tests:
+  20 endpoint + 5 contract + 2 cache-evidence-isolation.
+- **REQ-5** — `_search_notebook` symmetric-with-knowledge filter + ingest
+  payload + endpoint guard. Three-service touch (klai-focus ingest,
+  klai-retrieval-api search, klai-retrieval-api endpoint). 17 tests:
+  6 new + 11 unchanged scope_filter.
+- **REQ-7** — `klai-libs/identity-assert/` shared library with
+  `IdentityAsserter`, in-process LRU cache (60 s TTL), structlog telemetry,
+  fail-closed contract. 39 tests.
+- **Backfill script** — `klai-focus/research-api/scripts/backfill_notebook_visibility.py`
+  added so historical klai_focus chunks (pre-REQ-5) get the new payload
+  fields applied before retrieval starts filtering them out.
+- **Architectural decisions resolved** during Phase A:
+  - End-user JWT forwarding header: `Authorization: Bearer <jwt>` (matches
+    `klai-retrieval-api/middleware/auth.py` precedent).
+  - REQ-4 path: REQ-4.2 (global verify) when REQ-4 ships in Phase B —
+    `/admin/retrieve` split is YAGNI until a true admin/diagnostic caller
+    appears. SPEC REQ-4.5 forbids the admin-flag-on-internal-secret hybrid.
+  - `notebook_visibility` storage: Qdrant payload field, value mirrors
+    `Notebook.scope` ∈ {"personal", "org"} — no translation layer.
+- **Contract drift caught and fixed** during Phase A: the library originally
+  sent the shared INTERNAL_SECRET in a custom `X-Internal-Secret` header,
+  but portal-api's `/internal/*` surface uses `Authorization: Bearer
+  <secret>` per `_require_internal_token`. The end-to-end contract test
+  caught this before merge; library now uses the correct header.
+
+Phase A is independently revertable per service via the
+`IDENTITY_VERIFY_MODE=off` flag documented in research.md §5.1. Status moves
+from `draft` to `in-progress` because the SPEC has consumers but is not
+yet fully delivered (REQ-2/3/4/6 outstanding, see Phase B/C/D in
+`progress.md`).
 
 ### v0.2.0 (2026-04-24)
 - Expanded from stub into full EARS-format SPEC with research.md + acceptance.md

--- a/klai-focus/research-api/app/services/ingestion.py
+++ b/klai-focus/research-api/app/services/ingestion.py
@@ -31,10 +31,27 @@ async def ingest_source(source_id: str) -> None:
 async def _run_ingestion(db: AsyncSession, source_id: str) -> None:
     from sqlalchemy import select
 
+    from app.models.notebook import Notebook
+
     row = await db.execute(select(Source).where(Source.id == source_id))
     source: Source | None = row.scalar_one_or_none()
     if source is None:
         logger.error("Ingestion: source %s not found", source_id)
+        return
+
+    # SPEC-SEC-IDENTITY-ASSERT-001 REQ-5: resolve notebook visibility + owner
+    # so each chunk written to klai_focus carries the gate that retrieval-api's
+    # _search_notebook enforces. Fail fast if the notebook is missing — the
+    # source row references it via FK, so absence is unrecoverable.
+    nb_row = await db.execute(select(Notebook).where(Notebook.id == source.notebook_id))
+    notebook: Notebook | None = nb_row.scalar_one_or_none()
+    if notebook is None:
+        logger.error(
+            "Ingestion: notebook %s missing for source %s — abort",
+            source.notebook_id,
+            source_id,
+        )
+        await _set_status(db, source_id, "error", error_message="notebook_missing")
         return
 
     await _set_status(db, source_id, "processing")
@@ -49,6 +66,14 @@ async def _run_ingestion(db: AsyncSession, source_id: str) -> None:
         )
         if not chunks:
             raise ValueError("Geen tekst gevonden in het document")
+
+        # Stamp every chunk with the visibility gate. Notebook.scope is
+        # ("personal", "org") — the same string is forwarded as
+        # notebook_visibility so the Qdrant filter in retrieval-api can
+        # match without a translation layer.
+        for chunk in chunks:
+            chunk["notebook_visibility"] = notebook.scope
+            chunk["owner_user_id"] = notebook.owner_user_id
 
         texts = [c["content"] for c in chunks]
         embeddings = await tei.embed_texts(texts)

--- a/klai-focus/research-api/app/services/qdrant_store.py
+++ b/klai-focus/research-api/app/services/qdrant_store.py
@@ -56,8 +56,17 @@ def ensure_collection() -> None:
         else:
             raise
 
-    # Create payload indexes (idempotent)
-    for field_name in ("tenant_id", "notebook_id", "source_id"):
+    # Create payload indexes (idempotent). notebook_visibility / owner_user_id
+    # were added by SPEC-SEC-IDENTITY-ASSERT-001 REQ-5 — index both so the
+    # personal-vs-team gate in retrieval-api's _search_notebook stays cheap
+    # at query time.
+    for field_name in (
+        "tenant_id",
+        "notebook_id",
+        "source_id",
+        "notebook_visibility",
+        "owner_user_id",
+    ):
         try:
             client.create_payload_index(
                 collection_name=collection_name,
@@ -75,6 +84,13 @@ def upsert_chunks(
     """
     Upsert chunk vectors into the klai_focus collection.
     Point ID is a deterministic UUID derived from chunk_id via uuid5.
+
+    SPEC-SEC-IDENTITY-ASSERT-001 REQ-5: every chunk MUST carry
+    ``notebook_visibility`` and ``owner_user_id`` so retrieval-api's
+    ``_search_notebook`` can enforce the personal-vs-team gate without a
+    DB roundtrip. Both values come from the parent Notebook record and
+    are passed via ``chunk_data`` by the ingestion layer (see
+    ``app/services/ingestion.py``).
     """
     client = get_client()
     points = []
@@ -94,6 +110,12 @@ def upsert_chunks(
                     "chunk_index": chunk_data.get("chunk_index", 0),
                     "metadata": chunk_data.get("metadata") or {},
                     "created_at": datetime.now(timezone.utc).isoformat(),
+                    # SPEC-SEC-IDENTITY-ASSERT-001 REQ-5: visibility + owner.
+                    # Required keys — KeyError here means the ingestion layer
+                    # did not look up the notebook scope, which is a programmer
+                    # error worth crashing the ingest job over.
+                    "notebook_visibility": chunk_data["notebook_visibility"],
+                    "owner_user_id": chunk_data["owner_user_id"],
                 },
             )
         )

--- a/klai-focus/research-api/scripts/backfill_notebook_visibility.py
+++ b/klai-focus/research-api/scripts/backfill_notebook_visibility.py
@@ -1,0 +1,194 @@
+"""Backfill notebook_visibility + owner_user_id payload on klai_focus chunks.
+
+SPEC-SEC-IDENTITY-ASSERT-001 REQ-5 introduced two new payload fields on
+every klai_focus chunk:
+
+- ``notebook_visibility`` ∈ {"personal", "org"} — mirrors
+  ``Notebook.scope`` and drives the personal-vs-team gate at retrieval
+  time (``klai-retrieval-api/services/search.py:_notebook_filter``).
+- ``owner_user_id`` — copied from ``Notebook.owner_user_id``; required
+  for the personal-leg of the visibility gate.
+
+New ingest writes these fields automatically. This script applies them to
+historical chunks so retrieval keeps working after the SPEC ships.
+Without backfill, legacy chunks match neither leg of the new filter and
+become invisible — that's the deliberate fail-secure default, but is
+operationally undesirable.
+
+Run inside the research-api container:
+
+    docker exec -it klai-core-research-api-1 \\
+        python -m scripts.backfill_notebook_visibility --dry-run
+
+    docker exec -it klai-core-research-api-1 \\
+        python -m scripts.backfill_notebook_visibility --execute
+
+Idempotent. Re-running on an already-backfilled chunk is a no-op (the
+script reads each chunk's payload and only writes when at least one of
+the two fields is missing). Notebooks that no longer exist (e.g. deleted
+between ingest and backfill) are skipped with a warning — those orphan
+chunks are unreachable anyway and a future tenant-cleanup pass can
+remove them.
+
+Performance: processes one notebook at a time using
+``client.set_payload`` with a per-notebook filter. For large tenants
+this is O(notebooks), not O(chunks), so it scales linearly with the DB
+size rather than the vector index size. Default batch size matches the
+existing klai_focus collection pattern.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+
+from qdrant_client.http import models as qdrant_models
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.database import get_session
+from app.models.notebook import Notebook
+from app.services import qdrant_store
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("backfill-notebook-visibility")
+
+
+async def _list_notebooks(db: AsyncSession) -> list[Notebook]:
+    rows = await db.execute(select(Notebook))
+    return list(rows.scalars().all())
+
+
+def _count_chunks_missing_visibility(notebook_id: str) -> int:
+    """Return how many chunks for this notebook still lack the new fields.
+
+    Uses Qdrant's count API with a payload-must-not filter. A chunk that
+    already has BOTH fields populated does not match — we count the
+    complement (one or both missing).
+    """
+
+    client = qdrant_store.get_client()
+    # Match chunks for this notebook where notebook_visibility is missing.
+    # Qdrant's "is_empty" filter matches chunks where the field is absent
+    # OR has the empty-keyword value, which is exactly what we want.
+    result = client.count(
+        collection_name=settings.qdrant_collection,
+        count_filter=qdrant_models.Filter(
+            must=[
+                qdrant_models.FieldCondition(
+                    key="notebook_id",
+                    match=qdrant_models.MatchValue(value=notebook_id),
+                ),
+                qdrant_models.IsEmptyCondition(
+                    is_empty=qdrant_models.PayloadField(key="notebook_visibility"),
+                ),
+            ]
+        ),
+        exact=True,
+    )
+    return result.count
+
+
+def _apply_payload(notebook: Notebook) -> int:
+    """Write ``notebook_visibility`` + ``owner_user_id`` to every chunk of the notebook.
+
+    Returns the number of chunks updated. Only chunks missing
+    ``notebook_visibility`` are touched — already-backfilled chunks are
+    skipped via the same is_empty filter used for counting.
+    """
+
+    client = qdrant_store.get_client()
+    pending = _count_chunks_missing_visibility(notebook.id)
+    if pending == 0:
+        return 0
+
+    client.set_payload(
+        collection_name=settings.qdrant_collection,
+        payload={
+            "notebook_visibility": notebook.scope,
+            "owner_user_id": notebook.owner_user_id,
+        },
+        points_selector=qdrant_models.FilterSelector(
+            filter=qdrant_models.Filter(
+                must=[
+                    qdrant_models.FieldCondition(
+                        key="notebook_id",
+                        match=qdrant_models.MatchValue(value=notebook.id),
+                    ),
+                    qdrant_models.IsEmptyCondition(
+                        is_empty=qdrant_models.PayloadField(key="notebook_visibility"),
+                    ),
+                ]
+            )
+        ),
+    )
+    return pending
+
+
+async def _run(*, execute: bool) -> int:
+    """Iterate every notebook and backfill its chunks. Returns total updated."""
+
+    total_updated = 0
+    skipped_empty = 0
+
+    async for db in get_session():
+        notebooks = await _list_notebooks(db)
+        log.info("found %d notebooks", len(notebooks))
+
+        for notebook in notebooks:
+            pending = _count_chunks_missing_visibility(notebook.id)
+            if pending == 0:
+                skipped_empty += 1
+                continue
+
+            log.info(
+                "notebook=%s scope=%s owner=%s pending_chunks=%d",
+                notebook.id,
+                notebook.scope,
+                notebook.owner_user_id,
+                pending,
+            )
+            if not execute:
+                continue
+
+            updated = _apply_payload(notebook)
+            total_updated += updated
+            log.info("notebook=%s updated_chunks=%d", notebook.id, updated)
+
+        break  # only need one session yielded
+
+    log.info(
+        "summary: notebooks_already_backfilled=%d total_chunks_updated=%d execute=%s",
+        skipped_empty,
+        total_updated,
+        execute,
+    )
+    return total_updated
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__.split("\n")[0] if __doc__ else "",
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would change; no writes.",
+    )
+    group.add_argument(
+        "--execute",
+        action="store_true",
+        help="Apply payload writes.",
+    )
+    args = parser.parse_args(argv)
+
+    asyncio.run(_run(execute=args.execute))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/klai-libs/identity-assert/README.md
+++ b/klai-libs/identity-assert/README.md
@@ -1,0 +1,214 @@
+# klai-identity-assert
+
+Shared identity-assertion helper for Klai service-to-service calls.
+Implements [SPEC-SEC-IDENTITY-ASSERT-001](../../.moai/specs/SPEC-SEC-IDENTITY-ASSERT-001/spec.md)
+REQ-7.
+
+## Why this exists
+
+Every Klai service-to-service call that carries a tenant or user identity
+claim must verify that claim against a source of truth before acting on
+it. The shared `INTERNAL_SECRET` proves *network* identity (the caller is
+one of our services); it does **not** prove *tenant* identity.
+
+This library is the one and only implementation of "ask portal-api whether
+this identity claim is real". Every Python consumer
+(`klai-knowledge-mcp`, `klai-scribe`, `klai-retrieval-api`, future
+additions) imports it. Services do not re-implement the contract.
+
+## When to call
+
+Call `IdentityAsserter.verify` immediately before any operation that:
+
+1. Reads, writes, or filters data on behalf of a specific user or org, AND
+2. Receives the user/org identity from a service-to-service caller (i.e.
+   not directly from a Zitadel JWT validated in this service's own
+   middleware).
+
+If your handler authenticates via Zitadel JWT directly and uses the
+JWT's `sub` / `resourceowner` claims, you do **not** need this library —
+your auth middleware already verified the identity.
+
+## Quickstart
+
+```python
+from klai_identity_assert import IdentityAsserter
+
+asserter = IdentityAsserter(
+    portal_base_url=settings.portal_base_url,        # e.g. "http://portal-api:8000"
+    internal_secret=settings.internal_secret,        # the shared INTERNAL_SECRET
+)
+
+result = await asserter.verify(
+    caller_service="scribe",            # one of KNOWN_CALLER_SERVICES
+    claimed_user_id=user_id,
+    claimed_org_id=org_id,
+    bearer_jwt=jwt_or_none,             # forward end-user JWT when available
+    request_headers=request.headers,    # propagates X-Request-ID for tracing
+)
+
+if not result.verified:
+    # Refuse the upstream operation. The reason MUST stay in logs only —
+    # echoing it to the end-user client leaks information (REQ-2.2).
+    logger.warning("identity_assertion_failed", reason=result.reason)
+    raise HTTPException(403, detail="identity_assertion_failed")
+
+# Proceed with result.user_id / result.org_id (the canonical resolved tuple).
+```
+
+## Contract
+
+### `caller_service` allowlist
+
+Mirrors portal-api REQ-1.2. Currently:
+
+- `knowledge-mcp`
+- `scribe`
+- `retrieval-api`
+- `connector`
+- `mailer`
+
+Adding a new service requires a synchronised change in
+`klai-portal/backend/app/api/internal.py` and this library's
+`KNOWN_CALLER_SERVICES`. If only one side is updated, calls fail closed
+with `library_misconfigured` (consumer side) or `unknown_caller_service`
+(portal side).
+
+### `bearer_jwt` semantics
+
+| Caller passes | Portal evidence | When to use |
+|---|---|---|
+| Zitadel JWT (active) | `"jwt"` | Strongest assertion — caller forwarded the end-user JWT |
+| `None` | `"membership"` | Fallback — portal looks up membership by `(user_id, org_id)` |
+| Zitadel JWT (expired/invalid) | (deny) | Portal returns `invalid_jwt` deny — does NOT fall through to membership |
+
+The `None` fallback is narrower (it only catches "this user belongs to
+this org" — not "this caller is acting *as* this user"). Strong identity
+binding requires forwarding the user's JWT.
+
+### Reason codes
+
+Stable codes returned in `VerifyResult.reason` on deny:
+
+| Code | Source | Meaning |
+|---|---|---|
+| `unknown_caller_service` | portal | `caller_service` not in allowlist |
+| `invalid_jwt` | portal | JWT signature/audience/exp failure |
+| `jwt_identity_mismatch` | portal | JWT sub or resourceowner ≠ claimed tuple |
+| `no_membership` | portal | Claimed user has no active membership in claimed org |
+| `cache_unavailable` | portal | Redis-backed verifier cache unreachable (HTTP 503) |
+| `portal_unreachable` | library | Network error / 5xx / malformed body / unrecognised reason |
+| `library_misconfigured` | library | `caller_service` not in `KNOWN_CALLER_SERVICES` (caller bug) |
+
+### Caching
+
+- **Library side** (this package): per-process LRU, 60 s TTL, in-memory
+  only. Verified results are cached; denials never are. Privacy-bound:
+  the cache is per-consumer-process. See [REQ-7.2 + research §2.4](../../.moai/specs/SPEC-SEC-IDENTITY-ASSERT-001/research.md).
+- **Portal side**: Redis-backed cache, 60 s TTL, keyed on
+  `(caller_service, claimed_user_id, claimed_org_id, evidence)`.
+
+The two caches are independent. A 60 s TTL on both sides means worst-case
+revocation propagation is bounded at ~60 s, which is shorter than the
+Zitadel JWT `exp` for any active user session.
+
+### Failure mode — fail closed
+
+The library MUST refuse operations under degraded conditions:
+
+- Network error against portal → `portal_unreachable`
+- Portal HTTP 5xx → `portal_unreachable`
+- Malformed JSON body → `portal_unreachable`
+- Reason code not in the documented list → `portal_unreachable`
+- Caller passed an unknown `caller_service` → `library_misconfigured`
+
+This is the deliberate inverse of the SPEC-SEC-005 rate limiter (which
+fails open). An auth-class control fails closed. See [SPEC §11
+"Risks & Mitigations"](../../.moai/specs/SPEC-SEC-IDENTITY-ASSERT-001/spec.md#risks--mitigations).
+
+## Migration: before / after
+
+### Before — caller-asserted identity (REJECTED PATTERN)
+
+```python
+# klai-scribe — body.org_id is trusted on faith
+async def ingest_to_kb(body: IngestToKBRequest, user_id: str = Depends(jwt_user)):
+    # ❌ body.org_id is whatever the caller chose to send
+    await ingest_scribe_transcript(org_id=body.org_id, user_id=user_id)
+```
+
+### After — verified identity
+
+```python
+# klai-scribe — org_id resolved from JWT's resourceowner, then verified
+async def ingest_to_kb(
+    request: Request,
+    body: IngestToKBRequest,
+    user_id: str = Depends(jwt_user),
+    bearer_jwt: str = Depends(bearer_token_str),
+):
+    org_id = jwt_payload.resourceowner  # canonical org from JWT
+
+    result = await asserter.verify(
+        caller_service="scribe",
+        claimed_user_id=user_id,
+        claimed_org_id=org_id,
+        bearer_jwt=bearer_jwt,
+        request_headers=request.headers,
+    )
+    if not result.verified:
+        raise HTTPException(403, detail="identity_assertion_failed")
+
+    await ingest_scribe_transcript(org_id=result.org_id, user_id=result.user_id)
+```
+
+## Telemetry
+
+Every `verify` call emits one structlog event with stable key
+`event="identity_assert_call"` and fields:
+
+- `caller_service`
+- `claimed_user_id_hash` (SHA-256 prefix; never the raw UUID)
+- `claimed_org_id`
+- `verified` (bool)
+- `cached` (bool)
+- `latency_ms`
+- `evidence` (on allow)
+- `reason` (on deny)
+
+Allow events log at `info` level. Deny events log at `warning`. Combined
+with portal-side `identity_verify_decision` events sharing the same
+`X-Request-ID`, one VictoriaLogs LogsQL query traces the full chain:
+
+```
+event:"identity_assert_call" AND verified:false  # all denials, all callers
+event:"identity_verify_decision" AND verified:false  # same, portal side
+```
+
+## Adding a new consumer
+
+1. Add the service name to `KNOWN_CALLER_SERVICES` here AND to portal-api
+   `/internal/identity/verify` allowlist (`klai-portal/backend/app/api/internal.py`).
+2. Add `klai-identity-assert` as an editable install in your service's
+   `pyproject.toml`:
+
+   ```toml
+   dependencies = [
+       "klai-identity-assert @ file:///${PROJECT_ROOT}/../klai-libs/identity-assert",
+       ...
+   ]
+   ```
+
+   Mirror the `klai-image-storage` pattern that knowledge-ingest /
+   connector use today.
+3. Construct one `IdentityAsserter` per process (lifespan startup).
+4. Replace any caller-asserted identity reads with `verify` results.
+5. Add a regression test that asserts the call refuses upstream
+   operations on `result.verified is False`.
+
+## Versioning
+
+Library version follows the SPEC version. v0.1.0 ships with the first
+landing of REQ-1 + REQ-7 (Phase A of SPEC-SEC-IDENTITY-ASSERT-001).
+Subsequent SPEC requirements (REQ-2 / REQ-3 / REQ-4 / REQ-6) consume
+this library without changing it.

--- a/klai-libs/identity-assert/klai_identity_assert/__init__.py
+++ b/klai-libs/identity-assert/klai_identity_assert/__init__.py
@@ -1,0 +1,62 @@
+"""Shared identity-assertion helper for Klai service-to-service calls.
+
+SPEC-SEC-IDENTITY-ASSERT-001 — consolidates the identity-verify call into one
+implementation that every Python consumer (knowledge-mcp, scribe,
+retrieval-api, mailer, connector) imports. Services do not re-implement the
+contract; they use this library or they fail review.
+
+Public API (all re-exported at package root):
+
+- :class:`IdentityAsserter` — async client; instantiate once per process
+- :class:`VerifyResult` — frozen dataclass returned by every verify call
+- :class:`IdentityAssertError` — base exception
+- :class:`PortalUnreachable` — network/5xx failure (raise mode only)
+- :class:`IdentityDenied` — portal returned verified=false (raise mode only)
+- :data:`KNOWN_CALLER_SERVICES` — frozenset, mirrors portal allowlist
+
+Quickstart
+----------
+
+::
+
+    from klai_identity_assert import IdentityAsserter, VerifyResult
+
+    asserter = IdentityAsserter(
+        portal_base_url=settings.portal_base_url,
+        internal_secret=settings.internal_secret,
+    )
+
+    result = await asserter.verify(
+        caller_service="scribe",
+        claimed_user_id=user_id,
+        claimed_org_id=org_id,
+        bearer_jwt=jwt_or_none,
+        request_headers=trace_headers,  # propagates X-Request-ID
+    )
+    if not result.verified:
+        raise HTTPException(403, detail="identity_assertion_failed")
+"""
+
+from klai_identity_assert.client import IdentityAsserter
+from klai_identity_assert.exceptions import (
+    IdentityAssertError,
+    IdentityDenied,
+    PortalUnreachable,
+)
+from klai_identity_assert.models import (
+    KNOWN_CALLER_SERVICES,
+    Evidence,
+    ReasonCode,
+    VerifyResult,
+)
+
+__all__ = [
+    "KNOWN_CALLER_SERVICES",
+    "Evidence",
+    "IdentityAssertError",
+    "IdentityAsserter",
+    "IdentityDenied",
+    "PortalUnreachable",
+    "ReasonCode",
+    "VerifyResult",
+]

--- a/klai-libs/identity-assert/klai_identity_assert/cache.py
+++ b/klai-libs/identity-assert/klai_identity_assert/cache.py
@@ -1,0 +1,150 @@
+"""Per-process TTL cache for verified identity tuples.
+
+SPEC-SEC-IDENTITY-ASSERT-001 REQ-7.2: each consumer caches successful verify
+results for 60 seconds, keyed on the full tuple
+``(caller_service, claimed_user_id, claimed_org_id, hash(bearer_jwt or "none"))``.
+
+Privacy boundary: the cache is per-process (NOT redis-backed at the consumer
+side). A shared cache across consumers would let one service infer that
+another service just looked up the same user — a cross-service privacy smell
+that research.md §2.4 explicitly rules out. Portal-api keeps its own
+redis-backed cache on the verifier side; the consumer cache is independent.
+
+Negative caching: this cache stores only ``verified=True`` results. Denials
+are never cached (mirrors portal REQ-1.5). Re-querying after a deny gives the
+caller a chance to recover (e.g. user just got their membership granted).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import threading
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+
+from klai_identity_assert.models import VerifyResult
+
+
+@dataclass(frozen=True, slots=True)
+class _CacheKey:
+    caller_service: str
+    claimed_user_id: str
+    claimed_org_id: str
+    jwt_fingerprint: str
+
+
+def _fingerprint_jwt(bearer_jwt: str | None) -> str:
+    """Return a fingerprint that distinguishes JWT-bearing from JWT-less calls.
+
+    Why hash and not store the JWT itself: the cache lives in process memory
+    next to the rest of the verified identity — leaking a JWT into a cache
+    key would put it inside heap dumps and tracebacks. The hash is sufficient
+    to distinguish "same JWT" from "different JWT" within the 60s window.
+    """
+
+    if bearer_jwt is None:
+        return "none"
+    digest = hashlib.sha256(bearer_jwt.encode("utf-8")).hexdigest()
+    return digest[:16]  # 64 bits is plenty to avoid collisions in 60s
+
+
+class IdentityCache:
+    """Bounded LRU cache with monotonic-clock TTL.
+
+    Thread-safe: holds a lock around mutations. Async callers do not need
+    awaitable locking because operations are O(1) and the hold is microseconds.
+    """
+
+    def __init__(self, *, ttl_seconds: float = 60.0, max_entries: int = 1024) -> None:
+        if ttl_seconds <= 0:
+            raise ValueError("ttl_seconds must be positive")
+        if max_entries <= 0:
+            raise ValueError("max_entries must be positive")
+        self._ttl_seconds = ttl_seconds
+        self._max_entries = max_entries
+        self._store: OrderedDict[_CacheKey, tuple[float, VerifyResult]] = OrderedDict()
+        self._lock = threading.Lock()
+
+    def _key(
+        self,
+        caller_service: str,
+        claimed_user_id: str,
+        claimed_org_id: str,
+        bearer_jwt: str | None,
+    ) -> _CacheKey:
+        return _CacheKey(
+            caller_service=caller_service,
+            claimed_user_id=claimed_user_id,
+            claimed_org_id=claimed_org_id,
+            jwt_fingerprint=_fingerprint_jwt(bearer_jwt),
+        )
+
+    def get(
+        self,
+        *,
+        caller_service: str,
+        claimed_user_id: str,
+        claimed_org_id: str,
+        bearer_jwt: str | None,
+        now: float | None = None,
+    ) -> VerifyResult | None:
+        """Return a cached verified result, or ``None`` on miss / expiry.
+
+        ``now`` is exposed for deterministic testing; production callers omit
+        it and the cache uses :func:`time.monotonic`.
+        """
+
+        key = self._key(caller_service, claimed_user_id, claimed_org_id, bearer_jwt)
+        current = time.monotonic() if now is None else now
+        with self._lock:
+            entry = self._store.get(key)
+            if entry is None:
+                return None
+            expires_at, result = entry
+            if current >= expires_at:
+                # Lazy eviction on miss — the entry is gone for any subsequent caller.
+                del self._store[key]
+                return None
+            # LRU touch: move to end so it survives the next sweep.
+            self._store.move_to_end(key)
+            # Mark cached=True without losing the original verified state.
+            return VerifyResult(
+                verified=result.verified,
+                user_id=result.user_id,
+                org_id=result.org_id,
+                reason=result.reason,
+                evidence=result.evidence,
+                cached=True,
+            )
+
+    def put(
+        self,
+        *,
+        caller_service: str,
+        claimed_user_id: str,
+        claimed_org_id: str,
+        bearer_jwt: str | None,
+        result: VerifyResult,
+        now: float | None = None,
+    ) -> None:
+        """Cache a verified result. No-op for non-verified results (REQ-1.5)."""
+
+        if not result.verified:
+            return
+        key = self._key(caller_service, claimed_user_id, claimed_org_id, bearer_jwt)
+        current = time.monotonic() if now is None else now
+        with self._lock:
+            self._store[key] = (current + self._ttl_seconds, result)
+            self._store.move_to_end(key)
+            while len(self._store) > self._max_entries:
+                self._store.popitem(last=False)
+
+    def clear(self) -> None:
+        """Drop every cached entry. Test-only."""
+        with self._lock:
+            self._store.clear()
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._store)

--- a/klai-libs/identity-assert/klai_identity_assert/client.py
+++ b/klai-libs/identity-assert/klai_identity_assert/client.py
@@ -1,0 +1,300 @@
+"""IdentityAsserter — entry point for service-to-service identity verification.
+
+SPEC-SEC-IDENTITY-ASSERT-001 REQ-7.1 / REQ-7.2: consumers instantiate one
+:class:`IdentityAsserter` per service (or use the module-level singleton via
+:func:`verify_identity`) and call :meth:`IdentityAsserter.verify` for every
+service-to-service call that carries a tenant or user identity claim.
+
+Contract summary:
+
+- Returns :class:`~klai_identity_assert.models.VerifyResult` for every code
+  path. Consumers branch on ``verified`` and refuse the upstream operation
+  when ``False``.
+- Caches successful verifications for 60 seconds in-process. Denials are
+  never cached (REQ-1.5).
+- Fails closed: portal unreachable / network error / 5xx → returns a denial
+  with ``reason="portal_unreachable"`` (REQ-7.2).
+- Emits one ``identity_assert_call`` structlog event per call (REQ-7.5).
+- Propagates ``X-Request-ID`` via the headers passed by the caller, so the
+  portal's ``identity_verify_decision`` log entry shares the same trace ID
+  (REQ-4.6 / observability rule).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+import httpx
+import structlog
+
+from klai_identity_assert.cache import IdentityCache
+from klai_identity_assert.exceptions import IdentityDenied, PortalUnreachable
+from klai_identity_assert.models import KNOWN_CALLER_SERVICES, VerifyResult
+from klai_identity_assert.telemetry import emit_call, measure_latency
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+_logger = structlog.get_logger("klai_identity_assert.client")
+
+# Default network timeout matches portal /internal/* p95 budget (research §4.2).
+# Portal is expected to respond within 100 ms cold-cache; 2 seconds gives
+# ample headroom while still fail-closing fast under genuine outage.
+_DEFAULT_TIMEOUT_SECONDS = 2.0
+
+# Default cache TTL — REQ-7.2.
+_DEFAULT_CACHE_TTL_SECONDS = 60.0
+
+
+def _interpret_response(payload: Any) -> VerifyResult:
+    """Map a JSON body from /internal/identity/verify to a VerifyResult.
+
+    Defensive parser: the portal contract is fixed (REQ-1.1) but the consumer
+    is the second line of defence. Unknown shapes fail closed.
+    """
+
+    if not isinstance(payload, dict):
+        return VerifyResult.deny("portal_unreachable")
+    body = cast("dict[str, Any]", payload)
+
+    if not bool(body.get("verified")):
+        reason = body.get("reason")
+        # Trust only the documented reason codes; anything else is treated as
+        # a generic portal-unreachable so downstream log analysis stays clean.
+        known: tuple[str, ...] = (
+            "unknown_caller_service",
+            "invalid_jwt",
+            "jwt_identity_mismatch",
+            "no_membership",
+            "cache_unavailable",
+        )
+        if isinstance(reason, str) and reason in known:
+            return VerifyResult.deny(reason)  # type: ignore[arg-type]
+        return VerifyResult.deny("portal_unreachable")
+
+    user_id = body.get("user_id")
+    org_id = body.get("org_id")
+    evidence = body.get("evidence")
+    if not isinstance(user_id, str) or not isinstance(org_id, str):
+        return VerifyResult.deny("portal_unreachable")
+    if evidence not in ("jwt", "membership"):
+        return VerifyResult.deny("portal_unreachable")
+    return VerifyResult.allow(user_id=user_id, org_id=org_id, evidence=evidence)
+
+
+class IdentityAsserter:
+    """Stateful client for portal-api ``/internal/identity/verify``.
+
+    Construct one per process. The instance owns an httpx.AsyncClient with
+    connection pooling and the per-process LRU cache. Reuse it across calls
+    — instantiating per-request would defeat both pooling and caching.
+    """
+
+    def __init__(
+        self,
+        *,
+        portal_base_url: str,
+        internal_secret: str,
+        timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+        cache_ttl_seconds: float = _DEFAULT_CACHE_TTL_SECONDS,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        if not portal_base_url:
+            raise ValueError("portal_base_url is required")
+        if not internal_secret:
+            raise ValueError("internal_secret is required")
+        self._portal_base_url = portal_base_url.rstrip("/")
+        self._internal_secret = internal_secret
+        self._timeout_seconds = timeout_seconds
+        self._owns_client = http_client is None
+        self._http: httpx.AsyncClient = http_client or httpx.AsyncClient(
+            timeout=httpx.Timeout(timeout_seconds),
+        )
+        self._cache = IdentityCache(ttl_seconds=cache_ttl_seconds)
+
+    @property
+    def cache(self) -> IdentityCache:
+        """Expose the cache for inspection (test fixtures, operator tools)."""
+        return self._cache
+
+    async def aclose(self) -> None:
+        """Release resources. Idempotent. Only closes the http client we own."""
+        if self._owns_client:
+            await self._http.aclose()
+
+    async def __aenter__(self) -> IdentityAsserter:
+        return self
+
+    async def __aexit__(self, *_exc_info: object) -> None:
+        await self.aclose()
+
+    async def verify(
+        self,
+        *,
+        caller_service: str,
+        claimed_user_id: str,
+        claimed_org_id: str,
+        bearer_jwt: str | None,
+        request_headers: Mapping[str, str] | None = None,
+    ) -> VerifyResult:
+        """Verify a claimed identity against portal-api.
+
+        Returns
+        -------
+        VerifyResult
+            Always returns a result; never raises for portal/network failure.
+            Use :meth:`verify_or_raise` for exception-driven flow.
+        """
+
+        if caller_service not in KNOWN_CALLER_SERVICES:
+            # Misconfigured caller: fail closed AND loud (REQ-1.2 says portal
+            # returns 400 — we surface the same outcome here without a network
+            # round trip, since the call would always fail anyway).
+            result = VerifyResult.deny("library_misconfigured")
+            with measure_latency() as latency:
+                pass
+            emit_call(
+                caller_service=caller_service,
+                claimed_user_id=claimed_user_id,
+                claimed_org_id=claimed_org_id,
+                result=result,
+                latency_ms=latency["latency_ms"],
+            )
+            return result
+
+        cached = self._cache.get(
+            caller_service=caller_service,
+            claimed_user_id=claimed_user_id,
+            claimed_org_id=claimed_org_id,
+            bearer_jwt=bearer_jwt,
+        )
+        if cached is not None:
+            with measure_latency() as latency:
+                pass
+            emit_call(
+                caller_service=caller_service,
+                claimed_user_id=claimed_user_id,
+                claimed_org_id=claimed_org_id,
+                result=cached,
+                latency_ms=latency["latency_ms"],
+            )
+            return cached
+
+        body: dict[str, str | None] = {
+            "caller_service": caller_service,
+            "claimed_user_id": claimed_user_id,
+            "claimed_org_id": claimed_org_id,
+            "bearer_jwt": bearer_jwt,
+        }
+        headers: dict[str, str] = {
+            "X-Internal-Secret": self._internal_secret,
+            "Content-Type": "application/json",
+        }
+        if request_headers is not None:
+            request_id = request_headers.get("X-Request-ID") or request_headers.get("x-request-id")
+            if request_id:
+                headers["X-Request-ID"] = request_id
+
+        with measure_latency() as latency:
+            try:
+                response = await self._http.post(
+                    f"{self._portal_base_url}/internal/identity/verify",
+                    json=body,
+                    headers=headers,
+                )
+            except httpx.HTTPError as exc:
+                _logger.warning(
+                    "identity_assert_portal_unreachable",
+                    caller_service=caller_service,
+                    error=str(exc),
+                )
+                result = VerifyResult.deny("portal_unreachable")
+                emit_call(
+                    caller_service=caller_service,
+                    claimed_user_id=claimed_user_id,
+                    claimed_org_id=claimed_org_id,
+                    result=result,
+                    latency_ms=latency["latency_ms"],
+                )
+                return result
+
+        # 5xx → fail closed as portal_unreachable. 4xx with verified=false body
+        # → use the documented reason. Anything else with a malformed body →
+        # also fail closed.
+        if response.status_code >= 500:
+            result = VerifyResult.deny("portal_unreachable")
+            emit_call(
+                caller_service=caller_service,
+                claimed_user_id=claimed_user_id,
+                claimed_org_id=claimed_org_id,
+                result=result,
+                latency_ms=latency["latency_ms"],
+            )
+            return result
+
+        try:
+            payload = response.json()
+        except ValueError:
+            result = VerifyResult.deny("portal_unreachable")
+            emit_call(
+                caller_service=caller_service,
+                claimed_user_id=claimed_user_id,
+                claimed_org_id=claimed_org_id,
+                result=result,
+                latency_ms=latency["latency_ms"],
+            )
+            return result
+
+        result = _interpret_response(payload)
+        if result.verified:
+            self._cache.put(
+                caller_service=caller_service,
+                claimed_user_id=claimed_user_id,
+                claimed_org_id=claimed_org_id,
+                bearer_jwt=bearer_jwt,
+                result=result,
+            )
+
+        emit_call(
+            caller_service=caller_service,
+            claimed_user_id=claimed_user_id,
+            claimed_org_id=claimed_org_id,
+            result=result,
+            latency_ms=latency["latency_ms"],
+        )
+        return result
+
+    async def verify_or_raise(
+        self,
+        *,
+        caller_service: str,
+        claimed_user_id: str,
+        claimed_org_id: str,
+        bearer_jwt: str | None,
+        request_headers: Mapping[str, str] | None = None,
+    ) -> VerifyResult:
+        """Like :meth:`verify` but raises on every non-verified outcome.
+
+        Maps consumer-side and portal-side failures onto two exception types:
+
+        - :class:`~klai_identity_assert.exceptions.PortalUnreachable` for
+          network errors and ``portal_unreachable``-coded results.
+        - :class:`~klai_identity_assert.exceptions.IdentityDenied` for every
+          other denial (``no_membership``, ``jwt_identity_mismatch``, etc.).
+
+        Use this when the calling site prefers an early-return-via-raise
+        pattern. Default :meth:`verify` is the recommended path.
+        """
+
+        result = await self.verify(
+            caller_service=caller_service,
+            claimed_user_id=claimed_user_id,
+            claimed_org_id=claimed_org_id,
+            bearer_jwt=bearer_jwt,
+            request_headers=request_headers,
+        )
+        if result.verified:
+            return result
+        if result.reason == "portal_unreachable":
+            raise PortalUnreachable(f"portal /internal/identity/verify failed for {caller_service}")
+        raise IdentityDenied(result.reason or "unknown")

--- a/klai-libs/identity-assert/klai_identity_assert/client.py
+++ b/klai-libs/identity-assert/klai_identity_assert/client.py
@@ -186,8 +186,14 @@ class IdentityAsserter:
             "claimed_org_id": claimed_org_id,
             "bearer_jwt": bearer_jwt,
         }
+        # portal-api's /internal/* endpoints carry the shared INTERNAL_SECRET in
+        # ``Authorization: Bearer ...`` (see _require_internal_token in
+        # klai-portal/backend/app/api/internal.py). We follow that contract here.
+        # Custom ``X-Internal-Secret`` is the convention used by callees of
+        # portal-api (knowledge-ingest, retrieval-api), not by callers OF
+        # portal-api — different direction, different header.
         headers: dict[str, str] = {
-            "X-Internal-Secret": self._internal_secret,
+            "Authorization": f"Bearer {self._internal_secret}",
             "Content-Type": "application/json",
         }
         if request_headers is not None:

--- a/klai-libs/identity-assert/klai_identity_assert/exceptions.py
+++ b/klai-libs/identity-assert/klai_identity_assert/exceptions.py
@@ -1,0 +1,40 @@
+"""Exceptions raised by the identity-assert helper.
+
+The library follows a fail-closed contract (REQ-7.2): any failure that prevents
+arriving at a verified outcome MUST surface as a denial — either via
+``VerifyResult.verified=False`` or via one of these exceptions when the caller
+opts into raising mode.
+
+Default mode returns a ``VerifyResult`` for every code path; exception mode is
+opt-in via :meth:`IdentityAsserter.verify_or_raise` for callers that prefer
+exception-driven flow control.
+"""
+
+from __future__ import annotations
+
+
+class IdentityAssertError(Exception):
+    """Base class for all identity-assert library errors."""
+
+
+class PortalUnreachable(IdentityAssertError):
+    """Network failure or 5xx response from portal /internal/identity/verify.
+
+    SPEC-SEC-IDENTITY-ASSERT-001 REQ-7.2 mandates fail-closed behaviour: if
+    portal cannot be reached, every consumer SHALL refuse the upstream
+    operation. This exception is the explicit raise-mode signal; default
+    return-mode surfaces the same condition as
+    ``VerifyResult.deny("portal_unreachable")``.
+    """
+
+
+class IdentityDenied(IdentityAssertError):
+    """Portal returned a verified=false response; raised only in opt-in mode.
+
+    Default return-mode surfaces the same condition as a non-verified
+    ``VerifyResult`` with the corresponding ``reason``.
+    """
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(f"identity_denied: {reason}")
+        self.reason = reason

--- a/klai-libs/identity-assert/klai_identity_assert/models.py
+++ b/klai-libs/identity-assert/klai_identity_assert/models.py
@@ -1,0 +1,99 @@
+"""Result and request types for the identity-assert helper.
+
+SPEC-SEC-IDENTITY-ASSERT-001 REQ-7.1: ``VerifyResult`` is a frozen dataclass
+returned by every call to :class:`IdentityAsserter.verify`. Consumers branch
+on ``verified`` and may surface ``reason`` in operator-facing logs (never to
+end-user clients — see REQ-2.2).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+# Stable evidence types — mirrors portal-api REQ-1.3 / REQ-1.4 contract.
+Evidence = Literal["jwt", "membership"]
+
+# Stable reject codes — mirrors portal-api REQ-1.7 stable_code list. Plus two
+# consumer-side codes the library raises before ever reaching portal:
+#   - "portal_unreachable": network or 5xx error against /internal/identity/verify
+#   - "library_misconfigured": SDK config invalid (caller passed an unknown service)
+ReasonCode = Literal[
+    "unknown_caller_service",
+    "invalid_jwt",
+    "jwt_identity_mismatch",
+    "no_membership",
+    "cache_unavailable",
+    "portal_unreachable",
+    "library_misconfigured",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class VerifyResult:
+    """Outcome of a single identity-assertion call.
+
+    Attributes
+    ----------
+    verified:
+        ``True`` only when the portal returned 200 + verified=true. Any other
+        outcome (4xx, 5xx, network error, cache miss-followed-by-failure) is
+        ``False`` — the caller MUST refuse the upstream operation.
+    user_id, org_id:
+        Canonical resolved identity from portal. Both populated when
+        ``verified`` is True. Both ``None`` on deny.
+    reason:
+        Stable code on deny (see :data:`ReasonCode`). ``None`` on allow.
+    evidence:
+        ``"jwt"`` when the verification rested on a fresh JWT validation,
+        ``"membership"`` when the fallback membership lookup was decisive
+        (used when the caller passed ``bearer_jwt=None``). ``None`` on deny.
+    cached:
+        ``True`` when this result was returned from the consumer-side LRU
+        cache (REQ-7.2). ``False`` on cache miss / live portal call.
+    """
+
+    verified: bool
+    user_id: str | None
+    org_id: str | None
+    reason: ReasonCode | None
+    evidence: Evidence | None
+    cached: bool
+
+    @classmethod
+    def deny(cls, reason: ReasonCode) -> VerifyResult:
+        """Construct a non-verified result with a stable reason code."""
+        return cls(verified=False, user_id=None, org_id=None, reason=reason, evidence=None, cached=False)
+
+    @classmethod
+    def allow(
+        cls,
+        *,
+        user_id: str,
+        org_id: str,
+        evidence: Evidence,
+        cached: bool = False,
+    ) -> VerifyResult:
+        """Construct a verified result with the canonical resolved identity."""
+        return cls(
+            verified=True,
+            user_id=user_id,
+            org_id=org_id,
+            reason=None,
+            evidence=evidence,
+            cached=cached,
+        )
+
+
+# Recognised caller services. Mirrors portal-api REQ-1.2 reject list. Adding a
+# new caller requires a synchronised change to portal-api's allowlist; consumers
+# fail-closed if they pass an unknown service identifier.
+KNOWN_CALLER_SERVICES: frozenset[str] = frozenset(
+    {
+        "knowledge-mcp",
+        "scribe",
+        "retrieval-api",
+        "connector",
+        "mailer",
+    }
+)

--- a/klai-libs/identity-assert/klai_identity_assert/telemetry.py
+++ b/klai-libs/identity-assert/klai_identity_assert/telemetry.py
@@ -1,0 +1,87 @@
+"""Structlog event emission for identity-assertion calls.
+
+SPEC-SEC-IDENTITY-ASSERT-001 REQ-7.5: every consumer call SHALL emit a
+structlog entry with stable key ``event="identity_assert_call"`` and fields
+``caller_service``, ``verified``, ``cached``, ``latency_ms``, plus ``reason``
+on deny.
+
+This per-service telemetry is independent of the portal-api
+``identity_verify_decision`` log (REQ-1.7); the two together let operators
+compute consumer-side cache hit rate and detect portal load anomalies.
+
+Privacy: claimed identity values (user_id) are never logged in clear. They
+are SHA-256 hashed and truncated, matching the ``_hash_sub`` pattern in
+``klai-retrieval-api/retrieval_api/middleware/auth.py``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+import structlog
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from klai_identity_assert.models import VerifyResult
+
+_logger = structlog.get_logger("klai_identity_assert")
+
+
+def hash_user_id(user_id: str) -> str:
+    """Return a 16-hex-char prefix of SHA-256 — same convention as retrieval-api."""
+    return hashlib.sha256(user_id.encode("utf-8")).hexdigest()[:16]
+
+
+@contextmanager
+def measure_latency() -> Generator[dict[str, float], None, None]:
+    """Yield a dict that gets ``latency_ms`` populated when the block exits.
+
+    Using a dict-as-out-param keeps the call sites flat — no separate
+    timer object to thread through. ``latency_ms`` reflects elapsed wall
+    time including network I/O.
+    """
+
+    holder: dict[str, float] = {"latency_ms": 0.0}
+    started = time.monotonic()
+    try:
+        yield holder
+    finally:
+        holder["latency_ms"] = (time.monotonic() - started) * 1000.0
+
+
+def emit_call(
+    *,
+    caller_service: str,
+    claimed_user_id: str,
+    claimed_org_id: str,
+    result: VerifyResult,
+    latency_ms: float,
+) -> None:
+    """Emit one ``identity_assert_call`` structlog event.
+
+    Logged at info level on allow (operator-visible cache hit rate), warning
+    on deny (security-relevant decision). Network errors are surfaced via
+    ``result.reason="portal_unreachable"`` and also log at warning.
+    """
+
+    fields: dict[str, object] = {
+        "caller_service": caller_service,
+        "claimed_user_id_hash": hash_user_id(claimed_user_id),
+        "claimed_org_id": claimed_org_id,
+        "verified": result.verified,
+        "cached": result.cached,
+        "latency_ms": round(latency_ms, 2),
+    }
+    if result.evidence is not None:
+        fields["evidence"] = result.evidence
+    if result.reason is not None:
+        fields["reason"] = result.reason
+
+    if result.verified:
+        _logger.info("identity_assert_call", **fields)
+    else:
+        _logger.warning("identity_assert_call", **fields)

--- a/klai-libs/identity-assert/pyproject.toml
+++ b/klai-libs/identity-assert/pyproject.toml
@@ -1,0 +1,61 @@
+[project]
+name = "klai-identity-assert"
+version = "0.1.0"
+description = "Shared identity-assertion helper for Klai services (SPEC-SEC-IDENTITY-ASSERT-001)."
+requires-python = ">=3.12"
+readme = "README.md"
+license = { text = "Proprietary" }
+authors = [{ name = "Klai" }]
+
+# Runtime dependencies only. Each consumer service already pins concrete versions of
+# httpx/structlog; we express compatible lower bounds and let the embedder resolve.
+dependencies = [
+    "httpx>=0.28",
+    "structlog>=25.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8",
+    "pytest-asyncio>=1",
+    "respx>=0.22",
+    "ruff>=0.8",
+    "pyright>=1.1.390",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=8",
+    "pytest-asyncio>=1",
+    "respx>=0.22",
+    "ruff>=0.8",
+    "pyright>=1.1.390",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["klai_identity_assert"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 120
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "S", "RUF", "G", "LOG"]
+ignore = [
+    "S101",  # assert is fine in tests
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["S106"]  # test fixtures use fake tokens like "test-secret"
+
+[tool.pyright]
+pythonVersion = "3.12"
+typeCheckingMode = "strict"

--- a/klai-libs/identity-assert/tests/conftest.py
+++ b/klai-libs/identity-assert/tests/conftest.py
@@ -1,0 +1,71 @@
+"""Shared fixtures for klai-identity-assert tests."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from klai_identity_assert import IdentityAsserter
+
+# Test-only constants. test_client.py mirrors these for the ad-hoc transports
+# it builds outside the asserter fixture; keep the two locations in sync.
+_PORTAL_URL = "http://portal-api:8000"
+_INTERNAL_SECRET = "test-internal-secret"  # noqa: S105
+
+
+@pytest_asyncio.fixture
+async def asserter() -> AsyncIterator[IdentityAsserter]:
+    """An IdentityAsserter wired against the canonical test portal URL.
+
+    The httpx.AsyncClient is owned by the asserter and is cleaned up via
+    the async-context exit on fixture teardown.
+    """
+
+    async with IdentityAsserter(
+        portal_base_url=_PORTAL_URL,
+        internal_secret=_INTERNAL_SECRET,
+        cache_ttl_seconds=60.0,
+    ) as a:
+        yield a
+
+
+@pytest.fixture
+def fake_user_id() -> str:
+    return "11111111-1111-1111-1111-111111111111"
+
+
+@pytest.fixture
+def fake_org_id() -> str:
+    return "22222222-2222-2222-2222-222222222222"
+
+
+@pytest.fixture
+def other_user_id() -> str:
+    return "33333333-3333-3333-3333-333333333333"
+
+
+@pytest.fixture
+def other_org_id() -> str:
+    return "44444444-4444-4444-4444-444444444444"
+
+
+@pytest.fixture
+def fake_jwt() -> str:
+    # Not a real JWT — the consumer library never decodes the JWT, it merely
+    # forwards it. The portal does the actual JWT validation (REQ-1.3).
+    return "header.payload.signature"
+
+
+@pytest.fixture
+def httpx_no_pool() -> httpx.AsyncClient:
+    """An httpx.AsyncClient that fails immediately on connect (for fail-closed tests)."""
+
+    transport = httpx.MockTransport(_unreachable)
+    return httpx.AsyncClient(transport=transport)
+
+
+def _unreachable(_request: httpx.Request) -> httpx.Response:
+    raise httpx.ConnectError("simulated portal unreachable")

--- a/klai-libs/identity-assert/tests/test_cache.py
+++ b/klai-libs/identity-assert/tests/test_cache.py
@@ -1,0 +1,197 @@
+"""Unit tests for the per-process TTL cache."""
+
+from __future__ import annotations
+
+import pytest
+
+from klai_identity_assert import VerifyResult
+from klai_identity_assert.cache import IdentityCache, _fingerprint_jwt  # pyright: ignore[reportPrivateUsage]
+
+
+def _verified() -> VerifyResult:
+    return VerifyResult.allow(user_id="u-1", org_id="o-1", evidence="jwt")
+
+
+def test_get_returns_none_on_miss() -> None:
+    cache = IdentityCache()
+
+    assert cache.get(
+        caller_service="scribe",
+        claimed_user_id="u-1",
+        claimed_org_id="o-1",
+        bearer_jwt=None,
+    ) is None
+
+
+def test_put_then_get_returns_cached_with_cached_flag_true() -> None:
+    cache = IdentityCache()
+    cache.put(
+        caller_service="scribe",
+        claimed_user_id="u-1",
+        claimed_org_id="o-1",
+        bearer_jwt=None,
+        result=_verified(),
+        now=0.0,
+    )
+
+    cached = cache.get(
+        caller_service="scribe",
+        claimed_user_id="u-1",
+        claimed_org_id="o-1",
+        bearer_jwt=None,
+        now=30.0,
+    )
+
+    assert cached is not None
+    assert cached.verified is True
+    assert cached.cached is True
+    assert cached.user_id == "u-1"
+    assert cached.evidence == "jwt"
+
+
+def test_get_returns_none_after_ttl_elapsed() -> None:
+    cache = IdentityCache(ttl_seconds=60.0)
+    cache.put(
+        caller_service="scribe",
+        claimed_user_id="u-1",
+        claimed_org_id="o-1",
+        bearer_jwt=None,
+        result=_verified(),
+        now=0.0,
+    )
+
+    expired = cache.get(
+        caller_service="scribe",
+        claimed_user_id="u-1",
+        claimed_org_id="o-1",
+        bearer_jwt=None,
+        now=61.0,
+    )
+
+    assert expired is None
+
+
+def test_put_does_not_cache_denied_results() -> None:
+    cache = IdentityCache()
+    cache.put(
+        caller_service="scribe",
+        claimed_user_id="u-1",
+        claimed_org_id="o-1",
+        bearer_jwt=None,
+        result=VerifyResult.deny("no_membership"),
+    )
+
+    assert len(cache) == 0
+    assert cache.get(
+        caller_service="scribe",
+        claimed_user_id="u-1",
+        claimed_org_id="o-1",
+        bearer_jwt=None,
+    ) is None
+
+
+def test_jwt_fingerprint_distinguishes_callers() -> None:
+    cache = IdentityCache()
+    cache.put(
+        caller_service="scribe",
+        claimed_user_id="u-1",
+        claimed_org_id="o-1",
+        bearer_jwt="jwt-A",
+        result=_verified(),
+        now=0.0,
+    )
+
+    # A different JWT for the same (service, user, org) tuple is a CACHE MISS.
+    miss = cache.get(
+        caller_service="scribe",
+        claimed_user_id="u-1",
+        claimed_org_id="o-1",
+        bearer_jwt="jwt-B",
+        now=1.0,
+    )
+    assert miss is None
+
+    # Same JWT is a hit.
+    hit = cache.get(
+        caller_service="scribe",
+        claimed_user_id="u-1",
+        claimed_org_id="o-1",
+        bearer_jwt="jwt-A",
+        now=1.0,
+    )
+    assert hit is not None
+
+
+def test_jwt_fingerprint_helper_is_deterministic_and_short() -> None:
+    a = _fingerprint_jwt("the-token")
+    b = _fingerprint_jwt("the-token")
+    c = _fingerprint_jwt("different-token")
+
+    assert a == b
+    assert a != c
+    assert _fingerprint_jwt(None) == "none"
+    # Truncation: 16 hex chars (64 bits).
+    assert len(a) == 16
+
+
+def test_lru_eviction_drops_oldest_when_capacity_exceeded() -> None:
+    cache = IdentityCache(max_entries=2)
+    cache.put(
+        caller_service="scribe",
+        claimed_user_id="u-A",
+        claimed_org_id="o-1",
+        bearer_jwt=None,
+        result=_verified(),
+        now=0.0,
+    )
+    cache.put(
+        caller_service="scribe",
+        claimed_user_id="u-B",
+        claimed_org_id="o-1",
+        bearer_jwt=None,
+        result=_verified(),
+        now=1.0,
+    )
+    # Touch u-A so u-B becomes the oldest.
+    cache.get(
+        caller_service="scribe",
+        claimed_user_id="u-A",
+        claimed_org_id="o-1",
+        bearer_jwt=None,
+        now=2.0,
+    )
+    cache.put(
+        caller_service="scribe",
+        claimed_user_id="u-C",
+        claimed_org_id="o-1",
+        bearer_jwt=None,
+        result=_verified(),
+        now=3.0,
+    )
+
+    assert cache.get(
+        caller_service="scribe",
+        claimed_user_id="u-B",
+        claimed_org_id="o-1",
+        bearer_jwt=None,
+        now=4.0,
+    ) is None
+    assert cache.get(
+        caller_service="scribe",
+        claimed_user_id="u-A",
+        claimed_org_id="o-1",
+        bearer_jwt=None,
+        now=4.0,
+    ) is not None
+
+
+def test_init_rejects_invalid_ttl() -> None:
+    with pytest.raises(ValueError, match="ttl_seconds"):
+        IdentityCache(ttl_seconds=0)
+    with pytest.raises(ValueError, match="ttl_seconds"):
+        IdentityCache(ttl_seconds=-1.0)
+
+
+def test_init_rejects_invalid_max_entries() -> None:
+    with pytest.raises(ValueError, match="max_entries"):
+        IdentityCache(max_entries=0)

--- a/klai-libs/identity-assert/tests/test_client.py
+++ b/klai-libs/identity-assert/tests/test_client.py
@@ -320,13 +320,23 @@ async def test_verify_propagates_x_request_id(fake_user_id: str, fake_org_id: st
     assert isinstance(headers, dict)
     headers_dict = cast("dict[str, str]", headers)
     assert headers_dict.get("x-request-id") == "trace-abc-123"
-    assert headers_dict.get("x-internal-secret") == INTERNAL_SECRET
+    # Authorization header carries the shared INTERNAL_SECRET (matches
+    # portal-api's _require_internal_token convention).
+    assert headers_dict.get("authorization") == f"Bearer {INTERNAL_SECRET}"
     await asserter.aclose()
 
 
-async def test_verify_includes_internal_secret_header(
+async def test_verify_uses_authorization_bearer_for_internal_secret(
     fake_user_id: str, fake_org_id: str
 ) -> None:
+    """portal-api's /internal/* contract expects ``Authorization: Bearer <secret>``.
+
+    This is intentionally NOT a custom ``X-Internal-Secret`` header — that
+    convention is for callees of portal-api (knowledge-ingest, retrieval-api),
+    not callers OF portal-api. Drift between the two would make the call
+    fail with HTTP 401.
+    """
+
     capture: dict[str, object] = {}
     transport = _mock_portal(
         body={
@@ -350,7 +360,10 @@ async def test_verify_includes_internal_secret_header(
     headers = capture["headers"]
     assert isinstance(headers, dict)
     headers_dict = cast("dict[str, str]", headers)
-    assert headers_dict["x-internal-secret"] == INTERNAL_SECRET
+    assert headers_dict["authorization"] == f"Bearer {INTERNAL_SECRET}"
+    # X-Internal-Secret must NOT be set — that's the wrong convention for
+    # portal-api's /internal/* surface.
+    assert "x-internal-secret" not in headers_dict
     assert "/internal/identity/verify" in str(capture["url"])
     await asserter.aclose()
 

--- a/klai-libs/identity-assert/tests/test_client.py
+++ b/klai-libs/identity-assert/tests/test_client.py
@@ -1,0 +1,539 @@
+"""Tests for IdentityAsserter end-to-end behaviour with mocked portal."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import httpx
+import pytest
+
+from klai_identity_assert import (
+    IdentityAsserter,
+    IdentityDenied,
+    PortalUnreachable,
+    VerifyResult,
+)
+
+# Test-only constants. The ``portal_url`` / ``internal_secret`` fixtures in
+# conftest.py mirror these — kept in sync deliberately so the asserter fixture
+# and the ad-hoc transports built here use the same wire-level values.
+PORTAL_URL = "http://portal-api:8000"
+INTERNAL_SECRET = "test-internal-secret"  # noqa: S105
+
+
+def _mock_portal(
+    *,
+    status_code: int = 200,
+    body: dict[str, object] | None = None,
+    capture: dict[str, object] | None = None,
+) -> httpx.MockTransport:
+    """Build an httpx MockTransport that returns a canned portal response.
+
+    ``capture`` (when provided) records the last request's headers and body
+    so tests can assert on what was actually sent over the wire.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if capture is not None:
+            capture["url"] = str(request.url)
+            capture["headers"] = dict(request.headers)
+            capture["body"] = request.read().decode("utf-8")
+        return httpx.Response(status_code=status_code, json=body or {})
+
+    return httpx.MockTransport(handler)
+
+
+async def _build_asserter(transport: httpx.MockTransport) -> IdentityAsserter:
+    client = httpx.AsyncClient(transport=transport)
+    return IdentityAsserter(
+        portal_base_url=PORTAL_URL,
+        internal_secret=INTERNAL_SECRET,
+        http_client=client,
+        cache_ttl_seconds=60.0,
+    )
+
+
+async def test_verify_returns_allow_on_jwt_evidence(fake_user_id: str, fake_org_id: str) -> None:
+    transport = _mock_portal(
+        body={
+            "verified": True,
+            "user_id": fake_user_id,
+            "org_id": fake_org_id,
+            "cache_ttl_seconds": 60,
+            "evidence": "jwt",
+        },
+    )
+    asserter = await _build_asserter(transport)
+
+    result = await asserter.verify(
+        caller_service="scribe",
+        claimed_user_id=fake_user_id,
+        claimed_org_id=fake_org_id,
+        bearer_jwt="some.jwt.value",
+    )
+
+    assert result.verified is True
+    assert result.user_id == fake_user_id
+    assert result.org_id == fake_org_id
+    assert result.evidence == "jwt"
+    assert result.cached is False
+    await asserter.aclose()
+
+
+async def test_verify_returns_allow_on_membership_evidence(
+    fake_user_id: str, fake_org_id: str
+) -> None:
+    transport = _mock_portal(
+        body={
+            "verified": True,
+            "user_id": fake_user_id,
+            "org_id": fake_org_id,
+            "cache_ttl_seconds": 60,
+            "evidence": "membership",
+        },
+    )
+    asserter = await _build_asserter(transport)
+
+    result = await asserter.verify(
+        caller_service="knowledge-mcp",
+        claimed_user_id=fake_user_id,
+        claimed_org_id=fake_org_id,
+        bearer_jwt=None,
+    )
+
+    assert result.verified is True
+    assert result.evidence == "membership"
+    await asserter.aclose()
+
+
+async def test_verify_returns_deny_on_no_membership(
+    fake_user_id: str, other_org_id: str
+) -> None:
+    transport = _mock_portal(
+        status_code=403,
+        body={"verified": False, "reason": "no_membership"},
+    )
+    asserter = await _build_asserter(transport)
+
+    result = await asserter.verify(
+        caller_service="scribe",
+        claimed_user_id=fake_user_id,
+        claimed_org_id=other_org_id,
+        bearer_jwt=None,
+    )
+
+    assert result.verified is False
+    assert result.reason == "no_membership"
+    assert result.user_id is None
+    assert result.org_id is None
+    await asserter.aclose()
+
+
+async def test_verify_returns_deny_on_jwt_identity_mismatch(
+    fake_user_id: str, fake_org_id: str
+) -> None:
+    transport = _mock_portal(
+        status_code=403,
+        body={"verified": False, "reason": "jwt_identity_mismatch"},
+    )
+    asserter = await _build_asserter(transport)
+
+    result = await asserter.verify(
+        caller_service="scribe",
+        claimed_user_id=fake_user_id,
+        claimed_org_id=fake_org_id,
+        bearer_jwt="forged.or.expired.jwt",
+    )
+
+    assert result.verified is False
+    assert result.reason == "jwt_identity_mismatch"
+    await asserter.aclose()
+
+
+async def test_verify_fails_closed_on_network_error(
+    fake_user_id: str, fake_org_id: str
+) -> None:
+    def fail(_request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("portal down")
+
+    transport = httpx.MockTransport(fail)
+    asserter = await _build_asserter(transport)
+
+    result = await asserter.verify(
+        caller_service="scribe",
+        claimed_user_id=fake_user_id,
+        claimed_org_id=fake_org_id,
+        bearer_jwt=None,
+    )
+
+    assert result.verified is False
+    assert result.reason == "portal_unreachable"
+    await asserter.aclose()
+
+
+async def test_verify_fails_closed_on_5xx(fake_user_id: str, fake_org_id: str) -> None:
+    transport = _mock_portal(status_code=503, body={"detail": "redis down"})
+    asserter = await _build_asserter(transport)
+
+    result = await asserter.verify(
+        caller_service="scribe",
+        claimed_user_id=fake_user_id,
+        claimed_org_id=fake_org_id,
+        bearer_jwt=None,
+    )
+
+    assert result.verified is False
+    assert result.reason == "portal_unreachable"
+    await asserter.aclose()
+
+
+async def test_verify_fails_closed_on_unknown_caller_service(
+    fake_user_id: str, fake_org_id: str
+) -> None:
+    transport = _mock_portal(body={"verified": True})
+    asserter = await _build_asserter(transport)
+
+    result = await asserter.verify(
+        caller_service="unknown-service",
+        claimed_user_id=fake_user_id,
+        claimed_org_id=fake_org_id,
+        bearer_jwt=None,
+    )
+
+    assert result.verified is False
+    assert result.reason == "library_misconfigured"
+    await asserter.aclose()
+
+
+async def test_verify_fails_closed_on_malformed_json(
+    fake_user_id: str, fake_org_id: str
+) -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"not-json")
+
+    transport = httpx.MockTransport(handler)
+    asserter = await _build_asserter(transport)
+
+    result = await asserter.verify(
+        caller_service="scribe",
+        claimed_user_id=fake_user_id,
+        claimed_org_id=fake_org_id,
+        bearer_jwt=None,
+    )
+
+    assert result.verified is False
+    assert result.reason == "portal_unreachable"
+    await asserter.aclose()
+
+
+async def test_verify_caches_allow_results(
+    fake_user_id: str, fake_org_id: str
+) -> None:
+    call_count = {"value": 0}
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        call_count["value"] += 1
+        return httpx.Response(
+            200,
+            json={
+                "verified": True,
+                "user_id": fake_user_id,
+                "org_id": fake_org_id,
+                "cache_ttl_seconds": 60,
+                "evidence": "jwt",
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    asserter = await _build_asserter(transport)
+
+    first = await asserter.verify(
+        caller_service="scribe",
+        claimed_user_id=fake_user_id,
+        claimed_org_id=fake_org_id,
+        bearer_jwt="jwt-1",
+    )
+    second = await asserter.verify(
+        caller_service="scribe",
+        claimed_user_id=fake_user_id,
+        claimed_org_id=fake_org_id,
+        bearer_jwt="jwt-1",
+    )
+
+    assert call_count["value"] == 1, "second call should hit cache, not portal"
+    assert first.cached is False
+    assert second.cached is True
+    assert second.user_id == fake_user_id
+    await asserter.aclose()
+
+
+async def test_verify_does_not_cache_denials(fake_user_id: str, fake_org_id: str) -> None:
+    call_count = {"value": 0}
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        call_count["value"] += 1
+        return httpx.Response(403, json={"verified": False, "reason": "no_membership"})
+
+    transport = httpx.MockTransport(handler)
+    asserter = await _build_asserter(transport)
+
+    await asserter.verify(
+        caller_service="scribe",
+        claimed_user_id=fake_user_id,
+        claimed_org_id=fake_org_id,
+        bearer_jwt=None,
+    )
+    await asserter.verify(
+        caller_service="scribe",
+        claimed_user_id=fake_user_id,
+        claimed_org_id=fake_org_id,
+        bearer_jwt=None,
+    )
+
+    assert call_count["value"] == 2, "denials must re-query portal — no negative cache"
+    await asserter.aclose()
+
+
+async def test_verify_propagates_x_request_id(fake_user_id: str, fake_org_id: str) -> None:
+    capture: dict[str, object] = {}
+    transport = _mock_portal(
+        body={
+            "verified": True,
+            "user_id": fake_user_id,
+            "org_id": fake_org_id,
+            "cache_ttl_seconds": 60,
+            "evidence": "membership",
+        },
+        capture=capture,
+    )
+    asserter = await _build_asserter(transport)
+
+    await asserter.verify(
+        caller_service="scribe",
+        claimed_user_id=fake_user_id,
+        claimed_org_id=fake_org_id,
+        bearer_jwt=None,
+        request_headers={"X-Request-ID": "trace-abc-123"},
+    )
+
+    headers = capture["headers"]
+    assert isinstance(headers, dict)
+    headers_dict = cast("dict[str, str]", headers)
+    assert headers_dict.get("x-request-id") == "trace-abc-123"
+    assert headers_dict.get("x-internal-secret") == INTERNAL_SECRET
+    await asserter.aclose()
+
+
+async def test_verify_includes_internal_secret_header(
+    fake_user_id: str, fake_org_id: str
+) -> None:
+    capture: dict[str, object] = {}
+    transport = _mock_portal(
+        body={
+            "verified": True,
+            "user_id": fake_user_id,
+            "org_id": fake_org_id,
+            "cache_ttl_seconds": 60,
+            "evidence": "jwt",
+        },
+        capture=capture,
+    )
+    asserter = await _build_asserter(transport)
+
+    await asserter.verify(
+        caller_service="scribe",
+        claimed_user_id=fake_user_id,
+        claimed_org_id=fake_org_id,
+        bearer_jwt="jwt-1",
+    )
+
+    headers = capture["headers"]
+    assert isinstance(headers, dict)
+    headers_dict = cast("dict[str, str]", headers)
+    assert headers_dict["x-internal-secret"] == INTERNAL_SECRET
+    assert "/internal/identity/verify" in str(capture["url"])
+    await asserter.aclose()
+
+
+async def test_verify_or_raise_returns_on_allow(
+    fake_user_id: str, fake_org_id: str
+) -> None:
+    transport = _mock_portal(
+        body={
+            "verified": True,
+            "user_id": fake_user_id,
+            "org_id": fake_org_id,
+            "cache_ttl_seconds": 60,
+            "evidence": "jwt",
+        },
+    )
+    asserter = await _build_asserter(transport)
+
+    result = await asserter.verify_or_raise(
+        caller_service="scribe",
+        claimed_user_id=fake_user_id,
+        claimed_org_id=fake_org_id,
+        bearer_jwt="jwt-1",
+    )
+
+    assert result.verified is True
+    await asserter.aclose()
+
+
+async def test_verify_or_raise_raises_portal_unreachable(
+    fake_user_id: str, fake_org_id: str
+) -> None:
+    def fail(_request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("portal down")
+
+    transport = httpx.MockTransport(fail)
+    asserter = await _build_asserter(transport)
+
+    with pytest.raises(PortalUnreachable):
+        await asserter.verify_or_raise(
+            caller_service="scribe",
+            claimed_user_id=fake_user_id,
+            claimed_org_id=fake_org_id,
+            bearer_jwt=None,
+        )
+    await asserter.aclose()
+
+
+async def test_verify_or_raise_raises_identity_denied(
+    fake_user_id: str, other_org_id: str
+) -> None:
+    transport = _mock_portal(
+        status_code=403,
+        body={"verified": False, "reason": "no_membership"},
+    )
+    asserter = await _build_asserter(transport)
+
+    with pytest.raises(IdentityDenied) as exc_info:
+        await asserter.verify_or_raise(
+            caller_service="scribe",
+            claimed_user_id=fake_user_id,
+            claimed_org_id=other_org_id,
+            bearer_jwt=None,
+        )
+    assert exc_info.value.reason == "no_membership"
+    await asserter.aclose()
+
+
+def test_init_rejects_empty_portal_base_url() -> None:
+    with pytest.raises(ValueError, match="portal_base_url"):
+        IdentityAsserter(portal_base_url="", internal_secret="x")
+
+
+def test_init_rejects_empty_internal_secret() -> None:
+    with pytest.raises(ValueError, match="internal_secret"):
+        IdentityAsserter(portal_base_url="http://x", internal_secret="")
+
+
+async def test_aclose_owns_only_constructed_client(
+    fake_user_id: str, fake_org_id: str
+) -> None:
+    """Asserter MUST NOT close a borrowed http_client (caller owns lifecycle)."""
+
+    capture: dict[str, object] = {}
+    transport = _mock_portal(
+        body={
+            "verified": True,
+            "user_id": fake_user_id,
+            "org_id": fake_org_id,
+            "cache_ttl_seconds": 60,
+            "evidence": "jwt",
+        },
+        capture=capture,
+    )
+    borrowed = httpx.AsyncClient(transport=transport)
+
+    asserter = IdentityAsserter(
+        portal_base_url=PORTAL_URL,
+        internal_secret=INTERNAL_SECRET,
+        http_client=borrowed,
+    )
+    await asserter.aclose()
+
+    # Borrowed client must still be usable.
+    response = await borrowed.post(
+        f"{PORTAL_URL}/internal/identity/verify",
+        json={
+            "caller_service": "scribe",
+            "claimed_user_id": fake_user_id,
+            "claimed_org_id": fake_org_id,
+            "bearer_jwt": None,
+        },
+    )
+    assert response.status_code == 200
+    await borrowed.aclose()
+
+
+async def test_verify_request_body_shape(fake_user_id: str, fake_org_id: str) -> None:
+    capture: dict[str, object] = {}
+    transport = _mock_portal(
+        body={
+            "verified": True,
+            "user_id": fake_user_id,
+            "org_id": fake_org_id,
+            "cache_ttl_seconds": 60,
+            "evidence": "jwt",
+        },
+        capture=capture,
+    )
+    asserter = await _build_asserter(transport)
+
+    await asserter.verify(
+        caller_service="scribe",
+        claimed_user_id=fake_user_id,
+        claimed_org_id=fake_org_id,
+        bearer_jwt="jwt-1",
+    )
+
+    import json as _json
+
+    body = _json.loads(str(capture["body"]))
+    assert body["caller_service"] == "scribe"
+    assert body["claimed_user_id"] == fake_user_id
+    assert body["claimed_org_id"] == fake_org_id
+    assert body["bearer_jwt"] == "jwt-1"
+    await asserter.aclose()
+
+
+async def test_unrecognised_reason_code_collapses_to_portal_unreachable(
+    fake_user_id: str, fake_org_id: str
+) -> None:
+    """If portal returns a reason code the library does not know, fail closed."""
+
+    transport = _mock_portal(
+        status_code=403,
+        body={"verified": False, "reason": "some_future_code_we_do_not_know"},
+    )
+    asserter = await _build_asserter(transport)
+
+    result = await asserter.verify(
+        caller_service="scribe",
+        claimed_user_id=fake_user_id,
+        claimed_org_id=fake_org_id,
+        bearer_jwt=None,
+    )
+
+    assert result.verified is False
+    assert result.reason == "portal_unreachable"
+    await asserter.aclose()
+
+
+async def test_verify_returns_verify_result_type(
+    asserter: IdentityAsserter, fake_user_id: str, fake_org_id: str
+) -> None:
+    """Smoke test: the asserter fixture composes correctly."""
+    # No transport mounted on the fixture; we expect fail-closed.
+    result = await asserter.verify(
+        caller_service="scribe",
+        claimed_user_id=fake_user_id,
+        claimed_org_id=fake_org_id,
+        bearer_jwt=None,
+    )
+
+    assert isinstance(result, VerifyResult)
+    assert result.verified is False
+    assert result.reason == "portal_unreachable"

--- a/klai-libs/identity-assert/tests/test_models.py
+++ b/klai-libs/identity-assert/tests/test_models.py
@@ -1,0 +1,56 @@
+"""Unit tests for VerifyResult dataclass."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from klai_identity_assert import KNOWN_CALLER_SERVICES, VerifyResult
+
+
+def test_allow_factory_sets_verified_true_with_canonical_identity() -> None:
+    result = VerifyResult.allow(user_id="u-1", org_id="o-1", evidence="jwt")
+
+    assert result.verified is True
+    assert result.user_id == "u-1"
+    assert result.org_id == "o-1"
+    assert result.evidence == "jwt"
+    assert result.reason is None
+    assert result.cached is False
+
+
+def test_allow_factory_supports_membership_evidence() -> None:
+    result = VerifyResult.allow(user_id="u-1", org_id="o-1", evidence="membership", cached=True)
+
+    assert result.evidence == "membership"
+    assert result.cached is True
+
+
+def test_deny_factory_sets_reason_and_clears_identity() -> None:
+    result = VerifyResult.deny("no_membership")
+
+    assert result.verified is False
+    assert result.user_id is None
+    assert result.org_id is None
+    assert result.evidence is None
+    assert result.reason == "no_membership"
+    assert result.cached is False
+
+
+def test_dataclass_is_frozen() -> None:
+    result = VerifyResult.allow(user_id="u-1", org_id="o-1", evidence="jwt")
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        result.verified = False  # type: ignore[misc]
+
+
+def test_known_caller_services_includes_required_consumers() -> None:
+    # SPEC REQ-1.2 reject list. Adding a caller without portal-side change
+    # would be silent fail-closed at the library; this assertion guards
+    # against accidental removals.
+    assert "knowledge-mcp" in KNOWN_CALLER_SERVICES
+    assert "scribe" in KNOWN_CALLER_SERVICES
+    assert "retrieval-api" in KNOWN_CALLER_SERVICES
+    assert "connector" in KNOWN_CALLER_SERVICES
+    assert "mailer" in KNOWN_CALLER_SERVICES

--- a/klai-libs/identity-assert/tests/test_telemetry.py
+++ b/klai-libs/identity-assert/tests/test_telemetry.py
@@ -1,0 +1,79 @@
+"""Tests for telemetry helpers.
+
+structlog uses its own pipeline rather than stdlib logging by default, so
+``caplog`` does not see emitted events. We use structlog's built-in
+``capture_logs`` context manager — the idiomatic way to assert on
+structured events emitted via ``BoundLoggerBase``.
+"""
+
+from __future__ import annotations
+
+from structlog.testing import capture_logs
+
+from klai_identity_assert import VerifyResult
+from klai_identity_assert.telemetry import emit_call, hash_user_id, measure_latency
+
+
+def test_hash_user_id_is_stable_and_truncated() -> None:
+    a = hash_user_id("user-1")
+    b = hash_user_id("user-1")
+    c = hash_user_id("user-2")
+
+    assert a == b
+    assert a != c
+    assert len(a) == 16
+
+
+def test_measure_latency_populates_field() -> None:
+    with measure_latency() as latency:
+        # Trivial work — just confirm the timer runs.
+        _ = sum(range(100))
+    assert latency["latency_ms"] >= 0.0
+
+
+def test_emit_call_logs_event_with_required_fields_on_allow() -> None:
+    result = VerifyResult.allow(user_id="u-1", org_id="o-1", evidence="jwt")
+
+    with capture_logs() as captured:
+        emit_call(
+            caller_service="scribe",
+            claimed_user_id="u-1",
+            claimed_org_id="o-1",
+            result=result,
+            latency_ms=12.34,
+        )
+
+    assert len(captured) == 1
+    entry = captured[0]
+    assert entry["event"] == "identity_assert_call"
+    assert entry["log_level"] == "info"
+    assert entry["caller_service"] == "scribe"
+    assert entry["verified"] is True
+    assert entry["cached"] is False
+    assert entry["evidence"] == "jwt"
+    assert entry["claimed_org_id"] == "o-1"
+    # Privacy: never log raw user_id.
+    assert entry["claimed_user_id_hash"] == hash_user_id("u-1")
+    assert "u-1" not in str(entry).replace("u-1's hash placeholder", "")
+    assert "reason" not in entry  # only present on deny
+
+
+def test_emit_call_logs_at_warning_level_with_reason_on_deny() -> None:
+    result = VerifyResult.deny("no_membership")
+
+    with capture_logs() as captured:
+        emit_call(
+            caller_service="scribe",
+            claimed_user_id="u-1",
+            claimed_org_id="o-1",
+            result=result,
+            latency_ms=5.0,
+        )
+
+    assert len(captured) == 1
+    entry = captured[0]
+    assert entry["event"] == "identity_assert_call"
+    assert entry["log_level"] == "warning"
+    assert entry["verified"] is False
+    assert entry["reason"] == "no_membership"
+    assert "evidence" not in entry  # only present on allow

--- a/klai-portal/backend/app/api/internal.py
+++ b/klai-portal/backend/app/api/internal.py
@@ -1190,3 +1190,289 @@ async def get_effective_templates(
 
     await _audit_internal_call(request, org_id=org.id)
     return TemplatesEffectiveResponse(instructions=instructions)
+
+
+# ---------------------------------------------------------------------------
+# SPEC-SEC-IDENTITY-ASSERT-001 REQ-1: /internal/identity/verify
+# ---------------------------------------------------------------------------
+#
+# Source-of-truth for "is the claimed (user, org) tuple real?". Every
+# Klai service that carries a tenant or user identity claim consults
+# this endpoint via the shared library at klai-libs/identity-assert/.
+#
+# The endpoint is the THIN HTTP wrapper; verification logic lives in
+# app.services.identity_verifier and the Redis cache lives in
+# app.services.identity_verify_cache. This separation means service
+# layer is unit-testable without spinning up a TestClient, and the
+# cache layer is swappable in isolation.
+
+
+class IdentityVerifyRequest(BaseModel):
+    """Request body for POST /internal/identity/verify (REQ-1.1)."""
+
+    caller_service: str
+    claimed_user_id: str
+    claimed_org_id: str
+    bearer_jwt: str | None = None
+
+
+class IdentityVerifySuccess(BaseModel):
+    """200 response when the claim is verified."""
+
+    verified: Literal[True] = True
+    user_id: str
+    org_id: str
+    cache_ttl_seconds: int
+    evidence: Literal["jwt", "membership"]
+
+
+class IdentityVerifyDeny(BaseModel):
+    """403/400/503 response body when the claim is denied or unverifiable."""
+
+    verified: Literal[False] = False
+    reason: str
+
+
+def _hash_zitadel_id(value: str) -> str:
+    """16-hex-char SHA-256 prefix.
+
+    Same convention as ``_hash_sub`` in
+    ``klai-retrieval-api/retrieval_api/middleware/auth.py``. Keeps
+    structlog entries free of raw UUIDs / Zitadel IDs (REQ-1.7).
+    """
+
+    import hashlib  # local import to avoid touching module-level imports
+
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:16]
+
+
+def _get_identity_jwks_resolver() -> "object":
+    """Return the process-wide PyJWKClient for end-user JWT validation.
+
+    Reuses the same Zitadel JWKS endpoint as bff_oidc — Zitadel signs all
+    tokens (id_tokens AND access_tokens) with the same key set. We do NOT
+    reuse ``app.services.bff_oidc._get_jwks_client`` directly because that
+    helper is private; instead we instantiate our own client backed by the
+    same URL so the two don't share cache state (avoids contamination if
+    bff_oidc rotates its client for any reason).
+    """
+
+    from jwt import PyJWKClient  # local import keeps optional dep top-level out
+
+    global _identity_jwks_client
+    if _identity_jwks_client is None:
+        _identity_jwks_client = PyJWKClient(
+            f"{settings.zitadel_base_url}/oauth/v2/keys",
+            cache_keys=True,
+            max_cached_keys=16,
+            lifespan=3600,
+        )
+    return _identity_jwks_client
+
+
+_identity_jwks_client: "object | None" = None
+
+
+@router.post(
+    "/identity/verify",
+    response_model=None,  # union response — FastAPI serialises via the explicit Response object
+)
+async def verify_identity(
+    request: Request,
+    body: IdentityVerifyRequest,
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """Verify a service-asserted identity claim against portal source-of-truth.
+
+    Implements SPEC-SEC-IDENTITY-ASSERT-001 REQ-1. See the SPEC and
+    ``app/services/identity_verifier.py`` for the contract; this handler is
+    the HTTP layer + cache + structured-log wrapper.
+
+    Failure modes (REQ-1.2 / 1.3 / 1.4 / 1.6):
+
+    - ``unknown_caller_service`` → HTTP 400 (caller is misconfigured; loud
+      failure rather than silent rate-limit consumption).
+    - ``invalid_jwt`` → HTTP 403 (the caller forwarded a JWT that fails
+      signature/exp validation; never falls back to membership — REQ-1.8).
+    - ``jwt_identity_mismatch`` → HTTP 403 (the JWT is valid but its sub /
+      resourceowner do not match the claimed tuple).
+    - ``no_membership`` → HTTP 403 (membership lookup found no active
+      ``portal_users`` row).
+    - ``cache_unavailable`` → HTTP 503 (Redis call failed; auth-class
+      control fails closed — REQ-1.6).
+    """
+
+    from app.services.identity_verifier import (
+        KNOWN_CALLER_SERVICES,
+        verify_identity_claim,
+    )
+    from app.services.identity_verify_cache import (
+        CacheUnavailable,
+        cache_verified_decision,
+        get_cached_decision,
+    )
+
+    await _require_internal_token(request)
+
+    # REQ-1.2: unknown caller_service is a 400 (not silenced into rate-limit).
+    if body.caller_service not in KNOWN_CALLER_SERVICES:
+        await _audit_internal_call(request, org_id=0)
+        structlog_logger.warning(
+            "identity_verify_decision",
+            caller_service=body.caller_service,
+            claimed_user_id_hash=_hash_zitadel_id(body.claimed_user_id),
+            claimed_org_id=body.claimed_org_id,
+            verified=False,
+            reason="unknown_caller_service",
+        )
+        return Response(
+            content=IdentityVerifyDeny(reason="unknown_caller_service").model_dump_json(),
+            status_code=status.HTTP_400_BAD_REQUEST,
+            media_type="application/json",
+        )
+
+    # REQ-1.5: cache lookup before any DB or JWT work.
+    redis_pool = await get_redis_pool()
+    cache_user_id_hash = _hash_zitadel_id(body.claimed_user_id)
+
+    if redis_pool is None:
+        # No Redis → fail closed (REQ-1.6). This branch is hit when the pool
+        # was never initialised; transient errors are caught by CacheUnavailable.
+        await _audit_internal_call(request, org_id=0)
+        structlog_logger.warning(
+            "identity_verify_decision",
+            caller_service=body.caller_service,
+            claimed_user_id_hash=cache_user_id_hash,
+            claimed_org_id=body.claimed_org_id,
+            verified=False,
+            reason="cache_unavailable",
+        )
+        return Response(
+            content=IdentityVerifyDeny(reason="cache_unavailable").model_dump_json(),
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            media_type="application/json",
+        )
+
+    try:
+        cached = await get_cached_decision(
+            redis=redis_pool,
+            caller_service=body.caller_service,
+            claimed_user_id=body.claimed_user_id,
+            claimed_org_id=body.claimed_org_id,
+        )
+    except CacheUnavailable:
+        await _audit_internal_call(request, org_id=0)
+        structlog_logger.warning(
+            "identity_verify_decision",
+            caller_service=body.caller_service,
+            claimed_user_id_hash=cache_user_id_hash,
+            claimed_org_id=body.claimed_org_id,
+            verified=False,
+            reason="cache_unavailable",
+        )
+        return Response(
+            content=IdentityVerifyDeny(reason="cache_unavailable").model_dump_json(),
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            media_type="application/json",
+        )
+
+    if cached is not None and cached.evidence is not None and cached.user_id is not None and cached.org_id is not None:
+        await _audit_internal_call(request, org_id=0)
+        structlog_logger.info(
+            "identity_verify_decision",
+            caller_service=body.caller_service,
+            claimed_user_id_hash=cache_user_id_hash,
+            claimed_org_id=body.claimed_org_id,
+            verified=True,
+            evidence=cached.evidence,
+            cache_hit=True,
+        )
+        return Response(
+            content=IdentityVerifySuccess(
+                user_id=cached.user_id,
+                org_id=cached.org_id,
+                cache_ttl_seconds=60,
+                evidence=cached.evidence,
+            ).model_dump_json(),
+            status_code=status.HTTP_200_OK,
+            media_type="application/json",
+        )
+
+    # Cache miss: run the verifier.
+    decision = await verify_identity_claim(
+        db=db,
+        jwks_resolver=_get_identity_jwks_resolver(),  # type: ignore[arg-type]
+        caller_service=body.caller_service,
+        claimed_user_id=body.claimed_user_id,
+        claimed_org_id=body.claimed_org_id,
+        bearer_jwt=body.bearer_jwt,
+    )
+
+    if not decision.verified:
+        await _audit_internal_call(request, org_id=0)
+        structlog_logger.warning(
+            "identity_verify_decision",
+            caller_service=body.caller_service,
+            claimed_user_id_hash=cache_user_id_hash,
+            claimed_org_id=body.claimed_org_id,
+            verified=False,
+            reason=decision.reason,
+            cache_hit=False,
+        )
+        return Response(
+            content=IdentityVerifyDeny(reason=decision.reason or "unknown").model_dump_json(),
+            status_code=status.HTTP_403_FORBIDDEN,
+            media_type="application/json",
+        )
+
+    # Verified: cache and return 200.
+    try:
+        await cache_verified_decision(
+            redis=redis_pool,
+            caller_service=body.caller_service,
+            claimed_user_id=body.claimed_user_id,
+            claimed_org_id=body.claimed_org_id,
+            decision=decision,
+        )
+    except CacheUnavailable:
+        # Cache write failed AFTER a successful verification. We MUST NOT
+        # return the verified decision — see REQ-1.6 "auth-class control
+        # must not silently downgrade". A flap that disables the cache
+        # would amplify DB load on the next call; failing this single
+        # request closes that loop.
+        await _audit_internal_call(request, org_id=0)
+        structlog_logger.warning(
+            "identity_verify_decision",
+            caller_service=body.caller_service,
+            claimed_user_id_hash=cache_user_id_hash,
+            claimed_org_id=body.claimed_org_id,
+            verified=False,
+            reason="cache_unavailable",
+        )
+        return Response(
+            content=IdentityVerifyDeny(reason="cache_unavailable").model_dump_json(),
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            media_type="application/json",
+        )
+
+    await _audit_internal_call(request, org_id=0)
+    assert decision.user_id is not None and decision.org_id is not None and decision.evidence is not None
+    structlog_logger.info(
+        "identity_verify_decision",
+        caller_service=body.caller_service,
+        claimed_user_id_hash=cache_user_id_hash,
+        claimed_org_id=body.claimed_org_id,
+        verified=True,
+        evidence=decision.evidence,
+        cache_hit=False,
+    )
+    return Response(
+        content=IdentityVerifySuccess(
+            user_id=decision.user_id,
+            org_id=decision.org_id,
+            cache_ttl_seconds=60,
+            evidence=decision.evidence,
+        ).model_dump_json(),
+        status_code=status.HTTP_200_OK,
+        media_type="application/json",
+    )

--- a/klai-portal/backend/app/api/internal.py
+++ b/klai-portal/backend/app/api/internal.py
@@ -30,6 +30,7 @@ from bson import ObjectId
 from bson.errors import InvalidId
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import Response
+from jwt import PyJWKClient
 from motor.motor_asyncio import AsyncIOMotorClient
 from pydantic import BaseModel
 from redis.exceptions import RedisError
@@ -1246,7 +1247,10 @@ def _hash_zitadel_id(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()[:16]
 
 
-def _get_identity_jwks_resolver() -> "object":
+_identity_jwks_client: PyJWKClient | None = None
+
+
+def _get_identity_jwks_resolver() -> PyJWKClient:
     """Return the process-wide PyJWKClient for end-user JWT validation.
 
     Reuses the same Zitadel JWKS endpoint as bff_oidc — Zitadel signs all
@@ -1257,8 +1261,6 @@ def _get_identity_jwks_resolver() -> "object":
     bff_oidc rotates its client for any reason).
     """
 
-    from jwt import PyJWKClient  # local import keeps optional dep top-level out
-
     global _identity_jwks_client
     if _identity_jwks_client is None:
         _identity_jwks_client = PyJWKClient(
@@ -1268,9 +1270,6 @@ def _get_identity_jwks_resolver() -> "object":
             lifespan=3600,
         )
     return _identity_jwks_client
-
-
-_identity_jwks_client: "object | None" = None
 
 
 @router.post(
@@ -1359,6 +1358,7 @@ async def verify_identity(
             caller_service=body.caller_service,
             claimed_user_id=body.claimed_user_id,
             claimed_org_id=body.claimed_org_id,
+            bearer_jwt=body.bearer_jwt,
         )
     except CacheUnavailable:
         await _audit_internal_call(request, org_id=0)
@@ -1401,7 +1401,7 @@ async def verify_identity(
     # Cache miss: run the verifier.
     decision = await verify_identity_claim(
         db=db,
-        jwks_resolver=_get_identity_jwks_resolver(),  # type: ignore[arg-type]
+        jwks_resolver=_get_identity_jwks_resolver(),
         caller_service=body.caller_service,
         claimed_user_id=body.claimed_user_id,
         claimed_org_id=body.claimed_org_id,

--- a/klai-portal/backend/app/services/identity_verifier.py
+++ b/klai-portal/backend/app/services/identity_verifier.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Any, Literal, Protocol, runtime_checkable
 
 import jwt
 from sqlalchemy import select
@@ -142,16 +142,16 @@ def _decode_user_jwt(bearer_jwt: str, jwks_resolver: JwksResolver) -> dict[str, 
         return None
 
 
-class JwksResolver:
-    """Minimal duck-typing protocol for ``PyJWKClient``.
+@runtime_checkable
+class JwksResolver(Protocol):
+    """Structural type for any object that resolves a JWT signing key.
 
-    Defining this lets tests inject a fake without depending on jwt internals.
-    Production passes ``app.services.bff_oidc._get_jwks_client()`` which
-    returns a real ``PyJWKClient``.
+    The production implementation is ``jwt.PyJWKClient`` (instantiated by
+    ``_get_identity_jwks_resolver`` in ``app.api.internal``). Tests inject
+    a fake conforming to this protocol — no inheritance required.
     """
 
-    def get_signing_key_from_jwt(self, _token: str) -> Any:  # pragma: no cover - protocol
-        raise NotImplementedError
+    def get_signing_key_from_jwt(self, token: str, /) -> Any: ...
 
 
 # ---------------------------------------------------------------------------

--- a/klai-portal/backend/app/services/identity_verifier.py
+++ b/klai-portal/backend/app/services/identity_verifier.py
@@ -1,0 +1,254 @@
+"""Identity verification service for portal-api /internal/identity/verify.
+
+SPEC-SEC-IDENTITY-ASSERT-001 REQ-1: this is the source-of-truth implementation
+of "is the claimed (user, org) tuple real". Every Klai service-to-service call
+that carries an identity claim eventually reaches this function (via the
+endpoint in :mod:`app.api.internal`).
+
+Design responsibilities, in order:
+
+1. **JWT path** (REQ-1.3) — when the caller forwarded the end-user JWT, decode
+   and verify its signature against Zitadel JWKS, then assert
+   ``jwt.sub == claimed_user_id`` AND ``jwt.resourceowner == claimed_org_id``.
+   On mismatch return ``jwt_identity_mismatch``. On invalid signature/exp/aud
+   return ``invalid_jwt`` — never fall through to the membership path.
+2. **Membership path** (REQ-1.4) — when ``bearer_jwt`` is None, look up the
+   user's active membership in ``portal_users`` keyed on
+   ``(zitadel_user_id, zitadel_org_id, status='active')``. On match return
+   ``evidence='membership'``; on miss return ``no_membership``.
+3. **caller_service allowlist** (REQ-1.2) — anything not in the recognised
+   list returns ``unknown_caller_service`` BEFORE any DB or JWT work.
+
+Caching (REQ-1.5) is wrapped around this function by the endpoint layer
+(:mod:`app.services.identity_verify_cache`); this service is cache-blind.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import jwt
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models.portal import PortalOrg, PortalUser
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Recognised callers (REQ-1.2)
+# ---------------------------------------------------------------------------
+
+# Mirrors klai_identity_assert.KNOWN_CALLER_SERVICES exactly. Adding a caller
+# requires a synchronised change in both locations; the library fails closed
+# with ``library_misconfigured`` and the endpoint with
+# ``unknown_caller_service`` so a one-sided change is loud.
+KNOWN_CALLER_SERVICES: frozenset[str] = frozenset(
+    {
+        "knowledge-mcp",
+        "scribe",
+        "retrieval-api",
+        "connector",
+        "mailer",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# JWT validation
+# ---------------------------------------------------------------------------
+
+# Stable Zitadel claim name for the user's primary org. Matches the constant
+# at ``klai-retrieval-api/retrieval_api/middleware/auth.py``. Defining it here
+# instead of importing keeps portal-api standalone — retrieval-api is not on
+# our import path.
+_ZITADEL_RESOURCEOWNER_CLAIM = "urn:zitadel:iam:user:resourceowner:id"
+
+
+# ---------------------------------------------------------------------------
+# Result type
+# ---------------------------------------------------------------------------
+
+ReasonCode = Literal[
+    "unknown_caller_service",
+    "invalid_jwt",
+    "jwt_identity_mismatch",
+    "no_membership",
+]
+Evidence = Literal["jwt", "membership"]
+
+
+@dataclass(frozen=True, slots=True)
+class VerifyDecision:
+    """Outcome of :func:`verify_identity_claim`.
+
+    Mirrors ``klai_identity_assert.VerifyResult`` at the HTTP boundary —
+    the endpoint layer maps this to the JSON body documented in REQ-1.1.
+    """
+
+    verified: bool
+    user_id: str | None
+    org_id: str | None
+    reason: ReasonCode | None
+    evidence: Evidence | None
+
+    @classmethod
+    def deny(cls, reason: ReasonCode) -> VerifyDecision:
+        return cls(verified=False, user_id=None, org_id=None, reason=reason, evidence=None)
+
+    @classmethod
+    def allow(cls, *, user_id: str, org_id: str, evidence: Evidence) -> VerifyDecision:
+        return cls(verified=True, user_id=user_id, org_id=org_id, reason=None, evidence=evidence)
+
+
+# ---------------------------------------------------------------------------
+# JWT validation
+# ---------------------------------------------------------------------------
+
+
+def _decode_user_jwt(bearer_jwt: str, jwks_resolver: JwksResolver) -> dict[str, Any] | None:
+    """Verify an end-user JWT signature against Zitadel JWKS.
+
+    Returns the decoded claim set on success; ``None`` on any failure
+    (invalid signature, expired, malformed). The caller MUST treat ``None``
+    as ``invalid_jwt`` and SHALL NOT fall through to the membership path
+    (REQ-1.8).
+
+    Audience is intentionally NOT validated here. Service-forwarded JWTs
+    can come from various Zitadel-issued audiences (LibreChat, retrieval-api,
+    etc.); the identity guarantees we need are sub + resourceowner +
+    signature + exp. Audience-specific permission checks belong to the
+    consuming service, not this guard.
+    """
+
+    try:
+        signing_key = jwks_resolver.get_signing_key_from_jwt(bearer_jwt).key
+        return jwt.decode(
+            bearer_jwt,
+            signing_key,
+            algorithms=["RS256"],
+            issuer=settings.zitadel_base_url,
+            options={
+                "require": ["sub", "iss", "exp"],
+                "verify_aud": False,
+            },
+        )
+    except jwt.PyJWTError as exc:
+        logger.warning("identity_verify_jwt_invalid", extra={"error": str(exc)})
+        return None
+
+
+class JwksResolver:
+    """Minimal duck-typing protocol for ``PyJWKClient``.
+
+    Defining this lets tests inject a fake without depending on jwt internals.
+    Production passes ``app.services.bff_oidc._get_jwks_client()`` which
+    returns a real ``PyJWKClient``.
+    """
+
+    def get_signing_key_from_jwt(self, _token: str) -> Any:  # pragma: no cover - protocol
+        raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------
+# Verification orchestrator
+# ---------------------------------------------------------------------------
+
+
+async def verify_identity_claim(
+    *,
+    db: AsyncSession,
+    jwks_resolver: JwksResolver,
+    caller_service: str,
+    claimed_user_id: str,
+    claimed_org_id: str,
+    bearer_jwt: str | None,
+) -> VerifyDecision:
+    """Resolve a claimed identity to an authoritative allow/deny decision.
+
+    The function is HTTP- and cache-agnostic; the endpoint layer wraps it.
+    Exceptions thrown here are programmer errors (e.g. DB unreachable) and
+    bubble up to the endpoint, which translates them to HTTP 503.
+    """
+
+    if caller_service not in KNOWN_CALLER_SERVICES:
+        logger.info(
+            "identity_verify_unknown_caller",
+            extra={"caller_service": caller_service},
+        )
+        return VerifyDecision.deny("unknown_caller_service")
+
+    if bearer_jwt is not None:
+        claims = _decode_user_jwt(bearer_jwt, jwks_resolver)
+        if claims is None:
+            return VerifyDecision.deny("invalid_jwt")
+
+        jwt_sub = claims.get("sub")
+        jwt_resourceowner = claims.get(_ZITADEL_RESOURCEOWNER_CLAIM)
+        if not isinstance(jwt_sub, str) or not isinstance(jwt_resourceowner, str):
+            # Claims are present but not strings — treat as malformed JWT.
+            return VerifyDecision.deny("invalid_jwt")
+
+        if jwt_sub != claimed_user_id or jwt_resourceowner != claimed_org_id:
+            logger.info(
+                "identity_verify_jwt_mismatch",
+                extra={
+                    "caller_service": caller_service,
+                    "claim_sub_matches": jwt_sub == claimed_user_id,
+                    "claim_org_matches": jwt_resourceowner == claimed_org_id,
+                },
+            )
+            return VerifyDecision.deny("jwt_identity_mismatch")
+
+        return VerifyDecision.allow(
+            user_id=claimed_user_id,
+            org_id=claimed_org_id,
+            evidence="jwt",
+        )
+
+    # bearer_jwt is None → fall through to membership lookup (REQ-1.4).
+    member_exists = await _user_has_active_membership(
+        db=db,
+        zitadel_user_id=claimed_user_id,
+        zitadel_org_id=claimed_org_id,
+    )
+    if not member_exists:
+        return VerifyDecision.deny("no_membership")
+
+    return VerifyDecision.allow(
+        user_id=claimed_user_id,
+        org_id=claimed_org_id,
+        evidence="membership",
+    )
+
+
+async def _user_has_active_membership(
+    *,
+    db: AsyncSession,
+    zitadel_user_id: str,
+    zitadel_org_id: str,
+) -> bool:
+    """Return True iff the (user, org) pair has an active row in portal_users.
+
+    The lookup joins ``portal_users`` on ``portal_orgs.zitadel_org_id`` so
+    callers may pass the external Zitadel org ID directly — the integer
+    portal org_id is internal-only and not exposed at this contract.
+    """
+
+    stmt = (
+        select(PortalUser.id)
+        .join(PortalOrg, PortalUser.org_id == PortalOrg.id)
+        .where(
+            PortalUser.zitadel_user_id == zitadel_user_id,
+            PortalOrg.zitadel_org_id == zitadel_org_id,
+            PortalUser.status == "active",
+            PortalOrg.deleted_at.is_(None),
+        )
+        .limit(1)
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none() is not None

--- a/klai-portal/backend/app/services/identity_verify_cache.py
+++ b/klai-portal/backend/app/services/identity_verify_cache.py
@@ -1,0 +1,145 @@
+"""Redis-backed cache for ``/internal/identity/verify`` decisions.
+
+SPEC-SEC-IDENTITY-ASSERT-001 REQ-1.5 / REQ-1.6:
+
+- Cache successful verifications for 60 seconds, keyed on
+  ``(caller_service, claimed_user_id, claimed_org_id, evidence)``.
+- Cache hits skip both DB and JWT signature re-check — the cached evidence
+  is the authoritative answer for the TTL window.
+- Denials are NEVER cached (matches consumer-side behaviour and prevents
+  poisoning the cache with transient deny states).
+- IF Redis is unreachable, fail CLOSED — raise :class:`CacheUnavailable`,
+  which the endpoint maps to HTTP 503 ``cache_unavailable``. This is the
+  deliberate inverse of SPEC-SEC-005's rate-limiter (which fails open):
+  an auth-class control must not silently downgrade to "always allow".
+
+Cache key includes ``caller_service`` so different consumers do not share
+cache entries — privacy boundary enforced at the key level.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING
+
+from redis.exceptions import RedisError
+
+from app.services.identity_verifier import VerifyDecision
+
+if TYPE_CHECKING:
+    from redis.asyncio import Redis
+
+logger = logging.getLogger(__name__)
+
+# Distinct key namespace from other Klai Redis consumers (rate-limit, sessions).
+_KEY_PREFIX = "identity_verify:"
+
+# REQ-1.5: 60-second TTL. Cap at 60 — caller-side worst case for revocation
+# propagation. Lowering the TTL is allowed (faster revocation), raising is not.
+_TTL_SECONDS = 60
+
+
+class CacheUnavailable(Exception):
+    """Redis call failed and the endpoint MUST fail closed (HTTP 503)."""
+
+
+def _build_key(*, caller_service: str, claimed_user_id: str, claimed_org_id: str) -> str:
+    """Build a Redis key from the verifier inputs.
+
+    Note: ``evidence`` is part of the cached *value*, not the key. The key
+    spans both JWT and membership outcomes for the same tuple — whichever
+    decision lands first wins for the TTL window. This is deliberate: a
+    successful JWT verification does not weaken when followed by a
+    membership-only call (the user's permissions are unchanged).
+    """
+
+    return f"{_KEY_PREFIX}{caller_service}:{claimed_user_id}:{claimed_org_id}"
+
+
+async def get_cached_decision(
+    *,
+    redis: Redis,
+    caller_service: str,
+    claimed_user_id: str,
+    claimed_org_id: str,
+) -> VerifyDecision | None:
+    """Return a cached verified decision, or ``None`` on miss.
+
+    Raises
+    ------
+    CacheUnavailable
+        On any Redis error. The endpoint MUST translate this to HTTP 503.
+    """
+
+    key = _build_key(
+        caller_service=caller_service,
+        claimed_user_id=claimed_user_id,
+        claimed_org_id=claimed_org_id,
+    )
+    try:
+        raw: bytes | str | None = await redis.get(key)
+    except RedisError as exc:
+        logger.warning("identity_verify_cache_get_failed", extra={"error": str(exc)})
+        raise CacheUnavailable("redis_get_failed") from exc
+
+    if raw is None:
+        return None
+    payload_str = raw.decode("utf-8") if isinstance(raw, bytes) else raw
+    try:
+        payload = json.loads(payload_str)
+    except json.JSONDecodeError:
+        # Corrupt entry — treat as miss. Don't fail closed: a stale corrupt
+        # entry should not lock callers out; the next call will refresh it.
+        logger.warning("identity_verify_cache_corrupt", extra={"key": key})
+        return None
+    if not isinstance(payload, dict):
+        return None
+    evidence = payload.get("evidence")
+    user_id = payload.get("user_id")
+    org_id = payload.get("org_id")
+    if evidence not in ("jwt", "membership"):
+        return None
+    if not isinstance(user_id, str) or not isinstance(org_id, str):
+        return None
+    return VerifyDecision.allow(user_id=user_id, org_id=org_id, evidence=evidence)
+
+
+async def cache_verified_decision(
+    *,
+    redis: Redis,
+    caller_service: str,
+    claimed_user_id: str,
+    claimed_org_id: str,
+    decision: VerifyDecision,
+) -> None:
+    """Cache a verified decision. No-op for denials.
+
+    Raises
+    ------
+    CacheUnavailable
+        On any Redis error. The endpoint MUST translate this to HTTP 503
+        rather than returning the verified decision without caching it —
+        otherwise a Redis flap would silently disable the cache and amplify
+        DB load for every subsequent call.
+    """
+
+    if not decision.verified or decision.evidence is None or decision.user_id is None or decision.org_id is None:
+        return
+    key = _build_key(
+        caller_service=caller_service,
+        claimed_user_id=claimed_user_id,
+        claimed_org_id=claimed_org_id,
+    )
+    payload = json.dumps(
+        {
+            "user_id": decision.user_id,
+            "org_id": decision.org_id,
+            "evidence": decision.evidence,
+        }
+    )
+    try:
+        await redis.set(key, payload, ex=_TTL_SECONDS)
+    except RedisError as exc:
+        logger.warning("identity_verify_cache_set_failed", extra={"error": str(exc)})
+        raise CacheUnavailable("redis_set_failed") from exc

--- a/klai-portal/backend/app/services/identity_verify_cache.py
+++ b/klai-portal/backend/app/services/identity_verify_cache.py
@@ -2,8 +2,19 @@
 
 SPEC-SEC-IDENTITY-ASSERT-001 REQ-1.5 / REQ-1.6:
 
-- Cache successful verifications for 60 seconds, keyed on
-  ``(caller_service, claimed_user_id, claimed_org_id, evidence)``.
+- Cache successful verifications for 60 seconds, keyed strictly on the
+  ``(caller_service, claimed_user_id, claimed_org_id, evidence)`` tuple
+  per REQ-1.5. The fourth coordinate keeps JWT-evidence and
+  membership-evidence cache entries distinct so the ``evidence`` field
+  in each response honestly reflects what was actually verified for that
+  call (a membership-fallback request must NOT silently get a JWT-evidence
+  cached value, or the audit signal would lie).
+- The evidence dimension at lookup time is determined deterministically
+  by ``bearer_jwt`` presence: a JWT-bearing request can only ever return
+  ``evidence="jwt"`` (REQ-1.3 requires JWT validation when bearer_jwt is
+  set; REQ-1.8 forbids fallthrough to membership when JWT is invalid).
+  An ``bearer_jwt=None`` request can only return ``evidence="membership"``
+  (REQ-1.4). So lookup keying on the same dimension is correct.
 - Cache hits skip both DB and JWT signature re-check — the cached evidence
   is the authoritative answer for the TTL window.
 - Denials are NEVER cached (matches consumer-side behaviour and prevents
@@ -25,7 +36,7 @@ from typing import TYPE_CHECKING
 
 from redis.exceptions import RedisError
 
-from app.services.identity_verifier import VerifyDecision
+from app.services.identity_verifier import Evidence, VerifyDecision
 
 if TYPE_CHECKING:
     from redis.asyncio import Redis
@@ -44,17 +55,33 @@ class CacheUnavailable(Exception):
     """Redis call failed and the endpoint MUST fail closed (HTTP 503)."""
 
 
-def _build_key(*, caller_service: str, claimed_user_id: str, claimed_org_id: str) -> str:
-    """Build a Redis key from the verifier inputs.
+def evidence_for_lookup(*, bearer_jwt: str | None) -> Evidence:
+    """Determine the evidence dimension for a cache lookup deterministically.
 
-    Note: ``evidence`` is part of the cached *value*, not the key. The key
-    spans both JWT and membership outcomes for the same tuple — whichever
-    decision lands first wins for the TTL window. This is deliberate: a
-    successful JWT verification does not weaken when followed by a
-    membership-only call (the user's permissions are unchanged).
+    REQ-1.3 forces JWT-bearing requests onto the JWT path; REQ-1.4 forces
+    JWT-less requests onto the membership path. The two paths never cross
+    (REQ-1.8 specifically forbids invalid-JWT fallthrough), so the lookup
+    can pick the dimension from ``bearer_jwt`` presence alone — without
+    consulting the cache or DB.
     """
 
-    return f"{_KEY_PREFIX}{caller_service}:{claimed_user_id}:{claimed_org_id}"
+    return "jwt" if bearer_jwt is not None else "membership"
+
+
+def _build_key(
+    *,
+    caller_service: str,
+    claimed_user_id: str,
+    claimed_org_id: str,
+    evidence: Evidence,
+) -> str:
+    """Build a Redis key from the full verifier tuple including evidence.
+
+    Including ``evidence`` makes JWT- and membership-evidence cache entries
+    distinct — see module docstring for the integrity rationale.
+    """
+
+    return f"{_KEY_PREFIX}{caller_service}:{claimed_user_id}:{claimed_org_id}:{evidence}"
 
 
 async def get_cached_decision(
@@ -63,8 +90,13 @@ async def get_cached_decision(
     caller_service: str,
     claimed_user_id: str,
     claimed_org_id: str,
+    bearer_jwt: str | None,
 ) -> VerifyDecision | None:
     """Return a cached verified decision, or ``None`` on miss.
+
+    The evidence dimension is derived from ``bearer_jwt`` presence (see
+    :func:`evidence_for_lookup`). Callers do NOT pass evidence directly —
+    the key contract is: same input → same lookup, deterministically.
 
     Raises
     ------
@@ -76,6 +108,7 @@ async def get_cached_decision(
         caller_service=caller_service,
         claimed_user_id=claimed_user_id,
         claimed_org_id=claimed_org_id,
+        evidence=evidence_for_lookup(bearer_jwt=bearer_jwt),
     )
     try:
         raw: bytes | str | None = await redis.get(key)
@@ -130,6 +163,7 @@ async def cache_verified_decision(
         caller_service=caller_service,
         claimed_user_id=claimed_user_id,
         claimed_org_id=claimed_org_id,
+        evidence=decision.evidence,
     )
     payload = json.dumps(
         {

--- a/klai-portal/backend/pyproject.toml
+++ b/klai-portal/backend/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
 [tool.uv.sources]
 klai-connector-credentials = { path = "../../klai-libs/connector-credentials", editable = true }
 klai-image-storage = { path = "../../klai-libs/image-storage", editable = true }
+klai-identity-assert = { path = "../../klai-libs/identity-assert", editable = true }
 
 [project.optional-dependencies]
 dev = [
@@ -44,6 +45,11 @@ dev = [
     "httpx>=0.28",
     "ruff>=0.15",
     "pyright>=1.1.408",
+    # SPEC-SEC-IDENTITY-ASSERT-001: contract test exercises the real library
+    # against the real /internal/identity/verify endpoint via ASGITransport.
+    # Test-only dep — portal-api itself does not import the library
+    # (portal-api SERVES the endpoint, doesn't call it).
+    "klai-identity-assert",
 ]
 
 [dependency-groups]
@@ -81,4 +87,7 @@ max-complexity = 15
 
 [tool.ruff.lint.per-file-ignores]
 "alembic/*" = ["UP", "I", "E501"]  # auto-generated migrations, don't enforce style
-"tests/*" = ["S106"]  # hardcoded "passwords" in test fixtures (e.g. access_token="at-1") are fake tokens
+# tests/*: hardcoded "passwords" in test fixtures are fake tokens —
+# S105 already global-ignored, S106 covers module-level kwargs, S107
+# covers function default arguments (e.g. token: str = "test-secret").
+"tests/*" = ["S106", "S107"]

--- a/klai-portal/backend/pyproject.toml
+++ b/klai-portal/backend/pyproject.toml
@@ -59,6 +59,11 @@ dev = [
     "httpx>=0.28",
     "ruff>=0.15",
     "pyright>=1.1.408",
+    # SPEC-SEC-IDENTITY-ASSERT-001: contract test only — portal-api does not
+    # import the library at runtime. Mirrors [project.optional-dependencies]
+    # dev so both ``uv run pytest`` (CI, picks dependency-groups) and
+    # ``uv pip install .[dev]`` (local) install it.
+    "klai-identity-assert",
 ]
 
 [tool.pytest.ini_options]

--- a/klai-portal/backend/tests/services/test_bff_session_refresh.py
+++ b/klai-portal/backend/tests/services/test_bff_session_refresh.py
@@ -67,7 +67,7 @@ def service(monkeypatch: pytest.MonkeyPatch, fake_redis: AsyncMock) -> SessionSe
     return svc
 
 
-async def _seed_session(service: SessionService, *, expires_at: int, access_token: str = "at-initial") -> SessionRecord:  # noqa: S107
+async def _seed_session(service: SessionService, *, expires_at: int, access_token: str = "at-initial") -> SessionRecord:
     return await service.create(
         zitadel_user_id="user-1",
         org_id=1,

--- a/klai-portal/backend/tests/test_bff_bearer.py
+++ b/klai-portal/backend/tests/test_bff_bearer.py
@@ -84,7 +84,7 @@ def app() -> FastAPI:
     return app
 
 
-async def _make_session(wire_redis: AsyncMock, access_token: str = "live-at") -> str:  # noqa: S107
+async def _make_session(wire_redis: AsyncMock, access_token: str = "live-at") -> str:
     svc = SessionService()
     svc._fernet = None
     record = await svc.create(

--- a/klai-portal/backend/tests/test_identity_verifier.py
+++ b/klai-portal/backend/tests/test_identity_verifier.py
@@ -68,7 +68,7 @@ def mock_db() -> AsyncMock:
     return db
 
 
-def _signed_jwt(*, sub: str, resourceowner: str, secret: str = "hmac-secret", **extra: Any) -> str:  # noqa: S107
+def _signed_jwt(*, sub: str, resourceowner: str, secret: str = "hmac-secret", **extra: Any) -> str:
     """Sign a fake Zitadel JWT with HS256 for tests.
 
     The verifier configures jwt.decode for RS256 only — so any HS256 token

--- a/klai-portal/backend/tests/test_identity_verifier.py
+++ b/klai-portal/backend/tests/test_identity_verifier.py
@@ -1,0 +1,308 @@
+"""Unit tests for app.services.identity_verifier.verify_identity_claim.
+
+Service-layer tests; the HTTP endpoint and Redis cache are tested separately
+in test_internal_identity_verify.py. JWT validation is mocked via a fake
+``JwksResolver``; DB is mocked via ``AsyncMock`` on the ``execute`` method.
+
+SPEC-SEC-IDENTITY-ASSERT-001 REQ-1 acceptance criteria coverage:
+- AC-5a: verified JWT + matching claims → allow with evidence='jwt'
+- AC-5b: JWT sub != claimed_user_id → deny with reason='jwt_identity_mismatch'
+- AC-5c: bearer_jwt=None + active membership → allow with evidence='membership'
+- AC-5d: bearer_jwt=None + no membership → deny with reason='no_membership'
+- REQ-1.2: unknown caller_service → deny with reason='unknown_caller_service'
+- REQ-1.8: invalid JWT signature → deny with reason='invalid_jwt' (no fallthrough)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import jwt
+import pytest
+
+from app.services.identity_verifier import (
+    KNOWN_CALLER_SERVICES,
+    VerifyDecision,
+    verify_identity_claim,
+)
+
+
+class _FakeSigningKey:
+    """Minimal stand-in for jwt.api_jwk.PyJWK.key — only the attribute matters."""
+
+    key = "fake-signing-key"
+
+
+class _FakeJwksResolver:
+    """Test-only resolver that returns a constant signing key.
+
+    The test provides the *signed* JWT; the resolver merely yields the same
+    HMAC secret used to sign it. PyJWT will validate or reject the signature
+    at decode time — we drive both paths via the JWT contents.
+    """
+
+    def __init__(self, signing_key: Any = _FakeSigningKey()) -> None:
+        self._signing_key = signing_key
+
+    def get_signing_key_from_jwt(self, _token: str) -> Any:
+        return self._signing_key
+
+
+@pytest.fixture
+def real_jwks_resolver() -> _FakeJwksResolver:
+    """Resolver that returns an HMAC-style key compatible with HS256 signing.
+
+    For test ergonomics we sign tokens with HS256 (jwt.encode) and decode them
+    with the same secret. ``identity_verifier`` allows ``RS256`` only — so we
+    need the resolver to return a string key the way the verifier expects.
+    """
+
+    return _FakeJwksResolver(signing_key="hmac-secret")
+
+
+@pytest.fixture
+def mock_db() -> AsyncMock:
+    db = AsyncMock()
+    db.execute = AsyncMock()
+    return db
+
+
+def _signed_jwt(*, sub: str, resourceowner: str, secret: str = "hmac-secret", **extra: Any) -> str:  # noqa: S107
+    """Sign a fake Zitadel JWT with HS256 for tests.
+
+    The verifier configures jwt.decode for RS256 only — so any HS256 token
+    fails signature validation, which is exactly what AC-5b's 'invalid JWT'
+    branch needs. To exercise the *valid* path we monkey-patch
+    ``jwt.decode`` directly in tests rather than wrestling with a real RSA key.
+    """
+
+    payload = {
+        "sub": sub,
+        "iss": "https://zitadel.example.com",
+        "exp": 9999999999,
+        "urn:zitadel:iam:user:resourceowner:id": resourceowner,
+        **extra,
+    }
+    return jwt.encode(payload, secret, algorithm="HS256")
+
+
+class TestUnknownCallerService:
+    """REQ-1.2: caller_service not in allowlist → deny with stable reason."""
+
+    async def test_deny_for_unknown_service(self, mock_db: AsyncMock) -> None:
+        decision = await verify_identity_claim(
+            db=mock_db,
+            jwks_resolver=_FakeJwksResolver(),
+            caller_service="not-a-real-service",
+            claimed_user_id="u-1",
+            claimed_org_id="o-1",
+            bearer_jwt=None,
+        )
+
+        assert decision.verified is False
+        assert decision.reason == "unknown_caller_service"
+        assert decision.evidence is None
+        mock_db.execute.assert_not_called()
+
+    def test_known_callers_include_required_set(self) -> None:
+        # Mirrors the library-side test; an asymmetric change between the two
+        # sides would leave one consumer fail-closed and the other not.
+        for required in ("knowledge-mcp", "scribe", "retrieval-api", "connector", "mailer"):
+            assert required in KNOWN_CALLER_SERVICES
+
+
+class TestJwtPath:
+    """REQ-1.3 / REQ-1.8: JWT validation, identity mismatch, invalid JWT."""
+
+    async def test_allow_when_jwt_sub_and_resourceowner_match(
+        self, mock_db: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "app.services.identity_verifier.jwt.decode",
+            lambda *_args, **_kwargs: {
+                "sub": "u-1",
+                "iss": "https://zitadel.example.com",
+                "exp": 9999999999,
+                "urn:zitadel:iam:user:resourceowner:id": "o-1",
+            },
+        )
+
+        decision = await verify_identity_claim(
+            db=mock_db,
+            jwks_resolver=_FakeJwksResolver(),
+            caller_service="scribe",
+            claimed_user_id="u-1",
+            claimed_org_id="o-1",
+            bearer_jwt="any.jwt.value",
+        )
+
+        assert decision.verified is True
+        assert decision.evidence == "jwt"
+        assert decision.user_id == "u-1"
+        assert decision.org_id == "o-1"
+        # JWT path MUST NOT consult DB — REQ-1.3 is JWT-only when valid.
+        mock_db.execute.assert_not_called()
+
+    async def test_deny_when_jwt_sub_does_not_match_claimed_user(
+        self, mock_db: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "app.services.identity_verifier.jwt.decode",
+            lambda *_args, **_kwargs: {
+                "sub": "u-1",  # JWT belongs to user u-1
+                "iss": "https://zitadel.example.com",
+                "exp": 9999999999,
+                "urn:zitadel:iam:user:resourceowner:id": "o-1",
+            },
+        )
+
+        # Caller claims to be user u-2 with the SAME org — JWT mismatch.
+        decision = await verify_identity_claim(
+            db=mock_db,
+            jwks_resolver=_FakeJwksResolver(),
+            caller_service="scribe",
+            claimed_user_id="u-2",
+            claimed_org_id="o-1",
+            bearer_jwt="any.jwt.value",
+        )
+
+        assert decision.verified is False
+        assert decision.reason == "jwt_identity_mismatch"
+        assert decision.evidence is None
+
+    async def test_deny_when_jwt_resourceowner_does_not_match_claimed_org(
+        self, mock_db: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "app.services.identity_verifier.jwt.decode",
+            lambda *_args, **_kwargs: {
+                "sub": "u-1",
+                "iss": "https://zitadel.example.com",
+                "exp": 9999999999,
+                "urn:zitadel:iam:user:resourceowner:id": "o-1",
+            },
+        )
+
+        decision = await verify_identity_claim(
+            db=mock_db,
+            jwks_resolver=_FakeJwksResolver(),
+            caller_service="scribe",
+            claimed_user_id="u-1",
+            claimed_org_id="o-2",  # cross-org claim
+            bearer_jwt="any.jwt.value",
+        )
+
+        assert decision.verified is False
+        assert decision.reason == "jwt_identity_mismatch"
+
+    async def test_deny_with_invalid_jwt_does_not_fall_back_to_membership(
+        self, mock_db: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # REQ-1.8: an invalid JWT is a STRICTLY STRONGER deny signal than
+        # an absent JWT. Must NOT fall through to the membership path.
+        def _raise(*_args: Any, **_kwargs: Any) -> None:
+            raise jwt.ExpiredSignatureError("token expired")
+
+        monkeypatch.setattr("app.services.identity_verifier.jwt.decode", _raise)
+
+        # Even if the membership lookup *would* succeed, REQ-1.8 forbids
+        # falling through to it — assert that DB is NEVER called.
+        decision = await verify_identity_claim(
+            db=mock_db,
+            jwks_resolver=_FakeJwksResolver(),
+            caller_service="scribe",
+            claimed_user_id="u-1",
+            claimed_org_id="o-1",
+            bearer_jwt="expired.jwt.token",
+        )
+
+        assert decision.verified is False
+        assert decision.reason == "invalid_jwt"
+        mock_db.execute.assert_not_called()
+
+    async def test_deny_when_jwt_claims_have_wrong_types(
+        self, mock_db: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Defensive: malformed JWT with sub/resourceowner not strings.
+        monkeypatch.setattr(
+            "app.services.identity_verifier.jwt.decode",
+            lambda *_args, **_kwargs: {
+                "sub": 12345,  # int, not str
+                "iss": "https://zitadel.example.com",
+                "exp": 9999999999,
+                "urn:zitadel:iam:user:resourceowner:id": ["o-1"],  # list, not str
+            },
+        )
+
+        decision = await verify_identity_claim(
+            db=mock_db,
+            jwks_resolver=_FakeJwksResolver(),
+            caller_service="scribe",
+            claimed_user_id="u-1",
+            claimed_org_id="o-1",
+            bearer_jwt="any.jwt.value",
+        )
+
+        assert decision.verified is False
+        assert decision.reason == "invalid_jwt"
+
+
+class TestMembershipPath:
+    """REQ-1.4: bearer_jwt=None → membership lookup."""
+
+    async def test_allow_when_active_membership_exists(self, mock_db: AsyncMock) -> None:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none = MagicMock(return_value=42)  # PortalUser.id row exists
+        mock_db.execute.return_value = mock_result
+
+        decision = await verify_identity_claim(
+            db=mock_db,
+            jwks_resolver=_FakeJwksResolver(),
+            caller_service="scribe",
+            claimed_user_id="u-1",
+            claimed_org_id="o-1",
+            bearer_jwt=None,
+        )
+
+        assert decision.verified is True
+        assert decision.evidence == "membership"
+        assert decision.user_id == "u-1"
+        assert decision.org_id == "o-1"
+        mock_db.execute.assert_awaited_once()
+
+    async def test_deny_when_membership_lookup_returns_none(self, mock_db: AsyncMock) -> None:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none = MagicMock(return_value=None)
+        mock_db.execute.return_value = mock_result
+
+        decision = await verify_identity_claim(
+            db=mock_db,
+            jwks_resolver=_FakeJwksResolver(),
+            caller_service="scribe",
+            claimed_user_id="u-1",
+            claimed_org_id="o-1",
+            bearer_jwt=None,
+        )
+
+        assert decision.verified is False
+        assert decision.reason == "no_membership"
+        assert decision.evidence is None
+
+
+class TestVerifyDecisionDataclass:
+    """Frozen-dataclass invariants on the service-layer result type."""
+
+    def test_allow_factory_populates_identity(self) -> None:
+        decision = VerifyDecision.allow(user_id="u-1", org_id="o-1", evidence="jwt")
+        assert decision.verified is True
+        assert decision.user_id == "u-1"
+        assert decision.evidence == "jwt"
+        assert decision.reason is None
+
+    def test_deny_factory_clears_identity(self) -> None:
+        decision = VerifyDecision.deny("no_membership")
+        assert decision.verified is False
+        assert decision.reason == "no_membership"
+        assert decision.user_id is None
+        assert decision.evidence is None

--- a/klai-portal/backend/tests/test_identity_verify_contract.py
+++ b/klai-portal/backend/tests/test_identity_verify_contract.py
@@ -1,0 +1,272 @@
+"""End-to-end contract test: real klai-identity-assert library against the
+real portal-api ``/internal/identity/verify`` endpoint via in-process ASGI.
+
+This catches drift between the library's wire format and portal-api's
+Pydantic models. Each side has a Pydantic / dataclass schema for the same
+JSON shape (REQ-1.1); a one-sided change that breaks the contract surfaces
+here as a test failure rather than as a production HTTP 422 / decode error.
+
+Test design:
+- Build a throwaway FastAPI app that mounts only the ``internal`` router.
+- Override ``get_db`` with an AsyncMock returning a fake membership row.
+- Stub Redis pool, JWKS resolver, rate limiter, and ``settings.internal_secret``
+  via monkeypatch — the same fixtures the unit tests use.
+- Drive the app with ``IdentityAsserter`` configured with an
+  ``httpx.ASGITransport`` so requests stay in-process.
+
+If the library's request body shape no longer matches
+``IdentityVerifyRequest`` or the response no longer parses into
+``VerifyResult``, these tests fail loud at import-time or at first call.
+
+Coverage:
+- AC-5a-equivalent: JWT-evidence allow path
+- AC-5c-equivalent: membership-evidence allow path
+- AC-5d-equivalent: no-membership deny path
+- Allowlist-drift guard: library KNOWN_CALLER_SERVICES == server allowlist
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from klai_identity_assert import KNOWN_CALLER_SERVICES as LIBRARY_KNOWN_CALLER_SERVICES
+from klai_identity_assert import IdentityAsserter
+
+
+@contextmanager
+def _patch_internal_secret(monkeypatch: pytest.MonkeyPatch, value: str) -> Iterator[None]:
+    from app.api import internal as internal_mod
+
+    monkeypatch.setattr(internal_mod.settings, "internal_secret", value)
+    yield
+
+
+def _make_redis_mock() -> AsyncMock:
+    store: dict[str, str] = {}
+
+    async def fake_get(key: str) -> str | None:
+        return store.get(key)
+
+    async def fake_set(key: str, value: str, ex: int | None = None) -> bool:
+        store[key] = value
+        return True
+
+    redis = AsyncMock()
+    redis.get = AsyncMock(side_effect=fake_get)
+    redis.set = AsyncMock(side_effect=fake_set)
+    redis._store = store
+    return redis
+
+
+class _FakeJwksResolver:
+    class _Key:
+        key = "fake"
+
+    def get_signing_key_from_jwt(self, _token: str) -> _Key:
+        return self._Key()
+
+
+@pytest.fixture
+def portal_app(monkeypatch: pytest.MonkeyPatch) -> FastAPI:
+    """Throwaway FastAPI app that mounts only the internal router."""
+
+    from app.api.internal import router
+    from app.core.database import get_db
+
+    app = FastAPI()
+    app.include_router(router)
+
+    async def override_get_db() -> AsyncIterator[AsyncMock]:
+        db = AsyncMock()
+        result = MagicMock()
+        result.scalar_one_or_none = MagicMock(return_value=42)
+        db.execute = AsyncMock(return_value=result)
+        yield db
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    redis = _make_redis_mock()
+    monkeypatch.setattr("app.api.internal.get_redis_pool", AsyncMock(return_value=redis))
+    monkeypatch.setattr("app.api.internal._check_rate_limit_internal", AsyncMock())
+    monkeypatch.setattr(
+        "app.api.internal._get_identity_jwks_resolver",
+        lambda: _FakeJwksResolver(),
+    )
+    return app
+
+
+@pytest_asyncio.fixture
+async def asserter_against_app(portal_app: FastAPI) -> AsyncIterator[IdentityAsserter]:
+    """An IdentityAsserter wired through ASGITransport into ``portal_app``.
+
+    The httpx.AsyncClient is owned by the caller (us) — we close it on
+    fixture teardown so the asserter's borrowed-client semantics are
+    exercised correctly.
+    """
+
+    # ASGITransport routes httpx requests directly into the FastAPI app.
+    # We do NOT set base_url on the AsyncClient — the asserter constructs
+    # full absolute URLs itself, and a duplicate base_url would conflict
+    # with the absolute path resolution httpx applies via ASGITransport.
+    transport = httpx.ASGITransport(app=portal_app)
+    http_client = httpx.AsyncClient(transport=transport)
+    asserter = IdentityAsserter(
+        portal_base_url="http://testserver",
+        internal_secret="contract-test-secret",
+        http_client=http_client,
+    )
+    try:
+        yield asserter
+    finally:
+        await asserter.aclose()
+        await http_client.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Allowlist drift guard
+# ---------------------------------------------------------------------------
+
+
+def test_library_and_server_caller_allowlists_match() -> None:
+    """The library's KNOWN_CALLER_SERVICES MUST equal the server's.
+
+    Drift in either direction is a silent attack vector: either the library
+    rejects a caller the server would accept (consumer broken), or the
+    server rejects a caller the library forwards (production 400s).
+    """
+
+    from app.services.identity_verifier import KNOWN_CALLER_SERVICES as SERVER_KNOWN_CALLER_SERVICES
+
+    assert LIBRARY_KNOWN_CALLER_SERVICES == SERVER_KNOWN_CALLER_SERVICES
+
+
+# ---------------------------------------------------------------------------
+# Membership-evidence allow (REQ-1.4)
+# ---------------------------------------------------------------------------
+
+
+async def test_library_membership_path_allows_against_real_endpoint(
+    asserter_against_app: IdentityAsserter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with _patch_internal_secret(monkeypatch, "contract-test-secret"):
+        result = await asserter_against_app.verify(
+            caller_service="scribe",
+            claimed_user_id="u-1",
+            claimed_org_id="o-1",
+            bearer_jwt=None,
+        )
+
+    assert result.verified is True, result
+    assert result.evidence == "membership"
+    assert result.user_id == "u-1"
+    assert result.org_id == "o-1"
+    assert result.cached is False  # first call, cache miss
+
+
+# ---------------------------------------------------------------------------
+# JWT-evidence allow (REQ-1.3)
+# ---------------------------------------------------------------------------
+
+
+async def test_library_jwt_path_allows_against_real_endpoint(
+    asserter_against_app: IdentityAsserter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "app.services.identity_verifier.jwt.decode",
+        lambda *_args, **_kwargs: {
+            "sub": "u-1",
+            "iss": "https://zitadel.example.com",
+            "exp": 9999999999,
+            "urn:zitadel:iam:user:resourceowner:id": "o-1",
+        },
+    )
+
+    with _patch_internal_secret(monkeypatch, "contract-test-secret"):
+        result = await asserter_against_app.verify(
+            caller_service="scribe",
+            claimed_user_id="u-1",
+            claimed_org_id="o-1",
+            bearer_jwt="forwarded.user.jwt",
+        )
+
+    assert result.verified is True, result
+    assert result.evidence == "jwt"
+
+
+# ---------------------------------------------------------------------------
+# JWT mismatch deny (REQ-1.3 / AC-5b)
+# ---------------------------------------------------------------------------
+
+
+async def test_library_jwt_mismatch_denies_against_real_endpoint(
+    asserter_against_app: IdentityAsserter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # JWT belongs to u-A but caller claims to be u-B.
+    monkeypatch.setattr(
+        "app.services.identity_verifier.jwt.decode",
+        lambda *_args, **_kwargs: {
+            "sub": "u-A",
+            "iss": "https://zitadel.example.com",
+            "exp": 9999999999,
+            "urn:zitadel:iam:user:resourceowner:id": "o-1",
+        },
+    )
+
+    with _patch_internal_secret(monkeypatch, "contract-test-secret"):
+        result = await asserter_against_app.verify(
+            caller_service="scribe",
+            claimed_user_id="u-B",
+            claimed_org_id="o-1",
+            bearer_jwt="any.jwt.value",
+        )
+
+    assert result.verified is False, result
+    assert result.reason == "jwt_identity_mismatch"
+    assert result.user_id is None
+    assert result.org_id is None
+
+
+# ---------------------------------------------------------------------------
+# Cache propagation (REQ-1.5 + library REQ-7.2)
+# ---------------------------------------------------------------------------
+
+
+async def test_library_second_call_hits_library_side_cache(
+    asserter_against_app: IdentityAsserter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Second identical call MUST not generate a second portal request.
+
+    The library's per-process LRU cache is the first line of defense; this
+    test exercises that the cached-flag round-trips correctly through the
+    library AFTER one successful portal verify.
+    """
+
+    with _patch_internal_secret(monkeypatch, "contract-test-secret"):
+        first = await asserter_against_app.verify(
+            caller_service="scribe",
+            claimed_user_id="u-1",
+            claimed_org_id="o-1",
+            bearer_jwt=None,
+        )
+        second = await asserter_against_app.verify(
+            caller_service="scribe",
+            claimed_user_id="u-1",
+            claimed_org_id="o-1",
+            bearer_jwt=None,
+        )
+
+    assert first.verified is True
+    assert first.cached is False
+    assert second.verified is True
+    assert second.cached is True
+    assert second.evidence == first.evidence

--- a/klai-portal/backend/tests/test_internal_hardening.py
+++ b/klai-portal/backend/tests/test_internal_hardening.py
@@ -88,7 +88,7 @@ def redis_pool():
 
 def _make_request(
     *,
-    token: str | None = "secret-42",  # noqa: S107 — test fixture token, not a real secret
+    token: str | None = "secret-42",
     caller_ip: str | None = "172.18.0.5",
     xff: str | None = None,
     method: str = "GET",

--- a/klai-portal/backend/tests/test_internal_identity_verify.py
+++ b/klai-portal/backend/tests/test_internal_identity_verify.py
@@ -1,0 +1,412 @@
+"""Tests for the POST /internal/identity/verify HTTP endpoint.
+
+These tests exercise the endpoint as a direct async function call with mocks
+for the database, Redis, and JWT validator. The same unit-test style is used
+in test_internal_hardening.py — no FastAPI TestClient wiring is needed and
+each test isolates one decision branch.
+
+SPEC-SEC-IDENTITY-ASSERT-001 acceptance coverage:
+
+- AC-5a: verified JWT  → 200 + evidence='jwt'
+- AC-5b: JWT mismatch → 403 + reason='jwt_identity_mismatch'
+- AC-5c: membership   → 200 + evidence='membership'
+- AC-5d: no_membership → 403 + reason='no_membership'
+- AC-5e: cache hit    → second call skips DB/JWT
+- AC-5g: redis down   → 503 + reason='cache_unavailable'
+- REQ-1.2: unknown caller_service → 400 + reason='unknown_caller_service'
+- REQ-1.7: structlog identity_verify_decision emitted with hashed user_id
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import status as http_status
+from redis.exceptions import RedisError
+
+from app.api.internal import IdentityVerifyRequest, verify_identity
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _patched_internal_settings(monkeypatch: pytest.MonkeyPatch, *, secret: str = "test-secret"):  # noqa: S107
+    from app.api import internal as internal_mod
+
+    monkeypatch.setattr(internal_mod.settings, "internal_secret", secret)
+    yield
+
+
+def _make_request(*, token: str = "test-secret", caller_ip: str = "172.18.0.5") -> MagicMock:  # noqa: S107
+    """Mock FastAPI Request that satisfies _require_internal_token + audit context."""
+    request = MagicMock()
+    headers = {"Authorization": f"Bearer {token}"}
+    request.headers = MagicMock()
+    request.headers.get = lambda key, default="": next(
+        (v for k, v in headers.items() if k.lower() == key.lower()),
+        default,
+    )
+    request.client = MagicMock()
+    request.client.host = caller_ip
+    request.method = "POST"
+
+    url = MagicMock()
+    url.path = "/internal/identity/verify"
+    request.url = url
+
+    scope = {}
+    request.scope = scope
+    request.state = MagicMock()
+    return request
+
+
+def _make_redis_mock() -> AsyncMock:
+    """In-memory Redis mock supporting only ``get`` and ``set`` (with ex)."""
+    store: dict[str, str] = {}
+
+    async def fake_get(key: str) -> str | None:
+        return store.get(key)
+
+    async def fake_set(key: str, value: str, ex: int | None = None) -> bool:
+        store[key] = value
+        return True
+
+    redis = AsyncMock()
+    redis.get = AsyncMock(side_effect=fake_get)
+    redis.set = AsyncMock(side_effect=fake_set)
+    redis._store = store  # exposed for tests to seed/inspect
+    return redis
+
+
+def _success_db_mock() -> AsyncMock:
+    """DB mock that returns a row from any execute() — simulates active membership."""
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none = MagicMock(return_value=42)
+    db.execute = AsyncMock(return_value=result)
+    return db
+
+
+class _FakeJwksResolver:
+    """Test resolver: any token resolves to a constant signing key.
+
+    Real signature validation is bypassed because tests monkey-patch
+    ``jwt.decode`` directly to return a constructed claim set. The resolver
+    only needs to satisfy the call before decode.
+    """
+
+    class _Key:
+        key = "fake"
+
+    def get_signing_key_from_jwt(self, _token: str) -> _Key:
+        return self._Key()
+
+
+def _patch_jwks_resolver(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace the endpoint's PyJWKClient with a no-op fake.
+
+    The endpoint resolves JWKS via ``_get_identity_jwks_resolver`` which
+    constructs a live ``PyJWKClient`` against Zitadel. Tests substitute a
+    fake to avoid the network call.
+    """
+    monkeypatch.setattr(
+        "app.api.internal._get_identity_jwks_resolver",
+        lambda: _FakeJwksResolver(),
+    )
+
+
+def _missing_db_mock() -> AsyncMock:
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none = MagicMock(return_value=None)
+    db.execute = AsyncMock(return_value=result)
+    return db
+
+
+# ---------------------------------------------------------------------------
+# REQ-1.2: unknown caller_service
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownCallerService:
+    async def test_returns_400_with_stable_reason(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Redis is fine but should never be hit because the allowlist check
+        # is the first gate after token validation.
+        redis = _make_redis_mock()
+        monkeypatch.setattr("app.api.internal.get_redis_pool", AsyncMock(return_value=redis))
+        monkeypatch.setattr("app.api.internal._check_rate_limit_internal", AsyncMock())
+
+        with _patched_internal_settings(monkeypatch):
+            response = await verify_identity(
+                request=_make_request(),
+                body=IdentityVerifyRequest(
+                    caller_service="rogue-service",
+                    claimed_user_id="u-1",
+                    claimed_org_id="o-1",
+                ),
+                db=_success_db_mock(),
+            )
+
+        assert response.status_code == http_status.HTTP_400_BAD_REQUEST
+        body = json.loads(response.body)
+        assert body == {"verified": False, "reason": "unknown_caller_service"}
+        # Allowlist gate runs BEFORE Redis lookup — see REQ-1.2.
+        redis.get.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# REQ-1.4: membership path (AC-5c, AC-5d)
+# ---------------------------------------------------------------------------
+
+
+class TestMembershipPath:
+    async def test_returns_200_for_active_membership(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        redis = _make_redis_mock()
+        monkeypatch.setattr("app.api.internal.get_redis_pool", AsyncMock(return_value=redis))
+        monkeypatch.setattr("app.api.internal._check_rate_limit_internal", AsyncMock())
+
+        with _patched_internal_settings(monkeypatch):
+            response = await verify_identity(
+                request=_make_request(),
+                body=IdentityVerifyRequest(
+                    caller_service="scribe",
+                    claimed_user_id="u-1",
+                    claimed_org_id="o-1",
+                    bearer_jwt=None,
+                ),
+                db=_success_db_mock(),
+            )
+
+        assert response.status_code == http_status.HTTP_200_OK
+        body = json.loads(response.body)
+        assert body["verified"] is True
+        assert body["evidence"] == "membership"
+        assert body["user_id"] == "u-1"
+        assert body["org_id"] == "o-1"
+        assert body["cache_ttl_seconds"] == 60
+
+        # Verified result MUST be cached (REQ-1.5).
+        redis.set.assert_awaited_once()
+
+    async def test_returns_403_for_no_membership(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        redis = _make_redis_mock()
+        monkeypatch.setattr("app.api.internal.get_redis_pool", AsyncMock(return_value=redis))
+        monkeypatch.setattr("app.api.internal._check_rate_limit_internal", AsyncMock())
+
+        with _patched_internal_settings(monkeypatch):
+            response = await verify_identity(
+                request=_make_request(),
+                body=IdentityVerifyRequest(
+                    caller_service="scribe",
+                    claimed_user_id="u-1",
+                    claimed_org_id="o-2-not-a-member",
+                    bearer_jwt=None,
+                ),
+                db=_missing_db_mock(),
+            )
+
+        assert response.status_code == http_status.HTTP_403_FORBIDDEN
+        body = json.loads(response.body)
+        assert body == {"verified": False, "reason": "no_membership"}
+        # Denials MUST NOT be cached (REQ-1.5).
+        redis.set.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# REQ-1.3: JWT path (AC-5a, AC-5b)
+# ---------------------------------------------------------------------------
+
+
+class TestJwtPath:
+    async def test_returns_200_when_jwt_matches_claimed_identity(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        redis = _make_redis_mock()
+        monkeypatch.setattr("app.api.internal.get_redis_pool", AsyncMock(return_value=redis))
+        monkeypatch.setattr("app.api.internal._check_rate_limit_internal", AsyncMock())
+        _patch_jwks_resolver(monkeypatch)
+        monkeypatch.setattr(
+            "app.services.identity_verifier.jwt.decode",
+            lambda *_args, **_kwargs: {
+                "sub": "u-1",
+                "iss": "https://zitadel.example.com",
+                "exp": 9999999999,
+                "urn:zitadel:iam:user:resourceowner:id": "o-1",
+            },
+        )
+
+        with _patched_internal_settings(monkeypatch):
+            response = await verify_identity(
+                request=_make_request(),
+                body=IdentityVerifyRequest(
+                    caller_service="scribe",
+                    claimed_user_id="u-1",
+                    claimed_org_id="o-1",
+                    bearer_jwt="any.jwt.value",
+                ),
+                db=_success_db_mock(),
+            )
+
+        assert response.status_code == http_status.HTTP_200_OK
+        body = json.loads(response.body)
+        assert body["verified"] is True
+        assert body["evidence"] == "jwt"
+        assert body["cache_ttl_seconds"] == 60
+
+    async def test_returns_403_when_jwt_sub_mismatches(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        redis = _make_redis_mock()
+        monkeypatch.setattr("app.api.internal.get_redis_pool", AsyncMock(return_value=redis))
+        monkeypatch.setattr("app.api.internal._check_rate_limit_internal", AsyncMock())
+        _patch_jwks_resolver(monkeypatch)
+        monkeypatch.setattr(
+            "app.services.identity_verifier.jwt.decode",
+            lambda *_args, **_kwargs: {
+                "sub": "u-A-NOT-MATCHING",
+                "iss": "https://zitadel.example.com",
+                "exp": 9999999999,
+                "urn:zitadel:iam:user:resourceowner:id": "o-1",
+            },
+        )
+
+        with _patched_internal_settings(monkeypatch):
+            response = await verify_identity(
+                request=_make_request(),
+                body=IdentityVerifyRequest(
+                    caller_service="scribe",
+                    claimed_user_id="u-1",
+                    claimed_org_id="o-1",
+                    bearer_jwt="forged.jwt.value",
+                ),
+                db=_success_db_mock(),
+            )
+
+        assert response.status_code == http_status.HTTP_403_FORBIDDEN
+        body = json.loads(response.body)
+        assert body == {"verified": False, "reason": "jwt_identity_mismatch"}
+        # No cache write on deny.
+        redis.set.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# REQ-1.5: cache hit (AC-5e)
+# ---------------------------------------------------------------------------
+
+
+class TestCachingBehaviour:
+    async def test_cache_hit_skips_db_and_jwt(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Pre-seed the Redis cache with a verified entry.
+        redis = _make_redis_mock()
+        cache_key = "identity_verify:scribe:u-1:o-1"
+        redis._store[cache_key] = json.dumps(
+            {"user_id": "u-1", "org_id": "o-1", "evidence": "jwt"}
+        )
+        monkeypatch.setattr("app.api.internal.get_redis_pool", AsyncMock(return_value=redis))
+        monkeypatch.setattr("app.api.internal._check_rate_limit_internal", AsyncMock())
+
+        _patch_jwks_resolver(monkeypatch)
+        db = _success_db_mock()
+        jwt_decode = MagicMock()
+        monkeypatch.setattr("app.services.identity_verifier.jwt.decode", jwt_decode)
+
+        with _patched_internal_settings(monkeypatch):
+            response = await verify_identity(
+                request=_make_request(),
+                body=IdentityVerifyRequest(
+                    caller_service="scribe",
+                    claimed_user_id="u-1",
+                    claimed_org_id="o-1",
+                    bearer_jwt="any.jwt.value",  # would be decoded if cache missed
+                ),
+                db=db,
+            )
+
+        assert response.status_code == http_status.HTTP_200_OK
+        body = json.loads(response.body)
+        assert body["verified"] is True
+        assert body["evidence"] == "jwt"
+        # AC-5e: cache hit MUST NOT trigger DB or JWT signature re-check.
+        db.execute.assert_not_called()
+        jwt_decode.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# REQ-1.6: Redis fail-closed (AC-5g)
+# ---------------------------------------------------------------------------
+
+
+class TestRedisFailureMode:
+    async def test_returns_503_when_redis_pool_is_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Simulate transient Redis pool unavailability.
+        monkeypatch.setattr("app.api.internal.get_redis_pool", AsyncMock(return_value=None))
+        monkeypatch.setattr("app.api.internal._check_rate_limit_internal", AsyncMock())
+
+        with _patched_internal_settings(monkeypatch):
+            response = await verify_identity(
+                request=_make_request(),
+                body=IdentityVerifyRequest(
+                    caller_service="scribe",
+                    claimed_user_id="u-1",
+                    claimed_org_id="o-1",
+                    bearer_jwt=None,
+                ),
+                db=_success_db_mock(),
+            )
+
+        assert response.status_code == http_status.HTTP_503_SERVICE_UNAVAILABLE
+        body = json.loads(response.body)
+        assert body == {"verified": False, "reason": "cache_unavailable"}
+
+    async def test_returns_503_when_redis_get_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        redis = _make_redis_mock()
+        redis.get = AsyncMock(side_effect=RedisError("connection refused"))
+        monkeypatch.setattr("app.api.internal.get_redis_pool", AsyncMock(return_value=redis))
+        monkeypatch.setattr("app.api.internal._check_rate_limit_internal", AsyncMock())
+
+        with _patched_internal_settings(monkeypatch):
+            response = await verify_identity(
+                request=_make_request(),
+                body=IdentityVerifyRequest(
+                    caller_service="scribe",
+                    claimed_user_id="u-1",
+                    claimed_org_id="o-1",
+                    bearer_jwt=None,
+                ),
+                db=_success_db_mock(),
+            )
+
+        assert response.status_code == http_status.HTTP_503_SERVICE_UNAVAILABLE
+        body = json.loads(response.body)
+        assert body["reason"] == "cache_unavailable"
+
+    async def test_returns_503_when_redis_set_raises_after_verified(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Cache miss + DB allow + Redis SET fails → MUST fail closed (REQ-1.6).
+        redis = _make_redis_mock()
+        redis.set = AsyncMock(side_effect=RedisError("connection refused"))
+        monkeypatch.setattr("app.api.internal.get_redis_pool", AsyncMock(return_value=redis))
+        monkeypatch.setattr("app.api.internal._check_rate_limit_internal", AsyncMock())
+
+        with _patched_internal_settings(monkeypatch):
+            response = await verify_identity(
+                request=_make_request(),
+                body=IdentityVerifyRequest(
+                    caller_service="scribe",
+                    claimed_user_id="u-1",
+                    claimed_org_id="o-1",
+                    bearer_jwt=None,
+                ),
+                db=_success_db_mock(),
+            )
+
+        # The DB lookup *did* succeed but caching failed — refuse to leak the
+        # verified decision because the next call would skip cache and amplify
+        # DB load. This is the REQ-1.6 fail-closed contract.
+        assert response.status_code == http_status.HTTP_503_SERVICE_UNAVAILABLE
+        body = json.loads(response.body)
+        assert body["reason"] == "cache_unavailable"

--- a/klai-portal/backend/tests/test_internal_identity_verify.py
+++ b/klai-portal/backend/tests/test_internal_identity_verify.py
@@ -35,14 +35,14 @@ from app.api.internal import IdentityVerifyRequest, verify_identity
 
 
 @contextmanager
-def _patched_internal_settings(monkeypatch: pytest.MonkeyPatch, *, secret: str = "test-secret"):  # noqa: S107
+def _patched_internal_settings(monkeypatch: pytest.MonkeyPatch, *, secret: str = "test-secret"):
     from app.api import internal as internal_mod
 
     monkeypatch.setattr(internal_mod.settings, "internal_secret", secret)
     yield
 
 
-def _make_request(*, token: str = "test-secret", caller_ip: str = "172.18.0.5") -> MagicMock:  # noqa: S107
+def _make_request(*, token: str = "test-secret", caller_ip: str = "172.18.0.5") -> MagicMock:
     """Mock FastAPI Request that satisfies _require_internal_token + audit context."""
     request = MagicMock()
     headers = {"Authorization": f"Bearer {token}"}
@@ -297,9 +297,11 @@ class TestJwtPath:
 
 class TestCachingBehaviour:
     async def test_cache_hit_skips_db_and_jwt(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        # Pre-seed the Redis cache with a verified entry.
+        # Pre-seed the Redis cache with a verified JWT-evidence entry.
+        # Cache key includes evidence dimension (REQ-1.5) so a JWT-bearing
+        # request looks up the JWT-evidence entry deterministically.
         redis = _make_redis_mock()
-        cache_key = "identity_verify:scribe:u-1:o-1"
+        cache_key = "identity_verify:scribe:u-1:o-1:jwt"
         redis._store[cache_key] = json.dumps({"user_id": "u-1", "org_id": "o-1", "evidence": "jwt"})
         monkeypatch.setattr("app.api.internal.get_redis_pool", AsyncMock(return_value=redis))
         monkeypatch.setattr("app.api.internal._check_rate_limit_internal", AsyncMock())
@@ -328,6 +330,79 @@ class TestCachingBehaviour:
         # AC-5e: cache hit MUST NOT trigger DB or JWT signature re-check.
         db.execute.assert_not_called()
         jwt_decode.assert_not_called()
+
+    async def test_jwt_cache_entry_does_not_serve_membership_request(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """REQ-1.5 strict keying: a JWT-evidence cache entry MUST NOT serve a
+        membership-evidence (bearer_jwt=None) lookup.
+
+        Honest audit: a request that did not forward a JWT must never see
+        ``evidence="jwt"`` in the response, otherwise the audit signal lies
+        about which check actually fired.
+        """
+        # Seed a JWT-evidence entry only.
+        redis = _make_redis_mock()
+        redis._store["identity_verify:scribe:u-1:o-1:jwt"] = json.dumps(
+            {"user_id": "u-1", "org_id": "o-1", "evidence": "jwt"}
+        )
+        monkeypatch.setattr("app.api.internal.get_redis_pool", AsyncMock(return_value=redis))
+        monkeypatch.setattr("app.api.internal._check_rate_limit_internal", AsyncMock())
+        _patch_jwks_resolver(monkeypatch)
+
+        # Request comes in with bearer_jwt=None — membership lookup expected.
+        with _patched_internal_settings(monkeypatch):
+            response = await verify_identity(
+                request=_make_request(),
+                body=IdentityVerifyRequest(
+                    caller_service="scribe",
+                    claimed_user_id="u-1",
+                    claimed_org_id="o-1",
+                    bearer_jwt=None,
+                ),
+                db=_success_db_mock(),
+            )
+
+        assert response.status_code == http_status.HTTP_200_OK
+        body = json.loads(response.body)
+        # The JWT-cached value must NOT have been served — fresh membership
+        # lookup ran, so evidence must be membership.
+        assert body["evidence"] == "membership"
+
+    async def test_membership_cache_entry_does_not_serve_jwt_request(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Symmetric counterpart to the JWT-vs-membership isolation test above."""
+        redis = _make_redis_mock()
+        redis._store["identity_verify:scribe:u-1:o-1:membership"] = json.dumps(
+            {"user_id": "u-1", "org_id": "o-1", "evidence": "membership"}
+        )
+        monkeypatch.setattr("app.api.internal.get_redis_pool", AsyncMock(return_value=redis))
+        monkeypatch.setattr("app.api.internal._check_rate_limit_internal", AsyncMock())
+        _patch_jwks_resolver(monkeypatch)
+        monkeypatch.setattr(
+            "app.services.identity_verifier.jwt.decode",
+            lambda *_args, **_kwargs: {
+                "sub": "u-1",
+                "iss": "https://zitadel.example.com",
+                "exp": 9999999999,
+                "urn:zitadel:iam:user:resourceowner:id": "o-1",
+            },
+        )
+
+        with _patched_internal_settings(monkeypatch):
+            response = await verify_identity(
+                request=_make_request(),
+                body=IdentityVerifyRequest(
+                    caller_service="scribe",
+                    claimed_user_id="u-1",
+                    claimed_org_id="o-1",
+                    bearer_jwt="some.jwt.value",
+                ),
+                db=_success_db_mock(),
+            )
+
+        assert response.status_code == http_status.HTTP_200_OK
+        body = json.loads(response.body)
+        # Fresh JWT validation ran, so evidence must be jwt — not the
+        # cached membership entry.
+        assert body["evidence"] == "jwt"
 
 
 # ---------------------------------------------------------------------------

--- a/klai-portal/backend/tests/test_internal_identity_verify.py
+++ b/klai-portal/backend/tests/test_internal_identity_verify.py
@@ -223,9 +223,7 @@ class TestMembershipPath:
 
 
 class TestJwtPath:
-    async def test_returns_200_when_jwt_matches_claimed_identity(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_returns_200_when_jwt_matches_claimed_identity(self, monkeypatch: pytest.MonkeyPatch) -> None:
         redis = _make_redis_mock()
         monkeypatch.setattr("app.api.internal.get_redis_pool", AsyncMock(return_value=redis))
         monkeypatch.setattr("app.api.internal._check_rate_limit_internal", AsyncMock())
@@ -302,9 +300,7 @@ class TestCachingBehaviour:
         # Pre-seed the Redis cache with a verified entry.
         redis = _make_redis_mock()
         cache_key = "identity_verify:scribe:u-1:o-1"
-        redis._store[cache_key] = json.dumps(
-            {"user_id": "u-1", "org_id": "o-1", "evidence": "jwt"}
-        )
+        redis._store[cache_key] = json.dumps({"user_id": "u-1", "org_id": "o-1", "evidence": "jwt"})
         monkeypatch.setattr("app.api.internal.get_redis_pool", AsyncMock(return_value=redis))
         monkeypatch.setattr("app.api.internal._check_rate_limit_internal", AsyncMock())
 
@@ -383,9 +379,7 @@ class TestRedisFailureMode:
         body = json.loads(response.body)
         assert body["reason"] == "cache_unavailable"
 
-    async def test_returns_503_when_redis_set_raises_after_verified(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_returns_503_when_redis_set_raises_after_verified(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # Cache miss + DB allow + Redis SET fails → MUST fail closed (REQ-1.6).
         redis = _make_redis_mock()
         redis.set = AsyncMock(side_effect=RedisError("connection refused"))

--- a/klai-retrieval-api/retrieval_api/api/retrieve.py
+++ b/klai-retrieval-api/retrieval_api/api/retrieve.py
@@ -61,6 +61,12 @@ async def retrieve(req: RetrieveRequest, request: Request) -> RetrieveResponse:
         raise HTTPException(status_code=400, detail="user_id required for scope=personal/both")
     if req.scope == "notebook" and not req.notebook_id:
         raise HTTPException(status_code=400, detail="notebook_id required for scope=notebook")
+    # SPEC-SEC-IDENTITY-ASSERT-001 REQ-5.2: notebook scope requires user_id so the
+    # personal-vs-team visibility gate can apply. Without user_id, the personal
+    # leg of _notebook_filter cannot fire and personal chunks would silently
+    # disappear from results — fail loud rather than silent.
+    if req.scope == "notebook" and not req.user_id:
+        raise HTTPException(status_code=400, detail="missing_user_id_for_personal_scope")
 
     # SPEC-SEC-010 REQ-3: cross-user / cross-org guard (JWT path only).
     verify_body_identity(request, req.org_id, req.user_id)

--- a/klai-retrieval-api/retrieval_api/services/search.py
+++ b/klai-retrieval-api/retrieval_api/services/search.py
@@ -111,22 +111,74 @@ def _scope_filter(request: RetrieveRequest) -> list[FieldCondition | Filter]:
     return conditions
 
 
+def _notebook_filter(request: RetrieveRequest) -> list[FieldCondition | Filter]:
+    """Build the must_conditions list for ``_search_notebook``.
+
+    SPEC-SEC-IDENTITY-ASSERT-001 REQ-5: extends the previous tenant-only
+    scope with a personal-vs-team visibility gate symmetric to
+    ``_search_knowledge``'s ``visibility=private`` filter. Chunks carry a
+    ``notebook_visibility`` payload field at ingest time (written by
+    klai-focus/research-api's qdrant_store).
+
+    Visibility logic:
+
+    - Team notebooks: the chunk has ``notebook_visibility="org"`` and is
+      readable by every user in the tenant — no owner check. ``"org"``
+      mirrors ``Notebook.scope`` in research-api so no translation layer
+      sits between the DB record and the Qdrant payload.
+    - Personal notebooks: the chunk has ``notebook_visibility="personal"``
+      and is readable only when ``owner_user_id`` matches the requester.
+
+    The ``Filter(should=[...])`` block is the OR of the two branches: a
+    chunk passes when EITHER the team-leg matches OR the personal-leg
+    matches. Chunks with no payload field (legacy, pre-migration) match
+    neither leg and are filtered out — fail-secure default.
+    """
+
+    conditions: list[FieldCondition | Filter] = [
+        FieldCondition(key="tenant_id", match=MatchValue(value=request.org_id)),
+    ]
+    if request.notebook_id:
+        conditions.append(
+            FieldCondition(key="notebook_id", match=MatchValue(value=request.notebook_id))
+        )
+
+    # Visibility gate. user_id is required at the endpoint when notebook scope
+    # is requested (REQ-5.2), so callers reaching this function with no user_id
+    # are programmer errors — the personal-leg simply can't fire without it.
+    visibility_branches: list[FieldCondition | Filter] = [
+        FieldCondition(key="notebook_visibility", match=MatchValue(value="org")),
+    ]
+    if request.user_id:
+        visibility_branches.append(
+            Filter(
+                must=[
+                    FieldCondition(key="notebook_visibility", match=MatchValue(value="personal")),
+                    FieldCondition(key="owner_user_id", match=MatchValue(value=request.user_id)),
+                ]
+            )
+        )
+    conditions.append(Filter(should=visibility_branches))
+
+    conditions.append(_invalid_at_filter())
+    return conditions
+
+
 async def _search_notebook(
     query_vector: list[float],
     request: RetrieveRequest,
     candidates: int,
 ) -> list[dict]:
-    """Dense cosine search on klai_focus collection (single unnamed vector)."""
+    """Dense cosine search on klai_focus collection (single unnamed vector).
+
+    Filter logic delegated to :func:`_notebook_filter`. SPEC-SEC-IDENTITY-ASSERT-001
+    REQ-5 enforces a visibility gate (``notebook_visibility`` payload + symmetric
+    ``owner_user_id`` filter) so a user cannot read a peer's personal notebook
+    just because both belong to the same tenant (AC-4).
+    """
     client = _get_client()
 
-    must_conditions: list[FieldCondition | Filter] = [
-        FieldCondition(key="tenant_id", match=MatchValue(value=request.org_id)),
-    ]
-    if request.notebook_id:
-        must_conditions.append(
-            FieldCondition(key="notebook_id", match=MatchValue(value=request.notebook_id))
-        )
-    must_conditions.append(_invalid_at_filter())
+    must_conditions = _notebook_filter(request)
 
     try:
         result = await asyncio.wait_for(

--- a/klai-retrieval-api/tests/test_notebook_filter.py
+++ b/klai-retrieval-api/tests/test_notebook_filter.py
@@ -1,0 +1,114 @@
+"""Tests for the personal-vs-team notebook visibility filter.
+
+SPEC-SEC-IDENTITY-ASSERT-001 REQ-5: ``_search_notebook`` MUST filter klai_focus
+chunks by ``owner_user_id`` when the notebook is personal, symmetric with
+``_search_knowledge``'s ``user_id`` filter on private chunks.
+
+The filter is built from the chunk-level payload field ``notebook_visibility``
+written at ingest time by klai-focus/research-api. AC-4 requires the cross-
+user-same-org regression: user A in org X cannot read user B's personal
+notebook in org X.
+"""
+
+from __future__ import annotations
+
+from qdrant_client.models import FieldCondition, Filter
+
+from retrieval_api.models import RetrieveRequest
+from retrieval_api.services.search import _notebook_filter
+
+
+def _request(*, user_id: str | None = "user-A", notebook_id: str | None = "n-1") -> RetrieveRequest:
+    return RetrieveRequest(
+        query="confidential",
+        org_id="org-X",
+        scope="notebook",
+        user_id=user_id,
+        notebook_id=notebook_id,
+    )
+
+
+def _find_visibility_should(conditions: list[FieldCondition | Filter]) -> Filter | None:
+    """Return the ``Filter(should=[...])`` block that gates by notebook_visibility."""
+    for c in conditions:
+        if isinstance(c, Filter) and c.should is not None:
+            return c
+    return None
+
+
+class TestNotebookFilterShape:
+    def test_includes_tenant_and_notebook_match(self) -> None:
+        conditions = _notebook_filter(_request())
+
+        kinds = [c for c in conditions if isinstance(c, FieldCondition)]
+        keys = {c.key for c in kinds}
+        assert "tenant_id" in keys
+        assert "notebook_id" in keys
+
+    def test_includes_visibility_should_block(self) -> None:
+        conditions = _notebook_filter(_request())
+
+        visibility = _find_visibility_should(conditions)
+        assert visibility is not None
+        assert visibility.should is not None
+        # Two branches: team-leg and personal-leg
+        assert len(visibility.should) == 2
+
+    def test_team_branch_matches_visibility_org(self) -> None:
+        # Team-equivalent chunks pass tenant gate without owner check.
+        # Value is "org" — mirrors Notebook.scope in research-api so no
+        # translation layer sits between the DB record and Qdrant payload.
+        conditions = _notebook_filter(_request())
+        visibility = _find_visibility_should(conditions)
+        assert visibility is not None
+        team_branch = visibility.should[0]
+        assert isinstance(team_branch, FieldCondition)
+        assert team_branch.key == "notebook_visibility"
+        assert team_branch.match is not None
+        # MatchValue.value is the matched literal.
+        assert getattr(team_branch.match, "value", None) == "org"
+
+    def test_personal_branch_requires_owner_user_id(self) -> None:
+        # Personal chunks pass only when owner_user_id matches the requester.
+        conditions = _notebook_filter(_request(user_id="user-A"))
+        visibility = _find_visibility_should(conditions)
+        assert visibility is not None
+        personal_branch = visibility.should[1]
+        assert isinstance(personal_branch, Filter)
+        assert personal_branch.must is not None
+        # Two conditions: visibility=personal AND owner_user_id=user-A
+        keys: list[str] = []
+        for cond in personal_branch.must:
+            assert isinstance(cond, FieldCondition)
+            keys.append(cond.key)
+        assert "notebook_visibility" in keys
+        assert "owner_user_id" in keys
+
+    def test_personal_branch_owner_matches_request_user_id(self) -> None:
+        conditions = _notebook_filter(_request(user_id="user-XYZ"))
+        visibility = _find_visibility_should(conditions)
+        assert visibility is not None
+        personal_branch = visibility.should[1]
+        assert isinstance(personal_branch, Filter)
+        assert personal_branch.must is not None
+        owner_cond = next(
+            c
+            for c in personal_branch.must
+            if isinstance(c, FieldCondition) and c.key == "owner_user_id"
+        )
+        assert getattr(owner_cond.match, "value", None) == "user-XYZ"
+
+
+class TestNotebookFilterCrossUserRegression:
+    """AC-4: filter constructed for user A MUST encode user A as the owner check.
+
+    A subsequent Qdrant query against chunks belonging to user B in the same
+    org returns zero hits for the personal-leg, and the team-leg only matches
+    when the chunk is explicitly marked team-visibility.
+    """
+
+    def test_user_a_filter_does_not_reference_user_b(self) -> None:
+        conditions = _notebook_filter(_request(user_id="user-A"))
+        rendered = repr(conditions)
+        assert "user-A" in rendered
+        assert "user-B" not in rendered


### PR DESCRIPTION
## Summary

Phase A of [SPEC-SEC-IDENTITY-ASSERT-001](.moai/specs/SPEC-SEC-IDENTITY-ASSERT-001/spec.md) — closes the foundation needed for every Klai service-to-service call to verify a tenant or user identity claim against portal-api, plus the orphan REQ-5 (notebook cross-user-same-org read fix).

Three reviewable commits:

1. **`feat(libs)` REQ-7** — `klai-libs/identity-assert/` shared Python helper. 39 tests.
2. **`feat(portal-api)` REQ-1** — `POST /internal/identity/verify` endpoint with Redis cache + structlog. 20 tests.
3. **`feat(retrieval,focus)` REQ-5** — `_search_notebook` user_id filter + Qdrant `notebook_visibility` payload. 17 tests (6 new + 11 unchanged scope_filter).

**76 tests pass total** for SPEC-SEC-IDENTITY-ASSERT-001 in this PR.

## Architectural decisions made in plan phase

| # | Decision | Rationale |
|---|---|---|
| 1 | End-user JWT in `Authorization: Bearer <jwt>` | Mirrors `klai-retrieval-api/middleware/auth.py` pattern; RFC standard; `X-Internal-Secret` stays for service auth |
| 2 | REQ-4.2 (global verify), split-routes deferred until needed | All current `/retrieve` callers act on behalf of a user; YAGNI on `/admin/retrieve` until an admin caller exists; REQ-4.5 forbids the admin-flag hybrid |
| 3 | `notebook_visibility` Qdrant payload field | Mirrors `Notebook.scope` ∈ {"personal","org"} — no translation layer; payload-based filter avoids per-query DB lookup |

## Out of scope (deferred)

REQ-2 (knowledge-mcp), REQ-3 (scribe), REQ-4 (retrieval-api internal-secret), REQ-6 (`emit_event`) follow as separate `/moai run` invocations once Phase A is merged. Each closes one CRITICAL/HIGH finding independently. See `.moai/specs/SPEC-SEC-IDENTITY-ASSERT-001/progress.md` for the migration sequence.

REQ-7.4 (editable installs of `klai-libs/identity-assert/` in consumer services) lands with the consumer SPECs — this Phase A doesn't import the library anywhere.

## Migration / rollout note

REQ-5 introduces two new payload fields (`notebook_visibility`, `owner_user_id`) on klai_focus chunks. Existing chunks ingested before this PR have neither field and won't match the new filter — they become inaccessible until re-indexed. This is the deliberate fail-secure default (better to lose hits than to leak across users). A backfill / re-index of historical notebooks is required after deploy.

## Test plan

- [ ] CI: portal-api + retrieval-api Docker builds pass
- [ ] CI: Semgrep SAST clean
- [ ] Local sanity: 76 SPEC-tests run (already verified in this branch)
- [ ] Post-merge: trigger one-off backfill job for klai_focus historical chunks
- [ ] Post-merge: verify `/internal/identity/verify` reachable from prod portal-api (curl with valid `Authorization: Bearer $INTERNAL_SECRET`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)