### PR TITLE
fix(deploy): connect klai-mailer to net-redis network

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -319,8 +319,14 @@ services:
       # (SPEC-SEC-MAILER-INJECTION-001 REQ-8). Wiring via `environment:` instead
       # of duplicating into klai-mailer/.env keeps rotation atomic.
       INTERNAL_SECRET: ${PORTAL_API_INTERNAL_SECRET}
+      # Redis nonce store + per-recipient rate limiter
+      # (SPEC-SEC-MAILER-INJECTION-001 REQ-4 + REQ-6). Mailer fails closed
+      # with HTTP 503 when redis is unreachable, so it MUST share net-redis
+      # with the redis service — same pattern as portal-api and litellm.
+      REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379/0
     networks:
       - klai-net
+      - net-redis
 
   # ─── Portal API (FastAPI tenant provisioning) ─────────────────────────────
   portal-api:


### PR DESCRIPTION
## Summary
- klai-mailer was missing the `net-redis` Docker network → could not resolve hostname `redis` → fails closed with HTTP 503 on every webhook → Zitadel emits `password.code.added` but never `password.code.sent`. **No password-reset emails have left the system since the redis-nonce feature shipped.**
- Adds `net-redis` to klai-mailer's networks list — same pattern as portal-api and litellm.
- Wires `REDIS_URL` explicitly with the password (config.py default was wrong — no password, redis requires one).

## Live evidence on prod (core-01)
```bash
$ docker exec klai-core-klai-mailer-1 getent hosts redis
# exit 2 — name resolution fails

$ docker logs klai-core-klai-mailer-1 --tail 5
{"event":"mailer_nonce_redis_unavailable","error":"Error -3 connecting to redis:6379. Temporary failure in name resolution.","level":"error",...}
{"event":"mailer_nonce_redis_unavailable",...}
# Repeated ~10x as Zitadel retries the webhook
```

## Why this surfaced now
Reported via Steven (`steven@getklai.com`). His password-reset request finally reached Zitadel after PR #216 (case-insensitive email lookup). The next layer of the stack revealed this pre-existing redis-network bug — Zitadel called the webhook, mailer 503'd, no email.

## Test plan
- [x] Verify diff shape matches portal-api pattern
- [ ] After deploy: `docker exec klai-core-klai-mailer-1 getent hosts redis` returns an IP
- [ ] Trigger another password reset for `steven@getklai.com` and confirm:
  - `user.human.password.code.sent` event lands in `eventstore.events2`
  - `mailer_send_succeeded` (or equivalent) appears in mailer logs
  - Steven actually receives the email

🤖 Generated with [Claude Code](https://claude.com/claude-code)