### PR TITLE
spec(sec): SPEC-SEC-AUTH-COVERAGE-001 plan — auth.py coverage + observability hardening

### DIFF
--- a/.moai/specs/SPEC-SEC-AUTH-COVERAGE-001/acceptance.md
+++ b/.moai/specs/SPEC-SEC-AUTH-COVERAGE-001/acceptance.md
@@ -1,0 +1,397 @@
+# SPEC-SEC-AUTH-COVERAGE-001 Acceptance Scenarios
+
+Given/When/Then scenarios for the eight in-scope endpoints. All scenarios
+use `pytest`, `pytest-asyncio`, `respx` mounted against the real
+`ZitadelClient` instance, and `structlog.testing.capture_logs()` for
+event assertions. Common fixtures live in
+`klai-portal/backend/tests/auth_test_helpers.py` (NEW per REQ-5.6).
+
+Scenario count: **34 new scenarios** across four new test files.
+
+Format key:
+- **REQ**: which spec.md REQ ids the scenario verifies.
+- **File**: target test file.
+- **Setup**: respx routes + DB mock + cookie/body inputs.
+- **Action**: the `await login(...)` / handler invocation.
+- **Assert**: HTTP status, headers, body, captured events, audit log.
+
+---
+
+## TOTP endpoints — `tests/test_auth_totp_endpoints.py`
+
+### Scenario T1 — totp_setup happy path
+
+**REQ**: REQ-1.1, REQ-5.7
+
+**Given** a logged-in user with `user_id="uid-1"` AND Zitadel `register_user_totp` returns `{"uri": "otpauth://...", "totpSecret": "ABCD..."}`,
+**When** the user calls `POST /api/auth/totp/setup`,
+**Then** the response is 200 with body `{"uri": "otpauth://...", "secret": "ABCD..."}`, `audit.log_event` is called with `action="auth.totp.setup"` `actor="uid-1"`, and no `*_failed` event is emitted.
+
+### Scenario T2 — totp_setup Zitadel 5xx
+
+**REQ**: REQ-1.2
+
+**Given** Zitadel `register_user_totp` returns 502,
+**When** the user calls `POST /api/auth/totp/setup`,
+**Then** the response is 502, captured logs contain one `totp_setup_failed` event with `reason="zitadel_5xx"`, `zitadel_status=502`, `actor_user_id="uid-1"`, `outcome="502"`, `level="error"`.
+
+### Scenario T3 — totp_confirm happy path
+
+**REQ**: REQ-1.3
+
+**Given** Zitadel `verify_user_totp` returns 204,
+**When** the user calls `POST /api/auth/totp/confirm` with body `{"code": "123456"}`,
+**Then** the response is 204, `audit.log_event` is called with `action="auth.totp.confirmed"` `actor="uid-1"`, and no `*_failed` event is emitted.
+
+### Scenario T4 — totp_confirm wrong code
+
+**REQ**: REQ-1.4
+
+**Given** Zitadel `verify_user_totp` returns 400 (invalid code),
+**When** the user calls `POST /api/auth/totp/confirm` with body `{"code": "000000"}`,
+**Then** the response is 400 with detail `"Invalid code, please try again"`, captured logs contain one `totp_confirm_failed` with `reason="invalid_code"`, `zitadel_status=400`, `outcome="400"`, `level="warning"`.
+
+### Scenario T5 — totp_confirm Zitadel 5xx
+
+**REQ**: REQ-1.5
+
+**Given** Zitadel `verify_user_totp` returns 502,
+**When** the user calls `POST /api/auth/totp/confirm`,
+**Then** the response is 502, captured logs contain one `totp_confirm_failed` with `reason="zitadel_5xx"`, `zitadel_status=502`, `outcome="502"`, `level="error"`.
+
+### Scenario T6 — totp_login happy path
+
+**REQ**: REQ-1.8
+
+**Given** `_pending_totp` contains `{session_id, session_token, failures: 0}` AND Zitadel `update_session_with_totp` returns the session AND `finalize_auth_request` returns a callback URL,
+**When** the user calls `POST /api/auth/totp-login` with `{"temp_token": "...", "code": "123456", "auth_request_id": "ar-1"}`,
+**Then** the response is 200 with body containing `callback_url` AND `Set-Cookie: klai_sso=…` is present AND `audit.log_event` is called with `action="auth.login.totp"` AND no `*_failed` event is emitted AND the temp_token is removed from `_pending_totp`.
+
+### Scenario T7 — totp_login wrong code (1st failure)
+
+**REQ**: REQ-1.6
+
+**Given** `_pending_totp` has `failures: 0` AND `update_session_with_totp` returns 400,
+**When** the user calls `POST /api/auth/totp-login` with wrong code,
+**Then** the response is 400 with detail `"Invalid code, please try again"`, `failures` is now 1, `audit.log_event(action="auth.totp.failed")` is called, AND captured logs contain one `totp_login_failed` with `reason="invalid_code"`, `failures=1`, `outcome="400"`, `level="warning"`.
+
+### Scenario T8 — totp_login wrong code (5th failure → lockout)
+
+**REQ**: REQ-1.7
+
+**Given** `_pending_totp` has `failures: 4` AND `update_session_with_totp` returns 400,
+**When** the user calls `POST /api/auth/totp-login` with wrong code,
+**Then** the response is 429 with detail `"Too many failed attempts, please log in again"`, the temp_token is REMOVED from `_pending_totp`, AND captured logs contain one `totp_login_failed` with `reason="lockout"`, `failures=5`, `outcome="429"`, `level="error"`.
+
+### Scenario T9 — totp_login already locked
+
+**REQ**: REQ-1.7
+
+**Given** `_pending_totp` has `failures: 5`,
+**When** the user calls `POST /api/auth/totp-login`,
+**Then** the response is 429 IMMEDIATELY (Zitadel is not called), AND captured logs contain one `totp_login_failed` with `reason="lockout"`, `outcome="429"`.
+
+### Scenario T10 — totp_login expired temp_token
+
+**REQ**: REQ-1.8
+
+**Given** `_pending_totp.get(temp_token)` returns None,
+**When** the user calls `POST /api/auth/totp-login`,
+**Then** the response is 400 with detail `"Session expired, please log in again"`, AND captured logs contain one `totp_login_failed` with `reason="expired_token"`, `outcome="400"`, `level="warning"`.
+
+### Scenario T11 — totp_login Zitadel 5xx
+
+**REQ**: REQ-1.8
+
+**Given** `_pending_totp` valid AND `update_session_with_totp` returns 502,
+**When** the user calls `POST /api/auth/totp-login`,
+**Then** the response is 502, AND captured logs contain one `totp_login_failed` with `reason="zitadel_5xx"`, `zitadel_status=502`, `outcome="502"`, `level="error"`.
+
+### Scenario T12 — totp_login finalize fails
+
+**REQ**: REQ-1.8
+
+**Given** TOTP verification succeeds AND `finalize_auth_request` returns 400 with `"already been handled"`,
+**When** the user calls `POST /api/auth/totp-login`,
+**Then** the response is 409 with detail `"auth_request_stale"` (existing `_finalize_and_set_cookie` behaviour), AND `audit.log_event(action="auth.login.totp")` is still called (TOTP verification succeeded).
+
+### Scenario T13 — totp_login no Set-Cookie on failure
+
+**REQ**: REQ-1.6, REQ-1.7
+
+**Given** any `totp_login_failed` scenario above,
+**When** the response is returned,
+**Then** the response MUST NOT contain a `Set-Cookie: klai_sso` header (no session artefact on failure paths).
+
+---
+
+## IDP endpoints — `tests/test_auth_idp_endpoints.py`
+
+### Scenario I1 — idp_intent happy path
+
+**REQ**: REQ-2.1, REQ-5.7
+
+**Given** `body.idp_id` is the configured Google IDP id AND `zitadel.create_idp_intent` returns `{"authUrl": "https://accounts.google.com/..."}`,
+**When** the user calls `POST /api/auth/idp-intent`,
+**Then** the response is 200 with `auth_url` matching the Zitadel response, `audit.log_event(action="auth.idp.intent", actor="anonymous")` is called with the idp_id in details, AND no `*_failed` event is emitted.
+
+### Scenario I2 — idp_intent unknown IDP
+
+**REQ**: REQ-2.2
+
+**Given** `body.idp_id` is a string not in the allowlist,
+**When** the user calls `POST /api/auth/idp-intent`,
+**Then** the response is 400 with detail `"Unknown IDP"`, AND captured logs contain one `idp_intent_failed` with `reason="unknown_idp"`, `outcome="400"`, `level="warning"`. Zitadel is NOT called.
+
+### Scenario I3 — idp_intent Zitadel 5xx
+
+**REQ**: REQ-2.2
+
+**Given** `zitadel.create_idp_intent` returns 502,
+**When** the user calls `POST /api/auth/idp-intent`,
+**Then** the response is 502, AND captured logs contain one `idp_intent_failed` with `reason="zitadel_5xx"`, `zitadel_status=502`, `outcome="502"`, `level="error"`.
+
+### Scenario I4 — idp_intent missing authUrl
+
+**REQ**: REQ-2.2
+
+**Given** `zitadel.create_idp_intent` returns 200 with `{}` (no authUrl),
+**When** the user calls `POST /api/auth/idp-intent`,
+**Then** the response is 502, AND captured logs contain one `idp_intent_failed` with `reason="missing_auth_url"`, `outcome="502"`, `level="error"`.
+
+### Scenario I5 — idp_callback session creation 5xx
+
+**REQ**: REQ-2.4
+
+**Given** `zitadel.create_session_with_idp_intent` returns 502,
+**When** the user calls `GET /api/auth/idp-callback?id=...&token=...&auth_request_id=ar-1`,
+**Then** the response is 302 with Location starting with `/login?authRequest=ar-1`, AND captured logs contain one `idp_callback_failed` with `reason="session_creation_5xx"`, `zitadel_status=502`, `outcome="302→failure_url"`, `level="error"`.
+
+### Scenario I6 — idp_callback missing session id
+
+**REQ**: REQ-2.4
+
+**Given** `create_session_with_idp_intent` returns 200 but the response has no `sessionId`,
+**When** the user calls the callback,
+**Then** the response is 302 to failure_url, AND captured logs contain one `idp_callback_failed` with `reason="missing_session"`, `outcome="302→failure_url"`, `level="error"`.
+
+### Scenario I7 — idp_callback finalize 5xx
+
+**REQ**: REQ-2.4
+
+**Given** session created OK AND user lookup succeeds AND `finalize_auth_request` returns 502,
+**When** the user calls the callback,
+**Then** the response is 302 to failure_url, AND captured logs contain one `idp_callback_failed` with `reason="finalize_5xx"`, `zitadel_status=502`, `outcome="302→failure_url"`, `level="error"`.
+
+### Scenario I8 — idp_callback happy single-org
+
+**REQ**: REQ-2.3
+
+**Given** session created AND user identity fetched AND existing portal_users has exactly ONE row for the zitadel_user_id AND `finalize_auth_request` returns a callback URL,
+**When** the user calls the callback,
+**Then** the response is 302 to the callback URL with `Set-Cookie: klai_sso=…`, `audit.log_event(action="auth.login.idp", actor=zitadel_user_id, details={"method":"idp", "auto_provisioned": false})` is called, AND no `*_failed` event is emitted.
+
+---
+
+## Password endpoints — `tests/test_auth_password_endpoints.py`
+
+### Scenario P1 — password_reset known email
+
+**REQ**: REQ-3.1, REQ-5.7
+
+**Given** `zitadel.find_user_id_by_email` returns `"uid-1"` AND `zitadel.send_password_reset` returns 204,
+**When** the user calls `POST /api/auth/password/reset` with `{"email": "alice@acme.com"}`,
+**Then** the response is 204, `audit.log_event(action="auth.password.reset", actor="anonymous", details={"email_hash": <sha256>})` is called, AND no `*_failed` event is emitted.
+
+### Scenario P2 — password_reset unknown email
+
+**REQ**: REQ-3.1, REQ-3.2
+
+**Given** `find_user_id_by_email` returns None,
+**When** the user calls `POST /api/auth/password/reset` with an unknown email,
+**Then** the response is 204 (anti-enumeration), `audit.log_event(...)` is called, AND captured logs contain one `password_reset_failed` with `reason="unknown_email"`, `email_hash=<sha256>`, `outcome="204"`, `level="warning"`.
+
+### Scenario P3 — password_reset find_user_by_email 5xx
+
+**REQ**: REQ-3.3
+
+**Given** `find_user_id_by_email` returns 502,
+**When** the user calls `POST /api/auth/password/reset`,
+**Then** the response is 204 (anti-enumeration is preserved on infrastructure failures), AND captured logs contain one `password_reset_failed` with `reason="zitadel_5xx"`, `zitadel_status=502`, `email_hash=<sha256>`, `outcome="204"`, `level="error"`.
+
+### Scenario P4 — password_reset send_password_reset 5xx
+
+**REQ**: REQ-3.3
+
+**Given** `find_user_id_by_email` returns `"uid-1"` AND `send_password_reset` returns 502,
+**When** the user calls `POST /api/auth/password/reset`,
+**Then** the response is 204 (silent), AND captured logs contain one `password_reset_failed` with `reason="zitadel_5xx"`, `zitadel_status=502`, `outcome="204"`, `level="error"`.
+
+### Scenario P5 — password_set happy path
+
+**REQ**: REQ-3.4
+
+**Given** `zitadel.set_password_with_code` returns 204,
+**When** the user calls `POST /api/auth/password/set` with `{"user_id": "uid-1", "code": "123456", "new_password": "..."}`,
+**Then** the response is 204, `audit.log_event(action="auth.password.set", actor="uid-1", details={"reason":"set"})` is called, AND no `*_failed` event is emitted.
+
+### Scenario P6 — password_set expired link (410)
+
+**REQ**: REQ-3.5
+
+**Given** `set_password_with_code` returns 410,
+**When** the user calls `POST /api/auth/password/set`,
+**Then** the response is 400 with detail `"Link has expired or is invalid, request a new reset link"`, AND captured logs contain one `password_set_failed` with `reason="expired_link"`, `zitadel_status=410`, `outcome="400"`, `level="warning"`.
+
+### Scenario P7 — password_set invalid code (400)
+
+**REQ**: REQ-3.5
+
+**Given** `set_password_with_code` returns 400,
+**When** the user calls `POST /api/auth/password/set`,
+**Then** the response is 400 with detail `"Link has expired or is invalid, request a new reset link"`, AND captured logs contain one `password_set_failed` with `reason="invalid_code"`, `zitadel_status=400`, `outcome="400"`, `level="warning"`.
+
+### Scenario P8 — password_set Zitadel 5xx
+
+**REQ**: REQ-3.6
+
+**Given** `set_password_with_code` returns 502,
+**When** the user calls `POST /api/auth/password/set`,
+**Then** the response is 502 with detail `"Failed to set password, please try again later"`, AND captured logs contain one `password_set_failed` with `reason="zitadel_5xx"`, `zitadel_status=502`, `outcome="502"`, `level="error"`.
+
+---
+
+## SSO endpoint — `tests/test_auth_sso_endpoints.py`
+
+### Scenario S1 — sso_complete happy path
+
+**REQ**: REQ-4.5
+
+**Given** `klai_sso` cookie is a valid Fernet-encrypted payload of `{sid, stk}` AND `finalize_auth_request` returns a callback URL,
+**When** the user calls `POST /api/auth/sso-complete` with `{"auth_request_id": "ar-1"}`,
+**Then** the response is 200 with body `{"callback_url": "https://chat.getklai.com/..."}`, NO `audit.log_event` is called (REQ-4.4 — SSO success is silent), AND no `*_failed` event is emitted.
+
+### Scenario S2 — sso_complete missing cookie
+
+**REQ**: REQ-4.1
+
+**Given** no `klai_sso` cookie,
+**When** the user calls `POST /api/auth/sso-complete`,
+**Then** the response is 401 with detail `"No SSO session"`, AND captured logs contain one `sso_complete_failed` with `reason="no_cookie"`, `outcome="401"`, `level="warning"`. Zitadel is NOT called.
+
+### Scenario S3 — sso_complete tampered cookie
+
+**REQ**: REQ-4.2
+
+**Given** `klai_sso="not-a-valid-fernet-token"`,
+**When** the user calls `POST /api/auth/sso-complete`,
+**Then** the response is 401 with detail `"SSO cookie invalid"`, AND captured logs contain one `sso_complete_failed` with `reason="cookie_invalid"`, `outcome="401"`, `level="warning"`.
+
+### Scenario S4 — sso_complete finalize 5xx
+
+**REQ**: REQ-4.3
+
+**Given** valid cookie AND `finalize_auth_request` returns 502,
+**When** the user calls `POST /api/auth/sso-complete`,
+**Then** the response is 401 with detail `"SSO session no longer valid"`, AND captured logs contain one `sso_complete_failed` with `reason="session_expired"`, `zitadel_status=502`, `outcome="401"`, `level="warning"`.
+
+---
+
+## Cross-cutting verifications
+
+### Coverage gate (REQ-5.5)
+
+`pytest --cov=app.api.auth --cov-branch --cov-fail-under=85` SHALL exit 0.
+Branch coverage SHALL be ≥95%.
+
+### Helper extraction verification (REQ-5.1, REQ-5.2)
+
+`grep "_emit_mfa_check_failed" auth.py` returns exactly 1 line (the wrapper definition); the helper itself contains exactly `return _emit_auth_event("mfa_check_failed", ...)`.
+
+`_emit_auth_event` accepts BOTH `email=` (raw, hashed inside) AND `email_hash=` (pre-hashed). When `email` is passed, the emitted event has `email_hash` and NOT `email`. When `email_hash` is passed, the emitted event passes through.
+
+### Stdlib logger migration (REQ-5.3)
+
+`grep "logger\." klai-portal/backend/app/api/auth.py` returns:
+- the `logger = logging.getLogger(__name__)` line ONLY in the in-scope sections; OR
+- only `logger.*` calls in OUT-OF-SCOPE endpoints (passkey_*, email_otp_*, verify_email, idp_intent_signup, idp_signup_callback).
+
+Specifically: ZERO `logger.*` calls inside the bodies of `totp_setup`, `totp_confirm`, `totp_login`, `idp_intent`, `idp_callback`, `password_reset`, `password_set`, `sso_complete`.
+
+### Semgrep suppression removal (REQ-5.3)
+
+`grep "nosemgrep: python-logger-credential-disclosure" klai-portal/backend/app/api/auth.py` returns 0 matches.
+
+### MX:ANCHOR verification (REQ-5.4)
+
+`grep "@MX:ANCHOR" klai-portal/backend/app/api/auth.py` returns lines for:
+- `_mfa_unavailable` (existing from SPEC-SEC-MFA-001)
+- `_emit_mfa_check_failed` (existing — though now a wrapper, the anchor stays as a stable contract reference)
+- `_emit_auth_event` (NEW)
+- `_finalize_and_set_cookie` (NEW)
+- `_validate_callback_url` (NEW)
+
+Each `@MX:ANCHOR` line is preceded by a `@MX:REASON` line and followed by a `@MX:SPEC: SPEC-SEC-AUTH-COVERAGE-001` (or earlier SPEC) sub-line.
+
+### Shared test helpers verification (REQ-5.6)
+
+`tests/auth_test_helpers.py` exists and exports at least:
+- `respx_zitadel` fixture
+- `_make_login_body`, `_make_totp_login_body`, `_make_totp_confirm_body`, `_make_totp_setup_request` (no body — depends-only), `_make_idp_intent_body`, `_make_idp_callback_query`, `_make_password_reset_body`, `_make_password_set_body`, `_make_sso_complete_body`
+- `_make_sso_cookie(sid, stk)` (Fernet-encrypted helper)
+- `_make_db_mock`
+- `_audit_emit_patches`
+- `_capture_events(captured, name)` filter helper (replaces `_mfa_events` — generic)
+- `_expected_email_hash(email)`
+
+`tests/test_auth_mfa_fail_closed.py` imports from `tests/auth_test_helpers` and the diff is purely additive (no test-logic change).
+
+---
+
+## Out-of-test verification (Sync-phase manual check)
+
+These items can only be verified at deploy time, not in unit tests:
+
+- **Grafana queryability**: `service:portal-api event:totp_login_failed` (and the other 6 event names) returns the expected schema in production VictoriaLogs after first real failure. Documented in `docs/runbooks/auth-event-schema.md` (NEW, optional — could be folded into `mfa-check-failed.md` runbook).
+- **No PII regression**: `service:portal-api event:password_reset_failed` returns events with `email_hash` field but NEVER `email` field with plaintext. Verifiable via VictoriaLogs query.
+- **Audit trail completeness**: SELECT distinct(action) FROM portal_audit_log WHERE created_at > <merge> includes `auth.totp.setup`, `auth.totp.confirmed`, `auth.password.reset`, `auth.password.set`, `auth.idp.intent`, `auth.login.idp`. (Not yet present today.)
+- **Coverage report**: CI's coverage report on the merged commit shows ≥85% on `app.api.auth`.
+
+---
+
+## Coverage map — REQ ↔ scenarios
+
+| REQ | Verifying scenarios |
+|---|---|
+| REQ-1.1 | T1 |
+| REQ-1.2 | T2 |
+| REQ-1.3 | T3 |
+| REQ-1.4 | T4 |
+| REQ-1.5 | T5 |
+| REQ-1.6 | T7 |
+| REQ-1.7 | T8, T9 |
+| REQ-1.8 | T6, T10, T11, T12, T13 |
+| REQ-2.1 | I1 |
+| REQ-2.2 | I2, I3, I4 |
+| REQ-2.3 | I8 |
+| REQ-2.4 | I5, I6, I7 |
+| REQ-2.5 | I1..I8 |
+| REQ-3.1 | P1, P2 |
+| REQ-3.2 | P2 |
+| REQ-3.3 | P3, P4 |
+| REQ-3.4 | P5 |
+| REQ-3.5 | P6, P7 |
+| REQ-3.6 | P8 |
+| REQ-3.7 | P1..P8 |
+| REQ-4.1 | S2 |
+| REQ-4.2 | S3 |
+| REQ-4.3 | S4 |
+| REQ-4.4 | S1 (asserts no audit) |
+| REQ-4.5 | S1..S4 |
+| REQ-5.1 | "Helper extraction verification" check |
+| REQ-5.2 | "Helper extraction verification" check (email vs email_hash branch) |
+| REQ-5.3 | "Stdlib logger migration" + "Semgrep suppression removal" greps |
+| REQ-5.4 | "MX:ANCHOR verification" grep |
+| REQ-5.5 | Coverage gate (`--cov-fail-under=85`) |
+| REQ-5.6 | "Shared test helpers verification" check + import diff |
+| REQ-5.7 | T1, I1, P1, S1 (REQ-5.7 sample verification — every test module uses respx-not-MagicMock) |

--- a/.moai/specs/SPEC-SEC-AUTH-COVERAGE-001/plan.md
+++ b/.moai/specs/SPEC-SEC-AUTH-COVERAGE-001/plan.md
@@ -1,0 +1,239 @@
+# SPEC-SEC-AUTH-COVERAGE-001 Implementation Plan
+
+## Strategy: TDD per the project's `quality.development_mode = tdd`
+
+Five sub-stories, each one full RED-GREEN-REFACTOR cycle. Sub-stories are
+ordered by dependency: REQ-5.1/5.2 helper extraction lands first because
+all other REQs use `_emit_auth_event`; REQ-5.6 shared-helpers refactor
+lands second because new test files import from it; then REQs 1-4 in any
+order; then REQ-5.3/5.4/5.5 final-pass cleanup + coverage gate.
+
+Estimated cycle length: each sub-story is 6-12 commits worth of work
+(write tests RED, implement GREEN, refactor for clarity, ruff/pyright
+clean, optional simplify pass).
+
+---
+
+## Cycle order
+
+### Cycle A — REQ-5.1 + REQ-5.2 (`_emit_auth_event` helper)
+
+**Why first**: every other REQ writes a call site for this helper. Land
+the helper first, exercise it in the existing MFA tests, then tests for
+new endpoints can use it.
+
+Steps:
+1. **RED**: Add a unit test `tests/test_emit_auth_event.py` that exercises:
+   - Event name parameter shows up in the captured event's `event` field.
+   - `email=` is hashed to `email_hash`; raw `email` field is absent.
+   - `email_hash=` passes through unchanged.
+   - `level="warning"` routes to `_slog.warning`; `level="error"` to `_slog.error`.
+   - `request_id` is auto-bound from contextvars when set, absent otherwise.
+2. **GREEN**: Add `_emit_auth_event` in `auth.py`. Re-implement
+   `_emit_mfa_check_failed` as `return _emit_auth_event("mfa_check_failed", reason=…, mfa_policy=…, …)`.
+3. **REFACTOR**: Verify all existing `_emit_mfa_check_failed` callers still
+   pass (`pytest tests/test_auth_mfa_fail_closed.py`). No call-site
+   change needed (signature is preserved).
+
+### Cycle B — REQ-5.6 (`tests/auth_test_helpers.py`)
+
+**Why second**: every new test file imports from it.
+
+Steps:
+1. **RED**: Add `tests/auth_test_helpers.py` with the factories +
+   fixtures listed in spec.md REQ-5.6. Add a smoke test
+   `tests/test_auth_test_helpers_smoke.py` exercising each factory once.
+2. **GREEN**: implement the helpers. Most are extracted from
+   `tests/test_auth_mfa_fail_closed.py`.
+3. **REFACTOR**: Update `tests/test_auth_mfa_fail_closed.py` to import
+   from `auth_test_helpers`. The diff is delete-locals + add-imports;
+   test bodies unchanged. Run the full module to verify zero behaviour
+   change.
+
+### Cycle C — REQ-1 (TOTP endpoints)
+
+**Files affected**: `app/api/auth.py` (3 endpoint bodies),
+`tests/test_auth_totp_endpoints.py` (NEW, 13 scenarios).
+
+Steps:
+1. **RED**: Write all 13 T-scenarios. Use respx for Zitadel,
+   `MagicMock` for `_pending_totp` initial state where needed.
+2. **GREEN**: Modify each endpoint body:
+   - Add `audit.log_event(...)` for success paths.
+   - Add `_emit_auth_event(...)` for every failure path.
+   - Migrate stdlib `logger.exception` to `_slog.exception` (no semantic change beyond the message format).
+3. **REFACTOR**: Extract any shared TOTP-specific helper if patterns emerge
+   (e.g., a `_audit_totp_action(action, user_id)` if the audit-log call
+   sites become repetitive).
+
+### Cycle D — REQ-2 (IDP endpoints)
+
+**Files affected**: `app/api/auth.py` (idp_intent + idp_callback),
+`tests/test_auth_idp_endpoints.py` (NEW, 8 scenarios).
+
+The 8 callback scenarios are denser because the handler is large. The
+existing `tests/test_idp_callback_provision.py` covers the auto-provision
+happy path; this file complements it with failure paths.
+
+### Cycle E — REQ-3 (password endpoints)
+
+**Files affected**: `app/api/auth.py` (password_reset + password_set),
+`tests/test_auth_password_endpoints.py` (NEW, 8 scenarios).
+
+REQ-5.3 work intersects here: removing `# nosemgrep` annotations on
+`password_reset` / `password_set` after migrating their `logger.exception`
+calls to `_slog.exception`.
+
+### Cycle F — REQ-4 (sso_complete)
+
+**Files affected**: `app/api/auth.py` (sso_complete),
+`tests/test_auth_sso_endpoints.py` (NEW, 4 scenarios).
+
+Smallest cycle. Includes a Fernet-cookie helper in `auth_test_helpers.py`
+for the happy path test (encrypt a known sid+stk, pass as cookie).
+
+### Cycle G — REQ-5.3 + REQ-5.4 + REQ-5.5 (cleanup + coverage gate)
+
+Final pass:
+1. **REQ-5.3**: Sweep remaining stdlib `logger.*` calls in the in-scope
+   endpoints. Verify `# nosemgrep: python-logger-credential-disclosure`
+   annotations are gone.
+2. **REQ-5.4**: Add `@MX:ANCHOR` to `_finalize_and_set_cookie`,
+   `_validate_callback_url`, `_emit_auth_event` with full
+   `@MX:REASON` and `@MX:SPEC` sub-lines.
+3. **REQ-5.5**: Run `pytest --cov=app.api.auth --cov-branch --cov-fail-under=85`. If under 85%, identify the gap and add scenarios. Likely candidates: less-common idp_callback branches (multi-org → /select-workspace, allowed-domain mismatch, get_session_details fail-soft).
+
+---
+
+## Risk analysis
+
+### Risk A: in-scope endpoints depend on out-of-scope helpers
+
+Mitigation: The endpoints' test scenarios use respx + DB mocks. They do
+NOT exercise the in-memory `_pending_totp` cache directly except via the
+endpoint. When SPEC-SEC-SESSION-001 replaces the cache with Redis, the
+test scenarios continue to pass because they assert on observable
+behaviour (HTTP status, captured events) not implementation details.
+
+### Risk B: `idp_callback` is large (126 lines, 7 try/except branches)
+
+Mitigation: Cover the most-common failure paths first (8 scenarios per
+spec.md). The auto-provision-DB-failure branch is already covered by
+`test_idp_callback_provision.py`. If line coverage on this single
+function lags below 80%, add 2-3 targeted scenarios for the
+`get_session_details` fail-soft path and the multi-org redirect.
+
+### Risk C: Helper extraction breaks the existing MFA test suite
+
+Mitigation: `_emit_mfa_check_failed` keeps its public signature. The
+existing 13 MFA tests (in `test_auth_mfa_fail_closed.py`) are run after
+helper extraction (Cycle A REFACTOR step). Pre-existing PR pattern
+verifies via CI — if the MFA tests break, Cycle A is reverted before
+proceeding to Cycle B.
+
+### Risk D: Anti-enumeration regression on `password_reset`
+
+Mitigation: Spec REQ-3.1 / REQ-3.2 / REQ-3.3 explicitly preserve 204 on
+all paths. Test scenarios P2/P3/P4 assert the response code is 204 even
+when `_emit_auth_event` fires. CI fails if any password_reset scenario
+returns anything other than 204.
+
+### Risk E: Cycle G (REQ-5.5 coverage gate) reveals deeper coverage gaps
+
+Mitigation: If coverage is < 85% after Cycles A-F, the gate explicitly
+identifies missing lines via `--cov-report=term-missing`. Add 2-3
+"phantom" scenarios for legacy fail-soft branches (e.g., the `try:
+emit_event` in login() pre-fix already-covered scenario, or the
+`audit.log_event` exception swallow). These scenarios assert that the
+fail-soft swallows a fake exception — pure observability tests, no
+behaviour change.
+
+---
+
+## Dependency graph
+
+```
+Cycle A (REQ-5.1, 5.2) ────┬──→ Cycle B (REQ-5.6)
+                            │           │
+                            └───────────┴──→ Cycle C (REQ-1, TOTP)
+                                              │
+                                              ├──→ Cycle D (REQ-2, IDP)
+                                              │
+                                              ├──→ Cycle E (REQ-3, password)
+                                              │
+                                              └──→ Cycle F (REQ-4, SSO)
+                                                          │
+                                                          └──→ Cycle G (REQ-5.3, 5.4, 5.5 cleanup)
+```
+
+Cycles C-F are independent and can run in any order or parallel; Cycle
+G must come last because it gates on full-suite coverage.
+
+---
+
+## Quality gate (per cycle)
+
+After each cycle:
+- `pytest tests/<cycle's test files>` — green
+- `uv run ruff check klai-portal/backend/app/api/auth.py klai-portal/backend/tests/test_auth_*.py` — clean
+- `uv run ruff format --check klai-portal/backend/app/api/auth.py klai-portal/backend/tests/test_auth_*.py` — clean
+- `uv run --with pyright pyright klai-portal/backend/app/api/auth.py` — 0/0/0
+- `uv run pytest klai-portal/backend/tests/ -q` — full suite clean (catches collateral regressions early)
+
+After Cycle G:
+- `uv run --with pytest-cov pytest --cov=app.api.auth --cov-branch --cov-fail-under=85` — clean
+- Branch coverage ≥95% via `--cov-report=term-missing`
+
+---
+
+## MX tag plan (Phase 3.5)
+
+Targets identified during Phase 0.5 research:
+
+| Symbol | Current state | Action | Reason |
+|---|---|---|---|
+| `_emit_auth_event` (NEW) | n/a | Add `@MX:ANCHOR` with `@MX:REASON: fan_in≈15` | Single source of truth for structured auth-failure event schema; consumed by Grafana queries. |
+| `_finalize_and_set_cookie` (line 179) | no anchor | Retroactive `@MX:ANCHOR` with `@MX:REASON: fan_in=3` | Called from login, totp_login, sso_complete; cookie contract change must coordinate all three. |
+| `_validate_callback_url` (line 139) | no anchor | Retroactive `@MX:ANCHOR` with `@MX:REASON: fan_in=3` | Trust boundary for OIDC callback URL; affects login, idp_callback, sso_complete. |
+| `_emit_mfa_check_failed` (line 242) | has anchor (SPEC-SEC-MFA-001) | Update body to delegate to `_emit_auth_event`; keep anchor + update SPEC reference to also include SPEC-SEC-AUTH-COVERAGE-001 | Public contract preserved; implementation now thin wrapper. |
+| `_mfa_unavailable` (line 233) | has anchor (SPEC-SEC-MFA-001) | No change | Already correctly anchored. |
+
+Note: `_pending_totp` (TTLCache) intentionally NOT anchored. Its replacement
+under SEC-SESSION-001 will redesign the contract — anchoring now would
+need a refactor anyway.
+
+---
+
+## Effort estimate
+
+Sub-stories are independent. Effort below assumes one engineer / one
+focused session per cycle:
+
+| Cycle | Test scenarios | Code touch points | Notes |
+|---|---|---|---|
+| A | 8 | Add `_emit_auth_event`; refactor `_emit_mfa_check_failed` | Mechanical |
+| B | 1 (smoke) | Extract helpers; refactor existing test imports | Mechanical |
+| C | 13 | totp_setup, totp_confirm, totp_login bodies | Most failure-path scenarios |
+| D | 8 | idp_intent + idp_callback | Largest endpoint (idp_callback 126 lines) |
+| E | 8 | password_reset, password_set | Includes nosemgrep removal |
+| F | 4 | sso_complete | Smallest |
+| G | 0 (or 2-3 if coverage gap) | Anchors, logger sweep, coverage report | Final pass |
+| **TOTAL** | **~42 scenarios** | **8 endpoint bodies + 4 new test files + 1 helper module** | |
+
+If pytest --cov shows a gap after Cycle F, Cycle G adds 2-3 scenarios.
+Total can stretch to ~45 scenarios.
+
+---
+
+## Out-of-scope reminders (referenced from spec.md)
+
+The following will NOT be touched by this SPEC, even though they live in
+`auth.py`:
+
+- `_pending_totp` cache (line 73-97) — finding #13, SPEC-SEC-SESSION-001.
+- `_fernet` Fernet key fallback (line 106) — finding #16, SPEC-SEC-SESSION-001.
+- `exc.response.text` log reflection — finding A4, SPEC-SEC-INTERNAL-001.
+- `passkey_*` endpoints — deferred follow-up.
+- `email_otp_*` endpoints — deferred follow-up.
+- `verify_email` endpoint — deferred follow-up.
+- `idp_intent_signup` / `idp_signup_callback` — signup flow, separate scope.

--- a/.moai/specs/SPEC-SEC-AUTH-COVERAGE-001/research.md
+++ b/.moai/specs/SPEC-SEC-AUTH-COVERAGE-001/research.md
@@ -1,0 +1,414 @@
+# SPEC-SEC-AUTH-COVERAGE-001 Research
+
+Deep-reading analysis of `klai-portal/backend/app/api/auth.py` endpoints
+not covered by SPEC-SEC-MFA-001 (`login` + `_resolve_and_enforce_mfa` are
+already hardened and tested). Captures pre-existing audit findings, current
+test coverage, observability gaps, and the patterns SPEC-SEC-MFA-001
+established that this SPEC must propagate.
+
+---
+
+## 1. Scope: which endpoints, which not
+
+`auth.py` exposes 16 route handlers. SPEC-SEC-AUTH-COVERAGE-001 covers
+the eight that close the REQ-5.6 coverage gap from SPEC-SEC-MFA-001:
+
+| Endpoint | Path | Type | In scope |
+|---|---|---|---|
+| `login` | `POST /api/auth/login` | password login | ❌ already covered (SPEC-SEC-MFA-001, SPEC-SEC-MFA-001 v0.3.0) |
+| `totp_login` | `POST /api/auth/totp-login` | TOTP completion | ✅ |
+| `totp_setup` | `POST /api/auth/totp/setup` | TOTP enrolment start | ✅ |
+| `totp_confirm` | `POST /api/auth/totp/confirm` | TOTP enrolment commit | ✅ |
+| `idp_intent` | `POST /api/auth/idp-intent` | OAuth IDP login start | ✅ |
+| `idp_callback` | `GET /api/auth/idp-callback` | OAuth IDP callback | ✅ |
+| `password_reset` | `POST /api/auth/password/reset` | reset email | ✅ |
+| `password_set` | `POST /api/auth/password/set` | reset commit | ✅ |
+| `sso_complete` | `POST /api/auth/sso-complete` | SSO cookie reuse | ✅ |
+| `passkey_setup` / `passkey_confirm` | `POST /api/auth/passkey/...` | passkey enrolment | ❌ deferred (separate follow-up) |
+| `email_otp_setup` / `email_otp_confirm` / `email_otp_resend` | `POST /api/auth/email-otp/...` | email OTP flow | ❌ deferred |
+| `verify_email` | `POST /api/auth/verify-email` | email verification | ❌ deferred |
+| `idp_intent_signup` / `idp_signup_callback` | `POST/GET /api/auth/idp-intent-signup`, `/api/auth/idp-signup-callback` | IDP signup variant | ❌ deferred (signup flow is its own SPEC scope) |
+
+The deferred endpoints will be folded into a future SPEC if the coverage
+gap on them remains material after this SPEC lands. They are deferred,
+not ignored.
+
+---
+
+## 2. Pre-existing audit findings on the in-scope endpoints
+
+`SPEC-SEC-AUDIT-2026-04` (Cornelis 2026-04-22 + internal-wave audit
+2026-04-24) flags the following on these eight endpoints. **All of these
+are tracked in OTHER SPECs and are explicitly OUT OF SCOPE here.**
+
+| # | Finding | File ref | Routed to | Status |
+|---|---|---|---|---|
+| 13 | TOTP attempt counter is per-instance only (in-memory `_pending_totp` TTLCache, no Redis backing) | `auth.py:73-97` (the cache class) — affects `totp_login` | [SPEC-SEC-SESSION-001](../SPEC-SEC-SESSION-001/spec.md) | Open |
+| 15 | `klai_idp_pending` cookie has no IP / UA binding | `signup.py:243-391` — outside auth.py but related | SPEC-SEC-SESSION-001 | Open |
+| 16 | `klai_sso` cookie key regenerates on empty env (Fernet.generate_key() fallback) | `auth.py:106` (the `_fernet` initialisation) — affects `sso_complete`, `idp_callback`, `_finalize_and_set_cookie` | SPEC-SEC-SESSION-001 | Open |
+| A4 | `exc.response.text` log reflection (PII / token leakage in logs) | "20+ sites in klai-portal/backend/app/api/auth.py" — affects every `logger.exception("…%s", exc.response.text)` site | [SPEC-SEC-INTERNAL-001](../SPEC-SEC-INTERNAL-001/spec.md) | Open |
+
+**SPEC-SEC-AUTH-COVERAGE-001 does NOT fix any of these.** What it DOES
+do, indirectly:
+
+- Tests written under this SPEC will be parameterised so they continue to
+  pass after SEC-SESSION-001 lands (e.g., a TOTP test that verifies
+  "after 5 failures the token is invalidated" works against either a
+  per-instance counter or a Redis-backed counter — the test expresses the
+  invariant, not the implementation).
+- Tests will include a regression check that confirms `exc.response.text`
+  is NOT present in `caplog` records — once SEC-INTERNAL-001 lands, this
+  check protects against regression. Until then, the check passes with
+  `xfail` markers documented in acceptance.md.
+
+---
+
+## 3. Pattern propagation from SPEC-SEC-MFA-001
+
+SPEC-SEC-MFA-001 established three patterns that this SPEC propagates to
+the eight in-scope endpoints. The pattern set is the actual bulk of the
+work; tests are the verification surface.
+
+### 3.1 Pattern A — structlog for new log statements
+
+[`portal-logging-py.md`](../../../.claude/rules/klai/projects/portal-logging-py.md)
+mandates: *"Always use structlog. Never use logging.getLogger() for new
+log statements."*
+
+Current state of in-scope endpoints (read from `auth.py` 2026-04-27):
+
+| Endpoint | logger.* calls | _slog.* calls | Convert? |
+|---|---|---|---|
+| `totp_login` | 1× exception | 0 | YES |
+| `totp_setup` | 1× exception | 0 | YES |
+| `totp_confirm` | 1× exception | 0 | YES |
+| `idp_intent` | 1× exception, 1× error | 0 | YES |
+| `idp_callback` | 4× exception, 1× error | 2× info, 2× exception | partial — convert remaining 5 |
+| `password_reset` | 2× exception | 0 | YES |
+| `password_set` | 1× exception | 0 | YES |
+| `sso_complete` | 1× exception | 0 | YES |
+
+Total: ~16 stdlib `logger.*` call sites to migrate to `_slog.*`.
+
+This is mechanical work, low risk, but with two caveats:
+
+1. The `# nosemgrep: python-logger-credential-disclosure` annotations on
+   `password_reset`/`password_set` were added because Semgrep flagged
+   `logger.exception("...status=%s", exc.response.status_code)` as
+   credential exposure. Migrating to structlog should remove the need
+   for the suppression — `_slog.exception("set_password_failed", status=exc.response.status_code)` is structurally clean.
+2. The `exc.response.text` interpolation is finding A4 (out of scope),
+   so on conversion we keep ONLY the status code, not the response body.
+   This is a free hardening that comes with the migration even though A4
+   is formally tracked elsewhere.
+
+### 3.2 Pattern B — structured event emission
+
+SPEC-SEC-MFA-001 introduced the `mfa_check_failed` event for monitoring
+MFA enforcement failures. The same pattern applies to other auth-flow
+failure points:
+
+| Event name | Fires on | mfa_check_failed analogue |
+|---|---|---|
+| `totp_confirm_failed` | TOTP confirm 4xx (wrong code) or 5xx (Zitadel) | reason: `invalid_code` / `zitadel_5xx`; outcome: `400` / `502` |
+| `totp_login_failed` | TOTP-login 4xx (wrong code), counter exhausted, expired token | reason: `invalid_code` / `lockout` / `expired_token`; outcome: `400` / `429` |
+| `password_reset_failed` | reset Zitadel 5xx (today: silently swallowed) | reason: `zitadel_5xx` / `unknown_email`; outcome: `204` (we keep anti-enumeration) |
+| `password_set_failed` | reset commit 4xx (expired link) or 5xx | reason: `invalid_code` / `expired_link` / `zitadel_5xx`; outcome: `400` / `502` |
+| `idp_intent_failed` | unknown IDP id, Zitadel 5xx | reason: `unknown_idp` / `zitadel_5xx`; outcome: `400` / `502` |
+| `idp_callback_failed` | session creation 5xx, finalize 5xx, missing session id | reason: per-leg; outcome: `302→failure_url` |
+| `sso_complete_failed` | no cookie, decrypt fail, finalize 4xx/5xx | reason: `no_cookie` / `cookie_invalid` / `session_expired`; outcome: `401` |
+
+The schema mirrors `mfa_check_failed`:
+
+```jsonc
+{
+  "event": "<endpoint>_<action>_failed",
+  "service": "portal-api",
+  "level": "warning" | "error",
+  "request_id": "...",        // bound by LoggingContextMiddleware
+  "reason": "...",
+  "zitadel_status": <int|null>,
+  "email_hash": "<sha256 hex>",  // when email is in scope; else absent
+  "outcome": "<http code|fail-open>"
+}
+```
+
+This enables a single Grafana alert family for the whole auth surface
+rather than one alert per endpoint.
+
+### 3.3 Pattern C — @MX:ANCHOR on shared helpers
+
+`_emit_mfa_check_failed` (fan_in 8) and `_mfa_unavailable` (fan_in 6)
+got `@MX:ANCHOR` tags during SPEC-SEC-MFA-001 sync. This SPEC adds:
+
+- **`_emit_auth_event(event, ...)`** — shared helper for all the structured
+  failure events listed in 3.2. Replaces ad-hoc `_slog.warning("foo_failed", ...)` calls. Will have fan_in ~15+ once all endpoints use it. **@MX:ANCHOR required.**
+- **`_finalize_and_set_cookie`** — already exists at `auth.py:179`,
+  fan_in 3 (called from `login`, `totp_login`, and `sso_complete`).
+  **@MX:ANCHOR retroactively added** so future changes coordinate cookie
+  contract changes across all three callers.
+- **`_validate_callback_url`** — `auth.py:139`, fan_in 3 (login finalize
+  + idp callback + sso complete). **@MX:ANCHOR retroactively added.**
+
+---
+
+## 4. Endpoint-by-endpoint observability and coverage gaps
+
+Numbered findings here become REQ tags in spec.md.
+
+### 4.1 `totp_setup` (`POST /api/auth/totp/setup`)
+
+- **Code**: `auth.py:570-584` — calls `zitadel.register_user_totp(user_id)`. On 5xx → 502.
+- **Audit log**: NONE. A failed TOTP enrolment attempt against another
+  user's account (if `get_current_user_id` were ever bypassed) would be
+  invisible.
+- **Tests**: NONE.
+- **Recommendations**:
+  - Emit `audit.log_event(action="auth.totp.setup", actor=user_id, …)` on success.
+  - Emit `_emit_auth_event("totp_setup_failed", reason=…)` on any failure.
+  - Tests: happy path returns `uri`+`secret`; 5xx returns 502 + emits event.
+
+### 4.2 `totp_confirm` (`POST /api/auth/totp/confirm`)
+
+- **Code**: `auth.py:611-629` — calls `zitadel.verify_user_totp(user_id, code)`. 4xx → 400; 5xx → 502.
+- **Audit log**: NONE on success; NONE on failure. Brute-force attempts
+  against the confirm endpoint (which has no per-account rate limit on
+  the portal side — Zitadel does its own rate-limit) are invisible.
+- **Tests**: NONE.
+- **Recommendations**:
+  - Emit `audit.log_event(action="auth.totp.confirmed", actor=user_id, …)` on success.
+  - Emit `_emit_auth_event("totp_confirm_failed", reason="invalid_code"|"zitadel_5xx", …)` on failures.
+  - Tests: happy path returns 204; wrong code returns 400 + emits event;
+    Zitadel 5xx returns 502 + emits event with status.
+
+### 4.3 `totp_login` (`POST /api/auth/totp-login`)
+
+- **Code**: `auth.py:458-532` — most complex of the three TOTP endpoints.
+  Reads `_pending_totp` cache, increments `failures` counter, locks out
+  at `_TOTP_MAX_FAILURES=5`, emits `audit.log_event(action="auth.totp.failed")`
+  on each wrong code. On success: `audit.log_event(action="auth.login.totp")` then `_finalize_and_set_cookie`.
+- **Audit log**: PRESENT (success + failure). Good baseline.
+- **Tests**: NONE for this endpoint specifically. `tests/test_auth_security.py::TestAuthAuditLogging` covers `auth.login.totp` and `auth.totp.failed` actions but not the specific failure behaviour (lockout at 5, expired token, finalize failure).
+- **Pre-existing finding**: #13 (in-memory counter) — out of scope.
+- **Recommendations**:
+  - Add `_emit_auth_event("totp_login_failed", reason=…, …)` to mirror
+    the existing `audit.log_event` (so monitoring can use either layer).
+  - Tests: 7+ scenarios:
+    - Valid token + correct code → 200 + cookie.
+    - Valid token + wrong code (1st time) → 400, failures=1.
+    - Valid token + wrong code (5th time) → 429, token invalidated.
+    - Expired temp_token → 400.
+    - Already-locked token → 429 immediately.
+    - Zitadel 5xx during update_session_with_totp → 502.
+    - finalize_auth_request stale (409) → propagate per existing helper.
+
+### 4.4 `idp_intent` (`POST /api/auth/idp-intent`)
+
+- **Code**: `auth.py:739-766` — validates `idp_id` against allowlist, builds success/failure URLs from `settings.portal_url`, calls `zitadel.create_idp_intent`.
+- **Audit log**: NONE.
+- **Tests**: NONE.
+- **Concerns**:
+  - `success_url` is built from `settings.portal_url` (server-controlled), not request-controlled — no open redirect risk.
+  - `idp_id` is constrained to the allowlist `{settings.zitadel_idp_google_id, settings.zitadel_idp_microsoft_id}` minus empty strings — good, no injection.
+  - Empty `authUrl` from Zitadel → 502 (handled).
+- **Recommendations**:
+  - Emit `audit.log_event(action="auth.idp.intent", actor="anonymous", details={"idp_id": …})` on success.
+  - Emit `_emit_auth_event("idp_intent_failed", reason="unknown_idp"|"zitadel_5xx"|"missing_auth_url", …)`.
+  - Tests: 4 scenarios:
+    - Known IDP id → returns auth_url.
+    - Unknown IDP id → 400.
+    - Zitadel 5xx → 502 + event.
+    - Zitadel returns no `authUrl` → 502 + event (with `reason=missing_auth_url`).
+
+### 4.5 `idp_callback` (`GET /api/auth/idp-callback`)
+
+- **Code**: `auth.py:769-894` — most complex endpoint. Creates session
+  from intent, fetches user identity, looks up portal_users, handles
+  multi-org case (Redis pending session → /select-workspace), auto-provisions
+  via allowed-domain match, finalizes auth request, sets cookie, emits
+  `emit_event("login", method="idp")`.
+- **Audit log**: NONE — only `emit_event` (analytics, not audit).
+- **structlog**: PARTIAL — uses `_slog.info`, `_slog.exception` for
+  auto-provision; uses stdlib `logger.exception` for Zitadel-call failures.
+- **Tests**: PRESENT — `tests/test_idp_callback_provision.py` covers
+  auto-provision flow. Does NOT cover Zitadel/session failure paths.
+- **Concerns**:
+  - On every Zitadel failure path the response is 302 → failure_url. This
+    is correct UX (user sees the login form again). But there is NO
+    `audit.log_event` and NO structured failure event — every failure
+    is invisible.
+  - `_validate_callback_url(callback_url)` runs after a successful
+    `finalize_auth_request` — defends against Zitadel returning a hostile
+    callback URL.
+  - The auto-provision INSERT writes the email plaintext to `portal_users.email`. That's a DB-storage concern, not log-related — out of scope here.
+- **Recommendations**:
+  - Emit `audit.log_event(action="auth.login.idp", details={"method":"idp"})` on success.
+  - Emit `_emit_auth_event("idp_callback_failed", reason="session_creation_5xx"|"missing_session"|"finalize_5xx"|"get_session_details_failed", …)` on each failure leg.
+  - Migrate remaining stdlib `logger.exception` calls to `_slog.exception`.
+  - Tests: 6 scenarios:
+    - Happy path single-org → 302 to callback_url + cookie.
+    - Multi-org (existing test scope) → 302 to /select-workspace.
+    - Session-creation 5xx → 302 to failure_url + event.
+    - Session details fetch fails → continues (existing fail-open), event emitted.
+    - Finalize 5xx → 302 to failure_url + event.
+    - Auto-provision DB failure → user gets `org_found=false` (existing fail-open), `_slog.exception` fired (existing).
+
+### 4.6 `password_reset` (`POST /api/auth/password/reset`)
+
+- **Code**: `auth.py:317-335` — looks up user by email, sends reset.
+  Always returns 204 (anti-enumeration).
+- **Audit log**: NONE on success, NONE on failure.
+- **Tests**: NONE.
+- **Concerns**:
+  - **Anti-enumeration is the security property.** Every failure path
+    must return 204 too. Verified by reading the code — it does.
+  - Currently silently swallows all errors. Without a structured event,
+    a Zitadel outage is invisible AND the user gets no email. Adding the
+    event is a pure observability win (no UX regression).
+  - Email plaintext is the input; cannot be hashed in the request. But
+    the `audit.log_event` and `_emit_auth_event` calls MUST hash via
+    sha256 (the same `email_hash` field used in mfa_check_failed).
+- **Recommendations**:
+  - Emit `audit.log_event(action="auth.password.reset", actor="anonymous", details={"email_hash": <sha256>})` on every call (success or fail).
+  - Emit `_emit_auth_event("password_reset_failed", reason="zitadel_5xx"|"unknown_email", outcome="204", …)` on failure paths (still returns 204!).
+  - Tests: 4 scenarios:
+    - Known email → 204 + audit log + (no failed event).
+    - Unknown email → 204 + audit log + event with reason=unknown_email.
+    - Zitadel 5xx during find_user_id_by_email → 204 + event.
+    - Zitadel 5xx during send_password_reset → 204 + event.
+
+### 4.7 `password_set` (`POST /api/auth/password/set`)
+
+- **Code**: `auth.py:338-355` — `zitadel.set_password_with_code(user_id, code, new_password)`. 4xx (400/404/410) → "link expired"; 5xx → 502.
+- **Audit log**: NONE.
+- **Tests**: NONE.
+- **Concerns**:
+  - The `# nosemgrep: python-logger-credential-disclosure` is on the
+    `logger.exception` call — Semgrep was flagging because `exc.response.text` could contain the new password if Zitadel echoes it. The current code only logs `status=` so the suppression is defensive. Migrating to structlog removes the need.
+  - Brute-force attempts against the confirm code (4-6 digit?) should be
+    monitored — `_emit_auth_event` makes this trivially queryable.
+- **Recommendations**:
+  - Emit `audit.log_event(action="auth.password.set", actor=user_id, details={"reason": "code_invalid"|"set"})`.
+  - Emit `_emit_auth_event("password_set_failed", reason=…, …)` on failure.
+  - Tests: 4 scenarios:
+    - Valid code + valid password → 204 + audit log.
+    - Expired code (410) → 400 + event.
+    - Wrong code (400) → 400 + event.
+    - Zitadel 5xx → 502 + event.
+
+### 4.8 `sso_complete` (`POST /api/auth/sso-complete`)
+
+- **Code**: `auth.py:535-567` — reads `klai_sso` cookie, decrypts,
+  finalizes auth request. Three failure modes: no cookie → 401;
+  decrypt fail → 401; finalize fail → 401 ("session no longer valid").
+- **Audit log**: NONE.
+- **Tests**: NONE.
+- **Concerns**:
+  - Pre-existing finding #16 (Fernet key regen) means decrypt CAN fail
+    spuriously after a portal-api restart with empty `SSO_COOKIE_KEY`.
+    Tracked under SPEC-SEC-SESSION-001. Out of scope here, BUT the test
+    suite added under this SPEC must include "decrypt fail returns 401
+    cleanly" so the SEC-SESSION-001 fix is verifiable.
+- **Recommendations**:
+  - Emit `_emit_auth_event("sso_complete_failed", reason="no_cookie"|"cookie_invalid"|"session_expired", outcome="401", …)`.
+  - Tests: 4 scenarios:
+    - Valid cookie → 200 + callback_url.
+    - No cookie → 401 + event.
+    - Tampered/invalid cookie → 401 + event.
+    - Finalize 5xx → 401 + event.
+
+---
+
+## 5. Test infrastructure already in place
+
+`tests/test_auth_mfa_fail_closed.py` (landed via SPEC-SEC-MFA-001)
+established the test harness this SPEC reuses:
+
+- **respx fixture** mounted on `settings.zitadel_base_url`.
+- **`structlog.testing.capture_logs()`** for asserting on event emission.
+- **`AsyncMock(spec=AsyncSession)`** + `MagicMock` for DB session and
+  Response.
+- **`_audit_emit_patches()`** helper that suppresses `audit.log_event`
+  + `emit_event` side effects.
+- **`_make_login_body()` / `_make_db_mock()`** factory helpers.
+
+This SPEC should add:
+
+- **`_make_totp_body()`** for `TOTPLoginRequest`, `TOTPConfirmRequest`,
+  `TOTPSetupResponse` shapes.
+- **`_make_idp_intent_body()`** + **`_make_idp_callback_query()`**.
+- **`_make_password_reset_body()`** + **`_make_password_set_body()`**.
+- **`_make_sso_cookie()`** — produces a valid `klai_sso` Fernet-encrypted
+  cookie for the happy-path test.
+
+These belong in a **new shared module** `tests/auth_test_helpers.py`
+imported by both `test_auth_mfa_fail_closed.py` (refactor to use
+the shared module) and the new test files this SPEC creates.
+
+Test file plan:
+
+- `tests/test_auth_totp_endpoints.py` — totp_setup, totp_confirm, totp_login.
+- `tests/test_auth_idp_endpoints.py` — idp_intent, idp_callback (extend
+  test_idp_callback_provision.py? No — keep that focused; this is the
+  failure-path module.).
+- `tests/test_auth_password_endpoints.py` — password_reset, password_set.
+- `tests/test_auth_sso_endpoints.py` — sso_complete.
+
+Total estimated new tests: ~30. Plus refactor of existing test files to
+use the shared helpers module.
+
+---
+
+## 6. Coverage projection
+
+Current `app.api.auth` coverage (measured 2026-04-27 with
+`pytest --cov=app.api.auth --cov-branch`):
+
+- 537 statements, 100 branches.
+- 64% line coverage, 89% branch coverage.
+
+Per-endpoint missing coverage (estimated from line ranges):
+
+| Endpoint | Lines | Currently covered? |
+|---|---|---|
+| `_finalize_and_set_cookie` (179-219) | 41 lines | partial via login + idp_callback tests |
+| `password_reset` (317-335) | 19 lines | 0% |
+| `password_set` (338-355) | 18 lines | 0% |
+| `totp_login` (458-532) | 75 lines | 0% |
+| `sso_complete` (535-567) | 33 lines | 0% |
+| `totp_setup` (570-584) | 15 lines | 0% |
+| `totp_confirm` (611-629) | 19 lines | 0% |
+| `idp_intent` (739-766) | 28 lines | 0% |
+| `idp_callback` (769-894) | 126 lines | partial via test_idp_callback_provision.py |
+
+Estimated lines added to coverage by this SPEC: ~280 of the 537 total.
+**Projected coverage: ~85-90%** depending on how many fallback / edge-case
+branches get tested.
+
+This achieves SPEC-SEC-MFA-001 REQ-5.6's deferred 85% target.
+
+---
+
+## 7. Cross-references
+
+- **Tracker**: [SPEC-SEC-AUDIT-2026-04](../SPEC-SEC-AUDIT-2026-04/spec.md)
+- **Predecessor**: [SPEC-SEC-MFA-001](../SPEC-SEC-MFA-001/spec.md) —
+  established the structlog + structured event + @MX:ANCHOR pattern and
+  the test infrastructure this SPEC reuses. REQ-5.6 was deferred from
+  there to here.
+- **Sibling SPECs (out of scope here)**:
+  - [SPEC-SEC-SESSION-001](../SPEC-SEC-SESSION-001/spec.md) — TOTP counter,
+    cookie binding, Fernet key regen (findings #13, #15, #16).
+  - [SPEC-SEC-INTERNAL-001](../SPEC-SEC-INTERNAL-001/spec.md) —
+    `exc.response.text` log reflection (finding A4).
+- **Source under change** (read-only research targets, modification scope
+  per spec.md):
+  - [klai-portal/backend/app/api/auth.py](../../../klai-portal/backend/app/api/auth.py)
+  - [klai-portal/backend/app/services/zitadel.py](../../../klai-portal/backend/app/services/zitadel.py)
+    (read-only — no changes needed)
+  - [klai-portal/backend/tests/test_auth_mfa_fail_closed.py](../../../klai-portal/backend/tests/test_auth_mfa_fail_closed.py)
+    (refactor to import shared helpers)
+  - [klai-portal/backend/tests/test_idp_callback_provision.py](../../../klai-portal/backend/tests/test_idp_callback_provision.py)
+    (potentially extend, not strictly required)
+- **Logging rules**: [.claude/rules/klai/projects/portal-logging-py.md](../../../.claude/rules/klai/projects/portal-logging-py.md)
+- **MX tag protocol**: [.claude/rules/moai/workflow/mx-tag-protocol.md](../../../.claude/rules/moai/workflow/mx-tag-protocol.md)

--- a/.moai/specs/SPEC-SEC-AUTH-COVERAGE-001/spec.md
+++ b/.moai/specs/SPEC-SEC-AUTH-COVERAGE-001/spec.md
@@ -1,0 +1,301 @@
+---
+id: SPEC-SEC-AUTH-COVERAGE-001
+version: 0.1.0
+status: draft
+created: 2026-04-27
+updated: 2026-04-27
+author: Mark Vletter
+priority: medium
+issue_number: 0
+tracker: SPEC-SEC-AUDIT-2026-04
+lifecycle: spec-first
+predecessor: SPEC-SEC-MFA-001
+---
+
+# SPEC-SEC-AUTH-COVERAGE-001: auth.py coverage + observability hardening
+
+## HISTORY
+
+### v0.1.0 (2026-04-27)
+- Initial draft created via `/moai plan SPEC-SEC-AUTH-COVERAGE-001`.
+- Closes the deferred REQ-5.6 from
+  [SPEC-SEC-MFA-001](../SPEC-SEC-MFA-001/spec.md): bring overall coverage
+  on `klai-portal/backend/app/api/auth.py` to ≥85%.
+- Propagates the structlog + structured-event + @MX:ANCHOR patterns
+  established by SPEC-SEC-MFA-001 to the eight remaining in-scope auth
+  endpoints (totp_setup, totp_confirm, totp_login, idp_intent,
+  idp_callback, password_reset, password_set, sso_complete).
+- Cornelis-audit findings on these endpoints (#13, #15, #16, A4) are
+  out of scope — tracked by SPEC-SEC-SESSION-001 and SPEC-SEC-INTERNAL-001.
+
+---
+
+## Goal
+
+Two goals, in priority order:
+
+1. **Coverage** — Reach ≥85% line coverage and ≥95% branch coverage on
+   `klai-portal/backend/app/api/auth.py` measured via `pytest --cov`. This
+   closes SPEC-SEC-MFA-001 REQ-5.6 (deferred there per `minimal-changes`).
+2. **Observability hardening** — Apply the SPEC-SEC-MFA-001 pattern set
+   (structlog `_slog` for new log statements, structured `mfa_check_failed`-style
+   events on every failure leg, sha256-hashed email PII, audit log presence
+   on every state-changing endpoint, @MX:ANCHOR on shared helpers with
+   fan_in ≥3) to the remaining eight in-scope auth endpoints. The
+   underlying behaviour is preserved — this SPEC adds visibility and tests,
+   it does NOT change response shapes or status codes for any endpoint.
+
+---
+
+## Findings addressed
+
+This SPEC does NOT close audit findings — those are tracked in their own
+SPECs. It addresses the deferred coverage target and the observability
+asymmetry between `login` (covered by SPEC-SEC-MFA-001) and the eight
+sibling endpoints in the same file.
+
+| Source | Item | Resolution |
+|---|---|---|
+| SPEC-SEC-MFA-001 REQ-5.6 | "Overall coverage on `app.api.auth` SHALL be ≥85%" — deferred | Closed via REQ-5 of this SPEC. |
+| Internal observability gap | login / totp_login emit `audit.log_event`; six other endpoints do not | Closed via REQ-1..REQ-4 audit-log additions. |
+| Internal observability gap | login emits structured `mfa_check_failed` events; other endpoints emit nothing structured | Closed via REQ-1..REQ-4 `_emit_auth_event` additions. |
+| portal-logging-py.md rule | "Always use structlog for new log statements" | Closed via REQ-5 stdlib→structlog migration on the 16 logger.* call sites. |
+| MX tag protocol | `_finalize_and_set_cookie` (fan_in=3), `_validate_callback_url` (fan_in=3), `_emit_auth_event` (fan_in≥15) lack @MX:ANCHOR | Closed via REQ-5 anchor additions. |
+
+---
+
+## Environment
+
+- **Service**: `klai-portal/backend` (Python 3.13, FastAPI, SQLAlchemy async).
+- **Files in scope**:
+  - `klai-portal/backend/app/api/auth.py` — 8 endpoint handlers, 16 log-statement migrations, helper extraction.
+  - `klai-portal/backend/tests/test_auth_totp_endpoints.py` — NEW (totp_setup, totp_confirm, totp_login).
+  - `klai-portal/backend/tests/test_auth_idp_endpoints.py` — NEW (idp_intent, idp_callback failure paths).
+  - `klai-portal/backend/tests/test_auth_password_endpoints.py` — NEW (password_reset, password_set).
+  - `klai-portal/backend/tests/test_auth_sso_endpoints.py` — NEW (sso_complete).
+  - `klai-portal/backend/tests/auth_test_helpers.py` — NEW shared module (request-body factories, db-mock factories, respx fixture, `_audit_emit_patches`, `_mfa_events`-style filter).
+  - `klai-portal/backend/tests/test_auth_mfa_fail_closed.py` — REFACTOR to import shared helpers.
+- **Out of scope** (explicit non-goals):
+  - `passkey_setup`, `passkey_confirm` (deferred to a separate follow-up).
+  - `email_otp_setup`, `email_otp_confirm`, `email_otp_resend`, `verify_email` (deferred — same flow class).
+  - `idp_intent_signup`, `idp_signup_callback` (signup flow, separate scope).
+  - Cornelis-audit findings #13, #15, #16, A4 (tracked by SPEC-SEC-SESSION-001 and SPEC-SEC-INTERNAL-001).
+- **Identity provider**: Zitadel (auth.getklai.com), service account `portal-api`.
+- **Observability**: structlog JSON → Alloy → VictoriaLogs; Grafana for alerts.
+
+---
+
+## Assumptions
+
+- The endpoints' current response semantics are correct (Cornelis-audit
+  did not flag them). This SPEC adds tests + observability around the
+  existing behaviour — it does NOT change behaviour beyond what the
+  observability hardening adds.
+- The `_pending_totp` in-memory cache (finding #13) will be replaced by
+  Redis under SPEC-SEC-SESSION-001. Tests written here express invariants
+  ("after 5 failures the token is invalidated") not implementation
+  details ("the in-memory dict has 0 entries"), so they survive that
+  migration.
+- `respx>=0.22` (added in SPEC-SEC-MFA-001) is available; `structlog.testing.capture_logs` is used as the assertion surface.
+- The shared `_emit_auth_event` helper produces events queryable in
+  VictoriaLogs as `service:portal-api event:<name>_failed`. Grafana alerts
+  for these events are NOT in scope for this SPEC — they will follow in
+  a separate observability rollup if the rate is non-trivial.
+
+---
+
+## Out of Scope
+
+- **Audit findings on these endpoints** — see Findings table above. SEC-SESSION-001 and SEC-INTERNAL-001 own those.
+- **Behaviour changes** — no status code shifts, no response body shape changes, no new failure modes introduced. This is purely additive (audit logs, structured events, tests, anchors).
+- **Frontend changes** — the failure events are server-side observability; the existing frontend handlers for 400/401/502 remain unchanged.
+- **Grafana alerts** — defining alerts for the new events is not in scope. They are query-able in VictoriaLogs immediately on deploy. If sustained rates indicate alert is justified, follow-up SPEC.
+- **Rate-limiting at the API layer** — TOTP confirm and password set are rate-limited by Zitadel server-side; portal-api adds no per-request rate limit. This SPEC keeps that posture.
+- **passkey_*, email_otp_*, verify_email, idp_*_signup endpoints** — deferred (research.md §1).
+- **DB-storage PII (email plaintext in `portal_users.email`)** — out of scope; that is a column-level encryption SPEC.
+
+---
+
+## Threat Model
+
+The auth endpoints have already been audited by Cornelis (2026-04-22).
+Exploitable findings are tracked in their own SPECs. The threat surface
+this SPEC addresses is **observability-blind regressions**:
+
+1. **Silent Zitadel degradation.** A Zitadel 5xx flap during, e.g.,
+   `password_set` or `idp_intent` is currently logged with
+   `logger.exception` (a non-queryable string). On-call has no way to
+   distinguish a genuine "user typed wrong code" 400 from a 5xx
+   degradation that took us out. After this SPEC, every 5xx leg emits
+   a structured `*_failed` event with `zitadel_status`, queryable
+   independently of the human-readable log message.
+
+2. **Brute-force enumeration.** TOTP confirm and password reset endpoints
+   are currently rate-limited only at Zitadel. A coordinated brute-force
+   from a single IP would show in Caddy access logs but not in any
+   business-event log. After this SPEC, `totp_confirm_failed` /
+   `password_set_failed` events with `reason=invalid_code` enable rate
+   queries in VictoriaLogs without needing Caddy log correlation.
+
+3. **Audit-trail gaps.** Today's audit log only captures `auth.login*`
+   actions. A successful TOTP enrolment, a successful password reset,
+   or an IDP-callback session completion has no audit row. After this
+   SPEC, every state-changing auth action emits `audit.log_event` with
+   the correct `actor` (zitadel_user_id when known, sha256(email) when
+   anonymous, `"unknown"` when neither).
+
+4. **Test-coverage regression.** `auth.py` is 537 statements; today only
+   ~64% are covered. A future refactor of, e.g., `idp_callback` could
+   silently break the auto-provision flow without any test failing
+   (only the existing `test_idp_callback_provision.py` covers a happy
+   path). After this SPEC, ≥85% line coverage with respx-mocked
+   regression scenarios protects against silent regressions.
+
+**Explicit non-threats**:
+
+- This SPEC does NOT defend against new attacker-controlled inputs —
+  Cornelis-audit confirmed the existing input handling is sound.
+- This SPEC does NOT change anti-enumeration behaviour on
+  `password_reset` (always returns 204).
+
+---
+
+## Requirements
+
+### REQ-1: TOTP endpoints — audit log + structured events + tests
+
+WHEN a request reaches `totp_setup`, `totp_confirm`, or `totp_login`,
+THE handler SHALL emit an `audit.log_event` for state changes and a
+structured `*_failed` event for every failure leg, AND new pytest
+regression tests SHALL exist that exercise every documented branch.
+
+- **REQ-1.1**: WHEN `totp_setup` succeeds, THE handler SHALL emit
+  `audit.log_event(action="auth.totp.setup", actor=user_id, resource_type="user", resource_id=user_id, details={"reason": "initiated"})`.
+- **REQ-1.2**: WHEN `totp_setup` fails (5xx), THE handler SHALL emit
+  `_emit_auth_event("totp_setup_failed", reason="zitadel_5xx", zitadel_status=<int>, actor_user_id=<id>, outcome="502", level="error")` BEFORE raising the existing 502.
+- **REQ-1.3**: WHEN `totp_confirm` succeeds, THE handler SHALL emit
+  `audit.log_event(action="auth.totp.confirmed", actor=user_id, …)`.
+- **REQ-1.4**: WHEN `totp_confirm` fails 4xx (wrong code), THE handler
+  SHALL emit `_emit_auth_event("totp_confirm_failed", reason="invalid_code", zitadel_status=<int>, actor_user_id=<id>, outcome="400", level="warning")` BEFORE raising the existing 400.
+- **REQ-1.5**: WHEN `totp_confirm` fails 5xx, THE handler SHALL emit the same event with `reason="zitadel_5xx"`, `outcome="502"`, `level="error"`.
+- **REQ-1.6**: WHEN `totp_login` fails 4xx (wrong code) AND `failures<MAX`, THE handler SHALL emit `_emit_auth_event("totp_login_failed", reason="invalid_code", failures=<int>, outcome="400", level="warning")` IN ADDITION TO the existing `audit.log_event(action="auth.totp.failed", …)`.
+- **REQ-1.7**: WHEN `totp_login` reaches the lockout threshold, THE handler SHALL emit `_emit_auth_event("totp_login_failed", reason="lockout", failures=<MAX>, outcome="429", level="error")` BEFORE invalidating the temp token.
+- **REQ-1.8**: A new test file `tests/test_auth_totp_endpoints.py` SHALL contain at least 13 scenarios covering: setup happy + 5xx; confirm happy + invalid + 5xx; login happy + 1st-fail + 5th-fail-lockout + already-locked + expired-token + finalize-fail.
+
+### REQ-2: IDP endpoints — audit log + structured events + tests
+
+WHEN a request reaches `idp_intent` or `idp_callback`, THE handler SHALL
+emit an `audit.log_event` for state changes and a structured event for
+every failure leg.
+
+- **REQ-2.1**: WHEN `idp_intent` succeeds, THE handler SHALL emit
+  `audit.log_event(action="auth.idp.intent", actor="anonymous", details={"idp_id": <hashed>, "auth_request_id": <id>})`.
+  The `idp_id` is a stable Zitadel ID (not PII) so it MAY be logged
+  unhashed; preference is to log it as-is so on-call can identify the
+  IDP without needing a lookup table.
+- **REQ-2.2**: WHEN `idp_intent` fails (unknown IDP, Zitadel 5xx, missing
+  authUrl), THE handler SHALL emit
+  `_emit_auth_event("idp_intent_failed", reason="unknown_idp"|"zitadel_5xx"|"missing_auth_url", …, outcome="400"|"502", level=<warning|error>)`.
+- **REQ-2.3**: WHEN `idp_callback` succeeds (single-org or multi-org
+  branch), THE handler SHALL emit
+  `audit.log_event(action="auth.login.idp", actor=zitadel_user_id, details={"method": "idp", "auto_provisioned": <bool>})`.
+- **REQ-2.4**: WHEN `idp_callback` fails on any leg
+  (session_creation_5xx, missing_session, finalize_5xx, get_session_details_failed),
+  THE handler SHALL emit
+  `_emit_auth_event("idp_callback_failed", reason=<leg>, …, outcome="302→failure_url", level="error")`
+  AND continue with the existing 302-to-failure_url behaviour
+  (no status code change).
+- **REQ-2.5**: A new test file `tests/test_auth_idp_endpoints.py` SHALL
+  contain at least 8 scenarios covering: intent happy + unknown_idp + 5xx + missing_authUrl; callback session-creation-5xx + finalize-5xx + missing-session + auto-provision-DB-fail.
+
+### REQ-3: Password endpoints — audit log + structured events + tests
+
+WHEN a request reaches `password_reset` or `password_set`, THE handler
+SHALL emit `audit.log_event` for every call (anti-enumeration is
+preserved by always returning 204) and a structured event for every
+failure leg.
+
+- **REQ-3.1**: WHEN `password_reset` is called (regardless of outcome),
+  THE handler SHALL emit
+  `audit.log_event(action="auth.password.reset", actor="anonymous", details={"email_hash": <sha256>})`.
+- **REQ-3.2**: WHEN `password_reset` cannot find a user (unknown email),
+  THE handler SHALL emit
+  `_emit_auth_event("password_reset_failed", reason="unknown_email", email_hash=<sha256>, outcome="204", level="warning")`.
+  The HTTP response remains 204 (anti-enumeration).
+- **REQ-3.3**: WHEN `password_reset` fails on Zitadel 5xx, THE handler
+  SHALL emit `_emit_auth_event("password_reset_failed", reason="zitadel_5xx", zitadel_status=<int>, email_hash=<sha256>, outcome="204", level="error")`.
+- **REQ-3.4**: WHEN `password_set` succeeds, THE handler SHALL emit
+  `audit.log_event(action="auth.password.set", actor=user_id, details={"reason": "set"})`.
+- **REQ-3.5**: WHEN `password_set` fails 4xx (expired/invalid link), THE handler
+  SHALL emit `_emit_auth_event("password_set_failed", reason="invalid_code"|"expired_link", actor_user_id=<id>, outcome="400", level="warning")`.
+- **REQ-3.6**: WHEN `password_set` fails 5xx, THE handler SHALL emit
+  `_emit_auth_event("password_set_failed", reason="zitadel_5xx", zitadel_status=<int>, actor_user_id=<id>, outcome="502", level="error")`.
+- **REQ-3.7**: A new test file `tests/test_auth_password_endpoints.py` SHALL contain at least 8 scenarios covering: reset happy + unknown_email + find_user_5xx + send_reset_5xx; set happy + expired-link + 5xx + audit log presence.
+
+### REQ-4: SSO endpoint — structured events + tests
+
+WHEN a request reaches `sso_complete`, THE handler SHALL emit a structured
+event for every failure leg.
+
+- **REQ-4.1**: WHEN `sso_complete` is missing the `klai_sso` cookie, THE handler SHALL emit `_emit_auth_event("sso_complete_failed", reason="no_cookie", outcome="401", level="warning")` BEFORE raising the existing 401.
+- **REQ-4.2**: WHEN the cookie is present but decryption fails, THE handler SHALL emit `_emit_auth_event("sso_complete_failed", reason="cookie_invalid", outcome="401", level="warning")` BEFORE raising the existing 401.
+- **REQ-4.3**: WHEN `finalize_auth_request` raises HTTPStatusError on a valid cookie, THE handler SHALL emit `_emit_auth_event("sso_complete_failed", reason="session_expired", zitadel_status=<int>, outcome="401", level="warning")` BEFORE raising the existing 401.
+- **REQ-4.4**: `sso_complete` SHALL NOT emit `audit.log_event` for success — the cookie reuse is silent UX (the user did not interact). Failures are observability-only.
+- **REQ-4.5**: A new test file `tests/test_auth_sso_endpoints.py` SHALL contain at least 4 scenarios covering: happy path + no cookie + tampered cookie + finalize 5xx.
+
+### REQ-5: Cross-cutting hardening (helpers, logger migration, coverage gate)
+
+The following cross-cutting changes apply across the in-scope endpoints
+to honour the SPEC-SEC-MFA-001 pattern set:
+
+- **REQ-5.1**: A new helper `_emit_auth_event(event: str, *, reason: str, outcome: str, level: str = "warning", **fields: Any) -> None` SHALL be added to `auth.py`. It is a generalisation of `_emit_mfa_check_failed` — instead of a fixed event name, it takes one as a parameter. `_emit_mfa_check_failed` SHALL be reimplemented as a thin wrapper that calls `_emit_auth_event("mfa_check_failed", …)`.
+- **REQ-5.2**: Email values passed via the `email` keyword SHALL be sha256-hashed inside the helper into an `email_hash` field; raw emails MUST NEVER appear in the emitted event. The helper SHALL accept `email_hash` directly as an alternative for callers who already hashed.
+- **REQ-5.3**: Every stdlib `logger.*` call site in the eight in-scope endpoints SHALL be migrated to `_slog.*` per `portal-logging-py.md`. The `# nosemgrep: python-logger-credential-disclosure` annotations on `password_reset` and `password_set` SHALL be REMOVED post-migration (structlog removes the false-positive trigger).
+- **REQ-5.4**: `@MX:ANCHOR` tags SHALL be added to `_finalize_and_set_cookie` (fan_in=3), `_validate_callback_url` (fan_in=3), and the new `_emit_auth_event` (projected fan_in≥15). Each MUST include `@MX:REASON` and `@MX:SPEC: SPEC-SEC-AUTH-COVERAGE-001` sub-lines.
+- **REQ-5.5**: `pytest --cov=app.api.auth --cov-branch --cov-fail-under=85` SHALL pass on this SPEC's branch. Branch coverage SHALL be ≥95%.
+- **REQ-5.6**: A shared test-helper module `tests/auth_test_helpers.py` SHALL be created exposing the request-body factories, DB mock factory, respx fixture, audit-emit patches, and event-filter helper. `tests/test_auth_mfa_fail_closed.py` SHALL be refactored to import from this module (no behaviour change, only de-duplication).
+- **REQ-5.7**: All new tests SHALL use respx against the real `ZitadelClient` (REQ-5.7 from SPEC-SEC-MFA-001) — no `MagicMock` on `app.api.auth.zitadel`. Existing legacy tests in `test_auth_security.py` keep their patch-based pattern unchanged.
+
+---
+
+## Non-Functional Requirements
+
+- **Performance**: The added `_emit_auth_event` and `audit.log_event` calls add ≤2 calls per request × ~1 ms each = ≤2 ms p95 overhead per auth call. Anti-enumeration on `password_reset` keeps the same ≤200 ms total. No new Zitadel round-trips, no new DB queries.
+- **Observability**: Every fail-closed outcome SHALL be visible in VictoriaLogs via `service:portal-api AND event:<endpoint>_<action>_failed`. Cross-correlatable with Caddy access logs via `request_id`.
+- **Privacy**: `email_hash` (sha256 lowercased) is the only user-identifying field for unauthenticated endpoints; `actor_user_id` (zitadel id, an opaque uuid) is used for authenticated endpoints. Plaintext emails MUST NEVER appear in the emitted events.
+- **Backward compatibility**: All response shapes, status codes, and headers remain unchanged. Audit log writes are fire-and-forget (existing pattern); a write failure does NOT block the response.
+- **Test discipline**: Existing test files unchanged in semantics. Refactoring of `test_auth_mfa_fail_closed.py` is import-only (no test logic changes). Coverage measured via `pytest-cov`; reported in CHANGELOG.
+
+---
+
+## Success Criteria
+
+- `pytest --cov=app.api.auth --cov-branch` reports ≥85% line coverage and ≥95% branch coverage.
+- `tests/test_auth_totp_endpoints.py`, `tests/test_auth_idp_endpoints.py`, `tests/test_auth_password_endpoints.py`, `tests/test_auth_sso_endpoints.py` exist with ≥33 total new scenarios and pass via `pytest`.
+- `tests/auth_test_helpers.py` exists; `tests/test_auth_mfa_fail_closed.py` imports from it; both files share a single source of truth for request/db factories.
+- `_emit_auth_event` exists and is documented with `@MX:ANCHOR`. `_emit_mfa_check_failed` is now a 1-line wrapper.
+- All eight in-scope endpoints emit at least one structured `*_failed` event for every failure leg, verifiable via `capture_logs()` assertions.
+- All eight in-scope endpoints emit `audit.log_event` for every state-changing success path (sso_complete excluded per REQ-4.4).
+- All stdlib `logger.*` call sites in the eight in-scope endpoints are migrated to `_slog.*`. `grep "logger\." auth.py` returns at most the existing pre-scope `logger = logging.getLogger(__name__)` declaration plus any out-of-scope endpoints' calls.
+- `# nosemgrep: python-logger-credential-disclosure` annotations on `password_reset` and `password_set` are removed.
+- `@MX:ANCHOR` tags on `_finalize_and_set_cookie`, `_validate_callback_url`, and `_emit_auth_event` are present and pass `verify-alert-runbooks`-equivalent MX validator (P1 unblocked).
+- `ruff check app/api/auth.py tests/test_auth_*.py` clean.
+- `ruff format --check app/api/auth.py tests/test_auth_*.py` clean.
+- `uv run --with pyright pyright app/api/auth.py` reports 0/0/0.
+- Full backend `pytest` reports zero regressions vs the pre-SPEC baseline.
+
+---
+
+## Cross-references
+
+- Tracker: [SPEC-SEC-AUDIT-2026-04](../SPEC-SEC-AUDIT-2026-04/spec.md)
+- Predecessor: [SPEC-SEC-MFA-001](../SPEC-SEC-MFA-001/spec.md)
+- Sibling SPECs (out of scope): [SPEC-SEC-SESSION-001](../SPEC-SEC-SESSION-001/spec.md), [SPEC-SEC-INTERNAL-001](../SPEC-SEC-INTERNAL-001/spec.md)
+- Research: [research.md](./research.md)
+- Acceptance: [acceptance.md](./acceptance.md)
+- Plan: [plan.md](./plan.md)
+- Source under change:
+  - [klai-portal/backend/app/api/auth.py](../../../klai-portal/backend/app/api/auth.py)
+  - [klai-portal/backend/tests/test_auth_mfa_fail_closed.py](../../../klai-portal/backend/tests/test_auth_mfa_fail_closed.py) (refactor only)
+- Logging rules: [portal-logging-py.md](../../../.claude/rules/klai/projects/portal-logging-py.md)
+- MX tag protocol: [mx-tag-protocol.md](../../../.claude/rules/moai/workflow/mx-tag-protocol.md)


### PR DESCRIPTION
## Summary

Plan-fase artifacts voor [SPEC-SEC-AUTH-COVERAGE-001](.moai/specs/SPEC-SEC-AUTH-COVERAGE-001/spec.md) — sluit de deferred REQ-5.6 uit SPEC-SEC-MFA-001 (overall ≥85% coverage op `klai-portal/backend/app/api/auth.py`) en propageert de SPEC-SEC-MFA-001 pattern set (`_slog`, structured `*_failed` events, `@MX:ANCHOR`, audit log) naar de acht overige in-scope auth endpoints: TOTP {setup, confirm, login}, IDP {intent, callback}, password {reset, set}, sso_complete.

**No code changes** — alleen 4 SPEC documents:

- `research.md` — endpoint-by-endpoint deep-read + cross-references naar SEC-SESSION-001 / SEC-INTERNAL-001 / SEC-AUDIT-2026-04
- `spec.md` — 5 EARS REQs (TOTP / IDP / password / SSO / cross-cutting helpers)
- `acceptance.md` — 34 Given/When/Then scenarios met REQ↔scenario coverage tabel
- `plan.md` — 7 implementatie cycles in dependency order, MX tag plan, risk analysis

## Out of scope (expliciet)

Cornelis-audit findings op deze endpoints leven in zustier-SPECs en worden NIET dubbel gefixt:

- `#13` (TOTP counter per-instance), `#15` (idp cookie binding), `#16` (Fernet key regen) → [SPEC-SEC-SESSION-001](.moai/specs/SPEC-SEC-SESSION-001/spec.md)
- `A4` (`exc.response.text` log reflection, 20+ sites) → [SPEC-SEC-INTERNAL-001](.moai/specs/SPEC-SEC-INTERNAL-001/spec.md)

Tests asserteren observable behavior (HTTP status + captured events), zodat ze die toekomstige migraties overleven.

Ook deferred (geen runs in deze SPEC): passkey × 2, email_otp × 3, verify_email, idp_*_signup × 2 endpoints.

## Test plan

- [x] SPEC structure validated locally
- [ ] Post-merge: user reviews + opens `/moai run SPEC-SEC-AUTH-COVERAGE-001` to start implementation cycles A-G

## Voorgestelde follow-up

- `/moai run SPEC-SEC-AUTH-COVERAGE-001` (start cycles A-G; ~42 nieuwe test scenarios + helper extraction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)