### PR TITLE
fix: SPEC-INFRA-TENANT-DELETE-001 status endpoint RBAC + info disclosure

### DIFF
--- a/klai-portal/backend/app/api/admin/deprovision_org.py
+++ b/klai-portal/backend/app/api/admin/deprovision_org.py
@@ -344,7 +344,7 @@ async def get_deprovision_status(
     #   other endpoints with this flag without SPEC justification.
     """
     try:
-        _, org, _ = await _get_caller_org(credentials, db, allow_during_deprovisioning=True)
+        _, org, caller_user = await _get_caller_org(credentials, db, allow_during_deprovisioning=True)
     except HTTPException as exc:
         if exc.status_code == status.HTTP_404_NOT_FOUND:
             # Org row is gone — successful deprovisioning completed.
@@ -354,8 +354,23 @@ async def get_deprovision_status(
             ) from exc
         raise
 
+    # SEC: only org-owner (admin role) may poll deprovisioning status. Without
+    # this guard, members/group-admins could see step names + (previously) full
+    # error strings during a failed deprovision — info disclosure of internal
+    # infrastructure (container hostnames, step orchestration internals).
+    _require_admin(caller_user)
+
     payload: dict = {"status": org.provisioning_status}
     if org.provisioning_status == "failed_deprovisioning" and org.last_failure:
-        payload["last_failure"] = org.last_failure
+        # SEC: do NOT expose `last_failure.error` to the owner — error strings
+        # may include internal hostnames (klai-core-*-1), DSN fragments from
+        # asyncpg/httpx exceptions, or other infra detail. Step name + timestamp
+        # is enough for the owner to contact support; full error stays in
+        # portal_orgs.last_failure (visible only via direct DB access by
+        # platform admins) and in VictoriaLogs (queryable via Grafana MCP).
+        payload["last_failure"] = {
+            "step": org.last_failure.get("step", "unknown"),
+            "failed_at": org.last_failure.get("failed_at"),
+        }
 
     return payload

--- a/klai-portal/backend/tests/test_deprovision_endpoints.py
+++ b/klai-portal/backend/tests/test_deprovision_endpoints.py
@@ -434,10 +434,13 @@ class TestGetDeprovisionStatus:
         assert result == {"status": "deprovisioning"}
 
     @pytest.mark.asyncio
-    async def test_includes_last_failure_on_failed_state(self):
+    async def test_includes_sanitized_last_failure_on_failed_state(self):
+        """Owner sees only step + failed_at; error string with infra detail
+        and attempt count are NOT exposed (would leak internal hostnames /
+        DSN fragments)."""
         last_failure = {
             "step": "_delete_caddy_upstream",
-            "error": "timeout",
+            "error": "Connection refused to klai-core-knowledge-ingest-1:8000",
             "attempt": 3,
             "failed_at": "2026-05-03T12:00:00+00:00",
         }
@@ -454,7 +457,31 @@ class TestGetDeprovisionStatus:
             result = await get_deprovision_status(creds, db)
 
         assert result["status"] == "failed_deprovisioning"
-        assert result["last_failure"] == last_failure
+        # Sanitized: only step + failed_at exposed, NOT error string or attempt.
+        assert result["last_failure"] == {
+            "step": "_delete_caddy_upstream",
+            "failed_at": "2026-05-03T12:00:00+00:00",
+        }
+        assert "error" not in result["last_failure"]
+        assert "attempt" not in result["last_failure"]
+
+    @pytest.mark.asyncio
+    async def test_non_admin_member_blocked_by_require_admin(self):
+        """Members and group-admins MUST NOT see deprovision status — admin only."""
+        org = _make_org(provisioning_status="deprovisioning")
+        user = _make_user(role="member")  # not admin
+        db = AsyncMock()
+        db.add = MagicMock()
+        creds = _make_credentials()
+
+        with patch(
+            "app.api.admin.deprovision_org._get_caller_org",
+            AsyncMock(return_value=("zit-user-1", org, user)),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await get_deprovision_status(creds, db)
+
+        assert exc_info.value.status_code == 403
 
     @pytest.mark.asyncio
     async def test_returns_ready_when_not_deprovisioning(self):

--- a/klai-portal/frontend/src/routes/admin/deprovisioning-status.tsx
+++ b/klai-portal/frontend/src/routes/admin/deprovisioning-status.tsx
@@ -23,11 +23,12 @@ const TIMEOUT_MS = 5 * 60_000
 
 interface DeprovisionStatus {
   status: 'deprovisioning' | 'failed_deprovisioning' | 'ready' | 'gone'
+  // Backend deliberately strips `error` + `attempt` from the owner-facing
+  // payload — they may contain internal infra detail. Full fields are
+  // available to platform admins via direct DB query / VictoriaLogs.
   last_failure?: {
     step: string
-    error: string
-    attempt: number
-    failed_at: string
+    failed_at?: string
   }
 }
 


### PR DESCRIPTION
## Summary

Two security holes in \`GET /api/admin/org/me/deprovision-status\` found by post-merge security review:

1. **Missing role check** — any authenticated org member could poll it. Now requires admin role (consistent with other admin endpoints).
2. **\`last_failure\` exposed unfiltered** — error string can contain internal hostnames, DSN fragments, stack-trace-ish detail. Combined with #1, members could harvest infra detail during a failed deprovision. Now strips \`error\` + \`attempt\`, keeps only \`step\` + \`failed_at\` (enough for "contact support with this code"). Full error stays in DB / VictoriaLogs for ops.

## Verified safe by inspection

- Slug sanitization in \`_slugify_unique\` ([a-zA-Z0-9-]) blocks path traversal.
- Cookie SameSite=Lax + DELETE requires CORS preflight = standard CSRF mitigation.
- Step 16 DELETEs use parameterized text() queries.
- Audit table INSERT-permissive RLS gated by GRANT to portal_api only.
- knowledge-ingest /internal/v1 endpoint not exposed via Caddy.

## Test plan

- [x] 145/145 deprovision tests pass (added 1 new test for member-blocked, updated 1 for sanitization)
- [x] pyright clean
- [x] ruff check + format clean
- [ ] CI green
- [ ] Merge + auto-deploy
- [ ] Smoke: \`curl /api/admin/org/me/deprovision-status\` still 401 from outside

🤖 Generated with [Claude Code](https://claude.com/claude-code)