### PR TITLE
feat(ingest): SPEC-INGEST-CONTENT-PG-001 — enrichment task takes only artifact_id (#1)

### DIFF
--- a/.moai/specs/SPEC-INGEST-CONTENT-PG-001/spec.md
+++ b/.moai/specs/SPEC-INGEST-CONTENT-PG-001/spec.md
@@ -1,0 +1,137 @@
+---
+id: SPEC-INGEST-CONTENT-PG-001
+version: "0.1.0"
+status: draft
+created: 2026-05-06
+updated: 2026-05-06
+author: Mark Vletter
+priority: high
+related:
+  - audit-2026-05-06 finding 1 (parent)
+  - SPEC-INGEST-UNIQUE-ARTIFACT-001 (companion: closes the active-row race)
+  - SPEC-RAG-REBUILD-KB-001 (precedent: re-derive chunks from PG body)
+---
+
+# SPEC-INGEST-CONTENT-PG-001: Pass `artifact_id` only to enrichment task
+
+## Summary
+
+The Procrastinate enrichment task currently freezes the document body and
+all derived metadata into its job arguments at `defer_async` time. A
+second direct-POST that arrives within the (typically seconds-long)
+worker pickup window writes new raw vectors to Qdrant — but the worker
+still processes the older content from its frozen args, overwriting the
+new vectors with stale enrichment.
+
+This SPEC moves the canonical state to PostgreSQL: the enrichment task
+takes only `artifact_id`, and the worker reads `extra_payload` (including
+`document_text`) from `knowledge.artifacts.extra` at execution time.
+
+This is the same pattern that the Gitea-webhook flow already uses
+correctly (`ingest_from_gitea` re-fetches from Gitea per-execution) and
+matches LlamaIndex's docstore + worker model.
+
+## Motivation
+
+Audit 2026-05-06 finding 1 (independently verified):
+
+- `defer_async(document_text=req.content, ...)` in `routes/ingest.py`
+  serialises the body into the job row.
+- `_enrich_document` reads `document_text` directly from its parameter,
+  never re-reads from `pg_store`.
+- The race window is the period between Phase-1 completion and worker
+  pickup of the enrichment task — typically seconds, longer under
+  enrich-bulk queue saturation.
+
+Affected callers (direct-POST flow):
+- `klai-knowledge-mcp` `save_personal_knowledge`
+- `klai-connector` `sync_engine` (per-document POST)
+- `klai-portal` `partner_knowledge`, `knowledge_ingest_client`
+- `klai-scribe` `knowledge_adapter`
+
+## Scope
+
+### In scope
+
+1. **New `pg_store.read_artifact_for_enrichment(artifact_id)`** — returns
+   the artifact row + parsed `extra` JSONB, or `None` if the artifact has
+   been deleted between enqueue and dequeue (connector-purge race).
+
+2. **`enrichment_tasks._load_and_enrich(artifact_id)`** — single shim
+   that:
+   - Reads the artifact via `read_artifact_for_enrichment`.
+   - Soft-skips if the artifact is missing or has no `document_text`
+     on `extra` (legacy rows go through `rebuild_kb`).
+   - Re-derives `chunks` + `parents` from the *current*
+     `extra.document_text` via `chunker.chunk_markdown_with_parents`.
+   - Delegates to the unchanged `_enrich_document` body with the
+     PG-sourced kwargs.
+
+3. **Task signature simplification** — both `enrich_document_interactive`
+   and `enrich_document_bulk` accept only `artifact_id: str`. All other
+   parameters disappear from the Procrastinate job row.
+
+4. **`routes/ingest.py` writes `extra_payload` to PG** before deferring
+   — `pg_store.update_artifact_extra(artifact_id, extra_payload)` after
+   the existing `extra_payload` build, then `defer_async(artifact_id=...)`.
+   JSONB merge semantics so the existing `pg_extra` from `create_artifact`
+   stays intact.
+
+5. **Test coverage**:
+   - `read_artifact_for_enrichment`: missing id, missing artifact, dict
+     extra, JSON-string extra.
+   - `_load_and_enrich`: soft-skip on missing artifact, soft-skip on
+     missing `document_text`, full-state delegation to `_enrich_document`.
+   - Signature contract: `_load_and_enrich(artifact_id)` is one-arg;
+     anything else is a regression.
+   - Updated existing tests to mock `update_artifact_extra` and disable
+     the graphiti enqueue branch.
+
+### Out of scope
+
+- Backwards compatibility for in-flight tasks: the system has no
+  production load yet, re-ingest of existing data is the recovery path
+  if any test data needs catch-up.
+- Schema migration for `knowledge.artifacts.extra` — no new columns
+  needed; existing JSONB shape is already a superset.
+- Refactoring `_enrich_document`'s body — it still accepts the same
+  kwargs; only the *source* of those kwargs moves from task-args to PG.
+- klai-retrieval-api `embed_single`/`embed_batch` (own retry-budget
+  finding, separate scope).
+
+## Acceptance criteria
+
+1. `tests/test_enrichment_loads_from_pg.py`: 8 tests pass covering
+   `read_artifact_for_enrichment` + `_load_and_enrich` contracts.
+2. Existing regression tests pass after mock additions:
+   - `test_ingest_content_hash_dedup.py`
+   - `test_ingest_enrichment_dedup.py`
+   - `test_enrichment_dedup.py`
+3. ruff check + ruff format --check clean on all modified files.
+4. `_load_and_enrich` signature has exactly one parameter
+   (`artifact_id: str`).
+5. End-to-end smoke (manual, post-deploy): two rapid POSTs to
+   `/ingest/v1/document` for the same path with different content;
+   eventual Qdrant payload reflects the second content's enrichment,
+   not the first's.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Worker re-chunks with different boundaries than Phase-1, leading to mismatched raw vs. enriched chunk counts | Phase-1 and Phase-2 use the same `chunker.chunk_markdown_with_parents` defaults. Both Phase-1 and Phase-2 do delete-then-insert keyed on `(org_id, kb_slug, path)`, so chunk-count drift is self-healing within a single ingest cycle. |
+| Procrastinate retries replay an old job-row whose `artifact_id` no longer exists (connector-purge in flight) | `_load_and_enrich` returns silently when `read_artifact_for_enrichment` returns `None` — same soft-skip pattern as `ingest_graphiti_episode` already uses. |
+| Legacy artifact rows without `document_text` on `extra` cannot be enriched via this path | Logged as `enrichment_aborted_no_document_text`. Operator runs `rebuild_kb` for those KBs (existing tool, SPEC-RAG-REBUILD-KB-001). |
+| Companion SPEC-INGEST-UNIQUE-ARTIFACT-001 must land before this PR is exercised heavily | Both can land independently; their interaction is benign (the UNIQUE constraint catches concurrent inserts; this SPEC catches stale content). |
+
+## References
+
+- `docs/audit-ingest-pipeline-2026-05-06/findings.md` § Finding 1
+- `docs/audit-ingest-pipeline-2026-05-06/research/finding-1.md`
+  (LlamaIndex docstore pattern, Procrastinate queueing_lock semantics,
+  Inngest debounce-and-re-fetch)
+- `klai-knowledge-ingest/knowledge_ingest/ingest_tasks.py::ingest_from_gitea`
+  — the Gitea-flow precedent that already implements this correctly
+- `klai-knowledge-ingest/knowledge_ingest/rebuild_tasks.py` — the
+  re-derive-from-PG-body pattern that this SPEC adopts for the
+  enrichment worker

--- a/klai-knowledge-ingest/knowledge_ingest/enrichment_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/enrichment_tasks.py
@@ -30,7 +30,16 @@ from typing import Any
 
 import structlog
 
-from knowledge_ingest import embedder, enrichment, kb_config, qdrant_store, queues, sparse_embedder
+from knowledge_ingest import (
+    chunker,
+    embedder,
+    enrichment,
+    kb_config,
+    pg_store,
+    qdrant_store,
+    queues,
+    sparse_embedder,
+)
 from knowledge_ingest.content_profiles import get_profile
 from knowledge_ingest.db import get_pool
 
@@ -98,6 +107,74 @@ def init_app(connector: Any) -> Any:
     return _procrastinate_app
 
 
+async def _load_and_enrich(artifact_id: str) -> None:
+    """SPEC-INGEST-CONTENT-PG-001 (audit finding 1): single entry point for
+    both enrichment task variants.
+
+    Re-reads the artifact's content + extra_payload from PostgreSQL at
+    execution time, re-derives the chunk + parent decomposition from the
+    current document body, and delegates to the existing
+    ``_enrich_document`` body. This is the canonical pattern that closes
+    the race-window where a second direct-POST overwrote the raw Qdrant
+    vectors while the worker still processed an older content snapshot
+    frozen in the task args.
+
+    If the artifact has been deleted between enqueue and dequeue (typically
+    by the connector purge orchestrator), the function returns silently —
+    same soft-skip semantics as ``ingest_graphiti_episode`` uses.
+    """
+    artifact = await pg_store.read_artifact_for_enrichment(artifact_id)
+    if artifact is None:
+        logger.info("enrichment_aborted_artifact_missing", artifact_id=artifact_id)
+        return
+
+    extra: dict = artifact["extra"] or {}
+    document_text: str = extra.get("document_text", "") or ""
+    if not document_text:
+        # Pre-SPEC-INGEST-CONTENT-PG-001 artifact rows may have no
+        # document_text on extra. Without a body we cannot enrich; the
+        # rebuild_kb path is the right tool to repair these legacy rows.
+        logger.info(
+            "enrichment_aborted_no_document_text",
+            artifact_id=artifact_id,
+            kb_slug=artifact["kb_slug"],
+            path=artifact["path"],
+        )
+        return
+
+    title: str = extra.get("title") or ""
+    # Re-derive chunks deterministically from the current PG body so
+    # Phase-2 always operates on the same content the artifact row claims
+    # is current, regardless of what was in flight at enqueue time.
+    children, parents = chunker.chunk_markdown_with_parents(document_text)
+    chunks_text = [c.text for c in children]
+    parents_serialised: list[dict] = [
+        {
+            "text": p.text,
+            "token_count": chunker._approx_token_count(p.text),
+            "position": p.position,
+        }
+        for p in parents
+    ]
+    parent_index_per_child: list[int | None] = [c.parent_index for c in children]
+
+    await _enrich_document(
+        org_id=artifact["org_id"],
+        kb_slug=artifact["kb_slug"],
+        path=artifact["path"],
+        document_text=document_text,
+        chunks=chunks_text,
+        title=title,
+        artifact_id=artifact_id,
+        user_id=artifact["user_id"],
+        extra_payload=extra,
+        synthesis_depth=artifact["synthesis_depth"],
+        content_type=artifact["content_type"] or "unknown",
+        parents=parents_serialised,
+        parent_index_per_child=parent_index_per_child,
+    )
+
+
 def _register_tasks(procrastinate_app: Any) -> None:
     """Register task functions on the given App instance."""
     import procrastinate
@@ -105,72 +182,23 @@ def _register_tasks(procrastinate_app: Any) -> None:
     @procrastinate_app.task(
         queue=queues.ENRICH_INTERACTIVE, retry=procrastinate.RetryStrategy(max_attempts=2)
     )
-    async def enrich_document_interactive(
-        org_id: str,
-        kb_slug: str,
-        path: str,
-        document_text: str,
-        chunks: list[str],
-        title: str,
-        artifact_id: str,
-        user_id: str | None,
-        extra_payload: dict,
-        synthesis_depth: int,
-        content_type: str = "unknown",
-        parents: list[dict] | None = None,
-        parent_index_per_child: list[int | None] | None = None,
-    ) -> None:
-        """Enrich chunks for a single-doc upload (high priority)."""
-        await _enrich_document(
-            org_id,
-            kb_slug,
-            path,
-            document_text,
-            chunks,
-            title,
-            artifact_id,
-            user_id,
-            extra_payload,
-            synthesis_depth,
-            content_type=content_type,
-            parents=parents,
-            parent_index_per_child=parent_index_per_child,
-        )
+    async def enrich_document_interactive(artifact_id: str) -> None:
+        """Enrich chunks for a single-doc upload (high priority).
+
+        SPEC-INGEST-CONTENT-PG-001: takes only ``artifact_id``; all other
+        fields are loaded from PostgreSQL at execution time.
+        """
+        await _load_and_enrich(artifact_id)
 
     @procrastinate_app.task(
         queue=queues.ENRICH_BULK, retry=procrastinate.RetryStrategy(max_attempts=2)
     )
-    async def enrich_document_bulk(
-        org_id: str,
-        kb_slug: str,
-        path: str,
-        document_text: str,
-        chunks: list[str],
-        title: str,
-        artifact_id: str,
-        user_id: str | None,
-        extra_payload: dict,
-        synthesis_depth: int,
-        content_type: str = "unknown",
-        parents: list[dict] | None = None,
-        parent_index_per_child: list[int | None] | None = None,
-    ) -> None:
-        """Enrich chunks for crawl/import jobs (lower priority)."""
-        await _enrich_document(
-            org_id,
-            kb_slug,
-            path,
-            document_text,
-            chunks,
-            title,
-            artifact_id,
-            user_id,
-            extra_payload,
-            synthesis_depth,
-            content_type=content_type,
-            parents=parents,
-            parent_index_per_child=parent_index_per_child,
-        )
+    async def enrich_document_bulk(artifact_id: str) -> None:
+        """Enrich chunks for crawl/import jobs (lower priority).
+
+        SPEC-INGEST-CONTENT-PG-001: takes only ``artifact_id``.
+        """
+        await _load_and_enrich(artifact_id)
 
     # Expose task functions via app attributes for use in ingest.py
     procrastinate_app.enrich_document_interactive = enrich_document_interactive  # type: ignore[attr-defined]
@@ -455,14 +483,13 @@ async def _enrich_document(
         # After max_attempts the job lands in permanent-failed state — visible in
         # logs and the Procrastinate dashboard.
         total_ms = int((time.monotonic() - t_total) * 1000)
-        logger.error(
+        logger.exception(
             "enrichment_failed_will_retry",
             kb_slug=kb_slug,
             path=path,
             org_id=org_id,
             artifact_id=artifact_id,
             total_ms=total_ms,
-            exc_info=True,
         )
         raise  # Procrastinate retry handles this
 
@@ -472,12 +499,11 @@ async def _enrich_document(
         # basic embeddings.  These are infrastructure issues, not data quality
         # issues, so retrying the enrichment LLM call would not help.
         total_ms = int((time.monotonic() - t_total) * 1000)
-        logger.error(
+        logger.exception(
             "enrichment_infra_failed",
             kb_slug=kb_slug,
             path=path,
             org_id=org_id,
             artifact_id=artifact_id,
             total_ms=total_ms,
-            exc_info=True,
         )

--- a/klai-knowledge-ingest/knowledge_ingest/pg_store.py
+++ b/klai-knowledge-ingest/knowledge_ingest/pg_store.py
@@ -531,6 +531,60 @@ async def get_active_image_hashes_for_kb(org_id: str, kb_slug: str) -> set[str]:
     return {r["content_hash"] for r in rows}
 
 
+async def read_artifact_for_enrichment(artifact_id: str) -> dict | None:
+    """Return the full row + parsed extra JSONB for the enrichment worker.
+
+    SPEC-INGEST-CONTENT-PG-001 (audit finding 1): the enrichment task no
+    longer carries the document body or any payload metadata in its args.
+    It receives only ``artifact_id`` and re-reads the canonical state from
+    PostgreSQL at execution time. This closes the race-window where a
+    second direct-POST could overwrite the raw Qdrant vectors while the
+    worker still processed the older content from frozen task args.
+
+    Returns ``None`` if the artifact has been deleted between enqueue and
+    dequeue (e.g. by the connector purge orchestrator). Callers should
+    treat ``None`` as a soft-skip, the same way ``artifact_exists()`` is
+    used by the graphiti task today.
+    """
+    if not artifact_id:
+        return None
+    pool = await get_pool()
+    row = await pool.fetchrow(
+        """
+        SELECT id, org_id, kb_slug, path, user_id,
+               content_type, synthesis_depth,
+               assertion_mode, provenance_type, confidence,
+               belief_time_start, belief_time_end,
+               extra
+        FROM knowledge.artifacts
+        WHERE id = $1::uuid
+        """,
+        artifact_id,
+    )
+    if row is None:
+        return None
+    raw_extra = row["extra"]
+    if isinstance(raw_extra, str):
+        extra: dict = json.loads(raw_extra) if raw_extra else {}
+    else:
+        extra = dict(raw_extra) if raw_extra else {}
+    return {
+        "artifact_id": str(row["id"]),
+        "org_id": row["org_id"],
+        "kb_slug": row["kb_slug"],
+        "path": row["path"],
+        "user_id": row["user_id"],
+        "content_type": row["content_type"],
+        "synthesis_depth": row["synthesis_depth"],
+        "assertion_mode": row["assertion_mode"],
+        "provenance_type": row["provenance_type"],
+        "confidence": row["confidence"],
+        "belief_time_start": row["belief_time_start"],
+        "belief_time_end": row["belief_time_end"],
+        "extra": extra,
+    }
+
+
 async def artifact_exists(artifact_id: str) -> bool:
     """SPEC-CONNECTOR-DELETE-LIFECYCLE-001 REQ-07: existence-guard helper.
 

--- a/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
@@ -34,6 +34,7 @@ from knowledge_ingest.config import settings
 from knowledge_ingest.content_labeler import generate_content_label
 from knowledge_ingest.content_profiles import get_profile
 from knowledge_ingest.db import get_pool
+from knowledge_ingest.identity import assert_caller_identity
 from knowledge_ingest.models import (
     BulkSyncRequest,
     GiteaPushEvent,
@@ -41,7 +42,6 @@ from knowledge_ingest.models import (
     KBWebhookRequest,
     UpdateKBVisibilityRequest,
 )
-from knowledge_ingest.identity import assert_caller_identity
 from knowledge_ingest.portal_client import fetch_taxonomy_nodes
 from knowledge_ingest.taxonomy_classifier import classify_document
 
@@ -316,8 +316,8 @@ async def ingest_document(req: IngestRequest) -> dict:
         if not chunks:
             return {"status": "skipped", "reason": "empty document", "chunks": 0}
         texts = [c.text for c in chunks]
-        parent_index_per_child: list[int | None] = [c.parent_index for c in chunks]
-        parents_serialised: list[dict] = [
+        [c.parent_index for c in chunks]
+        [
             {
                 "text": p.text,
                 "token_count": chunker._approx_token_count(p.text),
@@ -530,7 +530,19 @@ async def ingest_document(req: IngestRequest) -> dict:
     # (proposal_generator.py::_MIN_UNMATCHED_FOR_PROPOSAL). Removed via
     # SPEC-KB-027 R2 cleanup (PR #90 obsolete; harvested as standalone fix).
 
-    # Enqueue enrichment as async Procrastinate task (non-blocking)
+    # SPEC-INGEST-CONTENT-PG-001 (audit finding 1): persist the full
+    # extra_payload onto the artifact row so the enrichment worker can
+    # reconstruct everything from artifact_id alone. The task no longer
+    # carries the document body or any payload metadata in its args.
+    # JSONB merge semantics — fields written here add to the pg_extra
+    # already attached at create_artifact time.
+    await pg_store.update_artifact_extra(artifact_id, extra_payload)
+
+    # Enqueue enrichment as async Procrastinate task (non-blocking).
+    # SPEC-INGEST-CONTENT-PG-001: task takes only artifact_id; all other
+    # fields are loaded from PostgreSQL at execution time. Closes the
+    # race-window where two POSTs in quick succession could leave the
+    # worker processing a stale (frozen-in-args) content snapshot.
     if await org_config.is_enrichment_enabled(req.org_id, pool):
         from knowledge_ingest import enrichment_tasks
 
@@ -545,21 +557,7 @@ async def ingest_document(req: IngestRequest) -> dict:
 
             await task_fn.configure(
                 queueing_lock=f"{req.org_id}:{req.kb_slug}:{req.path}",
-            ).defer_async(
-                org_id=req.org_id,
-                kb_slug=req.kb_slug,
-                path=req.path,
-                document_text=req.content,
-                chunks=texts,
-                title=title,
-                artifact_id=artifact_id,
-                user_id=req.user_id,
-                extra_payload=extra_payload,
-                synthesis_depth=kf["synthesis_depth"],
-                content_type=req.content_type,
-                parents=parents_serialised,
-                parent_index_per_child=parent_index_per_child,
-            )
+            ).defer_async(artifact_id=artifact_id)
         except AlreadyEnqueued:
             logger.info(
                 "enrichment_already_queued",
@@ -619,9 +617,7 @@ async def ingest_document(req: IngestRequest) -> dict:
 @router.post("/ingest/v1/document")
 async def ingest_document_route(req: IngestRequest, request: Request) -> dict:
     """Ingest a document. SPEC-TI-003 AC-6: identity assertion on body org_id."""
-    await assert_caller_identity(
-        request, claimed_org_id=req.org_id, claimed_user_id=req.user_id
-    )
+    await assert_caller_identity(request, claimed_org_id=req.org_id, claimed_user_id=req.user_id)
     return await ingest_document(req)
 
 

--- a/klai-knowledge-ingest/tests/test_enrichment_dedup.py
+++ b/klai-knowledge-ingest/tests/test_enrichment_dedup.py
@@ -5,6 +5,7 @@ Verifies that:
 - AlreadyEnqueued raised by defer_async is caught and logged (not propagated)
 - ingest_document returns ok even when the enrichment task is already queued
 """
+
 from __future__ import annotations
 
 import sys
@@ -69,6 +70,10 @@ def _base_patches(mock_app):
                 return_value="art-test",
             ),
             patch(
+                "knowledge_ingest.routes.ingest.pg_store.update_artifact_extra",
+                new_callable=AsyncMock,
+            ),
+            patch(
                 "knowledge_ingest.routes.ingest.qdrant_store.upsert_chunks",
                 new_callable=AsyncMock,
             ),
@@ -85,9 +90,20 @@ def _base_patches(mock_app):
             ),
             patch.dict(
                 sys.modules,
-                {"knowledge_ingest.enrichment_tasks": types.SimpleNamespace(get_app=lambda: mock_app)},
+                {
+                    "knowledge_ingest.enrichment_tasks": types.SimpleNamespace(
+                        get_app=lambda: mock_app
+                    )
+                },
             ),
+            patch("knowledge_ingest.routes.ingest.settings") as mock_settings,
         ):
+            # Disable the graphiti enqueue branch — these tests focus on
+            # the enrichment-defer contract, not the FalkorDB pipeline.
+            mock_settings.graphiti_enabled = False
+            mock_settings.chunk_size = 1500
+            mock_settings.chunk_overlap = 200
+            mock_settings.enrichment_enabled = True
             yield
 
     return _stack()

--- a/klai-knowledge-ingest/tests/test_enrichment_loads_from_pg.py
+++ b/klai-knowledge-ingest/tests/test_enrichment_loads_from_pg.py
@@ -1,0 +1,302 @@
+"""Tests for SPEC-INGEST-CONTENT-PG-001 (audit finding 1).
+
+Pin the contract:
+- ``read_artifact_for_enrichment`` returns the full row + parsed extra
+  JSONB, or None when the artifact is missing.
+- ``_load_and_enrich`` skips silently when the artifact is missing or
+  has no ``document_text`` on extra.
+- ``_load_and_enrich`` re-derives chunks + parents from the *current*
+  ``extra.document_text``, not from any frozen task arg.
+- Procrastinate task variants accept only ``artifact_id``; all other
+  fields flow through PG.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Procrastinate stub — same pattern as test_ingest_enrichment_dedup.py
+# ---------------------------------------------------------------------------
+
+
+class _AlreadyEnqueued(Exception):
+    """Stub for procrastinate.exceptions.AlreadyEnqueued."""
+
+
+def _install_procrastinate_stub() -> None:
+    if "procrastinate" in sys.modules:
+        return
+    exceptions_mod = types.ModuleType("procrastinate.exceptions")
+    exceptions_mod.AlreadyEnqueued = _AlreadyEnqueued  # type: ignore[attr-defined]
+    pkg = types.ModuleType("procrastinate")
+    pkg.exceptions = exceptions_mod  # type: ignore[attr-defined]
+    sys.modules["procrastinate"] = pkg
+    sys.modules["procrastinate.exceptions"] = exceptions_mod
+
+
+_install_procrastinate_stub()
+
+
+# ---------------------------------------------------------------------------
+# read_artifact_for_enrichment
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_read_artifact_returns_none_for_missing():
+    mock_pool = MagicMock()
+    mock_pool.fetchrow = AsyncMock(return_value=None)
+    with patch(
+        "knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock, return_value=mock_pool
+    ):
+        from knowledge_ingest.pg_store import read_artifact_for_enrichment
+
+        result = await read_artifact_for_enrichment("00000000-0000-0000-0000-000000000000")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_read_artifact_returns_none_for_empty_id():
+    """Defensive: empty/None id short-circuits without a DB hit."""
+    with patch("knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock) as get_pool:
+        from knowledge_ingest.pg_store import read_artifact_for_enrichment
+
+        assert await read_artifact_for_enrichment("") is None
+        get_pool.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_read_artifact_returns_dict_with_parsed_extra():
+    """JSONB extra is returned as a dict, not as a JSON string."""
+    fake_row = {
+        "id": "11111111-2222-3333-4444-555555555555",
+        "org_id": "org1",
+        "kb_slug": "kb1",
+        "path": "docs/page.md",
+        "user_id": None,
+        "content_type": "kb_article",
+        "synthesis_depth": 1,
+        "assertion_mode": "factual",
+        "provenance_type": "extracted",
+        "confidence": None,
+        "belief_time_start": 0,
+        "belief_time_end": 253402300800,
+        "extra": '{"document_text": "# Hi", "title": "Hi", "tags": ["onboarding"]}',
+    }
+    mock_pool = MagicMock()
+    mock_pool.fetchrow = AsyncMock(return_value=fake_row)
+
+    with patch(
+        "knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock, return_value=mock_pool
+    ):
+        from knowledge_ingest.pg_store import read_artifact_for_enrichment
+
+        result = await read_artifact_for_enrichment("11111111-2222-3333-4444-555555555555")
+
+    assert result is not None
+    assert result["org_id"] == "org1"
+    assert result["kb_slug"] == "kb1"
+    assert result["path"] == "docs/page.md"
+    assert result["content_type"] == "kb_article"
+    assert result["synthesis_depth"] == 1
+    # extra MUST be a dict, not a JSON string
+    assert isinstance(result["extra"], dict)
+    assert result["extra"]["document_text"] == "# Hi"
+    assert result["extra"]["title"] == "Hi"
+    assert result["extra"]["tags"] == ["onboarding"]
+
+
+@pytest.mark.asyncio
+async def test_read_artifact_handles_dict_extra():
+    """Some asyncpg deployments return JSONB as native dict already."""
+    fake_row = {
+        "id": "11111111-2222-3333-4444-555555555555",
+        "org_id": "org1",
+        "kb_slug": "kb1",
+        "path": "docs/page.md",
+        "user_id": None,
+        "content_type": "kb_article",
+        "synthesis_depth": 1,
+        "assertion_mode": "factual",
+        "provenance_type": "extracted",
+        "confidence": None,
+        "belief_time_start": 0,
+        "belief_time_end": 253402300800,
+        "extra": {"document_text": "body", "title": "T"},
+    }
+    mock_pool = MagicMock()
+    mock_pool.fetchrow = AsyncMock(return_value=fake_row)
+
+    with patch(
+        "knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock, return_value=mock_pool
+    ):
+        from knowledge_ingest.pg_store import read_artifact_for_enrichment
+
+        result = await read_artifact_for_enrichment("11111111-2222-3333-4444-555555555555")
+
+    assert isinstance(result["extra"], dict)
+    assert result["extra"]["document_text"] == "body"
+
+
+# ---------------------------------------------------------------------------
+# _load_and_enrich — soft-skip + delegation contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_load_and_enrich_skips_when_artifact_missing():
+    """Connector-purge or upstream race deleted the artifact: soft-skip."""
+    with (
+        patch(
+            "knowledge_ingest.enrichment_tasks.pg_store.read_artifact_for_enrichment",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "knowledge_ingest.enrichment_tasks._enrich_document", new_callable=AsyncMock
+        ) as mock_enrich,
+    ):
+        from knowledge_ingest.enrichment_tasks import _load_and_enrich
+
+        await _load_and_enrich("00000000-0000-0000-0000-000000000000")
+
+    mock_enrich.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_load_and_enrich_skips_when_document_text_missing():
+    """Legacy artifact rows without document_text are not enrichable
+    via this path; rebuild_kb is the right tool. Soft-skip with a log
+    event, no exception.
+    """
+    fake_artifact = {
+        "artifact_id": "11111111-2222-3333-4444-555555555555",
+        "org_id": "org1",
+        "kb_slug": "kb1",
+        "path": "docs/page.md",
+        "user_id": None,
+        "content_type": "kb_article",
+        "synthesis_depth": 0,
+        "assertion_mode": "factual",
+        "provenance_type": "extracted",
+        "confidence": None,
+        "belief_time_start": 0,
+        "belief_time_end": 253402300800,
+        "extra": {"title": "Hi"},  # no document_text!
+    }
+    with (
+        patch(
+            "knowledge_ingest.enrichment_tasks.pg_store.read_artifact_for_enrichment",
+            new_callable=AsyncMock,
+            return_value=fake_artifact,
+        ),
+        patch(
+            "knowledge_ingest.enrichment_tasks._enrich_document", new_callable=AsyncMock
+        ) as mock_enrich,
+    ):
+        from knowledge_ingest.enrichment_tasks import _load_and_enrich
+
+        await _load_and_enrich("11111111-2222-3333-4444-555555555555")
+
+    mock_enrich.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_load_and_enrich_passes_pg_state_to_enrich_document():
+    """The kwargs handed to _enrich_document come entirely from PG —
+    not from any caller-frozen state. This is the contract that closes
+    the audit-finding-1 race window.
+    """
+    fake_artifact = {
+        "artifact_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        "org_id": "org-pg",
+        "kb_slug": "kb-pg",
+        "path": "docs/p.md",
+        "user_id": "user-1",
+        "content_type": "kb_article",
+        "synthesis_depth": 2,
+        "assertion_mode": "factual",
+        "provenance_type": "extracted",
+        "confidence": None,
+        "belief_time_start": 0,
+        "belief_time_end": 253402300800,
+        "extra": {
+            "document_text": "# Title\n\nSome body.\n\n## Section\n\nMore body.\n",
+            "title": "Title",
+            "tags": ["onboarding"],
+            "source_type": "upload",
+        },
+    }
+
+    captured_kwargs: dict = {}
+
+    async def _fake_enrich(**kwargs) -> None:
+        captured_kwargs.update(kwargs)
+
+    with (
+        patch(
+            "knowledge_ingest.enrichment_tasks.pg_store.read_artifact_for_enrichment",
+            new_callable=AsyncMock,
+            return_value=fake_artifact,
+        ),
+        patch("knowledge_ingest.enrichment_tasks._enrich_document", side_effect=_fake_enrich),
+    ):
+        from knowledge_ingest.enrichment_tasks import _load_and_enrich
+
+        await _load_and_enrich("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+
+    # The downstream call MUST receive the PG-sourced fields verbatim
+    assert captured_kwargs["org_id"] == "org-pg"
+    assert captured_kwargs["kb_slug"] == "kb-pg"
+    assert captured_kwargs["path"] == "docs/p.md"
+    assert captured_kwargs["user_id"] == "user-1"
+    assert captured_kwargs["synthesis_depth"] == 2
+    assert captured_kwargs["content_type"] == "kb_article"
+    assert captured_kwargs["title"] == "Title"
+    assert captured_kwargs["artifact_id"] == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+    # document_text is the canonical body that the worker re-chunks
+    assert "# Title" in captured_kwargs["document_text"]
+    assert "## Section" in captured_kwargs["document_text"]
+
+    # chunks list is non-empty and derived from the body
+    assert isinstance(captured_kwargs["chunks"], list)
+    assert len(captured_kwargs["chunks"]) >= 1
+    # Parents should also be derived
+    assert isinstance(captured_kwargs["parents"], list)
+    assert isinstance(captured_kwargs["parent_index_per_child"], list)
+    assert len(captured_kwargs["parent_index_per_child"]) == len(captured_kwargs["chunks"])
+
+    # extra_payload is the *current* PG extra — not a frozen task arg
+    assert captured_kwargs["extra_payload"]["tags"] == ["onboarding"]
+    assert captured_kwargs["extra_payload"]["source_type"] == "upload"
+
+
+# ---------------------------------------------------------------------------
+# Smoke test on the task variants — confirm signature accepts only artifact_id
+# ---------------------------------------------------------------------------
+
+
+def test_task_variants_have_single_arg_signature():
+    """SPEC-INGEST-CONTENT-PG-001: the public task signature must be
+    ``(artifact_id: str)`` — anything else means task-args still carry
+    content and the audit finding 1 race regression is back.
+    """
+    import inspect
+
+    from knowledge_ingest import enrichment_tasks
+
+    # We can introspect the underlying functions via _register_tasks's
+    # inner closures. The simplest contract: the enrich variants are
+    # exposed on the procrastinate app object after init. Here we only
+    # verify the inner shim signature, which the task wrappers call.
+    sig = inspect.signature(enrichment_tasks._load_and_enrich)
+    params = list(sig.parameters.values())
+    assert len(params) == 1, f"_load_and_enrich must take 1 param, got {params}"
+    assert params[0].name == "artifact_id"

--- a/klai-knowledge-ingest/tests/test_ingest_content_hash_dedup.py
+++ b/klai-knowledge-ingest/tests/test_ingest_content_hash_dedup.py
@@ -6,6 +6,7 @@ current active artifact, ingest_document() must return early with
 {"status": "skipped", "reason": "content unchanged"} without performing
 any chunking, embedding, or Qdrant upserts.
 """
+
 from __future__ import annotations
 
 import hashlib
@@ -15,10 +16,10 @@ import pytest
 
 from knowledge_ingest.models import IngestRequest
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_request(content: str = "# Hello\nWorld") -> IngestRequest:
     return IngestRequest(
@@ -39,21 +40,26 @@ def _sha256(text: str) -> str:
 # Tests
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_skips_when_content_unchanged():
     """ingest_document returns 'skipped' without calling embed when hash matches."""
     req = _make_request()
     stored_hash = _sha256(req.content)
 
-    with patch(
-        "knowledge_ingest.pg_store.get_active_content_hash",
-        new_callable=AsyncMock,
-        return_value=stored_hash,
-    ), patch(
-        "knowledge_ingest.embedder.embed",
-        new_callable=AsyncMock,
-    ) as mock_embed:
+    with (
+        patch(
+            "knowledge_ingest.pg_store.get_active_content_hash",
+            new_callable=AsyncMock,
+            return_value=stored_hash,
+        ),
+        patch(
+            "knowledge_ingest.embedder.embed",
+            new_callable=AsyncMock,
+        ) as mock_embed,
+    ):
         from knowledge_ingest.routes.ingest import ingest_document
+
         result = await ingest_document(req)
 
     assert result["status"] == "skipped"
@@ -72,45 +78,58 @@ async def test_proceeds_when_content_changed():
     mock_pool.fetchval = AsyncMock(return_value=None)
     mock_pool.fetchrow = AsyncMock(return_value=None)
 
-    with patch(
-        "knowledge_ingest.pg_store.get_active_content_hash",
-        new_callable=AsyncMock,
-        return_value=old_hash,  # different from current content
-    ), patch(
-        "knowledge_ingest.pg_store.soft_delete_artifact",
-        new_callable=AsyncMock,
-    ), patch(
-        "knowledge_ingest.pg_store.create_artifact",
-        new_callable=AsyncMock,
-        return_value="artifact-uuid-1",
-    ), patch(
-        "knowledge_ingest.embedder.embed",
-        new_callable=AsyncMock,
-        return_value=[[0.1] * 10],
-    ), patch(
-        "knowledge_ingest.qdrant_store.upsert_chunks",
-        new_callable=AsyncMock,
-    ), patch(
-        "knowledge_ingest.org_config.is_enrichment_enabled",
-        new_callable=AsyncMock,
-        return_value=False,
-    ), patch(
-        "knowledge_ingest.routes.ingest.kb_config.get_kb_visibility",
-        new_callable=AsyncMock,
-        return_value="internal",
-    ), patch(
-        "knowledge_ingest.routes.ingest.get_pool",
-        new_callable=AsyncMock,
-        return_value=mock_pool,
-    ), patch(
-        "knowledge_ingest.routes.ingest.settings"
-    ) as mock_settings:
+    with (
+        patch(
+            "knowledge_ingest.pg_store.get_active_content_hash",
+            new_callable=AsyncMock,
+            return_value=old_hash,  # different from current content
+        ),
+        patch(
+            "knowledge_ingest.pg_store.soft_delete_artifact",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "knowledge_ingest.pg_store.create_artifact",
+            new_callable=AsyncMock,
+            return_value="artifact-uuid-1",
+        ),
+        patch(
+            "knowledge_ingest.pg_store.update_artifact_extra",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "knowledge_ingest.embedder.embed",
+            new_callable=AsyncMock,
+            return_value=[[0.1] * 10],
+        ),
+        patch(
+            "knowledge_ingest.qdrant_store.upsert_chunks",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "knowledge_ingest.org_config.is_enrichment_enabled",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "knowledge_ingest.routes.ingest.kb_config.get_kb_visibility",
+            new_callable=AsyncMock,
+            return_value="internal",
+        ),
+        patch(
+            "knowledge_ingest.routes.ingest.get_pool",
+            new_callable=AsyncMock,
+            return_value=mock_pool,
+        ),
+        patch("knowledge_ingest.routes.ingest.settings") as mock_settings,
+    ):
         mock_settings.graphiti_enabled = False
         mock_settings.chunk_size = 1500
         mock_settings.chunk_overlap = 200
         mock_settings.enrichment_enabled = False
 
         from knowledge_ingest.routes.ingest import ingest_document
+
         result = await ingest_document(req)
 
     assert result["status"] == "ok"
@@ -126,45 +145,58 @@ async def test_proceeds_when_no_previous_artifact():
     mock_pool.fetchval = AsyncMock(return_value=None)
     mock_pool.fetchrow = AsyncMock(return_value=None)
 
-    with patch(
-        "knowledge_ingest.pg_store.get_active_content_hash",
-        new_callable=AsyncMock,
-        return_value=None,  # no previous artifact
-    ), patch(
-        "knowledge_ingest.pg_store.soft_delete_artifact",
-        new_callable=AsyncMock,
-    ), patch(
-        "knowledge_ingest.pg_store.create_artifact",
-        new_callable=AsyncMock,
-        return_value="artifact-uuid-2",
-    ), patch(
-        "knowledge_ingest.embedder.embed",
-        new_callable=AsyncMock,
-        return_value=[[0.1] * 10],
-    ), patch(
-        "knowledge_ingest.qdrant_store.upsert_chunks",
-        new_callable=AsyncMock,
-    ), patch(
-        "knowledge_ingest.org_config.is_enrichment_enabled",
-        new_callable=AsyncMock,
-        return_value=False,
-    ), patch(
-        "knowledge_ingest.routes.ingest.kb_config.get_kb_visibility",
-        new_callable=AsyncMock,
-        return_value="internal",
-    ), patch(
-        "knowledge_ingest.routes.ingest.get_pool",
-        new_callable=AsyncMock,
-        return_value=mock_pool,
-    ), patch(
-        "knowledge_ingest.routes.ingest.settings"
-    ) as mock_settings:
+    with (
+        patch(
+            "knowledge_ingest.pg_store.get_active_content_hash",
+            new_callable=AsyncMock,
+            return_value=None,  # no previous artifact
+        ),
+        patch(
+            "knowledge_ingest.pg_store.soft_delete_artifact",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "knowledge_ingest.pg_store.create_artifact",
+            new_callable=AsyncMock,
+            return_value="artifact-uuid-2",
+        ),
+        patch(
+            "knowledge_ingest.pg_store.update_artifact_extra",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "knowledge_ingest.embedder.embed",
+            new_callable=AsyncMock,
+            return_value=[[0.1] * 10],
+        ),
+        patch(
+            "knowledge_ingest.qdrant_store.upsert_chunks",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "knowledge_ingest.org_config.is_enrichment_enabled",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "knowledge_ingest.routes.ingest.kb_config.get_kb_visibility",
+            new_callable=AsyncMock,
+            return_value="internal",
+        ),
+        patch(
+            "knowledge_ingest.routes.ingest.get_pool",
+            new_callable=AsyncMock,
+            return_value=mock_pool,
+        ),
+        patch("knowledge_ingest.routes.ingest.settings") as mock_settings,
+    ):
         mock_settings.graphiti_enabled = False
         mock_settings.chunk_size = 1500
         mock_settings.chunk_overlap = 200
         mock_settings.enrichment_enabled = False
 
         from knowledge_ingest.routes.ingest import ingest_document
+
         result = await ingest_document(req)
 
     assert result["status"] == "ok"
@@ -183,44 +215,57 @@ async def test_content_hash_stored_on_create():
 
     mock_create = AsyncMock(return_value="artifact-uuid-3")
 
-    with patch(
-        "knowledge_ingest.pg_store.get_active_content_hash",
-        new_callable=AsyncMock,
-        return_value=None,
-    ), patch(
-        "knowledge_ingest.pg_store.soft_delete_artifact",
-        new_callable=AsyncMock,
-    ), patch(
-        "knowledge_ingest.pg_store.create_artifact",
-        mock_create,
-    ), patch(
-        "knowledge_ingest.embedder.embed",
-        new_callable=AsyncMock,
-        return_value=[[0.1] * 10],
-    ), patch(
-        "knowledge_ingest.qdrant_store.upsert_chunks",
-        new_callable=AsyncMock,
-    ), patch(
-        "knowledge_ingest.org_config.is_enrichment_enabled",
-        new_callable=AsyncMock,
-        return_value=False,
-    ), patch(
-        "knowledge_ingest.routes.ingest.kb_config.get_kb_visibility",
-        new_callable=AsyncMock,
-        return_value="internal",
-    ), patch(
-        "knowledge_ingest.routes.ingest.get_pool",
-        new_callable=AsyncMock,
-        return_value=mock_pool,
-    ), patch(
-        "knowledge_ingest.routes.ingest.settings"
-    ) as mock_settings:
+    with (
+        patch(
+            "knowledge_ingest.pg_store.get_active_content_hash",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "knowledge_ingest.pg_store.soft_delete_artifact",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "knowledge_ingest.pg_store.create_artifact",
+            mock_create,
+        ),
+        patch(
+            "knowledge_ingest.pg_store.update_artifact_extra",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "knowledge_ingest.embedder.embed",
+            new_callable=AsyncMock,
+            return_value=[[0.1] * 10],
+        ),
+        patch(
+            "knowledge_ingest.qdrant_store.upsert_chunks",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "knowledge_ingest.org_config.is_enrichment_enabled",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "knowledge_ingest.routes.ingest.kb_config.get_kb_visibility",
+            new_callable=AsyncMock,
+            return_value="internal",
+        ),
+        patch(
+            "knowledge_ingest.routes.ingest.get_pool",
+            new_callable=AsyncMock,
+            return_value=mock_pool,
+        ),
+        patch("knowledge_ingest.routes.ingest.settings") as mock_settings,
+    ):
         mock_settings.graphiti_enabled = False
         mock_settings.chunk_size = 1500
         mock_settings.chunk_overlap = 200
         mock_settings.enrichment_enabled = False
 
         from knowledge_ingest.routes.ingest import ingest_document
+
         await ingest_document(req)
 
     call_kwargs = mock_create.call_args.kwargs


### PR DESCRIPTION
## Audit finding 1: stale-content race in direct-POST flow

The Procrastinate enrichment task currently freezes the document body and all derived metadata into its job arguments at `defer_async` time. A second direct-POST that arrives within the (typically seconds-long) worker pickup window writes new raw vectors to Qdrant — but the worker still processes the older content from its frozen args, **overwriting the new vectors with stale enrichment**.

SPEC: [.moai/specs/SPEC-INGEST-CONTENT-PG-001/spec.md](https://github.com/GetKlai/klai/blob/feature/SPEC-INGEST-CONTENT-PG-001/.moai/specs/SPEC-INGEST-CONTENT-PG-001/spec.md)

## The fix in one sentence

Task takes only `artifact_id`; worker re-reads canonical state from PostgreSQL at execution time. Same pattern as the Gitea-webhook flow already uses, same pattern as LlamaIndex's docstore + worker model.

## What changes

| File | Change |
|---|---|
| `pg_store.py` | New `read_artifact_for_enrichment(artifact_id)` — returns row + parsed `extra` JSONB, or `None` if missing. |
| `enrichment_tasks.py` | New `_load_and_enrich(artifact_id)` shim that reads PG, soft-skips on missing artifact / missing `document_text`, re-derives chunks + parents from the *current* body, and delegates to unchanged `_enrich_document`. |
| `enrichment_tasks.py` | `enrich_document_interactive` + `enrich_document_bulk` task signatures simplified to `(artifact_id: str)`. |
| `routes/ingest.py` | `pg_store.update_artifact_extra(artifact_id, extra_payload)` before defer; `defer_async(artifact_id=...)` only. |
| `enrichment_tasks.py` | Pre-existing G201 chore: `logger.error(..., exc_info=True)` → `logger.exception(...)`. |
| `tests/test_enrichment_loads_from_pg.py` | 8 new tests — read getter contract, soft-skip semantics, full-state delegation, signature contract. |
| Existing dedup tests | Mock additions for `update_artifact_extra`, `graphiti_enabled = False` to focus on enrichment-defer contract. |

## What this PR does NOT do

- No backwards-compat for in-flight tasks (Mark confirmed: no production load yet, re-ingest is the recovery path).
- No schema migration (`knowledge.artifacts.extra` JSONB shape is already a superset).
- No refactor of `_enrich_document`'s body — it still accepts the same kwargs; only the *source* of those kwargs moves from task-args to PG.

## Companion to PR #395

[#395](https://github.com/GetKlai/klai/pull/395) closes the *active-row uniqueness* race in Phase-1 (audit finding 7). This PR closes the *content-staleness* race in Phase-2. Orthogonal — both can land independently.

## Verification

- 29 tests green in this PR's regression set:
  - 8 new tests in `test_enrichment_loads_from_pg.py`
  - `test_ingest_content_hash_dedup.py`, `test_ingest_enrichment_dedup.py`, `test_enrichment_dedup.py`, `test_chunker_parent_child.py`
- ruff check + ruff format --check clean

## Confidence: 90

The fix is the right shape (matches the Gitea-flow pattern that already works), and the worker re-read is verified to produce the same kwargs that the existing `_enrich_document` body expects. The 10 percent reservation: I have not yet smoke-tested two-rapid-POST end-to-end against a real PG + Qdrant + worker — that's acceptance criterion 5, manual on first deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)