### PR TITLE
fix: caller-service header on every /retrieve caller (SPEC-SEC-IDENTITY-ASSERT-001 hotfix)

### DIFF
--- a/.claude/rules/klai/pitfalls/process-rules.md
+++ b/.claude/rules/klai/pitfalls/process-rules.md
@@ -1,5 +1,66 @@
 # Process Rules
 
+## retrieve-caller-service-header-mismatch (CRIT)
+When a SPEC adds a new MANDATORY request header (or any other contract
+change) on a receiver, the SAME PR MUST update every active caller, even
+the ones in other repositories or directories the SPEC author does not
+normally edit. SPEC-SEC-IDENTITY-ASSERT-001 Phase D landed on 2026-04-28
+and made `X-Caller-Service` required on `retrieval-api /retrieve`. The
+SPEC PR updated the receiver and its tests; it did NOT touch the four
+in-repo callers:
+
+| Caller | File | Symptom |
+|---|---|---|
+| LiteLLM hook | `deploy/litellm/klai_knowledge.py` | Every chat ran with no KB context for 7 days |
+| Partner API | `klai-portal/backend/app/services/partner_chat.py` | Partner /chat/completions returned no KB chunks |
+| Gap re-scorer | `klai-portal/backend/app/services/gap_rescorer.py` | Background job silently returned 400 on every call |
+| Focus narrow retrieval | `klai-focus/research-api/app/services/retrieval_client.py` | Notebook narrow returned [] for 7 days |
+
+**Why nobody noticed:** every caller wrapped the call in a fail-open
+`except Exception → log.warning → return empty/no context`. The chat
+still produced a coherent answer (just from general knowledge, not the
+KB). No alerts on retrieval-failure rate. Discovered only when a user
+asked "is the KB even being queried?" and we tailed the logs.
+
+**Prevention (mechanical, several layers):**
+
+1. **Allowlist tests.** Every consumer of
+   `klai_identity_assert.KNOWN_CALLER_SERVICES` MUST have a unit test
+   that locks in `X-Caller-Service: <its-name>` on the outbound
+   `/retrieve` call. The test mocks the httpx client and asserts the
+   header is set. Without it, the next refactor that drops the header
+   passes CI silently. We added these tests for all 4 callers in the
+   2026-05-05 hotfix — keep them.
+
+2. **Receiver-side contract test.** `klai-retrieval-api` should ship a
+   smoke test that POSTs to `/retrieve` from a real httpx client using
+   the EXACT header set every caller sends. A unit test inside the
+   receiver covers the receiver only — it does not validate that any
+   caller still complies.
+
+3. **Cross-repo audit on contract changes.** When a SPEC adds a new
+   header / required field on an internal endpoint, grep the entire
+   monorepo for callers BEFORE merging:
+   ```bash
+   grep -rn '/retrieve\|RETRIEVE_URL\|knowledge_retrieve_url' \
+       --include='*.py' --include='*.ts' .
+   ```
+   For every match outside the SPEC's own service, either patch it in
+   the same PR or open a tracking issue and ship the receiver-side
+   change behind a per-caller header allowlist for the soak window.
+
+4. **Fail-loud on retrieval failure.** The hook now bumps `warning →
+   error` on any /retrieve failure AND injects a user-visible
+   "[Klai Kennisbank — TIJDELIJK NIET BEREIKBAAR]" notice into the
+   system prompt so the user sees an explicit warning. Same class as
+   `fail-open-auth` in this file: silent-degrade on a feature the user
+   thinks they have is worse than a loud error.
+
+5. **Grafana alert on failure rate.** Pending: alert on
+   `service:litellm AND message:"retrieval"` ERROR-rate > 0 for 5 min.
+   This regression was visible in logs from minute one — only the lack
+   of an alert kept it hidden for a week.
+
 ## verify-image-pullable-before-pin (HIGH)
 When pinning an external image tag in any compose file (`vexaai/*`,
 `ghcr.io/*`, etc.), verify the tag is actually pullable BEFORE

--- a/deploy/grafana/provisioning/alerting/litellm-rules.yaml
+++ b/deploy/grafana/provisioning/alerting/litellm-rules.yaml
@@ -1,0 +1,111 @@
+# LiteLLM knowledge hook health alerts (added 2026-05-05).
+#
+# Routed via spec=SPEC-SEC-IDENTITY-ASSERT-001 -> klai-ops-alerts-email.
+#
+#   R1  litellm_retrieval_failed   CRIT  ANY KB-retrieval failure logged by
+#                                        klai_knowledge_hook in the last 5m
+#
+# Why an error-rate alert (not a count threshold):
+#   The 2026-04-28 -> 2026-05-05 outage went undetected for 7 days because
+#   `KlaiKnowledgeHook: retrieval failed (...)` was logged at WARNING level
+#   without an alert. After the fix the same event is logged at ERROR plus
+#   a user-visible system-prompt notice, but a log line still requires an
+#   alert to surface in pager rotation. Single failure -> page; KB-retrieval
+#   is the entire value-add of Klai chat, every failure matters.
+#
+# Pitfall avoidance:
+#   - UID stays well under the 40-char Grafana limit (see
+#     `pitfalls/process-rules.md#grafana-uid-40-char-limit`).
+#   - LogsQL pattern matches BOTH error variants emitted by the hook
+#     (HTTP error + generic exception).
+
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: litellm-knowledge-hook
+    folder: Klai
+    interval: 1m
+    rules:
+
+      # ── R1: litellm_retrieval_failed ───────────────────────────────────
+      - uid: obs-001-litellm-kb-retrieval-failed
+        title: litellm_retrieval_failed
+        condition: threshold
+        data:
+          - refId: query
+            datasourceUid: victorialogs
+            queryType: instant
+            relativeTimeRange:
+              from: 300
+              to: 0
+            model:
+              refId: query
+              datasource:
+                type: victoriametrics-logs-datasource
+                uid: victorialogs
+              expr: |
+                _time:5m service:litellm "KlaiKnowledgeHook: retrieval"
+                  -"jwt rejected by receiver"
+                  | stats count() as n
+              queryType: instant
+          - refId: reduce
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 300
+              to: 0
+            model:
+              refId: reduce
+              type: reduce
+              reducer: last
+              expression: query
+          - refId: threshold
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 300
+              to: 0
+            model:
+              refId: threshold
+              type: threshold
+              expression: reduce
+              conditions:
+                - evaluator: { params: [0], type: gt }
+                  operator: { type: and }
+                  reducer: { params: [], type: last }
+                  type: query
+        noDataState: OK
+        execErrState: OK
+        for: 0s
+        keepFiringFor: 10m
+        isPaused: false
+        labels:
+          severity: critical
+          spec: SPEC-SEC-IDENTITY-ASSERT-001
+          service_group: litellm
+        annotations:
+          summary: 'LiteLLM klai_knowledge hook failing to reach retrieval-api'
+          runbook_url: 'docs/runbooks/litellm-retrieval-failed.md'
+          description: |
+            ``KlaiKnowledgeHook`` logged at least one retrieval failure in
+            the last 5m. Every failure means a chat answered without KB
+            context; the user's "Chat met: <collection>" UI lies to them.
+
+            Triage:
+              1. VictoriaLogs (Grafana -> Explore):
+                   _time:15m service:litellm "KlaiKnowledgeHook: retrieval"
+                 Look at the message detail — common failure modes:
+                   * `HTTP 400` body=`missing_caller_service` → header
+                     contract regression, see pitfalls →
+                     `retrieve-caller-service-header-mismatch`.
+                   * `HTTP 401`/`403` invalid_jwt_audience → Zitadel
+                     project/audience for retrieval-api drifted.
+                   * `ConnectError`/`TimeoutError` → retrieval-api down or
+                     network blip; check
+                     `service:retrieval-api` health-check in Grafana.
+              2. Confirm impact: `_time:15m service:litellm "KB injection"`
+                 — if zero, the hook has been broken throughout the
+                 window; user-facing degradation is in effect.
+              3. The "jwt rejected by receiver" log line is excluded from
+                 this alert — that one is the legacy fallback retry path
+                 (Phase C-1), which is expected to fire until Phase D
+                 cleanup. It is followed by the actual outcome.

--- a/deploy/litellm/klai_knowledge.py
+++ b/deploy/litellm/klai_knowledge.py
@@ -116,13 +116,22 @@ async def _retrieve_jwt_headers() -> dict[str, str] | None:
 
     Returns ``None`` when no token client is configured OR when minting
     fails. The caller then uses the legacy X-Internal-Secret path.
+
+    SPEC-SEC-IDENTITY-ASSERT-001 REQ-4.2: ``X-Caller-Service`` header is
+    required by retrieval-api for any /retrieve request that carries an
+    end-user identity in the body. We always include it — both on the JWT
+    and the legacy auth path — so a future Phase D cleanup that removes
+    the legacy path doesn't quietly drop the header.
     """
     client = _get_token_client()
     if client is None:
         return None
     try:
         token = await client.get_token()  # type: ignore[attr-defined]
-        return {"Authorization": f"Bearer {token}"}
+        return {
+            "Authorization": f"Bearer {token}",
+            "X-Caller-Service": "litellm",
+        }
     except Exception as exc:
         # Mint failed (Zitadel down, bad creds, network error). Logged
         # by ZitadelTokenClient; we just record the fallback decision.
@@ -136,7 +145,7 @@ async def _retrieve_jwt_headers() -> dict[str, str] | None:
 
 
 def _retrieve_legacy_headers() -> dict[str, str]:
-    """Legacy X-Internal-Secret header set for the /retrieve call.
+    """Legacy X-Internal-Secret + X-Caller-Service header set for /retrieve.
 
     Uses RETRIEVAL_INTERNAL_SECRET (which falls back to PORTAL_INTERNAL_SECRET
     when unset). retrieval-api validates against its own INTERNAL_SECRET env
@@ -144,10 +153,19 @@ def _retrieve_legacy_headers() -> dict[str, str]:
     a DIFFERENT secret from portal-api's. Sending portal-api's secret here is
     the bug that historically caused `invalid_internal_secret` rejections on
     every retrieve call when the two secrets diverged.
+
+    SPEC-SEC-IDENTITY-ASSERT-001 REQ-4.2: ``X-Caller-Service: litellm`` is
+    REQUIRED — without it retrieval-api returns HTTP 400
+    ``missing_caller_service`` and the hook silently degrades chat to
+    "no KB". This was the regression that broke production for ~7 days
+    after Phase D landed on 2026-04-28.
     """
-    if RETRIEVAL_INTERNAL_SECRET:
-        return {"X-Internal-Secret": RETRIEVAL_INTERNAL_SECRET}
-    return {}
+    if not RETRIEVAL_INTERNAL_SECRET:
+        return {}
+    return {
+        "X-Internal-Secret": RETRIEVAL_INTERNAL_SECRET,
+        "X-Caller-Service": "litellm",
+    }
 
 
 async def _retrieve_with_dual_auth(
@@ -635,16 +653,57 @@ class KlaiKnowledgeHook(CustomLogger):
         # 401/403 (e.g. when Zitadel audience/scope grant for the receiver
         # is not yet wired up). See ``_retrieve_with_dual_auth``.
         t0 = time.monotonic()
+        retrieval_failure: str | None = None
+        result: dict[str, Any] = {}
         try:
             async with httpx.AsyncClient(timeout=RETRIEVE_TIMEOUT) as client:
                 resp = await _retrieve_with_dual_auth(client, retrieve_body)
                 resp.raise_for_status()
                 result = resp.json()
+        except httpx.HTTPStatusError as exc:
+            # @MX:WARN: 4xx from /retrieve is a config error, not a transient
+            # failure. Surface to the user — silent-degrade hid the
+            # caller-service-header regression in production for 7 days.
+            # @MX:REASON: SPEC-SEC-IDENTITY-ASSERT-001 Phase D + the
+            # `retrieve-caller-service-header-mismatch` pitfall.
+            body_snippet = ""
+            try:
+                body_snippet = exc.response.text[:200]
+            except Exception:
+                pass
+            logger.error(
+                "KlaiKnowledgeHook: retrieval HTTP %d — body=%r — failing loud",
+                exc.response.status_code,
+                body_snippet,
+            )
+            retrieval_failure = f"HTTP {exc.response.status_code}"
         except Exception as exc:
-            logger.warning("KlaiKnowledgeHook: retrieval failed (%s) — degrading", exc)
-            # Templates still apply even when KB retrieval fails.
-            _prepend_system_prefix(messages, templates_block)
+            # Network errors / timeouts: still log error (was warning), but
+            # surface in chat so a sustained outage is impossible to miss.
+            logger.error(
+                "KlaiKnowledgeHook: retrieval failed (%s) — failing loud", exc
+            )
+            retrieval_failure = type(exc).__name__
+
+        if retrieval_failure is not None:
+            kb_unavailable_notice = (
+                "[Klai Kennisbank — TIJDELIJK NIET BEREIKBAAR. Antwoord op basis "
+                "van algemene kennis. Begin je antwoord met deze waarschuwing aan "
+                f"de gebruiker: 'Let op: ik kon de kennisbank niet bereiken "
+                f"({retrieval_failure}) — dit antwoord is niet gebaseerd op jullie "
+                "eigen documentatie. Ververs of probeer het later opnieuw.']\n"
+            )
+            prefix = "\n\n".join(b for b in (templates_block, kb_unavailable_notice) if b)
+            _prepend_system_prefix(messages, prefix)
             data["messages"] = messages
+            data.setdefault("metadata", {})["_klai_kb_meta"] = {
+                "org_id": org_id,
+                "user_id": user_id,
+                "chunks_injected": 0,
+                "retrieval_ms": int((time.monotonic() - t0) * 1000),
+                "gate_bypassed": False,
+                "retrieval_failure": retrieval_failure,
+            }
             return data
 
         retrieval_ms = int((time.monotonic() - t0) * 1000)

--- a/deploy/litellm/tests/test_klai_knowledge_hook.py
+++ b/deploy/litellm/tests/test_klai_knowledge_hook.py
@@ -134,7 +134,13 @@ def _patch_http(monkeypatch, portal_resp=None, retrieval_resp=None):
 class TestKlaiKnowledgeHookLegacy:
     @pytest.mark.asyncio
     async def test_retrieve_request_includes_auth_header(self, monkeypatch):
-        """V001: retrieve request must include X-Internal-Secret header."""
+        """V001: retrieve request must include X-Internal-Secret header.
+
+        Regression-guard for the 2026-04-28 → 2026-05-05 outage:
+        retrieval-api requires X-Caller-Service: litellm; without it a 400
+        is returned and the hook degrades silently. Both headers MUST be
+        present on every legacy-auth /retrieve request.
+        """
         mod = _load_hook(monkeypatch)
         hook = mod.KlaiKnowledgeHook()
         cache = _make_cache(feature_enabled=True)
@@ -157,6 +163,7 @@ class TestKlaiKnowledgeHookLegacy:
             post_call = mc.post.call_args
             headers = post_call.kwargs.get("headers") or {}
             assert headers.get("X-Internal-Secret") == "test-retrieval-secret"
+            assert headers.get("X-Caller-Service") == "litellm"
 
     @pytest.mark.asyncio
     async def test_no_secret_no_header(self, monkeypatch):
@@ -230,6 +237,7 @@ class TestKlaiKnowledgeHookDualAuth:
             assert mc.post.call_count == 1
             headers = mc.post.call_args.kwargs.get("headers") or {}
             assert headers.get("Authorization") == "Bearer fake.jwt.token"
+            assert headers.get("X-Caller-Service") == "litellm"
             assert "X-Internal-Secret" not in headers
 
     @pytest.mark.asyncio
@@ -261,6 +269,7 @@ class TestKlaiKnowledgeHookDualAuth:
             assert mc.post.call_count == 1
             headers = mc.post.call_args.kwargs.get("headers") or {}
             assert headers.get("X-Internal-Secret") == "test-retrieval-secret"
+            assert headers.get("X-Caller-Service") == "litellm"
             assert "Authorization" not in headers
 
     @pytest.mark.asyncio
@@ -294,7 +303,9 @@ class TestKlaiKnowledgeHookDualAuth:
             first_headers = mc.post.call_args_list[0].kwargs.get("headers") or {}
             second_headers = mc.post.call_args_list[1].kwargs.get("headers") or {}
             assert first_headers.get("Authorization") == "Bearer fake.jwt.token"
+            assert first_headers.get("X-Caller-Service") == "litellm"
             assert second_headers.get("X-Internal-Secret") == "test-retrieval-secret"
+            assert second_headers.get("X-Caller-Service") == "litellm"
             assert "Authorization" not in second_headers
 
     @pytest.mark.asyncio
@@ -352,7 +363,100 @@ class TestKlaiKnowledgeHookDualAuth:
             assert mc.post.call_count == 1
             headers = mc.post.call_args.kwargs.get("headers") or {}
             assert headers.get("X-Internal-Secret") == "test-retrieval-secret"
+            assert headers.get("X-Caller-Service") == "litellm"
             assert "Authorization" not in headers
+
+
+# ─── 2026-05-05 fail-loud regression tests ──────────────────────────────────
+
+
+class TestKlaiKnowledgeHookFailLoud:
+    """Regression-guard for the silent-degradation incident.
+
+    Until 2026-05-05 the hook caught any /retrieve failure as a warning and
+    silently dropped KB context. This hid the SPEC-SEC-IDENTITY-ASSERT-001
+    Phase D regression for ~7 days. The new contract: a /retrieve failure
+    MUST surface to the user via a system-prompt notice, AND the call MUST
+    be marked in `_klai_kb_meta.retrieval_failure` so observability sees it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_retrieve_400_surfaces_in_system_prompt(self, monkeypatch):
+        """A 400 from retrieval-api injects a visible 'KB unreachable' notice."""
+        import httpx as _httpx
+
+        mod = _load_hook(monkeypatch)
+        hook = mod.KlaiKnowledgeHook()
+        cache = _make_cache(feature_enabled=True)
+
+        data = {"user": "aabbcc112233445566778899", "messages": [
+            {"role": "user", "content": "What are the team policies?"}
+        ]}
+
+        # Build a MagicMock that raises HTTPStatusError like a real 400 would.
+        bad_resp = _make_resp(
+            {"detail": {"error": "missing_caller_service"}}, status_code=400
+        )
+        bad_resp.text = '{"detail":{"error":"missing_caller_service"}}'
+        bad_resp.raise_for_status = MagicMock(
+            side_effect=_httpx.HTTPStatusError(
+                "400", request=MagicMock(), response=bad_resp
+            )
+        )
+
+        with patch("klai_knowledge.httpx.AsyncClient") as cls:
+            mc = AsyncMock()
+            mc.get = AsyncMock(return_value=_make_resp({"instructions": []}))
+            mc.post = AsyncMock(return_value=bad_resp)
+            mc.__aenter__ = AsyncMock(return_value=mc)
+            mc.__aexit__ = AsyncMock(return_value=None)
+            cls.return_value = mc
+
+            await hook.async_pre_call_hook(_make_user_api_key(), cache, data, "completion")
+
+            # System prompt must contain a user-visible "KB unreachable" notice.
+            system_msg = next(
+                (m for m in data["messages"] if m["role"] == "system"), None
+            )
+            assert system_msg is not None, "fail-loud must inject a system message"
+            assert "Kennisbank" in system_msg["content"]
+            assert "TIJDELIJK NIET BEREIKBAAR" in system_msg["content"]
+
+            # Failure marker MUST be in metadata for observability.
+            kb_meta = data.get("metadata", {}).get("_klai_kb_meta", {})
+            assert kb_meta.get("retrieval_failure") is not None
+            assert kb_meta.get("chunks_injected") == 0
+
+    @pytest.mark.asyncio
+    async def test_retrieve_network_error_surfaces_in_system_prompt(self, monkeypatch):
+        """ConnectError → same fail-loud path as HTTP error."""
+        import httpx as _httpx
+
+        mod = _load_hook(monkeypatch)
+        hook = mod.KlaiKnowledgeHook()
+        cache = _make_cache(feature_enabled=True)
+
+        data = {"user": "aabbcc112233445566778899", "messages": [
+            {"role": "user", "content": "What are the team policies?"}
+        ]}
+
+        with patch("klai_knowledge.httpx.AsyncClient") as cls:
+            mc = AsyncMock()
+            mc.get = AsyncMock(return_value=_make_resp({"instructions": []}))
+            mc.post = AsyncMock(side_effect=_httpx.ConnectError("connection refused"))
+            mc.__aenter__ = AsyncMock(return_value=mc)
+            mc.__aexit__ = AsyncMock(return_value=None)
+            cls.return_value = mc
+
+            await hook.async_pre_call_hook(_make_user_api_key(), cache, data, "completion")
+
+            system_msg = next(
+                (m for m in data["messages"] if m["role"] == "system"), None
+            )
+            assert system_msg is not None
+            assert "TIJDELIJK NIET BEREIKBAAR" in system_msg["content"]
+            kb_meta = data.get("metadata", {}).get("_klai_kb_meta", {})
+            assert kb_meta.get("retrieval_failure") == "ConnectError"
 
 
 # ─── KB-010 new tests ────────────────────────────────────────────────────────

--- a/docs/runbooks/litellm-retrieval-failed.md
+++ b/docs/runbooks/litellm-retrieval-failed.md
@@ -1,0 +1,96 @@
+# LiteLLM knowledge-hook retrieval failed
+
+**Alert:** `obs-001-litellm-kb-retrieval-failed` (CRIT)
+**Source:** `deploy/grafana/provisioning/alerting/litellm-rules.yaml`
+**Symptom:** at least one `KlaiKnowledgeHook: retrieval` log line in the
+last 5 min on `service:litellm`. Every fired log line means a chat
+answered without KB context — the user's "Chat met: <collection>" UI
+is silently lying.
+
+## What happens when this fires
+
+The LiteLLM `klai_knowledge_hook` calls retrieval-api on every chat
+message to inject KB chunks into the system prompt. When the call
+fails, the hook (post-2026-05-05 fail-loud rewrite) prepends a notice
+to the system prompt instructing the model to start its reply with
+"Let op: ik kon de kennisbank niet bereiken (...)". The user sees a
+plain-language warning instead of a coherent answer that secretly
+omits the KB.
+
+A single failure pages because every failed call = a real user got a
+worse answer than they expected.
+
+## Triage
+
+1. **Identify the failure mode.** In Grafana → Explore → VictoriaLogs:
+
+   ```
+   _time:15m service:litellm "KlaiKnowledgeHook: retrieval"
+   ```
+
+   Inspect the message body. Most common modes:
+
+   | Symptom | Likely cause | Fix |
+   |---|---|---|
+   | `HTTP 400` body contains `missing_caller_service` | Caller stopped sending `X-Caller-Service` header (or a new caller was added without it). | See pitfalls → `retrieve-caller-service-header-mismatch`. Add the header in the caller; redeploy. |
+   | `HTTP 400` body contains `unknown_caller_service` | Caller sent a `X-Caller-Service` value not in `klai_identity_assert.KNOWN_CALLER_SERVICES`. | Add the new service name to the lib + portal-api `identity_verifier.KNOWN_CALLER_SERVICES`. The contract test in portal-api will lock the two lists together. |
+   | `HTTP 401` `invalid_jwt_audience` | Zitadel project / audience config drifted (Phase C-1 JWT path). Hook falls back to legacy `X-Internal-Secret` automatically. | If the fallback also fails: Zitadel project for retrieval-api is misconfigured. Re-check `KLAI_LITELLM_CLIENT_*` in SOPS. |
+   | `HTTP 401` `invalid_internal_secret` | `RETRIEVAL_API_INTERNAL_SECRET` divergence between caller and receiver. | Compare SOPS env vars on both ends. Rotate secret if needed. |
+   | `ConnectError` / `TimeoutError` | retrieval-api is down or networking blip. | Check `service:retrieval-api` health, `docker ps`, and the rate-limit / Redis pool errors (separate latent bug). |
+
+2. **Confirm impact.** Run:
+
+   ```
+   _time:15m service:litellm "KB injection"
+   ```
+
+   If this returns zero hits, the hook has been broken across the
+   whole window — every chat in that window has degraded. Tell the
+   on-call / customer-success rep so support can triage tickets.
+
+3. **Check for regression PRs.** Recent merges that touched any of:
+   - `deploy/litellm/klai_knowledge.py`
+   - `klai-libs/identity-assert/`
+   - `klai-retrieval-api/retrieval_api/middleware/auth.py`
+   - any caller (`partner_chat.py`, `gap_rescorer.py`,
+     `klai-focus/research-api/app/services/retrieval_client.py`)
+
+   Bisect with `git log --oneline --since='1 day ago'` on the affected
+   service.
+
+## Resolution
+
+- **Caller missing header**: PR fix following the same pattern as PR
+  #311 (2026-05-05). Add `X-Caller-Service: <name>` to the outbound
+  call AND register `<name>` in BOTH allowlists (lib + portal-api).
+- **Receiver allowlist drift**: add the new caller name to
+  `klai-libs/identity-assert/.../models.py` `KNOWN_CALLER_SERVICES`
+  AND `klai-portal/backend/app/services/identity_verifier.py`
+  `KNOWN_CALLER_SERVICES` in the same PR. The
+  `test_library_and_server_caller_allowlists_match` portal-api test
+  blocks merges that update only one side.
+- **Network blip**: usually self-healing. If retrieval-api is in a
+  restart loop, `docker logs klai-core-retrieval-api-1 --tail 100` and
+  fix the underlying cause (env var, image version, port).
+
+## Excluded from this alert by design
+
+The log line `KlaiKnowledgeHook: jwt rejected by receiver (HTTP 401) —
+retrying with legacy auth header` is filtered out of the LogsQL query.
+It is the EXPECTED Phase C-1 fallback path while Zitadel audience
+config is rolled out per-receiver. The actual outcome (success or
+failure of the legacy retry) is logged separately and IS caught by
+this alert.
+
+## Background
+
+This alert was added on 2026-05-05 after a 7-day silent outage caused
+by SPEC-SEC-IDENTITY-ASSERT-001 Phase D (landed 2026-04-28). The
+receiver gained a mandatory header check; none of the four in-repo
+callers were updated; every chat ran without KB context for a week.
+The hook caught the failure as a `warning` and degraded silently with
+no alert. After the fix, the failure log is at `error` level AND a
+user-visible notice is prepended to the system prompt AND this alert
+fires immediately.
+
+See pitfalls/process-rules.md → `retrieve-caller-service-header-mismatch`.

--- a/klai-focus/research-api/app/services/retrieval_client.py
+++ b/klai-focus/research-api/app/services/retrieval_client.py
@@ -24,11 +24,20 @@ def _auth_headers() -> dict[str, str]:
 
     Returns an empty dict if the secret is not configured; the caller is expected
     to log-and-skip in that case. We never send an empty X-Internal-Secret value.
+
+    SPEC-SEC-IDENTITY-ASSERT-001 REQ-4.2: ``X-Caller-Service: research-api``
+    is REQUIRED — without it retrieval-api returns HTTP 400
+    ``missing_caller_service`` and the caller silently returns []. Phase D
+    landed 2026-04-28 and broke focus narrow retrieval for 7 days. See
+    pitfalls → retrieve-caller-service-header-mismatch.
     """
     secret = settings.retrieval_api_internal_secret
     if not secret:
         return {}
-    return {"X-Internal-Secret": secret}
+    return {
+        "X-Internal-Secret": secret,
+        "X-Caller-Service": "research-api",
+    }
 
 
 async def retrieve_narrow(

--- a/klai-focus/research-api/tests/test_retrieval_client_headers.py
+++ b/klai-focus/research-api/tests/test_retrieval_client_headers.py
@@ -1,0 +1,104 @@
+"""Regression-guard for the SPEC-SEC-IDENTITY-ASSERT-001 silent-degradation incident.
+
+Phase D landed 2026-04-28 and made `X-Caller-Service` REQUIRED on every
+retrieval-api `/retrieve` call. The research-api `_auth_headers()` helper
+was never updated, so `retrieve_narrow()` silently returned [] for every
+focus notebook for 7 days.
+
+These tests assert that the helper now emits the header and that
+`retrieve_narrow` propagates it onto the outbound call. See
+`pitfalls/process-rules.md` -> `retrieve-caller-service-header-mismatch`.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Settings() is called at module-import time inside app.core.config; satisfy
+# the required fields with placeholder values BEFORE importing anything that
+# transitively pulls Settings in.
+os.environ.setdefault("POSTGRES_DSN", "postgresql+asyncpg://test/test")
+os.environ.setdefault("RETRIEVAL_API_URL", "http://retrieval-api:8040")
+os.environ.setdefault("RETRIEVAL_API_INTERNAL_SECRET", "test-secret")
+os.environ.setdefault("ZITADEL_API_AUDIENCE", "test-audience")
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def test_auth_headers_includes_caller_service(monkeypatch):
+    """_auth_headers() emits X-Caller-Service: research-api when secret is set."""
+    from app.services import retrieval_client as mod
+
+    fake_settings = MagicMock()
+    fake_settings.retrieval_api_internal_secret = "test-secret"
+    monkeypatch.setattr(mod, "settings", fake_settings)
+
+    headers = mod._auth_headers()
+
+    assert headers.get("X-Internal-Secret") == "test-secret"
+    assert headers.get("X-Caller-Service") == "research-api", (
+        "X-Caller-Service header missing — retrieval-api 400s and the "
+        "caller silently returns []. See pitfalls."
+    )
+
+
+def test_auth_headers_empty_when_no_secret(monkeypatch):
+    """No secret configured -> empty dict, NEVER half-set headers."""
+    from app.services import retrieval_client as mod
+
+    fake_settings = MagicMock()
+    fake_settings.retrieval_api_internal_secret = ""
+    monkeypatch.setattr(mod, "settings", fake_settings)
+
+    assert mod._auth_headers() == {}
+
+
+@pytest.mark.asyncio
+async def test_retrieve_narrow_sends_caller_service(monkeypatch):
+    """retrieve_narrow() forwards the X-Caller-Service header to httpx."""
+    from app.services import retrieval_client as mod
+
+    captured: dict = {}
+
+    class _Resp:
+        status_code = 200
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"chunks": []}
+
+    class _Client:
+        def __init__(self, timeout=None):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            return None
+
+        async def post(self, url, json=None, headers=None):
+            captured["url"] = url
+            captured["headers"] = headers or {}
+            return _Resp()
+
+    monkeypatch.setattr(mod.httpx, "AsyncClient", _Client)
+
+    fake_settings = MagicMock()
+    fake_settings.retrieval_api_url = "http://retrieval-api:8040"
+    fake_settings.retrieval_api_internal_secret = "test-secret"
+    monkeypatch.setattr(mod, "settings", fake_settings)
+
+    out = await mod.retrieve_narrow(
+        question="hello",
+        notebook_id="nb-1",
+        tenant_id="tenant-1",
+    )
+
+    assert out == []
+    assert captured["headers"].get("X-Caller-Service") == "research-api"
+    assert captured["headers"].get("X-Internal-Secret") == "test-secret"

--- a/klai-libs/identity-assert/klai_identity_assert/models.py
+++ b/klai-libs/identity-assert/klai_identity_assert/models.py
@@ -106,6 +106,13 @@ class VerifyResult:
 # Recognised caller services. Mirrors portal-api REQ-1.2 reject list. Adding a
 # new caller requires a synchronised change to portal-api's allowlist; consumers
 # fail-closed if they pass an unknown service identifier.
+#
+# `litellm`, `portal-api`, `research-api` were added 2026-05-05 after the
+# caller-service header check (SPEC-SEC-IDENTITY-ASSERT-001 Phase D, landed
+# 2026-04-28) silently broke every internal caller of retrieval-api `/retrieve`.
+# The fail-open in those callers degraded chat to "no KB" without surfacing
+# a single error for 7 days. See pitfalls/process-rules.md →
+# retrieve-caller-service-header-mismatch.
 KNOWN_CALLER_SERVICES: frozenset[str] = frozenset(
     {
         "knowledge-mcp",
@@ -113,5 +120,8 @@ KNOWN_CALLER_SERVICES: frozenset[str] = frozenset(
         "retrieval-api",
         "connector",
         "mailer",
+        "litellm",
+        "portal-api",
+        "research-api",
     }
 )

--- a/klai-portal/backend/app/services/gap_rescorer.py
+++ b/klai-portal/backend/app/services/gap_rescorer.py
@@ -88,7 +88,12 @@ async def rescore_open_gaps(
         return 0
 
     resolved_count = 0
-    headers = {**get_trace_headers()}
+    # SPEC-SEC-IDENTITY-ASSERT-001 REQ-4.2: retrieval-api requires
+    # X-Caller-Service for any /retrieve with an end-user identity in the
+    # body. We send `system` here in user_id, but the header is still
+    # validated. Without it: 400 missing_caller_service → silent rescore
+    # noop. See pitfalls → retrieve-caller-service-header-mismatch.
+    headers = {"X-Caller-Service": "portal-api", **get_trace_headers()}
     if settings.internal_secret:
         headers["Authorization"] = f"Bearer {settings.internal_secret}"
 

--- a/klai-portal/backend/app/services/identity_verifier.py
+++ b/klai-portal/backend/app/services/identity_verifier.py
@@ -47,6 +47,11 @@ logger = logging.getLogger(__name__)
 # requires a synchronised change in both locations; the library fails closed
 # with ``library_misconfigured`` and the endpoint with
 # ``unknown_caller_service`` so a one-sided change is loud.
+#
+# `litellm`, `portal-api`, `research-api` were added 2026-05-05 after the
+# caller-service header check (SPEC-SEC-IDENTITY-ASSERT-001 Phase D, landed
+# 2026-04-28) silently broke every internal caller of retrieval-api. See
+# pitfalls/process-rules.md -> retrieve-caller-service-header-mismatch.
 KNOWN_CALLER_SERVICES: frozenset[str] = frozenset(
     {
         "knowledge-mcp",
@@ -54,6 +59,9 @@ KNOWN_CALLER_SERVICES: frozenset[str] = frozenset(
         "retrieval-api",
         "connector",
         "mailer",
+        "litellm",
+        "portal-api",
+        "research-api",
     }
 )
 

--- a/klai-portal/backend/app/services/partner_chat.py
+++ b/klai-portal/backend/app/services/partner_chat.py
@@ -122,6 +122,11 @@ async def retrieve_context(
 
     # SPEC-SEC-010 REQ-6.1: authenticate to retrieval-api with the dedicated
     # retrieval_api_internal_secret (separate from portal-api's mailer secret).
+    # SPEC-SEC-IDENTITY-ASSERT-001 REQ-4.2: X-Caller-Service is REQUIRED;
+    # without it retrieval-api returns 400 missing_caller_service. Phase D
+    # landed 2026-04-28 and silently broke partner chat for 7 days because
+    # the header was never added here. See pitfalls →
+    # retrieve-caller-service-header-mismatch.
     retrieval_secret = settings.retrieval_api_internal_secret or settings.internal_secret
     async with httpx.AsyncClient(timeout=10.0) as client:
         resp = await client.post(
@@ -129,6 +134,7 @@ async def retrieve_context(
             json=retrieve_body,
             headers={
                 "X-Internal-Secret": retrieval_secret,
+                "X-Caller-Service": "portal-api",
                 **get_trace_headers(),
             },
         )

--- a/klai-portal/backend/tests/test_gap_rescorer.py
+++ b/klai-portal/backend/tests/test_gap_rescorer.py
@@ -67,6 +67,14 @@ async def test_rescore_marks_resolved_when_no_longer_gap() -> None:
     # Should have committed to persist resolved_at updates
     mock_db.commit.assert_called_once()
 
+    # Regression-guard for SPEC-SEC-IDENTITY-ASSERT-001 silent-degradation:
+    # the /retrieve call MUST send X-Caller-Service or retrieval-api 400s.
+    post_headers = mock_client.post.call_args.kwargs["headers"]
+    assert post_headers.get("X-Caller-Service") == "portal-api", (
+        "X-Caller-Service header missing — would silently 400 in prod. "
+        "See pitfalls/process-rules.md → retrieve-caller-service-header-mismatch."
+    )
+
 
 @pytest.mark.asyncio
 async def test_rescore_keeps_open_when_still_gap() -> None:

--- a/klai-portal/backend/tests/test_partner_chat.py
+++ b/klai-portal/backend/tests/test_partner_chat.py
@@ -371,3 +371,63 @@ async def test_streaming_retrieval_log_fires():
         await chat_completions(request=req, auth=make_partner_auth(kb_access={10: "read"}), db=db)
 
     mock_asyncio.create_task.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# 2026-05-05 regression-guard: SPEC-SEC-IDENTITY-ASSERT-001 caller-service
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retrieve_context_sends_caller_service_header(monkeypatch):
+    """retrieve_context MUST send X-Caller-Service: portal-api on /retrieve.
+
+    Phase D of SPEC-SEC-IDENTITY-ASSERT-001 (landed 2026-04-28) made this
+    header mandatory. Without it retrieval-api returns 400
+    `missing_caller_service` and partner chat returns empty context for
+    every customer call. The hook silently degraded for 7 days. This test
+    locks the header in. See pitfalls →
+    retrieve-caller-service-header-mismatch.
+    """
+    from app.services.partner_chat import retrieve_context
+
+    captured: dict = {}
+
+    class _MockResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"chunks": []}
+
+    class _MockClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            return None
+
+        async def post(self, url, json=None, headers=None):
+            captured["url"] = url
+            captured["headers"] = headers or {}
+            return _MockResp()
+
+    monkeypatch.setattr("app.services.partner_chat.httpx.AsyncClient", lambda timeout: _MockClient())
+
+    fake_settings = MagicMock()
+    fake_settings.knowledge_retrieve_url = "http://retrieval-api:8040"
+    fake_settings.retrieval_api_internal_secret = "test-retrieval-secret"
+    fake_settings.internal_secret = "test-portal-secret"
+
+    await retrieve_context(
+        org_id=42,
+        zitadel_org_id="z-1",
+        kb_slugs=["kb-alpha"],
+        messages=[{"role": "user", "content": "hello"}],
+        settings=fake_settings,
+    )
+
+    assert captured["headers"].get("X-Caller-Service") == "portal-api", (
+        "X-Caller-Service header missing — retrieval-api 400s and partner chat returns no KB context. See pitfalls."
+    )
+    assert captured["headers"].get("X-Internal-Secret") == "test-retrieval-secret"


### PR DESCRIPTION
## Summary

SPEC-SEC-IDENTITY-ASSERT-001 Phase D landed **2026-04-28** and made `X-Caller-Service` mandatory on retrieval-api `/retrieve`. **Four in-repo callers were never updated**. Each of them wrapped the call in fail-open `except Exception → log warning → return empty context`, so the regression silently degraded chat (and 3 other surfaces) without surfacing a single error for **7 days**.

Detected 2026-05-05 from production logs:
- 0 successful `KB injection` lines in the last 6 h.
- Hundreds of `KlaiKnowledgeHook: retrieval failed (HTTP 400)` warnings every minute.
- Receiver-side: every call returned `400 missing_caller_service`.

## What changed

| File | Change |
|---|---|
| `klai-libs/identity-assert/.../models.py` | `KNOWN_CALLER_SERVICES` gains `litellm`, `portal-api`, `research-api`. |
| `deploy/litellm/klai_knowledge.py` | Adds `X-Caller-Service: litellm` on both auth paths. **Fail-loud rewrite**: any /retrieve failure now logs `error` and injects a user-visible "[Klai Kennisbank — TIJDELIJK NIET BEREIKBAAR]" notice into the system prompt. |
| `klai-portal/backend/app/services/partner_chat.py` | `X-Caller-Service: portal-api`. |
| `klai-portal/backend/app/services/gap_rescorer.py` | `X-Caller-Service: portal-api`. |
| `klai-focus/research-api/app/services/retrieval_client.py` | `X-Caller-Service: research-api`. |
| `deploy/grafana/provisioning/alerting/litellm-rules.yaml` | New CRIT alert `obs-001-litellm-kb-retrieval-failed` — fires on ANY retrieval-failure log line in 5 min. |
| `.claude/rules/klai/pitfalls/process-rules.md` | New `retrieve-caller-service-header-mismatch (CRIT)` pitfall. |

Plus regression-guard tests on all 4 callers + 2 new fail-loud tests on the hook (HTTP 4xx and connect-error paths).

## Why fail-loud, not silent-degrade

This regression hid for 7 days because the hook caught every error as a warning and quietly returned the chat without KB chunks. The user thinks "Chat met: Support" is talking to the support KB, but the model is answering from general knowledge alone. That is a worse user experience than a clear error message.

After this PR:
- The retrieval failure goes to `error` log level → caught by the alert.
- The system prompt injects a notice instructing Mistral to start with "Let op: ik kon de kennisbank niet bereiken (HTTP 400) — dit antwoord is niet gebaseerd op jullie eigen documentatie." The user sees the failure.
- `_klai_kb_meta.retrieval_failure` records the failure type for observability.

## Test plan

- [x] `deploy/litellm/tests/test_klai_knowledge_hook.py` — 9 header + fail-loud tests pass locally
- [x] `klai-libs/identity-assert/tests/` — 43 tests pass
- [x] `klai-retrieval-api/tests/test_identity_assert.py` — 8 tests pass (allowlist still rejects unknown services)
- [x] `klai-portal/backend/tests/test_gap_rescorer.py` + `test_partner_chat.py` — header-assertion tests pass
- [x] `klai-focus/research-api/tests/test_retrieval_client_headers.py` — 3 tests pass
- [x] `ruff check` + `ruff format --check` clean on all 11 files
- [ ] CI green (deploy-litellm, portal-api, retrieval-api, research-api workflows)
- [ ] Post-deploy: tail `docker logs klai-core-litellm-1 | grep "KB injection"` — should appear on every chat with a non-trivial query
- [ ] Post-deploy: confirm Grafana alert is provisioned and registered
- [ ] Post-deploy: open `voys.getklai.com/app/chat` → "Chat met: Support" → ask a Voys-specific question → answer cites source URLs from the KB

🤖 Generated with [Claude Code](https://claude.com/claude-code)