### PR TITLE
feat(infra): SPEC-SEC-WEBHOOK-001 REQ-6 — shared uvicorn launcher across 4 services

### DIFF
--- a/klai-knowledge-ingest/Dockerfile
+++ b/klai-knowledge-ingest/Dockerfile
@@ -29,6 +29,10 @@ ENV UV_COMPILE_BYTECODE=1 \
 RUN uv sync --frozen --no-dev --no-install-project
 
 COPY --chown=app:app klai-knowledge-ingest/knowledge_ingest knowledge_ingest
+# SPEC-SEC-WEBHOOK-001 REQ-6: shared uvicorn launcher (Caddy IP resolution +
+# --proxy-headers). Copied from repo root scripts/ directory.
+COPY --chown=app:app scripts/uvicorn-launch.sh /app/scripts/uvicorn-launch.sh
+RUN chmod +x /app/scripts/uvicorn-launch.sh
 
 ENV PATH="/repo/klai-knowledge-ingest/.venv/bin:${PATH}" \
     VIRTUAL_ENV="/repo/klai-knowledge-ingest/.venv"
@@ -38,7 +42,8 @@ USER app
 
 EXPOSE 8000
 
-# SPEC-SEC-WEBHOOK-001 REQ-1.6: --proxy-headers + allow-ips=127.0.0.1 for internal
-# services. knowledge-ingest is reached only on klai-net (portal-api forwarding,
-# klai-connector crawl delegation); no upstream is trusted to set X-Forwarded-For.
-CMD ["uvicorn", "knowledge_ingest.app:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers", "--forwarded-allow-ips", "127.0.0.1"]
+# SPEC-SEC-WEBHOOK-001 REQ-1.6 + REQ-6: shared launcher resolves Caddy IP at
+# start time and passes --proxy-headers --forwarded-allow-ips=<resolved>.
+# knowledge-ingest is internal-only (klai-net), so DNS lookup falls back to
+# 127.0.0.1 — the correct safe default for an internal service.
+CMD ["/app/scripts/uvicorn-launch.sh", "knowledge_ingest.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/klai-portal/backend/Dockerfile
+++ b/klai-portal/backend/Dockerfile
@@ -59,6 +59,10 @@ COPY klai-portal/backend/alembic alembic
 COPY klai-portal/backend/alembic.ini alembic.ini
 COPY klai-portal/backend/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
+# SPEC-SEC-WEBHOOK-001 REQ-6: shared uvicorn launcher (Caddy IP resolution +
+# --proxy-headers). Copied from repo root scripts/ directory.
+COPY scripts/uvicorn-launch.sh /app/scripts/uvicorn-launch.sh
+RUN chmod +x /app/scripts/uvicorn-launch.sh
 
 RUN adduser --disabled-password --gecos "" klai
 

--- a/klai-portal/backend/entrypoint.sh
+++ b/klai-portal/backend/entrypoint.sh
@@ -7,42 +7,17 @@
 #
 # Introduced by SPEC-CHAT-TEMPLATES-CLEANUP-001 after SPEC-CHAT-TEMPLATES-001
 # required manual `docker exec ... alembic upgrade head` on production.
+#
+# SPEC-SEC-WEBHOOK-001 REQ-6: uvicorn launch delegated to shared launcher.
+# The Caddy IP resolution and --proxy-headers logic now lives in a single
+# script (scripts/uvicorn-launch.sh) shared across all klai backend services.
 set -eu
 
 echo "[entrypoint] Running alembic upgrade head…"
 alembic upgrade head
 echo "[entrypoint] Migrations applied."
 
-# SPEC-SEC-WEBHOOK-001 REQ-1: uvicorn --proxy-headers trust-boundary.
-#
-# Without --proxy-headers, `request.client.host` equals the TCP peer — that
-# is Caddy's klai-net container IP (172.x.y.z) for every external request.
-# Cornelis audit #2 exploited exactly that to bypass the Vexa webhook auth
-# check (the now-deleted "internal Docker network = trusted" shortcut
-# short-circuited on Caddy's own IP). REQ-2 removed the shortcut in #155;
-# this step adds the proper proxy-headers handling so future rate-limiting,
-# CSRF-exempt audits, and log correlation see the REAL external client IP.
-#
-# `--forwarded-allow-ips` must NOT be `*` (REQ-1.2) and must NOT be a
-# hardcoded IP (container IPs change per restart —
-# .claude/rules/klai/infra/servers.md). We resolve `caddy` at container
-# start time via Docker's embedded DNS. If caddy is unresolvable (bootstrap
-# race, compose network misconfig), we fall back to 127.0.0.1 which means
-# "trust nobody's X-Forwarded-For" — safe default that keeps the service
-# up and surfaces the misconfiguration via `request.client.host` showing
-# the TCP peer instead of a real client.
-CADDY_IP="$(getent hosts caddy 2>/dev/null | awk '{print $1}' | head -n1)"
-if [ -z "$CADDY_IP" ]; then
-    echo "[entrypoint] WARN: cannot resolve caddy via Docker DNS — falling back to --forwarded-allow-ips=127.0.0.1 (X-Forwarded-For ignored)."
-    CADDY_IP="127.0.0.1"
-else
-    echo "[entrypoint] Resolved caddy → $CADDY_IP (trusted source for X-Forwarded-For / X-Forwarded-Proto)."
-fi
-
-echo "[entrypoint] Starting uvicorn with --proxy-headers --forwarded-allow-ips=$CADDY_IP"
-exec uvicorn app.main:app \
+exec /app/scripts/uvicorn-launch.sh app.main:app \
     --host 0.0.0.0 \
     --port 8010 \
-    --proxy-headers \
-    --forwarded-allow-ips="$CADDY_IP" \
     "$@"

--- a/klai-retrieval-api/Dockerfile
+++ b/klai-retrieval-api/Dockerfile
@@ -29,13 +29,16 @@ RUN uv pip install --system -e .
 
 COPY --chown=app:app klai-retrieval-api/retrieval_api retrieval_api
 COPY --chown=app:app klai-retrieval-api/scripts scripts
+# SPEC-SEC-WEBHOOK-001 REQ-6: shared uvicorn launcher (Caddy IP resolution +
+# --proxy-headers). Copied from repo root scripts/ directory.
+COPY --chown=app:app scripts/uvicorn-launch.sh /app/scripts/uvicorn-launch.sh
+RUN chmod +x /app/scripts/uvicorn-launch.sh
 
 USER app
 
-# SPEC-SEC-WEBHOOK-001 REQ-1.6: --proxy-headers + allow-ips=127.0.0.1 for internal
-# services. retrieval-api is reached service-to-service on klai-net (portal-api,
-# litellm), NOT through Caddy — so no upstream is trusted to set X-Forwarded-For.
-# request.client.host then equals the TCP peer's container IP. The app-level XFF
-# read in `middleware/auth.py::_source_ip` is also updated (REQ-1.5) to use
-# `request.client.host` instead of the raw header.
-CMD ["uvicorn", "retrieval_api.main:app", "--host", "0.0.0.0", "--port", "8040", "--proxy-headers", "--forwarded-allow-ips", "127.0.0.1"]
+# SPEC-SEC-WEBHOOK-001 REQ-1.6 + REQ-6: shared launcher resolves Caddy IP at
+# start time and passes --proxy-headers --forwarded-allow-ips=<resolved>.
+# retrieval-api is reached service-to-service on klai-net (portal-api, litellm),
+# NOT through Caddy, so the DNS lookup will fall back to 127.0.0.1 — which is
+# the correct safe default for an internal service.
+CMD ["/app/scripts/uvicorn-launch.sh", "retrieval_api.main:app", "--host", "0.0.0.0", "--port", "8040"]

--- a/klai-scribe/scribe-api/Dockerfile
+++ b/klai-scribe/scribe-api/Dockerfile
@@ -48,6 +48,10 @@ ENV PATH="/repo/klai-scribe/scribe-api/.venv/bin:${PATH}" \
 COPY klai-scribe/scribe-api/app app
 COPY klai-scribe/scribe-api/alembic alembic
 COPY klai-scribe/scribe-api/alembic.ini alembic.ini
+# SPEC-SEC-WEBHOOK-001 REQ-6: shared uvicorn launcher (Caddy IP resolution +
+# --proxy-headers). Copied from repo root scripts/ directory.
+COPY scripts/uvicorn-launch.sh /app/scripts/uvicorn-launch.sh
+RUN chmod +x /app/scripts/uvicorn-launch.sh
 
 RUN adduser --disabled-password --gecos "" klai && \
     mkdir -p /data/audio && chown klai:klai /data/audio
@@ -56,9 +60,9 @@ EXPOSE 8020
 
 USER klai
 
-# SPEC-SEC-WEBHOOK-001 REQ-1.6: --proxy-headers + allow-ips=127.0.0.1 for internal
-# services. scribe-api is reached only on klai-net (portal-api BFF proxy); no
-# upstream is trusted to set X-Forwarded-For. request.client.host reflects the
-# TCP peer's container IP, which is the legitimate caller identity for
-# service-to-service rate-limiting.
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8020", "--proxy-headers", "--forwarded-allow-ips", "127.0.0.1"]
+# SPEC-SEC-WEBHOOK-001 REQ-1.6 + REQ-6: shared launcher resolves Caddy IP at
+# start time and passes --proxy-headers --forwarded-allow-ips=<resolved>.
+# scribe-api is internal-only (klai-net via portal-api BFF proxy), so DNS
+# lookup falls back to 127.0.0.1 — the correct safe default for an internal
+# service.
+CMD ["/app/scripts/uvicorn-launch.sh", "app.main:app", "--host", "0.0.0.0", "--port", "8020"]

--- a/scripts/uvicorn-launch.sh
+++ b/scripts/uvicorn-launch.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+# uvicorn-launch.sh — shared uvicorn launcher for all klai backend services.
+#
+# Purpose
+# -------
+# SPEC-SEC-WEBHOOK-001 REQ-1 hardened the trust boundary on uvicorn's
+# reverse-proxy header parsing by requiring --proxy-headers together with
+# a narrowly-scoped --forwarded-allow-ips instead of the wildcard "*".
+#
+# REQ-6 (this script) eliminates the duplication: four services previously
+# each carried their own copy of the Caddy-IP resolution logic with subtle
+# variations. A single source of truth prevents drift and makes the security
+# invariant auditable in one place.
+#
+# How it works
+# ------------
+# 1. If UVICORN_FORWARDED_ALLOW_IPS is set (e.g. in tests or special
+#    deployments), that value is used directly — no DNS lookup performed.
+# 2. Otherwise the script resolves the "caddy" hostname via Docker's embedded
+#    DNS (getent hosts caddy). If Caddy is reachable, its container IP is
+#    trusted as the sole forwarding proxy.
+# 3. If the DNS lookup fails (bootstrap race, network misconfiguration), the
+#    script falls back to 127.0.0.1. This means "trust nobody's
+#    X-Forwarded-For" which is the safe default — the service stays up but
+#    client IPs will show Caddy's TCP peer address rather than the real
+#    external client address, making the misconfiguration visible in logs.
+#
+# Usage
+# -----
+#   /app/scripts/uvicorn-launch.sh <module:app> [extra uvicorn args...]
+#
+# Example
+#   /app/scripts/uvicorn-launch.sh app.main:app --host 0.0.0.0 --port 8000
+#
+# References
+# ----------
+#   SPEC-SEC-WEBHOOK-001 REQ-1, REQ-6
+#   .claude/rules/klai/infra/servers.md (container IPs change per restart)
+#
+# POSIX compatibility: written for /bin/sh (alpine uses ash, not bash).
+
+set -eu
+
+APP_TARGET="${1:?uvicorn-launch.sh: first argument must be module:app target}"
+shift  # remaining args are passed through to uvicorn
+
+# Allow tests and special deployments to override without a DNS lookup.
+if [ -n "${UVICORN_FORWARDED_ALLOW_IPS:-}" ]; then
+    CADDY_IP="$UVICORN_FORWARDED_ALLOW_IPS"
+    echo "[uvicorn-launch] UVICORN_FORWARDED_ALLOW_IPS override → --forwarded-allow-ips=$CADDY_IP"
+else
+    CADDY_IP="$(getent hosts caddy 2>/dev/null | awk '{print $1}' | head -n1)"
+    if [ -z "$CADDY_IP" ]; then
+        echo "[uvicorn-launch] WARN: cannot resolve caddy via Docker DNS — falling back to --forwarded-allow-ips=127.0.0.1 (X-Forwarded-For ignored)."
+        CADDY_IP="127.0.0.1"
+    else
+        echo "[uvicorn-launch] Resolved caddy → $CADDY_IP (trusted source for X-Forwarded-For / X-Forwarded-Proto)."
+    fi
+fi
+
+echo "[uvicorn-launch] Starting: uvicorn $APP_TARGET --proxy-headers --forwarded-allow-ips=$CADDY_IP $*"
+exec uvicorn "$APP_TARGET" \
+    --proxy-headers \
+    --forwarded-allow-ips="$CADDY_IP" \
+    "$@"

--- a/tests/scripts/test_uvicorn_launch.sh
+++ b/tests/scripts/test_uvicorn_launch.sh
@@ -1,0 +1,136 @@
+#!/bin/sh
+# tests/scripts/test_uvicorn_launch.sh
+#
+# Shell unit tests for scripts/uvicorn-launch.sh.
+#
+# Verifies the env-var override path and the DNS-fallback path without
+# requiring a live Docker network or a running uvicorn process.
+#
+# Run locally:  sh tests/scripts/test_uvicorn_launch.sh
+# Run in CI:    included in any "shell scripts" quality gate.
+#
+# POSIX-compatible (ash / dash / bash all supported).
+
+set -eu
+
+SCRIPT="$(dirname "$0")/../../scripts/uvicorn-launch.sh"
+
+PASS=0
+FAIL=0
+
+_pass() { echo "PASS: $1"; PASS=$((PASS+1)); }
+_fail() { echo "FAIL: $1"; FAIL=$((FAIL+1)); }
+
+# ---------------------------------------------------------------------------
+# Stub uvicorn so we can capture the command line without a real Python env.
+# We put a fake "uvicorn" ahead of the real one (or the missing one) on PATH.
+# ---------------------------------------------------------------------------
+TMPDIR_STUB="$(mktemp -d)"
+STUB_BIN="$TMPDIR_STUB/uvicorn"
+
+# Stub writes the full argv to a file for inspection, then exits 0.
+cat > "$STUB_BIN" << 'EOF'
+#!/bin/sh
+echo "$@" > "$STUB_CAPTURE_FILE"
+EOF
+chmod +x "$STUB_BIN"
+ORIG_PATH="$PATH"
+export PATH="$TMPDIR_STUB:$PATH"
+
+# Also stub getent so we can simulate DNS outcomes without a real network.
+STUB_GETENT="$TMPDIR_STUB/getent"
+
+# ---- Test 1: UVICORN_FORWARDED_ALLOW_IPS override is honoured ---------------
+STUB_CAPTURE="$TMPDIR_STUB/capture_t1.txt"
+export STUB_CAPTURE_FILE="$STUB_CAPTURE"
+
+UVICORN_FORWARDED_ALLOW_IPS="10.0.0.99" \
+    sh "$SCRIPT" "app.main:app" --host 0.0.0.0 --port 8000 > /dev/null 2>&1
+ARGV="$(cat "$STUB_CAPTURE" 2>/dev/null || echo '')"
+if echo "$ARGV" | grep -q -- '--forwarded-allow-ips=10.0.0.99'; then
+    _pass "env-var override sets --forwarded-allow-ips=10.0.0.99"
+else
+    _fail "env-var override: expected --forwarded-allow-ips=10.0.0.99, got: $ARGV"
+fi
+unset UVICORN_FORWARDED_ALLOW_IPS
+
+# ---- Test 2: --proxy-headers flag is always present -------------------------
+if echo "$ARGV" | grep -q -- '--proxy-headers'; then
+    _pass "--proxy-headers present when env-var override used"
+else
+    _fail "--proxy-headers missing when env-var override used. Args: $ARGV"
+fi
+
+# ---- Test 3: module:app target is the first uvicorn argument ----------------
+FIRST_ARG="$(echo "$ARGV" | awk '{print $1}')"
+if [ "$FIRST_ARG" = "app.main:app" ]; then
+    _pass "module:app target is the first uvicorn argument"
+else
+    _fail "expected first arg 'app.main:app', got: $FIRST_ARG"
+fi
+
+# ---- Test 4: extra args are passed through ----------------------------------
+if echo "$ARGV" | grep -q -- '--host 0.0.0.0' && echo "$ARGV" | grep -q -- '--port 8000'; then
+    _pass "extra args (--host, --port) are passed through"
+else
+    _fail "extra args missing from uvicorn command. Args: $ARGV"
+fi
+
+# ---- Test 5: DNS fallback to 127.0.0.1 when getent returns nothing ----------
+# Provide a getent stub that simulates "no caddy DNS entry".
+cat > "$STUB_GETENT" << 'EOF'
+#!/bin/sh
+# simulate DNS miss: output nothing, exit 1
+exit 1
+EOF
+chmod +x "$STUB_GETENT"
+
+STUB_CAPTURE="$TMPDIR_STUB/capture_t5.txt"
+export STUB_CAPTURE_FILE="$STUB_CAPTURE"
+
+sh "$SCRIPT" "retrieval_api.main:app" --host 0.0.0.0 --port 8040 > /dev/null 2>&1
+ARGV5="$(cat "$STUB_CAPTURE" 2>/dev/null || echo '')"
+if echo "$ARGV5" | grep -q -- '--forwarded-allow-ips=127.0.0.1'; then
+    _pass "DNS miss falls back to --forwarded-allow-ips=127.0.0.1"
+else
+    _fail "DNS miss fallback: expected --forwarded-allow-ips=127.0.0.1, got: $ARGV5"
+fi
+
+# ---- Test 6: DNS success uses resolved IP -----------------------------------
+# Provide a getent stub that simulates a successful Caddy DNS resolution.
+cat > "$STUB_GETENT" << 'EOF'
+#!/bin/sh
+# simulate successful caddy DNS resolution
+echo "172.20.0.5   caddy"
+EOF
+chmod +x "$STUB_GETENT"
+
+STUB_CAPTURE="$TMPDIR_STUB/capture_t6.txt"
+export STUB_CAPTURE_FILE="$STUB_CAPTURE"
+
+sh "$SCRIPT" "knowledge_ingest.app:app" --host 0.0.0.0 --port 8000 > /dev/null 2>&1
+ARGV6="$(cat "$STUB_CAPTURE" 2>/dev/null || echo '')"
+if echo "$ARGV6" | grep -q -- '--forwarded-allow-ips=172.20.0.5'; then
+    _pass "DNS success uses resolved IP --forwarded-allow-ips=172.20.0.5"
+else
+    _fail "DNS success: expected --forwarded-allow-ips=172.20.0.5, got: $ARGV6"
+fi
+
+# ---- Test 7: missing first argument causes non-zero exit --------------------
+if sh "$SCRIPT" 2>/dev/null; then
+    _fail "missing module:app argument should exit non-zero"
+else
+    _pass "missing module:app argument exits non-zero"
+fi
+
+# ---- Cleanup ----------------------------------------------------------------
+rm -rf "$TMPDIR_STUB"
+export PATH="$ORIG_PATH"
+
+# ---- Summary ----------------------------------------------------------------
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -ne 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- **What was duplicated before:** Four services each carried their own copy of the `--proxy-headers --forwarded-allow-ips` launch logic. The canonical version (portal-api `entrypoint.sh`) performed a dynamic DNS lookup via `getent hosts caddy`; the other three (retrieval-api, knowledge-ingest, scribe-api) had a hardcoded `--forwarded-allow-ips 127.0.0.1` inline in the Dockerfile `CMD`.
- **What this PR does:** Extracts a single `scripts/uvicorn-launch.sh` that all four services now share. The script resolves the Caddy container IP at start time via Docker's embedded DNS and falls back to `127.0.0.1` when Caddy is unreachable. An `UVICORN_FORWARDED_ALLOW_IPS` env-var override path is available for tests and special deployments.
- **Shell unit tests** added in `tests/scripts/test_uvicorn_launch.sh` covering the env-var override path, DNS miss fallback, DNS success, missing-arg exit, and extra-arg pass-through.

## How the script resolves Caddy IP

1. If `UVICORN_FORWARDED_ALLOW_IPS` is set, that value is used directly (test / override path).
2. Otherwise `getent hosts caddy` is called; the first IP in the output is used.
3. If the lookup returns nothing (bootstrap race, network misconfiguration), the script falls back to `127.0.0.1` — safe default that keeps the service up but ignores X-Forwarded-For, making the misconfiguration visible in logs.

## Test plan

- [ ] **portal-api**: `docker build -f klai-portal/backend/Dockerfile .` succeeds. Container started with `caddy` as a network peer resolves the Caddy IP; `docker exec ... ps aux | grep uvicorn` shows `--forwarded-allow-ips=172.x.y.z`.
- [ ] **retrieval-api**: `docker build -f klai-retrieval-api/Dockerfile .` succeeds. Container started in isolation shows `--forwarded-allow-ips=127.0.0.1` (DNS miss fallback) in the process list.
- [ ] **knowledge-ingest**: same as retrieval-api.
- [ ] **scribe-api**: same as retrieval-api.
- [ ] **Shell unit tests**: `sh tests/scripts/test_uvicorn_launch.sh` reports 7 passed, 0 failed.
- [ ] CI Docker build workflows (portal-api.yml, retrieval-api.yml, knowledge-ingest.yml, scribe-api.yml) all pass — these build from repo root context so `scripts/uvicorn-launch.sh` is in the build context for each.

## Files changed

| File | Change |
|---|---|
| `scripts/uvicorn-launch.sh` | New — shared launcher |
| `tests/scripts/test_uvicorn_launch.sh` | New — shell unit tests |
| `klai-portal/backend/entrypoint.sh` | Delegates to shared launcher after alembic |
| `klai-portal/backend/Dockerfile` | COPYs `scripts/uvicorn-launch.sh` to `/app/scripts/` |
| `klai-retrieval-api/Dockerfile` | COPYs script; replaces inline CMD |
| `klai-knowledge-ingest/Dockerfile` | COPYs script; replaces inline CMD |
| `klai-scribe/scribe-api/Dockerfile` | COPYs script; replaces inline CMD |

SPEC-SEC-WEBHOOK-001 REQ-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)