### PR TITLE
docs(audit): 2026-05-05 follow-ups + won't-fix rationale

### DIFF
--- a/.moai/specs/SPEC-INFRA-TENANT-DELETE-002/spec.md
+++ b/.moai/specs/SPEC-INFRA-TENANT-DELETE-002/spec.md
@@ -1,0 +1,71 @@
+---
+id: SPEC-INFRA-TENANT-DELETE-002
+version: "0.1.0"
+status: draft
+created: 2026-05-05
+updated: 2026-05-05
+author: Mark Vletter
+priority: high
+related:
+  - SPEC-INFRA-TENANT-DELETE-001 (parent, base 17-step orchestrator)
+  - SPEC-CODEBASE-AUDIT-001 (parent audit, Cluster F)
+---
+
+# SPEC-INFRA-TENANT-DELETE-002: 7 GDPR purge gaps (G1-G7)
+
+## Summary
+
+Sluit 7 PII-purge gaps gevonden in audit Cluster F. Tenant-deprovisioning achterhaalt zeven stores die niet automatisch gepurged worden, plus één code-bug in step 8 (Qdrant filter-key mismatch).
+
+## Motivation
+
+Per `reports/audit-2026-05-04/multi-tenancy-gdpr.md`:
+
+| ID | Severity | Store | Issue |
+|---|---|---|---|
+| G1 | HIGH | `portal_join_requests` | Niet in step 16 DELETE-list |
+| G2 | HIGH | `portal_org_allowed_domains` | Niet in step 16 DELETE-list |
+| G3 | HIGH | `knowledge.*` connector-KB content | Alleen personal-KB gepurged via klai-docs |
+| G4 | HIGH | Qdrant `klai_focus` | step 8 filter-key bug (`org_id` vs `tenant_id`) |
+| G5 | HIGH | `scribe.transcriptions` | Geen `org_id` kolom, geen wipe-stap |
+| G6 | MED | klai-connector eigen schema | Sync-runs metadata blijft |
+| G7 | HIGH | `research.*` schema + uploads | Manual cleanup-script, niet automatisch |
+
+## Scope
+
+### In scope
+
+1. **G1+G2**: voeg `portal_join_requests` + `portal_org_allowed_domains` toe aan `_finalize_postgres_delete` DELETE-list (`klai-portal/backend/app/services/provisioning/deprovisioning_steps.py:530`); `@MX:WARN` block updaten
+2. **G3**: nieuw endpoint `POST /internal/v1/orgs/{org_id}/wipe-postgres` op knowledge-ingest die `knowledge.{artifacts,embedding_queue,artifact_entities,derivations,kb_config,crawl_jobs,crawled_pages,page_links,crawl_domains,artifact_images}` purges WHERE org_id; aangeroepen door step 13a in deprovisioning_orchestrator
+3. **G4 (CODE BUG FIX)**: in `deprovisioning_steps.py` step 8 — twee aparte deletes per Qdrant collection: `klai_knowledge` met `org_id` filter, `klai_focus` met `tenant_id` filter (matcht respectieve payload schemas)
+4. **G5**: schemamigratie scribe — `ALTER TABLE scribe.transcriptions ADD COLUMN org_id VARCHAR(64) NOT NULL DEFAULT ''` + backfill via portal-api lookup; nieuwe `_delete_scribe_transcriptions` step ZONDER S3-blob delete (al gedekt door step 10)
+5. **G6**: nieuw endpoint `POST /internal/v1/orgs/{org_id}/wipe-connector-state` op klai-connector die `connector.sync_runs` purges; aangeroepen door step 8a (na portal_connectors cascade-delete maar voor schema-orphan-cleanup)
+6. **G7**: automatische call van `scripts/research_tenant_cleanup.py` als step 13b OF nieuwe `POST /internal/v1/orgs/{org_id}/wipe-research` endpoint op research-api
+
+### Out of scope
+
+- Moneybird soft-archive vs hard-delete (bewuste retentie NL fiscale 7 jaar)
+- LibreChat per-tenant Mongo (al gepurged in step 4)
+
+## Acceptance criteria
+
+1. Per nieuw endpoint: dedicated test met seeded tenant-data, verify post-call rij-count = 0
+2. Integration test: maak test-tenant met data in alle 7 stores, run deprovisioning, verifieer ALLE stores leeg
+3. Regression-test in `tests/test_deprovisioning_steps.py` voor de DELETE-list aanvullingen + Qdrant filter-key fix
+4. Audit-log: `tenant_lifecycle_events` toont nieuwe step-namen
+5. Per pitfall `validator-env-parity`: geen nieuwe env-vars vereist — alleen nieuwe HTTP endpoints
+
+## Risk
+
+| Risk | Mitigatie |
+|---|---|
+| Schema-migration scribe op grote tabel | `ADD COLUMN ... DEFAULT '' NOT NULL` is niet-blocking in pg18; backfill via batch-script post-migrate |
+| Cross-service endpoint-toegang faalt | Same X-Internal-Secret pattern als bestaande wipe-graph endpoint |
+| G3 wipe-postgres parallel met running enrichment-tasks | Procrastinate task-cancel call voor wipe; documentatie in runbook |
+
+## References
+
+- `reports/audit-2026-05-04/multi-tenancy-gdpr.md` (G1-G7 detail)
+- `klai-portal/backend/app/services/provisioning/deprovisioning_steps.py`
+- `klai-knowledge-ingest/knowledge_ingest/routes/internal.py::wipe_org_graph` — canonical pattern
+- `scripts/research_tenant_cleanup.py` — manual cleanup origineel

--- a/.moai/specs/SPEC-INGEST-ALEMBIC-001/spec.md
+++ b/.moai/specs/SPEC-INGEST-ALEMBIC-001/spec.md
@@ -1,0 +1,77 @@
+---
+id: SPEC-INGEST-ALEMBIC-001
+version: "0.1.0"
+status: draft
+created: 2026-05-05
+updated: 2026-05-05
+author: Mark Vletter
+priority: high
+related:
+  - SPEC-CODEBASE-AUDIT-001 (parent, Cluster I)
+  - SPEC-CONNECTOR-DELETE-LIFECYCLE-001 (precedent met `knowledge.artifact_images`)
+---
+
+# SPEC-INGEST-ALEMBIC-001: Bootstrap Alembic in knowledge-ingest
+
+## Summary
+
+knowledge-ingest is **niet alembic-managed** — alleen één raw `migrations/001_crawl_domains.sql` + runtime DDL via `pg_store`. Per `reports/audit-2026-05-04/db-schema-consistency.md` TP-8: schema-evolutie loopt impliciet via portal-api alembic OF runtime, geen migration history, geen rollback. Audit-gat: fresh `docker compose down -v` zou ingest niet starten zonder manuele bootstrap-DDL.
+
+## Motivation
+
+Per `pitfalls/process-rules.md::scribe-deploy-no-alembic` (HIGH): elke service met DDL nodig heeft een entrypoint met `alembic upgrade head`. knowledge-ingest is de laatste service met dit gat.
+
+## Scope
+
+### In scope
+
+1. **Bootstrap alembic dir** in knowledge-ingest:
+   - `alembic.ini` mirroring portal-api/connector pattern
+   - `alembic/env.py` met dual-mode online/offline
+   - `alembic/script.py.mako`
+   - `alembic/versions/0001_baseline.py` met:
+     - `op.execute("CREATE SCHEMA IF NOT EXISTS knowledge")`
+     - Alle huidige `knowledge.*` tabellen (extracted via `pg_dump --schema-only --schema=knowledge` van prod)
+     - Plus content van bestaande `migrations/001_crawl_domains.sql`
+2. **`klai-knowledge-ingest/entrypoint.sh`** mirror van klai-connector:
+   ```bash
+   #!/bin/bash
+   set -eu
+   export PYTHONPATH=.
+   alembic upgrade head
+   exec /app/scripts/uvicorn-launch.sh knowledge_ingest.app:app --host 0.0.0.0 --port 8000
+   ```
+3. **Dockerfile update**: COPY entrypoint.sh + ENTRYPOINT
+4. **Stamp prod als baseline** (deploy-step, niet code):
+   ```bash
+   ssh core-01 "docker exec klai-core-knowledge-ingest-1 alembic stamp 0001_baseline"
+   ```
+5. **Cleanup**: verwijder `klai-knowledge-ingest/migrations/001_crawl_domains.sql`
+6. **CI guard**: extend `rules/no-alembic-without-entrypoint.yml` ast-grep om knowledge-ingest mee te nemen
+
+### Future scope (apart SPEC)
+
+- Schema-ownership migreren: portal-api stopt met `knowledge.*` tabellen aanmaken; knowledge-ingest neemt het over
+
+## Acceptance criteria
+
+1. Fresh dev-stack (`docker compose down -v && docker compose up -d`) start knowledge-ingest succesvol — schema bootstrap automatisch
+2. `alembic stamp` op prod werkt zonder DDL-uitvoering
+3. ruff check clean op alembic/* files
+4. ast-grep `no-alembic-without-entrypoint` rule fired niet meer voor knowledge-ingest
+5. Smoke-test: trigger nieuwe migration on top → werkt via entrypoint pre-flight
+
+## Risks
+
+| Risk | Mitigatie |
+|---|---|
+| `alembic stamp` op prod faalt | First test op staging; verify `alembic current` post-stamp |
+| Conflicten met portal-api alembic die historisch ook `knowledge.*` schreef | Audit pre-baseline of portal-api migraties referenties hebben naar `knowledge.*`; eventueel coordinated migration |
+| Entrypoint deploy hangt op import error | Pre-validate met `alembic upgrade head --sql` lokaal |
+
+## References
+
+- `reports/audit-2026-05-04/db-schema-consistency.md` (TP-8)
+- `reports/audit-2026-05-04/deep-pass-knowledge-ingest.md` (sectie 4)
+- `klai-connector/entrypoint.sh` — canonical pattern
+- `.claude/rules/klai/pitfalls/process-rules.md::scribe-deploy-no-alembic`

--- a/.moai/specs/SPEC-LOGGING-EXTRACT-001/spec.md
+++ b/.moai/specs/SPEC-LOGGING-EXTRACT-001/spec.md
@@ -1,0 +1,81 @@
+---
+id: SPEC-LOGGING-EXTRACT-001
+version: "0.1.0"
+status: draft
+created: 2026-05-05
+updated: 2026-05-05
+author: Mark Vletter
+priority: medium
+related:
+  - SPEC-CODEBASE-AUDIT-001 (parent, Cluster J)
+---
+
+# SPEC-LOGGING-EXTRACT-001: Extract `setup_logging()` + `RequestContextMiddleware` naar `klai-libs/log-utils`
+
+## Summary
+
+8 services dupliceren een 80-123 LOC `logging_setup.py` met dezelfde `setup_logging()` + `RequestContextMiddleware` shape. Per `reports/audit-2026-05-04/maintainability-duplication-naming.md` 5.2: ~560 LOC dedup-kans. Plus standardize `uvicorn.access` op INFO+healthcheck-filter (mailer pattern, lessons learned uit 4-h outage).
+
+## Motivation
+
+- DRY: één canonical implementation in `klai-libs/log-utils/log_utils/structlog_setup.py`
+- Consistency: alle services krijgen `RequestContextMiddleware` + `_HealthCheckAccessFilter` zoals mailer (na 4-h outage 2026-04-29)
+- Mailer is precedent: `INFO + healthcheck-filter` voorkomt dat unhandled exceptions onzichtbaar worden in `docker logs`
+
+## Scope
+
+### In scope
+
+1. **`klai-libs/log-utils/log_utils/structlog_setup.py`** (nieuwe module):
+   - `setup_logging(service_name: str)` — structlog config + ProcessorFormatter + uvicorn.access INFO + `_HealthCheckAccessFilter`
+   - `RequestContextMiddleware` (FastAPI middleware) — bind `request_id`, `org_id` op contextvars; respect `X-Request-ID` header van Caddy
+   - Re-exports in `log_utils/__init__.py`
+   - Unit tests in `klai-libs/log-utils/tests/test_structlog_setup.py`
+
+2. **Per service migratie** (8 services):
+   - klai-portal/backend
+   - klai-knowledge-ingest
+   - klai-retrieval-api
+   - klai-knowledge-mcp (mocht het wel/niet hebben — zie audit)
+   - klai-connector
+   - klai-mailer (al canonical, verwijder eigen kopie als shared)
+   - klai-scribe/scribe-api
+   - klai-scribe/whisper-server
+   - klai-focus/research-api
+   
+   Per service:
+   - Add `klai-log-utils` als path-dep in pyproject.toml `[tool.uv.sources]` (al voor portal/connector/mcp/scribe; uitbreiden naar overige)
+   - Vervang lokale `logging_setup.py` import door `from log_utils.structlog_setup import setup_logging, RequestContextMiddleware`
+   - Verwijder lokale `logging_setup.py` file
+   - Verifieer service-startup logs nog hetzelfde JSON-format produceren
+
+3. **Naming conventie fix** (uit audit 5.5):
+   - portal-api: rename `LoggingContextMiddleware` → `RequestContextMiddleware` (matcht rest)
+
+### Out of scope
+
+- klai-libs naming-prefix fix (`log_utils` → `klai_log_utils`) — separate SPEC die ALLE klai-libs prefix-consistent maakt
+- Cross-service trace-correlation header changes — al in place via `app.trace.get_trace_headers()`
+
+## Acceptance criteria
+
+1. `klai-libs/log-utils` heeft `structlog_setup` module met >85% coverage
+2. Alle 8 services importeren `setup_logging` + `RequestContextMiddleware` uit klai-libs
+3. Per service: `docker logs <ctr> 2>&1 | head -5` toont identiek JSON-format
+4. Smoke-test: één request met `X-Request-ID: <uuid>` toont propagation in logs over alle services
+5. Geen lokale `logging_setup.py` files meer
+
+## Risks
+
+| Risk | Mitigatie |
+|---|---|
+| Path-dep build context faalt voor services die nu niet repo-root build (mailer, focus) | Eerst migrate naar repo-root build context (al onderdeel van separate maintainability SPEC) — tijdelijk: kopieer log-utils inhoud per service |
+| Healthcheck-filter regression | Per service smoke-test `curl /health` + verify logs |
+| Test-fixtures verwachten lokale `logging_setup` path | Update test-imports in elke service |
+
+## References
+
+- `reports/audit-2026-05-04/maintainability-duplication-naming.md` (5.2)
+- `reports/audit-2026-05-04/pattern-divergence.md` (rij 11-13)
+- `klai-mailer/app/logging_setup.py` — canonical met `_HealthCheckAccessFilter`
+- `pitfalls/process-rules.md::redis-url-password-must-be-parsed-manually` — uitleg waarom mailer access-logs INFO zijn (4-h outage)

--- a/.moai/specs/SPEC-RESTORE-001/spec.md
+++ b/.moai/specs/SPEC-RESTORE-001/spec.md
@@ -1,0 +1,93 @@
+---
+id: SPEC-RESTORE-001
+version: "0.1.0"
+status: draft
+created: 2026-05-05
+updated: 2026-05-05
+author: Mark Vletter
+priority: high
+related:
+  - SPEC-INFRA-005 (backup pipeline parent)
+  - SPEC-CODEBASE-AUDIT-001 (parent, Cluster M)
+---
+
+# SPEC-RESTORE-001: End-to-end restore runbook + maandelijks test-restore in CI
+
+## Summary
+
+Sluit Schrödinger's-backup risico: backup-pipeline produceert daily encrypted artifacts naar Storage Box, maar **er is geen restore runbook en geen verificatie-test**. Bij een echte outage moet operator backup.sh reverse-engineeren onder druk. Deze SPEC voegt staging-restore-script + cron-driven verificatie + canonical runbook toe.
+
+## Motivation
+
+Per `reports/audit-2026-05-04/i18n-a11y-backup.md` (8.19):
+- **HIGH gap**: Geen end-to-end restore runbook (`docs/runbooks/restore.md` ontbreekt)
+- **HIGH gap**: Geen periodieke test-restore in CI/cron — backup-set kan corrupt zijn zonder dat iemand het merkt
+- **MED**: Storage Box retention "TODO" — onbeperkt opbouwen
+
+## Scope
+
+### In scope
+
+1. **`scripts/test-restore.sh`** — staging-restore-script dat:
+   - Pulls latest backup van Storage Box
+   - Decrypt met age recipient (mac of test-host)
+   - Restore naar isolated test-postgres + test-mongo + test-redis containers
+   - Run smoke-queries (count rows, verify schemas)
+   - Tear down containers
+   - Output: pass/fail + report
+
+2. **`docs/runbooks/restore.md`** — end-to-end runbook met:
+   - Disaster scenarios (full host loss, single-DB corruption, single-blob corruption)
+   - Per scenario: specifieke restore-commands
+   - Pre-flight verificatie (age key access, Storage Box connectivity)
+   - Per-store restore-volgorde (Postgres eerst voor metadata, dan blob-stores)
+   - Post-restore validation checklist
+
+3. **Maandelijkse test-restore in CI** — GitHub Action `test-restore.yml`:
+   - `schedule: cron: '0 4 1 * *'` (1e van maand 04:00 UTC)
+   - Pulls backup van afgelopen 24u, draait `test-restore.sh`, alarmeert bij failure (push naar Uptime Kuma + Grafana)
+   - Failure-report naar `reports/restore-tests/<date>.md`
+
+4. **Storage Box retention policy**:
+   - Local 30d (huidige)
+   - Remote tier-rotation: dagelijks laatste 30 + wekelijks laatste 12 + maandelijks laatste 12 = ~64 backups
+   - Auto-cleanup script `scripts/storagebox-prune.sh` met dry-run flag
+
+### Out of scope
+
+- LUKS migratie van core-01 (apart traject prod-01 migration)
+- VictoriaLogs offsite backup (apart SPEC)
+
+## Acceptance criteria
+
+1. `scripts/test-restore.sh --dry-run` werkt zonder echte restore
+2. `scripts/test-restore.sh` op test-host: alle 7 stores restoreren + smoke-queries pass
+3. `docs/runbooks/restore.md` reviewed door 2e operator (peer-review)
+4. Eerste cron-run slaagt (handmatige trigger via `gh workflow run test-restore.yml`)
+5. Storage Box retention: na 1 maand bevat 30+12+12 = 54 artifacts (verify via SSH)
+
+## Implementation notes
+
+- Test-host: dedicated machine (kan dev-host of klai-private VM zijn) met SSH-key in CI secrets
+- Postgres restore: `pg_restore` op temp container; verify schemas matchen `pg_dump --schema-only` van source
+- Mongo restore: `mongorestore --archive` op temp container
+- Redis restore: stop test-redis, copy `dump.rdb`, start test-redis
+- FalkorDB restore: idem als Redis (RDB-format)
+- Qdrant restore: snapshot API per collection
+- Garage restore: rsync blobs naar test-Garage
+- Retention prune: respect age + tier-class via filename-pattern
+
+## Risks
+
+| Risk | Mitigatie |
+|---|---|
+| Test-host disk vult (backups stack op) | Per-run cleanup; max 1 active test-restore tegelijk |
+| Schema-mismatch tussen prod en test-restore tooling | Use latest production image-tags voor test-Postgres/Mongo |
+| age key compromise op test-host | Read-only key (recipient-only voor decrypt) |
+
+## References
+
+- `reports/audit-2026-05-04/i18n-a11y-backup.md` (8.19)
+- `deploy/scripts/backup.sh` — bestaande backup pipeline
+- `deploy/volume-mounts.yaml` — SPEC-INFRA-005 inventory
+- `klai-infra/SERVERS.md` — Disaster recovery sectie

--- a/.moai/specs/SPEC-SEC-AUTH-HARDENING-001/spec.md
+++ b/.moai/specs/SPEC-SEC-AUTH-HARDENING-001/spec.md
@@ -1,0 +1,76 @@
+---
+id: SPEC-SEC-AUTH-HARDENING-001
+version: "0.1.0"
+status: draft
+created: 2026-05-05
+updated: 2026-05-05
+author: Mark Vletter
+priority: high
+related:
+  - SPEC-CODEBASE-AUDIT-001 (parent, Cluster D)
+---
+
+# SPEC-SEC-AUTH-HARDENING-001: Auth-flow hardening (PKCE, replay, SSRF, cookie-isolation, observability)
+
+## Summary
+
+Bundelt 8 HIGH/MED security-findings rond auth-flows: connector-OAuth zonder PKCE, ontbrekende replay-protection op 3 webhooks, research-api SSRF in `convert_url`, gedeelde Fernet-key voor sso+oauth_state cookies, fire-and-forget provision tasks zonder observability.
+
+## Motivation
+
+Per `reports/audit-2026-05-04/auth-flow-review.md` + `renovate-docker-pyramid-adversarial.md` (Adversarial 1, 2, 5):
+- **TP-O1 HIGH**: connector-OAuth (Google/MS) zonder PKCE
+- **TP-W1 HIGH**: geen replay-protection op Moneybird/Vexa/Gitea webhooks
+- **TP-S1 HIGH**: research-api `convert_url` zonder SSRF-guard
+- **Adv-1 HIGH**: provision_tenant fire-and-forget zonder observability handoff
+- **Adv-2 MED**: OAuth state cookie deelt `sso_cookie_key` (no key-separation)
+- **TP-O2 MED**: `klai_oauth_state` op brede `.getklai.com` domain (niet `__Host-`)
+- **TP-W3 MED**: geen rate-limit op portal/ingest webhooks
+- **Adv-5 MED**: deprovision lock-released-before-task-queued race
+
+## Scope
+
+### In scope
+
+1. **PKCE S256** op `/api/oauth/{provider}/authorize` voor Google/MS connector OAuth + state-payload uitbreiden met `code_verifier` (32 bytes urlsafe)
+2. **`klai-libs/webhook-replay`** package extracten uit mailer's `app/nonce.py` + adopteren in portal Moneybird/Vexa webhooks + ingest Gitea webhook
+3. **`research-api/services/docling.py::convert_url`** wrap in `validate_url_pinned()` import uit `klai_image_storage.url_guard`
+4. **`oauth_state_cookie_key`** Settings-veld + Fernet-instantiatie + HKDF-derive uit `portal_secrets_key` (nieuwe key-class)
+5. **`__Host-klai_oauth_state`** cookie-prefix (geen domain-attribute)
+6. **Provision/deprovision observability**: 202 Accepted + polling URL OF Redis Streams queue ipv `BackgroundTasks.add_task`
+7. **Deprovision row-lock fix**: audit-emit synchroon vóór 202 return; long-running steps na queueing
+8. **Per-source rate-limit** op portal/ingest webhooks via mailer's sliding-window pattern
+
+### Out of scope
+
+- Settings-validators (gedekt door SPEC-SEC-VALIDATOR-COVERAGE-001)
+- klai-docs CSP/rehype-sanitize (al PR #313)
+- ingest header drift (al PR #314)
+
+## Acceptance criteria
+
+1. Per fix: dedicated test in respectievelijke service `tests/`
+2. PKCE: state-payload contains `code_verifier`; OAuth callback verifies via `code_verifier` matches `code_challenge`; test van replay en wrong-verifier
+3. webhook-replay: nonce-store TTL 5min; fail-closed bij Redis-down (per mailer pattern); test cross-service consume
+4. research-api SSRF: `validate_url_pinned` faalt op `http://portal-api:8010/...` met test-fixture
+5. oauth_state_cookie_key: rotation kan zonder impact op sso_cookie_key
+6. Provision observability: status-endpoint dat tenant-state polling toelaat
+7. Geen 401-cascade tijdens rollout (atomic deploy per fix)
+
+## Sequencing (per fix in eigen PR)
+
+1. webhook-replay extract (laaghangend, geen breaking change)
+2. research-api SSRF fix (single-file, single-test)
+3. PKCE OAuth (single-service portal-api)
+4. oauth_state_cookie_key separation (vereist SOPS env-var pre-flight)
+5. `__Host-` cookie prefix (klein, snel)
+6. Provision/deprovision observability (groot, eigen sub-SPEC mogelijk)
+7. Webhook rate-limit (afgeleid van mailer pattern)
+
+## References
+
+- `reports/audit-2026-05-04/auth-flow-review.md`
+- `reports/audit-2026-05-04/renovate-docker-pyramid-adversarial.md` (sectie 3.12 Adversarial)
+- `klai-mailer/app/nonce.py` — replay-protection canonical pattern
+- `klai-libs/image-storage/url_guard.py::validate_url_pinned`
+- RFC 9700 OAuth 2.0 Security BCP

--- a/.moai/specs/SPEC-SEC-EDGE-CSP-001/spec.md
+++ b/.moai/specs/SPEC-SEC-EDGE-CSP-001/spec.md
@@ -1,0 +1,76 @@
+---
+id: SPEC-SEC-EDGE-CSP-001
+version: "0.2.0"
+status: in-progress
+created: 2026-05-05
+updated: 2026-05-05
+author: Mark Vletter
+priority: high
+related:
+  - SPEC-CODEBASE-AUDIT-001 (parent, Cluster E)
+---
+
+# SPEC-SEC-EDGE-CSP-001: Site-wide CSP hardening + edge-rate-limit + permissive CORS fix
+
+## Summary
+
+Verhardt edge security beyond `frame-ancestors` only: per-host CSP met script-src/style-src/connect-src/object-src, CORS hardening op scribe/research-api permissief regex met credentials, edge rate-limit op `/api/*` catch-all, HSTS preload, Permissions-Policy uitbreiding.
+
+## Motivation
+
+Per `reports/audit-2026-05-04/frontend-edge-security.md` (3.5 + 3.6):
+- **TP-FE-2/EDGE-1 HIGH**: site-wide CSP only `frame-ancestors` — geen XSS-defense-in-depth
+- **TP-EDGE-2 HIGH**: scribe + research-api permissief `allow_origin_regex` met `allow_credentials=True` (latent risk)
+- **TP-EDGE-3 MED**: geen edge rate-limit op `/api/*` catch-all
+- **TP-EDGE-4 MED**: HSTS mist `preload` directive
+- **TP-EDGE-5 MED**: Permissions-Policy is sparse
+
+Plus al deels gedekt door PR #313 (klai-docs `rehype-sanitize` voor TP-FE-1).
+
+## Scope
+
+### In scope
+
+1. **Per-host CSP** in `deploy/caddy/Caddyfile`:
+   - Default: `script-src 'self' 'wasm-unsafe-eval' https://*.sentry.io https://my.getklai.com; object-src 'none'; base-uri 'self'; form-action 'self' https://auth.getklai.com`
+   - Grafana/admin: `unsafe-inline` toegestaan
+   - klai-docs: stricter (na PR #313 rehype-sanitize)
+   - Tenant LibreChat: aparte file
+2. **scribe-api + research-api**: vervang `allow_origin_regex` Starlette CORS door `KlaiCORSMiddleware`-stijl hardcoded compiled regex (rejecting multi-label edge cases)
+3. **Edge rate-limit** op Caddy `handle /api/*`: `rate_limit { zone api_per_ip { key {remote_host} events 600 window 1m } }`
+4. **HSTS preload**: `Strict-Transport-Security: max-age=31536000; includeSubDomains; preload` (na verificatie alle subdomains HTTPS-only) + submit naar hstspreload.org
+5. **Permissions-Policy** uitbreiding: `interest-cohort=(), browsing-topics=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=(), autoplay=(self), fullscreen=(self), picture-in-picture=()`
+
+### Already done (PR #313)
+
+- klai-docs `rehype-sanitize` na `rehype-raw` (TP-FE-1)
+
+### Out of scope
+
+- Frontend dep upgrades (next 16.2.3, picomatch) — separate PR met `npm audit fix`
+
+## Acceptance criteria
+
+1. Caddyfile lint via `caddy validate` clean
+2. CSP-headers per route via `curl -I` test
+3. `tests/caddy/test_caddyfile_csp_headers.py` regression-guard
+4. scribe + research-api CORS test: rejected origins krijgen geen ACAC header
+5. Rate-limit verify: 601e request in 1 min krijgt 429
+6. HSTS preload verifier OK voordat submit
+7. SecurityHeaders.com score ≥ A
+
+## Risks
+
+| Risk | Mitigatie |
+|---|---|
+| CSP breaks Sentry / Mantine / BlockNote inline | Per-host policies + browser-test pre-deploy |
+| Rate-limit blokkeert legitime burst-callers (frontend bulk-ops) | 600/min per-IP is ruim; partner-API heeft eigen 120/min |
+| HSTS preload is permanent | Verifier pre-submit; 1-jaar `max-age` first |
+| Permissions-Policy breekt bestaande feature | Test in dev-tenant eerst |
+
+## References
+
+- `reports/audit-2026-05-04/frontend-edge-security.md`
+- `deploy/caddy/Caddyfile`
+- `klai-portal/backend/app/middleware/klai_cors.py` — KlaiCORSMiddleware canonical
+- https://hstspreload.org

--- a/.moai/specs/SPEC-SEC-PORTAL-RLS-001/spec.md
+++ b/.moai/specs/SPEC-SEC-PORTAL-RLS-001/spec.md
@@ -1,0 +1,77 @@
+---
+id: SPEC-SEC-PORTAL-RLS-001
+version: "0.1.0"
+status: draft
+created: 2026-05-05
+updated: 2026-05-05
+author: Mark Vletter
+priority: high
+related:
+  - SPEC-CODEBASE-AUDIT-001 (parent, Cluster C)
+---
+
+# SPEC-SEC-PORTAL-RLS-001: RLS coverage voor `portal_join_requests` + `portal_org_allowed_domains`
+
+## Summary
+
+Voeg RLS-policies toe aan twee portal-tabellen die wel `org_id` kolom hebben maar geen `CREATE POLICY` (pre-auth invitation flows). Plus mechanische guards via ast-grep om untenanted SyncRun queries in klai-connector te blokkeren.
+
+## Motivation
+
+Per `reports/audit-2026-05-04/tenant-scoping.md`:
+- TP-1 HIGH: `portal_join_requests` mist RLS — admin token-based approve heeft geen DB-laag fallback
+- TP-2 HIGH: `portal_org_allowed_domains` mist RLS — domain-claims kunnen cross-tenant leaken
+- TP-5 HIGH-onbekend: `klai-connector/connector.sync_runs` heeft `org_id` maar geen `CREATE POLICY`
+
+## Scope
+
+### In scope
+
+1. **`portal_join_requests`** Category-D RLS-policy met `OR T IS NULL` branch voor pre-auth `auth_select.py` flow
+2. **`portal_org_allowed_domains`** Category-D RLS-policy
+3. Beide tabellen toevoegen aan `RLS_DML_TABLES` in `app/core/rls_guard.py`
+4. ast-grep rule `rules/no-untenanted-syncrun-query.yml` die elke `select(SyncRun)`/`update(SyncRun)`/`delete(SyncRun)` zonder `.where(SyncRun.org_id == ...)` flagt als CI violation
+5. Test `klai-connector/tests/test_sync_runs_tenant_isolation.py` met twee tenants
+6. Regression-test in portal `tests/test_rls_coverage.py` die `pg_policies` checkt op alle tabellen met `org_id`
+
+### Out of scope
+
+- Postgres RLS op `connector.sync_runs` zelf (te zwaar voor deze SPEC; pure ast-grep + tests volstaan)
+- RLS op andere niet-portal services (knowledge.*, scribe.*, research.*) — apart per service
+
+## Acceptance criteria
+
+1. Alembic migration + post-deploy SQL voor beide tabellen
+2. Migration draait op staging zonder errors
+3. `assert_portal_users_rls_ready` startup-assertion uitgebreid voor de twee nieuwe tabellen
+4. ast-grep rule fired in CI op test-fixture met untenanted SyncRun query
+5. Regression-test detecteert ontbrekende policy als RLS_DML_TABLES uit sync raakt met `pg_policies`
+
+## Implementation outline
+
+```sql
+-- alembic migration + post-deploy SQL
+ALTER TABLE portal_join_requests ENABLE ROW LEVEL SECURITY;
+ALTER TABLE portal_join_requests FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY tenant_isolation ON portal_join_requests
+  USING (org_id = current_setting('app.current_org_id', true)::int
+         OR current_setting('app.current_org_id', true) IS NULL)
+  WITH CHECK (org_id = current_setting('app.current_org_id', true)::int);
+
+-- Idem voor portal_org_allowed_domains, maar Category-D strict (no OR NULL)
+```
+
+## Risks
+
+| Risk | Mitigatie |
+|---|---|
+| `auth_select.py` flow breekt door strict RLS | Category-D `OR T IS NULL` branch voor pre-auth |
+| Admin token-based approve auth_join verbreken | Test `test_auth_join_token_approve_after_rls` |
+| ast-grep false-positives op test-fixtures | `paths_exclude_glob` voor `tests/regression-fixtures/` |
+
+## References
+
+- `reports/audit-2026-05-04/tenant-scoping.md` (TP-1, TP-2, TP-5)
+- `.claude/rules/klai/projects/portal-security.md` (4-categorieën RLS framework)
+- `klai-portal/backend/app/core/rls_guard.py::RLS_DML_TABLES`

--- a/.moai/specs/SPEC-SEC-VALIDATOR-COVERAGE-001/spec.md
+++ b/.moai/specs/SPEC-SEC-VALIDATOR-COVERAGE-001/spec.md
@@ -1,0 +1,104 @@
+---
+id: SPEC-SEC-VALIDATOR-COVERAGE-001
+version: "0.1.0"
+status: draft
+created: 2026-05-05
+updated: 2026-05-05
+author: Mark Vletter
+priority: high
+related:
+  - SPEC-CODEBASE-AUDIT-001 (parent audit, Cluster A)
+  - SPEC-SEC-WEBHOOK-001 (validator-env-parity precedent)
+---
+
+# SPEC-SEC-VALIDATOR-COVERAGE-001: Fail-closed Settings validators voor 12 auth-secrets
+
+## Summary
+
+Sluit het `fail-open-auth` HIGH pitfall-patroon door 12 missing fail-closed `@model_validator(mode="after")` validators toe te voegen aan pydantic Settings in 4 services. Empty/whitespace-only auth-secrets falen nu silent — een misconfigured deploy disabled auth zonder error. Deze SPEC dwingt fail-fast bij startup.
+
+## Motivation
+
+Per `reports/audit-2026-05-04/security-findings.md` sectie 1: 12 TPs gevonden waar Settings-velden voor auth-secrets geen non-empty validator hebben. Per pitfall `validator-env-parity` (HIGH): elke validator moet eerst de env-var in SOPS hebben staan, anders triggert het 502-cascade bij service-restart.
+
+## Scope
+
+### In scope (12 validators × 4 services)
+
+**klai-portal/backend/app/core/config.py** (8 validators):
+- `internal_secret` (mailer→portal Bearer)
+- `klai_connector_secret` (portal→connector Bearer)
+- `knowledge_ingest_secret` (portal→ingest X-Internal-Secret)
+- `retrieval_api_internal_secret` (portal→retrieval)
+- `docs_internal_secret` (portal→docs)
+- `zitadel_portal_client_secret` (BFF code exchange)
+- `portal_secrets_key` + `encryption_key` + `sso_cookie_key` + `bff_session_key` (encryption keys at rest — 4 separate)
+
+**klai-connector/app/core/config.py** (1 validator):
+- `portal_caller_secret` (inbound from portal)
+
+**klai-knowledge-ingest/knowledge_ingest/config.py** (1 validator):
+- `gitea_webhook_secret` (HMAC verify Gitea push)
+
+**klai-mailer/app/config.py** (1 validator):
+- `portal_internal_secret` (mailer→portal outbound)
+
+**klai-retrieval-api/retrieval_api/config.py** (1 validator):
+- `portal_internal_secret` (retrieval→portal IdentityAsserter)
+
+### Out of scope
+
+- Reserved-but-unused secrets (`vexa_admin_token`, `docs_internal_secret` in ingest) — separate cleanup
+- Secret rotation procedure (covered by SPEC-RESTORE-001 / docs/runbooks/credential-rotation.md)
+
+## Acceptance criteria
+
+1. Per service: voor elk listed secret-veld bestaat `@model_validator(mode="after") _require_<field>` die `ValueError` raises bij empty/whitespace-only
+2. Per service: dedicated test `tests/test_config_fail_closed.py` (mailer-style) met `test_settings_startup_fails_without_<field>` voor elke validator
+3. Pre-flight: env-var bestaat in `klai-infra/core-01/.env.sops` BEFORE merge (per pitfall `validator-env-parity`)
+4. Post-deploy verify: `docker exec klai-core-<service>-1 printenv <VAR>` toont non-empty waarde
+5. Geen container-restart-loop op deploy
+
+## Implementation outline
+
+Volg precies het `klai-mailer/app/config.py::_require_webhook_secret` pattern:
+```python
+@model_validator(mode="after")
+def _require_<field>(self) -> "Settings":
+    """SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-<n>: fail-closed on missing <FIELD>.
+
+    [Why] [Where used] [Failure mode without validator]
+    Env-parity: <FIELD> must exist in klai-infra/core-01/.env.sops BEFORE merge.
+    """
+    if not self.<field> or not self.<field>.strip():
+        raise ValueError(
+            "Missing required: <FIELD> (SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-<n>). "
+            "Set it in SOPS before starting <service>."
+        )
+    return self
+```
+
+## Sequencing (one batch per service to limit blast radius)
+
+1. **portal-api batch** — 8 validators in 1 PR + tests; SOPS env-vars (8 vars) in 1 SOPS commit BEFORE PR-merge
+2. **klai-connector batch** — 1 validator
+3. **klai-knowledge-ingest batch** — 1 validator
+4. **klai-mailer batch** — 1 validator
+5. **klai-retrieval-api batch** — 1 validator
+
+Per batch: SSH SOPS workflow uit `.claude/rules/klai/infra/sops-env.md`, deploy, verify, then merge code-PR.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Deploy-loop bij missing env-var | Pre-flight grep + verify in SOPS BEFORE merge |
+| Per-key rotation impact | Document per validator wat het breekt bij empty value |
+| Cross-service trust-boundary breakage tijdens rollout | Sequentiële per-service deploy (één tegelijk) |
+
+## References
+
+- `.claude/rules/klai/pitfalls/process-rules.md` — `fail-open-auth`, `validator-env-parity`, `empty-secret-fail-open`
+- `.claude/rules/klai/infra/sops-env.md` — SSH SOPS workflow
+- `reports/audit-2026-05-04/security-findings.md` (sectie 1.x)
+- `klai-mailer/app/config.py::_require_webhook_secret` — canonical pattern

--- a/.moai/specs/audit-2026-05-05-followups.md
+++ b/.moai/specs/audit-2026-05-05-followups.md
@@ -1,0 +1,76 @@
+# Audit 2026-05-05 — Won't-fix items + follow-up SPECs
+
+> Audit-driven sweep of 21 PRs from 2026-05-05 session via 4 evaluator-active
+> agents (security / infra / GDPR / refactor clusters). Most CRIT and HIGH
+> findings were addressed in-session. This document captures the items that
+> were **deliberately not fixed** in the same PRs and the follow-up SPECs
+> that should land them properly.
+
+---
+
+## Won't-fix in original PRs (cosmetic / non-blocking)
+
+| Audit ref | Item | Why not fixed in PR | Follow-up |
+|---|---|---|---|
+| #1 F5 | connector test `importlib.reload` not isolation-safe | xdist-style nit; tests are not run in parallel mode in CI today | Bundle into a future "test-isolation hardening" SPEC |
+| #1 F6 | knowledge-ingest `taxonomy_auto_categorise` test asserts on error-message text | brittle if InternalSecretMiddleware error-text reformats; LOW value to fix in isolation | Bundle |
+| #1 F9 | `test_valid_env_constructs_settings` is low-marginal-value | adds defence-in-depth without proving any specific validator | Leave; remove only if test count budget tightens |
+| #1 F10 | ast-grep CI step skips silently if `uvx` is absent | works on developer machines; CI containers have `uvx` available | Add `uvx` install to ast-grep CI step in a CI-hardening PR |
+| #2 MED | knowledge-ingest + scribe-api push `:sha` tag on every PR build | operational concern (GHCR storage growth); not a security issue | Separate **SPEC-CI-GHCR-RETENTION-001** if storage cost climbs |
+| #3 MED 8 | `_FakeSession` regex SQL parsing fragile | SQLAlchemy compile-format dialect-sensitive; could silently mismatch | Migrate to direct `Mock(execute)` counter pattern in test-quality SPEC |
+| #3 MED 10 | G3 idempotency test uses 2 separate mock pools | bypasses real "DELETE on empty set = 0" invariant; works as smoke-test | Live-PG fixture in CI (separate **SPEC-CI-PG-FIXTURE-001**) |
+| #3 MED 11 | Qdrant klai_focus filter key claim unverified in CI | live-prod-probe done 2026-05-05 (`tenant_id` confirmed); future drift not auto-detected | Same SPEC-CI-PG-FIXTURE-001 — extend with Qdrant integration |
+| #4 MED A2 | `setup_logging` default param drift between mailer wrapper and shared lib | wrapper makes mailer-side ergonomic; drift only confuses future adopters | Document explicitly in `klai-libs/log-utils/README.md` |
+| #4 MED B1 | `RequestContextMiddleware` not E2E-tested in mailer | shared-lib tests cover the unit; mailer integration would duplicate | Bundle into shared-lib-adoption SPEC |
+| #4 MED D1 | Dockerfile trailing-slash cosmetic conflict #319 ↔ #335 | merge resolution decides; both forms work | Resolve at merge time (whoever lands second) |
+| #4 LOW B2 | `test_notify_replay` redundant patch after pop+reimport | works; cosmetic redundancy | Leave |
+| #4 LOW C5 | `klai-libs/log-utils` declares `starlette>=0.40` runtime dep | every klai service already depends on FastAPI (transitively pulls Starlette) | Leave — explicit dep is correct hygiene |
+| #4 LOW D2 | Stage 1 of mailer Dockerfile installs `git` (vestigial) | no runtime impact; reserved for future VCS-deps | Drop in next mailer Dockerfile pass |
+
+---
+
+## Fixed in-session (audit-pass commits)
+
+For traceability — these items were closed by per-PR amendments during the
+2026-05-05 audit-fix sweep:
+
+| Audit ref | Item | PR | Commit/SHA |
+|---|---|---|---|
+| #1 F1 | connector test tautology | #324 | `25c59f7a` |
+| #1 F2 | ingest valid-test bypassed import-time path | #325 | `9d281327` |
+| #1 F3 | BFF_SESSION_KEY validator vs `or sso_cookie_key` fallback | #323 | `8830d65c` |
+| #1 F4 | conftest BFF == SSO same Fernet key | #323 | `8830d65c` |
+| #1 F7 | frontend_url whitespace silent pass | #348 (new) | `9f025e3f` |
+| #1 F8 | ast-grep `_cross_org_marker` fragility (noqa removable) | #318 | `a227863d` |
+| #2 CRIT | knowledge.parent_chunks missing from baseline + composite PK/FK drift | #337 | `8eaf4194` |
+| #2 MED | runbook stamp command needs `--workdir` | #337 | `6d69664b` |
+| #2 HIGH | portal-api Pre-deploy env check ungated | #331 | `be9be496` |
+| #3 CRIT 1+2 | org_id type mismatch (int → Zitadel string) on 4 wipe steps | #343 | `0d063fba` |
+| #3 HIGH 5 | G3 wipe-postgres test missing X-Internal-Secret header assertion | #343 | `0816721b` |
+| #3 HIGH 6 | G6 wipe-state didn't purge connector.connectors | #332 | `6226ba03` |
+| #3 HIGH 7 | 4xx body not logged before raise_for_status | #343 | `0d063fba` |
+| #3 MED 9 | step-number drift in G3 endpoint docstring (13a → 9a) | #336 | `af399785` |
+| #4 CRIT C1 | `:latest` deploy gate missing on #319 + #335 (mailer-incident class) | #319 + #335 | `4bee9b60` + `7fc0ae8f` |
+| #4 HIGH C3 | klai-libs/log-utils paths trigger dropped from #335 workflow | #335 | `7fc0ae8f` |
+| #4 HIGH C4 | rate_limit.py still used redis_asyncio.from_url (pitfall class) | #335 | `7fc0ae8f` |
+| #4 HIGH A1 | klai-log-utils missing from #335 [project.dependencies] | #335 | `7fc0ae8f` |
+| #4 MED E1 | portal_client.py inline guards not documented vs validator | #326 | `c208c678` |
+
+---
+
+## Notes for next audit pass
+
+- **CI infrastructure gap**: items #3 MED 8/10/11 and #1 F10 are all symptoms
+  of "CI does not have a live Postgres or Qdrant fixture". A single
+  SPEC-CI-PG-FIXTURE-001 (or "CI service-container hardening") would close
+  all of them. Frame it as a Wave 4 cluster K item alongside the existing
+  SPEC-COVERAGE-CRITICAL-MODULES-001.
+
+- **Test-quality cluster**: items #1 F5/F6/F9 + #3 MED 8 are all
+  test-mechanics nits. Bundle into SPEC-TEST-QUALITY-001 (new — not yet on
+  the roadmap). Low individual value, high collective hygiene value if a
+  team reviewer reads them all together.
+
+- **Documentation cluster**: items #4 MED A2 + LOW B2 + #1 F8's docstring
+  comment + portal_client guard relationship — all "small documentation
+  improvements". Could ride along with the next manager-docs sync pass.

--- a/.moai/specs/audit-2026-05-05-followups.md
+++ b/.moai/specs/audit-2026-05-05-followups.md
@@ -10,17 +10,19 @@
 
 ## Won't-fix in original PRs (cosmetic / non-blocking)
 
+> **Update 2026-05-05 (later in session)**: 5 items previously in this
+> section were actually addressed in follow-up commits — moved to the
+> "Fixed in-session" table below. The `Why not fixed in PR` column for
+> those items would now read "fixed via per-PR amend; see Fixed table".
+
+Items that genuinely will not be addressed in the original PRs:
+
 | Audit ref | Item | Why not fixed in PR | Follow-up |
 |---|---|---|---|
-| #1 F5 | connector test `importlib.reload` not isolation-safe | xdist-style nit; tests are not run in parallel mode in CI today | Bundle into a future "test-isolation hardening" SPEC |
-| #1 F6 | knowledge-ingest `taxonomy_auto_categorise` test asserts on error-message text | brittle if InternalSecretMiddleware error-text reformats; LOW value to fix in isolation | Bundle |
-| #1 F9 | `test_valid_env_constructs_settings` is low-marginal-value | adds defence-in-depth without proving any specific validator | Leave; remove only if test count budget tightens |
-| #1 F10 | ast-grep CI step skips silently if `uvx` is absent | works on developer machines; CI containers have `uvx` available | Add `uvx` install to ast-grep CI step in a CI-hardening PR |
 | #2 MED | knowledge-ingest + scribe-api push `:sha` tag on every PR build | operational concern (GHCR storage growth); not a security issue | Separate **SPEC-CI-GHCR-RETENTION-001** if storage cost climbs |
-| #3 MED 8 | `_FakeSession` regex SQL parsing fragile | SQLAlchemy compile-format dialect-sensitive; could silently mismatch | Migrate to direct `Mock(execute)` counter pattern in test-quality SPEC |
-| #3 MED 10 | G3 idempotency test uses 2 separate mock pools | bypasses real "DELETE on empty set = 0" invariant; works as smoke-test | Live-PG fixture in CI (separate **SPEC-CI-PG-FIXTURE-001**) |
+| #3 MED 8 | `_FakeSession` regex SQL parsing fragile | refactor scope > audit-pass; needs SQLAlchemy statement-inspection rewrite | Separate PR — SPEC-TEST-QUALITY-001 deferred |
+| #3 MED 10 | G3 idempotency test uses 2 separate mock pools | bypasses real "DELETE on empty set = 0" invariant; works as smoke-test | Live-PG fixture in CI — **SPEC-CI-PG-FIXTURE-001** stub PR #356 |
 | #3 MED 11 | Qdrant klai_focus filter key claim unverified in CI | live-prod-probe done 2026-05-05 (`tenant_id` confirmed); future drift not auto-detected | Same SPEC-CI-PG-FIXTURE-001 — extend with Qdrant integration |
-| #4 MED A2 | `setup_logging` default param drift between mailer wrapper and shared lib | wrapper makes mailer-side ergonomic; drift only confuses future adopters | Document explicitly in `klai-libs/log-utils/README.md` |
 | #4 MED B1 | `RequestContextMiddleware` not E2E-tested in mailer | shared-lib tests cover the unit; mailer integration would duplicate | Bundle into shared-lib-adoption SPEC |
 | #4 MED D1 | Dockerfile trailing-slash cosmetic conflict #319 ↔ #335 | merge resolution decides; both forms work | Resolve at merge time (whoever lands second) |
 | #4 LOW B2 | `test_notify_replay` redundant patch after pop+reimport | works; cosmetic redundancy | Leave |
@@ -55,6 +57,11 @@ For traceability — these items were closed by per-PR amendments during the
 | #4 HIGH C4 | rate_limit.py still used redis_asyncio.from_url (pitfall class) | #335 | `7fc0ae8f` |
 | #4 HIGH A1 | klai-log-utils missing from #335 [project.dependencies] | #335 | `7fc0ae8f` |
 | #4 MED E1 | portal_client.py inline guards not documented vs validator | #326 | `c208c678` |
+| #1 F5 | connector test `importlib.reload` not isolation-safe | #324 | `9dd66d09` (later in session) |
+| #1 F6 | knowledge-ingest 401 detail-string brittle | #355 | `86ce8924` (documented trade-off + cross-ref) |
+| #1 F9 | `test_valid_env_constructs_settings` low marginal value | #323 | `73fd28c9` (added canary-vs-conftest-drift docstring) |
+| #1 F10 | ast-grep CI step would skip silently | #356 | `8ee2209f` (new `rules-tests.yml` workflow with uv install) |
+| #4 MED A2 | `setup_logging` default param drift wrapper-vs-shared-lib | #319 | `81f30abb` (verified-from-source README in same SPEC) |
 
 ---
 

--- a/.moai/specs/audit-roadmap-index.md
+++ b/.moai/specs/audit-roadmap-index.md
@@ -1,0 +1,49 @@
+# SPEC-CODEBASE-AUDIT-001 — fix-SPEC roadmap index
+
+Geconsolideerd uit `reports/audit-2026-05-04/roadmap.md` (15 fix-SPECs in 4 waves).
+Stub-files zijn aangemaakt voor de hoogste-prioriteit 7. Resterende 8 zijn nog te
+schrijven via `manager-spec` agent op basis van `synthesis.md` clusters.
+
+## Created stubs (✅)
+
+| SPEC | Cluster | Wave | Status |
+|---|---|---|---|
+| SPEC-SEC-VALIDATOR-COVERAGE-001 | A — Settings & validators | 1 | draft |
+| SPEC-SEC-PORTAL-RLS-001 | C — RLS coverage | 1 | draft |
+| SPEC-SEC-AUTH-HARDENING-001 | D — Auth-flow hardening | 1 | draft |
+| SPEC-SEC-EDGE-CSP-001 | E — Edge security | 1 | in-progress (PR #313 deels) |
+| SPEC-INFRA-TENANT-DELETE-002 | F — GDPR/PII | 1 | draft |
+| SPEC-RESTORE-001 | M — Operations | 2 | draft |
+| SPEC-INGEST-ALEMBIC-001 | I — DB schema | 2 | draft |
+| SPEC-LOGGING-EXTRACT-001 | J — Maintainability | 3 | draft |
+
+## Already in-flight or done
+
+| Item | Status |
+|---|---|
+| Wave-0 cleanup (~1966 LOC delete) | PR #310 |
+| FRONTEND_URL host-allowlist validator (Adv 3+4) | PR #310 |
+| klai-docs rehype-sanitize XSS fix | PR #313 |
+| knowledge-ingest header drift (Cluster G TP-1) | PR #314 |
+
+## To-be-stubbed (later via manager-spec)
+
+| SPEC | Cluster | Wave |
+|---|---|---|
+| SPEC-INFRA-REDIS-SPLIT-001 (al ergens gedraft) | B | 1 |
+| SPEC-DB-SCHEMA-HARMONIZATION-001 | I | 2 |
+| SPEC-CI-COVERAGE-001 | K | 2 |
+| SPEC-API-VERSION-001 (+ SPEC-INGEST-HEADER-DRIFT-001 closed via PR #314) | G | 3 |
+| SPEC-MAINTAINABILITY-REFACTOR-001 (top-5 F-grade functies) | J | 3 |
+| SPEC-CONNECTOR-CLEANUP-001 EXTEND (al draft) | H | 3 |
+| SPEC-CODEBASE-CLEANUP-001 (rest van dead code) | H | 3 |
+| SPEC-COVERAGE-CONFIG-001 + SPEC-COVERAGE-CRITICAL-MODULES-001 + SPEC-CONTRACT-TESTS-001 | K | 4 |
+| SPEC-DEPS-CONSOLIDATION-001 | N | 4 |
+| SPEC-OBS-METRICS-001 | M | 4 |
+| SPEC-DOCS-DRIFT-001 | L | 4 |
+
+## Cross-references
+
+- Master roadmap: `reports/audit-2026-05-04/roadmap.md`
+- Findings synthesis: `reports/audit-2026-05-04/synthesis.md`
+- Parent audit SPEC: `.moai/specs/SPEC-CODEBASE-AUDIT-001/spec.md` (v0.7.0, completed)


### PR DESCRIPTION
Companion document to PR #315 (audit-roadmap-index). Captures the 4-agent audit pass results: 19 findings FIXED in-session (mapped to PR/commit) + 14 won't-fix items with rationale + 3 cross-cutting follow-up clusters (CI-infra fixture, test-quality, doc cluster).

Self-contained in `.moai/specs/` next to the roadmap so the audit story is traceable end-to-end without external context.