### PR TITLE
docs(spec): expand 3 follow-up SPEC stubs with plan.md + acceptance.md

### DIFF
--- a/.moai/specs/SPEC-AUTH-TOTP-POPORDER-001/acceptance.md
+++ b/.moai/specs/SPEC-AUTH-TOTP-POPORDER-001/acceptance.md
@@ -1,0 +1,106 @@
+# SPEC-AUTH-TOTP-POPORDER-001 — Acceptance Criteria
+
+Five Given/When/Then scenarios derived from the state machine in
+`spec.md` § Specifications. The full set must pass before merge.
+
+## AC-1: happy path unchanged
+
+- **Given** a user has logged in via `POST /api/auth/login` and received
+  a `temp_token` for an `awaiting-totp` pending entry,
+- **When** they POST to `/api/auth/totp-login` with a valid TOTP code
+  AND `_finalize_and_set_cookie` returns successfully,
+- **Then** the response is `200` with the SSO cookie set,
+  the pending entry is removed from `_pending_totp`,
+  and a single `auth.login.totp` audit event is written.
+
+**Test:** `tests/test_auth_totp_finalize_retry.py::test_happy_path_unchanged`
+
+---
+
+## AC-2: invalid TOTP code retry-allowed
+
+- **Given** an `awaiting-totp` pending entry exists,
+- **When** the user submits an invalid TOTP code (Zitadel returns
+  400/401 for `update_session_with_totp`),
+- **Then** `_pending_totp[temp_token].failures` is incremented,
+  the response is `400 "Invalid code, please try again"`,
+  the pending entry remains in state `awaiting-totp` (NOT popped),
+  and an `auth.totp.failed` audit event is written with reason `invalid_code`.
+
+**Test:** `tests/test_auth_totp_finalize_retry.py::test_invalid_code_keeps_pending_in_awaiting_totp`
+
+---
+
+## AC-3 (regression): finalize 5xx then idempotent retry
+
+This is the bug the SPEC is fixing. Before this commit the user sees
+"Session expired" after any 5xx from finalize; after this commit the
+retry succeeds without re-doing TOTP.
+
+- **Given** an `awaiting-totp` entry exists,
+- **When** the user submits a valid TOTP code (Zitadel 200) AND
+  `_finalize_and_set_cookie` then raises `HTTPException(502)` (e.g. a
+  transient infra issue or a `_validate_callback_url` regression),
+- **Then** the pending entry transitions to state `finalize-pending`
+  with `finalize_expiry = monotonic() + 60`,
+  the response is `502` (or whatever finalize raised, propagated),
+  and the pending entry is NOT popped.
+
+- **When** the user retries `POST /api/auth/totp-login` with the SAME
+  `temp_token` within 60 seconds,
+- **Then** the handler detects state `finalize-pending`,
+  SKIPS the Zitadel `update_session_with_totp` call (the TOTP code is
+  one-time-use; Zitadel already accepted it),
+  re-calls `_finalize_and_set_cookie` with the stored session_id +
+  session_token,
+  on success returns `200` with the SSO cookie set,
+  and pops the pending entry.
+
+**Test:** `tests/test_auth_totp_finalize_retry.py::test_finalize_5xx_then_retry_succeeds`
+
+---
+
+## AC-4: finalize 5xx then 60s timeout
+
+- **Given** a pending entry has been in state `finalize-pending` for
+  more than 60 seconds (`monotonic() > finalize_expiry`),
+- **When** the user retries `POST /api/auth/totp-login` with the same
+  `temp_token`,
+- **Then** the handler detects the expired entry, pops it,
+  and returns `400 "Session expired, please log in again"`
+  (CURRENT behaviour preserved for stale sessions).
+
+**Test:** `tests/test_auth_totp_finalize_retry.py::test_finalize_pending_60s_timeout`
+
+---
+
+## AC-5: retry-after-success is a no-op
+
+- **Given** a previous retry has already succeeded — the SSO cookie
+  was issued, the pending entry was popped (AC-3 happy continuation),
+- **When** the user retries `POST /api/auth/totp-login` with the same
+  `temp_token` again (e.g. duplicate browser submit),
+- **Then** the handler finds NO pending entry (state was popped on
+  first success), and returns `400 "Session expired, please log in
+  again"` — the one-token-one-cookie invariant holds: NO second SSO
+  cookie is issued, NO duplicate audit event is written.
+
+**Test:** `tests/test_auth_totp_finalize_retry.py::test_retry_after_success_is_no_op`
+
+---
+
+## Run Acceptance Aggregate
+
+The SPEC is **acceptable** when:
+
+- AC-1, AC-2, AC-3, AC-4, AC-5 all pass.
+- `pytest -q` over the full `klai-portal/backend/tests/` stays green
+  (no regression in any other auth-flow test).
+- A grep of the production logs for the new event
+  `totp_finalize_pending_retry` returns ZERO occurrences before
+  deploy AND non-zero occurrences in any week with at least one
+  finalize 5xx (proves the new path is actually exercised).
+- The pop-ordering bug is unreproducible — manual repro via patching
+  `_validate_callback_url` to raise `HTTPException(502)` and triggering
+  a real TOTP login + retry sequence within 60s yields a `200 SSO
+  cookie set` response on the retry.

--- a/.moai/specs/SPEC-AUTH-TOTP-POPORDER-001/plan.md
+++ b/.moai/specs/SPEC-AUTH-TOTP-POPORDER-001/plan.md
@@ -1,0 +1,71 @@
+# SPEC-AUTH-TOTP-POPORDER-001 — Implementation Plan
+
+## Approach
+
+Refactor `_pending_totp` from a flat dict-of-tokens into a small state
+machine. Each entry is a dict with an explicit ``state`` field
+(``awaiting-totp`` | ``finalize-pending``) plus a ``finalize_expiry``
+timestamp set when state transitions to ``finalize-pending``.
+
+The handler ``totp_login`` becomes a state-aware dispatcher:
+
+1. Look up entry by ``temp_token``. If absent OR expired → 400 "Session
+   expired" (current behaviour preserved for the no-pending case).
+2. If state is ``awaiting-totp``: existing flow — call Zitadel TOTP
+   verify, on success transition to ``finalize-pending`` and call
+   ``_finalize_and_set_cookie``.
+3. If state is ``finalize-pending``: skip Zitadel TOTP verify, just
+   re-call ``_finalize_and_set_cookie``. Idempotent.
+4. Pop entry only on terminal outcomes (success, lockout, user-error).
+
+## Task Decomposition
+
+| # | Task | File | Risk |
+|---|---|---|---|
+| 1 | Hoist ``_pending_totp`` schema into a TypedDict; add ``state`` + ``finalize_expiry`` fields with backward-compatible defaults | `app/api/auth.py` | Low — additive change to in-memory dict shape |
+| 2 | Introduce ``_PendingTOTP`` state-machine helper class with `put`, `get`, `transition_to_finalize_pending`, `pop`, `cleanup_expired` methods | `app/api/auth.py` | Medium — concentration of state handling logic; test before refactoring callers |
+| 3 | Update ``login`` (creating awaiting-totp entry) and ``totp_login`` (state-aware dispatch) to use the helper | `app/api/auth.py` | Medium — touches the auth happy path; full integration tests required |
+| 4 | Add expiry sweep — best-effort cleanup of expired ``finalize-pending`` entries on any ``totp_login`` request | `app/api/auth.py` | Low — opportunistic cleanup, not a hard invariant |
+| 5 | Tests for all 5 acceptance scenarios in `acceptance.md` | new `tests/test_auth_totp_finalize_retry.py` | Low — pure unit tests with mocked Zitadel |
+| 6 | Update `@MX:ANCHOR` on `_pending_totp` to reflect the state-machine invariants | `app/api/auth.py` | Low — annotation only |
+
+## Files Affected
+
+- `klai-portal/backend/app/api/auth.py` — `_pending_totp` schema, `login`, `totp_login`, `_PendingTOTP` helper class
+- `klai-portal/backend/tests/test_auth_totp_finalize_retry.py` (new) — 5 G/W/T scenarios + expiry-sweep coverage
+- `klai-portal/backend/tests/test_auth_totp_endpoints.py` — extend existing TOTP tests if helper-class refactor affects them (read-before-edit)
+
+## Technology Choices
+
+- **No external dependency.** ``_pending_totp`` stays an in-memory dict — Redis migration is a separate concern (cross-service horizontal-scaling SPEC, see Out of Scope).
+- **TypedDict** over dataclass to keep the structure JSON-serialisable for any future Redis port (forward-compatible).
+- **Explicit state field** instead of "implicit state via field presence" (e.g. checking if ``finalize_expiry`` exists) — explicit is auditable, presence-checks are not.
+- **Time source via ``time.monotonic()``** for the 60s expiry — wall-clock skew during NTP correction would otherwise cause early expiry.
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| The ``_PendingTOTP`` helper masks a subtle bug (e.g. `get` returning a copy when callers expect a reference) | Helper exposes only string-keyed primitives + opaque transitions; callers cannot reach into entry internals |
+| Idempotent retry leaks the SSO cookie (one user, two cookies) | Retry path explicitly checks for an existing cookie via the request and refuses to issue a second; test in AC-5 |
+| Expiry sweep amplifies the cost of a high-volume login storm | Sweep is opportunistic (one entry max per request) and bounded by the dict size; in production the dict rarely exceeds ~10 entries (TOTP retry window is short) |
+| Behaviour change breaks existing integration tests | Run full `pytest -q` after each task above, not only at the end |
+
+## Success Criteria
+
+- All 5 acceptance scenarios in `acceptance.md` pass.
+- The full portal-api test suite stays green (currently 1399+, post-FU#1 1407).
+- No regression in TOTP-related metric / event names — `totp_login_failed` reasons stay enumerable.
+- The pop-ordering bug is unreproducible: triggering a 5xx in `_finalize_and_set_cookie` followed by a retry within 60s yields a successful login, NOT a "Session expired" 400.
+
+## Out of Scope
+
+- Replacing the in-memory dict with Redis. Single-instance limitation persists; horizontal scaling is a separate SPEC (cross-cuts auth + retrieval).
+- Changing TOTP code-validation semantics (one-time-use, ``_TOTP_MAX_FAILURES`` accounting).
+- Changing the response message wording for the existing failure modes.
+
+## Ordering & Branch Strategy
+
+Single PR. Tasks 1-2 (schema + helper) committed first as a no-op
+refactor; tasks 3-4 (handler) on top; tasks 5-6 (tests + MX) last.
+PR body must include the AC matrix and the rollback command.

--- a/.moai/specs/SPEC-CI-E2E-GATE-001/acceptance.md
+++ b/.moai/specs/SPEC-CI-E2E-GATE-001/acceptance.md
@@ -1,0 +1,102 @@
+# SPEC-CI-E2E-GATE-001 — Acceptance Criteria
+
+Seven Given/When/Then scenarios. The SPEC is acceptable when all
+seven hold during the Phase-4 soak window AND for the first 30 days
+post-flip.
+
+## AC-1 — Login bootstrap journey passes against staging
+
+- **Given** the staging tenant is up with the seeded user and the
+  `STAGING_SMOKE_TOTP_SEED` secret is configured,
+- **When** the smoke workflow triggers via `workflow_run` from a
+  service `Build and push *` job,
+- **Then** the runner navigates to `https://staging.getklai.com`,
+  performs the email/password/TOTP flow, lands on `/app/*`, and
+  records the journey as `pass` with measured duration < 30 seconds.
+
+**Test:** `tests/e2e/smoke.spec.ts::login bootstrap`
+
+## AC-2 — Hostname allowlist refuses a production-hostname call
+
+- **Given** the runner's `host_guard.ts` allowlist is in effect,
+- **When** the test attempts a `page.goto(url)` where
+  `urlparse(url).hostname` is `getklai.com` (production-shaped),
+- **Then** the runner aborts the run with a hard error
+  `production_hostname_blocked` and the test marks itself as a
+  catastrophic failure (NOT a regular `fail`). The smoke workflow
+  exits non-zero so production deploy never runs.
+
+**Test:** mutation test in `tests/e2e/_lib/host_guard.test.ts`
+
+## AC-3 — Password-reset journey end-to-end
+
+- **Given** the seeded user exists in staging Zitadel and the
+  Mailtrap (or chosen test inbox) is configured,
+- **When** the runner triggers `POST /api/auth/password/reset` for
+  the seeded user's email,
+- **Then** within 30 seconds the test inbox API receives a message
+  with subject containing "password" or "wachtwoord", the runner
+  extracts the reset link, follows it, sets a new password, and
+  records the journey as `pass`.
+
+**Test:** `tests/e2e/smoke.spec.ts::password reset email`
+
+## AC-4 — Smoke fail blocks production deploy
+
+- **Given** a feature branch deliberately reverts PR #230 (the
+  2026-04-29 callback-allowlist hotfix), restoring the broken state,
+- **When** the branch is merged and the post-deploy-smoke workflow
+  runs,
+- **Then** the login-bootstrap journey returns `fail` (502 on
+  totp-login), the smoke workflow exits non-zero, and the production
+  `deploy` job for portal-api does NOT run (verified by checking the
+  workflow's job DAG).
+
+**Test:** manual phase-4 verification on a sandbox feature branch.
+
+## AC-5 — Smoke fail blocks deploy for OTHER services too
+
+- **Given** a feature branch deliberately reverts PR #231 (the
+  2026-04-29 mailer redis URL hotfix),
+- **When** the branch is merged and triggers a `Build and push klai-mailer`,
+- **Then** the password-reset journey returns `fail` (mailer 5xx),
+  the smoke workflow exits non-zero, and the production `deploy` job
+  for `klai-mailer` does NOT run.
+
+**Test:** manual phase-4 verification on a sandbox feature branch.
+
+## AC-6 — Override workflow-dispatch bypasses the gate
+
+- **Given** the smoke is in a known-flake state (e.g. staging Zitadel
+  briefly down) AND a real production hotfix needs to ship,
+- **When** an operator triggers the deploy job via
+  `workflow_dispatch` with `--force-deploy=true`,
+- **Then** the deploy runs, the smoke result is logged but ignored
+  for gating purposes, AND the override is recorded in a structlog
+  event `smoke_gate_override_used` for audit purposes.
+
+**Test:** manual phase-4 verification.
+
+## AC-7 — Nightly full-suite catches what the per-merge subset misses
+
+- **Given** the nightly workflow runs at 03:00 UTC against staging,
+- **When** any of the 14 journeys from SPEC-TEST-E2E-001 returns
+  `fail` or `warn`,
+- **Then** a Slack message posts to `#klai-ops-alerts` with the
+  failing journey name and a link to the run; the next morning's
+  on-call sees it before user impact.
+
+**Test:** the existing observability infrastructure; verified by
+manually failing one journey in staging on a chosen night.
+
+## Run Acceptance Aggregate
+
+The SPEC is **acceptable** when:
+
+- All 7 ACs pass for the first 30 days post-flip.
+- The 2026-04-29 dual outage shape (PR #230 callback allowlist + PR
+  #231 mailer redis URL) is reproducibly caught by the gate.
+- Median smoke runtime ≤ 90s; P99 ≤ 3 minutes; hard timeout 5
+  minutes.
+- Cost ≤ $20/month at 30 smokes/day.
+- Zero production false-positives in 30 days.

--- a/.moai/specs/SPEC-CI-E2E-GATE-001/plan.md
+++ b/.moai/specs/SPEC-CI-E2E-GATE-001/plan.md
@@ -1,0 +1,108 @@
+# SPEC-CI-E2E-GATE-001 — Implementation Plan
+
+## Approach
+
+Stand up a dedicated **staging tenant** that mirrors production
+topology (Caddy + portal-api + mailer + Zitadel + retrieval-api +
+knowledge-ingest), wire it as the smoke target between the existing
+`build-push` and `deploy` GitHub Actions jobs, and ship a 5-journey
+Playwright smoke that runs in under 90 seconds. The smoke executes
+against staging only — a hostname allowlist in the runner enforces the
+"NEVER touch production" invariant.
+
+The 14-journey full SPEC-TEST-E2E-001 runbook stays as the manual
+interactive validation. This SPEC defines a SUBSET that becomes the
+per-merge gate.
+
+## Task Decomposition
+
+### Phase 1 — Stand up staging tenant (Week 1)
+
+| # | Task | Files / infra | Risk |
+|---|---|---|---|
+| 1 | Provision a fresh server (`staging-01`) — same Hetzner cloud spec as core-01 (CPX31 or equivalent) | new infra in `klai-infra/staging-01/` | Medium — DNS + cert setup is a one-shot operation, must coordinate `staging.getklai.com` cert |
+| 2 | Bring up the same docker-compose stack on staging — postgres + redis + caddy + portal-api + mailer + zitadel + retrieval-api + knowledge-ingest | `klai-infra/staging-01/docker-compose.yml` | Medium — staging Zitadel is a fresh instance; no shared user data with prod |
+| 3 | Create `ci-smoke@staging-getklai.com` service account in staging Zitadel with TOTP enabled. Store TOTP seed in GitHub Actions secret `STAGING_SMOKE_TOTP_SEED` | staging Zitadel + GitHub repo settings | High — service-account credentials in CI secrets are a real attack surface; mitigated by scope (only this workflow can read the secret) |
+| 4 | Seed staging tenant with one known KB (`smoke-kb`), one known template (`smoke-template`), one active user above | new `klai-infra/staging-01/seed.sql` | Low — idempotent seed script, runnable from any operator workstation |
+
+### Phase 2 — Smoke runner (Week 2)
+
+| # | Task | Files | Risk |
+|---|---|---|---|
+| 5 | Write `tests/e2e/smoke.spec.ts` — Playwright Test in TypeScript covering the 5-journey subset | new directory `tests/e2e/` | Medium — first TS test in the repo; follow `klai-portal/frontend/` tooling conventions |
+| 6 | Implement the hostname-allowlist guard at runner level — refuses any `page.goto(url)` where `urlparse(url).hostname` is not in the staging set | `tests/e2e/_lib/host_guard.ts` | High — this is the "NEVER touch prod" invariant; needs a mutation test that proves a deliberate prod-hostname attempt fails the run |
+| 7 | Implement the test inbox poll for password-reset journey — Mailtrap.io free tier (decision deferred to operator) OR a dedicated mail server in staging-01 | `tests/e2e/_lib/inbox_poll.ts` | Medium — Mailtrap rate limits and API quirks; abstract the poll behind an interface so swap-in to a self-hosted alternative is one file |
+| 8 | Implement the TOTP-code generator — pyotp-equivalent in TS (`otpauth` npm package) reading `STAGING_SMOKE_TOTP_SEED` | `tests/e2e/_lib/totp.ts` | Low — npm `otpauth` is well-established |
+
+### Phase 3 — CI wiring (Week 3)
+
+| # | Task | Files | Risk |
+|---|---|---|---|
+| 9 | New `.github/workflows/post-deploy-smoke.yml` triggered by `workflow_run` from each service's `Build and push *` workflow on completion | new workflow file | Medium — `workflow_run` triggers have a non-obvious timing model; must verify the smoke fires within 60s of build complete |
+| 10 | Update each service's `deploy` job to gate on `smoke` workflow result via `needs:` cross-workflow dependency | every service's `.github/workflows/*.yml` | High — wrong wiring means production deploys are blocked by an unrelated smoke run; phase in service-by-service with manual override during the first week |
+| 11 | Add nightly full-suite workflow `.github/workflows/e2e-nightly.yml` running the full SPEC-TEST-E2E-001 runbook subset on cron | new workflow file | Low — nightly is non-blocking, results post to Slack |
+
+### Phase 4 — Soak + flip (Week 4)
+
+| # | Task | Files | Risk |
+|---|---|---|---|
+| 12 | Run the smoke in `report-only` mode for 7 consecutive days. Track pass/warn/fail rate | observability dashboard | Low |
+| 13 | After 7 days of zero unexplained failures, flip `deploy.needs: [smoke]` to blocking | every service's deploy job | High — first day after flipping, watch for any false-positive that would block a real deploy |
+| 14 | Document the override path: a manual workflow-dispatch with `--force-deploy=true` for emergency deploys when the smoke is broken | `docs/runbooks/post-deploy-smoke-override.md` | Low — explicit operator action, audited via workflow logs |
+
+## Files Affected
+
+- New `klai-infra/staging-01/` — entire staging compose stack
+- New `tests/e2e/` — TypeScript Playwright test directory
+- New `.github/workflows/post-deploy-smoke.yml`
+- New `.github/workflows/e2e-nightly.yml`
+- 8 existing service workflows under `.github/workflows/` — each gets `deploy.needs: [smoke]`
+- New `docs/runbooks/post-deploy-smoke-override.md` — emergency-bypass procedure
+- New `klai-infra/staging-01/seed.sql` — staging-tenant seed data
+- New GitHub Actions secrets — `STAGING_SMOKE_TOTP_SEED`, `STAGING_SMOKE_PASSWORD`, `MAILTRAP_API_TOKEN` (or equivalent)
+
+## Technology Choices
+
+- **Playwright Test (TypeScript)** over Pytest+Playwright — mirrors `klai-portal/frontend/` tooling; better test-runner UX; native parallelism.
+- **Mailtrap.io free tier** for the test inbox — defer the self-hosted alternative until the smoke proves valuable. Free tier covers the projected ~30 smokes/day.
+- **`otpauth` npm package** for TOTP code generation — battle-tested, no native deps.
+- **`workflow_run` cross-workflow dispatch** for triggering smoke on build completion — avoids the alternative of bundling the smoke into every service's workflow file (8 copies of the same job).
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Smoke runs against production by accident (the catastrophic failure mode) | Hostname allowlist in `host_guard.ts` + a CI step that asserts the allowlist exists + a mutation test in the runner repo proving a deliberate prod-hostname call aborts the run |
+| Service-account TOTP seed exposed via GitHub Actions secret leakage | Secret scoped to the smoke workflow only; rotated quarterly; service account has zero data — only a known-KB and known-template; cannot exfiltrate user data |
+| Smoke flakiness blocks legitimate deploys | Phase-4 soak (7 days report-only) catches systemic flakes; `--force-deploy` workflow-dispatch provides emergency override |
+| Staging tenant drifts from production over time | Quarterly review with diff against production docker-compose; staging seed script is the canonical "what staging looks like" |
+| 90s budget exceeded as journeys grow | Hard timeout in the workflow + per-journey budget; nightly full-suite catches regressions in journeys we cut from the per-merge gate |
+
+## Success Criteria
+
+- A deliberate regression in the `_validate_callback_url` allowlist (the 2026-04-29 outage shape) is caught by the smoke gate within 90 seconds of the merge that introduces it. Reproduce: revert PR #230 in a feature branch, observe the smoke fire on the resulting build-push; the production deploy never runs.
+- The 2026-04-29 mailer broken-redis-URL outage shape is caught the same way — Phase 1 of the rollout includes a regression test that reverts PR #231 and verifies the smoke catches it.
+- Smoke median runtime ≤ 90 seconds. P99 ≤ 3 minutes. Hard timeout 5 minutes.
+- Cost ≤ $20/month at 30 smokes/day median.
+- Zero production false-positives in the first 30 days post-flip.
+
+## Out of Scope
+
+- Replacing the manual SPEC-TEST-E2E-001 runbook. The full 14-journey runbook stays as the interactive validation.
+- Cross-browser, mobile, accessibility coverage — Chromium-only.
+- Performance benchmarking — existence of a successful response is the assertion, not response-time SLOs.
+- Backfill smoke for already-merged PRs — gate is forward-only.
+
+## Decision Points to Resolve in Phase 1
+
+1. Staging tenant infrastructure: dedicated `staging-01` server vs core-01 with namespace isolation.
+2. Test inbox provider: Mailtrap.io vs self-hosted MailHog vs Gmail `+ci` filter.
+3. Service-account TOTP seed rotation cadence and revocation playbook.
+4. Flake-retry policy: how many retries before the gate is considered failing (suggest: 1 retry with a different wallclock, then fail).
+
+## Phasing Recommendation
+
+- **Week 1**: Phase 1 (staging tenant + service account)
+- **Week 2**: Phase 2 (smoke runner + 1 journey: login bootstrap)
+- **Week 3**: Phase 3 (CI wiring + remaining journeys + nightly)
+- **Week 4**: Phase 4 (soak + flip)

--- a/.moai/specs/SPEC-INFRA-REDIS-SPLIT-001/acceptance.md
+++ b/.moai/specs/SPEC-INFRA-REDIS-SPLIT-001/acceptance.md
@@ -1,0 +1,94 @@
+# SPEC-INFRA-REDIS-SPLIT-001 — Acceptance Criteria
+
+Six Given/When/Then scenarios. The SPEC is acceptable when all six
+hold for every klai service that uses Redis.
+
+## AC-1 — per-component settings construct cleanly
+
+- **Given** a service's `Settings()` is instantiated with all six
+  `REDIS_HOST`, `REDIS_PORT`, `REDIS_USERNAME`, `REDIS_PASSWORD`,
+  `REDIS_DB`, `REDIS_SSL` env vars set,
+- **When** the service starts up,
+- **Then** `Settings()` constructs without raising; the resulting
+  Redis client connects on first use; no `redis_url_legacy_shim_used`
+  WARNING is emitted.
+
+**Test target:** every service's `tests/test_config_*.py`
+
+## AC-2 — Stage-A shim falls back to legacy URL with a warning
+
+- **Given** only `REDIS_URL` is set in the env (per-component vars
+  unset) — the Stage-A "operator hasn't migrated SOPS yet" state,
+- **When** the service starts up under Stage A code,
+- **Then** the shim parses `REDIS_URL` via `parse_redis_url`,
+  populates the per-component fields from the parsed result,
+  emits a structlog WARNING `redis_url_legacy_shim_used` with the
+  service name, AND the resulting Redis client connects normally.
+
+**Test:** `klai-libs/redis-config/tests/test_legacy_url_shim.py`
+
+## AC-3 — both sources present: per-component wins, warning still fires
+
+- **Given** BOTH `REDIS_URL` AND the per-component vars are set
+  (the Stage-B "operator migrated SOPS, both coexist" state),
+- **When** the service starts up,
+- **Then** the per-component vars take precedence (verified by
+  asserting the active host/port match the per-component values
+  even when the URL would have parsed to different values),
+  AND the shim still emits the WARNING — Stage-C cleanup is what
+  removes the warning.
+
+**Test:** `klai-libs/redis-config/tests/test_legacy_url_shim.py`
+
+## AC-4 — Stage-D code path: legacy URL alone refuses boot
+
+- **Given** the service has shipped Stage-D (shim removed, legacy
+  setting deleted) AND only `REDIS_URL` is set in the env (operator
+  forgot Stage C),
+- **When** the service starts up,
+- **Then** boot fails with a clear pydantic ValidationError naming
+  the missing `REDIS_HOST` field (NOT a cryptic Redis connection
+  error). The operator sees the misconfiguration in deploy logs
+  immediately.
+
+**Test:** every service's `tests/test_config_*.py` post-Stage-D
+
+## AC-5 — semgrep rule blocks `Redis.from_url(...)` reintroduction
+
+- **Given** a developer's PR reintroduces `redis.asyncio.Redis.from_url(settings.redis_url)`
+  in any klai service path under `klai-*`,
+- **When** the PR's CI runs the `no-redis-from-url` rule via
+  `ast-grep/action`,
+- **Then** the CI step exits non-zero with the `no-redis-from-url`
+  message pointing at this SPEC. PR cannot merge.
+
+**Test:** `rules/no-redis-from-url.yml` regression fixture in the
+project's existing semgrep test harness
+
+## AC-6 — runbook walks an operator through a SOPS migration
+
+- **Given** a fresh operator with no prior context AND
+  `docs/runbooks/redis-config-migration.md`,
+- **When** they follow the runbook step by step on a staging
+  environment that mirrors production SOPS,
+- **Then** they complete Stage B + Stage C for at least one service
+  in under 30 minutes, AND the verification script at the end of the
+  runbook reports zero `redis_url_legacy_shim_used` warnings within
+  five minutes after Stage C.
+
+**Test:** runbook itself; manual verification on a staging
+environment before main rollout begins.
+
+## Run Acceptance Aggregate
+
+The SPEC is **acceptable** when:
+
+- AC-1 through AC-6 all hold for every service after its Stage D.
+- All eight services have completed Stage D in the planned rollout
+  window (target: one calendar quarter).
+- `mailer_zitadel_webhook_failed` and equivalent service alerts have
+  ZERO firings caused by Redis configuration during the migration.
+- The semgrep rule `no-redis-from-url` is in CI for every klai
+  service workflow.
+- `klai-infra/core-01/.env.sops` contains zero `REDIS_URL=` entries
+  after the rollout completes.

--- a/.moai/specs/SPEC-INFRA-REDIS-SPLIT-001/plan.md
+++ b/.moai/specs/SPEC-INFRA-REDIS-SPLIT-001/plan.md
@@ -1,0 +1,88 @@
+# SPEC-INFRA-REDIS-SPLIT-001 — Implementation Plan
+
+## Approach
+
+Migrate every klai service from a single `REDIS_URL` env var to per-component `REDIS_HOST`, `REDIS_PORT`, `REDIS_USERNAME`, `REDIS_PASSWORD`, `REDIS_DB`, `REDIS_SSL`. Phased rollout with backward-compat shim during migration so each service ships independently. Final cleanup PR removes the `REDIS_URL` setting after all services + SOPS are migrated.
+
+The mailer rollout is the reference implementation: its existing `parse_redis_url` (PR #231 / SPEC-SEC-MAILER-INJECTION-001 REQ-6.5) plus the boot validator (PR #239 / REQ-6.5 fail-fast) form the working pattern. This SPEC replicates that pattern across the seven other services.
+
+## Service Rollout Table
+
+| # | Service | Settings file | Existing redis usage | Rollout PR ID (TBD) |
+|---|---|---|---|---|
+| 1 | klai-mailer | `klai-mailer/app/config.py` | nonce + rate-limit (REQ-6) | reference-impl (already shipped) |
+| 2 | klai-knowledge-mcp | `klai-knowledge-mcp/config.py` | session cache | new |
+| 3 | klai-portal-api | `klai-portal/backend/app/core/config.py` | RLS GUC cache, SSO state | new (highest blast radius — staged behind shim for 7d) |
+| 4 | klai-retrieval-api | `klai-retrieval-api/retrieval_api/config.py` | retrieval result cache | new |
+| 5 | klai-knowledge-ingest | `klai-knowledge-ingest/knowledge_ingest/config.py` | crawl-status pubsub | new |
+| 6 | klai-scribe-api | `klai-scribe/scribe-api/app/config.py` | meeting-state cache | new |
+| 7 | klai-connector | `klai-connector/app/config.py` | sync-job lock | new |
+| 8 | klai-focus / research-api | `klai-focus/research-api/app/config.py` | notebook cache | new |
+
+Each service rollout follows the SAME 5-stage pattern:
+
+**Stage A** — PR adds per-component settings + shim that reads `REDIS_URL` if individual vars are unset; emits `redis_url_legacy_shim_used` WARNING. Lands first.
+
+**Stage B** — Operator updates `klai-infra/core-01/.env.sops` to add per-component vars alongside the existing `REDIS_URL`. Both coexist; shim warning still fires.
+
+**Stage C** — Operator removes `REDIS_URL` from SOPS once warning has stopped (typically next deploy after Stage B).
+
+**Stage D** — Per-service follow-up PR removes the shim and the `REDIS_URL` setting after 7 consecutive days of no `redis_url_legacy_shim_used` warning. Settings becomes per-component-only.
+
+**Stage E** (cross-cutting, last) — semgrep rule `no-redis-from-url` blocks any future `Redis.from_url(settings.redis_url)` reintroduction. New service workflow file added.
+
+## Task Decomposition
+
+| # | Task | Files | Risk |
+|---|---|---|---|
+| 1 | Extract `parse_redis_url` from `klai-mailer/app/redis_url.py` to a shared lib `klai-libs/redis-config/` | new lib + `klai-mailer/app/redis_url.py` reduced to a re-export | Medium — touches an already-shipped module; a re-export keeps the import path stable |
+| 2 | Define the canonical `RedisSettings` mixin in the shared lib: per-component fields with the shim validator | `klai-libs/redis-config/` | Medium — the contract every service inherits |
+| 3 | Per-service Stage-A PRs (×7) — each adds `RedisSettings` to the service's settings class, swaps `from_url` to kwargs, ships the shim | per service | Low individually; coordinate timing so a service is not deployed mid-rollout |
+| 4 | Operator Stage-B + Stage-C — SOPS update across all services in one batch | `klai-infra/core-01/.env.sops` | Medium — wrong copy-paste between vars and SOPS values is the obvious risk; mitigate with a verification script in the migration runbook |
+| 5 | Per-service Stage-D PRs (×7) — remove shim + legacy setting. Land in same week as the 7-day soak completes | per service | Low individually |
+| 6 | Stage E — semgrep rule + workflow integration | new `rules/no-redis-from-url.yml`, every service workflow file | Low |
+
+## Files Affected
+
+- `klai-libs/redis-config/` — new shared lib (mirrors `klai-libs/log-utils`, `klai-libs/identity-assert` patterns)
+- 8 service settings files (see Service Rollout Table)
+- 8 service docker-compose entries — switch from `${REDIS_URL}` to the per-component vars
+- `klai-infra/core-01/.env.sops` — Stage B + C
+- `rules/no-redis-from-url.yml` (new semgrep rule) + 8 workflow files (each service's CI integrates the rule via `ast-grep/action`)
+- New `docs/runbooks/redis-config-migration.md` — operator step-by-step for the SOPS migration with verification commands
+
+## Technology Choices
+
+- **Shared lib** over copy-paste in each service — one source of truth for the parser + shim. Same pattern as `klai-libs/log-utils`.
+- **Per-component env vars** over a single SOPS-encoded URL — eliminates the URL-encoding-of-password failure class entirely. Matches 12-factor.
+- **Boot validator on each per-component field** — non-empty `REDIS_HOST` and integer `REDIS_PORT`; password may be empty for unauth Redis (dev) but emit a startup WARNING in that case.
+- **`redis-py 5.x` kwargs constructor** — already supported across all current klai services; no version bump required.
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Stage-A shim hides a per-component env var typo (operator sets `REDIS_PORT=6739` but forgets, shim falls back to URL) | Stage-A explicitly logs the source of each value at startup: `redis_settings_source field=REDIS_HOST source=env|legacy_url`. Operators see exactly which path is active per field |
+| Mid-rollout service A reads URL, service B reads per-component, with mismatched values | Solved by Stage B making BOTH consistent. The Stage-C cleanup happens only after a 7-day soak with both sources present |
+| Forgetting a service in the rollout | Stage E semgrep rule fires CI failure on any future `Redis.from_url(...)` — even if a service is skipped today, the rule protects future regressions |
+| Existing tests assume URL-style settings | Settings tests use the shim path; both URL-only and per-component-only configurations have parametrised tests in the shared lib |
+
+## Success Criteria
+
+- All 8 services pass their full test suites at every rollout stage.
+- Zero production incidents during the rollout window (verified by absence of `mailer_zitadel_webhook_failed`, `caddy_5xx_count_high`, etc. firing during the migration weeks).
+- After Stage E, semgrep CI rejects any PR that reintroduces `Redis.from_url(...)` against any klai service path.
+- Operator-runbook `redis-config-migration.md` walks a fresh operator through the SOPS migration end-to-end without ambiguity.
+
+## Out of Scope
+
+- Migrating Redis itself (Redis Cluster, Sentinel, ElastiCache).
+- Adding TLS / `rediss://` support to the broker. The schema accommodates `REDIS_SSL=true` for future use but the broker is unchanged.
+- Changing the password rotation cadence. The rotation playbook becomes safer because URL-encoding of new passwords is no longer required, but the rotation policy itself stays in the existing credential-rotation runbook.
+
+## Ordering & Branch Strategy
+
+- **One PR per stage per service**, not one mega-PR. Smaller PRs review faster, fail-fast in CI, ship independently.
+- **Mailer is already done** — use it as the reference. Other 7 services follow the same diff shape.
+- **Portal-api is staged behind a 7-day soak** — highest blast radius. All other services finish Stage A → Stage D before portal-api starts Stage A.
+- **Stage E (semgrep) lands ONLY after Stage D for all 8 services** — otherwise the rule false-fires on a service still in transition.


### PR DESCRIPTION
## Why

PR #234 created three SPEC stubs from the 2026-04-29 retro. Stubs have spec.md only; this PR adds the missing plan.md + acceptance.md to each so they are ready for `/moai run` without further /moai plan rounds.

## What changed

6 new files. Pure documentation. Zero code.

| SPEC | plan.md highlights | acceptance.md highlights |
|---|---|---|
| `SPEC-AUTH-TOTP-POPORDER-001` | 6-task decomposition, single PR, 4 risks | 5 G/W/T (happy, invalid code, finalize 5xx + retry, 60s timeout, retry-after-success no-op) |
| `SPEC-INFRA-REDIS-SPLIT-001` | 5-stage rollout (A→E) across 8 services, mailer as reference, portal-api with 7-day soak | 6 G/W/T (per-component, shim, both-sources, Stage-D fail-fast, semgrep block, runbook) |
| `SPEC-CI-E2E-GATE-001` | 4-week phasing: staging tenant → runner → CI wiring → soak+flip | 7 G/W/T (login, host allowlist, password reset, blocks portal-api deploy, blocks mailer deploy, override, nightly) |

The acceptance.md for SPEC-CI-E2E-GATE-001 explicitly references the 2026-04-29 dual-outage shape (PR #230 + PR #231) as the canonical regression case the gate must catch.

## Verification

- [x] All 6 files lint as valid Markdown
- [x] Each SPEC directory has spec.md + plan.md + acceptance.md
- [x] Each acceptance.md ties back to specific REQs in spec.md

## Out of scope

- Implementation. Each SPEC is now ready for `/moai run`; that's the next step per SPEC.
- spec-compact.md auto-generation. /moai plan would emit those; here we ship plan.md + acceptance.md as the higher-leverage artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)