### PR TITLE
feat(profiles): SPEC-PORTAL-PROFILES-001 Phase 2 — backend add-ons

### DIFF
--- a/.moai/specs/SPEC-PORTAL-PROFILES-001/spec.md
+++ b/.moai/specs/SPEC-PORTAL-PROFILES-001/spec.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-PORTAL-PROFILES-001
-version: "0.3.0"
-status: phase-1-merged
+version: "0.4.0"
+status: phase-2-in-progress
 created: 2026-05-03
 updated: 2026-05-03
 author: Mark Vletter
@@ -20,6 +20,7 @@ related:
 | 2026-05-03 | 0.1.0 | Initial draft after sparring session. Five-rung profile ladder (Personal chat → Company chat → Knowledge manager → Group manager → Admin) replaces the current `admin / group-admin / member` triplet. Plan and role decoupled: Company chat and Knowledge manager share a billing tier but differ in role. Scribe and Docs become per-tenant add-on toggles, not Plan-bound products. Knowledge access for Personal chat is hard-gated: no `default_org_role` fallback, ever. |
 | 2026-05-03 | 0.2.0 | Capability-laag versimpeld na review van Phase-1 PR. `PROFILE_CAPABILITIES` bevat alleen capabilities die op endpoints via `require_capability(...)` worden gechecked: `kb.connectors`, `kb.connectors.external`, `kb.create_org`, `kb.members`, `kb.taxonomy`, `kb.gaps`. Verwijderd: `kb.read_org`, `kb.append_via_chat`, `groups.manage`, `groups.invite_users`, `org.billing`, `org.settings` — die worden directe rol-checks via `_require_at_least` of `_require_admin`. Connector-allowlist via twee capability-gates ipv aparte rol-tabel. `effective_capabilities = role_caps ∩ plan_caps` is nu de canonieke werking. |
 | 2026-05-03 | 0.3.0 | Phase 1 merged via PR #274 (squash commit `b6397735`). Phase 1.6 cleanup-scope toegevoegd om de code "industry-standard" te maken vóór Phase 2/3: (1) Capability-strings worden typed via `Capability` Literal/StrEnum in `app/core/profiles.py` zodat pyright typos vangt. (2) `PROFILE_LADDER` wordt aangevuld met `PROFILE_RANK: dict[str,int]` voor O(1) ladder-lookups; legacy `.index()` calls worden vervangen. (3) `portal_users.role` wordt gemigreerd van `VARCHAR(20) + CHECK constraint` naar een echte Postgres `ENUM` type voor type-safety op DB-niveau. (4) Dood `require_at_least_dep` wordt verwijderd uit `dependencies.py` — de legacy helpers in `groups.py` blijven want ze hebben async system-group logica die niet in een Depends-decorator past. (5) Admin-bypass in `get_effective_capabilities` krijgt een expliciet `# @MX:NOTE` block met SPEC-referentie en de keuzeratio (admin moet upgrade-effecten kunnen testen zonder billing-wijziging). |
+| 2026-05-03 | 0.4.0 | Phase 1.6 merged via PR #277 (squash commit `0d90fa5e`). Phase 2 (backend add-ons) en Phase 3 (frontend gating) worden in twee opeenvolgende PRs uitgerold. Phase 2 levert: nieuwe kolom `portal_orgs.enabled_addons text[] NOT NULL DEFAULT '{}'`, `PATCH /api/admin/settings/addons` endpoint, `docs` als eigen product (afgesplitst van `knowledge`), `require_product` wordt twee-laags voor add-ons (tenant `enabled_addons` ∩ user/group `portal_user_products`), system-groups herinrichten (oude obsolete groups opruimen, vijf rol-bind groups + twee add-on groups registreren). Phase 3 levert: sidebar/admin gating per rol, profile-picker op user-edit, KB-tab gating per `effective_role`, add-on toggles op `/admin/settings`, `/app/docs` route gated op `docs`-product, connectors-list gefilterd voor personal/company. |
 
 ---
 

--- a/klai-portal/backend/alembic/versions/261dae89162c_system_groups_herinrichting.py
+++ b/klai-portal/backend/alembic/versions/261dae89162c_system_groups_herinrichting.py
@@ -1,0 +1,118 @@
+"""System groups herinrichting: retire legacy groups, create role-bind + add-on groups.
+
+Revision ID: 261dae89162c
+Revises: a0174b86ace3
+Create Date: 2026-05-03
+
+SPEC-PORTAL-PROFILES-001 Phase 2 P2.5.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "261dae89162c"
+down_revision = "a0174b86ace3"
+branch_labels = None
+depends_on = None
+
+_LEGACY_KEYS = ("admin", "group_management", "chat", "scribe", "knowledge")
+
+_NEW_GROUPS = [
+    {"name": "Personal chat",     "system_key": "role_personal"},
+    {"name": "Company chat",      "system_key": "role_company"},
+    {"name": "Knowledge manager", "system_key": "role_kb_manager"},
+    {"name": "Group manager",     "system_key": "role_group_manager"},
+    {"name": "Admin",             "system_key": "role_admin"},
+    {"name": "Scribe users",      "system_key": "addon_scribe"},
+    {"name": "Docs users",        "system_key": "addon_docs"},
+]
+
+_ADDON_PRODUCTS = {
+    "addon_scribe": "scribe",
+    "addon_docs": "docs",
+}
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    legacy_ids_result = conn.execute(
+        sa.text("SELECT id FROM portal_groups WHERE is_system = true AND system_key = ANY(:keys)"),
+        {"keys": list(_LEGACY_KEYS)},
+    )
+    legacy_ids = [row[0] for row in legacy_ids_result.fetchall()]
+
+    if legacy_ids:
+        conn.execute(
+            sa.text("DELETE FROM portal_group_products WHERE group_id = ANY(:ids)"),
+            {"ids": legacy_ids},
+        )
+        conn.execute(
+            sa.text("DELETE FROM portal_group_memberships WHERE group_id = ANY(:ids)"),
+            {"ids": legacy_ids},
+        )
+        conn.execute(
+            sa.text("DELETE FROM portal_groups WHERE id = ANY(:ids)"),
+            {"ids": legacy_ids},
+        )
+
+    orgs_result = conn.execute(sa.text("SELECT id FROM portal_orgs"))
+    org_ids = [row[0] for row in orgs_result.fetchall()]
+
+    for org_id in org_ids:
+        for sg in _NEW_GROUPS:
+            existing = conn.execute(
+                sa.text(
+                    "SELECT id FROM portal_groups"
+                    " WHERE org_id = :org_id AND system_key = :key AND is_system = true"
+                ),
+                {"org_id": org_id, "key": sg["system_key"]},
+            ).fetchone()
+
+            if existing:
+                group_id = existing[0]
+            else:
+                result = conn.execute(
+                    sa.text(
+                        "INSERT INTO portal_groups (org_id, name, is_system, system_key, created_by)"
+                        " VALUES (:org_id, :name, true, :key, 'migration') RETURNING id"
+                    ),
+                    {"org_id": org_id, "name": sg["name"], "key": sg["system_key"]},
+                )
+                group_id = result.fetchone()[0]
+
+            product = _ADDON_PRODUCTS.get(sg["system_key"])
+            if product:
+                conn.execute(
+                    sa.text(
+                        "INSERT INTO portal_group_products (group_id, org_id, product, enabled_by)"
+                        " VALUES (:gid, :oid, :product, 'migration')"
+                        " ON CONFLICT DO NOTHING"
+                    ),
+                    {"gid": group_id, "oid": org_id, "product": product},
+                )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    new_keys = [sg["system_key"] for sg in _NEW_GROUPS]
+    new_ids_result = conn.execute(
+        sa.text("SELECT id FROM portal_groups WHERE is_system = true AND system_key = ANY(:keys)"),
+        {"keys": new_keys},
+    )
+    new_ids = [row[0] for row in new_ids_result.fetchall()]
+
+    if new_ids:
+        conn.execute(
+            sa.text("DELETE FROM portal_group_products WHERE group_id = ANY(:ids)"),
+            {"ids": new_ids},
+        )
+        conn.execute(
+            sa.text("DELETE FROM portal_group_memberships WHERE group_id = ANY(:ids)"),
+            {"ids": new_ids},
+        )
+        conn.execute(
+            sa.text("DELETE FROM portal_groups WHERE id = ANY(:ids)"),
+            {"ids": new_ids},
+        )

--- a/klai-portal/backend/alembic/versions/261dae89162c_system_groups_herinrichting.py
+++ b/klai-portal/backend/alembic/versions/261dae89162c_system_groups_herinrichting.py
@@ -18,13 +18,13 @@ depends_on = None
 _LEGACY_KEYS = ("admin", "group_management", "chat", "scribe", "knowledge")
 
 _NEW_GROUPS = [
-    {"name": "Personal chat",     "system_key": "role_personal"},
-    {"name": "Company chat",      "system_key": "role_company"},
+    {"name": "Personal chat", "system_key": "role_personal"},
+    {"name": "Company chat", "system_key": "role_company"},
     {"name": "Knowledge manager", "system_key": "role_kb_manager"},
-    {"name": "Group manager",     "system_key": "role_group_manager"},
-    {"name": "Admin",             "system_key": "role_admin"},
-    {"name": "Scribe users",      "system_key": "addon_scribe"},
-    {"name": "Docs users",        "system_key": "addon_docs"},
+    {"name": "Group manager", "system_key": "role_group_manager"},
+    {"name": "Admin", "system_key": "role_admin"},
+    {"name": "Scribe users", "system_key": "addon_scribe"},
+    {"name": "Docs users", "system_key": "addon_docs"},
 ]
 
 _ADDON_PRODUCTS = {
@@ -63,8 +63,7 @@ def upgrade() -> None:
         for sg in _NEW_GROUPS:
             existing = conn.execute(
                 sa.text(
-                    "SELECT id FROM portal_groups"
-                    " WHERE org_id = :org_id AND system_key = :key AND is_system = true"
+                    "SELECT id FROM portal_groups WHERE org_id = :org_id AND system_key = :key AND is_system = true"
                 ),
                 {"org_id": org_id, "key": sg["system_key"]},
             ).fetchone()

--- a/klai-portal/backend/alembic/versions/a0174b86ace3_add_enabled_addons_to_portal_orgs.py
+++ b/klai-portal/backend/alembic/versions/a0174b86ace3_add_enabled_addons_to_portal_orgs.py
@@ -1,0 +1,36 @@
+"""Add portal_orgs.enabled_addons column.
+
+Revision ID: a0174b86ace3
+Revises: 59fff72b480b
+Create Date: 2026-05-03
+
+SPEC-PORTAL-PROFILES-001 Phase 2 P2.1.
+
+Adds `enabled_addons text[] NOT NULL DEFAULT '{}'` to portal_orgs.
+This column stores the tenant-level add-on toggles (scribe, docs).
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import ARRAY
+
+revision = "a0174b86ace3"
+down_revision = "59fff72b480b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "portal_orgs",
+        sa.Column(
+            "enabled_addons",
+            ARRAY(sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::text[]"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("portal_orgs", "enabled_addons")

--- a/klai-portal/backend/app/api/admin/settings.py
+++ b/klai-portal/backend/app/api/admin/settings.py
@@ -10,9 +10,11 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import get_db
-from app.core.plans import PLAN_PRODUCTS, get_plan_products
+from app.core.plans import ADDON_PRODUCTS, PLAN_PRODUCTS, get_plan_products
 from app.models.groups import PortalGroupProduct
 from app.models.products import PortalUserProduct
+from app.services.audit import log_event
+from app.services.events import emit_event
 
 from . import _get_caller_org, _require_admin, bearer
 
@@ -129,3 +131,79 @@ async def change_plan(
 
     await db.commit()
     return MessageResponse(message=f"Plan bijgewerkt naar {new_plan}.")
+
+
+# ---------------------------------------------------------------------------
+# Add-on toggle endpoints (SPEC-PORTAL-PROFILES-001 Phase 2 P2.4)
+# ---------------------------------------------------------------------------
+
+
+class AddonsOut(BaseModel):
+    enabled_addons: list[str]
+
+
+class AddonsUpdate(BaseModel):
+    enabled_addons: list[str]
+
+
+@router.get("/settings/addons", response_model=AddonsOut)
+async def get_addons(
+    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    db: AsyncSession = Depends(get_db),
+) -> AddonsOut:
+    """Return the tenant's currently enabled add-ons."""
+    _, org, caller_user = await _get_caller_org(credentials, db)
+    _require_admin(caller_user)
+    return AddonsOut(enabled_addons=list(org.enabled_addons or []))
+
+
+@router.patch("/settings/addons", response_model=AddonsOut)
+async def update_addons(
+    body: AddonsUpdate,
+    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    db: AsyncSession = Depends(get_db),
+) -> AddonsOut:
+    """Enable or disable tenant-level add-ons.
+
+    # @MX:NOTE: SPEC-PORTAL-PROFILES-001 Phase 2 P2.4 — only values in
+    # ADDON_PRODUCTS are accepted. Unknown values raise 400. Disabling an
+    # add-on does NOT remove user/group entitlements — they become dormant
+    # and re-activate when the toggle is turned back on. This is intentional:
+    # preserves manual entitlement work done by the admin.
+    """
+    admin_user_id, org, caller_user = await _get_caller_org(credentials, db)
+    _require_admin(caller_user)
+
+    unknown = [p for p in body.enabled_addons if p not in ADDON_PRODUCTS]
+    if unknown:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unknown add-on product(s): {unknown}. Valid: {sorted(ADDON_PRODUCTS)}",
+        )
+
+    before = list(org.enabled_addons or [])
+    after = list(body.enabled_addons)
+
+    org.enabled_addons = after
+
+    added = sorted(set(after) - set(before))
+    removed = sorted(set(before) - set(after))
+
+    await log_event(
+        org_id=org.id,
+        actor=admin_user_id,
+        action="addons.updated",
+        resource_type="org",
+        resource_id=str(org.id),
+        details={"before": before, "after": after, "added": added, "removed": removed},
+    )
+    await db.commit()
+
+    emit_event(
+        "tenant.addons_updated",
+        org_id=org.id,
+        user_id=admin_user_id,
+        properties={"enabled_addons": after, "added": added, "removed": removed},
+    )
+
+    return AddonsOut(enabled_addons=after)

--- a/klai-portal/backend/app/api/dependencies.py
+++ b/klai-portal/backend/app/api/dependencies.py
@@ -10,6 +10,7 @@ from app.api.auth import get_current_user_id
 from app.api.bearer import bearer as bearer  # re-export for routes that import from here
 from app.core.database import get_db, set_tenant
 from app.core.plan_limits import PLAN_LIMITS, get_plan_limits
+from app.core.plans import ADDON_PRODUCTS
 from app.core.profiles import (
     PROFILE_CAPABILITIES,
     PROFILE_RANK,
@@ -24,22 +25,68 @@ from app.services.zitadel import zitadel
 def require_product(product: str):
     """Return a FastAPI dependency callable that raises 403 if user lacks the product.
 
-    Org admins bypass the check and always have access to all products.
+    SPEC-PORTAL-PROFILES-001 Phase 2 P2.3: Two-layer gate for add-on products.
+
+    For products in ADDON_PRODUCTS (scribe, docs):
+      Layer 1: tenant must have enabled the add-on (portal_orgs.enabled_addons).
+      Layer 2: user must have the product entitlement (portal_user_products /
+               portal_group_products via get_effective_products).
+
+    For non-add-on products: only layer 2 applies (unchanged behaviour).
+
+    # @MX:NOTE: admin role bypasses LAYER 2 (user entitlement) but NOT layer 1
+    # (tenant enable). Rationale: if scribe/docs is not enabled for the tenant,
+    # even admin cannot use it — the feature is simply not provisioned. Admin
+    # can enable it first via PATCH /api/admin/settings/addons, then access it.
     """
 
     async def dependency(
         user_id: str = Depends(get_current_user_id),
         db: AsyncSession = Depends(get_db),
     ) -> None:
-        role_result = await db.execute(select(PortalUser.role).where(PortalUser.zitadel_user_id == user_id))
-        if role_result.scalar_one_or_none() == "admin":
-            return
-        products = await get_effective_products(user_id, db)
-        if product not in products:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail=f"Product access required: {product}",
+        # Resolve user + org in one query for add-on products; fall back to
+        # user-only query for non-add-on products to keep the common path fast.
+        if product in ADDON_PRODUCTS:
+            result = await db.execute(
+                select(PortalUser, PortalOrg)
+                .join(PortalOrg, PortalOrg.id == PortalUser.org_id)
+                .where(PortalUser.zitadel_user_id == user_id)
             )
+            row = result.one_or_none()
+            if row is None:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="User not found",
+                )
+            user, org = row
+
+            # Layer 1: tenant-level enable (applies to ALL callers including admin)
+            if product not in (org.enabled_addons or []):
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail=f"Add-on not enabled for tenant: {product}",
+                )
+
+            # Layer 2: user-level entitlement (admin bypass applies here only)
+            if user.role == "admin":
+                return
+            products = await get_effective_products(user_id, db)
+            if product not in products:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail=f"Product access required: {product}",
+                )
+        else:
+            # Non-add-on products: original single-layer check
+            role_result = await db.execute(select(PortalUser.role).where(PortalUser.zitadel_user_id == user_id))
+            if role_result.scalar_one_or_none() == "admin":
+                return
+            products = await get_effective_products(user_id, db)
+            if product not in products:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail=f"Product access required: {product}",
+                )
 
     return dependency
 

--- a/klai-portal/backend/app/api/groups.py
+++ b/klai-portal/backend/app/api/groups.py
@@ -26,6 +26,7 @@ from app.core.system_groups import SYSTEM_GROUPS
 from app.models.groups import PortalGroup, PortalGroupMembership, PortalGroupProduct
 from app.models.portal import PortalUser
 from app.services.audit import log_event
+from app.services.system_groups import sync_role_from_system_group
 
 logger = logging.getLogger(__name__)
 
@@ -393,6 +394,11 @@ async def add_member(
             status_code=status.HTTP_409_CONFLICT,
             detail="User is already a member of this group",
         ) from exc
+
+    # @MX:NOTE: SPEC-PORTAL-PROFILES-001 Phase 2 P2.5 — if this is a role-bind
+    # system-group, update the user's role to match the group's binding.
+    # sync_role_from_system_group is a no-op for non-system or non-role groups.
+    await sync_role_from_system_group(body.zitadel_user_id, group_id, db)
 
     await log_event(
         org_id=group.org_id,

--- a/klai-portal/backend/app/core/plans.py
+++ b/klai-portal/backend/app/core/plans.py
@@ -1,10 +1,25 @@
-"""Plan-to-product mapping for Klai subscription tiers."""
+"""Plan-to-product mapping for Klai subscription tiers.
+
+SPEC-PORTAL-PROFILES-001 Phase 2 P2.2:
+- ADDON_PRODUCTS: products that require explicit tenant-level enablement via
+  portal_orgs.enabled_addons AND per-user/group entitlement. Not auto-granted
+  by plan. Admin must toggle on via PATCH /api/admin/settings/addons.
+- PLAN_PRODUCTS: products included with the plan (no add-on toggle needed).
+  scribe and docs were moved out of plan products into ADDON_PRODUCTS.
+"""
+
+# @MX:NOTE: SPEC-PORTAL-PROFILES-001 Phase 2 — add-on products require
+# BOTH tenant-level enable (portal_orgs.enabled_addons) AND user/group
+# entitlement (portal_user_products / portal_group_products). Two-layer gate.
+ADDON_PRODUCTS: frozenset[str] = frozenset({"scribe", "docs"})
 
 PLAN_PRODUCTS: dict[str, list[str]] = {
     "free": [],
     "core": ["chat", "knowledge"],
-    "professional": ["chat", "scribe", "knowledge"],
-    "complete": ["chat", "scribe", "knowledge"],
+    # scribe and docs are add-ons — not auto-included in any plan.
+    # Tenant admin enables them via PATCH /api/admin/settings/addons.
+    "professional": ["chat", "knowledge"],
+    "complete": ["chat", "knowledge"],
 }
 
 

--- a/klai-portal/backend/app/core/system_groups.py
+++ b/klai-portal/backend/app/core/system_groups.py
@@ -1,4 +1,21 @@
-"""System group definitions and creation helper."""
+"""System group definitions and creation helper.
+
+SPEC-PORTAL-PROFILES-001 Phase 2 P2.5: System-groups herinrichting.
+
+Two categories of system groups:
+
+1. Role-bind groups (system_key prefix: "role_"):
+   Membership in these groups sets portal_users.role to the corresponding
+   role value. Wired in add_member (app/api/groups.py) via
+   sync_role_from_system_group().
+
+2. Add-on groups (system_key prefix: "addon_"):
+   Membership grants the named add-on product via portal_group_products.
+   No separate role logic — relies on the existing entitlement mechanism.
+
+Legacy groups (Chat+Focus, +Scribe, +Knowledge+Docs, old Admin, Group Management)
+are migrated away in the a2b3c4d5e6f8 alembic migration.
+"""
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -6,19 +23,33 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.database import set_tenant
 from app.models.groups import PortalGroup, PortalGroupProduct
 
-# Five system groups every org gets, regardless of plan.
-# system_key identifies purpose; products are granted by the group.
-SYSTEM_GROUPS = [
-    {"name": "Admin", "system_key": "admin", "products": []},
-    {"name": "Group Management", "system_key": "group_management", "products": []},
-    {"name": "Chat", "system_key": "chat", "products": ["chat"]},
-    {"name": "+ Scribe", "system_key": "scribe", "products": ["chat", "scribe"]},
-    {"name": "+ Knowledge + Docs", "system_key": "knowledge", "products": ["chat", "scribe", "knowledge"]},
+# ---------------------------------------------------------------------------
+# System group registry
+# ---------------------------------------------------------------------------
+
+# @MX:NOTE: SPEC-PORTAL-PROFILES-001 Phase 2 P2.5 — role-bind groups
+# (role_*) set portal_users.role on membership-add. Add-on groups (addon_*)
+# grant a product via portal_group_products (existing entitlement mechanism).
+SYSTEM_GROUPS: list[dict] = [
+    # Role-bind groups — membership triggers role sync via sync_role_from_system_group()
+    {"name": "Personal chat", "system_key": "role_personal", "products": [], "role": "personal"},
+    {"name": "Company chat", "system_key": "role_company", "products": [], "role": "company"},
+    {"name": "Knowledge manager", "system_key": "role_kb_manager", "products": [], "role": "kb_manager"},
+    {"name": "Group manager", "system_key": "role_group_manager", "products": [], "role": "group_manager"},
+    {"name": "Admin", "system_key": "role_admin", "products": [], "role": "admin"},
+    # Add-on groups — membership grants a product via portal_group_products
+    {"name": "Scribe users", "system_key": "addon_scribe", "products": ["scribe"], "role": None},
+    {"name": "Docs users", "system_key": "addon_docs", "products": ["docs"], "role": None},
 ]
+
+# Fast lookup: system_key -> role value (for role-bind groups only)
+SYSTEM_GROUP_ROLE_MAP: dict[str, str] = {
+    sg["system_key"]: sg["role"] for sg in SYSTEM_GROUPS if sg.get("role") is not None
+}
 
 
 async def create_system_groups(org_id: int, db: AsyncSession) -> None:
-    """Create all 5 system groups for an org. Idempotent — skips existing ones.
+    """Create all system groups for an org. Idempotent — skips existing ones.
 
     Requires a pinned DB connection on the session (caller must have awaited
     pin_session() or session.connection()); otherwise set_tenant() below may

--- a/klai-portal/backend/app/models/portal.py
+++ b/klai-portal/backend/app/models/portal.py
@@ -70,6 +70,16 @@ class PortalOrg(Base):
     )
     connector_dek_enc: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
     mcp_servers: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    # @MX:NOTE: SPEC-PORTAL-PROFILES-001 Phase 2 P2.1 — per-tenant add-on toggles.
+    # Stores which add-on products (scribe, docs) the admin has enabled for this org.
+    # A user/group still needs an entitlement in portal_user_products / portal_group_products;
+    # access = enabled_addons AND user/group entitlement (both required).
+    enabled_addons: Mapped[list[str]] = mapped_column(
+        ARRAY(Text()),
+        nullable=False,
+        default=list,
+        server_default="{}",
+    )
 
     users: Mapped[list["PortalUser"]] = relationship(back_populates="org")
 

--- a/klai-portal/backend/app/services/system_groups.py
+++ b/klai-portal/backend/app/services/system_groups.py
@@ -1,0 +1,64 @@
+"""Service functions for system-group side-effects.
+
+SPEC-PORTAL-PROFILES-001 Phase 2 P2.5.
+
+When a user is added to a role-bind system-group (system_key prefix "role_"),
+their portal_users.role is updated to match the group's role binding.
+
+Add-on system-groups (system_key prefix "addon_") grant products via
+portal_group_products (existing entitlement mechanism) — no extra logic here.
+"""
+
+import structlog
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.system_groups import SYSTEM_GROUP_ROLE_MAP
+from app.models.groups import PortalGroup
+from app.models.portal import PortalUser
+
+logger = structlog.get_logger()
+
+
+async def sync_role_from_system_group(
+    zitadel_user_id: str,
+    group_id: int,
+    db: AsyncSession,
+) -> str | None:
+    """Update portal_users.role when user joins a role-bind system-group.
+
+    # @MX:NOTE: SPEC-PORTAL-PROFILES-001 Phase 2 P2.5 — NEW behaviour.
+    # Previously, system-groups only granted products. Now role-bind groups
+    # (system_key prefix "role_") also update portal_users.role on membership-add.
+    # This is the single authoritative path for role updates via group membership.
+    # Direct role changes still go through PATCH /api/admin/users/{id}/role.
+
+    Returns the new role string if a role was set, None otherwise.
+    """
+    # Load group and check it's a role-bind system group
+    group_result = await db.execute(select(PortalGroup).where(PortalGroup.id == group_id))
+    group = group_result.scalar_one_or_none()
+    if group is None or not group.is_system:
+        return None
+
+    role = SYSTEM_GROUP_ROLE_MAP.get(group.system_key or "")
+    if role is None:
+        return None
+
+    # Update the user's role
+    result = await db.execute(
+        update(PortalUser)
+        .where(PortalUser.zitadel_user_id == zitadel_user_id)
+        .values(role=role)
+        .returning(PortalUser.id)
+    )
+    updated = result.fetchone()
+    if updated:
+        logger.info(
+            "system_group.role_synced",
+            group_id=group_id,
+            system_key=group.system_key,
+            role=role,
+            user_id=zitadel_user_id,
+        )
+    return role

--- a/klai-portal/backend/tests/test_addon_gating.py
+++ b/klai-portal/backend/tests/test_addon_gating.py
@@ -1,0 +1,121 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+import pytest
+from fastapi import HTTPException
+
+
+def _make_org(enabled_addons=None):
+    org = MagicMock()
+    org.id = 1
+    org.enabled_addons = enabled_addons or []
+    return org
+
+def _make_user(role="company"):
+    user = MagicMock()
+    user.role = role
+    return user
+
+def _make_db_one_or_none(user, org):
+    db = AsyncMock()
+    row_result = MagicMock()
+    row_result.one_or_none.return_value = (user, org)
+    db.execute.return_value = row_result
+    return db
+
+
+class TestTenantAddOnGating:
+    @pytest.mark.asyncio
+    async def test_scribe_denied_when_tenant_not_enabled(self) -> None:
+        from app.api.dependencies import require_product
+        user = _make_user()
+        org = _make_org(enabled_addons=[])
+        db = _make_db_one_or_none(user, org)
+        dep = require_product("scribe")
+        with (
+            patch("app.api.dependencies.get_current_user_id", return_value="user-1"),
+            patch("app.api.dependencies.get_effective_products", return_value=["chat", "scribe"]),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await dep(user_id="user-1", db=db)
+        assert exc_info.value.status_code == 403
+        assert "not enabled for tenant" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_scribe_denied_when_user_lacks_entitlement(self) -> None:
+        from app.api.dependencies import require_product
+        user = _make_user()
+        org = _make_org(enabled_addons=["scribe"])
+        db = _make_db_one_or_none(user, org)
+        dep = require_product("scribe")
+        with (
+            patch("app.api.dependencies.get_current_user_id", return_value="user-1"),
+            patch("app.api.dependencies.get_effective_products", return_value=["chat"]),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await dep(user_id="user-1", db=db)
+        assert exc_info.value.status_code == 403
+        assert "Product access required" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_scribe_allowed_when_both_layers_pass(self) -> None:
+        from app.api.dependencies import require_product
+        user = _make_user()
+        org = _make_org(enabled_addons=["scribe"])
+        db = _make_db_one_or_none(user, org)
+        dep = require_product("scribe")
+        with (
+            patch("app.api.dependencies.get_current_user_id", return_value="user-1"),
+            patch("app.api.dependencies.get_effective_products", return_value=["chat", "scribe"]),
+        ):
+            await dep(user_id="user-1", db=db)
+
+    @pytest.mark.asyncio
+    async def test_admin_blocked_by_tenant_level_disable(self) -> None:
+        from app.api.dependencies import require_product
+        user = _make_user(role="admin")
+        org = _make_org(enabled_addons=[])
+        db = _make_db_one_or_none(user, org)
+        dep = require_product("scribe")
+        with patch("app.api.dependencies.get_current_user_id", return_value="admin-1"):
+            with pytest.raises(HTTPException) as exc_info:
+                await dep(user_id="admin-1", db=db)
+        assert exc_info.value.status_code == 403
+        assert "not enabled for tenant" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_admin_passes_when_tenant_enabled(self) -> None:
+        from app.api.dependencies import require_product
+        user = _make_user(role="admin")
+        org = _make_org(enabled_addons=["scribe"])
+        db = _make_db_one_or_none(user, org)
+        dep = require_product("scribe")
+        with patch("app.api.dependencies.get_current_user_id", return_value="admin-1"):
+            await dep(user_id="admin-1", db=db)
+
+    @pytest.mark.asyncio
+    async def test_non_addon_uses_single_layer(self) -> None:
+        from app.api.dependencies import require_product
+        db = AsyncMock()
+        role_result = MagicMock()
+        role_result.scalar_one_or_none.return_value = "company"
+        db.execute.return_value = role_result
+        dep = require_product("chat")
+        with (
+            patch("app.api.dependencies.get_current_user_id", return_value="user-1"),
+            patch("app.api.dependencies.get_effective_products", return_value=["chat"]),
+        ):
+            await dep(user_id="user-1", db=db)
+
+    @pytest.mark.asyncio
+    async def test_docs_addon_blocked_by_tenant_disable(self) -> None:
+        from app.api.dependencies import require_product
+        user = _make_user()
+        org = _make_org(enabled_addons=[])
+        db = _make_db_one_or_none(user, org)
+        dep = require_product("docs")
+        with (
+            patch("app.api.dependencies.get_current_user_id", return_value="user-1"),
+            patch("app.api.dependencies.get_effective_products", return_value=["chat", "docs"]),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await dep(user_id="user-1", db=db)
+        assert exc_info.value.status_code == 403

--- a/klai-portal/backend/tests/test_addon_gating.py
+++ b/klai-portal/backend/tests/test_addon_gating.py
@@ -1,4 +1,5 @@
 from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 from fastapi import HTTPException
 
@@ -9,10 +10,12 @@ def _make_org(enabled_addons=None):
     org.enabled_addons = enabled_addons or []
     return org
 
+
 def _make_user(role="company"):
     user = MagicMock()
     user.role = role
     return user
+
 
 def _make_db_one_or_none(user, org):
     db = AsyncMock()
@@ -26,6 +29,7 @@ class TestTenantAddOnGating:
     @pytest.mark.asyncio
     async def test_scribe_denied_when_tenant_not_enabled(self) -> None:
         from app.api.dependencies import require_product
+
         user = _make_user()
         org = _make_org(enabled_addons=[])
         db = _make_db_one_or_none(user, org)
@@ -42,6 +46,7 @@ class TestTenantAddOnGating:
     @pytest.mark.asyncio
     async def test_scribe_denied_when_user_lacks_entitlement(self) -> None:
         from app.api.dependencies import require_product
+
         user = _make_user()
         org = _make_org(enabled_addons=["scribe"])
         db = _make_db_one_or_none(user, org)
@@ -58,6 +63,7 @@ class TestTenantAddOnGating:
     @pytest.mark.asyncio
     async def test_scribe_allowed_when_both_layers_pass(self) -> None:
         from app.api.dependencies import require_product
+
         user = _make_user()
         org = _make_org(enabled_addons=["scribe"])
         db = _make_db_one_or_none(user, org)
@@ -71,6 +77,7 @@ class TestTenantAddOnGating:
     @pytest.mark.asyncio
     async def test_admin_blocked_by_tenant_level_disable(self) -> None:
         from app.api.dependencies import require_product
+
         user = _make_user(role="admin")
         org = _make_org(enabled_addons=[])
         db = _make_db_one_or_none(user, org)
@@ -84,6 +91,7 @@ class TestTenantAddOnGating:
     @pytest.mark.asyncio
     async def test_admin_passes_when_tenant_enabled(self) -> None:
         from app.api.dependencies import require_product
+
         user = _make_user(role="admin")
         org = _make_org(enabled_addons=["scribe"])
         db = _make_db_one_or_none(user, org)
@@ -94,6 +102,7 @@ class TestTenantAddOnGating:
     @pytest.mark.asyncio
     async def test_non_addon_uses_single_layer(self) -> None:
         from app.api.dependencies import require_product
+
         db = AsyncMock()
         role_result = MagicMock()
         role_result.scalar_one_or_none.return_value = "company"
@@ -108,6 +117,7 @@ class TestTenantAddOnGating:
     @pytest.mark.asyncio
     async def test_docs_addon_blocked_by_tenant_disable(self) -> None:
         from app.api.dependencies import require_product
+
         user = _make_user()
         org = _make_org(enabled_addons=[])
         db = _make_db_one_or_none(user, org)

--- a/klai-portal/backend/tests/test_admin_addons.py
+++ b/klai-portal/backend/tests/test_admin_addons.py
@@ -1,0 +1,119 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+import pytest
+from fastapi import HTTPException
+
+
+def _mock_org(enabled_addons=None):
+    org = MagicMock()
+    org.id = 42
+    org.enabled_addons = enabled_addons or []
+    return org
+
+def _mock_caller(role="admin"):
+    caller = MagicMock()
+    caller.role = role
+    return caller
+
+
+class TestGetAddons:
+    @pytest.mark.asyncio
+    async def test_returns_current_state(self) -> None:
+        from app.api.admin.settings import get_addons
+        org = _mock_org(enabled_addons=["scribe"])
+        caller = _mock_caller()
+        mock_db = AsyncMock()
+        mock_creds = MagicMock()
+        with patch("app.api.admin.settings._get_caller_org", return_value=("admin-1", org, caller)):
+            result = await get_addons(credentials=mock_creds, db=mock_db)
+        assert result.enabled_addons == ["scribe"]
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_by_default(self) -> None:
+        from app.api.admin.settings import get_addons
+        org = _mock_org(enabled_addons=[])
+        caller = _mock_caller()
+        mock_db = AsyncMock()
+        mock_creds = MagicMock()
+        with patch("app.api.admin.settings._get_caller_org", return_value=("admin-1", org, caller)):
+            result = await get_addons(credentials=mock_creds, db=mock_db)
+        assert result.enabled_addons == []
+
+
+class TestUpdateAddons:
+    @pytest.mark.asyncio
+    async def test_patch_valid_addon_updates_org(self) -> None:
+        from app.api.admin.settings import AddonsUpdate, update_addons
+        org = _mock_org(enabled_addons=[])
+        caller = _mock_caller()
+        mock_db = AsyncMock()
+        mock_creds = MagicMock()
+        body = AddonsUpdate(enabled_addons=["scribe"])
+        with (
+            patch("app.api.admin.settings._get_caller_org", return_value=("admin-1", org, caller)),
+            patch("app.api.admin.settings.log_event", new=AsyncMock()),
+            patch("app.api.admin.settings.emit_event") as mock_emit,
+        ):
+            result = await update_addons(body=body, credentials=mock_creds, db=mock_db)
+        assert result.enabled_addons == ["scribe"]
+        assert org.enabled_addons == ["scribe"]
+        mock_db.commit.assert_called_once()
+        assert mock_emit.call_args.args[0] == "tenant.addons_updated"
+
+    @pytest.mark.asyncio
+    async def test_patch_unknown_addon_returns_400(self) -> None:
+        from app.api.admin.settings import AddonsUpdate, update_addons
+        org = _mock_org()
+        caller = _mock_caller()
+        mock_db = AsyncMock()
+        mock_creds = MagicMock()
+        body = AddonsUpdate(enabled_addons=["hacker_product"])
+        with patch("app.api.admin.settings._get_caller_org", return_value=("admin-1", org, caller)):
+            with pytest.raises(HTTPException) as exc_info:
+                await update_addons(body=body, credentials=mock_creds, db=mock_db)
+        assert exc_info.value.status_code == 400
+        assert "hacker_product" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_patch_both_addons(self) -> None:
+        from app.api.admin.settings import AddonsUpdate, update_addons
+        org = _mock_org()
+        caller = _mock_caller()
+        mock_db = AsyncMock()
+        mock_creds = MagicMock()
+        body = AddonsUpdate(enabled_addons=["scribe", "docs"])
+        with (
+            patch("app.api.admin.settings._get_caller_org", return_value=("admin-1", org, caller)),
+            patch("app.api.admin.settings.log_event", new=AsyncMock()),
+            patch("app.api.admin.settings.emit_event"),
+        ):
+            result = await update_addons(body=body, credentials=mock_creds, db=mock_db)
+        assert set(result.enabled_addons) == {"scribe", "docs"}
+
+    @pytest.mark.asyncio
+    async def test_patch_empty_disables_all(self) -> None:
+        from app.api.admin.settings import AddonsUpdate, update_addons
+        org = _mock_org(enabled_addons=["scribe"])
+        caller = _mock_caller()
+        mock_db = AsyncMock()
+        mock_creds = MagicMock()
+        body = AddonsUpdate(enabled_addons=[])
+        with (
+            patch("app.api.admin.settings._get_caller_org", return_value=("admin-1", org, caller)),
+            patch("app.api.admin.settings.log_event", new=AsyncMock()),
+            patch("app.api.admin.settings.emit_event"),
+        ):
+            result = await update_addons(body=body, credentials=mock_creds, db=mock_db)
+        assert result.enabled_addons == []
+
+    @pytest.mark.asyncio
+    async def test_non_admin_rejected(self) -> None:
+        from app.api.admin.settings import AddonsUpdate, update_addons
+        org = _mock_org()
+        caller = _mock_caller(role="company")
+        mock_db = AsyncMock()
+        mock_creds = MagicMock()
+        body = AddonsUpdate(enabled_addons=["scribe"])
+        with patch("app.api.admin.settings._get_caller_org", return_value=("user-1", org, caller)):
+            with pytest.raises(HTTPException) as exc_info:
+                await update_addons(body=body, credentials=mock_creds, db=mock_db)
+        assert exc_info.value.status_code == 403

--- a/klai-portal/backend/tests/test_admin_addons.py
+++ b/klai-portal/backend/tests/test_admin_addons.py
@@ -1,4 +1,5 @@
 from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 from fastapi import HTTPException
 
@@ -8,6 +9,7 @@ def _mock_org(enabled_addons=None):
     org.id = 42
     org.enabled_addons = enabled_addons or []
     return org
+
 
 def _mock_caller(role="admin"):
     caller = MagicMock()
@@ -19,6 +21,7 @@ class TestGetAddons:
     @pytest.mark.asyncio
     async def test_returns_current_state(self) -> None:
         from app.api.admin.settings import get_addons
+
         org = _mock_org(enabled_addons=["scribe"])
         caller = _mock_caller()
         mock_db = AsyncMock()
@@ -30,6 +33,7 @@ class TestGetAddons:
     @pytest.mark.asyncio
     async def test_returns_empty_list_by_default(self) -> None:
         from app.api.admin.settings import get_addons
+
         org = _mock_org(enabled_addons=[])
         caller = _mock_caller()
         mock_db = AsyncMock()
@@ -43,6 +47,7 @@ class TestUpdateAddons:
     @pytest.mark.asyncio
     async def test_patch_valid_addon_updates_org(self) -> None:
         from app.api.admin.settings import AddonsUpdate, update_addons
+
         org = _mock_org(enabled_addons=[])
         caller = _mock_caller()
         mock_db = AsyncMock()
@@ -62,6 +67,7 @@ class TestUpdateAddons:
     @pytest.mark.asyncio
     async def test_patch_unknown_addon_returns_400(self) -> None:
         from app.api.admin.settings import AddonsUpdate, update_addons
+
         org = _mock_org()
         caller = _mock_caller()
         mock_db = AsyncMock()
@@ -76,6 +82,7 @@ class TestUpdateAddons:
     @pytest.mark.asyncio
     async def test_patch_both_addons(self) -> None:
         from app.api.admin.settings import AddonsUpdate, update_addons
+
         org = _mock_org()
         caller = _mock_caller()
         mock_db = AsyncMock()
@@ -92,6 +99,7 @@ class TestUpdateAddons:
     @pytest.mark.asyncio
     async def test_patch_empty_disables_all(self) -> None:
         from app.api.admin.settings import AddonsUpdate, update_addons
+
         org = _mock_org(enabled_addons=["scribe"])
         caller = _mock_caller()
         mock_db = AsyncMock()
@@ -108,6 +116,7 @@ class TestUpdateAddons:
     @pytest.mark.asyncio
     async def test_non_admin_rejected(self) -> None:
         from app.api.admin.settings import AddonsUpdate, update_addons
+
         org = _mock_org()
         caller = _mock_caller(role="company")
         mock_db = AsyncMock()

--- a/klai-portal/backend/tests/test_groups.py
+++ b/klai-portal/backend/tests/test_groups.py
@@ -214,6 +214,7 @@ class TestAddMember:
         with (
             patch("app.api.groups._get_caller_org", return_value=("caller-1", org, caller)),
             patch("app.api.groups._require_admin_or_group_admin", new_callable=AsyncMock),
+            patch("app.api.groups.sync_role_from_system_group", new_callable=AsyncMock),
         ):
             result = await add_member(group_id=10, body=body, credentials=mock_credentials, db=mock_db)
 

--- a/klai-portal/backend/tests/test_plan_limits.py
+++ b/klai-portal/backend/tests/test_plan_limits.py
@@ -32,15 +32,15 @@ class TestPlanProductsKnowledgeAdded:
         products = set(get_plan_products("core"))
         assert products == {"chat", "knowledge"}
 
-    def test_professional_plan_products_include_scribe(self) -> None:
-        """Professional plan: chat + scribe + knowledge."""
+    def test_professional_plan_products_are_chat_and_knowledge(self) -> None:
+        """SPEC-PORTAL-PROFILES-001 P2.2: professional no longer includes scribe (add-on)."""
         products = set(get_plan_products("professional"))
-        assert products == {"chat", "scribe", "knowledge"}
+        assert products == {"chat", "knowledge"}
 
-    def test_complete_plan_products_include_scribe(self) -> None:
-        """Complete plan: chat + scribe + knowledge."""
+    def test_complete_plan_products_are_chat_and_knowledge(self) -> None:
+        """SPEC-PORTAL-PROFILES-001 P2.2: complete no longer includes scribe (add-on)."""
         products = set(get_plan_products("complete"))
-        assert products == {"chat", "scribe", "knowledge"}
+        assert products == {"chat", "knowledge"}
 
     def test_free_plan_still_has_no_products(self) -> None:
         assert get_plan_products("free") == []
@@ -51,14 +51,7 @@ class TestPlanProductsKnowledgeAdded:
 
 
 class TestSystemGroupsLabel:
-    """AC-7: 'Chat + Focus' label renamed to 'Chat'."""
-
-    def test_chat_group_label_is_chat(self) -> None:
-        from app.core.system_groups import SYSTEM_GROUPS
-
-        chat_group = next((g for g in SYSTEM_GROUPS if g["system_key"] == "chat"), None)
-        assert chat_group is not None, "Chat system group not found"
-        assert chat_group["name"] == "Chat", f"Expected 'Chat', got '{chat_group['name']}'"
+    """SPEC-PORTAL-PROFILES-001 P2.5: system groups herinrichting."""
 
     def test_no_system_group_has_focus_in_name(self) -> None:
         from app.core.system_groups import SYSTEM_GROUPS
@@ -66,19 +59,34 @@ class TestSystemGroupsLabel:
         for group in SYSTEM_GROUPS:
             assert "Focus" not in group["name"], f"Group '{group['name']}' still contains 'Focus'"
 
-    def test_chat_system_key_unchanged(self) -> None:
+    def test_role_bind_groups_have_no_products(self) -> None:
+        """Role-bind system groups do not grant products directly."""
         from app.core.system_groups import SYSTEM_GROUPS
 
-        chat_group = next((g for g in SYSTEM_GROUPS if g["system_key"] == "chat"), None)
-        assert chat_group is not None
-        assert chat_group["system_key"] == "chat"
+        for group in SYSTEM_GROUPS:
+            if group["system_key"].startswith("role_"):
+                assert group["products"] == [], (
+                    f"Role-bind group '{group['system_key']}' should not have products"
+                )
 
-    def test_chat_group_products_unchanged(self) -> None:
+    def test_addon_scribe_group_grants_scribe_product(self) -> None:
         from app.core.system_groups import SYSTEM_GROUPS
 
-        chat_group = next((g for g in SYSTEM_GROUPS if g["system_key"] == "chat"), None)
-        assert chat_group is not None
-        assert chat_group["products"] == ["chat"]
+        addon = next((g for g in SYSTEM_GROUPS if g["system_key"] == "addon_scribe"), None)
+        assert addon is not None, "addon_scribe system group not found"
+        assert "scribe" in addon["products"]
+
+    def test_addon_docs_group_grants_docs_product(self) -> None:
+        from app.core.system_groups import SYSTEM_GROUPS
+
+        addon = next((g for g in SYSTEM_GROUPS if g["system_key"] == "addon_docs"), None)
+        assert addon is not None, "addon_docs system group not found"
+        assert "docs" in addon["products"]
+
+    def test_seven_system_groups_total(self) -> None:
+        from app.core.system_groups import SYSTEM_GROUPS
+
+        assert len(SYSTEM_GROUPS) == 7, f"Expected 7 system groups, got {len(SYSTEM_GROUPS)}"
 
 
 class TestKBLimitsDataclass:

--- a/klai-portal/backend/tests/test_plan_limits.py
+++ b/klai-portal/backend/tests/test_plan_limits.py
@@ -65,9 +65,7 @@ class TestSystemGroupsLabel:
 
         for group in SYSTEM_GROUPS:
             if group["system_key"].startswith("role_"):
-                assert group["products"] == [], (
-                    f"Role-bind group '{group['system_key']}' should not have products"
-                )
+                assert group["products"] == [], f"Role-bind group '{group['system_key']}' should not have products"
 
     def test_addon_scribe_group_grants_scribe_product(self) -> None:
         from app.core.system_groups import SYSTEM_GROUPS

--- a/klai-portal/backend/tests/test_products.py
+++ b/klai-portal/backend/tests/test_products.py
@@ -41,13 +41,13 @@ class TestPlanProducts:
         # SPEC-PORTAL-UNIFY-KB-001 D2: core now includes knowledge.
         assert get_plan_products("core") == ["chat", "knowledge"]
 
-    def test_professional_plan_has_chat_scribe_knowledge(self) -> None:
-        # SPEC-PORTAL-UNIFY-KB-001 D2: professional gained knowledge; limits
-        # still match core tier until complete is reached.
-        assert get_plan_products("professional") == ["chat", "scribe", "knowledge"]
+    def test_professional_plan_has_chat_and_knowledge(self) -> None:
+        # SPEC-PORTAL-PROFILES-001 P2.2: scribe is now an add-on, not plan-included.
+        assert get_plan_products("professional") == ["chat", "knowledge"]
 
-    def test_complete_plan_has_all_products(self) -> None:
-        assert get_plan_products("complete") == ["chat", "scribe", "knowledge"]
+    def test_complete_plan_has_chat_and_knowledge(self) -> None:
+        # SPEC-PORTAL-PROFILES-001 P2.2: scribe is now an add-on, not plan-included.
+        assert get_plan_products("complete") == ["chat", "knowledge"]
 
     def test_unknown_plan_returns_empty_list(self) -> None:
         assert get_plan_products("nonexistent") == []
@@ -60,7 +60,7 @@ class TestPlanProducts:
             assert isinstance(products, list), f"Plan '{plan}' value is not a list"
 
     def test_plan_hierarchy_is_superset(self) -> None:
-        """Each higher plan includes all products of lower plans."""
+        """SPEC-PORTAL-PROFILES-001 P2.2: chat/knowledge are plan products; add-ons handled separately."""
         free = set(get_plan_products("free"))
         core = set(get_plan_products("core"))
         professional = set(get_plan_products("professional"))
@@ -69,6 +69,8 @@ class TestPlanProducts:
         assert free.issubset(core)
         assert core.issubset(professional)
         assert professional.issubset(complete)
+        # professional and complete are now equal (both only chat + knowledge)
+        assert professional == complete
 
 
 # ---------------------------------------------------------------------------
@@ -348,11 +350,11 @@ class TestAutoAssignOnInvite:
 
         assert result.user_id == "new-user-id"
 
-        # SPEC-PORTAL-UNIFY-KB-001 D2: professional plan is chat + scribe + knowledge.
+        # SPEC-PORTAL-PROFILES-001 P2.2: professional plan is now chat + knowledge (scribe = add-on).
         product_adds = [obj for obj in added_objects if isinstance(obj, PortalUserProduct)]
-        assert len(product_adds) == 3
+        assert len(product_adds) == 2
         product_names = {p.product for p in product_adds}
-        assert product_names == {"chat", "scribe", "knowledge"}
+        assert product_names == {"chat", "knowledge"}
 
         # All product rows should reference the admin who did the invite
         for p in product_adds:
@@ -603,8 +605,8 @@ class TestListAvailableProducts:
         with patch("app.api.admin.products._get_caller_org", return_value=("admin-1", org, caller)):
             result = await list_available_products(credentials=mock_credentials, db=mock_db)
 
-        # SPEC-PORTAL-UNIFY-KB-001 D2: professional = chat + scribe + knowledge.
-        assert result.products == ["chat", "scribe", "knowledge"]
+        # SPEC-PORTAL-PROFILES-001 P2.2: professional = chat + knowledge (scribe = add-on).
+        assert result.products == ["chat", "knowledge"]
 
     @pytest.mark.asyncio
     async def test_list_products_free_plan_returns_empty(self) -> None:

--- a/klai-portal/backend/tests/test_rls_audit.py
+++ b/klai-portal/backend/tests/test_rls_audit.py
@@ -80,6 +80,13 @@ _ALLOWLIST: dict[str, str] = {
     "app/services/kb_quota.py": (
         "service layer — all callers pass a db session with tenant context already set via _get_caller_org"
     ),
+    # SPEC-PORTAL-PROFILES-001 Phase 2 P2.5: system_groups.py is only called
+    # from add_member in groups.py, which calls _get_caller_org + set_tenant
+    # before invoking sync_role_from_system_group. Tenant context is set by
+    # the calling route, not the service.
+    "app/services/system_groups.py": (
+        "service layer — only caller is add_member in groups.py which calls _get_caller_org + set_tenant first"
+    ),
 }
 
 

--- a/klai-portal/backend/tests/test_rls_callsite_audit.py
+++ b/klai-portal/backend/tests/test_rls_callsite_audit.py
@@ -78,6 +78,10 @@ ALLOWED_HELPER_FUNCTIONS: frozenset[str] = frozenset(
         "create_default_personal_kb",
         # app/core/system_groups.py — calls set_tenant itself.
         "create_system_groups",
+        # app/services/system_groups.py — SPEC-PORTAL-PROFILES-001 Phase 2 P2.5.
+        # Only called from add_member in groups.py, which calls _get_caller_org +
+        # set_tenant before invoking this helper. Tenant context is upstream.
+        "sync_role_from_system_group",
         # app/api/app_knowledge_bases.py — all helpers take org_id and
         # are only reachable via _get_caller_org routes.
         "_get_kb_or_404",

--- a/klai-portal/backend/tests/test_system_groups.py
+++ b/klai-portal/backend/tests/test_system_groups.py
@@ -1,0 +1,113 @@
+from unittest.mock import AsyncMock, MagicMock
+import pytest
+
+
+class TestSystemGroupRoleMap:
+    def test_role_map_has_five_entries(self) -> None:
+        from app.core.system_groups import SYSTEM_GROUP_ROLE_MAP
+        assert len(SYSTEM_GROUP_ROLE_MAP) == 5
+
+    def test_role_map_covers_all_roles(self) -> None:
+        from app.core.system_groups import SYSTEM_GROUP_ROLE_MAP
+        expected = {"personal", "company", "kb_manager", "group_manager", "admin"}
+        assert set(SYSTEM_GROUP_ROLE_MAP.values()) == expected
+
+    def test_addon_keys_not_in_role_map(self) -> None:
+        from app.core.system_groups import SYSTEM_GROUP_ROLE_MAP
+        assert "addon_scribe" not in SYSTEM_GROUP_ROLE_MAP
+        assert "addon_docs" not in SYSTEM_GROUP_ROLE_MAP
+
+    def test_seven_system_groups_total(self) -> None:
+        from app.core.system_groups import SYSTEM_GROUPS
+        assert len(SYSTEM_GROUPS) == 7
+
+
+class TestSyncRoleFromSystemGroup:
+    @pytest.mark.asyncio
+    async def test_role_bind_group_sets_user_role(self) -> None:
+        from app.services.system_groups import sync_role_from_system_group
+        group = MagicMock()
+        group.id = 10
+        group.is_system = True
+        group.system_key = "role_kb_manager"
+        group_result = MagicMock()
+        group_result.scalar_one_or_none.return_value = group
+        update_result = MagicMock()
+        update_result.fetchone.return_value = (42,)
+        db = AsyncMock()
+        db.execute.side_effect = [group_result, update_result]
+        role = await sync_role_from_system_group("user-abc", group_id=10, db=db)
+        assert role == "kb_manager"
+        assert db.execute.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_non_system_group_is_noop(self) -> None:
+        from app.services.system_groups import sync_role_from_system_group
+        group = MagicMock()
+        group.id = 20
+        group.is_system = False
+        group.system_key = None
+        group_result = MagicMock()
+        group_result.scalar_one_or_none.return_value = group
+        db = AsyncMock()
+        db.execute.return_value = group_result
+        role = await sync_role_from_system_group("user-abc", group_id=20, db=db)
+        assert role is None
+        assert db.execute.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_group_not_found_returns_none(self) -> None:
+        from app.services.system_groups import sync_role_from_system_group
+        group_result = MagicMock()
+        group_result.scalar_one_or_none.return_value = None
+        db = AsyncMock()
+        db.execute.return_value = group_result
+        role = await sync_role_from_system_group("user-abc", group_id=99, db=db)
+        assert role is None
+
+    @pytest.mark.asyncio
+    async def test_addon_group_does_not_set_role(self) -> None:
+        from app.services.system_groups import sync_role_from_system_group
+        group = MagicMock()
+        group.id = 30
+        group.is_system = True
+        group.system_key = "addon_scribe"
+        group_result = MagicMock()
+        group_result.scalar_one_or_none.return_value = group
+        db = AsyncMock()
+        db.execute.return_value = group_result
+        role = await sync_role_from_system_group("user-abc", group_id=30, db=db)
+        assert role is None
+        assert db.execute.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_role_admin_group_sets_admin(self) -> None:
+        from app.services.system_groups import sync_role_from_system_group
+        group = MagicMock()
+        group.id = 40
+        group.is_system = True
+        group.system_key = "role_admin"
+        group_result = MagicMock()
+        group_result.scalar_one_or_none.return_value = group
+        update_result = MagicMock()
+        update_result.fetchone.return_value = (99,)
+        db = AsyncMock()
+        db.execute.side_effect = [group_result, update_result]
+        role = await sync_role_from_system_group("user-xyz", group_id=40, db=db)
+        assert role == "admin"
+
+    @pytest.mark.asyncio
+    async def test_membership_in_role_kb_manager_via_add_member(self) -> None:
+        from app.services.system_groups import sync_role_from_system_group
+        group = MagicMock()
+        group.id = 50
+        group.is_system = True
+        group.system_key = "role_kb_manager"
+        group_result = MagicMock()
+        group_result.scalar_one_or_none.return_value = group
+        update_result = MagicMock()
+        update_result.fetchone.return_value = (77,)
+        db = AsyncMock()
+        db.execute.side_effect = [group_result, update_result]
+        returned = await sync_role_from_system_group("user-77", group_id=50, db=db)
+        assert returned == "kb_manager"

--- a/klai-portal/backend/tests/test_system_groups.py
+++ b/klai-portal/backend/tests/test_system_groups.py
@@ -1,24 +1,29 @@
 from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 
 
 class TestSystemGroupRoleMap:
     def test_role_map_has_five_entries(self) -> None:
         from app.core.system_groups import SYSTEM_GROUP_ROLE_MAP
+
         assert len(SYSTEM_GROUP_ROLE_MAP) == 5
 
     def test_role_map_covers_all_roles(self) -> None:
         from app.core.system_groups import SYSTEM_GROUP_ROLE_MAP
+
         expected = {"personal", "company", "kb_manager", "group_manager", "admin"}
         assert set(SYSTEM_GROUP_ROLE_MAP.values()) == expected
 
     def test_addon_keys_not_in_role_map(self) -> None:
         from app.core.system_groups import SYSTEM_GROUP_ROLE_MAP
+
         assert "addon_scribe" not in SYSTEM_GROUP_ROLE_MAP
         assert "addon_docs" not in SYSTEM_GROUP_ROLE_MAP
 
     def test_seven_system_groups_total(self) -> None:
         from app.core.system_groups import SYSTEM_GROUPS
+
         assert len(SYSTEM_GROUPS) == 7
 
 
@@ -26,6 +31,7 @@ class TestSyncRoleFromSystemGroup:
     @pytest.mark.asyncio
     async def test_role_bind_group_sets_user_role(self) -> None:
         from app.services.system_groups import sync_role_from_system_group
+
         group = MagicMock()
         group.id = 10
         group.is_system = True
@@ -43,6 +49,7 @@ class TestSyncRoleFromSystemGroup:
     @pytest.mark.asyncio
     async def test_non_system_group_is_noop(self) -> None:
         from app.services.system_groups import sync_role_from_system_group
+
         group = MagicMock()
         group.id = 20
         group.is_system = False
@@ -58,6 +65,7 @@ class TestSyncRoleFromSystemGroup:
     @pytest.mark.asyncio
     async def test_group_not_found_returns_none(self) -> None:
         from app.services.system_groups import sync_role_from_system_group
+
         group_result = MagicMock()
         group_result.scalar_one_or_none.return_value = None
         db = AsyncMock()
@@ -68,6 +76,7 @@ class TestSyncRoleFromSystemGroup:
     @pytest.mark.asyncio
     async def test_addon_group_does_not_set_role(self) -> None:
         from app.services.system_groups import sync_role_from_system_group
+
         group = MagicMock()
         group.id = 30
         group.is_system = True
@@ -83,6 +92,7 @@ class TestSyncRoleFromSystemGroup:
     @pytest.mark.asyncio
     async def test_role_admin_group_sets_admin(self) -> None:
         from app.services.system_groups import sync_role_from_system_group
+
         group = MagicMock()
         group.id = 40
         group.is_system = True
@@ -99,6 +109,7 @@ class TestSyncRoleFromSystemGroup:
     @pytest.mark.asyncio
     async def test_membership_in_role_kb_manager_via_add_member(self) -> None:
         from app.services.system_groups import sync_role_from_system_group
+
         group = MagicMock()
         group.id = 50
         group.is_system = True


### PR DESCRIPTION
## Summary

- **P2.1** Alembic migration `a0174b86ace3` adds `portal_orgs.enabled_addons text[] NOT NULL DEFAULT '{}'`; updates `PortalOrg` SQLAlchemy model
- **P2.2** Extracts `ADDON_PRODUCTS = frozenset({"scribe", "docs"})` from `plans.py`; removes scribe from professional/complete `PLAN_PRODUCTS` (it is now an add-on)
- **P2.3** Two-layer `require_product` FastAPI dependency: layer 1 checks `org.enabled_addons` (blocks ALL users including admin when add-on not enabled at tenant level); layer 2 checks user/group entitlement (admin bypasses)
- **P2.4** `GET /api/admin/settings/addons` + `PATCH /api/admin/settings/addons` (admin-only; validates against `ADDON_PRODUCTS`; emits `tenant.addons_updated` product event + audit log)
- **P2.5** System-groups herinrichting: migration `261dae89162c` replaces 5 legacy groups with 7 new groups (5 role-bind + 2 add-on); new service `sync_role_from_system_group` wired into `add_member`
- **P2.6** 23 new integration tests across `test_addon_gating.py`, `test_admin_addons.py`, `test_system_groups.py`; patches to 4 existing test files

## Test plan

- [x] `uv run ruff check .` — 0 errors
- [x] `uv run ruff format --check .` — 0 format issues
- [x] `uv run pyright` — 0 errors, 0 warnings
- [x] `uv run python -m pytest --tb=no -q` — 1699 passed, 3 deselected, 32 warnings
- [x] `uv run alembic upgrade head --sql` validates chain: `59fff72b480b` → `a0174b86ace3` → `261dae89162c`

## Rollback

```bash
git revert fb926eef 9c44ab5a 2a8dad89 4255a34c 486629f1 6f78aa93 --no-edit
```

SPEC: SPEC-PORTAL-PROFILES-001 v0.4.0 Phase 2