### PR TITLE
fix(portal-api): normalise userName to lowercase at Zitadel user-creation sites

### DIFF
--- a/klai-portal/backend/app/services/zitadel.py
+++ b/klai-portal/backend/app/services/zitadel.py
@@ -67,12 +67,22 @@ class ZitadelClient:
         password: str,
         preferred_language: str = "nl",
     ) -> dict:
-        """Create a human user inside a specific org."""
+        """Create a human user inside a specific org.
+
+        ``userName`` is lowercased before submission to Zitadel. Email
+        addresses are case-insensitive per RFC 5321 §2.4, but Zitadel
+        stores the userName / loginName byte-for-byte and matches against
+        it case-sensitively in some downstream calls (notably
+        ``/v2/sessions`` user check). Storing only the lowercase form
+        eliminates a class of "user signed up as Steven@... but typed
+        steven@... at login" issues at the source. The display ``email``
+        field keeps its original case for outgoing mail headers.
+        """
         resp = await self._http.post(
             "/management/v1/users/human/_import",
             headers={"x-zitadel-orgid": org_id},
             json={
-                "userName": email,
+                "userName": email.lower(),
                 "profile": {
                     "firstName": first_name,
                     "lastName": last_name,
@@ -127,12 +137,18 @@ class ZitadelClient:
         last_name: str,
         preferred_language: str = "nl",
     ) -> dict:
-        """Create a human user and send initialization email (password-less invite)."""
+        """Create a human user and send initialization email (password-less invite).
+
+        ``userName`` is lowercased before submission — see
+        ``create_human_user`` for rationale. The display ``email`` field
+        keeps its original case so the invite mail addresses the user
+        the way the inviting admin typed it.
+        """
         resp = await self._http.post(
             "/management/v1/users/human/_import",
             headers={"x-zitadel-orgid": org_id},
             json={
-                "userName": email,
+                "userName": email.lower(),
                 "profile": {
                     "firstName": first_name,
                     "lastName": last_name,
@@ -588,7 +604,11 @@ class ZitadelClient:
             "/v2/users/human",
             headers={"x-zitadel-orgid": org_id},
             json={
-                "username": email,
+                # username is lowercased to keep all auto-provisioned IDP
+                # users on the same case-insensitive footing as humans
+                # created via ``create_human_user`` and ``invite_user``.
+                # See ``create_human_user`` docstring for rationale.
+                "username": email.lower(),
                 "profile": {
                     "givenName": given_name or email.split("@")[0],
                     "familyName": family_name,

--- a/klai-portal/backend/tests/test_zitadel_username_normalization.py
+++ b/klai-portal/backend/tests/test_zitadel_username_normalization.py
@@ -1,0 +1,201 @@
+"""Tests for case-normalisation of ``userName`` / ``username`` fields at
+user-creation time in ``app.services.zitadel``.
+
+Sibling-bug coverage for the 2026-04-30 case-sensitive-loginName regression.
+
+Background:
+    PR #235 fixed ``create_session_with_password`` to pass the canonical
+    ``userId`` instead of the user-typed email. That fix made login
+    case-insensitive at the SESSION layer. But the underlying
+    user-creation paths still wrote the userName / loginName field with
+    whatever case the operator typed. A user invited as
+    ``Steven@getklai.com`` got that exact value as their loginName,
+    which bit Steven on 2026-04-30. New users created via these paths
+    going forward are normalised to lowercase so the data layer cannot
+    re-introduce the case-mismatch class regardless of what later
+    consumers do with loginName.
+
+The display ``email`` field keeps original case (used in outgoing mail
+headers — preserves the inviter's intended capitalisation for greeting
+purposes).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _zitadel_client_with_mocked_http(response_body: dict | None = None):
+    """Construct a ZitadelClient with a mocked _http returning the given body."""
+    from app.services.zitadel import ZitadelClient
+
+    client = ZitadelClient.__new__(ZitadelClient)
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = response_body or {"userId": "u-1"}
+    mock_resp.raise_for_status = MagicMock()
+
+    mock_http = AsyncMock()
+    mock_http.post = AsyncMock(return_value=mock_resp)
+    client._http = mock_http
+    return client, mock_http
+
+
+class TestCreateHumanUserUsernameLowercased:
+    """``create_human_user`` MUST lowercase the userName even when the
+    caller typed mixed case."""
+
+    @pytest.mark.asyncio
+    async def test_username_lowercased_when_email_mixed_case(self) -> None:
+        client, mock_http = _zitadel_client_with_mocked_http()
+
+        await client.create_human_user(
+            org_id="org-1",
+            email="Steven@GetKlai.COM",
+            first_name="Steven",
+            last_name="Buurma",
+            password="x",
+        )
+
+        _args, kwargs = mock_http.post.call_args
+        body = kwargs["json"]
+        assert body["userName"] == "steven@getklai.com"
+
+    @pytest.mark.asyncio
+    async def test_email_field_preserves_original_case(self) -> None:
+        """Display email keeps original case for outgoing-mail headers."""
+        client, mock_http = _zitadel_client_with_mocked_http()
+
+        await client.create_human_user(
+            org_id="org-1",
+            email="Steven@GetKlai.COM",
+            first_name="S",
+            last_name="B",
+            password="x",
+        )
+
+        _args, kwargs = mock_http.post.call_args
+        assert kwargs["json"]["email"]["email"] == "Steven@GetKlai.COM"
+
+    @pytest.mark.asyncio
+    async def test_already_lowercase_email_passes_through(self) -> None:
+        client, mock_http = _zitadel_client_with_mocked_http()
+
+        await client.create_human_user(
+            org_id="org-1",
+            email="lower@example.com",
+            first_name="L",
+            last_name="C",
+            password="x",
+        )
+
+        _args, kwargs = mock_http.post.call_args
+        assert kwargs["json"]["userName"] == "lower@example.com"
+
+
+class TestInviteUserUsernameLowercased:
+    """``invite_user`` MUST lowercase the userName even when the inviting
+    admin typed mixed case."""
+
+    @pytest.mark.asyncio
+    async def test_username_lowercased_when_email_mixed_case(self) -> None:
+        client, mock_http = _zitadel_client_with_mocked_http()
+
+        await client.invite_user(
+            org_id="org-1",
+            email="NewHire@Acme.IO",
+            first_name="New",
+            last_name="Hire",
+        )
+
+        _args, kwargs = mock_http.post.call_args
+        body = kwargs["json"]
+        assert body["userName"] == "newhire@acme.io"
+
+    @pytest.mark.asyncio
+    async def test_email_field_preserves_original_case(self) -> None:
+        client, mock_http = _zitadel_client_with_mocked_http()
+
+        await client.invite_user(
+            org_id="org-1",
+            email="NewHire@Acme.IO",
+            first_name="N",
+            last_name="H",
+        )
+
+        _args, kwargs = mock_http.post.call_args
+        assert kwargs["json"]["email"]["email"] == "NewHire@Acme.IO"
+
+    @pytest.mark.asyncio
+    async def test_send_codes_flag_unchanged(self) -> None:
+        """Regression: the lowercase rename must not break the invite-mail
+        send-codes flag."""
+        client, mock_http = _zitadel_client_with_mocked_http()
+
+        await client.invite_user(
+            org_id="org-1",
+            email="anyone@example.com",
+            first_name="A",
+            last_name="N",
+        )
+
+        _args, kwargs = mock_http.post.call_args
+        assert kwargs["json"]["sendCodes"] is True
+
+
+class TestCreateZitadelUserFromIdpUsernameLowercased:
+    """``create_zitadel_user_from_idp`` MUST lowercase the username even
+    when the IDP-provided email has mixed case. Auto-provisioned IDP
+    users land on the same case-insensitive footing as manually-created
+    humans."""
+
+    @pytest.mark.asyncio
+    async def test_username_lowercased_when_idp_email_mixed_case(self) -> None:
+        client, mock_http = _zitadel_client_with_mocked_http(response_body={"userId": "u-idp-1"})
+
+        intent_data = {
+            "idpInformation": {
+                "idpId": "google-idp",
+                "userId": "google-uid-123",
+                "userName": "google-username",
+                "rawInformation": {
+                    "User": {
+                        "given_name": "Mixed",
+                        "family_name": "Case",
+                        "email": "Mixed.Case@Example.IO",
+                    }
+                },
+            }
+        }
+
+        await client.create_zitadel_user_from_idp(intent_data, org_id="org-1")
+
+        _args, kwargs = mock_http.post.call_args
+        body = kwargs["json"]
+        assert body["username"] == "mixed.case@example.io"
+
+    @pytest.mark.asyncio
+    async def test_idp_email_preserved_for_display(self) -> None:
+        """The display email keeps original case (matches what the IDP
+        actually returned)."""
+        client, mock_http = _zitadel_client_with_mocked_http(response_body={"userId": "u-1"})
+
+        intent_data = {
+            "idpInformation": {
+                "idpId": "google-idp",
+                "userId": "google-uid-123",
+                "rawInformation": {
+                    "User": {
+                        "given_name": "M",
+                        "family_name": "C",
+                        "email": "Mixed.Case@Example.IO",
+                    }
+                },
+            }
+        }
+
+        await client.create_zitadel_user_from_idp(intent_data, org_id="org-1")
+
+        _args, kwargs = mock_http.post.call_args
+        assert kwargs["json"]["email"]["email"] == "Mixed.Case@Example.IO"


### PR DESCRIPTION
## Why

Sibling closure to PR #235 (case-sensitive create_session_with_password). #235 made LOGIN case-insensitive at runtime by routing through Zitadel userId. This PR closes the data layer half: new users are written with lowercase userName/loginName so the case-mismatch class can never re-emerge from sign-ups, invites, or IDP auto-provisioning.

## What changed

Three call sites in `klai-portal/backend/app/services/zitadel.py` lowercased on the `userName` / `username` field while keeping the display `email.email` field at original case (used in outgoing mail headers):

- `create_human_user` (admin-driven signup)
- `invite_user` (admin invitation)
- `create_zitadel_user_from_idp` (Google / Microsoft auto-provisioning)

Plus `tests/test_zitadel_username_normalization.py` (new, 8 cases) covering all three sites.

## Verification before merge

- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run pytest tests/test_zitadel_username_normalization.py -v` — 8/8
- [x] `uv run pytest -q` — 1407/1407 portal-api suite

## Out of scope

Existing mixed-case loginNames (e.g. Steven Buurma's `Steven@getklai.com`) are NOT migrated. They log in correctly via the userId routing from PR #235. A retroactive lowercase migration is a separate concern and would require coordination with Zitadel's eventstore + downstream consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)