### PR TITLE
chore(portal-admin-ui): SPEC-PORTAL-ADMIN-UI-001 cleanup — cleanErrorMessage everywhere, shared test mocks, displayName helper

### DIFF
--- a/klai-portal/frontend/src/routes/admin/_components/UserAvatar.tsx
+++ b/klai-portal/frontend/src/routes/admin/_components/UserAvatar.tsx
@@ -32,6 +32,20 @@ export function userInitials(input: {
   return input.email.slice(0, 2).toUpperCase()
 }
 
+/**
+ * Standard "full name with email fallback" rendering used across the admin
+ * surfaces (users table, profiles drill-in, groups detail). Lives next to
+ * UserAvatar so the two stay in sync — same input shape, same fallback rules.
+ */
+export function displayName(input: {
+  first_name?: string | null
+  last_name?: string | null
+  email: string
+}): string {
+  const full = `${input.first_name ?? ''} ${input.last_name ?? ''}`.trim()
+  return full || input.email
+}
+
 interface UserAvatarProps {
   uid: string
   first_name?: string | null

--- a/klai-portal/frontend/src/routes/admin/_components/__tests__/ProfilePicker.test.tsx
+++ b/klai-portal/frontend/src/routes/admin/_components/__tests__/ProfilePicker.test.tsx
@@ -1,20 +1,9 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
+import { profileLadderMessages } from './_messages'
 import { ProfilePicker } from '../ProfilePicker'
 
-vi.mock('@/paraglide/messages', () => ({
-  profile_picker_title: () => 'Profile',
-  profile_personal_label: () => 'Personal chat',
-  profile_personal_description: () => 'Personal description',
-  profile_company_label: () => 'Company chat',
-  profile_company_description: () => 'Company description',
-  profile_kb_manager_label: () => 'Knowledge manager',
-  profile_kb_manager_description: () => 'KB manager description',
-  profile_group_manager_label: () => 'Group manager',
-  profile_group_manager_description: () => 'Group manager description',
-  profile_admin_label: () => 'Admin',
-  profile_admin_description: () => 'Admin description',
-}))
+vi.mock('@/paraglide/messages', () => ({ ...profileLadderMessages }))
 
 describe('ProfilePicker', () => {
   it('renders all 5 ladder profiles in order', () => {

--- a/klai-portal/frontend/src/routes/admin/_components/__tests__/_messages.ts
+++ b/klai-portal/frontend/src/routes/admin/_components/__tests__/_messages.ts
@@ -1,0 +1,89 @@
+/**
+ * Shared paraglide message mocks for admin-area tests.
+ *
+ * Each test file used to inline the same 5 profile_*_label / profile_*_description
+ * pairs plus generic admin_users_* / admin_profiles_* keys. Renaming an i18n key
+ * meant updating 6+ test files. Centralising here means rename + update ladder
+ * helper once, all consumers stay green.
+ *
+ * Usage:
+ *
+ *   vi.mock('@/paraglide/messages', () => ({
+ *     ...adminMessageMocks,
+ *     // override or add page-specific keys here
+ *   }))
+ */
+
+export const profileLadderMessages = {
+  profile_personal_label: () => 'Personal chat',
+  profile_personal_description: () => 'Personal description',
+  profile_company_label: () => 'Company chat',
+  profile_company_description: () => 'Company description',
+  profile_kb_manager_label: () => 'Knowledge manager',
+  profile_kb_manager_description: () => 'KB manager description',
+  profile_group_manager_label: () => 'Group manager',
+  profile_group_manager_description: () => 'Group manager description',
+  profile_admin_label: () => 'Admin',
+  profile_admin_description: () => 'Admin description',
+  profile_picker_title: () => 'Profile',
+  profile_picker_self_edit_hint: () => 'You cannot change your own profile.',
+  profile_picker_save: () => 'Save profile',
+  profile_picker_description: () => 'Select profile',
+} as const
+
+export const adminUsersMessages = {
+  admin_users_field_first_name: () => 'First name',
+  admin_users_field_last_name: () => 'Last name',
+  admin_users_field_email: () => 'Email',
+  admin_users_field_profile: () => 'Profile',
+  admin_users_field_language: () => 'Language',
+  admin_users_language_nl: () => 'Dutch',
+  admin_users_language_en: () => 'English',
+  admin_users_col_name: () => 'Name',
+  admin_users_col_email: () => 'Email',
+  admin_users_col_invited: () => 'Invited',
+  admin_users_cancel: () => 'Cancel',
+  admin_users_invite_button: () => 'Invite user',
+  admin_users_invite_submit: () => 'Send',
+  admin_users_invite_submit_loading: () => 'Sending...',
+  admin_users_error_invite_generic: () => 'Invitation failed.',
+  admin_users_error_edit_generic: () => 'Failed',
+  admin_users_edit_heading: () => 'Edit user',
+  admin_users_edit_subtitle: () =>
+    'Profiles control what tools the user can use. Groups control which knowledge bases the user can access within those tools.',
+  admin_users_edit_submit: () => 'Save',
+  admin_users_edit_submit_loading: () => 'Saving...',
+  admin_users_action_suspend: () => 'Suspend',
+  admin_users_action_reactivate: () => 'Reactivate',
+  admin_users_action_offboard: () => 'Offboard',
+  admin_users_confirm_suspend_title: () => 'Suspend user?',
+  admin_users_confirm_suspend_description: () => '...',
+  admin_users_confirm_offboard_title: () => 'Offboard user?',
+  admin_users_confirm_offboard_description: () => '...',
+  admin_settings_saved: () => 'Saved',
+} as const
+
+export const adminProfilesMessages = {
+  admin_profiles_title: () => 'Profiles',
+  admin_profiles_subtitle: () => 'Manage who can do what across the workspace.',
+  admin_profiles_back: () => 'Back to profiles',
+  admin_profiles_loading: () => 'Loading profiles...',
+  admin_profiles_drill_in_empty: () => 'No members in this profile yet.',
+  admin_profiles_error_change: () => 'Failed to change profile.',
+  admin_profiles_demote_action: () => 'Demote to Personal chat',
+  admin_profiles_demote_confirm: ({ name }: { name: string }) =>
+    `Demote ${name} to Personal chat?`,
+  admin_profiles_demote_success: () => 'User demoted to Personal chat',
+  admin_profiles_demote_self_blocked: () => 'You cannot demote yourself.',
+  admin_groups_name: () => 'Name',
+  admin_groups_members_title: () => 'Members',
+  admin_groups_members_add: () => 'Add member',
+  admin_groups_members_search_placeholder: () => 'Search…',
+  admin_groups_members_success_added: () => 'Added',
+} as const
+
+export const adminMessageMocks = {
+  ...profileLadderMessages,
+  ...adminUsersMessages,
+  ...adminProfilesMessages,
+} as const

--- a/klai-portal/frontend/src/routes/admin/profiles/$profile/__tests__/add-member.test.tsx
+++ b/klai-portal/frontend/src/routes/admin/profiles/$profile/__tests__/add-member.test.tsx
@@ -47,14 +47,9 @@ vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }))
 
-vi.mock('@/paraglide/messages', () => ({
-  admin_groups_members_add: () => 'Add member',
-  admin_groups_members_search_placeholder: () => 'Search…',
-  admin_groups_members_success_added: () => 'Added',
-  admin_users_cancel: () => 'Cancel',
-  admin_profiles_error_change: () => 'Failed',
-  profile_kb_manager_label: () => 'Knowledge manager',
-}))
+import { adminMessageMocks } from '../../../_components/__tests__/_messages'
+
+vi.mock('@/paraglide/messages', () => ({ ...adminMessageMocks }))
 
 import { Route as RouteCfg } from '../add-member'
 

--- a/klai-portal/frontend/src/routes/admin/profiles/$profile/__tests__/index.test.tsx
+++ b/klai-portal/frontend/src/routes/admin/profiles/$profile/__tests__/index.test.tsx
@@ -34,26 +34,9 @@ vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }))
 
-vi.mock('@/paraglide/messages', () => ({
-  admin_profiles_back: () => 'Back to profiles',
-  admin_profiles_loading: () => 'Loading...',
-  admin_profiles_drill_in_empty: () => 'No members in this profile yet.',
-  admin_profiles_error_change: () => 'Failed',
-  admin_profiles_demote_action: () => 'Demote to Personal chat',
-  admin_profiles_demote_confirm: ({ name }: { name: string }) => `Demote ${name} to Personal chat?`,
-  admin_profiles_demote_success: () => 'Demoted',
-  admin_profiles_demote_self_blocked: () => 'You cannot demote yourself.',
-  admin_groups_members_title: () => 'Members',
-  admin_groups_members_add: () => 'Add member',
-  admin_users_col_name: () => 'Name',
-  admin_users_col_email: () => 'Email',
-  admin_users_col_invited: () => 'Invited',
-  admin_users_cancel: () => 'Cancel',
-  profile_company_label: () => 'Company chat',
-  profile_company_description: () => 'Company description',
-  profile_personal_label: () => 'Personal chat',
-  profile_personal_description: () => 'Personal description',
-}))
+import { adminMessageMocks } from '../../../_components/__tests__/_messages'
+
+vi.mock('@/paraglide/messages', () => ({ ...adminMessageMocks }))
 
 vi.mock('@/hooks/useCurrentUser', () => ({
   useCurrentUser: () => ({ user: { user_id: 'someone-else' } }),

--- a/klai-portal/frontend/src/routes/admin/profiles/$profile/index.tsx
+++ b/klai-portal/frontend/src/routes/admin/profiles/$profile/index.tsx
@@ -13,7 +13,7 @@ import { getLocale } from '@/paraglide/runtime'
 import { datetime } from '@/paraglide/registry'
 import { apiFetch } from '@/lib/apiFetch'
 import { PROFILE_LADDER, type ProfileRole } from '@/lib/profiles'
-import { UserAvatar } from '../../_components/UserAvatar'
+import { UserAvatar, displayName } from '../../_components/UserAvatar'
 import { cleanErrorMessage } from '../../_components/errors'
 import { useCurrentUser } from '@/hooks/useCurrentUser'
 
@@ -41,11 +41,6 @@ function formatDate(isoString: string): string {
     month: 'short',
     year: 'numeric',
   })
-}
-
-function displayName(user: OrgUser): string {
-  const full = `${user.first_name} ${user.last_name}`.trim()
-  return full || user.email
 }
 
 function AdminProfileDetail() {

--- a/klai-portal/frontend/src/routes/admin/profiles/__tests__/index.test.tsx
+++ b/klai-portal/frontend/src/routes/admin/profiles/__tests__/index.test.tsx
@@ -20,23 +20,9 @@ vi.mock('@/lib/auth', () => ({
   useAuth: () => ({ isAuthenticated: true }),
 }))
 
-vi.mock('@/paraglide/messages', () => ({
-  admin_profiles_title: () => 'Profiles',
-  admin_profiles_subtitle: () => 'Manage who can do what',
-  admin_profiles_loading: () => 'Loading profiles...',
-  admin_groups_name: () => 'Name',
-  admin_groups_members_title: () => 'Members',
-  profile_personal_label: () => 'Personal chat',
-  profile_personal_description: () => 'Personal description',
-  profile_company_label: () => 'Company chat',
-  profile_company_description: () => 'Company description',
-  profile_kb_manager_label: () => 'Knowledge manager',
-  profile_kb_manager_description: () => 'KB manager description',
-  profile_group_manager_label: () => 'Group manager',
-  profile_group_manager_description: () => 'Group manager description',
-  profile_admin_label: () => 'Admin',
-  profile_admin_description: () => 'Admin description',
-}))
+import { adminMessageMocks } from '../../_components/__tests__/_messages'
+
+vi.mock('@/paraglide/messages', () => ({ ...adminMessageMocks }))
 
 import { Route as RouteCfg } from '../index'
 

--- a/klai-portal/frontend/src/routes/admin/users/$userId/__tests__/edit.test.tsx
+++ b/klai-portal/frontend/src/routes/admin/users/$userId/__tests__/edit.test.tsx
@@ -43,41 +43,9 @@ vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }))
 
-vi.mock('@/paraglide/messages', () => ({
-  admin_users_edit_heading: () => 'Edit user',
-  admin_users_edit_subtitle: () =>
-    'Profiles control what tools the user can use. Groups control which knowledge bases the user can access within those tools.',
-  admin_users_edit_submit: () => 'Save',
-  admin_users_edit_submit_loading: () => 'Saving...',
-  admin_users_field_first_name: () => 'First name',
-  admin_users_field_last_name: () => 'Last name',
-  admin_users_field_language: () => 'Language',
-  admin_users_field_profile: () => 'Profile',
-  admin_users_language_nl: () => 'Dutch',
-  admin_users_language_en: () => 'English',
-  admin_users_cancel: () => 'Cancel',
-  admin_users_error_edit_generic: () => 'Failed',
-  admin_users_action_suspend: () => 'Suspend',
-  admin_users_action_reactivate: () => 'Reactivate',
-  admin_users_action_offboard: () => 'Offboard',
-  admin_users_confirm_suspend_title: () => 'Suspend user?',
-  admin_users_confirm_suspend_description: () => '...',
-  admin_users_confirm_offboard_title: () => 'Offboard user?',
-  admin_users_confirm_offboard_description: () => '...',
-  admin_settings_saved: () => 'Saved',
-  profile_picker_title: () => 'Profile',
-  profile_picker_self_edit_hint: () => 'You cannot change your own profile.',
-  profile_personal_label: () => 'Personal chat',
-  profile_personal_description: () => 'Personal description',
-  profile_company_label: () => 'Company chat',
-  profile_company_description: () => 'Company description',
-  profile_kb_manager_label: () => 'Knowledge manager',
-  profile_kb_manager_description: () => 'KB manager description',
-  profile_group_manager_label: () => 'Group manager',
-  profile_group_manager_description: () => 'Group manager description',
-  profile_admin_label: () => 'Admin',
-  profile_admin_description: () => 'Admin description',
-}))
+import { adminMessageMocks } from '../../../_components/__tests__/_messages'
+
+vi.mock('@/paraglide/messages', () => ({ ...adminMessageMocks }))
 
 import { Route as RouteCfg } from '../edit'
 

--- a/klai-portal/frontend/src/routes/admin/users/__tests__/invite.test.tsx
+++ b/klai-portal/frontend/src/routes/admin/users/__tests__/invite.test.tsx
@@ -26,25 +26,9 @@ vi.mock('@/lib/auth', () => ({
   useAuth: () => ({ isAuthenticated: true }),
 }))
 
-vi.mock('@/paraglide/messages', () => ({
-  admin_users_invite_button: () => 'Invite user',
-  admin_users_field_first_name: () => 'First name',
-  admin_users_field_last_name: () => 'Last name',
-  admin_users_field_email: () => 'Email',
-  admin_users_field_profile: () => 'Profile',
-  admin_users_field_language: () => 'Language',
-  admin_users_language_nl: () => 'Dutch',
-  admin_users_language_en: () => 'English',
-  admin_users_invite_submit: () => 'Send',
-  admin_users_invite_submit_loading: () => 'Sending...',
-  admin_users_cancel: () => 'Cancel',
-  admin_users_error_invite_generic: () => 'Failed',
-  profile_personal_label: () => 'Personal chat',
-  profile_company_label: () => 'Company chat',
-  profile_kb_manager_label: () => 'Knowledge manager',
-  profile_group_manager_label: () => 'Group manager',
-  profile_admin_label: () => 'Admin',
-}))
+import { adminMessageMocks } from '../../_components/__tests__/_messages'
+
+vi.mock('@/paraglide/messages', () => ({ ...adminMessageMocks }))
 
 import { Route as RouteCfg } from '../invite'
 

--- a/klai-portal/frontend/src/routes/admin/users/index.tsx
+++ b/klai-portal/frontend/src/routes/admin/users/index.tsx
@@ -42,6 +42,7 @@ import { adminLogger } from '@/lib/logger'
 import { QueryErrorState } from '@/components/ui/query-error-state'
 import { useSuspendUser, useReactivateUser, useOffboardUser } from '@/hooks/useUserLifecycle'
 import { PROFILE_LADDER, type ProfileRole } from '@/lib/profiles'
+import { cleanErrorMessage } from '../_components/errors'
 
 export const Route = createFileRoute('/admin/users/')({
   component: UsersPage,
@@ -175,11 +176,13 @@ function UsersPage() {
     },
   })
 
+  // SPEC-PORTAL-ADMIN-UI-001 REQ-16: strip "<status>: " prefix from
+  // apiFetch-formatted errors so the banner reads as natural prose.
   const mutationError =
-    (deleteMutation.error instanceof Error ? deleteMutation.error.message : deleteMutation.error ? m.admin_users_error_delete_generic() : null) ??
-    (resendInviteMutation.error instanceof Error ? resendInviteMutation.error.message : resendInviteMutation.error ? m.admin_users_error_resend_invite_generic() : null) ??
-    (changeProfileMutation.error instanceof Error ? changeProfileMutation.error.message : changeProfileMutation.error ? m.admin_profiles_error_change() : null) ??
-    (leaveWorkspaceMutation.error instanceof Error ? leaveWorkspaceMutation.error.message : leaveWorkspaceMutation.error ? m.admin_users_error_leave_workspace() : null)
+    (deleteMutation.error ? cleanErrorMessage(deleteMutation.error, m.admin_users_error_delete_generic()) : null) ??
+    (resendInviteMutation.error ? cleanErrorMessage(resendInviteMutation.error, m.admin_users_error_resend_invite_generic()) : null) ??
+    (changeProfileMutation.error ? cleanErrorMessage(changeProfileMutation.error, m.admin_profiles_error_change()) : null) ??
+    (leaveWorkspaceMutation.error ? cleanErrorMessage(leaveWorkspaceMutation.error, m.admin_users_error_leave_workspace()) : null)
 
   // SPEC-PORTAL-ADMIN-UI-001 REQ-1: columns Name | Email | Profile | Status | Last active | Actions.
   // "Last active" rendered from created_at (Invited date) — backend has no

--- a/klai-portal/frontend/src/routes/admin/users/invite.tsx
+++ b/klai-portal/frontend/src/routes/admin/users/invite.tsx
@@ -10,6 +10,7 @@ import { Select } from '@/components/ui/select'
 import * as m from '@/paraglide/messages'
 import { apiFetch } from '@/lib/apiFetch'
 import { PROFILE_LADDER, type ProfileRole } from '@/lib/profiles'
+import { cleanErrorMessage } from '../_components/errors'
 
 export const Route = createFileRoute('/admin/users/invite')({
   component: InviteUserPage,
@@ -164,9 +165,7 @@ function InviteUserPage() {
 
         {inviteMutation.error && (
           <p className="text-sm text-[var(--color-destructive)]">
-            {inviteMutation.error instanceof Error
-              ? inviteMutation.error.message
-              : m.admin_users_error_invite_generic()}
+            {cleanErrorMessage(inviteMutation.error, m.admin_users_error_invite_generic())}
           </p>
         )}
 


### PR DESCRIPTION
## Summary

Three follow-up cleanups caught in self-review of PR #339.

**CRITICAL — `cleanErrorMessage` was inconsistently applied**. PR #333 added the helper but only wired it into 2 of the 4 surfaces that need it. `users/invite.tsx` and `users/index.tsx` were still rendering raw `"409: ..."` strings — meaning the min-1-admin error in the change-profile submenu (the one we fixed in #333) was still displayed with the HTTP code prefix. Both now route through `cleanErrorMessage` with their existing fallback strings.

**IMPORTANT — Paraglide message mocks deduplicated**. Each new admin test file (6 of them) inlined the same five `profile_*_label` / `profile_*_description` pairs plus assorted `admin_users_*` / `admin_profiles_*` keys. Renaming an i18n key meant updating six test files. New shared helper at `_components/__tests__/_messages.ts` exports `profileLadderMessages`, `adminUsersMessages`, `adminProfilesMessages` and the spread-ready `adminMessageMocks`. Underscore filename prefix keeps it out of the TanStack Router scan.

**SUGGESTION — `displayName` helper extracted** to `UserAvatar.tsx` next to `userInitials` so the two stay in sync. The local definition in `profiles/$profile/index.tsx` is gone. `groups/$groupId/index.tsx` is intentionally untouched (Sparring #6: groups out of scope) — can adopt the helper in a future groups-touching PR.

## Quality
- `npx tsc -b` clean
- `npm run lint` clean
- vitest `src/routes/admin`: **8 files, 31 tests, all green**
- backend `tests/test_spec_portal_admin_ui_001.py` (4) + `tests/test_r6_admin_handover.py` (7) — 11/11 green

## Test plan post-deploy
- [ ] Trigger a 409 in invite (e.g. duplicate email) → form banner shows the message **without** `"409: "` prefix
- [ ] Try to demote the last admin via `/admin/users` overflow ⋯ → "Change profile to" → ban­ner shows *"Cannot change profile: this is the last admin..."* without `"409: "` prefix
- [ ] All other admin surfaces continue working as before (no functional change beyond error-message scrubbing)