### PR TITLE
feat(security): SPEC-TI-009 / B-4 -- Garage KB-image auth-proxy via portal-api

### DIFF
--- a/deploy/caddy/Caddyfile
+++ b/deploy/caddy/Caddyfile
@@ -231,10 +231,13 @@
         }
     }
 
-    # Knowledge base images served via Garage S3 website endpoint (anonymous reads)
+    # Knowledge base images -- auth-proxied via portal-api (SPEC-TI-009 / B-4).
+    # CHANGED: no longer serves directly from Garage website-mode (anonymous reads).
+    # portal-api verifies session.org_id == path[org_id] before streaming from S3.
+    # Operator step: disable Garage website-mode ->
+    #   ssh core-01 "docker exec klai-core-garage-1 garage bucket website --deny klai-images"
     handle_path /kb-images/* {
-        reverse_proxy garage:3902 {
-            header_up Host klai-images.web.garage
+        reverse_proxy portal-api:8000 {
             header_up -X-Internal-Secret
             header_up -X-Caller-Service
             header_up -X-Org-ID

--- a/klai-libs/image-storage/klai_image_storage/storage.py
+++ b/klai-libs/image-storage/klai_image_storage/storage.py
@@ -6,9 +6,10 @@ was a straight port of ``klai-connector/app/services/s3_storage.py``).
 The store wraps the synchronous minio client with :func:`asyncio.to_thread`
 so the embedding service's event loop (FastAPI endpoints, Procrastinate
 workers, connector sync tasks) stays non-blocking. Images are uploaded
-authenticated over the S3 API (Garage on :3900) and served anonymously
-via Garage website mode through a Caddy reverse proxy at
-``/kb-images/{object_key}``.
+authenticated over the S3 API (Garage on :3900) and served through
+an auth-proxy at ``GET /kb-images/{org_id}/{kb_slug}/{filename}`` in
+portal-api (SPEC-TI-009 / finding B-4). Direct anonymous reads via
+Garage website mode (:3902) were closed as part of that SPEC.
 
 Content-addressed keys (SHA-256 of bytes) give free deduplication across
 tenants' own KBs. The key format + URL prefix are wire-level contracts;

--- a/klai-portal/backend/app/api/kb_images.py
+++ b/klai-portal/backend/app/api/kb_images.py
@@ -1,0 +1,209 @@
+"""KB-image auth-proxy route -- SPEC-TI-009 / finding B-4.
+
+Replaces anonymous Caddy -> Garage website-mode read with auth-proxied stream.
+Verifies the requesting caller has access to the org_id encoded in the path,
+then streams the image bytes directly from Garage S3 API (private, authenticated).
+
+Authorization model (checked in order):
+1. BFF session cookie  - session.org_id == path[org_id]
+2. Widget session JWT  - org_id in the token allowed org set
+3. Partner API key     - key org_id == path[org_id]
+
+If none matches, returns 401 (unauthenticated) or 403 (wrong org).
+
+Object key format (unchanged from SPEC-KB-IMAGE-002):
+    {org_id}/images/{kb_slug}/{sha256}.{ext}
+
+Cache-Control: private, max-age=86400.
+
+[DRAFT] Widget path: session-cookie and partner-key callers are fully supported.
+Widget session token callers go through _auth_via_session_token in
+partner_dependencies and are covered by the partner-key code path below.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.responses import StreamingResponse
+from minio import Minio
+from minio.error import S3Error
+
+from app.api.partner_dependencies import PartnerAuthContext, get_partner_key
+from app.api.session_deps import get_optional_session
+from app.core.config import settings
+from app.core.session import SessionContext
+
+logger = structlog.get_logger()
+
+router = APIRouter(tags=["KB Images"])
+
+_CACHE_CONTROL = "private, max-age=86400"
+_STREAM_CHUNK_SIZE = 65536
+
+
+def _make_minio_client() -> Minio:
+    """Build a Minio client from settings (private S3 port :3900, not :3902)."""
+    return Minio(
+        settings.garage_s3_endpoint,
+        access_key=settings.garage_s3_access_key,
+        secret_key=settings.garage_s3_secret_key,
+        region="garage",
+        secure=False,
+    )
+
+
+def _stat_object(client: Minio, bucket: str, object_key: str) -> str:
+    """Stat the S3 object; return Content-Type.
+
+    Raises HTTPException(404) if the key does not exist.
+    Raises HTTPException(502) on unexpected S3 errors.
+    """
+    try:
+        stat = client.stat_object(bucket, object_key)
+        return stat.content_type or "application/octet-stream"
+    except S3Error as exc:
+        if exc.code in ("NoSuchKey", "NoSuchBucket"):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Image not found",
+            ) from exc
+        logger.exception("kb_image_stat_error", object_key=object_key, error_code=exc.code)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Storage error",
+        ) from exc
+
+
+async def _stream_object(client: Minio, bucket: str, object_key: str) -> AsyncIterator[bytes]:
+    """Async generator that streams S3 object bytes in chunks via asyncio.to_thread.
+
+    Existence is guaranteed by the prior _stat_object call in get_kb_image.
+    Unexpected S3 errors during streaming are logged but cannot be converted to
+    a proper HTTP error because the response headers have already been sent.
+    """
+    try:
+        response = await asyncio.to_thread(client.get_object, bucket, object_key)
+    except S3Error as exc:
+        logger.exception("kb_image_s3_stream_error", object_key=object_key, error_code=exc.code)
+        # Cannot raise HTTPException here -- response headers already sent.
+        return
+
+    try:
+        while True:
+            chunk = await asyncio.to_thread(response.read, _STREAM_CHUNK_SIZE)
+            if not chunk:
+                break
+            yield chunk
+    finally:
+        await asyncio.to_thread(response.close)
+        await asyncio.to_thread(response.release_conn)
+
+
+async def _resolve_caller_org_id(
+    request: Request,
+    session: SessionContext | None,
+) -> int:
+    """Resolve the org_id of the caller from session or partner key.
+
+    Raises HTTPException(401) when the caller is not authenticated.
+    """
+    if session is not None:
+        if session.org_id is None:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="session_not_finalized",
+            )
+        return session.org_id
+
+    auth_header = request.headers.get("authorization", "")
+    if not auth_header.startswith("Bearer "):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="cookie_required",
+        )
+
+    from app.core.database import get_db
+
+    db_gen = get_db()
+    db = await db_gen.__anext__()
+    try:
+        auth_ctx: PartnerAuthContext = await get_partner_key(request, db)
+        return auth_ctx.org_id
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("kb_image_partner_auth_error")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid credentials",
+        ) from exc
+    finally:
+        try:
+            await db_gen.aclose()
+        except Exception:
+            logger.debug("kb_image_db_aclose_error", exc_info=True)
+
+
+# @MX:ANCHOR: KB-image auth-proxy endpoint -- AC-1 through AC-5 of SPEC-TI-009
+# @MX:REASON: Single enforcement point for cross-tenant image access control.
+#   Every image fetch from the browser goes through this handler after the
+#   Caddy backend is switched from garage:3902 to portal-api:8000.
+#   Changing the org_id check or the S3 key format breaks tenant isolation.
+# @MX:SPEC: SPEC-TI-009, finding B-4
+@router.get("/kb-images/{org_id}/{kb_slug}/{filename}")
+async def get_kb_image(
+    org_id: int,
+    kb_slug: str,
+    filename: str,
+    request: Request,
+    session: SessionContext | None = Depends(get_optional_session),
+) -> StreamingResponse:
+    """Auth-proxied KB-image read (SPEC-TI-009 AC-1).
+
+    Authorization: session.org_id or partner key org_id must equal path org_id.
+    Streams from Garage S3 API (private, authenticated).
+    Cache-Control: private, max-age=86400.
+    """
+    # Step 1: Resolve caller identity
+    caller_org_id = await _resolve_caller_org_id(request, session)
+
+    # Step 2: Authorize -- caller org MUST match path org_id (AC-5)
+    if caller_org_id != org_id:
+        logger.warning(
+            "kb_image_cross_tenant_blocked",
+            caller_org_id=caller_org_id,
+            path_org_id=org_id,
+            kb_slug=kb_slug,
+            filename=filename,
+        )
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
+
+    # Step 3: Build Garage S3 object key (format from SPEC-KB-IMAGE-002)
+    object_key = f"{org_id}/images/{kb_slug}/{filename}"
+
+    # Step 4: Guard against unconfigured Garage endpoint (dev / test env)
+    if not settings.garage_s3_endpoint:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Image storage not configured",
+        )
+
+    client = _make_minio_client()
+
+    content_type = await asyncio.to_thread(_stat_object, client, settings.garage_kb_bucket, object_key)
+
+    structlog.contextvars.bind_contextvars(org_id=org_id, kb_slug=kb_slug)
+
+    # Step 5: Return StreamingResponse with cache headers (AC-1)
+    return StreamingResponse(
+        _stream_object(client, settings.garage_kb_bucket, object_key),
+        media_type=content_type,
+        headers={
+            "Cache-Control": _CACHE_CONTROL,
+            "X-Content-Type-Options": "nosniff",
+        },
+    )

--- a/klai-portal/backend/app/core/config.py
+++ b/klai-portal/backend/app/core/config.py
@@ -208,6 +208,7 @@ class Settings(BaseSettings):
     garage_s3_access_key: str = ""
     garage_s3_secret_key: str = ""
     garage_s3_bucket: str = "klai-scribe"  # default bucket name for scribe artifacts
+    garage_kb_bucket: str = "klai-images"  # SPEC-TI-009: bucket for KB images (auth-proxied via portal-api)
 
     # SPEC-INFRA-TENANT-DELETE-001 R1: platform-org slug guard for admin deprovision endpoint.
     # The DELETE /api/admin/orgs/{slug}/deprovision endpoint requires the caller to be

--- a/klai-portal/backend/app/main.py
+++ b/klai-portal/backend/app/main.py
@@ -23,6 +23,7 @@ from app.api.connectors import router as connectors_router
 from app.api.groups import router as groups_router
 from app.api.internal import router as internal_router
 from app.api.internal_connectors import router as internal_connectors_router
+from app.api.kb_images import router as kb_images_router
 from app.api.knowledge import router as knowledge_router
 from app.api.knowledge_bases import router as knowledge_bases_router
 from app.api.mcp_servers import router as mcp_servers_router
@@ -277,6 +278,7 @@ app.include_router(app_gaps_router)
 app.include_router(connectors_router)
 app.include_router(taxonomy_router)
 app.include_router(vitals_router)
+app.include_router(kb_images_router)
 app.include_router(mcp_servers_router)
 app.include_router(admin_api_keys_router)
 app.include_router(admin_widgets_router)

--- a/klai-portal/backend/tests/test_kb_images_auth_proxy.py
+++ b/klai-portal/backend/tests/test_kb_images_auth_proxy.py
@@ -1,0 +1,257 @@
+"""Tests for KB-image auth-proxy endpoint -- SPEC-TI-009 / finding B-4.
+
+Coverage:
+- test_authenticated_user_can_read_own_org_image        -> 200
+- test_authenticated_user_cannot_read_foreign_org_image -> 403
+- test_unauthenticated_request_rejected                 -> 401
+- test_widget_public_image_works                        -> 200
+- test_partner_api_key_image_access                     -> 200
+- test_404_for_nonexistent_object                       -> 404
+- test_cache_control_header_set_correctly               -> private, max-age=86400
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+ORG_ID = 42
+OTHER_ORG_ID = 99
+KB_SLUG = "my-kb"
+FILENAME = "abc123.png"
+
+
+@pytest.fixture()
+def kb_app():
+    from fastapi import FastAPI
+
+    from app.api.kb_images import router
+
+    app = FastAPI()
+    app.include_router(router)
+    yield app
+    app.dependency_overrides.clear()
+
+
+def _make_session(org_id=ORG_ID):
+    s = MagicMock()
+    s.org_id = org_id
+    return s
+
+
+def _make_fake_stat(content_type="image/png"):
+    stat = MagicMock()
+    stat.content_type = content_type
+    return stat
+
+
+def _make_fake_s3_response(data=b"fake"):
+    resp = MagicMock()
+    resp.read = MagicMock(side_effect=[data, b""])
+    resp.close = MagicMock()
+    resp.release_conn = MagicMock()
+    return resp
+
+
+def _mock_settings():
+    s = MagicMock()
+    s.garage_s3_endpoint = "garage:3900"
+    s.garage_s3_access_key = "key"
+    s.garage_s3_secret_key = "secret"
+    s.garage_kb_bucket = "klai-images"
+    return s
+
+
+def _mock_minio(data=b"fake", content_type="image/png"):
+    mock_cls = MagicMock()
+    mock_client = MagicMock()
+    mock_client.stat_object.return_value = _make_fake_stat(content_type)
+    mock_client.get_object.return_value = _make_fake_s3_response(data)
+    mock_cls.return_value = mock_client
+    return mock_cls
+
+
+@pytest.mark.anyio
+async def test_authenticated_user_can_read_own_org_image(kb_app):
+    """AC-1: session user reads own org image -> 200."""
+    from app.api.session_deps import get_optional_session
+
+    session = _make_session(org_id=ORG_ID)
+    kb_app.dependency_overrides[get_optional_session] = lambda: session
+    mock_cls = _mock_minio()
+    with (
+        patch("app.api.kb_images.Minio", mock_cls),
+        patch("app.api.kb_images.settings", _mock_settings()),
+    ):
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=kb_app), base_url="http://test") as client:
+            resp = await client.get(f"/kb-images/{ORG_ID}/{KB_SLUG}/{FILENAME}")
+    assert resp.status_code == 200
+    assert resp.headers["Cache-Control"] == "private, max-age=86400"
+
+
+@pytest.mark.anyio
+async def test_authenticated_user_cannot_read_foreign_org_image(kb_app):
+    """AC-5: session user org=42 requests org=99 image -> 403."""
+    from app.api.session_deps import get_optional_session
+
+    session = _make_session(org_id=ORG_ID)
+    kb_app.dependency_overrides[get_optional_session] = lambda: session
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=kb_app), base_url="http://test") as client:
+        resp = await client.get(f"/kb-images/{OTHER_ORG_ID}/{KB_SLUG}/{FILENAME}")
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "Access denied"
+
+
+@pytest.mark.anyio
+async def test_unauthenticated_request_rejected(kb_app):
+    """No session and no Authorization header -> 401."""
+    from app.api.session_deps import get_optional_session
+
+    kb_app.dependency_overrides[get_optional_session] = lambda: None
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=kb_app), base_url="http://test") as client:
+        resp = await client.get(f"/kb-images/{ORG_ID}/{KB_SLUG}/{FILENAME}")
+    assert resp.status_code == 401
+
+
+def _mock_get_db():
+    """Callable that returns an async generator yielding a MagicMock db session.
+
+    Mirrors the signature of get_db(): called as get_db(), returns an
+    async generator. The code does:
+        db_gen = get_db()
+        db = await db_gen.__anext__()
+        ...
+        await db_gen.aclose()
+    """
+
+    async def _gen():
+        db = MagicMock()
+        db.aclose = AsyncMock()
+        yield db
+
+    # Return _gen itself (the factory), NOT _gen() (the generator instance).
+    # get_db is called as get_db() inside _resolve_caller_org_id; patching
+    # app.core.database.get_db with _gen means get_db() == _gen() which is
+    # correct.
+    return _gen
+
+
+@pytest.mark.anyio
+async def test_widget_public_image_works(kb_app):
+    """Widget/partner caller with matching org_id -> 200."""
+    from app.api.partner_dependencies import PartnerAuthContext
+    from app.api.session_deps import get_optional_session
+
+    ctx = PartnerAuthContext(
+        key_id="wgt",
+        org_id=ORG_ID,
+        zitadel_org_id="z",
+        permissions={"chat": True},
+        kb_access={},
+        rate_limit_rpm=60,
+    )
+    kb_app.dependency_overrides[get_optional_session] = lambda: None
+    mock_cls = _mock_minio(content_type="image/webp")
+    with (
+        patch("app.api.kb_images.get_partner_key", new=AsyncMock(return_value=ctx)),
+        patch("app.core.database.get_db", new=_mock_get_db()),
+        patch("app.api.kb_images.Minio", mock_cls),
+        patch("app.api.kb_images.settings", _mock_settings()),
+    ):
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=kb_app), base_url="http://test") as client:
+            resp = await client.get(
+                f"/kb-images/{ORG_ID}/{KB_SLUG}/{FILENAME}",
+                headers={"Authorization": "Bearer some-widget-token"},
+            )
+    assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_partner_api_key_image_access(kb_app):
+    """Partner API key with matching org_id -> 200."""
+    from app.api.partner_dependencies import PartnerAuthContext
+    from app.api.session_deps import get_optional_session
+
+    ctx = PartnerAuthContext(
+        key_id="pk_live_x",
+        org_id=ORG_ID,
+        zitadel_org_id="z",
+        permissions={},
+        kb_access={},
+        rate_limit_rpm=120,
+    )
+    kb_app.dependency_overrides[get_optional_session] = lambda: None
+    mock_cls = _mock_minio(content_type="image/jpeg")
+    with (
+        patch("app.api.kb_images.get_partner_key", new=AsyncMock(return_value=ctx)),
+        patch("app.core.database.get_db", new=_mock_get_db()),
+        patch("app.api.kb_images.Minio", mock_cls),
+        patch("app.api.kb_images.settings", _mock_settings()),
+    ):
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=kb_app), base_url="http://test") as client:
+            resp = await client.get(
+                f"/kb-images/{ORG_ID}/{KB_SLUG}/{FILENAME}",
+                headers={"Authorization": "Bearer pk_live_testkey"},
+            )
+    assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_404_for_nonexistent_object(kb_app):
+    """Garage NoSuchKey -> 404."""
+    from minio.error import S3Error
+
+    from app.api.session_deps import get_optional_session
+
+    session = _make_session(org_id=ORG_ID)
+    kb_app.dependency_overrides[get_optional_session] = lambda: session
+
+    mock_cls = MagicMock()
+    mock_client = MagicMock()
+
+    def _raise_no_such_key(*args, **kwargs):
+        mock_resp = MagicMock()
+        mock_resp.status = 404
+        mock_resp.headers = {}
+        mock_resp.reason = "Not Found"
+        raise S3Error(
+            response=mock_resp,
+            code="NoSuchKey",
+            message="No such key",
+            resource="/test",
+            request_id="r",
+            host_id="h",
+        )
+
+    # _stat_object calls stat_object first; raise NoSuchKey there so the 404
+    # is returned before streaming starts (response headers not yet sent).
+    mock_client.stat_object.side_effect = _raise_no_such_key
+    mock_cls.return_value = mock_client
+
+    with (
+        patch("app.api.kb_images.Minio", mock_cls),
+        patch("app.api.kb_images.settings", _mock_settings()),
+    ):
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=kb_app), base_url="http://test") as client:
+            resp = await client.get(f"/kb-images/{ORG_ID}/{KB_SLUG}/{FILENAME}")
+    assert resp.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_cache_control_header_set_correctly(kb_app):
+    """Successful response carries Cache-Control: private, max-age=86400."""
+    from app.api.session_deps import get_optional_session
+
+    session = _make_session(org_id=ORG_ID)
+    kb_app.dependency_overrides[get_optional_session] = lambda: session
+    mock_cls = _mock_minio()
+    with (
+        patch("app.api.kb_images.Minio", mock_cls),
+        patch("app.api.kb_images.settings", _mock_settings()),
+    ):
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=kb_app), base_url="http://test") as client:
+            resp = await client.get(f"/kb-images/{ORG_ID}/{KB_SLUG}/{FILENAME}")
+    assert resp.status_code == 200
+    assert resp.headers["Cache-Control"] == "private, max-age=86400"


### PR DESCRIPTION
## Summary

- New `GET /kb-images/{org_id}/{kb_slug}/{filename}` endpoint in portal-api auth-proxies KB images from Garage S3.
- Accepts BFF session cookie OR partner/widget API key; enforces `caller_org_id == path org_id` (blocks cross-tenant image leakage, finding B-4).
- Streams from Garage private S3 API (`:3900`) via `asyncio.to_thread` + minio. Cache-Control: `private, max-age=86400`.
- Caddy `/kb-images/*` backend switched from `garage:3902` (anonymous website-mode) to `portal-api:8000`.
- `storage.py` docstring updated to reference new pattern.

## Architecture decision

Option A (auth-proxy via portal-api) chosen over Option B (presigned URLs) per SPEC-TI-009:
- Images may contain tenant PII, so cross-tenant read must be blocked at the application layer.
- Presigned URLs require Garage version with proper presign support; website-mode endpoint has no auth.
- Auth-proxy adds ~1 hop but gives explicit org_id check on every image fetch.

## New files

- `klai-portal/backend/app/api/kb_images.py` -- 209-line endpoint with `@MX:ANCHOR` annotation
- `klai-portal/backend/tests/test_kb_images_auth_proxy.py` -- 7 tests (all pass, ruff clean)

## Operator step (REQUIRED post-deploy)

After deploying this PR, disable anonymous reads on the Garage `klai-images` bucket to close the bypass:

```bash
# Option A: disable website mode on the bucket entirely
garage bucket website --deny klai-images

# Option B: or keep website mode but set a 403 default page
```

Until this step is done, the old anonymous `garage:3902` route is still reachable directly (not via Caddy). The Caddy change in this PR removes the proxy path, but Garage itself still accepts direct requests.

## Test plan

- [x] 7 unit tests cover: authenticated read own org (200), cross-tenant blocked (403), unauthenticated (401), widget auth (200), partner API key (200), NoSuchKey (404), Cache-Control header
- [x] `uv run ruff check . && uv run ruff format --check .` -- both pass
- [x] `uv run pytest tests/test_kb_images_auth_proxy.py -v` -- 7/7 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)