### PR TITLE
fix(rag): TAXONOMY-001 multi-KB + Redis cache + SQL bug fix

### DIFF
--- a/deploy/litellm/klai_knowledge.py
+++ b/deploy/litellm/klai_knowledge.py
@@ -446,101 +446,221 @@ _QUERY_REWRITE_AND_CLASSIFY_PROMPT = (
 )
 
 
-def _format_taxonomy_for_prompt(tree: list[dict], max_nodes: int = 30) -> str:
-    """Format taxonomy tree as 'id: name' lines for the LLM prompt."""
-    if not tree:
+def _format_taxonomy_for_prompt(
+    trees: dict[str, list[dict]] | list[dict],
+    max_nodes_per_kb: int = 30,
+) -> str:
+    """Format taxonomy nodes for the classifier prompt.
+
+    Accepts either:
+      * the multi-KB shape ``{kb_slug: [node, ...]}``; renders KB-context
+        labels so the LLM can disambiguate name-collisions across KBs
+        ("Beleid" in voys-support vs voys-billing point at different
+        IDs even though they share a name).
+      * the legacy single-KB shape ``[node, ...]``; renders flat lines.
+
+    Both branches cap node count per KB to keep prompt size bounded.
+    """
+    # Legacy single-KB shape.
+    if isinstance(trees, list):
+        if not trees:
+            return "(none)"
+        lines = [
+            f"- id={node['id']}: {node['name']}" for node in trees[:max_nodes_per_kb]
+        ]
+        if len(trees) > max_nodes_per_kb:
+            lines.append(f"... ({len(trees) - max_nodes_per_kb} more nodes omitted)")
+        return "\n".join(lines)
+
+    # Multi-KB shape.
+    if not trees:
         return "(none)"
-    lines = [f"- id={node['id']}: {node['name']}" for node in tree[:max_nodes]]
-    if len(tree) > max_nodes:
-        lines.append(f"... ({len(tree) - max_nodes} more nodes omitted)")
-    return "\n".join(lines)
+    lines: list[str] = []
+    for kb_slug in sorted(trees.keys()):
+        nodes = trees[kb_slug]
+        if not nodes:
+            continue
+        lines.append(f"[{kb_slug}]")
+        for node in nodes[:max_nodes_per_kb]:
+            lines.append(f"  - id={node['id']}: {node['name']}")
+        if len(nodes) > max_nodes_per_kb:
+            lines.append(f"  ... ({len(nodes) - max_nodes_per_kb} more nodes omitted)")
+    return "\n".join(lines) if lines else "(none)"
 
 
-async def _fetch_taxonomy_tree(
+def _flatten_trees(trees: dict[str, list[dict]] | list[dict]) -> list[dict]:
+    """Return one flat node list across all KBs (for valid_ids lookup)."""
+    if isinstance(trees, list):
+        return list(trees)
+    flat: list[dict] = []
+    for nodes in trees.values():
+        flat.extend(nodes)
+    return flat
+
+
+# SPEC-RAG-TAXONOMY-001 (multi-KB + Redis cache).
+#
+# Cache key: tax_trees:{org_id}:{sorted_kb_slugs_csv}. TTL 300s — short
+# enough that taxonomy changes propagate within minutes without manual
+# bust, long enough that high-traffic chats hit Redis instead of the
+# DB through retrieval-api on every turn.
+_TAXONOMY_TREES_TTL_S = 300
+_TAXONOMY_COVERAGE_TTL_S = 300
+_MAX_KBS_FOR_TAXONOMY = 5
+
+
+def _taxonomy_cache_keys(org_id: str, kb_slugs: list[str]) -> tuple[str, str]:
+    """Stable cache keys for trees + coverage, sorted for determinism."""
+    sig = ",".join(sorted(set(kb_slugs)))
+    return (f"tax_trees:{org_id}:{sig}", f"tax_coverage:{org_id}:{sig}")
+
+
+async def _fetch_taxonomy_trees(
     org_id: str,
-    kb_slug: str,
+    kb_slugs: list[str],
+    cache,
     *,
     _transport: httpx.AsyncBaseTransport | None = None,
-) -> list[dict]:
-    """Fetch the taxonomy tree from retrieval-api /internal/v1/taxonomy/tree.
+) -> dict[str, list[dict]]:
+    """Fetch trees for all KBs in scope. Returns ``{kb_slug: [node, ...]}``.
 
-    Returns [] on any error (fail-open per REQ-2).
+    Multi-KB by design: a single retrieval-api roundtrip handles N slugs.
+    Redis-cached via the LiteLLM DualCache passed by the proxy — a hit
+    returns the same dict shape as the live fetch. Fail-open on any
+    error: returns {} so the hook proceeds without taxonomy narrowing.
+
+    Caps at ``_MAX_KBS_FOR_TAXONOMY`` slugs — beyond that the prompt
+    grows past the single-call budget and the filter is skipped.
     """
-    if not TAXONOMY_ENABLED or not _RETRIEVAL_BASE_URL:
-        return []
-    url = f"{_RETRIEVAL_BASE_URL}/internal/v1/taxonomy/tree"
+    if not TAXONOMY_ENABLED or not _RETRIEVAL_BASE_URL or not kb_slugs:
+        return {}
+    if len(kb_slugs) > _MAX_KBS_FOR_TAXONOMY:
+        logger.info(
+            "KlaiKnowledgeHook: taxonomy_skipped reason=too_many_kbs count=%d",
+            len(kb_slugs),
+        )
+        return {}
+
+    cache_key, _ = _taxonomy_cache_keys(org_id, kb_slugs)
+    if cache is not None:
+        try:
+            cached = await cache.async_get_cache(cache_key)
+        except Exception:
+            cached = None
+        if isinstance(cached, dict):
+            return cached
+
+    url = f"{_RETRIEVAL_BASE_URL}/internal/v1/taxonomy/trees"
     legacy_headers = _retrieve_legacy_headers()
     client_kwargs: dict = {"timeout": TAXONOMY_FETCH_TIMEOUT}
     if _transport is not None:
         client_kwargs["transport"] = _transport
+
+    # httpx serialises list[str] params as repeated query keys when given
+    # a list of (key, value) tuples — that's the shape FastAPI's
+    # ``Query(...)`` decoder expects for kb_slugs=a&kb_slugs=b.
+    params = [("org_id", org_id)] + [("kb_slugs", s) for s in kb_slugs]
     try:
         async with httpx.AsyncClient(**client_kwargs) as client:
-            resp = await client.get(
-                url,
-                params={"org_id": org_id, "kb_slug": kb_slug},
-                headers=legacy_headers,
-            )
+            resp = await client.get(url, params=params, headers=legacy_headers)
             resp.raise_for_status()
-            return resp.json()  # list[dict] with id, name, parent_id, depth
+            data = resp.json()
     except Exception as exc:
         logger.warning(
-            "KlaiKnowledgeHook: taxonomy_tree_fetch_failed org=%s kb=%s error=%s",
+            "KlaiKnowledgeHook: taxonomy_trees_fetch_failed org=%s kbs=%s error=%s",
             org_id,
-            kb_slug,
+            kb_slugs,
             str(exc)[:120],
         )
-        return []
+        return {}
+
+    if not isinstance(data, dict):
+        return {}
+
+    if cache is not None:
+        try:
+            await cache.async_set_cache(cache_key, data, ttl=_TAXONOMY_TREES_TTL_S)
+        except Exception:
+            pass
+    return data
 
 
 async def _fetch_taxonomy_coverage(
     org_id: str,
-    kb_slug: str,
+    kb_slugs: list[str],
+    cache,
     *,
     _transport: httpx.AsyncBaseTransport | None = None,
-) -> float:
-    """Fetch the taxonomy coverage ratio from retrieval-api /internal/v1/taxonomy/coverage.
+) -> dict[str, float]:
+    """Fetch per-KB coverage ratios. Returns ``{kb_slug: 0.0|1.0}``.
 
-    Returns 0.0 on any error (fail-open — caller skips filter when 0.0 < threshold).
+    Redis-cached. Missing KBs default to 0.0. Fail-open on any error.
     """
-    if not TAXONOMY_ENABLED or not _RETRIEVAL_BASE_URL:
-        return 0.0
+    if not TAXONOMY_ENABLED or not _RETRIEVAL_BASE_URL or not kb_slugs:
+        return {slug: 0.0 for slug in kb_slugs}
+
+    _, cache_key = _taxonomy_cache_keys(org_id, kb_slugs)
+    if cache is not None:
+        try:
+            cached = await cache.async_get_cache(cache_key)
+        except Exception:
+            cached = None
+        if isinstance(cached, dict):
+            return {slug: float(cached.get(slug, 0.0)) for slug in kb_slugs}
+
     url = f"{_RETRIEVAL_BASE_URL}/internal/v1/taxonomy/coverage"
     legacy_headers = _retrieve_legacy_headers()
     client_kwargs: dict = {"timeout": TAXONOMY_FETCH_TIMEOUT}
     if _transport is not None:
         client_kwargs["transport"] = _transport
+    params = [("org_id", org_id)] + [("kb_slugs", s) for s in kb_slugs]
     try:
         async with httpx.AsyncClient(**client_kwargs) as client:
-            resp = await client.get(
-                url,
-                params={"org_id": org_id, "kb_slug": kb_slug},
-                headers=legacy_headers,
-            )
+            resp = await client.get(url, params=params, headers=legacy_headers)
             resp.raise_for_status()
-            return float(resp.json().get("coverage", 0.0))
+            data = resp.json()
     except Exception as exc:
         logger.warning(
-            "KlaiKnowledgeHook: taxonomy_coverage_fetch_failed org=%s kb=%s error=%s",
+            "KlaiKnowledgeHook: taxonomy_coverage_fetch_failed org=%s kbs=%s error=%s",
             org_id,
-            kb_slug,
+            kb_slugs,
             str(exc)[:120],
         )
-        return 0.0
+        return {slug: 0.0 for slug in kb_slugs}
+
+    coverage = {slug: float(data.get(slug, 0.0)) for slug in kb_slugs}
+    if cache is not None:
+        try:
+            await cache.async_set_cache(
+                cache_key, coverage, ttl=_TAXONOMY_COVERAGE_TTL_S
+            )
+        except Exception:
+            pass
+    return coverage
 
 
 async def _rewrite_and_classify(
     raw_query: str,
     history: list[dict],
-    taxonomy_tree: list[dict],
+    taxonomy_trees: dict[str, list[dict]] | list[dict],
     *,
     _transport: httpx.AsyncBaseTransport | None = None,
 ) -> tuple[str, list[int], dict]:
     """Return ``(rewritten_query, classified_node_ids, debug_meta)`` in one LLM call.
 
-    Replaces the standalone ``_rewrite_query`` call when taxonomy_tree is non-empty.
-    When taxonomy_tree is empty, falls back to plain rewrite (no classification).
+    Accepts either the multi-KB shape ``{kb_slug: [node, ...]}`` or the
+    legacy single-KB ``[node, ...]`` for backward compat. Internally the
+    classifier sees one merged prompt with KB-context labels (multi-KB)
+    or a flat list (single-KB). Returned IDs are always the unfiltered
+    flat unique-id space — retrieval-api's ANY-of filter does the rest.
 
-    Anti-hallucination guard (REQ-4): only returns node IDs that exist in tree.
+    Replaces the standalone ``_rewrite_query`` call when at least one
+    KB has taxonomy nodes. With empty trees it falls back to plain
+    rewrite (no classification).
+
+    Anti-hallucination guard (REQ-4): only returns node IDs that exist
+    in the union of all provided trees.
+
     Fail-open on any error: falls back to (raw_query, [], meta_with_skip_reason).
     """
     import json as _json  # noqa: PLC0415 — local import avoids shadowing module-level vars
@@ -558,13 +678,15 @@ async def _rewrite_and_classify(
         meta["skipped"] = "no_api_key"
         return raw_query, [], meta
 
+    flat_tree = _flatten_trees(taxonomy_trees)
+
     # No history AND no taxonomy → nothing to do
-    if not history and not taxonomy_tree:
+    if not history and not flat_tree:
         meta["skipped"] = "no_history_no_tree"
         return raw_query, [], meta
 
     # Fall back to plain text prompt when no taxonomy is available
-    if not taxonomy_tree:
+    if not flat_tree:
         rewritten, rewrite_meta = await _rewrite_query(
             raw_query, history, _transport=_transport
         )
@@ -572,7 +694,7 @@ async def _rewrite_and_classify(
 
     # Build combined prompt
     history_str = _format_history_for_rewrite(history) if history else "(none)"
-    taxonomy_str = _format_taxonomy_for_prompt(taxonomy_tree)
+    taxonomy_str = _format_taxonomy_for_prompt(taxonomy_trees)
     prompt = _QUERY_REWRITE_AND_CLASSIFY_PROMPT.format(
         history=history_str,
         raw_query=raw_query,
@@ -593,7 +715,7 @@ async def _rewrite_and_classify(
     if _transport is not None:
         client_kwargs["transport"] = _transport
 
-    valid_ids: set[int] = {int(n["id"]) for n in taxonomy_tree}
+    valid_ids: set[int] = {int(n["id"]) for n in flat_tree}
     t_start = time.monotonic()
     try:
         async with httpx.AsyncClient(**client_kwargs) as client:
@@ -1108,29 +1230,51 @@ class KlaiKnowledgeHook(CustomLogger):
 
         conversation_history = _build_conversation_history(messages)
 
-        # SPEC-RAG-TAXONOMY-001: fetch taxonomy tree for the first KB in scope.
-        # Good-enough heuristic for v1: multi-KB queries skip taxonomy filter.
-        # Fail-open: empty tree = no classify, no filter (REQ-2).
-        first_kb_slug: str | None = (
-            kb_slugs_for_request[0] if kb_slugs_for_request else None
+        # SPEC-RAG-TAXONOMY-001 (multi-KB): fetch taxonomy trees + coverage for
+        # every KB the request is scoped to in a single retrieval-api roundtrip,
+        # Redis-cached. v1 was first-KB-only; v2 merges trees across KBs and
+        # uses per-KB coverage so a mixed-coverage request still benefits from
+        # the KBs that *do* have a curated taxonomy.
+        #
+        # Scope rules:
+        #   * `kb_slugs_for_request is None` → "all org KBs". We don't know the
+        #     full set client-side, so taxonomy is skipped (no_kbs_in_scope).
+        #     Fail-open: retrieval-api still applies its org/scope filters.
+        #   * personal-only scope ("personal") → no org KBs → skip taxonomy.
+        kbs_in_scope: list[str] = (
+            list(kb_slugs_for_request) if kb_slugs_for_request else []
         )
-        taxonomy_tree: list[dict] = []
-        taxonomy_coverage: float = 0.0
-        if first_kb_slug and TAXONOMY_ENABLED and scope in ("org", "both"):
-            taxonomy_tree, taxonomy_coverage = await asyncio.gather(
-                _fetch_taxonomy_tree(org_id, first_kb_slug),
-                _fetch_taxonomy_coverage(org_id, first_kb_slug),
+        taxonomy_trees: dict[str, list[dict]] = {}
+        taxonomy_coverage_map: dict[str, float] = {}
+        if kbs_in_scope and TAXONOMY_ENABLED and scope in ("org", "both"):
+            taxonomy_trees, taxonomy_coverage_map = await asyncio.gather(
+                _fetch_taxonomy_trees(org_id, kbs_in_scope, cache),
+                _fetch_taxonomy_coverage(org_id, kbs_in_scope, cache),
             )
+
+        # Filter to KBs that meet the coverage threshold. The classifier sees
+        # ONLY trees from these KBs so it cannot return IDs from a KB without
+        # curated taxonomy (REQ-1+2: low-coverage KBs run unfiltered).
+        kbs_with_coverage: list[str] = [
+            slug
+            for slug in kbs_in_scope
+            if taxonomy_coverage_map.get(slug, 0.0) >= KLAI_TAXONOMY_COVERAGE_THRESHOLD
+        ]
+        trees_for_classify: dict[str, list[dict]] = {
+            slug: taxonomy_trees.get(slug, []) for slug in kbs_with_coverage
+        }
 
         # SPEC-RAG-QUERY-REWRITE-001 + SPEC-RAG-TAXONOMY-001:
         # Combined rewrite + classify in a single LLM call (REQ-5 zero added roundtrip).
-        # When taxonomy_tree is empty, falls back to plain rewrite (no classification).
+        # When trees_for_classify is empty, falls back to plain rewrite.
+        # Anti-hallucination guard inside _rewrite_and_classify filters IDs to
+        # the union of all valid IDs across the provided KBs (REQ-4).
         # Fail-open: any failure returns (raw_query, [], meta_with_skip_reason).
         (
             rewritten_query,
             classified_node_ids,
             rewrite_meta,
-        ) = await _rewrite_and_classify(query, conversation_history, taxonomy_tree)
+        ) = await _rewrite_and_classify(query, conversation_history, trees_for_classify)
         try:
             logger.info(
                 "query_rewrite org_id=%s user_id=%s raw_query=%r rewritten_query=%r "
@@ -1147,29 +1291,38 @@ class KlaiKnowledgeHook(CustomLogger):
             # Logging itself must never abort the hook (REQ-2 fail-open).
             pass
 
-        # SPEC-RAG-TAXONOMY-001 REQ-1+2: inject taxonomy filter iff coverage >= threshold
-        # AND the classifier returned at least one valid node ID.
+        # SPEC-RAG-TAXONOMY-001 REQ-1+2: inject taxonomy filter iff at least
+        # one in-scope KB has coverage AND the classifier returned >= 1 valid
+        # node ID. node IDs are globally unique across portal_taxonomy_nodes,
+        # so retrieval-api's ANY-of filter is collision-free across KBs.
         taxonomy_applied = False
         taxonomy_skip_reason: str | None = None
-        if TAXONOMY_ENABLED and first_kb_slug:
-            if taxonomy_coverage < KLAI_TAXONOMY_COVERAGE_THRESHOLD:
-                taxonomy_skip_reason = "low_coverage"
-            elif not classified_node_ids:
-                taxonomy_skip_reason = "empty_classify"
-            else:
-                taxonomy_applied = True
+        if not TAXONOMY_ENABLED:
+            taxonomy_skip_reason = "disabled"
+        elif not kbs_in_scope:
+            taxonomy_skip_reason = "no_kbs_in_scope"
+        elif not kbs_with_coverage:
+            taxonomy_skip_reason = "all_kbs_low_coverage"
+        elif not classified_node_ids:
+            taxonomy_skip_reason = "empty_classify"
         else:
-            taxonomy_skip_reason = "no_kb_slug" if not first_kb_slug else "disabled"
+            taxonomy_applied = True
 
         # REQ-7: log taxonomy_classify event on every classify invocation.
-        if TAXONOMY_ENABLED and first_kb_slug:
+        if TAXONOMY_ENABLED and kbs_in_scope:
             try:
+                coverage_repr = ",".join(
+                    f"{slug}={taxonomy_coverage_map.get(slug, 0.0):.2f}"
+                    for slug in kbs_in_scope
+                )
                 logger.info(
-                    "taxonomy_classify org_id=%s kb_slug=%s coverage_ratio=%.3f "
-                    "classified_node_ids=%s was_applied=%s skip_reason=%s",
+                    "taxonomy_classify org_id=%s kb_slugs=%s coverage=%s "
+                    "kbs_with_coverage=%s classified_node_ids=%s "
+                    "was_applied=%s skip_reason=%s",
                     org_id,
-                    first_kb_slug,
-                    taxonomy_coverage,
+                    ",".join(kbs_in_scope),
+                    coverage_repr,
+                    ",".join(kbs_with_coverage),
                     classified_node_ids,
                     taxonomy_applied,
                     taxonomy_skip_reason,

--- a/deploy/litellm/tests/test_taxonomy_classify.py
+++ b/deploy/litellm/tests/test_taxonomy_classify.py
@@ -1,11 +1,15 @@
-"""SPEC-RAG-TAXONOMY-001 — _rewrite_and_classify + fetch helpers unit tests.
+"""SPEC-RAG-TAXONOMY-001 (multi-KB) — _rewrite_and_classify + fetch helpers.
 
-Tests:
-- _rewrite_and_classify: skip when no tree, happy path, anti-hallucination guard,
-  fail-open on LLM error, falls back to plain rewrite when tree is empty.
-- _fetch_taxonomy_tree: returns list on 200, [] on 4xx/5xx/timeout.
-- _fetch_taxonomy_coverage: returns float on 200, 0.0 on error.
-- _format_taxonomy_for_prompt: truncates at max_nodes.
+Tests cover the v2 multi-KB shape:
+- ``_rewrite_and_classify`` accepts ``dict[str, list[dict]]`` (multi-KB)
+  AND ``list[dict]`` (legacy single-KB) for backward compat.
+- ``_fetch_taxonomy_trees`` calls ``/internal/v1/taxonomy/trees`` with
+  repeated ``kb_slugs`` query params and a Redis cache hit short-circuit.
+- ``_fetch_taxonomy_coverage`` returns ``{kb_slug: 0.0|1.0}`` via the
+  multi-KB endpoint.
+- ``_format_taxonomy_for_prompt`` renders both shapes with KB-context
+  labels for the multi-KB shape.
+- ``_flatten_trees`` produces a single flat list across all KBs.
 
 litellm is not installed locally (runs in Docker), so we mock the import.
 """
@@ -75,6 +79,28 @@ def _load_hook(monkeypatch, extra_env=None):
 
 
 # ---------------------------------------------------------------------------
+# Cache stub (mimics LiteLLM DualCache surface used by the hook)
+# ---------------------------------------------------------------------------
+
+
+class _StubCache:
+    """In-memory cache supporting async_get_cache / async_set_cache."""
+
+    def __init__(self) -> None:
+        self.store: dict = {}
+        self.gets: list[str] = []
+        self.sets: list[tuple[str, object, int | None]] = []
+
+    async def async_get_cache(self, key: str):
+        self.gets.append(key)
+        return self.store.get(key)
+
+    async def async_set_cache(self, key: str, value, ttl: int | None = None) -> None:
+        self.sets.append((key, value, ttl))
+        self.store[key] = value
+
+
+# ---------------------------------------------------------------------------
 # Transport mocks
 # ---------------------------------------------------------------------------
 
@@ -85,8 +111,10 @@ class _MockTransport(httpx.AsyncBaseTransport):
     def __init__(self, status_code: int, json_body=None) -> None:
         self._status_code = status_code
         self._json_body = json_body if json_body is not None else {}
+        self.requests: list[httpx.Request] = []
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
         return httpx.Response(
             status_code=self._status_code,
             headers={"content-type": "application/json"},
@@ -99,10 +127,11 @@ class _RoutedTransport(httpx.AsyncBaseTransport):
     """Return different responses based on the request URL path."""
 
     def __init__(self, routes: dict) -> None:
-        # routes = {"/internal/v1/taxonomy/tree": (200, [...]), ...}
         self._routes = routes
+        self.requests: list[httpx.Request] = []
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
         path = request.url.path
         status, body = self._routes.get(path, (404, {"detail": "not found"}))
         return httpx.Response(
@@ -133,7 +162,38 @@ def _llm_json_response(rewritten_query: str, taxonomy_node_ids: list) -> dict:
     }
 
 
-_TREE = [
+# Multi-KB sample: support and billing each have their own subtree.
+# Node IDs are globally unique (single PK), so the merged set covers both.
+_TREES_MULTI = {
+    "support": [
+        {
+            "id": 1,
+            "kb_slug": "support",
+            "name": "SSO",
+            "slug": "sso",
+            "parent_id": None,
+        },
+        {"id": 2, "kb_slug": "support", "name": "SAML", "slug": "saml", "parent_id": 1},
+    ],
+    "billing": [
+        {
+            "id": 10,
+            "kb_slug": "billing",
+            "name": "Invoices",
+            "slug": "invoices",
+            "parent_id": None,
+        },
+        {
+            "id": 11,
+            "kb_slug": "billing",
+            "name": "Refunds",
+            "slug": "refunds",
+            "parent_id": 10,
+        },
+    ],
+}
+
+_TREE_LEGACY = [
     {"id": 1, "name": "SSO", "parent_id": None, "depth": 0},
     {"id": 2, "name": "SAML", "parent_id": 1, "depth": 1},
     {"id": 3, "name": "OAuth", "parent_id": 1, "depth": 1},
@@ -154,7 +214,9 @@ class TestRewriteAndClassifySkips:
     @pytest.mark.asyncio
     async def test_skips_empty_query(self, monkeypatch):
         hook = _load_hook(monkeypatch)
-        rewritten, ids, meta = await hook._rewrite_and_classify("", _HISTORY, _TREE)
+        rewritten, ids, meta = await hook._rewrite_and_classify(
+            "", _HISTORY, _TREES_MULTI
+        )
         assert rewritten == ""
         assert ids == []
         assert meta["skipped"] == "empty_query"
@@ -163,7 +225,7 @@ class TestRewriteAndClassifySkips:
     async def test_skips_when_disabled(self, monkeypatch):
         hook = _load_hook(monkeypatch, extra_env={"QUERY_REWRITE_ENABLED": "false"})
         rewritten, ids, meta = await hook._rewrite_and_classify(
-            "Wat is SAML?", _HISTORY, _TREE
+            "Wat is SAML?", _HISTORY, _TREES_MULTI
         )
         assert rewritten == "Wat is SAML?"
         assert ids == []
@@ -173,23 +235,33 @@ class TestRewriteAndClassifySkips:
     async def test_skips_when_no_api_key(self, monkeypatch):
         hook = _load_hook(monkeypatch, extra_env={"MISTRAL_API_KEY": ""})
         rewritten, ids, meta = await hook._rewrite_and_classify(
-            "Wat is SAML?", _HISTORY, _TREE
+            "Wat is SAML?", _HISTORY, _TREES_MULTI
         )
         assert ids == []
         assert meta["skipped"] == "no_api_key"
 
     @pytest.mark.asyncio
-    async def test_skips_classify_when_no_history_and_no_tree(self, monkeypatch):
+    async def test_skips_when_no_history_and_empty_dict(self, monkeypatch):
         hook = _load_hook(monkeypatch)
-        rewritten, ids, meta = await hook._rewrite_and_classify("Wat is SAML?", [], [])
-        # No history, no tree → skip (no_history_no_tree)
+        rewritten, ids, meta = await hook._rewrite_and_classify("Wat is SAML?", [], {})
         assert rewritten == "Wat is SAML?"
         assert ids == []
         assert meta["skipped"] == "no_history_no_tree"
 
     @pytest.mark.asyncio
-    async def test_falls_back_to_plain_rewrite_when_tree_empty(self, monkeypatch):
-        """Empty tree → falls back to _rewrite_query (plain text prompt, no classify)."""
+    async def test_skips_when_no_history_and_empty_list(self, monkeypatch):
+        """Legacy list shape: empty list also triggers the no-tree skip."""
+        hook = _load_hook(monkeypatch)
+        rewritten, ids, meta = await hook._rewrite_and_classify("Wat is SAML?", [], [])
+        assert rewritten == "Wat is SAML?"
+        assert ids == []
+        assert meta["skipped"] == "no_history_no_tree"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_plain_rewrite_when_dict_empty_with_history(
+        self, monkeypatch
+    ):
+        """Empty trees dict + history → plain _rewrite_query, no classify."""
         hook = _load_hook(monkeypatch)
         rewritten_str = "Wat is de status van de SAML-configuratie?"
         transport = _MockTransport(
@@ -202,92 +274,68 @@ class TestRewriteAndClassifySkips:
             },
         )
         rewritten, ids, meta = await hook._rewrite_and_classify(
-            "Wat is de status?", _HISTORY, [], _transport=transport
+            "Wat is de status?", _HISTORY, {}, _transport=transport
         )
         assert rewritten == rewritten_str
         assert ids == []
-        # Meta is from plain _rewrite_query: was_changed should be True
         assert meta["was_changed"] is True
 
 
 # ---------------------------------------------------------------------------
-# _rewrite_and_classify — happy path
+# _rewrite_and_classify — multi-KB happy path
 # ---------------------------------------------------------------------------
 
 
-class TestRewriteAndClassifyHappyPath:
+class TestRewriteAndClassifyMultiKB:
     @pytest.mark.asyncio
-    async def test_returns_rewritten_query_and_ids(self, monkeypatch):
-        """Full happy path: LLM returns rewritten query + valid IDs."""
+    async def test_returns_ids_from_any_kb(self, monkeypatch):
+        """Classifier may pick IDs from any KB in the merged tree."""
         hook = _load_hook(monkeypatch)
         transport = _MockTransport(
             status_code=200,
-            json_body=_llm_json_response(
-                "Hoe configureer je SAML-authenticatie?", [1, 2]
-            ),
+            # Picks IDs from BOTH support (1, 2) and billing (10).
+            json_body=_llm_json_response("Hoe regel ik SAML en facturen?", [1, 2, 10]),
         )
 
         rewritten, ids, meta = await hook._rewrite_and_classify(
-            "Hoe doe je dat?", _HISTORY, _TREE, _transport=transport
+            "Hoe doe je dat?", _HISTORY, _TREES_MULTI, _transport=transport
         )
 
-        assert rewritten == "Hoe configureer je SAML-authenticatie?"
-        assert 1 in ids
-        assert 2 in ids
+        assert rewritten == "Hoe regel ik SAML en facturen?"
+        assert set(ids) == {1, 2, 10}
         assert meta["was_changed"] is True
-        assert meta["rewrite_ms"] >= 0
 
     @pytest.mark.asyncio
-    async def test_drops_hallucinated_ids(self, monkeypatch):
-        """Anti-hallucination guard (REQ-4): IDs not in tree are filtered out."""
+    async def test_drops_hallucinated_ids_across_kbs(self, monkeypatch):
+        """Anti-hallucination guard: IDs not in ANY KB tree are filtered out."""
         hook = _load_hook(monkeypatch)
         transport = _MockTransport(
             status_code=200,
-            # IDs 1, 2, 3 are valid; 99 and 1000 are hallucinated
-            json_body=_llm_json_response("Hoe configureer je SAML?", [1, 2, 99, 1000]),
+            # Valid: 1, 11. Hallucinated: 99, 1000.
+            json_body=_llm_json_response("Hoe regel ik SAML?", [1, 11, 99, 1000]),
         )
 
         rewritten, ids, meta = await hook._rewrite_and_classify(
-            "Hoe doe je dat?", _HISTORY, _TREE, _transport=transport
+            "Hoe doe je dat?", _HISTORY, _TREES_MULTI, _transport=transport
+        )
+
+        assert set(ids) == {1, 11}
+
+    @pytest.mark.asyncio
+    async def test_legacy_list_shape_still_works(self, monkeypatch):
+        """Backward compat: list[dict] tree shape continues to work."""
+        hook = _load_hook(monkeypatch)
+        transport = _MockTransport(
+            status_code=200,
+            json_body=_llm_json_response("Hoe configureer je SAML?", [1, 2]),
+        )
+
+        rewritten, ids, meta = await hook._rewrite_and_classify(
+            "Hoe doe je dat?", _HISTORY, _TREE_LEGACY, _transport=transport
         )
 
         assert set(ids) == {1, 2}
-        assert 99 not in ids
-        assert 1000 not in ids
-
-    @pytest.mark.asyncio
-    async def test_returns_empty_ids_when_llm_classifies_none(self, monkeypatch):
-        """LLM returns empty taxonomy_node_ids → [] is valid (query is off-topic)."""
-        hook = _load_hook(monkeypatch)
-        transport = _MockTransport(
-            status_code=200,
-            json_body=_llm_json_response("Hoe reset ik mijn wachtwoord?", []),
-        )
-
-        rewritten, ids, meta = await hook._rewrite_and_classify(
-            "Wachtwoord vergeten", _HISTORY, _TREE, _transport=transport
-        )
-
-        assert ids == []
-        assert rewritten == "Hoe reset ik mijn wachtwoord?"
-
-    @pytest.mark.asyncio
-    async def test_was_changed_false_when_query_unchanged(self, monkeypatch):
-        """If LLM returns the same query text, was_changed is False."""
-        hook = _load_hook(monkeypatch)
-        raw = "Wat is OAuth?"
-        transport = _MockTransport(
-            status_code=200,
-            json_body=_llm_json_response(raw, [3]),
-        )
-
-        rewritten, ids, meta = await hook._rewrite_and_classify(
-            raw, _HISTORY, _TREE, _transport=transport
-        )
-
-        assert rewritten == raw
-        assert meta["was_changed"] is False
-        assert 3 in ids
+        assert meta["was_changed"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -302,10 +350,9 @@ class TestRewriteAndClassifyFailOpen:
         transport = _MockTransport(status_code=500, json_body={"detail": "boom"})
 
         rewritten, ids, meta = await hook._rewrite_and_classify(
-            "Wat is SAML?", _HISTORY, _TREE, _transport=transport
+            "Wat is SAML?", _HISTORY, _TREES_MULTI, _transport=transport
         )
 
-        # Must return raw query unchanged (fail-open REQ-2)
         assert rewritten == "Wat is SAML?"
         assert ids == []
         assert meta["skipped"] == "exception"
@@ -313,7 +360,6 @@ class TestRewriteAndClassifyFailOpen:
 
     @pytest.mark.asyncio
     async def test_falls_back_on_malformed_json(self, monkeypatch):
-        """LLM returns non-JSON content → fail-open."""
         hook = _load_hook(monkeypatch)
 
         class _BadJsonTransport(httpx.AsyncBaseTransport):
@@ -321,21 +367,22 @@ class TestRewriteAndClassifyFailOpen:
                 return httpx.Response(
                     status_code=200,
                     headers={"content-type": "application/json"},
-                    content=b'{"choices": [{"message": {"role": "assistant", "content": "not valid json at all"}}]}',
+                    content=(
+                        b'{"choices": [{"message": {"role": "assistant", '
+                        b'"content": "not valid json at all"}}]}'
+                    ),
                     request=request,
                 )
 
         rewritten, ids, meta = await hook._rewrite_and_classify(
-            "Wat is SAML?", _HISTORY, _TREE, _transport=_BadJsonTransport()
+            "Wat is SAML?", _HISTORY, _TREES_MULTI, _transport=_BadJsonTransport()
         )
 
-        # json.loads("not valid json at all") raises → parsed = {} → rewritten_query absent
         assert rewritten == "Wat is SAML?"
         assert ids == []
 
     @pytest.mark.asyncio
     async def test_falls_back_when_rewritten_query_empty(self, monkeypatch):
-        """LLM returns empty rewritten_query → fall back to raw."""
         hook = _load_hook(monkeypatch)
         transport = _MockTransport(
             status_code=200,
@@ -343,7 +390,7 @@ class TestRewriteAndClassifyFailOpen:
         )
 
         rewritten, ids, meta = await hook._rewrite_and_classify(
-            "Wat is SAML?", _HISTORY, _TREE, _transport=transport
+            "Wat is SAML?", _HISTORY, _TREES_MULTI, _transport=transport
         )
 
         assert rewritten == "Wat is SAML?"
@@ -352,142 +399,235 @@ class TestRewriteAndClassifyFailOpen:
 
 
 # ---------------------------------------------------------------------------
-# _fetch_taxonomy_tree
+# _fetch_taxonomy_trees (multi-KB)
 # ---------------------------------------------------------------------------
 
 
-class TestFetchTaxonomyTree:
+class TestFetchTaxonomyTrees:
     @pytest.mark.asyncio
-    async def test_returns_list_on_200(self, monkeypatch):
+    async def test_returns_dict_on_200(self, monkeypatch):
         hook = _load_hook(monkeypatch)
-        tree_data = [{"id": 1, "name": "Root", "parent_id": None, "depth": 0}]
-        transport = _MockTransport(status_code=200, json_body=tree_data)
+        transport = _MockTransport(status_code=200, json_body=_TREES_MULTI)
+        cache = _StubCache()
 
-        result = await hook._fetch_taxonomy_tree("org-1", "kb-1", _transport=transport)
+        result = await hook._fetch_taxonomy_trees(
+            "org-1", ["support", "billing"], cache, _transport=transport
+        )
 
-        assert result == tree_data
+        assert "support" in result
+        assert "billing" in result
+        # One request, with kb_slugs as repeated query params.
+        assert len(transport.requests) == 1
+        req_url = str(transport.requests[0].url)
+        assert "kb_slugs=support" in req_url
+        assert "kb_slugs=billing" in req_url
 
     @pytest.mark.asyncio
-    async def test_returns_empty_on_404(self, monkeypatch):
+    async def test_redis_cache_hit_short_circuits_request(self, monkeypatch):
         hook = _load_hook(monkeypatch)
-        transport = _MockTransport(status_code=404, json_body={"detail": "not found"})
+        transport = _MockTransport(status_code=200, json_body={"unused": []})
+        cache = _StubCache()
+        cache.store["tax_trees:org-1:billing,support"] = _TREES_MULTI
 
-        result = await hook._fetch_taxonomy_tree("org-1", "kb-x", _transport=transport)
+        result = await hook._fetch_taxonomy_trees(
+            "org-1", ["support", "billing"], cache, _transport=transport
+        )
 
-        assert result == []
+        assert result == _TREES_MULTI
+        # No HTTP request fired.
+        assert transport.requests == []
 
     @pytest.mark.asyncio
-    async def test_returns_empty_on_500(self, monkeypatch):
+    async def test_writes_to_cache_on_miss(self, monkeypatch):
         hook = _load_hook(monkeypatch)
-        transport = _MockTransport(status_code=500, json_body={"detail": "error"})
+        transport = _MockTransport(status_code=200, json_body=_TREES_MULTI)
+        cache = _StubCache()
 
-        result = await hook._fetch_taxonomy_tree("org-1", "kb-1", _transport=transport)
+        await hook._fetch_taxonomy_trees(
+            "org-1", ["support", "billing"], cache, _transport=transport
+        )
 
-        assert result == []
+        keys_set = [k for k, _, _ in cache.sets]
+        assert "tax_trees:org-1:billing,support" in keys_set
 
     @pytest.mark.asyncio
-    async def test_returns_empty_when_taxonomy_disabled(self, monkeypatch):
+    async def test_returns_empty_on_5xx(self, monkeypatch):
+        hook = _load_hook(monkeypatch)
+        transport = _MockTransport(status_code=500, json_body={"detail": "boom"})
+        cache = _StubCache()
+
+        result = await hook._fetch_taxonomy_trees(
+            "org-1", ["support"], cache, _transport=transport
+        )
+
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_disabled(self, monkeypatch):
         hook = _load_hook(monkeypatch, extra_env={"TAXONOMY_ENABLED": "false"})
+        cache = _StubCache()
 
-        # No transport passed; if it made a real request it would fail
-        result = await hook._fetch_taxonomy_tree("org-1", "kb-1")
+        result = await hook._fetch_taxonomy_trees("org-1", ["support"], cache)
 
-        assert result == []
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_kb_slugs_empty(self, monkeypatch):
+        hook = _load_hook(monkeypatch)
+        cache = _StubCache()
+
+        result = await hook._fetch_taxonomy_trees("org-1", [], cache)
+
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_skips_when_too_many_kbs(self, monkeypatch):
+        """Cap at _MAX_KBS_FOR_TAXONOMY (5) — returns {} above the cap."""
+        hook = _load_hook(monkeypatch)
+        cache = _StubCache()
+        too_many = ["kb1", "kb2", "kb3", "kb4", "kb5", "kb6"]
+
+        result = await hook._fetch_taxonomy_trees("org-1", too_many, cache)
+
+        assert result == {}
 
 
 # ---------------------------------------------------------------------------
-# _fetch_taxonomy_coverage
+# _fetch_taxonomy_coverage (multi-KB)
 # ---------------------------------------------------------------------------
 
 
 class TestFetchTaxonomyCoverage:
     @pytest.mark.asyncio
-    async def test_returns_float_on_200(self, monkeypatch):
+    async def test_returns_per_kb_floats_on_200(self, monkeypatch):
         hook = _load_hook(monkeypatch)
-        transport = _MockTransport(status_code=200, json_body={"coverage": 0.65})
+        transport = _MockTransport(
+            status_code=200, json_body={"support": 1.0, "billing": 0.0}
+        )
+        cache = _StubCache()
 
         result = await hook._fetch_taxonomy_coverage(
-            "org-1", "kb-1", _transport=transport
+            "org-1", ["support", "billing"], cache, _transport=transport
         )
 
-        assert abs(result - 0.65) < 1e-6
+        assert result == {"support": 1.0, "billing": 0.0}
 
     @pytest.mark.asyncio
-    async def test_returns_zero_on_error(self, monkeypatch):
+    async def test_missing_kb_defaults_to_zero(self, monkeypatch):
+        """If the API only returns coverage for one KB, others default to 0."""
+        hook = _load_hook(monkeypatch)
+        transport = _MockTransport(status_code=200, json_body={"support": 1.0})
+        cache = _StubCache()
+
+        result = await hook._fetch_taxonomy_coverage(
+            "org-1", ["support", "billing"], cache, _transport=transport
+        )
+
+        assert result == {"support": 1.0, "billing": 0.0}
+
+    @pytest.mark.asyncio
+    async def test_returns_zeros_on_error(self, monkeypatch):
         hook = _load_hook(monkeypatch)
         transport = _MockTransport(status_code=500, json_body={"detail": "boom"})
+        cache = _StubCache()
 
         result = await hook._fetch_taxonomy_coverage(
-            "org-1", "kb-1", _transport=transport
+            "org-1", ["support", "billing"], cache, _transport=transport
         )
 
-        assert result == 0.0
+        assert result == {"support": 0.0, "billing": 0.0}
 
     @pytest.mark.asyncio
-    async def test_returns_zero_when_key_missing(self, monkeypatch):
-        """Response JSON without 'coverage' key → 0.0."""
-        hook = _load_hook(monkeypatch)
-        transport = _MockTransport(status_code=200, json_body={})
-
-        result = await hook._fetch_taxonomy_coverage(
-            "org-1", "kb-1", _transport=transport
-        )
-
-        assert result == 0.0
-
-    @pytest.mark.asyncio
-    async def test_returns_zero_when_disabled(self, monkeypatch):
+    async def test_returns_zeros_when_disabled(self, monkeypatch):
         hook = _load_hook(monkeypatch, extra_env={"TAXONOMY_ENABLED": "false"})
+        cache = _StubCache()
 
-        result = await hook._fetch_taxonomy_coverage("org-1", "kb-1")
+        result = await hook._fetch_taxonomy_coverage("org-1", ["support"], cache)
 
-        assert result == 0.0
+        assert result == {"support": 0.0}
+
+    @pytest.mark.asyncio
+    async def test_redis_cache_hit_short_circuits_request(self, monkeypatch):
+        hook = _load_hook(monkeypatch)
+        transport = _MockTransport(status_code=200, json_body={"unused": 1.0})
+        cache = _StubCache()
+        cache.store["tax_coverage:org-1:billing,support"] = {
+            "support": 1.0,
+            "billing": 0.0,
+        }
+
+        result = await hook._fetch_taxonomy_coverage(
+            "org-1", ["support", "billing"], cache, _transport=transport
+        )
+
+        assert result == {"support": 1.0, "billing": 0.0}
+        assert transport.requests == []
 
 
 # ---------------------------------------------------------------------------
-# _format_taxonomy_for_prompt
+# _format_taxonomy_for_prompt (multi-KB + legacy)
 # ---------------------------------------------------------------------------
 
 
 class TestFormatTaxonomyForPrompt:
-    def test_formats_nodes_as_id_name_lines(self, monkeypatch):
+    def test_legacy_list_renders_flat_lines(self, monkeypatch):
         hook = _load_hook(monkeypatch)
-        tree = [
-            {"id": 1, "name": "SSO", "parent_id": None, "depth": 0},
-            {"id": 2, "name": "SAML", "parent_id": 1, "depth": 1},
-        ]
-        result = hook._format_taxonomy_for_prompt(tree)
+        result = hook._format_taxonomy_for_prompt(_TREE_LEGACY)
         assert "id=1: SSO" in result
         assert "id=2: SAML" in result
 
-    def test_returns_none_for_empty_tree(self, monkeypatch):
+    def test_multi_kb_dict_renders_kb_labels(self, monkeypatch):
+        """Multi-KB shape MUST surface the KB context to the LLM."""
         hook = _load_hook(monkeypatch)
-        result = hook._format_taxonomy_for_prompt([])
-        assert result == "(none)"
+        result = hook._format_taxonomy_for_prompt(_TREES_MULTI)
+        # KB context labels.
+        assert "[support]" in result
+        assert "[billing]" in result
+        # Nodes from each KB.
+        assert "id=1: SSO" in result
+        assert "id=10: Invoices" in result
 
-    def test_truncates_at_max_nodes(self, monkeypatch):
+    def test_returns_none_for_empty_legacy(self, monkeypatch):
         hook = _load_hook(monkeypatch)
-        tree = [
-            {"id": i, "name": f"Node {i}", "parent_id": None, "depth": 0}
-            for i in range(50)
-        ]
+        assert hook._format_taxonomy_for_prompt([]) == "(none)"
 
-        result = hook._format_taxonomy_for_prompt(tree, max_nodes=10)
+    def test_returns_none_for_empty_dict(self, monkeypatch):
+        hook = _load_hook(monkeypatch)
+        assert hook._format_taxonomy_for_prompt({}) == "(none)"
 
-        # Exactly 10 node lines + 1 truncation line
-        lines = result.splitlines()
-        node_lines = [ln for ln in lines if ln.startswith("- id=")]
+    def test_truncates_at_max_nodes_per_kb(self, monkeypatch):
+        hook = _load_hook(monkeypatch)
+        big = {
+            "kb1": [
+                {"id": i, "kb_slug": "kb1", "name": f"Node {i}", "parent_id": None}
+                for i in range(50)
+            ]
+        }
+
+        result = hook._format_taxonomy_for_prompt(big, max_nodes_per_kb=10)
+
+        node_lines = [ln for ln in result.splitlines() if "id=" in ln]
         assert len(node_lines) == 10
         assert "more nodes omitted" in result
 
-    def test_no_truncation_line_when_within_limit(self, monkeypatch):
+
+# ---------------------------------------------------------------------------
+# _flatten_trees
+# ---------------------------------------------------------------------------
+
+
+class TestFlattenTrees:
+    def test_flattens_dict_to_single_list(self, monkeypatch):
         hook = _load_hook(monkeypatch)
-        tree = [
-            {"id": i, "name": f"Node {i}", "parent_id": None, "depth": 0}
-            for i in range(5)
-        ]
+        flat = hook._flatten_trees(_TREES_MULTI)
+        ids = {n["id"] for n in flat}
+        assert ids == {1, 2, 10, 11}
 
-        result = hook._format_taxonomy_for_prompt(tree, max_nodes=10)
+    def test_passthrough_for_legacy_list(self, monkeypatch):
+        hook = _load_hook(monkeypatch)
+        flat = hook._flatten_trees(_TREE_LEGACY)
+        assert flat == _TREE_LEGACY
 
-        assert "omitted" not in result
-        assert result.count("- id=") == 5
+    def test_empty_dict_returns_empty_list(self, monkeypatch):
+        hook = _load_hook(monkeypatch)
+        assert hook._flatten_trees({}) == []

--- a/klai-retrieval-api/retrieval_api/api/taxonomy.py
+++ b/klai-retrieval-api/retrieval_api/api/taxonomy.py
@@ -1,9 +1,16 @@
 """Internal taxonomy endpoints for the LiteLLM hook.
 
-GET /internal/v1/taxonomy/tree   — taxonomy node list for a KB
-GET /internal/v1/taxonomy/coverage — coverage ratio for a KB
+GET /internal/v1/taxonomy/trees      — multi-KB taxonomy node list
+GET /internal/v1/taxonomy/coverage   — multi-KB coverage ratio map
+
+Both endpoints accept ``kb_slugs`` as a repeated query parameter:
+  /internal/v1/taxonomy/trees?org_id=…&kb_slugs=support&kb_slugs=billing
 
 Auth: same X-Internal-Secret as /retrieve (enforced by AuthMiddleware globally).
+
+Note: the legacy single-KB ``/tree`` and ``/coverage`` endpoints are
+retained as thin wrappers around the multi-KB helpers for any caller
+that hasn't migrated yet.
 """
 
 from __future__ import annotations
@@ -13,36 +20,61 @@ from fastapi import APIRouter, Query
 
 from retrieval_api.services.taxonomy_lookup import (
     get_kb_taxonomy_coverage,
-    get_taxonomy_tree,
+    get_taxonomy_trees,
 )
 
 logger = structlog.get_logger()
 
 router = APIRouter(prefix="/internal/v1/taxonomy")
 
+# Module-level Query singletons — avoid ruff B008 ("function call in default
+# argument") while keeping FastAPI's parameter-source declaration centralised.
+_ORG_ID_Q = Query(..., description="Zitadel org ID")
+_KB_SLUGS_Q = Query(..., description="One or more KB slugs")
+_KB_SLUG_Q = Query(..., description="KB slug")
 
-@router.get("/tree")
-async def taxonomy_tree(
-    org_id: str = Query(..., description="Zitadel org ID"),
-    kb_slug: str = Query(..., description="KB slug"),
-) -> list[dict]:
-    """Return the flat taxonomy node list for the KB.
 
-    Returns [] when the KB has no taxonomy or on any DB error (fail-open).
+@router.get("/trees")
+async def taxonomy_trees(
+    org_id: str = _ORG_ID_Q,
+    kb_slugs: list[str] = _KB_SLUGS_Q,
+) -> dict[str, list[dict]]:
+    """Return ``{kb_slug: [node, ...]}`` for the requested KBs.
+
+    Empty mapping when no KB has taxonomy or on any DB error (fail-open).
     """
-    tree = await get_taxonomy_tree(org_id, kb_slug)
-    # Convert TypedDicts to plain dicts for JSON serialization
-    return [dict(node) for node in tree]
+    grouped = await get_taxonomy_trees(org_id, kb_slugs)
+    return {slug: [dict(n) for n in nodes] for slug, nodes in grouped.items()}
 
 
 @router.get("/coverage")
 async def taxonomy_coverage(
-    org_id: str = Query(..., description="Zitadel org ID"),
-    kb_slug: str = Query(..., description="KB slug"),
-) -> dict:
-    """Return the taxonomy tagging coverage ratio for the KB.
+    org_id: str = _ORG_ID_Q,
+    kb_slugs: list[str] = _KB_SLUGS_Q,
+) -> dict[str, float]:
+    """Return ``{kb_slug: coverage_ratio}`` for the requested KBs."""
+    return await get_kb_taxonomy_coverage(org_id, kb_slugs)
 
-    Returns {"coverage": 0.0} on any DB error (fail-open).
-    """
-    coverage = await get_kb_taxonomy_coverage(org_id, kb_slug)
-    return {"coverage": coverage}
+
+# ---------------------------------------------------------------------------
+# Legacy single-KB endpoints (kept for backward compat with any in-flight
+# clients; thin wrappers around the multi-KB helpers).
+# ---------------------------------------------------------------------------
+
+
+@router.get("/tree")
+async def taxonomy_tree_legacy(
+    org_id: str = _ORG_ID_Q,
+    kb_slug: str = _KB_SLUG_Q,
+) -> list[dict]:
+    grouped = await get_taxonomy_trees(org_id, [kb_slug])
+    return [dict(n) for n in grouped.get(kb_slug, [])]
+
+
+@router.get("/coverage-single")
+async def taxonomy_coverage_legacy(
+    org_id: str = _ORG_ID_Q,
+    kb_slug: str = _KB_SLUG_Q,
+) -> dict:
+    cov = await get_kb_taxonomy_coverage(org_id, [kb_slug])
+    return {"coverage": cov.get(kb_slug, 0.0)}

--- a/klai-retrieval-api/retrieval_api/services/taxonomy_lookup.py
+++ b/klai-retrieval-api/retrieval_api/services/taxonomy_lookup.py
@@ -1,164 +1,157 @@
-"""Taxonomy tree and coverage helpers for query-time taxonomy filtering.
+"""Taxonomy tree + coverage helpers for query-time taxonomy filtering.
 
-Fetches the KB taxonomy tree and coverage stats from the klai database via the
-shared asyncpg pool (events.py pool). Results are cached in-process with TTLs:
+Reads from the actual portal taxonomy schema:
+  - ``portal_taxonomy_nodes`` (per-KB taxonomy tree, ``kb_id`` FK)
+  - ``portal_knowledge_bases`` (slug + org_id resolution)
+  - ``portal_orgs`` (zitadel_org_id → id resolution)
 
-  - Taxonomy tree: 60 s per (org_id, kb_slug)
-  - Coverage ratio: 300 s per (org_id, kb_slug)
+Multi-KB by design: the tree fetch accepts a list of slugs and returns
+a single flat list with ``kb_slug`` annotated on each node. Taxonomy
+node IDs are globally unique (single PK across all KBs of all tenants),
+so the merged tree is collision-free — the LLM classifier can return
+any subset of valid IDs and the retrieval-api ANY-of filter does the
+rest at query time.
 
-All functions are fail-open: on any DB error they return empty / 0.0 so
-retrieval proceeds without taxonomy narrowing (SPEC-RAG-TAXONOMY-001 REQ-2).
+Coverage proxy: a KB has "taxonomy coverage" iff it has ≥ 1 node
+defined. Binary signal — KBs with curated taxonomy → 1.0; KBs without
+→ 0.0. Future v2 can refine to "fraction of chunks tagged" if the
+binary signal proves too coarse.
+
+All functions are fail-open: any DB error returns empty / zero so the
+hook proceeds without taxonomy narrowing (SPEC-RAG-TAXONOMY-001 REQ-2).
+
+Caching lives one layer up in the LiteLLM hook (Redis-backed,
+cross-process) — this module only owns the DB lookup.
 """
 
 from __future__ import annotations
 
-import time
 from typing import TypedDict
 
 import structlog
 
 logger = structlog.get_logger()
 
-# ---------------------------------------------------------------------------
-# In-process TTL caches
-# ---------------------------------------------------------------------------
-
-# (org_id, kb_slug) -> (expires_at: float, value: list[dict])
-_tree_cache: dict[tuple[str, str], tuple[float, list[dict]]] = {}
-_TREE_TTL: float = 60.0  # seconds
-
-# (org_id, kb_slug) -> (expires_at: float, coverage: float)
-_coverage_cache: dict[tuple[str, str], tuple[float, float]] = {}
-_COVERAGE_TTL: float = 300.0  # 5 minutes
-
 
 class TaxonomyNode(TypedDict):
     id: int
+    kb_slug: str
     name: str
+    slug: str
     parent_id: int | None
-    depth: int
 
 
 # ---------------------------------------------------------------------------
 # SQL queries
 # ---------------------------------------------------------------------------
 
-# Returns the flat taxonomy tree for a KB.
-# Tables: portal_orgs (for zitadel_org_id→id resolution), portal_kb_nodes
-_TREE_SQL = """
+# Single-trip multi-KB tree fetch. Returns one row per node, annotated
+# with the KB slug so callers can group by KB if needed for prompt
+# disambiguation. ``ANY($2::text[])`` accepts a list of slugs.
+_TREES_SQL = """
     SELECT
         n.id,
+        kb.slug AS kb_slug,
         n.name,
-        n.parent_id,
-        n.depth
-    FROM portal_kb_nodes n
-    JOIN portal_kbs kb ON kb.id = n.kb_id
+        n.slug AS node_slug,
+        n.parent_id
+    FROM portal_taxonomy_nodes n
+    JOIN portal_knowledge_bases kb ON kb.id = n.kb_id
     JOIN portal_orgs org ON org.id = kb.org_id
     WHERE org.zitadel_org_id = $1
-      AND kb.slug = $2
-    ORDER BY n.depth, n.id
+      AND kb.slug = ANY($2::text[])
+    ORDER BY kb.slug, n.parent_id NULLS FIRST, n.sort_order, n.id
 """
 
-# Coverage = fraction of chunks in the KB that have at least one taxonomy_node_id tagged.
-# We proxy "tagged" chunks via `knowledge.artifacts` rows that have taxonomy_node_ids
-# set. The query is intentionally simple and approximate.
+# Coverage = does the KB have taxonomy nodes defined? Binary signal.
+# Single-trip multi-KB lookup so the hook can decide per-KB.
 _COVERAGE_SQL = """
     SELECT
-        COUNT(*) FILTER (
-            WHERE a.extra->'taxonomy_node_ids' IS NOT NULL
-              AND jsonb_array_length(a.extra->'taxonomy_node_ids') > 0
-        )::float
-            / NULLIF(COUNT(*), 0) AS coverage_ratio
-    FROM knowledge.artifacts a
-    JOIN portal_kbs kb ON kb.slug = a.kb_slug
+        kb.slug AS kb_slug,
+        COUNT(n.id) AS node_count
+    FROM portal_knowledge_bases kb
     JOIN portal_orgs org ON org.id = kb.org_id
+    LEFT JOIN portal_taxonomy_nodes n ON n.kb_id = kb.id
     WHERE org.zitadel_org_id = $1
-      AND a.kb_slug = $2
+      AND kb.slug = ANY($2::text[])
+    GROUP BY kb.slug
 """
 
 
-async def get_taxonomy_tree(org_id: str, kb_slug: str) -> list[TaxonomyNode]:
-    """Return the flat taxonomy node list for the KB, cached 60 s.
+async def get_taxonomy_trees(
+    org_id: str,
+    kb_slugs: list[str],
+) -> dict[str, list[TaxonomyNode]]:
+    """Return ``{kb_slug: [node, ...]}`` for the requested KBs.
 
-    Returns an empty list on any error (fail-open per REQ-2).
+    Empty input → empty dict. Missing KBs are simply absent from the
+    result. Fail-open on any DB error: returns ``{}`` so the hook
+    proceeds without taxonomy narrowing.
     """
-    cache_key = (org_id, kb_slug)
-    now = time.monotonic()
+    if not kb_slugs:
+        return {}
 
-    entry = _tree_cache.get(cache_key)
-    if entry is not None:
-        expires_at, cached_tree = entry
-        if now < expires_at:
-            return cached_tree
+    from retrieval_api.services.events import get_pool
 
-    # Cache miss — fetch from DB
+    pool = get_pool()
+    if pool is None:
+        logger.debug("taxonomy_lookup_skipped", reason="no_db_pool", org_id=org_id)
+        return {}
+
     try:
-        from retrieval_api.services.events import _pool
-
-        if _pool is None:
-            logger.debug(
-                "taxonomy_lookup_skipped",
-                reason="no_db_pool",
-                org_id=org_id,
-                kb_slug=kb_slug,
-            )
-            return []
-
-        rows = await _pool.fetch(_TREE_SQL, org_id, kb_slug)
-        tree: list[TaxonomyNode] = [
-            TaxonomyNode(
-                id=row["id"],
-                name=row["name"],
-                parent_id=row["parent_id"],
-                depth=row["depth"],
-            )
-            for row in rows
-        ]
-    except Exception:
+        rows = await pool.fetch(_TREES_SQL, org_id, list(kb_slugs))
+    except Exception as exc:
         logger.warning(
             "taxonomy_tree_fetch_failed",
             org_id=org_id,
-            kb_slug=kb_slug,
-            exc_info=True,
+            kb_slugs=kb_slugs,
+            error=str(exc)[:200],
         )
-        return []
+        return {}
 
-    _tree_cache[cache_key] = (now + _TREE_TTL, tree)
-    return tree
+    grouped: dict[str, list[TaxonomyNode]] = {}
+    for row in rows:
+        node: TaxonomyNode = {
+            "id": int(row["id"]),
+            "kb_slug": row["kb_slug"],
+            "name": row["name"],
+            "slug": row["node_slug"],
+            "parent_id": int(row["parent_id"]) if row["parent_id"] is not None else None,
+        }
+        grouped.setdefault(row["kb_slug"], []).append(node)
+    return grouped
 
 
-async def get_kb_taxonomy_coverage(org_id: str, kb_slug: str) -> float:
-    """Return the fraction of KB artifacts that have taxonomy tags, cached 5 min.
+async def get_kb_taxonomy_coverage(
+    org_id: str,
+    kb_slugs: list[str],
+) -> dict[str, float]:
+    """Return ``{kb_slug: coverage_ratio}`` for the requested KBs.
 
-    Returns 0.0 on any error (fail-open — caller skips filter when coverage is low).
+    v1: binary signal — 1.0 if the KB has ≥ 1 taxonomy node, 0.0 otherwise.
+    Missing KBs default to 0.0. Fail-open on any DB error.
     """
-    cache_key = (org_id, kb_slug)
-    now = time.monotonic()
+    if not kb_slugs:
+        return {}
 
-    entry = _coverage_cache.get(cache_key)
-    if entry is not None:
-        expires_at, cached_cov = entry
-        if now < expires_at:
-            return cached_cov
+    from retrieval_api.services.events import get_pool
+
+    pool = get_pool()
+    if pool is None:
+        return {slug: 0.0 for slug in kb_slugs}
 
     try:
-        from retrieval_api.services.events import _pool
-
-        if _pool is None:
-            return 0.0
-
-        row = await _pool.fetchrow(_COVERAGE_SQL, org_id, kb_slug)
-        coverage: float = (
-            float(row["coverage_ratio"]) if row and row["coverage_ratio"] is not None else 0.0
-        )
-    except Exception:
+        rows = await pool.fetch(_COVERAGE_SQL, org_id, list(kb_slugs))
+    except Exception as exc:
         logger.warning(
             "taxonomy_coverage_fetch_failed",
             org_id=org_id,
-            kb_slug=kb_slug,
-            exc_info=True,
+            kb_slugs=kb_slugs,
+            error=str(exc)[:200],
         )
-        coverage = 0.0
+        return {slug: 0.0 for slug in kb_slugs}
 
-    _coverage_cache[cache_key] = (now + _COVERAGE_TTL, coverage)
+    coverage: dict[str, float] = {slug: 0.0 for slug in kb_slugs}
+    for row in rows:
+        coverage[row["kb_slug"]] = 1.0 if int(row["node_count"]) > 0 else 0.0
     return coverage

--- a/klai-retrieval-api/tests/test_taxonomy_lookup.py
+++ b/klai-retrieval-api/tests/test_taxonomy_lookup.py
@@ -1,39 +1,31 @@
-"""SPEC-RAG-TAXONOMY-001 — taxonomy_lookup.py unit tests.
+"""SPEC-RAG-TAXONOMY-001 (multi-KB) — taxonomy_lookup.py unit tests.
 
-Tests tree fetch, coverage fetch, in-process cache, and fail-open behaviour.
-All tests mock the asyncpg pool so no real DB is needed.
+Tests the v2 multi-KB API:
+- ``get_taxonomy_trees(org_id, kb_slugs)`` returns ``{kb_slug: [node, ...]}``.
+- ``get_kb_taxonomy_coverage(org_id, kb_slugs)`` returns
+  ``{kb_slug: 0.0|1.0}`` — binary signal (KB has nodes vs not).
+- Both functions fail-open: any DB error returns empty / zero so the
+  hook proceeds without taxonomy narrowing.
+
+Caching is intentionally absent at this layer — the LiteLLM hook owns
+the Redis cache, this module only owns the DB lookup. All tests mock
+the asyncpg pool so no real DB is needed.
 """
 
 from __future__ import annotations
 
-import time
-
 import pytest
 
 # ---------------------------------------------------------------------------
-# Helpers / fixtures
+# Pool mock helpers
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture(autouse=True)
-def _clear_caches():
-    """Reset in-process TTL caches before each test to prevent cross-test pollution."""
-    from retrieval_api.services import taxonomy_lookup
-
-    taxonomy_lookup._tree_cache.clear()
-    taxonomy_lookup._coverage_cache.clear()
-    yield
-    taxonomy_lookup._tree_cache.clear()
-    taxonomy_lookup._coverage_cache.clear()
-
-
-def _make_pool_mock(
-    fetch_rows=None, fetchrow_value=None, raise_on_fetch=False, raise_on_fetchrow=False
-):
-    """Build a minimal asyncpg Pool mock.
+def _make_pool_mock(fetch_rows=None, raise_on_fetch=False, capture_args=None):
+    """Build a minimal asyncpg Pool mock supporting ``fetch``.
 
     ``fetch_rows`` is the list of row-like dicts returned by pool.fetch().
-    ``fetchrow_value`` is the dict returned by pool.fetchrow().
+    ``capture_args`` (optional list) collects (sql, *args) tuples per call.
     """
 
     class _FakeRow(dict):
@@ -42,225 +34,203 @@ def _make_pool_mock(
 
     class _FakePool:
         async def fetch(self, sql, *args):
+            if capture_args is not None:
+                capture_args.append((sql, args))
             if raise_on_fetch:
                 raise RuntimeError("DB exploded")
             return [_FakeRow(r) for r in (fetch_rows or [])]
-
-        async def fetchrow(self, sql, *args):
-            if raise_on_fetchrow:
-                raise RuntimeError("DB exploded")
-            if fetchrow_value is None:
-                return None
-            return _FakeRow(fetchrow_value)
 
     return _FakePool()
 
 
 # ---------------------------------------------------------------------------
-# get_taxonomy_tree
+# get_taxonomy_trees (multi-KB)
 # ---------------------------------------------------------------------------
 
 
-class TestGetTaxonomyTree:
+class TestGetTaxonomyTrees:
     @pytest.mark.asyncio
-    async def test_returns_tree_from_db(self, monkeypatch):
-        """Happy path: pool.fetch returns rows → list of TaxonomyNode dicts."""
+    async def test_returns_grouped_by_kb_slug(self, monkeypatch):
+        """Happy path: rows from multiple KBs get grouped by kb_slug."""
         rows = [
-            {"id": 1, "name": "Root", "parent_id": None, "depth": 0},
-            {"id": 2, "name": "Child", "parent_id": 1, "depth": 1},
+            {
+                "id": 1,
+                "kb_slug": "support",
+                "name": "SSO",
+                "node_slug": "sso",
+                "parent_id": None,
+            },
+            {
+                "id": 2,
+                "kb_slug": "support",
+                "name": "SAML",
+                "node_slug": "saml",
+                "parent_id": 1,
+            },
+            {
+                "id": 10,
+                "kb_slug": "billing",
+                "name": "Invoices",
+                "node_slug": "invoices",
+                "parent_id": None,
+            },
         ]
         pool = _make_pool_mock(fetch_rows=rows)
         monkeypatch.setattr("retrieval_api.services.events._pool", pool)
 
-        from retrieval_api.services.taxonomy_lookup import get_taxonomy_tree
+        from retrieval_api.services.taxonomy_lookup import get_taxonomy_trees
 
-        result = await get_taxonomy_tree("org-1", "my-kb")
+        result = await get_taxonomy_trees("org-1", ["support", "billing"])
 
-        assert len(result) == 2
-        assert result[0]["id"] == 1
-        assert result[0]["name"] == "Root"
-        assert result[0]["parent_id"] is None
-        assert result[0]["depth"] == 0
-        assert result[1]["id"] == 2
-        assert result[1]["parent_id"] == 1
+        assert set(result.keys()) == {"support", "billing"}
+        assert len(result["support"]) == 2
+        assert result["support"][0]["id"] == 1
+        assert result["support"][0]["kb_slug"] == "support"
+        assert result["support"][0]["name"] == "SSO"
+        assert result["support"][0]["slug"] == "sso"
+        assert result["support"][0]["parent_id"] is None
+        assert result["support"][1]["parent_id"] == 1
+        assert result["billing"][0]["id"] == 10
+
+    @pytest.mark.asyncio
+    async def test_passes_kb_slugs_as_array_param(self, monkeypatch):
+        """The query MUST receive kb_slugs as a list for ANY($2::text[])."""
+        captured: list = []
+        pool = _make_pool_mock(fetch_rows=[], capture_args=captured)
+        monkeypatch.setattr("retrieval_api.services.events._pool", pool)
+
+        from retrieval_api.services.taxonomy_lookup import get_taxonomy_trees
+
+        await get_taxonomy_trees("org-1", ["support", "billing"])
+
+        assert len(captured) == 1
+        _, args = captured[0]
+        assert args[0] == "org-1"
+        assert args[1] == ["support", "billing"]
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_dict_for_empty_input(self, monkeypatch):
+        """Empty kb_slugs short-circuits — no DB call."""
+        captured: list = []
+        pool = _make_pool_mock(fetch_rows=[], capture_args=captured)
+        monkeypatch.setattr("retrieval_api.services.events._pool", pool)
+
+        from retrieval_api.services.taxonomy_lookup import get_taxonomy_trees
+
+        result = await get_taxonomy_trees("org-1", [])
+
+        assert result == {}
+        assert captured == []  # no DB roundtrip
 
     @pytest.mark.asyncio
     async def test_returns_empty_when_pool_is_none(self, monkeypatch):
-        """No DB pool → fail-open, return []."""
+        """No pool → fail-open, return {}."""
         monkeypatch.setattr("retrieval_api.services.events._pool", None)
 
-        from retrieval_api.services.taxonomy_lookup import get_taxonomy_tree
+        from retrieval_api.services.taxonomy_lookup import get_taxonomy_trees
 
-        result = await get_taxonomy_tree("org-1", "my-kb")
-        assert result == []
+        result = await get_taxonomy_trees("org-1", ["support"])
+        assert result == {}
 
     @pytest.mark.asyncio
     async def test_returns_empty_on_db_error(self, monkeypatch):
-        """DB exception → fail-open, return []."""
+        """DB exception → fail-open, return {}."""
         pool = _make_pool_mock(raise_on_fetch=True)
         monkeypatch.setattr("retrieval_api.services.events._pool", pool)
 
-        from retrieval_api.services.taxonomy_lookup import get_taxonomy_tree
+        from retrieval_api.services.taxonomy_lookup import get_taxonomy_trees
 
-        result = await get_taxonomy_tree("org-1", "my-kb")
-        assert result == []
+        result = await get_taxonomy_trees("org-1", ["support"])
+        assert result == {}
 
     @pytest.mark.asyncio
-    async def test_cache_hit_skips_db(self, monkeypatch):
-        """Second call with same (org_id, kb_slug) returns cached result without hitting DB."""
-        rows = [{"id": 42, "name": "Cached", "parent_id": None, "depth": 0}]
+    async def test_kb_with_no_nodes_absent_from_result(self, monkeypatch):
+        """A KB with zero nodes is simply absent from the result dict."""
+        rows = [
+            {
+                "id": 1,
+                "kb_slug": "support",
+                "name": "SSO",
+                "node_slug": "sso",
+                "parent_id": None,
+            },
+        ]
         pool = _make_pool_mock(fetch_rows=rows)
         monkeypatch.setattr("retrieval_api.services.events._pool", pool)
 
-        from retrieval_api.services.taxonomy_lookup import get_taxonomy_tree
+        from retrieval_api.services.taxonomy_lookup import get_taxonomy_trees
 
-        # First call — populates cache
-        first = await get_taxonomy_tree("org-c", "kb-c")
-        assert len(first) == 1
+        result = await get_taxonomy_trees("org-1", ["support", "billing"])
 
-        # Swap pool to one that raises — should NOT be called
-        bad_pool = _make_pool_mock(raise_on_fetch=True)
-        monkeypatch.setattr("retrieval_api.services.events._pool", bad_pool)
-
-        # Second call — must come from cache
-        second = await get_taxonomy_tree("org-c", "kb-c")
-        assert second == first
-
-    @pytest.mark.asyncio
-    async def test_expired_cache_refetches(self, monkeypatch):
-        """Cache entry past TTL triggers a fresh fetch."""
-        rows = [{"id": 7, "name": "Fresh", "parent_id": None, "depth": 0}]
-        pool = _make_pool_mock(fetch_rows=rows)
-        monkeypatch.setattr("retrieval_api.services.events._pool", pool)
-
-        from retrieval_api.services import taxonomy_lookup
-        from retrieval_api.services.taxonomy_lookup import get_taxonomy_tree
-
-        # Pre-seed cache with an already-expired entry
-        taxonomy_lookup._tree_cache[("org-e", "kb-e")] = (
-            time.monotonic() - 1.0,  # already expired
-            [{"id": 99, "name": "Stale", "parent_id": None, "depth": 0}],
-        )
-
-        result = await get_taxonomy_tree("org-e", "kb-e")
-
-        # Should have fetched fresh from DB
-        assert result[0]["id"] == 7
-        assert result[0]["name"] == "Fresh"
-
-    @pytest.mark.asyncio
-    async def test_returns_empty_list_for_kb_with_no_nodes(self, monkeypatch):
-        """DB returns zero rows → empty list (no tree)."""
-        pool = _make_pool_mock(fetch_rows=[])
-        monkeypatch.setattr("retrieval_api.services.events._pool", pool)
-
-        from retrieval_api.services.taxonomy_lookup import get_taxonomy_tree
-
-        result = await get_taxonomy_tree("org-1", "empty-kb")
-        assert result == []
+        assert "support" in result
+        assert "billing" not in result
 
 
 # ---------------------------------------------------------------------------
-# get_kb_taxonomy_coverage
+# get_kb_taxonomy_coverage (multi-KB, binary signal)
 # ---------------------------------------------------------------------------
 
 
 class TestGetKbTaxonomyCoverage:
     @pytest.mark.asyncio
-    async def test_returns_coverage_from_db(self, monkeypatch):
-        """Happy path: pool.fetchrow returns a coverage_ratio → float returned."""
-        pool = _make_pool_mock(fetchrow_value={"coverage_ratio": 0.72})
+    async def test_binary_signal_one_when_kb_has_nodes(self, monkeypatch):
+        """KB with node_count > 0 → coverage 1.0."""
+        rows = [
+            {"kb_slug": "support", "node_count": 5},
+            {"kb_slug": "billing", "node_count": 0},
+        ]
+        pool = _make_pool_mock(fetch_rows=rows)
         monkeypatch.setattr("retrieval_api.services.events._pool", pool)
 
         from retrieval_api.services.taxonomy_lookup import get_kb_taxonomy_coverage
 
-        result = await get_kb_taxonomy_coverage("org-1", "my-kb")
-        assert abs(result - 0.72) < 1e-6
+        result = await get_kb_taxonomy_coverage("org-1", ["support", "billing"])
+
+        assert result == {"support": 1.0, "billing": 0.0}
 
     @pytest.mark.asyncio
-    async def test_returns_zero_when_pool_is_none(self, monkeypatch):
-        """No pool → 0.0 (fail-open)."""
+    async def test_missing_kb_defaults_to_zero(self, monkeypatch):
+        """KB not in DB result → defaults to 0.0 in returned map."""
+        rows = [{"kb_slug": "support", "node_count": 3}]
+        pool = _make_pool_mock(fetch_rows=rows)
+        monkeypatch.setattr("retrieval_api.services.events._pool", pool)
+
+        from retrieval_api.services.taxonomy_lookup import get_kb_taxonomy_coverage
+
+        result = await get_kb_taxonomy_coverage("org-1", ["support", "billing", "unknown"])
+
+        assert result == {"support": 1.0, "billing": 0.0, "unknown": 0.0}
+
+    @pytest.mark.asyncio
+    async def test_returns_zeros_when_pool_is_none(self, monkeypatch):
         monkeypatch.setattr("retrieval_api.services.events._pool", None)
 
         from retrieval_api.services.taxonomy_lookup import get_kb_taxonomy_coverage
 
-        result = await get_kb_taxonomy_coverage("org-1", "my-kb")
-        assert result == 0.0
+        result = await get_kb_taxonomy_coverage("org-1", ["support", "billing"])
+        assert result == {"support": 0.0, "billing": 0.0}
 
     @pytest.mark.asyncio
-    async def test_returns_zero_on_db_error(self, monkeypatch):
-        """DB exception → 0.0 (fail-open)."""
-        pool = _make_pool_mock(raise_on_fetchrow=True)
+    async def test_returns_zeros_on_db_error(self, monkeypatch):
+        """DB exception → fail-open, all-zeros map for the requested slugs."""
+        pool = _make_pool_mock(raise_on_fetch=True)
         monkeypatch.setattr("retrieval_api.services.events._pool", pool)
 
         from retrieval_api.services.taxonomy_lookup import get_kb_taxonomy_coverage
 
-        result = await get_kb_taxonomy_coverage("org-1", "my-kb")
-        assert result == 0.0
+        result = await get_kb_taxonomy_coverage("org-1", ["support", "billing"])
+        assert result == {"support": 0.0, "billing": 0.0}
 
     @pytest.mark.asyncio
-    async def test_returns_zero_when_coverage_ratio_is_null(self, monkeypatch):
-        """DB returns coverage_ratio=NULL (empty KB) → 0.0."""
-        pool = _make_pool_mock(fetchrow_value={"coverage_ratio": None})
+    async def test_returns_empty_dict_for_empty_input(self, monkeypatch):
+        """Empty kb_slugs short-circuits — no DB call, returns {}."""
+        captured: list = []
+        pool = _make_pool_mock(fetch_rows=[], capture_args=captured)
         monkeypatch.setattr("retrieval_api.services.events._pool", pool)
 
         from retrieval_api.services.taxonomy_lookup import get_kb_taxonomy_coverage
 
-        result = await get_kb_taxonomy_coverage("org-1", "empty-kb")
-        assert result == 0.0
+        result = await get_kb_taxonomy_coverage("org-1", [])
 
-    @pytest.mark.asyncio
-    async def test_returns_zero_when_fetchrow_returns_none(self, monkeypatch):
-        """DB returns no row at all → 0.0."""
-        pool = _make_pool_mock(fetchrow_value=None)
-        monkeypatch.setattr("retrieval_api.services.events._pool", pool)
-
-        from retrieval_api.services.taxonomy_lookup import get_kb_taxonomy_coverage
-
-        result = await get_kb_taxonomy_coverage("org-1", "no-kb")
-        assert result == 0.0
-
-    @pytest.mark.asyncio
-    async def test_cache_hit_skips_db(self, monkeypatch):
-        """Second call returns cached coverage without hitting DB again."""
-        pool = _make_pool_mock(fetchrow_value={"coverage_ratio": 0.55})
-        monkeypatch.setattr("retrieval_api.services.events._pool", pool)
-
-        from retrieval_api.services.taxonomy_lookup import get_kb_taxonomy_coverage
-
-        first = await get_kb_taxonomy_coverage("org-cc", "kb-cc")
-        assert abs(first - 0.55) < 1e-6
-
-        # Replace pool with one that raises — must not be reached
-        bad_pool = _make_pool_mock(raise_on_fetchrow=True)
-        monkeypatch.setattr("retrieval_api.services.events._pool", bad_pool)
-
-        second = await get_kb_taxonomy_coverage("org-cc", "kb-cc")
-        assert abs(second - 0.55) < 1e-6
-
-    @pytest.mark.asyncio
-    async def test_different_kb_slugs_are_cached_independently(self, monkeypatch):
-        """Each (org_id, kb_slug) pair has its own cache entry."""
-        call_count = 0
-
-        class _CountingPool:
-            async def fetchrow(self, sql, org_id, kb_slug):
-                nonlocal call_count
-                call_count += 1
-                return {"coverage_ratio": 0.3 if kb_slug == "kb-a" else 0.8}
-
-        monkeypatch.setattr("retrieval_api.services.events._pool", _CountingPool())
-
-        from retrieval_api.services.taxonomy_lookup import get_kb_taxonomy_coverage
-
-        cov_a = await get_kb_taxonomy_coverage("org-1", "kb-a")
-        cov_b = await get_kb_taxonomy_coverage("org-1", "kb-b")
-
-        assert abs(cov_a - 0.3) < 1e-6
-        assert abs(cov_b - 0.8) < 1e-6
-        assert call_count == 2  # one fetch each
-
-        # Cached now — no more DB calls
-        await get_kb_taxonomy_coverage("org-1", "kb-a")
-        await get_kb_taxonomy_coverage("org-1", "kb-b")
-        assert call_count == 2
+        assert result == {}
+        assert captured == []


### PR DESCRIPTION
## Why

The original SPEC-RAG-TAXONOMY-001 implementation shipped with three defects that together made the feature broken-by-default in production. None of them surfaced as user-facing errors because the design is fail-open — they just made taxonomy filtering silently never apply.

## The 3 bugs

### 1. Wrong table names in SQL (HIGH)
`retrieval_api/services/taxonomy_lookup.py` queried:
- ❌ \`portal_kb_nodes\` — does not exist
- ❌ \`knowledge.artifacts.extra->'taxonomy_node_ids'\` — field is on Qdrant chunks, not artifacts

Real schema:
- ✅ \`portal_taxonomy_nodes\` (per-KB tree, FK \`kb_id\` → \`portal_knowledge_bases\`)
- ✅ \`portal_knowledge_bases.org_id\` → \`portal_orgs.zitadel_org_id\` for tenant scoping

Every taxonomy fetch silently returned empty / zero — fail-open masked the bug as "feature is off".

### 2. First-KB-only heuristic (HIGH)
The hook picked \`kb_slugs_for_request[0]\` and classified against that one tree. Mixed-coverage chats (\`support\` + \`billing\`) only saw \`support\`'s tree. With the v1 acceptance bar at "good-enough heuristic", multi-KB queries effectively had taxonomy off — opposite of the SPEC's intent.

### 3. No cache (MED)
Each chat hit retrieval-api → DB twice (trees + coverage). 2x roundtrip on every turn, no benefit on identical follow-ups.

## The fix

### retrieval-api side
- **\`services/taxonomy_lookup.py\` rewritten against the real schema.** \`get_taxonomy_trees(org_id, kb_slugs)\` returns \`{kb_slug: [node, ...]}\` from a single SQL roundtrip with \`ANY(\$2::text[])\`. \`get_kb_taxonomy_coverage(org_id, kb_slugs)\` returns \`{kb_slug: 0.0|1.0}\` — binary signal (KB has nodes vs not).
- **New endpoints \`/internal/v1/taxonomy/trees\` and \`/coverage\`** accepting \`kb_slugs\` as repeated query params (\`?kb_slugs=support&kb_slugs=billing\`). Legacy \`/tree\` and \`/coverage-single\` kept as thin wrappers for in-flight callers.
- **In-process TTL caches removed** — caching moved to the hook layer (Redis, cross-process) where it actually helps under multi-replica load.

### LiteLLM hook side
- \`_fetch_taxonomy_trees\` and \`_fetch_taxonomy_coverage\` now multi-KB with a stable Redis cache key \`tax_{trees,coverage}:{org}:{slugs}\` (sorted, deterministic). 300s TTL.
- \`_format_taxonomy_for_prompt\` accepts both dict and list shapes; the multi-KB shape surfaces \`[kb_slug]\` labels so the LLM can disambiguate name-collisions across KBs.
- \`_flatten_trees\` builds the union for the anti-hallucination guard — taxonomy node IDs are globally unique (single PK), so the merged set is collision-free; retrieval-api's ANY-of filter handles the rest.
- \`_rewrite_and_classify\` accepts \`dict[str, list[dict]]\` OR \`list[dict]\` (backward compat).
- Hook main path filters in-scope KBs by per-KB coverage **before** invoking the classifier. New skip reasons: \`no_kbs_in_scope\` / \`all_kbs_low_coverage\` (replaces \`no_kb_slug\` / \`low_coverage\`).
- \`_MAX_KBS_FOR_TAXONOMY = 5\` cap to keep the classifier prompt bounded; above the cap the filter is skipped fail-open.

## Test status
- ✅ 32/32 hook tests (\`test_taxonomy_classify.py\`) — multi-KB grouping, hallucinated-ID filtering across KB boundaries, Redis cache hit/miss, legacy list shape backward compat
- ✅ 11/11 lookup tests (\`test_taxonomy_lookup.py\`) — binary signal, missing-KB defaults, fail-open
- ✅ 11/11 filter/model tests
- ✅ Ruff check + format clean on all touched files

The 18 pre-existing failures in \`test_klai_knowledge_hook.py\` (TestKlaiKnowledgeHookKB010/013, TestGapIntegration, TestTokenRouterKB010) are out of scope — they're the AsyncMock fixture issue tracked for PR D.

## Behaviour after merge
- Voys (\`support\` KB has 0 taxonomy nodes today): \`taxonomy_classify\` logs \`skip_reason=all_kbs_low_coverage\`, retrieval runs unfiltered. Same as today, but visibly correct in logs.
- Multi-KB tenants once they curate taxonomy: classifier sees \`[support]\` + \`[billing]\` labels in the prompt; classified IDs from any KB are valid for retrieval-api's ANY-of filter.

## Rollback
Single revert. The legacy \`/tree\` and \`/coverage-single\` endpoints are kept so any unexpected legacy caller keeps working post-merge.