### PR TITLE
fix(gap_rescorer): use X-Internal-Secret instead of Authorization Bearer

### DIFF
--- a/klai-portal/backend/app/services/gap_rescorer.py
+++ b/klai-portal/backend/app/services/gap_rescorer.py
@@ -93,9 +93,25 @@ async def rescore_open_gaps(
     # body. We send `system` here in user_id, but the header is still
     # validated. Without it: 400 missing_caller_service → silent rescore
     # noop. See pitfalls → retrieve-caller-service-header-mismatch.
-    headers = {"X-Caller-Service": "portal-api", **get_trace_headers()}
-    if settings.internal_secret:
-        headers["Authorization"] = f"Bearer {settings.internal_secret}"
+    #
+    # SPEC-SEC-010 REQ-1: retrieval-api's AuthMiddleware treats
+    # `Authorization: Bearer <token>` strictly as a JWT — non-JWT strings
+    # (like our shared `internal_secret`) fail decode and return 401
+    # `invalid_jwt_signature`. There is NO fallback to X-Internal-Secret
+    # when the Bearer arm is taken. So this caller MUST send
+    # X-Internal-Secret like every other portal-api → retrieval-api
+    # caller (partner_chat, klai_connector_client, litellm hook).
+    # Use the dedicated retrieval_api_internal_secret rotation
+    # boundary (REQ-6.1) — falls back to internal_secret for
+    # backwards-compat with envs that haven't split the secret yet.
+    # Audit reference: .moai/audits/retrieval-coupling-2026-05-06/
+    # findings/F1-gap-rescorer-bearer-auth.md
+    retrieval_secret = settings.retrieval_api_internal_secret or settings.internal_secret
+    headers = {
+        "X-Internal-Secret": retrieval_secret,
+        "X-Caller-Service": "portal-api",
+        **get_trace_headers(),
+    }
 
     async with httpx.AsyncClient(timeout=httpx.Timeout(10.0)) as client:
         for row in gap_queries:

--- a/klai-portal/backend/tests/test_gap_rescorer.py
+++ b/klai-portal/backend/tests/test_gap_rescorer.py
@@ -52,7 +52,8 @@ async def test_rescore_marks_resolved_when_no_longer_gap() -> None:
         patch("app.services.gap_rescorer.httpx.AsyncClient") as mock_client_cls,
     ):
         mock_settings.knowledge_retrieve_url = "http://test-retrieve:8000"
-        mock_settings.internal_secret = "test-secret"
+        mock_settings.internal_secret = "fallback-secret"
+        mock_settings.retrieval_api_internal_secret = "retrieval-test-secret"
         mock_settings.klai_gap_soft_threshold = 0.4
         mock_settings.klai_gap_dense_threshold = 0.35
 
@@ -73,6 +74,21 @@ async def test_rescore_marks_resolved_when_no_longer_gap() -> None:
     assert post_headers.get("X-Caller-Service") == "portal-api", (
         "X-Caller-Service header missing — would silently 400 in prod. "
         "See pitfalls/process-rules.md → retrieve-caller-service-header-mismatch."
+    )
+
+    # Regression-guard for F1 (audit retrieval-coupling-2026-05-06):
+    # retrieval-api's AuthMiddleware treats `Authorization: Bearer ...`
+    # strictly as a JWT — non-JWT shared secrets fail with 401
+    # `invalid_jwt_signature`. There is NO fallback to X-Internal-Secret
+    # when Bearer is taken. So gap_rescorer MUST use X-Internal-Secret.
+    assert post_headers.get("X-Internal-Secret") == "retrieval-test-secret", (
+        "X-Internal-Secret header missing or wrong value — would 401 in prod. "
+        "See .moai/audits/retrieval-coupling-2026-05-06/findings/F1-...md."
+    )
+    assert "Authorization" not in post_headers, (
+        "Authorization header MUST NOT be set on retrieval-api calls — the "
+        "Bearer arm of AuthMiddleware tries JWT decode and would 401 a "
+        "shared-secret value. F1 regression guard."
     )
 
 
@@ -224,6 +240,52 @@ async def test_rescore_skips_on_retrieval_error() -> None:
 
     assert result == 0
     mock_db.commit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rescore_falls_back_to_internal_secret_when_split_secret_unset() -> None:
+    """When retrieval_api_internal_secret is empty, falls back to internal_secret.
+
+    Backwards compatibility for envs that haven't split the secret yet.
+    """
+    from app.services.gap_rescorer import rescore_open_gaps
+
+    mock_row = MagicMock()
+    mock_row.query_text = "fallback test"
+    mock_row.gap_type = "soft"
+
+    mock_result = MagicMock()
+    mock_result.all.return_value = [mock_row]
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(side_effect=[MagicMock(), mock_result, MagicMock()])
+    mock_db.commit = AsyncMock()
+
+    mock_response = MagicMock()
+    mock_response.is_success = True
+    mock_response.json.return_value = {"chunks": [{"reranker_score": 0.8}]}
+
+    with (
+        patch("app.services.gap_rescorer.settings") as mock_settings,
+        patch("app.services.gap_rescorer.httpx.AsyncClient") as mock_client_cls,
+    ):
+        mock_settings.knowledge_retrieve_url = "http://test-retrieve:8000"
+        mock_settings.internal_secret = "shared-fallback"
+        mock_settings.retrieval_api_internal_secret = ""  # not yet rotated
+        mock_settings.klai_gap_soft_threshold = 0.4
+        mock_settings.klai_gap_dense_threshold = 0.35
+
+        mock_client = AsyncMock()
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        await rescore_open_gaps(org_id=1, zitadel_org_id="z1", kb_slug="test-kb", db=mock_db)
+
+    post_headers = mock_client.post.call_args.kwargs["headers"]
+    assert post_headers.get("X-Internal-Secret") == "shared-fallback", (
+        "Should fall back to internal_secret when split secret is empty"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes **F1** from the [retrieval coupling audit](https://github.com/GetKlai/klai/pull/386) — gap_rescorer's auth header was `Authorization: Bearer <internal_secret>`, which retrieval-api's AuthMiddleware decodes as a JWT and rejects with 401 `invalid_jwt_signature`. There is no fallback to X-Internal-Secret when the Bearer arm is taken (verified in [`klai-retrieval-api/retrieval_api/middleware/auth.py:325-365`](https://github.com/GetKlai/klai/blob/main/klai-retrieval-api/retrieval_api/middleware/auth.py#L325-L365)).

**Currently dormant on prod** because `portal_retrieval_gaps` is empty (LiteLLM gap-emit pipeline broke 7 days ago and was hotfixed in #311 but has not yet emitted new rows). The bug fires the moment gap-emit resumes.

## Change

One-line auth-header fix + uses the dedicated `retrieval_api_internal_secret` rotation boundary (SPEC-SEC-010 REQ-6.1, matching `partner_chat.py`), with fallback to the legacy `internal_secret` for envs that haven't split the secret yet.

## Tests

8 tests pass. Three new regression guards in `test_rescore_marks_resolved_when_no_longer_gap`:
- ✅ `X-Internal-Secret` equals the split secret
- ✅ `Authorization` header is **NOT** present (Bearer would 401)
- ✅ Fallback to `internal_secret` when split secret is empty (new dedicated test)

Existing `X-Caller-Service: portal-api` guard kept (SPEC-SEC-IDENTITY-ASSERT-001 hotfix #311).

## Verification audit log

VictoriaLogs (14d): 0 `invalid_jwt_signature` on retrieval-api, 64 `invalid_internal_secret`, 13 `invalid_jwt_audience`. The Bearer-as-JWT bug never fired in steady state because the upstream pipeline isn't producing inputs (`portal_retrieval_gaps` table count = 0). Pre-emptive fix before gap-emit pipeline recovers.

Audit reference: `.moai/audits/retrieval-coupling-2026-05-06/findings/F1-gap-rescorer-bearer-auth.md` (#386).

🤖 Generated with [Claude Code](https://claude.com/claude-code)