### PR TITLE
refactor(litellm): drop role-based aliases klai-pipeline + klai-embeddings

### DIFF
--- a/.claude/rules/klai/pitfalls/process-rules.md
+++ b/.claude/rules/klai/pitfalls/process-rules.md
@@ -502,7 +502,9 @@ survived the forward audit:
   meeting-bot traffic past the api-gateway layer.
 - `GRAPHITI_LLM_MODEL` on retrieval-api: prod set `klai-pipeline`,
   code default was `klai-fast`. Different quality/cost on graph
-  extraction.
+  extraction. (Resolved May 2026: dropped the role-based klai-pipeline
+  alias; both code and prod now use klai-fast which points at the
+  same Mistral Small 4 model.)
 - `VEXA_ADMIN_TOKEN` on portal-api: prod set a real token, code default
   was `""`. No current runtime reader, but future callers would have
   silently gotten an empty token.

--- a/.claude/rules/klai/platform/litellm.md
+++ b/.claude/rules/klai/platform/litellm.md
@@ -7,14 +7,15 @@ paths:
 # LiteLLM
 
 ## Tier aliases (HARD)
-Never use raw model names. Only `klai-fast`, `klai-primary`, `klai-large`, `klai-pipeline`.
+Never use raw model names. Aliases are tier-/model-named, NEVER role-named (no `klai-eval-judge`, `klai-pipeline` etc). New tiers are added when an existing tier is structurally insufficient for a task.
 
-| Alias | Mistral (default) | Task |
+| Alias | Backing model | Task |
 |---|---|---|
-| `klai-fast` | `mistral-small-2603` | Lightweight, high-volume, latency-sensitive |
-| `klai-primary` | `mistral-small-2603` | Standard quality, user-facing |
-| `klai-large` | `mistral-large-2512` | Agentic, tool use, MCP flows |
-| `klai-pipeline` | `mistral-small-2603` | Internal services (bypasses custom_router) |
+| `klai-fast` | `mistral-small-2603` | Lightweight, high-volume, latency-sensitive. Bypasses custom_router. |
+| `klai-primary` | `mistral-small-2603` | Standard quality, user-facing. Routed via custom_router (may upgrade to klai-large for tool-calls). |
+| `klai-medium` | `mistral-medium-3.5` | Middle tier — used when klai-fast hits its output-token ceiling but klai-large is overkill. |
+| `klai-large` | `mistral-large-2512` | Agentic, tool use, MCP flows. |
+| `klai-bge-m3` | BGE-M3 on TEI/gpu-01 | Embeddings. Distinct model TYPE (not text-completion). |
 
 ## Provider swap
 Switch all services by changing 3 entries in `deploy/litellm/config.yaml`, then `docker compose restart litellm`.
@@ -29,7 +30,7 @@ Switch all services by changing 3 entries in `deploy/litellm/config.yaml`, then 
 - `/health` — requires valid virtual key (NOT master key).
 
 ## custom_router.py
-- Content heuristics fire on ALL `klai-primary` calls. Internal services must use `klai-pipeline` to bypass.
+- Content heuristics fire on ALL `klai-primary` calls. Internal services must use `klai-fast` to bypass.
 - Never use `klai-primary` for background services processing document content with URLs.
 
 ## Mistral quota

--- a/.moai/specs/SPEC-RAG-EVAL-001/plan.md
+++ b/.moai/specs/SPEC-RAG-EVAL-001/plan.md
@@ -142,7 +142,7 @@ Five units, executed in dependency order. Each is a separate commit (or commit c
 - **Concurrent runs against the same suite.** Mitigated by Procrastinate `queue_lock=f"rag-eval-{suite}"` (REQ-5).
 - **Voys KB drift.** As the KB grows, baseline metrics will shift even without retrieval changes. Mitigation: every row's `meta` includes `kb_artifact_count` snapshot so score changes can be correlated with corpus changes.
 - **No personal-KB data.** `knowledge_personal.yaml` ships with 10 synthetic queries in v1. Document as known limitation; backfill once alpha customers create personal KBs.
-- **Judge-LLM scoring drift.** Mistral small can be inconsistent across runs. Mitigation: run nightly so variance averages out over 7 days. If individual-night variance exceeds 0.1 standard deviation on `baseline` metrics, escalate the model choice (consider klai-pipeline) in a follow-up SPEC.
+- **Judge-LLM scoring drift.** Mistral small can be inconsistent across runs. Mitigation: run nightly so variance averages out over 7 days. If individual-night variance exceeds 0.1 standard deviation on `baseline` metrics, escalate the model choice (consider klai-medium or klai-large) in a follow-up SPEC.
 - **Cost overrun.** Estimate is ~€5/month. Mitigation: log `total_tokens` per row; if monthly aggregate exceeds €15 (3× budget), pause the cron and re-evaluate.
 
 ## 6. Sequencing

--- a/deploy/SECRETS_MATRIX.md
+++ b/deploy/SECRETS_MATRIX.md
@@ -53,7 +53,7 @@ from SOPS `klai-infra/core-01/.env.sops`) unless noted otherwise.
 | `CONNECTOR_ZITADEL_CLIENT_ID` | klai-connector | Zitadel OIDC client_id for connector token introspection. Mapped to `ZITADEL_CLIENT_ID` in-container. |
 | `CONNECTOR_ZITADEL_CLIENT_SECRET` | klai-connector | Zitadel OIDC client_secret for connector introspection. Mapped to `ZITADEL_CLIENT_SECRET` in-container. |
 | `DOCS_INTERNAL_SECRET` | portal-api | Shared secret portal-api → klai-docs for KB provisioning calls. |
-| `GRAPHITI_LLM_MODEL` | retrieval-api | LLM model name used by Graphiti for knowledge-graph extraction. Prod uses `klai-pipeline`; config.py default is `klai-fast`. Not a secret — declared here because the prod value differs from the code default. |
+| `GRAPHITI_LLM_MODEL` | retrieval-api | LLM model name used by Graphiti for knowledge-graph extraction. Defaults to `klai-fast` (Mistral Small 4) in both prod and config.py. Not a secret — declared here so future overrides remain visible in the matrix. |
 | `FIRECRAWL_INTERNAL_KEY` | portal-api | Shared web-search API key (portal re-uses the Firecrawl internal key for URL extraction). |
 | `GITHUB_ADMIN_PAT` | portal-api | GitHub PAT with `admin:org` scope — used during offboarding to remove members from the GetKlai org. |
 | `KLAI_CONNECTOR_SECRET` | portal-api | Shared secret for portal → klai-connector orchestration calls (SOPS key: `PORTAL_API_KLAI_CONNECTOR_SECRET`, mapped inline). |

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -787,11 +787,11 @@ services:
       FALKORDB_PORT: "6379"
       GRAPHITI_ENABLED: "true"
       GRAPH_SEARCH_TIMEOUT: "60.0"
-      # Graphiti LLM model for knowledge-graph extraction. Prod uses
-      # the heavier pipeline model; config.py defaults to klai-fast
-      # which is not suitable for graph extraction. Overrides the
-      # default to match pre-SPEC-SEC-ENVFILE-SCOPE-001 behaviour.
-      GRAPHITI_LLM_MODEL: ${GRAPHITI_LLM_MODEL:-klai-pipeline}
+      # Graphiti LLM model for knowledge-graph extraction. klai-fast
+      # points at Mistral Small 4 (same model the dropped klai-pipeline
+      # alias used to point at). Override via env if a different tier
+      # is required for graph extraction.
+      GRAPHITI_LLM_MODEL: ${GRAPHITI_LLM_MODEL:-klai-fast}
       RERANKER_ENABLED: "true"
       RERANKER_TIMEOUT: "60.0"
       OPENAI_API_KEY: "dummy"

--- a/deploy/litellm/config.yaml
+++ b/deploy/litellm/config.yaml
@@ -27,17 +27,6 @@ model_list:
     rpm: 200
     tpm: 400000
 
-  # Pipeline: Mistral Small — internal background services (Graphiti
-  # extraction, enrichment, coreference). Bypasses custom_router.py
-  # because the router only fires on klai-primary. Required by compose
-  # env GRAPHITI_LLM_MODEL=klai-pipeline (deploy/docker-compose.yml).
-  - model_name: klai-pipeline
-    litellm_params:
-      model: mistral/mistral-small-2603
-      api_key: os.environ/MISTRAL_API_KEY
-    rpm: 500
-    tpm: 400000
-
   # Medium: Mistral Medium 3.5 — middle-tier between klai-fast and klai-large.
   # Use for tasks where klai-fast hits its output-token ceiling but klai-large
   # is overkill. First consumer: SPEC-RAG-EVAL-001 RAGAS faithfulness metric
@@ -55,7 +44,7 @@ model_list:
   # knowledge-ingest through the proxy so external consumers (RAGAS
   # AnswerRelevancy, future query-rewriting SPECs) can reach it via
   # standard OpenAI-compatible /v1/embeddings.
-  - model_name: klai-embeddings
+  - model_name: klai-bge-m3
     litellm_params:
       model: openai/bge-m3
       api_base: http://172.18.0.1:7997/v1

--- a/dev/litellm-config.yaml
+++ b/dev/litellm-config.yaml
@@ -28,14 +28,6 @@ model_list:
     rpm: 50
     tpm: 200000
 
-  # Pipeline: internal services (bypasses routing in prod)
-  - model_name: klai-pipeline
-    litellm_params:
-      model: anthropic/claude-haiku-4-5-20251001
-      api_key: os.environ/ANTHROPIC_API_KEY
-    rpm: 50
-    tpm: 100000
-
 router_settings:
   routing_strategy: simple-shuffle
 

--- a/docs/architecture/klai-knowledge-architecture.md
+++ b/docs/architecture/klai-knowledge-architecture.md
@@ -1104,7 +1104,7 @@ Migration required for existing tenants: see §9.5 provisioning changes.
 
 At tenant creation, provisioning adds a step:
 1. `POST /team/new` — creates a LiteLLM team (alias = org slug)
-2. `POST /key/generate` — creates a team key with `metadata: {org_id: "<zitadel_org_id>"}` and `models: ["klai-primary", "klai-fast", "klai-large"]` (the user-facing LiteLLM tier aliases — `klai-pipeline` is excluded because it bypasses custom_router and is reserved for internal services)
+2. `POST /key/generate` — creates a team key with `metadata: {org_id: "<zitadel_org_id>"}` and `models: ["klai-primary", "klai-fast", "klai-large"]` (the user-facing LiteLLM tier aliases — internal-only aliases like `klai-medium` and `klai-bge-m3` are excluded from tenant keys)
 3. The returned key replaces `settings.litellm_master_key` as `LITELLM_API_KEY` in the LibreChat `.env`
 
 `zitadel_org_id` is used (not the integer PK) — it is the stable cross-system identifier available on `PortalOrg.zitadel_org_id`, and the correct key for Qdrant scope `org_{zitadel_org_id}`.

--- a/docs/architecture/retrieval-improvements-roadmap.md
+++ b/docs/architecture/retrieval-improvements-roadmap.md
@@ -67,11 +67,11 @@ docker exec klai-core-knowledge-ingest-1 \
 
 ### Known tuning gaps in v1 (follow-up SPECs)
 
-The harness produces usable baseline numbers, but two metric paths have known issues that will be addressed in follow-up work — they don't block Tier 1/2 progression because the working metrics (precision/recall/retrieval_ms) are sufficient to A/B-compare variants.
+The harness produces usable baseline numbers, but two metric paths had known issues at v1 that have since been addressed.
 
-1. **Faithfulness JSON-parse failures (28/30 NaN).** Judge LLM (klai-fast) hits the 3072-token completion limit on long context-relevant analyses, returning truncated JSON that RAGAS can't parse. Fix: shorten the judge prompt or switch to `klai-pipeline` for the faithfulness metric only.
-2. **Answer_relevance 30/30 NaN.** RAGAS's `AnswerRelevancy` metric requires an embeddings model (`embed_query`); we plug in a langchain `ChatOpenAI` LLM today, which doesn't satisfy that interface. Fix: configure a LiteLLM embeddings alias and use `LangchainEmbeddingsWrapper` in `judge_client.py`.
-3. **Runtime 14 min for 30 queries** exceeds REQ-7's 5 min target. Likely a knock-on effect of #1 (model regenerating after parse failures). Resolves once #1 is fixed.
+1. **Faithfulness JSON-parse failures (28/30 NaN).** Judge LLM (klai-fast) hit the 3072-token completion limit on long context-relevant analyses, returning truncated JSON that RAGAS could not parse. **Resolved (PR #312):** Faithfulness metric now uses `klai-medium` (Mistral Medium 3.5) which has a larger output window and produces reliable structured JSON.
+2. **Answer_relevance 30/30 NaN.** RAGAS's `AnswerRelevancy` metric requires an embeddings model (`embed_query`); we plugged in only an LLM, which did not satisfy that interface. **Resolved (PR #312):** Added `klai-bge-m3` LiteLLM alias pointing at the BGE-M3 model already running on TEI/gpu-01; AnswerRelevancy uses it via a small in-module embeddings adapter.
+3. **Runtime 14 min for 30 queries** exceeds REQ-7's 5 min target. Was a knock-on effect of #1 (model regenerating after parse failures). Should resolve along with #1 — re-measure on the next baseline run.
 
 ## Why prioritise improvements before launch
 

--- a/docs/research/models/llm-selection-knowledge-graph.md
+++ b/docs/research/models/llm-selection-knowledge-graph.md
@@ -35,16 +35,15 @@ Medium 3.5 sits between Small 4 and Large 3 on capability but is **more expensiv
 
 ### LiteLLM aliases
 
-Aliases are tier-based (ascending capability/cost). New tiers are added when an existing tier is structurally insufficient for a task — never role-named (no `klai-eval-judge` etc), always tier-named. New consumers reuse the smallest tier that fits.
+Aliases are **tier-/model-named** — they describe what the underlying model IS, never what it does. No role-based names like `klai-eval-judge`, `klai-pipeline` (the historical role-name was retired 2026-05-05 in favour of `klai-fast` since they pointed at the same Mistral Small 4 model). New tiers are added when an existing tier is structurally insufficient. New consumers reuse the smallest tier that fits.
 
 | Alias | Current mapping | Use for |
 |---|---|---|
-| `klai-primary` | Mistral Small 4 (EU) | Default for most user-facing tasks |
-| `klai-fast` | Mistral Small 4 (EU) | Bypass-routed lightweight tasks (no custom_router) |
-| `klai-pipeline` | Mistral Small 4 (EU) | Internal background pipelines (Graphiti, enrichment, coreference) |
-| `klai-medium` | **Mistral Medium 3.5** (EU) | Tasks where klai-fast hits its output ceiling but klai-large is overkill. First consumer: SPEC-RAG-EVAL-001 RAGAS faithfulness judge (multi-statement JSON output). Added 2026-05-05. |
-| `klai-large` | Mistral Large 3 (EU) | Complex reasoning, agentic / tool-use flows |
-| `klai-embeddings` | **BGE-M3 via TEI/gpu-01** | Embeddings (distinct model TYPE — not a text-completion tier). First consumer: SPEC-RAG-EVAL-001 RAGAS AnswerRelevancy. Added 2026-05-05. |
+| `klai-primary` | Mistral Small 4 (EU) | Default for most user-facing tasks. Routed via custom_router (may upgrade to klai-large for tool-calls). |
+| `klai-fast` | Mistral Small 4 (EU) | Lightweight, latency-sensitive, internal background work (Graphiti, enrichment, coreference). Bypasses custom_router. |
+| `klai-medium` | **Mistral Medium 3.5** (EU) | Middle tier — used when klai-fast hits its output-token ceiling but klai-large is overkill. First consumer: SPEC-RAG-EVAL-001 RAGAS faithfulness judge (multi-statement JSON output). Added 2026-05-05. |
+| `klai-large` | Mistral Large 3 (EU) | Complex reasoning, agentic / tool-use flows. |
+| `klai-bge-m3` | **BGE-M3 on TEI/gpu-01** | Embeddings. Distinct model TYPE (not a text-completion tier). First consumer: SPEC-RAG-EVAL-001 RAGAS AnswerRelevancy. Added 2026-05-05. |
 
 ## Analysis per model
 

--- a/klai-knowledge-ingest/knowledge_ingest/config.py
+++ b/klai-knowledge-ingest/knowledge_ingest/config.py
@@ -125,7 +125,7 @@ class Settings(BaseSettings):
     rag_eval_judge_timeout: int = 30
     rag_eval_judge_model: str = "klai-fast"
     rag_eval_faithfulness_model: str = "klai-medium"
-    rag_eval_embeddings_model: str = "klai-embeddings"
+    rag_eval_embeddings_model: str = "klai-bge-m3"
     rag_eval_suites_dir: str = "knowledge_ingest/eval/suites"
 
     model_config = {"env_file": ".env"}

--- a/klai-knowledge-ingest/knowledge_ingest/eval/judge_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/eval/judge_client.py
@@ -6,7 +6,7 @@ Two responsibilities:
      given a query and retrieved chunks.
   2. evaluate_query: run the four RAGAS metrics with per-metric LLM/embeddings
      injection — light metrics on klai-fast, faithfulness on klai-medium
-     (Mistral Medium 3.5), answer_relevancy embeddings on klai-embeddings (BGE-M3).
+     (Mistral Medium 3.5), answer_relevancy embeddings on klai-bge-m3 (BGE-M3).
 
 Both functions are fail-open: any HTTP or RAGAS failure returns None / a
 metrics dict with None values instead of raising (REQ-3 generalisation).
@@ -16,7 +16,7 @@ Per-metric model assignment (post-baseline-fix 2026-05-05):
   - context_recall     → klai-fast LLM
   - faithfulness       → klai-medium LLM (Mistral Medium 3.5; klai-fast
                           truncates the multi-statement JSON output)
-  - answer_relevancy   → klai-fast LLM + klai-embeddings (BGE-M3 via TEI)
+  - answer_relevancy   → klai-fast LLM + klai-bge-m3 (BGE-M3 via TEI)
 
 RAGAS 0.4.3 API notes:
   - Uses EvaluationDataset + SingleTurnSample (not HF datasets).
@@ -114,9 +114,9 @@ class _SimpleEmbeddings:
 
 
 def _build_ragas_embeddings() -> _SimpleEmbeddings:
-    """Build the RAGAS embeddings adapter pointed at klai-embeddings.
+    """Build the RAGAS embeddings adapter pointed at klai-bge-m3.
 
-    klai-embeddings is the LiteLLM alias for BGE-M3 on TEI/gpu-01.
+    klai-bge-m3 is the LiteLLM alias for BGE-M3 on TEI/gpu-01.
     Used by AnswerRelevancy to compare imaginary-question vectors with
     the user's actual question.
     """
@@ -252,7 +252,7 @@ async def evaluate_query(
 
         # Per-metric model assignment: light metrics on klai-fast, faithfulness
         # on klai-medium (Mistral Medium 3.5), answer_relevancy on klai-fast +
-        # klai-embeddings (BGE-M3). See module docstring for rationale.
+        # klai-bge-m3 (BGE-M3). See module docstring for rationale.
         light_llm = _build_ragas_llm()
         heavy_llm = _build_ragas_llm(model=settings.rag_eval_faithfulness_model)
         embeddings = _build_ragas_embeddings()

--- a/klai-knowledge-ingest/tests/eval/test_config_defaults.py
+++ b/klai-knowledge-ingest/tests/eval/test_config_defaults.py
@@ -46,9 +46,9 @@ def test_rag_eval_faithfulness_model_default() -> None:
 
 
 def test_rag_eval_embeddings_model_default() -> None:
-    """AnswerRelevancy embeddings default to klai-embeddings (BGE-M3 via TEI)."""
+    """AnswerRelevancy embeddings default to klai-bge-m3 (BGE-M3 via TEI)."""
     settings = Settings(_env_file=None)
-    assert settings.rag_eval_embeddings_model == "klai-embeddings"
+    assert settings.rag_eval_embeddings_model == "klai-bge-m3"
 
 
 def test_retrieval_internal_secret_via_canonical_env(

--- a/klai-knowledge-ingest/tests/eval/test_judge_client.py
+++ b/klai-knowledge-ingest/tests/eval/test_judge_client.py
@@ -30,7 +30,7 @@ def _make_settings(**overrides):
     s.litellm_api_key = overrides.get("litellm_api_key", "test-key")
     s.rag_eval_judge_model = overrides.get("rag_eval_judge_model", "klai-fast")
     s.rag_eval_faithfulness_model = overrides.get("rag_eval_faithfulness_model", "klai-medium")
-    s.rag_eval_embeddings_model = overrides.get("rag_eval_embeddings_model", "klai-embeddings")
+    s.rag_eval_embeddings_model = overrides.get("rag_eval_embeddings_model", "klai-bge-m3")
     s.rag_eval_judge_timeout = overrides.get("rag_eval_judge_timeout", 30)
     return s
 

--- a/klai-portal/backend/app/services/provisioning/orchestrator.py
+++ b/klai-portal/backend/app/services/provisioning/orchestrator.py
@@ -339,10 +339,11 @@ async def _provision(org_id: int, db: AsyncSession) -> None:
                         # directly; LiteLLM's custom_router may upgrade to
                         # klai-large (tool calls) or downgrade to klai-fast (web
                         # search). All three MUST be in scope.
-                        # @MX:REASON: deploy/litellm/config.yaml only defines
-                        # klai-primary, klai-fast, klai-large, klai-pipeline;
-                        # klai-pipeline is reserved for internal services and
-                        # bypasses custom_router (see platform/litellm.md).
+                        # @MX:REASON: deploy/litellm/config.yaml defines the
+                        # tier ladder klai-primary, klai-fast, klai-medium,
+                        # klai-large + the klai-bge-m3 embeddings model.
+                        # Internal-only aliases (klai-medium, klai-bge-m3)
+                        # are excluded from tenant keys (see platform/litellm.md).
                         "models": ["klai-primary", "klai-fast", "klai-large"],
                     },
                 )

--- a/klai-portal/backend/tests/test_provisioning_orchestrator.py
+++ b/klai-portal/backend/tests/test_provisioning_orchestrator.py
@@ -233,9 +233,10 @@ async def test_litellm_key_generate_uses_real_model_aliases(mock_orchestrator_en
     Regression guard: a previous bug shipped with `["klai-llm","klai-fallback"]`
     — names that don't exist anywhere in the LiteLLM config. LibreChat (which
     is hardcoded to call `klai-primary`) then got 401s for every tenant. The
-    legitimate aliases per platform/litellm.md are klai-fast, klai-primary,
-    klai-large, klai-pipeline — and klai-pipeline is reserved for internal
-    services, so tenant keys must scope to the three user-facing tiers.
+    legitimate aliases per platform/litellm.md are klai-primary, klai-fast,
+    klai-medium, klai-large + klai-bge-m3 embeddings — internal-only aliases
+    (klai-medium, klai-bge-m3) are excluded from tenant keys, so tenant keys
+    scope to the three user-facing tiers (klai-primary, klai-fast, klai-large).
     """
     from app.services.provisioning import orchestrator
 


### PR DESCRIPTION
## Summary

Part 2 of 2. Drops the two role-based LiteLLM aliases in favour of tier/model-named ones, per the convention documented in [docs/research/models/llm-selection-knowledge-graph.md](docs/research/models/llm-selection-knowledge-graph.md).

| Old (role-based) | New | Model | Why |
|---|---|---|---|
| \`klai-pipeline\` | \`klai-fast\` | mistral-small-2603 | Both pointed at the same Mistral Small 4. The alias was named after \"internal pipelines\", not the model. |
| \`klai-embeddings\` | \`klai-bge-m3\` | BGE-M3 on TEI/gpu-01 | \"embeddings\" describes what it DOES, not what it IS. The model is BGE-M3. |

## Sequencing — depends on klai-infra#3

[klai-infra#3](https://github.com/GetKlai/klai-infra/pull/3) (already merged) updated \`/opt/klai/.env\` to \`GRAPHITI_LLM_MODEL=klai-fast\` so dropping the \`klai-pipeline\` alias from LiteLLM does not cause a 404 during the deploy gap. Verified: \`grep '^GRAPHITI_LLM_MODEL=' /opt/klai/.env\` returns \`klai-fast\` on core-01.

## Changes

**LiteLLM config:**
- \`deploy/litellm/config.yaml\` — drop \`klai-pipeline\`, rename \`klai-embeddings\` → \`klai-bge-m3\`
- \`dev/litellm-config.yaml\` — drop \`klai-pipeline\` (dev variant)

**Compose default:**
- \`deploy/docker-compose.yml\` — \`GRAPHITI_LLM_MODEL\` default \`klai-fast\`

**Code:**
- \`klai-knowledge-ingest/knowledge_ingest/config.py\` — \`rag_eval_embeddings_model\` default \`klai-bge-m3\`
- \`klai-knowledge-ingest/knowledge_ingest/eval/judge_client.py\` — rename comments + module docstring
- \`klai-portal/backend/app/services/provisioning/orchestrator.py\` — provisioning comment updated

**Tests:**
- \`tests/eval/test_config_defaults.py\` — pin \`klai-bge-m3\` default
- \`tests/eval/test_judge_client.py\` — settings fixture default
- \`tests/test_provisioning_orchestrator.py\` — comment alignment

**Docs (all alias references in sync):**
- \`.claude/rules/klai/platform/litellm.md\` — tier-naming policy + alias table
- \`.claude/rules/klai/pitfalls/process-rules.md\` — \"Resolved May 2026\" postfix on the historical incident
- \`docs/architecture/klai-knowledge-architecture.md\` — provisioning context
- \`docs/architecture/retrieval-improvements-roadmap.md\` — fault-history marked Resolved (PR #312 + this)
- \`docs/research/models/llm-selection-knowledge-graph.md\` — alias table updated, naming policy explicit
- \`deploy/SECRETS_MATRIX.md\` — \`GRAPHITI_LLM_MODEL\` note simplified
- \`.moai/specs/SPEC-RAG-EVAL-001/plan.md\` — risk-mitigation note (klai-pipeline → klai-medium)

## Test plan

- [x] 58/58 eval tests green locally
- [x] 11/11 portal provisioning-orchestrator tests green locally
- [x] Ruff check + format clean
- [ ] CI green
- [ ] Post-merge ops:
  1. \`docker compose up -d --force-recreate litellm knowledge-ingest\` on core-01
  2. Verify \`docker exec klai-core-knowledge-ingest-1 ... /v1/models\` returns \`[klai-primary, klai-fast, klai-large, klai-medium, klai-bge-m3]\` — no \`klai-pipeline\`, no \`klai-embeddings\`
  3. Run \`baseline-v4\` smoke-test against Voys

🤖 Generated with [Claude Code](https://claude.com/claude-code)