### PR TITLE
fix(scribe): tolerate optional whisper-server payload fields + log tracebacks

### DIFF
--- a/klai-scribe/scribe-api/app/api/transcribe.py
+++ b/klai-scribe/scribe-api/app/api/transcribe.py
@@ -181,7 +181,17 @@ async def transcribe(
         record.status = "failed"
         await db.commit()
         await db.refresh(record)
-        logger.warning("Transcription failed for %s, audio preserved at %s", txn_id, audio_path)
+        # exc_info=True per `klai/projects/portal-logging-py.md` —
+        # except blocks MUST capture traceback, otherwise the same
+        # warning at 3am has no usable root cause in VictoriaLogs.
+        # Without this, we couldn't see the KeyError that surfaced
+        # during the 2026-05-03 e2e walkthrough.
+        logger.warning(
+            "transcription_failed",
+            txn_id=txn_id,
+            audio_path=audio_path,
+            exc_info=True,
+        )
         return _to_response(record)
 
     # Success — mutate record + purge audio from disk (retention policy).
@@ -243,7 +253,7 @@ async def retry_transcription(
         record.status = "failed"
         await db.commit()
         await db.refresh(record)
-        logger.warning("Retry failed for %s", txn_id)
+        logger.warning("retry_transcription_failed", txn_id=txn_id, exc_info=True)
         return _to_response(record)
 
     # Success — mutate record + purge audio from disk (retention policy).

--- a/klai-scribe/scribe-api/app/services/providers.py
+++ b/klai-scribe/scribe-api/app/services/providers.py
@@ -134,11 +134,21 @@ class WhisperHttpProvider:
                 )
 
             payload = resp.json()
+            # Whisper-server response fields aren't all guaranteed across
+            # upstream versions. text/language/duration are part of the
+            # OpenAI-compatible contract; inference_time_seconds is a Vexa
+            # extension that's optional. Prefer .get() over [] for fields
+            # that may be absent — a missing optional extension shouldn't
+            # cause 100% transcription failure (KeyError → outer broad
+            # except in transcribe.py → status='failed', root cause
+            # invisible per `portal-logging-py.md` rule).
+            # Discovered during e2e walkthrough 2026-05-03 — every
+            # Voys-tenant scribe upload was hitting this KeyError.
             return TranscriptionResult(
-                text=payload["text"],
-                language=payload["language"],
-                duration_seconds=float(payload["duration"]),
-                inference_time_seconds=float(payload["inference_time_seconds"]),
+                text=payload.get("text", ""),
+                language=payload.get("language", "und"),
+                duration_seconds=float(payload.get("duration", 0.0)),
+                inference_time_seconds=float(payload.get("inference_time_seconds", 0.0)),
                 provider=settings.whisper_provider_name,
                 model=payload.get("model", "large-v3-turbo"),
             )

--- a/klai-scribe/scribe-api/tests/conftest.py
+++ b/klai-scribe/scribe-api/tests/conftest.py
@@ -19,6 +19,10 @@ _DEFAULTS: dict[str, str] = {
     "WHISPER_PROVIDER_NAME": "vexa-transcription-service",
     "STT_PROVIDER": "whisper_http",
     "ZITADEL_ISSUER": "https://auth.test.local",
+    # SPEC-SEC-INTERNAL-001 REQ-9.4 — pydantic Settings validator rejects
+    # empty/whitespace. Tests don't call /ingest, so any non-empty
+    # placeholder satisfies the validator.
+    "KNOWLEDGE_INGEST_SECRET": "test-knowledge-ingest-secret",
 }
 for _k, _v in _DEFAULTS.items():
     os.environ.setdefault(_k, _v)

--- a/klai-scribe/scribe-api/tests/test_providers.py
+++ b/klai-scribe/scribe-api/tests/test_providers.py
@@ -209,3 +209,55 @@ class TestNon200Non503Surfaces503:
             await WhisperHttpProvider().transcribe(b"audio", language=None)
         assert exc_info.value.status_code == 503
         assert len(client.calls) == 1
+
+
+class TestPayloadFieldsAreOptional:
+    """Discovered during 2026-05-03 e2e walk: every Voys-tenant scribe
+    upload was returning status='failed' because the live whisper-server
+    response is missing the `inference_time_seconds` field that the
+    provider was reading via `payload[...]`. The KeyError was swallowed
+    by the broad except in transcribe.py and surfaced only as
+    `status: failed` in the UI — root cause invisible.
+
+    These regression tests pin the provider against future upstream
+    schema-drift on optional fields. text/language/duration are part
+    of the OpenAI-compatible contract; inference_time_seconds is a
+    Vexa extension and should be treated as optional.
+    """
+
+    async def test_missing_inference_time_seconds_does_not_raise(self, patch_client) -> None:
+        # Whisper-server response observed live on 2026-05-03 — no
+        # `inference_time_seconds` field present.
+        client = patch_client([
+            httpx.Response(
+                200,
+                json={
+                    "text": "",
+                    "language": "en",
+                    "language_probability": 0.6,
+                    "duration": 0.0,
+                    "segments": [],
+                },
+            )
+        ])
+
+        result = await WhisperHttpProvider().transcribe(b"audio", language=None)
+
+        assert isinstance(result, TranscriptionResult)
+        assert result.text == ""
+        assert result.language == "en"
+        assert result.duration_seconds == 0.0
+        assert result.inference_time_seconds == 0.0  # default for missing field
+        assert len(client.calls) == 1
+
+    async def test_minimal_response_uses_safe_defaults(self, patch_client) -> None:
+        # Pathological-but-spec-allowed: only `text` is present.
+        client = patch_client([httpx.Response(200, json={"text": "hi"})])
+
+        result = await WhisperHttpProvider().transcribe(b"audio", language=None)
+
+        assert result.text == "hi"
+        assert result.language == "und"
+        assert result.duration_seconds == 0.0
+        assert result.inference_time_seconds == 0.0
+        assert result.model == "large-v3-turbo"


### PR DESCRIPTION
## Summary

100% van Voys-tenant scribe uploads returned `status: failed`. Root cause:
`WhisperHttpProvider.transcribe` las `payload['inference_time_seconds']`
via dict-subscript, maar dat veld is in de huidige whisper-server response
weg. KeyError → broad except in transcribe.py → status='failed' →
UI toont "Mislukt" zonder enige error in logs.

Live geverifieerd tijdens 2026-05-03 e2e walkthrough op voys.getklai.com:

```
GET /api/scribe/v1/transcriptions
{
  "items": [
    {"id":"...", "name":"e2e-canary-silent-1s.wav", "status":"failed", ...},
    {"id":"...", "name":"recording.webm", "status":"failed", ...}
  ]
}
```

Direct `httpx.post` op whisper-server endpoint:
```
status: 200
body: {"text":"","language":"en","language_probability":0.6,"duration":0.0,"segments":[]}
```

Geen `inference_time_seconds` key → de provider crasht op KeyError.

## Fix

1. `providers.py:137-152` — `.get()` met safe defaults voor alle
   optionele velden. text/language/duration zijn OpenAI-compatible
   contract; inference_time_seconds is een Vexa-extensie die optioneel
   moet zijn.

2. `transcribe.py:180-196` + `252-258` — `logger.warning(..., exc_info=True)`
   zodat de exception traceback in VictoriaLogs landt. Per
   `klai/projects/portal-logging-py.md` HARD rule.

3. `conftest.py` — `KNOWLEDGE_INGEST_SECRET` default zodat tests
   `app.core.config` kunnen importeren.

## Test plan

- [x] 11/11 tests groen lokaal (`pytest tests/test_providers.py`)
- [x] Twee nieuwe regression-tests in `TestPayloadFieldsAreOptional`
- [ ] CI pass
- [ ] Na deploy: bestaande `failed` transcripts kunnen via "Opnieuw
      proberen" UI-button hersteld worden (audio is op disk preserved)

## Discovery

Gevonden tijdens een handmatige Playwright e2e walkthrough op
voys.getklai.com. Zie ook `docs/testing/test-suite-plan.md` voor de
geplande automation rond dit type tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)