### PR TITLE
fix(chat): narrow toggle in dropdown + tri-state kb_slugs_filter contract

### DIFF
--- a/deploy/litellm/klai_knowledge.py
+++ b/deploy/litellm/klai_knowledge.py
@@ -630,10 +630,39 @@ class KlaiKnowledgeHook(CustomLogger):
             data["messages"] = messages
             return data
 
-        # Determine retrieval scope, KB slug filter, and answer mode
-        scope = "both" if feature.get("kb_personal_enabled", True) else "org"
-        kb_slugs = feature.get("kb_slugs_filter")  # None = all org KBs
+        # Determine retrieval scope, KB slug filter, and answer mode.
+        #
+        # `kb_slugs_filter` tri-state contract (matches portal-api +
+        # ChatConfigBar dropdown):
+        #   None   = "all org KBs" (default)
+        #   []     = "no org KBs"  (user turned every collection off)
+        #   [...]  = explicit subset
+        #
+        # Combined with `kb_personal_enabled`, this gives 6 reachable
+        # states. The historic `if kb_slugs:` branch treated `[]` and
+        # `None` identically, so a user who turned EVERY org collection
+        # off (and personal too) silently still got every org chunk
+        # injected — exact opposite of intent.
+        kb_personal = feature.get("kb_personal_enabled", True)
+        kb_slugs = feature.get("kb_slugs_filter")
         kb_narrow = feature.get("kb_narrow", False)
+
+        # User explicitly opted out of every scope → skip retrieval. Templates
+        # may still apply (REQ-TEMPLATES-HOOK-U2 fail-open).
+        if not kb_personal and kb_slugs == []:
+            _prepend_system_prefix(messages, templates_block)
+            data["messages"] = messages
+            return data
+
+        # Translate (kb_personal, kb_slugs) → retrieval-api `scope` + optional
+        # `kb_slugs` filter.
+        if kb_personal and kb_slugs == []:
+            # Personal-only: no org KBs at all.
+            scope = "personal"
+            kb_slugs_for_request: list[str] | None = None
+        else:
+            scope = "both" if kb_personal else "org"
+            kb_slugs_for_request = kb_slugs if kb_slugs else None
 
         conversation_history = _build_conversation_history(messages)
 
@@ -645,8 +674,8 @@ class KlaiKnowledgeHook(CustomLogger):
             "top_k": RETRIEVE_TOP_K,
             "conversation_history": conversation_history,
         }
-        if kb_slugs:
-            retrieve_body["kb_slugs"] = kb_slugs
+        if kb_slugs_for_request:
+            retrieve_body["kb_slugs"] = kb_slugs_for_request
 
         # SPEC-SEC-SERVICE-AUTH-001 Phase C-1: prefer JWT auth, fall back to
         # legacy X-Internal-Secret on either mint failure OR receiver-side

--- a/deploy/litellm/tests/test_klai_knowledge_hook.py
+++ b/deploy/litellm/tests/test_klai_knowledge_hook.py
@@ -367,6 +367,131 @@ class TestKlaiKnowledgeHookDualAuth:
             assert "Authorization" not in headers
 
 
+# ─── kb_slugs_filter tri-state tests (2026-05-05 follow-up) ─────────────────
+
+
+class TestKlaiKnowledgeHookSlugsTriState:
+    """Pin the tri-state contract for ``kb_slugs_filter``:
+
+    * ``None`` → all org KBs (no filter sent)
+    * ``[]``   → user explicitly turned every org collection off
+    * ``[..]`` → explicit subset
+
+    The hook used to treat ``[]`` and ``None`` as identical via
+    ``if kb_slugs:``, so a user who turned every collection off (and
+    personal too) silently still got every org chunk injected — the
+    exact opposite of intent. See pitfalls →
+    ``kb-slugs-filter-empty-list-collapse``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_empty_slugs_and_personal_off_skips_retrieval(self, monkeypatch):
+        """[] + personal=False → hook short-circuits, no /retrieve call."""
+        mod = _load_hook(monkeypatch)
+        hook = mod.KlaiKnowledgeHook()
+        cache = _make_cache(
+            feature={
+                "enabled": True,
+                "kb_retrieval_enabled": True,
+                "kb_personal_enabled": False,
+                "kb_slugs_filter": [],
+                "kb_narrow": False,
+                "version": 0,
+            }
+        )
+        data = {"user": "u1" * 12, "messages": [
+            {"role": "user", "content": "What about that thing?"}
+        ]}
+
+        with patch("klai_knowledge.httpx.AsyncClient") as cls:
+            mc = AsyncMock()
+            mc.get = AsyncMock(return_value=_make_resp({"instructions": []}))
+            mc.post = AsyncMock(return_value=_make_resp({"chunks": []}))
+            mc.__aenter__ = AsyncMock(return_value=mc)
+            mc.__aexit__ = AsyncMock(return_value=None)
+            cls.return_value = mc
+
+            await hook.async_pre_call_hook(_make_user_api_key(), cache, data, "completion")
+
+            # No /retrieve call — user opted out of every scope.
+            assert mc.post.call_count == 0, (
+                "kb_personal=False + kb_slugs=[] MUST skip retrieval entirely. "
+                "If a /retrieve call goes out the user gets back chunks they "
+                "explicitly told us not to fetch."
+            )
+
+    @pytest.mark.asyncio
+    async def test_empty_slugs_and_personal_on_uses_personal_scope(self, monkeypatch):
+        """[] + personal=True → scope=personal, no kb_slugs filter."""
+        mod = _load_hook(monkeypatch)
+        hook = mod.KlaiKnowledgeHook()
+        cache = _make_cache(
+            feature={
+                "enabled": True,
+                "kb_retrieval_enabled": True,
+                "kb_personal_enabled": True,
+                "kb_slugs_filter": [],
+                "kb_narrow": False,
+                "version": 0,
+            }
+        )
+        data = {"user": "u1" * 12, "messages": [
+            {"role": "user", "content": "What about that thing?"}
+        ]}
+
+        with patch("klai_knowledge.httpx.AsyncClient") as cls:
+            mc = AsyncMock()
+            mc.get = AsyncMock(return_value=_make_resp({"instructions": []}))
+            mc.post = AsyncMock(return_value=_make_resp({"chunks": []}))
+            mc.__aenter__ = AsyncMock(return_value=mc)
+            mc.__aexit__ = AsyncMock(return_value=None)
+            cls.return_value = mc
+
+            await hook.async_pre_call_hook(_make_user_api_key(), cache, data, "completion")
+
+            assert mc.post.call_count == 1
+            body = mc.post.call_args.kwargs["json"]
+            assert body["scope"] == "personal", (
+                f"Expected scope=personal when only personal is enabled, got {body['scope']!r}"
+            )
+            assert "kb_slugs" not in body, (
+                "kb_slugs filter MUST NOT be sent in personal-only scope."
+            )
+
+    @pytest.mark.asyncio
+    async def test_null_slugs_keeps_both_scope_no_filter(self, monkeypatch):
+        """None + personal=True → scope=both, no filter (default behaviour)."""
+        mod = _load_hook(monkeypatch)
+        hook = mod.KlaiKnowledgeHook()
+        cache = _make_cache(
+            feature={
+                "enabled": True,
+                "kb_retrieval_enabled": True,
+                "kb_personal_enabled": True,
+                "kb_slugs_filter": None,
+                "kb_narrow": False,
+                "version": 0,
+            }
+        )
+        data = {"user": "u1" * 12, "messages": [
+            {"role": "user", "content": "What about that thing?"}
+        ]}
+
+        with patch("klai_knowledge.httpx.AsyncClient") as cls:
+            mc = AsyncMock()
+            mc.get = AsyncMock(return_value=_make_resp({"instructions": []}))
+            mc.post = AsyncMock(return_value=_make_resp({"chunks": []}))
+            mc.__aenter__ = AsyncMock(return_value=mc)
+            mc.__aexit__ = AsyncMock(return_value=None)
+            cls.return_value = mc
+
+            await hook.async_pre_call_hook(_make_user_api_key(), cache, data, "completion")
+
+            body = mc.post.call_args.kwargs["json"]
+            assert body["scope"] == "both"
+            assert "kb_slugs" not in body
+
+
 # ─── 2026-05-05 fail-loud regression tests ──────────────────────────────────
 
 

--- a/klai-portal/backend/app/api/app_account.py
+++ b/klai-portal/backend/app/api/app_account.py
@@ -158,11 +158,19 @@ async def patch_kb_preference(
     if "kb_slugs_filter" in body.model_fields_set:
         slugs = body.kb_slugs_filter
 
-        # Normalize empty list to null (empty list would mean "no org KBs", null means "all")
-        if slugs is not None and len(slugs) == 0:
-            slugs = None
-
-        if slugs is not None:
+        # Tri-state contract:
+        #   None  = "all org KBs" (default; client did not narrow)
+        #   []    = "no org KBs"  (user explicitly turned all off)
+        #   [..]  = explicit subset
+        #
+        # The earlier collapse `[] -> None` here was a silent destruction of
+        # user intent: when the user turned off the LAST org KB the client
+        # sent `[]`, the server stored it as `None`, the GET round-trip
+        # returned `None`, and the next render flipped every collection back
+        # to "on". The frontend's toggleSlug comment explicitly warns
+        # "DO NOT collapse empty to null" — this commit makes the server
+        # honour that contract.
+        if slugs is not None and len(slugs) > 0:
             # Validate all slugs belong to the caller's org (REQ-N3)
             result = await db.execute(
                 select(PortalKnowledgeBase.slug).where(

--- a/klai-portal/backend/tests/test_kb_preference_empty_list.py
+++ b/klai-portal/backend/tests/test_kb_preference_empty_list.py
@@ -1,0 +1,130 @@
+"""Regression-guard for the kb_slugs_filter `[]` preservation contract.
+
+The PATCH /api/app/account/kb-preference endpoint historically collapsed
+``kb_slugs_filter: []`` to ``None`` in `_normalise`-style code. This made
+the tri-state contract (None=all, []=none, [..]=subset) impossible to
+express — when a user turned off the LAST org KB the client sent ``[]``,
+the server stored ``None``, and the next render flipped every collection
+back to "on".
+
+This test pins the contract: an explicit empty list MUST round-trip as
+``[]``, not ``None``.
+
+Pure unit test of `patch_kb_preference`. Mocks the AsyncSession and the
+auth dependency; no real DB or network involved.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+class _FakeUser:
+    def __init__(self) -> None:
+        self.kb_retrieval_enabled = True
+        self.kb_personal_enabled = True
+        self.kb_slugs_filter: list[str] | None = None
+        self.kb_narrow = False
+        self.kb_pref_version = 0
+        self.active_template_ids: list[int] | None = None
+        self.librechat_user_id = ""
+
+
+class _FakeOrg:
+    id = 42
+
+
+def _empty_query_result() -> MagicMock:
+    """Empty SQLAlchemy result — no rows, used to allow validation to pass."""
+    rows: list = []
+    res = MagicMock()
+    res.__iter__ = lambda self: iter(rows)
+    return res
+
+
+@pytest.mark.asyncio
+async def test_empty_kb_slugs_filter_round_trips_as_empty_list(monkeypatch):
+    """``kb_slugs_filter: []`` must be stored verbatim, never collapsed to None.
+
+    See pitfalls/process-rules.md → ``kb-slugs-filter-empty-list-collapse``
+    once that lands. The frontend's ``ChatConfigBar.toggleSlug`` comment
+    explicitly warns "DO NOT collapse empty to null"; this test pins the
+    server contract that matches.
+    """
+    from app.api.app_account import KBPreferencePatch, patch_kb_preference
+
+    fake_user = _FakeUser()
+    fake_user.kb_slugs_filter = ["existing-kb"]  # non-empty before
+    fake_org = _FakeOrg()
+
+    db = AsyncMock()
+    db.commit = AsyncMock()
+    # Validation step is bypassed because the empty list short-circuits
+    # the validation branch (no slugs → no DB lookup needed).
+    db.execute = AsyncMock(return_value=_empty_query_result())
+
+    monkeypatch.setattr(
+        "app.api.app_account._get_caller_org",
+        AsyncMock(return_value=(MagicMock(), fake_org, fake_user)),
+    )
+    # Skip the fire-and-forget Redis cache invalidation in tests.
+    monkeypatch.setattr(
+        "app.api.app_account._invalidate_litellm_kb_cache",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        "app.api.app_account.invalidate_templates",
+        AsyncMock(return_value=None),
+    )
+
+    body = KBPreferencePatch(kb_slugs_filter=[])
+    result = await patch_kb_preference(body=body, credentials=MagicMock(), db=db)
+
+    # The stored value MUST be `[]`, not `None`. This is the core contract.
+    assert fake_user.kb_slugs_filter == [], (
+        "kb_slugs_filter=[] MUST be preserved verbatim. The earlier "
+        "collapse-to-None reintroduced the very bug the frontend "
+        "comment in ChatConfigBar.toggleSlug warns about: turning off "
+        "the last org KB silently re-enables every collection."
+    )
+    # Response MUST also reflect [] so the client doesn't see None and
+    # render every collection as active again.
+    assert result.kb_slugs_filter == []
+
+
+@pytest.mark.asyncio
+async def test_null_kb_slugs_filter_remains_null(monkeypatch):
+    """``None`` is the explicit "all org KBs" sentinel and must survive."""
+    from app.api.app_account import KBPreferencePatch, patch_kb_preference
+
+    fake_user = _FakeUser()
+    fake_user.kb_slugs_filter = ["a", "b"]  # non-null before
+    fake_org = _FakeOrg()
+
+    db = AsyncMock()
+    db.commit = AsyncMock()
+    db.execute = AsyncMock(return_value=_empty_query_result())
+
+    monkeypatch.setattr(
+        "app.api.app_account._get_caller_org",
+        AsyncMock(return_value=(MagicMock(), fake_org, fake_user)),
+    )
+    monkeypatch.setattr(
+        "app.api.app_account._invalidate_litellm_kb_cache",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        "app.api.app_account.invalidate_templates",
+        AsyncMock(return_value=None),
+    )
+
+    body = KBPreferencePatch(kb_slugs_filter=None)
+    # Force "kb_slugs_filter" into model_fields_set so the endpoint sees the
+    # explicit None (not "field omitted"). Pydantic v2: pass through model_dump.
+    body = KBPreferencePatch.model_validate({"kb_slugs_filter": None})
+    result = await patch_kb_preference(body=body, credentials=MagicMock(), db=db)
+
+    assert fake_user.kb_slugs_filter is None
+    assert result.kb_slugs_filter is None

--- a/klai-portal/frontend/src/routes/app/_components/ChatConfigBar.tsx
+++ b/klai-portal/frontend/src/routes/app/_components/ChatConfigBar.tsx
@@ -91,9 +91,18 @@ export function ChatConfigBar() {
     mutation.mutate({ kb_slugs_filter: next.length === allSlugs.length ? null : next })
   }
 
-  const allActive = (pref?.kb_personal_enabled ?? false) && currentSlugs.length === allSlugs.length
+  // "anything active" — true when ANY collection is on (personal or any
+  // org KB). Drives the dropdown header button:
+  //   * if anythingActive → label "Alles uit", click turns ALL off (incl. personal).
+  //   * else              → label "Alles aan", click turns ALL on.
+  // Previously this was `allActive` (TRUE only when EVERYTHING was on),
+  // which meant a partially-on state always showed "Alles aan" and clicking
+  // it re-enabled everything — exactly the user complaint.
+  const anythingActive =
+    (pref?.kb_personal_enabled ?? false) || currentSlugs.length > 0
+
   function toggleAll() {
-    if (allActive) {
+    if (anythingActive) {
       mutation.mutate({ kb_slugs_filter: [], kb_personal_enabled: false })
     } else {
       mutation.mutate({ kb_slugs_filter: null, kb_personal_enabled: true })
@@ -160,7 +169,7 @@ export function ChatConfigBar() {
                   onClick={toggleAll}
                   className="text-[10px] font-semibold tracking-wide text-gray-500 hover:text-gray-900 transition-colors"
                 >
-                  {allActive ? 'Alles uit' : 'Alles aan'}
+                  {anythingActive ? 'Alles uit' : 'Alles aan'}
                 </button>
               </div>
               {/* Personal */}
@@ -200,43 +209,61 @@ export function ChatConfigBar() {
                   </span>
                 </button>
               ))}
+
+              {/* Modus: kb_narrow checkbox row, separated from collections
+                  by a divider. When ON, the LiteLLM hook prepends a strict
+                  "answer ONLY from KB" prompt; OFF means KB chunks are
+                  additional context and the model may supplement with
+                  general knowledge. Logically a SCOPE setting (filtering
+                  the answer source), so it lives in the same dropdown as
+                  the collection scope toggles. */}
+              <div className="my-1 border-t border-gray-100" />
+              <div className="flex items-center justify-between px-3 py-1.5">
+                <span className="text-[10px] font-semibold tracking-wide text-gray-400">
+                  {m.chatbar_mode_label()}
+                </span>
+              </div>
+              <button
+                type="button"
+                onClick={toggleNarrow}
+                title={
+                  pref.kb_narrow
+                    ? m.chatbar_mode_narrow_tooltip_on()
+                    : m.chatbar_mode_narrow_tooltip_off()
+                }
+                aria-checked={pref.kb_narrow}
+                role="checkbox"
+                className="w-full flex items-center gap-2.5 px-3 py-2 text-[13px] hover:bg-gray-50 transition-colors text-left"
+              >
+                <span
+                  className={`flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-sm border ${
+                    pref.kb_narrow
+                      ? 'bg-green-500 border-green-500'
+                      : 'border-gray-300 bg-white'
+                  }`}
+                  aria-hidden="true"
+                >
+                  {pref.kb_narrow && (
+                    <svg
+                      viewBox="0 0 12 12"
+                      className="h-2.5 w-2.5 text-white"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2.5"
+                    >
+                      <polyline points="2 6 5 9 10 3" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                  )}
+                </span>
+                <span
+                  className={pref.kb_narrow ? 'text-gray-900 font-medium' : 'text-gray-400'}
+                >
+                  {m.chatbar_mode_narrow_on()}
+                </span>
+              </button>
             </div>
           )}
         </div>
-      </div>
-
-      {/* Modus: kb_narrow toggle. Click flips between "KB + algemene
-          kennis" (default, kb_narrow=false) and "Alleen kennisbank"
-          (kb_narrow=true). The LiteLLM hook honours kb_narrow already
-          (deploy/litellm/klai_knowledge.py): narrow mode prepends a
-          stricter system prompt that forbids general-knowledge answers
-          and tells the model to say "Ik kan dit niet vinden in de
-          kennisbank" when the KB lacks the answer. Replaces the
-          equivalent toggle that lived in the deprecated KBScopeBar. */}
-      <div className="flex items-center gap-2 min-w-0">
-        <span className="text-[13px] text-gray-400 whitespace-nowrap">
-          {m.chatbar_mode_label()}:
-        </span>
-        <button
-          type="button"
-          onClick={toggleNarrow}
-          title={
-            pref.kb_narrow
-              ? m.chatbar_mode_narrow_tooltip_on()
-              : m.chatbar_mode_narrow_tooltip_off()
-          }
-          aria-pressed={pref.kb_narrow}
-          className="flex items-center gap-1.5 text-[14px] font-semibold text-gray-700 hover:text-gray-900 transition-colors"
-        >
-          <span
-            className={`h-2 w-2 shrink-0 rounded-full ${pref.kb_narrow ? 'bg-green-500' : 'bg-gray-200'}`}
-          />
-          <span className={pref.kb_narrow ? 'text-gray-900' : 'text-gray-400'}>
-            {pref.kb_narrow
-              ? m.chatbar_mode_narrow_on()
-              : m.chatbar_mode_narrow_off()}
-          </span>
-        </button>
       </div>
 
       {/* Templates: multi-select. Hidden when backend has no templates yet. */}


### PR DESCRIPTION
Follow-up to #316 fixing three concrete bugs reported by Mark:

## 1. Narrow toggle moves INTO the dropdown as a checkbox row

Previous PR put it as a separate pill outside the dropdown — not what was asked. Now it sits inside the same dropdown as the collection toggles, after a divider, with a real square ☐/☑ checkbox indicator and `role=\"checkbox\"`.

## 2. \"Alles uit / Alles aan\" actually works in mixed state

Before: button label + action was driven by `allActive` (only true when literally everything is on). Mixed state ⇒ \"Alles aan\" ⇒ click re-enables everything. Useless when you wanted to clear from a partial state.

After: `anythingActive` — true when ANY scope is on. Mixed state ⇒ \"Alles uit\" ⇒ click clears everything. Empty state ⇒ \"Alles aan\" ⇒ click enables everything. One click does what the label says.

## 3. Last-collection-off no longer silently re-enables everything

The frontend `toggleSlug` comment explicitly says \"DO NOT collapse empty to null — that would flip 'turn last off' into 'turn everything back on' and break user intent.\" The server (`app_account.patch_kb_preference`) was doing exactly that: `if slugs is not None and len(slugs) == 0: slugs = None`. Removed.

Tri-state contract is now consistent across all layers:
- `None` → all org KBs (default)
- `[]` → user opted out of every org KB
- `[..]` → explicit subset

The LiteLLM hook (`klai_knowledge.async_pre_call_hook`) now honours this:
- `kb_personal=False AND kb_slugs=[]` → skip retrieval entirely (no chunks injected, templates still apply)
- `kb_personal=True AND kb_slugs=[]` → scope=personal, no kb_slugs filter
- `kb_personal=False AND kb_slugs=null` → scope=org, no filter
- `kb_personal=True AND kb_slugs=null` → scope=both, no filter
- explicit subset → as before

Previously the hook used `if kb_slugs:` which made `[]` and `None` indistinguishable — so users who turned every collection off still got every org chunk back.

## Test plan

- [x] `tests/test_kb_preference_empty_list.py`: 2 tests pinning the `[]` round-trip
- [x] `TestKlaiKnowledgeHookSlugsTriState`: 3 tests pinning hook routing for (personal, slugs) matrix
- [x] paraglide compile + tsc -b clean
- [x] eslint clean on ChatConfigBar.tsx
- [x] ruff clean on all touched Python
- [ ] Browser flow on staging (Mark to verify):
  - [ ] Open dropdown → see Persoonlijk + 9 collections + divider + \"Alleen kennisbank\" checkbox row
  - [ ] Click \"Alles uit\" header from current state (Voys tenant) → all dots gray, checkbox stays at its previous state (separate concept)
  - [ ] Manually click each collection off → all stay off (no rebound)
  - [ ] Click checkbox → checkmark appears, label bolds; chat with question NOT in KB returns \"Ik kan dit niet vinden in de kennisbank\"
  - [ ] Click checkbox again → unchecked; chat resumes general-knowledge supplementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)