### PR TITLE
fix(e2e): close credential-leak + guard restoreOrgDisplayName

### DIFF
--- a/klai-portal/frontend/e2e/prod-tenant/_config/.gitignore
+++ b/klai-portal/frontend/e2e/prod-tenant/_config/.gitignore
@@ -1,1 +1,1 @@
-storageState.json
+storageState*.json

--- a/klai-portal/frontend/e2e/prod-tenant/_lib/cleanup.ts
+++ b/klai-portal/frontend/e2e/prod-tenant/_lib/cleanup.ts
@@ -80,14 +80,60 @@ export async function deleteTranscript(
 }
 
 /**
- * Restore the org's display-name to the default (used by J09).
- * Defensive: if the default isn't known yet, the journey can pass
- * the original value via `previous` instead.
+ * Restore the org's display-name (used by J09 cleanup).
+ *
+ * Two safety guards — both critical when running in voys-attached
+ * mode against a real customer tenant. Display names are NOT prefix-
+ * scoped (free-text field), so we derive safety from state instead:
+ *
+ *   1. previousDisplayName must be a truthy non-empty string. An
+ *      empty/undefined value would silently wipe the org name. Common
+ *      cause: the journey crashed before it captured the original
+ *      via getCurrentOrgDisplayName.
+ *
+ *   2. The CURRENT display name on the server MUST start with
+ *      E2E_NAME_GUARD ('e2e-'). That proves the journey actually put
+ *      a test-value there. If something else is in the field (the
+ *      journey didn't run, a parallel run crashed, the user manually
+ *      changed it between create and cleanup), refuse — this avoids
+ *      the worst case where a stale `previousDisplayName` from a
+ *      prior run blows away genuine data.
+ *
+ * Both guards throw loud rather than swallow. Failing the cleanup
+ * step is the SAFE outcome; the test will be flagged but tenant
+ * data stays intact.
  */
 export async function restoreOrgDisplayName(
   request: APIRequestContext,
   previousDisplayName: string,
 ): Promise<void> {
+  if (!previousDisplayName || previousDisplayName.trim() === '') {
+    throw new Error(
+      `[cleanup] restoreOrgDisplayName refused: previousDisplayName is empty. ` +
+        `Capture the original via getCurrentOrgDisplayName BEFORE the journey ` +
+        `mutates it, and pass that exact value here.`,
+    )
+  }
+
+  const currentResp = await request.get('/api/admin/settings')
+  if (!currentResp.ok()) {
+    throw new Error(
+      `[cleanup] restoreOrgDisplayName: could not read current settings ` +
+        `(${currentResp.status()}). Refusing to PATCH without verified state.`,
+    )
+  }
+  const current = (await currentResp.json()) as { display_name?: string }
+  const currentName = current.display_name ?? ''
+
+  if (!currentName.startsWith(E2E_NAME_GUARD)) {
+    throw new Error(
+      `[cleanup] restoreOrgDisplayName refused: current display name is ` +
+        `'${currentName}', not '${E2E_NAME_GUARD}'-prefixed. The journey ` +
+        `may not have changed it, or someone else has touched it since. ` +
+        `Refusing to overwrite — verify tenant state manually.`,
+    )
+  }
+
   const r = await request.patch('/api/admin/settings', {
     data: { display_name: previousDisplayName },
   })


### PR DESCRIPTION
## Why

Post-merge review of PR #271 surfaced two safety bugs in the e2e scaffolding. Both are critical when running in voys-attached mode against a real customer tenant.

## Bug 1 — credential-leak in `.gitignore` (HIGH)

`_config/.gitignore` had:

```
storageState.json
```

But `capture-voys-session.ts` writes `storageState.voys.json`. The pattern doesn't match — first `git add .` after running the capture script would commit live Google session cookies to the repo.

**Fix**: change pattern to `storageState*.json` so both `storageState.json` (isolated mode) and `storageState.voys.json` (voys-attached mode) are ignored.

Verified via `git check-ignore -v`:
- `storageState.voys.json` → IGNORED
- `storageState.json` → IGNORED

## Bug 2 — `restoreOrgDisplayName` had no safety guard (MEDIUM-HIGH)

Display name is a free-text field, so the `e2e-` prefix that protects KB / template / transcript deletes can't apply directly. If the journey crashed before capturing the original via `getCurrentOrgDisplayName`, `previousDisplayName` could be empty — silently wiping "Voys" → "" on the customer tenant.

**Fix**: two state-derived guards, both throw loud rather than swallow:

1. Refuse if `previousDisplayName` is empty/whitespace
2. `GET /api/admin/settings` first; refuse to `PATCH` unless the current display name starts with `E2E_NAME_GUARD` (proves the journey actually mutated it)

Failing the cleanup is the **safe** outcome — test gets flagged but tenant data stays intact.

## Scope

- 2 files, 50 insertions, 4 deletions
- No journey specs exist yet (Fase 4 still pending), so zero behaviour change for any current code path
- Pure safety hardening on top of merged scaffold (#271)