### PR TITLE
feat(rag): SPEC-RAG-TAXONOMY-001 — query-time taxonomy filter

### DIFF
--- a/deploy/litellm/klai_knowledge.py
+++ b/deploy/litellm/klai_knowledge.py
@@ -16,6 +16,7 @@ KB-context presence is signalled to downstream hooks via data["_klai_kb_meta"].
 The custom_router uses this to prevent model downgrade for KB-enriched requests.
 """
 
+import asyncio
 import logging
 import os
 import re
@@ -291,6 +292,19 @@ QUERY_REWRITE_HISTORY_TURNS = int(os.getenv("QUERY_REWRITE_HISTORY_TURNS", "4"))
 MISTRAL_API_KEY = os.getenv("MISTRAL_API_KEY", "")
 MISTRAL_API_URL = "https://api.mistral.ai/v1/chat/completions"
 
+# SPEC-RAG-TAXONOMY-001: Query-time taxonomy filtering
+# KNOWLEDGE_RETRIEVE_URL already set above. Taxonomy endpoints live on the same
+# retrieval-api base: /internal/v1/taxonomy/tree and /internal/v1/taxonomy/coverage.
+_RETRIEVAL_BASE_URL = (KNOWLEDGE_RETRIEVE_URL or "").rsplit("/retrieve", 1)[0]
+TAXONOMY_ENABLED = os.getenv("TAXONOMY_ENABLED", "true").lower() == "true"
+# Coverage threshold: if < this fraction of KB chunks are tagged, skip filter.
+# Default 0.30 — only skip when KB is mostly untagged (REQ-2 coverage-stats fallback).
+KLAI_TAXONOMY_COVERAGE_THRESHOLD = float(
+    os.getenv("KLAI_TAXONOMY_COVERAGE_THRESHOLD", "0.30")
+)
+# Timeout for each taxonomy HTTP call (tree fetch + coverage fetch).
+TAXONOMY_FETCH_TIMEOUT = float(os.getenv("TAXONOMY_FETCH_TIMEOUT", "0.8"))
+
 _QUERY_REWRITE_PROMPT = (
     "You are a query rewriter for a RAG search system. Rewrite the user's "
     "current question so it makes sense as a stand-alone search query — "
@@ -407,6 +421,220 @@ async def _rewrite_query(
     rewritten = rewritten[:500]
     meta["was_changed"] = rewritten.lower() != raw_query.strip().lower()
     return rewritten, meta
+
+
+# ---------------------------------------------------------------------------
+# SPEC-RAG-TAXONOMY-001: Combined rewrite + classify prompt
+# Single LLM call returns BOTH the rewritten query AND taxonomy node IDs.
+# Keeps added token cost < 100 tokens (REQ-6) vs the standalone rewrite prompt.
+# ---------------------------------------------------------------------------
+
+_QUERY_REWRITE_AND_CLASSIFY_PROMPT = (
+    "You are a query rewriter and topic classifier for a RAG search system.\n\n"
+    "Tasks (combined, single JSON response):\n"
+    "1. Rewrite the user's current question into a self-contained search query "
+    "— resolve pronouns and references using the conversation history. "
+    "If already clear, return it unchanged.\n"
+    "2. From the taxonomy below, select ALL node IDs whose topic is genuinely "
+    "relevant to the rewritten query. An empty list means no narrowing.\n\n"
+    "Conversation history (oldest → newest):\n{history}\n\n"
+    "User's current question: {raw_query}\n\n"
+    "Available taxonomy nodes:\n{taxonomy}\n\n"
+    "Reply with ONLY a JSON object, no markdown, no explanation:\n"
+    '{{"rewritten_query": "<string, max 200 chars, same language as user>", '
+    '"taxonomy_node_ids": [<int>, ...]}}'
+)
+
+
+def _format_taxonomy_for_prompt(tree: list[dict], max_nodes: int = 30) -> str:
+    """Format taxonomy tree as 'id: name' lines for the LLM prompt."""
+    if not tree:
+        return "(none)"
+    lines = [f"- id={node['id']}: {node['name']}" for node in tree[:max_nodes]]
+    if len(tree) > max_nodes:
+        lines.append(f"... ({len(tree) - max_nodes} more nodes omitted)")
+    return "\n".join(lines)
+
+
+async def _fetch_taxonomy_tree(
+    org_id: str,
+    kb_slug: str,
+    *,
+    _transport: httpx.AsyncBaseTransport | None = None,
+) -> list[dict]:
+    """Fetch the taxonomy tree from retrieval-api /internal/v1/taxonomy/tree.
+
+    Returns [] on any error (fail-open per REQ-2).
+    """
+    if not TAXONOMY_ENABLED or not _RETRIEVAL_BASE_URL:
+        return []
+    url = f"{_RETRIEVAL_BASE_URL}/internal/v1/taxonomy/tree"
+    legacy_headers = _retrieve_legacy_headers()
+    client_kwargs: dict = {"timeout": TAXONOMY_FETCH_TIMEOUT}
+    if _transport is not None:
+        client_kwargs["transport"] = _transport
+    try:
+        async with httpx.AsyncClient(**client_kwargs) as client:
+            resp = await client.get(
+                url,
+                params={"org_id": org_id, "kb_slug": kb_slug},
+                headers=legacy_headers,
+            )
+            resp.raise_for_status()
+            return resp.json()  # list[dict] with id, name, parent_id, depth
+    except Exception as exc:
+        logger.warning(
+            "KlaiKnowledgeHook: taxonomy_tree_fetch_failed org=%s kb=%s error=%s",
+            org_id,
+            kb_slug,
+            str(exc)[:120],
+        )
+        return []
+
+
+async def _fetch_taxonomy_coverage(
+    org_id: str,
+    kb_slug: str,
+    *,
+    _transport: httpx.AsyncBaseTransport | None = None,
+) -> float:
+    """Fetch the taxonomy coverage ratio from retrieval-api /internal/v1/taxonomy/coverage.
+
+    Returns 0.0 on any error (fail-open — caller skips filter when 0.0 < threshold).
+    """
+    if not TAXONOMY_ENABLED or not _RETRIEVAL_BASE_URL:
+        return 0.0
+    url = f"{_RETRIEVAL_BASE_URL}/internal/v1/taxonomy/coverage"
+    legacy_headers = _retrieve_legacy_headers()
+    client_kwargs: dict = {"timeout": TAXONOMY_FETCH_TIMEOUT}
+    if _transport is not None:
+        client_kwargs["transport"] = _transport
+    try:
+        async with httpx.AsyncClient(**client_kwargs) as client:
+            resp = await client.get(
+                url,
+                params={"org_id": org_id, "kb_slug": kb_slug},
+                headers=legacy_headers,
+            )
+            resp.raise_for_status()
+            return float(resp.json().get("coverage", 0.0))
+    except Exception as exc:
+        logger.warning(
+            "KlaiKnowledgeHook: taxonomy_coverage_fetch_failed org=%s kb=%s error=%s",
+            org_id,
+            kb_slug,
+            str(exc)[:120],
+        )
+        return 0.0
+
+
+async def _rewrite_and_classify(
+    raw_query: str,
+    history: list[dict],
+    taxonomy_tree: list[dict],
+    *,
+    _transport: httpx.AsyncBaseTransport | None = None,
+) -> tuple[str, list[int], dict]:
+    """Return ``(rewritten_query, classified_node_ids, debug_meta)`` in one LLM call.
+
+    Replaces the standalone ``_rewrite_query`` call when taxonomy_tree is non-empty.
+    When taxonomy_tree is empty, falls back to plain rewrite (no classification).
+
+    Anti-hallucination guard (REQ-4): only returns node IDs that exist in tree.
+    Fail-open on any error: falls back to (raw_query, [], meta_with_skip_reason).
+    """
+    import json as _json  # noqa: PLC0415 — local import avoids shadowing module-level vars
+
+    meta: dict = {"was_changed": False, "rewrite_ms": 0}
+
+    # Early exits (same skip conditions as _rewrite_query)
+    if not raw_query or not raw_query.strip():
+        meta["skipped"] = "empty_query"
+        return raw_query, [], meta
+    if not QUERY_REWRITE_ENABLED:
+        meta["skipped"] = "disabled"
+        return raw_query, [], meta
+    if not MISTRAL_API_KEY:
+        meta["skipped"] = "no_api_key"
+        return raw_query, [], meta
+
+    # No history AND no taxonomy → nothing to do
+    if not history and not taxonomy_tree:
+        meta["skipped"] = "no_history_no_tree"
+        return raw_query, [], meta
+
+    # Fall back to plain text prompt when no taxonomy is available
+    if not taxonomy_tree:
+        rewritten, rewrite_meta = await _rewrite_query(
+            raw_query, history, _transport=_transport
+        )
+        return rewritten, [], rewrite_meta
+
+    # Build combined prompt
+    history_str = _format_history_for_rewrite(history) if history else "(none)"
+    taxonomy_str = _format_taxonomy_for_prompt(taxonomy_tree)
+    prompt = _QUERY_REWRITE_AND_CLASSIFY_PROMPT.format(
+        history=history_str,
+        raw_query=raw_query,
+        taxonomy=taxonomy_str,
+    )
+    payload = {
+        "model": QUERY_REWRITE_MODEL,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": 300,
+        "temperature": 0.0,
+        "response_format": {"type": "json_object"},
+    }
+    headers = {
+        "Authorization": f"Bearer {MISTRAL_API_KEY}",
+        "Content-Type": "application/json",
+    }
+    client_kwargs: dict = {"timeout": QUERY_REWRITE_TIMEOUT}
+    if _transport is not None:
+        client_kwargs["transport"] = _transport
+
+    valid_ids: set[int] = {int(n["id"]) for n in taxonomy_tree}
+    t_start = time.monotonic()
+    try:
+        async with httpx.AsyncClient(**client_kwargs) as client:
+            resp = await client.post(MISTRAL_API_URL, json=payload, headers=headers)
+            resp.raise_for_status()
+            raw_content = resp.json()["choices"][0]["message"]["content"]
+        parsed = _json.loads(raw_content or "{}")
+    except Exception as exc:
+        meta["rewrite_ms"] = int((time.monotonic() - t_start) * 1000)
+        meta["skipped"] = "exception"
+        meta["error"] = str(exc)[:120]
+        logger.warning(
+            "query_rewrite_and_classify_failed error=%s rewrite_ms=%d",
+            meta["error"],
+            meta["rewrite_ms"],
+        )
+        return raw_query, [], meta
+
+    meta["rewrite_ms"] = int((time.monotonic() - t_start) * 1000)
+
+    # Extract rewritten query
+    rewritten = (parsed.get("rewritten_query") or "").strip().strip('"').strip("'")
+    if not rewritten:
+        meta["skipped"] = "empty_rewritten_query"
+        return raw_query, [], meta
+    rewritten = rewritten[:500]
+    meta["was_changed"] = rewritten.lower() != raw_query.strip().lower()
+
+    # Extract and validate taxonomy node IDs (anti-hallucination guard REQ-4)
+    raw_ids = parsed.get("taxonomy_node_ids") or []
+    classified: list[int] = []
+    for item in raw_ids:
+        try:
+            node_id = int(item)
+        except (TypeError, ValueError):
+            continue
+        if node_id in valid_ids:
+            classified.append(node_id)
+
+    meta["classified_node_ids"] = classified
+    return rewritten, classified, meta
 
 
 async def _get_kb_feature(user_id: str, org_id: str, cache) -> dict:
@@ -837,7 +1065,9 @@ class KlaiKnowledgeHook(CustomLogger):
                 "(identity-resolve-failed) — dit antwoord is niet gebaseerd op "
                 "jullie eigen documentatie. Probeer het later opnieuw.']\n"
             )
-            prefix = "\n\n".join(b for b in (templates_block, kb_unavailable_notice) if b)
+            prefix = "\n\n".join(
+                b for b in (templates_block, kb_unavailable_notice) if b
+            )
             _prepend_system_prefix(messages, prefix)
             data["messages"] = messages
             return data
@@ -878,13 +1108,29 @@ class KlaiKnowledgeHook(CustomLogger):
 
         conversation_history = _build_conversation_history(messages)
 
-        # SPEC-RAG-QUERY-REWRITE-001: rewrite the raw query into a
-        # self-contained search query before /retrieve. Fail-open: any
-        # failure path returns the raw query unchanged with skip reason
-        # recorded in meta. ~150-300ms typical, <500ms p95 (REQ-4).
-        rewritten_query, rewrite_meta = await _rewrite_query(
-            query, conversation_history
+        # SPEC-RAG-TAXONOMY-001: fetch taxonomy tree for the first KB in scope.
+        # Good-enough heuristic for v1: multi-KB queries skip taxonomy filter.
+        # Fail-open: empty tree = no classify, no filter (REQ-2).
+        first_kb_slug: str | None = (
+            kb_slugs_for_request[0] if kb_slugs_for_request else None
         )
+        taxonomy_tree: list[dict] = []
+        taxonomy_coverage: float = 0.0
+        if first_kb_slug and TAXONOMY_ENABLED and scope in ("org", "both"):
+            taxonomy_tree, taxonomy_coverage = await asyncio.gather(
+                _fetch_taxonomy_tree(org_id, first_kb_slug),
+                _fetch_taxonomy_coverage(org_id, first_kb_slug),
+            )
+
+        # SPEC-RAG-QUERY-REWRITE-001 + SPEC-RAG-TAXONOMY-001:
+        # Combined rewrite + classify in a single LLM call (REQ-5 zero added roundtrip).
+        # When taxonomy_tree is empty, falls back to plain rewrite (no classification).
+        # Fail-open: any failure returns (raw_query, [], meta_with_skip_reason).
+        (
+            rewritten_query,
+            classified_node_ids,
+            rewrite_meta,
+        ) = await _rewrite_and_classify(query, conversation_history, taxonomy_tree)
         try:
             logger.info(
                 "query_rewrite org_id=%s user_id=%s raw_query=%r rewritten_query=%r "
@@ -901,6 +1147,36 @@ class KlaiKnowledgeHook(CustomLogger):
             # Logging itself must never abort the hook (REQ-2 fail-open).
             pass
 
+        # SPEC-RAG-TAXONOMY-001 REQ-1+2: inject taxonomy filter iff coverage >= threshold
+        # AND the classifier returned at least one valid node ID.
+        taxonomy_applied = False
+        taxonomy_skip_reason: str | None = None
+        if TAXONOMY_ENABLED and first_kb_slug:
+            if taxonomy_coverage < KLAI_TAXONOMY_COVERAGE_THRESHOLD:
+                taxonomy_skip_reason = "low_coverage"
+            elif not classified_node_ids:
+                taxonomy_skip_reason = "empty_classify"
+            else:
+                taxonomy_applied = True
+        else:
+            taxonomy_skip_reason = "no_kb_slug" if not first_kb_slug else "disabled"
+
+        # REQ-7: log taxonomy_classify event on every classify invocation.
+        if TAXONOMY_ENABLED and first_kb_slug:
+            try:
+                logger.info(
+                    "taxonomy_classify org_id=%s kb_slug=%s coverage_ratio=%.3f "
+                    "classified_node_ids=%s was_applied=%s skip_reason=%s",
+                    org_id,
+                    first_kb_slug,
+                    taxonomy_coverage,
+                    classified_node_ids,
+                    taxonomy_applied,
+                    taxonomy_skip_reason,
+                )
+            except Exception:
+                pass
+
         retrieve_body: dict = {
             "query": rewritten_query,
             "raw_query": query,
@@ -915,6 +1191,11 @@ class KlaiKnowledgeHook(CustomLogger):
         }
         if kb_slugs_for_request:
             retrieve_body["kb_slugs"] = kb_slugs_for_request
+        # REQ-3: inject taxonomy_node_ids only when coverage is sufficient
+        # and the classifier produced valid IDs. The org/kb scoping filters
+        # are NEVER weakened — they run in addition to this filter.
+        if taxonomy_applied:
+            retrieve_body["taxonomy_node_ids"] = classified_node_ids
 
         # SPEC-SEC-SERVICE-AUTH-001 Phase C-1: prefer JWT auth, fall back to
         # legacy X-Internal-Secret on either mint failure OR receiver-side

--- a/deploy/litellm/tests/test_taxonomy_classify.py
+++ b/deploy/litellm/tests/test_taxonomy_classify.py
@@ -1,0 +1,493 @@
+"""SPEC-RAG-TAXONOMY-001 — _rewrite_and_classify + fetch helpers unit tests.
+
+Tests:
+- _rewrite_and_classify: skip when no tree, happy path, anti-hallucination guard,
+  fail-open on LLM error, falls back to plain rewrite when tree is empty.
+- _fetch_taxonomy_tree: returns list on 200, [] on 4xx/5xx/timeout.
+- _fetch_taxonomy_coverage: returns float on 200, 0.0 on error.
+- _format_taxonomy_for_prompt: truncates at max_nodes.
+
+litellm is not installed locally (runs in Docker), so we mock the import.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import types
+
+import httpx
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# litellm mock (required for import)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _mock_litellm():
+    litellm_mod = types.ModuleType("litellm")
+    integrations_mod = types.ModuleType("litellm.integrations")
+    custom_logger_mod = types.ModuleType("litellm.integrations.custom_logger")
+
+    class CustomLogger:
+        async def async_pre_call_hook(self, *args, **kwargs):
+            pass
+
+    custom_logger_mod.CustomLogger = CustomLogger
+    integrations_mod.custom_logger = custom_logger_mod
+    litellm_mod.integrations = integrations_mod
+
+    sys.modules["litellm"] = litellm_mod
+    sys.modules["litellm.integrations"] = integrations_mod
+    sys.modules["litellm.integrations.custom_logger"] = custom_logger_mod
+
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Module loader
+# ---------------------------------------------------------------------------
+
+
+def _load_hook(monkeypatch, extra_env=None):
+    env = {
+        "PORTAL_INTERNAL_SECRET": "test-portal-secret",
+        "RETRIEVAL_INTERNAL_SECRET": "test-retrieval-secret",
+        "KNOWLEDGE_RETRIEVE_URL": "http://retrieval-api:8040/retrieve",
+        "PORTAL_API_URL": "http://portal-api:8000",
+        "MISTRAL_API_KEY": "test-mistral-key",
+        "TAXONOMY_ENABLED": "true",
+        "KLAI_TAXONOMY_COVERAGE_THRESHOLD": "0.30",
+    }
+    if extra_env:
+        env.update(extra_env)
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+
+    sys.modules.pop("klai_knowledge", None)
+    import klai_knowledge
+
+    importlib.reload(klai_knowledge)
+    return klai_knowledge
+
+
+# ---------------------------------------------------------------------------
+# Transport mocks
+# ---------------------------------------------------------------------------
+
+
+class _MockTransport(httpx.AsyncBaseTransport):
+    """Return a fixed status + JSON body for every request."""
+
+    def __init__(self, status_code: int, json_body=None) -> None:
+        self._status_code = status_code
+        self._json_body = json_body if json_body is not None else {}
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            status_code=self._status_code,
+            headers={"content-type": "application/json"},
+            content=json.dumps(self._json_body).encode(),
+            request=request,
+        )
+
+
+class _RoutedTransport(httpx.AsyncBaseTransport):
+    """Return different responses based on the request URL path."""
+
+    def __init__(self, routes: dict) -> None:
+        # routes = {"/internal/v1/taxonomy/tree": (200, [...]), ...}
+        self._routes = routes
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        status, body = self._routes.get(path, (404, {"detail": "not found"}))
+        return httpx.Response(
+            status_code=status,
+            headers={"content-type": "application/json"},
+            content=json.dumps(body).encode(),
+            request=request,
+        )
+
+
+def _llm_json_response(rewritten_query: str, taxonomy_node_ids: list) -> dict:
+    """Build a Mistral-style JSON choices response."""
+    return {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": json.dumps(
+                        {
+                            "rewritten_query": rewritten_query,
+                            "taxonomy_node_ids": taxonomy_node_ids,
+                        }
+                    ),
+                }
+            }
+        ],
+        "usage": {"prompt_tokens": 120, "completion_tokens": 20},
+    }
+
+
+_TREE = [
+    {"id": 1, "name": "SSO", "parent_id": None, "depth": 0},
+    {"id": 2, "name": "SAML", "parent_id": 1, "depth": 1},
+    {"id": 3, "name": "OAuth", "parent_id": 1, "depth": 1},
+]
+
+_HISTORY = [
+    {"role": "user", "content": "Hoe configureer je SAML?"},
+    {"role": "assistant", "content": "Je moet eerst de IdP instellen."},
+]
+
+
+# ---------------------------------------------------------------------------
+# _rewrite_and_classify — skip conditions
+# ---------------------------------------------------------------------------
+
+
+class TestRewriteAndClassifySkips:
+    @pytest.mark.asyncio
+    async def test_skips_empty_query(self, monkeypatch):
+        hook = _load_hook(monkeypatch)
+        rewritten, ids, meta = await hook._rewrite_and_classify("", _HISTORY, _TREE)
+        assert rewritten == ""
+        assert ids == []
+        assert meta["skipped"] == "empty_query"
+
+    @pytest.mark.asyncio
+    async def test_skips_when_disabled(self, monkeypatch):
+        hook = _load_hook(monkeypatch, extra_env={"QUERY_REWRITE_ENABLED": "false"})
+        rewritten, ids, meta = await hook._rewrite_and_classify(
+            "Wat is SAML?", _HISTORY, _TREE
+        )
+        assert rewritten == "Wat is SAML?"
+        assert ids == []
+        assert meta["skipped"] == "disabled"
+
+    @pytest.mark.asyncio
+    async def test_skips_when_no_api_key(self, monkeypatch):
+        hook = _load_hook(monkeypatch, extra_env={"MISTRAL_API_KEY": ""})
+        rewritten, ids, meta = await hook._rewrite_and_classify(
+            "Wat is SAML?", _HISTORY, _TREE
+        )
+        assert ids == []
+        assert meta["skipped"] == "no_api_key"
+
+    @pytest.mark.asyncio
+    async def test_skips_classify_when_no_history_and_no_tree(self, monkeypatch):
+        hook = _load_hook(monkeypatch)
+        rewritten, ids, meta = await hook._rewrite_and_classify("Wat is SAML?", [], [])
+        # No history, no tree → skip (no_history_no_tree)
+        assert rewritten == "Wat is SAML?"
+        assert ids == []
+        assert meta["skipped"] == "no_history_no_tree"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_plain_rewrite_when_tree_empty(self, monkeypatch):
+        """Empty tree → falls back to _rewrite_query (plain text prompt, no classify)."""
+        hook = _load_hook(monkeypatch)
+        rewritten_str = "Wat is de status van de SAML-configuratie?"
+        transport = _MockTransport(
+            status_code=200,
+            json_body={
+                "choices": [
+                    {"message": {"role": "assistant", "content": rewritten_str}}
+                ],
+                "usage": {"prompt_tokens": 80, "completion_tokens": 20},
+            },
+        )
+        rewritten, ids, meta = await hook._rewrite_and_classify(
+            "Wat is de status?", _HISTORY, [], _transport=transport
+        )
+        assert rewritten == rewritten_str
+        assert ids == []
+        # Meta is from plain _rewrite_query: was_changed should be True
+        assert meta["was_changed"] is True
+
+
+# ---------------------------------------------------------------------------
+# _rewrite_and_classify — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestRewriteAndClassifyHappyPath:
+    @pytest.mark.asyncio
+    async def test_returns_rewritten_query_and_ids(self, monkeypatch):
+        """Full happy path: LLM returns rewritten query + valid IDs."""
+        hook = _load_hook(monkeypatch)
+        transport = _MockTransport(
+            status_code=200,
+            json_body=_llm_json_response(
+                "Hoe configureer je SAML-authenticatie?", [1, 2]
+            ),
+        )
+
+        rewritten, ids, meta = await hook._rewrite_and_classify(
+            "Hoe doe je dat?", _HISTORY, _TREE, _transport=transport
+        )
+
+        assert rewritten == "Hoe configureer je SAML-authenticatie?"
+        assert 1 in ids
+        assert 2 in ids
+        assert meta["was_changed"] is True
+        assert meta["rewrite_ms"] >= 0
+
+    @pytest.mark.asyncio
+    async def test_drops_hallucinated_ids(self, monkeypatch):
+        """Anti-hallucination guard (REQ-4): IDs not in tree are filtered out."""
+        hook = _load_hook(monkeypatch)
+        transport = _MockTransport(
+            status_code=200,
+            # IDs 1, 2, 3 are valid; 99 and 1000 are hallucinated
+            json_body=_llm_json_response("Hoe configureer je SAML?", [1, 2, 99, 1000]),
+        )
+
+        rewritten, ids, meta = await hook._rewrite_and_classify(
+            "Hoe doe je dat?", _HISTORY, _TREE, _transport=transport
+        )
+
+        assert set(ids) == {1, 2}
+        assert 99 not in ids
+        assert 1000 not in ids
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_ids_when_llm_classifies_none(self, monkeypatch):
+        """LLM returns empty taxonomy_node_ids → [] is valid (query is off-topic)."""
+        hook = _load_hook(monkeypatch)
+        transport = _MockTransport(
+            status_code=200,
+            json_body=_llm_json_response("Hoe reset ik mijn wachtwoord?", []),
+        )
+
+        rewritten, ids, meta = await hook._rewrite_and_classify(
+            "Wachtwoord vergeten", _HISTORY, _TREE, _transport=transport
+        )
+
+        assert ids == []
+        assert rewritten == "Hoe reset ik mijn wachtwoord?"
+
+    @pytest.mark.asyncio
+    async def test_was_changed_false_when_query_unchanged(self, monkeypatch):
+        """If LLM returns the same query text, was_changed is False."""
+        hook = _load_hook(monkeypatch)
+        raw = "Wat is OAuth?"
+        transport = _MockTransport(
+            status_code=200,
+            json_body=_llm_json_response(raw, [3]),
+        )
+
+        rewritten, ids, meta = await hook._rewrite_and_classify(
+            raw, _HISTORY, _TREE, _transport=transport
+        )
+
+        assert rewritten == raw
+        assert meta["was_changed"] is False
+        assert 3 in ids
+
+
+# ---------------------------------------------------------------------------
+# _rewrite_and_classify — failure / fail-open
+# ---------------------------------------------------------------------------
+
+
+class TestRewriteAndClassifyFailOpen:
+    @pytest.mark.asyncio
+    async def test_falls_back_on_500(self, monkeypatch):
+        hook = _load_hook(monkeypatch)
+        transport = _MockTransport(status_code=500, json_body={"detail": "boom"})
+
+        rewritten, ids, meta = await hook._rewrite_and_classify(
+            "Wat is SAML?", _HISTORY, _TREE, _transport=transport
+        )
+
+        # Must return raw query unchanged (fail-open REQ-2)
+        assert rewritten == "Wat is SAML?"
+        assert ids == []
+        assert meta["skipped"] == "exception"
+        assert "error" in meta
+
+    @pytest.mark.asyncio
+    async def test_falls_back_on_malformed_json(self, monkeypatch):
+        """LLM returns non-JSON content → fail-open."""
+        hook = _load_hook(monkeypatch)
+
+        class _BadJsonTransport(httpx.AsyncBaseTransport):
+            async def handle_async_request(self, request):
+                return httpx.Response(
+                    status_code=200,
+                    headers={"content-type": "application/json"},
+                    content=b'{"choices": [{"message": {"role": "assistant", "content": "not valid json at all"}}]}',
+                    request=request,
+                )
+
+        rewritten, ids, meta = await hook._rewrite_and_classify(
+            "Wat is SAML?", _HISTORY, _TREE, _transport=_BadJsonTransport()
+        )
+
+        # json.loads("not valid json at all") raises → parsed = {} → rewritten_query absent
+        assert rewritten == "Wat is SAML?"
+        assert ids == []
+
+    @pytest.mark.asyncio
+    async def test_falls_back_when_rewritten_query_empty(self, monkeypatch):
+        """LLM returns empty rewritten_query → fall back to raw."""
+        hook = _load_hook(monkeypatch)
+        transport = _MockTransport(
+            status_code=200,
+            json_body=_llm_json_response("", [1]),
+        )
+
+        rewritten, ids, meta = await hook._rewrite_and_classify(
+            "Wat is SAML?", _HISTORY, _TREE, _transport=transport
+        )
+
+        assert rewritten == "Wat is SAML?"
+        assert ids == []
+        assert meta.get("skipped") == "empty_rewritten_query"
+
+
+# ---------------------------------------------------------------------------
+# _fetch_taxonomy_tree
+# ---------------------------------------------------------------------------
+
+
+class TestFetchTaxonomyTree:
+    @pytest.mark.asyncio
+    async def test_returns_list_on_200(self, monkeypatch):
+        hook = _load_hook(monkeypatch)
+        tree_data = [{"id": 1, "name": "Root", "parent_id": None, "depth": 0}]
+        transport = _MockTransport(status_code=200, json_body=tree_data)
+
+        result = await hook._fetch_taxonomy_tree("org-1", "kb-1", _transport=transport)
+
+        assert result == tree_data
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_404(self, monkeypatch):
+        hook = _load_hook(monkeypatch)
+        transport = _MockTransport(status_code=404, json_body={"detail": "not found"})
+
+        result = await hook._fetch_taxonomy_tree("org-1", "kb-x", _transport=transport)
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_500(self, monkeypatch):
+        hook = _load_hook(monkeypatch)
+        transport = _MockTransport(status_code=500, json_body={"detail": "error"})
+
+        result = await hook._fetch_taxonomy_tree("org-1", "kb-1", _transport=transport)
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_taxonomy_disabled(self, monkeypatch):
+        hook = _load_hook(monkeypatch, extra_env={"TAXONOMY_ENABLED": "false"})
+
+        # No transport passed; if it made a real request it would fail
+        result = await hook._fetch_taxonomy_tree("org-1", "kb-1")
+
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _fetch_taxonomy_coverage
+# ---------------------------------------------------------------------------
+
+
+class TestFetchTaxonomyCoverage:
+    @pytest.mark.asyncio
+    async def test_returns_float_on_200(self, monkeypatch):
+        hook = _load_hook(monkeypatch)
+        transport = _MockTransport(status_code=200, json_body={"coverage": 0.65})
+
+        result = await hook._fetch_taxonomy_coverage(
+            "org-1", "kb-1", _transport=transport
+        )
+
+        assert abs(result - 0.65) < 1e-6
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_on_error(self, monkeypatch):
+        hook = _load_hook(monkeypatch)
+        transport = _MockTransport(status_code=500, json_body={"detail": "boom"})
+
+        result = await hook._fetch_taxonomy_coverage(
+            "org-1", "kb-1", _transport=transport
+        )
+
+        assert result == 0.0
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_when_key_missing(self, monkeypatch):
+        """Response JSON without 'coverage' key → 0.0."""
+        hook = _load_hook(monkeypatch)
+        transport = _MockTransport(status_code=200, json_body={})
+
+        result = await hook._fetch_taxonomy_coverage(
+            "org-1", "kb-1", _transport=transport
+        )
+
+        assert result == 0.0
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_when_disabled(self, monkeypatch):
+        hook = _load_hook(monkeypatch, extra_env={"TAXONOMY_ENABLED": "false"})
+
+        result = await hook._fetch_taxonomy_coverage("org-1", "kb-1")
+
+        assert result == 0.0
+
+
+# ---------------------------------------------------------------------------
+# _format_taxonomy_for_prompt
+# ---------------------------------------------------------------------------
+
+
+class TestFormatTaxonomyForPrompt:
+    def test_formats_nodes_as_id_name_lines(self, monkeypatch):
+        hook = _load_hook(monkeypatch)
+        tree = [
+            {"id": 1, "name": "SSO", "parent_id": None, "depth": 0},
+            {"id": 2, "name": "SAML", "parent_id": 1, "depth": 1},
+        ]
+        result = hook._format_taxonomy_for_prompt(tree)
+        assert "id=1: SSO" in result
+        assert "id=2: SAML" in result
+
+    def test_returns_none_for_empty_tree(self, monkeypatch):
+        hook = _load_hook(monkeypatch)
+        result = hook._format_taxonomy_for_prompt([])
+        assert result == "(none)"
+
+    def test_truncates_at_max_nodes(self, monkeypatch):
+        hook = _load_hook(monkeypatch)
+        tree = [
+            {"id": i, "name": f"Node {i}", "parent_id": None, "depth": 0}
+            for i in range(50)
+        ]
+
+        result = hook._format_taxonomy_for_prompt(tree, max_nodes=10)
+
+        # Exactly 10 node lines + 1 truncation line
+        lines = result.splitlines()
+        node_lines = [ln for ln in lines if ln.startswith("- id=")]
+        assert len(node_lines) == 10
+        assert "more nodes omitted" in result
+
+    def test_no_truncation_line_when_within_limit(self, monkeypatch):
+        hook = _load_hook(monkeypatch)
+        tree = [
+            {"id": i, "name": f"Node {i}", "parent_id": None, "depth": 0}
+            for i in range(5)
+        ]
+
+        result = hook._format_taxonomy_for_prompt(tree, max_nodes=10)
+
+        assert "omitted" not in result
+        assert result.count("- id=") == 5

--- a/klai-retrieval-api/retrieval_api/api/taxonomy.py
+++ b/klai-retrieval-api/retrieval_api/api/taxonomy.py
@@ -1,0 +1,48 @@
+"""Internal taxonomy endpoints for the LiteLLM hook.
+
+GET /internal/v1/taxonomy/tree   — taxonomy node list for a KB
+GET /internal/v1/taxonomy/coverage — coverage ratio for a KB
+
+Auth: same X-Internal-Secret as /retrieve (enforced by AuthMiddleware globally).
+"""
+
+from __future__ import annotations
+
+import structlog
+from fastapi import APIRouter, Query
+
+from retrieval_api.services.taxonomy_lookup import (
+    get_kb_taxonomy_coverage,
+    get_taxonomy_tree,
+)
+
+logger = structlog.get_logger()
+
+router = APIRouter(prefix="/internal/v1/taxonomy")
+
+
+@router.get("/tree")
+async def taxonomy_tree(
+    org_id: str = Query(..., description="Zitadel org ID"),
+    kb_slug: str = Query(..., description="KB slug"),
+) -> list[dict]:
+    """Return the flat taxonomy node list for the KB.
+
+    Returns [] when the KB has no taxonomy or on any DB error (fail-open).
+    """
+    tree = await get_taxonomy_tree(org_id, kb_slug)
+    # Convert TypedDicts to plain dicts for JSON serialization
+    return [dict(node) for node in tree]
+
+
+@router.get("/coverage")
+async def taxonomy_coverage(
+    org_id: str = Query(..., description="Zitadel org ID"),
+    kb_slug: str = Query(..., description="KB slug"),
+) -> dict:
+    """Return the taxonomy tagging coverage ratio for the KB.
+
+    Returns {"coverage": 0.0} on any DB error (fail-open).
+    """
+    coverage = await get_kb_taxonomy_coverage(org_id, kb_slug)
+    return {"coverage": coverage}

--- a/klai-retrieval-api/retrieval_api/main.py
+++ b/klai-retrieval-api/retrieval_api/main.py
@@ -13,6 +13,7 @@ from starlette.middleware.cors import CORSMiddleware
 
 from retrieval_api.api.chat import router as chat_router
 from retrieval_api.api.retrieve import router as retrieve_router
+from retrieval_api.api.taxonomy import router as taxonomy_router
 from retrieval_api.config import settings
 from retrieval_api.logging_setup import RequestContextMiddleware, setup_logging
 from retrieval_api.middleware.auth import AuthMiddleware
@@ -90,6 +91,7 @@ app.add_middleware(
 )
 app.include_router(retrieve_router, prefix="")
 app.include_router(chat_router, prefix="")
+app.include_router(taxonomy_router, prefix="")
 
 # Prometheus metrics endpoint — scraped by Grafana Alloy → VictoriaMetrics
 app.mount("/metrics", make_asgi_app())

--- a/klai-retrieval-api/retrieval_api/services/taxonomy_lookup.py
+++ b/klai-retrieval-api/retrieval_api/services/taxonomy_lookup.py
@@ -1,0 +1,164 @@
+"""Taxonomy tree and coverage helpers for query-time taxonomy filtering.
+
+Fetches the KB taxonomy tree and coverage stats from the klai database via the
+shared asyncpg pool (events.py pool). Results are cached in-process with TTLs:
+
+  - Taxonomy tree: 60 s per (org_id, kb_slug)
+  - Coverage ratio: 300 s per (org_id, kb_slug)
+
+All functions are fail-open: on any DB error they return empty / 0.0 so
+retrieval proceeds without taxonomy narrowing (SPEC-RAG-TAXONOMY-001 REQ-2).
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TypedDict
+
+import structlog
+
+logger = structlog.get_logger()
+
+# ---------------------------------------------------------------------------
+# In-process TTL caches
+# ---------------------------------------------------------------------------
+
+# (org_id, kb_slug) -> (expires_at: float, value: list[dict])
+_tree_cache: dict[tuple[str, str], tuple[float, list[dict]]] = {}
+_TREE_TTL: float = 60.0  # seconds
+
+# (org_id, kb_slug) -> (expires_at: float, coverage: float)
+_coverage_cache: dict[tuple[str, str], tuple[float, float]] = {}
+_COVERAGE_TTL: float = 300.0  # 5 minutes
+
+
+class TaxonomyNode(TypedDict):
+    id: int
+    name: str
+    parent_id: int | None
+    depth: int
+
+
+# ---------------------------------------------------------------------------
+# SQL queries
+# ---------------------------------------------------------------------------
+
+# Returns the flat taxonomy tree for a KB.
+# Tables: portal_orgs (for zitadel_org_id→id resolution), portal_kb_nodes
+_TREE_SQL = """
+    SELECT
+        n.id,
+        n.name,
+        n.parent_id,
+        n.depth
+    FROM portal_kb_nodes n
+    JOIN portal_kbs kb ON kb.id = n.kb_id
+    JOIN portal_orgs org ON org.id = kb.org_id
+    WHERE org.zitadel_org_id = $1
+      AND kb.slug = $2
+    ORDER BY n.depth, n.id
+"""
+
+# Coverage = fraction of chunks in the KB that have at least one taxonomy_node_id tagged.
+# We proxy "tagged" chunks via `knowledge.artifacts` rows that have taxonomy_node_ids
+# set. The query is intentionally simple and approximate.
+_COVERAGE_SQL = """
+    SELECT
+        COUNT(*) FILTER (
+            WHERE a.extra->'taxonomy_node_ids' IS NOT NULL
+              AND jsonb_array_length(a.extra->'taxonomy_node_ids') > 0
+        )::float
+            / NULLIF(COUNT(*), 0) AS coverage_ratio
+    FROM knowledge.artifacts a
+    JOIN portal_kbs kb ON kb.slug = a.kb_slug
+    JOIN portal_orgs org ON org.id = kb.org_id
+    WHERE org.zitadel_org_id = $1
+      AND a.kb_slug = $2
+"""
+
+
+async def get_taxonomy_tree(org_id: str, kb_slug: str) -> list[TaxonomyNode]:
+    """Return the flat taxonomy node list for the KB, cached 60 s.
+
+    Returns an empty list on any error (fail-open per REQ-2).
+    """
+    cache_key = (org_id, kb_slug)
+    now = time.monotonic()
+
+    entry = _tree_cache.get(cache_key)
+    if entry is not None:
+        expires_at, cached_tree = entry
+        if now < expires_at:
+            return cached_tree
+
+    # Cache miss — fetch from DB
+    try:
+        from retrieval_api.services.events import _pool
+
+        if _pool is None:
+            logger.debug(
+                "taxonomy_lookup_skipped",
+                reason="no_db_pool",
+                org_id=org_id,
+                kb_slug=kb_slug,
+            )
+            return []
+
+        rows = await _pool.fetch(_TREE_SQL, org_id, kb_slug)
+        tree: list[TaxonomyNode] = [
+            TaxonomyNode(
+                id=row["id"],
+                name=row["name"],
+                parent_id=row["parent_id"],
+                depth=row["depth"],
+            )
+            for row in rows
+        ]
+    except Exception:
+        logger.warning(
+            "taxonomy_tree_fetch_failed",
+            org_id=org_id,
+            kb_slug=kb_slug,
+            exc_info=True,
+        )
+        return []
+
+    _tree_cache[cache_key] = (now + _TREE_TTL, tree)
+    return tree
+
+
+async def get_kb_taxonomy_coverage(org_id: str, kb_slug: str) -> float:
+    """Return the fraction of KB artifacts that have taxonomy tags, cached 5 min.
+
+    Returns 0.0 on any error (fail-open — caller skips filter when coverage is low).
+    """
+    cache_key = (org_id, kb_slug)
+    now = time.monotonic()
+
+    entry = _coverage_cache.get(cache_key)
+    if entry is not None:
+        expires_at, cached_cov = entry
+        if now < expires_at:
+            return cached_cov
+
+    try:
+        from retrieval_api.services.events import _pool
+
+        if _pool is None:
+            return 0.0
+
+        row = await _pool.fetchrow(_COVERAGE_SQL, org_id, kb_slug)
+        coverage: float = (
+            float(row["coverage_ratio"]) if row and row["coverage_ratio"] is not None else 0.0
+        )
+    except Exception:
+        logger.warning(
+            "taxonomy_coverage_fetch_failed",
+            org_id=org_id,
+            kb_slug=kb_slug,
+            exc_info=True,
+        )
+        coverage = 0.0
+
+    _coverage_cache[cache_key] = (now + _COVERAGE_TTL, coverage)
+    return coverage

--- a/klai-retrieval-api/tests/test_taxonomy_lookup.py
+++ b/klai-retrieval-api/tests/test_taxonomy_lookup.py
@@ -1,0 +1,266 @@
+"""SPEC-RAG-TAXONOMY-001 — taxonomy_lookup.py unit tests.
+
+Tests tree fetch, coverage fetch, in-process cache, and fail-open behaviour.
+All tests mock the asyncpg pool so no real DB is needed.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    """Reset in-process TTL caches before each test to prevent cross-test pollution."""
+    from retrieval_api.services import taxonomy_lookup
+
+    taxonomy_lookup._tree_cache.clear()
+    taxonomy_lookup._coverage_cache.clear()
+    yield
+    taxonomy_lookup._tree_cache.clear()
+    taxonomy_lookup._coverage_cache.clear()
+
+
+def _make_pool_mock(
+    fetch_rows=None, fetchrow_value=None, raise_on_fetch=False, raise_on_fetchrow=False
+):
+    """Build a minimal asyncpg Pool mock.
+
+    ``fetch_rows`` is the list of row-like dicts returned by pool.fetch().
+    ``fetchrow_value`` is the dict returned by pool.fetchrow().
+    """
+
+    class _FakeRow(dict):
+        def __getitem__(self, key):
+            return super().__getitem__(key)
+
+    class _FakePool:
+        async def fetch(self, sql, *args):
+            if raise_on_fetch:
+                raise RuntimeError("DB exploded")
+            return [_FakeRow(r) for r in (fetch_rows or [])]
+
+        async def fetchrow(self, sql, *args):
+            if raise_on_fetchrow:
+                raise RuntimeError("DB exploded")
+            if fetchrow_value is None:
+                return None
+            return _FakeRow(fetchrow_value)
+
+    return _FakePool()
+
+
+# ---------------------------------------------------------------------------
+# get_taxonomy_tree
+# ---------------------------------------------------------------------------
+
+
+class TestGetTaxonomyTree:
+    @pytest.mark.asyncio
+    async def test_returns_tree_from_db(self, monkeypatch):
+        """Happy path: pool.fetch returns rows → list of TaxonomyNode dicts."""
+        rows = [
+            {"id": 1, "name": "Root", "parent_id": None, "depth": 0},
+            {"id": 2, "name": "Child", "parent_id": 1, "depth": 1},
+        ]
+        pool = _make_pool_mock(fetch_rows=rows)
+        monkeypatch.setattr("retrieval_api.services.events._pool", pool)
+
+        from retrieval_api.services.taxonomy_lookup import get_taxonomy_tree
+
+        result = await get_taxonomy_tree("org-1", "my-kb")
+
+        assert len(result) == 2
+        assert result[0]["id"] == 1
+        assert result[0]["name"] == "Root"
+        assert result[0]["parent_id"] is None
+        assert result[0]["depth"] == 0
+        assert result[1]["id"] == 2
+        assert result[1]["parent_id"] == 1
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_pool_is_none(self, monkeypatch):
+        """No DB pool → fail-open, return []."""
+        monkeypatch.setattr("retrieval_api.services.events._pool", None)
+
+        from retrieval_api.services.taxonomy_lookup import get_taxonomy_tree
+
+        result = await get_taxonomy_tree("org-1", "my-kb")
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_db_error(self, monkeypatch):
+        """DB exception → fail-open, return []."""
+        pool = _make_pool_mock(raise_on_fetch=True)
+        monkeypatch.setattr("retrieval_api.services.events._pool", pool)
+
+        from retrieval_api.services.taxonomy_lookup import get_taxonomy_tree
+
+        result = await get_taxonomy_tree("org-1", "my-kb")
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_skips_db(self, monkeypatch):
+        """Second call with same (org_id, kb_slug) returns cached result without hitting DB."""
+        rows = [{"id": 42, "name": "Cached", "parent_id": None, "depth": 0}]
+        pool = _make_pool_mock(fetch_rows=rows)
+        monkeypatch.setattr("retrieval_api.services.events._pool", pool)
+
+        from retrieval_api.services.taxonomy_lookup import get_taxonomy_tree
+
+        # First call — populates cache
+        first = await get_taxonomy_tree("org-c", "kb-c")
+        assert len(first) == 1
+
+        # Swap pool to one that raises — should NOT be called
+        bad_pool = _make_pool_mock(raise_on_fetch=True)
+        monkeypatch.setattr("retrieval_api.services.events._pool", bad_pool)
+
+        # Second call — must come from cache
+        second = await get_taxonomy_tree("org-c", "kb-c")
+        assert second == first
+
+    @pytest.mark.asyncio
+    async def test_expired_cache_refetches(self, monkeypatch):
+        """Cache entry past TTL triggers a fresh fetch."""
+        rows = [{"id": 7, "name": "Fresh", "parent_id": None, "depth": 0}]
+        pool = _make_pool_mock(fetch_rows=rows)
+        monkeypatch.setattr("retrieval_api.services.events._pool", pool)
+
+        from retrieval_api.services import taxonomy_lookup
+        from retrieval_api.services.taxonomy_lookup import get_taxonomy_tree
+
+        # Pre-seed cache with an already-expired entry
+        taxonomy_lookup._tree_cache[("org-e", "kb-e")] = (
+            time.monotonic() - 1.0,  # already expired
+            [{"id": 99, "name": "Stale", "parent_id": None, "depth": 0}],
+        )
+
+        result = await get_taxonomy_tree("org-e", "kb-e")
+
+        # Should have fetched fresh from DB
+        assert result[0]["id"] == 7
+        assert result[0]["name"] == "Fresh"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_for_kb_with_no_nodes(self, monkeypatch):
+        """DB returns zero rows → empty list (no tree)."""
+        pool = _make_pool_mock(fetch_rows=[])
+        monkeypatch.setattr("retrieval_api.services.events._pool", pool)
+
+        from retrieval_api.services.taxonomy_lookup import get_taxonomy_tree
+
+        result = await get_taxonomy_tree("org-1", "empty-kb")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# get_kb_taxonomy_coverage
+# ---------------------------------------------------------------------------
+
+
+class TestGetKbTaxonomyCoverage:
+    @pytest.mark.asyncio
+    async def test_returns_coverage_from_db(self, monkeypatch):
+        """Happy path: pool.fetchrow returns a coverage_ratio → float returned."""
+        pool = _make_pool_mock(fetchrow_value={"coverage_ratio": 0.72})
+        monkeypatch.setattr("retrieval_api.services.events._pool", pool)
+
+        from retrieval_api.services.taxonomy_lookup import get_kb_taxonomy_coverage
+
+        result = await get_kb_taxonomy_coverage("org-1", "my-kb")
+        assert abs(result - 0.72) < 1e-6
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_when_pool_is_none(self, monkeypatch):
+        """No pool → 0.0 (fail-open)."""
+        monkeypatch.setattr("retrieval_api.services.events._pool", None)
+
+        from retrieval_api.services.taxonomy_lookup import get_kb_taxonomy_coverage
+
+        result = await get_kb_taxonomy_coverage("org-1", "my-kb")
+        assert result == 0.0
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_on_db_error(self, monkeypatch):
+        """DB exception → 0.0 (fail-open)."""
+        pool = _make_pool_mock(raise_on_fetchrow=True)
+        monkeypatch.setattr("retrieval_api.services.events._pool", pool)
+
+        from retrieval_api.services.taxonomy_lookup import get_kb_taxonomy_coverage
+
+        result = await get_kb_taxonomy_coverage("org-1", "my-kb")
+        assert result == 0.0
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_when_coverage_ratio_is_null(self, monkeypatch):
+        """DB returns coverage_ratio=NULL (empty KB) → 0.0."""
+        pool = _make_pool_mock(fetchrow_value={"coverage_ratio": None})
+        monkeypatch.setattr("retrieval_api.services.events._pool", pool)
+
+        from retrieval_api.services.taxonomy_lookup import get_kb_taxonomy_coverage
+
+        result = await get_kb_taxonomy_coverage("org-1", "empty-kb")
+        assert result == 0.0
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_when_fetchrow_returns_none(self, monkeypatch):
+        """DB returns no row at all → 0.0."""
+        pool = _make_pool_mock(fetchrow_value=None)
+        monkeypatch.setattr("retrieval_api.services.events._pool", pool)
+
+        from retrieval_api.services.taxonomy_lookup import get_kb_taxonomy_coverage
+
+        result = await get_kb_taxonomy_coverage("org-1", "no-kb")
+        assert result == 0.0
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_skips_db(self, monkeypatch):
+        """Second call returns cached coverage without hitting DB again."""
+        pool = _make_pool_mock(fetchrow_value={"coverage_ratio": 0.55})
+        monkeypatch.setattr("retrieval_api.services.events._pool", pool)
+
+        from retrieval_api.services.taxonomy_lookup import get_kb_taxonomy_coverage
+
+        first = await get_kb_taxonomy_coverage("org-cc", "kb-cc")
+        assert abs(first - 0.55) < 1e-6
+
+        # Replace pool with one that raises — must not be reached
+        bad_pool = _make_pool_mock(raise_on_fetchrow=True)
+        monkeypatch.setattr("retrieval_api.services.events._pool", bad_pool)
+
+        second = await get_kb_taxonomy_coverage("org-cc", "kb-cc")
+        assert abs(second - 0.55) < 1e-6
+
+    @pytest.mark.asyncio
+    async def test_different_kb_slugs_are_cached_independently(self, monkeypatch):
+        """Each (org_id, kb_slug) pair has its own cache entry."""
+        call_count = 0
+
+        class _CountingPool:
+            async def fetchrow(self, sql, org_id, kb_slug):
+                nonlocal call_count
+                call_count += 1
+                return {"coverage_ratio": 0.3 if kb_slug == "kb-a" else 0.8}
+
+        monkeypatch.setattr("retrieval_api.services.events._pool", _CountingPool())
+
+        from retrieval_api.services.taxonomy_lookup import get_kb_taxonomy_coverage
+
+        cov_a = await get_kb_taxonomy_coverage("org-1", "kb-a")
+        cov_b = await get_kb_taxonomy_coverage("org-1", "kb-b")
+
+        assert abs(cov_a - 0.3) < 1e-6
+        assert abs(cov_b - 0.8) < 1e-6
+        assert call_count == 2  # one fetch each
+
+        # Cached now — no more DB calls
+        await get_kb_taxonomy_coverage("org-1", "kb-a")
+        await get_kb_taxonomy_coverage("org-1", "kb-b")
+        assert call_count == 2


### PR DESCRIPTION
## Summary

- Closes the gap between ingest-time taxonomy classification (`taxonomy_node_ids` already written to Qdrant) and query-time filtering (Qdrant ANY-of filter existed in `_scope_filter` but was never invoked).
- Adds a combined **rewrite + classify** single Mistral JSON-mode call in the LiteLLM hook (`_rewrite_and_classify`) so taxonomy narrowing costs zero extra LLM roundtrips (REQ-5, REQ-6).
- Introduces in-process TTL caches in retrieval-api (`taxonomy_lookup.py`) — 60 s for the tree, 300 s for coverage — and exposes them via `GET /internal/v1/taxonomy/tree` and `/coverage`.
- Anti-hallucination guard (REQ-4): any node ID returned by the LLM that does not appear in the fetched tree is dropped silently.
- Fail-open everywhere (REQ-2): empty tree, low coverage, LLM error, or DB error all result in retrieval proceeding without taxonomy narrowing.

## Scope

| File | Change |
|---|---|
| `deploy/litellm/klai_knowledge.py` | Added `_rewrite_and_classify`, `_fetch_taxonomy_tree`, `_fetch_taxonomy_coverage`, `_format_taxonomy_for_prompt`; modified hook body to use `asyncio.gather` for parallel fetch + inject `taxonomy_node_ids` when coverage ≥ threshold |
| `klai-retrieval-api/retrieval_api/services/taxonomy_lookup.py` | New — DB queries + TTL caches via shared asyncpg pool |
| `klai-retrieval-api/retrieval_api/api/taxonomy.py` | New — internal FastAPI router (`/internal/v1/taxonomy/tree`, `/coverage`) |
| `klai-retrieval-api/retrieval_api/main.py` | Registers taxonomy router |
| `deploy/litellm/tests/test_taxonomy_classify.py` | New — 24 tests for classify + fetch helpers + prompt formatting |
| `klai-retrieval-api/tests/test_taxonomy_lookup.py` | New — 13 tests for tree/coverage fetch, cache hit/miss/expiry, fail-open |

## Test plan

- [x] `deploy/litellm/tests/test_taxonomy_classify.py` — 24 tests all green
- [x] `klai-retrieval-api/tests/test_taxonomy_lookup.py` — 13 tests all green
- [x] `klai-retrieval-api/tests/test_taxonomy_filter.py` — 11 existing model tests unchanged, all green
- [x] `ruff check` + `ruff format --check` — clean on all 6 touched files
- [x] No real network calls in tests — httpx `AsyncBaseTransport` and asyncpg pool mocks throughout
- [ ] Post-deploy: verify `taxonomy_classify` log events appear in VictoriaLogs with `was_applied=True` after enabling TAXONOMY_ENABLED on core-01

## Deploy notes

New env vars (all optional, fail-open defaults):

| Var | Default | Purpose |
|---|---|---|
| `TAXONOMY_ENABLED` | `true` | Master switch; set `false` to disable entirely |
| `KLAI_TAXONOMY_COVERAGE_THRESHOLD` | `0.30` | Skip filter when < 30% of chunks are tagged |
| `TAXONOMY_FETCH_TIMEOUT` | `0.8` | Per-fetch timeout to retrieval-api (seconds) |

No DB migrations. No schema changes. Retrieval-api reads from existing `portal_kb_nodes` and `knowledge.artifacts` tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)