### PR TITLE
fix(alembic): SPEC-AUTH-009 DROP TABLE belongs in post_deploy SQL, not alembic

### DIFF
--- a/.claude/rules/klai/pitfalls/process-rules.md
+++ b/.claude/rules/klai/pitfalls/process-rules.md
@@ -419,6 +419,59 @@ on the very first new-build connector, requiring
 `docker exec klai-core-klai-connector-1 sh -c 'PYTHONPATH=. .venv/bin/alembic upgrade head'`
 as a hand-applied fix before this entrypoint pattern landed.
 
+## alembic-cannot-drop-non-portal_api-tables (HIGH)
+
+`portal_api` is the role that runs `alembic upgrade head` from the
+portal-api `entrypoint.sh`. Tables created with RLS (or any table whose
+ownership is `klai` superuser instead of `portal_api`) cannot be dropped
+by `op.drop_table(...)` — Postgres raises
+`InsufficientPrivilegeError: must be owner of table <name>`. The
+entrypoint then crash-loops and the deploy lands in 502.
+
+This bit SPEC-AUTH-009 (PR #259, 2026-05-04). Migration `ed5b78b296f5`
+ended with `op.drop_table("portal_org_allowed_domains")`. The table was
+owned by `klai` (RLS pattern from SPEC-AUTH-006), not `portal_api`. On
+deploy:
+
+1. `alembic upgrade head` ran the ADD COLUMN statements fine.
+2. The DROP TABLE failed with `InsufficientPrivilegeError`.
+3. portal-api crash-looped on every `alembic upgrade` retry.
+4. `voys.getklai.com/api/auth/oidc/start` → 502.
+
+**Recovery (manual, on prod):**
+```bash
+# As klai superuser:
+DROP TABLE IF EXISTS <table> CASCADE;
+# Re-run any pending migration steps (ADD COLUMN with backfill, etc.) manually:
+ALTER TABLE ... ;
+UPDATE ... ;
+# Stamp alembic so the entrypoint doesn't re-attempt the failing migration:
+UPDATE alembic_version SET version_num = '<failed-revision>';
+docker restart klai-core-portal-api-1
+```
+
+**Prevention:** Whenever a migration drops a table whose `pg_class.relowner`
+is not `portal_api`, do NOT use `op.drop_table(...)`. Instead:
+
+1. Replace the `op.drop_table(...)` call with a comment explaining the delegation.
+2. Add a sibling `alembic/versions/post_deploy_<revision>.sql` containing
+   `DROP TABLE IF EXISTS <name> CASCADE;` (idempotent).
+3. The post-deploy SQL is run by an operator (or `apply_post_deploy_sql.sh`)
+   as `klai` superuser AFTER `alembic upgrade head` completes successfully.
+
+Mirrors the RLS pattern (`post_deploy_f0a1b2c3d4e5.sql` for SPEC-WIDGET-002,
+`post_deploy_rls_*.sql` for the RLS rollouts).
+
+**Detection during PR review:** for any migration with `op.drop_table(...)`
+or `op.execute("ALTER TABLE ... OWNER TO ...")`, check `pg_class.relowner`
+on the live DB (or recall the table's history). If it was created by an
+RLS-enabled migration, it almost certainly is owned by `klai`.
+
+```bash
+# Quick owner-check on prod:
+ssh core-01 "docker exec klai-core-postgres-1 sh -c 'psql -U \$POSTGRES_USER -d \$POSTGRES_DB -c \"SELECT tablename, tableowner FROM pg_tables WHERE tablename = ARG;\"'"
+```
+
 ## ruff-format-and-ruff-check-are-different (MED)
 `uv run ruff check` and `uv run ruff format --check` enforce different
 things. Lint (`check`) catches code-correctness issues (unused imports,

--- a/klai-portal/backend/alembic/versions/ed5b78b296f5_spec_auth_009_primary_domain.py
+++ b/klai-portal/backend/alembic/versions/ed5b78b296f5_spec_auth_009_primary_domain.py
@@ -70,12 +70,24 @@ def upgrade() -> None:
         postgresql_where=sa.text("deleted_at IS NULL"),
     )
 
-    # R2: Drop the SPEC-AUTH-006 allowed-domains table (pre-launch, no data migration).
-    op.drop_table("portal_org_allowed_domains")
+    # R2: SPEC-AUTH-006's portal_org_allowed_domains table is replaced by
+    # portal_orgs.primary_domain.  The DROP TABLE is intentionally NOT done
+    # here — the table is owned by `klai` (superuser) and `portal_api`
+    # (the alembic-running role) lacks DROP TABLE privileges, which would
+    # crash the entrypoint with InsufficientPrivilegeError.
+    #
+    # Drop is delegated to alembic/versions/post_deploy_ed5b78b296f5.sql,
+    # which an operator runs manually as `klai` after deploy.  Pattern
+    # mirrors `post_deploy_f0a1b2c3d4e5.sql` (SPEC-WIDGET-002) and the RLS
+    # post-deploys.  See `klai/projects/portal-backend.md::RLS + Alembic`.
 
 
 def downgrade() -> None:
-    # Recreate portal_org_allowed_domains for reversibility
+    # Recreate portal_org_allowed_domains for reversibility.
+    # NOTE: The CREATE TABLE will assign ownership to portal_api (the
+    # alembic-running role).  If the original table was owned by klai
+    # superuser (RLS pattern), a separate ALTER TABLE OWNER run by klai is
+    # needed to restore that.  Pre-launch this is non-critical.
     op.create_table(
         "portal_org_allowed_domains",
         sa.Column("id", sa.Integer(), nullable=False),

--- a/klai-portal/backend/alembic/versions/post_deploy_ed5b78b296f5.sql
+++ b/klai-portal/backend/alembic/versions/post_deploy_ed5b78b296f5.sql
@@ -1,0 +1,15 @@
+-- Post-deploy DDL for SPEC-AUTH-009 migration ed5b78b296f5.
+-- Run as `klai` superuser after `alembic upgrade ed5b78b296f5` completes.
+-- The Alembic migration itself cannot run this statement because the
+-- migration role (`portal_api`) is not the table owner of
+-- `portal_org_allowed_domains` — DROP TABLE raises InsufficientPrivilegeError
+-- and crashes the portal-api entrypoint into a restart loop.
+--
+-- Idempotent: safe to re-run.
+--
+-- Pattern mirrors post_deploy_f0a1b2c3d4e5.sql (SPEC-WIDGET-002) and the RLS
+-- post-deploys.  See klai/projects/portal-backend.md "RLS + Alembic".
+
+-- 1. Drop the SPEC-AUTH-006 allowed-domains table; replaced by
+--    portal_orgs.primary_domain (added in this migration's upgrade()).
+DROP TABLE IF EXISTS portal_org_allowed_domains CASCADE;


### PR DESCRIPTION
## Summary

Migration `ed5b78b296f5` (SPEC-AUTH-009 primary_domain) ended with `op.drop_table(portal_org_allowed_domains)`. That table was created by SPEC-AUTH-006 with `klai` (superuser) ownership via the RLS pattern. The portal-api entrypoint runs `alembic upgrade head` as the `portal_api` role — which lacks DROP TABLE on klai-owned tables.

Result on yesterday's deploy of #259: `InsufficientPrivilegeError`, entrypoint crash-loop, `voys.getklai.com/api/auth/oidc/start` → 502.

Recovery was manual: DROP TABLE as klai, re-run remaining DDL, stamp `alembic_version`.

This PR makes the same migration safe for fresh deploys (staging, dev, future tenant onboarding) by following the existing klai pattern (RLS post_deploys, SPEC-WIDGET-002).

## Changes

- `op.drop_table(...)` removed; replaced by a comment delegating to post_deploy SQL
- New `post_deploy_ed5b78b296f5.sql` with idempotent `DROP TABLE IF EXISTS portal_org_allowed_domains CASCADE`
- New pitfall doc `alembic-cannot-drop-non-portal_api-tables (HIGH)` in `process-rules.md`

## Operator action (already taken on prod)

Production was already stamped to `ed5b78b296f5` and the table dropped during the recovery. No further action needed for the live system. Future deploys (staging, dev, new customers) will use the post-deploy script via `apply_post_deploy_sql.sh`.

## Test plan

- [x] `alembic` validates: single head `ed5b78b296f5`
- [x] `ruff check .` clean
- [x] `pyright` clean
- [ ] Reviewer: confirm the pitfall doc captures the right detection signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)