### PR TITLE
docs(sync): SPEC-SEC-HYGIENE-001 scribe-slice shipped + alembic-deploy pitfall

### DIFF
--- a/.claude/rules/klai/pitfalls/process-rules.md
+++ b/.claude/rules/klai/pitfalls/process-rules.md
@@ -291,3 +291,60 @@ self-documenting about the expected prod value if SOPS drift occurs.
 The same-shape generalisation: **trust the container env, not the
 config source.** Any "silent fallback to a code default" in a migration
 off a blanket-inherit pattern is a latent bug.
+
+## scribe-deploy-no-alembic (HIGH)
+The `scribe-api.yml` GitHub Action does `docker compose up -d` only —
+it does NOT run `alembic upgrade head`. The Dockerfile CMD is
+`uvicorn`, no migrate step in the entrypoint either. New migrations
+land in the image but are not applied to the DB on deploy.
+
+**What it looks like in production**: app starts, any code path that
+references the new column raises `asyncpg.exceptions.UndefinedColumnError`.
+If wrapped in try/except (e.g. lifespan startup hooks), it logs a warning
+and the rest of the app keeps working — you only notice when the new
+feature silently does nothing. If NOT wrapped, the request fails with
+a 500.
+
+**SPEC-SEC-HYGIENE-001 scribe-slice (2026-04-27)** got bitten by this:
+migration `0007_c5f9e3a4` (adds `error_reason`) shipped in the image but
+not applied. Reaper-on-startup logged `scribe_startup_reaper_failed` with
+the `UndefinedColumnError`. The lifespan try/except caught it, app stayed
+up, but the new feature was dormant until manual `docker exec
+klai-core-scribe-api-1 alembic upgrade head` + container restart.
+
+**Prevention**:
+1. Any scribe SPEC that adds a migration MUST include in its acceptance
+   criteria: "after CI deploy completes, run `docker exec
+   klai-core-scribe-api-1 alembic upgrade head` and restart the
+   container" — and put that in the PR body so the merger doesn't forget.
+2. Better long-term fix: add a step to `scribe-api.yml` after `docker
+   compose up -d`:
+   ```yaml
+   - name: Apply alembic migrations
+     uses: appleboy/ssh-action@v1
+     with:
+       script: |
+         docker exec klai-core-scribe-api-1 alembic upgrade head
+   ```
+   Or move it into the Dockerfile CMD (`alembic upgrade head && exec uvicorn ...`).
+3. **General rule for all klai services with their own deploy workflow**:
+   grep the `.github/workflows/<service>.yml` for `alembic` BEFORE landing
+   any migration. If absent, use option 1 (manual + PR-body reminder) as
+   a stopgap and file a follow-up SPEC for option 2.
+
+**Audit (2026-04-27)** — verified by greping `Dockerfile` ENTRYPOINT/CMD
+across services:
+
+| Service | Auto-migrates on container start? |
+|---|---|
+| portal-api | YES — `entrypoint.sh` runs `alembic upgrade head` then exec's uvicorn |
+| scribe-api | NO — `CMD uvicorn …` only |
+| klai-connector | NO — `CMD uvicorn …` only |
+| klai-mailer | NO — `CMD uvicorn …` only |
+| klai-knowledge-mcp | NO — `CMD python main.py` only |
+| klai-knowledge-ingest | NO — `CMD uvicorn …` only |
+| klai-retrieval-api | NO — `CMD uvicorn …` only |
+
+Every service except portal-api needs the manual-migrate step or an
+entrypoint port. The portal-api `entrypoint.sh` (introduced by
+SPEC-CHAT-TEMPLATES-CLEANUP-001) is the canonical pattern to copy.

--- a/.moai/project/structure.md
+++ b/.moai/project/structure.md
@@ -147,12 +147,24 @@ deploy/
 klai-scribe/
 ├── scribe-api/                # Transcription management API (FastAPI)
 │   ├── app/                   # Application code
+│   │   ├── services/          # audio_storage, janitor (orphan sweep),
+│   │   │                      # reaper (stranded-row recovery on startup)
+│   │   ├── core/              # auth (Zitadel JWT + sub regex), config
+│   │   └── api/               # health (sanitised 503 on whisper failure),
+│   │                          # transcribe
 │   ├── tests/
 │   └── pyproject.toml
 ├── whisper-server/            # Self-hosted Whisper inference server
 │   └── pyproject.toml
 └── scripts/                   # Utility scripts
 ```
+
+Scribe hardening landed in SPEC-SEC-HYGIENE-001 (scribe-slice, 2026-04-27):
+path-traversal helper for audio paths, Zitadel `sub` charset whitelist,
+worker-startup reaper for stranded `processing` rows, finalize-order
+inversion + orphan-audio janitor, `whisper_server_url` allowlist validator
+with sanitised `/health` body, and an MX:WARN annotation on the CORS
+registration site.
 
 ---
 

--- a/.moai/specs/SPEC-SEC-HYGIENE-001/progress.md
+++ b/.moai/specs/SPEC-SEC-HYGIENE-001/progress.md
@@ -32,6 +32,24 @@
 ### Risks / Follow-ups
 
 - **R-37**: `/health` now returns 503 (was 200/degraded) when whisper is unreachable. Status.getklai.com config must be updated to interpret 503 as a degraded but expected state — coordinated with monitoring update.
-- **R-35-migration**: alembic migration `0007` must be applied before this code deploys (otherwise `error_reason` column is missing → reaper UPDATE fails). Standard alembic flow handles this in CI.
+- **R-35-migration**: alembic migration `0007` must be applied before this code deploys (otherwise `error_reason` column is missing → reaper UPDATE fails). **WRONG assumption** — see "Lessons learned" below; the scribe-api CI workflow does NOT run alembic. Migration was applied manually post-deploy.
 - **R-37-prod**: prod env `WHISPER_SERVER_URL=http://172.18.0.1:8000` is in the allowlist (verified). No env-parity action needed.
 - **datetime.utcnow() deprecation**: pre-existing in scribe model + transcribe handler. Not addressed in this slice (out of scope, would touch unchanged code).
+
+### Status: SHIPPED (2026-04-27)
+
+- Polish commit `de6d8da9` (adversarial review pass): tightened 7 issues found in self-review, see commit body.
+- Merge commit on main: `4463bb3d` (PR #179, admin-bypass since branch protection requires reviewer).
+- GitHub Action `scribe-api.yml` run `24980535397`: build + push + deploy + Trivy scan all green.
+- Container on core-01: started `2026-04-27T06:46:31Z`, restarted `2026-04-27T06:49:51Z` after migration.
+- Alembic state: `0007_c5f9e3a4 (head)` applied via `docker exec klai-core-scribe-api-1 alembic upgrade head`.
+- DB column verified: `scribe.transcriptions.error_reason character varying(64)` present, nullable.
+- Reaper success on restart: 0 occurrences of `scribe_startup_reaper_failed` in logs after the migration applied.
+- `/health` probe: HTTP 200, body `{"status":"ok","whisper_server":"ok"}`.
+- Predicted-failure path observed live: first startup (06:46:31Z) logged `scribe_startup_reaper_failed` with `UndefinedColumnError: column transcriptions.error_reason does not exist` — exactly the scenario the lifespan try/except was designed to handle. App stayed up serving normal traffic; reaper was dormant until migration + restart.
+
+### Lessons learned
+
+- **scribe-api deploy pipeline does not run alembic**. The `Dockerfile` CMD is `uvicorn` only; the GitHub Action does `docker pull + compose up -d`. New migrations require manual `docker exec ... alembic upgrade head` after deploy. Captured as a pitfall entry in `.claude/rules/klai/pitfalls/process-rules.md` so future SPECs touching scribe schema don't get bitten the same way.
+- **Best-effort lifespan migration handler worked as designed**. Wrapping `reap_stranded` in try/except in `app.lifespan` meant the missing-column condition logged a warning but did not block app startup. Validated live during this deploy.
+- **Optie B (allowlist set + `*.getklai.com` suffix) is the right shape** for operator-controlled outbound URL configs. Different threat model than `validate_url` (user-supplied URLs) — that one blocks internal hosts; this one only allows them. Codify this distinction in any future "outbound URL config" SPEC.

--- a/.moai/specs/SPEC-SEC-HYGIENE-001/spec.md
+++ b/.moai/specs/SPEC-SEC-HYGIENE-001/spec.md
@@ -1,9 +1,9 @@
 ---
 id: SPEC-SEC-HYGIENE-001
-version: 0.3.0
-status: draft
+version: 0.4.0
+status: in-progress
 created: 2026-04-24
-updated: 2026-04-24
+updated: 2026-04-27
 author: Mark Vletter
 priority: low
 tracker: SPEC-SEC-AUDIT-2026-04
@@ -21,6 +21,21 @@ tracker: SPEC-SEC-AUDIT-2026-04
 > one PR or five is a call for /run.
 
 ## HISTORY
+
+### v0.4.0 (2026-04-27) — scribe-slice shipped
+- Shipped HY-33..HY-38 (klai-scribe slice) via PR #179, merge commit `4463bb3d`.
+- Production deploy verified on core-01: container running new image, alembic
+  upgraded `0006 → 0007_c5f9e3a4` (manual `docker exec` since the scribe-api
+  CI workflow does not run alembic), `/health` returns 200, reaper succeeded
+  on second startup (first startup logged `scribe_startup_reaper_failed` as
+  expected before the migration applied — caught by the lifespan try/except).
+- Status flipped `draft → in-progress` since one of five planned slices has
+  shipped. Remaining slices (portal HY-19..HY-28, connector HY-30..HY-32,
+  retrieval HY-39..HY-44, MCP HY-45..HY-48, mailer HY-49..HY-50) stay
+  outstanding and may be split into per-service follow-up SPECs per
+  Out-of-Scope §v0.3.0.
+- See `.moai/specs/SPEC-SEC-HYGIENE-001/progress.md` for the AC checklist
+  with implementation notes and deploy verification chain.
 
 ### v0.3.0 (2026-04-24)
 - Expanded scope to absorb 21 additional findings from the internal-wave review


### PR DESCRIPTION
## Summary

Documentation sync after PR #179 merge (\`4463bb3d\`) and production deploy. Pure docs — no code.

| File | Change |
|---|---|
| \`spec.md\` | bump to v0.4.0 + status \`draft → in-progress\`; HISTORY entry for the scribe-slice ship |
| \`progress.md\` | "Status: SHIPPED" section with deploy verification chain + lessons learned |
| \`structure.md\` | scribe-api tree expanded with new \`services/\` modules + 1 paragraph on hygiene improvements |
| \`pitfalls/process-rules.md\` | NEW pitfall \`scribe-deploy-no-alembic (HIGH)\` with full per-service audit |

## Key finding from the deploy

The lifespan try/except in \`app.main\` worked exactly as designed: first container start (06:46:31Z) logged \`scribe_startup_reaper_failed\` with \`UndefinedColumnError: column transcriptions.error_reason does not exist\` — predicted in the implementation PR, observed live, app stayed up serving normal traffic. Manual \`docker exec klai-core-scribe-api-1 alembic upgrade head\` + restart resolved it.

## New pitfall: \`scribe-deploy-no-alembic\`

Audited every per-service Dockerfile in the monorepo:

| Service | Auto-migrates on container start? |
|---|---|
| portal-api | YES — \`entrypoint.sh\` runs \`alembic upgrade head\` |
| **All 6 other services** | NO — \`CMD uvicorn …\` only |

Pitfall documents the prevention steps (manual migrate + PR-body reminder, OR copy portal's entrypoint pattern) so future SPECs touching connector / mailer / MCP / ingest / retrieval / scribe schemas don't get bitten the same way.

## Test plan

- [x] No code changes — pure docs
- [ ] Reviewer: spot-check \`structure.md\` paragraph reads accurately
- [ ] Reviewer: confirm pitfall audit table matches actual Dockerfiles (auditable via \`grep -E "alembic upgrade" .github/workflows/*.yml */Dockerfile\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)