### PR TITLE
docs(sec): SPEC-SEC-SESSION-001 close-out — alerts + CHANGELOG + status

### DIFF
--- a/.moai/specs/SPEC-SEC-AUDIT-2026-04/spec.md
+++ b/.moai/specs/SPEC-SEC-AUDIT-2026-04/spec.md
@@ -1,9 +1,9 @@
 ---
 id: SPEC-SEC-AUDIT-2026-04
-version: 0.4.0
+version: 0.6.0
 status: draft
 created: 2026-04-24
-updated: 2026-04-28
+updated: 2026-04-29
 author: Mark Vletter
 priority: critical
 type: tracker
@@ -12,6 +12,19 @@ type: tracker
 # SPEC-SEC-AUDIT-2026-04: Security Audit Response Tracker
 
 ## HISTORY
+
+### v0.6.0 (2026-04-29)
+- SPEC-SEC-SESSION-001 shipped: implementation (#197) deployed to core-01
+  same day; close-out PR adds CHANGELOG entry, status promotion to
+  `done`, and two new Grafana alerts (`session_sso_cookie_key_missing` CRIT,
+  `session_totp_redis_unavailable` CRIT) at `portal-session-rules.yaml`.
+  - Findings #13 (TOTP per-instance counter), #15 (`klai_idp_pending`
+    no binding), #16 (`klai_sso` ephemeral-key fallback) closed.
+  - 22 new tests; container restart on core-01 emitted zero
+    `sso_cookie_key_missing_startup_abort` events; 0 errors on
+    `service:portal-api` in the 20-minute post-deploy scan.
+- Live status table updated: 11 of 13 tracked SPECs shipped (was 10 of 13).
+- Estimate revised: 4-8 PRs remaining (was 6-10).
 
 ### v0.5.0 (2026-04-28, late)
 - SPEC-SEC-AUTH-COVERAGE-001 fully shipped: implementation (#195) + alerts/runbook/CHANGELOG follow-through (#198), both deployed to core-01.
@@ -91,13 +104,13 @@ Implementation teams should read the linked sub-SPEC, not this tracker, when pic
 | SPEC-SEC-IMAP-001 | P1 | **shipped** | #165 #172 #174 #176 #177 |
 | SPEC-SEC-MFA-001 | P1 | **shipped** | #181 + #189 db-failure-events refactor |
 | SPEC-SEC-ENVFILE-SCOPE-001 | P1 | **shipped** | #163 + #170 (3-vars-dropped fix) + #171 close-out |
-| SPEC-SEC-SESSION-001 | P2 | **queued** | — |
+| SPEC-SEC-SESSION-001 | P2 | **shipped** | #197 + close-out (alerts/CHANGELOG) |
 | SPEC-SEC-INTERNAL-001 | P2 | **queued** | — |
 | SPEC-SEC-HYGIENE-001 | P3 | **partial** (scribe slice #179 + retrieval slice #188 open; connector / portal / knowledge-mcp slices queued) | #179 + #188 (open) |
 | SPEC-SEC-AUTH-COVERAGE-001 | P0 | **shipped** | #184 plan + #186 v0.2 + #195 run + #198 alerts/runbook/CHANGELOG |
 
-**Implementation rate:** ~28 PRs merged in 4 days (audit-response only).
-**Remaining:** ~6-10 PRs to close the 3 fully-queued originals + IDENTITY-ASSERT-001 residue + HYGIENE-001 slices.
+**Implementation rate:** ~30 PRs merged in 5 days (audit-response only).
+**Remaining:** ~4-8 PRs to close the 2 fully-queued originals (TENANT-001, INTERNAL-001) + IDENTITY-ASSERT-001 residue + HYGIENE-001 slices.
 
 ---
 

--- a/.moai/specs/SPEC-SEC-SESSION-001/spec.md
+++ b/.moai/specs/SPEC-SEC-SESSION-001/spec.md
@@ -1,9 +1,9 @@
 ---
 id: SPEC-SEC-SESSION-001
-version: 0.2.0
-status: draft
+version: 0.3.0
+status: done
 created: 2026-04-24
-updated: 2026-04-24
+updated: 2026-04-29
 author: Mark Vletter
 priority: medium
 tracker: SPEC-SEC-AUDIT-2026-04
@@ -12,6 +12,44 @@ tracker: SPEC-SEC-AUDIT-2026-04
 # SPEC-SEC-SESSION-001: Session and Cookie Robustness
 
 ## HISTORY
+
+### v0.3.0 (2026-04-29) — shipped
+- Implementation merged via PR #197 (squash `298195aa`) and deployed to
+  core-01 the same day. Container `klai-core-portal-api-1` rolled over
+  cleanly: lifespan startup emitted no `sso_cookie_key_missing_startup_abort`
+  event, public health endpoint returned 200, zero error events on
+  `service:portal-api` in the 20-minute post-deploy scan.
+- All six REQs landed:
+  - REQ-1: in-memory `_pending_totp = TTLCache(...)` replaced with Redis
+    keys `totp_pending:<token>` (HASH) + `totp_pending_failures:<token>`
+    (STRING via atomic `INCR`). 5-failure ceiling now cross-replica
+    consistent. Fail-CLOSED on Redis unavailability (HTTP 503).
+  - REQ-2: `klai_idp_pending` Fernet payload extended with `ua_hash` +
+    `ip_subnet` (`/24` IPv4 / `/48` IPv6). `_verify_idp_pending_binding`
+    rejects mismatch with HTTP 403 + structlog event; cookie preserved
+    for legitimate retry within TTL.
+  - REQ-3: `_fernet = Fernet(... else generate_key())` replaced with
+    `@lru_cache _get_sso_fernet()` that raises `RuntimeError` on empty
+    key. Three callsites migrated.
+  - REQ-4: lifespan startup-guard runs BEFORE the dev/prod branch in
+    `app.main`, so `is_auth_dev_mode` no longer bypasses the SSO key
+    check. Empty key emits structlog `critical` event then re-raises.
+  - REQ-5: four structured events live in VictoriaLogs:
+    `totp_pending_lockout`, `totp_pending_redis_unavailable`,
+    `idp_pending_binding_mismatch`, `sso_cookie_key_missing_startup_abort`.
+    All carry prefix-only PII (8-hex hash prefixes, `/24`/`/48` subnets,
+    8-char token prefixes) — no raw UA, IP, or session credentials.
+  - REQ-6: 22 new tests across six files (acceptance scenarios 1-8). Two
+    new Grafana alerts on the SESSION-specific events (this close-out PR).
+- Caller-IP / subnet helper extracted to `app/services/request_ip.py` once
+  the third callsite (auth IDP-pending + signup binding-check) joined the
+  existing `app/api/internal.py` consumer; `internal.py` aliases the
+  legacy `_resolve_caller_ip` name to keep the test patch surface intact.
+- Known limitation (filed for follow-up, not blocking): `_totp_pending_create`
+  uses sequential `HSET` + `EXPIRE` rather than a Redis pipeline, so a
+  portal-api crash in the microsecond window between the two calls would
+  leak one orphan hash without TTL. Real-world impact: <1 hash per crash;
+  `maxmemory` policy on Redis caps long-term growth.
 
 ### v0.2.0 (2026-04-24)
 - Expanded from stub via `/moai plan SPEC-SEC-SESSION-001`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,115 @@
 # Changelog
 
+## [Unreleased] — 2026-04-29 — SPEC-SEC-SESSION-001: session and cookie robustness
+
+Closes Cornelis 2026-04-22 audit findings #13 (TOTP per-instance counter),
+#15 (`klai_idp_pending` cookie no origin-context binding), #16 (`klai_sso`
+ephemeral-key fallback on empty `SSO_COOKIE_KEY`). Behavioural changes are
+backward-compatible at the HTTP surface — only the server-side storage
+substrate, the Fernet payload shape, and the lifespan startup-abort path
+change.
+
+### Added (security)
+
+- **`klai-portal/backend/app/api/auth.py::_get_sso_fernet`** —
+  `@lru_cache(maxsize=1)` accessor that raises `RuntimeError` on empty /
+  whitespace `SSO_COOKIE_KEY` instead of falling through to
+  `Fernet.generate_key()`. Mirrors the pattern already used by
+  `signup.py::_get_fernet`. Three callsites migrated (`_encrypt_sso`,
+  `_decrypt_sso`, `idp_signup_callback`'s pending-cookie encrypt site).
+- **`klai-portal/backend/app/api/auth.py::_totp_pending_create` / `_get` /
+  `_incr_failures` / `_delete`** — Redis-backed pending-state primitives
+  using two keys per token: `totp_pending:<token>` (HASH with
+  `session_id`, `session_token`, `ua_hash`, `ip_subnet`) +
+  `totp_pending_failures:<token>` (STRING incremented via atomic `INCR`).
+  Both keys carry the same TTL (`settings.totp_pending_ttl_seconds`,
+  default 300 s). Replaces the in-memory `_pending_totp = TTLCache(...)`
+  which let a 5-failure ceiling become an N×5 ceiling behind a
+  round-robin proxy.
+- **`klai-portal/backend/app/api/signup.py::_verify_idp_pending_binding`** —
+  consume-side check that compares the decrypted Fernet payload's
+  `ua_hash` / `ip_subnet` against values derived from the current
+  request. Mismatch returns HTTP 403 + structlog event; the cookie is
+  preserved so the legitimate user can resume from the same browser
+  within TTL.
+- **`klai-portal/backend/app/services/request_ip.py`** (NEW) — public
+  `resolve_caller_ip` (right-most `X-Forwarded-For` entry from Caddy →
+  `request.client.host` → `"unknown"`) plus `resolve_caller_ip_subnet`
+  (`/24` IPv4, `/48` IPv6). Extracted from `app/api/internal.py` once a
+  third callsite (auth IDP-pending issue + signup-social binding
+  consume) joined the existing internal-rate-limit consumer.
+- **`klai-portal/backend/app/main.py` lifespan SSO check** — calls
+  `_get_sso_fernet()` BEFORE the dev/prod branch so
+  `is_auth_dev_mode=True` no longer bypasses the SSO-key validation
+  (REQ-4.4 closes the silent-on-dev-box failure mode). Empty key emits
+  structlog `critical` event `sso_cookie_key_missing_startup_abort`
+  with `env_var="SSO_COOKIE_KEY"` + `sops_path` BEFORE re-raising, so
+  Alloy captures the abort in VictoriaLogs even though the process is
+  about to exit non-zero.
+- **4 structured events** in VictoriaLogs:
+  `totp_pending_lockout` (warning, on the 5th failed code),
+  `totp_pending_redis_unavailable` (error, fail-CLOSED on Redis outage),
+  `idp_pending_binding_mismatch` (warning, on UA / IP-subnet mismatch),
+  `sso_cookie_key_missing_startup_abort` (critical, on lifespan abort).
+  All events carry prefix-only PII (8-hex hash prefixes, `/24`/`/48`
+  subnet network addresses, 8-char token prefixes) — never raw UA, raw
+  IP, full token, or session credentials. PII guard verified by
+  `tests/test_session_logging_pii.py`.
+- **`deploy/grafana/provisioning/alerting/portal-session-rules.yaml`**
+  (NEW) — two LogsQL alerts on the new events:
+  - R1 `session_sso_cookie_key_missing` (critical): `>= 1` event in any
+    1m window. A single occurrence means a portal-api replica failed to
+    boot due to misconfigured `SSO_COOKIE_KEY` — operators must intervene.
+  - R2 `session_totp_redis_unavailable` (critical): `> 3` events in 1m.
+    Sustained burst means TOTP login is broken (fail-CLOSED kicks in
+    when Redis is unreachable; users see HTTP 503).
+- **22 new tests** across six files: `test_auth_totp_lockout.py`,
+  `test_idp_pending_binding.py`, `test_startup_sso_key_guard.py`,
+  `test_auth_login_happy_path.py`, `test_session_logging_pii.py`, plus
+  request-parameter migrations across `test_auth_security.py`,
+  `test_auth_mfa_fail_closed.py`, `test_social_signup.py`,
+  `test_auth_totp_endpoints.py`, `test_auth_idp_endpoints.py`.
+
+### Changed
+
+- **`SSO_COOKIE_KEY` startup validation moved out of the prod-only
+  missing-vars list in `app/main.py`** — was double-listed there
+  pre-SPEC; the lifespan-level check via `_get_sso_fernet()` is the
+  authoritative guard now. ZITADEL_PAT / PORTAL_SECRETS_KEY /
+  ENCRYPTION_KEY / DATABASE_URL still validated by the prod-only block.
+- **`klai-portal/backend/tests/conftest.py`** — adds the shared
+  `fake_redis` fixture (in-memory `fakeredis.aioredis.FakeRedis` swapped
+  into the `_pool_holder` singleton for one test). All Redis-using auth
+  tests pick it up via fixture parameter.
+- **`klai-portal/backend/tests/helpers.py`** — adds `make_request()`
+  factory that builds a synthetic Starlette `Request` for tests that
+  bypass the FastAPI router. Defaults to `127.0.0.1:12345` so
+  `resolve_caller_ip` returns a parseable address without per-test
+  setup.
+- **`klai-portal/backend/pyproject.toml`** — adds `fakeredis>=2.26` to
+  both dev dep groups (`[project.optional-dependencies]` and
+  `[dependency-groups]`).
+- **`klai-portal/backend/app/core/config.py`** — adds
+  `totp_pending_ttl_seconds: int = 300` setting; default matches the
+  legacy in-memory window. Tunable per environment without code change.
+
+### Removed
+
+- **`_pending_totp = TTLCache(...)` module global** in `app/api/auth.py`.
+  The `TTLCache` class itself remains available as a generic utility
+  (REQ-1.8), but the production TOTP path no longer routes through it.
+- **`Fernet.generate_key()` fallback** at the old `auth.py:106`. There
+  is now no path under which portal-api will issue cookies signed with
+  an ephemeral, per-replica key. Misconfiguration aborts the process.
+
+### Coverage
+
+- 22 dedicated tests across the four security-critical surfaces (Redis
+  TOTP helpers, lifespan SSO guard, IDP-pending binding check, PII
+  redaction). Acceptance scenarios 1-8 from `acceptance.md` all
+  represented; CI `Build and push portal-api / quality` job passed
+  pytest + ruff + pyright + ruff-format on the merged PR.
+
 ## [Unreleased] — 2026-04-28 — SPEC-SEC-AUTH-COVERAGE-001: auth.py coverage + observability hardening (14 endpoints)
 
 Companion to SPEC-SEC-MFA-001. Same Cornelis-audit context (2026-04-22)

--- a/deploy/grafana/provisioning/alerting/portal-session-rules.yaml
+++ b/deploy/grafana/provisioning/alerting/portal-session-rules.yaml
@@ -1,0 +1,232 @@
+# SPEC-SEC-SESSION-001 — portal-api session/cookie health alerts.
+#
+# Routed via spec=SPEC-SEC-SESSION-001 -> klai-ops-alerts-email.
+#
+#   R1  session_sso_cookie_key_missing       CRIT  >= 1 event in any 1m window.
+#                                                  A portal-api replica failed
+#                                                  to boot because SSO_COOKIE_KEY
+#                                                  is empty / unset / whitespace.
+#                                                  The lifespan guard aborts the
+#                                                  process before traffic, so
+#                                                  every event = one boot loop.
+#   R2  session_totp_redis_unavailable       CRIT  > 3 events in 1m.
+#                                                  TOTP login is fail-CLOSED on
+#                                                  Redis unavailability (SPEC
+#                                                  REQ-1.7) — sustained burst
+#                                                  means real users cannot
+#                                                  complete TOTP and see HTTP 503.
+#
+# Why these two events and not the other two SPEC-SEC-SESSION-001 events:
+#   - totp_pending_lockout (REQ-5.1, warning) is working-as-designed signal —
+#     a user mis-typed their TOTP code five times. Adding a Grafana alert
+#     would generate brute-force noise; lockout volume is more useful as a
+#     dashboard metric than an alert.
+#   - idp_pending_binding_mismatch (REQ-5.2, warning) is a potential attack
+#     signal but at single-event frequency it is indistinguishable from a
+#     user switching network mid-signup (mobile WiFi -> 4G crossing a /24
+#     boundary). Rate-based alert tuning belongs in a follow-up SPEC after
+#     baseline volume is observed.
+#
+# Pitfall avoidance (matches portal-auth-rules.yaml conventions):
+#   - Always go through `reduce` between LogsQL output and SSE math.
+#   - execErrState: OK — VictoriaLogs plugin sometimes trips "long vs wide"
+#     errors on stats reduce chains; miss-on-hiccup beats false-page.
+
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: sec-session-001-portal-api
+    folder: Klai
+    interval: 1m
+    rules:
+
+      # ── R1: session_sso_cookie_key_missing ─────────────────────────────
+      # The lifespan guard at app.main calls _get_sso_fernet() once at
+      # startup. An empty / whitespace SSO_COOKIE_KEY raises RuntimeError;
+      # before the raise propagates, _slog.critical(
+      #   "sso_cookie_key_missing_startup_abort",
+      #   env_var="SSO_COOKIE_KEY", sops_path="..."
+      # ) fires so Alloy captures the abort in VictoriaLogs even though
+      # the process is about to exit non-zero. A single event = one boot
+      # loop — there is no benign reason for this event in a healthy
+      # cluster.
+      - uid: sec-session-001-sso-cookie-key-missing
+        title: session_sso_cookie_key_missing
+        condition: threshold
+        data:
+          - refId: query
+            datasourceUid: victorialogs
+            queryType: instant
+            relativeTimeRange:
+              from: 60
+              to: 0
+            model:
+              refId: query
+              datasource:
+                type: victoriametrics-logs-datasource
+                uid: victorialogs
+              expr: '_time:1m service:portal-api event:sso_cookie_key_missing_startup_abort | stats count() as n'
+              queryType: instant
+          - refId: reduce
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 60
+              to: 0
+            model:
+              refId: reduce
+              type: reduce
+              reducer: last
+              expression: query
+          - refId: threshold
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 60
+              to: 0
+            model:
+              refId: threshold
+              type: threshold
+              expression: reduce
+              conditions:
+                - evaluator: { params: [0], type: gt }
+                  operator: { type: and }
+                  reducer: { params: [], type: last }
+                  type: query
+        noDataState: OK
+        execErrState: OK
+        for: 0m
+        keepFiringFor: 30m
+        isPaused: false
+        labels:
+          severity: critical
+          spec: SPEC-SEC-SESSION-001
+          service_group: portal-api
+        annotations:
+          summary: 'portal-api refusing to start: SSO_COOKIE_KEY missing'
+          description: |
+            A portal-api replica emitted ``sso_cookie_key_missing_startup_abort``
+            at startup and refused to serve traffic. SPEC-SEC-SESSION-001 REQ-4
+            requires the lifespan to abort BEFORE accepting any request when
+            ``settings.sso_cookie_key`` is empty, unset, or whitespace-only.
+            Replicas in this state will boot-loop until the env var is fixed
+            (Docker restart policy will keep retrying, each retry will fire
+            this alert again).
+
+            Triage:
+              1. Confirm the replica is in CrashLoopBackOff or its Docker
+                 equivalent on core-01:
+                   docker ps -a --filter name=portal-api
+                 Restarts > 1 in the last minute means the loop is active.
+              2. Verify SSO_COOKIE_KEY is present in the environment that
+                 the container actually sees (NOT just /opt/klai/.env on
+                 the host):
+                   docker exec klai-core-portal-api-1 printenv \
+                     | grep -E '^(SSO|PORTAL_API_SSO)_COOKIE_KEY'
+                 If empty or absent → fix at the source (SOPS-encrypted
+                 ``klai-infra/core-01/.env.sops`` is canonical).
+              3. After fixing the env, recreate the container so the new
+                 env propagates:
+                   docker compose -f /opt/klai/docker-compose.yml \
+                     up -d portal-api
+              4. Confirm the alert clears within 1m (the boot loop should
+                 stop on the first successful start).
+
+            Out of scope for this alert: rotation of an existing valid key
+            (use the runbook in ``docs/runbooks/sso_cookie_key-rotation.md``
+            once it lands; tracked as a follow-up to this SPEC).
+
+      # ── R2: session_totp_redis_unavailable ─────────────────────────────
+      # SPEC REQ-1.7 makes the TOTP path fail-CLOSED on Redis unavailability:
+      # an unreachable Redis pool causes /api/auth/totp-login to return HTTP
+      # 503 with "Authentication unavailable, please retry" instead of
+      # falling through to the in-memory ceiling (the bug we fixed). A
+      # sustained burst of these events means real users with TOTP enabled
+      # cannot complete login. Critical because login UX is broken; the >3
+      # threshold tolerates a single transient blip while still firing
+      # within ~30s of a real Redis outage.
+      - uid: sec-session-001-totp-redis-unavailable
+        title: session_totp_redis_unavailable
+        condition: threshold
+        data:
+          - refId: query
+            datasourceUid: victorialogs
+            queryType: instant
+            relativeTimeRange:
+              from: 60
+              to: 0
+            model:
+              refId: query
+              datasource:
+                type: victoriametrics-logs-datasource
+                uid: victorialogs
+              expr: '_time:1m service:portal-api event:totp_pending_redis_unavailable | stats count() as n'
+              queryType: instant
+          - refId: reduce
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 60
+              to: 0
+            model:
+              refId: reduce
+              type: reduce
+              reducer: last
+              expression: query
+          - refId: threshold
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 60
+              to: 0
+            model:
+              refId: threshold
+              type: threshold
+              expression: reduce
+              conditions:
+                - evaluator: { params: [3], type: gt }
+                  operator: { type: and }
+                  reducer: { params: [], type: last }
+                  type: query
+        noDataState: OK
+        execErrState: OK
+        for: 1m
+        keepFiringFor: 5m
+        isPaused: false
+        labels:
+          severity: critical
+          spec: SPEC-SEC-SESSION-001
+          service_group: portal-api
+        annotations:
+          summary: 'portal-api TOTP login broken: Redis unreachable'
+          description: |
+            More than 3 ``totp_pending_redis_unavailable`` events fired in
+            the last minute. Per SPEC-SEC-SESSION-001 REQ-1.7 the TOTP path
+            fails CLOSED on Redis unavailability — affected users see HTTP
+            503 ``Authentication unavailable, please retry`` and cannot
+            complete login. Single-replica blips are tolerated by the >3
+            threshold; sustained bursts mean Redis itself is down or the
+            portal-api -> redis network path is broken.
+
+            Triage:
+              1. Confirm Redis is the root cause:
+                   docker ps --filter name=redis
+                   docker logs --tail 50 klai-core-redis-1
+                 If the container is restarting or PING is failing, this
+                 is a Redis outage. Recover Redis first.
+              2. Confirm portal-api can reach Redis:
+                   docker exec klai-core-portal-api-1 \
+                     python -c "import redis.asyncio, asyncio; \
+                                asyncio.run(redis.asyncio.from_url('redis://...').ping())"
+                 (substitute the real REDIS_URL from the container env).
+                 A timeout / refused-connection here means Redis is up
+                 but unreachable — check klai-net network state.
+              3. Cross-check the ``phase`` field on the captured events:
+                   _time:5m service:portal-api event:totp_pending_redis_unavailable
+                     | stats by (phase) count()
+                 ``phase=create`` means /login can't enqueue;
+                 ``phase=get`` / ``incr`` / ``delete`` means an in-flight
+                 TOTP attempt failed mid-verify. The latter is worse —
+                 those users get a 503 mid-login.
+              4. There is NO fallback path by design. Recover Redis, then
+                 affected users retry from the password screen. Do NOT
+                 weaken the fail-closed semantics — opening the door
+                 lifts the brute-force ceiling that SPEC-SEC-SESSION-001
+                 specifically closed.


### PR DESCRIPTION
## Summary
- SPEC-SEC-SESSION-001 (#197) shipped to production yesterday; this is the documentation + alerting follow-through.
- Promotes the SPEC to `status: done` (v0.3.0), updates the SPEC-SEC-AUDIT-2026-04 tracker (v0.6.0) marking findings #13/#15/#16 closed, and adds a CHANGELOG entry in the same shape as the SPEC-SEC-AUTH-COVERAGE-001 follow-through (#198).
- Adds two LogsQL alerts at `deploy/grafana/provisioning/alerting/portal-session-rules.yaml` — one for the lifespan boot-loop signal (`sso_cookie_key_missing_startup_abort`), one for sustained Redis-down on the TOTP path.

## Why two alerts and not four
The SPEC adds four structured events (REQ-5). Only two warrant a dedicated alert:
- `sso_cookie_key_missing_startup_abort` — single event = real boot failure, page immediately.
- `totp_pending_redis_unavailable` — sustained burst = TOTP login broken for users; tolerate single blips with a `>3` threshold.

The other two (`totp_pending_lockout`, `idp_pending_binding_mismatch`) are working-as-designed at single-event frequency — alarming on them would generate brute-force-probe noise. Rate-based tuning belongs in a follow-up after baseline volume is observed.

## Real-traffic verification
0 errors on `service:portal-api` in the 20-minute post-deploy scan; container rolled over cleanly with no `sso_cookie_key_missing_startup_abort` event. PR #197 is live and healthy.

## Test plan
- [ ] CI green (no code changes — only docs + Grafana yaml).
- [ ] After merge: confirm `portal-session-rules.yaml` is picked up by Grafana provisioning (sync-docker-compose-config workflow).
- [ ] Smoke-test R1 by deploying a non-prod portal-api with empty `SSO_COOKIE_KEY` (the alert should fire within ~1m of the boot abort).

## Notes for reviewers
- The `[Unreleased]` section in `CHANGELOG.md` follows the convention from #198 — Added / Changed / Removed / Coverage. No version-numbered release section is created (matches the rest of the file).
- No application code changed; this is purely documentation + alerting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)