### PR TITLE
test(retrieval-api): refresh stale test_tei + test_graph_search

### DIFF
--- a/klai-retrieval-api/tests/test_graph_search.py
+++ b/klai-retrieval-api/tests/test_graph_search.py
@@ -1,4 +1,5 @@
 """Tests for retrieval_api.services.graph_search and RRF merge."""
+
 from __future__ import annotations
 
 import asyncio
@@ -6,15 +7,32 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from retrieval_api.services import graph_search
 from retrieval_api.api.retrieve import _rrf_merge
+from retrieval_api.services import graph_search
 
 
-def _make_graph_result(uuid: str, fact: str, score: float = 0.8) -> MagicMock:
+def _make_graph_result(
+    uuid: str,
+    fact: str,
+    score: float = 0.8,
+    weight: float | None = None,
+) -> MagicMock:
+    """Build a fake Graphiti EdgeResult for tests.
+
+    ``weight`` MUST be set explicitly because ``_convert_results`` in
+    ``graph_search.py`` reads ``getattr(r, "weight", None)`` and applies a
+    Hebbian boost when it is non-None and > 0. A bare ``MagicMock`` returns
+    a fresh MagicMock for every attribute access — including ``r.weight``.
+    ``float(MagicMock())`` evaluates to ``1.0`` via the default
+    ``__float__`` magic, so the boost would silently fire and the test
+    would assert against a boosted score instead of the base ``score``.
+    Defaulting to ``None`` matches the production "no Hebbian data" path.
+    """
     r = MagicMock()
     r.uuid = uuid
     r.fact = fact
     r.score = score
+    r.weight = weight
     return r
 
 
@@ -31,9 +49,7 @@ async def test_search_disabled():
 async def test_search_success():
     """Returns converted chunk-compatible dicts on success."""
     mock_graphiti = AsyncMock()
-    mock_graphiti.search = AsyncMock(
-        return_value=[_make_graph_result("e1", "Mark decided X", 0.9)]
-    )
+    mock_graphiti.search = AsyncMock(return_value=[_make_graph_result("e1", "Mark decided X", 0.9)])
 
     with (
         patch("retrieval_api.services.graph_search.settings") as mock_settings,
@@ -70,6 +86,38 @@ async def test_search_timeout():
 
 
 @pytest.mark.asyncio
+async def test_search_applies_hebbian_boost_when_weight_set():
+    """When the EdgeResult carries a positive ``weight`` (Hebbian
+    reinforcement count), the score is multiplied by ``1 + 0.1 * log1p(weight)``.
+
+    Locks in the boost contract that ``_make_graph_result`` defaults to no
+    boost for; without this test a regression that drops the weight-aware
+    branch from ``_convert_results`` would only surface in production.
+    """
+    import math
+
+    base_score = 0.5
+    weight = 10.0
+    expected = base_score * (1.0 + 0.1 * math.log1p(weight))
+
+    mock_graphiti = AsyncMock()
+    mock_graphiti.search = AsyncMock(
+        return_value=[_make_graph_result("e1", "Mark decided X", base_score, weight=weight)]
+    )
+
+    with (
+        patch("retrieval_api.services.graph_search.settings") as mock_settings,
+        patch("retrieval_api.services.graph_search._get_graphiti", return_value=mock_graphiti),
+    ):
+        mock_settings.graphiti_enabled = True
+        mock_settings.graph_search_timeout = 5.0
+        result = await graph_search.search("query", "org-1", top_k=10)
+
+    assert len(result) == 1
+    assert result[0]["score"] == pytest.approx(expected)
+
+
+@pytest.mark.asyncio
 async def test_search_exception():
     """Returns empty list on generic exception — graceful degradation (AC-7)."""
     mock_graphiti = AsyncMock()
@@ -89,17 +137,41 @@ async def test_search_exception():
 def test_rrf_merge_combines_results():
     """RRF merge produces combined result set with updated scores (AC-5)."""
     qdrant = [
-        {"chunk_id": "q1", "text": "a", "score": 0.9, "artifact_id": None,
-         "content_type": None, "context_prefix": None, "scope": "org",
-         "valid_at": None, "invalid_at": None},
-        {"chunk_id": "q2", "text": "b", "score": 0.8, "artifact_id": None,
-         "content_type": None, "context_prefix": None, "scope": "org",
-         "valid_at": None, "invalid_at": None},
+        {
+            "chunk_id": "q1",
+            "text": "a",
+            "score": 0.9,
+            "artifact_id": None,
+            "content_type": None,
+            "context_prefix": None,
+            "scope": "org",
+            "valid_at": None,
+            "invalid_at": None,
+        },
+        {
+            "chunk_id": "q2",
+            "text": "b",
+            "score": 0.8,
+            "artifact_id": None,
+            "content_type": None,
+            "context_prefix": None,
+            "scope": "org",
+            "valid_at": None,
+            "invalid_at": None,
+        },
     ]
     graph = [
-        {"chunk_id": "graph:g1", "text": "c", "score": 0.7, "artifact_id": None,
-         "content_type": "graph_edge", "context_prefix": None, "scope": "org",
-         "valid_at": None, "invalid_at": None},
+        {
+            "chunk_id": "graph:g1",
+            "text": "c",
+            "score": 0.7,
+            "artifact_id": None,
+            "content_type": "graph_edge",
+            "context_prefix": None,
+            "scope": "org",
+            "valid_at": None,
+            "invalid_at": None,
+        },
     ]
     merged = _rrf_merge(qdrant, graph)
 
@@ -115,12 +187,28 @@ def test_rrf_merge_combines_results():
 def test_rrf_merge_empty_graph():
     """RRF with empty graph results preserves Qdrant order (AC-5)."""
     qdrant = [
-        {"chunk_id": "q1", "text": "a", "score": 0.9, "artifact_id": None,
-         "content_type": None, "context_prefix": None, "scope": "org",
-         "valid_at": None, "invalid_at": None},
-        {"chunk_id": "q2", "text": "b", "score": 0.8, "artifact_id": None,
-         "content_type": None, "context_prefix": None, "scope": "org",
-         "valid_at": None, "invalid_at": None},
+        {
+            "chunk_id": "q1",
+            "text": "a",
+            "score": 0.9,
+            "artifact_id": None,
+            "content_type": None,
+            "context_prefix": None,
+            "scope": "org",
+            "valid_at": None,
+            "invalid_at": None,
+        },
+        {
+            "chunk_id": "q2",
+            "text": "b",
+            "score": 0.8,
+            "artifact_id": None,
+            "content_type": None,
+            "context_prefix": None,
+            "scope": "org",
+            "valid_at": None,
+            "invalid_at": None,
+        },
     ]
     merged = _rrf_merge(qdrant, [])
 
@@ -131,9 +219,17 @@ def test_rrf_merge_empty_graph():
 
 def test_rrf_merge_deduplication():
     """Chunk appearing in both lists is deduplicated in output."""
-    shared = {"chunk_id": "shared", "text": "x", "score": 0.5, "artifact_id": None,
-              "content_type": None, "context_prefix": None, "scope": "org",
-              "valid_at": None, "invalid_at": None}
+    shared = {
+        "chunk_id": "shared",
+        "text": "x",
+        "score": 0.5,
+        "artifact_id": None,
+        "content_type": None,
+        "context_prefix": None,
+        "scope": "org",
+        "valid_at": None,
+        "invalid_at": None,
+    }
     qdrant = [dict(shared)]
     graph = [dict(shared)]
     merged = _rrf_merge(qdrant, graph)

--- a/klai-retrieval-api/tests/test_tei.py
+++ b/klai-retrieval-api/tests/test_tei.py
@@ -1,17 +1,35 @@
-"""Tests for TEI embedding service."""
+"""Tests for TEI embedding service.
+
+The production code calls the OpenAI-compatible ``/v1/embeddings`` endpoint
+(served by Infinity at port 7997 on gpu-01) — NOT the raw HuggingFace TEI
+``/embed`` endpoint. Request shape: ``{"input": str|list, "model": "BAAI/bge-m3"}``.
+Response shape: ``{"data": [{"embedding": [...], "index": int}]}``.
+
+Earlier versions of these tests targeted the HF TEI shape and broke silently
+when the code migrated to the OpenAI-compat client. Refreshed to match.
+"""
 
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-
 from retrieval_api.services.tei import embed_batch, embed_single
+
+
+def _openai_embedding_response(vectors: list[list[float]]) -> dict:
+    """Build an OpenAI-compatible /v1/embeddings response body."""
+    return {
+        "data": [{"embedding": vec, "index": i} for i, vec in enumerate(vectors)],
+        "model": "BAAI/bge-m3",
+        "object": "list",
+    }
 
 
 class TestEmbedSingle:
     @patch("retrieval_api.services.tei.httpx.AsyncClient")
-    async def test_nested_response_unwrapped(self, mock_client_cls):
-        """TEI returns [[float,...]] for single input -- should unwrap to [float,...]."""
+    async def test_returns_first_embedding_from_data_array(self, mock_client_cls):
+        """``embed_single`` returns the first vector from the OpenAI-compat
+        ``data[0].embedding`` shape."""
         mock_client = AsyncMock()
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
@@ -19,22 +37,15 @@ class TestEmbedSingle:
 
         mock_resp = MagicMock()
         mock_resp.raise_for_status = MagicMock()
-        mock_resp.json.return_value = [[0.1, 0.2, 0.3]]
+        mock_resp.json.return_value = _openai_embedding_response([[0.1, 0.2, 0.3]])
         mock_client.post = AsyncMock(return_value=mock_resp)
 
         result = await embed_single("test text")
         assert result == [0.1, 0.2, 0.3]
 
-        # Verify correct payload was sent
-        call_args = mock_client.post.call_args
-        assert "/embed" in call_args[0][0]
-        sent_json = call_args[1]["json"]
-        assert sent_json["inputs"] == "test text"
-        assert sent_json["normalize"] is True
-
     @patch("retrieval_api.services.tei.httpx.AsyncClient")
-    async def test_flat_response_passthrough(self, mock_client_cls):
-        """If TEI returns [float,...] directly, pass through unchanged."""
+    async def test_correct_payload_sent(self, mock_client_cls):
+        """Request payload uses the OpenAI-compat ``input`` + ``model`` keys."""
         mock_client = AsyncMock()
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
@@ -42,17 +53,23 @@ class TestEmbedSingle:
 
         mock_resp = MagicMock()
         mock_resp.raise_for_status = MagicMock()
-        mock_resp.json.return_value = [0.4, 0.5, 0.6]
+        mock_resp.json.return_value = _openai_embedding_response([[0.1, 0.2, 0.3]])
         mock_client.post = AsyncMock(return_value=mock_resp)
 
-        result = await embed_single("test text")
-        assert result == [0.4, 0.5, 0.6]
+        await embed_single("test text")
+
+        call_args = mock_client.post.call_args
+        # URL targets the OpenAI-compat endpoint, not the HF TEI /embed endpoint.
+        assert "/v1/embeddings" in call_args[0][0]
+        sent_json = call_args[1]["json"]
+        assert sent_json["input"] == "test text"
+        assert sent_json["model"] == "BAAI/bge-m3"
 
 
 class TestEmbedBatch:
     @patch("retrieval_api.services.tei.httpx.AsyncClient")
     async def test_returns_list_of_vectors(self, mock_client_cls):
-        """embed_batch returns list of vectors."""
+        """``embed_batch`` returns one vector per input from ``data[*].embedding``."""
         mock_client = AsyncMock()
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
@@ -60,15 +77,42 @@ class TestEmbedBatch:
 
         mock_resp = MagicMock()
         mock_resp.raise_for_status = MagicMock()
-        mock_resp.json.return_value = [[0.1, 0.2], [0.3, 0.4]]
+        mock_resp.json.return_value = _openai_embedding_response([[0.1, 0.2], [0.3, 0.4]])
         mock_client.post = AsyncMock(return_value=mock_resp)
 
         result = await embed_batch(["text1", "text2"])
         assert result == [[0.1, 0.2], [0.3, 0.4]]
 
     @patch("retrieval_api.services.tei.httpx.AsyncClient")
-    async def test_correct_inputs_sent(self, mock_client_cls):
-        """Verify the correct inputs are sent to TEI."""
+    async def test_preserves_input_order_when_data_returned_unsorted(self, mock_client_cls):
+        """OpenAI servers may return ``data`` items out of order; ``embed_batch``
+        sorts on ``index`` before extracting embeddings (production contract)."""
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        # Deliberately scrambled order — index field is the source of truth.
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "data": [
+                {"embedding": [0.3], "index": 2},
+                {"embedding": [0.1], "index": 0},
+                {"embedding": [0.2], "index": 1},
+            ],
+            "model": "BAAI/bge-m3",
+            "object": "list",
+        }
+        mock_client.post = AsyncMock(return_value=mock_resp)
+
+        result = await embed_batch(["alpha", "beta", "gamma"])
+        # Output must follow the original input order (index 0 → 1 → 2).
+        assert result == [[0.1], [0.2], [0.3]]
+
+    @patch("retrieval_api.services.tei.httpx.AsyncClient")
+    async def test_correct_payload_sent(self, mock_client_cls):
+        """Batch payload uses ``input`` (list) + ``model`` keys."""
         mock_client = AsyncMock()
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
@@ -76,13 +120,13 @@ class TestEmbedBatch:
 
         mock_resp = MagicMock()
         mock_resp.raise_for_status = MagicMock()
-        mock_resp.json.return_value = [[0.1], [0.2], [0.3]]
+        mock_resp.json.return_value = _openai_embedding_response([[0.1], [0.2], [0.3]])
         mock_client.post = AsyncMock(return_value=mock_resp)
 
-        texts = ["alpha", "beta", "gamma"]
-        await embed_batch(texts)
+        await embed_batch(["alpha", "beta", "gamma"])
 
         call_args = mock_client.post.call_args
+        assert "/v1/embeddings" in call_args[0][0]
         sent_json = call_args[1]["json"]
-        assert sent_json["inputs"] == ["alpha", "beta", "gamma"]
-        assert sent_json["normalize"] is True
+        assert sent_json["input"] == ["alpha", "beta", "gamma"]
+        assert sent_json["model"] == "BAAI/bge-m3"


### PR DESCRIPTION
## Summary

Closes 5 pre-existing test failures on main that survived earlier audit work because they're test-only and didn't block any production-touching PR.

## test_tei (4 tests)

The tests targeted the raw HuggingFace TEI `/embed` shape:
- request: `{"inputs": ..., "normalize": True}`
- response: `[[float...]]` (nested) or `[float...]` (flat)

Production code calls the OpenAI-compatible `/v1/embeddings` endpoint at gpu-01 (Infinity):
- request: `{"input": ..., "model": "BAAI/bge-m3"}`
- response: `{"data": [{"embedding": [...], "index": int}]}`

Two stale "nested vs flat" tests collapsed into one — the distinction no longer exists. Added `test_preserves_input_order_when_data_returned_unsorted` to cover `embed_batch`'s `data.sort(key=lambda x: x["index"])` contract (OpenAI-compat servers don't guarantee response order).

## test_graph_search::test_search_success

`_make_graph_result` did not set `r.weight`. A bare `MagicMock` returns a fresh MagicMock for any attribute access, and `float(MagicMock())` evaluates to `1.0` via the default `__float__` magic. `graph_search._convert_results` saw `weight=MagicMock()`, took the Hebbian boost branch, and the test silently asserted against a boosted score (`0.9 * 1.0693 = 0.9624`) instead of the base `0.9`.

Made `weight` an explicit parameter on the helper with a docstring explaining the MagicMock attribute trap. Added `test_search_applies_hebbian_boost_when_weight_set` to cover the boost path (which previously had zero real coverage — the broken test accidentally exercised it).

## Tests

13/13 in touched files green. Ruff check + format clean.

## Out of scope

E2E prod-tenant CI failures (missing `E2E_BASE_URL` etc.) — still being built per current state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)