### PR TITLE
feat(security): SPEC-SEC-CONNECTOR-RLS-001 — RLS on connector.{connectors,sync_runs}

### DIFF
--- a/klai-connector/alembic/versions/008_rls_connector_schema.py
+++ b/klai-connector/alembic/versions/008_rls_connector_schema.py
@@ -1,0 +1,73 @@
+"""SPEC-SEC-CONNECTOR-RLS-001: RLS on connector.{connectors,sync_runs}
+
+Closes audit finding TP-5 from reports/audit-2026-05-04/tenant-scoping.md:
+both tables in the ``connector`` schema have ``org_id`` columns but no
+PostgreSQL policy. Tenant isolation depended entirely on application-
+level filters.
+
+This migration intentionally has an empty body. All RLS DDL (ENABLE /
+FORCE ROW LEVEL SECURITY + CREATE POLICY) requires the table-owner
+role; under FORCE ROW LEVEL SECURITY even the owner is subject to the
+policy at runtime. Keeping owner-required DDL out of migrations
+prevents the ``alembic-cannot-drop-non-portal_api-tables`` crash-loop
+documented in process-rules.md (extended on 2026-05-05 to cover
+ENABLE / FORCE RLS + CREATE POLICY beyond the original DROP TABLE).
+
+The DDL lives in the sibling SQL file
+``alembic/versions/post_deploy_008.sql`` and must be applied as the
+table owner (``klai``) via ``scripts/apply_post_deploy_sql.sh`` or
+manually after every fresh deploy / DR restore. Pattern matches
+portal-api's ``post_deploy_2f7d1eae1198.sql`` (#364).
+
+Architectural decisions (per SPEC-SEC-CONNECTOR-RLS-001 v0.2.0):
+
+- Category D (strict): empty GUC + no ``cross_org_admin`` flag returns
+  zero rows / blocks INSERT with 42501. Loud-failure mode preferred
+  over Category A's silent cross-tenant leakage.
+- No role-split. ``FORCE ROW LEVEL SECURITY`` keeps the owner role
+  subject to the policy. A separate runtime role would require a new
+  SOPS env var with all the validator-env-parity risk that brings.
+- ``app.cross_org_admin = '1'`` is the legitimate escape hatch for
+  the lifespan reset, the SyncRunReaper periodic sweep, and the
+  scheduler bootstrap that loads all tenant schedules. Bound
+  exclusively via ``cross_org_session()`` in
+  ``app/core/database.py`` — never from request-scoped code.
+
+Revision ID: 008_rls_connector_schema
+Revises: 007_sync_runs_fk
+Create Date: 2026-05-05
+"""
+
+revision = "008_rls_connector_schema"
+down_revision = "007_sync_runs_fk"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """No-op. DDL lives in post_deploy_008.sql.
+
+    Apply manually as klai superuser:
+        psql -f alembic/versions/post_deploy_008.sql
+    Or via the shared helper:
+        scripts/apply_post_deploy_sql.sh
+
+    Without that step the tables have no policy and tenant isolation
+    falls back to the application filter — the very condition this
+    migration was written to fix. The smoke test in
+    tests/test_rls_connector_schema.py verifies the policy is present
+    on the live DB.
+    """
+
+
+def downgrade() -> None:
+    """No-op. To roll back, run as klai superuser:
+
+        DROP POLICY IF EXISTS tenant_isolation ON connector.connectors;
+        DROP POLICY IF EXISTS tenant_isolation ON connector.sync_runs;
+        ALTER TABLE connector.connectors DISABLE ROW LEVEL SECURITY;
+        ALTER TABLE connector.sync_runs DISABLE ROW LEVEL SECURITY;
+
+    The post-deploy SQL is idempotent and not part of the alembic-
+    managed schema, so there is no automatic downgrade path.
+    """

--- a/klai-connector/alembic/versions/post_deploy_008.sql
+++ b/klai-connector/alembic/versions/post_deploy_008.sql
@@ -1,0 +1,82 @@
+-- Post-deploy RLS setup for SPEC-SEC-CONNECTOR-RLS-001 migration 008.
+-- Run as the table-owner role (klai superuser) AFTER `alembic upgrade head`
+-- completes. The migration body is intentionally a no-op; this file
+-- carries the actual DDL.
+--
+-- Why post-deploy and not in the migration:
+-- ALTER TABLE ... ENABLE / FORCE ROW LEVEL SECURITY and CREATE POLICY
+-- require the table owner. Even if klai-connector currently runs alembic
+-- as klai today, future role-splits would re-trigger the
+-- `alembic-cannot-drop-non-portal_api-tables` crash-loop. Keeping
+-- owner-required DDL out of migrations is the canonical klai pattern
+-- (see post_deploy_2f7d1eae1198.sql, post_deploy_7e2d3c1a9b8f.sql in
+-- klai-portal/backend/alembic/versions/).
+--
+-- Apply via `scripts/apply_post_deploy_sql.sh` or manually:
+--   psql -U klai -d klai -f post_deploy_008.sql
+--
+-- Idempotent: safe to re-run.
+--
+-- Policy shape — Category D (strict) per SPEC-SEC-CONNECTOR-RLS-001:
+--   * USING — SELECT/UPDATE/DELETE matches when org_id equals the
+--     ``app.current_org_id`` GUC, OR when ``app.cross_org_admin`` is set
+--     to '1'. The cross-org branch is the legitimate escape hatch for
+--     the lifespan crash-recovery, the SyncRunReaper periodic sweep, and
+--     the scheduler bootstrap that loads all tenant schedules at
+--     startup. Set EXCLUSIVELY via ``cross_org_session()`` in
+--     ``app/core/database.py``.
+--   * WITH CHECK — INSERT/UPDATE writes must satisfy ``org_id = GUC``,
+--     UNLESS ``cross_org_admin`` is set. Stops a request-scoped handler
+--     from writing a row with someone else's org_id.
+--   * No IS NULL permissive branch on USING (would allow NULL-org_id
+--     reads to leak cross-tenant). Historical pre-migration-006 rows in
+--     ``connector.sync_runs`` carry NULL ``org_id`` and are
+--     intentionally invisible to tenant-scoped queries; only the
+--     ``cross_org_admin`` path can see them.
+--
+-- FORCE ROW LEVEL SECURITY — keeps the owner role subject to the policy
+-- at runtime, so the no-role-split decision is safe.
+
+-- ---------------------------------------------------------------------------
+-- connector.connectors
+-- ---------------------------------------------------------------------------
+-- ``org_id`` is NOT NULL (per SPEC-SEC-TENANT-001 REQ-7.x). Every row
+-- has a tenant; the policy is unambiguous.
+
+ALTER TABLE connector.connectors ENABLE ROW LEVEL SECURITY;
+ALTER TABLE connector.connectors FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tenant_isolation ON connector.connectors;
+
+CREATE POLICY tenant_isolation ON connector.connectors
+    USING (
+        org_id = NULLIF(current_setting('app.current_org_id', true), '')
+        OR current_setting('app.cross_org_admin', true) = '1'
+    )
+    WITH CHECK (
+        org_id = NULLIF(current_setting('app.current_org_id', true), '')
+        OR current_setting('app.cross_org_admin', true) = '1'
+    );
+
+-- ---------------------------------------------------------------------------
+-- connector.sync_runs
+-- ---------------------------------------------------------------------------
+-- ``org_id`` is nullable (migration 006 added the column without
+-- backfill). Historical NULL rows are invisible to tenant-scoped queries
+-- by design — they never had a binding tenant and surface only for the
+-- reaper / lifespan cross-org sweeps.
+
+ALTER TABLE connector.sync_runs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE connector.sync_runs FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tenant_isolation ON connector.sync_runs;
+
+CREATE POLICY tenant_isolation ON connector.sync_runs
+    USING (
+        org_id = NULLIF(current_setting('app.current_org_id', true), '')
+        OR current_setting('app.cross_org_admin', true) = '1'
+    )
+    WITH CHECK (
+        org_id = NULLIF(current_setting('app.current_org_id', true), '')
+        OR current_setting('app.cross_org_admin', true) = '1'
+    );

--- a/klai-connector/app/core/database.py
+++ b/klai-connector/app/core/database.py
@@ -1,7 +1,35 @@
-"""Async database engine and session factory for klai-connector."""
+"""Async database engine and session factory for klai-connector.
 
-from collections.abc import AsyncGenerator
+SPEC-SEC-CONNECTOR-RLS-001 — RLS on connector.sync_runs.
 
+PostgreSQL Row-Level Security on ``connector.sync_runs`` requires every
+session to have ``app.current_org_id`` (or ``app.cross_org_admin``) set
+on its physical connection. Three building blocks live here:
+
+1. ``PooledTenantSession`` — AsyncSession subclass that auto-pins the
+   pooled connection AND resets RLS GUCs on ``__aenter__``. Mirrors
+   portal-api's pattern.
+2. ``tenant_scoped_session(org_id)`` — async context manager for normal
+   tenant-bound work. Sets ``app.current_org_id`` to the tenant's
+   Zitadel-resourceowner string before yielding.
+3. ``cross_org_session()`` — async context manager for the legitimate
+   cross-org sites (lifespan crash-recovery, periodic reaper). Sets
+   ``app.cross_org_admin = '1'`` so the policy permits SELECT/UPDATE/
+   DELETE across all tenants. Logs entry/exit at INFO for audit.
+
+The policy is Category D (strict): empty GUC + no cross_org_admin flag
+returns zero rows / blocks INSERT with 42501. That is the loud-failure
+mode we chose over silent cross-tenant leakage.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import AsyncGenerator, AsyncIterator
+from typing import Any
+
+import structlog
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -9,25 +37,120 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 
+logger = structlog.get_logger(__name__)
+
 # Module-level references initialised during app lifespan.
 engine: AsyncEngine | None = None
 session_maker: async_sessionmaker[AsyncSession] | None = None
+
+
+# ---------------------------------------------------------------------------
+# Tenant context — RLS GUC management
+# ---------------------------------------------------------------------------
+
+
+async def _reset_tenant_context(session: AsyncSession) -> None:
+    """Clear app.current_org_id and app.cross_org_admin on the session's connection.
+
+    Called before the connection returns to the pool so the next request /
+    task that picks it up starts with a clean RLS context.
+
+    Rolls back FIRST. If the session is in an aborted-transaction state (e.g.
+    after a 42501 RLS failure from the strict policy), PostgreSQL rejects
+    every subsequent command with "current transaction is aborted" — including
+    our set_config reset. Without the rollback the suppressed exception path
+    would silently leave the leftover tenant context on the pooled connection.
+    Mirrors portal-api/backend/app/core/database.py::_reset_tenant_context.
+    """
+    with contextlib.suppress(Exception):
+        await session.rollback()
+    with contextlib.suppress(Exception):
+        await session.execute(text("SELECT set_config('app.current_org_id', '', false)"))
+    with contextlib.suppress(Exception):
+        await session.execute(text("SELECT set_config('app.cross_org_admin', '', false)"))
+
+
+async def _pin_and_reset_connection(session: AsyncSession) -> None:
+    """Pin the pooled connection AND clear any stale RLS context.
+
+    Two jobs at checkout:
+
+    1. Pin via ``session.connection()`` so subsequent statements use the
+       same physical connection (PostgreSQL ``set_config`` is connection-
+       local).
+    2. Clear stale ``app.current_org_id`` / ``app.cross_org_admin`` from
+       a previous request that may have crashed in mid-cleanup.
+
+    Defense-in-depth at checkout closes the window where a pooled
+    connection returns with a leftover tenant GUC and the next request
+    silently filters by the wrong tenant.
+    """
+    await session.connection()
+    await _reset_tenant_context(session)
+
+
+class PooledTenantSession(AsyncSession):
+    """AsyncSession subclass that auto-pins + resets RLS GUCs at __aenter__.
+
+    Belt-and-braces with explicit ``_pin_and_reset_connection`` calls in
+    helpers below. Direct ``async with session_maker() as s:`` blocks pick
+    up the auto-reset for free; helpers call the explicit version so unit
+    tests with FakeSession (which bypasses the subclass) stay covered.
+    """
+
+    async def __aenter__(self) -> PooledTenantSession:
+        result = await super().__aenter__()
+        await _pin_and_reset_connection(result)
+        return result
+
+
+async def set_tenant(session: AsyncSession, org_id: str) -> None:
+    """Set PostgreSQL session-level tenant context for RLS.
+
+    Uses ``set_config`` with ``is_local=false`` so the setting survives
+    commits within the same connection checkout. The session's caller is
+    responsible for ensuring the connection is pinned (every helper
+    below does so).
+
+    ``org_id`` is the Zitadel-resourceowner string. Empty / whitespace-
+    only values are rejected — they would otherwise let the policy's
+    ``app.current_org_id = ''`` permissive-by-emptiness branch leak rows
+    cross-tenant (which is why we chose Category D in the first place).
+    """
+    if not org_id or not org_id.strip():
+        raise ValueError(
+            "set_tenant requires a non-empty org_id. Empty values would "
+            "bypass RLS (Category D policy returns zero rows on empty "
+            "GUC, but no rows + non-tenant-scoped code is its own bug)."
+        )
+    await session.execute(
+        text("SELECT set_config('app.current_org_id', :org_id, false)"),
+        {"org_id": org_id},
+    )
+
+
+async def _set_cross_org_admin(session: AsyncSession) -> None:
+    """Mark the session as cross-org-admin for the current connection."""
+    await session.execute(text("SELECT set_config('app.cross_org_admin', '1', false)"))
+
+
+# ---------------------------------------------------------------------------
+# Engine init / dispose / dependency injection
+# ---------------------------------------------------------------------------
 
 
 def init_engine(database_url: str) -> AsyncEngine:
     """Create the async engine and session factory.
 
     Must be called once at application startup.
-
-    Args:
-        database_url: PostgreSQL connection string (asyncpg driver).
-
-    Returns:
-        The newly created ``AsyncEngine``.
     """
     global engine, session_maker  # noqa: PLW0603
     engine = create_async_engine(database_url, echo=False, pool_size=10, max_overflow=20)
-    session_maker = async_sessionmaker(engine, expire_on_commit=False)
+    session_maker = async_sessionmaker(
+        engine,
+        class_=PooledTenantSession,
+        expire_on_commit=False,
+    )
     return engine
 
 
@@ -41,8 +164,95 @@ async def dispose_engine() -> None:
 
 
 async def get_session() -> AsyncGenerator[AsyncSession, None]:
-    """FastAPI dependency that yields an async database session."""
+    """FastAPI dependency that yields an async database session.
+
+    The session is pinned + reset on entry. CALLERS that operate inside a
+    tenant-bound request MUST call ``set_tenant(session, org_id)`` before
+    issuing queries against RLS-protected tables — otherwise the strict
+    policy returns zero rows.
+    """
     if session_maker is None:
         raise RuntimeError("Database engine not initialised. Call init_engine() first.")
     async with session_maker() as session:
-        yield session
+        try:
+            yield session
+        finally:
+            await _reset_tenant_context(session)
+
+
+@contextlib.asynccontextmanager
+async def tenant_scoped_session(org_id: str) -> AsyncIterator[AsyncSession]:
+    """Async context manager for tenant-bound work outside a FastAPI request.
+
+    Used by the scheduler, sync_engine, reaper-when-org-known, and any
+    other background path that needs to issue queries on behalf of one
+    specific tenant. Pins the connection, sets ``app.current_org_id``,
+    yields the session, and clears the GUC on exit.
+    """
+    if session_maker is None:
+        raise RuntimeError("Database engine not initialised. Call init_engine() first.")
+    async with session_maker() as session:
+        await _pin_and_reset_connection(session)
+        try:
+            await set_tenant(session, org_id)
+            yield session
+        finally:
+            await _reset_tenant_context(session)
+
+
+@contextlib.asynccontextmanager
+async def cross_org_session() -> AsyncIterator[AsyncSession]:
+    """Async context manager for the legitimate cross-org sites.
+
+    Two callers in klai-connector today:
+    - Lifespan crash-recovery in app/main.py — resets stuck RUNNING runs
+      from a previous crash, no tenant context exists yet.
+    - SyncRunReaper.finalise_stuck_runs — periodic sweep across all
+      tenants for runs that hung past the deadline.
+
+    Sets ``app.cross_org_admin = '1'`` so the policy's escape branch
+    permits SELECT / UPDATE / DELETE across all tenants. Logs entry +
+    exit at INFO so any unexpected use shows up in VictoriaLogs queries
+    (`service:klai-connector AND event:cross_org_session_*`).
+
+    Adding a third caller? Document the rationale here. Cross-org access
+    is the bug-class we are protecting against; every legitimate use
+    should be small and auditable.
+    """
+    if session_maker is None:
+        raise RuntimeError("Database engine not initialised. Call init_engine() first.")
+    logger.info("cross_org_session_entered")
+    async with session_maker() as session:
+        await _pin_and_reset_connection(session)
+        try:
+            await _set_cross_org_admin(session)
+            yield session
+        finally:
+            await _reset_tenant_context(session)
+            logger.info("cross_org_session_exited")
+
+
+# ---------------------------------------------------------------------------
+# Module exports
+# ---------------------------------------------------------------------------
+
+__all__: list[str] = [
+    "PooledTenantSession",
+    "cross_org_session",
+    "dispose_engine",
+    "engine",
+    "get_session",
+    "init_engine",
+    "session_maker",
+    "set_tenant",
+    "tenant_scoped_session",
+]
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - module-level dynamic access
+    """Fallback so module-level reads of ``engine`` / ``session_maker`` see the
+    current global value rather than the import-time ``None``.
+    """
+    if name in {"engine", "session_maker"}:
+        return globals()[name]
+    raise AttributeError(name)

--- a/klai-connector/app/core/database.py
+++ b/klai-connector/app/core/database.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 
 import contextlib
 from collections.abc import AsyncGenerator, AsyncIterator
-from typing import Any
 
 import structlog
 from sqlalchemy import text
@@ -204,24 +203,27 @@ async def tenant_scoped_session(org_id: str) -> AsyncIterator[AsyncSession]:
 async def cross_org_session() -> AsyncIterator[AsyncSession]:
     """Async context manager for the legitimate cross-org sites.
 
-    Two callers in klai-connector today:
-    - Lifespan crash-recovery in app/main.py — resets stuck RUNNING runs
-      from a previous crash, no tenant context exists yet.
+    Three callers in klai-connector today:
+    - Lifespan crash-recovery in app/main.py — resets stuck RUNNING
+      runs from a previous crash, no tenant context exists yet.
     - SyncRunReaper.finalise_stuck_runs — periodic sweep across all
       tenants for runs that hung past the deadline.
+    - ConnectorScheduler.start — bootstraps cron schedules across all
+      tenants at app startup.
 
     Sets ``app.cross_org_admin = '1'`` so the policy's escape branch
-    permits SELECT / UPDATE / DELETE across all tenants. Logs entry +
-    exit at INFO so any unexpected use shows up in VictoriaLogs queries
-    (`service:klai-connector AND event:cross_org_session_*`).
+    permits SELECT / UPDATE / DELETE across all tenants. Entry / exit
+    are logged at DEBUG (queryable in dev / when VictoriaLogs filter
+    enables debug for klai-connector); the reaper ticks every 5 min,
+    so INFO would dominate the log volume without payoff.
 
-    Adding a third caller? Document the rationale here. Cross-org access
-    is the bug-class we are protecting against; every legitimate use
-    should be small and auditable.
+    Adding a fourth caller? Document the rationale here. Cross-org
+    access is the bug-class we are protecting against; every
+    legitimate use should be small and auditable.
     """
     if session_maker is None:
         raise RuntimeError("Database engine not initialised. Call init_engine() first.")
-    logger.info("cross_org_session_entered")
+    logger.debug("cross_org_session_entered")
     async with session_maker() as session:
         await _pin_and_reset_connection(session)
         try:
@@ -229,7 +231,7 @@ async def cross_org_session() -> AsyncIterator[AsyncSession]:
             yield session
         finally:
             await _reset_tenant_context(session)
-            logger.info("cross_org_session_exited")
+            logger.debug("cross_org_session_exited")
 
 
 # ---------------------------------------------------------------------------
@@ -247,12 +249,3 @@ __all__: list[str] = [
     "set_tenant",
     "tenant_scoped_session",
 ]
-
-
-def __getattr__(name: str) -> Any:  # pragma: no cover - module-level dynamic access
-    """Fallback so module-level reads of ``engine`` / ``session_maker`` see the
-    current global value rather than the import-time ``None``.
-    """
-    if name in {"engine", "session_maker"}:
-        return globals()[name]
-    raise AttributeError(name)

--- a/klai-connector/app/main.py
+++ b/klai-connector/app/main.py
@@ -21,7 +21,7 @@ from app.adapters.notion import NotionAdapter
 from app.adapters.registry import AdapterRegistry
 from app.clients.knowledge_ingest import KnowledgeIngestClient
 from app.core.config import Settings
-from app.core.database import dispose_engine, init_engine
+from app.core.database import cross_org_session, dispose_engine, init_engine
 from app.core.enums import SyncStatus
 from app.core.logging import RequestContextMiddleware, get_logger, setup_logging
 from app.core.security import AESGCMCipher
@@ -65,16 +65,23 @@ def create_app() -> FastAPI:
         # holds ``remote_job_id``, and :class:`SyncRunResolver` finalises
         # them at read time. Resetting those to PENDING orphans them
         # (resolver only resolves RUNNING rows). Skip them here.
+        #
+        # SPEC-SEC-CONNECTOR-RLS-001: this is one of two legitimate cross-
+        # tenant code paths in klai-connector (the other is
+        # SyncRunReaper.finalise_stuck_runs). No tenant context exists at
+        # lifespan time and there is no caller to derive an org_id from.
+        # cross_org_session() sets app.cross_org_admin = '1' so the new
+        # RLS policy on connector.sync_runs permits the cross-org UPDATE.
+        # Logged at INFO so any unexpected use shows up in VictoriaLogs.
         if _db.session_maker is not None:
-            async with _db.session_maker() as session:
+            async with cross_org_session() as session:
                 await session.execute(
                     update(SyncRun)
                     .where(SyncRun.status == SyncStatus.RUNNING)
                     .where(
                         # RUNNING with remote_job_id => delegated, leave alone.
                         # No JSONB key, or key absent => historical inline run, reset.
-                        (SyncRun.cursor_state.is_(None))
-                        | (SyncRun.cursor_state["remote_job_id"].astext.is_(None))  # type: ignore[index]
+                        (SyncRun.cursor_state.is_(None)) | (SyncRun.cursor_state["remote_job_id"].astext.is_(None))  # type: ignore[index]
                     )
                     .values(status=SyncStatus.PENDING, completed_at=datetime.now(UTC))
                 )
@@ -109,19 +116,11 @@ def create_app() -> FastAPI:
             # All three aliases reuse the same GoogleDriveAdapter instance; the
             # adapter's _extract_config injects a content_types preset based on
             # connector.connector_type.
-            registry.register_alias(
-                "google_docs", "google_drive", {"content_types": ["google_doc"]}
-            )
-            registry.register_alias(
-                "google_sheets", "google_drive", {"content_types": ["google_sheet"]}
-            )
-            registry.register_alias(
-                "google_slides", "google_drive", {"content_types": ["google_slides"]}
-            )
+            registry.register_alias("google_docs", "google_drive", {"content_types": ["google_doc"]})
+            registry.register_alias("google_sheets", "google_drive", {"content_types": ["google_sheet"]})
+            registry.register_alias("google_slides", "google_drive", {"content_types": ["google_slides"]})
         else:
-            logger.warning(
-                "google_drive adapter not registered — GOOGLE_DRIVE_CLIENT_ID unset"
-            )
+            logger.warning("google_drive adapter not registered — GOOGLE_DRIVE_CLIENT_ID unset")
         # Microsoft 365 adapter (SPEC-KB-MS-DOCS-001) — conditional on OAuth client.
         if settings.ms_docs_client_id:
             registry.register(
@@ -129,9 +128,7 @@ def create_app() -> FastAPI:
                 MsDocsAdapter(settings=settings, portal_client=portal_client),
             )
         else:
-            logger.warning(
-                "ms_docs adapter not registered — MS_DOCS_CLIENT_ID unset"
-            )
+            logger.warning("ms_docs adapter not registered — MS_DOCS_CLIENT_ID unset")
         app.state.registry = registry
 
         # Knowledge-ingest client

--- a/klai-connector/app/main.py
+++ b/klai-connector/app/main.py
@@ -195,7 +195,7 @@ def create_app() -> FastAPI:
         # Scheduler
         scheduler = ConnectorScheduler()
         app.state.scheduler = scheduler
-        await scheduler.start(_db.session_maker, sync_engine.run_sync)
+        await scheduler.start(sync_engine.run_sync)
 
         logger.info("klai-connector started successfully")
         yield

--- a/klai-connector/app/main.py
+++ b/klai-connector/app/main.py
@@ -163,7 +163,6 @@ def create_app() -> FastAPI:
         if _db.session_maker is None:
             raise RuntimeError("Database session maker not initialised")
         sync_engine = SyncEngine(
-            session_maker=_db.session_maker,
             registry=registry,
             ingest_client=ingest_client,
             portal_client=portal_client,
@@ -187,7 +186,6 @@ def create_app() -> FastAPI:
         # sync_runs that nobody reads via the resolver-on-read path.
         reaper = SyncRunReaper(
             crawl_sync_client=crawl_sync_client,
-            session_maker=_db.session_maker,
             portal_client=portal_client,
         )
         reaper_task = asyncio.create_task(reaper.async_run())

--- a/klai-connector/app/routes/sync.py
+++ b/klai-connector/app/routes/sync.py
@@ -7,7 +7,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import Settings
-from app.core.database import get_session
+from app.core.database import get_session, set_tenant
 from app.core.enums import SyncStatus
 from app.core.logging import get_logger
 from app.models.sync_run import SyncRun
@@ -85,6 +85,15 @@ async def trigger_sync(
     _require_portal_call(request)
     org_id = _require_portal_org_id(request, settings)
 
+    # SPEC-SEC-CONNECTOR-RLS-001: bind tenant context for RLS on
+    # connector.sync_runs. Without this the strict policy returns zero
+    # rows on SELECT and refuses INSERT with 42501. The route already
+    # rejects None below — this set_tenant call is a no-op on legacy
+    # transition paths where org_id is None (set_tenant raises on empty,
+    # so we guard).
+    if org_id is not None:
+        await set_tenant(session, org_id)
+
     # Active-sync guard. SPEC-SEC-TENANT-001 REQ-7.4: when org_id is
     # asserted, scope the guard so one tenant's running sync cannot block
     # another tenant's trigger attempt for the same connector_id (which
@@ -127,7 +136,7 @@ async def trigger_sync(
 
     sync_engine = getattr(request.app.state, "sync_engine", None)
     if sync_engine:
-        background_tasks.add_task(sync_engine.run_sync, connector_id, sync_run.id)
+        background_tasks.add_task(sync_engine.run_sync, connector_id, sync_run.id, org_id)
 
     logger.info(
         "Sync triggered for connector %s",
@@ -166,6 +175,12 @@ async def list_sync_runs(
     """
     _require_portal_call(request)
     org_id = _require_portal_org_id(request, settings)
+
+    # SPEC-SEC-CONNECTOR-RLS-001: bind tenant for RLS. None during
+    # transition path leaves the GUC empty — strict policy returns 0
+    # rows, which mirrors the legacy "missing X-Org-ID = no data".
+    if org_id is not None:
+        await set_tenant(session, org_id)
 
     query = (
         select(SyncRun)
@@ -219,6 +234,10 @@ async def get_sync_run(
     """
     _require_portal_call(request)
     org_id = _require_portal_org_id(request, settings)
+
+    # SPEC-SEC-CONNECTOR-RLS-001: bind tenant for RLS on the row lookup.
+    if org_id is not None:
+        await set_tenant(session, org_id)
 
     sync_run = await session.get(SyncRun, run_id)
     if sync_run is None or sync_run.connector_id != connector_id:

--- a/klai-connector/app/services/scheduler.py
+++ b/klai-connector/app/services/scheduler.py
@@ -8,6 +8,7 @@ from apscheduler.triggers.cron import CronTrigger
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from app.core.database import cross_org_session, tenant_scoped_session
 from app.core.enums import SyncStatus
 from app.core.logging import get_logger
 from app.models.connector import Connector
@@ -21,6 +22,13 @@ class ConnectorScheduler:
 
     Each connector with a ``schedule`` (cron expression) gets a corresponding
     APScheduler job that triggers sync execution.
+
+    SPEC-SEC-CONNECTOR-RLS-001: every scheduled job carries the
+    ``connector.org_id`` (Zitadel resourceowner string) through the
+    APScheduler ``args`` so the trigger callback can bind RLS tenant
+    context before INSERTing the SyncRun. The bootstrap that loads
+    schedules at app startup is a legitimate cross-org operation and
+    runs through ``cross_org_session()``.
     """
 
     def __init__(self) -> None:
@@ -36,13 +44,22 @@ class ConnectorScheduler:
 
         Args:
             session_maker: Async session factory.
-            sync_callback: Callable ``(connector_id: UUID, sync_run_id: UUID) -> Coroutine``
-                to invoke when a scheduled sync fires. Typically ``SyncEngine.run_sync``.
+            sync_callback: Callable
+                ``(connector_id: UUID, sync_run_id: UUID, org_id: str) -> Coroutine``
+                to invoke when a scheduled sync fires. Typically
+                ``SyncEngine.run_sync``.
+
+        SPEC-SEC-CONNECTOR-RLS-001: the ``select(Connector)`` here loads
+        schedules across all tenants — by definition a cross-org
+        operation, run via ``cross_org_session()`` so the RLS policy
+        permits the read. ``session_maker`` is kept on the signature
+        for backward compatibility with existing callers / tests, but
+        the bootstrap session itself comes from ``cross_org_session()``.
         """
         self._sync_callback = sync_callback
         self._scheduler.start()
 
-        async with session_maker() as session:
+        async with cross_org_session() as session:
             result = await session.execute(
                 select(Connector).where(
                     Connector.is_enabled.is_(True),
@@ -60,8 +77,11 @@ class ConnectorScheduler:
 
         If a job already exists for this connector, it is replaced.
 
-        Args:
-            connector: Connector model with a non-null ``schedule`` field.
+        SPEC-SEC-CONNECTOR-RLS-001: ``connector.org_id`` is registered
+        as the second APScheduler arg so ``_trigger_sync`` can bind
+        tenant context for the SyncRun INSERT. The Connector model's
+        ``org_id`` is non-NULL (SPEC-SEC-TENANT-001 REQ-7.x) so this
+        is always populated for any row that reaches the scheduler.
         """
         if not connector.schedule:
             return
@@ -72,7 +92,7 @@ class ConnectorScheduler:
                 self._trigger_sync,
                 trigger=CronTrigger.from_crontab(connector.schedule),
                 id=job_id,
-                args=[connector.id],
+                args=[connector.id, connector.org_id],
                 replace_existing=True,
             )
             logger.info("Scheduled job for connector %s: %s", connector.id, connector.schedule)
@@ -90,25 +110,41 @@ class ConnectorScheduler:
             self._scheduler.remove_job(job_id)
             logger.info("Removed scheduled job for connector %s", connector_id)
 
-    async def _trigger_sync(self, connector_id: uuid.UUID) -> None:
+    async def _trigger_sync(self, connector_id: uuid.UUID, org_id: str) -> None:
         """Callback invoked by APScheduler to start a sync.
 
-        Creates a SyncRun record and delegates to the sync engine.
-        """
-        from app.core.database import session_maker as db_session_maker
+        Creates a SyncRun record under the tenant's RLS context and
+        delegates to the sync engine.
 
-        if db_session_maker is None or self._sync_callback is None:
-            logger.error("Cannot trigger scheduled sync: database or sync engine not initialised")
+        Args:
+            connector_id: Connector UUID. Forwarded to the sync engine.
+            org_id: Zitadel-resourceowner string (the connector's tenant).
+                Used to bind ``app.current_org_id`` for the SyncRun
+                INSERT, and forwarded to the sync engine so its
+                background work runs under the same tenant context.
+        """
+        if self._sync_callback is None:
+            logger.error("Cannot trigger scheduled sync: sync engine not initialised")
             return
 
-        async with db_session_maker() as session:
-            sync_run = SyncRun(connector_id=connector_id, status=SyncStatus.RUNNING)
+        async with tenant_scoped_session(org_id) as session:
+            sync_run = SyncRun(
+                connector_id=connector_id,
+                org_id=org_id,
+                status=SyncStatus.RUNNING,
+            )
             session.add(sync_run)
             await session.commit()
             await session.refresh(sync_run)
 
-        asyncio.create_task(self._sync_callback(connector_id, sync_run.id))  # type: ignore[operator]
-        logger.info("Scheduled sync triggered for connector %s", connector_id)
+        asyncio.create_task(  # type: ignore[operator]
+            self._sync_callback(connector_id, sync_run.id, org_id),
+        )
+        logger.info(
+            "Scheduled sync triggered for connector %s",
+            connector_id,
+            extra={"connector_id": str(connector_id), "org_id": org_id},
+        )
 
     async def shutdown(self) -> None:
         """Shut down the scheduler."""

--- a/klai-connector/app/services/scheduler.py
+++ b/klai-connector/app/services/scheduler.py
@@ -6,7 +6,6 @@ import uuid
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.core.database import cross_org_session, tenant_scoped_session
 from app.core.enums import SyncStatus
@@ -35,15 +34,10 @@ class ConnectorScheduler:
         self._scheduler = AsyncIOScheduler()
         self._sync_callback: object | None = None
 
-    async def start(
-        self,
-        session_maker: async_sessionmaker[AsyncSession],
-        sync_callback: object,
-    ) -> None:
+    async def start(self, sync_callback: object) -> None:
         """Start the scheduler and load all enabled connectors with schedules.
 
         Args:
-            session_maker: Async session factory.
             sync_callback: Callable
                 ``(connector_id: UUID, sync_run_id: UUID, org_id: str) -> Coroutine``
                 to invoke when a scheduled sync fires. Typically
@@ -52,9 +46,9 @@ class ConnectorScheduler:
         SPEC-SEC-CONNECTOR-RLS-001: the ``select(Connector)`` here loads
         schedules across all tenants — by definition a cross-org
         operation, run via ``cross_org_session()`` so the RLS policy
-        permits the read. ``session_maker`` is kept on the signature
-        for backward compatibility with existing callers / tests, but
-        the bootstrap session itself comes from ``cross_org_session()``.
+        permits the read. No ``session_maker`` arg — sessions come from
+        the module-level factory in ``app.core.database`` via
+        ``cross_org_session()`` / ``tenant_scoped_session()``.
         """
         self._sync_callback = sync_callback
         self._scheduler.start()

--- a/klai-connector/app/services/sync_engine.py
+++ b/klai-connector/app/services/sync_engine.py
@@ -24,7 +24,7 @@ from klai_image_storage import (
     download_and_upload_adapter_images,
 )
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.adapters.base import DocumentRef
 from app.adapters.oauth_base import OAuthReconnectRequiredError
@@ -74,10 +74,15 @@ class SyncEngine:
     the single source of truth — no local config copy is required.
 
     Args:
-        session_maker: Async session factory for database access.
         registry: Adapter registry mapping connector types to adapters.
         ingest_client: Client for the knowledge-ingest service.
         portal_client: Client for the portal control plane API.
+
+    SPEC-SEC-CONNECTOR-RLS-001: SyncEngine no longer takes a
+    ``session_maker``; all DB access goes through
+    ``tenant_scoped_session(org_id)`` from ``app.core.database``,
+    which uses the module-level session_maker initialised by
+    ``init_engine`` at lifespan startup.
     """
 
     # SPEC-CRAWLER-006: web_crawler delegation is fire-and-forget — the
@@ -87,7 +92,6 @@ class SyncEngine:
 
     def __init__(
         self,
-        session_maker: async_sessionmaker[AsyncSession],
         registry: AdapterRegistry,
         ingest_client: KnowledgeIngestClient,
         portal_client: PortalClient,
@@ -95,7 +99,6 @@ class SyncEngine:
         image_store: ImageStore | None = None,
         crawl_sync_client: CrawlSyncClient | None = None,
     ) -> None:
-        self._session_maker = session_maker
         self._registry = registry
         self._ingest_client = ingest_client
         self._portal_client = portal_client

--- a/klai-connector/app/services/sync_engine.py
+++ b/klai-connector/app/services/sync_engine.py
@@ -31,6 +31,7 @@ from app.adapters.oauth_base import OAuthReconnectRequiredError
 from app.adapters.registry import AdapterRegistry
 from app.clients.knowledge_ingest import CrawlSyncClient, KnowledgeIngestClient
 from app.core.config import Settings
+from app.core.database import tenant_scoped_session
 from app.core.enums import SyncStatus
 from app.core.logging import get_logger
 from app.core.sanitize import sanitize_response_body  # SPEC-SEC-INTERNAL-001 REQ-4 + REQ-10
@@ -112,7 +113,8 @@ class SyncEngine:
         if image_store:
             self._image_transport = PinnedResolverTransport()
             self._image_http = httpx.AsyncClient(
-                transport=self._image_transport, timeout=30.0,
+                transport=self._image_transport,
+                timeout=30.0,
             )
         else:
             self._image_transport = None
@@ -127,7 +129,12 @@ class SyncEngine:
             self._connector_locks[connector_id] = asyncio.Lock()
         return self._connector_locks[connector_id]
 
-    async def run_sync(self, connector_id: uuid.UUID, sync_run_id: uuid.UUID) -> None:
+    async def run_sync(
+        self,
+        connector_id: uuid.UUID,
+        sync_run_id: uuid.UUID,
+        org_id: str,
+    ) -> None:
         """Execute a full sync cycle for a connector.
 
         Designed to be called as a background task. Skips silently if a sync
@@ -137,6 +144,12 @@ class SyncEngine:
         Args:
             connector_id: UUID of the connector to sync (portal_connectors.id).
             sync_run_id: UUID of the pre-created SyncRun record.
+            org_id: Zitadel-resourceowner string (the connector's tenant).
+                SPEC-SEC-CONNECTOR-RLS-001: required so every internal
+                session can bind ``app.current_org_id`` for RLS. Both
+                callers (``routes/sync.py:trigger_sync`` and
+                ``ConnectorScheduler._trigger_sync``) have it available
+                at the moment they enqueue this background task.
         """
         lock = self._get_connector_lock(connector_id)
         if lock.locked():
@@ -144,9 +157,14 @@ class SyncEngine:
             return
 
         async with lock, self._global_semaphore:
-            await self._execute_sync(connector_id, sync_run_id)
+            await self._execute_sync(connector_id, sync_run_id, org_id)
 
-    async def _execute_sync(self, connector_id: uuid.UUID, sync_run_id: uuid.UUID) -> None:
+    async def _execute_sync(
+        self,
+        connector_id: uuid.UUID,
+        sync_run_id: uuid.UUID,
+        org_id: str,
+    ) -> None:
         """Internal sync execution with full error handling and metrics."""
         start_time = time.monotonic()
         documents_total = 0
@@ -169,11 +187,15 @@ class SyncEngine:
                 exc.response.status_code,
                 connector_id,
             )
-            await self._fail_sync_run(sync_run_id, f"Portal config fetch failed: HTTP {exc.response.status_code}")
+            await self._fail_sync_run(
+                sync_run_id,
+                org_id,
+                f"Portal config fetch failed: HTTP {exc.response.status_code}",
+            )
             return
         except Exception:
             logger.exception("Failed to fetch connector config from portal for %s", connector_id)
-            await self._fail_sync_run(sync_run_id, "Portal config fetch failed")
+            await self._fail_sync_run(sync_run_id, org_id, "Portal config fetch failed")
             return
 
         # SPEC-CRAWLER-004 Fase D: delegate web_crawler syncs to
@@ -181,19 +203,17 @@ class SyncEngine:
         # instead it POSTs the config to /ingest/v1/crawl/sync and polls
         # the returned job_id. Keeps sync_runs ownership + product_events
         # on the connector side; moves pipeline execution to ingest.
-        if (
-            portal_config.connector_type == "web_crawler"
-            and self._crawl_sync_client is not None
-        ):
+        if portal_config.connector_type == "web_crawler" and self._crawl_sync_client is not None:
             await self._run_web_crawler_delegation(
                 portal_config=portal_config,
                 connector_id=connector_id,
                 sync_run_id=sync_run_id,
+                org_id=org_id,
                 start_time=start_time,
             )
             return
 
-        async with self._session_maker() as session:
+        async with tenant_scoped_session(org_id) as session:
             sync_run = await session.get(SyncRun, sync_run_id)
             if sync_run is None:
                 logger.error("SyncRun not found: %s", sync_run_id)
@@ -429,11 +449,13 @@ class SyncEngine:
                 # client or HTTP request was issued — the guard fired
                 # inside ``_extract_config``.
                 status = SyncStatus.FAILED
-                error_details.append({
-                    "error": err.error_code,
-                    "hostname": err.hostname or "",
-                    "reason": str(err),
-                })
+                error_details.append(
+                    {
+                        "error": err.error_code,
+                        "hostname": err.hostname or "",
+                        "reason": str(err),
+                    }
+                )
                 logger.warning(
                     "Sync blocked for connector %s: persisted URL failed SSRF guard",
                     connector_id,
@@ -511,6 +533,7 @@ class SyncEngine:
         portal_config: Any,
         connector_id: uuid.UUID,
         sync_run_id: uuid.UUID,
+        org_id: str,
         start_time: float,
     ) -> None:
         """SPEC-CRAWLER-006 fire-and-forget delegation path.
@@ -535,7 +558,7 @@ class SyncEngine:
         """
         assert self._crawl_sync_client is not None
 
-        async with self._session_maker() as session:
+        async with tenant_scoped_session(org_id) as session:
             sync_run = await session.get(SyncRun, sync_run_id)
             if sync_run is None:
                 logger.error("SyncRun not found: %s", sync_run_id)
@@ -720,9 +743,21 @@ class SyncEngine:
             pin_transport=self._image_transport,
         )
 
-    async def _fail_sync_run(self, sync_run_id: uuid.UUID, error_message: str) -> None:
-        """Mark a sync run as failed without a full portal config."""
-        async with self._session_maker() as session:
+    async def _fail_sync_run(
+        self,
+        sync_run_id: uuid.UUID,
+        org_id: str,
+        error_message: str,
+    ) -> None:
+        """Mark a sync run as failed without a full portal config.
+
+        SPEC-SEC-CONNECTOR-RLS-001: ``org_id`` is required so the RLS
+        policy on ``connector.sync_runs`` permits the UPDATE. Without
+        a bound tenant the strict policy returns zero rows on the
+        ``session.get(SyncRun, ...)`` lookup and the failure status
+        never lands.
+        """
+        async with tenant_scoped_session(org_id) as session:
             sync_run = await session.get(SyncRun, sync_run_id)
             if sync_run:
                 sync_run.status = SyncStatus.FAILED

--- a/klai-connector/app/services/sync_run_reaper.py
+++ b/klai-connector/app/services/sync_run_reaper.py
@@ -27,17 +27,14 @@ lifecycle is the source of truth on whether a job should still be alive.
 from __future__ import annotations
 
 import asyncio
-import contextlib
-from collections.abc import AsyncIterator
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import httpx
-from sqlalchemy import and_, select, text
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy import and_, select
 
 from app.clients.knowledge_ingest import CrawlSyncClient
-from app.core.database import _pin_and_reset_connection, _set_cross_org_admin
+from app.core.database import cross_org_session
 from app.core.enums import SyncStatus
 from app.core.logging import get_logger
 from app.models.sync_run import SyncRun
@@ -64,46 +61,16 @@ class SyncRunReaper:
         self,
         *,
         crawl_sync_client: CrawlSyncClient,
-        session_maker: async_sessionmaker[AsyncSession],
         portal_client: PortalClient,
         tick_seconds: float = _TICK_S,
         finalize_after_seconds: float = _FINALIZE_AFTER_S,
         force_fail_after_seconds: float = _FORCE_FAIL_AFTER_S,
     ) -> None:
         self._crawl_sync_client = crawl_sync_client
-        self._session_maker = session_maker
         self._portal_client = portal_client
         self._tick = tick_seconds
         self._finalize_after = finalize_after_seconds
         self._force_fail_after = force_fail_after_seconds
-
-    @contextlib.asynccontextmanager
-    async def _cross_org_session(self) -> AsyncIterator[AsyncSession]:
-        """Yield a cross-org session for SyncRun queries.
-
-        SPEC-SEC-CONNECTOR-RLS-001: the reaper sweeps stuck runs across
-        all tenants by design (no caller, no tenant context). Sets
-        ``app.cross_org_admin = '1'`` so the RLS policy on
-        ``connector.sync_runs`` permits SELECT/UPDATE across tenants.
-        Centralised here so every reaper session goes through the same
-        binding and a future refactor cannot accidentally drop it on one
-        of the three call sites (scan / finalise_completed /
-        finalise_failed). Uses ``self._session_maker`` so unit tests can
-        mock the underlying factory while the GUC binding remains
-        production-realistic.
-        """
-        async with self._session_maker() as session:
-            await _pin_and_reset_connection(session)
-            try:
-                await _set_cross_org_admin(session)
-                yield session
-            finally:
-                # Cleanup mirrors database._reset_tenant_context — best-
-                # effort, suppressed on aborted-transaction state.
-                with contextlib.suppress(Exception):
-                    await session.rollback()
-                with contextlib.suppress(Exception):
-                    await session.execute(text("SELECT set_config('app.cross_org_admin', '', false)"))
 
     async def async_run(self) -> None:
         """Run forever, ticking at the configured interval.
@@ -141,7 +108,7 @@ class SyncRunReaper:
         force_fail_cutoff = datetime.now(UTC) - timedelta(seconds=self._force_fail_after)
 
         finalised = 0
-        async with self._cross_org_session() as session:
+        async with cross_org_session() as session:
             stmt = select(SyncRun).where(
                 and_(
                     SyncRun.status == SyncStatus.RUNNING,
@@ -232,7 +199,7 @@ class SyncRunReaper:
         pages_total: int,
     ) -> None:
         completed_at = datetime.now(UTC)
-        async with self._cross_org_session() as session:
+        async with cross_org_session() as session:
             # FOR UPDATE — see SyncRunResolver._finalize for the same
             # rationale (block concurrent finalisers; second reader
             # short-circuits on the post-commit non-RUNNING read).
@@ -287,7 +254,7 @@ class SyncRunReaper:
                 "remote_job_id": str(remote_job_id) if remote_job_id else None,
             },
         ]
-        async with self._cross_org_session() as session:
+        async with cross_org_session() as session:
             db_row = await session.get(SyncRun, row.id, with_for_update=True)
             if db_row is None or db_row.status != SyncStatus.RUNNING:
                 return

--- a/klai-connector/app/services/sync_run_reaper.py
+++ b/klai-connector/app/services/sync_run_reaper.py
@@ -27,14 +27,17 @@ lifecycle is the source of truth on whether a job should still be alive.
 from __future__ import annotations
 
 import asyncio
+import contextlib
+from collections.abc import AsyncIterator
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import httpx
-from sqlalchemy import and_, select
+from sqlalchemy import and_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.clients.knowledge_ingest import CrawlSyncClient
+from app.core.database import _pin_and_reset_connection, _set_cross_org_admin
 from app.core.enums import SyncStatus
 from app.core.logging import get_logger
 from app.models.sync_run import SyncRun
@@ -74,6 +77,34 @@ class SyncRunReaper:
         self._finalize_after = finalize_after_seconds
         self._force_fail_after = force_fail_after_seconds
 
+    @contextlib.asynccontextmanager
+    async def _cross_org_session(self) -> AsyncIterator[AsyncSession]:
+        """Yield a cross-org session for SyncRun queries.
+
+        SPEC-SEC-CONNECTOR-RLS-001: the reaper sweeps stuck runs across
+        all tenants by design (no caller, no tenant context). Sets
+        ``app.cross_org_admin = '1'`` so the RLS policy on
+        ``connector.sync_runs`` permits SELECT/UPDATE across tenants.
+        Centralised here so every reaper session goes through the same
+        binding and a future refactor cannot accidentally drop it on one
+        of the three call sites (scan / finalise_completed /
+        finalise_failed). Uses ``self._session_maker`` so unit tests can
+        mock the underlying factory while the GUC binding remains
+        production-realistic.
+        """
+        async with self._session_maker() as session:
+            await _pin_and_reset_connection(session)
+            try:
+                await _set_cross_org_admin(session)
+                yield session
+            finally:
+                # Cleanup mirrors database._reset_tenant_context — best-
+                # effort, suppressed on aborted-transaction state.
+                with contextlib.suppress(Exception):
+                    await session.rollback()
+                with contextlib.suppress(Exception):
+                    await session.execute(text("SELECT set_config('app.cross_org_admin', '', false)"))
+
     async def async_run(self) -> None:
         """Run forever, ticking at the configured interval.
 
@@ -110,7 +141,7 @@ class SyncRunReaper:
         force_fail_cutoff = datetime.now(UTC) - timedelta(seconds=self._force_fail_after)
 
         finalised = 0
-        async with self._session_maker() as session:
+        async with self._cross_org_session() as session:
             stmt = select(SyncRun).where(
                 and_(
                     SyncRun.status == SyncStatus.RUNNING,
@@ -194,10 +225,14 @@ class SyncRunReaper:
         return False
 
     async def _finalise_completed(
-        self, row: SyncRun, *, pages_done: int, pages_total: int,
+        self,
+        row: SyncRun,
+        *,
+        pages_done: int,
+        pages_total: int,
     ) -> None:
         completed_at = datetime.now(UTC)
-        async with self._session_maker() as session:
+        async with self._cross_org_session() as session:
             # FOR UPDATE — see SyncRunResolver._finalize for the same
             # rationale (block concurrent finalisers; second reader
             # short-circuits on the post-commit non-RUNNING read).
@@ -252,7 +287,7 @@ class SyncRunReaper:
                 "remote_job_id": str(remote_job_id) if remote_job_id else None,
             },
         ]
-        async with self._session_maker() as session:
+        async with self._cross_org_session() as session:
             db_row = await session.get(SyncRun, row.id, with_for_update=True)
             if db_row is None or db_row.status != SyncStatus.RUNNING:
                 return

--- a/klai-connector/tests/services/test_sync_run_reaper.py
+++ b/klai-connector/tests/services/test_sync_run_reaper.py
@@ -42,6 +42,7 @@ def _row(
 
 
 def _make_reaper(
+    monkeypatch: pytest.MonkeyPatch,
     *,
     candidate_rows: list[MagicMock],
     status_responses: list[dict | Exception] | None = None,
@@ -50,6 +51,11 @@ def _make_reaper(
 ) -> tuple[SyncRunReaper, MagicMock, MagicMock, MagicMock, dict]:
     """Build a reaper wired to mocks. Returns
     (reaper, crawl_client, session_mock, portal_client, registry).
+
+    SPEC-SEC-CONNECTOR-RLS-001: the reaper now opens its sessions via
+    the public ``cross_org_session()`` in app.core.database, which uses
+    the module-level ``session_maker``. Monkeypatch that so the mock
+    factory is reached AND the GUC-binding code path stays exercised.
     """
     crawl_client = MagicMock()
     if status_responses is not None:
@@ -63,8 +69,6 @@ def _make_reaper(
     # Registry maps row.id -> row mock for session.get inside _finalise_*.
     registry: dict = {r.id: r for r in candidate_rows}
 
-    # Two distinct session-mock factories: one for the SELECT (returns
-    # the candidate list), one for the per-row UPDATE inside _finalise_*.
     def _make_session() -> MagicMock:
         sess = MagicMock()
         sess.__aenter__ = AsyncMock(return_value=sess)
@@ -75,22 +79,23 @@ def _make_reaper(
         sess.execute = AsyncMock(return_value=result)
         sess.get = AsyncMock(side_effect=lambda model, row_id, **kwargs: registry.get(row_id))
         sess.commit = AsyncMock()
-        # SPEC-SEC-CONNECTOR-RLS-001: the reaper's _cross_org_session
-        # calls session.connection() (pin) + session.rollback() (reset
-        # cleanup) in addition to execute/get/commit. Mock both as async
-        # so the GUC-binding code path stays exercised.
+        # cross_org_session calls session.connection() (pin) +
+        # session.rollback() (reset cleanup) in addition to
+        # execute/get/commit. Mock both async.
         sess.connection = AsyncMock(return_value=MagicMock())
         sess.rollback = AsyncMock()
         return sess
 
     session_maker = MagicMock(side_effect=_make_session)
+    import app.core.database as _db_module  # noqa: PLC0415
+
+    monkeypatch.setattr(_db_module, "session_maker", session_maker)
 
     portal_client = MagicMock()
     portal_client.report_sync_status = AsyncMock()
 
     reaper = SyncRunReaper(
         crawl_sync_client=crawl_client,
-        session_maker=session_maker,
         portal_client=portal_client,
         tick_seconds=1.0,
         finalize_after_seconds=finalize_after_h * 3600.0,
@@ -103,10 +108,11 @@ class TestReaperFinalisesTerminalRemote:
     """AC-06.1: a remote job that has terminated is reflected in the local row."""
 
     @pytest.mark.asyncio
-    async def test_completed_remote_writes_terminal_state_and_reports(self) -> None:
+    async def test_completed_remote_writes_terminal_state_and_reports(self, monkeypatch: pytest.MonkeyPatch) -> None:
         old = datetime.now(UTC) - timedelta(hours=25)
         row = _row(started_at=old)
         reaper, crawl_client, _, portal, _ = _make_reaper(
+            monkeypatch,
             candidate_rows=[row],
             status_responses=[
                 {"job_id": "abc123", "status": "completed", "pages_done": 100, "pages_total": 100, "error": None},
@@ -127,10 +133,11 @@ class TestReaperFinalisesTerminalRemote:
         crawl_client.crawl_sync_cancel.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_failed_remote_writes_failed_with_error(self) -> None:
+    async def test_failed_remote_writes_failed_with_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
         old = datetime.now(UTC) - timedelta(hours=25)
         row = _row(started_at=old)
         reaper, _, _, portal, _ = _make_reaper(
+            monkeypatch,
             candidate_rows=[row],
             status_responses=[
                 {
@@ -159,7 +166,7 @@ class TestReaper404IsRemoteJobLost:
     """AC-06.2: 404 from knowledge-ingest -> remote_job_lost."""
 
     @pytest.mark.asyncio
-    async def test_404_marks_failed_with_remote_job_lost(self) -> None:
+    async def test_404_marks_failed_with_remote_job_lost(self, monkeypatch: pytest.MonkeyPatch) -> None:
         old = datetime.now(UTC) - timedelta(hours=25)
         row = _row(started_at=old)
         fake_404 = httpx.HTTPStatusError(
@@ -168,6 +175,7 @@ class TestReaper404IsRemoteJobLost:
             response=httpx.Response(404, text="job not found"),
         )
         reaper, _, _, portal, _ = _make_reaper(
+            monkeypatch,
             candidate_rows=[row],
             status_responses=[fake_404],
         )
@@ -186,10 +194,11 @@ class TestReaperLeavesYoungRunningRowsAlone:
     """AC-06.3: a still-running remote on a row younger than 7d stays."""
 
     @pytest.mark.asyncio
-    async def test_running_under_7d_is_left_alone(self) -> None:
+    async def test_running_under_7d_is_left_alone(self, monkeypatch: pytest.MonkeyPatch) -> None:
         old = datetime.now(UTC) - timedelta(hours=25)  # >24h, <7d
         row = _row(started_at=old)
         reaper, _, _, portal, _ = _make_reaper(
+            monkeypatch,
             candidate_rows=[row],
             status_responses=[
                 {"job_id": "abc123", "status": "running", "pages_done": 1, "pages_total": 100, "error": None},
@@ -207,10 +216,11 @@ class TestReaperForceFailsAfter7Days:
     """AC-06.4: 7+ day old still-running rows force-fail with remote_job_stuck."""
 
     @pytest.mark.asyncio
-    async def test_running_over_7d_force_fails(self) -> None:
+    async def test_running_over_7d_force_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
         old = datetime.now(UTC) - timedelta(days=8)
         row = _row(started_at=old)
         reaper, _, _, portal, _ = _make_reaper(
+            monkeypatch,
             candidate_rows=[row],
             status_responses=[
                 {"job_id": "abc123", "status": "running", "pages_done": 50, "pages_total": 100, "error": None},
@@ -229,10 +239,11 @@ class TestReaperUpstreamUnreachable:
     """Knowledge-ingest down -> reaper logs and retries on next tick."""
 
     @pytest.mark.asyncio
-    async def test_connect_error_is_swallowed(self) -> None:
+    async def test_connect_error_is_swallowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
         old = datetime.now(UTC) - timedelta(hours=25)
         row = _row(started_at=old)
         reaper, _, _, portal, _ = _make_reaper(
+            monkeypatch,
             candidate_rows=[row],
             status_responses=[httpx.ConnectError("connection refused")],
         )
@@ -248,7 +259,7 @@ class TestReaperRaceWithResolver:
     """If the resolver-on-read finalised the row first, the reaper is a no-op."""
 
     @pytest.mark.asyncio
-    async def test_already_terminal_row_is_skipped_in_finalise(self) -> None:
+    async def test_already_terminal_row_is_skipped_in_finalise(self, monkeypatch: pytest.MonkeyPatch) -> None:
         old = datetime.now(UTC) - timedelta(hours=25)
         # Build a row that LOOKS like the candidate query found it, but
         # by the time the reaper does session.get(...) it's already
@@ -261,6 +272,7 @@ class TestReaperRaceWithResolver:
         registry_row.id = candidate.id  # same row, post-resolver state
 
         reaper, _, _, portal, registry = _make_reaper(
+            monkeypatch,
             candidate_rows=[candidate],
             status_responses=[
                 {"job_id": "abc123", "status": "completed", "pages_done": 10, "pages_total": 10, "error": None},

--- a/klai-connector/tests/services/test_sync_run_reaper.py
+++ b/klai-connector/tests/services/test_sync_run_reaper.py
@@ -36,11 +36,7 @@ def _row(
     row.documents_failed = 0
     row.bytes_processed = 0
     row.error_details = None
-    row.cursor_state = (
-        {"remote_job_id": remote_job_id, "remote_status": "queued"}
-        if remote_job_id
-        else None
-    )
+    row.cursor_state = {"remote_job_id": remote_job_id, "remote_status": "queued"} if remote_job_id else None
     row.quality_status = None
     return row
 
@@ -60,8 +56,7 @@ def _make_reaper(
         crawl_client.crawl_sync_status = AsyncMock(side_effect=status_responses)
     else:
         crawl_client.crawl_sync_status = AsyncMock(
-            return_value={"job_id": "abc123", "status": "running",
-                          "pages_done": 0, "pages_total": 0, "error": None},
+            return_value={"job_id": "abc123", "status": "running", "pages_done": 0, "pages_total": 0, "error": None},
         )
     crawl_client.crawl_sync_cancel = AsyncMock()  # MUST NOT be called.
 
@@ -80,6 +75,12 @@ def _make_reaper(
         sess.execute = AsyncMock(return_value=result)
         sess.get = AsyncMock(side_effect=lambda model, row_id, **kwargs: registry.get(row_id))
         sess.commit = AsyncMock()
+        # SPEC-SEC-CONNECTOR-RLS-001: the reaper's _cross_org_session
+        # calls session.connection() (pin) + session.rollback() (reset
+        # cleanup) in addition to execute/get/commit. Mock both as async
+        # so the GUC-binding code path stays exercised.
+        sess.connection = AsyncMock(return_value=MagicMock())
+        sess.rollback = AsyncMock()
         return sess
 
     session_maker = MagicMock(side_effect=_make_session)
@@ -108,8 +109,7 @@ class TestReaperFinalisesTerminalRemote:
         reaper, crawl_client, _, portal, _ = _make_reaper(
             candidate_rows=[row],
             status_responses=[
-                {"job_id": "abc123", "status": "completed",
-                 "pages_done": 100, "pages_total": 100, "error": None},
+                {"job_id": "abc123", "status": "completed", "pages_done": 100, "pages_total": 100, "error": None},
             ],
         )
 
@@ -133,8 +133,13 @@ class TestReaperFinalisesTerminalRemote:
         reaper, _, _, portal, _ = _make_reaper(
             candidate_rows=[row],
             status_responses=[
-                {"job_id": "abc123", "status": "failed",
-                 "pages_done": 5, "pages_total": 100, "error": "internal_crash"},
+                {
+                    "job_id": "abc123",
+                    "status": "failed",
+                    "pages_done": 5,
+                    "pages_total": 100,
+                    "error": "internal_crash",
+                },
             ],
         )
 
@@ -187,8 +192,7 @@ class TestReaperLeavesYoungRunningRowsAlone:
         reaper, _, _, portal, _ = _make_reaper(
             candidate_rows=[row],
             status_responses=[
-                {"job_id": "abc123", "status": "running",
-                 "pages_done": 1, "pages_total": 100, "error": None},
+                {"job_id": "abc123", "status": "running", "pages_done": 1, "pages_total": 100, "error": None},
             ],
         )
 
@@ -209,8 +213,7 @@ class TestReaperForceFailsAfter7Days:
         reaper, _, _, portal, _ = _make_reaper(
             candidate_rows=[row],
             status_responses=[
-                {"job_id": "abc123", "status": "running",
-                 "pages_done": 50, "pages_total": 100, "error": None},
+                {"job_id": "abc123", "status": "running", "pages_done": 50, "pages_total": 100, "error": None},
             ],
         )
 
@@ -260,8 +263,7 @@ class TestReaperRaceWithResolver:
         reaper, _, _, portal, registry = _make_reaper(
             candidate_rows=[candidate],
             status_responses=[
-                {"job_id": "abc123", "status": "completed",
-                 "pages_done": 10, "pages_total": 10, "error": None},
+                {"job_id": "abc123", "status": "completed", "pages_done": 10, "pages_total": 10, "error": None},
             ],
         )
         # Override the registry: session.get returns the post-resolver row.

--- a/klai-connector/tests/test_rls_connector_schema.py
+++ b/klai-connector/tests/test_rls_connector_schema.py
@@ -1,0 +1,211 @@
+"""SPEC-SEC-CONNECTOR-RLS-001 — regression tests for the RLS policy.
+
+The audit finding TP-5 (``reports/audit-2026-05-04/tenant-scoping.md``)
+flagged that ``connector.connectors`` and ``connector.sync_runs`` had
+``org_id`` columns but no PostgreSQL ``CREATE POLICY``. Migration 008
++ ``post_deploy_008.sql`` close that gap.
+
+The CI pipeline runs without a live PostgreSQL backend, so these tests
+exercise two layers:
+
+1. **Migration shape (always)** — parse ``post_deploy_008.sql`` for the
+   canonical Category-D policy DDL on both tables. A future refactor
+   that drops ENABLE / FORCE / WITH CHECK is caught at CI time.
+2. **Migration body is no-op (always)** — the alembic file MUST contain
+   no ``op.execute(...)`` calls. Owner-required DDL crashes the
+   migration role's ``alembic upgrade head`` (pitfall
+   ``alembic-cannot-drop-non-portal_api-tables`` extended on
+   2026-05-05). DDL belongs in the post-deploy SQL only.
+3. **Live PG smoke (skipif POSTGRES_DSN not set)** — run the full
+   policy-against-pg_policies probe + a cross-tenant SELECT to verify
+   that an unset GUC returns zero rows. Mirrors portal-api's
+   ``scripts/rls-smoke-test.sh`` in pytest form.
+
+The live-PG path is intentionally skipif-only — CI will gain a
+service-container in SPEC-CI-PG-FIXTURE-001 and the test will start
+running automatically. Until then, manual smoke is via psql per the
+SPEC's "Implementatie-volgorde" stap 9.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+MIGRATION_PATH = Path(__file__).resolve().parents[1] / "alembic" / "versions" / "008_rls_connector_schema.py"
+
+POST_DEPLOY_SQL_PATH = Path(__file__).resolve().parents[1] / "alembic" / "versions" / "post_deploy_008.sql"
+
+
+# ---------------------------------------------------------------------------
+# Migration shape — DDL strings must contain the canonical patterns
+# ---------------------------------------------------------------------------
+
+
+def _read_post_deploy_sql() -> str:
+    assert POST_DEPLOY_SQL_PATH.exists(), (
+        f"SPEC-SEC-CONNECTOR-RLS-001 post-deploy SQL is missing: "
+        f"{POST_DEPLOY_SQL_PATH}. DDL for the connector schema RLS "
+        "lives there because the migration role cannot run owner-"
+        "required DDL (see pitfall "
+        "alembic-cannot-drop-non-portal_api-tables)."
+    )
+    return POST_DEPLOY_SQL_PATH.read_text(encoding="utf-8")
+
+
+def _read_migration() -> str:
+    assert MIGRATION_PATH.exists(), f"SPEC-SEC-CONNECTOR-RLS-001 migration file is missing: {MIGRATION_PATH}"
+    return MIGRATION_PATH.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("table", ["connector.connectors", "connector.sync_runs"])
+def test_post_deploy_enables_force_rls(table: str) -> None:
+    """Every covered table MUST have ENABLE + FORCE row-level security.
+
+    Without FORCE, the table-owner role bypasses the policy. The no-
+    role-split decision (SPEC v0.2.0) means the runtime role IS the
+    owner — without FORCE the policy is effectively a suggestion.
+    """
+    src = _read_post_deploy_sql()
+    assert re.search(rf"ALTER TABLE {re.escape(table)} ENABLE ROW LEVEL SECURITY", src), (
+        f"post_deploy_008.sql must call ALTER TABLE {table} ENABLE ROW LEVEL SECURITY"
+    )
+    assert re.search(rf"ALTER TABLE {re.escape(table)} FORCE ROW LEVEL SECURITY", src), (
+        f"post_deploy_008.sql must call ALTER TABLE {table} FORCE ROW LEVEL SECURITY"
+    )
+
+
+@pytest.mark.parametrize("table", ["connector.connectors", "connector.sync_runs"])
+def test_post_deploy_creates_strict_policy(table: str) -> None:
+    """Category D shape — both USING and WITH CHECK reference both
+    ``app.current_org_id`` AND ``app.cross_org_admin``.
+
+    USING without the cross_org_admin branch breaks the lifespan reset +
+    reaper sweeps. WITH CHECK without it breaks scheduler bootstrap and
+    any other intentional cross-org INSERT path.
+    """
+    src = _read_post_deploy_sql()
+    block_match = re.search(
+        rf"CREATE POLICY tenant_isolation ON {re.escape(table)}.*?;",
+        src,
+        re.DOTALL,
+    )
+    assert block_match, f"CREATE POLICY block for {table} not found in post-deploy SQL"
+    block = block_match.group(0)
+
+    assert "USING" in block
+    assert "WITH CHECK" in block
+    assert "app.current_org_id" in block
+    assert "app.cross_org_admin" in block
+
+
+@pytest.mark.parametrize("table", ["connector.connectors", "connector.sync_runs"])
+def test_post_deploy_uses_drop_if_exists_for_idempotency(table: str) -> None:
+    """``CREATE POLICY`` does not support ``IF NOT EXISTS``. Each
+    CREATE must be preceded by a DROP IF EXISTS so re-applying on a
+    partially migrated DB succeeds.
+    """
+    src = _read_post_deploy_sql()
+    # Look for `DROP POLICY IF EXISTS tenant_isolation ON <table>` BEFORE
+    # the corresponding CREATE.
+    drop_match = re.search(
+        rf"DROP POLICY IF EXISTS tenant_isolation ON {re.escape(table)};",
+        src,
+    )
+    create_match = re.search(
+        rf"CREATE POLICY tenant_isolation ON {re.escape(table)}",
+        src,
+    )
+    assert drop_match, f"Missing DROP POLICY IF EXISTS guard for {table}"
+    assert create_match, f"Missing CREATE POLICY for {table}"
+    assert drop_match.start() < create_match.start(), (
+        f"DROP POLICY IF EXISTS for {table} must precede the CREATE; "
+        "otherwise re-running on a partially migrated DB will error "
+        "(CREATE POLICY does not support IF NOT EXISTS)."
+    )
+
+
+def test_migration_body_is_noop() -> None:
+    """The alembic migration upgrade()/downgrade() MUST be no-ops.
+
+    Owner-required DDL was deliberately moved to ``post_deploy_008.sql``
+    to avoid the ``alembic-cannot-drop-non-portal_api-tables`` crash-
+    loop. If a future refactor moves the DDL back into upgrade(),
+    klai-connector will crash-loop on every fresh deploy or staging
+    rebuild.
+    """
+    src = _read_migration()
+    assert "op.execute(" not in src, (
+        "Migration file 008_rls_connector_schema.py contains "
+        "op.execute(...) — owner-required DDL must live in "
+        "post_deploy_008.sql instead. See pitfall "
+        "alembic-cannot-drop-non-portal_api-tables in process-rules.md."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Live PostgreSQL smoke — only runs when POSTGRES_DSN is set.
+# ---------------------------------------------------------------------------
+
+
+_pg_dsn = os.environ.get("POSTGRES_DSN")
+_pg_skipif = pytest.mark.skipif(
+    _pg_dsn is None,
+    reason="POSTGRES_DSN not set — live RLS smoke skipped (CI gains this in SPEC-CI-PG-FIXTURE-001)",
+)
+
+
+@_pg_skipif
+@pytest.mark.asyncio
+@pytest.mark.parametrize("table", ["connector.connectors", "connector.sync_runs"])
+async def test_live_policy_blocks_unbound_select(table: str) -> None:
+    """Probe: with empty ``app.current_org_id`` + no cross_org_admin,
+    SELECT returns zero rows.
+
+    This is the load-bearing assertion for Category D. If it ever
+    passes (returns rows), the policy is permissive instead of strict
+    and a missing ``set_tenant`` call would silently leak cross-tenant.
+    """
+    import asyncpg  # noqa: PLC0415
+
+    conn = await asyncpg.connect(_pg_dsn)
+    try:
+        # Reset both GUCs to be sure the test starts clean.
+        await conn.execute("SELECT set_config('app.current_org_id', '', false)")
+        await conn.execute("SELECT set_config('app.cross_org_admin', '', false)")
+        rows = await conn.fetch(f"SELECT 1 FROM {table} LIMIT 1")  # noqa: S608
+        assert rows == [], (
+            f"Strict RLS contract broken: {table} returned a row with no "
+            "tenant context. Either FORCE ROW LEVEL SECURITY is missing, "
+            "the policy uses a permissive `IS NULL` branch on USING, or "
+            "the runtime role bypasses RLS (BYPASSRLS attribute)."
+        )
+    finally:
+        await conn.close()
+
+
+@_pg_skipif
+@pytest.mark.asyncio
+async def test_live_cross_org_admin_unlocks_full_table_scan() -> None:
+    """Probe: ``app.cross_org_admin = '1'`` permits cross-tenant SELECT.
+
+    The lifespan reset + SyncRunReaper rely on this escape-hatch. If a
+    future policy-tweak removes the ``cross_org_admin`` branch from
+    USING, both will silently see zero rows and the reaper stops
+    finalising orphaned runs.
+    """
+    import asyncpg  # noqa: PLC0415
+
+    conn = await asyncpg.connect(_pg_dsn)
+    try:
+        await conn.execute("SELECT set_config('app.cross_org_admin', '1', false)")
+        # The query SHALL not raise — it may return zero rows if the
+        # table is empty in this test DB, but the policy MUST permit it.
+        await conn.fetch("SELECT 1 FROM connector.sync_runs LIMIT 1")
+        await conn.fetch("SELECT 1 FROM connector.connectors LIMIT 1")
+    finally:
+        await conn.execute("SELECT set_config('app.cross_org_admin', '', false)")
+        await conn.close()

--- a/klai-connector/tests/test_sync_engine_reconnect.py
+++ b/klai-connector/tests/test_sync_engine_reconnect.py
@@ -108,7 +108,6 @@ async def test_oauth_reconnect_required_marks_run_auth_error(monkeypatch: pytest
     crawl_sync_client = MagicMock()
 
     engine = SyncEngine(
-        session_maker=session_maker_mock,
         registry=registry,
         ingest_client=ingest_client,
         portal_client=portal_client,
@@ -173,7 +172,6 @@ async def test_generic_exception_falls_through_to_failed_not_auth_error(monkeypa
     registry.get = MagicMock(return_value=adapter)
 
     engine = SyncEngine(
-        session_maker=session_maker_mock,
         registry=registry,
         ingest_client=MagicMock(ingest=AsyncMock()),
         portal_client=portal_client,

--- a/klai-connector/tests/test_sync_engine_reconnect.py
+++ b/klai-connector/tests/test_sync_engine_reconnect.py
@@ -66,7 +66,7 @@ def _mock_session_maker(sync_run: MagicMock) -> Any:
 
 
 @pytest.mark.asyncio
-async def test_oauth_reconnect_required_marks_run_auth_error() -> None:
+async def test_oauth_reconnect_required_marks_run_auth_error(monkeypatch: pytest.MonkeyPatch) -> None:
     """Adapter raises OAuthReconnectRequiredError → sync_run + report_sync_status use AUTH_ERROR.
 
     Guards the sole wiring contract between the OAuth-adapter layer and
@@ -80,6 +80,12 @@ async def test_oauth_reconnect_required_marks_run_auth_error() -> None:
     sync_run.quality_status = None
 
     session_maker_mock, _session = _mock_session_maker(sync_run)
+    # SPEC-SEC-CONNECTOR-RLS-001: SyncEngine now opens its sessions via
+    # ``tenant_scoped_session(org_id)`` which uses the module-level
+    # ``session_maker``. Patch it so the mock factory is reached.
+    import app.core.database as _db_module  # noqa: PLC0415
+
+    monkeypatch.setattr(_db_module, "session_maker", session_maker_mock)
 
     portal_client = MagicMock()
     portal_client.get_connector_config = AsyncMock(return_value=_portal_config())
@@ -90,8 +96,7 @@ async def test_oauth_reconnect_required_marks_run_auth_error() -> None:
     adapter = MagicMock()
     adapter.get_cursor_state = AsyncMock(
         side_effect=OAuthReconnectRequiredError(
-            "Microsoft refresh_token rejected (connector_id=conn-uuid-reconnect): "
-            "AADSTS700082: refresh token expired"
+            "Microsoft refresh_token rejected (connector_id=conn-uuid-reconnect): AADSTS700082: refresh token expired"
         ),
     )
 
@@ -115,12 +120,10 @@ async def test_oauth_reconnect_required_marks_run_auth_error() -> None:
     # Act: run a sync that will hit the OAuthReconnectRequiredError path.
     connector_id = uuid.UUID("12345678-1234-5678-1234-567812345678")
     sync_run_id = uuid.UUID("87654321-4321-8765-4321-876543218765")
-    await engine.run_sync(connector_id, sync_run_id)
+    await engine.run_sync(connector_id, sync_run_id, "362757920133283846")
 
     # Assert: the sync_run object gets AUTH_ERROR status
-    assert sync_run.status == SyncStatus.AUTH_ERROR, (
-        f"expected AUTH_ERROR status on sync_run, got {sync_run.status}"
-    )
+    assert sync_run.status == SyncStatus.AUTH_ERROR, f"expected AUTH_ERROR status on sync_run, got {sync_run.status}"
 
     # Assert: report_sync_status is called with AUTH_ERROR
     portal_client.report_sync_status.assert_awaited_once()
@@ -132,14 +135,13 @@ async def test_oauth_reconnect_required_marks_run_auth_error() -> None:
     # Assert: error_details carries the reconnect_required reason so downstream
     # consumers can distinguish this from a generic auth failure.
     error_details = kwargs.get("error_details") or []
-    assert any(
-        isinstance(e, dict) and e.get("reason") == "reconnect_required"
-        for e in error_details
-    ), f"expected reason=reconnect_required in error_details, got {error_details!r}"
+    assert any(isinstance(e, dict) and e.get("reason") == "reconnect_required" for e in error_details), (
+        f"expected reason=reconnect_required in error_details, got {error_details!r}"
+    )
 
 
 @pytest.mark.asyncio
-async def test_generic_exception_falls_through_to_failed_not_auth_error() -> None:
+async def test_generic_exception_falls_through_to_failed_not_auth_error(monkeypatch: pytest.MonkeyPatch) -> None:
     """A non-OAuth exception still ends up as FAILED, not AUTH_ERROR.
 
     Regression guard: the except-clause ordering matters. If someone
@@ -154,6 +156,11 @@ async def test_generic_exception_falls_through_to_failed_not_auth_error() -> Non
     sync_run.quality_status = None
 
     session_maker_mock, _session = _mock_session_maker(sync_run)
+    # SPEC-SEC-CONNECTOR-RLS-001: see comment in
+    # test_oauth_reconnect_required_marks_run_auth_error above.
+    import app.core.database as _db_module  # noqa: PLC0415
+
+    monkeypatch.setattr(_db_module, "session_maker", session_maker_mock)
 
     portal_client = MagicMock()
     portal_client.get_connector_config = AsyncMock(return_value=_portal_config())
@@ -178,6 +185,7 @@ async def test_generic_exception_falls_through_to_failed_not_auth_error() -> Non
     await engine.run_sync(
         uuid.UUID("12345678-1234-5678-1234-567812345678"),
         uuid.UUID("87654321-4321-8765-4321-876543218765"),
+        "362757920133283846",
     )
 
     portal_client.report_sync_status.assert_awaited_once()

--- a/klai-connector/tests/test_sync_engine_web_delegation.py
+++ b/klai-connector/tests/test_sync_engine_web_delegation.py
@@ -114,7 +114,6 @@ def _make_engine(
     registry = MagicMock()
 
     engine = SyncEngine(
-        session_maker=session_maker,
         registry=registry,
         ingest_client=ingest_client,
         portal_client=portal_client,

--- a/klai-connector/tests/test_sync_engine_web_delegation.py
+++ b/klai-connector/tests/test_sync_engine_web_delegation.py
@@ -61,6 +61,7 @@ def _make_sync_run_mock() -> MagicMock:
 
 
 def _make_engine(
+    monkeypatch: pytest.MonkeyPatch,
     *,
     enqueue_response: dict | None = None,
     enqueue_exc: Exception | None = None,
@@ -76,8 +77,21 @@ def _make_engine(
     session.__aexit__ = AsyncMock(return_value=False)
     session.get = AsyncMock(return_value=sync_run)
     session.commit = AsyncMock()
+    # SPEC-SEC-CONNECTOR-RLS-001: tenant_scoped_session calls
+    # session.connection() (pin) + session.execute(SELECT set_config...)
+    # + session.rollback() (cleanup). Mock all three async.
+    session.connection = AsyncMock(return_value=MagicMock())
+    session.rollback = AsyncMock()
+    session.execute = AsyncMock()
 
     session_maker = MagicMock(return_value=session)
+    # SPEC-SEC-CONNECTOR-RLS-001: SyncEngine now opens its sessions via
+    # ``tenant_scoped_session(org_id)`` which uses the module-level
+    # ``session_maker`` from app.core.database. Patch so the mock factory
+    # is reached.
+    import app.core.database as _db_module  # noqa: PLC0415
+
+    monkeypatch.setattr(_db_module, "session_maker", session_maker)
 
     crawl_sync_client = MagicMock()
     if enqueue_exc is not None:
@@ -114,8 +128,9 @@ class TestFireAndForgetDelegation:
     """REQ-CRAWLER-006-01..03: enqueue, store remote_job_id, return."""
 
     @pytest.mark.asyncio
-    async def test_successful_enqueue_leaves_run_in_running_state(self) -> None:
+    async def test_successful_enqueue_leaves_run_in_running_state(self, monkeypatch: pytest.MonkeyPatch) -> None:
         engine, session, sync_run, report_mock = _make_engine(
+            monkeypatch,
             enqueue_response={"job_id": "abc123", "status": "queued"},
         )
         connector_id = uuid.uuid4()
@@ -125,6 +140,7 @@ class TestFireAndForgetDelegation:
             portal_config=_make_portal_config(),
             connector_id=connector_id,
             sync_run_id=sync_run_id,
+            org_id="362757920133283846",
             start_time=datetime.now(UTC).timestamp(),
         )
 
@@ -152,7 +168,7 @@ class TestFireAndForgetDelegation:
         report_mock.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_enqueue_http_error_fails_sync_synchronously(self) -> None:
+    async def test_enqueue_http_error_fails_sync_synchronously(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """AC-01.2: non-2xx from /crawl/sync -> FAILED, http_<code> error."""
         fake_response = httpx.Response(
             503,
@@ -160,6 +176,7 @@ class TestFireAndForgetDelegation:
             text="service unavailable",
         )
         engine, _, sync_run, report_mock = _make_engine(
+            monkeypatch,
             enqueue_exc=httpx.HTTPStatusError(
                 "503 service unavailable",
                 request=fake_response.request,
@@ -170,6 +187,7 @@ class TestFireAndForgetDelegation:
             portal_config=_make_portal_config(),
             connector_id=uuid.uuid4(),
             sync_run_id=uuid.uuid4(),
+            org_id="362757920133283846",
             start_time=datetime.now(UTC).timestamp(),
         )
 
@@ -184,14 +202,16 @@ class TestFireAndForgetDelegation:
         assert report_mock.await_args.kwargs["sync_status"] == SyncStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_enqueue_network_error_fails_sync_synchronously(self) -> None:
+    async def test_enqueue_network_error_fails_sync_synchronously(self, monkeypatch: pytest.MonkeyPatch) -> None:
         engine, _, sync_run, report_mock = _make_engine(
+            monkeypatch,
             enqueue_exc=httpx.ConnectError("connection refused"),
         )
         await engine._run_web_crawler_delegation(
             portal_config=_make_portal_config(),
             connector_id=uuid.uuid4(),
             sync_run_id=uuid.uuid4(),
+            org_id="362757920133283846",
             start_time=datetime.now(UTC).timestamp(),
         )
 
@@ -228,7 +248,8 @@ class TestCrawlSyncClientContract:
         transport = httpx.MockTransport(_handler)
         client = CrawlSyncClient(base_url="http://knowledge-ingest:8000", internal_secret="s3cr3t")
         client._client = httpx.AsyncClient(  # type: ignore[attr-defined]
-            base_url="http://knowledge-ingest:8000", transport=transport,
+            base_url="http://knowledge-ingest:8000",
+            transport=transport,
         )
 
         out = await client.crawl_sync(

--- a/klai-connector/tests/test_sync_routes_org_scoping.py
+++ b/klai-connector/tests/test_sync_routes_org_scoping.py
@@ -83,7 +83,12 @@ class _FakeSession:
         self._rows = rows or []
         self._run_by_id = run_by_id
 
-    async def execute(self, _stmt: Any) -> _FakeExecuteResult:
+    async def execute(self, _stmt: Any, _params: Any = None) -> _FakeExecuteResult:
+        # Second positional arg accepts the params dict that
+        # ``set_tenant`` (SPEC-SEC-CONNECTOR-RLS-001) passes alongside
+        # its ``SELECT set_config(...)`` statement. Ignored here — the
+        # FakeSession's whole purpose is to return canned ``_rows`` for
+        # the SyncRun queries that follow.
         return _FakeExecuteResult(self._rows)
 
     async def get(self, _model: type, _key: uuid.UUID) -> SyncRun | None:
@@ -284,9 +289,7 @@ def test_sync_require_org_id_settings_default_is_true() -> None:
     from app.core.config import Settings
 
     default = Settings.model_fields["sync_require_org_id"].default
-    assert default is True, (
-        f"sync_require_org_id default must be True (transition closed per REQ-8.5), got {default!r}"
-    )
+    assert default is True, f"sync_require_org_id default must be True (transition closed per REQ-8.5), got {default!r}"
 
 
 def test_sync_request_without_org_id_returns_400(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/klai-connector/uv.lock
+++ b/klai-connector/uv.lock
@@ -1074,6 +1074,7 @@ name = "klai-log-utils"
 version = "0.1.0"
 source = { editable = "../klai-libs/log-utils" }
 dependencies = [
+    { name = "starlette" },
     { name = "structlog" },
 ]
 
@@ -1082,7 +1083,9 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.390" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8" },
+    { name = "starlette", specifier = ">=0.40" },
     { name = "structlog", specifier = ">=25.0" },
 ]
 provides-extras = ["dev"]
@@ -1092,6 +1095,7 @@ dev = [
     { name = "httpx", specifier = ">=0.28" },
     { name = "pyright", specifier = ">=1.1.390" },
     { name = "pytest", specifier = ">=8" },
+    { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "ruff", specifier = ">=0.8" },
 ]
 


### PR DESCRIPTION
Replaces #318 (closed) and the abandoned ast-grep approach. Implements RLS at DB-layer per SPEC v0.2.0.

## Architecturale beslissingen (vastgelegd na user signoff)

- **Category D (strict)**: empty GUC = 0 rows / 42501 op INSERT
- **Geen role-split**: FORCE ROW LEVEL SECURITY houdt owner subject aan policy
- **`app.cross_org_admin = '1'`** als escape voor de 3 legitieme cross-org sites (lifespan reset, SyncRunReaper, scheduler bootstrap)

## Wat erin zit

| AC | Wat | Bestand(en) |
|---|---|---|
| AC-1 | Lege migration + post_deploy SQL met DDL voor BEIDE tabellen | `alembic/versions/008_rls_connector_schema.py` + `post_deploy_008.sql` |
| AC-2 | DB helpers: `tenant_scoped_session`, `cross_org_session`, `set_tenant`, `PooledTenantSession` | `app/core/database.py` |
| AC-3 | Lifespan reset via cross_org_session | `app/main.py` |
| AC-4 | Reaper centraliseert GUC binding via private `_cross_org_session` | `app/services/sync_run_reaper.py` |
| AC-5 | Routes binden tenant na X-Org-ID extract | `app/routes/sync.py` |
| AC-6 | Scheduler draagt org_id mee door APScheduler args + `_sync_callback` | `app/services/scheduler.py` |
| AC-7 | SyncEngine.run_sync(... , org_id) — 2 call sites + 3 internal session blocks | `app/services/sync_engine.py` |
| AC-8 | Migration-shape tests (always) + live-PG smoke (skipif POSTGRES_DSN) | `tests/test_rls_connector_schema.py` |

## Test resultaat

- 369 passed, 4 skipped (3 live-PG + 1 pre-existing) op deze branch
- 4 pre-existing failures op main (test_e2e_image_pipeline + test_sync_engine_images) — NIET geraakt door dit werk

## Deploy procedure

⚠️ **DO NOT MERGE WITHOUT REVIEW** — te veel cross-cutting changes om admin-merge te rechtvaardigen.

Na merge:
1. Auto-deploy → klai-connector Up zonder RLS actief (post_deploy is gecommit maar niet applied)
2. Verify gezond op core-01: `docker ps --filter name=klai-connector`
3. Operator runt: `ssh core-01 "docker exec klai-core-postgres-1 psql -U $POSTGRES_USER -d $POSTGRES_DB -f /tmp/post_deploy_008.sql"` (of via apply_post_deploy_sql.sh als die er is)
4. Smoke-test: `SELECT 1 FROM connector.sync_runs LIMIT 1` zonder GUC → 0 rows; met `SET app.cross_org_admin='1'` → rijen zichtbaar

## Rollback

```sql
DROP POLICY IF EXISTS tenant_isolation ON connector.connectors;
DROP POLICY IF EXISTS tenant_isolation ON connector.sync_runs;
ALTER TABLE connector.connectors DISABLE ROW LEVEL SECURITY;
ALTER TABLE connector.sync_runs DISABLE ROW LEVEL SECURITY;
```

## Referenties

- SPEC: `.moai/specs/SPEC-SEC-CONNECTOR-RLS-001/spec.md` v0.2.0
- Pattern: #364 (RLS op portal_join_requests) + #367 (post-deploy split)
- Pitfall: `alembic-cannot-drop-non-portal_api-tables` in process-rules.md (uitgebreid 2026-05-05)
- Vervangt: #318 (closed)