### PR TITLE
fix(SPEC-CONNECTOR-DELETE-LIFECYCLE-001): janitor sweep for orphan FalkorDB + Garage

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/connector_cleanup.py
+++ b/klai-knowledge-ingest/knowledge_ingest/connector_cleanup.py
@@ -260,33 +260,86 @@ async def purge_connector(
     await qdrant_store.delete_connector(org_id, kb_slug, connector_id)
     log.info("connector_purge_step_qdrant_deleted")
 
-    # Step 9: Garage S3 image keys that became orphan in step 4b. Best-
-    # effort: ``ImageStore.delete_keys`` swallows per-key failures and
-    # returns the count actually removed. SPEC REQ-06.4.
+    # Step 9: Garage S3 image keys — orchestrator-scoped ones from step 4b.
     s3_images_deleted = 0
-    if orphan_image_keys:
+    image_store = None
+    try:
+        from knowledge_ingest.adapters.crawler import _build_image_store
+
+        image_store = _build_image_store()
+    except Exception:
+        logger.exception("connector_purge_step_image_store_init_failed")
+
+    if orphan_image_keys and image_store is not None:
+        s3_images_deleted = await image_store.delete_keys(orphan_image_keys)
+        log.info(
+            "connector_purge_step_s3_images_deleted",
+            count=s3_images_deleted,
+            requested=len(orphan_image_keys),
+        )
+
+    # Step 10 (JANITOR): catch the cleanup-misses that the per-connector
+    # logic above structurally cannot find:
+    #   a) FalkorDB episodes written AFTER our cancel — graphiti tasks
+    #      with sync LLM calls don't honour asyncio cancellation, so
+    #      mid-flight episodes can land between cancel + delete. The
+    #      artifact-id snapshot we took in step 1 still applies — any
+    #      episode in FalkorDB referencing those artifact-ids is now
+    #      orphan because the artifact rows are gone (step 5).
+    #   b) Garage keys that lost their last reference at step 5's CASCADE
+    #      on artifact_images. Refcount on content_hash: a key is orphan
+    #      iff no artifact in this KB still references its hash.
+    # Both run unconditionally — even when steps 4b/7 returned zero,
+    # because their inputs depend on rows that no longer exist.
+    falkor_orphans_deleted = await graph_module.delete_orphan_episodes_for_artifact_ids(
+        org_id, artifact_ids
+    )
+    log.info(
+        "connector_purge_step_falkor_orphans_swept",
+        count=falkor_orphans_deleted,
+    )
+
+    janitor_s3_deleted = 0
+    if image_store is not None:
         try:
-            from knowledge_ingest.adapters.crawler import (
-                _build_image_store,
-            )
+            from minio import Minio
 
-            image_store = _build_image_store()
-        except Exception:
-            logger.exception("connector_purge_step_image_store_init_failed")
-            image_store = None
+            from knowledge_ingest.adapters.crawler import _build_image_store
+            from knowledge_ingest.config import settings as ki_settings
 
-        if image_store is None:
-            log.warning(
-                "connector_purge_step_image_store_unavailable",
-                key_count=len(orphan_image_keys),
+            active_hashes = await pg_store.get_active_image_hashes_for_kb(org_id, kb_slug)
+            # List all S3 keys under {org}/images/{kb_slug}/, derive the
+            # content_hash from each filename, and propose for delete the
+            # ones whose hash isn't in active_hashes.
+            prefix = f"{org_id}/images/{kb_slug}/"
+            from minio import Minio  # noqa: F811
+
+            mc = Minio(
+                ki_settings.garage_s3_endpoint,
+                access_key=ki_settings.garage_access_key,
+                secret_key=ki_settings.garage_secret_key,
+                region=ki_settings.garage_region,
+                secure=False,
             )
-        else:
-            s3_images_deleted = await image_store.delete_keys(orphan_image_keys)
+            orphan_under_prefix: list[str] = []
+            for obj in mc.list_objects(ki_settings.garage_bucket, prefix=prefix, recursive=True):
+                key = obj.object_name
+                basename = key.rsplit("/", 1)[-1]
+                content_hash = basename.rsplit(".", 1)[0]
+                if content_hash and content_hash not in active_hashes:
+                    orphan_under_prefix.append(key)
+            if orphan_under_prefix:
+                janitor_s3_deleted = await image_store.delete_keys(orphan_under_prefix)
             log.info(
-                "connector_purge_step_s3_images_deleted",
-                count=s3_images_deleted,
-                requested=len(orphan_image_keys),
+                "connector_purge_step_garage_orphans_swept",
+                count=janitor_s3_deleted,
+                scanned=len(orphan_under_prefix),
+                active_hashes=len(active_hashes),
             )
+        except Exception:
+            logger.exception("connector_purge_step_garage_janitor_failed")
+
+    s3_images_deleted += janitor_s3_deleted
 
     # NOTE: connector.sync_runs cleanup is invoked by the portal-side
     # delete-orchestration BEFORE it asks knowledge-ingest to purge. That
@@ -301,7 +354,7 @@ async def purge_connector(
         artifacts_deleted=artifacts_deleted,
         crawl_jobs_deleted=crawl_jobs_deleted,
         qdrant_chunks_deleted=0,  # qdrant_store.delete_connector doesn't return a count today
-        falkor_episodes_deleted=len(episode_ids),
+        falkor_episodes_deleted=len(episode_ids) + falkor_orphans_deleted,
         s3_images_deleted=s3_images_deleted,
         sync_runs_deleted=None,
     )

--- a/klai-knowledge-ingest/knowledge_ingest/graph.py
+++ b/klai-knowledge-ingest/knowledge_ingest/graph.py
@@ -7,6 +7,7 @@ LLM client: OpenAIGenericClient pointing at LiteLLM proxy (AC-14).
 Graph DB: FalkorDB via FalkorDriver (AC-11).
 Tenant isolation: every episode uses group_id=org_id (AC-10).
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -24,6 +25,7 @@ try:
     from graphiti_core.llm_client.openai_generic_client import OpenAIGenericClient
     from graphiti_core.nodes import EpisodeType
     from openai import AsyncOpenAI
+
     _GRAPHITI_AVAILABLE = True
 except ImportError:
     _GRAPHITI_AVAILABLE = False  # graphiti-core not installed yet; added in /run SPEC-KB-011
@@ -174,6 +176,7 @@ def _get_semaphore() -> asyncio.Semaphore:
         _episode_semaphore = asyncio.Semaphore(settings.graphiti_max_concurrent)
     return _episode_semaphore
 
+
 _graphiti_client: Graphiti | None = None
 
 
@@ -238,7 +241,6 @@ def _get_graphiti() -> Graphiti:
     return _graphiti_client
 
 
-
 async def _update_edge_weights(
     nodes: list,
     org_id: str,
@@ -269,6 +271,7 @@ async def _update_edge_weights(
             updated = records[0].get("updated", 0)
     return updated
 
+
 async def delete_kb_episodes(org_id: str, episode_ids: list[str]) -> None:
     """Delete FalkorDB nodes for a set of episodes within an org's graph.
 
@@ -291,6 +294,58 @@ async def delete_kb_episodes(org_id: str, episode_ids: list[str]) -> None:
         "MATCH (n:Entity) WHERE NOT ((:Episodic)--(n)) DETACH DELETE n",
     )
     logger.info("graph_kb_episodes_deleted", org_id=org_id, count=len(episode_ids))
+
+
+async def delete_orphan_episodes_for_artifact_ids(org_id: str, artifact_ids: list[str]) -> int:
+    """Janitor: drop FalkorDB episodes whose ``artifact_id`` is in the given list.
+
+    SPEC-CONNECTOR-DELETE-LIFECYCLE-001 follow-up. Some Graphiti tasks
+    do synchronous LLM calls that don't honour ``asyncio.CancelledError``
+    — they keep running after the procrastinate cancel and write a fresh
+    episode for an already-deleted artifact. Those episodes never made
+    it into ``knowledge.artifacts.extra->>graphiti_episode_id`` (the row
+    was already gone), so ``delete_kb_episodes`` cannot find them via
+    the normal path.
+
+    The orchestrator runs this AFTER ``delete_connector_artifacts`` with
+    the artifact-id snapshot taken BEFORE the delete: any episode in
+    FalkorDB referring to those artifact-ids is by definition orphan
+    (the artifact does not exist in postgres anymore).
+
+    Also cleans Entity nodes that lose all incident Episodic edges
+    after the delete — same pattern as ``delete_kb_episodes``.
+
+    Returns the count of Episodic nodes deleted. No-op when graphiti is
+    disabled or ``artifact_ids`` is empty.
+    """
+    if not settings.graphiti_enabled or not artifact_ids:
+        return 0
+    graphiti = _get_graphiti()
+    driver = graphiti.driver.clone(org_id)
+    result = await driver.execute_query(
+        "MATCH (e:Episodic) WHERE e.artifact_id IN $artifact_ids "
+        "WITH e, e.uuid AS uuid "
+        "DETACH DELETE e "
+        "RETURN count(uuid) AS deleted",
+        artifact_ids=artifact_ids,
+    )
+    deleted = 0
+    if result is not None:
+        records, _, _ = result
+        if records:
+            deleted = int(records[0].get("deleted", 0) or 0)
+    if deleted:
+        # Entities now potentially orphaned by the episode-delete above.
+        await driver.execute_query(
+            "MATCH (n:Entity) WHERE NOT ((:Episodic)--(n)) DETACH DELETE n",
+        )
+    logger.info(
+        "graph_orphan_episodes_deleted",
+        org_id=org_id,
+        artifact_count=len(artifact_ids),
+        episodes_deleted=deleted,
+    )
+    return deleted
 
 
 async def compute_entity_pagerank(org_id: str) -> dict[str, float]:
@@ -411,9 +466,7 @@ async def ingest_episode(
 
                 # Store entity UUIDs + PageRank scores in Qdrant for retrieval boosting
                 entity_uuids_list = [
-                    str(getattr(n, "uuid", ""))
-                    for n in nodes
-                    if getattr(n, "uuid", None)
+                    str(getattr(n, "uuid", "")) for n in nodes if getattr(n, "uuid", None)
                 ]
                 if entity_uuids_list:
                     try:
@@ -435,7 +488,9 @@ async def ingest_episode(
 
             except Exception as exc:
                 exc_str = str(exc).lower()
-                is_rate_limit = "rate limit" in exc_str or "429" in exc_str or "ratelimit" in exc_str  # noqa: E501
+                is_rate_limit = (
+                    "rate limit" in exc_str or "429" in exc_str or "ratelimit" in exc_str
+                )  # noqa: E501
                 if attempt < max_attempts - 1:
                     # Rate limit: back off long enough for Mistral's sliding window to reset.
                     # Other errors: short exponential backoff (1s, 2s).

--- a/klai-knowledge-ingest/knowledge_ingest/pg_store.py
+++ b/klai-knowledge-ingest/knowledge_ingest/pg_store.py
@@ -478,6 +478,32 @@ async def get_orphan_image_keys_for_connector(
     return [r["s3_key"] for r in rows]
 
 
+async def get_active_image_hashes_for_kb(org_id: str, kb_slug: str) -> set[str]:
+    """Return content_hashes still referenced by any artifact in a KB.
+
+    SPEC-CONNECTOR-DELETE-LIFECYCLE-001 janitor support. The Garage
+    cleanup janitor calls this AFTER ``delete_connector_artifacts`` to
+    work out which S3 keys still have a referencing artifact_image row
+    for this KB. Keys whose hash is NOT in this set are orphan and safe
+    to delete from S3.
+
+    Returns an empty set when the KB has no images / no artifacts.
+    """
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT DISTINCT ai.content_hash
+              FROM knowledge.artifact_images ai
+              JOIN knowledge.artifacts a ON a.id = ai.artifact_id
+             WHERE a.org_id = $1 AND a.kb_slug = $2
+            """,
+            org_id,
+            kb_slug,
+        )
+    return {r["content_hash"] for r in rows}
+
+
 async def artifact_exists(artifact_id: str) -> bool:
     """SPEC-CONNECTOR-DELETE-LIFECYCLE-001 REQ-07: existence-guard helper.
 

--- a/klai-knowledge-ingest/tests/test_connector_cleanup.py
+++ b/klai-knowledge-ingest/tests/test_connector_cleanup.py
@@ -75,6 +75,17 @@ async def test_purge_connector_orders_steps_correctly(mocked_proc_app: MagicMock
     async def fake_delete_qdrant(*_a: object, **_kw: object) -> None:
         call_order.append("qdrant_delete_connector")
 
+    async def fake_delete_orphan_episodes(*_a: object, **_kw: object) -> int:
+        call_order.append("delete_orphan_episodes_for_artifact_ids")
+        return 0
+
+    async def fake_get_active_hashes(*_a: object, **_kw: object) -> set[str]:
+        call_order.append("get_active_image_hashes_for_kb")
+        return set()
+
+    async def fake_build_image_store_returns_none() -> None:
+        return None
+
     with (
         patch(
             "knowledge_ingest.connector_cleanup._list_artifact_ids",
@@ -108,6 +119,20 @@ async def test_purge_connector_orders_steps_correctly(mocked_proc_app: MagicMock
             "knowledge_ingest.connector_cleanup.qdrant_store.delete_connector",
             side_effect=fake_delete_qdrant,
         ),
+        patch(
+            "knowledge_ingest.connector_cleanup.graph_module.delete_orphan_episodes_for_artifact_ids",
+            side_effect=fake_delete_orphan_episodes,
+        ),
+        patch(
+            "knowledge_ingest.connector_cleanup.pg_store.get_active_image_hashes_for_kb",
+            side_effect=fake_get_active_hashes,
+        ),
+        # ImageStore init returns None so the Garage paths are skipped in this
+        # mock-only test. Real Garage integration is covered by integration tests.
+        patch(
+            "knowledge_ingest.adapters.crawler._build_image_store",
+            return_value=None,
+        ),
     ):
         report = await purge_connector(
             org_id="org-zid",
@@ -129,6 +154,7 @@ async def test_purge_connector_orders_steps_correctly(mocked_proc_app: MagicMock
         "delete_connector_crawl_jobs",
         "delete_kb_episodes",
         "qdrant_delete_connector",
+        "delete_orphan_episodes_for_artifact_ids",
     ]
     assert isinstance(report, CleanupReport)
     assert report.artifacts_deleted == 2


### PR DESCRIPTION
Closes the two residuals from the live e2e: in-flight graphiti episodes that ignored asyncio cancel, and Garage keys that bypassed artifact_images bookkeeping. Both now caught by an unconditional janitor pass at end of purge_connector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)