### PR TITLE
fix(caddy): SPEC-SEC-AUDIT-2026-04 C1 — defense-in-depth header strip on public routes

### DIFF
--- a/deploy/caddy/Caddyfile
+++ b/deploy/caddy/Caddyfile
@@ -70,6 +70,25 @@
     # in the service code is a SPEC-SEC-HYGIENE-001 violation.
     # ────────────────────────────────────────────────────────────────────────
 
+    # SPEC-SEC-AUDIT-2026-04 C1: strip internal-trust headers on every inbound
+    # public reverse_proxy. These headers are ONLY valid when set by internal
+    # services — a client spoofing them must never reach an upstream.
+    # header_up with a "-" prefix removes the named request header before
+    # forwarding. This is a no-op if the header is absent, so it is safe on
+    # all routes including those that don't read these headers today.
+    #
+    # Headers stripped:
+    #   X-Internal-Secret  — service-to-service shared secret (klai-mailer,
+    #                         knowledge-ingest, retrieval-api, scribe-api,
+    #                         connector, knowledge-mcp)
+    #   X-Caller-Service   — IDENTITY-ASSERT caller identity claim
+    #   X-Org-ID           — tenant scope injected by portal on internal hops
+    #   X-User-ID          — user identity injected by portal/knowledge-mcp
+    #
+    # DO NOT strip on tenant caddyfiles (imported below) — those route
+    # LibreChat <-> knowledge-mcp on the internal Docker network where
+    # these headers are legitimately set.
+
     # Logs ingest (VictoriaLogs push endpoint for remote Alloy agents)
     @logs-ingest host logs-ingest.{$DOMAIN}
     handle @logs-ingest {
@@ -80,6 +99,10 @@
         # VictoriaLogs requires basic auth — pass credentials upstream
         reverse_proxy victorialogs:9428 {
             header_up Authorization "Basic {$VICTORIALOGS_BASIC_AUTH_B64}"
+            header_up -X-Internal-Secret
+            header_up -X-Caller-Service
+            header_up -X-Org-ID
+            header_up -X-User-ID
         }
     }
 
@@ -89,14 +112,24 @@
         # Allow framing from our own domains for OIDC flow inside portal iframe.
         header Content-Security-Policy "frame-ancestors 'self' *.{$DOMAIN}"
         # Zitadel handles its own rate limiting internally
-        reverse_proxy h2c://zitadel:8080
+        reverse_proxy h2c://zitadel:8080 {
+            header_up -X-Internal-Secret
+            header_up -X-Caller-Service
+            header_up -X-Org-ID
+            header_up -X-User-ID
+        }
     }
 
     # LiteLLM model proxy — /health only (for uptime monitoring)
     @llm host llm.{$DOMAIN}
     handle @llm {
         handle /health/liveliness {
-            reverse_proxy litellm:4000
+            reverse_proxy litellm:4000 {
+                header_up -X-Internal-Secret
+                header_up -X-Caller-Service
+                header_up -X-Org-ID
+                header_up -X-User-ID
+            }
         }
         respond 403
     }
@@ -115,7 +148,12 @@
                 window 1m
             }
         }
-        reverse_proxy grafana:3000
+        reverse_proxy grafana:3000 {
+            header_up -X-Internal-Secret
+            header_up -X-Caller-Service
+            header_up -X-Org-ID
+            header_up -X-User-ID
+        }
     }
 
     @grafana host grafana.{$DOMAIN}
@@ -129,7 +167,12 @@
         }
         @grafana-html path / /login /logout /d/* /dashboards* /explore* /alerting* /datasources* /plugins* /admin*
         header @grafana-html Cache-Control "no-cache, no-store, must-revalidate"
-        reverse_proxy grafana:3000
+        reverse_proxy grafana:3000 {
+            header_up -X-Internal-Secret
+            header_up -X-Caller-Service
+            header_up -X-Org-ID
+            header_up -X-User-ID
+        }
     }
 
     # GlitchTip (frontend error tracking)
@@ -142,7 +185,12 @@
                 window 1m
             }
         }
-        reverse_proxy glitchtip-web:8000
+        reverse_proxy glitchtip-web:8000 {
+            header_up -X-Internal-Secret
+            header_up -X-Caller-Service
+            header_up -X-Org-ID
+            header_up -X-User-ID
+        }
     }
 
     # Connector API (GitHub + external source sync) — must be before portal /api/* catch-all
@@ -155,7 +203,12 @@
                 window 1m
             }
         }
-        reverse_proxy klai-connector:8200
+        reverse_proxy klai-connector:8200 {
+            header_up -X-Internal-Secret
+            header_up -X-Caller-Service
+            header_up -X-Org-ID
+            header_up -X-User-ID
+        }
     }
 
     # Portal API — stricter limit on sensitive provisioning endpoints
@@ -170,13 +223,22 @@
                 window 1m
             }
         }
-        reverse_proxy portal-api:8010
+        reverse_proxy portal-api:8010 {
+            header_up -X-Internal-Secret
+            header_up -X-Caller-Service
+            header_up -X-Org-ID
+            header_up -X-User-ID
+        }
     }
 
     # Knowledge base images served via Garage S3 website endpoint (anonymous reads)
     handle_path /kb-images/* {
         reverse_proxy garage:3902 {
             header_up Host klai-images.web.garage
+            header_up -X-Internal-Secret
+            header_up -X-Caller-Service
+            header_up -X-Org-ID
+            header_up -X-User-ID
         }
     }
 
@@ -189,7 +251,12 @@
                 window 1m
             }
         }
-        reverse_proxy portal-api:8010
+        reverse_proxy portal-api:8010 {
+            header_up -X-Internal-Secret
+            header_up -X-Caller-Service
+            header_up -X-Org-ID
+            header_up -X-User-ID
+        }
     }
 
     # Dev environment — dev.getklai.com routes to portal-api-dev + /srv/portal-dev
@@ -205,7 +272,12 @@
         }
         route {
             @dev-api path /api/*
-            reverse_proxy @dev-api portal-api-dev:8010
+            reverse_proxy @dev-api portal-api-dev:8010 {
+                header_up -X-Internal-Secret
+                header_up -X-Caller-Service
+                header_up -X-Org-ID
+                header_up -X-User-ID
+            }
 
             root * /srv/portal-dev
 
@@ -221,7 +293,12 @@
     }
 
     handle /api/* {
-        reverse_proxy portal-api:8010
+        reverse_proxy portal-api:8010 {
+            header_up -X-Internal-Secret
+            header_up -X-Caller-Service
+            header_up -X-Org-ID
+            header_up -X-User-ID
+        }
     }
 
     # SEC-023 / F-038 — Scribe/Docs are no longer publicly routed.
@@ -244,7 +321,12 @@
             }
         }
         uri strip_prefix /bots
-        reverse_proxy api-gateway:8000
+        reverse_proxy api-gateway:8000 {
+            header_up -X-Internal-Secret
+            header_up -X-Caller-Service
+            header_up -X-Org-ID
+            header_up -X-User-ID
+        }
     }
 
     # Portal SPA — static files (fallback for all *.${DOMAIN})

--- a/tests/caddy/test_caddyfile_strips_internal_headers.py
+++ b/tests/caddy/test_caddyfile_strips_internal_headers.py
@@ -1,0 +1,152 @@
+"""
+Static analysis regression test — SPEC-SEC-AUDIT-2026-04 C1.
+
+Verifies that every public-facing ``reverse_proxy`` block in the Caddyfile
+strips all internal-trust headers before forwarding the request upstream.
+
+Background
+----------
+No portal-api inbound endpoint currently reads ``X-Internal-Secret`` from
+``request.headers`` (they compare against ``settings.internal_secret``
+instead), so the finding is not exploitable today.  However, Caddy stripping
+the header at the edge is the defense-in-depth control that ensures even a
+future endpoint regression cannot be exploited externally.
+
+Headers in scope (SPEC-SEC-AUDIT-2026-04 C1):
+    X-Internal-Secret  — service-to-service shared secret
+    X-Caller-Service   — IDENTITY-ASSERT caller identity
+    X-Org-ID           — tenant scope injected on internal hops
+    X-User-ID          — user identity injected by portal / knowledge-mcp
+
+What this test does NOT check
+------------------------------
+* Tenant caddyfiles imported from ``/etc/caddy/tenants/*.caddyfile`` — those
+  route LibreChat <-> knowledge-mcp on the internal Docker network, where
+  these headers are legitimately present.  The import directive itself is
+  detected and excluded from the assertion set.
+* The syntax correctness of the Caddyfile — use ``caddy validate`` for that.
+"""
+
+from __future__ import annotations
+
+import re
+import textwrap
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Locate the Caddyfile relative to this test file.
+# Repo layout: tests/caddy/ -> ../../deploy/caddy/Caddyfile
+# ---------------------------------------------------------------------------
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CADDYFILE = _REPO_ROOT / "deploy" / "caddy" / "Caddyfile"
+
+# Headers that MUST be stripped in every public-facing reverse_proxy block.
+_REQUIRED_STRIPS = {
+    "X-Internal-Secret",
+    "X-Caller-Service",
+    "X-Org-ID",
+    "X-User-ID",
+}
+
+
+def _extract_reverse_proxy_blocks(text: str) -> list[tuple[int, str]]:
+    """Return (line_number, block_text) for every reverse_proxy directive.
+
+    Each block is the ``reverse_proxy <upstream> { ... }`` span.
+    Single-line ``reverse_proxy <upstream>`` (no braces) are also returned
+    as single-line blocks — they have no header_up directives, which will
+    cause the test to fail as intended.
+    """
+    blocks: list[tuple[int, str]] = []
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines):
+        stripped = lines[i].lstrip()
+        if not stripped.startswith("reverse_proxy "):
+            i += 1
+            continue
+        line_no = i + 1  # 1-based for error messages
+        # Look-ahead: is there an opening brace on the same line or next?
+        rest = stripped
+        brace_depth = rest.count("{") - rest.count("}")
+        block_lines = [rest]
+        j = i + 1
+        if brace_depth > 0:
+            while j < len(lines) and brace_depth > 0:
+                l = lines[j]
+                brace_depth += l.count("{") - l.count("}")
+                block_lines.append(l.strip())
+                j += 1
+        blocks.append((line_no, "\n".join(block_lines)))
+        i = j if j > i + 1 else i + 1
+    return blocks
+
+
+def _block_strips_header(block: str, header: str) -> bool:
+    """Return True if the block contains ``header_up -<header>``."""
+    # Match both exact case and case-insensitive variants.
+    pattern = re.compile(
+        r"header_up\s+-" + re.escape(header),
+        re.IGNORECASE,
+    )
+    return bool(pattern.search(block))
+
+
+def _is_internal_only_block(context_before: str) -> bool:
+    """Heuristic: block is preceded by an import or tenant comment."""
+    return "import" in context_before.lower()
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+def test_caddyfile_exists() -> None:
+    assert _CADDYFILE.exists(), (
+        f"Caddyfile not found at {_CADDYFILE}. "
+        "Run this test from the repository root."
+    )
+
+
+def test_public_reverse_proxy_strips_internal_headers() -> None:
+    """Every public-facing reverse_proxy block must strip all internal-trust headers."""
+    text = _CADDYFILE.read_text(encoding="utf-8")
+    blocks = _extract_reverse_proxy_blocks(text)
+
+    assert blocks, "No reverse_proxy directives found — is the Caddyfile path correct?"
+
+    failures: list[str] = []
+
+    for line_no, block in blocks:
+        # Skip single-line blocks that proxy to the Garage S3 website host
+        # but only have a Host header_up — those also need the strip directives,
+        # so we intentionally do NOT skip them here.
+
+        missing = [
+            h for h in sorted(_REQUIRED_STRIPS) if not _block_strips_header(block, h)
+        ]
+        if missing:
+            preview = textwrap.shorten(block.replace("\n", " "), width=120)
+            failures.append(
+                f"  Line {line_no}: missing header_up strip(s) for {missing!r}\n"
+                f"    Block: {preview}"
+            )
+
+    if failures:
+        joined = "\n".join(failures)
+        raise AssertionError(
+            "SPEC-SEC-AUDIT-2026-04 C1 regression:\n"
+            "The following reverse_proxy blocks do not strip all internal-trust headers.\n"
+            "Add `header_up -<HeaderName>` inside each block listed below.\n\n"
+            + joined
+        )
+
+
+def test_required_strips_comment_present() -> None:
+    """The Caddyfile must contain the SPEC reference comment for auditability."""
+    text = _CADDYFILE.read_text(encoding="utf-8")
+    assert "SPEC-SEC-AUDIT-2026-04 C1" in text, (
+        "Expected the SPEC-SEC-AUDIT-2026-04 C1 audit comment to be present "
+        "in deploy/caddy/Caddyfile."
+    )


### PR DESCRIPTION
## Summary

- Strips 4 internal-trust headers on all 13 public-facing `reverse_proxy` blocks in `deploy/caddy/Caddyfile`
- Adds a static-analysis regression test that will fail CI if a future Caddyfile edit removes a strip

## Headers stripped

| Header | Purpose | Risk if spoofed |
|---|---|---|
| `X-Internal-Secret` | Service-to-service shared secret | Bypass internal auth checks |
| `X-Caller-Service` | IDENTITY-ASSERT caller identity claim | Impersonate a trusted internal service |
| `X-Org-ID` | Tenant scope injected on internal hops | Cross-tenant data access |
| `X-User-ID` | User identity injected by portal/knowledge-mcp | Identity spoofing |

## Reverse_proxy blocks affected (all 13 public-facing)

| Block | Upstream |
|---|---|
| `@logs-ingest` | `victorialogs:9428` |
| `@auth` | `zitadel:8080` |
| `@llm /health/liveliness` | `litellm:4000` |
| `@grafana-health` | `grafana:3000` |
| `@grafana` | `grafana:3000` |
| `@glitchtip` | `glitchtip-web:8000` |
| `@connector` | `klai-connector:8200` |
| `@portal-api-sensitive` | `portal-api:8010` |
| `/kb-images/*` | `garage:3902` |
| `/partner/*` | `portal-api:8010` |
| `@dev-host /api/*` | `portal-api-dev:8010` |
| `/api/*` | `portal-api:8010` |
| `/bots/*` | `api-gateway:8000` |

## What is NOT touched

Tenant caddyfiles (`import /etc/caddy/tenants/*.caddyfile`) are left unchanged. Those route LibreChat ↔ knowledge-mcp on the Docker-internal network, where `X-Internal-Secret`, `X-User-ID`, and `X-Org-ID` are legitimately set by internal services.

## Exploitability today

Not exploitable at merge time: all portal-api endpoints compare against `settings.internal_secret` directly — none read `X-Internal-Secret` from `request.headers`. This PR closes the defense-in-depth gap so a future endpoint regression cannot be exploited from the public internet.

## Deploy note

The `caddy.yml` workflow does `docker compose up -d caddy` which recreates the container with the new config. Caddy reloads its config on startup. No manual steps required.

## Regression test

`tests/caddy/test_caddyfile_strips_internal_headers.py` — pure Python static analysis, no runtime deps beyond pytest. Parses the Caddyfile and asserts every `reverse_proxy` block contains all four `header_up -<Header>` directives. Verified locally:

```
3 passed in 0.12s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)