### PR TITLE
feat(retrieval-api): SPEC-SEC-HYGIENE-001 retrieval slice (HY-39..HY-44)

### DIFF
--- a/klai-retrieval-api/pyproject.toml
+++ b/klai-retrieval-api/pyproject.toml
@@ -40,10 +40,16 @@ line-length = 100
 target-version = "py312"
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "UP", "B", "S", "RUF", "G", "LOG"]
+# SPEC-SEC-HYGIENE-001 REQ-43.4: TRY rules added so future regressions of
+# `logger.error(...)` inside `except` (TRY400) or `error=str(exc)`-style
+# traceback dropping (TRY401) are caught in CI.
+select = ["E", "F", "I", "UP", "B", "S", "RUF", "G", "LOG", "TRY"]
 ignore = [
     "S101",  # assert is fine in tests
     "S105",  # hardcoded passwords — too many false positives on config defaults
+    "TRY003",  # raise-vanilla-args — too noisy for our HTTPException patterns
+    "TRY300",  # try-consider-using-else — stylistic, not a safety issue
+    "TRY301",  # raise-within-try — needed when wrapping/translating exceptions
 ]
 
 [tool.pytest.ini_options]

--- a/klai-retrieval-api/retrieval_api/api/retrieve.py
+++ b/klai-retrieval-api/retrieval_api/api/retrieve.py
@@ -176,8 +176,10 @@ async def retrieve(req: RetrieveRequest, request: Request) -> RetrieveResponse:
                 graph_results_count = len(graph_results)
                 if graph_results:
                     raw_results = _rrf_merge(raw_results, graph_results)
-            except Exception as exc:
-                logger.warning("Graph search task failed", error=str(exc))
+            except Exception:
+                # SPEC-SEC-HYGIENE-001 REQ-43.3: exc_info=True preserves the
+                # traceback that the previous `error=str(exc)` dropped (TRY401).
+                logger.warning("Graph search task failed", exc_info=True)
 
         candidates_retrieved = len(raw_results)
         decision_record["search_candidates_count"] = candidates_retrieved

--- a/klai-retrieval-api/retrieval_api/config.py
+++ b/klai-retrieval-api/retrieval_api/config.py
@@ -129,7 +129,18 @@ class Settings(BaseSettings):
 
     @property
     def jwt_auth_enabled(self) -> bool:
-        """True when both Zitadel issuer and audience are configured."""
+        """True when both Zitadel issuer and audience are configured.
+
+        SPEC-SEC-HYGIENE-001 REQ-44.2 / REQ-44.6: the SPEC asks for a
+        startup validator that fails when ``jwt_auth_enabled=True AND
+        jwks_url=""``. That failure mode is **unreachable by construction**
+        in retrieval-api because there is no separate ``jwks_url`` field —
+        it is derived inside ``middleware.auth._fetch_jwks`` as
+        ``f"{zitadel_issuer}/oauth/v2/keys"``. ``jwt_auth_enabled`` is
+        True only when ``zitadel_issuer`` is non-empty, so the JWKS URL
+        cannot be empty when JWT auth is enabled. No validator is needed;
+        this docstring serves as the SPEC's "documented acceptance".
+        """
         return bool(
             self.zitadel_issuer
             and self.zitadel_issuer.strip()

--- a/klai-retrieval-api/retrieval_api/config.py
+++ b/klai-retrieval-api/retrieval_api/config.py
@@ -69,6 +69,11 @@ class Settings(BaseSettings):
     portal_events_user: str = "klai"
     portal_events_password: str = ""
     portal_events_db: str = "klai"
+    # SPEC-SEC-HYGIENE-001 REQ-40: cap on the in-flight `_pending` task set
+    # in services/events.py. Under a flood (Redis fail-open + retrieval
+    # spike) unbounded growth would OOM the worker. 1000 is generous
+    # headroom for normal traffic; tune via the env var.
+    retrieval_events_max_pending: int = 1000
 
     # SPEC-SEC-010 — Authentication and request hardening
     # Shared secret for internal service-to-service calls (portal-api, research-api, LiteLLM hook).

--- a/klai-retrieval-api/retrieval_api/logging_setup.py
+++ b/klai-retrieval-api/retrieval_api/logging_setup.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import re
 import sys
 import uuid
 
@@ -9,6 +10,14 @@ import structlog
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
+
+# SPEC-SEC-HYGIENE-001 REQ-41: hard caps on incoming trace headers so an
+# attacker cannot poison every log line with terminal escape sequences,
+# HTML tags, or multi-megabyte garbage. Values that fail validation are
+# either replaced (X-Request-ID → server UUID) or dropped from the log
+# context (X-Org-ID), never propagated verbatim.
+_REQUEST_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
+_ORG_ID_RE = re.compile(r"^[0-9]{1,20}$")
 
 
 def setup_logging(service_name: str = "retrieval-api") -> None:
@@ -64,16 +73,26 @@ def setup_logging(service_name: str = "retrieval-api") -> None:
 
 
 class RequestContextMiddleware(BaseHTTPMiddleware):
-    """Bind trace context from upstream services to structlog for log correlation."""
+    """Bind trace context from upstream services to structlog for log correlation.
+
+    SPEC-SEC-HYGIENE-001 REQ-41: header values are validated against tight
+    regexes before they reach the structlog context. Invalid X-Request-ID
+    is replaced with a server-generated UUID; invalid X-Org-ID is dropped
+    from the context entirely (not rejected at the HTTP layer, because
+    the same header has multiple legitimate origins downstream).
+    """
 
     async def dispatch(self, request: Request, call_next: ...) -> Response:
         structlog.contextvars.clear_contextvars()
         structlog.contextvars.bind_contextvars(service="retrieval-api")
 
-        request_id = request.headers.get("x-request-id") or str(uuid.uuid4())
+        raw_request_id = request.headers.get("x-request-id") or ""
+        request_id = raw_request_id if _REQUEST_ID_RE.match(raw_request_id) else str(uuid.uuid4())
         structlog.contextvars.bind_contextvars(request_id=request_id)
-        if org_id := request.headers.get("x-org-id"):
-            structlog.contextvars.bind_contextvars(org_id=org_id)
+
+        raw_org_id = request.headers.get("x-org-id")
+        if raw_org_id and _ORG_ID_RE.match(raw_org_id):
+            structlog.contextvars.bind_contextvars(org_id=raw_org_id)
 
         response = await call_next(request)
         response.headers["X-Request-ID"] = request_id

--- a/klai-retrieval-api/retrieval_api/main.py
+++ b/klai-retrieval-api/retrieval_api/main.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from contextlib import asynccontextmanager
 
@@ -96,16 +97,23 @@ app.mount("/metrics", make_asgi_app())
 
 @app.get("/health")
 async def health():
-    """Check reachability of TEI, Qdrant, and LiteLLM."""
+    """Check reachability of TEI, Qdrant, LiteLLM, and (optionally) FalkorDB.
+
+    SPEC-SEC-HYGIENE-001 REQ-39: dependency failures MUST NOT leak internal
+    topology (hostnames, IPs, error strings) to unauthenticated callers, and
+    sync clients MUST NOT block the asyncio event loop. The exception detail
+    is preserved in structured logs via ``exc_info=True``.
+    """
     checks: dict[str, str] = {}
 
     # TEI (dense embeddings, port 7997 on gpu-01)
     try:
         async with httpx.AsyncClient(timeout=3.0) as client:
             resp = await client.get(f"{settings.tei_url}/health")
-            checks["tei"] = "ok" if resp.status_code == 200 else f"status={resp.status_code}"
-    except Exception as exc:
-        checks["tei"] = f"error: {exc}"
+            checks["tei"] = "ok" if resp.status_code == 200 else "error"
+    except Exception:
+        logger.warning("health_check_failed: tei", exc_info=True)
+        checks["tei"] = "error"
 
     # Qdrant
     try:
@@ -122,8 +130,9 @@ async def health():
             )
         await qc.get_collections()
         checks["qdrant"] = "ok"
-    except Exception as exc:
-        checks["qdrant"] = f"error: {exc}"
+    except Exception:
+        logger.warning("health_check_failed: qdrant", exc_info=True)
+        checks["qdrant"] = "error"
 
     # LiteLLM
     try:
@@ -132,24 +141,34 @@ async def health():
             if settings.litellm_api_key:
                 headers["Authorization"] = f"Bearer {settings.litellm_api_key}"
             resp = await client.get(f"{settings.litellm_url}/health/liveliness", headers=headers)
-            checks["litellm"] = "ok" if resp.status_code == 200 else f"status={resp.status_code}"
-    except Exception as exc:
-        checks["litellm"] = f"error: {exc}"
+            checks["litellm"] = "ok" if resp.status_code == 200 else "error"
+    except Exception:
+        logger.warning("health_check_failed: litellm", exc_info=True)
+        checks["litellm"] = "error"
 
-    # FalkorDB — only checked when Graphiti is enabled (AC-12)
+    # FalkorDB — only checked when Graphiti is enabled (AC-12).
+    # REQ-39.1: ``db.connection.ping()`` is the falkordb sync client; running
+    # it directly in an async handler blocks the event loop (Caddy polls
+    # /health every ~10 s). Hop into the default thread pool via
+    # ``asyncio.to_thread`` so concurrent /health probes and live retrieve
+    # traffic are not stalled on the ping round-trip.
     if settings.graphiti_enabled:
         try:
             from falkordb import FalkorDB
 
             db = FalkorDB(host=settings.falkordb_host, port=settings.falkordb_port)
-            db.connection.ping()
+            await asyncio.to_thread(db.connection.ping)
             checks["falkordb"] = "ok"
-        except Exception as exc:
-            checks["falkordb"] = f"error: {exc}"
+        except Exception:
+            logger.warning("health_check_failed: falkordb", exc_info=True)
+            checks["falkordb"] = "error"
 
     all_ok = all(v == "ok" for v in checks.values())
     status_code = 200 if all_ok else 503
 
     from fastapi.responses import JSONResponse
 
-    return JSONResponse(content={"status": "ok" if all_ok else "degraded", **checks}, status_code=status_code)
+    return JSONResponse(
+        content={"status": "ok" if all_ok else "degraded", **checks},
+        status_code=status_code,
+    )

--- a/klai-retrieval-api/retrieval_api/metrics.py
+++ b/klai-retrieval-api/retrieval_api/metrics.py
@@ -66,3 +66,11 @@ cross_org_rejected_total = Counter(
     "retrieval_api_cross_org_rejected_total",
     "Requests rejected because body org_id != JWT resourceowner",
 )
+
+# SPEC-SEC-HYGIENE-001 REQ-40 — events that overflow the bounded
+# ``services.events._pending`` set are dropped to prevent OOM during
+# flood conditions; this counter makes drops observable in Prometheus.
+retrieval_events_dropped_total = Counter(
+    "retrieval_events_dropped_total",
+    "Product events dropped because the pending-tasks cap was reached",
+)

--- a/klai-retrieval-api/retrieval_api/middleware/auth.py
+++ b/klai-retrieval-api/retrieval_api/middleware/auth.py
@@ -157,7 +157,11 @@ async def _fetch_jwks() -> dict[str, Any]:
     import httpx  # local import keeps the middleware cheap to load at startup
 
     jwks_url = f"{settings.zitadel_issuer}/oauth/v2/keys"
-    async with httpx.AsyncClient(timeout=10.0) as client:
+    # SPEC-SEC-HYGIENE-001 REQ-44.3: cap the JWKS fetch timeout at 3 s
+    # (down from 10 s). Zitadel's JWKS endpoint responds sub-second; a
+    # 10 s ceiling left workers exposed to slow-loris on the JWKS host
+    # for longer than necessary.
+    async with httpx.AsyncClient(timeout=3.0) as client:
         resp = await client.get(jwks_url)
         resp.raise_for_status()
         return resp.json()

--- a/klai-retrieval-api/retrieval_api/services/events.py
+++ b/klai-retrieval-api/retrieval_api/services/events.py
@@ -6,22 +6,36 @@ resolved automatically from the Zitadel ``tenant_id`` using a sub-query.
 
 Pool lifecycle is managed by the FastAPI lifespan (init_pool / close_pool).
 Connection params are taken from individual settings (no DSN parsing needed).
+
+SPEC-SEC-HYGIENE-001 REQ-40: ``_pending`` is capped at
+``settings.retrieval_events_max_pending`` (default 1000). When the cap is
+hit ``emit_event`` drops the new event, increments
+``retrieval_events_dropped_total`` and emits a rate-limited
+``retrieval_events_cap_hit`` warning so operators see the back-pressure
+without flooding the log pipeline.
 """
 
 from __future__ import annotations
 
 import asyncio
 import json
+import time
 
 import asyncpg
 import structlog
 
 from retrieval_api.config import settings
+from retrieval_api.metrics import retrieval_events_dropped_total
 
 logger = structlog.get_logger()
 
 _pool: asyncpg.Pool | None = None
 _pending: set[asyncio.Task] = set()
+
+# REQ-40.2: rate-limit cap-hit warnings to ~1/min so a flood of drops
+# cannot itself flood the log pipeline.
+_CAP_LOG_INTERVAL_SECONDS = 60.0
+_last_cap_log_time: float = 0.0
 
 _INSERT_SQL = """
     INSERT INTO product_events (event_type, org_id, user_id, properties)
@@ -92,6 +106,24 @@ def emit_event(
                 tenant_id=tenant_id,
                 exc_info=True,
             )
+
+    # SPEC-SEC-HYGIENE-001 REQ-40.1: bounded pending set. Drop new events
+    # rather than letting the in-flight task set grow without limit when
+    # the insert pipeline can't keep up (e.g. portal DB blip + traffic
+    # spike). Drops are observable via Prometheus + a rate-limited log.
+    if len(_pending) >= settings.retrieval_events_max_pending:
+        retrieval_events_dropped_total.inc()
+        global _last_cap_log_time
+        now = time.monotonic()
+        if now - _last_cap_log_time >= _CAP_LOG_INTERVAL_SECONDS:
+            _last_cap_log_time = now
+            logger.warning(
+                "retrieval_events_cap_hit",
+                pending=len(_pending),
+                cap=settings.retrieval_events_max_pending,
+                event_type=event_type,
+            )
+        return
 
     try:
         task = asyncio.create_task(_insert())

--- a/klai-retrieval-api/retrieval_api/services/graph_search.py
+++ b/klai-retrieval-api/retrieval_api/services/graph_search.py
@@ -83,8 +83,10 @@ async def search(query: str, org_id: str, top_k: int = 20) -> list[dict]:
             timeout_s=settings.graph_search_timeout,
         )
         return []
-    except Exception as exc:
-        logger.warning("graph_search_failed", org_id=org_id, error=str(exc))
+    except Exception:
+        # SPEC-SEC-HYGIENE-001 REQ-43.3: exc_info=True preserves the
+        # traceback that the previous `error=str(exc)` dropped (TRY401).
+        logger.warning("graph_search_failed", org_id=org_id, exc_info=True)
         return []
 
 

--- a/klai-retrieval-api/retrieval_api/services/rate_limit.py
+++ b/klai-retrieval-api/retrieval_api/services/rate_limit.py
@@ -91,6 +91,17 @@ async def check_and_increment(
             pipe.expire(key, 120)
             await pipe.execute()
         return True, 0
+    # @MX:WARN: fail-open on Redis errors. The branch below returns
+    #     ``(True, 0)`` (allow + no retry) for ANY redis exception,
+    #     bypassing rate-limit enforcement when redis is the failure mode.
+    # @MX:REASON: deliberate availability choice per SPEC-RETRIEVAL-RL-001
+    #     REQ-4.5. retrieval-api sits on the hot path for user queries;
+    #     fail-closed would take the service down whenever redis hiccups,
+    #     which is worse than briefly serving a few unmetered requests.
+    #     A future fail-closed-with-circuit-breaker variant is tracked as
+    #     SPEC-RETRIEVAL-RL-FAILCLOSED-001. Annotated under
+    #     SPEC-SEC-HYGIENE-001 REQ-42 so the next audit sees the rationale
+    #     and does not re-file this as a finding.
     except Exception:
         logger.exception("rate_limiter_degraded", reason="redis_unreachable", key=key)
         return True, 0

--- a/klai-retrieval-api/retrieval_api/services/router.py
+++ b/klai-retrieval-api/retrieval_api/services/router.py
@@ -52,8 +52,10 @@ async def fetch_source_catalog(org_id: str) -> list[KBEntry]:
             for hit in result.hits
             if hit.value  # skip empty/null labels
         ]
-    except Exception as exc:
-        logger.warning("router_facet_failed", org_id=org_id, error=str(exc))
+    except Exception:
+        # SPEC-SEC-HYGIENE-001 REQ-43.3: exc_info=True preserves the
+        # traceback that the previous `error=str(exc)` dropped (TRY401).
+        logger.warning("router_facet_failed", org_id=org_id, exc_info=True)
         entries = []
 
     _catalog_cache[org_id] = (entries, time.monotonic())

--- a/klai-retrieval-api/retrieval_api/services/search.py
+++ b/klai-retrieval-api/retrieval_api/services/search.py
@@ -191,8 +191,12 @@ async def _search_notebook(
             ),
             timeout=5.0,
         )
-    except (TimeoutError, Exception) as exc:
-        logger.error("qdrant_search_failed", collection=settings.qdrant_focus_collection, error=str(exc))
+    except Exception:
+        # SPEC-SEC-HYGIENE-001 REQ-43: logger.exception preserves the
+        # traceback (TRY400/TRY401); the previous `error=str(exc)` discarded it.
+        logger.exception(
+            "qdrant_search_failed", collection=settings.qdrant_focus_collection
+        )
         raise
 
     return [
@@ -291,8 +295,10 @@ async def _search_knowledge(
             ),
             timeout=5.0,
         )
-    except (TimeoutError, Exception) as exc:
-        logger.error("qdrant_search_failed", collection=settings.qdrant_collection, error=str(exc))
+    except Exception:
+        # SPEC-SEC-HYGIENE-001 REQ-43: logger.exception preserves the
+        # traceback (TRY400/TRY401); the previous `error=str(exc)` discarded it.
+        logger.exception("qdrant_search_failed", collection=settings.qdrant_collection)
         raise
 
     return [
@@ -359,8 +365,11 @@ async def fetch_chunks_by_urls(
             ),
             timeout=3.0,
         )
-    except (TimeoutError, Exception) as exc:
-        logger.warning("link_expand_failed", error=str(exc))
+    except Exception:
+        # SPEC-SEC-HYGIENE-001 REQ-43: link expansion failure is expected on
+        # transient qdrant blips, so warning-level is correct; exc_info=True
+        # preserves the traceback that the previous `error=str(exc)` dropped.
+        logger.warning("link_expand_failed", exc_info=True)
         return []
 
     return [

--- a/klai-retrieval-api/tests/test_auth_jwks_timeout.py
+++ b/klai-retrieval-api/tests/test_auth_jwks_timeout.py
@@ -1,0 +1,99 @@
+"""SPEC-SEC-HYGIENE-001 REQ-44.3: JWKS fetch timeout is capped at 3 seconds.
+
+Background: REQ-44.1, .2, .4, .5, .6 describe failure modes that don't exist
+in retrieval-api's current code (no `jwt_auth_enabled=False` dev-bypass
+branch in the middleware; `jwks_url` is derived from `zitadel_issuer` so
+``jwt_auth_enabled=True AND jwks_url=""`` is unreachable by construction).
+What IS still worthwhile is the timeout cap on the outbound JWKS fetch:
+JWKS endpoints respond in sub-second; a 10-second ceiling is unnecessarily
+generous and bounds nothing useful against a slow-loris JWKS endpoint.
+
+This test pins ``_fetch_jwks`` to ``timeout <= 3.0``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+class _RecordingClient:
+    """An ``httpx.AsyncClient`` stub that records the timeout it was constructed with."""
+
+    timeout_seen: float | None = None
+
+    def __init__(self, timeout: float | None = None, **_kw: Any) -> None:
+        # httpx accepts a Timeout object too; for our test we always pass a float.
+        type(self).timeout_seen = timeout  # type: ignore[assignment]
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_a):
+        return False
+
+    async def get(self, _url: str):
+        class _Resp:
+            status_code = 200
+
+            def raise_for_status(self) -> None: ...
+
+            def json(self) -> dict:
+                return {"keys": []}
+
+        return _Resp()
+
+
+async def test_fetch_jwks_timeout_capped_at_three_seconds(monkeypatch):
+    """REQ-44.3: ``httpx.AsyncClient`` for JWKS uses ``timeout <= 3.0``."""
+    from retrieval_api.middleware import auth
+
+    # Reset the recording slot so prior tests don't leak.
+    _RecordingClient.timeout_seen = None
+    # ``_fetch_jwks`` does ``import httpx`` locally — patch the httpx
+    # module attribute itself so the local rebind picks up our stub.
+    import httpx as _httpx
+    monkeypatch.setattr(_httpx, "AsyncClient", _RecordingClient)
+
+    await auth._fetch_jwks()
+
+    assert _RecordingClient.timeout_seen is not None, (
+        "Test scaffolding broken — _fetch_jwks did not construct an httpx "
+        "AsyncClient via our stub."
+    )
+    assert _RecordingClient.timeout_seen <= 3.0, (
+        f"_fetch_jwks built httpx.AsyncClient with timeout="
+        f"{_RecordingClient.timeout_seen}s; REQ-44.3 caps it at 3.0s. "
+        "JWKS endpoints respond sub-second; the previous 10s upper bound "
+        "left workers exposed to slow-loris on the JWKS host."
+    )
+
+
+@pytest.mark.parametrize(
+    ("doc_field", "must_appear"),
+    [
+        (
+            "config.py jwt_auth_enabled property docstring",
+            "REQ-44",
+        ),
+    ],
+)
+def test_unreachable_failure_modes_are_documented(doc_field: str, must_appear: str):
+    """REQ-44.2 / REQ-44.6 failure modes are unreachable by construction.
+
+    No code change is needed because ``jwt_auth_enabled`` is derived from
+    ``zitadel_issuer``: if the issuer is empty, the property is False;
+    therefore ``jwt_auth_enabled=True AND jwks_url=""`` (where
+    ``jwks_url == f"{issuer}/oauth/v2/keys"``) cannot occur. The SPEC's
+    'documented acceptance' clause requires this rationale to live in the
+    code itself so the next reviewer doesn't re-file the finding.
+    """
+    from pathlib import Path
+
+    config_path = Path(__file__).resolve().parents[1] / "retrieval_api" / "config.py"
+    src = config_path.read_text(encoding="utf-8")
+    assert must_appear in src, (
+        f"{doc_field} must mention {must_appear!r} so the unreachable-by-"
+        "construction acceptance is traceable from the source."
+    )

--- a/klai-retrieval-api/tests/test_events_bounded.py
+++ b/klai-retrieval-api/tests/test_events_bounded.py
@@ -1,0 +1,223 @@
+"""SPEC-SEC-HYGIENE-001 REQ-40 / AC-40: bounded ``_pending`` task set.
+
+The ``services.events.emit_event`` helper schedules every product event as
+a fire-and-forget asyncio task tracked by the module-level ``_pending``
+set. Under a flood (Redis fail-open at REQ-42 + a retrieval spike) the
+task creation rate can outpace task completion, causing ``_pending`` to
+grow without bound — eventually OOM-ing the worker.
+
+This test pins:
+
+* REQ-40.1 — ``_pending`` is capped at ``settings.retrieval_events_max_pending``
+  (default 1000); excess events are dropped, not queued.
+* REQ-40.1 — drops increment a ``retrieval_events_dropped_total``
+  Prometheus counter.
+* REQ-40.2 — drops emit a ``retrieval_events_cap_hit`` structlog event,
+  rate-limited so a flood cannot itself flood the log pipeline.
+* REQ-40.3 (recovery) — once pending tasks complete, ``_pending`` drains
+  to zero and subsequent ``emit_event`` calls proceed normally.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+
+import pytest
+
+
+# Read prometheus counter values via the registry's collect() to avoid
+# coupling to the internal ._value attribute (which exists but is private).
+def _counter_value(counter, **labels) -> float:
+    """Return the current value of a labelled or unlabelled Counter."""
+    if labels:
+        return counter.labels(**labels)._value.get()
+    return counter._value.get()
+
+
+@pytest.fixture
+async def clean_events(monkeypatch):
+    """Cancel any pending tasks left over from prior tests and reset state."""
+    from retrieval_api.services import events
+
+    # Wipe any leftovers from earlier tests.
+    for task in list(events._pending):
+        if not task.done():
+            task.cancel()
+    events._pending.clear()
+    monkeypatch.setattr(events, "_last_cap_log_time", 0.0, raising=False)
+    yield events
+    # Same teardown to be polite to the next test.
+    for task in list(events._pending):
+        if not task.done():
+            task.cancel()
+    events._pending.clear()
+
+
+@pytest.fixture
+def log_capture():
+    """Capture structlog event records emitted at WARNING+."""
+    from retrieval_api.logging_setup import setup_logging
+    setup_logging()
+
+    records: list[logging.LogRecord] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    handler = _Capture(level=logging.DEBUG)
+    root = logging.getLogger()
+    prev_level = root.level
+    root.addHandler(handler)
+    root.setLevel(logging.DEBUG)
+    try:
+        yield records
+    finally:
+        root.removeHandler(handler)
+        root.setLevel(prev_level)
+
+
+# --------------------------------------------------------------------------- #
+# REQ-40.1 — _pending is bounded
+# --------------------------------------------------------------------------- #
+
+
+async def test_pending_set_capped_at_configured_max(clean_events, monkeypatch, log_capture):
+    """REQ-40.1 + REQ-40.2: 2000 emits with a hanging worker → 1000 in flight, 1000 dropped."""
+    events = clean_events
+
+    # 1) Force the cap to a small number so the test is fast and the
+    #    behaviour is identical regardless of the production default.
+    monkeypatch.setattr(events.settings, "retrieval_events_max_pending", 5, raising=False)
+
+    # 2) Stub the asyncpg pool so every insert hangs forever — that's what
+    #    forces _pending to grow.
+    class _HangingPool:
+        async def execute(self, *_a, **_kw):
+            await asyncio.sleep(3600)
+
+    monkeypatch.setattr(events, "_pool", _HangingPool())
+
+    # 3) Capture counter starting value (other tests may have ticked it).
+    start = _counter_value(events.retrieval_events_dropped_total)
+
+    # 4) Burst of 20 emits with cap=5 → first 5 in flight, next 15 dropped.
+    n_total = 20
+    n_cap = 5
+    for i in range(n_total):
+        events.emit_event("test_burst", tenant_id=f"t-{i}")
+
+    # Give the loop one tick so created tasks settle into _pending.
+    await asyncio.sleep(0)
+
+    assert len(events._pending) <= n_cap, (
+        f"_pending exceeded the cap: {len(events._pending)} > {n_cap}. "
+        "REQ-40.1 requires emit_event to drop new events when the cap is hit."
+    )
+
+    end = _counter_value(events.retrieval_events_dropped_total)
+    dropped = end - start
+    assert dropped == n_total - n_cap, (
+        f"retrieval_events_dropped_total incremented by {dropped}, "
+        f"expected {n_total - n_cap} (n_total - cap)."
+    )
+
+    # REQ-40.2: at least one rate-limited cap-hit log was emitted.
+    cap_hit_logs = [
+        rec for rec in log_capture
+        if isinstance(rec.msg, dict) and rec.msg.get("event") == "retrieval_events_cap_hit"
+    ]
+    assert cap_hit_logs, (
+        "Expected at least one `retrieval_events_cap_hit` structlog event "
+        "after the cap was breached, found none."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# REQ-40.2 — cap-hit log is rate-limited (not one per dropped event)
+# --------------------------------------------------------------------------- #
+
+
+async def test_cap_hit_log_is_rate_limited(clean_events, monkeypatch, log_capture):
+    """REQ-40.2: a flood of drops emits at most one cap-hit log per minute."""
+    events = clean_events
+
+    monkeypatch.setattr(events.settings, "retrieval_events_max_pending", 1, raising=False)
+
+    class _HangingPool:
+        async def execute(self, *_a, **_kw):
+            await asyncio.sleep(3600)
+
+    monkeypatch.setattr(events, "_pool", _HangingPool())
+
+    # First emit fills the slot, next 50 all drop in the same wall-clock minute.
+    for i in range(51):
+        events.emit_event("burst", tenant_id=f"t-{i}")
+
+    await asyncio.sleep(0)
+
+    cap_hit_logs = [
+        rec for rec in log_capture
+        if isinstance(rec.msg, dict) and rec.msg.get("event") == "retrieval_events_cap_hit"
+    ]
+    assert len(cap_hit_logs) <= 2, (
+        f"Cap-hit log fired {len(cap_hit_logs)} times for a 50-event drop burst — "
+        "REQ-40.2 requires it be rate-limited (at most ~once per minute)."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# REQ-40 (recovery) — _pending drains to zero, cap resets
+# --------------------------------------------------------------------------- #
+
+
+async def test_pending_recovers_after_inserts_complete(clean_events, monkeypatch):
+    """REQ-40 (recovery): once tasks complete, _pending empties and cap resets."""
+    events = clean_events
+
+    monkeypatch.setattr(events.settings, "retrieval_events_max_pending", 5, raising=False)
+
+    # Quick-completing pool: each execute returns immediately.
+    class _FastPool:
+        async def execute(self, *_a, **_kw):
+            return None
+
+    monkeypatch.setattr(events, "_pool", _FastPool())
+
+    for i in range(5):
+        events.emit_event("recovery", tenant_id=f"t-{i}")
+
+    # Drain — every task is a no-op so this finishes promptly.
+    for _ in range(20):
+        if not events._pending:
+            break
+        await asyncio.sleep(0.01)
+
+    assert len(events._pending) == 0, (
+        f"_pending should drain to zero after fast inserts complete, "
+        f"saw {len(events._pending)} stragglers."
+    )
+
+    # Subsequent emits proceed normally — no drops because cap window has reset.
+    start = _counter_value(events.retrieval_events_dropped_total)
+    events.emit_event("post_recovery", tenant_id="t-99")
+    await asyncio.sleep(0.01)
+    end = _counter_value(events.retrieval_events_dropped_total)
+    assert end == start, "Post-recovery emit was incorrectly counted as a drop"
+
+
+# --------------------------------------------------------------------------- #
+# Static guard — env var is documented in config.py
+# --------------------------------------------------------------------------- #
+
+
+def test_settings_exposes_retrieval_events_max_pending():
+    """REQ-40.1: ``RETRIEVAL_EVENTS_MAX_PENDING`` is configurable via Settings."""
+    config_path = Path(__file__).resolve().parents[1] / "retrieval_api" / "config.py"
+    src = config_path.read_text(encoding="utf-8")
+    assert "retrieval_events_max_pending" in src, (
+        "Settings must expose `retrieval_events_max_pending` so deploys can "
+        "tune the cap via the RETRIEVAL_EVENTS_MAX_PENDING env var (REQ-40.1)."
+    )

--- a/klai-retrieval-api/tests/test_health_safety.py
+++ b/klai-retrieval-api/tests/test_health_safety.py
@@ -1,0 +1,265 @@
+"""SPEC-SEC-HYGIENE-001 REQ-39 / AC-39: /health event-loop + topology safety.
+
+Verifies that the retrieval-api /health endpoint:
+
+* REQ-39.1 — wraps the synchronous FalkorDB ping in ``asyncio.to_thread``
+  so it does not block the event loop. Concurrent /health calls run in
+  parallel via the default thread pool.
+* REQ-39.2 — returns the literal string ``"error"`` for failing dependency
+  fields in the JSON body, never echoing the underlying exception
+  message (which can include internal hostnames or IP addresses).
+* REQ-39.3 — logs the full exception (with traceback) via ``exc_info``
+  when a dependency check fails.
+* REQ-39.4 — preserves the existing 503 status code when at least one
+  dependency is unhealthy and 200 when all are healthy.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any
+
+import httpx
+import pytest
+from httpx import ASGITransport
+
+# --------------------------------------------------------------------------- #
+# Fakes for the four dependencies probed by /health
+# --------------------------------------------------------------------------- #
+
+
+class _OK:
+    status_code = 200
+
+
+async def _httpx_get_ok(self, url: str, headers: dict[str, Any] | None = None, **_kw):
+    return _OK()
+
+
+async def _httpx_get_connect_error(self, url: str, headers: dict[str, Any] | None = None, **_kw):
+    raise httpx.ConnectError(f"{url}: connection refused")
+
+
+class _FakeQdrantOK:
+    def __init__(self, *_a, **_kw): ...
+
+    async def get_collections(self):
+        return []
+
+
+class _FakeQdrantFail:
+    def __init__(self, *_a, **_kw): ...
+
+    async def get_collections(self):
+        raise ConnectionError("qdrant: no route to host 172.18.0.4:6333")
+
+
+class _FakeFalkorOK:
+    class _Conn:
+        def ping(self) -> None: ...
+
+    def __init__(self, *_a, **_kw):
+        self.connection = self._Conn()
+
+
+def _slow_falkor(sleep_for: float):
+    class _Conn:
+        def ping(self) -> None:
+            time.sleep(sleep_for)
+
+    class _Falkor:
+        def __init__(self, *_a, **_kw):
+            self.connection = _Conn()
+
+    return _Falkor
+
+
+class _FailFalkor:
+    class _Conn:
+        def ping(self) -> None:
+            raise ConnectionError("falkordb: no route to host 172.18.0.5:6379")
+
+    def __init__(self, *_a, **_kw):
+        self.connection = self._Conn()
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def all_deps_ok(monkeypatch):
+    """Patch every dependency probed by /health to return success quickly."""
+    import falkordb
+    import qdrant_client
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", _httpx_get_ok, raising=True)
+    monkeypatch.setattr(qdrant_client, "AsyncQdrantClient", _FakeQdrantOK)
+    monkeypatch.setattr(falkordb, "FalkorDB", _FakeFalkorOK)
+
+
+@pytest.fixture
+def log_capture():
+    """Capture stdlib log records so we can inspect ``exc_info``.
+
+    structlog routes through the stdlib logger at the root level
+    (see ``logging_setup.setup_logging``); attaching a plain
+    ``logging.Handler`` is the most reliable way to verify ``exc_info``
+    propagation across the integration.
+    """
+    records: list[logging.LogRecord] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    handler = _Capture(level=logging.DEBUG)
+    root = logging.getLogger()
+    prev_level = root.level
+    root.addHandler(handler)
+    root.setLevel(logging.DEBUG)
+    try:
+        yield records
+    finally:
+        root.removeHandler(handler)
+        root.setLevel(prev_level)
+
+
+# --------------------------------------------------------------------------- #
+# REQ-39.4 — status code preservation
+# --------------------------------------------------------------------------- #
+
+
+def test_health_returns_200_when_all_deps_ok(all_deps_ok, monkeypatch):
+    """REQ-39.4: with every dep healthy, /health is 200."""
+    from fastapi.testclient import TestClient
+
+    from retrieval_api.config import settings
+    from retrieval_api.main import app
+
+    monkeypatch.setattr(settings, "graphiti_enabled", True, raising=False)
+
+    client = TestClient(app)
+    r = client.get("/health")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "ok"
+    assert body["tei"] == "ok"
+    assert body["qdrant"] == "ok"
+    assert body["litellm"] == "ok"
+    assert body["falkordb"] == "ok"
+
+
+def test_health_returns_503_when_one_dep_down(monkeypatch):
+    """REQ-39.4: with at least one dep unhealthy, /health stays 503."""
+    import qdrant_client
+    from fastapi.testclient import TestClient
+
+    from retrieval_api.config import settings
+    from retrieval_api.main import app
+
+    monkeypatch.setattr(settings, "graphiti_enabled", False, raising=False)
+    monkeypatch.setattr(httpx.AsyncClient, "get", _httpx_get_connect_error, raising=True)
+    monkeypatch.setattr(qdrant_client, "AsyncQdrantClient", _FakeQdrantOK)
+
+    client = TestClient(app)
+    r = client.get("/health")
+    assert r.status_code == 503
+
+
+# --------------------------------------------------------------------------- #
+# REQ-39.2 / REQ-39.3 — topology + exc_info
+# --------------------------------------------------------------------------- #
+
+
+def test_health_response_body_does_not_leak_internal_topology(monkeypatch, log_capture):
+    """REQ-39.2: failing dependency fields say 'error' (literal), not the URL.
+
+    REQ-39.3: the underlying exception MUST be captured via ``exc_info``
+    on the structlog/stdlib log record, so operators can still debug.
+    """
+    import falkordb
+    import qdrant_client
+    from fastapi.testclient import TestClient
+
+    from retrieval_api.config import settings
+    from retrieval_api.main import app
+
+    monkeypatch.setattr(settings, "graphiti_enabled", True, raising=False)
+    monkeypatch.setattr(httpx.AsyncClient, "get", _httpx_get_connect_error, raising=True)
+    monkeypatch.setattr(qdrant_client, "AsyncQdrantClient", _FakeQdrantFail)
+    monkeypatch.setattr(falkordb, "FalkorDB", _FailFalkor)
+
+    client = TestClient(app)
+    r = client.get("/health")
+    assert r.status_code == 503
+
+    body = r.json()
+    # AC-39 step 6: every failing dep field is the literal "error", not "error: <url>"
+    for dep in ("tei", "qdrant", "litellm", "falkordb"):
+        assert body.get(dep) == "error", (
+            f"{dep!r} response field leaks topology — expected 'error', got {body.get(dep)!r}"
+        )
+
+    # AC-39 step 6: no internal IPs / hostnames / verbose error strings anywhere in the body
+    body_str = str(body)
+    for needle in ("172.18.", "connection refused", "no route to host"):
+        assert needle not in body_str, (
+            f"/health response leaks topology via {needle!r}: {body_str}"
+        )
+
+    # AC-39 step 7: structlog captures the full exception via exc_info
+    exc_records = [rec for rec in log_capture if rec.exc_info is not None]
+    assert exc_records, (
+        "Expected at least one log record with exc_info attached for the "
+        "/health dependency failures, found none. Without exc_info the "
+        "exception detail is lost (REQ-39.3)."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# REQ-39.1 — sync FalkorDB ping does not block the event loop
+# --------------------------------------------------------------------------- #
+
+
+async def test_health_falkordb_ping_does_not_block_event_loop(monkeypatch, all_deps_ok):
+    """REQ-39.1: sync ``db.connection.ping()`` MUST run in a thread pool.
+
+    The strategy: replace FalkorDB's ping with a 400 ms sleep and fire four
+    concurrent /health requests on the same event loop via ``asyncio.gather``
+    against an in-process ASGI transport. If the ping blocks the loop, total
+    wall time approaches ``n * sleep = 1.6 s``. With ``asyncio.to_thread``
+    the pings run concurrently in the default thread-pool executor, so total
+    wall time stays close to a single ping (~0.4 s + scheduler overhead).
+    """
+    import falkordb
+
+    from retrieval_api.config import settings
+    from retrieval_api.main import app
+
+    monkeypatch.setattr(settings, "graphiti_enabled", True, raising=False)
+
+    sleep_secs = 0.4
+    monkeypatch.setattr(falkordb, "FalkorDB", _slow_falkor(sleep_secs))
+
+    transport = ASGITransport(app=app)
+    n_concurrent = 4
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        start = time.monotonic()
+        results = await asyncio.gather(*(ac.get("/health") for _ in range(n_concurrent)))
+        elapsed = time.monotonic() - start
+
+    assert all(r.status_code == 200 for r in results), [r.status_code for r in results]
+
+    # Sequential (event loop blocked): n * sleep = 1.6 s.
+    # Concurrent (asyncio.to_thread + thread pool >= n): max(sleep) + overhead ≈ 0.5 s.
+    # Threshold = 60% of the sequential bound, generous to avoid CI flakes.
+    upper_bound = (n_concurrent * sleep_secs) * 0.6
+    assert elapsed < upper_bound, (
+        f"Event loop appears blocked by sync FalkorDB ping: "
+        f"{n_concurrent} concurrent /health calls took {elapsed:.2f}s "
+        f"(expected < {upper_bound:.2f}s with asyncio.to_thread)."
+    )

--- a/klai-retrieval-api/tests/test_rate_limit_annotation.py
+++ b/klai-retrieval-api/tests/test_rate_limit_annotation.py
@@ -1,0 +1,159 @@
+"""SPEC-SEC-HYGIENE-001 REQ-42 / AC-42: rate-limit fail-open annotation.
+
+Two parts:
+
+* REQ-42.1 — the ``except Exception`` block in
+  ``services/rate_limit.py`` MUST carry an ``@MX:WARN`` annotation with
+  an ``@MX:REASON`` linking to either SPEC-SEC-HYGIENE-001 REQ-42 or the
+  follow-up SPEC-RETRIEVAL-RL-FAILCLOSED-001. The annotation documents
+  why we deliberately fail-open on Redis errors so the next audit doesn't
+  re-file the finding.
+* REQ-42.2 — the warning log emitted on the fail-open branch MUST
+  capture the traceback (via ``logger.exception(...)`` or
+  ``logger.warning(..., exc_info=True)``), NOT discard it via
+  ``error=str(exc)``.
+
+A behavioural sub-test confirms the fail-open contract: a Redis pool that
+raises on every operation MUST cause ``check_and_increment`` to return
+``(True, 0)``.
+
+Note on the SPEC text vs. reality: the SPEC (drafted 2026-04-24) refers
+to a function ``check_limit`` and a log event ``rate_limit_redis_unavailable``.
+The actual function is ``check_and_increment`` and the event is
+``rate_limiter_degraded``; ``logger.exception`` is already in place
+(REQ-42.2 effectively pre-satisfied). This test covers what the SPEC
+*intends* against the code as it stands today.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_RL = _REPO_ROOT / "retrieval_api" / "services" / "rate_limit.py"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+# --------------------------------------------------------------------------- #
+# REQ-42.1 — MX:WARN + MX:REASON on the fail-open branch
+# --------------------------------------------------------------------------- #
+
+
+def test_rate_limit_fail_open_carries_mx_warn_annotation():
+    """REQ-42.1: ``@MX:WARN`` precedes the fail-open ``except Exception`` block."""
+    src = _read(_RL)
+
+    # Find the fail-open except block (the one returning True, 0).
+    fail_open_block = re.search(
+        r"except\s+Exception:[^\n]*\n"  # except line
+        r"(?:[ \t]+[^\n]*\n)+"           # body lines
+        r"[ \t]+return\s+True,\s*0",     # ending in `return True, 0`
+        src,
+    )
+    assert fail_open_block, (
+        "Could not locate the fail-open `except Exception:` block in "
+        "rate_limit.py — has the function shape changed?"
+    )
+
+    # Look for MX:WARN within ~12 lines before the except.
+    block_start = fail_open_block.start()
+    pre_block = src[max(0, block_start - 800) : block_start]
+    assert "@MX:WARN" in pre_block, (
+        "Fail-open `except Exception:` block lacks an `@MX:WARN` annotation "
+        "in the preceding ~12 lines. REQ-42.1 requires the annotation so "
+        "the next audit sees this is a deliberate availability choice."
+    )
+    assert "@MX:REASON" in pre_block, (
+        "Fail-open `except Exception:` block lacks an `@MX:REASON` "
+        "annotation. REQ-42.1 requires the rationale to be machine-readable."
+    )
+
+    # Reason must reference either this SPEC or the future fail-closed SPEC.
+    assert re.search(
+        r"SPEC-SEC-HYGIENE-001\s+REQ-42|SPEC-RETRIEVAL-RL-FAILCLOSED-001",
+        pre_block,
+    ), (
+        "@MX:REASON does not reference SPEC-SEC-HYGIENE-001 REQ-42 or "
+        "SPEC-RETRIEVAL-RL-FAILCLOSED-001 — needed for traceability."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# REQ-42.2 — fail-open branch logs the traceback (no `error=str(exc)`)
+# --------------------------------------------------------------------------- #
+
+
+def test_rate_limit_fail_open_logs_with_traceback():
+    """REQ-42.2: the warning log captures the traceback."""
+    src = _read(_RL)
+    # Strip line comments so explanatory text doesn't trip the guard.
+    code = "\n".join(line.split("#", 1)[0] for line in src.splitlines())
+    assert "error=str(exc)" not in code, (
+        "rate_limit.py still logs via `error=str(exc)` (TRY401) — the "
+        "traceback would be discarded. Use logger.exception(...) or "
+        "logger.warning(..., exc_info=True)."
+    )
+    # Confirm the redis_unreachable log path uses one of the two safe forms.
+    assert re.search(
+        r"logger\.exception\([^)]*redis_unreachable|"
+        r"logger\.warning\([^)]*redis_unreachable[^)]*exc_info\s*=\s*True",
+        src,
+    ), (
+        "Fail-open log call for `redis_unreachable` must use "
+        "logger.exception(...) or logger.warning(..., exc_info=True)."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# AC-42 step 6/7 — behavioural fail-open contract
+# --------------------------------------------------------------------------- #
+
+
+async def test_rate_limit_fails_open_when_redis_pipeline_raises(monkeypatch):
+    """REQ-42 (behavioural): Redis errors → ``(True, 0)`` (allow + no retry)."""
+    from retrieval_api.services import rate_limit
+
+    class _RaisingPipeline:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_a):
+            return False
+
+        def zremrangebyscore(self, *_a, **_kw):
+            return None
+
+        def zcard(self, *_a, **_kw):
+            return None
+
+        def zadd(self, *_a, **_kw):
+            return None
+
+        def expire(self, *_a, **_kw):
+            return None
+
+        async def execute(self):
+            raise ConnectionError("simulated redis outage")
+
+    class _RaisingPool:
+        def pipeline(self, transaction: bool = True):  # noqa: ARG002
+            return _RaisingPipeline()
+
+    async def _fake_pool(_url: str):
+        return _RaisingPool()
+
+    monkeypatch.setattr(rate_limit, "get_redis_pool", _fake_pool)
+
+    allowed, retry_after = await rate_limit.check_and_increment(
+        redis_url="redis://does-not-matter",
+        key="test:key",
+        limit_per_minute=10,
+    )
+    assert allowed is True, "fail-open contract broken — Redis error must allow request"
+    assert retry_after == 0, "fail-open path must not surface a Retry-After"

--- a/klai-retrieval-api/tests/test_rate_limit_annotation.py
+++ b/klai-retrieval-api/tests/test_rate_limit_annotation.py
@@ -30,8 +30,6 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-import pytest
-
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _RL = _REPO_ROOT / "retrieval_api" / "services" / "rate_limit.py"
 
@@ -142,7 +140,7 @@ async def test_rate_limit_fails_open_when_redis_pipeline_raises(monkeypatch):
             raise ConnectionError("simulated redis outage")
 
     class _RaisingPool:
-        def pipeline(self, transaction: bool = True):  # noqa: ARG002
+        def pipeline(self, transaction: bool = True):
             return _RaisingPipeline()
 
     async def _fake_pool(_url: str):

--- a/klai-retrieval-api/tests/test_request_id_validation.py
+++ b/klai-retrieval-api/tests/test_request_id_validation.py
@@ -1,0 +1,195 @@
+"""SPEC-SEC-HYGIENE-001 REQ-41 / AC-41: header validation for trace context.
+
+``RequestContextMiddleware`` binds ``X-Request-ID`` and ``X-Org-ID`` from
+incoming request headers into the structlog context. Without validation
+an attacker can poison every log line with arbitrary bytes — terminal
+escape sequences, HTML tags, multi-megabyte garbage. This test pins the
+two regex contracts:
+
+* REQ-41.1 — ``X-Request-ID`` must match ``^[A-Za-z0-9_-]{1,128}$``;
+  invalid / missing / oversized values get a server-generated UUID.
+* REQ-41.2 — ``X-Org-ID`` must match ``^[0-9]{1,20}$``; invalid values
+  are *dropped* from the log context (not rejected at the HTTP layer,
+  because the same header has multiple legitimate origins).
+
+REQ-41.4 (apply the same regex cap symmetrically across portal-api,
+connector, scribe, mailer, research-api, and knowledge-ingest) is
+DEFERRED to a follow-up cross-service slice; this file covers
+retrieval-api only.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+
+import pytest
+import structlog
+from starlette.requests import Request
+from starlette.responses import Response
+
+from retrieval_api.logging_setup import RequestContextMiddleware
+
+_UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+
+
+def _make_request(headers: dict[str, str] | None) -> Request:
+    """Build a minimal ASGI scope dict for ``Request`` with the given headers."""
+    raw_headers: list[tuple[bytes, bytes]] = []
+    for k, v in (headers or {}).items():
+        raw_headers.append((k.lower().encode("latin-1"), v.encode("latin-1")))
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/health",
+        "headers": raw_headers,
+        "query_string": b"",
+    }
+    return Request(scope=scope)
+
+
+async def _noop_call_next(_request: Request) -> Response:
+    return Response("ok")
+
+
+async def _dispatch_and_capture_context(headers: dict[str, str] | None) -> dict:
+    """Drive the middleware once; return the structlog contextvars seen at handler time."""
+    middleware = RequestContextMiddleware(app=None)  # type: ignore[arg-type]
+    captured: dict = {}
+
+    async def _capture(_request: Request) -> Response:
+        # Snapshot contextvars at the moment the inner handler would run —
+        # that's what every downstream log call inside this request will see.
+        captured.update(structlog.contextvars.get_contextvars())
+        return Response("ok")
+
+    await middleware.dispatch(_make_request(headers), _capture)
+    return captured
+
+
+# --------------------------------------------------------------------------- #
+# REQ-41.1 — X-Request-ID validation
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("inbound", "should_keep"),
+    [
+        ("abc-123", True),
+        ("plain_id", True),
+        ("A" * 128, True),                       # exactly at cap
+        ("A" * 129, False),                      # over cap → UUID
+        ("<script>", False),                     # invalid charset
+        ("\x1b[31mred\x1b[0m", False),           # ANSI escape
+        ("hello world", False),                  # space disallowed
+        ("rid;rm -rf /", False),                 # shell metacharacters
+    ],
+    ids=[
+        "kebab-id",
+        "snake-id",
+        "exactly-128-A",
+        "129-A-overflow",
+        "html-tag",
+        "ansi-escape",
+        "space",
+        "shell-injection",
+    ],
+)
+async def test_request_id_validation(inbound: str, should_keep: bool):
+    """REQ-41.1: keep valid id verbatim, replace invalid/oversized with a UUID."""
+    ctx = await _dispatch_and_capture_context({"x-request-id": inbound})
+
+    request_id = ctx.get("request_id")
+    assert request_id, "RequestContextMiddleware must always bind `request_id`"
+
+    if should_keep:
+        assert request_id == inbound, (
+            f"X-Request-ID {inbound!r} is valid (matches "
+            f"^[A-Za-z0-9_-]{{1,128}}$) and must be preserved verbatim, "
+            f"got {request_id!r}"
+        )
+    else:
+        assert request_id != inbound, (
+            f"X-Request-ID {inbound!r} fails the regex / length cap and "
+            f"must be replaced — got {request_id!r}"
+        )
+        assert _UUID_RE.match(request_id), (
+            f"Replacement `request_id` is not a UUID: {request_id!r}"
+        )
+
+
+async def test_request_id_oversized_garbage_does_not_pollute_context():
+    """REQ-41.3: 10KB of garbage in X-Request-ID → server-generated UUID."""
+    garbage = "A" * 10_000
+    ctx = await _dispatch_and_capture_context({"x-request-id": garbage})
+    assert ctx["request_id"] != garbage
+    assert _UUID_RE.match(ctx["request_id"]), (
+        f"Oversized X-Request-ID was not replaced with a UUID: {ctx['request_id']!r}"
+    )
+
+
+@pytest.mark.parametrize("missing_value", ["", None], ids=["empty", "absent"])
+async def test_request_id_missing_or_empty_gets_uuid(missing_value: str | None):
+    """REQ-41.1: empty / absent X-Request-ID → server-generated UUID."""
+    headers = {"x-request-id": missing_value} if missing_value is not None else {}
+    ctx = await _dispatch_and_capture_context(headers)
+    assert _UUID_RE.match(ctx["request_id"]), (
+        f"Missing/empty X-Request-ID did not fall back to a UUID: {ctx['request_id']!r}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# REQ-41.2 — X-Org-ID validation
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("inbound", "should_keep"),
+    [
+        ("42", True),
+        ("0", True),
+        ("9" * 20, True),                        # exactly at cap
+        ("1" * 22, False),                       # over cap → drop
+        ("abc", False),                          # non-numeric
+        ("-5", False),                           # negative sign
+        ("3.14", False),                         # decimal
+        ("12 34", False),                        # space
+        ("<svg>", False),                        # HTML tag
+    ],
+    ids=[
+        "small-int",
+        "zero",
+        "exactly-20-digits",
+        "22-digit-overflow",
+        "alpha",
+        "negative",
+        "float",
+        "space",
+        "html-tag",
+    ],
+)
+async def test_org_id_validation(inbound: str, should_keep: bool):
+    """REQ-41.2: numeric X-Org-ID kept verbatim, anything else dropped."""
+    ctx = await _dispatch_and_capture_context({"x-org-id": inbound})
+
+    if should_keep:
+        assert ctx.get("org_id") == inbound, (
+            f"X-Org-ID {inbound!r} is valid (matches ^[0-9]{{1,20}}$) and "
+            f"must be preserved verbatim, got {ctx.get('org_id')!r}"
+        )
+    else:
+        assert "org_id" not in ctx, (
+            f"X-Org-ID {inbound!r} fails the regex / length cap and must be "
+            f"DROPPED from log context entirely (not rejected at HTTP layer). "
+            f"Found bound value: {ctx.get('org_id')!r}"
+        )
+
+
+def test_uuid_replacement_uses_uuid4():
+    """Sanity: ``uuid.uuid4()`` produces strings matching our regex."""
+    assert _UUID_RE.match(str(uuid.uuid4()))

--- a/klai-retrieval-api/tests/test_search_error_handling.py
+++ b/klai-retrieval-api/tests/test_search_error_handling.py
@@ -1,0 +1,255 @@
+"""SPEC-SEC-HYGIENE-001 REQ-43 / AC-43: TRY-rule antipattern fixes in search.py.
+
+Three sub-checks:
+
+* REQ-43.1 — ``except (TimeoutError, Exception)`` is dead code (TimeoutError
+  is a subclass of Exception). Use ``except Exception`` instead, with a
+  separate ``except TimeoutError`` branch placed before it when timeouts
+  need distinct handling.
+* REQ-43.2 — ``logger.error("...", error=str(exc))`` (and the same pattern
+  at warning level) discards the traceback. Use ``logger.exception(...)``
+  inside an ``except`` block, or ``logger.warning(..., exc_info=True)`` if
+  the failure is expected and warning-level is appropriate.
+* REQ-43.3 — every other file in retrieval-api gets the same treatment:
+  no ``error=str(exc)`` survives anywhere under ``retrieval_api/``.
+* REQ-43.4 — ``ruff check retrieval_api/services/search.py`` exits 0 with
+  the project's lint config (which now includes the ``TRY`` rule set).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SEARCH_PY = _REPO_ROOT / "retrieval_api" / "services" / "search.py"
+_RETRIEVAL_API_PKG = _REPO_ROOT / "retrieval_api"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _strip_comments(text: str) -> str:
+    """Return source with ``# ...`` end-of-line comments removed.
+
+    The HYGIENE-001 fix comments deliberately quote the old antipattern
+    string for traceability (``# ... the previous error=str(exc) ...``);
+    those mentions inside comments must NOT trip the grep guards.
+    """
+    lines: list[str] = []
+    for line in text.splitlines():
+        # Naive but safe enough: split on the first '#' that isn't inside
+        # a string literal. For our static guard, false positives in test
+        # data strings are acceptable since they wouldn't match the exact
+        # pattern we're guarding against anyway.
+        idx = line.find("#")
+        if idx >= 0:
+            lines.append(line[:idx])
+        else:
+            lines.append(line)
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------- #
+# REQ-43.1 — no `except (TimeoutError, Exception)` in search.py
+# --------------------------------------------------------------------------- #
+
+
+def test_search_does_not_use_timeouterror_in_exception_tuple():
+    """REQ-43.1: ``except (TimeoutError, Exception)`` is dead code."""
+    src = _read(_SEARCH_PY)
+    bad = re.findall(r"except\s*\(\s*TimeoutError\s*,\s*Exception\s*\)", src)
+    assert not bad, (
+        "search.py still contains `except (TimeoutError, Exception)` — "
+        "TimeoutError is a subclass of Exception, so the TimeoutError "
+        "alternative is unreachable. Use `except Exception` (or split "
+        "into two branches with TimeoutError first)."
+    )
+
+    # Also catch the reverse ordering for safety.
+    reverse = re.findall(r"except\s*\(\s*Exception\s*,\s*TimeoutError\s*\)", src)
+    assert not reverse, "search.py still contains `except (Exception, TimeoutError)`."
+
+
+# --------------------------------------------------------------------------- #
+# REQ-43.2 — no `error=str(exc)` in search.py
+# --------------------------------------------------------------------------- #
+
+
+def test_search_does_not_log_via_error_str_exc():
+    """REQ-43.2: ``error=str(exc)`` discards the traceback (TRY401)."""
+    src = _strip_comments(_read(_SEARCH_PY))
+    assert "error=str(exc)" not in src, (
+        "search.py still logs via `error=str(exc)` — use "
+        "`logger.exception(...)` (preserves traceback) or "
+        "`logger.warning(..., exc_info=True)` instead."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# REQ-43.3 — same fix applied across the rest of retrieval-api
+# --------------------------------------------------------------------------- #
+
+
+def test_no_error_str_exc_anywhere_under_retrieval_api():
+    """REQ-43.3: grep `retrieval_api/` for the same pattern; uniformly fixed."""
+    offenders: list[str] = []
+    for py in _RETRIEVAL_API_PKG.rglob("*.py"):
+        if "error=str(exc)" in _strip_comments(_read(py)):
+            offenders.append(str(py.relative_to(_REPO_ROOT)))
+
+    assert not offenders, (
+        "Files still using `error=str(exc)` (drops traceback): "
+        + ", ".join(offenders)
+    )
+
+
+# --------------------------------------------------------------------------- #
+# REQ-43.2 (behavioural) — exception with traceback reaches the log handler
+# --------------------------------------------------------------------------- #
+
+
+def _capture_records():
+    records: list[logging.LogRecord] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    handler = _Capture(level=logging.DEBUG)
+    root = logging.getLogger()
+    prev_level = root.level
+    root.addHandler(handler)
+    root.setLevel(logging.DEBUG)
+    return records, handler, prev_level
+
+
+@pytest.fixture
+def log_capture():
+    # Ensure ``setup_logging`` (and therefore ``structlog.configure``) has
+    # run BEFORE the structlog loggers in retrieval_api.services.* are
+    # first-used in this test. ``cache_logger_on_first_use=True`` would
+    # otherwise pin them to structlog's default PrintLogger(stderr), and
+    # our root-handler capture would never see the records.
+    from retrieval_api.logging_setup import setup_logging
+
+    setup_logging()
+    records, handler, prev_level = _capture_records()
+    try:
+        yield records
+    finally:
+        logging.getLogger().removeHandler(handler)
+        logging.getLogger().setLevel(prev_level)
+
+
+async def test_search_logs_exception_with_traceback_on_qdrant_failure(monkeypatch, log_capture):
+    """REQ-43.2 (behavioural): a TimeoutError surfaces as a log record with traceback.
+
+    Strategy: stub ``_get_client`` so ``query_points`` raises ``TimeoutError``
+    inside the existing ``asyncio.wait_for`` await. The exception bubbles
+    through the ``except`` block — which must log via ``logger.exception(...)``
+    so ``rec.exc_info`` is populated on the captured ``LogRecord``.
+    """
+    from retrieval_api.services import search
+
+    class _RaisingClient:
+        async def query_points(self, *_a, **_kw):
+            raise TimeoutError("simulated qdrant timeout")
+
+    monkeypatch.setattr(
+        "retrieval_api.services.search._get_client",
+        lambda: _RaisingClient(),
+    )
+
+    class _Req:
+        # Minimal duck-typed request — `_search_notebook` only reads these.
+        notebook_id = "nb-1"
+        org_id = "org-xyz"
+
+    with pytest.raises(TimeoutError):
+        await search._search_notebook([0.1] * 8, _Req(), candidates=10)
+
+    # structlog's ``wrap_for_formatter`` processor passes the post-processed
+    # event_dict as ``record.msg`` (a dict, not a string). The
+    # ``format_exc_info`` processor — configured in
+    # ``logging_setup.setup_logging`` — has already rendered the traceback
+    # into ``event_dict["exception"]`` before this point, so the stdlib
+    # ``record.exc_info`` is no longer carrying the traceback either.
+    def _event_dict(rec: logging.LogRecord) -> dict:
+        if isinstance(rec.msg, dict):
+            return rec.msg
+        return {}
+
+    qdrant_records = [
+        rec for rec in log_capture
+        if _event_dict(rec).get("event") == "qdrant_search_failed"
+    ]
+    assert qdrant_records, (
+        "Expected `qdrant_search_failed` log record, found none. "
+        f"All captured event names: {[_event_dict(r).get('event') for r in log_capture]}"
+    )
+
+    has_traceback = any(
+        "TimeoutError" in str(_event_dict(rec).get("exception", ""))
+        for rec in qdrant_records
+    )
+    assert has_traceback, (
+        "qdrant_search_failed log record has no rendered traceback in the "
+        "structlog event dict — `logger.exception(...)` either was not used "
+        "or the `format_exc_info` processor is no longer wired in. "
+        "REQ-43.2 expects the traceback to survive the log call."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# REQ-43.4 — ruff TRY rules pass on search.py
+# --------------------------------------------------------------------------- #
+
+
+def test_ruff_try_rules_pass_on_search_py():
+    """REQ-43.4: ruff ``TRY`` rules are clean on search.py.
+
+    Scoped via ``--select TRY`` to a) verify the antipattern (TRY400 on
+    ``logger.error`` inside ``except``) is gone and b) keep this assertion
+    independent of pre-existing non-TRY lint issues that are out of
+    HYGIENE-001 REQ-43 scope (e.g. E402 caused by the
+    ``warnings.filterwarnings`` call positioned before late imports).
+    """
+    result = subprocess.run(
+        [sys.executable, "-m", "ruff", "check", "--select", "TRY", str(_SEARCH_PY)],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"ruff TRY check failed for search.py:\n"
+        f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+    )
+
+
+def test_ruff_pyproject_enforces_try_rules():
+    """REQ-43.4: ``pyproject.toml`` lint config enables the ``TRY`` rule set.
+
+    This is the CI-side guard: even if ``search.py`` is clean today, a
+    future regression that re-introduces ``logger.error(...)`` inside
+    ``except`` should fail CI on the next PR.
+    """
+    pyproject = _read(_REPO_ROOT / "pyproject.toml")
+    # Look for "TRY" inside the lint.select list (allow whitespace, quotes).
+    select_match = re.search(
+        r"\[tool\.ruff\.lint\][^[]*?select\s*=\s*\[([^\]]*)\]",
+        pyproject,
+        flags=re.DOTALL,
+    )
+    assert select_match, "Could not locate `[tool.ruff.lint] select = [...]` in pyproject.toml"
+    select_body = select_match.group(1)
+    assert re.search(r"['\"]TRY['\"]", select_body), (
+        "pyproject.toml `[tool.ruff.lint] select` does not enable TRY rules. "
+        "Required by REQ-43.4 to prevent regression."
+    )

--- a/klai-retrieval-api/tests/test_search_error_handling.py
+++ b/klai-retrieval-api/tests/test_search_error_handling.py
@@ -221,7 +221,7 @@ def test_ruff_try_rules_pass_on_search_py():
     HYGIENE-001 REQ-43 scope (e.g. E402 caused by the
     ``warnings.filterwarnings`` call positioned before late imports).
     """
-    result = subprocess.run(
+    result = subprocess.run(  # noqa: S603 — invocation args are controlled within this test
         [sys.executable, "-m", "ruff", "check", "--select", "TRY", str(_SEARCH_PY)],
         cwd=_REPO_ROOT,
         capture_output=True,

--- a/klai-retrieval-api/tests/test_search_error_handling.py
+++ b/klai-retrieval-api/tests/test_search_error_handling.py
@@ -169,8 +169,12 @@ async def test_search_logs_exception_with_traceback_on_qdrant_failure(monkeypatc
 
     class _Req:
         # Minimal duck-typed request — `_search_notebook` only reads these.
+        # user_id is read by the SPEC-SEC-IDENTITY-ASSERT-001 visibility gate
+        # in `_notebook_filter`; None disables the personal-leg, which is
+        # fine for this exception-path test.
         notebook_id = "nb-1"
         org_id = "org-xyz"
+        user_id = None
 
     with pytest.raises(TimeoutError):
         await search._search_notebook([0.1] * 8, _Req(), candidates=10)


### PR DESCRIPTION
## Summary

Closes the retrieval-api slice of SPEC-SEC-HYGIENE-001 (six P3 hygiene findings, HY-39..HY-44). Per the SPEC's explicit permission to split the aggregate by service, this is the retrieval-api delivery; portal-api / connector / scribe / mailer / knowledge-mcp slices are tracked separately.

| REQ | Status | Commit |
|---|---|---|
| HY-39 — `/health` event-loop + topology safety | full fix | `b3d12cf9` |
| HY-43 — search.py TRY antipattern + ruff TRY rules | full fix | `f27ab01e` |
| HY-42 — rate_limit MX:WARN annotation | docs-only | `44e9637d` |
| HY-41 — X-Request-ID / X-Org-ID regex validation | full fix (retrieval-api scope) | `7e4ec034` |
| HY-40 — bounded `_pending` event task set | full fix | `42da6ba5` |
| HY-44 — JWKS fetch timeout cap | slim slice | `7340d337` |

## SPEC text vs reality (deliberate scope reductions)

Two findings turned out to describe code shapes that do not match the current retrieval-api implementation. Both kept the spirit, dropped the impossible code change:

- **REQ-41.4 (cross-service propagation)** — DEFERRED. The same regex caps on `RequestContextMiddleware` need to land in portal-api / connector / scribe / mailer / research-api / knowledge-ingest as a follow-up cross-service slice. Out of scope here.
- **REQ-44.1 / 44.4 / 44.2 / 44.6** — the SPEC assumes a `jwt_auth_enabled=False` dev-bypass branch and a discrete `settings.jwks_url` field; neither exists. `dispatch` always validates Bearer tokens; the JWKS URL is derived from `zitadel_issuer`; the failure mode REQ-44.6 describes is unreachable by construction. REQ-44.1 (short-circuit) and REQ-44.4 (15-min cache TTL) would be cosmetic given current behaviour. Documented as such in `config.py`'s `jwt_auth_enabled` docstring. Only the timeout cap (REQ-44.3) is a real, measurable improvement and is shipped here.

## Test plan

- [x] `uv run --extra dev pytest tests/test_health_safety.py tests/test_search_error_handling.py tests/test_rate_limit_annotation.py tests/test_request_id_validation.py tests/test_events_bounded.py tests/test_auth_jwks_timeout.py` — 40/40 pass
- [x] `uv run --extra dev ruff check retrieval_api/ tests/test_*safety*.py tests/test_*error_handling*.py tests/test_*annotation*.py tests/test_*validation*.py tests/test_*bounded*.py tests/test_*timeout*.py` — clean (0 errors in new code)
- [x] Pre-existing failures on main (`test_api.py::test_health_all_ok`, `test_auth.py::test_missing_zitadel_audience_fails_import`, `test_graph_search.py::test_search_success`, `test_tei.py` × 4) verified present on `main` — not regressions from this slice
- [x] `klai-infra/core-01/.env.sops` + `deploy/docker-compose.yml` env-parity preflight (validator-env-parity HIGH) — no new mandatory env vars; `RETRIEVAL_EVENTS_MAX_PENDING` defaults to 1000 if unset
- [ ] Manual verification on staging: hit `/health` with one dependency disabled and confirm the response body contains `"tei": "error"` (not the full URL); confirm `request_id` log fields contain UUIDs when garbage X-Request-ID is sent

## Out of scope (future SPECs)

- REQ-41.4 cross-service `RequestContextMiddleware` symmetric application
- Other v0.3.0 service slices (connector, scribe, knowledge-mcp, mailer)
- v0.2.0 portal-api slices (REQ-19..REQ-28)
- Structural rate-limit fail-closed (`SPEC-RETRIEVAL-RL-FAILCLOSED-001`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)