### PR TITLE
fix(hygiene): compose-up.sh tolerates pull failures for locally-tagged images

### DIFF
--- a/deploy/scripts/compose-up.sh
+++ b/deploy/scripts/compose-up.sh
@@ -59,13 +59,25 @@ done
 
 if [[ -n "$SERVICE" ]]; then
     echo "Pulling $SERVICE..."
-    docker compose pull "$SERVICE"
+    # Pull is best-effort. Some services intentionally have no
+    # registry image and `docker compose pull` exits non-zero:
+    #   - retrieval-api: image klai/retrieval-api:local — tag-aliased
+    #     locally from ghcr.io/getklai/retrieval-api:latest before this
+    #     script runs (see retrieval-api.yml workflow `docker tag`).
+    #   - bge-m3-sparse on gpu-01: built from local context.
+    # For these the existing image is already up-to-date in the local
+    # daemon; we proceed to `up -d` which uses what's there.
+    if ! docker compose pull "$SERVICE" 2>&1; then
+        echo "WARN: pull failed for $SERVICE (likely a locally-tagged image like klai/<svc>:local) — proceeding with existing local image"
+    fi
     echo "Recreating $SERVICE with --remove-orphans..."
     # shellcheck disable=SC2086
     docker compose up -d --remove-orphans $NO_DEPS_FLAG "$SERVICE"
 else
     echo "Pulling all services..."
-    docker compose pull
+    if ! docker compose pull 2>&1; then
+        echo "WARN: bulk pull had failures (likely klai/<svc>:local-tagged services) — proceeding with existing local images"
+    fi
     echo "Recreating all services with --remove-orphans..."
     docker compose up -d --remove-orphans
 fi


### PR DESCRIPTION
## Summary

Hotfix for the post-merge failure on retrieval-api deploy after PR #266.
`compose-up.sh` did unconditional `docker compose pull <svc>` and
exited non-zero on services that use a `klai/<svc>:local` tag (no
registry image to pull). Result: retrieval-api workflow failed before
the `up -d` step, no recreate happened, prod stayed up but the new
image wasn't applied.

Affected services:
- `retrieval-api` (image `klai/retrieval-api:local` — tag-aliased
  from `ghcr.io/getklai/retrieval-api:latest` by retrieval-api.yml)
- `bge-m3-sparse` (gpu-01, built from local context)

## Fix

`compose-up.sh` now logs a warning and proceeds when `docker compose
pull` fails. The `up -d` step uses the local image that was already
loaded by the preceding workflow steps (in retrieval-api's case the
`docker tag` step). Net result: locally-tagged services deploy
correctly via the wrapper, keeping `--remove-orphans` + post-deploy
snapshot benefits.

## Test plan

- [x] Hotfix committed on a clean branch off main (post-PR-#266)
- [ ] CI passes (no portal-api / connector tests touched, just compose-up.sh)
- [ ] After merge: retrieval-api workflow succeeds on next push
- [ ] Smoke: `ssh core-01 "/opt/klai/scripts/compose-up.sh retrieval-api"` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)