### PR TITLE
docs(audit-ti): SPEC-TI-002/006-007/010A/010B follow-up SPECs

### DIFF
--- a/.moai/specs/SPEC-TI-002-FOLLOWUP-001/spec.md
+++ b/.moai/specs/SPEC-TI-002-FOLLOWUP-001/spec.md
@@ -1,0 +1,105 @@
+# SPEC-TI-002-FOLLOWUP-001 — Fix connector sync_engine + scheduler RLS wiring
+
+**Predecessor:** `SPEC-TI-002-RLS-CONNECTOR` (PR #375, merged 2026-05-06)
+**Adversarial audit:** PR #381 (`feature/SPEC-TI-010B-REDIS`, closed) — wiring gap found in connector background paths.
+**Pitfall:** `asyncpg-pool-guc-not-shared` (HIGH) — same class, SQLAlchemy variant: a fresh session from `session_maker()` has no `app.current_org_id` GUC.
+**Priority:** MEDIUM (latent on prod — `klai` superuser bypasses RLS today; activates the moment SPEC-TI-011 lands per-service roles)
+**Status:** Ready
+
+## Goal
+
+Close the wiring gap left by SPEC-TI-002 in two connector background
+modules. `sync_engine.py` and `scheduler.py` currently open SQLAlchemy
+sessions via raw `async with self._session_maker() as session` blocks
+that never go through `set_tenant`, `tenant_scoped_session`, or
+`cross_org_session`. After SPEC-TI-002's `FORCE ROW LEVEL SECURITY` is
+applied AND SPEC-TI-011 migrates klai-connector off the superuser DSN,
+every background sync raises 42501. The reference correct pattern
+already lives in `app/services/sync_run_reaper.py` and
+`app/services/sync_run_resolver.py` — replicate it on the five
+remaining sites.
+
+## Acceptance criteria
+
+- **AC-1** Every `async with self._session_maker() as session` in
+  `klai-connector/app/services/sync_engine.py` is replaced with
+  either `tenant_scoped_session(org_id)` (when org is known) or
+  `cross_org_session()` (when the path deliberately spans orgs). Each
+  replacement carries an inline comment documenting the choice.
+
+- **AC-2** Every `async with session_maker() as session` /
+  `async with db_session_maker() as session` in
+  `klai-connector/app/services/scheduler.py` is replaced with the
+  same helpers. The `start()` sweep over all connectors uses
+  `cross_org_session()` (deliberate cross-org); `_trigger_sync` first
+  resolves `Connector.org_id` and then opens
+  `tenant_scoped_session(org_id)` for the `SyncRun` INSERT.
+
+- **AC-3** `_execute_sync` (sync_engine.py:196) uses
+  `tenant_scoped_session(portal_config.zitadel_org_id)`. The web
+  crawler delegation branch (line 538) does the same.
+
+- **AC-4** `_fail_sync_run` (sync_engine.py:725) is updated to either
+  (a) accept `org_id` from its callers and use
+  `tenant_scoped_session(org_id)`, OR (b) use `cross_org_session()`
+  with a docstring explaining why a failed-run UPDATE may be applied
+  cross-org (typical: failure path may run when portal_config lookup
+  itself failed). Whichever option is chosen MUST be documented at the
+  call site.
+
+- **AC-5** A new regression test
+  `klai-connector/tests/services/test_rls_wiring.py` mocks
+  `session_maker()` to return a session whose underlying connection
+  raises `InsufficientPrivilegeError` unless
+  `app.current_org_id` is set on it. The test exercises every
+  sync_engine + scheduler entry point that issues DML and asserts no
+  42501 escapes.
+
+- **AC-6** Existing `tests/services/test_sync_engine_*.py` are extended
+  to assert the GUC is set BEFORE any DML on `connector.sync_runs` /
+  `connector.connectors` runs. Existing green tests stay green.
+
+- **AC-7** This SPEC depends on SPEC-TI-011 (per-service DB roles)
+  landing before the wiring fix can be VERIFIED on prod. Until then,
+  klai-superuser bypasses RLS and there is no observable failure to
+  alert on.
+
+## Background
+
+Audit on origin/main found five offending call sites — all in the
+connector's background sync path:
+
+| File | Line | Function | Action |
+|---|---|---|---|
+| `app/services/sync_engine.py` | 196 | `_execute_sync` (`session.get(SyncRun, …)`) | `tenant_scoped_session(portal_config.zitadel_org_id)` |
+| `app/services/sync_engine.py` | 538 | web crawler delegation path | `tenant_scoped_session(portal_config.zitadel_org_id)` |
+| `app/services/sync_engine.py` | 725 | `_fail_sync_run` (UPDATE SyncRun) | `cross_org_session()` OR plumb org_id (AC-4) |
+| `app/services/scheduler.py` | 45 | `start()` (SELECT all connectors) | `cross_org_session()` (deliberate cross-org sweep) |
+| `app/services/scheduler.py` | 104 | `_trigger_sync` (INSERT SyncRun) | resolve org → `tenant_scoped_session(org_id)` |
+
+The reference pattern already exists in this service:
+`app/services/sync_run_reaper.py` and
+`app/services/sync_run_resolver.py` use `cross_org_session()` and
+`tenant_scoped_session()` correctly.
+
+## Operator step (after merge + SPEC-TI-011)
+
+```bash
+# After SPEC-TI-011 migrates klai-connector to a non-superuser role,
+# tail VictoriaLogs for one full sync cycle and verify zero 42501s:
+#   service:klai-connector AND (level:error OR error_code:42501)
+```
+
+No DDL, no migration. Pure code refactor; revert is `git revert <sha>`.
+
+## Out of scope
+
+- Refactoring SQLAlchemy models or renaming `session_maker`.
+- Knowledge-ingest pg_store wiring — separate SPEC:
+  `SPEC-TI-003-FOLLOWUP-001`.
+- Scribe `app/core/database.py` helper infra — separate SPEC:
+  `SPEC-TI-010A-FOLLOWUP-001`.
+- Migrating services off the `klai` superuser DSN — separate SPEC:
+  `SPEC-TI-011-PER-SERVICE-DB-ROLES`.
+- The B-2 / B-5 / B-9 / B-10 Redis fixes from PR #381 — separate SPEC:
+  `SPEC-TI-010B-FOLLOWUP-001`.

--- a/.moai/specs/SPEC-TI-006-007-FOLLOWUP-001/spec.md
+++ b/.moai/specs/SPEC-TI-006-007-FOLLOWUP-001/spec.md
@@ -1,0 +1,149 @@
+# SPEC-TI-006-007-FOLLOWUP-001 — Close webhook-replay wiring + ownership gaps
+
+**Predecessor:** PR #380 (closed, branch `feature/SPEC-TI-006-007-WEBHOOK-REPLAY-GITEA`).
+SPEC-TI-006 (Moneybird/Vexa/Gitea webhook replay-protection) and SPEC-TI-007
+(Gitea webhook hardening) stayed unmerged because adversarial audit on PR #380
+surfaced four BLOCKER findings + one LOW.
+**Pitfalls:** `fail-open-auth` (HIGH), `empty-secret-fail-open` (HIGH),
+`alembic-cannot-drop-non-portal_api-tables` (HIGH),
+`validator-env-parity` (HIGH).
+**Priority:** HIGH — without these fixes, Gitea webhooks 503 the moment
+SPEC-TI-006/007 land (Redis network unreachable) and the Gitea
+replay-check is bypassable by simply omitting one header.
+**Status:** Ready
+
+## Goal
+
+Close the four wiring/ownership/fail-open bugs PR #380's audit found, plus one
+consistency gap on portal-api config validation, so SPEC-TI-006 and SPEC-TI-007
+can be re-opened and actually deliver replay-protection on
+Gitea/Moneybird/Vexa webhooks. All five fixes are mechanical: compose-network
+membership, header REQUIRED guard, migration-ownership step, fail-loud DB
+exception class, and a `_require_*` field validator.
+
+## Acceptance criteria
+
+- **AC-1** `deploy/docker-compose.yml`: knowledge-ingest joins
+  `net-redis` and adds `depends_on: redis` (alongside its existing
+  `depends_on: postgres`). Mirror the retrieval-api pattern at
+  lines ~820-823. Without this, `REDIS_URL` resolves to a hostname
+  unreachable on knowledge-ingest's networks (`net-redis` is
+  `internal: true`) and every Gitea webhook 503s on the first
+  nonce-store call.
+
+- **AC-2** Gitea handler in `klai-knowledge-ingest/knowledge_ingest/routes/ingest.py`
+  REQUIRES the `X-Gitea-Delivery` header. A request without it (or
+  with a whitespace-only value) returns **400 Bad Request** with
+  body `{"detail": "missing X-Gitea-Delivery header"}`. The current
+  `if delivery_id:` short-circuit (lines 656-657) is removed —
+  replay check ALWAYS runs against `delivery_id`, never silently
+  skipped. Class: `fail-open-auth`.
+
+- **AC-3** The existing test `test_missing_delivery_id_skips_replay_check`
+  is renamed to `test_missing_delivery_id_returns_400` and inverted:
+  it asserts 400, not 200. The previous test locked in the bug as
+  "desired behavior" — leaving it would re-introduce the gap.
+  Add a sibling `test_empty_delivery_id_returns_400` covering the
+  whitespace-only header case (`X-Gitea-Delivery: "   "`).
+
+- **AC-4** Migration `0002_gitea_repo_to_org.py` adds
+  `op.execute("ALTER TABLE knowledge.gitea_repo_to_org OWNER TO klai;")`
+  immediately after the `op.create_table(...)` call. Without this,
+  the alembic role becomes the table owner and the post-deploy SQL
+  `post_deploy_0002_gitea_repo_to_org.sql` fails with
+  `InsufficientPrivilegeError: must be owner of table` on the
+  `ENABLE ROW LEVEL SECURITY` step. Same recovery class as the
+  `alembic-cannot-drop-non-portal_api-tables` pitfall.
+
+- **AC-5** `_get_org_id_from_db` in `routes/ingest.py:843-855`
+  distinguishes "repo not found" from "DB error":
+  - `asyncpg.exceptions.UndefinedTableError` → re-raise as a new
+    `ConfigurationError` (HTTP 500 + structured log
+    `gitea_org_lookup_table_missing` at ERROR level).
+  - Empty result row → return `None` (caller maps to 200
+    `{"status": "ignored"}` as today).
+  - Any other `Exception` → re-raise as `ConfigurationError`
+    (HTTP 500 + ERROR log).
+
+  The current bare `except Exception: return None` collapses missing
+  table, broken pool, RLS denial, and "unknown repo" into one
+  silent `200 ignored`. Class: `fail-open-auth`.
+
+- **AC-6** `klai-portal/backend/app/core/config.py:184` (`redis_url`)
+  gets a `_require_redis_url` field-validator matching the
+  `_require_moneybird_webhook_token` style. Empty / whitespace-only
+  / missing → `ValidationError` at Settings load (BEFORE FastAPI
+  lifespan, so misconfigured deploys fail-fast instead of returning
+  503 on first webhook). Test in `tests/test_redis_url_validator.py`
+  covers reject (empty, whitespace) and accept cases. Class:
+  `validator-env-parity`.
+
+- **AC-7** A CI smoke-test (added to the `knowledge-ingest.yml`
+  workflow, or an integration test in `klai-knowledge-ingest/tests/`)
+  verifies that knowledge-ingest, started with deploy-compose.yml
+  network membership applied, can `redis.ping()` against the
+  `net-redis`-attached redis service. Closes the gap that AC-1 alone
+  could regress on a future compose edit.
+
+## Background
+
+PR #380 wired `klai-libs/webhook-replay` correctly on portal-api
+(Moneybird, Vexa) but the audit found three classes of bug on
+knowledge-ingest (Gitea):
+
+1. **Network isolation** (AC-1): `net-redis` has `internal: true`.
+   Services not on the network cannot resolve the hostname through
+   Docker's embedded DNS. Connection refused, webhook 503s.
+2. **Header fail-open** (AC-2/3): Moneybird/Vexa nonce parts come
+   from payload fields (`event_id`, `vexa_meeting_id`, `timestamp`)
+   that are always present. Gitea uses a HEADER an attacker
+   controls. Empty header silently bypassed replay-protection,
+   leaving HMAC as the only defense. The test that locked this in
+   was itself the bug.
+3. **DB-error fail-open** (AC-5): `_get_org_id_from_db` swallowed
+   any exception as "unknown repo → 200 ignored". Combined with
+   AC-4's failure mode, a deploy could appear green while no Gitea
+   event ever landed.
+
+AC-4 prevents the migration-ownership trap: post-deploy SQL ships
+`ENABLE RLS`, which requires table-owner privileges, but the alembic
+role is not `klai`. AC-6 is consistency hygiene: every other
+auth-relevant field in `config.py` already has a `_require_*`
+validator; `redis_url` was the gap.
+
+## Operator step (after merge)
+
+No manual step beyond standard deploy. Post-merge verification:
+
+```bash
+# AC-1 — knowledge-ingest can reach redis
+ssh core-01 "docker exec klai-core-knowledge-ingest-1 \
+  python -c 'import redis,os; redis.from_url(os.environ[\"REDIS_URL\"]).ping()'"
+
+# AC-4 — table owner is klai
+ssh core-01 "docker exec klai-core-postgres-1 \
+  psql -U klai -d klai -c \"SELECT tableowner FROM pg_tables \
+  WHERE tablename='gitea_repo_to_org';\""
+# Expect: klai
+
+# AC-2 — empty header rejected
+curl -X POST https://api.getklai.com/webhooks/gitea -d '{}' -i
+# Expect: HTTP/1.1 400 Bad Request
+```
+
+## Out of scope
+
+- Re-implementing SPEC-TI-006 / SPEC-TI-007 in full. This SPEC closes
+  the four BLOCKER + one LOW from PR #380; the predecessor SPECs are
+  re-opened on a fresh branch that includes these fixes.
+- Moneybird/Vexa flows on portal-api — already wired correctly on
+  PR #380 (portal-api is on `net-redis`). Only AC-6 touches
+  portal-api.
+- Lifecycle hook for nonce store init at startup — covered indirectly
+  if AC-7 passes.
+- Migrating knowledge-ingest off the `klai` superuser DSN —
+  `SPEC-TI-011-PER-SERVICE-DB-ROLES`. AC-4 works regardless of which
+  non-superuser role runs alembic, because the explicit `OWNER TO
+  klai` step runs while the migration is still executing as the
+  alembic role and Postgres allows ownership transfers FROM the
+  current owner.

--- a/.moai/specs/SPEC-TI-010A-FOLLOWUP-001/spec.md
+++ b/.moai/specs/SPEC-TI-010A-FOLLOWUP-001/spec.md
@@ -1,0 +1,112 @@
+# SPEC-TI-010A-FOLLOWUP-001 — scribe-api RLS infrastructure + transcribe.py cross-org leak
+
+**Predecessor:** PR #382 (closed, branch `feature/SPEC-TI-010A-MARKERS-SCRIBE`); SPEC-TI-010A unmerged
+**Pitfalls:** `rls-policy-shape-must-match-lifespan-assert` (HIGH), `asyncpg-pool-guc-not-shared` (HIGH), `multi-layer-gate-audit-all-sides` (HIGH)
+**Priority:** HIGH
+**Status:** Ready
+
+## Goal
+
+Make scribe-api safe to enable RLS on. Today `klai-scribe/scribe-api/app/core/database.py` is 13 lines — `create_async_engine` + `AsyncSessionLocal`, nothing else. There is no `set_tenant`, no `tenant_scoped_session`, no `cross_org_session`, no `_pin_and_reset_connection`. The original SPEC-TI-010A tried to add `org_id` + RLS policies to `scribe.transcriptions` without first landing this infrastructure, which would have produced a worst-of-both outcome: every INSERT blocked by the WITH CHECK clause (no GUC set → policy false), and every SELECT leaking cross-org via the policy's `USING (... IS NULL)` fail-open branch. Audit also caught a missing `org_id` filter in the KB-ingest endpoint that lets a multi-org Zitadel user pull another tenant's transcript into their own KB.
+
+## Acceptance criteria
+
+- **AC-1** `klai-scribe/scribe-api/app/core/database.py` exposes `set_tenant(db, org_id)`,
+  `tenant_scoped_session(org_id)`, `cross_org_session()`, and `_pin_and_reset_connection`,
+  copied verbatim from `klai-connector/app/core/database.py` and adapted for the scribe
+  schema (GUC names, schema search_path). The full GUC lifecycle (set on entry, reset
+  on exit, reset-on-pool-return) is preserved.
+
+- **AC-2** Every authenticated scribe endpoint calls `set_tenant(db, caller.org_id)`
+  immediately after auth resolution and BEFORE any query against `scribe.transcriptions`.
+  Endpoints in scope: `POST /v1/transcribe`, `POST /v1/transcriptions/{id}/retry`,
+  `POST /v1/transcriptions/{id}/ingest`, `GET /v1/transcriptions`,
+  `GET /v1/transcriptions/{id}`, `PATCH /v1/transcriptions/{id}`,
+  `DELETE /v1/transcriptions/{id}`.
+
+- **AC-3** `ingest_transcription_to_kb` in `app/api/transcribe.py` adds
+  `Transcription.org_id == caller.org_id` to the SELECT WHERE clause alongside the
+  existing `user_id` filter. Regression test seeds two rows with the SAME `user_id`
+  but different `org_id` against a real Postgres fixture and asserts that the ingest
+  call from `org_a`'s context returns/processes only `org_a`'s row. Mocked-DB tests
+  do NOT satisfy this AC — the existing `test_ingest_cross_org_denied` mocks `None`
+  and so misses the leak in production.
+
+- **AC-4** `app/services/reaper.py` switches from bare `AsyncSessionLocal()` to
+  `cross_org_session()` and the docstring explicitly states the cross-org-by-design
+  rationale. The reaper no longer relies on the policy's `USING IS NULL` branch as
+  its safety net.
+
+- **AC-5** New post-deploy SQL `post_deploy_<rev>_scribe_transcriptions_rls.sql`
+  is idempotent (`DROP POLICY IF EXISTS` then `CREATE POLICY`) and applies the
+  Cat-D strict shape on `scribe.transcriptions`: `USING (org_id = _rls_current_org_id())`
+  and `WITH CHECK (org_id = _rls_current_org_id())`. No `IS NULL` fallback in either
+  clause — every authenticated caller has an `org_id`, and the reaper now uses
+  `cross_org_session()` (AC-4). See pitfall `rls-policy-shape-must-match-lifespan-assert`.
+
+- **AC-6** Integration test against a real Postgres fixture asserts: (a) INSERT into
+  `scribe.transcriptions` with no GUC set raises a policy violation, (b) INSERT with
+  GUC set to a matching `org_id` succeeds, (c) SELECT with no GUC set returns 0 rows,
+  (d) SELECT with GUC set to `org_a` returns only `org_a`'s rows when the table holds
+  rows for `org_a` and `org_b`. All four cases must pass.
+
+- **AC-7** Regression test for `klai-portal/backend/app/api/internal_connectors.py`
+  asserts that `set_tenant(db, connector.org_id)` is called on the session BEFORE the
+  subsequent DELETE statement. The C-5 cross-org-by-design pattern (initial SELECT
+  spans all orgs to find the connector, then pin to its org for the delete) is
+  preserved; the test locks it in.
+
+- **AC-8** Depends on SPEC-TI-011-PER-SERVICE-DB-ROLES providing the `scribe_api`
+  non-superuser role. RLS does not fire while scribe-api connects as `klai`
+  (superuser bypasses RLS). Operator step below MUST run AFTER SPEC-TI-011 has
+  migrated scribe-api to its dedicated role.
+
+## Background
+
+The PR #382 audit caught a worst-of-both failure mode that would have shipped if the
+post-deploy SQL had been applied without the helper infrastructure:
+
+```sql
+-- The proposed policy from PR #382:
+USING (org_id = NULLIF(current_setting('app.current_org', true), '')::int
+       OR current_setting('app.current_org', true) = '')
+WITH CHECK (org_id = NULLIF(current_setting('app.current_org', true), '')::int);
+```
+
+With no `set_tenant` call ever happening, every connection sees `app.current_org = ''`:
+- INSERT path: `WITH CHECK` evaluates `org_id = NULL`, which is `NULL` (falsy) → policy
+  rejection on every write. Scribe-api stops accepting transcriptions.
+- SELECT path: `USING` evaluates the second branch (`'' = ''` → true) → all rows visible
+  to every connection regardless of caller. Cross-org leak on every read.
+
+Writes blocked, reads leak. The fix is to land the helper infrastructure FIRST so
+every authenticated query has a real GUC value, then apply a Cat-D strict policy with
+no `IS NULL` escape hatch.
+
+The transcribe.py leak is independent: a Zitadel user with memberships in `org_a` and
+`org_b` (same `user_id` across both) can call `POST /v1/transcriptions/{id}/ingest`
+from `org_a`'s portal session against `org_b`'s transcription ID. The current SELECT
+filters only on `user_id`, so the row is returned and ingested into `org_a`'s KB.
+All other transcribe.py endpoints already use the dual `user_id + org_id` filter —
+ingest is the lone exception.
+
+## Operator step (after merge + SPEC-TI-011)
+
+```bash
+ssh core-01 "docker exec -i klai-core-postgres-1 psql -U klai -d klai" \
+    < klai-scribe/scribe-api/alembic/versions/post_deploy_<rev>_scribe_transcriptions_rls.sql
+```
+
+Verify zero policy-violation errors and zero cross-org SELECT anomalies in
+VictoriaLogs over the next hour:
+- `service:scribe-api AND message:"new row violates row-level security"`
+- `service:scribe-api AND level:error AND message:"transcriptions"`
+
+## Out of scope
+
+- Refactor of scribe-api to SQLAlchemy 2.x style or asyncpg-direct patterns.
+- Whisper-server, scribe ingest workers, or any scribe component beyond scribe-api.
+- Migration of `scribe.transcriptions` to a different schema or table layout.
+- Migrating scribe-api off the `klai` superuser DSN — separate SPEC: `SPEC-TI-011-PER-SERVICE-DB-ROLES`.
+- Audit of other scribe schemas (`scribe.jobs`, etc.) for the same class of bug —
+  separate SPEC if those tables hold tenant data.

--- a/.moai/specs/SPEC-TI-010B-FOLLOWUP-001/spec.md
+++ b/.moai/specs/SPEC-TI-010B-FOLLOWUP-001/spec.md
@@ -1,0 +1,119 @@
+# SPEC-TI-010B-FOLLOWUP-001 — Redis tenant-key namespace consistency
+
+**Predecessor:** PR #381 (closed, branch `feature/SPEC-TI-010B-REDIS`) — adversarial audit
+**Priority:** HIGH (GDPR-relevant — retrieval-log query content survives deprovisioning)
+**Status:** Ready
+
+## Goal
+
+Pick ONE namespace convention for tenant-scoped Redis keys and apply it
+consistently across writers and the deprovisioning sweep. Today the
+writer for `rl:` (retrieval-log) and `templates_rl:` (rate-limit) uses
+`PortalOrg.id` (int PK), while `deprovisioning_steps.py` SCANs/DELs
+using `state.zitadel_org_id` (string Zitadel resourceowner). The
+namespaces never overlap, so deprovisioning never deletes the actual
+keys. Retrieval-log entries — containing `chunk_ids`,
+`query_resolved`, and `reranker_scores` for a deleted tenant — survive
+in Redis until their TTL expires (0–60 minutes).
+
+The chosen convention is `zitadel_org_id` (string), matching the
+already-consistent `templates:`, `kb_ver:`, and `kb_feature:` keys and
+LiteLLM's metadata. This is also resilient to `PortalOrg.id` reuse if
+an org is ever recreated with the same int PK.
+
+## Acceptance criteria
+
+- **AC-1** `klai-portal/backend/app/services/retrieval_log.py:46`
+  writes keys as `f"rl:{zitadel_org_id}:{user_id}"`. The writer
+  function signature accepts `zitadel_org_id: str` (not `org_id: int`).
+  All callers are updated to pass the Zitadel resourceowner.
+
+- **AC-2** `klai-portal/backend/app/api/app_templates.py:110` calls
+  `check_rate_limit(pool, f"templates_rl:{org.zitadel_org_id}", ...)`
+  using the string Zitadel resourceowner.
+
+- **AC-3** `klai-portal/backend/app/services/provisioning/deprovisioning_steps.py:222,227`
+  patterns (`f"rl:{zid}:*"`, `f"templates_rl:{zid}"`) are unchanged —
+  these were always correct against `state.zitadel_org_id`. The fix
+  is on the writer side.
+
+- **AC-4** A regression test in
+  `klai-portal/backend/tests/test_retrieval_log_keying.py` asserts:
+  - `retrieval_log` writer SETs a key matching
+    `rl:<zitadel_org_id>:<user_id>` against a fakeredis or real Redis
+    fixture.
+  - `app_templates` rate-limit writer SETs a key matching
+    `templates_rl:<zitadel_org_id>`.
+  - Neither writer produces a key prefixed with the int `org.id`.
+
+- **AC-5** A regression test in
+  `klai-portal/backend/tests/test_deprovisioning_redis_sweep.py`:
+  - Seeds synthetic keys `rl:362757920133283846:user-x` and
+    `templates_rl:362757920133283846`.
+  - Invokes the deprovisioning Redis-sweep step with
+    `state.zitadel_org_id = "362757920133283846"`.
+  - Asserts both keys are deleted post-sweep.
+
+- **AC-6** `_invalidate_litellm_kb_cache` in
+  `klai-portal/backend/app/api/app_account.py:41-47` is refactored to
+  use `get_redis_pool()` instead of constructing a bespoke
+  `aioredis.Redis(host=..., port=..., password=...)` instance. Lower
+  priority — ship in a separate commit if it complicates AC-1..AC-5.
+
+## Background
+
+Writer (today, wrong):
+
+```python
+# retrieval_log.py:46
+key = f"rl:{org_id}:{user_id}"          # org_id: int, PortalOrg.id PK
+
+# app_templates.py:110
+check_rate_limit(pool, f"templates_rl:{org_id}", ...)  # org.id (int)
+```
+
+Deprovisioning (today, correct shape but never matches):
+
+```python
+# deprovisioning_steps.py:222,227
+f"rl:{zid}:*"                            # zid = state.zitadel_org_id (str)
+f"templates_rl:{zid}"
+```
+
+Because `org.id` (e.g. `42`) and `zitadel_org_id` (e.g.
+`"362757920133283846"`) are different namespaces, the deprovisioning
+SCAN never matches the writer's keys. Retrieval-log entries persist
+until their per-key TTL elapses; rate-limit keys auto-expire in ~1
+minute and are less critical, but the same audit gap evidences the
+B-10 audit pass was incomplete.
+
+The `templates:`, `kb_ver:`, and `kb_feature:` keys already use
+`zitadel_org_id` consistently across writer and consumer paths, so
+aligning `rl:` and `templates_rl:` on the same convention is the
+lower-risk choice and matches LiteLLM's metadata.
+
+## Operator step (after merge)
+
+No SQL or out-of-band action. Ship the code change, deploy
+portal-api, then monitor:
+
+```
+service:portal-api AND message:"retrieval_log" AND level:error
+service:portal-api AND message:"deprovisioning" AND level:error
+```
+
+Existing `rl:<int>:*` keys in Redis from the pre-fix writer will
+expire on their own TTL (max 60 minutes) and will not be touched by
+the new sweep. Operator may optionally purge them with a one-shot
+`SCAN 0 MATCH 'rl:*'` filtered to numeric-only first segment, but
+this is not required.
+
+## Out of scope
+
+- Connector wiring bugs in `sync_engine.py` / `scheduler.py` —
+  separate SPEC: `SPEC-TI-002-FOLLOWUP-001`.
+- Redis URL password parsing concerns — already covered by the
+  `redis-url-password-must-be-parsed-manually` pitfall.
+- Migration of `templates:` / `kb_ver:` / `kb_feature:` keys — these
+  already use `zitadel_org_id` and are correct.
+- TTL changes on retrieval-log entries.


### PR DESCRIPTION
## Wat zit hierin

Vier follow-up SPECs uit de 2026-05-06 audit-respons. Elke SPEC capturet de BLOCKER findings van een gesloten audit-PR zodat het werk niet verloren gaat.

| SPEC | Lines | Adresseert | Predecessor |
|---|---|---|---|
| SPEC-TI-002-FOLLOWUP-001 | 105 | connector `sync_engine` + `scheduler` RLS wiring (5 call sites) | PR #381 audit |
| SPEC-TI-006-007-FOLLOWUP-001 | 149 | webhook-replay: net-redis netwerk, Gitea fail-open, table-ownership, redis_url validator | PR #380 audit |
| SPEC-TI-010A-FOLLOWUP-001 | 112 | scribe-api krijgt set_tenant infra + transcribe.py cross-org leak | PR #382 audit |
| SPEC-TI-010B-FOLLOWUP-001 | 119 | Redis tenant-key namespace consistency (`rl:` + `templates_rl:` writer/deprov mismatch) | PR #381 audit |

Alle 4 SPECs hangen af van **SPEC-TI-011** (per-service DB rollen) voor de RLS-side fixes om écht te firen op prod. Wiring fixes zelf kunnen onafhankelijk landen — vandaag latent door klai-superuser bypass.

## Stijl

Gemodelleerd op SPEC-TI-003-FOLLOWUP-001 (concise, EARS ACs, geen fase-bureaucratie). 105-149 regels per SPEC.

## Doc-only PR

Geen code changes, niets te deployen, geen CI nodig. Reviewer beoordeelt alleen scope + correctheid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)