### PR TITLE
fix(portal): unbreak role-enum + system-groups migrations (prod 502 hotfix)

### DIFF
--- a/klai-portal/backend/alembic/versions/261dae89162c_system_groups_herinrichting.py
+++ b/klai-portal/backend/alembic/versions/261dae89162c_system_groups_herinrichting.py
@@ -35,6 +35,12 @@ _ADDON_PRODUCTS = {
 
 def upgrade() -> None:
     conn = op.get_bind()
+    # portal_groups, portal_group_products and portal_group_memberships are
+    # RLS-protected. The install_rls_guard policy raises 42501 when
+    # app.current_org_id is unset and app.cross_org_admin is not true. Alembic
+    # opens its own connection without a tenant scope, so we set the
+    # cross-org admin GUC for the duration of this migration's transaction.
+    conn.execute(sa.text("SET LOCAL app.cross_org_admin = TRUE"))
 
     legacy_ids_result = conn.execute(
         sa.text("SELECT id FROM portal_groups WHERE is_system = true AND system_key = ANY(:keys)"),
@@ -94,6 +100,7 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     conn = op.get_bind()
+    conn.execute(sa.text("SET LOCAL app.cross_org_admin = TRUE"))
 
     new_keys = [sg["system_key"] for sg in _NEW_GROUPS]
     new_ids_result = conn.execute(

--- a/klai-portal/backend/alembic/versions/59fff72b480b_migrate_portal_users_role_to_enum.py
+++ b/klai-portal/backend/alembic/versions/59fff72b480b_migrate_portal_users_role_to_enum.py
@@ -14,7 +14,6 @@ CHECK constraint.
 Down migration reverts to VARCHAR(20) + the v2 CHECK constraint from a1b2c3d4e5f6.
 """
 
-import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -23,8 +22,6 @@ down_revision: str = "a1b2c3d4e5f6"
 branch_labels = None
 depends_on = None
 
-_ENUM_NAME = "portal_user_role"
-_ENUM_VALUES = ("personal", "company", "kb_manager", "group_manager", "admin")
 _CHECK_NAME = "ck_portal_users_role_v2"
 
 
@@ -39,43 +36,43 @@ def upgrade() -> None:
     # 2. Drop the old CHECK constraint (a1b2c3d4e5f6 added ck_portal_users_role_v2)
     op.drop_constraint(_CHECK_NAME, "portal_users", type_="check")
 
-    # 3. Alter column to use the ENUM type (raw DDL required; SQLAlchemy has no
+    # 3. Drop the old VARCHAR server_default before changing type. Postgres
+    #    won't auto-cast a VARCHAR default to the new ENUM type and will
+    #    raise DatatypeMismatchError on ALTER TYPE if a default is still set.
+    op.execute("ALTER TABLE portal_users ALTER COLUMN role DROP DEFAULT")  # nosemgrep
+
+    # 4. Alter column to use the ENUM type (raw DDL required; SQLAlchemy has no
     #    ALTER COLUMN ... USING syntax).
     op.execute(  # nosemgrep
         "ALTER TABLE portal_users ALTER COLUMN role TYPE portal_user_role USING role::portal_user_role"
     )
 
-    # 4. Set server_default using the typed cast
-    op.alter_column(
-        "portal_users",
-        "role",
-        server_default="'company'::portal_user_role",
-        existing_type=sa.Enum(*_ENUM_VALUES, name=_ENUM_NAME, create_type=False),
-        existing_nullable=False,
+    # 5. Set server_default with the typed cast now that the column is ENUM
+    op.execute(  # nosemgrep
+        "ALTER TABLE portal_users ALTER COLUMN role SET DEFAULT 'company'::portal_user_role"
     )
 
 
 def downgrade() -> None:
-    # 1. Change column back to VARCHAR(20) with text cast
+    # 1. Drop the typed default before changing type back
+    op.execute("ALTER TABLE portal_users ALTER COLUMN role DROP DEFAULT")  # nosemgrep
+
+    # 2. Change column back to VARCHAR(20) with text cast
     op.execute(  # nosemgrep
         "ALTER TABLE portal_users ALTER COLUMN role TYPE VARCHAR(20) USING role::text"
     )
 
-    # 2. Restore server_default as plain string
-    op.alter_column(
-        "portal_users",
-        "role",
-        server_default="company",
-        existing_type=sa.VARCHAR(20),
-        existing_nullable=False,
+    # 3. Restore server_default as plain string
+    op.execute(  # nosemgrep
+        "ALTER TABLE portal_users ALTER COLUMN role SET DEFAULT 'company'"
     )
 
-    # 3. Restore the CHECK constraint from a1b2c3d4e5f6
+    # 4. Restore the CHECK constraint from a1b2c3d4e5f6
     op.create_check_constraint(
         _CHECK_NAME,
         "portal_users",
         "role IN ('personal', 'company', 'kb_manager', 'group_manager', 'admin')",
     )
 
-    # 4. Drop the ENUM type
+    # 5. Drop the ENUM type
     op.execute("DROP TYPE portal_user_role")  # nosemgrep


### PR DESCRIPTION
## Summary

Two SPEC-PORTAL-PROFILES-001 migrations crashed the portal-api entrypoint on core-01. Container went into a restart loop; Caddy returned 502 on every `/api/*` route (incl. `/api/auth/oidc/start`). This PR fixes both migration files so the next image build runs cleanly.

### Migration 1 — `59fff72b480b` (role VARCHAR -> ENUM)
`ALTER COLUMN role TYPE portal_user_role` was issued without first dropping the existing `'company'::varchar` default. Postgres won't auto-cast a VARCHAR default to a new enum type and raises `DatatypeMismatchError`.

Fix: standard 3-step dance — `DROP DEFAULT` -> `ALTER TYPE ... USING` -> `SET DEFAULT 'company'::portal_user_role`. Mirrored on downgrade. Removed the now-unused `sa` import.

### Migration 2 — `261dae89162c` (system_groups herinrichting)
Cross-org SELECT/INSERT/DELETE sweep over `portal_groups`, `portal_group_memberships`, `portal_group_products`. Those are RLS-protected and `install_rls_guard` raises 42501 when neither `app.current_org_id` nor `app.cross_org_admin` is set. Alembic opens its own connection with no tenant scope.

Fix: `SET LOCAL app.cross_org_admin = TRUE` at the top of `upgrade()` and `downgrade()` — scoped to the migration's transaction.

## Recovery already done on core-01

1. Manually applied the corrected `59fff72b480b` DDL inside Postgres + stamped `alembic_version`.
2. `docker cp`'d the fixed `261dae89162c` migration file into the running container.
3. Container restart -> entrypoint `alembic upgrade head` succeeded -> uvicorn up.
4. Verified: `https://my.getklai.com/api/auth/oidc/start` and `https://getklai.getklai.com/api/auth/oidc/start` both return 302 (correct OIDC redirect).
5. DB state: `alembic_version = 261dae89162c`, `portal_users.role` is the enum with `'company'::portal_user_role` default, `portal_orgs.enabled_addons` exists, all 7 new system_groups (`role_*` + `addon_*`) present.

The container's hand-patched migration file gets overwritten on the next image build, hence this PR — without it the next deploy reintroduces the crash.

## Test plan

- [ ] CI portal-api quality job (ruff check + format + pyright + pytest)
- [ ] Verify `alembic upgrade head` is a no-op on prod after merge (current = head)
- [ ] Confirm portal-api stays up after the next CI deploy

## Related pitfalls

- `validator-env-parity`-style: prod-only failure mode (DB has VARCHAR default; CI test DB is fresh and has no default to convert).
- New: alembic migrations against RLS-protected tables MUST set `app.cross_org_admin = TRUE` explicitly. Worth adding to `portal-backend.md` after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)