### PR TITLE
fix(SPEC-CONNECTOR-DELETE-LIFECYCLE-001): finalize-delete uses inbound internal_secret

### DIFF
--- a/klai-portal/backend/app/api/internal_connectors.py
+++ b/klai-portal/backend/app/api/internal_connectors.py
@@ -43,7 +43,12 @@ def _verify_internal_bearer(authorization: str | None) -> None:
     if not authorization or not authorization.startswith("Bearer "):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
     presented = authorization.removeprefix("Bearer ")
-    if not hmac.compare_digest(presented, settings.knowledge_ingest_secret):
+    # ``internal_secret`` is the INBOUND secret for service->portal calls
+    # (matches what knowledge-ingest sends as PORTAL_INTERNAL_TOKEN). The
+    # original code used ``knowledge_ingest_secret`` which is the OUTBOUND
+    # token (portal -> knowledge-ingest), wrong direction — caught live
+    # by a 401 on the finalize-delete callback during e2e on Voys.
+    if not hmac.compare_digest(presented, settings.internal_secret):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
 
 

--- a/klai-portal/backend/tests/test_connector_lifecycle.py
+++ b/klai-portal/backend/tests/test_connector_lifecycle.py
@@ -201,7 +201,7 @@ async def test_finalize_delete_idempotent_when_row_missing(
 ) -> None:
     """REQ-04.4: row already gone => 204 (worker retry after partial success)."""
     monkeypatch.setattr(
-        "app.api.internal_connectors.settings.knowledge_ingest_secret",
+        "app.api.internal_connectors.settings.internal_secret",
         "test-secret",
     )
     db = _FakeDB(fetch_value=None)
@@ -221,7 +221,7 @@ async def test_finalize_delete_drops_row_when_state_deleting(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
-        "app.api.internal_connectors.settings.knowledge_ingest_secret",
+        "app.api.internal_connectors.settings.internal_secret",
         "test-secret",
     )
     connector = _FakeConnector(id="conn-uuid", kb_id=42, state="deleting")
@@ -245,7 +245,7 @@ async def test_finalize_delete_409_when_state_active(monkeypatch: pytest.MonkeyP
     from fastapi import HTTPException
 
     monkeypatch.setattr(
-        "app.api.internal_connectors.settings.knowledge_ingest_secret",
+        "app.api.internal_connectors.settings.internal_secret",
         "test-secret",
     )
     connector = _FakeConnector(id="conn-uuid", kb_id=42, state="active")


### PR DESCRIPTION
Live e2e caught: 401 on connector_purge_task -> portal callback. Bearer was checked against the OUTBOUND token. Fixed to use the inbound `internal_secret` (PORTAL_API_INTERNAL_SECRET).

🤖 Generated with [Claude Code](https://claude.com/claude-code)