### PR TITLE
fix(rag-eval): chunk_id key + silence test warnings + parametric parent_index test

### DIFF
--- a/deploy/litellm/tests/test_klai_knowledge_hook.py
+++ b/deploy/litellm/tests/test_klai_knowledge_hook.py
@@ -40,8 +40,29 @@ def _mock_litellm():
     sys.modules.pop("klai_knowledge", None)
 
 
-def _load_hook(monkeypatch, extra_env=None):
-    """Import and reload klai_knowledge with the given env vars."""
+
+
+def _load_hook(monkeypatch, extra_env=None, *, mock_fire_and_forget=True):
+    """Import and reload klai_knowledge with the given env vars.
+
+    By default also silences the fire-and-forget producers
+    (``_fire_gap_event`` and ``_fire_retrieval_log``). Both are
+    synchronous functions that internally build a ``_post()`` coroutine
+    and try to schedule it via
+    ``asyncio.get_running_loop().create_task(_post())``. In a test
+    context without a running loop the schedule call raises
+    ``RuntimeError``, which the function catches and silently swallows
+    — but the inner coroutine is already constructed and never awaited.
+    Python then raises ``RuntimeWarning: coroutine '_post' was never
+    awaited`` at GC, AFTER pytest's warning-capture has torn down,
+    polluting the test output via ``sys.unraisablehook``.
+
+    Per ``.claude/rules/klai/lang/testing.md`` the canonical fix is to
+    replace the producer with a sync ``MagicMock`` so no coroutine is
+    constructed in the first place. Tests that specifically exercise
+    these producers (``TestFireGapEvent``) pass
+    ``mock_fire_and_forget=False`` to skip the patch.
+    """
     env = {
         "PORTAL_INTERNAL_SECRET": "test-portal-secret",
         "RETRIEVAL_INTERNAL_SECRET": "test-retrieval-secret",
@@ -56,6 +77,9 @@ def _load_hook(monkeypatch, extra_env=None):
     sys.modules.pop("klai_knowledge", None)
     import klai_knowledge
     importlib.reload(klai_knowledge)
+    if mock_fire_and_forget:
+        monkeypatch.setattr(klai_knowledge, "_fire_gap_event", MagicMock())
+        monkeypatch.setattr(klai_knowledge, "_fire_retrieval_log", MagicMock())
     return klai_knowledge
 
 
@@ -82,11 +106,18 @@ def _make_cache(feature_enabled: bool | None = None, feature: dict | None = None
 
     if feature is None and feature_enabled is None:
         # Cache miss for KB feature — both kb_ver and kb_feature keys return
-        # None to force the portal HTTP call. Templates cache still seeded so
-        # the templates roundtrip stays out of the way of feature-flag tests.
+        # None to force the portal HTTP call. Templates + taxonomy caches are
+        # still seeded so those roundtrips stay out of the way of
+        # feature-flag tests (a test that doesn't set ``mc.get`` would
+        # otherwise trip the AsyncMock-never-awaited warning when the hook
+        # tries to fetch trees/coverage).
         async def _get(key: str) -> object:
             if key.startswith("templates:"):
                 return []
+            if key.startswith("tax_trees:"):
+                return {}
+            if key.startswith("tax_coverage:"):
+                return {}
             return None
 
         cache.async_get_cache = AsyncMock(side_effect=_get)
@@ -113,6 +144,16 @@ def _make_cache(feature_enabled: bool | None = None, feature: dict | None = None
                 return feat
             if key.startswith("templates:"):
                 return []
+            # Taxonomy lookups: pre-seed empty dicts so tests with kb_slugs
+            # filter don't need to mock ``mc.get`` for the
+            # /internal/v1/taxonomy/{trees,coverage} endpoints. Without
+            # this, a kb_slugs test triggers the multi-KB fetch path and
+            # the unconfigured AsyncMock returns a coroutine that's never
+            # awaited (RuntimeWarning at GC).
+            if key.startswith("tax_trees:"):
+                return {}
+            if key.startswith("tax_coverage:"):
+                return {}
             return None
 
         cache.async_get_cache = AsyncMock(side_effect=_get)
@@ -1086,10 +1127,14 @@ class TestFireGapEvent:
         """R2.1: _fire_gap_event schedules an async POST task."""
         import asyncio as _asyncio
 
-        mod = _load_hook(monkeypatch)
+        mod = _load_hook(monkeypatch, mock_fire_and_forget=False)
 
+        # ``create_task`` must close the coroutine it's handed — a real
+        # event loop would await it, but our MagicMock loop just stores
+        # it as call_args. Without ``.close()`` the coroutine surfaces
+        # at GC as ``RuntimeWarning: coroutine '_post' was never awaited``.
         mock_loop = MagicMock()
-        mock_loop.create_task = MagicMock()
+        mock_loop.create_task = MagicMock(side_effect=lambda coro: coro.close())
 
         with patch.object(_asyncio, "get_running_loop", return_value=mock_loop):
             mod._fire_gap_event(
@@ -1106,10 +1151,14 @@ class TestFireGapEvent:
         """R2.2: payload contains all required fields with correct types."""
         import asyncio as _asyncio
 
-        mod = _load_hook(monkeypatch)
+        mod = _load_hook(monkeypatch, mock_fire_and_forget=False)
 
+        # ``create_task`` must close the coroutine it's handed — a real
+        # event loop would await it, but our MagicMock loop just stores
+        # it as call_args. Without ``.close()`` the coroutine surfaces
+        # at GC as ``RuntimeWarning: coroutine '_post' was never awaited``.
         mock_loop = MagicMock()
-        mock_loop.create_task = MagicMock()
+        mock_loop.create_task = MagicMock(side_effect=lambda coro: coro.close())
 
         chunks = [
             {"reranker_score": 0.3, "score": 0.2, "metadata": {"kb_slug": "my-kb"}},
@@ -1131,10 +1180,14 @@ class TestFireGapEvent:
         """R2.5: hard gaps have nearest_kb_slug = None."""
         import asyncio as _asyncio
 
-        mod = _load_hook(monkeypatch)
+        mod = _load_hook(monkeypatch, mock_fire_and_forget=False)
 
+        # ``create_task`` must close the coroutine it's handed — a real
+        # event loop would await it, but our MagicMock loop just stores
+        # it as call_args. Without ``.close()`` the coroutine surfaces
+        # at GC as ``RuntimeWarning: coroutine '_post' was never awaited``.
         mock_loop = MagicMock()
-        mock_loop.create_task = MagicMock()
+        mock_loop.create_task = MagicMock(side_effect=lambda coro: coro.close())
 
         with patch.object(_asyncio, "get_running_loop", return_value=mock_loop):
             mod._fire_gap_event(
@@ -1151,7 +1204,7 @@ class TestFireGapEvent:
         """R2.3: if no event loop, skip silently without raising."""
         import asyncio as _asyncio
 
-        mod = _load_hook(monkeypatch)
+        mod = _load_hook(monkeypatch, mock_fire_and_forget=False)
 
         with patch.object(_asyncio, "get_running_loop", side_effect=RuntimeError("no event loop")):
             # Should not raise

--- a/klai-knowledge-ingest/knowledge_ingest/eval/ragas_runner.py
+++ b/klai-knowledge-ingest/knowledge_ingest/eval/ragas_runner.py
@@ -108,7 +108,12 @@ async def run_evaluation(suite: str, variant: str | None = None) -> dict:
         chunks = retrieval.chunks
         retrieval_ms = retrieval.retrieval_ms
         total_tokens = retrieval.total_tokens
-        chunk_ids = [c.get("id", "") for c in chunks if c.get("id")]
+        # Retrieval-api emits chunks keyed on ``chunk_id`` (see ChunkResult
+        # in retrieval_api/models.py). The earlier ``c.get("id")`` lookup
+        # quietly returned None on every chunk, leaving the
+        # retrieved_chunk_ids column empty on every eval row and breaking
+        # the Grafana per-chunk drill-down for any post-mortem analysis.
+        chunk_ids = [c.get("chunk_id", "") for c in chunks if c.get("chunk_id")]
 
         answer = await judge_client.generate_answer(
             query=query.query,

--- a/klai-knowledge-ingest/tests/test_rebuild_tasks.py
+++ b/klai-knowledge-ingest/tests/test_rebuild_tasks.py
@@ -159,39 +159,93 @@ async def test_rebuild_kb_iterates_artifacts(_common_patches):
 
 
 @pytest.mark.asyncio
-async def test_rebuild_kb_threads_parents_into_enrich_document(_common_patches):
+async def test_rebuild_kb_threads_parents_into_enrich_document(monkeypatch):
     """SPEC-RAG-PARENT-CHILD-001: rebuild MUST pass ``parents`` +
-    ``parent_index_per_child`` to ``_enrich_document``.
+    ``parent_index_per_child`` to ``_enrich_document``, AND the indices
+    must correctly route each child to its corresponding parent.
 
     Without these kwargs, ``_enrich_document`` upserts each child chunk to
-    Qdrant with ``parent_chunk_id=None`` and the parent expansion in
+    Qdrant with ``parent_chunk_id=None`` and parent expansion in
     retrieval-api silently degrades to chunk-text-only. A previous version
     of rebuild_tasks.py passed neither — the result on Voys-support was
-    448/448 rebuilt artifacts with zero parent linkage in Qdrant. This
-    test locks the contract so the regression cannot reappear silently.
-    """
-    from knowledge_ingest.rebuild_tasks import _rebuild_kb_core
+    448/448 rebuilt artifacts with zero parent linkage in Qdrant.
 
-    _common_patches["mock_list"].return_value = [
-        _make_artifact("art-1", "doc1.md", "Some body text"),
+    This test uses 4 child chunks fanning out across 3 parents
+    (``[0, 0, 1, 2]``) so the assertion locks BOTH:
+      1. The kwargs are passed (regression for the original bug).
+      2. The actual mapping is preserved end-to-end. Earlier the test
+         used a single chunk with ``parent_index=0`` (the dataclass
+         default), which would have passed even if the code threaded a
+         constant ``[0]`` instead of reading ``c.parent_index``.
+    """
+    chunks = [
+        _make_chunk("child-0", parent_index=0),
+        _make_chunk("child-1", parent_index=0),
+        _make_chunk("child-2", parent_index=1),
+        _make_chunk("child-3", parent_index=2),
+    ]
+    parents = [
+        _make_parent_chunk("parent-0", position=0),
+        _make_parent_chunk("parent-1", position=1),
+        _make_parent_chunk("parent-2", position=2),
     ]
 
-    await _rebuild_kb_core(org_id=_ORG, kb_slug=_KB)
+    mock_chunker = MagicMock()
+    mock_chunker.chunk_markdown_with_parents.return_value = (chunks, parents)
+    mock_chunker._approx_token_count.return_value = 50
 
-    assert _common_patches["mock_enrich"].call_count == 1
-    enrich_kwargs = _common_patches["mock_enrich"].call_args.kwargs
+    mock_pg = MagicMock()
+    mock_pg.delete_parent_chunks_for_artifact = AsyncMock(return_value=1)
+    mock_pg.insert_parent_chunks = AsyncMock(return_value=[10, 11, 12])
 
-    # parents was serialised from parent_chunks_obj — should be a list of dicts.
+    mock_enrich = AsyncMock()
+
+    with (
+        patch(
+            "knowledge_ingest.rebuild_tasks._list_active_artifacts",
+            new_callable=AsyncMock,
+        ) as mock_list,
+        patch.dict(
+            sys.modules,
+            {
+                "knowledge_ingest.enrichment_tasks": types.SimpleNamespace(
+                    _enrich_document=mock_enrich
+                ),
+                "knowledge_ingest.chunker": mock_chunker,
+                "knowledge_ingest.pg_store": mock_pg,
+            },
+        ),
+    ):
+        mock_list.return_value = [
+            _make_artifact("art-1", "doc1.md", "Some body text"),
+        ]
+
+        from knowledge_ingest.rebuild_tasks import _rebuild_kb_core
+
+        await _rebuild_kb_core(org_id=_ORG, kb_slug=_KB)
+
+    assert mock_enrich.call_count == 1
+    enrich_kwargs = mock_enrich.call_args.kwargs
+
+    # ``parents`` was serialised from parent_chunks_obj — list of dicts.
     assert "parents" in enrich_kwargs, "rebuild must pass parents= to _enrich_document"
     assert isinstance(enrich_kwargs["parents"], list)
-    assert len(enrich_kwargs["parents"]) == 1
-    assert enrich_kwargs["parents"][0]["text"] == "parent text"
+    assert len(enrich_kwargs["parents"]) == 3
+    assert [p["text"] for p in enrich_kwargs["parents"]] == [
+        "parent-0",
+        "parent-1",
+        "parent-2",
+    ]
 
-    # parent_index_per_child mirrors child_chunks order.
+    # ``parent_index_per_child`` MUST mirror child_chunks order
+    # (multiple distinct values, not just the default 0).
     assert "parent_index_per_child" in enrich_kwargs, (
         "rebuild must pass parent_index_per_child= to _enrich_document"
     )
-    assert enrich_kwargs["parent_index_per_child"] == [0]
+    assert enrich_kwargs["parent_index_per_child"] == [0, 0, 1, 2], (
+        "parent_index_per_child must preserve each child's parent_index "
+        "attribute — not a constant or default"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Three small fixes bundled per Mark's three vragen:

**1. retrieved_chunk_ids was always empty.** Retrieval-api emits chunks keyed on `chunk_id`, not `id`. Eval-runner used `c.get('id')`, returned None on every chunk, broke the per-chunk Grafana drill-down. One-line fix.

**2. Six `coroutine ... never awaited` warnings in hook tests.** Two sources, fixed both:
- `_fire_gap_event` / `_fire_retrieval_log` leaked their inner coroutine when the test had no event loop. Default `_load_hook(...)` now patches both producers with sync MagicMock; TestFireGapEvent opts out via `mock_fire_and_forget=False` and closes the coroutine via `create_task` side_effect.
- `_make_cache` pre-seeds `tax_trees:`/`tax_coverage:` so kb_slugs-filter tests don't leak via the multi-KB fetch path.

**3. parent_index test was too weak.** The original asserted `[0]` against a single chunk with the dataclass default. Strengthened to 4 children → 3 parents (`[0, 0, 1, 2]`) — would now fail if production threads a constant.

Tests: 49/49 hook (`-W error::RuntimeWarning` clean), 14/14 judge_client, 6/6 rebuild_tasks.