### PR TITLE
fix(grafana): shorten alert UIDs > 40 chars (Grafana down)

### DIFF
--- a/deploy/grafana/provisioning/alerting/portal-auth-rules.yaml
+++ b/deploy/grafana/provisioning/alerting/portal-auth-rules.yaml
@@ -45,7 +45,7 @@ groups:
       # Threshold: > 10 events in a 5-minute window (≈ > 2/min sustained).
       # Triage starts by grouping by event + reason to identify the failing
       # endpoint and root cause.
-      - uid: sec-auth-coverage-001-auth-failure-rate-high
+      - uid: sec-authcov-001-failure-rate-high
         title: auth_failure_rate_high
         condition: threshold
         data:
@@ -139,7 +139,7 @@ groups:
       # is normal); the cross-endpoint burst is what makes it operationally
       # significant.
       # Threshold: > 5 events in any 1m window.
-      - uid: sec-auth-coverage-001-auth-zitadel-5xx-burst
+      - uid: sec-authcov-001-zitadel-5xx-burst
         title: auth_zitadel_5xx_burst
         condition: threshold
         data:

--- a/deploy/grafana/provisioning/alerting/portal-mfa-rules.yaml
+++ b/deploy/grafana/provisioning/alerting/portal-mfa-rules.yaml
@@ -126,7 +126,7 @@ groups:
       # bypass attempt combined with a policy mis-configuration. Either is a
       # security investigation, not just availability.
       # SPEC-SEC-MFA-001 REQ-4.6.
-      - uid: sec-mfa-001-mfa-check-failed-fail-open-burst
+      - uid: sec-mfa-001-check-fail-open-burst
         title: mfa_check_failed_fail_open_burst
         condition: threshold
         data:


### PR DESCRIPTION
## Summary
- 🚨 Grafana on core-01 has been in CrashLoopBackOff since #203 merged. The reload triggered by the new alert file exposed 3 pre-existing UIDs that exceed Grafana's 40-char provisioning limit.
- This commit shortens the 3 over-limit UIDs (#198 + #181 origin). All UIDs introduced by the close-out PR (#203) are 38 chars and unchanged.

## Affected UIDs
| Old (chars) | New (chars) |
|---|---|
| `sec-auth-coverage-001-auth-failure-rate-high` (44) | `sec-authcov-001-failure-rate-high` (33) |
| `sec-auth-coverage-001-auth-zitadel-5xx-burst` (43) | `sec-authcov-001-zitadel-5xx-burst` (32) |
| `sec-mfa-001-mfa-check-failed-fail-open-burst` (44) | `sec-mfa-001-check-fail-open-burst` (33) |

## Root cause
Grafana validates UIDs at provisioning time. The previous file-set was loaded into the running container; subsequent yaml edits to `portal-auth-rules.yaml` / `portal-mfa-rules.yaml` would have surfaced the same error, but the files were stable until #203 added a sibling alert file that forced a config reload across the whole `alerting/` directory.

## Severity
- Grafana UI down ≈ 10 minutes (no dashboards, no alert firing).
- VictoriaLogs + Prometheus + Alloy unaffected — data still flowing in.
- Application services (portal-api, Caddy, Redis, etc.) unaffected.

## Test plan
- [ ] CI green (alerting-checks).
- [ ] After merge: Grafana container reaches `Up` state on core-01 within ~1 min.
- [ ] After merge: query an alert via Grafana API to verify UIDs are now accepted.

## Follow-up (out of scope)
- Add a CI lint that fails alerting-checks on UIDs > 40 chars (would have caught this pre-merge). File a thin SPEC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)