### PR TITLE
fix(SPEC-CONNECTOR-DELETE-LIFECYCLE-001): add connector-purge to procrastinate worker queue list

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/app.py
+++ b/klai-knowledge-ingest/knowledge_ingest/app.py
@@ -75,6 +75,12 @@ async def lifespan(app: FastAPI):
                         "enrich-bulk",
                         "graphiti-bulk",
                         "taxonomy-backfill",
+                        # SPEC-CONNECTOR-DELETE-LIFECYCLE-001 REQ-04: orchestrated
+                        # connector-purge worker. Without "connector-purge" in this
+                        # list the procrastinate task sits in 'todo' forever and
+                        # the user-visible delete looks stuck (state stays
+                        # 'deleting'). Caught by live e2e on Voys post-PR-C.
+                        "connector-purge",
                     ],
                     install_signal_handlers=False,
                 )


### PR DESCRIPTION
Live e2e on Voys caught this: PR A registered the connector_purge_task on a new `connector-purge` queue but `app.py`'s worker watch-list was never updated. Tasks sit in 'todo' forever; delete looks stuck. One-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)