### PR TITLE
docs(audit): retrieval coupling audit 2026-05-06

### DIFF
--- a/.moai/audits/retrieval-coupling-2026-05-06/audit.md
+++ b/.moai/audits/retrieval-coupling-2026-05-06/audit.md
@@ -1,0 +1,70 @@
+# Retrieval coupling audit — 2026-05-06
+
+## Context
+
+Audit-vraag (Mark, 2026-05-06): is de `/retrieve` pipeline van klai-retrieval-api correct gekoppeld? Werken alle stappen samen zoals bedoeld, geven callers het juiste mee, en gaat er niets stilletjes verloren?
+
+Methodologie: pure code-following. Pipeline gevolgd vanaf [`POST /retrieve`](../../../klai-retrieval-api/retrieval_api/api/retrieve.py) entry point, doorheen alle services (search, reranker, gate, router, evidence_tier, parent_lookup, diversity, graph_search), tot en met de 4 callers.
+
+## Wijzigingen op eerdere versie
+
+- **Schrapping van findings #1 + #3 (focus narrow + broad):** klai-focus is via `SPEC-DECOMM-FOCUS-001` (PR #368, commit `e6fabc73`) van main verwijderd. De code-paden in `klai-focus/research-api/app/services/retrieval_client.py` (`retrieve_narrow` / `retrieve_broad`) bestaan dus niet meer als runtime-callers — eerste bevindingen waren gebaseerd op een working tree die nog op een pre-decommissie branch zat.
+- **Nieuwe finding F5:** notebook-scope code-pad in retrieval-api zelf (`_search_notebook`, `_notebook_filter`, `qdrant_focus_collection` setting, `scope="notebook"`/`"broad"` branches) is door bovenstaande decommissie volledig onbereikbaar geworden — code blijft staan, maar geen enkele live caller raakt het meer.
+
+## Pipeline-overzicht (verifiëring)
+
+`POST /retrieve` flow zoals werkelijk gewired in `retrieve.py`:
+
+1. Auth (scope `klai:internal:retrieval:query` of internal-secret bypass) → `verify_body_identity` pinst `request.state.verified_caller`.
+2. Coreference rewrite (LiteLLM, klai-fast model, 3-turn historie).
+3. Embed dense + sparse parallel via TEI + BGE-M3-sparse sidecar.
+4. Gate-check tegen reference-vectors in `data/gate_reference.jsonl` — bypass bij top1-top2 margin > 0.1.
+5. Query-router (3 lagen: keyword → semantic centroids → optional LLM) bepaalt source-selectie als kb_slugs niet expliciet meegegeven.
+6. Hybrid search Qdrant (3-leg RRF: vector_chunk + vector_questions + vector_sparse) + parallel Graphiti graph search.
+7. RRF-merge over beide via `1/(k+rank+1)`, `k=60`.
+8. Link expansion (1-hop op `links_to` payload).
+9. Authority boost: `score += 0.05 * log(1 + incoming_link_count)`.
+10. Cross-encoder rerank via Infinity (`bge-reranker-v2-m3`).
+11. Source-aware select (mention-detect + per-source quota).
+12. Quality boost (feedback-based, ≥3 votes).
+13. Evidence-tier scoring + U-shape ordering — **shadow mode by default** (geserveerde volgorde = flat reranker).
+14. Parent-text swap (child → parent chunk via `knowledge.parent_chunks`).
+15. Telemetry: `step_latency_seconds`, `retrieval_decision_record` log, `knowledge.queried` product event (uit `verified_caller`, niet uit body).
+
+## Findings
+
+| ID | Severity | Title | Status na agent-verificatie |
+|---|---|---|---|
+| F1 | HIGH (latent) | gap_rescorer authentiseert met `Authorization: Bearer <internal_secret>` — wordt door retrieval-api als JWT geïnterpreteerd → 401 | **CONFIRMED, currently DORMANT.** `portal_retrieval_gaps` is leeg op prod (LiteLLM gap-emit pipeline brak 7 dagen geleden); bug fired niet in steady state, maar fired op eerste herstel van gap-emit. Test mockt alleen `X-Caller-Service`, niet de auth-header. Fix: 1-line + assert-test. |
+| F2 | LOW (latent) | partner_chat dropt `knowledge.queried` events (geen user_id → geen verified_caller) | **NOT-A-BUG-BUT-DESIGN.** SPEC-API-001 zegt expliciet "partners have no end-user concept". 0 actieve partner-keys op prod, dus latente lacune. Recommended: synthetic `user_id=f"partner:{key_id}"` + auth.py `partner:`-prefix bypass. |
+| F3 | INFO | Link-expansion: score=0 + authority boost beïnvloeden top-20 reranker niet | **PARTIALLY CONFIRMED — math was wrong.** Qdrant native `Fusion.RRF` gebruikt k=2 (schaal 0.05-1.5), niet cosine 0.5-0.95. Met N≥17 inlinks beat een expanded chunk al rank-19. Niet dead-weight, wel suboptimaal score-merge tussen verschillende schalen. Phase 1: instrumenteer top-k overlap. Phase 2: RRF-merge i.p.v. additieve boost. |
+| F4 | INFO — action recommended | Evidence-tier shadow mode by default (`EVIDENCE_SHADOW_MODE=true`); content_type/temporal/pagerank weights beïnvloeden output niet | **CONFIRMED.** Geen `EVIDENCE_*` env vars op prod. RAGAS-cron wired LITERALLY GISTEREN (PR #369). 284 shadow_eval events in 8d, top-1 chunk wisselt in 2/5 sample requests, max delta 0.574 — materieel. Run RAGAS A/B nu via bestaande `variant` kolom; staged rollout of decommissioneren met 30-dagen deadline. |
+| F5 | INFO — recommend Optie A | Notebook scope (`_search_notebook`, `_notebook_filter`, `req.scope == "notebook"` branches) is onbereikbaar code geworden na klai-focus deprecation | **CONFIRMED.** 0 live callers; klai_focus Qdrant collection bestaat niet op prod (404). Test-impact: 5 files. Recommended: `SPEC-RETRIEVAL-NOTEBOOK-SCOPE-REMOVE-001` strip notebook/broad branches uit retrieval-api models/api/services/config + portal-api `deprovisioning_steps.py:268`. |
+| F6 | NIT | `parent_lookup` warning-logs gebruiken format-string i.p.v. structlog kwargs (queryability-verlies in VictoriaLogs) | **CONFIRMED, harmless.** Log fired 0× per 30d. 5 andere retrieval-api files hebben gelijksoortige antipatterns. Bundelen met bredere logging-cleanup. |
+
+Per-finding details + literatuur-citaten + log-evidence staan in `findings/F<N>-*.md`.
+
+## Wat opvalt — niet als finding maar als observatie
+
+- **Klai_focus Qdrant collection bestaat niet meer op prod** — F5-agent heeft dit geverifieerd: `GET /collections/klai_focus → 404`. Cleanup van de `qdrant_focus_collection` setting + `_search_notebook` code valt onder F5.
+- **Branches die nog vóór SPEC-DECOMM-FOCUS-001 zijn afgesplitst** dragen `klai-focus/` als getrackte files mee. Dat lost zichzelf op bij merge naar main; geen actie nodig vanuit dit audit-rapport.
+
+## Beslissing per finding
+
+| Finding | Beslissing | Vehikel |
+|---|---|---|
+| F1 | **Hotfix** — voor gap-emit pipeline herstelt | PR met test (geen SPEC) |
+| F2 | **Defer** tot eerste partner-integratie nadert | Ticket / referentie naar `F2-...md` |
+| F3 phase 1 (instrumentation) | **Quick-win** — voegt vereist signal toe voor phase 2 beslissing | PR (geen SPEC) |
+| F3 phase 2 (RRF migration) | **SPEC** — score-fusion herontwerp, A/B nodig | Toekomstige SPEC |
+| F4 | **SPEC** — `SPEC-EVIDENCE-002` of R10 op SPEC-EVIDENCE-001 | RAGAS A/B met `variant` kolom + rollout-plan |
+| F5 | **SPEC** — `SPEC-RETRIEVAL-NOTEBOOK-SCOPE-REMOVE-001` | Multi-service refactor met deletion-criteria |
+| F6 | **Bundle** in opportunistic logging-cleanup | Geen aparte vehikel |
+
+## Status
+
+- [x] Audit uitgevoerd, ruwe findings vastgelegd
+- [x] Findings ge-cleaned op klai-focus decommissie
+- [x] Sub-agent verificatie per finding
+- [x] Eindbeslissing per finding
+- [ ] Hotfixes + SPECs ingepland

--- a/.moai/audits/retrieval-coupling-2026-05-06/audit.md
+++ b/.moai/audits/retrieval-coupling-2026-05-06/audit.md
@@ -39,7 +39,7 @@ Methodologie: pure code-following. Pipeline gevolgd vanaf [`POST /retrieve`](../
 | F2 | LOW (latent) | partner_chat dropt `knowledge.queried` events (geen user_id → geen verified_caller) | **NOT-A-BUG-BUT-DESIGN.** SPEC-API-001 zegt expliciet "partners have no end-user concept". 0 actieve partner-keys op prod, dus latente lacune. Recommended: synthetic `user_id=f"partner:{key_id}"` + auth.py `partner:`-prefix bypass. |
 | F3 | INFO | Link-expansion: score=0 + authority boost beïnvloeden top-20 reranker niet | **PARTIALLY CONFIRMED — math was wrong.** Qdrant native `Fusion.RRF` gebruikt k=2 (schaal 0.05-1.5), niet cosine 0.5-0.95. Met N≥17 inlinks beat een expanded chunk al rank-19. Niet dead-weight, wel suboptimaal score-merge tussen verschillende schalen. Phase 1: instrumenteer top-k overlap. Phase 2: RRF-merge i.p.v. additieve boost. |
 | F4 | INFO — action recommended | Evidence-tier shadow mode by default (`EVIDENCE_SHADOW_MODE=true`); content_type/temporal/pagerank weights beïnvloeden output niet | **CONFIRMED.** Geen `EVIDENCE_*` env vars op prod. RAGAS-cron wired LITERALLY GISTEREN (PR #369). 284 shadow_eval events in 8d, top-1 chunk wisselt in 2/5 sample requests, max delta 0.574 — materieel. Run RAGAS A/B nu via bestaande `variant` kolom; staged rollout of decommissioneren met 30-dagen deadline. |
-| F5 | INFO — recommend Optie A | Notebook scope (`_search_notebook`, `_notebook_filter`, `req.scope == "notebook"` branches) is onbereikbaar code geworden na klai-focus deprecation | **CONFIRMED.** 0 live callers; klai_focus Qdrant collection bestaat niet op prod (404). Test-impact: 5 files. Recommended: `SPEC-RETRIEVAL-NOTEBOOK-SCOPE-REMOVE-001` strip notebook/broad branches uit retrieval-api models/api/services/config + portal-api `deprovisioning_steps.py:268`. |
+| F5 | ✅ ALREADY-DONE | Notebook scope (`_search_notebook`, `_notebook_filter`, `req.scope == "notebook"` branches) is onbereikbaar code geworden na klai-focus deprecation | **CLOSED door `SPEC-DECOMM-FOCUS-001` (#368, commit `e6fabc73`, 2026-05-05).** Geverifieerd op origin/main: alle codepaden weg (`_search_notebook`, `_notebook_filter`, `qdrant_focus_collection`, scope literals, test-fixtures, deprovisioning tuple). Audit forkte vóór deze merge. |
 | F6 | NIT | `parent_lookup` warning-logs gebruiken format-string i.p.v. structlog kwargs (queryability-verlies in VictoriaLogs) | **CONFIRMED, harmless.** Log fired 0× per 30d. 5 andere retrieval-api files hebben gelijksoortige antipatterns. Bundelen met bredere logging-cleanup. |
 
 Per-finding details + literatuur-citaten + log-evidence staan in `findings/F<N>-*.md`.
@@ -53,12 +53,12 @@ Per-finding details + literatuur-citaten + log-evidence staan in `findings/F<N>-
 
 | Finding | Beslissing | Vehikel |
 |---|---|---|
-| F1 | **Hotfix** — voor gap-emit pipeline herstelt | PR met test (geen SPEC) |
+| F1 | **Hotfix** — voor gap-emit pipeline herstelt | PR met test (geen SPEC) — **#387** |
 | F2 | **Defer** tot eerste partner-integratie nadert | Ticket / referentie naar `F2-...md` |
 | F3 phase 1 (instrumentation) | **Quick-win** — voegt vereist signal toe voor phase 2 beslissing | PR (geen SPEC) |
 | F3 phase 2 (RRF migration) | **SPEC** — score-fusion herontwerp, A/B nodig | Toekomstige SPEC |
 | F4 | **SPEC** — `SPEC-EVIDENCE-002` of R10 op SPEC-EVIDENCE-001 | RAGAS A/B met `variant` kolom + rollout-plan |
-| F5 | **SPEC** — `SPEC-RETRIEVAL-NOTEBOOK-SCOPE-REMOVE-001` | Multi-service refactor met deletion-criteria |
+| F5 | ✅ Done | `SPEC-DECOMM-FOCUS-001` (#368, gemerged 2026-05-05) |
 | F6 | **Bundle** in opportunistic logging-cleanup | Geen aparte vehikel |
 
 ## Status

--- a/.moai/audits/retrieval-coupling-2026-05-06/findings/F1-gap-rescorer-bearer-auth.md
+++ b/.moai/audits/retrieval-coupling-2026-05-06/findings/F1-gap-rescorer-bearer-auth.md
@@ -1,0 +1,320 @@
+# F1 — gap_rescorer authentiseert verkeerd → 401 silent
+
+**Severity:** HIGH
+**Status:** OPEN — needs verification
+
+## Initial finding
+
+In [`klai-portal/backend/app/services/gap_rescorer.py:96-98`](../../../klai-portal/backend/app/services/gap_rescorer.py#L96-L98):
+
+```python
+headers = {"X-Caller-Service": "portal-api", **get_trace_headers()}
+if settings.internal_secret:
+    headers["Authorization"] = f"Bearer {settings.internal_secret}"
+```
+
+retrieval-api `AuthMiddleware` ([`klai-retrieval-api/retrieval_api/middleware/auth.py:325-365`](../../../klai-retrieval-api/retrieval_api/middleware/auth.py#L325-L365)) treats elke `Authorization: Bearer <token>` als JWT. Geen fallback naar X-Internal-Secret-header pad bij decode-failure:
+
+```python
+if bearer_token is not None:
+    payload, error = await _decode_jwt(bearer_token)
+    if error is not None:
+        return _unauthorized(error)        # ← 401, geen retry
+elif internal_header is not None:
+    ...
+```
+
+**Verwacht effect:** elke gap-rescore call → 401 `invalid_jwt_signature`. gap_rescorer's `if not resp.is_success: continue` ([line 114-119](../../../klai-portal/backend/app/services/gap_rescorer.py#L114-L119)) eet de fout, logt warning, kennis-gaps worden nooit auto-resolved.
+
+## Wired-up confirm
+
+`schedule_rescore` wordt aangeroepen vanuit:
+- `klai-portal/backend/app/api/internal.py:506` (page-save)
+- `klai-portal/backend/app/api/internal.py:743` (connector sync)
+
+Dus de service draait wel.
+
+## Open vragen voor verificatie
+
+1. Komen er werkelijk 401's binnen op retrieval-api van portal-api caller? Query VictoriaLogs:
+   ```
+   service:retrieval-api AND auth_rejected AND reason:invalid_jwt_signature
+   ```
+   over de afgelopen 30 dagen, en check of de timing samenvalt met page-save / connector-sync events.
+2. Is er ergens nog een mechanisme dat de `Authorization: Bearer` als shared-secret accepteert dat ik gemist heb? Bijv. een legacy-pad dat in test-fixtures wel werkt maar in productie niet?
+3. Hebben de gaps vóór 2026-04-25 (commit `0c29e6c5`) ooit wél resolved? Query `portal_retrieval_gaps` kolom `resolved_at IS NOT NULL` — is dat na 2026-04-25 op nul gevallen?
+
+## Voorgestelde fix (voor agent te valideren)
+
+Eén regel:
+
+```python
+headers = {
+    "X-Internal-Secret": settings.internal_secret,
+    "X-Caller-Service": "portal-api",
+    **get_trace_headers(),
+}
+```
+
+Verwijder de `if settings.internal_secret:` guard — als secret leeg is, is gap_rescorer sowieso niet bedoeld om te draaien. Of: voeg test toe die de outbound header controleert tegen retrieval-api auth contract.
+
+## Verification
+
+**Status: CONFIRMED (mechanism) / PARTIALLY CONFIRMED (production impact)**
+
+### Code-trace verification — CONFIRMED
+
+`klai-retrieval-api/retrieval_api/middleware/auth.py:325-365` reads the request
+exactly as the finding describes. There is **no fallback path** from the Bearer
+arm to the internal-secret arm:
+
+```python
+internal_header = request.headers.get("x-internal-secret")
+auth_header = request.headers.get("authorization", "")
+bearer_token: str | None = None
+if auth_header.lower().startswith("bearer "):
+    bearer_token = auth_header[len("Bearer ") :].strip() or None
+
+# REQ-1.3: prefer JWT path when both credentials are present.
+if bearer_token is not None:
+    payload, error = await _decode_jwt(bearer_token)
+    if error is not None:
+        return _unauthorized(error)             # ← 401, hard return
+    ...
+elif internal_header is not None:
+    if not _constant_time_secret_match(...):
+        return _unauthorized("invalid_internal_secret")
+    ...
+else:
+    return _unauthorized("missing_credentials")
+```
+
+`_decode_jwt` itself fails-closed on a non-JWT input. Verified empirically
+with the same `python-jose` version retrieval-api uses:
+
+```
+$ uv run python -c "from jose import jwt; jwt.get_unverified_header('some_random_secret_abc123')"
+JWTError: Error decoding token headers.
+```
+
+A plain shared-secret string has no `.` separators (verified on prod:
+`INTERNAL_SECRET_LEN=64`, `INTERNAL_DOTS=0` → 64-char hex token), so the very
+first decode step throws `JWTError`, which the handler converts to
+`return {}, "invalid_jwt_signature"` (auth.py:202-203). Result: every
+gap_rescorer call lands on the JWT arm and gets 401 without ever reaching
+the internal-secret comparison. **Mechanism confirmed.**
+
+### Caller construction — CONFIRMED
+
+`klai-portal/backend/app/services/gap_rescorer.py:96-98` builds the header
+dict exactly as the finding shows. Line 98 is unconditional once
+`settings.internal_secret` is truthy (which the prod validator enforces —
+`config.py:471-485`).
+
+### Cross-caller asymmetry — STRONG SMOKING GUN
+
+The fix-commit `0377f550` (PR #311, 2026-05-05, "fix: caller-service header
+on every /retrieve caller") touched four callers in one PR. Three got
+`X-Internal-Secret`; gap_rescorer got `Authorization: Bearer`:
+
+| Caller (commit 0377f550) | Header used |
+|---|---|
+| `klai-portal/.../partner_chat.py:136` | `X-Internal-Secret: retrieval_secret` |
+| `klai-focus/.../retrieval_client.py` | `X-Internal-Secret: secret` |
+| `deploy/litellm/klai_knowledge.py:169` | `X-Internal-Secret: RETRIEVAL_INTERNAL_SECRET` |
+| `klai-portal/.../gap_rescorer.py:97-98` | `Authorization: Bearer {settings.internal_secret}` |
+
+The other three callers ALSO use the dedicated `retrieval_api_internal_secret`
+setting, not the generic `internal_secret`. gap_rescorer uses the wrong
+secret name AND the wrong header. Two stacked bugs.
+
+The Bearer-as-shared-secret pattern was first introduced in commit
+`a3311246` (2026-03-27, SPEC-KB-015: "auto-close gaps when retrieval
+confidence recovers") — predates SPEC-SEC-010. Git diff:
+
+```
++    headers = {"Authorization": f"Bearer {settings.internal_secret}"} if settings.internal_secret else {}
+```
+
+There is no commit in `klai-retrieval-api/retrieval_api/middleware/auth.py`
+(or any predecessor under `klai-retrieve-api/`) that ever accepted Bearer
+as a shared secret. The receiver was JWT-only from inception.
+
+### Test coverage — INADEQUATE (false-confidence)
+
+`klai-portal/backend/tests/test_gap_rescorer.py` exists with 7 tests, all
+green. The relevant assertion (line 73-76):
+
+```python
+post_headers = mock_client.post.call_args.kwargs["headers"]
+assert post_headers.get("X-Caller-Service") == "portal-api", (...)
+```
+
+The test only checks the `X-Caller-Service` header — never the auth header.
+The httpx client is mocked with `AsyncMock` returning `is_success=True`, so
+the test never validates the auth shape against a real or fake retrieval-api
+auth contract. **The test would still pass even if gap_rescorer sent
+no auth header at all.**
+
+### Production evidence — PARTIALLY CONFIRMED (different shape than predicted)
+
+VictoriaLogs (30d retention, queried 2026-04-22 → 2026-05-06):
+
+| Reason | Count over 14 days |
+|---|---|
+| `invalid_internal_secret` | 64 |
+| `invalid_jwt_audience` | 13 |
+| **`invalid_jwt_signature`** | **0** |
+
+Zero `invalid_jwt_signature` rejections. If gap_rescorer were calling
+retrieval-api regularly, this counter should be elevated.
+
+DB check on prod (`core-01`):
+
+```
+SELECT COUNT(*) AS total, MIN(occurred_at), MAX(occurred_at)
+FROM portal_retrieval_gaps;
+ total | min | max
+-------+-----+-----
+     0 |     |
+```
+
+The `portal_retrieval_gaps` table is **completely empty**. The schema
+exists (`information_schema.tables` returned 1), `KNOWLEDGE_RETRIEVE_URL` is
+set (`http://retrieval-api:8040`), and `schedule_rescore` is wired in
+(`internal.py:506` page-save, `:743` connector sync). But no gap rows are
+being recorded by `/internal/v1/gap-events` from the LiteLLM hook — which
+means rescore loop iterations always exit at the "no open gaps" branch
+(`gap_rescorer.py:86-88`) before constructing any HTTP request. The
+auth bug therefore never fires in steady state.
+
+This matches the SPEC-SEC-IDENTITY-ASSERT-001 hotfix history: PR #311 was
+prompted by "0 KB injection lines in the last 6h, hundreds of retrieval
+failed (400) warnings" — the LiteLLM `/retrieve` chat path was silently
+failing for 7 days, so no gap classification ran, so no gap events were
+emitted, so `portal_retrieval_gaps` stayed empty.
+
+**Net effect:** the bug is real and 100% reproducible (a single test
+hitting retrieval-api with the actual headers gap_rescorer sends would
+return 401), but it is **dormant** in production because the upstream
+gap-emit pipeline isn't producing inputs. It will start firing the moment
+either:
+1. The LiteLLM hook starts emitting gap events again (possibly already
+   happening since PR #311 fix landed 2026-05-05, but no new gap rows
+   yet at the time of this audit on 2026-05-06), OR
+2. A different code path inserts into `portal_retrieval_gaps`.
+
+The verifications-by-falsification I attempted:
+- "Maybe `_decode_jwt` short-circuits when audience is wrong before signature?" — No, `get_unverified_header` runs first and dies first on a non-JWT string.
+- "Maybe there's a legacy fallback path that accepts Bearer-as-shared-secret?" — No: `git log -p` over the entire history of `klai-retrieval-api/retrieval_api/middleware/auth.py` (and prior `klai-retrieve-api/` paths) shows the JWT path has always been signature-verified-only; no shared-secret-as-Bearer ever existed.
+- "Maybe the test_gap_rescorer test exercises real auth?" — No, it asserts on a mocked httpx response and never compares the Authorization header to anything.
+
+## Recommended fix
+
+**Status: CONFIRMED**
+
+Apply the one-line fix exactly as proposed, with one tweak — use the dedicated
+`retrieval_api_internal_secret` (matching `partner_chat.py`) so gap_rescorer
+crosses the same trust boundary the rest of the portal-api → retrieval-api
+traffic does:
+
+```python
+# klai-portal/backend/app/services/gap_rescorer.py:96-98
+
+retrieval_secret = settings.retrieval_api_internal_secret or settings.internal_secret
+headers = {
+    "X-Internal-Secret": retrieval_secret,
+    "X-Caller-Service": "portal-api",
+    **get_trace_headers(),
+}
+```
+
+Drop the `if settings.internal_secret:` guard — the prod validator already
+enforces non-empty internal_secret (config.py:471-485) and
+retrieval_api_internal_secret (config.py:536-549). If the secret is empty
+in dev, gap_rescorer should fail-loud rather than send an unauthenticated
+request that 401s anyway.
+
+Mirror the existing fallback pattern used in `partner_chat.py:130`:
+`settings.retrieval_api_internal_secret or settings.internal_secret` — preserves
+backward-compat for any environment where only the legacy `internal_secret`
+is set, while preferring the dedicated secret when configured.
+
+### Test addition (mandatory before merge)
+
+Extend `tests/test_gap_rescorer.py::test_rescore_marks_resolved_when_no_longer_gap`:
+
+```python
+post_headers = mock_client.post.call_args.kwargs["headers"]
+assert post_headers.get("X-Caller-Service") == "portal-api"
+assert post_headers.get("X-Internal-Secret") == "test-secret", (
+    "X-Internal-Secret missing or wrong — retrieval-api AuthMiddleware "
+    "rejects Authorization: Bearer with invalid_jwt_signature 401. "
+    "See finding F1, audits/retrieval-coupling-2026-05-06/."
+)
+assert "Authorization" not in post_headers, (
+    "Authorization: Bearer is treated as JWT-only by retrieval-api. "
+    "Use X-Internal-Secret instead."
+)
+```
+
+The negative assertion (`"Authorization" not in post_headers`) is the
+regression-guard that pins the fix.
+
+### Cross-repo audit (mechanical, not narrative)
+
+Per `.claude/rules/klai/pitfalls/process-rules.md` →
+`retrieve-caller-service-header-mismatch`, run the same
+allowlist sweep across every caller of `/retrieve`. As of 2026-05-06 four
+known callers exist (partner_chat, gap_rescorer, litellm hook, focus
+research-api retrieval_client). Three are correct; gap_rescorer is the
+outlier. Future callers should land with header-shape regression tests
+identical to the one above.
+
+## Risk if not fixed
+
+**Status: CONFIRMED — currently dormant, becomes acute on first gap event**
+
+**Today (dormant):** zero production impact because `portal_retrieval_gaps`
+is empty. The bug consumes no requests and emits no errors.
+
+**The moment the upstream pipeline recovers:** every page-save and connector-
+sync will fire `schedule_rescore` → fresh DB session sees gap rows → 50
+queries/trigger × 401 each. Side effects:
+- Knowledge gaps that should auto-resolve will stay open indefinitely. The
+  product feature ("close gaps when retrieval confidence recovers",
+  SPEC-KB-015) is silently non-functional.
+- `gap_rescorer.py:114-119` swallows `resp.is_success == False` as a
+  warning log and `continue` — no exception, no alert, no metric increment.
+  Per the file pattern this matches the same fail-open class as
+  `retrieve-caller-service-header-mismatch` (process-rules.md) — silent
+  degradation on a feature the user thinks they have.
+- Retrieval-api's `auth_rejected_total{reason="invalid_jwt_signature"}`
+  Prometheus counter starts ticking, but no Grafana alert currently fires
+  on it. (The PR #311 alert only watches `litellm KB retrieval failed`
+  log lines, not retrieval-api's auth_rejected counter.)
+- `_source_ip` rate-limit bucket for portal-api's container IP fills with
+  401-rejected requests. Up to 600 rpm before hitting `_rate_limited`
+  (settings.rate_limit_rpm); rescore loops cap at 50 queries × N orgs.
+  Probably under the limit but adjacent legitimate traffic from portal-api
+  shares the same `retrieval:rl:internal:<source_ip>` key and competes for
+  the same budget.
+
+**Detection time without the fix:** indefinite. The DB is empty so a metric
+on `resolved_count` would show 0 (correctly, given 0 inputs). Only a
+side-by-side comparison of "rows inserted into portal_retrieval_gaps" vs
+"rows where resolved_at IS NOT NULL" would surface the gap. Today neither
+counter exists in any dashboard.
+
+**Severity:** HIGH (matches initial finding). Reasoning:
+- Mechanism is confirmed and 100% reproducible.
+- Production evidence is dormant only because of a separate upstream issue;
+  the fix for that upstream issue (PR #311, 2026-05-05) has already landed.
+- First successful end-to-end gap event recorded after PR #311 will trigger
+  the silent-degrade. Fix is one line; cost of leaving it in is full
+  feature regression.
+
+Recommended action: apply the one-line fix as part of this audit's
+remediation batch, NOT as a separate SPEC. The change is too small to merit
+its own SPEC and the rationale is already captured in this finding +
+pitfalls/process-rules.md.

--- a/.moai/audits/retrieval-coupling-2026-05-06/findings/F2-partner-chat-events-drop.md
+++ b/.moai/audits/retrieval-coupling-2026-05-06/findings/F2-partner-chat-events-drop.md
@@ -1,0 +1,167 @@
+# F2 — partner_chat dropt `knowledge.queried` events
+
+**Severity:** LOW (functioneel oké, telemetrie verlies)
+**Status:** OPEN — needs verification
+
+## Initial finding
+
+[`klai-portal/backend/app/services/partner_chat.py:108-116`](../../../klai-portal/backend/app/services/partner_chat.py#L108-L116) bouwt /retrieve body:
+
+```python
+retrieve_body: dict = {
+    "query": query,
+    "org_id": zitadel_org_id,
+    "scope": "org",
+    "top_k": 8,
+    "conversation_history": conversation_history,
+}
+```
+
+Geen `user_id`. Dat is voor `scope=org` toegestaan (geen 400). Maar in [`auth.py:514-523`](../../../klai-retrieval-api/retrieval_api/middleware/auth.py#L514-L523) (internal-secret pad):
+
+```python
+# auth.method == "internal" — REQ-4.2 portal-side verification.
+if body_user_id is None:
+    return                       # ← geen verified_caller pinned
+```
+
+En [`retrieve.py:411-433`](../../../klai-retrieval-api/retrieval_api/api/retrieve.py#L411-L433):
+
+```python
+if req.scope != "notebook":
+    verified = getattr(request.state, "verified_caller", None)
+    if verified is not None:
+        emit_event("knowledge.queried", ...)
+    else:
+        logger.warning("product_event_skipped_no_identity", ...)
+```
+
+Resultaat: `knowledge.queried` events vanuit partner-API verkeer worden gedropt. Logs tonen `product_event_skipped_no_identity` warnings.
+
+## Wired-up confirm
+
+`retrieve_context` wordt aangeroepen vanuit `klai-portal/backend/app/api/partner.py:185`. Dus actief.
+
+## Open vragen voor verificatie
+
+1. Komen er werkelijk `product_event_skipped_no_identity` warnings in VictoriaLogs voor `service:retrieval-api`? Hoeveel per dag?
+2. Hoeveel partner-API calls per dag draaien? Quantificeren wat we missen.
+3. Is `knowledge.queried` voor partner verkeer überhaupt gewenst? Of is het bewust apart gehouden van eindgebruiker-events?
+4. Heeft de partner-API een eindgebruiker concept of zijn alle calls "tenant-level"? Als tenant-level, is `user_id=None` correct en moeten we juist een ander event-type emitteren (bijv. `partner.knowledge_queried`)?
+
+## Voorgestelde fix opties (voor agent te valideren)
+
+**Optie A — fix het event:** geef partner_chat een synthetisch user_id (bijv. `f"partner:{partner_app_id}"`), zodat de event-emit doorloopt en in dashboards te onderscheiden is.
+
+**Optie B — accept het skipt:** documenteer dat partner-API events bewust niet in `knowledge.queried` komen; dempen van de warning omdat het een verwachte staat is voor partner-flows.
+
+**Optie C — apart event:** `partner.knowledge_queried` event met tenant-level data, los van `knowledge.queried`.
+
+## Verification
+
+### Code-trace — CONFIRMED
+
+Alle drie call sites bevestigd op de in de finding genoemde regels:
+
+1. **partner_chat.retrieve_context body** — `klai-portal/backend/app/services/partner_chat.py:108-116` bouwt:
+   ```python
+   retrieve_body: dict = {
+       "query": query,
+       "org_id": zitadel_org_id,
+       "scope": "org",
+       "top_k": 8,
+       "conversation_history": conversation_history,
+   }
+   ```
+   Geen `user_id` veld. Header set is `X-Internal-Secret` + `X-Caller-Service: portal-api` (regel 130-140).
+
+2. **retrieval-api auth.py:514-523** — internal-secret pad:
+   ```python
+   # auth.method == "internal" — REQ-4.2 portal-side verification.
+   if body_user_id is None:
+       # Bodies that don't carry an end-user claim ... return
+       return
+   ```
+   Bevestigd: `verified_caller` blijft unpinned. De NOTE comment in de code zelf zegt: "hitting this branch means a different surface — leave the verified tuple unpinned and let downstream raise if it tries to read it."
+
+3. **retrieval-api retrieve.py:411-433** — knowledge.queried emit:
+   ```python
+   if req.scope != "notebook":
+       verified = getattr(request.state, "verified_caller", None)
+       if verified is not None:
+           emit_event("knowledge.queried", ...)
+       else:
+           # Defense in depth: should be unreachable ...
+           logger.warning("product_event_skipped_no_identity", ...)
+   ```
+   Bevestigd: zonder verified pin, geen emit, alleen warning. De code-comment zegt expliciet "should be unreachable" — dat is feitelijk niet waar voor de partner-API code path.
+
+### Partner-API auth context — CONFIRMED (NOT-A-BUG-BUT-DESIGN)
+
+`klai-portal/backend/app/api/partner.py` gebruikt `PartnerAuthContext` (key-based Bearer auth). Er is **geen end-user identity** in de partner request — het is een tenant+key-bearer model. Belangrijke design-keuze in SPEC-API-001:
+
+- **spec.md regel 66 (Assumptions):** _"Partners use their own user/session management; the Partner API has no concept of end users"_
+- **spec.md regel 77 (Out of Scope):** _"Per-end-user authentication within the partner's scope — partners operate at org level only"_
+- **partner.py:205** gebruikt al de patroon `user_id=f"partner:{auth.key_id}"` voor `write_retrieval_log` — bewijst dat synthetic-id voor partner-context al een geaccepteerd convention is in dezelfde file.
+
+Conclusie: dit is geen ontwerp-omissie maar een onbedoelde lacune toen SPEC-SEC-IDENTITY-ASSERT-001 Phase D (2026-04-28) `verified_caller`-pinning toevoegde — partner-traffic mist een synthetic identity en valt door de "should be unreachable" else-branch.
+
+### Production evidence — PARTIALLY CONFIRMED (geen huidig verkeer)
+
+Drie observaties uit prod:
+
+- `ssh core-01 "docker logs --since 7d klai-core-retrieval-api-1 | grep -c product_event_skipped_no_identity"` → **0**
+- `ssh core-01 "docker logs --since 7d klai-core-portal-api-1 | grep -c partner_chat"` → **0**
+- `SELECT COUNT(*) FROM partner_api_keys` → **0**
+
+Partner-API draait maar wordt niet gebruikt in productie — er bestaat geen enkele partner key. Dit is daarom een **latente bug**: hij wordt pas zichtbaar zodra de eerste partner-tenant integreert.
+
+Wel zichtbaar: 34 historische `knowledge.queried` events met `user_id=NULL` (allemaal `org_id=1`, allemaal voor 2026-04-22). Die zijn van vóór SPEC-SEC-IDENTITY-ASSERT-001 Phase D landde — andere oorzaak (LiteLLM hook of gap_rescorer pre-guard) en niet relevant voor deze finding.
+
+### Design alternatief check — geen apart event-type bestaat
+
+`grep -rn "partner.knowledge_queried"` over alle services + SPECs → 0 hits. Er is geen ander telemetrie-kanaal waarin partner-RAG calls worden bijgehouden. Als de scenario activeert worden ze gewoon stilletjes gemist in de Knowledge-dashboards.
+
+## Recommended fix
+
+**Optie A (synthetic user_id) — RECOMMENDED.**
+
+Wijziging in `klai-portal/backend/app/services/partner_chat.py:108-116`: voeg `"user_id": f"partner:{key_id}"` toe aan de retrieve body, met `key_id` als nieuwe parameter op `retrieve_context`. Caller (`partner.py:185`) geeft `auth.key_id` mee.
+
+Daarmee:
+1. retrieval-api `auth.py:515` valt niet meer in de unpinned-branch want `body_user_id` is niet `None`.
+2. Het volgt het portal-side `KNOWN_CALLER_SERVICES` allowlist pad in `auth.py:546+` (asserter.verify) — maar wacht, dat vereist dat portal-api's `/internal/identity/verify` endpoint `partner:<key_id>` accepteert.
+
+**Belangrijk implementatie-detail (nog te valideren):** synthetic `user_id` moet de portal-side identity assertion doorstaan. Dat vraagt een mini-extension: portal-api `/internal/identity/verify` moet `claimed_user_id="partner:<key_id>"` als geldig accepteren mits er een actieve `partner_api_keys` row bestaat met dat key_id en `org_id == claimed_org_id`. Zonder die uitbreiding kantelt fix A naar een 403 op iedere partner /retrieve. Dit is werk maar consistent met REQ-4.2's intent (portal verifieert end-user identiteit; "partner:<key_id>" is een geldige tenant-bearer identiteit voor partner traffic).
+
+**Eenvoudiger sub-variant — RECOMMENDED ALS EERSTE STAP:** sla portal-verify over voor synthetic `partner:*` user_ids door retrieval-api `auth.py:514-523` te wijzigen naar:
+
+```python
+if body_user_id is not None and str(body_user_id).startswith("partner:"):
+    # Partner API operates at org-level only (SPEC-API-001 Out-of-Scope:
+    # "no concept of end users"). Pin org without round-trip to portal —
+    # the X-Internal-Secret + X-Caller-Service still gates the call.
+    request.state.verified_caller = VerifiedCaller(
+        user_id=str(body_user_id), org_id=str(body_org_id)
+    )
+    return
+```
+
+Dat is contained, uitlegbaar, en consistent met het bestaande `partner:<key_id>` pattern in `partner.py:205` voor `write_retrieval_log`.
+
+**Waarom niet B (accept-the-skip):** dashboards in SPEC-GRAFANA-METRICS REQ ("Knowledge: Queries Per Week", "Knowledge: Query Success Rate") zouden partner-traffic missen. Op tenant-billing impact: partner-keys staan los van LiteLLM team-key billing, dus het ontbreken van `knowledge.queried` events betekent dat een partner-tenant geen RAG-aktivieit toont in de Klai admin-portal — dat is precies de blast-area waar deze events voor zijn gemaakt.
+
+**Waarom niet C (apart event-type):** `partner.knowledge_queried` zou requireren dat élke dashboard query (Knowledge: Queries Per Week, etc.) UNION ALL twee event-types. SPEC-GRAFANA-METRICS noemt nergens `partner.*` events. Voegt onderhoudslast toe aan iedere toekomstige knowledge-dashboard zonder duidelijke baten — partner-traffic is functioneel hetzelfde RAG-event als LiteLLM-traffic, alleen met andere actor.
+
+**Net-out:** Optie A met de `partner:` prefix sub-variant. Eén commit, één extra clausule in retrieval-api auth, één parameter-doorgift in partner_chat. Test: één unit test in `klai-retrieval-api/tests/test_identity_assert.py` die asserts dat `body_user_id="partner:foo"` → `verified_caller` gezet → `knowledge.queried` event geëmit.
+
+## Risk if not fixed
+
+**Latent maar verwacht.** Productie heeft nu nul partner keys, dus het probleem manifest zich niet. Zodra de eerste partner-integratie live gaat:
+
+- **Telemetrie loss:** elke partner /chat/completions request mist een `knowledge.queried` event. Klai admin-portal Knowledge-dashboards (Queries Per Week, Query Success Rate) tonen partner-traffic niet → onmogelijk om partner-tenant adoptie of retrieval-quality te volgen.
+- **Debugging gap:** een partner die meldt "RAG werkt niet" kan niet worden bevestigd via product_events. `request_id`-correlatie via VictoriaLogs blijft werken (logs are unaffected) — dus traceable, maar niet via de canonical product-events tabel.
+- **Audit trail incompleteness:** SPEC-SEC-IDENTITY-ASSERT-001 ontwerp-intent ("verifieerde identiteit als enkele bron voor business-metrics") wordt voor partner-traffic niet ingelost. De `product_event_skipped_no_identity` warning zal in logs verschijnen voor élke partner request, wat het karakter heeft van false-positive ruis omdat het ontwerp-bedoeld is dat partner geen end-user identity heeft.
+- **Severity bevestigd LOW:** geen functionele regressie in chat-output, geen security-impact, geen data corruption. Telemetrie-only. Maar uitstel is goedkoop nu (geen echt verkeer) en duurder later (eerste partner-launch + dashboard-fix tegelijkertijd is meer risk dan nu in een rustig venster).
+
+**Aanbevolen status:** Optie A sub-variant landen vóór de eerste partner-tenant launches. Geen rush, geen prod-incident, maar niet vergeten.

--- a/.moai/audits/retrieval-coupling-2026-05-06/findings/F3-link-expansion-dead-weight.md
+++ b/.moai/audits/retrieval-coupling-2026-05-06/findings/F3-link-expansion-dead-weight.md
@@ -1,0 +1,185 @@
+# F3 — Link-expansion is in praktijk dead weight
+
+**Severity:** INFO — performance / config
+**Status:** OPEN — needs verification
+
+## Initial finding
+
+Link-expansion in [`retrieve.py:205-236`](../../../klai-retrieval-api/retrieval_api/api/retrieve.py#L205-L236) (SPEC-CRAWLER-003 R14-R16):
+
+1. Pak `links_to` van top-`link_expand_seed_k=10` chunks
+2. `fetch_chunks_by_urls` haalt extra chunks op met `score=0.0` ([`search.py:383`](../../../klai-retrieval-api/retrieval_api/services/search.py#L383))
+3. Authority boost: `score += 0.05 * log(1 + incoming_link_count)` ([`retrieve.py:243`](../../../klai-retrieval-api/retrieval_api/api/retrieve.py#L243))
+
+**Probleem:** stap 5 rerank pakt alleen de top-`reranker_candidates=20` van `raw_results`. Dense Qdrant chunks scoren typisch 0.5-0.95 op cosine similarity. Een link-expanded chunk start op 0.0 + maximaal `0.05 * log(101) ≈ 0.23` als hij 100 inlinks heeft. Dat haalt de top-20 niet.
+
+## Implicatie
+
+- Latency-cost: extra Qdrant scroll-call (3s timeout, lijn 370) per request
+- Output-impact: vrijwel nul — de uitgebreide chunks bereiken de reranker niet
+
+## Open vragen voor verificatie
+
+1. Empirisch: query VictoriaLogs op `link_expand_count` veld in `retrieve` log-events. Hoeveel chunks worden er gemiddeld toegevoegd?
+2. Komt een link-expanded chunk ooit in `reranker_scores_top5`? Cross-correleer chunk_ids van link_expand met de uiteindelijke top-5.
+3. Best practice in moderne RAG (research): is link-expansion zoals hier geïmplementeerd nog state-of-the-art, of zijn er betere benaderingen (bijv. graph-augmented rerank, knowledge-graph traversal als rerank-feature)?
+4. Wat zou een betere ontwerp zijn:
+   - **Optie A:** link-expanded chunks meteen door de reranker laten gaan (uitsluiten van de top-20 cut-off). Latency-impact?
+   - **Optie B:** authority-boost veel agressiever maken (hogere coefficient, of multiplicatief i.p.v. additief).
+   - **Optie C:** link-expansion uitschakelen tot een SPEC z'n waarde aantoont.
+
+## Voorgestelde aanpak (voor agent te valideren)
+
+Online valideren: zoek naar literatuur / blog-posts over "link expansion in hybrid retrieval RAG", "1-hop document expansion reranker", "incoming-link authority boost RAG". Zijn er gepubliceerde benchmarks die deze pattern als nuttig classificeren?
+
+Als het pattern zeldzaam is of verlaten: optie C (uitschakelen) overwegen.
+
+## Verification
+
+### Score-arithmetic correction (the original finding had the score scale wrong)
+
+De initiele finding nam aan dat dense Qdrant chunks scoren op `0.5-0.95 cosine similarity`. Dat klopt niet voor deze pipeline. `_search_knowledge` (`search.py:223-300`) gebruikt **Qdrant native `Fusion.RRF`** (`search.py:295`) met de Qdrant default `k=2` (geverifieerd via [Qdrant docs](https://qdrant.tech/documentation/concepts/hybrid-queries/) — "k is a constant (set to 2 by default)"). De `score` op `raw_results` is dus geen cosine, maar een RRF-fused score. Voor 3 prefetch-legs (vector_chunk + vector_questions + vector_sparse, allemaal rank 1):
+
+| Rank | 3-leg RRF (k=2) | 2-leg RRF (geen sparse) |
+|---|---|---|
+| 1 | 1.0000 | 0.6667 |
+| 5 | 0.4286 | 0.2857 |
+| 10 | 0.2500 | 0.1667 |
+| 19 | 0.1429 | 0.0952 |
+| 59 (top-cap) | ~0.05 | ~0.03 |
+
+De authority boost `0.05 * log(1+N)`:
+
+| N (incoming) | boost |
+|---|---|
+| 1 | 0.0347 |
+| 10 | 0.1199 |
+| 100 | 0.2308 |
+| 1000 | 0.3454 |
+
+**Conclusie van de wiskunde:** de initiele claim (boost ≈ 0.23 max → kan top-20 niet halen) overschat de Qdrant scores en onderschat dus de impact van expansion. Een link-expanded chunk start op `0.0 + boost`. Een dense chunk op rank 19 zit op ~0.143. Met **N ≥ 17 inkomende links beat een expanded chunk een dense rank-19** (`0.05 * log(18) ≈ 0.145 > 0.143`). Met N ≥ 100 (boost 0.23) verslaat hij ranks 14-19. **De expanded chunks zijn dus geen dead weight per se**; in productie kunnen ze wel degelijk de top-20 binnenkomen wanneer de inlinks-distributie scheef genoeg is.
+
+Aan de andere kant: de boost wordt op **alle** 60+expanded chunks toegepast (`retrieve.py:240` itereert over `raw_results`, niet alleen de expanded subset). Dense chunks krijgen ook een boost wanneer hun bron veel inlinks heeft. Het netto-effect is dus dat expanded chunks de top-20 binnenkomen alleen als hun N significant hoger is dan dat van de dense chunk op de uitsmijter-positie.
+
+### Tweede RRF-pad (`_rrf_merge` met k=60) is in productie dood
+
+`retrieve.py:45-64` definieert een aparte `_rrf_merge(k=60)` die alleen wordt aangeroepen wanneer `graph_results` niet leeg is (lijn 195). Empirisch — `service:retrieval-api AND graph_results_count:>0` over 48h: **0 hits**. Graphiti-pad fired niet in productie deze week, dus `_rrf_merge` (k=60) speelt geen rol. De analyse "scores 0.012-0.016" was hypothetisch en valt af.
+
+### Empirische evidence (VictoriaLogs, 2026-05-05 → 2026-05-06)
+
+`service:retrieval-api AND link_expand_count:>0`:
+- **214 retrieve-requests** met expansion fired
+- **3685 expanded chunks toegevoegd** in totaal
+- **Gemiddelde 17.2 chunks per request**, mediaan/dominant op `link_expand_count=20` (107 hits — d.w.z. de cap wordt vaak gehaald)
+- Verdeling: `link_expand_count=20` (107x), `=19` (48x), `=18` (24x), rest <10x. Erg sterk geconcentreerd op de cap.
+
+Latency-cost (`link_expand_ms`):
+- avg = **8.9ms**, p50 = 7.7ms, p95 = 13.2ms, max = 53.3ms (over dezelfde 214 requests)
+- Total request `total_ms` is meestal 400-500ms, dus de scroll-call kost ~2% van de end-to-end latency. Niet pijnlijk.
+
+`reranker_scores_top5` zoals geobserveerd in 2026-05-06 03:00 UTC voorbeelden:
+- Voorbeeld query "How do I handle een klant…": `[0.84, 0.66, 0.49, 0.35, 0.16]`
+- Voorbeeld query "?": `[0.96, 0.87, 0.79, 0.75, 0.57]`
+- Voorbeeld query "hoi" (degenerate): `[0.035, 0.028, 0.008, 0.006, 0.006]`
+
+Dit zijn cross-encoder scores, geen vector scores — niet direct vergelijkbaar met de raw_results-score. Wat ze WEL bevestigen: de reranker krijgt 20 candidates en scoort ze van scratch; als een expanded chunk de top-20 haalt vanwege de boost, krijgt hij een eerlijke beoordeling op semantische relevantie ten opzichte van de query.
+
+### Wat ik NIET kon valideren
+
+- **Of expanded chunks daadwerkelijk in de finale top-5 verschijnen.** Het log-event `retrieval_decision_record` bevat `reranker_scores_top5` maar niet de chunk_ids of een flag "is_link_expanded". Dedicated logging is nodig om de overlap (seed_ids ∩ top5, expanded_ids ∩ top5) te meten. Zonder die telemetry kan ik niet onderscheiden tussen "expansion brengt nuttige chunks" en "expansion brengt chunks die alsnog door de reranker worden weggegooid".
+- **Lokale reproductie** van een query met `link_expand_enabled=true` vs `false` op staging — geen toegang tot een staging retrieval-api binnen scope van deze audit.
+
+### Literatuur — bevindingen samengevat
+
+1. **Score-additie tussen verschillende schalen is een bekend anti-pattern.** Gerard Laforge ([blog post](https://glaforge.dev/posts/2026/02/10/advanced-rag-understanding-reciprocal-rank-fusion-in-hybrid-search/), 2026): "how do you meaningfully combine a cosine similarity score of 0.85 with a BM25 score of 12.4? Those values are on two distinct unrelated scales!" De aanbevolen oplossing: **rank-based fusion (RRF) met k=60**, niet additieve normalisatie. De Klai-implementatie violeert dit: hij telt een `0.05 * log(1+N)` term op bij een Qdrant-RRF score (k=2). De schalen zijn niet alignend.
+
+2. **HippoRAG (NeurIPS 2024, [arxiv:2405.14831](https://arxiv.org/abs/2405.14831), [github](https://github.com/OSU-NLP-Group/HippoRAG))** combineert PageRank niet additief met embedding similarity. Het encoder-pad identificeert alleen seed nodes; de finale ranking is pure-PageRank: `passage_score = sum of (PPR_node_probability × node_specificity)`. Dat is een conceptueel andere manier van graph-augmented retrieval — graph-signaal als primary ranking, niet als kleine boost.
+
+3. **Microsoft GraphRAG ([github](https://github.com/microsoft/graphrag))** doet entity-level expansion (subgraph rond query-entities), niet 1-hop link expansion. De retrieved subgraph wordt textually gelineariseerd tot pseudo-documents en die gaan parallel naast de gewone embedding-retrieval naar de LLM — geen additieve score-merge.
+
+4. **Elastic graph RAG ([blog](https://www.elastic.co/search-labs/blog/rag-graph-traversal))** voert iteratieve graph expansion uit en pruned door shortest-paths. Expanded triplets gaan **niet** direct in de reranker; ze worden eerst gelineariseerd tot pseudo-documents. Reranking gebeurt op het einde, op een homogene candidate set.
+
+5. **Graph-Based Re-ranking survey, [arxiv:2503.14802](https://arxiv.org/html/2503.14802v1)** documenteert GAR/SlideGAR (Adaptive Re-ranking) als de canonieke pattern: een neighbor-expansion candidate pool wordt iteratief uitgebreid via reranker-feedback — niet via een vooraf-gefixeerde additieve boost. De survey merkt expliciet op: "a standard benchmark to measure performance has not yet been developed to evaluate graph-based passage and document ranking tasks." Geen BEIR/STaRK/MTEB benchmark dwingt deze additieve-boost pattern af.
+
+6. **HopRAG ([arxiv:2502.12442](https://arxiv.org/abs/2502.12442))** doet retrieve-reason-prune: lexically/semantically similar passages → multi-hop neighbor exploration → reasoning-guided pruning. Geen additieve score-mix.
+
+**Samenvatting van literatuur:** geen van de gevestigde graph-augmented RAG patterns gebruikt "1-hop link expansion + score=0 + additieve `c * log(1+inlinks)` boost" als integratiepatroon. Het Klai-design is custom en niet aantoonbaar gevalideerd op een publieke benchmark. Wat in de literatuur dominant is: (a) RRF-merge tussen graph-leg en dense-leg, of (b) graph-as-primary-ranking (HippoRAG), of (c) graph-naar-pseudo-document linearization (GraphRAG, Elastic). Geen daarvan komt overeen met deze pipeline.
+
+### Wat dit netto betekent
+
+- De pipeline is **niet zo dood als de initiele finding suggereerde** — de RRF-score schaal alignet net wel ongeveer met de boost-schaal voor chunks met N ≥ 17 inlinks.
+- De pipeline is **wel structureel mis-gedesignd**: de boost-coefficient (0.05) is gekalibreerd onder de aanname van cosine similarity (0.5-0.95), terwijl de echte score Qdrant-RRF is (0.05-1.5). De default coefficient is op de verkeerde aannames gefit.
+- **Latency-cost is laag** (~9ms p50, ~13ms p95).
+- **Output-bijdrage is onzichtbaar** door het ontbreken van `is_link_expanded` flag in `reranker_scores_top5` logging.
+
+## Recommended fix
+
+**Optie D (uitschakelen tot validatie) is niet de beste keuze** — er is een plausibele kans dat de pipeline wel waarde toevoegt, en de kosten zijn laag. **Maar de huidige kalibratie is bewijsbaar verkeerd ten opzichte van de score-schaal.**
+
+**Aanbevolen pad — gefaseerd:**
+
+### Fase 1: instrument om empirisch waarde aan te tonen (1 PR, low risk)
+
+Voeg in `retrieve.py` na de rerank-stap (lijn 249) een log-veld toe:
+
+```python
+expanded_chunk_ids = {c["chunk_id"] for c in raw_results if c not in seed_chunks_pre_expand}
+top_k_chunk_ids = [r["chunk_id"] for r in reranked[:req.top_k]]
+decision_record["link_expand_top_k_overlap"] = len(set(top_k_chunk_ids) & expanded_chunk_ids)
+decision_record["link_expand_seed_top_k_overlap"] = len(set(top_k_chunk_ids) & {c["chunk_id"] for c in seed_chunks})
+```
+
+(Vereist een kleine refactor — `seed_chunks_pre_expand` moet bewaard worden vanaf lijn 207 vóór de boost-stap.)
+
+Met deze velden in de logs kun je over een week meten:
+- `avg(link_expand_top_k_overlap)` — hoe vaak komt een expanded chunk daadwerkelijk in de finale top-k?
+- Distributie van `incoming_link_count` op de chunks die wel in top-k komen.
+
+Als avg < 0.1 (i.e. expansion zelden bijdraagt), dan is Optie D (uitschakelen) gerechtvaardigd. Als avg > 0.5, dan is de pipeline aantoonbaar nuttig.
+
+### Fase 2: structureel fix de score-schaal (na 1 week meten)
+
+**Optie A (canoniek aanbevolen door de literatuur):** vervang de additieve boost met een RRF-merge tussen drie ranklists:
+
+```python
+# pseudocode
+ranking_dense = sorted(qdrant_results, key=lambda r: r["score"], reverse=True)
+ranking_authority = sorted(all_chunks, key=lambda r: r.get("incoming_link_count", 0), reverse=True)
+ranking_expansion = expansion_chunks  # rank-ordered van fetch_chunks_by_urls
+fused = rrf_merge_n([ranking_dense, ranking_authority, ranking_expansion], k=60)
+```
+
+Dit aligneert met Qdrant's eigen praktijk (Fusion.RRF in `_search_knowledge`) en met de RRF-pattern die literatuur expliciet aanbeveelt voor heterogene score-bronnen ([Laforge 2026](https://glaforge.dev/posts/2026/02/10/advanced-rag-understanding-reciprocal-rank-fusion-in-hybrid-search/), [Cormack 2009 origineel](https://opensearch.org/blog/introducing-reciprocal-rank-fusion-hybrid-search/)). De boost-coefficient verdwijnt — geen kalibratie meer nodig.
+
+**Optie A.alt (minimal change):** als de RRF-refactor te groot is, hercalibreer op z'n minst de boost-coefficient. De huidige Qdrant top-rank score is ~1.0 (3-leg RRF). Een boost die "modest signaal" is moet ~5-10% van de top-score zijn, dus ~0.05-0.1 in absolute waarde. Bij N=10 inlinks geeft `0.05 * log(11) = 0.12` — binnen die range. Bij N=1000 geeft `0.05 * log(1001) = 0.35` — boven 30% van de top-score, te hoog. Aanbevolen: **boost-coefficient verlagen naar 0.03 EN cappen op 0.15** om het buitenste deel van de log-curve af te knippen:
+
+```python
+boost = min(settings.link_authority_boost * math.log(1 + incoming), 0.15)
+```
+
+**Optie B (boost veel hoger maken) wordt afgeraden** — dat verergert het scale-mismatch probleem en kan irrelevante expanded chunks de top-20 doen domineren.
+
+**Optie C (entity-PageRank vervanging):** out-of-scope voor deze finding; vereist aparte SPEC en kennisgraaf-integratie. De codebase heeft al `entity_pagerank_max` als payload-veld (`search.py:321, 393`); een toekomstige SPEC kan onderzoeken of dat signaal directer bruikbaar is dan het Notion-style 1-hop-links pad.
+
+### Voorgestelde acties
+
+1. **Niet uitschakelen** — kosten zijn laag, mogelijke waarde is plausibel, maar onbewezen.
+2. **Wel instrumenteren** (Fase 1) — maakt de empirische vraag definitief beantwoordbaar.
+3. **Op basis van metingen na 1 week:** ofwel Optie A (RRF-refactor — canonieke fix), ofwel Optie A.alt (kalibratie-tweak — minimaal-invasief), ofwel Optie D (uitschakelen — als de telemetry zegt dat het pad nul oplevert).
+
+## Risk if not fixed
+
+**Severity blijft INFO**, met de volgende nuances ten opzichte van het oorspronkelijke severity-oordeel:
+
+- **Latency-risico: minimaal.** ~9ms p50 op een 400-500ms request, ~2%. Geen p99-tail risico binnen de geobserveerde 48h. Niet pijnlijk genoeg om alleen op latency-basis fix-prioriteit te krijgen.
+- **Output-kwaliteitsrisico: onbekend, mogelijk relevant.** Door de gebrekkige boost-kalibratie kunnen er twee tegenovergestelde regressies optreden:
+  - Type 1: nooit een expanded chunk in top-k ondanks dat hij relevant is (oorspronkelijke claim — gedeeltelijk waar voor lage-N pages).
+  - Type 2: een expanded chunk met hoge N (bijv. een homepage met 1000 inlinks, boost 0.35) verdringt een relevante dense chunk uit de top-20, en alleen de reranker-cross-encoder kan dat nog goedmaken — als dat überhaupt lukt (homepage-content is vaak generiek). Dit is het inverse risico dat in de SPEC-rationale ("logaritmische demping voorkomt dat homepages disproportioneel scoren") als gemitigeerd werd verklaard, maar de schaalmis-match herintroduceert het risico stilletjes.
+- **Onderhoudsrisico: middelhoog.** De huidige code lijkt de RRF-conventie (Qdrant native, k=60 in-code merge) consistent toe te passen, maar de additieve authority-boost breekt die conventie zonder commentaar. Een toekomstige refactor (bijv. om de drie ranks te uniformiseren) zal moeten reverse-engineeren of de boost een design-keuze of een schaal-fout was. De motivatie "modest signaal ten opzichte van semantische relevantie" in de SPEC is op de verkeerde score-scale gebaseerd; dat verdient een correctie ongeacht of de feature live blijft.
+- **SPEC-correctness risico: laag-middelhoog.** SPEC-CRAWLER-003 R17 specifieert wel de formule maar geeft geen empirische validatie van de coefficient op de echte score-scale. Een formele post-hoc evaluatie zoals voorgesteld in Fase 1 sluit een open vraag van de oorspronkelijke SPEC af.
+
+**Conclusie van de assessor:** de finding is reëel maar niet zo extreem als de eerste analyse suggereerde. De pipeline doet iets wel-gedefinieerd, niet niets — maar wat het doet is gekalibreerd op een aanname die niet klopt met de actuele score-distributie. Aanbevolen pad: instrument eerst, fix de schaal daarna. Niet domweg uitschakelen, niet domweg laten staan.
+
+## Risk if not fixed
+
+_Agent vult dit in._

--- a/.moai/audits/retrieval-coupling-2026-05-06/findings/F4-evidence-shadow-mode-default.md
+++ b/.moai/audits/retrieval-coupling-2026-05-06/findings/F4-evidence-shadow-mode-default.md
@@ -1,0 +1,208 @@
+# F4 — Evidence-tier shadow mode by default
+
+**Severity:** INFO — quality / decision-state
+**Status:** OPEN — needs verification
+
+## Initial finding
+
+[`retrieve.py:293-318`](../../../klai-retrieval-api/retrieval_api/api/retrieve.py#L293-L318):
+
+```python
+shadow_mode = os.environ.get("EVIDENCE_SHADOW_MODE", "true").lower() in ("true", "1", "yes")
+...
+scored = evidence_tier.apply(copy.deepcopy(reranked))
+
+if shadow_mode:
+    logger.info("shadow_eval", ...)
+    serving = reranked      # flat order served
+else:
+    serving = scored        # U-shape + weighted score served
+```
+
+`evidence_tier.apply` rekent `final_score = reranker * content_type_weight * assertion_weight * temporal_decay * pagerank_weight` en past U-shape ordering toe (Lost-in-the-Middle mitigatie). Maar in shadow mode beïnvloedt het de output niet — pure offline scoring.
+
+Default: ON. Per SPEC-EVIDENCE-001 R9: "disable shadow mode after RAGAS validation confirms improvement".
+
+## Implicatie
+
+- Content-type weights (kb_article=1.00, web_crawl=0.65, pdf_document=0.90, etc.) doen niets vandaag.
+- Temporal decay (0-30d=1.00, >365d=0.85) doet niets vandaag.
+- PageRank-boost via `entity_pagerank_max` doet niets vandaag.
+- U-shape ordering (Liu et al. 2023) wordt uitgerekend, niet toegepast.
+
+## Open vragen voor verificatie
+
+1. Is RAGAS-validatie ooit gerund? Check `klai-knowledge-ingest/knowledge_ingest/eval/` history en of er resultaten in een recent dashboard staan.
+2. Wat zeggen de `shadow_eval` logs in VictoriaLogs? Specifiek: hoe vaak verschilt de top-5 tussen `flat_top_chunk_ids` en `evidence_top_chunk_ids`? Is de score-delta materieel?
+3. Best practice (research): is U-shape ordering (Liu et al. 2023, "Lost in the Middle") nog state-of-the-art voor moderne LLMs (Claude 4.x, GPT-4.x, Gemini 2.x)? Of hebben modellen die context-position issue al verholpen?
+4. Welke andere RAG-systemen gebruiken evidence-tier scoring met content_type weights — wat is hun calibratie methodologie?
+
+## Voorgestelde aanpak (voor agent te valideren)
+
+Twee fronten:
+
+**A. Validatie voortdrijven:** Verzamel `shadow_eval` logs voor 30 dagen, bouw een offline analyse: zou `serving=scored` betere resultaten geven (op een gold-set met thumbs-up/down feedback uit `quality_score`)? Als ja → activeer in flag-controlled rollout.
+
+**B. Beslissing nemen:** Als de shadow-mode al maanden draait zonder beslissing, ofwel
+- Activeren in canary (5% traffic) met dashboard, of
+- Bewust uitstellen + datum vastpinnen, of
+- Decommissioneren (verwijder de hele evidence_tier code) als we besloten hebben dat het niet helpt.
+
+## Verification
+
+### 1. Code-trace bevestigd
+
+`klai-retrieval-api/retrieval_api/api/retrieve.py:293-318` (geverifieerd 2026-05-06):
+
+- `EVIDENCE_SHADOW_MODE` default = `"true"` (regel 293).
+- `scored = evidence_tier.apply(copy.deepcopy(reranked))` draait altijd (regel 299) — er is dus volledige CPU-kost van scoring + U-shape ordering op iedere request.
+- `serving = reranked` als `shadow_mode=true` (regel 316). De `scored` lijst wordt alleen gelogd, nooit aan de LLM gegeven.
+
+`evidence_tier.py` heeft drie sub-flags (`EVIDENCE_CONTENT_TYPE_ENABLED`, `EVIDENCE_TEMPORAL_DECAY_ENABLED`, `EVIDENCE_PAGERANK_ENABLED`) die individueel uitgezet kunnen worden, plus `EVIDENCE_ASSERTION_MODE_ENABLED` (in v1 altijd 1.00 — pure plumbing).
+
+**Productie env** (geverifieerd via `ssh core-01 'docker exec klai-core-retrieval-api-1 env | grep -i evidence'` op 2026-05-06): **geen** EVIDENCE_* environment variables gezet. Alle defaults staan dus actief: scoring draait, shadow mode aan, geen serving-effect.
+
+### 2. RAGAS-validatie status
+
+SPEC-EVIDENCE-001 R8 ("RAGAS evaluatieframework") is in de SPEC zelf afgevinkt (`progress.md` zegt "DONE" 2026-04-03), maar betreft alleen het `klai-retrieval-api/evaluation/eval_runner.py` script + 5 placeholder queries. De productie-RAGAS-pipeline werd pas later geleverd door **SPEC-RAG-EVAL-001** (`f4c11d78` op 2026-04-?? voor de harness, gevolgd door fixes `01c6294f`, `c909716a`, `6256ae85`, `d46557f6`).
+
+De nightly cron is **literally één dag oud**: commit `a5dfe5be feat(rag-eval): wire nightly cron via @procrastinate.periodic` (#369) is gemerged op 2026-05-05 — daarvóór moest het handmatig per `docker exec` worden getriggerd. PR-beschrijving bevestigt: "The eval harness has been operator-triggered since SPEC-RAG-EVAL-001 shipped. The Procrastinate task was registered but no scheduler fired it — every measurement run required a manual docker-exec."
+
+De harness schrijft naar `knowledge.rag_eval_results` met een `variant` kolom (default `'baseline'`, gestuurd door `RAG_EVAL_VARIANT` env var). Er is dus infrastructuur om `baseline` vs. `evidence_tier` te vergelijken — maar er is geen indicatie dat deze A/B-vergelijking ooit gedraaid is. Geen evidence in de SPEC, geen Grafana-panel beschrijving, geen besluit-document.
+
+**Conclusie RAGAS:** Het framework bestaat, de pipeline draait sinds gisteren autonoom, maar er is geen baseline-vs-evidence-tier vergelijking gedaan. De voorwaarde uit R9 ("disable shadow mode after RAGAS validation confirms improvement") is dus formeel niet vervuld.
+
+### 3. Productie shadow_eval logs (afgelopen 7 dagen, VictoriaLogs)
+
+| Datum | shadow_eval entries |
+|---|---:|
+| 2026-04-29 | 0 |
+| 2026-04-30 | 4 |
+| 2026-05-01 | 6 |
+| 2026-05-02 | 0 |
+| 2026-05-03 | 0 |
+| 2026-05-04 | 60 |
+| 2026-05-05 | 154 |
+| 2026-05-06 (tot nu) | 60 |
+| **Totaal** | **284** |
+
+De spike op 5 mei (154) sluit aan bij het wiren van de RAGAS-cron + `RAG_EVAL_VARIANT=baseline` runs die zelf via `/retrieve` lopen. Real-user traffic produceert een handvol calls per dag — dit is een **lage-volume** dienst, primair retrieval-voor-eval en LiteLLM-knowledge-hook.
+
+**Sample van 5 willekeurige `shadow_eval`-events (2 mei 2026):**
+
+| Request | flat top-1 == evidence top-1? | Top-5 set overlap | Max abs score_delta |
+|---|---|---|---|
+| a030...7e0 | **NEE** (ad7b... vs b05d...) | 3/5 | 0.029 |
+| 47500...4ced | JA (zelfde, maar #2-5 herordend) | 4/5 | 0.574 |
+| e5f07...1f6f | **NEE** (445c... vs 7962...) | 4/5 | 0.488 |
+| 6159...2422 | JA (zelfde, herordend) | 4/5 | 0.431 |
+| be89...aa20 | JA (zelfde, herordend) | 4/5 | 0.144 |
+
+**Interpretatie van de score_deltas:** De deltas zijn *niet* marginaal. In 2 van 5 sample-requests verandert het meest-relevante chunk (top-1) volledig. In 4 van 5 verandert ten minste de volgorde van top-5 substantieel (deltas tot 0.57). Dit is materieel — evidence-tier zou de output meetbaar veranderen voor de meerderheid van requests.
+
+Wat we **niet** kunnen verifiëren zonder RAGAS A/B: of die verandering een verbetering of verslechtering is. De grote deltas kunnen evengoed betekenen dat content-type weights het reranker-signaal overrulen op een manier die de gebruiker NIET wil (bv. een verse `web_crawl` chunk met sterke reranker-score wordt 35% gediscount door de 0.65 weight, terwijl een oudere `kb_article` met zwakkere reranker-score voorbij wordt geboost).
+
+### 4. Literatuur-research (mei 2026)
+
+#### "Lost in the Middle" — geldigheid voor moderne LLMs
+
+- **Origineel:** Liu et al. 2023, [arXiv:2307.03172](https://arxiv.org/abs/2307.03172) — getest op Claude-1.3, GPT-3.5-Turbo, MPT-30B-Instruct. >30% degradatie wanneer relevant doc midden in context.
+- **Databricks long-context RAG benchmark** ([blog](https://www.databricks.com/blog/long-context-rag-performance-llms)): "GPT-4o and Claude 3.5-Sonnet show little to no performance deterioration at longer lengths." Llama-3.1-405b begint te degraderen bij 32k. Het Lost-in-the-Middle effect is dus **model-afhankelijk** en grotendeels gemitigeerd in de huidige frontier-modellen die Klai gebruikt.
+- **GM-Extract studie (november 2025)**, [arXiv:2511.13900](https://arxiv.org/abs/2511.13900) is het meest belastend: "a distinct U-shaped curve was not consistently observed" en mitigaties hebben "surprising cases where they lead to a negative impact." De aanbeveling is application-specific evaluatie, niet one-size-fits-all reordering.
+- **Maxim AI overzicht 2025** ([artikel](https://www.getmaxim.ai/articles/solving-the-lost-in-the-middle-problem-advanced-rag-techniques-for-long-context-llms/)): retrieval reordering wordt nog steeds genoemd als techniek, maar als één van meerdere — context engineering en agentic retrieval krijgen meer aandacht.
+
+**Conclusie U-shape:** in 2026 is U-shape ordering geen "no-brainer SOTA" meer. Voor frontier-modellen (Claude 3.5+, GPT-4o, Mistral Large 4) is het effect klein tot afwezig. Voor zwakkere modellen kan het nog meetbare winst geven. Vraagt om **eigen meting** op de Klai stack (klai-fast = Mistral Small 4) — daar is het niet duidelijk uit literatuur of het helpt.
+
+#### Content-type / source-credibility weighting
+
+- **PoniakTimes 2025 overzicht** ([artikel](https://www.poniaktimes.com/reliable-rag-ai-search/)): credibility-weighting wordt actief geadviseerd voor enterprise RAG, vooral bij gemengde bronnen (web + docs + transcripts) — exact Klai's situatie.
+- **TrustworthyRAG survey** ([arXiv:2409.10102](https://arxiv.org/html/2409.10102v1)) en de RA-RAG paper die in SPEC-EVIDENCE-001 wordt geciteerd ([arXiv:2410.22954](https://arxiv.org/abs/2410.22954)) bevestigen dat metadata-gewogen retrieval +51% kan toevoegen in adversariële settings.
+- Geen 2025/2026-paper die specifiek de **calibratie** van content-type weights (kb_article=1.00 vs web_crawl=0.65) beoordeelt. De Klai-defaults zijn redelijk maar onbevestigd — een tenant met grotendeels web_crawl content krijgt een 35% downweight die mogelijk te streng is.
+
+#### Temporal decay
+
+- **TimeRAG (CIKM 2025)** [PDF](http://playbigdata.ruc.edu.cn/dou/publication/2025_CIKM_TimeRAG.pdf) en **Bloomberg case study** beschreven in de "Refresh Trap" blog ([Medium](https://medium.com/@eyosiasteshale/the-refresh-trap-the-hidden-economics-of-vector-decay-in-rag-systems-f73bc15aa011)): temporal embeddings verbeteren top-1 accuracy 6-9% op tijds-gevoelige benchmarks.
+- Voor Klai's gebruikssituatie (interne KB-content, beleidsdocumenten, meeting transcripts) is de temporal-decay-curve mogelijk **anders** dan voor news/finance: een interne policy van 6 maanden oud is meestal nog steeds correct. De huidige decay (`<30d=1.00, >365d=0.85`) is conservatief, maximaal -15%, dus zelfs als hij niet helpt, schaadt hij niet veel.
+
+**Net-net:** De literatuur ondersteunt evidence-tier scoring **als concept**, maar bevestigt niet dat de specifieke gewichten en U-shape stap meetbaar helpen op Klai's stack zonder eigen meting.
+
+### 5. Wat we kunnen en niet kunnen verifiëren
+
+**Wel:**
+- Default = shadow on. Productie heeft geen overrides.
+- Scoring draait per request, levert materiële deltas op (sample), kost CPU.
+- RAGAS-harness bestaat, draait sinds gisteren autonoom op een baseline.
+- U-shape voordeel is ambigu in 2026 literatuur.
+
+**Niet:**
+- Of `serving=scored` *beter* of *slechter* zou zijn op Klai's queries — dat is exact wat de RAGAS A/B-meting moet uitwijzen, en die is nog niet gedraaid.
+- Of de specifieke gewicht-calibratie (kb_article=1.00, web_crawl=0.65, etc.) optimaal is voor Klai's content mix.
+- Hoe Mistral Small 4 (klai-fast) reageert op middle-of-context content — geen publieke benchmark gevonden.
+
+## Recommended fix
+
+**Niet activeren zonder data. Niet decommissioneren.** De pragmatische volgorde:
+
+### Stap 1 — Run de RAGAS A/B (priority HIGH, blokkerend voor stap 2)
+
+Trigger de RAGAS-harness twee keer met dezelfde suite, één keer met `EVIDENCE_SHADOW_MODE=true` (huidige productie = `variant=baseline`) en één keer met `EVIDENCE_SHADOW_MODE=false` (`variant=evidence_tier_v1`). De harness schrijft naar `knowledge.rag_eval_results` met de variant kolom, dus de A/B is al architecturaal voorbereid.
+
+Concreet:
+```bash
+# Bestaande baseline (variant=baseline) draait al nightly via #369
+# Trigger eenmalig een evidence-tier run:
+ssh core-01 'docker exec -e RAG_EVAL_VARIANT=evidence_tier_v1 -e EVIDENCE_SHADOW_MODE=false \
+  klai-core-knowledge-ingest-1 \
+  python -m knowledge_ingest.eval --suite chat --suite knowledge_org'
+```
+
+Vergelijk daarna `context_precision`, `context_recall`, `faithfulness`, `answer_relevance` per suite tussen beide varianten (Wilcoxon signed-rank op de paired query-resultaten — al beschreven in SPEC-EVIDENCE-001 R8).
+
+**Beslisregel:**
+- Evidence-tier wint signifcant op 2+ van de 4 metrics → activeer (stap 2).
+- Geen significant verschil → laat shadow staan, ga naar stap 3 (decommissioneer-overweging).
+- Evidence-tier verliest → fix de calibratie (per-content-type weights herzien) of decommissioneer.
+
+### Stap 2 — Activeer met staged rollout (alleen als RAGAS positief)
+
+Niet via een env var op een datum. Via een per-org / percentage rollout in de retrieve-handler:
+
+1. Voeg een `RetrievalSettings`-veld `evidence_serving_percentage: int = 0` toe (Pydantic-settings, default 0).
+2. In `retrieve.py:301`: vervang de boolean `if shadow_mode` door deterministische sampling op `request_id` of `org_id` hash, threshold = `evidence_serving_percentage`.
+3. Rollout-schema: 5% → 25% → 100% met 48u-soak per stap, monitoring van `quality_score` (thumbs-up/down feedback uit het bestaande feedback-systeem) en RAGAS metrics.
+4. Per-tenant override mogelijk via een nieuwe `portal_orgs.evidence_tier_enabled` kolom voor klanten die expliciet baseline willen blijven.
+
+### Stap 3 — Als RAGAS niets significant laat zien (post-meting beslissing)
+
+Twee opties:
+
+**3a. Decommissioneer** — verwijder `evidence_tier.py`, de aanroep in `retrieve.py:299-318`, de drie sub-flags uit `Settings`, de `final_score` / `evidence_tier_metadata` velden uit `ChunkResult`. Spaart ~50ms CPU per request en simpelt de code. Voorwaarde: minstens 2 weken RAGAS-data zonder verschil > 1pp op alle 4 metrics.
+
+**3b. Behoud als plumbing voor SPEC-EVIDENCE-002** — als assertion-mode weights er ooit komen (nu staat alles op 1.00), heeft de scoring-pipeline al z'n vorm. Decommissioneren = die SPEC opnieuw schrijven. Acceptabele middenweg: laat de scoring staan maar ZET DE U-SHAPE ORDERING ECHT UIT (`EVIDENCE_TEMPORAL_DECAY_ENABLED=false`, `EVIDENCE_CONTENT_TYPE_ENABLED=false`) zodat de CPU-kost wegvalt. Dat is mechanisch goedkoper dan `_order_for_llm` weghalen.
+
+### Stap 4 — Tijdvenster en eigenaar
+
+De huidige situatie ("shadow al twee maanden, beslissing onduidelijk") is exact het scale-the-answer-to-the-problem-scenario uit `pitfalls/process-rules.md`: een feature die niets doet maar wel kost. Maximaal 30 dagen na merge van #369 (dus deadline ~2026-06-04) moet de beslissing zijn genomen — schrijf het als kalender-reminder of als een `@MX:TODO` op `retrieve.py:293` met expiry-datum.
+
+## Risk if not fixed
+
+| Risico | Impact | Waarschijnlijkheid | Notities |
+|---|---|---|---|
+| Code-rot van ongebruikte feature | LAAG-MEDIUM | HOOG (code blijft staan, refactor-kosten verdubbelen wanneer iemand `retrieve.py` aanpakt) | Bv. SPEC-RAG-PARENT-CHILD-001 (regel 320+ in dezelfde functie) heeft al moeite gehad met de `serving=reranked` vs `serving=scored` branch. |
+| Verspilde inference-CPU | LAAG | ZEKER (elke request loopt door `apply()` + `_order_for_llm`) | ~50ms per request schat ik op basis van 6 numerieke ops × N chunks (typisch N=20). Niet een productie-blocker bij huidige laag volume, wel meetbaar zodra LiteLLM-knowledge-hook traffic schaalt. |
+| Onbekende kwaliteit-impact bij activatie | HOOG | MEDIUM | Activeren via env-var-flip zonder RAGAS = blind gokken op een gereedschap waarvan literatuur (GM-Extract Nov-2025) zegt dat het soms slechter wordt. Sample-deltas tonen dat 4/5 requests materieel ander top-5 zouden serveren. |
+| Reputatieschade door verkeerde weights | MEDIUM | LAAG-MEDIUM | Als content_type weights niet goed gekalibreerd zijn voor een tenant met overwegend `web_crawl` content (bv. een tenant die hun documentatie-portal heeft gecrawld als "externe bron"), krijgt die tenant systematisch slechtere antwoorden. Dit is exact het scenario dat shadow-mode ZOU moeten voorkomen — maar zonder beslissing eindeloos uitstellen helpt evenmin. |
+| Drift tussen SPEC-statement en werkelijkheid | LAAG | HOOG | `progress.md` zegt "DONE" sinds 2026-04-03, R9-criterium "disable shadow mode after RAGAS validation" is niet bewust gevolgd. Voor audit-traceerbaarheid is dit nu zo gerepareerd worden dat de SPEC of het audit-record klopt. |
+
+**Bottom-line risico**: het is geen acuut productie-incident. Het is een feature-rot scenario waarbij dood gewicht zich opstapelt en een toekomstige refactor (parent-child child-text swap, SPEC-EVIDENCE-002 assertion modes, een hypothetische scoring v2) duurder en risicovoller maakt. Zolang RAGAS-baseline draait, is de marginale kost om óók een evidence_tier_v1 variant te draaien laag — dus stap 1 is realistisch binnen één week te doen.
+
+### Bronnen (geverifieerd via WebFetch / WebSearch op 2026-05-06)
+
+- Liu et al. 2023, "Lost in the Middle" — [arXiv:2307.03172](https://arxiv.org/abs/2307.03172)
+- GM-Extract studie nov-2025 (mitigaties soms negatief) — [arXiv:2511.13900](https://arxiv.org/abs/2511.13900)
+- Databricks long-context RAG benchmark — [databricks.com/blog/long-context-rag-performance-llms](https://www.databricks.com/blog/long-context-rag-performance-llms)
+- TrustworthyRAG survey — [arXiv:2409.10102](https://arxiv.org/html/2409.10102v1)
+- TimeRAG (CIKM 2025) — [PDF](http://playbigdata.ruc.edu.cn/dou/publication/2025_CIKM_TimeRAG.pdf)
+- "The Refresh Trap" — [medium.com/@eyosiasteshale](https://medium.com/@eyosiasteshale/the-refresh-trap-the-hidden-economics-of-vector-decay-in-rag-systems-f73bc15aa011)
+- "Reliable RAG: Source Credibility" — [poniaktimes.com](https://www.poniaktimes.com/reliable-rag-ai-search/)
+- Maxim AI "Solving Lost in the Middle" 2025 — [getmaxim.ai](https://www.getmaxim.ai/articles/solving-the-lost-in-the-middle-problem-advanced-rag-techniques-for-long-context-llms/)

--- a/.moai/audits/retrieval-coupling-2026-05-06/findings/F5-notebook-scope-reachable-no-callers.md
+++ b/.moai/audits/retrieval-coupling-2026-05-06/findings/F5-notebook-scope-reachable-no-callers.md
@@ -1,7 +1,27 @@
 # F5 — Notebook scope: reachable code, geen actieve callers
 
 **Severity:** INFO — code hygiene
-**Status:** OPEN — needs verification
+**Status:** ✅ ALREADY-DONE — closed by `SPEC-DECOMM-FOCUS-001` (#368, commit `e6fabc73`, 2026-05-05).
+
+## Update na audit (2026-05-06)
+
+Het cleanup-werk dat de F5-agent voorstelde (Optie A) was al **vóór deze audit** geïmplementeerd in `SPEC-DECOMM-FOCUS-001` (PR #368, 2026-05-05). Geverifieerd op `origin/main` (HEAD = `2ac1b359`):
+
+- ✅ `_search_notebook`, `_notebook_filter` verwijderd uit `retrieval-api/services/search.py`
+- ✅ `qdrant_focus_collection` setting verwijderd uit `config.py`
+- ✅ `Literal["notebook", "broad"]` verwijderd uit `models.py`
+- ✅ `notebook_id` veld verwijderd
+- ✅ Alle `if req.scope == "notebook"` / `"broad"` branches in `retrieve.py` + `chat.py` verwijderd
+- ✅ `klai_focus` tuple verwijderd uit `provisioning/deprovisioning_steps.py:246` (comment annoteert SPEC-DECOMM-FOCUS-001)
+- ✅ `research-api` verwijderd uit `KNOWN_CALLER_SERVICES` (klai-libs/identity-assert + portal-api/identity_verifier — comments documenteren removal)
+- ✅ `klai_focus` Qdrant collection gedropped op prod (manueel via runbook in PR #368)
+- ✅ klai-focus directory volledig verwijderd
+
+De originele audit was uitgevoerd op een working tree die forkte vóór `e6fabc73`, dus de F5 finding zag een verouderde code-state. Geen verdere actie nodig.
+
+---
+
+## Originele finding (preserved for reference)
 
 ## Initial finding
 

--- a/.moai/audits/retrieval-coupling-2026-05-06/findings/F5-notebook-scope-reachable-no-callers.md
+++ b/.moai/audits/retrieval-coupling-2026-05-06/findings/F5-notebook-scope-reachable-no-callers.md
@@ -1,0 +1,188 @@
+# F5 — Notebook scope: reachable code, geen actieve callers
+
+**Severity:** INFO — code hygiene
+**Status:** OPEN — needs verification
+
+## Initial finding
+
+retrieval-api ondersteunt `scope="notebook"` (en "broad"), met dedicated codepaden:
+
+- [`models.py:15`](../../../klai-retrieval-api/retrieval_api/models.py#L15): scope literal omvat `"notebook"` en `"broad"`
+- [`retrieve.py:79-86`](../../../klai-retrieval-api/retrieval_api/api/retrieve.py#L79-L86): notebook-specifieke validation (notebook_id + user_id required)
+- [`search.py:115-220`](../../../klai-retrieval-api/retrieval_api/services/search.py#L115-L220): `_search_notebook` op `qdrant_focus_collection` met `_notebook_filter` (visibility gate)
+- [`config.py:13`](../../../klai-retrieval-api/retrieval_api/config.py#L13): `qdrant_focus_collection: str = "klai_focus"`
+- [`search.py:419-444`](../../../klai-retrieval-api/retrieval_api/services/search.py#L419-L444): broad-scope merge tussen klai_knowledge en klai_focus
+
+**Enige caller van notebook/broad scope** was klai-focus research-api (`retrieve_narrow` / `retrieve_broad`). Maar:
+
+- klai-focus is in HEAD maar **niet in `deploy/docker-compose.yml`**
+- **Niet running op core-01** (`docker ps | grep -i focus` leeg)
+- 0 imports van buitenaf naar `klai-focus/research-api`-modules
+
+Dus: notebook/broad scope code is wel uitvoerbaar maar wordt door geen enkele live service aangeroepen. Bestanden in retrieval-api dragen vanaf nu maintenance-cost zonder waarde.
+
+## Open vragen voor verificatie
+
+1. Klopt het dat geen enkele live service `scope="notebook"` of `scope="broad"` aanroept? Grep alle services in compose.
+2. Welke kant gaat klai-focus op? Definitief verwijderen, gepauzeerd-houden voor revival, of ergens een herontwerp?
+3. Als klai-focus dood is: kan `klai_focus` Qdrant collection ook weg? `provisioning/deprovisioning_steps.py:237` doet alleen DROP bij tenant-delete. Zijn er nog actieve klai_focus collections op prod? Check via Qdrant API.
+4. Wat is de impact van scope-cleanup op tests? Hoeveel tests gebruiken notebook/broad scope als fixture?
+
+## Voorgestelde aanpak (voor agent te valideren)
+
+**Optie A — Definitief deleten** (als klai-focus nooit terugkomt):
+- Verwijder `klai-focus/` directory
+- Verwijder uit retrieval-api: `_search_notebook`, `_notebook_filter`, broad-scope merge in `hybrid_search`, `qdrant_focus_collection` setting
+- Verwijder uit `models.py`: `"notebook"` en `"broad"` uit scope Literal
+- Migratie: drop `klai_focus` Qdrant collection
+- SPEC: ergens onder `SPEC-DEPRECATE-FOCUS-001` of als wave-1 cleanup
+
+**Optie B — Gepauzeerd houden:**
+- Toevoegen aan `.codeindexignore` zodat klai-focus uit toekomstige analyses valt
+- README.md in klai-focus root: "PAUSED — code preserved, not deployed"
+- Code in retrieval-api blijft staan (mogelijk inactief maar bereikbaar)
+- Kosten: maintenance-overhead (test-fixtures, security audits, dependency-updates blijven applicabel)
+
+## Verification
+
+**Status:** CONFIRMED — notebook/broad scope is reachable code with zero live callers. klai-focus is decommissioned per SPEC-PORTAL-UNIFY-KB-001 (Phase C, commit `998f6f71`, 2026-04-23).
+
+### 1. Caller-cross-check — every service in `deploy/docker-compose.yml`
+
+Greppen over alle service-bronbomen op `scope.*(notebook|broad)` en `/retrieve`:
+
+| Service | `/retrieve` caller? | `scope=` value(s) used |
+|---|---|---|
+| portal-api (`klai-portal/backend`) | YES — `services/partner_chat.py:111`, `services/gap_rescorer.py:110` | `"org"` only |
+| LiteLLM hook (`deploy/litellm/klai_knowledge.py`) | YES — `klai_knowledge.py:199,212` | `"personal"`, `"both"`, `"org"` (line 1225/1228; never `notebook` or `broad`) |
+| knowledge-ingest RAGAS harness (`klai-knowledge-ingest/.../eval/retrieval_client.py:83`) | YES (eval-only) | scope-default `"org"` (no override) |
+| klai-connector | NO — only doc-references in comments |
+| klai-mailer | NO — only doc-references in comments |
+| klai-knowledge-mcp | NO — own MCP surface, doesn't call `/retrieve` |
+| scribe-api | NO — only mentions retrieval-api in auth-config comment |
+| runtime-api / api-gateway / admin-api / meeting-api | NO — Vexa stack, no retrieval coupling |
+| librechat-getklai | NO — talks to LiteLLM, not directly to retrieval-api |
+| klai-widget | NO |
+
+`grep -rn 'scope.*notebook\|scope.*broad' --include='*.py' --include='*.ts' [services]` returns **only matches inside `klai-retrieval-api/` itself** (definitions + tests). Zero live callers in any service still in `docker-compose.yml`.
+
+The only repo-level caller of `scope="notebook"` / `scope="broad"` is `klai-focus/research-api/app/services/retrieval_client.py:70,111` — which is in the FROZEN tree.
+
+### 2. klai-focus deployment status — definitively dead
+
+- **`docker ps -a` op core-01:** `grep -iE 'focus|research|notebook'` → empty. Zero containers, also not stopped/exited. (42 total containers running on core-01; none related to focus.)
+- **`deploy/docker-compose.yml`:** geen `research-api` of `klai-focus` service-blok. Bevestigd door `deploy/VERSIONS.md:7`: *"research-api removed in SPEC-PORTAL-UNIFY-KB-001"*.
+- **GitHub Actions:** `ls .github/workflows/ | grep -iE 'focus|research'` → leeg. Geen `*focus*.yml` / `*research*.yml` deploy-pijplijn. Service kan dus ook niet worden ge(re)deployed via CI.
+- **Geen ssh-only deploy-script:** `grep -rn 'research-api' deploy/` levert alleen `deploy/VERSIONS.md` (decommission-note) en `deploy/caddy/Caddyfile:310` (decommission-comment) op. Geen handmatig deploy-pad.
+- **klai-focus README:** `klai-focus/README.md` opent met `# FROZEN — replaced by Knowledge per SPEC-PORTAL-UNIFY-KB-001` en zegt expliciet *"Kept in the git tree for historical reference only. Do not resurrect."*
+
+SPEC-PORTAL-UNIFY-KB-001 noemt `SPEC-RESEARCH-API-ARCHIVE-001` als toekomstige optionele follow-up *"mocht de `klai-focus/` submodule ooit volledig uit de tree worden verwijderd"* — die SPEC bestaat nog niet, en is ook niet nodig om de retrieval-api kant te schoonmaken (de twee zijn ontkoppeld).
+
+### 3. Qdrant collection state op prod
+
+```
+GET http://qdrant:6333/collections          → {"collections":[{"name":"klai_knowledge"}]}
+GET http://qdrant:6333/collections/klai_focus → {"status":{"error":"Not found: Collection `klai_focus` doesn't exist!"}}
+```
+
+**De `klai_focus` collection bestaat niet meer op prod.** Geen actieve tenants met klai_focus chunks. Geen point-count nodig — er is letterlijk niets om weg te gooien.
+
+Bij-effect: `klai-portal/backend/app/services/provisioning/deprovisioning_steps.py:268` itereert nog steeds over `("klai_focus", "tenant_id")` als deel van de tenant-purge. Dat code-pad logt "qdrant_collection_not_found" en gaat door (idempotent), dus prod faalt niet — maar het is dode code geworden.
+
+### 4. Test-impact
+
+`grep -rn "scope.*notebook\|scope.*broad\|qdrant_focus_collection\|_search_notebook\|_notebook_filter\|klai_focus" klai-retrieval-api/tests/`:
+
+| File | Hits | Total lines | Action |
+|---|---|---|---|
+| `tests/test_notebook_filter.py` | 9 | 114 | DELETE entire file |
+| `tests/test_api.py` | 11 | 464 | Remove ~3 test functies (notebook validation, broad merge) |
+| `tests/test_search.py` | 4 | 170 | Remove `_search_notebook`/`_notebook_filter` testjes |
+| `tests/test_search_error_handling.py` | 3 | 259 | Remove notebook-error-path testjes |
+| `tests/test_assertion_mode_taxonomy.py` | 1 | 79 | 1-line scope-fixture aanpassen |
+
+Totaal: **5 test-bestanden, 28 hits**. Eén volledig file weg, vier files gedeeltelijk opgeschoond. Niet groot.
+
+### 5. Decision research — bestaande SPECs
+
+- **SPEC-PORTAL-UNIFY-KB-001 (Phase C, 2026-04-23, GA):** decommissioned `research-api` ten gunste van een unified Knowledge surface. Status: shipped. Bewust besloten "Focus-data wordt niet gemigreerd — research-api volledig decommission (hard)".
+- **SPEC-SEC-AUDIT-2026-04 spec.md:318:** klai-focus is een "governance call, not a SPEC" — twee opties zijn al genoemd: (a) directory deleten, (b) HARD-rule tegen resurrection.
+- **`SPEC-RESEARCH-API-ARCHIVE-001`:** referenced as toekomstige follow-up, niet aangemaakt.
+- **Geen revival-signalen** in roadmap of recente SPECs. Notebook-scope is een artefact van de pre-unify architectuur.
+
+### 6. Aanbeveling — Optie A (deleten, beperkte scope)
+
+**Optie A — Definitief deleten van notebook/broad scope uit retrieval-api.**
+
+Motivatie:
+- klai-focus is dood, decommission staat in een geshipte SPEC, geen revival-signaal.
+- klai_focus collection bestaat niet meer op prod → geen data-migratierisico.
+- 0 live callers → geen runtime-impact.
+- Code is bereikbaar via de openbare `/retrieve`-API en draagt review-, security-audit- en test-onderhoudslast.
+- Test-cleanup is klein (1 file weg, 4 files gedeeltelijk).
+- Optie B (gepauzeerd) is hier slecht: notebook-scope is geen klai-focus interne code maar een actieve API-contract-tak van retrieval-api. Een README in klai-focus verandert daar niets aan.
+
+**Beperking:** "Optie A" beperkt zich tot retrieval-api + portal-api deprovisioning. Het volledig verwijderen van `klai-focus/` directory (zoals voorgesteld in de oorspronkelijke Optie A) is een aparte governance-call (zie SPEC-RESEARCH-API-ARCHIVE-001 placeholder) en hoeft NIET met deze finding mee. De FROZEN README in klai-focus is genoeg signaal voor het submodule.
+
+## Recommended fix
+
+**SPEC-RETRIEVAL-NOTEBOOK-SCOPE-REMOVE-001** (kleine cleanup-SPEC, één PR):
+
+### klai-retrieval-api delete-list
+
+| File | Delete |
+|---|---|
+| `retrieval_api/models.py` L15 | `"notebook"`, `"broad"` uit scope `Literal` halen |
+| `retrieval_api/models.py` L17 | `notebook_id: str \| None = None` field weg |
+| `retrieval_api/api/retrieve.py` L79-86 | notebook-validatie weg (notebook_id, user_id required gates) |
+| `retrieval_api/api/retrieve.py` L177, 205, 246, 411 | `req.scope != "notebook"` guards weg (skip-graphiti, skip-link-expand, skip-rerank, skip-product-event); de bodies blijven, alleen de guard valt weg |
+| `retrieval_api/api/chat.py` L28-29, L64 | idem voor chat endpoint |
+| `retrieval_api/services/search.py` L115-220 | `_notebook_filter`, `_search_notebook` volledig weg (incl. visibility gate logica) |
+| `retrieval_api/services/search.py` L419-444 | `if scope == "notebook"` en `if scope == "broad"` branches in `hybrid_search` weg (alleen `personal/org/both` over) |
+| `retrieval_api/config.py` L13 | `qdrant_focus_collection` setting weg |
+| `retrieval_api/config.py` L123 | comment over "focus" caller bijwerken |
+
+### klai-retrieval-api tests
+
+| File | Action |
+|---|---|
+| `tests/test_notebook_filter.py` | DELETE (114 regels, 9 hits) |
+| `tests/test_search.py` | Remove notebook/broad-specifieke testjes (4 hits) |
+| `tests/test_api.py` | Remove notebook/broad endpoint-validatie tests (~11 hits, 3 testfuncties geschat) |
+| `tests/test_search_error_handling.py` | Remove notebook-pad error tests (3 hits) |
+| `tests/test_assertion_mode_taxonomy.py` | Update 1 fixture-regel |
+
+### klai-portal cleanup
+
+| File | Action |
+|---|---|
+| `backend/app/services/provisioning/deprovisioning_steps.py` L233-300 (step 8 `_delete_qdrant_points`) | `("klai_focus", "tenant_id")` tuple uit `collections` lijst halen; doc-strings + comments bijwerken (G4 referentie naar twee-collections-pattern weg). Test in `test_deprovisioning_*` bijwerken indien aanwezig |
+
+### Documentation cleanup (optional in zelfde PR, anders follow-up)
+
+| File | Action |
+|---|---|
+| `docs/architecture/knowledge-ingest-flow.md` (regels 798-979) | Notebook/broad scope-tabellen + "Part 5: Klai Focus" sectie weg |
+| `docs/architecture/platform.md:132` | `research-api` van core-01 service-lijst |
+| `docs/runbooks/credential-rotation.md`, `litellm-retrieval-failed.md`, `gpu-01-setup.md` | Strip research-api / klai-focus referenties |
+
+### Qdrant migratie
+
+Geen. De collection bestaat niet meer (geverifieerd 2026-05-06). Niets te droppen.
+
+### Niet in scope van deze SPEC
+
+- `klai-focus/` directory blijft staan met de bestaande FROZEN README (per SPEC-PORTAL-UNIFY-KB-001 design). Volledige verwijdering valt onder de toekomstige `SPEC-RESEARCH-API-ARCHIVE-001`.
+
+### PR-grootte schatting
+
+~10-15 source-files aangeraakt, 1 testfile weg + ~4 testfiles getrimd, +1 deprovisioning-step bijgewerkt. Single PR, single SPEC-ID, een ochtend werk + CI-cycle.
+
+## Risk if not fixed
+
+- **Maintenance overhead permanent:** `_search_notebook` en `_notebook_filter` blijven security-audit-scope houden. SPEC-SEC-IDENTITY-ASSERT-001 REQ-5 visibility-gate in `_notebook_filter` is een non-trivial stuk auth-logica die getest, gereviewd en bij elke security-audit opnieuw beoordeeld wordt — voor een feature die niemand gebruikt.
+- **API-contract surface:** `/retrieve` blijft `scope="notebook"` en `scope="broad"` accepteren. Een nieuw geschreven LLM-tool of een externe partner-integratie kan deze waarden ontdekken via API-introspectie / OpenAPI schema en beginnen te gebruiken — wat dan een verborgen revival forceert.
+- **Confusing dead code:** nieuwe ontwikkelaars die de retrieval-api leren kennen verspillen tijd om "wat is notebook-scope, waar wordt het gebruikt" uit te zoeken. Eind 2026-05-06 audit tijd: ~30 min per persoon.
+- **GDPR-purge dead branch:** `deprovisioning_steps.py` step 8 itereert nog over `klai_focus`. Bij elke tenant-delete log je `qdrant_collection_not_found` voor klai_focus. Dat is harmless maar misleidend — bij future bugs op step 8 verdwaalt de oncall in irrelevante "klai_focus not found" lines.
+- **Test-fixture rot:** 28 test-hits over 5 files vergroten test-suite zonder waarde. Re-runs duren marginaal langer; refactors van retrieval-search worden duurder omdat je notebook-paden ook nog meeneemt.
+- **Severity blijft INFO** — geen security- of correctheids-risico. Dit is pure code-hygiëne. Maar de cost-of-inaction is niet 0: de surface groeit, niet krimpt, zo lang het blijft staan.

--- a/.moai/audits/retrieval-coupling-2026-05-06/findings/F6-parent-lookup-log-style.md
+++ b/.moai/audits/retrieval-coupling-2026-05-06/findings/F6-parent-lookup-log-style.md
@@ -1,0 +1,103 @@
+# F6 — parent_lookup gebruikt format-string i.p.v. structlog kwargs
+
+**Severity:** NIT — log queryability
+**Status:** OPEN — needs verification
+
+## Initial finding
+
+[`klai-retrieval-api/retrieval_api/services/parent_lookup.py:39`](../../../klai-retrieval-api/retrieval_api/services/parent_lookup.py#L39):
+
+```python
+logger.warning("parent_lookup_no_pool count=%d", len(unique_ids))
+```
+
+En [`parent_lookup.py:48`](../../../klai-retrieval-api/retrieval_api/services/parent_lookup.py#L48):
+
+```python
+logger.warning(
+    "parent_lookup_failed count=%d error=%s",
+    len(unique_ids),
+    str(exc)[:200],
+)
+```
+
+Andere modules in dezelfde service gebruiken structlog kwargs:
+
+```python
+logger.warning("retrieval_events_cap_hit", pending=len(_pending), cap=cap, event_type=event_type)
+```
+
+`%d` interpolatie maakt `count` geen losse field maar onderdeel van de message — onqueryable in VictoriaLogs (kan geen `_time:5m AND parent_lookup_no_pool AND count>100` doen).
+
+Bovendien: `error=str(exc)[:200]` is precies de TRY401/anti-pattern uit `klai/projects/portal-logging-py.md`. Beter: `exc_info=True`.
+
+## Open vragen voor verificatie
+
+1. Gebruikt portal-logging-py rule (`/Users/mvletter/Developer/Klai/.claude/rules/klai/projects/portal-logging-py.md`) op retrieval-api consistent? Vind alle instances in retrieval-api die format-string-style loggen.
+2. Is `parent_lookup_no_pool` ooit afgevuurd in productie? Als ja: hebben we last gehad van count-veld onqueryability bij debugging?
+
+## Voorgestelde fix
+
+```python
+# Line 39:
+logger.warning("parent_lookup_no_pool", count=len(unique_ids))
+
+# Line 47-52:
+except Exception:
+    logger.warning(
+        "parent_lookup_failed",
+        count=len(unique_ids),
+        exc_info=True,
+    )
+```
+
+## Verification
+
+**Status:** CONFIRMED — finding is real, but smaller in impact than the title suggests.
+
+**Rule check.** `.claude/rules/klai/projects/portal-logging-py.md` mandates:
+1. structlog kwargs (`logger.warning("event", count=N, error=str(e))`) — not `%`-format. Quote: *"Pass structured key/value pairs — not string concatenation. IDs, counts, and status values as separate kwargs make logs queryable in VictoriaLogs."*
+2. `exc_info=True` for any except-block log (HARD rule). Quote: *"`logger.warning("failed", error=str(exc))` throws away the stack frame. Prefer `exc_info=True` over string interpolation of the exception."*
+3. ruff `TRY401` is enabled to catch the `error=str(exc)` anti-pattern.
+
+Both lines 39 and 48 violate rule 1 (`count=%d` is in the message string, not a kwarg). Line 48 additionally violates rule 2 (`error=str(exc)[:200]` instead of `exc_info=True`).
+
+**Ruff config.** `klai-retrieval-api/pyproject.toml` already enables `G` (flake8-logging-format) + `TRY` rule families with `TRY401` un-ignored — so the lint config is correct. The reason it doesn't fire on these lines: retrieval-api has no `quality` CI job that runs `uv run ruff check .` on every PR (unlike portal-api's `portal-api.yml`). The local lint would catch this; CI does not.
+
+**Scope across the codebase.**
+- **retrieval-api `services/*.py` (mid-migration):** 5 other format-string warning sites — `coreference.py:63`, `gate.py:65`, `reranker.py:59`, `tei.py:63`, `main.py:42`. Some sibling files (`events.py`, `graph_search.py`, `router.py`, `rate_limit.py`, `search.py`) already use the structlog-kwargs idiom, so the codebase is partially migrated.
+- **retrieval-api `evaluation/eval_runner.py`:** ~13 lines of `%s`/`%d` style. Standalone CLI script, not on the request path — much lower priority.
+- **portal-api:** ~100+ format-string log lines across `app/api/*.py` and `app/services/*.py`. Not in scope of this audit (separate cleanup).
+- **`error=str(exc)` without `exc_info=True`:** ~50+ instances repo-wide (mailer, knowledge-ingest, portal-api). Out of audit scope.
+
+**Production data.** `docker logs --since 30d klai-core-retrieval-api-1 | grep -c parent_lookup` = **0**. The line has not fired in production in the last 30 days, so the queryability gap has caused no actual debug pain. Pure hygiene fix.
+
+## Recommended fix
+
+Two-line change in `parent_lookup.py`:
+
+```python
+# Line 39:
+logger.warning("parent_lookup_no_pool", count=len(unique_ids))
+
+# Lines 47-52:
+except Exception:
+    logger.warning(
+        "parent_lookup_failed",
+        count=len(unique_ids),
+        exc_info=True,
+    )
+```
+
+Out of scope for this finding (track separately if desired):
+- Migrate the other 5 retrieval-api `services/*.py` sites to kwargs.
+- Add a `quality` CI job to retrieval-api that runs `uv run ruff check .` so future regressions of `G`/`TRY` rules fail CI — without it the lint config is decorative.
+
+## Risk if not fixed
+
+**Severity:** NIT, confirmed. Two concrete (small) consequences:
+
+1. **Queryability gap.** When the line eventually fires (e.g. parent-chunks DB outage), VictoriaLogs cannot answer `parent_lookup_no_pool AND count>100` — count is buried in the message string. Operator falls back to grep-on-message, slower triage.
+2. **Stack-frame loss on the failure path (line 48).** If `pool.fetch()` ever raises something unexpected (asyncpg version bump, parent_chunks schema drift), there is no traceback in the log — only the truncated `str(exc)[:200]`. Same anti-pattern that pitfall `data-before-code` and the rule's HARD section warn about. Cost of fix is two lines; cost of debugging without the traceback at 3am is ~30 min of "where did this come from?".
+
+No production impact today (0 hits in 30d). Net cost-vs-benefit of the fix is strongly positive — fixes belong in the same PR as any other change to this file.


### PR DESCRIPTION
## Summary

Code-following audit of the `klai-retrieval-api /retrieve` pipeline, triggered by the question "is everything correctly wired and does it behave the way it should?". Methodology: pure code trace from `POST /retrieve` through every service (search, reranker, gate, router, evidence_tier, parent_lookup, diversity, graph_search) and out to all 4 callers. Each finding then verified by an independent sub-agent with code-trace, production log evidence, and literature/best-practice research.

## Findings

| ID | Severity | Verdict | Vehicle |
|---|---|---|---|
| F1 | HIGH (latent) | gap_rescorer sends `Authorization: Bearer <internal_secret>`; retrieval-api treats Bearer as JWT-only → 401 silent. Currently dormant because gap-emit pipeline is empty post-#311 hotfix. | Hotfix-PR |
| F2 | LOW (latent) | partner_chat sends `/retrieve` without user_id; verified_caller never pinned; `knowledge.queried` events dropped. 0 active partner keys; design-aligned per SPEC-API-001. | Defer until first partner integration |
| F3 | INFO | Link-expansion score arithmetic mixes Qdrant-RRF (k=2) with additive log-boost — different scales (anti-pattern). Original "dead weight" claim was off; with N≥17 inlinks expansion *can* land in top-20. | Phase 1 instrument (PR), phase 2 RRF migrate (SPEC) |
| F4 | INFO | Evidence-tier scoring runs every request but `EVIDENCE_SHADOW_MODE=true` default; production env has no `EVIDENCE_*` vars. Sample shadow_eval shows top-1 chunk changes in 2/5 requests. RAGAS-cron wired one day before this audit (PR #369). | `SPEC-EVIDENCE-002` (or R10 on SPEC-EVIDENCE-001) |
| F5 | INFO | Notebook scope (`_search_notebook`, `_notebook_filter`, `qdrant_focus_collection`, `scope="notebook"`/`"broad"`) unreachable post-`SPEC-DECOMM-FOCUS-001`. Qdrant `klai_focus` collection returns 404 on prod. | `SPEC-RETRIEVAL-NOTEBOOK-SCOPE-REMOVE-001` |
| F6 | NIT | `parent_lookup.py:39,48` uses format-string `%d` instead of structlog kwargs (TRY401 violation). Log fired 0× in 30d. | Bundle in opportunistic logging-cleanup |

## Documents

- [`.moai/audits/retrieval-coupling-2026-05-06/audit.md`](.moai/audits/retrieval-coupling-2026-05-06/audit.md) — overview + decisions
- `findings/F1-gap-rescorer-bearer-auth.md` — verification + smoking gun in PR #311 commit shape
- `findings/F2-partner-chat-events-drop.md` — design context from SPEC-API-001
- `findings/F3-link-expansion-dead-weight.md` — score-arithmetic correction + literature (HippoRAG, GraphRAG, Elastic, HopRAG, Qdrant docs)
- `findings/F4-evidence-shadow-mode-default.md` — RAGAS status + Lost-in-the-Middle research (Databricks, GM-Extract Nov 2025)
- `findings/F5-notebook-scope-reachable-no-callers.md` — caller-cross-check + Qdrant collection state
- `findings/F6-parent-lookup-log-style.md` — rule-confirmation + scope of similar antipatterns

## Notes

- Audit doc only — no production code changes in this PR.
- Per-finding sub-agents ran in parallel: tools_used totals = 218, total agent runtime ~32 min, all returned with `Status: CONFIRMED` or `Status: PARTIALLY CONFIRMED` plus written evidence.
- Klai-focus directory removal is **not** part of this PR — already merged to main as `SPEC-DECOMM-FOCUS-001` (#368) before this audit started; pre-decommissie branches still carry the files until they merge.

## Follow-up PRs (decisions)

1. `chore(retrieval-api): fix gap_rescorer auth header` — F1 hotfix
2. `chore(retrieval-api): instrument link_expand top-k overlap` — F3 phase 1
3. `SPEC-EVIDENCE-002` — RAGAS A/B + flag rollout (F4)
4. `SPEC-RETRIEVAL-NOTEBOOK-SCOPE-REMOVE-001` — strip notebook/broad code (F5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)