### PR TITLE
fix(admin): add GET /api/admin/org/me — danger-zone modal precondition

### DIFF
--- a/klai-portal/backend/app/api/admin/deprovision_org.py
+++ b/klai-portal/backend/app/api/admin/deprovision_org.py
@@ -151,9 +151,9 @@ async def get_own_org(
     `{slug, name}`. Caller must be the org owner (portal_role='admin').
 
     Discovered during the 2026-05-03 e2e walkthrough: the danger-zone page
-    was issuing 4× `GET /api/admin/org/me` (one per render of the
+    was issuing 4x `GET /api/admin/org/me` (one per render of the
     delete-modal precondition) and getting 405 because the only handler
-    on this path was DELETE. Frontend was correct — backend was missing
+    on this path was DELETE. Frontend was correct; backend was missing
     the GET counterpart. SPEC-INFRA-TENANT-DELETE-001 R10.
 
     # @MX:NOTE: SPEC-INFRA-TENANT-DELETE-001 R10. Read-only sibling of the

--- a/klai-portal/backend/app/api/admin/deprovision_org.py
+++ b/klai-portal/backend/app/api/admin/deprovision_org.py
@@ -1,6 +1,7 @@
 """SPEC-INFRA-TENANT-DELETE-001 R1/R8/R10 — tenant deprovisioning endpoints.
 
-Four endpoints:
+Five endpoints:
+  GET    /api/admin/org/me                      — owner read of current org metadata
   DELETE /api/admin/org/me                      — owner self-service
   DELETE /api/admin/orgs/{slug}/deprovision     — platform-admin
   POST   /api/admin/orgs/{slug}/retry-deprovisioning  — admin retry after failure
@@ -129,6 +130,48 @@ def _require_platform_admin(caller_org: PortalOrg) -> None:
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Access denied: platform admin org required",
         )
+
+
+# ---------------------------------------------------------------------------
+# Owner read: GET /api/admin/org/me
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/org/me",
+    status_code=status.HTTP_200_OK,
+)
+async def get_own_org(
+    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, str]:
+    """Owner-readable metadata for the caller's current organisation.
+
+    Returns the minimum surface needed by the danger-zone delete-modal:
+    `{slug, name}`. Caller must be the org owner (portal_role='admin').
+
+    Discovered during the 2026-05-03 e2e walkthrough: the danger-zone page
+    was issuing 4× `GET /api/admin/org/me` (one per render of the
+    delete-modal precondition) and getting 405 because the only handler
+    on this path was DELETE. Frontend was correct — backend was missing
+    the GET counterpart. SPEC-INFRA-TENANT-DELETE-001 R10.
+
+    # @MX:NOTE: SPEC-INFRA-TENANT-DELETE-001 R10. Read-only sibling of the
+    # DELETE /org/me endpoint. Same auth pattern. No state-machine guard:
+    # if the org is already in a deprovisioning state the modal still
+    # needs slug+name to render the polling UI.
+    """
+    _, caller_org, caller_user = await _get_caller_org(
+        credentials,
+        db,
+        allow_during_deprovisioning=True,
+    )
+    _require_admin(caller_user)
+
+    return {
+        "slug": caller_org.slug,
+        "name": caller_org.name,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/klai-portal/backend/tests/test_deprovision_endpoints.py
+++ b/klai-portal/backend/tests/test_deprovision_endpoints.py
@@ -23,6 +23,7 @@ from app.api.admin.deprovision_org import (
     deprovision_org_by_slug,
     deprovision_own_org,
     get_deprovision_status,
+    get_own_org,
     retry_deprovisioning,
 )
 
@@ -529,3 +530,61 @@ class TestGetDeprovisionStatus:
                 await get_deprovision_status(creds, db)
 
         assert exc_info.value.status_code == 404
+
+
+class TestGetOwnOrg:
+    """SPEC-INFRA-TENANT-DELETE-001 R10 — owner-readable org metadata.
+
+    Discovered during 2026-05-03 e2e walkthrough on voys.getklai.com:
+    danger-zone page issued GET /api/admin/org/me and got 405 because
+    only DELETE was registered. Added the GET handler to render the
+    delete-modal precondition (org slug + name).
+    """
+
+    @pytest.mark.asyncio
+    async def test_returns_slug_and_name_for_admin(self):
+        org = _make_org(slug="voys")
+        org.name = "Voys"
+        user = _make_user(role="admin")
+        db = AsyncMock()
+        creds = _make_credentials()
+
+        with _caller_org_patch(org, user):
+            result = await get_own_org(creds, db)
+
+        assert result == {"slug": "voys", "name": "Voys"}
+
+    @pytest.mark.asyncio
+    async def test_raises_403_for_non_admin(self):
+        org = _make_org(slug="voys")
+        org.name = "Voys"
+        user = _make_user(role="member")
+        db = AsyncMock()
+        creds = _make_credentials()
+
+        with _caller_org_patch(org, user):
+            with pytest.raises(HTTPException) as exc_info:
+                await get_own_org(creds, db)
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_allows_during_deprovisioning(self):
+        # The modal needs slug+name to render the polling UI even after
+        # deprovisioning has started. allow_during_deprovisioning=True is
+        # the contract — verify _get_caller_org is called with that flag.
+        org = _make_org(slug="voys", provisioning_status="deprovisioning")
+        org.name = "Voys"
+        user = _make_user(role="admin")
+        db = AsyncMock()
+        creds = _make_credentials()
+
+        with patch(
+            "app.api.admin.deprovision_org._get_caller_org",
+            AsyncMock(return_value=("zit-user-1", org, user)),
+        ) as mock_caller:
+            result = await get_own_org(creds, db)
+
+        # First positional or keyword arg lands on credentials/db, then the flag.
+        mock_caller.assert_awaited_once_with(creds, db, allow_during_deprovisioning=True)
+        assert result == {"slug": "voys", "name": "Voys"}


### PR DESCRIPTION
Discovered during 2026-05-03 e2e walkthrough: danger-zone page issued 4× `GET /api/admin/org/me` and got 405 Method Not Allowed because the only handler registered was DELETE. Adds the GET sibling. Returns minimum surface for the modal: `{slug, name}`. 3/3 tests pass locally.