### PR TITLE
fix: org-wide FalkorDB orphan sweep

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/connector_cleanup.py
+++ b/klai-knowledge-ingest/knowledge_ingest/connector_cleanup.py
@@ -291,12 +291,18 @@ async def purge_connector(
     #      iff no artifact in this KB still references its hash.
     # Both run unconditionally — even when steps 4b/7 returned zero,
     # because their inputs depend on rows that no longer exist.
-    falkor_orphans_deleted = await graph_module.delete_orphan_episodes_for_artifact_ids(
-        org_id, artifact_ids
+    # Org-wide sweep: catches both this connector's late-arrivers AND
+    # historical orphans from previous failed purges. Computes alive
+    # set from postgres (artifacts table is now in its post-delete
+    # state) and intersects against FalkorDB's episode set.
+    alive_artifact_ids = await pg_store.get_alive_artifact_ids_for_org(org_id)
+    falkor_orphans_deleted = await graph_module.sweep_orphan_episodes_org_wide(
+        org_id, alive_artifact_ids
     )
     log.info(
         "connector_purge_step_falkor_orphans_swept",
         count=falkor_orphans_deleted,
+        alive_artifact_count=len(alive_artifact_ids),
     )
 
     janitor_s3_deleted = 0

--- a/klai-knowledge-ingest/knowledge_ingest/graph.py
+++ b/klai-knowledge-ingest/knowledge_ingest/graph.py
@@ -296,6 +296,77 @@ async def delete_kb_episodes(org_id: str, episode_ids: list[str]) -> None:
     logger.info("graph_kb_episodes_deleted", org_id=org_id, count=len(episode_ids))
 
 
+async def sweep_orphan_episodes_org_wide(org_id: str, alive_artifact_ids: set[str]) -> int:
+    """ORG-WIDE sweep of FalkorDB episodes whose artifact_id is no longer in postgres.
+
+    SPEC-CONNECTOR-DELETE-LIFECYCLE-001 follow-up to the per-connector
+    janitor. The artifact-id snapshot misses two failure modes:
+
+    1. Late-arriving graphiti episodes from PREVIOUS purge cycles where
+       the cancel-jobs filter was broken (e.g. earlier worker bugs).
+       Those episodes never made it into the next purge's snapshot
+       because their artifact rows were already gone by then.
+    2. Operator-driven cleanup that bypassed the orchestrator.
+
+    Implementation: list every Episodic in the org's graph, keep only
+    those whose ``artifact_id`` is in ``alive_artifact_ids`` (computed
+    by the caller from postgres), DETACH DELETE the rest, then sweep
+    Entities that lost all incident episodes.
+
+    Returns count of episodes deleted. No-op when graphiti is disabled.
+    """
+    if not settings.graphiti_enabled:
+        return 0
+    graphiti = _get_graphiti()
+    driver = graphiti.driver.clone(org_id)
+    list_result = await driver.execute_query(
+        "MATCH (e:Episodic) WHERE e.artifact_id IS NOT NULL RETURN e.artifact_id AS artifact_id"
+    )
+    falkor_artifact_ids: set[str] = set()
+    if list_result is not None:
+        records, _, _ = list_result
+        for r in records or []:
+            aid = r.get("artifact_id")
+            if aid:
+                falkor_artifact_ids.add(str(aid))
+
+    orphan_ids = falkor_artifact_ids - alive_artifact_ids
+    if not orphan_ids:
+        logger.info(
+            "graph_orphan_sweep_clean",
+            org_id=org_id,
+            falkor_episodes=len(falkor_artifact_ids),
+            alive=len(alive_artifact_ids),
+        )
+        return 0
+
+    del_result = await driver.execute_query(
+        "MATCH (e:Episodic) WHERE e.artifact_id IN $orphan_ids "
+        "WITH e, e.uuid AS uuid "
+        "DETACH DELETE e "
+        "RETURN count(uuid) AS deleted",
+        orphan_ids=list(orphan_ids),
+    )
+    deleted = 0
+    if del_result is not None:
+        records, _, _ = del_result
+        if records:
+            deleted = int(records[0].get("deleted", 0) or 0)
+    if deleted:
+        await driver.execute_query(
+            "MATCH (n:Entity) WHERE NOT ((:Episodic)--(n)) DETACH DELETE n",
+        )
+    logger.info(
+        "graph_orphan_episodes_swept",
+        org_id=org_id,
+        scanned=len(falkor_artifact_ids),
+        alive=len(alive_artifact_ids),
+        orphan_artifact_ids=len(orphan_ids),
+        episodes_deleted=deleted,
+    )
+    return deleted
+
+
 async def delete_orphan_episodes_for_artifact_ids(org_id: str, artifact_ids: list[str]) -> int:
     """Janitor: drop FalkorDB episodes whose ``artifact_id`` is in the given list.
 
@@ -490,7 +561,7 @@ async def ingest_episode(
                 exc_str = str(exc).lower()
                 is_rate_limit = (
                     "rate limit" in exc_str or "429" in exc_str or "ratelimit" in exc_str
-                )  # noqa: E501
+                )
                 if attempt < max_attempts - 1:
                     # Rate limit: back off long enough for Mistral's sliding window to reset.
                     # Other errors: short exponential backoff (1s, 2s).

--- a/klai-knowledge-ingest/knowledge_ingest/pg_store.py
+++ b/klai-knowledge-ingest/knowledge_ingest/pg_store.py
@@ -478,6 +478,22 @@ async def get_orphan_image_keys_for_connector(
     return [r["s3_key"] for r in rows]
 
 
+async def get_alive_artifact_ids_for_org(org_id: str) -> set[str]:
+    """Return every artifact UUID in postgres for this org, as a set of strings.
+
+    Used by ``graph_module.sweep_orphan_episodes_org_wide`` to compute
+    which FalkorDB episodes have lost their backing artifact and are
+    therefore orphan.
+    """
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT id::text AS id FROM knowledge.artifacts WHERE org_id = $1",
+            org_id,
+        )
+    return {r["id"] for r in rows}
+
+
 async def get_active_image_hashes_for_kb(org_id: str, kb_slug: str) -> set[str]:
     """Return content_hashes still referenced by any artifact in a KB.
 

--- a/klai-knowledge-ingest/tests/test_connector_cleanup.py
+++ b/klai-knowledge-ingest/tests/test_connector_cleanup.py
@@ -75,9 +75,13 @@ async def test_purge_connector_orders_steps_correctly(mocked_proc_app: MagicMock
     async def fake_delete_qdrant(*_a: object, **_kw: object) -> None:
         call_order.append("qdrant_delete_connector")
 
-    async def fake_delete_orphan_episodes(*_a: object, **_kw: object) -> int:
-        call_order.append("delete_orphan_episodes_for_artifact_ids")
+    async def fake_sweep_episodes(*_a: object, **_kw: object) -> int:
+        call_order.append("sweep_orphan_episodes_org_wide")
         return 0
+
+    async def fake_get_alive_artifacts(*_a: object, **_kw: object) -> set[str]:
+        call_order.append("get_alive_artifact_ids_for_org")
+        return set()
 
     async def fake_get_active_hashes(*_a: object, **_kw: object) -> set[str]:
         call_order.append("get_active_image_hashes_for_kb")
@@ -120,8 +124,12 @@ async def test_purge_connector_orders_steps_correctly(mocked_proc_app: MagicMock
             side_effect=fake_delete_qdrant,
         ),
         patch(
-            "knowledge_ingest.connector_cleanup.graph_module.delete_orphan_episodes_for_artifact_ids",
-            side_effect=fake_delete_orphan_episodes,
+            "knowledge_ingest.connector_cleanup.graph_module.sweep_orphan_episodes_org_wide",
+            side_effect=fake_sweep_episodes,
+        ),
+        patch(
+            "knowledge_ingest.connector_cleanup.pg_store.get_alive_artifact_ids_for_org",
+            side_effect=fake_get_alive_artifacts,
         ),
         patch(
             "knowledge_ingest.connector_cleanup.pg_store.get_active_image_hashes_for_kb",
@@ -154,7 +162,8 @@ async def test_purge_connector_orders_steps_correctly(mocked_proc_app: MagicMock
         "delete_connector_crawl_jobs",
         "delete_kb_episodes",
         "qdrant_delete_connector",
-        "delete_orphan_episodes_for_artifact_ids",
+        "get_alive_artifact_ids_for_org",
+        "sweep_orphan_episodes_org_wide",
     ]
     assert isinstance(report, CleanupReport)
     assert report.artifacts_deleted == 2


### PR DESCRIPTION
Replaces the connector-scoped FalkorDB janitor with an org-wide one. Catches historical orphans from previous failed purges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)