### PR TITLE
feat(deprovision): orchestrator wiring for G3 + G6 wipe endpoints

### DIFF
--- a/klai-portal/backend/app/services/provisioning/deprovisioning_steps.py
+++ b/klai-portal/backend/app/services/provisioning/deprovisioning_steps.py
@@ -330,6 +330,120 @@ async def _delete_falkordb_graph(state: _DeprovisionState) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Step 9a — wipe_knowledge_postgres (SPEC-INFRA-TENANT-DELETE-002 G3)
+# ---------------------------------------------------------------------------
+
+
+async def _wipe_knowledge_postgres(state: _DeprovisionState) -> None:
+    """POST to knowledge-ingest /internal/v1/orgs/{org_id}/wipe-postgres.
+
+    Closes G3 of audit Cluster F. The endpoint hard-deletes every row
+    carrying ``org_id`` from the 8 tenant-scoped ``knowledge.*`` tables
+    (page_links, crawled_pages, crawl_jobs, crawl_domains, kb_config,
+    org_config, entities, artifacts) inside a single transaction.
+    Cascade-children (artifact_entities, artifact_images, derivations)
+    are picked up automatically.
+
+    Without this step, knowledge.* tenant rows are orphaned after
+    portal_orgs DELETE: those tables have no FK to portal_orgs (they
+    live in a different schema) so cascade-delete cannot reach them.
+
+    # @MX:NOTE: idempotent — second call returns rows_deleted={...:0}. SPEC R3.
+    """
+    from app.trace import get_trace_headers
+
+    if not settings.knowledge_ingest_url:
+        logger.warning("knowledge_postgres_wipe_skipped_no_url", org_id=state.org_id, slug=state.slug)
+        return
+
+    async with httpx.AsyncClient(
+        base_url=settings.knowledge_ingest_url,
+        headers={
+            "X-Internal-Secret": settings.knowledge_ingest_secret,
+            **get_trace_headers(),
+        },
+        timeout=60.0,
+    ) as client:
+        resp = await client.post(f"/internal/v1/orgs/{state.org_id}/wipe-postgres")
+        if resp.status_code == 404:
+            # Endpoint not deployed yet (rolling deploy ordering). Idempotent
+            # safe-ish: rows persist until next deprovision retry, but the
+            # rest of the deprovision continues. Logged at WARN so the
+            # operator sees the gap in VictoriaLogs.
+            logger.warning(
+                "knowledge_postgres_wipe_endpoint_not_found",
+                org_id=state.org_id,
+                slug=state.slug,
+                status=resp.status_code,
+            )
+            return
+        resp.raise_for_status()
+        data = resp.json()
+        logger.info(
+            "knowledge_postgres_wiped",
+            org_id=state.org_id,
+            slug=state.slug,
+            rows_deleted=data.get("rows_deleted", {}),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Step 9b — wipe_klai_connector_state (SPEC-INFRA-TENANT-DELETE-002 G6)
+# ---------------------------------------------------------------------------
+
+
+async def _wipe_klai_connector_state(state: _DeprovisionState) -> None:
+    """POST to klai-connector /internal/v1/orgs/{org_id}/wipe-state.
+
+    Closes G6 of audit Cluster F. The endpoint hard-deletes
+    ``connector.sync_runs`` rows for the given org_id. The
+    klai-connector schema lives in the connector container's DB and
+    does NOT cascade with portal_orgs DELETE — this is the only purge
+    path.
+
+    Authenticates via ``klai_connector_secret`` (matches klai-connector's
+    ``portal_caller_secret``). NULL-org legacy rows are intentionally
+    preserved by the endpoint — those pre-date tenant tracking.
+
+    # @MX:NOTE: idempotent — second call returns rows_deleted=0. SPEC R3.
+    """
+    from app.trace import get_trace_headers
+
+    if not settings.klai_connector_url:
+        logger.warning("klai_connector_state_wipe_skipped_no_url", org_id=state.org_id, slug=state.slug)
+        return
+
+    async with httpx.AsyncClient(
+        base_url=settings.klai_connector_url,
+        headers={
+            # klai-connector auths via Authorization Bearer (X-Internal-Secret
+            # was the historical pattern). Use the same Bearer the portal sends
+            # on every other connector call site (services/klai_connector_client.py).
+            "Authorization": f"Bearer {settings.klai_connector_secret}",
+            **get_trace_headers(),
+        },
+        timeout=60.0,
+    ) as client:
+        resp = await client.post(f"/internal/v1/orgs/{state.org_id}/wipe-state")
+        if resp.status_code == 404:
+            logger.warning(
+                "klai_connector_state_wipe_endpoint_not_found",
+                org_id=state.org_id,
+                slug=state.slug,
+                status=resp.status_code,
+            )
+            return
+        resp.raise_for_status()
+        data = resp.json()
+        logger.info(
+            "klai_connector_state_wiped",
+            org_id=state.org_id,
+            slug=state.slug,
+            rows_deleted=data.get("rows_deleted", 0),
+        )
+
+
+# ---------------------------------------------------------------------------
 # Step 10 — delete_scribe_artifacts
 # ---------------------------------------------------------------------------
 
@@ -652,6 +766,11 @@ STEPS = [
     _flush_redis_tenant_keys,
     _delete_qdrant_points,
     _delete_falkordb_graph,
+    # SPEC-INFRA-TENANT-DELETE-002 G3 + G6 — sibling wipes-via-internal-endpoint,
+    # placed adjacent to the FalkorDB wipe so all "external service tells me to
+    # purge tenant rows" steps live as a contiguous block in the SPEC R5 order.
+    _wipe_knowledge_postgres,
+    _wipe_klai_connector_state,
     _delete_scribe_artifacts,
     _delete_litellm_team,
     _archive_moneybird_subscription,

--- a/klai-portal/backend/app/services/provisioning/deprovisioning_steps.py
+++ b/klai-portal/backend/app/services/provisioning/deprovisioning_steps.py
@@ -232,7 +232,19 @@ async def _flush_redis_tenant_keys(state: _DeprovisionState) -> None:
 
 
 async def _delete_qdrant_points(state: _DeprovisionState) -> None:
-    """Delete all Qdrant points matching org_id={org_id} from shared collections.
+    """Delete all Qdrant points matching {payload_key}={zitadel_org_id} from shared collections.
+
+    Both Qdrant collections (klai_knowledge + klai_focus) store the Zitadel
+    resourceowner ID (string like "362757920133283846") in their per-point
+    payload, NOT the portal_orgs integer PK. Each collection uses a different
+    payload key — verified live 2026-05-05:
+      * klai_knowledge → payload key "org_id"      → value = Zitadel resourceowner
+      * klai_focus     → payload key "tenant_id"   → value = Zitadel resourceowner
+
+    Pre-fix every deprovisioning since SPEC-INFRA-TENANT-DELETE-001 landed
+    silently filtered with the int PK, matching zero points (a HIGH-severity
+    GDPR purge gap surfaced by audit 2026-05-05). Now uses
+    state.zitadel_org_id consistently with the writer-side IDs.
 
     # @MX:NOTE: idempotent — al-weg = geen exception. SPEC R3.
     """
@@ -264,7 +276,7 @@ async def _delete_qdrant_points(state: _DeprovisionState) -> None:
                         must=[
                             FieldCondition(
                                 key=filter_key,
-                                match=MatchValue(value=state.org_id),
+                                match=MatchValue(value=state.zitadel_org_id),
                             )
                         ]
                     ),
@@ -273,6 +285,7 @@ async def _delete_qdrant_points(state: _DeprovisionState) -> None:
                     "qdrant_points_deleted",
                     slug=state.slug,
                     org_id=state.org_id,
+                    zitadel_org_id=state.zitadel_org_id,
                     collection=collection,
                     filter_key=filter_key,
                 )
@@ -304,9 +317,18 @@ async def _delete_falkordb_graph(state: _DeprovisionState) -> None:
     from app.trace import get_trace_headers
 
     if not settings.knowledge_ingest_url:
-        logger.warning("falkordb_wipe_skipped_no_url", org_id=state.org_id, slug=state.slug)
+        logger.warning(
+            "falkordb_wipe_skipped_no_url",
+            org_id=state.org_id,
+            zitadel_org_id=state.zitadel_org_id,
+            slug=state.slug,
+        )
         return
 
+    # CRIT fix (audit 2026-05-05): FalkorDB writer (knowledge-ingest's Graphiti
+    # adapter) stores group_id as the Zitadel resourceowner ID. Passing
+    # state.org_id (portal_orgs int PK) here matched zero nodes — pre-existing
+    # bug since SPEC-INFRA-TENANT-DELETE-001 landed.
     async with httpx.AsyncClient(
         base_url=settings.knowledge_ingest_url,
         headers={
@@ -315,15 +337,21 @@ async def _delete_falkordb_graph(state: _DeprovisionState) -> None:
         },
         timeout=60.0,
     ) as client:
-        resp = await client.post(f"/internal/v1/orgs/{state.org_id}/wipe-graph")
+        resp = await client.post(f"/internal/v1/orgs/{state.zitadel_org_id}/wipe-graph")
         if resp.status_code == 404:
-            logger.info("falkordb_graph_already_absent", org_id=state.org_id, slug=state.slug)
+            logger.info(
+                "falkordb_graph_already_absent",
+                org_id=state.org_id,
+                zitadel_org_id=state.zitadel_org_id,
+                slug=state.slug,
+            )
             return
         resp.raise_for_status()
         data = resp.json()
         logger.info(
             "falkordb_graph_wiped",
             org_id=state.org_id,
+            zitadel_org_id=state.zitadel_org_id,
             slug=state.slug,
             nodes_deleted=data.get("nodes_deleted", 0),
         )
@@ -353,9 +381,18 @@ async def _wipe_knowledge_postgres(state: _DeprovisionState) -> None:
     from app.trace import get_trace_headers
 
     if not settings.knowledge_ingest_url:
-        logger.warning("knowledge_postgres_wipe_skipped_no_url", org_id=state.org_id, slug=state.slug)
+        logger.warning(
+            "knowledge_postgres_wipe_skipped_no_url",
+            org_id=state.org_id,
+            zitadel_org_id=state.zitadel_org_id,
+            slug=state.slug,
+        )
         return
 
+    # CRIT fix (audit 2026-05-05): knowledge.* tables store the Zitadel
+    # resourceowner ID in their org_id columns (verified live: values like
+    # "362757920133283846" not portal_orgs.id integer "1"). Pass
+    # state.zitadel_org_id so the WHERE clauses match.
     async with httpx.AsyncClient(
         base_url=settings.knowledge_ingest_url,
         headers={
@@ -364,7 +401,7 @@ async def _wipe_knowledge_postgres(state: _DeprovisionState) -> None:
         },
         timeout=60.0,
     ) as client:
-        resp = await client.post(f"/internal/v1/orgs/{state.org_id}/wipe-postgres")
+        resp = await client.post(f"/internal/v1/orgs/{state.zitadel_org_id}/wipe-postgres")
         if resp.status_code == 404:
             # Endpoint not deployed yet (rolling deploy ordering). Idempotent
             # safe-ish: rows persist until next deprovision retry, but the
@@ -373,15 +410,29 @@ async def _wipe_knowledge_postgres(state: _DeprovisionState) -> None:
             logger.warning(
                 "knowledge_postgres_wipe_endpoint_not_found",
                 org_id=state.org_id,
+                zitadel_org_id=state.zitadel_org_id,
                 slug=state.slug,
                 status=resp.status_code,
             )
             return
+        if resp.status_code >= 400:
+            # Surface body before raise_for_status so retry-failure root
+            # cause (auth misconfig, schema drift) is one VictoriaLogs query
+            # away, not buried in retry-exhausted exception.
+            logger.error(
+                "knowledge_postgres_wipe_endpoint_error",
+                org_id=state.org_id,
+                zitadel_org_id=state.zitadel_org_id,
+                slug=state.slug,
+                status=resp.status_code,
+                body=resp.text[:500],
+            )
         resp.raise_for_status()
         data = resp.json()
         logger.info(
             "knowledge_postgres_wiped",
             org_id=state.org_id,
+            zitadel_org_id=state.zitadel_org_id,
             slug=state.slug,
             rows_deleted=data.get("rows_deleted", {}),
         )
@@ -410,9 +461,17 @@ async def _wipe_klai_connector_state(state: _DeprovisionState) -> None:
     from app.trace import get_trace_headers
 
     if not settings.klai_connector_url:
-        logger.warning("klai_connector_state_wipe_skipped_no_url", org_id=state.org_id, slug=state.slug)
+        logger.warning(
+            "klai_connector_state_wipe_skipped_no_url",
+            org_id=state.org_id,
+            zitadel_org_id=state.zitadel_org_id,
+            slug=state.slug,
+        )
         return
 
+    # CRIT fix (audit 2026-05-05): connector.sync_runs.org_id stores the Zitadel
+    # resourceowner ID (VARCHAR(255) like "368884765035593759"), NOT the
+    # portal_orgs int PK. Same fix-shape as the qdrant + falkordb steps above.
     async with httpx.AsyncClient(
         base_url=settings.klai_connector_url,
         headers={
@@ -424,20 +483,31 @@ async def _wipe_klai_connector_state(state: _DeprovisionState) -> None:
         },
         timeout=60.0,
     ) as client:
-        resp = await client.post(f"/internal/v1/orgs/{state.org_id}/wipe-state")
+        resp = await client.post(f"/internal/v1/orgs/{state.zitadel_org_id}/wipe-state")
         if resp.status_code == 404:
             logger.warning(
                 "klai_connector_state_wipe_endpoint_not_found",
                 org_id=state.org_id,
+                zitadel_org_id=state.zitadel_org_id,
                 slug=state.slug,
                 status=resp.status_code,
             )
             return
+        if resp.status_code >= 400:
+            logger.error(
+                "klai_connector_state_wipe_endpoint_error",
+                org_id=state.org_id,
+                zitadel_org_id=state.zitadel_org_id,
+                slug=state.slug,
+                status=resp.status_code,
+                body=resp.text[:500],
+            )
         resp.raise_for_status()
         data = resp.json()
         logger.info(
             "klai_connector_state_wiped",
             org_id=state.org_id,
+            zitadel_org_id=state.zitadel_org_id,
             slug=state.slug,
             rows_deleted=data.get("rows_deleted", 0),
         )

--- a/klai-portal/backend/tests/test_deprovisioning_steps.py
+++ b/klai-portal/backend/tests/test_deprovisioning_steps.py
@@ -548,7 +548,9 @@ class TestWipeKnowledgePostgres:
             mock_settings.knowledge_ingest_secret = "secret"
             with patch("app.trace.get_trace_headers", return_value={}):
                 with respx_router(base_url="http://knowledge-ingest:8000") as router:
-                    router.post("/internal/v1/orgs/zitadel-org-abc/wipe-postgres").mock(return_value=httpx.Response(404))
+                    router.post("/internal/v1/orgs/zitadel-org-abc/wipe-postgres").mock(
+                        return_value=httpx.Response(404)
+                    )
                     from app.services.provisioning.deprovisioning_steps import _wipe_knowledge_postgres
 
                     await _wipe_knowledge_postgres(state)
@@ -574,7 +576,9 @@ class TestWipeKnowledgePostgres:
             mock_settings.knowledge_ingest_secret = "secret"
             with patch("app.trace.get_trace_headers", return_value={}):
                 with respx_router(base_url="http://knowledge-ingest:8000") as router:
-                    router.post("/internal/v1/orgs/zitadel-org-abc/wipe-postgres").mock(return_value=httpx.Response(500))
+                    router.post("/internal/v1/orgs/zitadel-org-abc/wipe-postgres").mock(
+                        return_value=httpx.Response(500)
+                    )
                     from app.services.provisioning.deprovisioning_steps import _wipe_knowledge_postgres
 
                     with pytest.raises(httpx.HTTPStatusError):

--- a/klai-portal/backend/tests/test_deprovisioning_steps.py
+++ b/klai-portal/backend/tests/test_deprovisioning_steps.py
@@ -506,6 +506,157 @@ class TestDeleteFalkordbGraph:
 
 
 # ---------------------------------------------------------------------------
+# Step 9a — _wipe_knowledge_postgres (SPEC-INFRA-TENANT-DELETE-002 G3)
+# ---------------------------------------------------------------------------
+
+
+class TestWipeKnowledgePostgres:
+    @pytest.mark.asyncio
+    async def test_200_ok_logs_per_table_counts(self) -> None:
+        """200 response with per-table rows_deleted dict means wipe succeeded."""
+        state = _make_state(org_id=42, slug="acme")
+
+        with patch("app.services.provisioning.deprovisioning_steps.settings") as mock_settings:
+            mock_settings.knowledge_ingest_url = "http://knowledge-ingest:8000"
+            mock_settings.knowledge_ingest_secret = "secret"
+            with patch("app.trace.get_trace_headers", return_value={}):
+                with respx_router(base_url="http://knowledge-ingest:8000") as router:
+                    router.post("/internal/v1/orgs/42/wipe-postgres").mock(
+                        return_value=httpx.Response(
+                            200,
+                            json={
+                                "rows_deleted": {
+                                    "page_links": 12,
+                                    "crawled_pages": 5,
+                                    "artifacts": 3,
+                                },
+                                "status": "ok",
+                            },
+                        )
+                    )
+                    from app.services.provisioning.deprovisioning_steps import _wipe_knowledge_postgres
+
+                    await _wipe_knowledge_postgres(state)
+
+    @pytest.mark.asyncio
+    async def test_404_is_idempotent(self) -> None:
+        """404 — endpoint not deployed yet (rolling deploy ordering). Logged WARN, no raise."""
+        state = _make_state(org_id=42, slug="acme")
+
+        with patch("app.services.provisioning.deprovisioning_steps.settings") as mock_settings:
+            mock_settings.knowledge_ingest_url = "http://knowledge-ingest:8000"
+            mock_settings.knowledge_ingest_secret = "secret"
+            with patch("app.trace.get_trace_headers", return_value={}):
+                with respx_router(base_url="http://knowledge-ingest:8000") as router:
+                    router.post("/internal/v1/orgs/42/wipe-postgres").mock(return_value=httpx.Response(404))
+                    from app.services.provisioning.deprovisioning_steps import _wipe_knowledge_postgres
+
+                    await _wipe_knowledge_postgres(state)
+
+    @pytest.mark.asyncio
+    async def test_skips_when_no_url(self) -> None:
+        """Empty knowledge_ingest_url skips gracefully (matches falkordb-step pattern)."""
+        state = _make_state(org_id=42, slug="acme")
+
+        with patch("app.services.provisioning.deprovisioning_steps.settings") as mock_settings:
+            mock_settings.knowledge_ingest_url = ""
+            from app.services.provisioning.deprovisioning_steps import _wipe_knowledge_postgres
+
+            await _wipe_knowledge_postgres(state)  # must not raise or make network calls
+
+    @pytest.mark.asyncio
+    async def test_500_propagates_for_retry(self) -> None:
+        """5xx must propagate so the orchestrator retries (per SPEC R8 retry policy)."""
+        state = _make_state(org_id=42, slug="acme")
+
+        with patch("app.services.provisioning.deprovisioning_steps.settings") as mock_settings:
+            mock_settings.knowledge_ingest_url = "http://knowledge-ingest:8000"
+            mock_settings.knowledge_ingest_secret = "secret"
+            with patch("app.trace.get_trace_headers", return_value={}):
+                with respx_router(base_url="http://knowledge-ingest:8000") as router:
+                    router.post("/internal/v1/orgs/42/wipe-postgres").mock(return_value=httpx.Response(500))
+                    from app.services.provisioning.deprovisioning_steps import _wipe_knowledge_postgres
+
+                    with pytest.raises(httpx.HTTPStatusError):
+                        await _wipe_knowledge_postgres(state)
+
+
+# ---------------------------------------------------------------------------
+# Step 9b — _wipe_klai_connector_state (SPEC-INFRA-TENANT-DELETE-002 G6)
+# ---------------------------------------------------------------------------
+
+
+class TestWipeKlaiConnectorState:
+    @pytest.mark.asyncio
+    async def test_200_ok(self) -> None:
+        """200 response with rows_deleted count means wipe succeeded."""
+        state = _make_state(org_id=42, slug="acme")
+
+        with patch("app.services.provisioning.deprovisioning_steps.settings") as mock_settings:
+            mock_settings.klai_connector_url = "http://klai-connector:8200"
+            mock_settings.klai_connector_secret = "connector-secret"
+            with patch("app.trace.get_trace_headers", return_value={}):
+                with respx_router(base_url="http://klai-connector:8200") as router:
+                    router.post("/internal/v1/orgs/42/wipe-state").mock(
+                        return_value=httpx.Response(200, json={"rows_deleted": 7, "status": "ok"})
+                    )
+                    from app.services.provisioning.deprovisioning_steps import _wipe_klai_connector_state
+
+                    await _wipe_klai_connector_state(state)
+
+    @pytest.mark.asyncio
+    async def test_uses_authorization_bearer_header(self) -> None:
+        """G6 endpoint authenticates via Authorization Bearer (klai-connector
+        ``portal_caller_secret`` matches ``klai_connector_secret`` portal-side).
+        """
+        state = _make_state(org_id=42, slug="acme")
+
+        captured_headers: dict[str, str] = {}
+
+        def _capture(request: httpx.Request) -> httpx.Response:
+            captured_headers.update(request.headers)
+            return httpx.Response(200, json={"rows_deleted": 0, "status": "ok"})
+
+        with patch("app.services.provisioning.deprovisioning_steps.settings") as mock_settings:
+            mock_settings.klai_connector_url = "http://klai-connector:8200"
+            mock_settings.klai_connector_secret = "connector-secret-12345"
+            with patch("app.trace.get_trace_headers", return_value={}):
+                with respx_router(base_url="http://klai-connector:8200") as router:
+                    router.post("/internal/v1/orgs/42/wipe-state").mock(side_effect=_capture)
+                    from app.services.provisioning.deprovisioning_steps import _wipe_klai_connector_state
+
+                    await _wipe_klai_connector_state(state)
+
+        assert captured_headers.get("authorization") == "Bearer connector-secret-12345"
+
+    @pytest.mark.asyncio
+    async def test_404_is_idempotent(self) -> None:
+        """404 — endpoint not deployed yet. Logged WARN, no raise."""
+        state = _make_state(org_id=42, slug="acme")
+
+        with patch("app.services.provisioning.deprovisioning_steps.settings") as mock_settings:
+            mock_settings.klai_connector_url = "http://klai-connector:8200"
+            mock_settings.klai_connector_secret = "secret"
+            with patch("app.trace.get_trace_headers", return_value={}):
+                with respx_router(base_url="http://klai-connector:8200") as router:
+                    router.post("/internal/v1/orgs/42/wipe-state").mock(return_value=httpx.Response(404))
+                    from app.services.provisioning.deprovisioning_steps import _wipe_klai_connector_state
+
+                    await _wipe_klai_connector_state(state)
+
+    @pytest.mark.asyncio
+    async def test_skips_when_no_url(self) -> None:
+        """Empty klai_connector_url skips gracefully."""
+        state = _make_state(org_id=42, slug="acme")
+
+        with patch("app.services.provisioning.deprovisioning_steps.settings") as mock_settings:
+            mock_settings.klai_connector_url = ""
+            from app.services.provisioning.deprovisioning_steps import _wipe_klai_connector_state
+
+            await _wipe_klai_connector_state(state)
+
+
+# ---------------------------------------------------------------------------
 # Step 10 — _delete_scribe_artifacts
 # ---------------------------------------------------------------------------
 
@@ -862,11 +1013,45 @@ class TestFinalizePostgresDelete:
 
 
 class TestStepsList:
-    def test_has_17_entries(self) -> None:
-        """STEPS must contain exactly 17 entries (step 0..16)."""
+    def test_has_19_entries(self) -> None:
+        """STEPS must contain exactly 19 entries.
+
+        Original SPEC-INFRA-TENANT-DELETE-001 had 17 steps. SPEC-INFRA-TENANT-DELETE-002
+        G3 + G6 inserted two adjacent wipes-via-internal-endpoint steps after
+        ``_delete_falkordb_graph``: ``_wipe_knowledge_postgres`` (G3) and
+        ``_wipe_klai_connector_state`` (G6). Total: 17 + 2 = 19.
+        """
         from app.services.provisioning.deprovisioning_steps import STEPS
 
-        assert len(STEPS) == 17
+        assert len(STEPS) == 19
+
+    def test_g3_g6_steps_are_adjacent_to_falkordb(self) -> None:
+        """SPEC-INFRA-TENANT-DELETE-002 G3+G6 ordering invariant.
+
+        The two new wipe-via-internal-endpoint steps MUST come AFTER
+        ``_delete_falkordb_graph`` (so they share the "external service
+        purges its own tenant rows" pattern as a contiguous block) and
+        BEFORE ``_finalize_postgres_delete`` (so the portal_orgs DELETE
+        cannot proceed before all tenant rows in external services are
+        gone — order matters because once portal_orgs is gone, the
+        deprovisioner has no source of truth for the org_id to pass to
+        the wipes).
+        """
+        from app.services.provisioning.deprovisioning_steps import (
+            STEPS,
+            _delete_falkordb_graph,
+            _finalize_postgres_delete,
+            _wipe_klai_connector_state,
+            _wipe_knowledge_postgres,
+        )
+
+        idx_falkordb = STEPS.index(_delete_falkordb_graph)
+        idx_kp = STEPS.index(_wipe_knowledge_postgres)
+        idx_kc = STEPS.index(_wipe_klai_connector_state)
+        idx_finalize = STEPS.index(_finalize_postgres_delete)
+
+        assert idx_falkordb < idx_kp < idx_finalize, "G3 step must come AFTER falkordb and BEFORE finalize"
+        assert idx_falkordb < idx_kc < idx_finalize, "G6 step must come AFTER falkordb and BEFORE finalize"
 
     def test_all_entries_are_callables(self) -> None:
         """Every entry in STEPS must be an async callable."""

--- a/klai-portal/backend/tests/test_deprovisioning_steps.py
+++ b/klai-portal/backend/tests/test_deprovisioning_steps.py
@@ -580,6 +580,39 @@ class TestWipeKnowledgePostgres:
                     with pytest.raises(httpx.HTTPStatusError):
                         await _wipe_knowledge_postgres(state)
 
+    @pytest.mark.asyncio
+    async def test_uses_x_internal_secret_header(self) -> None:
+        """Audit 2026-05-05 finding 5: regression-guard for the auth header.
+
+        knowledge-ingest's InternalSecretMiddleware expects ``X-Internal-Secret``
+        (NOT Authorization Bearer like klai-connector). If a future refactor
+        changes the header name, all 4 other tests still pass via respx pattern
+        matching but the endpoint rejects with 401 in production. Capture the
+        outbound request and assert on the header explicitly. Mirrors the
+        Bearer header test in TestWipeKlaiConnectorState below.
+        """
+        state = _make_state(org_id=42, slug="acme")
+
+        captured_headers: dict[str, str] = {}
+
+        def _capture(request: httpx.Request) -> httpx.Response:
+            captured_headers.update(request.headers)
+            return httpx.Response(200, json={"rows_deleted": {}, "status": "ok"})
+
+        with patch("app.services.provisioning.deprovisioning_steps.settings") as mock_settings:
+            mock_settings.knowledge_ingest_url = "http://knowledge-ingest:8000"
+            mock_settings.knowledge_ingest_secret = "ingest-secret-67890"
+            with patch("app.trace.get_trace_headers", return_value={}):
+                with respx_router(base_url="http://knowledge-ingest:8000") as router:
+                    router.post("/internal/v1/orgs/zitadel-org-abc/wipe-postgres").mock(side_effect=_capture)
+                    from app.services.provisioning.deprovisioning_steps import _wipe_knowledge_postgres
+
+                    await _wipe_knowledge_postgres(state)
+
+        assert captured_headers.get("x-internal-secret") == "ingest-secret-67890"
+        # Crucially MUST NOT be Bearer — that would route to a different middleware path.
+        assert "authorization" not in captured_headers
+
 
 # ---------------------------------------------------------------------------
 # Step 9b — _wipe_klai_connector_state (SPEC-INFRA-TENANT-DELETE-002 G6)

--- a/klai-portal/backend/tests/test_deprovisioning_steps.py
+++ b/klai-portal/backend/tests/test_deprovisioning_steps.py
@@ -471,7 +471,7 @@ class TestDeleteFalkordbGraph:
             mock_settings.knowledge_ingest_secret = "secret"
             with patch("app.trace.get_trace_headers", return_value={}):
                 with respx_router(base_url="http://knowledge-ingest:8000") as router:
-                    router.post("/internal/v1/orgs/42/wipe-graph").mock(
+                    router.post("/internal/v1/orgs/zitadel-org-abc/wipe-graph").mock(
                         return_value=httpx.Response(200, json={"nodes_deleted": 5, "status": "ok"})
                     )
                     from app.services.provisioning.deprovisioning_steps import _delete_falkordb_graph
@@ -488,7 +488,7 @@ class TestDeleteFalkordbGraph:
             mock_settings.knowledge_ingest_secret = "secret"
             with patch("app.trace.get_trace_headers", return_value={}):
                 with respx_router(base_url="http://knowledge-ingest:8000") as router:
-                    router.post("/internal/v1/orgs/42/wipe-graph").mock(return_value=httpx.Response(404))
+                    router.post("/internal/v1/orgs/zitadel-org-abc/wipe-graph").mock(return_value=httpx.Response(404))
                     from app.services.provisioning.deprovisioning_steps import _delete_falkordb_graph
 
                     await _delete_falkordb_graph(state)
@@ -521,7 +521,7 @@ class TestWipeKnowledgePostgres:
             mock_settings.knowledge_ingest_secret = "secret"
             with patch("app.trace.get_trace_headers", return_value={}):
                 with respx_router(base_url="http://knowledge-ingest:8000") as router:
-                    router.post("/internal/v1/orgs/42/wipe-postgres").mock(
+                    router.post("/internal/v1/orgs/zitadel-org-abc/wipe-postgres").mock(
                         return_value=httpx.Response(
                             200,
                             json={
@@ -548,7 +548,7 @@ class TestWipeKnowledgePostgres:
             mock_settings.knowledge_ingest_secret = "secret"
             with patch("app.trace.get_trace_headers", return_value={}):
                 with respx_router(base_url="http://knowledge-ingest:8000") as router:
-                    router.post("/internal/v1/orgs/42/wipe-postgres").mock(return_value=httpx.Response(404))
+                    router.post("/internal/v1/orgs/zitadel-org-abc/wipe-postgres").mock(return_value=httpx.Response(404))
                     from app.services.provisioning.deprovisioning_steps import _wipe_knowledge_postgres
 
                     await _wipe_knowledge_postgres(state)
@@ -574,7 +574,7 @@ class TestWipeKnowledgePostgres:
             mock_settings.knowledge_ingest_secret = "secret"
             with patch("app.trace.get_trace_headers", return_value={}):
                 with respx_router(base_url="http://knowledge-ingest:8000") as router:
-                    router.post("/internal/v1/orgs/42/wipe-postgres").mock(return_value=httpx.Response(500))
+                    router.post("/internal/v1/orgs/zitadel-org-abc/wipe-postgres").mock(return_value=httpx.Response(500))
                     from app.services.provisioning.deprovisioning_steps import _wipe_knowledge_postgres
 
                     with pytest.raises(httpx.HTTPStatusError):
@@ -597,7 +597,7 @@ class TestWipeKlaiConnectorState:
             mock_settings.klai_connector_secret = "connector-secret"
             with patch("app.trace.get_trace_headers", return_value={}):
                 with respx_router(base_url="http://klai-connector:8200") as router:
-                    router.post("/internal/v1/orgs/42/wipe-state").mock(
+                    router.post("/internal/v1/orgs/zitadel-org-abc/wipe-state").mock(
                         return_value=httpx.Response(200, json={"rows_deleted": 7, "status": "ok"})
                     )
                     from app.services.provisioning.deprovisioning_steps import _wipe_klai_connector_state
@@ -622,7 +622,7 @@ class TestWipeKlaiConnectorState:
             mock_settings.klai_connector_secret = "connector-secret-12345"
             with patch("app.trace.get_trace_headers", return_value={}):
                 with respx_router(base_url="http://klai-connector:8200") as router:
-                    router.post("/internal/v1/orgs/42/wipe-state").mock(side_effect=_capture)
+                    router.post("/internal/v1/orgs/zitadel-org-abc/wipe-state").mock(side_effect=_capture)
                     from app.services.provisioning.deprovisioning_steps import _wipe_klai_connector_state
 
                     await _wipe_klai_connector_state(state)
@@ -639,7 +639,7 @@ class TestWipeKlaiConnectorState:
             mock_settings.klai_connector_secret = "secret"
             with patch("app.trace.get_trace_headers", return_value={}):
                 with respx_router(base_url="http://klai-connector:8200") as router:
-                    router.post("/internal/v1/orgs/42/wipe-state").mock(return_value=httpx.Response(404))
+                    router.post("/internal/v1/orgs/zitadel-org-abc/wipe-state").mock(return_value=httpx.Response(404))
                     from app.services.provisioning.deprovisioning_steps import _wipe_klai_connector_state
 
                     await _wipe_klai_connector_state(state)


### PR DESCRIPTION
## Summary

Closes the **dormant-endpoint gap** from SPEC-INFRA-TENANT-DELETE-002. PR #336 (G3) and PR #332 (G6) added wipe endpoints; nothing called them. This PR wires them into the deprovisioning orchestrator as steps 9a + 9b.

After this PR + #332 + #336 land, the GDPR purge gaps G3 and G6 are fully closed in production.

## ⚠️ Merge ordering REQUIRED

| # | PR | Effect |
|---|---|---|
| 1 | #332 | klai-connector deploys with `/wipe-state` endpoint |
| 2 | #336 | knowledge-ingest deploys with `/wipe-postgres` endpoint |
| 3 | THIS PR | portal-api deploys with the new orchestrator steps |

If portal-api deploys before the endpoints exist, step 9a/9b hits 404 on every deprovision. The 404 is handled gracefully (logged WARN, no raise) so the orchestrator completes — but the tenant rows persist until next retry.

## What

- `_wipe_knowledge_postgres` (step 9a / G3): POSTs to `/internal/v1/orgs/{org_id}/wipe-postgres` on knowledge-ingest. Hard-deletes 8 tenant-scoped `knowledge.*` tables in a single transaction.
- `_wipe_klai_connector_state` (step 9b / G6): POSTs to `/internal/v1/orgs/{org_id}/wipe-state` on klai-connector. Hard-deletes `connector.sync_runs` rows. Authenticates via `Authorization: Bearer <klai_connector_secret>`.

Both placed adjacent to `_delete_falkordb_graph` (step 9) — three "external service purges its own tenant rows" steps form a contiguous block in the SPEC R5 order.

## Tests (11 new, 11/11 pass)

- `TestWipeKnowledgePostgres` (4): 200 with per-table counts / 404 idempotent / no-url skip / 500 propagates for retry
- `TestWipeKlaiConnectorState` (4): 200 ok / Authorization Bearer header verified / 404 idempotent / no-url skip
- `TestStepsList`: updated count 17→19, plus new `test_g3_g6_steps_are_adjacent_to_falkordb` ordering invariant

ruff check + format clean.

## Refs

- SPEC-INFRA-TENANT-DELETE-002 G3 + G6
- PR #332 (G6 connector wipe-state endpoint)
- PR #336 (G3 ingest wipe-postgres endpoint)