### PR TITLE
feat(alerting): mailer notify-failure alerts + runbook (closes 2026-04-29 signal gap)

### DIFF
--- a/deploy/grafana/provisioning/alerting/mailer-rules.yaml
+++ b/deploy/grafana/provisioning/alerting/mailer-rules.yaml
@@ -1,0 +1,215 @@
+# SPEC-OBS-001 follow-up — klai-mailer alerts (LogsQL via VictoriaLogs).
+#
+# Routed via spec=SPEC-OBS-001 → klai-ops-alerts-email.
+#
+#   M1  mailer_zitadel_webhook_failed   CRIT  Zitadel notification → klai-mailer
+#                                              returned non-2xx >5 times in 5m.
+#                                              The 2026-04-29 four-hour outage
+#                                              would have fired in 5 minutes.
+#   M2  mailer_notify_5xx_count_high   CRIT  >5 mailer access-log lines with
+#                                              5xx status on /notify in 5m.
+#                                              Direct mailer-side signal,
+#                                              independent of Zitadel logs.
+#
+# Why a dedicated mailer rules file:
+#
+# The existing `caddy_5xx_count_high` catches every 5xx that PASSES THROUGH
+# Caddy. But Zitadel calls `http://klai-mailer:8000/notify` directly over
+# the Docker network — never through Caddy. So a mailer outage is invisible
+# to Caddy-edge alerts. M1 closes that gap by querying Zitadel's own
+# notification-channel log line. M2 doubles the signal from the mailer
+# side (now that uvicorn access logs are visible via the FU#2 logging fix).
+#
+# Field shapes verified against production VictoriaLogs (2026-04-30):
+#   service:zitadel AND msg:"sending notification failed"
+#     → matches Zitadel's `webhook didn't return a success status` log
+#       across notification types (user.human.password.code.added,
+#       user.human.invite.code.added, etc.)
+#   service:klai-mailer AND _msg:"POST /notify"
+#     → matches uvicorn's access log for /notify requests after the
+#       FU#2 logging fix (PR #233) re-enabled access logs at INFO.
+#
+# Pitfalls inherited from caddy-rules.yaml:
+#   - Always go through `reduce` between LogsQL output and SSE math
+#   - SSE math has no max(), no ternary
+#   - execErrState: OK so plugin hiccups don't false-fire
+
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: obs-001-mailer
+    folder: Klai
+    interval: 1m
+    rules:
+
+      # ── M1: mailer_zitadel_webhook_failed ────────────────────────────────
+      #
+      # Watches Zitadel's notification-channel log for failures targeting
+      # klai-mailer. This is the EARLIEST signal that password-reset emails,
+      # invitation emails, and email-OTP codes are not being delivered.
+      #
+      # On 2026-04-29 the broken-redis-URL outage produced ~14k of these log
+      # lines over 4 hours (~1Hz retry loop), entirely invisible to existing
+      # alerts. Threshold of 5 in 5m is conservative — Zitadel retries up
+      # to ~5 times per individual notification, so 5 failures across 5
+      # minutes is the very bottom of "real outage" signal.
+      - uid: obs-001-mailer-zitadel-webhook-failed
+        title: mailer_zitadel_webhook_failed
+        condition: threshold
+        data:
+          - refId: query
+            datasourceUid: victorialogs
+            queryType: instant
+            relativeTimeRange:
+              from: 300
+              to: 0
+            model:
+              refId: query
+              datasource:
+                type: victoriametrics-logs-datasource
+                uid: victorialogs
+              expr: 'service:zitadel AND msg:"sending notification failed" AND error:"klai-mailer:8000"'
+              queryType: instant
+          - refId: reduce
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 300
+              to: 0
+            model:
+              refId: reduce
+              type: reduce
+              reducer: count
+              expression: query
+          - refId: threshold
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 300
+              to: 0
+            model:
+              refId: threshold
+              type: threshold
+              expression: reduce
+              conditions:
+                - evaluator: { params: [5], type: gt }
+                  operator: { type: and }
+                  reducer: { params: [], type: last }
+                  type: query
+        noDataState: OK
+        execErrState: OK
+        for: 5m
+        keepFiringFor: 10m
+        isPaused: false
+        labels:
+          severity: critical
+          spec: SPEC-OBS-001
+          service_group: mailer
+        annotations:
+          summary: 'Zitadel cannot deliver notifications to klai-mailer (>5 failures in 5m)'
+          runbook_url: 'docs/runbooks/platform-recovery.md#mailer-zitadel-webhook-failed'
+          description: |
+            Zitadel logged more than 5 `sending notification failed` events
+            targeting klai-mailer in the last 5 minutes. This means at
+            least one user-facing email flow is broken: password reset,
+            invitations, email-OTP codes, MFA setup mails.
+
+            The 2026-04-29 broken-redis-URL outage emitted ~14k of these
+            log lines over 4 hours before a user reported "email not
+            arriving". This alert closes that signal gap.
+
+            Triage:
+              1. Check the actual error from Zitadel's view:
+                   service:zitadel AND msg:"sending notification failed" AND error:"klai-mailer:8000"
+                 The error= field contains the HTTP status and a partial
+                 reason from the mailer's response.
+              2. Inspect mailer's own logs for the same window (now
+                 visible after the FU#2 access-log fix):
+                   service:klai-mailer AND _time:5m
+                 If access logs show requests reaching mailer but every
+                 one returns 5xx, see step 3. If no access logs show a
+                 request reaching mailer, see step 4.
+              3. Mailer-internal failure: pull the live ASGI traceback
+                 by tailing mailer logs while triggering a fresh
+                 password reset:
+                   ssh core-01 "docker logs --tail 0 -f klai-core-klai-mailer-1"
+                   curl -X POST https://my.getklai.com/api/auth/password/reset \
+                     -d '{"email":"<your-email>"}' -H "Content-Type: application/json"
+              4. Network/auth failure: Zitadel's call isn't even reaching
+                 mailer. Check klai-net Docker network membership for
+                 zitadel + klai-mailer. Verify WEBHOOK_SECRET matches
+                 between the two containers.
+
+      # ── M2: mailer_notify_5xx_count_high ────────────────────────────────
+      #
+      # Direct signal from the mailer side. Independent of Zitadel logs so
+      # the alert still fires if Zitadel logging is interrupted. Becomes
+      # actionable once the FU#2 logging fix (PR #233) lets uvicorn emit
+      # access lines.
+      - uid: obs-001-mailer-notify-5xx-count-high
+        title: mailer_notify_5xx_count_high
+        condition: threshold
+        data:
+          - refId: query
+            datasourceUid: victorialogs
+            queryType: instant
+            relativeTimeRange:
+              from: 300
+              to: 0
+            model:
+              refId: query
+              datasource:
+                type: victoriametrics-logs-datasource
+                uid: victorialogs
+              # The uvicorn access log for /notify lines with a 5xx status.
+              # Substring match on the message body — matches "POST /notify HTTP/1.1" 5XX.
+              expr: 'service:klai-mailer AND _msg:"POST /notify" AND _msg:" 5"'
+              queryType: instant
+          - refId: reduce
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 300
+              to: 0
+            model:
+              refId: reduce
+              type: reduce
+              reducer: count
+              expression: query
+          - refId: threshold
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 300
+              to: 0
+            model:
+              refId: threshold
+              type: threshold
+              expression: reduce
+              conditions:
+                - evaluator: { params: [5], type: gt }
+                  operator: { type: and }
+                  reducer: { params: [], type: last }
+                  type: query
+        noDataState: OK
+        execErrState: OK
+        for: 5m
+        keepFiringFor: 10m
+        isPaused: false
+        labels:
+          severity: critical
+          spec: SPEC-OBS-001
+          service_group: mailer
+        annotations:
+          summary: 'klai-mailer returned >5 5xx on POST /notify in 5 min'
+          runbook_url: 'docs/runbooks/platform-recovery.md#mailer-zitadel-webhook-failed'
+          description: |
+            More than 5 mailer access-log lines for `POST /notify` with
+            a 5xx status in the last 5 minutes. Same operational meaning
+            as `mailer_zitadel_webhook_failed` (emails not delivered) but
+            measured from the mailer side.
+
+            Both alerts are expected to fire together when the actual
+            failure is in mailer code (broken renderer, bad redis URL,
+            SMTP outage). If only `mailer_zitadel_webhook_failed` fires,
+            the requests are not even reaching mailer — likely a Docker
+            network or webhook-secret mismatch.
+
+            Same triage steps as `mailer_zitadel_webhook_failed`.

--- a/docs/runbooks/platform-recovery.md
+++ b/docs/runbooks/platform-recovery.md
@@ -869,3 +869,86 @@ After fix: health-failure log volume drops, alert auto-resolves within 10m of th
 If LibreChat ever upgrades and changes the "health" / "fail" text in their log format, this rule silently breaks. Quarterly review: confirm fire-count > 0 for SOME period of last quarter — if always zero, either we're suspiciously healthy (good) or the rule broke (bad).
 
 A long-term fix is to instrument LibreChat with structured-event logging via a sidecar, so we can match `event:health_failed` instead of substring text. Out of OBS-001 scope.
+
+---
+
+## mailer-zitadel-webhook-failed
+
+Triggered by either `mailer_zitadel_webhook_failed` or `mailer_notify_5xx_count_high` from `deploy/grafana/provisioning/alerting/mailer-rules.yaml`. Both signal "Zitadel-issued emails (password reset, invitation, MFA setup) are not being delivered". The 2026-04-29 broken-redis-URL outage emitted ~14k of these log lines over 4 hours before a user reported the symptom — both alerts close that signal gap.
+
+**Severity: critical**. Every minute of fire = users locked out of password recovery.
+
+### Step 1 — Confirm both alerts fire together
+
+```
+service:zitadel AND msg:"sending notification failed" AND error:"klai-mailer:8000"
+service:klai-mailer AND _msg:"POST /notify" AND _msg:" 5"
+```
+
+- Both fire → mailer-internal failure (renderer crashes, broken dependency, SMTP auth, etc.). Skip to Step 3.
+- Only the Zitadel-side alert fires → Zitadel's request never reaches mailer. Step 2.
+- Only the mailer-side alert fires → uvicorn access logs show 5xx but Zitadel's notification channel is silent. Rare; means mailer is being hit by something OTHER than Zitadel (e.g. a rogue probe). Investigate `request.host` or source-ip in the access log.
+
+### Step 2 — Network / auth path Zitadel → mailer
+
+```bash
+# Verify both containers share the klai-net network
+ssh core-01 "docker inspect klai-core-zitadel-1 klai-core-klai-mailer-1 --format '{{.Name}} {{.NetworkSettings.Networks}}'"
+
+# Verify the WEBHOOK_SECRET env var matches between the two
+ssh core-01 "docker exec klai-core-klai-mailer-1 sh -c 'echo \$WEBHOOK_SECRET' | sha256sum"
+ssh core-01 "docker exec klai-core-zitadel-1 sh -c 'cat /etc/zitadel-config.yaml' | grep -A 2 webhook"
+```
+
+Mismatch on either → fix in SOPS (`klai-infra/core-01/.env.sops`), redeploy both services.
+
+### Step 3 — Mailer-internal failure: capture the live ASGI traceback
+
+The mailer access log shows the request reaching mailer but every one returns 5xx. Root cause is in the handler or one of its dependencies (renderer, SMTP, redis nonce, settings validator). Capture the traceback by tailing the live container while triggering a fresh password reset:
+
+```bash
+# Window 1 — tail mailer logs in real time
+ssh core-01 "docker logs --tail 0 -f klai-core-klai-mailer-1"
+
+# Window 2 — trigger one fresh password reset
+curl -X POST https://my.getklai.com/api/auth/password/reset \
+  -H "Content-Type: application/json" \
+  -d '{"email":"<an existing-user-email>"}'
+```
+
+The full ASGI traceback prints inline. Common patterns:
+
+- `ValueError("Port could not be cast to integer value as ...")` → `REDIS_URL` password contains URL-reserved chars without percent-encoding. Fix in SOPS, redeploy. See `redis-url-password-must-be-parsed-manually` pitfall.
+- `aiosmtplib.errors.SMTPAuthenticationError` → SMTP password rotated upstream without updating SOPS. Update SOPS, redeploy.
+- `jinja2.exceptions.TemplateNotFound` / `UndefinedError` → renderer regression. Either Zitadel is sending a new event_type the renderer doesn't handle, or a recent renderer commit broke a template. `git log klai-mailer/app/renderer.py` for the suspect.
+- `httpx.ConnectError` to `portal-api:8010` → portal-internal callback is down. Check portal-api liveness first.
+
+### Step 4 — Rollback escape hatch
+
+If the root cause is in a recent mailer commit and Step 3 hasn't pinpointed the exact line within 10 minutes, revert the most recent mailer change to restore service:
+
+```bash
+LAST_MAILER_COMMIT=$(git log --pretty=format:"%h" --diff-filter=AM -1 -- klai-mailer/)
+echo "Reverting $LAST_MAILER_COMMIT — diagnose forward in a follow-up PR"
+git revert "$LAST_MAILER_COMMIT" --no-edit
+git push origin main
+gh run watch --exit-status
+ssh core-01 "docker ps --format '{{.Names}}\t{{.Status}}' | grep mailer"
+# Container should show "Up <fresh seconds>" within 90 seconds.
+```
+
+### Verify
+
+After fix, both alerts auto-resolve within 10 minutes of the last failing notification.
+
+```bash
+# Trigger one real password reset to confirm end-to-end delivery
+curl -X POST https://my.getklai.com/api/auth/password/reset \
+  -H "Content-Type: application/json" \
+  -d '{"email":"<your-email>"}'
+# Wait 30 seconds, check inbox.
+```
+
+### Follow-up
+
+If the same root cause class fires twice in one quarter, that's a structural problem — file a SPEC. The 2026-04-29 incident produced two such SPECs that are now on the stack: `SPEC-INFRA-REDIS-SPLIT-001` (eliminate the URL-encoded-password failure mode) and `SPEC-CI-E2E-GATE-001` (post-deploy E2E smoke gate that would have caught the regression in build-deploy seconds, not user-report hours).


### PR DESCRIPTION
## Why

The 2026-04-29 mailer outage was four-times longer to diagnose than necessary because no alert fired. Caddy edge alerts cover every 5xx passing through Caddy, but Zitadel calls `http://klai-mailer:8000/notify` directly over the Docker network — Caddy never sees those failures. ~14k notification-channel failures over 4 hours, fully invisible until a user reported the symptom.

## What changed

- `deploy/grafana/provisioning/alerting/mailer-rules.yaml` (new) — 2 critical alerts:
  - `mailer_zitadel_webhook_failed` — Zitadel-side signal, fires from Zitadel's notification-channel log
  - `mailer_notify_5xx_count_high` — mailer-side signal, fires from mailer's uvicorn access log (now visible since PR #233)
- `docs/runbooks/platform-recovery.md` — new `mailer-zitadel-webhook-failed` section with 4-step triage pipeline + rollback escape hatch

Both rules follow the existing SPEC-OBS-001 LogsQL→reduce→threshold pattern. `execErrState: OK` so plugin hiccups don't false-page.

## Verification

- [x] YAML valid (`python -c "yaml.safe_load(...)"`)
- [x] Schema matches existing `portal-api-rules.yaml` / `caddy-rules.yaml`

Provisioned alerts auto-load on Grafana restart — no manual import step. Grafana will pick them up via `deploy/grafana/provisioning/alerting/`.

## Out of scope

- Portal-api-specific 5xx alert: existing `caddy_5xx_count_high` already catches all 5xx through Caddy, including portal-api. Adding a host-filtered duplicate is premature optimisation.
- VictoriaLogs query syntax variance across versions: pinned to the existing pattern in `caddy-rules.yaml` which is verified working in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)