### PR TITLE
chore(portal): suppress semgrep unverified-jwt-decode false positive on widget peek

### DIFF
--- a/klai-portal/backend/app/api/partner_dependencies.py
+++ b/klai-portal/backend/app/api/partner_dependencies.py
@@ -104,9 +104,20 @@ async def _auth_via_session_token(token: str, db: AsyncSession) -> PartnerAuthCo
     # SPEC-SEC-HYGIENE-001 REQ-24.2: signing key is HKDF-derived per tenant,
     # so we need the tenant slug BEFORE we can verify the signature. Peek at
     # the unverified payload to read org_id, look up the slug, then re-decode
-    # with signature verification using the derived key. A forged token will
-    # fail the verified decode with InvalidSignatureError.
+    # with signature verification using the derived key at line 126 below.
+    # A forged token fails the verified decode with InvalidSignatureError.
+    #
+    # The unverified peek's only output is `org_id_unverified`, which is used
+    # SOLELY to look up the per-tenant HKDF salt — it is NEVER used for
+    # authorization or any session-state decision. Authorization happens on
+    # the verified `payload` returned by `decode_session_token`.
+    #
+    # Semgrep's `python.jwt.security.unverified-jwt-decode` rule is a static
+    # pattern match that cannot trace through to the verified decode below.
+    # Suppression is correct here; do NOT remove without refactoring to a
+    # kid-based JWT scheme (which is a breaking change for live widget JWTs).
     try:
+        # nosemgrep: python.jwt.security.unverified-jwt-decode.unverified-jwt-decode
         unverified = jwt.decode(token, options={"verify_signature": False})
     except jwt.InvalidTokenError as exc:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=_AUTH_ERROR) from exc


### PR DESCRIPTION
## Summary

The semgrep rule `python.jwt.security.unverified-jwt-decode` is firing on
`klai-portal/backend/app/api/partner_dependencies.py:110` and blocking CI
on every portal PR. This is a **false positive** — the unverified decode
is the deliberate HKDF per-tenant signing key pattern shipped in
SPEC-SEC-HYGIENE-001 / HY-24 (commit \`7be258ba\`).

## Why the unverified decode is correct

The widget JWT signing key is HKDF-derived from a per-tenant secret. To
verify a token we need to know **which tenant it belongs to**, but the
tenant slug lives **inside the JWT payload**. So the flow is:

1. \`jwt.decode(..., options={\"verify_signature\": False})\` — peek to
   read \`org_id\` (line 110)
2. Look up tenant slug from \`org_id\`
3. Derive HKDF signing key from tenant slug + master secret
4. \`decode_session_token(token, key=derived_key)\` — verified decode at
   line 126

Step 4 is what actually authorizes the request. Step 1's output is never
trusted.

## Why semgrep can't see this

Semgrep's \`unverified-jwt-decode\` rule is a static pattern match. It
flags any \`verify_signature: False\` call without flow-tracing through to
the verified decode that follows. The pattern is structurally correct
here — there's no upstream fix coming.

## Future hardening (not in scope)

The clean fix is a \`kid\`-based JWT scheme where the tenant identifier is
in the header, so semgrep sees a single verified decode. That's a
breaking change for live widget JWTs and needs its own SPEC.

## Changes

- Expanded the existing comment block to explicitly call out the
  semgrep rationale (so future reviewers don't try to remove the peek)
- Added \`# nosemgrep: python.jwt.security.unverified-jwt-decode.unverified-jwt-decode\`
  directly above the unverified \`jwt.decode\` call

## Test plan

- [ ] CI semgrep job passes (the suppression is the fix)
- [ ] No other behavior change — only comments + nosemgrep marker
- [ ] Existing widget JWT auth still works in dev (covered by
      SPEC-SEC-HYGIENE-001 tests already on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)