### PR TITLE
docs(spec): three follow-up SPEC stubs from 2026-04-29 outage retro

### DIFF
--- a/.moai/specs/SPEC-AUTH-TOTP-POPORDER-001/spec.md
+++ b/.moai/specs/SPEC-AUTH-TOTP-POPORDER-001/spec.md
@@ -1,0 +1,122 @@
+---
+id: SPEC-AUTH-TOTP-POPORDER-001
+version: "0.1.0"
+status: draft
+created: "2026-04-30"
+updated: "2026-04-30"
+author: MoAI
+priority: medium
+issue_number: 0
+---
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 0.1.0 | 2026-04-30 | MoAI | Stub created from SPEC-SEC-HYGIENE-001 v0.7.1 follow-up — `_pending_totp.pop()` ordering UX-fidelity bug uncovered during the 2026-04-29 callback-allowlist incident. |
+
+# SPEC-AUTH-TOTP-POPORDER-001: TOTP pending-token pop ordering on finalize failure
+
+## Overview
+
+Fix a UX-fidelity bug in `klai-portal/backend/app/api/auth.py::totp_login`. When Zitadel's `update_session_with_totp` succeeds but the subsequent `_finalize_and_set_cookie` raises (e.g. transient infra failure, a system bug like the 2026-04-29 REQ-20 callback-allowlist regression), the `_pending_totp.pop(body.temp_token)` call has already wiped the temp token. The user's retry then hits the "Session expired" branch (HTTP 400) — even though the actual problem is a 5xx system error, not user input.
+
+This is not a security/correctness bug — Zitadel's session is the authority — but it produces a misleading error message that pushes the user to "log in again from scratch" when in fact the system was wrong, not the user.
+
+## Environment
+
+- **Service:** klai-portal-api (FastAPI)
+- **Module:** [klai-portal/backend/app/api/auth.py](../../../klai-portal/backend/app/api/auth.py) — `totp_login` handler
+- **Affected lines:** approx. 680-755 (handler body)
+- **Related SPECs:** SPEC-AUTH-001 (login lifecycle), SPEC-SEC-HYGIENE-001 (REQ-20 callback validator) — the 502 failure mode that exposed this bug.
+
+## Assumptions
+
+- A1: `_pending_totp` is an in-memory dict keyed by `temp_token`. Single-instance only — when scaled horizontally this becomes a Redis-backed cache (separate concern).
+- A2: A successful `update_session_with_totp` call is idempotent on the (session_id, session_token) pair, BUT the TOTP code itself is one-time-use. So a retry with the same code WITHOUT first calling Zitadel again will fail at Zitadel.
+- A3: The user-visible failure mode today (`HTTP 400 "Session expired, please log in again"`) is acceptable in the strict sense — re-login is always safe — but is a poor UX signal when the actual fault is server-side.
+
+## Requirements
+
+### R1 — Ubiquitous: temp-token lifetime tied to terminal handler outcomes
+
+The `_pending_totp` entry SHALL persist for the entire `totp_login` handler lifetime and SHALL be popped only on a TERMINAL outcome:
+
+- **Success** — `_finalize_and_set_cookie` returns and the response is set.
+- **User error** — TOTP code rejected by Zitadel (`update_session_with_totp` raised `httpx.HTTPStatusError` with status 400 or 401).
+- **Lockout** — `_TOTP_MAX_FAILURES` reached.
+
+The temp-token entry SHALL NOT be popped when the handler raises a `5xx`-class HTTPException after a successful Zitadel TOTP verification, because the user has nothing to fix and a retry within the temp-token TTL is the natural recovery path.
+
+### R2 — Event-driven: idempotent retry after 5xx finalize failure
+
+WHEN the user retries `POST /api/auth/totp-login` with the same `temp_token` after a previous 5xx response THEN the handler SHALL detect the "post-Zitadel-success, pre-finalize" state stored on the pending entry, SHALL skip the (already-completed) Zitadel TOTP verification, and SHALL retry only the finalize step.
+
+### R3 — State-driven: TTL-bounded retry window
+
+IF a temp-token entry is in the post-Zitadel-success state THEN it SHALL expire 60 seconds after the original successful Zitadel call. After expiry, retries return `HTTP 400 "Session expired, please log in again"` (current behaviour) so an abandoned session does not leak Zitadel-session tokens indefinitely.
+
+### R4 — Unwanted Behavior: no security regression
+
+The following invariants MUST hold:
+
+- A retry with the same `temp_token` MUST NOT bypass `_TOTP_MAX_FAILURES` accounting.
+- A retry MUST NOT re-issue the SSO cookie if a previous successful retry already issued one (one-token, one-cookie).
+- The TOTP code itself MUST NOT be cached — only the post-Zitadel session_id and session_token are stored on the pending entry.
+
+### R5 — Optional: improved error response on finalize 5xx
+
+Where the finalize step fails with a known transient error class, the response SHALL include a `Retry-After: <seconds>` header so the frontend can auto-retry without forcing a new password+TOTP cycle.
+
+## Specifications
+
+### Pending-token state machine (proposed)
+
+```
+                      +---------------+ Zitadel 200 + finalize 200
+   POST /login OK --->| awaiting-totp |---------------------------------> COMPLETE (popped)
+                      +---------------+
+                              |
+                              | Zitadel 400/401 < _TOTP_MAX_FAILURES
+                              v
+                      +---------------+
+                      | retry-allowed | --- Zitadel 400/401 = max ---> POPPED (lockout 429)
+                      +---------------+
+                              |
+                              | Zitadel 200, finalize 5xx
+                              v
+                      +-------------------+
+                      | finalize-pending  | --- retry & finalize 200 ---> COMPLETE (popped)
+                      | (60s TTL)         |
+                      +-------------------+   --- 60s elapsed ---> POPPED (400 Session expired)
+```
+
+### Acceptance scenarios (preview — full set in `acceptance.md` post-`/moai plan`)
+
+- **AC-1 happy path:** unchanged, retains current behavior; one TOTP submit → SSO cookie → `_pending_totp` popped.
+- **AC-2 wrong code:** `Zitadel 400` → `_pending_totp.failures += 1` → user sees "Invalid code, please try again" (current).
+- **AC-3 finalize 5xx then retry:** Zitadel 200, finalize raises `HTTPException(502)` → `_pending_totp` retains entry in `finalize-pending` state → user retries with same `temp_token` → handler detects state, skips Zitadel call, retries finalize → SSO cookie issued → `_pending_totp` popped. NO "Session expired" misleading error.
+- **AC-4 finalize 5xx then 60s timeout:** as AC-3 but user waits >60s → entry expired → next retry returns `HTTP 400 "Session expired"` (current behaviour preserved for stale sessions).
+- **AC-5 retry after success is no-op:** as AC-3 but user retries AFTER first successful retry → entry already popped → `HTTP 400 "Session expired"` (one-token-one-cookie invariant).
+
+## Files Affected
+
+- `klai-portal/backend/app/api/auth.py` — `totp_login` handler refactor: introduce `_pending_totp` state field, hoist finalize into a separate `_retry_finalize_only` branch.
+- `klai-portal/backend/tests/test_auth_totp_endpoints.py` (or new `test_auth_totp_finalize_retry.py`) — 5 scenarios covering the state machine.
+
+## MX Tag Plan
+
+- `_pending_totp` global is currently `# @MX:NOTE` quality. The state-machine refactor will hoist it to `# @MX:ANCHOR` because fan_in increases (handler reads BOTH on initial submit and on retry path) and the lifetime invariants become safety-critical.
+- `_finalize_and_set_cookie` is `@MX:ANCHOR` already; this SPEC adds a "may be retried after 5xx" note.
+
+## Exclusions
+
+- Replacing `_pending_totp` with a Redis-backed store. Single-instance limitation persists; horizontal scaling is a separate SPEC.
+- Changing the TOTP code-validation semantics or rate-limit policy.
+- Changing the `_finalize_and_set_cookie` failure modes themselves — this SPEC accepts that 5xx exists and makes the user experience graceful.
+
+## Implementation Notes (for `/moai run`)
+
+- Reproduction test: temporarily patch `_validate_callback_url` to raise `HTTPException(502)` and confirm current code wipes `_pending_totp`. The fix should make the same test pass with retry.
+- Be careful with the `_TOTP_MAX_FAILURES` counter: only increment on Zitadel-side failures (400/401), NOT on finalize-side 5xx.
+- Idempotent SSO cookie re-issue: if `klai_sso` already exists on the request, do NOT issue a fresh one on retry — preserve the original-issuer semantics.

--- a/.moai/specs/SPEC-CI-E2E-GATE-001/spec.md
+++ b/.moai/specs/SPEC-CI-E2E-GATE-001/spec.md
@@ -1,0 +1,170 @@
+---
+id: SPEC-CI-E2E-GATE-001
+version: "0.1.0"
+status: draft
+created: "2026-04-30"
+updated: "2026-04-30"
+author: MoAI
+priority: high
+issue_number: 0
+---
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 0.1.0 | 2026-04-30 | MoAI | Stub created as the structural forcing-function answer to the 2026-04-29 dual outage (login 502 + mailer 500). Both regressions could have been caught in the CI deploy window if a real end-to-end login + password-reset smoke had been wired up. |
+
+# SPEC-CI-E2E-GATE-001: Post-deploy E2E smoke gate as a forcing function for security-allowlist regressions
+
+## Overview
+
+Wire `SPEC-TEST-E2E-001` (the manual Playwright smoke runbook) into a CI-driven post-deploy gate that blocks merges of regressions that would 5xx the live login or mailer flows. The gate runs against a dedicated **staging tenant** (NOT production), uses a service-account login (NOT a human's credentials), and reports pass/warn/fail per journey to a GitHub status check on the merge commit.
+
+The forcing-function value of this SPEC is that the next class of regression — a security-allowlist that misses a hostname, a config validator that rejects a real prod value, a dependency that drops a payload field — is caught before the deploy fans out to all production services. Two such regressions hit prod on 2026-04-29 in the same hour because no staging-equivalent test exercised the actual login + mail flow against the deployed image. Both incidents would have been caught by a 90-second smoke run between build-push and deploy.
+
+## Environment
+
+- **Runner:** GitHub Actions on ubuntu-latest with the Playwright Docker image. Triggered after `build-push` succeeds, BEFORE `deploy` runs.
+- **Target tenant:** NEW dedicated staging tenant — `staging.getklai.com` (apex) or `staging-ci.getklai.com`. NOT the existing `getklai.getklai.com` tenant (which is internal Klai usage and is the production-equivalent for Klai-the-customer).
+- **Staging Zitadel:** either a separate Zitadel instance OR the production Zitadel with a dedicated org for staging. Decision deferred to the implementer.
+- **Login mechanism in CI:** dedicated service-user account with TOTP secret stored in GitHub Actions secrets. The smoke uses pyotp (or equivalent) to generate the code at runtime — no human interaction.
+- **Existing artifact reuse:** `.moai/specs/SPEC-TEST-E2E-001/` (the runbook). The CI gate runs a SUBSET of those journeys (auth, chat, throwaway-KB, cleanup, report) — a 90-second tier. The full 14-journey runbook stays as the manual interactive version.
+
+## Assumptions
+
+- A1: The merge-to-main workflow has a `build-push` job followed by a `deploy` job. The gate slots between them.
+- A2: A 90-second budget is acceptable per merge — measured from build complete to deploy start. CI cost ~$0.005 per run; expected runs ~30/day = $4.5/month.
+- A3: The staging tenant can be torn down + reseeded daily (or per-run) without affecting customers. Throwaway data in staging is acceptable; data in production is not.
+- A4: Service-account TOTP secrets stored in GitHub Actions encrypted secrets are sufficiently protected. They are NOT stored in any other location and are scoped to the smoke workflow only.
+- A5: The mailer flow uses a dedicated test inbox (Mailtrap, MailHog, or a `+ci@getklai.com` Gmail filter rule) so the smoke can verify password-reset emails arrive.
+
+## Requirements
+
+### R1 — Ubiquitous: gate runs on every PR merging to main
+
+Every merge commit to `main` SHALL trigger the smoke workflow as a required GitHub status check before `deploy` runs. The check SHALL pass / fail / warn per the per-journey contract from `SPEC-TEST-E2E-001` § R3.
+
+### R2 — Event-driven: build-push success → smoke trigger
+
+WHEN the `build-push` job for any klai service workflow completes successfully on a merge commit THEN the smoke workflow SHALL be triggered with the new image SHA as input. The smoke SHALL deploy the new image to the staging tenant ONLY (not production), run the journey subset, and report results.
+
+### R3 — Event-driven: smoke fail blocks production deploy
+
+WHEN the smoke workflow returns FAIL on any must-pass journey THEN the `deploy` job for production SHALL not run. A GitHub Status of `failure` on the smoke check SHALL prevent the workflow from proceeding to the production-deploy step. An operator override (manual workflow re-run with `--force-deploy` flag) is permitted but SHALL be logged.
+
+### R4 — State-driven: staging tenant is per-run reseeded
+
+IF a smoke run starts THEN it SHALL execute against a freshly-seeded staging tenant state: one known KB, one known template, one known active user with TOTP enabled. State SHALL be reset between runs so each smoke begins from the same baseline.
+
+### R5 — Unwanted Behavior: smoke MUST NOT touch production
+
+The smoke workflow SHALL NEVER call any URL pointing to a production-tenant subdomain (`*.getklai.com` excluding the explicit staging hostnames). A pre-flight URL allowlist SHALL be enforced in the smoke runner; any test action whose target URL fails the allowlist check SHALL abort the run with a clear error.
+
+### R6 — Optional: nightly full-suite smoke
+
+Where a 90-second per-merge gate is too short for the full 14-journey SPEC-TEST-E2E-001 inventory, a separate **nightly** workflow SHALL run the full SPEC against staging on a cron schedule. Nightly results SHALL be posted to a Slack / GitHub Discussion channel for asynchronous review.
+
+### R7 — Optional: smoke result archive
+
+Smoke run reports + screenshots SHALL be uploaded as GitHub Actions artifacts with 14-day retention. This makes it easy to bisect the merge that introduced a regression by reviewing the failing run alongside the passing prior run.
+
+## Specifications
+
+### Smoke journey subset (per-merge gate)
+
+The 90-second tier SHALL cover at minimum:
+
+| # | Journey | Why included |
+|---|---|---|
+| 1 | Login bootstrap | Catches REQ-20-class regressions (callback URL allowlist) |
+| 2 | Auth/shell | Catches RLS / cookie / CORS regressions |
+| 3 | Chat (read-only) | Catches retrieval-api / portal connectivity |
+| 4 | Password-reset email | Catches mailer-class regressions (the 2026-04-29 outage) |
+| 5 | KB write + cleanup | Catches knowledge-ingest deploy errors |
+
+Total budget: ≤90 seconds wall clock.
+
+### Test inbox for password-reset verification (R4 + Journey 4)
+
+Decision (deferred to implementation): Mailtrap.io free tier OR a dedicated Mailtrap-like service hosted in klai-infra. The smoke polls the inbox API for an arrival within 30 seconds of triggering the reset; absence is a FAIL.
+
+### CI/CD wiring
+
+```yaml
+deploy:
+  needs: [build-push, smoke]   # smoke is now blocking
+  if: needs.smoke.outcome == 'success'
+  ...
+
+smoke:
+  needs: [build-push]
+  runs-on: ubuntu-latest
+  timeout-minutes: 3
+  steps:
+    - uses: actions/checkout@v6
+    - uses: docker/setup-buildx-action@v3
+    - run: |
+        # Deploy new image to staging tenant
+        ssh staging-01 "docker compose pull && docker compose up -d ${{ matrix.service }}"
+        # Run the smoke journeys
+        npx playwright test smoke.spec.ts \
+          --reporter=json,junit \
+          --output-dir=.tmp/e2e-screenshots/$RUN_TS/
+    - uses: actions/upload-artifact@v5
+      with:
+        name: smoke-${{ github.sha }}
+        path: .tmp/e2e-reports/
+        retention-days: 14
+```
+
+### Hostname allowlist (REQ-5)
+
+Hardcoded in the smoke runner:
+
+```
+ALLOWED_SMOKE_HOSTS = {
+    "staging.getklai.com",
+    "staging-ci.getklai.com",
+    "auth-staging.getklai.com",
+    "localhost", "127.0.0.1",
+}
+```
+
+Any `page.goto(url)` call where `urlparse(url).hostname not in ALLOWED_SMOKE_HOSTS` aborts the run.
+
+## Files Affected
+
+- New `.github/workflows/post-deploy-smoke.yml` — the smoke workflow.
+- New `tests/e2e/smoke.spec.ts` (or equivalent in chosen test framework) — the actual journey code.
+- New `klai-infra/staging-01/` — staging tenant Docker compose, Caddy config, isolated Zitadel.
+- Existing `.github/workflows/portal-api.yml`, `klai-mailer.yml`, `retrieval-api.yml`, etc. — add `needs: [smoke]` to their `deploy` jobs.
+- Existing `.moai/specs/SPEC-TEST-E2E-001/` — referenced as the source of truth for journey definitions; this SPEC declares which subset becomes the gate.
+
+## MX Tag Plan
+
+- The smoke workflow file is `# @MX:ANCHOR` (deploy gate — fan_in across every klai service workflow).
+- The journey subset definition is `# @MX:ANCHOR` (changing it changes what is and isn't caught).
+
+## Exclusions
+
+- **Replacing manual SPEC-TEST-E2E-001 runbook:** No. The full 14-journey runbook remains as the interactive validation. This SPEC defines a 5-journey CI subset.
+- **Cross-browser, mobile, accessibility coverage:** out of scope; CI smoke is Chromium-only.
+- **Performance benchmarking:** out of scope; existence of the response is the assertion, not response time (beyond a generous timeout).
+- **Backfill smoke for already-merged PRs:** out of scope; the gate is forward-only.
+- **Replacing SPEC-SEC-AUTH-COVERAGE-001 contract tests:** No. Those are unit-level. This SPEC is integration-level.
+
+## Implementation Notes (for `/moai run`)
+
+- Decision points to resolve before implementation:
+  1. Staging tenant infrastructure: dedicated server vs core-01 with namespace isolation
+  2. Test inbox: Mailtrap.io vs self-hosted MailHog vs Gmail `+ci` filter
+  3. Service-account TOTP: how to rotate the seed if the GitHub Actions secret is exposed
+  4. Failure-mode budget: how many flake-retries before the gate is considered failing (suggest: 1 retry)
+- Phasing recommendation:
+  1. Week 1: Stand up staging tenant + 1 smoke journey (login bootstrap)
+  2. Week 2: Add password-reset journey + test inbox
+  3. Week 3: Add remaining 3 journeys + nightly full-suite workflow
+  4. Week 4: Flip `deploy` jobs to `needs: [smoke]` and observe for 7 days
+- Hard rule: do NOT enable `needs: [smoke]` on production deploy jobs until the smoke has run green for 7 consecutive days (no flakes). Flake noise is worse than no gate.
+- Anti-pattern to avoid: do NOT use a real human's TOTP-enabled account for the service login. Always create a dedicated `ci-smoke@getklai.com` account.

--- a/.moai/specs/SPEC-INFRA-REDIS-SPLIT-001/spec.md
+++ b/.moai/specs/SPEC-INFRA-REDIS-SPLIT-001/spec.md
@@ -1,0 +1,133 @@
+---
+id: SPEC-INFRA-REDIS-SPLIT-001
+version: "0.1.0"
+status: draft
+created: "2026-04-30"
+updated: "2026-04-30"
+author: MoAI
+priority: medium
+issue_number: 0
+---
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 0.1.0 | 2026-04-30 | MoAI | Stub created from SPEC-SEC-MAILER-INJECTION-001 v0.3.1 follow-up — replace `REDIS_URL` with `REDIS_HOST` + `REDIS_PASSWORD` across all klai services to eliminate the URL-encoding-of-password class of bugs that caused the 2026-04-29 mailer outage. |
+
+# SPEC-INFRA-REDIS-SPLIT-001: Replace `REDIS_URL` with `REDIS_HOST` + `REDIS_PASSWORD` across klai services
+
+## Overview
+
+Eliminate the entire class of "operator forgot to URL-encode the Redis password" bugs by retiring the single `REDIS_URL` env var in favour of `REDIS_HOST`, `REDIS_PORT`, `REDIS_USERNAME`, `REDIS_PASSWORD`, `REDIS_DB`, and `REDIS_SSL` env vars across every klai service that uses Redis. Each variable carries one piece of information; no escaping ambiguity.
+
+The 2026-04-29 mailer `/notify` 500 outage was caused by `redis_asyncio.from_url(settings.redis_url)` calling `urllib.parse.urlparse`, which fails on passwords with reserved characters (`:`, `/`, `+`, `@`). REQ-6.5 of SPEC-SEC-MAILER-INJECTION-001 v0.3.1 fixed it for mailer with a custom `parse_redis_url`, but the same bug class is latent in every other service that uses `from_url(REDIS_URL)`. Fixing one service at a time after each rotation is whack-a-mole; the structural fix is to remove the URL pattern.
+
+This SPEC ALSO touches the deploy infrastructure (klai-infra repo): SOPS env files migrate from `REDIS_URL=redis://:pw@host:port/db` to the per-component variables. Rollout requires careful ordering across services to avoid partial-config breakage.
+
+## Environment
+
+- **Affected services** (all use Redis): klai-portal-api, klai-mailer, klai-retrieval-api, klai-knowledge-ingest, klai-scribe-api, klai-connector, klai-knowledge-mcp, klai-focus / research-api.
+- **Affected infra:** klai-infra/core-01/.env.sops, deploy/docker-compose.yml.
+- **Library:** redis-py 5.x — accepts both `from_url(...)` and `Redis(host=..., port=..., password=..., ...)` constructor patterns. The kwargs pattern is the target.
+- **Existing fix anchor:** `klai-mailer/app/redis_url.py::parse_redis_url` — the structural URL parser introduced in REQ-6.5. This SPEC's exit criterion is "no service uses `parse_redis_url` because no service receives a URL anymore".
+
+## Assumptions
+
+- A1: All current services can be deployed with both the old `REDIS_URL` env var and the new per-component variables in parallel during the migration window. Pydantic settings allows defaulting one from the other so single-deploy cutovers are NOT required.
+- A2: The Redis broker itself does not change — only the client-side configuration changes. Same hostname, same port, same password.
+- A3: The current production password value continues to contain reserved characters that REQUIRE URL-encoding when used as a URL component. Operators will not be required to rotate the password as part of this migration.
+- A4: SOPS files in klai-infra are updated by the operator (not Claude) per the existing `follow-loaded-procedures` rule.
+
+## Requirements
+
+### R1 — Ubiquitous: per-component env vars are the source of truth
+
+Each klai service that uses Redis SHALL read individual `REDIS_HOST`, `REDIS_PORT`, `REDIS_USERNAME`, `REDIS_PASSWORD`, `REDIS_DB`, `REDIS_SSL` env vars via pydantic-settings, AND SHALL construct the Redis client via `redis_asyncio.Redis(host=..., port=..., username=..., password=..., db=..., ssl=...)` kwargs. No service SHALL call `redis_asyncio.from_url(...)`.
+
+### R2 — Event-driven: backward-compat shim during migration
+
+WHEN a service starts AND `REDIS_URL` is set AND any of the per-component vars is unset THEN the service SHALL parse `REDIS_URL` (using `parse_redis_url`) to fill in the missing per-component values. The shim SHALL emit a structlog WARNING (`redis_url_legacy_shim_used`) so operators see they are still on the legacy var.
+
+### R3 — State-driven: deprecation removal after migration
+
+IF the migration is complete (all SOPS files updated, all services redeployed, no `redis_url_legacy_shim_used` warnings observed for 7 consecutive days) THEN the legacy shim SHALL be removed in a follow-up commit and `REDIS_URL` SHALL no longer be a recognized setting.
+
+### R4 — Unwanted Behavior: prevent reintroduction of `from_url(...)`
+
+A semgrep rule SHALL block any new code introducing `redis_asyncio.from_url(...)` or `redis.Redis.from_url(...)` in `klai-*/`. The rule MAY be bypassed in test fixtures via `# nosemgrep` with a justifying comment.
+
+### R5 — Optional: per-service Redis health-check endpoint
+
+Where a service exposes a `/health` endpoint, the health check MAY include a Redis ping (with a short timeout) so that the next time Redis configuration drifts, the operator sees `503` on `/health` IMMEDIATELY at deploy rather than waiting for the next request to fail.
+
+## Specifications
+
+### Per-component env var schema
+
+```
+REDIS_HOST=redis           # required, no default
+REDIS_PORT=6379            # default 6379
+REDIS_USERNAME=            # default empty (compatible with default ACL)
+REDIS_PASSWORD=<password>  # required if Redis is auth-enabled
+REDIS_DB=0                 # default 0
+REDIS_SSL=false            # default false; true → use rediss:// equivalent
+```
+
+### Service-by-service rollout
+
+| # | Service | Owner | Notes |
+|---|---|---|---|
+| 1 | klai-mailer | done (REQ-6.5 already uses kwargs path internally; switch settings to per-component) | smallest blast radius, validate the pattern |
+| 2 | klai-knowledge-mcp | — | next — no transactional state |
+| 3 | klai-portal-api | CRITICAL | rollback script must be tested first |
+| 4 | klai-retrieval-api | — | |
+| 5 | klai-knowledge-ingest | — | |
+| 6 | klai-scribe-api | — | |
+| 7 | klai-connector | — | |
+| 8 | klai-focus / research-api | — | |
+
+Each service rollout follows: (a) PR adding per-component settings + shim, (b) deploy with shim active, (c) update SOPS to per-component vars, (d) re-deploy, (e) verify shim warning is gone, (f) (after all services) PR removing the shim and the `REDIS_URL` setting.
+
+### Semgrep rule (REQ-4)
+
+```yaml
+rules:
+  - id: no-redis-from-url
+    pattern-either:
+      - pattern: redis_asyncio.from_url(...)
+      - pattern: redis.asyncio.from_url(...)
+      - pattern: $REDIS.Redis.from_url(...)
+    message: |
+      `Redis.from_url(url)` calls `urllib.parse.urlparse`, which fails on
+      passwords with reserved characters. Use individual env vars +
+      `Redis(host=..., port=..., password=..., ...)` kwargs. See
+      SPEC-INFRA-REDIS-SPLIT-001.
+    languages: [python]
+    severity: ERROR
+```
+
+## Files Affected
+
+- Every klai service's `app/config.py` (or equivalent) — add per-component settings, add shim.
+- Every klai service's Redis client construction site (use CodeIndex `query "Redis client construction"` to enumerate).
+- `klai-infra/core-01/.env.sops` — replace `REDIS_URL=...` with per-component vars.
+- `deploy/docker-compose.yml` — pass per-component vars in each service environment block.
+- New `rules/no-redis-from-url.yml` (semgrep) + workflow integration.
+
+## MX Tag Plan
+
+- Each service's Redis client constructor becomes `# @MX:ANCHOR` after refactor (fan_in increases as the kwargs path becomes the only constructor).
+- `parse_redis_url` in mailer (REQ-6.5) is `@MX:ANCHOR` — gets a `# @MX:NOTE: deprecated post-migration` after R3 completes.
+
+## Exclusions
+
+- Migrating Redis itself (e.g. Redis Cluster, Redis Sentinel, ElastiCache) — out of scope; this SPEC only changes how clients address the existing single Redis broker.
+- Adding TLS / `rediss://` support to the broker — out of scope; only the env var schema accommodates `REDIS_SSL=true` for future use.
+- Changing the password rotation cadence — this SPEC removes the URL-encoding-of-password class of bug, which makes rotation safer, but does not enforce a rotation policy.
+
+## Implementation Notes (for `/moai run`)
+
+- Use the mailer rollout (#1) as the reference implementation. Its `parse_redis_url` already handles the messy URL form; the SPEC's R2 shim can re-use that helper.
+- Stage 1 PR per service is small (config schema + shim + tests). Stage 2 is the SOPS update (operator action). Stage 3 is the cleanup PR (post-7-day soak).
+- Add a CI check that fails if both `REDIS_URL` and `REDIS_HOST` are set in the same env file — they are mutually exclusive after the shim is removed.


### PR DESCRIPTION
## Why

Three SPECs created from explicit out-of-scope items called out in yesterday's hotfixes (PR #230 callback URL allowlist, PR #231 mailer redis URL parser, PR #233 mailer logging). Each stub is structured per the EARS template and ready for `/moai plan` expansion.

| SPEC | Priority | Source incident |
|---|---|---|
| `SPEC-AUTH-TOTP-POPORDER-001` | medium | The misleading "Session expired" UX during the callback-allowlist outage |
| `SPEC-INFRA-REDIS-SPLIT-001` | medium | The mailer redis URL parser outage — eliminate the bug class instead of fixing per-service |
| `SPEC-CI-E2E-GATE-001` | high | Both regressions would have been caught here — the structural forcing function |

## What changed

3 new files in `.moai/specs/SPEC-*/spec.md`. Each contains:

- EARS-format requirements (R1..R5/R7)
- Exclusions section
- `@MX` tag plan
- Implementation Notes for `/moai run`
- File-affected list
- Decision points still to resolve

Pure documentation PR — zero code changes.

## Verification

- [x] `git diff --stat`: 3 files, 425 insertions, 0 source-code changes
- [x] Each SPEC frontmatter has all 8 required fields per `manager-spec` schema
- [x] Each SPEC references its source incident PR for traceability

## Out of scope

- `/moai plan SPEC-XXX` expansion — each stub is the framing, not the full SPEC. The SPEC owner (or next agent) runs `/moai plan` to add `research.md`, `acceptance.md`, `plan.md`.
- Implementation — none of the three SPECs are implemented in this PR. They are roadmap items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)