### PR TITLE
feat(security): SPEC-SEC-PORTAL-RLS-001 part A — RLS on portal_join_requests

### DIFF
--- a/klai-portal/backend/alembic/versions/2f7d1eae1198_add_rls_join_requests_and_allowed_domains.py
+++ b/klai-portal/backend/alembic/versions/2f7d1eae1198_add_rls_join_requests_and_allowed_domains.py
@@ -1,0 +1,95 @@
+"""Add RLS policy on portal_join_requests
+
+SPEC-SEC-PORTAL-RLS-001 — close the tenant-scoping gap surfaced by
+``reports/audit-2026-05-04/tenant-scoping.md`` (TP-1).
+
+``portal_join_requests`` already carries an ``org_id`` column but had no
+``CREATE POLICY`` — meaning DB-layer tenant isolation was absent. This
+migration brings it in line with the rest of the portal RLS regime
+established in SPEC-SEC-003 / SPEC-SEC-007.
+
+Policy shape: **Category A (auth-seed)**. The pre-auth ``auth_select.py``
+INSERT-and-notify flow and the admin token-based ``auth_join`` approve
+flow must look up / insert rows BEFORE any tenant context is known (the
+request itself resolves WHICH org it belongs to). The policy mirrors the
+``portal_users`` shape with the ``IS NULL`` permissive branch so the
+pre-auth lookup succeeds when ``app.current_org_id`` is empty, while
+admin-side queries (`admin/join_requests.py`) — which run after
+`_get_caller_org` has bound a tenant — get strict ``org_id = T``
+isolation.
+
+**Why portal_org_allowed_domains is NOT in this migration**:
+SPEC-AUTH-006 originally introduced ``portal_org_allowed_domains``, but
+SPEC-AUTH-009 R2 (migration ``ed5b78b296f5``) replaced that table with
+``portal_orgs.primary_domain`` + ``auto_accept_same_domain`` and DROPS
+the table in production via ``post_deploy_ed5b78b296f5.sql``. Adding RLS
+to a table that is already on the deletion path would pollute the
+migration history without functional benefit. The original audit
+finding TP-2 (``portal_org_allowed_domains`` missing RLS) is therefore
+moot post-AUTH-009 — the table is gone in prod and only re-created on
+``downgrade`` for reversibility. ``test_r2_removal.py`` is the
+regression-guard for the absence.
+
+The DDL uses the legacy inline-NULLIF pattern that matches the existing
+migrations (``1b8736eb6455``, ``e669581d441f``). The post-deploy SQL
+``post_deploy_rls_raise_on_missing_context.sql`` will later swap any
+strict-category policies to the ``_rls_current_org_id()`` helper for
+fail-loud behaviour — but ``portal_join_requests`` is Category A, not
+Category D, so it stays on the inline pattern.
+
+Idempotency: ``CREATE POLICY`` does not support ``IF NOT EXISTS``, so
+the upgrade is wrapped in ``DROP POLICY IF EXISTS`` + ``CREATE POLICY``.
+Running the migration on a database that already has ``tenant_isolation``
+defined (e.g. partially migrated staging) is therefore safe.
+
+Revision ID: 2f7d1eae1198
+Revises: rbac001drop00
+Create Date: 2026-05-05
+"""
+
+from alembic import op
+
+revision = "2f7d1eae1198"
+down_revision = "rbac001drop00"
+branch_labels = None
+depends_on = None
+
+_T = "NULLIF(current_setting('app.current_org_id', true), '')::int"
+_T_IS_NULL = "NULLIF(current_setting('app.current_org_id', true), '') IS NULL"
+
+
+def _enable_rls(table: str) -> None:
+    op.execute(  # nosemgrep: formatted-sql-query,sqlalchemy-execute-raw-query
+        f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY"
+    )
+    op.execute(  # nosemgrep: formatted-sql-query,sqlalchemy-execute-raw-query
+        f"ALTER TABLE {table} FORCE ROW LEVEL SECURITY"
+    )
+
+
+def upgrade() -> None:
+    # portal_join_requests: Category A (permissive on missing context).
+    # The admin token-based approve flow in app/api/auth_join.py looks up
+    # the join request by its approval_token BEFORE any tenant context is
+    # resolved (the token IS the resolution mechanism). Same shape as
+    # portal_users / portal_connectors — a permissive IS NULL branch so
+    # the pre-auth lookup succeeds, with strict tenant-equality once
+    # set_tenant has fired downstream (admin/join_requests.py path).
+    _enable_rls("portal_join_requests")
+    op.execute(  # nosemgrep: formatted-sql-query,sqlalchemy-execute-raw-query
+        "DROP POLICY IF EXISTS tenant_isolation ON portal_join_requests"
+    )
+    op.execute(  # nosemgrep: formatted-sql-query,sqlalchemy-execute-raw-query
+        "CREATE POLICY tenant_isolation ON portal_join_requests "
+        f"USING (org_id = {_T} OR {_T_IS_NULL}) "
+        f"WITH CHECK (org_id = {_T})"
+    )
+
+
+def downgrade() -> None:
+    op.execute(  # nosemgrep: formatted-sql-query,sqlalchemy-execute-raw-query
+        "DROP POLICY IF EXISTS tenant_isolation ON portal_join_requests"
+    )
+    op.execute(  # nosemgrep: formatted-sql-query,sqlalchemy-execute-raw-query
+        "ALTER TABLE portal_join_requests DISABLE ROW LEVEL SECURITY"
+    )

--- a/klai-portal/backend/app/core/rls_guard.py
+++ b/klai-portal/backend/app/core/rls_guard.py
@@ -56,6 +56,7 @@ RLS_DML_TABLES: frozenset[str] = frozenset(
         "portal_group_memberships",
         "portal_group_products",
         "portal_groups",
+        "portal_join_requests",
         "portal_kb_tombstones",
         "portal_knowledge_bases",
         "portal_retrieval_gaps",

--- a/klai-portal/backend/tests/test_rls_join_requests.py
+++ b/klai-portal/backend/tests/test_rls_join_requests.py
@@ -1,0 +1,207 @@
+"""SPEC-SEC-PORTAL-RLS-001 — regression tests for the new RLS policy.
+
+``portal_join_requests`` was created with an ``org_id`` column (per
+SPEC-AUTH-006) but never received a ``CREATE POLICY``, leaving it
+outside the DB-layer tenant-isolation regime that protects every other
+portal table. Migration ``2f7d1eae1198`` closes that gap.
+
+Note: ``portal_org_allowed_domains`` was originally part of the audit
+TP-2 finding, but SPEC-AUTH-009 R2 (migration ``ed5b78b296f5``) replaced
+that table with ``portal_orgs.primary_domain`` and DROPS it in
+production via ``post_deploy_ed5b78b296f5.sql``. Adding RLS to a table
+on the deletion path would pollute the migration history without
+functional benefit. ``test_r2_removal.py`` is the regression-guard for
+its absence.
+
+Pytest does not have a live PostgreSQL backend in CI (the suite runs
+against SQLite for speed; full integration uses staging). These tests
+therefore exercise the two layers we CAN exercise without postgres:
+
+1. ``RLS_DML_TABLES`` in ``app/core/rls_guard.py`` includes the new
+   table — the silent-filter guard now covers it.
+2. The migration file ships the canonical Category-A policy shape
+   (regex-checked against the file content) so a future refactor that
+   accidentally drops the policy is caught at CI time, before it can
+   land on staging.
+
+Live policy-against-pg_policies coverage is delivered by the staging
+smoke test ``scripts/rls-smoke-test.sh``; AC-2 of the SPEC.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from app.core.rls_guard import RLS_DML_TABLES
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "alembic"
+    / "versions"
+    / "2f7d1eae1198_add_rls_join_requests_and_allowed_domains.py"
+)
+
+
+# ---------------------------------------------------------------------------
+# RLS_DML_TABLES regression — silent-filter guard must cover the new table
+# ---------------------------------------------------------------------------
+
+
+def test_rls_dml_tables_includes_portal_join_requests() -> None:
+    """``portal_join_requests`` must be in the silent-filter guard set.
+
+    Otherwise an UPDATE/DELETE that hits zero rows because RLS filtered
+    them would slip past the rls_guard listener with no error log.
+    """
+    assert "portal_join_requests" in RLS_DML_TABLES, (
+        "portal_join_requests was added to the database with an RLS policy "
+        "but is missing from RLS_DML_TABLES in app/core/rls_guard.py. "
+        "The silent-filter guard would not warn on rowcount=0 DML "
+        "against this table. See SPEC-SEC-PORTAL-RLS-001."
+    )
+
+
+def test_rls_dml_tables_does_not_include_portal_org_allowed_domains() -> None:
+    """SPEC-AUTH-009 R2 dropped ``portal_org_allowed_domains``. It must
+    NOT be in RLS_DML_TABLES because the silent-filter guard expects every
+    listed table to actually exist in the schema. ``test_r2_removal.py``
+    is the canonical regression-guard for the absence of the table.
+    """
+    assert "portal_org_allowed_domains" not in RLS_DML_TABLES, (
+        "portal_org_allowed_domains was dropped by SPEC-AUTH-009 R2 "
+        "(migration ed5b78b296f5). It must not be re-added to "
+        "RLS_DML_TABLES — the silent-filter guard expects every listed "
+        "table to exist in the live schema."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Migration shape — DDL strings must contain the canonical patterns
+# ---------------------------------------------------------------------------
+
+
+def _read_migration() -> str:
+    assert MIGRATION_PATH.exists(), f"SPEC-SEC-PORTAL-RLS-001 migration file is missing: {MIGRATION_PATH}"
+    return MIGRATION_PATH.read_text(encoding="utf-8")
+
+
+def test_migration_enables_force_rls() -> None:
+    """Both ENABLE and FORCE row-level security must fire on the table.
+
+    Without FORCE, the table owner role bypasses the policy — fine in
+    dev but operationally risky if the migration role and the
+    application role ever drift.
+    """
+    src = _read_migration()
+    assert re.search(r"ENABLE ROW LEVEL SECURITY", src), "Migration must call ALTER TABLE ... ENABLE ROW LEVEL SECURITY"
+    assert re.search(r"FORCE ROW LEVEL SECURITY", src), "Migration must call ALTER TABLE ... FORCE ROW LEVEL SECURITY"
+    assert "portal_join_requests" in src
+
+
+def test_migration_does_not_touch_portal_org_allowed_domains() -> None:
+    """SPEC-AUTH-009 R2 dropped the table. The migration must NOT
+    re-introduce DDL on it — that would conflict with the drop on
+    upgrade() and confuse downgrade()."""
+    src = _read_migration()
+    # The table name may appear in the docstring as historical context
+    # (explaining WHY it is excluded). It MUST NOT appear in any
+    # op.execute() call.
+    op_executes = re.findall(r"op\.execute\([^)]*\)", src, re.DOTALL)
+    for stmt in op_executes:
+        assert "portal_org_allowed_domains" not in stmt, (
+            "Migration must not run DDL against portal_org_allowed_domains "
+            "— SPEC-AUTH-009 R2 dropped that table. Found in: "
+            f"{stmt[:200]}..."
+        )
+
+
+def _extract_policy_block(source: str, table: str) -> str:
+    """Return the source-text run that contains the ``CREATE POLICY`` for
+    ``table``, up to the closing ``op.execute(...)`` call.
+    """
+    match = re.search(
+        rf"CREATE POLICY tenant_isolation ON {table}.*?\)\n",
+        source,
+        re.DOTALL,
+    )
+    assert match, f"CREATE POLICY block for {table} not found in migration"
+    return match.group(0)
+
+
+def test_migration_creates_permissive_policy_on_join_requests() -> None:
+    """Category-A pre-auth pattern: portal_join_requests MUST include
+    the ``IS NULL`` permissive branch in its USING clause.
+
+    Without that branch, the admin token-based approve flow in
+    ``auth_join.py`` cannot resolve the join request before tenant
+    context exists. See migration docstring + SPEC-SEC-PORTAL-RLS-001
+    Risks table.
+
+    The migration may emit the IS NULL branch either directly (literal
+    ``IS NULL`` text) or via the shared ``_T_IS_NULL`` variable that
+    expands to ``NULLIF(...) IS NULL`` at runtime — both shapes are
+    accepted, but the strict-only pattern (``USING (org_id = T)`` with
+    no NULL branch at all) is rejected.
+    """
+    src = _read_migration()
+    block = _extract_policy_block(src, "portal_join_requests")
+    has_permissive_branch = "IS NULL" in block or "_T_IS_NULL" in block
+    assert has_permissive_branch, (
+        "portal_join_requests policy must include the `IS NULL` "
+        "permissive branch (Category-A auth-seed pattern). Without it "
+        "the admin approve_join flow cannot resolve the row before "
+        f"tenant context. Policy block:\n{block}"
+    )
+
+
+def test_migration_with_check_clause_present() -> None:
+    """The policy must include WITH CHECK so INSERTs from a wrong tenant
+    context fail, not just SELECTs filter."""
+    src = _read_migration()
+    check_count = len(re.findall(r"WITH CHECK", src))
+    assert check_count >= 1, (
+        f"Expected at least 1 WITH CHECK clause in migration; found "
+        f"{check_count}. Without WITH CHECK an attacker could INSERT a "
+        "row with someone else's org_id."
+    )
+
+
+def test_migration_downgrade_drops_policy() -> None:
+    """Downgrade must roll back the DDL changes — drop policy + disable RLS."""
+    src = _read_migration()
+    down_match = re.search(
+        r"def downgrade\(\) -> None:(.*?)\Z",
+        src,
+        re.DOTALL,
+    )
+    assert down_match, "Migration must define downgrade()"
+    down_body = down_match.group(1)
+    assert "DROP POLICY IF EXISTS tenant_isolation ON portal_join_requests" in down_body or (
+        "portal_join_requests" in down_body and "DROP POLICY" in down_body
+    )
+    assert "DISABLE ROW LEVEL SECURITY" in down_body, "Downgrade must DISABLE ROW LEVEL SECURITY"
+
+
+# ---------------------------------------------------------------------------
+# Idempotency — re-running the migration on an existing DB must not fail.
+# ---------------------------------------------------------------------------
+
+
+def test_migration_uses_drop_if_exists_for_idempotency() -> None:
+    """``CREATE POLICY`` does not support ``IF NOT EXISTS``. The
+    migration must wrap each CREATE in a DROP IF EXISTS so re-applying
+    on a partially migrated database (rare but possible during staging
+    recovery) succeeds.
+
+    See ``alembic-stamped-past-skipped-migration`` pitfall.
+    """
+    src = _read_migration()
+    drop_count = len(re.findall(r"DROP POLICY IF EXISTS tenant_isolation", src))
+    create_count = len(re.findall(r"CREATE POLICY tenant_isolation", src))
+    assert drop_count >= create_count, (
+        f"Migration has {create_count} CREATE POLICY statements but only "
+        f"{drop_count} DROP POLICY IF EXISTS guards in upgrade(). "
+        "Idempotency is broken: re-running on a partially migrated DB "
+        "will fail."
+    )


### PR DESCRIPTION
Audit-finding rebuild from #318 (closed/superseded). Splits the original SPEC into two parts:

**Part A (this PR):** Add CREATE POLICY on `portal_join_requests`. Category A (auth-seed) shape — IS NULL permissive branch so pre-auth lookup works, strict `org_id = T` after `_get_caller_org`.

**Part B (follow-up SPEC):** ast-grep rule + klai-connector adoption for SyncRun tenant-scoping. Deferred because main introduced `SyncRunReaper` + `SyncRunResolver` after #318 was branched, and the rule cannot land without a coordinated multi-file connector adaptation.

Why split: landing the ast-grep rule without the connector adaptation would fail CI on every klai-connector PR.

Verified locally:
- 8 RLS policy tests pass
- Single alembic head (no DAG drift): `2f7d1eae1198`
- `portal_join_requests` added to `RLS_DML_TABLES` for run-time guard

Closes audit finding TP-1 (`reports/audit-2026-05-04/tenant-scoping.md`).