### PR TITLE
fix: SPEC-INFRA-TENANT-DELETE-001 critical RLS + Moneybird fixes

### DIFF
--- a/klai-portal/backend/app/api/admin/__init__.py
+++ b/klai-portal/backend/app/api/admin/__init__.py
@@ -80,7 +80,13 @@ async def _get_caller_org(
     # via the API. SET LOCAL is transaction-scoped so the next request on
     # this pooled connection starts clean (cleared by _reset_tenant_context).
     if org.slug == _app_settings.platform_org_slug:
-        await db.execute(text("SELECT set_config('app.is_platform_admin', 'true', true)"))
+        # GUC value MUST match the post_deploy SQL policy:
+        # `current_setting('app.is_platform_admin', true) = '1'`. Using '1'
+        # rather than 'true' aligns with the policy and with the convention
+        # used by app.current_org_id (also stored as text). A value mismatch
+        # would silently filter the SELECT-policy to zero rows — defeating
+        # the whole audit-readability fix.
+        await db.execute(text("SELECT set_config('app.is_platform_admin', '1', true)"))
 
     return zitadel_user_id, org, caller_user
 

--- a/klai-portal/backend/app/services/moneybird_client.py
+++ b/klai-portal/backend/app/services/moneybird_client.py
@@ -62,22 +62,22 @@ class MoneybirdClient:
         )
 
     async def stop_subscription(self, subscription_id: str) -> None:
-        """Stop/pause a recurring sales invoice (subscription).
+        """Stop a recurring sales invoice (subscription).
 
-        Moneybird recurring invoices can be stopped by setting frequency_type
-        to "stopped" via PATCH on the recurring_sales_invoices endpoint.
-
-        # @MX:TODO: verify Moneybird API path during integration test.
-        # The Moneybird REST API docs show recurring_sales_invoices as the
-        # canonical resource for subscription billing. The frequency_type field
-        # accepts "stopped" to deactivate recurring billing.
+        Per Moneybird docs (developer.moneybird.com/api/recurring_sales_invoices):
+        DELETE on the resource is the only mechanism to stop automatic invoicing.
+        The API behaves polymorphically:
+          - If no invoices were ever created from this recurring template, the
+            recurring invoice is destroyed → 204.
+          - If invoices have been created, the recurring template is deactivated
+            (history is preserved) → 204.
+        Either way: billing stops. There is no PATCH-based "frequency_type=stopped"
+        endpoint — that was a guess in the original implementation that this fix
+        replaces.
 
         Idempotent: 404 means the subscription is already absent or deleted.
         """
-        resp = await self._http.patch(
-            f"/recurring_sales_invoices/{subscription_id}",
-            json={"recurring_sales_invoice": {"frequency_type": "stopped"}},
-        )
+        resp = await self._http.delete(f"/recurring_sales_invoices/{subscription_id}")
         if resp.status_code == 404:
             logger.info(
                 "moneybird_subscription_already_absent",
@@ -88,6 +88,7 @@ class MoneybirdClient:
         logger.info(
             "moneybird_subscription_stopped",
             subscription_id=subscription_id,
+            status=resp.status_code,
         )
 
     async def archive_contact(self, contact_id: str) -> None:

--- a/klai-portal/backend/app/services/provisioning/deprovisioning_orchestrator.py
+++ b/klai-portal/backend/app/services/provisioning/deprovisioning_orchestrator.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import suppress
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import UTC, datetime
 
 import asyncpg
@@ -89,7 +89,6 @@ class _DeprovisionState:
     deprovisioner_user_id: str
     deprovisioner_type: str  # 'owner' | 'platform_admin' | 'system'
     org_name: str
-    failures: list[str] = field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -222,8 +221,17 @@ async def _resolve_zitadel_oidc_app_id(client_id: str | None) -> str:
             for app in apps:
                 if app.get("oidcConfig", {}).get("clientId") == client_id:
                     return app.get("id", "")
-    except Exception:
-        logger.warning("zitadel_oidc_app_id_lookup_failed", client_id=client_id, exc_info=True)
+    except (httpx.HTTPError, KeyError, ValueError, TypeError) as exc:
+        # HTTPError: Zitadel down/4xx/5xx. KeyError/ValueError/TypeError: malformed
+        # JSON response shape. We deliberately NARROW the catch — bare `except`
+        # would mask AttributeError or IndexError which signal a programming bug,
+        # not "service degraded". Step 14 handles empty app_id gracefully.
+        logger.warning(
+            "zitadel_oidc_app_id_lookup_failed",
+            client_id=client_id,
+            error=type(exc).__name__,
+            exc_info=True,
+        )
 
     return ""
 
@@ -250,8 +258,14 @@ async def _resolve_litellm_team_id(slug: str) -> str:
             for team in teams:
                 if team.get("team_alias") == slug:
                     return str(team.get("team_id", ""))
-    except Exception:
-        logger.warning("litellm_team_id_lookup_failed", slug=slug, exc_info=True)
+    except (httpx.HTTPError, KeyError, ValueError, TypeError) as exc:
+        # Same narrowing rationale as _resolve_zitadel_oidc_app_id above.
+        logger.warning(
+            "litellm_team_id_lookup_failed",
+            slug=slug,
+            error=type(exc).__name__,
+            exc_info=True,
+        )
 
     return ""
 

--- a/klai-portal/backend/app/services/provisioning/deprovisioning_steps.py
+++ b/klai-portal/backend/app/services/provisioning/deprovisioning_steps.py
@@ -541,9 +541,18 @@ async def _finalize_postgres_delete(state: _DeprovisionState) -> None:
     #   added to this DELETE list, otherwise the final hard-delete throws FK violation
     #   and the tenant gets stuck in failed_deprovisioning.
     """
+    from app.core.database import set_tenant
     from app.services.audit.tenant_lifecycle import emit_lifecycle_event
 
     db = state.db
+
+    # 0. Set tenant context for RLS Category-D tables. Without this, the
+    # explicit DELETEs below (portal_knowledge_bases, portal_groups,
+    # portal_kb_tombstones, vexa_meetings — all in RLS_DML_TABLES per
+    # rls_guard.py) raise IntegrityError 42501 because the orchestrator
+    # opens its own AsyncSessionLocal which RESETS app.current_org_id.
+    # See portal-backend.md "Pool-GUC pollution" pitfall.
+    await set_tenant(db, state.org_id)
 
     # 1. Audit event — inside this transaction so a failure rolls back the delete too.
     await emit_lifecycle_event(

--- a/klai-portal/backend/tests/test_deprovisioning_steps.py
+++ b/klai-portal/backend/tests/test_deprovisioning_steps.py
@@ -730,12 +730,15 @@ class TestFinalizePostgresDelete:
         # Also patch invalidate_tenant_slug_cache so we don't clear the module-level
         # cache in app.api.auth (would cause cross-test pollution: other tests rely on
         # the cache being warm and would try to load from DB on cache miss).
+        # set_tenant is patched because production code uses it to set the RLS
+        # Category-D tenant context before the explicit DELETEs.
         with (
             patch(
                 "app.services.audit.tenant_lifecycle.emit_lifecycle_event",
                 new=AsyncMock(),
             ) as mock_emit,
             patch("app.api.auth.invalidate_tenant_slug_cache", new=MagicMock()),
+            patch("app.core.database.set_tenant", new=AsyncMock()) as mock_set_tenant,
         ):
             from app.services.provisioning.deprovisioning_steps import _finalize_postgres_delete
 
@@ -743,6 +746,10 @@ class TestFinalizePostgresDelete:
 
         mock_emit.assert_awaited_once()
         state.db.commit.assert_awaited_once()
+        # Verify tenant context is set before DELETEs run — without it the
+        # Category-D RLS policies on portal_knowledge_bases / portal_groups /
+        # portal_kb_tombstones / vexa_meetings raise IntegrityError 42501.
+        mock_set_tenant.assert_awaited_once_with(state.db, state.org_id)
 
     @pytest.mark.asyncio
     async def test_execute_called_for_each_non_cascading_child_table(self) -> None:
@@ -764,6 +771,7 @@ class TestFinalizePostgresDelete:
                 new=AsyncMock(),
             ),
             patch("app.api.auth.invalidate_tenant_slug_cache", new=MagicMock()),
+            patch("app.core.database.set_tenant", new=AsyncMock()),
         ):
             from app.services.provisioning.deprovisioning_steps import _finalize_postgres_delete
 

--- a/klai-portal/backend/tests/test_moneybird_client.py
+++ b/klai-portal/backend/tests/test_moneybird_client.py
@@ -69,36 +69,50 @@ class TestMoneybirdClientConstruction:
 
 
 class TestStopSubscription:
+    """Per Moneybird API: DELETE /recurring_sales_invoices/{id} stops billing
+    (destroys the recurring template if no invoices exist, deactivates if they do).
+    There is no PATCH-based 'frequency_type=stopped' endpoint — the original
+    PATCH-with-body implementation was a guess and would 404.
+    """
+
+    @pytest.mark.asyncio
+    async def test_204_returns_none(self, client) -> None:
+        with respx.mock(base_url=_BASE_URL) as mock:
+            mock.delete(f"/recurring_sales_invoices/{_SUBSCRIPTION_ID}").mock(return_value=httpx.Response(204))
+            result = await client.stop_subscription(_SUBSCRIPTION_ID)
+        assert result is None
+
     @pytest.mark.asyncio
     async def test_200_returns_none(self, client) -> None:
+        """Some Moneybird responses return 200 instead of 204 — both = success."""
         with respx.mock(base_url=_BASE_URL) as mock:
-            mock.patch(f"/recurring_sales_invoices/{_SUBSCRIPTION_ID}").mock(
+            mock.delete(f"/recurring_sales_invoices/{_SUBSCRIPTION_ID}").mock(
                 return_value=httpx.Response(200, json={"id": _SUBSCRIPTION_ID})
             )
             result = await client.stop_subscription(_SUBSCRIPTION_ID)
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_200_sends_stopped_frequency_type(self, client) -> None:
+    async def test_uses_delete_method_with_no_body(self, client) -> None:
         with respx.mock(base_url=_BASE_URL) as mock:
-            route = mock.patch(f"/recurring_sales_invoices/{_SUBSCRIPTION_ID}").mock(return_value=httpx.Response(200))
+            route = mock.delete(f"/recurring_sales_invoices/{_SUBSCRIPTION_ID}").mock(return_value=httpx.Response(204))
             await client.stop_subscription(_SUBSCRIPTION_ID)
-        import json
-
-        body = json.loads(route.calls.last.request.content)
-        assert body["recurring_sales_invoice"]["frequency_type"] == "stopped"
+        # Verify exactly one DELETE call with empty body
+        assert len(route.calls) == 1
+        assert route.calls.last.request.method == "DELETE"
+        assert route.calls.last.request.content == b""
 
     @pytest.mark.asyncio
     async def test_404_is_idempotent(self, client) -> None:
         with respx.mock(base_url=_BASE_URL) as mock:
-            mock.patch(f"/recurring_sales_invoices/{_SUBSCRIPTION_ID}").mock(return_value=httpx.Response(404))
+            mock.delete(f"/recurring_sales_invoices/{_SUBSCRIPTION_ID}").mock(return_value=httpx.Response(404))
             result = await client.stop_subscription(_SUBSCRIPTION_ID)
         assert result is None
 
     @pytest.mark.asyncio
     async def test_500_raises_http_status_error(self, client) -> None:
         with respx.mock(base_url=_BASE_URL) as mock:
-            mock.patch(f"/recurring_sales_invoices/{_SUBSCRIPTION_ID}").mock(return_value=httpx.Response(500))
+            mock.delete(f"/recurring_sales_invoices/{_SUBSCRIPTION_ID}").mock(return_value=httpx.Response(500))
             with pytest.raises(httpx.HTTPStatusError):
                 await client.stop_subscription(_SUBSCRIPTION_ID)
 
@@ -106,7 +120,7 @@ class TestStopSubscription:
     async def test_422_raises_http_status_error(self, client) -> None:
         """Non-404 client errors also propagate."""
         with respx.mock(base_url=_BASE_URL) as mock:
-            mock.patch(f"/recurring_sales_invoices/{_SUBSCRIPTION_ID}").mock(
+            mock.delete(f"/recurring_sales_invoices/{_SUBSCRIPTION_ID}").mock(
                 return_value=httpx.Response(422, json={"error": "invalid"})
             )
             with pytest.raises(httpx.HTTPStatusError):


### PR DESCRIPTION
## Summary

Critical post-merge fixes to SPEC-INFRA-TENANT-DELETE-001. Found by stepping back and asking 'are these really safe to run in production?'. Four real bugs that would have surfaced on the first production tenant-delete:

1. **CRITICAL — RLS GUC value mismatch**. Python wrote \`'true'\`, SQL policy compared \`= '1'\`. Audit-trail unreadable via API. → Aligned both to \`'1'\`.
2. **CRITICAL — orchestrator never sets tenant context**. Step 16 DELETEs on Category-D RLS tables (portal_knowledge_bases, portal_groups, portal_kb_tombstones, vexa_meetings) raise \`42501\` because the BackgroundTask opens a fresh AsyncSessionLocal which RESETS \`app.current_org_id\` (pool-GUC pollution pitfall). → Added \`set_tenant\` at start of step 16.
3. **HIGH — Moneybird stop_subscription used wrong API call**. Verified against Moneybird docs: PATCH with frequency_type body doesn't exist; correct is DELETE on the resource. → Rewrote to DELETE.
4. **HIGH — bare \`except Exception\`** in \`_resolve_*\` masked programming bugs as 'service degraded'. → Narrowed to (HTTPError, KeyError, ValueError, TypeError).

Plus dead code cleanup (unused \`state.failures\` field).

## Why these matter

Without fix #1: audit-trail SELECT silently returns 0 rows for legit platform admins. Defeats the audit-readability fix from the previous PR.

Without fix #2: first real deprovision against a tenant with KBs / meetings / groups crashes mid-step-16 → \`failed_deprovisioning\` with no recovery path beyond manual psql.

Without fix #3: first delete with active Moneybird subscription either silently no-ops or 404s. Billing keeps running.

Without fix #4: future refactor introduces a typo in \`_resolve_zitadel_oidc_app_id\` JSON parsing → silent skip instead of loud crash.

## Test plan

- [x] 144/144 deprovision tests pass
- [x] 1559/1560 wider portal-api suite (1 fail is pre-existing local-env DEBUG=true, not regression)
- [x] pyright clean
- [x] ruff check + format clean
- [ ] CI green
- [ ] Merge + auto-deploy
- [ ] Verify on core-01: \`docker logs klai-core-portal-api-1 --tail 30\` shows clean startup
- [ ] Smoke: \`curl -X DELETE https://my.getklai.com/api/admin/org/me\` still returns 401 (auth working)

🤖 Generated with [Claude Code](https://claude.com/claude-code)