### PR TITLE
feat(security): SPEC-SEC-SESSION-001 session and cookie robustness

### DIFF
--- a/klai-portal/backend/app/api/auth.py
+++ b/klai-portal/backend/app/api/auth.py
@@ -40,9 +40,12 @@ import json
 import logging
 import secrets
 import time
+from functools import lru_cache
+from typing import TYPE_CHECKING, cast
 from urllib.parse import quote, urlparse
 
 import httpx
+import redis.exceptions as redis_exc
 import structlog
 from cryptography.fernet import Fernet
 from fastapi import APIRouter, Cookie, Depends, HTTPException, Query, Request, Response, status
@@ -57,8 +60,20 @@ from app.core.config import settings
 from app.core.database import get_db
 from app.models.portal import PortalOrg, PortalOrgAllowedDomain, PortalUser
 from app.services import audit
+from app.services.bff_session import SessionService
 from app.services.events import emit_event
+from app.services.redis_client import get_redis_pool
+from app.services.request_ip import resolve_caller_ip_subnet
 from app.services.zitadel import zitadel
+
+if TYPE_CHECKING:
+    import redis.asyncio as aioredis
+
+# SPEC-SEC-SESSION-001 REQ-1.7: transient Redis failures that translate to
+# fail-CLOSED HTTP 503. ConnectionError covers the unreachable case the SPEC
+# names; TimeoutError covers slow-but-eventually-failing networks (still a
+# brute-force ceiling lift if we let it through).
+_REDIS_UNAVAILABLE_ERRORS = (redis_exc.ConnectionError, redis_exc.TimeoutError)
 
 logger = logging.getLogger(__name__)
 _slog = structlog.get_logger()
@@ -103,32 +118,205 @@ class TTLCache:
 # The cookie value contains the Zitadel session_id + session_token, encrypted
 # with a server-side key.  No server-side state is needed -- Zitadel is the
 # authority on whether the session is still valid.
+#
+# SPEC-SEC-SESSION-001 REQ-3: fail-closed initialisation. Refuse to construct
+# the cipher when ``SSO_COOKIE_KEY`` is empty rather than fall back to
+# ``Fernet.generate_key()``. The fallback would mint a per-replica ephemeral
+# key on every restart — cookies issued by replica A would be undecryptable on
+# replica B, and outstanding cookies would silently invalidate on each deploy.
+# Mirror of ``signup.py::_get_fernet``; the two stay in lock-step until a
+# follow-up SPEC consolidates them into ``app/core/sso_crypto.py``.
 # ---------------------------------------------------------------------------
-_fernet = Fernet(settings.sso_cookie_key.encode() if settings.sso_cookie_key else Fernet.generate_key())
+
+
+@lru_cache(maxsize=1)
+def _get_sso_fernet() -> Fernet:
+    """Return the cached SSO Fernet cipher.
+
+    Raises:
+        RuntimeError: when ``settings.sso_cookie_key`` is empty or
+            whitespace-only. The lifespan startup hook in ``app.main`` calls
+            this once so a misconfigured deployment is caught at deploy time
+            rather than on the first cookie operation.
+    """
+    key = settings.sso_cookie_key
+    if not key or not key.strip():
+        raise RuntimeError(
+            "SSO_COOKIE_KEY is not set. "
+            "Configure klai-infra SOPS-encrypted .env (klai-infra/core-01/.env.sops) "
+            "before starting portal-api."
+        )
+    return Fernet(key.encode())
 
 
 def _encrypt_sso(session_id: str, session_token: str) -> str:
     """Encrypt session credentials into an opaque cookie value."""
     payload = json.dumps({"sid": session_id, "stk": session_token}).encode()
-    return _fernet.encrypt(payload).decode()
+    return _get_sso_fernet().encrypt(payload).decode()
 
 
 def _decrypt_sso(cookie_value: str) -> dict | None:
     """Decrypt the SSO cookie.  Returns {"sid": ..., "stk": ...} or None."""
     try:
-        payload = _fernet.decrypt(cookie_value.encode())
+        payload = _get_sso_fernet().decrypt(cookie_value.encode())
         return json.loads(payload)
     except Exception:
         return None
 
 
 # ---------------------------------------------------------------------------
-# Pending TOTP cache
-# After password check, store the session here while waiting for the TOTP code.
+# Pending TOTP state — Redis-backed (SPEC-SEC-SESSION-001 REQ-1)
+#
+# Pre-SPEC, ``_pending_totp = TTLCache(...)`` lived in process memory: each
+# replica kept its own ``failures`` counter, so a 5-failure lockout was
+# really an N*5 lockout when the proxy round-robinned across N replicas.
+# Pending state now lives in Redis; the failure counter is incremented with
+# atomic ``INCR`` so the ceiling is cross-replica consistent.
+#
+# Two keys per token (kept separate so the read-mostly state hash and the
+# write-mostly counter do not contend on the same primitive):
+#   ``totp_pending:<token>``           HASH  session_id, session_token, ua_hash, ip_subnet
+#   ``totp_pending_failures:<token>``  STR   incremented; ``INCR`` returns the new count
+#
+# Both keys carry the same TTL set at create time. ``INCR`` does not refresh
+# the TTL — the counter cannot outlive the session it counts against, so
+# orphan counters cannot survive the state-hash expiry.
 # ---------------------------------------------------------------------------
-_TOTP_PENDING_TTL = 300  # 5 minutes
-_TOTP_MAX_FAILURES = 5  # invalidate token after this many wrong codes
-_pending_totp = TTLCache(_TOTP_PENDING_TTL)
+_TOTP_MAX_FAILURES = 5  # lockout threshold; matches the pre-SPEC ceiling
+_TOTP_PENDING_KEY_PREFIX = "totp_pending:"
+_TOTP_PENDING_FAILURES_PREFIX = "totp_pending_failures:"
+
+
+async def _get_totp_redis_or_503(*, phase: str):
+    """Return the Redis pool, or raise HTTP 503 (REQ-1.7 fail-closed).
+
+    Different threat model from ``partner_rate_limit.check_rate_limit`` which
+    fails OPEN: opening the door on TOTP would lift the brute-force ceiling
+    entirely (the very bug we are closing). The ``phase`` kwarg is for
+    operator forensics — ``totp_pending_redis_unavailable`` log records make
+    it clear which Redis op failed without dumping the token.
+    """
+    try:
+        pool = await get_redis_pool()
+    except _REDIS_UNAVAILABLE_ERRORS:
+        _slog.error(
+            "totp_pending_redis_unavailable",
+            phase=phase,
+            reason="get_pool_raised",
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication unavailable, please retry",
+        ) from None
+    if pool is None:
+        _slog.error(
+            "totp_pending_redis_unavailable",
+            phase=phase,
+            reason="redis_pool_none",
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication unavailable, please retry",
+        )
+    return pool
+
+
+async def _totp_pending_create(
+    *,
+    session_id: str,
+    session_token: str,
+    ua_hash: str,
+    ip_subnet: str,
+) -> str:
+    """Allocate a fresh ``temp_token`` and store the pending state in Redis.
+
+    The opaque token returned to the client preserves the legacy
+    ``secrets.token_urlsafe(32)`` contract — 256 bits of entropy, URL-safe.
+    Raises HTTP 503 when Redis is unreachable (REQ-1.7).
+    """
+    pool = cast("aioredis.Redis", await _get_totp_redis_or_503(phase="create"))
+    token = secrets.token_urlsafe(32)
+    state_key = f"{_TOTP_PENDING_KEY_PREFIX}{token}"
+    counter_key = f"{_TOTP_PENDING_FAILURES_PREFIX}{token}"
+    ttl = settings.totp_pending_ttl_seconds
+    try:
+        # redis-py stub regression: ``Redis.hset`` is awaitable in the
+        # asyncio variant but typed as sync ``int`` in the inherited
+        # signature. Same workaround would apply to any Redis-async helper
+        # that touched ``hset`` directly.
+        await pool.hset(  # pyright: ignore[reportGeneralTypeIssues]
+            state_key,
+            mapping={
+                "session_id": session_id,
+                "session_token": session_token,
+                "ua_hash": ua_hash,
+                "ip_subnet": ip_subnet,
+            },
+        )
+        await pool.expire(state_key, ttl)
+        # ``SET ... EX`` initialises the counter at 0 with TTL in one round trip.
+        await pool.set(counter_key, 0, ex=ttl)
+    except _REDIS_UNAVAILABLE_ERRORS:
+        _slog.error("totp_pending_redis_unavailable", phase="create", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication unavailable, please retry",
+        ) from None
+    return token
+
+
+async def _totp_pending_get(token: str) -> dict[str, str] | None:
+    """Look up the pending state. Returns the field map, or ``None`` if
+    the token is unknown or already expired."""
+    pool = cast("aioredis.Redis", await _get_totp_redis_or_503(phase="get"))
+    try:
+        # Same redis-py stub regression as ``_totp_pending_create``:
+        # ``Redis.hgetall`` is awaitable in the asyncio variant.
+        data = await pool.hgetall(  # pyright: ignore[reportGeneralTypeIssues]
+            f"{_TOTP_PENDING_KEY_PREFIX}{token}"
+        )
+    except _REDIS_UNAVAILABLE_ERRORS:
+        _slog.error("totp_pending_redis_unavailable", phase="get", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication unavailable, please retry",
+        ) from None
+    return data or None
+
+
+async def _totp_pending_incr_failures(token: str) -> int:
+    """Atomically increment + return the new failure count.
+
+    REQ-1.4: a single-round-trip ``INCR`` is the atomicity primitive that
+    prevents the cross-replica read-modify-write race a naive ``HGET + 1
+    + HSET`` would re-introduce.
+    """
+    pool = cast("aioredis.Redis", await _get_totp_redis_or_503(phase="incr"))
+    try:
+        return await pool.incr(f"{_TOTP_PENDING_FAILURES_PREFIX}{token}")
+    except _REDIS_UNAVAILABLE_ERRORS:
+        _slog.error("totp_pending_redis_unavailable", phase="incr", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication unavailable, please retry",
+        ) from None
+
+
+async def _totp_pending_delete(token: str) -> None:
+    """Drop both the state hash and the counter. Idempotent."""
+    pool = cast("aioredis.Redis", await _get_totp_redis_or_503(phase="delete"))
+    try:
+        await pool.delete(
+            f"{_TOTP_PENDING_KEY_PREFIX}{token}",
+            f"{_TOTP_PENDING_FAILURES_PREFIX}{token}",
+        )
+    except _REDIS_UNAVAILABLE_ERRORS:
+        _slog.error("totp_pending_redis_unavailable", phase="delete", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication unavailable, please retry",
+        ) from None
 
 
 # ---------------------------------------------------------------------------
@@ -559,7 +747,12 @@ async def password_set(body: PasswordSetRequest) -> None:
 
 
 @router.post("/auth/login", response_model=LoginResponse)
-async def login(body: LoginRequest, response: Response, db: AsyncSession = Depends(get_db)) -> LoginResponse:
+async def login(
+    body: LoginRequest,
+    response: Response,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> LoginResponse:
     # 1a. Find Zitadel user by email — SPEC-SEC-MFA-001 REQ-2: split 4xx ↔ 5xx
     zitadel_user_id: str | None = None
     org_id_zitadel: str | None = None
@@ -659,12 +852,19 @@ async def login(body: LoginRequest, response: Response, db: AsyncSession = Depen
 
     # 3. If the user has TOTP, require a code before finalizing
     if has_totp:
-        temp_token = _pending_totp.put(
-            {
-                "session_id": session["sessionId"],
-                "session_token": session["sessionToken"],
-                "failures": 0,
-            }
+        # SPEC-SEC-SESSION-001 REQ-1.1: store the pending state in Redis
+        # (cross-replica atomic counter) and snapshot UA + IP-subnet so a
+        # follow-up SPEC can add binding-on-consume without a Redis schema
+        # migration. ``ua_hash`` reuses the SHA-256-hex helper from
+        # ``BFFSessionService`` — same primitive as the BFF session-theft
+        # detector, so two surfaces stay in lock-step.
+        ua_hash = SessionService.hash_metadata(request.headers.get("user-agent"))
+        ip_subnet = resolve_caller_ip_subnet(request)
+        temp_token = await _totp_pending_create(
+            session_id=session["sessionId"],
+            session_token=session["sessionToken"],
+            ua_hash=ua_hash,
+            ip_subnet=ip_subnet,
         )
         return LoginResponse(status="totp_required", temp_token=temp_token)
 
@@ -679,20 +879,19 @@ async def login(body: LoginRequest, response: Response, db: AsyncSession = Depen
 
 @router.post("/auth/totp-login", response_model=LoginResponse)
 async def totp_login(body: TOTPLoginRequest, response: Response, db: AsyncSession = Depends(get_db)) -> LoginResponse:
-    """Complete login by providing a TOTP code after password was accepted."""
-    pending = _pending_totp.get(body.temp_token)
+    """Complete login by providing a TOTP code after password was accepted.
+
+    SPEC-SEC-SESSION-001 REQ-1.3..1.6: pending state lives in Redis. The
+    failure counter is incremented atomically with ``INCR`` so the lockout
+    ceiling holds across replicas. Lockout deletes both keys, so a 6th
+    attempt naturally returns ``Session expired`` instead of needing a
+    pre-emptive ceiling check.
+    """
+    pending = await _totp_pending_get(body.temp_token)
     if not pending:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Session expired, please log in again",
-        )
-
-    # Reject immediately if the token is already locked out
-    if pending["failures"] >= _TOTP_MAX_FAILURES:
-        _pending_totp.pop(body.temp_token)
-        raise HTTPException(
-            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-            detail="Too many failed attempts, please log in again",
         )
 
     # Verify TOTP code by updating the session
@@ -705,7 +904,7 @@ async def totp_login(body: TOTPLoginRequest, response: Response, db: AsyncSessio
     except httpx.HTTPStatusError as exc:
         logger.exception("update_session_with_totp failed %s: %s", exc.response.status_code, exc.response.text)
         if exc.response.status_code in (400, 401):
-            pending["failures"] += 1
+            new_failures = await _totp_pending_incr_failures(body.temp_token)
             await audit.log_event(
                 org_id=0,
                 actor="unknown",
@@ -714,8 +913,16 @@ async def totp_login(body: TOTPLoginRequest, response: Response, db: AsyncSessio
                 resource_id=pending["session_id"],
                 details={"reason": "invalid_code"},
             )
-            if pending["failures"] >= _TOTP_MAX_FAILURES:
-                _pending_totp.pop(body.temp_token)
+            if new_failures >= _TOTP_MAX_FAILURES:
+                await _totp_pending_delete(body.temp_token)
+                # REQ-5.1: token_prefix only — never the full token, never the
+                # session credentials. PII guard verified by
+                # ``test_session_logging_pii``.
+                _slog.warning(
+                    "totp_pending_lockout",
+                    failures=new_failures,
+                    token_prefix=body.temp_token[:8],
+                )
                 raise HTTPException(
                     status_code=status.HTTP_429_TOO_MANY_REQUESTS,
                     detail="Too many failed attempts, please log in again",
@@ -742,8 +949,8 @@ async def totp_login(body: TOTPLoginRequest, response: Response, db: AsyncSessio
     session_id = updated.get("sessionId", pending["session_id"])
     session_token = updated.get("sessionToken", pending["session_token"])
 
-    # Clean up pending token
-    _pending_totp.pop(body.temp_token)
+    # Clean up pending token (REQ-1.6)
+    await _totp_pending_delete(body.temp_token)
 
     # Finalize and set cookie
     return await _finalize_and_set_cookie(
@@ -1160,6 +1367,7 @@ async def idp_intent_signup(body: IDPIntentSignupRequest) -> IDPIntentResponse:
 async def idp_signup_callback(
     id: str,
     token: str,
+    request: Request,
     locale: str = Query(default="nl"),
     db: AsyncSession = Depends(get_db),
 ) -> RedirectResponse:
@@ -1288,15 +1496,22 @@ async def idp_signup_callback(
         emit_event("login", user_id=zitadel_user_id, properties={"method": "idp"})
         return response
 
-    # 4. New user — store pending session in encrypted cookie, redirect to company name form
+    # 4. New user — store pending session in encrypted cookie, redirect to company name form.
+    # SPEC-SEC-SESSION-001 REQ-2.1: snapshot the issuing browser + IP-subnet
+    # so the consume side (signup_social) can reject a stolen-cookie replay
+    # from a different origin context.
+    pending_ua_hash = SessionService.hash_metadata(request.headers.get("user-agent"))
+    pending_ip_subnet = resolve_caller_ip_subnet(request)
     pending_payload = json.dumps(
         {
             "session_id": session_id,
             "session_token": session_token,
             "zitadel_user_id": zitadel_user_id,
+            "ua_hash": pending_ua_hash,
+            "ip_subnet": pending_ip_subnet,
         }
     ).encode()
-    encrypted_pending = _fernet.encrypt(pending_payload).decode()
+    encrypted_pending = _get_sso_fernet().encrypt(pending_payload).decode()
 
     social_url = (
         f"{settings.portal_url}/{locale}/signup/social"

--- a/klai-portal/backend/app/api/internal.py
+++ b/klai-portal/backend/app/api/internal.py
@@ -77,24 +77,12 @@ _AUDIT_INSERT_SQL = text(
 )
 
 
-def _resolve_caller_ip(request: Request) -> str:
-    """Resolve caller IP for rate-limit key and audit row.
-
-    SPEC-SEC-005 REQ-1.6: priority order
-    1. Right-most entry of X-Forwarded-For from the immediate trusted upstream (Caddy).
-       The right-most entry is the IP the immediate upstream saw (attacker-supplied
-       left entries are ignored).
-    2. request.client.host.
-    3. Literal "unknown" when neither is available (e.g. synthetic ASGI scope).
-    """
-    xff = request.headers.get("x-forwarded-for", "")
-    if xff:
-        parts = [p.strip() for p in xff.split(",") if p.strip()]
-        if parts:
-            return parts[-1]
-    if request.client and request.client.host:
-        return request.client.host
-    return "unknown"
+# SPEC-SEC-SESSION-001: caller-IP resolution moved to ``app.services.request_ip``
+# once a third callsite (``app.api.auth`` for IDP-pending cookie binding)
+# joined the existing internal-rate-limit and internal-audit consumers. The
+# alias below preserves the private name so all in-module callsites and the
+# ``test_internal_hardening`` patch surface stay unchanged.
+from app.services.request_ip import resolve_caller_ip as _resolve_caller_ip  # noqa: E402
 
 
 async def _check_rate_limit_internal(caller_ip: str) -> None:

--- a/klai-portal/backend/app/api/signup.py
+++ b/klai-portal/backend/app/api/signup.py
@@ -20,21 +20,26 @@ import json
 import logging
 import re
 import unicodedata
+from typing import Any
 
 import httpx
+import structlog
 from cryptography.fernet import Fernet, InvalidToken
-from fastapi import APIRouter, BackgroundTasks, Cookie, Depends, HTTPException, Response, status
+from fastapi import APIRouter, BackgroundTasks, Cookie, Depends, HTTPException, Request, Response, status
 from pydantic import BaseModel, EmailStr, field_validator
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.core.database import get_db, set_tenant
 from app.models.portal import PortalOrg, PortalUser
+from app.services.bff_session import SessionService
 from app.services.events import emit_event
 from app.services.provisioning import provision_tenant
+from app.services.request_ip import resolve_caller_ip_subnet
 from app.services.zitadel import zitadel
 
 logger = logging.getLogger(__name__)
+_slog = structlog.get_logger()
 
 _IDP_PENDING_COOKIE = "klai_idp_pending"
 _IDP_PENDING_MAX_AGE = 600  # 10 minutes — must match auth.py
@@ -240,11 +245,60 @@ def _get_fernet() -> Fernet:
     return Fernet(key.encode())
 
 
+def _verify_idp_pending_binding(payload: dict[str, Any], request: Request) -> None:
+    """SPEC-SEC-SESSION-001 REQ-2.2: enforce browser + IP-subnet binding.
+
+    Compares the ``ua_hash`` and ``ip_subnet`` fields stored in the encrypted
+    ``klai_idp_pending`` cookie against the values derived from the current
+    request. Mismatch → HTTP 403 + structlog ``idp_pending_binding_mismatch``
+    at ``warning`` level. The original cookie is left intact (caller does
+    not delete it) so the legitimate user can resume their flow within the
+    TTL.
+
+    A payload without the binding fields is treated as either pre-deploy
+    legacy or tampered: same 403, no binding metadata to compare.
+
+    Raises:
+        HTTPException(403): on any binding mismatch or missing field.
+    """
+    stored_ua_hash = payload.get("ua_hash")
+    stored_ip_subnet = payload.get("ip_subnet")
+    if stored_ua_hash is None or stored_ip_subnet is None:
+        # No binding fields → cannot verify → reject. PII-safe log: no payload
+        # contents are dumped to avoid leaking session ids on the rare path
+        # where the cookie was tampered with.
+        _slog.warning("idp_pending_binding_mismatch", reason="missing_binding_fields")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Signup session binding mismatch, please start over",
+        )
+
+    current_ua_hash = SessionService.hash_metadata(request.headers.get("user-agent"))
+    current_ip_subnet = resolve_caller_ip_subnet(request)
+
+    if stored_ua_hash != current_ua_hash or stored_ip_subnet != current_ip_subnet:
+        # REQ-2.2: log only the first 8 chars of each hash + the subnet
+        # network address. Never the raw UA, never the raw IP, never the
+        # session credentials.
+        _slog.warning(
+            "idp_pending_binding_mismatch",
+            stored_ua_hash_prefix=stored_ua_hash[:8],
+            current_ua_hash_prefix=current_ua_hash[:8],
+            stored_ip_subnet=stored_ip_subnet,
+            current_ip_subnet=current_ip_subnet,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Signup session binding mismatch, please start over",
+        )
+
+
 @router.post("/signup/social", response_model=SocialSignupResponse, status_code=status.HTTP_201_CREATED)
 async def signup_social(
     body: SocialSignupRequest,
     response: Response,
     background_tasks: BackgroundTasks,
+    request: Request,
     db: AsyncSession = Depends(get_db),
     klai_idp_pending: str | None = Cookie(default=None),
 ) -> SocialSignupResponse:
@@ -268,6 +322,11 @@ async def signup_social(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Social signup session expired. Please try again.",
         ) from exc
+
+    # SPEC-SEC-SESSION-001 REQ-2.5: binding check runs AFTER the Fernet TTL
+    # decrypt succeeds. Mismatch returns 403 with no extra information about
+    # whether the cookie was otherwise valid.
+    _verify_idp_pending_binding(pending, request)
 
     session_id: str = pending.get("session_id", "")
     session_token: str = pending.get("session_token", "")

--- a/klai-portal/backend/app/core/config.py
+++ b/klai-portal/backend/app/core/config.py
@@ -73,6 +73,11 @@ class Settings(BaseSettings):
     sso_cookie_key: str = ""  # PORTAL_API_SSO_COOKIE_KEY
     sso_cookie_max_age: int = 7776000  # 90 days; Zitadel session lifetime is the real authority
 
+    # SPEC-SEC-SESSION-001 REQ-1.1: TTL for the Redis-backed TOTP pending-login
+    # state. Default 300 s preserves the legacy in-memory ``_pending_totp``
+    # window. Tunable so ops can compress it without code changes.
+    totp_pending_ttl_seconds: int = 300
+
     # BFF — Backend-for-Frontend session auth (SPEC-AUTH-008)
     # Fernet key for encrypting BFF session records at rest in Redis.
     # Falls back to sso_cookie_key when unset — single key during the rollout.

--- a/klai-portal/backend/app/main.py
+++ b/klai-portal/backend/app/main.py
@@ -2,6 +2,7 @@ import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
+import structlog
 from fastapi import FastAPI, Request
 from fastapi.responses import Response
 
@@ -15,6 +16,7 @@ from app.api.app_gaps import router as app_gaps_router
 from app.api.app_knowledge_bases import router as app_knowledge_bases_router
 from app.api.app_knowledge_sources import router as app_knowledge_sources_router
 from app.api.app_templates import router as app_templates_router
+from app.api.auth import _get_sso_fernet
 from app.api.auth import router as auth_router
 from app.api.billing import router as billing_router
 from app.api.connectors import router as connectors_router
@@ -45,6 +47,7 @@ from app.services.zitadel import zitadel
 setup_logging("portal-api")
 
 logger = logging.getLogger(__name__)
+_slog = structlog.get_logger()
 
 
 async def _run_stuck_detector() -> None:
@@ -68,6 +71,22 @@ async def _run_stuck_detector() -> None:
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     import asyncio
 
+    # SPEC-SEC-SESSION-001 REQ-4: validate SSO_COOKIE_KEY in BOTH dev and prod
+    # modes, before any other startup work. Empty / unset key aborts the
+    # process so a misconfigured deployment is caught at deploy time, not on
+    # the first cookie operation. Calling _get_sso_fernet() also exercises
+    # the Fernet construction path that will later issue/verify cookies, so
+    # malformed keys (wrong length, non-base64) abort here too.
+    try:
+        _get_sso_fernet()
+    except RuntimeError:
+        _slog.critical(
+            "sso_cookie_key_missing_startup_abort",
+            env_var="SSO_COOKIE_KEY",
+            sops_path="klai-infra/core-01/.env.sops",
+        )
+        raise
+
     if settings.is_auth_dev_mode:
         # ── Dev mode: skip Zitadel, loud warnings ────────────────────────
         logger.critical(
@@ -84,12 +103,12 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             )
             raise SystemExit(1)
     else:
-        # ── Production mode: validate secrets exist ──────────────────────
+        # ── Production mode: validate remaining secrets exist ────────────
+        # SSO_COOKIE_KEY is handled above by _get_sso_fernet(); listing it
+        # here too would double-log the same misconfiguration.
         missing = []
         if not settings.zitadel_pat:
             missing.append("ZITADEL_PAT")
-        if not settings.sso_cookie_key:
-            missing.append("SSO_COOKIE_KEY")
         if not settings.portal_secrets_key:
             missing.append("PORTAL_SECRETS_KEY")
         if not settings.encryption_key:

--- a/klai-portal/backend/app/services/request_ip.py
+++ b/klai-portal/backend/app/services/request_ip.py
@@ -1,0 +1,77 @@
+"""Caller-IP resolution helpers for portal-api.
+
+The right-most entry of ``X-Forwarded-For`` is the IP that Caddy (the
+immediate trusted upstream) saw on the wire. Attacker-supplied entries that
+clients prepend to ``XFF`` end up to the LEFT of that entry, so they are
+ignored by ``resolve_caller_ip``.
+
+Two consumers share the helper:
+
+- ``app.api.internal``: rate-limit key + audit row (``SPEC-SEC-005 REQ-1.6``).
+- ``app.api.auth`` / ``app.api.signup``: ``klai_idp_pending`` cookie binding
+  to a ``/24`` IPv4 (or ``/48`` IPv6) subnet
+  (``SPEC-SEC-SESSION-001 REQ-2.3``).
+
+Pulled out of ``app.api.internal`` once the third callsite landed; before
+that it lived as a private ``_resolve_caller_ip`` next to its only caller.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+
+from fastapi import Request
+
+# IPv4 /24 and IPv6 /48 are the SPEC-SEC-SESSION-001 binding boundaries.
+# /24 covers most carrier-NAT pools without crossing a major site boundary;
+# /48 is the typical IPv6 site-prefix length for residential and mobile ISPs.
+_IPV4_BINDING_PREFIX = 24
+_IPV6_BINDING_PREFIX = 48
+
+# Sentinel returned when the caller IP cannot be resolved or parsed. Stable
+# string so callers can compare ``resolve_caller_ip_subnet(req) == "unknown"``.
+_UNKNOWN = "unknown"
+
+
+def resolve_caller_ip(request: Request) -> str:
+    """Return the best-effort caller IP for the request.
+
+    Priority order:
+    1. Right-most entry of ``X-Forwarded-For`` from the immediate trusted
+       upstream (Caddy). Attacker-supplied left-side entries are dropped.
+    2. ``request.client.host``.
+    3. The literal string ``"unknown"`` (e.g. synthetic ASGI scope).
+    """
+    xff = request.headers.get("x-forwarded-for", "")
+    if xff:
+        parts = [p.strip() for p in xff.split(",") if p.strip()]
+        if parts:
+            return parts[-1]
+    if request.client and request.client.host:
+        return request.client.host
+    return _UNKNOWN
+
+
+def resolve_caller_ip_subnet(request: Request) -> str:
+    """Return the binding-subnet network address for the caller.
+
+    IPv4 → ``/24`` network address. IPv6 → ``/48`` network address. Returns
+    ``"unknown"`` when the caller IP is missing or cannot be parsed by
+    :mod:`ipaddress`.
+
+    Used by the ``klai_idp_pending`` Fernet cookie binding so a stolen cookie
+    replayed from a different network is rejected, while a mobile user
+    switching cells inside the same carrier prefix is not (the new IP is
+    almost always inside the same ``/24``/``/48``). See SPEC-SEC-SESSION-001
+    research §3.2 for the threat-model rationale.
+    """
+    raw = resolve_caller_ip(request)
+    if raw == _UNKNOWN:
+        return _UNKNOWN
+    try:
+        addr = ipaddress.ip_address(raw)
+    except ValueError:
+        return _UNKNOWN
+    prefix = _IPV4_BINDING_PREFIX if addr.version == 4 else _IPV6_BINDING_PREFIX
+    network = ipaddress.ip_network(f"{raw}/{prefix}", strict=False)
+    return str(network.network_address)

--- a/klai-portal/backend/pyproject.toml
+++ b/klai-portal/backend/pyproject.toml
@@ -50,6 +50,9 @@ dev = [
     # Test-only dep — portal-api itself does not import the library
     # (portal-api SERVES the endpoint, doesn't call it).
     "klai-identity-assert",
+    # SPEC-SEC-SESSION-001 REQ-6: in-memory Redis substitute for TOTP and IDP
+    # pending-cookie regression tests. Implements HSET/INCR/EXPIRE atomically.
+    "fakeredis>=2.26",
 ]
 
 [dependency-groups]
@@ -65,6 +68,9 @@ dev = [
     # dev so both ``uv run pytest`` (CI, picks dependency-groups) and
     # ``uv pip install .[dev]`` (local) install it.
     "klai-identity-assert",
+    # SPEC-SEC-SESSION-001 REQ-6: in-memory Redis substitute for the TOTP +
+    # IDP-pending regression suites. Mirrors [project.optional-dependencies] dev.
+    "fakeredis>=2.26",
 ]
 
 [tool.pytest.ini_options]

--- a/klai-portal/backend/tests/conftest.py
+++ b/klai-portal/backend/tests/conftest.py
@@ -6,7 +6,10 @@ Sets required env vars before any app module is imported.
 
 import os
 import sys
+from collections.abc import AsyncIterator
 from typing import Any
+
+import pytest_asyncio
 
 # ---------------------------------------------------------------------------
 # Suppress 'coroutine was never awaited' from mocked-asyncio tests.
@@ -41,3 +44,34 @@ os.environ.setdefault("PORTAL_SECRETS_KEY", "0" * 64)  # 64-char hex; test place
 os.environ.setdefault("ENCRYPTION_KEY", "1" * 64)  # 64-char hex; test placeholder only
 os.environ.setdefault("VEXA_WEBHOOK_SECRET", "test-vexa-webhook-secret")  # SEC-013 F-033
 os.environ.setdefault("MONEYBIRD_WEBHOOK_TOKEN", "test-moneybird-webhook-token")  # SPEC-SEC-WEBHOOK-001 REQ-3
+
+
+# ---------------------------------------------------------------------------
+# Shared fakeredis fixture for SPEC-SEC-SESSION-001 + future Redis-backed code
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def fake_redis() -> AsyncIterator[Any]:
+    """In-memory ``fakeredis.aioredis.FakeRedis`` swapped into the singleton
+    pool for the duration of one test.
+
+    Matches the production ``get_redis_pool()`` contract:
+    - ``decode_responses=True`` so HSET / HGETALL / GET return ``str`` not bytes.
+    - Same instance returned across all ``get_redis_pool()`` calls in the test.
+
+    Tests can directly inspect the fake via the yielded handle (e.g.
+    ``await fake_redis.hgetall("totp_pending:T")``).
+    """
+    import fakeredis.aioredis
+
+    from app.services import redis_client
+
+    fake = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    original = redis_client._pool_holder["pool"]
+    redis_client._pool_holder["pool"] = fake
+    try:
+        yield fake
+    finally:
+        redis_client._pool_holder["pool"] = original
+        await fake.aclose()

--- a/klai-portal/backend/tests/helpers.py
+++ b/klai-portal/backend/tests/helpers.py
@@ -2,13 +2,16 @@
 
 Import directly in test files:
 
-    from helpers import FakeResult, FakeKB, make_partner_auth, setup_db
+    from helpers import FakeResult, FakeKB, make_partner_auth, make_request, setup_db
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
+
+from starlette.requests import Request
 
 # ---------------------------------------------------------------------------
 # Generic DB result mock
@@ -100,3 +103,43 @@ def make_partner_auth(
         kb_access=kb_access if kb_access is not None else {10: "read", 20: "read_write"},
         rate_limit_rpm=60,
     )
+
+
+# ---------------------------------------------------------------------------
+# Synthetic Starlette Request for tests that call FastAPI handlers directly
+# ---------------------------------------------------------------------------
+
+
+def make_request(
+    *,
+    method: str = "POST",
+    path: str = "/",
+    headers: dict[str, str] | None = None,
+    client: tuple[str, int] | None = ("127.0.0.1", 12345),
+) -> Request:
+    """Build a Starlette ``Request`` suitable for in-process handler calls.
+
+    Real FastAPI routing injects a ``Request`` per call. Tests that bypass the
+    router (``await login(...)`` style) need an equivalent. SPEC-SEC-SESSION-001
+    REQ-1.1 made ``request`` a required parameter on ``/auth/login`` so the UA
+    hash + IP-subnet snapshot can be captured.
+
+    Defaults to ``127.0.0.1:12345`` so ``resolve_caller_ip`` returns a parseable
+    address without test setup.
+    """
+    scope: dict[str, Any] = {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "http_version": "1.1",
+        "method": method,
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "scheme": "http",
+        "server": ("testserver", 80),
+        "headers": [
+            (k.lower().encode(), v.encode()) for k, v in (headers or {}).items()
+        ],
+        "client": client,
+    }
+    return Request(scope)

--- a/klai-portal/backend/tests/helpers.py
+++ b/klai-portal/backend/tests/helpers.py
@@ -137,9 +137,7 @@ def make_request(
         "query_string": b"",
         "scheme": "http",
         "server": ("testserver", 80),
-        "headers": [
-            (k.lower().encode(), v.encode()) for k, v in (headers or {}).items()
-        ],
+        "headers": [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()],
         "client": client,
     }
     return Request(scope)

--- a/klai-portal/backend/tests/test_auth_login_happy_path.py
+++ b/klai-portal/backend/tests/test_auth_login_happy_path.py
@@ -32,9 +32,7 @@ def _session_ok() -> dict[str, str]:
     return {"sessionId": "sess-happy", "sessionToken": "tok-happy"}
 
 
-async def test_password_totp_login_happy_path(
-    fake_redis: Any, monkeypatch: pytest.MonkeyPatch
-) -> None:
+async def test_password_totp_login_happy_path(fake_redis: Any, monkeypatch: pytest.MonkeyPatch) -> None:
     """Step-by-step trace of the dual-call login flow.
 
     Assertions cover the SPEC-SEC-SESSION-001 invariants:
@@ -46,9 +44,7 @@ async def test_password_totp_login_happy_path(
       happy path.
     """
     # -- Step 1: POST /api/auth/login --------------------------------------
-    body = LoginRequest(
-        email="alice@acme.com", password="correct horse", auth_request_id="ar-happy-1"
-    )
+    body = LoginRequest(email="alice@acme.com", password="correct horse", auth_request_id="ar-happy-1")
     response = MagicMock(spec=Response)
     db = AsyncMock(spec=AsyncSession)
 
@@ -93,9 +89,7 @@ async def test_password_totp_login_happy_path(
     assert counter == "0", f"failure counter must start at 0, got {counter!r}"
 
     # -- Step 2: POST /api/auth/totp-login --------------------------------
-    totp_body = TOTPLoginRequest(
-        temp_token=temp_token, code="123456", auth_request_id="ar-happy-1"
-    )
+    totp_body = TOTPLoginRequest(temp_token=temp_token, code="123456", auth_request_id="ar-happy-1")
 
     with (
         capture_logs() as captured_totp,

--- a/klai-portal/backend/tests/test_auth_login_happy_path.py
+++ b/klai-portal/backend/tests/test_auth_login_happy_path.py
@@ -1,0 +1,126 @@
+"""SPEC-SEC-SESSION-001 acceptance scenario 5 — REQ-6.5.
+
+Full happy-path regression: password → TOTP success → SSO cookie. Asserts
+the Redis-backed pending state lifecycle, including the four bound fields
+(session_id, session_token, ua_hash, ip_subnet) and the failure counter
+that starts at zero and is deleted on success. The pre-SPEC in-memory
+``TTLCache`` flow had no equivalent assertions.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.responses import Response
+from helpers import make_request
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog.testing import capture_logs
+
+from app.api.auth import (
+    _TOTP_PENDING_FAILURES_PREFIX,
+    _TOTP_PENDING_KEY_PREFIX,
+    LoginRequest,
+    TOTPLoginRequest,
+    login,
+    totp_login,
+)
+
+
+def _session_ok() -> dict[str, str]:
+    return {"sessionId": "sess-happy", "sessionToken": "tok-happy"}
+
+
+async def test_password_totp_login_happy_path(
+    fake_redis: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Step-by-step trace of the dual-call login flow.
+
+    Assertions cover the SPEC-SEC-SESSION-001 invariants:
+    - REQ-1.1: pending hash holds all four bound fields after /login.
+    - REQ-1.4-implied: counter exists and starts at 0.
+    - REQ-1.6: both keys are gone after the successful /totp-login.
+    - REQ-2.3: ``ip_subnet`` is the /24 network address.
+    - REQ-5: no lockout / redis-unavailable events are emitted on the
+      happy path.
+    """
+    # -- Step 1: POST /api/auth/login --------------------------------------
+    body = LoginRequest(
+        email="alice@acme.com", password="correct horse", auth_request_id="ar-happy-1"
+    )
+    response = MagicMock(spec=Response)
+    db = AsyncMock(spec=AsyncSession)
+
+    request = make_request(
+        headers={
+            "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+            "x-forwarded-for": "203.0.113.42",
+        }
+    )
+
+    with (
+        capture_logs() as captured,
+        patch("app.api.auth.zitadel") as mock_zitadel,
+        patch("app.api.auth.audit") as mock_audit,
+        patch("app.api.auth.emit_event"),
+        patch("app.api.auth._resolve_and_enforce_mfa", AsyncMock(return_value=None)),
+    ):
+        mock_zitadel.find_user_by_email = AsyncMock(return_value=("uid-happy", "zorg-happy"))
+        mock_zitadel.has_totp = AsyncMock(return_value=True)
+        mock_zitadel.create_session_with_password = AsyncMock(return_value=_session_ok())
+        mock_audit.log_event = AsyncMock()
+
+        login_result = await login(body=body, response=response, request=request, db=db)
+
+    assert login_result.status == "totp_required"
+    assert login_result.temp_token  # urlsafe-base64, non-empty
+    temp_token = login_result.temp_token
+
+    # -- Redis state after step 1 -----------------------------------------
+    state_key = f"{_TOTP_PENDING_KEY_PREFIX}{temp_token}"
+    counter_key = f"{_TOTP_PENDING_FAILURES_PREFIX}{temp_token}"
+
+    state = await fake_redis.hgetall(state_key)
+    assert state["session_id"] == "sess-happy"
+    assert state["session_token"] == "tok-happy"
+    # SHA-256 hex of the UA → 64 hex chars; non-empty proves hash_metadata ran.
+    assert len(state["ua_hash"]) == 64
+    # /24 network address for 203.0.113.42 is 203.0.113.0
+    assert state["ip_subnet"] == "203.0.113.0"
+
+    counter = await fake_redis.get(counter_key)
+    assert counter == "0", f"failure counter must start at 0, got {counter!r}"
+
+    # -- Step 2: POST /api/auth/totp-login --------------------------------
+    totp_body = TOTPLoginRequest(
+        temp_token=temp_token, code="123456", auth_request_id="ar-happy-1"
+    )
+
+    with (
+        capture_logs() as captured_totp,
+        patch("app.api.auth.zitadel") as mock_zitadel,
+        patch("app.api.auth.audit") as mock_audit,
+        patch("app.api.auth._finalize_and_set_cookie") as mock_finalize,
+    ):
+        mock_zitadel.update_session_with_totp = AsyncMock(
+            return_value={"sessionId": "sess-happy", "sessionToken": "tok-happy-renewed"}
+        )
+        mock_audit.log_event = AsyncMock()
+        # Bypass the cookie-set + auth-finalize round trip; this test asserts
+        # the pending-state lifecycle, not the SSO cookie shape (covered by
+        # the dedicated SSO tests).
+        mock_finalize.return_value = MagicMock(status="success")
+
+        totp_result = await totp_login(body=totp_body, response=Response(), db=db)
+
+    assert totp_result is not None
+
+    # -- Redis state after step 2 — both keys gone (REQ-1.6) -------------
+    assert await fake_redis.exists(state_key) == 0
+    assert await fake_redis.exists(counter_key) == 0
+
+    # -- No noise on the happy path (REQ-5) ------------------------------
+    happy_path_events = {e.get("event") for e in captured + captured_totp}
+    assert "totp_pending_lockout" not in happy_path_events
+    assert "totp_pending_redis_unavailable" not in happy_path_events

--- a/klai-portal/backend/tests/test_auth_mfa_fail_closed.py
+++ b/klai-portal/backend/tests/test_auth_mfa_fail_closed.py
@@ -20,6 +20,7 @@ import httpx
 import pytest
 import respx
 from fastapi import HTTPException
+from helpers import make_request
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog.testing import capture_logs
 
@@ -144,7 +145,7 @@ async def test_required_has_any_mfa_500_returns_503(respx_zitadel: respx.MockRou
 
     with capture_logs() as captured, audit_patch, emit_patch:
         with pytest.raises(HTTPException) as exc:
-            await login(body=_make_login_body(), response=response, db=db)
+            await login(body=_make_login_body(), response=response, request=make_request(), db=db)
 
     assert exc.value.status_code == 503
     assert exc.value.headers["Retry-After"] == "5"
@@ -177,7 +178,7 @@ async def test_find_user_by_email_500_returns_503(respx_zitadel: respx.MockRoute
 
     with capture_logs() as captured, audit_patch, emit_patch:
         with pytest.raises(HTTPException) as exc:
-            await login(body=_make_login_body(), response=response, db=db)
+            await login(body=_make_login_body(), response=response, request=make_request(), db=db)
 
     assert exc.value.status_code == 503
     assert exc.value.headers["Retry-After"] == "5"
@@ -220,7 +221,7 @@ async def test_optional_has_any_mfa_500_proceeds_no_event(respx_zitadel: respx.M
     audit_patch, emit_patch = _audit_emit_patches()
 
     with capture_logs() as captured, audit_patch, emit_patch:
-        result = await login(body=_make_login_body(), response=response, db=db)
+        result = await login(body=_make_login_body(), response=response, request=make_request(), db=db)
 
     assert result is not None
     # Under mfa_policy="optional" the `if mfa_policy == "required":` guard
@@ -239,6 +240,7 @@ async def test_optional_has_any_mfa_500_proceeds_no_event(respx_zitadel: respx.M
 @pytest.mark.asyncio
 async def test_happy_path_required_with_totp_enrolled_returns_totp_required(
     respx_zitadel: respx.MockRouter,
+    fake_redis: Any,
 ) -> None:
     respx_zitadel.post("/v2/users").mock(
         return_value=httpx.Response(
@@ -255,7 +257,7 @@ async def test_happy_path_required_with_totp_enrolled_returns_totp_required(
     audit_patch, emit_patch = _audit_emit_patches()
 
     with capture_logs() as captured, audit_patch, emit_patch:
-        result = await login(body=_make_login_body(), response=response, db=db)
+        result = await login(body=_make_login_body(), response=response, request=make_request(), db=db)
 
     assert result.status == "totp_required"
     assert result.temp_token  # non-empty opaque token
@@ -288,7 +290,7 @@ async def test_happy_path_optional_no_mfa_sets_cookie(respx_zitadel: respx.MockR
     audit_patch, emit_patch = _audit_emit_patches()
 
     with capture_logs() as captured, audit_patch, emit_patch:
-        result = await login(body=_make_login_body(), response=response, db=db)
+        result = await login(body=_make_login_body(), response=response, request=make_request(), db=db)
 
     assert result.status == "ok"
     response.set_cookie.assert_called_once()  # session cookie minted by _finalize_and_set_cookie
@@ -316,7 +318,7 @@ async def test_find_user_by_email_no_results_continues_to_password_check(
 
     with capture_logs() as captured, audit_patch, emit_patch:
         with pytest.raises(HTTPException) as exc:
-            await login(body=_make_login_body(), response=response, db=db)
+            await login(body=_make_login_body(), response=response, request=make_request(), db=db)
 
     assert exc.value.status_code == 401
     assert "incorrect" in str(exc.value.detail).lower()
@@ -349,7 +351,7 @@ async def test_portal_user_found_org_fetch_raises_returns_503(respx_zitadel: res
 
     with capture_logs() as captured, audit_patch, emit_patch:
         with pytest.raises(HTTPException) as exc:
-            await login(body=_make_login_body(), response=response, db=db)
+            await login(body=_make_login_body(), response=response, request=make_request(), db=db)
 
     assert exc.value.status_code == 503
     assert exc.value.headers["Retry-After"] == "5"
@@ -390,7 +392,7 @@ async def test_portal_user_lookup_raises_proceeds_documented_fail_open(
     audit_patch, emit_patch = _audit_emit_patches()
 
     with capture_logs() as captured, audit_patch, emit_patch:
-        result = await login(body=_make_login_body(), response=response, db=db)
+        result = await login(body=_make_login_body(), response=response, request=make_request(), db=db)
 
     assert result is not None
     response.set_cookie.assert_called_once()
@@ -429,7 +431,7 @@ async def test_required_has_any_mfa_request_error_returns_503(respx_zitadel: res
 
     with capture_logs() as captured, audit_patch, emit_patch:
         with pytest.raises(HTTPException) as exc:
-            await login(body=_make_login_body(), response=response, db=db)
+            await login(body=_make_login_body(), response=response, request=make_request(), db=db)
 
     assert exc.value.status_code == 503
     assert exc.value.headers["Retry-After"] == "5"
@@ -476,7 +478,7 @@ async def test_portal_user_orphan_org_proceeds_documented_fail_open(
     audit_patch, emit_patch = _audit_emit_patches()
 
     with capture_logs() as captured, audit_patch, emit_patch:
-        result = await login(body=_make_login_body(), response=response, db=db)
+        result = await login(body=_make_login_body(), response=response, request=make_request(), db=db)
 
     # Login succeeds (fail-open) and a session cookie is minted
     assert result is not None
@@ -526,7 +528,7 @@ async def test_required_has_any_mfa_generic_exception_returns_503(respx_zitadel:
         patch.object(zitadel_singleton, "has_any_mfa", AsyncMock(side_effect=RuntimeError("kernel panic"))),
     ):
         with pytest.raises(HTTPException) as exc:
-            await login(body=_make_login_body(), response=response, db=db)
+            await login(body=_make_login_body(), response=response, request=make_request(), db=db)
 
     assert exc.value.status_code == 503
     assert exc.value.headers["Retry-After"] == "5"
@@ -557,7 +559,7 @@ async def test_find_user_by_email_request_error_returns_503(respx_zitadel: respx
 
     with capture_logs() as captured, audit_patch, emit_patch:
         with pytest.raises(HTTPException) as exc:
-            await login(body=_make_login_body(), response=response, db=db)
+            await login(body=_make_login_body(), response=response, request=make_request(), db=db)
 
     assert exc.value.status_code == 503
     assert exc.value.headers["Retry-After"] == "5"
@@ -599,7 +601,7 @@ async def test_recommended_policy_behaves_like_optional(respx_zitadel: respx.Moc
     audit_patch, emit_patch = _audit_emit_patches()
 
     with capture_logs() as captured, audit_patch, emit_patch:
-        result = await login(body=_make_login_body(), response=response, db=db)
+        result = await login(body=_make_login_body(), response=response, request=make_request(), db=db)
 
     assert result.status == "ok"
     response.set_cookie.assert_called_once()

--- a/klai-portal/backend/tests/test_auth_security.py
+++ b/klai-portal/backend/tests/test_auth_security.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 from fastapi import HTTPException
+from helpers import make_request
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -71,7 +72,7 @@ class TestAuthAuditLogging:
 
                 mock_audit.log_event = AsyncMock()
 
-                await login(body=body, response=response, db=db)
+                await login(body=body, response=response, request=make_request(), db=db)
 
             # Verify audit.log_event was called with action="auth.login"
             mock_audit.log_event.assert_called()
@@ -101,7 +102,7 @@ class TestAuthAuditLogging:
             mock_audit.log_event = AsyncMock()
 
             with pytest.raises(Exception) as exc_info:
-                await login(body=body, response=response, db=db)
+                await login(body=body, response=response, request=make_request(), db=db)
 
             assert exc_info.value.status_code == 401  # type: ignore[union-attr]
 
@@ -168,17 +169,16 @@ class TestAuthAuditLogging:
             assert call.kwargs.get("org_id") == 8, "audit must carry real org_id, not sentinel 0"
 
     @pytest.mark.asyncio
-    async def test_totp_login_writes_auth_login_totp(self) -> None:
+    async def test_totp_login_writes_auth_login_totp(self, fake_redis) -> None:
         """After a successful TOTP verification, audit must log action='auth.login.totp'."""
-        from app.api.auth import TOTPLoginRequest, _pending_totp, totp_login
+        from app.api.auth import TOTPLoginRequest, _totp_pending_create, totp_login
 
-        # Pre-populate the TOTP pending cache
-        temp_token = _pending_totp.put(
-            {
-                "session_id": "sess-totp",
-                "session_token": "tok-totp",
-                "failures": 0,
-            }
+        # Pre-populate the Redis-backed TOTP pending state (SPEC-SEC-SESSION-001 REQ-1)
+        temp_token = await _totp_pending_create(
+            session_id="sess-totp",
+            session_token="tok-totp",
+            ua_hash="",
+            ip_subnet="0.0.0.0",  # noqa: S104 — placeholder, not a network bind
         )
         body = TOTPLoginRequest(temp_token=temp_token, code="123456", auth_request_id="ar-totp")
         response = MagicMock()
@@ -212,16 +212,15 @@ class TestAuthAuditLogging:
             assert found, "Expected audit.log_event called with action='auth.login.totp'"
 
     @pytest.mark.asyncio
-    async def test_totp_failed_writes_audit_totp_failed(self) -> None:
+    async def test_totp_failed_writes_audit_totp_failed(self, fake_redis) -> None:
         """When TOTP verification fails (400), audit must log action='auth.totp.failed'."""
-        from app.api.auth import TOTPLoginRequest, _pending_totp, totp_login
+        from app.api.auth import TOTPLoginRequest, _totp_pending_create, totp_login
 
-        temp_token = _pending_totp.put(
-            {
-                "session_id": "sess-totp-2",
-                "session_token": "tok-totp-2",
-                "failures": 0,
-            }
+        temp_token = await _totp_pending_create(
+            session_id="sess-totp-2",
+            session_token="tok-totp-2",
+            ua_hash="",
+            ip_subnet="0.0.0.0",  # noqa: S104 — placeholder, not a network bind
         )
         body = TOTPLoginRequest(temp_token=temp_token, code="000000", auth_request_id="ar-totp-2")
         response = MagicMock()
@@ -282,7 +281,7 @@ class TestAuthAuditLogging:
                 mock_audit.log_event = AsyncMock(side_effect=Exception("audit DB down"))
 
                 # Should not raise -- login must succeed despite audit failure
-                result = await login(body=body, response=response, db=db)
+                result = await login(body=body, response=response, request=make_request(), db=db)
                 assert result is not None
 
 
@@ -325,13 +324,13 @@ class TestMFAPolicyEnforcement:
             mock_audit.log_event = AsyncMock()
 
             with pytest.raises(Exception) as exc_info:
-                await login(body=body, response=response, db=db)
+                await login(body=body, response=response, request=make_request(), db=db)
 
             assert exc_info.value.status_code == 403  # type: ignore[union-attr]
             assert "MFA required" in str(exc_info.value.detail)  # type: ignore[union-attr]
 
     @pytest.mark.asyncio
-    async def test_mfa_required_with_mfa_enrolled_proceeds(self) -> None:
+    async def test_mfa_required_with_mfa_enrolled_proceeds(self, fake_redis) -> None:
         """When org.mfa_policy='required' and user has MFA, login proceeds normally."""
         from app.api.auth import LoginRequest, login
 
@@ -362,7 +361,7 @@ class TestMFAPolicyEnforcement:
 
             # Should NOT raise 403 -- user has MFA enrolled
             # (will return totp_required since has_totp=True)
-            result = await login(body=body, response=response, db=db)
+            result = await login(body=body, response=response, request=make_request(), db=db)
             assert result.status == "totp_required"
 
     @pytest.mark.asyncio
@@ -395,7 +394,7 @@ class TestMFAPolicyEnforcement:
 
             mock_audit.log_event = AsyncMock()
 
-            result = await login(body=body, response=response, db=db)
+            result = await login(body=body, response=response, request=make_request(), db=db)
             # Login should succeed -- no 403
             assert result is not None
             # has_any_mfa should NOT have been called
@@ -435,7 +434,7 @@ class TestMFAPolicyEnforcement:
             mock_audit.log_event = AsyncMock()
 
             # Should NOT raise -- fail-open means login proceeds (provisioning grace)
-            result = await login(body=body, response=response, db=db)
+            result = await login(body=body, response=response, request=make_request(), db=db)
             assert result is not None
 
     # SPEC-SEC-MFA-001 REQ-5.3: ``test_mfa_check_failure_defaults_to_pass`` is

--- a/klai-portal/backend/tests/test_auth_totp_endpoints.py
+++ b/klai-portal/backend/tests/test_auth_totp_endpoints.py
@@ -161,9 +161,7 @@ async def test_totp_confirm_zitadel_5xx(respx_zitadel: respx.MockRouter) -> None
 
 
 @pytest.mark.asyncio
-async def test_totp_login_expired_token(
-    respx_zitadel: respx.MockRouter, fake_redis: Any
-) -> None:
+async def test_totp_login_expired_token(respx_zitadel: respx.MockRouter, fake_redis: Any) -> None:
     """REQ-1.8 — unknown temp_token → 400 + event with reason=expired_token.
 
     The ``fake_redis`` fixture installs a reachable empty Redis. Without
@@ -189,9 +187,7 @@ async def test_totp_login_expired_token(
 
 
 @pytest.mark.asyncio
-async def test_totp_login_already_locked_returns_expired(
-    respx_zitadel: respx.MockRouter, fake_redis: Any
-) -> None:
+async def test_totp_login_already_locked_returns_expired(respx_zitadel: respx.MockRouter, fake_redis: Any) -> None:
     """SPEC-SEC-SESSION-001 supersedes REQ-1.7's immediate-lockout leg.
 
     Pre-Redis behaviour: a token whose in-memory ``failures`` reached MAX
@@ -222,9 +218,7 @@ async def test_totp_login_already_locked_returns_expired(
 
 
 @pytest.mark.asyncio
-async def test_totp_login_invalid_code_first_failure(
-    respx_zitadel: respx.MockRouter, fake_redis: Any
-) -> None:
+async def test_totp_login_invalid_code_first_failure(respx_zitadel: respx.MockRouter, fake_redis: Any) -> None:
     """REQ-1.6 — wrong code (1st failure) → 400 + emit + audit, failures=1."""
     respx_zitadel.route().mock(return_value=httpx.Response(401, json={"error": "bad code"}))
     temp_token = await _put_pending(fake_redis, failures=0)
@@ -250,9 +244,7 @@ async def test_totp_login_invalid_code_first_failure(
 
 
 @pytest.mark.asyncio
-async def test_totp_login_invalid_code_lockout(
-    respx_zitadel: respx.MockRouter, fake_redis: Any
-) -> None:
+async def test_totp_login_invalid_code_lockout(respx_zitadel: respx.MockRouter, fake_redis: Any) -> None:
     """REQ-1.7 — wrong code that pushes failures to MAX → 429 + lockout event."""
     respx_zitadel.route().mock(return_value=httpx.Response(401, json={"error": "bad code"}))
     temp_token = await _put_pending(fake_redis, failures=_TOTP_MAX_FAILURES - 1)
@@ -277,9 +269,7 @@ async def test_totp_login_invalid_code_lockout(
 
 
 @pytest.mark.asyncio
-async def test_totp_login_zitadel_5xx(
-    respx_zitadel: respx.MockRouter, fake_redis: Any
-) -> None:
+async def test_totp_login_zitadel_5xx(respx_zitadel: respx.MockRouter, fake_redis: Any) -> None:
     """REQ-1.8 — zitadel 5xx → 502 + event."""
     respx_zitadel.route().mock(return_value=httpx.Response(502, json={"error": "bad gw"}))
     temp_token = await _put_pending(fake_redis, failures=0)

--- a/klai-portal/backend/tests/test_auth_totp_lockout.py
+++ b/klai-portal/backend/tests/test_auth_totp_lockout.py
@@ -1,0 +1,211 @@
+"""SPEC-SEC-SESSION-001 REQ-1 Redis-backed TOTP regression suite.
+
+Covers acceptance scenarios 1 (cross-replica lockout) and 7 (Redis-down
+fail-closed), plus the REQ-1.8 invariant that the in-memory ``_pending_totp``
+global is gone.
+
+Pre-SPEC, ``_pending_totp = TTLCache(...)`` lived in process memory: each
+portal-api replica had its own ``failures`` counter, so 4 wrongs on replica A
+plus 4 wrongs on replica B locked the token at attempt 8 (or 12, or 16,
+linearly with replica count). The Redis-backed atomic ``INCR`` here makes
+the 5-failure ceiling cross-replica consistent.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from fastapi import HTTPException
+from fastapi.responses import Response
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog.testing import capture_logs
+
+
+def _zitadel_400_error() -> httpx.HTTPStatusError:
+    return httpx.HTTPStatusError(
+        "wrong code",
+        request=httpx.Request("POST", "https://example.invalid/v2/sessions"),
+        response=httpx.Response(400, json={"message": "invalid"}),
+    )
+
+
+# ---------------------------------------------------------------------------
+# REQ-1.4 + REQ-1.5 + REQ-6.1 — cross-replica lockout
+# ---------------------------------------------------------------------------
+
+
+async def test_cross_replica_lockout_at_attempt_5(
+    fake_redis: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """5th wrong TOTP returns 429 regardless of how attempts are distributed
+    across replicas. The Redis-backed atomic counter is the proof.
+    """
+    from app.api.auth import (
+        _TOTP_PENDING_FAILURES_PREFIX,
+        _TOTP_PENDING_KEY_PREFIX,
+        TOTPLoginRequest,
+        _totp_pending_create,
+        totp_login,
+    )
+
+    temp_token = await _totp_pending_create(
+        session_id="sess-abc",
+        session_token="tok-xyz",
+        ua_hash="",
+        ip_subnet="0.0.0.0",  # noqa: S104 — placeholder, not a network bind
+    )
+
+    monkeypatch.setattr(
+        "app.api.auth.zitadel.update_session_with_totp",
+        AsyncMock(side_effect=_zitadel_400_error()),
+    )
+    monkeypatch.setattr("app.api.auth.audit.log_event", AsyncMock())
+
+    body = TOTPLoginRequest(temp_token=temp_token, code="000000", auth_request_id="ar-x")
+    db = AsyncMock(spec=AsyncSession)
+
+    statuses: list[int] = []
+    with capture_logs() as captured:
+        for _ in range(5):
+            try:
+                await totp_login(body=body, response=Response(), db=db)
+            except HTTPException as exc:
+                statuses.append(exc.status_code)
+
+    assert statuses == [400, 400, 400, 400, 429], (
+        f"expected 4 invalid-code rejections then 429 lockout, got {statuses}"
+    )
+
+    # REQ-1.5: both Redis keys deleted after lockout
+    assert await fake_redis.exists(f"{_TOTP_PENDING_KEY_PREFIX}{temp_token}") == 0
+    assert await fake_redis.exists(f"{_TOTP_PENDING_FAILURES_PREFIX}{temp_token}") == 0
+
+    # REQ-5.1 + REQ-6.5 PII guard: lockout event emitted once with token_prefix only
+    lockout = [e for e in captured if e.get("event") == "totp_pending_lockout"]
+    assert len(lockout) == 1, f"expected 1 lockout event, got {lockout!r}"
+    assert lockout[0]["log_level"] == "warning"
+    assert lockout[0]["failures"] == 5
+    assert lockout[0]["token_prefix"] == temp_token[:8]
+    # Token prefix only — no full token, no Zitadel session credentials.
+    assert "session_id" not in lockout[0]
+    assert "session_token" not in lockout[0]
+    assert "temp_token" not in lockout[0]
+
+
+async def test_sixth_attempt_after_lockout_returns_session_expired(
+    fake_redis: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """REQ-1.3 + acceptance scenario 1: a 6th attempt after the lockout
+    returns HTTP 400 ``Session expired`` because the keys are gone.
+    """
+    from app.api.auth import TOTPLoginRequest, _totp_pending_create, totp_login
+
+    temp_token = await _totp_pending_create(
+        session_id="sess-abc",
+        session_token="tok-xyz",
+        ua_hash="",
+        ip_subnet="0.0.0.0",  # noqa: S104 — placeholder, not a network bind
+    )
+    monkeypatch.setattr(
+        "app.api.auth.zitadel.update_session_with_totp",
+        AsyncMock(side_effect=_zitadel_400_error()),
+    )
+    monkeypatch.setattr("app.api.auth.audit.log_event", AsyncMock())
+
+    body = TOTPLoginRequest(temp_token=temp_token, code="000000", auth_request_id="ar-x")
+    db = AsyncMock(spec=AsyncSession)
+
+    # Drive 5 failures → lockout
+    for _ in range(5):
+        try:
+            await totp_login(body=body, response=Response(), db=db)
+        except HTTPException:
+            pass
+
+    # 6th call: keys gone → 400 "Session expired"
+    with pytest.raises(HTTPException) as exc_info:
+        await totp_login(body=body, response=Response(), db=db)
+    assert exc_info.value.status_code == 400
+    assert "Session expired" in exc_info.value.detail
+
+
+# ---------------------------------------------------------------------------
+# REQ-1.7 + REQ-5.3 — fail-closed on Redis unavailability
+# ---------------------------------------------------------------------------
+
+
+async def test_redis_unavailable_fails_closed_when_pool_is_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """REQ-1.7: Redis pool unavailable → HTTP 503, NOT a degraded fall-through.
+
+    Failing open here lifts the brute-force ceiling entirely (the in-memory
+    counter is the bug we're fixing). Different threat model from
+    ``partner_rate_limit.check_rate_limit`` which fails open by design.
+    """
+    from app.api.auth import TOTPLoginRequest, totp_login
+    from app.services import redis_client
+
+    redis_client._pool_holder["pool"] = None
+    monkeypatch.setattr(
+        "app.services.redis_client.get_redis_pool",
+        AsyncMock(return_value=None),
+    )
+
+    body = TOTPLoginRequest(temp_token="any-token", code="000000", auth_request_id="ar-x")
+    db = AsyncMock(spec=AsyncSession)
+
+    with capture_logs() as captured:
+        with pytest.raises(HTTPException) as exc_info:
+            await totp_login(body=body, response=Response(), db=db)
+
+    assert exc_info.value.status_code == 503
+    assert "Authentication unavailable" in exc_info.value.detail
+
+    unavail = [e for e in captured if e.get("event") == "totp_pending_redis_unavailable"]
+    assert len(unavail) >= 1
+    assert any(e.get("log_level") == "error" for e in unavail)
+
+
+async def test_redis_connection_error_during_get_fails_closed(
+    fake_redis: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """REQ-1.7 second case: Redis is configured but raises mid-call → 503."""
+    import redis.exceptions as redis_exc
+
+    from app.api.auth import TOTPLoginRequest, totp_login
+
+    async def _boom(*_args: Any, **_kwargs: Any) -> Any:
+        raise redis_exc.ConnectionError("network down")
+
+    monkeypatch.setattr(fake_redis, "hgetall", _boom)
+
+    body = TOTPLoginRequest(temp_token="any-token", code="000000", auth_request_id="ar-x")
+    db = AsyncMock(spec=AsyncSession)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await totp_login(body=body, response=Response(), db=db)
+
+    assert exc_info.value.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# REQ-1.8 — in-memory global removed
+# ---------------------------------------------------------------------------
+
+
+def test_in_memory_pending_totp_global_removed() -> None:
+    """The pre-SPEC ``_pending_totp`` module global SHALL be gone.
+
+    The ``TTLCache`` class itself MAY remain as a generic utility (REQ-1.8),
+    but the production TOTP path must not route through it.
+    """
+    from app.api import auth
+
+    assert not hasattr(auth, "_pending_totp"), (
+        "Pre-SPEC `_pending_totp` global must be removed (REQ-1.8). "
+        "Use the Redis-backed `_totp_pending_*` helpers instead."
+    )

--- a/klai-portal/backend/tests/test_auth_totp_lockout.py
+++ b/klai-portal/backend/tests/test_auth_totp_lockout.py
@@ -37,9 +37,7 @@ def _zitadel_400_error() -> httpx.HTTPStatusError:
 # ---------------------------------------------------------------------------
 
 
-async def test_cross_replica_lockout_at_attempt_5(
-    fake_redis: Any, monkeypatch: pytest.MonkeyPatch
-) -> None:
+async def test_cross_replica_lockout_at_attempt_5(fake_redis: Any, monkeypatch: pytest.MonkeyPatch) -> None:
     """5th wrong TOTP returns 429 regardless of how attempts are distributed
     across replicas. The Redis-backed atomic counter is the proof.
     """
@@ -75,9 +73,7 @@ async def test_cross_replica_lockout_at_attempt_5(
             except HTTPException as exc:
                 statuses.append(exc.status_code)
 
-    assert statuses == [400, 400, 400, 400, 429], (
-        f"expected 4 invalid-code rejections then 429 lockout, got {statuses}"
-    )
+    assert statuses == [400, 400, 400, 400, 429], f"expected 4 invalid-code rejections then 429 lockout, got {statuses}"
 
     # REQ-1.5: both Redis keys deleted after lockout
     assert await fake_redis.exists(f"{_TOTP_PENDING_KEY_PREFIX}{temp_token}") == 0
@@ -170,9 +166,7 @@ async def test_redis_unavailable_fails_closed_when_pool_is_none(
     assert any(e.get("log_level") == "error" for e in unavail)
 
 
-async def test_redis_connection_error_during_get_fails_closed(
-    fake_redis: Any, monkeypatch: pytest.MonkeyPatch
-) -> None:
+async def test_redis_connection_error_during_get_fails_closed(fake_redis: Any, monkeypatch: pytest.MonkeyPatch) -> None:
     """REQ-1.7 second case: Redis is configured but raises mid-call → 503."""
     import redis.exceptions as redis_exc
 

--- a/klai-portal/backend/tests/test_idp_pending_binding.py
+++ b/klai-portal/backend/tests/test_idp_pending_binding.py
@@ -1,0 +1,220 @@
+"""SPEC-SEC-SESSION-001 REQ-2 IDP-pending cookie binding regression suite.
+
+Covers acceptance scenarios 2 (UA mismatch → 403) and 4 (mobile-carrier
+``/24`` + IPv6 ``/48`` boundaries pass), plus REQ-2.2 / REQ-2.4 edge cases:
+empty UA header tolerated, log records carry only short prefixes, original
+user keeps their cookie when an attacker replay attempt is rejected.
+
+Tests target the ``_verify_idp_pending_binding`` helper directly. The
+helper is the single point that owns the binding policy — keeping the test
+suite away from the surrounding social-signup mocking machinery.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+from helpers import make_request
+from structlog.testing import capture_logs
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _payload(*, ua_hash: str, ip_subnet: str) -> dict[str, Any]:
+    """Mimic the decrypted ``klai_idp_pending`` payload shape."""
+    return {
+        "session_id": "sess-bind",
+        "session_token": "tok-bind",
+        "zitadel_user_id": "z-user-bind",
+        "ua_hash": ua_hash,
+        "ip_subnet": ip_subnet,
+    }
+
+
+_UA_FIREFOX = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Firefox/127"
+_UA_CURL = "curl/8.5.0"
+# SHA-256 hex of _UA_FIREFOX, computed once via hashlib in fixture-construction:
+_UA_FIREFOX_HASH = (
+    "f99c75bcd0f4dfd5d9b50bcaf6e83bff7d8b8d9a1cb23eb53f9e4ba4ac1e0fd2"  # placeholder, real value computed at runtime
+)
+
+
+@pytest.fixture
+def helper():
+    """Resolve the binding helper lazily so the import error stays
+    inside the test (clearer failure on RED)."""
+    from app.api.signup import _verify_idp_pending_binding
+
+    return _verify_idp_pending_binding
+
+
+# ---------------------------------------------------------------------------
+# REQ-2.2 + REQ-6.2 — UA mismatch rejected
+# ---------------------------------------------------------------------------
+
+
+def test_binding_rejects_different_ua(helper) -> None:
+    """Acceptance scenario 2: stolen cookie replayed from a different UA → 403."""
+    from app.services.bff_session import SessionService
+
+    stored_ua_hash = SessionService.hash_metadata(_UA_FIREFOX)
+    payload = _payload(ua_hash=stored_ua_hash, ip_subnet="203.0.113.0")
+
+    # Same IP, different UA
+    request = make_request(
+        headers={"user-agent": _UA_CURL, "x-forwarded-for": "203.0.113.10"},
+    )
+
+    with capture_logs() as captured:
+        with pytest.raises(HTTPException) as exc:
+            helper(payload, request)
+
+    assert exc.value.status_code == 403
+    assert "binding" in exc.value.detail.lower()
+
+    # REQ-5.2: structured event with prefix fields, no raw UA / IP
+    events = [e for e in captured if e.get("event") == "idp_pending_binding_mismatch"]
+    assert len(events) == 1
+    event = events[0]
+    assert event["log_level"] == "warning"
+    # Prefix only — never the full hex
+    assert len(event["stored_ua_hash_prefix"]) == 8
+    assert len(event["current_ua_hash_prefix"]) == 8
+    assert event["stored_ua_hash_prefix"] != event["current_ua_hash_prefix"]
+    # Subnets match here (only UA differs); event should reflect that
+    assert event["stored_ip_subnet"] == event["current_ip_subnet"] == "203.0.113.0"
+    # PII guard
+    assert "user_agent" not in event
+    assert _UA_FIREFOX not in str(event)
+    assert _UA_CURL not in str(event)
+    assert "203.0.113.10" not in str(event)
+    assert "session_id" not in event
+
+
+# ---------------------------------------------------------------------------
+# REQ-2.3 — IP /24 mismatch rejected
+# ---------------------------------------------------------------------------
+
+
+def test_binding_rejects_different_ipv4_subnet(helper) -> None:
+    """Cookie issued from /24 ``198.51.100.0`` cannot be replayed from
+    a different /24."""
+    from app.services.bff_session import SessionService
+
+    stored_ua_hash = SessionService.hash_metadata(_UA_FIREFOX)
+    payload = _payload(ua_hash=stored_ua_hash, ip_subnet="198.51.100.0")
+
+    # Same UA, but the new caller IP is in a totally different /24
+    request = make_request(
+        headers={"user-agent": _UA_FIREFOX, "x-forwarded-for": "203.0.113.42"},
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        helper(payload, request)
+
+    assert exc.value.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# REQ-2.3 + REQ-6.3 — same /24 passes (mobile-carrier UX)
+# ---------------------------------------------------------------------------
+
+
+def test_binding_passes_same_subnet_different_last_octet(helper) -> None:
+    """Acceptance scenario 4: a mobile user moving from ``198.51.100.10``
+    to ``198.51.100.214`` (same /24) keeps signing up successfully.
+    """
+    from app.services.bff_session import SessionService
+
+    stored_ua_hash = SessionService.hash_metadata(_UA_FIREFOX)
+    payload = _payload(ua_hash=stored_ua_hash, ip_subnet="198.51.100.0")
+
+    request = make_request(
+        headers={"user-agent": _UA_FIREFOX, "x-forwarded-for": "198.51.100.214"},
+    )
+
+    # Returns None on success — no exception raised
+    helper(payload, request)
+
+
+def test_binding_passes_ipv6_in_same_48(helper) -> None:
+    """IPv6 companion — issue from ``2001:db8:1234:5678::1`` and consume
+    from ``2001:db8:1234:5678:89ab::42`` should both resolve to the same
+    ``/48`` and pass.
+    """
+    from app.services.bff_session import SessionService
+
+    stored_ua_hash = SessionService.hash_metadata(_UA_FIREFOX)
+    payload = _payload(ua_hash=stored_ua_hash, ip_subnet="2001:db8:1234::")
+
+    request = make_request(
+        headers={
+            "user-agent": _UA_FIREFOX,
+            "x-forwarded-for": "2001:db8:1234:5678:89ab::42",
+        },
+    )
+
+    helper(payload, request)
+
+
+# ---------------------------------------------------------------------------
+# REQ-2.4 — empty UA header tolerated
+# ---------------------------------------------------------------------------
+
+
+def test_binding_handles_missing_ua_header(helper) -> None:
+    """REQ-2.4: a cookie issued with an empty UA matches another empty-UA
+    consume request. The hash function is run on ``""`` deterministically.
+    """
+    from app.services.bff_session import SessionService
+
+    empty_ua_hash = SessionService.hash_metadata(None)
+    payload = _payload(ua_hash=empty_ua_hash, ip_subnet="203.0.113.0")
+
+    # No User-Agent header at all
+    request = make_request(headers={"x-forwarded-for": "203.0.113.99"})
+
+    helper(payload, request)
+
+
+def test_binding_rejects_when_ua_appears_after_being_absent(helper) -> None:
+    """A cookie issued with no UA cannot be consumed by a request that
+    suddenly has one."""
+    from app.services.bff_session import SessionService
+
+    empty_ua_hash = SessionService.hash_metadata(None)
+    payload = _payload(ua_hash=empty_ua_hash, ip_subnet="203.0.113.0")
+
+    request = make_request(
+        headers={"user-agent": _UA_FIREFOX, "x-forwarded-for": "203.0.113.99"},
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        helper(payload, request)
+    assert exc.value.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Defence — payload without binding fields rejected
+# ---------------------------------------------------------------------------
+
+
+def test_binding_rejects_payload_without_binding_fields(helper) -> None:
+    """A cookie without ``ua_hash`` / ``ip_subnet`` is either pre-deploy
+    legacy or tampered — either way, refuse it."""
+    payload = {
+        "session_id": "sess-bind",
+        "session_token": "tok-bind",
+        "zitadel_user_id": "z-user-bind",
+    }
+    request = make_request(
+        headers={"user-agent": _UA_FIREFOX, "x-forwarded-for": "203.0.113.10"},
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        helper(payload, request)
+    assert exc.value.status_code == 403

--- a/klai-portal/backend/tests/test_session_logging_pii.py
+++ b/klai-portal/backend/tests/test_session_logging_pii.py
@@ -1,0 +1,173 @@
+"""SPEC-SEC-SESSION-001 acceptance scenario 8 — REQ-2.2, REQ-5.1, REQ-5.2.
+
+A consolidated PII guard for the structured events the SPEC adds:
+
+- ``totp_pending_lockout`` (REQ-5.1)
+- ``idp_pending_binding_mismatch`` (REQ-5.2)
+
+The other two events (``totp_pending_redis_unavailable``, REQ-5.3 and
+``sso_cookie_key_missing_startup_abort``, REQ-5.4) are exercised by their
+own regression files (``test_auth_totp_lockout`` and
+``test_startup_sso_key_guard``).
+
+This module is the single place that fails loud if a future change adds
+raw User-Agent strings, raw caller IPs, the full opaque token, or Zitadel
+session credentials to any of these events.
+
+Implementation note: tests intercept the structlog emit by patching the
+module-level ``_slog`` proxy with a ``MagicMock``, then inspect the
+``call_args``. ``structlog.testing.capture_logs`` is unreliable in the
+full suite because an unrelated test (the CORS allowlist suite) calls
+``structlog.reset_defaults()`` mid-run; the cached lazy-proxy in
+``app.api.auth`` then keeps emitting through the ``setup_logging``
+processors instead of the temporary ``LogCapture`` chain. Patching
+the proxy bypasses the cache entirely and keeps the assertion stable.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from fastapi import HTTPException
+from fastapi.responses import Response
+from helpers import make_request
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# Sentinels we explicitly assert never appear in any captured event kwargs.
+_UA_FIREFOX = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Firefox/127"
+_UA_CURL = "curl/8.5.0"
+_RAW_IPV4 = "203.0.113.42"
+_RAW_IPV4_REPLAY = "198.51.100.7"
+_SESSION_ID = "sess-pii-guard-9999"
+_SESSION_TOKEN = "tok-pii-guard-zzzz"  # nosec — test placeholder
+
+
+def _zitadel_400_error() -> httpx.HTTPStatusError:
+    return httpx.HTTPStatusError(
+        "wrong code",
+        request=httpx.Request("POST", "https://example.invalid/v2/sessions"),
+        response=httpx.Response(400, json={"message": "invalid"}),
+    )
+
+
+def _assert_no_pii(kwargs: dict[str, Any]) -> None:
+    """Reject any structured-log kwarg that leaks UA, raw IP, session ids,
+    or the full opaque token."""
+    forbidden_substrings = [
+        _UA_FIREFOX,
+        _UA_CURL,
+        _RAW_IPV4,
+        _RAW_IPV4_REPLAY,
+        _SESSION_ID,
+        _SESSION_TOKEN,
+    ]
+    serialized = json.dumps(kwargs, default=repr)
+    for needle in forbidden_substrings:
+        assert needle not in serialized, (
+            f"PII leak: {needle!r} appeared in event kwargs:\n{serialized}"
+        )
+    forbidden_keys = {"user_agent", "raw_ip", "client_ip", "session_id", "session_token"}
+    leaked = forbidden_keys & set(kwargs.keys())
+    assert not leaked, f"PII leak via kwarg(s) {leaked!r} in event {kwargs!r}"
+
+
+# ---------------------------------------------------------------------------
+# REQ-5.1 — totp_pending_lockout has no raw token / session ids
+# ---------------------------------------------------------------------------
+
+
+async def test_no_pii_in_totp_lockout_logs(
+    fake_redis: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Drive a token to the 5-failure lockout and inspect the structlog
+    kwargs the production code passed to ``_slog.warning``."""
+    from app.api.auth import TOTPLoginRequest, _totp_pending_create, totp_login
+
+    temp_token = await _totp_pending_create(
+        session_id=_SESSION_ID,
+        session_token=_SESSION_TOKEN,
+        ua_hash="",
+        ip_subnet="0.0.0.0",  # noqa: S104 — placeholder, not a network bind
+    )
+    monkeypatch.setattr(
+        "app.api.auth.zitadel.update_session_with_totp",
+        AsyncMock(side_effect=_zitadel_400_error()),
+    )
+    monkeypatch.setattr("app.api.auth.audit.log_event", AsyncMock())
+
+    mock_slog = MagicMock()
+    monkeypatch.setattr("app.api.auth._slog", mock_slog)
+
+    body = TOTPLoginRequest(temp_token=temp_token, code="000000", auth_request_id="ar-pii")
+    db = AsyncMock(spec=AsyncSession)
+
+    for _ in range(5):
+        try:
+            await totp_login(body=body, response=Response(), db=db)
+        except HTTPException:
+            pass
+
+    # Find the lockout call (others may exist for other unrelated emits)
+    lockout_calls = [
+        call for call in mock_slog.warning.call_args_list
+        if call.args and call.args[0] == "totp_pending_lockout"
+    ]
+    assert len(lockout_calls) == 1, (
+        f"expected 1 totp_pending_lockout emit, got {mock_slog.warning.call_args_list}"
+    )
+
+    kwargs = lockout_calls[0].kwargs
+    assert kwargs["failures"] == 5
+    # Token prefix only — never the full opaque token. The token is the
+    # longest-lived in-memory secret in the TOTP flow.
+    assert kwargs["token_prefix"] == temp_token[:8]
+    assert temp_token not in json.dumps(kwargs, default=repr)
+
+    _assert_no_pii(kwargs)
+
+
+# ---------------------------------------------------------------------------
+# REQ-5.2 — idp_pending_binding_mismatch carries prefixes only
+# ---------------------------------------------------------------------------
+
+
+def test_no_pii_in_binding_mismatch_logs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Inspect the binding event captured when a stolen-cookie replay
+    arrives from a different UA + a different IP /24."""
+    from app.api.signup import _verify_idp_pending_binding
+    from app.services.bff_session import SessionService
+
+    mock_slog = MagicMock()
+    monkeypatch.setattr("app.api.signup._slog", mock_slog)
+
+    payload = {
+        "session_id": _SESSION_ID,
+        "session_token": _SESSION_TOKEN,
+        "zitadel_user_id": "z-user-pii",
+        "ua_hash": SessionService.hash_metadata(_UA_FIREFOX),
+        "ip_subnet": "203.0.113.0",
+    }
+    request = make_request(
+        headers={"user-agent": _UA_CURL, "x-forwarded-for": _RAW_IPV4_REPLAY},
+    )
+
+    with pytest.raises(HTTPException):
+        _verify_idp_pending_binding(payload, request)
+
+    mismatch_calls = [
+        call for call in mock_slog.warning.call_args_list
+        if call.args and call.args[0] == "idp_pending_binding_mismatch"
+    ]
+    assert len(mismatch_calls) == 1
+    kwargs = mismatch_calls[0].kwargs
+    # Prefixes are 8 chars of hex; never the full hash (correlatable with
+    # the cookie value otherwise).
+    assert len(kwargs["stored_ua_hash_prefix"]) == 8
+    assert len(kwargs["current_ua_hash_prefix"]) == 8
+    assert kwargs["stored_ua_hash_prefix"] != kwargs["current_ua_hash_prefix"]
+
+    _assert_no_pii(kwargs)

--- a/klai-portal/backend/tests/test_session_logging_pii.py
+++ b/klai-portal/backend/tests/test_session_logging_pii.py
@@ -67,9 +67,7 @@ def _assert_no_pii(kwargs: dict[str, Any]) -> None:
     ]
     serialized = json.dumps(kwargs, default=repr)
     for needle in forbidden_substrings:
-        assert needle not in serialized, (
-            f"PII leak: {needle!r} appeared in event kwargs:\n{serialized}"
-        )
+        assert needle not in serialized, f"PII leak: {needle!r} appeared in event kwargs:\n{serialized}"
     forbidden_keys = {"user_agent", "raw_ip", "client_ip", "session_id", "session_token"}
     leaked = forbidden_keys & set(kwargs.keys())
     assert not leaked, f"PII leak via kwarg(s) {leaked!r} in event {kwargs!r}"
@@ -80,9 +78,7 @@ def _assert_no_pii(kwargs: dict[str, Any]) -> None:
 # ---------------------------------------------------------------------------
 
 
-async def test_no_pii_in_totp_lockout_logs(
-    fake_redis: Any, monkeypatch: pytest.MonkeyPatch
-) -> None:
+async def test_no_pii_in_totp_lockout_logs(fake_redis: Any, monkeypatch: pytest.MonkeyPatch) -> None:
     """Drive a token to the 5-failure lockout and inspect the structlog
     kwargs the production code passed to ``_slog.warning``."""
     from app.api.auth import TOTPLoginRequest, _totp_pending_create, totp_login
@@ -113,12 +109,9 @@ async def test_no_pii_in_totp_lockout_logs(
 
     # Find the lockout call (others may exist for other unrelated emits)
     lockout_calls = [
-        call for call in mock_slog.warning.call_args_list
-        if call.args and call.args[0] == "totp_pending_lockout"
+        call for call in mock_slog.warning.call_args_list if call.args and call.args[0] == "totp_pending_lockout"
     ]
-    assert len(lockout_calls) == 1, (
-        f"expected 1 totp_pending_lockout emit, got {mock_slog.warning.call_args_list}"
-    )
+    assert len(lockout_calls) == 1, f"expected 1 totp_pending_lockout emit, got {mock_slog.warning.call_args_list}"
 
     kwargs = lockout_calls[0].kwargs
     assert kwargs["failures"] == 5
@@ -159,7 +152,8 @@ def test_no_pii_in_binding_mismatch_logs(monkeypatch: pytest.MonkeyPatch) -> Non
         _verify_idp_pending_binding(payload, request)
 
     mismatch_calls = [
-        call for call in mock_slog.warning.call_args_list
+        call
+        for call in mock_slog.warning.call_args_list
         if call.args and call.args[0] == "idp_pending_binding_mismatch"
     ]
     assert len(mismatch_calls) == 1

--- a/klai-portal/backend/tests/test_social_signup.py
+++ b/klai-portal/backend/tests/test_social_signup.py
@@ -16,6 +16,7 @@ import httpx
 import pytest
 from cryptography.fernet import Fernet
 from fastapi import HTTPException
+from helpers import make_request
 
 # ---------------------------------------------------------------------------
 # Test constants
@@ -42,11 +43,30 @@ def _make_http_error(status_code: int) -> httpx.HTTPStatusError:
     return httpx.HTTPStatusError("err", request=request, response=response)
 
 
-def _encrypt_pending(session_id: str, session_token: str, user_id: str) -> str:
-    """Return a valid Fernet-encrypted klai_idp_pending cookie value."""
+def _encrypt_pending(
+    session_id: str,
+    session_token: str,
+    user_id: str,
+    *,
+    ua_hash: str = "",
+    ip_subnet: str = "127.0.0.0",
+) -> str:
+    """Return a valid Fernet-encrypted klai_idp_pending cookie value.
+
+    SPEC-SEC-SESSION-001 REQ-2.1: payload includes ``ua_hash`` and
+    ``ip_subnet``. Defaults match ``helpers.make_request()`` defaults
+    (no UA header → empty hash; client="127.0.0.1" → "127.0.0.0" /24)
+    so existing happy-path tests keep passing without per-test setup.
+    """
     fernet = Fernet(_FERNET_KEY.encode())
     payload = json.dumps(
-        {"session_id": session_id, "session_token": session_token, "zitadel_user_id": user_id}
+        {
+            "session_id": session_id,
+            "session_token": session_token,
+            "zitadel_user_id": user_id,
+            "ua_hash": ua_hash,
+            "ip_subnet": ip_subnet,
+        }
     ).encode()
     return fernet.encrypt(payload).decode()
 
@@ -243,13 +263,15 @@ class TestIDPSignupCallback:
         with (
             patch("app.api.auth.settings") as mock_settings,
             patch("app.api.auth.zitadel") as mock_zitadel,
-            patch("app.api.auth._fernet") as mock_fernet,
+            patch("app.api.auth._get_sso_fernet") as mock_fernet,
         ):
             _configure_settings_mock(mock_settings)
             _configure_zitadel_mock(mock_zitadel)
-            mock_fernet.encrypt = MagicMock(return_value=b"ENCRYPTED_PENDING")
+            mock_fernet.return_value.encrypt = MagicMock(return_value=b"ENCRYPTED_PENDING")
 
-            response = await idp_signup_callback(id="intent-id", token="intent-token", locale="nl", db=db)
+            response = await idp_signup_callback(
+                id="intent-id", token="intent-token", request=make_request(), locale="nl", db=db
+            )
 
         assert response.status_code == 302
         location = response.headers["location"]
@@ -268,13 +290,15 @@ class TestIDPSignupCallback:
         with (
             patch("app.api.auth.settings") as mock_settings,
             patch("app.api.auth.zitadel") as mock_zitadel,
-            patch("app.api.auth._fernet") as mock_fernet,
+            patch("app.api.auth._get_sso_fernet") as mock_fernet,
         ):
             _configure_settings_mock(mock_settings)
             _configure_zitadel_mock(mock_zitadel)
-            mock_fernet.encrypt = MagicMock(return_value=b"ENCRYPTED_PENDING")
+            mock_fernet.return_value.encrypt = MagicMock(return_value=b"ENCRYPTED_PENDING")
 
-            response = await idp_signup_callback(id="intent-id", token="intent-token", locale="en", db=db)
+            response = await idp_signup_callback(
+                id="intent-id", token="intent-token", request=make_request(), locale="en", db=db
+            )
 
         assert "/en/signup/social" in response.headers["location"]
 
@@ -290,14 +314,16 @@ class TestIDPSignupCallback:
         with (
             patch("app.api.auth.settings") as mock_settings,
             patch("app.api.auth.zitadel") as mock_zitadel,
-            patch("app.api.auth._fernet") as mock_fernet,
+            patch("app.api.auth._get_sso_fernet") as mock_fernet,
             patch("app.api.auth.emit_event") as mock_emit_event,
         ):
             _configure_settings_mock(mock_settings)
             _configure_zitadel_mock(mock_zitadel)
-            mock_fernet.encrypt = MagicMock(return_value=b"ENCRYPTED_SSO")
+            mock_fernet.return_value.encrypt = MagicMock(return_value=b"ENCRYPTED_SSO")
 
-            response = await idp_signup_callback(id="intent-id", token="intent-token", locale="nl", db=db)
+            response = await idp_signup_callback(
+                id="intent-id", token="intent-token", request=make_request(), locale="nl", db=db
+            )
 
         assert response.status_code == 302
         assert response.headers["location"] == f"{_PORTAL_URL}/"
@@ -316,7 +342,7 @@ class TestIDPSignupCallback:
         with (
             patch("app.api.auth.settings") as mock_settings,
             patch("app.api.auth.zitadel") as mock_zitadel,
-            patch("app.api.auth._fernet") as mock_fernet,
+            patch("app.api.auth._get_sso_fernet") as mock_fernet,
         ):
             _configure_settings_mock(mock_settings)
             _configure_zitadel_mock(
@@ -324,9 +350,11 @@ class TestIDPSignupCallback:
                 intent_user_id=None,  # forces create_zitadel_user_from_idp branch
                 create_user_return="new-zitadel-user-999",
             )
-            mock_fernet.encrypt = MagicMock(return_value=b"ENCRYPTED_PENDING")
+            mock_fernet.return_value.encrypt = MagicMock(return_value=b"ENCRYPTED_PENDING")
 
-            response = await idp_signup_callback(id="intent-id", token="intent-token", locale="nl", db=db)
+            response = await idp_signup_callback(
+                id="intent-id", token="intent-token", request=make_request(), locale="nl", db=db
+            )
 
         mock_zitadel.create_zitadel_user_from_idp.assert_awaited_once()
         mock_zitadel.create_session_for_user_idp.assert_awaited()
@@ -349,7 +377,9 @@ class TestIDPSignupCallback:
             _configure_settings_mock(mock_settings)
             _configure_zitadel_mock(mock_zitadel, retrieve_idp_intent_error=_make_http_error(500))
 
-            response = await idp_signup_callback(id="intent-id", token="intent-token", locale="nl", db=db)
+            response = await idp_signup_callback(
+                id="intent-id", token="intent-token", request=make_request(), locale="nl", db=db
+            )
 
         assert response.status_code == 302
         assert "error=idp_failed" in response.headers["location"]
@@ -373,7 +403,9 @@ class TestIDPSignupCallback:
                 create_user_error=_make_http_error(500),
             )
 
-            response = await idp_signup_callback(id="intent-id", token="intent-token", locale="nl", db=db)
+            response = await idp_signup_callback(
+                id="intent-id", token="intent-token", request=make_request(), locale="nl", db=db
+            )
 
         assert response.status_code == 302
         assert "error=idp_failed" in response.headers["location"]
@@ -393,7 +425,9 @@ class TestIDPSignupCallback:
             _configure_settings_mock(mock_settings)
             _configure_zitadel_mock(mock_zitadel, create_session_error=_make_http_error(400))
 
-            response = await idp_signup_callback(id="intent-id", token="intent-token", locale="nl", db=db)
+            response = await idp_signup_callback(
+                id="intent-id", token="intent-token", request=make_request(), locale="nl", db=db
+            )
 
         assert response.status_code == 302
         assert "/nl/signup" in response.headers["location"]
@@ -413,7 +447,7 @@ class TestIDPSignupCallback:
         with (
             patch("app.api.auth.settings") as mock_settings,
             patch("app.api.auth.zitadel") as mock_zitadel,
-            patch("app.api.auth._fernet") as mock_fernet,
+            patch("app.api.auth._get_sso_fernet") as mock_fernet,
             patch("app.api.auth.asyncio.sleep", new_callable=AsyncMock),
         ):
             _configure_settings_mock(mock_settings)
@@ -426,9 +460,11 @@ class TestIDPSignupCallback:
                     session_success,
                 ]
             )
-            mock_fernet.encrypt = MagicMock(return_value=b"ENCRYPTED_PENDING")
+            mock_fernet.return_value.encrypt = MagicMock(return_value=b"ENCRYPTED_PENDING")
 
-            response = await idp_signup_callback(id="intent-id", token="intent-token", locale="nl", db=db)
+            response = await idp_signup_callback(
+                id="intent-id", token="intent-token", request=make_request(), locale="nl", db=db
+            )
 
         assert response.status_code == 302
         assert mock_zitadel.create_session_for_user_idp.await_count == 3
@@ -448,7 +484,9 @@ class TestIDPSignupCallback:
             _configure_settings_mock(mock_settings)
             _configure_zitadel_mock(mock_zitadel, session_return={})  # empty dict, no ids
 
-            response = await idp_signup_callback(id="intent-id", token="intent-token", locale="nl", db=db)
+            response = await idp_signup_callback(
+                id="intent-id", token="intent-token", request=make_request(), locale="nl", db=db
+            )
 
         assert response.status_code == 302
         assert "error=idp_failed" in response.headers["location"]
@@ -468,7 +506,9 @@ class TestIDPSignupCallback:
             _configure_settings_mock(mock_settings)
             _configure_zitadel_mock(mock_zitadel, get_session_error=_make_http_error(500))
 
-            response = await idp_signup_callback(id="intent-id", token="intent-token", locale="nl", db=db)
+            response = await idp_signup_callback(
+                id="intent-id", token="intent-token", request=make_request(), locale="nl", db=db
+            )
 
         assert response.status_code == 302
         assert "error=idp_failed" in response.headers["location"]
@@ -487,7 +527,9 @@ class TestIDPSignupCallback:
             _configure_settings_mock(mock_settings)
             _configure_zitadel_mock(mock_zitadel, session_detail={"session": {"factors": {}}})
 
-            response = await idp_signup_callback(id="intent-id", token="intent-token", locale="nl", db=db)
+            response = await idp_signup_callback(
+                id="intent-id", token="intent-token", request=make_request(), locale="nl", db=db
+            )
 
         assert response.status_code == 302
         assert "error=idp_failed" in response.headers["location"]
@@ -506,7 +548,9 @@ class TestIDPSignupCallback:
             _configure_settings_mock(mock_settings)
             _configure_zitadel_mock(mock_zitadel, retrieve_idp_intent_error=_make_http_error(500))
 
-            response = await idp_signup_callback(id="intent-id", token="intent-token", locale="de", db=db)
+            response = await idp_signup_callback(
+                id="intent-id", token="intent-token", request=make_request(), locale="de", db=db
+            )
 
         # Even when locale="de", failure_url uses "nl"
         assert "/nl/signup" in response.headers["location"]
@@ -572,6 +616,7 @@ class TestSignupSocial:
                 response=response_mock,
                 background_tasks=background_tasks,
                 db=db,
+                request=make_request(),
                 klai_idp_pending=pending_cookie,
             )
 
@@ -595,6 +640,7 @@ class TestSignupSocial:
                 response=response_mock,
                 background_tasks=MagicMock(),
                 db=db,
+                request=make_request(),
                 klai_idp_pending=None,
             )
 
@@ -614,6 +660,7 @@ class TestSignupSocial:
                     response=response_mock,
                     background_tasks=MagicMock(),
                     db=db,
+                    request=make_request(),
                     klai_idp_pending="this-is-not-a-valid-fernet-token",
                 )
 
@@ -640,7 +687,8 @@ class TestSignupSocial:
                     response=self._make_response_mock(),
                     background_tasks=MagicMock(),
                     db=db,
-                    klai_idp_pending=pending_cookie,
+                    request=make_request(),
+                klai_idp_pending=pending_cookie,
                 )
 
         assert exc_info.value.status_code == 409
@@ -666,7 +714,8 @@ class TestSignupSocial:
                     response=self._make_response_mock(),
                     background_tasks=MagicMock(),
                     db=db,
-                    klai_idp_pending=pending_cookie,
+                    request=make_request(),
+                klai_idp_pending=pending_cookie,
                 )
 
         assert exc_info.value.status_code == 502
@@ -693,7 +742,8 @@ class TestSignupSocial:
                     response=self._make_response_mock(),
                     background_tasks=MagicMock(),
                     db=db,
-                    klai_idp_pending=pending_cookie,
+                    request=make_request(),
+                klai_idp_pending=pending_cookie,
                 )
 
         assert exc_info.value.status_code == 502
@@ -732,7 +782,8 @@ class TestSignupSocial:
                     response=self._make_response_mock(),
                     background_tasks=MagicMock(),
                     db=db,
-                    klai_idp_pending=pending_cookie,
+                    request=make_request(),
+                klai_idp_pending=pending_cookie,
                 )
 
         assert exc_info.value.status_code == 502

--- a/klai-portal/backend/tests/test_social_signup.py
+++ b/klai-portal/backend/tests/test_social_signup.py
@@ -688,7 +688,7 @@ class TestSignupSocial:
                     background_tasks=MagicMock(),
                     db=db,
                     request=make_request(),
-                klai_idp_pending=pending_cookie,
+                    klai_idp_pending=pending_cookie,
                 )
 
         assert exc_info.value.status_code == 409
@@ -715,7 +715,7 @@ class TestSignupSocial:
                     background_tasks=MagicMock(),
                     db=db,
                     request=make_request(),
-                klai_idp_pending=pending_cookie,
+                    klai_idp_pending=pending_cookie,
                 )
 
         assert exc_info.value.status_code == 502
@@ -743,7 +743,7 @@ class TestSignupSocial:
                     background_tasks=MagicMock(),
                     db=db,
                     request=make_request(),
-                klai_idp_pending=pending_cookie,
+                    klai_idp_pending=pending_cookie,
                 )
 
         assert exc_info.value.status_code == 502
@@ -783,7 +783,7 @@ class TestSignupSocial:
                     background_tasks=MagicMock(),
                     db=db,
                     request=make_request(),
-                klai_idp_pending=pending_cookie,
+                    klai_idp_pending=pending_cookie,
                 )
 
         assert exc_info.value.status_code == 502

--- a/klai-portal/backend/tests/test_startup_sso_key_guard.py
+++ b/klai-portal/backend/tests/test_startup_sso_key_guard.py
@@ -1,0 +1,181 @@
+"""SPEC-SEC-SESSION-001 REQ-3 + REQ-4 regression suite.
+
+Covers acceptance scenario 3 (REQ-6.4):
+
+- ``_get_sso_fernet()`` raises ``RuntimeError`` mentioning ``SSO_COOKIE_KEY``
+  when the key is empty or whitespace-only.
+- ``_get_sso_fernet()`` returns a cached ``Fernet`` instance on subsequent
+  calls when the key is valid.
+- The startup-validation pattern from ``app.main.lifespan`` aborts in BOTH
+  prod and dev modes (REQ-4.4) — the dev-mode bypass that pre-SPEC code
+  used to allow is closed.
+- Before re-raising, the lifespan emits a ``critical``-level structlog
+  event ``sso_cookie_key_missing_startup_abort`` (REQ-5.4).
+
+Implementation note: the lifespan tests reproduce the exact 4-line
+``try / except / _slog.critical / raise`` pattern that lives in
+``app.main.lifespan`` instead of importing ``app.main`` itself. Importing
+``app.main`` triggers ``setup_logging("portal-api")`` at module-load time,
+which globally reconfigures structlog and breaks
+``tests/test_cors_allowlist.py``'s ``structlog.configure``-based capture.
+The pattern under test is short enough that copying it keeps the assertion
+local to this file without losing coverage of REQ-4.4 or REQ-5.4.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from unittest.mock import MagicMock
+
+import pytest
+from cryptography.fernet import Fernet
+
+from app.api.auth import _get_sso_fernet
+from app.core.config import settings
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_sso_fernet_cache() -> Iterator[None]:
+    """Reset the lru_cache so each test sees the monkeypatched settings value."""
+    _get_sso_fernet.cache_clear()
+    yield
+    _get_sso_fernet.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# _get_sso_fernet — unit tests (REQ-3)
+# ---------------------------------------------------------------------------
+
+
+def test_get_sso_fernet_raises_runtime_error_when_key_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """REQ-3.1: empty SSO_COOKIE_KEY refuses to construct the cipher."""
+    monkeypatch.setattr(settings, "sso_cookie_key", "")
+
+    with pytest.raises(RuntimeError, match="SSO_COOKIE_KEY"):
+        _get_sso_fernet()
+
+
+def test_get_sso_fernet_raises_runtime_error_when_key_whitespace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A whitespace-only key is treated identically to empty (defence in depth)."""
+    monkeypatch.setattr(settings, "sso_cookie_key", "   \t\n  ")
+
+    with pytest.raises(RuntimeError, match="SSO_COOKIE_KEY"):
+        _get_sso_fernet()
+
+
+def test_get_sso_fernet_returns_cached_fernet_with_valid_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """REQ-3.3: subsequent calls return the same cached instance."""
+    valid_key = Fernet.generate_key().decode()
+    monkeypatch.setattr(settings, "sso_cookie_key", valid_key)
+
+    first = _get_sso_fernet()
+    second = _get_sso_fernet()
+
+    assert isinstance(first, Fernet)
+    assert first is second  # lru_cache(maxsize=1) — same id() across calls
+
+
+def test_get_sso_fernet_no_fallback_to_generate_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """REQ-3.2: the ``Fernet.generate_key()`` fallback is removed.
+
+    A misconfigured deployment must NEVER silently issue cookies signed with
+    an ephemeral, per-replica key.
+    """
+    monkeypatch.setattr(settings, "sso_cookie_key", "")
+    sentinel = "should-not-be-called"
+    monkeypatch.setattr(Fernet, "generate_key", lambda: sentinel)  # type: ignore[arg-type]
+
+    with pytest.raises(RuntimeError):
+        _get_sso_fernet()
+
+
+# ---------------------------------------------------------------------------
+# Lifespan-pattern tests (REQ-4)
+# ---------------------------------------------------------------------------
+#
+# These reproduce the literal 4-line ``try / except / _slog.critical / raise``
+# block that lives in ``app.main.lifespan``. Keeping the pattern local to
+# the test file avoids the side effect of importing ``app.main`` (which runs
+# ``setup_logging`` at module load and globally reconfigures structlog).
+# Drift between the production block and these tests is mitigated by the
+# fact that the helper under test (``_get_sso_fernet``) is the same one the
+# production lifespan calls — any mistake in the production wrapper is
+# immediately visible at deploy time as either a missing log event or a
+# silent process abort.
+
+
+def _run_lifespan_sso_check(slog: MagicMock) -> None:
+    """Mirror of ``app.main.lifespan``'s SPEC-SEC-SESSION-001 REQ-4 block.
+
+    Kept literal so a divergence is visible in code review.
+    """
+    try:
+        _get_sso_fernet()
+    except RuntimeError:
+        slog.critical(
+            "sso_cookie_key_missing_startup_abort",
+            env_var="SSO_COOKIE_KEY",
+            sops_path="klai-infra/core-01/.env.sops",
+        )
+        raise
+
+
+def test_lifespan_pattern_aborts_on_empty_sso_cookie_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """REQ-4.1: production startup refuses to continue without a key."""
+    monkeypatch.setattr(settings, "sso_cookie_key", "")
+    slog = MagicMock()
+
+    with pytest.raises(RuntimeError, match="SSO_COOKIE_KEY"):
+        _run_lifespan_sso_check(slog)
+
+
+def test_lifespan_pattern_aborts_in_dev_mode_too(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """REQ-4.4: dev mode SHALL NOT bypass the SSO key check.
+
+    Pre-SPEC code skipped secret validation entirely under
+    ``is_auth_dev_mode``, leaving "works on a single-replica dev box until
+    the first restart" as the silent failure mode. The lifespan check runs
+    BEFORE the dev/prod branch in production, so dev mode hits the same
+    abort. This test asserts that property at the helper level.
+    """
+    monkeypatch.setattr(settings, "sso_cookie_key", "")
+    monkeypatch.setattr(settings, "debug", True)
+    monkeypatch.setattr(settings, "auth_dev_mode", True)
+    monkeypatch.setattr(settings, "auth_dev_user_id", "z-user-test")
+    slog = MagicMock()
+
+    # The helper is mode-agnostic — any caller running the lifespan pattern
+    # aborts on empty key, including dev mode.
+    with pytest.raises(RuntimeError, match="SSO_COOKIE_KEY"):
+        _run_lifespan_sso_check(slog)
+
+
+def test_lifespan_pattern_emits_critical_structlog_event_before_raise(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """REQ-5.4: ``sso_cookie_key_missing_startup_abort`` at level ``critical``
+    fires BEFORE the ``RuntimeError`` propagates so Alloy captures it in
+    VictoriaLogs even though the process is about to exit non-zero.
+    """
+    monkeypatch.setattr(settings, "sso_cookie_key", "")
+    slog = MagicMock()
+
+    with pytest.raises(RuntimeError):
+        _run_lifespan_sso_check(slog)
+
+    slog.critical.assert_called_once()
+    args, kwargs = slog.critical.call_args
+    assert args == ("sso_cookie_key_missing_startup_abort",)
+    # REQ-4.3: error names the env var so the operator knows what to fix.
+    assert kwargs["env_var"] == "SSO_COOKIE_KEY"
+    # SOPS path is the canonical source of truth for the secret — surface
+    # it in the event so on-call doesn't have to guess.
+    assert "sops" in kwargs["sops_path"].lower()

--- a/klai-portal/backend/uv.lock
+++ b/klai-portal/backend/uv.lock
@@ -374,6 +374,19 @@ wheels = [
 ]
 
 [[package]]
+name = "fakeredis"
+version = "2.35.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "redis" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/50/b748233c02fa77e5105238190cc9bb58b852eb1c8b1d0763230d3a5b745a/fakeredis-2.35.1.tar.gz", hash = "sha256:5bae5eba7b9d93cb968944ac40936373cf2397ff71667d4b595df65c3d2e413f", size = 189118 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/27/b8b057a23f7777177e92d3a602fd866751b6b45014964548997e92e048fd/fakeredis-2.35.1-py3-none-any.whl", hash = "sha256:67d97e11f562b7870e11e5c30cf182270bfb2dd37f6707dba47cc6d91628d1b9", size = 129678 },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.136.1"
 source = { registry = "https://pypi.org/simple" }
@@ -689,11 +702,11 @@ dependencies = [
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "structlog" },
     { name = "uvicorn", extra = ["standard"] },
-    { name = "yt-dlp" },
 ]
 
 [package.optional-dependencies]
 dev = [
+    { name = "fakeredis" },
     { name = "httpx" },
     { name = "klai-identity-assert" },
     { name = "pyright" },
@@ -705,6 +718,7 @@ dev = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "fakeredis" },
     { name = "httpx" },
     { name = "klai-identity-assert" },
     { name = "pyright" },
@@ -721,6 +735,7 @@ requires-dist = [
     { name = "authheaders", specifier = ">=0.16,<1.0" },
     { name = "cryptography", specifier = ">=46.0" },
     { name = "docker", specifier = ">=7.1" },
+    { name = "fakeredis", marker = "extra == 'dev'", specifier = ">=2.26" },
     { name = "fastapi", specifier = ">=0.136" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28" },
@@ -745,12 +760,12 @@ requires-dist = [
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.49" },
     { name = "structlog", specifier = ">=25.5" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.44" },
-    { name = "yt-dlp", specifier = ">=2026.3.17" },
 ]
 provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "fakeredis", specifier = ">=2.26" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "klai-identity-assert", editable = "../../klai-libs/identity-assert" },
     { name = "pyright", specifier = ">=1.1.408" },
@@ -1281,6 +1296,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575 },
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.49"
 source = { registry = "https://pypi.org/simple" }
@@ -1525,13 +1549,4 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085 },
     { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531 },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598 },
-]
-
-[[package]]
-name = "yt-dlp"
-version = "2026.3.17"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8b/34/7c6b4e3f89cb6416d2cd7ab6dab141a1df97ab0fb22d15816db2c92148c9/yt_dlp-2026.3.17.tar.gz", hash = "sha256:ba7aa31d533f1ffccfe70e421596d7ca8ff0bf1398dc6bb658b7d9dec057d2c9", size = 3119221 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/13/5093bcb954878e50f7217fd2ab94282b53934022e4e4a03265582da83bf5/yt_dlp-2026.3.17-py3-none-any.whl", hash = "sha256:32992db94303a8a5d211a183f2174834fe7f8c29d83ed2e7a324eae97a8f26d8", size = 3315134 },
 ]


### PR DESCRIPTION
## Summary
- Closes Cornelis 2026-04-22 audit findings #13 (cross-replica TOTP brute-force), #15 (`klai_idp_pending` cookie replay), #16 (empty `SSO_COOKIE_KEY` fall-through).
- Redis-backed TOTP pending state with atomic `INCR`; UA + `/24` (or `/48`) IP-subnet binding on the IDP-pending Fernet cookie; fail-closed `_fernet` init + lifespan guard that aborts startup in BOTH dev and prod modes.
- Caller-IP / subnet resolution extracted to `app/services/request_ip.py` (third callsite trigger: internal + auth + signup).

## Spec
[`.moai/specs/SPEC-SEC-SESSION-001/spec.md`](.moai/specs/SPEC-SEC-SESSION-001/spec.md) — REQs 1–6 + acceptance scenarios 1–8.

## Test plan
- [ ] CI green (ruff + pyright + pytest on portal-api)
- [x] 1205/1205 portal-api tests pass locally — 22 new across `test_auth_totp_lockout`, `test_idp_pending_binding`, `test_startup_sso_key_guard`, `test_auth_login_happy_path`, `test_session_logging_pii`, `test_social_signup`
- [x] Validator-env-parity: `SSO_COOKIE_KEY` already lives in `klai-infra/core-01/.env.sops` + `deploy/docker-compose.yml`; `TOTP_PENDING_TTL_SECONDS` is new but optional (default `300`).
- [ ] After deploy: confirm `sso_cookie_key_missing_startup_abort` appears in VictoriaLogs only on a deliberately-misconfigured staging container (smoke).
- [ ] After deploy: confirm a real password+TOTP login still issues `klai_sso` (production happy-path).

## Notes for reviewers
- `pyright: ignore[reportGeneralTypeIssues]` on two lines (`pool.hset` / `pool.hgetall`) — redis-py async-class inherits sync return types in the bundled stubs; the runtime `await` is correct.
- PII-guard tests patch `_slog` directly instead of using `structlog.testing.capture_logs`. The CORS allowlist suite calls `structlog.reset_defaults()` mid-run, which strands the cached lazy-proxy on the old chain — patching the proxy is order-independent.
- `TTLCache` class kept (REQ-1.8); only the `_pending_totp` global removed.
- The runbook for `SSO_COOKIE_KEY` rotation stays out of scope per the SPEC's §Out of Scope (filed for `klai-infra` runbooks alongside `INTERNAL_SECRET_ROTATION.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)