### PR TITLE
feat(ingest): SPEC-INGEST-UNIQUE-ARTIFACT-001 — partial UNIQUE on active artifacts (#7)

### DIFF
--- a/klai-knowledge-ingest/alembic/versions/0003_artifacts_unique_active_path.py
+++ b/klai-knowledge-ingest/alembic/versions/0003_artifacts_unique_active_path.py
@@ -1,0 +1,50 @@
+"""SPEC-INGEST-UNIQUE-ARTIFACT-001 -- partial UNIQUE index on knowledge.artifacts.
+
+Closes the race window where two concurrent ``ingest_document()`` calls with
+identical ``(org_id, kb_slug, path)`` both pass ``get_active_content_hash``
+(see no active row), both call ``soft_delete_artifact`` (idempotent), and
+both call ``create_artifact`` -- leaving two active rows for the same path.
+
+The active-row predicate is ``belief_time_end = 253402300800`` (the
+``9999-12-31`` sentinel meaning "still current"). Soft-deleted rows have
+``belief_time_end < sentinel`` and are excluded from the unique index, so
+re-ingesting the same path after a soft-delete remains valid.
+
+Pre-flight on prod 2026-05-06: 0 duplicate active rows across all tenants
+(including Voys), so this migration runs without a cleanup pass.
+
+CREATE INDEX CONCURRENTLY cannot run inside a transaction block. Alembic
+wraps every migration in a transaction by default; we commit it before the
+index command and let PostgreSQL handle the rest in auto-commit mode.
+
+Revision ID: 9a3c4d5e6f7b
+Revises: dd1b439a57d0
+Create Date: 2026-05-06
+SPEC: SPEC-INGEST-UNIQUE-ARTIFACT-001
+Audit: 2026-05-06 finding 7
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "9a3c4d5e6f7b"
+down_revision: str | None = "dd1b439a57d0"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Break out of alembic's implicit transaction so CREATE INDEX
+    # CONCURRENTLY is allowed.
+    op.execute("COMMIT")
+    op.execute(
+        "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS uq_artifacts_active_path "
+        "ON knowledge.artifacts (org_id, kb_slug, path) "
+        "WHERE belief_time_end = 253402300800"
+    )
+
+
+def downgrade() -> None:
+    op.execute("COMMIT")
+    op.execute("DROP INDEX CONCURRENTLY IF EXISTS knowledge.uq_artifacts_active_path")

--- a/klai-knowledge-ingest/knowledge_ingest/pg_store.py
+++ b/klai-knowledge-ingest/knowledge_ingest/pg_store.py
@@ -6,9 +6,21 @@ import json
 import time
 import uuid
 
+import asyncpg
+import structlog
+
 from knowledge_ingest.db import get_pool
 
+logger = structlog.get_logger()
+
 _SENTINEL = 253402300800  # 9999-12-31 — sentinel value for "still active"
+
+# SPEC-INGEST-UNIQUE-ARTIFACT-001 — name of the partial unique index
+# created by alembic 0003_artifacts_unique_active_path.py. The
+# UniqueViolationError handler below uses this constraint name to
+# distinguish race-loss from any other unique-violation that might
+# surface in the future.
+_ACTIVE_ARTIFACT_UNIQUE_INDEX = "uq_artifacts_active_path"
 
 
 async def get_active_content_hash(org_id: str, kb_slug: str, path: str) -> str | None:
@@ -46,39 +58,93 @@ async def create_artifact(
     extra: dict | None = None,
     content_hash: str | None = None,
 ) -> str:
-    """Create a knowledge artifact record. Returns the artifact UUID."""
+    """Create a knowledge artifact record. Returns the artifact UUID.
+
+    SPEC-INGEST-UNIQUE-ARTIFACT-001 (audit finding 7): on
+    ``UniqueViolationError`` from the partial unique index
+    ``uq_artifacts_active_path``, this function silently resolves
+    the race by fetching the winning artifact's id and returning it.
+    The race event is logged at error level (fires the existing
+    ``obs-001-ingest-error-rate-elevated`` Grafana alert) so
+    operators always know when this happens. Caller (ingest_document
+    + downstream MCP / connector / scribe) receives a normal return
+    value and a consistent artifact_id.
+    """
     artifact_id = str(uuid.uuid4())
     now = int(time.time())
     pool = await get_pool()
     extra_json = json.dumps(extra) if extra else "{}"
-    await pool.execute(
-        """
-        INSERT INTO knowledge.artifacts
-          (id, org_id, user_id, kb_slug, path,
-           provenance_type, assertion_mode,
-           synthesis_depth, confidence,
-           belief_time_start, belief_time_end,
-           content_type, extra, content_hash,
-           created_at)
-        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
-        """,
-        artifact_id,
-        org_id,
-        user_id,
-        kb_slug,
-        path,
-        provenance_type,
-        assertion_mode,
-        synthesis_depth,
-        confidence,
-        belief_time_start,
-        belief_time_end,
-        content_type,
-        extra_json,
-        content_hash,
-        now,
-    )
-    return artifact_id
+    try:
+        await pool.execute(
+            """
+            INSERT INTO knowledge.artifacts
+              (id, org_id, user_id, kb_slug, path,
+               provenance_type, assertion_mode,
+               synthesis_depth, confidence,
+               belief_time_start, belief_time_end,
+               content_type, extra, content_hash,
+               created_at)
+            VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
+            """,
+            artifact_id,
+            org_id,
+            user_id,
+            kb_slug,
+            path,
+            provenance_type,
+            assertion_mode,
+            synthesis_depth,
+            confidence,
+            belief_time_start,
+            belief_time_end,
+            content_type,
+            extra_json,
+            content_hash,
+            now,
+        )
+        return artifact_id
+    except asyncpg.UniqueViolationError as exc:
+        # Only swallow the violation that originates from our active-path
+        # constraint. Any other unique violation (e.g. id collision —
+        # vanishingly unlikely but possible) is a real bug; re-raise it.
+        constraint_name = getattr(exc, "constraint_name", "") or ""
+        if _ACTIVE_ARTIFACT_UNIQUE_INDEX not in constraint_name:
+            raise
+
+        winning_artifact_id = await pool.fetchval(
+            """
+            SELECT id FROM knowledge.artifacts
+            WHERE org_id = $1 AND kb_slug = $2 AND path = $3
+              AND belief_time_end = $4
+            """,
+            org_id,
+            kb_slug,
+            path,
+            _SENTINEL,
+        )
+        # Defensive: if the winning row vanished between INSERT and SELECT
+        # (e.g. a concurrent soft_delete), surface a clear error rather
+        # than returning None and letting the caller hit a downstream
+        # NULL violation.
+        if winning_artifact_id is None:
+            logger.error(
+                "artifact_create_race_lost_no_winner",
+                org_id=org_id,
+                kb_slug=kb_slug,
+                path=path,
+                my_attempt_id=artifact_id,
+            )
+            raise
+
+        logger.error(
+            "artifact_create_race_lost",
+            org_id=org_id,
+            kb_slug=kb_slug,
+            path=path,
+            winning_artifact_id=str(winning_artifact_id),
+            my_attempt_id=artifact_id,
+        )
+        return str(winning_artifact_id)
 
 
 def _personal_slug(user_id: str) -> str:

--- a/klai-knowledge-ingest/tests/test_artifact_unique_constraint.py
+++ b/klai-knowledge-ingest/tests/test_artifact_unique_constraint.py
@@ -1,0 +1,228 @@
+"""Tests for SPEC-INGEST-UNIQUE-ARTIFACT-001 (audit finding 7).
+
+Pin the contract:
+- ``create_artifact`` swallows ``UniqueViolationError`` originating from the
+  ``uq_artifacts_active_path`` partial unique index, fetches the winning
+  artifact_id, logs the race at error level, and returns the winning id.
+- ``UniqueViolationError`` from any *other* constraint (e.g. PK collision)
+  re-raises — only the active-path race is handled silently.
+- If the winning row has vanished between INSERT and SELECT (concurrent
+  soft-delete), the function logs and re-raises rather than returning None.
+
+These tests exercise the error-handling branch directly via ``asyncpg``
+mocking. The migration itself is not exercised (it requires a real PG
+instance with the partial-unique-index applied) — manual smoke test on
+deploy is acceptance criterion 2 of the SPEC.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import asyncpg
+import pytest
+import structlog.testing
+
+
+def _build_unique_violation(constraint_name: str) -> asyncpg.UniqueViolationError:
+    """Construct a UniqueViolationError carrying the given constraint name.
+
+    ``asyncpg.UniqueViolationError`` accepts an optional message and reads
+    constraint_name from the args — but the asyncpg public path sets it
+    via ``__init__`` of PostgresError. The simplest portable approach is
+    to construct the exception then attach the attribute directly.
+    """
+    err = asyncpg.UniqueViolationError("simulated unique violation")
+    # asyncpg stores constraint_name as a Python attribute on the
+    # exception instance (read by getattr in production code).
+    err.constraint_name = constraint_name  # type: ignore[attr-defined]
+    return err
+
+
+@pytest.mark.asyncio
+async def test_happy_path_returns_new_artifact_id():
+    """No race: INSERT succeeds, function returns the freshly-generated id."""
+    mock_pool = MagicMock()
+    mock_pool.execute = AsyncMock(return_value=None)
+    mock_pool.fetchval = AsyncMock()  # not called on happy path
+
+    with patch(
+        "knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock, return_value=mock_pool
+    ):
+        from knowledge_ingest.pg_store import create_artifact
+
+        artifact_id = await create_artifact(
+            org_id="org1",
+            kb_slug="kb1",
+            path="docs/page.md",
+            provenance_type="extracted",
+            assertion_mode="factual",
+            synthesis_depth=0,
+            confidence=None,
+            belief_time_start=0,
+            belief_time_end=253402300800,
+        )
+
+    assert isinstance(artifact_id, str)
+    assert len(artifact_id) == 36  # uuid4 hex with dashes
+    mock_pool.execute.assert_awaited_once()
+    mock_pool.fetchval.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_race_returns_winning_artifact_id_and_logs_error():
+    """UniqueViolation from uq_artifacts_active_path: SELECT winner, log, return."""
+    winning_id = "11111111-2222-3333-4444-555555555555"
+
+    mock_pool = MagicMock()
+    mock_pool.execute = AsyncMock(side_effect=_build_unique_violation("uq_artifacts_active_path"))
+    mock_pool.fetchval = AsyncMock(return_value=winning_id)
+
+    with patch(
+        "knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock, return_value=mock_pool
+    ):
+        from knowledge_ingest.pg_store import create_artifact
+
+        with structlog.testing.capture_logs() as captured:
+            returned = await create_artifact(
+                org_id="org1",
+                kb_slug="kb1",
+                path="docs/page.md",
+                provenance_type="extracted",
+                assertion_mode="factual",
+                synthesis_depth=0,
+                confidence=None,
+                belief_time_start=0,
+                belief_time_end=253402300800,
+            )
+
+    assert returned == winning_id
+
+    # Race is logged at error level so obs-001 fires
+    race_events = [e for e in captured if e.get("event") == "artifact_create_race_lost"]
+    assert len(race_events) == 1
+    evt = race_events[0]
+    assert evt["log_level"] == "error", (
+        f"race must log at error to fire obs-001 alert; got {evt.get('log_level')!r}"
+    )
+    assert evt["org_id"] == "org1"
+    assert evt["kb_slug"] == "kb1"
+    assert evt["path"] == "docs/page.md"
+    assert evt["winning_artifact_id"] == winning_id
+    # The losing attempt id is also captured for forensic correlation
+    assert "my_attempt_id" in evt
+    assert evt["my_attempt_id"] != winning_id
+
+
+@pytest.mark.asyncio
+async def test_unrelated_unique_violation_reraises():
+    """A unique violation from a different constraint must NOT be swallowed.
+
+    The race-handling logic is scoped to ``uq_artifacts_active_path``. If
+    a future schema change introduces another unique constraint (e.g. on
+    artifact_id PK), a violation there is a real bug, not a race — the
+    caller must see the exception.
+    """
+    mock_pool = MagicMock()
+    mock_pool.execute = AsyncMock(side_effect=_build_unique_violation("artifacts_pkey"))
+    mock_pool.fetchval = AsyncMock()
+
+    with patch(
+        "knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock, return_value=mock_pool
+    ):
+        from knowledge_ingest.pg_store import create_artifact
+
+        with pytest.raises(asyncpg.UniqueViolationError):
+            await create_artifact(
+                org_id="org1",
+                kb_slug="kb1",
+                path="docs/page.md",
+                provenance_type="extracted",
+                assertion_mode="factual",
+                synthesis_depth=0,
+                confidence=None,
+                belief_time_start=0,
+                belief_time_end=253402300800,
+            )
+
+    mock_pool.fetchval.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_race_with_vanished_winner_logs_and_reraises():
+    """Edge case: winning row was soft-deleted between INSERT and SELECT.
+
+    If fetchval returns None (no active row matches the path anymore), we
+    must NOT return None and let the caller hit a downstream NULL — log
+    the anomaly at error level and re-raise the original violation so the
+    caller knows something is off.
+    """
+    violation = _build_unique_violation("uq_artifacts_active_path")
+    mock_pool = MagicMock()
+    mock_pool.execute = AsyncMock(side_effect=violation)
+    mock_pool.fetchval = AsyncMock(return_value=None)  # winner vanished
+
+    with patch(
+        "knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock, return_value=mock_pool
+    ):
+        from knowledge_ingest.pg_store import create_artifact
+
+        with structlog.testing.capture_logs() as captured:
+            with pytest.raises(asyncpg.UniqueViolationError):
+                await create_artifact(
+                    org_id="org1",
+                    kb_slug="kb1",
+                    path="docs/page.md",
+                    provenance_type="extracted",
+                    assertion_mode="factual",
+                    synthesis_depth=0,
+                    confidence=None,
+                    belief_time_start=0,
+                    belief_time_end=253402300800,
+                )
+
+    # The "no winner" anomaly must be loud
+    no_winner_events = [
+        e for e in captured if e.get("event") == "artifact_create_race_lost_no_winner"
+    ]
+    assert len(no_winner_events) == 1
+    assert no_winner_events[0]["log_level"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_race_returns_string_not_uuid_object():
+    """asyncpg can return a UUID object; ingest_document expects a str.
+    Without explicit str() conversion the artifact_id propagates as a UUID
+    and downstream JSON serialisation in extra_payload silently fails.
+    """
+    import uuid as _uuid
+
+    winning_uuid = _uuid.UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+
+    mock_pool = MagicMock()
+    mock_pool.execute = AsyncMock(side_effect=_build_unique_violation("uq_artifacts_active_path"))
+    mock_pool.fetchval = AsyncMock(return_value=winning_uuid)
+
+    with patch(
+        "knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock, return_value=mock_pool
+    ):
+        from knowledge_ingest.pg_store import create_artifact
+
+        returned = await create_artifact(
+            org_id="org1",
+            kb_slug="kb1",
+            path="docs/page.md",
+            provenance_type="extracted",
+            assertion_mode="factual",
+            synthesis_depth=0,
+            confidence=None,
+            belief_time_start=0,
+            belief_time_end=253402300800,
+        )
+
+    assert isinstance(returned, str), (
+        "create_artifact must return str even when asyncpg returns UUID — "
+        "downstream code (extra_payload, JSON in Procrastinate args) "
+        "depends on string identity."
+    )
+    assert returned == str(winning_uuid)


### PR DESCRIPTION
## Audit finding 7: race-window on knowledge.artifacts

Closes the 1-2s race window between `get_active_content_hash` and `create_artifact` under concurrent ingest of the same `(org_id, kb_slug, path)`. SPEC: [.moai/specs/SPEC-INGEST-UNIQUE-ARTIFACT-001/spec.md](https://github.com/GetKlai/klai/blob/docs/audit-ti-2026-05-05/.moai/specs/SPEC-INGEST-UNIQUE-ARTIFACT-001/spec.md).

Audit research: [docs/audit-ingest-pipeline-2026-05-06/research/finding-7.md](https://github.com/GetKlai/klai/blob/docs/audit-ti-2026-05-05/docs/audit-ingest-pipeline-2026-05-06/research/finding-7.md) (will become reachable on main once #392 + this lands).

## Pre-flight done

```
SELECT org_id, COUNT(*) ... knowledge.artifacts WHERE belief_time_end = 253402300800 ... HAVING COUNT(*) > 1
```
**Result on prod 2026-05-06: 0 rows.** No tenant has duplicates, including Voys. Migration runs without a cleanup pass.

## What this PR does

| File | Change |
|---|---|
| `alembic/versions/0003_artifacts_unique_active_path.py` | Partial unique index on `(org_id, kb_slug, path) WHERE belief_time_end = 253402300800`. Uses `CREATE INDEX CONCURRENTLY` with the `op.execute('COMMIT')` trick to break out of alembic's implicit transaction. Down-migration drops the index. |
| `knowledge_ingest/pg_store.py` | `create_artifact` now catches `asyncpg.UniqueViolationError` scoped to `uq_artifacts_active_path`. On race: SELECT the winning artifact_id, log `artifact_create_race_lost` at error level (fires `obs-001-ingest-error-rate-elevated`), return the winning id. Other unique violations re-raise unchanged. |
| `tests/test_artifact_unique_constraint.py` | 5 tests: happy path, race-resolution + log, unrelated violation re-raises, vanished-winner edge case, UUID→str conversion. |

## Design (Mark, 2026-05-06)

- **Pre-flight = acceptance criterion**, not auto-cleanup. Migration ABORTS if the predicate is violated; manual cleanup must run first.
- **Race handling: fail loud internally, silent for caller.**
  - Internal: `logger.error` → VictoriaLogs `level:error` → existing `obs-001` Grafana alert fires.
  - External: caller (MCP / connector / scribe / portal) sees a normal return value with the winning artifact_id.
  - Phase-1 Qdrant write is idempotent on `(org_id, kb_slug, path)` so vectors are consistent regardless of who won the race.

## Why this is safe to merge before #1

This SPEC closes the **active-row-uniqueness** race in Phase 1. SPEC #1 (audit finding 1, full SPEC pending) will close the **content-staleness** race in Phase 2. Both fixes are orthogonal — this one stands on its own.

## Verification

- 5 new unit tests green
- 7 regression tests green (`test_ingest_content_hash_dedup`, `test_ingest_enrichment_dedup`)
- ruff check + format clean

## Deploy steps

1. CI builds + pushes the new image
2. Re-run the pre-flight query on prod immediately before `alembic upgrade head` (acceptance criterion 1)
3. `docker exec klai-core-knowledge-ingest-1 alembic upgrade head` runs the migration via the existing entrypoint
4. Smoke-test: post-migration, run an ingest that previously raced (or simulate via two parallel POSTs in dev) — expect a single `artifact_create_race_lost` error log when the race triggers, no 5xx to caller

🤖 Generated with [Claude Code](https://claude.com/claude-code)