### PR TITLE
feat(rag): SPEC-RAG-REBUILD-KB-001 — operator-triggered KB rebuild backfill

### DIFF
--- a/docs/runbooks/rebuild-kb.md
+++ b/docs/runbooks/rebuild-kb.md
@@ -1,0 +1,204 @@
+# Runbook: Operator-Triggered KB Rebuild (`rebuild_kb`)
+
+**SPEC:** SPEC-RAG-REBUILD-KB-001  
+**Service:** `klai-knowledge-ingest`  
+**Queue:** `rebuild-kb` (LLM lane)  
+**Author:** operator  
+
+---
+
+## When to run
+
+Run `rebuild_kb` after deploying **pipeline changes that alter how chunks are produced**:
+
+| SPEC | Change | Rebuild needed? |
+|------|--------|----------------|
+| SPEC-RAG-CONTEXTUAL-001 | Chunk enrichment now uses a per-document `document_summary` instead of the full document body in the context prompt | Yes — existing chunks have no summary-driven prefix |
+| SPEC-RAG-PARENT-CHILD-001 | Chunks are now produced as small child + large parent pairs; parents persisted to `knowledge.parent_chunks` | Yes — existing artifacts have no `parent_chunks` rows |
+| SPEC-RAG-TAXONOMY-001 | Retrieval changes only, no ingest change | No |
+
+Do **not** run for:
+- Retrieval-only changes (reranker tuning, search weight adjustments)
+- Portal UI changes
+- Connector changes that do not alter chunk content
+
+---
+
+## Pre-flight checklist
+
+Before triggering the rebuild:
+
+1. **Confirm the SPEC migrations have been applied.** The rebuild writes to
+   `knowledge.parent_chunks` — this table is created by migration `015_parent_chunks.sql`.
+   Check on core-01:
+   ```bash
+   ssh core-01 "docker exec klai-core-postgres-1 sh -c \
+     'psql -U \$POSTGRES_USER -d \$POSTGRES_DB -c \
+     \"SELECT to_regclass(\\\"public.knowledge.parent_chunks\\\");\"'"
+   ```
+   Expected: non-null result. If NULL, the migration has not run — do not proceed.
+
+2. **Confirm knowledge-ingest is on the expected image.**
+   ```bash
+   ssh core-01 "docker exec klai-core-knowledge-ingest-1 python -c \
+     'from knowledge_ingest.rebuild_tasks import rebuild_kb_inline; print(\"OK\")"'
+   ```
+   Expected output: `OK`. If ImportError, the container is running an old image.
+
+3. **Check the LLM queue backlog.**
+   A pre-existing `enrich-bulk` backlog will contend with the rebuild LLM calls.
+   Check how many jobs are pending:
+   ```bash
+   ssh core-01 "docker exec klai-core-postgres-1 sh -c \
+     'psql -U \$POSTGRES_USER -d \$POSTGRES_DB -c \
+     \"SELECT queue, status, count(*) FROM procrastinate_jobs GROUP BY 1,2 ORDER BY 1,2;\"'"
+   ```
+
+4. **Estimate cost before proceeding.** See the cost section below.
+
+---
+
+## How to trigger
+
+### Option A — inline (recommended for operators, visible progress)
+
+```bash
+ssh core-01 "docker exec klai-core-knowledge-ingest-1 \
+  python -c 'import asyncio; \
+             from knowledge_ingest.rebuild_tasks import rebuild_kb_inline; \
+             result = asyncio.run(rebuild_kb_inline(\"<org_zitadel_id>\", \"<kb_slug>\")); \
+             print(result)'"
+```
+
+Replace `<org_zitadel_id>` with the Zitadel organisation ID (found in portal-api logs or the `portal_orgs` table) and `<kb_slug>` with the KB slug (e.g. `voys-support`).
+
+The function runs synchronously and prints a result dict on completion:
+
+```json
+{
+  "org_id": "...",
+  "kb_slug": "...",
+  "artifacts_processed": 42,
+  "artifacts_skipped": 3,
+  "artifacts_failed": 0,
+  "duration_ms": 180000
+}
+```
+
+### Option B — via Procrastinate queue
+
+Enqueues the task on the `rebuild-kb` queue; the worker picks it up within seconds.
+
+```bash
+ssh core-01 "docker exec klai-core-knowledge-ingest-1 \
+  python -c 'import asyncio, procrastinate, procrastinate.contrib.django; \
+             from knowledge_ingest.enrichment_tasks import get_app; \
+             app = get_app(); \
+             asyncio.run( \
+               app.rebuild_kb.configure( \
+                 queueing_lock=\"rebuild-kb-<org_id>-<kb_slug>\" \
+               ).defer_async(org_id=\"<org_id>\", kb_slug=\"<kb_slug>\") \
+             )'"
+```
+
+**Note:** If a rebuild is already queued or running for this KB, `AlreadyEnqueued` is raised — do not bypass, wait for the running job to finish.
+
+---
+
+## How to monitor
+
+### VictoriaLogs queries
+
+```
+# Overall progress
+service:knowledge-ingest AND event:rebuild_kb_*
+
+# Single artifact outcomes
+service:knowledge-ingest AND event:rebuild_artifact_processed AND kb_slug:<slug>
+service:knowledge-ingest AND event:rebuild_skip_no_text AND kb_slug:<slug>
+service:knowledge-ingest AND event:rebuild_artifact_failed AND kb_slug:<slug>
+
+# Completion summary
+service:knowledge-ingest AND event:rebuild_kb_completed AND kb_slug:<slug>
+```
+
+### Expected log sequence
+
+1. `rebuild_kb_started` — task begins
+2. `rebuild_kb_artifacts_found` — total artifact count
+3. Per artifact: `rebuild_artifact_processed` / `rebuild_skip_no_text` / `rebuild_artifact_failed`
+4. `rebuild_kb_completed` — summary with counts and duration
+
+### Procrastinate job status (Option B only)
+
+```bash
+ssh core-01 "docker exec klai-core-postgres-1 sh -c \
+  'psql -U \$POSTGRES_USER -d \$POSTGRES_DB -c \
+  \"SELECT id, status, queueing_lock, attempts, errors \
+    FROM procrastinate_jobs WHERE queue = \\\"rebuild-kb\\\" ORDER BY id DESC LIMIT 5;\"'"
+```
+
+---
+
+## Cost estimate
+
+Per artifact cost breakdown (approximate):
+
+| Step | Model | Cost/artifact |
+|------|-------|--------------|
+| document_summary (SPEC-RAG-CONTEXTUAL-001) | `klai-medium` | ~€0.0002 |
+| chunk enrichment (context prefix + HyPE questions) | `klai-fast` | ~€0.0005 |
+| **Total** | | **~€0.0007/artifact** |
+
+For Voys's 501 active artifacts: **~€0.35 per full rebuild**.
+
+Costs are approximate and depend on chunk count per document and the LiteLLM proxy cache hit rate. Repeated rebuilds with unchanged content benefit from cache hits on document_summary generation.
+
+---
+
+## Skipped artifacts
+
+Artifacts without `extra.document_text` are skipped silently with a `rebuild_skip_no_text` log event. This is expected behaviour in v1.
+
+**Why this happens:** The default ingest pipeline does not currently write `document_text` to `knowledge.artifacts.extra`. See the OPEN QUESTION in `knowledge_ingest/rebuild_tasks.py` docstring. A follow-up SPEC will address this by either:
+- storing `document_text` in `extra` during initial ingest, or
+- adding per-connector re-fetch adapters.
+
+Until that follow-up ships, only artifacts where a connector explicitly wrote `document_text` into `extra` (e.g. direct KB uploads via the portal) will be rebuilt.
+
+---
+
+## Failure handling
+
+- **Fail-open per artifact:** One failed artifact does not abort the rebuild. The error is logged as `rebuild_artifact_failed` and counted in `artifacts_failed`.
+- **Re-running is safe:** The rebuild is fully idempotent. Trigger it again after fixing the root cause of failures.
+- **Failures-only re-run:** Not supported in v1 — a full KB re-run is always performed. Track in follow-up SPEC.
+
+### Common failure causes
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `rebuild_artifact_failed` with `EnrichmentError` | LiteLLM rate limit or model unavailable | Wait, re-run |
+| `rebuild_artifact_failed` with `UndefinedColumnError` | `knowledge.parent_chunks` table missing | Apply migration 015, re-run |
+| All artifacts skipped | `document_text` not stored on `extra` | See "Skipped artifacts" above |
+| `AlreadyEnqueued` | Rebuild already queued for this KB | Wait for running job, re-run after |
+
+---
+
+## Rollback
+
+The rebuild is non-destructive in the sense that Qdrant chunks are replaced atomically per-path (delete-then-insert), so rolling back is another rebuild with the previous code.
+
+If the pipeline version that introduced an issue needs to be rolled back:
+
+1. Roll back the knowledge-ingest image to the previous tag (see `version-management.md`).
+2. Re-run `rebuild_kb` against the rolled-back image.
+
+---
+
+## Related
+
+- `docs/runbooks/rag-quality.md` — general RAG quality debugging
+- SPEC-RAG-CONTEXTUAL-001 — document_summary enrichment
+- SPEC-RAG-PARENT-CHILD-001 — parent-child chunking
+- `knowledge_ingest/rebuild_tasks.py` — source code with full design notes

--- a/klai-knowledge-ingest/knowledge_ingest/enrichment_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/enrichment_tasks.py
@@ -90,6 +90,11 @@ def init_app(connector: Any) -> Any:
 
     register_eval_tasks(_procrastinate_app)
 
+    # SPEC-RAG-REBUILD-KB-001: operator-triggered KB rebuild backfill task.
+    from knowledge_ingest.rebuild_tasks import register_rebuild_tasks
+
+    register_rebuild_tasks(_procrastinate_app)
+
     return _procrastinate_app
 
 

--- a/klai-knowledge-ingest/knowledge_ingest/queues.py
+++ b/klai-knowledge-ingest/knowledge_ingest/queues.py
@@ -63,6 +63,10 @@ RAG_EVAL = "rag-eval"
 TAXONOMY_BACKFILL = "taxonomy-backfill"
 """One-shot backfill jobs (clustering, taxonomy)."""
 
+REBUILD_KB = "rebuild-kb"
+"""Operator-triggered KB rebuild backfill (SPEC-RAG-REBUILD-KB-001).
+LLM-bound: many per-artifact enrichment calls; runs on the LLM lane."""
+
 
 # --- Worker lanes -----------------------------------------------------------
 #
@@ -93,6 +97,7 @@ LLM_QUEUES: list[str] = [
     GRAPHITI_BULK,
     RAG_EVAL,
     TAXONOMY_BACKFILL,
+    REBUILD_KB,
 ]
 """Throughput-bound LLM work — bounded by upstream rate limit."""
 

--- a/klai-knowledge-ingest/knowledge_ingest/rebuild_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/rebuild_tasks.py
@@ -1,0 +1,319 @@
+"""
+Operator-triggered KB rebuild task (SPEC-RAG-REBUILD-KB-001).
+
+Brings ALL existing artifacts in a KB up to the current pipeline by
+re-running chunking, enrichment, embedding, and Qdrant upsert for every
+active artifact.
+
+When to use
+-----------
+After deploying pipeline changes that alter how chunks are produced:
+  - SPEC-RAG-CONTEXTUAL-001 (merged): document_summary-driven context prefix.
+  - SPEC-RAG-PARENT-CHILD-001 (merged): child + parent chunk pairs stored in
+    ``knowledge.parent_chunks``.
+
+Idempotency
+-----------
+Re-running with unchanged content yields the same output. The LiteLLM proxy
+may cache summary generation; chunking and enrichment are deterministic per
+input. Qdrant upsert uses delete-then-insert per path — no orphans.
+
+Queues
+------
+REBUILD_KB (LLM lane) — many per-artifact LLM calls; bounded by upstream
+rate limit via semaphore inside ``_rebuild_artifact``.
+
+Concurrency
+-----------
+A bounded asyncio.Semaphore (default: 4) throttles concurrent per-artifact
+rebuilds to keep LiteLLM happy under the daily token budget.
+
+Queueing lock
+-------------
+``queueing_lock=f"rebuild-kb-{org_id}-{kb_slug}"`` ensures concurrent
+rebuild tasks for the same KB are blocked (``AlreadyEnqueued`` raised at
+defer time — caller should surface this as a 409-equivalent).
+
+Source text (v1 scope)
+----------------------
+Reads document text from ``knowledge.artifacts.extra->>'document_text'``.
+Artifacts without this field are skipped and counted in ``artifacts_skipped``
+with a ``rebuild_skip_no_text`` log event.
+
+OPEN QUESTION: ``document_text`` is not currently stored on
+``knowledge.artifacts.extra`` by the default ingest pipeline. Most existing
+artifacts will have ``document_text`` absent and will be skipped. A follow-up
+SPEC should either:
+  a) store ``document_text`` in ``extra`` during initial ingest, or
+  b) provide a per-connector re-fetch adapter (more complex, out of v1 scope).
+Until that lands, this task is primarily useful for artifacts where the
+connector explicitly wrote ``document_text`` into extra (e.g. KB connector
+direct uploads, some Notion pages where content was persisted for future
+reprocessing).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from typing import Any
+
+import structlog
+
+from knowledge_ingest import queues
+
+logger = structlog.get_logger()
+
+# Maximum concurrent per-artifact rebuilds — keeps LiteLLM rate-limit happy.
+_SEMAPHORE_LIMIT = 4
+
+# Sentinel value for "still active" belief_time_end (mirrors pg_store._SENTINEL).
+_SENTINEL = 253402300800
+
+
+def register_rebuild_tasks(procrastinate_app: Any) -> None:
+    """Register the rebuild_kb Procrastinate task on the given App instance.
+
+    Called from ``enrichment_tasks.init_app()`` alongside other task
+    registrations. No automatic retry — operators retrigger manually after
+    fixing the root cause. Idempotency ensures a re-run is always safe.
+    """
+    import procrastinate
+
+    # @MX:ANCHOR: public Procrastinate task — queueing_lock guarantees at most
+    # @MX:REASON: one concurrent rebuild per (org_id, kb_slug) pair; callers
+    #             in tests and the runbook both rely on AlreadyEnqueued being
+    #             raised on duplicate defer.
+    @procrastinate_app.task(
+        queue=queues.REBUILD_KB,
+        retry=procrastinate.RetryStrategy(max_attempts=1),
+    )
+    async def rebuild_kb(org_id: str, kb_slug: str) -> dict:
+        """Rebuild all active artifacts in a KB against the current pipeline.
+
+        Iterates every active artifact in (org_id, kb_slug); for each:
+          1. Reads document_text from extra JSONB — skips if absent.
+          2. Re-chunks with chunk_markdown_with_parents.
+          3. Re-runs _enrich_document (enrichment + TEI + sparse embedding +
+             Qdrant delete-then-upsert).
+          4. Replaces parent_chunks rows in PostgreSQL.
+
+        Returns ``{org_id, kb_slug, artifacts_processed, artifacts_skipped,
+                   artifacts_failed, duration_ms}``.
+        """
+        return await _rebuild_kb_core(org_id=org_id, kb_slug=kb_slug)
+
+    procrastinate_app.rebuild_kb = rebuild_kb  # type: ignore[attr-defined]
+
+
+async def rebuild_kb_inline(org_id: str, kb_slug: str) -> dict:
+    """Inline variant for operator runbook use (no Procrastinate queue).
+
+    Calls the same core logic as the Procrastinate task synchronously.
+    Useful for docker exec one-liners where you want direct output.
+
+    Example::
+
+        import asyncio
+        from knowledge_ingest.rebuild_tasks import rebuild_kb_inline
+        asyncio.run(rebuild_kb_inline("<org_zitadel_id>", "<kb_slug>"))
+    """
+    return await _rebuild_kb_core(org_id=org_id, kb_slug=kb_slug)
+
+
+async def _list_active_artifacts(org_id: str, kb_slug: str) -> list[dict]:
+    """Return all currently-active artifact rows for a KB.
+
+    Selects only rows with belief_time_end == _SENTINEL (still active).
+    """
+    from knowledge_ingest.db import get_pool
+
+    pool = await get_pool()
+    rows = await pool.fetch(
+        """
+        SELECT id, path, content_type, extra, synthesis_depth,
+               belief_time_start, belief_time_end, user_id
+        FROM knowledge.artifacts
+        WHERE org_id = $1
+          AND kb_slug = $2
+          AND belief_time_end = $3
+        ORDER BY created_at
+        """,
+        org_id,
+        kb_slug,
+        _SENTINEL,
+    )
+    return [dict(r) for r in rows]
+
+
+async def _rebuild_artifact(
+    *,
+    org_id: str,
+    kb_slug: str,
+    artifact: dict,
+    semaphore: asyncio.Semaphore,
+) -> str:
+    """Rebuild one artifact. Returns 'processed', 'skipped', or 'failed'.
+
+    Fail-open: exceptions are caught, logged, and counted as 'failed'
+    so that remaining artifacts in the KB continue processing.
+    """
+    artifact_id = str(artifact["id"])
+    path: str = artifact.get("path") or artifact_id
+
+    async with semaphore:
+        try:
+            # Parse extra JSONB. asyncpg may return it as str or dict.
+            raw_extra = artifact.get("extra")
+            extra: dict = {}
+            if raw_extra:
+                extra = json.loads(raw_extra) if isinstance(raw_extra, str) else dict(raw_extra)
+
+            document_text: str | None = extra.get("document_text")
+            if not document_text:
+                logger.info(
+                    "rebuild_skip_no_text",
+                    org_id=org_id,
+                    kb_slug=kb_slug,
+                    artifact_id=artifact_id,
+                    path=path,
+                )
+                return "skipped"
+
+            content_type: str = artifact.get("content_type") or "unknown"
+            synthesis_depth: int = artifact.get("synthesis_depth") or 0
+            user_id: str | None = artifact.get("user_id")
+            belief_time_start: int | None = artifact.get("belief_time_start")
+            belief_time_end: int | None = artifact.get("belief_time_end")
+            title = path
+
+            # Step 1: Re-chunk with parent-child chunking (SPEC-RAG-PARENT-CHILD-001).
+            from knowledge_ingest import chunker
+
+            child_chunks, parent_chunks_obj = chunker.chunk_markdown_with_parents(document_text)
+            child_texts = [c.text for c in child_chunks]
+
+            if not child_texts:
+                logger.info(
+                    "rebuild_skip_no_chunks",
+                    org_id=org_id,
+                    kb_slug=kb_slug,
+                    artifact_id=artifact_id,
+                    path=path,
+                )
+                return "skipped"
+
+            # Serialise ParentChunk dataclasses to the dict shape pg_store expects.
+            parents_serialised: list[dict] = [
+                {
+                    "text": p.text,
+                    "token_count": chunker._approx_token_count(p.text),
+                    "position": p.position,
+                }
+                for p in parent_chunks_obj
+            ]
+
+            # Build extra_payload matching the shape expected by _enrich_document.
+            # Carry through all original metadata so Qdrant payload stays consistent.
+            extra_payload: dict = dict(extra)
+            extra_payload.setdefault("belief_time_start", belief_time_start)
+            extra_payload.setdefault("belief_time_end", belief_time_end)
+
+            # Steps 2-3: enrichment + TEI/sparse embedding + Qdrant delete-then-upsert.
+            # _enrich_document handles all of this atomically for a single document.
+            from knowledge_ingest.enrichment_tasks import _enrich_document
+
+            await _enrich_document(
+                org_id=org_id,
+                kb_slug=kb_slug,
+                path=path,
+                document_text=document_text,
+                chunks=child_texts,
+                title=title,
+                artifact_id=artifact_id,
+                user_id=user_id,
+                extra_payload=extra_payload,
+                synthesis_depth=synthesis_depth,
+                content_type=content_type,
+            )
+
+            # Step 4: Replace parent_chunks rows in PostgreSQL.
+            from knowledge_ingest import pg_store
+
+            await pg_store.delete_parent_chunks_for_artifact(artifact_id)
+            if parents_serialised:
+                await pg_store.insert_parent_chunks(
+                    artifact_id=artifact_id,
+                    org_id=org_id,
+                    parents=parents_serialised,
+                )
+
+            logger.info(
+                "rebuild_artifact_processed",
+                org_id=org_id,
+                kb_slug=kb_slug,
+                artifact_id=artifact_id,
+                path=path,
+                children=len(child_texts),
+                parents=len(parents_serialised),
+            )
+            return "processed"
+
+        except Exception:
+            logger.exception(
+                "rebuild_artifact_failed",
+                org_id=org_id,
+                kb_slug=kb_slug,
+                artifact_id=artifact_id,
+                path=path,
+            )
+            return "failed"
+
+
+async def _rebuild_kb_core(org_id: str, kb_slug: str) -> dict:
+    """Core rebuild logic shared by the Procrastinate task and rebuild_kb_inline."""
+    t_start = time.monotonic()
+    logger.info("rebuild_kb_started", org_id=org_id, kb_slug=kb_slug)
+
+    artifacts = await _list_active_artifacts(org_id=org_id, kb_slug=kb_slug)
+    total = len(artifacts)
+    logger.info(
+        "rebuild_kb_artifacts_found",
+        org_id=org_id,
+        kb_slug=kb_slug,
+        total=total,
+    )
+
+    semaphore = asyncio.Semaphore(_SEMAPHORE_LIMIT)
+
+    # Process all artifacts concurrently, bounded by the semaphore.
+    # asyncio.gather propagates each artifact's outcome independently.
+    outcomes = await asyncio.gather(
+        *(
+            _rebuild_artifact(
+                org_id=org_id,
+                kb_slug=kb_slug,
+                artifact=artifact,
+                semaphore=semaphore,
+            )
+            for artifact in artifacts
+        )
+    )
+
+    processed = outcomes.count("processed")
+    skipped = outcomes.count("skipped")
+    failed = outcomes.count("failed")
+    duration_ms = int((time.monotonic() - t_start) * 1000)
+
+    result: dict = {
+        "org_id": org_id,
+        "kb_slug": kb_slug,
+        "artifacts_processed": processed,
+        "artifacts_skipped": skipped,
+        "artifacts_failed": failed,
+        "duration_ms": duration_ms,
+    }
+
+    logger.info("rebuild_kb_completed", **result)
+    return result

--- a/klai-knowledge-ingest/tests/test_rebuild_tasks.py
+++ b/klai-knowledge-ingest/tests/test_rebuild_tasks.py
@@ -1,0 +1,333 @@
+"""Tests for SPEC-RAG-REBUILD-KB-001: operator-triggered KB rebuild.
+
+Covers:
+  - test_rebuild_kb_iterates_artifacts: every active artifact triggers one rebuild call.
+  - test_rebuild_kb_skips_artifacts_without_text: rebuild_skip_no_text log path.
+  - test_rebuild_kb_propagates_failures_per_artifact: fail-open per artifact.
+  - test_rebuild_kb_queueing_lock: AlreadyEnqueued raised on duplicate defer.
+  - test_rebuild_kb_summary_log_event: rebuild_kb_completed log event shape.
+
+All tests mock external I/O — no real network, no real DB, no real Qdrant.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import structlog.testing
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_ORG = "org-zitadel-123"
+_KB = "my-kb"
+
+_SENTINEL = 253402300800
+
+
+def _make_artifact(artifact_id: str, path: str, document_text: str | None) -> dict:
+    """Build a minimal artifact dict as returned by _list_active_artifacts."""
+    extra: dict = {}
+    if document_text is not None:
+        extra["document_text"] = document_text
+    return {
+        "id": artifact_id,
+        "path": path,
+        "content_type": "kb_article",
+        "extra": extra,
+        "synthesis_depth": 0,
+        "belief_time_start": 1_700_000_000,
+        "belief_time_end": _SENTINEL,
+        "user_id": None,
+    }
+
+
+def _make_chunk(text: str = "chunk text", parent_index: int = 0) -> MagicMock:
+    """Return a mock Chunk object as returned by chunk_markdown_with_parents."""
+    c = MagicMock()
+    c.text = text
+    c.parent_index = parent_index
+    return c
+
+
+def _make_parent_chunk(text: str = "parent text", position: int = 0) -> MagicMock:
+    """Return a mock ParentChunk object."""
+    p = MagicMock()
+    p.text = text
+    p.position = position
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _patch_env(monkeypatch):
+    """Ensure required env vars are set before any knowledge_ingest import."""
+    monkeypatch.setenv("KNOWLEDGE_INGEST_SECRET", "test-secret-value-123")
+    monkeypatch.setenv("PORTAL_INTERNAL_TOKEN", "test-portal-internal-token-456")
+
+
+@pytest.fixture()
+def _common_patches():
+    """Patch all external I/O used by _rebuild_kb_core and _rebuild_artifact.
+
+    _rebuild_artifact uses lazy imports inside the function body:
+      from knowledge_ingest.enrichment_tasks import _enrich_document
+      from knowledge_ingest import chunker
+      from knowledge_ingest import pg_store
+
+    We patch at the source modules so the lazy imports pick up the mocks.
+    """
+    chunks = [_make_chunk("child text")]
+    parents = [_make_parent_chunk("parent text")]
+
+    mock_chunker = MagicMock()
+    mock_chunker.chunk_markdown_with_parents.return_value = (chunks, parents)
+    mock_chunker._approx_token_count.return_value = 50
+
+    mock_pg = MagicMock()
+    mock_pg.delete_parent_chunks_for_artifact = AsyncMock(return_value=1)
+    mock_pg.insert_parent_chunks = AsyncMock(return_value=[1])
+
+    mock_enrich = AsyncMock()
+
+    with (
+        patch(
+            "knowledge_ingest.rebuild_tasks._list_active_artifacts",
+            new_callable=AsyncMock,
+        ) as mock_list,
+        # Patch the lazy import targets so they resolve to our mocks.
+        patch.dict(
+            sys.modules,
+            {
+                "knowledge_ingest.enrichment_tasks": types.SimpleNamespace(
+                    _enrich_document=mock_enrich
+                ),
+                "knowledge_ingest.chunker": mock_chunker,
+                "knowledge_ingest.pg_store": mock_pg,
+            },
+        ),
+    ):
+        yield {
+            "mock_list": mock_list,
+            "mock_enrich": mock_enrich,
+            "mock_chunker": mock_chunker,
+            "mock_pg": mock_pg,
+            "chunks": chunks,
+            "parents": parents,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Test 1: iterates every active artifact
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rebuild_kb_iterates_artifacts(_common_patches):
+    """Every active artifact with document_text triggers one _enrich_document call."""
+    from knowledge_ingest.rebuild_tasks import _rebuild_kb_core
+
+    artifacts = [
+        _make_artifact("art-1", "doc1.md", "Text for doc 1"),
+        _make_artifact("art-2", "doc2.md", "Text for doc 2"),
+    ]
+    _common_patches["mock_list"].return_value = artifacts
+
+    result = await _rebuild_kb_core(org_id=_ORG, kb_slug=_KB)
+
+    assert result["artifacts_processed"] == 2
+    assert result["artifacts_skipped"] == 0
+    assert result["artifacts_failed"] == 0
+    assert _common_patches["mock_enrich"].call_count == 2
+
+    # Both artifacts must have been passed to _enrich_document
+    called_paths = {c.kwargs["path"] for c in _common_patches["mock_enrich"].call_args_list}
+    assert called_paths == {"doc1.md", "doc2.md"}
+
+
+# ---------------------------------------------------------------------------
+# Test 2: skips artifacts without document_text
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rebuild_kb_skips_artifacts_without_text(_common_patches):
+    """Artifacts without extra.document_text are skipped with rebuild_skip_no_text log."""
+    from knowledge_ingest.rebuild_tasks import _rebuild_kb_core
+
+    artifacts = [
+        _make_artifact("art-no-text", "no-text.md", None),  # no document_text
+        _make_artifact("art-with-text", "with-text.md", "Body"),
+    ]
+    _common_patches["mock_list"].return_value = artifacts
+
+    with structlog.testing.capture_logs() as captured:
+        result = await _rebuild_kb_core(org_id=_ORG, kb_slug=_KB)
+
+    assert result["artifacts_skipped"] == 1
+    assert result["artifacts_processed"] == 1
+    assert result["artifacts_failed"] == 0
+
+    skip_events = [e for e in captured if e["event"] == "rebuild_skip_no_text"]
+    assert len(skip_events) == 1
+    assert skip_events[0]["artifact_id"] == "art-no-text"
+
+    # Only the artifact with text should trigger enrichment
+    assert _common_patches["mock_enrich"].call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Test 3: one artifact failure does not abort the rest
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rebuild_kb_propagates_failures_per_artifact(_common_patches):
+    """When one artifact's enrichment raises, others still process; failed counted."""
+    from knowledge_ingest.rebuild_tasks import _rebuild_kb_core
+
+    artifacts = [
+        _make_artifact("art-bad", "bad.md", "Good text but enrich fails"),
+        _make_artifact("art-ok-1", "ok1.md", "Fine"),
+        _make_artifact("art-ok-2", "ok2.md", "Also fine"),
+    ]
+    _common_patches["mock_list"].return_value = artifacts
+
+    # Make the first artifact fail during enrichment
+    async def _side_effect(**kwargs):
+        if kwargs.get("artifact_id") == "art-bad":
+            raise RuntimeError("LLM timeout")
+
+    _common_patches["mock_enrich"].side_effect = _side_effect
+
+    result = await _rebuild_kb_core(org_id=_ORG, kb_slug=_KB)
+
+    assert result["artifacts_failed"] == 1
+    assert result["artifacts_processed"] == 2
+    assert result["artifacts_skipped"] == 0
+
+    # All three artifacts were attempted
+    assert _common_patches["mock_enrich"].call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# Test 4: queueing_lock prevents duplicate defers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rebuild_kb_queueing_lock():
+    """Deferring rebuild_kb twice for the same (org_id, kb_slug) raises AlreadyEnqueued.
+
+    Uses a fake procrastinate module (no psycopg dependency) to verify that
+    register_rebuild_tasks wires the task with queueing_lock semantics, and
+    that a second configure().defer_async() with the same lock raises the
+    exception class.
+    """
+
+    # Fake AlreadyEnqueued exception class (matches procrastinate.exceptions)
+    class _AlreadyEnqueued(Exception):
+        pass
+
+    # Track deferred tasks by queueing_lock
+    _deferred_locks: set[str] = set()
+
+    class _FakeConfigured:
+        def __init__(self, lock: str) -> None:
+            self._lock = lock
+
+        async def defer_async(self, **kwargs):
+            if self._lock in _deferred_locks:
+                raise _AlreadyEnqueued(f"Lock {self._lock} already enqueued")
+            _deferred_locks.add(self._lock)
+
+    class _FakeTask:
+        def configure(self, *, queueing_lock: str, **kwargs):
+            return _FakeConfigured(queueing_lock)
+
+    class _FakeApp:
+        def task(self, *, queue: str, retry=None):
+            def decorator(fn):
+                task_obj = _FakeTask()
+                task_obj._fn = fn
+                return task_obj
+
+            return decorator
+
+    # Inject the fake exceptions module so register_rebuild_tasks can import it
+    fake_proc_exc = types.SimpleNamespace(AlreadyEnqueued=_AlreadyEnqueued)
+    fake_proc = types.SimpleNamespace(
+        RetryStrategy=MagicMock(return_value=None),
+        exceptions=fake_proc_exc,
+    )
+
+    with patch.dict(
+        sys.modules,
+        {
+            "procrastinate": fake_proc,
+            "procrastinate.exceptions": fake_proc_exc,
+        },
+    ):
+        from knowledge_ingest.rebuild_tasks import register_rebuild_tasks
+
+        app = _FakeApp()
+        register_rebuild_tasks(app)
+
+        # The task was registered and is accessible
+        task = app.rebuild_kb  # type: ignore[attr-defined]
+
+        # First defer succeeds
+        await task.configure(queueing_lock=f"rebuild-kb-{_ORG}-{_KB}").defer_async(
+            org_id=_ORG, kb_slug=_KB
+        )
+
+        # Second defer for the same lock raises AlreadyEnqueued
+        with pytest.raises(_AlreadyEnqueued):
+            await task.configure(queueing_lock=f"rebuild-kb-{_ORG}-{_KB}").defer_async(
+                org_id=_ORG, kb_slug=_KB
+            )
+
+
+# ---------------------------------------------------------------------------
+# Test 5: rebuild_kb_completed log event shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rebuild_kb_summary_log_event(_common_patches):
+    """rebuild_kb_completed is logged with the expected result dict shape."""
+    from knowledge_ingest.rebuild_tasks import _rebuild_kb_core
+
+    _common_patches["mock_list"].return_value = [
+        _make_artifact("art-a", "a.md", "Text A"),
+    ]
+
+    with structlog.testing.capture_logs() as captured:
+        result = await _rebuild_kb_core(org_id=_ORG, kb_slug=_KB)
+
+    # Verify the returned dict has all required keys with correct types
+    assert result["org_id"] == _ORG
+    assert result["kb_slug"] == _KB
+    assert "artifacts_processed" in result
+    assert "artifacts_skipped" in result
+    assert "artifacts_failed" in result
+    assert "duration_ms" in result
+    assert isinstance(result["duration_ms"], int)
+
+    # Verify the structlog event was emitted with matching fields
+    completed_events = [e for e in captured if e["event"] == "rebuild_kb_completed"]
+    assert len(completed_events) == 1
+    evt = completed_events[0]
+    assert evt["org_id"] == _ORG
+    assert evt["kb_slug"] == _KB
+    assert evt["artifacts_processed"] == 1
+    assert evt["artifacts_skipped"] == 0
+    assert evt["artifacts_failed"] == 0


### PR DESCRIPTION
## Summary

- Adds `rebuild_kb` Procrastinate task that re-runs the full ingest pipeline (chunking, enrichment, TEI/sparse embedding, Qdrant upsert, `parent_chunks` replacement) for every active artifact in a KB
- New `REBUILD_KB = "rebuild-kb"` queue constant appended to `LLM_QUEUES`; task wired into `init_app()` via `register_rebuild_tasks()`
- Operator runbook at `docs/runbooks/rebuild-kb.md` with trigger commands, VictoriaLogs monitoring queries, cost estimate (~€0.35 for Voys's 501 artifacts), and failure-handling table

## Design decisions

- **Fail-open per artifact**: one artifact failure does not abort the rest; counted in `artifacts_failed`
- **Bounded concurrency**: `asyncio.Semaphore(4)` throttles concurrent per-artifact LLM calls
- **Queueing lock**: `queueing_lock=f"rebuild-kb-{org_id}-{kb_slug}"` — `AlreadyEnqueued` raised at defer time on duplicate; callers surface as 409
- **Idempotent**: Qdrant delete-then-insert per path + `pg_store.delete_parent_chunks_for_artifact` before re-insert
- **Lazy imports**: `chunker`, `enrichment_tasks._enrich_document`, `pg_store` imported inside `_rebuild_artifact` to avoid psycopg at module level
- **v1 scope**: reads `document_text` from `knowledge.artifacts.extra`; artifacts without it are skipped with `rebuild_skip_no_text` log event (known gap, see OPEN QUESTION in module docstring)

## Test plan

- [x] `test_rebuild_kb_iterates_artifacts` — every active artifact triggers one `_enrich_document` call
- [x] `test_rebuild_kb_skips_artifacts_without_text` — skip path + `rebuild_skip_no_text` log event
- [x] `test_rebuild_kb_propagates_failures_per_artifact` — fail-open: one failure counted, rest process
- [x] `test_rebuild_kb_queueing_lock` — duplicate defer raises `AlreadyEnqueued` (fake Procrastinate app, no psycopg dependency)
- [x] `test_rebuild_kb_summary_log_event` — `rebuild_kb_completed` event shape + returned dict keys
- [x] All 5 tests pass (`uv run pytest tests/test_rebuild_tasks.py -v`)
- [x] `ruff check` + `ruff format --check` clean on both new files

## Scope

Does NOT touch:
- SPEC-RAG-TAXONOMY-001 files (retrieval_api/taxonomy, litellm classifier)
- SPEC-RAG-PARENT-CHILD-001 (already merged in #338)
- Any existing enrichment or chunker logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)