### PR TITLE
docs(project): sync project docs after yt-dlp removal + identity-assert

### DIFF
--- a/.moai/project/structure.md
+++ b/.moai/project/structure.md
@@ -23,7 +23,8 @@ klai-mono/                     # Monorepo root (GetKlai/klai)
 ├── klai-retrieval-api/             # Hybrid retrieval service (vector + graph)
 ├── klai-libs/                      # Shared editable Python libraries
 │   ├── image-storage/         # Image pipeline + canonical SSRF guard (SPEC-KB-IMAGE-002, SPEC-SEC-SSRF-001)
-│   └── connector-credentials/ # Tenant-scoped encrypted credential store
+│   ├── connector-credentials/ # Tenant-scoped encrypted credential store
+│   └── identity-assert/       # Service-to-service identity verification (SPEC-SEC-IDENTITY-ASSERT-001)
 ├── scripts/                   # Shared utilities and deploy scripts
 ├── docs/                      # Project documentation (specs, architecture, runbooks)
 ├── .claude/                   # Claude Code assets (agents, rules, commands, skills)

--- a/.moai/project/tech.md
+++ b/.moai/project/tech.md
@@ -28,7 +28,6 @@ Klai is a multi-service TypeScript/Python monorepo. The frontend stack is TypeSc
 | Mail authentication (DKIM/SPF/ARC) | authheaders + dkimpy + authres | >=0.16 |
 | Public Suffix List (RFC 7489 alignment) | publicsuffix2 | >=2.2, <3.0 |
 | MongoDB Driver | motor | >=3.6 |
-| YouTube extractor | yt-dlp | >=2026.3 |
 | Linting | ruff | >=0.8 |
 | Type Checking | pyright | >=1.1 |
 | Testing | pytest + pytest-asyncio | >=8 / >=0.24 |
@@ -196,6 +195,31 @@ structurally prevented because there is only one implementation.
 
 **Purpose:** Tenant-scoped encrypted credential storage for connector
 configs. Consumed by `klai-portal/backend` and `klai-connector`.
+
+### klai-libs/identity-assert
+
+**Purpose:** Shared service-to-service identity verification helper
+(SPEC-SEC-IDENTITY-ASSERT-001). Calls portal-api's
+`POST /internal/identity/verify` endpoint with consumer-side caching
+(60 s TTL, fail-closed). Single implementation across every Python
+consumer that carries a tenant or user identity claim — services do
+not re-implement the contract.
+
+**Consumers:** future Phase B/C/D adopters (`klai-knowledge-mcp`,
+`klai-scribe`, `klai-retrieval-api`). Phase A landed the library +
+endpoint; consumers migrate one PR each.
+
+| Module | Purpose |
+|---|---|
+| `client` | `IdentityAsserter` — async httpx client + LRU cache |
+| `models` | `VerifyResult` frozen dataclass + `KNOWN_CALLER_SERVICES` allowlist |
+| `cache` | In-process TTL cache (privacy boundary: per-process only) |
+| `telemetry` | structlog `identity_assert_call` event with hashed user_id |
+
+| Layer | Technology | Version |
+|-------|-----------|---------|
+| HTTP Client | httpx | >=0.28 |
+| Structured Logging | structlog | >=25.0 |
 
 ---
 


### PR DESCRIPTION
## Summary

Wraps up today's three landed SPECs by closing two stale gaps in the project-level docs:

1. **tech.md** Portal Backend: drop ``yt-dlp`` row (removed yesterday in PR #187)
2. **tech.md** Shared Libraries: add ``klai-libs/identity-assert`` subsection mirroring existing image-storage / connector-credentials format
3. **structure.md** klai-libs tree: add ``identity-assert/`` line so the directory listing matches reality

## Not touched

- ``klai-focus/research-api`` still uses ``youtube-transcript-api`` for its own YouTube path — separate service, different lib, still in use. Row stays.
- ``product.md`` — high-level enough that these implementation details don't belong there.
- No ``codemaps/`` directory exists in this project, nothing to regenerate.

## Sync rationale (per /moai sync workflow)

Status check after PR #178 / #183 / #187 merges showed only ``tech.md`` had stale refs and ``klai-identity-assert`` was missing from the shared-libs documentation. Three small edits, no risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)