### PR TITLE
fix(SPEC-PROCRASTINATE-ZOMBIE-001): recover orphan procrastinate jobs after worker crash

### DIFF
--- a/.moai/specs/SPEC-PROCRASTINATE-ZOMBIE-001/spec.md
+++ b/.moai/specs/SPEC-PROCRASTINATE-ZOMBIE-001/spec.md
@@ -1,0 +1,139 @@
+---
+id: SPEC-PROCRASTINATE-ZOMBIE-001
+version: "1.0"
+status: draft
+created: 2026-05-01
+updated: 2026-05-01
+author: Mark Vletter
+priority: high
+issue_number: 0
+---
+
+## HISTORY
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| 1.0 | 2026-05-01 | Mark Vletter | Initial draft. 21 zombie procrastinate jobs found in production accumulated over 25 days (5–30 April), saturating worker concurrency on `enrich-bulk` + `graphiti-bulk` queues. Discovered while validating the connector-delete e2e cycle on Voys (SPEC-CONNECTOR-DELETE-LIFECYCLE-001). |
+
+---
+
+# SPEC-PROCRASTINATE-ZOMBIE-001: Recover orphaned procrastinate jobs after worker crash
+
+## Context
+
+`klai-knowledge-ingest` runs the procrastinate worker as a background asyncio task inside the FastAPI lifespan. Each deploy recreates the container; Docker sends SIGTERM and waits 10 seconds (the daemon default) before SIGKILL.
+
+Two enrichment task types regularly exceed that 10-second window:
+
+- `enrich_document_bulk` — embeddings + LLM rerank (5–30s)
+- `ingest_graphiti_episode` — Mistral entity + relation extraction via LiteLLM (30–60s)
+
+When SIGKILL fires mid-task:
+
+1. The worker process dies with no chance to write a final job status to PostgreSQL.
+2. The next worker startup calls procrastinate's built-in `prune_stalled_workers_v1` (heartbeat older than `stalled_worker_timeout`, default 30 s). That **deletes the worker row** but the FK `procrastinate_jobs.worker_id → procrastinate_workers.id ON DELETE SET NULL` only nulls out `worker_id`. The job's `status` stays `doing` forever.
+3. Procrastinate v3.7.2 has `get_stalled_jobs(seconds_since_heartbeat=…)` as a read API but ships **no built-in retry path** for the rows it returns — every consumer is expected to wire that itself.
+
+Each surviving zombie permanently consumes a worker concurrency slot. After enough deploys, enrichment throughput collapses.
+
+### Production evidence (2026-04-30, before fix)
+
+```sql
+SELECT count(*) FROM procrastinate_jobs WHERE status = 'doing';
+-- 21 (across 5 April .. 30 April, all worker_id IS NULL)
+```
+
+Distribution:
+
+- `graphiti-bulk` × 19 (Mistral LLM calls killed mid-extraction)
+- `enrich-bulk` × 2
+
+All 21 align with previous deploy timestamps. The `connector-purge` queue did still pick up new work because each queue has its own slot, but the heavy enrichment lanes were partially blocked.
+
+---
+
+## Scope
+
+In scope:
+
+- `klai-knowledge-ingest` worker lifespan in `klai-knowledge-ingest/knowledge_ingest/app.py`
+- A new module `knowledge_ingest/zombie_recovery.py`
+- `deploy/docker-compose.yml` — add `stop_grace_period: 90s` on the `knowledge-ingest` service
+
+Out of scope (separate follow-ups):
+
+- Other services that may use procrastinate in the future. Today only `knowledge-ingest` does (verified 2026-05-01 grep across the monorepo).
+- Procrastinate upstream contribution to make the recovery automatic.
+- Alembic migration changes — none needed.
+
+---
+
+## Requirements (EARS)
+
+### REQ-1 (Recovery on worker startup)
+
+**WHEN** the `knowledge-ingest` lifespan starts and `enrichment_enabled` is true,
+**THE SYSTEM SHALL** call `recover_zombie_jobs(proc_app)` BEFORE starting the procrastinate worker (`proc_app.run_worker_async`).
+
+### REQ-2 (Stalled worker pruning)
+
+`recover_zombie_jobs` SHALL call `proc_app.job_manager.prune_stalled_workers(STALLED_WORKER_TIMEOUT_SECONDS)` with `STALLED_WORKER_TIMEOUT_SECONDS = 120` to remove dead worker rows.
+
+The 120-second window is conservative relative to procrastinate's 10-second heartbeat interval — it will not prune the live worker that is about to start.
+
+### REQ-3 (Retry orphan jobs)
+
+After pruning workers, `recover_zombie_jobs` SHALL select every row matching `status = 'doing' AND worker_id IS NULL` and call `proc_app.job_manager.retry_job_by_id_async(job_id, retry_at=now())` for each.
+
+The retry API resets `status = 'todo'`, increments `attempts`, and clears the worker reference. Every queue task in this service is idempotent (Episode UUID dedup, content_hash dedup, connector_purge_task is idempotent by construction), so re-execution is safe.
+
+### REQ-4 (Best-effort)
+
+Recovery SHALL be best-effort. If `prune_stalled_workers`, the SELECT, or any individual `retry_job_by_id_async` raises, the lifespan SHALL log the exception and continue — the worker still starts and processes new jobs.
+
+### REQ-5 (Observability)
+
+Recovery SHALL emit one structured log event per outcome:
+
+- `procrastinate_pruned_stalled_workers` with `count` (only if any were pruned)
+- `procrastinate_zombie_recovery_clean` if no orphan jobs found
+- `procrastinate_zombies_retried` with `workers_pruned`, `jobs_retried`, `jobs_total` if any retries happened
+- `procrastinate_zombie_retry_failed` per failing retry (with traceback)
+- `procrastinate_zombie_recovery_failed` if the wrapping try/except triggers
+
+### REQ-6 (Reduce zombie creation rate)
+
+`deploy/docker-compose.yml` SHALL set `stop_grace_period: 90s` on the `knowledge-ingest` service.
+
+90 s exceeds the 99th-percentile observed graphiti task duration (~60 s) so most LLM calls finish before SIGKILL. The recovery loop in REQ-1..REQ-5 covers the residual cases.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Recovery races with a still-alive worker (false positive) | `STALLED_WORKER_TIMEOUT_SECONDS = 120` is 12× the 10s heartbeat — a live worker cannot be 120 s stale. |
+| Idempotency assumption wrong for some task | Audited 2026-05-01: every registered task in `enrichment_tasks.py` and `connector_purge_tasks.py` is idempotent. New tasks must remain idempotent (existing project convention). |
+| Recovery itself fails and blocks startup | REQ-4 guarantees the lifespan continues even on recovery failure. |
+| `stop_grace_period: 90s` slows down deploys noticeably | True, but only when an enrichment task is actively running at deploy time. In practice deploys finish in 15-30 s; the longer window only kicks in for the rare overlap. |
+| New procrastinate-using service skips this hook | Documented in `.claude/rules/klai/projects/knowledge.md` (added in this SPEC). |
+
+---
+
+## Success Criteria
+
+- After deploy: `SELECT count(*) FROM procrastinate_jobs WHERE status = 'doing' AND worker_id IS NULL` reaches 0 within 5 seconds of new container startup.
+- One-shot cleanup of the existing 21 zombies happens automatically on first deploy of this PR (no manual SQL needed).
+- Container shutdown logs show `procrastinate_zombies_retried` with the correct counts when zombies were present.
+- Subsequent deploys do not introduce new zombies as long as graphiti tasks finish within 90 s — verified by re-querying `count(*) WHERE status='doing' AND worker_id IS NULL` 5 minutes after each deploy for 1 week.
+- Pre-flight check in PR body: `grep -c stop_grace_period deploy/docker-compose.yml` ≥ 1.
+
+---
+
+## Out of scope (explicit non-goals)
+
+- Replacing procrastinate.
+- Custom heartbeat protocol.
+- Retroactive cleanup of `succeeded` / `failed` jobs (covered by `delete_old_jobs` already).
+- Changing task signatures or semantics. Only the worker lifecycle + recovery is touched.

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1186,6 +1186,13 @@ services:
   knowledge-ingest:
     image: ghcr.io/getklai/knowledge-ingest:latest
     restart: unless-stopped
+    # SPEC-PROCRASTINATE-ZOMBIE-001: graphiti enrichment tasks call LiteLLM
+    # which can take 30-60s. Docker default 10s SIGTERM-to-SIGKILL window
+    # would interrupt those mid-call and orphan the procrastinate job in
+    # 'doing' state forever. 90s lets nearly all in-flight LLM calls
+    # finish gracefully on deploy. Recovery for the residual cases lives
+    # in knowledge_ingest.zombie_recovery (runs at next worker startup).
+    stop_grace_period: 90s
     environment:
       POSTGRES_DSN: postgresql+asyncpg://klai:${POSTGRES_PASSWORD}@postgres:5432/klai
       QDRANT_URL: http://qdrant:6333

--- a/klai-knowledge-ingest/knowledge_ingest/app.py
+++ b/klai-knowledge-ingest/knowledge_ingest/app.py
@@ -67,6 +67,20 @@ async def lifespan(app: FastAPI):
         logger.info("Procrastinate app initialised.")
 
         async with proc_app.open_async():
+            # SPEC-PROCRASTINATE-ZOMBIE-001: reset jobs orphaned by killed
+            # containers (status='doing' AND worker_id IS NULL) before starting
+            # the new worker. Procrastinate v3's built-in prune_stalled_workers
+            # only deletes the worker rows; orphaned jobs would otherwise stay
+            # in 'doing' forever and consume worker concurrency slots.
+            from knowledge_ingest.zombie_recovery import recover_zombie_jobs  # noqa: PLC0415
+
+            try:
+                await recover_zombie_jobs(proc_app)
+            except Exception:
+                # Recovery is best-effort. If it fails, log and continue —
+                # the worker still starts and processes new jobs.
+                logger.exception("procrastinate_zombie_recovery_failed")
+
             worker_task = asyncio.create_task(
                 proc_app.run_worker_async(
                     queues=[

--- a/klai-knowledge-ingest/knowledge_ingest/zombie_recovery.py
+++ b/klai-knowledge-ingest/knowledge_ingest/zombie_recovery.py
@@ -1,0 +1,88 @@
+"""Stalled-job recovery for procrastinate workers.
+
+Procrastinate v3 detects stalled workers via heartbeat (`procrastinate_workers.last_heartbeat`)
+and prunes their rows on the next worker startup. The FK
+`procrastinate_jobs.worker_id → procrastinate_workers.id ON DELETE SET NULL`
+sets `worker_id = NULL` on jobs whose owning worker disappeared.
+
+But procrastinate does NOT reset those jobs — their status stays `doing` forever.
+On every container kill (Docker SIGKILL after the 10s default `stop_grace_period`)
+that happens mid-LLM-call, one or more graphiti/enrich jobs become permanent zombies.
+After enough deploys the worker concurrency slots fill up and enrichment stalls.
+
+This module fills the gap: at lifespan startup, it prunes stalled worker rows
+and retries every job in `doing` status whose owner is gone.
+
+Safe to run because every task this worker handles is idempotent:
+- ``ingest_graphiti_episode`` dedups via Episode UUID
+- ``enrich_document_bulk`` dedups via content_hash + artifact_id
+- ``connector_purge_task`` is fully idempotent by design (SPEC-CONNECTOR-DELETE-LIFECYCLE-001)
+
+See SPEC-PROCRASTINATE-ZOMBIE-001.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any
+
+import structlog
+
+logger = structlog.get_logger()
+
+# Worker rows older than this are considered dead. Default heartbeat interval
+# is 10s; a 120s window accommodates a slow-restarting worker without
+# false-positive pruning.
+STALLED_WORKER_TIMEOUT_SECONDS = 120.0
+
+
+async def recover_zombie_jobs(proc_app: Any) -> dict[str, int]:
+    """Reset jobs orphaned by dead workers back to ``todo``.
+
+    Two-step:
+    1. Prune stalled worker rows (heartbeat older than STALLED_WORKER_TIMEOUT_SECONDS).
+       FK CASCADE sets ``worker_id = NULL`` on each orphaned job.
+    2. Retry every job still in ``doing`` with ``worker_id IS NULL``.
+
+    Returns counts for observability/tests.
+    """
+    pruned_workers = await proc_app.job_manager.prune_stalled_workers(
+        STALLED_WORKER_TIMEOUT_SECONDS
+    )
+    pruned_count = len(pruned_workers)
+    if pruned_count:
+        logger.info("procrastinate_pruned_stalled_workers", count=pruned_count)
+
+    rows = await proc_app.connector.execute_query_all_async(
+        query="""
+            SELECT id, queue_name, task_name
+            FROM procrastinate_jobs
+            WHERE status = 'doing' AND worker_id IS NULL
+        """,
+    )
+    if not rows:
+        logger.info("procrastinate_zombie_recovery_clean")
+        return {"workers_pruned": pruned_count, "jobs_retried": 0}
+
+    retry_at = datetime.datetime.now(datetime.UTC)
+    retried = 0
+    for row in rows:
+        job_id = row["id"]
+        try:
+            await proc_app.job_manager.retry_job_by_id_async(job_id=job_id, retry_at=retry_at)
+            retried += 1
+        except Exception:
+            logger.exception(
+                "procrastinate_zombie_retry_failed",
+                job_id=job_id,
+                queue=row.get("queue_name"),
+                task=row.get("task_name"),
+            )
+
+    logger.info(
+        "procrastinate_zombies_retried",
+        workers_pruned=pruned_count,
+        jobs_retried=retried,
+        jobs_total=len(rows),
+    )
+    return {"workers_pruned": pruned_count, "jobs_retried": retried}

--- a/klai-knowledge-ingest/tests/test_zombie_recovery.py
+++ b/klai-knowledge-ingest/tests/test_zombie_recovery.py
@@ -1,0 +1,109 @@
+"""Unit tests for ``zombie_recovery.recover_zombie_jobs``.
+
+SPEC-PROCRASTINATE-ZOMBIE-001 REQ-1..REQ-5.
+
+The tests mock the procrastinate ``proc_app`` because the recovery logic
+is all about correct sequencing + correct calls. Integration with the
+real procrastinate schema is covered by the production deploy itself:
+the existing 21 zombies are the live regression test.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from knowledge_ingest.zombie_recovery import (
+    STALLED_WORKER_TIMEOUT_SECONDS,
+    recover_zombie_jobs,
+)
+
+
+def _make_proc_app(stalled_workers: list[int], doing_rows: list[dict]) -> MagicMock:
+    """Build a proc_app whose connector/job_manager return canned data."""
+    proc_app = MagicMock()
+    proc_app.job_manager = MagicMock()
+    proc_app.job_manager.prune_stalled_workers = AsyncMock(return_value=stalled_workers)
+    proc_app.job_manager.retry_job_by_id_async = AsyncMock(return_value=None)
+    proc_app.connector = MagicMock()
+    proc_app.connector.execute_query_all_async = AsyncMock(return_value=doing_rows)
+    return proc_app
+
+
+@pytest.mark.asyncio
+async def test_recovery_clean_when_no_zombies():
+    """REQ-3: when no orphan jobs exist, recovery is a no-op."""
+    proc_app = _make_proc_app(stalled_workers=[], doing_rows=[])
+
+    result = await recover_zombie_jobs(proc_app)
+
+    assert result == {"workers_pruned": 0, "jobs_retried": 0}
+    proc_app.job_manager.prune_stalled_workers.assert_awaited_once_with(
+        STALLED_WORKER_TIMEOUT_SECONDS
+    )
+    proc_app.job_manager.retry_job_by_id_async.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recovery_retries_each_orphan_job():
+    """REQ-3: every orphan row gets retried with retry_at."""
+    rows = [
+        {"id": 100, "queue_name": "graphiti-bulk", "task_name": "ingest_graphiti_episode"},
+        {"id": 101, "queue_name": "enrich-bulk", "task_name": "enrich_document_bulk"},
+        {"id": 102, "queue_name": "graphiti-bulk", "task_name": "ingest_graphiti_episode"},
+    ]
+    proc_app = _make_proc_app(stalled_workers=[42, 43], doing_rows=rows)
+
+    result = await recover_zombie_jobs(proc_app)
+
+    assert result == {"workers_pruned": 2, "jobs_retried": 3}
+    assert proc_app.job_manager.retry_job_by_id_async.await_count == 3
+    retried_ids = {
+        call.kwargs["job_id"] for call in proc_app.job_manager.retry_job_by_id_async.await_args_list
+    }
+    assert retried_ids == {100, 101, 102}
+
+
+@pytest.mark.asyncio
+async def test_recovery_continues_when_one_retry_fails():
+    """REQ-4: a failing retry on one job does not abort the others."""
+    rows = [
+        {"id": 200, "queue_name": "graphiti-bulk", "task_name": "ingest_graphiti_episode"},
+        {"id": 201, "queue_name": "graphiti-bulk", "task_name": "ingest_graphiti_episode"},
+        {"id": 202, "queue_name": "graphiti-bulk", "task_name": "ingest_graphiti_episode"},
+    ]
+    proc_app = _make_proc_app(stalled_workers=[], doing_rows=rows)
+    # Middle job raises; outer caller should still see counts for the successes.
+    proc_app.job_manager.retry_job_by_id_async = AsyncMock(
+        side_effect=[None, RuntimeError("simulated DB blip"), None]
+    )
+
+    result = await recover_zombie_jobs(proc_app)
+
+    assert result == {"workers_pruned": 0, "jobs_retried": 2}
+    assert proc_app.job_manager.retry_job_by_id_async.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_select_uses_status_doing_and_worker_id_null():
+    """REQ-3: the SQL must filter on status='doing' AND worker_id IS NULL."""
+    proc_app = _make_proc_app(stalled_workers=[], doing_rows=[])
+
+    await recover_zombie_jobs(proc_app)
+
+    proc_app.connector.execute_query_all_async.assert_awaited_once()
+    call_kwargs = proc_app.connector.execute_query_all_async.await_args.kwargs
+    query = call_kwargs["query"]
+    assert "status = 'doing'" in query
+    assert "worker_id IS NULL" in query
+
+
+@pytest.mark.asyncio
+async def test_uses_120_second_stalled_worker_timeout():
+    """REQ-2: 120s window prevents pruning the live worker about to start."""
+    proc_app = _make_proc_app(stalled_workers=[], doing_rows=[])
+
+    await recover_zombie_jobs(proc_app)
+
+    proc_app.job_manager.prune_stalled_workers.assert_awaited_once_with(120.0)


### PR DESCRIPTION
## Summary

- Recovers procrastinate jobs orphaned by container kills (status='doing' AND worker_id IS NULL)
- Adds `stop_grace_period: 90s` to knowledge-ingest so graphiti LLM tasks (30-60s) finish gracefully on deploy
- 5 unit tests, ruff clean, format clean

## Root cause

Docker default SIGTERM-to-SIGKILL window = 10s. Graphiti enrichment LLM calls take 30-60s. Every deploy SIGKILLs in-flight tasks. Procrastinate v3 prunes stalled worker rows on next startup but leaves their jobs in 'doing' forever (FK SET NULL is incomplete recovery). After enough deploys the worker concurrency on `enrich-bulk` + `graphiti-bulk` queues saturates.

Production evidence (2026-04-30): 21 zombies across 25 days, all `worker_id IS NULL` + `status='doing'`. Found while validating SPEC-CONNECTOR-DELETE-LIFECYCLE-001.

## Fix shape

1. `deploy/docker-compose.yml`: `stop_grace_period: 90s` on knowledge-ingest
2. `knowledge_ingest/zombie_recovery.py` (new): `recover_zombie_jobs()` calls `prune_stalled_workers(120s)` then `retry_job_by_id_async` on each orphan
3. `knowledge_ingest/app.py`: lifespan invokes recovery inside `proc_app.open_async()` before `run_worker_async()`, best-effort

## Test plan

- [x] 5 unit tests pass (clean-state, retry-all, partial-failure, SQL shape, 120s timeout)
- [x] ruff check clean on new files
- [x] ruff format clean on new files
- [ ] After deploy: SELECT count(*) FROM procrastinate_jobs WHERE status='doing' AND worker_id IS NULL returns 0 within 5s of new container startup
- [ ] Worker startup logs show procrastinate_zombies_retried with non-zero counts on first deploy
- [ ] Subsequent deploys (next week) introduce no new zombies

## Out of scope

- Other services using procrastinate (today only knowledge-ingest does — verified)
- Procrastinate upstream PR for built-in recovery
- Stop_grace_period for non-LLM services

🤖 Generated with [Claude Code](https://claude.com/claude-code)