### PR TITLE
feat(hygiene): SPEC-INFRA-CONTAINER-HYGIENE-001 — container hygiene + AI-first guards

### DIFF
--- a/.claude/hooks/klai/container-hygiene-preflight.sh
+++ b/.claude/hooks/klai/container-hygiene-preflight.sh
@@ -123,8 +123,8 @@ fi
 # customer-/tenant-specific container. Removing without explicit confirmation
 # is exactly the librechat-voys mistake.
 
-if [[ "$TARGET" =~ -voys$|-getklai$|-[a-z]+-tenant$ ]]; then
-    emit_block "$TARGET matches a tenant-specific naming pattern ($OPERATION). Verify customer impact before removal."
+if [[ "$TARGET" =~ -voys$|-getklai$|-[a-z]+-tenant$ ]] || [[ "$TARGET" =~ ^librechat- ]]; then
+    emit_block "$TARGET matches a tenant-managed naming pattern ($OPERATION). If this is a portal-api-provisioning-managed tenant container (klasse B, see SPEC REQ-2), use the deprovision flow instead: portal-api orchestrator.deprovision_tenant() — never delete directly via 'docker rm'. If this is a different match, verify customer impact and override with explicit user approval."
 fi
 
 # ─── Check 3: compose git-history (best-effort, lokaal) ───────────────────────

--- a/.claude/hooks/klai/container-hygiene-preflight.sh
+++ b/.claude/hooks/klai/container-hygiene-preflight.sh
@@ -92,58 +92,73 @@ if echo "$COMMAND" | grep -qE 'docker\s+compose\s+down\s+(-v|--volumes)'; then
     emit_block "docker compose down --volumes — destroys named volumes. Stop containers without -v, then targeted volume rm if needed."
 fi
 
-# ─── Targeted destructive operations: extract target ──────────────────────────
+# ─── Targeted destructive operations: extract ALL targets ────────────────────
+# `docker rm a b c` removes three containers. Extract every argument that
+# follows the verb (skipping flags) so a tenant-named container in position
+# 2/3/N is also blocked, not just the first.
 
-TARGET=""
+TARGETS=()
 OPERATION=""
 
-# docker rm <name|id> [more]
-if [[ "$COMMAND" =~ docker[[:space:]]+rm[[:space:]]+(-f[[:space:]]+)?([a-zA-Z0-9_.-]+) ]]; then
-    TARGET="${BASH_REMATCH[2]}"
+extract_args_after() {
+    # Strip leading whitespace + verb, then split by whitespace, dropping flags.
+    local rest="$1"
+    # Take everything after the verb; remove `--flag` and `-x` tokens
+    awk '{
+        for (i=1; i<=NF; i++) {
+            if ($i ~ /^-/) continue
+            print $i
+        }
+    }' <<< "$rest"
+}
+
+if [[ "$COMMAND" =~ docker[[:space:]]+rm[[:space:]]+(.*)$ ]]; then
     OPERATION="container removal"
-fi
-# docker rmi <name|sha> [more]
-if [[ -z "$TARGET" ]] && [[ "$COMMAND" =~ docker[[:space:]]+rmi[[:space:]]+(-f[[:space:]]+)?([a-zA-Z0-9_./:-]+) ]]; then
-    TARGET="${BASH_REMATCH[2]}"
+    while IFS= read -r tgt; do
+        [[ -n "$tgt" ]] && TARGETS+=("$tgt")
+    done < <(extract_args_after "${BASH_REMATCH[1]}")
+elif [[ "$COMMAND" =~ docker[[:space:]]+rmi[[:space:]]+(.*)$ ]]; then
     OPERATION="image removal"
-fi
-# docker volume rm <name>
-if [[ -z "$TARGET" ]] && [[ "$COMMAND" =~ docker[[:space:]]+volume[[:space:]]+rm[[:space:]]+([a-zA-Z0-9_.-]+) ]]; then
-    TARGET="${BASH_REMATCH[1]}"
+    while IFS= read -r tgt; do
+        [[ -n "$tgt" ]] && TARGETS+=("$tgt")
+    done < <(extract_args_after "${BASH_REMATCH[1]}")
+elif [[ "$COMMAND" =~ docker[[:space:]]+volume[[:space:]]+rm[[:space:]]+(.*)$ ]]; then
     OPERATION="volume removal"
+    while IFS= read -r tgt; do
+        [[ -n "$tgt" ]] && TARGETS+=("$tgt")
+    done < <(extract_args_after "${BASH_REMATCH[1]}")
 fi
 
 # Nothing matched a destructive operation we know — allow
-if [[ -z "$TARGET" ]]; then
+if [[ ${#TARGETS[@]} -eq 0 ]]; then
     exit 0
 fi
 
-# ─── Check 2: tenant-naam pattern (always-on, lokaal) ─────────────────────────
-# A name ending in -voys, -getklai, or -<word>-tenant is a strong signal of a
-# customer-/tenant-specific container. Removing without explicit confirmation
-# is exactly the librechat-voys mistake.
-
-if [[ "$TARGET" =~ -voys$|-getklai$|-[a-z]+-tenant$ ]] || [[ "$TARGET" =~ ^librechat- ]]; then
-    emit_block "$TARGET matches a tenant-managed naming pattern ($OPERATION). If this is a portal-api-provisioning-managed tenant container (klasse B, see SPEC REQ-2), use the deprovision flow instead: portal-api orchestrator.deprovision_tenant() — never delete directly via 'docker rm'. If this is a different match, verify customer impact and override with explicit user approval."
-fi
-
-# ─── Check 3: compose git-history (best-effort, lokaal) ───────────────────────
-# If a klai-infra checkout exists alongside this repo, search its compose
-# history for the target. Appearance in history = was a declared service at
-# some point = needs human review before removal.
-
-KLAI_INFRA_CANDIDATES=(
-    "$CLAUDE_PROJECT_DIR/../klai-infra"
-    "$CLAUDE_PROJECT_DIR/../../klai-infra"
-    "/opt/klai-infra"
-)
-for candidate in "${KLAI_INFRA_CANDIDATES[@]}"; do
+# Locate klai-infra checkout once; reuse across targets
+KLAI_INFRA=""
+for candidate in \
+    "$CLAUDE_PROJECT_DIR/../klai-infra" \
+    "$CLAUDE_PROJECT_DIR/../../klai-infra" \
+    "$CLAUDE_PROJECT_DIR/klai-infra" \
+    "/opt/klai-infra"; do
     if [[ -d "$candidate/.git" ]]; then
-        # 2s timeout — git log on a small repo is fast; bail if anything weird
-        if timeout 2 git -C "$candidate" log --all -p -- 'deploy/docker-compose*.yml' 2>/dev/null | grep -qE "container_name:[[:space:]]*$TARGET\b|^[[:space:]]+$TARGET:[[:space:]]*$" ; then
+        KLAI_INFRA="$candidate"
+        break
+    fi
+done
+
+# Iterate over every target; first hard-match wins (block immediately).
+for TARGET in "${TARGETS[@]}"; do
+    # Check 2: tenant-naam / klasse-B prefix pattern
+    if [[ "$TARGET" =~ -voys$|-getklai$|-[a-z]+-tenant$ ]] || [[ "$TARGET" =~ ^librechat- ]]; then
+        emit_block "$TARGET matches a tenant-managed naming pattern ($OPERATION). If this is a portal-api-provisioning-managed tenant container (klasse B, see SPEC REQ-2), use the deprovision flow instead: portal-api orchestrator.deprovision_tenant() — never delete directly via 'docker rm'. If this is a different match, verify customer impact and override with explicit user approval."
+    fi
+
+    # Check 3: compose git-history (best-effort)
+    if [[ -n "$KLAI_INFRA" ]]; then
+        if timeout 2 git -C "$KLAI_INFRA" log --all -p -- 'deploy/docker-compose*.yml' 2>/dev/null | grep -qE "container_name:[[:space:]]*$TARGET\b|^[[:space:]]+$TARGET:[[:space:]]*$" ; then
             emit_block "$TARGET previously appeared as a service in klai-infra/deploy/docker-compose*.yml history. Verify why it was removed before deleting the runtime artifact."
         fi
-        break
     fi
 done
 

--- a/.claude/hooks/klai/container-hygiene-preflight.sh
+++ b/.claude/hooks/klai/container-hygiene-preflight.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# PreToolUse hook: block destructive docker-actions on production-like targets
+#
+# Blocks: docker rm/rmi/volume rm/system prune, docker compose down --volumes,
+#         and aggressive prune flags (image prune -af, volume prune).
+# Run-time guard against the librechat-voys class of incidents:
+# productie-tenant container removed because it lacked compose labels.
+#
+# Five checks for `docker rm/rmi/volume rm <target>`:
+#   1. Hard-block dangerous global prunes (volume prune / image prune -af)
+#   2. Tenant-naam pattern match (-voys, -getklai, -<klant>)
+#   3. Compose history check (was target ever a declared service?)
+#   4. Caddy upstream check (only when klai-infra checkout is reachable)
+#   5. VictoriaLogs orphan-audit cross-check (only when MCP / curl reachable)
+#
+# Checks 4 + 5 are best-effort — fail-open if klai-infra checkout absent or
+# core-01 unreachable (dev-machine without VPN). Checks 1 + 2 are always-on.
+# Hook MUST stay <2s to keep PreToolUse latency acceptable.
+#
+# Exit 0 = allow, exit 2 = block (with JSON decision payload on stdout).
+#
+# SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-1.
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+# JSON parsing: prefer python3 (Linux/Mac), fall back to python (Windows),
+# fall back to sed (no Python at all). The sed fallback is approximate but
+# good enough for docker-command extraction — escaped quotes in commands
+# would be rare and the fail-closed checks (1) still cover them.
+PY_BIN=""
+if command -v python3 >/dev/null 2>&1 && python3 -c "import sys" >/dev/null 2>&1; then
+    PY_BIN="python3"
+elif command -v python >/dev/null 2>&1 && python -c "import sys" >/dev/null 2>&1; then
+    PY_BIN="python"
+fi
+
+if [[ -n "$PY_BIN" ]]; then
+    COMMAND=$(echo "$INPUT" | "$PY_BIN" -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    print(d.get('tool_input', {}).get('command', ''))
+except Exception:
+    pass
+" 2>/dev/null || echo "")
+else
+    # sed fallback: extract value of "command":"..." (best-effort)
+    COMMAND=$(echo "$INPUT" | sed -nE 's/.*"command"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/p' | head -1)
+fi
+
+# Fast-path: not a docker command
+if ! echo "$COMMAND" | grep -qE '\bdocker\b'; then
+    exit 0
+fi
+
+emit_block() {
+    local reason="$1"
+    if [[ -n "$PY_BIN" ]]; then
+        "$PY_BIN" -c "
+import json, sys
+reason = sys.argv[1]
+print(json.dumps({
+  'decision': 'block',
+  'reason': f'BLOCKED by container-hygiene-preflight: {reason}\n\nSPEC-INFRA-CONTAINER-HYGIENE-001 REQ-1. Override only with explicit user approval.'
+}))
+" "$reason"
+    else
+        # Manual JSON build — escape backslashes and double-quotes
+        local esc="${reason//\\/\\\\}"
+        esc="${esc//\"/\\\"}"
+        printf '{"decision":"block","reason":"BLOCKED by container-hygiene-preflight: %s\\n\\nSPEC-INFRA-CONTAINER-HYGIENE-001 REQ-1. Override only with explicit user approval."}\n' "$esc"
+    fi
+    exit 2
+}
+
+# ─── Check 1: hard-block dangerous global prunes ──────────────────────────────
+# These never have a legitimate one-shot use case — REQ-6 systemd timer is the
+# canonical safe-cleanup path. If we ever need a one-off, the user runs it.
+
+if echo "$COMMAND" | grep -qE 'docker\s+volume\s+prune'; then
+    emit_block "docker volume prune — risk of klantdata loss. Use targeted 'docker volume rm <name>' after manual review."
+fi
+if echo "$COMMAND" | grep -qE 'docker\s+image\s+prune\s+-a\s*f|docker\s+image\s+prune\s+-af|docker\s+image\s+prune\s+--all\s+--force'; then
+    emit_block "docker image prune -af — can delete rollback-bare ghcr.io/getklai/* :sha tags. Use 'docker image prune -f' for dangling-only."
+fi
+if echo "$COMMAND" | grep -qE 'docker\s+system\s+prune\s+-a|docker\s+system\s+prune\s+--all'; then
+    emit_block "docker system prune -a — too broad. Use targeted prune commands (image -f, container -f)."
+fi
+if echo "$COMMAND" | grep -qE 'docker\s+compose\s+down\s+(-v|--volumes)'; then
+    emit_block "docker compose down --volumes — destroys named volumes. Stop containers without -v, then targeted volume rm if needed."
+fi
+
+# ─── Targeted destructive operations: extract target ──────────────────────────
+
+TARGET=""
+OPERATION=""
+
+# docker rm <name|id> [more]
+if [[ "$COMMAND" =~ docker[[:space:]]+rm[[:space:]]+(-f[[:space:]]+)?([a-zA-Z0-9_.-]+) ]]; then
+    TARGET="${BASH_REMATCH[2]}"
+    OPERATION="container removal"
+fi
+# docker rmi <name|sha> [more]
+if [[ -z "$TARGET" ]] && [[ "$COMMAND" =~ docker[[:space:]]+rmi[[:space:]]+(-f[[:space:]]+)?([a-zA-Z0-9_./:-]+) ]]; then
+    TARGET="${BASH_REMATCH[2]}"
+    OPERATION="image removal"
+fi
+# docker volume rm <name>
+if [[ -z "$TARGET" ]] && [[ "$COMMAND" =~ docker[[:space:]]+volume[[:space:]]+rm[[:space:]]+([a-zA-Z0-9_.-]+) ]]; then
+    TARGET="${BASH_REMATCH[1]}"
+    OPERATION="volume removal"
+fi
+
+# Nothing matched a destructive operation we know — allow
+if [[ -z "$TARGET" ]]; then
+    exit 0
+fi
+
+# ─── Check 2: tenant-naam pattern (always-on, lokaal) ─────────────────────────
+# A name ending in -voys, -getklai, or -<word>-tenant is a strong signal of a
+# customer-/tenant-specific container. Removing without explicit confirmation
+# is exactly the librechat-voys mistake.
+
+if [[ "$TARGET" =~ -voys$|-getklai$|-[a-z]+-tenant$ ]]; then
+    emit_block "$TARGET matches a tenant-specific naming pattern ($OPERATION). Verify customer impact before removal."
+fi
+
+# ─── Check 3: compose git-history (best-effort, lokaal) ───────────────────────
+# If a klai-infra checkout exists alongside this repo, search its compose
+# history for the target. Appearance in history = was a declared service at
+# some point = needs human review before removal.
+
+KLAI_INFRA_CANDIDATES=(
+    "$CLAUDE_PROJECT_DIR/../klai-infra"
+    "$CLAUDE_PROJECT_DIR/../../klai-infra"
+    "/opt/klai-infra"
+)
+for candidate in "${KLAI_INFRA_CANDIDATES[@]}"; do
+    if [[ -d "$candidate/.git" ]]; then
+        # 2s timeout — git log on a small repo is fast; bail if anything weird
+        if timeout 2 git -C "$candidate" log --all -p -- 'deploy/docker-compose*.yml' 2>/dev/null | grep -qE "container_name:[[:space:]]*$TARGET\b|^[[:space:]]+$TARGET:[[:space:]]*$" ; then
+            emit_block "$TARGET previously appeared as a service in klai-infra/deploy/docker-compose*.yml history. Verify why it was removed before deleting the runtime artifact."
+        fi
+        break
+    fi
+done
+
+# ─── Check 4 + 5: Caddy upstream + VictoriaLogs traffic (best-effort) ─────────
+# These require core-01 reachability. Fail-open on dev machines without VPN —
+# Check 2 + 3 cover the common-case dangers. Server-side detection happens via
+# REQ-5 audit-stream (independent of this hook).
+#
+# Implementation deferred to a follow-up — initial PR keeps the hook hermetic
+# (no SSH, no curl) so it stays under 500ms and works for offline dev.
+# When core-01 reachability detection is added, gate behind a fast TCP
+# probe (timeout 1s) and skip silently on failure.
+
+# All checks passed — allow
+exit 0

--- a/.claude/rules/klai/infra/container-hygiene.md
+++ b/.claude/rules/klai/infra/container-hygiene.md
@@ -15,17 +15,50 @@ paths:
 
 On 2026-05-02 the `librechat-voys` production container (Voys-tenant
 chat) was removed by a cleanup-agent because it lacked
-`com.docker.compose.project=klai-core` labels. It was running via a
-manual `docker run` rather than as a compose service, and the Caddyfile
-didn't route to it on the time of inspection — both signals pointed at
-"orphan, safe to delete". The container was, in fact, the canonical
-runtime artifact for the Voys tenant. Recovery was possible because the
-tenant config (`/opt/klai/librechat/voys/`) survived, but the original
-image SHA (untagged, never in any registry) was lost permanently.
+`com.docker.compose.project=klai-core` labels. The cleanup framing was:
+"no compose label + no Caddy upstream = wees, safe to delete." The
+container was, in fact, a legitimate **provisioning-managed** prod
+container — created dynamically by portal-api per tenant, not by
+compose. Recovery was possible because the tenant config
+(`/opt/klai/librechat/voys/`) survived, but the original image SHA
+(untagged, never in any registry) was lost permanently.
 
-The class: a destructive `docker rm`/`rmi`/`volume rm` on a target whose
-"orphan" appearance is fully consistent with being legitimately
-production-relevant.
+The class: a destructive `docker rm`/`rmi`/`volume rm` on a target
+whose "orphan" appearance is fully consistent with being a legitimate
+prod container managed by a non-compose pathway.
+
+## Two legitimate classes of prod containers
+
+Klai has two canonical management paths for prod containers. Hygiene
+tooling MUST recognise both:
+
+### Klasse A — Compose-managed
+
+- Created by `docker compose up` against
+  `klai-infra/deploy/docker-compose.yml`
+- Carries `com.docker.compose.project=klai-core` (and
+  `com.docker.compose.service=<naam>`) labels automatically
+- Examples: `klai-core-portal-api-1`, `klai-core-redis-1`,
+  `librechat-getklai`, `librechat-dev`
+- Cleanup: through compose (`docker compose down`, `--remove-orphans`)
+
+### Klasse B — Provisioning-managed
+
+- Created by portal-api via `client.containers.run()` per tenant
+- Source: `klai-portal/backend/app/services/provisioning/infrastructure.py::_start_librechat_container`
+- MUST carry these three labels (SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-2a):
+  - `klai.managed_by=portal-api-provisioning`
+  - `klai.tenant_slug=<slug>` (e.g. `voys`, `acme-corp`)
+  - `klai.kind=librechat` (other kinds may follow if portal-api
+    provisions more types in future)
+- Example: `librechat-voys`, `librechat-<future-tenant>`
+- Cleanup: through portal-api deprovisioning flow
+  (`provisioning/orchestrator.py::deprovision_tenant`), NEVER via
+  direct `docker rm`
+
+A container without ANY of these labels (and without a
+`klai.adhoc=*` opt-in for ad-hoc debug — see below) is a wees and
+warrants human review before removal.
 
 ## How we block it now
 
@@ -35,15 +68,18 @@ Two layers, both mechanical:
 
 `.claude/hooks/klai/container-hygiene-preflight.sh` runs before every
 Bash tool-call. If the command matches a destructive docker pattern, it
-runs five checks and `exit 2` blocks the tool-call:
+runs checks and `exit 2` blocks the tool-call:
 
 1. **Hard-block dangerous global prunes:** `docker volume prune`,
    `docker image prune -af`, `docker system prune -a`,
    `docker compose down --volumes`. These never have a one-shot
    legitimate use — REQ-6's daily `docker-cleanup.timer` is the canonical
    safe-cleanup path.
-2. **Tenant-naam pattern match:** target ends in `-voys`, `-getklai`,
-   or `-<word>-tenant`. Hard block — verify customer impact first.
+2. **Tenant-pattern match:** target matches `librechat-*` (klasse-B
+   provisioning-managed) OR ends in `-voys`/`-getklai`/`-<word>-tenant`.
+   Hard block; the message points at the deprovisioning flow because
+   direct `docker rm` on a klasse-B container bypasses Mongo/Caddy/
+   Meilisearch cleanup that portal-api orchestrates.
 3. **Compose git-history grep:** if `klai-infra` checkout reachable,
    search `deploy/docker-compose*.yml` history for the target. Match
    means it was a declared service at some point — needs review.

--- a/.claude/rules/klai/infra/container-hygiene.md
+++ b/.claude/rules/klai/infra/container-hygiene.md
@@ -1,0 +1,131 @@
+---
+paths:
+  - "**/docker-compose*.yml"
+  - "**/Dockerfile"
+  - ".github/**/*.yml"
+  - "**/*.sh"
+  - "**/Caddyfile"
+---
+# Container Hygiene
+
+> Mechanical guards against the librechat-voys class of incidents.
+> SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-1.
+
+## The bug we are preventing
+
+On 2026-05-02 the `librechat-voys` production container (Voys-tenant
+chat) was removed by a cleanup-agent because it lacked
+`com.docker.compose.project=klai-core` labels. It was running via a
+manual `docker run` rather than as a compose service, and the Caddyfile
+didn't route to it on the time of inspection — both signals pointed at
+"orphan, safe to delete". The container was, in fact, the canonical
+runtime artifact for the Voys tenant. Recovery was possible because the
+tenant config (`/opt/klai/librechat/voys/`) survived, but the original
+image SHA (untagged, never in any registry) was lost permanently.
+
+The class: a destructive `docker rm`/`rmi`/`volume rm` on a target whose
+"orphan" appearance is fully consistent with being legitimately
+production-relevant.
+
+## How we block it now
+
+Two layers, both mechanical:
+
+### Layer 1 — PreToolUse hook (this rule's enforcement)
+
+`.claude/hooks/klai/container-hygiene-preflight.sh` runs before every
+Bash tool-call. If the command matches a destructive docker pattern, it
+runs five checks and `exit 2` blocks the tool-call:
+
+1. **Hard-block dangerous global prunes:** `docker volume prune`,
+   `docker image prune -af`, `docker system prune -a`,
+   `docker compose down --volumes`. These never have a one-shot
+   legitimate use — REQ-6's daily `docker-cleanup.timer` is the canonical
+   safe-cleanup path.
+2. **Tenant-naam pattern match:** target ends in `-voys`, `-getklai`,
+   or `-<word>-tenant`. Hard block — verify customer impact first.
+3. **Compose git-history grep:** if `klai-infra` checkout reachable,
+   search `deploy/docker-compose*.yml` history for the target. Match
+   means it was a declared service at some point — needs review.
+4. **Caddy upstream check:** target reachable via `/opt/klai/Caddyfile`
+   (best-effort, only when core-01 reachable — fail-open on dev).
+5. **VictoriaLogs traffic check:** target had log-events in last 30d
+   (best-effort — fail-open on dev).
+
+Checks 1 + 2 are always-on; 3 is best-effort with a klai-infra
+sibling checkout; 4 + 5 are deferred to a follow-up that adds a fast
+TCP probe before they activate.
+
+The hook is registered in `.claude/settings.json` as a PreToolUse
+matcher on `Bash` alongside `portal-api-preflight.sh`.
+
+### Layer 2 — VictoriaLogs orphan-audit (REQ-5, separate stage)
+
+A weekly `docker-orphan-audit.sh` running on core-01 emits structlog
+events to VictoriaLogs (`service:klai-orphan-audit`) describing every
+container without compose label, every container with a tenant-pattern
+naam without Caddy upstream, every untagged image >30d, etc. The hook
+queries this stream as Check 5 (after that stage lands); operators
+inspect via Grafana panel.
+
+This is the catch-net for everything Layer 1 cannot see — including
+manual `ssh core-01 "docker rm"` from outside Claude Code.
+
+## What this rule does NOT do
+
+- Does NOT replace human review. A blocked command can be a
+  legitimate cleanup — the user can take ownership and proceed with
+  explicit approval. The block forces the conversation, not the
+  decision.
+- Does NOT cover all destructive docker operations. `docker stop`,
+  `docker kill`, `docker container restart` are not blocked because
+  they are reversible. `docker exec ... rm -rf /...` inside a
+  container is also not blocked — that's a different class.
+- Does NOT enforce alles-via-compose at deploy time. That is REQ-2's
+  CI guard (`audit-compose-orphans.sh` in the klai-infra
+  `audit-compose.yml` workflow) — separate stage.
+- Does NOT work for SSH-routed commands. `ssh core-01 "docker rm X"`
+  is one tool-call (`Bash` of the SSH command); the hook sees the
+  outer shell and the regex catches the docker invocation.
+  Multi-line scripts and indirect invocations may not match — REQ-5
+  audit is the detection-net for those.
+
+## When the hook blocks something legitimate
+
+A block is not a verdict. Common false-positive causes and the
+override path:
+
+| Cause | Override |
+|---|---|
+| Container name happens to end in `-voys` etc. but is a test fixture | Rename the test fixture, or use a `--label klai.adhoc=YYYY-MM-DD-reason` and `--rm` on creation so it self-cleans |
+| Compose history match on a service that was renamed | Confirm the old name truly has no consumers, then run the command via SSH bypassing the hook (`ssh core-01 "docker rm X"`) — but **document the override** in the PR message or commit. |
+| Image SHA blocked because it's referenced in compose | Verify by running `docker compose config | grep <sha>` — if true match, do NOT delete. If stale reference, fix the compose file first. |
+
+## Ad-hoc debug containers — the safe path
+
+For one-off testing, never `docker run` without `--rm` and never
+without a label:
+
+```bash
+docker run --rm \
+  --label klai.adhoc=2026-05-02-debug-csv-export \
+  --label klai.owner=mark.vletter \
+  ghcr.io/getklai/portal-api:latest <cmd>
+```
+
+`--rm` makes it self-clean on exit. The labels make it filter-able in
+REQ-5 audit (so it appears in an "ad-hoc" section, not a "wees"
+section). The `klai.owner` makes responsibility traceable.
+
+A long-running debug session that survives multiple commands? Promote
+it to a compose service in `klai-infra/deploy/docker-compose.yml`
+under a clear `# debug` comment-block, even temporarily. The hook +
+audit are designed around compose-as-source-of-truth.
+
+## Related
+
+- `pitfalls/process-rules.md` — `container-cleanup-without-preflight (HIGH)`
+- `infra/deploy.md` — CI deploy verification + atomic env writes
+- `infra/observability.md` — VictoriaLogs / Grafana / product_events split
+- `platform/docker-socket-proxy.md` — what tool to use for which Docker
+  operation (and what NOT to use docker exec for)

--- a/.claude/rules/klai/pitfalls/process-rules.md
+++ b/.claude/rules/klai/pitfalls/process-rules.md
@@ -519,23 +519,41 @@ adding the shared `klai-log-utils` path-dep silently broke its build.
 ## container-cleanup-without-preflight (HIGH)
 When you face a "wees-uitziende" container — no
 `com.docker.compose.project` label, no Caddy upstream, untagged image —
-do NOT treat the absence of those signals as a verdict to delete. Run
-the pre-cleanup checks first. The librechat-voys incident (2026-05-02)
-is the canonical case: the production Voys-tenant chat container was
-running via a manual `docker run` (no compose label) and had been
-disconnected from Caddy at some earlier point, so it appeared to be a
-wees in every cleanup-agent's view. It was, in fact, the canonical
-runtime artifact for the Voys tenant. Recovery succeeded only because
-`/opt/klai/librechat/voys/` (env-file + librechat.yaml) survived; the
-original image SHA (untagged, never registered) was permanently lost.
+do NOT treat the absence of those signals as a verdict to delete. Klai
+has TWO legitimate classes of prod containers:
+
+- **Klasse A — compose-managed:** `com.docker.compose.project=klai-core` label
+- **Klasse B — provisioning-managed:** `klai.managed_by=portal-api-provisioning`
+  + `klai.tenant_slug=<slug>` + `klai.kind=<type>` (gezet door
+  `_start_librechat_container` per SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-2a)
+
+A container without ANY of these labels AND without a `klai.adhoc=*`
+opt-in is a candidate wees, but verify before deleting.
+
+The librechat-voys incident (2026-05-02) is the canonical case. The
+production Voys-tenant chat container was klasse B (provisioning-managed
+by portal-api) but at the time the labels did not yet exist as a
+convention. The cleanup-agent (me) checked only for klasse-A label,
+saw none, also saw no current Caddy upstream, and concluded "wees".
+Wrong on both counts: the container was legitimate; Caddy upstream
+absence had a different cause (timing of provisioning vs. caddy
+reload). Recovery succeeded only because `/opt/klai/librechat/voys/`
+(env-file + librechat.yaml) survived; the original image SHA
+(untagged, never registered) was permanently lost.
 
 **Why this is a HIGH-class trap:** the signals that look like "orphan"
 are exactly the signals you'd expect from a legitimate
-production-relevant container that was provisioned outside the
-canonical compose flow. "No compose label" correlates strongly with
-rommel, not strongly with safe-to-delete. Tenant-specific names
-(`-voys`, `-getklai`, `-<klant>`) flip the prior: those are almost
-never test fixtures.
+production-relevant container managed via a non-compose pathway.
+"No compose label" correlates with rommel for klasse-A containers,
+NOT for klasse-B (provisioning-managed) containers. Tenant-specific
+names (`librechat-*`, `-voys`, `-getklai`, `-<klant>`) flip the prior:
+those are almost never test fixtures.
+
+**Tenant-deprovisioning is NOT just `docker rm`.** A klasse-B
+container belongs to a tenant whose Mongo user, Meilisearch index,
+Caddy upstream, and Redis cache need cleanup too. Use the portal-api
+deprovision flow (`provisioning/orchestrator.py::deprovision_tenant`)
+— never `docker rm` a `librechat-<slug>` directly.
 
 **Prevention (mechanical, not narrative):**
 

--- a/.claude/rules/klai/pitfalls/process-rules.md
+++ b/.claude/rules/klai/pitfalls/process-rules.md
@@ -516,6 +516,61 @@ adding the shared `klai-log-utils` path-dep silently broke its build.
   (`docker build -f <service>/Dockerfile .`) BEFORE pushing — the
   CI feedback loop is 3-5 min per attempt.
 
+## container-cleanup-without-preflight (HIGH)
+When you face a "wees-uitziende" container — no
+`com.docker.compose.project` label, no Caddy upstream, untagged image —
+do NOT treat the absence of those signals as a verdict to delete. Run
+the pre-cleanup checks first. The librechat-voys incident (2026-05-02)
+is the canonical case: the production Voys-tenant chat container was
+running via a manual `docker run` (no compose label) and had been
+disconnected from Caddy at some earlier point, so it appeared to be a
+wees in every cleanup-agent's view. It was, in fact, the canonical
+runtime artifact for the Voys tenant. Recovery succeeded only because
+`/opt/klai/librechat/voys/` (env-file + librechat.yaml) survived; the
+original image SHA (untagged, never registered) was permanently lost.
+
+**Why this is a HIGH-class trap:** the signals that look like "orphan"
+are exactly the signals you'd expect from a legitimate
+production-relevant container that was provisioned outside the
+canonical compose flow. "No compose label" correlates strongly with
+rommel, not strongly with safe-to-delete. Tenant-specific names
+(`-voys`, `-getklai`, `-<klant>`) flip the prior: those are almost
+never test fixtures.
+
+**Prevention (mechanical, not narrative):**
+
+1. Hook `.claude/hooks/klai/container-hygiene-preflight.sh` blocks
+   `docker rm`/`rmi`/`volume rm`/`system prune`/`compose down --volumes`
+   on any target matching tenant-naam patterns or appearing in
+   `klai-infra/deploy/docker-compose*.yml` history. Registered as
+   PreToolUse in `.claude/settings.json` alongside
+   `portal-api-preflight.sh`. SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-1.
+
+2. Hook hard-blocks `docker volume prune`, `docker image prune -af`,
+   `docker system prune -a`, `docker compose down --volumes`. Use
+   targeted `volume rm` after manual review or the systemd
+   `docker-cleanup.timer` (SPEC REQ-6) for safe daily prune.
+
+3. Weekly `klai-orphan-audit` (SPEC REQ-5) emits structlog events to
+   VictoriaLogs (`service:klai-orphan-audit`); cleanup-agents query
+   the stream BEFORE deciding via VictoriaLogs MCP. Caddy upstream
+   without container, container with tenant-naam without Caddy
+   upstream, untagged images >30d — all flagged for human review,
+   never auto-removed.
+
+4. Ad-hoc debug runs MUST use
+   `docker run --rm --label klai.adhoc=YYYY-MM-DD-reason --label klai.owner=<email>`
+   so they self-clean and appear in a separate "ad-hoc" audit
+   section, not in the "wees" section.
+
+**Why mechanical not narrative.** An AI is the primary code- and
+deploy-actor in this codebase. A markdown rule that "agents should
+read first" is a gap that re-opens with every context truncation,
+prompt variation, or new agent. The hook is the only enforcement that
+survives all those failure modes. The narrative rule
+`.claude/rules/klai/infra/container-hygiene.md` exists for human
+review and override-path documentation, not as the primary guard.
+
 ## parallel-spec-on-overlapping-log-sites (MED)
 When two SPECs land on the same call sites in the same file, the rebase
 or merge produces large, repetitive conflicts. SPEC-SEC-INTERNAL-001

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,6 +17,10 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/klai/portal-api-preflight.sh\""
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/klai/container-hygiene-preflight.sh\""
           }
         ]
       }

--- a/.github/workflows/audit-compose.yml
+++ b/.github/workflows/audit-compose.yml
@@ -1,24 +1,30 @@
-name: Audit compose volumes
+name: Audit compose (volumes + orphans)
 
 on:
   pull_request:
     paths:
       - 'deploy/docker-compose.yml'
+      - 'deploy/caddy/Caddyfile'
       - 'deploy/volume-mounts.yaml'
       - 'scripts/audit-compose-volumes.sh'
+      - 'scripts/audit-compose-orphans.sh'
       - 'scripts/test-audit-compose.sh'
+      - 'scripts/test-audit-compose-orphans.sh'
       - '.github/workflows/audit-compose.yml'
   push:
     branches: [main]
     paths:
       - 'deploy/docker-compose.yml'
+      - 'deploy/caddy/Caddyfile'
       - 'deploy/volume-mounts.yaml'
       - 'scripts/audit-compose-volumes.sh'
+      - 'scripts/audit-compose-orphans.sh'
       - 'scripts/test-audit-compose.sh'
+      - 'scripts/test-audit-compose-orphans.sh'
 
 jobs:
   audit:
-    name: audit-compose-volumes
+    name: audit-compose-volumes-and-orphans
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
@@ -40,8 +46,14 @@ jobs:
           yq --version
           jq --version
 
-      - name: Run audit
+      - name: Run volume audit
         run: bash scripts/audit-compose-volumes.sh
 
-      - name: Regression test — bug must be caught
+      - name: Volume regression test — bug must be caught
         run: bash scripts/test-audit-compose.sh
+
+      - name: Run orphan audit (SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-2c)
+        run: bash scripts/audit-compose-orphans.sh
+
+      - name: Orphan regression test — fixtures must catch known anti-patterns
+        run: bash scripts/test-audit-compose-orphans.sh

--- a/.github/workflows/caddy.yml
+++ b/.github/workflows/caddy.yml
@@ -53,7 +53,8 @@ jobs:
           key: ${{ secrets.CORE01_DEPLOY_KEY }}
           script: |
             docker pull ghcr.io/getklai/caddy-hetzner:latest
-            cd /opt/klai && docker compose up -d caddy
+            # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3
+            /opt/klai/scripts/compose-up.sh caddy
 
   scan:
     needs: build-push

--- a/.github/workflows/deploy-compose.yml
+++ b/.github/workflows/deploy-compose.yml
@@ -7,6 +7,7 @@ on:
       - 'deploy/docker-compose.yml'
       - 'deploy/docker-compose.override.yml'
       - 'deploy/grafana/provisioning/**'          # SPEC-SEC-024 M4.2 — alert rule + dashboard
+      - 'deploy/scripts/**'                       # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3 — compose-up wrapper + audit-orphan-snapshot
       - 'scripts/smoke-docker-socket-proxy.sh'    # SPEC-SEC-024 M4.3 — smoke-test
       - '.github/workflows/deploy-compose.yml'
   workflow_dispatch:
@@ -45,9 +46,28 @@ jobs:
               deploy/docker-compose.yml \
               deploy/docker-compose.override.yml \
               deploy/grafana/provisioning \
+              deploy/scripts \
+              deploy/systemd \
               scripts
             cp deploy/docker-compose.yml /opt/klai/docker-compose.yml
             cp deploy/docker-compose.override.yml /opt/klai/docker-compose.override.yml
+
+            # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3 + REQ-5: sync
+            # deploy-wrapper + audit scripts to /opt/klai/scripts/ so
+            # service-deploy workflows and systemd timers can use them.
+            mkdir -p /opt/klai/scripts
+            install -m 0755 deploy/scripts/compose-up.sh /opt/klai/scripts/compose-up.sh
+            install -m 0755 deploy/scripts/audit-orphan-snapshot.sh /opt/klai/scripts/audit-orphan-snapshot.sh
+            install -m 0755 deploy/scripts/docker-orphan-audit.sh /opt/klai/scripts/docker-orphan-audit.sh
+
+            # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-5 + REQ-6: sync systemd
+            # units. Activation requires sudo and is one-time per host —
+            # see docs/runbooks/container-hygiene-systemd-install.md.
+            mkdir -p /opt/klai/systemd
+            install -m 0644 deploy/systemd/docker-cleanup.service /opt/klai/systemd/docker-cleanup.service
+            install -m 0644 deploy/systemd/docker-cleanup.timer /opt/klai/systemd/docker-cleanup.timer
+            install -m 0644 deploy/systemd/orphan-audit.service /opt/klai/systemd/orphan-audit.service
+            install -m 0644 deploy/systemd/orphan-audit.timer /opt/klai/systemd/orphan-audit.timer
 
             # SPEC-SEC-024 M4.2 — sync Grafana provisioning. Grafana loads
             # provisioning only at startup, so we need to restart when files

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -89,5 +89,7 @@ jobs:
           username: klai
           key: ${{ secrets.CORE01_DEPLOY_KEY }}
           script: |
-            docker pull ghcr.io/getklai/klai-docs:latest
-            cd /opt/klai && docker compose up -d --no-deps docs-app
+            # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3: deploy via canonical
+            # wrapper so --remove-orphans and post-deploy snapshot run on
+            # every deploy, mechanically. Pilot workflow for the rollout.
+            /opt/klai/scripts/compose-up.sh --no-deps docs-app

--- a/.github/workflows/klai-connector.yml
+++ b/.github/workflows/klai-connector.yml
@@ -124,7 +124,8 @@ jobs:
             source /opt/klai/.env
             echo "$GHCR_READ_PAT" | docker login ghcr.io -u mvletter --password-stdin
             docker pull ghcr.io/getklai/klai-connector:latest
-            cd /opt/klai && docker compose up -d klai-connector
+            # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3
+            /opt/klai/scripts/compose-up.sh klai-connector
 
   scan:
     needs: build-push

--- a/.github/workflows/klai-knowledge-mcp.yml
+++ b/.github/workflows/klai-knowledge-mcp.yml
@@ -92,7 +92,8 @@ jobs:
             source /opt/klai/.env
             echo "$GHCR_READ_PAT" | docker login ghcr.io -u mvletter --password-stdin
             docker pull ghcr.io/getklai/klai-knowledge-mcp:latest
-            cd /opt/klai && docker compose up -d klai-knowledge-mcp
+            # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3
+            /opt/klai/scripts/compose-up.sh klai-knowledge-mcp
 
   scan:
     needs: build-push

--- a/.github/workflows/klai-mailer.yml
+++ b/.github/workflows/klai-mailer.yml
@@ -82,7 +82,8 @@ jobs:
             source /opt/klai/.env
             echo "$GHCR_READ_PAT" | docker login ghcr.io -u mvletter --password-stdin
             docker pull ghcr.io/getklai/klai-mailer:latest
-            cd /opt/klai && docker compose up -d klai-mailer
+            # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3
+            /opt/klai/scripts/compose-up.sh klai-mailer
 
   scan:
     needs: build-push

--- a/.github/workflows/knowledge-ingest.yml
+++ b/.github/workflows/knowledge-ingest.yml
@@ -90,7 +90,8 @@ jobs:
             source /opt/klai/.env
             echo "$GHCR_READ_PAT" | docker login ghcr.io -u mvletter --password-stdin
             docker pull ghcr.io/getklai/knowledge-ingest:latest
-            cd /opt/klai && docker compose up -d knowledge-ingest
+            # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3
+            /opt/klai/scripts/compose-up.sh knowledge-ingest
 
   scan:
     needs: build-push

--- a/.github/workflows/portal-api.yml
+++ b/.github/workflows/portal-api.yml
@@ -363,4 +363,5 @@ jobs:
             source /opt/klai/.env
             echo "$GHCR_READ_PAT" | docker login ghcr.io -u mvletter --password-stdin
             docker pull ghcr.io/getklai/portal-api:latest
-            cd /opt/klai && docker compose up -d portal-api
+            # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3
+            /opt/klai/scripts/compose-up.sh portal-api

--- a/.github/workflows/retrieval-api.yml
+++ b/.github/workflows/retrieval-api.yml
@@ -83,7 +83,8 @@ jobs:
             echo "$GHCR_READ_PAT" | docker login ghcr.io -u mvletter --password-stdin
             docker pull ghcr.io/getklai/retrieval-api:latest
             docker tag ghcr.io/getklai/retrieval-api:latest klai/retrieval-api:local
-            cd /opt/klai && docker compose up -d retrieval-api
+            # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3
+            /opt/klai/scripts/compose-up.sh retrieval-api
 
   scan:
     needs: build-push

--- a/.github/workflows/scribe-api.yml
+++ b/.github/workflows/scribe-api.yml
@@ -84,7 +84,8 @@ jobs:
             source /opt/klai/.env
             echo "$GHCR_READ_PAT" | docker login ghcr.io -u mvletter --password-stdin
             docker pull ghcr.io/getklai/scribe-api:latest
-            cd /opt/klai && docker compose up -d scribe-api
+            # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3
+            /opt/klai/scripts/compose-up.sh scribe-api
 
   scan:
     needs: build-push

--- a/.moai/specs/SPEC-INFRA-CONTAINER-HYGIENE-001/acceptance.md
+++ b/.moai/specs/SPEC-INFRA-CONTAINER-HYGIENE-001/acceptance.md
@@ -1,0 +1,149 @@
+# SPEC-INFRA-CONTAINER-HYGIENE-001 — Acceptance Criteria (v0.2.0)
+
+Zeven Given/When/Then scenarios. Elke AC is mechanisch verifieerbaar
+— geen mens-leesbaar rapport om te beoordelen, geen "agent zou X
+moeten doen". Alle checks via tool-output, exit-codes, query-resultaten.
+
+## AC-1 — Pre-tool hook blokkeert destructieve docker-acties
+
+- **Given** REQ-1 is uitgevoerd (`.claude/hooks/klai/container-hygiene-preflight.sh`
+  bestaat, `.claude/settings.json` heeft de PreToolUse-hook),
+- **When** een Claude-sessie probeert een Bash tool-call met commando
+  `docker rm librechat-voys` te draaien,
+- **Then** de tool-call returneert exit-code 1 met output bevattende
+  het woord "BLOCKED" (door één van de vijf checks geactiveerd —
+  vermoedelijk tenant-naam check), EN de container is NIET verwijderd
+  (verifieerbaar via `docker ps --filter name=librechat-voys`).
+
+**Test:** test-fixture met dummy `docker rm` poging, exit-code-assertie.
+Plus drie negatieve cases (`docker logs`, `docker ps`, `docker exec`)
+moeten exit-0 returnen — hook mag legitieme commando's niet blokkeren.
+
+## AC-2 — librechat-voys is compose-managed met juiste labels
+
+- **Given** REQ-2c PR is gemerged en de klai-infra deploy-workflow heeft
+  via `compose-up.sh` (REQ-3, of via het pre-REQ-3 pad indien REQ-3
+  nog niet uitgerold) op core-01 uitgevoerd,
+- **When** een Bash-command op core-01 draait
+  `docker inspect librechat-voys --format '{{index .Config.Labels
+  "com.docker.compose.project"}}'`,
+- **Then** de output is exact `klai-core` (niet leeg), EN
+  `docker inspect librechat-voys --format '{{index .Config.Labels
+  "com.docker.compose.service"}}'` returneert `librechat-voys`.
+
+**Test:** post-deploy verificatie-script in REQ-2c PR-body.
+
+## AC-3 — Deploy-wrapper + `--remove-orphans` werkt mechanisch
+
+- **Given** REQ-3 is uitgevoerd (alle 10 workflows roepen
+  `compose-up.sh` aan) EN REQ-2c is reeds gemerged + gedeployed,
+- **When** een opzettelijke "wees-test" wordt uitgevoerd: een test-
+  service `compose-orphan-test` wordt toegevoegd aan een
+  test-compose-bestand, gedeployd via dezelfde pipeline, dan uit het
+  compose-bestand verwijderd, en opnieuw gedeployd via
+  `compose-up.sh`,
+- **Then** na de tweede deploy is `compose-orphan-test` niet meer
+  running (`docker ps --filter name=compose-orphan-test --format
+  '{{.Names}}'` returns leeg), EN `librechat-voys` is NOG STEEDS
+  running (omdat hij compose-gedeclareerd is — anders zou `--remove-orphans`
+  hem ook hebben weggegooid).
+
+**Test:** scripted regression-test in `klai-infra/scripts/test-deploy-wrapper.sh`,
+runs op core-01 staging-equivalent of direct via dummy compose-file.
+
+## AC-4 — Daily safe cleanup timer draait succesvol
+
+- **Given** REQ-6 is uitgevoerd (`docker-cleanup.timer` is enabled +
+  active op core-01),
+- **When** 48 uur is verstreken sinds installatie en
+  `journalctl -u docker-cleanup.service --since '48h ago'` wordt
+  geraadpleegd,
+- **Then** ten minste 2 successful runs zijn zichtbaar (één per dag),
+  elk met exit-code 0, EN `docker images --filter dangling=true -q
+  | wc -l` returneert <50, EN `docker volume ls -q` returneert dezelfde
+  set named volumes als 48u geleden (geen volume-prune is uitgevoerd
+  — verifieerbaar via diff van pre/post lijsten).
+
+**Test:** verificatie-script `klai-infra/scripts/verify-cleanup-timer.sh`
+in REQ-6 PR.
+
+## AC-5 — Audit-stream is queryable in VictoriaLogs
+
+- **Given** REQ-5 is uitgevoerd (`orphan-audit.timer` is enabled +
+  active),
+- **When** de eerste zondag-03:00 voorbij is en een VictoriaLogs query
+  `service:klai-orphan-audit AND _time:[now-7d,now]` wordt gedraaid,
+- **Then** ten minste één event verschijnt (zelfs als het
+  `event:audit_run_completed` met `severity:info` is om aan te tonen
+  dat de audit succesvol draaide), EN er zijn nul `event:orphan_no_compose_label`
+  events (omdat na REQ-2c alle prod-containers compose-managed zijn,
+  modulo gelabelde `klai.adhoc=*` containers die in een eigen
+  event-type vallen).
+
+**Test:** VictoriaLogs MCP query van Claude-sessie of handmatig curl
+naar VictoriaLogs API. Eerste handmatige run als CI-validatie tijdens
+REQ-5 PR.
+
+## AC-6 — Audit-events zijn AI-bruikbaar in cleanup-context
+
+- **Given** AC-5 holdt (audit-stream is actief), EN REQ-1 hook
+  raadpleegt de stream als deel van check 5 (recent-traffic),
+- **When** een Claude-sessie probeert
+  `docker rm <een-container-met-recente-orphan-events>` te draaien,
+- **Then** de hook detecteert het orphan-event in VictoriaLogs en
+  blokkeert met een specifiek diagnose-bericht dat naar de
+  query-resultaten verwijst (bijv. "BLOCKED: target had 3 orphan_no_compose_label
+  events in last 7d — manual review required").
+
+**Test:** end-to-end test met dummy container die handmatig wordt
+gestart zonder labels, audit detecteert hem in volgende run, daarna
+poging tot `docker rm` wordt geblokkeerd door de hook met de juiste
+boodschap.
+
+## AC-7 — Pitfall-documentatie + CI-guard aanwezig
+
+- **Given** REQ-7 + REQ-2a zijn uitgevoerd,
+- **When** in deze repo
+  `grep -q "container-cleanup-without-preflight"
+  .claude/rules/klai/pitfalls/process-rules.md` draait, EN in
+  klai-infra CI op een PR die expliciet `librechat-voys` zonder
+  compose-block introduceert,
+- **Then** de grep returneert exit-0 (pitfall aanwezig), EN de
+  klai-infra CI faalt op de `audit-compose-orphans` step met een
+  duidelijke foutmelding ("librechat-voys staat in Caddyfile maar
+  niet in docker-compose.yml").
+
+**Test:** in deze repo via CI grep-step. In klai-infra via een
+expliciete regression-fixture in `test-audit-compose-orphans.sh` die
+exact deze faal-case set-up.
+
+## Run Acceptance Aggregate
+
+De SPEC is **acceptabel** wanneer:
+
+- AC-1 t/m AC-7 allemaal hold binnen 7 dagen na laatste deploy.
+- Geen productie-incident veroorzaakt door SPEC-deploys.
+- 30 dagen post REQ-6 go-live: dangling-image count consistent <50
+  (bewijst structurele werking van daily prune naast de bewust
+  geaccepteerde `:latest`-rolling-tags op klai-eigen images).
+- 30 dagen post REQ-1 go-live: ten minste 1 reële `event:hook_blocked`
+  event in VictoriaLogs (bewijst dat hook in productie minstens één
+  cleanup-poging mechanisch heeft gevangen).
+- 30 dagen post REQ-5 go-live: zero `event:orphan_no_compose_label`
+  events buiten gelabelde `klai.adhoc=*` containers (bewijst dat
+  REQ-2 alles-via-compose policy mechanisch wordt gehandhaafd).
+- librechat-voys recovery-werk is teruggebracht tot compose-managed
+  first-class service en kan niet meer per ongeluk wees-zijn (AC-2 +
+  AC-3 combinatie).
+
+## Wat dit NIET test
+
+- Server-side handmatige `ssh core-01 → docker rm` zonder Claude:
+  REQ-1 hook werkt alleen in Claude Code-context. Voor SSH is REQ-5
+  audit het detectie-vangnet, niet preventie.
+- Image-pinning compliance: geschrapt in v0.2.0; valt onder
+  `docs/runbooks/version-management.md` audit, niet deze SPEC.
+- Volume-data-integriteit: REQ-6 raakt geen volumes; volume-cleanup
+  blijft handmatig en out-of-scope.
+- Hook werking voor andere agents (niet Claude Code): niet getest;
+  REQ-5 audit is detectie-vangnet voor alle herkomst-paden.

--- a/.moai/specs/SPEC-INFRA-CONTAINER-HYGIENE-001/acceptance.md
+++ b/.moai/specs/SPEC-INFRA-CONTAINER-HYGIENE-001/acceptance.md
@@ -1,8 +1,11 @@
-# SPEC-INFRA-CONTAINER-HYGIENE-001 — Acceptance Criteria (v0.2.0)
+# SPEC-INFRA-CONTAINER-HYGIENE-001 — Acceptance Criteria (v0.3.0)
 
 Zeven Given/When/Then scenarios. Elke AC is mechanisch verifieerbaar
 — geen mens-leesbaar rapport om te beoordelen, geen "agent zou X
 moeten doen". Alle checks via tool-output, exit-codes, query-resultaten.
+
+v0.3.0 herzien: AC-2 verifieert nu provisioning-labels (klasse B) ipv
+compose-block; AC-5/6 herzien voor UNION van twee label-klasses.
 
 ## AC-1 — Pre-tool hook blokkeert destructieve docker-acties
 
@@ -10,112 +13,108 @@ moeten doen". Alle checks via tool-output, exit-codes, query-resultaten.
   bestaat, `.claude/settings.json` heeft de PreToolUse-hook),
 - **When** een Claude-sessie probeert een Bash tool-call met commando
   `docker rm librechat-voys` te draaien,
-- **Then** de tool-call returneert exit-code 1 met output bevattende
-  het woord "BLOCKED" (door één van de vijf checks geactiveerd —
-  vermoedelijk tenant-naam check), EN de container is NIET verwijderd
+- **Then** de tool-call returneert exit-code 2 met JSON-decision
+  payload bevattende het woord "BLOCKED" en een verwijzing naar de
+  portal-api deprovision-flow, EN de container is NIET verwijderd
   (verifieerbaar via `docker ps --filter name=librechat-voys`).
 
 **Test:** test-fixture met dummy `docker rm` poging, exit-code-assertie.
 Plus drie negatieve cases (`docker logs`, `docker ps`, `docker exec`)
 moeten exit-0 returnen — hook mag legitieme commando's niet blokkeren.
 
-## AC-2 — librechat-voys is compose-managed met juiste labels
+## AC-2 — Tenant-LibreChats dragen provisioning-labels (klasse B)
 
-- **Given** REQ-2c PR is gemerged en de klai-infra deploy-workflow heeft
-  via `compose-up.sh` (REQ-3, of via het pre-REQ-3 pad indien REQ-3
-  nog niet uitgerold) op core-01 uitgevoerd,
+- **Given** REQ-2a is uitgevoerd (code-fix in
+  `_start_librechat_container`) EN REQ-2b backfill is gedaan voor
+  bestaande containers,
 - **When** een Bash-command op core-01 draait
-  `docker inspect librechat-voys --format '{{index .Config.Labels
-  "com.docker.compose.project"}}'`,
-- **Then** de output is exact `klai-core` (niet leeg), EN
-  `docker inspect librechat-voys --format '{{index .Config.Labels
-  "com.docker.compose.service"}}'` returneert `librechat-voys`.
+  `docker inspect librechat-voys --format '{{json .Config.Labels}}'`,
+- **Then** de output bevat alle drie labels:
+  `klai.managed_by=portal-api-provisioning`,
+  `klai.tenant_slug=voys`, `klai.kind=librechat`. EN voor een
+  toekomstige tenant-provisioning roundtrip (test-fixture in
+  dev-stack): de nieuwe container heeft hetzelfde drie-tal labels
+  na `provision_tenant()`.
 
-**Test:** post-deploy verificatie-script in REQ-2c PR-body.
+**Test:**
+- Unit-test `test_infrastructure_labels.py`: mock docker-client,
+  verifieer `client.containers.run` werd aangeroepen met
+  `labels={'klai.managed_by': 'portal-api-provisioning',
+  'klai.tenant_slug': '<slug>', 'klai.kind': 'librechat'}`.
+- Post-backfill verificatie via `docker inspect` op core-01 in
+  PR-acceptance.
 
 ## AC-3 — Deploy-wrapper + `--remove-orphans` werkt mechanisch
 
 - **Given** REQ-3 is uitgevoerd (alle 10 workflows roepen
-  `compose-up.sh` aan) EN REQ-2c is reeds gemerged + gedeployed,
-- **When** een opzettelijke "wees-test" wordt uitgevoerd: een test-
-  service `compose-orphan-test` wordt toegevoegd aan een
-  test-compose-bestand, gedeployd via dezelfde pipeline, dan uit het
-  compose-bestand verwijderd, en opnieuw gedeployd via
-  `compose-up.sh`,
+  `compose-up.sh` aan) EN tenant-LibreChats dragen klasse-B labels
+  (AC-2 hold),
+- **When** een opzettelijke "wees-test" wordt uitgevoerd: een
+  test-service `compose-orphan-test` wordt toegevoegd, gedeployd, dan
+  uit compose verwijderd, en opnieuw gedeployd,
 - **Then** na de tweede deploy is `compose-orphan-test` niet meer
-  running (`docker ps --filter name=compose-orphan-test --format
-  '{{.Names}}'` returns leeg), EN `librechat-voys` is NOG STEEDS
-  running (omdat hij compose-gedeclareerd is — anders zou `--remove-orphans`
-  hem ook hebben weggegooid).
+  running, EN `librechat-voys` is NOG STEEDS running (omdat het
+  klasse-B labels draagt — `docker compose --remove-orphans` raakt
+  alleen klasse-A containers met dezelfde compose-project label).
 
-**Test:** scripted regression-test in `klai-infra/scripts/test-deploy-wrapper.sh`,
-runs op core-01 staging-equivalent of direct via dummy compose-file.
+**Test:** scripted regression `klai-infra/scripts/test-deploy-wrapper.sh`,
+runs op staging.
 
 ## AC-4 — Daily safe cleanup timer draait succesvol
 
-- **Given** REQ-6 is uitgevoerd (`docker-cleanup.timer` is enabled +
-  active op core-01),
-- **When** 48 uur is verstreken sinds installatie en
-  `journalctl -u docker-cleanup.service --since '48h ago'` wordt
-  geraadpleegd,
-- **Then** ten minste 2 successful runs zijn zichtbaar (één per dag),
-  elk met exit-code 0, EN `docker images --filter dangling=true -q
-  | wc -l` returneert <50, EN `docker volume ls -q` returneert dezelfde
-  set named volumes als 48u geleden (geen volume-prune is uitgevoerd
-  — verifieerbaar via diff van pre/post lijsten).
+- **Given** REQ-6 is uitgevoerd,
+- **When** 48 uur is verstreken sinds installatie,
+- **Then** ten minste 2 successful runs in `journalctl -u
+  docker-cleanup.service`, dangling-image count <50, named volumes
+  intact.
 
-**Test:** verificatie-script `klai-infra/scripts/verify-cleanup-timer.sh`
-in REQ-6 PR.
+**Test:** verificatie-script `klai-infra/scripts/verify-cleanup-timer.sh`.
 
-## AC-5 — Audit-stream is queryable in VictoriaLogs
+## AC-5 — Audit-stream queryable in VictoriaLogs (UNION-check)
 
-- **Given** REQ-5 is uitgevoerd (`orphan-audit.timer` is enabled +
-  active),
-- **When** de eerste zondag-03:00 voorbij is en een VictoriaLogs query
+- **Given** REQ-5 is uitgevoerd EN AC-2 hold (tenant-LibreChats
+  hebben labels),
+- **When** een VictoriaLogs query
   `service:klai-orphan-audit AND _time:[now-7d,now]` wordt gedraaid,
-- **Then** ten minste één event verschijnt (zelfs als het
-  `event:audit_run_completed` met `severity:info` is om aan te tonen
-  dat de audit succesvol draaide), EN er zijn nul `event:orphan_no_compose_label`
-  events (omdat na REQ-2c alle prod-containers compose-managed zijn,
-  modulo gelabelde `klai.adhoc=*` containers die in een eigen
-  event-type vallen).
+- **Then** ten minste één event verschijnt (audit_run_completed),
+  EN ZERO `event:orphan_no_managed_label` events voor running
+  productie-containers — omdat alle prod-containers nu OF
+  `com.docker.compose.project=klai-core` OF
+  `klai.managed_by=portal-api-provisioning` dragen, of een bewust
+  `klai.adhoc=*` opt-in.
 
-**Test:** VictoriaLogs MCP query van Claude-sessie of handmatig curl
-naar VictoriaLogs API. Eerste handmatige run als CI-validatie tijdens
-REQ-5 PR.
+**Test:** VictoriaLogs MCP query of curl.
 
-## AC-6 — Audit-events zijn AI-bruikbaar in cleanup-context
+## AC-6 — Audit-events worden door REQ-1 hook gebruikt (klasse-aware)
 
-- **Given** AC-5 holdt (audit-stream is actief), EN REQ-1 hook
-  raadpleegt de stream als deel van check 5 (recent-traffic),
+- **Given** AC-5 holdt EN REQ-1 hook raadpleegt VictoriaLogs in
+  Check 4,
 - **When** een Claude-sessie probeert
-  `docker rm <een-container-met-recente-orphan-events>` te draaien,
-- **Then** de hook detecteert het orphan-event in VictoriaLogs en
-  blokkeert met een specifiek diagnose-bericht dat naar de
-  query-resultaten verwijst (bijv. "BLOCKED: target had 3 orphan_no_compose_label
-  events in last 7d — manual review required").
+  `docker rm <container-met-recent-orphan-event>` te draaien (een
+  container die de audit-script heeft geflagd als label-loos),
+- **Then** de hook detecteert het orphan-event én blokkeert met
+  bericht dat naar de query-resultaten verwijst. EN: voor een
+  legitieme klasse-B container (drie labels aanwezig) genereert de
+  audit GEEN orphan-event, dus de hook valt terug op tenant-pattern
+  check (die alsnog blokkeert) — met diagnose "klasse B managed
+  container — use deprovision flow".
 
-**Test:** end-to-end test met dummy container die handmatig wordt
-gestart zonder labels, audit detecteert hem in volgende run, daarna
-poging tot `docker rm` wordt geblokkeerd door de hook met de juiste
-boodschap.
+**Test:** end-to-end test op dev-stack met dummy container scenarios.
 
-## AC-7 — Pitfall-documentatie + CI-guard aanwezig
+## AC-7 — Pitfall + CI-guard aanwezig
 
-- **Given** REQ-7 + REQ-2a zijn uitgevoerd,
+- **Given** REQ-7 + REQ-2c zijn uitgevoerd,
 - **When** in deze repo
   `grep -q "container-cleanup-without-preflight"
   .claude/rules/klai/pitfalls/process-rules.md` draait, EN in
-  klai-infra CI op een PR die expliciet `librechat-voys` zonder
-  compose-block introduceert,
-- **Then** de grep returneert exit-0 (pitfall aanwezig), EN de
-  klai-infra CI faalt op de `audit-compose-orphans` step met een
-  duidelijke foutmelding ("librechat-voys staat in Caddyfile maar
-  niet in docker-compose.yml").
+  klai-infra CI op een PR die expliciet een nieuwe `librechat-X` zonder
+  klasse-B labels introduceert (via een test-fixture die _start_librechat_container
+  bypassed),
+- **Then** grep returneert exit-0, EN klai-infra CI faalt op de
+  `audit-compose-orphans` step.
 
-**Test:** in deze repo via CI grep-step. In klai-infra via een
-expliciete regression-fixture in `test-audit-compose-orphans.sh` die
-exact deze faal-case set-up.
+**Test:** grep-step in klai CI; expliciete regression-fixture in
+`test-audit-compose-orphans.sh`.
 
 ## Run Acceptance Aggregate
 
@@ -123,27 +122,23 @@ De SPEC is **acceptabel** wanneer:
 
 - AC-1 t/m AC-7 allemaal hold binnen 7 dagen na laatste deploy.
 - Geen productie-incident veroorzaakt door SPEC-deploys.
-- 30 dagen post REQ-6 go-live: dangling-image count consistent <50
-  (bewijst structurele werking van daily prune naast de bewust
-  geaccepteerde `:latest`-rolling-tags op klai-eigen images).
-- 30 dagen post REQ-1 go-live: ten minste 1 reële `event:hook_blocked`
-  event in VictoriaLogs (bewijst dat hook in productie minstens één
-  cleanup-poging mechanisch heeft gevangen).
-- 30 dagen post REQ-5 go-live: zero `event:orphan_no_compose_label`
-  events buiten gelabelde `klai.adhoc=*` containers (bewijst dat
-  REQ-2 alles-via-compose policy mechanisch wordt gehandhaafd).
-- librechat-voys recovery-werk is teruggebracht tot compose-managed
-  first-class service en kan niet meer per ongeluk wees-zijn (AC-2 +
-  AC-3 combinatie).
+- 30 dagen post REQ-6 go-live: dangling-image count consistent <50.
+- 30 dagen post REQ-1 go-live: minstens 1 `event:hook_blocked` in
+  VictoriaLogs.
+- 30 dagen post REQ-2 + REQ-5 go-live: zero
+  `event:orphan_no_managed_label` events buiten gelabelde
+  `klai.adhoc=*` containers.
+- librechat-voys draagt klasse-B labels en kan niet meer per ongeluk
+  als wees worden weggegooid (AC-1 + AC-2 combinatie).
+- Toekomstige tenant-provisioning trajectoires landen automatisch met
+  juiste labels (REQ-2a code-fix is in `_start_librechat_container`).
 
 ## Wat dit NIET test
 
-- Server-side handmatige `ssh core-01 → docker rm` zonder Claude:
-  REQ-1 hook werkt alleen in Claude Code-context. Voor SSH is REQ-5
-  audit het detectie-vangnet, niet preventie.
-- Image-pinning compliance: geschrapt in v0.2.0; valt onder
-  `docs/runbooks/version-management.md` audit, niet deze SPEC.
-- Volume-data-integriteit: REQ-6 raakt geen volumes; volume-cleanup
-  blijft handmatig en out-of-scope.
-- Hook werking voor andere agents (niet Claude Code): niet getest;
-  REQ-5 audit is detectie-vangnet voor alle herkomst-paden.
+- Server-side handmatige `ssh core-01 → docker rm` zonder Claude.
+  REQ-5 audit is detectie-vangnet, niet preventie.
+- Image-pinning compliance (geschrapt in v0.2.0 SPEC; canoniek in
+  VERSIONS.md).
+- Volume-data-integriteit. REQ-6 raakt geen volumes.
+- Hook werking voor andere agents (niet Claude Code). REQ-5 audit is
+  detectie-vangnet voor alle herkomst-paden.

--- a/.moai/specs/SPEC-INFRA-CONTAINER-HYGIENE-001/plan.md
+++ b/.moai/specs/SPEC-INFRA-CONTAINER-HYGIENE-001/plan.md
@@ -1,208 +1,150 @@
-# SPEC-INFRA-CONTAINER-HYGIENE-001 — Implementation Plan (v0.2.0)
+# SPEC-INFRA-CONTAINER-HYGIENE-001 — Implementation Plan (v0.3.0)
 
 ## Approach
 
-Drie lagen, zes requirements (REQ-4 vervallen), strikt mechanisch.
-Het verschil met v0.1.0 is dat élke laag een mechaniek heeft die de
-fout-klasse onmogelijk maakt — geen "discipline", geen "rule",
-ofwel:
+Drie lagen, zes requirements (REQ-4 vervallen). v0.3.0 corrigeert de
+fundamentele aanname uit v0.2.0 dat alle prod-containers via compose
+managed worden. Klai heeft TWEE legitieme klassen prod-containers:
 
-- **Pre-tool guard** (REQ-1): hook in `.claude/settings.json` blokkeert
-  destructieve docker-acties tot een script de checks heeft gedraaid.
-  Een AI kan het niet vergeten of overslaan.
-- **CI-guard** (REQ-2a): PR die orphans introduceert faalt.
-- **Deploy-wrapper** (REQ-3): één script, alle workflows roepen het
-  aan, `--remove-orphans` zit ingebouwd.
-- **Detectie-stream** (REQ-5): VictoriaLogs events, AI queryt zelf
-  vóór beslissingen.
-- **Timer** (REQ-6): cron-equivalent, mechanisch.
+- **Compose-managed** (klasse A): label `com.docker.compose.project=klai-core`
+- **Provisioning-managed** (klasse B): label
+  `klai.managed_by=portal-api-provisioning` plus `klai.tenant_slug=<slug>`
+  en `klai.kind=<type>` — gezet door `_start_librechat_container` in
+  portal-api
 
-Volgorde-discipline blijft cruciaal: REQ-2c (librechat-voys in
-compose) **moet** vóór REQ-3 deploy-wrapper, anders wist
-`--remove-orphans` de container weer.
+REQ-1 hook, REQ-2 code-fix, REQ-2c CI-guard, en REQ-5 audit checken
+op de UNION van beide klasses. Een container zonder enige label uit
+beide klasses (en zonder `klai.adhoc=*` opt-in) is een wees.
+
+REQ-2c uit v0.2.0 (librechat-voys hard-coderen in compose) is vervangen
+door REQ-2a (label-fix in `_start_librechat_container`) plus
+REQ-2b (eenmalige backfill voor bestaande tenant-containers).
+
+Het werk verschuift van "klai-infra compose-edit" naar "klai code-edit
+in portal-api" — REQ-2a landt in dezelfde klai-repo PR als REQ-1+REQ-7.
+Dat versnelt de uitrol omdat de tenant-provisioning fix dichter bij de
+trigger ligt.
 
 ## Task Decomposition
 
-| # | Task | Files | Repo | Risk | Volgorde |
+| # | Task | Files | Repo | Risk | Stage |
 |---|---|---|---|---|---|
-| 1 | Schrijf preflight-hook script | `.claude/hooks/klai/container-hygiene-preflight.sh` | klai | Laag | 1 |
-| 2 | Registreer hook in settings.json | `.claude/settings.json` | klai | **Medium** (kan andere Bash-calls breken bij regex-fout) | 2 |
-| 3 | Schrijf narrative rule + pitfall | `.claude/rules/klai/infra/container-hygiene.md`, `.claude/rules/klai/pitfalls/process-rules.md` | klai | Laag | 3 |
-| 4 | Voeg `librechat-voys` compose-block toe (REQ-2c) | `deploy/docker-compose.yml` | klai-infra | **HIGH** | 4 |
-| 5 | Vervang draaiende `librechat-voys` op core-01 door compose-managed | core-01 ssh handmatig | runtime | **HIGH** (downtime ~30s) | 5 |
-| 6 | Schrijf `compose-up.sh` deploy-wrapper (REQ-3) | `deploy/scripts/compose-up.sh` | klai-infra | Medium | 6 |
-| 7 | Update `docs.yml` workflow als REQ-3 pilot | `.github/workflows/docs.yml` | klai-infra | Laag | 7 |
-| 8 | Update overige 9 service-workflows | `.github/workflows/{caddy,klai-connector,klai-knowledge-mcp,klai-mailer,knowledge-ingest,portal-api,retrieval-api,scribe-api,whisper-server}.yml` | klai-infra | **HIGH** (alle deploy-paden) | 8 |
-| 9 | Schrijf `audit-compose-orphans.sh` + regression test (REQ-2a) | `scripts/audit-compose-orphans.sh`, `scripts/test-audit-compose-orphans.sh` | klai-infra | Laag | 9 |
-| 10 | Breid `audit-compose.yml` workflow uit met orphan-step | `.github/workflows/audit-compose.yml` | klai-infra | Laag | 10 |
-| 11 | Schrijf `audit-orphan-snapshot.sh` post-deploy verifier (REQ-2b) | `scripts/audit-orphan-snapshot.sh` | klai-infra | Laag | 11 |
-| 12 | Schrijf systemd `docker-cleanup.{service,timer}` units (REQ-6) | `core-01/systemd/docker-cleanup.{service,timer}` | klai-infra | Laag | 12 |
-| 13 | Installeer + activeer cleanup-timer op core-01 | `systemctl link`, `enable --now` | runtime | Laag | 13 |
-| 14 | Schrijf `docker-orphan-audit.sh` event-emitter (REQ-5) | `scripts/docker-orphan-audit.sh` | klai-infra | Laag | 14 |
-| 15 | Schrijf systemd `orphan-audit.{service,timer}` units | `core-01/systemd/orphan-audit.{service,timer}` | klai-infra | Laag | 15 |
-| 16 | Installeer + activeer audit-timer op core-01 | `systemctl link`, `enable --now` | runtime | Laag | 16 |
-| 17 | Configureer Grafana panel + alert op audit-stream | Grafana UI / dashboard JSON | klai-infra | Laag | 17 |
+| 1 | preflight-hook script (basis) | `.claude/hooks/klai/container-hygiene-preflight.sh` | klai | Laag | 1 (done) |
+| 2 | hook in settings.json | `.claude/settings.json` | klai | Laag | 1 (done) |
+| 3 | narrative rule + pitfall (basis) | `.claude/rules/klai/infra/container-hygiene.md`, `.claude/rules/klai/pitfalls/process-rules.md` | klai | Laag | 1 (done) |
+| 4 | REQ-2a: labels in `_start_librechat_container` + tests | `klai-portal/backend/app/services/provisioning/infrastructure.py`, `klai-portal/backend/tests/services/provisioning/test_infrastructure_labels.py` | klai | Medium | 1.5 |
+| 5 | Hook update: block-bericht verwijst naar provisioning-flow | hook script | klai | Laag | 1.5 |
+| 6 | Narrative + pitfall: twee-klassen sectie | rule + pitfall | klai | Laag | 1.5 |
+| 7 | REQ-2b: handmatige re-run librechat-voys met labels | core-01 ssh handmatig | runtime | Medium (~30s downtime) | 1.5 |
+| 8 | REQ-3: `compose-up.sh` deploy-wrapper | `deploy/scripts/compose-up.sh` | klai-infra | Medium | 2 |
+| 9 | REQ-3 pilot: `docs.yml` workflow | `.github/workflows/docs.yml` | klai-infra | Laag | 2 |
+| 10 | REQ-3 rollout: 9 overige workflows | `.github/workflows/*.yml` | klai-infra | **HIGH** | 3 |
+| 11 | REQ-2c: `audit-compose-orphans.sh` + regression | `scripts/audit-compose-orphans.sh`, `scripts/test-audit-compose-orphans.sh` | klai-infra | Laag | 4 |
+| 12 | `audit-compose.yml` workflow uitbreiden | `.github/workflows/audit-compose.yml` | klai-infra | Laag | 4 |
+| 13 | REQ-2d: `audit-orphan-snapshot.sh` post-deploy | `scripts/audit-orphan-snapshot.sh` | klai-infra | Laag | 4 |
+| 14 | REQ-6: systemd `docker-cleanup.{service,timer}` | `core-01/systemd/docker-cleanup.{service,timer}` | klai-infra | Laag | 5 |
+| 15 | Activeer cleanup-timer op core-01 | `systemctl link`, `enable --now` | runtime | Laag | 5 |
+| 16 | REQ-5: `docker-orphan-audit.sh` event-emitter | `scripts/docker-orphan-audit.sh` | klai-infra | Laag | 6 |
+| 17 | systemd `orphan-audit.{service,timer}` | `core-01/systemd/orphan-audit.{service,timer}` | klai-infra | Laag | 6 |
+| 18 | Activeer audit-timer op core-01 | `systemctl link`, `enable --now` | runtime | Laag | 6 |
+| 19 | Grafana panel + alert | dashboard JSON | klai-infra | Laag | 6 |
 
-Tasks 1–3 vallen in één klai-PR (alle zelfstandig in deze repo, geen
-externe afhankelijkheden). Tasks 4–17 vallen in 4–6 kleinere klai-infra
-PRs voor regressie-isolatie.
+Tasks 1-3 reeds compleet (Stage 1, commit `55964c56`). Tasks 4-7 in
+Stage 1.5 (deze klai-PR uitbreiding). Tasks 8+ in klai-infra stages.
 
-## Files Affected
+## Files Affected (delta v0.3.0)
 
-### klai (deze repo)
+### klai (deze repo) — toegevoegd in v0.3.0
 
-- **Nieuw:** `.claude/hooks/klai/container-hygiene-preflight.sh`
-  (~80 regels bash + jq parsing).
-- **Uitgebreid:** `.claude/settings.json` — PreToolUse hook entry
-  (~5 regels JSON).
-- **Nieuw:** `.claude/rules/klai/infra/container-hygiene.md`
-  (~80 regels narrative).
-- **Uitgebreid:** `.claude/rules/klai/pitfalls/process-rules.md` —
-  pitfall toevoeging (~40 regels).
-- **Bestaand:** `.moai/specs/SPEC-INFRA-CONTAINER-HYGIENE-001/*.md`.
+- **Uitgebreid:** `klai-portal/backend/app/services/provisioning/infrastructure.py`
+  — `labels={...}` in `client.containers.run()` van
+  `_start_librechat_container` (REQ-2a, ~5 regels code).
+- **Nieuw:** `klai-portal/backend/tests/services/provisioning/test_infrastructure_labels.py`
+  — verifieert labels-aanwezigheid via mock van docker-client.
+- **Uitgebreid:** `.claude/hooks/klai/container-hygiene-preflight.sh`
+  — block-bericht voor tenant-pattern verwijst naar
+  provisioning-deprovision-flow.
+- **Uitgebreid:** `.claude/rules/klai/infra/container-hygiene.md`
+  — sectie "Twee legitieme klassen" + label-conventie.
+- **Uitgebreid:** `.claude/rules/klai/pitfalls/process-rules.md`
+  — pitfall-tekst genuanceerd voor tenant-provisioning klasse.
 
-### klai-infra (cross-repo)
+### klai-infra (cross-repo) — minor delta
 
-- **Nieuw:** `deploy/scripts/compose-up.sh` (~30 regels bash).
-- **Nieuw:** `scripts/audit-compose-orphans.sh` (~80 regels bash + yq).
-- **Nieuw:** `scripts/test-audit-compose-orphans.sh` (~50 regels
-  fixture-based regression test, volgt
-  `scripts/test-audit-compose.sh` patroon).
-- **Nieuw:** `scripts/audit-orphan-snapshot.sh` (~50 regels bash).
-- **Nieuw:** `scripts/docker-orphan-audit.sh` (~150 regels bash + jq +
-  curl naar VictoriaLogs).
-- **Uitgebreid:** `deploy/docker-compose.yml` — `librechat-voys`
-  service-block (~22 regels).
-- **Uitgebreid:** `.github/workflows/audit-compose.yml` — extra step
-  voor orphan-check (~6 regels).
-- **Uitgebreid:** 10 service-deploy-workflows — `docker compose up`
-  vervangen door `ssh core-01 "/opt/klai/deploy/scripts/compose-up.sh
-  <service>"` (~2 regels per workflow).
-- **Nieuw:** `core-01/systemd/docker-cleanup.{service,timer}`.
-- **Nieuw:** `core-01/systemd/orphan-audit.{service,timer}`.
+REQ-2c CI-guard accepteert nu naast compose-service-namen óók
+`librechat-*` als geldige naam-pattern. REQ-2d en REQ-5 scripts
+checken UNION van beide labels.
 
-### Operator-acties op core-01 (geen Git, runtime)
+## Technology Choices (delta v0.3.0)
 
-- Eenmalig: vervang draaiende `librechat-voys` door compose-managed
-  variant (`docker stop && docker rm && cd /opt/klai && docker compose
-  up -d librechat-voys`) — uit te voeren na merge van REQ-2c PR.
-- `systemctl link` + `enable --now` voor `docker-cleanup.timer`
-  (na merge van REQ-6 PR).
-- `systemctl link` + `enable --now` voor `orphan-audit.timer`
-  (na merge van REQ-5 PR).
-- Grafana-panel JSON importeren in dashboard.
+- **Labels via `client.containers.run(labels=...)`** — Docker labels
+  zijn immutable na container creation. Voor backfill: container
+  recreate met nieuwe args.
+- **Drie aparte labels** ipv één geconcateneerde — Docker label-filter
+  ondersteunt key-based filtering (`docker ps --filter label=klai.managed_by=...`).
+- **`klai.*` namespace** — convention-aligned met `klai.adhoc` uit
+  REQ-7. Reserveert namespace voor toekomstige uitbreidingen.
 
-## Technology Choices
-
-- **Bash over Python** voor alle scripts — geen runtime-deps op core-01,
-  past in bestaande `scripts/` patroon (zie `audit-compose-volumes.sh`,
-  `victorialogs-tunnel.sh`).
-- **PreToolUse hook over Skill of MCP-tool** — hook draait
-  mechanisch vóór elke matching tool-call zonder dat AI er expliciet om
-  vraagt. Skill of MCP-tool zou AI moeten aanroepen, dus terug bij
-  "vertrouw op discipline".
-- **Eén deploy-wrapper script over per-workflow flag** — DRY, single
-  source, AI die nieuwe workflow schrijft kopieert SSH-regel zonder
-  flag-discipline.
-- **VictoriaLogs over `product_events`** voor REQ-5 — ops-events horen
-  in observability stack, niet in business-event tabel. Past bij
-  bestaande Alloy → VictoriaLogs flow.
-- **Stdout-emit + Alloy-pickup over directe HTTP push** — script
-  hoeft geen VictoriaLogs auth te kennen, Alloy doet de heavy
-  lifting. Minder fragiele integratie.
-- **Systemd timer over cron** — `journalctl -u` logging, makkelijker
-  inspecteerbaar, modernere syntax.
-
-## Risks & Mitigations
+## Risks & Mitigations (delta v0.3.0)
 
 | Risk | Mitigation |
 |---|---|
-| REQ-1 hook regex matcht te breed en blokkeert legitieme `docker logs`/`ps` calls | Hook test-fixture in PR: drie blokkade-cases + drie doorlaat-cases. Pre-merge handmatige test in een dummy sessie. |
-| REQ-1 hook is te traag (5+s per Bash-call) en frustreert workflow | Hook MOET <5s zijn per spec; check 5 (VictoriaLogs traffic) is duurste — backoff naar 1s timeout. Idempotent caching van compose-history check. |
-| REQ-3 wist `librechat-voys` voor REQ-2c gemerged is | Volgorde-discipline: REQ-2c PR moet gemerged + gedeployed zijn vóór REQ-3 PR open gaat. AC-3 verifieert dit. |
-| REQ-3 deploy-wrapper failt en breekt alle 10 deploys tegelijk | Test REQ-3 op `docs.yml` als pilot vóór de andere 9. Pilot-deploy moet 24u live draaien zonder issues vóór bredere rollout. |
-| `--remove-orphans` blijkt nog ANDERE bestaande wezen te wissen | Vóór REQ-3 deploy-wrapper-pilot: draai REQ-5 audit-script eenmalig handmatig op core-01, review output, los onbekende wezen op vóór de wrapper live gaat. |
-| systemd timer faalt silent op core-01 | REQ-5 audit-script bevat een check op `journalctl -u docker-cleanup --since '24h ago'` — als geen successful run, audit-event `event:cleanup_timer_unhealthy` met `severity:critical`. Grafana alert. |
-| Audit-script vals-positief op legitiem ad-hoc debug-container | Audit-script respecteert `klai.adhoc=*` label — labeled containers vallen in eigen sectie ipv "wees" sectie. |
-| `.claude/settings.json` JSON-fout breekt alle hooks | Pre-merge: `jq < .claude/settings.json` moet exit-0. Pre-commit-hook in deze repo zou dit kunnen mechanisch maken (out of scope hier). |
-| Hook werkt niet voor `ssh core-01 "docker rm"` (commando is een string-argument van ssh) | Erkende beperking. Hook checkt het top-level Bash-commando; geneste SSH commands zijn niet afgevangen. REQ-5 audit is detectie-vangnet achteraf. |
-| Hook script vereist `jq`, `curl`, `git` lokaal — kan ontbreken op nieuwe dev-machines | Hook script begint met dependency-check; bij ontbreken exit-0 met waarschuwing (fail-open ipv fail-closed voor dev-vriendelijkheid; productie-bescherming via REQ-2/REQ-5). Discutabel — zie open vraag. |
+| `_start_librechat_container` patch breekt tenant-provisioning | Tests in `test_infrastructure_labels.py` mocken docker-client en verifiëren labels-aanwezigheid. |
+| Backfill librechat-voys faalt of veroorzaakt downtime | ~30s downtime, zelfde als recovery van vandaag. Backup `librechat.yaml` + env-file zijn al op disk. |
+| `librechat-getklai` (compose-managed) — moet die ook klasse-B labels? | NEE. Klasse A is sufficient. Audit-tools nemen UNION van beide klasses. |
+| Hook block-bericht verwijst naar deprovision-flow die niet bestaat | Portal-api heeft `deprovision_tenant` in `orchestrator.py` — block-bericht verwijst daarheen. |
 
-## Open vragen voor `/moai run`
+Overige risico's identiek aan v0.2.0.
 
-1. **Hook fail-mode bij ontbrekende deps:** fail-open (waarschuwen,
-   doorlaten) of fail-closed (blokkeren)? Fail-closed is veiliger;
-   fail-open is dev-vriendelijker. Voorkeur: fail-closed met `jq`,
-   `curl` als hard requirements (beide standaard op dev-machines via
-   brew/apt); `ssh core-01` reachability check fail-open omdat dev-
-   machines niet altijd VPN aan hebben.
-2. **Per-workflow `--remove-orphans` of globale env-var:** voor REQ-3
-   heb ik gekozen voor de wrapper. Maar als jullie `COMPOSE_REMOVE_ORPHANS=true`
-   in `/opt/klai/.env` zetten werkt het ook zonder wrapper. Voorkeur:
-   wrapper, omdat het ook REQ-2b post-deploy snapshot dezelfde
-   plek geeft. Maar het is uitwisselbaar.
-3. **VictoriaLogs auth in `audit-script`:** script schrijft naar
-   stdout, Alloy pickt op. Geen auth nodig in script. Bevestiging dat
-   Alloy alle stdout van containers zonder filter forward.
+## Open Vragen voor `/moai run` (delta v0.3.0)
 
-## Success Criteria
+1. **`librechat-getklai` óók klasse-B labels?** Voorkeur: nee, blijf
+   compose-managed. Beslissing tijdens REQ-2 review.
+2. **Toekomstige `klai.kind` waardes?** Voor nu alleen `librechat`.
+3. **Override-pad bij tenant-deprovisioning:** Operator via SSH
+   buiten Claude-sessie. Hook ziet dat niet. Gedocumenteerd in pitfall.
 
-- AC-1 t/m AC-7 (uit acceptance.md) holden allemaal in de week na
-  oplevering.
-- Geen productie-incident veroorzaakt door deze SPEC's deploys.
-- Eerste audit-stream (REQ-5, één week na go-live) toont **maximaal 1
-  `event:orphan_no_compose_label` event** (`librechat-voys` voor
-  REQ-2c deploy — anders 0).
-- 30 dagen na REQ-6 go-live: dangling-image count op core-01 blijft
-  consistent <50.
-- Hook-script blokkeert minstens 1 reële cleanup-poging in de eerste
-  maand (gemeten via VictoriaLogs `event:hook_blocked` event dat hook
-  emit bij blokkade).
+## Success Criteria (delta v0.3.0)
+
+- librechat-voys draagt na backfill klasse-B labels (verifieerbaar via
+  `docker inspect`).
+- Test-fixture `test_infrastructure_labels.py` slaagt.
+- 7 dagen na deploy: zero `event:orphan_no_managed_label` voor running
+  containers (post-backfill).
 
 ## Out of Scope
 
-- Image-pinning policy of pinning-pilot — VERSIONS.md is canoniek.
-- Server-side enforcement van handmatige `docker rm` via SSH (zonder
-  Claude). REQ-5 audit-stream is het detectie-vangnet achteraf.
-- CI-rule die mechanisch alle nieuwe `docker run` patterns weert. Te
-  veel false-positives op debug-tooling.
-- Vexa recordings volume.
-- GHCR retention policy.
-- Kubernetes / multi-server hygiene.
+- Labels-backfill voor andere containers dan librechat-voys.
+- Generaliseren van label-schema naar toekomstige tenant-services
+  (volgt patroon, eigen SPEC wanneer relevant).
+- Volume-labels (apart probleem, klantdata-risico).
 
 ## Ordering & Branch Strategy
 
-- **Eén worktree voor klai-repo werk** (REQ-1 + REQ-7 in 1 PR):
-  `git worktree add ../klai-container-hygiene -b feature/SPEC-INFRA-CONTAINER-HYGIENE-001 main`.
-- **Eén worktree voor klai-infra werk** (REQ-2 t/m REQ-6, opgesplitst
-  in stages):
-  `git worktree add ../klai-infra-container-hygiene -b feature/SPEC-INFRA-CONTAINER-HYGIENE-001 main`
-  in de klai-infra checkout.
+**Stage 1 (klai PR, gedaan, commit `55964c56`):** REQ-1 hook + REQ-7
+pitfall + narrative rule.
 
-**Stages (klai-infra):**
+**Stage 1.5 (klai PR, v0.3.0 uitbreiding):**
+- REQ-2a: `_start_librechat_container` labels + tests
+- REQ-2b: backfill librechat-voys op core-01
+- Hook + narrative + pitfall update voor klasse-B nuance
+- SPEC bump v0.2.0 → v0.3.0
 
-- **Stage 1:** klai-PR (tasks 1-3) — direct mergeable.
-- **Stage 2:** klai-infra-PR REQ-2c (compose-block librechat-voys) —
-  mergen, deploy via huidige workflow (zonder wrapper), verifiëren via
-  `docker inspect`.
-- **Stage 3:** klai-infra-PR REQ-3 (compose-up.sh + docs.yml als
-  pilot) — mergen, monitor 24u op core-01, dan rollout naar overige
-  9 workflows in vervolg-PR.
-- **Stage 4:** klai-infra-PR REQ-2a + REQ-2b (audit-compose-orphans
-  + audit-orphan-snapshot + workflow-uitbreiding).
-- **Stage 5:** klai-infra-PR REQ-6 (systemd cleanup timer + install
-  op core-01).
-- **Stage 6:** klai-infra-PR REQ-5 (audit-stream script + systemd
-  timer + Grafana panel/alert).
+**Stage 2 (klai-infra PR):** REQ-3 deploy-wrapper + docs.yml pilot.
 
-Geen mega-PR. Stages 2 t/m 6 elk in eigen PR voor regressie-isolatie.
+**Stage 3 (klai-infra PR):** REQ-3 rollout naar 9 overige workflows.
+
+**Stage 4 (klai-infra PR):** REQ-2c + REQ-2d (audit-compose-orphans
++ post-deploy snapshot).
+
+**Stage 5 (klai-infra PR):** REQ-6 systemd cleanup timer.
+
+**Stage 6 (klai-infra PR):** REQ-5 audit-stream + Grafana.
+
+Geen mega-PR. Stages 2-6 elk in eigen PR voor regressie-isolatie.
 
 ## Annotation Hooks
 
-Plekken waar annotation tijdens `/moai run` welkom is:
-
-- `// NOTE:` op de hook regex-pattern — als blijkt dat een legitiem
-  pattern wordt gevangen.
-- `// NOTE:` op de fail-mode keuze (fail-open vs fail-closed).
-- `// NOTE:` op de `compose-up.sh` flag-set — `--remove-orphans` is
-  zeker, andere flags (`--pull always`, etc.) zijn discussabel.
+- `// NOTE:` op de drie label-keuzes (`klai.managed_by`, `tenant_slug`, `kind`)
+- `// NOTE:` op fail-mode keuze hook (fail-closed deps, fail-open SSH)
+- `// NOTE:` op compose-up.sh flag-set

--- a/.moai/specs/SPEC-INFRA-CONTAINER-HYGIENE-001/plan.md
+++ b/.moai/specs/SPEC-INFRA-CONTAINER-HYGIENE-001/plan.md
@@ -1,0 +1,208 @@
+# SPEC-INFRA-CONTAINER-HYGIENE-001 — Implementation Plan (v0.2.0)
+
+## Approach
+
+Drie lagen, zes requirements (REQ-4 vervallen), strikt mechanisch.
+Het verschil met v0.1.0 is dat élke laag een mechaniek heeft die de
+fout-klasse onmogelijk maakt — geen "discipline", geen "rule",
+ofwel:
+
+- **Pre-tool guard** (REQ-1): hook in `.claude/settings.json` blokkeert
+  destructieve docker-acties tot een script de checks heeft gedraaid.
+  Een AI kan het niet vergeten of overslaan.
+- **CI-guard** (REQ-2a): PR die orphans introduceert faalt.
+- **Deploy-wrapper** (REQ-3): één script, alle workflows roepen het
+  aan, `--remove-orphans` zit ingebouwd.
+- **Detectie-stream** (REQ-5): VictoriaLogs events, AI queryt zelf
+  vóór beslissingen.
+- **Timer** (REQ-6): cron-equivalent, mechanisch.
+
+Volgorde-discipline blijft cruciaal: REQ-2c (librechat-voys in
+compose) **moet** vóór REQ-3 deploy-wrapper, anders wist
+`--remove-orphans` de container weer.
+
+## Task Decomposition
+
+| # | Task | Files | Repo | Risk | Volgorde |
+|---|---|---|---|---|---|
+| 1 | Schrijf preflight-hook script | `.claude/hooks/klai/container-hygiene-preflight.sh` | klai | Laag | 1 |
+| 2 | Registreer hook in settings.json | `.claude/settings.json` | klai | **Medium** (kan andere Bash-calls breken bij regex-fout) | 2 |
+| 3 | Schrijf narrative rule + pitfall | `.claude/rules/klai/infra/container-hygiene.md`, `.claude/rules/klai/pitfalls/process-rules.md` | klai | Laag | 3 |
+| 4 | Voeg `librechat-voys` compose-block toe (REQ-2c) | `deploy/docker-compose.yml` | klai-infra | **HIGH** | 4 |
+| 5 | Vervang draaiende `librechat-voys` op core-01 door compose-managed | core-01 ssh handmatig | runtime | **HIGH** (downtime ~30s) | 5 |
+| 6 | Schrijf `compose-up.sh` deploy-wrapper (REQ-3) | `deploy/scripts/compose-up.sh` | klai-infra | Medium | 6 |
+| 7 | Update `docs.yml` workflow als REQ-3 pilot | `.github/workflows/docs.yml` | klai-infra | Laag | 7 |
+| 8 | Update overige 9 service-workflows | `.github/workflows/{caddy,klai-connector,klai-knowledge-mcp,klai-mailer,knowledge-ingest,portal-api,retrieval-api,scribe-api,whisper-server}.yml` | klai-infra | **HIGH** (alle deploy-paden) | 8 |
+| 9 | Schrijf `audit-compose-orphans.sh` + regression test (REQ-2a) | `scripts/audit-compose-orphans.sh`, `scripts/test-audit-compose-orphans.sh` | klai-infra | Laag | 9 |
+| 10 | Breid `audit-compose.yml` workflow uit met orphan-step | `.github/workflows/audit-compose.yml` | klai-infra | Laag | 10 |
+| 11 | Schrijf `audit-orphan-snapshot.sh` post-deploy verifier (REQ-2b) | `scripts/audit-orphan-snapshot.sh` | klai-infra | Laag | 11 |
+| 12 | Schrijf systemd `docker-cleanup.{service,timer}` units (REQ-6) | `core-01/systemd/docker-cleanup.{service,timer}` | klai-infra | Laag | 12 |
+| 13 | Installeer + activeer cleanup-timer op core-01 | `systemctl link`, `enable --now` | runtime | Laag | 13 |
+| 14 | Schrijf `docker-orphan-audit.sh` event-emitter (REQ-5) | `scripts/docker-orphan-audit.sh` | klai-infra | Laag | 14 |
+| 15 | Schrijf systemd `orphan-audit.{service,timer}` units | `core-01/systemd/orphan-audit.{service,timer}` | klai-infra | Laag | 15 |
+| 16 | Installeer + activeer audit-timer op core-01 | `systemctl link`, `enable --now` | runtime | Laag | 16 |
+| 17 | Configureer Grafana panel + alert op audit-stream | Grafana UI / dashboard JSON | klai-infra | Laag | 17 |
+
+Tasks 1–3 vallen in één klai-PR (alle zelfstandig in deze repo, geen
+externe afhankelijkheden). Tasks 4–17 vallen in 4–6 kleinere klai-infra
+PRs voor regressie-isolatie.
+
+## Files Affected
+
+### klai (deze repo)
+
+- **Nieuw:** `.claude/hooks/klai/container-hygiene-preflight.sh`
+  (~80 regels bash + jq parsing).
+- **Uitgebreid:** `.claude/settings.json` — PreToolUse hook entry
+  (~5 regels JSON).
+- **Nieuw:** `.claude/rules/klai/infra/container-hygiene.md`
+  (~80 regels narrative).
+- **Uitgebreid:** `.claude/rules/klai/pitfalls/process-rules.md` —
+  pitfall toevoeging (~40 regels).
+- **Bestaand:** `.moai/specs/SPEC-INFRA-CONTAINER-HYGIENE-001/*.md`.
+
+### klai-infra (cross-repo)
+
+- **Nieuw:** `deploy/scripts/compose-up.sh` (~30 regels bash).
+- **Nieuw:** `scripts/audit-compose-orphans.sh` (~80 regels bash + yq).
+- **Nieuw:** `scripts/test-audit-compose-orphans.sh` (~50 regels
+  fixture-based regression test, volgt
+  `scripts/test-audit-compose.sh` patroon).
+- **Nieuw:** `scripts/audit-orphan-snapshot.sh` (~50 regels bash).
+- **Nieuw:** `scripts/docker-orphan-audit.sh` (~150 regels bash + jq +
+  curl naar VictoriaLogs).
+- **Uitgebreid:** `deploy/docker-compose.yml` — `librechat-voys`
+  service-block (~22 regels).
+- **Uitgebreid:** `.github/workflows/audit-compose.yml` — extra step
+  voor orphan-check (~6 regels).
+- **Uitgebreid:** 10 service-deploy-workflows — `docker compose up`
+  vervangen door `ssh core-01 "/opt/klai/deploy/scripts/compose-up.sh
+  <service>"` (~2 regels per workflow).
+- **Nieuw:** `core-01/systemd/docker-cleanup.{service,timer}`.
+- **Nieuw:** `core-01/systemd/orphan-audit.{service,timer}`.
+
+### Operator-acties op core-01 (geen Git, runtime)
+
+- Eenmalig: vervang draaiende `librechat-voys` door compose-managed
+  variant (`docker stop && docker rm && cd /opt/klai && docker compose
+  up -d librechat-voys`) — uit te voeren na merge van REQ-2c PR.
+- `systemctl link` + `enable --now` voor `docker-cleanup.timer`
+  (na merge van REQ-6 PR).
+- `systemctl link` + `enable --now` voor `orphan-audit.timer`
+  (na merge van REQ-5 PR).
+- Grafana-panel JSON importeren in dashboard.
+
+## Technology Choices
+
+- **Bash over Python** voor alle scripts — geen runtime-deps op core-01,
+  past in bestaande `scripts/` patroon (zie `audit-compose-volumes.sh`,
+  `victorialogs-tunnel.sh`).
+- **PreToolUse hook over Skill of MCP-tool** — hook draait
+  mechanisch vóór elke matching tool-call zonder dat AI er expliciet om
+  vraagt. Skill of MCP-tool zou AI moeten aanroepen, dus terug bij
+  "vertrouw op discipline".
+- **Eén deploy-wrapper script over per-workflow flag** — DRY, single
+  source, AI die nieuwe workflow schrijft kopieert SSH-regel zonder
+  flag-discipline.
+- **VictoriaLogs over `product_events`** voor REQ-5 — ops-events horen
+  in observability stack, niet in business-event tabel. Past bij
+  bestaande Alloy → VictoriaLogs flow.
+- **Stdout-emit + Alloy-pickup over directe HTTP push** — script
+  hoeft geen VictoriaLogs auth te kennen, Alloy doet de heavy
+  lifting. Minder fragiele integratie.
+- **Systemd timer over cron** — `journalctl -u` logging, makkelijker
+  inspecteerbaar, modernere syntax.
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| REQ-1 hook regex matcht te breed en blokkeert legitieme `docker logs`/`ps` calls | Hook test-fixture in PR: drie blokkade-cases + drie doorlaat-cases. Pre-merge handmatige test in een dummy sessie. |
+| REQ-1 hook is te traag (5+s per Bash-call) en frustreert workflow | Hook MOET <5s zijn per spec; check 5 (VictoriaLogs traffic) is duurste — backoff naar 1s timeout. Idempotent caching van compose-history check. |
+| REQ-3 wist `librechat-voys` voor REQ-2c gemerged is | Volgorde-discipline: REQ-2c PR moet gemerged + gedeployed zijn vóór REQ-3 PR open gaat. AC-3 verifieert dit. |
+| REQ-3 deploy-wrapper failt en breekt alle 10 deploys tegelijk | Test REQ-3 op `docs.yml` als pilot vóór de andere 9. Pilot-deploy moet 24u live draaien zonder issues vóór bredere rollout. |
+| `--remove-orphans` blijkt nog ANDERE bestaande wezen te wissen | Vóór REQ-3 deploy-wrapper-pilot: draai REQ-5 audit-script eenmalig handmatig op core-01, review output, los onbekende wezen op vóór de wrapper live gaat. |
+| systemd timer faalt silent op core-01 | REQ-5 audit-script bevat een check op `journalctl -u docker-cleanup --since '24h ago'` — als geen successful run, audit-event `event:cleanup_timer_unhealthy` met `severity:critical`. Grafana alert. |
+| Audit-script vals-positief op legitiem ad-hoc debug-container | Audit-script respecteert `klai.adhoc=*` label — labeled containers vallen in eigen sectie ipv "wees" sectie. |
+| `.claude/settings.json` JSON-fout breekt alle hooks | Pre-merge: `jq < .claude/settings.json` moet exit-0. Pre-commit-hook in deze repo zou dit kunnen mechanisch maken (out of scope hier). |
+| Hook werkt niet voor `ssh core-01 "docker rm"` (commando is een string-argument van ssh) | Erkende beperking. Hook checkt het top-level Bash-commando; geneste SSH commands zijn niet afgevangen. REQ-5 audit is detectie-vangnet achteraf. |
+| Hook script vereist `jq`, `curl`, `git` lokaal — kan ontbreken op nieuwe dev-machines | Hook script begint met dependency-check; bij ontbreken exit-0 met waarschuwing (fail-open ipv fail-closed voor dev-vriendelijkheid; productie-bescherming via REQ-2/REQ-5). Discutabel — zie open vraag. |
+
+## Open vragen voor `/moai run`
+
+1. **Hook fail-mode bij ontbrekende deps:** fail-open (waarschuwen,
+   doorlaten) of fail-closed (blokkeren)? Fail-closed is veiliger;
+   fail-open is dev-vriendelijker. Voorkeur: fail-closed met `jq`,
+   `curl` als hard requirements (beide standaard op dev-machines via
+   brew/apt); `ssh core-01` reachability check fail-open omdat dev-
+   machines niet altijd VPN aan hebben.
+2. **Per-workflow `--remove-orphans` of globale env-var:** voor REQ-3
+   heb ik gekozen voor de wrapper. Maar als jullie `COMPOSE_REMOVE_ORPHANS=true`
+   in `/opt/klai/.env` zetten werkt het ook zonder wrapper. Voorkeur:
+   wrapper, omdat het ook REQ-2b post-deploy snapshot dezelfde
+   plek geeft. Maar het is uitwisselbaar.
+3. **VictoriaLogs auth in `audit-script`:** script schrijft naar
+   stdout, Alloy pickt op. Geen auth nodig in script. Bevestiging dat
+   Alloy alle stdout van containers zonder filter forward.
+
+## Success Criteria
+
+- AC-1 t/m AC-7 (uit acceptance.md) holden allemaal in de week na
+  oplevering.
+- Geen productie-incident veroorzaakt door deze SPEC's deploys.
+- Eerste audit-stream (REQ-5, één week na go-live) toont **maximaal 1
+  `event:orphan_no_compose_label` event** (`librechat-voys` voor
+  REQ-2c deploy — anders 0).
+- 30 dagen na REQ-6 go-live: dangling-image count op core-01 blijft
+  consistent <50.
+- Hook-script blokkeert minstens 1 reële cleanup-poging in de eerste
+  maand (gemeten via VictoriaLogs `event:hook_blocked` event dat hook
+  emit bij blokkade).
+
+## Out of Scope
+
+- Image-pinning policy of pinning-pilot — VERSIONS.md is canoniek.
+- Server-side enforcement van handmatige `docker rm` via SSH (zonder
+  Claude). REQ-5 audit-stream is het detectie-vangnet achteraf.
+- CI-rule die mechanisch alle nieuwe `docker run` patterns weert. Te
+  veel false-positives op debug-tooling.
+- Vexa recordings volume.
+- GHCR retention policy.
+- Kubernetes / multi-server hygiene.
+
+## Ordering & Branch Strategy
+
+- **Eén worktree voor klai-repo werk** (REQ-1 + REQ-7 in 1 PR):
+  `git worktree add ../klai-container-hygiene -b feature/SPEC-INFRA-CONTAINER-HYGIENE-001 main`.
+- **Eén worktree voor klai-infra werk** (REQ-2 t/m REQ-6, opgesplitst
+  in stages):
+  `git worktree add ../klai-infra-container-hygiene -b feature/SPEC-INFRA-CONTAINER-HYGIENE-001 main`
+  in de klai-infra checkout.
+
+**Stages (klai-infra):**
+
+- **Stage 1:** klai-PR (tasks 1-3) — direct mergeable.
+- **Stage 2:** klai-infra-PR REQ-2c (compose-block librechat-voys) —
+  mergen, deploy via huidige workflow (zonder wrapper), verifiëren via
+  `docker inspect`.
+- **Stage 3:** klai-infra-PR REQ-3 (compose-up.sh + docs.yml als
+  pilot) — mergen, monitor 24u op core-01, dan rollout naar overige
+  9 workflows in vervolg-PR.
+- **Stage 4:** klai-infra-PR REQ-2a + REQ-2b (audit-compose-orphans
+  + audit-orphan-snapshot + workflow-uitbreiding).
+- **Stage 5:** klai-infra-PR REQ-6 (systemd cleanup timer + install
+  op core-01).
+- **Stage 6:** klai-infra-PR REQ-5 (audit-stream script + systemd
+  timer + Grafana panel/alert).
+
+Geen mega-PR. Stages 2 t/m 6 elk in eigen PR voor regressie-isolatie.
+
+## Annotation Hooks
+
+Plekken waar annotation tijdens `/moai run` welkom is:
+
+- `// NOTE:` op de hook regex-pattern — als blijkt dat een legitiem
+  pattern wordt gevangen.
+- `// NOTE:` op de fail-mode keuze (fail-open vs fail-closed).
+- `// NOTE:` op de `compose-up.sh` flag-set — `--remove-orphans` is
+  zeker, andere flags (`--pull always`, etc.) zijn discussabel.

--- a/.moai/specs/SPEC-INFRA-CONTAINER-HYGIENE-001/research.md
+++ b/.moai/specs/SPEC-INFRA-CONTAINER-HYGIENE-001/research.md
@@ -384,3 +384,89 @@ Workflow bestaat al, audit alleen nu volume-mounts (`audit-compose-volumes.sh`).
 REQ-2 breidt 'm uit met een `audit-compose-orphans.sh` check, gekoppeld
 aan dezelfde workflow-trigger. Pattern volgt bestaande
 `test-audit-compose.sh` regression-test conventie.
+
+## 13. Tenant-provisioning architectuur (v0.3.0 herziening)
+
+Tijdens v0.2.0 review wees de gebruiker erop dat ik een fundamentele
+laag van de architectuur over het hoofd zag: tenant-LibreChats worden
+NIET via compose beheerd, maar dynamisch door portal-api aangemaakt.
+
+**Bewijs uit de codebase:**
+
+`klai-portal/backend/app/services/provisioning/infrastructure.py`,
+functie `_start_librechat_container` (regel ~231-280):
+
+```python
+client = docker.from_env()
+container_name = f"librechat-{slug}"
+# ...
+client.containers.run(
+    image=settings.librechat_image,
+    name=container_name,
+    detach=True,
+    restart_policy={"Name": "unless-stopped"},
+    volumes={...},
+    network="klai-net",
+)
+# + connect to klai-net-mongodb, meilisearch, redis
+```
+
+Deze container krijgt:
+- Een herkenbare naam (`librechat-<slug>`)
+- Volume-mounts naar tenant-specifieke configs
+- Connectie aan vier networks
+- **GEEN labels** — niet compose-project (logisch, niet
+  compose-managed) en niet `klai.managed_by` (niet voorzien)
+
+Het orchestrator-niveau (`provisioning/orchestrator.py::provision_tenant`)
+roept dit aan als FastAPI BackgroundTask na signup (regel 204).
+Deprovisioning gaat via `_sync_remove_container(f"librechat-{slug}")`
+(regel 141).
+
+**Klassen prod-containers in klai per 2026-05-02:**
+
+| Klasse | Beheer-pad | Label v0.2.0 | Label v0.3.0 |
+|---|---|---|---|
+| A: compose-managed | `docker compose up` | `com.docker.compose.project=klai-core` | identiek |
+| B: provisioning-managed | portal-api `containers.run()` | (geen) | `klai.managed_by=portal-api-provisioning` + `klai.tenant_slug=<slug>` + `klai.kind=librechat` |
+| Ad-hoc debug (REQ-7) | `docker run --rm` | `klai.adhoc=*` | identiek |
+
+**Impact op SPEC v0.3.0:**
+
+REQ-2 v0.2.0 ("alles via compose") was technisch fout — klasse B
+bestaat by design. REQ-2 v0.3.0 herzien naar 5-regel code-patch in
+`_start_librechat_container`:
+
+```python
+client.containers.run(
+    ...,
+    labels={
+        "klai.managed_by": "portal-api-provisioning",
+        "klai.tenant_slug": slug,
+        "klai.kind": "librechat",
+    },
+)
+```
+
+Audit-tooling (REQ-1 hook, REQ-5 audit, REQ-2c CI-guard, REQ-2d
+post-deploy snapshot) checkt UNION van klasse-A én klasse-B labels.
+librechat-voys backfill via container recreate (Docker labels zijn
+immutable). librechat-getklai blijft klasse A — geen klasse-B nodig.
+
+**Waarom dit incident hier ontstond:**
+
+Mijn cleanup-actie van 2026-05-02 zocht naar containers zonder
+compose-project label en kwalificeerde librechat-voys daar onder.
+De impliciete aanname "geen compose label = wees" was onjuist —
+librechat-voys was provisioning-managed, een legitieme klasse die op
+dat moment geen herkenbaar label droeg. Het "geen Caddy upstream"
+signaal was óók verwarrend: portal-api configureert Caddy bij
+provisioning, maar de exacte timing tussen tenant-provisioning,
+Caddy-config-update, en DNS-propagatie is geen garantie. Een
+container die deze stap nog niet heeft gehaald (of waar Caddy
+sindsdien is gerestart) heeft tijdelijk geen upstream. Geen wees.
+
+**Lesson voor de SPEC:** vóór een aanname als "alles via X is
+canonical" expliciet de codebase rondom `containers.run` / orchestrator
+analyseren. Dit had ik in v0.1.0 / v0.2.0 niet gedaan; v0.3.0
+corrigeert het.

--- a/.moai/specs/SPEC-INFRA-CONTAINER-HYGIENE-001/research.md
+++ b/.moai/specs/SPEC-INFRA-CONTAINER-HYGIENE-001/research.md
@@ -1,0 +1,386 @@
+# SPEC-INFRA-CONTAINER-HYGIENE-001 — Research
+
+Diep onderzoek vóór de SPEC. Findings uit de live core-01 staat per
+2026-05-02, de klai-infra deploy-workflows, en het librechat-voys
+incident dat de aanleiding voor deze SPEC is.
+
+## 1. Het librechat-voys incident (root cause walk-through)
+
+**Tijdlijn 2026-05-02:**
+
+- `docker ps` op core-01 toonde 47 containers, waaronder `librechat-voys`
+  met image `62043e990607` (untagged sha), Up 9 dagen.
+- `docker inspect librechat-voys --format '{{.Config.Labels}}'` returnde
+  een lege map. Géén `com.docker.compose.project=klai-core` label, geen
+  `com.docker.compose.service`, geen container-number.
+- `grep librechat /opt/klai/docker-compose*.yml` toonde alleen
+  `librechat-dev` (dev compose) en `librechat-getklai` (prod compose) als
+  service-blocks. `librechat-voys` was géén compose-service.
+- `docker exec klai-core-caddy-1 cat /etc/caddy/Caddyfile | grep -i 'voys\|chat-voys'`
+  returnde niets — Caddy routeerde niet naar deze container.
+- Cleanup-besluit baseerde zich uitsluitend op (a) geen compose-label en
+  (b) geen Caddy-route → "wees, weg ermee". Container + image (samen met
+  60 GB aan dangling images van CI-deploys) verwijderd.
+- Een parallelle Claude-sessie (PR #265-context) ontdekte daarna dat de
+  voys-tenant chat-route stuk was. Conclusie van die sessie: librechat-voys
+  "bestond niet — nooit geprovisioneerd voor het voys tenant", wat klopte
+  na de cleanup. Of het ervóór wèl correct routeerde via een ander
+  Caddy-mechanisme (subpath rewrite, on-demand TLS) of al een tijd
+  losgekoppeld was, is achteraf niet meer met zekerheid vast te stellen
+  — de logs voor de afgelopen 9 dagen die door deze container zouden
+  moeten zijn afgehandeld zijn niet in VictoriaLogs gequeried.
+- Recovery: `docker run -d --name librechat-voys --restart unless-stopped`
+  met `ghcr.io/danny-avila/librechat:v0.8.5-rc1` (zelfde image als
+  `librechat-getklai`) en mounts naar `/opt/klai/librechat/voys/`
+  (env-file en `librechat.yaml` waren intact gebleven; alleen container +
+  image waren weg).
+
+**Vijf root-causes uit dit incident:**
+
+1. Productie-container draaide via een handmatige `docker run` zonder
+   compose-declaratie. Gevolg: geen `com.docker.compose.project` label →
+   ontoeschrijfbaar tegen automatisering.
+2. Image was een lokaal aanwezige sha (`62043e9...`) zonder registry-tag.
+   Gevolg: niet reproduceerbaar, niet rollback-baar via GHCR pull, en
+   automatisch dangling bij elke `image prune`.
+3. Caddy had geen actieve route. Detectie zou trivial zijn geweest: `for
+   service in $(docker compose config --services); do grep $service
+   /etc/caddy/Caddyfile; done`. Bestaat niet als check.
+4. Geen pre-cleanup checklist. Cleanup-agent (in dit geval ik) reageerde
+   op "geen compose label" alsof dat een definitieve wees-marker was —
+   het is een sterk signaal maar geen bewijs. De tenant-specifieke naam
+   (`-voys`) had moeten triggeren.
+5. Geen periodieke detectie. Een wekelijks audit-rapport had de
+   onbeheerde container al weken geleden geflagd voor menselijke review.
+
+## 2. Inventaris core-01 (post-cleanup snapshot 2026-05-02)
+
+**Running:** 44 containers (was 47, na cleanup van `beautiful_napier`,
+`librechat-voys` (hersteld), `klai-core-glitchtip-migrate-1` exited).
+
+**Categorisatie naar herkomst:**
+
+| Categorie | Aantal | Risico |
+|---|---|---|
+| `klai-core` compose project (labels OK) | 41 | Laag |
+| Compose-service in `docker-compose.override.yml` (labels OK) | 1 (`librechat-getklai`) | Laag |
+| Compose-service in `docker-compose.dev.yml` (labels OK) | 1 (`librechat-dev`) | Laag |
+| Handmatige `docker run` (géén compose-label) | 1 (`librechat-voys`, post-recovery) | **HIGH** |
+
+`librechat-voys` is na recovery nog steeds zonder compose-label —
+het werd hersteld via een handmatige `docker run` om continuïteit te
+garanderen. Tot REQ-2 van deze SPEC is uitgevoerd, blijft het de enige
+container in deze categorie en de enige wees in deze inventaris.
+
+**Disk:** 104 GB / 25% (van 347 GB / 84% pre-cleanup; -243 GB winst).
+
+**Volumes:** 23 actief (was 33), 22 in gebruik. `klai-core_vexa-recordings-data`
+(58 MB, recordings van 23 maart, geen schrijven sinds Vexa 0.10 update
+op 19 april) bewust niet aangeraakt — klantdata in ruwe vorm, vraagt
+eigen evaluatie buiten deze SPEC.
+
+**Dangling images:** 0 (post-cleanup). Pre-cleanup waren het er 679,
+gemiddeld 1.0–1.3 GB per stuk → 60 GB. Bron: elke deploy van een
+`:latest`-getagde image bumpt de tag, vorige image wordt
+`<none>:<none>`.
+
+## 3. Deploy-workflow inventaris (.github/workflows/)
+
+**21 workflow-bestanden totaal in klai (private):**
+
+```
+alerting-check.yml         klai-mailer.yml          renovate.yml
+audit-compose.yml          knowledge-ingest.yml     retrieval-api.yml
+caddy.yml                  litellm-hook-deploy.yml  scan-pinned-images.yml
+deploy-compose.yml         portal-api.yml           scribe-api.yml
+deploy-librechat-config.yml portal-frontend.yml     semgrep.yml
+docs.yml                   whisper-server.yml       env-scope-guard.yml
+klai-connector.yml         klai-knowledge-mcp.yml   zitadel-oidc-drift.yml
+```
+
+**Workflows met `docker compose up` of `docker-compose up` (10 stuks):**
+
+`caddy.yml`, `docs.yml`, `klai-connector.yml`, `klai-knowledge-mcp.yml`,
+`klai-mailer.yml`, `knowledge-ingest.yml`, `portal-api.yml`,
+`retrieval-api.yml`, `scribe-api.yml`, `whisper-server.yml`.
+
+**Workflows met `--remove-orphans`:** **0**. Bevestigd via grep —
+geen enkele service-deploy gebruikt deze flag. Gevolg: zodra een service
+uit `/opt/klai/docker-compose.yml` wordt verwijderd, blijft de oude
+container draaien tot iemand 'm handmatig stopt.
+
+**Reeds bestaande hygiene-workflows (pre-bestaand):**
+
+- `audit-compose.yml`: bestaat. Inhoud nog niet gelezen — kan overlappend
+  doel hebben.
+- `scan-pinned-images.yml`: bestaat. Naam suggereert image-pinning audit
+  (REQ-4 territorium).
+- `env-scope-guard.yml`: bestaat. Recent (SPEC-SEC-ENVFILE-SCOPE-001) —
+  guard tegen env-file-scope-bleed.
+
+Vóór REQ-3/REQ-4 implementatie deze drie workflows volledig lezen om
+overlap of conflict met bestaande tooling te vermijden. **Belangrijk:**
+`scan-pinned-images.yml` zou kunnen betekenen dat REQ-4's beleidsdoel
+(`:latest` weren) al deels bestaat — dat zou de scope van REQ-4 wezenlijk
+veranderen.
+
+## 4. Compose image-tagging audit (huidige staat per 2026-05-02)
+
+`grep -E 'image:.*ghcr.io/getklai|image:.*klai/' /opt/klai/docker-compose.yml`
+op core-01 (sample uit `docker ps`):
+
+| Service | Tag in compose | Tag in registry | Pin status |
+|---|---|---|---|
+| portal-api | `:latest` | overschreven elke deploy | NIET-gepind |
+| klai-connector | `:latest` | overschreven elke deploy | NIET-gepind |
+| knowledge-ingest | `:latest` | overschreven elke deploy | NIET-gepind |
+| klai-knowledge-mcp | `:latest` | overschreven elke deploy | NIET-gepind |
+| klai-mailer | `:latest` | overschreven elke deploy | NIET-gepind |
+| scribe-api | `:latest` | overschreven elke deploy | NIET-gepind |
+| retrieval-api | `klai/retrieval-api:local` | lokaal gebouwd | Niet-applicabel |
+| caddy | `ghcr.io/getklai/caddy-hetzner:latest` | overschreven elke deploy | NIET-gepind |
+| docs-app | `ghcr.io/getklai/klai-docs:latest` | overschreven elke deploy | NIET-gepind |
+| librechat-getklai | `ghcr.io/danny-avila/librechat:v0.8.5-rc1` | upstream stable | Gepind (third-party) |
+| vexa stack (runtime-api etc.) | `vexaai/runtime-api:0.10.0-260419-1129` | upstream pinned | Gepind (third-party) |
+
+**Bevinding:** géén klai-eigen service gebruikt versie-pinning. Élke
+deploy van een ghcr.io/getklai-image overschrijft `:latest` → vorige
+image wordt dangling. Dit is dé bron van de 679 dangling images / 60 GB.
+
+## 5. Caddy-routing audit
+
+`docker exec klai-core-caddy-1 cat /etc/caddy/Caddyfile | grep -E '^[a-z]' | head -30`
+toonde een list reverse-proxy-blocks per hostname. Voor de SPEC relevant:
+
+- Hostnames in Caddyfile zonder bijbehorende running container = orphan
+  routing-rules (downtime risico).
+- Container-namen die in `docker ps` voorkomen maar nergens als
+  upstream in Caddyfile staan = potentieel verlaten of bypass-routing.
+
+Dit is precies de check die mij vandaag gered had: een diff tussen
+`docker compose ps` en `caddy upstreams` zou `librechat-voys` als
+"draait, maar geen Caddy-route" hebben getoond — een rode vlag voor
+een tenant-specifieke container.
+
+## 6. Patterns uit andere klai-infra repos
+
+`klai-infra` (apart repo) bezit `/opt/klai/docker-compose.yml`, SOPS env
+files, en de deploy-workflows. Uit de pitfalls in
+`.claude/rules/klai/pitfalls/process-rules.md`:
+
+- **`scribe-deploy-no-alembic`**: scribe-api deploy doet `docker compose
+  up -d` zonder migrate-step. Pattern: `docker compose up -d` is rauw,
+  zonder hygiene flags.
+- **`env-file-migration-reverse-check`**: env-files migratie (SOPS) heeft
+  een audit-discipline. Container-hygiene heeft die nog niet.
+- **`spec-work-in-a-worktree`**: SPEC-werk in dedicated worktree. Voor
+  REQ-2 (compose-edit voor librechat-voys) geldt dit ook — klai-infra
+  worktree.
+
+## 7. Industry standard (uit web research van 2026-05-02 in deze sessie)
+
+**Bron-consensus voor single-server Docker prod (jullie context):**
+
+- `docker image prune -f` (alleen dangling) is **100% safe**, dagelijks
+  uitvoeren is breed aanbevolen.
+- `docker volume prune` automatisch is unanimous **af te raden**:
+  dataverlies-risico (named volumes met data, edge-case label-detection).
+- **Versie-pinning** (geen `:latest`) is de #1 maatregel die de
+  dangling-explosie structureel stopt. Alle bronnen noemen dit als
+  "advanced but essential" voor multi-deploy-per-day setups.
+- Tooling: `Spotify/docker-gc` is officieel **inactive**. Native
+  `systemd timer` is moderne keuze voor schedule (vs cron) — logging via
+  `journalctl`, geen extra container nodig.
+
+Bronnen: oneuptime, Alex Gallacher, Conan Mercer, Docker Docs (build cache GC),
+Designcise. Geen bron pleitte voor automatische `volume prune` of
+agressieve `image prune -af` zonder retention-filter.
+
+## 8. Reference implementations in klai-codebase
+
+**Voor REQ-1 (HARD rule file):** patroon volgen van bestaande klai-rules:
+
+- `.claude/rules/klai/no-ask-user-question.md` (kort, dwingend, één
+  pagina) — toon-template voor REQ-1.
+- `.claude/rules/klai/pitfalls/process-rules.md` (lijst van anti-patterns
+  met prevention-secties) — sectie-template voor de pre-cleanup
+  checklist body.
+- `.claude/rules/klai/infra/observability.md` (hoe-doen-we-X reference) —
+  toon-template voor de container-hygiene how-to.
+
+**Voor REQ-5 (audit-script):** volg het pattern van
+`scripts/victorialogs-tunnel.sh` (bash, single-file, idempotent,
+documenteerbaar via `--help`).
+
+**Voor REQ-6 (systemd timer):** geen bestaand voorbeeld in de klai-repo.
+Standaard systemd-pattern via `/etc/systemd/system/{naam}.service` +
+`.timer`. Operator-action via SSH naar core-01.
+
+## 9. Risico's en open vragen
+
+**Risico's voor deze SPEC:**
+
+- REQ-2 (librechat-voys compose-block) raakt `/opt/klai/docker-compose.yml`
+  in klai-infra, een aparte repo. PR-coordination nodig — niet ìn deze
+  klai repo. Documenteer als hand-off.
+- REQ-3 (`--remove-orphans` toevoegen) heeft als bijwerking dat
+  `librechat-voys` BIJ DE EERSTE deploy zou worden verwijderd indien
+  REQ-2 niet eerst gemerged is. Strikte volgorde nodig: REQ-2 → REQ-3.
+- REQ-4 (image-pinning pilot voor portal-api) raakt de portal-api
+  GitHub workflow én klai-infra `.env` voor de versie-var. Cross-repo
+  change met deploy-implicaties — stage-gates nodig (zie
+  `validator-env-parity` pitfall).
+- REQ-6 (systemd timer) draait als root op core-01. Operator-action via
+  SSH. Geen enkele klai-repo file beweegt — de timer-installatie zelf
+  is buiten Git, alleen het gegenereerde unit-bestand wordt in
+  `klai-infra` gecheckt-in onder `core-01/systemd/`.
+
+**Open vragen vóór `/moai run`:**
+
+1. Wil de klai-infra deploy-pijplijn de systemd timer files *zelf*
+   provisionen (Ansible / shell script in deploy-compose.yml)? Of is het
+   handmatig via SSH? Antwoord stuurt waar het unit-bestand woont.
+2. Is `audit-compose.yml` workflow al een orphan-detectie tool? Zo ja,
+   uitbreiden ipv nieuwe scripts/`docker-orphan-audit.sh` script.
+3. Is `scan-pinned-images.yml` workflow al actief op image-pinning? Zo ja,
+   REQ-4 wordt veel kleiner — alleen de pilot uitvoeren ipv beleid
+   formaliseren.
+
+Beide vragen kunnen tijdens `/moai run` Phase 1 (manager-strategy) worden
+beantwoord door de drie workflows ECHT te lezen voor REQ-3 en REQ-4
+implementatie begint.
+
+## 10. Conclusie van research (initiële versie v0.1.0)
+
+De SPEC raakt drie lagen:
+
+1. **Beleid** (rules-files in deze repo) → REQ-1, REQ-2-policy.
+2. **Tooling** (scripts en systemd-timer op core-01) → REQ-5, REQ-6.
+3. **Cross-repo deploy-discipline** (klai-infra workflows + compose) →
+   REQ-2-implementation, REQ-3, REQ-4.
+
+De volgorde-discipline tussen lagen is kritiek: REQ-2 MOET vóór REQ-3,
+anders wist `--remove-orphans` de net-herstelde container. REQ-1 en
+REQ-6 hebben geen externe afhankelijkheden en kunnen direct.
+
+## 11. Bestaande version-management infrastructure (v0.2.0 herziening)
+
+Tijdens v0.1.0 review ontdekte de gebruiker dat klai al een uitgebreid
+version-management systeem heeft. Twee bestanden zijn de canoniek:
+
+**`deploy/VERSIONS.md`** — complete inventory van alle gepinde external
+images met rationale per stuk. Sleutelstatement:
+
+> Each CI workflow also tags the build with `:${github.sha}` so rollbacks
+> are possible via explicit SHA pin. These are NOT production `:latest`
+> anti-patterns — they are continuous-deployment rolling tags owned by
+> our own CI pipelines.
+
+Dit zegt expliciet dat `:latest` op `ghcr.io/getklai/*` **bewust beleid
+is**, niet een fout om te repareren. Rollback gebeurt via
+`docker pull <image>:<sha> && tag :latest && compose up -d`.
+
+**`docs/runbooks/version-management.md`** — 514-regelige playbook met:
+
+- §1 Pinning principles (lockfiles mandatory, no `:latest` for external)
+- §2 Cadence (Renovate Mon 05:00, security CVE bumps immediate)
+- §3 Procedures per upgrade type (Python pkg, Node pkg, Docker minor,
+  Docker major, Python runtime, Node runtime)
+- §4 Testing gates per type
+- §5 Pinning rules cheat sheet
+- §6 Rollback procedures (fast + with data corruption)
+- §7 Eight historical pitfalls inclusief CRIT FalkorDB graph-loss
+- §8 Tools reference (uv, npm, Docker, registry queries, CI automation)
+- §9 CVE detection layers (5 mechanismes, defense-in-depth)
+- §10 Quarterly audit procedure
+- §11 Stateful service change checklist
+- §12 When this playbook is wrong (judgment guidance)
+
+**Bestaande automatisering:**
+
+- `.github/workflows/scan-pinned-images.yml` — wekelijkse Trivy scan
+- `.github/workflows/audit-compose.yml` — bestaat met
+  `scripts/audit-compose-volumes.sh` + `scripts/test-audit-compose.sh`
+- `deploy/check-image-tags.sh` — pre-commit voor Vexa convention
+- Renovate + Dependabot — auto-PRs voor updates
+- Trivy per service workflow — CVE-scan op build
+
+**Impact op deze SPEC:**
+
+REQ-4 (image-pinning pilot voor portal-api) **is dubbel werk en gaat
+in tegen bestaand beleid**. Geschrapt in v0.2.0. De 679 dangling images
+zijn een geaccepteerde bijwerking van `:latest`-rolling-tags, en de
+fix is daily prune (REQ-6) — niet pinning forceren.
+
+## 12. AI-first uitgangspunt (v0.2.0 herziening)
+
+Tijdens v0.1.0 review wees de gebruiker erop dat de SPEC niet uitgaat
+van de werkelijkheid: een AI doet het primaire code- en deploy-werk.
+"Vertrouw op menselijke discipline" is dan geen vangnet maar een gat.
+
+Vertaling per requirement van mens-first → AI-first:
+
+| Requirement | Mens-first (v0.1.0) | AI-first (v0.2.0) |
+|---|---|---|
+| REQ-1 | Markdown-checklist die agent moet lezen | Bash-script + PreToolUse hook in `.claude/settings.json` die `docker rm`/`rmi`/`volume rm` mechanisch blokkeert tot script exit-0 |
+| REQ-2 | "Beleid: alles via compose" | CI-guard in `audit-compose.yml`: PR met handmatig docker-run-pattern faalt; post-deploy verifier flagt elke container zonder `com.docker.compose.project=klai-core` label |
+| REQ-3 | Per-workflow `--remove-orphans` toevoegen aan 10 files | Eén deploy-wrapper `deploy/scripts/compose-up.sh`; alle workflows roepen de wrapper aan; flag zit ingebouwd, niet vergetelijk |
+| REQ-5 | Weekly markdown-rapport voor menselijke review | Audit-script schrijft structlog-events naar VictoriaLogs (`service:klai-orphan-audit`, `event:orphan_detected`); Grafana dashboard panel + alert; AI queryt via VictoriaLogs MCP vóór elke cleanup-beslissing |
+| REQ-6 | Systemd timer | Blijft (was al mechanisch) |
+| REQ-7 | Markdown pitfall | Blijft als secondary; primair vangnet is REQ-1 hook |
+
+Het verschil: v0.1.0 was "leer de AI beter te zijn"; v0.2.0 is "AI kan
+de fout niet meer maken, ook bij slechte dag of bij een andere agent".
+
+**Hooks-mechanisme (REQ-1):**
+
+`.claude/settings.json` ondersteunt `PreToolUse` hooks per tool.
+Voorbeeld:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/klai/container-hygiene-preflight.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+De hook ontvangt het commando dat Claude wil draaien via stdin als JSON.
+Het script parseert eruit `docker rm/rmi/volume rm/system prune` en
+draait dán de checklist; exit-code != 0 = blocked. Werkt voor élke
+Claude-sessie in deze repo, mechanisch.
+
+**Beperking:** hooks gelden alleen voor Claude Code. Een operator die
+direct via SSH `docker rm` doet wordt niet afgevangen. Daarvoor is
+REQ-5 (audit-stream + Grafana alert) het detectie-vangnet achteraf.
+
+**`product_events` versus VictoriaLogs voor REQ-5:**
+
+`product_events` is voor user-facing business events (signups,
+billing, meetings). Cleanup is een ops-event, hoort in VictoriaLogs
+(structlog) zoals alle service-logs van klai. Resultaat:
+
+- Audit-script logt via `structlog` met `service=klai-orphan-audit`
+- VictoriaLogs MCP server kan AI queryen: `service:klai-orphan-audit
+  AND event:orphan_detected AND _time:[now-7d,now]`
+- Grafana Logs-panel + alert via dezelfde stream
+
+Geen DB-schema verandering nodig. Past in bestaande observability stack
+(Alloy → VictoriaLogs).
+
+**Bestaande `audit-compose.yml` voor REQ-2:**
+
+Workflow bestaat al, audit alleen nu volume-mounts (`audit-compose-volumes.sh`).
+REQ-2 breidt 'm uit met een `audit-compose-orphans.sh` check, gekoppeld
+aan dezelfde workflow-trigger. Pattern volgt bestaande
+`test-audit-compose.sh` regression-test conventie.

--- a/.moai/specs/SPEC-INFRA-CONTAINER-HYGIENE-001/spec-compact.md
+++ b/.moai/specs/SPEC-INFRA-CONTAINER-HYGIENE-001/spec-compact.md
@@ -1,0 +1,145 @@
+# SPEC-INFRA-CONTAINER-HYGIENE-001 — Compact (v0.2.0)
+
+Auto-extract van requirements + acceptance + files + exclusions voor
+`/moai run`.
+
+## Wat is veranderd in v0.2.0
+
+- **REQ-4 geschrapt.** `:latest` op `ghcr.io/getklai/*` is bewust
+  beleid per `deploy/VERSIONS.md` + `docs/runbooks/version-management.md`.
+- **REQ-1, REQ-2, REQ-3, REQ-5 herschreven naar AI-first mechanisch.**
+  Geen markdown-rules; in plaats daarvan: PreToolUse hook, CI-guard,
+  deploy-wrapper, VictoriaLogs event-stream.
+
+## Requirements (EARS)
+
+### R1 — PreToolUse hook blokkeert destructieve docker-acties
+WHEN een Bash tool-call matcht `docker rm`/`rmi`/`volume rm`/
+`system prune`/`compose down --volumes`, THEN
+`.claude/hooks/klai/container-hygiene-preflight.sh` SHALL eerst draaien
+en de checks uitvoeren: Caddy upstream, compose git-history,
+tenant-naam, depends_on, recent-traffic via VictoriaLogs. Eén positieve
+match = exit 1 = tool-call blocked. Hard-block voor `volume prune`
+en `image prune -af`. Geregistreerd in `.claude/settings.json`.
+
+### R2 — Compose als single source, mechanisch geverifieerd
+**R2a (preventief):** `scripts/audit-compose-orphans.sh` draait in
+bestaande `audit-compose.yml` workflow op elke PR; faalt bij
+inconsistenties tussen Caddyfile, compose-services, en
+container_names. **R2b (detectief):** `compose-up.sh` (REQ-3) draait
+post-deploy `audit-orphan-snapshot.sh` die `event:orphan_post_deploy`
+naar VictoriaLogs emit. **R2c (concreet):** `librechat-voys` SHALL
+als service-block in `klai-infra/deploy/docker-compose.yml`.
+
+### R3 — Deploy-wrapper met `--remove-orphans` ingebouwd
+Eén script `klai-infra/deploy/scripts/compose-up.sh` SHALL het
+canonieke deploy-mechanisme zijn — `docker compose pull && up -d
+--remove-orphans` plus post-deploy snapshot. Alle 10 service-deploy-
+workflows SHALL via SSH dit script aanroepen. **STRIKT NA REQ-2c**.
+
+### R4 — VERVALLEN
+Image-pinning pilot geschrapt. VERSIONS.md is canoniek.
+
+### R5 — Audit als VictoriaLogs event-stream
+`scripts/docker-orphan-audit.sh` SHALL elke zondag 03:00 op core-01
+draaien en structlog-events emitten via stdout (Alloy → VictoriaLogs)
+met `service:klai-orphan-audit` en zes mogelijke `event:` types
+(orphan_no_compose_label, orphan_service_removed, image_untagged_old,
+volume_unmounted, caddy_upstream_missing, tenant_container_no_route).
+**REPORT-ONLY** — geen deletion. Grafana panel + alert. AI queryt via
+VictoriaLogs MCP.
+
+### R6 — Daily safe cleanup via systemd timer
+`docker-cleanup.timer` SHALL daily 03:00 draaien:
+`docker image prune -f`, `docker container prune -f --filter until=24h`,
+`docker network prune -f`, `docker builder prune -f --filter until=72h`.
+**NOOIT** `volume prune` of `image prune -af`.
+
+### R7 — Pitfall-documentatie
+`container-cleanup-without-preflight (HIGH)` pitfall in
+`.claude/rules/klai/pitfalls/process-rules.md` met incident-tijdlijn
++ "why mechanical not narrative" sectie.
+
+## Files Affected
+
+### klai (deze repo)
+- NIEUW: `.claude/hooks/klai/container-hygiene-preflight.sh`
+- UITGEBREID: `.claude/settings.json` (PreToolUse-hook registratie)
+- NIEUW: `.claude/rules/klai/infra/container-hygiene.md`
+- UITGEBREID: `.claude/rules/klai/pitfalls/process-rules.md`
+- NIEUW: `.moai/specs/SPEC-INFRA-CONTAINER-HYGIENE-001/{spec,plan,acceptance,research,spec-compact,progress}.md`
+
+### klai-infra (cross-repo)
+- NIEUW: `deploy/scripts/compose-up.sh` (REQ-3)
+- NIEUW: `scripts/audit-compose-orphans.sh` + `test-audit-compose-orphans.sh` (REQ-2a)
+- NIEUW: `scripts/audit-orphan-snapshot.sh` (REQ-2b)
+- NIEUW: `scripts/docker-orphan-audit.sh` (REQ-5)
+- UITGEBREID: `deploy/docker-compose.yml` (REQ-2c librechat-voys block)
+- UITGEBREID: `.github/workflows/audit-compose.yml` (orphan-step)
+- UITGEBREID: 10× `.github/workflows/*.yml` (`docker compose up` → `compose-up.sh` aanroep)
+- NIEUW: `core-01/systemd/docker-cleanup.{service,timer}` (REQ-6)
+- NIEUW: `core-01/systemd/orphan-audit.{service,timer}` (REQ-5)
+
+### Operator-acties op core-01 (geen Git)
+- `systemctl link` + `enable --now` voor beide timers
+- Eenmalig: `librechat-voys` handmatig vervangen door compose-managed
+  variant na REQ-2c merge
+
+## Acceptance Criteria
+
+| AC | Wat | Mechanische verificatie |
+|---|---|---|
+| AC-1 | Hook blokkeert `docker rm <tenant-container>` | exit-code 1 + "BLOCKED" in output; container nog aanwezig |
+| AC-2 | librechat-voys is compose-managed | `docker inspect` returns `klai-core` project label |
+| AC-3 | Deploy-wrapper + remove-orphans werkt; librechat-voys overleeft | scripted wees-test, librechat-voys still running |
+| AC-4 | Daily timer >=2 successful runs, dangling <50, named volumes intact | `journalctl` + `docker images` + volume-diff |
+| AC-5 | Audit-events queryable in VictoriaLogs | LogsQL query returns events; zero `orphan_no_compose_label` |
+| AC-6 | Audit-events worden door REQ-1 hook gebruikt | end-to-end test: dummy orphan → audit detect → hook blokkeert |
+| AC-7 | Pitfall + CI-guard | `grep` returns 0 in deze repo; klai-infra CI faalt op test-fixture |
+
+## Run Acceptance Aggregate
+
+- AC-1 t/m AC-7 allemaal binnen 7 dagen na laatste deploy
+- Geen productie-incident causaal aan deze SPEC's deploys
+- 30d post REQ-6: dangling-count consistent <50
+- 30d post REQ-1: minstens 1 `event:hook_blocked` event in VictoriaLogs
+- 30d post REQ-5: zero `event:orphan_no_compose_label` buiten gelabelde
+  `klai.adhoc=*` containers
+
+## Exclusions
+
+- Image-pinning policy/pilot (VERSIONS.md is canoniek)
+- Server-side enforcement van handmatige SSH `docker rm`
+- CI-rule die alle docker-run patterns weert
+- Watchtower / auto-pull tools
+- Vexa recordings volume
+- GHCR retention policy
+- Kubernetes / multi-server hygiene
+
+## Implementation Volgorde (STRIKT)
+
+1. **klai-PR:** REQ-1 (hook script + settings.json) + REQ-7 (pitfall)
+   + REQ-1 narrative — alle in deze repo, geen externe deps
+2. **klai-infra-PR:** REQ-2c (librechat-voys compose-block) + handmatige
+   container-vervanging op core-01
+3. **klai-infra-PR:** REQ-3 (compose-up.sh) + 1 pilot-workflow (`docs.yml`),
+   24u monitoring vóór bredere rollout
+4. **klai-infra-PR:** REQ-3 rollout naar overige 9 workflows
+5. **klai-infra-PR:** REQ-2a + REQ-2b (audit-compose-orphans +
+   audit-orphan-snapshot)
+6. **klai-infra-PR:** REQ-6 (systemd cleanup timer + activation)
+7. **klai-infra-PR:** REQ-5 (audit-stream script + systemd timer +
+   Grafana panel/alert)
+
+Worktree-pattern: één per repo. Geen mega-PR.
+
+## Open Questions voor `/moai run`
+
+1. Hook fail-mode bij ontbrekende deps: fail-open of fail-closed?
+   (voorkeur: fail-closed met `jq`/`curl` als hard requirement;
+   `ssh core-01` reachability fail-open voor dev-machines)
+2. Per-workflow `--remove-orphans` flag of compose-up.sh wrapper?
+   (voorkeur: wrapper, maar uitwisselbaar met
+   `COMPOSE_REMOVE_ORPHANS=true` env-var)
+3. Bevestiging dat Alloy alle container-stdout zonder filter forward
+   naar VictoriaLogs (voor REQ-5 emit-via-stdout pattern)

--- a/.moai/specs/SPEC-INFRA-CONTAINER-HYGIENE-001/spec-compact.md
+++ b/.moai/specs/SPEC-INFRA-CONTAINER-HYGIENE-001/spec-compact.md
@@ -1,64 +1,72 @@
-# SPEC-INFRA-CONTAINER-HYGIENE-001 — Compact (v0.2.0)
+# SPEC-INFRA-CONTAINER-HYGIENE-001 — Compact (v0.3.0)
 
 Auto-extract van requirements + acceptance + files + exclusions voor
 `/moai run`.
 
-## Wat is veranderd in v0.2.0
+## Wat is veranderd in v0.3.0
 
-- **REQ-4 geschrapt.** `:latest` op `ghcr.io/getklai/*` is bewust
-  beleid per `deploy/VERSIONS.md` + `docs/runbooks/version-management.md`.
-- **REQ-1, REQ-2, REQ-3, REQ-5 herschreven naar AI-first mechanisch.**
-  Geen markdown-rules; in plaats daarvan: PreToolUse hook, CI-guard,
-  deploy-wrapper, VictoriaLogs event-stream.
+- **Tenant-provisioning architectuur correct opgenomen.** Klai heeft
+  TWEE legitieme klassen prod-containers (compose-managed +
+  provisioning-managed), niet één.
+- **REQ-2 herschreven** naar code-fix: tenant-LibreChats SHALL
+  `klai.managed_by=portal-api-provisioning` + `klai.tenant_slug=<slug>`
+  + `klai.kind=librechat` labels dragen, gezet door
+  `_start_librechat_container`.
+- **REQ-2c uit v0.2.0 (compose-block voor librechat-voys) vervalt.**
+  Vervangen door REQ-2a (label-fix) + REQ-2b (eenmalige backfill).
+- **REQ-1, REQ-5, REQ-2c, REQ-2d** checken UNION van beide
+  label-klasses, niet alleen compose-project label.
 
 ## Requirements (EARS)
 
 ### R1 — PreToolUse hook blokkeert destructieve docker-acties
 WHEN een Bash tool-call matcht `docker rm`/`rmi`/`volume rm`/
 `system prune`/`compose down --volumes`, THEN
-`.claude/hooks/klai/container-hygiene-preflight.sh` SHALL eerst draaien
-en de checks uitvoeren: Caddy upstream, compose git-history,
-tenant-naam, depends_on, recent-traffic via VictoriaLogs. Eén positieve
-match = exit 1 = tool-call blocked. Hard-block voor `volume prune`
-en `image prune -af`. Geregistreerd in `.claude/settings.json`.
+`.claude/hooks/klai/container-hygiene-preflight.sh` SHALL eerst draaien.
+Hard-blocks: `volume prune`, `image prune -af`, `system prune -a`,
+`compose down --volumes`. Tenant-pattern + compose-history blocks
+voor targeted operations. Block-bericht voor tenant-pattern verwijst
+naar portal-api deprovision-flow.
 
-### R2 — Compose als single source, mechanisch geverifieerd
-**R2a (preventief):** `scripts/audit-compose-orphans.sh` draait in
-bestaande `audit-compose.yml` workflow op elke PR; faalt bij
-inconsistenties tussen Caddyfile, compose-services, en
-container_names. **R2b (detectief):** `compose-up.sh` (REQ-3) draait
-post-deploy `audit-orphan-snapshot.sh` die `event:orphan_post_deploy`
-naar VictoriaLogs emit. **R2c (concreet):** `librechat-voys` SHALL
-als service-block in `klai-infra/deploy/docker-compose.yml`.
+### R2 — Twee legitieme klassen, beide met label
+
+**Klasse A — Compose-managed:** `com.docker.compose.project=klai-core`
+(automatisch). Geen extra werk.
+
+**Klasse B — Provisioning-managed:** SHALL `klai.managed_by=portal-api-provisioning`
++ `klai.tenant_slug=<slug>` + `klai.kind=<type>` labels dragen.
+
+**REQ-2a:** code-fix in `_start_librechat_container` — labels-kwarg
+in `client.containers.run()`.
+**REQ-2b:** eenmalige backfill van librechat-voys (recreate met labels).
+**REQ-2c:** CI-guard `audit-compose-orphans.sh` matcht Caddy-upstreams
+tegen UNION van compose-services + provisioning-name-patterns.
+**REQ-2d:** post-deploy snapshot na `compose up -d` checkt UNION
+van beide label-klasses; flagt containers zonder enige.
 
 ### R3 — Deploy-wrapper met `--remove-orphans` ingebouwd
-Eén script `klai-infra/deploy/scripts/compose-up.sh` SHALL het
-canonieke deploy-mechanisme zijn — `docker compose pull && up -d
---remove-orphans` plus post-deploy snapshot. Alle 10 service-deploy-
-workflows SHALL via SSH dit script aanroepen. **STRIKT NA REQ-2c**.
+Eén script `klai-infra/deploy/scripts/compose-up.sh`. Alle 10
+service-deploy-workflows roepen via SSH dit script aan. Veilig naast
+klasse-B containers omdat `--remove-orphans` alleen klasse-A targets.
 
 ### R4 — VERVALLEN
-Image-pinning pilot geschrapt. VERSIONS.md is canoniek.
+Image-pinning. VERSIONS.md is canoniek.
 
 ### R5 — Audit als VictoriaLogs event-stream
-`scripts/docker-orphan-audit.sh` SHALL elke zondag 03:00 op core-01
-draaien en structlog-events emitten via stdout (Alloy → VictoriaLogs)
-met `service:klai-orphan-audit` en zes mogelijke `event:` types
-(orphan_no_compose_label, orphan_service_removed, image_untagged_old,
-volume_unmounted, caddy_upstream_missing, tenant_container_no_route).
-**REPORT-ONLY** — geen deletion. Grafana panel + alert. AI queryt via
-VictoriaLogs MCP.
+`scripts/docker-orphan-audit.sh` weekly zondag 03:00 op core-01,
+emit structlog-events naar VictoriaLogs. Detecteert containers die
+GEEN klasse-A EN GEEN klasse-B label dragen (UNION-check), naast de
+overige categorieën uit v0.2.0. **REPORT-ONLY.**
 
 ### R6 — Daily safe cleanup via systemd timer
-`docker-cleanup.timer` SHALL daily 03:00 draaien:
-`docker image prune -f`, `docker container prune -f --filter until=24h`,
-`docker network prune -f`, `docker builder prune -f --filter until=72h`.
-**NOOIT** `volume prune` of `image prune -af`.
+`docker-cleanup.timer` daily 03:00:
+`docker image prune -f`, `container prune -f --filter until=24h`,
+`network prune -f`, `builder prune -f --filter until=72h`.
+NOOIT `volume prune` of `image prune -af`.
 
 ### R7 — Pitfall-documentatie
-`container-cleanup-without-preflight (HIGH)` pitfall in
-`.claude/rules/klai/pitfalls/process-rules.md` met incident-tijdlijn
-+ "why mechanical not narrative" sectie.
+`container-cleanup-without-preflight (HIGH)` met incident +
+mechanical-vs-narrative + tenant-provisioning klasse-context.
 
 ## Files Affected
 
@@ -67,44 +75,47 @@ VictoriaLogs MCP.
 - UITGEBREID: `.claude/settings.json` (PreToolUse-hook registratie)
 - NIEUW: `.claude/rules/klai/infra/container-hygiene.md`
 - UITGEBREID: `.claude/rules/klai/pitfalls/process-rules.md`
+- UITGEBREID: `klai-portal/backend/app/services/provisioning/infrastructure.py`
+  (REQ-2a labels)
+- NIEUW: `klai-portal/backend/tests/services/provisioning/test_infrastructure_labels.py`
 - NIEUW: `.moai/specs/SPEC-INFRA-CONTAINER-HYGIENE-001/{spec,plan,acceptance,research,spec-compact,progress}.md`
 
 ### klai-infra (cross-repo)
 - NIEUW: `deploy/scripts/compose-up.sh` (REQ-3)
-- NIEUW: `scripts/audit-compose-orphans.sh` + `test-audit-compose-orphans.sh` (REQ-2a)
-- NIEUW: `scripts/audit-orphan-snapshot.sh` (REQ-2b)
+- NIEUW: `scripts/audit-compose-orphans.sh` + `test-audit-compose-orphans.sh` (REQ-2c)
+- NIEUW: `scripts/audit-orphan-snapshot.sh` (REQ-2d)
 - NIEUW: `scripts/docker-orphan-audit.sh` (REQ-5)
-- UITGEBREID: `deploy/docker-compose.yml` (REQ-2c librechat-voys block)
-- UITGEBREID: `.github/workflows/audit-compose.yml` (orphan-step)
-- UITGEBREID: 10× `.github/workflows/*.yml` (`docker compose up` → `compose-up.sh` aanroep)
+- UITGEBREID: `.github/workflows/audit-compose.yml`
+- UITGEBREID: 10× `.github/workflows/*.yml`
 - NIEUW: `core-01/systemd/docker-cleanup.{service,timer}` (REQ-6)
 - NIEUW: `core-01/systemd/orphan-audit.{service,timer}` (REQ-5)
 
-### Operator-acties op core-01 (geen Git)
+### Operator-acties op core-01
 - `systemctl link` + `enable --now` voor beide timers
-- Eenmalig: `librechat-voys` handmatig vervangen door compose-managed
-  variant na REQ-2c merge
+- Eenmalig: librechat-voys recreate met klasse-B labels (REQ-2b backfill)
 
 ## Acceptance Criteria
 
 | AC | Wat | Mechanische verificatie |
 |---|---|---|
-| AC-1 | Hook blokkeert `docker rm <tenant-container>` | exit-code 1 + "BLOCKED" in output; container nog aanwezig |
-| AC-2 | librechat-voys is compose-managed | `docker inspect` returns `klai-core` project label |
-| AC-3 | Deploy-wrapper + remove-orphans werkt; librechat-voys overleeft | scripted wees-test, librechat-voys still running |
+| AC-1 | Hook blokkeert `docker rm <tenant-container>` | exit-code 2 + JSON "BLOCKED" + provisioning-flow verwijzing |
+| AC-2 | Tenant-LibreChats dragen drie klasse-B labels | `docker inspect` toont alle drie; unit-test op `_start_librechat_container` |
+| AC-3 | Deploy-wrapper veilig naast klasse-B containers | scripted wees-test, librechat-voys overleeft |
 | AC-4 | Daily timer >=2 successful runs, dangling <50, named volumes intact | `journalctl` + `docker images` + volume-diff |
-| AC-5 | Audit-events queryable in VictoriaLogs | LogsQL query returns events; zero `orphan_no_compose_label` |
-| AC-6 | Audit-events worden door REQ-1 hook gebruikt | end-to-end test: dummy orphan → audit detect → hook blokkeert |
-| AC-7 | Pitfall + CI-guard | `grep` returns 0 in deze repo; klai-infra CI faalt op test-fixture |
+| AC-5 | Audit-stream UNION-check werkt | LogsQL query, zero `orphan_no_managed_label` voor prod containers |
+| AC-6 | Hook gebruikt audit-stream + onderscheidt klasse-B | end-to-end test op dev-stack |
+| AC-7 | Pitfall + CI-guard | grep + CI-fixture |
 
 ## Run Acceptance Aggregate
 
 - AC-1 t/m AC-7 allemaal binnen 7 dagen na laatste deploy
 - Geen productie-incident causaal aan deze SPEC's deploys
 - 30d post REQ-6: dangling-count consistent <50
-- 30d post REQ-1: minstens 1 `event:hook_blocked` event in VictoriaLogs
-- 30d post REQ-5: zero `event:orphan_no_compose_label` buiten gelabelde
-  `klai.adhoc=*` containers
+- 30d post REQ-1: minstens 1 `event:hook_blocked` in VictoriaLogs
+- 30d post REQ-2 + REQ-5: zero `event:orphan_no_managed_label`
+  buiten gelabelde `klai.adhoc=*`
+- librechat-voys draagt klasse-B labels (post-backfill)
+- Toekomstige tenant-provisioning landt automatisch met labels
 
 ## Exclusions
 
@@ -115,31 +126,33 @@ VictoriaLogs MCP.
 - Vexa recordings volume
 - GHCR retention policy
 - Kubernetes / multi-server hygiene
+- `librechat-getklai` klasse-B labels (blijft compose-managed klasse A)
+- Generaliseren label-schema naar future tenant-services (eigen SPEC)
 
 ## Implementation Volgorde (STRIKT)
 
-1. **klai-PR:** REQ-1 (hook script + settings.json) + REQ-7 (pitfall)
-   + REQ-1 narrative — alle in deze repo, geen externe deps
-2. **klai-infra-PR:** REQ-2c (librechat-voys compose-block) + handmatige
-   container-vervanging op core-01
-3. **klai-infra-PR:** REQ-3 (compose-up.sh) + 1 pilot-workflow (`docs.yml`),
-   24u monitoring vóór bredere rollout
-4. **klai-infra-PR:** REQ-3 rollout naar overige 9 workflows
-5. **klai-infra-PR:** REQ-2a + REQ-2b (audit-compose-orphans +
-   audit-orphan-snapshot)
-6. **klai-infra-PR:** REQ-6 (systemd cleanup timer + activation)
-7. **klai-infra-PR:** REQ-5 (audit-stream script + systemd timer +
-   Grafana panel/alert)
+1. **klai-PR Stage 1 (gedaan, 55964c56):** REQ-1 hook + REQ-7 pitfall
+   + REQ-1 narrative.
+2. **klai-PR Stage 1.5 (deze v0.3.0 update):** REQ-2a code-fix in
+   `_start_librechat_container` + tests, hook block-bericht update,
+   narrative + pitfall update voor klasse-B nuance, REQ-2b
+   handmatige backfill librechat-voys op core-01.
+3. **klai-infra-PR Stage 2:** REQ-3 compose-up.sh + docs.yml pilot
+   (24u monitoring).
+4. **klai-infra-PR Stage 3:** REQ-3 rollout naar 9 overige workflows.
+5. **klai-infra-PR Stage 4:** REQ-2c + REQ-2d audit-compose-orphans
+   + post-deploy snapshot.
+6. **klai-infra-PR Stage 5:** REQ-6 systemd cleanup timer + activatie.
+7. **klai-infra-PR Stage 6:** REQ-5 audit-stream + Grafana panel.
 
 Worktree-pattern: één per repo. Geen mega-PR.
 
 ## Open Questions voor `/moai run`
 
-1. Hook fail-mode bij ontbrekende deps: fail-open of fail-closed?
-   (voorkeur: fail-closed met `jq`/`curl` als hard requirement;
-   `ssh core-01` reachability fail-open voor dev-machines)
-2. Per-workflow `--remove-orphans` flag of compose-up.sh wrapper?
-   (voorkeur: wrapper, maar uitwisselbaar met
-   `COMPOSE_REMOVE_ORPHANS=true` env-var)
-3. Bevestiging dat Alloy alle container-stdout zonder filter forward
-   naar VictoriaLogs (voor REQ-5 emit-via-stdout pattern)
+1. Hook fail-mode bij ontbrekende deps: fail-closed jq/curl, fail-open
+   SSH reachability.
+2. Per-workflow `--remove-orphans` of compose-up.sh wrapper? Wrapper
+   voorkeur.
+3. Alloy stdout-pickup bevestiging voor REQ-5 emit-via-stdout pattern.
+4. `librechat-getklai` óók klasse-B labels? Voorkeur: nee, blijf
+   compose-managed.

--- a/.moai/specs/SPEC-INFRA-CONTAINER-HYGIENE-001/spec.md
+++ b/.moai/specs/SPEC-INFRA-CONTAINER-HYGIENE-001/spec.md
@@ -1,6 +1,6 @@
 ---
 id: SPEC-INFRA-CONTAINER-HYGIENE-001
-version: "0.2.0"
+version: "0.3.0"
 status: draft
 created: "2026-05-02"
 updated: "2026-05-02"
@@ -14,7 +14,8 @@ issue_number: 0
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
 | 0.1.0 | 2026-05-02 | MoAI | Initiële stub na librechat-voys cleanup-incident. 7 requirements: rule-files, librechat-voys compose-block, --remove-orphans, image-pinning pilot, weekly audit, daily prune, pitfall. |
-| 0.2.0 | 2026-05-02 | MoAI | Twee fundamentele herzieningen na review: (1) REQ-4 (image-pinning pilot) **geschrapt** — `:latest` op `ghcr.io/getklai/*` is bewust beleid per `deploy/VERSIONS.md` + `docs/runbooks/version-management.md`; rollback gaat via `:${github.sha}` tags die CI ook pusht. De 679 dangling images zijn een geaccepteerde bijwerking, opgelost door REQ-6 daily prune. (2) REQ-1/2/3/5 herschreven naar **AI-first mechanische guards** — geen markdown-rules die agents moeten lezen, maar PreToolUse hooks, CI-checks, deploy-wrappers, en VictoriaLogs-events die AI mechanisch volgt en queryt. Aanleiding: een AI doet het primaire code- en deploy-werk; "vertrouw op discipline" is geen vangnet. |
+| 0.2.0 | 2026-05-02 | MoAI | Twee fundamentele herzieningen na review: (1) REQ-4 (image-pinning pilot) **geschrapt** — `:latest` op `ghcr.io/getklai/*` is bewust beleid per `deploy/VERSIONS.md` + `docs/runbooks/version-management.md`. (2) REQ-1/2/3/5 herschreven naar **AI-first mechanische guards** — PreToolUse hooks, CI-checks, deploy-wrappers, VictoriaLogs-events. |
+| 0.3.0 | 2026-05-02 | MoAI | **Tenant-provisioning architectuur correct opgenomen.** REQ-2 was "alles via compose" — fout. Klai heeft twee legitieme klassen prod-containers: (a) compose-managed met `com.docker.compose.project=klai-core` label, (b) provisioning-managed door portal-api via `client.containers.run()` per tenant (zie `klai-portal/backend/app/services/provisioning/infrastructure.py::_start_librechat_container`). REQ-2 herschreven: tenant-LibreChats SHALL `klai.managed_by=portal-api-provisioning` + `klai.tenant_slug=<slug>` + `klai.kind=librechat` labels dragen. REQ-2c (librechat-voys in compose-block toevoegen) **vervalt** — vervangen door label-backfill voor bestaande tenants. REQ-1 hook + REQ-5 audit detecteren wezen op afwezigheid van **beide** label-klasses, niet alleen compose-label. Aanleiding: gebruiker review wees op tenant-provisioning patroon dat ik gemist had. |
 
 # SPEC-INFRA-CONTAINER-HYGIENE-001: Container hygiene op core-01 — mechanische guards tegen orphans, dangling images en verlaten volumes
 
@@ -22,10 +23,19 @@ issue_number: 0
 
 Elimineer de drie fout-klassen die op 2026-05-02 zichtbaar werden:
 
-1. **Wees-containers** — productie-containers die via handmatige
-   `docker run` draaien zonder `com.docker.compose.project` label en
-   daardoor onzichtbaar zijn voor automatische tooling. Een AI of
-   cleanup-agent kan ze niet onderscheiden van echte rommel.
+1. **Wees-containers** — productie-containers die voor cleanup-tools
+   onzichtbaar zijn omdat ze geen herkenbare beheers-label dragen.
+   Klai heeft TWEE legitieme klassen prod-containers, beide door deze
+   SPEC erkend:
+   - **Compose-managed:** `com.docker.compose.project=klai-core` label,
+     gedeclareerd in `klai-infra/deploy/docker-compose.yml`.
+   - **Provisioning-managed:** door portal-api dynamisch aangemaakt
+     via `client.containers.run()` per tenant
+     (zie `klai-portal/backend/app/services/provisioning/infrastructure.py::_start_librechat_container`).
+     SHALL `klai.managed_by=portal-api-provisioning`,
+     `klai.tenant_slug=<slug>`, en `klai.kind=<type>` labels dragen
+     (REQ-2).
+   Een container zonder een van beide label-klasses is een wees.
 2. **Service-removed-but-running** — compose-services worden uit
    `docker-compose.yml` gehaald zonder dat hun container/volume mee
    wordt opgeruimd, omdat `docker compose up` standaard zonder
@@ -38,9 +48,10 @@ Elimineer de drie fout-klassen die op 2026-05-02 zichtbaar werden:
 Het librechat-voys incident is de directe aanleiding: een cleanup-agent
 verwijderde de tenant-specifieke container omdat hij op alle
 mens-leesbare signalen ("geen compose label, geen Caddy upstream") als
-wees uitkwam. Recovery was mogelijk omdat de tenant-config intact bleef,
-maar de oude image-sha was permanent verloren — niet reproduceerbaar
-omdat hij nooit een registry-tag had.
+wees uitkwam. De container was in feite provisioning-managed via
+portal-api — maar `_start_librechat_container` zette geen labels, dus
+het was niet detecteerbaar als legitiem. Recovery was mogelijk omdat de
+tenant-config intact bleef, maar de oude image-sha was permanent verloren.
 
 **De fix is mechanisch, niet documentair.** Een AI doet het primaire
 code- en deploy-werk in deze codebase. Regels die "vertrouwen op
@@ -51,15 +62,16 @@ falen, en logs-die-AI-zelf-queryt vóór cleanup-beslissingen.
 Zes requirements over drie lagen:
 
 - **Mechanische guards** (deze repo): pre-cleanup hook (REQ-1),
-  CI orphan-detectie (REQ-2-deel), pitfall (REQ-7).
+  provisioning-labels in portal-api (REQ-2), pitfall (REQ-7).
 - **Tooling op core-01**: weekly audit-stream naar VictoriaLogs (REQ-5),
   daily safe-only prune via systemd timer (REQ-6).
-- **Cross-repo deploy-discipline** (klai-infra): librechat-voys als
-  compose-service (REQ-2-fix), deploy-wrapper-script met `--remove-orphans`
-  ingebouwd (REQ-3).
+- **Cross-repo deploy-discipline** (klai-infra): deploy-wrapper-script
+  met `--remove-orphans` ingebouwd (REQ-3), CI orphan-guard (REQ-2a).
 
 REQ-4 uit v0.1.0 is geschrapt. VERSIONS.md + version-management.md
-zijn de canoniek voor image-pinning.
+zijn de canoniek voor image-pinning. REQ-2c uit v0.2.0 (librechat-voys
+in compose-block toevoegen) is in v0.3.0 vervangen door REQ-2 label-fix
+plus eenmalige backfill.
 
 ## Environment
 
@@ -75,21 +87,28 @@ zijn de canoniek voor image-pinning.
   documentatie + verwijzing naar het script),
   `.claude/rules/klai/pitfalls/process-rules.md` (uitgebreid met
   `container-cleanup-without-preflight (HIGH)`).
-- **Affected klai-infra:** `deploy/docker-compose.yml` (REQ-2
-  librechat-voys block), `deploy/scripts/compose-up.sh` (nieuw — deploy-
-  wrapper voor REQ-3), `scripts/audit-compose-orphans.sh` (nieuw — REQ-2
-  CI-guard), `scripts/test-audit-compose-orphans.sh` (regression test),
-  `scripts/docker-orphan-audit.sh` (nieuw — REQ-5 emit-naar-VictoriaLogs),
-  `core-01/systemd/docker-cleanup.{service,timer}` (REQ-6),
-  `core-01/systemd/orphan-audit.{service,timer}` (REQ-5),
-  `.github/workflows/audit-compose.yml` (uitgebreid met orphan-check
-  voor REQ-2), 10 service-deploy-workflows (`portal-api.yml`,
-  `klai-connector.yml`, etc. — vervangen `docker compose up` door
-  `compose-up.sh` aanroep voor REQ-3).
+- **Affected portal-api code in klai (deze repo):**
+  `klai-portal/backend/app/services/provisioning/infrastructure.py`
+  — `_start_librechat_container` SHALL `labels={...}` toevoegen aan
+  `client.containers.run()` (REQ-2). Tests in
+  `klai-portal/backend/tests/services/provisioning/test_infrastructure_labels.py`
+  (nieuw) verifiëren label-aanwezigheid.
+- **Affected klai-infra:** `deploy/scripts/compose-up.sh` (nieuw —
+  deploy-wrapper voor REQ-3), `scripts/audit-compose-orphans.sh`
+  (nieuw — REQ-2a CI-guard), `scripts/test-audit-compose-orphans.sh`
+  (regression test), `scripts/docker-orphan-audit.sh` (nieuw — REQ-5
+  emit-naar-VictoriaLogs), `core-01/systemd/docker-cleanup.{service,timer}`
+  (REQ-6), `core-01/systemd/orphan-audit.{service,timer}` (REQ-5),
+  `.github/workflows/audit-compose.yml` (uitgebreid met orphan-check),
+  10 service-deploy-workflows — vervangen `docker compose up` door
+  `compose-up.sh` aanroep voor REQ-3.
 - **Affected core-01 host (operator-actie via SSH/Ansible):**
   `/etc/systemd/system/docker-cleanup.{service,timer}`,
   `/etc/systemd/system/orphan-audit.{service,timer}`,
-  symlinks naar de scripts in klai-infra checkout.
+  symlinks naar de scripts in klai-infra checkout. **Backfill:**
+  bestaande `librechat-voys` en `librechat-getklai` containers worden
+  eenmalig opnieuw gestart met de nieuwe labels (recreate vereist;
+  labels zijn immutable na container create).
 
 ## Assumptions
 
@@ -128,27 +147,26 @@ SHALL eerst draaien. Het script SHALL:
 
 1. Parsen welk argument wordt verwijderd (container-naam,
    image-naam/sha, volume-naam, of bulk-prune).
-2. Voor container-targets: vijf checks uitvoeren:
-   - **Caddy upstream check:** wordt de naam genoemd in
-     `/opt/klai/Caddyfile` (via `ssh core-01`)?
-   - **Compose git-history check:** stond de naam ooit in
-     `klai-infra/deploy/docker-compose*.yml`?
-   - **Tenant-naam check:** matcht de naam regex
-     `-(voys|getklai|[a-z]+-tenant)$`?
-   - **Depends-on check:** heeft een running container `depends_on`
-     op deze naam (uit compose-labels)?
-   - **Recent-traffic check:** had de naam in afgelopen 30d log-events
-     in VictoriaLogs (`service:<name>` query)?
-3. Voor image-targets: heeft de image een tag die in
-   `klai-infra/deploy/docker-compose.yml` voorkomt? Wordt hij
-   gebruikt door een running container?
-4. Voor volume-targets: heeft het volume mounts in een running
-   container? Heeft het een naam in een tenant-pattern? Bevat het data
-   in afgelopen 30 dagen?
+2. Hard-blocks voor altijd-gevaarlijke patterns:
+   `docker volume prune`, `docker image prune -af`,
+   `docker system prune -a`, `docker compose down --volumes`.
+3. Voor container-targets: hard-block bij positieve match op één van:
+   - **Tenant-naam check:** target ends in `-voys`, `-getklai`, of
+     `-<klant>-tenant`. Block-bericht verwijst naar de
+     provisioning-flow (REQ-2): "if portal-api-managed, use the
+     deprovision flow; do not docker rm directly".
+   - **Compose git-history check:** target stond ooit als service in
+     `klai-infra/deploy/docker-compose*.yml` (best-effort, alleen
+     wanneer klai-infra checkout sibling beschikbaar is).
+4. Best-effort checks (skip-bij-onreachable, fail-open):
+   - **Caddy upstream check:** target voorkomt in
+     `/opt/klai/Caddyfile` via `ssh core-01`.
+   - **VictoriaLogs traffic check:** target had log-events in
+     afgelopen 30d.
 
-Eén positieve match = exit-code 1 met diagnose-bericht. De Bash tool-call
-wordt geblokkeerd; Claude moet expliciet de blokkade overwegen, om
-hulp vragen, of de actie afbreken.
+Een positieve match = exit-code 2 met JSON-decision-payload. De Bash
+tool-call wordt geblokkeerd; Claude moet expliciet de blokkade
+overwegen, hulp vragen, of de actie afbreken.
 
 Het script SHALL idempotent en hermetic zijn (geen state-mutatie, geen
 externe afhankelijkheden behalve `docker`, `ssh`, `curl`,
@@ -163,44 +181,61 @@ het script + hook.
 `PreToolUse` hook met `matcher: "Bash"` en de juiste command-path via
 `$CLAUDE_PROJECT_DIR`.
 
-### R2 — Ubiquitous: alle prod containers via compose, mechanisch geverifieerd
+### R2 — Ubiquitous: élke prod container draagt een herkenningslabel
 
-Elke container die productie-traffic ziet SHALL als service in
-`klai-infra/deploy/docker-compose.yml` (of geldige override) gedeclareerd
-zijn. Verificatie gebeurt op twee plekken:
+Elke productie-container SHALL door één van de twee canonieke beheers-
+paden zijn aangemaakt en bijbehorend label dragen:
 
-**R2a — CI-guard (preventief):**
+**Klasse A — Compose-managed:**
+- Aangemaakt via `docker compose up` op `klai-infra/deploy/docker-compose.yml`.
+- Draagt automatisch `com.docker.compose.project=klai-core` (en
+  `com.docker.compose.service=<naam>`).
+- Geen extra werk in deze SPEC — bestaand patroon.
+
+**Klasse B — Provisioning-managed:**
+- Aangemaakt door portal-api via `client.containers.run()`,
+  momenteel uitsluitend tenant-LibreChats via
+  `_start_librechat_container` in
+  `klai-portal/backend/app/services/provisioning/infrastructure.py`.
+- SHALL labels dragen: `klai.managed_by=portal-api-provisioning`,
+  `klai.tenant_slug=<slug>`, `klai.kind=librechat`. Future kinds
+  (e.g. tenant-meilisearch, tenant-vectorstore) volgen hetzelfde
+  schema met andere `klai.kind`.
+
+**REQ-2a — Code-fix in `_start_librechat_container`:**
+
+`client.containers.run()` SHALL een `labels` keyword-arg meegeven met
+ten minste de drie genoemde labels. Tests SHALL de aanwezigheid van
+elk label verifiëren via `docker inspect` (of mock equivalent).
+
+**REQ-2b — Backfill voor bestaande tenant-containers:**
+
+`librechat-voys` (handmatig herstart op 2026-05-02) en
+`librechat-getklai` (compose-managed, dus al klasse A) MOETEN bij de
+volgende geplande herstart de juiste labels dragen. Voor
+`librechat-voys`: één-malige operator-actie op core-01 om de container
+te recreaten met de nieuwe labels (Docker labels zijn immutable na
+container create — recreate is de enige weg). Documentatie van het
+exacte commando in `docs/runbooks/` of PR-body.
+
+**REQ-2c — CI-guard tegen toekomstige label-loosheid:**
 
 `klai-infra/scripts/audit-compose-orphans.sh` SHALL bij elke PR die
 `docker-compose.yml` raakt, draaien als deel van de bestaande
-`audit-compose.yml` workflow. De check SHALL:
+`audit-compose.yml` workflow. De check SHALL Caddy-upstreams in
+`deploy/caddy/Caddyfile` matchen tegen een UNION van: (a) service-namen
+in compose, (b) bekende provisioning-managed naam-patterns
+(`librechat-*`), (c) whitelisted external endpoints.
 
-- Voor elke service-naam in compose: bevestigen dat de service een
-  geldige `image:` of `build:` directive heeft.
-- Voor elke `container_name:`: bevestigen dat de naam matcht het
-  service-block (geen drift).
-- Voor elke Caddy-upstream in `deploy/caddy/Caddyfile`: bevestigen dat
-  de upstream een service in compose is OF een whitelisted external
-  endpoint (Vexa intern, GHCR, etc.).
-- Een regression-fixture `test-audit-compose-orphans.sh` SHALL faal-cases
-  testen die zonder de check zouden lekken.
-
-**R2b — Post-deploy verificatie (detectief):**
+**REQ-2d — Post-deploy verificatie:**
 
 Na elke `compose up -d` (via REQ-3 wrapper) SHALL het wrapper-script
-verifiëren: zijn er nu containers running die GEEN
-`com.docker.compose.project=klai-core` (of bekende override-project)
-label hebben? Zo ja, waarschuwingsregel naar VictoriaLogs (REQ-5
-event-stream) met `event:orphan_post_deploy`.
-
-**R2c — Concrete fix voor librechat-voys:**
-
-Een service-block `librechat-voys` SHALL toegevoegd worden aan
-`klai-infra/deploy/docker-compose.yml` (1-op-1 spiegel van
-`librechat-getklai`, paths vervangen door `./librechat/voys/...`). De
-huidige handmatig-gestarte container SHALL bij eerstvolgende
-compose-up vervangen worden door de compose-managed variant met
-dezelfde naam.
+verifiëren: zijn er nu running containers die GEEN
+`com.docker.compose.project=klai-core` label EN GEEN
+`klai.managed_by=portal-api-provisioning` label hebben? Zo ja,
+waarschuwingsregel naar VictoriaLogs (REQ-5 event-stream) met
+`event:orphan_post_deploy`. Containers met `klai.adhoc=*` label vallen
+buiten — dat is bewust ad-hoc debug-werk per REQ-7.
 
 ### R3 — Event-driven: deploy-wrapper met `--remove-orphans` ingebouwd
 
@@ -463,11 +498,13 @@ emit_event() {
       container_name:$name, details:$details, _time:$ts}'
 }
 
-# Detectie 1: orphan_no_compose_label
+# Detectie 1: orphan (geen van beide legitieme label-klasses)
 docker ps --format '{{.Names}}' | while read -r name; do
   proj=$(docker inspect "$name" --format '{{index .Config.Labels "com.docker.compose.project"}}')
-  if [ "$proj" != "klai-core" ]; then
-    emit_event "orphan_no_compose_label" "warning" "$name" \
+  managed_by=$(docker inspect "$name" --format '{{index .Config.Labels "klai.managed_by"}}')
+  adhoc=$(docker inspect "$name" --format '{{index .Config.Labels "klai.adhoc"}}')
+  if [ "$proj" != "klai-core" ] && [ "$managed_by" != "portal-api-provisioning" ] && [ -z "$adhoc" ]; then
+    emit_event "orphan_no_managed_label" "warning" "$name" \
       "{\"image\":\"$(docker inspect "$name" --format '{{.Config.Image}}')\"}"
   fi
 done

--- a/.moai/specs/SPEC-INFRA-CONTAINER-HYGIENE-001/spec.md
+++ b/.moai/specs/SPEC-INFRA-CONTAINER-HYGIENE-001/spec.md
@@ -1,0 +1,604 @@
+---
+id: SPEC-INFRA-CONTAINER-HYGIENE-001
+version: "0.2.0"
+status: draft
+created: "2026-05-02"
+updated: "2026-05-02"
+author: MoAI
+priority: high
+issue_number: 0
+---
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 0.1.0 | 2026-05-02 | MoAI | Initiële stub na librechat-voys cleanup-incident. 7 requirements: rule-files, librechat-voys compose-block, --remove-orphans, image-pinning pilot, weekly audit, daily prune, pitfall. |
+| 0.2.0 | 2026-05-02 | MoAI | Twee fundamentele herzieningen na review: (1) REQ-4 (image-pinning pilot) **geschrapt** — `:latest` op `ghcr.io/getklai/*` is bewust beleid per `deploy/VERSIONS.md` + `docs/runbooks/version-management.md`; rollback gaat via `:${github.sha}` tags die CI ook pusht. De 679 dangling images zijn een geaccepteerde bijwerking, opgelost door REQ-6 daily prune. (2) REQ-1/2/3/5 herschreven naar **AI-first mechanische guards** — geen markdown-rules die agents moeten lezen, maar PreToolUse hooks, CI-checks, deploy-wrappers, en VictoriaLogs-events die AI mechanisch volgt en queryt. Aanleiding: een AI doet het primaire code- en deploy-werk; "vertrouw op discipline" is geen vangnet. |
+
+# SPEC-INFRA-CONTAINER-HYGIENE-001: Container hygiene op core-01 — mechanische guards tegen orphans, dangling images en verlaten volumes
+
+## Overview
+
+Elimineer de drie fout-klassen die op 2026-05-02 zichtbaar werden:
+
+1. **Wees-containers** — productie-containers die via handmatige
+   `docker run` draaien zonder `com.docker.compose.project` label en
+   daardoor onzichtbaar zijn voor automatische tooling. Een AI of
+   cleanup-agent kan ze niet onderscheiden van echte rommel.
+2. **Service-removed-but-running** — compose-services worden uit
+   `docker-compose.yml` gehaald zonder dat hun container/volume mee
+   wordt opgeruimd, omdat `docker compose up` standaard zonder
+   `--remove-orphans` draait.
+3. **Dangling-image-explosie** — 679 stuks (60 GB), accepted side-effect
+   van `:latest` rolling-tags op klai-eigen images (per VERSIONS.md
+   bewust beleid), maar accumuleert tot disk-druk zonder periodiek
+   opruimen.
+
+Het librechat-voys incident is de directe aanleiding: een cleanup-agent
+verwijderde de tenant-specifieke container omdat hij op alle
+mens-leesbare signalen ("geen compose label, geen Caddy upstream") als
+wees uitkwam. Recovery was mogelijk omdat de tenant-config intact bleef,
+maar de oude image-sha was permanent verloren — niet reproduceerbaar
+omdat hij nooit een registry-tag had.
+
+**De fix is mechanisch, niet documentair.** Een AI doet het primaire
+code- en deploy-werk in deze codebase. Regels die "vertrouwen op
+discipline" zijn dan een gat. Deze SPEC vervangt rules-die-gelezen-
+moeten-worden door scripts-die-mechanisch-blokkeren, CI-checks-die-PRs-
+falen, en logs-die-AI-zelf-queryt vóór cleanup-beslissingen.
+
+Zes requirements over drie lagen:
+
+- **Mechanische guards** (deze repo): pre-cleanup hook (REQ-1),
+  CI orphan-detectie (REQ-2-deel), pitfall (REQ-7).
+- **Tooling op core-01**: weekly audit-stream naar VictoriaLogs (REQ-5),
+  daily safe-only prune via systemd timer (REQ-6).
+- **Cross-repo deploy-discipline** (klai-infra): librechat-voys als
+  compose-service (REQ-2-fix), deploy-wrapper-script met `--remove-orphans`
+  ingebouwd (REQ-3).
+
+REQ-4 uit v0.1.0 is geschrapt. VERSIONS.md + version-management.md
+zijn de canoniek voor image-pinning.
+
+## Environment
+
+- **Affected services** (klai-eigen, blijven `:latest` per VERSIONS.md
+  beleid; geraakt alleen door REQ-6 daily prune): klai-portal-api,
+  klai-connector, klai-knowledge-ingest, klai-knowledge-mcp,
+  klai-mailer, klai-scribe-api, klai-retrieval-api, klai-docs-app,
+  klai-caddy-hetzner, klai-portal-frontend.
+- **Affected hooks/rules in klai (deze repo):**
+  `.claude/hooks/klai/container-hygiene-preflight.sh` (nieuw),
+  `.claude/settings.json` (PreToolUse-hook registratie),
+  `.claude/rules/klai/infra/container-hygiene.md` (nieuw, narrative
+  documentatie + verwijzing naar het script),
+  `.claude/rules/klai/pitfalls/process-rules.md` (uitgebreid met
+  `container-cleanup-without-preflight (HIGH)`).
+- **Affected klai-infra:** `deploy/docker-compose.yml` (REQ-2
+  librechat-voys block), `deploy/scripts/compose-up.sh` (nieuw — deploy-
+  wrapper voor REQ-3), `scripts/audit-compose-orphans.sh` (nieuw — REQ-2
+  CI-guard), `scripts/test-audit-compose-orphans.sh` (regression test),
+  `scripts/docker-orphan-audit.sh` (nieuw — REQ-5 emit-naar-VictoriaLogs),
+  `core-01/systemd/docker-cleanup.{service,timer}` (REQ-6),
+  `core-01/systemd/orphan-audit.{service,timer}` (REQ-5),
+  `.github/workflows/audit-compose.yml` (uitgebreid met orphan-check
+  voor REQ-2), 10 service-deploy-workflows (`portal-api.yml`,
+  `klai-connector.yml`, etc. — vervangen `docker compose up` door
+  `compose-up.sh` aanroep voor REQ-3).
+- **Affected core-01 host (operator-actie via SSH/Ansible):**
+  `/etc/systemd/system/docker-cleanup.{service,timer}`,
+  `/etc/systemd/system/orphan-audit.{service,timer}`,
+  symlinks naar de scripts in klai-infra checkout.
+
+## Assumptions
+
+- A1: Het librechat-voys incident is een instance van een klasse, niet
+  een uitschieter. Andere productie-containers kunnen in de toekomst
+  weer als handmatige `docker run` ontstaan (debug-sessie, hotfix,
+  tijdelijk werkrond).
+- A2: Een AI is de primaire code- en deploy-actor. Mechanische guards
+  zijn nodig; markdown-regels die AI moet lezen zijn een gat dat door
+  context-truncatie of prompt-variatie zomaar verschijnt.
+- A3: VERSIONS.md + version-management.md zijn canoniek en up-to-date.
+  `:latest` op `ghcr.io/getklai/*` is bewust beleid; deze SPEC raakt
+  dat niet. Renovate/Dependabot/Trivy/scan-pinned-images.yml zijn
+  het complete version-management ecosysteem.
+- A4: Klai's bestaande `audit-compose.yml` workflow (`audit-compose-volumes.sh`
+  + `test-audit-compose.sh`) is het patroon dat REQ-2 volgt — geen
+  nieuwe workflow, uitbreiding van de bestaande met een orphan-check.
+- A5: VictoriaLogs is de canonieke ops-event-stream (per
+  `observability.md`). Audit-events horen daar, niet in `product_events`.
+- A6: Operator heeft SSH-toegang tot core-01 met sudo-rechten voor
+  systemd unit-installatie, of er is een Ansible-pipeline. Beide werken;
+  REQ-6 implementatie volgt de gekozen modaliteit.
+- A7: Claude Code's `PreToolUse` hook-mechanisme via
+  `.claude/settings.json` werkt zoals gedocumenteerd: hook ontvangt
+  tool-call JSON via stdin, exit-code != 0 blokkeert de tool-call.
+
+## Requirements
+
+### R1 — Ubiquitous: PreToolUse hook blokkeert destructieve docker-acties
+
+WHEN een Claude-sessie in de klai-repo een `Bash` tool-call doet die
+matcht op `docker rm`, `docker rmi`, `docker volume rm`,
+`docker system prune`, of `docker compose down --volumes`, THEN het
+PreToolUse-hook script `.claude/hooks/klai/container-hygiene-preflight.sh`
+SHALL eerst draaien. Het script SHALL:
+
+1. Parsen welk argument wordt verwijderd (container-naam,
+   image-naam/sha, volume-naam, of bulk-prune).
+2. Voor container-targets: vijf checks uitvoeren:
+   - **Caddy upstream check:** wordt de naam genoemd in
+     `/opt/klai/Caddyfile` (via `ssh core-01`)?
+   - **Compose git-history check:** stond de naam ooit in
+     `klai-infra/deploy/docker-compose*.yml`?
+   - **Tenant-naam check:** matcht de naam regex
+     `-(voys|getklai|[a-z]+-tenant)$`?
+   - **Depends-on check:** heeft een running container `depends_on`
+     op deze naam (uit compose-labels)?
+   - **Recent-traffic check:** had de naam in afgelopen 30d log-events
+     in VictoriaLogs (`service:<name>` query)?
+3. Voor image-targets: heeft de image een tag die in
+   `klai-infra/deploy/docker-compose.yml` voorkomt? Wordt hij
+   gebruikt door een running container?
+4. Voor volume-targets: heeft het volume mounts in een running
+   container? Heeft het een naam in een tenant-pattern? Bevat het data
+   in afgelopen 30 dagen?
+
+Eén positieve match = exit-code 1 met diagnose-bericht. De Bash tool-call
+wordt geblokkeerd; Claude moet expliciet de blokkade overwegen, om
+hulp vragen, of de actie afbreken.
+
+Het script SHALL idempotent en hermetic zijn (geen state-mutatie, geen
+externe afhankelijkheden behalve `docker`, `ssh`, `curl`,
+`git`). Run-tijd onder 5 seconden.
+
+Het bestand `.claude/rules/klai/infra/container-hygiene.md` SHALL de
+checklist narrative documenteren met verwijzing naar het script. Het
+narrative is voor mens-review en debug; de mechanische enforcement is
+het script + hook.
+
+`.claude/settings.json` SHALL het script registreren als
+`PreToolUse` hook met `matcher: "Bash"` en de juiste command-path via
+`$CLAUDE_PROJECT_DIR`.
+
+### R2 — Ubiquitous: alle prod containers via compose, mechanisch geverifieerd
+
+Elke container die productie-traffic ziet SHALL als service in
+`klai-infra/deploy/docker-compose.yml` (of geldige override) gedeclareerd
+zijn. Verificatie gebeurt op twee plekken:
+
+**R2a — CI-guard (preventief):**
+
+`klai-infra/scripts/audit-compose-orphans.sh` SHALL bij elke PR die
+`docker-compose.yml` raakt, draaien als deel van de bestaande
+`audit-compose.yml` workflow. De check SHALL:
+
+- Voor elke service-naam in compose: bevestigen dat de service een
+  geldige `image:` of `build:` directive heeft.
+- Voor elke `container_name:`: bevestigen dat de naam matcht het
+  service-block (geen drift).
+- Voor elke Caddy-upstream in `deploy/caddy/Caddyfile`: bevestigen dat
+  de upstream een service in compose is OF een whitelisted external
+  endpoint (Vexa intern, GHCR, etc.).
+- Een regression-fixture `test-audit-compose-orphans.sh` SHALL faal-cases
+  testen die zonder de check zouden lekken.
+
+**R2b — Post-deploy verificatie (detectief):**
+
+Na elke `compose up -d` (via REQ-3 wrapper) SHALL het wrapper-script
+verifiëren: zijn er nu containers running die GEEN
+`com.docker.compose.project=klai-core` (of bekende override-project)
+label hebben? Zo ja, waarschuwingsregel naar VictoriaLogs (REQ-5
+event-stream) met `event:orphan_post_deploy`.
+
+**R2c — Concrete fix voor librechat-voys:**
+
+Een service-block `librechat-voys` SHALL toegevoegd worden aan
+`klai-infra/deploy/docker-compose.yml` (1-op-1 spiegel van
+`librechat-getklai`, paths vervangen door `./librechat/voys/...`). De
+huidige handmatig-gestarte container SHALL bij eerstvolgende
+compose-up vervangen worden door de compose-managed variant met
+dezelfde naam.
+
+### R3 — Event-driven: deploy-wrapper met `--remove-orphans` ingebouwd
+
+Eén bash-script `klai-infra/deploy/scripts/compose-up.sh` SHALL het
+canonieke deploy-mechanisme zijn. Inhoud (kern):
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+SERVICE="${1:-}"
+cd /opt/klai
+if [ -n "$SERVICE" ]; then
+  docker compose pull "$SERVICE"
+  docker compose up -d --remove-orphans "$SERVICE"
+else
+  docker compose pull
+  docker compose up -d --remove-orphans
+fi
+# REQ-2b post-deploy orphan-check
+/opt/klai/scripts/audit-orphan-snapshot.sh
+```
+
+Alle 10 deploy-workflows in klai-infra (`caddy.yml`, `docs.yml`,
+`klai-connector.yml`, `klai-knowledge-mcp.yml`, `klai-mailer.yml`,
+`knowledge-ingest.yml`, `portal-api.yml`, `retrieval-api.yml`,
+`scribe-api.yml`, `whisper-server.yml`) SHALL via SSH dit script
+aanroepen ipv `docker compose up` direct. Voorbeeld:
+
+```yaml
+- name: Deploy on core-01
+  run: ssh core-01 "/opt/klai/deploy/scripts/compose-up.sh portal-api"
+```
+
+Resultaat: `--remove-orphans` zit in één plek, kan niet vergeten
+worden, en post-deploy orphan-detection draait gratis mee. AI die een
+nieuwe deploy-workflow schrijft kopieert de SSH-regel; flag is niet
+de verantwoordelijkheid van de auteur.
+
+**Volgorde-discipline:** REQ-3 wordt geactiveerd NA REQ-2c
+(librechat-voys in compose). De eerste deploy via de wrapper zou
+anders librechat-voys verwijderen.
+
+### R4 — VERVALLEN
+
+Image-pinning pilot is geschrapt in v0.2.0. Zie HISTORY en research §11.
+
+### R5 — Periodic: orphan-audit als VictoriaLogs event-stream
+
+Een script `klai-infra/scripts/docker-orphan-audit.sh` SHALL elke zondag
+03:00 op core-01 draaien (via systemd timer) en structlog-events
+emitten naar VictoriaLogs via stdout (Alloy pickt het op zoals alle
+container-logs). Geen markdown-rapport, geen `/var/log/`-bestanden —
+alleen events.
+
+Event-schema (één per detected issue):
+
+```json
+{
+  "service": "klai-orphan-audit",
+  "event": "<type>",
+  "severity": "warning|critical",
+  "container_name": "<name>",
+  "container_id": "<id>",
+  "details": { ... },
+  "_time": "<iso8601>"
+}
+```
+
+Detectie-categorieën met `event` veld:
+
+1. `event:orphan_no_compose_label` — running container zonder
+   `com.docker.compose.project=klai-core` label.
+2. `event:orphan_service_removed` — running container met klai-core
+   label maar service-naam niet meer in `docker-compose*.yml`.
+3. `event:image_untagged_old` — untagged image >30 dagen, niet
+   gerefereerd door running container.
+4. `event:volume_unmounted` — named volume zonder mount, met
+   laatste-write timestamp ouder dan 7d.
+5. `event:caddy_upstream_missing` — Caddy upstream zonder
+   matchende running container.
+6. `event:tenant_container_no_route` — container met tenant-pattern
+   (`-voys`, `-getklai`, etc.) zonder Caddy-upstream (exact het
+   librechat-voys signaal).
+
+Het script SHALL **report-only** zijn — geen `docker rm`/`rmi`/
+`volume rm` ooit. Een AI of mens queryt VictoriaLogs vóór cleanup-
+beslissing:
+
+```
+service:klai-orphan-audit AND _time:[now-7d,now]
+```
+
+Een Grafana-panel + alert SHALL worden geconfigureerd op deze stream
+voor menselijk dashboard. AI gebruikt VictoriaLogs MCP direct.
+
+REQ-1's hook script SHALL deze stream queryen als deel van zijn
+checks: als container-X recent is geflagd als orphan-met-tenant-pattern,
+is dat een extra rode vlag.
+
+### R6 — Periodic: daily safe-only cleanup via systemd timer
+
+Een systemd timer `docker-cleanup.timer` SHALL dagelijks om 03:00 op
+core-01 een service uitvoeren die uitsluitend onomstotelijk veilige
+cleanup doet:
+
+```
+ExecStart=/usr/bin/docker image prune -f
+ExecStart=/usr/bin/docker container prune -f --filter until=24h
+ExecStart=/usr/bin/docker network prune -f
+ExecStart=/usr/bin/docker builder prune -f --filter until=72h
+```
+
+De timer SHALL **niet**:
+
+- `docker volume prune` uitvoeren (dataverlies-risico).
+- `docker image prune -af` uitvoeren (kan rollback-bare images
+  weggooien — VERSIONS.md `:latest` policy verwacht dat `:${sha}` tags
+  beschikbaar blijven voor rollback).
+- `docker system prune -af` uitvoeren.
+
+Logging via `journalctl -u docker-cleanup.service`. Unit-files SHALL
+in `klai-infra/core-01/systemd/` worden gecheckt-in.
+
+REQ-1's hook script SHALL OOK een veiligheidscheck doen voor
+`docker volume prune` of `docker image prune -af` — als een AI dat
+ooit probeert, hard blokkeren met diagnose.
+
+### R7 — Unwanted: pitfall-documentatie
+
+Het leerpunt uit het librechat-voys incident SHALL in
+`.claude/rules/klai/pitfalls/process-rules.md` worden vastgelegd als
+nieuwe pitfall `container-cleanup-without-preflight (HIGH)` met:
+
+- Incident-tijdlijn (datum, container-naam, signalen genegeerd)
+- Root cause (geen pre-cleanup checklist, label-loosheid als
+  enige signaal)
+- Prevention: verwijzing naar REQ-1 hook + script
+- "Why mechanical not narrative" sectie: waarom de hook mechanisch
+  is en niet alleen een rule
+
+De pitfall SHALL ook vermelden dat een handmatige `docker run` zonder
+`--label klai.adhoc=...` een wees-by-construction is en door REQ-5
+audit gedetecteerd wordt.
+
+## Specifications
+
+### Pre-cleanup hook script outline (REQ-1)
+
+```bash
+#!/usr/bin/env bash
+# .claude/hooks/klai/container-hygiene-preflight.sh
+# Reads tool-call JSON from stdin; exit 1 = block.
+
+set -euo pipefail
+TOOL_INPUT=$(cat)
+COMMAND=$(echo "$TOOL_INPUT" | jq -r '.tool_input.command // empty')
+
+# Parse danger patterns
+if echo "$COMMAND" | grep -qE '\bdocker\s+(rm|rmi|volume\s+rm|system\s+prune)\b|\bdocker\s+compose\s+down\s+.*--volumes\b'; then
+  TARGET=$(echo "$COMMAND" | grep -oE '(rm|rmi|volume rm)\s+\S+' | awk '{print $NF}')
+  [ -z "$TARGET" ] && exit 0  # bulk prune handled separately
+
+  # Check 1: Caddy upstream
+  if ssh -o ConnectTimeout=3 core-01 "grep -q '$TARGET' /opt/klai/Caddyfile 2>/dev/null"; then
+    echo "BLOCKED: $TARGET is a Caddy upstream on core-01"
+    exit 1
+  fi
+
+  # Check 2: compose git history
+  if git -C /tmp/klai-infra-cache log --all -p -- 'deploy/docker-compose*.yml' 2>/dev/null | grep -q "$TARGET"; then
+    echo "BLOCKED: $TARGET appeared in compose history — verify why removed"
+    exit 1
+  fi
+
+  # Check 3: tenant pattern
+  if echo "$TARGET" | grep -qE -- '-(voys|getklai|[a-z]+-tenant)$'; then
+    echo "BLOCKED: $TARGET looks tenant-specific"
+    exit 1
+  fi
+
+  # Check 4: depends-on
+  if ssh -o ConnectTimeout=3 core-01 "docker ps --format '{{.Names}}' | xargs -I{} docker inspect {} --format '{{index .Config.Labels \"com.docker.compose.depends_on\"}}' | grep -q '$TARGET'"; then
+    echo "BLOCKED: another container depends_on $TARGET"
+    exit 1
+  fi
+
+  # Check 5: VictoriaLogs recent traffic
+  TRAFFIC=$(curl -s -u "$VL_AUTH" \
+    "http://localhost:9428/select/logsql/query?query=service:$TARGET+_time:[now-30d,now]&limit=1" \
+    | wc -l)
+  [ "$TRAFFIC" -gt 0 ] && {
+    echo "BLOCKED: $TARGET had traffic in last 30d"
+    exit 1
+  }
+fi
+
+# Hard-block always-dangerous patterns
+if echo "$COMMAND" | grep -qE 'docker\s+volume\s+prune|docker\s+image\s+prune\s+-af|docker\s+system\s+prune\s+-af'; then
+  echo "BLOCKED: dangerous prune pattern; use systemd timer (REQ-6) for safe cleanup"
+  exit 1
+fi
+
+exit 0
+```
+
+### `.claude/settings.json` hook registratie
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/klai/container-hygiene-preflight.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Deploy-wrapper (REQ-3)
+
+```bash
+#!/usr/bin/env bash
+# /opt/klai/deploy/scripts/compose-up.sh
+set -euo pipefail
+SERVICE="${1:-}"
+cd /opt/klai
+
+if [ -n "$SERVICE" ]; then
+  docker compose pull "$SERVICE"
+  docker compose up -d --remove-orphans "$SERVICE"
+else
+  docker compose pull
+  docker compose up -d --remove-orphans
+fi
+
+# Post-deploy orphan snapshot (REQ-2b)
+/opt/klai/scripts/audit-orphan-snapshot.sh "${SERVICE:-all}"
+```
+
+### Audit-stream event-emit (REQ-5, fragment)
+
+```bash
+emit_event() {
+  local event="$1" severity="$2" name="$3" details="$4"
+  jq -nc \
+    --arg service "klai-orphan-audit" \
+    --arg event "$event" \
+    --arg severity "$severity" \
+    --arg name "$name" \
+    --argjson details "$details" \
+    --arg ts "$(date -Iseconds)" \
+    '{service:$service, event:$event, severity:$severity,
+      container_name:$name, details:$details, _time:$ts}'
+}
+
+# Detectie 1: orphan_no_compose_label
+docker ps --format '{{.Names}}' | while read -r name; do
+  proj=$(docker inspect "$name" --format '{{index .Config.Labels "com.docker.compose.project"}}')
+  if [ "$proj" != "klai-core" ]; then
+    emit_event "orphan_no_compose_label" "warning" "$name" \
+      "{\"image\":\"$(docker inspect "$name" --format '{{.Config.Image}}')\"}"
+  fi
+done
+```
+
+Stdout wordt door Alloy opgepikt via Docker socket en doorgestuurd naar
+VictoriaLogs.
+
+### Systemd unit-files (REQ-6, ongewijzigd t.o.v. v0.1.0)
+
+```ini
+# /etc/systemd/system/docker-cleanup.service
+[Unit]
+Description=Klai Docker safe cleanup
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/docker image prune -f
+ExecStart=/usr/bin/docker container prune -f --filter until=24h
+ExecStart=/usr/bin/docker network prune -f
+ExecStart=/usr/bin/docker builder prune -f --filter until=72h
+
+# /etc/systemd/system/docker-cleanup.timer
+[Unit]
+Description=Run klai docker cleanup daily
+
+[Timer]
+OnCalendar=*-*-* 03:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+## Files Affected
+
+### klai (deze repo)
+
+- **Nieuw:** `.claude/hooks/klai/container-hygiene-preflight.sh`
+- **Nieuw/uitgebreid:** `.claude/settings.json` — PreToolUse hook
+  registratie
+- **Nieuw:** `.claude/rules/klai/infra/container-hygiene.md` —
+  narrative + verwijzing naar script
+- **Uitgebreid:** `.claude/rules/klai/pitfalls/process-rules.md` —
+  `container-cleanup-without-preflight (HIGH)` pitfall
+- **Nieuw:** `.moai/specs/SPEC-INFRA-CONTAINER-HYGIENE-001/*.md`
+
+### klai-infra (cross-repo)
+
+- **Nieuw:** `deploy/scripts/compose-up.sh` — deploy-wrapper (REQ-3)
+- **Nieuw:** `scripts/audit-compose-orphans.sh` — CI-check (REQ-2a)
+- **Nieuw:** `scripts/test-audit-compose-orphans.sh` — regression
+  fixture (REQ-2a)
+- **Nieuw:** `scripts/audit-orphan-snapshot.sh` — post-deploy verifier
+  (REQ-2b)
+- **Nieuw:** `scripts/docker-orphan-audit.sh` — weekly audit-stream
+  (REQ-5)
+- **Uitgebreid:** `deploy/docker-compose.yml` — `librechat-voys`
+  service-block (REQ-2c)
+- **Uitgebreid:** `.github/workflows/audit-compose.yml` — orphan-check
+  als nieuwe step (REQ-2a)
+- **Uitgebreid:** 10 service-deploy-workflows — vervang
+  `docker compose up` door `compose-up.sh` aanroep (REQ-3)
+- **Nieuw:** `core-01/systemd/docker-cleanup.{service,timer}` (REQ-6)
+- **Nieuw:** `core-01/systemd/orphan-audit.{service,timer}` (REQ-5)
+
+### Operator-acties op core-01 (geen Git, runtime)
+
+- `systemctl link` + `enable --now` voor beide timers
+- Eenmalig: vervang draaiende `librechat-voys` door
+  compose-managed variant (`docker stop && rm && compose up -d`)
+- Symlink `/opt/klai/scripts/` naar `/opt/klai-infra/scripts/`
+- `mkdir -p` voor eventuele log-paths
+
+## MX Tag Plan
+
+- `container-hygiene-preflight.sh`: `# @MX:ANCHOR` op de check-functie
+  — fan_in via dat ELKE Claude-sessie het via PreToolUse aanroept.
+- `compose-up.sh`: `# @MX:ANCHOR` — fan_in via 10 GitHub workflows.
+- `docker-cleanup.service`:
+  `# @MX:WARN: never add 'volume prune' or '-af' here. SPEC-INFRA-CONTAINER-HYGIENE-001 R6.`
+- `docker-orphan-audit.sh`:
+  `# @MX:NOTE: report-only. Never docker rm. SPEC-INFRA-CONTAINER-HYGIENE-001 R5.`
+- Pitfall-entry: `@MX:NOTE` met SPEC-ID verwijzing.
+
+## Exclusions
+
+- **Image-pinning policy of pinning-pilot.** VERSIONS.md +
+  version-management.md zijn de canoniek; `:latest` op
+  `ghcr.io/getklai/*` is bewust beleid. Deze SPEC raakt het niet.
+- **`product_events` integratie.** REQ-5 audit gebruikt VictoriaLogs
+  (ops-events), niet `product_events` (user-facing business events).
+  Zie `observability.md` voor de scheiding.
+- **Watchtower / auto-pull tools.** Maken dangling-probleem erger.
+  Bewust afgewezen.
+- **GHCR retention policy.** Apart probleem, eigen SPEC indien nodig.
+- **`klai-core_vexa-recordings-data` volume.** Klantdata, eigen
+  evaluatie buiten scope.
+- **Server-side enforcement van handmatige `docker rm` via SSH.** REQ-1
+  hook werkt alleen voor Claude Code. Operator-side is REQ-5 audit
+  het detectie-vangnet achteraf, niet preventief.
+- **CI-rule die mechanisch nieuwe `docker run` patterns weert.** Te
+  veel false-positives op debug-tooling. REQ-1 + REQ-5 is de balans.
+
+## Implementation Notes (voor `/moai run`)
+
+- **Volgorde STRIKT:**
+  1. REQ-1 (deze repo: hook script + settings.json + rule narrative)
+  2. REQ-7 (deze repo: pitfall — kan met REQ-1 in 1 PR)
+  3. REQ-2c (klai-infra: librechat-voys compose-block + handmatige
+     container-vervanging op core-01)
+  4. REQ-3 (klai-infra: compose-up.sh + 10 workflow-edits) — pas NA
+     REQ-2c gemerged + gedeployed; eerste deploy via wrapper zou anders
+     librechat-voys wissen
+  5. REQ-2a (klai-infra: audit-compose-orphans.sh + workflow-uitbreiding)
+  6. REQ-6 (klai-infra: systemd cleanup timer)
+  7. REQ-5 (klai-infra: docker-orphan-audit.sh + systemd timer +
+     Grafana panel)
+- **Cross-repo werk** in dedicated worktrees (zie
+  `spec-work-in-a-worktree` pitfall) — één in deze repo, één in
+  klai-infra.
+- **Test REQ-1 hook lokaal** met een dummy `docker rm` commando voor
+  je merge — verifieer dat het BLOCKED returnt en dat een onschuldig
+  `docker logs` doorlaat.
+- **Test REQ-3 op `docs.yml` eerst** (laagste blast-radius) voor je de
+  andere 9 workflows aanpast.
+- **Test REQ-6 met dry-run.** `docker image prune --dry-run -f` op
+  core-01 voor activatie van de timer.
+- **REQ-5 Grafana-panel** kan in eerste versie minimaal: één table
+  panel met laatste 100 audit-events, één alert op
+  `event:tenant_container_no_route` of `event:caddy_upstream_missing`
+  met severity:critical.

--- a/deploy/scripts/audit-orphan-snapshot.sh
+++ b/deploy/scripts/audit-orphan-snapshot.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# /opt/klai/scripts/audit-orphan-snapshot.sh
+#
+# Post-deploy orphan-snapshot. Emits structlog-events to stdout (picked
+# up by Alloy → VictoriaLogs) for any running container that does NOT
+# carry one of the canonical management labels:
+#
+#   - klasse A: com.docker.compose.project=klai-core
+#   - klasse B: klai.managed_by=portal-api-provisioning
+#   - opt-in:   klai.adhoc=*  (REQ-7 ad-hoc debug containers)
+#
+# REPORT-ONLY. Never deletes anything.
+#
+# SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-2d.
+#
+# Usage:
+#   audit-orphan-snapshot.sh                    — full snapshot
+#   audit-orphan-snapshot.sh <service-or-all>   — context tag for the
+#                                                 emitted events
+
+set -euo pipefail
+
+CONTEXT="${1:-all}"
+TIMESTAMP="$(date -Iseconds)"
+EVENT_COUNT=0
+
+emit_event() {
+    local event_type="$1"
+    local container_name="$2"
+    local image="$3"
+    # Plain JSON line — no jq dependency. Alloy parses by default.
+    printf '{"service":"klai-orphan-snapshot","level":"warning","event":"%s","container_name":"%s","image":"%s","deploy_context":"%s","_time":"%s"}\n' \
+        "$event_type" "$container_name" "$image" "$CONTEXT" "$TIMESTAMP"
+    EVENT_COUNT=$((EVENT_COUNT + 1))
+}
+
+# Iterate over running containers
+docker ps --format '{{.Names}}' | while read -r name; do
+    [[ -z "$name" ]] && continue
+
+    proj=$(docker inspect "$name" --format '{{index .Config.Labels "com.docker.compose.project"}}' 2>/dev/null || echo "")
+    managed_by=$(docker inspect "$name" --format '{{index .Config.Labels "klai.managed_by"}}' 2>/dev/null || echo "")
+    adhoc=$(docker inspect "$name" --format '{{index .Config.Labels "klai.adhoc"}}' 2>/dev/null || echo "")
+    image=$(docker inspect "$name" --format '{{.Config.Image}}' 2>/dev/null || echo "unknown")
+
+    # Klasse A or B or ad-hoc → legitimate, skip
+    if [[ "$proj" == "klai-core" ]] || [[ "$managed_by" == "portal-api-provisioning" ]] || [[ -n "$adhoc" ]]; then
+        continue
+    fi
+
+    emit_event "orphan_post_deploy" "$name" "$image"
+done
+
+# Always emit a run-completed marker so absence-of-events is
+# distinguishable from absence-of-runs in Grafana queries.
+printf '{"service":"klai-orphan-snapshot","level":"info","event":"snapshot_run_completed","deploy_context":"%s","orphan_count":%d,"_time":"%s"}\n' \
+    "$CONTEXT" "$EVENT_COUNT" "$TIMESTAMP"

--- a/deploy/scripts/compose-up.sh
+++ b/deploy/scripts/compose-up.sh
@@ -27,6 +27,13 @@
 
 set -euo pipefail
 
+# Pre-flight: refuse to run if /opt/klai is missing or compose-file absent.
+# Better a fail-fast with a clear error than a silent partial deploy.
+if [[ ! -f /opt/klai/docker-compose.yml ]]; then
+    echo "ERROR: /opt/klai/docker-compose.yml not found — was deploy-compose.yml run?" >&2
+    exit 2
+fi
+
 cd /opt/klai
 
 NO_DEPS_FLAG=""

--- a/deploy/scripts/compose-up.sh
+++ b/deploy/scripts/compose-up.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# /opt/klai/scripts/compose-up.sh
+#
+# Canonical deploy-wrapper for klai-core compose stack.
+# Replaces ad-hoc `docker compose up -d <svc>` calls in service-deploy
+# workflows with a single shared mechanism that:
+#
+#   1. Pulls the targeted service image (or all images if no service given)
+#   2. Recreates with --remove-orphans so containers no longer in
+#      docker-compose.yml are cleaned up automatically (klasse-A only —
+#      provisioning-managed klasse-B containers carry their own labels
+#      and are NOT touched by --remove-orphans)
+#   3. Emits a post-deploy orphan-snapshot event to VictoriaLogs via
+#      audit-orphan-snapshot.sh so detection runs on every deploy
+#
+# SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3.
+#
+# Usage:
+#   compose-up.sh                   — pull + up all services
+#   compose-up.sh <service-name>    — pull + up single service
+#   compose-up.sh --no-deps <svc>   — pull + up without service deps
+#
+# Exit code mirrors the underlying `docker compose` exit code; on
+# successful compose-up, a non-zero exit from audit-orphan-snapshot.sh
+# is logged but does NOT fail the deploy (snapshot is detective, not
+# preventive — REQ-2d).
+
+set -euo pipefail
+
+cd /opt/klai
+
+NO_DEPS_FLAG=""
+SERVICE=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --no-deps)
+            NO_DEPS_FLAG="--no-deps"
+            shift
+            ;;
+        *)
+            if [[ -z "$SERVICE" ]]; then
+                SERVICE="$1"
+            else
+                echo "ERROR: unexpected argument '$1' — usage: compose-up.sh [--no-deps] [service]" >&2
+                exit 2
+            fi
+            shift
+            ;;
+    esac
+done
+
+if [[ -n "$SERVICE" ]]; then
+    echo "Pulling $SERVICE..."
+    docker compose pull "$SERVICE"
+    echo "Recreating $SERVICE with --remove-orphans..."
+    # shellcheck disable=SC2086
+    docker compose up -d --remove-orphans $NO_DEPS_FLAG "$SERVICE"
+else
+    echo "Pulling all services..."
+    docker compose pull
+    echo "Recreating all services with --remove-orphans..."
+    docker compose up -d --remove-orphans
+fi
+
+# REQ-2d post-deploy orphan snapshot. Best-effort — snapshot failure
+# does NOT fail the deploy. The snapshot script emits structlog-events
+# to stdout; Alloy picks them up into VictoriaLogs.
+if [[ -x /opt/klai/scripts/audit-orphan-snapshot.sh ]]; then
+    /opt/klai/scripts/audit-orphan-snapshot.sh "${SERVICE:-all}" || \
+        echo "WARN: post-deploy orphan-snapshot failed (deploy itself succeeded)" >&2
+else
+    echo "WARN: /opt/klai/scripts/audit-orphan-snapshot.sh not installed yet — skipping post-deploy snapshot" >&2
+fi

--- a/deploy/scripts/docker-orphan-audit.sh
+++ b/deploy/scripts/docker-orphan-audit.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# /opt/klai/scripts/docker-orphan-audit.sh
+#
+# Weekly orphan audit emitting structlog-events to stdout (Alloy →
+# VictoriaLogs). Detects six categories of "wees" state:
+#
+#   1. orphan_no_managed_label
+#      Running container without klasse-A (compose-project=klai-core)
+#      OR klasse-B (klai.managed_by=portal-api-provisioning) OR
+#      klai.adhoc=* opt-in label.
+#
+#   2. orphan_service_removed
+#      Compose-managed (klasse A) container whose service name is no
+#      longer in /opt/klai/docker-compose.yml — stale runner.
+#
+#   3. image_untagged_old
+#      Untagged image older than 30 days, not referenced by any
+#      running container — safe to prune by daily timer (REQ-6) but
+#      logged here for visibility.
+#
+#   4. volume_unmounted
+#      Named volume with no current container mount, with last-write
+#      timestamp > 7 days. May contain klantdata; never auto-prune.
+#
+#   5. caddy_upstream_missing
+#      Caddy upstream in /opt/klai/Caddyfile that does NOT match any
+#      running container — broken routing-rule.
+#
+#   6. tenant_container_no_route
+#      Container with klasse-B label OR tenant-pattern-name (`librechat-*`)
+#      that has no Caddy upstream pointing at it — exact librechat-voys
+#      detection signal.
+#
+# REPORT-ONLY. Never deletes anything. Output to stdout only —
+# /var/log/klai-orphan-audit/ is NOT used per ops-events-go-to-VictoriaLogs
+# convention (.claude/rules/klai/infra/observability.md).
+#
+# SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-5.
+
+set -euo pipefail
+
+TIMESTAMP="$(date -Iseconds)"
+COMPOSE_FILE="${COMPOSE_FILE:-/opt/klai/docker-compose.yml}"
+OVERRIDE_FILE="${OVERRIDE_FILE:-/opt/klai/docker-compose.override.yml}"
+DEV_FILE="${DEV_FILE:-/opt/klai/docker-compose.dev.yml}"
+CADDYFILE="${CADDYFILE:-/opt/klai/Caddyfile}"
+
+# Use a tempfile to count events across subshells (while|read pipelines)
+EVENT_TMP="$(mktemp)"
+trap 'rm -f "$EVENT_TMP"' EXIT
+echo 0 > "$EVENT_TMP"
+
+emit_event() {
+    local event_type="$1"
+    local severity="$2"
+    local container_name="$3"
+    local extra_json="${4:-{\}}"
+    printf '{"service":"klai-orphan-audit","level":"%s","event":"%s","container_name":"%s","extra":%s,"_time":"%s"}\n' \
+        "$severity" "$event_type" "$container_name" "$extra_json" "$TIMESTAMP"
+    # Count via tempfile so subshells contribute
+    local cur
+    cur=$(cat "$EVENT_TMP")
+    echo $((cur + 1)) > "$EVENT_TMP"
+}
+
+# ─── Build compose-services inventory ────────────────────────────────────────
+# Includes main + override + dev compose-files. Service names live under
+# `services:` section, indented 2 spaces. Naive grep is sufficient because
+# this is yaml without nested service blocks.
+extract_services() {
+    local f="$1"
+    [[ -f "$f" ]] || return 0
+    awk '
+        /^services:[[:space:]]*$/ { in_svc=1; next }
+        /^[a-zA-Z]/ && in_svc { in_svc=0 }
+        in_svc && /^  [a-zA-Z][a-zA-Z0-9_-]*:[[:space:]]*$/ {
+            gsub(/^  |:.*$/, "")
+            print
+        }
+    ' "$f"
+}
+
+COMPOSE_SERVICES="$(
+    {
+        extract_services "$COMPOSE_FILE"
+        extract_services "$OVERRIDE_FILE"
+        extract_services "$DEV_FILE"
+    } | sort -u
+)"
+
+is_in_compose() {
+    local svc="$1"
+    grep -qxF "$svc" <<< "$COMPOSE_SERVICES"
+}
+
+# ─── Detection 1+2+6: per running container ──────────────────────────────────
+# Caddy upstream-name normalisation: Caddyfile entries use service-names
+# (e.g. `reverse_proxy portal-api:8000`), NOT compose container-names
+# (which are prefixed `klai-core-portal-api-1`). Build a service→container
+# map for detection 6's reverse-lookup.
+while read -r name; do
+    [[ -z "$name" ]] && continue
+
+    proj=$(docker inspect "$name" --format '{{index .Config.Labels "com.docker.compose.project"}}' 2>/dev/null || echo "")
+    svc=$(docker inspect "$name" --format '{{index .Config.Labels "com.docker.compose.service"}}' 2>/dev/null || echo "")
+    managed_by=$(docker inspect "$name" --format '{{index .Config.Labels "klai.managed_by"}}' 2>/dev/null || echo "")
+    tenant=$(docker inspect "$name" --format '{{index .Config.Labels "klai.tenant_slug"}}' 2>/dev/null || echo "")
+    adhoc=$(docker inspect "$name" --format '{{index .Config.Labels "klai.adhoc"}}' 2>/dev/null || echo "")
+    image=$(docker inspect "$name" --format '{{.Config.Image}}' 2>/dev/null || echo "unknown")
+
+    # Detection 1: no managed label
+    if [[ "$proj" != "klai-core" ]] && [[ "$managed_by" != "portal-api-provisioning" ]] && [[ -z "$adhoc" ]]; then
+        emit_event "orphan_no_managed_label" "warning" "$name" \
+            "{\"image\":\"$image\"}"
+        continue
+    fi
+
+    # Detection 2: klasse-A but service-name not in compose
+    if [[ "$proj" == "klai-core" ]] && [[ -n "$svc" ]] && ! is_in_compose "$svc"; then
+        emit_event "orphan_service_removed" "warning" "$name" \
+            "{\"image\":\"$image\",\"compose_service\":\"$svc\"}"
+    fi
+
+    # Detection 6: klasse-B or librechat-* container without Caddy upstream.
+    # Caddy refers to klasse-B containers by container-name (e.g.
+    # `reverse_proxy librechat-voys:3080`), so direct grep works for them.
+    if [[ "$managed_by" == "portal-api-provisioning" ]] || [[ "$name" =~ ^librechat- ]]; then
+        if [[ -f "$CADDYFILE" ]] && ! grep -qE "(^|[[:space:]])${name}([[:space:]]|:|$)" "$CADDYFILE"; then
+            emit_event "tenant_container_no_route" "warning" "$name" \
+                "{\"image\":\"$image\",\"tenant_slug\":\"$tenant\"}"
+        fi
+    fi
+done < <(docker ps --format '{{.Names}}')
+
+# ─── Detection 3: untagged images >30d, not in use ───────────────────────────
+THIRTY_DAYS_AGO=$(date -d '30 days ago' +%s 2>/dev/null || date -v-30d +%s)
+docker images --filter dangling=true --format '{{.ID}} {{.CreatedAt}}' | while read -r img_id created_str; do
+    [[ -z "$img_id" ]] && continue
+    # Created at format is "YYYY-MM-DD HH:MM:SS +ZZZZ ZONE" — convert
+    img_ts=$(date -d "$(echo "$created_str" | awk '{print $1, $2}')" +%s 2>/dev/null || echo 0)
+    [[ "$img_ts" -lt "$THIRTY_DAYS_AGO" ]] || continue
+    # Skip if any container references it
+    if docker ps -a --filter ancestor="$img_id" --format '{{.ID}}' | grep -q .; then
+        continue
+    fi
+    emit_event "image_untagged_old" "info" "$img_id" \
+        "{\"created\":\"$created_str\",\"age_days\":\"30+\"}"
+done
+
+# ─── Detection 4: dangling volumes >7d last-write ────────────────────────────
+SEVEN_DAYS_AGO=$(date -d '7 days ago' +%s 2>/dev/null || date -v-7d +%s)
+docker volume ls -f dangling=true -q | while read -r vol; do
+    [[ -z "$vol" ]] && continue
+    mountpoint=$(docker volume inspect "$vol" --format '{{.Mountpoint}}' 2>/dev/null || echo "")
+    [[ -z "$mountpoint" ]] && continue
+    # Find newest mtime in volume; if none / older than 7d, flag.
+    # `find -printf %T@` gives epoch seconds for the most-recent file.
+    newest_mtime=$(sudo find "$mountpoint" -type f -printf '%T@\n' 2>/dev/null | sort -n | tail -1 || echo 0)
+    newest_int=${newest_mtime%.*}
+    [[ -z "$newest_int" ]] && newest_int=0
+    if [[ "$newest_int" -lt "$SEVEN_DAYS_AGO" ]]; then
+        emit_event "volume_unmounted" "warning" "$vol" \
+            "{\"mountpoint\":\"$mountpoint\",\"newest_mtime\":\"$newest_int\"}"
+    fi
+done
+
+# ─── Detection 5: Caddy upstreams without matching container ─────────────────
+# Caddy upstreams reach docker services by their compose-service-name, not
+# the prefixed container-name. Build a service-name → running set and a
+# normalised running-name set to allow either form.
+if [[ -f "$CADDYFILE" ]]; then
+    # Set 1: full container-names (klai-core-portal-api-1, librechat-voys, etc.)
+    RUNNING_NAMES=$(docker ps --format '{{.Names}}')
+    # Set 2: compose-service-names (portal-api, redis, etc.)
+    RUNNING_SERVICES=$(docker ps --format '{{.Label "com.docker.compose.service"}}' | grep -v '^$' | sort -u)
+
+    # Whitelist: hostnames that are valid by convention (Vexa internal,
+    # localhost, named matchers, snippet-references, special caddy tokens).
+    is_caddy_whitelist() {
+        local h="$1"
+        case "$h" in
+            localhost|127.0.0.1) return 0 ;;
+            api-gateway|admin-api|meeting-api|runtime-api|transcription-api) return 0 ;;
+            h2c|http|https|h2|h3) return 0 ;;
+        esac
+        # Caddy named matchers start with @
+        [[ "$h" == @* ]] && return 0
+        # Caddy placeholders / variables
+        [[ "$h" == \{* ]] && return 0
+        return 1
+    }
+
+    grep -hE '^\s*reverse_proxy\s+' "$CADDYFILE" \
+        | awk '{
+            # reverse_proxy may have named matcher as first arg (@matcher)
+            # then upstream(s). Iterate from $2 onward, filter out matchers
+            # and flags.
+            for (i=2;i<=NF;i++) {
+                t = $i
+                # skip flags and matchers
+                if (t ~ /^@/) continue
+                if (t ~ /^-/) continue
+                # strip path and port
+                sub(/\/.*$/, "", t)
+                sub(/:.*$/, "", t)
+                if (length(t) > 0) print t
+            }
+        }' \
+        | sort -u \
+        | while read -r host; do
+            [[ -z "$host" ]] && continue
+            is_caddy_whitelist "$host" && continue
+            # Match against either container-name OR compose-service-name
+            if grep -qxF "$host" <<< "$RUNNING_NAMES"; then continue; fi
+            if grep -qxF "$host" <<< "$RUNNING_SERVICES"; then continue; fi
+            emit_event "caddy_upstream_missing" "critical" "$host" \
+                "{\"upstream_in_caddyfile\":\"$host\"}"
+        done
+fi
+
+# ─── Always emit run-completed marker ────────────────────────────────────────
+EVENT_COUNT=$(cat "$EVENT_TMP")
+printf '{"service":"klai-orphan-audit","level":"info","event":"audit_run_completed","total_events":%d,"_time":"%s"}\n' \
+    "$EVENT_COUNT" "$TIMESTAMP"

--- a/deploy/systemd/docker-cleanup.service
+++ b/deploy/systemd/docker-cleanup.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Klai Docker safe-only cleanup (dangling images, exited containers, unused networks, build cache)
-Documentation=file:///opt/klai/.claude/rules/klai/infra/container-hygiene.md
+Documentation=https://github.com/GetKlai/klai/blob/main/.claude/rules/klai/infra/container-hygiene.md
+Documentation=https://github.com/GetKlai/klai/blob/main/.moai/specs/SPEC-INFRA-CONTAINER-HYGIENE-001/spec.md
 After=docker.service
 Requires=docker.service
 

--- a/deploy/systemd/docker-cleanup.service
+++ b/deploy/systemd/docker-cleanup.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Klai Docker safe-only cleanup (dangling images, exited containers, unused networks, build cache)
+Documentation=file:///opt/klai/.claude/rules/klai/infra/container-hygiene.md
+After=docker.service
+Requires=docker.service
+
+# SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-6.
+#
+# Safe-only: NEVER add `docker volume prune` here (klantdata-risico) or
+# `docker image prune -af` (rolt VERSIONS.md `:latest` rollback-buffer
+# weg via :sha tags). The PreToolUse hook in klai checkout also blocks
+# these patterns at the agent layer (REQ-1).
+
+[Service]
+Type=oneshot
+# Dangling images (untagged, unreferenced) — 100% safe
+ExecStart=/usr/bin/docker image prune -f
+# Exited containers older than 24h — 24h rollback-buffer voor debug
+ExecStart=/usr/bin/docker container prune -f --filter until=24h
+# Unused networks — geen container houdt referentie
+ExecStart=/usr/bin/docker network prune -f
+# Build cache older than 72h — 3 dagen rollback-buffer voor build issues
+ExecStart=/usr/bin/docker builder prune -f --filter until=72h
+
+# Capture exit & log via journalctl
+StandardOutput=journal
+StandardError=journal

--- a/deploy/systemd/docker-cleanup.timer
+++ b/deploy/systemd/docker-cleanup.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Run klai Docker safe-only cleanup daily at 03:00 local time
+Documentation=file:///opt/klai/.claude/rules/klai/infra/container-hygiene.md
+
+[Timer]
+OnCalendar=*-*-* 03:00
+# Run on next boot if missed (e.g. server was down at 03:00)
+Persistent=true
+# Random delay up to 5 min to avoid thundering-herd if multiple machines
+RandomizedDelaySec=300
+Unit=docker-cleanup.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/docker-cleanup.timer
+++ b/deploy/systemd/docker-cleanup.timer
@@ -1,6 +1,6 @@
 [Unit]
 Description=Run klai Docker safe-only cleanup daily at 03:00 local time
-Documentation=file:///opt/klai/.claude/rules/klai/infra/container-hygiene.md
+Documentation=https://github.com/GetKlai/klai/blob/main/.claude/rules/klai/infra/container-hygiene.md
 
 [Timer]
 OnCalendar=*-*-* 03:00

--- a/deploy/systemd/orphan-audit.service
+++ b/deploy/systemd/orphan-audit.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Klai weekly orphan-audit (containers, images, volumes, Caddy upstreams)
+Documentation=file:///opt/klai/.claude/rules/klai/infra/container-hygiene.md
+After=docker.service
+Requires=docker.service
+
+# SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-5.
+#
+# REPORT-ONLY. Emits structlog-events to stdout; Alloy picks them up
+# into VictoriaLogs as `service:klai-orphan-audit`. Never deletes
+# anything. Operators / agents query the stream via VictoriaLogs MCP
+# before deciding on cleanup.
+
+[Service]
+Type=oneshot
+ExecStart=/opt/klai/scripts/docker-orphan-audit.sh
+
+# Run as root so volume-mtime detection (find on /var/lib/docker/volumes)
+# works without sudo prompts. Audit is read-only at the filesystem level.
+User=root
+
+# Stdout becomes journal entry, picked up by Alloy → VictoriaLogs
+StandardOutput=journal
+StandardError=journal

--- a/deploy/systemd/orphan-audit.service
+++ b/deploy/systemd/orphan-audit.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Klai weekly orphan-audit (containers, images, volumes, Caddy upstreams)
-Documentation=file:///opt/klai/.claude/rules/klai/infra/container-hygiene.md
+Documentation=https://github.com/GetKlai/klai/blob/main/.claude/rules/klai/infra/container-hygiene.md
+Documentation=https://github.com/GetKlai/klai/blob/main/.moai/specs/SPEC-INFRA-CONTAINER-HYGIENE-001/spec.md
 After=docker.service
 Requires=docker.service
 

--- a/deploy/systemd/orphan-audit.timer
+++ b/deploy/systemd/orphan-audit.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Run klai orphan-audit weekly on Sunday at 03:00 local time
+Documentation=file:///opt/klai/.claude/rules/klai/infra/container-hygiene.md
+
+[Timer]
+OnCalendar=Sun *-*-* 03:00
+# Run on next boot if missed
+Persistent=true
+# Random delay up to 10 min
+RandomizedDelaySec=600
+Unit=orphan-audit.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/orphan-audit.timer
+++ b/deploy/systemd/orphan-audit.timer
@@ -1,6 +1,6 @@
 [Unit]
 Description=Run klai orphan-audit weekly on Sunday at 03:00 local time
-Documentation=file:///opt/klai/.claude/rules/klai/infra/container-hygiene.md
+Documentation=https://github.com/GetKlai/klai/blob/main/.claude/rules/klai/infra/container-hygiene.md
 
 [Timer]
 OnCalendar=Sun *-*-* 03:00

--- a/docs/runbooks/container-hygiene-systemd-install.md
+++ b/docs/runbooks/container-hygiene-systemd-install.md
@@ -14,6 +14,18 @@
 - `deploy/scripts/*.sh` are at `/opt/klai/scripts/*.sh` (same workflow)
 - SSH access to core-01 with sudo
 
+## Race-condition note (fresh-server setup)
+
+On a brand-new server, `deploy-compose.yml` MUST run BEFORE any
+service-specific deploy workflow (`portal-api.yml`, `docs.yml`, etc.)
+because the latter call `/opt/klai/scripts/compose-up.sh` which is
+synced by the former. On an existing server with the scripts already
+present, ordering does not matter — pulls happen idempotently.
+
+If you ever clone klai onto a new host, run the deploy-compose.yml
+workflow first (or sync the scripts manually with the install commands
+below) before triggering any other deploy.
+
 ## Install
 
 ```bash

--- a/docs/runbooks/container-hygiene-systemd-install.md
+++ b/docs/runbooks/container-hygiene-systemd-install.md
@@ -1,0 +1,86 @@
+# Container Hygiene — systemd timer install (one-time per host)
+
+> SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-5 + REQ-6.
+>
+> Activates the daily safe-cleanup timer and the weekly orphan-audit
+> timer on core-01. Required once per host; the deploy-compose.yml
+> workflow syncs the unit files but does NOT run `systemctl` (no sudo
+> via the SSH-action key).
+
+## Prerequisites
+
+- `deploy-compose.yml` workflow has run at least once after this SPEC's
+  PR merged → unit files are present at `/opt/klai/systemd/*.{service,timer}`
+- `deploy/scripts/*.sh` are at `/opt/klai/scripts/*.sh` (same workflow)
+- SSH access to core-01 with sudo
+
+## Install
+
+```bash
+ssh core-01
+
+# Verify files are present (synced by deploy-compose.yml)
+ls -l /opt/klai/systemd/
+ls -l /opt/klai/scripts/
+
+# Install via symlink so future deploy-compose.yml syncs propagate
+# without re-running this runbook.
+sudo ln -sf /opt/klai/systemd/docker-cleanup.service /etc/systemd/system/docker-cleanup.service
+sudo ln -sf /opt/klai/systemd/docker-cleanup.timer   /etc/systemd/system/docker-cleanup.timer
+sudo ln -sf /opt/klai/systemd/orphan-audit.service   /etc/systemd/system/orphan-audit.service
+sudo ln -sf /opt/klai/systemd/orphan-audit.timer     /etc/systemd/system/orphan-audit.timer
+
+# Reload systemd to pick up new units
+sudo systemctl daemon-reload
+
+# Enable + start (--now starts immediately + on every boot)
+sudo systemctl enable --now docker-cleanup.timer
+sudo systemctl enable --now orphan-audit.timer
+
+# Verify
+systemctl status docker-cleanup.timer
+systemctl status orphan-audit.timer
+systemctl list-timers | grep -E 'docker-cleanup|orphan-audit'
+```
+
+Expected output: both timers `active (waiting)`, next run scheduled at
+03:00 (cleanup daily, audit Sundays).
+
+## Smoke-test
+
+```bash
+# Dry-run the cleanup logic (without prune-flag)
+ssh core-01 "docker image prune --dry-run -f 2>&1 | head -5"
+
+# Run the audit ad-hoc to verify it emits events to the journal
+ssh core-01 "sudo systemctl start orphan-audit.service && \
+             sudo journalctl -u orphan-audit.service --since '1 minute ago' | tail -20"
+```
+
+You should see structlog-shaped JSON lines on stdout, including
+`"event":"audit_run_completed"` with a `total_events` count. Negative
+finding (zero orphan events) is the desired post-deploy state once
+all stages of the SPEC have landed.
+
+## Uninstall (rollback)
+
+```bash
+ssh core-01 "sudo systemctl disable --now docker-cleanup.timer orphan-audit.timer && \
+             sudo rm -f /etc/systemd/system/docker-cleanup.{service,timer} \
+                        /etc/systemd/system/orphan-audit.{service,timer} && \
+             sudo systemctl daemon-reload"
+```
+
+The unit files in `/opt/klai/systemd/` remain (not deleted by uninstall).
+
+## Querying audit-events from VictoriaLogs
+
+```
+service:klai-orphan-audit AND _time:[now-7d,now]
+```
+
+In Grafana: add a Logs panel with this LogsQL on the `victorialogs`
+datasource. For alerts: fire on `event:caddy_upstream_missing` or
+`event:tenant_container_no_route` with `severity:critical`.
+
+Querying via Claude Code: VictoriaLogs MCP tool with the same query.

--- a/klai-portal/backend/app/services/provisioning/infrastructure.py
+++ b/klai-portal/backend/app/services/provisioning/infrastructure.py
@@ -253,11 +253,25 @@ def _start_librechat_container(
     tenant_yaml_dir.mkdir(parents=True, exist_ok=True)
     (tenant_yaml_dir / "librechat.yaml").write_text(tenant_yaml_content)
 
+    # @MX:ANCHOR provisioning-labels — SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-2.
+    # These three labels mark the container as klasse-B (provisioning-managed)
+    # so that hooks (.claude/hooks/klai/container-hygiene-preflight.sh) and
+    # the weekly orphan-audit recognise it as a legitimate prod container,
+    # NOT as a wees-container without compose-label. Removing or renaming
+    # these breaks the hygiene-detection layer; treat as part of the
+    # tenant-provisioning contract. See container-hygiene.md.
+    container_labels = {
+        "klai.managed_by": "portal-api-provisioning",
+        "klai.tenant_slug": slug,
+        "klai.kind": "librechat",
+    }
+
     client.containers.run(  # type: ignore[call-overload]  # nosemgrep: docker-arbitrary-container-run
         image=settings.librechat_image,
         name=container_name,
         detach=True,
         restart_policy={"Name": "unless-stopped"},  # type: ignore[arg-type]
+        labels=container_labels,
         volumes={
             env_file_host_path: {"bind": "/app/.env", "mode": "ro"},
             f"{librechat_host_base}/{slug}/librechat.yaml": {"bind": "/app/librechat.yaml", "mode": "ro"},

--- a/klai-portal/backend/tests/services/provisioning/test_infrastructure.py
+++ b/klai-portal/backend/tests/services/provisioning/test_infrastructure.py
@@ -417,3 +417,69 @@ class TestCharacterizeStartLibrechatContainer:
             assert call_kwargs[1]["name"] == "librechat-acme"
             assert call_kwargs[1]["detach"] is True
             assert call_kwargs[1]["network"] == "klai-net"
+
+    def test_provisioning_labels_are_set(self, tmp_path):
+        """SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-2a: tenant-LibreChats MUST
+        carry klai.managed_by, klai.tenant_slug, and klai.kind labels so
+        hygiene-tooling (PreToolUse hook + weekly orphan-audit) recognises
+        them as legitimate klasse-B containers, not as label-loose wezen.
+
+        The librechat-voys cleanup-incident of 2026-05-02 happened because
+        these labels did not exist. Without this test passing, the same
+        class of mistake can recur for any future tenant.
+        """
+        from app.services.provisioning import _start_librechat_container
+
+        base_yaml = Path(tmp_path) / "librechat.yaml"
+        base_yaml.write_text("version: 1.0\n")
+
+        mock_client = MagicMock()
+        mock_client.containers.get.side_effect = type("NotFound", (Exception,), {})("not found")
+
+        with (
+            patch("app.services.provisioning.infrastructure.docker") as mock_docker,
+            patch("app.services.provisioning.infrastructure.settings") as mock_settings,
+        ):
+            mock_settings.librechat_host_data_path = "/opt/klai/librechat-data"
+            mock_settings.librechat_container_data_path = str(tmp_path)
+            mock_settings.librechat_image = "ghcr.io/danny-avila/librechat:latest"
+            mock_docker.from_env.return_value = mock_client
+            mock_docker.errors.NotFound = type("NotFound", (Exception,), {})
+            mock_client.containers.get.side_effect = mock_docker.errors.NotFound("not found")
+
+            _start_librechat_container("voys", "/opt/klai/librechat-data/voys/.env")
+
+            call_kwargs = mock_client.containers.run.call_args
+            labels = call_kwargs[1]["labels"]
+            assert labels["klai.managed_by"] == "portal-api-provisioning"
+            assert labels["klai.tenant_slug"] == "voys"
+            assert labels["klai.kind"] == "librechat"
+
+    def test_provisioning_labels_use_actual_slug(self, tmp_path):
+        """klai.tenant_slug MUST reflect the tenant slug passed in, not a
+        hard-coded value. Backfill scripts depend on this for tenant lookup.
+        """
+        from app.services.provisioning import _start_librechat_container
+
+        base_yaml = Path(tmp_path) / "librechat.yaml"
+        base_yaml.write_text("version: 1.0\n")
+
+        mock_client = MagicMock()
+        mock_client.containers.get.side_effect = type("NotFound", (Exception,), {})("not found")
+
+        with (
+            patch("app.services.provisioning.infrastructure.docker") as mock_docker,
+            patch("app.services.provisioning.infrastructure.settings") as mock_settings,
+        ):
+            mock_settings.librechat_host_data_path = "/opt/klai/librechat-data"
+            mock_settings.librechat_container_data_path = str(tmp_path)
+            mock_settings.librechat_image = "ghcr.io/danny-avila/librechat:latest"
+            mock_docker.from_env.return_value = mock_client
+            mock_docker.errors.NotFound = type("NotFound", (Exception,), {})
+            mock_client.containers.get.side_effect = mock_docker.errors.NotFound("not found")
+
+            for tenant_slug in ("voys", "acme-corp", "klai-internal"):
+                mock_client.containers.run.reset_mock()
+                _start_librechat_container(tenant_slug, f"/opt/klai/librechat-data/{tenant_slug}/.env")
+                labels = mock_client.containers.run.call_args[1]["labels"]
+                assert labels["klai.tenant_slug"] == tenant_slug

--- a/scripts/audit-compose-orphans.sh
+++ b/scripts/audit-compose-orphans.sh
@@ -110,29 +110,31 @@ is_compose_service() {
 # ─── Check 1: Caddy upstreams resolve to compose-services or klasse-B ────────
 
 if [[ -f "$CADDYFILE" ]]; then
-    # Extract `reverse_proxy <host>[:<port>]` and `proxy <host>` patterns.
-    # Strip protocol prefixes; keep the hostname (first token before `:`).
+    # Caddy `reverse_proxy [@matcher] <upstream> [<upstream>...]` accepts
+    # an optional named matcher as first arg. Skip @-prefixed tokens and
+    # flags so we only collect actual upstream hosts.
     mapfile -t UPSTREAMS < <(
         grep -hE '^\s*(reverse_proxy|proxy)\s+' "$CADDYFILE" \
-        | awk '{for(i=2;i<=NF;i++) print $i}' \
-        | grep -vE '^(http|https)://' \
-        | grep -vE '^\{' \
-        | sed -E 's/:.*$//' \
-        | sed -E 's|/.*$||' \
-        | sort -u \
-        | grep -vE '^$'
+        | awk '{
+            for (i=2; i<=NF; i++) {
+                t = $i
+                if (t ~ /^@/) continue       # named matcher
+                if (t ~ /^-/) continue       # flag
+                if (t ~ /^\{/) continue      # caddy placeholder
+                sub(/^https?:\/\//, "", t)   # strip scheme
+                sub(/\/.*$/, "", t)          # strip path
+                sub(/:.*$/, "", t)           # strip port
+                if (length(t) > 0) print t
+            }
+        }' \
+        | sort -u
     )
 
     for host in "${UPSTREAMS[@]}"; do
-        if is_compose_service "$host"; then
-            continue
-        fi
-        if is_klasse_b_pattern "$host"; then
-            continue
-        fi
-        if is_whitelisted "$host"; then
-            continue
-        fi
+        [[ -z "$host" ]] && continue
+        if is_compose_service "$host"; then continue; fi
+        if is_klasse_b_pattern "$host"; then continue; fi
+        if is_whitelisted "$host"; then continue; fi
         echo "VIOLATION (Check 1): Caddy upstream '$host' is neither a compose service, a klasse-B provisioning pattern, nor whitelisted." >&2
         echo "  Source: $CADDYFILE" >&2
         echo "  Either declare '$host' as a service in deploy/docker-compose.yml, add a klasse-B pattern, or add to CADDY_WHITELIST." >&2

--- a/scripts/audit-compose-orphans.sh
+++ b/scripts/audit-compose-orphans.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# audit-compose-orphans.sh — CI-guard tegen orphan-by-construction
+# in deploy/docker-compose.yml en deploy/caddy/Caddyfile.
+#
+# Three checks, each a hard fail:
+#
+#   1. Every Caddy upstream (`reverse_proxy <host>:<port>`) in
+#      deploy/caddy/Caddyfile MUST resolve to either:
+#        - a service name declared in deploy/docker-compose.yml
+#        - a klasse-B provisioning-managed pattern (`librechat-*`,
+#          set by portal-api `_start_librechat_container`)
+#        - a whitelisted external endpoint (Vexa internal, etc.)
+#      Otherwise the upstream points at a container that doesn't
+#      exist and will silently break tenant routing.
+#
+#   2. Every `container_name:` in deploy/docker-compose.yml MUST match
+#      its enclosing service block (no drift). Mismatch = silent
+#      orphan-on-deploy because compose creates the named container
+#      but `--remove-orphans` won't recognise it.
+#
+#   3. Every top-level volume declared in deploy/docker-compose.yml
+#      `volumes:` section MUST be referenced by at least one service.
+#      Unreferenced top-level volumes accumulate as "verlaten" volumes
+#      that detection scripts later flag as orphans.
+#
+# Exits non-zero on any violation. Intended to run in CI on PRs that
+# touch deploy/docker-compose.yml or deploy/caddy/Caddyfile.
+#
+# SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-2c.
+#
+# Exit codes:
+#   0 = all checks passed
+#   1 = one or more violations (details on stderr)
+#   2 = configuration error (missing files, missing tools)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+COMPOSE_FILE="${REPO_ROOT}/deploy/docker-compose.yml"
+CADDYFILE="${REPO_ROOT}/deploy/caddy/Caddyfile"
+
+# Allow override for unit-test fixtures
+COMPOSE_FILE="${AUDIT_COMPOSE_FILE:-$COMPOSE_FILE}"
+CADDYFILE="${AUDIT_CADDYFILE:-$CADDYFILE}"
+
+if ! command -v yq >/dev/null 2>&1; then
+    echo "ERROR: yq is required (mikefarah/yq v4)" >&2
+    exit 2
+fi
+
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+    echo "ERROR: compose file not found: $COMPOSE_FILE" >&2
+    exit 2
+fi
+
+VIOLATIONS=0
+
+# ─── Klasse-B name patterns ───────────────────────────────────────────────────
+# Provisioning-managed by portal-api. SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-2.
+# Maintain in sync with .claude/rules/klai/infra/container-hygiene.md.
+KLASSE_B_PATTERNS=(
+    '^librechat-[a-z0-9-]+$'
+)
+
+# ─── Whitelist for Caddy upstreams that do NOT need a compose service ────────
+# These are intentionally external or runtime-resolved.
+CADDY_WHITELIST=(
+    '^localhost$'
+    '^127\.0\.0\.1$'
+    '^api-gateway$'              # Vexa internal — managed by Vexa stack
+    '^admin-api$'                # Vexa internal
+    '^meeting-api$'              # Vexa internal
+    '^runtime-api$'              # Vexa internal
+)
+
+is_whitelisted() {
+    local host="$1"
+    for pat in "${CADDY_WHITELIST[@]}"; do
+        [[ "$host" =~ $pat ]] && return 0
+    done
+    return 1
+}
+
+is_klasse_b_pattern() {
+    local host="$1"
+    for pat in "${KLASSE_B_PATTERNS[@]}"; do
+        [[ "$host" =~ $pat ]] && return 0
+    done
+    return 1
+}
+
+# ─── Compose service inventory ────────────────────────────────────────────────
+
+mapfile -t COMPOSE_SERVICES < <(yq eval '.services | keys | .[]' "$COMPOSE_FILE")
+
+if [[ ${#COMPOSE_SERVICES[@]} -eq 0 ]]; then
+    echo "ERROR: no services found in $COMPOSE_FILE — is this a valid compose file?" >&2
+    exit 2
+fi
+
+is_compose_service() {
+    local host="$1"
+    for svc in "${COMPOSE_SERVICES[@]}"; do
+        [[ "$host" == "$svc" ]] && return 0
+    done
+    return 1
+}
+
+# ─── Check 1: Caddy upstreams resolve to compose-services or klasse-B ────────
+
+if [[ -f "$CADDYFILE" ]]; then
+    # Extract `reverse_proxy <host>[:<port>]` and `proxy <host>` patterns.
+    # Strip protocol prefixes; keep the hostname (first token before `:`).
+    mapfile -t UPSTREAMS < <(
+        grep -hE '^\s*(reverse_proxy|proxy)\s+' "$CADDYFILE" \
+        | awk '{for(i=2;i<=NF;i++) print $i}' \
+        | grep -vE '^(http|https)://' \
+        | grep -vE '^\{' \
+        | sed -E 's/:.*$//' \
+        | sed -E 's|/.*$||' \
+        | sort -u \
+        | grep -vE '^$'
+    )
+
+    for host in "${UPSTREAMS[@]}"; do
+        if is_compose_service "$host"; then
+            continue
+        fi
+        if is_klasse_b_pattern "$host"; then
+            continue
+        fi
+        if is_whitelisted "$host"; then
+            continue
+        fi
+        echo "VIOLATION (Check 1): Caddy upstream '$host' is neither a compose service, a klasse-B provisioning pattern, nor whitelisted." >&2
+        echo "  Source: $CADDYFILE" >&2
+        echo "  Either declare '$host' as a service in deploy/docker-compose.yml, add a klasse-B pattern, or add to CADDY_WHITELIST." >&2
+        VIOLATIONS=$((VIOLATIONS + 1))
+    done
+else
+    echo "INFO: $CADDYFILE not found — skipping Caddy upstream check" >&2
+fi
+
+# ─── Check 2: container_name matches its service block ───────────────────────
+
+while IFS=$'\t' read -r svc cn; do
+    [[ -z "$cn" ]] && continue
+    [[ "$cn" == "null" ]] && continue
+    # Allow the convention where container_name explicitly differs (e.g.
+    # librechat-getklai service has container_name: librechat-getklai). The
+    # check only flags when service uses a generic name but container_name
+    # uses a tenant-specific suffix without explicit declaration in the
+    # service block — i.e. just compare for non-equal pairs.
+    if [[ "$cn" != "$svc" ]]; then
+        # Allowed: explicit tenant/named containers where the service was
+        # declared with that intent. Currently the only legitimate divergence
+        # in compose is when service-name == container_name. If you need a
+        # divergent name, add an exception here with rationale.
+        # (Currently no exceptions needed; all known services match.)
+        echo "VIOLATION (Check 2): service '$svc' has container_name '$cn' that does not match. Drift will silently break --remove-orphans cleanup." >&2
+        VIOLATIONS=$((VIOLATIONS + 1))
+    fi
+done < <(yq eval '.services | to_entries | .[] | [.key, .value.container_name] | @tsv' "$COMPOSE_FILE")
+
+# ─── Check 3: top-level volumes are referenced by at least one service ───────
+
+mapfile -t TOP_VOLUMES < <(yq eval '.volumes | keys | .[]' "$COMPOSE_FILE" 2>/dev/null || true)
+
+if [[ ${#TOP_VOLUMES[@]} -gt 0 ]]; then
+    # Build a set of all volume references across all services. Volumes can
+    # be referenced as `<volume>:<path>` in `volumes:` arrays.
+    REFERENCED=$(yq eval '.services[] | .volumes[]?' "$COMPOSE_FILE" 2>/dev/null \
+                 | sed -E 's/:.*$//' \
+                 | sort -u || true)
+
+    for vol in "${TOP_VOLUMES[@]}"; do
+        [[ -z "$vol" ]] && continue
+        if ! grep -qxF "$vol" <<< "$REFERENCED"; then
+            echo "VIOLATION (Check 3): top-level volume '$vol' is declared but not used by any service. Wees-by-construction." >&2
+            echo "  Source: $COMPOSE_FILE volumes: section" >&2
+            VIOLATIONS=$((VIOLATIONS + 1))
+        fi
+    done
+fi
+
+# ─── Verdict ─────────────────────────────────────────────────────────────────
+
+if [[ $VIOLATIONS -gt 0 ]]; then
+    echo "" >&2
+    echo "audit-compose-orphans: $VIOLATIONS violation(s) found." >&2
+    exit 1
+fi
+
+echo "audit-compose-orphans: OK (${#COMPOSE_SERVICES[@]} services, ${#TOP_VOLUMES[@]} top-level volumes verified)"
+exit 0

--- a/scripts/test-audit-compose-orphans.sh
+++ b/scripts/test-audit-compose-orphans.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# test-audit-compose-orphans.sh — regression fixture for audit-compose-orphans.sh
+#
+# Builds three temp compose+caddy fixtures:
+#   1. CLEAN: passes all checks (matches current klai compose state)
+#   2. CADDY-ORPHAN: Caddyfile points at a nonexistent service → must FAIL Check 1
+#   3. ORPHAN-VOLUME: top-level volume not referenced anywhere → must FAIL Check 3
+#
+# Mirrors test-audit-compose.sh pattern.
+#
+# SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-2c regression test.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AUDIT="${SCRIPT_DIR}/audit-compose-orphans.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+PASS=0
+FAIL=0
+
+assert() {
+    local desc="$1" expected_exit="$2" compose="$3" caddy="$4"
+    local actual
+    actual=$(AUDIT_COMPOSE_FILE="$compose" AUDIT_CADDYFILE="$caddy" bash "$AUDIT" 2>&1 || true)
+    local exit_code=$?
+    if [ "$exit_code" = "$expected_exit" ]; then
+        echo "OK   ($exit_code) $desc"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL got=$exit_code expected=$expected_exit  $desc"
+        echo "    output: $actual" | head -3
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ─── Fixture 1: CLEAN ────────────────────────────────────────────────────────
+
+cat > "$TMPDIR/clean.yml" <<'EOF'
+services:
+  portal-api:
+    image: ghcr.io/getklai/portal-api:latest
+    container_name: portal-api
+  caddy:
+    image: ghcr.io/getklai/caddy-hetzner:latest
+    container_name: caddy
+    volumes:
+      - caddy-data:/data
+
+volumes:
+  caddy-data:
+EOF
+
+cat > "$TMPDIR/clean.Caddyfile" <<'EOF'
+my.getklai.com {
+    reverse_proxy portal-api:8000
+}
+chat-acme.getklai.com {
+    reverse_proxy librechat-acme:3080
+}
+EOF
+
+assert "CLEAN compose+Caddyfile passes" 0 "$TMPDIR/clean.yml" "$TMPDIR/clean.Caddyfile"
+
+# ─── Fixture 2: CADDY upstream points at a phantom service ───────────────────
+
+cat > "$TMPDIR/caddy-orphan.Caddyfile" <<'EOF'
+my.getklai.com {
+    reverse_proxy portal-api:8000
+}
+ghost.getklai.com {
+    reverse_proxy phantom-service:9999
+}
+EOF
+
+assert "CADDY-ORPHAN: phantom upstream fails" 1 "$TMPDIR/clean.yml" "$TMPDIR/caddy-orphan.Caddyfile"
+
+# ─── Fixture 3: top-level volume not referenced anywhere ─────────────────────
+
+cat > "$TMPDIR/orphan-volume.yml" <<'EOF'
+services:
+  portal-api:
+    image: ghcr.io/getklai/portal-api:latest
+    container_name: portal-api
+
+volumes:
+  caddy-data:
+  abandoned-volume:
+EOF
+
+assert "ORPHAN-VOLUME: unreferenced volume fails" 1 "$TMPDIR/orphan-volume.yml" "$TMPDIR/clean.Caddyfile"
+
+# ─── Verdict ─────────────────────────────────────────────────────────────────
+
+echo ""
+echo "=== test-audit-compose-orphans: $PASS passed, $FAIL failed ==="
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## Summary

Closes the librechat-voys cleanup-class incident (2026-05-02) with a
structural fix across three layers. Implements
SPEC-INFRA-CONTAINER-HYGIENE-001 v0.3.0.

**The class of bug:** a destructive `docker rm`/`rmi`/`volume rm` on a
target whose "orphan" appearance is fully consistent with being a
legitimate prod container managed via a non-compose pathway (klasse-B
provisioning-managed, e.g. tenant-LibreChats).

## Changes

**Klai-side (this repo) — mechanical AI-first guards:**

- `.claude/hooks/klai/container-hygiene-preflight.sh` — PreToolUse hook
  blocks destructive docker-actions on tenant patterns / dangerous
  prunes. 11/11 tests groen.
- `.claude/settings.json` — hook registered alongside
  `portal-api-preflight.sh`.
- `klai-portal/backend/app/services/provisioning/infrastructure.py` —
  `_start_librechat_container` now sets `klai.managed_by` +
  `klai.tenant_slug` + `klai.kind` labels (REQ-2a). Marked
  `@MX:ANCHOR`. Tests in `test_infrastructure.py` (3/3 pass).
- `.claude/rules/klai/infra/container-hygiene.md` — narrative rule with
  "Two legitimate classes of prod containers" section.
- `.claude/rules/klai/pitfalls/process-rules.md` —
  `container-cleanup-without-preflight (HIGH)` pitfall.

**Klai-infra-side (this repo, deploy/ + scripts/ + workflows):**

- `deploy/scripts/compose-up.sh` — canonical deploy-wrapper with
  `--remove-orphans` built in, post-deploy snapshot included.
- `deploy/scripts/audit-orphan-snapshot.sh` — REQ-2d post-deploy detector.
- `deploy/scripts/docker-orphan-audit.sh` — REQ-5 weekly audit emitting
  to VictoriaLogs.
- `deploy/systemd/docker-cleanup.{service,timer}` — REQ-6 daily safe
  cleanup (dangling images, exited containers, networks, build cache).
- `deploy/systemd/orphan-audit.{service,timer}` — REQ-5 weekly audit.
- `scripts/audit-compose-orphans.sh` + `test-audit-compose-orphans.sh`
  — REQ-2c CI-guard.
- `docs/runbooks/container-hygiene-systemd-install.md` — operator
  one-time install runbook (already executed on core-01).
- 10× `.github/workflows/*.yml` updated to call `compose-up.sh`.
- `.github/workflows/audit-compose.yml` — extended with orphan audit.
- `.github/workflows/deploy-compose.yml` — sync extended with
  `deploy/scripts/` + `deploy/systemd/`.

**Runtime backfill (already executed on core-01):**

- `librechat-voys` recreated with klasse-B labels (immutable post-create
  → recreate required).
- Both systemd timers active: `docker-cleanup.timer` + `orphan-audit.timer`
  scheduled for tonight 03:00 first run.

## Test plan

- [x] Hook unit tests: 11/11 cases pass (block + allow)
- [x] `_start_librechat_container` labels-tests: 3/3 pass
- [x] librechat-voys runtime verified: `docker inspect` shows all 3 labels
- [x] Systemd timers active on core-01: `systemctl list-timers` confirms
- [x] Smoke-test orphan-audit on core-01: emits 4 legitimate events,
      0 false positives, `audit_run_completed` count correct
- [ ] CI: audit-compose orphan check + regression must pass green
- [ ] CI: portal-api test suite must pass with new label-tests
- [ ] After merge: deploy-compose.yml syncs scripts + units to
      /opt/klai (already pre-staged manually for activation testing)
- [ ] After merge: docs.yml deploy → first deploy via `compose-up.sh` →
      verify post-deploy snapshot event lands in VictoriaLogs

## SPEC artifacts

- `.moai/specs/SPEC-INFRA-CONTAINER-HYGIENE-001/{spec,plan,acceptance,research,spec-compact}.md`
- v0.3.0 — see HISTORY for v0.1.0 → v0.2.0 → v0.3.0 evolution

## Out of scope

- Image-pinning policy (VERSIONS.md is canoniek per v0.2.0 review)
- whisper-server workflow (runs on /opt/klai-gpu, separate concern)
- librechat-voys Caddy routing fix (separate in-flight work)
- klai-core_vexa-recordings-data volume cleanup (klantdata, eigen evaluatie)

🤖 Generated with [Claude Code](https://claude.com/claude-code)