### PR TITLE
feat(security): SPEC-SEC-VALIDATOR-COVERAGE-001 retrieval — fail-closed PORTAL_INTERNAL_SECRET

### DIFF
--- a/klai-retrieval-api/retrieval_api/config.py
+++ b/klai-retrieval-api/retrieval_api/config.py
@@ -102,9 +102,17 @@ class Settings(BaseSettings):
     def _validate_security_settings(self) -> Settings:
         """REQ-1.1 / REQ-5.2: fail-closed on missing required security config.
 
-        Required (fail-closed): INTERNAL_SECRET — without it, auth is bypassed.
-        Required (fail-closed): REDIS_URL — rate limiter fails open to identity
-            check only, but Redis config is still expected.
+        Required (fail-closed):
+          - INTERNAL_SECRET — without it, inbound auth is bypassed.
+          - REDIS_URL — rate limiter fails open to identity check only, but
+            Redis config is still expected.
+          - PORTAL_INTERNAL_SECRET — SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-14.
+            Outbound retrieval-api → portal-api Bearer for the
+            /internal/identity/verify call (SPEC-SEC-IDENTITY-ASSERT-001).
+            With an empty value, the IdentityAsserter constructor would
+            raise downstream — this validator surfaces the same failure
+            at startup with an actionable message instead of at the first
+            internal-secret request.
 
         Optional (graceful degrade):
           ZITADEL_ISSUER + ZITADEL_API_AUDIENCE — if either is empty, the JWT
@@ -114,12 +122,18 @@ class Settings(BaseSettings):
           This is the correct state until SEC-012 lands: retrieval-api is only
           called by trusted services (portal-api, focus, LiteLLM hook) using
           the internal-secret path; no end-user JWT flows through it yet.
+
+        Pre-flight (validator-env-parity pitfall): all three required env
+        vars verified populated in /opt/klai/.env on core-01 prior to
+        landing this REQ-14 extension (2026-05-05).
         """
         missing: list[str] = []
         if not self.internal_secret or not self.internal_secret.strip():
             missing.append("INTERNAL_SECRET")
         if not self.redis_url or not self.redis_url.strip():
             missing.append("REDIS_URL")
+        if not self.portal_internal_secret or not self.portal_internal_secret.strip():
+            missing.append("PORTAL_INTERNAL_SECRET (SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-14)")
         if missing:
             raise ValueError(
                 "Missing required security configuration (SPEC-SEC-010 REQ-5.2): "

--- a/klai-retrieval-api/tests/test_portal_internal_secret_validator.py
+++ b/klai-retrieval-api/tests/test_portal_internal_secret_validator.py
@@ -1,0 +1,80 @@
+"""SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-14 — fail-closed validator for
+retrieval-api ``PORTAL_INTERNAL_SECRET``.
+
+retrieval-api → portal-api outbound trust boundary. The IdentityAsserter
+in retrieval_api.middleware.auth uses this Bearer to call
+/internal/identity/verify on portal-api when an internal-secret request
+includes org_id / user_id in the body (SPEC-SEC-IDENTITY-ASSERT-001).
+
+With an empty/whitespace value, the outbound httpx call would send
+``Authorization: Bearer `` (literal trailing space) — exact
+empty-secret-fail-open pattern from
+.claude/rules/klai/pitfalls/process-rules.md. Pre this REQ-14 extension,
+the failure surfaced at IdentityAsserter construct time (deeper in the
+stack); now it surfaces at Settings() time alongside INTERNAL_SECRET
+and REDIS_URL.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+from pydantic import ValidationError
+
+
+def _purge_config_module() -> None:
+    """Drop cached config module so re-import re-runs the model_validator."""
+    sys.modules.pop("retrieval_api.config", None)
+
+
+def test_valid_portal_internal_secret_accepted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sanity: non-empty value passes."""
+    monkeypatch.setenv("PORTAL_INTERNAL_SECRET", "valid-non-empty-secret")
+    _purge_config_module()
+    config_module = importlib.import_module("retrieval_api.config")
+    assert config_module.settings.portal_internal_secret == "valid-non-empty-secret"
+
+
+@pytest.mark.parametrize("value", ["", "   ", "\t\n "], ids=["empty", "spaces", "whitespace"])
+def test_empty_or_whitespace_portal_internal_secret_refuses_startup(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    """REQ-14: empty / whitespace-only PORTAL_INTERNAL_SECRET raises ValidationError.
+
+    The module-level ``settings = Settings()`` in retrieval_api.config means
+    the failure surfaces at IMPORT TIME — that is the actual production
+    behaviour (container refuses to start).
+    """
+    monkeypatch.setenv("PORTAL_INTERNAL_SECRET", value)
+    _purge_config_module()
+    with pytest.raises(ValidationError) as exc_info:
+        importlib.import_module("retrieval_api.config")
+    msg = str(exc_info.value)
+    assert "PORTAL_INTERNAL_SECRET" in msg
+    assert "SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-14" in msg
+
+
+def test_missing_portal_internal_secret_env_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PORTAL_INTERNAL_SECRET absent triggers the validator: field default is empty string."""
+    monkeypatch.delenv("PORTAL_INTERNAL_SECRET", raising=False)
+    _purge_config_module()
+    with pytest.raises(ValidationError) as exc_info:
+        importlib.import_module("retrieval_api.config")
+    assert "PORTAL_INTERNAL_SECRET" in str(exc_info.value)
+
+
+def test_aggregated_message_lists_all_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When BOTH INTERNAL_SECRET and PORTAL_INTERNAL_SECRET are empty, the
+    aggregated error names both — the operator gets one fix-once message
+    instead of a stuttering chain of single-field failures.
+    """
+    monkeypatch.setenv("INTERNAL_SECRET", "")
+    monkeypatch.setenv("PORTAL_INTERNAL_SECRET", "")
+    _purge_config_module()
+    with pytest.raises(ValidationError) as exc_info:
+        importlib.import_module("retrieval_api.config")
+    msg = str(exc_info.value)
+    assert "INTERNAL_SECRET" in msg
+    assert "PORTAL_INTERNAL_SECRET" in msg


### PR DESCRIPTION
Closes the **empty-secret-fail-open** pitfall on the outbound retrieval-api → portal-api trust boundary.

## What

Validator REQ-14: retrieval-api's IdentityAsserter calls `/internal/identity/verify` on portal-api with this Bearer (SPEC-SEC-IDENTITY-ASSERT-001 REQ-4). Pre this extension, the empty-secret failure surfaced at IdentityAsserter constructor time — deeper in the stack, on the FIRST internal-secret request, not at startup.

The existing `_validate_security_settings` model_validator now also checks `portal_internal_secret` alongside INTERNAL_SECRET and REDIS_URL.

## Pre-flight

PORTAL_INTERNAL_SECRET verified populated in retrieval-api container env on core-01.

## Tests

- 6 new tests in `tests/test_portal_internal_secret_validator.py`
- All pass

## Refs

- .claude/rules/klai/pitfalls/process-rules.md::empty-secret-fail-open