### PR TITLE
fix(litellm-hook): zitadel_user_id on /retrieve (third layer of caller-service chain)

### DIFF
--- a/deploy/litellm/klai_knowledge.py
+++ b/deploy/litellm/klai_knowledge.py
@@ -434,6 +434,7 @@ async def _get_kb_feature(user_id: str, org_id: str, cache) -> dict:
             "kb_slugs_filter": None,
             "kb_narrow": False,
             "version": 0,
+            "zitadel_user_id": None,
         }
 
     # Step 1: check version pointer (short-lived — invalidated by preference changes)
@@ -467,6 +468,7 @@ async def _get_kb_feature(user_id: str, org_id: str, cache) -> dict:
             "kb_slugs_filter": None,
             "kb_narrow": False,
             "version": 0,
+            "zitadel_user_id": None,
         }
 
     version = data.get("kb_pref_version", 0)
@@ -477,6 +479,12 @@ async def _get_kb_feature(user_id: str, org_id: str, cache) -> dict:
         "kb_slugs_filter": data.get("kb_slugs_filter"),
         "kb_narrow": data.get("kb_narrow", False),
         "version": version,
+        # SPEC-SEC-IDENTITY-ASSERT-001 follow-up: portal-api maps the LibreChat
+        # ObjectId we pass in the URL to the portal_users row and exposes the
+        # canonical Zitadel sub here. retrieval-api's identity-verify path,
+        # personal-KB qdrant filter, and the verify-cache key all match on
+        # zitadel_user_id — using the LibreChat ObjectId would 403 every call.
+        "zitadel_user_id": data.get("zitadel_user_id"),
     }
 
     # Store version pointer (30s) and feature data (300s) separately
@@ -767,20 +775,25 @@ class KlaiKnowledgeHook(CustomLogger):
             # Master key usage — no org scope available, skip silently
             return data
 
-        # user_id = LibreChat MongoDB ObjectId sent as the "user" field
-        user_id = data.get("user", "")
-        if not user_id:
+        # librechat_user_id = LibreChat MongoDB ObjectId sent as the "user" field.
+        # We only use this against portal-api endpoints that explicitly accept
+        # the LibreChat ID (kb_feature, templates). Everything that asks
+        # "which Zitadel user is this?" — including retrieval-api's
+        # /retrieve identity-verify path and the personal-KB qdrant filter —
+        # gets the resolved zitadel_user_id from the kb_feature response.
+        librechat_user_id = data.get("user", "")
+        if not librechat_user_id:
             return data
 
         # SPEC-CHAT-TEMPLATES-001 REQ-TEMPLATES-HOOK: fetch active templates
         # before the KB path so they apply on EVERY downstream branch —
         # including early returns when KB retrieval is skipped or fails.
         # Fail-open: empty list on any portal-api error.
-        template_instructions = await _get_templates(org_id, user_id, cache)
+        template_instructions = await _get_templates(org_id, librechat_user_id, cache)
         templates_block = _build_template_instructions_block(template_instructions)
 
         # Feature gate + KB scope preference (version-based cache, 30s propagation)
-        feature = await _get_kb_feature(user_id, org_id, cache)
+        feature = await _get_kb_feature(librechat_user_id, org_id, cache)
         if not feature["enabled"]:
             # No KB entitlement. Templates still apply.
             _prepend_system_prefix(messages, templates_block)
@@ -790,6 +803,42 @@ class KlaiKnowledgeHook(CustomLogger):
         if not feature["kb_retrieval_enabled"]:
             # User disabled KB retrieval. Templates still apply.
             _prepend_system_prefix(messages, templates_block)
+            data["messages"] = messages
+            return data
+
+        # SPEC-SEC-IDENTITY-ASSERT-001 follow-up: retrieval-api forwards
+        # claimed_user_id to portal-api /internal/identity/verify which
+        # matches against PortalUser.zitadel_user_id. Sending the LibreChat
+        # ObjectId here lands on `reason: "no_membership"` and a 403
+        # `identity_assertion_failed` — observed in prod 2026-05-05 once
+        # the missing-X-Caller-Service header bug was fixed.
+        #
+        # From here on we use `user_id` (= Zitadel sub) for everything that
+        # leaves this process: retrieval-api request body, gap-events,
+        # retrieval-log, _klai_kb_meta. Personal-KB qdrant chunks are
+        # stamped with the same Zitadel sub at ingest time
+        # (klai-portal/backend/app/api/knowledge.py:172-204) so the
+        # personal-scope filter matches.
+        user_id: str | None = feature.get("zitadel_user_id")
+        if not user_id:
+            # portal-api couldn't resolve the LibreChat ObjectId → Zitadel sub.
+            # Without it, retrieval-api's identity-verify denies. Surface to
+            # the user via the existing fail-loud path instead of degrading.
+            logger.error(
+                "KlaiKnowledgeHook: portal returned no zitadel_user_id for "
+                "librechat_user_id=%s org_id=%s — failing loud",
+                librechat_user_id,
+                org_id,
+            )
+            kb_unavailable_notice = (
+                "[Klai Kennisbank — TIJDELIJK NIET BEREIKBAAR. Antwoord op basis "
+                "van algemene kennis. Begin je antwoord met deze waarschuwing aan "
+                "de gebruiker: 'Let op: ik kon de kennisbank niet bereiken "
+                "(identity-resolve-failed) — dit antwoord is niet gebaseerd op "
+                "jullie eigen documentatie. Probeer het later opnieuw.']\n"
+            )
+            prefix = "\n\n".join(b for b in (templates_block, kb_unavailable_notice) if b)
+            _prepend_system_prefix(messages, prefix)
             data["messages"] = messages
             return data
 
@@ -856,6 +905,9 @@ class KlaiKnowledgeHook(CustomLogger):
             "query": rewritten_query,
             "raw_query": query,
             "org_id": org_id,
+            # Zitadel sub — matches PortalUser.zitadel_user_id (identity-verify)
+            # AND owner_user_id on personal-KB qdrant chunks
+            # (klai-portal/backend/app/api/knowledge.py:172-204).
             "user_id": user_id,
             "scope": scope,
             "top_k": RETRIEVE_TOP_K,

--- a/deploy/litellm/tests/test_klai_knowledge_hook.py
+++ b/deploy/litellm/tests/test_klai_knowledge_hook.py
@@ -83,6 +83,9 @@ def _make_cache(feature_enabled: bool | None = None, feature: dict | None = None
             "kb_personal_enabled": True,
             "kb_slugs_filter": None,
             "version": 0,
+            # Resolved Zitadel sub — required since 2026-05-05 to make
+            # /retrieve identity-verify and personal-KB scope filter work.
+            "zitadel_user_id": "362901948573220875",
         }
 
         async def _get(key: str) -> object:
@@ -367,6 +370,98 @@ class TestKlaiKnowledgeHookDualAuth:
             assert "Authorization" not in headers
 
 
+# ─── identity mapping tests (2026-05-05 follow-up) ──────────────────────────
+
+
+class TestKlaiKnowledgeHookIdentityMapping:
+    """``/retrieve`` body MUST carry the Zitadel sub, NOT the LibreChat ObjectId.
+
+    SPEC-SEC-IDENTITY-ASSERT-001 made retrieval-api forward
+    ``claimed_user_id`` to portal-api ``/internal/identity/verify`` which
+    matches against ``PortalUser.zitadel_user_id``. Personal-KB qdrant
+    chunks are also stamped with the Zitadel sub at ingest time. Sending
+    the LibreChat ObjectId on either path returns no_membership / 0
+    chunks. The hook resolves the LibreChat ObjectId → Zitadel sub via
+    the kb_feature endpoint response.
+    """
+
+    @pytest.mark.asyncio
+    async def test_retrieve_body_uses_zitadel_user_id_not_librechat_objectid(
+        self, monkeypatch
+    ):
+        mod = _load_hook(monkeypatch)
+        hook = mod.KlaiKnowledgeHook()
+        cache = _make_cache(
+            feature={
+                "enabled": True,
+                "kb_retrieval_enabled": True,
+                "kb_personal_enabled": True,
+                "kb_slugs_filter": None,
+                "kb_narrow": False,
+                "version": 0,
+                "zitadel_user_id": "362901948573220875",
+            }
+        )
+        librechat_objectid = "aabbcc112233445566778899"
+        data = {"user": librechat_objectid, "messages": [
+            {"role": "user", "content": "What are the team policies?"}
+        ]}
+
+        with patch("klai_knowledge.httpx.AsyncClient") as cls:
+            mc = AsyncMock()
+            mc.get = AsyncMock(return_value=_make_resp({"instructions": []}))
+            mc.post = AsyncMock(return_value=_make_resp({"chunks": []}))
+            mc.__aenter__ = AsyncMock(return_value=mc)
+            mc.__aexit__ = AsyncMock(return_value=None)
+            cls.return_value = mc
+
+            await hook.async_pre_call_hook(_make_user_api_key(), cache, data, "completion")
+
+            assert mc.post.call_count == 1
+            body = mc.post.call_args.kwargs["json"]
+            assert body["user_id"] == "362901948573220875", (
+                f"/retrieve user_id should be the Zitadel sub, got {body['user_id']!r}."
+            )
+            assert body["user_id"] != librechat_objectid
+
+    @pytest.mark.asyncio
+    async def test_missing_zitadel_user_id_fails_loud(self, monkeypatch):
+        """portal-api returned None for zitadel_user_id → fail loud, no /retrieve."""
+        mod = _load_hook(monkeypatch)
+        hook = mod.KlaiKnowledgeHook()
+        cache = _make_cache(
+            feature={
+                "enabled": True,
+                "kb_retrieval_enabled": True,
+                "kb_personal_enabled": True,
+                "kb_slugs_filter": None,
+                "kb_narrow": False,
+                "version": 0,
+                "zitadel_user_id": None,
+            }
+        )
+        data = {"user": "aabbcc112233445566778899", "messages": [
+            {"role": "user", "content": "What are the team policies?"}
+        ]}
+
+        with patch("klai_knowledge.httpx.AsyncClient") as cls:
+            mc = AsyncMock()
+            mc.get = AsyncMock(return_value=_make_resp({"instructions": []}))
+            mc.post = AsyncMock(return_value=_make_resp({"chunks": []}))
+            mc.__aenter__ = AsyncMock(return_value=mc)
+            mc.__aexit__ = AsyncMock(return_value=None)
+            cls.return_value = mc
+
+            await hook.async_pre_call_hook(_make_user_api_key(), cache, data, "completion")
+
+            assert mc.post.call_count == 0
+            system_msg = next(
+                (m for m in data["messages"] if m["role"] == "system"), None
+            )
+            assert system_msg is not None
+            assert "TIJDELIJK NIET BEREIKBAAR" in system_msg["content"]
+
+
 # ─── kb_slugs_filter tri-state tests (2026-05-05 follow-up) ─────────────────
 
 
@@ -397,6 +492,7 @@ class TestKlaiKnowledgeHookSlugsTriState:
                 "kb_slugs_filter": [],
                 "kb_narrow": False,
                 "version": 0,
+                "zitadel_user_id": "362901948573220875",
             }
         )
         data = {"user": "u1" * 12, "messages": [
@@ -433,6 +529,7 @@ class TestKlaiKnowledgeHookSlugsTriState:
                 "kb_slugs_filter": [],
                 "kb_narrow": False,
                 "version": 0,
+                "zitadel_user_id": "362901948573220875",
             }
         )
         data = {"user": "u1" * 12, "messages": [
@@ -471,6 +568,7 @@ class TestKlaiKnowledgeHookSlugsTriState:
                 "kb_slugs_filter": None,
                 "kb_narrow": False,
                 "version": 0,
+                "zitadel_user_id": "362901948573220875",
             }
         )
         data = {"user": "u1" * 12, "messages": [

--- a/klai-portal/backend/app/api/internal.py
+++ b/klai-portal/backend/app/api/internal.py
@@ -600,6 +600,14 @@ class KnowledgeFeatureResponse(BaseModel):
     kb_slugs_filter: list[str] | None = None
     kb_narrow: bool = False
     kb_pref_version: int = 0
+    # SPEC-SEC-IDENTITY-ASSERT-001 follow-up: retrieval-api's identity-verify
+    # check matches against `PortalUser.zitadel_user_id`. The LiteLLM hook only
+    # has the LibreChat MongoDB ObjectId at hand. Returning the resolved
+    # zitadel_user_id here lets the hook send the right identifier on the
+    # /retrieve call, and matches what knowledge-ingest stamps on personal-KB
+    # qdrant chunks (klai-portal/backend/app/api/knowledge.py:172-204), so
+    # the personal-scope filter also works.
+    zitadel_user_id: str | None = None
 
 
 @router.get("/v1/users/{librechat_user_id}/feature/knowledge", response_model=KnowledgeFeatureResponse)
@@ -710,6 +718,7 @@ async def get_knowledge_feature(
         kb_slugs_filter=user.kb_slugs_filter,
         kb_narrow=user.kb_narrow,
         kb_pref_version=user.kb_pref_version,
+        zitadel_user_id=user.zitadel_user_id,
     )
 
 


### PR DESCRIPTION
Third bug in the chain that started with the 2026-04-28 silent degradation. Reproduced live in prod via Mark's chat — every retrieve still comes back 403 identity_assertion_failed, reason no_membership.

## Root cause

SPEC-SEC-IDENTITY-ASSERT-001 made retrieval-api forward claimed_user_id to portal-api /internal/identity/verify, which matches against PortalUser.zitadel_user_id. The LiteLLM hook was sending data['user'] — the **LibreChat MongoDB ObjectId** — straight through. Will never match a Zitadel sub.

Personal-KB qdrant chunks are also stamped with the Zitadel sub at ingest time (klai-portal/backend/app/api/knowledge.py:172-204). Personal scope only works when the hook sends the Zitadel sub.

## Fix

portal-api's kb_feature endpoint already does the LibreChat ObjectId → Zitadel sub mapping internally (lazy MongoDB lookup → cached on PortalUser.librechat_user_id). It just didn't expose the result.

- KnowledgeFeatureResponse.zitadel_user_id field added, populated from user.zitadel_user_id.
- Hook caches it; uses it for the /retrieve body, gap-events, retrieval-log, and _klai_kb_meta.
- If portal-api can't resolve (None returned) → fail loud (visible system-prompt notice + log error). Never silently degrade.

## Test plan

- [x] 11/11 hook unit tests pass locally (2 new + 9 existing)
- [x] ruff + ruff format clean
- [ ] CI green
- [ ] Live verification on Voys: ask a Voys-Support-specific question after deploy → response contains real KB chunks with 📎 source links

🤖 Generated with [Claude Code](https://claude.com/claude-code)