### PR TITLE
fix(deprovision): SPEC-INFRA-TENANT-DELETE-002 G1+G4 — close 2 GDPR purge gaps

### DIFF
--- a/klai-portal/backend/app/services/provisioning/deprovisioning_steps.py
+++ b/klai-portal/backend/app/services/provisioning/deprovisioning_steps.py
@@ -244,16 +244,26 @@ async def _delete_qdrant_points(state: _DeprovisionState) -> None:
         api_key=settings.qdrant_api_key or None,
         timeout=30,
     )
-    collections = ["klai_knowledge", "klai_focus"]
+    # SPEC-INFRA-TENANT-DELETE-002 G4 — the two collections store the tenant
+    # ID under DIFFERENT payload keys. klai_knowledge uses ``org_id`` (set by
+    # knowledge-ingest's writer), klai_focus uses ``tenant_id`` (set by the
+    # legacy research-api / focus pipeline). Iterating with a single hardcoded
+    # key would silently skip every klai_focus point of the deprovisioned
+    # tenant — a HIGH-severity GDPR purge gap. Tuple-pair the collection with
+    # its payload key so adding a future collection forces an explicit choice.
+    collections: list[tuple[str, str]] = [
+        ("klai_knowledge", "org_id"),
+        ("klai_focus", "tenant_id"),
+    ]
     try:
-        for collection in collections:
+        for collection, filter_key in collections:
             try:
                 await client.delete(
                     collection_name=collection,
                     points_selector=Filter(
                         must=[
                             FieldCondition(
-                                key="org_id",
+                                key=filter_key,
                                 match=MatchValue(value=state.org_id),
                             )
                         ]
@@ -264,6 +274,7 @@ async def _delete_qdrant_points(state: _DeprovisionState) -> None:
                     slug=state.slug,
                     org_id=state.org_id,
                     collection=collection,
+                    filter_key=filter_key,
                 )
             except Exception as exc:
                 # Collection might not exist (404-like) — treat as idempotent
@@ -588,6 +599,14 @@ async def _finalize_postgres_delete(state: _DeprovisionState) -> None:
     await db.execute(text("DELETE FROM portal_templates WHERE org_id = :id"), {"id": state.org_id})
     # portal_users — last of the non-cascading children that other tables may FK to.
     await db.execute(text("DELETE FROM portal_users WHERE org_id = :id"), {"id": state.org_id})
+    # SPEC-INFRA-TENANT-DELETE-002 G1 — portal_join_requests carries org_id
+    # (no ondelete=CASCADE on the FK) and was previously left as orphaned PII
+    # after the parent org was hard-deleted. Add an explicit DELETE here to
+    # close the GDPR-purge gap. Idempotent: zero rows for a tenant with no
+    # in-flight join requests is a no-op. SPEC-AUTH-009 R2 will eventually
+    # drop portal_org_allowed_domains entirely (G2 is therefore moot post-AUTH-009),
+    # so we do NOT add it to this list — the table is on the deletion path.
+    await db.execute(text("DELETE FROM portal_join_requests WHERE org_id = :id"), {"id": state.org_id})
 
     # 3. Hard-delete the org row — cascades the auto-CASCADE tables (connectors,
     #    widgets, feedback_events, retrieval_gaps, partner_api_keys) and SET NULLs

--- a/klai-portal/backend/app/services/provisioning/deprovisioning_steps.py
+++ b/klai-portal/backend/app/services/provisioning/deprovisioning_steps.py
@@ -599,13 +599,17 @@ async def _finalize_postgres_delete(state: _DeprovisionState) -> None:
     await db.execute(text("DELETE FROM portal_templates WHERE org_id = :id"), {"id": state.org_id})
     # portal_users — last of the non-cascading children that other tables may FK to.
     await db.execute(text("DELETE FROM portal_users WHERE org_id = :id"), {"id": state.org_id})
-    # SPEC-INFRA-TENANT-DELETE-002 G1 — portal_join_requests carries org_id
-    # (no ondelete=CASCADE on the FK) and was previously left as orphaned PII
-    # after the parent org was hard-deleted. Add an explicit DELETE here to
-    # close the GDPR-purge gap. Idempotent: zero rows for a tenant with no
-    # in-flight join requests is a no-op. SPEC-AUTH-009 R2 will eventually
-    # drop portal_org_allowed_domains entirely (G2 is therefore moot post-AUTH-009),
-    # so we do NOT add it to this list — the table is on the deletion path.
+    # SPEC-INFRA-TENANT-DELETE-002 G1 — portal_join_requests has a single FK
+    # `portal_join_requests_org_id_fkey FOREIGN KEY (org_id) REFERENCES
+    # portal_orgs(id) ON DELETE SET NULL` (verified 2026-05-05 against prod).
+    # WITHOUT this explicit DELETE, the portal_orgs DELETE below would simply
+    # NULL the org_id on every join_request row — leaving the email/name PII
+    # in place as orphaned data. With this DELETE, the rows are gone before
+    # the parent. Ordering is independent of portal_users (no FK between them
+    # — verified). Idempotent: zero rows for a tenant with no in-flight join
+    # requests is a no-op. SPEC-AUTH-009 R2 will drop portal_org_allowed_domains
+    # entirely, so G2 is moot post-AUTH-009 and that table is intentionally
+    # NOT in this list.
     await db.execute(text("DELETE FROM portal_join_requests WHERE org_id = :id"), {"id": state.org_id})
 
     # 3. Hard-delete the org row — cascades the auto-CASCADE tables (connectors,

--- a/klai-portal/backend/tests/test_deprovisioning_steps.py
+++ b/klai-portal/backend/tests/test_deprovisioning_steps.py
@@ -396,6 +396,47 @@ class TestDeleteQdrantPoints:
         assert "klai_focus" in call_args
 
     @pytest.mark.asyncio
+    async def test_filter_key_differs_per_collection(self) -> None:
+        """SPEC-INFRA-TENANT-DELETE-002 G4 regression-guard.
+
+        klai_knowledge stores the tenant ID under payload field ``org_id``;
+        klai_focus stores it under ``tenant_id``. Pre-fix the step iterated
+        with a hardcoded ``org_id`` key, silently leaving every klai_focus
+        point of the deprovisioned tenant untouched — a HIGH-severity GDPR
+        purge gap. This test asserts BOTH collections are deleted with the
+        correct payload key, so a future refactor that re-unifies the keys
+        without verifying the schemas is caught at CI.
+        """
+        state = _make_state(org_id=99, slug="testorg")
+        mock_client = AsyncMock()
+        mock_client.close = AsyncMock()
+
+        with (
+            patch("app.services.provisioning.deprovisioning_steps.settings") as mock_settings,
+            patch("qdrant_client.AsyncQdrantClient", return_value=mock_client),
+        ):
+            mock_settings.qdrant_url = "http://qdrant:6333"
+            mock_settings.qdrant_api_key = ""
+            from app.services.provisioning.deprovisioning_steps import _delete_qdrant_points
+
+            await _delete_qdrant_points(state)
+
+        # Reconstruct (collection, filter_key) tuples from the mock calls.
+        # The Filter is positional/kwargs as `points_selector=...`. Walk the
+        # FieldCondition.key inside.
+        seen: list[tuple[str, str]] = []
+        for call in mock_client.delete.await_args_list:
+            collection = call.kwargs.get("collection_name") or call.args[0]
+            filt = call.kwargs.get("points_selector")
+            assert filt is not None, "delete() must pass points_selector kwarg"
+            # filt.must is a list of FieldCondition; pick the first key.
+            key = filt.must[0].key
+            seen.append((collection, key))
+
+        assert ("klai_knowledge", "org_id") in seen, f"Expected ('klai_knowledge', 'org_id'), got {seen}"
+        assert ("klai_focus", "tenant_id") in seen, f"Expected ('klai_focus', 'tenant_id'), got {seen}"
+
+    @pytest.mark.asyncio
     async def test_collection_not_found_is_idempotent(self) -> None:
         """404-like exception from Qdrant must not propagate."""
         state = _make_state(org_id=42, slug="acme")
@@ -753,15 +794,20 @@ class TestFinalizePostgresDelete:
 
     @pytest.mark.asyncio
     async def test_execute_called_for_each_non_cascading_child_table(self) -> None:
-        """db.execute called exactly 8 times: 7 explicit child DELETEs + 1 portal_orgs DELETE.
+        """db.execute called exactly 9 times: 8 explicit child DELETEs + 1 portal_orgs DELETE.
 
         Order MUST be: portal_knowledge_bases, portal_kb_tombstones, vexa_meetings,
-        portal_groups, portal_products, portal_templates, portal_users, portal_orgs.
+        portal_groups, portal_products, portal_templates, portal_users,
+        portal_join_requests, portal_orgs.
 
         This list is the source of truth for the FK audit. If a new non-cascading
         FK is added to portal_orgs, this test must be updated AND the step's
         DELETE list extended — otherwise the production deprovision will fail
         on FK violation.
+
+        SPEC-INFRA-TENANT-DELETE-002 G1 added portal_join_requests after
+        portal_users (ordering matters: portal_users may be referenced by
+        join requests via inviting_user_id).
         """
         state = _make_state(org_id=42, slug="acme")
 
@@ -777,7 +823,7 @@ class TestFinalizePostgresDelete:
 
             await _finalize_postgres_delete(state)
 
-        assert state.db.execute.await_count == 8
+        assert state.db.execute.await_count == 9
 
         # Verify the table-name + order of every executed DELETE.
         expected_tables_in_order = [
@@ -788,6 +834,7 @@ class TestFinalizePostgresDelete:
             "portal_products",
             "portal_templates",
             "portal_users",
+            "portal_join_requests",
             "portal_orgs",
         ]
         actual_tables = []

--- a/klai-portal/backend/tests/test_deprovisioning_steps.py
+++ b/klai-portal/backend/tests/test_deprovisioning_steps.py
@@ -805,9 +805,13 @@ class TestFinalizePostgresDelete:
         DELETE list extended — otherwise the production deprovision will fail
         on FK violation.
 
-        SPEC-INFRA-TENANT-DELETE-002 G1 added portal_join_requests after
-        portal_users (ordering matters: portal_users may be referenced by
-        join requests via inviting_user_id).
+        SPEC-INFRA-TENANT-DELETE-002 G1 added portal_join_requests just
+        before portal_orgs. Ordering relative to portal_users is independent
+        — verified 2026-05-05: portal_join_requests has exactly ONE FK,
+        `org_id → portal_orgs(id) ON DELETE SET NULL`, and no FK to
+        portal_users. The DELETE must run BEFORE portal_orgs (otherwise
+        SET NULL leaves orphaned PII rows); placement after portal_users
+        is a docstring-readability choice, not a correctness requirement.
         """
         state = _make_state(org_id=42, slug="acme")
 


### PR DESCRIPTION
## Summary

Closes 2 of the 7 GDPR purge gaps identified in audit Cluster F. Both are HIGH-severity and code-only — no schema migrations, no new env-vars.

### G1 — portal_join_requests not purged on tenant delete

Add explicit `DELETE FROM portal_join_requests WHERE org_id = :id` to step 16 (`_finalize_postgres_delete`). The table carries `org_id` (no ondelete=CASCADE on the FK), so deprovisioned tenants left orphaned PII rows. Idempotent.

(G2 — portal_org_allowed_domains — intentionally NOT added: SPEC-AUTH-009 R2 drops the table entirely via post_deploy_ed5b78b296f5.sql. Adding it now would be DDL on the deletion path. The G2 finding is moot post-AUTH-009.)

### G4 — Qdrant filter-key bug per collection

`_delete_qdrant_points` iterated klai_knowledge AND klai_focus with a single hardcoded `org_id` filter, silently leaving every klai_focus point of the deprovisioned tenant: that collection was written by the legacy research-api/focus pipeline using payload field `tenant_id`, not `org_id`. Cross-collection drift never re-converged.

Fix: tuple-pair each collection with its payload key:
`[("klai_knowledge", "org_id"), ("klai_focus", "tenant_id")]`

## Tests

- New `test_filter_key_differs_per_collection` reconstructs (collection, key) tuples from the AsyncMock and asserts both pairs invoked. Regression-guard against future re-unification without schema verification.
- Updated DELETE-list test count 8 → 9 with portal_join_requests at the right ordering position (after portal_users, before portal_orgs).
- 5/5 in the touched test classes pass; ruff + format clean.

## Out of scope (separate PRs in the same SPEC)

- G3 knowledge-ingest `wipe-postgres` endpoint
- G5 scribe schema migration + transcriptions wipe
- G6 klai-connector `wipe-state` endpoint
- G7 research-api `wipe-research` (likely moot — dead service)

## Refs

- reports/audit-2026-05-04/multi-tenancy-gdpr.md
- SPEC-INFRA-TENANT-DELETE-001 (parent 17-step orchestrator)
- SPEC-AUTH-009 R2 (G2 deletion path)