### PR TITLE
docs(architecture): post-audit refresh of retrieval/ingest/knowledge docs

### DIFF
--- a/docs/architecture/klai-knowledge-architecture.md
+++ b/docs/architecture/klai-knowledge-architecture.md
@@ -4,7 +4,9 @@
 >
 > Source synthesis: `helpdesk-extractie-pipeline.md` (2026-03-18) + `Sovereign Knowledge, Augmented` (2026-01-13). The helpdesk pipeline is now treated as one ingestion adapter, not the product goal. The product goal is Klai Knowledge.
 >
-> *Last updated: 2026-03-30. For platform-wide infrastructure and stack decisions, see [architecture/platform.md](platform.md). For the research backing evidence-weighted scoring (§7.4) and assertion mode weights (§3.2, §13.4), see [Evidence-Weighted Knowledge Retrieval: Research Synthesis](../research/README.md).*
+> *Last updated: 2026-05-06 (post retrieval-coupling audit). For platform-wide infrastructure and stack decisions, see [architecture/platform.md](platform.md). For the research backing evidence-weighted scoring (§7.4) and assertion mode weights (§3.2, §13.4), see [Evidence-Weighted Knowledge Retrieval: Research Synthesis](../research/README.md).*
+>
+> *2026-05-06: §2 rewritten to remove the "Two products, one infrastructure" framing — Klai Focus / research-api was decommissioned by `SPEC-PORTAL-UNIFY-KB-001` (April 2026) and `SPEC-DECOMM-FOCUS-001` (May 2026). Klai Knowledge is now the single knowledge product. §7.4 evidence-tier activation track aligned with `SPEC-EVIDENCE-001-FOLLOWUP-001`.*
 
 ---
 
@@ -122,140 +124,75 @@ The BlockNote editor **currently lives in `klai-portal`** (frontend SPA). It was
 
 ## 2. Platform Service Architecture
 
-Klai Knowledge does not exist in isolation. It is one of two knowledge-oriented products on the platform. Understanding the boundary between them — and what they share — is a prerequisite for building either correctly.
+Klai Knowledge is the platform's single knowledge product. The earlier "Klai Focus + Klai Knowledge" two-product framing was unwound by `SPEC-PORTAL-UNIFY-KB-001` (April 2026) and `SPEC-DECOMM-FOCUS-001` (May 2026). The historical Focus narrative (notebook-based research, `notebook_*` scopes, hybrid `broad` mode) is preserved only in those two SPECs and the git history; this document describes the current state.
 
-### 2.1 Two products, one infrastructure layer
+### 2.1 Knowledge as a single product on shared infrastructure
 
-**Klai Focus** is a notebook-based research tool. A user assembles a specific set of documents, works with them intensively, and extracts insights. It is ephemeral and task-scoped. The outcome of a Focus session is a conclusion, a synthesis, a decision.
-
-**Klai Knowledge** is the organizational memory layer. It is persistent, curated, and broad. It accumulates what the organization knows over time. It is not a workspace — it is a record.
-
-These are complementary, not competing. The intended flow is:
-
-```
-Focus (narrow research on specific files)
-  → user reaches a conclusion
-  → "Save to Knowledge" action
-  → knowledge_artifact lands in personal or org scope
-  → optionally promoted to org KB
-```
-
-### 2.2 Shared infrastructure layer
-
-Both products run on top of shared platform services. Neither owns these services — they call them.
+Klai Knowledge is the organizational memory layer: persistent, curated, broad. It accumulates what the organization knows over time. There is no separate ephemeral notebook product — `/app/focus/*` redirects to `/app/knowledge`, and personal-notes-style use cases live as personal-scope knowledge artifacts.
 
 ```
 ┌─────────────────────────────────────────────────────────┐
 │                  Shared Platform Services                │
 │                                                         │
-│  embedding-service   BGE-M3 via FlagEmbedding           │
-│                      one HTTP service, called by both   │
-│                                                         │
-│  chunking-service    docling-serve HybridChunker        │
-│                      one HTTP service, called by both   │
-│                                                         │
-│  Qdrant cluster      one instance, scoped by tenant_id  │
-│                      all scopes live here               │
+│  TEI (embeddings)      BGE-M3 dense + bge-m3-sparse     │
+│  Infinity (reranker)   bge-reranker-v2-m3               │
+│  docling-serve         HybridChunker                    │
+│  Qdrant                klai_knowledge collection only   │
+│  FalkorDB              Graphiti knowledge graph         │
 └─────────────────────────────────────────────────────────┘
-          ▲                            ▲
-          │                            │
-┌─────────────────┐          ┌──────────────────────┐
-│  Focus Service  │          │  Knowledge Service   │
-│  /research/v1   │  calls   │  /knowledge/v1       │
-│                 │─────────▶│  Retrieval API       │
-│  (broad mode)   │          │                      │
-└─────────────────┘          └──────────────────────┘
+          ▲
+          │
+┌──────────────────────┐
+│  Knowledge Service   │
+│  retrieval-api +     │
+│  knowledge-ingest    │
+│                      │
+│  POST /retrieve      │
+│  POST /ingest        │
+└──────────────────────┘
 ```
 
-### 2.7 LibreChat integration via LiteLLM hook
+### 2.2 LibreChat + Partner API integration via LiteLLM hook
 
-LibreChat tenants access organizational knowledge automatically through a pre-call hook in the LiteLLM proxy. This is the primary consumer interface for §9.5.
+LibreChat tenants and Partner-API consumers reach knowledge automatically through a pre-call hook in the LiteLLM proxy. This is the primary consumer interface for §9.
 
 ```
-LibreChat-{slug} container
-  │  LITELLM_API_KEY = team-scoped key (metadata: org_id)
-  ▼
-LiteLLM proxy (klai-core stack)
-  │  KlaiKnowledgeHook.async_pre_call_hook
-  │    ├── trivial? → skip
-  │    ├── GET org_id from key metadata
-  │    └── POST /knowledge/v1/retrieve  (2s timeout, graceful degrade)
-  ▼
-klai-primary / klai-fast / klai-large (per .claude/rules/klai/platform/litellm.md)
+LibreChat-{slug} container          Partner-API consumer / Widget
+  │  LITELLM_API_KEY (org_id)         │  pk_live_... or widget JWT
+  ▼                                   ▼
+                LiteLLM proxy (klai-core)
+                  │  KlaiKnowledgeHook.async_pre_call_hook
+                  │    ├── trivial? → skip
+                  │    ├── resolve identity:
+                  │    │    LibreChat   → real Zitadel user_id
+                  │    │    Partner/Widget → synthetic `partner:<key_id>`
+                  │    └── POST /retrieve  (3s timeout, graceful degrade)
+                  ▼
+                klai-primary / klai-fast / klai-large
 ```
 
-Tenant isolation: one LiteLLM team key per LibreChat container, carrying `org_id` in key metadata. The hook uses this to scope every retrieval query. Containers provisioned before this change (using master key) will skip retrieval — no breakage, no context injection.
-
-**No tech stack duplication.** If Focus chunks a PDF, it calls the shared chunking-service. If Knowledge chunks a help article, it calls the same service. BGE-M3 runs once. Qdrant runs once.
+Tenant isolation: one LiteLLM team key per LibreChat container, carrying `org_id` in metadata. The hook uses this to scope every retrieval query. Partner-API and widget traffic carries an explicit `org_id` from the partner key's owning tenant (validated via portal `/internal/identity/verify` against `partner_api_keys` — see [knowledge-retrieval-flow.md § Identity verification](knowledge-retrieval-flow.md#identity-verification-on-every-retrieve-call)).
 
 ### 2.3 Qdrant scope conventions
 
-All scopes live in one Qdrant collection with `tenant_id` payload indexing.
+All knowledge lives in the `klai_knowledge` Qdrant collection with `org_id` payload indexing. Scope identifiers use Zitadel IDs — the stable cross-system identifiers available on `PortalOrg.zitadel_org_id` and `PortalUser.zitadel_user_id`. Not PostgreSQL integer PKs, not UUIDs.
 
-**Scope identifiers use Zitadel IDs** — the stable cross-system identifiers available on `PortalOrg.zitadel_org_id` and `PortalUser.zitadel_user_id`. Not PostgreSQL integer PKs (internal only), not UUIDs (no UUID column exists on these models).
-
-| `tenant_id` pattern | Owner | Used by |
+| Payload field | Scope semantic | Set by |
 |---|---|---|
-| `org_{zitadel_org_id}` | Organization | Knowledge Service (org KB) |
-| `user_{zitadel_org_id}_{zitadel_user_id}` | User | Knowledge Service (personal KB) |
-| `notebook_{notebook_uuid}` | User | Focus Service |
-| `gap_{zitadel_org_id}` | Organization | Knowledge Service (gap registry) |
-
-Focus owns the `notebook_*` scopes. Knowledge owns the rest. Neither reads the other's scopes directly — cross-scope retrieval goes through the owning service's API.
+| `org_id` | Organization (always required) | knowledge-ingest at upsert |
+| `user_id` | Personal scope (optional, only on personal artifacts) | knowledge-ingest |
+| `visibility` | `public` / `internal` / `private` (per-chunk) | knowledge-ingest from KB config |
+| `kb_slug` | Per-KB partition within an org | knowledge-ingest |
 
 **Interface-to-scope mapping:**
 
 | Interface | Org scope | Personal scope | Notes |
 |---|---|---|---|
-| LiteLLM pre-call hook | Yes (`org_{zitadel_org_id}`) | No | Automatic enrichment; no user identity available at this layer |
+| LiteLLM pre-call hook (LibreChat) | Yes (`org` or `both`) | Yes when `kb_personal_enabled=true` | KBScopeBar controls scope |
+| LiteLLM pre-call hook (Partner/Widget) | Yes (`org` only) | No | Scope-locked at credential creation |
 | MCP server tools | Yes | Yes | Explicit user action; Zitadel session provides both IDs |
 
-The hook retrieves org scope only — the team key metadata carries `zitadel_org_id`, but the hook has no reliable way to obtain the Zitadel user ID from a shared-key LibreChat request. Personal scope retrieval and saving go through the MCP server, which runs within a Zitadel-authenticated session.
-
-### 2.4 Chat modes in Focus
-
-The three Focus modes map directly onto retrieval scope:
-
-| Mode | Retrieval scope |
-|---|---|
-| `narrow` | `notebook_{notebook_uuid}` only |
-| `broad` | `notebook_{notebook_uuid}` + Knowledge Service retrieval API (`org_{org_uuid}`) |
-| `web` | `broad` + web search (Tavily / Brave) |
-
-`broad` mode is a hybrid retrieval call: Focus retrieves from its notebook scope in parallel with a call to the Knowledge retrieval API for the org scope. Results are merged with RRF before being passed to the LLM.
-
-This means **Focus broad mode is already a consumer of Klai Knowledge** — by design, not by accident. When the org KB has no relevant content yet, broad falls back gracefully to notebook-only results.
-
-### 2.5 The "Save to Knowledge" action
-
-A Focus session produces insights. Those insights should not die in the notebook. The "Save to Knowledge" action promotes a user-written synthesis from Focus into Klai Knowledge:
-
-```
-User writes conclusion in Focus chat or as a note
-  → "Save to Knowledge" (personal) or "Share to org KB"
-  → POST to Knowledge Service
-  → knowledge_artifact created with:
-      provenance_type: synthesized
-      synthesis_depth: 1
-      derived_from: [source UUIDs from the notebook]
-      assertion_mode: factual | belief | hypothesis (user selects)
-  → lands in user_{org_uuid}_{user_uuid} (personal) or org_{org_uuid} (org)
-```
-
-The notebook sources that fed the synthesis become the `derived_from` chain — the provenance is preserved automatically.
-
-### 2.6 What the Focus rewrite requires
-
-The current `/research/v1` backend has its own chunking and embedding pipeline. That is the duplication to remove.
-
-Concrete changes:
-1. Remove own chunking code → call shared chunking-service
-2. Remove own embedding code → call shared embedding-service
-3. Remove own Qdrant connection → use shared cluster with `notebook_{uuid}` scope
-4. Implement `broad` mode as hybrid retrieval: notebook scope + Knowledge retrieval API, merged with RRF
-5. Add "Save to Knowledge" endpoint: POST synthesis → Knowledge Service
-
-The Focus data model (notebooks, sources, history) stays in Focus's own PostgreSQL schema. Only the vector pipeline moves to shared infrastructure.
+`scope=notebook` and `scope=broad` were the integration points with the now-decommissioned Focus service. Both literals were removed from `RetrieveRequest` in `SPEC-DECOMM-FOCUS-001`; the only valid scopes today are `personal`, `org`, `both`.
 
 ---
 
@@ -811,46 +748,48 @@ The cross-encoder reads query + document together and assesses relevance at clai
 
 ### 7.4 Evidence-weighted scoring [LIVE — shadow mode]
 
-> Research backing: [Evidence-Weighted Knowledge Retrieval: Research Synthesis](../research/README.md)
+> Research backing: [Evidence-Weighted Knowledge Retrieval: Research Synthesis](../research/README.md). Activation track: [`SPEC-EVIDENCE-001-FOLLOWUP-001`](../../.moai/specs/SPEC-EVIDENCE-001-FOLLOWUP-001/spec.md). User-facing flow: [knowledge-retrieval-flow.md § Evidence tier scoring](knowledge-retrieval-flow.md#step-6-evidence-tier-scoring-shadow-mode).
 
 Evidence-weighted scoring runs in Step 6 of the retrieval pipeline. Currently in shadow mode (`EVIDENCE_SHADOW_MODE=true`): scores are computed and logged but do not reorder results. This is a **post-retrieval scoring adjustment**, not a replacement for semantic search.
 
-**Four scoring dimensions:**
+**Four scoring dimensions (multiplicative, each per-dimension feature-flagged):**
 
-| Dimension | Signal | V1 approach | Research evidence |
+| Dimension | Signal | V1 approach | Feature flag |
 |---|---|---|---|
-| Content type | `content_type` (kb_article, crawl, transcript, ...) | Tier-based weight: curated KB articles > web crawls > raw transcripts | RA-RAG: +51% accuracy; TREC Health: +60% MAP via credibility-weighted fusion |
-| Assertion mode | `assertion_mode` (factual, procedural, ...) | **Flat weights (all 1.00)** — activate only after A/B evaluation | Concept is novel — no empirical data for RAG specifically. See [Assertion Mode Weights research](../research/assertion-modes/assertion-mode-weights.md) |
-| Temporal decay | `ingested_at` / `belief_time_start` | Conservative linear decay, max 0.15 spread (0.85–1.00) | Conceptually sound but calibration is unsolved |
-| Chunk ordering | Position in context window | U-shape: strongest chunks first and last, weakest in middle | Lost in the Middle (Liu et al. 2023): >30% accuracy degradation for mid-positioned relevant content |
+| Content type | `content_type` (kb_article, pdf_document, web_crawl, ...) | Per-type weight, see table below | `EVIDENCE_CONTENT_TYPE_ENABLED` (default `true`) |
+| Temporal decay | `ingested_at` age | Step function across <30d / 30-180d / 180-365d / >365d brackets | `EVIDENCE_TEMPORAL_DECAY_ENABLED` (default `true`) |
+| PageRank | `entity_pagerank_max` from FalkorDB | `1 + 0.20 * log1p(pagerank * 100)` — capped ~+25% | `EVIDENCE_PAGERANK_ENABLED` (default `true`) |
+| Assertion mode | `assertion_mode` (factual, procedural, ...) | **Flat weights (all 1.00)** — activate via `SPEC-EVIDENCE-002` after A/B | `EVIDENCE_ASSERTION_MODE_ENABLED` (default `true`, but flat-weights neuter the effect) |
 
-**Why flat weights for assertion mode:**
+After scoring, chunks are reordered into a **U-shape** (strongest at position 0, second-strongest at the last position, mid-strength clustered in the middle) per Liu et al. 2023 "Lost in the Middle" ([arXiv:2307.03172](https://arxiv.org/abs/2307.03172)).
 
-The [weights research](../research/assertion-modes/assertion-mode-weights.md) established that the maximum safe weight spread for an ~85% accurate classifier is **0.20** (minimum weight 0.80 if maximum is 1.00). With four multiplicative scoring dimensions at ~85% accuracy each, there is a 48% chance of at least one misclassification per chunk. Starting flat eliminates this compounding risk.
-
-**Evaluation gate before widening weights:**
-
-1. 200+ chunk classification evaluation on Klai content (not biomedical proxy data)
-2. A/B retrieval test: 150 queries (50 curated + 100 RAGAS-synthetic), Wilcoxon signed-rank test
-3. Shadow scoring in production before cutover
-
-See [RAG Evaluation Framework](../research/evaluation/rag-evaluation-framework.md) for the full evaluation protocol.
-
-**Formula (V1):**
+**Formula:**
 
 ```
-evidence_score = base_rrf_score × content_type_weight × temporal_decay
+final_score = reranker_score × content_type_weight × assertion_mode_weight × temporal_decay × pagerank_weight
 ```
 
-Assertion mode and corroboration are **not multiplied in V1** — they are logged for shadow evaluation only.
+**Content type weights (production defaults):**
 
-**Content type tier mapping:**
+| Content type | Weight |
+|---|---|
+| `kb_article` | 1.00 |
+| `pdf_document` | 0.90 |
+| `meeting_transcript`, `1on1_transcript` | 0.80 |
+| `graph_edge` (Graphiti facts) | 0.70 |
+| `web_crawl` | 0.65 |
+| `unknown` (fallback) | 0.55 |
 
-| Tier | Content types | Weight |
-|---|---|---|
-| Tier 1 — Curated | `kb_article`, `procedure` | 1.00 |
-| Tier 2 — Structured | `faq`, `api_doc`, `changelog` | 0.95 |
-| Tier 3 — Imported | `web_crawl`, `email`, `transcript` | 0.90 |
+**Activation track (post-audit, SPEC-EVIDENCE-001-FOLLOWUP-001):** the shadow mode has been the default since 2026-03-30. The follow-up SPEC sets a 30-day deadline to choose one of four terminal states using a 7-day RAGAS A/B (`baseline` vs. `evidence_tier_full` vs. `evidence_tier_temporal_only`):
+
+1. **Activate** — staged 5%/50%/100% rollout with auto-revert on quality regression
+2. **Activate temporal-only** — narrow rollout of the dimension with strongest theoretical justification
+3. **Decommission** — remove `evidence_tier.apply()` + payload fields, free up CPU
+4. **Retain-flags-off** — `EVIDENCE_SHADOW_MODE=disabled` becomes the new default, code preserved
+
+Decision criteria: ≥+0.02 mean uplift on RAGAS Context Precision **and** Faithfulness with Wilcoxon paired `p<0.05` against baseline on the 50-curated query subset.
+
+**Assertion mode weight activation** is governed by a separate SPEC (`SPEC-EVIDENCE-002`) — it remains flat-1.00 in V1 even after the FOLLOWUP-001 decision because the multiplicative compounding risk (4 dimensions at ~85% classifier accuracy → 48% chance of misclassification per chunk) demands its own calibration cycle. See [Assertion Mode Weights research](../research/assertion-modes/assertion-mode-weights.md).
 
 **Corroboration scoring: deferred.** Cross-source corroboration requires three prerequisites not yet met: near-duplicate detection (SemHash), source-level grouping, and entity resolution validation (>90% precision, >85% recall). See [Corroboration Scoring research](../research/corroboration/corroboration-scoring.md).
 
@@ -1476,7 +1415,7 @@ No existing tool combines: Notion-quality web editor + Git as storage + wikilink
 - LibreChat webSearch enabled: SearXNG + Firecrawl scraper + Infinity reranker (bge-reranker-v2-m3, CPU)
 - Infinity reranker is shared infrastructure — will also serve the Knowledge retrieval pipeline (§7.1) when deployed
 
-The platform currently uses SearXNG (self-hosted, `http://searxng:8888`) for web search in LibreChat and Klai Focus. Web search is a user-initiated, opt-in action — not part of the Knowledge ingestion pipeline.
+The platform currently uses SearXNG (self-hosted, `http://searxng:8888`) for web search in LibreChat. Web search is a user-initiated, opt-in action — not part of the Knowledge ingestion pipeline.
 
 **Platform constraint:** all components must be open-source and privacy-friendly. Cloud APIs that send queries to US companies (Tavily, Brave Search API) are excluded regardless of GDPR compliance claims.
 

--- a/docs/architecture/knowledge-ingest-flow.md
+++ b/docs/architecture/knowledge-ingest-flow.md
@@ -927,6 +927,13 @@ link-graph signals are applied before reranking:
   important — this boost surfaces them ahead of equally-similar but less-linked pages.
   Default `link_authority_boost = 0.05` (configurable per deployment).
 
+> **Instrumentation (F3 phase 1, audit retrieval-coupling-2026-05-06):** the
+> `retrieval_decision_record` log entry carries a `link_expand` block measuring how
+> many expanded chunks survive the reranker into the served top-K
+> (`expanded_in_top_k`, `seed_in_top_k`, `expanded_top_k_chunk_ids`). Phase 2 (whether
+> to migrate to RRF-merge across dense/authority/expansion ranklists, recalibrate the
+> coefficient, or disable) is gated on ~7 days of this telemetry.
+
 **4b. Rerank.** The top candidates are reranked by `infinity-reranker`
 (bge-reranker-v2-m3 on GPU — gpu-01 via SSH tunnel at 172.18.0.1:7998). The reranker applies a cross-attention model that scores
 each (query, chunk) pair more precisely than vector distance alone. Top 5–10 survive.
@@ -1369,6 +1376,17 @@ The [evidence-weighted knowledge research programme](../research/README.md) inve
 6. **Corroboration scoring: deferred.** Three prerequisites must be met first: near-duplicate detection (SemHash), source-level grouping (`source_document_id`), and entity resolution validation (>90% precision, >85% recall). See [Corroboration Scoring](../research/corroboration/corroboration-scoring.md).
 
 **Evaluation protocol before activating weights:** 150 test queries (50 curated + 100 RAGAS-synthetic), Context Precision + NDCG@10 + Faithfulness metrics, Wilcoxon signed-rank paired tests, shadow scoring before cutover. See [RAG Evaluation Framework](../research/evaluation/rag-evaluation-framework.md).
+
+> **The existing evidence-tier scoring** (content_type / temporal_decay / pagerank
+> weights, U-shape ordering) shipped in shadow mode in March 2026 and is governed by
+> a separate activation track — `SPEC-EVIDENCE-001-FOLLOWUP-001` (audit
+> retrieval-coupling-2026-05-06). That SPEC sets a 30-day deadline to either activate
+> (5%/50%/100% staged rollout), activate `evidence_tier_temporal_only`, decommission,
+> or move to `EVIDENCE_SHADOW_MODE=disabled`. The `RAG_EVAL_VARIANT` mechanism from
+> `SPEC-RAG-EVAL-001` (#369) is what runs the A/B. See
+> [knowledge-retrieval-flow.md § Evidence tier scoring](knowledge-retrieval-flow.md#step-6-evidence-tier-scoring-shadow-mode).
+> The assertion-mode activation discussed in this section is the *next* dimension on
+> top of that — its own gating by `SPEC-EVIDENCE-002` is independent.
 
 ### Remaining open questions
 

--- a/docs/architecture/knowledge-retrieval-flow.md
+++ b/docs/architecture/knowledge-retrieval-flow.md
@@ -1,7 +1,7 @@
 # Knowledge Retrieval Flow: How Chat with Knowledge Works
 
 > Engineering reference for the full retrieval pipeline — from user preference to LLM context injection.
-> Verified against `klai-portal/`, `klai-retrieval-api/`, and `deploy/litellm/` — April 2026 (updated 2026-05-05).
+> Verified against `klai-portal/`, `klai-retrieval-api/`, and `deploy/litellm/` — April 2026 (updated 2026-05-06 post retrieval-coupling audit).
 >
 > For how knowledge is *stored* (ingestion, chunking, embedding), see
 > [knowledge-ingest-flow.md](knowledge-ingest-flow.md).
@@ -83,6 +83,37 @@ User types a message (LibreChat | Partner API consumer | chat widget on external
 
 Everything between "user sends message" and "model starts generating" happens in well
 under a second on a warm cache. The retrieval step itself typically takes 300–500ms.
+
+---
+
+## Identity verification on every `/retrieve` call
+
+retrieval-api authenticates and **verifies the body identity** on every call before
+running any pipeline work. Two trust gates are layered:
+
+1. **Service auth** — either `Authorization: Bearer <jwt>` (Zitadel-issued service
+   JWT with the `klai:internal:retrieval:query` scope) OR `X-Internal-Secret` matching
+   the rotation-bounded shared secret. Every internal-secret caller MUST also send
+   `X-Caller-Service: <known-service>`.
+2. **Body-vs-claim verification** — the `(claimed_user_id, claimed_org_id)` tuple
+   from the request body is verified against portal-api's
+   `/internal/identity/verify`. Three branches:
+
+   | Claim shape | Verification |
+   |---|---|
+   | Real Zitadel user (`claimed_user_id` is a Zitadel sub) | Active membership lookup against `portal_users` |
+   | Bearer JWT forwarded | JWT signature + `sub == claimed_user_id` AND `resourceowner == claimed_org_id` |
+   | **Partner API** synthetic identity (`claimed_user_id="partner:<key_id>"`) | `partner_api_keys` lookup; key's owning `org_id` must map to `claimed_org_id`. **Restricted to `caller_service="portal-api"`.** Other callers presenting the prefix get `partner_key_not_found`. |
+
+The verified tuple is pinned on `request.state.verified_caller`. `emit_event` for
+`knowledge.queried` reads from this pin — never from the body — so a tampered body
+cannot poison `product_events` (SPEC-SEC-IDENTITY-ASSERT-001 REQ-6).
+
+The partner-key branch (F2 fix-forward, audit retrieval-coupling-2026-05-06)
+intentionally lives in portal-api's `identity_verifier`, not in retrieval-api itself.
+An earlier in-process bypass in retrieval-api was removed because it allowed an
+attacker holding `X-Internal-Secret` to pin any `(partner:<key>, victim_org)` tuple
+without portal verification — collapsing the layered defense for partner traffic.
 
 ---
 
@@ -398,8 +429,37 @@ KB slug filter (when active):
 FalkorDB/Graphiti runs a graph traversal in parallel with the Qdrant search, resolving
 named entities in the query and traversing relationships to find conceptually connected
 chunks. Results are merged with Qdrant results using the same RRF formula before
-reranking. Timeout: 5 seconds. `GRAPHITI_ENABLED=true` on `retrieval-api` in production;
-disabled for `scope=notebook` (AC-6 in `retrieve.py`).
+reranking. Timeout: 5 seconds. `GRAPHITI_ENABLED=true` on `retrieval-api` in production.
+
+---
+
+### Step 4b: Link expansion + authority boost (SPEC-CRAWLER-003)
+
+**Simple:** When a top-ranked chunk links to other documents, those linked documents
+are pulled in as extra candidates. Documents that many other documents link to get a
+small ranking boost — the same logic that made PageRank work for the early web.
+
+**Technical:** Two separate mechanisms run after the initial Qdrant + graph search,
+before reranking:
+
+1. **1-hop link expansion** — for the top `link_expand_seed_k=10` chunks, the
+   `links_to` payload is mined for outbound URLs (capped at `link_expand_max_urls=30`).
+   `fetch_chunks_by_urls()` then scrolls Qdrant for chunks whose `source_url` matches
+   one of those URLs (`link_expand_candidates=20` cap), tagging each newly-added chunk
+   with an internal `_link_expanded=True` flag. Score starts at 0.0 — they earn their
+   way into the top-K through the authority boost and reranker.
+
+2. **Authority boost** — every chunk (seed or expanded) gets `score +=
+   link_authority_boost * log(1 + incoming_link_count)`. Default
+   `link_authority_boost=0.05`; a chunk with 100 incoming links gets ~+0.23 score
+   uplift.
+
+**Instrumentation (F3 phase 1, audit retrieval-coupling-2026-05-06):** the
+`retrieval_decision_record` log entry carries a `link_expand` block with `seed_k`,
+`candidate_urls`, `expanded_added`, `expanded_in_top_k`, `expanded_top_k_chunk_ids`,
+`seed_in_top_k`, `served_top_k`. This lets us measure how often expanded chunks
+actually survive into the served top-K vs. dying at the reranker cut-off — Phase 2
+(RRF migration vs. recalibrate boost vs. disable) waits on ~7 days of this data.
 
 ---
 
@@ -570,16 +630,59 @@ knowledge_ingest/rebuild_tasks.py`.
 
 ### Step 6: Evidence tier scoring (shadow mode)
 
-**Simple:** This is a work-in-progress layer that will eventually sort results by how
-*confidently* each chunk makes its claims — a direct assertion beats a vague statement.
-For now it runs silently and logs the scores without affecting what gets shown.
+**Simple:** A work-in-progress layer that re-weights results by source quality, recency,
+and graph centrality before optionally reordering for the LLM. It runs silently today —
+the weighted scores are computed and logged, but the flat reranker order is what gets
+served. A nightly RAGAS A/B will decide whether to activate it, recalibrate, or
+decommission.
 
-**Technical:** Each chunk is classified into an evidence tier: `assertion` > `fact` >
-`general`. Scores are attached to `evidence_tier_metadata` on each chunk. The environment
-variable `EVIDENCE_SHADOW_MODE` (default: `"true"`) controls whether these scores
-re-order the results. When shadow mode is disabled, results are served in a U-shape
-pattern (highest-confidence + lowest-confidence chunks first, mid-confidence last) to
-give the model the strongest anchors at the boundaries of its context window.
+**Technical:** Implemented in
+[`evidence_tier.apply()`](../../klai-retrieval-api/retrieval_api/services/evidence_tier.py).
+Each chunk is multiplied by four weights along independent dimensions, gated by
+per-dimension feature flags:
+
+```
+final_score = reranker_score
+            * content_type_weight       # EVIDENCE_CONTENT_TYPE_ENABLED
+            * assertion_mode_weight     # EVIDENCE_ASSERTION_MODE_ENABLED (flat 1.00 in v1)
+            * temporal_decay            # EVIDENCE_TEMPORAL_DECAY_ENABLED
+            * pagerank_weight           # EVIDENCE_PAGERANK_ENABLED
+```
+
+| Weight | Source | Default values |
+|---|---|---|
+| `content_type_weight` | Per-chunk `content_type` payload (set at ingest) | `kb_article=1.00`, `pdf_document=0.90`, `meeting_transcript=0.80`, `1on1_transcript=0.80`, `graph_edge=0.70`, `web_crawl=0.65`, `unknown=0.55` |
+| `assertion_mode_weight` | Per-chunk `assertion_mode` payload | All flat at 1.00 in v1 — plumbing only. SPEC-EVIDENCE-002 governs activation. |
+| `temporal_decay` | Chunk `ingested_at` age | `<30d=1.00`, `30-180d=0.95`, `180-365d=0.90`, `>365d=0.85` |
+| `pagerank_weight` | Per-chunk `entity_pagerank_max` from FalkorDB | `1 + 0.20 * log1p(pagerank * 100)` — capped ~+25% for hub entities |
+
+After scoring, chunks are reordered into a **U-shape** (`_order_for_llm`): strongest
+chunk at position 0, second-strongest at the last position, mid-strength chunks
+clustered in the middle. This mitigates "Lost in the Middle" (Liu et al. 2023,
+[arXiv:2307.03172](https://arxiv.org/abs/2307.03172)) — long-context LLMs historically
+showed >30% performance degradation when the strongest evidence sat in the middle of
+the prompt. Whether this still holds for modern frontier LLMs is part of what the
+RAGAS A/B will measure.
+
+**Shadow-mode contract:** `EVIDENCE_SHADOW_MODE=true` (default) computes the
+weighted/U-shape order, logs both orders side-by-side as `shadow_eval`, and serves the
+**flat reranker order**. The CPU cost (`copy.deepcopy(reranked) + apply()`) is paid on
+every request.
+
+**Activation path (SPEC-EVIDENCE-001-FOLLOWUP-001):** the shadow mode has been the
+default since 2026-03-30. RAGAS infrastructure landed 2026-05-05 (#369). The follow-up
+SPEC sets a 30-day deadline to either:
+
+1. Activate (5%/50%/100% staged rollout with auto-revert on quality regression),
+2. Activate `evidence_tier_temporal_only` (temporal decay isolated; the dimension with
+   the strongest theoretical justification),
+3. Decommission entirely (remove the `evidence_tier.apply()` call + payload fields), or
+4. Retain-flags-off (`EVIDENCE_SHADOW_MODE=disabled` becomes the new default — stops
+   the shadow CPU cost while preserving code for future revival).
+
+The RAGAS A/B uses three `RAG_EVAL_VARIANT` values (`baseline`, `evidence_tier_full`,
+`evidence_tier_temporal_only`) over 7 consecutive days. Decision criteria: ≥+0.02 on
+RAGAS Context Precision AND Faithfulness with Wilcoxon `p<0.05` against baseline.
 
 ---
 
@@ -762,7 +865,15 @@ Trailing punctuation and whitespace are ignored. "Ok!" and "Oké." are both triv
 | `RETRIEVAL_GATE_THRESHOLD` | `0.1` | Cosine margin threshold for gate bypass |
 | `retrieval_candidates` | `60` | Raw candidates fetched from Qdrant |
 | `reranker_candidates` | `20` | Top-N sent to cross-encoder |
-| `EVIDENCE_SHADOW_MODE` | `true` | Log evidence tiers without reordering results |
+| `EVIDENCE_SHADOW_MODE` | `true` | Compute weighted score + U-shape order, log as `shadow_eval`, serve flat reranker order. Activation gated by SPEC-EVIDENCE-001-FOLLOWUP-001 (RAGAS A/B + 30-day deadline). |
+| `EVIDENCE_CONTENT_TYPE_ENABLED` | `true` | Per-dimension flag for content_type weights. |
+| `EVIDENCE_TEMPORAL_DECAY_ENABLED` | `true` | Per-dimension flag for temporal decay. |
+| `EVIDENCE_PAGERANK_ENABLED` | `true` | Per-dimension flag for entity_pagerank_max boost. |
+| `link_expand_enabled` | `true` | 1-hop link expansion + authority boost (SPEC-CRAWLER-003). |
+| `link_expand_seed_k` | `10` | Top-N raw chunks whose `links_to` payload is mined. |
+| `link_expand_max_urls` | `30` | Cap on URLs collected from seed chunks per request. |
+| `link_expand_candidates` | `20` | Cap on Qdrant scroll results when fetching link-expanded chunks. |
+| `link_authority_boost` | `0.05` | Coefficient on `log(1 + incoming_link_count)` authority boost. |
 | `graphiti_enabled` | `true` (both `retrieval-api` and `knowledge-ingest`) | Include FalkorDB graph search (parallel with Qdrant 3-leg RRF). |
 | `graph_search_timeout` | `5.0` | FalkorDB search timeout (seconds) |
 | `coreference_timeout` | `3.0` | Coreference LLM call timeout (seconds) |
@@ -843,7 +954,13 @@ snapshot: [docs/architecture/retrieval-improvements-roadmap.md](retrieval-improv
 | Coreference | `klai-retrieval-api/retrieval_api/services/coreference.py` | Pronoun resolution via `klai-fast` |
 | Embeddings | `klai-retrieval-api/retrieval_api/services/tei.py` | Dense + sparse embedding via BGE-M3 |
 | Qdrant search | `klai-retrieval-api/retrieval_api/services/search.py` | Hybrid three-leg RRF search |
-| Source-aware select | `klai-retrieval-api/retrieval_api/services/source_aware_select.py` | `mentioned` / `diversify` mode; shares `STOP_WORDS` with `diversity.py` |
+| Source-aware select | `klai-retrieval-api/retrieval_api/services/diversity.py` | `source_aware_select()` — `mentioned` / `diversify` mode + `STOP_WORDS`. Called from `retrieve.py` step 5c. |
+| Evidence tier | `klai-retrieval-api/retrieval_api/services/evidence_tier.py` | `apply()` + `_order_for_llm()` U-shape; content_type / temporal / pagerank weights. Shadow-mode default. |
+| Parent text swap | `klai-retrieval-api/retrieval_api/services/parent_lookup.py` | SPEC-RAG-PARENT-CHILD-001 — batch-fetches `knowledge.parent_chunks` rows for chunks with `parent_chunk_id`. |
+| Quality boost | `klai-retrieval-api/retrieval_api/quality_boost.py` | SPEC-KB-015 — `feedback_count >= 3` cold-start gate, ±10% boost. |
+| Identity verify (portal) | `klai-portal/backend/app/services/identity_verifier.py` | `verify_identity_claim()` — JWT / membership / `partner:<key_id>` branches. |
+| Identity asserter (lib) | `klai-libs/identity-assert/klai_identity_assert/` | Consumer-side cache + retry around `/internal/identity/verify`. |
+| F2 audit ref | `.moai/audits/retrieval-coupling-2026-05-06/findings/F2-...md` | Why partner-key verification lives portal-side (not in retrieval-api). |
 | Router (signal) | `klai-retrieval-api/retrieval_api/services/router.py` | Keyword + semantic-centroid signal for source-aware select (SPEC-KB-021) |
 | Graph search | `klai-retrieval-api/retrieval_api/services/graph_search.py` | FalkorDB/Graphiti parallel traversal, RRF-merged with Qdrant results |
 | Reranker | `klai-retrieval-api/retrieval_api/services/reranker.py` | Cross-encoder reranking via BGE-reranker-v2-m3 on gpu-01 (Infinity) |


### PR DESCRIPTION
## Summary

Three docs/architecture refreshes after the [retrieval coupling audit](https://github.com/GetKlai/klai/pull/386) and `SPEC-DECOMM-FOCUS-001` (#368). Three commits, one per file, so reviewers can evaluate each independently.

## Commits

### 1. `docs(retrieval-flow): post-audit refresh`

The most directly affected doc. Stale content fixed:

- Step 4 graph search dropped a "disabled for `scope=notebook`" reference (scope no longer exists)
- Step 6 evidence tier description was wrong — described `assertion > fact > general` tiers, actual code uses content_type weights + temporal_decay + pagerank. Replaced with the real four-weight formula, default tables, U-shape rationale, and the SPEC-EVIDENCE-001-FOLLOWUP-001 activation path
- `source_aware_select.py` file path didn't exist; actual file is `diversity.py`

New content:

- New Step 4b: Link expansion + authority boost (was invisible) + F3 phase 1 instrumentation note
- New "Identity verification on every /retrieve call" section between consumer-classes and Part 1 — documents the two-gate model and the partner_key branch (F2 fix-forward)
- Config table extended with EVIDENCE_*_ENABLED flags + link_expand_* parameters
- Key files table extended with evidence_tier.py, parent_lookup.py, quality_boost.py, identity_verifier.py, identity-assert library, F2 audit-finding link

### 2. `docs(ingest-flow): note F3 instrumentation + EVIDENCE-001 activation SPEC`

Two callouts; the broader klai-focus / scope cleanup was already done by SPEC-DECOMM-FOCUS-001.

- Link-expansion section now points to F3 phase 1 instrumentation (#389)
- Assertion-mode evaluation section now distinguishes evidence_tier activation (FOLLOWUP-001) from assertion-mode activation (SPEC-EVIDENCE-002), cross-linked to retrieval-flow

### 3. `docs(architecture): post-Focus reality + evidence-tier accuracy`

Heaviest rewrite. §2 Platform Service Architecture entirely rewritten from "Two products, one infrastructure" to "Single product on shared infrastructure". §2.1-§2.6 collapsed (≈130 lines about Focus) into 3 clean subsections. §7.4 Evidence-weighted scoring rewritten to match production code (was missing pagerank, had wrong content-type weights, listed chunk ordering as a multiplicative dimension instead of an output ordering step) + activation track aligned with FOLLOWUP-001.

## Audit references

`.moai/audits/retrieval-coupling-2026-05-06/findings/F2 + F3 + F4 + F5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)