### PR TITLE
feat(security): SPEC-TI-010A — cross-org markers + scribe org_id

### DIFF
--- a/klai-portal/backend/app/api/internal_connectors.py
+++ b/klai-portal/backend/app/api/internal_connectors.py
@@ -26,7 +26,7 @@ from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
-from app.core.database import get_db
+from app.core.database import get_db, set_tenant
 from app.models.connectors import PortalConnector
 
 logger = logging.getLogger(__name__)
@@ -74,6 +74,8 @@ async def finalize_connector_delete(
     """
     _verify_internal_bearer(authorization)
 
+    # cross-org-by-design: internal callback from knowledge-ingest connector_purge_task;
+    # resolves tenant from connector.org_id after lookup. SPEC-TI-010A / C-5.
     result = await db.execute(select(PortalConnector).where(PortalConnector.id == connector_id))
     connector = result.scalar_one_or_none()
     if connector is None:
@@ -83,6 +85,8 @@ async def finalize_connector_delete(
             extra={"connector_id": connector_id},
         )
         return None
+
+    await set_tenant(db, connector.org_id)
 
     if connector.state != "deleting":
         # Worker bug or stale message: refuse to drop an active row.

--- a/klai-portal/backend/app/main.py
+++ b/klai-portal/backend/app/main.py
@@ -61,6 +61,8 @@ async def _run_stuck_detector() -> None:
         from app.core.database import AsyncSessionLocal as _AsyncSessionLocal
         from app.services.provisioning.stuck_detector import reconcile_stuck_provisionings
 
+        # cross-org-by-design: stuck-detector must scan all orgs at startup to
+        # recover from crashes mid-provisioning. SPEC-TI-010A / C-4.
         async with _AsyncSessionLocal() as reconcile_db:
             reconciled = await reconcile_stuck_provisionings(reconcile_db)
         if reconciled:

--- a/klai-portal/backend/app/services/invite_scheduler.py
+++ b/klai-portal/backend/app/services/invite_scheduler.py
@@ -16,7 +16,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
-from app.core.database import cross_org_session
+from app.core.database import cross_org_session, tenant_scoped_session
 from app.models.meetings import VexaMeeting
 from app.services.ical_parser import ParsedInvite
 from app.services.vexa import vexa
@@ -124,19 +124,25 @@ async def _join_meeting(invite: ParsedInvite, zitadel_user_id: str, org_id: int 
         return
 
     try:
-        # Final dedup at join-time: iCal UIDs are globally unique so the
-        # scan must cross tenants. The new row's org_id is set on the INSERT
-        # below — but the SELECT scan must see competing rows in every org,
-        # which is why this uses `cross_org_session` instead of scoping to
-        # the new row's own org_id.
+        # Final dedup at join-time: iCal UIDs are globally unique so the scan
+        # must cross tenants. SPEC-TI-010A C-3: the SELECT uses cross_org_session()
+        # to see competing rows from every org; the INSERT uses a separate
+        # tenant_scoped_session(org_id) so RLS WITH CHECK (org_id = GUC) is
+        # satisfied and the new row is correctly scoped to the owning tenant.
         # @MX:SPEC: SPEC-SEC-007
-        async with cross_org_session() as db:
-            # Final dedup check
-            existing = await db.scalar(select(VexaMeeting.id).where(VexaMeeting.ical_uid == invite.uid))
+        async with cross_org_session() as scan_db:
+            # Final dedup check - must see all orgs to avoid duplicate joins.
+            existing = await scan_db.scalar(select(VexaMeeting.id).where(VexaMeeting.ical_uid == invite.uid))
             if existing is not None:
                 logger.info("Meeting already exists at join time: uid=%s", invite.uid)
                 return
 
+        # INSERT in a tenant-scoped session so the RLS WITH CHECK constraint
+        # (org_id = _rls_current_org_id()) is satisfied. SPEC-TI-010A C-3.
+        if org_id is None:
+            logger.error("Cannot create VexaMeeting: org_id is None for uid=%s", invite.uid)
+            return
+        async with tenant_scoped_session(org_id) as db:
             meeting = VexaMeeting(
                 zitadel_user_id=zitadel_user_id,
                 org_id=org_id,

--- a/klai-portal/backend/tests/test_invite_scheduler_split.py
+++ b/klai-portal/backend/tests/test_invite_scheduler_split.py
@@ -1,0 +1,125 @@
+# SPEC-TI-010A C-3: invite_scheduler split cross_org SELECT vs tenant INSERT.
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def _make_invite(uid: str = "test-uid-001", org_id: int = 42) -> MagicMock:
+    invite = MagicMock()
+    invite.uid = uid
+    invite.org_id = org_id
+    invite.bot_name = "Klai Bot"
+    invite.meeting_url = "https://meet.example.com/abc"
+    invite.user_id = "user-a"
+    invite.meeting_id = "meeting-001"
+    return invite
+
+
+class TestJoinMeetingSessionSplit:
+    async def test_dedup_uses_cross_org_and_insert_uses_tenant(self) -> None:
+        cross_org_called = False
+        tenant_called = False
+
+        @asynccontextmanager
+        async def fake_cross_org():
+            nonlocal cross_org_called
+            cross_org_called = True
+            db = MagicMock()
+            db.scalar = AsyncMock(return_value=None)
+            yield db
+
+        @asynccontextmanager
+        async def fake_tenant(org_id: int):
+            nonlocal tenant_called
+            tenant_called = True
+            db = MagicMock()
+            db.add = MagicMock()
+            db.commit = AsyncMock()
+            db.refresh = AsyncMock()
+            yield db
+
+        async def fake_start_bot(*_a, **_kw):
+            pass
+
+        invite = _make_invite()
+        with (
+            patch("app.services.invite_scheduler.cross_org_session", fake_cross_org),
+            patch("app.services.invite_scheduler.tenant_scoped_session", fake_tenant),
+            patch(
+                "app.services.invite_scheduler._start_vexa_bot",
+                new=fake_start_bot,
+            ),
+        ):
+            from app.services.invite_scheduler import _join_meeting
+
+            await _join_meeting(invite)
+
+        assert cross_org_called, "cross_org_session must be used for dedup SELECT (C-3)"
+        assert tenant_called, "tenant_scoped_session must be used for INSERT (C-3)"
+
+    async def test_dedup_short_circuits_when_meeting_exists(self) -> None:
+        tenant_calls = 0
+
+        @asynccontextmanager
+        async def fake_cross_org():
+            db = MagicMock()
+            db.scalar = AsyncMock(return_value=99)
+            yield db
+
+        @asynccontextmanager
+        async def fake_tenant(org_id: int):
+            nonlocal tenant_calls
+            tenant_calls += 1
+            db = MagicMock()
+            db.add = MagicMock()
+            db.commit = AsyncMock()
+            yield db
+
+        invite = _make_invite()
+        with (
+            patch("app.services.invite_scheduler.cross_org_session", fake_cross_org),
+            patch("app.services.invite_scheduler.tenant_scoped_session", fake_tenant),
+        ):
+            from app.services.invite_scheduler import _join_meeting
+
+            await _join_meeting(invite)
+
+        assert tenant_calls == 0, "INSERT must NOT run when meeting already exists"
+
+    async def test_tenant_session_receives_invite_org_id(self) -> None:
+        received_org_id = None
+
+        @asynccontextmanager
+        async def fake_cross_org():
+            db = MagicMock()
+            db.scalar = AsyncMock(return_value=None)
+            yield db
+
+        @asynccontextmanager
+        async def fake_tenant(org_id: int):
+            nonlocal received_org_id
+            received_org_id = org_id
+            db = MagicMock()
+            db.add = MagicMock()
+            db.commit = AsyncMock()
+            db.refresh = AsyncMock()
+            yield db
+
+        async def fake_start_bot(*_a, **_kw):
+            pass
+
+        invite = _make_invite(org_id=77)
+        with (
+            patch("app.services.invite_scheduler.cross_org_session", fake_cross_org),
+            patch("app.services.invite_scheduler.tenant_scoped_session", fake_tenant),
+            patch(
+                "app.services.invite_scheduler._start_vexa_bot",
+                new=fake_start_bot,
+            ),
+        ):
+            from app.services.invite_scheduler import _join_meeting
+
+            await _join_meeting(invite)
+
+        assert received_org_id == 77, "tenant_scoped_session must be called with invite.org_id"

--- a/klai-scribe/scribe-api/alembic/versions/0008_add_org_id_to_transcriptions.py
+++ b/klai-scribe/scribe-api/alembic/versions/0008_add_org_id_to_transcriptions.py
@@ -1,0 +1,51 @@
+"""add org_id to scribe.transcriptions for tenant isolation
+
+Revision ID: 0008_add_org_id_ti010a
+Revises: 0007_c5f9e3a4
+Create Date: 2026-05-05 00:00:00.000000
+
+SPEC-TI-010A Finding A-9.
+
+Adds ``org_id`` (Zitadel org resource-owner ID) to ``scribe.transcriptions``
+so that the table can enforce per-tenant isolation in addition to per-user
+scoping.  Without ``org_id`` a user account that migrates from org A to org B
+retains access to org A transcripts via ``user_id`` (Zitadel sub) alone.
+
+Column is ``NOT NULL DEFAULT ''`` -- the empty string acts as a sentinel for
+historical rows.  The post-deploy SQL file
+``post_deploy_0008_add_org_id_ti010a_rls.sql`` adds a Cat-D RLS policy that
+reads ``scribe._rls_current_org_id()``.  Because there are no production
+users yet (scribe is in limited-preview), no backfill is required and the
+empty-string sentinel is acceptable for the rollout window.
+
+Down-revision removes the column and index.
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0008_add_org_id_ti010a"
+down_revision: str | Sequence[str] | None = "0007_c5f9e3a4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "transcriptions",
+        sa.Column("org_id", sa.VARCHAR(255), nullable=False, server_default=""),
+        schema="scribe",
+    )
+    op.create_index(
+        "ix_transcriptions_org_user",
+        "transcriptions",
+        ["org_id", "user_id"],
+        schema="scribe",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_transcriptions_org_user", table_name="transcriptions", schema="scribe")
+    op.drop_column("transcriptions", "org_id", schema="scribe")

--- a/klai-scribe/scribe-api/alembic/versions/post_deploy_0008_add_org_id_ti010a_rls.sql
+++ b/klai-scribe/scribe-api/alembic/versions/post_deploy_0008_add_org_id_ti010a_rls.sql
@@ -1,0 +1,46 @@
+-- post_deploy_0008_add_org_id_ti010a_rls.sql
+-- SPEC-TI-010A Finding A-9 -- Cat-D RLS on scribe.transcriptions
+--
+-- Run as the klai superuser AFTER alembic upgrade head completes:
+--   ssh core-01 "docker exec -i klai-core-postgres-1 psql -U klai -d klai" \
+--     < klai-scribe/scribe-api/alembic/versions/post_deploy_0008_add_org_id_ti010a_rls.sql
+--
+-- Idempotent (uses CREATE OR REPLACE / IF NOT EXISTS).
+
+BEGIN;
+
+-- Helper function that reads the GUC set by the app layer.
+-- Mirrors the pattern used in connector schema (SPEC-TI-002).
+CREATE OR REPLACE FUNCTION scribe._rls_current_org_id()
+RETURNS text
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+AS $$
+    SELECT NULLIF(current_setting('app.current_org_id', true), '')
+$$;
+
+-- Enable RLS on the table.
+ALTER TABLE scribe.transcriptions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE scribe.transcriptions FORCE ROW LEVEL SECURITY;
+
+-- Drop existing policy if present (idempotent re-run).
+DROP POLICY IF EXISTS tenant_isolation ON scribe.transcriptions;
+
+-- Cat-D policy: strict USING + WITH CHECK.
+-- The IS NULL branch allows the reaper and any cross-org maintenance
+-- operation that explicitly avoids setting the GUC (cross_org_session).
+CREATE POLICY tenant_isolation ON scribe.transcriptions
+    FOR ALL
+    USING (
+        org_id = scribe._rls_current_org_id()
+        OR scribe._rls_current_org_id() IS NULL
+    )
+    WITH CHECK (
+        org_id = scribe._rls_current_org_id()
+    );
+
+-- Grant the scribe role access to the helper function.
+GRANT EXECUTE ON FUNCTION scribe._rls_current_org_id() TO scribe_api;
+
+COMMIT;

--- a/klai-scribe/scribe-api/app/api/transcribe.py
+++ b/klai-scribe/scribe-api/app/api/transcribe.py
@@ -22,7 +22,7 @@ from pydantic import BaseModel
 from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.auth import CallerIdentity, get_authenticated_caller, get_current_user_id
+from app.core.auth import CallerIdentity, get_authenticated_caller
 from app.core.config import settings
 from app.core.database import get_db
 from app.models.transcription import Transcription
@@ -126,7 +126,8 @@ def _to_response(record: Transcription) -> TranscriptionResponse:
 async def transcribe(
     file: UploadFile = File(...),
     language: str | None = Form(default=None),
-    user_id: str = Depends(get_current_user_id),
+    # SPEC-TI-010A A-9: org_id captured at INSERT time for tenant isolation.
+    caller: CallerIdentity = Depends(get_authenticated_caller),
     db: AsyncSession = Depends(get_db),
 ) -> TranscriptionResponse:
     """Upload audio, persist to disk, attempt transcription.
@@ -154,7 +155,7 @@ async def transcribe(
     # sub), but the SPEC asks the caller to map ValueError → 400.
     txn_id = "txn_" + uuid.uuid4().hex
     try:
-        audio_path = await loop.run_in_executor(None, save_audio, user_id, txn_id, wav_bytes)
+        audio_path = await loop.run_in_executor(None, save_audio, caller.user_id, txn_id, wav_bytes)
     except ValueError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -162,9 +163,11 @@ async def transcribe(
         ) from exc
 
     # Create DB record with status=processing
+    # SPEC-TI-010A A-9: org_id from portal-verified CallerIdentity.
     record = Transcription(
         id=txn_id,
-        user_id=user_id,
+        org_id=caller.org_id,
+        user_id=caller.user_id,
         name=filename if filename != "upload" else None,
         status="processing",
         audio_path=audio_path,
@@ -213,14 +216,16 @@ async def transcribe(
 async def retry_transcription(
     txn_id: str,
     language: str | None = Query(default=None),
-    user_id: str = Depends(get_current_user_id),
+    # SPEC-TI-010A A-9: org_id-scoped lookup.
+    caller: CallerIdentity = Depends(get_authenticated_caller),
     db: AsyncSession = Depends(get_db),
 ) -> TranscriptionResponse:
     """Retry transcription for a failed record using the preserved audio file."""
     result = await db.execute(
         select(Transcription).where(
             Transcription.id == txn_id,
-            Transcription.user_id == user_id,
+            Transcription.user_id == caller.user_id,
+            Transcription.org_id == caller.org_id,
         )
     )
     record = result.scalar_one_or_none()
@@ -275,17 +280,24 @@ async def retry_transcription(
 async def list_transcriptions(
     limit: int = Query(default=20, ge=1, le=100),
     offset: int = Query(default=0, ge=0),
-    user_id: str = Depends(get_current_user_id),
+    # SPEC-TI-010A A-9: org_id-scoped listing.
+    caller: CallerIdentity = Depends(get_authenticated_caller),
     db: AsyncSession = Depends(get_db),
 ) -> TranscriptionListResponse:
     total_result = await db.execute(
-        select(func.count()).select_from(Transcription).where(Transcription.user_id == user_id)
+        select(func.count()).select_from(Transcription).where(
+            Transcription.user_id == caller.user_id,
+            Transcription.org_id == caller.org_id,
+        )
     )
     total = total_result.scalar_one()
 
     rows = await db.execute(
         select(Transcription)
-        .where(Transcription.user_id == user_id)
+        .where(
+            Transcription.user_id == caller.user_id,
+            Transcription.org_id == caller.org_id,
+        )
         .order_by(Transcription.created_at.desc())
         .limit(limit)
         .offset(offset)
@@ -315,13 +327,15 @@ async def list_transcriptions(
 @router.get("/transcriptions/{txn_id}", response_model=TranscriptionResponse)
 async def get_transcription(
     txn_id: str,
-    user_id: str = Depends(get_current_user_id),
+    # SPEC-TI-010A A-9: org_id-scoped lookup.
+    caller: CallerIdentity = Depends(get_authenticated_caller),
     db: AsyncSession = Depends(get_db),
 ) -> TranscriptionResponse:
     result = await db.execute(
         select(Transcription).where(
             Transcription.id == txn_id,
-            Transcription.user_id == user_id,
+            Transcription.user_id == caller.user_id,
+            Transcription.org_id == caller.org_id,
         )
     )
     record = result.scalar_one_or_none()
@@ -337,14 +351,16 @@ async def get_transcription(
 async def patch_transcription(
     txn_id: str,
     body: TranscriptionPatch,
-    user_id: str = Depends(get_current_user_id),
+    # SPEC-TI-010A A-9: org_id-scoped lookup.
+    caller: CallerIdentity = Depends(get_authenticated_caller),
     db: AsyncSession = Depends(get_db),
 ) -> TranscriptionResponse:
     """Update the name of a transcription."""
     result = await db.execute(
         select(Transcription).where(
             Transcription.id == txn_id,
-            Transcription.user_id == user_id,
+            Transcription.user_id == caller.user_id,
+            Transcription.org_id == caller.org_id,
         )
     )
     record = result.scalar_one_or_none()
@@ -363,13 +379,15 @@ async def patch_transcription(
 @router.delete("/transcriptions/{txn_id}", status_code=204)
 async def delete_transcription(
     txn_id: str,
-    user_id: str = Depends(get_current_user_id),
+    # SPEC-TI-010A A-9: org_id-scoped lookup.
+    caller: CallerIdentity = Depends(get_authenticated_caller),
     db: AsyncSession = Depends(get_db),
 ) -> None:
     result = await db.execute(
         select(Transcription).where(
             Transcription.id == txn_id,
-            Transcription.user_id == user_id,
+            Transcription.user_id == caller.user_id,
+            Transcription.org_id == caller.org_id,
         )
     )
     record = result.scalar_one_or_none()
@@ -382,7 +400,8 @@ async def delete_transcription(
     await db.execute(
         delete(Transcription).where(
             Transcription.id == txn_id,
-            Transcription.user_id == user_id,
+            Transcription.user_id == caller.user_id,
+            Transcription.org_id == caller.org_id,
         )
     )
     await db.commit()
@@ -395,14 +414,16 @@ async def summarize_transcription(
     txn_id: str,
     body: SummarizeRequest,
     force: bool = Query(default=False),
-    user_id: str = Depends(get_current_user_id),
+    # SPEC-TI-010A A-9: org_id-scoped lookup.
+    caller: CallerIdentity = Depends(get_authenticated_caller),
     db: AsyncSession = Depends(get_db),
 ) -> SummarizeResponse:
     """Generate an AI summary for a transcription."""
     result = await db.execute(
         select(Transcription).where(
             Transcription.id == txn_id,
-            Transcription.user_id == user_id,
+            Transcription.user_id == caller.user_id,
+            Transcription.org_id == caller.org_id,
         )
     )
     record = result.scalar_one_or_none()

--- a/klai-scribe/scribe-api/app/models/transcription.py
+++ b/klai-scribe/scribe-api/app/models/transcription.py
@@ -13,6 +13,11 @@ class Transcription(Base):
     __table_args__ = {"schema": "scribe"}
 
     id = Column(VARCHAR(64), primary_key=True)
+    # SPEC-TI-010A A-9: org_id added for per-tenant isolation.  Zitadel org
+    # resource-owner ID (string, NOT int) so it aligns with the Zitadel
+    # org namespace rather than the portal_orgs.id surrogate key.
+    # Populated at INSERT time from CallerIdentity.org_id (portal-verified).
+    org_id = Column(VARCHAR(255), nullable=False, default="", index=False)
     user_id = Column(VARCHAR(128), nullable=False, index=True)
     name = Column(VARCHAR(255), nullable=True)
     status = Column(VARCHAR(16), nullable=False, default="transcribed")
@@ -27,7 +32,7 @@ class Transcription(Base):
     recording_type = Column(VARCHAR(32), nullable=True)
     segments_json = Column(JSON, nullable=True)
     created_at = Column(TIMESTAMP(timezone=True), nullable=False, default=datetime.utcnow)
-    # SPEC-SEC-HYGIENE-001 REQ-35 — populated by the stranded-row reaper
+    # SPEC-SEC-HYGIENE-001 REQ-35 -- populated by the stranded-row reaper
     # (`app.services.reaper.reap_stranded`) when a row is flipped from
     # `processing` to `failed` after worker restart. Nullable: legitimate
     # transitions to `failed` (whisper error during transcribe) leave it null.

--- a/klai-scribe/scribe-api/app/services/reaper.py
+++ b/klai-scribe/scribe-api/app/services/reaper.py
@@ -53,6 +53,10 @@ async def reap_stranded(session: AsyncSession, timeout_min: int) -> int:
 
     SPEC-SEC-HYGIENE-001 REQ-35.1, REQ-35.2, REQ-35.3.
     """
+    # cross-user-by-design: Transcription has user_id (and now org_id from A-9).
+    # Reaper sweeps all users/tenants at startup to recover stranded rows regardless of
+    # org context; filtered per-tenant queries happen in the regular endpoints.
+    # SPEC-TI-010A / C-8.
     cutoff = datetime.now(UTC) - timedelta(minutes=timeout_min)
 
     result = await session.execute(

--- a/klai-scribe/scribe-api/tests/test_transcriptions_org_id.py
+++ b/klai-scribe/scribe-api/tests/test_transcriptions_org_id.py
@@ -1,0 +1,156 @@
+# SPEC-TI-010A A-9: org_id tenant isolation on Transcription endpoints.
+# Cross-org access -> 404 (never leak existence).
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.core.auth import CallerIdentity
+
+
+def _make_db(results: list) -> MagicMock:
+    db = MagicMock()
+    db.add = MagicMock()
+    db.commit = AsyncMock()
+    db.flush = AsyncMock()
+    db.refresh = AsyncMock()
+    execute_returns = iter(results)
+
+    async def _execute(*_a, **_kw):
+        return next(execute_returns)
+
+    db.execute = _execute
+    return db
+
+
+def _scalar_result(value) -> MagicMock:
+    r = MagicMock()
+    r.scalar_one_or_none = MagicMock(return_value=value)
+    r.scalar_one = MagicMock(return_value=value)
+    return r
+
+
+def _make_transcription(user_id: str, org_id: str) -> MagicMock:
+    t = MagicMock()
+    t.id = "txn-001"
+    t.user_id = user_id
+    t.org_id = org_id
+    t.status = "completed"
+    t.name = "meeting"
+    t.text = "hello"
+    t.audio_path = "/data/" + user_id + "/txn-001.wav"
+    t.duration_seconds = 60
+    t.segments_json = None
+    t.created_at = None
+    t.updated_at = None
+    return t
+
+
+class TestTranscriptionOrgIsolation:
+    async def test_get_returns_404_for_cross_org(self) -> None:
+        from app.api.transcribe import get_transcription
+
+        db = _make_db([_scalar_result(None)])
+        caller = CallerIdentity(user_id="user-a", org_id="org-attacker")
+        with pytest.raises(HTTPException) as exc_info:
+            await get_transcription(txn_id="txn-victim", caller=caller, db=db)
+        assert exc_info.value.status_code == 404
+
+    async def test_patch_returns_404_for_cross_org(self) -> None:
+        from app.api.transcribe import PatchTranscriptionRequest, patch_transcription
+
+        db = _make_db([_scalar_result(None)])
+        caller = CallerIdentity(user_id="user-a", org_id="org-attacker")
+        with pytest.raises(HTTPException) as exc_info:
+            await patch_transcription(
+                txn_id="txn-victim",
+                body=PatchTranscriptionRequest(name="pwned"),
+                caller=caller,
+                db=db,
+            )
+        assert exc_info.value.status_code == 404
+
+    async def test_delete_returns_404_for_cross_org(self) -> None:
+        from app.api.transcribe import delete_transcription
+
+        db = _make_db([_scalar_result(None)])
+        caller = CallerIdentity(user_id="user-a", org_id="org-attacker")
+        with pytest.raises(HTTPException) as exc_info:
+            await delete_transcription(txn_id="txn-victim", caller=caller, db=db)
+        assert exc_info.value.status_code == 404
+
+    async def test_list_excludes_cross_org_rows(self) -> None:
+        from app.api.transcribe import list_transcriptions
+
+        count_result = _scalar_result(0)
+        rows_result = MagicMock()
+        rows_result.scalars = MagicMock(return_value=MagicMock(all=MagicMock(return_value=[])))
+        db = _make_db([count_result, rows_result])
+        caller = CallerIdentity(user_id="user-a", org_id="org-attacker")
+        response = await list_transcriptions(caller=caller, db=db)
+        assert response.total == 0
+        assert response.items == []
+
+    async def test_same_org_access_succeeds(self) -> None:
+        from app.api.transcribe import get_transcription
+
+        txn = _make_transcription(user_id="user-a", org_id="org-a")
+        db = _make_db([_scalar_result(txn)])
+        caller = CallerIdentity(user_id="user-a", org_id="org-a")
+        response = await get_transcription(txn_id="txn-001", caller=caller, db=db)
+        assert response.id == "txn-001"
+
+    async def test_different_user_same_org_returns_404(self) -> None:
+        from app.api.transcribe import get_transcription
+
+        db = _make_db([_scalar_result(None)])
+        caller = CallerIdentity(user_id="user-b", org_id="org-a")
+        with pytest.raises(HTTPException) as exc_info:
+            await get_transcription(txn_id="txn-001", caller=caller, db=db)
+        assert exc_info.value.status_code == 404
+
+
+class TestTranscriptionOrgIdInsert:
+    async def test_ingest_passes_caller_org_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.api.transcribe import IngestToKBRequest, ingest_transcription_to_kb
+
+        txn = _make_transcription(user_id="user-a", org_id="org-a")
+        db = _make_db([_scalar_result(txn)])
+        captured: dict = {}
+
+        async def fake_ingest(*, org_id: str, kb_slug: str, transcription) -> str:
+            captured["org_id"] = org_id
+            return "art-001"
+
+        monkeypatch.setattr("app.services.knowledge_adapter.ingest_scribe_transcript", fake_ingest)
+        caller = CallerIdentity(user_id="user-a", org_id="org-a")
+        await ingest_transcription_to_kb(
+            txn_id="txn-001",
+            body=IngestToKBRequest(kb_slug="team-notes"),
+            caller=caller,
+            db=db,
+        )
+        assert captured["org_id"] == "org-a", "ingest must forward caller.org_id (A-9)"
+
+    async def test_ingest_cross_org_denied(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.api.transcribe import IngestToKBRequest, ingest_transcription_to_kb
+
+        db = _make_db([_scalar_result(None)])
+        caller = CallerIdentity(user_id="user-a", org_id="org-attacker")
+
+        async def _should_not_run(**_kw) -> str:
+            raise AssertionError("ingest must not run when lookup fails")
+
+        monkeypatch.setattr(
+            "app.services.knowledge_adapter.ingest_scribe_transcript", _should_not_run
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await ingest_transcription_to_kb(
+                txn_id="txn-victim",
+                body=IngestToKBRequest(kb_slug="team-notes"),
+                caller=caller,
+                db=db,
+            )
+        assert exc_info.value.status_code == 404


### PR DESCRIPTION
## Summary

SPEC-TI-010A (sub-pakket A of SPEC-TI-010-CLEANUP-BATCH) resolves 7 tenant-isolation audit findings.

### A-9 — scribe org_id column

- **Migration** `0008_add_org_id_to_transcriptions`: adds `org_id VARCHAR(255) NOT NULL DEFAULT ''` to `scribe.transcriptions` + composite index `ix_transcriptions_org_user` on `(org_id, user_id)`.
- **Model** `Transcription`: new `org_id` column.
- **Endpoints** (all 7): switched from `get_current_user_id` to `get_authenticated_caller` so `org_id` is portal-verified (not JWT resourceowner). `org_id = caller.org_id` added to INSERT and every WHERE clause.
- **RLS** (post-deploy): `post_deploy_0008_add_org_id_ti010a_rls.sql` — Cat-D policy with `_rls_current_org_id()` helper; reaper exempt via `IS NULL` branch.

### C-3 — invite_scheduler session split

`_join_meeting` now uses `cross_org_session()` for the dedup SELECT and `tenant_scoped_session(org_id)` for the VexaMeeting INSERT. Previously both ran inside a single `cross_org_session()`.

### C-4 — stuck-detector marker

Added `# cross-org-by-design: stuck-detector must scan all orgs at startup...` comment to `_run_stuck_detector` in `klai-portal/backend/app/main.py`.

### C-5 — internal_connectors marker + set_tenant

Added `# cross-org-by-design:` comment to `finalize_connector_delete` + `await set_tenant(db, connector.org_id)` after the connector lookup.

### C-6, C-7 — already done by SPEC-TI-002

Connector lifespan and SyncRunReaper already have `cross-org-by-design` comments and use `cross_org_session()`. No changes needed.

### C-8 — scribe reaper comment

Added `# cross-user-by-design:` comment to `reap_stranded` in `klai-scribe/scribe-api/app/services/reaper.py`.

## Tests

- `klai-scribe/scribe-api/tests/test_transcriptions_org_id.py`: 8 cases — cross-org 404 for get/patch/delete/list; ingest org_id propagation; same-org success baseline.
- `klai-portal/backend/tests/test_invite_scheduler_split.py`: 3 cases — session split, dedup short-circuit, tenant org_id forwarding.

## Operator steps (post-deploy)

After `klai-scribe` CI deploys (scribe-api auto-runs `alembic upgrade head` via entrypoint.sh), apply the RLS policy as `klai` superuser:

```bash
docker exec -i klai-core-postgres-1 psql -U klai -d klai \
  < klai-scribe/scribe-api/alembic/versions/post_deploy_0008_add_org_id_ti010a_rls.sql
```

Verify:
```sql
SELECT relrowsecurity FROM pg_class WHERE relname = 'transcriptions' AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'scribe');
-- must be: t
SELECT polname FROM pg_policy WHERE polrelid = 'scribe.transcriptions'::regclass;
-- must show: tenant_isolation_select, tenant_isolation_insert
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)