### PR TITLE
feat(libs): SPEC-LOGGING-EXTRACT-001 — extract setup_logging to klai-libs

### DIFF
--- a/.github/workflows/klai-mailer.yml
+++ b/.github/workflows/klai-mailer.yml
@@ -5,11 +5,13 @@ on:
     branches: [main]
     paths:
       - 'klai-mailer/**'
+      - 'klai-libs/log-utils/**'
       - '.github/workflows/klai-mailer.yml'
   pull_request:
     branches: [main]
     paths:
       - 'klai-mailer/**'
+      - 'klai-libs/log-utils/**'
       - '.github/workflows/klai-mailer.yml'
   workflow_dispatch:
 
@@ -63,7 +65,10 @@ jobs:
       - name: Build and push klai-mailer
         uses: docker/build-push-action@v7
         with:
-          context: ./klai-mailer
+          # SPEC-LOGGING-EXTRACT-001: build from repo root so the Dockerfile
+          # can COPY the shared klai-libs/log-utils path dep.
+          context: .
+          file: klai-mailer/Dockerfile
           push: true
           # `:latest` is published ONLY on push to main. PR builds publish
           # only the SHA tag so a `docker pull :latest` cannot accidentally

--- a/klai-libs/log-utils/README.md
+++ b/klai-libs/log-utils/README.md
@@ -9,9 +9,15 @@ service via a path dependency:
 klai-log-utils = { path = "../klai-libs/log-utils" }
 ```
 
-Source SPEC: `SPEC-SEC-INTERNAL-001` v0.3.0.
+Source SPECs:
+- `SPEC-SEC-INTERNAL-001` v0.3.0 — secret sanitisation + constant-time compare
+- `SPEC-LOGGING-EXTRACT-001` (this PR) — `setup_logging` +
+  `RequestContextMiddleware` + `HealthCheckAccessFilter` extracted from
+  the klai-mailer canonical implementation
 
 ## Public API
+
+### Secret-handling (SPEC-SEC-INTERNAL-001)
 
 ```python
 from log_utils import (
@@ -21,6 +27,116 @@ from log_utils import (
     verify_shared_secret,     # REQ-1.7 — constant-time inbound compare
 )
 ```
+
+### Structured logging (SPEC-LOGGING-EXTRACT-001)
+
+```python
+from log_utils import (
+    setup_logging,                    # service-bootstrap helper
+    RequestContextMiddleware,         # FastAPI/Starlette middleware (X-Request-ID, X-Org-ID, X-User-ID)
+    HealthCheckAccessFilter,          # logging.Filter dropping uvicorn /health access lines
+    DEFAULT_HEALTHCHECK_PATHS,        # frozenset[str] — defaults to {"/health"}
+    DEFAULT_THIRD_PARTY_LEVELS,       # dict[str, int] — sqlalchemy.engine + httpx muted to WARNING
+)
+```
+
+#### `setup_logging(service_name, *, healthcheck_paths=DEFAULT_HEALTHCHECK_PATHS, third_party_levels=None, extra_processors=None) -> None`
+
+Bootstraps structlog + the standard `logging` module to emit JSON to
+stdout. Call once at process start, BEFORE any logger is acquired.
+
+```python
+# In app/main.py:
+from log_utils import setup_logging
+setup_logging("portal-api")
+```
+
+`service_name` is REQUIRED and positional — there is no default. Each
+adopting service passes its own name so log records are filterable by
+`service:<name>` in VictoriaLogs.
+
+Optional kwargs:
+- `healthcheck_paths`: `Iterable[str]` — paths whose uvicorn access-log
+  records the filter SHALL drop. Defaults to `{"/health"}`. Pass an
+  explicit iterable to add service-specific paths
+  (e.g. `{"/health", "/internal/v1/healthz"}`).
+- `third_party_levels`: `dict[str, int] | None` — logger-name → level
+  mapping. `None` (default) applies `DEFAULT_THIRD_PARTY_LEVELS`
+  (sqlalchemy.engine + httpx muted to WARNING). Pass an explicit dict
+  to override.
+- `extra_processors`: `list[structlog.types.Processor] | None` — extra
+  processors prepended to the shared chain. portal-api uses this for
+  its `mask_secret_str` processor.
+
+Output format is controlled by the `LOG_FORMAT` env var: `json`
+(default, production) or `console` (dev — readable colour output). The
+internal hard-coded log level is INFO; there is intentionally no `level`
+parameter — service-level filtering should happen at the contextvar
+layer, not by raising the root logger threshold.
+
+If your service has historically called a wrapper that supplied a default
+`service_name` (e.g. klai-mailer's `app/logging_setup.py::setup_logging()`
+with no arguments), the wrapper is a thin shim for backward-compat with
+pre-extraction call sites — audit 2026-05-05 finding A2 noted the
+default-argument drift between wrapper and shared lib. New services
+should call `log_utils.setup_logging` directly with an explicit
+`service_name`. The shared lib intentionally does NOT supply a default
+to make adoption-by-grep visible.
+
+#### `RequestContextMiddleware`
+
+FastAPI / Starlette middleware that binds `request_id`, `org_id`, and
+optionally `user_id` to structlog context-vars for the duration of each
+request, then echoes `X-Request-ID` back on the response.
+
+```python
+from fastapi import FastAPI
+from log_utils import RequestContextMiddleware
+
+app = FastAPI()
+app.add_middleware(RequestContextMiddleware)
+```
+
+Optional construction kwargs:
+- `service_name`: `str | None` — if provided, re-binds the `service`
+  contextvar on every request. Useful when the contextvar set by
+  `setup_logging` might be cleared by another middleware. Default `None`
+  (no re-bind; rely on setup_logging's bind).
+- `bind_user_id`: `bool` — if `True`, also bind `user_id` from the
+  `X-User-ID` header when present. Default `False` — most services do
+  not have a tenant-scoped user header in their inbound flow.
+
+Reads `X-Request-ID` (set by Caddy / upstream services per
+SPEC-INFRA-004) and falls back to `uuid.uuid4()` if absent. The
+`X-Request-ID` is echoed back on the response so client-side correlation
+works.
+
+#### `HealthCheckAccessFilter(paths=DEFAULT_HEALTHCHECK_PATHS)`
+
+Drops `uvicorn.access` log records for health-check paths so
+VictoriaLogs is not flooded with `GET /health 200` noise.
+`setup_logging` already wires this in for the canonical paths
+(`DEFAULT_HEALTHCHECK_PATHS`); manual install is only needed for
+service-specific paths beyond the default.
+
+```python
+import logging
+from log_utils import HealthCheckAccessFilter
+
+# Drop /health AND /internal/v1/healthz access lines:
+logging.getLogger("uvicorn.access").addFilter(
+    HealthCheckAccessFilter(paths={"/health", "/internal/v1/healthz"})
+)
+```
+
+The constructor kwarg is `paths` (not `extra_paths`); the iterable
+REPLACES the default. Pass `{*DEFAULT_HEALTHCHECK_PATHS, "/extra"}` to
+ADD instead of replace.
+
+Defensive parsing: if uvicorn's record shape changes, the filter
+returns True (record passes through) rather than swallowing arbitrary
+records — better to leak a healthcheck line than swallow a real
+request log.
 
 ### `sanitize_response_body(exc_or_response, secret_values=None, *, max_len=512) -> str`
 
@@ -68,8 +184,23 @@ uv run pytest
 
 ## Versioning
 
-`0.1.0` is the initial ship. The four-symbol public API
-(`sanitize_response_body`, `sanitize_from_settings`,
-`extract_secret_values`, `verify_shared_secret`) is stable; any
-breaking change requires a major-version bump and a coordinated update
-in every consuming service.
+`0.1.0` is the initial ship — both the SPEC-SEC-INTERNAL-001 secret
+helpers and the SPEC-LOGGING-EXTRACT-001 structlog setup ship in the
+same package version. Breaking changes to ANY public symbol below
+require a major-version bump and a coordinated update in every
+consuming service.
+
+Secret-handling (4):
+  - `sanitize_response_body`
+  - `sanitize_from_settings`
+  - `extract_secret_values`
+  - `verify_shared_secret`
+
+Structured logging (5):
+  - `setup_logging`
+  - `RequestContextMiddleware`
+  - `HealthCheckAccessFilter`
+  - `DEFAULT_HEALTHCHECK_PATHS`
+  - `DEFAULT_THIRD_PARTY_LEVELS`
+
+Adding new symbols is a minor-version change.

--- a/klai-libs/log-utils/log_utils/__init__.py
+++ b/klai-libs/log-utils/log_utils/__init__.py
@@ -5,15 +5,32 @@ SPEC-SEC-INTERNAL-001 v0.3.0:
 - REQ-4.1  sanitize_response_body -- strip secret substrings from upstream bodies
 - REQ-4.2  extract_secret_values  -- pydantic-Settings introspection
 - REQ-4.4  sanitize_from_settings -- convenience wrapper
+
+SPEC-LOGGING-EXTRACT-001:
+- setup_logging              -- canonical structlog + stdlib setup
+- HealthCheckAccessFilter    -- drop /health uvicorn access lines
+- RequestContextMiddleware   -- bind X-Request-ID / X-Org-ID to logs
 """
 
 from .sanitize import sanitize_from_settings, sanitize_response_body
 from .secret_compare import verify_shared_secret
 from .settings_scan import extract_secret_values
+from .structlog_setup import (
+    DEFAULT_HEALTHCHECK_PATHS,
+    DEFAULT_THIRD_PARTY_LEVELS,
+    HealthCheckAccessFilter,
+    RequestContextMiddleware,
+    setup_logging,
+)
 
 __all__ = [
+    "DEFAULT_HEALTHCHECK_PATHS",
+    "DEFAULT_THIRD_PARTY_LEVELS",
+    "HealthCheckAccessFilter",
+    "RequestContextMiddleware",
     "extract_secret_values",
     "sanitize_from_settings",
     "sanitize_response_body",
+    "setup_logging",
     "verify_shared_secret",
 ]

--- a/klai-libs/log-utils/log_utils/structlog_setup.py
+++ b/klai-libs/log-utils/log_utils/structlog_setup.py
@@ -1,0 +1,255 @@
+"""Shared structlog setup + ASGI request-context middleware for Klai services.
+
+SPEC-LOGGING-EXTRACT-001 — extracted from ``klai-mailer/app/logging_setup.py``
+(the canonical with ``_HealthCheckAccessFilter``).
+
+Public surface:
+
+- :func:`setup_logging` — configure structlog + stdlib logging, route
+  ``uvicorn.access`` at INFO with a healthcheck filter, and bind
+  ``service`` as a contextvar so every log line carries it.
+- :class:`HealthCheckAccessFilter` — drops uvicorn access lines for paths
+  that you treat as healthchecks (default: ``/health``). Defensive against
+  uvicorn access-record format changes: if ``record.args`` doesn't match
+  the expected shape the record passes through.
+- :class:`RequestContextMiddleware` — Starlette middleware that binds
+  ``request_id`` (from ``X-Request-ID`` header set by Caddy, or a fresh
+  UUID) and optionally ``org_id`` / ``user_id`` for downstream log
+  correlation. Echoes ``X-Request-ID`` back to the client for browser
+  trace parity.
+
+Why "extract not refactor": the mailer's 2026-04-29 /notify outage proved
+the value of routing ``uvicorn.access`` at INFO + filtering healthcheck
+spam. Each service that re-implements the same pattern slightly
+differently is one config-drift away from re-living that outage. This
+module is the single source of truth.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import uuid
+from collections.abc import Awaitable, Callable, Iterable
+from typing import Any
+
+import structlog
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+# ---------------------------------------------------------------------------
+# Healthcheck access-log filter
+# ---------------------------------------------------------------------------
+
+# Paths that uvicorn.access SHALL drop. Healthcheck spam from Docker's
+# liveness probe (every ~10s) drowns the signal of real request lines.
+# Route paths must match ``request_line`` byte-for-byte as uvicorn formats
+# them: ``GET /health HTTP/1.1`` (no host, no query).
+DEFAULT_HEALTHCHECK_PATHS: frozenset[str] = frozenset({"/health"})
+
+
+class HealthCheckAccessFilter(logging.Filter):
+    """Drop uvicorn access-log records for healthcheck endpoints.
+
+    Inspects ``record.args`` (the tuple uvicorn passes to its
+    ``%s "%s %s HTTP/%s" %d`` format string). Args layout:
+    ``(client_addr, method, full_path, http_version, status_code)``.
+
+    Defensive: if ``args`` is missing or doesn't match the expected
+    shape, the record passes through. Better to leak a healthcheck line
+    than swallow a real request log on a future uvicorn change.
+    """
+
+    def __init__(self, paths: Iterable[str] = DEFAULT_HEALTHCHECK_PATHS) -> None:
+        super().__init__()
+        self._paths: frozenset[str] = frozenset(paths)
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        args = record.args
+        if not isinstance(args, tuple) or len(args) < 3:
+            return True
+        full_path = args[2]
+        if not isinstance(full_path, str):
+            return True
+        # full_path looks like "/health" or "/health?check=1"; split on '?'
+        path_only = full_path.split("?", 1)[0]
+        return path_only not in self._paths
+
+
+# Backward-compat private alias for code that imports the leading-underscore name
+# (e.g. klai-mailer/tests/test_logging_setup.py and the original mailer module).
+_HealthCheckAccessFilter = HealthCheckAccessFilter
+
+
+# ---------------------------------------------------------------------------
+# setup_logging
+# ---------------------------------------------------------------------------
+
+# Default third-party loggers that get muted to WARNING. Each service can
+# extend or override via ``setup_logging(third_party_levels=...)``.
+DEFAULT_THIRD_PARTY_LEVELS: dict[str, int] = {
+    "sqlalchemy.engine": logging.WARNING,
+    "httpx": logging.WARNING,
+}
+
+
+def setup_logging(
+    service_name: str,
+    *,
+    healthcheck_paths: Iterable[str] = DEFAULT_HEALTHCHECK_PATHS,
+    third_party_levels: dict[str, int] | None = None,
+    extra_processors: list[structlog.types.Processor] | None = None,
+) -> None:
+    """Configure structlog with stdlib integration.
+
+    Sets up the canonical Klai logging pipeline:
+
+    - structlog routed through ``stdlib.ProcessorFormatter`` so every
+      logger (structlog AND stdlib) renders through the same chain.
+    - Root logger at INFO writing to stdout (which Docker / Alloy tail).
+    - ``uvicorn.access`` at INFO so every request appears in
+      ``docker logs`` (lesson learnt the hard way during the 2026-04-29
+      mailer outage). Healthcheck spam is filtered via
+      :class:`HealthCheckAccessFilter`.
+    - Noisy third-party loggers muted to WARNING.
+    - ``service`` bound as a structlog contextvar.
+
+    Args:
+        service_name: The Docker / compose service name. Bound as a
+            structlog contextvar so every log line carries it. Required.
+        healthcheck_paths: Iterable of route paths whose access-log
+            records the filter SHALL drop. Defaults to ``{"/health"}``.
+        third_party_levels: Mapping of logger-name -> level for
+            third-party loggers that should be muted. Defaults to
+            ``{"sqlalchemy.engine": WARNING, "httpx": WARNING}``. Pass
+            an explicit dict to add/override (e.g. ``{"redis": WARNING}``).
+        extra_processors: Optional structlog processors prepended to the
+            shared chain (e.g. portal-api's ``mask_secret_str``).
+    """
+    log_format = os.environ.get("LOG_FORMAT", "json").lower()
+
+    shared_processors: list[structlog.types.Processor] = [
+        structlog.contextvars.merge_contextvars,
+        *(extra_processors or []),
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.add_logger_name,
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.format_exc_info,
+    ]
+
+    if log_format == "console":
+        renderer: structlog.types.Processor = structlog.dev.ConsoleRenderer()
+    else:
+        renderer = structlog.processors.JSONRenderer()
+
+    structlog.configure(
+        processors=[
+            *shared_processors,
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+        ],
+        wrapper_class=structlog.stdlib.BoundLogger,
+        context_class=dict,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        cache_logger_on_first_use=True,
+    )
+
+    formatter = structlog.stdlib.ProcessorFormatter(
+        processor=renderer,
+        foreign_pre_chain=shared_processors,
+    )
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(formatter)
+
+    root_logger = logging.getLogger()
+    root_logger.handlers.clear()
+    root_logger.addHandler(handler)
+    root_logger.setLevel(logging.INFO)
+
+    # uvicorn.access at INFO so every request is visible in `docker logs`
+    # — the diagnostic signal that was missing during the 2026-04-29 mailer
+    # /notify 500 outage. Spam from Docker healthcheck is filtered via the
+    # access-record filter so signal-to-noise stays good.
+    access_logger = logging.getLogger("uvicorn.access")
+    access_logger.setLevel(logging.INFO)
+    access_logger.addFilter(HealthCheckAccessFilter(paths=healthcheck_paths))
+
+    levels = dict(DEFAULT_THIRD_PARTY_LEVELS)
+    if third_party_levels is not None:
+        levels.update(third_party_levels)
+    for logger_name, level in levels.items():
+        logging.getLogger(logger_name).setLevel(level)
+
+    structlog.contextvars.bind_contextvars(service=service_name)
+
+
+# ---------------------------------------------------------------------------
+# RequestContextMiddleware
+# ---------------------------------------------------------------------------
+
+
+class RequestContextMiddleware(BaseHTTPMiddleware):
+    """Bind upstream trace context to structlog for log correlation.
+
+    Reads ``X-Request-ID`` set by Caddy (or generates a UUID4 if absent),
+    binds it as a structlog contextvar so every log line carries
+    ``request_id``, optionally also binds ``org_id`` (from ``X-Org-ID``)
+    and ``user_id`` (from ``X-User-ID``), then echoes ``X-Request-ID``
+    back to the client.
+
+    Use after :func:`setup_logging` so the ``service`` contextvar set by
+    setup_logging is preserved.
+
+    Args:
+        app: The ASGI app this middleware wraps (passed by Starlette).
+        service_name: Optional. If provided, the middleware re-binds the
+            ``service`` contextvar on every request — useful when the
+            service name might be cleared by other middleware. If ``None``
+            (the default), the contextvar set by :func:`setup_logging` is
+            preserved.
+        bind_user_id: If ``True``, bind ``user_id`` from ``X-User-ID``
+            header when present. Default ``False`` (most services don't
+            have a tenant-scoped user header in their inbound flow).
+    """
+
+    def __init__(
+        self,
+        app: Any,
+        *,
+        service_name: str | None = None,
+        bind_user_id: bool = False,
+    ) -> None:
+        super().__init__(app)
+        self._service_name = service_name
+        self._bind_user_id = bind_user_id
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        structlog.contextvars.clear_contextvars()
+        if self._service_name is not None:
+            structlog.contextvars.bind_contextvars(service=self._service_name)
+
+        request_id = request.headers.get("x-request-id") or str(uuid.uuid4())
+        structlog.contextvars.bind_contextvars(request_id=request_id)
+        if org_id := request.headers.get("x-org-id"):
+            structlog.contextvars.bind_contextvars(org_id=org_id)
+        if self._bind_user_id and (user_id := request.headers.get("x-user-id")):
+            structlog.contextvars.bind_contextvars(user_id=user_id)
+
+        response = await call_next(request)
+        response.headers["X-Request-ID"] = request_id
+        return response
+
+
+__all__ = [
+    "DEFAULT_HEALTHCHECK_PATHS",
+    "DEFAULT_THIRD_PARTY_LEVELS",
+    "HealthCheckAccessFilter",
+    "RequestContextMiddleware",
+    "setup_logging",
+]

--- a/klai-libs/log-utils/pyproject.toml
+++ b/klai-libs/log-utils/pyproject.toml
@@ -9,13 +9,18 @@ authors = [{ name = "Klai" }]
 
 # Runtime dependencies. Each consumer service pins concrete versions of structlog;
 # we express a compatible lower bound and let the embedder resolve.
+# starlette is required by RequestContextMiddleware (BaseHTTPMiddleware) — every
+# consumer service is FastAPI-based so starlette is already on their runtime
+# dependency graph; pinning it here makes the contract explicit.
 dependencies = [
     "structlog>=25.0",
+    "starlette>=0.40",
 ]
 
 [project.optional-dependencies]
 dev = [
     "pytest>=8",
+    "pytest-asyncio>=0.24",
     "httpx>=0.28",
     "ruff>=0.8",
     "pyright>=1.1.390",
@@ -24,6 +29,7 @@ dev = [
 [dependency-groups]
 dev = [
     "pytest>=8",
+    "pytest-asyncio>=0.24",
     "httpx>=0.28",
     "ruff>=0.8",
     "pyright>=1.1.390",
@@ -41,6 +47,7 @@ packages = ["log_utils"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+asyncio_mode = "auto"
 
 [tool.ruff]
 line-length = 120

--- a/klai-libs/log-utils/tests/test_structlog_setup.py
+++ b/klai-libs/log-utils/tests/test_structlog_setup.py
@@ -1,0 +1,309 @@
+"""Tests for log_utils.structlog_setup -- SPEC-LOGGING-EXTRACT-001.
+
+Covers:
+
+- ``setup_logging`` configures structlog and adds the healthcheck
+  filter to ``uvicorn.access``.
+- ``HealthCheckAccessFilter`` drops /health and passes everything else
+  (including defensive shape checks against future uvicorn changes).
+- ``RequestContextMiddleware`` binds ``request_id`` to structlog
+  contextvars from the ``X-Request-ID`` header (Caddy-set), generates a
+  fresh UUID4 when the header is absent, echoes the id back to the
+  client, and binds optional ``org_id`` / ``user_id``.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+import httpx
+import pytest
+import structlog
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+from log_utils import (
+    DEFAULT_HEALTHCHECK_PATHS,
+    HealthCheckAccessFilter,
+    RequestContextMiddleware,
+    setup_logging,
+)
+from log_utils.structlog_setup import _HealthCheckAccessFilter
+
+# ---------------------------------------------------------------------------
+# HealthCheckAccessFilter
+# ---------------------------------------------------------------------------
+
+
+def _make_access_record(method: str, path: str, status: int) -> logging.LogRecord:
+    """Build a LogRecord shaped like uvicorn.access emits.
+
+    args layout: (client_addr, method, full_path, http_version, status_code).
+    """
+    return logging.LogRecord(
+        name="uvicorn.access",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg='%s - "%s %s HTTP/%s" %d',
+        args=("127.0.0.1:54321", method, path, "1.1", status),
+        exc_info=None,
+    )
+
+
+class TestHealthCheckAccessFilter:
+    def setup_method(self) -> None:
+        self.filter = HealthCheckAccessFilter()
+
+    def test_health_check_access_filter_drops_health_logs(self) -> None:
+        """The headline contract: /health access lines are dropped."""
+        record = _make_access_record("GET", "/health", 200)
+        assert self.filter.filter(record) is False
+
+    def test_health_with_query_dropped(self) -> None:
+        record = _make_access_record("GET", "/health?probe=1", 200)
+        assert self.filter.filter(record) is False
+
+    def test_real_request_passes(self) -> None:
+        record = _make_access_record("POST", "/notify", 500)
+        assert self.filter.filter(record) is True
+
+    def test_unknown_path_passes(self) -> None:
+        record = _make_access_record("GET", "/wp-admin", 404)
+        assert self.filter.filter(record) is True
+
+    def test_health_prefix_paths_pass(self) -> None:
+        """Filter is byte-strict: /healthcheck and /health/sub must pass."""
+        for path in ("/healthcheck", "/health/sub", "/healthx"):
+            record = _make_access_record("GET", path, 200)
+            assert self.filter.filter(record) is True, f"path {path!r} dropped"
+
+    def test_no_args_passes(self) -> None:
+        record = logging.LogRecord(
+            name="uvicorn.access",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="x",
+            args=None,
+            exc_info=None,
+        )
+        assert self.filter.filter(record) is True
+
+    def test_short_args_passes(self) -> None:
+        record = logging.LogRecord(
+            name="uvicorn.access",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="x %s",
+            args=("only-one",),
+            exc_info=None,
+        )
+        assert self.filter.filter(record) is True
+
+    def test_non_string_path_passes(self) -> None:
+        record = logging.LogRecord(
+            name="uvicorn.access",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg='%s - "%s %s HTTP/%s" %d',
+            args=("127.0.0.1", "GET", 12345, "1.1", 200),
+            exc_info=None,
+        )
+        assert self.filter.filter(record) is True
+
+    def test_custom_paths(self) -> None:
+        f = HealthCheckAccessFilter(paths={"/livez", "/readyz"})
+        for path in ("/livez", "/readyz"):
+            assert f.filter(_make_access_record("GET", path, 200)) is False
+        assert f.filter(_make_access_record("GET", "/health", 200)) is True
+
+    def test_private_alias_is_same_class(self) -> None:
+        """Backward-compat: code importing ``_HealthCheckAccessFilter`` keeps working."""
+        assert _HealthCheckAccessFilter is HealthCheckAccessFilter
+
+
+# ---------------------------------------------------------------------------
+# setup_logging
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _restore_logging_state():
+    """Snapshot + restore root + uvicorn.access state around each test.
+
+    setup_logging mutates global logging state. Without this fixture, one
+    test's setup_logging call bleeds into subsequent tests.
+    """
+    root = logging.getLogger()
+    saved_handlers = list(root.handlers)
+    saved_level = root.level
+    access = logging.getLogger("uvicorn.access")
+    saved_access_filters = list(access.filters)
+    saved_access_level = access.level
+    yield
+    root.handlers = saved_handlers
+    root.setLevel(saved_level)
+    access.filters = saved_access_filters
+    access.setLevel(saved_access_level)
+    structlog.reset_defaults()
+    structlog.contextvars.clear_contextvars()
+
+
+class TestSetupLogging:
+    def test_setup_logging_configures_structlog(self) -> None:
+        setup_logging("test-svc")
+        # is_configured() is the structlog API for "configure() was called"
+        assert structlog.is_configured() is True
+
+    def test_setup_logging_binds_service_contextvar(self) -> None:
+        setup_logging("test-svc")
+        merged = structlog.contextvars.get_contextvars()
+        assert merged.get("service") == "test-svc"
+
+    def test_setup_logging_routes_uvicorn_access_at_info(self) -> None:
+        setup_logging("test-svc")
+        access = logging.getLogger("uvicorn.access")
+        assert access.level == logging.INFO
+
+    def test_setup_logging_attaches_healthcheck_filter(self) -> None:
+        setup_logging("test-svc")
+        access = logging.getLogger("uvicorn.access")
+        # At least one of the attached filters is our HealthCheckAccessFilter
+        attached = [f for f in access.filters if isinstance(f, HealthCheckAccessFilter)]
+        assert len(attached) == 1
+
+    def test_setup_logging_silences_default_third_party(self) -> None:
+        setup_logging("test-svc")
+        assert logging.getLogger("sqlalchemy.engine").level == logging.WARNING
+        assert logging.getLogger("httpx").level == logging.WARNING
+
+    def test_setup_logging_extra_third_party_levels_merge(self) -> None:
+        setup_logging("test-svc", third_party_levels={"redis": logging.WARNING})
+        assert logging.getLogger("redis").level == logging.WARNING
+        # Defaults still applied
+        assert logging.getLogger("httpx").level == logging.WARNING
+
+    def test_setup_logging_custom_healthcheck_paths(self) -> None:
+        setup_logging("test-svc", healthcheck_paths={"/livez"})
+        access = logging.getLogger("uvicorn.access")
+        attached = [f for f in access.filters if isinstance(f, HealthCheckAccessFilter)]
+        assert len(attached) == 1
+        # Filter's paths reflect the override
+        assert attached[0].filter(_make_access_record("GET", "/livez", 200)) is False
+        assert attached[0].filter(_make_access_record("GET", "/health", 200)) is True
+
+    def test_default_healthcheck_paths_is_health(self) -> None:
+        assert DEFAULT_HEALTHCHECK_PATHS == frozenset({"/health"})
+
+
+# ---------------------------------------------------------------------------
+# RequestContextMiddleware
+# ---------------------------------------------------------------------------
+
+
+def _build_app(*, service_name: str | None = None, bind_user_id: bool = False) -> Starlette:
+    """Build a minimal Starlette app with the middleware installed.
+
+    The ``/echo`` endpoint returns the merged structlog contextvars so
+    tests can assert on what got bound during the request.
+    """
+
+    async def echo(request: Request) -> JSONResponse:
+        return JSONResponse(dict(structlog.contextvars.get_contextvars()))
+
+    app = Starlette(routes=[Route("/echo", echo)])
+    app.add_middleware(
+        RequestContextMiddleware,
+        service_name=service_name,
+        bind_user_id=bind_user_id,
+    )
+    return app
+
+
+@pytest.mark.asyncio
+async def test_request_context_middleware_binds_request_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When no header is set, middleware generates a deterministic UUID4."""
+    fake_uuid = uuid.UUID("12345678-1234-5678-1234-567812345678")
+    monkeypatch.setattr(
+        "log_utils.structlog_setup.uuid.uuid4",
+        lambda: fake_uuid,
+    )
+    app = _build_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/echo")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["request_id"] == str(fake_uuid)
+    # And the response echoes it back to the client
+    assert response.headers["x-request-id"] == str(fake_uuid)
+
+
+@pytest.mark.asyncio
+async def test_request_context_middleware_uses_caddy_header() -> None:
+    """When Caddy passes X-Request-ID, middleware honours it (does NOT regenerate)."""
+    caddy_id = "caddy-trace-abc-123"
+    app = _build_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/echo", headers={"X-Request-ID": caddy_id})
+    body = response.json()
+    assert body["request_id"] == caddy_id
+    assert response.headers["x-request-id"] == caddy_id
+
+
+@pytest.mark.asyncio
+async def test_request_context_middleware_binds_org_id() -> None:
+    app = _build_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/echo", headers={"X-Org-ID": "org-42"})
+    body = response.json()
+    assert body["org_id"] == "org-42"
+
+
+@pytest.mark.asyncio
+async def test_request_context_middleware_org_id_absent_when_header_missing() -> None:
+    app = _build_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/echo")
+    body = response.json()
+    assert "org_id" not in body
+
+
+@pytest.mark.asyncio
+async def test_request_context_middleware_binds_service_when_configured() -> None:
+    app = _build_app(service_name="klai-test-svc")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/echo")
+    body = response.json()
+    assert body["service"] == "klai-test-svc"
+
+
+@pytest.mark.asyncio
+async def test_request_context_middleware_user_id_optional_off() -> None:
+    """user_id is opt-in — even when X-User-ID is set it's not bound by default."""
+    app = _build_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/echo", headers={"X-User-ID": "u-99"})
+    body = response.json()
+    assert "user_id" not in body
+
+
+@pytest.mark.asyncio
+async def test_request_context_middleware_user_id_bound_when_enabled() -> None:
+    app = _build_app(bind_user_id=True)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/echo", headers={"X-User-ID": "u-99"})
+    body = response.json()
+    assert body["user_id"] == "u-99"

--- a/klai-libs/log-utils/uv.lock
+++ b/klai-libs/log-utils/uv.lock
@@ -93,6 +93,7 @@ name = "klai-log-utils"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "starlette" },
     { name = "structlog" },
 ]
 
@@ -101,6 +102,7 @@ dev = [
     { name = "httpx" },
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
 
@@ -109,6 +111,7 @@ dev = [
     { name = "httpx" },
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
 
@@ -117,7 +120,9 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.390" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8" },
+    { name = "starlette", specifier = ">=0.40" },
     { name = "structlog", specifier = ">=25.0" },
 ]
 provides-extras = ["dev"]
@@ -127,6 +132,7 @@ dev = [
     { name = "httpx", specifier = ">=0.28" },
     { name = "pyright", specifier = ">=1.1.390" },
     { name = "pytest", specifier = ">=8" },
+    { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "ruff", specifier = ">=0.8" },
 ]
 
@@ -196,6 +202,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075 },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.12"
 source = { registry = "https://pypi.org/simple" }
@@ -218,6 +237,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277 },
     { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758 },
     { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821 },
+]
+
+[[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651 },
 ]
 
 [[package]]

--- a/klai-mailer/Dockerfile
+++ b/klai-mailer/Dockerfile
@@ -1,12 +1,48 @@
+# SPEC-LOGGING-EXTRACT-001: build context is the repo root and the image
+# mirrors the repo layout under /repo so the path dep
+# `../klai-libs/log-utils` resolves WITHIN the workspace. Switched from
+# `pip install .` to uv because pip does not read `[tool.uv.sources]` and
+# would fall through to a PyPI lookup that fails (uv-pip-install-skips-uv-sources
+# pitfall — same trap that bit klai-connector pre-fix).
+
+FROM python:3.12-slim AS deps
+
+# uv from the official distroless image
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+
+RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+
+# Repo-mirror layout
+WORKDIR /repo
+COPY klai-libs/log-utils klai-libs/log-utils
+COPY klai-mailer/pyproject.toml klai-mailer/pyproject.toml
+COPY klai-mailer/uv.lock klai-mailer/uv.lock
+
+WORKDIR /repo/klai-mailer
+
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_PYTHON_DOWNLOADS=never
+
+RUN uv sync --frozen --no-dev --no-install-project
+
+
+# Stage 2: Application
 FROM python:3.12-slim
 
-WORKDIR /app
+WORKDIR /repo/klai-mailer
 
-COPY pyproject.toml .
-RUN pip install --no-cache-dir .
+# Venv (has editable klai-log-utils pointer) + the shared-lib source the
+# editable install points at.
+COPY --from=deps /repo/klai-mailer/.venv /repo/klai-mailer/.venv
+COPY --from=deps /repo/klai-libs /repo/klai-libs
 
-COPY app/ ./app/
-COPY theme/ ./theme/
+ENV PATH="/repo/klai-mailer/.venv/bin:${PATH}" \
+    VIRTUAL_ENV="/repo/klai-mailer/.venv"
+
+# Application code (app/, theme/, zitadel-message-texts/ are under klai-mailer/).
+COPY klai-mailer/app/ ./app/
+COPY klai-mailer/theme/ ./theme/
 
 RUN useradd --system --no-create-home mailer
 USER mailer

--- a/klai-mailer/app/logging_setup.py
+++ b/klai-mailer/app/logging_setup.py
@@ -1,123 +1,59 @@
-"""Structured logging setup using structlog."""
+"""Structured logging setup for klai-mailer.
 
-import logging
-import os
-import sys
-import uuid
+SPEC-LOGGING-EXTRACT-001: the canonical setup_logging + middleware +
+healthcheck filter live in ``log_utils.structlog_setup``. This module is
+a thin compat shim so existing imports keep working:
 
-import structlog
-from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.requests import Request
-from starlette.responses import Response
+    from app.logging_setup import RequestContextMiddleware, setup_logging
+    from app.logging_setup import _HealthCheckAccessFilter  # tests/
 
-# Paths that the access log SHALL drop. Healthcheck spam from Docker's
-# liveness probe (every ~10s) drowns the signal of real /notify and
-# /internal/send requests. Route paths must match `request_line` byte-for-byte
-# as uvicorn formats them: ``GET /health HTTP/1.1`` (no host, no query).
-_ACCESS_LOG_FILTERED_PATHS: frozenset[str] = frozenset({"/health"})
+The mailer's own ``setup_logging()`` defaulted ``service_name`` to
+``"klai-mailer"`` and the middleware unconditionally rebound it on every
+request. We preserve both behaviours via ``_setup_logging`` /
+``RequestContextMiddleware`` wrappers.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from log_utils.structlog_setup import (
+    HealthCheckAccessFilter,
+)
+from log_utils.structlog_setup import (
+    RequestContextMiddleware as _BaseRequestContextMiddleware,
+)
+from log_utils.structlog_setup import setup_logging as _setup_logging
+
+# Backward-compat alias preserved for klai-mailer/tests/test_logging_setup.py
+# which imports the leading-underscore name. Both names resolve to the same class.
+_HealthCheckAccessFilter = HealthCheckAccessFilter
+
+# Service name bound to structlog contextvars on startup AND re-bound on every
+# request by the middleware below.
+_SERVICE_NAME = "klai-mailer"
 
 
-class _HealthCheckAccessFilter(logging.Filter):
-    """Drop uvicorn access log records for healthcheck endpoints.
+def setup_logging(service_name: str = _SERVICE_NAME) -> None:
+    """Configure structlog with stdlib integration (delegates to log_utils)."""
+    _setup_logging(service_name)
 
-    SPEC-SEC-MAILER-INJECTION-001 v0.3.2 follow-up: yesterday's /notify
-    500 outage was four-times longer to diagnose than necessary because the
-    mailer suppressed ``uvicorn.access`` at WARNING level — request
-    lines never appeared in ``docker logs``. Re-enabling INFO shows the
-    real request flow but also surfaces every Docker healthcheck. This
-    filter removes the noise without removing the signal.
 
-    The filter inspects ``record.args`` (the tuple uvicorn passes to
-    its ``%s "%s %s HTTP/%s" %d`` format string) so it works regardless
-    of the eventual rendered message. Defensive against changes to
-    uvicorn's access-log format: if ``args`` is missing or doesn't
-    match the expected shape, the record passes through (we'd rather
-    leak a healthcheck line than swallow a real request log).
+class RequestContextMiddleware(_BaseRequestContextMiddleware):
+    """Bind trace context from upstream services to structlog for log correlation.
+
+    klai-mailer's original middleware unconditionally rebound
+    ``service="klai-mailer"`` on every request. The shared
+    ``log_utils.structlog_setup.RequestContextMiddleware`` makes that
+    optional via a constructor kwarg; this subclass keeps the original
+    behaviour for the mailer.
     """
 
-    def filter(self, record: logging.LogRecord) -> bool:
-        args = record.args
-        if not isinstance(args, tuple) or len(args) < 3:
-            return True
-        # uvicorn access record args: (client_addr, method, full_path, http_version, status_code)
-        full_path = args[2]
-        if not isinstance(full_path, str):
-            return True
-        # full_path looks like "/health" or "/health?check=1"; split on '?'
-        path_only = full_path.split("?", 1)[0]
-        return path_only not in _ACCESS_LOG_FILTERED_PATHS
+    def __init__(self, app: Any) -> None:
+        super().__init__(app, service_name=_SERVICE_NAME)
 
 
-def setup_logging(service_name: str = "klai-mailer") -> None:
-    """Configure structlog with stdlib integration.
-
-    Args:
-        service_name: The Docker service name, bound as a context variable.
-    """
-    log_format = os.environ.get("LOG_FORMAT", "json").lower()
-
-    shared_processors: list[structlog.types.Processor] = [
-        structlog.contextvars.merge_contextvars,
-        structlog.stdlib.add_log_level,
-        structlog.stdlib.add_logger_name,
-        structlog.processors.TimeStamper(fmt="iso"),
-        structlog.processors.StackInfoRenderer(),
-        structlog.processors.format_exc_info,
-    ]
-
-    if log_format == "console":
-        renderer: structlog.types.Processor = structlog.dev.ConsoleRenderer()
-    else:
-        renderer = structlog.processors.JSONRenderer()
-
-    structlog.configure(
-        processors=[
-            *shared_processors,
-            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
-        ],
-        wrapper_class=structlog.stdlib.BoundLogger,
-        context_class=dict,
-        logger_factory=structlog.stdlib.LoggerFactory(),
-        cache_logger_on_first_use=True,
-    )
-
-    formatter = structlog.stdlib.ProcessorFormatter(
-        processor=renderer,
-        foreign_pre_chain=shared_processors,
-    )
-    handler = logging.StreamHandler(sys.stdout)
-    handler.setFormatter(formatter)
-
-    root_logger = logging.getLogger()
-    root_logger.handlers.clear()
-    root_logger.addHandler(handler)
-    root_logger.setLevel(logging.INFO)
-
-    # uvicorn.access at INFO so every request is visible in `docker logs`
-    # — the diagnostic signal that was missing during the 2026-04-29 mailer
-    # /notify 500 outage. Spam from Docker healthcheck is filtered out via
-    # _HealthCheckAccessFilter so signal-to-noise stays good.
-    access_logger = logging.getLogger("uvicorn.access")
-    access_logger.setLevel(logging.INFO)
-    access_logger.addFilter(_HealthCheckAccessFilter())
-    logging.getLogger("sqlalchemy.engine").setLevel(logging.WARNING)
-    logging.getLogger("httpx").setLevel(logging.WARNING)
-
-    structlog.contextvars.bind_contextvars(service=service_name)
-
-
-class RequestContextMiddleware(BaseHTTPMiddleware):
-    """Bind trace context from upstream services to structlog for log correlation."""
-
-    async def dispatch(self, request: Request, call_next: ...) -> Response:
-        structlog.contextvars.clear_contextvars()
-        structlog.contextvars.bind_contextvars(service="klai-mailer")
-
-        request_id = request.headers.get("x-request-id") or str(uuid.uuid4())
-        structlog.contextvars.bind_contextvars(request_id=request_id)
-        if org_id := request.headers.get("x-org-id"):
-            structlog.contextvars.bind_contextvars(org_id=org_id)
-
-        response = await call_next(request)
-        response.headers["X-Request-ID"] = request_id
-        return response
+__all__ = [
+    "RequestContextMiddleware",
+    "setup_logging",
+]

--- a/klai-mailer/pyproject.toml
+++ b/klai-mailer/pyproject.toml
@@ -13,7 +13,13 @@ dependencies = [
     "structlog>=25.0",
     "redis>=5.0",
     "email-validator>=2.0",
+    # SPEC-LOGGING-EXTRACT-001: shared setup_logging + RequestContextMiddleware
+    # + HealthCheckAccessFilter — klai-mailer is the canonical reference impl.
+    "klai-log-utils",
 ]
+
+[tool.uv.sources]
+klai-log-utils = { path = "../klai-libs/log-utils", editable = true }
 
 [project.optional-dependencies]
 dev = [

--- a/klai-mailer/uv.lock
+++ b/klai-mailer/uv.lock
@@ -304,6 +304,36 @@ wheels = [
 ]
 
 [[package]]
+name = "klai-log-utils"
+version = "0.1.0"
+source = { editable = "../klai-libs/log-utils" }
+dependencies = [
+    { name = "starlette" },
+    { name = "structlog" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.390" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8" },
+    { name = "starlette", specifier = ">=0.40" },
+    { name = "structlog", specifier = ">=25.0" },
+]
+provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "httpx", specifier = ">=0.28" },
+    { name = "pyright", specifier = ">=1.1.390" },
+    { name = "pytest", specifier = ">=8" },
+    { name = "pytest-asyncio", specifier = ">=0.24" },
+    { name = "ruff", specifier = ">=0.8" },
+]
+
+[[package]]
 name = "klai-mailer"
 version = "0.1.0"
 source = { virtual = "." }
@@ -313,6 +343,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
     { name = "jinja2" },
+    { name = "klai-log-utils" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "redis" },
@@ -340,6 +371,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "jinja2", specifier = ">=3.1" },
+    { name = "klai-log-utils", editable = "../klai-libs/log-utils" },
     { name = "lxml", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "pydantic", specifier = ">=2.9" },
     { name = "pydantic-settings", specifier = ">=2.6" },


### PR DESCRIPTION
## Summary

Closes part of **Cluster J** (Maintainability) from SPEC-CODEBASE-AUDIT-001: ~560 LOC dedup-kans across 8 services with same setup_logging() + RequestContextMiddleware boilerplate.

This PR delivers:
- **EXTRACT step** — canonical impl in \`klai-libs/log-utils/log_utils/structlog_setup.py\`
- **DEMO migration** of klai-mailer (which was the canonical mailer-pattern reference)

Other 7 services migrate per-PR later — out of scope here to limit blast radius.

## API

\`\`\`python
from log_utils import (
    setup_logging,                   # service_name + extension points
    RequestContextMiddleware,        # binds request_id, org_id, user_id on contextvars
    HealthCheckAccessFilter,         # drops /health logs
    DEFAULT_HEALTHCHECK_PATHS,
    DEFAULT_THIRD_PARTY_LEVELS,
)
\`\`\`

## Test plan

- [x] 25 new tests in klai-libs/log-utils pass
- [x] 96 mailer pre-existing tests pass (full suite)
- [x] 54 total tests in klai-libs/log-utils (29 existing + 25 new) pass
- [x] ruff clean on both packages
- [x] mailer app import smoke-test confirms RequestContextMiddleware wired

## Refs

- reports/audit-2026-05-04/maintainability-duplication-naming.md (5.2)
- reports/audit-2026-05-04/pattern-divergence.md (rij 11-13)
- .moai/specs/SPEC-LOGGING-EXTRACT-001/spec.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)