### PR TITLE
hotfix(infra): BFF_SESSION_KEY falls back to SSO_COOKIE_KEY at compose level

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -430,7 +430,15 @@ services:
       ZITADEL_IDP_MICROSOFT_ID: ${ZITADEL_IDP_MICROSOFT_ID}
       # ─── Auth — session / BFF (SPEC-AUTH-008) ───────────────────
       SSO_COOKIE_KEY: ${PORTAL_API_SSO_COOKIE_KEY}
-      BFF_SESSION_KEY: ${PORTAL_API_BFF_SESSION_KEY:-}
+      # SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-10 removed the silent
+      # `bff_session_key or sso_cookie_key` fallback in code AND added a
+      # fail-closed startup validator. Until BFF_SESSION_KEY is rotated to
+      # its own value in SOPS, fall back to SSO_COOKIE_KEY's value here so
+      # the validator passes AND already-encrypted Redis sessions remain
+      # decryptable (the Fernet key must match what the cookie was minted
+      # with). This is the docker-compose equivalent of the in-code
+      # fallback the validator made explicit at startup-time.
+      BFF_SESSION_KEY: ${PORTAL_API_BFF_SESSION_KEY:-${PORTAL_API_SSO_COOKIE_KEY}}
       # ─── Internal service-to-service secrets ────────────────────
       INTERNAL_SECRET: ${PORTAL_API_INTERNAL_SECRET}
       KLAI_CONNECTOR_SECRET: ${PORTAL_API_KLAI_CONNECTOR_SECRET}


### PR DESCRIPTION
Production hotfix — portal-api crash-loop after #323.

Root cause: env-file-migration-reverse-check pitfall (in reverse). The validator-bearing PR removed the in-code `bff_session_key or sso_cookie_key` fallback AND added a fail-closed validator. Compose still passes `${PORTAL_API_BFF_SESSION_KEY:-}` (empty default) because SOPS doesn't carry a dedicated BFF_SESSION_KEY entry yet → empty string → validator rejects → crash-loop.

Fix: chain the compose default to `${PORTAL_API_SSO_COOKIE_KEY}` so the validator passes with the SAME Fernet value the in-code fallback used pre-#323. Existing Redis sessions remain decryptable.

Once SOPS adds a dedicated `PORTAL_API_BFF_SESSION_KEY`, the explicit value takes over via `:-` default semantics — no second compose change needed.