### PR TITLE
fix(portal): deploy KlaiTenantHostMiddleware (close cross-tenant data exposure)

### DIFF
--- a/klai-portal/backend/app/core/session.py
+++ b/klai-portal/backend/app/core/session.py
@@ -59,3 +59,8 @@ class SessionContext:
 
     access_token_expires_at: int
     """Unix seconds when `access_token` stops being valid."""
+
+    org_id: int | None = None
+    """Portal org the session is bound to. None for pre-finalised sessions
+    (e.g. mid-multi-org workspace selection). Read by KlaiTenantHostMiddleware
+    to validate the URL hostname against the session's tenant."""

--- a/klai-portal/backend/app/main.py
+++ b/klai-portal/backend/app/main.py
@@ -39,6 +39,7 @@ from app.logging_setup import setup_logging
 from app.middleware.klai_cors import KlaiCORSMiddleware
 from app.middleware.logging_context import LoggingContextMiddleware
 from app.middleware.session import SessionMiddleware
+from app.middleware.tenant_host import KlaiTenantHostMiddleware
 from app.services.bot_poller import poll_loop
 from app.services.events import _pending as _event_tasks
 from app.services.recording_cleanup import recording_cleanup_loop
@@ -215,10 +216,12 @@ app = FastAPI(
 #   -> no_cache_authenticated (@http decorator)
 #   -> LoggingContextMiddleware (binds request_id, org_id, user_id to structlog)
 #   -> SessionMiddleware (resolves BFF session cookie + CSRF check)
+#   -> KlaiTenantHostMiddleware (validates URL tenant slug == session org slug)
 #   -> route handler
-# So we register in reverse: SessionMiddleware first (inner), CORS last (outer).
+# So we register in reverse: tenant-host first (innermost), CORS last (outer).
 # REQ-6.7 (SPEC-SEC-CORS-001): CORS must be the LAST add_middleware call so that
 # CSRF-reject 403s from SessionMiddleware carry CORS headers to cross-origin browsers.
+app.add_middleware(KlaiTenantHostMiddleware)
 app.add_middleware(SessionMiddleware)
 app.add_middleware(LoggingContextMiddleware)
 

--- a/klai-portal/backend/app/middleware/session.py
+++ b/klai-portal/backend/app/middleware/session.py
@@ -158,6 +158,7 @@ def _to_context(record: SessionRecord) -> SessionContext:
         access_token=record.access_token,
         csrf_token=record.csrf_token,
         access_token_expires_at=record.access_token_expires_at,
+        org_id=record.org_id,
     )
 
 

--- a/klai-portal/backend/app/middleware/tenant_host.py
+++ b/klai-portal/backend/app/middleware/tenant_host.py
@@ -24,7 +24,9 @@ runs with O(50) tenants, so after warm-up the lookup is a dict hit.
 
 from __future__ import annotations
 
+import re
 import time
+from urllib.parse import urlunsplit
 
 import structlog
 from fastapi import Request, Response, status
@@ -36,6 +38,14 @@ from app.core.config import settings
 from app.core.session import SessionContext
 
 logger = structlog.get_logger()
+
+# RFC 1123 hostname-label shape: lowercase alphanumeric + hyphens, max 63
+# chars, must start and end with alphanumeric. Klai slugs are stored in
+# ``portal_orgs.slug`` (max 64 chars per ``app/utils/slug.py``); enforcing
+# this shape before splicing the slug into a hostname is defense-in-depth
+# against any future schema change or rogue admin entry that could break
+# the redirect URL or cross-host into an attacker-controlled domain.
+_HOSTNAME_LABEL_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$")
 
 # ---------------------------------------------------------------------------
 # Skip rules
@@ -144,6 +154,17 @@ class KlaiTenantHostMiddleware(BaseHTTPMiddleware):
             # Fail-open: another layer (404 in handlers) will surface this.
             return await call_next(request)
 
+        # Defence-in-depth: slug is server-controlled (portal_orgs.slug)
+        # but a hostname-shape validation makes it impossible to accidentally
+        # produce a redirect Location that escapes ``*.{settings.domain}``.
+        if not _HOSTNAME_LABEL_PATTERN.match(session_slug):
+            logger.error(
+                "tenant_host_invalid_session_slug",
+                org_id=session.org_id,
+                session_slug=session_slug,
+            )
+            return await call_next(request)
+
         if host_slug == session_slug:
             return await call_next(request)
 
@@ -184,9 +205,19 @@ class KlaiTenantHostMiddleware(BaseHTTPMiddleware):
 
     @staticmethod
     def _mismatch_response(request: Request, session_slug: str) -> Response:
-        target = f"https://{session_slug}.{settings.domain}{request.url.path}"
-        if request.url.query:
-            target = f"{target}?{request.url.query}"
+        # Both ``session_slug`` (validated against ``_HOSTNAME_LABEL_PATTERN``
+        # by the caller) and ``settings.domain`` (hardcoded config) are
+        # server-controlled. Construct the URL with ``urlunsplit`` so the
+        # path/query/host segments stay structurally separated.
+        target = urlunsplit(
+            (
+                "https",
+                f"{session_slug}.{settings.domain}",
+                request.url.path,
+                request.url.query,
+                "",
+            )
+        )
 
         accept = request.headers.get("accept", "")
         wants_html = "text/html" in accept and "application/json" not in accept

--- a/klai-portal/backend/app/middleware/tenant_host.py
+++ b/klai-portal/backend/app/middleware/tenant_host.py
@@ -1,0 +1,225 @@
+"""
+KlaiTenantHostMiddleware — validates URL hostname against the session's tenant.
+
+Klai is subdomain-routed: every customer lives at `<org-slug>.getklai.com`.
+The session cookie is scoped to `.getklai.com` so it follows the user across
+all tenant subdomains. Without this guard, a user logged in to org A would
+silently see their own org-A data when visiting `<orgB-slug>.getklai.com` —
+the URL would lie about which tenant the user is viewing.
+
+This middleware closes that gap. On every request:
+
+1. Skip when there is no session, when the request is a CORS preflight,
+   when the path is on the public/pre-auth allow-list, or when the
+   hostname is not a tenant subdomain (e.g. ``my.getklai.com``).
+2. Resolve the session's org slug from ``portal_orgs.slug`` and compare
+   it to the first DNS label of the request hostname.
+3. On match: pass through.
+4. On mismatch: return either a 302 redirect (HTML navigation) or a
+   409 JSON payload (XHR) so the SPA can call ``window.location.replace``.
+
+The slug lookup is cached in-process for ``_SLUG_CACHE_TTL_SECONDS``. Klai
+runs with O(50) tenants, so after warm-up the lookup is a dict hit.
+"""
+
+from __future__ import annotations
+
+import time
+
+import structlog
+from fastapi import Request, Response, status
+from fastapi.responses import JSONResponse, RedirectResponse
+from sqlalchemy import select
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+
+from app.core.config import settings
+from app.core.session import SessionContext
+
+logger = structlog.get_logger()
+
+# ---------------------------------------------------------------------------
+# Skip rules
+# ---------------------------------------------------------------------------
+
+# Path prefixes that operate without a session-tenant binding. The CSRF
+# allow-list in `app.middleware.session` is the spiritual sibling of this
+# list; we keep it separate because the rules diverge (e.g. webhooks need
+# CSRF skip but also tenant-host skip).
+_SKIP_PATH_PREFIXES: tuple[str, ...] = (
+    "/api/auth/",  # OIDC start/callback, login finishers, IDP intent, sso-complete
+    "/api/signup",  # pre-session signup
+    "/api/health",  # liveness probe
+    "/api/perf",  # sendBeacon analytics, intentionally unauthenticated
+    "/api/public/",  # reserved public surface
+    "/api/webhooks/",  # signed webhook callers, no session
+    "/internal/",  # service-to-service (X-Internal-Secret auth)
+    "/partner/",  # partner API keys, not the BFF cookie
+    "/health",  # bare health endpoint
+    "/docs",  # FastAPI Swagger UI
+    "/openapi.json",
+    "/redoc",
+)
+
+# First DNS label values that are NOT tenant slugs. Subdomains used for
+# Klai infrastructure that share `.{settings.domain}` but never carry a
+# tenant context.
+_NON_TENANT_HOSTS: frozenset[str] = frozenset(
+    {
+        "my",  # canonical login portal — see klai/infra/servers.md
+        "auth",  # Zitadel
+        "llm",  # LiteLLM proxy
+        "grafana",
+        "errors",  # GlitchTip
+        "connector",  # public klai-connector ingress
+        "logs-ingest",  # VictoriaLogs push
+        "dev",  # protected dev portal
+    }
+)
+
+# ---------------------------------------------------------------------------
+# Slug cache
+# ---------------------------------------------------------------------------
+
+_SLUG_CACHE_TTL_SECONDS = 300.0
+_slug_cache: dict[int, tuple[str, float]] = {}
+
+
+def _slug_cache_clear() -> None:
+    """Test hook — purge the in-process slug cache."""
+    _slug_cache.clear()
+
+
+async def _resolve_org_slug(org_id: int) -> str | None:
+    """Return ``portal_orgs.slug`` for ``org_id``, cached for 5 minutes.
+
+    Returns ``None`` when the org row is missing (deleted or unknown).
+    """
+    now = time.monotonic()
+    cached = _slug_cache.get(org_id)
+    if cached is not None and cached[1] > now:
+        return cached[0]
+
+    # Local import to avoid pulling the engine at module import time.
+    from app.core.database import AsyncSessionLocal
+    from app.models.portal import PortalOrg
+
+    async with AsyncSessionLocal() as db:
+        result = await db.execute(select(PortalOrg.slug).where(PortalOrg.id == org_id))
+        slug = result.scalar_one_or_none()
+
+    if slug is not None:
+        _slug_cache[org_id] = (slug, now + _SLUG_CACHE_TTL_SECONDS)
+    return slug
+
+
+# ---------------------------------------------------------------------------
+# Middleware
+# ---------------------------------------------------------------------------
+
+
+class KlaiTenantHostMiddleware(BaseHTTPMiddleware):
+    """Reject requests whose URL hostname does not match the session tenant.
+
+    Registered as the innermost middleware (after SessionMiddleware) so that
+    ``request.state.session`` is already populated.
+    """
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        if self._should_skip(request):
+            return await call_next(request)
+
+        session = getattr(request.state, "session", None)
+        if not isinstance(session, SessionContext) or session.org_id is None:
+            # Unauthenticated / pre-finalised — let other middleware decide.
+            return await call_next(request)
+
+        host = request.url.hostname or ""
+        host_slug = self._extract_tenant_slug(host)
+        if host_slug is None:
+            return await call_next(request)
+
+        session_slug = await _resolve_org_slug(session.org_id)
+        if session_slug is None:
+            # Org row not found (deleted / cache miss on a vanished row).
+            # Fail-open: another layer (404 in handlers) will surface this.
+            return await call_next(request)
+
+        if host_slug == session_slug:
+            return await call_next(request)
+
+        return self._mismatch_response(request, session_slug)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _should_skip(request: Request) -> bool:
+        if request.method == "OPTIONS":
+            return True
+        path = request.url.path
+        if any(path.startswith(prefix) for prefix in _SKIP_PATH_PREFIXES):
+            return True
+        return False
+
+    @staticmethod
+    def _extract_tenant_slug(host: str) -> str | None:
+        """Return the tenant slug from a hostname, or None when not applicable.
+
+        Returns None for:
+          * empty / missing host
+          * host that does not end with ``.{settings.domain}`` (local dev,
+            custom domains)
+          * first DNS label in :data:`_NON_TENANT_HOSTS`
+        """
+        if not host:
+            return None
+        suffix = "." + settings.domain
+        if not host.endswith(suffix):
+            return None
+        first_label = host[: -len(suffix)].split(".", 1)[0]
+        if not first_label or first_label in _NON_TENANT_HOSTS:
+            return None
+        return first_label
+
+    @staticmethod
+    def _mismatch_response(request: Request, session_slug: str) -> Response:
+        target = f"https://{session_slug}.{settings.domain}{request.url.path}"
+        if request.url.query:
+            target = f"{target}?{request.url.query}"
+
+        accept = request.headers.get("accept", "")
+        wants_html = "text/html" in accept and "application/json" not in accept
+
+        logger.info(
+            "tenant_host_mismatch",
+            host=request.url.hostname,
+            session_slug=session_slug,
+            path=request.url.path,
+            response_kind="redirect" if wants_html else "json",
+        )
+
+        if wants_html:
+            return RedirectResponse(url=target, status_code=status.HTTP_302_FOUND)
+
+        # 409 Conflict: the request URL conflicts with the session's tenant.
+        # Frontend (apiFetch.ts) parses ``error_code`` and does
+        # ``window.location.replace(redirect_to)``.
+        return JSONResponse(
+            status_code=status.HTTP_409_CONFLICT,
+            content={
+                "detail": {
+                    "error_code": "tenant_host_mismatch",
+                    "redirect_to": target,
+                }
+            },
+        )
+
+
+__all__ = [
+    "_NON_TENANT_HOSTS",
+    "_SKIP_PATH_PREFIXES",
+    "KlaiTenantHostMiddleware",
+    "_resolve_org_slug",
+    "_slug_cache_clear",
+]

--- a/klai-portal/backend/tests/test_tenant_host_integration.py
+++ b/klai-portal/backend/tests/test_tenant_host_integration.py
@@ -1,0 +1,226 @@
+"""End-to-end-ish integration tests for KlaiTenantHostMiddleware.
+
+These boot a minimal FastAPI app wired up the same way main.py is, and
+drive it with Starlette's TestClient using real HTTP semantics:
+
+  * Real Host headers (sent via client.get(..., headers={"host": ...}))
+  * Real session injection via a stub middleware
+  * Real Accept negotiation (302 vs 409 branching)
+
+The unit tests in test_tenant_host_middleware.py cover the dispatch
+function directly with mocked Request objects. These integration tests
+verify the middleware actually fires when wired into Starlette's
+middleware stack with the same registration order as production.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from app.core.session import SessionContext
+from app.middleware import tenant_host as mw_module
+from app.middleware.tenant_host import KlaiTenantHostMiddleware
+
+
+class _StubSessionMiddleware(BaseHTTPMiddleware):
+    """Inject a fixed SessionContext on request.state.
+
+    Mirrors the interface of the real SessionMiddleware (which the
+    integration test does not need — we only care that
+    request.state.session is populated when the tenant-host guard runs).
+    """
+
+    def __init__(self, app: object, *, session: SessionContext | None) -> None:
+        super().__init__(app)  # type: ignore[arg-type]
+        self._session = session
+
+    async def dispatch(self, request, call_next):  # type: ignore[no-untyped-def]
+        request.state.session = self._session
+        return await call_next(request)
+
+
+def _make_app(session: SessionContext | None) -> FastAPI:
+    """Build a minimal app with the same middleware order as main.py."""
+    app = FastAPI()
+
+    @app.get("/api/me")
+    async def get_me() -> dict:
+        return {"ok": True}
+
+    @app.get("/api/auth/oidc/start")
+    async def oidc_start() -> dict:
+        return {"redirected": True}
+
+    # Same order as main.py: tenant-host innermost, session outer.
+    app.add_middleware(KlaiTenantHostMiddleware)
+    app.add_middleware(_StubSessionMiddleware, session=session)
+    return app
+
+
+@pytest.fixture(autouse=True)
+def _patch_slug_resolver() -> Iterator[None]:
+    """Map org_id 42 -> 'voys', 43 -> 'getklai'. Anything else -> None."""
+    mw_module._slug_cache_clear()
+
+    async def fake_resolver(org_id: int) -> str | None:
+        return {42: "voys", 43: "getklai"}.get(org_id)
+
+    with patch.object(mw_module, "_resolve_org_slug", fake_resolver):
+        yield
+
+
+def _session(org_id: int | None) -> SessionContext | None:
+    if org_id is None:
+        return None
+    return SessionContext(
+        sid="test-sid",
+        zitadel_user_id="test-user",
+        access_token="test-token",
+        csrf_token="test-csrf",
+        access_token_expires_at=2_000_000_000,
+        org_id=org_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Match — request reaches the route
+# ---------------------------------------------------------------------------
+
+
+def test_matching_host_reaches_route() -> None:
+    app = _make_app(_session(42))
+    client = TestClient(app)
+    response = client.get("/api/me", headers={"host": "voys.getklai.com"})
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# Mismatch — 302 for HTML
+# ---------------------------------------------------------------------------
+
+
+def test_mismatch_html_navigation_returns_302() -> None:
+    app = _make_app(_session(43))  # session is on 'getklai'
+    client = TestClient(app)
+    response = client.get(
+        "/api/me?page=2",
+        headers={"host": "voys.getklai.com", "accept": "text/html"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    assert response.headers["location"] == "https://getklai.getklai.com/api/me?page=2"
+
+
+# ---------------------------------------------------------------------------
+# Mismatch — 409 for XHR
+# ---------------------------------------------------------------------------
+
+
+def test_mismatch_xhr_returns_409_with_structured_body() -> None:
+    app = _make_app(_session(43))
+    client = TestClient(app)
+    response = client.get(
+        "/api/me",
+        headers={"host": "voys.getklai.com", "accept": "application/json"},
+    )
+    assert response.status_code == 409
+    assert response.json() == {
+        "detail": {
+            "error_code": "tenant_host_mismatch",
+            "redirect_to": "https://getklai.getklai.com/api/me",
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# Skip rules end-to-end
+# ---------------------------------------------------------------------------
+
+
+def test_pre_auth_path_bypasses_guard_even_on_wrong_host() -> None:
+    """A user with a session on org 43 hitting /api/auth/oidc/start on
+    voys.getklai.com (= wrong host) should still pass the middleware,
+    because OIDC paths are pre-auth-flow control."""
+    app = _make_app(_session(43))
+    client = TestClient(app)
+    response = client.get(
+        "/api/auth/oidc/start",
+        headers={"host": "voys.getklai.com"},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"redirected": True}
+
+
+def test_no_session_passes_through() -> None:
+    """No session = let other middleware return 401, do not 409."""
+    app = _make_app(None)
+    client = TestClient(app)
+    response = client.get(
+        "/api/me",
+        headers={"host": "voys.getklai.com"},
+    )
+    assert response.status_code == 200  # the stub route returns 200
+
+
+def test_my_subdomain_passes_through() -> None:
+    """my.getklai.com is the canonical login portal, never a tenant."""
+    app = _make_app(_session(42))
+    client = TestClient(app)
+    response = client.get(
+        "/api/me",
+        headers={"host": "my.getklai.com"},
+    )
+    assert response.status_code == 200
+
+
+def test_options_preflight_passes_through() -> None:
+    """OPTIONS preflight must reach (not exist here, hence 405) regardless
+    of host. A 405 from FastAPI proves the middleware did NOT short-circuit."""
+    app = _make_app(_session(43))
+    client = TestClient(app)
+    response = client.options(
+        "/api/me",
+        headers={"host": "voys.getklai.com"},
+    )
+    # FastAPI does not register OPTIONS for plain GET routes, so it 405s.
+    # The point: middleware did not return 409.
+    assert response.status_code in (405, 200)
+
+
+# ---------------------------------------------------------------------------
+# Cache warmup is observable across requests
+# ---------------------------------------------------------------------------
+
+
+def test_two_requests_share_slug_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The slug resolver is called once across two same-org requests."""
+    mw_module._slug_cache_clear()
+    call_count = 0
+
+    async def counting_resolver(org_id: int) -> str | None:
+        nonlocal call_count
+        call_count += 1
+        return {42: "voys"}.get(org_id)
+
+    # Replace the patched fixture's resolver for this test only.
+    monkeypatch.setattr(mw_module, "_resolve_org_slug", counting_resolver)
+
+    app = _make_app(_session(42))
+    client = TestClient(app)
+
+    r1 = client.get("/api/me", headers={"host": "voys.getklai.com"})
+    r2 = client.get("/api/me", headers={"host": "voys.getklai.com"})
+
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    # The fake resolver is called every time because it doesn't write to the
+    # cache (the real _resolve_org_slug does). This test documents that the
+    # resolver itself is the sole caching point — middleware is stateless.
+    assert call_count == 2

--- a/klai-portal/backend/tests/test_tenant_host_middleware.py
+++ b/klai-portal/backend/tests/test_tenant_host_middleware.py
@@ -200,6 +200,34 @@ class TestPassThrough:
         call_next.assert_awaited_once_with(request)
         assert response.status_code == 200
 
+    @pytest.mark.parametrize(
+        "bad_slug",
+        [
+            "evil.com",  # would escape the .getklai.com suffix
+            "bad/path",  # path separator
+            "with space",  # whitespace
+            "UPPERCASE",  # uppercase forbidden
+            "-leadinghyphen",
+            "trailing-",
+            "",  # empty
+            "a" * 65,  # exceeds Klai MAX_SLUG_LENGTH (64)
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_invalid_session_slug_fails_open(self, bad_slug: str) -> None:
+        """A session slug that does not match the hostname-label regex is
+        rejected (fail-open, not 302/409) — defense-in-depth against any
+        future schema bug producing a malformed slug."""
+        middleware = KlaiTenantHostMiddleware(app=MagicMock())
+        request = _make_request(host="voys.getklai.com", session_org_id=42)
+        call_next = AsyncMock(return_value=MagicMock(status_code=200))
+
+        with patch.object(mw_module, "_resolve_org_slug", _slug_resolver({42: bad_slug})):
+            response = await middleware.dispatch(request, call_next)
+
+        call_next.assert_awaited_once_with(request)
+        assert response.status_code == 200
+
 
 # ---------------------------------------------------------------------------
 # Mismatch cases

--- a/klai-portal/backend/tests/test_tenant_host_middleware.py
+++ b/klai-portal/backend/tests/test_tenant_host_middleware.py
@@ -1,0 +1,325 @@
+"""Tests for KlaiTenantHostMiddleware (tenant-host guard).
+
+Verifies that requests where the URL hostname's tenant slug does not match
+the session's org slug are rejected with the appropriate response shape:
+302 redirect for HTML navigation, 409 JSON for XHR. Skip rules cover
+unauthenticated requests, OPTIONS preflights, exempt path prefixes, and
+non-tenant subdomains (e.g. ``my.getklai.com``).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.core.session import SessionContext
+from app.middleware import tenant_host as mw_module
+from app.middleware.tenant_host import KlaiTenantHostMiddleware
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_request(
+    *,
+    host: str = "voys.getklai.com",
+    path: str = "/api/me",
+    method: str = "GET",
+    query: str = "",
+    accept: str = "application/json",
+    session_org_id: int | None = 42,
+) -> MagicMock:
+    """Build a Starlette-compatible request mock."""
+    request = MagicMock()
+    request.method = method
+    request.url = MagicMock()
+    request.url.hostname = host
+    request.url.path = path
+    request.url.query = query
+    request.headers = {"accept": accept}
+
+    if session_org_id is not None:
+        request.state.session = SessionContext(
+            sid="test-sid",
+            zitadel_user_id="test-user",
+            access_token="test-token",
+            csrf_token="test-csrf",
+            access_token_expires_at=2_000_000_000,
+            org_id=session_org_id,
+        )
+    else:
+        request.state.session = None
+
+    return request
+
+
+def _slug_resolver(mapping: dict[int, str]) -> Any:
+    """Return an AsyncMock that maps org_id → slug."""
+    return AsyncMock(side_effect=lambda org_id: mapping.get(org_id))
+
+
+@pytest.fixture(autouse=True)
+def _clear_slug_cache() -> None:
+    """Each test starts with an empty slug cache."""
+    mw_module._slug_cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Pass-through cases
+# ---------------------------------------------------------------------------
+
+
+class TestPassThrough:
+    @pytest.mark.asyncio
+    async def test_matching_slug_passes(self) -> None:
+        """Host slug matches session org slug — request proceeds."""
+        middleware = KlaiTenantHostMiddleware(app=MagicMock())
+        request = _make_request(host="voys.getklai.com", session_org_id=42)
+        call_next = AsyncMock(return_value=MagicMock(status_code=200))
+
+        with patch.object(mw_module, "_resolve_org_slug", _slug_resolver({42: "voys"})):
+            response = await middleware.dispatch(request, call_next)
+
+        call_next.assert_awaited_once_with(request)
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_no_session_passes(self) -> None:
+        """Unauthenticated requests are someone else's problem."""
+        middleware = KlaiTenantHostMiddleware(app=MagicMock())
+        request = _make_request(session_org_id=None)
+        call_next = AsyncMock(return_value=MagicMock(status_code=401))
+
+        response = await middleware.dispatch(request, call_next)
+
+        call_next.assert_awaited_once_with(request)
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_options_preflight_passes(self) -> None:
+        """CORS preflight must reach the CORS middleware unmolested."""
+        middleware = KlaiTenantHostMiddleware(app=MagicMock())
+        request = _make_request(method="OPTIONS")
+        call_next = AsyncMock(return_value=MagicMock(status_code=204))
+
+        response = await middleware.dispatch(request, call_next)
+
+        call_next.assert_awaited_once_with(request)
+        assert response.status_code == 204
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/api/auth/oidc/start",
+            "/api/auth/idp-callback",
+            "/api/signup",
+            "/api/health",
+            "/api/perf",
+            "/api/public/anything",
+            "/api/webhooks/moneybird",
+            "/internal/something",
+            "/partner/v1/widget-config",
+            "/health",
+            "/docs",
+            "/openapi.json",
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_skip_path_prefixes(self, path: str) -> None:
+        """Pre-auth, internal, partner, and probe paths are exempt."""
+        middleware = KlaiTenantHostMiddleware(app=MagicMock())
+        request = _make_request(host="wrong.getklai.com", path=path, session_org_id=42)
+        call_next = AsyncMock(return_value=MagicMock(status_code=200))
+
+        with patch.object(mw_module, "_resolve_org_slug", _slug_resolver({42: "voys"})):
+            response = await middleware.dispatch(request, call_next)
+
+        call_next.assert_awaited_once_with(request)
+        assert response.status_code == 200
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "my.getklai.com",
+            "auth.getklai.com",
+            "llm.getklai.com",
+            "grafana.getklai.com",
+            "errors.getklai.com",
+            "connector.getklai.com",
+            "logs-ingest.getklai.com",
+            "dev.getklai.com",
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_non_tenant_subdomains_pass(self, host: str) -> None:
+        """Klai infrastructure subdomains are not tenant slugs."""
+        middleware = KlaiTenantHostMiddleware(app=MagicMock())
+        request = _make_request(host=host, session_org_id=42)
+        call_next = AsyncMock(return_value=MagicMock(status_code=200))
+
+        response = await middleware.dispatch(request, call_next)
+
+        call_next.assert_awaited_once_with(request)
+        assert response.status_code == 200
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "localhost",
+            "127.0.0.1",
+            "portal-api",
+            "example.com",  # custom domain not under getklai.com
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_non_klai_hosts_pass(self, host: str) -> None:
+        """Hosts outside ``*.getklai.com`` are skipped (dev / custom domains)."""
+        middleware = KlaiTenantHostMiddleware(app=MagicMock())
+        request = _make_request(host=host, session_org_id=42)
+        call_next = AsyncMock(return_value=MagicMock(status_code=200))
+
+        response = await middleware.dispatch(request, call_next)
+
+        call_next.assert_awaited_once_with(request)
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_unknown_org_slug_fails_open(self) -> None:
+        """If session.org_id has no portal_orgs row, fail open."""
+        middleware = KlaiTenantHostMiddleware(app=MagicMock())
+        request = _make_request(host="voys.getklai.com", session_org_id=999)
+        call_next = AsyncMock(return_value=MagicMock(status_code=200))
+
+        with patch.object(mw_module, "_resolve_org_slug", _slug_resolver({})):
+            response = await middleware.dispatch(request, call_next)
+
+        call_next.assert_awaited_once_with(request)
+        assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Mismatch cases
+# ---------------------------------------------------------------------------
+
+
+class TestMismatchResponse:
+    @pytest.mark.asyncio
+    async def test_html_request_returns_302_redirect(self) -> None:
+        """Browser navigation gets a 302 to the correct subdomain."""
+        middleware = KlaiTenantHostMiddleware(app=MagicMock())
+        request = _make_request(
+            host="voys.getklai.com",
+            path="/admin/users",
+            session_org_id=42,
+            accept="text/html,application/xhtml+xml",
+        )
+        call_next = AsyncMock()
+
+        with patch.object(mw_module, "_resolve_org_slug", _slug_resolver({42: "getklai"})):
+            response = await middleware.dispatch(request, call_next)
+
+        call_next.assert_not_awaited()
+        assert response.status_code == 302
+        assert response.headers["location"] == "https://getklai.getklai.com/admin/users"
+
+    @pytest.mark.asyncio
+    async def test_html_request_preserves_query_string(self) -> None:
+        """The ?foo=bar tail follows the redirect."""
+        middleware = KlaiTenantHostMiddleware(app=MagicMock())
+        request = _make_request(
+            host="voys.getklai.com",
+            path="/admin/users",
+            query="page=2&filter=admin",
+            session_org_id=42,
+            accept="text/html",
+        )
+        call_next = AsyncMock()
+
+        with patch.object(mw_module, "_resolve_org_slug", _slug_resolver({42: "getklai"})):
+            response = await middleware.dispatch(request, call_next)
+
+        assert response.status_code == 302
+        assert response.headers["location"] == ("https://getklai.getklai.com/admin/users?page=2&filter=admin")
+
+    @pytest.mark.asyncio
+    async def test_xhr_request_returns_409_json(self) -> None:
+        """XHR/fetch gets a 409 with structured error_code body."""
+        middleware = KlaiTenantHostMiddleware(app=MagicMock())
+        request = _make_request(
+            host="voys.getklai.com",
+            path="/api/me",
+            session_org_id=42,
+            accept="application/json",
+        )
+        call_next = AsyncMock()
+
+        with patch.object(mw_module, "_resolve_org_slug", _slug_resolver({42: "getklai"})):
+            response = await middleware.dispatch(request, call_next)
+
+        call_next.assert_not_awaited()
+        assert response.status_code == 409
+        body = json.loads(response.body)
+        assert body == {
+            "detail": {
+                "error_code": "tenant_host_mismatch",
+                "redirect_to": "https://getklai.getklai.com/api/me",
+            }
+        }
+
+    @pytest.mark.asyncio
+    async def test_xhr_request_with_query_string(self) -> None:
+        """409 JSON's redirect_to preserves the query string."""
+        middleware = KlaiTenantHostMiddleware(app=MagicMock())
+        request = _make_request(
+            host="voys.getklai.com",
+            path="/api/me",
+            query="x=1",
+            session_org_id=42,
+            accept="application/json",
+        )
+        call_next = AsyncMock()
+
+        with patch.object(mw_module, "_resolve_org_slug", _slug_resolver({42: "getklai"})):
+            response = await middleware.dispatch(request, call_next)
+
+        body = json.loads(response.body)
+        assert body["detail"]["redirect_to"] == "https://getklai.getklai.com/api/me?x=1"
+
+    @pytest.mark.asyncio
+    async def test_accept_with_both_html_and_json_returns_json(self) -> None:
+        """Ambiguous Accept (e.g. */*) defaults to JSON 409 — safer for SPAs."""
+        middleware = KlaiTenantHostMiddleware(app=MagicMock())
+        request = _make_request(
+            host="voys.getklai.com",
+            path="/api/me",
+            session_org_id=42,
+            accept="text/html, application/json, */*",
+        )
+        call_next = AsyncMock()
+
+        with patch.object(mw_module, "_resolve_org_slug", _slug_resolver({42: "getklai"})):
+            response = await middleware.dispatch(request, call_next)
+
+        assert response.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# Slug-cache behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestSlugCache:
+    @pytest.mark.asyncio
+    async def test_cache_hit_skips_db(self) -> None:
+        """Second request for the same org_id hits the in-memory cache."""
+        # Pre-populate the cache so we know the lookup path is short-circuited.
+        import time as time_mod
+
+        mw_module._slug_cache[7] = ("acme", time_mod.monotonic() + 60)
+
+        result = await mw_module._resolve_org_slug(7)
+        assert result == "acme"

--- a/klai-portal/frontend/src/lib/apiFetch.ts
+++ b/klai-portal/frontend/src/lib/apiFetch.ts
@@ -119,6 +119,7 @@ async function doFetch<T>(path: string, options: ApiFetchOptions): Promise<T> {
   if (!res.ok) {
     let detail = `${res.status}`
     let validationIssues: ValidationIssue[] | undefined
+    let detailObject: Record<string, unknown> | undefined
     try {
       const body = (await res.json()) as {
         detail?: string | ValidationIssue[] | Record<string, unknown>
@@ -133,11 +134,31 @@ async function doFetch<T>(path: string, options: ApiFetchOptions): Promise<T> {
         // Some portal-api routes raise HTTPException(detail={"error_code": ...})
         // for structured error signalling (quota exceeded, capability gate, etc.)
         // Stringify here so callers can JSON.parse(err.detail) to read the code.
+        detailObject = body.detail
         detail = JSON.stringify(body.detail)
       }
     } catch {
       // no JSON body
     }
+
+    // Tenant-host guard: portal-api returns 409 when the URL hostname's tenant
+    // slug does not match the session's org slug (KlaiTenantHostMiddleware).
+    // Redirect the browser to the correct subdomain — the SPA on the wrong
+    // subdomain otherwise renders content that contradicts the URL.
+    if (
+      res.status === 409 &&
+      detailObject?.error_code === 'tenant_host_mismatch' &&
+      typeof detailObject?.redirect_to === 'string'
+    ) {
+      authLogger.info('tenant_host_mismatch — redirecting to correct subdomain', {
+        redirect_to: detailObject.redirect_to,
+      })
+      window.location.replace(detailObject.redirect_to)
+      // Return a never-resolving promise so the caller does not see a
+      // misleading ApiError flash before the redirect kicks in.
+      return new Promise<T>(() => {})
+    }
+
     throw new ApiError(res.status, detail, validationIssues)
   }
 


### PR DESCRIPTION
## Summary

Cherry-picks the three commits from the unmerged `feature/tenant-host-guard` branch onto main. Closes the cross-tenant data exposure where a user logged in as org A could browse `<orgB-slug>.getklai.com/app/*` and see org-A data because the BFF session cookie is scoped to `.getklai.com` and follows across all tenant subdomains.

The original branch was developed and pushed but never opened as a PR. This PR brings the work onto main as-is.

## Commits cherry-picked

- `708c8c9a` (now `320bd8fd`) — feat(portal): KlaiTenantHostMiddleware — validate URL tenant vs session org
- `2fb99bb5` (now `761f6827`) — test(portal): integration tests for tenant-host guard via TestClient
- `6510f7f6` (now `6844577b`) — fix(portal): harden tenant-host slug splicing — semgrep SSRF false positive

## Behaviour

| Request shape | Result |
|---|---|
| Host slug matches session org slug | Pass through |
| Mismatch + `Accept: text/html` | 302 to `https://<correct>.getklai.com<path>?<query>` |
| Mismatch + XHR / JSON | 409 with `{detail: {error_code: tenant_host_mismatch, redirect_to: ...}}` |
| `/api/auth/oidc/start` (login flow) | Bypassed |
| `my.getklai.com` | Bypassed |
| Unauthenticated | Pass through (no 409 spam pre-login) |
| OPTIONS preflight | Not short-circuited |

## Test plan

- [x] 50 tests pass: 42 unit (`test_tenant_host_middleware.py`) + 8 integration (`test_tenant_host_integration.py`)
- [x] `uv run ruff check .` — clean
- [x] `uv run --with pyright pyright app/middleware/tenant_host.py` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)