### PR TITLE
fix(rag-eval): raise Faithfulness max_tokens to 8192

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/eval/judge_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/eval/judge_client.py
@@ -70,18 +70,39 @@ def _make_async_openai_client():
     )
 
 
-def _build_ragas_llm(model: str | None = None):
+# Faithfulness's NLI verdicts prompt produces a multi-statement JSON
+# (one verdict object per atomic statement). RAGAS' default cap is
+# 1024 tokens — too small once the answer has > 5 statements, which
+# yields a truncated completion and "The output is incomplete due to
+# a max_tokens length limit." parse failure. 8192 covers the longest
+# Voys answers comfortably and is well within klai-medium's output
+# budget. Light metrics (precision/recall, answer_relevancy) emit
+# small JSON; the default cap is fine for them.
+_FAITHFULNESS_MAX_TOKENS = 8192
+
+
+def _build_ragas_llm(
+    model: str | None = None,
+    *,
+    max_tokens: int | None = None,
+):
     """Build a RAGAS LLM wrapper pointed at the LiteLLM proxy.
 
     Falls back to ``settings.rag_eval_judge_model`` when ``model`` is None,
     keeping the original generate_answer / light-metric path unchanged.
-    Faithfulness gets the heavier Mistral Medium 3.5 via klai-medium.
+    Faithfulness gets the heavier Mistral Medium 3.5 via klai-medium AND
+    a higher ``max_tokens`` so the multi-statement NLI verdicts prompt
+    isn't truncated at 1024 tokens (RAGAS' default).
     """
     from ragas.llms import llm_factory
 
+    extra: dict[str, int] = {}
+    if max_tokens is not None:
+        extra["max_tokens"] = max_tokens
     return llm_factory(
         model or settings.rag_eval_judge_model,
         client=_make_async_openai_client(),
+        **extra,
     )
 
 
@@ -256,7 +277,10 @@ async def evaluate_query(
 
         # Per-metric model assignment (see module docstring).
         light_llm = _build_ragas_llm()
-        heavy_llm = _build_ragas_llm(model=settings.rag_eval_faithfulness_model)
+        heavy_llm = _build_ragas_llm(
+            model=settings.rag_eval_faithfulness_model,
+            max_tokens=_FAITHFULNESS_MAX_TOKENS,
+        )
         embeddings = _build_ragas_embeddings()
 
         ctx_precision = ContextPrecision(llm=light_llm)

--- a/klai-knowledge-ingest/tests/eval/test_judge_client.py
+++ b/klai-knowledge-ingest/tests/eval/test_judge_client.py
@@ -451,6 +451,54 @@ def test_build_ragas_embeddings_returns_canonical_modern_provider() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Faithfulness max_tokens regression guard
+# ---------------------------------------------------------------------------
+
+
+def test_build_ragas_llm_threads_max_tokens_kwarg() -> None:
+    """Regression: RAGAS' default max_tokens is 1024 — too small for the
+    Faithfulness NLI verdicts prompt (multi-statement JSON), producing::
+
+        The output is incomplete due to a max_tokens length limit.
+
+    PR G adds an opt-in ``max_tokens`` kwarg on ``_build_ragas_llm`` and
+    threads ``_FAITHFULNESS_MAX_TOKENS`` (8192) into the heavy_llm path.
+    This test locks both contracts:
+      1. The kwarg, when supplied, lands in the LLM's model_args dict.
+      2. The light_llm path (no kwarg) keeps RAGAS' default — we don't
+         want to inflate token usage for context_precision/recall/answer_rel
+         where the JSON output is small.
+    """
+    from knowledge_ingest.eval.judge_client import (
+        _FAITHFULNESS_MAX_TOKENS,
+        _build_ragas_llm,
+    )
+
+    settings = _make_settings()
+
+    with patch("knowledge_ingest.eval.judge_client.settings", settings):
+        heavy = _build_ragas_llm(model="klai-medium", max_tokens=_FAITHFULNESS_MAX_TOKENS)
+        light = _build_ragas_llm()
+
+    # Heavy LLM carries the explicit max_tokens override.
+    assert heavy.model_args.get("max_tokens") == _FAITHFULNESS_MAX_TOKENS, (
+        f"heavy_llm max_tokens should be {_FAITHFULNESS_MAX_TOKENS}, "
+        f"got {heavy.model_args.get('max_tokens')}"
+    )
+    # 8192 is well above RAGAS' default of 1024 — guard against an
+    # accidental down-rev to a value < 4096 that would re-trigger
+    # the truncation regression on multi-statement Faithfulness prompts.
+    assert _FAITHFULNESS_MAX_TOKENS >= 4096, (
+        "Faithfulness max_tokens must stay >= 4096 to fit the NLI verdicts JSON"
+    )
+
+    # Light LLM keeps RAGAS' default (no override).
+    assert light.model_args.get("max_tokens") == 1024, (
+        "Light LLM should keep RAGAS default max_tokens=1024 — small JSON output"
+    )
+
+
+# ---------------------------------------------------------------------------
 # AsyncMock import sanity.
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
RAGAS' InstructorBaseRagasLLM defaults to max_tokens=1024. Faithfulness NLI verdicts prompt emits multi-statement JSON — at 1024 tokens any 6+ statement answer truncates mid-JSON producing 'The output is incomplete due to a max_tokens length limit'. Hook stores faithfulness=None silently. On post_pr_abcdef_v1 Voys run 5 of 8 queries hit this. Fix adds max_tokens kwarg to _build_ragas_llm, threads _FAITHFULNESS_MAX_TOKENS=8192 only into the heavy_llm Faithfulness path, keeps light_llm at RAGAS' default 1024. Regression test asserts heavy_llm.model_args['max_tokens']==8192 and light_llm keeps 1024. 14/14 tests green.