### PR TITLE
feat(security): SPEC-SEC-VALIDATOR-COVERAGE-001 ingest — fail-closed GITEA_WEBHOOK_SECRET

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/config.py
+++ b/klai-knowledge-ingest/knowledge_ingest/config.py
@@ -158,5 +158,31 @@ class Settings(BaseSettings):
             raise ValueError("Missing required: PORTAL_INTERNAL_TOKEN (SEC-014)")
         return self
 
+    @model_validator(mode="after")
+    def _require_gitea_webhook_secret(self) -> Settings:
+        """SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-12: fail-closed on missing
+        GITEA_WEBHOOK_SECRET.
+
+        Gitea POSTs to /webhooks/gitea on every push to a tenant-tracked
+        repository. The handler verifies the X-Gitea-Signature HMAC against
+        ``Settings.gitea_webhook_secret`` via ``hmac.compare_digest``. With
+        an empty/whitespace-only value, every comparison would succeed
+        against an attacker request that also has an empty signature —
+        exact fail-open-auth pattern, attacker can trigger ingestion of
+        attacker-controlled markdown into the tenant KB.
+
+        Env-parity: GITEA_WEBHOOK_SECRET must exist in
+        klai-infra/core-01/.env.sops BEFORE merge. Pre-flight verified
+        2026-05-05: value populated in /opt/klai/.env on core-01.
+        """
+        if not self.gitea_webhook_secret or not self.gitea_webhook_secret.strip():
+            raise ValueError(
+                "Missing required: GITEA_WEBHOOK_SECRET (SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-12). "
+                "knowledge-ingest verifies Gitea push-webhook HMACs against this; "
+                "an empty value would accept any caller and let an attacker inject "
+                "tenant KB content. Set it in SOPS before starting knowledge-ingest."
+            )
+        return self
+
 
 settings = Settings()

--- a/klai-knowledge-ingest/tests/conftest.py
+++ b/klai-knowledge-ingest/tests/conftest.py
@@ -13,6 +13,8 @@ import os
 
 os.environ.setdefault("KNOWLEDGE_INGEST_SECRET", "test-secret-value-123")
 os.environ.setdefault("PORTAL_INTERNAL_TOKEN", "test-portal-internal-token-456")  # SEC-014
+# SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-12 — gitea webhook HMAC secret.
+os.environ.setdefault("GITEA_WEBHOOK_SECRET", "test-gitea-webhook-secret-789")
 
 # Imports below need the env vars above — keep this order to allow the
 # module-level ``settings = Settings()`` call in ``knowledge_ingest.config``

--- a/klai-knowledge-ingest/tests/test_gitea_webhook_secret_validator.py
+++ b/klai-knowledge-ingest/tests/test_gitea_webhook_secret_validator.py
@@ -35,12 +35,18 @@ def _import_settings_class():
 
 
 def test_valid_gitea_webhook_secret_accepted(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Sanity: non-empty value passes."""
+    """Sanity: non-empty value lets the module import + the singleton construct.
+
+    Imports knowledge_ingest.config to exercise the actual production code
+    path (module-level ``settings = Settings()`` runs under the patched env),
+    not just direct ``Settings()`` construction. Audit 2026-05-05 finding 2:
+    the previous test bypassed import-time validation and would silently
+    pass even if the module-level singleton was broken.
+    """
     monkeypatch.setenv("GITEA_WEBHOOK_SECRET", "valid-non-empty-webhook-secret")
     _reload_config_module(monkeypatch)
-    SettingsCls = _import_settings_class()
-    s = SettingsCls()
-    assert s.gitea_webhook_secret == "valid-non-empty-webhook-secret"
+    config_module = importlib.import_module("knowledge_ingest.config")
+    assert config_module.settings.gitea_webhook_secret == "valid-non-empty-webhook-secret"
 
 
 @pytest.mark.parametrize("value", ["", "   ", "\t\n "], ids=["empty", "spaces", "whitespace"])

--- a/klai-knowledge-ingest/tests/test_gitea_webhook_secret_validator.py
+++ b/klai-knowledge-ingest/tests/test_gitea_webhook_secret_validator.py
@@ -1,0 +1,84 @@
+"""SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-12 — fail-closed validator for
+``GITEA_WEBHOOK_SECRET``.
+
+Gitea POSTs to ``/webhooks/gitea`` on every push to a tenant-tracked
+repository. The handler verifies the X-Gitea-Signature HMAC against
+``Settings.gitea_webhook_secret`` via ``hmac.compare_digest``. With an
+empty/whitespace-only value, every comparison would succeed against an
+attacker request that also has an empty signature — exact fail-open-auth
+pattern from .claude/rules/klai/pitfalls/process-rules.md.
+
+Pre-flight: GITEA_WEBHOOK_SECRET verified populated in /opt/klai/.env
+on core-01 before this validator landed (validator-env-parity pitfall).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+from pydantic import ValidationError
+
+
+def _reload_config_module(monkeypatch: pytest.MonkeyPatch):
+    """Re-import knowledge_ingest.config so the module-level Settings()
+    instantiation re-runs under the test's monkey-patched env."""
+    sys.modules.pop("knowledge_ingest.config", None)
+    sys.modules.pop("knowledge_ingest", None)
+
+
+def _import_settings_class():
+    import knowledge_ingest.config as config_module
+
+    return config_module.Settings
+
+
+def test_valid_gitea_webhook_secret_accepted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sanity: non-empty value passes."""
+    monkeypatch.setenv("GITEA_WEBHOOK_SECRET", "valid-non-empty-webhook-secret")
+    _reload_config_module(monkeypatch)
+    SettingsCls = _import_settings_class()
+    s = SettingsCls()
+    assert s.gitea_webhook_secret == "valid-non-empty-webhook-secret"
+
+
+@pytest.mark.parametrize("value", ["", "   ", "\t\n "], ids=["empty", "spaces", "whitespace"])
+def test_empty_or_whitespace_gitea_webhook_secret_refuses_startup(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    """REQ-12: empty / whitespace-only GITEA_WEBHOOK_SECRET raises ValidationError.
+
+    The module-level ``settings = Settings()`` in knowledge_ingest.config
+    means the failure surfaces at IMPORT TIME — that is the actual
+    production behaviour (container refuses to start). The ``with
+    pytest.raises`` block must wrap the import itself, not the
+    Settings() class call after a successful import.
+    """
+    monkeypatch.setenv("GITEA_WEBHOOK_SECRET", value)
+    _reload_config_module(monkeypatch)
+    with pytest.raises(ValidationError) as exc_info:
+        importlib.import_module("knowledge_ingest.config")
+    msg = str(exc_info.value)
+    assert "GITEA_WEBHOOK_SECRET" in msg
+    assert "SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-12" in msg
+
+
+def test_missing_gitea_webhook_secret_env_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    """GITEA_WEBHOOK_SECRET absent triggers the validator: field default is empty string."""
+    monkeypatch.delenv("GITEA_WEBHOOK_SECRET", raising=False)
+    _reload_config_module(monkeypatch)
+    with pytest.raises(ValidationError) as exc_info:
+        importlib.import_module("knowledge_ingest.config")
+    assert "GITEA_WEBHOOK_SECRET" in str(exc_info.value)
+
+
+def test_module_level_settings_singleton_fails_on_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The module-level ``settings = Settings()`` in knowledge_ingest.config
+    triggers the same validator. An empty env var refuses module import,
+    which is the actual production behaviour: container fails to start."""
+    monkeypatch.setenv("GITEA_WEBHOOK_SECRET", "")
+    sys.modules.pop("knowledge_ingest.config", None)
+    sys.modules.pop("knowledge_ingest", None)
+    with pytest.raises(ValidationError):
+        importlib.import_module("knowledge_ingest.config")


### PR DESCRIPTION
Closes the **fail-open-auth** pitfall on the inbound trust boundary Gitea → knowledge-ingest webhook handler.

## What

Validator REQ-12: `/webhooks/gitea` verifies X-Gitea-Signature HMAC against `Settings.gitea_webhook_secret` via `hmac.compare_digest`. With an empty value, an attacker can inject tenant KB content directly via the webhook.

## Pre-flight

GITEA_WEBHOOK_SECRET verified populated in /opt/klai/.env on core-01.

## Tests

- 6 new tests in `tests/test_gitea_webhook_secret_validator.py` covering valid / empty / whitespace / missing-env / module-level-singleton
- conftest.py: GITEA_WEBHOOK_SECRET added to setdefault block

## Refs

- .claude/rules/klai/pitfalls/process-rules.md::fail-open-auth