### PR TITLE
chore(spec): SPEC-SEC-SESSION-001 research + comment accuracy fixes

### DIFF
--- a/.moai/specs/SPEC-SEC-SESSION-001/research.md
+++ b/.moai/specs/SPEC-SEC-SESSION-001/research.md
@@ -414,9 +414,16 @@ SPEC.
 | `klai-portal/backend/app/api/signup.py` | Verify `ua_hash` + `ip_subnet` on consume; no changes to `_get_fernet` (already correct) | REQ-2.2 |
 | `klai-portal/backend/app/main.py` (lifespan) | Call `_get_sso_fernet()` on startup | REQ-4 |
 | `klai-portal/backend/app/core/config.py` | Add `totp_pending_ttl_seconds: int = 300` setting | REQ-1.1 |
-| `klai-portal/backend/tests/api/test_auth_totp_lockout.py` (new) | REQ-6.1 regression | REQ-6 |
-| `klai-portal/backend/tests/api/test_idp_pending_binding.py` (new) | REQ-6.2 / REQ-6.3 regression | REQ-6 |
-| `klai-portal/backend/tests/api/test_startup_sso_key_guard.py` (new) | REQ-6.4 regression | REQ-6 |
+| `klai-portal/backend/tests/test_auth_totp_lockout.py` (new) | REQ-6.1 regression | REQ-6 |
+| `klai-portal/backend/tests/test_idp_pending_binding.py` (new) | REQ-6.2 / REQ-6.3 regression | REQ-6 |
+| `klai-portal/backend/tests/test_startup_sso_key_guard.py` (new) | REQ-6.4 regression | REQ-6 |
+| `klai-portal/backend/tests/test_request_ip.py` (new, v0.3.1) | IPv4-mapped IPv6 unit tests (research §7) | REQ-2.3 |
+| `klai-portal/backend/tests/test_session_logging_pii.py` (new) | PII guard for the 4 structlog events | REQ-5 |
+| `klai-portal/backend/tests/test_auth_login_happy_path.py` (new) | scenario 5 happy-path TOTP login regression | REQ-6.5 |
+
+NB: actual test files landed at flat ``tests/`` (no ``tests/api/`` sub-package
+in the portal-api repo layout). The original SPEC plan assumed a nested
+layout that does not exist in the codebase; flat layout used instead.
 
 No DB migrations. No frontend changes. No infra changes (Redis is
 already available).

--- a/klai-portal/backend/app/api/auth.py
+++ b/klai-portal/backend/app/api/auth.py
@@ -271,8 +271,13 @@ async def _totp_pending_get(token: str) -> dict[str, str] | None:
     the token is unknown or already expired."""
     pool = cast("aioredis.Redis", await _get_totp_redis_or_503(phase="get"))
     try:
-        # Same redis-py stub regression as ``_totp_pending_create``:
-        # ``Redis.hgetall`` is awaitable in the asyncio variant.
+        # redis-py async stubs treat ``Redis.hgetall`` as the sync
+        # ``dict[Unknown, Unknown]`` return type; the runtime override on
+        # ``redis.asyncio.Redis`` is awaitable. ``hset`` had the same
+        # stub gap pre-pipeline-refactor; after that refactor the call
+        # is queued via ``pipeline()`` and pyright is happy. ``hgetall``
+        # is the only remaining direct-call site that needs the
+        # suppression.
         data = await pool.hgetall(  # pyright: ignore[reportGeneralTypeIssues]
             f"{_TOTP_PENDING_KEY_PREFIX}{token}"
         )


### PR DESCRIPTION
## Summary
Two doc-only tech-debt items surfaced by the v0.3.1 close-out review.

## Changes

### 1. `research.md` "Files to change" table — wrong paths
The original SPEC plan referenced `tests/api/test_*` paths but portal-api uses a flat `tests/` layout (no nested `api/` sub-package). Future SPEC-implementers using research.md as a precedent would look in the wrong place. Updated to the actual flat layout, plus added the three test files that landed post-plan (`test_request_ip`, `test_session_logging_pii`, `test_auth_login_happy_path`) and a short NB documenting the deviation.

### 2. `_totp_pending_get` had a misleading `pyright: ignore` comment
The comment claimed "Same redis-py stub regression as `_totp_pending_create`". After the v0.3.1 pipeline refactor, `_totp_pending_create` no longer uses a direct `hset` call — the pipeline-queued form sidesteps the stub gap. The comment was pointing at a dead reference. Updated to be self-contained.

## Test plan
- [x] Ruff check + ruff format + pyright clean on the changed surface.
- [ ] CI green (no behaviour change, only docs + comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)