### PR TITLE
fix(rebuild-kb): reconstruct document_text from Qdrant when extra is empty

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/rebuild_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/rebuild_tasks.py
@@ -122,6 +122,75 @@ async def rebuild_kb_inline(org_id: str, kb_slug: str) -> dict:
     return await _rebuild_kb_core(org_id=org_id, kb_slug=kb_slug)
 
 
+async def _reconstruct_document_text(
+    org_id: str,
+    kb_slug: str,
+    path: str,
+) -> str | None:
+    """Reconstruct a document body from its existing Qdrant chunks.
+
+    Used by the rebuild path when the legacy artifact row has no
+    ``document_text`` on its extra JSONB. We pull every chunk for
+    ``(org_id, kb_slug, path)`` from Qdrant in chunk_index order, then
+    concat the (non-enriched) text values with double-newline separators.
+
+    The reconstruction is lossy — markdown frontmatter is dropped at
+    ingest time and chunk overlap leaves duplication on boundaries.
+    Good enough to feed the summary generator + new chunker; not the
+    same as a fresh re-fetch from the source connector.
+
+    Returns None when no chunks are found.
+    """
+    from qdrant_client.models import FieldCondition, Filter, MatchValue
+
+    from knowledge_ingest import qdrant_store
+
+    client = qdrant_store.get_client()
+    try:
+        scroll_result, _ = await client.scroll(
+            collection_name=qdrant_store.COLLECTION,
+            scroll_filter=Filter(
+                must=[
+                    FieldCondition(key="org_id", match=MatchValue(value=org_id)),
+                    FieldCondition(key="kb_slug", match=MatchValue(value=kb_slug)),
+                    FieldCondition(key="path", match=MatchValue(value=path)),
+                ]
+            ),
+            limit=512,
+            with_payload=True,
+            with_vectors=False,
+        )
+    except Exception as exc:
+        logger.warning(
+            "rebuild_qdrant_scroll_failed",
+            org_id=org_id,
+            kb_slug=kb_slug,
+            path=path,
+            error=str(exc)[:200],
+        )
+        return None
+
+    if not scroll_result:
+        return None
+
+    # Sort by chunk_index when present; fall back to insertion order.
+    def _idx(point):
+        try:
+            return int(point.payload.get("chunk_index", 0))
+        except Exception:
+            return 0
+
+    sorted_points = sorted(scroll_result, key=_idx)
+    parts: list[str] = []
+    for p in sorted_points:
+        text = p.payload.get("text") or ""
+        if text:
+            parts.append(text)
+    if not parts:
+        return None
+    return "\n\n".join(parts)
+
+
 async def _list_active_artifacts(org_id: str, kb_slug: str) -> list[dict]:
     """Return all currently-active artifact rows for a KB.
 
@@ -172,14 +241,35 @@ async def _rebuild_artifact(
 
             document_text: str | None = extra.get("document_text")
             if not document_text:
+                # Fallback: reconstruct document_text from existing Qdrant chunks.
+                # Concat the original chunk text in chunk_index order. Loses
+                # frontmatter and exact whitespace but is enough material for
+                # the chunker + summary-generator to produce a usable rebuild.
+                # This is the v1 path for legacy artifacts ingested before we
+                # started persisting document_text on extra; new ingests can
+                # skip the reconstruction once the storage gap is closed.
+                document_text = await _reconstruct_document_text(
+                    org_id=org_id,
+                    kb_slug=kb_slug,
+                    path=path,
+                )
+                if not document_text:
+                    logger.info(
+                        "rebuild_skip_no_text",
+                        org_id=org_id,
+                        kb_slug=kb_slug,
+                        artifact_id=artifact_id,
+                        path=path,
+                    )
+                    return "skipped"
                 logger.info(
-                    "rebuild_skip_no_text",
+                    "rebuild_text_reconstructed_from_qdrant",
                     org_id=org_id,
                     kb_slug=kb_slug,
                     artifact_id=artifact_id,
                     path=path,
+                    chars=len(document_text),
                 )
-                return "skipped"
 
             content_type: str = artifact.get("content_type") or "unknown"
             synthesis_depth: int = artifact.get("synthesis_depth") or 0


### PR DESCRIPTION
## Summary

The first \`rebuild_kb\` run on Voys (501 artifacts) skipped 100% — \`document_text\` was never persisted on \`knowledge.artifacts.extra\`. The original PR (#341) flagged this as an open question; this PR closes it pragmatically.

## Fix

When the artifact row has no \`document_text\` on its extra JSONB:

1. Scroll all chunks for \`(org_id, kb_slug, path)\` from Qdrant.
2. Sort by \`chunk_index\`.
3. Concat the \`.text\` fields with \`\n\n\` separators.
4. Use that as document_text input for re-chunking + summary generation.

Lossy: frontmatter dropped at ingest time isn't recoverable; chunk-overlap leaves duplication on boundaries. Good enough to feed the new pipeline.

If Qdrant ALSO has no chunks → \`rebuild_skip_no_text\` (unchanged behavior). Reconstruction-success path logs \`rebuild_text_reconstructed_from_qdrant\` so we can distinguish.

## Why pragmatic

Re-fetching from external connectors is the proper long-term answer but would need per-connector adapters. For Voys's 501 existing artifacts the reconstruction approach lets us measure CONTEXTUAL-001 + PARENT-CHILD-001 deltas TODAY.

## Test plan

- [x] All 5 existing rebuild_kb tests still green
- [x] Ruff clean
- [ ] Post-merge: re-run \`rebuild_kb_inline('368884765035593759', 'support')\` on Voys and confirm \`artifacts_processed > 0\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)