### PR TITLE
SPEC-SEC-TENANT-001 tech-debt: migrate REQ-1.4 + REQ-2.1 log events to structlog

### DIFF
--- a/klai-portal/backend/app/api/admin/users.py
+++ b/klai-portal/backend/app/api/admin/users.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping
 from datetime import datetime
 from typing import Final, Literal
 
+import structlog
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials
 from pydantic import BaseModel, EmailStr
@@ -24,6 +25,13 @@ from app.services.zitadel import zitadel
 from . import _get_caller_org, _require_admin, bearer
 
 logger = logging.getLogger(__name__)
+# Structured-event logger for VictoriaLogs queryability — follows the
+# dual-logger pattern established in app/api/auth.py. Per
+# .claude/rules/klai/projects/portal-logging-py.md, all NEW log statements
+# in this file go via structlog so kwargs land as queryable JSON keys
+# instead of an `extra` blob. The legacy `logger` calls in this file
+# pre-date that rule and remain on stdlib until a dedicated migration.
+_slog = structlog.get_logger()
 
 # SPEC-SEC-TENANT-001 REQ-2.2 (v0.5.0 / β): frozen module-level mapping from
 # the portal role (InviteRequest.role Literal) to the optional Zitadel
@@ -204,14 +212,11 @@ async def invite_user(
         # REQ-2.1 observability: structured event so the absence-of-grant is
         # queryable in VictoriaLogs (e.g. confirm zero org:* grants land for
         # non-admin invites in production).
-        logger.info(
+        _slog.info(
             "invite_no_zitadel_grant",
-            extra={
-                "event": "invite_no_zitadel_grant",
-                "org_id": org.id,
-                "portal_role": body.role,
-                "zitadel_user_id": zitadel_user_id,
-            },
+            org_id=org.id,
+            portal_role=body.role,
+            zitadel_user_id=zitadel_user_id,
         )
     else:
         try:
@@ -514,15 +519,14 @@ async def offboard_user(
 
     user.status = "offboarded"
     # SPEC-SEC-TENANT-001 REQ-1.4: structured event for VictoriaLogs audit so
-    # any future cross-tenant regression is queryable.
-    logger.info(
+    # any future cross-tenant regression is queryable. structlog kwargs land
+    # as top-level JSON keys (queryable as `org_id:<n>`,
+    # `memberships_removed_count:<n>` in LogsQL) — not under an `extra` blob.
+    _slog.info(
         "user_offboarded",
-        extra={
-            "event": "user_offboarded",
-            "org_id": org.id,
-            "zitadel_user_id": zitadel_user_id,
-            "memberships_removed_count": memberships_removed_count,
-        },
+        org_id=org.id,
+        zitadel_user_id=zitadel_user_id,
+        memberships_removed_count=memberships_removed_count,
     )
     await log_event(
         org_id=org.id,


### PR DESCRIPTION
## Summary

Tech-debt follow-up to PR #200. Migrates the two new structured-event log statements introduced by SPEC-SEC-TENANT-001 (`event="user_offboarded"` REQ-1.4, `event="invite_no_zitadel_grant"` REQ-2.1) from stdlib `logging.getLogger()` to `structlog.get_logger()`, per `.claude/rules/klai/projects/portal-logging-py.md` *"Never use logging.getLogger() for new log statements"*.

Stacked on top of `feature/SPEC-SEC-TENANT-001` (PR #200) — rebase / merge in that order.

## Why

PR #200 self-review flagged this as klai-rule violation #1: the new log events used the file's pre-existing stdlib logger for minimal-changes consistency with the rest of users.py. ProcessorFormatter wraps the output to JSON in production, so it works — but kwargs land under an `extra.*` namespace instead of as top-level fields. VictoriaLogs queries are noisier (`extra.org_id:<n>` rather than `org_id:<n>`).

## Approach

Dual-logger pattern, following the established convention in [app/api/auth.py:79](klai-portal/backend/app/api/auth.py#L79):

- `logger = logging.getLogger(__name__)` retained for legacy paths (logger.exception on Zitadel failures, etc.)
- `_slog = structlog.get_logger()` added for the two new structured-event paths

The two new events now emit with native kwargs that land as queryable JSON keys:

```python
_slog.info("user_offboarded", org_id=..., zitadel_user_id=..., memberships_removed_count=...)
_slog.info("invite_no_zitadel_grant", org_id=..., portal_role=..., zitadel_user_id=...)
```

File-wide logger migration is **explicitly out of scope** here — that belongs in a dedicated SPEC.

## Test plan

- [x] `klai-portal/backend`: `uv run pytest tests/test_admin_users.py tests/test_user_lifecycle.py` — 18 passed (no regression).
- [x] `klai-portal/backend`: `uv run ruff format --check app/api/admin/users.py` — clean.
- [x] `klai-portal/backend`: `uv run ruff check app/api/admin/users.py` — clean.
- [x] `klai-portal/backend`: `uv run --with pyright pyright app/api/admin/users.py` — 0 errors.
- [ ] CI: `gh run watch --exit-status`.

## Behavioural change

None. Both events emit at INFO level with the same key set; only the JSON shape (top-level vs nested under `extra`) changes. Existing VictoriaLogs queries that use `extra.org_id:` should be updated to `org_id:` post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)