### PR TITLE
cleanup(infra): remove BFF→SSO compose fallback now that SOPS has its own key

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -430,15 +430,11 @@ services:
       ZITADEL_IDP_MICROSOFT_ID: ${ZITADEL_IDP_MICROSOFT_ID}
       # ─── Auth — session / BFF (SPEC-AUTH-008) ───────────────────
       SSO_COOKIE_KEY: ${PORTAL_API_SSO_COOKIE_KEY}
-      # SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-10 removed the silent
-      # `bff_session_key or sso_cookie_key` fallback in code AND added a
-      # fail-closed startup validator. Until BFF_SESSION_KEY is rotated to
-      # its own value in SOPS, fall back to SSO_COOKIE_KEY's value here so
-      # the validator passes AND already-encrypted Redis sessions remain
-      # decryptable (the Fernet key must match what the cookie was minted
-      # with). This is the docker-compose equivalent of the in-code
-      # fallback the validator made explicit at startup-time.
-      BFF_SESSION_KEY: ${PORTAL_API_BFF_SESSION_KEY:-${PORTAL_API_SSO_COOKIE_KEY}}
+      # SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-10: BFF_SESSION_KEY is a
+      # required env var, validated fail-closed at portal-api startup.
+      # Empty default here means an absent SOPS entry crashes the boot
+      # — that is the contract; no silent fallback to SSO_COOKIE_KEY.
+      BFF_SESSION_KEY: ${PORTAL_API_BFF_SESSION_KEY:-}
       # ─── Internal service-to-service secrets ────────────────────
       INTERNAL_SECRET: ${PORTAL_API_INTERNAL_SECRET}
       KLAI_CONNECTOR_SECRET: ${PORTAL_API_KLAI_CONNECTOR_SECRET}

--- a/klai-portal/backend/app/core/config.py
+++ b/klai-portal/backend/app/core/config.py
@@ -82,7 +82,10 @@ class Settings(BaseSettings):
 
     # BFF — Backend-for-Frontend session auth (SPEC-AUTH-008)
     # Fernet key for encrypting BFF session records at rest in Redis.
-    # Falls back to sso_cookie_key when unset — single key during the rollout.
+    # SPEC-SEC-VALIDATOR-COVERAGE-001 REQ-10 removed the historical
+    # ``bff_session_key or sso_cookie_key`` fallback. The key is now a
+    # required, fail-closed setting; the validator at the bottom of this
+    # class refuses to start the app on an empty value.
     bff_session_key: str = ""  # PORTAL_API_BFF_SESSION_KEY
     bff_session_ttl_seconds: int = 30 * 24 * 3600  # 30 days, matches Zitadel refresh-token lifetime
     bff_access_token_skew_seconds: int = 60  # refresh this many seconds before expiry


### PR DESCRIPTION
Follow-up to #360 + klai-infra#4. The compose fallback that chained `PORTAL_API_BFF_SESSION_KEY` to `PORTAL_API_SSO_COOKIE_KEY` was a noodklep until SOPS gained a dedicated entry. That entry is now live (klai-infra PR #4, commit 5bc9b95c, verified via `docker exec klai-core-portal-api-1 printenv BFF_SESSION_KEY` — distinct Fernet value, not the SSO key). The fallback is dead code AND a foot-gun for future BFF rotations.

Also: stale comment in `config.py` line 85 ("Falls back to sso_cookie_key when unset") was true pre-#323, false since. Now points at REQ-10's validator as the single source of truth.

Verified: 41 tests pass (test_config_fail_closed + test_bff_session).