### PR TITLE
fix(portal): invalidate current-user cache on add-on toggle save

### DIFF
--- a/klai-portal/frontend/src/routes/admin/settings.tsx
+++ b/klai-portal/frontend/src/routes/admin/settings.tsx
@@ -97,10 +97,17 @@ function AdminSettingsPage() {
       }),
     onSuccess: (_data, next) => {
       adminLogger.info('Add-ons updated', { enabled_addons: next })
-      // SPEC-PORTAL-RBAC-001 REQ-12: keep React Query cache in sync with the
-      // saved state so addonsDirty flips back to false and the Save button
-      // disables straight away.
+      // SPEC-PORTAL-RBAC-001 REQ-12: keep the addons-list cache in sync with
+      // the saved state so addonsDirty flips back to false and the Save
+      // button disables straight away.
       queryClient.setQueryData(['admin-enabled-addons'], { enabled_addons: next })
+      // The sidebar in /app reads `user.products` from useCurrentUser()
+      // (queryKey ['current-user']). user.products is derived server-side
+      // from (role, plan, enabled_addons), so flipping an add-on toggle
+      // invalidates that view too. Without this, /app keeps the stale
+      // products list until the next hard refresh and the toggled-off
+      // add-on lingers in the sidebar.
+      void queryClient.invalidateQueries({ queryKey: ['current-user'] })
       setSavedAddons(true)
       setTimeout(() => setSavedAddons(false), 2500)
     },


### PR DESCRIPTION
## Summary

Toggling Scribe / Docs off on `/admin/settings` did not remove the item from the `/app` sidebar until a hard refresh. Mark reproduced this on Voys.

## Root cause

The Save handler on `/admin/settings` already updates the `['admin-enabled-addons']` query cache so the Save button disables correctly (PR #300, REQ-12). But the **sidebar** in `/app` reads `user.products` from `useCurrentUser` which has `queryKey: ['current-user']` -- a separate cache. Backend returns the right list on the next `/api/me` call (server-side derivation works), but the client cache stays stale.

## Fix

One `invalidateQueries({ queryKey: ['current-user'] })` in `addonsMutation.onSuccess`. Next render of `/app` refetches `/api/me`, sidebar settles.

## Test plan

- [x] Code review — addonsMutation.onSuccess invalidates both caches.
- [ ] Post-deploy on `voys.getklai.com`:
  - Toggle Scribe ON → refresh `/app` → Scribe appears in sidebar (already worked)
  - Toggle Scribe OFF → refresh `/app` → Scribe disappears (was the bug; fixed by this PR)
  - Toggle without refresh: navigate from `/admin/settings` to `/app` → sidebar reflects new state without page reload