### PR TITLE
SPEC-SEC-TENANT-001 phase 3: klai-connector cross-tenant fix + portal X-Org-ID injection

### DIFF
--- a/klai-connector/alembic/versions/006_add_org_id_to_sync_runs.py
+++ b/klai-connector/alembic/versions/006_add_org_id_to_sync_runs.py
@@ -1,0 +1,89 @@
+"""Add org_id column to connector.sync_runs (tenant scoping).
+
+SPEC-SEC-TENANT-001 REQ-7.1 (v0.5.0): the ``connector.sync_runs`` table
+gains an ``org_id VARCHAR(255) NOT NULL`` column so that all sync-route
+handlers can filter on tenancy. The type matches ``Connector.org_id``
+(set by migration ``003_org_id_string``): the Zitadel resourceowner
+string.
+
+Backfill is intra-DB: every existing ``sync_runs`` row joins against
+its parent ``connector.connectors`` row (via ``connector_id``) and copies
+the org_id forward in a single SQL statement. No cross-DB script is
+required — the v0.4.0 SPEC HISTORY documents the simplification.
+
+Migration shape (single transaction):
+  1. Add ``org_id`` as nullable.
+  2. Backfill via ``UPDATE … FROM connector.connectors`` join.
+  3. ``ALTER … SET NOT NULL`` (commit point — fails loud if any row
+     lacks a parent connector).
+  4. Add index ``ix_sync_runs_org_id`` for the per-org filter on
+     ``trigger_sync`` / ``list_sync_runs`` / ``get_sync_run``.
+
+Orphans: a ``sync_runs`` row whose parent connector has been deleted
+from ``connector.connectors`` keeps ``org_id IS NULL`` after step 2 and
+trips the NOT NULL alter in step 3. Per the SPEC's Risks table the
+runbook deletes those rows BEFORE applying the migration:
+  ``DELETE FROM connector.sync_runs WHERE connector_id NOT IN
+   (SELECT id FROM connector.connectors)``.
+This is consistent with the SPEC-CONNECTOR-CLEANUP-001 REQ-04 follow-up
+(connector-delete cascade for sync_runs).
+
+Revision ID: 006_add_org_id_to_sync_runs
+Revises: 005_add_sync_run_quality_status
+Create Date: 2026-04-29
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "006_add_org_id_to_sync_runs"
+down_revision: str | None = "005_add_sync_run_quality_status"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # 1. Add nullable column so existing rows do not break the constraint.
+    op.add_column(
+        "sync_runs",
+        sa.Column("org_id", sa.String(255), nullable=True),
+        schema="connector",
+    )
+
+    # 2. Backfill from the sibling connector.connectors table. Intra-DB join;
+    #    no cross-DB script needed (v0.5.0 simplification — see SPEC HISTORY).
+    op.execute(
+        """
+        UPDATE connector.sync_runs r
+        SET org_id = c.org_id
+        FROM connector.connectors c
+        WHERE r.connector_id = c.id
+        """
+    )
+
+    # 3. Enforce NOT NULL. Any orphan sync_run (parent connector deleted upstream)
+    #    trips this; the runbook pre-step deletes orphans BEFORE the migration
+    #    runs. SPEC-SEC-TENANT-001 REQ-7.1 + Risks table.
+    op.alter_column(
+        "sync_runs",
+        "org_id",
+        nullable=False,
+        schema="connector",
+    )
+
+    # 4. Index for per-org filtering on the three sync-route handlers
+    #    (trigger_sync / list_sync_runs / get_sync_run).
+    op.create_index(
+        "ix_sync_runs_org_id",
+        "sync_runs",
+        ["org_id"],
+        schema="connector",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_sync_runs_org_id", table_name="sync_runs", schema="connector")
+    op.drop_column("sync_runs", "org_id", schema="connector")

--- a/klai-connector/alembic/versions/006_add_org_id_to_sync_runs.py
+++ b/klai-connector/alembic/versions/006_add_org_id_to_sync_runs.py
@@ -1,32 +1,24 @@
 """Add org_id column to connector.sync_runs (tenant scoping).
 
-SPEC-SEC-TENANT-001 REQ-7.1 (v0.5.0): the ``connector.sync_runs`` table
-gains an ``org_id VARCHAR(255) NOT NULL`` column so that all sync-route
-handlers can filter on tenancy. The type matches ``Connector.org_id``
-(set by migration ``003_org_id_string``): the Zitadel resourceowner
-string.
+SPEC-SEC-TENANT-001 REQ-7.1 (v0.5.1): the ``connector.sync_runs`` table
+gains an ``org_id VARCHAR(255)`` column so that all sync-route handlers
+can filter on tenancy. The type matches ``Connector.org_id`` (set by
+migration ``003_org_id_string``): the Zitadel resourceowner string.
 
-Backfill is intra-DB: every existing ``sync_runs`` row joins against
-its parent ``connector.connectors`` row (via ``connector_id``) and copies
-the org_id forward in a single SQL statement. No cross-DB script is
-required — the v0.4.0 SPEC HISTORY documents the simplification.
+No backfill. Historical rows that pre-date this migration keep
+``org_id IS NULL``. Per-org filters (``WHERE org_id = '<x>'``) do not
+match NULL rows, so pre-deploy sync history is invisible to any tenant
+after this migration. Acceptable because:
 
-Migration shape (single transaction):
-  1. Add ``org_id`` as nullable.
-  2. Backfill via ``UPDATE … FROM connector.connectors`` join.
-  3. ``ALTER … SET NOT NULL`` (commit point — fails loud if any row
-     lacks a parent connector).
-  4. Add index ``ix_sync_runs_org_id`` for the per-org filter on
-     ``trigger_sync`` / ``list_sync_runs`` / ``get_sync_run``.
+  (a) sync_runs is operational/audit data — no business state is lost;
+  (b) ``trigger_sync`` always populates org_id for new rows (handler
+      requires the ``X-Org-ID`` header — see REQ-7.4 + REQ-8.1);
+  (c) avoiding a backfill removes the cross-DB / orphan-cleanup
+      complexity that v0.4.0 / v0.5.0 carried, with no functional cost.
 
-Orphans: a ``sync_runs`` row whose parent connector has been deleted
-from ``connector.connectors`` keeps ``org_id IS NULL`` after step 2 and
-trips the NOT NULL alter in step 3. Per the SPEC's Risks table the
-runbook deletes those rows BEFORE applying the migration:
-  ``DELETE FROM connector.sync_runs WHERE connector_id NOT IN
-   (SELECT id FROM connector.connectors)``.
-This is consistent with the SPEC-CONNECTOR-CLEANUP-001 REQ-04 follow-up
-(connector-delete cascade for sync_runs).
+The column stays nullable for historical rows. A future SPEC may flip
+it to ``NOT NULL`` once those rows have aged out (sync_runs are
+regularly truncated by retention policy) or are deliberately deleted.
 
 Revision ID: 006_add_org_id_to_sync_runs
 Revises: 005_add_sync_run_quality_status
@@ -46,36 +38,11 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    # 1. Add nullable column so existing rows do not break the constraint.
     op.add_column(
         "sync_runs",
         sa.Column("org_id", sa.String(255), nullable=True),
         schema="connector",
     )
-
-    # 2. Backfill from the sibling connector.connectors table. Intra-DB join;
-    #    no cross-DB script needed (v0.5.0 simplification — see SPEC HISTORY).
-    op.execute(
-        """
-        UPDATE connector.sync_runs r
-        SET org_id = c.org_id
-        FROM connector.connectors c
-        WHERE r.connector_id = c.id
-        """
-    )
-
-    # 3. Enforce NOT NULL. Any orphan sync_run (parent connector deleted upstream)
-    #    trips this; the runbook pre-step deletes orphans BEFORE the migration
-    #    runs. SPEC-SEC-TENANT-001 REQ-7.1 + Risks table.
-    op.alter_column(
-        "sync_runs",
-        "org_id",
-        nullable=False,
-        schema="connector",
-    )
-
-    # 4. Index for per-org filtering on the three sync-route handlers
-    #    (trigger_sync / list_sync_runs / get_sync_run).
     op.create_index(
         "ix_sync_runs_org_id",
         "sync_runs",

--- a/klai-connector/app/core/config.py
+++ b/klai-connector/app/core/config.py
@@ -53,6 +53,17 @@ class Settings(BaseSettings):
     portal_internal_secret: str = ""
     portal_caller_secret: str = ""  # Secret portal sends TO klai-connector (must match portal's KLAI_CONNECTOR_SECRET)
 
+    # SPEC-SEC-TENANT-001 REQ-7.6 (v0.5.0): transition-period flag for the
+    # X-Org-ID header that portal-side REQ-8.1 starts injecting. When False
+    # (default during deploy), missing headers degrade to a WARN log
+    # ``event="sync_missing_org_id"`` and the route proceeds without org
+    # scoping (backward-compatible). When flipped to True (after the portal
+    # deploy lands and VictoriaLogs shows zero ``sync_missing_org_id`` events
+    # for the agreed dwell time), missing headers return HTTP 400. Set via
+    # SOPS env (``SYNC_REQUIRE_ORG_ID=true``) once the portal-side rollout
+    # has soaked. See SPEC REQ-8.5 for the deploy-order runbook.
+    sync_require_org_id: bool = False
+
     # Google Drive OAuth (SPEC-KB-025)
     google_drive_client_id: str = ""  # empty = connector disabled
     google_drive_client_secret: str = ""

--- a/klai-connector/app/models/sync_run.py
+++ b/klai-connector/app/models/sync_run.py
@@ -20,6 +20,11 @@ class SyncRun(Base):
     Columns:
         id: UUID primary key
         connector_id: UUID — portal_connectors.id (no FK; portal is source of truth)
+        org_id: VARCHAR(255) — Zitadel resourceowner; tenant scope for sync routes
+            (SPEC-SEC-TENANT-001 REQ-7.2). Same shape and source of truth as
+            ``Connector.org_id``: the value the portal asserts in the
+            ``X-Org-ID`` header on every sync proxy call. No FK; portal is
+            source of truth (consistent with ``connector_id``).
         status: VARCHAR(20) -- 'running', 'completed', 'failed', 'auth_error', 'pending'
         started_at: TIMESTAMPTZ
         completed_at: TIMESTAMPTZ
@@ -43,6 +48,9 @@ class SyncRun(Base):
         index=True,
         # No ForeignKey — connector_id is a portal UUID, portal is source of truth.
     )
+    # SPEC-SEC-TENANT-001 REQ-7.2 (v0.5.0 / Zitadel-resourceowner string).
+    # Backfilled in migration 006 from ``connector.connectors.org_id``.
+    org_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
     status: Mapped[str] = mapped_column(String(20), nullable=False)
     started_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=func.now())
     completed_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True), nullable=True)

--- a/klai-connector/app/models/sync_run.py
+++ b/klai-connector/app/models/sync_run.py
@@ -25,6 +25,12 @@ class SyncRun(Base):
             ``Connector.org_id``: the value the portal asserts in the
             ``X-Org-ID`` header on every sync proxy call. No FK; portal is
             source of truth (consistent with ``connector_id``).
+
+            Nullable: historical rows (pre-migration 006) keep NULL —
+            no backfill is performed. Those rows fall outside per-org
+            filters and are invisible to all tenants. New rows always
+            populate org_id because ``trigger_sync`` requires the
+            ``X-Org-ID`` header (REQ-7.4).
         status: VARCHAR(20) -- 'running', 'completed', 'failed', 'auth_error', 'pending'
         started_at: TIMESTAMPTZ
         completed_at: TIMESTAMPTZ
@@ -48,9 +54,12 @@ class SyncRun(Base):
         index=True,
         # No ForeignKey — connector_id is a portal UUID, portal is source of truth.
     )
-    # SPEC-SEC-TENANT-001 REQ-7.2 (v0.5.0 / Zitadel-resourceowner string).
-    # Backfilled in migration 006 from ``connector.connectors.org_id``.
-    org_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    # SPEC-SEC-TENANT-001 REQ-7.2 (v0.5.1 / Zitadel-resourceowner string).
+    # Nullable: no backfill on migration 006 — historical rows keep NULL and
+    # are invisible to per-org filters. trigger_sync requires X-Org-ID for
+    # every new row (REQ-7.4), so the column is effectively NOT NULL on the
+    # write path.
+    org_id: Mapped[str | None] = mapped_column(String(255), nullable=True, index=True)
     status: Mapped[str] = mapped_column(String(20), nullable=False)
     started_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=func.now())
     completed_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True), nullable=True)

--- a/klai-connector/app/routes/sync.py
+++ b/klai-connector/app/routes/sync.py
@@ -6,10 +6,12 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import Settings
 from app.core.database import get_session
 from app.core.enums import SyncStatus
 from app.core.logging import get_logger
 from app.models.sync_run import SyncRun
+from app.routes.deps import get_settings
 from app.schemas.sync import SyncRunResponse
 
 logger = get_logger(__name__)
@@ -27,12 +29,51 @@ def _require_portal_call(request: Request) -> None:
         raise HTTPException(status_code=403, detail="Portal service token required")
 
 
+def _require_portal_org_id(request: Request, settings: Settings) -> str | None:
+    """Read ``X-Org-ID`` from the portal-asserted header.
+
+    SPEC-SEC-TENANT-001 REQ-7.3 / REQ-7.6 (v0.5.0):
+
+    - The header value is the Zitadel resourceowner string. The connector
+      trusts it because :func:`_require_portal_call` already proved the
+      caller holds ``PORTAL_CALLER_SECRET``.
+    - During the transition period (``settings.sync_require_org_id=False``):
+      a missing header logs ``event="sync_missing_org_id"`` at WARN and
+      returns ``None``. Handlers MUST treat ``None`` as
+      "skip org scoping" (backward-compat with the pre-REQ-7 portal).
+    - Once flipped to True (post portal-side REQ-8.1 deploy + dwell, see
+      REQ-8.5 deploy runbook): a missing header raises HTTP 400.
+
+    Empty values are treated identically to absent — no caller should
+    ever send ``X-Org-ID:`` with no value, and accepting it would defeat
+    the WARN signal.
+    """
+    raw = request.headers.get("x-org-id")
+    org_id = raw.strip() if raw else ""
+    if org_id:
+        return org_id
+
+    connector_id = request.path_params.get("connector_id")
+    logger.warning(
+        "sync_missing_org_id",
+        extra={
+            "event": "sync_missing_org_id",
+            "connector_id": str(connector_id) if connector_id else None,
+            "path": request.url.path,
+        },
+    )
+    if settings.sync_require_org_id:
+        raise HTTPException(status_code=400, detail="X-Org-ID header required")
+    return None
+
+
 @router.post("/connectors/{connector_id}/sync", status_code=202, response_model=SyncRunResponse)
 async def trigger_sync(
     connector_id: uuid.UUID,
     request: Request,
     background_tasks: BackgroundTasks,
     session: AsyncSession = Depends(get_session),
+    settings: Settings = Depends(get_settings),
 ) -> SyncRun:
     """Trigger an on-demand sync for a connector.
 
@@ -42,27 +83,47 @@ async def trigger_sync(
     Returns 409 if a sync is already in progress for this connector.
     """
     _require_portal_call(request)
+    org_id = _require_portal_org_id(request, settings)
 
-    # Check for active sync (in-DB guard; the in-memory lock is an additional layer).
-    active_run_result = await session.execute(
-        select(SyncRun).where(
-            SyncRun.connector_id == connector_id,
-            SyncRun.status == SyncStatus.RUNNING,
-        )
+    # Active-sync guard. SPEC-SEC-TENANT-001 REQ-7.4: when org_id is
+    # asserted, scope the guard so one tenant's running sync cannot block
+    # another tenant's trigger attempt for the same connector_id (which
+    # cannot legitimately happen — connector_id is per-tenant on the portal
+    # side — but the scoping makes the guard's intent explicit and is a
+    # belt-and-braces measure for the REQ-7 trust contract).
+    active_run_query = select(SyncRun).where(
+        SyncRun.connector_id == connector_id,
+        SyncRun.status == SyncStatus.RUNNING,
     )
+    if org_id is not None:
+        active_run_query = active_run_query.where(SyncRun.org_id == org_id)
+    active_run_result = await session.execute(active_run_query)
     if active_run_result.scalars().first() is not None:
         raise HTTPException(status_code=409, detail="Sync already running for this connector")
 
-    # Create sync run record.
+    if org_id is None:
+        # Transition-period legacy path: portal has not yet rolled out REQ-8.1
+        # X-Org-ID injection. Reject the trigger because we cannot persist a
+        # NOT NULL org_id on the new SyncRun row. (See REQ-7.6: only reads
+        # degrade gracefully; writes require the header.) The WARN was
+        # already emitted by _require_portal_org_id; surface a 400 even when
+        # sync_require_org_id=False so the caller knows the trigger failed
+        # for a deterministic reason rather than silently 500-ing on the
+        # NOT NULL constraint.
+        raise HTTPException(
+            status_code=400,
+            detail="X-Org-ID header required to create a sync run",
+        )
+
     sync_run = SyncRun(
         connector_id=connector_id,
+        org_id=org_id,
         status=SyncStatus.RUNNING,
     )
     session.add(sync_run)
     await session.commit()
     await session.refresh(sync_run)
 
-    # Schedule background sync.
     sync_engine = getattr(request.app.state, "sync_engine", None)
     if sync_engine:
         background_tasks.add_task(sync_engine.run_sync, connector_id, sync_run.id)
@@ -70,7 +131,11 @@ async def trigger_sync(
     logger.info(
         "Sync triggered for connector %s",
         connector_id,
-        extra={"connector_id": str(connector_id), "sync_run_id": str(sync_run.id)},
+        extra={
+            "connector_id": str(connector_id),
+            "sync_run_id": str(sync_run.id),
+            "org_id": org_id,
+        },
     )
     return sync_run
 
@@ -81,19 +146,29 @@ async def list_sync_runs(
     request: Request,
     limit: int = 20,
     session: AsyncSession = Depends(get_session),
+    settings: Settings = Depends(get_settings),
 ) -> list[SyncRun]:
     """List sync history for a connector (most recent first).
 
     Called by the portal control plane to retrieve sync history for the UI.
+
+    SPEC-SEC-TENANT-001 REQ-7.3: filtered on ``X-Org-ID`` when the header
+    is present. During the transition period (REQ-7.6) a missing header
+    falls back to legacy connector_id-only filtering with a WARN event.
     """
     _require_portal_call(request)
+    org_id = _require_portal_org_id(request, settings)
 
-    result = await session.execute(
+    query = (
         select(SyncRun)
         .where(SyncRun.connector_id == connector_id)
         .order_by(SyncRun.started_at.desc())
         .limit(min(limit, 100))
     )
+    if org_id is not None:
+        query = query.where(SyncRun.org_id == org_id)
+
+    result = await session.execute(query)
     return list(result.scalars().all())
 
 
@@ -103,12 +178,24 @@ async def get_sync_run(
     run_id: uuid.UUID,
     request: Request,
     session: AsyncSession = Depends(get_session),
+    settings: Settings = Depends(get_settings),
 ) -> SyncRun:
-    """Get details of a specific sync run."""
+    """Get details of a specific sync run.
+
+    SPEC-SEC-TENANT-001 REQ-7.3 / REQ-7.5: filters on org_id when
+    asserted. A run that exists but belongs to a different tenant
+    returns 404 — never 403 — to avoid leaking existence
+    (``portal-security.md`` "never leak existence").
+    """
     _require_portal_call(request)
+    org_id = _require_portal_org_id(request, settings)
 
     sync_run = await session.get(SyncRun, run_id)
     if sync_run is None or sync_run.connector_id != connector_id:
+        raise HTTPException(status_code=404, detail="Sync run not found")
+
+    # REQ-7.5: cross-tenant run -> 404, not 403.
+    if org_id is not None and sync_run.org_id != org_id:
         raise HTTPException(status_code=404, detail="Sync run not found")
 
     return sync_run

--- a/klai-connector/app/routes/sync.py
+++ b/klai-connector/app/routes/sync.py
@@ -102,14 +102,15 @@ async def trigger_sync(
         raise HTTPException(status_code=409, detail="Sync already running for this connector")
 
     if org_id is None:
-        # Transition-period legacy path: portal has not yet rolled out REQ-8.1
-        # X-Org-ID injection. Reject the trigger because we cannot persist a
-        # NOT NULL org_id on the new SyncRun row. (See REQ-7.6: only reads
-        # degrade gracefully; writes require the header.) The WARN was
-        # already emitted by _require_portal_org_id; surface a 400 even when
-        # sync_require_org_id=False so the caller knows the trigger failed
-        # for a deterministic reason rather than silently 500-ing on the
-        # NOT NULL constraint.
+        # SPEC-SEC-TENANT-001 v0.5.1: ``trigger_sync`` rejects missing
+        # X-Org-ID even during the transition period. Persisting a row
+        # without org_id is technically possible (the column is nullable
+        # post-migration 006), but a row that is invisible to every
+        # tenant's per-org filter is effectively orphaned at creation
+        # time — never queryable, never associated with a triggering
+        # caller. Fail-fast at the handler with a deterministic 400
+        # rather than create operational debris. The WARN event was
+        # already emitted by ``_require_portal_org_id``.
         raise HTTPException(
             status_code=400,
             detail="X-Org-ID header required to create a sync run",

--- a/klai-connector/tests/test_sync_routes_org_scoping.py
+++ b/klai-connector/tests/test_sync_routes_org_scoping.py
@@ -1,0 +1,263 @@
+"""SPEC-SEC-TENANT-001 A-6 + A-8 — sync-route org scoping (v0.5.0 / β).
+
+Coverage:
+- A-6: cross-tenant ``GET /syncs/{run_id}`` returns 404, never 200/403.
+- A-8 case 8.a: missing ``X-Org-ID`` during transition (flag OFF) on a
+  read endpoint logs ``event="sync_missing_org_id"`` and returns 200
+  with legacy connector_id-only filter.
+- A-8 case 8.b: missing ``X-Org-ID`` after transition (flag ON) returns
+  HTTP 400 with ``{"detail": "X-Org-ID header required"}``.
+
+Test design follows the FakeSession pattern from
+``test_connector_routes_not_found.py`` — no real Postgres, no real
+Redis. ``_require_portal_call`` is monkey-patched to a no-op so the
+test does not need to thread the portal-secret through the auth
+middleware (that path is covered by ``test_auth_middleware_*.py``).
+
+Implementation note: ``trigger_sync`` rejects missing-X-Org-ID at HTTP
+400 even when ``sync_require_org_id=False`` because the new SyncRun
+row carries a ``NOT NULL org_id`` column — the v0.5.0 v0.5.0
+implementation (this commit) makes that fail-fast deterministic
+instead of letting it 500 inside SQLAlchemy. The transition-period
+graceful degradation in REQ-7.6 therefore applies to READ endpoints
+only, which the tests below pin.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core.database import get_session
+from app.core.enums import SyncStatus
+from app.models.sync_run import SyncRun
+from app.routes.deps import get_settings
+from app.routes.sync import router as sync_router
+
+_CONN_A = uuid.UUID("11111111-1111-1111-1111-111111111111")
+_CONN_B = uuid.UUID("22222222-2222-2222-2222-222222222222")
+_RUN_B = uuid.UUID("33333333-3333-3333-3333-333333333333")
+_ORG_A = "org-a-resourceowner"
+_ORG_B = "org-b-resourceowner"
+
+
+class _FakeScalarResult:
+    def __init__(self, items: list[Any]) -> None:
+        self._items = items
+
+    def first(self) -> Any:
+        return self._items[0] if self._items else None
+
+    def all(self) -> list[Any]:
+        return list(self._items)
+
+
+class _FakeExecuteResult:
+    def __init__(self, items: list[Any]) -> None:
+        self._items = items
+
+    def scalars(self) -> _FakeScalarResult:
+        return _FakeScalarResult(self._items)
+
+
+class _FakeSession:
+    """Minimal AsyncSession stub for the three sync handlers.
+
+    ``run_by_id`` -> what ``session.get(SyncRun, run_id)`` returns.
+    ``rows`` -> what ``session.execute(...).scalars().all/first()`` returns.
+    """
+
+    def __init__(self, *, rows: list[SyncRun] | None = None, run_by_id: SyncRun | None = None) -> None:
+        self._rows = rows or []
+        self._run_by_id = run_by_id
+
+    async def execute(self, _stmt: Any) -> _FakeExecuteResult:
+        return _FakeExecuteResult(self._rows)
+
+    async def get(self, _model: type, _key: uuid.UUID) -> SyncRun | None:
+        return self._run_by_id
+
+    async def commit(self) -> None:  # pragma: no cover
+        return None
+
+    async def refresh(self, _obj: Any) -> None:  # pragma: no cover
+        return None
+
+    def add(self, _obj: Any) -> None:  # pragma: no cover
+        return None
+
+
+def _build_client(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    session: _FakeSession,
+    sync_require_org_id: bool = False,
+) -> TestClient:
+    app = FastAPI()
+    app.include_router(sync_router, prefix="/api/v1")
+
+    async def _override_get_session() -> AsyncIterator[_FakeSession]:
+        yield session
+
+    app.dependency_overrides[get_session] = _override_get_session
+    app.dependency_overrides[get_settings] = lambda: SimpleNamespace(
+        sync_require_org_id=sync_require_org_id,
+    )
+
+    # Bypass the portal-secret check: the auth-middleware tests cover that
+    # path. Here we exercise org-scoping behaviour assuming the request has
+    # already been authenticated as a portal call.
+    def _noop_portal_call(_request: Any) -> None:
+        return None
+
+    monkeypatch.setattr("app.routes.sync._require_portal_call", _noop_portal_call)
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _make_run(*, run_id: uuid.UUID, connector_id: uuid.UUID, org_id: str) -> SyncRun:
+    return SyncRun(
+        id=run_id,
+        connector_id=connector_id,
+        org_id=org_id,
+        status=SyncStatus.COMPLETED,
+        # started_at has server_default=func.now() but the FakeSession path
+        # never hits the DB; populate it client-side so SyncRunResponse
+        # validation succeeds on the way out.
+        started_at=datetime.now(UTC),
+        documents_total=0,
+        documents_ok=0,
+        documents_failed=0,
+        bytes_processed=0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# A-6 — cross-tenant fetch returns 404
+# ---------------------------------------------------------------------------
+
+
+def test_get_sync_run_cross_tenant_returns_404(monkeypatch: pytest.MonkeyPatch) -> None:
+    """REQ-7.3 / REQ-7.5: run belongs to org B, caller asserts org A → 404."""
+    run_b = _make_run(run_id=_RUN_B, connector_id=_CONN_B, org_id=_ORG_B)
+    client = _build_client(monkeypatch, session=_FakeSession(run_by_id=run_b))
+
+    resp = client.get(
+        f"/api/v1/connectors/{_CONN_B}/syncs/{_RUN_B}",
+        headers={"X-Org-ID": _ORG_A},
+    )
+
+    assert resp.status_code == 404, f"REQ-7.5 cross-tenant fetch must return 404, got {resp.status_code}: {resp.text}"
+    assert resp.json() == {"detail": "Sync run not found"}
+
+
+def test_get_sync_run_same_tenant_returns_200(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Positive control: caller asserts the right org → 200."""
+    run_b = _make_run(run_id=_RUN_B, connector_id=_CONN_B, org_id=_ORG_B)
+    client = _build_client(monkeypatch, session=_FakeSession(run_by_id=run_b))
+
+    resp = client.get(
+        f"/api/v1/connectors/{_CONN_B}/syncs/{_RUN_B}",
+        headers={"X-Org-ID": _ORG_B},
+    )
+
+    assert resp.status_code == 200, f"same-tenant fetch must return 200, got {resp.status_code}: {resp.text}"
+    assert resp.json()["id"] == str(_RUN_B)
+
+
+def test_list_sync_runs_filters_by_org_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """REQ-7.3: list endpoint filters on org_id when header is present.
+
+    The FakeSession returns whatever rows we give it regardless of the
+    SQL clause, so this test asserts the call shape (200 with rows for
+    the asserting org). The real org_id filter is exercised by A-7
+    integration tests at deploy-time; here we pin that the route
+    accepts the header and the rows are returned to the caller.
+    """
+    rows = [
+        _make_run(run_id=uuid.uuid4(), connector_id=_CONN_B, org_id=_ORG_B),
+    ]
+    client = _build_client(monkeypatch, session=_FakeSession(rows=rows))
+
+    resp = client.get(
+        f"/api/v1/connectors/{_CONN_B}/syncs",
+        headers={"X-Org-ID": _ORG_B},
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert len(resp.json()) == 1
+
+
+# ---------------------------------------------------------------------------
+# A-8 — transition flag behaviour (REQ-7.6 + REQ-8.5)
+# ---------------------------------------------------------------------------
+
+
+def test_list_sync_runs_missing_org_id_transition_off_returns_200(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Case 8.a: flag OFF, missing header → 200 with legacy filter + WARN."""
+    rows = [
+        _make_run(run_id=uuid.uuid4(), connector_id=_CONN_A, org_id=_ORG_A),
+    ]
+    client = _build_client(
+        monkeypatch,
+        session=_FakeSession(rows=rows),
+        sync_require_org_id=False,
+    )
+
+    resp = client.get(f"/api/v1/connectors/{_CONN_A}/syncs")
+
+    assert resp.status_code == 200, (
+        f"REQ-7.6 transition-period read must succeed without X-Org-ID, got {resp.status_code}: {resp.text}"
+    )
+
+
+def test_list_sync_runs_missing_org_id_transition_on_returns_400(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Case 8.b: flag ON, missing header → 400 ``X-Org-ID header required``."""
+    client = _build_client(
+        monkeypatch,
+        session=_FakeSession(rows=[]),
+        sync_require_org_id=True,
+    )
+
+    resp = client.get(f"/api/v1/connectors/{_CONN_A}/syncs")
+
+    assert resp.status_code == 400, (
+        f"REQ-7.6 post-transition read must reject without X-Org-ID, got {resp.status_code}: {resp.text}"
+    )
+    assert resp.json() == {"detail": "X-Org-ID header required"}
+
+
+def test_trigger_sync_missing_org_id_returns_400_regardless_of_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """REQ-7.4 + v0.5.0 implementation: trigger requires X-Org-ID always.
+
+    The new SyncRun row carries a NOT NULL org_id column (REQ-7.1), so
+    the trigger handler cannot create a row without the header. Rather
+    than let SQLAlchemy 500 on the constraint violation, the handler
+    returns a deterministic 400 — the same shape REQ-7.6 mandates for
+    reads after the transition closes. This ensures fail-fast even when
+    sync_require_org_id is still False.
+    """
+    client = _build_client(
+        monkeypatch,
+        session=_FakeSession(rows=[]),
+        sync_require_org_id=False,
+    )
+
+    resp = client.post(f"/api/v1/connectors/{_CONN_A}/sync")
+
+    assert resp.status_code == 400, (
+        f"trigger_sync without X-Org-ID must 400 (cannot create NOT NULL row), got {resp.status_code}: {resp.text}"
+    )

--- a/klai-connector/tests/test_sync_routes_org_scoping.py
+++ b/klai-connector/tests/test_sync_routes_org_scoping.py
@@ -14,13 +14,13 @@ Redis. ``_require_portal_call`` is monkey-patched to a no-op so the
 test does not need to thread the portal-secret through the auth
 middleware (that path is covered by ``test_auth_middleware_*.py``).
 
-Implementation note: ``trigger_sync`` rejects missing-X-Org-ID at HTTP
-400 even when ``sync_require_org_id=False`` because the new SyncRun
-row carries a ``NOT NULL org_id`` column — the v0.5.0 v0.5.0
-implementation (this commit) makes that fail-fast deterministic
-instead of letting it 500 inside SQLAlchemy. The transition-period
-graceful degradation in REQ-7.6 therefore applies to READ endpoints
-only, which the tests below pin.
+Implementation note (v0.5.1): ``trigger_sync`` rejects missing-X-Org-ID
+at HTTP 400 even when ``sync_require_org_id=False``. The column itself
+is nullable post-migration 006 (no backfill — historical rows keep
+NULL), but persisting a NEW row with org_id=NULL would create an
+orphan invisible to every tenant's per-org filter. Fail-fast at the
+handler keeps the new-row contract clean. Transition-period graceful
+degradation in REQ-7.6 therefore applies to READ endpoints only.
 """
 
 from __future__ import annotations
@@ -241,13 +241,15 @@ def test_list_sync_runs_missing_org_id_transition_on_returns_400(
 def test_trigger_sync_missing_org_id_returns_400_regardless_of_flag(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """REQ-7.4 + v0.5.0 implementation: trigger requires X-Org-ID always.
+    """REQ-7.4 / v0.5.1: trigger requires X-Org-ID always.
 
-    The new SyncRun row carries a NOT NULL org_id column (REQ-7.1), so
-    the trigger handler cannot create a row without the header. Rather
-    than let SQLAlchemy 500 on the constraint violation, the handler
-    returns a deterministic 400 — the same shape REQ-7.6 mandates for
-    reads after the transition closes. This ensures fail-fast even when
+    Migration 006 made org_id nullable (no backfill — historical rows
+    keep NULL), so a new SyncRun with org_id=NULL would technically
+    succeed at the schema layer. But such a row is invisible to every
+    tenant's per-org filter and effectively orphaned at creation time.
+    The handler fail-fasts with a deterministic 400 to keep the new-row
+    contract clean — same shape REQ-7.6 mandates for reads after the
+    transition closes. This ensures fail-fast even when
     sync_require_org_id is still False.
     """
     client = _build_client(

--- a/klai-connector/tests/test_sync_run_model.py
+++ b/klai-connector/tests/test_sync_run_model.py
@@ -21,18 +21,27 @@ from app.models.sync_run import SyncRun
 
 
 def test_sync_run_model_declares_org_id_column() -> None:
-    """REQ-7.2: org_id is a VARCHAR(255), NOT NULL, indexed."""
+    """REQ-7.2 (v0.5.1): org_id is a VARCHAR(255), nullable, indexed.
+
+    Nullable because migration 006 does NOT backfill historical rows —
+    those keep NULL and fall outside per-org filters. trigger_sync
+    requires X-Org-ID for every new row (REQ-7.4), so the column is
+    effectively NOT NULL on the write path even though the schema
+    constraint is relaxed.
+    """
     column = SyncRun.__table__.c.org_id
 
     assert isinstance(column.type, String), (
-        f"REQ-7.2 (v0.5.0): SyncRun.org_id must be String, got {type(column.type).__name__}. "
-        "Type was reconciled from int to Zitadel-resourceowner string in v0.5.0 to match "
-        "Connector.org_id (migration 003_org_id_string) and PortalOrg.zitadel_org_id."
+        f"REQ-7.2: SyncRun.org_id must be String, got {type(column.type).__name__}. "
+        "Type matches Connector.org_id (migration 003_org_id_string) and PortalOrg.zitadel_org_id."
     )
     assert column.type.length == 255, (
         f"REQ-7.2: SyncRun.org_id length must be 255 to match Connector.org_id, got {column.type.length}."
     )
-    assert column.nullable is False, "REQ-7.1: SyncRun.org_id must be NOT NULL."
+    assert column.nullable is True, (
+        "REQ-7.1 (v0.5.1): SyncRun.org_id is nullable. Historical rows keep NULL "
+        "(no backfill); new rows populated by trigger_sync via X-Org-ID."
+    )
     assert column.index is True, "REQ-7.2: SyncRun.org_id must be indexed."
 
 

--- a/klai-connector/tests/test_sync_run_model.py
+++ b/klai-connector/tests/test_sync_run_model.py
@@ -1,0 +1,51 @@
+"""SPEC-SEC-TENANT-001 A-5 — SyncRun.org_id schema contract.
+
+Pure SQLAlchemy reflection tests; no DB connection needed. Verify that
+the model declares the column with the v0.5.0 / β shape:
+    org_id: VARCHAR(255), NOT NULL, indexed.
+
+The corresponding migration (``006_add_org_id_to_sync_runs``) creates
+the underlying database column with the matching definition; the model
+↔ schema parity is enforced by Alembic autogenerate at deploy time, but
+this test pins the model side independently.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import String
+
+from app.core.enums import SyncStatus
+from app.models.sync_run import SyncRun
+
+
+def test_sync_run_model_declares_org_id_column() -> None:
+    """REQ-7.2: org_id is a VARCHAR(255), NOT NULL, indexed."""
+    column = SyncRun.__table__.c.org_id
+
+    assert isinstance(column.type, String), (
+        f"REQ-7.2 (v0.5.0): SyncRun.org_id must be String, got {type(column.type).__name__}. "
+        "Type was reconciled from int to Zitadel-resourceowner string in v0.5.0 to match "
+        "Connector.org_id (migration 003_org_id_string) and PortalOrg.zitadel_org_id."
+    )
+    assert column.type.length == 255, (
+        f"REQ-7.2: SyncRun.org_id length must be 255 to match Connector.org_id, got {column.type.length}."
+    )
+    assert column.nullable is False, "REQ-7.1: SyncRun.org_id must be NOT NULL."
+    assert column.index is True, "REQ-7.2: SyncRun.org_id must be indexed."
+
+
+def test_sync_run_instance_accepts_org_id_kwarg() -> None:
+    """REQ-7.2: SyncRun(...) constructor accepts org_id as kwarg.
+
+    Pre-fix this test would raise ``TypeError: 'org_id' is an invalid
+    keyword argument for SyncRun`` — proving the regression guard fired
+    against any future revert that drops the column from the model.
+    """
+    run = SyncRun(
+        connector_id=uuid.uuid4(),
+        org_id="org-a-resourceowner",
+        status=SyncStatus.RUNNING,
+    )
+    assert run.org_id == "org-a-resourceowner"

--- a/klai-portal/backend/app/api/connectors.py
+++ b/klai-portal/backend/app/api/connectors.py
@@ -576,7 +576,14 @@ async def trigger_sync(
     await assert_can_add_item_to_kb(kb=kb, org=org)
 
     try:
-        sync_run = await klai_connector_client.trigger_sync(connector_id)
+        # SPEC-SEC-TENANT-001 REQ-8.2: pass the authenticated session's
+        # Zitadel resourceowner as X-Org-ID so the connector can filter
+        # the sync run by tenancy. Source MUST be PortalOrg.zitadel_org_id
+        # — never a body field, never a query-string parameter.
+        sync_run = await klai_connector_client.trigger_sync(
+            connector_id,
+            org_id=org.zitadel_org_id,
+        )
     except httpx.HTTPStatusError as exc:
         if exc.response.status_code == status.HTTP_409_CONFLICT:
             raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Sync already running") from exc
@@ -622,7 +629,12 @@ async def list_sync_runs(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Connector not found")
 
     try:
-        return await klai_connector_client.get_sync_runs(connector_id, limit=limit)
+        # SPEC-SEC-TENANT-001 REQ-8.2: org_id sourced from PortalOrg.zitadel_org_id.
+        return await klai_connector_client.get_sync_runs(
+            connector_id,
+            org_id=org.zitadel_org_id,
+            limit=limit,
+        )
     except httpx.HTTPError as exc:
         logger.exception("Failed to reach klai-connector for sync history of %s", connector_id)
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Sync service unavailable") from exc

--- a/klai-portal/backend/app/services/klai_connector_client.py
+++ b/klai-portal/backend/app/services/klai_connector_client.py
@@ -39,11 +39,39 @@ class KlaiConnectorClient:
     Raises httpx.HTTPStatusError on 4xx/5xx responses.
     """
 
-    def _headers(self) -> dict[str, str]:
-        return {"Authorization": f"Bearer {settings.klai_connector_secret}", **get_trace_headers()}
+    def _headers(self, *, org_id: str | None = None) -> dict[str, str]:
+        """Build outbound headers for a klai-connector call.
 
-    async def trigger_sync(self, connector_id: str) -> SyncRunData:
+        SPEC-SEC-TENANT-001 REQ-8.1 / REQ-8.3 (v0.5.0): when ``org_id`` is
+        provided (the Zitadel resourceowner string from
+        ``PortalOrg.zitadel_org_id``), include it as ``X-Org-ID`` so the
+        connector can filter sync routes by tenancy. The portal-caller
+        bearer + trace headers continue to authenticate the channel and
+        propagate request-id correlation.
+
+        ``org_id=None`` is reserved for callsites that do NOT hit a
+        sync-route endpoint (e.g. ``compute_fingerprint``); those continue
+        to send no ``X-Org-ID`` because the connector does not require
+        tenancy on those paths.
+        """
+        headers: dict[str, str] = {
+            "Authorization": f"Bearer {settings.klai_connector_secret}",
+            **get_trace_headers(),
+        }
+        if org_id is not None:
+            headers["X-Org-ID"] = org_id
+        return headers
+
+    async def trigger_sync(self, connector_id: str, *, org_id: str) -> SyncRunData:
         """Trigger an on-demand sync. Returns the created SyncRun (status: running).
+
+        Args:
+            connector_id: Portal connector UUID.
+            org_id: Zitadel resourceowner string (PortalOrg.zitadel_org_id);
+                injected as ``X-Org-ID`` on the outbound request so the
+                connector can filter the sync-runs query by tenancy
+                (SPEC-SEC-TENANT-001 REQ-8.1, keyword-only to make the
+                requirement self-documenting at every callsite).
 
         Raises:
             httpx.HTTPStatusError: On 4xx/5xx from klai-connector.
@@ -51,13 +79,24 @@ class KlaiConnectorClient:
         async with httpx.AsyncClient(timeout=15.0) as client:
             response = await client.post(
                 f"{settings.klai_connector_url}/api/v1/connectors/{connector_id}/sync",
-                headers=self._headers(),
+                headers=self._headers(org_id=org_id),
             )
             response.raise_for_status()
             return SyncRunData(**response.json())
 
-    async def get_sync_runs(self, connector_id: str, limit: int = 20) -> list[SyncRunData]:
+    async def get_sync_runs(
+        self,
+        connector_id: str,
+        *,
+        org_id: str,
+        limit: int = 20,
+    ) -> list[SyncRunData]:
         """Fetch sync history for a connector from klai-connector.
+
+        Args:
+            connector_id: Portal connector UUID.
+            org_id: Zitadel resourceowner string (see ``trigger_sync``).
+            limit: Max rows to return (capped at 100 by the connector).
 
         Raises:
             httpx.HTTPStatusError: On 4xx/5xx from klai-connector.
@@ -66,7 +105,7 @@ class KlaiConnectorClient:
             response = await client.get(
                 f"{settings.klai_connector_url}/api/v1/connectors/{connector_id}/syncs",
                 params={"limit": min(limit, 100)},
-                headers=self._headers(),
+                headers=self._headers(org_id=org_id),
             )
             response.raise_for_status()
             return [SyncRunData(**r) for r in response.json()]

--- a/klai-portal/backend/tests/test_klai_connector_client.py
+++ b/klai-portal/backend/tests/test_klai_connector_client.py
@@ -1,0 +1,88 @@
+"""SPEC-SEC-TENANT-001 A-8 (portal-side) — klai_connector_client header injection.
+
+REQ-8.1 / REQ-8.4 (v0.5.0 / β): the sync client methods MUST forward
+``X-Org-ID`` on every outbound call to klai-connector. The header value
+is the Zitadel resourceowner string sourced from
+``PortalOrg.zitadel_org_id`` at the route layer (REQ-8.2 / REQ-8.3).
+
+Tests assert the header construction via the private ``_headers``
+helper (the single point that decides whether to include ``X-Org-ID``)
+and pin the keyword-only signature contract. The end-to-end httpx
+behaviour is exercised by integration / smoke tests outside this
+suite — the unit-level guarantee is that a non-None ``org_id`` always
+produces a header and that callsites cannot silently omit the kwarg.
+"""
+
+from __future__ import annotations
+
+from app.services.klai_connector_client import KlaiConnectorClient
+
+
+def test_headers_include_x_org_id_when_provided() -> None:
+    """REQ-8.1: _headers(org_id=...) returns X-Org-ID."""
+    client = KlaiConnectorClient()
+    headers = client._headers(org_id="org-a-resourceowner")
+
+    assert headers.get("X-Org-ID") == "org-a-resourceowner", (
+        f"REQ-8.1: X-Org-ID must be present when org_id is supplied; got {headers!r}"
+    )
+    assert "Authorization" in headers, "portal-caller bearer must remain present"
+
+
+def test_headers_omit_x_org_id_when_none() -> None:
+    """compute_fingerprint and other non-sync paths must not receive X-Org-ID.
+
+    REQ-7 only attaches the header to sync-route endpoints. The
+    private helper takes ``org_id=None`` for callsites that hit other
+    endpoints (today: ``compute_fingerprint``).
+    """
+    client = KlaiConnectorClient()
+    headers = client._headers(org_id=None)
+
+    assert "X-Org-ID" not in headers, f"X-Org-ID MUST NOT leak onto non-sync endpoints; got {headers!r}"
+    assert "Authorization" in headers
+
+
+def test_trigger_sync_signature_requires_org_id_kwarg() -> None:
+    """REQ-8.4: org_id is keyword-only and required.
+
+    A future portal-side handler that forgets to pass org_id MUST fail
+    at call time (TypeError) rather than silently send a request without
+    the header. This pins that contract at the signature level.
+    """
+    import inspect
+
+    sig = inspect.signature(KlaiConnectorClient.trigger_sync)
+    org_id_param = sig.parameters.get("org_id")
+    assert org_id_param is not None, "trigger_sync MUST declare org_id parameter"
+    assert org_id_param.kind == inspect.Parameter.KEYWORD_ONLY, (
+        "trigger_sync.org_id MUST be keyword-only so callsites read self-documentingly"
+    )
+    assert org_id_param.default is inspect.Parameter.empty, (
+        "trigger_sync.org_id MUST have no default — REQ-8.4 forbids the silent omission path"
+    )
+
+
+def test_get_sync_runs_signature_requires_org_id_kwarg() -> None:
+    """REQ-8.4: same contract on get_sync_runs."""
+    import inspect
+
+    sig = inspect.signature(KlaiConnectorClient.get_sync_runs)
+    org_id_param = sig.parameters.get("org_id")
+    assert org_id_param is not None
+    assert org_id_param.kind == inspect.Parameter.KEYWORD_ONLY
+    assert org_id_param.default is inspect.Parameter.empty
+
+
+def test_compute_fingerprint_does_not_send_x_org_id() -> None:
+    """compute_fingerprint is NOT a sync-route endpoint.
+
+    REQ-7 only adds X-Org-ID to /connectors/{id}/sync, /syncs, and
+    /syncs/{run_id}. The compute_fingerprint endpoint has no
+    tenancy filter and MUST NOT receive an X-Org-ID — keeping the
+    blast radius of the new header narrow.
+    """
+    import inspect
+
+    sig = inspect.signature(KlaiConnectorClient.compute_fingerprint)
+    assert "org_id" not in sig.parameters


### PR DESCRIPTION
## Summary

Phase 3 of SPEC-SEC-TENANT-001 — closes the internal-wave audit Finding V (klai-connector sync-routes performed no org scoping; PORTAL_CALLER_SECRET leak = cross-tenant read/trigger). Independent of phase 1+2 (PR #200) at the code level — branches from main, no rebase needed.

Stacked-context: implements the SPEC v0.5.0 contracts that PR #200 documents, plus the v0.5.1 refinements (no backfill + trigger_sync-fail-fast). A small SPEC v0.5.1 HISTORY commit lands on PR #200 to keep the SPEC and shipped behaviour paired.

## REQ coverage

### REQ-7 (klai-connector)

| REQ | File | Change |
|---|---|---|
| REQ-7.1 (v0.5.1) | [alembic/versions/006_add_org_id_to_sync_runs.py](klai-connector/alembic/versions/006_add_org_id_to_sync_runs.py) | New migration: ADD COLUMN `org_id VARCHAR(255)` nullable + `ix_sync_runs_org_id` index. **No backfill.** Historical rows keep NULL and fall outside per-org filters. |
| REQ-7.2 (v0.5.1) | [app/models/sync_run.py](klai-connector/app/models/sync_run.py) | `org_id: Mapped[str \| None] = mapped_column(String(255), nullable=True, index=True)`. Type matches `Connector.org_id` (Zitadel resourceowner, set by migration `003_org_id_string`). |
| REQ-7.3 | [app/routes/sync.py](klai-connector/app/routes/sync.py) | New `_require_portal_org_id(request, settings) -> str \| None` helper. All three handlers filter on `SyncRun.org_id` when asserted. |
| REQ-7.4 | sync.py `trigger_sync` | Persists `org_id` on the new SyncRun row. Active-sync guard scoped by org_id too. |
| REQ-7.5 | sync.py `get_sync_run` | Cross-tenant returns HTTP 404 (`Sync run not found`), never 403 — never leak existence. |
| REQ-7.6 | [app/core/config.py](klai-connector/app/core/config.py) `sync_require_org_id: bool = False` | Transition flag. WARN `event="sync_missing_org_id"` always fires; reads degrade gracefully when flag is False; reads return 400 when flipped. |
| REQ-7.7 | sync.py | Connector does NOT derive org_id from connector_id (no callback to portal). Trust contract: portal asserts via header, connector trusts because portal-caller-secret authenticated the channel. |

### REQ-8 (klai-portal)

| REQ | File | Change |
|---|---|---|
| REQ-8.1 | [app/services/klai_connector_client.py](klai-portal/backend/app/services/klai_connector_client.py) | `trigger_sync` + `get_sync_runs` require keyword-only `org_id: str`. Inject `X-Org-ID` via `_headers(org_id=...)`. |
| REQ-8.2 / REQ-8.3 | [app/api/connectors.py](klai-portal/backend/app/api/connectors.py) | Callsites at line ~579 (`trigger_sync`) + ~625 (`list_sync_runs`) pass `org.zitadel_org_id` from `_get_caller_org` — the Zitadel resourceowner string. |
| REQ-8.4 | [tests/test_klai_connector_client.py](klai-portal/backend/tests/test_klai_connector_client.py) | Header injection + signature contract pinned (keyword-only, no default). |
| REQ-8.5 | PR body + SPEC | Deploy order documented below. |

## v0.5.1 refinements (this PR ships with)

**No backfill on migration 006.** Historical `sync_runs` rows pre-date the column and keep `org_id IS NULL`. Per-org filters (`WHERE org_id = '<x>'`) do not match NULL, so pre-deploy sync history becomes invisible to every tenant after deploy. Acceptable because (a) sync_runs is operational/audit data, no business state is lost; (b) `trigger_sync` always populates org_id on new rows; (c) the cross-DB / orphan-cleanup complexity that v0.4.0 / v0.5.0 carried is gone with no functional cost. A future SPEC may flip the column to NOT NULL once historical rows have aged out by retention policy.

**`trigger_sync` returns HTTP 400 on missing X-Org-ID regardless of the transition flag.** Persisting a row with `org_id=NULL` would succeed at the schema layer (the column is nullable) but produce a row invisible to every tenant — operational debris at creation time. Fail-fast at the handler keeps the new-row contract clean. WARN event still fires for VictoriaLogs visibility. Acceptance A-8 read-side cases unchanged; the new `test_trigger_sync_missing_org_id_returns_400_regardless_of_flag` pins the WRITE-side deviation.

## Test plan

- [x] `klai-connector`: `uv run pytest tests/test_sync_run_model.py tests/test_sync_routes_org_scoping.py` — 8 passed (A-5 schema nullable+indexed, A-6 cross-tenant 404, A-8 transition flag both cases, trigger 400-on-missing, list filter, same-tenant 200).
- [x] `klai-connector`: `uv run --with pyright pyright app/routes/sync.py app/models/sync_run.py app/core/config.py tests/test_sync_*` — 0 errors.
- [x] `klai-connector`: `uv run ruff format --check` on changed files — clean.
- [x] `klai-connector`: existing tests `test_connector_routes_not_found.py` — 6 passed (no regression).
- [x] `klai-portal/backend`: `uv run pytest tests/test_klai_connector_client.py tests/test_connectors_quota.py` — 10 passed.
- [x] `klai-portal/backend`: `uv run --with pyright pyright app/services/klai_connector_client.py app/api/connectors.py tests/test_klai_connector_client.py` — 0 errors.
- [ ] CI: `gh run watch --exit-status`.

## Deploy order (REQ-8.5)

1. **portal-api first**: starts injecting `X-Org-ID` on every sync proxy call. Connector ignores the header until next deploy.
2. **klai-connector second**: ships with `sync_require_org_id=False`. Existing reads continue to work via legacy connector_id-only filter (with a WARN log per request from old portal callers, if any). New writes via `trigger_sync` require the header — but the portal already sends it after step 1.
3. **Flag flip (manual, post-soak)**: after VictoriaLogs shows zero `sync_missing_org_id` events for the agreed dwell time, set `SYNC_REQUIRE_ORG_ID=true` via SOPS env on the connector. Reads then 400 on missing header — final fail-closed state.

No DB pre-flight required. The migration is non-destructive and safe to apply at any point in the rollout.

## Known follow-ups

- `klai-mailer` + `klai-knowledge-mcp` may benefit from the same X-Org-ID pattern when they grow tenant-scoped operations. Out of scope for SPEC-SEC-TENANT-001.
- The JWT-claim admin-bypass tech debt in retrieval-api migrates to a portal-signed assertion under SPEC-SEC-IDENTITY-ASSERT-001 (γ direction). After that lands, the `admin` bare-key match in `_extract_role` (kept in PR #200 for SPEC-SEC-010 test compatibility) can also retire.
- A future SPEC can flip `sync_runs.org_id` to NOT NULL after historical rows have aged out by retention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)