### PR TITLE
fix(portal-api,sec): MFA fail-closed (SPEC-SEC-MFA-001)

### DIFF
--- a/.moai/specs/SPEC-SEC-MFA-001/progress.md
+++ b/.moai/specs/SPEC-SEC-MFA-001/progress.md
@@ -59,6 +59,26 @@
 - docs/runbooks/mfa-check-failed.md — NEW
 - .moai/specs/SPEC-SEC-MFA-001/{progress.md,tasks.md} — workflow tracking
 
+### Polish pass (2026-04-27)
+
+After the initial commit (623e4aa6) a self-review surfaced two nits + one
+documentation gap; all addressed in a follow-up commit on the same branch:
+
+1. **Logger consistency** — `has_totp_check_failed` warning switched from
+   stdlib `logger.warning` to `_slog.warning` to honour
+   `.claude/rules/klai/projects/portal-logging-py.md`'s "structlog for new
+   log statements" rule.
+2. **Orphan PortalOrg FK** — added explicit branch in
+   `_resolve_and_enforce_mfa` for `portal_user is not None and org is None`
+   (the org row was deleted/soft-deleted while the FK still pointed at it).
+   Pre-existing behaviour silently fell back to `mfa_policy="optional"`;
+   we keep fail-open semantics but emit `mfa_check_failed` warning so the
+   data-integrity bug is observable in Grafana.
+3. **Coverage gap (REQ-5.6)** — explicitly documented as a deferred
+   follow-up below; no code change.
+
+New test added: `test_portal_user_orphan_org_proceeds_documented_fail_open`.
+
 ### Known limitations / deferred
 
 - **Coverage gap on auth.py overall (64% vs SPEC's 85% target)**: The gap is
@@ -67,13 +87,14 @@
   modules. Closing the gap requires testing untouched endpoints — out of
   scope for SPEC-SEC-MFA-001 per the `minimal-changes` pitfall. The MFA
   enforcement block itself (the SPEC's actual concern) has full branch
-  coverage.
+  coverage. Recommended follow-up: track in a separate SPEC for `auth.py`
+  coverage hardening (TOTP setup, IDP intent, password reset, sso_complete).
 - **Submodule pin bump (T-013)**: not required — Grafana provisioning is in
   the superproject, not in klai-infra.
 
 ### Verification
 
-- pytest tests/test_auth_mfa_fail_closed.py tests/test_auth_security.py: 22/22 passed
-- pytest (full backend): 1156 passed
+- pytest tests/test_auth_mfa_fail_closed.py tests/test_auth_security.py: 23/23 passed
+- pytest (full backend): 1160 passed
 - uv run ruff check app/api/auth.py tests/...: clean
 - uv run --with pyright pyright app/api/auth.py: 0/0/0

--- a/.moai/specs/SPEC-SEC-MFA-001/progress.md
+++ b/.moai/specs/SPEC-SEC-MFA-001/progress.md
@@ -1,0 +1,79 @@
+## SPEC-SEC-MFA-001 Progress
+
+- Started: 2026-04-25
+- Branch: feature/SPEC-SEC-MFA-001 (worktree at ~/.moai/worktrees/klai/SPEC-SEC-MFA-001)
+- Base: origin/main @ 19dcf997 (Merge PR #175)
+- Mode: TDD (per quality.yaml development_mode)
+- Harness level: thorough (security domain + auth keyword)
+- Scale-based mode: Standard (≈8 files, 3 domains: backend/tests/infra/docs)
+
+### Phase log
+
+- Phase 0.9 (JIT language detection): Python 3.13 (klai-portal/backend pyproject.toml)
+- Phase 0.95 (mode select): Standard Mode — multi-domain feature, sub-agent solo
+- Phase 1 (strategy): Approved by user 2026-04-25
+  - Research validated against live code: 3 fail-open holes intact at expected line ranges
+  - Adjustment 1: respx not in pyproject.toml (added respx>=0.22 to dev deps)
+  - Adjustment 2: klai-infra is a git submodule but Grafana provisioning lives in
+    deploy/grafana/provisioning/alerting/ in the SUPERPROJECT; no submodule pin bump
+    required after all (SPEC research path was incorrect)
+  - Adjustment 3: structlog `_slog` already in auth.py; reused for new event emission
+- Phase 1.5 / 1.6 (task decomposition + acceptance-as-tasks): see tasks.md
+- Phase 1.7 (file scaffolding): not applicable; modifies existing files
+- Phase 1.8 (MX context scan): no @MX:ANCHOR or @MX:WARN in target files
+- Phase 2 (TDD RED-GREEN-REFACTOR):
+  - RED: 9 base scenarios written to tests/test_auth_mfa_fail_closed.py;
+    pytest 5 failed / 4 passed against current code (expected RED state)
+  - GREEN: refactored login() with split try, _resolve_and_enforce_mfa helper,
+    _emit_mfa_check_failed event, _mfa_unavailable 503 helper. Added hashlib import.
+    All 9 scenarios + 4 retained existing tests passing.
+  - Run-phase additions: 3 explicit acceptance Run-phase additions added
+    (REQ-1.6 generic Exception, REQ-2.2 RequestError, REQ-3.4 recommended)
+  - Total fail-closed scenarios: 12 / Total auth tests: 22 / Backend total: 1156 passed
+- Phase 2.5 (TRUST 5):
+  - Tested: 12 new + 4 retained MFA tests + 1156 backend tests, no regressions
+  - Readable: SPEC-mapped docstrings on each helper, inline REQ-references
+  - Unified: matches existing structlog / httpx / audit / event patterns
+  - Secured: email sha256-hashed (REQ-4.3), 503 before cookie set (REQ-1.5)
+  - Trackable: structured events with auto-bound request_id via LoggingContextMiddleware
+- Phase 2.75 / Quality gate:
+  - ruff check: clean (3 UP037 auto-fixed)
+  - pyright: 0 errors / 0 warnings on auth.py
+- Phase 2.8 (review): self-review per workflow-modes.md Pre-submission Self-Review
+  - Helper extraction proportional; no over-engineering
+  - YAGNI honored: no speculative configuration knobs added
+  - SPEC-only changes; no unrelated improvements
+- Coverage: 64% overall on app.api.auth (pre-existing — many other endpoints
+  not in scope per minimal-changes pitfall). MFA enforcement block (helpers
+  lines ~233-380 + login refactor section) has full branch coverage.
+- Phase 2.10 (simplify): inline self-review pass; no structural simplifications
+  necessary beyond refactor already done
+
+### Files changed
+
+- klai-portal/backend/app/api/auth.py — refactored login() + 3 new helpers
+- klai-portal/backend/pyproject.toml — added respx>=0.22 to dev deps
+- klai-portal/backend/tests/test_auth_mfa_fail_closed.py — NEW, 12 scenarios
+- klai-portal/backend/tests/test_auth_security.py — REQ-5.3 delete, REQ-5.4 narrow
+- deploy/grafana/provisioning/alerting/portal-mfa-rules.yaml — NEW, 2 alerts
+- docs/runbooks/mfa-check-failed.md — NEW
+- .moai/specs/SPEC-SEC-MFA-001/{progress.md,tasks.md} — workflow tracking
+
+### Known limitations / deferred
+
+- **Coverage gap on auth.py overall (64% vs SPEC's 85% target)**: The gap is
+  caused by other endpoints in auth.py (TOTP setup, IDP intent, password
+  reset, sso_complete) that have partial test coverage in unrelated test
+  modules. Closing the gap requires testing untouched endpoints — out of
+  scope for SPEC-SEC-MFA-001 per the `minimal-changes` pitfall. The MFA
+  enforcement block itself (the SPEC's actual concern) has full branch
+  coverage.
+- **Submodule pin bump (T-013)**: not required — Grafana provisioning is in
+  the superproject, not in klai-infra.
+
+### Verification
+
+- pytest tests/test_auth_mfa_fail_closed.py tests/test_auth_security.py: 22/22 passed
+- pytest (full backend): 1156 passed
+- uv run ruff check app/api/auth.py tests/...: clean
+- uv run --with pyright pyright app/api/auth.py: 0/0/0

--- a/.moai/specs/SPEC-SEC-MFA-001/spec.md
+++ b/.moai/specs/SPEC-SEC-MFA-001/spec.md
@@ -1,17 +1,25 @@
 ---
 id: SPEC-SEC-MFA-001
-version: 0.2.0
-status: draft
+version: 0.3.0
+status: completed
 created: 2026-04-24
-updated: 2026-04-24
+updated: 2026-04-27
 author: Mark Vletter
 priority: high
 tracker: SPEC-SEC-AUDIT-2026-04
+lifecycle: spec-first
 ---
 
 # SPEC-SEC-MFA-001: MFA Fail-Closed in Login Flow
 
 ## HISTORY
+
+### v0.3.0 (2026-04-27)
+- Implementation completed via `/moai run` + `/moai sync` cycle on branch
+  `feature/SPEC-SEC-MFA-001` (commits 623e4aa6 + b08f26d1 + sync commit).
+- Status: draft → completed (Level 1 spec-first lifecycle).
+- See § Implementation Notes for divergences, deferred items and the
+  Cornelis audit closure mapping.
 
 ### v0.2.0 (2026-04-24)
 - Expanded stub to full EARS-format SPEC via `/moai plan SPEC-SEC-MFA-001`
@@ -435,3 +443,107 @@ the NEW behaviour.
 - Source under change:
   - [klai-portal/backend/app/api/auth.py](../../../klai-portal/backend/app/api/auth.py)
   - [klai-portal/backend/app/services/zitadel.py](../../../klai-portal/backend/app/services/zitadel.py)
+
+---
+
+## Implementation Notes (v0.3.0 — 2026-04-27)
+
+This section is appended at the close of the Level 1 (spec-first) lifecycle
+to record what was actually built versus what was planned. It is the
+canonical answer to "did this SPEC ship?" and to "where did it diverge
+from the plan?".
+
+### Status
+
+- Branch: `feature/SPEC-SEC-MFA-001`
+- Commits:
+  - `623e4aa6` — fix(portal-api,sec): MFA fail-closed enforcement
+  - `b08f26d1` — fix(portal-api,sec): MFA polish — structlog + orphan-org visibility
+  - sync commit (this commit) — docs(sync): SPEC status + MX anchors + CHANGELOG
+- Verification at sync time: pytest 1160 passed (23 auth-specific), ruff
+  clean, pyright 0/0/0.
+
+### Coverage of REQ-1..REQ-5
+
+| REQ | Outcome |
+|---|---|
+| REQ-1.1..1.7 | Implemented in `_resolve_and_enforce_mfa` + login pre-auth split. Verified in `test_auth_mfa_fail_closed.py` scenarios 1, 4, 8, plus REQ-1.6 generic-Exception variant. |
+| REQ-2.1..2.7 | Implemented via split pre-auth try in `login()`. 4xx-as-not-found preserved (scenario 6 + comment). REQ-2.2 RequestError variant added as Run-phase test. |
+| REQ-3.1..3.7 | Implemented per the SPEC's clarified short-circuit reading: `has_any_mfa` is not called under `mfa_policy in {"optional", "recommended"}`, so the fail-open warning fires only when the lookup is actually attempted (DB path). REQ-3.4 recommended variant covered. REQ-3.7 SPEC-cross-reference comment added. |
+| REQ-4.1..4.4 | `_emit_mfa_check_failed` helper emits structlog event with all fields. Email is sha256-hashed; `request_id` is auto-bound by `LoggingContextMiddleware`. |
+| REQ-4.5..4.7 | Grafana alerts and runbook delivered (see Divergences below for path correction). |
+| REQ-5.1..5.5 | New module `tests/test_auth_mfa_fail_closed.py` with 13 respx-backed scenarios. caplog/`structlog.testing.capture_logs()` assertions on every fail-closed scenario. |
+| REQ-5.6 | **Partial**. The MFA enforcement block (helpers and login refactor) has full branch coverage. The "overall ≥85% on `app.api.auth`" target is **not met** (current 64%, pre-existing) because other endpoints in the same file (TOTP setup, IDP intent, password reset, sso_complete) lack tests. Closing this gap requires adding tests for endpoints unrelated to MFA — out of scope per the `minimal-changes` pitfall. **Recommended follow-up SPEC**: `auth.py` coverage hardening for the remaining endpoints. |
+| REQ-5.7 | The new test module uses `respx` against the real `ZitadelClient` instance — no `MagicMock` on `app.api.auth.zitadel`. Existing `TestMFAPolicyEnforcement` retains the legacy `patch(...)` style for the three regression tests that survived REQ-5.3. |
+
+### Divergences from spec.md plan
+
+1. **Grafana alert path correction.** spec.md REQ-4.5/4.7 specified
+   `klai-infra/deploy/grafana/alerts/mfa-check-failed.yaml`. Actual path:
+   `deploy/grafana/provisioning/alerting/portal-mfa-rules.yaml` in the
+   superproject. Reason: Grafana provisioning is owned by the superproject's
+   `deploy/grafana/` tree, not by the `klai-infra` submodule (the submodule
+   only contains host-level deploy scripts). No submodule pin bump was
+   needed. The runbook
+   [docs/runbooks/mfa-check-failed.md](../../../docs/runbooks/mfa-check-failed.md)
+   was created in the superproject `docs/runbooks/` directory matching the
+   existing convention.
+
+2. **respx as new dev dependency.** spec.md REQ-5.1 said respx was already
+   a dev dependency of `klai-portal/backend`. It was not. Added
+   `respx>=0.22` to both `[project.optional-dependencies] dev` and
+   `[dependency-groups] dev` in `klai-portal/backend/pyproject.toml`.
+   `uv.lock` regenerated.
+
+3. **Run-phase test additions.** Acceptance scenarios noted three "Run-phase
+   addition" cases that were not in the original 8-scenario block: REQ-1.6
+   (generic Exception during `has_any_mfa`), REQ-2.2 (`find_user_by_email`
+   `RequestError`), REQ-3.4 (`mfa_policy="recommended"` behaves like
+   optional). All three were added during Run.
+
+4. **Orphan PortalOrg FK observability** (post-initial polish). Self-review
+   surfaced an edge case the SPEC did not explicitly cover: `db.scalar`
+   returns a `PortalUser`, but `db.get(PortalOrg, ...)` returns `None`
+   (deleted/soft-deleted org while the FK still points at it). Pre-existing
+   behaviour silently fell back to `mfa_policy="optional"` with no signal.
+   Added an explicit branch in `_resolve_and_enforce_mfa` that keeps
+   fail-open semantics (the user logs in) but emits `mfa_check_failed`
+   warning so the orphan is visible in Grafana. New test:
+   `test_portal_user_orphan_org_proceeds_documented_fail_open`.
+
+5. **Logger choice for `has_totp` fail-open warning.** Switched from stdlib
+   `logger.warning` to `_slog.warning` to honour
+   `.claude/rules/klai/projects/portal-logging-py.md`'s "structlog for new
+   log statements" rule.
+
+### Out-of-test verification (deferred to deploy / post-merge)
+
+These items from acceptance.md "Out-of-test verification" cannot be
+discharged by unit tests; they will be confirmed during the post-merge
+deploy on core-01:
+
+- Grafana alert rules load on production Grafana (after PR merge triggers
+  `alerting-check.yml` workflow; manual visual check in Grafana UI under
+  Alerting → mfa-check-failed).
+- LogsQL query
+  (`service:portal-api event:mfa_check_failed`) returns the expected
+  schema in production VictoriaLogs.
+- Runbook reachable from alert annotation (Grafana alert detail view shows
+  the `runbook_url` link).
+- Manual code-review of the final `auth.py::login` handler against the
+  fail-open path catalogue in research.md §4 — performed during this sync
+  phase: only FO-1-4xx (well-formed not-found), FO-2 (has_totp UI flag) and
+  FO-4 (portal_user not in portal — provisioning grace) remain as
+  documented fail-open paths under `mfa_policy="optional"` orgs. All other
+  fail-open holes are closed.
+
+### Cornelis audit closure
+
+This SPEC closes the following entries in
+[SPEC-SEC-AUDIT-2026-04](../SPEC-SEC-AUDIT-2026-04/spec.md):
+
+- **#11** — `has_any_mfa` HTTPStatusError fail-open (`user_has_mfa = True`).
+  Resolved: 503 + `Retry-After: 5`.
+- **#12** — `find_user_by_email` failure leaving `zitadel_user_id = None`
+  → MFA block skipped. Resolved: pre-auth try split; 5xx ≥500 escalates
+  to 503 BEFORE `create_session_with_password` runs.

--- a/.moai/specs/SPEC-SEC-MFA-001/tasks.md
+++ b/.moai/specs/SPEC-SEC-MFA-001/tasks.md
@@ -1,0 +1,40 @@
+## Task Decomposition
+SPEC: SPEC-SEC-MFA-001
+Mode: TDD (RED-GREEN-REFACTOR per task)
+
+| Task ID | Description | Requirement | Dependencies | Planned Files | Status |
+|---------|-------------|-------------|--------------|---------------|--------|
+| T-001 | Add respx>=0.22 to dev dependency-group | REQ-5.1 | — | klai-portal/backend/pyproject.toml | done |
+| T-002 | RED: tests/test_auth_mfa_fail_closed.py with respx Scenarios 1, 2, 6, 7, 7a, 8 (fail-closed paths) | REQ-1.1..1.7, 2.1..2.7, 3.2, 5.1, 5.2, 5.4, 5.7 | T-001 | klai-portal/backend/tests/test_auth_mfa_fail_closed.py | done |
+| T-003 | RED: Scenarios 3, 4, 5 (regression + documented fail-open) added to same module | REQ-3.1, 3.6, 5.2(c,d,e), 5.5 | T-002 | klai-portal/backend/tests/test_auth_mfa_fail_closed.py | done |
+| T-003a | Run-phase additions: REQ-1.6 (generic Exception), REQ-2.2 (RequestError on find_user_by_email), REQ-3.4 (recommended policy) | REQ-1.6, 2.2, 3.4 | T-006 | klai-portal/backend/tests/test_auth_mfa_fail_closed.py | done |
+| T-004 | GREEN: split pre-auth try in auth.py::login (find_user_by_email vs has_totp) | REQ-2.1, 2.2, 2.3, 2.4, 2.5, 2.6 | T-002, T-003 | klai-portal/backend/app/api/auth.py | done |
+| T-005 | GREEN: extract _emit_mfa_check_failed helper (structlog event with reason, mfa_policy, zitadel_status, email_hash, outcome, level routing) | REQ-4.1, 4.2, 4.3, 4.4 | T-004 | klai-portal/backend/app/api/auth.py | done |
+| T-006 | GREEN: extract _resolve_and_enforce_mfa helper; replace user_has_mfa=True fallback with 503 raise; split DB-lookup fail-open vs portal_user-found-org-fetch-fails 503 | REQ-1.1..1.6, 3.1, 3.2, 3.4, 3.7 | T-005 | klai-portal/backend/app/api/auth.py | done |
+| T-007 | Update test_auth_security.py: delete test_mfa_check_failure_defaults_to_pass; narrow test_mfa_policy_lookup_failure_defaults_to_optional docstring | REQ-5.3, 5.4 | T-006 | klai-portal/backend/tests/test_auth_security.py | done |
+| T-008 | REFACTOR: pre-submission self-review (no structural simplification needed; ruff complexity passes) | (quality gate) | T-007 | klai-portal/backend/app/api/auth.py | done |
+| T-009 | Quality gate: ruff check (clean), pyright (0/0/0), full backend pytest (1156 passed), coverage on MFA-block fully covered (overall 64% pre-existing) | REQ-5.6 | T-008 | — | done (coverage gap on overall auth.py is out of scope; MFA-block is fully covered) |
+| T-010 | Inline simplify self-review on changed files (no structural changes warranted) | (run.md Phase 2.10) | T-009 | — | done |
+| T-011 | Add Grafana alert YAML in deploy/grafana/provisioning/alerting/portal-mfa-rules.yaml (path corrected from SPEC; Grafana lives in superproject, not klai-infra) | REQ-4.5, 4.6, 4.7 | — | deploy/grafana/provisioning/alerting/portal-mfa-rules.yaml | done |
+| T-012 | Add runbook docs/runbooks/mfa-check-failed.md | REQ-4.7 | T-011 | docs/runbooks/mfa-check-failed.md | done |
+| T-013 | Bump klai-infra submodule pin | n/a | — | — | not needed (Grafana lives in superproject) |
+| T-014 | Conventional commits + push + draft PR | (git_strategy personal) | T-009..T-012 | — | pending |
+
+### Coverage map (acceptance.md → tasks)
+
+- Scenario 1 (has_any_mfa 500 + required → 503): T-002, T-006
+- Scenario 2 (find_user_by_email 500 → 503): T-002, T-004
+- Scenario 3 (optional + has_any_mfa 500 → 200 fail-open): T-003, T-006
+- Scenario 4 (happy MFA): T-003 (regression)
+- Scenario 5 (happy no-MFA optional): T-003 (regression)
+- Scenario 6 (404 → continues to 401): T-002, T-004
+- Scenario 7 (portal_user found + org fetch raises → 503): T-002, T-006
+- Scenario 7a (portal_user not found → fail-open 200): T-002, T-006
+- Scenario 8 (RequestError → 503): T-002, T-006
+
+### Out-of-test verification (Sync phase, not Run)
+
+- Grafana alert rules load on staging
+- LogsQL query returns expected schema
+- Runbook reachable from alert annotation
+- Manual code review against research §4 fail-open catalogue

--- a/.moai/specs/SPEC-SEC-MFA-001/tasks.md
+++ b/.moai/specs/SPEC-SEC-MFA-001/tasks.md
@@ -18,7 +18,8 @@ Mode: TDD (RED-GREEN-REFACTOR per task)
 | T-011 | Add Grafana alert YAML in deploy/grafana/provisioning/alerting/portal-mfa-rules.yaml (path corrected from SPEC; Grafana lives in superproject, not klai-infra) | REQ-4.5, 4.6, 4.7 | — | deploy/grafana/provisioning/alerting/portal-mfa-rules.yaml | done |
 | T-012 | Add runbook docs/runbooks/mfa-check-failed.md | REQ-4.7 | T-011 | docs/runbooks/mfa-check-failed.md | done |
 | T-013 | Bump klai-infra submodule pin | n/a | — | — | not needed (Grafana lives in superproject) |
-| T-014 | Conventional commits + push + draft PR | (git_strategy personal) | T-009..T-012 | — | pending |
+| T-014 | Conventional commits + push + draft PR | (git_strategy personal) | T-009..T-012 | — | done (commit 623e4aa6 + polish commit, branch pushed) |
+| T-015 | Polish pass: structlog for has_totp warning + orphan PortalOrg fail-open + visibility test | self-review | T-014 | klai-portal/backend/app/api/auth.py, klai-portal/backend/tests/test_auth_mfa_fail_closed.py, .moai/specs/SPEC-SEC-MFA-001/progress.md | done |
 
 ### Coverage map (acceptance.md → tasks)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,89 @@
 # Changelog
 
+## [Unreleased] — 2026-04-27 — SPEC-SEC-MFA-001: MFA fail-closed in login flow
+
+Closes SPEC-SEC-AUDIT-2026-04 findings #11 and #12 (Cornelis audit
+2026-04-22). The portal-api login handler now refuses login with HTTP 503 +
+`Retry-After: 5` whenever the MFA enforcement check cannot complete under
+`mfa_policy="required"`, instead of silently bypassing MFA. Documented
+fail-open behaviour is preserved under `mfa_policy="optional"` /
+`"recommended"`.
+
+### Fixed (security)
+
+- **`klai-portal/backend/app/api/auth.py::login`** — replaced the
+  `user_has_mfa = True` fallback with an explicit fail-closed branch.
+  `has_any_mfa` raising `httpx.HTTPStatusError`, `httpx.RequestError`, or
+  any unexpected exception now raises `HTTPException(503, …, headers={"Retry-After": "5"})`
+  before any cookie or session artefact is created.
+- **Pre-auth try split** — `find_user_by_email` 5xx and `RequestError` now
+  surface as 503 BEFORE `create_session_with_password` runs. 4xx is still
+  treated as "well-formed not found" and the password check returns 401.
+  This closes the finding-#12 path where `zitadel_user_id` could remain
+  `None` and silently skip the MFA enforcement block.
+- **DB-lookup splits** — `portal_user` lookup raise still fail-opens
+  (provisioning grace), but `portal_user found + PortalOrg fetch raise`
+  now fail-closes 503 rather than silently downgrading to optional.
+- **Orphan `PortalOrg` FK** — `portal_user.org_id` pointing at a missing
+  org now emits a `mfa_check_failed` warning while preserving fail-open
+  semantics. Pre-existing behaviour was a silent fall-back, hiding
+  data-integrity bugs.
+
+### Added
+
+- **`klai-portal/backend/app/api/auth.py`** — three helpers:
+  - `_mfa_unavailable()` — single source of truth for the 503 response.
+  - `_emit_mfa_check_failed()` — structured structlog event emitter (fields:
+    `reason`, `mfa_policy`, `zitadel_status`, `email_hash` (sha256), `outcome`).
+    Email is never logged in plaintext.
+  - `_resolve_and_enforce_mfa()` — extracted MFA enforcement block, fully
+    branch-tested.
+- **`klai-portal/backend/tests/test_auth_mfa_fail_closed.py`** (NEW) — 13
+  respx-mocked scenarios exercising every fail-closed and documented
+  fail-open branch. Uses respx against the real `ZitadelClient` instance
+  (not `MagicMock` on `app.api.auth.zitadel`), per REQ-5.7.
+- **`klai-portal/backend/pyproject.toml`** — `respx>=0.22` added to dev
+  dependency group.
+- **`deploy/grafana/provisioning/alerting/portal-mfa-rules.yaml`** (NEW) —
+  two LogsQL alerts: rate >1/min sustained 5m (warning) and fail-open
+  burst >10/min (critical), both linking to the runbook below.
+- **`docs/runbooks/mfa-check-failed.md`** (NEW) — triage steps for both
+  alerts, including security-escalation criteria.
+- **`@MX:ANCHOR`** annotations on `_mfa_unavailable` and
+  `_emit_mfa_check_failed` documenting the cross-component contracts
+  (Grafana alert schema + runbook + frontend 503 expectations).
+
+### Changed
+
+- **`klai-portal/backend/tests/test_auth_security.py`** — `TestMFAPolicyEnforcement`
+  narrowed:
+  - `test_mfa_check_failure_defaults_to_pass` — **deleted** (REQ-5.3); the
+    fail-open behaviour it asserted is now an anti-pattern.
+  - `test_mfa_policy_lookup_failure_defaults_to_optional` — narrowed to
+    cover only the "portal_user lookup raised" arm; the
+    "portal_user found + org fetch raises" arm is now covered by the new
+    fail-closed test module.
+
+### Operational notes
+
+- **Behaviour change for production users in required-MFA orgs.** During a
+  Zitadel restart flap (5xx window) login now returns 503 + `Retry-After: 5`
+  instead of silently letting the user through without MFA. Users retry
+  within seconds. The portal frontend already handles 502 with a generic
+  "try again later" message; 503 surfaces identically.
+- **Grafana alerts go live with this PR.** `alerting-check.yml` will
+  validate the YAML on merge; the alerts appear under "Klai → sec-mfa-001-portal-api"
+  group after the next Grafana provisioning reload.
+- **No DB migration required.** No new env vars. No backward-incompatible
+  API contract changes.
+- **Coverage gap** (deferred): overall coverage on `klai-portal/backend/app/api/auth.py`
+  is 64% (target 85%), unchanged from before. The MFA enforcement block
+  itself has full branch coverage. Closing the overall gap requires testing
+  unrelated endpoints (TOTP setup, IDP intent, password reset, sso_complete)
+  and is recommended as a follow-up SPEC.
+
+---
+
 ## [Unreleased] — 2026-04-22 — SPEC-INFRA-005: Stateful service persistence hardening
 
 Triggered by the 2026-04-19 FalkorDB graph data loss incident

--- a/deploy/grafana/provisioning/alerting/portal-mfa-rules.yaml
+++ b/deploy/grafana/provisioning/alerting/portal-mfa-rules.yaml
@@ -1,0 +1,215 @@
+# SPEC-SEC-MFA-001 R4 — portal-api MFA enforcement health alerts (LogsQL via VictoriaLogs).
+#
+# Routed via spec=SPEC-SEC-MFA-001 → klai-ops-alerts-email (severity warning + critical).
+#
+#   R1  mfa_check_failed_rate_high       WARN  >1 mfa_check_failed/min sustained 5m
+#   R2  mfa_check_failed_fail_open_burst CRIT  >10 fail-open events in any 1m window
+#
+# These alerts surface the SPEC's deliberate trade-off: under
+# mfa_policy="optional" we still log mfa_check_failed warnings whenever a
+# Zitadel or DB lookup fails, so the failure-rate is observable. Under
+# mfa_policy="required" the same code path returns 503 to the caller (also
+# emitted as mfa_check_failed), so a sustained spike of either kind is
+# operationally interesting:
+#
+#   - high-rate (R1):   Zitadel availability problem OR a wave of provisioning-
+#                       race users — investigate before the 503s ripple to
+#                       customer support tickets.
+#   - fail-open burst (R2): Many simultaneous fail-opens means many users were
+#                       silently let through MFA enforcement they would have
+#                       failed under "required". The most likely cause is a
+#                       Zitadel-wide outage; the second-most-likely is a
+#                       policy mis-configuration. Either way it is a security
+#                       investigation, not just availability.
+#
+# Pitfall avoidance (matches portal-api-rules.yaml conventions):
+#   - Always go through `reduce` between LogsQL output and SSE math.
+#   - execErrState: OK — VictoriaLogs plugin sometimes trips "long vs wide"
+#     errors on stats reduce chains; miss-on-hiccup beats false-page.
+#   - Single-value LogsQL stats result + `reduce: last` returns the scalar.
+
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: sec-mfa-001-portal-api
+    folder: Klai
+    interval: 1m
+    rules:
+
+      # ── R1: mfa_check_failed_rate_high ──────────────────────────────────
+      # Fires when the rate of mfa_check_failed events exceeds 1/min averaged
+      # over the last 5 minutes (i.e. 5 or more events in the window).
+      # SPEC-SEC-MFA-001 REQ-4.5.
+      - uid: sec-mfa-001-mfa-check-failed-rate-high
+        title: mfa_check_failed_rate_high
+        condition: threshold
+        data:
+          - refId: query
+            datasourceUid: victorialogs
+            queryType: instant
+            relativeTimeRange:
+              from: 300
+              to: 0
+            model:
+              refId: query
+              datasource:
+                type: victoriametrics-logs-datasource
+                uid: victorialogs
+              expr: '_time:5m service:portal-api event:mfa_check_failed | stats count() as n'
+              queryType: instant
+          - refId: reduce
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 300
+              to: 0
+            model:
+              refId: reduce
+              type: reduce
+              reducer: last
+              expression: query
+          - refId: threshold
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 300
+              to: 0
+            model:
+              refId: threshold
+              type: threshold
+              expression: reduce
+              conditions:
+                - evaluator: { params: [5], type: gt }
+                  operator: { type: and }
+                  reducer: { params: [], type: last }
+                  type: query
+        noDataState: OK
+        execErrState: OK
+        for: 5m
+        keepFiringFor: 10m
+        isPaused: false
+        labels:
+          severity: warning
+          spec: SPEC-SEC-MFA-001
+          service_group: portal-api
+        annotations:
+          summary: 'portal-api MFA check failures > 1/min sustained for 5m'
+          runbook_url: 'docs/runbooks/mfa-check-failed.md'
+          description: |
+            More than 5 ``mfa_check_failed`` events were emitted by portal-api
+            in the last 5 minutes (≈ >1/min sustained). Either Zitadel is
+            flapping (5xx on /v2/users or /authentication_methods) or the
+            portal-api ↔ portal-db connection is degraded (RLS GUC leak,
+            pool exhaustion). Under mfa_policy="required" each event also
+            corresponds to an HTTP 503 returned to a real user, so triage
+            quickly.
+
+            Triage:
+              1. VictoriaLogs query in Grafana → Explore:
+                   _time:5m service:portal-api event:mfa_check_failed
+                     | stats by (reason, mfa_policy, outcome) count()
+                 Group by `reason` to identify the failing leg
+                 (find_user_by_email_5xx / has_any_mfa_5xx / db_lookup_failed /
+                 unexpected) and by `outcome` (503 vs fail-open).
+              2. If `reason` is dominated by has_any_mfa_5xx or
+                 find_user_by_email_5xx → check Zitadel health:
+                   curl -fsS https://auth.getklai.com/debug/healthz
+                 + check `service:zitadel level:error` in VictoriaLogs.
+              3. If `reason` is dominated by db_lookup_failed →
+                 check portal-api DB pool stats and recent RLS guard logs:
+                   _time:15m service:portal-api ("RLS:" OR "InsufficientPrivilege")
+              4. Confirm user impact: any of the events with outcome=503 is a
+                 real user denied login; respond to support tickets if open.
+
+      # ── R2: mfa_check_failed_fail_open_burst ─────────────────────────────
+      # Higher-severity: a burst of fail-open events suggests either a
+      # Zitadel-wide outage affecting many optional-policy orgs, OR an active
+      # bypass attempt combined with a policy mis-configuration. Either is a
+      # security investigation, not just availability.
+      # SPEC-SEC-MFA-001 REQ-4.6.
+      - uid: sec-mfa-001-mfa-check-failed-fail-open-burst
+        title: mfa_check_failed_fail_open_burst
+        condition: threshold
+        data:
+          - refId: query
+            datasourceUid: victorialogs
+            queryType: instant
+            relativeTimeRange:
+              from: 60
+              to: 0
+            model:
+              refId: query
+              datasource:
+                type: victoriametrics-logs-datasource
+                uid: victorialogs
+              expr: '_time:1m service:portal-api event:mfa_check_failed outcome:fail-open | stats count() as n'
+              queryType: instant
+          - refId: reduce
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 60
+              to: 0
+            model:
+              refId: reduce
+              type: reduce
+              reducer: last
+              expression: query
+          - refId: threshold
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 60
+              to: 0
+            model:
+              refId: threshold
+              type: threshold
+              expression: reduce
+              conditions:
+                - evaluator: { params: [10], type: gt }
+                  operator: { type: and }
+                  reducer: { params: [], type: last }
+                  type: query
+        noDataState: OK
+        execErrState: OK
+        for: 1m
+        keepFiringFor: 5m
+        isPaused: false
+        labels:
+          severity: critical
+          spec: SPEC-SEC-MFA-001
+          service_group: portal-api
+        annotations:
+          summary: 'portal-api fail-open MFA bypasses > 10/min'
+          runbook_url: 'docs/runbooks/mfa-check-failed.md#fail-open-burst'
+          description: |
+            More than 10 ``mfa_check_failed`` events with ``outcome=fail-open``
+            fired in the last minute. Each event represents a login that
+            *could* have been silently let through without MFA enforcement
+            because the org's policy is optional/recommended (or because the
+            portal_user lookup raised and we cannot determine policy).
+
+            This is significant because:
+              - A Zitadel-wide outage will cause every login to log this. If
+                the rate is elevated and Zitadel is flapping → confirm and
+                wait for recovery; do NOT change `mfa_policy="required"` for
+                a fix-forward.
+              - A small number of fail-opens at any time is normal. A burst
+                indicates either an outage OR a security event:
+                  · An attacker enumerating accounts during a Zitadel hiccup
+                    in the hope of a policy mis-config.
+                  · A recent code or config change broke the lookup path
+                    (regression — check recent merges).
+
+            Triage:
+              1. Check the alert R1 (mfa_check_failed_rate_high) — if both
+                 are firing, the underlying cause is shared. Triage R1 first.
+              2. Filter for the impacted orgs:
+                   _time:5m service:portal-api event:mfa_check_failed outcome:fail-open
+                     | stats by (mfa_policy, reason) count()
+                 If a single `reason=db_lookup_failed` dominates → DB problem
+                 affecting our ability to determine policy at all.
+              3. Cross-check Zitadel health (see R1 step 2). A burst that
+                 correlates with Zitadel 5xx is the expected, documented
+                 failure mode — not a security incident.
+              4. If Zitadel is healthy and the burst persists → escalate to
+                 security on-call; consider temporary
+                 `auth_dev_mode=False` shut-off / rate-limit at Caddy if a
+                 bypass attempt is suspected.

--- a/deploy/grafana/provisioning/alerting/portal-mfa-rules.yaml
+++ b/deploy/grafana/provisioning/alerting/portal-mfa-rules.yaml
@@ -178,7 +178,7 @@ groups:
           service_group: portal-api
         annotations:
           summary: 'portal-api fail-open MFA bypasses > 10/min'
-          runbook_url: 'docs/runbooks/mfa-check-failed.md#fail-open-burst'
+          runbook_url: 'docs/runbooks/mfa-check-failed.md#triage-fail-open-burst-alert'
           description: |
             More than 10 ``mfa_check_failed`` events with ``outcome=fail-open``
             fired in the last minute. Each event represents a login that

--- a/docs/runbooks/mfa-check-failed.md
+++ b/docs/runbooks/mfa-check-failed.md
@@ -1,0 +1,185 @@
+# Runbook — `mfa_check_failed`
+
+> Linked from Grafana alerts `mfa_check_failed_rate_high` and
+> `mfa_check_failed_fail_open_burst`
+> (`deploy/grafana/provisioning/alerting/portal-mfa-rules.yaml`).
+>
+> SPEC: [SPEC-SEC-MFA-001](../../.moai/specs/SPEC-SEC-MFA-001/spec.md)
+
+## What this signal means
+
+`portal-api`'s login handler (`klai-portal/backend/app/api/auth.py::login`)
+emits a structured `mfa_check_failed` event whenever it cannot complete the
+MFA enforcement check for a login attempt. The event covers two distinct
+outcomes:
+
+- `outcome="503"` — login was rejected with HTTP 503 + `Retry-After: 5`.
+  This happens under `mfa_policy="required"` whenever Zitadel is unreachable,
+  the `has_any_mfa` lookup raises, the pre-auth `find_user_by_email` returns
+  5xx, or the `PortalOrg` DB fetch raises while we know there is a portal
+  user. The user sees a "please retry in a moment" error.
+- `outcome="fail-open"` — login proceeded WITHOUT enforcement. This happens
+  under `mfa_policy in {"optional", "recommended"}` (deliberate trade-off in
+  REQ-3) AND when the `portal_user` lookup itself raised before we could
+  determine policy (provisioning grace per REQ-3.2).
+
+Both arms emit the same event so the rate is fully observable in
+VictoriaLogs.
+
+## Event schema
+
+```jsonc
+{
+  "event": "mfa_check_failed",
+  "service": "portal-api",
+  "level": "warning" | "error",
+  "request_id": "...",          // bound by LoggingContextMiddleware
+  "reason": "has_any_mfa_5xx" | "find_user_by_email_5xx"
+          | "db_lookup_failed" | "unexpected",
+  "mfa_policy": "required" | "optional" | "unresolved",
+  "zitadel_status": 500 | null, // null on RequestError / DB failure
+  "email_hash": "<sha256 of lowercased email>",
+  "outcome": "503" | "fail-open"
+}
+```
+
+Email is **never** logged in plaintext — only the SHA-256 hex digest of the
+lowercased email is recorded (privacy + correlation).
+
+## Alert summary
+
+| Alert | Threshold | Severity | Source |
+|---|---|---|---|
+| `mfa_check_failed_rate_high` | >5 events in any rolling 5m | warning | LogsQL `_time:5m service:portal-api event:mfa_check_failed \| stats count() as n` (n > 5) |
+| `mfa_check_failed_fail_open_burst` | >10 fail-open events in any rolling 1m | critical | LogsQL `_time:1m service:portal-api event:mfa_check_failed outcome:fail-open \| stats count() as n` (n > 10) |
+
+## Triage — high-rate alert
+
+1. **Locate the failing leg.** Run in Grafana → Explore (datasource:
+   VictoriaLogs):
+
+   ```
+   _time:5m service:portal-api event:mfa_check_failed
+     | stats by (reason, mfa_policy, outcome) count()
+   ```
+
+   The dominant `reason` tells you whether to look at Zitadel or at the
+   portal DB.
+
+2. **If `reason` is `has_any_mfa_5xx` or `find_user_by_email_5xx`:** the
+   problem is Zitadel-side. Check:
+
+   ```bash
+   curl -fsS https://auth.getklai.com/debug/healthz
+   ```
+
+   Plus VictoriaLogs:
+
+   ```
+   _time:15m service:zitadel level:error
+   ```
+
+   See [zitadel.md](../../.claude/rules/klai/platform/zitadel.md) for the
+   Login V2 / PAT / restart-flap escalation paths. A transient Zitadel
+   restart flap (5xx for ~30 seconds during rolling deploys) is documented
+   and self-resolves; sustained 5xx is a real outage.
+
+3. **If `reason` is `db_lookup_failed`:** the portal_user / portal_orgs
+   lookup raised. Most common cause is a category-A RLS GUC leak — see
+   [portal-backend.md § Pool-GUC pollution](../../.claude/rules/klai/projects/portal-backend.md).
+   Quick check:
+
+   ```
+   _time:15m service:portal-api ("RLS:" OR "InsufficientPrivilege")
+   ```
+
+   Pool exhaustion shows as `connection.*timeout` in the same window.
+
+4. **If `reason` is `unexpected`:** an exception type that is neither
+   `httpx.HTTPStatusError` nor `httpx.RequestError` raised inside
+   `has_any_mfa`. Treat as a code regression — check the recent merges to
+   `klai-portal/backend/app/services/zitadel.py` and
+   `klai-portal/backend/app/api/auth.py`.
+
+5. **Confirm user impact.** Each event with `outcome="503"` corresponds to a
+   real user who was denied login. Cross-check support tickets opened in the
+   last 30 minutes; reach out proactively if the count is non-trivial.
+
+## Triage — fail-open burst alert
+
+This is a higher-severity signal. A small steady-state of fail-opens is
+expected (every Zitadel hiccup → some optional-policy users see a swallowed
+warning). A *burst* means either a wider outage or a security event.
+
+1. **Always check the rate alert first.** If
+   `mfa_check_failed_rate_high` is also firing, both alerts share a root
+   cause — triage the wider one (the high-rate alert) and the burst will
+   subside as the underlying issue is resolved.
+
+2. **Group the bursts to identify the cause:**
+
+   ```
+   _time:5m service:portal-api event:mfa_check_failed outcome:fail-open
+     | stats by (mfa_policy, reason) count()
+   ```
+
+   Patterns:
+   - `reason=has_any_mfa_5xx` and `mfa_policy=optional` dominating →
+     Zitadel-wide outage affecting optional-policy orgs. This is the
+     documented expected fail mode — no security action required, just wait
+     for Zitadel recovery and let the rate alert run its `keepFiringFor`.
+   - `reason=db_lookup_failed` dominating → DB-level issue affecting our
+     ability to determine policy. See § "high-rate alert" step 3.
+   - Single `reason=unexpected` repeating → likely a code regression. Check
+     recent merges; consider rollback if the burst correlates with a deploy.
+
+3. **Security escalation criteria.** Escalate to security on-call IF:
+   - Zitadel is healthy (your `auth.getklai.com/debug/healthz` returns 200)
+     AND DB is healthy AND the burst persists for >5 minutes.
+   - The burst is concentrated on a single `email_hash` (suggests
+     enumeration / credential stuffing during a noise-generating window).
+   - You see a coincident spike in Caddy 4xx-on-/api/auth/login from a
+     small number of source IPs.
+
+   Mitigation while escalating: rate-limit `/api/auth/login` at Caddy
+   (`@public_limit { not method GET }` is the existing pattern in
+   `deploy/caddy/Caddyfile`).
+
+4. **What NOT to do.**
+
+   - Do **NOT** flip `mfa_policy="required"` to `"optional"` for an org "to
+     stop the alert". The alert is the SPEC working as designed.
+   - Do **NOT** silence the rule in Grafana. If the alert is genuinely
+     wrong (false-positive on weekends, etc.) raise the threshold by editing
+     `portal-mfa-rules.yaml` and link this runbook in the commit.
+
+## Useful queries
+
+```
+# All fail-closed (503) events in the last hour, grouped by reason
+_time:1h service:portal-api event:mfa_check_failed outcome:503
+  | stats by (reason) count()
+
+# Distinct affected user-hashes (for support cross-reference)
+_time:1h service:portal-api event:mfa_check_failed
+  | stats by (email_hash) count()
+
+# Trace a single user's failed-login chain via request_id
+request_id:<uuid>
+```
+
+## Related
+
+- [SPEC-SEC-MFA-001](../../.moai/specs/SPEC-SEC-MFA-001/spec.md) — fail-closed
+  semantics and event schema.
+- [`klai-portal/backend/app/api/auth.py`](../../klai-portal/backend/app/api/auth.py)
+  — `_emit_mfa_check_failed`, `_resolve_and_enforce_mfa`, refactored
+  `login` handler.
+- [`deploy/grafana/provisioning/alerting/portal-mfa-rules.yaml`](../../deploy/grafana/provisioning/alerting/portal-mfa-rules.yaml)
+  — alert definitions.
+- [`.claude/rules/klai/platform/zitadel.md`](../../.claude/rules/klai/platform/zitadel.md)
+  — Zitadel availability, PAT rotation, Login V2 recovery.
+- [`.claude/rules/klai/projects/portal-backend.md`](../../.claude/rules/klai/projects/portal-backend.md)
+  — Pool-GUC pollution and RLS guard patterns.
+- [`.claude/rules/klai/infra/observability.md`](../../.claude/rules/klai/infra/observability.md)
+  — VictoriaLogs / Grafana MCP / log fields.

--- a/klai-portal/backend/app/api/auth.py
+++ b/klai-portal/backend/app/api/auth.py
@@ -35,6 +35,7 @@ has expired there, ``finalize_auth_request`` will fail and the user sees the log
 """
 
 import asyncio
+import hashlib
 import json
 import logging
 import secrets
@@ -220,6 +221,168 @@ async def _finalize_and_set_cookie(
     return LoginResponse(callback_url=_validate_callback_url(callback_url))
 
 
+
+# ---------------------------------------------------------------------------
+# SPEC-SEC-MFA-001: MFA fail-closed enforcement helpers
+# ---------------------------------------------------------------------------
+
+_MFA_503_DETAIL = "Authentication service temporarily unavailable, please retry in a moment"
+_MFA_503_HEADERS = {"Retry-After": "5"}
+
+
+def _mfa_unavailable() -> HTTPException:
+    """Return the 503 raised when MFA enforcement cannot complete (SPEC-SEC-MFA-001)."""
+    return HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail=_MFA_503_DETAIL,
+        headers=_MFA_503_HEADERS,
+    )
+
+
+def _emit_mfa_check_failed(
+    *,
+    reason: str,
+    mfa_policy: str,
+    outcome: str,
+    email: str,
+    zitadel_status: int | None = None,
+    level: str = "warning",
+) -> None:
+    """Emit a structured ``mfa_check_failed`` event (SPEC-SEC-MFA-001 REQ-4).
+
+    Email is sha256-hashed before logging — never the plaintext email.
+    ``request_id`` is auto-bound by structlog contextvars from
+    ``LoggingContextMiddleware``; no manual propagation needed.
+    """
+    email_hash = hashlib.sha256(email.lower().encode("utf-8")).hexdigest()
+    log_method = getattr(_slog, level, _slog.warning)
+    log_method(
+        "mfa_check_failed",
+        reason=reason,
+        mfa_policy=mfa_policy,
+        zitadel_status=zitadel_status,
+        email_hash=email_hash,
+        outcome=outcome,
+    )
+
+
+async def _resolve_and_enforce_mfa(
+    *,
+    zitadel_user_id: str,
+    email: str,
+    db: AsyncSession,
+) -> "PortalUser | None":
+    """Resolve mfa_policy for the calling user and enforce SPEC-SEC-MFA-001.
+
+    Returns the ``PortalUser`` row for downstream audit context, or ``None``
+    when the user is not yet provisioned in portal.
+
+    Raises:
+        HTTPException(503): Org fetch failed (cannot determine policy for a
+            known portal user) OR Zitadel/connection failure during
+            ``has_any_mfa`` under ``mfa_policy="required"``.
+        HTTPException(403): ``mfa_policy="required"`` and the user has no MFA
+            enrolled (existing behaviour, unchanged).
+
+    Fail-open paths (login proceeds):
+        - portal_user lookup raised — cannot map email to org; preserve
+          provisioning grace (REQ-3.2 fail-open arm).
+        - ``mfa_policy in {"optional", "recommended"}`` regardless of
+          ``has_any_mfa`` outcome — orgs that have not opted into enforcement
+          accept availability over security at login time (REQ-3).
+    """
+    portal_user: PortalUser | None = None
+    db_failure: str | None = None
+    try:
+        portal_user = await db.scalar(
+            select(PortalUser).where(PortalUser.zitadel_user_id == zitadel_user_id)
+        )
+    except Exception:
+        db_failure = "portal_user"
+        logger.warning("portal_user lookup failed", exc_info=True)
+
+    org: PortalOrg | None = None
+    if portal_user is not None and db_failure is None:
+        try:
+            org = await db.get(PortalOrg, portal_user.org_id)
+        except Exception:
+            db_failure = "portal_org"
+            logger.warning("portal_org lookup failed", exc_info=True)
+
+    if db_failure == "portal_user":
+        # REQ-3.2 fail-open arm: cannot map email to portal-org; if we 503'd
+        # here every brand-new tenant before provisioning would be locked out.
+        _emit_mfa_check_failed(
+            reason="db_lookup_failed",
+            mfa_policy="optional",
+            outcome="fail-open",
+            email=email,
+            level="warning",
+        )
+        return portal_user  # always None on this branch
+
+    if db_failure == "portal_org":
+        # REQ-3.2 fail-closed arm: known portal_user but unresolvable org
+        # policy — refuse rather than silently downgrade to optional.
+        _emit_mfa_check_failed(
+            reason="db_lookup_failed",
+            mfa_policy="unresolved",
+            outcome="503",
+            email=email,
+            level="error",
+        )
+        raise _mfa_unavailable()
+
+    mfa_policy = org.mfa_policy if org else "optional"
+    if mfa_policy != "required":
+        # REQ-3 / REQ-3.4: optional and recommended preserve fail-open.
+        # has_any_mfa is short-circuited entirely under these policies.
+        return portal_user
+
+    try:
+        user_has_mfa = await zitadel.has_any_mfa(zitadel_user_id)
+    except httpx.HTTPStatusError as exc:
+        _emit_mfa_check_failed(
+            reason="has_any_mfa_5xx",
+            mfa_policy="required",
+            outcome="503",
+            email=email,
+            zitadel_status=exc.response.status_code,
+            level="error",
+        )
+        raise _mfa_unavailable() from exc
+    except httpx.RequestError as exc:
+        _emit_mfa_check_failed(
+            reason="has_any_mfa_5xx",
+            mfa_policy="required",
+            outcome="503",
+            email=email,
+            zitadel_status=None,
+            level="error",
+        )
+        raise _mfa_unavailable() from exc
+    except Exception as exc:
+        # REQ-1.6: any unexpected exception type still fails closed under
+        # required policy. Better a transient 503 than a silent bypass.
+        _emit_mfa_check_failed(
+            reason="unexpected",
+            mfa_policy="required",
+            outcome="503",
+            email=email,
+            zitadel_status=None,
+            level="error",
+        )
+        raise _mfa_unavailable() from exc
+
+    if not user_has_mfa:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="MFA required by your organization. Please set up two-factor authentication.",
+        )
+
+    return portal_user
+
+
 # ---------------------------------------------------------------------------
 # Request / Response models
 # ---------------------------------------------------------------------------
@@ -358,16 +521,49 @@ async def password_set(body: PasswordSetRequest) -> None:
 
 @router.post("/auth/login", response_model=LoginResponse)
 async def login(body: LoginRequest, response: Response, db: AsyncSession = Depends(get_db)) -> LoginResponse:
-    # 1. Check if user has TOTP registered
-    has_totp = False
+    # 1a. Find Zitadel user by email — SPEC-SEC-MFA-001 REQ-2: split 4xx ↔ 5xx
     zitadel_user_id: str | None = None
+    org_id_zitadel: str | None = None
     try:
         user_info = await zitadel.find_user_by_email(body.email)
         if user_info:
-            zitadel_user_id, org_id = user_info
-            has_totp = await zitadel.has_totp(zitadel_user_id, org_id)
+            zitadel_user_id, org_id_zitadel = user_info
     except httpx.HTTPStatusError as exc:
-        logger.warning("TOTP check failed %s — continuing without 2FA check", exc.response.status_code)
+        if exc.response.status_code >= 500:
+            _emit_mfa_check_failed(
+                reason="find_user_by_email_5xx",
+                mfa_policy="unresolved",
+                outcome="503",
+                email=body.email,
+                zitadel_status=exc.response.status_code,
+                level="error",
+            )
+            raise _mfa_unavailable() from exc
+        # 4xx: well-formed not-found / client error — treat as user_info=None
+        # and continue to the password check (which will return 401 for an
+        # unknown user). Closes finding #12 (REQ-2.3, REQ-2.5).
+    except httpx.RequestError as exc:
+        _emit_mfa_check_failed(
+            reason="find_user_by_email_5xx",
+            mfa_policy="unresolved",
+            outcome="503",
+            email=body.email,
+            zitadel_status=None,
+            level="error",
+        )
+        raise _mfa_unavailable() from exc
+
+    # 1b. has_totp — UI-flag only; failure is fail-open (no enforcement
+    # implication; user simply does not see the TOTP prompt). REQ-2.6 moves
+    # this OUT of the find_user_by_email try so a TOTP outage never causes a
+    # find_user_by_email-style 5xx escalation.
+    has_totp = False
+    if zitadel_user_id:
+        try:
+            has_totp = await zitadel.has_totp(zitadel_user_id, org_id_zitadel)
+        except (httpx.HTTPStatusError, httpx.RequestError):
+            logger.warning("has_totp_check_failed -- defaulting to no-totp prompt", exc_info=True)
+            has_totp = False
 
     # 2. Create a Zitadel session by checking email + password
     try:
@@ -392,34 +588,16 @@ async def login(body: LoginRequest, response: Response, db: AsyncSession = Depen
             detail="Login failed, please try again later",
         ) from exc
 
-    # 2b. Enforce MFA policy (NEN 7510: REQ-SEC-001-08)
+    # 2b. Enforce MFA policy — SPEC-SEC-MFA-001 (supersedes the previous
+    # NEN 7510 REQ-SEC-001-08 implementation: fail-closed under required,
+    # documented fail-open under optional).
     portal_user_for_mfa: PortalUser | None = None
-    mfa_policy = "optional"
     if zitadel_user_id:
-        try:
-            portal_user_for_mfa = await db.scalar(
-                select(PortalUser).where(PortalUser.zitadel_user_id == zitadel_user_id)
-            )
-            if portal_user_for_mfa:
-                org_for_mfa = await db.get(PortalOrg, portal_user_for_mfa.org_id)
-                mfa_policy = org_for_mfa.mfa_policy if org_for_mfa else "optional"
-        except Exception:
-            logger.warning("MFA policy lookup failed -- defaulting to optional (fail-open)", exc_info=True)
-
-        if mfa_policy == "required":
-            try:
-                user_has_mfa = await zitadel.has_any_mfa(zitadel_user_id)
-            except httpx.HTTPStatusError as exc:
-                logger.warning(
-                    "has_any_mfa check failed %s -- defaulting to pass (fail-open)",
-                    exc.response.status_code,
-                )
-                user_has_mfa = True
-            if not user_has_mfa:
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail="MFA required by your organization. Please set up two-factor authentication.",
-                )
+        portal_user_for_mfa = await _resolve_and_enforce_mfa(
+            zitadel_user_id=zitadel_user_id,
+            email=body.email,
+            db=db,
+        )
 
     emit_event("login", user_id=zitadel_user_id, properties={"method": "password"})
 

--- a/klai-portal/backend/app/api/auth.py
+++ b/klai-portal/backend/app/api/auth.py
@@ -287,6 +287,10 @@ async def _resolve_and_enforce_mfa(
     Fail-open paths (login proceeds):
         - portal_user lookup raised — cannot map email to org; preserve
           provisioning grace (REQ-3.2 fail-open arm).
+        - portal_user found but PortalOrg row is missing (orphan FK — deleted
+          or soft-deleted org). We log + fail-open since this is data-integrity,
+          not infrastructure failure, and a real user with a stale org should
+          not be locked out without observability.
         - ``mfa_policy in {"optional", "recommended"}`` regardless of
           ``has_any_mfa`` outcome — orgs that have not opted into enforcement
           accept availability over security at login time (REQ-3).
@@ -332,6 +336,21 @@ async def _resolve_and_enforce_mfa(
             level="error",
         )
         raise _mfa_unavailable()
+
+    if portal_user is not None and org is None:
+        # Orphan FK: portal_user.org_id points at a row that does not exist
+        # (deleted org, soft-deleted row, migration rollback). Pre-existing
+        # behaviour silently fell back to mfa_policy="optional" without any
+        # signal — that hid data-integrity bugs from operators. We keep the
+        # fail-open semantics (the user should still be able to log in) but
+        # emit a warning so the orphan is observable in Grafana.
+        _emit_mfa_check_failed(
+            reason="db_lookup_failed",
+            mfa_policy="optional",
+            outcome="fail-open",
+            email=email,
+            level="warning",
+        )
 
     mfa_policy = org.mfa_policy if org else "optional"
     if mfa_policy != "required":
@@ -562,7 +581,11 @@ async def login(body: LoginRequest, response: Response, db: AsyncSession = Depen
         try:
             has_totp = await zitadel.has_totp(zitadel_user_id, org_id_zitadel)
         except (httpx.HTTPStatusError, httpx.RequestError):
-            logger.warning("has_totp_check_failed -- defaulting to no-totp prompt", exc_info=True)
+            # has_totp drives only the UI prompt; failure here is fail-open
+            # (user falls through to password-only screen). We use structlog
+            # explicitly because portal-logging-py rules require it for any
+            # NEW log statement, and this catch is added by SPEC-SEC-MFA-001.
+            _slog.warning("has_totp_check_failed", exc_info=True)
             has_totp = False
 
     # 2. Create a Zitadel session by checking email + password

--- a/klai-portal/backend/app/api/auth.py
+++ b/klai-portal/backend/app/api/auth.py
@@ -221,7 +221,6 @@ async def _finalize_and_set_cookie(
     return LoginResponse(callback_url=_validate_callback_url(callback_url))
 
 
-
 # ---------------------------------------------------------------------------
 # SPEC-SEC-MFA-001: MFA fail-closed enforcement helpers
 # ---------------------------------------------------------------------------
@@ -313,9 +312,7 @@ async def _resolve_and_enforce_mfa(
     portal_user: PortalUser | None = None
     db_failure: str | None = None
     try:
-        portal_user = await db.scalar(
-            select(PortalUser).where(PortalUser.zitadel_user_id == zitadel_user_id)
-        )
+        portal_user = await db.scalar(select(PortalUser).where(PortalUser.zitadel_user_id == zitadel_user_id))
     except Exception:
         db_failure = "portal_user"
         logger.warning("portal_user lookup failed", exc_info=True)

--- a/klai-portal/backend/app/api/auth.py
+++ b/klai-portal/backend/app/api/auth.py
@@ -230,6 +230,13 @@ _MFA_503_DETAIL = "Authentication service temporarily unavailable, please retry 
 _MFA_503_HEADERS = {"Retry-After": "5"}
 
 
+# @MX:ANCHOR: Single source of truth for the SPEC-SEC-MFA-001 fail-closed 503.
+# @MX:REASON: fan_in=6 — both login() pre-auth raises and every fail-closed
+#   branch in _resolve_and_enforce_mfa raise via this helper. Changing the
+#   detail or Retry-After header here shifts contract for every fail-closed
+#   path at once. Coordinate with frontend and the Grafana mfa_check_failed
+#   alert annotation before touching.
+# @MX:SPEC: SPEC-SEC-MFA-001
 def _mfa_unavailable() -> HTTPException:
     """Return the 503 raised when MFA enforcement cannot complete (SPEC-SEC-MFA-001)."""
     return HTTPException(
@@ -239,6 +246,14 @@ def _mfa_unavailable() -> HTTPException:
     )
 
 
+# @MX:ANCHOR: Single emit point for the structured `mfa_check_failed` event.
+# @MX:REASON: fan_in=8 — every Zitadel/DB failure leg in login() and
+#   _resolve_and_enforce_mfa funnels through this helper. The fields it
+#   produces (reason, mfa_policy, zitadel_status, email_hash, outcome, log_level)
+#   are the schema consumed by Grafana alerts (portal-mfa-rules.yaml) and
+#   docs/runbooks/mfa-check-failed.md. Adding a field is fine; renaming or
+#   removing breaks alerting.
+# @MX:SPEC: SPEC-SEC-MFA-001
 def _emit_mfa_check_failed(
     *,
     reason: str,

--- a/klai-portal/backend/pyproject.toml
+++ b/klai-portal/backend/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
     "pytest>=9",
     "pytest-asyncio>=1",
     "httpx>=0.28",
+    "respx>=0.22",
     "ruff>=0.15",
     "pyright>=1.1.408",
 ]
@@ -51,6 +52,7 @@ dev = [
     "pytest>=9",
     "pytest-asyncio>=1",
     "httpx>=0.28",
+    "respx>=0.22",
     "ruff>=0.15",
     "pyright>=1.1.408",
 ]

--- a/klai-portal/backend/tests/test_auth_mfa_fail_closed.py
+++ b/klai-portal/backend/tests/test_auth_mfa_fail_closed.py
@@ -308,9 +308,7 @@ async def test_find_user_by_email_no_results_continues_to_password_check(
     not infrastructure failure. Login proceeds to password-check which fails 401.
     """
     respx_zitadel.post("/v2/users").mock(return_value=httpx.Response(200, json={"result": []}))
-    respx_zitadel.post("/v2/sessions").mock(
-        return_value=httpx.Response(401, json={"error": "invalid credentials"})
-    )
+    respx_zitadel.post("/v2/sessions").mock(return_value=httpx.Response(401, json={"error": "invalid credentials"}))
 
     db = _make_db_mock()
     response = MagicMock()
@@ -516,8 +514,11 @@ async def test_required_has_any_mfa_generic_exception_returns_503(respx_zitadel:
     # only swaps a single coroutine at the client level — REQ-5.7 compliant in spirit).
     from app.services.zitadel import zitadel as zitadel_singleton
 
-    with capture_logs() as captured, audit_patch, emit_patch, patch.object(
-        zitadel_singleton, "has_any_mfa", AsyncMock(side_effect=RuntimeError("kernel panic"))
+    with (
+        capture_logs() as captured,
+        audit_patch,
+        emit_patch,
+        patch.object(zitadel_singleton, "has_any_mfa", AsyncMock(side_effect=RuntimeError("kernel panic"))),
     ):
         with pytest.raises(HTTPException) as exc:
             await login(body=_make_login_body(), response=response, db=db)
@@ -543,9 +544,7 @@ async def test_required_has_any_mfa_generic_exception_returns_503(respx_zitadel:
 async def test_find_user_by_email_request_error_returns_503(respx_zitadel: respx.MockRouter) -> None:
     """REQ-2.2 — connection failure during find_user_by_email still fail-closes."""
     respx_zitadel.post("/v2/users").mock(side_effect=httpx.ConnectError("Connection refused"))
-    sessions = respx_zitadel.post("/v2/sessions").mock(
-        return_value=httpx.Response(200, json=_session_ok())
-    )
+    sessions = respx_zitadel.post("/v2/sessions").mock(return_value=httpx.Response(200, json=_session_ok()))
 
     db = _make_db_mock()
     response = MagicMock()

--- a/klai-portal/backend/tests/test_auth_mfa_fail_closed.py
+++ b/klai-portal/backend/tests/test_auth_mfa_fail_closed.py
@@ -1,0 +1,556 @@
+"""SPEC-SEC-MFA-001 fail-closed regression suite.
+
+Verifies that ``login()`` rejects with HTTP 503 + ``Retry-After: 5`` whenever
+the MFA enforcement check cannot be completed under
+``mfa_policy == "required"``. Preserves fail-open behaviour under
+``mfa_policy == "optional"`` (deliberate trade-off documented in spec.md).
+
+All Zitadel HTTP calls are mocked via ``respx`` against the real
+``ZitadelClient`` instance — never via ``MagicMock`` on the module attribute
+(REQ-5.7). This catches regressions in the client wrapper itself.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+import respx
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog.testing import capture_logs
+
+from app.api.auth import LoginRequest, login
+from app.core.config import settings
+from app.models.portal import PortalOrg, PortalUser
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def respx_zitadel():
+    """Mock the Zitadel HTTP surface against ``settings.zitadel_base_url``.
+
+    Uses ``assert_all_called=False`` so individual scenarios can omit endpoints
+    that should not be hit (e.g. scenario 2 expects ``/v2/sessions`` to receive
+    zero calls).
+    """
+    with respx.mock(base_url=settings.zitadel_base_url, assert_all_called=False) as router:
+        yield router
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_TEST_EMAIL = "alice@acme.com"
+
+
+def _make_login_body(email: str = _TEST_EMAIL) -> LoginRequest:
+    return LoginRequest(
+        email=email,
+        password="correct-horse-battery-staple",
+        auth_request_id="ar-mfa-fc-1",
+    )
+
+
+def _expected_email_hash(email: str = _TEST_EMAIL) -> str:
+    return hashlib.sha256(email.lower().encode("utf-8")).hexdigest()
+
+
+def _session_ok() -> dict[str, Any]:
+    return {"sessionId": "sess-abc", "sessionToken": "tok-xyz"}
+
+
+def _make_db_mock(
+    *,
+    portal_user_org_id: int | None = 10,
+    portal_user_zitadel_id: str = "uid-req",
+    org_mfa_policy: str | None = "required",
+    scalar_side_effect: Exception | None = None,
+    get_side_effect: Exception | None = None,
+) -> AsyncMock:
+    """Return an ``AsyncMock(spec=AsyncSession)`` wired for MFA-lookup tests.
+
+    - ``portal_user_org_id=None`` => ``db.scalar`` returns ``None`` (user not in portal).
+    - ``scalar_side_effect`` => ``db.scalar`` raises (DB lookup failure).
+    - ``org_mfa_policy=None`` => ``db.get`` returns ``None`` (org missing).
+    - ``get_side_effect`` => ``db.get`` raises (org fetch failure).
+    """
+    db = AsyncMock(spec=AsyncSession)
+    db.add = MagicMock()  # SQLAlchemy Session.add is sync; AsyncMock would coerce it
+
+    if scalar_side_effect is not None:
+        db.scalar = AsyncMock(side_effect=scalar_side_effect)
+    elif portal_user_org_id is None:
+        db.scalar = AsyncMock(return_value=None)
+    else:
+        portal_user = MagicMock(spec=PortalUser)
+        portal_user.org_id = portal_user_org_id
+        portal_user.zitadel_user_id = portal_user_zitadel_id
+        db.scalar = AsyncMock(return_value=portal_user)
+
+    if get_side_effect is not None:
+        db.get = AsyncMock(side_effect=get_side_effect)
+    elif org_mfa_policy is None:
+        db.get = AsyncMock(return_value=None)
+    else:
+        org = MagicMock(spec=PortalOrg)
+        org.id = portal_user_org_id or 10
+        org.mfa_policy = org_mfa_policy
+        db.get = AsyncMock(return_value=org)
+
+    return db
+
+
+def _audit_emit_patches() -> tuple[Any, Any]:
+    """Suppress audit + analytics side effects without mocking the zitadel module."""
+    return (
+        patch("app.api.auth.audit.log_event", AsyncMock()),
+        patch("app.api.auth.emit_event", MagicMock()),
+    )
+
+
+def _mfa_events(captured: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return only the ``mfa_check_failed`` records from a structlog capture."""
+    return [e for e in captured if e.get("event") == "mfa_check_failed"]
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1 — mfa_policy=required + has_any_mfa 500 → 503 (REQ-1.1, 1.3, 1.4, 1.5, 4.1, 4.2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_required_has_any_mfa_500_returns_503(respx_zitadel: respx.MockRouter) -> None:
+    respx_zitadel.post("/v2/users").mock(
+        return_value=httpx.Response(
+            200, json={"result": [{"userId": "uid-req", "details": {"resourceOwner": "zorg-req"}}]}
+        )
+    )
+    respx_zitadel.get("/v2/users/uid-req/authentication_methods").mock(
+        return_value=httpx.Response(500, json={"error": "internal"})
+    )
+    respx_zitadel.post("/v2/sessions").mock(return_value=httpx.Response(200, json=_session_ok()))
+
+    db = _make_db_mock(org_mfa_policy="required")
+    response = MagicMock()
+    audit_patch, emit_patch = _audit_emit_patches()
+
+    with capture_logs() as captured, audit_patch, emit_patch:
+        with pytest.raises(HTTPException) as exc:
+            await login(body=_make_login_body(), response=response, db=db)
+
+    assert exc.value.status_code == 503
+    assert exc.value.headers["Retry-After"] == "5"
+    assert "temporarily unavailable" in str(exc.value.detail).lower()
+    response.set_cookie.assert_not_called()  # REQ-1.5 — no session artefact on this path
+
+    events = _mfa_events(captured)
+    assert len(events) == 1
+    assert events[0]["reason"] == "has_any_mfa_5xx"
+    assert events[0]["mfa_policy"] == "required"
+    assert events[0]["zitadel_status"] == 500
+    assert events[0]["outcome"] == "503"
+    assert events[0]["log_level"] == "error"
+    assert events[0]["email_hash"] == _expected_email_hash()
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2 — find_user_by_email 500 → 503 (REQ-2.1, 2.4(b), 2.5, 4.1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_find_user_by_email_500_returns_503(respx_zitadel: respx.MockRouter) -> None:
+    respx_zitadel.post("/v2/users").mock(return_value=httpx.Response(500, json={"error": "internal"}))
+    sessions = respx_zitadel.post("/v2/sessions").mock(return_value=httpx.Response(200, json=_session_ok()))
+
+    db = _make_db_mock()
+    response = MagicMock()
+    audit_patch, emit_patch = _audit_emit_patches()
+
+    with capture_logs() as captured, audit_patch, emit_patch:
+        with pytest.raises(HTTPException) as exc:
+            await login(body=_make_login_body(), response=response, db=db)
+
+    assert exc.value.status_code == 503
+    assert exc.value.headers["Retry-After"] == "5"
+    assert sessions.call_count == 0  # REQ-2.5 — create_session_with_password never invoked
+    response.set_cookie.assert_not_called()
+
+    events = _mfa_events(captured)
+    assert len(events) == 1
+    assert events[0]["reason"] == "find_user_by_email_5xx"
+    assert events[0]["mfa_policy"] == "unresolved"
+    assert events[0]["zitadel_status"] == 500
+    assert events[0]["outcome"] == "503"
+    assert events[0]["log_level"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3 — mfa_policy=optional + has_any_mfa 500 → 200 documented fail-open
+# (REQ-3.1, 3.6 — short-circuit means has_any_mfa is not called under optional)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_optional_has_any_mfa_500_proceeds_no_event(respx_zitadel: respx.MockRouter) -> None:
+    respx_zitadel.post("/v2/users").mock(
+        return_value=httpx.Response(
+            200, json={"result": [{"userId": "uid-opt", "details": {"resourceOwner": "zorg-opt"}}]}
+        )
+    )
+    # has_totp + has_any_mfa share this URL. Return 200 so has_totp succeeds with no enrolment.
+    auth_methods = respx_zitadel.get("/v2/users/uid-opt/authentication_methods").mock(
+        return_value=httpx.Response(200, json={"authMethodTypes": []})
+    )
+    respx_zitadel.post("/v2/sessions").mock(return_value=httpx.Response(200, json=_session_ok()))
+    respx_zitadel.post(url__regex=r"/v2/oidc/auth_requests/.+").mock(
+        return_value=httpx.Response(200, json={"callbackUrl": "https://chat.getklai.com/cb"})
+    )
+
+    db = _make_db_mock(portal_user_org_id=11, portal_user_zitadel_id="uid-opt", org_mfa_policy="optional")
+    response = MagicMock()
+    audit_patch, emit_patch = _audit_emit_patches()
+
+    with capture_logs() as captured, audit_patch, emit_patch:
+        result = await login(body=_make_login_body(), response=response, db=db)
+
+    assert result is not None
+    # Under mfa_policy="optional" the `if mfa_policy == "required":` guard
+    # short-circuits has_any_mfa, so the call is never attempted and no
+    # mfa_check_failed event is emitted (acceptance.md Scenario 3 clarification).
+    assert _mfa_events(captured) == []
+    # has_totp is the only call to /authentication_methods (one call, returns 200)
+    assert auth_methods.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Scenario 4 — Happy path MFA login (REQ-5.2(d))
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_happy_path_required_with_totp_enrolled_returns_totp_required(
+    respx_zitadel: respx.MockRouter,
+) -> None:
+    respx_zitadel.post("/v2/users").mock(
+        return_value=httpx.Response(
+            200, json={"result": [{"userId": "uid-req", "details": {"resourceOwner": "zorg-req"}}]}
+        )
+    )
+    respx_zitadel.get("/v2/users/uid-req/authentication_methods").mock(
+        return_value=httpx.Response(200, json={"authMethodTypes": ["AUTHENTICATION_METHOD_TYPE_TOTP"]})
+    )
+    respx_zitadel.post("/v2/sessions").mock(return_value=httpx.Response(200, json=_session_ok()))
+
+    db = _make_db_mock(org_mfa_policy="required")
+    response = MagicMock()
+    audit_patch, emit_patch = _audit_emit_patches()
+
+    with capture_logs() as captured, audit_patch, emit_patch:
+        result = await login(body=_make_login_body(), response=response, db=db)
+
+    assert result.status == "totp_required"
+    assert result.temp_token  # non-empty opaque token
+    response.set_cookie.assert_not_called()  # cookie minted on totp-login completion, not here
+    assert _mfa_events(captured) == []
+
+
+# ---------------------------------------------------------------------------
+# Scenario 5 — Happy path no-MFA under optional (REQ-5.2(e))
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_happy_path_optional_no_mfa_sets_cookie(respx_zitadel: respx.MockRouter) -> None:
+    respx_zitadel.post("/v2/users").mock(
+        return_value=httpx.Response(
+            200, json={"result": [{"userId": "uid-opt", "details": {"resourceOwner": "zorg-opt"}}]}
+        )
+    )
+    respx_zitadel.get("/v2/users/uid-opt/authentication_methods").mock(
+        return_value=httpx.Response(200, json={"authMethodTypes": []})
+    )
+    respx_zitadel.post("/v2/sessions").mock(return_value=httpx.Response(200, json=_session_ok()))
+    respx_zitadel.post(url__regex=r"/v2/oidc/auth_requests/.+").mock(
+        return_value=httpx.Response(200, json={"callbackUrl": "https://chat.getklai.com/cb"})
+    )
+
+    db = _make_db_mock(portal_user_org_id=11, portal_user_zitadel_id="uid-opt", org_mfa_policy="optional")
+    response = MagicMock()
+    audit_patch, emit_patch = _audit_emit_patches()
+
+    with capture_logs() as captured, audit_patch, emit_patch:
+        result = await login(body=_make_login_body(), response=response, db=db)
+
+    assert result.status == "ok"
+    response.set_cookie.assert_called_once()  # session cookie minted by _finalize_and_set_cookie
+    assert _mfa_events(captured) == []
+
+
+# ---------------------------------------------------------------------------
+# Scenario 6 — find_user_by_email returns no results → continue to 401 (REQ-2.3, 5.2(f))
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_find_user_by_email_no_results_continues_to_password_check(
+    respx_zitadel: respx.MockRouter,
+) -> None:
+    """Zitadel returns ``{"result": []}`` for unknown users — well-formed not-found,
+    not infrastructure failure. Login proceeds to password-check which fails 401.
+    """
+    respx_zitadel.post("/v2/users").mock(return_value=httpx.Response(200, json={"result": []}))
+    respx_zitadel.post("/v2/sessions").mock(
+        return_value=httpx.Response(401, json={"error": "invalid credentials"})
+    )
+
+    db = _make_db_mock()
+    response = MagicMock()
+    audit_patch, emit_patch = _audit_emit_patches()
+
+    with capture_logs() as captured, audit_patch, emit_patch:
+        with pytest.raises(HTTPException) as exc:
+            await login(body=_make_login_body(), response=response, db=db)
+
+    assert exc.value.status_code == 401
+    assert "incorrect" in str(exc.value.detail).lower()
+    assert _mfa_events(captured) == []
+
+
+# ---------------------------------------------------------------------------
+# Scenario 7 — portal_user found + org fetch raises → 503 (REQ-3.2, 5.4)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_portal_user_found_org_fetch_raises_returns_503(respx_zitadel: respx.MockRouter) -> None:
+    respx_zitadel.post("/v2/users").mock(
+        return_value=httpx.Response(
+            200, json={"result": [{"userId": "uid-req", "details": {"resourceOwner": "zorg-req"}}]}
+        )
+    )
+    respx_zitadel.get("/v2/users/uid-req/authentication_methods").mock(
+        return_value=httpx.Response(200, json={"authMethodTypes": []})
+    )
+    respx_zitadel.post("/v2/sessions").mock(return_value=httpx.Response(200, json=_session_ok()))
+
+    db = _make_db_mock(
+        org_mfa_policy=None,
+        get_side_effect=RuntimeError("RLS: app.current_org_id is not set"),
+    )
+    response = MagicMock()
+    audit_patch, emit_patch = _audit_emit_patches()
+
+    with capture_logs() as captured, audit_patch, emit_patch:
+        with pytest.raises(HTTPException) as exc:
+            await login(body=_make_login_body(), response=response, db=db)
+
+    assert exc.value.status_code == 503
+    assert exc.value.headers["Retry-After"] == "5"
+    response.set_cookie.assert_not_called()
+
+    events = _mfa_events(captured)
+    assert len(events) == 1
+    assert events[0]["reason"] == "db_lookup_failed"
+    assert events[0]["mfa_policy"] == "unresolved"
+    assert events[0]["outcome"] == "503"
+    assert events[0]["log_level"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# Scenario 7a — portal_user lookup raises → fail-open optional (REQ-3.2, 5.4)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_portal_user_lookup_raises_proceeds_documented_fail_open(
+    respx_zitadel: respx.MockRouter,
+) -> None:
+    respx_zitadel.post("/v2/users").mock(
+        return_value=httpx.Response(
+            200, json={"result": [{"userId": "uid-req", "details": {"resourceOwner": "zorg-req"}}]}
+        )
+    )
+    respx_zitadel.get("/v2/users/uid-req/authentication_methods").mock(
+        return_value=httpx.Response(200, json={"authMethodTypes": []})
+    )
+    respx_zitadel.post("/v2/sessions").mock(return_value=httpx.Response(200, json=_session_ok()))
+    respx_zitadel.post(url__regex=r"/v2/oidc/auth_requests/.+").mock(
+        return_value=httpx.Response(200, json={"callbackUrl": "https://chat.getklai.com/cb"})
+    )
+
+    db = _make_db_mock(scalar_side_effect=RuntimeError("DB connection lost"))
+    response = MagicMock()
+    audit_patch, emit_patch = _audit_emit_patches()
+
+    with capture_logs() as captured, audit_patch, emit_patch:
+        result = await login(body=_make_login_body(), response=response, db=db)
+
+    assert result is not None
+    response.set_cookie.assert_called_once()
+
+    events = _mfa_events(captured)
+    assert len(events) == 1
+    assert events[0]["reason"] == "db_lookup_failed"
+    assert events[0]["mfa_policy"] == "optional"
+    assert events[0]["outcome"] == "fail-open"
+    assert events[0]["log_level"] == "warning"
+
+
+# ---------------------------------------------------------------------------
+# Scenario 8 — has_any_mfa RequestError → 503 (REQ-1.2, 5.2(a)-variant)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_required_has_any_mfa_request_error_returns_503(respx_zitadel: respx.MockRouter) -> None:
+    respx_zitadel.post("/v2/users").mock(
+        return_value=httpx.Response(
+            200, json={"result": [{"userId": "uid-req", "details": {"resourceOwner": "zorg-req"}}]}
+        )
+    )
+    respx_zitadel.get("/v2/users/uid-req/authentication_methods").mock(
+        side_effect=httpx.ConnectError("Connection refused")
+    )
+    respx_zitadel.post("/v2/sessions").mock(return_value=httpx.Response(200, json=_session_ok()))
+
+    db = _make_db_mock(org_mfa_policy="required")
+    response = MagicMock()
+    audit_patch, emit_patch = _audit_emit_patches()
+
+    with capture_logs() as captured, audit_patch, emit_patch:
+        with pytest.raises(HTTPException) as exc:
+            await login(body=_make_login_body(), response=response, db=db)
+
+    assert exc.value.status_code == 503
+    assert exc.value.headers["Retry-After"] == "5"
+
+    events = _mfa_events(captured)
+    assert len(events) == 1
+    assert events[0]["reason"] == "has_any_mfa_5xx"
+    assert events[0]["zitadel_status"] is None  # no response body to read
+    assert events[0]["outcome"] == "503"
+    assert events[0]["log_level"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# Run-phase addition (REQ-1.6) — unexpected exception type still fails closed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_required_has_any_mfa_generic_exception_returns_503(respx_zitadel: respx.MockRouter) -> None:
+    """REQ-1.6 — any non-httpx exception during has_any_mfa still fail-closes."""
+    respx_zitadel.post("/v2/users").mock(
+        return_value=httpx.Response(
+            200, json={"result": [{"userId": "uid-req", "details": {"resourceOwner": "zorg-req"}}]}
+        )
+    )
+    # Bypass respx by patching the client method directly with a non-httpx exception.
+    respx_zitadel.get("/v2/users/uid-req/authentication_methods").mock(
+        return_value=httpx.Response(200, json={"authMethodTypes": []})  # has_totp succeeds
+    )
+    respx_zitadel.post("/v2/sessions").mock(return_value=httpx.Response(200, json=_session_ok()))
+
+    db = _make_db_mock(org_mfa_policy="required")
+    response = MagicMock()
+    audit_patch, emit_patch = _audit_emit_patches()
+
+    # Patch the bound method on the singleton (still does NOT mock app.api.auth.zitadel,
+    # only swaps a single coroutine at the client level — REQ-5.7 compliant in spirit).
+    from app.services.zitadel import zitadel as zitadel_singleton
+
+    with capture_logs() as captured, audit_patch, emit_patch, patch.object(
+        zitadel_singleton, "has_any_mfa", AsyncMock(side_effect=RuntimeError("kernel panic"))
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await login(body=_make_login_body(), response=response, db=db)
+
+    assert exc.value.status_code == 503
+    assert exc.value.headers["Retry-After"] == "5"
+
+    events = _mfa_events(captured)
+    assert len(events) == 1
+    assert events[0]["reason"] == "unexpected"
+    assert events[0]["mfa_policy"] == "required"
+    assert events[0]["zitadel_status"] is None
+    assert events[0]["outcome"] == "503"
+    assert events[0]["log_level"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# Run-phase addition (REQ-2.2) — find_user_by_email RequestError → 503
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_find_user_by_email_request_error_returns_503(respx_zitadel: respx.MockRouter) -> None:
+    """REQ-2.2 — connection failure during find_user_by_email still fail-closes."""
+    respx_zitadel.post("/v2/users").mock(side_effect=httpx.ConnectError("Connection refused"))
+    sessions = respx_zitadel.post("/v2/sessions").mock(
+        return_value=httpx.Response(200, json=_session_ok())
+    )
+
+    db = _make_db_mock()
+    response = MagicMock()
+    audit_patch, emit_patch = _audit_emit_patches()
+
+    with capture_logs() as captured, audit_patch, emit_patch:
+        with pytest.raises(HTTPException) as exc:
+            await login(body=_make_login_body(), response=response, db=db)
+
+    assert exc.value.status_code == 503
+    assert exc.value.headers["Retry-After"] == "5"
+    assert sessions.call_count == 0  # password check not attempted
+
+    events = _mfa_events(captured)
+    assert len(events) == 1
+    assert events[0]["reason"] == "find_user_by_email_5xx"
+    assert events[0]["mfa_policy"] == "unresolved"
+    assert events[0]["zitadel_status"] is None
+    assert events[0]["outcome"] == "503"
+    assert events[0]["log_level"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# Run-phase addition (REQ-3.4) — mfa_policy="recommended" behaves like optional
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recommended_policy_behaves_like_optional(respx_zitadel: respx.MockRouter) -> None:
+    """REQ-3.4 — `recommended` is a UI-only hint; at login time it does NOT enforce."""
+    respx_zitadel.post("/v2/users").mock(
+        return_value=httpx.Response(
+            200, json={"result": [{"userId": "uid-rec", "details": {"resourceOwner": "zorg-rec"}}]}
+        )
+    )
+    auth_methods = respx_zitadel.get("/v2/users/uid-rec/authentication_methods").mock(
+        return_value=httpx.Response(200, json={"authMethodTypes": []})
+    )
+    # has_any_mfa would fail if called — proves recommended skips it.
+    respx_zitadel.post("/v2/sessions").mock(return_value=httpx.Response(200, json=_session_ok()))
+    respx_zitadel.post(url__regex=r"/v2/oidc/auth_requests/.+").mock(
+        return_value=httpx.Response(200, json={"callbackUrl": "https://chat.getklai.com/cb"})
+    )
+
+    db = _make_db_mock(portal_user_org_id=12, portal_user_zitadel_id="uid-rec", org_mfa_policy="recommended")
+    response = MagicMock()
+    audit_patch, emit_patch = _audit_emit_patches()
+
+    with capture_logs() as captured, audit_patch, emit_patch:
+        result = await login(body=_make_login_body(), response=response, db=db)
+
+    assert result.status == "ok"
+    response.set_cookie.assert_called_once()
+    # has_totp called once (probes UI flag); has_any_mfa NOT called under recommended.
+    assert auth_methods.call_count == 1
+    assert _mfa_events(captured) == []

--- a/klai-portal/backend/tests/test_auth_mfa_fail_closed.py
+++ b/klai-portal/backend/tests/test_auth_mfa_fail_closed.py
@@ -442,6 +442,54 @@ async def test_required_has_any_mfa_request_error_returns_503(respx_zitadel: res
 
 
 # ---------------------------------------------------------------------------
+# Scenario 7b — orphan PortalOrg FK → fail-open + emit warning
+# Pre-existing silent fall-back was hiding data-integrity bugs (e.g. soft-
+# deleted org). We keep fail-open semantics but make it observable.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_portal_user_orphan_org_proceeds_documented_fail_open(
+    respx_zitadel: respx.MockRouter,
+) -> None:
+    respx_zitadel.post("/v2/users").mock(
+        return_value=httpx.Response(
+            200, json={"result": [{"userId": "uid-orphan", "details": {"resourceOwner": "zorg-orphan"}}]}
+        )
+    )
+    respx_zitadel.get("/v2/users/uid-orphan/authentication_methods").mock(
+        return_value=httpx.Response(200, json={"authMethodTypes": []})
+    )
+    respx_zitadel.post("/v2/sessions").mock(return_value=httpx.Response(200, json=_session_ok()))
+    respx_zitadel.post(url__regex=r"/v2/oidc/auth_requests/.+").mock(
+        return_value=httpx.Response(200, json={"callbackUrl": "https://chat.getklai.com/cb"})
+    )
+
+    # portal_user exists, but db.get(PortalOrg, ...) returns None (orphan FK).
+    db = _make_db_mock(
+        portal_user_org_id=99,
+        portal_user_zitadel_id="uid-orphan",
+        org_mfa_policy=None,  # forces db.get to return None
+    )
+    response = MagicMock()
+    audit_patch, emit_patch = _audit_emit_patches()
+
+    with capture_logs() as captured, audit_patch, emit_patch:
+        result = await login(body=_make_login_body(), response=response, db=db)
+
+    # Login succeeds (fail-open) and a session cookie is minted
+    assert result is not None
+    response.set_cookie.assert_called_once()
+
+    events = _mfa_events(captured)
+    assert len(events) == 1
+    assert events[0]["reason"] == "db_lookup_failed"
+    assert events[0]["mfa_policy"] == "optional"
+    assert events[0]["outcome"] == "fail-open"
+    assert events[0]["log_level"] == "warning"
+
+
+# ---------------------------------------------------------------------------
 # Run-phase addition (REQ-1.6) — unexpected exception type still fails closed
 # ---------------------------------------------------------------------------
 

--- a/klai-portal/backend/tests/test_auth_security.py
+++ b/klai-portal/backend/tests/test_auth_security.py
@@ -403,7 +403,14 @@ class TestMFAPolicyEnforcement:
 
     @pytest.mark.asyncio
     async def test_mfa_policy_lookup_failure_defaults_to_optional(self) -> None:
-        """If the portal_user/org DB lookup fails, MFA enforcement defaults to optional (fail-open)."""
+        """If portal_user lookup itself raises, MFA enforcement defaults to optional (fail-open).
+
+        SPEC-SEC-MFA-001 REQ-5.4 narrowed: this test covers ONLY the
+        "portal_user lookup raised" arm — the call returns ``None`` semantics.
+        The complementary "portal_user found but PortalOrg fetch raises" arm
+        is fail-CLOSED and is covered by
+        ``test_auth_mfa_fail_closed.py::test_portal_user_found_org_fetch_raises_returns_503``.
+        """
         from app.api.auth import LoginRequest, login
 
         body = LoginRequest(email="user@test.com", password="pass123", auth_request_id="ar-mfa-4")
@@ -421,46 +428,19 @@ class TestMFAPolicyEnforcement:
             mock_zitadel.create_session_with_password = AsyncMock(return_value=_make_session_response())
             mock_zitadel.finalize_auth_request = AsyncMock(return_value="https://chat.getklai.com/callback")
 
-            # DB throws on portal_user lookup
+            # DB throws on portal_user lookup — cannot map email to org → fail-open
             db.scalar = AsyncMock(side_effect=Exception("DB connection lost"))
             db.get = AsyncMock(return_value=None)
 
             mock_audit.log_event = AsyncMock()
 
-            # Should NOT raise -- fail-open means login proceeds
+            # Should NOT raise -- fail-open means login proceeds (provisioning grace)
             result = await login(body=body, response=response, db=db)
             assert result is not None
 
-    @pytest.mark.asyncio
-    async def test_mfa_check_failure_defaults_to_pass(self) -> None:
-        """If has_any_mfa raises HTTPStatusError, login proceeds (fail-open)."""
-        from app.api.auth import LoginRequest, login
-
-        body = LoginRequest(email="user@test.com", password="pass123", auth_request_id="ar-mfa-5")
-        response = MagicMock()
-        db = AsyncMock()
-
-        with (
-            patch("app.api.auth.zitadel") as mock_zitadel,
-            patch("app.api.auth.audit") as mock_audit,
-            patch("app.api.auth.emit_event"),
-            patch("app.api.auth.select"),
-        ):
-            mock_zitadel.find_user_by_email = AsyncMock(return_value=("uid-mfa5", "zorg-mfa5"))
-            mock_zitadel.has_totp = AsyncMock(return_value=False)
-            mock_zitadel.create_session_with_password = AsyncMock(return_value=_make_session_response())
-            mock_zitadel.finalize_auth_request = AsyncMock(return_value="https://chat.getklai.com/callback")
-            mock_zitadel.has_any_mfa = AsyncMock(side_effect=_make_http_error(500))
-
-            mock_portal_user = MagicMock()
-            mock_portal_user.org_id = 10
-            mock_org = MagicMock()
-            mock_org.mfa_policy = "required"
-            db.scalar = AsyncMock(return_value=mock_portal_user)
-            db.get = AsyncMock(return_value=mock_org)
-
-            mock_audit.log_event = AsyncMock()
-
-            # Should NOT raise 403 -- has_any_mfa failure = fail-open
-            result = await login(body=body, response=response, db=db)
-            assert result is not None
+    # SPEC-SEC-MFA-001 REQ-5.3: ``test_mfa_check_failure_defaults_to_pass`` is
+    # intentionally REMOVED. The fail-open behaviour it documented (has_any_mfa
+    # 5xx => user_has_mfa = True) is now an anti-pattern: under
+    # ``mfa_policy="required"`` we fail-CLOSED with HTTP 503 instead.
+    # Replacement coverage lives in
+    # ``test_auth_mfa_fail_closed.py::test_required_has_any_mfa_500_returns_503``.

--- a/klai-portal/backend/uv.lock
+++ b/klai-portal/backend/uv.lock
@@ -668,6 +668,7 @@ dev = [
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "respx" },
     { name = "ruff" },
 ]
 
@@ -677,6 +678,7 @@ dev = [
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "respx" },
     { name = "ruff" },
 ]
 
@@ -705,6 +707,7 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.26" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "redis", extras = ["hiredis"], specifier = ">=7.4" },
+    { name = "respx", marker = "extra == 'dev'", specifier = ">=0.22" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.49" },
     { name = "structlog", specifier = ">=25.5" },
@@ -719,6 +722,7 @@ dev = [
     { name = "pyright", specifier = ">=1.1.408" },
     { name = "pytest", specifier = ">=9" },
     { name = "pytest-asyncio", specifier = ">=1" },
+    { name = "respx", specifier = ">=0.22" },
     { name = "ruff", specifier = ">=0.15" },
 ]
 
@@ -1194,6 +1198,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947 },
+]
+
+[[package]]
+name = "respx"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Convert portal-api login MFA enforcement to **fail-closed** under
`mfa_policy="required"`. Zitadel and DB lookup failures now reject login
with HTTP **503 + `Retry-After: 5`** instead of silently bypassing MFA.

Closes [SPEC-SEC-AUDIT-2026-04](.moai/specs/SPEC-SEC-AUDIT-2026-04/spec.md)
findings **#11** (`has_any_mfa` HTTPStatusError fail-open) and **#12**
(`find_user_by_email` failure leaving `zitadel_user_id = None` → MFA block
skipped). Audit source: Cornelis 2026-04-22.

## What changed

### Code (`klai-portal/backend/app/api/auth.py`)

Three new helpers + login refactor:

- `_mfa_unavailable()` — single source of truth for the 503 response (`@MX:ANCHOR`, fan_in=6).
- `_emit_mfa_check_failed(...)` — structured `mfa_check_failed` structlog event with sha256-hashed email, never plaintext (`@MX:ANCHOR`, fan_in=8).
- `_resolve_and_enforce_mfa(...)` — extracted MFA enforcement helper with explicit fail-open vs fail-closed branches per REQ-3.

`login()` itself now:

1. Splits `find_user_by_email` from `has_totp` so a Zitadel 5xx surfaces as 503 BEFORE `create_session_with_password` runs (closes finding #12). 4xx remains "well-formed not found" → 401.
2. Removes the `user_has_mfa = True` fallback (closes finding #11). Under `mfa_policy="required"` any failure of `has_any_mfa` (HTTPStatusError, RequestError, generic Exception per REQ-1.6) raises 503 + `Retry-After: 5` BEFORE any cookie or session artefact is created.
3. Splits DB-lookup behaviour: `portal_user` lookup raise → fail-OPEN (provisioning grace); `portal_user found + PortalOrg fetch raise` → fail-CLOSED 503; `portal_user found + PortalOrg None` (orphan FK) → fail-OPEN with warning event (post-polish addition for observability).

### Tests

- **NEW** `klai-portal/backend/tests/test_auth_mfa_fail_closed.py` — 13 respx-mocked scenarios covering every fail-closed and documented fail-open branch. Uses respx against the real `ZitadelClient` instance (REQ-5.7 — no `MagicMock` on `app.api.auth.zitadel`).
- **CHANGED** `klai-portal/backend/tests/test_auth_security.py` — `test_mfa_check_failure_defaults_to_pass` deleted (REQ-5.3); `test_mfa_policy_lookup_failure_defaults_to_optional` narrowed (REQ-5.4).
- **NEW** dev dep `respx>=0.22` in pyproject.toml.

### Observability

- **NEW** `deploy/grafana/provisioning/alerting/portal-mfa-rules.yaml` — two LogsQL alerts:
  - `mfa_check_failed_rate_high` (warn) — >1/min sustained 5m
  - `mfa_check_failed_fail_open_burst` (crit) — >10/min in any 1m window
- **NEW** `docs/runbooks/mfa-check-failed.md` — triage steps for both alerts including security-escalation criteria.

### Documentation

- `spec.md` status: draft → completed; Implementation Notes section appended.
- `CHANGELOG.md` entry under `[Unreleased]`.

## Behaviour change

**Required-MFA orgs only.** During Zitadel restart flaps or DB hiccups the login endpoint now returns **HTTP 503 + `Retry-After: 5`** instead of silently letting the user through without MFA. Users retry within seconds.

The portal frontend already handles 502 with a generic "try again later" message; 503 surfaces identically — no frontend change needed (verified via research.md §6.2).

`mfa_policy="optional"` and `"recommended"` orgs are **unchanged** — fail-open is preserved as a deliberate trade-off (REQ-3, documented in spec.md and the runbook).

## Test plan

- [x] `pytest klai-portal/backend/tests/test_auth_mfa_fail_closed.py` — 13/13 pass
- [x] `pytest klai-portal/backend/tests/test_auth_security.py` — 10/10 pass
- [x] Full backend `pytest` — 1160 passed, no regressions
- [x] `ruff check` — clean
- [x] `pyright` — 0/0/0
- [x] Manual code review of final `auth.py::login` against research.md §4 fail-open catalogue — only documented fail-open paths remain
- [ ] Post-merge: Grafana alerts load + visible in UI (Klai → sec-mfa-001-portal-api group)
- [ ] Post-merge: LogsQL `service:portal-api event:mfa_check_failed` returns the schema declared in REQ-4.1
- [ ] Post-merge: First production fail-closed event observed in VictoriaLogs
- [ ] Post-merge: `gh run watch` for `portal-api.yml` + `alerting-check.yml` workflows green

## Deployment readiness

- **No DB migration required.**
- **No new runtime env vars** (only a dev dep: `respx`).
- **No backward-incompatible API contract change** — only the failure-mode HTTP status shifts (formerly silent bypass or 500, now 503).
- **Security alerts go live with this PR** via Grafana provisioning reload after merge.

## Known limitations / deferred

- **REQ-5.6 — overall ≥85% coverage on `auth.py`** is **partial**. The MFA enforcement block (helpers + login refactor) has full branch coverage. Overall on `app.api.auth` is 64% (pre-existing) because other endpoints in the same file (TOTP setup, IDP intent, password reset, sso_complete) lack tests. Closing the gap requires testing endpoints unrelated to MFA — out of scope per the `minimal-changes` pitfall. Tracked as a recommended follow-up SPEC for `auth.py` coverage hardening.

## Files

```
modified:   klai-portal/backend/app/api/auth.py            (+260 / -32)
modified:   klai-portal/backend/tests/test_auth_security.py (-32)
new:        klai-portal/backend/tests/test_auth_mfa_fail_closed.py
modified:   klai-portal/backend/pyproject.toml             (respx)
modified:   klai-portal/backend/uv.lock
new:        deploy/grafana/provisioning/alerting/portal-mfa-rules.yaml
new:        docs/runbooks/mfa-check-failed.md
modified:   .moai/specs/SPEC-SEC-MFA-001/spec.md           (status + Implementation Notes)
new:        .moai/specs/SPEC-SEC-MFA-001/progress.md
new:        .moai/specs/SPEC-SEC-MFA-001/tasks.md
modified:   CHANGELOG.md
```

## Commits

- `623e4aa6` — fix(portal-api,sec): MFA fail-closed enforcement
- `b08f26d1` — fix(portal-api,sec): MFA polish — structlog + orphan-org visibility
- `512e7792` — docs(sync): SPEC-SEC-MFA-001 status, MX anchors, CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)