### PR TITLE
feat(e2e): add J01-login spec + fix __dirname in ESM config

### DIFF
--- a/klai-portal/frontend/e2e/prod-tenant/J01-login.spec.ts
+++ b/klai-portal/frontend/e2e/prod-tenant/J01-login.spec.ts
@@ -1,0 +1,28 @@
+/**
+ * J01 — Login + TOTP, persist storage-state for J02..J11.
+ *
+ * Runs ONLY in `isolated-tenant` mode (E2E_MODE default). The
+ * playwright config skips this spec in `voys-attached` mode because
+ * the storage-state is captured manually via `npm run e2e:capture-session`.
+ *
+ * Verifies the full auth chain: Zitadel email+password → TOTP step →
+ * portal-api session cookie → /app/* landing → /api/me 200. The
+ * persisted storage-state is consumed by all downstream journeys
+ * via the `authenticated-journeys` project's `dependencies: ['login']`.
+ *
+ * docs/testing/test-suite-plan.md §6 (J01).
+ */
+import { test, expect } from '@playwright/test'
+import fs from 'node:fs'
+import { loginAsE2EBot, persistAuthState } from './_lib/auth'
+import { STORAGE_STATE } from './_config/playwright.prod.config'
+
+test('J01 — login + TOTP and persist storage-state', async ({ page }) => {
+  await loginAsE2EBot(page)
+
+  await expect(page).toHaveURL(/\/app(\/|$)/)
+
+  await persistAuthState(page, STORAGE_STATE)
+
+  expect(fs.existsSync(STORAGE_STATE), `storageState should exist at ${STORAGE_STATE}`).toBe(true)
+})

--- a/klai-portal/frontend/e2e/prod-tenant/_config/playwright.prod.config.ts
+++ b/klai-portal/frontend/e2e/prod-tenant/_config/playwright.prod.config.ts
@@ -1,5 +1,9 @@
 import { defineConfig, devices } from '@playwright/test'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// ESM-friendly __dirname (frontend package.json is `"type": "module"`).
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 /**
  * Production-tenant E2E config.


### PR DESCRIPTION
## What

First concrete journey from the test-suite-plan + drive-by fix on a config bug found while validating J01.

## J01-login.spec.ts (new)

Thin wrapper around the existing `_lib/auth.ts` helpers per test plan §6:

1. `loginAsE2EBot(page)` — email + password + TOTP via otplib
2. Assert `/app/*` landing
3. `persistAuthState(page, STORAGE_STATE)` — saves cookies for J02..J11 to consume via `dependencies: ['login']`

In `voys-attached` mode J01 is correctly skipped via `testIgnore` (storage-state captured manually via `npm run e2e:capture-session`).

## Drive-by fix: `__dirname` in ESM config

`_config/playwright.prod.config.ts` was using `__dirname` directly. Frontend `package.json` sets `"type": "module"`, so `__dirname` is undefined in ES module scope:

```
ReferenceError: __dirname is not defined in ES module scope
    at file:///.../e2e/prod-tenant/_config/playwright.prod.config.ts:57:45
```

PR #271 didn't catch this because no specs existed yet to trigger config-load. The fix is the standard ESM pattern (already used in `capture-voys-session.ts` and `fixtures.ts`):

```ts
const __dirname = path.dirname(fileURLToPath(import.meta.url))
```

## Verified

```bash
$ npx playwright test --config e2e/prod-tenant/_config/playwright.prod.config.ts --list
  [login] › J01-login.spec.ts:20:1 › J01 — login + TOTP and persist storage-state
Total: 1 test in 1 file

$ E2E_MODE=voys-attached … --list
Total: 0 tests in 0 files   # J01 correctly skipped
```

## Not in scope

- E2E secrets setup (Fase 1 of rollout — repo-owner work, not code)
- J02..J12 journey specs (next PRs)

## Scope

2 files, +32 lines. No behaviour change for anything outside e2e dir.