### PR TITLE
fix(rag-eval): use canonical RAGAS embedding_factory + polish

### DIFF
--- a/deploy/litellm/tests/test_klai_knowledge_hook.py
+++ b/deploy/litellm/tests/test_klai_knowledge_hook.py
@@ -948,17 +948,21 @@ class TestKlaiKnowledgeHookKB010:
 
 class TestTokenRouterKB010:
     @pytest.mark.asyncio
-    async def test_token_router_skips_downgrade_when_kb_injected(self, monkeypatch):
-        """AC-010-17: model stays klai-primary when _klai_kb_meta present.
+    async def test_kb_meta_skips_safety_net_downgrade(self, monkeypatch):
+        """AC-010-17: kb-meta bypasses the *safety-net* downgrade only.
 
-        Specifically guards the *safety-net* downgrade at the bottom of the
-        router (long total context → klai-fast). The long-user-message
-        downgrade higher up the chain still fires regardless of KB context
-        — that's by design: a long single user message means an analytical
-        request, not a KB lookup. So we mock the per-call token_counter to
-        return a number BELOW the per-message threshold but ABOVE the total
-        threshold, exercising only the safety-net path that KB context is
-        meant to bypass.
+        Naming history: the original test was
+        ``test_token_router_skips_downgrade_when_kb_injected`` — the name
+        implied "any" downgrade, but the router has multiple downgrade
+        branches and kb-meta only bypasses the safety-net (large total
+        context → klai-fast). The long-user-message branch (analytical
+        request → klai-large) fires regardless of KB context — that's by
+        design.
+
+        This test mocks the per-call token_counter to return a number
+        BELOW the per-message threshold but ABOVE the total threshold,
+        exercising only the safety-net path that KB context is meant to
+        bypass.
         """
         litellm_mod = sys.modules["litellm"]
 

--- a/klai-knowledge-ingest/knowledge_ingest/eval/judge_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/eval/judge_client.py
@@ -85,53 +85,36 @@ def _build_ragas_llm(model: str | None = None):
     )
 
 
-class _LiteLLMRagasEmbeddings:
-    """RAGAS 0.4.3 BaseRagasEmbedding adapter pointed at klai-bge-m3.
-
-    Implements the modern interface (``aembed_text``, ``aembed_texts``,
-    ``embed_text``, ``embed_texts``) that ``ragas.metrics.collections``
-    metrics consume. Backed by sync + async OpenAI clients against the
-    LiteLLM proxy; the proxy aliases ``klai-bge-m3`` to the BGE-M3
-    deployment on TEI/gpu-01.
-    """
-
-    def __init__(self, base_url: str, api_key: str, model: str) -> None:
-        from openai import AsyncOpenAI, OpenAI
-
-        # Sync + async OpenAI clients sharing the LiteLLM proxy. RAGAS calls
-        # both depending on the metric (AnswerRelevancy uses the async path).
-        self._sync = OpenAI(base_url=base_url, api_key=api_key)
-        self._async = AsyncOpenAI(base_url=base_url, api_key=api_key)
-        self._model = model
-
-    def embed_text(self, text: str, **kwargs: Any) -> list[float]:
-        resp = self._sync.embeddings.create(input=text, model=self._model)
-        return resp.data[0].embedding
-
-    def embed_texts(self, texts: list[str], **kwargs: Any) -> list[list[float]]:
-        resp = self._sync.embeddings.create(input=texts, model=self._model)
-        return [d.embedding for d in resp.data]
-
-    async def aembed_text(self, text: str, **kwargs: Any) -> list[float]:
-        resp = await self._async.embeddings.create(input=text, model=self._model)
-        return resp.data[0].embedding
-
-    async def aembed_texts(self, texts: list[str], **kwargs: Any) -> list[list[float]]:
-        resp = await self._async.embeddings.create(input=texts, model=self._model)
-        return [d.embedding for d in resp.data]
-
-
-def _build_ragas_embeddings() -> _LiteLLMRagasEmbeddings:
+def _build_ragas_embeddings():
     """Build the RAGAS embeddings adapter pointed at klai-bge-m3.
+
+    Uses RAGAS' canonical ``embedding_factory(provider="openai", ...,
+    interface="modern")`` which returns the
+    ``ragas.embeddings.openai_provider.OpenAIEmbeddings`` instance that
+    ``ragas.metrics.collections`` validates against. A custom class that
+    only ducks the method shape is rejected with::
+
+        Collections metrics only support modern embeddings.
+        Found: <CustomClass>. Use: embedding_factory('openai', ...,
+        interface='modern')
 
     klai-bge-m3 is the LiteLLM alias for BGE-M3 on TEI/gpu-01. Used by
     AnswerRelevancy to compare imaginary-question vectors with the user's
-    actual question.
+    actual question. The OpenAI client is pointed at the LiteLLM proxy so
+    every embedding call routes through klai-bge-m3.
     """
-    return _LiteLLMRagasEmbeddings(
+    from openai import AsyncOpenAI
+    from ragas.embeddings.base import embedding_factory
+
+    client = AsyncOpenAI(
         base_url=f"{settings.litellm_url}/v1",
         api_key=settings.litellm_api_key or "no-key",
+    )
+    return embedding_factory(
+        provider="openai",
         model=settings.rag_eval_embeddings_model,
+        client=client,
+        interface="modern",
     )
 
 

--- a/klai-knowledge-ingest/knowledge_ingest/rebuild_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/rebuild_tasks.py
@@ -34,22 +34,22 @@ Queueing lock
 rebuild tasks for the same KB are blocked (``AlreadyEnqueued`` raised at
 defer time — caller should surface this as a 409-equivalent).
 
-Source text (v1 scope)
-----------------------
+Source text
+-----------
 Reads document text from ``knowledge.artifacts.extra->>'document_text'``.
-Artifacts without this field are skipped and counted in ``artifacts_skipped``
-with a ``rebuild_skip_no_text`` log event.
+PR #347 (SPEC-RAG-CONTEXTUAL-001) made the ingest route persist
+``document_text`` on ``extra`` for every fresh ingest, so re-ingests
+after that change rebuild without any reconstruction.
 
-OPEN QUESTION: ``document_text`` is not currently stored on
-``knowledge.artifacts.extra`` by the default ingest pipeline. Most existing
-artifacts will have ``document_text`` absent and will be skipped. A follow-up
-SPEC should either:
-  a) store ``document_text`` in ``extra`` during initial ingest, or
-  b) provide a per-connector re-fetch adapter (more complex, out of v1 scope).
-Until that lands, this task is primarily useful for artifacts where the
-connector explicitly wrote ``document_text`` into extra (e.g. KB connector
-direct uploads, some Notion pages where content was persisted for future
-reprocessing).
+Artifacts ingested before PR #347 will not have ``document_text`` on
+``extra``. For those, ``_reconstruct_document_text`` rebuilds the body
+by concatenating the existing Qdrant chunks for the artifact's path in
+chunk_index order. The reconstruction is lossy — frontmatter is dropped
+and chunk overlap leaves duplication on boundaries — but it is enough
+material to feed the new chunker + summary generator. Artifacts where
+neither path produces text (no extra.document_text AND no Qdrant chunks)
+are skipped with a ``rebuild_skip_no_text`` log event and counted in
+``artifacts_skipped``.
 """
 
 from __future__ import annotations

--- a/klai-knowledge-ingest/tests/eval/test_judge_client.py
+++ b/klai-knowledge-ingest/tests/eval/test_judge_client.py
@@ -411,6 +411,46 @@ async def test_metrics_run_in_parallel(monkeypatch, _patch_module_deps) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Embeddings adapter regression guard
+# ---------------------------------------------------------------------------
+
+
+def test_build_ragas_embeddings_returns_canonical_modern_provider() -> None:
+    """Regression: ``ragas.metrics.collections`` rejects custom embedding
+    classes with::
+
+        Collections metrics only support modern embeddings.
+        Found: <CustomClass>. Use: embedding_factory('openai', ...,
+        interface='modern')
+
+    PR C originally shipped a custom ``_LiteLLMRagasEmbeddings`` adapter
+    that satisfied the BaseRagasEmbedding *method* shape (aembed_text /
+    aembed_texts / embed_text / embed_texts) but failed the RAGAS *type*
+    check, producing all-None metrics on every eval row. The fix is to
+    use ``embedding_factory(provider='openai', ..., interface='modern')``
+    which returns the canonical
+    ``ragas.embeddings.openai_provider.OpenAIEmbeddings``. This test
+    locks the contract so a future refactor to a custom class will
+    fail loud instead of silently zeroing out the eval matrix.
+    """
+    from knowledge_ingest.eval.judge_client import _build_ragas_embeddings
+
+    settings = _make_settings()
+
+    with patch("knowledge_ingest.eval.judge_client.settings", settings):
+        emb = _build_ragas_embeddings()
+
+    cls = type(emb)
+    # Canonical RAGAS modern provider — anything outside this namespace
+    # means we drifted back to a custom class.
+    assert cls.__module__.startswith("ragas.embeddings."), (
+        f"Expected RAGAS-canonical embeddings, got {cls.__module__}.{cls.__name__}"
+    )
+    # The factory returns OpenAIEmbeddings for provider='openai'.
+    assert cls.__name__ == "OpenAIEmbeddings", f"Expected OpenAIEmbeddings, got {cls.__name__}"
+
+
+# ---------------------------------------------------------------------------
 # AsyncMock import sanity.
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Why

The custom \`_LiteLLMRagasEmbeddings\` adapter shipped in #350 satisfied the BaseRagasEmbedding *method* shape but failed the \`ragas.metrics.collections\` *type* check at runtime:

\`\`\`
Collections metrics only support modern embeddings.
Found: _LiteLLMRagasEmbeddings.
Use: embedding_factory('openai', model='text-embedding-ada-002',
client=openai_client, interface='modern')
\`\`\`

The PR C unit tests passed because they mocked the metric classes themselves, short-circuiting the validation. In production, every eval row ended up with all four metrics = None.

**Evidence (post-PR-A/B/C/D/E run on Voys-support, variant=post_pr_abcde_v1):** 30 rows written, retrieval returned chunks_len=8 per row, generate_answer returned ~1682-char answers, but \`context_precision\` / \`context_recall\` / \`faithfulness\` / \`answer_relevance\` were all NULL. The whole eval matrix was unreadable.

## Fix

Replace the custom class with the canonical RAGAS factory call:

\`\`\`python
embedding_factory(
    provider="openai",
    model=settings.rag_eval_embeddings_model,
    client=AsyncOpenAI(base_url=f"{settings.litellm_url}/v1", api_key=...),
    interface="modern",
)
\`\`\`

Returns \`ragas.embeddings.openai_provider.OpenAIEmbeddings\`, which is exactly the type \`ragas.metrics.collections.AnswerRelevancy\` validates against. Pointed at the LiteLLM proxy with \`model=klai-bge-m3\` so embedding calls still route through BGE-M3 on TEI/gpu-01.

## Regression guard

\`test_build_ragas_embeddings_returns_canonical_modern_provider\` calls the REAL \`_build_ragas_embeddings\` (no mocks) and asserts:
- type module starts with \`ragas.embeddings.\`
- type name is \`OpenAIEmbeddings\`

A future refactor back to a custom class fails this test loud instead of silently zeroing the eval matrix.

## Polish bundled

| Item | Reason |
|---|---|
| \`rebuild_tasks.py\` docstring rewrite | The "OPEN QUESTION: document_text not stored on extra" block is achterhaald — PR #347 (CONTEXTUAL-001) made ingest persist it; rebuild now reconstructs from Qdrant for legacy artifacts only. New docstring reflects current reality. |
| Renamed \`test_token_router_skips_downgrade_when_kb_injected\` → \`test_kb_meta_skips_safety_net_downgrade\` | The old name implied "any" downgrade, but the router has multiple downgrade branches and kb-meta only bypasses the safety-net (long total context → klai-fast). The long-user-message branch fires regardless of KB context. New name reflects what the test actually proves; docstring records the rename. |

## Tests

- ✅ 13/13 \`tests/eval/test_judge_client.py\` green (incl. regression guard against real RAGAS install — runs in 12s)
- ✅ 6/6 \`tests/test_rebuild_tasks.py\` green (PR E parent_chunk_id threading test still passes after docstring rewrite)
- ✅ 1/1 token-router test green under new name

Ruff check + format clean across all touched files.

## Operational follow-up after merge + deploy

\`\`\`bash
ssh core-01 "docker exec klai-core-knowledge-ingest-1 \
  python -m knowledge_ingest.eval --suite chat --variant post_pr_abcdef_v1"
\`\`\`

Should now produce 30 rows with all 4 metric columns populated. Compare against \`baseline-v4\` (precision 0.231, recall 0.253, faithfulness NaN, answer_relevance 0.706) for the post-stack delta.

## Rollback
Single revert. The custom class is fully replaced; no compat shim remaining.