### PR TITLE
fix(scribe): pass model field to Vexa transcription-service (HTTP 422 fix)

### DIFF
--- a/klai-scribe/scribe-api/app/core/config.py
+++ b/klai-scribe/scribe-api/app/core/config.py
@@ -41,6 +41,11 @@ class Settings(BaseSettings):
     stt_provider: str = "whisper_http"
     # Provider label stored in audit column — update to "whisper-gpu" when moving to Phase 3+
     whisper_provider_name: str = "whisper-cpu"
+    # OpenAI-compatible `model` field on POST /v1/audio/transcriptions.
+    # Vexa transcription-service requires this field (HTTP 422 if missing).
+    # `large-v3-turbo` is the model the service runs internally and the value
+    # it returns in its response payload, so the round-trip is consistent.
+    whisper_model: str = "large-v3-turbo"
 
     # Upload limits
     max_upload_mb: int = 100

--- a/klai-scribe/scribe-api/app/services/providers.py
+++ b/klai-scribe/scribe-api/app/services/providers.py
@@ -68,7 +68,13 @@ class WhisperHttpProvider:
         audio_wav: bytes,
         language: str | None,
     ) -> TranscriptionResult:
-        data: dict = {"transcription_tier": _DEFERRED_TIER}
+        # `model` is required by the OpenAI-compatible transcription-service
+        # (HTTP 422 if missing). `transcription_tier` is the Vexa extension
+        # for two-tier admission control (SPEC-VEXA-003 §5.1).
+        data: dict = {
+            "model": settings.whisper_model,
+            "transcription_tier": _DEFERRED_TIER,
+        }
         if language:
             data["language"] = language
 

--- a/klai-scribe/scribe-api/tests/test_providers.py
+++ b/klai-scribe/scribe-api/tests/test_providers.py
@@ -38,6 +38,12 @@ def _patch_settings(monkeypatch: pytest.MonkeyPatch) -> None:
         "vexa-transcription-service",
         raising=False,
     )
+    monkeypatch.setattr(
+        providers.settings,
+        "whisper_model",
+        "large-v3-turbo",
+        raising=False,
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -110,8 +116,32 @@ class TestTierDeferredIsPosted:
         posted = client.calls[0]
         assert posted["url"] == "http://transcription-service.test/v1/audio/transcriptions"
         assert posted["data"]["transcription_tier"] == _DEFERRED_TIER
+        assert posted["data"]["model"] == "large-v3-turbo"
         assert posted["data"]["language"] == "nl"
         assert posted["files"]["file"][0] == "audio.wav"
+
+
+class TestModelFieldIsPosted:
+    """Regression guard for the Vexa transcription-service `model` requirement.
+
+    The OpenAI-compatible POST /v1/audio/transcriptions endpoint rejects with
+    HTTP 422 when `model` is missing. Production was broken when scribe-api
+    only sent `transcription_tier` + optional `language`. This test pins the
+    contract so a future refactor cannot silently drop it again.
+    """
+
+    async def test_request_carries_model_even_without_language(self, patch_client) -> None:
+        client = patch_client([_success_response()])
+        await WhisperHttpProvider().transcribe(b"audio-bytes", language=None)
+
+        assert len(client.calls) == 1
+        posted = client.calls[0]
+        assert "model" in posted["data"], (
+            "model field is required by the transcription-service; missing it "
+            "regresses to the HTTP 422 / status='failed' bug"
+        )
+        assert posted["data"]["model"] == "large-v3-turbo"
+        assert "language" not in posted["data"]
 
 
 class TestBackpressureRetry:


### PR DESCRIPTION
## Summary

Production transcribe at `voys.getklai.com/app/transcribe` is broken — every recording results in status=`failed`. Root cause: scribe-api's `WhisperHttpProvider` does not send the now-required `model` form field to the OpenAI-compatible Vexa transcription-service.

- VictoriaLogs evidence (request_id `ab19a2af-ed08-4ad2-a9a5-42950a09ec56`, 2026-05-03 06:04:51Z):
  ```
  status=422  body={"detail":[{"type":"missing","loc":["body","model"],"msg":"Field required"}]}
  event=transcription-service error
  ```
- Reproduced from core-01 with direct curl: missing `model` → 422; `model=large-v3-turbo` → passes the validator.

## Changes

- `app/core/config.py` — new `whisper_model: str = "large-v3-turbo"` Settings field. Default matches the model the transcription-service runs internally and the value already returned in the response payload (so the existing `payload.get("model", "large-v3-turbo")` round-trip stays consistent). Operator-tunable via env var.
- `app/services/providers.py` — `WhisperHttpProvider.transcribe()` now posts `{"model": settings.whisper_model, "transcription_tier": "deferred"}` in the multipart form data.
- `tests/test_providers.py`:
  - extends `TestTierDeferredIsPosted` to also assert `data["model"]`,
  - new `TestModelFieldIsPosted` regression class — runs the no-language path explicitly, since that is the path the bug lived on.

## Test plan

- [x] `pytest tests/test_providers.py` → 9/9 passing locally on Windows.
- [ ] CI workflow `scribe-api.yml` builds + pushes the image, deploys to core-01.
- [ ] After deploy: upload a clip via voys.getklai.com/app/transcribe → expect a transcript instead of "Failed".
- [ ] Spot-check VictoriaLogs `service:scribe-api AND level:error` for one request_id post-deploy → expect no `transcription-service error / status=422`.

## Risk / notes

- No DB schema change; the `scribe-deploy-no-alembic` pitfall does not apply.
- No new env var required for prod (default works); operators can override with `WHISPER_MODEL=…` if they switch the transcription-service to a different model.
- Pre-existing ruff lint findings in `tests/test_providers.py` (F401, UP037, E501) are unrelated to this fix and untouched. `scribe-api.yml` does not gate on ruff anyway — only ast-grep guards run pre-build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)