### PR TITLE
chore(knowledge-ingest): remove dead single-doc taxonomy proposal call

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
@@ -42,7 +42,6 @@ from knowledge_ingest.models import (
     UpdateKBVisibilityRequest,
 )
 from knowledge_ingest.portal_client import fetch_taxonomy_nodes
-from knowledge_ingest.proposal_generator import DocumentSummary, maybe_generate_proposal
 from knowledge_ingest.taxonomy_classifier import classify_document
 
 _SENTINEL = 253402300800  # 9999-12-31
@@ -492,27 +491,12 @@ async def ingest_document(req: IngestRequest) -> dict:
         has_taxonomy=has_taxonomy,
     )
 
-    # Taxonomy proposal generation (SPEC-KB-022 R4) — fire-and-forget, non-blocking.
-    # Self-bootstrapping: fires when taxonomy_node_ids is empty regardless of whether the KB
-    # already has nodes. This covers both:
-    #   - KB with 0 nodes: all documents are unmatched -> proposals generated from scratch
-    #   - KB with nodes: only truly unmatched documents (confidence < 0.5) trigger proposals
-    # The >= 3 threshold in maybe_generate_proposal prevents noise from single documents.
-    if has_taxonomy and not taxonomy_node_ids:
-        import asyncio as _asyncio
-
-        _t = _asyncio.create_task(
-            maybe_generate_proposal(
-                org_id=req.org_id,
-                kb_slug=req.kb_slug,
-                unmatched_documents=[
-                    DocumentSummary(title=title, content_preview=req.content[:500])
-                ],
-                existing_nodes=taxonomy_nodes,
-            )
-        )
-        _background_tasks.add(_t)
-        _t.add_done_callback(_background_tasks.discard)
+    # SPEC-KB-022 R4: Taxonomy proposal generation runs in batch mode only —
+    # see klai-knowledge-ingest/knowledge_ingest/taxonomy_tasks.py::_run_backfill.
+    # The single-doc fire-and-forget call that used to live here was always a
+    # no-op: maybe_generate_proposal short-circuits when len(unmatched) < 3
+    # (proposal_generator.py::_MIN_UNMATCHED_FOR_PROPOSAL). Removed via
+    # SPEC-KB-027 R2 cleanup (PR #90 obsolete; harvested as standalone fix).
 
     # Enqueue enrichment as async Procrastinate task (non-blocking)
     if await org_config.is_enrichment_enabled(req.org_id, pool):


### PR DESCRIPTION
## Summary

Harvested R2 from the now-closed PR #90 (SPEC-KB-027 obsolete after klai-focus FROZEN). The single-doc call to `maybe_generate_proposal` in `routes/ingest.py` was a deliberate no-op: the function short-circuits when `len(unmatched_documents) < _MIN_UNMATCHED_FOR_PROPOSAL` (=3), and the call site only ever passed one document. Net result: a fire-and-forget asyncio task that did nothing except create CPU + GC overhead.

## Changes

- Removed the 21-line `if has_taxonomy and not taxonomy_node_ids:` block in `routes/ingest.py:495-515`
- Removed the now-unused imports of `DocumentSummary` and `maybe_generate_proposal`
- Replaced with a comment explaining batch-mode-only proposal generation (still runs in `taxonomy_tasks.py::_run_backfill`)

The function `maybe_generate_proposal` itself stays — its tests and proposal_generator module are unchanged.

## Test plan

- [x] `ruff check knowledge_ingest/routes/ingest.py` clean
- [x] No callers of `maybe_generate_proposal` outside batch path remain (`grep -rn maybe_generate_proposal knowledge_ingest/` → only `proposal_generator.py` defines it; no other callers)
- [x] `DocumentSummary` is unused outside tests (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)