### PR TITLE
fix(profiles): allow tenant-enabled add-ons as assignable products

### DIFF
--- a/klai-portal/backend/app/api/admin/products.py
+++ b/klai-portal/backend/app/api/admin/products.py
@@ -13,7 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.database import get_db
 from app.core.plans import get_plan_products
 from app.models.groups import PortalGroup, PortalGroupMembership, PortalGroupProduct
-from app.models.portal import PortalUser
+from app.models.portal import PortalOrg, PortalUser
 from app.models.products import PortalUserProduct
 from app.services.audit import log_event
 
@@ -75,15 +75,30 @@ class ProductSummaryResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+def _assignable_products(org: PortalOrg) -> list[str]:
+    """Products an admin may assign: plan-included products plus tenant-enabled add-ons.
+
+    SPEC-PORTAL-PROFILES-001 Phase 2 — add-ons (scribe, docs) are gated by both
+    `portal_orgs.enabled_addons` (tenant-level unlock) AND a per-user/group
+    assignment via `portal_user_products` / `portal_group_products`. This
+    helper combines the two pools so the frontend dropdown and the assign
+    endpoints accept add-ons once the admin has flipped the toggle on
+    `/admin/settings`.
+    """
+    plan_products = set(get_plan_products(org.plan))
+    enabled_addons = set(org.enabled_addons or [])
+    return sorted(plan_products | enabled_addons)
+
+
 @router.get("/products", response_model=ProductsResponse)
 async def list_available_products(
     credentials: HTTPAuthorizationCredentials = Depends(bearer),
     db: AsyncSession = Depends(get_db),
 ) -> ProductsResponse:
-    """Return products available under the org's current plan."""
+    """Return products an admin may assign: plan products plus enabled add-ons."""
     _, org, caller_user = await _get_caller_org(credentials, db)
     _require_admin(caller_user)
-    return ProductsResponse(products=get_plan_products(org.plan))
+    return ProductsResponse(products=_assignable_products(org))
 
 
 @router.post("/users/{zitadel_user_id}/products", status_code=status.HTTP_201_CREATED)
@@ -93,15 +108,14 @@ async def assign_product(
     credentials: HTTPAuthorizationCredentials = Depends(bearer),
     db: AsyncSession = Depends(get_db),
 ) -> MessageResponse:
-    """Assign a product to a user within plan ceiling."""
+    """Assign a product to a user. Plan-included or tenant-enabled add-on only."""
     admin_user_id, org, caller_user = await _get_caller_org(credentials, db)
     _require_admin(caller_user)
 
-    # Plan ceiling check
-    if body.product not in get_plan_products(org.plan):
+    if body.product not in _assignable_products(org):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail=f"Product '{body.product}' exceeds plan ceiling",
+            detail=f"Product '{body.product}' is not available for this org",
         )
 
     # Check user belongs to this org

--- a/klai-portal/backend/app/api/groups.py
+++ b/klai-portal/backend/app/api/groups.py
@@ -529,16 +529,22 @@ async def assign_group_product(
     credentials: HTTPAuthorizationCredentials = Depends(bearer),
     db: AsyncSession = Depends(get_db),
 ) -> GroupProductOut:
-    """Assign a product to a group. Org admin only, plan ceiling enforced."""
+    """Assign a product to a group. Org admin only.
+
+    Accepted products: plan-included products plus tenant-enabled add-ons
+    (`portal_orgs.enabled_addons`). SPEC-PORTAL-PROFILES-001 Phase 2 — add-ons
+    require both the tenant-level toggle on `/admin/settings` AND a per-group
+    or per-user assignment before they show up in `get_effective_products`.
+    """
     caller_user_id, org, caller_user = await _get_caller_org(credentials, db)
     _require_admin(caller_user)
     await _get_group_or_404(group_id, org.id, db)
 
-    # Plan ceiling check
-    if body.product not in get_plan_products(org.plan):
+    assignable = set(get_plan_products(org.plan)) | set(org.enabled_addons or [])
+    if body.product not in assignable:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Product not included in org plan",
+            detail="Product not available for this org",
         )
 
     record = PortalGroupProduct(

--- a/klai-portal/backend/app/services/entitlements.py
+++ b/klai-portal/backend/app/services/entitlements.py
@@ -9,7 +9,7 @@ from sqlalchemy import select, union
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import set_tenant
-from app.core.plans import get_plan_products
+from app.core.plans import ADDON_PRODUCTS, get_plan_products
 from app.models.groups import PortalGroupMembership, PortalGroupProduct
 from app.models.portal import PortalOrg, PortalUser
 from app.models.products import PortalUserProduct
@@ -24,16 +24,22 @@ from app.models.products import PortalUserProduct
 # @MX:NOTE Plan-included products (chat, knowledge) are the floor for any user on a paying
 #   plan. Without this union, sidebars and gates render empty for admins/users without an
 #   explicit per-user/per-group product entitlement — which broke the post-Phase-3 UI.
-#   Add-on products (scribe, docs) are NOT in PLAN_PRODUCTS — those still require explicit
-#   per-tenant enabled_addons + per-user/group entitlement (handled by require_product).
+#   Add-on products (scribe, docs) are filtered against org.enabled_addons: an entitlement
+#   row whose tenant toggle is off becomes dormant — kept in DB to preserve manual admin
+#   work, but excluded from effective products so the sidebar/gates honor the toggle.
 # @MX:SPEC SPEC-SEC-007, SPEC-PORTAL-PROFILES-001
 async def get_effective_products(zitadel_user_id: str, db: AsyncSession) -> list[str]:
     """Return all products a user has access to.
 
-    Three sources, all unioned:
+    Three sources, all unioned then filtered:
       1. Plan-included products (from org.plan via PLAN_PRODUCTS) — the floor for anyone on a paying plan.
       2. Direct per-user assignments (portal_user_products) — explicitly granted to this user.
       3. Group-inherited assignments (portal_group_products via portal_group_memberships).
+
+    Add-on products (ADDON_PRODUCTS — scribe, docs) are then filtered against
+    `portal_orgs.enabled_addons`: a row whose tenant toggle is off becomes
+    dormant. This keeps the SPEC-PORTAL-PROFILES-001 two-layer gate consistent
+    between `require_product` (API gating) and `/api/me` (sidebar gating).
 
     Self-heals tenant context: looks up the user's org_id and calls
     set_tenant() before querying the RLS-protected tables. This lets callers
@@ -45,17 +51,17 @@ async def get_effective_products(zitadel_user_id: str, db: AsyncSession) -> list
     Returns empty list if the user has no portal row yet (pre-provisioning
     or deleted user).
     """
-    # Resolve user's tenant + plan. portal_users has a permissive-on-missing
-    # policy so this lookup is safe without prior set_tenant().
+    # Resolve user's tenant + plan + enabled add-ons. portal_users has a
+    # permissive-on-missing policy so this lookup is safe without prior set_tenant().
     org_row = await db.execute(
-        select(PortalUser.org_id, PortalOrg.plan)
+        select(PortalUser.org_id, PortalOrg.plan, PortalOrg.enabled_addons)
         .join(PortalOrg, PortalOrg.id == PortalUser.org_id)
         .where(PortalUser.zitadel_user_id == zitadel_user_id)
     )
     row = org_row.one_or_none()
     if row is None:
         return []
-    org_id, plan = row
+    org_id, plan, enabled_addons = row
     await set_tenant(db, org_id)
 
     # Plan-included products (free / core / professional / complete → chat, knowledge, …)
@@ -78,4 +84,11 @@ async def get_effective_products(zitadel_user_id: str, db: AsyncSession) -> list
     result = await db.execute(combined)
     user_and_group_products: set[str] = set(result.scalars().all())
 
-    return sorted(plan_products | user_and_group_products)
+    effective = plan_products | user_and_group_products
+
+    # Dormancy filter: an add-on entitlement only counts when the tenant
+    # toggle is on. Non-add-on products (chat, knowledge) bypass this.
+    enabled_addon_set: set[str] = set(enabled_addons or [])
+    effective = {p for p in effective if p not in ADDON_PRODUCTS or p in enabled_addon_set}
+
+    return sorted(effective)

--- a/klai-portal/backend/tests/test_admin_addons.py
+++ b/klai-portal/backend/tests/test_admin_addons.py
@@ -4,9 +4,10 @@ import pytest
 from fastapi import HTTPException
 
 
-def _mock_org(enabled_addons=None):
+def _mock_org(enabled_addons=None, plan="core"):
     org = MagicMock()
     org.id = 42
+    org.plan = plan
     org.enabled_addons = enabled_addons or []
     return org
 
@@ -15,6 +16,13 @@ def _mock_caller(role="admin"):
     caller = MagicMock()
     caller.role = role
     return caller
+
+
+def _make_db_mock() -> AsyncMock:
+    """AsyncMock DB session with sync ``add()`` to avoid coroutine warnings."""
+    db = AsyncMock()
+    db.add = MagicMock()
+    return db
 
 
 class TestGetAddons:
@@ -125,4 +133,184 @@ class TestUpdateAddons:
         with patch("app.api.admin.settings._get_caller_org", return_value=("user-1", org, caller)):
             with pytest.raises(HTTPException) as exc_info:
                 await update_addons(body=body, credentials=mock_creds, db=mock_db)
+        assert exc_info.value.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# SPEC-PORTAL-PROFILES-001 P2.4 — addon assignment via products / groups
+# Closes the gap where enabled_addons unlocked the toggle but no endpoint
+# would accept the addon as an assignable product.
+# ---------------------------------------------------------------------------
+
+
+class TestListAvailableProductsAddons:
+    @pytest.mark.asyncio
+    async def test_addon_appears_when_enabled(self) -> None:
+        from app.api.admin.products import list_available_products
+
+        org = _mock_org(plan="core", enabled_addons=["scribe"])
+        caller = _mock_caller()
+        mock_db = AsyncMock()
+        mock_creds = MagicMock()
+        with patch("app.api.admin.products._get_caller_org", return_value=("admin-1", org, caller)):
+            result = await list_available_products(credentials=mock_creds, db=mock_db)
+        assert set(result.products) == {"chat", "knowledge", "scribe"}
+
+    @pytest.mark.asyncio
+    async def test_addon_absent_when_disabled(self) -> None:
+        from app.api.admin.products import list_available_products
+
+        org = _mock_org(plan="core", enabled_addons=[])
+        caller = _mock_caller()
+        mock_db = AsyncMock()
+        mock_creds = MagicMock()
+        with patch("app.api.admin.products._get_caller_org", return_value=("admin-1", org, caller)):
+            result = await list_available_products(credentials=mock_creds, db=mock_db)
+        assert "scribe" not in result.products
+        assert "docs" not in result.products
+
+    @pytest.mark.asyncio
+    async def test_both_addons_appear_when_both_enabled(self) -> None:
+        from app.api.admin.products import list_available_products
+
+        org = _mock_org(plan="professional", enabled_addons=["scribe", "docs"])
+        caller = _mock_caller()
+        mock_db = AsyncMock()
+        mock_creds = MagicMock()
+        with patch("app.api.admin.products._get_caller_org", return_value=("admin-1", org, caller)):
+            result = await list_available_products(credentials=mock_creds, db=mock_db)
+        assert set(result.products) == {"chat", "knowledge", "scribe", "docs"}
+
+
+class TestAssignUserProductAddon:
+    @pytest.mark.asyncio
+    async def test_assign_addon_succeeds_when_enabled(self) -> None:
+        from app.api.admin.products import assign_product
+
+        org = _mock_org(plan="core", enabled_addons=["scribe"])
+        caller = _mock_caller()
+        mock_db = _make_db_mock()
+        # User lookup returns a user; duplicate check returns None.
+        mock_db.scalar.side_effect = [MagicMock(), None]
+        mock_creds = MagicMock()
+
+        body = MagicMock()
+        body.product = "scribe"
+        with (
+            patch("app.api.admin.products._get_caller_org", return_value=("admin-1", org, caller)),
+            patch("app.api.admin.products.log_event", new=AsyncMock()),
+        ):
+            result = await assign_product(
+                zitadel_user_id="user-1",
+                body=body,
+                credentials=mock_creds,
+                db=mock_db,
+            )
+        assert result.message == "Product assigned"
+        mock_db.add.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_assign_addon_rejected_when_not_enabled(self) -> None:
+        from app.api.admin.products import assign_product
+
+        org = _mock_org(plan="core", enabled_addons=[])
+        caller = _mock_caller()
+        mock_db = AsyncMock()
+        mock_creds = MagicMock()
+
+        body = MagicMock()
+        body.product = "scribe"
+        with patch("app.api.admin.products._get_caller_org", return_value=("admin-1", org, caller)):
+            with pytest.raises(HTTPException) as exc_info:
+                await assign_product(
+                    zitadel_user_id="user-1",
+                    body=body,
+                    credentials=mock_creds,
+                    db=mock_db,
+                )
+        assert exc_info.value.status_code == 403
+        assert "scribe" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_assign_unknown_product_still_rejected(self) -> None:
+        from app.api.admin.products import assign_product
+
+        org = _mock_org(plan="professional", enabled_addons=["scribe", "docs"])
+        caller = _mock_caller()
+        mock_db = AsyncMock()
+        mock_creds = MagicMock()
+
+        body = MagicMock()
+        body.product = "hacker_product"
+        with patch("app.api.admin.products._get_caller_org", return_value=("admin-1", org, caller)):
+            with pytest.raises(HTTPException) as exc_info:
+                await assign_product(
+                    zitadel_user_id="user-1",
+                    body=body,
+                    credentials=mock_creds,
+                    db=mock_db,
+                )
+        assert exc_info.value.status_code == 403
+
+
+class TestAssignGroupProductAddon:
+    @pytest.mark.asyncio
+    async def test_assign_addon_succeeds_when_enabled(self) -> None:
+        from datetime import UTC, datetime
+
+        from app.api.groups import assign_group_product
+
+        org = _mock_org(plan="core", enabled_addons=["docs"])
+        caller = _mock_caller()
+        mock_db = _make_db_mock()
+
+        # Real flow loads enabled_at via db.refresh() from a server_default;
+        # simulate that so the GroupProductOut construction succeeds.
+        async def _refresh_side_effect(record):
+            record.enabled_at = datetime.now(UTC)
+
+        mock_db.refresh = AsyncMock(side_effect=_refresh_side_effect)
+        mock_creds = MagicMock()
+
+        body = MagicMock()
+        body.product = "docs"
+
+        with (
+            patch("app.api.groups._get_caller_org", return_value=("admin-1", org, caller)),
+            patch("app.api.groups._get_group_or_404", new=AsyncMock(return_value=MagicMock())),
+            patch("app.api.groups.log_event", new=AsyncMock()),
+        ):
+            result = await assign_group_product(
+                group_id=7,
+                body=body,
+                credentials=mock_creds,
+                db=mock_db,
+            )
+
+        assert result.product == "docs"
+        mock_db.add.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_assign_addon_rejected_when_not_enabled(self) -> None:
+        from app.api.groups import assign_group_product
+
+        org = _mock_org(plan="core", enabled_addons=[])
+        caller = _mock_caller()
+        mock_db = AsyncMock()
+        mock_creds = MagicMock()
+
+        body = MagicMock()
+        body.product = "docs"
+
+        with (
+            patch("app.api.groups._get_caller_org", return_value=("admin-1", org, caller)),
+            patch("app.api.groups._get_group_or_404", new=AsyncMock(return_value=MagicMock())),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await assign_group_product(
+                    group_id=7,
+                    body=body,
+                    credentials=mock_creds,
+                    db=mock_db,
+                )
         assert exc_info.value.status_code == 403

--- a/klai-portal/backend/tests/test_entitlements_rls.py
+++ b/klai-portal/backend/tests/test_entitlements_rls.py
@@ -32,11 +32,11 @@ async def test_sets_tenant_context_before_union_query(monkeypatch: pytest.Monkey
     """set_tenant must run between the org lookup and the entitlements query."""
     calls: list[tuple[str, object]] = []
 
-    # Org-lookup now returns (org_id, plan) via row.one_or_none() — see
-    # SPEC-PORTAL-PROFILES-001 follow-up that unioned plan-products into
-    # the result.
+    # Org-lookup returns (org_id, plan, enabled_addons) via row.one_or_none() —
+    # see SPEC-PORTAL-PROFILES-001 follow-up that unioned plan-products and
+    # added the dormancy filter for add-ons.
     org_row = MagicMock()
-    org_row.one_or_none.return_value = (42, "free")
+    org_row.one_or_none.return_value = (42, "free", ["scribe"])
     products_scalars = MagicMock()
     products_scalars.all.return_value = ["chat", "scribe"]
     products_result = MagicMock()

--- a/klai-portal/backend/tests/test_entitlements_self_heal.py
+++ b/klai-portal/backend/tests/test_entitlements_self_heal.py
@@ -27,17 +27,18 @@ import pytest
 from app.services import entitlements
 
 
-def _make_org_row(org_id: int | None, plan: str | None = "core"):
+def _make_org_row(org_id: int | None, plan: str | None = "core", enabled_addons: list[str] | None = None):
     """Build a mock row mimicking SQLAlchemy's ``result.one_or_none()`` output.
 
     Returns a MagicMock whose ``one_or_none()`` returns either a
-    ``(org_id, plan)`` tuple (for found users) or ``None`` (for missing users).
+    ``(org_id, plan, enabled_addons)`` tuple (for found users) or ``None``
+    (for missing users).
     """
     row = MagicMock()
     if org_id is None:
         row.one_or_none = MagicMock(return_value=None)
     else:
-        row.one_or_none = MagicMock(return_value=(org_id, plan))
+        row.one_or_none = MagicMock(return_value=(org_id, plan, enabled_addons or []))
     return row
 
 
@@ -59,8 +60,9 @@ async def test_self_heals_tenant_context_before_querying(monkeypatch):
     monkeypatch.setattr(entitlements, "set_tenant", _fake_set_tenant)
     monkeypatch.setattr(entitlements, "get_plan_products", lambda plan: [])
 
-    # First execute = lookup user's (org_id, plan). Second = union(direct, group).
-    org_row = _make_org_row(42, "core")
+    # First execute = lookup user's (org_id, plan, enabled_addons). Second = union(direct, group).
+    # enabled_addons must include "scribe" so the dormancy filter doesn't strip it.
+    org_row = _make_org_row(42, "core", enabled_addons=["scribe"])
     products_row = _make_products_row(["scribe"])
 
     async def _execute(_stmt):
@@ -180,7 +182,8 @@ async def test_plan_user_and_group_products_unioned(monkeypatch):
         lambda plan: ["chat", "knowledge"] if plan == "professional" else [],
     )
 
-    org_row = _make_org_row(7, "professional")
+    # Both add-ons must be enabled at tenant level for the dormancy filter to keep them.
+    org_row = _make_org_row(7, "professional", enabled_addons=["scribe", "docs"])
     # The union query returns user + group products together (deduplicated by SQL UNION).
     products_row = _make_products_row(["scribe", "docs"])
 
@@ -214,3 +217,80 @@ async def test_dedupe_when_plan_overlaps_with_explicit_grant(monkeypatch):
 
     result = await entitlements.get_effective_products("user-5", db)
     assert sorted(result) == ["chat", "knowledge"]  # no duplicate
+
+
+@pytest.mark.asyncio
+async def test_addon_dormant_when_tenant_toggle_off(monkeypatch):
+    """SPEC-PORTAL-PROFILES-001 P2.4 dormancy: a user/group entitlement for
+    an add-on is filtered out when the tenant toggle is off. The DB row stays
+    (preserves admin work) but `/api/me` and `require_product` agree it's
+    inactive.
+    """
+
+    async def _fake_set_tenant(_session, _org_id: int) -> None:
+        pass
+
+    monkeypatch.setattr(entitlements, "set_tenant", _fake_set_tenant)
+    monkeypatch.setattr(
+        entitlements,
+        "get_plan_products",
+        lambda plan: ["chat", "knowledge"] if plan == "core" else [],
+    )
+
+    # User has `scribe` granted (per-user or per-group) but tenant toggle is off.
+    org_row = _make_org_row(7, "core", enabled_addons=[])
+    products_row = _make_products_row(["scribe"])
+
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[org_row, products_row])
+
+    result = await entitlements.get_effective_products("user-6", db)
+    assert "scribe" not in result
+    assert sorted(result) == ["chat", "knowledge"]
+
+
+@pytest.mark.asyncio
+async def test_addon_active_when_tenant_toggle_on(monkeypatch):
+    """Mirror of the dormant case: same entitlement, tenant flag flipped on,
+    add-on now appears."""
+
+    async def _fake_set_tenant(_session, _org_id: int) -> None:
+        pass
+
+    monkeypatch.setattr(entitlements, "set_tenant", _fake_set_tenant)
+    monkeypatch.setattr(
+        entitlements,
+        "get_plan_products",
+        lambda plan: ["chat", "knowledge"] if plan == "core" else [],
+    )
+
+    org_row = _make_org_row(7, "core", enabled_addons=["scribe"])
+    products_row = _make_products_row(["scribe"])
+
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[org_row, products_row])
+
+    result = await entitlements.get_effective_products("user-7", db)
+    assert sorted(result) == ["chat", "knowledge", "scribe"]
+
+
+@pytest.mark.asyncio
+async def test_partial_dormancy_keeps_active_addon(monkeypatch):
+    """Tenant has only one of two add-ons enabled; the disabled one is
+    filtered out, the enabled one survives."""
+
+    async def _fake_set_tenant(_session, _org_id: int) -> None:
+        pass
+
+    monkeypatch.setattr(entitlements, "set_tenant", _fake_set_tenant)
+    monkeypatch.setattr(entitlements, "get_plan_products", lambda plan: [])
+
+    org_row = _make_org_row(7, "core", enabled_addons=["docs"])
+    products_row = _make_products_row(["scribe", "docs"])
+
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[org_row, products_row])
+
+    result = await entitlements.get_effective_products("user-8", db)
+    assert "docs" in result
+    assert "scribe" not in result


### PR DESCRIPTION
## Summary
SPEC-PORTAL-PROFILES-001 Phase 2 P2.4 finishing touches — closes the gap that left `/admin/settings` add-on toggles cosmetic.

**Commit 1 — `fix(profiles): allow tenant-enabled add-ons as assignable products`**
- `list_available_products` returns plan products plus `org.enabled_addons` so the admin UI surfaces Scribe / Docs once toggled on `/admin/settings`
- `assign_product` and `assign_group_product` accept add-ons that the tenant has enabled (replaces the plan-ceiling check)
- Two-layer gating stays intact: tenant toggle is the unlock, per-user / per-group assignment is still explicit

**Commit 2 — `fix(profiles): make get_effective_products honor enabled_addons dormancy`**
- `get_effective_products` now also filters on `enabled_addons`. An entitlement row whose tenant toggle is off becomes dormant (DB row preserved, not surfaced)
- Without this, an admin who disables an add-on after granting it would see the sidebar item linger until `require_product` 403'd them at the first click. Now `/api/me` and `require_product` agree

## Why
Without commit 1: enabling Scribe or Docs on `/admin/settings` was a dead-end UX. The toggle saved, but `/api/admin/products` only returned plan products so the assignment dropdown on the group page never offered the add-on. The sidebar stayed empty.

Without commit 2: the reverse path (admin grants the add-on, then later disables it at tenant level) left a stale tab in the sidebar that hard-faulted on click. SPEC says "dormant"; we made it dormant in the place that drives the sidebar.

## Test plan
- [x] `tests/test_admin_addons.py` — three new classes: `TestListAvailableProductsAddons`, `TestAssignUserProductAddon`, `TestAssignGroupProductAddon`. Cover both allowed-when-enabled and rejected-when-disabled paths
- [x] `tests/test_entitlements_self_heal.py` — three new tests for dormancy: off, on, partial
- [x] Full backend suite: 1813 passed, 0 failed
- [x] `ruff check` + `ruff format --check` clean on all changed files
- [x] `pyright` clean on changed endpoint files + entitlements
- [ ] Post-deploy on prod (`my.getklai.com` → Voys tenant):
  - On `/admin/groups/<group>` add Scribe to a group that contains me, refresh `/app`, sidebar shows Transcribe
  - On `/admin/settings` toggle Scribe off, refresh `/app`, sidebar drops Transcribe (entitlement row stays in DB, verified via product summary)
  - Toggle Scribe back on, sidebar restores without re-assigning

## Migration / risk
- No schema change — `portal_orgs.enabled_addons` already exists since migration `a0174b86ace3`
- Empty `enabled_addons` gives identical behaviour to before the fix (plan-only products)
- `get_effective_products` signature unchanged — internal query gains a column, callers untouched
- Frontend can deploy independent of backend — existing groups UI calls `/api/admin/products` and picks up the extra options once backend rolls out