### PR TITLE
docs(architecture): update retrieval + ingest flow for post-RAG-stack reality

### DIFF
--- a/docs/architecture/knowledge-ingest-flow.md
+++ b/docs/architecture/knowledge-ingest-flow.md
@@ -345,15 +345,23 @@ payload, not `[]`. Retrieval-api reads list-shaped keys (`anchor_texts`, `links_
 key-absent, `None`, and non-list values all as `[]`, so the two shapes are
 interchangeable at the consumer boundary.
 
-Chunking is done by a custom `chunker.py` inside knowledge-ingest:
+Chunking is done by `chunker.chunk_markdown_with_parents` (SPEC-RAG-PARENT-CHILD-001).
+It produces TWO chunk layers per document — *children* for matching and *parents* for
+LLM context — in a single pass:
+
 1. **Heading split** — the document is first split at H1/H2/H3 headings
    (`^(#{1,3})\s+(.+)$`). Each section keeps its heading prepended so chunks are
-   self-contained.
-2. **Size split** — sections that are still larger than `chunk_size` (default 1500
-   **characters**, roughly 300–400 tokens for BGE-M3) are further split at paragraph
-   boundaries (`\n\n`) or sentence boundaries (`. `).
-3. **Overlap** — consecutive chunks share a 200-character tail/head overlap to prevent
-   answers from falling between chunks.
+   self-contained. Each section becomes one **parent chunk**.
+2. **Size split (children)** — within each parent, the text is further split at
+   paragraph (`\n\n`) or sentence (`. `) boundaries until each *child* fits in
+   `chunk_size` (default 1500 chars, roughly 300–400 tokens for BGE-M3).
+3. **Overlap** — consecutive children share a 200-character tail/head overlap so an
+   answer doesn't fall between two children.
+4. **Parent-child linkage** — every child carries `parent_index` pointing to its
+   parent in the parents list. Parents are persisted to PostgreSQL `knowledge.parent_chunks`
+   AT enrichment time (so the row IDs are then threaded into each child's Qdrant
+   payload as `parent_chunk_id`). Retrieval-api uses that linkage to expand each
+   matched child back to its parent text after reranking.
 
 The content profile defines `chunk_tokens_max` per document type. The chunker converts
 this to characters (`tokens × 4`) and uses it as `chunk_size`. Effective chunk sizes:
@@ -422,9 +430,29 @@ surrounding context from the document and generates:
 - 3–5 *hypothetical questions* the chunk would answer.
 
 The context strategy (from the profile) determines which surrounding text goes into the
-prompt: `first_n` uses the document's opening paragraphs, `rolling_window` uses nearby
-chunks, `front_matter` uses YAML metadata, and `most_recent` uses the most recent chunks
-(useful for email threads where the latest message is most relevant).
+prompt. As of SPEC-RAG-CONTEXTUAL-001 (Anthropic-pattern contextual retrieval), the
+heaviest path is the new **document_summary** strategy:
+
+- **Document summary** — generated **once per artifact** before chunk enrichment starts
+  (`contextual.generate_document_summary`, klai-fast, 1–2 Dutch/English sentences).
+  Persisted on `extra_payload["document_summary"]` so re-ingest of the same content
+  returns it from cache. The per-chunk enrichment prompt then references this short
+  summary instead of the full document body — ~8x reduction in per-chunk input tokens
+  for a 20-chunk document.
+- **Document language** — auto-detected once via `lingua-language-detector` and cached
+  on `document_language` so the prompt picks the right Dutch/English template
+  per-document (a Dutch tenant can have English vendor docs).
+
+Other context strategies still exist for non-summary content types:
+`first_n` uses the document's opening paragraphs, `rolling_window` uses nearby chunks,
+`front_matter` uses YAML metadata, and `most_recent` uses the most recent chunks (useful
+for email threads where the latest message is most relevant).
+
+The summary itself rides along on every Qdrant point — `document_summary` is a payload
+field on the chunk so retrieval-api can surface it for source-label rendering and for
+the LLM at injection time. Combined with the chunk's own `context_prefix`, the LLM gets
+a layered context: artifact-level summary + chunk-level prefix + chunk text + parent
+text (after expansion at retrieval time).
 
 If the LLM call fails, the chunk falls back to its original text — enrichment failure
 never blocks a chunk from being retrievable.
@@ -722,6 +750,58 @@ to do and returns cleanly. Verified end-to-end against Voys on 2026-04-30
 with 0 cross-store residue across all 9 affected stores (portal_connectors,
 sync_runs, artifacts, crawl_jobs, artifact_images, crawled_pages, Qdrant
 chunks, FalkorDB nodes, Garage S3 objects).
+
+---
+
+### Phase 7: Operator-triggered rebuild (SPEC-RAG-REBUILD-KB-001)
+
+When pipeline-shaping changes ship — new chunking strategy, new chunk metadata, new
+embedding pre-processing — every active artifact needs to be re-run through the
+pipeline. We do this via the operator-triggered `rebuild_kb` task instead of
+re-fetching from source connectors. Source-fetch isn't always possible (deleted Notion
+pages, expired crawl content) and would be 100x more expensive than reusing what's
+already in Qdrant.
+
+**Two source-text paths.** For each artifact, the rebuild reads document text from one
+of two places:
+1. **`extra.document_text`** — persisted at ingest time since SPEC-RAG-CONTEXTUAL-001
+   shipped. Re-ingests after that change rebuild without any reconstruction step.
+2. **Reconstruction from Qdrant** — for *legacy* artifacts ingested before the persist
+   path landed: `_reconstruct_document_text` pulls every existing Qdrant chunk for the
+   artifact's path in `chunk_index` order and concatenates the (non-enriched) text
+   values. Lossy — markdown frontmatter is dropped, chunk overlap leaves duplication —
+   but enough material to feed the new chunker + summary generator.
+
+**What rebuild does per artifact.** Inside a bounded `asyncio.Semaphore(_SEMAPHORE_LIMIT=4)`:
+1. Read `extra.document_text` or reconstruct from Qdrant.
+2. Re-chunk with `chunker.chunk_markdown_with_parents` (children + parents +
+   parent_index_per_child).
+3. Delete stale `parent_chunks` rows for the artifact.
+4. Call `_enrich_document` with `parents` + `parent_index_per_child` — *that* is what
+   threads the generated `parent_chunks.id` into each child's Qdrant payload as
+   `parent_chunk_id`. Calling `_enrich_document` without those kwargs upserts every
+   child with `parent_chunk_id=None` and parent expansion silently degrades
+   (regression that PR #357 fixed; the test
+   `test_rebuild_kb_threads_parents_into_enrich_document` locks the contract).
+5. `_enrich_document` itself runs the same enrichment + embedding + Qdrant
+   delete-then-upsert as fresh ingest.
+
+**Concurrency contract.** Procrastinate `queueing_lock=f"rebuild-kb-{org_id}-{kb_slug}"`
+prevents concurrent rebuilds for the same KB; `AlreadyEnqueued` is raised at defer time
+on duplicate. Inline runbook variant: `rebuild_kb_inline(org_id, kb_slug)` for direct
+operator invocation.
+
+**Operator runbook:**
+```bash
+docker exec klai-core-knowledge-ingest-1 python -c \
+  "import asyncio; from knowledge_ingest.rebuild_tasks import rebuild_kb_inline; \
+   print(asyncio.run(rebuild_kb_inline('<org_zitadel_id>', '<kb_slug>')))"
+```
+
+Used post-deploy whenever a SPEC changes how chunks are produced — recent example: PR
+#357 (parent_chunk_id threading) required Voys to be re-rebuilt to populate
+`parent_chunk_id` on chunks ingested before the fix landed. 515 artifacts processed,
+~5400 chunks regenerated.
 
 ---
 

--- a/docs/architecture/knowledge-retrieval-flow.md
+++ b/docs/architecture/knowledge-retrieval-flow.md
@@ -46,16 +46,31 @@ User types a message (LibreChat | Partner API consumer | chat widget on external
         │
         ├──▶ Fetch rules (strict guardrails) + templates (response scaffolds) for org/KB
         │
+        ├──▶ Multi-KB taxonomy lookup (parallel) — trees + binary coverage map
+        │       (Redis-cached at hook layer, single retrieval-api roundtrip,
+        │       SPEC-RAG-TAXONOMY-001 multi-KB)
+        │
+        ├──▶ Combined query rewrite + taxonomy classify (single klai-fast call)
+        │       (resolve pronouns + classify into the merged taxonomy nodes
+        │       across all in-scope KBs, anti-hallucination guard against
+        │       union of valid IDs, SPEC-RAG-QUERY-REWRITE-001 + SPEC-RAG-TAXONOMY-001)
+        │
         ├──▶ POST to retrieval-api → returns ranked knowledge chunks
         │         │
-        │         ├── Coreference resolution (resolve pronouns)
+        │         ├── Coreference resolution (retrieval-api side, internal pronoun pass)
         │         ├── Generate embeddings (dense + sparse, parallel)
         │         ├── Retrieval gate (is KB retrieval even needed?)
         │         ├── Hybrid vector search in Qdrant (3-leg RRF) + parallel graph search (FalkorDB)
+        │         │   (chunks carry document_summary + context_prefix from
+        │         │    SPEC-RAG-CONTEXTUAL-001 — Anthropic-pattern contextual retrieval)
+        │         ├── Apply taxonomy_node_ids filter (when classifier returned IDs
+        │         │   AND in-scope KB has coverage)
         │         ├── Source-aware selection (mentioned / diversify mode, SPEC-KB-021)
         │         ├── Reranking (cross-encoder scores each chunk against the query)
+        │         ├── Parent expansion — expand each top-K child to its parent chunk
+        │         │   text via parent_chunk_id (SPEC-RAG-PARENT-CHILD-001)
         │         ├── Quality score boost (feedback signals from Qdrant payload)
-        │         └── Return top-K chunks
+        │         └── Return top-K chunks (parent text where expansion succeeded)
         │
         ├──▶ Write retrieval log to Redis (fire-and-forget, for feedback correlation)
         │
@@ -196,7 +211,66 @@ against is no longer the current version.
 
 The retrieval API (`klai-retrieval-api`) is a standalone service that owns the complete
 search pipeline. The LiteLLM hook calls it with a query and gets back a ranked list of
-text chunks. Everything below happens inside that service.
+text chunks.
+
+Before the call to `/retrieve`, the hook itself does two things: it **rewrites the query
+and classifies it into the multi-KB taxonomy in a single LLM round-trip**. After the
+chunks come back, the retrieval API also runs **parent expansion** — replacing each
+matched child chunk with its larger parent for better LLM context. The original
+"coreference resolution" step inside retrieval-api is still there as an internal pass.
+
+---
+
+### Step 0: Hook-side rewrite + taxonomy classify (single klai-fast call)
+
+**Simple:** Two pieces of preparation happen in the LiteLLM hook *before* it calls
+the search engine. First, "What did he say about it?" gets rewritten into a fully
+self-contained question. Second, the question gets categorised into one of the customer's
+knowledge-base topic tags (when the customer has a curated taxonomy). Both happen in a
+single AI call to keep the latency overhead near zero.
+
+**Technical:** The hook fires three small lookups in parallel before retrieval:
+
+1. **Multi-KB taxonomy trees + coverage map.** A single GET to
+   `retrieval-api/internal/v1/taxonomy/trees?kb_slugs=a&kb_slugs=b&...` returns
+   `{kb_slug: [node, ...]}` for every in-scope KB. A second parallel GET to
+   `/internal/v1/taxonomy/coverage` returns `{kb_slug: 0.0|1.0}` — a binary signal
+   marking which KBs have a curated taxonomy. Both are Redis-cached at the hook layer
+   (TTL 300s, deterministic key sorted on `kb_slugs`) so high-traffic chats don't keep
+   re-fetching. Capped at 5 KBs in scope; above that, taxonomy is skipped fail-open.
+   See `SPEC-RAG-TAXONOMY-001`.
+
+2. **Combined rewrite + classify.** The hook makes a single `klai-fast` call (Mistral
+   Small) with both the conversation history (last 4 turns) AND the merged taxonomy
+   trees from KBs that meet the coverage threshold. The model returns:
+
+   ```json
+   { "rewritten_query": "<self-contained question>",
+     "taxonomy_node_ids": [12, 18] }
+   ```
+
+   Anti-hallucination guard: returned IDs are filtered against the *union* of valid IDs
+   across all provided KBs (taxonomy node IDs are globally unique on
+   `portal_taxonomy_nodes`, so cross-KB collisions are impossible). When no KB has
+   coverage, the call falls back to a plain rewrite-only prompt — the classifier path
+   simply isn't invoked. See `SPEC-RAG-QUERY-REWRITE-001` (REQ-5: zero added roundtrip)
+   and `SPEC-RAG-TAXONOMY-001`.
+
+3. **Filter decision.** The hook then decides whether to attach `taxonomy_node_ids` to
+   the `/retrieve` request body. The filter applies iff (a) at least one in-scope KB has
+   coverage above `KLAI_TAXONOMY_COVERAGE_THRESHOLD` (default 0.30, i.e. has at least one
+   taxonomy node), AND (b) the classifier returned at least one valid node ID. Otherwise
+   the filter is skipped fail-open and retrieval runs with the standard org/KB scope
+   filter only.
+
+The whole hook-side rewrite + classify path is fail-open: any LLM timeout, any malformed
+JSON, any retrieval-api error during the taxonomy lookup logs a warning and falls back to
+the raw user query without the taxonomy filter. The chat keeps working — just without the
+narrowing.
+
+Tenants that haven't curated their taxonomy yet (Voys-support, today): every query logs
+`taxonomy_classify ... skip_reason=all_kbs_low_coverage` and the filter is never applied.
+The rewrite path still runs for them.
 
 ---
 
@@ -274,6 +348,17 @@ downstream hooks can observe the decision.
 **Simple:** Qdrant is the database that holds all the knowledge chunks as vectors. We
 search it three ways at once: by semantic meaning, by the questions each chunk answers,
 and by exact keywords. The results are merged into a single ranked list.
+
+> Each chunk in Qdrant is *contextually enriched* per the Anthropic-pattern
+> retrieval (`SPEC-RAG-CONTEXTUAL-001`). Two payload fields ride along with the
+> chunk text and improve embedding quality at ingest time:
+> - `document_summary` — one short summary per artifact, generated once at
+>   ingest and shared across every child chunk.
+> - `context_prefix` — a per-chunk one-liner placing the chunk in its document
+>   context. Embedded together with the chunk text.
+>
+> The reranker (Step 5) sees `context_prefix + text` — the same shape stored in
+> Qdrant — so reranker scoring stays calibrated to the embedded representation.
 
 **Technical:** Against the `klai_knowledge` collection, a three-leg prefetch query is
 executed:
@@ -446,6 +531,40 @@ These fields enable post-retrieval analysis: which sources does the router recom
 which the diversity algorithm selects vs. which actually end up in the top-K.
 
 The final `top_k` chunks (default: 5) are returned to the LiteLLM hook.
+
+---
+
+### Step 5d: Parent expansion (SPEC-RAG-PARENT-CHILD-001)
+
+**Simple:** When ingest chunks a document it actually creates two layers — small *child*
+chunks (good for matching, bad for context because they cut sentences) and large *parent*
+chunks (good for context, too noisy for matching). The retrieval engine matches on
+children to stay precise, then swaps each match for its parent text before sending the
+result to the LLM. The model sees broader context without the matching step getting
+diluted.
+
+**Technical:** Each Qdrant child chunk carries a `parent_chunk_id` payload field
+referencing a row in PostgreSQL `knowledge.parent_chunks`. After Step 5c, retrieval-api
+runs a single batched lookup:
+
+```sql
+SELECT id, text FROM knowledge.parent_chunks WHERE id = ANY($1::bigint[])
+```
+
+For each top-K child whose `parent_chunk_id` resolves, the chunk's `text` field is
+replaced with the parent's `text` and `is_parent_text` is set to `true` on the
+`ChunkResult`. Children without a `parent_chunk_id` (legacy artifacts ingested before
+SPEC-RAG-PARENT-CHILD-001 landed, or artifacts where rebuild_kb hasn't yet propagated the
+linkage) fall back to their own chunk text — fail-open.
+
+The reranker (Step 5) still scores against the *child* text — that's where matching
+precision lives. Parent expansion only changes what the LLM ultimately reads.
+
+Backfill for legacy artifacts: `rebuild_kb_inline(org_id, kb_slug)` reconstructs document
+text from existing Qdrant chunks (lossy but workable), re-chunks with parent-child
+chunking, and re-upserts to Qdrant with the new `parent_chunk_id` linkage. See the
+operator runbook in `docs/runbooks/rag-quality.md` and `klai-knowledge-ingest/
+knowledge_ingest/rebuild_tasks.py`.
 
 ---
 
@@ -691,7 +810,21 @@ The retrieval pipeline above is exercised nightly by a RAGAS-based evaluation ha
 | Alert rule | `deploy/grafana/provisioning/alerting/rag-eval-rules.yaml` |
 | Triage runbook | [docs/runbooks/rag-quality.md](../runbooks/rag-quality.md) |
 
-**Voys baseline (2026-05-05):** `context_precision=0.25`, `context_recall=0.26`, `retrieval_ms=542`. Faithfulness/answer_relevance have known tuning gaps documented in the roadmap. The low precision/recall is the **expected starting point** that Tier 1 SPECs will improve.
+**Voys baseline → post-stack measurements (2026-05-05, chat suite, n=30):**
+
+| Metric | `baseline-v4` (pre-stack) | `post_pr_abcdefg_v1` (full Tier 1+2 live) | Δ |
+|---|---|---|---|
+| `context_precision` | 0.231 | **0.372** | +0.141 (+61%) |
+| `context_recall` | 0.253 | **0.642** | +0.389 (+154%) |
+| `faithfulness` | NaN (judge truncation) | **0.812** | first measurable |
+| `answer_relevance` | 0.706 | 0.711 | +0.005 |
+
+The eval-harness calls retrieval-api directly and bypasses the LiteLLM hook, so query
+rewriting and taxonomy classifying (which live in the hook) are NOT measured by the
+numbers above. Their effect shows up only on real chat traffic. The +61% precision /
++154% recall / first-measurable faithfulness come from contextual-retrieval chunks +
+parent-child expansion + the rebuild_kb backfill alone. Detailed roadmap closing
+snapshot: [docs/architecture/retrieval-improvements-roadmap.md](retrieval-improvements-roadmap.md).
 
 **Multi-tenant by design:** every query in a suite YAML carries its own `org_zitadel_id`. v1 ships with Voys-only suites. Adding additional tenants post-launch is a YAML drop-in — no service split, no per-tenant deployment.
 


### PR DESCRIPTION
Both docs predated the 7-PR Tier 1+2 stack that landed on 2026-05-05. They described retrieval as 'raw query in, ranked chunks out' and ingest as 'chunk + embed + enrich'. Reality on main today is several layers deeper.

**knowledge-retrieval-flow.md** updates:
- Big-picture ASCII tree: now shows multi-KB taxonomy lookup + combined rewrite/classify BEFORE retrieval, parent expansion + contextual chunks INSIDE retrieval.
- New Step 0: hook-side rewrite + classify (single klai-fast call, anti-hallucination guard against union of valid IDs, Redis cache, fail-open).
- Note in Step 4: chunks now carry document_summary + context_prefix; reranker scores against context_prefix + text.
- New Step 5d: parent expansion via parent_chunk_id, plus the rebuild_kb backfill path for legacy artifacts.
- Quality measurement section: replaced stale single-line baseline with the full baseline-v4 vs post_pr_abcdefg_v1 cijfertabel (precision +61%, recall +154%, faithfulness from broken to 0.81). Explicitly flags the eval-harness bypass of the hook.

**knowledge-ingest-flow.md** updates:
- Chunking section: chunker.chunk_markdown_with_parents produces children+parents in one pass.
- Phase 2 Step A: per-document summary generated once (cached on extra.document_summary); per-chunk prompt references the short summary instead of the full doc body (~8x token reduction).
- New Phase 7: rebuild_kb operator-triggered backfill, including the parent_chunk_id threading contract that PR #357 fixed.

Docs-only PR. No code change.