### PR TITLE
fix(SPEC-TI-002): rename RLS helper to _rls_current_org_text() — Postgres has no return-type overload

### DIFF
--- a/.claude/rules/klai/pitfalls/process-rules.md
+++ b/.claude/rules/klai/pitfalls/process-rules.md
@@ -1,5 +1,56 @@
 # Process Rules
 
+## postgres-no-return-type-overload (HIGH)
+PostgreSQL does NOT support function overloading by return type alone.
+Two zero-argument functions with the same name and different return
+types cannot coexist in the same schema. `CREATE OR REPLACE FUNCTION`
+on an existing function with a different return type fails with:
+
+```
+ERROR:  cannot change return type of existing function
+HINT:  Use DROP FUNCTION _rls_current_org_id() first.
+```
+
+Reference: SPEC-TI-002 (PR #375, 2026-05-06). The post-deploy SQL
+declared `_rls_current_org_id() RETURNS text` next to portal-api's
+existing `_rls_current_org_id() RETURNS integer`. The SPEC author
+believed Postgres allowed return-type overloading; it does not. The
+migration's ENABLE+FORCE RLS step succeeded but the policy creation
+aborted, leaving connector.connectors and connector.sync_runs with
+default-deny RLS and no policies — a 100% read/write block on every
+connector operation.
+
+Recovered by hot-renaming to `_rls_current_org_text()` in prod via
+post-deploy SQL, then back-filling the source tree
+(fix/SPEC-TI-002-rls-function-name-collision).
+
+**Prevention:**
+
+1. **Schema-qualify per-service RLS helpers.** Each service that needs a
+   different-typed `_rls_current_org_id` should put it in its own
+   schema (e.g. `connector._rls_current_org_id() RETURNS text`,
+   `knowledge._rls_current_org_id() RETURNS text`,
+   `public._rls_current_org_id() RETURNS integer`). Schema-qualified
+   functions don't collide. SPEC-TI-003 already does this correctly
+   with `knowledge._rls_current_org_id()`.
+
+2. **Or use a clearly-different name.** `_rls_current_org_text()` /
+   `_rls_current_org_int()` / `_rls_current_<service>_org()` make the
+   type explicit at the call site and remove ambiguity in policy
+   definitions.
+
+3. **Never rely on "return type overloading".** It is not a Postgres
+   feature regardless of how the docs read at first glance. The actual
+   overloading dimension is parameter list (zero-arg vs one-arg vs
+   two-arg, OR same arity but different parameter types). Return type
+   alone is never enough.
+
+4. **Smoke-test the post-deploy SQL on a non-prod DB before merging
+   the SPEC.** Apply against a snapshot or stage DB. Any error here is
+   a deployment-blocker — production policies must exist BEFORE the
+   alembic migration ENABLE+FORCEs RLS, or the table becomes default-
+   deny with no recourse from the application layer.
+
 ## scale-the-answer-to-the-problem (HIGH)
 When a user asks "what is industry standard?" do not autopilot to the
 most architecturally-elegant answer in the search results. Anchor on

--- a/klai-connector/alembic/versions/008_rls_tenant_isolation.py
+++ b/klai-connector/alembic/versions/008_rls_tenant_isolation.py
@@ -14,7 +14,7 @@ cross-tenant data leak.
 
 This migration enables ENABLE + FORCE ROW LEVEL SECURITY on both tables.
 It does NOT create the RLS policies; policies (and the helper function
-_rls_current_org_id()) require CREATE FUNCTION / CREATE POLICY privileges
+_rls_current_org_text()) require CREATE FUNCTION / CREATE POLICY privileges
 that belong to the ``klai`` superuser role, NOT to the ``connector_api``
 role that alembic runs as. Those DDL statements live in the companion
 post-deploy SQL file:

--- a/klai-connector/alembic/versions/post_deploy_008_rls_tenant_isolation.sql
+++ b/klai-connector/alembic/versions/post_deploy_008_rls_tenant_isolation.sql
@@ -1,56 +1,30 @@
--- post_deploy_008_rls_tenant_isolation.sql
--- Run as `klai` superuser. The Alembic migration role (`connector_api`)
--- cannot CREATE OR REPLACE FUNCTION or CREATE POLICY.
+-- post_deploy_008_rls_tenant_isolation.sql — HOTFIX 2026-05-06
+-- Run as `klai` superuser.
+--
+-- Hotfix rationale:
+--   PostgreSQL does NOT support function overloading by return type alone.
+--   The original SPEC-TI-002 SQL assumed it could create a `text`-returning
+--   variant of `_rls_current_org_id()` next to portal-api's `integer`
+--   variant. CREATE OR REPLACE FUNCTION rejects this with
+--     "ERROR: cannot change return type of existing function"
+--   Rename the connector helper to `_rls_current_org_text()` and update the
+--   policies to call the renamed function.
+--
+-- This SQL file is the prod-applied fix; a follow-up commit will sync the
+-- repo copy at klai-connector/alembic/versions/post_deploy_008_rls_tenant_isolation.sql.
 -- Idempotent: safe to re-run.
---
--- SPEC-TI-002 / audit finding A-7 (tenant-isolation audit 2026-05-05)
---
--- What this does
--- --------------
--- 1. Creates _rls_current_org_id() RETURNS text in the public schema
---    (shared with portal-api's integer variant — they coexist because
---     the connector schema's org_id is text/varchar, not integer).
---    The function is overloaded by return type; if a text variant already
---    exists it is replaced with CREATE OR REPLACE.
---    - Returns NULL  when app.cross_org_admin = 'true'  (cross_org bypass)
---    - Returns the org_id text  when app.current_org_id is set
---    - RAISES 42501  when neither GUC is set  (fail-loud Cat-D policy)
---
--- 2. Creates Cat-D tenant_isolation policies on connector.connectors and
---    connector.sync_runs using the helper function.
---
---    USING:      org_id = _rls_current_org_id() OR _rls_current_org_id() IS NULL
---    WITH CHECK: org_id = _rls_current_org_id()  -- no IS NULL branch intentionally
---
---    The WITH CHECK deliberately lacks the IS NULL branch. An INSERT or UPDATE
---    must always carry an explicit org_id matching the calling tenant context.
---    Cross-org sessions may SELECT across tenants but NOT INSERT/UPDATE without
---    an explicit org_id. This prevents "orphan row" bugs. See standards.md §1.
---
--- Deployment order
--- ----------------
--- 1. Alembic migration 008_rls_tenant_isolation runs first (ENABLE + FORCE).
--- 2. Run this file as klai superuser.
--- 3. Restart klai-connector so the updated session-helpers are active.
--- 4. Smoke-test: connector sync trigger, list sync runs.
---
--- Operator command
--- ----------------
--- ssh core-01 "docker exec -i klai-core-postgres-1 psql -U klai -d klai" \
---   < klai-connector/alembic/versions/post_deploy_008_rls_tenant_isolation.sql
 
 BEGIN;
 
 -- ----------------------------------------------------------------------------
--- 1. Helper function: _rls_current_org_id() RETURNS text
+-- 1. Helper function: _rls_current_org_text() RETURNS text
 --
 -- connector schema uses org_id VARCHAR(255) — Zitadel resourceowner string.
--- RETURNS text (not integer) — different from portal-api's integer variant.
--- PostgreSQL allows function overloading by return type when used in
--- USING/WITH CHECK expressions directly (no cast ambiguity).
+-- Renamed from `_rls_current_org_id()` to avoid clash with portal-api's
+-- existing integer-returning variant (Postgres has no return-type overload).
 -- STABLE: same result within a transaction for the same session settings.
 -- ----------------------------------------------------------------------------
-CREATE OR REPLACE FUNCTION _rls_current_org_id()
+CREATE OR REPLACE FUNCTION _rls_current_org_text()
     RETURNS text
     LANGUAGE plpgsql
     STABLE
@@ -59,9 +33,6 @@ DECLARE
     v_org    text := current_setting('app.current_org_id', true);
     v_bypass text := current_setting('app.cross_org_admin', true);
 BEGIN
-    -- Explicit bypass for cross-org admin sweeps (cross_org_session() in
-    -- klai-connector/app/core/database.py). Returns NULL so USING policies
-    -- evaluate TRUE for every row (via IS NULL branch).
     IF v_bypass = 'true' THEN
         RETURN NULL;
     END IF;
@@ -78,51 +49,42 @@ BEGIN
 END;
 $$;
 
-COMMENT ON FUNCTION _rls_current_org_id() IS
+COMMENT ON FUNCTION _rls_current_org_text() IS
     'Returns the current tenant org_id (text/varchar) from app.current_org_id GUC. '
     'Returns NULL when app.cross_org_admin=true (cross-org bypass). '
     'RAISES ERRCODE 42501 (insufficient_privilege) when neither GUC is set. '
     'Used by RLS policies on connector.connectors and connector.sync_runs. '
-    'SPEC-TI-002 / finding A-7.';
+    'SPEC-TI-002 / finding A-7. Renamed from _rls_current_org_id() (hotfix 2026-05-06).';
 
 -- Grant EXECUTE to the connector service role if it exists.
--- The role name may differ between environments; adjust as needed.
 DO $$
 BEGIN
     IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'connector_api') THEN
-        EXECUTE 'GRANT EXECUTE ON FUNCTION _rls_current_org_id() TO connector_api';
+        EXECUTE 'GRANT EXECUTE ON FUNCTION _rls_current_org_text() TO connector_api';
     END IF;
 END $$;
 
 -- ----------------------------------------------------------------------------
--- 2. Policy on connector.connectors
---    Cat-D (strict, fail-loud on missing context).
---    USING: allows cross-org bypass (IS NULL branch from helper returning NULL)
---           and per-tenant equality otherwise.
---    WITH CHECK: no NULL branch — INSERT/UPDATE always require explicit org_id.
+-- 2. Policy on connector.connectors (Cat-D, fail-loud).
 -- ----------------------------------------------------------------------------
 DROP POLICY IF EXISTS tenant_isolation ON connector.connectors;
 CREATE POLICY tenant_isolation ON connector.connectors
     FOR ALL
-    USING      (org_id = _rls_current_org_id() OR _rls_current_org_id() IS NULL)
-    WITH CHECK (org_id = _rls_current_org_id());
+    USING      (org_id = _rls_current_org_text() OR _rls_current_org_text() IS NULL)
+    WITH CHECK (org_id = _rls_current_org_text());
 
 -- ----------------------------------------------------------------------------
--- 3. Policy on connector.sync_runs
---    Same Cat-D pattern. sync_runs.org_id is nullable (legacy rows from
---    before migration 006 may have org_id IS NULL). Those rows are
---    effectively invisible to per-tenant queries, but visible under
---    cross_org_session() — needed by the lifespan startup sweep and reaper.
+-- 3. Policy on connector.sync_runs (Cat-D, fail-loud).
+--    sync_runs.org_id is nullable (legacy rows from pre-006 may be NULL).
 -- ----------------------------------------------------------------------------
 DROP POLICY IF EXISTS tenant_isolation ON connector.sync_runs;
 CREATE POLICY tenant_isolation ON connector.sync_runs
     FOR ALL
-    USING      (org_id = _rls_current_org_id() OR _rls_current_org_id() IS NULL)
-    WITH CHECK (org_id = _rls_current_org_id());
+    USING      (org_id = _rls_current_org_text() OR _rls_current_org_text() IS NULL)
+    WITH CHECK (org_id = _rls_current_org_text());
 
--- Sanity marker (visible in psql output, no side-effects in prod):
 SELECT
-    'post_deploy_008 applied — _rls_current_org_id() (text variant) created, '
+    'post_deploy_008 applied (HOTFIX) — _rls_current_org_text() created, '
     'tenant_isolation policies installed on connector.connectors and connector.sync_runs'
     AS status;
 


### PR DESCRIPTION
## Probleem

PR #375 is gemerged op main. De post-deploy SQL declareerde `_rls_current_org_id() RETURNS text` in het public-schema náást de bestaande integer-variant van portal-api. PostgreSQL ondersteunt **geen** function-overloading op alleen return type. `CREATE OR REPLACE FUNCTION` weigerde met:

```
ERROR:  cannot change return type of existing function
HINT:  Use DROP FUNCTION _rls_current_org_id() first.
```

Resultaat: ENABLE+FORCE RLS op connector.connectors / connector.sync_runs zonder policies → default-deny → 100% blocked op alle connector queries zodra de connector-deploy de alembic migratie 008 uitvoert.

## Recovery

Direct na merge gedetecteerd voordat de connector-deploy klaar was. Hot-applied een hernoemde-functie variant (`_rls_current_org_text()`) op prod via direct SQL. Dit PR back-fillt de source tree zodat re-runs / docs / nieuwe omgevingen consistent zijn.

Geen application-code change nodig — apps zetten alleen GUCs (`app.current_org_id`, `app.cross_org_admin`); de policies roepen de functie aan.

## Verificatie

```
$ ssh core-01 "docker exec klai-core-postgres-1 psql -U klai -d klai -c \"SELECT proname, pg_get_function_result(p.oid) FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace WHERE proname LIKE '_rls_current_org%';\""
       proname        | pg_get_function_result
----------------------+------------------------
 _rls_current_org_id  | integer
 _rls_current_org_text | text
```

```
$ ssh core-01 "docker exec klai-core-postgres-1 psql -U klai -d klai -c \"SELECT schemaname, tablename, policyname FROM pg_policies WHERE schemaname='connector';\""
 schemaname  |  tablename  |    policyname
-------------+-------------+-------------------
 connector   | connectors  | tenant_isolation
 connector   | sync_runs   | tenant_isolation
```

## Pitfall toegevoegd

`postgres-no-return-type-overload` (HIGH) in `.claude/rules/klai/pitfalls/process-rules.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)