### PR TITLE
fix(portal-api): case-insensitive email lookup for password reset & login

### DIFF
--- a/klai-portal/backend/app/services/zitadel.py
+++ b/klai-portal/backend/app/services/zitadel.py
@@ -278,10 +278,19 @@ class ZitadelClient:
         resp.raise_for_status()
 
     async def find_user_id_by_email(self, email: str) -> str | None:
-        """Return the Zitadel userId for the given email, or None if not found."""
+        """Return the Zitadel userId for the given email, or None if not found.
+
+        Email matching is case-insensitive: Zitadel stores loginName with the
+        original case the user signed up with, but email addresses are
+        case-insensitive per RFC 5321 §2.4. Without IGNORE_CASE, a user typing
+        "steven@..." is silently not found if their loginName is "Steven@...",
+        which breaks the password-reset flow (returns 204 without sending mail).
+        """
         resp = await self._http.post(
             "/v2/users",
-            json={"queries": [{"loginNameQuery": {"loginName": email, "method": "TEXT_QUERY_METHOD_EQUALS"}}]},
+            json={
+                "queries": [{"loginNameQuery": {"loginName": email, "method": "TEXT_QUERY_METHOD_EQUALS_IGNORE_CASE"}}]
+            },
         )
         resp.raise_for_status()
         result = resp.json().get("result", [])
@@ -361,10 +370,16 @@ class ZitadelClient:
     # ── MFA / TOTP ────────────────────────────────────────────────────────────
 
     async def find_user_by_email(self, email: str) -> tuple[str, str] | None:
-        """Return (userId, orgId) for the given email, or None if not found."""
+        """Return (userId, orgId) for the given email, or None if not found.
+
+        Case-insensitive — see find_user_id_by_email for rationale. Used by
+        login + MFA flows where the user types their email manually.
+        """
         resp = await self._http.post(
             "/v2/users",
-            json={"queries": [{"loginNameQuery": {"loginName": email, "method": "TEXT_QUERY_METHOD_EQUALS"}}]},
+            json={
+                "queries": [{"loginNameQuery": {"loginName": email, "method": "TEXT_QUERY_METHOD_EQUALS_IGNORE_CASE"}}]
+            },
         )
         resp.raise_for_status()
         result = resp.json().get("result", [])

--- a/klai-portal/backend/tests/test_zitadel_email_lookup.py
+++ b/klai-portal/backend/tests/test_zitadel_email_lookup.py
@@ -1,0 +1,114 @@
+"""
+Tests for Zitadel email-based user lookup helpers.
+
+Bug context: Zitadel's loginName field stores emails with the original case
+the user signed up with (e.g. "Steven@getklai.com"). The search query
+defaulted to TEXT_QUERY_METHOD_EQUALS which is case-sensitive, so a user
+typing the lower-case form on the password-reset form was silently treated
+as "unknown email" and the endpoint returned 204 without sending a mail.
+
+Both find_user_id_by_email (password reset, invite, internal language lookup)
+and find_user_by_email (login, MFA) MUST use TEXT_QUERY_METHOD_EQUALS_IGNORE_CASE.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _zitadel_client_with_mocked_http(result: list[dict]):
+    """Construct a ZitadelClient with a mocked _http returning the given result list."""
+    from app.services.zitadel import ZitadelClient
+
+    client = ZitadelClient.__new__(ZitadelClient)
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"result": result}
+    mock_resp.raise_for_status = MagicMock()
+
+    mock_http = AsyncMock()
+    mock_http.post = AsyncMock(return_value=mock_resp)
+    client._http = mock_http
+    return client, mock_http
+
+
+class TestFindUserIdByEmailCaseInsensitive:
+    """find_user_id_by_email must match emails case-insensitively."""
+
+    @pytest.mark.asyncio
+    async def test_uses_equals_ignore_case_method(self) -> None:
+        """The Zitadel query MUST use TEXT_QUERY_METHOD_EQUALS_IGNORE_CASE.
+
+        With TEXT_QUERY_METHOD_EQUALS, a user whose loginName is
+        "Steven@getklai.com" is silently not found when typing
+        "steven@getklai.com" — exactly the bug we are fixing.
+        """
+        client, mock_http = _zitadel_client_with_mocked_http([{"userId": "u-123"}])
+
+        await client.find_user_id_by_email("steven@getklai.com")
+
+        mock_http.post.assert_awaited_once()
+        _args, kwargs = mock_http.post.call_args
+        sent_query = kwargs["json"]["queries"][0]["loginNameQuery"]
+        assert sent_query["method"] == "TEXT_QUERY_METHOD_EQUALS_IGNORE_CASE"
+        assert sent_query["loginName"] == "steven@getklai.com"
+
+    @pytest.mark.asyncio
+    async def test_returns_user_id_when_found(self) -> None:
+        client, _ = _zitadel_client_with_mocked_http([{"userId": "u-123"}])
+
+        result = await client.find_user_id_by_email("anyone@example.com")
+
+        assert result == "u-123"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_not_found(self) -> None:
+        client, _ = _zitadel_client_with_mocked_http([])
+
+        result = await client.find_user_id_by_email("ghost@example.com")
+
+        assert result is None
+
+
+class TestFindUserByEmailCaseInsensitive:
+    """find_user_by_email (used by login + MFA) must match case-insensitively."""
+
+    @pytest.mark.asyncio
+    async def test_uses_equals_ignore_case_method(self) -> None:
+        client, mock_http = _zitadel_client_with_mocked_http(
+            [
+                {
+                    "userId": "u-1",
+                    "details": {"resourceOwner": "org-1"},
+                }
+            ]
+        )
+
+        await client.find_user_by_email("steven@getklai.com")
+
+        mock_http.post.assert_awaited_once()
+        _args, kwargs = mock_http.post.call_args
+        sent_query = kwargs["json"]["queries"][0]["loginNameQuery"]
+        assert sent_query["method"] == "TEXT_QUERY_METHOD_EQUALS_IGNORE_CASE"
+
+    @pytest.mark.asyncio
+    async def test_returns_user_id_and_org_id(self) -> None:
+        client, _ = _zitadel_client_with_mocked_http(
+            [
+                {
+                    "userId": "u-1",
+                    "details": {"resourceOwner": "org-1"},
+                }
+            ]
+        )
+
+        result = await client.find_user_by_email("user@example.com")
+
+        assert result == ("u-1", "org-1")
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_not_found(self) -> None:
+        client, _ = _zitadel_client_with_mocked_http([])
+
+        result = await client.find_user_by_email("ghost@example.com")
+
+        assert result is None


### PR DESCRIPTION
## Summary
- Steven (and anyone signed up with mixed-case loginName) couldn't reset their password — the BFF silently returned 204 without ever calling Zitadel.
- `find_user_id_by_email` and `find_user_by_email` were using `TEXT_QUERY_METHOD_EQUALS`, which is case-sensitive. Switched both to `TEXT_QUERY_METHOD_EQUALS_IGNORE_CASE`.
- Added 6 tests covering query method, found case, and not-found case for both helpers.

## Live verification
Tested directly against `https://auth.getklai.com/v2/users` from `klai-core-portal-api-1`:

| Method | Query value | Result |
|---|---|---|
| `EQUALS` | `steven@getklai.com` | **0 results** (current bug) |
| `EQUALS` | `Steven@getklai.com` | 1 result |
| `EQUALS_IGNORE_CASE` | `steven@getklai.com` | 1 result (fix) |

Steven's stored `username` / `email` in Zitadel: `Steven@getklai.com` (capital S — case the user signed up with).

## Why this matters
- Password reset: silent failure — user thinks "I'll never get a mail" because the UI shows "Email on its way" but the BFF returned 204 before the Zitadel call.
- Login: same lookup is used by `login` for the email→userId mapping, so we plugged the same hole there.
- Invite + internal language lookup: same upgrade applies.

## Blast radius
LOW per `codeindex impact`:
- `find_user_id_by_email` — 3 direct callers (password_reset, invite_user, get_user_language)
- `find_user_by_email` — 1 direct caller (login)
- Behaviour change is strictly more permissive (matches what users intuitively expect — RFC 5321 §2.4).

## Test plan
- [x] 31 backend tests pass (6 new + adjacent auth/MFA/zitadel-session)
- [x] `ruff check` + `ruff format --check` clean
- [ ] Verify on prod after deploy: trigger password reset for `steven@getklai.com` and confirm a `user.human.password.code.added` event lands in Zitadel eventstore + a webhook lands in `klai-mailer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)