### PR TITLE
chore(retrieval-api): logging hygiene per F6 audit

### DIFF
--- a/klai-retrieval-api/retrieval_api/main.py
+++ b/klai-retrieval-api/retrieval_api/main.py
@@ -38,8 +38,9 @@ async def _warmup_reranker() -> None:
                 },
             )
         logger.info("reranker warmup complete")
-    except Exception as exc:
-        logger.warning("reranker warmup failed (non-fatal): %s", exc)
+    except Exception:
+        # F6 audit cleanup (TRY401): exc_info=True preserves traceback.
+        logger.warning("reranker warmup failed (non-fatal)", exc_info=True)
 
 
 @asynccontextmanager

--- a/klai-retrieval-api/retrieval_api/services/coreference.py
+++ b/klai-retrieval-api/retrieval_api/services/coreference.py
@@ -59,8 +59,9 @@ async def resolve(query: str, history: list[dict]) -> str:
     except TimeoutError:
         logger.warning("Coreference resolution timed out, using original query")
         return query
-    except Exception as exc:
-        logger.warning("Coreference resolution failed: %s", exc)
+    except Exception:
+        # F6 audit cleanup (TRY401): exc_info=True preserves traceback.
+        logger.warning("Coreference resolution failed", exc_info=True)
         return query
 
 

--- a/klai-retrieval-api/retrieval_api/services/gate.py
+++ b/klai-retrieval-api/retrieval_api/services/gate.py
@@ -61,8 +61,9 @@ async def _ensure_reference_vectors() -> list[list[float]]:
 
         texts = [q["query"] for q in queries]
         _reference_vectors = await embed_batch(texts)
-    except Exception as exc:
-        logger.warning("Failed to embed gate reference queries: %s", exc)
+    except Exception:
+        # F6 audit cleanup (TRY401): exc_info=True preserves traceback.
+        logger.warning("Failed to embed gate reference queries", exc_info=True)
         _reference_vectors = []
 
     return _reference_vectors

--- a/klai-retrieval-api/retrieval_api/services/parent_lookup.py
+++ b/klai-retrieval-api/retrieval_api/services/parent_lookup.py
@@ -15,7 +15,7 @@ through to using the child's own text.
 
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 import structlog
 
@@ -36,7 +36,7 @@ async def fetch_parents(parent_ids: Iterable[int]) -> dict[int, str]:
 
     pool = events.get_pool()
     if pool is None:
-        logger.warning("parent_lookup_no_pool count=%d", len(unique_ids))
+        logger.warning("parent_lookup_no_pool", count=len(unique_ids))
         return {}
 
     try:
@@ -44,12 +44,10 @@ async def fetch_parents(parent_ids: Iterable[int]) -> dict[int, str]:
             "SELECT id, text FROM knowledge.parent_chunks WHERE id = ANY($1::bigint[])",
             unique_ids,
         )
-    except Exception as exc:
-        logger.warning(
-            "parent_lookup_failed count=%d error=%s",
-            len(unique_ids),
-            str(exc)[:200],
-        )
+    except Exception:
+        # SPEC-SEC-HYGIENE-001 REQ-43.3 / TRY401: exc_info=True preserves the
+        # traceback that the previous str(exc)[:200] dropped. F6 audit cleanup.
+        logger.warning("parent_lookup_failed", count=len(unique_ids), exc_info=True)
         return {}
 
     return {int(row["id"]): row["text"] for row in rows}

--- a/klai-retrieval-api/retrieval_api/services/reranker.py
+++ b/klai-retrieval-api/retrieval_api/services/reranker.py
@@ -55,8 +55,9 @@ async def rerank(
             )
             resp.raise_for_status()
             data = resp.json()
-    except Exception as exc:
-        logger.warning("Reranker call failed, falling back to Qdrant scores: %s", exc)
+    except Exception:
+        # F6 audit cleanup (TRY401): exc_info=True preserves traceback.
+        logger.warning("Reranker call failed, falling back to Qdrant scores", exc_info=True)
         fallback = candidates[:top_k]
         for c in fallback:
             c["reranker_score"] = None

--- a/klai-retrieval-api/retrieval_api/services/taxonomy_lookup.py
+++ b/klai-retrieval-api/retrieval_api/services/taxonomy_lookup.py
@@ -100,12 +100,14 @@ async def get_taxonomy_trees(
 
     try:
         rows = await pool.fetch(_TREES_SQL, org_id, list(kb_slugs))
-    except Exception as exc:
+    except Exception:
+        # SPEC-SEC-HYGIENE-001 REQ-43.3 / TRY401: exc_info=True preserves the
+        # traceback that error=str(exc)[:200] dropped. F6 audit cleanup.
         logger.warning(
             "taxonomy_tree_fetch_failed",
             org_id=org_id,
             kb_slugs=kb_slugs,
-            error=str(exc)[:200],
+            exc_info=True,
         )
         return {}
 
@@ -142,12 +144,14 @@ async def get_kb_taxonomy_coverage(
 
     try:
         rows = await pool.fetch(_COVERAGE_SQL, org_id, list(kb_slugs))
-    except Exception as exc:
+    except Exception:
+        # SPEC-SEC-HYGIENE-001 REQ-43.3 / TRY401: exc_info=True preserves the
+        # traceback that error=str(exc)[:200] dropped. F6 audit cleanup.
         logger.warning(
             "taxonomy_coverage_fetch_failed",
             org_id=org_id,
             kb_slugs=kb_slugs,
-            error=str(exc)[:200],
+            exc_info=True,
         )
         return {slug: 0.0 for slug in kb_slugs}
 

--- a/klai-retrieval-api/retrieval_api/services/tei.py
+++ b/klai-retrieval-api/retrieval_api/services/tei.py
@@ -59,6 +59,7 @@ async def embed_sparse(text: str) -> SparseVector | None:
             resp.raise_for_status()
             item = resp.json()["results"][0]
             return SparseVector(indices=item["indices"], values=item["values"])
-    except Exception as exc:
-        logger.warning("sparse_sidecar_unavailable: %s", exc)
+    except Exception:
+        # F6 audit cleanup (TRY401): exc_info=True preserves traceback.
+        logger.warning("sparse_sidecar_unavailable", exc_info=True)
         return None


### PR DESCRIPTION
## Summary

F6 from the [retrieval coupling audit](https://github.com/GetKlai/klai/pull/386) — bring all retrieval-api log call-sites onto `structlog kwargs` / `exc_info=True` pattern. Per the project's `portal-logging-py.md` rule:
- Format-string interpolation (`logger.warning("foo: %s", exc)`) drops queryable structure in VictoriaLogs.
- `error=str(exc)[:200]` (TRY401 anti-pattern) drops the traceback frame, making 3am debugging hard.

## Sites migrated (7 + 2 TRY401)

| File | Line | Before | After |
|---|---|---|---|
| `main.py` | 42 | `logger.warning("reranker warmup failed: %s", exc)` | `exc_info=True` |
| `services/coreference.py` | 63 | `logger.warning("Coreference resolution failed: %s", exc)` | `exc_info=True` |
| `services/reranker.py` | 59 | `logger.warning("Reranker call failed... %s", exc)` | `exc_info=True` |
| `services/tei.py` | 63 | `logger.warning("sparse_sidecar_unavailable: %s", exc)` | `exc_info=True` |
| `services/gate.py` | 65 | `logger.warning("Failed to embed gate ref... %s", exc)` | `exc_info=True` |
| `services/parent_lookup.py` | 39 | `"parent_lookup_no_pool count=%d"` | `count=` kwarg |
| `services/parent_lookup.py` | 48 | `"parent_lookup_failed count=%d error=%s"` | `count=` kwarg + `exc_info=True` |
| `services/taxonomy_lookup.py` | 104 | `error=str(exc)[:200]` | `exc_info=True` |
| `services/taxonomy_lookup.py` | 146 | `error=str(exc)[:200]` | `exc_info=True` |

Plus: `parent_lookup.py` UP035 cleanup (`typing.Iterable` → `collections.abc.Iterable`).

## Tests

- 16 critical-path tests green (test_evidence_pipeline, test_coreference, test_gate, test_search, test_api).
- Ruff check on touched files: ✅ pass.
- Ruff format on touched files: ✅ pass.
- The 5 test failures observed on this branch (`test_tei::*`, `test_graph_search::test_search_success`) are **pre-existing on main** — verified by stashing F6 changes and re-running: same 5 failures appear. Out of scope for this PR.

## What this PR does NOT do

- Does NOT migrate stdlib `logging.getLogger` to `structlog.get_logger` — that's a wider refactor; left as a follow-up.
- Does NOT change the format-string log-call inside `main.py:49-54` (the lifespan boot log) — info-level startup line, low queryability impact.
- Does NOT touch the pre-existing failing tests (out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)