### PR TITLE
docs(audit-ti): SPEC-TI-003-FOLLOWUP-001 + SPEC-TI-011 + asyncpg pitfall

### DIFF
--- a/.claude/rules/klai/pitfalls/process-rules.md
+++ b/.claude/rules/klai/pitfalls/process-rules.md
@@ -82,6 +82,38 @@ WITH CHECK (org_id = NULLIF(current_setting('app.current_org_id', true), '')::in
   in the same PR, or extend the rls-policy-smoke-test CI job to import
   `app.main` and invoke the lifespan assertion.
 
+## asyncpg-pool-guc-not-shared (HIGH)
+Postgres GUCs (`current_setting('app.foo', true)`) are **connection-local**,
+not pool-local. Setting the GUC on connection A does NOT propagate to
+connection B that a later `pool.acquire()` returns. Pinning one
+connection in an outer `async with tenant_scoped_connection(...)` and
+letting the body call `pool.acquire()` on its own gives the body a
+DIFFERENT connection without the GUC — every query against an
+RLS-protected table raises ERRCODE 42501.
+
+Reference: SPEC-TI-003 (PR #376, 2026-05-06).
+
+```python
+# WRONG — the SPEC author wrote this literally:
+async with tenant_scoped_connection(org_id) as _conn:
+    del _conn  # connection held open to keep GUC set; pg_store uses pool
+    await run_crawl_job(...)  # → pg_store grabs a DIFFERENT pool conn → 42501
+```
+
+Fix: pass the `conn` from the helper through every function that issues
+SQL, or have the leaf function open its own `tenant_scoped_connection`.
+
+**Prevention:**
+- `tenant_scoped_connection` helpers MUST yield a `Connection` callers
+  PASS through — never pin-and-pray.
+- Code review for any RLS helper: grep `pool.acquire()` / `get_pool()`
+  in the same service. Every site must accept a `conn` parameter, be
+  inside the helper, or never touch RLS-protected tables.
+- contextvars and per-request middleware do NOT help — they carry
+  Python state, not Postgres connection state.
+- Pre-merge: run a smoke-test against a clean Postgres with the
+  FORCE-RLS post-deploy SQL applied. Any wiring gap surfaces as 42501.
+
 ## scale-the-answer-to-the-problem (HIGH)
 When a user asks "what is industry standard?" do not autopilot to the
 most architecturally-elegant answer in the search results. Anchor on

--- a/.moai/specs/SPEC-TI-003-FOLLOWUP-001/spec.md
+++ b/.moai/specs/SPEC-TI-003-FOLLOWUP-001/spec.md
@@ -1,0 +1,103 @@
+# SPEC-TI-003-FOLLOWUP-001 — Refactor knowledge-ingest pg_store to pass `conn` explicitly
+
+**Predecessor:** `SPEC-TI-003-RLS-KNOWLEDGE` (PR #376, merged 2026-05-06)
+**Pitfall:** `asyncpg-pool-guc-not-shared` (HIGH)
+**Priority:** MEDIUM (mitigated by emergency `NO FORCE`; activates when SPEC-TI-011 lands per-service roles)
+**Status:** Ready
+
+## Goal
+
+Restore the tenant-isolation hardening promised by SPEC-TI-003 by making
+the connection-locality of the RLS GUC explicit in the API. Today
+`tenant_scoped_connection(org_id)` pins one connection while every
+function in `pg_store.py` (and friends) grabs a different connection from
+the pool, so the GUC is never visible to the queries that actually need
+it. Audit on origin/main found 26 unique functions across 6 files
+affected.
+
+The bug is currently latent on prod because `klai` (the connecting role)
+is a Postgres superuser and bypasses RLS regardless. SPEC-TI-011 will
+move services to non-superuser roles; this SPEC is its prerequisite.
+
+## Acceptance criteria
+
+- **AC-1** Every function in `klai-knowledge-ingest/knowledge_ingest/`
+  that issues SQL against `knowledge.*` tables takes an
+  `asyncpg.Connection` (typically named `conn`) as its first non-`self`
+  argument and uses it for all query execution.
+
+- **AC-2** No function under `knowledge_ingest/` outside of `db.py`
+  calls `get_pool()` or `pool.acquire()` while issuing SQL against
+  `knowledge.*`. Allowed exceptions: `rag_eval_results` queries,
+  procrastinate-internal calls, and lifespan-startup hooks (which use
+  `cross_org_admin_connection()` — see AC-3).
+
+- **AC-3** New helper `cross_org_admin_connection()` in `db.py` for
+  startup reapers and deprovision sweeps. Mirrors
+  `klai-connector/app/core/database.py::cross_org_session()`. Sets
+  `app.cross_org_admin = 'true'` on the pinned connection.
+
+- **AC-4** `tenant_scoped_connection(org_id)` docstring is updated to
+  state explicitly that the GUC applies ONLY to queries via the
+  yielded connection — pass it down, do not rely on pinning.
+
+- **AC-5** A regression test in `tests/test_db_rls_wiring.py` runs
+  two concurrent `tenant_scoped_connection(org_a)` and
+  `tenant_scoped_connection(org_b)` blocks against a real Postgres
+  fixture and asserts each block reads its own GUC (no bleed).
+
+- **AC-6** A second regression test calls a refactored pg_store
+  function WITHOUT a `conn` argument and expects a `TypeError` (the
+  function signature now requires it). pyright/mypy must also flag
+  the missing argument as a type error.
+
+- **AC-7** New post-deploy SQL `post_deploy_dd1b439a57d0_force.sql`
+  re-applies `FORCE ROW LEVEL SECURITY` on all 13 `knowledge.*` tables.
+  Operator runs this AFTER (a) this SPEC's code is deployed and (b)
+  SPEC-TI-011 has migrated knowledge-ingest off the klai-superuser DSN.
+
+- **AC-8** The hot-fix `derivations` policy (currently scoped by
+  `child_id`, hot-applied 2026-05-06) is back-filled into source as
+  part of this SPEC.
+
+- **AC-9** `_rls_current_org_id()` keeps its fail-loud `RAISE 42501`
+  on missing GUC. Do NOT downgrade to `RETURN NULL` — that hides
+  wiring gaps as silent default-deny.
+
+## Background
+
+Caller pattern that was wrong (verbatim from `crawl_tasks.py`):
+
+```python
+async with tenant_scoped_connection(org_id) as _conn:
+    del _conn  # connection held open to keep GUC set; pg_store uses pool
+    await run_crawl_job(...)  # ← grabs DIFFERENT pool conn → no GUC
+```
+
+Correct pattern:
+
+```python
+async with tenant_scoped_connection(org_id) as conn:
+    await run_crawl_job(conn, ...)  # ← same conn → same GUC
+```
+
+For the full incident, see pitfall `asyncpg-pool-guc-not-shared` (HIGH).
+
+## Operator step (after merge + SPEC-TI-011)
+
+```bash
+ssh core-01 "docker exec -i klai-core-postgres-1 psql -U klai -d klai" \
+    < klai-knowledge-ingest/alembic/versions/post_deploy_dd1b439a57d0_force.sql
+```
+
+Verify zero 42501 errors in VictoriaLogs over the next hour.
+
+## Out of scope
+
+- Refactor of connector `sync_engine.py` / `scheduler.py` — same class
+  of bug, separate SPEC: `SPEC-TI-002-FOLLOWUP-001`.
+- Refactor of scribe `app/core/database.py` to add the helper
+  infrastructure — separate SPEC: `SPEC-TI-010A-FOLLOWUP-001`.
+- Migrating services off the `klai` superuser DSN — separate SPEC:
+  `SPEC-TI-011-PER-SERVICE-DB-ROLES`.
+- Migration of knowledge-ingest from asyncpg to SQLAlchemy.

--- a/.moai/specs/SPEC-TI-011-PER-SERVICE-DB-ROLES/spec.md
+++ b/.moai/specs/SPEC-TI-011-PER-SERVICE-DB-ROLES/spec.md
@@ -1,0 +1,157 @@
+# SPEC-TI-011 — Per-service Postgres roles so RLS actually fires
+
+**Audit ref:** Discovered 2026-05-06 during SPEC-TI-003 incident response
+**Priority:** HIGH (the entire RLS-rollout audit is cosmetic on prod until this lands)
+**Status:** Ready
+
+## Goal
+
+Move every klai service that today connects to Postgres as the `klai`
+superuser to a dedicated **non-superuser, non-`bypassrls`** role. PostgreSQL
+superusers always bypass RLS, regardless of `FORCE`. Today only `portal-api`
+connects as a non-superuser (`portal_api`); the RLS policies added by
+SPEC-TI-002 (connector), SPEC-TI-003 (knowledge), SPEC-TI-005 (portal
+hygiene), SPEC-TI-010A (scribe) all exist in `pg_policies` but are never
+evaluated for the services that own that data.
+
+Confirmed on prod 2026-05-06:
+
+```
+postgres=> SELECT rolname, rolsuper, rolbypassrls FROM pg_roles
+            WHERE rolname IN ('klai','portal_api');
+  rolname   | rolsuper | rolbypassrls
+------------+----------+--------------
+ klai       | t        | t
+ portal_api | f        | f
+```
+
+## Acceptance criteria
+
+- **AC-1** Four new roles exist on the postgres instance, each with
+  `LOGIN`, `NOSUPERUSER`, `NOBYPASSRLS`, and a per-role password:
+  - `connector_api`
+  - `knowledge_ingest`
+  - `retrieval_api`
+  - `scribe_api`
+
+- **AC-2** Each role has the minimum privileges needed for its service
+  to function:
+  - `USAGE` on its primary schema (e.g. `connector_api` on `connector`)
+  - `CRUD` (`SELECT, INSERT, UPDATE, DELETE`) on every table in that
+    schema
+  - `EXECUTE` on every RLS helper function in `public` and the schema
+  - `USAGE, SELECT, UPDATE` on every sequence in the schema
+  - No `CREATE` on the schema (alembic migrations continue to run as
+    `klai` — see operator step)
+
+- **AC-3** SOPS contains four new env vars, one per service:
+  - `CONNECTOR_POSTGRES_DSN` (used by klai-connector)
+  - `KNOWLEDGE_INGEST_POSTGRES_DSN` (used by knowledge-ingest)
+  - `RETRIEVAL_API_POSTGRES_DSN` (used by retrieval-api)
+  - `SCRIBE_API_POSTGRES_DSN` (used by scribe-api)
+
+  Each DSN uses its dedicated role + per-role password.
+
+- **AC-4** `deploy/docker-compose.yml` passes the right DSN to each
+  service via the `environment:` block. The legacy `POSTGRES_DSN`
+  fallback (which uses `klai` superuser) is removed from these four
+  services.
+
+- **AC-5** Each service's pydantic config picks up the new DSN env var.
+  Backward compatibility: if a service-specific DSN is unset, the
+  service refuses to start with a fail-loud `ValidationError`. Do NOT
+  silently fall back to the klai superuser DSN.
+
+- **AC-6** Each service's lifespan logs the active DB role at startup
+  and warns if `current_user` resolves to a superuser:
+
+  ```python
+  row = await conn.fetchrow("SELECT current_user, rolsuper, rolbypassrls "
+                             "FROM pg_roles WHERE rolname = current_user")
+  if row["rolsuper"] or row["rolbypassrls"]:
+      logger.error("RLS bypass detected: connected as %s (super=%s, bypass=%s) — "
+                   "tenant isolation is INACTIVE", row[0], row[1], row[2])
+  ```
+
+- **AC-7** Smoke test (CI): `tests/test_db_role_no_rls_bypass.py` per
+  service connects with the dedicated DSN and asserts:
+  - `current_user` is the expected role (not `klai`)
+  - `rolsuper = false AND rolbypassrls = false`
+  - A query without GUC against an RLS-protected table returns 0 rows
+    (where today as klai it returns all rows)
+
+- **AC-8** This SPEC depends on the wiring SPECs landing FIRST so the
+  switch to the non-super role does not immediately produce 42501
+  storms:
+  - `SPEC-TI-003-FOLLOWUP-001` (knowledge-ingest pg_store wiring)
+  - `SPEC-TI-002-FOLLOWUP-001` (connector sync_engine + scheduler)
+  - `SPEC-TI-010A-FOLLOWUP-001` (scribe `set_tenant` infrastructure)
+
+## Implementation skeleton
+
+### Role-creation SQL (operator-applied as klai)
+
+```sql
+-- per service, with passwords from SOPS
+CREATE ROLE connector_api WITH LOGIN NOSUPERUSER NOBYPASSRLS PASSWORD :pw_connector;
+CREATE ROLE knowledge_ingest WITH LOGIN NOSUPERUSER NOBYPASSRLS PASSWORD :pw_knowledge;
+CREATE ROLE retrieval_api WITH LOGIN NOSUPERUSER NOBYPASSRLS PASSWORD :pw_retrieval;
+CREATE ROLE scribe_api WITH LOGIN NOSUPERUSER NOBYPASSRLS PASSWORD :pw_scribe;
+
+-- per service, per schema
+GRANT USAGE ON SCHEMA connector TO connector_api;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA connector TO connector_api;
+GRANT USAGE, SELECT, UPDATE ON ALL SEQUENCES IN SCHEMA connector TO connector_api;
+ALTER DEFAULT PRIVILEGES IN SCHEMA connector
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO connector_api;
+ALTER DEFAULT PRIVILEGES IN SCHEMA connector
+    GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO connector_api;
+GRANT EXECUTE ON FUNCTION public._rls_current_org_text() TO connector_api;
+-- (similar block per service+schema)
+```
+
+### Operator step
+
+1. Generate four passwords (1Password / `openssl rand`)
+2. SOPS edit: add the four DSN env vars
+3. Run the role-creation SQL on prod as klai
+4. Push compose change + deploy
+5. Verify: each service logs `current_user = <its-role>` at startup,
+   no superuser warning, no 42501 spike in VictoriaLogs
+
+## Rollback
+
+```sql
+-- per service
+DROP ROLE IF EXISTS connector_api;
+-- compose change reverts the DSN env var to fall back to klai-DSN
+```
+
+If a service fails fast on startup (AC-5), revert SOPS to remove the
+service-specific DSN. The service then needs the legacy klai DSN to be
+restored (or its config code reverted to fall back). Test in staging
+first.
+
+## Why this matters
+
+Today every klai service that touches an RLS-protected table runs as
+the `klai` superuser. A bug in the application layer that drops an
+`org_id` filter would silently leak across tenants — RLS does NOT
+catch it because superuser bypasses every policy. SPEC-TI-002 and
+SPEC-TI-003 added policies but did not deliver the protection they
+promised. This SPEC closes that gap.
+
+Concrete proof on prod:
+
+```
+postgres=> SET ROLE klai;
+SET
+postgres=> SET app.current_org_id = '';
+SET
+postgres=> ALTER TABLE knowledge.artifacts FORCE ROW LEVEL SECURITY;
+postgres=> SELECT COUNT(*) FROM knowledge.artifacts;  -- 1026 rows visible
+```
+
+After this SPEC, the same query as `knowledge_ingest` would either
+raise 42501 (helper variant) or return 0 rows (NULLIF variant) — RLS
+actually fires.


### PR DESCRIPTION
## Wat zit hierin

Twee follow-up SPECs uit de SPEC-TI-003 incident-respons + de pitfall.

### SPEC-TI-003-FOLLOWUP-001 (wiring fix)

Refactor knowledge-ingest `pg_store` om `conn` expliciet door te geven. Vandaag pinnen `tenant_scoped_connection(org_id)` één connectie terwijl alle pg_store-functies een ANDERE pool-conn pakken — de GUC bereikt nooit de queries die hem nodig hebben. 26 functies in 6 files raken dit aan.

Bug is nu latent op prod omdat klai-superuser RLS sowieso bypassed (zie SPEC-TI-011). Activeert zodra we naar non-super rollen gaan.

### SPEC-TI-011-PER-SERVICE-DB-ROLES (de échte fix voor RLS-effectiviteit)

Foundationele ops-change. Vandaag connect alles behalve portal-api als `klai` superuser → bypassed ALLE RLS. De RLS-policies van SPEC-TI-002 (connector), SPEC-TI-003 (knowledge), SPEC-TI-010A (scribe) bestaan in pg_policies maar worden nooit geëvalueerd voor de services die de data bezitten.

Provisioneert vier dedicated rollen (`connector_api`, `knowledge_ingest`, `retrieval_api`, `scribe_api` — NOSUPERUSER, NOBYPASSRLS). Migreert services naar dedicated DSNs. Hangt af van de wiring-SPECs eerst landen, anders 42501-storm.

### Pitfall

`asyncpg-pool-guc-not-shared` (HIGH) — 30 regels, klai concise stijl. Postgres GUCs zijn connection-local; pin-en-pray werkt niet.

## Out of scope (apart open te zetten)

- SPEC-TI-002-FOLLOWUP-001 — connector sync_engine + scheduler wiring
- SPEC-TI-006/007-FOLLOWUP-001 — webhook-replay 3 BLOCKER findings
- SPEC-TI-010A-FOLLOWUP-001 — scribe `set_tenant` infra + cross-org leak in transcribe
- SPEC-TI-010B-FOLLOWUP-001 — Redis key namespace + sync_engine wiring

Findings staan in agent-audits van vandaag (zie comments op #380/#381/#382).

## Doc-only PR

Geen code changes. Niets te deployen. Reviewer hoeft alleen te beoordelen of de SPEC-scope juist is en de pitfall klopt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)