### PR TITLE
fix(rebuild-kb): thread parent_chunk_id into Qdrant during rebuild

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/rebuild_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/rebuild_tasks.py
@@ -283,6 +283,10 @@ async def _rebuild_artifact(
 
             child_chunks, parent_chunks_obj = chunker.chunk_markdown_with_parents(document_text)
             child_texts = [c.text for c in child_chunks]
+            # Each child knows its parent's index in parent_chunks_obj —
+            # _enrich_document needs this list to thread parent_chunks.id
+            # into each child's Qdrant payload (parent_chunk_id).
+            parent_index_per_child: list[int | None] = [c.parent_index for c in child_chunks]
 
             if not child_texts:
                 logger.info(
@@ -310,8 +314,23 @@ async def _rebuild_artifact(
             extra_payload.setdefault("belief_time_start", belief_time_start)
             extra_payload.setdefault("belief_time_end", belief_time_end)
 
-            # Steps 2-3: enrichment + TEI/sparse embedding + Qdrant delete-then-upsert.
-            # _enrich_document handles all of this atomically for a single document.
+            # SPEC-RAG-PARENT-CHILD-001: clear stale parent_chunks rows before
+            # _enrich_document re-inserts them. Without this, the prior
+            # rebuild's parent rows pile up and child→parent lookup at retrieval
+            # time hits the wrong target.
+            from knowledge_ingest import pg_store as _pg_store
+
+            await _pg_store.delete_parent_chunks_for_artifact(artifact_id)
+
+            # Steps 2-3: enrichment + TEI/sparse embedding + Qdrant
+            # delete-then-upsert. _enrich_document inserts parent_chunks rows
+            # itself (so it can thread the generated row ids into each
+            # child's Qdrant payload as ``parent_chunk_id``) — passing
+            # ``parents`` + ``parent_index_per_child`` here is what lights up
+            # the parent-child retrieval expansion in retrieval-api. Before
+            # this fix the rebuild path called ``_enrich_document`` without
+            # them, so every Voys child chunk had ``parent_chunk_id=None``
+            # and parent expansion silently degraded to chunk-text-only.
             from knowledge_ingest.enrichment_tasks import _enrich_document
 
             await _enrich_document(
@@ -326,18 +345,9 @@ async def _rebuild_artifact(
                 extra_payload=extra_payload,
                 synthesis_depth=synthesis_depth,
                 content_type=content_type,
+                parents=parents_serialised,
+                parent_index_per_child=parent_index_per_child,
             )
-
-            # Step 4: Replace parent_chunks rows in PostgreSQL.
-            from knowledge_ingest import pg_store
-
-            await pg_store.delete_parent_chunks_for_artifact(artifact_id)
-            if parents_serialised:
-                await pg_store.insert_parent_chunks(
-                    artifact_id=artifact_id,
-                    org_id=org_id,
-                    parents=parents_serialised,
-                )
 
             logger.info(
                 "rebuild_artifact_processed",

--- a/klai-knowledge-ingest/tests/test_rebuild_tasks.py
+++ b/klai-knowledge-ingest/tests/test_rebuild_tasks.py
@@ -154,6 +154,47 @@ async def test_rebuild_kb_iterates_artifacts(_common_patches):
 
 
 # ---------------------------------------------------------------------------
+# Test 1b: parent-child threading regression guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rebuild_kb_threads_parents_into_enrich_document(_common_patches):
+    """SPEC-RAG-PARENT-CHILD-001: rebuild MUST pass ``parents`` +
+    ``parent_index_per_child`` to ``_enrich_document``.
+
+    Without these kwargs, ``_enrich_document`` upserts each child chunk to
+    Qdrant with ``parent_chunk_id=None`` and the parent expansion in
+    retrieval-api silently degrades to chunk-text-only. A previous version
+    of rebuild_tasks.py passed neither — the result on Voys-support was
+    448/448 rebuilt artifacts with zero parent linkage in Qdrant. This
+    test locks the contract so the regression cannot reappear silently.
+    """
+    from knowledge_ingest.rebuild_tasks import _rebuild_kb_core
+
+    _common_patches["mock_list"].return_value = [
+        _make_artifact("art-1", "doc1.md", "Some body text"),
+    ]
+
+    await _rebuild_kb_core(org_id=_ORG, kb_slug=_KB)
+
+    assert _common_patches["mock_enrich"].call_count == 1
+    enrich_kwargs = _common_patches["mock_enrich"].call_args.kwargs
+
+    # parents was serialised from parent_chunks_obj — should be a list of dicts.
+    assert "parents" in enrich_kwargs, "rebuild must pass parents= to _enrich_document"
+    assert isinstance(enrich_kwargs["parents"], list)
+    assert len(enrich_kwargs["parents"]) == 1
+    assert enrich_kwargs["parents"][0]["text"] == "parent text"
+
+    # parent_index_per_child mirrors child_chunks order.
+    assert "parent_index_per_child" in enrich_kwargs, (
+        "rebuild must pass parent_index_per_child= to _enrich_document"
+    )
+    assert enrich_kwargs["parent_index_per_child"] == [0]
+
+
+# ---------------------------------------------------------------------------
 # Test 2: skips artifacts without document_text
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Why

SPEC-RAG-PARENT-CHILD-001 introduced parent + child chunks: the LLM matches against small child chunks for precision and then expands to the larger parent for context. The expansion lookup in retrieval-api uses \`parent_chunk_id\` on each Qdrant child payload.

The rebuild_kb path (used to bring legacy artifacts onto the new pipeline) was passing the wrong arguments to \`_enrich_document\`: it gave it the chunked text but NOT the parents and the per-child→parent index mapping. Without those kwargs, \`_enrich_document\` upserts each child chunk to Qdrant with \`parent_chunk_id=None\`. The rebuild THEN inserted parent rows into Postgres separately, but with no link from Qdrant.

## Audit on Voys-support after the previous rebuild_kb run

\`\`\`
has document_summary: 4983 / 5479  (~92%)
has context_prefix:   5479
has parent_chunk_id:  0            ← THIS bug
has parent_id:        0
parent_chunks PG rows: 876 across 448 artifacts
\`\`\`

Parent rows existed in PG, no Qdrant child pointed at them. Effect: parent expansion silently degraded to "use the matched child chunk text only" — equivalent to disabling the feature for every artifact rebuilt this way (the entire backlog of legacy artifacts on Voys, BLG, and any tenant ever rebuilt).

## Fix

In \`rebuild_tasks.py::_rebuild_artifact\`:

1. Extract \`parent_index_per_child\` from the chunker output (each child knows its parent's position in \`parent_chunks_obj\`).
2. Move \`delete_parent_chunks_for_artifact\` BEFORE the \`_enrich_document\` call (so stale rows are cleared first).
3. Pass \`parents=parents_serialised\` AND \`parent_index_per_child\` to \`_enrich_document\`.
4. Drop the post-call \`insert_parent_chunks\` — that's now done inside \`_enrich_document\` (line 401 of enrichment_tasks.py), and that's the ONLY way it can thread the generated row ids into Qdrant.

## Tests

New regression guard: \`test_rebuild_kb_threads_parents_into_enrich_document\` asserts both kwargs are passed. Locks the contract so the bug cannot return silently.

\`\`\`
6/6 tests in tests/test_rebuild_tasks.py green.
\`\`\`

Ruff check + format clean.

## Operational follow-up after merge + deploy

\`\`\`bash
docker exec klai-core-knowledge-ingest-1 python -c \
  "import asyncio; from knowledge_ingest.rebuild_tasks \
   import rebuild_kb_inline; \
   asyncio.run(rebuild_kb_inline('368884765035593759','support'))"
\`\`\`

The 515 Voys-support artifacts will then have proper \`parent_chunk_id\` linkage in Qdrant and the eval matrix can measure parent_child_v1 against baseline.

## Rollback
Single revert. The \`_enrich_document\` API change is backward-compatible (kwargs are optional with None default).