### PR TITLE
docs(sec): SPEC-SEC-HYGIENE-001 v0.7.0 — mailer slice covered, SPEC closed out

### DIFF
--- a/.moai/specs/SPEC-SEC-HYGIENE-001/progress.md
+++ b/.moai/specs/SPEC-SEC-HYGIENE-001/progress.md
@@ -606,3 +606,88 @@ untouched for audit traceability.
 
 Plus `.moai/specs/SPEC-SEC-HYGIENE-001/acceptance.md` (Implementation
 note documenting the HY-47 deferral) and this progress.md update.
+
+---
+
+## SPEC-SEC-HYGIENE-001 Progress — mailer-slice close-out (2026-04-29)
+
+Branch: `docs/SPEC-SEC-HYGIENE-001-closeout` (worktree at
+`klai-hygiene-closeout`, branched from `origin/main` at `3eef95a5`).
+
+Doc-only close-out. No code or test change in this commit. The actual
+mailer hardening that satisfies HY-49 + HY-50 already shipped to `main`
+in commit `a54499a0` under SPEC-SEC-MAILER-INJECTION-001.
+
+### HY-49 — Signature error-taxonomy oracle (covered)
+
+REQ-49.4 says: *"IF SPEC-SEC-MAILER-INJECTION-001 claims this fix in
+its /run, HY-49 is marked as 'covered' in the HYGIENE-001 close-out
+PR."*
+
+MAILER-INJECTION-001 commit `a54499a0` lands REQ-7 (uniform error
+body) and REQ-10 (strict signature parser). Mapping:
+
+- **REQ-49.1** (uniform `401 unauthorized` across every Zitadel
+  signature failure) ↔ MAILER-INJECTION-001 REQ-7.1. Implemented in
+  `klai-mailer/app/main.py` `_verify_zitadel_signature`: catches
+  `SignatureError`, returns `HTTPException(status_code=401,
+  detail="invalid signature")` byte-identical across every failure
+  mode.
+- **REQ-49.2** (precise `verification_phase` preserved in structlog)
+  ↔ REQ-7.2. The `mailer_signature_invalid` event carries a
+  `reason` field with sentinel values (`missing_header`,
+  `malformed_header`, `timestamp_out_of_window`, `hmac_mismatch`,
+  `unknown_vN_field`, `replay`).
+- **REQ-49.3** (regression test asserts byte-identity across all
+  failure modes) ↔ AC-6 in MAILER-INJECTION-001 acceptance.md.
+
+Status: ✅ **covered** by `a54499a0`.
+
+### HY-50 — Permissive signature-version parser (covered, exceeded)
+
+REQ-50.4 says: *"IF SPEC-SEC-MAILER-INJECTION-001 claims this
+documentation item, HY-50 closes as 'covered'."*
+
+HY-50 was scoped docs-only (REQ-50.1 = MX:NOTE annotation, REQ-50.2 =
+"no code change today"). MAILER-INJECTION-001 REQ-10 went further and
+implemented strict rejection of unknown `vN=` fields — `_parse_signature_header`
+in `klai-mailer/app/signature.py` raises `SignatureError(reason="unknown_vN_field")`
+on any non-`t`/`v1` token, on >5 tokens, and on malformed tokens.
+The downgrade-attack window HY-50 worried about is structurally
+closed, not just annotated.
+
+The MX:NOTE that REQ-50.1 specified is therefore not added — the
+strict-by-default parser is the stronger contract and a future
+Zitadel `v2=` rollout will be caught by a forced `SignatureError`,
+not by a comment. If a future operator needs to learn about the
+v1-only verification stance, the `SignatureError` reason sentinel
+itself documents it.
+
+Status: ✅ **covered (and exceeded)** by `a54499a0`.
+
+### Verification
+
+- `git log origin/main --oneline --grep "REQ-7 + REQ-10"` →
+  `a54499a0 feat(mailer): REQ-7 + REQ-10 uniform 401 + strict signature parser`.
+- `git log origin/main` confirms `a54499a0` reachable from `main`
+  (non-merge ancestor, direct commit).
+
+### SPEC overall status
+
+Per the v0.7.0 HISTORY entry in `spec.md`, all 6 slices are now
+either shipped or formally covered:
+
+| Slice | Items | Status |
+|---|---|---|
+| Portal | HY-19..HY-28 (8 items) | shipped on `main` |
+| Connector | HY-30..HY-32 | shipped (v0.5.0 close-out) |
+| Scribe | HY-33..HY-38 | shipped (v0.4.0 close-out, PR #179) |
+| Retrieval | HY-39..HY-44 | shipped (PR #188) |
+| Knowledge-MCP | HY-45/46/48 | shipped (v0.6.0 close-out) |
+| Knowledge-MCP | HY-47 | deferred → `SPEC-INGEST-RATELIMIT-001` |
+| Mailer | HY-49/HY-50 | covered (this commit) |
+
+SPEC frontmatter flipped: `status: in-progress` → `status: done`,
+`version: 0.6.0` → `version: 0.7.0`.
+
+### Status: SHIPPED (close-out only — no code change)

--- a/.moai/specs/SPEC-SEC-HYGIENE-001/spec.md
+++ b/.moai/specs/SPEC-SEC-HYGIENE-001/spec.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-SEC-HYGIENE-001
-version: 0.6.0
-status: in-progress
+version: 0.7.0
+status: done
 created: 2026-04-24
 updated: 2026-04-29
 author: Mark Vletter
@@ -21,6 +21,61 @@ tracker: SPEC-SEC-AUDIT-2026-04
 > one PR or five is a call for /run.
 
 ## HISTORY
+
+### v0.7.0 (2026-04-29) — mailer slice covered, SPEC closed out
+
+Final HYGIENE-001 close-out. All in-scope findings are now landed on
+`main` or formally deferred. SPEC status flips `in-progress → done`.
+
+**Mailer slice (HY-49 + HY-50): covered by SPEC-SEC-MAILER-INJECTION-001.**
+
+Per REQ-49.4 and REQ-50.4 of this SPEC, HY-49 and HY-50 close as
+"covered" once SPEC-SEC-MAILER-INJECTION-001 lands the equivalent fix.
+That happened in commit `a54499a0` on `main`
+(`feat(mailer): REQ-7 + REQ-10 uniform 401 + strict signature parser`):
+
+- **HY-49 (REQ-49.1/49.2/49.3)** ↔ **MAILER-INJECTION-001 REQ-7**.
+  All Zitadel signature-verification failures now return a byte-
+  identical `401 {"detail": "invalid signature"}` from
+  `_verify_zitadel_signature` in `klai-mailer/app/main.py`. The
+  precise failure reason is preserved in structlog at
+  `mailer_signature_invalid` with a `reason` field
+  (`missing_header`, `malformed_header`, `timestamp_out_of_window`,
+  `hmac_mismatch`, `unknown_vN_field`, `replay`). No
+  `WWW-Authenticate` or other side-channel response headers. See
+  `app/signature.py` for the `SignatureError` sentinel set and
+  `tests/` for AC-6 + AC-8 byte-identity assertions.
+
+- **HY-50 (REQ-50.1/50.2/50.3)** ↔ **MAILER-INJECTION-001 REQ-10**.
+  HY-50 was scoped docs-only ("annotate the parser, no code change
+  today"). REQ-10 went further and *implemented* the strict parser:
+  `_parse_signature_header` in `klai-mailer/app/signature.py` rejects
+  any unknown `vN=` token (e.g. a future `v2=`), rejects headers with
+  more than 5 tokens, and rejects malformed tokens — all surfacing
+  as `unknown_vN_field` and returning the same uniform 401 from
+  REQ-7. The HY-50 worry (silent-accept downgrade attack during a
+  hypothetical v1/v2 transition) is structurally closed, not just
+  annotated. The MX:NOTE that REQ-50.1 asked for is therefore
+  redundant and not added — the reject-by-default parser is the
+  stronger contract.
+
+No code or test change in this SPEC's repo footprint. Doc-only commit.
+
+**Other slices** — already shipped on `main` prior to this close-out:
+
+| Slice | Status | Reference |
+|---|---|---|
+| Portal HY-19..HY-28 | shipped | direct commits on `main` (REQ-19 `8695ef7d`, REQ-20 `6bd07440`, REQ-21 `0d1903f6`, REQ-22 `74bdd261`, REQ-23 `44bf0f08`, REQ-24 `7be258ba`, REQ-27 `838f5a89`, REQ-28 `cf772a76`; REQ-25/REQ-26 not allocated) |
+| Connector HY-30..HY-32 | shipped | v0.5.0 close-out, see HISTORY entry below |
+| Scribe HY-33..HY-38 | shipped | PR #179, merge `4463bb3d`; v0.4.0 close-out below |
+| Retrieval HY-39..HY-44 | shipped | PR #188, merge `99a7571c` |
+| Knowledge-MCP HY-45/46/48 | shipped | v0.6.0 close-out below |
+| Knowledge-MCP HY-47 | deferred | structurally relocated to `SPEC-INGEST-RATELIMIT-001` (see v0.6.0 entry) |
+| Mailer HY-49/HY-50 | covered | this entry (via SPEC-SEC-MAILER-INJECTION-001) |
+
+Of the 29 internal-wave findings, 28 ship as code/docs in this SPEC's
+slices. HY-47 is the only deliberate deferral and has its own
+follow-up SPEC.
 
 ### v0.6.0 (2026-04-29) — knowledge-mcp slice (HY-45/46/48 shipped, HY-47 deferred)
 


### PR DESCRIPTION
## Summary

Final close-out for SPEC-SEC-HYGIENE-001. Doc-only — no code or test change.

- Bumps `spec.md` frontmatter `version: 0.6.0 → 0.7.0` and `status: in-progress → done`.
- Adds v0.7.0 HISTORY entry documenting how HY-49 + HY-50 close as "covered" via SPEC-SEC-MAILER-INJECTION-001 commit `a54499a0`.
- Appends mailer-slice close-out section to `progress.md` with the full HY-49/REQ-7 and HY-50/REQ-10 mapping.

## Why now

HY-49 and HY-50 carry an explicit escape hatch in their REQ blocks (REQ-49.4 / REQ-50.4): if SPEC-SEC-MAILER-INJECTION-001 lands the equivalent fix, they auto-close as "covered" once this PR records it. That SPEC's REQ-7 (uniform 401) and REQ-10 (strict parser) shipped on main as `a54499a0` already — this PR just registers the closure.

HY-50 is technically *exceeded*: it was scoped docs-only ("annotate the parser, no code change today"), but REQ-10 implemented strict rejection of unknown `vN=` tokens. The MX:NOTE that REQ-50.1 asked for is therefore not added — the strict-by-default parser is the stronger contract.

## Slice status after this PR

| Slice | Items | Status |
|---|---|---|
| Portal | HY-19..HY-28 | shipped (direct commits on main) |
| Connector | HY-30..HY-32 | shipped (v0.5.0) |
| Scribe | HY-33..HY-38 | shipped (PR #179, v0.4.0) |
| Retrieval | HY-39..HY-44 | shipped (PR #188) |
| Knowledge-MCP | HY-45/46/48 | shipped (v0.6.0) |
| Knowledge-MCP | HY-47 | deferred → SPEC-INGEST-RATELIMIT-001 |
| Mailer | HY-49/HY-50 | covered (this PR) |

28 of 29 internal-wave findings landed as code/docs. HY-47 is the only deliberate deferral and has its own follow-up SPEC.

## Test plan

- [x] `git status` confirms only 2 files modified (spec.md + progress.md)
- [x] `git diff --stat` shows 142 insertions, 2 deletions, no code touched
- [x] Commit `a54499a0` confirmed reachable from `origin/main` via `git log origin/main --grep "REQ-7 + REQ-10"`
- [ ] CI is doc-only — no code workflows should trigger; if they do, expect green

🤖 Generated with [Claude Code](https://claude.com/claude-code)