### PR TITLE
fix(ci): gate scribe-api/knowledge-ingest/portal-api deploy + :latest tag

### DIFF
--- a/.github/workflows/knowledge-ingest.yml
+++ b/.github/workflows/knowledge-ingest.yml
@@ -73,13 +73,20 @@ jobs:
           context: .
           file: klai-knowledge-ingest/Dockerfile
           push: true
+          # `:latest` is published ONLY on push to main. PR builds publish
+          # only the SHA tag so `docker pull :latest` cannot accidentally
+          # pull PR-build code. Mirrors klai-connector / klai-mailer.
           tags: |
-            ghcr.io/getklai/knowledge-ingest:latest
             ghcr.io/getklai/knowledge-ingest:${{ github.sha }}
+            ${{ github.event_name == 'push' && 'ghcr.io/getklai/knowledge-ingest:latest' || '' }}
           # GHA layer cache disabled: it failed to invalidate on source code changes.
           # Builds are fast enough (~1 min) without caching.
 
+      # 2026-05-05 mailer-incident class: this step previously had no `if:`
+      # gate, so PR builds also auto-deployed `:latest` to prod. Same
+      # pattern that bit klai-mailer post PR #319 → hotfix #322.
       - name: Deploy to core-01
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.CORE01_HOST }}

--- a/.github/workflows/portal-api.yml
+++ b/.github/workflows/portal-api.yml
@@ -275,9 +275,12 @@ jobs:
           context: .
           file: klai-portal/backend/Dockerfile
           push: true
+          # `:latest` is published ONLY on push to main. PR builds publish
+          # only the SHA tag so `docker pull :latest` cannot accidentally
+          # pull PR-build code. Mirrors klai-connector / klai-mailer.
           tags: |
-            ghcr.io/getklai/portal-api:latest
             ghcr.io/getklai/portal-api:${{ github.sha }}
+            ${{ github.event_name == 'push' && 'ghcr.io/getklai/portal-api:latest' || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -352,7 +355,11 @@ jobs:
             fi
             echo "Pre-flight OK — all critical vars present."
 
+      # 2026-05-05 mailer-incident class: this step previously had no `if:`
+      # gate, so PR builds also auto-deployed `:latest` to prod. Same
+      # pattern that bit klai-mailer post PR #319 → hotfix #322.
       - name: Deploy to core-01
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.CORE01_HOST }}

--- a/.github/workflows/portal-api.yml
+++ b/.github/workflows/portal-api.yml
@@ -330,7 +330,13 @@ jobs:
     needs: [build-push]
     runs-on: ubuntu-latest
     steps:
+      # Audit 2026-05-05: defence-in-depth gate. The deploy job is gated
+      # via `needs: build-push` (build-push is itself gated), but the
+      # Pre-deploy env check step has no `if:` — if a future change
+      # loosens the build-push gate, this step would SSH into prod from
+      # PR context. Match the Deploy step's gate explicitly.
       - name: Pre-deploy env check
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.CORE01_HOST }}

--- a/.github/workflows/scribe-api.yml
+++ b/.github/workflows/scribe-api.yml
@@ -67,13 +67,23 @@ jobs:
           context: .
           file: klai-scribe/scribe-api/Dockerfile
           push: true
+          # `:latest` is published ONLY on push to main. PR builds publish
+          # only the SHA tag so `docker pull :latest` cannot accidentally
+          # pull PR-build code. Mirrors klai-connector / klai-mailer
+          # (post hotfix #322).
           tags: |
-            ghcr.io/getklai/scribe-api:latest
             ghcr.io/getklai/scribe-api:${{ github.sha }}
+            ${{ github.event_name == 'push' && 'ghcr.io/getklai/scribe-api:latest' || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # 2026-05-05 mailer-incident class: this step previously had no `if:`
+      # gate, so PR builds also auto-deployed `:latest` to prod. The first
+      # PR build that produced a recreate after a long quiet period could
+      # surface a hidden validator-env-parity regression as a 30+ minute
+      # outage. Same pattern that bit klai-mailer post PR #319 → hotfix #322.
       - name: Deploy to core-01
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.CORE01_HOST }}


### PR DESCRIPTION
## Summary

Companion to klai-mailer hotfix #322. Closes the same workflow-flaw class on the three remaining service workflows that still had it.

The 2026-05-05 mailer incident's root cause was unconditional deploy + unconditional `:latest` tag on PR builds, combined with a hidden validator-env-parity regression. Three more services have the same setup:

| service | deploy gated? | :latest gated? |
|---------|---------------|----------------|
| klai-connector | yes | yes |
| klai-mailer (post #322) | yes | yes |
| retrieval-api | yes | n/a |
| klai-knowledge-mcp | yes | n/a |
| **scribe-api** | NO | NO | ← fix |
| **knowledge-ingest** | NO | NO | ← fix |
| **portal-api** | NO | NO | ← fix |

## Changes

For each of scribe-api.yml, knowledge-ingest.yml, portal-api.yml:

- Build step: `:latest` tag conditional on `github.event_name == 'push' && github.ref == 'refs/heads/main'`. PR builds publish only the SHA tag so `docker pull :latest` cannot fetch PR-build code.
- Deploy step: same conditional. PR builds no longer ssh into core-01 to swap containers.

Mirrors the klai-connector / klai-mailer (post #322) shape exactly.

## Why one PR for three workflows (not three PRs)

Cleanup principle: a single PR makes the pattern visible to reviewers and to anyone auditing gate state in the future. Mailer's gate was hotfix-#322 because it was incident-response under time pressure; this is the principled cleanup that prevents the next mailer-class incident from any of the other three services.

## Verified

- All 3 yaml files validate cleanly via `yaml.safe_load`
- `if:` syntax matches klai-connector.yml lines 116 and 104
- No other yaml drift

## Refs

- 2026-05-05 mailer incident: klai-infra PR #4 + klai PR #322
- Pitfall: `validator-env-parity` (HIGH) — root cause class
- Pitfall: `env-file-migration-reverse-check` (HIGH) — companion class