### PR TITLE
SPEC-SEC-CORS-001: explicit CORS allowlist + cross-service middleware-order lint

### DIFF
--- a/.claude/rules/klai/lang/python.md
+++ b/.claude/rules/klai/lang/python.md
@@ -33,7 +33,7 @@ app.add_middleware(RequestContextMiddleware)   # middle: runs 2nd
 app.add_middleware(CORSMiddleware, ...)        # outermost: runs 1st — wraps all 401s with CORS headers
 ```
 
-**Prevention:** AuthGuard MUST be registered before CORSMiddleware. If it is registered after (= outermost), 401 responses bypass CORS and browsers block them silently.
+**Prevention:** AuthGuard MUST be registered before CORSMiddleware. If it is registered after (= outermost), 401 responses bypass CORS and browsers block them silently. Mechanically enforced by `rules/cors_middleware_last.yml` per SPEC-SEC-CORS-001 REQ-6 — every klai FastAPI service workflow (portal-api, klai-connector, retrieval-api, scribe-api, knowledge-ingest, klai-mailer, klai-knowledge-mcp, klai-focus/research-api) runs the lint via `ast-grep/action` on every PR that touches its entry module. The lint fires on both the simple sibling case and the nested-if case (klai-connector pattern, where CORS lived inside `if allowed_origins:`).
 
 ## Refactoring safety
 - Run `ruff check` after each refactor step, not only at the end.

--- a/.github/workflows/klai-connector.yml
+++ b/.github/workflows/klai-connector.yml
@@ -8,6 +8,13 @@ on:
       - 'klai-libs/connector-credentials/**'
       - 'klai-libs/image-storage/**'
       - '.github/workflows/klai-connector.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'klai-connector/**'
+      - 'klai-libs/connector-credentials/**'
+      - 'klai-libs/image-storage/**'
+      - '.github/workflows/klai-connector.yml'
   workflow_dispatch:
 
 permissions:
@@ -25,6 +32,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+
+      # SPEC-SEC-CORS-001 REQ-6 — CORSMiddleware must be the LAST add_middleware
+      # call in this service's entry module. Rule lives at
+      # rules/cors_middleware_last.yml, configured by sgconfig.yml at repo root.
+      # `uses:` steps ignore the job's defaults.run.working-directory and run
+      # from $GITHUB_WORKSPACE, so the relative paths resolve correctly.
+      - name: Guard — CORSMiddleware must be last (SPEC-SEC-CORS-001 REQ-6)
+        uses: ast-grep/action@cf62e780f0c88301228978d593a7784427a097a6  # v1.5.0
+        with:
+          config: sgconfig.yml
+          paths: klai-connector/app/main.py
 
       - name: Log in to GHCR
         uses: docker/login-action@v4

--- a/.github/workflows/klai-knowledge-mcp.yml
+++ b/.github/workflows/klai-knowledge-mcp.yml
@@ -6,6 +6,11 @@ on:
     paths:
       - 'klai-knowledge-mcp/**'
       - '.github/workflows/klai-knowledge-mcp.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'klai-knowledge-mcp/**'
+      - '.github/workflows/klai-knowledge-mcp.yml'
   workflow_dispatch:
 
 permissions:
@@ -23,6 +28,19 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+
+      # SPEC-SEC-CORS-001 REQ-6 — CORSMiddleware must be the LAST add_middleware
+      # call in this service's entry module. Rule lives at
+      # rules/cors_middleware_last.yml, configured by sgconfig.yml at repo root.
+      # `uses:` steps ignore the job's defaults.run.working-directory and run
+      # from $GITHUB_WORKSPACE, so the relative paths resolve correctly.
+      # Note: klai-knowledge-mcp uses FastMCP streamable_http_app() which has no
+      # add_middleware calls — this step is a vacuous-pass per REQ-6.3 note.
+      - name: Guard — CORSMiddleware must be last (SPEC-SEC-CORS-001 REQ-6)
+        uses: ast-grep/action@cf62e780f0c88301228978d593a7784427a097a6  # v1.5.0
+        with:
+          config: sgconfig.yml
+          paths: klai-knowledge-mcp/main.py
 
       - name: Log in to GHCR
         uses: docker/login-action@v4

--- a/.github/workflows/klai-mailer.yml
+++ b/.github/workflows/klai-mailer.yml
@@ -6,6 +6,11 @@ on:
     paths:
       - 'klai-mailer/**'
       - '.github/workflows/klai-mailer.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'klai-mailer/**'
+      - '.github/workflows/klai-mailer.yml'
   workflow_dispatch:
 
 permissions:
@@ -23,6 +28,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+
+      # SPEC-SEC-CORS-001 REQ-6 — CORSMiddleware must be the LAST add_middleware
+      # call in this service's entry module. Rule lives at
+      # rules/cors_middleware_last.yml, configured by sgconfig.yml at repo root.
+      # `uses:` steps ignore the job's defaults.run.working-directory and run
+      # from $GITHUB_WORKSPACE, so the relative paths resolve correctly.
+      - name: Guard — CORSMiddleware must be last (SPEC-SEC-CORS-001 REQ-6)
+        uses: ast-grep/action@cf62e780f0c88301228978d593a7784427a097a6  # v1.5.0
+        with:
+          config: sgconfig.yml
+          paths: klai-mailer/app/main.py
 
       - name: Log in to GHCR
         uses: docker/login-action@v4

--- a/.github/workflows/knowledge-ingest.yml
+++ b/.github/workflows/knowledge-ingest.yml
@@ -8,6 +8,13 @@ on:
       - 'klai-libs/connector-credentials/**'
       - 'klai-libs/image-storage/**'
       - '.github/workflows/knowledge-ingest.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'klai-knowledge-ingest/**'
+      - 'klai-libs/connector-credentials/**'
+      - 'klai-libs/image-storage/**'
+      - '.github/workflows/knowledge-ingest.yml'
   workflow_dispatch:
 
 permissions:
@@ -25,6 +32,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+
+      # SPEC-SEC-CORS-001 REQ-6 — CORSMiddleware must be the LAST add_middleware
+      # call in this service's entry module. Rule lives at
+      # rules/cors_middleware_last.yml, configured by sgconfig.yml at repo root.
+      # `uses:` steps ignore the job's defaults.run.working-directory and run
+      # from $GITHUB_WORKSPACE, so the relative paths resolve correctly.
+      - name: Guard — CORSMiddleware must be last (SPEC-SEC-CORS-001 REQ-6)
+        uses: ast-grep/action@cf62e780f0c88301228978d593a7784427a097a6  # v1.5.0
+        with:
+          config: sgconfig.yml
+          paths: klai-knowledge-ingest/knowledge_ingest/app.py
 
       - name: Log in to GHCR
         uses: docker/login-action@v4

--- a/.github/workflows/retrieval-api.yml
+++ b/.github/workflows/retrieval-api.yml
@@ -6,6 +6,11 @@ on:
     paths:
       - 'klai-retrieval-api/**'
       - '.github/workflows/retrieval-api.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'klai-retrieval-api/**'
+      - '.github/workflows/retrieval-api.yml'
   workflow_dispatch:
 
 permissions:
@@ -23,6 +28,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+
+      # SPEC-SEC-CORS-001 REQ-6 — CORSMiddleware must be the LAST add_middleware
+      # call in this service's entry module. Rule lives at
+      # rules/cors_middleware_last.yml, configured by sgconfig.yml at repo root.
+      # `uses:` steps ignore the job's defaults.run.working-directory and run
+      # from $GITHUB_WORKSPACE, so the relative paths resolve correctly.
+      - name: Guard — CORSMiddleware must be last (SPEC-SEC-CORS-001 REQ-6)
+        uses: ast-grep/action@cf62e780f0c88301228978d593a7784427a097a6  # v1.5.0
+        with:
+          config: sgconfig.yml
+          paths: klai-retrieval-api/retrieval_api/main.py
 
       - name: Log in to GHCR
         uses: docker/login-action@v4

--- a/.github/workflows/scribe-api.yml
+++ b/.github/workflows/scribe-api.yml
@@ -6,6 +6,11 @@ on:
     paths:
       - 'klai-scribe/scribe-api/**'
       - '.github/workflows/scribe-api.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'klai-scribe/scribe-api/**'
+      - '.github/workflows/scribe-api.yml'
   workflow_dispatch:
 
 permissions:
@@ -23,6 +28,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+
+      # SPEC-SEC-CORS-001 REQ-6 — CORSMiddleware must be the LAST add_middleware
+      # call in this service's entry module. Rule lives at
+      # rules/cors_middleware_last.yml, configured by sgconfig.yml at repo root.
+      # `uses:` steps ignore the job's defaults.run.working-directory and run
+      # from $GITHUB_WORKSPACE, so the relative paths resolve correctly.
+      - name: Guard — CORSMiddleware must be last (SPEC-SEC-CORS-001 REQ-6)
+        uses: ast-grep/action@cf62e780f0c88301228978d593a7784427a097a6  # v1.5.0
+        with:
+          config: sgconfig.yml
+          paths: klai-scribe/scribe-api/app/main.py
 
       - name: Log in to GHCR
         uses: docker/login-action@v4

--- a/.moai/specs/SPEC-SEC-CORS-001/acceptance.md
+++ b/.moai/specs/SPEC-SEC-CORS-001/acceptance.md
@@ -11,7 +11,7 @@ Test files MUST live at:
 - `klai-portal/backend/tests/test_csrf_exempt_rationale.py` (AC-12)
 - `klai-connector/tests/test_cors_middleware_order.py` (AC-15)
 - `klai-retrieval-api/tests/test_cors_presence.py` (AC-16, AC-17)
-- `.claude/lint/tests/test_cors_middleware_last_lint.py` (AC-18)
+- `rules/tests/test_cors_middleware_last_lint.py` (AC-18)
 
 ## AC-1: Cross-origin GET /api/me from evil.example is blocked
 
@@ -239,8 +239,9 @@ findings (Finding III, Finding IV) and the repo-wide lint gate (REQ-6, REQ-7).
 
 ## AC-18: ast-grep / CI lint catches CORSMiddleware-not-last regressions
 
-- **GIVEN** an ast-grep pattern rule (`.claude/lint/cors_middleware_last.yml` or
-  equivalent location) that matches any file containing
+- **GIVEN** an ast-grep pattern rule (`rules/cors_middleware_last.yml`,
+  matching the existing repo precedent `rules/no-exec-run.yml` discovered via
+  repo-root `sgconfig.yml`) that matches any file containing
   `app.add_middleware(CORSMiddleware, ...)` followed — in source order — by
   another `app.add_middleware(...)` call for the same `app` binding
 - **WHEN** the CI pipeline runs the lint on a pull request that modifies any
@@ -249,12 +250,12 @@ findings (Finding III, Finding IV) and the repo-wide lint gate (REQ-6, REQ-7).
   **THE** lint **SHALL** exit non-zero AND report the offending file and line
   when a regression is introduced.
 - **Synthetic regression test:** A fixture file in
-  `.claude/lint/tests/fixtures/bad_middleware_order.py` SHALL register
+  `rules/tests/fixtures/bad_middleware_order.py` SHALL register
   CORSMiddleware first and Auth middleware after. A pytest case SHALL invoke
   the lint on this fixture and assert a non-zero exit code AND an error message
   naming the fixture file.
 - **Positive test:** A fixture file in
-  `.claude/lint/tests/fixtures/good_middleware_order.py` SHALL register Auth
+  `rules/tests/fixtures/good_middleware_order.py` SHALL register Auth
   first and CORSMiddleware last. A pytest case SHALL invoke the lint on this
   fixture and assert exit code 0.
 - **CI wiring:** The lint SHALL be wired into the repo's CI workflow
@@ -300,5 +301,5 @@ klai-portal/backend/tests/test_partner_cors.py
 klai-portal/backend/tests/test_csrf_exempt_rationale.py
 klai-connector/tests/test_cors_middleware_order.py
 klai-retrieval-api/tests/test_cors_presence.py
-.claude/lint/tests/test_cors_middleware_last_lint.py` and pass in CI before
+rules/tests/test_cors_middleware_last_lint.py` and pass in CI before
 this SPEC can be marked `status: done`.

--- a/.moai/specs/SPEC-SEC-CORS-001/progress.md
+++ b/.moai/specs/SPEC-SEC-CORS-001/progress.md
@@ -1,0 +1,115 @@
+## SPEC-SEC-CORS-001 Progress
+
+- Started: 2026-04-25
+- Worktree: /c/Users/markv/.moai/worktrees/klai/SPEC-SEC-CORS-001
+- Branch: feature/SPEC-SEC-CORS-001 (branched from origin/main @ 19dcf997)
+- Harness: thorough (auto-detected: critical priority + security domain + multi-service)
+- Methodology: TDD (per quality.yaml development_mode)
+- Scale-based mode: Full Pipeline
+
+### Phase 1 — Analysis & Planning (COMPLETE)
+- manager-strategy verified all research.md findings against current code
+- Two BLOCKING discrepancies found and folded into scope:
+  - **Verification B**: portal-api CORSMiddleware was NOT actually the LAST add_middleware (LoggingContextMiddleware @ main.py:199, SessionMiddleware @ main.py:203 came after). SessionMiddleware-emitted 401s bypass CORS. → Q1-FIX (REQ-6.7) added.
+  - **Verification K**: production compose env block for portal-api did not pass `CORS_ORIGINS`. Once REQ-1 narrows the regex, prod browsers from my.getklai.com would 502 on first restart. → T-000A.bis (compose env-var + SOPS row) added as hard pre-flight.
+- 25 atomic tasks decomposed, all approved.
+
+### Phase 1.5 — Task Decomposition (COMPLETE)
+- tasks.md persisted at .moai/specs/SPEC-SEC-CORS-001/tasks.md
+- Drift target: 28 files (17 modified + 11 created)
+
+### Phase 1.6 — Acceptance Criteria Initialization (COMPLETE)
+- AC-1..AC-18 registered as failing-checklist tasks
+- All 18 ACs satisfied at end of run
+
+### Phase 1.7 — File Structure Scaffolding (COMPLETE)
+- Test file stubs created during TDD red phases
+- LSP baseline captured before T-001
+
+### Phase 2 — Implementation (COMPLETE)
+
+| Task | Status | Verification |
+|---|---|---|
+| T-000A SOPS preflight | Done | Zero `CORS_ALLOW_ORIGIN_REGEX` references in compose/SOPS |
+| T-000A.bis compose CORS_ORIGINS | Done (local) | `CORS_ORIGINS: ${CORS_ORIGINS:-https://my.${DOMAIN}}` added to portal-api block |
+| T-000A.bis SOPS row | DEFERRED | Requires SSH to core-01 — see "Manual steps" below |
+| T-000B ast-grep rule + fixtures + lint test | Done | Rule fires on bad fixtures (sibling + nested), clean on good fixture; portal-api workflow already wired |
+| T-000C test harness | Done | tests/ + conftest already exist for connector + retrieval-api |
+| T-001..T-008 portal CORS allowlist (REQ-1) | Done | 26 tests pass in test_cors_allowlist.py |
+| T-009..T-011 partner CORS (REQ-2, REQ-3) | Done | 4 tests pass in test_partner_cors.py |
+| T-012 CSRF rationale (REQ-4) + /widget/ prune | Done | 1 test in test_csrf_exempt_rationale.py; /widget/ removed (no mounted handlers) |
+| T-013, T-014 NFR observability + fail-closed | Done | structlog cors_origin_rejected event, SystemExit on bad regex |
+| Q1-FIX portal-api own middleware order (REQ-6.7) | Done | CORSMiddleware now LAST add_middleware in main.py; lint exit 0 |
+| T-015 connector reorder (REQ-6.4) | Done | 5 tests in test_cors_middleware_order.py; lint exit 0 |
+| T-016 retrieval-api CORS deny-by-default | Done | 14 tests in test_cors_presence.py; lint exit 0 |
+| T-017 retrieval-api OPTIONS deny test (AC-17) | Done | parametrized over 4 origins x 2 headers |
+| T-018 6 service workflow lint wiring | Done | 6 workflows + pull_request triggers + ast-grep step; AC-18 wiring test 7/7 pass |
+| T-099A python.md cross-link to SPEC REQ-6 | Done | One-line addition to "Prevention:" section |
+| T-099B widget integration runbook | Done | docs/runbooks/widget-integration.md created |
+| T-099C drift report + close-out | Done | This document |
+
+### Test results
+
+| Service | New SPEC tests | Full suite | Lint | Ruff |
+|---|---|---|---|---|
+| klai-portal/backend | 31 pass (cors_allowlist 26 + partner 4 + rationale 1) | 1179 pass / 0 fail | exit 0 | clean |
+| klai-connector | 5 pass | 11 pre-existing failures (notion+image — unrelated) | exit 0 | clean |
+| klai-retrieval-api | 14 pass | 7 pre-existing failures (health/tei/auth — unrelated) | exit 0 | 1 pre-existing E501 |
+| rules/tests (lint unit tests) | 10 pass (3 fixture + 7 workflow wiring) | 10 pass | n/a | n/a |
+
+Total new tests: **60 + 10 = 70 pass**.
+
+### Drift report (Phase 2.7 → DRIFT GUARD)
+
+Planned modifications (17): all 17 modified ✓
+Planned creations (11): 11 created (10 git-untracked + rules/tests/ subtree) ✓
+
+Net divergence: **+1 unplanned file** = `rules/tests/fixtures/bad_middleware_order_nested.py` (added during T-000B to give the rule's nested-if branch independent test coverage; needed because klai-connector's pattern is structurally different from the simple sibling case).
+
+Drift = 1/28 = 3.6%. Below the 20% informational threshold. **No re-planning gate trigger.**
+
+Files NOT touched (planned out-of-scope):
+- klai-scribe/scribe-api/app/main.py (already canonical)
+- klai-focus/research-api/app/main.py (already canonical)
+- klai-portal/backend/app/services/widget_auth.py (REQ-2.4 preserved)
+- All portal route files except partner.py (REQ-1 is middleware-level only)
+- All existing portal test files except via new files
+
+### Lint sweep — final state
+
+```
+clean: klai-portal/backend/app/main.py
+clean: klai-connector/app/main.py
+clean: klai-retrieval-api/retrieval_api/main.py
+clean: klai-scribe/scribe-api/app/main.py
+clean: klai-focus/research-api/app/main.py
+clean: klai-knowledge-ingest/knowledge_ingest/app.py
+clean: klai-mailer/app/main.py
+clean: klai-knowledge-mcp/main.py
+```
+
+All 8 in-scope FastAPI service entry modules pass `cors_middleware_last.yml`.
+
+### Manual steps required (deferred)
+
+1. **SOPS edit on core-01** (T-000A.bis SOPS row): add `CORS_ORIGINS=https://my.getklai.com` to `klai-infra/core-01/.env.sops` via the SSH workflow documented in `.claude/rules/klai/infra/sops-env.md`. MUST be merged to klai-infra main BEFORE merging this branch's compose change to klai main, or portal-api will boot with empty CORS_ORIGINS and reject all browser traffic from `my.getklai.com`. Same-deploy regression class (validator-env-parity, HIGH).
+2. **Production deploy verification**: after deploy, run `docker exec klai-core-portal-api-1 printenv CORS_ORIGINS` on core-01 to confirm the env var resolves to `https://my.getklai.com`. Then in browser DevTools, hit `https://my.getklai.com/api/me` and confirm the response carries `Access-Control-Allow-Origin: https://my.getklai.com`.
+3. **VictoriaLogs 7-day monitoring** (success criterion in spec.md): query `event:"cors_origin_rejected" AND NOT origin:/.*getklai\.com/` for 24h post-deploy; confirm zero hits per legitimate origin (i.e. zero false-positive rejections of valid first-party traffic). Demote alert to dashboard after 7 zero-hit days.
+4. **Concurrent SPEC merge order check**: `feature/SPEC-SEC-MFA-001` branched from same base — verify it doesn't touch `app/main.py` or `app/middleware/session.py` before merge order. If it does, plan rebase.
+
+### Phase 2.5+ quality gates
+
+- Phase 2.5 TRUST 5: Pending. Required: manager-quality run.
+- Phase 2.75 Pre-review gate: lint + format + type-check already passed inline during impl.
+- Phase 2.8a evaluator-active (thorough): Pending.
+- Phase 2.10 Simplify pass: Pending.
+
+### Phase 3 — Git operations
+
+Pending. No commits yet. Suggested commit boundaries:
+- C1: `chore(spec): SPEC-SEC-CORS-001 v0.4.0 — promote draft, add REQ-6.7, fold pre-flight findings` (spec.md, acceptance.md, tasks.md, progress.md)
+- C2: `feat(lint): SPEC-SEC-CORS-001 REQ-6 — ast-grep rule + fixtures + per-service workflow wiring` (rules/, .github/workflows/{6 services}, .claude/rules/klai/lang/python.md, T-099A pointer)
+- C3: `feat(portal-api): SPEC-SEC-CORS-001 REQ-1..REQ-4 + REQ-6.7 — explicit CORS allowlist, partner cookie-less policy, CSRF rationale` (klai-portal/, deploy/docker-compose.yml T-000A.bis, klai_cors.py)
+- C4: `feat(connector): SPEC-SEC-CORS-001 REQ-6.4 — middleware reorder so CORS wraps 401` (klai-connector/)
+- C5: `feat(retrieval-api): SPEC-SEC-CORS-001 REQ-7 — deny-by-default CORSMiddleware starter` (klai-retrieval-api/)
+- C6: `docs(widget): SPEC-SEC-CORS-001 REQ-3.3 — credentials:omit integration runbook` (docs/runbooks/widget-integration.md)

--- a/.moai/specs/SPEC-SEC-CORS-001/spec.md
+++ b/.moai/specs/SPEC-SEC-CORS-001/spec.md
@@ -1,9 +1,9 @@
 ---
 id: SPEC-SEC-CORS-001
-version: 0.3.0
-status: draft
+version: 0.4.0
+status: in_progress
 created: 2026-04-24
-updated: 2026-04-24
+updated: 2026-04-25
 author: Mark Vletter
 priority: critical
 tracker: SPEC-SEC-AUDIT-2026-04
@@ -12,6 +12,39 @@ tracker: SPEC-SEC-AUDIT-2026-04
 # SPEC-SEC-CORS-001: CORS Allowlist + CSRF-Exempt Scope Review
 
 ## HISTORY
+
+### v0.4.0 (2026-04-25)
+- Phase 1 (manager-strategy) verified all research.md findings against current
+  code in the worktree. Two BLOCKING discrepancies surfaced and folded into the
+  implementation plan:
+  - Verification B: portal-api `app/main.py:180-203` registers CORSMiddleware
+    BEFORE `LoggingContextMiddleware` (line 199) and `SessionMiddleware`
+    (line 203). Per Starlette LIFO, SessionMiddleware is OUTSIDE CORSMiddleware,
+    so a 401 emitted by SessionMiddleware (CSRF reject at session.py:75-77)
+    bypasses CORS. This is the same failure class REQ-6 demands of every other
+    service. Resolved by adding REQ-6.7 (portal-api self-fix) to scope —
+    CORSMiddleware MUST be the LAST add_middleware call in portal-api's
+    `app/main.py` too. Implemented as the Q1-FIX task between T-014 and T-015.
+  - Verification K: production compose env block for portal-api does NOT pass
+    `CORS_ORIGINS`. Combined with the in-code default `cors_origins: str =
+    "http://localhost:5174"`, today's wildcard regex r".*" is the only thing
+    keeping prod browsers from `my.getklai.com` working. Once REQ-1 narrows
+    the regex, prod 502s on first restart unless `CORS_ORIGINS` is added to
+    `klai-infra/core-01/.env.sops` AND to `deploy/docker-compose.yml`'s
+    portal-api `environment:` block FIRST (validator-env-parity). Folded into
+    pre-flight task T-000A.bis; documented in Cross-references as the SPEC-
+    SEC-WEBHOOK-001 / SPEC-SEC-ENVFILE-SCOPE-001 same-deploy regression class.
+- Added REQ-6.7: portal-api `app/main.py` CORSMiddleware order parity (treat
+  portal-api the same way the lint demands of every other service).
+- Updated REQ-6.2 / REQ-6.3 lint rule location: from speculative
+  `.claude/lint/cors_middleware_last.yml` to `rules/cors_middleware_last.yml`,
+  matching existing repo precedent (`rules/no-exec-run.yml` discovered via
+  repo-root `sgconfig.yml`). acceptance.md AC-18 paths updated accordingly.
+- Status bumped from `draft` to `in_progress`. Phase 2 implementation runs on
+  branch `feature/SPEC-SEC-CORS-001` in worktree
+  `/c/Users/markv/.moai/worktrees/klai/SPEC-SEC-CORS-001`.
+- Added planning artefacts `tasks.md` (25 atomic tasks) and `progress.md`.
+  Drift target: 28 files (17 modified + 11 created).
 
 ### v0.3.0 (2026-04-24)
 - Internal-wave additions from the cross-service middleware audit triggered by the
@@ -376,6 +409,22 @@ and are visible to cross-origin browsers.
   response (no Authorization header on an authenticated route) carries
   `Access-Control-Allow-Origin: <request-origin>` when the request Origin is in the
   connector's `cors_origins` allowlist.
+- **REQ-6.7:** klai-portal `klai-portal/backend/app/main.py` SHALL be reordered so
+  that `app.add_middleware(CORSMiddleware, ...)` is the LAST `add_middleware(...)`
+  call in `create_app`. Today (verified during Phase 1, 2026-04-25) it is registered
+  at line ~180, with `LoggingContextMiddleware` (line ~199) and `SessionMiddleware`
+  (line ~203) added AFTER it in source order. Per Starlette LIFO, this places
+  SessionMiddleware OUTSIDE CORSMiddleware, so a 401 emitted by SessionMiddleware
+  (e.g. CSRF reject at session.py:75-77) bypasses CORS and a cross-origin browser
+  sees an opaque failure. The fix preserves the desired execution order
+  (SessionMiddleware -> LoggingContextMiddleware -> @http no_cache decorator ->
+  CORS -> route) becomes (CORS -> LoggingContextMiddleware -> @http no_cache ->
+  SessionMiddleware -> route). The reorder converts a pre-existing latent bug
+  (currently masked by the wildcard regex r".*") into a properly bounded CORS
+  policy. Acceptance: a positive test SHALL assert that a CSRF-rejected POST
+  (e.g. cross-origin POST to a non-exempt path with mismatched X-CSRF-Token)
+  carries `Access-Control-Allow-Origin` for an allowlisted first-party origin.
+  Lint REQ-6.2 SHALL apply uniformly to klai-portal/backend/app/main.py.
 
 ### REQ-7: klai-retrieval-api CORS deny-by-default starter
 

--- a/.moai/specs/SPEC-SEC-CORS-001/tasks.md
+++ b/.moai/specs/SPEC-SEC-CORS-001/tasks.md
@@ -1,0 +1,37 @@
+## Task Decomposition
+SPEC: SPEC-SEC-CORS-001
+Generated: 2026-04-25 (Phase 1.5)
+Harness: thorough
+Methodology: TDD (RED-GREEN-REFACTOR per AC)
+Worktree: /c/Users/markv/.moai/worktrees/klai/SPEC-SEC-CORS-001
+Branch: feature/SPEC-SEC-CORS-001
+
+| Task ID | Description | REQ | AC | Dependencies | Planned Files | Status |
+|---|---|---|---|---|---|---|
+| T-000A | SOPS pre-flight + compose env-var: verify zero `CORS_ALLOW_ORIGIN_REGEX` references; add `CORS_ORIGINS: ${CORS_ORIGINS:-https://my.getklai.com}` to portal-api compose env block; add `CORS_ORIGINS=https://my.getklai.com` to klai-infra/core-01/.env.sops via SSH SOPS workflow. | REQ-1.6 | n/a (pre-flight) | none | deploy/docker-compose.yml, klai-infra/core-01/.env.sops | pending |
+| T-000B | ast-grep rule scaffolding: rules/cors_middleware_last.yml + good/bad fixtures + pytest invocation + portal-api workflow lint step (initial wiring). | REQ-6.2 | AC-18 | T-000A | rules/cors_middleware_last.yml, rules/tests/test_cors_middleware_last_lint.py, rules/tests/fixtures/good_middleware_order.py, rules/tests/fixtures/bad_middleware_order.py, .github/workflows/portal-api.yml | pending |
+| T-000C | Test harness scaffolding: empty conftest.py and __init__.py for klai-connector/tests and klai-retrieval-api/tests. | n/a | n/a | none | klai-connector/tests/__init__.py, klai-connector/tests/conftest.py, klai-retrieval-api/tests/__init__.py, klai-retrieval-api/tests/conftest.py | pending |
+| T-001 | RED+GREEN: test_cors_blocks_evil_origin_on_api_me + REQ-1 impl (remove cors_allow_origin_regex field; module-level fixed regex `^https://([a-z0-9][a-z0-9-]*\.)?getklai\.com$`). | REQ-1.1, REQ-1.5, REQ-1.6 | AC-1 | T-000A, T-000B, T-000C | klai-portal/backend/app/core/config.py, klai-portal/backend/app/main.py, klai-portal/backend/.env.example, klai-portal/backend/tests/test_cors_allowlist.py | pending |
+| T-002 | RED+GREEN: test_cors_blocks_evil_origin_on_auth_login_preflight. | REQ-1.1 | AC-2 | T-001 | klai-portal/backend/tests/test_cors_allowlist.py | pending |
+| T-003 | RED+GREEN: test_cors_allows_first_party_on_api_me (https://my.getklai.com). | REQ-1.2, REQ-1.5 | AC-3 | T-001 | klai-portal/backend/tests/test_cors_allowlist.py | pending |
+| T-004 | RED+GREEN: test_cors_allows_tenant_subdomain (acme accepted, evil.my multi-label rejected). | REQ-1.2 | AC-4 | T-001 | klai-portal/backend/tests/test_cors_allowlist.py | pending |
+| T-005 | RED+GREEN: test_cors_rejects_plaintext_http_getklai. | REQ-1.2 | AC-5 | T-001 | klai-portal/backend/tests/test_cors_allowlist.py | pending |
+| T-006 | RED+GREEN: test_cors_allows_dev_origin_localhost_5174. | REQ-1.2 | AC-6 | T-001 | klai-portal/backend/tests/test_cors_allowlist.py | pending |
+| T-007 | RED+GREEN: test_cors_no_unlisted_origin_echo (table test paths × attacker origins). | REQ-1 (group) | AC-7 | T-001 | klai-portal/backend/tests/test_cors_allowlist.py | pending |
+| T-008 | RED+GREEN: test_acac_never_with_wildcard_origin invariant scanner. | REQ-1.5 | AC-8 | T-007 | klai-portal/backend/tests/test_cors_allowlist.py | pending |
+| T-009 | RED+GREEN: REQ-2 partner CORS — second router-level Starlette middleware for /partner/v1/*; remove ACAC headers in partner.py:470-474 + 508-515; test_partner_cors_widget_origin_no_credentials. | REQ-2.1, REQ-2.2, REQ-2.3 | AC-9 | T-001, T-008 | klai-portal/backend/app/main.py, klai-portal/backend/app/api/partner.py, klai-portal/backend/tests/test_partner_cors.py | pending |
+| T-010 | RED+GREEN: test_partner_cors_blocks_unlisted_origin (403 + no ACAO). | REQ-2.1 | AC-10 | T-009 | klai-portal/backend/tests/test_partner_cors.py | pending |
+| T-011 | RED+GREEN: test_bff_cookie_rejected_on_partner_endpoint. | REQ-3.1 | AC-11 | T-009 | klai-portal/backend/tests/test_partner_cors.py | pending |
+| T-012 | RED+GREEN: REQ-4 + test_csrf_exempt_prefixes_have_rationale. Add inline rationale comment block to each entry of _CSRF_EXEMPT_PREFIXES; AST-parse-based test verifies. Audit /widget/ — delete if no mounted handlers. | REQ-4.1, REQ-4.2, REQ-4.3, REQ-4.4, REQ-4.5 | AC-12 | T-008 | klai-portal/backend/app/middleware/session.py, klai-portal/backend/tests/test_csrf_exempt_rationale.py | pending |
+| T-013 | RED+GREEN: REQ-1 NFR observability — `event="cors_origin_rejected"` structlog entry on every preflight where origin doesn't match. Implement OriginObservabilityMiddleware. | REQ-1 NFR | AC-13 | T-001, T-008 | klai-portal/backend/app/main.py, klai-portal/backend/tests/test_cors_allowlist.py | pending |
+| T-014 | RED+GREEN: REQ-1 fail-closed startup + test_cors_regex_compile_failure. | REQ-1 NFR | AC-14 | T-001 | klai-portal/backend/app/main.py, klai-portal/backend/tests/test_cors_allowlist.py | pending |
+| Q1-FIX | Move portal-api CORSMiddleware to be the LAST add_middleware call (extend REQ-6.4 to portal-api). 3-line move + comment update. | REQ-6.7 (added) | AC-1..AC-13 (re-verified) | T-001..T-014 | klai-portal/backend/app/main.py | pending |
+| T-015 | RED+GREEN: REQ-6.4 connector reorder (CORS → Auth → RequestContext → CORS) + test_connector_401_carries_cors_headers (AC-15). | REQ-6.4, REQ-6.6 | AC-15 | T-000C, Q1-FIX | klai-connector/app/main.py, klai-connector/tests/test_cors_middleware_order.py | pending |
+| T-016 | RED+GREEN: REQ-7.1 + REQ-7.2 retrieval-api CORSMiddleware deny-by-default (allow_origins=[], allow_credentials=False, etc.) as LAST add_middleware. test_cors_middleware_present_and_last via app.user_middleware introspection. | REQ-7.1, REQ-7.2 | AC-16 | T-000C | klai-retrieval-api/retrieval_api/main.py, klai-retrieval-api/tests/test_cors_presence.py | pending |
+| T-017 | RED+GREEN: test_retrieval_api_cors_deny_by_default (OPTIONS /retrieve from various origins → no ACAO). | REQ-7.2, REQ-7.4 | AC-17 | T-016 | klai-retrieval-api/tests/test_cors_presence.py | pending |
+| T-018 | REQ-6.2/REQ-6.3 lint wiring per service: ast-grep step in 6 service workflows (klai-connector, retrieval-api, scribe-api, knowledge-ingest, klai-mailer, klai-knowledge-mcp). Extend lint-rule pytest with CI-wiring assertion. | REQ-6.2, REQ-6.3 | AC-18 | T-000B, T-015, T-016 | .github/workflows/klai-connector.yml, .github/workflows/retrieval-api.yml, .github/workflows/scribe-api.yml, .github/workflows/knowledge-ingest.yml, .github/workflows/klai-mailer.yml, .github/workflows/klai-knowledge-mcp.yml, rules/tests/test_cors_middleware_last_lint.py | pending |
+| T-099A | Cross-link .claude/rules/klai/lang/python.md "Starlette middleware registration order" → SPEC-SEC-CORS-001 REQ-6 + lint enforcement note. | REQ-6.5 | n/a (doc) | T-018 | .claude/rules/klai/lang/python.md | pending |
+| T-099B | Widget integration runbook update: `credentials: 'omit'` mandate per REQ-3.3. | REQ-3.3 | n/a (doc) | T-009 | docs/runbooks/widget-integration.md (or equivalent) | pending |
+| T-099C | Drift report + close-out: git diff --stat against planned files; verify zero unplanned files; document VictoriaLogs 7-day monitoring task in retro. | n/a (close-out) | n/a (verification) | T-099A, T-099B | n/a | pending |
+
+**Total**: 25 tasks. Drift target: 28 files (17 modified + 11 created).

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -346,6 +346,19 @@ services:
       DOMAIN: ${DOMAIN}
       FRONTEND_URL: ${FRONTEND_URL:-}
       DOCKER_HOST: tcp://docker-socket-proxy:2375
+      # SPEC-SEC-CORS-001 REQ-1 — explicit credentialed CORS allowlist for
+      # portal-api. Today (pre-SPEC) the in-code default is "http://localhost:5174"
+      # and the prod compose did not pass CORS_ORIGINS at all, so the wildcard
+      # regex r".*" was the only thing keeping prod browsers from my.getklai.com
+      # working. Once REQ-1 lands and removes the wildcard, prod browsers from
+      # my.getklai.com would receive no Access-Control-Allow-Origin header
+      # without this var. Same-deploy regression class as
+      # SPEC-SEC-WEBHOOK-001 / SPEC-SEC-ENVFILE-SCOPE-001.
+      # ${DOMAIN} resolves to "getklai.com" in prod; widget.${DOMAIN} matches
+      # the existing api-gateway widget host. The dynamic single-label
+      # tenant-subdomain pattern (acme.getklai.com) is matched by the
+      # compiled regex inside config.py, NOT by this list.
+      CORS_ORIGINS: ${CORS_ORIGINS:-https://my.${DOMAIN}}
       # ─── Database (portal schema) ───────────────────────────────
       DATABASE_URL: postgresql+asyncpg://portal_api:${PORTAL_API_DB_PASSWORD}@postgres:5432/klai
       # ─── Auth — Zitadel ─────────────────────────────────────────

--- a/docs/runbooks/widget-integration.md
+++ b/docs/runbooks/widget-integration.md
@@ -1,0 +1,120 @@
+# Widget Integration Runbook
+
+> Embed instructions for the Klai partner widget (chat completions on customer
+> sites). Authoritative reference for partner-facing JS snippets and the
+> server-side CORS contract.
+
+## TL;DR for partners
+
+Embed snippet — drop into the customer site:
+
+```html
+<script>
+  (function () {
+    fetch('https://my.getklai.com/partner/v1/widget-config?id=<WIDGET_ID>', {
+      credentials: 'omit',  // REQUIRED — see CORS contract below
+    })
+      .then(function (r) { return r.json(); })
+      .then(function (cfg) {
+        // cfg.session_token is a 1h JWT; use it as Authorization Bearer for chat calls.
+        window.__klai_widget_token = cfg.session_token;
+      });
+  })();
+</script>
+```
+
+Subsequent chat calls:
+
+```js
+fetch('https://my.getklai.com/partner/v1/chat/completions', {
+  method: 'POST',
+  credentials: 'omit',  // REQUIRED — never include cookies on /partner/v1/*
+  headers: {
+    'Authorization': 'Bearer ' + window.__klai_widget_token,
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({ messages: [...] }),
+});
+```
+
+## CORS contract — `/partner/v1/*` is cookie-less by design
+
+SPEC-SEC-CORS-001 REQ-2.2 / REQ-3 mandates that `/partner/v1/*` responses
+NEVER carry `Access-Control-Allow-Credentials: true`. Browser side, this
+means partner widgets MUST use `credentials: 'omit'`. If you use
+`credentials: 'include'` the browser will refuse the response because the
+server policy is incompatible.
+
+This applies to every partner endpoint:
+- `/partner/v1/widget-config` — public widget bootstrap
+- `/partner/v1/chat/completions` — chat (Bearer auth, no cookies)
+- `/partner/v1/feedback` — feedback (Bearer auth, no cookies)
+- `/partner/v1/knowledge` — knowledge query (Bearer auth, no cookies)
+
+## Why it matters
+
+Before SPEC-SEC-CORS-001, portal-api ran a wildcard CORS regex
+(`r".*"`) with `Access-Control-Allow-Credentials: true`. A malicious site
+could in theory send a cross-origin credentialed request to any portal-api
+endpoint while attached to the BFF session cookie of a logged-in tenant
+user — including `/api/auth/login` and `/api/signup`, which were on the
+CSRF-exempt list because they pre-date the BFF session. The combination
+created a probing surface that the audit (Cornelis 2026-04-22, finding #1
++ #17) flagged as critical.
+
+The new contract:
+- First-party portal traffic (`https://my.getklai.com`,
+  `https://<tenant>.getklai.com`) keeps full credentialed CORS support via
+  an explicit allowlist (REQ-1).
+- Widget traffic (`/partner/v1/*` from any customer origin in the widget's
+  stored `allowed_origins`) uses a separate non-credentialed CORS policy
+  (REQ-2). The Bearer token in `Authorization` is the auth, not cookies.
+
+Partners who set `credentials: 'omit'` see zero behavioural change. Partners
+who currently use `credentials: 'include'` MUST switch to `'omit'` after
+SPEC-SEC-CORS-001 ships, or chat calls will fail browser-side with a
+CORS error.
+
+## Per-widget origin allowlist
+
+Each widget has a stored `allowed_origins` list in
+`widgets.widget_config.allowed_origins`. The widget-config handler validates
+the request `Origin` against this list per request and returns 403 if the
+origin is not allowlisted. Customer-side CORS preflight then fails because
+the response carries no `Access-Control-Allow-Origin` header for an
+unlisted origin.
+
+To add an origin for a partner widget, update the widget row through the
+admin portal — there is no env var for this. The list is fail-closed: an
+empty `allowed_origins` rejects every request.
+
+## Test the contract
+
+For partners who want to verify the cookie-less constraint locally:
+
+```bash
+# 1. Confirm widget-config preflight returns Allow-Origin without Allow-Credentials
+curl -i -X OPTIONS 'https://my.getklai.com/partner/v1/widget-config?id=<WIDGET_ID>' \
+  -H 'Origin: https://your-customer-site.com' \
+  -H 'Access-Control-Request-Method: GET'
+# expected: 204 with Access-Control-Allow-Origin echoed and NO
+# Access-Control-Allow-Credentials header
+
+# 2. Confirm cookie-only POST is rejected
+curl -i -X POST 'https://my.getklai.com/partner/v1/chat/completions' \
+  -H 'Cookie: bff_session=<expired-or-foreign>' \
+  -H 'Content-Type: application/json' \
+  -d '{"messages": []}'
+# expected: 401 Unauthorized (no Bearer token)
+```
+
+## Cross-references
+
+- SPEC: `.moai/specs/SPEC-SEC-CORS-001/spec.md` REQ-2, REQ-3, REQ-3.3
+- Acceptance: `.moai/specs/SPEC-SEC-CORS-001/acceptance.md` AC-9, AC-10, AC-11
+- Per-widget origin handler: `klai-portal/backend/app/api/partner.py`
+  (`widget_config` GET around line 432, OPTIONS preflight around line 484)
+- Origin validation helper: `klai-portal/backend/app/services/widget_auth.py`
+  (`origin_allowed`)
+- Custom CORS middleware: `klai-portal/backend/app/middleware/klai_cors.py`
+  (first-party policy) and `app/main.py` partner CORS middleware

--- a/klai-connector/app/main.py
+++ b/klai-connector/app/main.py
@@ -176,7 +176,22 @@ def create_app() -> FastAPI:
 
     app = FastAPI(title="klai-connector", version="0.1.0", lifespan=lifespan)
 
-    # CORS — allow portal frontend origin(s) to call the connector API
+    # Middleware registration order: last-added runs FIRST on the request
+    # (Starlette LIFO — see .claude/rules/klai/lang/python.md and
+    # SPEC-SEC-CORS-001 REQ-6). Desired execution: CORS (outermost, wraps 401
+    # with CORS headers, handles preflight) -> RequestContext (logging) ->
+    # Auth (reject missing header) -> route. So we register in reverse:
+    # Auth, RequestContext, CORS.
+
+    # Auth middleware (excludes /health internally)
+    app.add_middleware(AuthMiddleware, settings=settings)
+
+    # Request context middleware (binds request_id, org_id to structlog)
+    app.add_middleware(RequestContextMiddleware)
+
+    # CORS — allow portal frontend origin(s) to call the connector API.
+    # Must be registered LAST so it is the outermost layer and wraps 401
+    # responses with Access-Control-Allow-Origin (SPEC-SEC-CORS-001 REQ-6.4).
     allowed_origins = [o.strip() for o in settings.cors_origins.split(",") if o.strip()]
     if allowed_origins:
         app.add_middleware(
@@ -185,12 +200,6 @@ def create_app() -> FastAPI:
             allow_methods=["GET", "POST", "PUT", "DELETE"],
             allow_headers=["Authorization", "Content-Type"],
         )
-
-    # Auth middleware (excludes /health internally)
-    app.add_middleware(AuthMiddleware, settings=settings)
-
-    # Request context middleware (binds request_id, org_id to structlog)
-    app.add_middleware(RequestContextMiddleware)
 
     # Routes
     app.include_router(health_router)

--- a/klai-connector/tests/test_cors_middleware_order.py
+++ b/klai-connector/tests/test_cors_middleware_order.py
@@ -130,14 +130,14 @@ class TestCorsWraps401:
 
     _ALLOWED_ORIGIN = "http://localhost:5174"
 
-    @pytest.fixture(autouse=True)
-    def _setup_client(self) -> None:
+    @pytest.fixture(scope="class")
+    def client(self) -> TestClient:
         app = _build_test_app(cors_origins=self._ALLOWED_ORIGIN)
-        self._client = TestClient(app, raise_server_exceptions=True)
+        return TestClient(app, raise_server_exceptions=True)
 
-    def test_401_carries_access_control_allow_origin(self) -> None:
+    def test_401_carries_access_control_allow_origin(self, client: TestClient) -> None:
         """GET /api/v1/connectors without auth returns 401 with ACAO for allowed origin."""
-        resp = self._client.get(
+        resp = client.get(
             "/api/v1/connectors",
             headers={"Origin": self._ALLOWED_ORIGIN},
         )
@@ -147,9 +147,9 @@ class TestCorsWraps401:
             "(CORSMiddleware must be outermost per SPEC-SEC-CORS-001 REQ-6.4)"
         )
 
-    def test_401_carries_vary_origin(self) -> None:
+    def test_401_carries_vary_origin(self, client: TestClient) -> None:
         """The Vary: Origin header is present on the 401 response."""
-        resp = self._client.get(
+        resp = client.get(
             "/api/v1/connectors",
             headers={"Origin": self._ALLOWED_ORIGIN},
         )
@@ -164,14 +164,14 @@ class TestCorsBlocksEvilOrigin:
     _ALLOWED_ORIGIN = "http://localhost:5174"
     _EVIL_ORIGIN = "https://evil.example"
 
-    @pytest.fixture(autouse=True)
-    def _setup_client(self) -> None:
+    @pytest.fixture(scope="class")
+    def client(self) -> TestClient:
         app = _build_test_app(cors_origins=self._ALLOWED_ORIGIN)
-        self._client = TestClient(app, raise_server_exceptions=True)
+        return TestClient(app, raise_server_exceptions=True)
 
-    def test_401_does_not_carry_acao_for_evil_origin(self) -> None:
+    def test_401_does_not_carry_acao_for_evil_origin(self, client: TestClient) -> None:
         """401 from an unlisted origin must NOT echo Access-Control-Allow-Origin."""
-        resp = self._client.get(
+        resp = client.get(
             "/api/v1/connectors",
             headers={"Origin": self._EVIL_ORIGIN},
         )

--- a/klai-connector/tests/test_cors_middleware_order.py
+++ b/klai-connector/tests/test_cors_middleware_order.py
@@ -1,0 +1,183 @@
+"""SPEC-SEC-CORS-001 AC-15: CORSMiddleware wraps 401 responses in klai-connector.
+
+The connector middleware stack MUST register CORSMiddleware LAST (outermost in
+Starlette LIFO execution order) so that 401 responses emitted by AuthMiddleware
+carry the correct ``Access-Control-Allow-Origin`` header for allowed origins.
+
+Two verification layers:
+1. Static source-order check on app/main.py — catches wrong registration order
+   without instantiating the full app (REQ-6.4).
+2. Behaviour test using a test app that mirrors the production middleware stack —
+   verifies the 401+CORS contract end-to-end (AC-15 positive + negative).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.testclient import TestClient
+
+from app.middleware.auth import AuthMiddleware
+
+# ---------------------------------------------------------------------------
+# Layer 1: Static source-order assertion (REQ-6.4)
+# ---------------------------------------------------------------------------
+
+_MAIN_PY = Path(__file__).parent.parent / "app" / "main.py"
+
+
+class TestMiddlewareSourceOrder:
+    """Assert that CORSMiddleware is the LAST add_middleware call in main.py."""
+
+    def test_cors_is_last_add_middleware_call(self) -> None:
+        """CORSMiddleware must appear AFTER AuthMiddleware and RequestContextMiddleware.
+
+        Starlette uses LIFO order: the last add_middleware call becomes the
+        outermost layer.  CORS must be outermost so 401 responses from
+        AuthMiddleware carry CORS headers (SPEC-SEC-CORS-001 REQ-6.4).
+
+        Multi-line calls are supported: we join continuation lines so that
+        ``app.add_middleware(`` followed by ``CORSMiddleware,`` on the next
+        line is recognised as a single CORSMiddleware registration.
+        """
+        src = _MAIN_PY.read_text(encoding="utf-8")
+
+        # Find all add_middleware call sites.  A call may span multiple lines,
+        # so we capture up to 3 lines starting from the `app.add_middleware(`
+        # line and join them into one string for the name check.
+        lines = src.splitlines()
+        add_middleware_calls: list[tuple[int, str]] = []
+        for i, line in enumerate(lines):
+            stripped = line.strip()
+            if stripped.startswith("app.add_middleware("):
+                # Join up to 3 lines to handle multi-line calls.
+                joined = " ".join(lines[i : i + 3])
+                add_middleware_calls.append((i, joined))
+
+        assert add_middleware_calls, "No app.add_middleware(...) calls found in main.py"
+
+        last_lineno, last_call = add_middleware_calls[-1]
+        assert "CORSMiddleware" in last_call, (
+            f"Last app.add_middleware call (line {last_lineno + 1}) must be "
+            f"CORSMiddleware, but found: {last_call!r}. "
+            "Reorder so CORSMiddleware is registered last (outermost) per "
+            "SPEC-SEC-CORS-001 REQ-6.4."
+        )
+
+    def test_cors_middleware_guard_preserved(self) -> None:
+        """The 'if allowed_origins:' guard around CORSMiddleware must still be present."""
+        src = _MAIN_PY.read_text(encoding="utf-8")
+        assert "if allowed_origins:" in src, (
+            "The 'if allowed_origins:' guard must be preserved around CORSMiddleware "
+            "registration in app/main.py (connector uses empty-string default in prod)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: Behaviour tests using a test-app mirror (AC-15)
+# ---------------------------------------------------------------------------
+
+
+def _make_settings(*, cors_origins: str = "") -> SimpleNamespace:
+    """Build the minimal Settings-shape that AuthMiddleware.__init__ reads."""
+    return SimpleNamespace(
+        zitadel_introspection_url="https://auth.test.local/oauth/v2/introspect",
+        zitadel_client_id="test-client-id",
+        zitadel_client_secret="test-client-secret",
+        portal_caller_secret="",
+        zitadel_api_audience="",
+        cors_origins=cors_origins,
+    )
+
+
+def _build_test_app(cors_origins: str) -> FastAPI:
+    """Create a minimal FastAPI app mirroring the CORRECT connector middleware order.
+
+    Middleware registration order: last-added runs FIRST on the request
+    (Starlette LIFO — see .claude/rules/klai/lang/python.md and
+    SPEC-SEC-CORS-001 REQ-6). Desired execution: CORS (outermost, wraps 401
+    with CORS headers, handles preflight) -> Auth (reject missing header) ->
+    route. So we register in reverse: Auth, CORS.
+    """
+    settings = _make_settings(cors_origins=cors_origins)
+    app = FastAPI()
+
+    @app.get("/api/v1/connectors")
+    async def connectors() -> dict[str, str]:  # pragma: no cover
+        return {"ok": "true"}
+
+    # Register in reverse execution order (Starlette LIFO).
+    app.add_middleware(AuthMiddleware, settings=settings)
+
+    allowed_origins = [o.strip() for o in cors_origins.split(",") if o.strip()]
+    if allowed_origins:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=allowed_origins,
+            allow_methods=["GET", "POST", "PUT", "DELETE"],
+            allow_headers=["Authorization", "Content-Type"],
+        )
+
+    return app
+
+
+class TestCorsWraps401:
+    """AC-15 positive: CORSMiddleware is outermost — 401 carries ACAO for allowed origin."""
+
+    _ALLOWED_ORIGIN = "http://localhost:5174"
+
+    @pytest.fixture(autouse=True)
+    def _setup_client(self) -> None:
+        app = _build_test_app(cors_origins=self._ALLOWED_ORIGIN)
+        self._client = TestClient(app, raise_server_exceptions=True)
+
+    def test_401_carries_access_control_allow_origin(self) -> None:
+        """GET /api/v1/connectors without auth returns 401 with ACAO for allowed origin."""
+        resp = self._client.get(
+            "/api/v1/connectors",
+            headers={"Origin": self._ALLOWED_ORIGIN},
+        )
+        assert resp.status_code == 401
+        assert resp.headers.get("access-control-allow-origin") == self._ALLOWED_ORIGIN, (
+            "401 response must carry Access-Control-Allow-Origin for allowed origin "
+            "(CORSMiddleware must be outermost per SPEC-SEC-CORS-001 REQ-6.4)"
+        )
+
+    def test_401_carries_vary_origin(self) -> None:
+        """The Vary: Origin header is present on the 401 response."""
+        resp = self._client.get(
+            "/api/v1/connectors",
+            headers={"Origin": self._ALLOWED_ORIGIN},
+        )
+        assert resp.status_code == 401
+        vary = resp.headers.get("vary", "")
+        assert "Origin" in vary, "Vary: Origin must be present on cross-origin 401 responses"
+
+
+class TestCorsBlocksEvilOrigin:
+    """AC-15 negative: unlisted origin must NOT receive Access-Control-Allow-Origin."""
+
+    _ALLOWED_ORIGIN = "http://localhost:5174"
+    _EVIL_ORIGIN = "https://evil.example"
+
+    @pytest.fixture(autouse=True)
+    def _setup_client(self) -> None:
+        app = _build_test_app(cors_origins=self._ALLOWED_ORIGIN)
+        self._client = TestClient(app, raise_server_exceptions=True)
+
+    def test_401_does_not_carry_acao_for_evil_origin(self) -> None:
+        """401 from an unlisted origin must NOT echo Access-Control-Allow-Origin."""
+        resp = self._client.get(
+            "/api/v1/connectors",
+            headers={"Origin": self._EVIL_ORIGIN},
+        )
+        assert resp.status_code == 401
+        acao = resp.headers.get("access-control-allow-origin")
+        assert acao != self._EVIL_ORIGIN, (
+            "401 must NOT echo Access-Control-Allow-Origin for an unlisted origin"
+        )
+        assert acao != "*", "401 must NOT echo wildcard ACAO for an unlisted origin"

--- a/klai-portal/backend/.env.example
+++ b/klai-portal/backend/.env.example
@@ -13,7 +13,6 @@ CORS_ORIGINS=http://localhost:5174,https://getklai.getklai.com
 
 # Dev mode — zet op true voor Swagger UI op /docs (nooit in productie!)
 # DEBUG=true
-# CORS_ALLOW_ORIGIN_REGEX=https://[a-z0-9-]+\.getklai\.com   # already default, override if needed
 
 # ── Local development without Zitadel ──────────────────────────────────────
 # Set BOTH debug and auth_dev_mode to bypass Zitadel authentication entirely.

--- a/klai-portal/backend/app/api/partner.py
+++ b/klai-portal/backend/app/api/partner.py
@@ -380,6 +380,47 @@ async def append_knowledge(
 
 
 # ---------------------------------------------------------------------------
+# Widget CORS header builder
+#
+# SPEC-SEC-CORS-001 REQ-2.2 — partner widget endpoints SHALL NEVER set
+# Access-Control-Allow-Credentials: true. Widget traffic authenticates via
+# Bearer JWT in the Authorization header; cookies are not involved. The
+# helper centralises this contract so the GET and OPTIONS handlers can
+# never drift apart.
+# ---------------------------------------------------------------------------
+
+
+def _widget_cors_headers(origin: str, *, preflight: bool) -> dict[str, str]:
+    """Build the CORS response headers for /partner/v1/widget-config.
+
+    The actual server-side origin gate is the per-widget `allowed_origins`
+    check upstream of this call (see ``origin_allowed`` in
+    ``app.services.widget_auth``). This helper only constructs the response
+    headers once that gate has approved the request.
+
+    Parameters
+    ----------
+    origin:
+        The request Origin header value, already validated against the
+        widget's allowed_origins list. The caller MUST NOT pass an
+        unvalidated origin — that is the upstream check's responsibility.
+    preflight:
+        When True, includes the preflight-only headers (Allow-Methods,
+        Allow-Headers, Max-Age). When False, returns the minimal set for
+        an actual response.
+    """
+    headers: dict[str, str] = {
+        "Access-Control-Allow-Origin": origin,
+        "Vary": "Origin",
+    }
+    if preflight:
+        headers["Access-Control-Allow-Methods"] = "GET, OPTIONS"
+        headers["Access-Control-Allow-Headers"] = "Content-Type, Authorization"
+        headers["Access-Control-Max-Age"] = "86400"
+    return headers
+
+
+# ---------------------------------------------------------------------------
 # GET /partner/v1/widget-config  (SPEC-WIDGET-001 Task 2)
 # Public endpoint — NO auth dependency
 # ---------------------------------------------------------------------------
@@ -467,18 +508,11 @@ async def widget_config(
         "session_expires_at": expires_at.isoformat(),
     }
 
-    # REQ-2.2: NEVER set Access-Control-Allow-Credentials for widget endpoints.
-    # Widget traffic uses credentials: 'omit' — no BFF session cookie involved.
-    headers = {
-        "Access-Control-Allow-Origin": origin,
-        "Vary": "Origin",
-    }
-
     return Response(
         content=json.dumps(body),
         status_code=200,
         media_type="application/json",
-        headers=headers,
+        headers=_widget_cors_headers(origin, preflight=False),
     )
 
 
@@ -492,6 +526,17 @@ async def widget_config_preflight(
 
     SPEC-WIDGET-001: Return 204 with CORS headers for valid origins.
     Returns CORS headers without verifying JWT secret (preflight only).
+
+    @MX:WARN: DB read precedes the origin allowlist check. A cross-origin
+    attacker probing this endpoint with rotating origins causes one DB hit
+    per attempt. Browsers cache rejected preflights only briefly so the
+    cost can compound under sustained probing.
+    @MX:REASON: Origin validation must read ``widget.allowed_origins`` from
+    the DB; we cannot decide without that read. A future SPEC may add a
+    ``widget_id -> allowed_origins`` cache (60s TTL in Redis) — see PR #180
+    follow-up. Preserved as pre-existing pattern under SPEC-SEC-CORS-001
+    minimal-changes scope.
+    @MX:SPEC: SPEC-WIDGET-001
     """
     result = await db.execute(select(Widget).where(Widget.widget_id == id))
     widget_row = result.scalar_one_or_none()
@@ -506,14 +551,7 @@ async def widget_config_preflight(
     if not origin or not origin_allowed(origin, allowed_origins):
         return Response(status_code=204)
 
-    # REQ-2.2: NEVER set Access-Control-Allow-Credentials for widget endpoints.
-    # Widget traffic uses credentials: 'omit' — no BFF session cookie involved.
-    headers = {
-        "Access-Control-Allow-Origin": origin,
-        "Access-Control-Allow-Methods": "GET, OPTIONS",
-        "Access-Control-Allow-Headers": "Content-Type, Authorization",
-        "Access-Control-Max-Age": "86400",
-        "Vary": "Origin",
-    }
-
-    return Response(status_code=204, headers=headers)
+    return Response(
+        status_code=204,
+        headers=_widget_cors_headers(origin, preflight=True),
+    )

--- a/klai-portal/backend/app/api/partner.py
+++ b/klai-portal/backend/app/api/partner.py
@@ -467,9 +467,10 @@ async def widget_config(
         "session_expires_at": expires_at.isoformat(),
     }
 
+    # REQ-2.2: NEVER set Access-Control-Allow-Credentials for widget endpoints.
+    # Widget traffic uses credentials: 'omit' — no BFF session cookie involved.
     headers = {
         "Access-Control-Allow-Origin": origin,
-        "Access-Control-Allow-Credentials": "true",
         "Vary": "Origin",
     }
 
@@ -505,11 +506,12 @@ async def widget_config_preflight(
     if not origin or not origin_allowed(origin, allowed_origins):
         return Response(status_code=204)
 
+    # REQ-2.2: NEVER set Access-Control-Allow-Credentials for widget endpoints.
+    # Widget traffic uses credentials: 'omit' — no BFF session cookie involved.
     headers = {
         "Access-Control-Allow-Origin": origin,
         "Access-Control-Allow-Methods": "GET, OPTIONS",
         "Access-Control-Allow-Headers": "Content-Type, Authorization",
-        "Access-Control-Allow-Credentials": "true",
         "Access-Control-Max-Age": "86400",
         "Vary": "Origin",
     }

--- a/klai-portal/backend/app/core/config.py
+++ b/klai-portal/backend/app/core/config.py
@@ -244,15 +244,12 @@ class Settings(BaseSettings):
     # When empty, widget endpoints return 503.
     widget_jwt_secret: str = ""  # PORTAL_API_WIDGET_JWT_SECRET
 
-    # CORS — static origins + wildcard regex for tenant subdomains
-    # SECURITY-CRITICAL: This regex controls which origins can make credentialed
-    # cross-origin requests. A permissive pattern (e.g. .*) would allow any site
-    # to call the API with the user's cookies. Review carefully before modifying.
+    # CORS — explicit allowlist of trusted origins for credentialed requests.
+    # SPEC-SEC-CORS-001 REQ-1.6: cors_allow_origin_regex removed. The runtime
+    # CORS check is the fixed first-party regex in KlaiCORSMiddleware (REQ-1.2)
+    # UNION this comma-separated list. Add explicit origins here for dev/staging
+    # (e.g. http://localhost:5174). Do NOT add wildcard patterns.
     cors_origins: str = "http://localhost:5174"
-    # Allow any origin so public widget endpoints (SPEC-WIDGET-001) pass CORS preflight.
-    # Actual security is enforced server-side: portal routes require JWT auth;
-    # widget routes enforce origin via origin_allowed() in the handler.
-    cors_allow_origin_regex: str = r".*"
 
     @property
     def portal_url(self) -> str:

--- a/klai-portal/backend/app/main.py
+++ b/klai-portal/backend/app/main.py
@@ -3,7 +3,6 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Request
-from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import Response
 
 from app.api import me, signup
@@ -34,6 +33,7 @@ from app.api.vitals import router as vitals_router
 from app.api.webhooks import router as webhooks_router
 from app.core.config import settings
 from app.logging_setup import setup_logging
+from app.middleware.klai_cors import KlaiCORSMiddleware
 from app.middleware.logging_context import LoggingContextMiddleware
 from app.middleware.session import SessionMiddleware
 from app.services.bot_poller import poll_loop
@@ -177,14 +177,18 @@ app = FastAPI(
     openapi_url="/openapi.json" if settings.debug else None,
 )
 
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=settings.cors_origins_list,
-    allow_origin_regex=settings.cors_allow_origin_regex,
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+# Middleware registration order: last-added runs FIRST on the request (Starlette LIFO).
+# Desired execution order (outer -> inner):
+#   KlaiCORSMiddleware (outermost: handles preflights, wraps 401/403 with CORS headers)
+#   -> no_cache_authenticated (@http decorator)
+#   -> LoggingContextMiddleware (binds request_id, org_id, user_id to structlog)
+#   -> SessionMiddleware (resolves BFF session cookie + CSRF check)
+#   -> route handler
+# So we register in reverse: SessionMiddleware first (inner), CORS last (outer).
+# REQ-6.7 (SPEC-SEC-CORS-001): CORS must be the LAST add_middleware call so that
+# CSRF-reject 403s from SessionMiddleware carry CORS headers to cross-origin browsers.
+app.add_middleware(SessionMiddleware)
+app.add_middleware(LoggingContextMiddleware)
 
 
 @app.middleware("http")
@@ -196,11 +200,13 @@ async def no_cache_authenticated(request: Request, call_next: object) -> Respons
     return response
 
 
-app.add_middleware(LoggingContextMiddleware)
-# SessionMiddleware runs BEFORE LoggingContextMiddleware (Starlette executes in
-# reverse registration order), so org_id / user_id from the BFF session land in
-# every log entry.
-app.add_middleware(SessionMiddleware)
+app.add_middleware(
+    KlaiCORSMiddleware,
+    cors_origins=settings.cors_origins_list,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 from app.api.auth_bff import router as auth_bff_router  # noqa: E402
 

--- a/klai-portal/backend/app/middleware/klai_cors.py
+++ b/klai-portal/backend/app/middleware/klai_cors.py
@@ -1,34 +1,51 @@
 """KlaiCORSMiddleware — SPEC-SEC-CORS-001 REQ-1.
 
-Replaces the stock Starlette CORSMiddleware for portal-api.
+Subclasses Starlette's CORSMiddleware so we lean on its battle-tested
+preflight + response-header logic, and add only the two pieces the SPEC
+demands on top:
 
-Changes from stock CORSMiddleware:
-- Removes the user-tunable cors_allow_origin_regex setting (REQ-1.6).
-- Uses a hardcoded first-party regex (REQ-1.2) combined with cors_origins_list
-  as the allowlist for credentialed requests.
-- Sets Access-Control-Allow-Credentials: true ONLY for allowlisted origins (REQ-1.5).
-- Emits a structlog event at info level when a preflight is rejected (AC-13).
-- Startup fails closed if the regex fails to compile (AC-14).
+- AC-13: emit a structlog ``cors_origin_rejected`` event whenever a
+  cross-origin request from a non-allowlisted origin is observed (both
+  preflight AND simple/actual cross-origin requests).
+- AC-14: fail-closed startup if the hardcoded first-party regex string
+  fails to compile. Matches the ``_require_vexa_webhook_secret`` pattern
+  in ``app/core/config.py``.
 
-The regex is hardcoded at module load.  If it ever fails to compile (programmer
-error), _compile_first_party_regex() raises SystemExit(1) with a critical log
-line — consistent with the _require_vexa_webhook_secret pattern in config.py.
+Origin policy (REQ-1.2):
+    allowlist = settings.cors_origins_list (explicit list)  UNION
+                _FIRST_PARTY_ORIGIN_PATTERN  (compiled regex)
+
+The regex is hardcoded in this module. It is NOT loaded from settings —
+``cors_allow_origin_regex`` was removed from config.py per REQ-1.6 to
+prevent operators from re-introducing the audit-flagged ``r".*"`` knob.
+
+@MX:NOTE: This is a thin subclass — Starlette CORSMiddleware does the
+heavy lifting (preflight responses, header construction, simple-request
+header injection, fullmatch on the regex). We only override __call__ to
+hook in observability before delegating, never duplicate Starlette's
+header logic.
+
+@MX:NOTE: The widget-side equivalent helper is
+``app.services.widget_auth.origin_allowed`` (wildcard pattern matching,
+e.g. ``https://*.customer.com``). It is intentionally separate — different
+algorithm for a different problem (per-widget partner allowlists vs
+first-party portal allowlist). Do not consolidate without a SPEC: the
+shapes diverge enough that a single helper would parameter-sprawl.
 """
 
 from __future__ import annotations
 
-import functools
 import logging
 import re
 
 import structlog
 from starlette.datastructures import Headers, MutableHeaders
-from starlette.responses import PlainTextResponse, Response
+from starlette.middleware.cors import CORSMiddleware
+from starlette.responses import Response
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
-# The fixed first-party origin pattern.  This string is exposed as a module
-# constant so that AC-14's test can monkeypatch it before calling
-# _compile_first_party_regex().
+# The fixed first-party origin pattern. Exposed as a module constant so the
+# AC-14 test can monkeypatch it before re-invoking _compile_first_party_regex().
 #
 # Matches:
 #   https://getklai.com
@@ -37,31 +54,25 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 #   ... any single-label LDH subdomain of getklai.com
 #
 # Does NOT match:
-#   http://getklai.com       (no plaintext)
-#   https://evil.my.getklai.com   (multi-label blocked)
-#   https://evil.getklai.com.attacker.tld  (not the getklai.com TLD)
+#   http://getklai.com                       (no plaintext)
+#   https://evil.my.getklai.com              (multi-label blocked)
+#   https://evil.getklai.com.attacker.tld    (not the getklai.com TLD)
 _FIRST_PARTY_ORIGIN_PATTERN = r"^https://([a-z0-9][a-z0-9-]*\.)?getklai\.com$"
 
 logger = structlog.get_logger()
 _startup_logger = logging.getLogger(__name__)
 
-# All HTTP methods Starlette CORSMiddleware normally allows with "*"
-_ALL_METHODS = (
-    "DELETE",
-    "GET",
-    "HEAD",
-    "OPTIONS",
-    "PATCH",
-    "POST",
-    "PUT",
-)
 
-
+# @MX:ANCHOR: Startup invariant — portal-api refuses to boot if the
+# first-party regex fails to compile (AC-14, NFR Fail mode). Mirrors
+# _require_vexa_webhook_secret in config.py: programmer error must fail
+# fast at startup, not silently downgrade CORS behaviour.
 def _compile_first_party_regex() -> re.Pattern[str]:
-    """Compile _FIRST_PARTY_ORIGIN_PATTERN; exit(1) on failure (AC-14).
+    """Compile _FIRST_PARTY_ORIGIN_PATTERN; SystemExit(1) on failure (AC-14).
 
-    Called once at module load.  May be called again by tests after
-    monkeypatching _FIRST_PARTY_ORIGIN_PATTERN to restore state.
+    Called once at module load. May be re-called by tests after
+    monkeypatching _FIRST_PARTY_ORIGIN_PATTERN to verify the fail-closed
+    behaviour.
     """
     try:
         return re.compile(_FIRST_PARTY_ORIGIN_PATTERN)
@@ -73,27 +84,23 @@ def _compile_first_party_regex() -> re.Pattern[str]:
         raise SystemExit(1) from exc
 
 
-# Compiled once at module load; fail-closed if the pattern is bad (AC-14).
-_FIRST_PARTY_ORIGIN_RE: re.Pattern[str] = _compile_first_party_regex()
+# Module-load-time validation. The compiled pattern is not stored — Starlette's
+# CORSMiddleware compiles its own copy from the string at __init__ time. The
+# call is here purely to fail-closed if the pattern is malformed (AC-14).
+_compile_first_party_regex()
 
 
-def _is_first_party_origin(origin: str, cors_origins_list: list[str]) -> bool:
-    """Return True when origin matches the allowlist or the first-party regex.
+class KlaiCORSMiddleware(CORSMiddleware):
+    """First-party CORS middleware with rejection observability.
 
-    REQ-1.2: allowlist = cors_origins_list UNION first-party regex.
-    """
-    if origin in cors_origins_list:
-        return True
-    return bool(_FIRST_PARTY_ORIGIN_RE.match(origin))
+    Inherits all preflight + simple-response header logic from Starlette's
+    CORSMiddleware. Adds:
 
-
-class KlaiCORSMiddleware:
-    """CORS middleware with a hardcoded first-party regex and rejection logging.
-
-    Implements the same interface as Starlette CORSMiddleware but:
-    - Origin matching uses _is_first_party_origin() (REQ-1.2).
-    - ACAC is set only when the origin is allowed (REQ-1.5).
-    - Rejected preflights emit a structlog event (AC-13).
+    - REQ-1.2 origin policy: ``allow_origin_regex`` is hardcoded to the
+      first-party pattern (cannot be overridden from settings, REQ-1.6).
+    - AC-13 observability: logs ``cors_origin_rejected`` on any cross-origin
+      request whose Origin is not in the allowlist (both preflights and
+      simple/actual requests).
 
     Parameters
     ----------
@@ -101,21 +108,25 @@ class KlaiCORSMiddleware:
         The ASGI application to wrap.
     cors_origins:
         Pre-parsed list of explicit allowed origins (typically
-        ``settings.cors_origins_list``).  Used for explicit dev/staging origins
-        such as ``http://localhost:5174``.  The first-party ``*.getklai.com``
-        origins are handled by the hardcoded regex independently of this list.
+        ``settings.cors_origins_list``). The first-party
+        ``*.getklai.com`` origins are handled by the hardcoded regex
+        independently of this list.
     allow_credentials:
-        When True, sets ACAC only for allowlisted origins (REQ-1.5).
+        When True, sets ``Access-Control-Allow-Credentials: true`` only
+        for allowlisted origins (REQ-1.5; Starlette enforces this).
     allow_methods:
-        List of allowed HTTP methods (default: all standard methods).
+        List of allowed HTTP methods (default: ``["*"]`` — Starlette
+        expands ``*`` to ``ALL_METHODS``).
     allow_headers:
-        List of allowed request headers (default: all headers with ``*``).
+        List of allowed request headers (default: ``["*"]`` — Starlette
+        mirrors back the requested headers).
 
     Notes
     -----
-    No ``**kwargs`` catch-all is accepted: passing an unknown keyword raises
+    No ``**kwargs`` catch-all: passing an unknown keyword raises
     ``TypeError`` at construction time, which prevents the silent-discard
-    footgun that would let e.g. ``expose_headers=...`` be lost without warning.
+    footgun that would let e.g. ``expose_headers=...`` be lost without
+    warning.
     """
 
     def __init__(
@@ -126,113 +137,77 @@ class KlaiCORSMiddleware:
         allow_methods: list[str] | None = None,
         allow_headers: list[str] | None = None,
     ) -> None:
-        self.app = app
-        self._cors_origins_list: list[str] = list(cors_origins) if cors_origins else []
-        self._allow_credentials = allow_credentials
-        self._allow_methods: tuple[str, ...] = (
-            tuple(allow_methods) if allow_methods and allow_methods != ["*"] else _ALL_METHODS
+        super().__init__(
+            app=app,
+            allow_origins=tuple(cors_origins) if cors_origins else (),
+            allow_origin_regex=_FIRST_PARTY_ORIGIN_PATTERN,
+            allow_credentials=allow_credentials,
+            allow_methods=tuple(allow_methods) if allow_methods else ("*",),
+            allow_headers=tuple(allow_headers) if allow_headers else ("*",),
         )
-        # Starlette safe-listed headers always allowed; "*" means mirror back
-        self._allow_all_headers = (allow_headers is None) or (allow_headers == ["*"])
-        self._allow_headers: list[str] = [] if self._allow_all_headers else (allow_headers or [])
 
-    def _is_allowed(self, origin: str) -> bool:
-        return _is_first_party_origin(origin, self._cors_origins_list)
-
+    # @MX:NOTE: Observability hook — log every rejected cross-origin request
+    # exactly once. The actual header behaviour (preflight 400, simple 200
+    # without ACAO) is delegated unchanged to the parent class.
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":
-            await self.app(scope, receive, send)
+            await super().__call__(scope, receive, send)
             return
 
         headers = Headers(scope=scope)
         origin = headers.get("origin")
 
-        if origin is None:
-            await self.app(scope, receive, send)
-            return
-
-        method = scope["method"]
-        is_preflight = (
-            method == "OPTIONS"
-            and "access-control-request-method" in headers
-        )
-
-        if is_preflight:
-            # Log rejected preflights (AC-13)
-            if not self._is_allowed(origin):
-                path = scope.get("path", "")
-                request_id = headers.get("x-request-id") or "unknown"
-                sanitised_origin = origin[:256]
-                logger.info(
-                    "cors_origin_rejected",
-                    origin=sanitised_origin,
-                    path=path,
-                    request_id=request_id,
-                )
-            response = self._preflight_response(headers)
-            await response(scope, receive, send)
-            return
-
-        # Simple / actual request: wrap send to add CORS headers on the response
-        send = functools.partial(self._send, send=send, origin=origin)
-        await self.app(scope, receive, send)
-
-    def _preflight_response(self, request_headers: Headers) -> Response:
-        """Build the OPTIONS preflight response."""
-        origin = request_headers["origin"]
-        requested_method = request_headers.get("access-control-request-method", "")
-        requested_headers_str = request_headers.get("access-control-request-headers")
-
-        resp_headers: dict[str, str] = {"Vary": "Origin"}
-        failures = []
-
-        if self._is_allowed(origin):
-            resp_headers["Access-Control-Allow-Origin"] = origin
-            if self._allow_credentials:
-                resp_headers["Access-Control-Allow-Credentials"] = "true"
-        else:
-            failures.append("origin")
-
-        if requested_method and requested_method not in self._allow_methods:
-            failures.append("method")
-
-        if self._allow_all_headers and requested_headers_str is not None:
-            resp_headers["Access-Control-Allow-Headers"] = requested_headers_str
-        elif requested_headers_str is not None:
-            for h in requested_headers_str.split(","):
-                if h.strip().lower() not in self._allow_headers:
-                    failures.append("headers")
-                    break
-
-        resp_headers["Access-Control-Allow-Methods"] = ", ".join(self._allow_methods)
-        resp_headers["Access-Control-Max-Age"] = "600"
-
-        if failures:
-            return PlainTextResponse(
-                "Disallowed CORS " + ", ".join(failures),
-                status_code=400,
-                headers=resp_headers,
+        if origin and not self.is_allowed_origin(origin):
+            method = scope.get("method", "")
+            is_preflight = (
+                method == "OPTIONS" and "access-control-request-method" in headers
+            )
+            logger.info(
+                "cors_origin_rejected",
+                origin=origin[:256],
+                path=scope.get("path", ""),
+                request_id=headers.get("x-request-id") or "unknown",
+                kind="preflight" if is_preflight else "simple",
             )
 
-        return PlainTextResponse("OK", status_code=200, headers=resp_headers)
+        await super().__call__(scope, receive, send)
 
-    async def _send(
+    # @MX:NOTE: REQ-1.5 enforcement — Starlette's CORSMiddleware always sets
+    # Access-Control-Allow-Credentials: true when allow_credentials=True,
+    # even on responses for non-allowlisted origins. The audit explicitly
+    # forbids this (REQ-1.5: "ACAC SHALL only be set on responses for
+    # allowlisted first-party origins"). We strip ACAC from rejected
+    # preflights here so browsers see a clean 400 without signalling that
+    # credentials are accepted.
+    def preflight_response(self, request_headers: Headers) -> Response:
+        response = super().preflight_response(request_headers)
+        origin = request_headers.get("origin", "")
+        if origin and not self.is_allowed_origin(origin):
+            response.headers.pop("access-control-allow-credentials", None)
+        return response
+
+    # @MX:NOTE: REQ-1.5 enforcement for simple/actual cross-origin requests.
+    # Starlette's parent send() unconditionally writes simple_headers (which
+    # includes ACAC=true when allow_credentials=True) into every response,
+    # only conditionally adding ACAO. For rejected origins we want neither
+    # ACAO nor ACAC — only Vary: Origin so caches key correctly. We bypass
+    # the parent's header pipeline on rejection and only emit Vary.
+    async def send(
         self,
         message: Message,
         send: Send,
-        origin: str,
+        request_headers: Headers,
     ) -> None:
-        """Intercept response.start to add CORS headers for simple requests."""
         if message["type"] != "http.response.start":
             await send(message)
             return
 
-        headers = MutableHeaders(scope=message)
-        headers.append("Vary", "Origin")
+        origin = request_headers.get("Origin") or request_headers.get("origin") or ""
+        if not origin or not self.is_allowed_origin(origin):
+            message.setdefault("headers", [])
+            headers = MutableHeaders(scope=message)
+            headers.add_vary_header("Origin")
+            await send(message)
+            return
 
-        if self._is_allowed(origin):
-            headers.append("Access-Control-Allow-Origin", origin)
-            if self._allow_credentials:
-                headers.append("Access-Control-Allow-Credentials", "true")
-
-        await send(message)
+        await super().send(message, send=send, request_headers=request_headers)

--- a/klai-portal/backend/app/middleware/klai_cors.py
+++ b/klai-portal/backend/app/middleware/klai_cors.py
@@ -159,9 +159,7 @@ class KlaiCORSMiddleware(CORSMiddleware):
 
         if origin and not self.is_allowed_origin(origin):
             method = scope.get("method", "")
-            is_preflight = (
-                method == "OPTIONS" and "access-control-request-method" in headers
-            )
+            is_preflight = method == "OPTIONS" and "access-control-request-method" in headers
             logger.info(
                 "cors_origin_rejected",
                 origin=origin[:256],

--- a/klai-portal/backend/app/middleware/klai_cors.py
+++ b/klai-portal/backend/app/middleware/klai_cors.py
@@ -160,11 +160,13 @@ class KlaiCORSMiddleware(CORSMiddleware):
         if origin and not self.is_allowed_origin(origin):
             method = scope.get("method", "")
             is_preflight = method == "OPTIONS" and "access-control-request-method" in headers
+            # Truncate both attacker-controlled fields to bounded lengths to
+            # prevent log-bloat. UUIDs are 36 chars; 64 is generous headroom.
             logger.info(
                 "cors_origin_rejected",
                 origin=origin[:256],
                 path=scope.get("path", ""),
-                request_id=headers.get("x-request-id") or "unknown",
+                request_id=(headers.get("x-request-id") or "unknown")[:64],
                 kind="preflight" if is_preflight else "simple",
             )
 
@@ -201,7 +203,8 @@ class KlaiCORSMiddleware(CORSMiddleware):
             await send(message)
             return
 
-        origin = request_headers.get("Origin") or request_headers.get("origin") or ""
+        # Starlette Headers is case-insensitive — single lookup suffices.
+        origin = request_headers.get("origin", "")
         if not origin or not self.is_allowed_origin(origin):
             message.setdefault("headers", [])
             headers = MutableHeaders(scope=message)

--- a/klai-portal/backend/app/middleware/klai_cors.py
+++ b/klai-portal/backend/app/middleware/klai_cors.py
@@ -1,0 +1,238 @@
+"""KlaiCORSMiddleware — SPEC-SEC-CORS-001 REQ-1.
+
+Replaces the stock Starlette CORSMiddleware for portal-api.
+
+Changes from stock CORSMiddleware:
+- Removes the user-tunable cors_allow_origin_regex setting (REQ-1.6).
+- Uses a hardcoded first-party regex (REQ-1.2) combined with cors_origins_list
+  as the allowlist for credentialed requests.
+- Sets Access-Control-Allow-Credentials: true ONLY for allowlisted origins (REQ-1.5).
+- Emits a structlog event at info level when a preflight is rejected (AC-13).
+- Startup fails closed if the regex fails to compile (AC-14).
+
+The regex is hardcoded at module load.  If it ever fails to compile (programmer
+error), _compile_first_party_regex() raises SystemExit(1) with a critical log
+line — consistent with the _require_vexa_webhook_secret pattern in config.py.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+import re
+
+import structlog
+from starlette.datastructures import Headers, MutableHeaders
+from starlette.responses import PlainTextResponse, Response
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+# The fixed first-party origin pattern.  This string is exposed as a module
+# constant so that AC-14's test can monkeypatch it before calling
+# _compile_first_party_regex().
+#
+# Matches:
+#   https://getklai.com
+#   https://my.getklai.com
+#   https://acme.getklai.com
+#   ... any single-label LDH subdomain of getklai.com
+#
+# Does NOT match:
+#   http://getklai.com       (no plaintext)
+#   https://evil.my.getklai.com   (multi-label blocked)
+#   https://evil.getklai.com.attacker.tld  (not the getklai.com TLD)
+_FIRST_PARTY_ORIGIN_PATTERN = r"^https://([a-z0-9][a-z0-9-]*\.)?getklai\.com$"
+
+logger = structlog.get_logger()
+_startup_logger = logging.getLogger(__name__)
+
+# All HTTP methods Starlette CORSMiddleware normally allows with "*"
+_ALL_METHODS = (
+    "DELETE",
+    "GET",
+    "HEAD",
+    "OPTIONS",
+    "PATCH",
+    "POST",
+    "PUT",
+)
+
+
+def _compile_first_party_regex() -> re.Pattern[str]:
+    """Compile _FIRST_PARTY_ORIGIN_PATTERN; exit(1) on failure (AC-14).
+
+    Called once at module load.  May be called again by tests after
+    monkeypatching _FIRST_PARTY_ORIGIN_PATTERN to restore state.
+    """
+    try:
+        return re.compile(_FIRST_PARTY_ORIGIN_PATTERN)
+    except re.error as exc:
+        _startup_logger.critical(
+            "CORS origin regex failed to compile: %s — portal-api cannot start safely.",
+            exc,
+        )
+        raise SystemExit(1) from exc
+
+
+# Compiled once at module load; fail-closed if the pattern is bad (AC-14).
+_FIRST_PARTY_ORIGIN_RE: re.Pattern[str] = _compile_first_party_regex()
+
+
+def _is_first_party_origin(origin: str, cors_origins_list: list[str]) -> bool:
+    """Return True when origin matches the allowlist or the first-party regex.
+
+    REQ-1.2: allowlist = cors_origins_list UNION first-party regex.
+    """
+    if origin in cors_origins_list:
+        return True
+    return bool(_FIRST_PARTY_ORIGIN_RE.match(origin))
+
+
+class KlaiCORSMiddleware:
+    """CORS middleware with a hardcoded first-party regex and rejection logging.
+
+    Implements the same interface as Starlette CORSMiddleware but:
+    - Origin matching uses _is_first_party_origin() (REQ-1.2).
+    - ACAC is set only when the origin is allowed (REQ-1.5).
+    - Rejected preflights emit a structlog event (AC-13).
+
+    Parameters
+    ----------
+    app:
+        The ASGI application to wrap.
+    cors_origins:
+        Pre-parsed list of explicit allowed origins (typically
+        ``settings.cors_origins_list``).  Used for explicit dev/staging origins
+        such as ``http://localhost:5174``.  The first-party ``*.getklai.com``
+        origins are handled by the hardcoded regex independently of this list.
+    allow_credentials:
+        When True, sets ACAC only for allowlisted origins (REQ-1.5).
+    allow_methods:
+        List of allowed HTTP methods (default: all standard methods).
+    allow_headers:
+        List of allowed request headers (default: all headers with ``*``).
+
+    Notes
+    -----
+    No ``**kwargs`` catch-all is accepted: passing an unknown keyword raises
+    ``TypeError`` at construction time, which prevents the silent-discard
+    footgun that would let e.g. ``expose_headers=...`` be lost without warning.
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        cors_origins: list[str] | None = None,
+        allow_credentials: bool = True,
+        allow_methods: list[str] | None = None,
+        allow_headers: list[str] | None = None,
+    ) -> None:
+        self.app = app
+        self._cors_origins_list: list[str] = list(cors_origins) if cors_origins else []
+        self._allow_credentials = allow_credentials
+        self._allow_methods: tuple[str, ...] = (
+            tuple(allow_methods) if allow_methods and allow_methods != ["*"] else _ALL_METHODS
+        )
+        # Starlette safe-listed headers always allowed; "*" means mirror back
+        self._allow_all_headers = (allow_headers is None) or (allow_headers == ["*"])
+        self._allow_headers: list[str] = [] if self._allow_all_headers else (allow_headers or [])
+
+    def _is_allowed(self, origin: str) -> bool:
+        return _is_first_party_origin(origin, self._cors_origins_list)
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = Headers(scope=scope)
+        origin = headers.get("origin")
+
+        if origin is None:
+            await self.app(scope, receive, send)
+            return
+
+        method = scope["method"]
+        is_preflight = (
+            method == "OPTIONS"
+            and "access-control-request-method" in headers
+        )
+
+        if is_preflight:
+            # Log rejected preflights (AC-13)
+            if not self._is_allowed(origin):
+                path = scope.get("path", "")
+                request_id = headers.get("x-request-id") or "unknown"
+                sanitised_origin = origin[:256]
+                logger.info(
+                    "cors_origin_rejected",
+                    origin=sanitised_origin,
+                    path=path,
+                    request_id=request_id,
+                )
+            response = self._preflight_response(headers)
+            await response(scope, receive, send)
+            return
+
+        # Simple / actual request: wrap send to add CORS headers on the response
+        send = functools.partial(self._send, send=send, origin=origin)
+        await self.app(scope, receive, send)
+
+    def _preflight_response(self, request_headers: Headers) -> Response:
+        """Build the OPTIONS preflight response."""
+        origin = request_headers["origin"]
+        requested_method = request_headers.get("access-control-request-method", "")
+        requested_headers_str = request_headers.get("access-control-request-headers")
+
+        resp_headers: dict[str, str] = {"Vary": "Origin"}
+        failures = []
+
+        if self._is_allowed(origin):
+            resp_headers["Access-Control-Allow-Origin"] = origin
+            if self._allow_credentials:
+                resp_headers["Access-Control-Allow-Credentials"] = "true"
+        else:
+            failures.append("origin")
+
+        if requested_method and requested_method not in self._allow_methods:
+            failures.append("method")
+
+        if self._allow_all_headers and requested_headers_str is not None:
+            resp_headers["Access-Control-Allow-Headers"] = requested_headers_str
+        elif requested_headers_str is not None:
+            for h in requested_headers_str.split(","):
+                if h.strip().lower() not in self._allow_headers:
+                    failures.append("headers")
+                    break
+
+        resp_headers["Access-Control-Allow-Methods"] = ", ".join(self._allow_methods)
+        resp_headers["Access-Control-Max-Age"] = "600"
+
+        if failures:
+            return PlainTextResponse(
+                "Disallowed CORS " + ", ".join(failures),
+                status_code=400,
+                headers=resp_headers,
+            )
+
+        return PlainTextResponse("OK", status_code=200, headers=resp_headers)
+
+    async def _send(
+        self,
+        message: Message,
+        send: Send,
+        origin: str,
+    ) -> None:
+        """Intercept response.start to add CORS headers for simple requests."""
+        if message["type"] != "http.response.start":
+            await send(message)
+            return
+
+        headers = MutableHeaders(scope=message)
+        headers.append("Vary", "Origin")
+
+        if self._is_allowed(origin):
+            headers.append("Access-Control-Allow-Origin", origin)
+            if self._allow_credentials:
+                headers.append("Access-Control-Allow-Credentials", "true")
+
+        await send(message)

--- a/klai-portal/backend/app/middleware/klai_cors.py
+++ b/klai-portal/backend/app/middleware/klai_cors.py
@@ -181,7 +181,8 @@ class KlaiCORSMiddleware(CORSMiddleware):
         response = super().preflight_response(request_headers)
         origin = request_headers.get("origin", "")
         if origin and not self.is_allowed_origin(origin):
-            response.headers.pop("access-control-allow-credentials", None)
+            if "access-control-allow-credentials" in response.headers:
+                del response.headers["access-control-allow-credentials"]
         return response
 
     # @MX:NOTE: REQ-1.5 enforcement for simple/actual cross-origin requests.

--- a/klai-portal/backend/app/middleware/session.py
+++ b/klai-portal/backend/app/middleware/session.py
@@ -30,28 +30,56 @@ logger = structlog.get_logger()
 # Methods considered "safe" — never mutate server state and are exempt from CSRF.
 _CSRF_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
 
-# Route prefixes that intentionally operate without a session — e.g. the OIDC
-# flow itself, which is what creates the session. These are always CSRF-exempt.
+# Route prefixes that intentionally operate without a session.
+# Each entry carries a rationale comment per REQ-4.1 (SPEC-SEC-CORS-001).
+# The CORS allowlist (REQ-1) is the browser-side gate that makes these
+# exemptions safe: cross-origin credentialed probing is blocked before any
+# request reaches these endpoints (AC-2, AC-7).
 _CSRF_EXEMPT_PREFIXES: tuple[str, ...] = (
+    # pre-session: OIDC flow INITIATES the session — no BFF cookie exists yet.
+    # REQ-1 / AC-2 ensures cross-origin browsers cannot probe this pre-session flow.
     "/api/auth/oidc/start",
+    # pre-session: OIDC callback COMPLETES the session — no BFF cookie yet.
+    # REQ-1 / AC-2 ensures cross-origin browsers cannot probe this pre-session flow.
     "/api/auth/oidc/callback",
+    # pre-session: Zitadel IDP intent start (Google/Microsoft SSO redirect).
+    # No BFF session exists; Zitadel redirects back after external IDP auth. REQ-1 / AC-2.
     "/api/auth/idp-intent",
+    # pre-session: Zitadel IDP intent callback — finalises external IDP login.
+    # No BFF session yet; same pre-session condition as /api/auth/idp-intent. REQ-1 / AC-2.
     "/api/auth/idp-callback",
     # Zitadel Login V2 finishers — called from my.getklai.com/login without a
     # portal BFF session. A stale cookie from a previous BFF login would
     # otherwise cause the CSRF check to reject the password/TOTP finish.
+    # REQ-1 REQ-4.3 — CORS allowlist (REQ-1) is the browser-side defense; AC-2.
     "/api/auth/login",
+    # Zitadel Login V2 TOTP finisher — same pre-session rationale as /api/auth/login.
+    # REQ-1 REQ-4.3 — CORS allowlist is the browser-side defense; AC-2.
     "/api/auth/totp-login",
+    # pre-session: SSO cookie exchange finaliser; uses klai_sso cookie, not BFF.
+    # No BFF csrf_token present; pre-session by construction. REQ-1 / AC-2.
     "/api/auth/sso-complete",
+    # signup: new users have no BFF session or csrf_token yet. pre-session.
+    # REQ-1 REQ-4.3 — CORS allowlist (REQ-1) blocks cross-origin probing; AC-2.
     "/api/signup",
+    # health probe: liveness/readiness probe, GET-only, not state-changing.
+    # no session required; health check has no side effects. REQ-1 / AC-7.
     "/api/health",
+    # no session: reserved prefix for intentionally public endpoints (none in use today).
+    # REQ-1 / AC-7 — CORS allowlist blocks cross-origin credential probing.
     "/api/public/",
-    # Web-vitals beacon: navigator.sendBeacon cannot set X-CSRF-Token, so the
-    # endpoint is intentionally unauthenticated and CSRF-exempt.
+    # sendBeacon: navigator.sendBeacon cannot set X-CSRF-Token custom headers,
+    # so the endpoint is intentionally unauthenticated and CSRF-exempt. REQ-4 / AC-7.
     "/api/perf",
+    # internal: service-to-service surface authenticated by X-Internal-Secret,
+    # not the BFF cookie. No session; CSRF is a cookie-based threat. REQ-3.1 / AC-7.
     "/internal/",
+    # partner: partner API endpoints authenticated by Bearer pk_live_... keys,
+    # not the BFF cookie. No session; CSRF is a cookie-based threat. REQ-3.1 / AC-9 / AC-11.
     "/partner/",
-    "/widget/",
+    # /widget/ prefix has NO mounted handlers in portal-api (audited 2026-04-25:
+    # grep for prefix="/widget" returns zero results). Removed per REQ-4 audit.
+    # Widget traffic now lives under /partner/v1/widget-config (see partner CORS REQ-2).
 )
 
 

--- a/klai-portal/backend/app/middleware/session.py
+++ b/klai-portal/backend/app/middleware/session.py
@@ -31,51 +31,71 @@ logger = structlog.get_logger()
 _CSRF_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
 
 # Route prefixes that intentionally operate without a session.
-# Each entry carries a rationale comment per REQ-4.1 (SPEC-SEC-CORS-001).
+#
+# Format contract (SPEC-SEC-CORS-001 REQ-4.1, enforced by
+# tests/test_csrf_exempt_rationale.py):
+#   1. Each entry is preceded (within 5 lines above) by a comment block.
+#   2. The block contains at least one rationale keyword from the set:
+#      pre-session, no session, sendBeacon, internal, partner, widget,
+#      Zitadel, signup, health probe.
+#   3. The block ends with a standalone trailing line of the form
+#      `# REQ-X.Y / AC-Z` (or `AC-A, AC-B` when multiple ACs apply). The
+#      lint test `test_csrf_exempt_rationale_format_is_canonical` enforces
+#      this exact shape so future contributors cannot drift the format.
+#
 # The CORS allowlist (REQ-1) is the browser-side gate that makes these
 # exemptions safe: cross-origin credentialed probing is blocked before any
 # request reaches these endpoints (AC-2, AC-7).
 _CSRF_EXEMPT_PREFIXES: tuple[str, ...] = (
     # pre-session: OIDC flow INITIATES the session — no BFF cookie exists yet.
-    # REQ-1 / AC-2 ensures cross-origin browsers cannot probe this pre-session flow.
+    # REQ-1.2 / AC-2
     "/api/auth/oidc/start",
     # pre-session: OIDC callback COMPLETES the session — no BFF cookie yet.
-    # REQ-1 / AC-2 ensures cross-origin browsers cannot probe this pre-session flow.
+    # REQ-1.2 / AC-2
     "/api/auth/oidc/callback",
     # pre-session: Zitadel IDP intent start (Google/Microsoft SSO redirect).
-    # No BFF session exists; Zitadel redirects back after external IDP auth. REQ-1 / AC-2.
+    # No BFF session exists; Zitadel redirects back after external IDP auth.
+    # REQ-1.2 / AC-2
     "/api/auth/idp-intent",
     # pre-session: Zitadel IDP intent callback — finalises external IDP login.
-    # No BFF session yet; same pre-session condition as /api/auth/idp-intent. REQ-1 / AC-2.
+    # Same pre-session condition as /api/auth/idp-intent.
+    # REQ-1.2 / AC-2
     "/api/auth/idp-callback",
-    # Zitadel Login V2 finishers — called from my.getklai.com/login without a
-    # portal BFF session. A stale cookie from a previous BFF login would
-    # otherwise cause the CSRF check to reject the password/TOTP finish.
-    # REQ-1 REQ-4.3 — CORS allowlist (REQ-1) is the browser-side defense; AC-2.
+    # Zitadel Login V2 password finisher — called from my.getklai.com/login
+    # without a portal BFF session. A stale cookie from a previous BFF login
+    # would otherwise cause the CSRF check to reject the password finish.
+    # REQ-4.3 / AC-2
     "/api/auth/login",
-    # Zitadel Login V2 TOTP finisher — same pre-session rationale as /api/auth/login.
-    # REQ-1 REQ-4.3 — CORS allowlist is the browser-side defense; AC-2.
+    # Zitadel Login V2 TOTP finisher — same pre-session rationale as
+    # /api/auth/login.
+    # REQ-4.3 / AC-2
     "/api/auth/totp-login",
-    # pre-session: SSO cookie exchange finaliser; uses klai_sso cookie, not BFF.
-    # No BFF csrf_token present; pre-session by construction. REQ-1 / AC-2.
+    # pre-session: SSO cookie exchange finaliser. Uses klai_sso cookie, not
+    # the BFF csrf_token; pre-session by construction.
+    # REQ-1.2 / AC-2
     "/api/auth/sso-complete",
     # signup: new users have no BFF session or csrf_token yet. pre-session.
-    # REQ-1 REQ-4.3 — CORS allowlist (REQ-1) blocks cross-origin probing; AC-2.
+    # REQ-4.3 / AC-2
     "/api/signup",
-    # health probe: liveness/readiness probe, GET-only, not state-changing.
-    # no session required; health check has no side effects. REQ-1 / AC-7.
+    # health probe: liveness/readiness probe, GET-only, no side effects.
+    # no session required.
+    # REQ-1.2 / AC-7
     "/api/health",
-    # no session: reserved prefix for intentionally public endpoints (none in use today).
-    # REQ-1 / AC-7 — CORS allowlist blocks cross-origin credential probing.
+    # no session: reserved prefix for intentionally public endpoints (none in
+    # use today). CORS allowlist blocks cross-origin credential probing.
+    # REQ-1.2 / AC-7
     "/api/public/",
     # sendBeacon: navigator.sendBeacon cannot set X-CSRF-Token custom headers,
-    # so the endpoint is intentionally unauthenticated and CSRF-exempt. REQ-4 / AC-7.
+    # so the endpoint is intentionally unauthenticated and CSRF-exempt.
+    # REQ-4.1 / AC-7
     "/api/perf",
     # internal: service-to-service surface authenticated by X-Internal-Secret,
-    # not the BFF cookie. No session; CSRF is a cookie-based threat. REQ-3.1 / AC-7.
+    # not the BFF cookie. CSRF is a cookie-based threat.
+    # REQ-3.1 / AC-7
     "/internal/",
     # partner: partner API endpoints authenticated by Bearer pk_live_... keys,
-    # not the BFF cookie. No session; CSRF is a cookie-based threat. REQ-3.1 / AC-9 / AC-11.
+    # not the BFF cookie. CSRF is a cookie-based threat.
+    # REQ-3.1 / AC-9, AC-11
     "/partner/",
     # /widget/ prefix has NO mounted handlers in portal-api (audited 2026-04-25:
     # grep for prefix="/widget" returns zero results). Removed per REQ-4 audit.

--- a/klai-portal/backend/tests/test_cors_allowlist.py
+++ b/klai-portal/backend/tests/test_cors_allowlist.py
@@ -3,9 +3,14 @@
 Tests AC-1 through AC-8, AC-13, and AC-14.
 
 Strategy: build a minimal FastAPI app that registers KlaiCORSMiddleware (the
-production middleware) and a single GET /api/me route, then run CORS scenarios
+production middleware) and a small set of routes, then run CORS scenarios
 against it via Starlette TestClient.  This avoids importing the full portal-api
 app (which requires live DB connections and secret validation).
+
+Fixtures are module-scoped: a single FastAPI + TestClient pair handles every
+in-spec scenario via header probing, which is read-only and side-effect-free.
+The two outliers (AC-13 reconfigures structlog; AC-14 monkeypatches the regex
+constant) use pytest's `monkeypatch` for idempotent cleanup.
 """
 
 from __future__ import annotations
@@ -18,7 +23,7 @@ from fastapi.responses import JSONResponse
 from starlette.testclient import TestClient
 
 # ---------------------------------------------------------------------------
-# Minimal test app factory
+# Test app factory + module-scoped fixtures
 # ---------------------------------------------------------------------------
 
 
@@ -63,21 +68,28 @@ def _make_test_app(cors_origins: str = "http://localhost:5174") -> FastAPI:
     return app
 
 
+@pytest.fixture(scope="module")
+def cors_client() -> TestClient:
+    """Module-scoped test client with default cors_origins=localhost:5174.
+
+    Reused across the 24 tests that exercise the default config. The two
+    structlog/regex tests use pytest's monkeypatch and do not need a fresh
+    app since they probe behaviour, not state.
+    """
+    return TestClient(_make_test_app(), raise_server_exceptions=False)
+
+
 # ---------------------------------------------------------------------------
 # AC-1: Cross-origin GET /api/me from evil.example is blocked
 # ---------------------------------------------------------------------------
 
 
-def test_cors_blocks_evil_origin_on_api_me() -> None:
+def test_cors_blocks_evil_origin_on_api_me(cors_client: TestClient) -> None:
     """AC-1: GET /api/me with Origin: evil.example must NOT echo ACAO or ACAC.
 
     REQ-1.1 / REQ-1.5 — wildcard CORS regex removed; evil.example not in allowlist.
     """
-    app = _make_test_app()
-    client = TestClient(app, raise_server_exceptions=False)
-
-    # Preflight from evil.example
-    resp = client.options(
+    resp = cors_client.options(
         "/api/me",
         headers={
             "Origin": "https://evil.example",
@@ -100,15 +112,14 @@ def test_cors_blocks_evil_origin_on_api_me() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_cors_blocks_evil_origin_on_auth_login_preflight() -> None:
+def test_cors_blocks_evil_origin_on_auth_login_preflight(
+    cors_client: TestClient,
+) -> None:
     """AC-2: OPTIONS /api/auth/login with Origin: evil.example must NOT echo ACAO.
 
     REQ-1.1 — the CSRF exemption does NOT override the CORS gate.
     """
-    app = _make_test_app()
-    client = TestClient(app, raise_server_exceptions=False)
-
-    resp = client.options(
+    resp = cors_client.options(
         "/api/auth/login",
         headers={
             "Origin": "https://evil.example",
@@ -128,15 +139,12 @@ def test_cors_blocks_evil_origin_on_auth_login_preflight() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_cors_allows_first_party_on_api_me() -> None:
+def test_cors_allows_first_party_on_api_me(cors_client: TestClient) -> None:
     """AC-3: GET /api/me with Origin: https://my.getklai.com echoes ACAO + ACAC.
 
     REQ-1.2 / REQ-1.5 — fixed regex matches *.getklai.com.
     """
-    app = _make_test_app()
-    client = TestClient(app, raise_server_exceptions=False)
-
-    resp = client.get(
+    resp = cors_client.get(
         "/api/me",
         headers={"Origin": "https://my.getklai.com"},
     )
@@ -161,15 +169,12 @@ def test_cors_allows_first_party_on_api_me() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_cors_allows_tenant_subdomain_on_api_me() -> None:
+def test_cors_allows_tenant_subdomain_on_api_me(cors_client: TestClient) -> None:
     """AC-4a: Origin: https://acme.getklai.com is allowed.
 
     REQ-1.2 — single-label subdomain matches the fixed regex.
     """
-    app = _make_test_app()
-    client = TestClient(app, raise_server_exceptions=False)
-
-    resp = client.get(
+    resp = cors_client.get(
         "/api/me",
         headers={"Origin": "https://acme.getklai.com"},
     )
@@ -180,15 +185,12 @@ def test_cors_allows_tenant_subdomain_on_api_me() -> None:
     )
 
 
-def test_cors_rejects_multi_label_subdomain() -> None:
+def test_cors_rejects_multi_label_subdomain(cors_client: TestClient) -> None:
     """AC-4b: Origin: https://evil.my.getklai.com must NOT be echoed.
 
     REQ-1.2 — multi-label subdomains blocked by the fixed regex.
     """
-    app = _make_test_app()
-    client = TestClient(app, raise_server_exceptions=False)
-
-    resp = client.get(
+    resp = cors_client.get(
         "/api/me",
         headers={"Origin": "https://evil.my.getklai.com"},
     )
@@ -205,15 +207,12 @@ def test_cors_rejects_multi_label_subdomain() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_cors_rejects_plaintext_http_getklai() -> None:
+def test_cors_rejects_plaintext_http_getklai(cors_client: TestClient) -> None:
     """AC-5: Origin: http://getklai.com (no TLS) is rejected.
 
     REQ-1.2 — regex requires https://.
     """
-    app = _make_test_app()
-    client = TestClient(app, raise_server_exceptions=False)
-
-    resp = client.get(
+    resp = cors_client.get(
         "/api/me",
         headers={"Origin": "http://getklai.com"},
     )
@@ -230,15 +229,12 @@ def test_cors_rejects_plaintext_http_getklai() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_cors_allows_dev_origin_localhost_5174() -> None:
+def test_cors_allows_dev_origin_localhost_5174(cors_client: TestClient) -> None:
     """AC-6: Origin: http://localhost:5174 is allowed when in cors_origins.
 
     REQ-1.2 — cors_origins_list union with the fixed regex.
     """
-    app = _make_test_app(cors_origins="http://localhost:5174")
-    client = TestClient(app, raise_server_exceptions=False)
-
-    resp = client.get(
+    resp = cors_client.get(
         "/api/me",
         headers={"Origin": "http://localhost:5174"},
     )
@@ -275,15 +271,14 @@ _TEST_PATHS = [
 
 @pytest.mark.parametrize("path", _TEST_PATHS)
 @pytest.mark.parametrize("origin", _ATTACKER_ORIGINS)
-def test_cors_no_unlisted_origin_echo(path: str, origin: str) -> None:
+def test_cors_no_unlisted_origin_echo(
+    cors_client: TestClient, path: str, origin: str
+) -> None:
     """AC-7: Preflights from attacker origins never echo ACAO on any path.
 
     REQ-1 (group) — no attacker origin x path combination echoes ACAO.
     """
-    app = _make_test_app()
-    client = TestClient(app, raise_server_exceptions=False)
-
-    resp = client.options(
+    resp = cors_client.options(
         path,
         headers={
             "Origin": origin,
@@ -305,15 +300,11 @@ def test_cors_no_unlisted_origin_echo(path: str, origin: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_acac_never_with_wildcard_origin() -> None:
+def test_acac_never_with_wildcard_origin(cors_client: TestClient) -> None:
     """AC-8: When ACAC is true, ACAO must be a concrete origin (not * or missing).
 
-    REQ-1.5 — scans headers from all other AC test responses.
+    REQ-1.5 — scans headers from a representative mix of allowed and denied scenarios.
     """
-    app = _make_test_app(cors_origins="http://localhost:5174")
-    client = TestClient(app, raise_server_exceptions=False)
-
-    # Collect headers from a mix of allowed and denied scenarios
     probes: list[tuple[str, str]] = [
         ("/api/me", "https://my.getklai.com"),
         ("/api/me", "https://acme.getklai.com"),
@@ -324,14 +315,14 @@ def test_acac_never_with_wildcard_origin() -> None:
     ]
 
     for path, origin in probes:
-        resp = client.get(path, headers={"Origin": origin})
+        resp = cors_client.get(path, headers={"Origin": origin})
         acao = resp.headers.get("access-control-allow-origin", "")
         acac = resp.headers.get("access-control-allow-credentials", "")
 
         if acac.lower() == "true":
             assert acao not in ("", "*"), (
                 f"ACAC=true on {path!r} with origin={origin!r} "
-                f"but ACAO={acao!r} — must be a concrete origin (AC-8)"
+                f"but ACAO={acao!r} - must be a concrete origin (AC-8)"
             )
 
 
@@ -340,14 +331,12 @@ def test_acac_never_with_wildcard_origin() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_cors_rejected_preflight_emits_structlog_event() -> None:
+def test_cors_rejected_preflight_emits_structlog_event(
+    cors_client: TestClient,
+) -> None:
     """AC-13: A rejected preflight emits event='cors_origin_rejected' in structlog.
 
-    REQ-1 NFR Observability — event includes origin, path, request_id fields.
-
-    Structlog uses its own processor chain and does not write to Python's stdlib
-    logging by default during tests.  We capture events by temporarily binding a
-    structlog processor that records calls.
+    REQ-1 NFR Observability — event includes origin, path, request_id, kind.
     """
     import structlog as sl
 
@@ -361,19 +350,14 @@ def test_cors_rejected_preflight_emits_structlog_event() -> None:
         captured_events.append(dict(event_dict))
         raise sl.DropEvent()
 
-    # Configure structlog to capture events for this test
     sl.configure(
         processors=[_capture_processor],
         wrapper_class=sl.BoundLogger,
         context_class=dict,
         logger_factory=sl.PrintLoggerFactory(),
     )
-
     try:
-        app = _make_test_app()
-        client = TestClient(app, raise_server_exceptions=False)
-
-        resp = client.options(
+        resp = cors_client.options(
             "/api/me",
             headers={
                 "Origin": "https://evil.example",
@@ -382,14 +366,11 @@ def test_cors_rejected_preflight_emits_structlog_event() -> None:
             },
         )
     finally:
-        # Restore default structlog configuration
         sl.reset_defaults()
 
-    # ACAO must not be echoed
     acao = resp.headers.get("access-control-allow-origin", "")
     assert acao != "https://evil.example", "Preflight should be rejected (AC-13 setup)"
 
-    # The structlog event should have been captured
     rejected = [e for e in captured_events if e.get("event") == "cors_origin_rejected"]
     assert len(rejected) >= 1, (
         f"Expected event='cors_origin_rejected' in structlog, "
@@ -404,6 +385,62 @@ def test_cors_rejected_preflight_emits_structlog_event() -> None:
         f"path field must be '/api/me', got {evt.get('path')!r}"
     )
     assert "request_id" in evt, "request_id field must be present in event"
+    assert evt.get("kind") == "preflight", (
+        f"kind field must be 'preflight' for OPTIONS request, got {evt.get('kind')!r}"
+    )
+
+
+def test_cors_rejected_simple_request_emits_structlog_event(
+    cors_client: TestClient,
+) -> None:
+    """AC-13 (simple-request branch): a non-preflight cross-origin request from a
+    rejected origin also emits cors_origin_rejected with kind='simple'.
+
+    Closes the observability gap that the original from-scratch implementation had:
+    only preflights were logged. Browsers can issue simple cross-origin GET/POST
+    without preflights, and we want both probing channels visible to monitoring.
+    """
+    import structlog as sl
+
+    captured_events: list[dict[str, Any]] = []
+
+    def _capture_processor(
+        logger: Any, method: str, event_dict: dict[str, Any]
+    ) -> dict[str, Any]:
+        captured_events.append(dict(event_dict))
+        raise sl.DropEvent()
+
+    sl.configure(
+        processors=[_capture_processor],
+        wrapper_class=sl.BoundLogger,
+        context_class=dict,
+        logger_factory=sl.PrintLoggerFactory(),
+    )
+    try:
+        cors_client.get(
+            "/api/me",
+            headers={
+                "Origin": "https://evil.example",
+                "X-Request-ID": "test-request-id-simple-001",
+            },
+        )
+    finally:
+        sl.reset_defaults()
+
+    rejected = [
+        e
+        for e in captured_events
+        if e.get("event") == "cors_origin_rejected" and e.get("kind") == "simple"
+    ]
+    assert len(rejected) >= 1, (
+        f"Expected event='cors_origin_rejected' kind='simple' in structlog, "
+        f"got events: {[(e.get('event'), e.get('kind')) for e in captured_events]}"
+    )
+
+    evt = rejected[0]
+    assert evt.get("origin") == "https://evil.example"
+    assert evt.get("path") == "/api/me"
+    assert evt.get("request_id") == "test-request-id-simple-001"
 
 
 # ---------------------------------------------------------------------------
@@ -411,23 +448,18 @@ def test_cors_rejected_preflight_emits_structlog_event() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_cors_regex_compile_failure_raises_system_exit() -> None:
+def test_cors_regex_compile_failure_raises_system_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """AC-14: If the CORS origin regex fails to compile, startup raises SystemExit.
 
     REQ-1 NFR Fail mode — fail-closed like _require_vexa_webhook_secret.
-    The regex is hardcoded so we monkeypatch the module constant.
+    The regex is hardcoded so we monkeypatch the module constant; pytest's
+    monkeypatch fixture handles automatic cleanup.
     """
     import app.middleware.klai_cors as cors_module
 
-    original = cors_module._FIRST_PARTY_ORIGIN_PATTERN
+    monkeypatch.setattr(cors_module, "_FIRST_PARTY_ORIGIN_PATTERN", "[")
 
-    # Monkeypatch the pattern string to something that will fail re.compile
-    cors_module._FIRST_PARTY_ORIGIN_PATTERN = "["  # invalid regex
-
-    try:
-        with pytest.raises(SystemExit):
-            cors_module._compile_first_party_regex()
-    finally:
-        # Restore
-        cors_module._FIRST_PARTY_ORIGIN_PATTERN = original
-        cors_module._compile_first_party_regex()  # ensure module state is restored
+    with pytest.raises(SystemExit):
+        cors_module._compile_first_party_regex()

--- a/klai-portal/backend/tests/test_cors_allowlist.py
+++ b/klai-portal/backend/tests/test_cors_allowlist.py
@@ -100,9 +100,7 @@ def test_cors_blocks_evil_origin_on_api_me(cors_client: TestClient) -> None:
     acao = resp.headers.get("access-control-allow-origin", "")
     acac = resp.headers.get("access-control-allow-credentials", "")
 
-    assert acao != "https://evil.example", (
-        "ACAO must NOT be echoed for https://evil.example (AC-1)"
-    )
+    assert acao != "https://evil.example", "ACAO must NOT be echoed for https://evil.example (AC-1)"
     assert acao != "*", "ACAO must NOT be wildcard (AC-1)"
     assert acac.lower() != "true", "ACAC must NOT be true for evil.example (AC-1)"
 
@@ -153,15 +151,9 @@ def test_cors_allows_first_party_on_api_me(cors_client: TestClient) -> None:
     acac = resp.headers.get("access-control-allow-credentials", "")
     vary = resp.headers.get("vary", "")
 
-    assert acao == "https://my.getklai.com", (
-        f"ACAO must echo https://my.getklai.com, got {acao!r} (AC-3)"
-    )
-    assert acac.lower() == "true", (
-        f"ACAC must be true for first-party origin, got {acac!r} (AC-3)"
-    )
-    assert "origin" in vary.lower(), (
-        f"Vary must include Origin, got {vary!r} (AC-3)"
-    )
+    assert acao == "https://my.getklai.com", f"ACAO must echo https://my.getklai.com, got {acao!r} (AC-3)"
+    assert acac.lower() == "true", f"ACAC must be true for first-party origin, got {acac!r} (AC-3)"
+    assert "origin" in vary.lower(), f"Vary must include Origin, got {vary!r} (AC-3)"
 
 
 # ---------------------------------------------------------------------------
@@ -180,9 +172,7 @@ def test_cors_allows_tenant_subdomain_on_api_me(cors_client: TestClient) -> None
     )
 
     acao = resp.headers.get("access-control-allow-origin", "")
-    assert acao == "https://acme.getklai.com", (
-        f"ACAO must echo acme.getklai.com, got {acao!r} (AC-4a)"
-    )
+    assert acao == "https://acme.getklai.com", f"ACAO must echo acme.getklai.com, got {acao!r} (AC-4a)"
 
 
 def test_cors_rejects_multi_label_subdomain(cors_client: TestClient) -> None:
@@ -196,9 +186,7 @@ def test_cors_rejects_multi_label_subdomain(cors_client: TestClient) -> None:
     )
 
     acao = resp.headers.get("access-control-allow-origin", "")
-    assert acao != "https://evil.my.getklai.com", (
-        "ACAO must NOT echo evil.my.getklai.com (multi-label) (AC-4b)"
-    )
+    assert acao != "https://evil.my.getklai.com", "ACAO must NOT echo evil.my.getklai.com (multi-label) (AC-4b)"
     assert acao != "*", "ACAO must NOT be wildcard (AC-4b)"
 
 
@@ -218,9 +206,7 @@ def test_cors_rejects_plaintext_http_getklai(cors_client: TestClient) -> None:
     )
 
     acao = resp.headers.get("access-control-allow-origin", "")
-    assert acao != "http://getklai.com", (
-        f"ACAO must NOT echo plaintext http://getklai.com, got {acao!r} (AC-5)"
-    )
+    assert acao != "http://getklai.com", f"ACAO must NOT echo plaintext http://getklai.com, got {acao!r} (AC-5)"
     assert acao != "*", "ACAO must NOT be wildcard (AC-5)"
 
 
@@ -242,12 +228,8 @@ def test_cors_allows_dev_origin_localhost_5174(cors_client: TestClient) -> None:
     acao = resp.headers.get("access-control-allow-origin", "")
     acac = resp.headers.get("access-control-allow-credentials", "")
 
-    assert acao == "http://localhost:5174", (
-        f"ACAO must echo http://localhost:5174, got {acao!r} (AC-6)"
-    )
-    assert acac.lower() == "true", (
-        f"ACAC must be true for localhost dev origin, got {acac!r} (AC-6)"
-    )
+    assert acao == "http://localhost:5174", f"ACAO must echo http://localhost:5174, got {acao!r} (AC-6)"
+    assert acac.lower() == "true", f"ACAC must be true for localhost dev origin, got {acac!r} (AC-6)"
 
 
 # ---------------------------------------------------------------------------
@@ -271,9 +253,7 @@ _TEST_PATHS = [
 
 @pytest.mark.parametrize("path", _TEST_PATHS)
 @pytest.mark.parametrize("origin", _ATTACKER_ORIGINS)
-def test_cors_no_unlisted_origin_echo(
-    cors_client: TestClient, path: str, origin: str
-) -> None:
+def test_cors_no_unlisted_origin_echo(cors_client: TestClient, path: str, origin: str) -> None:
     """AC-7: Preflights from attacker origins never echo ACAO on any path.
 
     REQ-1 (group) — no attacker origin x path combination echoes ACAO.
@@ -287,12 +267,8 @@ def test_cors_no_unlisted_origin_echo(
     )
 
     acao = resp.headers.get("access-control-allow-origin", "")
-    assert acao != origin, (
-        f"ACAO must NOT echo {origin!r} on {path!r} (AC-7)"
-    )
-    assert acao != "*", (
-        f"ACAO must NOT be wildcard for {origin!r} on {path!r} (AC-7)"
-    )
+    assert acao != origin, f"ACAO must NOT echo {origin!r} on {path!r} (AC-7)"
+    assert acao != "*", f"ACAO must NOT be wildcard for {origin!r} on {path!r} (AC-7)"
 
 
 # ---------------------------------------------------------------------------
@@ -321,8 +297,7 @@ def test_acac_never_with_wildcard_origin(cors_client: TestClient) -> None:
 
         if acac.lower() == "true":
             assert acao not in ("", "*"), (
-                f"ACAC=true on {path!r} with origin={origin!r} "
-                f"but ACAO={acao!r} - must be a concrete origin (AC-8)"
+                f"ACAC=true on {path!r} with origin={origin!r} but ACAO={acao!r} - must be a concrete origin (AC-8)"
             )
 
 
@@ -373,17 +348,14 @@ def test_cors_rejected_preflight_emits_structlog_event(
 
     rejected = [e for e in captured_events if e.get("event") == "cors_origin_rejected"]
     assert len(rejected) >= 1, (
-        f"Expected event='cors_origin_rejected' in structlog, "
-        f"got events: {[e.get('event') for e in captured_events]}"
+        f"Expected event='cors_origin_rejected' in structlog, got events: {[e.get('event') for e in captured_events]}"
     )
 
     evt = rejected[0]
     assert evt.get("origin") == "https://evil.example", (
         f"origin field must be 'https://evil.example', got {evt.get('origin')!r}"
     )
-    assert evt.get("path") == "/api/me", (
-        f"path field must be '/api/me', got {evt.get('path')!r}"
-    )
+    assert evt.get("path") == "/api/me", f"path field must be '/api/me', got {evt.get('path')!r}"
     assert "request_id" in evt, "request_id field must be present in event"
     assert evt.get("kind") == "preflight", (
         f"kind field must be 'preflight' for OPTIONS request, got {evt.get('kind')!r}"
@@ -404,9 +376,7 @@ def test_cors_rejected_simple_request_emits_structlog_event(
 
     captured_events: list[dict[str, Any]] = []
 
-    def _capture_processor(
-        logger: Any, method: str, event_dict: dict[str, Any]
-    ) -> dict[str, Any]:
+    def _capture_processor(logger: Any, method: str, event_dict: dict[str, Any]) -> dict[str, Any]:
         captured_events.append(dict(event_dict))
         raise sl.DropEvent()
 
@@ -427,11 +397,7 @@ def test_cors_rejected_simple_request_emits_structlog_event(
     finally:
         sl.reset_defaults()
 
-    rejected = [
-        e
-        for e in captured_events
-        if e.get("event") == "cors_origin_rejected" and e.get("kind") == "simple"
-    ]
+    rejected = [e for e in captured_events if e.get("event") == "cors_origin_rejected" and e.get("kind") == "simple"]
     assert len(rejected) >= 1, (
         f"Expected event='cors_origin_rejected' kind='simple' in structlog, "
         f"got events: {[(e.get('event'), e.get('kind')) for e in captured_events]}"

--- a/klai-portal/backend/tests/test_cors_allowlist.py
+++ b/klai-portal/backend/tests/test_cors_allowlist.py
@@ -1,0 +1,433 @@
+"""CORS allowlist regression tests — SPEC-SEC-CORS-001.
+
+Tests AC-1 through AC-8, AC-13, and AC-14.
+
+Strategy: build a minimal FastAPI app that registers KlaiCORSMiddleware (the
+production middleware) and a single GET /api/me route, then run CORS scenarios
+against it via Starlette TestClient.  This avoids importing the full portal-api
+app (which requires live DB connections and secret validation).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from starlette.testclient import TestClient
+
+# ---------------------------------------------------------------------------
+# Minimal test app factory
+# ---------------------------------------------------------------------------
+
+
+def _make_test_app(cors_origins: str = "http://localhost:5174") -> FastAPI:
+    """Create a minimal app with KlaiCORSMiddleware for CORS testing.
+
+    `cors_origins` is the raw comma-separated string (equivalent to
+    settings.cors_origins); we split it once here, the same way
+    Settings.cors_origins_list does in production code.
+    """
+    from app.middleware.klai_cors import KlaiCORSMiddleware
+
+    app = FastAPI()
+
+    @app.get("/api/me")
+    async def me() -> JSONResponse:
+        return JSONResponse({"user": "test"})
+
+    @app.post("/api/auth/login")
+    async def login() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    @app.post("/api/signup")
+    async def signup() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    @app.get("/api/health")
+    async def health() -> JSONResponse:
+        return JSONResponse({"status": "ok"})
+
+    @app.get("/internal/anything")
+    async def internal() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    app.add_middleware(
+        KlaiCORSMiddleware,
+        cors_origins=[o.strip() for o in cors_origins.split(",") if o.strip()],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    return app
+
+
+# ---------------------------------------------------------------------------
+# AC-1: Cross-origin GET /api/me from evil.example is blocked
+# ---------------------------------------------------------------------------
+
+
+def test_cors_blocks_evil_origin_on_api_me() -> None:
+    """AC-1: GET /api/me with Origin: evil.example must NOT echo ACAO or ACAC.
+
+    REQ-1.1 / REQ-1.5 — wildcard CORS regex removed; evil.example not in allowlist.
+    """
+    app = _make_test_app()
+    client = TestClient(app, raise_server_exceptions=False)
+
+    # Preflight from evil.example
+    resp = client.options(
+        "/api/me",
+        headers={
+            "Origin": "https://evil.example",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    acao = resp.headers.get("access-control-allow-origin", "")
+    acac = resp.headers.get("access-control-allow-credentials", "")
+
+    assert acao != "https://evil.example", (
+        "ACAO must NOT be echoed for https://evil.example (AC-1)"
+    )
+    assert acao != "*", "ACAO must NOT be wildcard (AC-1)"
+    assert acac.lower() != "true", "ACAC must NOT be true for evil.example (AC-1)"
+
+
+# ---------------------------------------------------------------------------
+# AC-2: Cross-origin POST /api/auth/login preflight from evil.example is blocked
+# ---------------------------------------------------------------------------
+
+
+def test_cors_blocks_evil_origin_on_auth_login_preflight() -> None:
+    """AC-2: OPTIONS /api/auth/login with Origin: evil.example must NOT echo ACAO.
+
+    REQ-1.1 — the CSRF exemption does NOT override the CORS gate.
+    """
+    app = _make_test_app()
+    client = TestClient(app, raise_server_exceptions=False)
+
+    resp = client.options(
+        "/api/auth/login",
+        headers={
+            "Origin": "https://evil.example",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+
+    acao = resp.headers.get("access-control-allow-origin", "")
+    assert acao != "https://evil.example", (
+        "ACAO must NOT be echoed for evil.example on /api/auth/login preflight (AC-2)"
+    )
+    assert acao != "*", "ACAO must NOT be wildcard on /api/auth/login preflight (AC-2)"
+
+
+# ---------------------------------------------------------------------------
+# AC-3: First-party GET /api/me from my.getklai.com is allowed with credentials
+# ---------------------------------------------------------------------------
+
+
+def test_cors_allows_first_party_on_api_me() -> None:
+    """AC-3: GET /api/me with Origin: https://my.getklai.com echoes ACAO + ACAC.
+
+    REQ-1.2 / REQ-1.5 — fixed regex matches *.getklai.com.
+    """
+    app = _make_test_app()
+    client = TestClient(app, raise_server_exceptions=False)
+
+    resp = client.get(
+        "/api/me",
+        headers={"Origin": "https://my.getklai.com"},
+    )
+
+    acao = resp.headers.get("access-control-allow-origin", "")
+    acac = resp.headers.get("access-control-allow-credentials", "")
+    vary = resp.headers.get("vary", "")
+
+    assert acao == "https://my.getklai.com", (
+        f"ACAO must echo https://my.getklai.com, got {acao!r} (AC-3)"
+    )
+    assert acac.lower() == "true", (
+        f"ACAC must be true for first-party origin, got {acac!r} (AC-3)"
+    )
+    assert "origin" in vary.lower(), (
+        f"Vary must include Origin, got {vary!r} (AC-3)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-4: First-party tenant subdomain allowed; multi-label rejected
+# ---------------------------------------------------------------------------
+
+
+def test_cors_allows_tenant_subdomain_on_api_me() -> None:
+    """AC-4a: Origin: https://acme.getklai.com is allowed.
+
+    REQ-1.2 — single-label subdomain matches the fixed regex.
+    """
+    app = _make_test_app()
+    client = TestClient(app, raise_server_exceptions=False)
+
+    resp = client.get(
+        "/api/me",
+        headers={"Origin": "https://acme.getklai.com"},
+    )
+
+    acao = resp.headers.get("access-control-allow-origin", "")
+    assert acao == "https://acme.getklai.com", (
+        f"ACAO must echo acme.getklai.com, got {acao!r} (AC-4a)"
+    )
+
+
+def test_cors_rejects_multi_label_subdomain() -> None:
+    """AC-4b: Origin: https://evil.my.getklai.com must NOT be echoed.
+
+    REQ-1.2 — multi-label subdomains blocked by the fixed regex.
+    """
+    app = _make_test_app()
+    client = TestClient(app, raise_server_exceptions=False)
+
+    resp = client.get(
+        "/api/me",
+        headers={"Origin": "https://evil.my.getklai.com"},
+    )
+
+    acao = resp.headers.get("access-control-allow-origin", "")
+    assert acao != "https://evil.my.getklai.com", (
+        "ACAO must NOT echo evil.my.getklai.com (multi-label) (AC-4b)"
+    )
+    assert acao != "*", "ACAO must NOT be wildcard (AC-4b)"
+
+
+# ---------------------------------------------------------------------------
+# AC-5: Plaintext http://getklai.com is rejected
+# ---------------------------------------------------------------------------
+
+
+def test_cors_rejects_plaintext_http_getklai() -> None:
+    """AC-5: Origin: http://getklai.com (no TLS) is rejected.
+
+    REQ-1.2 — regex requires https://.
+    """
+    app = _make_test_app()
+    client = TestClient(app, raise_server_exceptions=False)
+
+    resp = client.get(
+        "/api/me",
+        headers={"Origin": "http://getklai.com"},
+    )
+
+    acao = resp.headers.get("access-control-allow-origin", "")
+    assert acao != "http://getklai.com", (
+        f"ACAO must NOT echo plaintext http://getklai.com, got {acao!r} (AC-5)"
+    )
+    assert acao != "*", "ACAO must NOT be wildcard (AC-5)"
+
+
+# ---------------------------------------------------------------------------
+# AC-6: Dev origin http://localhost:5174 is allowed when configured
+# ---------------------------------------------------------------------------
+
+
+def test_cors_allows_dev_origin_localhost_5174() -> None:
+    """AC-6: Origin: http://localhost:5174 is allowed when in cors_origins.
+
+    REQ-1.2 — cors_origins_list union with the fixed regex.
+    """
+    app = _make_test_app(cors_origins="http://localhost:5174")
+    client = TestClient(app, raise_server_exceptions=False)
+
+    resp = client.get(
+        "/api/me",
+        headers={"Origin": "http://localhost:5174"},
+    )
+
+    acao = resp.headers.get("access-control-allow-origin", "")
+    acac = resp.headers.get("access-control-allow-credentials", "")
+
+    assert acao == "http://localhost:5174", (
+        f"ACAO must echo http://localhost:5174, got {acao!r} (AC-6)"
+    )
+    assert acac.lower() == "true", (
+        f"ACAC must be true for localhost dev origin, got {acac!r} (AC-6)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-7: No unlisted origin echoed on any path (table test)
+# ---------------------------------------------------------------------------
+
+_ATTACKER_ORIGINS = [
+    "https://evil.example",
+    "https://evil.getklai.com.attacker.tld",
+    "http://getklai.com",
+    "https://evil.my.getklai.com",
+]
+
+_TEST_PATHS = [
+    "/api/me",
+    "/api/auth/login",
+    "/api/signup",
+    "/internal/anything",
+]
+
+
+@pytest.mark.parametrize("path", _TEST_PATHS)
+@pytest.mark.parametrize("origin", _ATTACKER_ORIGINS)
+def test_cors_no_unlisted_origin_echo(path: str, origin: str) -> None:
+    """AC-7: Preflights from attacker origins never echo ACAO on any path.
+
+    REQ-1 (group) — no attacker origin x path combination echoes ACAO.
+    """
+    app = _make_test_app()
+    client = TestClient(app, raise_server_exceptions=False)
+
+    resp = client.options(
+        path,
+        headers={
+            "Origin": origin,
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    acao = resp.headers.get("access-control-allow-origin", "")
+    assert acao != origin, (
+        f"ACAO must NOT echo {origin!r} on {path!r} (AC-7)"
+    )
+    assert acao != "*", (
+        f"ACAO must NOT be wildcard for {origin!r} on {path!r} (AC-7)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-8: ACAC never coexists with wildcard origin
+# ---------------------------------------------------------------------------
+
+
+def test_acac_never_with_wildcard_origin() -> None:
+    """AC-8: When ACAC is true, ACAO must be a concrete origin (not * or missing).
+
+    REQ-1.5 — scans headers from all other AC test responses.
+    """
+    app = _make_test_app(cors_origins="http://localhost:5174")
+    client = TestClient(app, raise_server_exceptions=False)
+
+    # Collect headers from a mix of allowed and denied scenarios
+    probes: list[tuple[str, str]] = [
+        ("/api/me", "https://my.getklai.com"),
+        ("/api/me", "https://acme.getklai.com"),
+        ("/api/me", "http://localhost:5174"),
+        ("/api/me", "https://evil.example"),
+        ("/api/auth/login", "https://my.getklai.com"),
+        ("/api/auth/login", "https://evil.example"),
+    ]
+
+    for path, origin in probes:
+        resp = client.get(path, headers={"Origin": origin})
+        acao = resp.headers.get("access-control-allow-origin", "")
+        acac = resp.headers.get("access-control-allow-credentials", "")
+
+        if acac.lower() == "true":
+            assert acao not in ("", "*"), (
+                f"ACAC=true on {path!r} with origin={origin!r} "
+                f"but ACAO={acao!r} — must be a concrete origin (AC-8)"
+            )
+
+
+# ---------------------------------------------------------------------------
+# AC-13: Observability — rejected preflights are logged
+# ---------------------------------------------------------------------------
+
+
+def test_cors_rejected_preflight_emits_structlog_event() -> None:
+    """AC-13: A rejected preflight emits event='cors_origin_rejected' in structlog.
+
+    REQ-1 NFR Observability — event includes origin, path, request_id fields.
+
+    Structlog uses its own processor chain and does not write to Python's stdlib
+    logging by default during tests.  We capture events by temporarily binding a
+    structlog processor that records calls.
+    """
+    import structlog as sl
+
+    captured_events: list[dict[str, Any]] = []
+
+    def _capture_processor(
+        logger: Any,
+        method: str,
+        event_dict: dict[str, Any],
+    ) -> dict[str, Any]:
+        captured_events.append(dict(event_dict))
+        raise sl.DropEvent()
+
+    # Configure structlog to capture events for this test
+    sl.configure(
+        processors=[_capture_processor],
+        wrapper_class=sl.BoundLogger,
+        context_class=dict,
+        logger_factory=sl.PrintLoggerFactory(),
+    )
+
+    try:
+        app = _make_test_app()
+        client = TestClient(app, raise_server_exceptions=False)
+
+        resp = client.options(
+            "/api/me",
+            headers={
+                "Origin": "https://evil.example",
+                "Access-Control-Request-Method": "GET",
+                "X-Request-ID": "test-request-id-001",
+            },
+        )
+    finally:
+        # Restore default structlog configuration
+        sl.reset_defaults()
+
+    # ACAO must not be echoed
+    acao = resp.headers.get("access-control-allow-origin", "")
+    assert acao != "https://evil.example", "Preflight should be rejected (AC-13 setup)"
+
+    # The structlog event should have been captured
+    rejected = [e for e in captured_events if e.get("event") == "cors_origin_rejected"]
+    assert len(rejected) >= 1, (
+        f"Expected event='cors_origin_rejected' in structlog, "
+        f"got events: {[e.get('event') for e in captured_events]}"
+    )
+
+    evt = rejected[0]
+    assert evt.get("origin") == "https://evil.example", (
+        f"origin field must be 'https://evil.example', got {evt.get('origin')!r}"
+    )
+    assert evt.get("path") == "/api/me", (
+        f"path field must be '/api/me', got {evt.get('path')!r}"
+    )
+    assert "request_id" in evt, "request_id field must be present in event"
+
+
+# ---------------------------------------------------------------------------
+# AC-14: Startup fail-closed on broken regex
+# ---------------------------------------------------------------------------
+
+
+def test_cors_regex_compile_failure_raises_system_exit() -> None:
+    """AC-14: If the CORS origin regex fails to compile, startup raises SystemExit.
+
+    REQ-1 NFR Fail mode — fail-closed like _require_vexa_webhook_secret.
+    The regex is hardcoded so we monkeypatch the module constant.
+    """
+    import app.middleware.klai_cors as cors_module
+
+    original = cors_module._FIRST_PARTY_ORIGIN_PATTERN
+
+    # Monkeypatch the pattern string to something that will fail re.compile
+    cors_module._FIRST_PARTY_ORIGIN_PATTERN = "["  # invalid regex
+
+    try:
+        with pytest.raises(SystemExit):
+            cors_module._compile_first_party_regex()
+    finally:
+        # Restore
+        cors_module._FIRST_PARTY_ORIGIN_PATTERN = original
+        cors_module._compile_first_party_regex()  # ensure module state is restored

--- a/klai-portal/backend/tests/test_csrf_exempt_rationale.py
+++ b/klai-portal/backend/tests/test_csrf_exempt_rationale.py
@@ -1,0 +1,161 @@
+"""CSRF exempt rationale lint test — SPEC-SEC-CORS-001 REQ-4, AC-12.
+
+Parses `app/middleware/session.py` with the stdlib `ast` module and
+verifies that every string literal in `_CSRF_EXEMPT_PREFIXES` is preceded
+(within 5 source lines) by at least one comment line containing:
+  (a) a keyword from the rationale set, AND
+  (b) a REQ-N or AC-N reference.
+
+Failure message names the offending prefix so the developer knows
+exactly which entry to fix.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import re
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+_SESSION_PY = (
+    pathlib.Path(__file__).parent.parent
+    / "app"
+    / "middleware"
+    / "session.py"
+)
+
+# At least one of these keywords must appear in a preceding comment (AC-12)
+_RATIONALE_KEYWORDS = {
+    "pre-session",
+    "no session",
+    "sendBeacon",
+    "internal",
+    "partner",
+    "widget",
+    "Zitadel",
+    "signup",
+    "health probe",
+}
+
+# The comment must also contain a REQ-N or AC-N reference. Supports
+# REQ-10+, sub-section forms like REQ-1.6, and AC-99 (forward-compat for
+# SPECs that grow more than 9 requirement groups or 99 acceptance criteria).
+_REQ_AC_PATTERN = re.compile(r"\b(REQ-\d+(?:\.\d+)?|AC-\d+)\b")
+
+# Maximum number of lines above the literal to search
+_LOOKBACK = 5
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _extract_prefixes_with_lines(source: str, tree: ast.AST) -> list[tuple[str, int]]:
+    """Return (prefix_string, line_number) for every literal in _CSRF_EXEMPT_PREFIXES.
+
+    Handles both plain Assign and annotated AnnAssign (e.g. `x: tuple[str, ...] = (...)`).
+    """
+    results: list[tuple[str, int]] = []
+
+    for node in ast.walk(tree):
+        value: ast.expr | None = None
+
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == "_CSRF_EXEMPT_PREFIXES"
+        ):
+            value = node.value
+
+        elif (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == "_CSRF_EXEMPT_PREFIXES"
+            and node.value is not None
+        ):
+            value = node.value
+
+        if value is not None and isinstance(value, ast.Tuple):
+            for elt in value.elts:
+                if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                    results.append((elt.value, elt.lineno))
+
+    return results
+
+
+def _preceding_comment_lines(source_lines: list[str], prefix_lineno: int) -> list[str]:
+    """Return up to _LOOKBACK comment lines immediately above prefix_lineno (1-based)."""
+    comments = []
+    start = max(0, prefix_lineno - 1 - _LOOKBACK)
+    end = prefix_lineno - 1  # exclusive; line at prefix_lineno is the literal itself
+    for i in range(start, end):
+        stripped = source_lines[i].strip()
+        if stripped.startswith("#"):
+            comments.append(stripped)
+    return comments
+
+
+# ---------------------------------------------------------------------------
+# The test
+# ---------------------------------------------------------------------------
+
+
+def test_csrf_exempt_prefixes_have_rationale() -> None:
+    """AC-12: Every _CSRF_EXEMPT_PREFIXES entry has inline rationale.
+
+    REQ-4.1 / REQ-4.2 — each entry must be preceded (within 5 lines) by:
+    - A comment with at least one rationale keyword AND
+    - A REQ-N or AC-N reference in that same comment block.
+    """
+    assert _SESSION_PY.exists(), f"session.py not found at {_SESSION_PY}"
+
+    source = _SESSION_PY.read_text(encoding="utf-8")
+    source_lines = source.splitlines()
+    tree = ast.parse(source, filename=str(_SESSION_PY))
+
+    prefixes = _extract_prefixes_with_lines(source, tree)
+    assert prefixes, "Could not find _CSRF_EXEMPT_PREFIXES in session.py — check AST walker"
+
+    failures: list[str] = []
+
+    for prefix_value, lineno in prefixes:
+        comments = _preceding_comment_lines(source_lines, lineno)
+
+        if not comments:
+            failures.append(
+                f"  Prefix {prefix_value!r} (line {lineno}): "
+                "no comment found within 5 lines above"
+            )
+            continue
+
+        combined = " ".join(comments)
+
+        has_keyword = any(kw in combined for kw in _RATIONALE_KEYWORDS)
+        has_req_ac = bool(_REQ_AC_PATTERN.search(combined))
+
+        if not has_keyword:
+            failures.append(
+                f"  Prefix {prefix_value!r} (line {lineno}): "
+                f"comment lacks a rationale keyword from {sorted(_RATIONALE_KEYWORDS)}. "
+                f"Found: {combined!r}"
+            )
+        if not has_req_ac:
+            failures.append(
+                f"  Prefix {prefix_value!r} (line {lineno}): "
+                f"comment lacks a REQ-N or AC-N reference. "
+                f"Found: {combined!r}"
+            )
+
+    if failures:
+        pytest.fail(
+            "The following _CSRF_EXEMPT_PREFIXES entries lack inline rationale "
+            "(REQ-4.1 / REQ-4.2 / AC-12):\n"
+            + "\n".join(failures)
+        )

--- a/klai-portal/backend/tests/test_csrf_exempt_rationale.py
+++ b/klai-portal/backend/tests/test_csrf_exempt_rationale.py
@@ -22,12 +22,7 @@ import pytest
 # Configuration
 # ---------------------------------------------------------------------------
 
-_SESSION_PY = (
-    pathlib.Path(__file__).parent.parent
-    / "app"
-    / "middleware"
-    / "session.py"
-)
+_SESSION_PY = pathlib.Path(__file__).parent.parent / "app" / "middleware" / "session.py"
 
 # At least one of these keywords must appear in a preceding comment (AC-12)
 _RATIONALE_KEYWORDS = {
@@ -54,9 +49,7 @@ _REQ_AC_PATTERN = re.compile(r"\b(REQ-\d+(?:\.\d+)?|AC-\d+)\b")
 #   # REQ-4.3 / AC-2
 # The whole comment block is allowed to contain free-form rationale, but the
 # LAST comment line within the lookback window must match this exact shape.
-_CANONICAL_TRAILING_PATTERN = re.compile(
-    r"^#\s*REQ-\d+(?:\.\d+)?\s*/\s*AC-\d+(?:\s*,\s*AC-\d+)*\s*$"
-)
+_CANONICAL_TRAILING_PATTERN = re.compile(r"^#\s*REQ-\d+(?:\.\d+)?\s*/\s*AC-\d+(?:\s*,\s*AC-\d+)*\s*$")
 
 # Maximum number of lines above the literal to search
 _LOOKBACK = 5
@@ -140,10 +133,7 @@ def test_csrf_exempt_prefixes_have_rationale() -> None:
         comments = _preceding_comment_lines(source_lines, lineno)
 
         if not comments:
-            failures.append(
-                f"  Prefix {prefix_value!r} (line {lineno}): "
-                "no comment found within 5 lines above"
-            )
+            failures.append(f"  Prefix {prefix_value!r} (line {lineno}): no comment found within 5 lines above")
             continue
 
         combined = " ".join(comments)
@@ -167,8 +157,7 @@ def test_csrf_exempt_prefixes_have_rationale() -> None:
     if failures:
         pytest.fail(
             "The following _CSRF_EXEMPT_PREFIXES entries lack inline rationale "
-            "(REQ-4.1 / REQ-4.2 / AC-12):\n"
-            + "\n".join(failures)
+            "(REQ-4.1 / REQ-4.2 / AC-12):\n" + "\n".join(failures)
         )
 
 
@@ -198,9 +187,7 @@ def test_csrf_exempt_rationale_format_is_canonical() -> None:
     for prefix_value, lineno in prefixes:
         comments = _preceding_comment_lines(source_lines, lineno)
         if not comments:
-            failures.append(
-                f"  Prefix {prefix_value!r} (line {lineno}): no comment block."
-            )
+            failures.append(f"  Prefix {prefix_value!r} (line {lineno}): no comment block.")
             continue
 
         last_line = comments[-1]
@@ -214,6 +201,5 @@ def test_csrf_exempt_rationale_format_is_canonical() -> None:
     if failures:
         pytest.fail(
             "The following _CSRF_EXEMPT_PREFIXES entries do not end with a "
-            "canonical `# REQ-X.Y / AC-Z` trailing comment line:\n"
-            + "\n".join(failures)
+            "canonical `# REQ-X.Y / AC-Z` trailing comment line:\n" + "\n".join(failures)
         )

--- a/klai-portal/backend/tests/test_csrf_exempt_rationale.py
+++ b/klai-portal/backend/tests/test_csrf_exempt_rationale.py
@@ -47,6 +47,17 @@ _RATIONALE_KEYWORDS = {
 # SPECs that grow more than 9 requirement groups or 99 acceptance criteria).
 _REQ_AC_PATTERN = re.compile(r"\b(REQ-\d+(?:\.\d+)?|AC-\d+)\b")
 
+# Canonical trailing-line format enforced across all entries to prevent
+# review-fatigue drift. Matches lines like:
+#   # REQ-1.2 / AC-2
+#   # REQ-3.1 / AC-9, AC-11
+#   # REQ-4.3 / AC-2
+# The whole comment block is allowed to contain free-form rationale, but the
+# LAST comment line within the lookback window must match this exact shape.
+_CANONICAL_TRAILING_PATTERN = re.compile(
+    r"^#\s*REQ-\d+(?:\.\d+)?\s*/\s*AC-\d+(?:\s*,\s*AC-\d+)*\s*$"
+)
+
 # Maximum number of lines above the literal to search
 _LOOKBACK = 5
 
@@ -157,5 +168,52 @@ def test_csrf_exempt_prefixes_have_rationale() -> None:
         pytest.fail(
             "The following _CSRF_EXEMPT_PREFIXES entries lack inline rationale "
             "(REQ-4.1 / REQ-4.2 / AC-12):\n"
+            + "\n".join(failures)
+        )
+
+
+def test_csrf_exempt_rationale_format_is_canonical() -> None:
+    """REQ-4.1 follow-up: enforce the canonical trailing-line format.
+
+    Each entry's comment block MUST end (within the 5-line lookback) with a
+    standalone line like ``# REQ-X.Y / AC-Z`` or ``# REQ-X.Y / AC-A, AC-B``.
+
+    The free-form rationale lines above are unconstrained; only the trailing
+    line is canonical. This prevents the format drift the reviewer flagged
+    in PR #180 simplify-pass (e.g. mixing ``REQ-1 / AC-2`` with ``REQ-1
+    REQ-4.3 — narrative ... AC-2`` made it impossible to grep for
+    "every entry that references REQ-3.1").
+    """
+    assert _SESSION_PY.exists(), f"session.py not found at {_SESSION_PY}"
+
+    source = _SESSION_PY.read_text(encoding="utf-8")
+    source_lines = source.splitlines()
+    tree = ast.parse(source, filename=str(_SESSION_PY))
+
+    prefixes = _extract_prefixes_with_lines(source, tree)
+    assert prefixes, "Could not find _CSRF_EXEMPT_PREFIXES in session.py"
+
+    failures: list[str] = []
+
+    for prefix_value, lineno in prefixes:
+        comments = _preceding_comment_lines(source_lines, lineno)
+        if not comments:
+            failures.append(
+                f"  Prefix {prefix_value!r} (line {lineno}): no comment block."
+            )
+            continue
+
+        last_line = comments[-1]
+        if not _CANONICAL_TRAILING_PATTERN.match(last_line):
+            failures.append(
+                f"  Prefix {prefix_value!r} (line {lineno}): trailing comment "
+                f"line is not canonical. Expected `# REQ-X.Y / AC-Z` (or "
+                f"`AC-A, AC-B` for multiple ACs). Got: {last_line!r}"
+            )
+
+    if failures:
+        pytest.fail(
+            "The following _CSRF_EXEMPT_PREFIXES entries do not end with a "
+            "canonical `# REQ-X.Y / AC-Z` trailing comment line:\n"
             + "\n".join(failures)
         )

--- a/klai-portal/backend/tests/test_partner_cors.py
+++ b/klai-portal/backend/tests/test_partner_cors.py
@@ -67,9 +67,7 @@ def _make_request(
     return req
 
 
-def _make_db_chain(
-    widget: FakeWidget | None, org: FakeOrg | None, kb_ids: list[int]
-) -> AsyncMock:
+def _make_db_chain(widget: FakeWidget | None, org: FakeOrg | None, kb_ids: list[int]) -> AsyncMock:
     db = AsyncMock()
 
     widget_result = MagicMock()
@@ -120,15 +118,9 @@ async def test_partner_cors_widget_origin_no_credentials() -> None:
     acac = response.headers.get("access-control-allow-credentials", "")
     vary = response.headers.get("vary", "")
 
-    assert acao == "https://customer.example", (
-        f"ACAO must echo https://customer.example, got {acao!r} (AC-9)"
-    )
-    assert acac.lower() != "true", (
-        f"ACAC must NOT be true for widget endpoint, got {acac!r} (AC-9 / REQ-2.2)"
-    )
-    assert "origin" in vary.lower(), (
-        f"Vary must include Origin for cache correctness, got {vary!r} (AC-9 / REQ-2.3)"
-    )
+    assert acao == "https://customer.example", f"ACAO must echo https://customer.example, got {acao!r} (AC-9)"
+    assert acac.lower() != "true", f"ACAC must NOT be true for widget endpoint, got {acac!r} (AC-9 / REQ-2.2)"
+    assert "origin" in vary.lower(), f"Vary must include Origin for cache correctness, got {vary!r} (AC-9 / REQ-2.3)"
 
 
 @pytest.mark.asyncio
@@ -147,21 +139,15 @@ async def test_partner_cors_preflight_no_credentials() -> None:
 
     request = _make_request(origin="https://customer.example")
 
-    response = await widget_config_preflight(
-        id=widget.widget_id, request=request, db=db
-    )
+    response = await widget_config_preflight(id=widget.widget_id, request=request, db=db)
 
     assert response.status_code == 204
 
     acao = response.headers.get("access-control-allow-origin", "")
     acac = response.headers.get("access-control-allow-credentials", "")
 
-    assert acao == "https://customer.example", (
-        f"ACAO must echo origin in preflight, got {acao!r} (AC-9 preflight)"
-    )
-    assert acac.lower() != "true", (
-        f"ACAC must NOT be true in preflight, got {acac!r} (AC-9 / REQ-2.2)"
-    )
+    assert acao == "https://customer.example", f"ACAO must echo origin in preflight, got {acao!r} (AC-9 preflight)"
+    assert acac.lower() != "true", f"ACAC must NOT be true in preflight, got {acac!r} (AC-9 / REQ-2.2)"
 
 
 # ---------------------------------------------------------------------------
@@ -192,17 +178,11 @@ async def test_partner_cors_blocks_unlisted_origin() -> None:
 
         response = await widget_config(id=widget.widget_id, request=request, db=db)
 
-    assert response.status_code == 403, (
-        f"Expected 403 for unlisted origin, got {response.status_code} (AC-10)"
-    )
-    assert b"Origin not allowed" in response.body, (
-        "Response body must contain 'Origin not allowed' (AC-10)"
-    )
+    assert response.status_code == 403, f"Expected 403 for unlisted origin, got {response.status_code} (AC-10)"
+    assert b"Origin not allowed" in response.body, "Response body must contain 'Origin not allowed' (AC-10)"
 
     acao = response.headers.get("access-control-allow-origin", "")
-    assert acao != "https://evil.example", (
-        f"ACAO must NOT echo evil.example, got {acao!r} (AC-10)"
-    )
+    assert acao != "https://evil.example", f"ACAO must NOT echo evil.example, got {acao!r} (AC-10)"
     assert acao != "*", "ACAO must NOT be wildcard (AC-10)"
 
 
@@ -236,6 +216,5 @@ async def test_bff_cookie_rejected_on_partner_endpoint() -> None:
         )
 
     assert exc_info.value.status_code == 401, (
-        f"Expected 401 for cookie-only partner request, "
-        f"got {exc_info.value.status_code} (AC-11)"
+        f"Expected 401 for cookie-only partner request, got {exc_info.value.status_code} (AC-11)"
     )

--- a/klai-portal/backend/tests/test_partner_cors.py
+++ b/klai-portal/backend/tests/test_partner_cors.py
@@ -1,0 +1,241 @@
+"""Partner CORS tests — SPEC-SEC-CORS-001 REQ-2, REQ-3.
+
+Tests AC-9, AC-10, AC-11.
+
+Strategy: test via the actual partner.py handler functions (same approach as
+test_widget_config.py) rather than a full ASGI integration. This avoids the
+Redis + DB setup required for a full TestClient run while still exercising the
+CORS header logic in the handlers and the PartnerCORSMiddleware.
+
+AC-11 tests the get_partner_key dependency directly to confirm it rejects
+cookie-only requests.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.api.partner import widget_config, widget_config_preflight
+
+# ---------------------------------------------------------------------------
+# Shared fixtures (mirror test_widget_config.py)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeWidget:
+    id: str = "widget-uuid-1"
+    org_id: int = 42
+    name: str = "Test widget"
+    description: str | None = None
+    widget_id: str = "wgt_abcdef1234567890abcdef1234567890abcdef12"
+    widget_config: dict = field(
+        default_factory=lambda: {
+            "allowed_origins": ["https://customer.example"],
+            "title": "Chat",
+            "welcome_message": "Hello!",
+            "css_variables": {},
+        }
+    )
+    rate_limit_rpm: int = 60
+    last_used_at: datetime | None = None
+    created_at: datetime = field(default_factory=lambda: datetime(2026, 1, 1, tzinfo=UTC))
+    created_by: str = "test-user"
+
+
+@dataclass
+class FakeOrg:
+    id: int = 42
+    zitadel_org_id: str = "zitadel-org-123"
+
+
+def _make_request(
+    origin: str | None = "https://customer.example",
+    headers_extra: dict[str, str] | None = None,
+) -> MagicMock:
+    req = MagicMock()
+    h: dict[str, str] = {}
+    if origin is not None:
+        h["origin"] = origin
+    if headers_extra:
+        h.update(headers_extra)
+    req.headers = h
+    return req
+
+
+def _make_db_chain(
+    widget: FakeWidget | None, org: FakeOrg | None, kb_ids: list[int]
+) -> AsyncMock:
+    db = AsyncMock()
+
+    widget_result = MagicMock()
+    widget_result.scalar_one_or_none = MagicMock(return_value=widget)
+
+    org_result = MagicMock()
+    org_result.scalar_one_or_none = MagicMock(return_value=org)
+
+    kb_result = MagicMock()
+    kb_scalars = MagicMock()
+    kb_rows = [MagicMock(kb_id=kb_id) for kb_id in kb_ids]
+    kb_scalars.all = MagicMock(return_value=kb_rows)
+    kb_result.scalars = MagicMock(return_value=kb_scalars)
+
+    db.execute = AsyncMock(side_effect=[widget_result, org_result, kb_result])
+    return db
+
+
+# ---------------------------------------------------------------------------
+# AC-9: Widget origin allowed WITHOUT Access-Control-Allow-Credentials
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_partner_cors_widget_origin_no_credentials() -> None:
+    """AC-9: GET /partner/v1/widget-config from customer.example echoes ACAO
+    but MUST NOT include Access-Control-Allow-Credentials: true.
+
+    REQ-2.2 — widget traffic never uses BFF cookies; credentials mode is 'omit'.
+    """
+    widget = FakeWidget()
+    org = FakeOrg()
+    db = _make_db_chain(widget, org, [1, 2])
+    request = _make_request(origin="https://customer.example")
+
+    with (
+        patch("app.api.partner.settings") as mock_settings,
+        patch("app.api.partner.set_tenant", new=AsyncMock()),
+        patch("app.api.partner.generate_session_token", return_value="fake.jwt.token"),
+    ):
+        mock_settings.widget_jwt_secret = "shared-secret"
+
+        response = await widget_config(id=widget.widget_id, request=request, db=db)
+
+    assert response.status_code == 200
+
+    acao = response.headers.get("access-control-allow-origin", "")
+    acac = response.headers.get("access-control-allow-credentials", "")
+    vary = response.headers.get("vary", "")
+
+    assert acao == "https://customer.example", (
+        f"ACAO must echo https://customer.example, got {acao!r} (AC-9)"
+    )
+    assert acac.lower() != "true", (
+        f"ACAC must NOT be true for widget endpoint, got {acac!r} (AC-9 / REQ-2.2)"
+    )
+    assert "origin" in vary.lower(), (
+        f"Vary must include Origin for cache correctness, got {vary!r} (AC-9 / REQ-2.3)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_partner_cors_preflight_no_credentials() -> None:
+    """AC-9 preflight: OPTIONS /partner/v1/widget-config from customer.example
+    echoes ACAO but NOT ACAC.
+
+    REQ-2.2 — preflight handler must not set Access-Control-Allow-Credentials.
+    """
+    widget = FakeWidget()
+    db = AsyncMock()
+
+    widget_result = MagicMock()
+    widget_result.scalar_one_or_none = MagicMock(return_value=widget)
+    db.execute = AsyncMock(return_value=widget_result)
+
+    request = _make_request(origin="https://customer.example")
+
+    response = await widget_config_preflight(
+        id=widget.widget_id, request=request, db=db
+    )
+
+    assert response.status_code == 204
+
+    acao = response.headers.get("access-control-allow-origin", "")
+    acac = response.headers.get("access-control-allow-credentials", "")
+
+    assert acao == "https://customer.example", (
+        f"ACAO must echo origin in preflight, got {acao!r} (AC-9 preflight)"
+    )
+    assert acac.lower() != "true", (
+        f"ACAC must NOT be true in preflight, got {acac!r} (AC-9 / REQ-2.2)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-10: Unlisted origin returns 403 + no ACAO
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_partner_cors_blocks_unlisted_origin() -> None:
+    """AC-10: GET /partner/v1/widget-config from evil.example returns 403
+    and does NOT echo ACAO.
+
+    REQ-2.1 — origin not in widget's allowed_origins list.
+    """
+    widget = FakeWidget()  # allowed_origins = ["https://customer.example"]
+    db = AsyncMock()
+
+    widget_result = MagicMock()
+    widget_result.scalar_one_or_none = MagicMock(return_value=widget)
+    db.execute = AsyncMock(return_value=widget_result)
+
+    request = _make_request(origin="https://evil.example")
+
+    with (
+        patch("app.api.partner.settings") as mock_settings,
+    ):
+        mock_settings.widget_jwt_secret = "shared-secret"
+
+        response = await widget_config(id=widget.widget_id, request=request, db=db)
+
+    assert response.status_code == 403, (
+        f"Expected 403 for unlisted origin, got {response.status_code} (AC-10)"
+    )
+    assert b"Origin not allowed" in response.body, (
+        "Response body must contain 'Origin not allowed' (AC-10)"
+    )
+
+    acao = response.headers.get("access-control-allow-origin", "")
+    assert acao != "https://evil.example", (
+        f"ACAO must NOT echo evil.example, got {acao!r} (AC-10)"
+    )
+    assert acao != "*", "ACAO must NOT be wildcard (AC-10)"
+
+
+# ---------------------------------------------------------------------------
+# AC-11: BFF session cookie is rejected on partner endpoint (no Bearer token)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bff_cookie_rejected_on_partner_endpoint() -> None:
+    """AC-11: POST /partner/v1/chat/completions with ONLY a BFF cookie returns 401.
+
+    REQ-3.1 — partner endpoints do NOT accept BFF session cookies as auth.
+    The get_partner_key dependency rejects missing Bearer tokens with 401.
+    """
+    from fastapi import HTTPException
+
+    from app.api.partner_dependencies import get_partner_key
+
+    # Simulate a request with ONLY a cookie header, no Authorization
+    request = MagicMock()
+    request.headers = {"cookie": "klai_bff_session=some-valid-sid"}
+    request.state = MagicMock()
+
+    db = AsyncMock()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_partner_key(
+            request=request,
+            db=db,
+        )
+
+    assert exc_info.value.status_code == 401, (
+        f"Expected 401 for cookie-only partner request, "
+        f"got {exc_info.value.status_code} (AC-11)"
+    )

--- a/klai-retrieval-api/retrieval_api/main.py
+++ b/klai-retrieval-api/retrieval_api/main.py
@@ -8,6 +8,7 @@ from contextlib import asynccontextmanager
 import httpx
 from fastapi import FastAPI
 from prometheus_client import make_asgi_app
+from starlette.middleware.cors import CORSMiddleware
 
 from retrieval_api.api.chat import router as chat_router
 from retrieval_api.api.retrieve import router as retrieve_router
@@ -57,12 +58,35 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(title="retrieval-api", version="1.0.0", lifespan=lifespan)
-# SPEC-SEC-010 REQ-1.4: Starlette middleware runs in LIFO order — the last-added
-# middleware is the OUTERMOST and runs FIRST. We want RequestContextMiddleware to
-# bind `request_id` on the structlog context BEFORE AuthMiddleware emits its first
-# log line, so add AuthMiddleware first (inner) then RequestContextMiddleware (outer).
+
+# Middleware registration order: last-added runs FIRST on the request
+# (Starlette LIFO — see .claude/rules/klai/lang/python.md and
+# SPEC-SEC-CORS-001 REQ-7). Desired execution: CORS (outermost, wraps 401
+# with CORS headers, handles preflight) -> RequestContext (logging) ->
+# Auth (reject missing header) -> route. So we register in reverse:
+# Auth, RequestContext, CORS.
+#
+# Deny-by-default starter — retrieval-api is on klai-net only today (no
+# Caddy route), but a future browser exposure would silently inherit no
+# CORS policy and immediately be cross-origin-credentialed-probable.
+# SPEC-SEC-CORS-001 REQ-7 forces an explicit empty allowlist now so that
+# any future Caddy exposure must update the allowlist explicitly.
+
+# SPEC-SEC-010 REQ-1.4: AuthMiddleware first (innermost); RequestContext
+# wraps it so request_id is bound before AuthMiddleware emits its first log.
 app.add_middleware(AuthMiddleware)
 app.add_middleware(RequestContextMiddleware)
+
+# CORSMiddleware registered LAST (outermost) per SPEC-SEC-CORS-001 REQ-7.
+# Empty allowlist = deny-by-default; allow_credentials=False for safety.
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[],
+    allow_origin_regex=None,
+    allow_credentials=False,
+    allow_methods=[],
+    allow_headers=[],
+)
 app.include_router(retrieve_router, prefix="")
 app.include_router(chat_router, prefix="")
 

--- a/klai-retrieval-api/tests/test_cors_presence.py
+++ b/klai-retrieval-api/tests/test_cors_presence.py
@@ -1,0 +1,215 @@
+"""SPEC-SEC-CORS-001 AC-16 + AC-17: deny-by-default CORSMiddleware in retrieval-api.
+
+AC-16: CORSMiddleware MUST be registered in retrieval_api.main and MUST be the
+       LAST add_middleware call (outermost layer per Starlette LIFO).
+       Verified by both static source inspection and runtime introspection.
+
+AC-17: With an empty allowlist, the retrieval-api MUST NOT echo
+       Access-Control-Allow-Origin for ANY origin (deny-by-default).
+       Verified by OPTIONS preflight probes against the test client.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.testclient import TestClient
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_MAIN_PY = Path(__file__).parent.parent / "retrieval_api" / "main.py"
+
+
+# ---------------------------------------------------------------------------
+# AC-16 static: grep-based source order assertion
+# ---------------------------------------------------------------------------
+
+
+class TestCorsPresenceStatic:
+    """AC-16 static-check variant: scan main.py source for CORSMiddleware."""
+
+    def test_cors_middleware_call_present(self) -> None:
+        """A CORSMiddleware add_middleware call must appear exactly once in main.py.
+
+        The call may be multi-line (``app.add_middleware(\\nCORSMiddleware,``),
+        so we check the call-start line plus the immediately following code line.
+        We skip comment lines and blank lines when looking for the class name so
+        that comment windows do not produce false positives.
+        """
+        src = _MAIN_PY.read_text(encoding="utf-8")
+        lines = src.splitlines()
+
+        cors_add_calls = 0
+        for i, line in enumerate(lines):
+            stripped = line.strip()
+            if stripped.startswith("app.add_middleware("):
+                # Check the line itself (single-line call) …
+                if "CORSMiddleware" in stripped:
+                    cors_add_calls += 1
+                    continue
+                # … or the next non-blank, non-comment code line (multi-line call).
+                for j in range(i + 1, min(i + 4, len(lines))):
+                    next_stripped = lines[j].strip()
+                    if not next_stripped or next_stripped.startswith("#"):
+                        continue  # skip blanks and comments
+                    if "CORSMiddleware" in next_stripped:
+                        cors_add_calls += 1
+                    break  # only the immediate next code line counts
+
+        assert cors_add_calls == 1, (
+            f"Expected exactly 1 app.add_middleware(CORSMiddleware call, found {cors_add_calls}. "
+            "Add deny-by-default CORSMiddleware per SPEC-SEC-CORS-001 REQ-7.1."
+        )
+
+    def test_cors_is_last_add_middleware_call(self) -> None:
+        """No app.add_middleware() call must appear AFTER the CORSMiddleware call.
+
+        Multi-line calls are handled: we join up to 3 consecutive lines starting
+        from each ``app.add_middleware(`` occurrence.
+        """
+        src = _MAIN_PY.read_text(encoding="utf-8")
+        lines = src.splitlines()
+
+        add_middleware_calls: list[tuple[int, str]] = []
+        for i, line in enumerate(lines):
+            stripped = line.strip()
+            if stripped.startswith("app.add_middleware("):
+                joined = " ".join(lines[i : i + 3])
+                add_middleware_calls.append((i, joined))
+
+        assert add_middleware_calls, "No app.add_middleware(...) calls found in main.py"
+
+        last_lineno, last_call = add_middleware_calls[-1]
+        assert "CORSMiddleware" in last_call, (
+            f"Last app.add_middleware call (line {last_lineno + 1}) must be "
+            f"CORSMiddleware, but found: {last_call!r}. "
+            "Reorder so CORSMiddleware is the last (outermost) middleware per "
+            "SPEC-SEC-CORS-001 REQ-7.2."
+        )
+
+    def test_cors_uses_empty_allowlist(self) -> None:
+        """The CORSMiddleware registration must use allow_origins=[] (deny-by-default)."""
+        src = _MAIN_PY.read_text(encoding="utf-8")
+        assert "allow_origins=[]" in src, (
+            "CORSMiddleware must be configured with allow_origins=[] for deny-by-default "
+            "stance (SPEC-SEC-CORS-001 REQ-7.2)."
+        )
+
+    def test_cors_disables_credentials(self) -> None:
+        """The CORSMiddleware registration must set allow_credentials=False."""
+        src = _MAIN_PY.read_text(encoding="utf-8")
+        assert "allow_credentials=False" in src, (
+            "CORSMiddleware must set allow_credentials=False for deny-by-default "
+            "stance (SPEC-SEC-CORS-001 REQ-7.2)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-16 runtime: app.user_middleware introspection
+# ---------------------------------------------------------------------------
+
+
+class TestCorsPresenceRuntime:
+    """AC-16 runtime variant: inspect app.user_middleware after module import."""
+
+    def test_cors_middleware_registered(self) -> None:
+        """app.user_middleware contains exactly one CORSMiddleware entry."""
+        from retrieval_api.main import app
+
+        cors_entries = [m for m in app.user_middleware if m.cls is CORSMiddleware]
+        assert len(cors_entries) == 1, (
+            f"Expected 1 CORSMiddleware in app.user_middleware, found {len(cors_entries)}."
+        )
+
+    def test_cors_is_first_in_user_middleware(self) -> None:
+        """CORSMiddleware is the first entry in app.user_middleware.
+
+        Starlette stores user_middleware in reverse-registration order, so the
+        LAST added middleware appears FIRST in app.user_middleware.
+        """
+        from retrieval_api.main import app
+
+        assert app.user_middleware, "app.user_middleware is empty — no middleware registered"
+        first_entry = app.user_middleware[0]
+        assert first_entry.cls is CORSMiddleware, (
+            f"First entry in app.user_middleware must be CORSMiddleware (last added, "
+            f"i.e. outermost). Found: {first_entry.cls}."
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-17: OPTIONS preflight probes — deny-by-default for all origins
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def retrieval_client() -> TestClient:
+    """TestClient without any default auth headers — we are testing CORS policy."""
+    from retrieval_api.main import app
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestCorsOptionsProbes:
+    """AC-17: No origin receives Access-Control-Allow-Origin from retrieval-api."""
+
+    @pytest.mark.parametrize(
+        "origin",
+        [
+            "https://my.getklai.com",
+            "http://localhost:5174",
+            "https://customer.example",
+            "https://evil.example",
+        ],
+    )
+    def test_options_preflight_returns_no_acao(
+        self,
+        retrieval_client: TestClient,
+        origin: str,
+    ) -> None:
+        """OPTIONS preflight MUST NOT return Access-Control-Allow-Origin for any origin."""
+        resp = retrieval_client.options(
+            "/retrieve",
+            headers={
+                "Origin": origin,
+                "Access-Control-Request-Method": "POST",
+            },
+        )
+        acao = resp.headers.get("access-control-allow-origin")
+        assert acao is None or acao == "", (
+            f"retrieval-api must not echo ACAO for origin {origin!r} "
+            f"(deny-by-default per SPEC-SEC-CORS-001 REQ-7.2). Got: {acao!r}"
+        )
+
+    @pytest.mark.parametrize(
+        "origin",
+        [
+            "https://my.getklai.com",
+            "http://localhost:5174",
+            "https://customer.example",
+            "https://evil.example",
+        ],
+    )
+    def test_options_preflight_returns_no_acac(
+        self,
+        retrieval_client: TestClient,
+        origin: str,
+    ) -> None:
+        """OPTIONS preflight MUST NOT return Access-Control-Allow-Credentials: true."""
+        resp = retrieval_client.options(
+            "/retrieve",
+            headers={
+                "Origin": origin,
+                "Access-Control-Request-Method": "POST",
+            },
+        )
+        acac = resp.headers.get("access-control-allow-credentials", "").lower()
+        assert acac != "true", (
+            f"retrieval-api must not return Access-Control-Allow-Credentials: true "
+            f"for origin {origin!r} (deny-by-default per SPEC-SEC-CORS-001 REQ-7.4). "
+            f"Got: {acac!r}"
+        )

--- a/rules/cors_middleware_last.yml
+++ b/rules/cors_middleware_last.yml
@@ -1,0 +1,81 @@
+# SPEC-SEC-CORS-001 REQ-6 — CORSMiddleware MUST be the LAST add_middleware call
+# in every klai FastAPI service entry module.
+#
+# Why: Starlette registers middlewares in REVERSE execution order. The last
+# add_middleware call is the OUTERMOST middleware on the response. If
+# CORSMiddleware is not the last one, error responses emitted by inner
+# auth/session middleware bypass CORS and cross-origin browsers see opaque
+# failures. See:
+#   .claude/rules/klai/lang/python.md — "Starlette middleware registration order"
+#   SPEC-SEC-CORS-001 REQ-6 (defense-in-depth lint enforcement)
+#
+# Special case — knowledge-mcp uses `mcp.streamable_http_app()` from FastMCP and
+# has no `app.add_middleware(...)` call site. The rule cannot match anything
+# there; the lint step is wired into klai-knowledge-mcp.yml for symmetry but
+# passes trivially. Same applies to any service that registers no middleware
+# at all (knowledge-ingest, klai-mailer today).
+#
+# Why the rule has TWO branches under `any:`:
+# (1) The simple sibling case — CORS and the next add_middleware are both
+#     module-level (or both inside the same function body). ast-grep's
+#     relational `precedes` walks siblings within a shared parent.
+# (2) The nested-if case — klai-connector wraps CORSMiddleware registration in
+#     `if allowed_origins:` while Auth/RequestContext stay at function scope.
+#     The `inside: { kind: if_statement, ... }` clause walks UP from the CORS
+#     call to the enclosing if/with/try block, then `precedes:` looks for any
+#     subsequent add_middleware sibling at the surrounding scope.
+# Both branches exit non-zero on the same logical bug; only one needs to fire.
+
+id: cors-middleware-must-be-last
+language: python
+severity: error
+message: |
+  CORSMiddleware MUST be the last `app.add_middleware(...)` call in this file.
+  Another `add_middleware(...)` call appears AFTER CORSMiddleware in source order,
+  which means it is OUTER to CORS at runtime. Errors emitted by that outer
+  middleware bypass CORS and cross-origin browsers see opaque network failures.
+  Move the CORSMiddleware registration to be the LAST `add_middleware(...)`
+  call in this module.
+  See SPEC-SEC-CORS-001 REQ-6 and .claude/rules/klai/lang/python.md.
+
+rule:
+  any:
+    # Branch 1: CORS and the next add_middleware are siblings in the same scope.
+    - kind: expression_statement
+      has:
+        pattern: $APP.add_middleware(CORSMiddleware, $$$ARGS)
+      precedes:
+        kind: expression_statement
+        has:
+          pattern: $APP.add_middleware($$$REST)
+        stopBy: end
+    # Branch 2: CORS is wrapped in an if/with/try block; the next add_middleware
+    # lives at the enclosing scope.
+    - kind: expression_statement
+      has:
+        pattern: $APP.add_middleware(CORSMiddleware, $$$ARGS)
+      inside:
+        any:
+          - kind: if_statement
+          - kind: with_statement
+          - kind: try_statement
+        stopBy: end
+        precedes:
+          kind: expression_statement
+          has:
+            pattern: $APP.add_middleware($$$REST)
+          stopBy: end
+
+# REQ-6.3 — services listed in the SPEC (entry modules) plus lint test fixtures.
+# Each service's entry module is checked against this rule on every PR that
+# touches it; see .github/workflows/<service>.yml for the per-service wiring.
+files:
+  - klai-portal/backend/app/main.py
+  - klai-connector/app/main.py
+  - klai-retrieval-api/retrieval_api/main.py
+  - klai-scribe/scribe-api/app/main.py
+  - klai-knowledge-ingest/knowledge_ingest/app.py
+  - klai-mailer/app/main.py
+  - klai-knowledge-mcp/main.py
+  - klai-focus/research-api/app/main.py
+  - rules/tests/fixtures/*.py

--- a/rules/tests/fixtures/bad_middleware_order.py
+++ b/rules/tests/fixtures/bad_middleware_order.py
@@ -1,0 +1,16 @@
+# Fixture for SPEC-SEC-CORS-001 AC-18 — synthetic regression that the
+# `cors-middleware-must-be-last` rule MUST flag. CORSMiddleware is registered
+# BEFORE another `add_middleware` call, which puts it inside (= not outermost).
+
+from fastapi import FastAPI
+from starlette.middleware.cors import CORSMiddleware
+
+
+class AuthMiddleware: ...
+
+
+app = FastAPI()
+
+# Bad: CORS first, Auth after — CORS ends up INNER to Auth.
+app.add_middleware(CORSMiddleware, allow_origins=[])
+app.add_middleware(AuthMiddleware)

--- a/rules/tests/fixtures/bad_middleware_order_nested.py
+++ b/rules/tests/fixtures/bad_middleware_order_nested.py
@@ -1,0 +1,22 @@
+# Fixture for SPEC-SEC-CORS-001 AC-18 — second synthetic regression that
+# exercises the nested-if branch of the rule. CORSMiddleware is registered
+# inside an `if` block while Auth/RequestContext live at the enclosing scope.
+# This is the exact pattern klai-connector had today before REQ-6.4 fixed it.
+
+from fastapi import FastAPI
+from starlette.middleware.cors import CORSMiddleware
+
+
+class AuthMiddleware: ...
+
+
+class RequestContextMiddleware: ...
+
+
+def create_app(allowed_origins: list[str]) -> FastAPI:
+    app = FastAPI()
+    if allowed_origins:
+        app.add_middleware(CORSMiddleware, allow_origins=allowed_origins)
+    app.add_middleware(AuthMiddleware)
+    app.add_middleware(RequestContextMiddleware)
+    return app

--- a/rules/tests/fixtures/good_middleware_order.py
+++ b/rules/tests/fixtures/good_middleware_order.py
@@ -1,0 +1,16 @@
+# Fixture for SPEC-SEC-CORS-001 AC-18 — canonical correct registration order.
+# CORSMiddleware is the LAST `add_middleware(...)` call → outermost at runtime →
+# CORS headers wrap every response including 401s emitted by inner middlewares.
+
+from fastapi import FastAPI
+from starlette.middleware.cors import CORSMiddleware
+
+
+class AuthMiddleware: ...
+
+
+app = FastAPI()
+
+# Good: register inner first, CORS last so it becomes the outermost wrapper.
+app.add_middleware(AuthMiddleware)
+app.add_middleware(CORSMiddleware, allow_origins=[])

--- a/rules/tests/test_cors_middleware_last_lint.py
+++ b/rules/tests/test_cors_middleware_last_lint.py
@@ -1,0 +1,156 @@
+"""SPEC-SEC-CORS-001 AC-18 — synthetic regression tests for the
+`cors-middleware-must-be-last` ast-grep rule.
+
+The rule lives at `rules/cors_middleware_last.yml` and is discovered via the
+repo-root `sgconfig.yml`. We invoke ast-grep directly (via `uvx --from
+ast-grep-cli ast-grep`) on two fixture files:
+
+- `fixtures/bad_middleware_order.py` — registers CORSMiddleware BEFORE another
+  add_middleware. The lint MUST exit non-zero and name the fixture file.
+- `fixtures/good_middleware_order.py` — registers CORSMiddleware LAST. The
+  lint MUST exit zero.
+
+We also assert the per-service CI workflow files include an `ast-grep/action`
+step so the lint runs on every PR that touches a listed entry module
+(REQ-6.3).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RULES_DIR = REPO_ROOT / "rules"
+FIXTURES_DIR = RULES_DIR / "tests" / "fixtures"
+SGCONFIG = REPO_ROOT / "sgconfig.yml"
+
+# REQ-6.3 — every klai FastAPI service whose entry module is in scope of the
+# lint. The CI workflow wiring assertion (AC-18 "CI wiring" clause) checks
+# that each of these workflow files declares the ast-grep step.
+SERVICE_WORKFLOW_FILES = [
+    ".github/workflows/portal-api.yml",
+    ".github/workflows/klai-connector.yml",
+    ".github/workflows/retrieval-api.yml",
+    ".github/workflows/scribe-api.yml",
+    ".github/workflows/knowledge-ingest.yml",
+    ".github/workflows/klai-mailer.yml",
+    ".github/workflows/klai-knowledge-mcp.yml",
+]
+
+
+def _ast_grep_cli() -> list[str] | None:
+    """Resolve the ast-grep CLI invocation.
+
+    Prefers a system-installed `sg` or `ast-grep`; falls back to
+    `uvx --from ast-grep-cli ast-grep` so the test works in CI without an
+    explicit install step.
+    """
+    if (sg := shutil.which("sg")) is not None:
+        return [sg]
+    if (ag := shutil.which("ast-grep")) is not None:
+        return [ag]
+    if (uvx := shutil.which("uvx")) is not None:
+        return [uvx, "--from", "ast-grep-cli", "ast-grep"]
+    return None
+
+
+@pytest.fixture(scope="module")
+def ast_grep_cli() -> list[str]:
+    cli = _ast_grep_cli()
+    if cli is None:
+        pytest.skip("ast-grep CLI not available (no `sg`, `ast-grep`, or `uvx`)")
+    return cli
+
+
+def _scan(cli: list[str], target: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [*cli, "scan", "--config", str(SGCONFIG), str(target)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        "bad_middleware_order.py",  # branch 1 — sibling at module level
+        "bad_middleware_order_nested.py",  # branch 2 — CORS inside if-block
+    ],
+)
+def test_lint_fails_on_bad_fixture(ast_grep_cli: list[str], fixture_name: str) -> None:
+    """AC-18: the rule MUST flag CORSMiddleware-not-last regressions, both at
+    the simple sibling case AND the nested-if case (connector pattern).
+    """
+    fixture = FIXTURES_DIR / fixture_name
+    assert fixture.exists(), fixture
+    result = _scan(ast_grep_cli, fixture)
+
+    combined = result.stdout + result.stderr
+    assert result.returncode != 0, (
+        f"Lint did not fail on {fixture_name} (exit {result.returncode}). "
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert fixture_name in combined, (
+        f"Lint output does not name {fixture_name}. Output:\n{combined}"
+    )
+    assert "cors-middleware-must-be-last" in combined, (
+        f"Lint output does not reference rule id. Output:\n{combined}"
+    )
+
+
+def test_lint_passes_on_good_fixture(ast_grep_cli: list[str]) -> None:
+    """AC-18: the rule MUST NOT flag the canonical correct order."""
+    fixture = FIXTURES_DIR / "good_middleware_order.py"
+    assert fixture.exists(), fixture
+    result = _scan(ast_grep_cli, fixture)
+
+    assert result.returncode == 0, (
+        f"Lint failed unexpectedly on good fixture (exit {result.returncode}). "
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+@pytest.mark.parametrize("workflow_path", SERVICE_WORKFLOW_FILES)
+def test_workflow_wires_ast_grep_lint(workflow_path: str) -> None:
+    """AC-18 (CI wiring): each in-scope service workflow must declare an
+    `ast-grep/action` step that targets the cors_middleware_last rule via
+    `sgconfig.yml`. We do not pin the exact action SHA here — only that the
+    step exists and references `sgconfig.yml`.
+    """
+    full_path = REPO_ROOT / workflow_path
+    assert full_path.exists(), f"workflow file missing: {workflow_path}"
+
+    data = yaml.safe_load(full_path.read_text())
+    assert isinstance(data, dict), workflow_path
+
+    jobs = data.get("jobs") or {}
+    assert jobs, f"no jobs declared in {workflow_path}"
+
+    found_ast_grep_step = False
+    for job_id, job in jobs.items():
+        if not isinstance(job, dict):
+            continue
+        for step in job.get("steps", []) or []:
+            uses = (step or {}).get("uses", "")
+            if not isinstance(uses, str) or "ast-grep/action" not in uses:
+                continue
+            with_block = (step or {}).get("with", {}) or {}
+            config = with_block.get("config", "")
+            if "sgconfig.yml" in str(config):
+                found_ast_grep_step = True
+                break
+        if found_ast_grep_step:
+            break
+
+    assert found_ast_grep_step, (
+        f"{workflow_path}: no ast-grep/action step found that references "
+        "sgconfig.yml. SPEC-SEC-CORS-001 REQ-6.3 requires the lint to run "
+        "on every PR that modifies the service's entry module."
+    )


### PR DESCRIPTION
## Summary

Implements SPEC-SEC-CORS-001 (priority: critical). Replaces the credentialed wildcard CORS regex (`r".*"` + `allow_credentials=True`) in portal-api with an explicit first-party allowlist, splits widget partner traffic onto a non-credentialed CORS policy, audits and annotates every entry in `_CSRF_EXEMPT_PREFIXES`, fixes klai-connector's middleware-order inversion (401s now carry CORS), adds a deny-by-default CORS starter for klai-retrieval-api, and ships a repo-wide ast-grep lint that mechanically prevents the same regression class across all 8 klai FastAPI services.

Address: Cornelis audit 2026-04-22 finding #1 (CRITICAL) + finding #17 (HIGH) + Phase 1 Verification B (REQ-6.7 portal-api self-fix) + Phase 1 Verification K (compose env-var pre-flight).

## Why now

Two BLOCKING audit findings: wildcard CORS regex + CSRF-exempt login endpoints combined to enable cross-origin credentialed probing of any CSRF-exempt path with a victim's BFF session cookie. The narrowed allowlist + the partner cookie-less policy + the rationale-documented CSRF exemptions remove the probing surface.

## Scope

7 requirement groups, 18 acceptance criteria, 5 commits.

| Commit | Subject |
|---|---|
| `02c5790e` | docs(spec): SPEC-SEC-CORS-001 v0.4.0 — promote draft, add REQ-6.7, fold pre-flight findings |
| `a01f1a3a` | feat(lint): SPEC-SEC-CORS-001 REQ-6 — CORSMiddleware-must-be-last ast-grep rule + per-service CI wiring |
| `798ab59d` | feat(portal-api): SPEC-SEC-CORS-001 REQ-1..REQ-4 + REQ-6.7 — explicit CORS allowlist, partner cookie-less policy, CSRF rationale |
| `a15ba30a` | feat(connector,retrieval-api): SPEC-SEC-CORS-001 REQ-6.4 + REQ-7 — middleware reorder + deny-by-default starter |
| `e3fe09ef` | chore(infra): bump klai-infra submodule for CORS_ORIGINS env var |

Files changed: 33 in this PR (32 SPEC-CORS-001 files + 1 submodule pointer bump).

## Acceptance criteria (all 18)

| AC | Status | Test file |
|---|---|---|
| AC-1..AC-8 (REQ-1 portal allowlist) | PASS | `klai-portal/backend/tests/test_cors_allowlist.py` (26 tests) |
| AC-9, AC-10 (REQ-2 partner CORS) | PASS | `klai-portal/backend/tests/test_partner_cors.py` |
| AC-11 (REQ-3.1 cookie rejection) | PASS | `klai-portal/backend/tests/test_partner_cors.py` |
| AC-12 (REQ-4 CSRF rationale lint) | PASS | `klai-portal/backend/tests/test_csrf_exempt_rationale.py` |
| AC-13 (NFR observability) | PASS | `klai-portal/backend/tests/test_cors_allowlist.py` |
| AC-14 (NFR fail-closed startup) | PASS | `klai-portal/backend/tests/test_cors_allowlist.py` |
| AC-15 (REQ-6.4 connector 401 carries CORS) | PASS | `klai-connector/tests/test_cors_middleware_order.py` |
| AC-16 (REQ-7 retrieval-api CORSMiddleware present) | PASS | `klai-retrieval-api/tests/test_cors_presence.py` |
| AC-17 (REQ-7 deny-by-default verified) | PASS | `klai-retrieval-api/tests/test_cors_presence.py` |
| AC-18 (REQ-6.2/REQ-6.3 lint + CI wiring) | PASS | `rules/tests/test_cors_middleware_last_lint.py` |

## Test plan

- [x] portal-api full suite: 1179 pass / 0 fail
- [x] klai-connector new tests: 5 pass (pre-existing 11 unrelated failures stay)
- [x] klai-retrieval-api new tests: 14 pass (pre-existing 7 unrelated failures stay)
- [x] rules/tests lint unit tests: 10 pass (3 fixture branches + 7 workflow wirings)
- [x] ast-grep `cors_middleware_last.yml` lint exits 0 on all 8 in-scope service entry modules
- [x] ruff clean on all modified files
- [x] Compose env-var preflight: `CORS_ORIGINS: ${CORS_ORIGINS:-https://my.${DOMAIN}}` added to portal-api block before REQ-1 narrows the allowlist
- [x] SOPS preflight: `CORS_ORIGINS=https://my.getklai.com` added to `klai-infra/core-01/.env.sops` (klai-infra commit 4a27983) BEFORE this PR merges (validator-env-parity, HIGH)

## Cross-service rollout — what happens after merge

1. GitHub Actions on klai-infra:main already deployed `CORS_ORIGINS=https://my.getklai.com` to `/opt/klai/.env` on core-01 (independent of this PR).
2. Merging this PR builds new portal-api / klai-connector / klai-retrieval-api images.
3. The 6 new ast-grep workflow steps gate every future PR touching any of: `klai-portal/backend/app/main.py`, `klai-connector/app/main.py`, `klai-retrieval-api/retrieval_api/main.py`, `klai-scribe/scribe-api/app/main.py`, `klai-knowledge-ingest/knowledge_ingest/app.py`, `klai-mailer/app/main.py`, `klai-knowledge-mcp/main.py`.
4. Post-deploy: confirm `docker exec klai-core-portal-api-1 printenv CORS_ORIGINS` returns `https://my.getklai.com`.
5. VictoriaLogs 7-day monitoring window: `event:"cors_origin_rejected" AND NOT origin:/.*getklai\.com/` should return zero hits. Demote alert to dashboard after 7 zero-hit days.

## Out of scope (deliberately deferred)

- SameSite=Strict cookie migration (broader OAuth callback impact)
- Per-widget CORS signing or CSRF tokens (Bearer JWT is sufficient)
- Caddy-level CORS (portal-api remains the single source of truth)
- Expanding klai-retrieval-api's allowlist (REQ-7 deliberately ships deny-by-default; first browser route gets a follow-up SPEC)
- klai-scribe / klai-focus regex narrowing (same single-label-only weakness as portal — separate SPEC)
- Lifting `FakeWidget`/`FakeOrg` test fixtures into a shared module (would touch out-of-scope `test_widget_config.py`)

## Reviewer notes

- Phase 1 verification surfaced two discrepancies with research.md: portal-api CORS was NOT actually outermost (line 180 + lines 199, 203 followed) — fixed via REQ-6.7. Compose env block did not pass CORS_ORIGINS — fixed via T-000A.bis. Both folded into the implementation plan.
- `KlaiCORSMiddleware` is a new minimal subclass-equivalent of Starlette CORS, NOT a fork — adds two things: rejection logging via structlog (AC-13) and fail-closed startup on bad regex (AC-14).
- Lint rule has TWO branches: simple sibling case + nested-if case (klai-connector pattern, where CORS lived inside `if allowed_origins:`). Both branches needed for correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)