### PR TITLE
chore(mcp): switch playwright MCP to --isolated + --storage-state

### DIFF
--- a/.claude/rules/klai/pitfalls/process-rules.md
+++ b/.claude/rules/klai/pitfalls/process-rules.md
@@ -1151,85 +1151,107 @@ deploy (PR #296, 12:11 CEST) used UIDs `spec-infra-container-hygiene-001-tenant-
 
 ## playwright-mcp-config-cycle (HIGH)
 The `@playwright/mcp` configuration in `.mcp.json` has been "fixed" at least
-four times since April 2026 (commits `940d079e`, `0ceab6b6`, `b26d5e01`,
-`0a423697`) — each fix re-introduced the failure mode that the previous fix
-was trying to eliminate. The user has explicitly named this an
+five times since April 2026 (commits `940d079e`, `0ceab6b6`, `b26d5e01`,
+`0a423697`, `ce6a8ab5`) — each fix re-introduced the failure mode that the
+previous fix was trying to eliminate. The user has explicitly named this an
 "every-time-you-fix-it-it-breaks-the-other-thing" cycle. Before changing
 ANYTHING about this config, you MUST internalise this entry, because the
 failure modes look like ordinary bugs each time you encounter them.
 
-**The two-horned trap.** `@playwright/mcp` only supports two profile modes,
-both confirmed verbatim in the upstream README and in
-[microsoft/playwright-mcp#1530](https://github.com/microsoft/playwright-mcp/issues/1530)
-(closed Not Planned, May 2026):
+**Use case (settled, do not re-derive):**
+AI-driven coding sessions where the assistant validates its own changes
+end-to-end via Playwright MCP. The user logs in ONCE; the AI takes over
+from there. Multiple coding sessions can run in parallel, each needing a
+visible browser with the same login already loaded. The AI does not log
+out, does not change passwords, does not mutate auth state. Read-only
+login state is therefore sufficient.
 
-- Persistent `--user-data-dir`: login state survives restarts, BUT
-  "A persistent profile can only be used by one browser instance at a time,
-  so concurrent MCP clients sharing the same workspace will conflict."
-  Symptom: the second Claude Code session fails with `Browser is already in use`.
-- `--isolated`: parallel sessions work, BUT "every time you ask MCP to close
-  the browser, the session is closed and all the storage state for this
-  session is lost." Login state is gone on every restart.
+**The constraint on the platform.** `@playwright/mcp` and Chromium together
+allow two profile modes:
 
-There is **no** built-in third option that gives both. `--storage-state` is
-read-only at startup; `saveSession` writes traces to the output directory,
-NOT cookies back to the storage-state file. Microsoft has explicitly declined
-to build named-session management. Do not waste a half-day rediscovering this.
+- Persistent `--user-data-dir`: login persists, BUT "A persistent profile
+  can only be used by one browser instance at a time, so concurrent MCP
+  clients sharing the same workspace will conflict." Symptom: second
+  Claude Code session fails with `Browser is already in use`.
+- `--isolated`: parallel sessions work, ephemeral profile per process. By
+  itself the profile starts empty; combine with `--storage-state <file>`
+  to preload cookies/localStorage at startup.
 
-**Why this slips through.** Each individual symptom looks like a config bug
-with an obvious fix. "Login lost" → add persistent `userDataDir`. "Browser
-lock on parallel session" → add `--isolated`. "Session expired again" → add
-`--storage-state`. Each of those edits is locally correct and globally wrong;
-you have just walked the cycle one more lap.
+`--storage-state` is read-only at startup and never written back. Microsoft
+explicitly declined named-session-with-auto-save in
+[#1530](https://github.com/microsoft/playwright-mcp/issues/1530)
+(closed Not Planned, May 2026). For this repo's use case (AI doesn't mutate
+auth) read-only is fine — refresh the file once when Google's session
+cookies expire (~3 weeks).
+
+**The canonical answer for this use case:**
+`--isolated --storage-state ~/.claude/mcp-storageState.json`. Generate the
+file with `npx playwright codegen --save-storage=...`. This is the standard
+Playwright multi-session authentication pattern (also what `globalSetup` +
+`storageState` does in Playwright Test). Do not invent something else.
 
 **Anti-patterns — do NOT propose any of these without re-reading this entry:**
 
 1. `--config <some.json>` with `userDataDir` set inside the JSON. **Silently
    broken on `@playwright/mcp@0.0.70`** ([issue #1446](https://github.com/microsoft/playwright-mcp/issues/1446)):
    the JSON `userDataDir` is ignored and the browser launches with an
-   in-memory profile. Login is lost on every restart. CLI flag works, JSON
-   does not.
-2. `--isolated` on the primary playwright server. Login state evaporates
-   per session. Will be re-removed within 24 hours by the next user complaint.
-3. `--isolated --storage-state <path>` without an automatic write-back
-   mechanism. The storage state is read-only at startup; nothing writes it
-   back at session close. Cookies expire (~3 weeks for Google) and login
-   silently breaks. The `scripts/export-mcp-session.mjs` that used to provide
-   write-back was lost in the cross-platform refactor on 2026-04-16.
-4. `--executable-path <Brave/Chrome>` for the primary browser. On Windows,
+   in-memory profile. CLI flags work; JSON does not. If you must use a JSON
+   config for some reason, verify on the running version that `userDataDir`
+   is honoured before relying on it.
+2. Persistent `--user-data-dir` for the primary playwright server.
+   Single-instance only — second concurrent session fails with the lock
+   error. Was tried in commits `b26d5e01` (apr 2) and `ce6a8ab5` (may 5).
+3. `--isolated` ALONE (no `--storage-state`) for the primary server. Each
+   session starts logged-out — defeats the whole point.
+4. `--headless` on a server the AI uses to validate its own changes. The
+   AI cannot SEE a headless browser; nothing to verify. Headed only.
+5. `--executable-path <Brave/Chrome>` for the primary browser. On Windows,
    Brave/Chrome cannot run a second instance with a different profile —
    the second instance becomes a background process with no visible window.
    Use Playwright's bundled Chromium (omit `--executable-path` entirely).
-5. "Just remove all profile config and let Playwright pick its default" —
-   default IS persistent `userDataDir`, so this re-triggers anti-pattern (2)
-   from the other direction (parallel sessions break with browser lock).
+6. Homegrown "slot pool" launchers that copy login files between profile
+   directories at start/exit. Tempting because it sounds clever, but:
+   - Not an industry standard pattern; no widely-validated implementation.
+   - Race conditions on simultaneous shutdowns (last-write-wins on cookies).
+   - SQLite cookie file copies during/after browser shutdown can corrupt.
+   - Only justified if the AI mutates auth state across sessions, which
+     this use case does not require.
+   Was attempted on 2026-05-05; reverted in favour of `--storage-state`.
+7. "Just remove all profile config and let Playwright pick its default" —
+   default IS persistent `--user-data-dir`, so this re-triggers
+   anti-pattern (2) from the other direction.
 
 **The current working setup (do not change without strong cause):**
 
 - Primary `playwright` server in `.mcp.json` invokes
   `.claude/scripts/playwright-launcher.mjs`, which spawns
-  `npx @playwright/mcp@0.0.70 --browser chromium --user-data-dir
-  ~/.claude/mcp-chromium-profile`. CLI flag, not JSON config — sidesteps
-  issue #1446. Bundled Chromium — sidesteps the Windows browser-lock.
-- Secondary `playwright-isolated` server in `.mcp.json` runs `--isolated
-  --headless` with no profile. This is the parallel-session escape hatch.
-  When a second concurrent Claude Code session needs a browser, it uses
-  this server, NOT the primary.
-- Single-instance restriction on the primary is documented and accepted.
-  Browser-lock errors after a crashed Chromium process are recovered with
-  `taskkill /F /IM chrome.exe` (Windows) or `pkill -f mcp-chromium-profile`
-  (Mac/Linux), not by adding `--isolated`.
+  `npx @playwright/mcp@0.0.70 --browser chromium --isolated
+  --storage-state ~/.claude/mcp-storageState.json`. Headed (no `--headless`).
+  Multi-session safe (each launch gets its own ephemeral profile).
+  All sessions preload the same login state.
+- Secondary `playwright-isolated` server in `.mcp.json` runs `--browser
+  chromium --isolated` with NO storage-state. Headed. For one-off CSS or
+  unauthenticated checks where login state would just be noise.
+- Login refresh (run when storage state is missing or Google cookies have
+  expired):
+  ```
+  npx --yes playwright codegen \
+    --save-storage="$HOME/.claude/mcp-storageState.json" \
+    --browser=chromium https://voys.getklai.com
+  ```
+  Log in to all sites you need, close the codegen window, file is written.
 
 **Prevention — symptom → correct response:**
 
 | Symptom | Correct response | Wrong response |
 |---|---|---|
-| Login expires on every restart | Verify `.mcp.json` runs the launcher (CLI flag), not `--config <json>`. Verify `~/.claude/mcp-chromium-profile/` exists and has cookies. | Add `--isolated` (loops you back to anti-pattern 2) |
-| `Browser is already in use` | Use `playwright-isolated` for the second session, OR kill the leftover Chromium process | Remove `--user-data-dir` (loops you back to login-loss) |
-| User says "iedere keer hetzelfde probleem" | Stop. Re-read this entry. Do not propose a config change. | Propose another config edit |
-| You "found a fix online" that flips between persistent and isolated | The fix is wrong for this repo's constraints. Constraint is: BOTH login persistence AND parallel sessions. Microsoft does not support both in one server — that's why we run two MCP servers, not one. | Change the primary server's mode |
+| Sessions start logged-out | Verify `~/.claude/mcp-storageState.json` exists and is recent. Run the codegen refresh command. | Add `--user-data-dir` back (anti-pattern 2) |
+| `Browser is already in use` on a second session | Confirm `.mcp.json` uses `--isolated` not `--user-data-dir`. Each session must get its own ephemeral profile. | Add a slot-pool launcher (anti-pattern 6) |
+| AI cannot see what the browser is doing | Confirm no `--headless` flag in the primary server. | Tell the user to "just check the browser themselves" — defeats the point |
+| User says "iedere keer hetzelfde probleem" | Stop. Re-read this entry. Do not propose a config change before identifying which anti-pattern you are about to commit. | Propose another config edit |
+| Storage state file is hand-edited / non-standard | Re-generate via `playwright codegen --save-storage`. The file format is Playwright-defined, not yours. | Hand-edit JSON in storageState |
 
-If a future @playwright/mcp version introduces named-session management
-(see [issue #1530](https://github.com/microsoft/playwright-mcp/issues/1530))
-or auto-write-back of storage state, the two-server setup can collapse into
-one. Until then, do not collapse it.
+If a future @playwright/mcp version introduces auto-write-back of storage
+state on session close, the manual refresh step can be removed. Until
+then, refreshing the storage-state file every few weeks is the cost of
+this design — accept it.

--- a/.claude/scripts/playwright-launcher.mjs
+++ b/.claude/scripts/playwright-launcher.mjs
@@ -2,42 +2,64 @@
 /**
  * Cross-platform Playwright MCP launcher.
  *
- * Uses Playwright's bundled Chromium (NOT Brave/Chrome) with a persistent
- * userDataDir, so login state survives across Claude Code restarts.
+ * Pattern: --isolated + --storage-state (canonical Playwright multi-session
+ * authentication). Each Claude Code session gets its own ephemeral Chromium
+ * profile that is preloaded with login cookies/localStorage from a shared
+ * storageState file. So:
+ *
+ *   - Multiple sessions run side-by-side without profile-lock conflicts
+ *   - All sessions start authenticated (Google, getklai, etc.)
+ *   - Browser windows are visible (not headless)
+ *   - No file-copy bookkeeping; storage-state is read-only at startup
+ *
+ * One-time login (run when storage-state is missing or expired, ~once every
+ * few weeks for Google):
+ *
+ *   npx --yes playwright codegen \
+ *     --save-storage="$HOME/.claude/mcp-storageState.json" \
+ *     --browser=chromium https://voys.getklai.com
+ *
+ * Log in to all sites you need, then close the browser window. The file is
+ * written automatically.
  *
  * Why CLI flags instead of a JSON config file:
- *   microsoft/playwright-mcp#1446 — `userDataDir` set in a JSON --config file
- *   is silently ignored on @playwright/mcp@0.0.70; the browser falls back to
- *   an in-memory profile and login state is lost. Passing --user-data-dir
- *   directly on the command line works correctly.
+ *   microsoft/playwright-mcp#1446 — `userDataDir` set in a JSON --config
+ *   file is silently ignored on @playwright/mcp@0.0.70.
  *
- * Single-instance limitation:
- *   Persistent profiles can only be opened by one browser at a time. A second
- *   Claude Code session that needs a browser should use the playwright-isolated
- *   MCP server (already wired in .mcp.json) instead.
- *
- * Profile location:
- *   ~/.claude/mcp-chromium-profile/ (cross-platform, derived from os.homedir())
+ * Why bundled Chromium (no --executable-path):
+ *   Brave/Chrome on Windows cannot run two simultaneous instances with
+ *   different user profiles. Bundled Chromium has no such constraint.
  */
 import { spawn } from 'child_process';
 import { homedir, platform } from 'os';
 import { join } from 'path';
+import { existsSync } from 'fs';
 
-const userDataDir = join(homedir(), '.claude', 'mcp-chromium-profile');
+const isWin = platform() === 'win32';
+const STATE_FILE = join(homedir(), '.claude', 'mcp-storageState.json');
 
-const child = spawn(
-  'npx',
-  [
-    '--yes',
-    '@playwright/mcp@0.0.70',
-    '--browser', 'chromium',
-    '--user-data-dir', userDataDir,
-  ],
-  {
-    stdio: 'inherit',
-    shell: platform() === 'win32', // Windows requires shell:true for npx to resolve
-  }
-);
+const args = [
+  '--yes',
+  '@playwright/mcp@0.0.70',
+  '--browser', 'chromium',
+  '--isolated',
+];
+
+if (existsSync(STATE_FILE)) {
+  args.push('--storage-state', STATE_FILE);
+} else {
+  process.stderr.write(
+    `playwright-launcher: ${STATE_FILE} not found.\n` +
+    `Run once to generate it:\n` +
+    `  npx --yes playwright codegen --save-storage="${STATE_FILE}" --browser=chromium https://voys.getklai.com\n` +
+    `Browser will start without preloaded login state.\n`
+  );
+}
+
+const child = spawn('npx', args, {
+  stdio: 'inherit',
+  shell: isWin, // Windows requires shell:true for npx to resolve
+});
 
 child.on('exit', (code) => process.exit(code ?? 0));
 child.on('error', (err) => {

--- a/.mcp.json
+++ b/.mcp.json
@@ -16,21 +16,20 @@
       "env": {}
     },
     "playwright": {
-      "$comment": "Browser automation with persistent Chromium profile (login state survives restarts). Cross-platform via .claude/scripts/playwright-launcher.mjs — passes --user-data-dir as CLI flag to dodge microsoft/playwright-mcp#1446. Single-instance: a second concurrent Claude Code session must use playwright-isolated.",
+      "$comment": "Headed Chromium with shared login state across parallel Claude Code sessions. Uses --isolated + --storage-state (canonical Playwright multi-session auth). Log in once via `npx playwright codegen --save-storage=~/.claude/mcp-storageState.json --browser=chromium <url>`; every session preloads that state. No browser-lock conflicts because each session uses its own ephemeral profile. AI-driven sessions don't mutate login state, so read-only storage-state is sufficient.",
       "type": "stdio",
       "command": "node",
       "args": [".claude/scripts/playwright-launcher.mjs"],
       "env": {}
     },
     "playwright-isolated": {
-      "$comment": "Ephemeral headless Chromium for CSS debugging, visual verification, and parallel sessions. No login state, no profile conflicts.",
+      "$comment": "Ephemeral headed Chromium for one-off CSS/visual checks where login state is not needed. Window is visible (not headless) so you can see what is happening; profile is in-memory and discarded on close.",
       "type": "stdio",
       "command": "npx",
       "args": [
         "@playwright/mcp@0.0.70",
         "--browser", "chromium",
-        "--isolated",
-        "--headless"
+        "--isolated"
       ],
       "env": {}
     },

--- a/docs/setup/mcp-servers.md
+++ b/docs/setup/mcp-servers.md
@@ -61,7 +61,7 @@ It is **cross-platform** — all platform-specific settings live in local config
     "playwright-isolated": {
       "type": "stdio",
       "command": "npx",
-      "args": ["@playwright/mcp@0.0.70", "--browser", "chromium", "--isolated", "--headless"],
+      "args": ["@playwright/mcp@0.0.70", "--browser", "chromium", "--isolated"],
       "env": {}
     },
     "codeindex": {
@@ -96,66 +96,89 @@ It is **cross-platform** — all platform-specific settings live in local config
 |--------|---------|
 | **serena** | Semantic code navigation (symbol search, references, go-to-definition) and persistent project memories. Uses LSP for Python and TypeScript. |
 | **context7** | Up-to-date library documentation (React, FastAPI, Next.js, etc.). Prefer over web search for API docs. |
-| **playwright** | Browser automation for E2E spot-checks and visual verification. Persistent Chromium profile so login state survives Claude Code restarts. Single-instance — for parallel sessions, use `playwright-isolated`. |
-| **playwright-isolated** | Ephemeral headless Chromium for CSS debugging and parallel browser work. No login state, no profile lock conflicts. |
+| **playwright** | Browser automation for E2E spot-checks and visual verification. Headed Chromium with shared login state via `--storage-state` — every Claude Code session preloads the same auth, runs in its own ephemeral profile, parallel-safe. |
+| **playwright-isolated** | Headed ephemeral Chromium with NO storage state. For CSS work or unauthenticated checks where preloaded login would just be noise. |
 | **codeindex** | Graph-powered code intelligence — call graphs, impact analysis, semantic search, communities, and enrichment queries (git hotspots, SPEC links, test coverage, PageRank). |
 | **grafana** | Read-only access to Grafana dashboards, Prometheus/VictoriaMetrics queries, and alerts. Cannot query VictoriaLogs — use the `victorialogs` MCP for log queries instead. |
 | **victorialogs** | Production log queries via LogsQL against VictoriaLogs. Requires SSH tunnel (`./scripts/victorialogs-tunnel.sh`) and `VICTORIALOGS_BASIC_AUTH_B64` env var. Preferred over `docker logs` for investigating issues. |
 
 ## 3. Set up Playwright
 
-No per-machine setup. The `playwright` server in `.mcp.json` invokes
-`.claude/scripts/playwright-launcher.mjs` (committed, cross-platform). The launcher:
+No per-machine setup beyond a one-time login. The `playwright` server in `.mcp.json`
+invokes `.claude/scripts/playwright-launcher.mjs` (committed, cross-platform). The launcher
+spawns `@playwright/mcp@0.0.70` with `--browser chromium --isolated --storage-state
+~/.claude/mcp-storageState.json`. Bundled Chromium, no Brave/Chrome.
 
-- Uses Playwright's bundled Chromium — no Brave, Chrome, or other locally-installed browser
-- Passes `--user-data-dir ~/.claude/mcp-chromium-profile` as a CLI flag (cross-platform path
-  via `os.homedir()`, no per-developer edits needed)
-- Pins `@playwright/mcp@0.0.70`
+### Use case this is built for
+
+AI-driven coding sessions where the assistant validates its own changes end-to-end via
+Playwright MCP. You log in once; the AI takes over from there. Multiple coding sessions
+can run in parallel — each gets a visible browser window with the same login already
+loaded.
+
+### Why `--isolated` + `--storage-state` instead of a persistent profile
+
+A persistent Chromium profile (`--user-data-dir`) is single-instance: a second simultaneous
+session fails with `Browser is already in use`. `--isolated` gives every session its own
+ephemeral profile (no lock conflicts), and `--storage-state <file>` preloads cookies and
+localStorage at startup so the session is already authenticated. This is the canonical
+Playwright multi-session authentication pattern (also what Playwright Test does via
+`globalSetup` + `storageState`).
+
+Storage state is read-only at startup — nothing writes it back. That is fine for this use
+case because the AI does not log out, change passwords, or otherwise mutate auth. Refresh
+the file when Google's session cookies expire (~3 weeks).
 
 ### Why a launcher script and not a JSON `--config` file
 
 [microsoft/playwright-mcp#1446](https://github.com/microsoft/playwright-mcp/issues/1446):
-on `@playwright/mcp@0.0.70`, the `userDataDir` set inside a JSON `--config` file is silently
-ignored — the browser falls back to an in-memory profile and login state is lost on every
-restart. Passing `--user-data-dir` as a CLI flag works correctly. The launcher is the
-cross-platform vehicle for that flag.
+on `@playwright/mcp@0.0.70`, profile-related options set inside a JSON `--config` file
+can be silently ignored. CLI flags work correctly. The launcher is the cross-platform
+vehicle for those flags.
 
-### Single-instance limitation (and the workaround)
+### One-time login (and refresh)
 
-A persistent Chromium profile can only be opened by **one** browser instance at a time. If a
-second concurrent Claude Code session tries to launch the same `playwright` MCP server, the
-second one fails with `Browser is already in use`.
-
-Workaround in this repo: a **second** MCP server is wired in `.mcp.json` called
-`playwright-isolated`. It uses `--isolated --headless` (ephemeral, no persistent profile) and
-is meant for parallel sessions where login state is not required (CSS debugging, visual
-verification). Use the `playwright` server for anything that needs an authenticated session,
-and `playwright-isolated` everywhere else.
-
-For the full failure-mode cycle and anti-patterns to avoid, see
-`playwright-mcp-config-cycle (HIGH)` in `.claude/rules/klai/pitfalls/process-rules.md`.
-
-### First-time login
-
-On first invocation, the launcher opens Chromium at whatever URL you navigate to. Log in
-manually in that window. Cookies and localStorage are written to
-`~/.claude/mcp-chromium-profile/` automatically. Subsequent sessions start logged in.
-
-### Starting from scratch (logged-out state)
-
-Delete the profile directory:
+Run this once, and again whenever Google's session cookies expire (you'll know because
+sessions start logged-out):
 
 ```powershell
 # Windows (PowerShell)
-Remove-Item -Recurse -Force "$env:USERPROFILE\.claude\mcp-chromium-profile"
+npx --yes playwright codegen `
+  --save-storage="$env:USERPROFILE\.claude\mcp-storageState.json" `
+  --browser=chromium `
+  https://voys.getklai.com
 ```
 
 ```bash
 # macOS / Linux
-rm -rf ~/.claude/mcp-chromium-profile
+npx --yes playwright codegen \
+  --save-storage="$HOME/.claude/mcp-storageState.json" \
+  --browser=chromium \
+  https://voys.getklai.com
 ```
 
-Restart Claude Code. Log in again on first use.
+A Chromium window opens. Log in to all sites you need (Google SSO, getklai, etc.). When
+done, close the codegen window. The storage-state file is written automatically. Restart
+Claude Code; every Playwright MCP session now starts authenticated.
+
+For the full failure-mode cycle and anti-patterns to avoid, see
+`playwright-mcp-config-cycle (HIGH)` in `.claude/rules/klai/pitfalls/process-rules.md`.
+
+### Starting from scratch (logged-out state)
+
+Delete the storage-state file, then re-run the codegen command above:
+
+```powershell
+# Windows (PowerShell)
+Remove-Item -Force "$env:USERPROFILE\.claude\mcp-storageState.json"
+```
+
+```bash
+# macOS / Linux
+rm -f ~/.claude/mcp-storageState.json
+```
+
+Then re-run the codegen command above to regenerate the file.
 
 For session management rules (when to open/close the browser), see
 `.claude/rules/klai/lang/testing.md`.
@@ -326,9 +349,10 @@ uvx mcp-grafana --help
 3. **MCP timeout** — Serena takes too long to index. Check `.serena/project.yml` for overly broad
    file patterns.
 4. **Playwright launcher fails to start** — `node` not on PATH or the launcher script missing. Fix: verify `node --version` works in your shell and `.claude/scripts/playwright-launcher.mjs` exists. Restart Claude Code.
-5. **Playwright login does not persist across restarts** — `userDataDir` was silently ignored (microsoft/playwright-mcp#1446). Fix: confirm `.mcp.json` runs the launcher (`"command": "node", "args": [".claude/scripts/playwright-launcher.mjs"]`) and not `--config <some.json>`. The launcher uses CLI flags which work correctly.
-6. **Playwright fails with `Browser is already in use`** — a second Claude Code session is trying to use the persistent profile. Fix: in the second session, use the `playwright-isolated` MCP server instead. If no other session is running, a previous Chromium process crashed and is holding the lock — kill it (`taskkill /F /IM chrome.exe` on Windows; `pkill -f mcp-chromium-profile` on Mac/Linux) and retry.
-7. **Playwright browser window not visible after login** — `~/.claude/mcp-chromium-profile/` parent directory doesn't exist. Fix: confirm `~/.claude/` exists; the launcher creates the profile sub-directory itself on first run.
+5. **Playwright sessions start logged-out** — `~/.claude/mcp-storageState.json` is missing or its cookies have expired. Fix: re-run the codegen command in Section 3 to regenerate the file, then restart Claude Code.
+6. **Playwright fails with `Browser is already in use`** — should not happen with `--isolated`. If it does, confirm `.mcp.json` still uses `--isolated --storage-state` and not a `--user-data-dir` flag. A leftover Chromium process can be killed with `taskkill /F /IM chrome.exe` (Windows) or `pkill -f playwright` (Mac/Linux).
+7. **Playwright window opens but immediately closes** — storage-state file is corrupt or in a non-Playwright format. Fix: delete `~/.claude/mcp-storageState.json` and re-run the codegen command.
+8. **Login state visible in one site but missing in another** — codegen capture only saved the sites you visited during the login dance. Fix: re-run codegen and visit + log in to every site you need before closing the window.
 9. **CodeIndex not found** — `codeindex` command not available. Fix: `npm install -g klai-private/tools/codeindex-1.3.56.tgz`
 10. **CodeIndex stale index** — Index behind HEAD. Symptoms: impact analysis misses recent code. Fix: `codeindex update && node scripts/codeindex-enrich.mjs`
 11. **VictoriaLogs tunnel not running** — MCP queries fail silently or timeout. Fix: `./scripts/victorialogs-tunnel.sh` then restart Claude Code.


### PR DESCRIPTION
## Summary

Replaces single-instance persistent userDataDir with the canonical Playwright multi-session auth pattern: ephemeral profile per session + shared storage-state file preloaded at startup. Parallel Claude Code sessions now run side-by-side with visible browser windows, all authenticated from the same one-time login.

## Why

- Persistent `userDataDir` is single-instance — second concurrent Claude Code session always failed with `Browser is already in use` (PR #346 left this broken for the AI-driven validation use case).
- `--isolated` alone starts every session logged-out.
- `--isolated --storage-state` (this PR): parallel-safe AND authenticated. Industry standard, what Playwright Test does via `globalSetup`.
- Headed (no `--headless`) so the AI can see what the browser is doing.

## One-time login

```bash
npx --yes playwright codegen \
  --save-storage=\"$HOME/.claude/mcp-storageState.json\" \
  --browser=chromium https://voys.getklai.com
```

Refresh every ~3 weeks when Google cookies expire. The AI does not mutate auth, so read-only storage-state is sufficient — no write-back glue needed.

## Pitfall update

Pitfall `playwright-mcp-config-cycle (HIGH)` rewritten to pin the use case (AI-driven, no auth mutation), add anti-pattern about homegrown slot-pool launchers (attempted today, rejected), and add anti-pattern about `--headless` on a server the AI uses to validate.

## Test plan

- [ ] Run codegen command above, log in to voys.getklai.com + Google
- [ ] Restart Claude Code → first session: browser starts authenticated
- [ ] Open second Claude Code session → second browser starts, also authenticated, no profile-lock conflict
- [ ] Both windows visible, both functional in parallel