### PR TITLE
fix(infra): split #364 RLS DDL to post-deploy SQL — owner-privilege class

### DIFF
--- a/.claude/rules/klai/pitfalls/process-rules.md
+++ b/.claude/rules/klai/pitfalls/process-rules.md
@@ -656,10 +656,20 @@ as a hand-applied fix before this entrypoint pattern landed.
 
 `portal_api` is the role that runs `alembic upgrade head` from the
 portal-api `entrypoint.sh`. Tables created with RLS (or any table whose
-ownership is `klai` superuser instead of `portal_api`) cannot be dropped
-by `op.drop_table(...)` — Postgres raises
+ownership is `klai` superuser instead of `portal_api`) cannot be **DROPPED,
+have RLS ENABLED on them, or have CREATE POLICY applied** by `op.execute(...)`
+in a normal alembic migration — Postgres raises
 `InsufficientPrivilegeError: must be owner of table <name>`. The
 entrypoint then crash-loops and the deploy lands in 502.
+
+The full list of owner-required DDL is broader than DROP TABLE:
+- `DROP TABLE` (original incident, SPEC-AUTH-009)
+- `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` (SPEC-SEC-PORTAL-RLS-001 #364, 2026-05-05)
+- `ALTER TABLE ... FORCE ROW LEVEL SECURITY`
+- `CREATE POLICY` / `DROP POLICY` (when target is owned by klai)
+- `ALTER TABLE ... OWNER TO ...`
+
+All of these need the post-deploy SQL pattern below.
 
 This bit SPEC-AUTH-009 (PR #259, 2026-05-04). Migration `ed5b78b296f5`
 ended with `op.drop_table("portal_org_allowed_domains")`. The table was

--- a/.moai/specs/audit-2026-05-05-followups.md
+++ b/.moai/specs/audit-2026-05-05-followups.md
@@ -20,11 +20,11 @@ Items that genuinely will not be addressed in the original PRs:
 | Audit ref | Item | Why not fixed in PR | Follow-up |
 |---|---|---|---|
 | #2 MED | knowledge-ingest + scribe-api push `:sha` tag on every PR build | operational concern (GHCR storage growth); not a security issue | Separate **SPEC-CI-GHCR-RETENTION-001** if storage cost climbs |
-| #3 MED 8 | `_FakeSession` regex SQL parsing fragile | refactor scope > audit-pass; needs SQLAlchemy statement-inspection rewrite | Separate PR — SPEC-TEST-QUALITY-001 deferred |
-| #3 MED 10 | G3 idempotency test uses 2 separate mock pools | bypasses real "DELETE on empty set = 0" invariant; works as smoke-test | Live-PG fixture in CI — **SPEC-CI-PG-FIXTURE-001** stub PR #356 |
+| #3 MED 8 | `_FakeSession` regex SQL parsing fragile | DONE 2026-05-05 in #332 commit `d12d8274` — refactored to SQLAlchemy structural inspection (BinaryExpression walk + BindParameter introspection) | Closed |
+| #3 MED 10 | G3 idempotency test uses 2 separate mock pools | bypasses real "DELETE on empty set = 0" invariant; works as smoke-test | Live-PG fixture in CI — **SPEC-CI-PG-FIXTURE-001** stub PR #356 (merged) |
 | #3 MED 11 | Qdrant klai_focus filter key claim unverified in CI | live-prod-probe done 2026-05-05 (`tenant_id` confirmed); future drift not auto-detected | Same SPEC-CI-PG-FIXTURE-001 — extend with Qdrant integration |
 | #4 MED B1 | `RequestContextMiddleware` not E2E-tested in mailer | shared-lib tests cover the unit; mailer integration would duplicate | Bundle into shared-lib-adoption SPEC |
-| #4 MED D1 | Dockerfile trailing-slash cosmetic conflict #319 ↔ #335 | merge resolution decides; both forms work | Resolve at merge time (whoever lands second) |
+| #4 MED D1 | Dockerfile trailing-slash cosmetic conflict #319 ↔ #335 | DONE 2026-05-05 — additive merge during #335 rebase; combined log-utils + webhook-replay COPY lines | Closed |
 | #4 LOW B2 | `test_notify_replay` redundant patch after pop+reimport | works; cosmetic redundancy | Leave |
 | #4 LOW C5 | `klai-libs/log-utils` declares `starlette>=0.40` runtime dep | every klai service already depends on FastAPI (transitively pulls Starlette) | Leave — explicit dep is correct hygiene |
 | #4 LOW D2 | Stage 1 of mailer Dockerfile installs `git` (vestigial) | no runtime impact; reserved for future VCS-deps | Drop in next mailer Dockerfile pass |
@@ -81,3 +81,17 @@ For traceability — these items were closed by per-PR amendments during the
 - **Documentation cluster**: items #4 MED A2 + LOW B2 + #1 F8's docstring
   comment + portal_client guard relationship — all "small documentation
   improvements". Could ride along with the next manager-docs sync pass.
+
+---
+
+## Post-batch additions (2026-05-05 evening session)
+
+Beyond the original audit-pass scope, these landed in the same evening
+session and are tracked here for traceability:
+
+| Ref | Item | PR | Notes |
+|---|---|---|---|
+| BFF-PARITY | `BFF_SESSION_KEY` validator-env-parity miss → 4-min prod outage | #360 (noodklep) → klai-infra#4 (SOPS) → #361 (cleanup) | Pattern: silent in-code fallback (`A or B`) deletion + new validator without SOPS pre-flight. Documented as proposed pitfall in `validator-env-parity` section of process-rules.md (extend in next pass). |
+| RLS-A-OWNER | #364 RLS migration crashed portal-api: `ALTER TABLE ENABLE ROW LEVEL SECURITY` requires klai owner | #367 | Migration body emptied; DDL moved to `post_deploy_2f7d1eae1198.sql`. Pitfall `alembic-cannot-drop-non-portal_api-tables` extended to enumerate all owner-required DDL (DROP TABLE, ENABLE/FORCE RLS, CREATE/DROP POLICY, ALTER OWNER). |
+| RLS-PIVOT | #318 closed (superseded). Original ast-grep rule + connector adoption replaced by RLS-on-sync_runs SPEC | SPEC-SEC-CONNECTOR-RLS-001 (skeleton) | Analysis showed ast-grep rule is heuristic application-level; RLS at DB level is the right layer. New SPEC implements it via Category D + cross_org_session helper. |
+| ALEMBIC-NOOP | knowledge-ingest #337 alembic baseline already stamped on prod | n/a | Verified `knowledge.alembic_version = '0001_baseline'` before merge — entrypoint's `alembic upgrade head` is no-op. |

--- a/klai-portal/backend/alembic/versions/2f7d1eae1198_add_rls_join_requests_and_allowed_domains.py
+++ b/klai-portal/backend/alembic/versions/2f7d1eae1198_add_rls_join_requests_and_allowed_domains.py
@@ -47,49 +47,46 @@ Revises: rbac001drop00
 Create Date: 2026-05-05
 """
 
-from alembic import op
-
 revision = "2f7d1eae1198"
 down_revision = "rbac001drop00"
 branch_labels = None
 depends_on = None
 
-_T = "NULLIF(current_setting('app.current_org_id', true), '')::int"
-_T_IS_NULL = "NULLIF(current_setting('app.current_org_id', true), '') IS NULL"
 
-
-def _enable_rls(table: str) -> None:
-    op.execute(  # nosemgrep: formatted-sql-query,sqlalchemy-execute-raw-query
-        f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY"
-    )
-    op.execute(  # nosemgrep: formatted-sql-query,sqlalchemy-execute-raw-query
-        f"ALTER TABLE {table} FORCE ROW LEVEL SECURITY"
-    )
+# All DDL for this migration (ENABLE ROW LEVEL SECURITY + CREATE POLICY)
+# requires the table-owner role (`klai` superuser), not the migration role
+# (`portal_api`). PostgreSQL refuses these statements when run by anyone
+# else with `ERROR: must be owner of table portal_join_requests` —
+# crash-looping portal-api on the next deploy. Same class as
+# `alembic-cannot-drop-non-portal_api-tables` in process-rules.md, just
+# with ENABLE / FORCE ROW LEVEL SECURITY instead of DROP TABLE.
+#
+# The DDL has been moved to a sibling post-deploy SQL file:
+#   alembic/versions/post_deploy_2f7d1eae1198.sql
+#
+# Apply it manually as the `klai` superuser after `alembic upgrade
+# 2f7d1eae1198` completes (or via `scripts/apply_post_deploy_sql.sh`).
+#
+# Pattern matches: post_deploy_7e2d3c1a9b8f.sql (RLS for
+# tenant_lifecycle_events), post_deploy_ed5b78b296f5.sql (DROP of
+# portal_org_allowed_domains), post_deploy_f0a1b2c3d4e5.sql (RLS for
+# widgets).
+#
+# This upgrade() is intentionally a no-op so the alembic_version row
+# advances cleanly even when the operator has not yet applied the
+# post-deploy SQL. Without that, every container start would re-attempt
+# the failing DDL and crash-loop on every restart.
 
 
 def upgrade() -> None:
-    # portal_join_requests: Category A (permissive on missing context).
-    # The admin token-based approve flow in app/api/auth_join.py looks up
-    # the join request by its approval_token BEFORE any tenant context is
-    # resolved (the token IS the resolution mechanism). Same shape as
-    # portal_users / portal_connectors — a permissive IS NULL branch so
-    # the pre-auth lookup succeeds, with strict tenant-equality once
-    # set_tenant has fired downstream (admin/join_requests.py path).
-    _enable_rls("portal_join_requests")
-    op.execute(  # nosemgrep: formatted-sql-query,sqlalchemy-execute-raw-query
-        "DROP POLICY IF EXISTS tenant_isolation ON portal_join_requests"
-    )
-    op.execute(  # nosemgrep: formatted-sql-query,sqlalchemy-execute-raw-query
-        "CREATE POLICY tenant_isolation ON portal_join_requests "
-        f"USING (org_id = {_T} OR {_T_IS_NULL}) "
-        f"WITH CHECK (org_id = {_T})"
-    )
+    # No-op: see file-level comment. DDL lives in
+    # post_deploy_2f7d1eae1198.sql, applied manually as klai superuser.
+    pass
 
 
 def downgrade() -> None:
-    op.execute(  # nosemgrep: formatted-sql-query,sqlalchemy-execute-raw-query
-        "DROP POLICY IF EXISTS tenant_isolation ON portal_join_requests"
-    )
-    op.execute(  # nosemgrep: formatted-sql-query,sqlalchemy-execute-raw-query
-        "ALTER TABLE portal_join_requests DISABLE ROW LEVEL SECURITY"
-    )
+    # No-op: the post-deploy SQL is idempotent and not part of the
+    # alembic-managed schema. To roll back, run as klai superuser:
+    #   DROP POLICY IF EXISTS tenant_isolation ON portal_join_requests;
+    #   ALTER TABLE portal_join_requests DISABLE ROW LEVEL SECURITY;
+    pass

--- a/klai-portal/backend/alembic/versions/post_deploy_2f7d1eae1198.sql
+++ b/klai-portal/backend/alembic/versions/post_deploy_2f7d1eae1198.sql
@@ -1,0 +1,37 @@
+-- Post-deploy RLS setup for SPEC-SEC-PORTAL-RLS-001 migration 2f7d1eae1198.
+-- Run as `klai` superuser after `alembic upgrade 2f7d1eae1198` completes.
+--
+-- Why post-deploy and not in the migration itself:
+-- The Alembic migration runs as the `portal_api` role; that role is NOT the
+-- owner of `portal_join_requests` (the table was created by `klai` superuser
+-- in an earlier RLS-pattern migration). PostgreSQL refuses
+-- `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` and `CREATE POLICY` from any
+-- role except the table owner — same class as
+-- `alembic-cannot-drop-non-portal_api-tables` in
+-- `.claude/rules/klai/pitfalls/process-rules.md` (extended in this PR to
+-- cover ENABLE / FORCE ROW LEVEL SECURITY too). Running these statements
+-- inside the migration crash-loops portal-api on startup until manually
+-- recovered.
+--
+-- Category A (auth-seed) policy: the admin token-based approve flow in
+-- `app/api/auth_join.py` looks up the join request by approval_token BEFORE
+-- any tenant context is resolved. The IS NULL permissive branch lets that
+-- pre-auth lookup succeed; admin/join_requests.py runs after `set_tenant`
+-- has fired and gets strict org_id = T isolation.
+--
+-- Idempotent: safe to re-run. ALTER TABLE ... ENABLE is a no-op when
+-- already enabled. DROP POLICY IF EXISTS + CREATE POLICY rebuilds cleanly.
+
+ALTER TABLE portal_join_requests ENABLE ROW LEVEL SECURITY;
+ALTER TABLE portal_join_requests FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tenant_isolation ON portal_join_requests;
+
+CREATE POLICY tenant_isolation ON portal_join_requests
+    USING (
+        org_id = NULLIF(current_setting('app.current_org_id', true), '')::int
+        OR NULLIF(current_setting('app.current_org_id', true), '') IS NULL
+    )
+    WITH CHECK (
+        org_id = NULLIF(current_setting('app.current_org_id', true), '')::int
+    );

--- a/klai-portal/backend/tests/test_rls_join_requests.py
+++ b/klai-portal/backend/tests/test_rls_join_requests.py
@@ -42,6 +42,13 @@ MIGRATION_PATH = (
     / "2f7d1eae1198_add_rls_join_requests_and_allowed_domains.py"
 )
 
+# DDL was moved to a post-deploy SQL file (run as klai superuser) because
+# `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` and `CREATE POLICY` require
+# the table-owner role, not the migration role (`portal_api`). See pitfall
+# `alembic-cannot-drop-non-portal_api-tables` in process-rules.md and the
+# header of post_deploy_2f7d1eae1198.sql for context.
+POST_DEPLOY_SQL_PATH = Path(__file__).resolve().parents[1] / "alembic" / "versions" / "post_deploy_2f7d1eae1198.sql"
+
 
 # ---------------------------------------------------------------------------
 # RLS_DML_TABLES regression — silent-filter guard must cover the new table
@@ -86,50 +93,83 @@ def _read_migration() -> str:
     return MIGRATION_PATH.read_text(encoding="utf-8")
 
 
-def test_migration_enables_force_rls() -> None:
+def _read_post_deploy_sql() -> str:
+    assert POST_DEPLOY_SQL_PATH.exists(), (
+        f"SPEC-SEC-PORTAL-RLS-001 post-deploy SQL file is missing: {POST_DEPLOY_SQL_PATH}. "
+        "DDL for portal_join_requests RLS lives there because the "
+        "migration role (portal_api) cannot run owner-required DDL "
+        "(see pitfall alembic-cannot-drop-non-portal_api-tables)."
+    )
+    return POST_DEPLOY_SQL_PATH.read_text(encoding="utf-8")
+
+
+def test_post_deploy_enables_force_rls() -> None:
     """Both ENABLE and FORCE row-level security must fire on the table.
 
     Without FORCE, the table owner role bypasses the policy — fine in
     dev but operationally risky if the migration role and the
     application role ever drift.
     """
-    src = _read_migration()
-    assert re.search(r"ENABLE ROW LEVEL SECURITY", src), "Migration must call ALTER TABLE ... ENABLE ROW LEVEL SECURITY"
-    assert re.search(r"FORCE ROW LEVEL SECURITY", src), "Migration must call ALTER TABLE ... FORCE ROW LEVEL SECURITY"
+    src = _read_post_deploy_sql()
+    assert re.search(r"ENABLE ROW LEVEL SECURITY", src), (
+        "post_deploy_2f7d1eae1198.sql must call ALTER TABLE ... ENABLE ROW LEVEL SECURITY"
+    )
+    assert re.search(r"FORCE ROW LEVEL SECURITY", src), (
+        "post_deploy_2f7d1eae1198.sql must call ALTER TABLE ... FORCE ROW LEVEL SECURITY"
+    )
     assert "portal_join_requests" in src
 
 
-def test_migration_does_not_touch_portal_org_allowed_domains() -> None:
-    """SPEC-AUTH-009 R2 dropped the table. The migration must NOT
+def test_migration_body_is_noop() -> None:
+    """The migration file's upgrade() and downgrade() MUST be no-ops.
+
+    The owner-required DDL was moved out of the migration to
+    post_deploy_2f7d1eae1198.sql to avoid the
+    `alembic-cannot-drop-non-portal_api-tables` crash-loop. If a future
+    refactor accidentally moves the DDL back into upgrade(), portal-api
+    will crash-loop on every fresh deploy.
+    """
+    src = _read_migration()
+    # Both upgrade() and downgrade() should be `pass`-only bodies. We
+    # assert the absence of `op.execute(`, which is the load-bearing
+    # API for raw DDL.
+    assert "op.execute(" not in src, (
+        "Migration file contains op.execute(...) — owner-required DDL "
+        "must live in post_deploy_2f7d1eae1198.sql instead. See pitfall "
+        "alembic-cannot-drop-non-portal_api-tables in process-rules.md."
+    )
+
+
+def test_post_deploy_does_not_touch_portal_org_allowed_domains() -> None:
+    """SPEC-AUTH-009 R2 dropped the table. Post-deploy SQL must NOT
     re-introduce DDL on it — that would conflict with the drop on
     upgrade() and confuse downgrade()."""
-    src = _read_migration()
-    # The table name may appear in the docstring as historical context
-    # (explaining WHY it is excluded). It MUST NOT appear in any
-    # op.execute() call.
-    op_executes = re.findall(r"op\.execute\([^)]*\)", src, re.DOTALL)
-    for stmt in op_executes:
-        assert "portal_org_allowed_domains" not in stmt, (
-            "Migration must not run DDL against portal_org_allowed_domains "
-            "— SPEC-AUTH-009 R2 dropped that table. Found in: "
-            f"{stmt[:200]}..."
-        )
+    src = _read_post_deploy_sql()
+    # Header docstring may mention the table as historical context.
+    # Strip SQL line-comments before searching for the table name in
+    # active DDL.
+    active_ddl = "\n".join(line for line in src.splitlines() if not line.lstrip().startswith("--"))
+    assert "portal_org_allowed_domains" not in active_ddl, (
+        "post_deploy_2f7d1eae1198.sql must not run DDL against "
+        "portal_org_allowed_domains — SPEC-AUTH-009 R2 dropped that "
+        "table."
+    )
 
 
 def _extract_policy_block(source: str, table: str) -> str:
     """Return the source-text run that contains the ``CREATE POLICY`` for
-    ``table``, up to the closing ``op.execute(...)`` call.
+    ``table``, up to the closing semicolon.
     """
     match = re.search(
-        rf"CREATE POLICY tenant_isolation ON {table}.*?\)\n",
+        rf"CREATE POLICY tenant_isolation ON {table}.*?;",
         source,
         re.DOTALL,
     )
-    assert match, f"CREATE POLICY block for {table} not found in migration"
+    assert match, f"CREATE POLICY block for {table} not found in post-deploy SQL"
     return match.group(0)
 
 
-def test_migration_creates_permissive_policy_on_join_requests() -> None:
+def test_post_deploy_creates_permissive_policy_on_join_requests() -> None:
     """Category-A pre-auth pattern: portal_join_requests MUST include
     the ``IS NULL`` permissive branch in its USING clause.
 
@@ -137,17 +177,10 @@ def test_migration_creates_permissive_policy_on_join_requests() -> None:
     ``auth_join.py`` cannot resolve the join request before tenant
     context exists. See migration docstring + SPEC-SEC-PORTAL-RLS-001
     Risks table.
-
-    The migration may emit the IS NULL branch either directly (literal
-    ``IS NULL`` text) or via the shared ``_T_IS_NULL`` variable that
-    expands to ``NULLIF(...) IS NULL`` at runtime — both shapes are
-    accepted, but the strict-only pattern (``USING (org_id = T)`` with
-    no NULL branch at all) is rejected.
     """
-    src = _read_migration()
+    src = _read_post_deploy_sql()
     block = _extract_policy_block(src, "portal_join_requests")
-    has_permissive_branch = "IS NULL" in block or "_T_IS_NULL" in block
-    assert has_permissive_branch, (
+    assert "IS NULL" in block, (
         "portal_join_requests policy must include the `IS NULL` "
         "permissive branch (Category-A auth-seed pattern). Without it "
         "the admin approve_join flow cannot resolve the row before "
@@ -155,53 +188,35 @@ def test_migration_creates_permissive_policy_on_join_requests() -> None:
     )
 
 
-def test_migration_with_check_clause_present() -> None:
+def test_post_deploy_with_check_clause_present() -> None:
     """The policy must include WITH CHECK so INSERTs from a wrong tenant
     context fail, not just SELECTs filter."""
-    src = _read_migration()
+    src = _read_post_deploy_sql()
     check_count = len(re.findall(r"WITH CHECK", src))
     assert check_count >= 1, (
-        f"Expected at least 1 WITH CHECK clause in migration; found "
-        f"{check_count}. Without WITH CHECK an attacker could INSERT a "
-        "row with someone else's org_id."
+        f"Expected at least 1 WITH CHECK clause in post-deploy SQL; "
+        f"found {check_count}. Without WITH CHECK an attacker could "
+        "INSERT a row with someone else's org_id."
     )
-
-
-def test_migration_downgrade_drops_policy() -> None:
-    """Downgrade must roll back the DDL changes — drop policy + disable RLS."""
-    src = _read_migration()
-    down_match = re.search(
-        r"def downgrade\(\) -> None:(.*?)\Z",
-        src,
-        re.DOTALL,
-    )
-    assert down_match, "Migration must define downgrade()"
-    down_body = down_match.group(1)
-    assert "DROP POLICY IF EXISTS tenant_isolation ON portal_join_requests" in down_body or (
-        "portal_join_requests" in down_body and "DROP POLICY" in down_body
-    )
-    assert "DISABLE ROW LEVEL SECURITY" in down_body, "Downgrade must DISABLE ROW LEVEL SECURITY"
 
 
 # ---------------------------------------------------------------------------
-# Idempotency — re-running the migration on an existing DB must not fail.
+# Idempotency — re-running on an existing DB must not fail.
 # ---------------------------------------------------------------------------
 
 
-def test_migration_uses_drop_if_exists_for_idempotency() -> None:
+def test_post_deploy_uses_drop_if_exists_for_idempotency() -> None:
     """``CREATE POLICY`` does not support ``IF NOT EXISTS``. The
-    migration must wrap each CREATE in a DROP IF EXISTS so re-applying
-    on a partially migrated database (rare but possible during staging
-    recovery) succeeds.
-
-    See ``alembic-stamped-past-skipped-migration`` pitfall.
+    post-deploy SQL must wrap each CREATE in a DROP IF EXISTS so
+    re-applying on a partially migrated database (rare but possible
+    during staging recovery) succeeds.
     """
-    src = _read_migration()
+    src = _read_post_deploy_sql()
     drop_count = len(re.findall(r"DROP POLICY IF EXISTS tenant_isolation", src))
     create_count = len(re.findall(r"CREATE POLICY tenant_isolation", src))
     assert drop_count >= create_count, (
-        f"Migration has {create_count} CREATE POLICY statements but only "
-        f"{drop_count} DROP POLICY IF EXISTS guards in upgrade(). "
+        f"Post-deploy SQL has {create_count} CREATE POLICY statements "
+        f"but only {drop_count} DROP POLICY IF EXISTS guards. "
         "Idempotency is broken: re-running on a partially migrated DB "
         "will fail."
     )


### PR DESCRIPTION
Follow-up to #364. The migration shipped with `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` + CREATE POLICY inside `upgrade()`. portal_api role can't run those — only klai superuser can. Resulted in prod crash-loop until I applied the DDL manually + stamped alembic_version.

Prod is already correct. This PR makes the migration FILE match prod state so fresh deploys / staging / DR don't re-hit the pitfall.

- `2f7d1eae1198` upgrade()/downgrade() → no-op
- New `post_deploy_2f7d1eae1198.sql` (idempotent, runs as klai)
- Extended pitfall `alembic-cannot-drop-non-portal_api-tables` to enumerate all owner-required DDL: DROP TABLE, ENABLE/FORCE RLS, CREATE/DROP POLICY, ALTER OWNER

No prod-side action needed — the post-deploy SQL only activates on environments that aren't already at this version_num.