### PR TITLE
fix(rag-eval): pass RETRIEVAL_API_INTERNAL_SECRET to knowledge-ingest container

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1271,6 +1271,10 @@ services:
       GRAPHITI_ENABLED: "true"
       PORTAL_URL: http://portal-api:8010
       PORTAL_INTERNAL_TOKEN: ${PORTAL_API_INTERNAL_SECRET}
+      # SPEC-RAG-EVAL-001 — RAGAS evaluation harness calls /retrieve on
+      # klai-retrieval-api. Same secret as the litellm-hook uses for
+      # /retrieve auth (see deploy/litellm/klai_knowledge.py).
+      RETRIEVAL_API_INTERNAL_SECRET: ${RETRIEVAL_API_INTERNAL_SECRET}
       # SPEC-CRAWLER-004 Fase A — shared Garage S3 image pipeline.
       # Empty GARAGE_S3_ENDPOINT disables image extraction silently.
       GARAGE_S3_ENDPOINT: garage:3900


### PR DESCRIPTION
## Summary

Final post-deploy fix for SPEC-RAG-EVAL-001. The previous fix (#306) made the harness's pydantic config accept both `RETRIEVAL_INTERNAL_SECRET` and `RETRIEVAL_API_INTERNAL_SECRET` env vars, but the knowledge-ingest container in `docker-compose.yml` doesn't actually surface either of those vars to the process.

Verified live on core-01: \`docker exec klai-core-knowledge-ingest-1 printenv | grep -i retrieval\` returns empty. /retrieve calls from the harness consequently return 401.

## Fix

Add `RETRIEVAL_API_INTERNAL_SECRET: \${RETRIEVAL_API_INTERNAL_SECRET}` to the knowledge-ingest service's environment block. Same secret the litellm-hook already uses (\`deploy/litellm/klai_knowledge.py::RETRIEVAL_INTERNAL_SECRET\`).

## Deploy

The \`deploy-compose\` workflow rsyncs \`deploy/docker-compose.yml\` → \`/opt/klai/docker-compose.yml\` and force-recreates the knowledge-ingest container on merge. No manual step needed.

## Verification post-merge

\`\`\`bash
ssh core-01

# 1. Confirm env var is in container
docker exec klai-core-knowledge-ingest-1 printenv RETRIEVAL_API_INTERNAL_SECRET

# 2. Re-run smoke test (no env-var overrides):
docker exec klai-core-knowledge-ingest-1 \
  python -m knowledge_ingest.eval --suite chat --variant baseline-v2

# 3. Confirm rows have actual metrics (not all NULL):
docker exec klai-core-postgres-1 psql -U klai -d klai -c \
  \"SELECT variant, AVG(context_precision)::numeric(4,2), COUNT(*) \
    FROM knowledge.rag_eval_results \
    WHERE variant LIKE 'baseline%' GROUP BY 1;\"
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)