### PR TITLE
feat(ingest): SPEC-INFRA-TENANT-DELETE-002 G3 — wipe-postgres endpoint

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/routes/internal.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/internal.py
@@ -67,15 +67,25 @@ class WipePostgresResponse(BaseModel):
 #   - embedding_queue    -> no FK to artifacts, no org_id; shared infra table
 #   - rag_eval_results   -> eval/analytics table, no tenant ownership column
 # ---------------------------------------------------------------------------
-_LEAF_TABLES: list[str] = [
-    "page_links",
-    "crawled_pages",
-    "crawl_jobs",
-    "crawl_domains",
-    "kb_config",
-    "org_config",
-    "entities",
-]
+# Pre-formed DELETE statements indexed by table-name. Avoiding an f-string
+# inside the wipe loop keeps three semgrep "asyncpg-sqli" / "raw-query"
+# findings green — the table identifier is hardcoded once, never built from
+# user input. The mapping is the single source of truth: any future column-
+# scoping change can update the SQL here without touching call sites.
+_LEAF_TABLE_DELETES: tuple[tuple[str, str], ...] = (
+    ("page_links", "DELETE FROM knowledge.page_links WHERE org_id = $1"),
+    ("crawled_pages", "DELETE FROM knowledge.crawled_pages WHERE org_id = $1"),
+    ("crawl_jobs", "DELETE FROM knowledge.crawl_jobs WHERE org_id = $1"),
+    ("crawl_domains", "DELETE FROM knowledge.crawl_domains WHERE org_id = $1"),
+    ("kb_config", "DELETE FROM knowledge.kb_config WHERE org_id = $1"),
+    ("org_config", "DELETE FROM knowledge.org_config WHERE org_id = $1"),
+    ("entities", "DELETE FROM knowledge.entities WHERE org_id = $1"),
+)
+
+# Backwards-compat alias: the schema-regression-guard test imports
+# ``_LEAF_TABLES`` to cross-check against ``information_schema.tables``.
+# Derived from the canonical mapping so the two cannot drift.
+_LEAF_TABLES: list[str] = [t for t, _ in _LEAF_TABLE_DELETES]
 
 
 async def _wipe_org_postgres(org_id: str) -> dict[str, int]:
@@ -92,11 +102,8 @@ async def _wipe_org_postgres(org_id: str) -> dict[str, int]:
                 org_id,
             )
 
-            for table in _LEAF_TABLES:
-                result = await conn.execute(
-                    f"DELETE FROM knowledge.{table} WHERE org_id = $1",  # noqa: S608
-                    org_id,
-                )
+            for table, query in _LEAF_TABLE_DELETES:
+                result = await conn.execute(query, org_id)
                 # asyncpg returns "DELETE N" as a string
                 count = int(result.split()[-1])
                 rows_deleted[table] = count

--- a/klai-knowledge-ingest/knowledge_ingest/routes/internal.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/internal.py
@@ -140,8 +140,11 @@ async def wipe_org_graph(org_id: str) -> WipeGraphResponse:
 async def wipe_org_postgres(org_id: str) -> WipePostgresResponse:
     """Hard-delete every row carrying *org_id* from all knowledge.* tables.
 
-    Called by the tenant-deprovisioning orchestrator as step 13a
-    (SPEC-INFRA-TENANT-DELETE-002 G3). Idempotent: successive calls return
+    Called by the tenant-deprovisioning orchestrator as step 9a (SPEC
+    sequencing was originally "13a" per the SPEC scope-section enumeration,
+    but the actual orchestrator implementation places this immediately after
+    the FalkorDB wipe at step 9, making the ordering 9a / 9b for G3 / G6
+    respectively). Idempotent: successive calls return
     ``rows_deleted[table] = 0`` for all tables after the first successful wipe.
 
     Tables wiped (in FK-safe order):

--- a/klai-knowledge-ingest/knowledge_ingest/routes/internal.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/internal.py
@@ -1,5 +1,5 @@
 """
-Internal deprovisioning routes — service-to-service only.
+Internal deprovisioning routes -- service-to-service only.
 
 All routes in this module are protected by the app-level
 ``InternalSecretMiddleware`` (checks ``X-Internal-Secret`` on every
@@ -7,11 +7,20 @@ request). No per-route auth guard is needed.
 
 Routes:
   POST /internal/v1/orgs/{org_id}/wipe-graph
-    — DETACH DELETE all FalkorDB nodes for the given org (tenant
+    -- DETACH DELETE all FalkorDB nodes for the given org (tenant
       deprovisioning). Idempotent: returns 0 when graph is already empty
       or Graphiti is disabled.
 
+  POST /internal/v1/orgs/{org_id}/wipe-postgres
+    -- Hard-delete all rows carrying org_id from every knowledge.* table.
+      Idempotent. Tables without an org_id column are intentionally NOT
+      wiped here (artifact_entities, artifact_images, derivations,
+      embedding_queue, rag_eval_results -- they are either cascade-deleted
+      as children of artifacts/entities, or are shared lookup / eval tables
+      with no tenant ownership column).
+
 SPEC-INFRA-TENANT-DELETE-001 Phase 7.
+SPEC-INFRA-TENANT-DELETE-002 G3.
 """
 
 from __future__ import annotations
@@ -23,6 +32,7 @@ from fastapi import APIRouter
 from pydantic import BaseModel
 
 from knowledge_ingest import graph as graph_module
+from knowledge_ingest.db import get_pool
 
 logger = structlog.get_logger()
 router = APIRouter()
@@ -31,6 +41,75 @@ router = APIRouter()
 class WipeGraphResponse(BaseModel):
     nodes_deleted: int
     status: str
+
+
+class WipePostgresResponse(BaseModel):
+    rows_deleted: dict[str, int]
+    status: str
+
+
+# ---------------------------------------------------------------------------
+# Tables that carry org_id in the knowledge schema, in FK-safe DELETE order.
+#
+# Leaf tables (no other knowledge.* table references them) are listed first.
+# ``entities`` is listed before ``artifacts`` because artifact_entities has
+# CASCADE on both artifact_id AND entity_id; deleting entities first removes
+# the artifact_entities rows that would otherwise block the entities DELETE.
+# ``artifacts`` is listed last: it has a self-referencing FK
+# (superseded_by -> artifacts.id, NO ACTION) so we null that column for the
+# org before deleting. Its child tables (artifact_entities, artifact_images,
+# derivations) are all CASCADE-deleted automatically.
+#
+# Tables intentionally excluded (no org_id column):
+#   - artifact_entities  -> CASCADE child of artifacts + entities
+#   - artifact_images    -> CASCADE child of artifacts
+#   - derivations        -> CASCADE child of artifacts
+#   - embedding_queue    -> no FK to artifacts, no org_id; shared infra table
+#   - rag_eval_results   -> eval/analytics table, no tenant ownership column
+# ---------------------------------------------------------------------------
+_LEAF_TABLES: list[str] = [
+    "page_links",
+    "crawled_pages",
+    "crawl_jobs",
+    "crawl_domains",
+    "kb_config",
+    "org_config",
+    "entities",
+]
+
+
+async def _wipe_org_postgres(org_id: str) -> dict[str, int]:
+    """Execute all DELETEs in a single transaction; return per-table row counts."""
+    pool = await get_pool()
+    rows_deleted: dict[str, int] = {}
+
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            # Null out the self-referencing superseded_by FK in artifacts so
+            # the subsequent DELETE is not blocked by NO ACTION constraint.
+            await conn.execute(
+                "UPDATE knowledge.artifacts SET superseded_by = NULL WHERE org_id = $1",
+                org_id,
+            )
+
+            for table in _LEAF_TABLES:
+                result = await conn.execute(
+                    f"DELETE FROM knowledge.{table} WHERE org_id = $1",  # noqa: S608
+                    org_id,
+                )
+                # asyncpg returns "DELETE N" as a string
+                count = int(result.split()[-1])
+                rows_deleted[table] = count
+
+            # Delete artifacts last; CASCADE removes artifact_entities,
+            # artifact_images, and derivations rows automatically.
+            result = await conn.execute(
+                "DELETE FROM knowledge.artifacts WHERE org_id = $1",
+                org_id,
+            )
+            rows_deleted["artifacts"] = int(result.split()[-1])
+
+    return rows_deleted
 
 
 @router.post(
@@ -46,8 +125,48 @@ async def wipe_org_graph(org_id: str) -> WipeGraphResponse:
     first successful wipe.
 
     Authentication: ``X-Internal-Secret`` header, enforced by
-    ``InternalSecretMiddleware`` at the app layer — no inline check here.
+    ``InternalSecretMiddleware`` at the app layer -- no inline check here.
     """
     logger.info("wipe_org_graph_requested", org_id=org_id)
     nodes_deleted = await asyncio.to_thread(graph_module.wipe_org_graph, org_id)
     return WipeGraphResponse(nodes_deleted=nodes_deleted, status="ok")
+
+
+@router.post(
+    "/internal/v1/orgs/{org_id}/wipe-postgres",
+    response_model=WipePostgresResponse,
+    summary="Wipe all knowledge.* Postgres rows for an org (deprovisioning)",
+)
+async def wipe_org_postgres(org_id: str) -> WipePostgresResponse:
+    """Hard-delete every row carrying *org_id* from all knowledge.* tables.
+
+    Called by the tenant-deprovisioning orchestrator as step 13a
+    (SPEC-INFRA-TENANT-DELETE-002 G3). Idempotent: successive calls return
+    ``rows_deleted[table] = 0`` for all tables after the first successful wipe.
+
+    Tables wiped (in FK-safe order):
+      knowledge.page_links, knowledge.crawled_pages, knowledge.crawl_jobs,
+      knowledge.crawl_domains, knowledge.kb_config, knowledge.org_config,
+      knowledge.entities (CASCADE removes artifact_entities rows),
+      knowledge.artifacts (CASCADE removes artifact_entities, artifact_images,
+      and derivations rows).
+
+    Tables intentionally excluded (no org_id column):
+      artifact_entities, artifact_images, derivations -- cascade-deleted as
+      children of artifacts or entities.
+      embedding_queue, rag_eval_results -- shared infra / eval tables with no
+      tenant ownership column; their lifecycle is not org-scoped.
+
+    Authentication: ``X-Internal-Secret`` header, enforced by
+    ``InternalSecretMiddleware`` at the app layer -- no inline check here.
+    """
+    logger.info("wipe_org_postgres_requested", org_id=org_id)
+    rows_deleted = await _wipe_org_postgres(org_id)
+    total = sum(rows_deleted.values())
+    logger.info(
+        "wipe_org_postgres_completed",
+        org_id=org_id,
+        total_rows_deleted=total,
+        per_table=rows_deleted,
+    )
+    return WipePostgresResponse(rows_deleted=rows_deleted, status="ok")

--- a/klai-knowledge-ingest/tests/test_wipe_postgres_endpoint.py
+++ b/klai-knowledge-ingest/tests/test_wipe_postgres_endpoint.py
@@ -1,0 +1,311 @@
+"""Tests for SPEC-INFRA-TENANT-DELETE-002 G3.
+
+POST /internal/v1/orgs/{org_id}/wipe-postgres
+
+Covers:
+  Test 1: 200 with per-table row counts summing to seeded count for tenant-a.
+  Test 2: Cross-tenant isolation -- tenant-b rows survive after tenant-a wipe.
+  Test 3: Idempotency -- second call returns all zeros.
+  Test 4: Wrong/missing X-Internal-Secret returns 401.
+  Test 5: Schema regression guard -- asserts every knowledge.* table
+          that has an org_id column is present in the route's _LEAF_TABLES.
+          Fails CI if a new table is added without updating the wipe list.
+
+Tests 1-3 use a mocked asyncpg pool (no live DB required).
+Test 5 uses information_schema introspection; skipped when POSTGRES_DSN is not set.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from knowledge_ingest.routes.internal import _LEAF_TABLES
+
+_ORG_A = "tenant-wipe-pg-a"
+_ORG_B = "tenant-wipe-pg-b"
+_SECRET = os.environ.get("KNOWLEDGE_INGEST_SECRET", "test-secret-value-123")
+_ENDPOINT_A = f"/internal/v1/orgs/{_ORG_A}/wipe-postgres"
+_ENDPOINT_B = f"/internal/v1/orgs/{_ORG_B}/wipe-postgres"
+
+# All tables the route is expected to wipe (leaf tables + artifacts).
+_EXPECTED_WIPE_TABLES = set(_LEAF_TABLES) | {"artifacts"}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_conn_mock(per_table_counts: dict) -> MagicMock:
+    """Return a mock asyncpg connection whose execute() simulates row counts."""
+    conn = MagicMock()
+
+    async def _execute(query: str, *args, **kwargs) -> str:
+        if "superseded_by" in query:
+            return "UPDATE 0"
+        parts = query.split()
+        table_full = parts[2] if len(parts) > 2 else ""
+        table = table_full.split(".")[-1] if "." in table_full else table_full
+        count = per_table_counts.get(table, 0)
+        return f"DELETE {count}"
+
+    conn.execute = _execute
+    tx = MagicMock()
+    tx.__aenter__ = AsyncMock(return_value=None)
+    tx.__aexit__ = AsyncMock(return_value=False)
+    conn.transaction = MagicMock(return_value=tx)
+    return conn
+
+
+def _make_pool_mock(conn_mock: MagicMock) -> MagicMock:
+    """Return a mock asyncpg pool that yields conn_mock via acquire()."""
+    pool = MagicMock()
+    acquire_ctx = MagicMock()
+    acquire_ctx.__aenter__ = AsyncMock(return_value=conn_mock)
+    acquire_ctx.__aexit__ = AsyncMock(return_value=False)
+    pool.acquire = MagicMock(return_value=acquire_ctx)
+    pool.close = AsyncMock(return_value=None)
+    return pool
+
+
+@pytest.fixture
+def wipe_pg_client():
+    """TestClient with the full app, DB and Qdrant mocked out."""
+    mock_pool_outer = MagicMock()
+    mock_pool_outer.close = AsyncMock(return_value=None)
+
+    with (
+        patch("knowledge_ingest.qdrant_store.ensure_collection", new_callable=AsyncMock),
+        patch(
+            "knowledge_ingest.db.get_pool",
+            new_callable=AsyncMock,
+            return_value=mock_pool_outer,
+        ),
+        patch("knowledge_ingest.db.close_pool", new_callable=AsyncMock),
+        patch("knowledge_ingest.config.settings.enrichment_enabled", False),
+    ):
+        from fastapi.testclient import TestClient
+
+        from knowledge_ingest.app import app
+
+        with TestClient(app, raise_server_exceptions=False) as c:
+            yield c
+
+
+# ---------------------------------------------------------------------------
+# Test 1: 200 with correct per-table row counts
+# ---------------------------------------------------------------------------
+
+
+class TestWipePostgresHappyPath:
+    def test_200_returns_per_table_counts(self, wipe_pg_client) -> None:
+        seeded = {
+            "page_links": 3,
+            "crawled_pages": 5,
+            "crawl_jobs": 2,
+            "crawl_domains": 1,
+            "kb_config": 1,
+            "org_config": 1,
+            "entities": 4,
+            "artifacts": 7,
+        }
+        conn_mock = _make_conn_mock(seeded)
+        pool_mock = _make_pool_mock(conn_mock)
+
+        with patch(
+            "knowledge_ingest.routes.internal.get_pool",
+            new_callable=AsyncMock,
+            return_value=pool_mock,
+        ):
+            resp = wipe_pg_client.post(
+                _ENDPOINT_A,
+                headers={"X-Internal-Secret": _SECRET},
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "ok"
+        rows = body["rows_deleted"]
+        assert rows["artifacts"] == 7
+        assert rows["page_links"] == 3
+        assert rows["crawled_pages"] == 5
+        assert rows["crawl_jobs"] == 2
+        assert rows["crawl_domains"] == 1
+        assert rows["kb_config"] == 1
+        assert rows["org_config"] == 1
+        assert rows["entities"] == 4
+        assert set(rows.keys()) == _EXPECTED_WIPE_TABLES
+
+    def test_200_status_ok_field_present(self, wipe_pg_client) -> None:
+        conn_mock = _make_conn_mock({})
+        pool_mock = _make_pool_mock(conn_mock)
+        with patch(
+            "knowledge_ingest.routes.internal.get_pool",
+            new_callable=AsyncMock,
+            return_value=pool_mock,
+        ):
+            resp = wipe_pg_client.post(
+                _ENDPOINT_A,
+                headers={"X-Internal-Secret": _SECRET},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Cross-tenant isolation
+# ---------------------------------------------------------------------------
+
+
+class TestWipePostgresTenantIsolation:
+    def test_only_target_org_rows_deleted(self, wipe_pg_client) -> None:
+        """Verify the DELETE uses org_id=$1 -- tenant-b data must survive."""
+        executed_calls = []
+
+        conn = MagicMock()
+
+        async def _tracking_execute(query: str, *args, **kwargs) -> str:
+            executed_calls.append((query, args))
+            if "superseded_by" in query:
+                return "UPDATE 0"
+            parts = query.split()
+            table_full = parts[2] if len(parts) > 2 else ""
+            table = table_full.split(".")[-1] if "." in table_full else table_full
+            return "DELETE 2" if table in _EXPECTED_WIPE_TABLES else "DELETE 0"
+
+        conn.execute = _tracking_execute
+        tx = MagicMock()
+        tx.__aenter__ = AsyncMock(return_value=None)
+        tx.__aexit__ = AsyncMock(return_value=False)
+        conn.transaction = MagicMock(return_value=tx)
+        pool_mock = _make_pool_mock(conn)
+
+        with patch(
+            "knowledge_ingest.routes.internal.get_pool",
+            new_callable=AsyncMock,
+            return_value=pool_mock,
+        ):
+            resp = wipe_pg_client.post(
+                _ENDPOINT_A,
+                headers={"X-Internal-Secret": _SECRET},
+            )
+
+        assert resp.status_code == 200
+
+        for _query, args in executed_calls:
+            assert args, f"Expected org_id bind param in: {_query}"
+            assert args[0] == _ORG_A, (
+                f"Expected org_id={_ORG_A!r} but got {args[0]!r} in query: {_query}"
+            )
+            assert _ORG_B not in args, f"Tenant-B org_id leaked into query: {_query}"
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestWipePostgresIdempotency:
+    def test_second_call_returns_all_zeros(self, wipe_pg_client) -> None:
+        first_seeded = {t: 2 for t in _EXPECTED_WIPE_TABLES}
+        conn_first = _make_conn_mock(first_seeded)
+        pool_first = _make_pool_mock(conn_first)
+
+        conn_second = _make_conn_mock({})
+        pool_second = _make_pool_mock(conn_second)
+
+        pools = iter([pool_first, pool_second])
+
+        async def _rotating_get_pool():
+            return next(pools)
+
+        with patch(
+            "knowledge_ingest.routes.internal.get_pool",
+            side_effect=_rotating_get_pool,
+        ):
+            resp1 = wipe_pg_client.post(_ENDPOINT_A, headers={"X-Internal-Secret": _SECRET})
+            resp2 = wipe_pg_client.post(_ENDPOINT_A, headers={"X-Internal-Secret": _SECRET})
+
+        assert resp1.status_code == 200
+        assert resp2.status_code == 200
+
+        rows2 = resp2.json()["rows_deleted"]
+        assert all(v == 0 for v in rows2.values()), (
+            f"Expected all zeros on second call, got: {rows2}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Auth
+# ---------------------------------------------------------------------------
+
+
+class TestWipePostgresAuth:
+    def test_401_without_secret_header(self, wipe_pg_client) -> None:
+        resp = wipe_pg_client.post(_ENDPOINT_A)
+        assert resp.status_code == 401
+
+    def test_401_with_wrong_secret(self, wipe_pg_client) -> None:
+        resp = wipe_pg_client.post(
+            _ENDPOINT_A,
+            headers={"X-Internal-Secret": "wrong-secret-xyz"},
+        )
+        assert resp.status_code == 401
+
+    def test_200_with_correct_secret(self, wipe_pg_client) -> None:
+        conn_mock = _make_conn_mock({})
+        pool_mock = _make_pool_mock(conn_mock)
+        with patch(
+            "knowledge_ingest.routes.internal.get_pool",
+            new_callable=AsyncMock,
+            return_value=pool_mock,
+        ):
+            resp = wipe_pg_client.post(
+                _ENDPOINT_A,
+                headers={"X-Internal-Secret": _SECRET},
+            )
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Schema regression guard (live DB, skipped without POSTGRES_DSN)
+# ---------------------------------------------------------------------------
+
+_pg_available = bool(os.environ.get("POSTGRES_DSN"))
+
+
+@pytest.mark.skipif(not _pg_available, reason="No POSTGRES_DSN set -- skipping live DB test")
+class TestWipePostgresSchemaGuard:
+    """Regression guard: fails CI if a new knowledge.* table with org_id is added
+    without also being added to the wipe list in routes/internal.py."""
+
+    @pytest.mark.asyncio
+    async def test_all_org_id_tables_are_in_wipe_list(self) -> None:
+        import asyncpg
+
+        dsn = os.environ["POSTGRES_DSN"]
+        conn = await asyncpg.connect(dsn)
+        try:
+            rows = await conn.fetch(
+                """
+                SELECT table_name
+                FROM information_schema.columns
+                WHERE table_schema = 'knowledge'
+                  AND column_name = 'org_id'
+                ORDER BY table_name
+                """
+            )
+        finally:
+            await conn.close()
+
+        live_tables = {row["table_name"] for row in rows}
+        missing = live_tables - _EXPECTED_WIPE_TABLES
+        assert not missing, (
+            f"The following knowledge.* tables have an org_id column but are NOT "
+            f"in the wipe list (_LEAF_TABLES + artifacts): {sorted(missing)}. "
+            f"Add them to _LEAF_TABLES in knowledge_ingest/routes/internal.py "
+            f"(or document why they are intentionally excluded)."
+        )


### PR DESCRIPTION
## Summary

Closes G3 of the 7 GDPR purge gaps. Adds `POST /internal/v1/orgs/{org_id}/wipe-postgres` to knowledge-ingest — purges `knowledge.*` tables that carry `org_id` for the given tenant. Idempotent.

Mirrors the existing `/internal/v1/orgs/{org_id}/wipe-graph` (FalkorDB) endpoint shape.

## ⚠️ BLOCKER until follow-up PR

This PR adds the endpoint but **nothing calls it yet**. Until a follow-up PR adds step 13a to `klai-portal/backend/app/services/provisioning/deprovisioning_orchestrator.py`, the GDPR purge gap is technically still open: `knowledge.*` rows of a deprovisioned tenant remain on disk. **Do NOT close G3 in the audit roadmap until both this PR AND the orchestrator wiring PR have merged.**

## Tables wiped (8, verified live 2026-05-05)

| Table | Note |
|---|---|
| knowledge.page_links | leaf |
| knowledge.crawled_pages | leaf |
| knowledge.crawl_jobs | leaf |
| knowledge.crawl_domains | leaf |
| knowledge.kb_config | leaf |
| knowledge.org_config | leaf |
| knowledge.entities | artifact_entities cascade-deleted via entity FK |
| knowledge.artifacts | artifact_entities + artifact_images + derivations cascade-deleted; superseded_by self-ref nulled before DELETE |

## Tables intentionally excluded

| Table | Reason |
|---|---|
| artifact_entities, artifact_images, derivations | No `org_id`; cascade-children of `artifacts` |
| embedding_queue | No `org_id`, no FK to artifacts; shared infra |
| rag_eval_results | No `org_id`; eval/analytics, no tenant ownership |

The SPEC enumerated 10 tables; the 2 missing from the live DB are auto-excluded by the introspection approach.

## Implementation review (self-read 2026-05-05)

- Single transaction (`async with conn.transaction()`) — atomicity guaranteed
- `superseded_by` self-ref NULL'd inside the transaction before `artifacts` DELETE — addresses NO ACTION FK
- f-string SQL is safe: `{table}` interpolated from hardcoded `_LEAF_TABLES`, `org_id` parameterized via `$1`
- DELETE order: leaf tables first, `artifacts` last (CASCADE picks up children)

## Tests (7 passed, 1 skipped)

- Cross-tenant isolation
- Idempotency
- Auth (X-Internal-Secret)
- The schema-regression-guard test is skipped without POSTGRES_DSN — runs in CI environments with a live PG fixture.
- ruff clean

## Refs

- SPEC-INFRA-TENANT-DELETE-002 G3
- reports/audit-2026-05-04/multi-tenancy-gdpr.md
- knowledge_ingest `wipe_org_graph` — canonical pattern