### PR TITLE
fix(knowledge): aggregate items across KBs in org-wide counter

### DIFF
--- a/klai-portal/frontend/src/routes/app/knowledge/index.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/index.tsx
@@ -254,7 +254,21 @@ function KnowledgePage() {
           </h1>
           {!kbsLoading && createdKbs.length > 0 && (
             <p className="text-sm text-[var(--color-muted-foreground)]">
-              {m.knowledge_page_stat_org({ count: String(createdKbs.length) })}
+              {m.knowledge_page_stat_org({
+                // Aggregate items across every visible KB. Was passing
+                // `createdKbs.length` (the *KB count*) into a message
+                // template that says "items indexed org-wide" - produced
+                // wrong-by-orders-of-magnitude output e.g. "1 items
+                // indexed" while the Support KB alone had 3941 items.
+                // Discovered during 2026-05-03 e2e walkthrough on
+                // voys.getklai.com.
+                count: String(
+                  allKbs.reduce(
+                    (sum, kb) => sum + (statsBySlug[kb.slug]?.items ?? 0),
+                    0,
+                  ),
+                ),
+              })}
             </p>
           )}
         </div>


### PR DESCRIPTION
Discovered during 2026-05-03 e2e walkthrough on voys.getklai.com. Header showed "1 items indexed org-wide" while Support KB alone had 3941 items — the call site was passing KB count instead of item count. Sum items across all KBs from existing stats query.