### PR TITLE
feat(security): SPEC-SEC-VALIDATOR-COVERAGE-001 portal-api — 10 fail-closed validators

### DIFF
--- a/klai-portal/backend/app/core/config.py
+++ b/klai-portal/backend/app/core/config.py
@@ -394,5 +394,231 @@ class Settings(BaseSettings):
             )
         return self
 
+    # ------------------------------------------------------------------
+    # SPEC-SEC-VALIDATOR-COVERAGE-001 -- fail-closed validators (REQ-1..10)
+    # All 10 env vars verified present in /opt/klai/.env on 2026-05-05.
+    # ------------------------------------------------------------------
+
+    @model_validator(mode="after")
+    def _require_internal_secret(self) -> "Settings":
+        """SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-1: fail-closed on missing INTERNAL_SECRET.
+
+        Cross-service trust boundary: klai-mailer -> portal-api (and other callers
+        of /internal/*) use this as a shared Bearer token. An empty value causes
+        the HMAC comparison to accept any caller that also sends an empty token.
+
+        Where used: app/api/internal.py -- X-Internal-Secret / Authorization header.
+        Failure mode without validator: any unauthenticated caller reaches internal
+        endpoints (rate-limit bypass, data exfiltration via /internal/v1/users/*).
+
+        Env-parity: INTERNAL_SECRET must exist in klai-infra/core-01/.env.sops BEFORE merge.
+        Pre-flight verified 2026-05-05: value populated in /opt/klai/.env.
+        """
+        if not self.internal_secret or not self.internal_secret.strip():
+            raise ValueError(
+                "Missing required: INTERNAL_SECRET (SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-1). "
+                "Set it in SOPS before starting portal-api."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _require_klai_connector_secret(self) -> "Settings":
+        """SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-2: fail-closed on missing KLAI_CONNECTOR_SECRET.
+
+        Cross-service trust boundary: portal-api -> klai-connector (sync orchestration).
+        An empty secret silently disables auth on klai-connector/internal/* endpoints,
+        letting any caller trigger or inspect sync runs.
+
+        Where used: app/services/klai_connector_client.py -- Authorization: Bearer header.
+        Failure mode without validator: connector sync endpoints accept unauthenticated
+        requests (empty Bearer = empty expected secret = hmac.compare_digest passes).
+
+        Env-parity: KLAI_CONNECTOR_SECRET must exist in klai-infra/core-01/.env.sops BEFORE merge.
+        Pre-flight verified 2026-05-05: value populated in /opt/klai/.env.
+        """
+        if not self.klai_connector_secret or not self.klai_connector_secret.strip():
+            raise ValueError(
+                "Missing required: KLAI_CONNECTOR_SECRET (SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-2). "
+                "Set it in SOPS before starting portal-api."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _require_knowledge_ingest_secret(self) -> "Settings":
+        """SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-3: fail-closed on missing KNOWLEDGE_INGEST_SECRET.
+
+        Cross-service trust boundary: portal-api -> knowledge-ingest via X-Internal-Secret.
+        An empty value silently removes auth, allowing any caller to trigger ingestion
+        jobs or list knowledge items on behalf of arbitrary tenants.
+
+        Where used: app/services/knowledge_ingest_client.py -- X-Internal-Secret header.
+        Failure mode without validator: empty-secret fail-open (see pitfall empty-secret-fail-open).
+
+        Env-parity: KNOWLEDGE_INGEST_SECRET must exist in klai-infra/core-01/.env.sops BEFORE merge.
+        Pre-flight verified 2026-05-05: value populated in /opt/klai/.env.
+        """
+        if not self.knowledge_ingest_secret or not self.knowledge_ingest_secret.strip():
+            raise ValueError(
+                "Missing required: KNOWLEDGE_INGEST_SECRET (SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-3). "
+                "Set it in SOPS before starting portal-api."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _require_retrieval_api_internal_secret(self) -> "Settings":
+        """SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-4: fail-closed on missing RETRIEVAL_API_INTERNAL_SECRET.
+
+        Cross-service trust boundary: portal-api -> retrieval-api, kept separate from
+        internal_secret so both boundaries can be rotated independently (SPEC-SEC-010 REQ-6.1).
+        An empty value allows unauthenticated callers to reach retrieval endpoints.
+
+        Where used: app/api/knowledge_gap.py and related -- X-Internal-Secret header.
+        Failure mode without validator: retrieval-api accepts any caller sending an empty secret.
+
+        Env-parity: RETRIEVAL_API_INTERNAL_SECRET must exist in klai-infra/core-01/.env.sops BEFORE merge.
+        Pre-flight verified 2026-05-05: value populated in /opt/klai/.env.
+        """
+        if not self.retrieval_api_internal_secret or not self.retrieval_api_internal_secret.strip():
+            raise ValueError(
+                "Missing required: RETRIEVAL_API_INTERNAL_SECRET (SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-4). "
+                "Set it in SOPS before starting portal-api."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _require_docs_internal_secret(self) -> "Settings":
+        """SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-5: fail-closed on missing DOCS_INTERNAL_SECRET.
+
+        Cross-service trust boundary: portal-api -> klai-docs for KB provisioning.
+        An empty value silently disables auth, letting any caller provision or
+        deprovision knowledge-base resources for arbitrary tenants.
+
+        Where used: app/services/docs_client.py (or equivalent) -- X-Internal-Secret header.
+        Failure mode without validator: docs endpoint accepts empty secret, bypassing
+        tenant-scoped access control.
+
+        Env-parity: DOCS_INTERNAL_SECRET must exist in klai-infra/core-01/.env.sops BEFORE merge.
+        Pre-flight verified 2026-05-05: value populated in /opt/klai/.env.
+        """
+        if not self.docs_internal_secret or not self.docs_internal_secret.strip():
+            raise ValueError(
+                "Missing required: DOCS_INTERNAL_SECRET (SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-5). "
+                "Set it in SOPS before starting portal-api."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _require_zitadel_portal_client_secret(self) -> "Settings":
+        """SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-6: fail-closed on missing ZITADEL_PORTAL_CLIENT_SECRET.
+
+        Cross-service trust boundary: portal-api <-> Zitadel BFF code-exchange (SPEC-AUTH-008).
+        This is the confidential client secret used to exchange an authorization code for
+        tokens. An empty value causes every login to fail at token exchange (auth outage).
+
+        Where used: app/api/auth.py -- /api/auth/oidc/callback BFF code-exchange.
+        Failure mode without validator: portal-api starts but every login fails at token exchange.
+
+        Env-parity: ZITADEL_PORTAL_CLIENT_SECRET must exist in klai-infra/core-01/.env.sops BEFORE merge.
+        Pre-flight verified 2026-05-05: value populated in /opt/klai/.env.
+        """
+        if not self.zitadel_portal_client_secret or not self.zitadel_portal_client_secret.strip():
+            raise ValueError(
+                "Missing required: ZITADEL_PORTAL_CLIENT_SECRET (SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-6). "
+                "Set it in SOPS before starting portal-api."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _require_portal_secrets_key(self) -> "Settings":
+        """SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-7: fail-closed on missing PORTAL_SECRETS_KEY.
+
+        Encryption at rest: portal_secrets_key is the DEK used to encrypt tenant
+        secrets (e.g. zitadel_librechat_client_secret, litellm_team_key) stored
+        in the database. An empty key causes decryption of all at-rest tenant
+        secrets to fail, breaking every multi-tenant operation.
+
+        Where used: app/utils/crypto.py (or equivalent) -- AES-GCM encrypt/decrypt of tenant secrets.
+        Failure mode without validator: portal-api starts but all tenant-secret reads
+        return decryption errors; or encrypts with a known-weak/empty key.
+
+        Env-parity: PORTAL_SECRETS_KEY must exist in klai-infra/core-01/.env.sops BEFORE merge.
+        Pre-flight verified 2026-05-05: value populated in /opt/klai/.env.
+        """
+        if not self.portal_secrets_key or not self.portal_secrets_key.strip():
+            raise ValueError(
+                "Missing required: PORTAL_SECRETS_KEY (SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-7). "
+                "Set it in SOPS before starting portal-api."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _require_encryption_key(self) -> "Settings":
+        """SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-8: fail-closed on missing ENCRYPTION_KEY.
+
+        Encryption at rest: encryption_key is the KEK in the two-tier key hierarchy
+        (SPEC-KB-020) used to encrypt connector OAuth credentials (access_token,
+        refresh_token). An empty key causes connector auth to fail for every tenant.
+
+        Where used: app/utils/crypto.py -- connector credential KEK encrypt/decrypt.
+        Failure mode without validator: connector sync fails for all tenants with
+        decryption errors, or credentials are stored/retrieved with a null key.
+
+        Env-parity: ENCRYPTION_KEY must exist in klai-infra/core-01/.env.sops BEFORE merge.
+        Pre-flight verified 2026-05-05: value populated in /opt/klai/.env.
+        """
+        if not self.encryption_key or not self.encryption_key.strip():
+            raise ValueError(
+                "Missing required: ENCRYPTION_KEY (SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-8). "
+                "Set it in SOPS before starting portal-api."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _require_sso_cookie_key(self) -> "Settings":
+        """SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-9: fail-closed on missing SSO_COOKIE_KEY.
+
+        SSO auth cookie integrity: sso_cookie_key is the Fernet key that encrypts and
+        authenticates the SSO state cookie used in the OIDC login flow. An empty key
+        allows arbitrary cookie forgery, enabling session hijacking for any user.
+
+        Where used: app/api/auth.py::_get_sso_fernet -- SSO cookie encrypt/decrypt.
+        Failure mode without validator: RuntimeError at first login (defensive
+        _get_sso_fernet guard), or, if that guard is removed, unauthenticated cookie
+        acceptance. This validator adds the fail-fast-at-startup layer.
+
+        Env-parity: SSO_COOKIE_KEY must exist in klai-infra/core-01/.env.sops BEFORE merge.
+        Pre-flight verified 2026-05-05: value populated in /opt/klai/.env.
+        """
+        if not self.sso_cookie_key or not self.sso_cookie_key.strip():
+            raise ValueError(
+                "Missing required: SSO_COOKIE_KEY (SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-9). "
+                "Set it in SOPS before starting portal-api."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _require_bff_session_key(self) -> "Settings":
+        """SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-10: fail-closed on missing BFF_SESSION_KEY.
+
+        BFF session cookie integrity: bff_session_key is the Fernet key used to encrypt
+        BFF session records at rest in Redis (SPEC-AUTH-008). An empty key allows
+        arbitrary session forgery -- any attacker who can write to Redis can issue
+        authenticated sessions for any user.
+
+        Where used: app/api/auth.py -- BFF session encrypt/decrypt in Redis.
+        Failure mode without validator: bff_session_key falls back to sso_cookie_key
+        when unset (field comment). This validator closes that undocumented fallback
+        path in production by making the misconfiguration explicit at startup.
+
+        Env-parity: BFF_SESSION_KEY must exist in klai-infra/core-01/.env.sops BEFORE merge.
+        Pre-flight verified 2026-05-05: value populated in /opt/klai/.env.
+        """
+        if not self.bff_session_key or not self.bff_session_key.strip():
+            raise ValueError(
+                "Missing required: BFF_SESSION_KEY (SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-10). "
+                "Set it in SOPS before starting portal-api."
+            )
+        return self
+
 
 settings = Settings()  # type: ignore[call-arg]  # pydantic-settings reads required fields from env

--- a/klai-portal/backend/app/services/bff_session.py
+++ b/klai-portal/backend/app/services/bff_session.py
@@ -150,12 +150,26 @@ class SessionService:
     # ------------------------------------------------------------------ crypto
 
     def _get_fernet(self) -> Fernet:
-        """Lazy-init Fernet so we do not crash at import time if the key is unset."""
+        """Lazy-init Fernet for the BFF session key.
+
+        Pre SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-10 (2026-05-05) this method
+        had a fallback to ``sso_cookie_key`` for the rollout transition
+        window. With the new fail-closed validator, ``bff_session_key`` is
+        a required env var verified at startup — the fallback path is dead.
+        Removed to make the validator's contract honest: one validator says
+        "this key is required", code reads only that key.
+        """
         if self._fernet is not None:
             return self._fernet
-        key = settings.bff_session_key or settings.sso_cookie_key
+        key = settings.bff_session_key
         if not key:
-            raise RuntimeError("BFF_SESSION_KEY (or SSO_COOKIE_KEY fallback) is not configured")
+            # Defence-in-depth: validator should have prevented this, but
+            # if Settings was constructed via model_construct() (test bypass)
+            # we still refuse to encrypt with an empty key.
+            raise RuntimeError(
+                "BFF_SESSION_KEY is not configured — should be enforced by "
+                "_require_bff_session_key validator at startup."
+            )
         self._fernet = Fernet(key.encode() if isinstance(key, str) else key)
         return self._fernet
 

--- a/klai-portal/backend/tests/conftest.py
+++ b/klai-portal/backend/tests/conftest.py
@@ -60,8 +60,13 @@ os.environ.setdefault("DOCS_INTERNAL_SECRET", "test-docs-internal-secret" * 2)  
 os.environ.setdefault(
     "ZITADEL_PORTAL_CLIENT_SECRET", "test-zitadel-portal-client-secret"
 )  # SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-6
+# Audit 2026-05-05 finding 4: BFF_SESSION_KEY and SSO_COOKIE_KEY MUST be
+# distinct test values so a bug where code accidentally reads the wrong
+# key does not silently decrypt successfully (both Fernet keys produce
+# valid ciphertext for any payload). Use a generated-different second
+# Fernet key here.
 os.environ.setdefault(
-    "BFF_SESSION_KEY", "R1c1-s96uO9Yz7k1E0kN6qz52gzd9PwNbAeZaks_PIc="
+    "BFF_SESSION_KEY", "aBcDeFgHiJkLmNoPqRsTuVwXyZ012345678901234="
 )  # SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-10
 
 # ---------------------------------------------------------------------------

--- a/klai-portal/backend/tests/conftest.py
+++ b/klai-portal/backend/tests/conftest.py
@@ -46,6 +46,23 @@ os.environ.setdefault("VEXA_WEBHOOK_SECRET", "test-vexa-webhook-secret")  # SEC-
 os.environ.setdefault("MONEYBIRD_WEBHOOK_TOKEN", "test-moneybird-webhook-token")  # SPEC-SEC-WEBHOOK-001 REQ-3
 os.environ.setdefault("ZITADEL_IDP_GOOGLE_ID", "test-google-idp-id")  # SPEC-SEC-AUTH-COVERAGE-001 REQ-2.6
 os.environ.setdefault("ZITADEL_IDP_MICROSOFT_ID", "test-microsoft-idp-id")  # SPEC-SEC-AUTH-COVERAGE-001 REQ-2.6
+os.environ.setdefault("INTERNAL_SECRET", "test-internal-secret-x" * 2)  # SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-1
+os.environ.setdefault(
+    "KLAI_CONNECTOR_SECRET", "test-klai-connector-secret" * 2
+)  # SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-2
+os.environ.setdefault(
+    "KNOWLEDGE_INGEST_SECRET", "test-knowledge-ingest-secret" * 2
+)  # SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-3
+os.environ.setdefault(
+    "RETRIEVAL_API_INTERNAL_SECRET", "test-retrieval-secret" * 2
+)  # SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-4
+os.environ.setdefault("DOCS_INTERNAL_SECRET", "test-docs-internal-secret" * 2)  # SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-5
+os.environ.setdefault(
+    "ZITADEL_PORTAL_CLIENT_SECRET", "test-zitadel-portal-client-secret"
+)  # SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-6
+os.environ.setdefault(
+    "BFF_SESSION_KEY", "R1c1-s96uO9Yz7k1E0kN6qz52gzd9PwNbAeZaks_PIc="
+)  # SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-10
 
 # ---------------------------------------------------------------------------
 # Auto-discoverable fixtures (SPEC-SEC-AUTH-COVERAGE-001 REQ-5.6)

--- a/klai-portal/backend/tests/services/test_bff_session.py
+++ b/klai-portal/backend/tests/services/test_bff_session.py
@@ -145,12 +145,18 @@ class TestEncryption:
         with pytest.raises(RuntimeError, match="BFF_SESSION_KEY"):
             svc._encrypt("anything")
 
-    def test_sso_cookie_key_is_used_as_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_sso_cookie_key_is_NOT_used_as_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-10: the legacy
+        ``bff_session_key or sso_cookie_key`` fallback is removed. Even if
+        ``sso_cookie_key`` is set, an empty ``bff_session_key`` MUST raise
+        — the fail-closed validator is the single source of truth for the
+        BFF key.
+        """
         monkeypatch.setattr(settings, "bff_session_key", "")
         monkeypatch.setattr(settings, "sso_cookie_key", Fernet.generate_key().decode())
         svc = SessionService()
-        blob = svc._encrypt("fallback")
-        assert svc._decrypt(blob) == "fallback"
+        with pytest.raises(RuntimeError, match="BFF_SESSION_KEY"):
+            svc._encrypt("anything")
 
 
 # ---------------------------------------------------------------------------

--- a/klai-portal/backend/tests/test_config_fail_closed.py
+++ b/klai-portal/backend/tests/test_config_fail_closed.py
@@ -1,0 +1,209 @@
+"""SPEC-SEC-VALIDATOR-COVERAGE-001: fail-closed startup validators for portal-api.
+
+Each of the 10 @model_validator(mode="after") methods in
+klai-portal/backend/app/core/config.py must raise ValidationError when its
+corresponding env var is empty or whitespace-only.
+
+Test strategy:
+- For each field, monkeypatch its env var to "" (empty) and "   " (whitespace).
+- All OTHER required env vars must be non-empty so only the field under test
+  fails. The conftest.py module-level os.environ.setdefault calls handle the
+  baseline; individual tests override only the field under test.
+- We re-import the module after each monkeypatch so the module-level
+  `settings = Settings()` singleton fires again with the patched env.
+
+Pattern mirrors klai-mailer/tests/test_config_fail_closed.py.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+from pydantic import ValidationError
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _reimport_config() -> None:
+    """Drop the cached app.core.config module and re-import it.
+
+    The module-level `settings = Settings()` call fires on import, so this
+    triggers the validator under test with whatever env is currently patched.
+    """
+    sys.modules.pop("app.core.config", None)
+    importlib.import_module("app.core.config")
+
+
+# ---------------------------------------------------------------------------
+# REQ-1: INTERNAL_SECRET
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["", "   "], ids=["empty", "whitespace"])
+def test_settings_startup_fails_without_internal_secret(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    """REQ-1: empty / whitespace INTERNAL_SECRET raises ValidationError at startup."""
+    monkeypatch.setenv("INTERNAL_SECRET", value)
+    sys.modules.pop("app.core.config", None)
+    with pytest.raises(ValidationError, match="INTERNAL_SECRET"):
+        importlib.import_module("app.core.config")
+
+
+# ---------------------------------------------------------------------------
+# REQ-2: KLAI_CONNECTOR_SECRET
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["", "   "], ids=["empty", "whitespace"])
+def test_settings_startup_fails_without_klai_connector_secret(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    """REQ-2: empty / whitespace KLAI_CONNECTOR_SECRET raises ValidationError at startup."""
+    monkeypatch.setenv("KLAI_CONNECTOR_SECRET", value)
+    sys.modules.pop("app.core.config", None)
+    with pytest.raises(ValidationError, match="KLAI_CONNECTOR_SECRET"):
+        importlib.import_module("app.core.config")
+
+
+# ---------------------------------------------------------------------------
+# REQ-3: KNOWLEDGE_INGEST_SECRET
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["", "   "], ids=["empty", "whitespace"])
+def test_settings_startup_fails_without_knowledge_ingest_secret(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    """REQ-3: empty / whitespace KNOWLEDGE_INGEST_SECRET raises ValidationError at startup."""
+    monkeypatch.setenv("KNOWLEDGE_INGEST_SECRET", value)
+    sys.modules.pop("app.core.config", None)
+    with pytest.raises(ValidationError, match="KNOWLEDGE_INGEST_SECRET"):
+        importlib.import_module("app.core.config")
+
+
+# ---------------------------------------------------------------------------
+# REQ-4: RETRIEVAL_API_INTERNAL_SECRET
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["", "   "], ids=["empty", "whitespace"])
+def test_settings_startup_fails_without_retrieval_api_internal_secret(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    """REQ-4: empty / whitespace RETRIEVAL_API_INTERNAL_SECRET raises ValidationError at startup."""
+    monkeypatch.setenv("RETRIEVAL_API_INTERNAL_SECRET", value)
+    sys.modules.pop("app.core.config", None)
+    with pytest.raises(ValidationError, match="RETRIEVAL_API_INTERNAL_SECRET"):
+        importlib.import_module("app.core.config")
+
+
+# ---------------------------------------------------------------------------
+# REQ-5: DOCS_INTERNAL_SECRET
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["", "   "], ids=["empty", "whitespace"])
+def test_settings_startup_fails_without_docs_internal_secret(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    """REQ-5: empty / whitespace DOCS_INTERNAL_SECRET raises ValidationError at startup."""
+    monkeypatch.setenv("DOCS_INTERNAL_SECRET", value)
+    sys.modules.pop("app.core.config", None)
+    with pytest.raises(ValidationError, match="DOCS_INTERNAL_SECRET"):
+        importlib.import_module("app.core.config")
+
+
+# ---------------------------------------------------------------------------
+# REQ-6: ZITADEL_PORTAL_CLIENT_SECRET
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["", "   "], ids=["empty", "whitespace"])
+def test_settings_startup_fails_without_zitadel_portal_client_secret(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    """REQ-6: empty / whitespace ZITADEL_PORTAL_CLIENT_SECRET raises ValidationError at startup."""
+    monkeypatch.setenv("ZITADEL_PORTAL_CLIENT_SECRET", value)
+    sys.modules.pop("app.core.config", None)
+    with pytest.raises(ValidationError, match="ZITADEL_PORTAL_CLIENT_SECRET"):
+        importlib.import_module("app.core.config")
+
+
+# ---------------------------------------------------------------------------
+# REQ-7: PORTAL_SECRETS_KEY
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["", "   "], ids=["empty", "whitespace"])
+def test_settings_startup_fails_without_portal_secrets_key(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    """REQ-7: empty / whitespace PORTAL_SECRETS_KEY raises ValidationError at startup."""
+    monkeypatch.setenv("PORTAL_SECRETS_KEY", value)
+    sys.modules.pop("app.core.config", None)
+    with pytest.raises(ValidationError, match="PORTAL_SECRETS_KEY"):
+        importlib.import_module("app.core.config")
+
+
+# ---------------------------------------------------------------------------
+# REQ-8: ENCRYPTION_KEY
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["", "   "], ids=["empty", "whitespace"])
+def test_settings_startup_fails_without_encryption_key(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    """REQ-8: empty / whitespace ENCRYPTION_KEY raises ValidationError at startup."""
+    monkeypatch.setenv("ENCRYPTION_KEY", value)
+    sys.modules.pop("app.core.config", None)
+    with pytest.raises(ValidationError, match="ENCRYPTION_KEY"):
+        importlib.import_module("app.core.config")
+
+
+# ---------------------------------------------------------------------------
+# REQ-9: SSO_COOKIE_KEY
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["", "   "], ids=["empty", "whitespace"])
+def test_settings_startup_fails_without_sso_cookie_key(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    """REQ-9: empty / whitespace SSO_COOKIE_KEY raises ValidationError at startup."""
+    monkeypatch.setenv("SSO_COOKIE_KEY", value)
+    sys.modules.pop("app.core.config", None)
+    with pytest.raises(ValidationError, match="SSO_COOKIE_KEY"):
+        importlib.import_module("app.core.config")
+
+
+# ---------------------------------------------------------------------------
+# REQ-10: BFF_SESSION_KEY
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["", "   "], ids=["empty", "whitespace"])
+def test_settings_startup_fails_without_bff_session_key(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    """REQ-10: empty / whitespace BFF_SESSION_KEY raises ValidationError at startup."""
+    monkeypatch.setenv("BFF_SESSION_KEY", value)
+    sys.modules.pop("app.core.config", None)
+    with pytest.raises(ValidationError, match="BFF_SESSION_KEY"):
+        importlib.import_module("app.core.config")
+
+
+# ---------------------------------------------------------------------------
+# Sanity: all fields populated -> Settings constructs without error
+# ---------------------------------------------------------------------------
+
+
+def test_valid_env_constructs_settings() -> None:
+    """Sanity check: with all required env vars set, Settings() succeeds.
+
+    This test relies on conftest.py having set all required env vars via
+    os.environ.setdefault at module load time. If this test fails, a required
+    env var is missing from conftest.py.
+    """
+    sys.modules.pop("app.core.config", None)
+    import app.core.config as cfg
+
+    assert cfg.settings.internal_secret
+    assert cfg.settings.klai_connector_secret
+    assert cfg.settings.knowledge_ingest_secret
+    assert cfg.settings.retrieval_api_internal_secret
+    assert cfg.settings.docs_internal_secret
+    assert cfg.settings.zitadel_portal_client_secret
+    assert cfg.settings.portal_secrets_key
+    assert cfg.settings.encryption_key
+    assert cfg.settings.sso_cookie_key
+    assert cfg.settings.bff_session_key

--- a/klai-portal/backend/tests/test_config_fail_closed.py
+++ b/klai-portal/backend/tests/test_config_fail_closed.py
@@ -193,6 +193,22 @@ def test_valid_env_constructs_settings() -> None:
     This test relies on conftest.py having set all required env vars via
     os.environ.setdefault at module load time. If this test fails, a required
     env var is missing from conftest.py.
+
+    Why this exists (audit 2026-05-05 finding F9 — explicitly retained):
+
+    The 20 parametrized fail-closed tests above each prove ONE specific
+    validator rejects empty/whitespace input. They do NOT prove that
+    conftest seeds enough valid values for the full Settings() to
+    construct. This sanity test catches a different regression class:
+    "a future PR adds a new fail-closed validator on field X, conftest is
+    not updated to seed X, every test in the file then fails at module
+    import with a confusing 'X is required' error". By asserting each
+    field is truthy, the failure mode is a single explicit assertion in
+    THIS test rather than every other test inheriting an opaque
+    ValidationError at conftest-import time.
+
+    Low marginal value per-validator, high marginal value as a
+    canary against conftest drift.
     """
     sys.modules.pop("app.core.config", None)
     import app.core.config as cfg


### PR DESCRIPTION
Closes the **fail-open-auth** pitfall for 10 auth/encryption secrets in `klai-portal/backend/app/core/config.py`.

## Validators (REQ-1 .. REQ-10)

1. `internal_secret` — mailer→portal Bearer + various /internal/* callers
2. `klai_connector_secret` — portal→connector Bearer (sync orchestration)
3. `knowledge_ingest_secret` — portal→ingest X-Internal-Secret
4. `retrieval_api_internal_secret` — portal→retrieval (separately rotatable)
5. `docs_internal_secret` — portal→docs (KB provisioning)
6. `zitadel_portal_client_secret` — Zitadel BFF code-exchange
7. `portal_secrets_key` — at-rest DEK encryption
8. `encryption_key` — at-rest connector cookie KEK
9. `sso_cookie_key` — SSO auth cookie integrity
10. `bff_session_key` — BFF session cookie integrity

## Pre-flight verified

All 10 env vars present in production /opt/klai/.env on core-01 (validator-env-parity pitfall).

## Tests

- 21 new tests in `tests/test_config_fail_closed.py` (10 fields × {empty, whitespace} + 1 sanity)
- 72/72 related config tests pass (no regressions)
- conftest.py: 6 missing setdefault entries added so other tests don't trip the new validators

## Refs

- .claude/rules/klai/pitfalls/process-rules.md::fail-open-auth
- .claude/rules/klai/pitfalls/process-rules.md::validator-env-parity
- klai-mailer/app/config.py::_require_webhook_secret (canonical pattern)