### PR TITLE
feat(security): SPEC-SEC-VALIDATOR-COVERAGE-001 connector — fail-closed PORTAL_CALLER_SECRET

### DIFF
--- a/klai-connector/app/core/config.py
+++ b/klai-connector/app/core/config.py
@@ -177,6 +177,31 @@ class Settings(BaseSettings):
             )
         return v
 
+    @field_validator("portal_caller_secret", mode="after")
+    @classmethod
+    def _require_portal_caller_secret(cls, v: str) -> str:
+        """SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-11: fail-closed on missing
+        PORTAL_CALLER_SECRET.
+
+        klai-connector verifies portal-api's inbound calls (sync trigger,
+        OAuth callbacks) by comparing the X-Internal-Secret header against
+        this value via hmac.compare_digest. An empty/whitespace value
+        would make every comparison succeed against a literal-empty
+        attacker request — fail-open-auth pitfall.
+
+        Env-parity: PORTAL_CALLER_SECRET (sourced from PORTAL_API_KLAI_CONNECTOR_SECRET
+        in the compose file) must exist in klai-infra/core-01/.env.sops
+        BEFORE merge. Pre-flight verified 2026-05-05: value populated
+        in /opt/klai/.env on core-01.
+        """
+        if not v or not v.strip():
+            raise ValueError(
+                "Missing required: PORTAL_CALLER_SECRET (SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-11). "
+                "klai-connector verifies portal-api's inbound X-Internal-Secret against this; "
+                "an empty value would accept any caller. Set it in SOPS before starting klai-connector."
+            )
+        return v
+
     # ------------------------------------------------------------------
     # SPEC-SEC-AUDIT-2026-04 B2: fail-closed startup on empty audience.
     # Before this fix the middleware had a warn-only fallback that silently

--- a/klai-connector/tests/test_audit_2026_04_b2.py
+++ b/klai-connector/tests/test_audit_2026_04_b2.py
@@ -52,6 +52,9 @@ _VALID_SETTINGS_KWARGS: dict[str, str] = {
     "portal_internal_secret": "test-portal-secret-12345",
     # SPEC-SEC-AUDIT-2026-04 B2: audience is mandatory.
     "zitadel_api_audience": "klai-connector-test-audience",
+    # SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-11: portal_caller_secret is now
+    # also fail-closed validated.
+    "portal_caller_secret": "test-caller-secret-12345",
 }
 
 

--- a/klai-connector/tests/test_encryption_key_validator.py
+++ b/klai-connector/tests/test_encryption_key_validator.py
@@ -37,6 +37,10 @@ def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     monkeypatch.setenv("KNOWLEDGE_INGEST_URL", "http://knowledge-ingest:8000")
     monkeypatch.setenv("KNOWLEDGE_INGEST_SECRET", valid_secret)
     monkeypatch.setenv("PORTAL_INTERNAL_SECRET", valid_secret)
+    # SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-11 — PORTAL_CALLER_SECRET is now
+    # also fail-closed validated, so it must be set for tests that drive
+    # only the encryption_key validator.
+    monkeypatch.setenv("PORTAL_CALLER_SECRET", valid_secret)
     yield
 
 

--- a/klai-connector/tests/test_portal_caller_secret_validator.py
+++ b/klai-connector/tests/test_portal_caller_secret_validator.py
@@ -1,0 +1,98 @@
+"""SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-11 — fail-closed validator for
+``PORTAL_CALLER_SECRET``.
+
+klai-connector verifies portal-api's inbound calls (sync trigger,
+OAuth callbacks) by comparing the X-Internal-Secret header against
+``Settings.portal_caller_secret`` via ``hmac.compare_digest``. An
+empty/whitespace value would make every comparison succeed against a
+literal-empty attacker request — fail-open-auth pitfall.
+
+Mirrors ``test_encryption_key_validator.py`` for fixture pattern.
+Pre-flight: PORTAL_CALLER_SECRET (sourced from PORTAL_API_KLAI_CONNECTOR_SECRET
+in compose) verified populated in /opt/klai/.env on core-01 before this
+validator landed (validator-env-parity pitfall).
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+from collections.abc import Iterator
+
+import pytest
+from pydantic import ValidationError
+
+
+@pytest.fixture
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Set every OTHER required env var so only PORTAL_CALLER_SECRET drives the outcome."""
+    valid_secret = "valid-non-empty-secret-string"
+    valid_key = base64.b64encode(b"\x00" * 32).decode()
+    monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://klai:pw@localhost:5432/klai")
+    monkeypatch.setenv("ZITADEL_INTROSPECTION_URL", "https://auth.example.com/introspect")
+    monkeypatch.setenv("ZITADEL_CLIENT_ID", "klai-connector")
+    monkeypatch.setenv("ZITADEL_CLIENT_SECRET", valid_secret)
+    monkeypatch.setenv("ZITADEL_API_AUDIENCE", "klai-connector-app")
+    monkeypatch.setenv("GITHUB_APP_ID", "12345")
+    monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY", "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----")
+    monkeypatch.setenv("KNOWLEDGE_INGEST_URL", "http://knowledge-ingest:8000")
+    monkeypatch.setenv("KNOWLEDGE_INGEST_SECRET", valid_secret)
+    monkeypatch.setenv("PORTAL_INTERNAL_SECRET", valid_secret)
+    monkeypatch.setenv("ENCRYPTION_KEY", valid_key)
+    yield
+
+
+def _import_settings_class():
+    """Import Settings via importlib so each test sees a fresh validator pass."""
+    import importlib
+
+    import app.core.config as config_module
+
+    importlib.reload(config_module)
+    return config_module.Settings  # noqa: N806 (returning class)
+
+
+def test_valid_portal_caller_secret_accepted(
+    _required_settings_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PORTAL_CALLER_SECRET", "valid-non-empty-secret-string")
+    settings_cls = _import_settings_class()
+    s = settings_cls()
+    assert s.portal_caller_secret == "valid-non-empty-secret-string"
+
+
+def test_empty_portal_caller_secret_rejected_with_actionable_message(
+    _required_settings_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PORTAL_CALLER_SECRET", "")
+    settings_cls = _import_settings_class()
+    with pytest.raises(ValidationError) as exc_info:
+        settings_cls()
+    msg = str(exc_info.value)
+    assert "PORTAL_CALLER_SECRET" in msg
+    assert "SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-11" in msg
+
+
+def test_whitespace_only_portal_caller_secret_rejected(
+    _required_settings_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PORTAL_CALLER_SECRET", "   ")
+    settings_cls = _import_settings_class()
+    with pytest.raises(ValidationError):
+        settings_cls()
+
+
+def test_missing_portal_caller_secret_env_rejected(
+    _required_settings_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """PORTAL_CALLER_SECRET entirely absent triggers the validator since the field default is ``""``."""
+    monkeypatch.delenv("PORTAL_CALLER_SECRET", raising=False)
+    settings_cls = _import_settings_class()
+    with pytest.raises(ValidationError) as exc_info:
+        settings_cls()
+    assert "PORTAL_CALLER_SECRET" in str(exc_info.value)
+
+
+def test_env_state_clean_after_module(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Conservative: monkeypatch undoes everything via fixture teardown."""
+    assert os.environ.get("PORTAL_CALLER_SECRET") is None or os.environ.get("PORTAL_CALLER_SECRET") != ""

--- a/klai-connector/tests/test_portal_caller_secret_validator.py
+++ b/klai-connector/tests/test_portal_caller_secret_validator.py
@@ -93,6 +93,21 @@ def test_missing_portal_caller_secret_env_rejected(
     assert "PORTAL_CALLER_SECRET" in str(exc_info.value)
 
 
-def test_env_state_clean_after_module(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Conservative: monkeypatch undoes everything via fixture teardown."""
-    assert os.environ.get("PORTAL_CALLER_SECRET") is None or os.environ.get("PORTAL_CALLER_SECRET") != ""
+def test_env_state_clean_after_monkeypatch_teardown(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify pytest's monkeypatch teardown removed env mutations from prior tests.
+
+    Pre-fix the assertion was `X is None or X != ""` — logically equivalent to
+    `X != ""`, which is True for any non-empty value AND True for None. A real
+    env-leak (PORTAL_CALLER_SECRET inherited from another test's setenv that
+    bypassed monkeypatch) would still produce X != "" → assertion still passes.
+    The test was a tautology. (Audit 2026-05-05 finding 1.)
+
+    Real isolation check: assert the env var is either entirely absent OR
+    matches what conftest seeds at module-load time (if any). In our setup
+    conftest.py does NOT seed PORTAL_CALLER_SECRET — only the in-test
+    monkeypatch fixtures do. So a clean teardown means absent.
+    """
+    assert os.environ.get("PORTAL_CALLER_SECRET") is None, (
+        "PORTAL_CALLER_SECRET leaked across tests — monkeypatch teardown failed "
+        "or some fixture bypassed monkeypatch with os.environ direct mutation."
+    )

--- a/klai-connector/tests/test_portal_caller_secret_validator.py
+++ b/klai-connector/tests/test_portal_caller_secret_validator.py
@@ -43,12 +43,19 @@ def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
 
 
 def _import_settings_class():
-    """Import Settings via importlib so each test sees a fresh validator pass."""
+    """Import Settings via importlib so each test sees a fresh validator pass.
+
+    Audit 2026-05-05 finding F5: previously used `importlib.reload(config_module)`
+    which keeps the old module in `sys.modules` and patches in place — xdist-unsafe
+    because the singleton mutation leaks across tests when run in parallel. Now
+    pops the module first, then re-imports clean. Mirrors portal-api's
+    `_reimport_config` helper (klai-portal/backend/tests/test_config_fail_closed.py).
+    """
     import importlib
+    import sys
 
-    import app.core.config as config_module
-
-    importlib.reload(config_module)
+    sys.modules.pop("app.core.config", None)
+    config_module = importlib.import_module("app.core.config")
     return config_module.Settings  # noqa: N806 (returning class)
 
 

--- a/klai-connector/tests/test_sec_internal_001.py
+++ b/klai-connector/tests/test_sec_internal_001.py
@@ -28,6 +28,9 @@ _VALID_SETTINGS_KWARGS: dict[str, str] = {
     "portal_internal_secret": "test-portal-secret-12345",
     # SPEC-SEC-AUDIT-2026-04 B2: audience is now mandatory (model_validator).
     "zitadel_api_audience": "klai-connector-test-audience",
+    # SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-11: portal_caller_secret is now
+    # also fail-closed validated (inbound from portal-api).
+    "portal_caller_secret": "test-caller-secret-12345",
 }
 
 


### PR DESCRIPTION
Closes the **fail-open-auth** pitfall on the inbound trust boundary portal-api → klai-connector.

## What

Validator REQ-11: klai-connector verifies portal-api's X-Internal-Secret header against `Settings.portal_caller_secret` via `hmac.compare_digest`. With an empty value, every comparison would succeed against an attacker request that also has an empty header.

## Pre-flight

PORTAL_CALLER_SECRET (sourced from PORTAL_API_KLAI_CONNECTOR_SECRET) verified populated in /opt/klai/.env on core-01.

## Tests

- 5 new tests in `tests/test_portal_caller_secret_validator.py`
- 32/32 config-validator tests pass (mailer-canonical pattern)
- Updated 3 adjacent test fixtures to set PORTAL_CALLER_SECRET so they isolate their own validator

## Refs

- .claude/rules/klai/pitfalls/process-rules.md::fail-open-auth