### PR TITLE
docs(spec): SPEC-TEST-E2E-001 — Klai portal smoke test runbook + first-run notes

### DIFF
--- a/.moai/specs/SPEC-TEST-E2E-001/acceptance.md
+++ b/.moai/specs/SPEC-TEST-E2E-001/acceptance.md
@@ -1,0 +1,62 @@
+# SPEC-TEST-E2E-001 — Acceptance Criteria
+
+Seven Given/When/Then scenarios. The run is acceptable when all seven evaluate true and the cleanup verification shows zero residual `e2e-test-` objects.
+
+## A1 — Login bootstrap (happy path)
+
+- **Given** the human user has logged into `https://getklai.getklai.com` via the shared Playwright browser and landed on `/app` or `/app/index`,
+- **When** the runner navigates the Playwright browser to `https://getklai.getklai.com`,
+- **Then** the resolved URL matches the pattern `/app/*` with no redirect to `/login`, `/signup`, `/select-workspace`, `/no-account`, or any IdP page, and the sidebar element from `klai-portal/frontend/src/components/layout/Sidebar.tsx` renders.
+
+## A2 — Authenticated-session abort
+
+- **Given** the Playwright session has no valid Zitadel cookie (e.g. user has not logged in or session expired),
+- **When** the runner navigates to `https://getklai.getklai.com` and observes a redirect to `/login` or any auth provider domain,
+- **Then** the runner emits a chat message instructing the user to log in manually, exits the journey loop without executing any subsequent journey, and produces no `.tmp/e2e-reports/` file beyond a stub indicating "aborted: not authenticated".
+
+## A3 — Read-only chat journey passes
+
+- **Given** the user is logged in and at least one knowledge base exists in the tenant,
+- **When** the runner navigates to `/app/chat`, picks the first knowledge base from the picker, submits the prompt `"e2e smoke test — please reply with OK"`, and waits up to 30 seconds for a streamed response,
+- **Then** the chat returns at least one message-rendered token, no console errors are logged during the journey, no HTTP response with status >= 500 is observed on the network, no model option in the model picker contains a US-only LLM brand name (per the `klai-portal-ui` project rule), and the journey is recorded with status `pass`.
+
+## A4 — Throwaway create + cleanup roundtrip
+
+- **Given** the runner is in Journey 4 (KB write),
+- **When** the runner creates a knowledge base named `e2e-test-{YYYYMMDD}-smoke-kb`, adds a text source named `e2e-test-{YYYYMMDD}-source` with body `"Smoke test content — see SPEC-TEST-E2E-001"`, registers both for cleanup, queries the KB via chat with prompt `"what does this say?"`, and reaches the cleanup phase,
+- **Then** the cleanup phase deletes the source and the KB in that order, the runner re-fetches the KB list and confirms the throwaway KB is absent, and Journey 4 is recorded with status `pass`.
+
+## A5 — Cleanup-on-failure
+
+- **Given** the runner has registered at least one throwaway object in the cleanup registry and a later journey raises an unexpected exception (e.g. browser crash, navigation timeout exceeding the journey budget),
+- **When** the runner exits via the failure handler before reaching the normal cleanup journey,
+- **Then** the failure handler processes the cleanup registry in the same order as the normal cleanup phase, all registered objects are deleted, the report's "Cleanup verification" section confirms zero `e2e-test-` objects remain, and the report's overall status is `fail` with the exception location recorded in the Findings section.
+
+## A6 — Excluded-action invariant
+
+- **Given** any journey is executing and an action would require clicking a UI element whose accessible text matches the Selector Blocklist in `spec.md` § Selector Blocklist (e.g. `Start meeting`, `Connect Google`, `Rotate key`, `Delete workspace`),
+- **When** the orchestration layer pattern-matches the target text against the blocklist before issuing `browser_click`,
+- **Then** the click is refused, the journey is recorded with status `warn` and reason `"skipped — excluded action: <matched phrase>"`, and the runner continues to the next journey rather than failing the run.
+
+## A7 — Per-journey report fields and screenshot path
+
+- **Given** the runner has completed all journeys (whether pass, warn, or fail),
+- **When** the runner generates the markdown report at `.tmp/e2e-reports/smoke-{YYYYMMDD-HHmm}.md`,
+- **Then** the report contains, for each journey: ordinal, name, status, console-error count, first-three console-error texts (verbatim, if any), slowest network call as `{route} {ms}ms` (only listed if >3000ms), and a screenshot path of the form `.tmp/e2e-screenshots/{YYYYMMDD-HHmm}/{journey-slug}.png` if and only if the journey status is `fail`. The report also includes a `Confidence: {0-100} — {evidence summary}` line at the bottom per the `report-confidence` project rule.
+
+## Run-Acceptance Aggregate
+
+The full smoke run is **acceptable** when:
+
+- A1 evaluates true (login bootstrap succeeded), AND
+- For each subsequent journey, either the journey-specific scenario evaluates true OR the journey is recorded as `warn` with a documented skip reason (per A6 or per R6 admin-skip), AND
+- A4 and A5 cleanup invariants both hold, AND
+- A7 report-format fields are all present.
+
+The run is **not acceptable** if:
+
+- Any throwaway object remains in the tenant after cleanup (violation of R4).
+- Any blocklisted action was actually executed (violation of R5).
+- The report is missing the Confidence line.
+
+A run with multiple `warn` journeys but no `fail` journeys is acceptable; a run with any `fail` journey is acceptable iff cleanup still completed correctly (failures are signal, not blockers).

--- a/.moai/specs/SPEC-TEST-E2E-001/plan.md
+++ b/.moai/specs/SPEC-TEST-E2E-001/plan.md
@@ -1,0 +1,118 @@
+# SPEC-TEST-E2E-001 — Implementation Plan
+
+This is a runbook, not a code-change SPEC. "Implementation" here means: Claude executes the journey list against the live tenant inside a single session, using `mcp__playwright__*` MCP tools, and writes the report and screenshots to `.tmp/`.
+
+## Run Mode
+
+- **Driver:** Claude Code session (this session or a future `/moai run SPEC-TEST-E2E-001`).
+- **Browser:** `mcp__playwright__*` (shared session). NOT `mcp__playwright-isolated__*` — the user's manual login must persist.
+- **Methodology:** Neither TDD nor DDD applies. There is no source code to write or refactor; the SPEC is the test plan and the runner is the test.
+
+## Pre-flight (human + runner together)
+
+1. Human: open a Playwright browser by asking the runner to navigate to `https://getklai.getklai.com`.
+2. Human: log in via Zitadel, choose the `getklai.getklai` workspace, land on `/app/*`.
+3. Human: type `ingelogd` (or English equivalent) in chat.
+4. Runner: confirm session via Journey 0.
+
+## Journey Execution
+
+Journeys execute sequentially in the order listed in `spec.md` § Journey Inventory. Each journey is bracketed by:
+
+1. **Pre-step:** capture initial console state via `browser_console_messages`.
+2. **Action steps:** the journey-specific navigation and assertions.
+3. **Post-step:** capture console-message diff, capture network requests via `browser_network_requests`, compute slowest call, classify status.
+4. **Status push:** append a `JourneyResult` entry to the in-session results list.
+5. **Failure branch:** if status is `fail`, capture screenshot to `.tmp/e2e-screenshots/{YYYYMMDD-HHmm}/{journey}.png` and continue (R3 — non-fatal).
+
+Fatal exit conditions (terminate run after running cleanup):
+
+- Authentication loss mid-run (URL redirects to `/login` outside Journey 0).
+- Browser session crash (any `mcp__playwright` call returns hard error twice in succession).
+- Tenant unreachable (DNS or 5xx on the root domain).
+
+## Cleanup Registry
+
+In-session structure:
+
+```
+cleanup_registry = [
+  {"type": "kb", "id": "<uuid-or-slug>", "name": "e2e-test-20260429-smoke-kb"},
+  {"type": "template", "id": "<uuid>", "name": "e2e-test-20260429-tpl"},
+]
+```
+
+Cleanup processing order: templates first, then KBs (KB deletion may cascade sources). Each delete is verified by re-fetching the list and confirming absence. If a delete fails, the failure is logged in the report's "Cleanup verification" section but does not block the report — the human can clean up manually using the recorded id.
+
+## Selector Blocklist Enforcement
+
+Before every `browser_click` call, the orchestration layer (Claude in this session) shall:
+
+1. Read the target element's accessible text via `browser_snapshot` or `browser_evaluate`.
+2. Compare against the case-insensitive blocklist defined in `spec.md` § Selector Blocklist.
+3. If matched: log the journey as `warn` with reason `"skipped — excluded action: <matched phrase>"` and skip the click.
+
+This is a defensive layer in addition to journey-level scoping. The journeys themselves are written never to require a blocklisted click; the blocklist is a belt-and-braces check.
+
+## Failure Modes & Mitigations
+
+| Failure mode | Likelihood | Mitigation |
+|---|---|---|
+| User logged out mid-run (Zitadel session expiry) | Low | Detect via URL pattern, abort cleanly with cleanup |
+| Throwaway KB delete fails (race with indexing) | Medium | Retry once after 10s, then log to cleanup-failure section |
+| Vexa meeting-bot accidentally started | Very low (selector blocklist + journey-6 read-only) | Two-layer guard: journey scope + blocklist |
+| Connector OAuth opened in new tab | Low | Detect new-tab event, close immediately, log warn |
+| Console errors flood the report | Medium | Cap at 3 verbatim errors per journey, summarize count |
+| Tenant has zero KBs / templates (read journeys vacuously pass) | Low | Detect empty list, mark journey `warn` with reason |
+| Admin pages 403 because user is not admin | Medium | Detect 403, mark all admin journeys `warn` per R6 (skip semantic) |
+
+## Risk Register
+
+- **R-1 — Real-tenant pollution:** mitigated by R4 enumeration + cleanup registry + selector blocklist.
+- **R-2 — Production data exposure in screenshots:** screenshots stay in `.tmp/` (gitignored). Report is reviewed by user before any external sharing.
+- **R-3 — Vexa cost trigger:** explicit Journey 6 is render-only; selector blocklist guards `start meeting`.
+- **R-4 — Connector token consumption:** R5 forbids OAuth; selector blocklist guards `connect *`.
+- **R-5 — Customer-facing impact:** the `getklai.getklai` tenant is Klai's own internal tenant per the user's framing. Worst case is 2-3 throwaway objects briefly visible in admin to other Klai team members.
+
+## Reference Implementations
+
+- Existing routes inventory: `klai-portal/frontend/src/routes/app/` and `klai-portal/frontend/src/routes/admin/` (full list captured in `research.md`).
+- KB creation flow: `klai-portal/frontend/src/routes/app/knowledge/new.tsx` — used to identify the KB creation form selectors.
+- Template creation flow: `klai-portal/frontend/src/routes/app/templates/new.tsx`.
+- Sidebar component: `klai-portal/frontend/src/components/layout/Sidebar.tsx` — used to detect admin role visibility.
+- Chat config: `klai-portal/frontend/src/routes/app/_components/ChatConfigBar.tsx` — KB picker selector source.
+
+## Task Decomposition
+
+| # | Task | Owner | Output |
+|---|---|---|---|
+| T0 | Confirm login (Journey 0) | Runner | URL = `/app/*`, sidebar visible |
+| T1 | Auth/shell journey | Runner | Account page rendered, locale switch tested |
+| T2 | Chat journey | Runner | Streamed response, no 5xx |
+| T3 | KB read tour | Runner | First 2 KBs × 5 tabs render |
+| T4 | KB write + chat-against-it | Runner | Throwaway KB created, registered for cleanup |
+| T5 | Templates journey | Runner | Existing template opens, throwaway created, registered |
+| T6 | Meetings render | Runner | `/app/meetings/start` renders, no start click |
+| T7 | Transcribe journey | Runner | List + 1 detail render |
+| T8 | Scribe render | Runner | Page renders |
+| T9 | Focus render | Runner | Page renders |
+| T10 | Gaps render | Runner | Page renders |
+| T11 | Admin tour (if admin) | Runner | 10 admin pages render or skip with warn |
+| T12 | Cleanup | Runner | All registered objects deleted, verified |
+| T13 | Report write | Runner | `.tmp/e2e-reports/smoke-{YYYYMMDD-HHmm}.md` |
+
+## Quality Gate
+
+This SPEC has no source-code lint/test gate. The acceptance criteria in `acceptance.md` ARE the gate. The run is considered acceptable when:
+
+- All 7 acceptance scenarios are satisfied.
+- Cleanup verification shows zero `e2e-test-` objects remaining in the tenant.
+- The report includes a Confidence line with a numeric score and observable-evidence summary.
+
+## Out of Scope
+
+- Conversion to a recurring CI smoke (separate SPEC if desired).
+- Functional correctness assertions (search relevance, transcription accuracy, LLM output quality).
+- Cross-browser, mobile, or performance load testing.
+- Accessibility audit.
+- Localization audit beyond the locale switcher render check.

--- a/.moai/specs/SPEC-TEST-E2E-001/research.md
+++ b/.moai/specs/SPEC-TEST-E2E-001/research.md
@@ -1,0 +1,121 @@
+# SPEC-TEST-E2E-001 — Research
+
+Inventory of the Klai portal's user-facing routes, captured by reading `klai-portal/frontend/src/routes/` on 2026-04-29. The smoke test journeys map directly onto this inventory; any route added later that this SPEC does not cover should be added in a v1.1 amendment.
+
+## Auth & Bootstrap Routes (excluded from the journey scope)
+
+These routes are part of the auth flow and are explicitly NOT exercised by the runner (see R5 + Exclusions).
+
+- [routes/index.tsx](klai-portal/frontend/src/routes/index.tsx) — root redirect logic
+- [routes/login.tsx](klai-portal/frontend/src/routes/login.tsx)
+- [routes/callback.tsx](klai-portal/frontend/src/routes/callback.tsx)
+- [routes/logged-out.tsx](klai-portal/frontend/src/routes/logged-out.tsx)
+- [routes/no-account.tsx](klai-portal/frontend/src/routes/no-account.tsx)
+- [routes/signup.tsx](klai-portal/frontend/src/routes/signup.tsx) and [$locale/signup/](klai-portal/frontend/src/routes/$locale/signup/)
+- [routes/verify.tsx](klai-portal/frontend/src/routes/verify.tsx)
+- [routes/select-workspace.tsx](klai-portal/frontend/src/routes/select-workspace.tsx)
+- [routes/provisioning.tsx](klai-portal/frontend/src/routes/provisioning.tsx)
+- [routes/join-request.tsx](klai-portal/frontend/src/routes/join-request.tsx)
+- [routes/password/forgot.tsx](klai-portal/frontend/src/routes/password/forgot.tsx) and [routes/password/set.tsx](klai-portal/frontend/src/routes/password/set.tsx)
+- [routes/$locale/password/forgot.tsx](klai-portal/frontend/src/routes/$locale/password/forgot.tsx)
+- [routes/setup/2fa.tsx](klai-portal/frontend/src/routes/setup/2fa.tsx) and [routes/setup/mfa.tsx](klai-portal/frontend/src/routes/setup/mfa.tsx)
+
+The runner verifies the **absence** of these in the post-login navigation (Journey 0 / R2).
+
+## App Routes (in journey scope)
+
+Located under [routes/app/](klai-portal/frontend/src/routes/app/) — these are the routes journeys 1-10 walk through.
+
+| Route file | Smoke journey |
+|---|---|
+| [app/route.tsx](klai-portal/frontend/src/routes/app/route.tsx) | Journey 1 — shell layout |
+| [app/index.tsx](klai-portal/frontend/src/routes/app/index.tsx) | Journey 0 — bootstrap landing |
+| [app/account.tsx](klai-portal/frontend/src/routes/app/account.tsx) | Journey 1 — account |
+| [app/chat.tsx](klai-portal/frontend/src/routes/app/chat.tsx) | Journey 2 — chat |
+| [app/_components/ChatConfigBar.tsx](klai-portal/frontend/src/routes/app/_components/ChatConfigBar.tsx) | Journey 2 — KB picker / model picker selectors |
+| [app/knowledge/index.tsx](klai-portal/frontend/src/routes/app/knowledge/index.tsx) | Journey 3 — KB list |
+| [app/knowledge/new.tsx](klai-portal/frontend/src/routes/app/knowledge/new.tsx) | Journey 4 — KB create form |
+| [app/knowledge/$kbSlug/index.tsx](klai-portal/frontend/src/routes/app/knowledge/$kbSlug/index.tsx) | Journey 3 — KB landing |
+| [app/knowledge/$kbSlug/overview.tsx](klai-portal/frontend/src/routes/app/knowledge/$kbSlug/overview.tsx) | Journey 3 — overview tab |
+| [app/knowledge/$kbSlug/members.tsx](klai-portal/frontend/src/routes/app/knowledge/$kbSlug/members.tsx) | Journey 3 — members tab (READ-ONLY) |
+| [app/knowledge/$kbSlug/settings.tsx](klai-portal/frontend/src/routes/app/knowledge/$kbSlug/settings.tsx) | Journey 3 — settings tab (READ-ONLY) |
+| [app/knowledge/$kbSlug/taxonomy.tsx](klai-portal/frontend/src/routes/app/knowledge/$kbSlug/taxonomy.tsx) | Journey 3 — taxonomy tab |
+| [app/knowledge/$kbSlug/advanced.tsx](klai-portal/frontend/src/routes/app/knowledge/$kbSlug/advanced.tsx) | Journey 3 — advanced tab |
+| [app/knowledge/$kbSlug_.add-source.tsx](klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source.tsx) | Journey 4 — add text source form |
+| [app/knowledge/$kbSlug_.add-connector.tsx](klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx) | EXCLUDED — connector OAuth (R5) |
+| [app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx](klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx) | EXCLUDED — connector edit (R5) |
+| [app/docs/$kbSlug/index.tsx](klai-portal/frontend/src/routes/app/docs/$kbSlug/index.tsx) | Journey 3 — docs viewer landing |
+| [app/docs/$kbSlug/$pageId.tsx](klai-portal/frontend/src/routes/app/docs/$kbSlug/$pageId.tsx) | Journey 3 — single page |
+| [app/templates/index.tsx](klai-portal/frontend/src/routes/app/templates/index.tsx) | Journey 5 — template list |
+| [app/templates/new.tsx](klai-portal/frontend/src/routes/app/templates/new.tsx) | Journey 5 — template create form |
+| [app/templates/$slug.edit.tsx](klai-portal/frontend/src/routes/app/templates/$slug.edit.tsx) | Journey 5 — template edit |
+| [app/meetings/start.tsx](klai-portal/frontend/src/routes/app/meetings/start.tsx) | Journey 6 — render only, no `Start meeting` click (R5 + blocklist) |
+| [app/meetings/$meetingId.tsx](klai-portal/frontend/src/routes/app/meetings/$meetingId.tsx) | Journey 6 — open if a recent meeting exists |
+| [app/transcribe/index.tsx](klai-portal/frontend/src/routes/app/transcribe/index.tsx) | Journey 7 — list |
+| [app/transcribe/add.tsx](klai-portal/frontend/src/routes/app/transcribe/add.tsx) | EXCLUDED — write |
+| [app/transcribe/$transcriptionId.tsx](klai-portal/frontend/src/routes/app/transcribe/$transcriptionId.tsx) | Journey 7 — detail |
+| [app/scribe.tsx](klai-portal/frontend/src/routes/app/scribe.tsx) | Journey 8 — render |
+| [app/focus.tsx](klai-portal/frontend/src/routes/app/focus.tsx) | Journey 9 — focus root |
+| [app/focus/$.tsx](klai-portal/frontend/src/routes/app/focus/$.tsx) | Journey 9 — catch-all focus child |
+| [app/gaps/index.tsx](klai-portal/frontend/src/routes/app/gaps/index.tsx) | Journey 10 — gaps list |
+
+## Admin Routes (Journey 11 — R6 conditional)
+
+Located under [routes/admin/](klai-portal/frontend/src/routes/admin/). Render-only — no clicks on rotate/regenerate/delete/invite buttons.
+
+| Route file | Smoke journey | Notes |
+|---|---|---|
+| [admin/route.tsx](klai-portal/frontend/src/routes/admin/route.tsx) | J11 shell | |
+| [admin/index.tsx](klai-portal/frontend/src/routes/admin/index.tsx) | J11 landing | |
+| [admin/users/](klai-portal/frontend/src/routes/admin/users/) | J11 users | No suspend/offboard clicks |
+| [admin/groups/](klai-portal/frontend/src/routes/admin/groups/) | J11 groups | |
+| [admin/api-keys/](klai-portal/frontend/src/routes/admin/api-keys/) | J11 api-keys | List + 1 detail tab render only; no rotate/regenerate (R5) |
+| [admin/widgets/](klai-portal/frontend/src/routes/admin/widgets/) | J11 widgets | List + 1 detail tab render only; no embed copy/rotate (R5) |
+| [admin/mcps/](klai-portal/frontend/src/routes/admin/mcps/) | J11 mcps | |
+| [admin/domains.tsx](klai-portal/frontend/src/routes/admin/domains.tsx) | J11 domains | No add/remove domain |
+| [admin/join-requests.tsx](klai-portal/frontend/src/routes/admin/join-requests.tsx) | J11 join-requests | No approve/reject |
+| [admin/templates/](klai-portal/frontend/src/routes/admin/templates/) | J11 templates (admin) | |
+| [admin/billing.tsx](klai-portal/frontend/src/routes/admin/billing.tsx) and [admin/billing.lazy.tsx](klai-portal/frontend/src/routes/admin/billing.lazy.tsx) | J11 billing | Render only, no plan change (R5) |
+| [admin/settings.tsx](klai-portal/frontend/src/routes/admin/settings.tsx) | J11 settings | Render only, no save (R5) |
+
+## Key Components Referenced
+
+- [components/layout/Sidebar.tsx](klai-portal/frontend/src/components/layout/Sidebar.tsx) — primary nav, also exposes admin-role visibility for R6 detection.
+- [components/help/HelpButton.tsx](klai-portal/frontend/src/components/help/HelpButton.tsx) — present on most pages; passive element, not exercised.
+- [components/ui/LocaleSwitcher.tsx](klai-portal/frontend/src/components/ui/LocaleSwitcher.tsx) — Journey 1 locale-switch test target.
+
+## Vite / Env Configuration
+
+From [klai-portal/frontend/vite.config.ts](klai-portal/frontend/vite.config.ts) (grepped during research):
+
+- Sentry org URL: `https://errors.getklai.com`
+- API proxy default target (dev): `https://getklai.getklai.com`
+- OIDC authority (`.env.local`): `https://auth.getklai.com`
+
+This confirms `getklai.getklai.com` is a valid first-party tenant in the dev/prod posture and matches the SPEC's target URL.
+
+## Backend Surface (out of journey scope, listed for context)
+
+The runner only interacts via the portal UI and does not call backend services directly. For traceability the relevant services are:
+
+- portal-api ([klai-portal/backend](klai-portal/backend)) — auth, KB metadata, templates, meetings.
+- klai-knowledge-ingest — background ingestion (the runner relies on the UI's status indicator).
+- klai-retrieval-api — chat retrieval (exercised indirectly via Journey 2).
+- klai-connector — connector OAuth (out of scope).
+- klai-mailer — email (out of scope).
+- klai-research-api — notebooks (only touched if a Journey opens `/app/notebook` — currently not in the inventory).
+
+If the SPEC is later expanded to cover notebooks or scribe deeper functionality, this section should be updated.
+
+## Open Questions Resolved Before File Creation
+
+1. **Which Playwright MCP — `mcp__playwright` or `mcp__playwright-isolated`?**
+   Decision: `mcp__playwright` (shared session). The user logs in once and that session must persist; isolated would require headless re-auth which violates the simplicity of the runbook. Captured in spec.md § Environment.
+2. **Should the runner attempt admin journeys if the user is not admin?**
+   Decision: skip with `warn` per R6, do not abort the run. Captured in R6 + A6.
+3. **What if the tenant has zero KBs?**
+   Decision: Journey 3 records `warn` with reason `"no KB available"`. Captured in plan.md § Failure Modes.
+4. **What happens if KB indexing for the throwaway source takes longer than the budget?**
+   Decision: 60-second timeout; if not ready, skip the chat-against-it sub-step with `warn` but still register for cleanup. Captured in plan.md.
+5. **Where do screenshots and reports live?**
+   Decision: `.tmp/e2e-screenshots/` and `.tmp/e2e-reports/`. Both should be in `.gitignore` (verified before run; if not, the runner will add a one-line gitignore entry — that is the only source-tree change permitted by this SPEC).

--- a/.moai/specs/SPEC-TEST-E2E-001/spec-compact.md
+++ b/.moai/specs/SPEC-TEST-E2E-001/spec-compact.md
@@ -1,0 +1,37 @@
+# SPEC-TEST-E2E-001 — Compact
+
+## Requirements
+
+- **R1 (Ubiquitous):** Read-only by default; writes only via R4 enumeration with prefix `e2e-test-{YYYYMMDD}-`.
+- **R2 (Event-driven):** WHEN runner starts THEN verify auth (`/app/*`, no redirect); abort with chat instruction otherwise.
+- **R3 (Event-driven):** WHEN journey completes THEN record status (pass/warn/fail), console errors, 4xx/5xx, slowest call >3s, screenshot on fail.
+- **R4 (State-driven):** IF throwaway resource created THEN prefix `e2e-test-{YYYYMMDD}-` + cleanup-registry tracking + delete before exit, including on failure. Permitted writes: 1 KB, 1 source in that KB, 1 chat prompt against it, 1 template. All deleted at cleanup.
+- **R5 (Unwanted):** No signup, MFA, password change, billing change, connector OAuth, meeting-bot start, widget embed, API key rotate, workspace settings mutation, or deletion of non-R4 resources.
+- **R6 (Optional):** Where admin role: read-only smoke on /admin/* pages; if not admin, skip with `warn`.
+
+## Acceptance Criteria
+
+- **A1 Login bootstrap:** Runner reaches `/app/*` after user login.
+- **A2 Authenticated-session abort:** No login → emit chat instruction, no journeys execute, only stub report.
+- **A3 Chat read-only:** First KB picked, prompt sent, streamed response, no 5xx, no US model names → `pass`.
+- **A4 Throwaway create+cleanup:** Create KB `e2e-test-{date}-smoke-kb` + source + chat-against-it → cleanup deletes both → list confirms absence → `pass`.
+- **A5 Cleanup-on-failure:** Mid-run exception → failure handler processes cleanup registry → zero `e2e-test-` objects remain → report status `fail` with exception location.
+- **A6 Excluded-action invariant:** Blocklist match before click → click refused → journey `warn` with `"skipped — excluded action: <phrase>"` → run continues.
+- **A7 Report fields:** Markdown report at `.tmp/e2e-reports/smoke-{YYYYMMDD-HHmm}.md` includes per-journey: ordinal, name, status, console errors (count + first 3 verbatim), slowest call >3s, screenshot path on fail. Bottom line `Confidence: {0-100} — {evidence}`.
+
+## Files to Modify
+
+None. SPEC produces only `.moai/specs/SPEC-TEST-E2E-001/` documents and runtime `.tmp/` artifacts (gitignored).
+
+## Exclusions
+
+- No functional correctness validation (search relevance, transcription accuracy, LLM output quality).
+- No CI integration / test framework scaffolding (Pytest, Vitest, Playwright Test runner).
+- No cross-browser, mobile, or performance load testing.
+- No accessibility audit.
+- No authentication flow testing (login is a manual user step).
+- No data fixture seeding beyond R4 throwaway list.
+- No source-code modifications anywhere in the repository.
+- No actions matching the Selector Blocklist (Start meeting, Connect *, Rotate, Regenerate, Delete workspace, etc.).
+- No connector OAuth flows that would consume external credentials.
+- No Vexa meeting-bot starts.

--- a/.moai/specs/SPEC-TEST-E2E-001/spec.md
+++ b/.moai/specs/SPEC-TEST-E2E-001/spec.md
@@ -1,0 +1,204 @@
+---
+id: SPEC-TEST-E2E-001
+version: "1.1.0"
+status: completed
+created: "2026-04-29"
+updated: "2026-04-30"
+author: MoAI
+priority: medium
+issue_number: 0
+lifecycle: spec-first
+---
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0.0 | 2026-04-29 | MoAI | Initial draft — Klai portal smoke test against the live `getklai.getklai.com` tenant. |
+| 1.1.0 | 2026-04-30 | MoAI | First execution complete; status `draft` → `completed`. See "Implementation Notes (2026-04-30 Run)" at the bottom of this document. |
+
+# SPEC-TEST-E2E-001: Klai Portal End-to-End Smoke Test
+
+## Overview
+
+This specification defines an interactive Playwright-driven smoke test of the Klai portal against the live `getklai.getklai.com` tenant. The runner is an AI-orchestrated session (Claude + `mcp__playwright`), not a CI test suite. The user logs in once via the shared Playwright browser; afterwards the runner autonomously walks predefined journeys, records pass/warn/fail per journey, and produces a markdown report with screenshots.
+
+The intent is **route-render and basic-API smoke coverage**, not full functional validation. The SPEC's value is in providing a repeatable, scope-bounded, cleanup-safe runbook that exercises the entire visible surface of the portal without risking destructive side-effects on a real tenant.
+
+## Environment
+
+- **Target tenant:** `https://getklai.getklai.com` (production-equivalent multi-tenant Klai instance).
+- **Runner:** Claude Code session driving Playwright via `mcp__playwright__*` MCP tools (NOT `mcp__playwright-isolated__*` — the user's pre-authenticated session must be reused).
+- **Auth provider:** Zitadel (`https://auth.getklai.com`) — login is performed once by the human user before the runner starts; the runner never touches credentials.
+- **Frontend stack:** React + TanStack Router, routes under `klai-portal/frontend/src/routes/` (see `research.md`).
+- **Backend stack:** FastAPI portal-api, knowledge-ingest, retrieval-api, connector, scribe, mailer, research-api (the runner only interacts via the public portal UI, not directly with these services).
+- **Local artifacts:**
+  - Markdown report: `.tmp/e2e-reports/smoke-{YYYYMMDD-HHmm}.md`
+  - Screenshots on fail: `.tmp/e2e-screenshots/{YYYYMMDD-HHmm}/{journey-name}.png`
+
+## Assumptions
+
+- A1: The human user is logged in as a tenant member of `getklai.getklai` before the runner starts; the runner verifies but never authenticates.
+- A2: The user is an admin of the tenant. If not, R6 (admin journey) is downgraded to skip with a `warn` status, not `fail`.
+- A3: The tenant already contains at least one knowledge base and at least one template; the runner uses the first existing KB it sees for read-only checks.
+- A4: `mcp__playwright__*` retains the cookies/storage state established by the human login for the entire run.
+- A5: Throwaway names prefixed `e2e-test-{YYYYMMDD}-` will not collide with real tenant data on any reasonable inspection.
+- A6: Console-error capture and network-request capture are available via `browser_console_messages` and `browser_network_requests` MCP tools.
+- A7: The cleanup phase runs deterministically before exit, including on early termination (Python-`finally`-equivalent semantics in the orchestration loop).
+
+## Requirements
+
+### R1 — Ubiquitous: Read-only by default
+
+The system shall, by default, perform only read-only operations against the live `getklai.getklai.com` tenant; any write operation (resource creation, modification, deletion) shall be explicitly enumerated in this SPEC under R4 and shall use the throwaway naming convention `e2e-test-{YYYYMMDD}-{slug}`.
+
+### R2 — Event-driven: Login bootstrap verification
+
+WHEN the runner starts and navigates to `https://getklai.getklai.com` THEN the system shall verify the Playwright session is authenticated by asserting the resolved URL matches `/app/*` (no redirect to `/login`, `/signup`, `/select-workspace`, `/no-account`, or any IdP page); IF authentication is not detected THEN the runner shall abort with a clear chat message instructing the user to log in manually before retrying, and shall not execute any journey.
+
+### R3 — Event-driven: Per-journey result capture
+
+WHEN each journey completes (pass, warn, or fail path) THEN the system shall record:
+- the journey name and ordinal,
+- a status of `pass` / `warn` / `fail`,
+- the count and first-three texts of console errors observed during the journey,
+- any HTTP 4xx or 5xx network responses with route + status code,
+- the slowest network call's route and duration in ms (only flagged if >3s),
+- a screenshot path under `.tmp/e2e-screenshots/{YYYYMMDD-HHmm}/{journey-name}.png` if the status is `fail`.
+
+The runner shall continue to the next journey on `warn` or non-fatal `fail`; only an authentication loss or browser session crash terminates the run early.
+
+### R4 — State-driven: Throwaway-object lifecycle
+
+IF the runner creates a throwaway resource (knowledge base, knowledge-base source, template) THEN:
+- the resource name SHALL start with `e2e-test-{YYYYMMDD}-`,
+- the resource SHALL be tracked in an in-memory cleanup registry keyed by resource type and identifier,
+- the resource SHALL be deleted in the cleanup phase before the runner reports the run summary,
+- on early termination via the failure handler the cleanup registry SHALL still be processed, leaving zero objects with the `e2e-test-` prefix in the tenant.
+
+The exhaustive list of permitted writes:
+1. Create one knowledge base named `e2e-test-{YYYYMMDD}-smoke-kb`.
+2. Add one short text source ("Smoke test content — see SPEC-TEST-E2E-001") to that knowledge base.
+3. Submit one chat prompt scoped to that knowledge base.
+4. Create one template named `e2e-test-{YYYYMMDD}-tpl`.
+5. Delete (1), (2), and (4) in the cleanup phase.
+
+No other writes are permitted by this SPEC.
+
+### R5 — Unwanted Behavior: Excluded destructive actions
+
+The system shall not, under any condition, perform any of the following actions:
+- Account signup or invite-acceptance.
+- MFA enrollment, MFA reset, or password change.
+- Billing plan change, billing portal redirect, payment method update.
+- Connector OAuth flow (Google Drive, Notion, Microsoft 365, GitHub, Moneybird, etc.).
+- Meeting-bot start (Vexa recorder), meeting deletion, transcription deletion.
+- Widget embedding outside the tenant or rotation of widget embed tokens.
+- API key creation, rotation, regeneration, or deletion.
+- Workspace settings mutations (domain whitelist, member role edits, KB ownership transfer, group membership edits, MCP credential edits).
+- Deletion of any resource not created by this SPEC's R4 list.
+
+### R6 — Optional: Admin coverage
+
+Where the logged-in user has admin role in the tenant, the system shall additionally execute read-only smoke checks on the admin surface (`/admin/users`, `/admin/groups`, `/admin/api-keys`, `/admin/widgets`, `/admin/mcps`, `/admin/domains`, `/admin/join-requests`, `/admin/templates`, `/admin/settings`, `/admin/billing`); if the user is not admin, these journeys shall be skipped with status `warn` and reason `"not admin in this tenant"`, and the run shall not be considered failed for that reason alone.
+
+## Specifications
+
+### Journey Inventory
+
+The following journeys execute in order. Order matters for cleanup safety: write journeys precede the journeys that depend on them, and cleanup is the last journey before the report.
+
+| # | Journey | Routes / Action | Type |
+|---|---|---|---|
+| 0 | Login bootstrap | `/` → assert `/app/*` | read |
+| 1 | Account & shell | `/app/account`, sidebar render, locale switch | read |
+| 2 | Chat | `/app/chat` — pick KB, send 1 prompt, await stream | read |
+| 3 | KB list + read-only KB tour | `/app/knowledge`, then for first 2 KBs: overview, members, settings, taxonomy, advanced, docs viewer + 1 page | read |
+| 4 | KB write | Create `e2e-test-{date}-smoke-kb`, add text source, query via chat | **write (R4)** |
+| 5 | Templates | `/app/templates` list + open existing edit; create `e2e-test-{date}-tpl` | **write (R4)** |
+| 6 | Meetings | `/app/meetings/start` render only, `/app/meetings/{id}` if a recent meeting exists | read |
+| 7 | Transcribe | `/app/transcribe` list, open one transcription | read |
+| 8 | Scribe | `/app/scribe` render | read |
+| 9 | Focus | `/app/focus` render | read |
+| 10 | Gaps | `/app/gaps` render | read |
+| 11 | Admin (R6) | `/admin/*` — users, groups, api-keys list, widgets list, mcps, domains, join-requests, templates, settings, billing — render only | read (admin) |
+| 12 | Cleanup | Delete throwaway KB, source, template; verify deletion | **write (R4)** |
+| 13 | Report | Aggregate results, write markdown to `.tmp/e2e-reports/` | local |
+
+### Selector Blocklist
+
+To enforce R5 mechanically, the runner shall maintain a static blocklist of UI elements that must NEVER be clicked. The orchestrator must pattern-match selectors before any `browser_click` call and refuse the click if it matches:
+
+- Buttons or links with text matching (case-insensitive): `delete workspace`, `transfer ownership`, `rotate key`, `regenerate`, `revoke`, `disconnect`, `start meeting`, `start recording`, `connect google`, `connect notion`, `connect microsoft`, `connect github`, `change plan`, `upgrade plan`, `cancel plan`, `add payment`, `invite member`, `remove member`, `delete user`, `suspend user`, `offboard`, `enable mfa`, `reset password`, `change password`.
+- Any modal confirm button preceded by a heading containing `Delete`, `Remove`, `Disconnect`, `Cancel subscription`, `Rotate`, `Regenerate`, `Reset`.
+
+### Output Format
+
+The markdown report shall include:
+- Header with timestamp, branch, target URL, runner version (SPEC version).
+- A summary line `pass / warn / fail` totals.
+- A per-journey table: ordinal, name, status, console errors, slow calls, screenshot path.
+- A "Findings" section with the first three console errors of any failing journey, verbatim.
+- A "Cleanup verification" section confirming zero `e2e-test-` objects remain.
+- A "Confidence" line at the bottom with a numeric score and one-line evidence summary, per the `report-confidence` project rule.
+
+### Exclusions
+
+This SPEC explicitly excludes:
+- Any **functional correctness** validation beyond route-rendering and basic API response (no assertion of search relevance, retrieval quality, transcription accuracy, or LLM output content).
+- **CI integration** — this is a one-shot interactive runbook, not an automated pipeline test.
+- **Test framework** scaffolding (Pytest, Vitest, Playwright Test runner config). The orchestration is performed by Claude inline via MCP calls; if a recurring CI smoke is later desired, that becomes a separate SPEC.
+- **Cross-browser** coverage — Chromium-only via the user's existing Playwright session.
+- **Performance benchmarking** beyond the >3s slow-call flag.
+- **Accessibility audit** — out of scope; covered by other SPECs if any.
+- **Authentication flow validation** — login is a manual user step, not a journey.
+- **Data fixture seeding** — the runner relies on existing tenant content (R4 is the only write surface).
+
+## Files Affected
+
+This SPEC produces no source-code modifications. The only files created live under:
+
+- `.moai/specs/SPEC-TEST-E2E-001/` — SPEC documents (this directory).
+- `.tmp/e2e-reports/` (gitignored) — runtime report output.
+- `.tmp/e2e-screenshots/` (gitignored) — runtime screenshot output.
+
+No portal frontend, backend, or infra files are modified.
+
+## MX Tag Plan
+
+No code is written by this SPEC; the MX tag plan is empty. Future work (e.g. converting this runbook into a Playwright Test suite) would re-evaluate MX tags at that point.
+
+## Implementation Notes (2026-04-30 Run)
+
+First execution of this runbook completed on **2026-04-30 ~07:46–08:00 UTC** by `mark.vletter@voys.nl` against the live `getklai.getklai.com` tenant. Detailed report at `.tmp/e2e-reports/smoke-20260430-0945.md` (gitignored — kept locally per SPEC § Files Affected).
+
+### Run summary
+
+| Status | Count | Journeys |
+|---|---|---|
+| pass | 9 | J0 login, J1 account+locale, J3 KB read tour, J5 templates, J6 meetings, J7 transcribe, J8 scribe, J10 gaps, J12 cleanup |
+| warn | 2 | J4 KB write (chat-query inherited from J2), J9 focus (route does not exist in current portal) |
+| fail | 2 | J2 chat (502 on chat-iframe SSO), J11 admin tour (500 on `/api/admin/domains` and `/api/admin/join-requests`) |
+
+R4 + R5 invariants both held: zero `e2e-test-` residuals after cleanup, no blocklisted action executed.
+
+### Findings shipped
+
+The two `fail` journeys exposed real production regressions, both resolved within the same day:
+
+- **J2 chat SSO 502** — callback-URL allowlist rejected `chat-{slug}.getklai.com` LibreChat tenant hosts. Resolved by [PR #243](https://github.com/GetKlai/klai/pull/243) (`chat-` prefix strip + `_STATIC_SYSTEM_SUBDOMAINS` enumeration). Follow-up [PR #248](https://github.com/GetKlai/klai/pull/248) derives the allowlist from Zitadel at startup so future host classes don't require a code change. Verified post-deploy: chat iframe renders the LibreChat "Welcome back" UI, 0 console errors, `chat-getklai.getklai.com/api/config` returns 200.
+- **J11 admin 500s** — `alembic_version` was at head but the SPEC-AUTH-006 migrations (`23c5c8b48669` add `portal_org_allowed_domains`, `b2c3d4e5f6g7` add `portal_join_requests`) had never run their `upgrade()` body in production. Fixed by applying alembic's offline `--sql` output directly via `psql` on `klai-core-postgres-1` (alembic_version untouched, schema caught up). Default privileges + sequence grants verified end-to-end through a UI POST/DELETE round-trip on `/admin/domains` (201 → 204). The same-shape regression risk is now documented as the `alembic-stamped-past-skipped-migration (HIGH)` pitfall added to `.claude/rules/klai/pitfalls/process-rules.md` in [PR #242](https://github.com/GetKlai/klai/pull/242).
+
+Multi-service alembic drift sweep ran clean: portal-api now matches schema, klai-connector at head `006_add_org_id_to_sync_runs`, scribe-api at head `0007_c5f9e3a4`, all sentinel columns present. Mailer / knowledge-ingest / retrieval-api have no alembic chain (Redis-only or raw-SQL bootstrap) and are not vulnerable to this bug class.
+
+### SPEC scope drift observed
+
+`spec.md` § Journey Inventory listed `/app/focus` as Journey 9, but that route currently redirects to `/app/knowledge` in the live portal. Recorded as `warn` rather than `fail`. Either the route was retired between SPEC-creation (2026-04-29) and execution (2026-04-30), or the SPEC inventory was authored against a stale routes inventory. A v1.0.1 patch could drop J9 from the inventory; deferred until a second run confirms the route really is gone.
+
+### Lifecycle
+
+This is a `spec-first` SPEC: the SPEC describes a one-shot runbook, not a maintained product feature. Status marked `completed`. Future re-runs of the smoke test do NOT require SPEC updates unless the journey inventory or tenant scope changes — in which case bump to v1.1.x with a new HISTORY entry.
+
+### Confidence
+
+`92` — 13/13 journeys executed end-to-end against live prod; both `fail` findings have shipped fixes verified in production (chat-iframe via Playwright, admin endpoints via UI POST/DELETE round-trip); cleanup-roundtrip invariant proved via API responses (KB DELETE 204 + GET 404). `-8` reflects: J4's chat-query step was inherited-skipped (the create+cleanup R4 invariant did pass, but A3-style retrieval validation is still unverified end-to-end), and J9's redirect was not investigated to confirm whether `/app/focus` is intentionally gone or accidentally broken.


### PR DESCRIPTION
## Summary

Adds the **SPEC-TEST-E2E-001** runbook documents that drove yesterday's live smoke test of `getklai.getklai.com`, plus a new "Implementation Notes (2026-04-30 Run)" section recording the first execution.

This is a **spec-first lifecycle SPEC** — the SPEC describes a one-shot runbook, not a maintained product feature. After this PR merges, status is `completed` and no further maintenance is expected unless the journey inventory or tenant scope changes.

## What is shipped

### New files (all docs, zero source-code change)

- `.moai/specs/SPEC-TEST-E2E-001/spec.md` — full runbook (13 journeys, EARS requirements, selector blocklist, output format)
- `.moai/specs/SPEC-TEST-E2E-001/plan.md` — execution plan (cleanup registry, failure-mode mitigations, risk register)
- `.moai/specs/SPEC-TEST-E2E-001/acceptance.md` — 7 Given/When/Then acceptance criteria
- `.moai/specs/SPEC-TEST-E2E-001/research.md` — codebase analysis driving the SPEC
- `.moai/specs/SPEC-TEST-E2E-001/spec-compact.md` — compressed form

The runbook output (markdown report + screenshots) lives under `.tmp/` per the SPEC's § Files Affected and is intentionally gitignored — only the SPEC documents are committed.

### Status transition

`draft` → `completed`. Version bumped 1.0.0 → 1.1.1. New HISTORY entry.

## Why now

The smoke test ran on 2026-04-30 and exposed two real production regressions, both already shipped:

- **J2 chat SSO 502** — `chat-{slug}.getklai.com` LibreChat tenant hosts were not in the callback-URL allowlist. Resolved by [#243](https://github.com/GetKlai/klai/pull/243); allowlist is now derived from Zitadel at startup per [#248](https://github.com/GetKlai/klai/pull/248). Verified post-deploy: chat iframe renders, 0 console errors.
- **J11 admin 500s** — `alembic_version` was at head but two SPEC-AUTH-006 migrations (`23c5c8b48669`, `b2c3d4e5f6g7`) had never executed their `upgrade()` body. Tables `portal_org_allowed_domains` and `portal_join_requests` did not exist. Fixed by applying alembic's offline `--sql` output via `psql` on `klai-core-postgres-1`. Default privileges + sequence grants verified end-to-end via UI POST/DELETE on `/admin/domains` (201 → 204). Pitfall documented in [#242](https://github.com/GetKlai/klai/pull/242).

The "Implementation Notes (2026-04-30 Run)" section in `spec.md` captures the full run summary, both findings, the multi-service drift sweep, and a note on observed scope drift (`/app/focus` redirects to `/app/knowledge` — likely retired).

## Test plan

- [x] No source code changes — no test runs required
- [x] Markdown renders correctly (verified locally)
- [x] All linked PRs (#242, #243, #248) are real and merged
- [x] HISTORY table is consistent with frontmatter `version` + `updated`
- [ ] Optional follow-up: bump to v1.0.2 dropping J9 (`/app/focus`) from the inventory after a second smoke-run confirms the route is gone

## Out of scope

- Conversion of this runbook to a recurring CI-driven Playwright Test suite (would be a new SPEC, e.g. SPEC-TEST-E2E-002 if/when desired)
- Functional correctness assertions beyond route-rendering + basic API smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)