### PR TITLE
feat(infra): SPEC-INFRA-AI-WORKFLOW-001 — mechanical guards for git/worktree hygiene

### DIFF
--- a/.claude/hooks/klai/git-no-stash.sh
+++ b/.claude/hooks/klai/git-no-stash.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# PreToolUse hook: block `git stash push` (and bare `git stash`).
+#
+# Stashes are silent backlog — they accumulate across sessions and
+# never get reviewed. The 2026-05-04 cleanup found 10 stashes with
+# WIP from branches that no longer exist.
+#
+# Alternative: WIP commit pattern (commit with WIP- prefix, switch
+# context, return, amend or interactive-rebase the WIP commit away).
+#
+# Exception: `git stash push -m "RESCUE-..."` is allowed (cleanup-time
+# rescue is a legitimate use, the prefix marks intent).
+#
+# Output: exit 2 + stderr message → CC interprets as block.
+# SPEC-INFRA-AI-WORKFLOW-001 REQ-3.
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+PY_BIN=""
+if command -v python3 >/dev/null 2>&1 && python3 -c "import sys" >/dev/null 2>&1; then
+    PY_BIN="python3"
+elif command -v python >/dev/null 2>&1 && python -c "import sys" >/dev/null 2>&1; then
+    PY_BIN="python"
+fi
+
+if [ -n "$PY_BIN" ]; then
+    COMMAND=$(echo "$INPUT" | "$PY_BIN" -c "
+import sys, json
+d = json.load(sys.stdin)
+print(d.get('tool_input', {}).get('command', ''))
+" 2>/dev/null || echo "")
+else
+    COMMAND=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+fi
+
+# Only check git stash creation commands.
+# `git stash list/show/pop/drop/apply` are read/safe — let them through.
+IS_STASH_PUSH=0
+if echo "$COMMAND" | grep -qE 'git[[:space:]]+stash[[:space:]]+push\b'; then
+    IS_STASH_PUSH=1
+fi
+# Bare `git stash` defaults to push.
+if echo "$COMMAND" | grep -qE 'git[[:space:]]+stash[[:space:]]*$'; then
+    IS_STASH_PUSH=1
+fi
+
+if [ "$IS_STASH_PUSH" -eq 0 ]; then
+    exit 0
+fi
+
+# Allow RESCUE-prefixed stashes.
+if echo "$COMMAND" | grep -qE -- '-m[[:space:]]+["'\'']?RESCUE-'; then
+    exit 0
+fi
+
+cat >&2 <<'EOF'
+BLOCKED: git stash push — stashes accumulate as silent backlog.
+
+The 2026-05-04 cleanup found 10 stashes with WIP from branches that
+no longer exist. None had been resolved.
+
+Alternative: commit-with-WIP-marker pattern.
+
+  git add -A
+  git commit -m "WIP: <what you were doing>" --no-verify
+  # ... switch context, do other work, come back ...
+  git checkout <your branch>
+  # ... finish the work ...
+  git commit --amend           # OR
+  git rebase -i HEAD~2         # to squash WIP away
+
+Why this is better than stash:
+  - WIP commit is visible in `git log` — you can't forget it.
+  - Survives branch switching without a stash-pop step.
+  - Survives `git worktree remove` of the original worktree.
+  - Clearly named so reviewers know it's intentional.
+
+Exception: `git stash push -m "RESCUE-..."` is allowed for cleanup ops.
+
+See SPEC-INFRA-AI-WORKFLOW-001 REQ-3.
+EOF
+exit 2

--- a/.claude/hooks/klai/pr-merge-teardown.sh
+++ b/.claude/hooks/klai/pr-merge-teardown.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# PostToolUse hook: after `gh pr merge`, surface the worktree-teardown
+# command if the current dir is a worktree (not the canonical repo).
+#
+# Why: `gh pr merge --delete-branch` from inside a worktree silently
+# fails its local-branch cleanup (worktree-bound branch can't be
+# deleted) and leaves the worktree on disk. After many PRs, you have
+# 33 dead worktrees. This hook surfaces the cleanup command in stdout.
+#
+# Does NOT auto-execute — surprise removals are bad. Just prints.
+#
+# SPEC-INFRA-AI-WORKFLOW-001 REQ-2.
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+PY_BIN=""
+if command -v python3 >/dev/null 2>&1 && python3 -c "import sys" >/dev/null 2>&1; then
+    PY_BIN="python3"
+elif command -v python >/dev/null 2>&1 && python -c "import sys" >/dev/null 2>&1; then
+    PY_BIN="python"
+fi
+
+if [ -n "$PY_BIN" ]; then
+    COMMAND=$(echo "$INPUT" | "$PY_BIN" -c "
+import sys, json
+d = json.load(sys.stdin)
+print(d.get('tool_input', {}).get('command', ''))
+" 2>/dev/null || echo "")
+else
+    COMMAND=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+fi
+
+# Only act on `gh pr merge` commands.
+if ! echo "$COMMAND" | grep -qE 'gh[[:space:]]+pr[[:space:]]+merge\b'; then
+    exit 0
+fi
+
+# Detect if PWD is a git worktree (and not the canonical repo).
+WT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+if [ -z "$WT_ROOT" ]; then
+    exit 0
+fi
+
+# Walk the worktree list and find the canonical repo (first entry).
+CANONICAL=$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {sub(/^worktree /, ""); print; exit}')
+if [ -z "$CANONICAL" ]; then
+    exit 0
+fi
+
+# Normalize paths for comparison (Windows backslash → forward slash, lowercase).
+norm() { echo "$1" | tr '\\' '/' | tr '[:upper:]' '[:lower:]'; }
+if [ "$(norm "$WT_ROOT")" = "$(norm "$CANONICAL")" ]; then
+    # We're in the canonical repo — no teardown needed.
+    exit 0
+fi
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "HEAD")
+
+cat <<EOF
+
+──────────────────────────────────────────────────────────────────
+[pr-merge-teardown] After this PR is confirmed MERGED, tear down the
+worktree to prevent accumulation:
+
+  cd "$CANONICAL"
+  git worktree remove --force "$WT_ROOT"
+  git branch -D "$CURRENT_BRANCH"
+
+Verify the merge first:
+  gh pr view <pr#> --json state,mergeCommit
+
+See SPEC-INFRA-AI-WORKFLOW-001 REQ-2.
+──────────────────────────────────────────────────────────────────
+
+EOF
+
+exit 0

--- a/.claude/hooks/klai/session-start-hygiene.sh
+++ b/.claude/hooks/klai/session-start-hygiene.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# SessionStart hook: hygiene audit. Warn if the local repo is
+# accumulating cruft.
+#
+# Thresholds (SPEC-INFRA-AI-WORKFLOW-001 REQ-4):
+#   - More than 5 worktrees besides the canonical repo
+#   - More than 3 local branches with `gone` upstream
+#   - More than 3 stashes that are NOT prefixed with RESCUE-
+#
+# Does NOT auto-clean — humans review and decide. Just prints the
+# audit + exact cleanup commands when thresholds are exceeded.
+
+set -euo pipefail
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+cd "$PROJECT_DIR" 2>/dev/null || exit 0
+
+# Skip if not a git repo.
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+    exit 0
+fi
+
+WT_COUNT=$(git worktree list 2>/dev/null | wc -l)
+WT_EXTRA=$((WT_COUNT - 1))  # subtract canonical repo
+
+GONE_COUNT=$(git branch -vv 2>/dev/null | grep -c ': gone\]' || true)
+
+STASH_COUNT=$(git stash list 2>/dev/null | grep -cv 'RESCUE-' || true)
+
+# Always-emit one-line summary.
+echo "[hygiene] worktrees=$WT_EXTRA  gone-branches=$GONE_COUNT  non-rescue-stashes=$STASH_COUNT"
+
+WARN=""
+if [ "$WT_EXTRA" -gt 5 ]; then
+    WARN="${WARN}  ⚠ $WT_EXTRA worktrees besides canonical repo (threshold 5)\n"
+    WARN="${WARN}    Audit:    git worktree list\n"
+    WARN="${WARN}    Cleanup:  see SPEC-INFRA-AI-WORKFLOW-001\n"
+fi
+if [ "$GONE_COUNT" -gt 3 ]; then
+    WARN="${WARN}  ⚠ $GONE_COUNT local branches with 'gone' upstream (threshold 3)\n"
+    WARN="${WARN}    Audit:    git branch -vv | grep ': gone]'\n"
+    WARN="${WARN}    Cleanup:  for b in \$(git branch -vv | grep ': gone]' | awk '{print \$1}'); do git branch -D \$b; done\n"
+fi
+if [ "$STASH_COUNT" -gt 3 ]; then
+    WARN="${WARN}  ⚠ $STASH_COUNT non-rescue stashes (threshold 3)\n"
+    WARN="${WARN}    Audit:    git stash list\n"
+    WARN="${WARN}    Each one: git stash show stash@{N} --stat\n"
+fi
+
+if [ -n "$WARN" ]; then
+    echo ""
+    echo "[hygiene] thresholds exceeded:"
+    printf "$WARN"
+    echo ""
+fi
+
+exit 0

--- a/.claude/hooks/klai/worktree-no-main.sh
+++ b/.claude/hooks/klai/worktree-no-main.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# PreToolUse hook: block `git worktree add <path> main`
+#
+# A worktree that checks out `main` in a non-canonical location forces
+# the canonical main repo into detached-HEAD whenever the user wants
+# to switch to main. This caused 33 worktrees of cross-worktree
+# friction in the 2026-05-04 cleanup. Block at source.
+#
+# Allowed: `git worktree add <path> -b <branch> main`
+#          (creates a NEW branch FROM main — main stays canonical)
+# Blocked: `git worktree add <path> main`
+#          `git worktree add <path> origin/main`
+#          `git worktree add <path> refs/heads/main`
+#
+# Output: exit 2 + stderr message → CC interprets as block.
+# SPEC-INFRA-AI-WORKFLOW-001 REQ-1.
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+PY_BIN=""
+if command -v python3 >/dev/null 2>&1 && python3 -c "import sys" >/dev/null 2>&1; then
+    PY_BIN="python3"
+elif command -v python >/dev/null 2>&1 && python -c "import sys" >/dev/null 2>&1; then
+    PY_BIN="python"
+fi
+
+if [ -n "$PY_BIN" ]; then
+    COMMAND=$(echo "$INPUT" | "$PY_BIN" -c "
+import sys, json
+d = json.load(sys.stdin)
+print(d.get('tool_input', {}).get('command', ''))
+" 2>/dev/null || echo "")
+else
+    COMMAND=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+fi
+
+# Only check git worktree add commands.
+if ! echo "$COMMAND" | grep -qE 'git[[:space:]]+worktree[[:space:]]+add[[:space:]]'; then
+    exit 0
+fi
+
+# Allow `-b <branch> [<base>]` form — that creates a new branch FROM the base.
+if echo "$COMMAND" | grep -qE 'git[[:space:]]+worktree[[:space:]]+add[[:space:]].*[[:space:]]-b[[:space:]]'; then
+    exit 0
+fi
+
+# Block dangerous patterns:
+BLOCKED=""
+if echo "$COMMAND" | grep -qE 'git[[:space:]]+worktree[[:space:]]+add[[:space:]].*[[:space:]](origin/)?main([[:space:]]|$)'; then
+    BLOCKED="git worktree add ... main"
+fi
+if echo "$COMMAND" | grep -qE 'git[[:space:]]+worktree[[:space:]]+add[[:space:]].*refs/heads/main'; then
+    BLOCKED="git worktree add ... refs/heads/main"
+fi
+
+if [ -n "$BLOCKED" ]; then
+    cat >&2 <<EOF
+BLOCKED: $BLOCKED — would claim 'main' in a non-canonical location.
+
+A worktree on main forces the canonical repo into detached-HEAD when
+you switch to main. This is the friction that caused the 2026-05-04
+cleanup mess (33 worktrees of cross-collision).
+
+Use one of these instead:
+  git worktree add <path> -b feature/<task> origin/main
+  git worktree add <path> -b fix/<task> origin/main
+
+If you genuinely need a read-only main snapshot:
+  git worktree add --detach <path> origin/main
+
+See SPEC-INFRA-AI-WORKFLOW-001 REQ-1.
+EOF
+    exit 2
+fi
+
+exit 0

--- a/.claude/rules/klai/pitfalls/process-rules.md
+++ b/.claude/rules/klai/pitfalls/process-rules.md
@@ -259,6 +259,59 @@ the risk — the mess ships as-is.
 See `.claude/rules/moai/workflow/worktree-integration.md` for the decision
 tree and `worktree add` flags.
 
+## worktree-teardown-after-merge (HIGH)
+After `gh pr merge --delete-branch` from inside a worktree, the LOCAL-side
+cleanup step (`git checkout main && git branch -D <feature>`) silently
+fails because:
+
+1. `git checkout main` errors with "main is already used by worktree at..."
+   if any other worktree (including a stale `klai-kb-sources` mirror) has
+   `main` checked out.
+2. Even when main IS available locally, `git branch -D <feature>` errors
+   with "cannot delete branch <X> used by worktree at <path>" — the
+   worktree IS the thing using it.
+
+`gh` reports the failure but the merge ITSELF succeeded on GitHub. The
+worktree directory stays on disk, the local branch stays in
+`git branch`, and over many PRs you accumulate dead worktrees.
+
+**The 2026-05-04 incident:** the canonical klai repo had 39 worktrees
+on disk (40 including main repo), 30 stale local branches with `gone`
+upstream, and 10 stashes — almost all from this exact failure mode
+across many sessions. The `klai-kb-sources` worktree had quietly been
+holding `main` for weeks, forcing every `git switch main` attempt into
+detached-HEAD as a workaround, which spawned more workarounds.
+
+**Prevention (mechanical, SPEC-INFRA-AI-WORKFLOW-001):**
+
+- `.claude/hooks/klai/pr-merge-teardown.sh` runs PostToolUse on
+  `gh pr merge`. If PWD is a worktree (not canonical repo), it prints
+  the exact teardown command: `git worktree remove --force <path> &&
+  git branch -D <branch>`. Does NOT auto-execute — surfaces the next
+  step so the next assistant turn (or human) sees and runs it.
+- `.claude/hooks/klai/worktree-no-main.sh` runs PreToolUse on
+  `git worktree add`. Refuses any form that checks out `main` in a
+  non-canonical location. Suggests `-b feature/<task> origin/main`
+  instead. This stops the kb-sources class of incident.
+- `.claude/hooks/klai/session-start-hygiene.sh` runs SessionStart and
+  warns if worktree count, gone-branch count, or non-rescue-stash
+  count exceed thresholds. Does NOT auto-clean.
+
+**Recovery for an existing collision (manual):**
+
+1. `git worktree list` to see who's holding main.
+2. If a non-canonical worktree (e.g. `klai-kb-sources`) has main and
+   you don't need it: `git worktree remove --force <path>`.
+3. Back in canonical repo: `git switch main` should now work.
+4. `git branch -vv | grep ': gone\]' | awk '{print $1}' | xargs -r
+   git branch -D` to prune stale local branches.
+
+**Windows-specific:** locked agent worktrees (`.claude/worktrees/agent-*`)
+may need `git worktree unlock <path>` before `git worktree remove`. The
+`bezmaw3bz` background command on 2026-05-04 hung on locked worktrees;
+the fix is to unlock first or use `--force` synchronously rather than
+running 30+ removes in a single bash chain.
+
 ## validator-env-parity (HIGH)
 When a pydantic `@model_validator` is added that REJECTS an empty /
 whitespace-only env var at app startup, verify the env var already exists

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,6 +21,14 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/klai/container-hygiene-preflight.sh\""
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/klai/worktree-no-main.sh\""
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/klai/git-no-stash.sh\""
           }
         ]
       }
@@ -32,6 +40,20 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/klai/post-push-ci.sh\""
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/klai/pr-merge-teardown.sh\""
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/klai/session-start-hygiene.sh\""
           }
         ]
       }

--- a/.moai/specs/SPEC-INFRA-AI-WORKFLOW-001/spec.md
+++ b/.moai/specs/SPEC-INFRA-AI-WORKFLOW-001/spec.md
@@ -1,0 +1,120 @@
+# SPEC-INFRA-AI-WORKFLOW-001 — AI workflow hygiene mechanical guards
+
+**Status:** draft
+**Created:** 2026-05-04
+**Type:** infrastructure / tooling
+
+## Why this exists
+
+A multi-AI-coding-session workflow on this repo accumulates entropy faster
+than humans can clean it up:
+
+- 39 worktrees on disk, only 5 active. Net result: ~34 worktrees of
+  long-merged or abandoned work, blocking the canonical main checkout
+  via cross-worktree main-collision.
+- 30+ stale local branches with `gone` upstream — never auto-pruned.
+- 10 stashes accumulated across sessions. Most contain WIP from abandoned
+  branches; some are dirty work that was stashed during context-switches
+  and never resolved.
+- Submodule pointers drift per session (`m klai-private` `m klai-website`)
+  because each session bumps them independently.
+
+The 2026-05-02 librechat-voys incident (SPEC-INFRA-CONTAINER-HYGIENE-001)
+established the principle: **mechanical guards, not markdown rules**.
+This SPEC applies the same principle to git workflow: an AI agent does
+the primary git work, so the hygiene rules MUST be enforced in code, not
+documented as "agents should remember to".
+
+## Requirements
+
+### REQ-1 [HARD] No worktree-add on `main`
+
+A `git worktree add <path> main` (or any flag-form that ends up checking
+out main in a non-canonical location) MUST be blocked at PreToolUse. A
+worktree on main forces the canonical main repo into detached-HEAD
+whenever the user wants to switch to main, creating exactly the friction
+that caused the cleanup mess.
+
+Allowed: `git worktree add <path> -b feature/X main` (creates a NEW
+branch FROM main; main itself stays in canonical repo).
+
+### REQ-2 [HARD] Auto-teardown after PR merge
+
+After a successful `gh pr merge ...`, if the current working directory
+is a worktree (not the canonical repo), PostToolUse MUST:
+
+1. Detect the worktree's path.
+2. Print a clear "this worktree is now dead, run X to remove" hint with
+   the exact `git worktree remove --force <path>` command.
+
+The hook MUST NOT auto-execute the removal — that would surprise users
+who are still poking around. The hook MUST surface the next step
+clearly, so agents and humans both see it.
+
+### REQ-3 [SHOULD] Block `git stash push` in agent sessions
+
+Stashes are silent backlog. PreToolUse on `git stash push` MUST:
+
+1. Block the command.
+2. Suggest the alternative: commit with a `WIP-` prefix in the current
+   branch, switch context, return, then amend or interactive-rebase the
+   WIP commit away.
+
+Exception: `git stash push -m "RESCUE-..."` is allowed (cleanup-time
+rescue is a legitimate use).
+
+### REQ-4 [SHOULD] SessionStart hygiene audit
+
+On every Claude Code SessionStart, run a hygiene audit and warn if any
+of these thresholds are exceeded:
+
+- More than 5 worktrees besides the canonical repo
+- More than 3 local branches with `gone` upstream
+- More than 3 stashes that are NOT prefixed with `RESCUE-`
+
+The warning MUST suggest the cleanup commands (one-liner per threshold
+exceeded). It MUST NOT auto-clean — humans review and decide.
+
+### REQ-5 [HARD] Pitfall documentation
+
+A new pitfall `worktree-teardown-after-merge` MUST be added to
+`.claude/rules/klai/pitfalls/process-rules.md` documenting:
+
+- The failure mode: `gh pr merge --delete-branch` from inside a worktree
+  fails its local-branch cleanup step silently when run from the worktree
+  itself, leaving the worktree on disk forever.
+- The Windows-specific edge case: `git worktree remove --force` may hang
+  on locked agent worktrees if file handles are still open in the dir.
+- The recovery path: detach-HEAD trick to free a branch from the
+  canonical repo when a worktree claims `main`.
+
+## Out of scope
+
+- Refactoring existing worktrees (one-off cleanup, not a recurring
+  problem once these guards are live).
+- Per-session locking semantics (file-level conflicts between parallel
+  AI sessions). Belongs in a follow-up SPEC.
+- Submodule pointer discipline. Mentioned in the workflow advice but
+  not enforced by this SPEC's hooks.
+
+## Acceptance criteria
+
+- AC-1: `git worktree add /tmp/x main` is blocked by the PreToolUse hook
+  with a clear "use `-b feature/X` to branch FROM main instead" message.
+- AC-2: After `gh pr merge 999 --admin --squash --delete-branch` from
+  inside a worktree, PostToolUse prints the exact `git worktree remove
+  --force <path>` command for the current worktree.
+- AC-3: `git stash push` (without `RESCUE-` message) is blocked with a
+  suggestion for the WIP-commit alternative.
+- AC-4: SessionStart prints a hygiene-audit summary; thresholds exceeded
+  trigger a warning with cleanup commands.
+- AC-5: `.claude/rules/klai/pitfalls/process-rules.md` contains the
+  `worktree-teardown-after-merge` pitfall.
+
+## Verification
+
+Each hook is a standalone bash script with deterministic input/output.
+Test by piping mock JSON inputs to each hook and asserting the
+`decision`/`reason` JSON output matches expectations. No CI changes
+needed — hooks live in `.claude/hooks/klai/` and are loaded by Claude
+Code's session runtime.


### PR DESCRIPTION
## Why

2026-05-04 cleanup found:
- 39 worktrees on disk (only 5 active)
- 30 local branches with `gone` upstream
- 10 stashes from abandoned branches
- `klai-kb-sources` quietly holding `main`, forcing detached-HEAD on every `git switch main`

Cause: an AI does the primary git work. Markdown rules ("agents should remember to clean up") don't survive context-truncations and parallel sessions. Per SPEC-INFRA-CONTAINER-HYGIENE-001 lesson: **mechanical guards, not narratives.**

## What

Five mechanical guards (4 hooks + 1 pitfall):

| Guard | Type | What it does |
|---|---|---|
| `worktree-no-main.sh` | PreToolUse | Refuses `git worktree add ... main`. Allows `-b feature/X main` (branch FROM main). |
| `pr-merge-teardown.sh` | PostToolUse | After `gh pr merge` from a worktree, prints exact `git worktree remove --force ... && git branch -D ...`. Does NOT auto-execute. |
| `git-no-stash.sh` | PreToolUse | Blocks `git stash push`. Allows `RESCUE-` prefix. Suggests WIP-commit pattern. |
| `session-start-hygiene.sh` | SessionStart | Audits worktree/gone-branch/stash counts. Warns above thresholds (5/3/3). Prints cleanup commands. |
| `worktree-teardown-after-merge` pitfall | Doc | New entry in `process-rules.md` documenting failure mode + Windows-specific edge cases + recovery path. |

## Verified locally

```
TEST 1: worktree-no-main BLOCKED on `add /tmp/x main` → exit 2 + clear msg ✓
TEST 2: worktree-no-main ALLOWED on `add /tmp/x -b feature/foo origin/main` ✓
TEST 3: git-no-stash BLOCKED on `stash push -u -m foo` → exit 2 ✓
TEST 4: git-no-stash ALLOWED on RESCUE- prefix and stash list ✓
TEST 5: pr-merge-teardown prints exact cleanup commands when in worktree ✓
TEST 6: session-start-hygiene correctly detects 9 worktrees + 18 stashes ✓
```

## Compatibility

All hooks use python3 → python → sed parser fallback (same pattern as existing klai hooks like `container-hygiene-preflight.sh`). Block decisions via stderr + exit 2 — no python-output dependency. Tested on Windows Git Bash where python3 is unavailable.

## Out of scope

- Per-session locking (file-level conflicts between parallel AI sessions) — follow-up SPEC.
- Submodule pointer discipline — mentioned in workflow advice but not enforced.
- Auto-cleanup of existing rommel — already done manually as part of 2026-05-04 cleanup.

See `.moai/specs/SPEC-INFRA-AI-WORKFLOW-001/spec.md` for EARS requirements + acceptance criteria.