### PR TITLE
fix(connector): fail-loud validator on CONNECTOR_ENCRYPTION_KEY

### DIFF
--- a/.claude/rules/klai/pitfalls/process-rules.md
+++ b/.claude/rules/klai/pitfalls/process-rules.md
@@ -887,6 +887,44 @@ Reference: SPEC-SEC-INTERNAL-001 connector empty-secret bypass; klai-portal/back
 
 **Prevention:** Outbound HTTP clients MUST refuse to construct the request if the credential is falsy. Raise at construction, never silently send.
 
+## empty-encryption-key-mid-lifespan-crash (HIGH)
+When a service uses a base64-encoded AES / Fernet / KEK env var that is consumed via `cipher = AESGCM(base64.b64decode(settings.encryption_key))` (or equivalent) during FastAPI lifespan, an empty / missing / invalid env var crashes mid-lifespan with a cryptic `ValueError: AES-256 requires a 32-byte key, got 0 bytes`. The container restart-loops, ops sees a stack trace deep inside cryptography internals, and the actual misconfiguration is invisible.
+
+Reference: 2026-05-04 incident on klai-connector. `CONNECTOR_ENCRYPTION_KEY` was declared in `deploy/docker-compose.yml` as `${CONNECTOR_ENCRYPTION_KEY}` but was never added to `klai-infra/core-01/.env.sops`. Compose interpolation passed empty string through, pydantic-settings happily stored `""`, and `AESGCMCipher(base64.b64decode(""))` crashed at `cipher = AESGCM(b"")`.
+
+**Prevention:**
+
+1. **Pydantic validator on every encryption-key field**, mirroring the `_require_*_secret` patterns in `klai-mailer/app/config.py` and `klai-connector/app/core/config.py`:
+   ```python
+   @field_validator("encryption_key", mode="after")
+   @classmethod
+   def _require_valid_encryption_key(cls, v: str) -> str:
+       if not v or not v.strip():
+           raise ValueError("CONNECTOR_ENCRYPTION_KEY must be non-empty base64 …")
+       try:
+           decoded = base64.b64decode(v, validate=True)
+       except Exception as exc:
+           raise ValueError(f"… valid base64. {exc!s}") from exc
+       if len(decoded) != EXPECTED_KEY_LEN:  # 32 for AES-256, 32 for Fernet
+           raise ValueError(f"… exactly {EXPECTED_KEY_LEN} bytes, got {len(decoded)}")
+       return v
+   ```
+   Validator runs at module-load (Settings init) — fails BEFORE the FastAPI lifespan, so the error surface is "ValidationError on Settings load" with an actionable message, not a mid-lifespan crash.
+
+2. **Test the validator** with: empty string, whitespace-only, invalid base64, decoded-too-short, decoded-too-long, missing-env. See `klai-connector/tests/test_encryption_key_validator.py` for a worked example.
+
+3. **VALIDATOR-ENV-PARITY applies**: before landing the validator, verify the env var exists in `klai-infra/core-01/.env.sops`. Without env-parity, the validator-bearing release crash-loops on every deploy. See validator-env-parity (HIGH) above.
+
+4. **Audit checklist** when adding a new encryption / KEK field to a service config:
+   - Field declared in `app/core/config.py` Settings? ✓
+   - Field interpolated in `deploy/docker-compose.yml` environment block? ✓
+   - Env var present in `klai-infra/core-01/.env.sops`? ✓
+   - `@field_validator(mode="after")` rejects empty + invalid format? ✓
+   - Test file covers all reject paths? ✓
+   - Test for valid 32-byte (or whatever-length) round-trip? ✓
+
+   All six required. Missing any = future restart-loop incident.
+
 ## non-constant-time-secret-compare (HIGH)
 `==` and `!=` short-circuit on the first non-matching byte. Comparing user-supplied tokens / signatures / secrets with these operators leaks length and content via timing. The leak is exploitable across the LAN; on a same-host attacker (think compromised sidecar), a few thousand probes recovers the secret byte-by-byte.
 

--- a/klai-connector/app/core/config.py
+++ b/klai-connector/app/core/config.py
@@ -110,6 +110,42 @@ class Settings(BaseSettings):
         return v
 
     # ------------------------------------------------------------------
+    # Fail-closed startup on the AES-256 KEK used by PostgresSecretsStore.
+    # Without this validator, an empty/missing CONNECTOR_ENCRYPTION_KEY
+    # crashes mid-lifespan with `AES-256 requires a 32-byte key, got 0
+    # bytes` and the container restart-loops with a cryptic trace. The
+    # validator surfaces the same misconfiguration at module-load time
+    # with an actionable error.
+    #
+    # VALIDATOR-ENV-PARITY: CONNECTOR_ENCRYPTION_KEY must exist in
+    # klai-infra/core-01/.env.sops before this code is deployed. Deploy
+    # order is env-var-first, validator-second. See validator-env-parity
+    # (HIGH) pitfall in .claude/rules/klai/pitfalls/process-rules.md.
+    # ------------------------------------------------------------------
+    @field_validator("encryption_key", mode="after")
+    @classmethod
+    def _require_valid_encryption_key(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError(
+                "CONNECTOR_ENCRYPTION_KEY must be a non-empty base64-encoded "
+                "32-byte AES-256 key. PostgresSecretsStore uses this as the "
+                "KEK for connector credential storage; an empty value would "
+                "crash the lifespan with a 0-byte cipher key."
+            )
+        try:
+            decoded = base64.b64decode(v, validate=True)
+        except Exception as exc:
+            raise ValueError(f"CONNECTOR_ENCRYPTION_KEY must be valid base64. Decode failed: {exc!s}.") from exc
+        if len(decoded) != 32:
+            raise ValueError(
+                "CONNECTOR_ENCRYPTION_KEY must decode to exactly 32 bytes "
+                f"(AES-256). Got {len(decoded)} bytes after base64 decode. "
+                "Generate a valid key with: python -c 'import secrets, base64; "
+                "print(base64.b64encode(secrets.token_bytes(32)).decode())'"
+            )
+        return v
+
+    # ------------------------------------------------------------------
     # SPEC-SEC-INTERNAL-001 REQ-9.3: fail-closed startup on empty outbound
     # secrets. Mirrors the SPEC-SEC-MAILER-INJECTION-001 mailer validators.
     # An ALLOW_EMPTY_OUTBOUND_SECRETS escape hatch (REQ-9.3 exception) is NOT

--- a/klai-connector/tests/test_audit_2026_04_b2.py
+++ b/klai-connector/tests/test_audit_2026_04_b2.py
@@ -44,7 +44,9 @@ _VALID_SETTINGS_KWARGS: dict[str, str] = {
     "zitadel_client_secret": "test-zitadel-secret-12345",
     "github_app_id": "12345",
     "github_app_private_key": _DUMMY_GITHUB_KEY,
-    "encryption_key": "0" * 64,
+    # Base64 of 32 zero bytes -- valid AES-256 KEK shape required by the
+    # encryption_key validator added 2026-05-04.
+    "encryption_key": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
     "knowledge_ingest_url": "http://knowledge-ingest:8000",
     "knowledge_ingest_secret": "test-ingest-secret-12345",
     "portal_internal_secret": "test-portal-secret-12345",

--- a/klai-connector/tests/test_encryption_key_validator.py
+++ b/klai-connector/tests/test_encryption_key_validator.py
@@ -1,0 +1,135 @@
+"""Acceptance tests: klai-connector encryption_key validator.
+
+Without this validator, an empty/missing CONNECTOR_ENCRYPTION_KEY env var
+crashes deep in the FastAPI lifespan with `AES-256 requires a 32-byte key,
+got 0 bytes`, putting the container into a restart loop with a cryptic
+trace. The validator surfaces the same misconfiguration at module-load
+time with an actionable error.
+
+Real incident: 2026-05-04. The env var was never declared in
+klai-infra/core-01/.env.sops; the connector was crash-looping for hours
+before SPEC-PORTAL-RBAC-001 deploy made it visible. After the env-var
+add + this validator, the same fail-mode raises ValidationError before
+any of the lifespan code runs.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+from collections.abc import Iterator
+
+import pytest
+from pydantic import ValidationError
+
+
+@pytest.fixture
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Set all OTHER required env vars so only encryption_key drives the test outcome."""
+    valid_secret = "valid-non-empty-secret-string"
+    monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://klai:pw@localhost:5432/klai")
+    monkeypatch.setenv("ZITADEL_INTROSPECTION_URL", "https://auth.example.com/introspect")
+    monkeypatch.setenv("ZITADEL_CLIENT_ID", "klai-connector")
+    monkeypatch.setenv("ZITADEL_CLIENT_SECRET", valid_secret)
+    monkeypatch.setenv("ZITADEL_API_AUDIENCE", "klai-connector-app")
+    monkeypatch.setenv("GITHUB_APP_ID", "12345")
+    monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY", "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----")
+    monkeypatch.setenv("KNOWLEDGE_INGEST_URL", "http://knowledge-ingest:8000")
+    monkeypatch.setenv("KNOWLEDGE_INGEST_SECRET", valid_secret)
+    monkeypatch.setenv("PORTAL_INTERNAL_SECRET", valid_secret)
+    yield
+
+
+def _import_settings_class():
+    """Import Settings via importlib so each test sees a fresh validator pass."""
+    import importlib
+
+    import app.core.config as config_module
+
+    importlib.reload(config_module)
+    return config_module.Settings  # noqa: N806 (returning class)
+
+
+def test_valid_32byte_key_accepted(_required_settings_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    valid_key = base64.b64encode(b"\x00" * 32).decode()
+    monkeypatch.setenv("ENCRYPTION_KEY", valid_key)
+    settings_cls = _import_settings_class()
+    s = settings_cls()
+    assert s.encryption_key == valid_key
+
+
+def test_empty_key_rejected_with_actionable_message(
+    _required_settings_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ENCRYPTION_KEY", "")
+    settings_cls = _import_settings_class()
+    with pytest.raises(ValidationError) as exc_info:
+        settings_cls()
+    msg = str(exc_info.value)
+    assert "CONNECTOR_ENCRYPTION_KEY" in msg
+    assert "32-byte" in msg
+
+
+def test_whitespace_only_key_rejected(_required_settings_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ENCRYPTION_KEY", "   ")
+    settings_cls = _import_settings_class()
+    with pytest.raises(ValidationError):
+        settings_cls()
+
+
+def test_invalid_base64_rejected(_required_settings_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ENCRYPTION_KEY", "this-is-not-valid-base64!!!@@@")
+    settings_cls = _import_settings_class()
+    with pytest.raises(ValidationError) as exc_info:
+        settings_cls()
+    assert "valid base64" in str(exc_info.value)
+
+
+def test_short_key_rejected(_required_settings_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Base64-decodes to 16 bytes -- valid base64, wrong length for AES-256."""
+    short_key = base64.b64encode(b"\x00" * 16).decode()
+    monkeypatch.setenv("ENCRYPTION_KEY", short_key)
+    settings_cls = _import_settings_class()
+    with pytest.raises(ValidationError) as exc_info:
+        settings_cls()
+    msg = str(exc_info.value)
+    assert "32 bytes" in msg
+    assert "Got 16 bytes" in msg
+
+
+def test_too_long_key_rejected(_required_settings_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Base64-decodes to 64 bytes -- valid base64, wrong length for AES-256."""
+    long_key = base64.b64encode(b"\x00" * 64).decode()
+    monkeypatch.setenv("ENCRYPTION_KEY", long_key)
+    settings_cls = _import_settings_class()
+    with pytest.raises(ValidationError) as exc_info:
+        settings_cls()
+    assert "Got 64 bytes" in str(exc_info.value)
+
+
+def test_error_message_includes_generation_command(
+    _required_settings_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The error message tells the operator how to generate a valid key."""
+    monkeypatch.setenv("ENCRYPTION_KEY", base64.b64encode(b"\x00" * 16).decode())
+    settings_cls = _import_settings_class()
+    with pytest.raises(ValidationError) as exc_info:
+        settings_cls()
+    msg = str(exc_info.value)
+    assert "secrets.token_bytes(32)" in msg
+
+
+def test_missing_env_var_rejected(_required_settings_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    """ENCRYPTION_KEY entirely absent triggers the missing-required pydantic error."""
+    monkeypatch.delenv("ENCRYPTION_KEY", raising=False)
+    settings_cls = _import_settings_class()
+    with pytest.raises(ValidationError):
+        settings_cls()
+
+
+# Sanity check: don't accidentally pollute other tests' env state.
+def test_env_state_clean_after_module(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Conservative: monkeypatch undoes everything via fixture teardown.
+    # This test ensures the suite doesn't leak any of the env vars set
+    # in the fixture above by depending on them being absent here.
+    assert os.environ.get("ENCRYPTION_KEY") is None or os.environ.get("ENCRYPTION_KEY") != ""

--- a/klai-connector/tests/test_sec_internal_001.py
+++ b/klai-connector/tests/test_sec_internal_001.py
@@ -19,7 +19,9 @@ _VALID_SETTINGS_KWARGS: dict[str, str] = {
     "zitadel_client_secret": "test-zitadel-secret-12345",
     "github_app_id": "12345",
     "github_app_private_key": "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----",
-    "encryption_key": "0" * 64,
+    # Base64 of 32 zero bytes -- valid AES-256 KEK shape required by the
+    # encryption_key validator added 2026-05-04.
+    "encryption_key": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
     "knowledge_ingest_url": "http://knowledge-ingest:8000",
     # The two fields under test default to "" and require fail-closed validators.
     "knowledge_ingest_secret": "test-ingest-secret-12345",


### PR DESCRIPTION
**Phase 2** follow-up to the 2026-05-04 connector outage. Phase 1 (env var add to SOPS + fresh key generation) is already live and restored the service. This PR ensures the same fail-mode cannot recur with a cryptic mid-lifespan trace.

## Changes

- New `@field_validator(mode='after')` on `encryption_key` in [klai-connector/app/core/config.py](klai-connector/app/core/config.py): rejects empty / whitespace / invalid-base64 / wrong-length at module-load.
- 9 new tests in `tests/test_encryption_key_validator.py` covering all reject paths + valid round-trip + missing-env case.
- Updated test fixtures in `test_audit_2026_04_b2.py` and `test_sec_internal_001.py` to use a base64-encoded 32-byte key (was `'0' * 64` which decodes to 48 bytes).
- New `empty-encryption-key-mid-lifespan-crash (HIGH)` pitfall in process-rules.md with a six-item audit checklist for every future KEK env var.

## Why

PostgresSecretsStore consumes `base64.b64decode(settings.encryption_key)` during FastAPI lifespan. Empty / missing → `AES-256 requires a 32-byte key, got 0 bytes` with a stack trace deep inside cryptography internals. Container restart-loops; ops sees a cryptic crash and the actual misconfiguration is invisible. After this PR: pydantic's ValidationError surfaces at module-load with an actionable message including a key-generation command.

## Pattern source

Mirrors the existing `_require_knowledge_ingest_secret` and `_require_portal_internal_secret` validators (SPEC-SEC-INTERNAL-001 REQ-9.3) and the `_require_webhook_secret` validators in klai-mailer (SPEC-SEC-MAILER-INJECTION-001).

## Audit-only follow-ups (NOT in this PR)

- `zitadel_client_secret` — no validator. Same fail-mode if empty. Deferred.
- `github_app_private_key` — has format validator but no non-empty validator. Deferred.

## Risk

- VALIDATOR-ENV-PARITY: `CONNECTOR_ENCRYPTION_KEY` is already in SOPS as of klai-infra commit `3ef03dc`. Validator-bearing release will not crash-loop on deploy.
- Pre-existing test failures on main (`test_e2e_image_pipeline`, `test_sync_engine_images`) are unrelated to this PR. Verified via stash round-trip.

## Refs

- Phase 1: klai-infra commit `3ef03dc` (CONNECTOR_ENCRYPTION_KEY added to SOPS).
- Pitfall: `.claude/rules/klai/pitfalls/process-rules.md` § `empty-encryption-key-mid-lifespan-crash`.