### PR TITLE
fix(ingest): close X-Internal-Token vs X-Internal-Secret drift (Cluster G TP-1)

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/clustering_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/clustering_tasks.py
@@ -174,7 +174,10 @@ async def _get_pending_proposals(org_id: str, kb_slug: str) -> list[dict]:
     url = f"{settings.portal_url}/api/v1/{kb_slug}/taxonomy/proposals"
     headers = {}
     if settings.portal_internal_token:
-        headers["x-internal-token"] = settings.portal_internal_token
+        # Authorization: Bearer matches portal_client.py:_fetch_from_portal —
+        # SPEC-CODEBASE-AUDIT-001 cluster G TP-1 unifies outbound auth on the
+        # Bearer pattern instead of the legacy x-internal-token header.
+        headers["Authorization"] = f"Bearer {settings.portal_internal_token}"
 
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:

--- a/klai-knowledge-ingest/knowledge_ingest/config.py
+++ b/klai-knowledge-ingest/knowledge_ingest/config.py
@@ -59,7 +59,8 @@ class Settings(BaseSettings):
     graphiti_llm_rps: float = 1.0
     # Portal integration for taxonomy (SPEC-KB-021)
     portal_url: str = "http://portal-api:8000"
-    portal_internal_token: str = ""  # X-Internal-Token for portal internal endpoints
+    # Bearer token for outbound calls to portal-api internal endpoints
+    portal_internal_token: str = ""
     taxonomy_classification_model: str = "klai-fast"
     taxonomy_classification_timeout: float = 30.0
     content_label_timeout: float = 15.0
@@ -110,10 +111,15 @@ class Settings(BaseSettings):
         """SEC-014: fail-closed on empty/missing PORTAL_INTERNAL_TOKEN.
 
         Same class of bug as F-003/F-012 but for the ingest→portal direction:
-        routes/taxonomy.py:_verify_internal_token historically returned without
-        check when the env var was empty, silently accepting any caller. Now
-        that portal taxonomy endpoints are actively consumed, missing config
-        must fail at startup rather than silently open the surface.
+        outbound calls in clustering_tasks/portal_client send this token as a
+        Bearer header to portal-api internal endpoints. An empty value would
+        silently degrade auth on the outbound side, so missing config must
+        fail at startup rather than open the surface.
+
+        (The legacy inbound _verify_internal_token per-route check on
+        routes/taxonomy.py was removed in SPEC-CODEBASE-AUDIT-001 cluster G
+        TP-1 — the InternalSecretMiddleware (X-Internal-Secret) now provides
+        the only inbound auth layer.)
         """
         if not self.portal_internal_token or not self.portal_internal_token.strip():
             raise ValueError("Missing required: PORTAL_INTERNAL_TOKEN (SEC-014)")

--- a/klai-knowledge-ingest/knowledge_ingest/routes/taxonomy.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/taxonomy.py
@@ -78,20 +78,6 @@ class BootstrapResponse(BaseModel):
     proposals_submitted: int
 
 
-def _verify_internal_token(request: Request) -> None:
-    """Verify X-Internal-Token header.
-
-    SEC-014: fail-closed. Empty/missing PORTAL_INTERNAL_TOKEN is caught at
-    startup by the pydantic validator in knowledge_ingest.config — here the
-    only failure mode is a wrong or absent header, which always returns 401.
-    """
-    import hmac
-
-    token = request.headers.get("x-internal-token", "")
-    if not token or not hmac.compare_digest(token, settings.portal_internal_token):
-        raise HTTPException(status_code=401, detail="Unauthorized")
-
-
 # ---------------------------------------------------------------------------
 # Procrastinate job status mapping
 # ---------------------------------------------------------------------------
@@ -656,8 +642,13 @@ async def taxonomy_auto_categorise(
 
     Called when a taxonomy proposal is approved in the portal.
     No LLM calls -- pure cosine similarity against provided centroid (SPEC-KB-024 R4).
+
+    Auth: enforced by InternalSecretMiddleware (X-Internal-Secret) — the
+    legacy per-route X-Internal-Token check was removed in
+    SPEC-CODEBASE-AUDIT-001 cluster G TP-1 to eliminate header drift across
+    ingest routes. portal_internal_token remains the outbound credential
+    used by clustering_tasks/portal_client to call portal-api.
     """
-    _verify_internal_token(request)
     categorised = await _auto_categorise_impl(
         org_id=req.org_id,
         kb_slug=req.kb_slug,

--- a/klai-knowledge-ingest/tests/test_auto_categorise.py
+++ b/klai-knowledge-ingest/tests/test_auto_categorise.py
@@ -157,20 +157,41 @@ async def test_auto_categorise_no_llm_calls(_patch_qdrant):
         mock_httpx_instance.post.assert_not_called()
 
 
-def test_auto_categorise_requires_auth(client):
-    """POST without X-Internal-Token should return 401."""
-    with patch("knowledge_ingest.routes.taxonomy.settings") as mock_settings:
-        mock_settings.portal_internal_token = "secret-token"
-        mock_settings.qdrant_url = "http://localhost:6333"
-        mock_settings.qdrant_api_key = ""
-        mock_settings.taxonomy_auto_categorise_threshold = 0.82
-        resp = client.post(
-            "/ingest/v1/taxonomy/auto-categorise",
-            json={
-                "org_id": "org-1",
-                "kb_slug": "test-kb",
-                "node_id": 42,
-                "cluster_centroid": [1.0, 0.0, 0.0],
-            },
-        )
+def test_auto_categorise_requires_auth():
+    """POST without X-Internal-Secret should return 401.
+
+    Auth is enforced by InternalSecretMiddleware on every non-/health route.
+    SPEC-CODEBASE-AUDIT-001 cluster G TP-1: the legacy per-route
+    X-Internal-Token check was removed; this test now exercises the
+    middleware-level 401 on the auto-categorise endpoint specifically (so a
+    future regression that bypasses the middleware on this route is caught).
+    """
+    mock_pool = MagicMock()
+    mock_pool.close = AsyncMock(return_value=None)
+
+    with (
+        patch("knowledge_ingest.qdrant_store.ensure_collection", new_callable=AsyncMock),
+        patch(
+            "knowledge_ingest.db.get_pool",
+            new_callable=AsyncMock,
+            return_value=mock_pool,
+        ),
+        patch("knowledge_ingest.db.close_pool", new_callable=AsyncMock),
+        patch("knowledge_ingest.config.settings.enrichment_enabled", False),
+    ):
+        from fastapi.testclient import TestClient
+
+        from knowledge_ingest.app import app
+
+        with TestClient(app, raise_server_exceptions=False) as unauthed:
+            resp = unauthed.post(
+                "/ingest/v1/taxonomy/auto-categorise",
+                json={
+                    "org_id": "org-1",
+                    "kb_slug": "test-kb",
+                    "node_id": 42,
+                    "cluster_centroid": [1.0, 0.0, 0.0],
+                },
+            )
         assert resp.status_code == 401
+        assert "X-Internal-Secret" in resp.json()["detail"]


### PR DESCRIPTION
## Summary

Closes **Cluster G TP-1** from SPEC-CODEBASE-AUDIT-001 (Contract drift):
- knowledge-ingest taxonomy routes had a per-route _verify_internal_token check on header X-Internal-Token while InternalSecretMiddleware already validates X-Internal-Secret app-wide. All other ingest routes use X-Internal-Secret only — taxonomy was the lone outlier with dual auth + divergent header naming.
- Plus 1 outbound site (clustering_tasks.py:177) sent x-internal-token instead of Bearer.

## Fix (conservative scope — no env-var/SOPS rename)

- Remove _verify_internal_token() function and its sole call site
- Outbound clustering_tasks.py: x-internal-token → Authorization: Bearer
- Tests: rewrite test_auto_categorise_requires_auth as middleware-401 regression guard

env-var \`portal_internal_token\` BEHELD (still used for outbound calls). No SOPS change required.

## Test plan

- [x] ruff clean on 4 edited files
- [x] 8/8 pytest pass on test_auto_categorise + test_auth_middleware
- [x] portal-api callers (knowledge_ingest_client.py): all use X-Internal-Secret already → zero cross-service breakage
- [ ] E2E prod-tenant suite (post-merge)

## Out-of-scope

clustering_tasks._get_pending_proposals has a separate auth-context mismatch on /api/v1/{kb_slug}/taxonomy/proposals (expects user-JWT, not internal-secret). Documented for follow-up SPEC.

## Refs

- reports/audit-2026-05-04/api-versioning-and-contract-drift.md (1.5 TP-1)
- reports/audit-2026-05-04/deep-pass-knowledge-ingest.md
- reports/audit-2026-05-04/synthesis.md (Cluster G)

🤖 Generated with [Claude Code](https://claude.com/claude-code)