### PR TITLE
fix(alerting): tighten mailer alert queries — no fragile substrings

### DIFF
--- a/deploy/grafana/provisioning/alerting/mailer-rules.yaml
+++ b/deploy/grafana/provisioning/alerting/mailer-rules.yaml
@@ -69,7 +69,17 @@ groups:
               datasource:
                 type: victoriametrics-logs-datasource
                 uid: victorialogs
-              expr: 'service:zitadel AND msg:"sending notification failed" AND error:"klai-mailer:8000"'
+              # Match every Zitadel notification-channel failure regardless
+              # of target host:port. The earlier shape (`error:"klai-mailer:8000"`)
+              # was a literal substring on the error message that would
+              # silently break if mailer ever moves to a different host or
+              # port — exactly the regression class this SPEC is meant to
+              # close. Mailer is the only registered webhook channel today,
+              # so a Zitadel notification-failed event implies the mailer
+              # is broken; if a second channel ever exists (e.g. Slack
+              # incident-bridge), revisit this filter to restore the target
+              # narrowing.
+              expr: 'service:zitadel AND msg:"sending notification failed"'
               queryType: instant
           - refId: reduce
             datasourceUid: __expr__
@@ -119,9 +129,11 @@ groups:
 
             Triage:
               1. Check the actual error from Zitadel's view:
-                   service:zitadel AND msg:"sending notification failed" AND error:"klai-mailer:8000"
-                 The error= field contains the HTTP status and a partial
-                 reason from the mailer's response.
+                   service:zitadel AND msg:"sending notification failed"
+                 The error= field on the matching log lines contains the
+                 HTTP status, target URL, and a partial reason from the
+                 receiving service's response — that tells you which
+                 webhook target is broken.
               2. Inspect mailer's own logs for the same window (now
                  visible after the FU#2 access-log fix):
                    service:klai-mailer AND _time:5m
@@ -161,8 +173,15 @@ groups:
                 type: victoriametrics-logs-datasource
                 uid: victorialogs
               # The uvicorn access log for /notify lines with a 5xx status.
-              # Substring match on the message body — matches "POST /notify HTTP/1.1" 5XX.
-              expr: 'service:klai-mailer AND _msg:"POST /notify" AND _msg:" 5"'
+              # The exact uvicorn line shape is:
+              #   `<addr> - "POST /notify HTTP/1.1" <status> <reason>`
+              # The status code is preceded by the closing quote of the
+              # request line, so the substring `" 5` (close-quote + space
+              # + digit five) is a tight anchor to "5xx access record".
+              # Combining it with the literal `POST /notify HTTP` rules
+              # out unrelated app-level log lines that happen to contain
+              # `" 5` (e.g. structlog JSON entries with " 5" inside).
+              expr: 'service:klai-mailer AND _msg:"POST /notify HTTP" AND _msg:"\" 5"'
               queryType: instant
           - refId: reduce
             datasourceUid: __expr__


### PR DESCRIPTION
## Why

Self-review of PR #238 identified two fragile LogsQL queries:

- **M1** (`mailer_zitadel_webhook_failed`) included `error:\"klai-mailer:8000\"` — literal substring on host:port. If mailer ever moves, the alert silently stops firing. Same regression class as the original 2026-04-29 incident.
- **M2** (`mailer_notify_5xx_count_high`) used `_msg:\" 5\"` — matches any log line with space+5. False-positives trivially on structlog entries with \" 5MB processed\" or similar.

## What changed

`deploy/grafana/provisioning/alerting/mailer-rules.yaml`:

| Alert | Before | After |
|---|---|---|
| M1 | `... AND error:\"klai-mailer:8000\"` | dropped that clause |
| M2 | `... AND _msg:\" 5\"` | `... AND _msg:\"POST /notify HTTP\" AND _msg:\"\\\" 5\"` |

M2's new pattern anchors on the exact uvicorn access-log shape:  `<addr> - \"POST /notify HTTP/1.1\" <status> <reason>`. The `\" 5` (close-quote + space + 5) is the tight anchor for 5xx class status; combining with `POST /notify HTTP` (only present in uvicorn access lines) rules out app-level log lines.

Triage block in the runbook annotation updated to match the looser M1 query.

## Verification

- [x] YAML valid (`python -c \"yaml.safe_load(...)\"`)
- [x] 2 rules unchanged (M1 + M2)

Provisioned alerts auto-reload on Grafana restart.

## Out of scope

Switching uvicorn to structured-JSON access logs would let us filter on a real `status_code` field instead of substring-matching the message body. Touches every klai service's logging_setup.py — separate SPEC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)