### PR TITLE
refactor(portal-api,sec): mfa_policy=unresolved on db-failure events (SPEC-SEC-MFA-001)

### DIFF
--- a/klai-portal/backend/app/api/auth.py
+++ b/klai-portal/backend/app/api/auth.py
@@ -328,9 +328,14 @@ async def _resolve_and_enforce_mfa(
     if db_failure == "portal_user":
         # REQ-3.2 fail-open arm: cannot map email to portal-org; if we 503'd
         # here every brand-new tenant before provisioning would be locked out.
+        # mfa_policy="unresolved" per SPEC REQ-4.1 — the lookup itself failed,
+        # so we cannot honestly claim the policy is "optional"; we are forcing
+        # optional behaviour as the deliberate fail-open trade-off, but
+        # operators triaging in Grafana need to distinguish that from a
+        # genuinely-resolved optional policy.
         _emit_mfa_check_failed(
             reason="db_lookup_failed",
-            mfa_policy="optional",
+            mfa_policy="unresolved",
             outcome="fail-open",
             email=email,
             level="warning",
@@ -356,9 +361,12 @@ async def _resolve_and_enforce_mfa(
         # signal — that hid data-integrity bugs from operators. We keep the
         # fail-open semantics (the user should still be able to log in) but
         # emit a warning so the orphan is observable in Grafana.
+        # mfa_policy="unresolved" per SPEC REQ-4.1 — the org row is gone, so
+        # the policy could not be resolved. The handler still applies optional
+        # behaviour (no enforcement) as the documented fail-open path.
         _emit_mfa_check_failed(
             reason="db_lookup_failed",
-            mfa_policy="optional",
+            mfa_policy="unresolved",
             outcome="fail-open",
             email=email,
             level="warning",

--- a/klai-portal/backend/tests/test_auth_mfa_fail_closed.py
+++ b/klai-portal/backend/tests/test_auth_mfa_fail_closed.py
@@ -398,7 +398,10 @@ async def test_portal_user_lookup_raises_proceeds_documented_fail_open(
     events = _mfa_events(captured)
     assert len(events) == 1
     assert events[0]["reason"] == "db_lookup_failed"
-    assert events[0]["mfa_policy"] == "optional"
+    # SPEC REQ-4.1: mfa_policy is "unresolved" when the lookup itself failed —
+    # the handler defaults to optional behaviour (fail-open) but cannot honestly
+    # claim the policy was resolved.
+    assert events[0]["mfa_policy"] == "unresolved"
     assert events[0]["outcome"] == "fail-open"
     assert events[0]["log_level"] == "warning"
 
@@ -482,7 +485,9 @@ async def test_portal_user_orphan_org_proceeds_documented_fail_open(
     events = _mfa_events(captured)
     assert len(events) == 1
     assert events[0]["reason"] == "db_lookup_failed"
-    assert events[0]["mfa_policy"] == "optional"
+    # SPEC REQ-4.1: orphan org → policy unresolved. Handler still applies
+    # optional behaviour (fail-open) but the field reflects resolution status.
+    assert events[0]["mfa_policy"] == "unresolved"
     assert events[0]["outcome"] == "fail-open"
     assert events[0]["log_level"] == "warning"
 


### PR DESCRIPTION
## Summary

Polish on top of #181. Aligns the `mfa_policy` field on `mfa_check_failed` structured-log events with SPEC REQ-4.1 literal reading: when the lookup itself fails, the field is `"unresolved"` (not `"optional"`).

Two fail-open arms in `_resolve_and_enforce_mfa` were affected:
- portal_user lookup raises (cannot map email to org) — fail-open with warning
- portal_user found, PortalOrg row missing (orphan FK) — fail-open with warning

Behaviour, HTTP response, and alert wiring are all unchanged. Only the structured-log field shifts so `stats by (reason, mfa_policy, outcome)` in Grafana can distinguish "forced optional because lookup failed" from "resolved policy is optional".

## Why

Operators triaging an alert need that distinction. With both cases logged as `"optional"`, a Grafana drilldown by `mfa_policy` collapsed the two situations into one bucket — losing operationally-meaningful signal. SPEC REQ-4.1 anticipated this; the initial implementation logged the effective behaviour instead of the resolution status.

## Test plan

- [x] `tests/test_auth_mfa_fail_closed.py` 23/23 pass
- [x] Full backend suite 1173/1173 pass
- [x] `ruff check app/api/auth.py tests/test_auth_mfa_fail_closed.py` clean
- [x] `pyright app/api/auth.py` 0/0/0
- [x] Runbook schema (`docs/runbooks/mfa-check-failed.md` line 39) already lists `"unresolved"` — no doc update needed
- [x] Grafana alerts (`portal-mfa-rules.yaml`) do not filter on `mfa_policy` value — no alert update needed

## Out of scope

- The 3 retained MagicMock-style tests in `test_auth_security.py::TestMFAPolicyEnforcement` (`test_mfa_required_no_mfa_enrolled_returns_403`, `test_mfa_required_with_mfa_enrolled_proceeds`, `test_mfa_optional_no_enforcement`). REQ-5.7 strictly says respx; pragmatically those three cover paths already exercised under respx in `test_auth_mfa_fail_closed.py` Scenarios 4 & 5. The 403-on-no-MFA-enrolled path is not duplicated, but is covered by the retained test. Worth a follow-up if you want strict REQ-5.7 compliance; not the cost of this PR.
- portal-api image OCI provenance labels (`org.opencontainers.image.revision`, `created`) are empty in the published image. Surfaced during rollout verification of #181; deserves its own SPEC against `klai-portal/.github/workflows/portal-api.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)