### PR TITLE
docs(sec): SPEC-SEC-INTERNAL-001 close-out — CHANGELOG + tracker + 3 pitfalls

### DIFF
--- a/.claude/rules/klai/pitfalls/process-rules.md
+++ b/.claude/rules/klai/pitfalls/process-rules.md
@@ -450,3 +450,88 @@ Two real incidents in the audit-response sprint:
    line was the regression — a known-good rebuild is always cheaper.
 
 See `.claude/rules/klai/infra/sops-env.md` for the full SOPS workflow.
+
+## astgrep-gitignore-shadowed-rules (HIGH)
+ast-grep silently respects `.gitignore` when discovering rule files in
+`ruleDirs`. The repo `.gitignore` carries `*-secret.*`, `*_secret.*`,
+`secret-*.*` and a handful of similar secret-file-hygiene patterns. A
+rule file named `no-string-compare-on-secret.yml` (matching `*-secret.*`)
+is silently dropped: `effectiveRuleCount` stays unchanged in
+`sg scan --inspect summary`, no warning hits stderr, and no parse error
+is reported. The same rule loads fine when invoked via
+`sg scan --rule path/to/file.yml`, which makes the bug very confusing
+to diagnose.
+
+**Symptom.** Your new rule passes a manual `sg scan --rule rules/foo.yml`
+test, but the per-service workflow doesn't fire it. `effectiveRuleCount`
+in `--inspect summary` reflects the existing rule count only.
+SPEC-SEC-INTERNAL-001 (2026-04-29) hit this with rule files named
+`no-string-{compare,neq}-on-secret.yml` and renamed them to
+`no-secret-{eq,neq}-compare.yml` to escape the gitignore filter.
+
+**Prevention.**
+- Before relying on a new rule under `rules/`, run
+  `git check-ignore -v rules/<file>.yml`. If that command prints any
+  matching pattern, rename the file.
+- Prefer prefixes like `no-secret-*-compare.yml` that don't end in
+  `secret.<ext>` / `_secret.<ext>` / `secret-*.<ext>`.
+- Verify rule loading with
+  `uv tool run --from ast-grep-cli sg scan -c sgconfig.yml --inspect entity .`
+  and grep for your rule's `id:` in the output.
+
+## uv-pip-install-skips-uv-sources (HIGH)
+`uv pip install --system -r pyproject.toml` (uv's pip-compatibility mode)
+does NOT read `[tool.uv.sources]`. Path-deps declared as
+`klai-log-utils = { path = "../../klai-libs/log-utils" }` get resolved
+as PyPI lookups and fail with
+`error: Failed to parse entry: 'klai-log-utils'` during the Docker
+build. This is a silent gotcha because `uv sync` (which IS uv-native)
+DOES honour `[tool.uv.sources]`, so the local dev experience works
+fine and only Docker breaks.
+
+**Symptom.** `docker build` fails on the install step with the parse
+error above. SPEC-SEC-INTERNAL-001 (2026-04-29) hit this when scribe-api
+was the only service still on the old `pip install` Dockerfile pattern;
+adding the shared `klai-log-utils` path-dep silently broke its build.
+
+**Prevention.**
+- Switch the Dockerfile to a repo-root build context plus
+  `uv sync --frozen --no-dev --no-install-project` and `COPY` lines
+  for every `klai-libs/*` path-dep the service consumes. Mirror the
+  pattern already used by knowledge-mcp / connector / portal-api.
+- The workflow's `docker/build-push-action` step needs `context: .`
+  and an explicit `file: <service>/Dockerfile` once the context is
+  broadened.
+- After rewriting, smoke-test the Dockerfile locally
+  (`docker build -f <service>/Dockerfile .`) BEFORE pushing — the
+  CI feedback loop is 3-5 min per attempt.
+
+## parallel-spec-on-overlapping-log-sites (MED)
+When two SPECs land on the same call sites in the same file, the rebase
+or merge produces large, repetitive conflicts. SPEC-SEC-INTERNAL-001
+REQ-4 was a 22-site sweep on `klai-portal/backend/app/api/auth.py` that
+rewrote `logger.exception("...", exc.response.status_code, exc.response.text)`
+to `... sanitize_response_body(exc)`. SPEC-SEC-AUTH-COVERAGE-001 (#195)
+landed concurrently and replaced the SAME 22 `logger.exception` calls
+with structured `_slog.exception(...)` + `_emit_auth_event(...)`
+events that don't log the body at all. Result: 20 conflict blocks on
+merge, all of the shape "my sanitize wrapper vs main's structured event".
+
+**Resolution rule.** Take the more-thorough version on each conflict —
+in this case main's structured events, because they already achieve
+REQ-4's goal (no body in the log) AND add observability fields the
+sanitizer does not. The other SPEC's contribution survives in the
+non-conflict zones (a single non-log substring-check site at line 399
+plus the import).
+
+**Prevention.**
+- Before opening a wide log-site sweep, grep `git log --all --oneline`
+  for adjacent SPECs touching the same file, AND check `gh pr list
+  --search "auth.py"` for in-flight branches.
+- If two SPECs MUST sweep the same file in the same week, coordinate
+  scope: one PR carries the structural refactor, the other adapts on
+  top instead of replaying the same edits.
+- Prefer rebase + per-commit conflict resolution for the secondary
+  branch when the primary is already merged; or use a merge commit if
+  the secondary has multiple commits worth preserving (as
+  SPEC-SEC-INTERNAL-001 did to keep its 7 batch-commits readable).

--- a/.moai/specs/SPEC-SEC-AUDIT-2026-04/spec.md
+++ b/.moai/specs/SPEC-SEC-AUDIT-2026-04/spec.md
@@ -1,6 +1,6 @@
 ---
 id: SPEC-SEC-AUDIT-2026-04
-version: 0.6.0
+version: 0.7.0
 status: draft
 created: 2026-04-24
 updated: 2026-04-29
@@ -12,6 +12,45 @@ type: tracker
 # SPEC-SEC-AUDIT-2026-04: Security Audit Response Tracker
 
 ## HISTORY
+
+### v0.7.0 (2026-04-29, late)
+- SPEC-SEC-INTERNAL-001 fully shipped (#201): service-wide internal-secret
+  surface hardening across portal-api / klai-mailer / klai-connector /
+  klai-scribe / klai-knowledge-mcp + new shared library `klai-libs/log-utils/`.
+  Closes findings #14, #18, A2, A3, A4 from the original Cornelis audit
+  PLUS the 7 internal-wave findings catalogued on 2026-04-24.
+  - **B0** new shared lib: 4-symbol public API, 29 tests, ruff + pyright strict.
+  - **B1** portal-api: REQ-1.1 (taxonomy compare-digest), REQ-2 (SCAN/UNLINK
+    replaces FLUSHALL), REQ-3 (BFF proxy header strip + regex catch-all),
+    REQ-5 (rate-limit fail-mode setting, default closed), REQ-4 sweep on
+    ~6 portal log sites that survived the AUTH-COVERAGE-001 structured-events
+    refactor.
+  - **B2** knowledge-mcp: REQ-8 Request-ID return contract (no body to chat UI),
+    REQ-9.5 fail-closed startup, REQ-1.5 verify_shared_secret.
+  - **B3** connector: REQ-9.3 Settings validators + runtime guards on
+    `_headers()` / `__init__`, REQ-10 `sync_runs.error_details` sanitize.
+  - **B4** scribe-api: REQ-9.4 validator, drop silent-omit guard, REQ-4
+    sweep on transcription-service log path. Dockerfile rewritten to
+    repo-root + uv pattern (the previous `uv pip install -r` flow did
+    not read `[tool.uv.sources]`).
+  - **B5** ast-grep cross-service: 4 rule files (LHS / RHS × == / !=)
+    with `kind: identifier` constraint, wired into all 5 service CI
+    workflows. Regression fixture at
+    `.github/test-fixtures/sec-internal-001/regression.py`.
+- Live status table updated: 12 of 13 tracked SPECs shipped (was 11 of 13).
+- Estimate revised: 3-6 PRs remaining (was 4-8).
+- Three new pitfalls captured in
+  `.claude/rules/klai/pitfalls/process-rules.md`:
+  - `astgrep-gitignore-shadowed-rules (HIGH)` — ast-grep silently
+    respects `.gitignore` during rule-dir discovery; rule files matching
+    `*-secret.*` etc. are dropped without an error message.
+  - `uv-pip-install-skips-uv-sources (HIGH)` — `uv pip install -r pyproject.toml`
+    does NOT read `[tool.uv.sources]`; switch the Dockerfile to
+    `uv sync --frozen` to honour path-deps.
+  - `parallel-spec-on-overlapping-log-sites (MED)` — when two SPECs
+    rewrite the same log call sites, the rebase produces large
+    conflicts; prefer the more-thorough version on resolution and
+    coordinate scope before opening a wide log-sweep PR.
 
 ### v0.6.0 (2026-04-29)
 - SPEC-SEC-SESSION-001 shipped: implementation (#197) deployed to core-01
@@ -91,7 +130,7 @@ Implementation teams should read the linked sub-SPEC, not this tracker, when pic
 
 ---
 
-## Live status (2026-04-28, late)
+## Live status (2026-04-29, late)
 
 | SPEC | Prio | Status | PRs |
 |---|---|---|---|
@@ -105,12 +144,12 @@ Implementation teams should read the linked sub-SPEC, not this tracker, when pic
 | SPEC-SEC-MFA-001 | P1 | **shipped** | #181 + #189 db-failure-events refactor |
 | SPEC-SEC-ENVFILE-SCOPE-001 | P1 | **shipped** | #163 + #170 (3-vars-dropped fix) + #171 close-out |
 | SPEC-SEC-SESSION-001 | P2 | **shipped** | #197 + close-out (alerts/CHANGELOG) |
-| SPEC-SEC-INTERNAL-001 | P2 | **queued** | — |
+| SPEC-SEC-INTERNAL-001 | P2 | **shipped** | #201 + close-out (CHANGELOG / pitfalls / tracker) |
 | SPEC-SEC-HYGIENE-001 | P3 | **partial** (scribe slice #179 + retrieval slice #188 open; connector / portal / knowledge-mcp slices queued) | #179 + #188 (open) |
 | SPEC-SEC-AUTH-COVERAGE-001 | P0 | **shipped** | #184 plan + #186 v0.2 + #195 run + #198 alerts/runbook/CHANGELOG |
 
-**Implementation rate:** ~30 PRs merged in 5 days (audit-response only).
-**Remaining:** ~4-8 PRs to close the 2 fully-queued originals (TENANT-001, INTERNAL-001) + IDENTITY-ASSERT-001 residue + HYGIENE-001 slices.
+**Implementation rate:** ~31 PRs merged in 6 days (audit-response only).
+**Remaining:** ~3-6 PRs to close the last fully-queued original (TENANT-001) + IDENTITY-ASSERT-001 residue + HYGIENE-001 slices.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,144 @@
 # Changelog
 
+## [Unreleased] — 2026-04-29 — SPEC-SEC-INTERNAL-001: service-wide internal-secret surface hardening
+
+Closes Cornelis 2026-04-22 audit findings #14 (rate-limit fail-open),
+#18 (FLUSHALL in regenerate), A2 (taxonomy timing compare), A3 (BFF
+proxy header passthrough), A4 (`exc.response.text` log reflection in
+20+ portal sites) plus 7 internal-wave findings (2026-04-24) covering
+mailer / connector / scribe-api / knowledge-mcp. Behavioural changes
+are backward-compatible at every wire-level surface; the new failure
+modes (fail-closed startup on empty mandatory secrets, 503 on Redis
+outage) only surface under conditions that should not exist in
+production. Production env-parity verified against
+`klai-infra/core-01/.env.sops` BEFORE merge per the
+`validator-env-parity` pitfall.
+
+### Added (security)
+
+- **`klai-libs/log-utils/`** (NEW shared package, distribution
+  `klai-log-utils`) — four-symbol public API: `sanitize_response_body`
+  (REQ-4.1, scrubs known-secret substrings before truncation, default
+  512 chars), `sanitize_from_settings` (REQ-4.4, convenience wrapper),
+  `extract_secret_values` (REQ-4.2, walks Pydantic `model_fields` and
+  matches secret-shaped names with length ≥ 8), `verify_shared_secret`
+  (REQ-1.7, constant-time `hmac.compare_digest` with empty-configured
+  ValueError guard). `py.typed` marker (PEP 561) so consumer pyright
+  doesn't fall back to `reportMissingTypeStubs`. 29 tests, ruff +
+  pyright strict clean.
+- **Per-service sanitizer wrappers** —
+  `klai-portal/backend/app/utils/response_sanitizer.py` /
+  `klai-connector/app/core/sanitize.py` /
+  `klai-scribe/scribe-api/app/core/sanitize.py` /
+  `klai-knowledge-mcp/main.py::_KNOWN_SECRETS` — each binds the local
+  Settings instance to the shared sanitizer.
+- **`klai-portal/backend/app/core/config.py::internal_rate_limit_fail_mode`**
+  (REQ-5) — new `Literal["open", "closed"]` Settings field, default
+  `"closed"`. Production fails-closed on Redis outage (returns HTTP
+  503 with `internal_rate_limit_fail_closed` warning); staging /
+  dev override to `"open"` for SEC-005 baseline behaviour.
+- **`klai-portal/backend/app/core/config.py::librechat_cache_key_pattern`**
+  (REQ-2.3) — new Settings field, default `"configs:*"`. Future
+  LibreChat upgrade can flip the namespace via SOPS without a code
+  change.
+- **`klai-portal/backend/app/api/proxy.py::_SECRET_HEADER_BLOCKLIST`**
+  + `_SECRET_HEADER_REGEX` (REQ-3) — explicit deny-list
+  (`x-internal-secret`, `x-klai-internal-secret`,
+  `x-retrieval-api-internal-secret`, `x-scribe-api-internal-secret`)
+  plus the catch-all regex
+  `(?i)^(x-)?(klai-internal|internal-auth|internal-token)`. Every
+  blocked attempt emits `proxy_header_injection_blocked` at info; the
+  header VALUE is never logged.
+- **Fail-closed Settings validators** on connector / scribe-api /
+  knowledge-mcp (REQ-9.3 / REQ-9.4 / REQ-9.5). Mirrors the mailer
+  validator already shipped in SPEC-SEC-MAILER-INJECTION-001 (#168).
+  Process refuses to import / start when any required outbound secret
+  is empty. Runtime guards on
+  `klai-connector/app/services/portal_client.py::_headers()` and
+  `klai-connector/app/clients/knowledge_ingest.py::__init__` catch the
+  `Settings.model_construct()` bypass path used in some unit tests.
+- **`rules/no-secret-eq-compare.yml` + `rules/no-secret-neq-compare.yml`**
+  + RHS variants (REQ-6) — ast-grep rules with a `kind: identifier`
+  constraint so `Model.field == ...` SQLAlchemy expressions don't
+  false-positive. Wired into the five service workflows
+  (`portal-api.yml` / `klai-mailer.yml` / `klai-connector.yml` /
+  `scribe-api.yml` / `klai-knowledge-mcp.yml`). Regression fixture at
+  `.github/test-fixtures/sec-internal-001/regression.py` with five
+  intentional violations.
+
+### Changed (security)
+
+- **`klai-portal/backend/app/api/internal.py::regenerate_librechat_configs`**
+  (REQ-2) — replaced `redis_client.flushall()` with
+  `scan_iter(match=settings.librechat_cache_key_pattern, count=100)` +
+  batched `unlink(*batch)`. Failure surfaces as
+  `redis-cache-invalidation: <exc>` in the response `errors` list (was
+  `redis-flushall: ...`); restart step still runs (REQ-2.5).
+  `app/services/provisioning/infrastructure.py::_flush_redis_and_restart_librechat`
+  follows the same SCAN+UNLINK shape on the sync redis client.
+- **`klai-portal/backend/app/api/taxonomy.py::_require_internal_token`**
+  (REQ-1.1) — now uses `log_utils.verify_shared_secret`. The previous
+  `if token != f"Bearer {settings.internal_secret}":` leaked
+  length/prefix timing.
+- **`klai-knowledge-mcp/main.py::save_to_docs`** (REQ-8) — return
+  contract changed from
+  `f"Error: klai-docs returned HTTP {resp.status_code}. Details: {resp.text[:300]}"`
+  to
+  `f"Error saving to docs: upstream returned HTTP {status}. Request ID: {uuid}. Operator: check VictoriaLogs."`.
+  The sanitised upstream body is logged server-side at the same
+  request_id so operators retain debuggability without leaking the
+  body to the chat UI.
+- **`klai-connector/app/services/sync_engine.py`** (REQ-10) — the
+  `enqueue_err.response.text[:500]` write into `sync_runs.error_details`
+  JSONB now passes through the connector's `sanitize_response_body`
+  wrapper first. A reflected `KNOWLEDGE_INGEST_SECRET` from upstream
+  cannot land in Postgres or in the portal connector-management UI.
+- **`klai-scribe/scribe-api/app/services/knowledge_adapter.py`** —
+  removed the `if settings.knowledge_ingest_secret:` silent-omit guard.
+  Header injection is now unconditional now that the Settings
+  validator enforces non-empty.
+- **`klai-scribe/scribe-api/Dockerfile`** — full rewrite to the
+  repo-root + `uv sync --frozen` pattern (mirrors knowledge-mcp /
+  connector / portal-api). The previous `uv pip install -r pyproject.toml`
+  flow did not honour `[tool.uv.sources]` so the `klai-log-utils`
+  path-dep silently fell through to a PyPI lookup.
+  `.github/workflows/scribe-api.yml` build context broadened to repo
+  root accordingly.
+- **REQ-4 sweep (~28 sites)** — every raw `exc.response.text` /
+  `resp.text[:N]` log call across portal-api / connector / scribe-api /
+  knowledge-mcp is rewritten through the per-service sanitizer
+  wrapper. Where SPEC-SEC-AUTH-COVERAGE-001 (#195) had already
+  replaced `logger.exception(...)` with structured `_slog.exception(...)`
+  + `_emit_auth_event(...)` (22 of the 24 auth.py sites), the merge
+  resolution kept main's structured-event approach — both achieve
+  REQ-4 and events are more thorough.
+
+### Tests
+
+- 29 in `klai-libs/log-utils/tests/`.
+- 11 new in portal-api (`tests/test_taxonomy_internal_token.py`,
+  `tests/test_proxy_header_injection.py`, 3 new fail-mode tests in
+  `tests/test_internal_hardening.py`, rewritten
+  `tests/test_librechat_regenerate.py` around the SCAN+UNLINK
+  contract — `redis_client.flushall.assert_not_called()` doubles as
+  a tripwire).
+- 12 in knowledge-mcp (`tests/test_sec_internal_001.py`) including
+  subprocess-based fail-closed boot tests and source-grep regression
+  guards.
+- 10 in connector (`tests/test_sec_internal_001.py`).
+- 8 in scribe-api (`tests/test_sec_internal_001.py`).
+
+### Deployed
+
+PR #201 merged 2026-04-29 07:47 UTC (admin override after CI green —
+required-review policy is in place but the PR was self-authored).
+Auto-deploy chain ran clean on all 5 services; container ages on
+core-01 are 1-3 minutes post-merge with zero error-level logs in the
+20-minute post-deploy window. `internal_rate_limit_fail_closed` count
+is zero (Redis healthy, defensive fail-closed path not exercised).
+
+---
+
 ## [Unreleased] — 2026-04-29 — SPEC-SEC-SESSION-001: session and cookie robustness
 
 Closes Cornelis 2026-04-22 audit findings #13 (TOTP per-instance counter),


### PR DESCRIPTION
## Summary

Documentation sync follow-through after [PR #201](https://github.com/GetKlai/klai/pull/201) merged 2026-04-29 07:47 UTC and auto-deployed to core-01.

- **CHANGELOG.md**: top-level `[Unreleased]` entry summarising the 7-batch implementation, the REQ-4 sweep, the merge-resolution choice on auth.py vs SPEC-SEC-AUTH-COVERAGE-001's structured events, and the test count.
- **SPEC-SEC-AUDIT-2026-04 tracker**: bumped to v0.7.0 with a HISTORY entry naming each batch and the new pitfalls. Live status flips INTERNAL-001 from `queued` to `shipped`. Implementation-rate counter is now 31 PRs in 6 days.
- **3 new pitfalls** in `.claude/rules/klai/pitfalls/process-rules.md`:
  - `astgrep-gitignore-shadowed-rules (HIGH)` — ast-grep silently respects `.gitignore` during rule discovery, so secret-hygiene patterns shadow rule filenames.
  - `uv-pip-install-skips-uv-sources (HIGH)` — `uv pip install -r pyproject.toml` does NOT read `[tool.uv.sources]`; Dockerfiles must use `uv sync --frozen` for path-deps.
  - `parallel-spec-on-overlapping-log-sites (MED)` — when two SPECs rewrite the same log call sites, take the more-thorough version on conflict resolution and coordinate scope BEFORE the next wide sweep.

## Test plan

- [x] CHANGELOG.md renders with two `[Unreleased]` blocks (INTERNAL-001 first, then SESSION-001 below it — same pattern as v0.6.0 / v0.5.0).
- [x] Tracker live-status table is consistent: 12 of 13 SPECs shipped after this PR; remaining estimate matches.
- [x] Pitfalls follow the existing `## name (severity)` + Symptom + Prevention shape.
- [x] CodeIndex memory: 4 entries saved (3 pitfalls + 1 pattern entry for the shared sanitizer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)