### PR TITLE
fix(audit-ti): C-2 CRIT — gate retry_provisioning on platform-admin org

### DIFF
--- a/klai-portal/backend/app/api/admin/__init__.py
+++ b/klai-portal/backend/app/api/admin/__init__.py
@@ -97,6 +97,24 @@ def _require_admin(caller_user: "PortalUser") -> None:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied: admin role required")
 
 
+def _require_platform_admin(caller_org: "PortalOrg") -> None:
+    """Raise 403 unless the caller's org is the platform-admin org.
+
+    # @MX:NOTE: SPEC-INFRA-TENANT-DELETE-001 R1 — platform-admin guard. Uses
+    #   _app_settings.platform_org_slug (default 'getklai') to identify the
+    #   platform org.
+    # @MX:ANCHOR fan_in=3 — every cross-tenant admin endpoint that operates on
+    #   a `slug` URL-parameter for an org other than the caller's own MUST
+    #   call this guard immediately after `_require_admin`. Failing to do so
+    #   is the audit-tenant-isolation-2026-05-05 finding C-2 class.
+    """
+    if caller_org.slug != _app_settings.platform_org_slug:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied: platform admin org required",
+        )
+
+
 # --- Sub-router inclusion (no prefix on sub-routers!) ---
 from .audit import router as audit_router  # noqa: E402
 from .deprovision_org import router as deprovision_org_router  # noqa: E402
@@ -117,6 +135,7 @@ router.include_router(deprovision_org_router)
 __all__ = [
     "_get_caller_org",
     "_require_admin",
+    "_require_platform_admin",
     "bearer",
     "router",
 ]

--- a/klai-portal/backend/app/api/admin/deprovision_org.py
+++ b/klai-portal/backend/app/api/admin/deprovision_org.py
@@ -22,8 +22,7 @@ from fastapi.security import HTTPAuthorizationCredentials
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.admin import _get_caller_org, _require_admin, bearer
-from app.core.config import settings
+from app.api.admin import _get_caller_org, _require_admin, _require_platform_admin, bearer
 from app.core.database import get_db
 from app.models.portal import PortalOrg
 from app.services.provisioning.deprovisioning_orchestrator import deprovision_tenant
@@ -119,17 +118,10 @@ def _guard_entry_state(org: PortalOrg) -> None:
         )
 
 
-def _require_platform_admin(caller_org: PortalOrg) -> None:
-    """Raise 403 unless the caller's org is the platform-admin org.
-
-    # @MX:NOTE: SPEC-INFRA-TENANT-DELETE-001 R1 — platform-admin guard. Uses
-    #   settings.platform_org_slug (default 'getklai') to identify the platform org.
-    """
-    if caller_org.slug != settings.platform_org_slug:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Access denied: platform admin org required",
-        )
+# NOTE: _require_platform_admin moved to app.api.admin.__init__ in
+# fix/audit-tenant-isolation/c-2-retry-provisioning-platform-admin so that
+# every admin endpoint can use the same guard without cross-importing
+# between sibling modules. Imported above.
 
 
 # ---------------------------------------------------------------------------

--- a/klai-portal/backend/app/api/admin/retry_provisioning.py
+++ b/klai-portal/backend/app/api/admin/retry_provisioning.py
@@ -10,6 +10,16 @@ Concurrency guarantee: `SELECT ... FOR UPDATE` on the target row serialises
 concurrent retry clicks. The second caller reads the row after the first
 committed the transition to `queued` and falls through to the
 `not_in_retryable_state` branch.
+
+Authorization (audit-tenant-isolation-2026-05-05 finding C-2):
+The handler operates on a `slug` URL-parameter that may identify a tenant
+DIFFERENT from the caller's own org (the failed-row predates any user-level
+tenancy). This is a cross-tenant action and MUST be gated by
+`_require_platform_admin` — only callers operating from the platform-admin
+org (settings.platform_org_slug, default 'getklai') may invoke it. Without
+this guard, any tenant-admin could revive any other tenant's failed-rollback
+org. Mirrors the gating in `deprovision_org.py::deprovision_org_by_slug`
+and `retry_deprovisioning`.
 """
 
 from __future__ import annotations
@@ -20,9 +30,10 @@ from fastapi.security import HTTPAuthorizationCredentials
 from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.admin import _get_caller_org, _require_admin, bearer
+from app.api.admin import _get_caller_org, _require_admin, _require_platform_admin, bearer
 from app.core.database import get_db
 from app.models.portal import PortalOrg
+from app.services.audit import log_event
 from app.services.provisioning.orchestrator import provision_tenant
 
 logger = structlog.get_logger()
@@ -52,6 +63,10 @@ async def retry_provisioning(
     """
     _, _caller_org, caller_user = await _get_caller_org(credentials, db)
     _require_admin(caller_user)
+    # audit-tenant-isolation-2026-05-05 finding C-2: this endpoint operates on
+    # an arbitrary tenant `slug` (the failed-row may belong to ANY tenant, not
+    # just the caller's). Gate cross-tenant actions on platform-admin org.
+    _require_platform_admin(_caller_org)
 
     # Find the failed row for this slug. Because the partial unique index only
     # enforces uniqueness over active rows, there MAY be multiple rows sharing
@@ -150,6 +165,24 @@ async def retry_provisioning(
         org_id=failed_org.id,
         slug=slug,
         admin_user=caller_user.zitadel_user_id,
+        platform_admin_org_id=_caller_org.id,
+    )
+
+    # Audit-trail (audit-tenant-isolation-2026-05-05 C-2): platform-admin
+    # actions on another tenant's row MUST be logged. Fire-and-forget via
+    # log_event — own session so the trail survives even if the BackgroundTask
+    # path raises later.
+    await log_event(
+        org_id=failed_org.id,
+        actor=caller_user.zitadel_user_id,
+        action="retry_provisioning",
+        resource_type="portal_org",
+        resource_id=str(failed_org.id),
+        details={
+            "slug": slug,
+            "platform_admin_org_id": _caller_org.id,
+            "platform_admin_org_slug": _caller_org.slug,
+        },
     )
 
     # Schedule the actual provisioning outside the request cycle.

--- a/klai-portal/backend/tests/test_deprovision_endpoints.py
+++ b/klai-portal/backend/tests/test_deprovision_endpoints.py
@@ -150,13 +150,13 @@ class TestGuardEntryState:
 class TestRequirePlatformAdmin:
     def test_allows_platform_org(self):
         org = _make_org(slug="getklai")
-        with patch("app.api.admin.deprovision_org.settings") as mock_settings:
+        with patch("app.api.admin._app_settings") as mock_settings:
             mock_settings.platform_org_slug = "getklai"
             _require_platform_admin(org)  # no exception
 
     def test_raises_403_for_non_platform_org(self):
         org = _make_org(slug="acme")
-        with patch("app.api.admin.deprovision_org.settings") as mock_settings:
+        with patch("app.api.admin._app_settings") as mock_settings:
             mock_settings.platform_org_slug = "getklai"
             with pytest.raises(HTTPException) as exc_info:
                 _require_platform_admin(org)
@@ -278,7 +278,7 @@ class TestDeprovisionOrgBySlug:
 
         with (
             _caller_org_patch(caller_org, user),
-            patch("app.api.admin.deprovision_org.settings") as mock_settings,
+            patch("app.api.admin._app_settings") as mock_settings,
         ):
             mock_settings.platform_org_slug = "getklai"
             result = await deprovision_org_by_slug("acme", background_tasks, creds, db)
@@ -301,7 +301,7 @@ class TestDeprovisionOrgBySlug:
 
         with (
             _caller_org_patch(caller_org, user),
-            patch("app.api.admin.deprovision_org.settings") as mock_settings,
+            patch("app.api.admin._app_settings") as mock_settings,
         ):
             mock_settings.platform_org_slug = "getklai"
             with pytest.raises(HTTPException) as exc_info:
@@ -320,7 +320,7 @@ class TestDeprovisionOrgBySlug:
 
         with (
             _caller_org_patch(caller_org, user),
-            patch("app.api.admin.deprovision_org.settings") as mock_settings,
+            patch("app.api.admin._app_settings") as mock_settings,
         ):
             mock_settings.platform_org_slug = "getklai"
             with pytest.raises(HTTPException) as exc_info:
@@ -353,7 +353,7 @@ class TestRetryDeprovisioning:
 
         with (
             _caller_org_patch(caller_org, user),
-            patch("app.api.admin.deprovision_org.settings") as mock_settings,
+            patch("app.api.admin._app_settings") as mock_settings,
         ):
             mock_settings.platform_org_slug = "getklai"
             result = await retry_deprovisioning("acme", background_tasks, creds, db)
@@ -379,7 +379,7 @@ class TestRetryDeprovisioning:
 
         with (
             _caller_org_patch(caller_org, user),
-            patch("app.api.admin.deprovision_org.settings") as mock_settings,
+            patch("app.api.admin._app_settings") as mock_settings,
         ):
             mock_settings.platform_org_slug = "getklai"
             with pytest.raises(HTTPException) as exc_info:
@@ -403,7 +403,7 @@ class TestRetryDeprovisioning:
 
         with (
             _caller_org_patch(caller_org, user),
-            patch("app.api.admin.deprovision_org.settings") as mock_settings,
+            patch("app.api.admin._app_settings") as mock_settings,
         ):
             mock_settings.platform_org_slug = "getklai"
             with pytest.raises(HTTPException) as exc_info:

--- a/klai-portal/backend/tests/test_retry_provisioning.py
+++ b/klai-portal/backend/tests/test_retry_provisioning.py
@@ -1,9 +1,16 @@
-"""SPEC-PROV-001 M4 — admin retry endpoint unit tests."""
+"""SPEC-PROV-001 M4 — admin retry endpoint unit tests.
+
+Authorization tests cover both the admin-role gate (`_require_admin`) and
+the platform-admin-org gate (`_require_platform_admin`) added in
+audit-tenant-isolation-2026-05-05 finding C-2.
+"""
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
+
+from app.core.config import settings
 
 
 def _make_failed_org(slug: str = "acme", org_id: int = 42) -> MagicMock:
@@ -13,6 +20,22 @@ def _make_failed_org(slug: str = "acme", org_id: int = 42) -> MagicMock:
     org.provisioning_status = "failed_rollback_complete"
     org.deleted_at = "2026-04-21T12:00:00+00:00"
     return org
+
+
+def _make_platform_caller_org() -> MagicMock:
+    """Caller's own org with slug==platform_org_slug so the platform-admin gate passes."""
+    caller_org = MagicMock()
+    caller_org.id = 1
+    caller_org.slug = settings.platform_org_slug
+    return caller_org
+
+
+def _make_tenant_caller_org(slug: str = "voys") -> MagicMock:
+    """Caller's own org with a non-platform slug — must trigger 403."""
+    caller_org = MagicMock()
+    caller_org.id = 17
+    caller_org.slug = slug
+    return caller_org
 
 
 def _mock_db_returning(*, failed_org, collision_org=None, existing_org=None):
@@ -59,7 +82,7 @@ async def test_retry_non_admin_returns_403() -> None:
     caller_user.role = "member"
 
     async def _fake_caller_resolver(*args, **kwargs):
-        return ("zit-user", MagicMock(), caller_user)
+        return ("zit-user", _make_platform_caller_org(), caller_user)
 
     with (
         patch("app.api.admin.retry_provisioning._get_caller_org", new=_fake_caller_resolver),
@@ -76,6 +99,37 @@ async def test_retry_non_admin_returns_403() -> None:
 
 
 @pytest.mark.asyncio
+async def test_retry_non_platform_admin_org_returns_403() -> None:
+    """audit-tenant-isolation-2026-05-05 finding C-2 regression test.
+
+    A regular tenant-admin (admin role, but non-platform-admin org) MUST NOT
+    be able to retry-provision another tenant's org. Without this gate, any
+    admin in any tenant could revive any other tenant's failed-rollback row.
+    """
+    from app.api.admin.retry_provisioning import retry_provisioning
+
+    admin = MagicMock()
+    admin.role = "admin"
+    admin.zitadel_user_id = "zit-tenant-admin"
+    tenant_caller_org = _make_tenant_caller_org(slug="voys")
+
+    async def _fake_caller_resolver(*args, **kwargs):
+        return ("zit-tenant-admin", tenant_caller_org, admin)
+
+    with patch("app.api.admin.retry_provisioning._get_caller_org", new=_fake_caller_resolver):
+        with pytest.raises(HTTPException) as excinfo:
+            await retry_provisioning(
+                slug="some-other-tenant",
+                background_tasks=MagicMock(),
+                credentials=MagicMock(),
+                db=AsyncMock(),
+            )
+
+    assert excinfo.value.status_code == 403
+    assert "platform admin" in str(excinfo.value.detail).lower()
+
+
+@pytest.mark.asyncio
 async def test_retry_happy_path_returns_202_and_queues_task() -> None:
     from app.api.admin.retry_provisioning import retry_provisioning
 
@@ -87,9 +141,12 @@ async def test_retry_happy_path_returns_202_and_queues_task() -> None:
     background_tasks = MagicMock()
 
     async def _fake_caller_resolver(*args, **kwargs):
-        return ("zit-admin", MagicMock(), admin)
+        return ("zit-admin", _make_platform_caller_org(), admin)
 
-    with patch("app.api.admin.retry_provisioning._get_caller_org", new=_fake_caller_resolver):
+    with (
+        patch("app.api.admin.retry_provisioning._get_caller_org", new=_fake_caller_resolver),
+        patch("app.api.admin.retry_provisioning.log_event", new=AsyncMock()) as mock_log,
+    ):
         response = await retry_provisioning(
             slug="acme",
             background_tasks=background_tasks,
@@ -102,6 +159,13 @@ async def test_retry_happy_path_returns_202_and_queues_task() -> None:
     assert failed_org.provisioning_status == "queued"
     db.commit.assert_awaited_once()
     background_tasks.add_task.assert_called_once()
+    # audit-tenant-isolation-2026-05-05 C-2: platform-admin action is audit-logged.
+    mock_log.assert_awaited_once()
+    log_kwargs = mock_log.await_args.kwargs
+    assert log_kwargs["action"] == "retry_provisioning"
+    assert log_kwargs["resource_type"] == "portal_org"
+    assert log_kwargs["resource_id"] == str(failed_org.id)
+    assert log_kwargs["actor"] == "zit-admin"
 
 
 @pytest.mark.asyncio
@@ -115,7 +179,7 @@ async def test_retry_pending_rollback_returns_409_manual_cleanup() -> None:
     db = _mock_db_returning(failed_org=None, existing_org=pending)
 
     async def _fake_caller_resolver(*args, **kwargs):
-        return ("zit-admin", MagicMock(), admin)
+        return ("zit-admin", _make_platform_caller_org(), admin)
 
     with patch("app.api.admin.retry_provisioning._get_caller_org", new=_fake_caller_resolver):
         with pytest.raises(HTTPException) as excinfo:
@@ -144,7 +208,7 @@ async def test_retry_ready_org_returns_409_not_in_retryable_state() -> None:
     db = _mock_db_returning(failed_org=None, existing_org=ready)
 
     async def _fake_caller_resolver(*args, **kwargs):
-        return ("zit-admin", MagicMock(), admin)
+        return ("zit-admin", _make_platform_caller_org(), admin)
 
     with patch("app.api.admin.retry_provisioning._get_caller_org", new=_fake_caller_resolver):
         with pytest.raises(HTTPException) as excinfo:
@@ -174,7 +238,7 @@ async def test_retry_slug_collision_returns_409_slug_in_use() -> None:
     db = _mock_db_returning(failed_org=failed_org, collision_org=collision)
 
     async def _fake_caller_resolver(*args, **kwargs):
-        return ("zit-admin", MagicMock(), admin)
+        return ("zit-admin", _make_platform_caller_org(), admin)
 
     with patch("app.api.admin.retry_provisioning._get_caller_org", new=_fake_caller_resolver):
         with pytest.raises(HTTPException) as excinfo:
@@ -205,7 +269,7 @@ async def test_retry_unknown_slug_returns_404() -> None:
     db = _mock_db_returning(failed_org=None, existing_org=None)
 
     async def _fake_caller_resolver(*args, **kwargs):
-        return ("zit-admin", MagicMock(), admin)
+        return ("zit-admin", _make_platform_caller_org(), admin)
 
     with patch("app.api.admin.retry_provisioning._get_caller_org", new=_fake_caller_resolver):
         with pytest.raises(HTTPException) as excinfo:

--- a/klai-portal/backend/uv.lock
+++ b/klai-portal/backend/uv.lock
@@ -784,6 +784,7 @@ name = "klai-log-utils"
 version = "0.1.0"
 source = { editable = "../../klai-libs/log-utils" }
 dependencies = [
+    { name = "starlette" },
     { name = "structlog" },
 ]
 
@@ -792,7 +793,9 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.390" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8" },
+    { name = "starlette", specifier = ">=0.40" },
     { name = "structlog", specifier = ">=25.0" },
 ]
 provides-extras = ["dev"]
@@ -802,6 +805,7 @@ dev = [
     { name = "httpx", specifier = ">=0.28" },
     { name = "pyright", specifier = ">=1.1.390" },
     { name = "pytest", specifier = ">=8" },
+    { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "ruff", specifier = ">=0.8" },
 ]
 


### PR DESCRIPTION
## Tenant-isolation finding fix: C-2 — retry_provisioning platform-admin gate

**Audit reference:** `reports/audit-tenant-isolation-2026-05-05/report.md` finding **C-2** (CRIT, re-prioritized from HIGH during synthesis).

**Pattern:** `reports/audit-tenant-isolation-2026-05-05/standards.md` section 16 (Platform-admin gating).

## What was wrong

POST /api/admin/orgs/{slug}/retry-provisioning only checked _require_admin(caller_user). Any tenant-admin in any tenant could revive any other tenant's failed-rollback org by passing the victim slug in the URL — direct cross-tenant action by a regular tenant-admin.

The sibling deprovision_org.py::deprovision_org_by_slug and retry_deprovisioning already gate on _require_platform_admin; retry_provisioning did not.

## Changes

1. Extract _require_platform_admin from app/api/admin/deprovision_org.py to app/api/admin/__init__.py — every cross-tenant admin endpoint imports from one place. Tagged @MX:ANCHOR fan_in=3.
2. Add the gate after _require_admin in retry_provisioning.py.
3. Audit-log via app.services.audit.log_event with action retry_provisioning, target portal_org, platform-admin context in details.
4. Regression test test_retry_non_platform_admin_org_returns_403 locks the gate.
5. Updated existing happy-path tests to use platform-admin caller_org and mock log_event.

## Tests

- tests/test_retry_provisioning.py: 7 tests pass (1 new + 6 updated).
- tests/test_deprovisioning_orchestrator.py + test_provisioning.py: 35 tests pass (no regression from helper extraction).
- ruff check + format: clean

## Operator-step (post-deploy)

None — pure code change, no migration, no env-var.

## Notes

- uv.lock diff is unrelated metadata refresh from klai-libs/log-utils.
- Part 1 of audit-tenant-isolation-2026-05-05 fix sequence. See next-steps.md for the roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)