### PR TITLE
fix(mailer): SPEC-SEC-MAILER-INJECTION-001 REQ-6.5 — boot validator on REDIS_URL

### DIFF
--- a/klai-mailer/app/config.py
+++ b/klai-mailer/app/config.py
@@ -12,8 +12,8 @@ class Settings(BaseSettings):
     smtp_password: str
     smtp_from: str = "noreply@example.com"
     smtp_from_name: str = "Klai"
-    smtp_tls: bool = True          # STARTTLS on port 587
-    smtp_ssl: bool = False         # Implicit TLS on port 465
+    smtp_tls: bool = True  # STARTTLS on port 587
+    smtp_ssl: bool = False  # Implicit TLS on port 465
 
     # Security — shared secret between Zitadel and this service.
     # Empty / whitespace-only values are rejected at startup (REQ-9.1).
@@ -73,6 +73,35 @@ class Settings(BaseSettings):
     def _require_internal_secret(cls, v: str) -> str:
         if not v or not v.strip():
             raise ValueError("Missing required: INTERNAL_SECRET")
+        return v
+
+    # @MX:NOTE: structural URL validator — fail-fast at boot prevents the
+    #   "service starts cleanly, then 5xx every webhook" failure mode that
+    #   the 2026-04-29 outage exposed (broken-redis-URL).
+    # Mirrors the lazy-fail path in `app/nonce.py::get_redis()` (which catches
+    #   `RedisURLError` and translates to a runtime 503), but moves the failure
+    #   forward to deploy time so the operator sees the misconfiguration
+    #   IMMEDIATELY in the deploy logs instead of waiting for the first
+    #   webhook to surface it. Counterpart: SPEC-SEC-MAILER-INJECTION-001
+    #   REQ-6.5.
+    # Boot-fail is safe here because `parse_redis_url` is permissive —
+    #   it accepts ANY structurally-valid URL including passwords with
+    #   reserved characters. The only way this validator raises is if
+    #   the URL is structurally broken (no scheme, no host, non-integer
+    #   port), which means the operator made a typo in SOPS and a
+    #   noisy startup failure is the correct response.
+    @field_validator("redis_url", mode="after")
+    @classmethod
+    def _require_parseable_redis_url(cls, v: str) -> str:
+        # Local import to avoid a top-level circular import:
+        # app.config is imported by app.redis_url indirectly via tests
+        # that build settings without the full app graph loaded.
+        from app.redis_url import RedisURLError, parse_redis_url
+
+        try:
+            parse_redis_url(v)
+        except RedisURLError as exc:
+            raise ValueError(f"Invalid REDIS_URL: {exc}") from exc
         return v
 
 

--- a/klai-mailer/tests/test_config_fail_closed.py
+++ b/klai-mailer/tests/test_config_fail_closed.py
@@ -26,6 +26,7 @@ def _fresh_settings_class():
     # exactly the startup behaviour we want to test. So instead we re-import
     # via a guarded reload and capture the exception.
     from app.config import Settings
+
     return Settings
 
 
@@ -95,3 +96,79 @@ def test_startup_exits_nonzero(settings_env, monkeypatch):
     )
     assert result.returncode != 0, f"expected non-zero exit, stderr: {result.stderr}"
     assert "Missing required: WEBHOOK_SECRET" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# REQ-6.5 boot validator: REDIS_URL must be structurally parseable.
+#
+# The 2026-04-29 outage exposed the "service starts cleanly, then 5xx every
+# webhook" failure mode. PR #231 fixed the runtime path; this test class
+# pins the boot-time fail-fast property added in this commit so a future
+# refactor cannot silently regress.
+# ---------------------------------------------------------------------------
+
+
+class TestRedisUrlFailFastValidator:
+    """The Settings validator on `redis_url` MUST refuse boot when the URL
+    is structurally broken, AND MUST accept any URL that the runtime
+    `parse_redis_url` accepts (including passwords with reserved chars)."""
+
+    def test_redis_url_with_reserved_chars_in_password_is_accepted(self, settings_env, monkeypatch):
+        """Regression: the 2026-04-29 prod URL had `:`, `/`, `+` in the
+        password. The validator MUST accept it because `parse_redis_url`
+        handles it. If this regresses, every deploy fails until SOPS is
+        edited — exactly the validator-env-parity pitfall."""
+        monkeypatch.setenv("REDIS_URL", "redis://:p:hPKBf/abc+def@redis:6379/0")
+        sys.modules.pop("app.config", None)
+        # No exception expected — settings construct cleanly.
+        from app.config import Settings
+
+        settings = Settings()
+        assert settings.redis_url == "redis://:p:hPKBf/abc+def@redis:6379/0"
+
+    def test_missing_scheme_refuses_boot(self, settings_env, monkeypatch):
+        monkeypatch.setenv("REDIS_URL", "no-scheme")
+        sys.modules.pop("app.config", None)
+        with pytest.raises(ValidationError) as exc_info:
+            importlib.import_module("app.config")
+        assert "Invalid REDIS_URL" in str(exc_info.value)
+
+    def test_unsupported_scheme_refuses_boot(self, settings_env, monkeypatch):
+        """Operator paste-error: `memcached://...` looks similar to
+        `redis://...`. The validator catches it at boot, not later."""
+        monkeypatch.setenv("REDIS_URL", "memcached://host:11211")
+        sys.modules.pop("app.config", None)
+        with pytest.raises(ValidationError) as exc_info:
+            importlib.import_module("app.config")
+        assert "Invalid REDIS_URL" in str(exc_info.value)
+
+    def test_non_integer_port_refuses_boot(self, settings_env, monkeypatch):
+        """Operator paste-error: a non-numeric port sneaks past the SOPS
+        round-trip. Boot fails loudly with the explicit field name."""
+        monkeypatch.setenv("REDIS_URL", "redis://redis:not-a-number/0")
+        sys.modules.pop("app.config", None)
+        with pytest.raises(ValidationError) as exc_info:
+            importlib.import_module("app.config")
+        assert "Invalid REDIS_URL" in str(exc_info.value)
+
+    def test_missing_host_refuses_boot(self, settings_env, monkeypatch):
+        monkeypatch.setenv("REDIS_URL", "redis://")
+        sys.modules.pop("app.config", None)
+        with pytest.raises(ValidationError) as exc_info:
+            importlib.import_module("app.config")
+        assert "Invalid REDIS_URL" in str(exc_info.value)
+
+    def test_default_value_in_dev_settings_is_parseable(self, settings_env, monkeypatch):
+        """Conftest default of `redis://redis:6379/0` MUST validate cleanly,
+        so the test suite itself doesn't regress whenever a future change
+        edits the validator."""
+        monkeypatch.delenv("REDIS_URL", raising=False)  # use default
+        sys.modules.pop("app.config", None)
+        from app.config import Settings
+
+        settings = Settings()
+        # The conftest sets a default; whatever it is, it must be valid.
+        from app.redis_url import parse_redis_url
+
+        parsed = parse_redis_url(settings.redis_url)
+        assert parsed.host  # non-empty


### PR DESCRIPTION
## Why

PR #231 closed the runtime path of the broken-redis-URL outage (parse_redis_url + RedisUnavailableError translation in get_redis). This PR closes the boot-time path: an operator paste-error in SOPS now refuses the deploy instead of letting the service start cleanly and 5xx every webhook for hours.

## What changed

- `klai-mailer/app/config.py` — new `@field_validator("redis_url", mode="after")` calls `parse_redis_url()` and raises ValidationError on structurally broken URLs.
- `klai-mailer/tests/test_config_fail_closed.py` — new `TestRedisUrlFailFastValidator` with 6 cases.

The validator is intentionally PERMISSIVE — it accepts every URL `parse_redis_url` accepts at runtime, including passwords with reserved chars (`:`, `/`, `+`, `@`). Only structurally broken inputs refuse boot. This avoids the `validator-env-parity` pitfall: prod's existing REDIS_URL validates cleanly post-merge.

## Verification before merge

- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run pytest tests/test_config_fail_closed.py -v` — 15/15
- [x] `uv run pytest -q` — 96/96 mailer suite

## Anti-regression

Including the test `test_redis_url_with_reserved_chars_in_password_is_accepted` with the exact 2026-04-29 outage URL shape (`redis://:p:hPKBf/abc+def@...`). If a future refactor breaks `parse_redis_url`'s tolerance for reserved chars, this test catches it before the validator ships.

## Rollback

```bash
git revert 470489fb
git push origin main
```

Reverting puts the lazy-fail behaviour back. Forward-fix is preferred — operator visibility into the misconfiguration moves from "wait for first webhook" to "read deploy log".

🤖 Generated with [Claude Code](https://claude.com/claude-code)