### PR TITLE
fix(security): SPEC-SEC-SESSION-001 v0.3.1 — close 3 latent gaps

### DIFF
--- a/.moai/specs/SPEC-SEC-SESSION-001/spec.md
+++ b/.moai/specs/SPEC-SEC-SESSION-001/spec.md
@@ -1,6 +1,6 @@
 ---
 id: SPEC-SEC-SESSION-001
-version: 0.3.0
+version: 0.3.1
 status: done
 created: 2026-04-24
 updated: 2026-04-29
@@ -12,6 +12,43 @@ tracker: SPEC-SEC-AUDIT-2026-04
 # SPEC-SEC-SESSION-001: Session and Cookie Robustness
 
 ## HISTORY
+
+### v0.3.1 (2026-04-29) — three latent gaps closed post-ship
+
+After the close-out review (#203) flagged three known limitations on the
+shipped implementation. All three closed in a single follow-up PR; no
+behavioural regression and no migration needed.
+
+- **IPv4-mapped IPv6 binding bug** — research §7 had documented this as
+  a "test should include this case", but the production code was
+  actually broken: ``::ffff:1.2.3.4`` resolved to network address
+  ``::`` (the all-zero ``/48``), so every IPv4-mapped caller globally
+  shared the same subnet — effectively no binding for dual-stack proxies
+  that report v4 clients as v4-mapped. ``resolve_caller_ip_subnet`` now
+  unwraps ``ipv4_mapped`` before the prefix decision, landing the
+  binding on the correct embedded ``/24``. Fix is one ``isinstance``
+  check plus one attribute access in ``app/services/request_ip.py``;
+  covered by 13 unit tests in ``tests/test_request_ip.py`` (incl.
+  native v4 vs v4-mapped equality, native v6 not-unwrapped, carrier-
+  handoff inside same v4 ``/24``).
+- **HSET + EXPIRE atomicity in `_totp_pending_create`** — pre-fix the
+  state hash was written first and the TTL was set in a follow-up
+  command, so a portal-api crash in the microsecond window between the
+  two would leak one orphan hash without TTL per crash. Now wrapped in
+  a ``pool.pipeline(transaction=True)`` block so the three writes
+  (HSET + EXPIRE + counter SET-EX) execute as one ``MULTI`` / ``EXEC``
+  — either all land or none do. Fakeredis pipeline support exercised
+  by the existing TOTP regression suite.
+- **Coverage measurement on security-critical paths (acceptance ≥95%)**
+  — added three new fail-closed tests covering ``_totp_pending_create``
+  / ``incr_failures`` / ``delete`` legs of REQ-1.7 (previously only the
+  ``get`` leg had a regression test). Final coverage:
+  ``app/services/request_ip.py`` 100%, ``_verify_idp_pending_binding``
+  100%, all four ``_totp_pending_*`` helpers 100% on both happy and
+  fail-closed paths, ``_get_sso_fernet`` 100%. Dead defensive
+  ``except`` in ``_get_totp_redis_or_503`` removed for clarity
+  (``get_redis_pool`` does not raise; the per-op excepts already cover
+  the surfaceable failure modes).
 
 ### v0.3.0 (2026-04-29) — shipped
 - Implementation merged via PR #197 (squash `298195aa`) and deployed to

--- a/klai-portal/backend/app/api/auth.py
+++ b/klai-portal/backend/app/api/auth.py
@@ -196,20 +196,14 @@ async def _get_totp_redis_or_503(*, phase: str):
     entirely (the very bug we are closing). The ``phase`` kwarg is for
     operator forensics — ``totp_pending_redis_unavailable`` log records make
     it clear which Redis op failed without dumping the token.
+
+    ``get_redis_pool`` does not raise — it lazily constructs the connection
+    pool and returns ``None`` only when ``settings.redis_url`` is unset.
+    The actual network failure surfaces on the FIRST per-call op (HSET /
+    HGETALL / INCR / DEL); each helper wraps its own op in a
+    ``_REDIS_UNAVAILABLE_ERRORS`` except.
     """
-    try:
-        pool = await get_redis_pool()
-    except _REDIS_UNAVAILABLE_ERRORS:
-        _slog.error(
-            "totp_pending_redis_unavailable",
-            phase=phase,
-            reason="get_pool_raised",
-            exc_info=True,
-        )
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Authentication unavailable, please retry",
-        ) from None
+    pool = await get_redis_pool()
     if pool is None:
         _slog.error(
             "totp_pending_redis_unavailable",
@@ -232,6 +226,13 @@ async def _totp_pending_create(
 ) -> str:
     """Allocate a fresh ``temp_token`` and store the pending state in Redis.
 
+    The three Redis writes (state HASH + state TTL + failure counter with
+    its own TTL) execute in a single ``MULTI``/``EXEC`` pipeline so the
+    state hash never lands without a TTL. The naive sequential form
+    (``HSET`` then ``EXPIRE``) leaks one orphan hash per portal-api crash
+    that lands in the microsecond window between the two commands;
+    ``transaction=True`` closes that window.
+
     The opaque token returned to the client preserves the legacy
     ``secrets.token_urlsafe(32)`` contract — 256 bits of entropy, URL-safe.
     Raises HTTP 503 when Redis is unreachable (REQ-1.7).
@@ -242,22 +243,20 @@ async def _totp_pending_create(
     counter_key = f"{_TOTP_PENDING_FAILURES_PREFIX}{token}"
     ttl = settings.totp_pending_ttl_seconds
     try:
-        # redis-py stub regression: ``Redis.hset`` is awaitable in the
-        # asyncio variant but typed as sync ``int`` in the inherited
-        # signature. Same workaround would apply to any Redis-async helper
-        # that touched ``hset`` directly.
-        await pool.hset(  # pyright: ignore[reportGeneralTypeIssues]
-            state_key,
-            mapping={
-                "session_id": session_id,
-                "session_token": session_token,
-                "ua_hash": ua_hash,
-                "ip_subnet": ip_subnet,
-            },
-        )
-        await pool.expire(state_key, ttl)
-        # ``SET ... EX`` initialises the counter at 0 with TTL in one round trip.
-        await pool.set(counter_key, 0, ex=ttl)
+        async with pool.pipeline(transaction=True) as pipe:
+            pipe.hset(
+                state_key,
+                mapping={
+                    "session_id": session_id,
+                    "session_token": session_token,
+                    "ua_hash": ua_hash,
+                    "ip_subnet": ip_subnet,
+                },
+            )
+            pipe.expire(state_key, ttl)
+            # ``SET ... EX`` initialises the counter at 0 with TTL in one round trip.
+            pipe.set(counter_key, 0, ex=ttl)
+            await pipe.execute()
     except _REDIS_UNAVAILABLE_ERRORS:
         _slog.error("totp_pending_redis_unavailable", phase="create", exc_info=True)
         raise HTTPException(

--- a/klai-portal/backend/app/services/request_ip.py
+++ b/klai-portal/backend/app/services/request_ip.py
@@ -59,19 +59,35 @@ def resolve_caller_ip_subnet(request: Request) -> str:
     ``"unknown"`` when the caller IP is missing or cannot be parsed by
     :mod:`ipaddress`.
 
-    Used by the ``klai_idp_pending`` Fernet cookie binding so a stolen cookie
-    replayed from a different network is rejected, while a mobile user
-    switching cells inside the same carrier prefix is not (the new IP is
-    almost always inside the same ``/24``/``/48``). See SPEC-SEC-SESSION-001
-    research §3.2 for the threat-model rationale.
+    IPv4-mapped IPv6 (``::ffff:a.b.c.d``) is unwrapped to its embedded
+    IPv4 address before the prefix decision so the binding lands on the
+    real ``/24`` of the wrapped v4 instead of the all-zero IPv6 ``/48``
+    that naive ``ip_network`` handling would produce. The naive form is a
+    real security bug — every IPv4-mapped IPv6 caller resolves to
+    ``::`` and binds to a subnet that matches every other IPv4-mapped
+    caller globally, effectively making the binding a no-op for
+    dual-stack proxies that report the v4 client as v4-mapped.
+
+    Used by the ``klai_idp_pending`` Fernet cookie binding so a stolen
+    cookie replayed from a different network is rejected, while a mobile
+    user switching cells inside the same carrier prefix is not (the new
+    IP is almost always inside the same ``/24`` / ``/48``). See
+    SPEC-SEC-SESSION-001 research §3.2 + §7 (open question 3) for the
+    threat-model rationale.
     """
     raw = resolve_caller_ip(request)
     if raw == _UNKNOWN:
         return _UNKNOWN
     try:
-        addr = ipaddress.ip_address(raw)
+        addr: ipaddress._BaseAddress = ipaddress.ip_address(raw)
     except ValueError:
         return _UNKNOWN
+
+    # SPEC-SEC-SESSION-001 research §7: unwrap IPv4-mapped IPv6 so the
+    # binding lands on the embedded /24, not the all-zero /48.
+    if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped is not None:
+        addr = addr.ipv4_mapped
+
     prefix = _IPV4_BINDING_PREFIX if addr.version == 4 else _IPV6_BINDING_PREFIX
-    network = ipaddress.ip_network(f"{raw}/{prefix}", strict=False)
+    network = ipaddress.ip_network(f"{addr}/{prefix}", strict=False)
     return str(network.network_address)

--- a/klai-portal/backend/tests/test_auth_totp_lockout.py
+++ b/klai-portal/backend/tests/test_auth_totp_lockout.py
@@ -186,6 +186,156 @@ async def test_redis_connection_error_during_get_fails_closed(fake_redis: Any, m
     assert exc_info.value.status_code == 503
 
 
+async def test_redis_connection_error_during_create_fails_closed(
+    fake_redis: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """REQ-1.7 + REQ-5.3: a ``ConnectionError`` raised by the pipeline
+    transaction during ``_totp_pending_create`` is mapped to HTTP 503 +
+    ``totp_pending_redis_unavailable`` event with ``phase=create``.
+
+    The pipeline replaces the legacy sequential ``HSET`` + ``EXPIRE``
+    pair (closes the orphan-hash window on portal-api crash mid-create);
+    the fail-closed contract still applies when the pipeline itself
+    cannot reach Redis.
+    """
+    import redis.exceptions as redis_exc
+
+    from app.api.auth import _totp_pending_create
+
+    class _BoomPipeline:
+        def __init__(self) -> None:
+            self.queued: list[str] = []
+
+        def hset(self, *_a: Any, **_kw: Any) -> _BoomPipeline:
+            self.queued.append("hset")
+            return self
+
+        def expire(self, *_a: Any, **_kw: Any) -> _BoomPipeline:
+            self.queued.append("expire")
+            return self
+
+        def set(self, *_a: Any, **_kw: Any) -> _BoomPipeline:
+            self.queued.append("set")
+            return self
+
+        async def execute(self) -> Any:
+            raise redis_exc.ConnectionError("network down mid-pipeline")
+
+        async def __aenter__(self) -> _BoomPipeline:
+            return self
+
+        async def __aexit__(self, *_a: Any) -> None:
+            return None
+
+    monkeypatch.setattr(fake_redis, "pipeline", lambda *_a, **_kw: _BoomPipeline())
+
+    with capture_logs() as captured:
+        with pytest.raises(HTTPException) as exc_info:
+            await _totp_pending_create(
+                session_id="sess-x",
+                session_token="tok-x",
+                ua_hash="",
+                ip_subnet="0.0.0.0",  # noqa: S104 — placeholder, not a network bind
+            )
+
+    assert exc_info.value.status_code == 503
+    unavail = [e for e in captured if e.get("event") == "totp_pending_redis_unavailable"]
+    assert any(e.get("phase") == "create" for e in unavail)
+
+
+async def test_redis_connection_error_during_incr_fails_closed(
+    fake_redis: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """REQ-1.7: ``INCR`` failing mid-flight on a wrong TOTP code → 503.
+
+    This is the worst-case leg from a UX perspective: the user already
+    submitted a (wrong) code, so the audit log fires for ``invalid_code``
+    and THEN Redis fails on the counter increment. Fail-CLOSED still
+    applies — opening the door would let an attacker dodge the brute-force
+    counter by saturating Redis network capacity.
+    """
+    import redis.exceptions as redis_exc
+
+    from app.api.auth import TOTPLoginRequest, _totp_pending_create, totp_login
+
+    temp_token = await _totp_pending_create(
+        session_id="sess-incr",
+        session_token="tok-incr",
+        ua_hash="",
+        ip_subnet="0.0.0.0",  # noqa: S104 — placeholder, not a network bind
+    )
+
+    monkeypatch.setattr(
+        "app.api.auth.zitadel.update_session_with_totp",
+        AsyncMock(side_effect=_zitadel_400_error()),
+    )
+    monkeypatch.setattr("app.api.auth.audit.log_event", AsyncMock())
+
+    async def _boom_incr(*_a: Any, **_kw: Any) -> Any:
+        raise redis_exc.ConnectionError("network down mid-incr")
+
+    monkeypatch.setattr(fake_redis, "incr", _boom_incr)
+
+    body = TOTPLoginRequest(temp_token=temp_token, code="000000", auth_request_id="ar-incr")
+    db = AsyncMock(spec=AsyncSession)
+
+    with capture_logs() as captured:
+        with pytest.raises(HTTPException) as exc_info:
+            await totp_login(body=body, response=Response(), db=db)
+
+    assert exc_info.value.status_code == 503
+    unavail = [e for e in captured if e.get("event") == "totp_pending_redis_unavailable"]
+    assert any(e.get("phase") == "incr" for e in unavail)
+
+
+async def test_redis_connection_error_during_delete_fails_closed(
+    fake_redis: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """REQ-1.7: ``DEL`` failing during cleanup after a successful TOTP
+    verification → 503 (the SSO cookie is NOT minted).
+
+    Unlike a successful flow, this scenario leaves a stranded
+    ``totp_pending`` hash in Redis. That hash will eventually expire via
+    its TTL; the user retries from the password screen. The trade-off
+    is documented under SPEC §Fail modes — opening the door (returning
+    success despite the failed cleanup) would re-introduce a window
+    where the same token could be reused, which is the very property
+    REQ-1.6 demands we close.
+    """
+    import redis.exceptions as redis_exc
+
+    from app.api.auth import TOTPLoginRequest, _totp_pending_create, totp_login
+
+    temp_token = await _totp_pending_create(
+        session_id="sess-del",
+        session_token="tok-del",
+        ua_hash="",
+        ip_subnet="0.0.0.0",  # noqa: S104 — placeholder, not a network bind
+    )
+
+    monkeypatch.setattr(
+        "app.api.auth.zitadel.update_session_with_totp",
+        AsyncMock(return_value={"sessionId": "sess-del", "sessionToken": "tok-del-renewed"}),
+    )
+    monkeypatch.setattr("app.api.auth.audit.log_event", AsyncMock())
+
+    async def _boom_delete(*_a: Any, **_kw: Any) -> Any:
+        raise redis_exc.ConnectionError("network down mid-delete")
+
+    monkeypatch.setattr(fake_redis, "delete", _boom_delete)
+
+    body = TOTPLoginRequest(temp_token=temp_token, code="123456", auth_request_id="ar-del")
+    db = AsyncMock(spec=AsyncSession)
+
+    with capture_logs() as captured:
+        with pytest.raises(HTTPException) as exc_info:
+            await totp_login(body=body, response=Response(), db=db)
+
+    assert exc_info.value.status_code == 503
+    unavail = [e for e in captured if e.get("event") == "totp_pending_redis_unavailable"]
+    assert any(e.get("phase") == "delete" for e in unavail)
+
+
 # ---------------------------------------------------------------------------
 # REQ-1.8 — in-memory global removed
 # ---------------------------------------------------------------------------

--- a/klai-portal/backend/tests/test_request_ip.py
+++ b/klai-portal/backend/tests/test_request_ip.py
@@ -1,0 +1,130 @@
+"""Unit tests for :mod:`app.services.request_ip`.
+
+Focused on the SPEC-SEC-SESSION-001 binding-subnet contract — including
+the IPv4-mapped IPv6 edge case that research.md §7 explicitly called
+out as a test-suite gap.
+
+A naive implementation that just trusts ``ipaddress.ip_address(raw).version``
+would route ``::ffff:1.2.3.4`` through the IPv6 ``/48`` branch and emit
+``::`` as the network address. That string would then match every other
+IPv4-mapped IPv6 caller in the world, making the cookie binding effectively
+a no-op for any dual-stack proxy that reports v4 clients as v4-mapped.
+``resolve_caller_ip_subnet`` therefore unwraps the embedded v4 first.
+"""
+
+from __future__ import annotations
+
+from helpers import make_request
+
+from app.services.request_ip import (
+    resolve_caller_ip,
+    resolve_caller_ip_subnet,
+)
+
+# ---------------------------------------------------------------------------
+# resolve_caller_ip — XFF priority + fallbacks
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_caller_ip_returns_rightmost_xff_entry() -> None:
+    """Right-most XFF entry is what Caddy saw on the wire; left entries
+    are attacker-controlled."""
+    request = make_request(headers={"x-forwarded-for": "1.2.3.4, 5.6.7.8, 203.0.113.10"})
+    assert resolve_caller_ip(request) == "203.0.113.10"
+
+
+def test_resolve_caller_ip_falls_back_to_client_host() -> None:
+    """No XFF → use ``request.client.host``."""
+    request = make_request(client=("198.51.100.42", 12345))
+    assert resolve_caller_ip(request) == "198.51.100.42"
+
+
+def test_resolve_caller_ip_returns_unknown_on_synthetic_scope() -> None:
+    """No XFF and no client → sentinel ``unknown``."""
+    request = make_request(client=None)
+    assert resolve_caller_ip(request) == "unknown"
+
+
+def test_resolve_caller_ip_strips_whitespace_in_xff() -> None:
+    request = make_request(headers={"x-forwarded-for": "  1.2.3.4 ,  203.0.113.10  "})
+    assert resolve_caller_ip(request) == "203.0.113.10"
+
+
+# ---------------------------------------------------------------------------
+# resolve_caller_ip_subnet — happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_subnet_ipv4_uses_slash_24() -> None:
+    """198.51.100.214 → 198.51.100.0 (/24 network address)."""
+    request = make_request(headers={"x-forwarded-for": "198.51.100.214"})
+    assert resolve_caller_ip_subnet(request) == "198.51.100.0"
+
+
+def test_subnet_ipv6_uses_slash_48() -> None:
+    """2001:db8:1234:5678::1 → 2001:db8:1234:: (/48 network address)."""
+    request = make_request(headers={"x-forwarded-for": "2001:db8:1234:5678::1"})
+    assert resolve_caller_ip_subnet(request) == "2001:db8:1234::"
+
+
+def test_subnet_returns_unknown_for_synthetic_scope() -> None:
+    request = make_request(client=None)
+    assert resolve_caller_ip_subnet(request) == "unknown"
+
+
+def test_subnet_returns_unknown_for_unparseable_ip() -> None:
+    """Garbage in XFF → sentinel rather than raising."""
+    request = make_request(headers={"x-forwarded-for": "not-an-ip"})
+    assert resolve_caller_ip_subnet(request) == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# IPv4-mapped IPv6 — research §7 open question 3
+# ---------------------------------------------------------------------------
+
+
+def test_subnet_unwraps_ipv4_mapped_ipv6_to_v4_slash_24() -> None:
+    """``::ffff:198.51.100.10`` SHALL bind to ``198.51.100.0``, not ``::``.
+
+    Without the unwrap step, every IPv4-mapped caller in the world
+    resolves to the same ``::`` /48 — the binding becomes a no-op for
+    every dual-stack proxy that reports v4 clients as v4-mapped IPv6.
+    """
+    request = make_request(headers={"x-forwarded-for": "::ffff:198.51.100.10"})
+    assert resolve_caller_ip_subnet(request) == "198.51.100.0"
+
+
+def test_subnet_unwrapped_ipv4_mapped_matches_native_ipv4() -> None:
+    """An IPv4-mapped binding MUST equal the native-IPv4 binding for the
+    same address. This is the property that makes the unwrap correct:
+    a stolen cookie issued from native v4 should still validate when
+    consumed via a dual-stack proxy that reports the same client as
+    v4-mapped, and vice versa."""
+    native = make_request(headers={"x-forwarded-for": "198.51.100.10"})
+    mapped = make_request(headers={"x-forwarded-for": "::ffff:198.51.100.10"})
+    assert resolve_caller_ip_subnet(native) == resolve_caller_ip_subnet(mapped)
+
+
+def test_subnet_native_ipv6_is_not_unwrapped() -> None:
+    """Native IPv6 (no v4-mapped prefix) keeps the /48 boundary.
+
+    Defends against a refactor that over-eagerly applies ipv4_mapped
+    detection to non-mapped IPv6 addresses.
+    """
+    request = make_request(headers={"x-forwarded-for": "2001:db8:cafe:babe::1"})
+    assert resolve_caller_ip_subnet(request) == "2001:db8:cafe::"
+
+
+def test_subnet_ipv4_mapped_carrier_handoff_inside_same_24() -> None:
+    """Two v4-mapped IPv6 addresses inside the same v4 /24 must produce
+    the same subnet — same property as the IPv4 mobile-carrier handoff
+    test in ``test_idp_pending_binding``."""
+    a = make_request(headers={"x-forwarded-for": "::ffff:198.51.100.10"})
+    b = make_request(headers={"x-forwarded-for": "::ffff:198.51.100.214"})
+    assert resolve_caller_ip_subnet(a) == resolve_caller_ip_subnet(b) == "198.51.100.0"
+
+
+def test_subnet_ipv4_mapped_different_24_produces_different_subnet() -> None:
+    a = make_request(headers={"x-forwarded-for": "::ffff:198.51.100.10"})
+    b = make_request(headers={"x-forwarded-for": "::ffff:203.0.113.10"})
+    assert resolve_caller_ip_subnet(a) != resolve_caller_ip_subnet(b)


### PR DESCRIPTION
## Summary
Follow-up to #197 (implementation) and #203 (close-out). Closes the 3 known limitations the close-out review flagged in the same PR — none of them surfaced as a production incident, but #1 is a real security bug that the close-out review caught while writing the spec HISTORY.

## Three gaps

### 1. 🚨 IPv4-mapped IPv6 binding bug (real, not just missing test)
`resolve_caller_ip_subnet` was treating `::ffff:1.2.3.4` via the IPv6 `/48` branch, producing network address `::`. Every IPv4-mapped caller globally resolved to the same subnet — effectively **no binding for dual-stack proxies that report v4 clients as v4-mapped**. The SPEC research §7 had documented this as a "test should include this case" but the production code was actually broken.

**Fix:** unwrap `ipv4_mapped` before the prefix decision so the binding lands on the embedded `/24`.

**Tests:** 13 new unit tests in [tests/test_request_ip.py](klai-portal/backend/tests/test_request_ip.py) covering native v4, native v6, IPv4-mapped, carrier-handoff inside same /24, native-v6-not-unwrapped regression guard.

### 2. HSET + EXPIRE atomicity in `_totp_pending_create`
Pre-fix the state HASH was written first and EXPIRE landed in a follow-up command — a portal-api crash in that microsecond window would leak one orphan hash without TTL per crash.

**Fix:** wrap the three writes in `pool.pipeline(transaction=True)` so they execute as one MULTI/EXEC. Bonus: the pyright suppression on `pool.hset` is gone (pipeline-queued `hset` returns the pipe object, sidestepping the redis-py async-stub bug).

### 3. Coverage on REQ-1.7 fail-closed legs
Shipped tests only covered the `get` phase. Added 3 tests for `create` / `incr` / `delete` — each forces a `redis.exceptions.ConnectionError` mid-op via monkeypatch and asserts HTTP 503 + structlog event with the right `phase`. Final coverage:

| Surface | Coverage |
|---|---|
| `app/services/request_ip.py` | 100% |
| `signup.py::_verify_idp_pending_binding` | 100% |
| `auth.py::_totp_pending_*` (4 helpers) | 100% happy + fail-closed |
| `auth.py::_get_sso_fernet` | 100% |

## Cleanup
Dead defensive `except` in `_get_totp_redis_or_503` removed. `get_redis_pool` does not raise (returns `None` when `redis_url` is unset, lazily constructs the pool otherwise). The per-op excepts in the four helpers cover the surfaceable failure modes.

## Test plan
- [x] 1287/1287 tests pass locally
- [x] ruff check + ruff format + pyright clean on the changed surface
- [ ] CI green
- [ ] After merge: container rolled over on core-01; smoke-test that login still works (the IPv4-mapped fix doesn't affect the canonical happy path, but the pipeline refactor is a code path used on every TOTP enrollment login)

## Notes for reviewers
- No SPEC-text changes other than the v0.3.1 HISTORY entry. No new requirements.
- Behavioural change is fail-CLOSED on more failure modes — IPv4-mapped callers that previously bypassed binding will now correctly enforce the v4 /24. Real impact: very low (Caddy reports clients as v4 directly; v4-mapped only appears in dual-stack proxy chains we don't currently use).

🤖 Generated with [Claude Code](https://claude.com/claude-code)