### PR TITLE
fix(mailer): observability — re-enable uvicorn.access at INFO with healthcheck filter

### DIFF
--- a/klai-mailer/app/logging_setup.py
+++ b/klai-mailer/app/logging_setup.py
@@ -10,6 +10,43 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
 
+# Paths that the access log SHALL drop. Healthcheck spam from Docker's
+# liveness probe (every ~10s) drowns the signal of real /notify and
+# /internal/send requests. Route paths must match `request_line` byte-for-byte
+# as uvicorn formats them: ``GET /health HTTP/1.1`` (no host, no query).
+_ACCESS_LOG_FILTERED_PATHS: frozenset[str] = frozenset({"/health"})
+
+
+class _HealthCheckAccessFilter(logging.Filter):
+    """Drop uvicorn access log records for healthcheck endpoints.
+
+    SPEC-SEC-MAILER-INJECTION-001 v0.3.2 follow-up: yesterday's /notify
+    500 outage was four-times longer to diagnose than necessary because the
+    mailer suppressed ``uvicorn.access`` at WARNING level — request
+    lines never appeared in ``docker logs``. Re-enabling INFO shows the
+    real request flow but also surfaces every Docker healthcheck. This
+    filter removes the noise without removing the signal.
+
+    The filter inspects ``record.args`` (the tuple uvicorn passes to
+    its ``%s "%s %s HTTP/%s" %d`` format string) so it works regardless
+    of the eventual rendered message. Defensive against changes to
+    uvicorn's access-log format: if ``args`` is missing or doesn't
+    match the expected shape, the record passes through (we'd rather
+    leak a healthcheck line than swallow a real request log).
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        args = record.args
+        if not isinstance(args, tuple) or len(args) < 3:
+            return True
+        # uvicorn access record args: (client_addr, method, full_path, http_version, status_code)
+        full_path = args[2]
+        if not isinstance(full_path, str):
+            return True
+        # full_path looks like "/health" or "/health?check=1"; split on '?'
+        path_only = full_path.split("?", 1)[0]
+        return path_only not in _ACCESS_LOG_FILTERED_PATHS
+
 
 def setup_logging(service_name: str = "klai-mailer") -> None:
     """Configure structlog with stdlib integration.
@@ -56,7 +93,13 @@ def setup_logging(service_name: str = "klai-mailer") -> None:
     root_logger.addHandler(handler)
     root_logger.setLevel(logging.INFO)
 
-    logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
+    # uvicorn.access at INFO so every request is visible in `docker logs`
+    # — the diagnostic signal that was missing during the 2026-04-29 mailer
+    # /notify 500 outage. Spam from Docker healthcheck is filtered out via
+    # _HealthCheckAccessFilter so signal-to-noise stays good.
+    access_logger = logging.getLogger("uvicorn.access")
+    access_logger.setLevel(logging.INFO)
+    access_logger.addFilter(_HealthCheckAccessFilter())
     logging.getLogger("sqlalchemy.engine").setLevel(logging.WARNING)
     logging.getLogger("httpx").setLevel(logging.WARNING)
 

--- a/klai-mailer/tests/test_logging_setup.py
+++ b/klai-mailer/tests/test_logging_setup.py
@@ -1,0 +1,121 @@
+"""Tests for ``app.logging_setup`` — the access-log filter that keeps
+healthcheck spam out of ``docker logs`` while preserving signal on
+real requests.
+
+Yesterday's 2026-04-29 mailer /notify 500 outage was four-times longer to
+diagnose than necessary because ``uvicorn.access`` had been suppressed
+at WARNING level — request lines never appeared in ``docker logs``.
+This module re-enables INFO and adds a healthcheck filter; the tests
+below pin both the access-record-passes contract and the
+healthcheck-record-drops contract.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from app.logging_setup import _HealthCheckAccessFilter
+
+
+def _make_access_record(method: str, path: str, status: int) -> logging.LogRecord:
+    """Build a LogRecord shaped like uvicorn's access logger emits.
+
+    uvicorn formats access lines as
+    ``%s - "%s %s HTTP/%s" %d`` with ``args`` being
+    ``(client_addr, method, full_path, http_version, status_code)``.
+    The filter inspects ``args`` directly, so the message-format string
+    here is irrelevant — only ``args`` matters.
+    """
+    record = logging.LogRecord(
+        name="uvicorn.access",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg='%s - "%s %s HTTP/%s" %d',
+        args=("127.0.0.1:54321", method, path, "1.1", status),
+        exc_info=None,
+    )
+    return record
+
+
+class TestHealthCheckAccessFilter:
+    """The filter MUST drop /health access lines and pass everything else."""
+
+    def setup_method(self) -> None:
+        self.filter = _HealthCheckAccessFilter()
+
+    def test_health_get_dropped(self) -> None:
+        record = _make_access_record("GET", "/health", 200)
+        assert self.filter.filter(record) is False
+
+    def test_health_with_query_dropped(self) -> None:
+        """Docker healthcheck might add `?check=1` or similar — still dropped."""
+        record = _make_access_record("GET", "/health?probe=1", 200)
+        assert self.filter.filter(record) is False
+
+    def test_notify_passes(self) -> None:
+        """The signal record we MUST keep — every /notify request."""
+        record = _make_access_record("POST", "/notify", 500)
+        assert self.filter.filter(record) is True
+
+    def test_internal_send_passes(self) -> None:
+        record = _make_access_record("POST", "/internal/send", 200)
+        assert self.filter.filter(record) is True
+
+    def test_404_passes(self) -> None:
+        """An unknown path is potential probing — keep it visible."""
+        record = _make_access_record("GET", "/wp-admin", 404)
+        assert self.filter.filter(record) is True
+
+    def test_root_passes(self) -> None:
+        record = _make_access_record("GET", "/", 200)
+        assert self.filter.filter(record) is True
+
+    def test_path_starting_with_health_passes(self) -> None:
+        """The filter is byte-strict on ``/health``; only the exact path
+        is dropped, not ``/health/foo`` or ``/healthcheck``."""
+        for path in ("/healthcheck", "/health/sub", "/healthx"):
+            record = _make_access_record("GET", path, 200)
+            assert self.filter.filter(record) is True, f"path {path!r} was dropped"
+
+    def test_record_with_no_args_passes(self) -> None:
+        """Defensive: if the record doesn't have the expected args shape
+        (e.g. a future uvicorn change), the filter passes the record
+        through rather than dropping a potentially-important line."""
+        record = logging.LogRecord(
+            name="uvicorn.access",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="some other format",
+            args=None,
+            exc_info=None,
+        )
+        assert self.filter.filter(record) is True
+
+    def test_record_with_unexpected_args_shape_passes(self) -> None:
+        """Same defensive contract — short args tuple."""
+        record = logging.LogRecord(
+            name="uvicorn.access",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="x %s",
+            args=("only-one",),
+            exc_info=None,
+        )
+        assert self.filter.filter(record) is True
+
+    def test_record_with_non_string_path_passes(self) -> None:
+        """Defensive: if args[2] is not a string, pass through rather
+        than crash on ``.split``."""
+        record = logging.LogRecord(
+            name="uvicorn.access",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg='%s - "%s %s HTTP/%s" %d',
+            args=("127.0.0.1", "GET", 12345, "1.1", 200),
+            exc_info=None,
+        )
+        assert self.filter.filter(record) is True


### PR DESCRIPTION
## Why

Closes the observability gap that made yesterday's mailer /notify 500 outage four-times longer to diagnose than necessary. The mailer's `setup_logging()` had been suppressing `uvicorn.access` at WARNING level — every request line was dropped, including the actual `POST /notify 500` calls. Spent 30 minutes hunting for the request entry in stdout before tailing the live container surfaced the ASGI traceback.

## What changed

- `klai-mailer/app/logging_setup.py`:
  - `uvicorn.access` level: `WARNING` → `INFO`
  - New `_HealthCheckAccessFilter` drops `GET /health` access lines (Docker healthcheck noise) — byte-strict on the path, defensive on unexpected `record.args` shapes
- `klai-mailer/tests/test_logging_setup.py` (new, 10 cases): healthcheck-drops + signal-passes + byte-strict boundary + defensive-shape contracts

## Verification before merge

- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run pytest tests/test_logging_setup.py -v` — 10/10 pass
- [x] `uv run pytest -q` — 90/90 mailer suite pass

## Out of scope

Other klai services (portal-api, retrieval-api, knowledge-ingest, scribe-api, connector, knowledge-mcp, focus, whisper-server) all apply the same WARNING suppression — 9 services in total. Each has different healthcheck cadence and observability priorities. The mailer is the proof-of-concept; if the pattern proves useful, it propagates per-service in follow-up PRs.

## Rollback

```bash
git revert c586ed15
git push origin main
```

The revert restores WARNING-level access logs (the broken-for-diagnosis state). Forward-fix is preferred — every operator-visible signal that this PR adds is one less reason for the next mailer outage to be invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)