### PR TITLE
docs(rag): retrieval-improvements roadmap + 5 SPECs (Tier 1 + Tier 2)

### DIFF
--- a/.moai/specs/SPEC-RAG-CONTEXTUAL-001/spec.md
+++ b/.moai/specs/SPEC-RAG-CONTEXTUAL-001/spec.md
@@ -1,0 +1,109 @@
+---
+id: SPEC-RAG-CONTEXTUAL-001
+version: "0.1.0"
+status: draft
+created: 2026-05-04
+updated: 2026-05-04
+author: Mark Vletter
+priority: high
+related:
+  - SPEC-RAG-EVAL-001 (precondition: must measure delta)
+  - SPEC-CRAWLER-005 (anchor_texts pattern, similar enrichment)
+roadmap: docs/architecture/retrieval-improvements-roadmap.md
+---
+
+# SPEC-RAG-CONTEXTUAL-001: Contextual Retrieval (Anthropic-pattern)
+
+## Summary
+
+Implement Anthropic's contextual-retrieval pattern: before embedding a chunk, prepend a 1-2 sentence LLM-generated context that situates the chunk in its source document. Anthropic's published benchmark: **49% reduction in retrieval-failure-rate** (top-20-chunk failures dropped from 5.7% to 2.9%) when combined with hybrid retrieval.
+
+This is the highest-ROI Tier-1 enhancement after the eval harness, because it addresses a structural limitation of every embedding-based RAG: **chunks are not self-contained**. Without context, the chunk *"This requires the customer's explicit consent and may take up to 14 days."* is a vague match against any privacy-related query. With the prepended context *"This chunk is from the Data Subject Access Request section of the Voys GDPR procedure manual."* it becomes a precise match for *"how long does a Voys GDPR access request take?"*.
+
+## Motivation
+
+1. **Cheap-once, win-forever.** Generating context per chunk is a one-time ingest cost. Anthropic's research: ~€1 per million doc-tokens with prompt caching. For Klai's pre-launch corpus (estimated < 100M tokens) the entire baseline is ~€100, then incremental on each new ingest.
+2. **Klai's enrichment pipeline is the perfect home.** `klai-knowledge-ingest/knowledge_ingest/enrichment_tasks.py` already runs as a Procrastinate fire-and-forget after ingest. Adding a `chunk_context` field to the same enrichment job is a natural extension.
+3. **Stacks with existing crawler enrichment.** SPEC-CRAWLER-005 already prepends `anchor_texts` and `links_to` for crawled pages. Contextual retrieval is the same pattern (write metadata that helps embedding) but works for ALL chunk types — uploads, Notion, Drive, M365 — not just crawled pages.
+
+## Scope
+
+### In scope
+
+**Backend — chunk-context generation**
+
+- New module `klai-knowledge-ingest/knowledge_ingest/contextual.py` with:
+  - `async def generate_chunk_context(chunk_text: str, document_summary: str, document_title: str, llm_client) -> str`
+  - Returns 1-2 sentence context (max ~100 tokens). Cached per `(document_id, chunk_index)` so re-runs are free.
+- LLM model: `klai-fast` (Mistral small via litellm). Prompt-caching enabled.
+- Prompt template (initial draft, refined in plan-phase):
+  ```
+  Document title: {title}
+  Document summary (1-2 sentences): {summary}
+  Chunk to contextualise: {chunk_text}
+
+  Write 1 sentence (≤30 words) that places this chunk in the document's
+  context, focusing on what topic, section, or scenario the chunk
+  addresses. Reply with ONLY the sentence, no preamble.
+  ```
+
+**Backend — wiring into enrichment**
+
+- `enrichment_tasks.enrich_document_interactive` and `enrich_document_bulk` get a new step:
+  - For each chunk in `extra_payload["chunks"]`, generate `chunk_context` and prepend it to the chunk text BEFORE the embedding call.
+  - Persist the original chunk + context separately:
+    - `chunk_text` (original, what the LLM sees in the prompt)
+    - `chunk_context` (new, what BM25 + embedding see)
+    - `embedding_input` = `chunk_context + "\n\n" + chunk_text` (what TEI/sparse models embed)
+- Document-level summary (`document_summary`) is generated once per document (not per chunk) via klai-fast at ingest time. Stored on artifact.
+
+**Qdrant schema**
+
+- New payload key `chunk_context: str | null`. Backward-compatible: existing chunks have `null`, new ingests have a string.
+- New ensure_collection() entry: index `chunk_context` for BM25 (sparse) so contextual BM25 works as Anthropic prescribed.
+
+**Re-embed of existing corpus**
+
+- One-shot Procrastinate task `recontextualize_kb` that takes `(org_id, kb_slug)` and:
+  - Iterates all chunks
+  - Generates context per chunk
+  - Re-embeds and updates Qdrant payload
+- Operator-triggered, not automatic. Documented in `docs/runbooks/recontextualize-kb.md`.
+
+**Eval comparison**
+
+- Use SPEC-RAG-EVAL-001 harness with `RAG_EVAL_VARIANT=contextual_v1` to measure delta vs baseline.
+- Target: ≥10% improvement in `context_precision` AND ≥5% improvement in `faithfulness` to declare success.
+
+### Out of scope
+
+- Self-updating context when documents change (initial: re-run `recontextualize_kb` manually; auto-trigger in follow-up)
+- Multi-language context (initial: same language as the document; mixed-language docs use English context)
+- Context-based query expansion (separate concern; HyDE territory in Tier 3)
+- Reranker integration changes (the cross-encoder already sees the full chunk text + context-prepended via `embedding_input`; no behaviour change there)
+
+## Acceptance Criteria (EARS)
+
+- **REQ-1**: WHEN a new document is ingested via the enrichment pipeline, every chunk SHALL have a `chunk_context` field of length 10-500 chars in its Qdrant payload.
+- **REQ-2**: WHEN context generation fails (LLM timeout, parse error), the chunk SHALL still be embedded with its original text and `chunk_context: null` — pipeline never blocks on this step.
+- **REQ-3**: The `embedding_input` SHALL be `chunk_context + "\n\n" + chunk_text` when context is present, and `chunk_text` alone when null. Reranker receives the full text plus context.
+- **REQ-4**: WHEN `recontextualize_kb` runs against an existing KB, every chunk's payload SHALL be updated and re-embedded; the operation SHALL be idempotent (re-running yields the same context for unchanged docs, due to caching).
+- **REQ-5**: After deploy + recontextualize-kb on the test-tenant corpus, RAGAS metrics on the `chat` suite SHALL show ≥10% improvement in `context_precision` (vs baseline run with `variant=baseline`).
+- **REQ-6**: Per-document one-time cost SHALL be < €0.05 for an 8000-token document (verified by counting LLM tokens in the contextual generation calls).
+
+## Open Questions (resolve in /plan)
+
+1. **Document summary generation** — generate once per document, or per ingest-batch? If a document is split across multiple ingest tasks (long Notion page), regenerating the summary is wasteful.
+2. **Prompt caching strategy** — Anthropic's pattern caches the document text and re-uses for each chunk. With Mistral via litellm, do we have the same caching support? Need verification.
+3. **Sparse vs dense behaviour** — should context be prepended for the dense embedding only, or also for sparse (BM25)? Anthropic's research uses both; verify our `bge-m3-sparse` accepts the longer input.
+4. **Backward compatibility** — chunks without `chunk_context` (the legacy corpus) need to keep working. The `embedding_input` fallback covers it, but the BM25 boost from contextual-BM25 only applies to new chunks. After re-contextualize, the corpus is uniform.
+
+## Estimated effort
+
+5-7 days:
+- Day 1-2: `contextual.py` module + unit tests + prompt iteration
+- Day 3: enrichment pipeline integration + `extra_payload` plumbing
+- Day 4: Qdrant schema migration + ensure_collection update
+- Day 5: `recontextualize_kb` task + runbook
+- Day 6: deploy to staging, re-contextualize the test-tenant corpus, run eval harness with `variant=contextual_v1`
+- Day 7: tune prompt based on eval delta, ship to production

--- a/.moai/specs/SPEC-RAG-EVAL-001/spec.md
+++ b/.moai/specs/SPEC-RAG-EVAL-001/spec.md
@@ -1,0 +1,127 @@
+---
+id: SPEC-RAG-EVAL-001
+version: "0.1.0"
+status: draft
+created: 2026-05-04
+updated: 2026-05-04
+author: Mark Vletter
+priority: high
+related:
+  - SPEC-RAG-CONTEXTUAL-001 (consumer of these metrics)
+  - SPEC-RAG-QUERY-REWRITE-001 (consumer of these metrics)
+  - SPEC-RAG-PARENT-CHILD-001 (consumer of these metrics)
+  - SPEC-RAG-TAXONOMY-001 (consumer of these metrics)
+roadmap: docs/architecture/retrieval-improvements-roadmap.md
+---
+
+# SPEC-RAG-EVAL-001: RAGAS Evaluation Harness
+
+## Summary
+
+Install [RAGAS](https://docs.ragas.io/) as the standing evaluation harness for Klai's retrieval pipeline. Without it, every Tier-2/3 retrieval improvement is anecdote-driven. With it, we can A/B compare optimisations against a reference query set per night and surface regressions in a Grafana panel.
+
+This is the **precondition** for SPEC-RAG-CONTEXTUAL-001, SPEC-RAG-QUERY-REWRITE-001, SPEC-RAG-PARENT-CHILD-001 and SPEC-RAG-TAXONOMY-001 — without metrics in place, none of those SPECs can claim impact.
+
+## Motivation
+
+1. **Reference-free metrics.** RAGAS evaluates context-precision, context-recall, faithfulness, answer-relevance via LLM-as-judge — no ground-truth labels required. We can run on production traces.
+2. **Pre-launch is the cheapest moment** to baseline the corpus. After launch, customer queries become the dataset; before, we control the seed query set.
+3. **Decision data, not opinions.** When we ask "should we add HyDE?", the answer is "what does RAGAS show on the technical-query subset?" — not "the blog post said 42%".
+
+## Scope
+
+### In scope
+
+**Backend — evaluation runner**
+
+- New module `klai-knowledge-ingest/knowledge_ingest/eval/ragas_runner.py` (or a new dedicated `klai-rag-eval` service if the install footprint is large; decision in plan-phase)
+- Procrastinate task `evaluate_retrieval_quality_nightly` that:
+  - Loads a YAML-defined query suite from `klai-knowledge-ingest/knowledge_ingest/eval/suites/` (one file per KB type: `chat.yaml`, `knowledge_org.yaml`, `knowledge_personal.yaml`)
+  - For each query: calls retrieval-api with same auth as production litellm-hook
+  - Captures retrieved chunks + a model answer via `klai-fast`
+  - Runs RAGAS metrics: `context_precision`, `context_recall`, `faithfulness`, `answer_relevance`
+  - Writes results to a new table `rag_eval_results` (org_id-scoped if we want per-tenant metrics, otherwise null/global)
+
+**Database — results table**
+
+```sql
+CREATE TABLE rag_eval_results (
+  id BIGSERIAL PRIMARY KEY,
+  run_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  suite TEXT NOT NULL,                  -- 'chat' / 'knowledge_org' / 'knowledge_personal'
+  variant TEXT NOT NULL DEFAULT 'baseline',  -- 'baseline' / 'contextual_v1' / 'parent_child' / ...
+  query_id TEXT NOT NULL,
+  context_precision FLOAT,
+  context_recall FLOAT,
+  faithfulness FLOAT,
+  answer_relevance FLOAT,
+  retrieved_chunk_ids TEXT[],
+  retrieval_ms INT,
+  total_tokens INT,
+  meta JSONB
+);
+CREATE INDEX ix_rag_eval_run_at_suite ON rag_eval_results (run_at DESC, suite);
+CREATE INDEX ix_rag_eval_variant_run_at ON rag_eval_results (variant, run_at DESC);
+```
+
+**Query suite format**
+
+```yaml
+# klai-knowledge-ingest/knowledge_ingest/eval/suites/chat.yaml
+suite: chat
+description: Representative queries against the chat / personal-KB flow
+queries:
+  - id: chat-faq-onboarding-1
+    org_zitadel_id: "test-tenant-1"
+    user_zitadel_id: "test-user-1"
+    query: "Hoe stel ik vakantie aan?"
+    expected_topics: ["HR", "verlof"]    # for context_precision LLM-judge
+  - id: chat-policy-1
+    query: "What is the bring-your-own-device policy?"
+    ...
+```
+
+The suite files start with **30 hand-written queries per type** (90 total). Generated as part of this SPEC's implementation by sampling production gap-event traces (when those exist) or by hand-curation against representative tenant data.
+
+**Grafana panel**
+
+- New PostgreSQL datasource panel "RAG quality (24h baseline)"
+- Three time-series: `context_precision`, `context_recall`, `faithfulness` per suite
+- Alert on `faithfulness < 0.85` for two consecutive runs (catastrophic regression)
+
+**CI integration (optional, decided in plan-phase)**
+
+- Workflow `rag-eval-pr.yml` runs the harness against a 10-query smoke subset on every PR that touches `klai-retrieval-api/`, `klai-knowledge-ingest/`, `klai-portal/backend/app/services/`, or `deploy/litellm/klai_knowledge.py`. Reports delta vs main in the PR comment.
+
+### Out of scope
+
+- Per-customer evaluation dashboards (post-launch)
+- Custom LLM-as-judge models (use Mistral via klai-fast initially)
+- Synthetic test-data generation (start with hand-written queries; revisit if the suite stagnates)
+- Performance benchmarking (latency-only metrics; RAGAS focuses on quality)
+
+## Acceptance Criteria (EARS)
+
+- **REQ-1**: WHEN `evaluate_retrieval_quality_nightly` is invoked, the harness SHALL load all `.yaml` files in `eval/suites/` and run every query through the production retrieval path.
+- **REQ-2**: For each query, the harness SHALL store one row in `rag_eval_results` with all four RAGAS metrics, retrieved chunk IDs, and elapsed retrieval time.
+- **REQ-3**: WHEN a query's retrieval fails (HTTP error, timeout > 10s), the row SHALL still be inserted with NULL metrics and a `meta.error` field.
+- **REQ-4**: The Grafana panel SHALL display a 7-day moving average of each metric per suite.
+- **REQ-5**: The harness SHALL run at most one evaluation in parallel — concurrent runs against the same suite raise `RuntimeError`.
+- **REQ-6**: WHEN a SPEC implementation team adds a `variant` column value (e.g. `contextual_v1`), the harness SHALL accept the variant via env var `RAG_EVAL_VARIANT` and tag every row with it; default `baseline`.
+- **REQ-7**: An operator SHALL be able to run the harness ad-hoc via `python -m knowledge_ingest.eval.ragas_runner --suite chat --variant my-experiment` and see results within 5 minutes for a 30-query suite.
+
+## Open Questions (resolve in /plan)
+
+1. **Service boundary** — does the runner live inside `klai-knowledge-ingest` (uses its existing Procrastinate worker + DB pool) or as a new `klai-rag-eval` service? Heuristic: if RAGAS install bloats knowledge-ingest by > 200 MB, split it; otherwise reuse.
+2. **LLM-as-judge cost** — RAGAS calls a judge LLM per metric per query. With 90 queries × 4 metrics × 30 nights/month = 10800 LLM calls/month. At klai-fast pricing (~€0.01 per 1k tokens, ~500 tokens per judge call) this is ~€54/month. Acceptable; verify in plan-phase.
+3. **Per-tenant or global?** Option A: one fixed test-tenant with curated KBs. Option B: sample real tenants. Option A is reproducible, Option B is realistic. Default A; revisit when we have customers.
+4. **Variant comparison UI** — do we need a Grafana panel that shows side-by-side (baseline vs variant) on the same chart, or is `WHERE variant = ?` SQL filter enough? Default: SQL filter; UI in follow-up if needed.
+
+## Estimated effort
+
+3-5 days for one engineer:
+- Day 1: install RAGAS, write 30 seed queries for `chat` suite, run end-to-end manually
+- Day 2: Procrastinate task + DB schema + migration
+- Day 3: 60 more queries (`knowledge_org` + `knowledge_personal` suites)
+- Day 4: Grafana panel + alert
+- Day 5: CI smoke harness on PR (optional, can defer)

--- a/.moai/specs/SPEC-RAG-PARENT-CHILD-001/spec.md
+++ b/.moai/specs/SPEC-RAG-PARENT-CHILD-001/spec.md
@@ -1,0 +1,117 @@
+---
+id: SPEC-RAG-PARENT-CHILD-001
+version: "0.1.0"
+status: draft
+created: 2026-05-04
+updated: 2026-05-04
+author: Mark Vletter
+priority: medium
+related:
+  - SPEC-RAG-EVAL-001 (precondition: must measure delta)
+  - SPEC-RAG-CONTEXTUAL-001 (orthogonal; both work together)
+roadmap: docs/architecture/retrieval-improvements-roadmap.md
+---
+
+# SPEC-RAG-PARENT-CHILD-001: Parent-child chunking
+
+## Summary
+
+Introduce a hierarchical chunk model — small "child" chunks (200-400 tokens) for embedding-and-matching, large "parent" chunks (1500-3000 tokens) for LLM context. Retrieval matches on child chunks but returns the parent chunk for the LLM prompt. This resolves the precision-vs-context tradeoff: small chunks match better, but small chunks lack the surrounding narrative the LLM needs to answer well.
+
+The current Klai chunk size is 1500 chars / 200 overlap. That's a single-tier compromise: precise enough to match, broad enough for context. Parent-child decouples the two: precise matching AND broad context.
+
+## Motivation
+
+1. **Long-document weakness in current stack.** A 12-page Notion page becomes ~30 chunks at 1500 chars each. Match is on a single chunk; the LLM sees only that chunk plus N neighbours. Compared to "match on a paragraph, return the whole section": the latter loses less narrative.
+2. **Industry-standard for 2026 RAG.** Most enterprise RAG implementations (Dify, Databricks RAG Studio, AWS Bedrock Knowledge Bases) ship parent-child as the default. Klai not having it is a comparative weakness.
+3. **Compatible with contextual retrieval.** SPEC-RAG-CONTEXTUAL-001 prepends context to chunks before embedding; parent-child changes WHICH chunk gets the context (the small child) and WHICH gets returned to the LLM (the large parent). The two compose cleanly.
+4. **Especially valuable for Knowledge-tier customers.** The big-doc-heavy enterprise tenants are exactly the ones who benefit most.
+
+## Scope
+
+### In scope
+
+**Backend — chunking strategy**
+
+- New module `klai-knowledge-ingest/knowledge_ingest/chunking.py` (or extend the existing chunker — decision in plan-phase) with:
+  - `def chunk_with_parents(text: str, document_id: str) -> tuple[list[ChildChunk], list[ParentChunk]]`
+  - Child: 300 tokens nominal, 50-token overlap. Indexed in Qdrant.
+  - Parent: 1500 tokens nominal, no overlap (boundaries align with section headings where possible). Indexed in Postgres `knowledge.parent_chunks` table.
+- Each child gets `parent_chunk_id: int` payload. Each parent has `parent_chunk_id` (PK) and `text` blob.
+
+**Database — parent storage**
+
+```sql
+CREATE TABLE knowledge.parent_chunks (
+  id BIGSERIAL PRIMARY KEY,
+  artifact_id UUID NOT NULL REFERENCES knowledge.artifacts(id) ON DELETE CASCADE,
+  org_id INT NOT NULL,
+  text TEXT NOT NULL,
+  token_count INT NOT NULL,
+  position INT NOT NULL,                -- ordering within document
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX ix_parent_chunks_artifact ON knowledge.parent_chunks (artifact_id);
+```
+
+Parent text is NOT in Qdrant — only IDs in child payloads. Retrieval-api fetches parent text via a JOIN at result-build time.
+
+**Qdrant payload extension**
+
+- Add `parent_chunk_id: int | null` to child chunk payload.
+- Existing chunks keep `null` (backward-compatible). New ingests populate it.
+
+**Retrieval-api — fetch parents**
+
+- New module `klai-retrieval-api/retrieval_api/services/parent_lookup.py`:
+  - `async def fetch_parents(child_chunks: list[dict], db: AsyncSession) -> dict[int, str]`
+  - Takes the top-K child chunks, queries `parent_chunks` for the matching IDs.
+  - Returns dict `{parent_id: parent_text}`.
+- `retrieve.py::retrieve` endpoint: after reranking, swaps child `text` for parent `text` in the response, where parent is available. Backward-compatible: chunks without `parent_chunk_id` keep their child text.
+- ChunkResult model gets new `is_parent_text: bool` flag for client-side debugging.
+
+**Eval comparison**
+
+- SPEC-RAG-EVAL-001 harness with `RAG_EVAL_VARIANT=parent_child_v1`.
+- Target: ≥10% improvement in `faithfulness` (LLM has more context to be faithful to) AND no regression in `context_precision`.
+
+**Re-ingest existing corpus**
+
+- Operator-triggered Procrastinate task `rechunk_kb_with_parents` per KB.
+- Documented in `docs/runbooks/rechunk-kb-with-parents.md`.
+- Idempotent: re-running reproduces parents from same input deterministically.
+
+### Out of scope
+
+- Multi-level hierarchy (grandparent / chapter chunks). Two levels is sufficient for 95% of use cases.
+- Dynamic parent boundaries based on semantic similarity. Use heading-based or fixed-size for v1.
+- Parent-aware reranker (the cross-encoder still sees the child for reranking — its strength is fine-grained matching). Re-rerank with parent in v2 if eval shows benefit.
+- Frontend display changes (chat UI doesn't need to know about parent vs child).
+
+## Acceptance Criteria (EARS)
+
+- **REQ-1**: WHEN a document is ingested via the new chunker, every child chunk SHALL have a `parent_chunk_id` payload pointing to a row in `knowledge.parent_chunks`.
+- **REQ-2**: WHEN the retrieval-api endpoint returns chunks AND `parent_chunk_id` is non-null, the response SHALL contain the parent's `text`, NOT the child's.
+- **REQ-3**: WHEN `parent_chunk_id` is null (legacy chunk), the response SHALL contain the child's text — backward-compatible.
+- **REQ-4**: Per-document ingest time SHALL increase by < 20% vs the current chunker (verified on a 10-document benchmark).
+- **REQ-5**: Parent-chunk text SHALL be deduplicated within a document — the same parent is returned at most once even if multiple children matched it (top-10 with parent dedup may yield < 10 unique parents).
+- **REQ-6**: Connector-delete SHALL cascade to `parent_chunks` via FK ON DELETE CASCADE.
+- **REQ-7**: After deploy + rechunk on test-tenant, RAGAS metrics with `variant=parent_child_v1` SHALL show ≥10% improvement in `faithfulness` AND no regression > 5% in `context_precision`.
+
+## Open Questions (resolve in /plan)
+
+1. **Heading-based vs fixed-size parents** — heading-based is more semantically coherent but requires parsing structure (markdown, HTML). Fixed-size always works. Default fixed-size for v1; revisit if eval-quality plateaus.
+2. **Top-K dedup ratio** — if 8 of top-10 children share 1 parent, do we return 1 chunk or 10? Default: dedup, so 1 unique parent + 2 other parents = 3 chunks. May reduce surface area to < 10 chunks. Trade-off documented.
+3. **Storage cost** — duplicating text (children + parents) doubles storage. For 100M tokens, this is ~200MB — negligible. Verify in plan.
+4. **Crawler integration** — the SPEC-CRAWLER-005 anchor_texts/links_to flow currently writes them on the chunk-level. Do they go on parent or child? Likely child (matching). Decide in plan.
+
+## Estimated effort
+
+7-10 days:
+- Day 1-2: `chunking.py` parent-child module + unit tests
+- Day 3: alembic migration + `parent_chunks` table
+- Day 4: enrichment_tasks integration + Qdrant payload update
+- Day 5-6: retrieval-api parent-lookup + integration tests
+- Day 7: rechunk task + runbook
+- Day 8: deploy to staging, rechunk test-tenant, run eval with `variant=parent_child_v1`
+- Day 9-10: tune chunk sizes based on eval; ship to production

--- a/.moai/specs/SPEC-RAG-QUERY-REWRITE-001/spec.md
+++ b/.moai/specs/SPEC-RAG-QUERY-REWRITE-001/spec.md
@@ -1,0 +1,107 @@
+---
+id: SPEC-RAG-QUERY-REWRITE-001
+version: "0.1.0"
+status: draft
+created: 2026-05-04
+updated: 2026-05-04
+author: Mark Vletter
+priority: high
+related:
+  - SPEC-RAG-EVAL-001 (precondition)
+roadmap: docs/architecture/retrieval-improvements-roadmap.md
+---
+
+# SPEC-RAG-QUERY-REWRITE-001: Query rewriting in the LiteLLM hook
+
+## Summary
+
+Add a lightweight query-understanding layer in `deploy/litellm/klai_knowledge.py` that rewrites or expands the raw user query via `klai-fast` before it goes into `retrieve_body["query"]`. Today the user's literal phrasing — including pronouns, follow-ups without context, vague phrasing — is fed 1-on-1 to the embedding model. Rewriting closes the semantic gap between question style and document style.
+
+Industry baseline for 2026: a query-rewriting layer typically adds **+15-25% precision on vague queries** at a cost of one extra `klai-fast` call (~200ms latency, ~€0.0003 per call).
+
+## Motivation
+
+1. **The most common quality regression is the simplest to fix.** "Wat zei hij over die deal?" doesn't match any document containing the deal — it depends on the previous turn for "hij" and "die deal". A rewrite *"What did Acme's CEO say about the Q4 partnership deal in the August call?"* matches.
+2. **No corpus changes needed.** Query rewriting is purely query-side. We can deploy and measure delta in days, no re-embedding, no backfill.
+3. **Synergy with SPEC-RAG-CONTEXTUAL-001.** Contextual retrieval makes chunks self-contained; query rewriting makes queries self-contained. The two compound — the bigger the gap they close together, the better the matching.
+4. **Foundation for SPEC-RAG-TAXONOMY-001.** The same LLM call can simultaneously produce a rewritten query AND a classification against the KB taxonomy — saving a roundtrip when SPEC-RAG-TAXONOMY-001 lands.
+
+## Scope
+
+### In scope
+
+**LiteLLM hook — query rewriter**
+
+- New helper in `deploy/litellm/klai_knowledge.py`:
+  ```python
+  async def _rewrite_query(
+      raw_query: str,
+      conversation_history: list[dict],
+      client: httpx.AsyncClient,
+  ) -> tuple[str, dict]:
+      """Return (rewritten_query, debug_meta). Falls back to raw_query on any error."""
+  ```
+- Call site: in the pre-call hook, just before `retrieve_body["query"] = query`.
+- Substitutes the rewritten query into `retrieve_body["query"]`. The original raw query is preserved in `retrieve_body["raw_query"]` (new field) for downstream logging only — retrieval-api ignores it.
+- Conversation history input: last 4 turns (user + assistant). Truncated to ~1000 chars.
+
+**Prompt** (initial draft, refined in plan-phase):
+
+```
+You are a query rewriter for a RAG system. Rewrite the user's question
+so that it makes sense as a stand-alone search query, resolving pronouns
+and references using the conversation history. If the question is
+already clear and self-contained, return it unchanged.
+
+Conversation history (last 4 turns):
+{history}
+
+User's current question:
+{raw_query}
+
+Reply with ONLY the rewritten question, no preamble or explanation.
+Maximum 200 characters. Same language as the user's input.
+```
+
+LLM model: `klai-fast` (Mistral small). Timeout: 1.5s. On timeout / non-200 / empty response: fall back to `raw_query` and log warning.
+
+**Logging**
+
+- New structured log event `query_rewrite` with fields: `org_id`, `user_id`, `raw_query`, `rewritten_query`, `rewrite_ms`, `was_changed: bool`.
+- These flow through the existing structlog pipeline and end up in VictoriaLogs. Useful for retrospective tuning of the prompt.
+
+**Eval comparison**
+
+- Use SPEC-RAG-EVAL-001 harness with `RAG_EVAL_VARIANT=query_rewrite_v1`.
+- Target: ≥15% improvement in `context_precision` on the `chat` suite, where queries are typically more conversational.
+
+### Out of scope
+
+- HyDE-style hypothetical answer generation (Tier 3, separate SPEC if metrics demand it)
+- Multi-query expansion (generate N alternative queries, run N retrievals, fuse) — adds latency, defer until eval shows the simple rewrite is insufficient
+- Query decomposition for multi-hop questions (Tier 3, SPEC-RAG-AGENTIC-001 if it lands)
+- Auto-translation (queries in NL retrieve from EN docs) — defer; requires a separate language-detection layer
+
+## Acceptance Criteria (EARS)
+
+- **REQ-1**: WHEN the litellm pre-call hook runs and `query` is non-empty, the hook SHALL invoke `_rewrite_query` and use the result for `retrieve_body["query"]`.
+- **REQ-2**: WHEN `_rewrite_query` returns a string identical to the raw query (no rewrite needed) OR the LLM call fails / times out, retrieval SHALL proceed with the raw query without retry.
+- **REQ-3**: The rewriter SHALL NOT add information not derivable from the conversation history. ([anti-hallucination guard]; verified by a unit test that asserts the rewriter does not invent entity names not in the input).
+- **REQ-4**: Total added latency SHALL be < 500ms p95 (target: 200-300ms typical).
+- **REQ-5**: Total added per-query token cost SHALL be < 200 tokens (verified by Mistral usage logs); at klai-fast pricing this is < €0.0005.
+- **REQ-6**: Every invocation SHALL log a `query_rewrite` event with the fields listed above.
+- **REQ-7**: After deploy, RAGAS metrics with `variant=query_rewrite_v1` on the `chat` suite SHALL show ≥15% improvement in `context_precision` vs baseline.
+
+## Open Questions (resolve in /plan)
+
+1. **Should the rewriter also see the available KB names?** Helps when query mentions "the policy" — rewriter could substitute the actual policy name. But adds tokens and may overfit.
+2. **Per-tenant prompt customization?** Some tenants might want domain-specific rewriter prompts (e.g. legal vs medical). Defer until a customer asks.
+3. **Conversation history limit** — 4 turns vs 6 vs 10? Each turn is ~50-200 tokens. 4 turns is enough for most pronoun resolution; 10 turns adds cost without clear gain.
+4. **What about no-retrieval queries?** Some chat turns are clearly meta ("repeat that", "shorter please"). The hook could detect these and skip rewriting + retrieval entirely. Defer to Tier 3 (agentic routing).
+
+## Estimated effort
+
+2-3 days:
+- Day 1: `_rewrite_query` helper + unit tests + prompt iteration on a hand-curated set of 10 vague queries
+- Day 2: Integrate into hook, deploy to staging, run eval harness with `variant=query_rewrite_v1`
+- Day 3: Tune prompt based on eval delta, deploy to production

--- a/.moai/specs/SPEC-RAG-TAXONOMY-001/spec.md
+++ b/.moai/specs/SPEC-RAG-TAXONOMY-001/spec.md
@@ -1,0 +1,128 @@
+---
+id: SPEC-RAG-TAXONOMY-001
+version: "0.1.0"
+status: draft
+created: 2026-05-04
+updated: 2026-05-04
+author: Mark Vletter
+priority: medium
+related:
+  - SPEC-RAG-EVAL-001 (precondition: must measure delta)
+  - SPEC-RAG-QUERY-REWRITE-001 (shares the same LLM call site)
+  - PR #90 (closed; the FROZEN klai-focus precursor — this SPEC ports the same intent to the Knowledge stack)
+roadmap: docs/architecture/retrieval-improvements-roadmap.md
+---
+
+# SPEC-RAG-TAXONOMY-001: Query-time taxonomy filtering
+
+## Summary
+
+Ingest-time taxonomy classification already lands on every chunk — `taxonomy_node_ids: int[]` is written into the Qdrant payload by `klai-knowledge-ingest/knowledge_ingest/taxonomy_classifier.py`. But query-time, nothing reads it. The retrieval-api code path that filters on `taxonomy_node_ids` exists in `_scope_filter()` but is never called by the LiteLLM hook because no caller produces the classification.
+
+This SPEC closes the loop: classify the (rewritten) query against the tenant's KB taxonomy in the LiteLLM hook, inject `taxonomy_node_ids` into the `retrieve_body`, and let the existing retrieval-api filter narrow the candidate pool before BM25 + dense + reranker run.
+
+The expected impact is biggest on **large categorised KBs** (>1000 chunks across many topics) where the top-K is currently polluted by chunks from off-topic categories that happened to have a strong embedding match. PR #90's original measurement on `klai-focus` showed **+10-15% precision on the categorical-noise subset** with no regression on the random-recall subset.
+
+## Motivation
+
+1. **The infrastructure is already there.** The classifier runs at ingest. The filter is wired in `_scope_filter()`. The taxonomy tree is curated per KB. Only the query-time call is missing — closing the gap is < 200 lines of new code.
+2. **Companion to query-rewriting.** SPEC-RAG-QUERY-REWRITE-001 already calls `klai-fast` per query in the litellm-hook. Re-using that call to ALSO emit `taxonomy_node_ids` adds zero latency and ~50 tokens per query. The two SPECs ship as one logical change for the hook.
+3. **PR #90 closed without landing.** The klai-focus implementation was scope-frozen and the PR closed obsolete. The Knowledge stack needs the same capability — this SPEC is the Knowledge-stack revival.
+4. **Coverage-stats fallback prevents the dead-zone.** A common failure mode of taxonomy filters: KB has 20% tagged content, query gets classified, filter excludes 80% of the KB, recall craters. The fallback (skip filter when coverage < threshold) avoids this without operator intervention.
+
+## Scope
+
+### In scope
+
+**LiteLLM hook — taxonomy classifier**
+
+- Extend the `_rewrite_query` helper from SPEC-RAG-QUERY-REWRITE-001 to ALSO return classified taxonomy nodes. Output shape:
+  ```python
+  async def _rewrite_and_classify(
+      raw_query: str,
+      conversation_history: list[dict],
+      taxonomy_tree: list[TaxonomyNode],
+      client: httpx.AsyncClient,
+  ) -> tuple[str, list[int], dict]:
+      """Return (rewritten_query, classified_node_ids, debug_meta)."""
+  ```
+- Single LLM call asks `klai-fast` to produce BOTH the rewritten query AND a JSON list of taxonomy node IDs the query is "about". Structured output via JSON-mode.
+- If the rewriter SPEC ships first without classification: the classification is added as a second field in the same prompt (no new roundtrip).
+- Empty list (`[]`) means "no narrowing" — the filter is not applied.
+
+**Coverage-stats fallback**
+
+- Before injecting the filter, the hook checks the KB's tagging coverage:
+  - New cached helper `get_kb_taxonomy_coverage(kb_slug, db) -> float` returns `tagged_chunks / total_chunks` for the KB.
+  - Cache TTL: 5 minutes per `(org_id, kb_slug)`.
+- Fallback rule: if coverage < `KLAI_TAXONOMY_COVERAGE_THRESHOLD` (default `0.30`), the filter is dropped and the query goes through without taxonomy narrowing. Logged as `taxonomy_filter_skipped_low_coverage`.
+
+**Taxonomy tree fetch**
+
+- New helper in retrieval-api `klai-retrieval-api/retrieval_api/services/taxonomy_lookup.py`:
+  - `async def get_taxonomy_tree(org_id: int, kb_slug: str, db: AsyncSession) -> list[TaxonomyNode]`
+  - Returns the flat list `(id, name, parent_id, depth)` for the LLM to classify against.
+  - Cached in process for 60s per `(org_id, kb_slug)`.
+- The hook calls this BEFORE the LLM rewrite/classify call.
+
+**Hook integration**
+
+- In `deploy/litellm/klai_knowledge.py`, the existing pre-call hook:
+  1. Resolves accessible KBs (existing logic)
+  2. Fetches taxonomy tree (new) — falls back to empty tree on failure
+  3. Calls `_rewrite_and_classify` with tree (new)
+  4. Sets `retrieve_body["query"]` to rewritten query (existing, from SPEC-RAG-QUERY-REWRITE-001)
+  5. Sets `retrieve_body["taxonomy_node_ids"]` to classified IDs **iff** coverage >= threshold (new)
+- All steps are best-effort: each individual failure falls back to "no narrowing" without blocking retrieval.
+
+**Retrieval-api — filter wiring (already exists, needs verification)**
+
+- `_scope_filter()` in `klai-retrieval-api/retrieval_api/services/search.py` already supports `taxonomy_node_ids` as an optional Qdrant `must` filter.
+- Verify: when `taxonomy_node_ids` is non-empty, the filter is `payload.taxonomy_node_ids[ANY] in {requested_ids}` (intersection, not subset).
+- Add a unit test that asserts the filter is included when IDs are provided AND skipped when the list is empty.
+
+**Eval comparison**
+
+- Use SPEC-RAG-EVAL-001 harness with `RAG_EVAL_VARIANT=taxonomy_v1`.
+- Target on the `knowledge_org` suite (where categorised KBs live):
+  - ≥10% improvement in `context_precision`
+  - No regression > 5% in `context_recall`
+- The `chat` suite is expected to show neutral movement (most chat queries are personal-KB and untagged).
+
+### Out of scope
+
+- **Auto-generating the taxonomy tree.** Customers curate their own taxonomy via the existing portal UI. This SPEC consumes whatever tree is there.
+- **Re-classifying existing chunks.** Classification at ingest already runs on all new content. Backfill of legacy untagged content is a separate operator-triggered task (uses the existing `recompute_taxonomy_tags` Procrastinate task, not introduced here).
+- **Hierarchical filtering.** Initial implementation does flat-set membership. If the LLM classifies a parent node, children are NOT auto-included. Revisit if eval shows this is a frequent miss.
+- **Per-tenant tuning of the coverage threshold.** Use a global default; ops-tunable via env var; per-tenant only if a customer asks.
+- **Frontend display of "filtered by topic X".** The chat UI doesn't expose the classification step. Internal debug only via `retrieve_body["raw_query"]` + structured logs.
+
+## Acceptance Criteria (EARS)
+
+- **REQ-1**: WHEN the litellm pre-call hook runs AND the KB taxonomy coverage is ≥ `KLAI_TAXONOMY_COVERAGE_THRESHOLD`, the hook SHALL invoke `_rewrite_and_classify` and inject the resulting `taxonomy_node_ids` into `retrieve_body`.
+- **REQ-2**: WHEN coverage < threshold OR the LLM classify call returns `[]` OR fails, retrieval SHALL proceed WITHOUT a `taxonomy_node_ids` filter (no narrowing). The fallback SHALL emit a structured log event.
+- **REQ-3**: WHEN `taxonomy_node_ids` is present in `retrieve_body`, retrieval-api SHALL include a `payload.taxonomy_node_ids` ANY-of filter in the Qdrant query, in addition to the existing `org_id` + `kb_slug` filters. The org/kb scoping SHALL NEVER be weakened by this filter.
+- **REQ-4**: The classifier SHALL only return node IDs that exist in the fetched taxonomy tree for the KB in question. (Anti-hallucination guard; verified by a unit test asserting the rewriter does not invent node IDs not in the tree.)
+- **REQ-5**: Total added latency SHALL be < 100ms p95 ON TOP of SPEC-RAG-QUERY-REWRITE-001's added latency (i.e. the combined budget for both SPECs is < 600ms p95). Achieved by re-using a single LLM call for both rewrite + classify.
+- **REQ-6**: Total added per-query token cost SHALL be < 100 tokens ON TOP of SPEC-RAG-QUERY-REWRITE-001 (combined budget < 300 tokens).
+- **REQ-7**: Every classify invocation SHALL log a `taxonomy_classify` event with: `org_id`, `kb_slug`, `coverage_ratio`, `classified_node_ids`, `was_applied: bool`, `skip_reason: str | null`.
+- **REQ-8**: After deploy, RAGAS metrics with `variant=taxonomy_v1` on the `knowledge_org` suite SHALL show ≥10% improvement in `context_precision` AND no regression > 5% in `context_recall` vs baseline.
+
+## Open Questions (resolve in /plan)
+
+1. **Combine with SPEC-RAG-QUERY-REWRITE-001's call or two roundtrips?** Strongly prefer combine — same model, same context window, JSON-output supports both fields. Decided in plan-phase based on JSON reliability of klai-fast (Mistral small).
+2. **Coverage threshold default — 0.30 or 0.50?** 0.30 is permissive (only skip when KB is mostly untagged); 0.50 is conservative (skip if half-untagged). Default 0.30; revisit after eval data.
+3. **What about the `chat` (personal) KB?** Personal KBs typically have NO curated taxonomy. The coverage check naturally drops the filter, so the SPEC degrades to no-op. Confirm with a unit test that the personal-KB happy path is identical to baseline.
+4. **Filter mode — ANY-of (intersection) vs ALL-of (subset)?** A query classified to nodes `[5, 12]` retrieves chunks tagged with EITHER (`ANY`) or BOTH (`ALL`). Anthropic's pattern uses ANY because a query is rarely about all classified topics simultaneously. Default ANY.
+5. **Hierarchical expansion later?** If the LLM consistently classifies the parent node `Beleid` but chunks are tagged with the child `Verlofbeleid`, recall drops. Track in eval; fix in v2 by walking the tree at query-time if the issue is real.
+
+## Estimated effort
+
+3-4 days (assuming SPEC-RAG-QUERY-REWRITE-001 has shipped):
+
+- Day 1: Extend `_rewrite_query` to `_rewrite_and_classify` + JSON-output prompt + unit tests
+- Day 2: `taxonomy_lookup.py` + coverage helper + cache + integration into hook
+- Day 3: Verify retrieval-api filter wiring + add filter-applied/filter-skipped tests + deploy to staging
+- Day 4: Run eval harness with `variant=taxonomy_v1` on `knowledge_org` suite, tune coverage threshold, ship to production
+
+If SPEC-RAG-QUERY-REWRITE-001 has NOT shipped: add 2 days for the standalone `_classify_query` helper + integration. Better to ship rewrite-first.

--- a/docs/architecture/retrieval-improvements-roadmap.md
+++ b/docs/architecture/retrieval-improvements-roadmap.md
@@ -1,0 +1,119 @@
+# Knowledge Retrieval Improvements — Roadmap
+
+> Strategy doc for getting Klai's RAG stack from "industry-standard baseline" to "production-grade for paying customers".
+> Companion to [knowledge-retrieval-flow.md](knowledge-retrieval-flow.md), which describes what runs today.
+> Created 2026-05-04 after holistic review of current code + 2026 RAG best-practice research.
+
+---
+
+## Where we stand today
+
+The current retrieval stack is healthy. Building blocks that already exist on `main`:
+
+| Layer | Implementation | File |
+|---|---|---|
+| Embedding | BGE-M3 (dense + sparse + late-interaction in one model) | `klai-knowledge-ingest/knowledge_ingest/embeddings/` |
+| Reranker | Infinity (cross-encoder, GPU-01) | tunnelled via `gpu-tunnel-key` |
+| Vector store | Qdrant — 3-leg RRF (`vector_chunk` + `vector_questions` + `vector_sparse`) | `klai-retrieval-api/retrieval_api/services/search.py` |
+| Knowledge graph | Graphiti / FalkorDB — entity & relationship extraction | `klai-knowledge-ingest/knowledge_ingest/graph.py` |
+| Query injection | LiteLLM pre-call hook | `deploy/litellm/klai_knowledge.py` |
+| Tenant scoping | Per-org and per-KB filters at query time | `_scope_filter()` in `search.py` |
+| Web crawl enrichment | crawl4ai + anchor_texts + links_to (SPEC-CRAWLER-005) | `klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py` |
+| Taxonomy classification | Ingest-time tagging into `taxonomy_node_ids` payload | `taxonomy_classifier.py` |
+
+Compared to the typical "naive RAG" pipelines that fail at 72-80% of enterprise pilots, this is well above baseline. The architecture is the right shape for a multi-tenant SaaS — hybrid retrieval with reranker is the foundation that 2026 research consistently identifies as highest-ROI.
+
+## Where the gaps are
+
+Three operational gaps prevent the stack from being "good enough for paying customers":
+
+1. **No measurement.** There is no end-to-end retrieval-quality metric. Without RAGAS or an equivalent harness, every optimisation is anecdote-driven.
+2. **No query understanding.** The raw user query goes 1-on-1 to `retrieve_body["query"]`. Vague or under-specified questions produce vague matches. The litellm-hook misses a query-rewriting step.
+3. **Chunks not self-contained.** Anchor_texts and links_to provide some context for crawled pages, but most KB chunks are still naked text segments without enough surrounding context for embedding precision. Anthropic's contextual-retrieval pattern fixes this.
+
+A separate latent gap: **query-time taxonomy filtering is wired in retrieval-api but never invoked by the hook**. The classifier exists at ingest time only; query-time classify-call has no caller. SPEC-PORTAL-PROFILES-001's closed predecessor (PR #90) attempted this for the FROZEN klai-focus stack and never landed for Knowledge.
+
+## Why prioritise improvements before launch
+
+Three reasons:
+
+1. **Pre-launch is the cheapest moment.** Adding `chunk_context` to ingest now means re-embedding the (small) existing corpus once. Doing it after launch means coordinating with active customers.
+2. **Metrics before features.** Without RAGAS in place, week 4's question *"did parent-child chunking help?"* has no answer. Build the harness first, then optimise.
+3. **Industry-standard expectation.** Customers comparing Klai to alternatives (Glean, Perplexity Enterprise, Notion AI) have a baseline expectation that the answer relates to the question. Without query rewriting, edge-case queries will feel "dumber" than the competition.
+
+## The roadmap — three tiers
+
+Each tier has a dedicated SPEC. Tier 1 must land before launch; Tier 2 should land before significant customer growth; Tier 3 is conditional on what RAGAS metrics reveal.
+
+### Tier 1 — measure + low-complexity wins (target: pre-launch)
+
+| SPEC | Scope | Expected impact |
+|---|---|---|
+| [SPEC-RAG-EVAL-001](../../.moai/specs/SPEC-RAG-EVAL-001/spec.md) | Install RAGAS evaluation harness; nightly metrics on representative query set per KB type | Baseline visibility; precondition for Tier 2/3 |
+| [SPEC-RAG-CONTEXTUAL-001](../../.moai/specs/SPEC-RAG-CONTEXTUAL-001/spec.md) | Anthropic-pattern contextual retrieval — pre-pend chunk-specific summary before embedding | -49% retrieval-failure-rate (Anthropic published) |
+| [SPEC-RAG-QUERY-REWRITE-001](../../.moai/specs/SPEC-RAG-QUERY-REWRITE-001/spec.md) | LiteLLM-hook layer that rewrites/expands user queries via `klai-fast` before retrieve | +15-25% precision on vague queries |
+
+### Tier 2 — moderate complexity, after Tier 1 metrics confirm need
+
+| SPEC | Scope | Expected impact |
+|---|---|---|
+| [SPEC-RAG-PARENT-CHILD-001](../../.moai/specs/SPEC-RAG-PARENT-CHILD-001/spec.md) | Parent-child chunking: child for matching, parent for LLM context | Better matching precision + better context-window utilisation on long docs |
+| [SPEC-RAG-TAXONOMY-001](../../.moai/specs/SPEC-RAG-TAXONOMY-001/spec.md) | Wire query-time taxonomy classifier + retrieval filter + coverage fallback | Cleaner top-K on large categorised KBs (>1000 chunks) |
+
+### Tier 3 — only on data, not preemptively
+
+These are powerful but expensive — wait until RAGAS metrics show specific failure modes that match each technique's strength.
+
+| Idea | When to consider | Source |
+|---|---|---|
+| HyDE (Hypothetical Document Embeddings) | RAGAS shows low context-precision on short technical queries | [HyDE — Pondhouse](https://www.pondhouse-data.com/blog/advanced-rag-hypothetical-document-embeddings) |
+| GraphRAG community-summaries | Users ask cross-document synthesis questions ("what changed between Q1 and Q3 reports") | [Microsoft GraphRAG](https://microsoft.github.io/graphrag/) |
+| Agentic RAG with query decomposition | Complex multi-hop queries surface in production traces | [Agentic RAG Patterns 2026](https://www.digitalapplied.com/blog/agentic-rag-patterns-multi-step-reasoning-guide) |
+
+## Sequencing
+
+```
+Week 1   ─ SPEC-RAG-EVAL-001              (RAGAS harness)
+            └─ baseline metrics captured
+Week 2-3 ─ SPEC-RAG-CONTEXTUAL-001        (parallel work, no shared files)
+         ─ SPEC-RAG-QUERY-REWRITE-001
+            └─ measure delta vs baseline
+Week 4   ─ DECIDE on Tier 2 priority based on metrics:
+            • long-doc precision low? → SPEC-RAG-PARENT-CHILD-001 first
+            • large-KB ruis high?     → SPEC-RAG-TAXONOMY-001 first
+            • both fine?              → focus on launch, defer Tier 2
+```
+
+## Constraints we will not break
+
+- **Reranker stays.** The Infinity cross-encoder is the highest-ROI single component in the current stack. None of the improvements remove it.
+- **Per-tenant scoping stays at retrieval time.** Adding query rewriting or HyDE must not bypass the `_scope_filter()` that enforces `org_id`. Verified in every SPEC's acceptance criteria.
+- **No regression on cost.** Tier 1+2 collectively must add < 30% per-query token cost. Agentic RAG (Tier 3) is the budget exception, used only on opt-in flows.
+
+## How to measure success
+
+After Tier 1 lands, the published deltas should be measurable in RAGAS metrics:
+- Context precision: +10-25%
+- Faithfulness: stable or up (contextual retrieval reduces hallucination by giving the LLM cleaner context)
+- Latency p95: +200-500ms (acceptable; LiteLLM hook pre-call already adds ~300ms)
+- Token cost per query: +10-15% (mostly from query-rewriting pass)
+
+If RAGAS does NOT show movement after Tier 1, we have either a measurement bug or a lower ceiling on the current corpus than expected — both are useful signals before further investment.
+
+## Sources
+
+Research input that fed this roadmap (May 2026):
+
+- [Optimizing RAG with Hybrid Search & Reranking — Superlinked](https://superlinked.com/vectorhub/articles/optimizing-rag-with-hybrid-search-reranking)
+- [Contextual Retrieval — Anthropic](https://www.anthropic.com/news/contextual-retrieval)
+- [9 advanced RAG techniques — Meilisearch](https://www.meilisearch.com/blog/rag-techniques)
+- [RAG Production Guide 2026 — Lushbinary](https://lushbinary.com/blog/rag-retrieval-augmented-generation-production-guide/)
+- [Parent-child Retrieval — Dify](https://dify.ai/blog/introducing-parent-child-retrieval-for-enhanced-knowledge)
+- [Document Chunking 9 Strategies Tested — LangCopilot](https://langcopilot.com/posts/2025-10-11-document-chunking-for-rag-practical-guide)
+- [RAGAS metrics — official docs](https://docs.ragas.io/en/stable/concepts/metrics/available_metrics/)
+- [BGE-M3 documentation](https://bge-model.com/bge/bge_m3.html)
+- [Microsoft GraphRAG](https://microsoft.github.io/graphrag/)
+
+---
+
+**Status:** roadmap accepted 2026-05-04. SPECs in `.moai/specs/SPEC-RAG-*/` are open for implementation.


### PR DESCRIPTION
## Summary

Documents the RAG retrieval roadmap in `docs/architecture/retrieval-improvements-roadmap.md` and adds 5 EARS-format SPECs covering Tier 1 (pre-launch) and Tier 2 improvements.

The current klai RAG stack — BGE-M3 hybrid (dense + sparse + late-interaction) + Infinity reranker + Graphiti/FalkorDB + crawl4ai enrichment + per-tenant scoping — sits well above the "naive RAG" baseline that fails 72-80% of enterprise pilots. But three operational gaps prevent us from being "good enough for paying customers":

1. **No measurement.** Every optimisation is anecdote-driven without RAGAS.
2. **No query understanding.** Raw user query goes 1-on-1 to retrieval.
3. **Chunks not self-contained.** Precision-vs-context tradeoff unresolved.

## What's in this PR

**Roadmap** (`docs/architecture/retrieval-improvements-roadmap.md`)
- Where we stand today (what's already on `main`)
- Where the gaps are (3 operational + 1 latent)
- Three-tier roadmap with sequencing
- Constraints we won't break (reranker stays, scoping stays, cost ceiling)
- How we measure success (target deltas in RAGAS metrics)
- Sources from May 2026 research

**Tier 1 SPECs** (target: pre-launch)
- `SPEC-RAG-EVAL-001` — RAGAS evaluation harness (precondition for everything)
- `SPEC-RAG-CONTEXTUAL-001` — Anthropic-pattern chunk context (-49% retrieval-failure-rate per Anthropic's published benchmark)
- `SPEC-RAG-QUERY-REWRITE-001` — LiteLLM-hook query rewriter (+15-25% precision on vague queries)

**Tier 2 SPECs** (after Tier 1 metrics confirm need)
- `SPEC-RAG-PARENT-CHILD-001` — Small-for-matching, large-for-context chunking
- `SPEC-RAG-TAXONOMY-001` — Wire query-time taxonomy filter + coverage fallback (closes PR #90's intent for the Knowledge stack)

## Why ship Tier 1 now

- **Pre-launch is the cheapest moment.** Adding `chunk_context` means re-embedding the small existing corpus once. Post-launch this means coordinating with active customers.
- **Metrics before features.** Without RAGAS, week-4's question "did parent-child help?" has no answer. Build the harness first.
- **Industry-standard expectation.** Customers comparing klai to Glean / Perplexity Enterprise / Notion AI expect the answer to relate to the question. Without query rewriting, edge-case queries will feel "dumber" than the competition.

## What's explicitly NOT in this PR

- **Tier 3** (HyDE, GraphRAG community-summaries, Agentic RAG) — deferred until RAGAS metrics surface specific failure modes that match each technique's strength.
- **Implementation** — these are SPECs only. Each Tier 1/2 SPEC is implemented in its own follow-up PR after `/plan` resolves the open questions.

## Constraints all SPECs share

- Per-tenant `_scope_filter()` at retrieval time MUST NOT be weakened
- Reranker stays (highest-ROI single component in current stack)
- Tier 1+2 collectively must add < 30% per-query token cost
- Every Tier 2/3 SPEC requires `SPEC-RAG-EVAL-001` measurement before claiming impact

## Test plan

- [ ] PR review: confirm roadmap accurately reflects what's on `main` today (cross-check with `docs/architecture/knowledge-retrieval-flow.md`)
- [ ] PR review: confirm SPECs are EARS-format and have measurable acceptance criteria
- [ ] PR review: confirm SPEC-RAG-EVAL-001 is the precondition for the others
- [ ] After merge: `/plan SPEC-RAG-EVAL-001` to start Tier 1 sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)