### PR TITLE
feat(partner): synthetic partner_user_id flows through to retrieval-api

### DIFF
--- a/klai-portal/backend/app/api/partner.py
+++ b/klai-portal/backend/app/api/partner.py
@@ -180,7 +180,12 @@ async def chat_completions(
     # 5. Translate kb_ids -> kb_slugs
     kb_slugs = await _resolve_kb_slugs(kb_ids, auth.org_id, db)
 
-    # 6. Retrieve context
+    # 6. Retrieve context.
+    # F2 (audit retrieval-coupling-2026-05-06): pass synthetic partner_user_id
+    # so retrieval-api pins verified_caller and emits the
+    # `knowledge.queried` product_event with the correct (org, partner-key)
+    # tuple. Matches the existing convention used at line ~205 below for
+    # write_retrieval_log.
     try:
         chunks, system_prompt = await retrieve_context(
             org_id=auth.org_id,
@@ -188,6 +193,7 @@ async def chat_completions(
             kb_slugs=kb_slugs,
             messages=request.messages,
             settings=settings,
+            partner_user_id=f"partner:{auth.key_id}",
         )
     except (httpx.TimeoutException, httpx.ReadTimeout) as exc:
         raise HTTPException(

--- a/klai-portal/backend/app/services/partner_chat.py
+++ b/klai-portal/backend/app/services/partner_chat.py
@@ -87,10 +87,22 @@ async def retrieve_context(
     kb_slugs: list[str],
     messages: list[dict],
     settings: Settings,
+    *,
+    partner_user_id: str | None = None,
 ) -> tuple[list[dict], str]:
     """Call retrieval-api and return (chunks, augmented_system_prompt).
 
     Follows the pattern from deploy/litellm/klai_knowledge.py.
+
+    ``partner_user_id`` (F2 audit cleanup, 2026-05-06): when given, attached
+    to the /retrieve body as ``user_id``. retrieval-api recognizes the
+    ``partner:`` prefix and pins ``verified_caller`` for product_events
+    integrity (SPEC-SEC-IDENTITY-ASSERT-001 REQ-6) without a round-trip
+    to portal-api's /internal/identity/verify (which would 403 on the
+    synthetic identity). Without this, ``knowledge.queried`` events for
+    partner traffic are silently dropped via the
+    ``product_event_skipped_no_identity`` warning branch in retrieve.py.
+    Audit ref: .moai/audits/retrieval-coupling-2026-05-06/findings/F2-...md.
     """
     query = _last_user_message(messages)
     if not query:
@@ -114,6 +126,9 @@ async def retrieve_context(
     }
     if kb_slugs:
         retrieve_body["kb_slugs"] = kb_slugs
+    if partner_user_id is not None:
+        # F2: synthetic partner-level identity for product_events tagging.
+        retrieve_body["user_id"] = partner_user_id
 
     retrieval_url = settings.knowledge_retrieve_url
     if not retrieval_url:

--- a/klai-portal/backend/tests/test_partner_chat.py
+++ b/klai-portal/backend/tests/test_partner_chat.py
@@ -431,3 +431,113 @@ async def test_retrieve_context_sends_caller_service_header(monkeypatch):
         "X-Caller-Service header missing — retrieval-api 400s and partner chat returns no KB context. See pitfalls."
     )
     assert captured["headers"].get("X-Internal-Secret") == "test-retrieval-secret"
+
+
+# ---------------------------------------------------------------------------
+# F2 (audit retrieval-coupling-2026-05-06): synthetic partner user_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retrieve_context_passes_partner_user_id(monkeypatch):
+    """When `partner_user_id` is given, /retrieve body carries `user_id`.
+
+    Without this, retrieval-api's verify_body_identity returns early without
+    pinning verified_caller, so emit_event drops the knowledge.queried event
+    via the product_event_skipped_no_identity warning branch.
+    """
+    from app.services.partner_chat import retrieve_context
+
+    captured: dict = {}
+
+    class _MockResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"chunks": []}
+
+    class _MockClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            return None
+
+        async def post(self, url, json=None, headers=None):
+            captured["body"] = json
+            return _MockResp()
+
+    monkeypatch.setattr(
+        "app.services.partner_chat.httpx.AsyncClient",
+        lambda timeout: _MockClient(),
+    )
+
+    fake_settings = MagicMock()
+    fake_settings.knowledge_retrieve_url = "http://retrieval-api:8040"
+    fake_settings.retrieval_api_internal_secret = "secret"
+    fake_settings.internal_secret = "fallback"
+
+    await retrieve_context(
+        org_id=42,
+        zitadel_org_id="z-1",
+        kb_slugs=[],
+        messages=[{"role": "user", "content": "hello"}],
+        settings=fake_settings,
+        partner_user_id="partner:key-abc-123",
+    )
+
+    assert captured["body"]["user_id"] == "partner:key-abc-123", (
+        "partner_user_id MUST flow through to retrieve body or knowledge.queried events drop. F2 audit ref."
+    )
+
+
+@pytest.mark.asyncio
+async def test_retrieve_context_omits_user_id_when_partner_user_id_none(monkeypatch):
+    """Backwards-compat: existing callers without partner_user_id parameter
+    MUST NOT have a user_id field in the body. Existing /retrieve behaviour
+    relies on this for non-partner internal callers."""
+    from app.services.partner_chat import retrieve_context
+
+    captured: dict = {}
+
+    class _MockResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"chunks": []}
+
+    class _MockClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            return None
+
+        async def post(self, url, json=None, headers=None):
+            captured["body"] = json
+            return _MockResp()
+
+    monkeypatch.setattr(
+        "app.services.partner_chat.httpx.AsyncClient",
+        lambda timeout: _MockClient(),
+    )
+
+    fake_settings = MagicMock()
+    fake_settings.knowledge_retrieve_url = "http://retrieval-api:8040"
+    fake_settings.retrieval_api_internal_secret = "s"
+    fake_settings.internal_secret = "s"
+
+    await retrieve_context(
+        org_id=42,
+        zitadel_org_id="z-1",
+        kb_slugs=[],
+        messages=[{"role": "user", "content": "hello"}],
+        settings=fake_settings,
+        # Note: no partner_user_id
+    )
+
+    assert "user_id" not in captured["body"], (
+        f"user_id leaked into body without explicit partner_user_id: {captured['body']}"
+    )

--- a/klai-retrieval-api/retrieval_api/middleware/auth.py
+++ b/klai-retrieval-api/retrieval_api/middleware/auth.py
@@ -543,6 +543,37 @@ async def verify_body_identity(
             detail={"error": "unknown_caller_service"},
         )
 
+    # F2 from retrieval coupling audit (2026-05-06): partner-API operates at
+    # org-level only — SPEC-API-001 explicitly states partners "have no
+    # concept of end users". The synthetic `partner:<key_id>` user_id used
+    # by partner_chat is NOT a real Zitadel user; portal-api
+    # /internal/identity/verify would 403 on it because the (user_id, org_id)
+    # tuple does not exist in portal_users.
+    #
+    # The partner key has already been validated by portal-api's
+    # get_partner_key dependency upstream — by the time this request reaches
+    # retrieval-api, portal-api has confirmed the bearer is a valid partner
+    # key for this org. The X-Internal-Secret + X-Caller-Service: portal-api
+    # combination is therefore a sufficient trust gate for this synthetic
+    # identity to flow through. Pin it directly so retrieval-api's
+    # emit_event sources the right tenant tag in product_events.
+    #
+    # Restricted to caller_service == "portal-api": no other service is
+    # supposed to manage partner keys, and the prefix bypass is the only
+    # path that skips the portal verify call. Audit ref:
+    # .moai/audits/retrieval-coupling-2026-05-06/findings/F2-...md
+    if caller_service == "portal-api" and str(body_user_id).startswith("partner:"):
+        logger.info(
+            "partner_synthetic_identity_pinned",
+            caller_service=caller_service,
+            partner_user_hash=_hash_sub(str(body_user_id)),
+            path=request.url.path,
+        )
+        request.state.verified_caller = VerifiedCaller(
+            user_id=str(body_user_id), org_id=str(body_org_id)
+        )
+        return
+
     asserter = _get_asserter()
     result = await asserter.verify(
         caller_service=caller_service,

--- a/klai-retrieval-api/tests/test_identity_assert.py
+++ b/klai-retrieval-api/tests/test_identity_assert.py
@@ -351,3 +351,112 @@ class TestJwtPathStillRejectsBodyMismatch:
             )
         assert resp.status_code == 403
         assert resp.json()["detail"] == {"error": "org_mismatch"}
+
+
+# ---------------------------------------------------------------------------
+# F2 (audit retrieval-coupling-2026-05-06): partner_chat sends synthetic
+# `partner:<key_id>` user_id. retrieval-api MUST recognize the prefix,
+# pin verified_caller without portal verify, and emit knowledge.queried.
+# ---------------------------------------------------------------------------
+
+
+class TestPartnerSyntheticIdentity:
+    def test_partner_user_id_pins_verified_caller_without_portal_verify(
+        self, monkeypatch, app_client
+    ):
+        """partner_chat sends `user_id="partner:<key_id>"` — retrieval-api
+        SHALL pin the synthetic tuple as verified_caller without calling
+        portal /internal/identity/verify (which would 403 — there's no real
+        Zitadel user with that synthetic id)."""
+        verify_called: list = []
+
+        class _PortalShouldNotBeCalled:
+            async def verify(self, **_kw):
+                verify_called.append(_kw)
+                raise AssertionError(
+                    "portal verify must NOT be called for partner: prefix; "
+                    "the partner key was already validated upstream."
+                )
+
+        monkeypatch.setattr(
+            "retrieval_api.middleware.auth._get_asserter",
+            lambda: _PortalShouldNotBeCalled(),
+        )
+
+        emit_calls: list[dict] = []
+        monkeypatch.setattr(
+            "retrieval_api.api.retrieve.emit_event",
+            lambda *a, **kw: emit_calls.append({"args": a, "kwargs": kw}),
+        )
+
+        with (
+            _patch_retrieval_pipeline_to_bypass()[0],
+            _patch_retrieval_pipeline_to_bypass()[1],
+            _patch_retrieval_pipeline_to_bypass()[2],
+            _patch_retrieval_pipeline_to_bypass()[3],
+        ):
+            resp = app_client.post(
+                "/retrieve",
+                json={
+                    "query": "q",
+                    "org_id": "tenant-acme",
+                    "user_id": "partner:abc-123",
+                    "scope": "org",
+                },
+                headers={
+                    "X-Internal-Secret": "test-internal-secret-do-not-use-in-prod",
+                    "X-Caller-Service": "portal-api",
+                },
+            )
+
+        assert resp.status_code == 200, resp.text
+        assert verify_called == [], (
+            "portal /internal/identity/verify MUST NOT be called for partner: prefix"
+        )
+        # emit_event was called for knowledge.queried with the synthetic tuple.
+        assert any(
+            "knowledge.queried" in (call["args"] + tuple(call["kwargs"].values()))
+            and call["kwargs"].get("tenant_id") == "tenant-acme"
+            and call["kwargs"].get("user_id") == "partner:abc-123"
+            for call in emit_calls
+        ), f"knowledge.queried event missing or wrong tuple: {emit_calls}"
+
+    def test_partner_prefix_only_for_portal_api_caller_service(self, monkeypatch, app_client):
+        """The partner: prefix bypass is GATED on caller_service == "portal-api".
+        Other services with `partner:` user_id MUST go through the portal
+        verify path (and reject, since no real user has that id)."""
+        from klai_identity_assert import VerifyResult
+
+        class _DenyAsserter:
+            async def verify(self, **_kw):
+                return VerifyResult.deny(reason="user_not_in_org")
+
+        monkeypatch.setattr(
+            "retrieval_api.middleware.auth._get_asserter",
+            lambda: _DenyAsserter(),
+        )
+
+        with (
+            _patch_retrieval_pipeline_to_bypass()[0],
+            _patch_retrieval_pipeline_to_bypass()[1],
+            _patch_retrieval_pipeline_to_bypass()[2],
+            _patch_retrieval_pipeline_to_bypass()[3],
+        ):
+            resp = app_client.post(
+                "/retrieve",
+                json={
+                    "query": "q",
+                    "org_id": "tenant-acme",
+                    "user_id": "partner:abc-123",
+                    "scope": "org",
+                },
+                headers={
+                    "X-Internal-Secret": "test-internal-secret-do-not-use-in-prod",
+                    # Different caller — bypass MUST NOT apply.
+                    "X-Caller-Service": "knowledge-mcp",
+                },
+            )
+
+        # Falls through to portal verify, which denies, → 403.
+        assert resp.status_code == 403
+        assert resp.json()["detail"] == {"error": "identity_assertion_failed"}


### PR DESCRIPTION
## Summary

F2 from the [retrieval coupling audit](https://github.com/GetKlai/klai/pull/386). Closes the latent telemetry gap whereby partner /retrieve calls do not produce `knowledge.queried` product_events.

Currently dormant (0 partner keys on prod), but ships before first integration so admin dashboards do not silently miss partner-traffic from day one.

## Why this is needed

`partner_chat.retrieve_context` sends `/retrieve` calls without a `user_id` in the body. retrieval-api's `verify_body_identity` (auth.py:514-523) treats body-user_id-None as "no identity claim", returns early without pinning `verified_caller`. retrieve.py:411-433 then emits `product_event_skipped_no_identity` warning instead of `knowledge.queried`. The "should be unreachable" branch annotated in the comment is in fact reachable for partner traffic.

## How

| Layer | Change |
|---|---|
| `partner_chat.retrieve_context` | New keyword-only `partner_user_id` param, attached to body as `user_id` when given. |
| `partner.py:185` (chat completions) | Passes `partner_user_id=f"partner:{auth.key_id}"`, matching the existing `partner:` convention used at line ~205 for `write_retrieval_log`. |
| `retrieval-api auth.py:514` | New gated bypass: `caller_service == "portal-api"` AND `body_user_id startswith "partner:"` → pin `verified_caller` directly from the body. Skips portal `/internal/identity/verify` (which would 403 on a synthetic identity that doesn't exist in `portal_users`). |

The bypass is restricted to a single caller_service (`portal-api`) — no other service is supposed to manage partner keys, so the synthetic identity has only one legitimate origin.

## Tests

retrieval-api (`tests/test_identity_assert.py`):
- `TestPartnerSyntheticIdentity::test_partner_user_id_pins_verified_caller_without_portal_verify` — portal verify MUST NOT be called; knowledge.queried emitted with the synthetic tuple.
- `TestPartnerSyntheticIdentity::test_partner_prefix_only_for_portal_api_caller_service` — falsification: same body shape with a different caller_service falls through to portal verify (and 403s in this test).

portal-api (`tests/test_partner_chat.py`):
- `test_retrieve_context_passes_partner_user_id` — body carries `user_id="partner:..."` when partner_user_id is given.
- `test_retrieve_context_omits_user_id_when_partner_user_id_none` — backwards-compat: body identical to legacy shape when partner_user_id is None.

All existing tests pass: 15/15 portal-api, 10/10 retrieval-api identity tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)