### PR TITLE
refactor(taxonomy): drop denormalised doc_count column

### DIFF
--- a/klai-portal/backend/alembic/versions/fd9c4a39d14b_drop_doc_count_from_taxonomy_nodes.py
+++ b/klai-portal/backend/alembic/versions/fd9c4a39d14b_drop_doc_count_from_taxonomy_nodes.py
@@ -1,0 +1,34 @@
+"""Drop doc_count from portal_taxonomy_nodes (R3 from closed PR #90).
+
+Revision ID: fd9c4a39d14b
+Revises: ed5b78b296f5
+Create Date: 2026-05-04
+
+The denormalized doc_count column was only updated on delete/merge, so it
+was stale on every re-ingest or backfill. Frontend never rendered it (only
+defined as TS type). Live counts, if needed, are queried from Qdrant via
+the coverage dashboard — a separate concern not handled here.
+
+Down-migration recreates the column without backfill (intentional: any
+post-deploy use of doc_count in restored code will show 0 until the next
+explicit aggregation run).
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "fd9c4a39d14b"
+down_revision = "ed5b78b296f5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_column("portal_taxonomy_nodes", "doc_count")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "portal_taxonomy_nodes",
+        sa.Column("doc_count", sa.Integer(), nullable=False, server_default="0"),
+    )

--- a/klai-portal/backend/app/api/taxonomy.py
+++ b/klai-portal/backend/app/api/taxonomy.py
@@ -39,7 +39,6 @@ class TaxonomyNodeOut(BaseModel):
     name: str
     slug: str
     description: str | None = None
-    doc_count: int
     sort_order: int
     created_at: datetime
     created_by: str
@@ -107,7 +106,6 @@ def _node_out(node: PortalTaxonomyNode) -> TaxonomyNodeOut:
         name=node.name,
         slug=node.slug,
         description=node.description,
-        doc_count=node.doc_count,
         sort_order=node.sort_order,
         created_at=node.created_at,
         created_by=node.created_by,
@@ -357,17 +355,14 @@ async def delete_taxonomy_node(
         .values(parent_id=node.parent_id)
     )
 
-    # Update parent doc_count if parent exists
-    reassigned_docs = node.doc_count
-    if node.parent_id is not None and reassigned_docs > 0:
-        parent_result = await db.execute(select(PortalTaxonomyNode).where(PortalTaxonomyNode.id == node.parent_id))
-        parent = parent_result.scalar_one_or_none()
-        if parent:
-            parent.doc_count += reassigned_docs
-
+    # Document counts are no longer denormalised on portal_taxonomy_nodes
+    # (column dropped in fd9c4a39d14b). Live counts come from Qdrant via the
+    # coverage dashboard. The endpoint still returns reassigned_docs for
+    # backward compatibility with the UI; we report 0 since we no longer
+    # track it server-side.
     await db.delete(node)
     await db.commit()
-    return {"reassigned_docs": reassigned_docs}
+    return {"reassigned_docs": 0}
 
 
 # -- Taxonomy proposals -------------------------------------------------------
@@ -582,7 +577,8 @@ async def _execute_merge(
     await db.execute(
         update(PortalTaxonomyNode).where(PortalTaxonomyNode.parent_id == source_id).values(parent_id=target_id)
     )
-    target_node.doc_count += source_node.doc_count
+    # doc_count column dropped (fd9c4a39d14b); merge no longer aggregates a
+    # denormalised counter. Live counts via Qdrant on the coverage dashboard.
     await db.delete(source_node)
 
 

--- a/klai-portal/backend/app/models/taxonomy.py
+++ b/klai-portal/backend/app/models/taxonomy.py
@@ -42,7 +42,6 @@ class PortalTaxonomyNode(Base):
     )
     name: Mapped[str] = mapped_column(String(128), nullable=False)
     slug: Mapped[str] = mapped_column(String(128), nullable=False)
-    doc_count: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
     sort_order: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-kb-types.ts
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-kb-types.ts
@@ -73,7 +73,6 @@ export interface TaxonomyNode {
   name: string
   slug: string
   description?: string | null
-  doc_count: number
   sort_order: number
   created_at: string
   created_by: string


### PR DESCRIPTION
## Summary

Harvested R3 from the closed PR #90. Drops the denormalised `doc_count` column on `portal_taxonomy_nodes`.

The column was only updated on delete and merge, and stale on every re-ingest or backfill (the comment in PR #90 was honest about that). Frontend never rendered it (only declared as TS type, not bound in any component). Live counts, where needed, come from Qdrant via the coverage dashboard — out of scope here.

## Changes

- New alembic migration `fd9c4a39d14b_drop_doc_count_from_taxonomy_nodes` (down: re-add column with default 0)
- Removed `doc_count` from `app/models/taxonomy.py` (column def)
- Removed `doc_count` from `TaxonomyNodeOut` response model (`app/api/taxonomy.py:42`) and `_node_out` builder (line 110)
- Delete-handler now returns `reassigned_docs: 0` (no server-side counter to reassign)
- Merge-handler no longer aggregates `target.doc_count += source.doc_count`
- Removed `doc_count` from `frontend/.../-kb-types.ts` TaxonomyNode interface

## Test plan

- [x] `validate_alembic.py` — single head `fd9c4a39d14b`
- [x] `pyright` — 0 errors on changed files
- [x] `pytest -k taxonomy` — 24 tests pass
- [x] `grep -rn doc_count` — only one comment remains (`api/taxonomy.py:580`, intentional reference)

## Migration safety

`portal_taxonomy_nodes` is a tenant-scoped table owned by `portal_api` (not RLS-promoted to `klai`). DROP COLUMN runs cleanly under the alembic role, no post-deploy SQL needed (unlike SPEC-AUTH-009's DROP TABLE issue from PR #289).

🤖 Generated with [Claude Code](https://claude.com/claude-code)