### PR TITLE
feat(security): SPEC-SEC-VALIDATOR-COVERAGE-001 mailer — fail-closed PORTAL_INTERNAL_SECRET

### DIFF
--- a/klai-mailer/app/config.py
+++ b/klai-mailer/app/config.py
@@ -77,6 +77,28 @@ class Settings(BaseSettings):
             raise ValueError("Missing required: INTERNAL_SECRET")
         return v
 
+    # SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-13: outbound mailer→portal Bearer.
+    # Mailer calls the portal's /internal/org/{id}/preferred-language endpoint
+    # (see app/portal_client.py) for locale resolution. With an empty
+    # portal_internal_secret, the outbound httpx request would send
+    # `Bearer ` (literal trailing space) and the portal would reject it
+    # OR — worse — historically log the empty bearer as a "valid" auth.
+    # Pre-flight (validator-env-parity): PORTAL_INTERNAL_SECRET sourced
+    # from PORTAL_API_INTERNAL_SECRET in the compose file's mailer env
+    # block; verified populated in /opt/klai/.env on core-01 2026-05-05.
+    @field_validator("portal_internal_secret", mode="after")
+    @classmethod
+    def _require_portal_internal_secret(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError(
+                "Missing required: PORTAL_INTERNAL_SECRET "
+                "(SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-13). "
+                "Mailer authenticates outbound /internal/* calls to portal-api with this Bearer; "
+                "an empty value would send `Bearer ` (literal trailing space) on every call. "
+                "Set it in SOPS before starting klai-mailer."
+            )
+        return v
+
     # @MX:NOTE: structural URL validator — fail-fast at boot prevents the
     #   "service starts cleanly, then 5xx every webhook" failure mode that
     #   the 2026-04-29 outage exposed (broken-redis-URL).

--- a/klai-mailer/app/portal_client.py
+++ b/klai-mailer/app/portal_client.py
@@ -26,6 +26,15 @@ async def get_user_language(email: str) -> str | None:
     - portal_internal_secret is not configured
     - the portal is unreachable
     - the request fails for any reason
+
+    Note on the portal_internal_secret guard:
+        SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-13 added a startup-time
+        ``_require_portal_internal_secret`` validator (klai-mailer/app/config.py)
+        that rejects empty/whitespace-only values. So in production the
+        guard below is unreachable — but it is intentionally retained as
+        defence-in-depth for the ``Settings.model_construct()`` bypass
+        path used by some tests. Same shape as the dual guard on the
+        klai-connector PortalClient (services/portal_client.py).
     """
     if not settings.portal_internal_secret:
         return None
@@ -60,6 +69,11 @@ async def resolve_org_admin_email(org_id: int) -> str:
     so the handler can return HTTP 503 `{"detail": "recipient lookup
     unavailable"}`. Fail-closed is correct: without the callback the
     service cannot prove the recipient is the legitimate admin.
+
+    See `get_user_language` above for the rationale on the
+    portal_internal_secret guard — startup validator REQ-13 makes this
+    branch unreachable in production; retained as defence-in-depth for
+    the model_construct() test-bypass path.
     """
     if not settings.portal_internal_secret:
         raise PortalLookupError("portal_internal_secret not configured")

--- a/klai-mailer/tests/test_config_fail_closed.py
+++ b/klai-mailer/tests/test_config_fail_closed.py
@@ -59,6 +59,25 @@ def test_empty_internal_secret_refuses_startup(settings_env, monkeypatch, value)
     assert "Missing required: INTERNAL_SECRET" in str(exc_info.value)
 
 
+@pytest.mark.parametrize("value", ["", "   ", "\t\n "], ids=["empty", "spaces", "whitespace"])
+def test_empty_portal_internal_secret_refuses_startup(settings_env, monkeypatch, value):
+    """SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-13: empty / whitespace
+    PORTAL_INTERNAL_SECRET raises ValidationError.
+
+    Closes empty-secret-fail-open on the outbound mailer→portal trust
+    boundary. With an empty value, app/portal_client.py would send
+    ``Authorization: Bearer `` (literal trailing space) on every locale
+    lookup call.
+    """
+    monkeypatch.setenv("PORTAL_INTERNAL_SECRET", value)
+    sys.modules.pop("app.config", None)
+    with pytest.raises(ValidationError) as exc_info:
+        importlib.import_module("app.config")
+    msg = str(exc_info.value)
+    assert "PORTAL_INTERNAL_SECRET" in msg
+    assert "SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-13" in msg
+
+
 def test_both_empty_raises(settings_env, monkeypatch):
     """Both secrets empty → import fails with at least one missing error."""
     monkeypatch.setenv("WEBHOOK_SECRET", "")


### PR DESCRIPTION
Closes the **empty-secret-fail-open** pitfall on the outbound mailer→portal trust boundary.

## What

Validator REQ-13: mailer calls portal's `/internal/org/{id}/preferred-language` (app/portal_client.py) for locale resolution. With an empty `portal_internal_secret`, the outbound httpx request would send `Authorization: Bearer ` (literal trailing space) on every call.

## Pre-flight

PORTAL_INTERNAL_SECRET sourced from PORTAL_API_INTERNAL_SECRET in compose; verified populated in mailer container post 2026-05-05 stabilize and now permanently in SOPS via klai-infra PR #4.

## Tests

- 3 new parametrized cases in `tests/test_config_fail_closed.py`
- 18/18 tests pass

## Refs

- .claude/rules/klai/pitfalls/process-rules.md::empty-secret-fail-open