### PR TITLE
feat(security): SPEC-SEC-PORTAL-RLS-001 — RLS on portal_join_requests + ast-grep guard

### DIFF
--- a/klai-connector/app/main.py
+++ b/klai-connector/app/main.py
@@ -3,11 +3,9 @@
 import base64
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
-from datetime import UTC, datetime
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from sqlalchemy import update
 
 import app.core.database as _db
 from app.adapters.airtable import AirtableAdapter
@@ -20,11 +18,9 @@ from app.adapters.registry import AdapterRegistry
 from app.clients.knowledge_ingest import KnowledgeIngestClient
 from app.core.config import Settings
 from app.core.database import dispose_engine, init_engine
-from app.core.enums import SyncStatus
 from app.core.logging import RequestContextMiddleware, get_logger, setup_logging
 from app.core.security import AESGCMCipher
 from app.middleware.auth import AuthMiddleware
-from app.models.sync_run import SyncRun
 from app.routes.connectors import router as connectors_router
 from app.routes.fingerprint import router as fingerprint_router
 from app.routes.health import router as health_router
@@ -33,6 +29,7 @@ from app.services.crypto import PostgresSecretsStore
 from app.services.portal_client import PortalClient
 from app.services.scheduler import ConnectorScheduler
 from app.services.sync_engine import SyncEngine
+from app.services.sync_runs import reset_stuck_running_runs_cross_org
 
 logger = get_logger(__name__)
 
@@ -51,18 +48,15 @@ def create_app() -> FastAPI:
         # Database
         init_engine(settings.database_url)
 
-        # Mark any sync_runs that were left RUNNING (e.g. from a previous crash/restart) as PENDING.
-        # PENDING preserves the cursor_state (which may contain checkpoint progress) so that
-        # the next sync can resume from where it left off rather than restarting from scratch.
+        # Crash-recovery: re-mark RUNNING runs as PENDING. Cross-org by
+        # design — runs in lifespan before any tenant context exists. The
+        # helper documents the rationale + carries the SyncRun.org_id
+        # marker that ast-grep rule no-untenanted-syncrun-query expects.
         if _db.session_maker is not None:
             async with _db.session_maker() as session:
-                await session.execute(
-                    update(SyncRun)
-                    .where(SyncRun.status == SyncStatus.RUNNING)
-                    .values(status=SyncStatus.PENDING, completed_at=datetime.now(UTC))
-                )
+                rowcount = await reset_stuck_running_runs_cross_org(session)
                 await session.commit()
-            logger.info("Cleaned up stuck RUNNING sync_runs on startup")
+            logger.info("Cleaned up stuck RUNNING sync_runs on startup (rows=%d)", rowcount)
 
         # Encryption
         key_bytes = base64.b64decode(settings.encryption_key)

--- a/klai-connector/app/services/sync_engine.py
+++ b/klai-connector/app/services/sync_engine.py
@@ -233,8 +233,12 @@ class SyncEngine:
             try:
                 cursor_state = await adapter.get_cursor_state(portal_config)
 
-                last_run = await self._get_last_successful_run(session, connector_id)
-                last_pending = await self._get_last_pending_run(session, connector_id)
+                last_run = await self._get_last_successful_run(
+                    session, connector_id, portal_config.zitadel_org_id
+                )
+                last_pending = await self._get_last_pending_run(
+                    session, connector_id, portal_config.zitadel_org_id
+                )
 
                 # Resume state: refs already ingested in an interrupted run.
                 resume_ingested_refs: set[str] = set()
@@ -822,11 +826,25 @@ class SyncEngine:
                 await session.commit()
 
     @staticmethod
-    async def _get_last_successful_run(session: AsyncSession, connector_id: uuid.UUID) -> SyncRun | None:
-        """Retrieve the most recent successful sync run for a connector."""
+    async def _get_last_successful_run(
+        session: AsyncSession,
+        connector_id: uuid.UUID,
+        org_id: str,
+    ) -> SyncRun | None:
+        """Retrieve the most recent successful sync run for a connector.
+
+        SPEC-SEC-PORTAL-RLS-001 REQ-3 — connector.sync_runs has no Postgres
+        RLS policy yet, so the application-level ``SyncRun.org_id`` filter
+        is the only tenant-isolation barrier. ``connector_id`` is allocated
+        per-tenant by the portal control plane (so two tenants can never
+        share one), but that invariant lives outside klai-connector and
+        was flagged by audit-2026-05-04 TP-5 as a soft contract. Adding the
+        explicit org-id filter closes the gap regardless of upstream drift.
+        """
         result = await session.execute(
             select(SyncRun)
             .where(
+                SyncRun.org_id == org_id,
                 SyncRun.connector_id == connector_id,
                 SyncRun.status == SyncStatus.COMPLETED,
             )
@@ -836,11 +854,20 @@ class SyncEngine:
         return result.scalars().first()
 
     @staticmethod
-    async def _get_last_pending_run(session: AsyncSession, connector_id: uuid.UUID) -> SyncRun | None:
-        """Retrieve the most recent PENDING sync run for a connector."""
+    async def _get_last_pending_run(
+        session: AsyncSession,
+        connector_id: uuid.UUID,
+        org_id: str,
+    ) -> SyncRun | None:
+        """Retrieve the most recent PENDING sync run for a connector.
+
+        See :meth:`_get_last_successful_run` for the SPEC-SEC-PORTAL-RLS-001
+        rationale on the ``SyncRun.org_id`` filter.
+        """
         result = await session.execute(
             select(SyncRun)
             .where(
+                SyncRun.org_id == org_id,
                 SyncRun.connector_id == connector_id,
                 SyncRun.status == SyncStatus.PENDING,
             )

--- a/klai-connector/app/services/sync_runs.py
+++ b/klai-connector/app/services/sync_runs.py
@@ -56,7 +56,20 @@ async def reset_stuck_running_runs_cross_org(session: AsyncSession) -> int:
     # Marker reference — see module docstring + SPEC-SEC-PORTAL-RLS-001 REQ-3.
     # This is the ONLY legitimate cross-org SyncRun operation; any other
     # site must filter by SyncRun.org_id.
-    _cross_org_marker = SyncRun.org_id  # noqa: F841 — see docstring
+    #
+    # Audit 2026-05-05 finding F8: a prior version of this marker used
+    # an explicit lint-suppression annotation that was removable by
+    # automated cleanup tools. If the suppression got stripped, F841
+    # would have triggered, ruff autofix would have REMOVED the
+    # assignment, and the ast-grep rule would then fire on this
+    # legitimate sweep — a silent security-rule regression.
+    #
+    # Replaced with `_ = SyncRun.org_id`. The `_` name is the universal
+    # "intentionally discarded" convention; F841 ignores it by default.
+    # No suppression annotation required, so there is nothing for
+    # autofix to strip. A future tightening of F841 to flag `_` itself
+    # would be a project-wide concern, not a silent bypass-only one.
+    _ = SyncRun.org_id
     result = await session.execute(
         update(SyncRun)
         .where(SyncRun.status == SyncStatus.RUNNING)

--- a/klai-connector/app/services/sync_runs.py
+++ b/klai-connector/app/services/sync_runs.py
@@ -1,0 +1,65 @@
+"""Sync-run helpers that intentionally span all tenants.
+
+This module is a deliberate, narrowly-scoped escape hatch for queries
+that legitimately need to operate across every tenant — currently only
+the lifespan crash-recovery sweep that re-marks RUNNING runs as PENDING
+on klai-connector startup.
+
+Why this lives in its own module
+--------------------------------
+
+The ast-grep rule ``no-untenanted-syncrun-query`` (SPEC-SEC-PORTAL-RLS-001
+REQ-3) requires every ``select`` / ``update`` / ``delete`` on ``SyncRun``
+to also reference ``SyncRun.org_id`` somewhere in the same function. The
+intent is to catch missing tenant filters mechanically. Crash recovery
+genuinely needs to span every tenant (the lifespan runs before any tenant
+context exists), so this helper:
+
+1. Documents the cross-org intent explicitly in its name + docstring,
+2. Touches ``SyncRun.org_id`` as a no-op so the rule's
+   "function references SyncRun.org_id" check passes — making this the
+   ONLY legitimate location where that bypass is acceptable, and
+3. Keeps the bypass out of ``app/main.py``, where any future
+   ``update(SyncRun)`` would otherwise also slip past the rule because
+   the entry-module used to be opted out of the lint scope.
+
+Any other ``SyncRun`` operation MUST tenant-scope via ``SyncRun.org_id``.
+"""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.sync_run import SyncRun, SyncStatus
+
+
+async def reset_stuck_running_runs_cross_org(session: AsyncSession) -> int:
+    """Re-mark RUNNING sync runs as PENDING across all tenants.
+
+    Called from the FastAPI lifespan handler at startup so that any run
+    left RUNNING by a previous crash / forced restart can resume from
+    its checkpoint. PENDING preserves ``cursor_state`` (which may contain
+    partial-progress refs) so the next sync continues where it left off
+    instead of restarting from scratch.
+
+    Cross-org by design: at lifespan time no tenant context exists, and
+    the sweep does not RETURN data — it only updates ``status`` +
+    ``completed_at``. The reference to ``SyncRun.org_id`` below is a
+    declarative marker that satisfies the
+    ``no-untenanted-syncrun-query`` ast-grep rule and documents that
+    the cross-org scope was a conscious choice, not an oversight.
+
+    Returns:
+        Number of rows updated (used for log instrumentation).
+    """
+    # Marker reference — see module docstring + SPEC-SEC-PORTAL-RLS-001 REQ-3.
+    # This is the ONLY legitimate cross-org SyncRun operation; any other
+    # site must filter by SyncRun.org_id.
+    _cross_org_marker = SyncRun.org_id  # noqa: F841 — see docstring
+    result = await session.execute(
+        update(SyncRun)
+        .where(SyncRun.status == SyncStatus.RUNNING)
+        .values(status=SyncStatus.PENDING, completed_at=datetime.now(UTC))
+    )
+    return result.rowcount or 0

--- a/klai-portal/backend/alembic/versions/2f7d1eae1198_add_rls_join_requests_and_allowed_domains.py
+++ b/klai-portal/backend/alembic/versions/2f7d1eae1198_add_rls_join_requests_and_allowed_domains.py
@@ -1,0 +1,95 @@
+"""Add RLS policy on portal_join_requests
+
+SPEC-SEC-PORTAL-RLS-001 — close the tenant-scoping gap surfaced by
+``reports/audit-2026-05-04/tenant-scoping.md`` (TP-1).
+
+``portal_join_requests`` already carries an ``org_id`` column but had no
+``CREATE POLICY`` — meaning DB-layer tenant isolation was absent. This
+migration brings it in line with the rest of the portal RLS regime
+established in SPEC-SEC-003 / SPEC-SEC-007.
+
+Policy shape: **Category A (auth-seed)**. The pre-auth ``auth_select.py``
+INSERT-and-notify flow and the admin token-based ``auth_join`` approve
+flow must look up / insert rows BEFORE any tenant context is known (the
+request itself resolves WHICH org it belongs to). The policy mirrors the
+``portal_users`` shape with the ``IS NULL`` permissive branch so the
+pre-auth lookup succeeds when ``app.current_org_id`` is empty, while
+admin-side queries (`admin/join_requests.py`) — which run after
+`_get_caller_org` has bound a tenant — get strict ``org_id = T``
+isolation.
+
+**Why portal_org_allowed_domains is NOT in this migration**:
+SPEC-AUTH-006 originally introduced ``portal_org_allowed_domains``, but
+SPEC-AUTH-009 R2 (migration ``ed5b78b296f5``) replaced that table with
+``portal_orgs.primary_domain`` + ``auto_accept_same_domain`` and DROPS
+the table in production via ``post_deploy_ed5b78b296f5.sql``. Adding RLS
+to a table that is already on the deletion path would pollute the
+migration history without functional benefit. The original audit
+finding TP-2 (``portal_org_allowed_domains`` missing RLS) is therefore
+moot post-AUTH-009 — the table is gone in prod and only re-created on
+``downgrade`` for reversibility. ``test_r2_removal.py`` is the
+regression-guard for the absence.
+
+The DDL uses the legacy inline-NULLIF pattern that matches the existing
+migrations (``1b8736eb6455``, ``e669581d441f``). The post-deploy SQL
+``post_deploy_rls_raise_on_missing_context.sql`` will later swap any
+strict-category policies to the ``_rls_current_org_id()`` helper for
+fail-loud behaviour — but ``portal_join_requests`` is Category A, not
+Category D, so it stays on the inline pattern.
+
+Idempotency: ``CREATE POLICY`` does not support ``IF NOT EXISTS``, so
+the upgrade is wrapped in ``DROP POLICY IF EXISTS`` + ``CREATE POLICY``.
+Running the migration on a database that already has ``tenant_isolation``
+defined (e.g. partially migrated staging) is therefore safe.
+
+Revision ID: 2f7d1eae1198
+Revises: rbac001drop00
+Create Date: 2026-05-05
+"""
+
+from alembic import op
+
+revision = "2f7d1eae1198"
+down_revision = "rbac001drop00"
+branch_labels = None
+depends_on = None
+
+_T = "NULLIF(current_setting('app.current_org_id', true), '')::int"
+_T_IS_NULL = "NULLIF(current_setting('app.current_org_id', true), '') IS NULL"
+
+
+def _enable_rls(table: str) -> None:
+    op.execute(  # nosemgrep: formatted-sql-query,sqlalchemy-execute-raw-query
+        f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY"
+    )
+    op.execute(  # nosemgrep: formatted-sql-query,sqlalchemy-execute-raw-query
+        f"ALTER TABLE {table} FORCE ROW LEVEL SECURITY"
+    )
+
+
+def upgrade() -> None:
+    # portal_join_requests: Category A (permissive on missing context).
+    # The admin token-based approve flow in app/api/auth_join.py looks up
+    # the join request by its approval_token BEFORE any tenant context is
+    # resolved (the token IS the resolution mechanism). Same shape as
+    # portal_users / portal_connectors — a permissive IS NULL branch so
+    # the pre-auth lookup succeeds, with strict tenant-equality once
+    # set_tenant has fired downstream (admin/join_requests.py path).
+    _enable_rls("portal_join_requests")
+    op.execute(  # nosemgrep: formatted-sql-query,sqlalchemy-execute-raw-query
+        "DROP POLICY IF EXISTS tenant_isolation ON portal_join_requests"
+    )
+    op.execute(  # nosemgrep: formatted-sql-query,sqlalchemy-execute-raw-query
+        "CREATE POLICY tenant_isolation ON portal_join_requests "
+        f"USING (org_id = {_T} OR {_T_IS_NULL}) "
+        f"WITH CHECK (org_id = {_T})"
+    )
+
+
+def downgrade() -> None:
+    op.execute(  # nosemgrep: formatted-sql-query,sqlalchemy-execute-raw-query
+        "DROP POLICY IF EXISTS tenant_isolation ON portal_join_requests"
+    )
+    op.execute(  # nosemgrep: formatted-sql-query,sqlalchemy-execute-raw-query
+        "ALTER TABLE portal_join_requests DISABLE ROW LEVEL SECURITY"
+    )

--- a/klai-portal/backend/app/core/rls_guard.py
+++ b/klai-portal/backend/app/core/rls_guard.py
@@ -56,6 +56,7 @@ RLS_DML_TABLES: frozenset[str] = frozenset(
         "portal_group_memberships",
         "portal_group_products",
         "portal_groups",
+        "portal_join_requests",
         "portal_kb_tombstones",
         "portal_knowledge_bases",
         "portal_retrieval_gaps",

--- a/klai-portal/backend/tests/test_rls_join_requests.py
+++ b/klai-portal/backend/tests/test_rls_join_requests.py
@@ -1,0 +1,207 @@
+"""SPEC-SEC-PORTAL-RLS-001 — regression tests for the new RLS policy.
+
+``portal_join_requests`` was created with an ``org_id`` column (per
+SPEC-AUTH-006) but never received a ``CREATE POLICY``, leaving it
+outside the DB-layer tenant-isolation regime that protects every other
+portal table. Migration ``2f7d1eae1198`` closes that gap.
+
+Note: ``portal_org_allowed_domains`` was originally part of the audit
+TP-2 finding, but SPEC-AUTH-009 R2 (migration ``ed5b78b296f5``) replaced
+that table with ``portal_orgs.primary_domain`` and DROPS it in
+production via ``post_deploy_ed5b78b296f5.sql``. Adding RLS to a table
+on the deletion path would pollute the migration history without
+functional benefit. ``test_r2_removal.py`` is the regression-guard for
+its absence.
+
+Pytest does not have a live PostgreSQL backend in CI (the suite runs
+against SQLite for speed; full integration uses staging). These tests
+therefore exercise the two layers we CAN exercise without postgres:
+
+1. ``RLS_DML_TABLES`` in ``app/core/rls_guard.py`` includes the new
+   table — the silent-filter guard now covers it.
+2. The migration file ships the canonical Category-A policy shape
+   (regex-checked against the file content) so a future refactor that
+   accidentally drops the policy is caught at CI time, before it can
+   land on staging.
+
+Live policy-against-pg_policies coverage is delivered by the staging
+smoke test ``scripts/rls-smoke-test.sh``; AC-2 of the SPEC.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from app.core.rls_guard import RLS_DML_TABLES
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "alembic"
+    / "versions"
+    / "2f7d1eae1198_add_rls_join_requests_and_allowed_domains.py"
+)
+
+
+# ---------------------------------------------------------------------------
+# RLS_DML_TABLES regression — silent-filter guard must cover the new table
+# ---------------------------------------------------------------------------
+
+
+def test_rls_dml_tables_includes_portal_join_requests() -> None:
+    """``portal_join_requests`` must be in the silent-filter guard set.
+
+    Otherwise an UPDATE/DELETE that hits zero rows because RLS filtered
+    them would slip past the rls_guard listener with no error log.
+    """
+    assert "portal_join_requests" in RLS_DML_TABLES, (
+        "portal_join_requests was added to the database with an RLS policy "
+        "but is missing from RLS_DML_TABLES in app/core/rls_guard.py. "
+        "The silent-filter guard would not warn on rowcount=0 DML "
+        "against this table. See SPEC-SEC-PORTAL-RLS-001."
+    )
+
+
+def test_rls_dml_tables_does_not_include_portal_org_allowed_domains() -> None:
+    """SPEC-AUTH-009 R2 dropped ``portal_org_allowed_domains``. It must
+    NOT be in RLS_DML_TABLES because the silent-filter guard expects every
+    listed table to actually exist in the schema. ``test_r2_removal.py``
+    is the canonical regression-guard for the absence of the table.
+    """
+    assert "portal_org_allowed_domains" not in RLS_DML_TABLES, (
+        "portal_org_allowed_domains was dropped by SPEC-AUTH-009 R2 "
+        "(migration ed5b78b296f5). It must not be re-added to "
+        "RLS_DML_TABLES — the silent-filter guard expects every listed "
+        "table to exist in the live schema."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Migration shape — DDL strings must contain the canonical patterns
+# ---------------------------------------------------------------------------
+
+
+def _read_migration() -> str:
+    assert MIGRATION_PATH.exists(), f"SPEC-SEC-PORTAL-RLS-001 migration file is missing: {MIGRATION_PATH}"
+    return MIGRATION_PATH.read_text(encoding="utf-8")
+
+
+def test_migration_enables_force_rls() -> None:
+    """Both ENABLE and FORCE row-level security must fire on the table.
+
+    Without FORCE, the table owner role bypasses the policy — fine in
+    dev but operationally risky if the migration role and the
+    application role ever drift.
+    """
+    src = _read_migration()
+    assert re.search(r"ENABLE ROW LEVEL SECURITY", src), "Migration must call ALTER TABLE ... ENABLE ROW LEVEL SECURITY"
+    assert re.search(r"FORCE ROW LEVEL SECURITY", src), "Migration must call ALTER TABLE ... FORCE ROW LEVEL SECURITY"
+    assert "portal_join_requests" in src
+
+
+def test_migration_does_not_touch_portal_org_allowed_domains() -> None:
+    """SPEC-AUTH-009 R2 dropped the table. The migration must NOT
+    re-introduce DDL on it — that would conflict with the drop on
+    upgrade() and confuse downgrade()."""
+    src = _read_migration()
+    # The table name may appear in the docstring as historical context
+    # (explaining WHY it is excluded). It MUST NOT appear in any
+    # op.execute() call.
+    op_executes = re.findall(r"op\.execute\([^)]*\)", src, re.DOTALL)
+    for stmt in op_executes:
+        assert "portal_org_allowed_domains" not in stmt, (
+            "Migration must not run DDL against portal_org_allowed_domains "
+            "— SPEC-AUTH-009 R2 dropped that table. Found in: "
+            f"{stmt[:200]}..."
+        )
+
+
+def _extract_policy_block(source: str, table: str) -> str:
+    """Return the source-text run that contains the ``CREATE POLICY`` for
+    ``table``, up to the closing ``op.execute(...)`` call.
+    """
+    match = re.search(
+        rf"CREATE POLICY tenant_isolation ON {table}.*?\)\n",
+        source,
+        re.DOTALL,
+    )
+    assert match, f"CREATE POLICY block for {table} not found in migration"
+    return match.group(0)
+
+
+def test_migration_creates_permissive_policy_on_join_requests() -> None:
+    """Category-A pre-auth pattern: portal_join_requests MUST include
+    the ``IS NULL`` permissive branch in its USING clause.
+
+    Without that branch, the admin token-based approve flow in
+    ``auth_join.py`` cannot resolve the join request before tenant
+    context exists. See migration docstring + SPEC-SEC-PORTAL-RLS-001
+    Risks table.
+
+    The migration may emit the IS NULL branch either directly (literal
+    ``IS NULL`` text) or via the shared ``_T_IS_NULL`` variable that
+    expands to ``NULLIF(...) IS NULL`` at runtime — both shapes are
+    accepted, but the strict-only pattern (``USING (org_id = T)`` with
+    no NULL branch at all) is rejected.
+    """
+    src = _read_migration()
+    block = _extract_policy_block(src, "portal_join_requests")
+    has_permissive_branch = "IS NULL" in block or "_T_IS_NULL" in block
+    assert has_permissive_branch, (
+        "portal_join_requests policy must include the `IS NULL` "
+        "permissive branch (Category-A auth-seed pattern). Without it "
+        "the admin approve_join flow cannot resolve the row before "
+        f"tenant context. Policy block:\n{block}"
+    )
+
+
+def test_migration_with_check_clause_present() -> None:
+    """The policy must include WITH CHECK so INSERTs from a wrong tenant
+    context fail, not just SELECTs filter."""
+    src = _read_migration()
+    check_count = len(re.findall(r"WITH CHECK", src))
+    assert check_count >= 1, (
+        f"Expected at least 1 WITH CHECK clause in migration; found "
+        f"{check_count}. Without WITH CHECK an attacker could INSERT a "
+        "row with someone else's org_id."
+    )
+
+
+def test_migration_downgrade_drops_policy() -> None:
+    """Downgrade must roll back the DDL changes — drop policy + disable RLS."""
+    src = _read_migration()
+    down_match = re.search(
+        r"def downgrade\(\) -> None:(.*?)\Z",
+        src,
+        re.DOTALL,
+    )
+    assert down_match, "Migration must define downgrade()"
+    down_body = down_match.group(1)
+    assert "DROP POLICY IF EXISTS tenant_isolation ON portal_join_requests" in down_body or (
+        "portal_join_requests" in down_body and "DROP POLICY" in down_body
+    )
+    assert "DISABLE ROW LEVEL SECURITY" in down_body, "Downgrade must DISABLE ROW LEVEL SECURITY"
+
+
+# ---------------------------------------------------------------------------
+# Idempotency — re-running the migration on an existing DB must not fail.
+# ---------------------------------------------------------------------------
+
+
+def test_migration_uses_drop_if_exists_for_idempotency() -> None:
+    """``CREATE POLICY`` does not support ``IF NOT EXISTS``. The
+    migration must wrap each CREATE in a DROP IF EXISTS so re-applying
+    on a partially migrated database (rare but possible during staging
+    recovery) succeeds.
+
+    See ``alembic-stamped-past-skipped-migration`` pitfall.
+    """
+    src = _read_migration()
+    drop_count = len(re.findall(r"DROP POLICY IF EXISTS tenant_isolation", src))
+    create_count = len(re.findall(r"CREATE POLICY tenant_isolation", src))
+    assert drop_count >= create_count, (
+        f"Migration has {create_count} CREATE POLICY statements but only "
+        f"{drop_count} DROP POLICY IF EXISTS guards in upgrade(). "
+        "Idempotency is broken: re-running on a partially migrated DB "
+        "will fail."
+    )

--- a/rules/no-untenanted-syncrun-query.yml
+++ b/rules/no-untenanted-syncrun-query.yml
@@ -72,23 +72,27 @@ rule:
 
 # Scope: klai-connector source + the lint test fixtures.
 #
-# Existing call sites
-# -------------------
-# Two call sites in `klai-connector/app/services/sync_engine.py`
-# (`_get_last_successful_run`, `_get_last_pending_run`) currently filter
-# only by `connector_id + status` without an `SyncRun.org_id` clause.
-# In production this is "safe-by-coincidence": connector_id is allocated
-# per-tenant on the portal side, so no two tenants share a connector_id.
-# But that invariant lives in the portal control plane, not in
-# klai-connector itself, which makes it exactly the kind of soft
-# contract the audit (TP-5) flagged.
+# Historical note
+# ---------------
+# The first version of this rule (SPEC-SEC-PORTAL-RLS-001 round-1) carved
+# `klai-connector/app/services/sync_engine.py` and `klai-connector/app/main.py`
+# out of scope because two pre-existing call sites filtered SyncRun by
+# `connector_id + status` only, and the lifespan crash-recovery sweep
+# spanned every tenant by design. Both have since been closed:
 #
-# Closing those two call sites is intentionally OUT OF SCOPE for
-# SPEC-SEC-PORTAL-RLS-001 (per the SPEC's "Out of scope" section).
-# They are listed in `ignores` below so this rule lands without
-# breaking the existing klai-connector CI build, while still firing
-# on any NEW untenanted query and on the lint fixtures. A follow-up
-# SPEC will fix the existing call sites and remove the entries.
+#   * `_get_last_successful_run` / `_get_last_pending_run` now take an
+#     explicit `org_id` parameter and filter on `SyncRun.org_id`
+#     (round-2 follow-up — closes the soft-contract dependency the audit
+#     flagged on connector_id uniqueness across tenants).
+#   * The crash-recovery sweep was extracted into
+#     `klai-connector/app/services/sync_runs.py::reset_stuck_running_runs_cross_org`.
+#     That helper carries an explicit `_cross_org_marker = SyncRun.org_id`
+#     line so the rule's "function references SyncRun.org_id" exit
+#     accepts the legitimate cross-org sweep — and ONLY that sweep.
+#
+# Both source files are now FULLY in-scope. A new untenanted SyncRun
+# query anywhere in klai-connector therefore fails this rule, including
+# in main.py and sync_engine.py.
 files:
   - klai-connector/app/**/*.py
   - rules/tests/fixtures/*.py
@@ -96,13 +100,3 @@ ignores:
   - klai-connector/tests/**/*.py
   - klai-connector/alembic/**/*.py
   - '**/conftest.py'
-  # Pre-existing call sites — see header comment, follow-up SPEC.
-  - klai-connector/app/services/sync_engine.py
-  # Legitimate cross-org crash-recovery sweep at startup (mark RUNNING
-  # rows as PENDING so they can resume after a restart). Runs in the
-  # `lifespan` context, before any tenant context exists; spans every
-  # tenant by design. Acceptable because it does not RETURN data — it
-  # only updates status. A follow-up could move this to an explicit
-  # cross_org_session() helper, but for now the entry-module is opted
-  # out of the rule.
-  - klai-connector/app/main.py

--- a/rules/no-untenanted-syncrun-query.yml
+++ b/rules/no-untenanted-syncrun-query.yml
@@ -1,0 +1,108 @@
+# SPEC-SEC-PORTAL-RLS-001 REQ-3 — block untenanted SyncRun queries.
+#
+# klai-connector's `connector.sync_runs` table has an `org_id` column
+# (SPEC-SEC-TENANT-001 REQ-7.2) but no Postgres RLS policy. The audit
+# (reports/audit-2026-05-04/tenant-scoping.md, TP-5) flagged this as a
+# tenant-isolation gap that depends entirely on application-level filters.
+#
+# This rule enforces the application-level filter mechanically: every
+# `select(SyncRun)`, `update(SyncRun)`, or `delete(SyncRun)` statement
+# must appear within an assignment or expression that ALSO references
+# `SyncRun.org_id` somewhere in the same chain.
+#
+# Pattern strategy
+# ----------------
+# ast-grep matches by AST shape. We anchor on the call expression
+# `select(SyncRun)` (and update / delete) inside a top-level statement,
+# then walk UP to the enclosing assignment / expression-statement and
+# check that the same statement contains a reference to `SyncRun.org_id`.
+#
+# False-negative budget: if a future caller writes `select(SyncRun).where(
+# col("org_id") == ...)` (using the literal string column name), this rule
+# does not see it. Our convention is the explicit `SyncRun.org_id ==`
+# attribute reference; a code-review enforcer is fine for this layer.
+#
+# False-positive budget: tests that intentionally exercise cross-org
+# behaviour are excluded via `ignores`. New cross-org call sites must
+# either tenant-scope or move to a justified position in `ignores`.
+
+id: no-untenanted-syncrun-query
+language: python
+severity: error
+message: |
+  Untenanted SyncRun query detected. Every select / update / delete
+  on SyncRun MUST also constrain SyncRun.org_id (or be wrapped in an
+  `if org_id is not None: query = query.where(SyncRun.org_id == ...)`
+  pattern). connector.sync_runs has no Postgres RLS — the application
+  filter is the only tenant-isolation barrier.
+  See SPEC-SEC-PORTAL-RLS-001 REQ-3 and reports/audit-2026-05-04/tenant-scoping.md.
+
+rule:
+  any:
+    # Anchor on the `select(SyncRun)` / `update(SyncRun)` / `delete(SyncRun)`
+    # call expression, then walk UP to the enclosing function definition
+    # and assert that the function body does NOT contain any reference to
+    # `SyncRun.org_id`. This catches both the chained-where pattern and
+    # the conditional `if org_id is not None: query = query.where(...)`
+    # pattern that splits the binding across two statements.
+    - pattern: select(SyncRun)
+      inside:
+        kind: function_definition
+        stopBy: end
+        not:
+          has:
+            pattern: SyncRun.org_id
+            stopBy: end
+    - pattern: update(SyncRun)
+      inside:
+        kind: function_definition
+        stopBy: end
+        not:
+          has:
+            pattern: SyncRun.org_id
+            stopBy: end
+    - pattern: delete(SyncRun)
+      inside:
+        kind: function_definition
+        stopBy: end
+        not:
+          has:
+            pattern: SyncRun.org_id
+            stopBy: end
+
+# Scope: klai-connector source + the lint test fixtures.
+#
+# Existing call sites
+# -------------------
+# Two call sites in `klai-connector/app/services/sync_engine.py`
+# (`_get_last_successful_run`, `_get_last_pending_run`) currently filter
+# only by `connector_id + status` without an `SyncRun.org_id` clause.
+# In production this is "safe-by-coincidence": connector_id is allocated
+# per-tenant on the portal side, so no two tenants share a connector_id.
+# But that invariant lives in the portal control plane, not in
+# klai-connector itself, which makes it exactly the kind of soft
+# contract the audit (TP-5) flagged.
+#
+# Closing those two call sites is intentionally OUT OF SCOPE for
+# SPEC-SEC-PORTAL-RLS-001 (per the SPEC's "Out of scope" section).
+# They are listed in `ignores` below so this rule lands without
+# breaking the existing klai-connector CI build, while still firing
+# on any NEW untenanted query and on the lint fixtures. A follow-up
+# SPEC will fix the existing call sites and remove the entries.
+files:
+  - klai-connector/app/**/*.py
+  - rules/tests/fixtures/*.py
+ignores:
+  - klai-connector/tests/**/*.py
+  - klai-connector/alembic/**/*.py
+  - '**/conftest.py'
+  # Pre-existing call sites — see header comment, follow-up SPEC.
+  - klai-connector/app/services/sync_engine.py
+  # Legitimate cross-org crash-recovery sweep at startup (mark RUNNING
+  # rows as PENDING so they can resume after a restart). Runs in the
+  # `lifespan` context, before any tenant context exists; spans every
+  # tenant by design. Acceptable because it does not RETURN data — it
+  # only updates status. A follow-up could move this to an explicit
+  # cross_org_session() helper, but for now the entry-module is opted
+  # out of the rule.
+  - klai-connector/app/main.py

--- a/rules/tests/fixtures/bad_syncrun_no_tenant.py
+++ b/rules/tests/fixtures/bad_syncrun_no_tenant.py
@@ -1,0 +1,19 @@
+# Fixture for SPEC-SEC-PORTAL-RLS-001 — untenanted SyncRun query.
+# The lint MUST flag this: `select(SyncRun)` is bound to a variable and
+# filtered only by connector_id + status. There is no SyncRun.org_id
+# clause anywhere in the chain, so a row from another tenant could leak
+# through (connector.sync_runs has no Postgres RLS policy — TP-5 in the
+# 2026-05-04 audit).
+
+from sqlalchemy import select
+
+from app.models.sync_run import SyncRun
+
+
+async def get_active_run(session, connector_id):
+    query = select(SyncRun).where(
+        SyncRun.connector_id == connector_id,
+        SyncRun.status == "running",
+    )
+    result = await session.execute(query)
+    return result.scalars().first()

--- a/rules/tests/fixtures/good_syncrun_tenant_scoped.py
+++ b/rules/tests/fixtures/good_syncrun_tenant_scoped.py
@@ -1,0 +1,17 @@
+# Fixture for SPEC-SEC-PORTAL-RLS-001 — canonical tenant-scoped SyncRun query.
+# `select(SyncRun)` is followed by a `.where(SyncRun.org_id == ...)` clause
+# in the same chain, so the tenant-isolation barrier is in place.
+
+from sqlalchemy import select
+
+from app.models.sync_run import SyncRun
+
+
+async def get_active_run(session, connector_id, org_id):
+    query = select(SyncRun).where(
+        SyncRun.connector_id == connector_id,
+        SyncRun.org_id == org_id,
+        SyncRun.status == "running",
+    )
+    result = await session.execute(query)
+    return result.scalars().first()

--- a/rules/tests/test_no_untenanted_syncrun_lint.py
+++ b/rules/tests/test_no_untenanted_syncrun_lint.py
@@ -1,0 +1,105 @@
+"""SPEC-SEC-PORTAL-RLS-001 REQ-3 — synthetic regression tests for the
+``no-untenanted-syncrun-query`` ast-grep rule.
+
+The rule lives at ``rules/no-untenanted-syncrun-query.yml`` and is
+discovered via the repo-root ``sgconfig.yml``. We invoke ast-grep
+directly against two fixture files:
+
+- ``fixtures/bad_syncrun_no_tenant.py`` — ``select(SyncRun)`` without a
+  ``SyncRun.org_id`` constraint anywhere in the chain. The lint MUST
+  exit non-zero and name the fixture file.
+- ``fixtures/good_syncrun_tenant_scoped.py`` — ``select(SyncRun)`` with
+  ``.where(SyncRun.org_id == org_id)``. The lint MUST exit zero.
+
+These tests are the mechanical guard for TP-5 (audit
+``reports/audit-2026-05-04/tenant-scoping.md``): connector.sync_runs has
+no Postgres RLS, so the application filter is the only barrier. If a
+future refactor drops the org_id clause, this rule fires before merge.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RULES_DIR = REPO_ROOT / "rules"
+FIXTURES_DIR = RULES_DIR / "tests" / "fixtures"
+SGCONFIG = REPO_ROOT / "sgconfig.yml"
+
+
+def _ast_grep_cli() -> list[str] | None:
+    """Resolve the ast-grep CLI invocation.
+
+    Prefers a system-installed ``sg`` or ``ast-grep``; falls back to
+    ``uvx --from ast-grep-cli ast-grep`` so the test works in CI without
+    an explicit install step.
+    """
+    if (sg := shutil.which("sg")) is not None:
+        return [sg]
+    if (ag := shutil.which("ast-grep")) is not None:
+        return [ag]
+    if (uvx := shutil.which("uvx")) is not None:
+        return [uvx, "--from", "ast-grep-cli", "ast-grep"]
+    return None
+
+
+@pytest.fixture(scope="module")
+def ast_grep_cli() -> list[str]:
+    cli = _ast_grep_cli()
+    if cli is None:
+        pytest.skip("ast-grep CLI not available (no `sg`, `ast-grep`, or `uvx`)")
+    return cli
+
+
+def _scan(cli: list[str], target: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [*cli, "scan", "--config", str(SGCONFIG), str(target)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_lint_fails_on_untenanted_syncrun(ast_grep_cli: list[str]) -> None:
+    """REQ-3: the rule MUST flag ``select(SyncRun)`` without ``org_id``.
+
+    Without this guard, a refactor that drops the application-level
+    tenant filter would not fail CI — and connector.sync_runs has no
+    Postgres RLS to fall back on (see TP-5).
+    """
+    fixture = FIXTURES_DIR / "bad_syncrun_no_tenant.py"
+    assert fixture.exists(), fixture
+    result = _scan(ast_grep_cli, fixture)
+
+    combined = result.stdout + result.stderr
+    assert result.returncode != 0, (
+        f"Lint did not fail on bad fixture (exit {result.returncode}). "
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "bad_syncrun_no_tenant.py" in combined, (
+        f"Lint output does not name the fixture. Output:\n{combined}"
+    )
+    assert "no-untenanted-syncrun-query" in combined, (
+        f"Lint output does not reference the rule id. Output:\n{combined}"
+    )
+
+
+def test_lint_passes_on_tenant_scoped_syncrun(ast_grep_cli: list[str]) -> None:
+    """REQ-3: the rule MUST NOT flag the canonical tenant-scoped pattern."""
+    fixture = FIXTURES_DIR / "good_syncrun_tenant_scoped.py"
+    assert fixture.exists(), fixture
+    result = _scan(ast_grep_cli, fixture)
+
+    # ast-grep returns exit 0 when no matches are found.
+    assert result.returncode == 0, (
+        f"Lint failed unexpectedly on good fixture (exit {result.returncode}). "
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "no-untenanted-syncrun-query" not in result.stdout, (
+        f"Lint flagged the good fixture. Output:\n{result.stdout}"
+    )


### PR DESCRIPTION
## Summary

Closes **TP-1** + **TP-5** from SPEC-CODEBASE-AUDIT-001 cluster C.

- **TP-1**: \`portal_join_requests\` had \`org_id\` column but no \`CREATE POLICY\` — DB-layer tenant isolation was absent. Migration \`2f7d1eae1198\` adds Category-A RLS policy.
- **TP-5**: ast-grep rule \`rules/no-untenanted-syncrun-query.yml\` + lint tests catches \`select|update|delete(SyncRun)\` without \`.where(...org_id...)\` in klai-connector.

## Adjusted scope (post-review)

\`portal_org_allowed_domains\` (originally TP-2) **intentionally NOT included**: SPEC-AUTH-009 R2 (migration \`ed5b78b296f5\`) replaced that table with \`portal_orgs.primary_domain\` and DROPS it via \`post_deploy_ed5b78b296f5.sql\`. Adding RLS to a deletion-path table would pollute migration history. \`test_r2_removal.py\` is the regression-guard for the absence — confirmed passing alongside the new RLS suite.

This adjustment was caught by user-review of the agent's first pass (which had attempted to add RLS to both tables). Validated by:
- Git log on the original migrations
- SPEC-AUTH-009 R2 + ed5b78b296f5 docstring
- Cross-grep showing only \`test_r2_removal.py\` references the table (no production code)

## Test plan

- [x] 8 new tests in test_rls_join_requests.py pass
- [x] 41 RLS regression tests pass (including 8 r2_removal tests)
- [x] ruff lint+format clean
- [x] alembic head clean (single head: 2f7d1eae1198)
- [x] ast-grep rule fires on bad fixture, silent on good fixture
- [x] 2 ast-grep lint tests pass

## Refs

- reports/audit-2026-05-04/tenant-scoping.md (TP-1, TP-2, TP-5)
- .moai/specs/SPEC-SEC-PORTAL-RLS-001/spec.md
- SPEC-AUTH-006 C5.4 (RLS originally specified)
- SPEC-AUTH-009 R2 + migration ed5b78b296f5 (allowed_domains drop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)