### PR TITLE
fix(rag-eval): config defaults match production (URL + secret alias)

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/config.py
+++ b/klai-knowledge-ingest/knowledge_ingest/config.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pydantic import model_validator
+from pydantic import AliasChoices, Field, model_validator
 from pydantic_settings import BaseSettings
 
 
@@ -91,16 +91,27 @@ class Settings(BaseSettings):
 
     # SPEC-RAG-EVAL-001 — nightly RAGAS evaluation harness settings.
     # retrieval_api_url: base URL of klai-retrieval-api (Docker internal network).
+    #   Production hostname is `retrieval-api` (no `klai-` prefix) on port 8040,
+    #   verified against /opt/klai/.env::KNOWLEDGE_RETRIEVE_URL.
     # retrieval_internal_secret: X-Internal-Secret for /retrieve auth.
-    #   Reuses RETRIEVAL_INTERNAL_SECRET env var (same secret as litellm-hook).
+    #   Accepts both RETRIEVAL_INTERNAL_SECRET (knowledge-ingest convention)
+    #   AND RETRIEVAL_API_INTERNAL_SECRET (production SOPS convention, same name
+    #   as portal-api and litellm-hook). Pydantic AliasChoices picks whichever
+    #   is set — same fall-through pattern as deploy/litellm/klai_knowledge.py.
     #   Warn-on-empty at startup (fail-open: harness skips retrieval auth when absent
-    #   in dev; production must set RETRIEVAL_INTERNAL_SECRET via SOPS).
+    #   in dev; production must set the secret via SOPS).
     # rag_eval_retrieval_timeout: seconds before a /retrieve call is declared failed (REQ-3).
     # rag_eval_judge_timeout: seconds before a klai-fast judge call is declared failed.
     # rag_eval_judge_model: LiteLLM model alias for answer generation and RAGAS judge.
     # rag_eval_suites_dir: directory containing suite YAML files.
-    retrieval_api_url: str = "http://klai-retrieval-api:8000"
-    retrieval_internal_secret: str = ""
+    retrieval_api_url: str = "http://retrieval-api:8040"
+    retrieval_internal_secret: str = Field(
+        default="",
+        validation_alias=AliasChoices(
+            "RETRIEVAL_INTERNAL_SECRET",
+            "RETRIEVAL_API_INTERNAL_SECRET",
+        ),
+    )
     rag_eval_retrieval_timeout: int = 10
     rag_eval_judge_timeout: int = 30
     rag_eval_judge_model: str = "klai-fast"

--- a/klai-knowledge-ingest/tests/eval/test_config_defaults.py
+++ b/klai-knowledge-ingest/tests/eval/test_config_defaults.py
@@ -1,0 +1,67 @@
+"""Pin the SPEC-RAG-EVAL-001 config defaults + alias resolution.
+
+Regression cover for the post-merge production smoke test where:
+- the default `retrieval_api_url` pointed at a non-existent hostname
+- `retrieval_internal_secret` only honoured RETRIEVAL_INTERNAL_SECRET, not the
+  production-side RETRIEVAL_API_INTERNAL_SECRET
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from knowledge_ingest.config import Settings
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip the two secret env vars so each test starts from a clean slate."""
+    monkeypatch.delenv("RETRIEVAL_INTERNAL_SECRET", raising=False)
+    monkeypatch.delenv("RETRIEVAL_API_INTERNAL_SECRET", raising=False)
+    monkeypatch.delenv("RETRIEVAL_API_URL", raising=False)
+    # KNOWLEDGE_INGEST_SECRET is required by the service-wide validator.
+    monkeypatch.setenv("KNOWLEDGE_INGEST_SECRET", "test-secret-for-config-tests")
+
+
+def test_retrieval_api_url_default_matches_production() -> None:
+    """Default URL must match the production hostname:port (verified 2026-05-04)."""
+    settings = Settings(_env_file=None)
+    assert settings.retrieval_api_url == "http://retrieval-api:8040"
+
+
+def test_retrieval_internal_secret_via_canonical_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RETRIEVAL_INTERNAL_SECRET wins when set."""
+    monkeypatch.setenv("RETRIEVAL_INTERNAL_SECRET", "sec-canonical")
+    settings = Settings(_env_file=None)
+    assert settings.retrieval_internal_secret == "sec-canonical"
+
+
+def test_retrieval_internal_secret_via_production_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RETRIEVAL_API_INTERNAL_SECRET (production SOPS name) is also honoured."""
+    monkeypatch.setenv("RETRIEVAL_API_INTERNAL_SECRET", "sec-prod-alias")
+    settings = Settings(_env_file=None)
+    assert settings.retrieval_internal_secret == "sec-prod-alias"
+
+
+def test_retrieval_internal_secret_canonical_wins_over_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When both are set, the canonical name takes precedence (deterministic)."""
+    monkeypatch.setenv("RETRIEVAL_INTERNAL_SECRET", "sec-canonical")
+    monkeypatch.setenv("RETRIEVAL_API_INTERNAL_SECRET", "sec-prod-alias")
+    settings = Settings(_env_file=None)
+    assert settings.retrieval_internal_secret == "sec-canonical"
+
+
+def test_retrieval_internal_secret_empty_when_neither_set() -> None:
+    """No env var set: defaults to empty string (warn-on-empty at startup)."""
+    assert "RETRIEVAL_INTERNAL_SECRET" not in os.environ
+    assert "RETRIEVAL_API_INTERNAL_SECRET" not in os.environ
+    settings = Settings(_env_file=None)
+    assert settings.retrieval_internal_secret == ""


### PR DESCRIPTION
## Summary

Post-merge fix for SPEC-RAG-EVAL-001. Two regressions surfaced when the harness ran against Voys for the first time:

1. **`retrieval_api_url` default was wrong** — `http://klai-retrieval-api:8000`. Real prod service is `retrieval-api:8040` (no `klai-` prefix, port 8040 not 8000). All 30 smoke-test queries hit \"Temporary failure in name resolution\" before manual env-var override fixed it.

2. **`retrieval_internal_secret` env-var name mismatch** — production SOPS sets `RETRIEVAL_API_INTERNAL_SECRET` (matching portal-api / litellm-hook convention) but the harness only read `RETRIEVAL_INTERNAL_SECRET`. Without the alias, the harness sends an empty secret → 401 from retrieval-api.

## Fix

- `retrieval_api_url` default updated to `http://retrieval-api:8040` (verified against `/opt/klai/.env::KNOWLEDGE_RETRIEVE_URL`).
- `retrieval_internal_secret` field now accepts BOTH env-var names via `pydantic.AliasChoices`. Canonical `RETRIEVAL_INTERNAL_SECRET` wins if both are set; falls back to `RETRIEVAL_API_INTERNAL_SECRET`.

## Verification

- 5 regression tests in `tests/eval/test_config_defaults.py` pin the defaults + alias resolution
- All 50 pre-existing eval tests still green
- Manual smoke test with these defaults baked in (env-var override removed) will auto-resolve hostname + secret on the next deploy.

## Baseline already captured

The first end-to-end smoke run (`variant=smoke-test-v3`) with manual overrides wrote 30 rows to `knowledge.rag_eval_results`:

| Metric | Average |
|---|---|
| context_precision | 0.22 |
| context_recall | 0.24 |
| faithfulness | 0.32 (n=3, judge JSON-parse fails on 27/30) |
| answer_relevance | NaN (embeddings model needed — separate follow-up) |
| retrieval_ms | 545ms |

Low context_precision/recall is the **expected** baseline — it's exactly the gap that SPEC-RAG-CONTEXTUAL-001 + SPEC-RAG-QUERY-REWRITE-001 will close.

## Known follow-ups (not in this PR)

- **Faithfulness max_tokens overflow** — judge LLM hits 3072-token completion limit on long context-relevant statements. Tune the prompt or raise the limit.
- **Answer_relevance needs an embeddings model** — RAGAS's AnswerRelevancy metric requires `embed_query`. Plug in a LiteLLM embeddings alias.
- **Runtime 14 min for 30 queries** — exceeds REQ-7's 5 min target. Likely caused by the same max_tokens issue (judge regenerating after parse failures).

These three are tuning issues, not blockers — the harness produces usable baseline numbers as-is.

## Test plan

- [x] 5 new regression tests pass locally
- [x] All 50 pre-existing eval tests still green
- [x] Ruff check + ruff format clean
- [ ] CI green
- [ ] Post-merge: re-run \`docker exec klai-core-knowledge-ingest-1 python -m knowledge_ingest.eval --suite chat --variant baseline\` (no env-var overrides) and confirm rows land with metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)