### PR TITLE
chore(vexa): upgrade v0.10.0 → v0.10.6

### DIFF
--- a/deploy/VERSIONS.md
+++ b/deploy/VERSIONS.md
@@ -8,7 +8,7 @@ Automated dependency updates are handled by Dependabot / Renovate. Upgrades foll
 
 **Exception — local builds:** `klai/retrieval-api:local` and `ghcr.io/mendableai/firecrawl:latest` are built on-host from source and not pullable from a registry. Their "versions" are tracked by git SHAs recorded in docker-compose.yml comments.
 
-**Exception — Vexa stack (SPEC-VEXA-003, 2026-04-19):** `vexaai/admin-api`, `vexaai/api-gateway`, `vexaai/meeting-api`, `vexaai/runtime-api`, `vexaai/vexa-bot`, `vexaai/transcription-service` are currently on `0.10.0-260419-1129`. Built locally on core-01 and gpu-01 from `Vexa-ai/vexa` upstream main `f0756bf`. Follow upstream's `<semver>-YYMMDD-HHMM` build convention; `deploy/check-image-tags.sh` enforces this in pre-commit. Rebuild cadence: monthly or when upstream ships a material fix (see deploy-notes in `.moai/specs/SPEC-VEXA-003/`).
+**Exception — Vexa stack (upstream v0.10.6, 2026-05-03):** `vexaai/admin-api`, `vexaai/api-gateway`, `vexaai/meeting-api`, `vexaai/runtime-api`, `vexaai/vexa-bot`, `vexaai/transcription-service` are currently on `0.10.6`. Pulled directly from Docker Hub — since v0.10.4 upstream publishes pre-built images, so the SPEC-VEXA-003 local-build flow is no longer needed. `deploy/check-image-tags.sh` enforces plain semver or timestamped-semver tag form (no `:latest` / `:dev` / `:staging`). Upgrade cadence: track upstream stable tags; bump for material fixes (chunk-leak, OOM, security). See `https://github.com/Vexa-ai/vexa/releases` for changelog.
 
 ---
 
@@ -77,7 +77,7 @@ Automated dependency updates are handled by Dependabot / Renovate. Upgrades foll
 |---|---|---|
 | `tei` | `ghcr.io/huggingface/text-embeddings-inference:1.9` | BGE-M3 dense embeddings. **Output-dimension critical** — verify bge-m3 embedding parity (same vector output for same input) before any upgrade, otherwise retrieval scores silently drift. |
 | `infinity` | `michaelf34/infinity:0.0.77` | BGE reranker-v2-m3. Upstream slowing (last release Aug 2025). |
-| `transcription-worker-1`, `transcription-worker-2` | `vexaai/transcription-service:0.10.0-260419-1129` | Vexa transcription-service (SPEC-VEXA-003 §3.4). Replaces the legacy custom `whisper-server` 146-line Python script. `faster-whisper` + Silero VAD + hallucination detection + two-tier admission (realtime/deferred) behind Nginx LB. CUDA 12.3.2 + cuDNN 9. Host port `127.0.0.1:8000` retained so `gpu-tunnel.service` and all consumer URLs stay unchanged. |
+| `transcription-worker-1`, `transcription-worker-2` | `vexaai/transcription-service:0.10.6` | Vexa transcription-service (SPEC-VEXA-003 §3.4). Replaces the legacy custom `whisper-server` 146-line Python script. `faster-whisper` + Silero VAD + hallucination detection + two-tier admission (realtime/deferred) behind Nginx LB. CUDA 12.3.2 + cuDNN 9. Host port `127.0.0.1:8000` retained so `gpu-tunnel.service` and all consumer URLs stay unchanged. |
 | `transcription-api` | `nginx:1.27-alpine` | Least-connections load balancer in front of the two CUDA workers. Config at `deploy/vexa-transcription/nginx.conf`. |
 | `bge-m3-sparse` | built from `./bge-m3-sparse` | Local build. Sparse embeddings sidecar for hybrid retrieval. |
 

--- a/deploy/check-image-tags.sh
+++ b/deploy/check-image-tags.sh
@@ -2,11 +2,18 @@
 # SPEC-VEXA-003 REQ-U-002 enforcement — no mutable Vexa image tags.
 #
 # Fails the commit if any vexaai/* image in deploy manifests points at a
-# mutable tag (latest, dev, staging) or a non-timestamp form. The immutable
-# pattern is `<semver>-YYMMDD-HHMM` per upstream build convention.
+# mutable tag (latest, dev, staging) or a non-pinned form.
 #
-# Placeholder `0.10.0-pending` tags are also rejected — compose files are
-# NOT deploy-ready until Phase 6 writes real timestamps to them.
+# Two pinned tag forms are accepted:
+#   1. Plain semver:        `<major>.<minor>.<patch>` (e.g. 0.10.6)
+#                           — used since v0.10.4, when upstream started
+#                             publishing pre-built images to Docker Hub.
+#   2. Timestamped semver:  `<major>.<minor>.<patch>-YYMMDD-HHMM`
+#                           — pre-v0.10.4 build convention, kept for
+#                             rollback compat with locally-built images.
+#
+# Placeholder `<semver>-pending` tags are also rejected — they indicate
+# a compose file is mid-migration and not deploy-ready.
 #
 # Wire into git hooks via .githooks/pre-commit or CI.
 
@@ -29,14 +36,16 @@ for F in $FILES; do
     # Rule 2: placeholder `pending` tags indicate the file is mid-migration.
     PENDING=$(grep -nE 'vexaai/[a-z0-9-]+:[0-9]+\.[0-9]+\.[0-9]+-pending' "$F" || true)
     if [ -n "$PENDING" ]; then
-        echo "ERROR: placeholder tag in $F — Phase 6 has not pinned real timestamps:" >&2
+        echo "ERROR: placeholder tag in $F — file is not deploy-ready:" >&2
         echo "$PENDING" >&2
         FAIL=1
     fi
 
-    # Rule 3: any other vexaai/* tag must match `<semver>-YYMMDD-HHMM`.
+    # Rule 3: any other vexaai/* tag must match plain semver OR
+    #         timestamped semver `<semver>-YYMMDD-HHMM`.
     BAD=$(grep -nE 'vexaai/[a-z0-9-]+:[^[:space:]#]+' "$F" \
-          | grep -vE 'vexaai/[a-z0-9-]+:[0-9]+\.[0-9]+\.[0-9]+-[0-9]{6}-[0-9]{4}' \
+          | grep -vE 'vexaai/[a-z0-9-]+:[0-9]+\.[0-9]+\.[0-9]+(-[0-9]{6}-[0-9]{4})?$' \
+          | grep -vE 'vexaai/[a-z0-9-]+:[0-9]+\.[0-9]+\.[0-9]+(-[0-9]{6}-[0-9]{4})?[[:space:]]' \
           | grep -vE 'vexaai/[a-z0-9-]+:(latest|dev|staging)\b' \
           | grep -vE 'vexaai/[a-z0-9-]+:[0-9]+\.[0-9]+\.[0-9]+-pending' \
           || true)
@@ -48,11 +57,11 @@ for F in $FILES; do
 done
 
 if [ "$FAIL" -eq 0 ]; then
-    echo "OK: all Vexa image tags are pinned to an immutable <semver>-YYMMDD-HHMM timestamp."
+    echo "OK: all Vexa image tags are pinned to plain or timestamped semver."
     exit 0
 fi
 
 echo "" >&2
-echo "Fix: update tags to the form vexaai/<svc>:<semver>-YYMMDD-HHMM." >&2
-echo "Phase 6 of SPEC-VEXA-003 writes these after 'make build' on core-01." >&2
+echo "Fix: update tags to vexaai/<svc>:<semver> (e.g. :0.10.6)" >&2
+echo "     or vexaai/<svc>:<semver>-YYMMDD-HHMM for locally-built rollback images." >&2
 exit 1

--- a/deploy/docker-compose.gpu.yml
+++ b/deploy/docker-compose.gpu.yml
@@ -108,7 +108,7 @@ services:
   # MAX_ACTIVE_REQUESTS / REALTIME_RESERVED_SLOTS. See plan.md R8.
 
   transcription-worker-1:
-    image: vexaai/transcription-service:0.10.0-pending
+    image: vexaai/transcription-service:0.10.6
     restart: unless-stopped
     environment:
       WORKER_ID: "1"
@@ -138,7 +138,7 @@ services:
       start_period: 180s
 
   transcription-worker-2:
-    image: vexaai/transcription-service:0.10.0-pending
+    image: vexaai/transcription-service:0.10.6
     restart: unless-stopped
     environment:
       WORKER_ID: "2"

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -912,17 +912,18 @@ services:
     depends_on:
       - postgres
 
-  # ─── Vexa stack (SPEC-VEXA-003 — upstream main v0.10.x, commit f0756bf) ──
-  # Source: https://github.com/Vexa-ai/vexa branch klai/main-260419
-  # Build pattern (Phase 6): on core-01 clone fork, run `make build` from
-  # deploy/compose/Makefile; images land as vexaai/<svc>:<version>-YYMMDD-HHMM.
-  # Tags below are placeholders — Phase 6 rewrites them to real build timestamps.
-  # The placeholder form is intentionally rejected by deploy/check-image-tags.sh
-  # so this compose file is NOT deploy-ready until Phase 6 completes.
+  # ─── Vexa stack (SPEC-VEXA-003 — upstream Vexa-ai/vexa v0.10.6) ──────────
+  # Source: https://github.com/Vexa-ai/vexa/releases/tag/v0.10.6
+  # Images pulled directly from Docker Hub (vexaai/*) — no local build needed.
+  # v0.10.6 brings Pack U audio unification (single audio-pipeline.ts module)
+  # and Pack M chunk-leak fix (resolves the v0.10.5.2 24-min recording crash
+  # class). Pack H helm hardening is irrelevant for our compose deploy.
+  # Tag format: plain semver `:0.10.6`. The pre-v0.10.4 timestamped form
+  # `<semver>-YYMMDD-HHMM` is no longer used upstream.
 
   # ─── Vexa admin-api (management) ────────────────────────────────────────
   admin-api:
-    image: vexaai/admin-api:0.10.0-260419-1129
+    image: vexaai/admin-api:0.10.6
     restart: unless-stopped
     environment:
       DB_HOST: postgres
@@ -954,7 +955,7 @@ services:
 
   # ─── Vexa api-gateway (public entry, rate-limited, CORS) ────────────────
   api-gateway:
-    image: vexaai/api-gateway:0.10.0-260419-1129
+    image: vexaai/api-gateway:0.10.6
     restart: unless-stopped
     environment:
       ADMIN_API_URL: http://admin-api:8001
@@ -992,7 +993,7 @@ services:
   # Network alias `vexa-meeting-api` retained for portal-api backwards compat
   # (REQ-E-001, REQ-U-001 — no config churn in portal-api during this migration).
   meeting-api:
-    image: vexaai/meeting-api:0.10.0-260419-1129
+    image: vexaai/meeting-api:0.10.6
     restart: unless-stopped
     environment:
       DB_HOST: postgres
@@ -1011,7 +1012,7 @@ services:
       RUNTIME_API_URL: http://runtime-api:8090
       RUNTIME_API_TOKEN: ${BOT_API_TOKEN}
       MEETING_API_URL: http://meeting-api:8080
-      BOT_IMAGE_NAME: vexaai/vexa-bot:0.10.0-260419-1129
+      BOT_IMAGE_NAME: vexaai/vexa-bot:0.10.6
       DOCKER_NETWORK: vexa-bots
       TRANSCRIPTION_COLLECTOR_URL: http://meeting-api:8080
       # Storage backend: Garage speaks S3, so minio-* vars point at Garage.
@@ -1089,11 +1090,11 @@ services:
 
   # ─── Vexa runtime-api (Docker-socket bot orchestrator) ──────────────────
   runtime-api:
-    image: vexaai/runtime-api:0.10.0-260419-1129
+    image: vexaai/runtime-api:0.10.6
     restart: unless-stopped
     environment:
       DOCKER_NETWORK: vexa-bots
-      BROWSER_IMAGE: vexaai/vexa-bot:0.10.0-260419-1129
+      BROWSER_IMAGE: vexaai/vexa-bot:0.10.6
       AGENT_IMAGE: ""                              # agent profile not shipped in v1
       REDIS_URL: redis://:${VEXA_REDIS_PASSWORD}@vexa-redis:6379/0
       MINIO_ENDPOINT: garage:3900

--- a/deploy/vexa/profiles.yaml
+++ b/deploy/vexa/profiles.yaml
@@ -7,14 +7,14 @@
 
 profiles:
   meeting:
-    image: "${BROWSER_IMAGE}"                     # vexaai/vexa-bot:0.10.0-<tag>
+    image: "${BROWSER_IMAGE}"                     # vexaai/vexa-bot:<semver>
     command: ["/app/vexa-bot/entrypoint.sh"]
     working_dir: "/app/vexa-bot"
     resources:
       cpu_request: "1000m"
       cpu_limit: "1500m"
       memory_request: "1100Mi"
-      memory_limit: "1536Mi"
+      memory_limit: "2560Mi"                      # v0.10.3 Bug B — Teams bot exit 137 (OOM); was 1536Mi
       shm_size: 2147483648                        # 2 GiB for Chromium stability
     idle_timeout: 0                               # meeting-api scheduler owns lifetime
     auto_remove: false                            # meeting-api explicitly tears down


### PR DESCRIPTION
## Summary

- Bumps the Vexa stack from v0.10.0 (`:0.10.0-260419-1129`, locally-built on core-01/gpu-01 per SPEC-VEXA-003 Phase 6) to upstream **v0.10.6**, pulled directly from Docker Hub. Since v0.10.4 upstream publishes pre-built images — local builds are no longer needed.
- Bumps bot meeting profile `memory_limit` from 1536Mi → 2560Mi (v0.10.3 Bug B Teams OOM fix).
- Loosens `deploy/check-image-tags.sh` Rule 3 to accept plain semver `:X.Y.Z` in addition to legacy `:X.Y.Z-YYMMDD-HHMM`. Both forms remain pinned/immutable; mutable tags (`latest`/`dev`/`staging`) still rejected.

## What lands cumulatively in v0.10.6 (vs our current v0.10.0)

| Version | What |
|---|---|
| v0.10.1/2 | OSS security hardening, transcription tuning |
| v0.10.3 | Incremental 30s recording chunk uploads (recordings survive mid-meeting SIGKILL), durable bot-exit callbacks, DB pool reset, OOM fix for Teams, `video=false` default on `POST /bots` |
| v0.10.4 | Zoom Web bot path (no Zoom SDK creds needed) + 4× CPU reduction per Zoom bot via `--in-process-gpu` |
| v0.10.5.x | Hotfix: `Execution context destroyed` mid-meeting crash (cross-platform) |
| **v0.10.6** | **Pack U** — single `services/audio-pipeline.ts` module replaces 3 platform-specific recordings, **Pack M** — chunk-leak fix closes the 24-min recording crash class |

Release notes: https://github.com/Vexa-ai/vexa/releases

## Test plan

- [x] `deploy/check-image-tags.sh` passes locally (regex updated to accept both tag forms)
- [x] No leftover `0.10.0-260419-1129` or `0.10.0-pending` references in `deploy/`
- [ ] CI green on this PR (no service workflows expected to fire — only deploy/ files changed)
- [ ] After merge: `gh run watch --exit-status` on the deploy-compose workflow
- [ ] Post-deploy on core-01: `docker ps --format '{{.Names}}\t{{.Image}}' | grep vexaai` — every line ends in `:0.10.6`
- [ ] Post-deploy on gpu-01 (via core-01 jump): same check on transcription-worker-1/2 and transcription-api
- [ ] Real Google Meet smoke test — start a bot, join, talk, leave, verify transcript renders in portal (this also retires the deploy-notes §8 known gap from v0.10.0 deploy)
- [ ] VictoriaLogs: query `service:portal-api AND request_id:<uuid>` for the smoke meeting — webhook envelope must still parse via `VexaWebhookPayload._normalize` (3 wire formats already handled; v0.10.6 still uses upstream envelope shape 1)

## Rollback

Old images stay on core-01/gpu-01 disk during the confidence window:

```bash
ssh core-01 'docker images vexaai/* --format "{{.Repository}}:{{.Tag}}"'
# Should still list :0.10.0-260419-1129 alongside the new :0.10.6
```

Revert is a single commit revert + `gh run watch`. The `check-image-tags.sh` regex accepts both forms, so revert lands without lint changes.

## What is NOT in scope

- The runtime-api Unix-socket hardcode (`requests_unixsocket`) is unchanged in v0.10.6 — our `alpine/socat` sidecar workaround stays. If upstream eventually adds TCP support, removal is a follow-up PR.
- No portal-api code change. `VexaClient` already accepts the v0.10 envelope shape; `VexaWebhookPayload` already normalizes 3 wire formats including the upstream v0.10 `data.meeting` envelope (see `meetings.py:474`).
- This is not a SPEC — it's a routine dependency bump that fits within the SPEC-VEXA-003 architecture established in April 2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)