### PR TITLE
fix(provisioning): scope tenant LiteLLM keys to real model aliases

### DIFF
--- a/docs/architecture/klai-knowledge-architecture.md
+++ b/docs/architecture/klai-knowledge-architecture.md
@@ -179,7 +179,7 @@ LiteLLM proxy (klai-core stack)
   │    ├── GET org_id from key metadata
   │    └── POST /knowledge/v1/retrieve  (2s timeout, graceful degrade)
   ▼
-Mistral Small 3.1 (klai-llm) / Ollama fallback (klai-fallback)
+klai-primary / klai-fast / klai-large (per .claude/rules/klai/platform/litellm.md)
 ```
 
 Tenant isolation: one LiteLLM team key per LibreChat container, carrying `org_id` in key metadata. The hook uses this to scope every retrieval query. Containers provisioned before this change (using master key) will skip retrieval — no breakage, no context injection.
@@ -1104,7 +1104,7 @@ Migration required for existing tenants: see §9.5 provisioning changes.
 
 At tenant creation, provisioning adds a step:
 1. `POST /team/new` — creates a LiteLLM team (alias = org slug)
-2. `POST /key/generate` — creates a team key with `metadata: {org_id: "<zitadel_org_id>"}` and `models: ["klai-llm", "klai-fallback"]`
+2. `POST /key/generate` — creates a team key with `metadata: {org_id: "<zitadel_org_id>"}` and `models: ["klai-primary", "klai-fast", "klai-large"]` (the user-facing LiteLLM tier aliases — `klai-pipeline` is excluded because it bypasses custom_router and is reserved for internal services)
 3. The returned key replaces `settings.litellm_master_key` as `LITELLM_API_KEY` in the LibreChat `.env`
 
 `zitadel_org_id` is used (not the integer PK) — it is the stable cross-system identifier available on `PortalOrg.zitadel_org_id`, and the correct key for Qdrant scope `org_{zitadel_org_id}`.

--- a/klai-portal/backend/app/services/provisioning/orchestrator.py
+++ b/klai-portal/backend/app/services/provisioning/orchestrator.py
@@ -331,7 +331,15 @@ async def _provision(org_id: int, db: AsyncSession) -> None:
                     json={
                         "team_id": team_id,
                         "metadata": {"org_id": zitadel_org_id},
-                        "models": ["klai-llm", "klai-fallback"],
+                        # @MX:ANCHOR fan_in=2 LibreChat tenants call klai-primary
+                        # directly; LiteLLM's custom_router may upgrade to
+                        # klai-large (tool calls) or downgrade to klai-fast (web
+                        # search). All three MUST be in scope.
+                        # @MX:REASON: deploy/litellm/config.yaml only defines
+                        # klai-primary, klai-fast, klai-large, klai-pipeline;
+                        # klai-pipeline is reserved for internal services and
+                        # bypasses custom_router (see platform/litellm.md).
+                        "models": ["klai-primary", "klai-fast", "klai-large"],
                     },
                 )
                 key_resp.raise_for_status()

--- a/klai-portal/backend/tests/test_provisioning_orchestrator.py
+++ b/klai-portal/backend/tests/test_provisioning_orchestrator.py
@@ -221,6 +221,65 @@ async def test_happy_path_transitions_to_ready(mock_orchestrator_env, monkeypatc
 
 
 # ---------------------------------------------------------------------------
+# REGRESSION — LiteLLM key models scope
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_litellm_key_generate_uses_real_model_aliases(mock_orchestrator_env) -> None:
+    """The /key/generate body MUST scope tenant keys to the actual LiteLLM
+    model aliases defined in deploy/litellm/config.yaml.
+
+    Regression guard: a previous bug shipped with `["klai-llm","klai-fallback"]`
+    — names that don't exist anywhere in the LiteLLM config. LibreChat (which
+    is hardcoded to call `klai-primary`) then got 401s for every tenant. The
+    legitimate aliases per platform/litellm.md are klai-fast, klai-primary,
+    klai-large, klai-pipeline — and klai-pipeline is reserved for internal
+    services, so tenant keys must scope to the three user-facing tiers.
+    """
+    from app.services.provisioning import orchestrator
+
+    db, _org = _make_db_and_org()
+
+    captured: list[dict] = []
+
+    class _CapturingClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return None
+
+        async def post(self, path, json=None):
+            if "/team/new" in path:
+                return mock_orchestrator_env["litellm_team_post"]
+            if "/key/generate" in path:
+                captured.append(json or {})
+                return mock_orchestrator_env["litellm_key_post"]
+            if "/team/delete" in path:
+                return MagicMock()
+            if "/kbs" in path:
+                ok = MagicMock()
+                ok.status_code = 200
+                ok.raise_for_status = MagicMock()
+                ok.json = MagicMock(return_value={"id": 1, "slug": "default"})
+                return ok
+            raise AssertionError(f"Unexpected httpx call: {path}")
+
+    orchestrator.httpx.AsyncClient = lambda **kw: _CapturingClient()
+
+    with patch("app.services.provisioning.state_machine.emit_event"):
+        await orchestrator._provision(1, db)
+
+    assert len(captured) == 1, f"Expected exactly one /key/generate POST, got {len(captured)}"
+    body = captured[0]
+    assert body.get("models") == ["klai-primary", "klai-fast", "klai-large"], (
+        f"Tenant LiteLLM key must scope to user-facing klai-* aliases, got {body.get('models')!r}. "
+        "See deploy/litellm/config.yaml for valid model names."
+    )
+
+
+# ---------------------------------------------------------------------------
 # Failure mid-run — compensators drain in LIFO order
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Tenant provisioning was issuing LiteLLM keys scoped to non-existent model names (`klai-llm`, `klai-fallback`), causing every tenant chat to fail with `401 key not allowed to access model` the moment LibreChat tried `klai-primary`.
- Replaces the bogus list with the actual user-facing tier aliases per [`.claude/rules/klai/platform/litellm.md`](.claude/rules/klai/platform/litellm.md): `klai-primary`, `klai-fast`, `klai-large`. `klai-pipeline` is intentionally excluded — that tier bypasses custom_router and is reserved for internal services.
- Adds a regression test that captures the `/key/generate` POST body and asserts the exact `models` list, so this can't drift silently again.

## Production state

The two existing broken tenant keys were already hot-fixed in place via `LiteLLM /key/update` before this PR:

Both keys went from their old model list to `["klai-primary","klai-fast","klai-large"]`. (Tenant names and key prefixes removed from this public text on 2026-09-19.)

So this PR is purely a forward-fix: any new tenant provisioned after merge gets the correct scope. No data migration needed.

## How LibreChat uses the scope

`deploy/librechat/librechat.yaml` is hardcoded to `klai-primary` for default model, titleModel, summaryModel and modelSpec preset. `deploy/litellm/custom_router.py` then upgrades `klai-primary` → `klai-large` on tool calls and downgrades to `klai-fast` for web-search content, so all three aliases must be in the key scope.

## Test plan

- [x] `uv run ruff check` + `uv run ruff format --check` on touched files
- [x] `uv run pytest tests/test_provisioning_orchestrator.py` (11 passed, including the new regression test)
- [ ] On merge: provision a fresh tenant and confirm `LITELLM_API_KEY` scope shows the three aliases via `GET /key/info`
- [ ] Smoke test chat in the freshly provisioned tenant

🤖 Generated with [Claude Code](https://claude.com/claude-code)
