### PR TITLE
chore(sec,obs): SPEC-SEC-AUTH-COVERAGE-001 follow-through — alerts + runbook + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,81 @@
 # Changelog
 
+## [Unreleased] — 2026-04-28 — SPEC-SEC-AUTH-COVERAGE-001: auth.py coverage + observability hardening (14 endpoints)
+
+Companion to SPEC-SEC-MFA-001. Same Cornelis-audit context (2026-04-22)
+applied to all 14 in-scope auth.py endpoints beyond `login`: every
+documented failure leg now emits a structured event, every state-changing
+success emits an audit log, and 74 new tests verify both.
+
+### Added (security observability)
+
+- **`klai-portal/backend/app/api/auth.py::_emit_auth_event`** — generalized
+  helper for structured auth-event emission. Privacy-safe (sha256 email
+  hashing via `email_hash`), structlog-based, fan_in ≥ 14. Replaces the
+  single-purpose `_emit_mfa_check_failed` (now a thin wrapper for
+  back-compat).
+- **16 structured `*_failed` events** emitted across 14 endpoints —
+  `totp_setup_failed`, `totp_confirm_failed`, `totp_login_failed`,
+  `passkey_setup_failed`, `passkey_confirm_failed`,
+  `email_otp_setup_failed`, `email_otp_confirm_failed`,
+  `email_otp_resend_failed`, `idp_intent_failed`,
+  `idp_intent_signup_failed`, `idp_callback_failed`,
+  `idp_signup_callback_failed`, `password_reset_failed`,
+  `password_set_failed`, `sso_complete_failed`, `verify_email_failed`.
+  Common shape: `{event, reason, outcome, zitadel_status, email_hash, level}`.
+- **`audit.log_event`** on every state-changing success: `auth.totp.setup`,
+  `auth.totp.confirmed`, `auth.totp.login`, `auth.passkey.setup`,
+  `auth.passkey.confirmed`, `auth.email-otp.setup`,
+  `auth.email-otp.confirmed`, `auth.email-otp.resent`, `auth.password.reset`,
+  `auth.password.set`, `auth.login.idp`, `auth.signup.idp`,
+  `auth.sso.completed`, `auth.email.verified`. Closes the audit-trail gap
+  flagged by Cornelis.
+- **`klai-portal/backend/tests/auth_test_helpers.py`** (NEW) — shared
+  fixtures and patches: `respx_zitadel`, `_make_login_body`,
+  `_expected_email_hash`, `_session_ok`, `_make_sso_cookie`, `_make_db_mock`,
+  `_audit_log_patch`, `_capture_events`. Replaces 5 duplicate
+  `_audit_log_patch` definitions across test files (DRY refactor in polish
+  round closed REQ-5.6 regression).
+- **74 new test scenarios** across 7 test files covering all 14 endpoints
+  via `respx`-mocked Zitadel HTTP layer (no `MagicMock` on
+  `app.api.auth.zitadel` per REQ-5.7).
+- **5 `@MX:ANCHOR` tags** on helpers with fan_in ≥ 3:
+  `_emit_auth_event`, `_mfa_unavailable`, `_emit_mfa_check_failed`,
+  `_finalize_and_set_cookie`, `_validate_callback_url`.
+- **`deploy/grafana/provisioning/alerting/portal-auth-rules.yaml`** (NEW) —
+  two LogsQL alerts on the new events:
+  - R1 `auth_failure_rate_high` (warning): > 10 events/5m across the 16
+    endpoint events.
+  - R2 `auth_zitadel_5xx_burst` (critical): > 5 `reason=zitadel_5xx`
+    events/1m (canonical Zitadel-outage signal).
+- **`docs/runbooks/auth-failure-burst.md`** (NEW) — triage runbook for R1
+  and R2: event taxonomy, cross-endpoint spread analysis, brute-force
+  probe detection via `email_hash` distribution, Zitadel-outage handling.
+
+### Changed
+
+- **`logger.*` → `_slog.*` migration** for all 14 in-scope endpoints
+  (REQ-5.3). Remaining 7 stdlib `logger.*` calls in shared helpers
+  (`get_current_user_id`, `_validate_callback_url`, `_decrypt_sso`,
+  `_finalize_and_set_cookie` cookie-set branch) are out-of-scope per the
+  endpoint-only contract.
+- **`klai-portal/backend/tests/conftest.py`** — re-exports `respx_zitadel`
+  fixture for pytest auto-discovery; adds defaults for
+  `ZITADEL_IDP_GOOGLE_ID`, `ZITADEL_IDP_MICROSOFT_ID`,
+  `MONEYBIRD_WEBHOOK_TOKEN`, `VEXA_WEBHOOK_SECRET` so cross-cutting tests
+  pass without a live `.env`.
+- **`klai-portal/backend/pyproject.toml`** — adds `respx>=0.22` to dev
+  dependency-group.
+
+### Coverage
+
+- `app.api.auth` line coverage: **64% → 80%** (+16% delta).
+- REQ-5.5 PARTIAL (target was ≥85%): the remaining 5% gap is in shared
+  helpers (`_finalize_and_set_cookie` error legs, `_validate_callback_url`
+  localhost / untrusted-host branches, `_decrypt_sso` exception path),
+  not in endpoint observability. Every documented failure leg of every
+  in-scope endpoint has a test.
+
 ## [Unreleased] — 2026-04-27 — SPEC-SEC-MFA-001: MFA fail-closed in login flow
 
 Closes SPEC-SEC-AUDIT-2026-04 findings #11 and #12 (Cornelis audit

--- a/deploy/grafana/provisioning/alerting/portal-auth-rules.yaml
+++ b/deploy/grafana/provisioning/alerting/portal-auth-rules.yaml
@@ -1,0 +1,223 @@
+# SPEC-SEC-AUTH-COVERAGE-001 follow-through — portal-api auth endpoint health alerts.
+#
+# Routed via spec=SPEC-SEC-AUTH-COVERAGE-001 -> klai-ops-alerts-email.
+#
+#   R1  auth_failure_rate_high      WARN  >2/min sustained 5m across the 16
+#                                         endpoint *_failed events emitted by
+#                                         _emit_auth_event in app/api/auth.py
+#   R2  auth_zitadel_5xx_burst      CRIT  >5 reason=zitadel_5xx events in any
+#                                         1m window (Zitadel-wide outage)
+#
+# Why two alerts:
+#   - SPEC-SEC-AUTH-COVERAGE-001 emits structured *_failed events on every
+#     documented failure leg of all 14 in-scope auth endpoints (totp/passkey/
+#     email_otp/idp/password/sso_complete/verify_email).  Without alerts the
+#     events are queryable in VictoriaLogs but invisible to anyone not
+#     looking — a Zitadel outage or attacker probe would degrade login UX
+#     silently for minutes before support tickets surface it.
+#   - R1 is the broad-net warning: SOMETHING is wrong somewhere in auth.
+#   - R2 is the targeted critical: it specifically isolates Zitadel-side
+#     5xx, the most common operational failure mode that affects multiple
+#     endpoints simultaneously.
+#
+# mfa_check_failed has its own dedicated rules in portal-mfa-rules.yaml
+# (SPEC-SEC-MFA-001) and is intentionally NOT included here — it has
+# different thresholds and a different runbook.
+#
+# Pitfall avoidance (matches portal-mfa-rules.yaml conventions):
+#   - Always go through `reduce` between LogsQL output and SSE math.
+#   - execErrState: OK — VictoriaLogs plugin sometimes trips "long vs wide"
+#     errors on stats reduce chains; miss-on-hiccup beats false-page.
+#   - LogsQL `field:in(a,b,c)` selector keeps the query short and
+#     maintainable when adding new endpoints.
+
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: sec-auth-coverage-001-portal-api
+    folder: Klai
+    interval: 1m
+    rules:
+
+      # ── R1: auth_failure_rate_high ──────────────────────────────────────
+      # Broad warning: sustained burst of any auth endpoint *_failed event.
+      # Threshold: > 10 events in a 5-minute window (≈ > 2/min sustained).
+      # Triage starts by grouping by event + reason to identify the failing
+      # endpoint and root cause.
+      - uid: sec-auth-coverage-001-auth-failure-rate-high
+        title: auth_failure_rate_high
+        condition: threshold
+        data:
+          - refId: query
+            datasourceUid: victorialogs
+            queryType: instant
+            relativeTimeRange:
+              from: 300
+              to: 0
+            model:
+              refId: query
+              datasource:
+                type: victoriametrics-logs-datasource
+                uid: victorialogs
+              expr: |
+                _time:5m service:portal-api event:in(
+                  totp_setup_failed,totp_confirm_failed,totp_login_failed,
+                  passkey_setup_failed,passkey_confirm_failed,
+                  email_otp_setup_failed,email_otp_confirm_failed,email_otp_resend_failed,
+                  idp_intent_failed,idp_intent_signup_failed,
+                  idp_callback_failed,idp_signup_callback_failed,
+                  password_reset_failed,password_set_failed,
+                  sso_complete_failed,verify_email_failed
+                ) | stats count() as n
+              queryType: instant
+          - refId: reduce
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 300
+              to: 0
+            model:
+              refId: reduce
+              type: reduce
+              reducer: last
+              expression: query
+          - refId: threshold
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 300
+              to: 0
+            model:
+              refId: threshold
+              type: threshold
+              expression: reduce
+              conditions:
+                - evaluator: { params: [10], type: gt }
+                  operator: { type: and }
+                  reducer: { params: [], type: last }
+                  type: query
+        noDataState: OK
+        execErrState: OK
+        for: 5m
+        keepFiringFor: 10m
+        isPaused: false
+        labels:
+          severity: warning
+          spec: SPEC-SEC-AUTH-COVERAGE-001
+          service_group: portal-api
+        annotations:
+          summary: 'portal-api auth endpoint failures > 2/min sustained for 5m'
+          runbook_url: 'docs/runbooks/auth-failure-burst.md'
+          description: |
+            More than 10 auth endpoint ``*_failed`` events were emitted by
+            portal-api in the last 5 minutes (≈ > 2/min sustained). This
+            covers the 16 SPEC-SEC-AUTH-COVERAGE-001 events (totp / passkey
+            / email_otp / idp / password / sso_complete / verify_email).
+            Each event corresponds to a real user hitting a failure on an
+            authentication-flow endpoint — bursts indicate either Zitadel
+            degradation or a regression on a specific endpoint.
+
+            Triage:
+              1. VictoriaLogs query in Grafana → Explore:
+                   _time:5m service:portal-api event:in(totp_setup_failed,...)
+                     | stats by (event, reason, outcome) count()
+                 Identify which (event, reason) pair dominates.
+              2. If multiple events spike together with reason=zitadel_5xx
+                 → check R2 (auth_zitadel_5xx_burst), which is the targeted
+                 alert for this case. Triage R2 first.
+              3. If a single event dominates with reason ≠ zitadel_5xx →
+                 likely a regression on that endpoint specifically. Check
+                 recent merges touching app/api/auth.py for the affected
+                 endpoint.
+              4. Confirm user impact via outcome= field: 4xx outcomes are
+                 client-side errors (often expected — wrong code, wrong
+                 password); 5xx outcomes are real outages.
+
+      # ── R2: auth_zitadel_5xx_burst ───────────────────────────────────────
+      # Targeted critical: a burst of reason=zitadel_5xx events across multiple
+      # endpoints simultaneously is the canonical Zitadel-outage signal. Per-
+      # endpoint thresholds would miss this (each endpoint at 1-2 events/min
+      # is normal); the cross-endpoint burst is what makes it operationally
+      # significant.
+      # Threshold: > 5 events in any 1m window.
+      - uid: sec-auth-coverage-001-auth-zitadel-5xx-burst
+        title: auth_zitadel_5xx_burst
+        condition: threshold
+        data:
+          - refId: query
+            datasourceUid: victorialogs
+            queryType: instant
+            relativeTimeRange:
+              from: 60
+              to: 0
+            model:
+              refId: query
+              datasource:
+                type: victoriametrics-logs-datasource
+                uid: victorialogs
+              expr: '_time:1m service:portal-api reason:zitadel_5xx | stats count() as n'
+              queryType: instant
+          - refId: reduce
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 60
+              to: 0
+            model:
+              refId: reduce
+              type: reduce
+              reducer: last
+              expression: query
+          - refId: threshold
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 60
+              to: 0
+            model:
+              refId: threshold
+              type: threshold
+              expression: reduce
+              conditions:
+                - evaluator: { params: [5], type: gt }
+                  operator: { type: and }
+                  reducer: { params: [], type: last }
+                  type: query
+        noDataState: OK
+        execErrState: OK
+        for: 1m
+        keepFiringFor: 5m
+        isPaused: false
+        labels:
+          severity: critical
+          spec: SPEC-SEC-AUTH-COVERAGE-001
+          service_group: portal-api
+        annotations:
+          summary: 'portal-api Zitadel 5xx burst across auth endpoints > 5/min'
+          runbook_url: 'docs/runbooks/auth-failure-burst.md#triage-zitadel-5xx-burst'
+          description: |
+            More than 5 portal-api auth events with ``reason=zitadel_5xx``
+            fired in the last minute. This is the canonical Zitadel-outage
+            signal: a single endpoint degrading 5xx is normal noise, but
+            multiple endpoints simultaneously means Zitadel itself (the
+            upstream IdP) is unhealthy.
+
+            User impact during a Zitadel outage:
+              - login: returns 502 (no fallback path).
+              - totp_login / email_otp_confirm: returns 502.
+              - idp_callback / idp_signup_callback: returns 502 OR 302 to
+                a signed failure_url (per failure leg in auth.py).
+              - password_reset / password_set / verify_email: returns 502.
+
+            Triage:
+              1. Confirm Zitadel is the root cause:
+                   curl -fsS https://auth.getklai.com/debug/healthz
+                 + check ``service:zitadel level:error`` in VictoriaLogs.
+              2. Confirm cross-endpoint spread (rules out one-endpoint
+                 regression):
+                   _time:5m service:portal-api reason:zitadel_5xx
+                     | stats by (event) count()
+                 If only one event has all the failures → it's an endpoint
+                 regression, not Zitadel. Triage as R1 step 3.
+              3. If Zitadel is genuinely down → wait for upstream recovery;
+                 do NOT change auth code. Monitor user-impact tickets.
+              4. If Zitadel is healthy AND the burst persists → check
+                 portal-api ↔ Zitadel network path (DNS, certs, connection
+                 pool exhaustion in httpx client).

--- a/docs/runbooks/auth-failure-burst.md
+++ b/docs/runbooks/auth-failure-burst.md
@@ -1,0 +1,188 @@
+# Runbook: portal-api auth endpoint failure burst
+
+**SPEC**: SPEC-SEC-AUTH-COVERAGE-001
+**Alert sources**: `deploy/grafana/provisioning/alerting/portal-auth-rules.yaml`
+**Owner rotation**: security on-call (R2 critical) / ops on-call (R1 warning)
+
+This runbook covers two alerts that fire on the structured `*_failed` events
+emitted by `_emit_auth_event` in `klai-portal/backend/app/api/auth.py`:
+
+| Alert | Severity | Window | Threshold |
+|---|---|---|---|
+| `auth_failure_rate_high` (R1) | warning  | 5m | > 10 events |
+| `auth_zitadel_5xx_burst` (R2)  | critical | 1m | > 5  events with `reason=zitadel_5xx` |
+
+For the dedicated MFA enforcement alert (`mfa_check_failed_*`), see
+[mfa-check-failed.md](mfa-check-failed.md). MFA events are intentionally
+excluded from the auth-coverage rules to avoid double-paging.
+
+## Event taxonomy
+
+The 16 events covered by R1, grouped by the auth flow they instrument:
+
+| Flow | Events |
+|---|---|
+| TOTP MFA | `totp_setup_failed`, `totp_confirm_failed`, `totp_login_failed` |
+| Passkey MFA | `passkey_setup_failed`, `passkey_confirm_failed` |
+| Email-OTP MFA | `email_otp_setup_failed`, `email_otp_confirm_failed`, `email_otp_resend_failed` |
+| IDP login | `idp_intent_failed`, `idp_callback_failed` |
+| IDP signup | `idp_intent_signup_failed`, `idp_signup_callback_failed` |
+| Password reset | `password_reset_failed`, `password_set_failed` |
+| SSO completion | `sso_complete_failed` |
+| Email verification | `verify_email_failed` |
+
+Every event carries the same field shape (per `_emit_auth_event`):
+
+| Field | Values |
+|---|---|
+| `event` | one of the 16 above |
+| `reason` | `zitadel_5xx` / `invalid_code` / `expired_link` / `unknown_idp` / `find_user_by_email_5xx` / `db_lookup_failed` / `unexpected` / etc. |
+| `outcome` | HTTP status code as string (`"400"`, `"401"`, `"502"`, `"302"`) |
+| `zitadel_status` | upstream HTTP status when applicable |
+| `email_hash` | sha256 hex of email (privacy-safe) |
+| `level` | `warning` / `error` |
+
+## Triage R1 (auth_failure_rate_high)
+
+This is a broad burst alert. Goal: identify whether one endpoint regressed
+or many endpoints are failing simultaneously.
+
+### Step 1 — group by event + reason
+
+Run in Grafana → Explore (VictoriaLogs datasource):
+
+```
+_time:5m service:portal-api event:in(
+  totp_setup_failed,totp_confirm_failed,totp_login_failed,
+  passkey_setup_failed,passkey_confirm_failed,
+  email_otp_setup_failed,email_otp_confirm_failed,email_otp_resend_failed,
+  idp_intent_failed,idp_intent_signup_failed,
+  idp_callback_failed,idp_signup_callback_failed,
+  password_reset_failed,password_set_failed,
+  sso_complete_failed,verify_email_failed
+) | stats by (event, reason, outcome) count()
+```
+
+### Step 2 — interpret
+
+- **Multiple events, dominated by `reason=zitadel_5xx`** → R2 should be
+  firing too. Triage [R2](#triage-zitadel-5xx-burst) first; the
+  underlying cause is shared.
+- **Single event dominates, `reason=zitadel_5xx`** → Zitadel endpoint that
+  this flow uses is degraded. Check whether other portal-api Zitadel
+  callers are healthy:
+  ```
+  _time:5m service:portal-api zitadel_status:5* | stats by (event) count()
+  ```
+- **Single event dominates, `reason ≠ zitadel_5xx`** → likely a code
+  regression on that specific endpoint. Check recent merges to
+  `klai-portal/backend/app/api/auth.py` (focus on the function for the
+  failing event). Common patterns:
+  - `reason=invalid_code` spikes on `*_confirm_failed` / `*_login_failed`
+    → could be a brute-force probe; check by `email_hash` distribution.
+  - `reason=expired_link` spikes on `password_set_failed` /
+    `verify_email_failed` → email delivery latency increased; check
+    klai-mailer health.
+  - `reason=unexpected` on any event → check container error logs:
+    `_time:30m service:portal-api level:error`.
+
+### Step 3 — confirm user impact
+
+`outcome` values map to HTTP responses returned to users:
+
+- `400` / `401` / `404` / `409` → client-side errors. Often expected
+  (wrong code, expired link). Burst = unusual usage pattern, not outage.
+- `502` / `503` → server-side failures. Each event = a real user blocked.
+  Open a status update if sustained.
+- `302` → redirect to a signed `failure_url` (idp_callback /
+  idp_signup_callback only). User saw an OAuth error page. Less visible
+  than 5xx but still real.
+
+### Step 4 — if no clear pattern
+
+Brute-force probe check — many `email_hash` values for `*_confirm_failed`
+or `*_login_failed`:
+
+```
+_time:5m service:portal-api event:in(totp_login_failed,email_otp_confirm_failed,passkey_confirm_failed,totp_confirm_failed)
+  | stats by (email_hash) count()
+  | where count() > 3
+```
+
+If many distinct `email_hash` values appear with > 3 failures each in
+5 minutes, this looks like enumeration. Escalate to security on-call.
+
+## Triage Zitadel 5xx burst
+
+(R2 `auth_zitadel_5xx_burst`)
+
+Critical alert. Cross-endpoint spike of `reason=zitadel_5xx` indicates
+Zitadel itself is unhealthy — a wide blast radius affecting login,
+signup, MFA, and account-flow endpoints simultaneously.
+
+### Step 1 — confirm Zitadel as root cause
+
+```
+curl -fsS https://auth.getklai.com/debug/healthz
+```
+
+Check Zitadel error logs:
+
+```
+_time:5m service:zitadel level:error | stats by (msg) count()
+```
+
+If Zitadel is genuinely 5xx-ing → confirmed root cause; skip to step 4.
+
+### Step 2 — confirm cross-endpoint spread
+
+```
+_time:5m service:portal-api reason:zitadel_5xx | stats by (event) count()
+```
+
+If only one event has all the failures → it's an endpoint regression
+masquerading as Zitadel. Triage as [R1 step 2](#step-2--interpret).
+
+If 3+ distinct events show non-zero counts → cross-endpoint spread
+confirmed.
+
+### Step 3 — rule out portal-api → Zitadel network path
+
+If Zitadel is healthy but portal-api still sees 5xx:
+
+```bash
+# From core-01:
+docker exec klai-core-portal-api-1 python -c "import httpx; print(httpx.get('https://auth.getklai.com/debug/healthz').status_code)"
+```
+
+If the container cannot reach Zitadel:
+
+- DNS in container: `docker exec klai-core-portal-api-1 getent hosts auth.getklai.com`
+- httpx client connection pool exhaustion: check `_time:30m service:portal-api "ConnectError"`
+- TLS chain issue: `docker exec klai-core-portal-api-1 openssl s_client -connect auth.getklai.com:443 -servername auth.getklai.com < /dev/null`
+
+### Step 4 — Zitadel outage handling
+
+When Zitadel is down, do NOT change auth.py code:
+
+- Login / TOTP login / email-OTP confirm → return 502; users cannot log in.
+- IDP callback / signup callback → return 502 OR 302 to failure_url.
+- Password reset / verify_email → return 502.
+- TOTP setup / passkey setup / email-otp setup → return 502 (config flows).
+
+Wait for Zitadel recovery. Post a status update if outage > 5 minutes.
+
+DO NOT temporarily disable MFA enforcement, dev-mode switch, or any
+fail-open code path during a Zitadel outage. Doing so degrades from
+"unavailable" to "insecure". The system is correctly fail-closed; user
+inconvenience is acceptable for the duration of the outage.
+
+### Step 5 — escalation
+
+If Zitadel is healthy AND R2 persists for > 5 minutes AND R1 step 4
+brute-force check is also positive:
+
+- Page security on-call.
+- Consider Caddy-level rate-limit on `/api/auth/*` if attack volume is
+  high.
+- Capture `email_hash` distribution for incident report.


### PR DESCRIPTION
## Summary

Operational follow-through on PR #195 (SPEC-SEC-AUTH-COVERAGE-001). The
SPEC shipped 16 structured `*_failed` events across 14 auth endpoints
but without alerts those events are queryable in VictoriaLogs and
invisible to operators. This adds the detection layer.

No code changes. No test changes. No portal-api deploy required.

## Changes

- **CHANGELOG.md** — `[Unreleased]` entry for SPEC-SEC-AUTH-COVERAGE-001
  (audit-trail gap closed; no entry was written when #195 merged).
- **`deploy/grafana/provisioning/alerting/portal-auth-rules.yaml`** (NEW) — 2 LogsQL alerts:
  - R1 `auth_failure_rate_high` (warning, 5m, > 10 events): broad burst
    across the 16 endpoint events.
  - R2 `auth_zitadel_5xx_burst` (critical, 1m, > 5 `reason=zitadel_5xx`):
    cross-endpoint Zitadel-outage signal.
- **`docs/runbooks/auth-failure-burst.md`** (NEW) — triage runbook for R1+R2 (event taxonomy, brute-force detection via `email_hash`, Zitadel outage handling).

## Design notes

- `mfa_check_failed` (SPEC-SEC-MFA-001) intentionally NOT included — has dedicated rules in `portal-mfa-rules.yaml` with different thresholds + runbook.
- LogsQL `event:in(a,b,c)` selector keeps R1 query maintainable.
- R2 anchor slug tested against GitHub markdown renderer to avoid the em-dash mismatch hit on SPEC-SEC-MFA-001.

## Test plan

- [x] YAML parseable: `yaml.safe_load` returns 2 rules
- [x] Alert structure mirrors `portal-mfa-rules.yaml` (queryType: instant + reduce + threshold pattern)
- [x] Runbook anchors validated against GitHub slugger
- [ ] CI green
- [ ] Grafana provisioning sync after merge (auto on next reconcile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)