### PR TITLE
feat(SPEC-CONNECTOR-DELETE-LIFECYCLE-001 PR C): cross-schema FK CASCADE for sync_runs

### DIFF
--- a/.github/workflows/klai-connector.yml
+++ b/.github/workflows/klai-connector.yml
@@ -100,12 +100,20 @@ jobs:
           file: klai-connector/Dockerfile
           push: true
           tags: |
-            ghcr.io/getklai/klai-connector:latest
             ghcr.io/getklai/klai-connector:${{ github.sha }}
+            ${{ github.event_name == 'push' && 'ghcr.io/getklai/klai-connector:latest' || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # SPEC-CONNECTOR-DELETE-LIFECYCLE-001 PR C lesson: an earlier version of
+      # this workflow ran the deploy step on every ``pull_request`` build,
+      # auto-publishing PR-build images to prod under the ``:latest`` tag and
+      # triggering a docker compose up -d on core-01. That dropped a broken
+      # (varchar(32)-overflow) alembic migration into prod from a PR that was
+      # never reviewed. The ``if`` condition below pins the deploy to
+      # main-branch pushes only — PRs build + scan but do not deploy.
       - name: Deploy to core-01
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.CORE01_HOST }}

--- a/klai-connector/alembic/versions/007_sync_runs_fk.py
+++ b/klai-connector/alembic/versions/007_sync_runs_fk.py
@@ -49,7 +49,13 @@ from collections.abc import Sequence
 
 from alembic import op
 
-revision: str = "007_sync_runs_fk_portal_connectors"
+# NB: revision IDs are stored in ``alembic_version.version_num`` which alembic
+# defaults to ``VARCHAR(32)``. The previous revision name
+# ``007_sync_runs_fk_portal_connectors`` was 34 chars and crashed the
+# alembic_version UPDATE in a prod deploy attempt — kept the migration
+# applied (DELETE + FK ran) but rolled back via the transaction. This
+# shorter id avoids that trap entirely.
+revision: str = "007_sync_runs_fk"
 down_revision: str | None = "006_add_org_id_to_sync_runs"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
@@ -70,18 +76,34 @@ def upgrade() -> None:
     )
 
     # Step 2: add the cross-schema FK with ON DELETE CASCADE.
+    # IF NOT EXISTS via an EXECUTE block — Postgres has no native syntax
+    # for "ALTER TABLE ADD CONSTRAINT IF NOT EXISTS" but ``information_schema``
+    # gives us the same idempotency. Critical for crash-loop recovery: if a
+    # previous migration attempt added the constraint but failed to record
+    # the version_num bump (the bug that triggered this rewrite), retrying
+    # must not error out on duplicate-constraint.
+    #
     # NB: PostgreSQL allows cross-schema FKs as long as the referencing role
     # has REFERENCES on the target table. If you hit a permission error,
     # see the docstring's "Pre-flight" section.
-    op.create_foreign_key(
-        "fk_sync_runs_portal_connectors",
-        source_table="sync_runs",
-        referent_table="portal_connectors",
-        local_cols=["connector_id"],
-        remote_cols=["id"],
-        source_schema="connector",
-        referent_schema="public",
-        ondelete="CASCADE",
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1
+                  FROM pg_constraint
+                 WHERE conname = 'fk_sync_runs_portal_connectors'
+                   AND connamespace = 'connector'::regnamespace
+            ) THEN
+                ALTER TABLE connector.sync_runs
+                  ADD CONSTRAINT fk_sync_runs_portal_connectors
+                  FOREIGN KEY (connector_id)
+                  REFERENCES public.portal_connectors(id)
+                  ON DELETE CASCADE;
+            END IF;
+        END $$;
+        """
     )
 
 
@@ -89,10 +111,7 @@ def downgrade() -> None:
     # Restore the pre-migration state: drop the FK. We deliberately do NOT
     # restore the orphan rows we deleted in upgrade() — the data is gone
     # and the original 004 migration also did not preserve it across the
-    # FK removal.
-    op.drop_constraint(
-        "fk_sync_runs_portal_connectors",
-        "sync_runs",
-        type_="foreignkey",
-        schema="connector",
+    # FK removal. Use IF EXISTS for symmetry with the idempotent upgrade.
+    op.execute(
+        "ALTER TABLE connector.sync_runs DROP CONSTRAINT IF EXISTS fk_sync_runs_portal_connectors"
     )

--- a/klai-connector/alembic/versions/007_sync_runs_fk_portal_connectors.py
+++ b/klai-connector/alembic/versions/007_sync_runs_fk_portal_connectors.py
@@ -1,0 +1,98 @@
+"""Add cross-schema FK ``connector.sync_runs.connector_id`` -> ``public.portal_connectors.id`` ON DELETE CASCADE.
+
+SPEC-CONNECTOR-DELETE-LIFECYCLE-001 REQ-08 / SPEC-CONNECTOR-CLEANUP-001 REQ-04.
+
+Background. ``connector.sync_runs`` originally had an FK to
+``connector.connectors.id``. SPEC-CONNECTOR-CLEANUP-001 dropped
+``connector.connectors`` (legacy table), and migration ``004_remove_sync_run_fk``
+removed the FK altogether. Since then orphan ``sync_runs`` rows could only be
+prevented by application-level discipline; the portal-side
+``klai_connector_client.delete_sync_runs`` introduced in PR #244 was the
+interim fence.
+
+This migration restores referential integrity by pointing the FK at the new
+canonical owner — ``public.portal_connectors`` — with ``ON DELETE CASCADE``,
+so deleting a connector row in the portal automatically removes its sync
+history. The interim app-level call becomes a redundant safety net and can
+be removed in a follow-up commit.
+
+Pre-flight. The migration runs as the role configured for klai-connector's
+``DATABASE_URL`` (typically ``klai`` superuser in dev; ``connector_api`` or
+similar in prod). That role MUST have ``REFERENCES`` privilege on
+``public.portal_connectors``. In prod we grant this once, before running
+the migration:
+
+    -- as klai superuser:
+    GRANT REFERENCES ON public.portal_connectors TO connector_api;
+
+If the grant is missing the migration fails with a clear permission-denied
+error rather than producing a silently-broken FK.
+
+Orphan cleanup. Pre-existing rows in ``connector.sync_runs`` whose
+``connector_id`` no longer exists in ``portal_connectors`` would block the
+``ALTER TABLE ... ADD CONSTRAINT`` step. We delete them in the same
+transaction immediately before adding the constraint. These are operational
+audit records pointing at long-gone connectors — losing them is acceptable
+(SPEC REQ-08.3); ``sync_runs`` is not source-of-truth user data.
+
+Post-migration: ``connector.sync_runs.org_id`` (added in migration 006) is
+preserved. Pre-migration-006 rows with ``org_id IS NULL`` still cannot be
+queried per-tenant (matches the deliberate trade-off documented in 006);
+the FK CASCADE applies regardless of whether ``org_id`` is set.
+
+Revision ID: 007_sync_runs_fk_portal_connectors
+Revises: 006_add_org_id_to_sync_runs
+Create Date: 2026-04-30
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "007_sync_runs_fk_portal_connectors"
+down_revision: str | None = "006_add_org_id_to_sync_runs"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Step 1: drop orphan sync_runs whose connector_id is not in portal_connectors.
+    # Without this the FK ADD will fail. SPEC REQ-08.3 explicitly accepts the
+    # data loss — these rows reference a long-gone connector and were never
+    # reachable through the portal UI anyway.
+    op.execute(
+        """
+        DELETE FROM connector.sync_runs
+         WHERE connector_id NOT IN (
+            SELECT id FROM public.portal_connectors
+         )
+        """
+    )
+
+    # Step 2: add the cross-schema FK with ON DELETE CASCADE.
+    # NB: PostgreSQL allows cross-schema FKs as long as the referencing role
+    # has REFERENCES on the target table. If you hit a permission error,
+    # see the docstring's "Pre-flight" section.
+    op.create_foreign_key(
+        "fk_sync_runs_portal_connectors",
+        source_table="sync_runs",
+        referent_table="portal_connectors",
+        local_cols=["connector_id"],
+        remote_cols=["id"],
+        source_schema="connector",
+        referent_schema="public",
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    # Restore the pre-migration state: drop the FK. We deliberately do NOT
+    # restore the orphan rows we deleted in upgrade() — the data is gone
+    # and the original 004 migration also did not preserve it across the
+    # FK removal.
+    op.drop_constraint(
+        "fk_sync_runs_portal_connectors",
+        "sync_runs",
+        type_="foreignkey",
+        schema="connector",
+    )

--- a/klai-connector/app/routes/sync.py
+++ b/klai-connector/app/routes/sync.py
@@ -2,8 +2,8 @@
 
 import uuid
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
-from sqlalchemy import delete, select
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import Settings
@@ -202,47 +202,11 @@ async def get_sync_run(
     return sync_run
 
 
-@router.delete("/connectors/{connector_id}/sync-runs", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_connector_sync_runs(
-    connector_id: uuid.UUID,
-    request: Request,
-    session: AsyncSession = Depends(get_session),
-    settings: Settings = Depends(get_settings),
-) -> None:
-    """Delete every sync_runs row for a connector.
-
-    Called by the portal control plane during connector-delete to keep
-    ``connector.sync_runs`` consistent with ``public.portal_connectors``.
-
-    Until SPEC-CONNECTOR-CLEANUP-001 REQ-04 lands a cross-schema FK with
-    ``ON DELETE CASCADE`` (klai-connector role needs ``REFERENCES`` on
-    ``public.portal_connectors`` first), this endpoint is the
-    application-level equivalent: the portal calls it just before
-    dropping the ``portal_connectors`` row, so neither side leaves an
-    audit trail of orphan ``sync_runs`` keyed on a now-missing
-    ``connector_id``.
-
-    Idempotent: a connector with no sync history returns 204 the same
-    way one with 50 runs does. Filters on ``org_id`` when the portal
-    asserts tenancy via ``X-Org-ID`` (SPEC-SEC-TENANT-001 REQ-7.x) so a
-    cross-tenant connector_id cannot be wiped by a confused caller.
-    """
-    _require_portal_call(request)
-    org_id = _require_portal_org_id(request, settings)
-
-    stmt = delete(SyncRun).where(SyncRun.connector_id == connector_id)
-    if org_id is not None:
-        stmt = stmt.where(SyncRun.org_id == org_id)
-    result = await session.execute(stmt)
-    await session.commit()
-
-    logger.info(
-        "Deleted %s sync_runs row(s) for connector %s",
-        result.rowcount,
-        connector_id,
-        extra={
-            "connector_id": str(connector_id),
-            "rows_deleted": result.rowcount,
-            "org_id": org_id,
-        },
-    )
+# DELETE /connectors/{id}/sync-runs removed by
+# SPEC-CONNECTOR-DELETE-LIFECYCLE-001 PR C (REQ-08): the new cross-schema
+# FK with ON DELETE CASCADE in migration 007 makes per-connector
+# sync_runs cleanup automatic. When the portal hard-deletes a row from
+# ``public.portal_connectors`` (via the finalize-delete callback after
+# the purge worker completes) PostgreSQL cascades to
+# ``connector.sync_runs`` for free. The dedicated endpoint is gone but
+# its replacement is the migration itself.

--- a/klai-portal/backend/app/services/klai_connector_client.py
+++ b/klai-portal/backend/app/services/klai_connector_client.py
@@ -110,30 +110,12 @@ class KlaiConnectorClient:
             response.raise_for_status()
             return [SyncRunData(**r) for r in response.json()]
 
-    async def delete_sync_runs(self, connector_id: str, *, org_id: str) -> None:
-        """Delete every sync_runs row for a connector.
-
-        SPEC-CONNECTOR-CLEANUP-001 REQ-04 (interim) — until the
-        ``connector.sync_runs.connector_id`` cross-schema FK with
-        ``ON DELETE CASCADE`` to ``public.portal_connectors`` lands,
-        the portal cleans the connector's sync history at delete time
-        by hitting this endpoint. Without it, every connector deletion
-        leaves an audit trail of orphan rows in ``connector.sync_runs``
-        keyed on a ``connector_id`` that no longer exists in
-        ``portal_connectors``. Discovered live during a Voys end-to-end
-        delete-cleanup audit on 2026-04-30.
-
-        Idempotent: zero rows is fine. Always called with the same
-        ``X-Org-ID`` as the rest of the connector lifecycle so the
-        connector cannot be made to wipe a different tenant's history
-        by ID confusion.
-        """
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            response = await client.delete(
-                f"{settings.klai_connector_url}/api/v1/connectors/{connector_id}/sync-runs",
-                headers=self._headers(org_id=org_id),
-            )
-            response.raise_for_status()
+    # delete_sync_runs() removed by SPEC-CONNECTOR-DELETE-LIFECYCLE-001
+    # PR C (REQ-08): the cross-schema FK with ON DELETE CASCADE on
+    # ``connector.sync_runs.connector_id`` -> ``public.portal_connectors.id``
+    # makes the explicit application-level delete redundant. The portal's
+    # finalize-delete endpoint hard-deletes the portal_connectors row;
+    # PostgreSQL cascades to sync_runs automatically.
 
     async def compute_fingerprint(
         self,


### PR DESCRIPTION
## Summary

PR C of [SPEC-CONNECTOR-DELETE-LIFECYCLE-001](.moai/specs/SPEC-CONNECTOR-DELETE-LIFECYCLE-001/spec.md). Adds the cross-schema FK with ``ON DELETE CASCADE`` from `connector.sync_runs.connector_id` → `public.portal_connectors.id` and removes the interim application-level cleanup that PR #244 + PR A introduced as fallback.

This is the canonical fix from SPEC-CONNECTOR-CLEANUP-001 REQ-04 finally landing.

## What's in PR C

| File | Change |
|---|---|
| `klai-connector/alembic/versions/007_sync_runs_fk_portal_connectors.py` | New migration: drop pre-existing orphan sync_runs (REQ-08.3 acceptable data loss) → ADD FOREIGN KEY ... ON DELETE CASCADE |
| `klai-connector/app/routes/sync.py` | Removed `DELETE /connectors/{id}/sync-runs` endpoint — the FK CASCADE replaces it |
| `klai-portal/backend/app/services/klai_connector_client.py` | Removed `delete_sync_runs` client method — nothing calls it after PR A |

## Pre-flight (CRIT)

Before merging this PR, run on prod as `klai` superuser:

```sql
GRANT REFERENCES ON public.portal_connectors TO connector_api;
```

(Or whatever role the klai-connector container connects as — check `DATABASE_URL` in the prod compose env.) If missing, migration 007 fails with a clear permission-denied error rather than producing a silently broken FK.

## Test plan

- [x] `ruff check` + `ruff format --check` clean
- [ ] CI: portal-api + klai-connector workflows green
- [ ] Pre-deploy: verify GRANT REFERENCES is in place on prod
- [ ] Post-deploy: confirm constraint exists via `SELECT conname FROM pg_constraint WHERE conname = 'fk_sync_runs_portal_connectors'`
- [ ] Manual e2e: re-run Voys flow (create connector → sync → DELETE in UI → wait for purge worker → finalize). After PR C: `connector.sync_runs` for the deleted connector is empty IMMEDIATELY when the `portal_connectors` row is dropped, no second cleanup-call needed.

## Architecture milestone

With PR C merged, all 7 stores are cleaned automatically by the orchestrator + DB constraints:

| Store | Cleaned by |
|---|---|
| `portal_connectors` | Worker calls `/finalize-delete` |
| `connector.sync_runs` | **PR C: FK CASCADE on portal_connectors delete** |
| `knowledge.artifacts` (+ FK cascade tables) | `pg_store.delete_connector_artifacts` |
| `knowledge.crawl_jobs` | `pg_store.delete_connector_crawl_jobs` |
| Qdrant | `qdrant_store.delete_connector` |
| FalkorDB | `graph_module.delete_kb_episodes` |
| Garage S3 images | PR B: `ImageStore.delete_keys` w/ refcount on artifact_images |

In-flight enrichment regrow is closed by REQ-07 guards (PR A): `enrich_document_*`, `ingest_graphiti_episode`, AND `ingest_document` itself all check `connector_state.connector_is_active` at the top.

## Refs

- SPEC: `.moai/specs/SPEC-CONNECTOR-DELETE-LIFECYCLE-001/spec.md` REQ-08
- Forwards SPEC-CONNECTOR-CLEANUP-001 REQ-04 to closure
- Builds on [#250](https://github.com/GetKlai/klai/pull/250) (PR A) and [#251](https://github.com/GetKlai/klai/pull/251) (PR B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)