### PR TITLE
fix: FalkorDB sweep matches Episodic.uuid not artifact_id

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/connector_cleanup.py
+++ b/klai-knowledge-ingest/knowledge_ingest/connector_cleanup.py
@@ -293,16 +293,18 @@ async def purge_connector(
     # because their inputs depend on rows that no longer exist.
     # Org-wide sweep: catches both this connector's late-arrivers AND
     # historical orphans from previous failed purges. Computes alive
-    # set from postgres (artifacts table is now in its post-delete
-    # state) and intersects against FalkorDB's episode set.
-    alive_artifact_ids = await pg_store.get_alive_artifact_ids_for_org(org_id)
+    # episode-uuid set from postgres
+    # (``artifacts.extra->>'graphiti_episode_id'`` — the FalkorDB
+    # ``Episodic.uuid`` value the ingest pipeline persists) and
+    # intersects against the org's FalkorDB graph.
+    alive_episode_uuids = await pg_store.get_alive_episode_uuids_for_org(org_id)
     falkor_orphans_deleted = await graph_module.sweep_orphan_episodes_org_wide(
-        org_id, alive_artifact_ids
+        org_id, alive_episode_uuids
     )
     log.info(
         "connector_purge_step_falkor_orphans_swept",
         count=falkor_orphans_deleted,
-        alive_artifact_count=len(alive_artifact_ids),
+        alive_episode_count=len(alive_episode_uuids),
     )
 
     janitor_s3_deleted = 0

--- a/klai-knowledge-ingest/knowledge_ingest/pg_store.py
+++ b/klai-knowledge-ingest/knowledge_ingest/pg_store.py
@@ -478,20 +478,31 @@ async def get_orphan_image_keys_for_connector(
     return [r["s3_key"] for r in rows]
 
 
-async def get_alive_artifact_ids_for_org(org_id: str) -> set[str]:
-    """Return every artifact UUID in postgres for this org, as a set of strings.
+async def get_alive_episode_uuids_for_org(org_id: str) -> set[str]:
+    """Return every Graphiti episode UUID still referenced by an artifact for this org.
 
-    Used by ``graph_module.sweep_orphan_episodes_org_wide`` to compute
-    which FalkorDB episodes have lost their backing artifact and are
-    therefore orphan.
+    Read from ``knowledge.artifacts.extra->>'graphiti_episode_id'`` —
+    this is where the ingest pipeline stores the FalkorDB ``Episodic.uuid``
+    after a successful ``graph_module.ingest_episode``. The org-wide
+    janitor uses the result to compute which FalkorDB episodes are no
+    longer referenced and therefore orphan.
+
+    Excludes the ``no-chunks`` sentinel that artifacts use when an
+    article had no extractable text.
     """
     pool = await get_pool()
     async with pool.acquire() as conn:
         rows = await conn.fetch(
-            "SELECT id::text AS id FROM knowledge.artifacts WHERE org_id = $1",
+            """
+            SELECT extra::jsonb->>'graphiti_episode_id' AS episode_uuid
+              FROM knowledge.artifacts
+             WHERE org_id = $1
+               AND extra IS NOT NULL
+               AND extra::jsonb->>'graphiti_episode_id' IS NOT NULL
+            """,
             org_id,
         )
-    return {r["id"] for r in rows}
+    return {r["episode_uuid"] for r in rows if r["episode_uuid"] != "no-chunks"}
 
 
 async def get_active_image_hashes_for_kb(org_id: str, kb_slug: str) -> set[str]:

--- a/klai-knowledge-ingest/tests/test_connector_cleanup.py
+++ b/klai-knowledge-ingest/tests/test_connector_cleanup.py
@@ -80,7 +80,7 @@ async def test_purge_connector_orders_steps_correctly(mocked_proc_app: MagicMock
         return 0
 
     async def fake_get_alive_artifacts(*_a: object, **_kw: object) -> set[str]:
-        call_order.append("get_alive_artifact_ids_for_org")
+        call_order.append("get_alive_episode_uuids_for_org")
         return set()
 
     async def fake_get_active_hashes(*_a: object, **_kw: object) -> set[str]:
@@ -128,7 +128,7 @@ async def test_purge_connector_orders_steps_correctly(mocked_proc_app: MagicMock
             side_effect=fake_sweep_episodes,
         ),
         patch(
-            "knowledge_ingest.connector_cleanup.pg_store.get_alive_artifact_ids_for_org",
+            "knowledge_ingest.connector_cleanup.pg_store.get_alive_episode_uuids_for_org",
             side_effect=fake_get_alive_artifacts,
         ),
         patch(
@@ -162,7 +162,7 @@ async def test_purge_connector_orders_steps_correctly(mocked_proc_app: MagicMock
         "delete_connector_crawl_jobs",
         "delete_kb_episodes",
         "qdrant_delete_connector",
-        "get_alive_artifact_ids_for_org",
+        "get_alive_episode_uuids_for_org",
         "sweep_orphan_episodes_org_wide",
     ]
     assert isinstance(report, CleanupReport)


### PR DESCRIPTION
Caught by live e2e: previous sweep matched a property that doesn't exist on Graphiti's Episodic schema. Now uses uuid-to-uuid via knowledge.artifacts.extra->>graphiti_episode_id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)