### PR TITLE
docs(mx): SPEC-SEC-SESSION-001 @MX:ANCHOR tags on fan_in>=3 helpers

### DIFF
--- a/klai-portal/backend/app/api/auth.py
+++ b/klai-portal/backend/app/api/auth.py
@@ -130,6 +130,14 @@ class TTLCache:
 # ---------------------------------------------------------------------------
 
 
+# @MX:ANCHOR: SSO Fernet cipher accessor — fail-closed on missing SSO_COOKIE_KEY
+# @MX:REASON: fan_in=4 (lifespan startup guard + _encrypt_sso + _decrypt_sso +
+#   idp_signup_callback pending-cookie issue). A regression here breaks every
+#   authenticated klai_sso session AND every social-signup pending cookie.
+#   The removed ``Fernet.generate_key()`` fallback must never come back —
+#   per-replica ephemeral keys would silently invalidate every outstanding
+#   cookie on each restart.
+# @MX:SPEC: SPEC-SEC-SESSION-001 REQ-3
 @lru_cache(maxsize=1)
 def _get_sso_fernet() -> Fernet:
     """Return the cached SSO Fernet cipher.

--- a/klai-portal/backend/app/services/request_ip.py
+++ b/klai-portal/backend/app/services/request_ip.py
@@ -52,6 +52,15 @@ def resolve_caller_ip(request: Request) -> str:
     return _UNKNOWN
 
 
+# @MX:ANCHOR: caller-IP /24 (IPv4) or /48 (IPv6) subnet derivation for cookie binding
+# @MX:REASON: fan_in=3 (auth.py login TOTP-pending issue, auth.py
+#   idp_signup_callback issue, signup.py _verify_idp_pending_binding consume).
+#   All three callsites depend on this returning a subnet that is stable across
+#   carrier handoffs but unique across distinct networks. The IPv4-mapped IPv6
+#   unwrap (lines 79-80) is security-critical — without it every dual-stack
+#   v4-mapped caller globally resolves to ``::`` and the cookie binding
+#   collapses to a no-op for that traffic class. v0.3.1 history.
+# @MX:SPEC: SPEC-SEC-SESSION-001 REQ-2.3
 def resolve_caller_ip_subnet(request: Request) -> str:
     """Return the binding-subnet network address for the caller.
 


### PR DESCRIPTION
## Summary
Closes the @MX tag debt that the `/moai sync` Phase 0.6 (MX validation) workflow flags as P1 BLOCKING on the SPEC-SEC-SESSION-001 surface.

## What was missing
Two SPEC-owned helpers had fan_in ≥ 3 in production code but no `@MX:ANCHOR` annotation. Per `mx-tag-protocol.md` HARD rule, P1 violations would block any future `/moai sync` until resolved.

| Helper | fan_in | Callers |
|---|---|---|
| `_get_sso_fernet` | 4 | lifespan + `_encrypt_sso` + `_decrypt_sso` + `idp_signup_callback` |
| `resolve_caller_ip_subnet` | 3 | login + `idp_signup_callback` + `_verify_idp_pending_binding` |

## What was checked + decided not to tag
- `_totp_pending_*` (4 helpers): fan_in = 1 each → no anchor.
- `_get_totp_redis_or_503`: fan_in = 4 BUT only called by other helpers in the same SPEC scope. Internal helper of helpers, not an API boundary. Skipping for noise reduction.
- `_verify_idp_pending_binding`: fan_in = 1 → no anchor.

## Project docs
`.moai/project/structure.md` / `tech.md` / `product.md` are written at a higher abstraction level than per-helper invariants. `tech.md` already lists Redis as "Session cache, rate limiting, LiteLLM cache" which still describes today's reality after the SPEC adds TOTP pending state. No project-doc update needed.

## Test plan
- [x] Ruff + ruff format clean on changed files
- [x] Smoke tests pass (28/28 on the SPEC test surfaces)
- [ ] CI green

## Notes for reviewers
- No code-behaviour change. Comments + tags only.
- The `/moai sync` workflow itself is mostly a no-op for SPEC-SEC-SESSION-001 because the implementation+docs+CHANGELOG+alerts+follow-ups all shipped piecemeal across PRs #197/#203/#207/#210/#212. This PR closes the one remaining sync-required gap (MX tags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)