### PR TITLE
chore(post-audit): polish identity_verifier + F3 test + lib/portal symmetry

### DIFF
--- a/klai-portal/backend/app/services/identity_verifier.py
+++ b/klai-portal/backend/app/services/identity_verifier.py
@@ -368,6 +368,8 @@ async def _resolve_partner_key_org_slug(
     F2 fix-forward (retrieval coupling audit 2026-05-06).
     """
 
+    from sqlalchemy.exc import DataError
+
     from app.models.partner_api_keys import PartnerAPIKey
 
     # Validate the partner_key_id is a sensible-length string before hitting
@@ -391,12 +393,18 @@ async def _resolve_partner_key_org_slug(
     )
     try:
         result = await db.execute(stmt)
-    except Exception:
-        # Malformed UUIDs surface as DataError from asyncpg/SQLAlchemy.
-        # Treat as partner_key_not_found to avoid leaking internal error
-        # state to the consumer.
-        logger.warning("identity_verify_partner_db_error", exc_info=True)
+    except DataError:
+        # Malformed UUID input surfaces as ``sqlalchemy.exc.DataError``
+        # wrapping ``asyncpg.exceptions.DataError`` ("invalid input syntax for
+        # type uuid"). This is caller-supplied garbage — treat as "not found"
+        # rather than 503.
+        logger.info("identity_verify_partner_malformed_uuid")
         return None, "partner_key_not_found"
+    # NOTE: do NOT catch broader Exception here. A real DB outage
+    # (OperationalError, connection refused) MUST bubble up so the
+    # /internal/identity/verify endpoint converts it to HTTP 503
+    # cache_unavailable rather than masquerading as a partner_key
+    # rejection. Audit: post-F2 polish 2026-05-06.
 
     row = result.one_or_none()
     if row is None:

--- a/klai-portal/backend/tests/test_identity_verifier.py
+++ b/klai-portal/backend/tests/test_identity_verifier.py
@@ -611,10 +611,21 @@ class TestPartnerKeyPath:
         assert decision.reason == "invalid_jwt"
         mock_db.execute.assert_not_called()
 
-    async def test_deny_on_db_error_fails_closed(self, mock_db: AsyncMock) -> None:
-        # Malformed UUIDs surface as DataError; treat as not_found rather
-        # than leaking internal state to the consumer.
-        mock_db.execute = AsyncMock(side_effect=Exception("invalid uuid format"))
+    async def test_deny_on_data_error_returns_not_found(self, mock_db: AsyncMock) -> None:
+        """Malformed UUID input surfaces as ``sqlalchemy.exc.DataError``;
+        treat as ``partner_key_not_found`` rather than leaking internal
+        error state to the consumer."""
+        from sqlalchemy.exc import DataError
+
+        # The DataError constructor needs (statement, params, orig). For a
+        # test we only care that the exception type matches.
+        mock_db.execute = AsyncMock(
+            side_effect=DataError(
+                "INSERT INTO ...",
+                {},
+                Exception("invalid input syntax for type uuid: 'not-a-uuid'"),
+            )
+        )
 
         decision = await verify_identity_claim(
             db=mock_db,
@@ -627,6 +638,31 @@ class TestPartnerKeyPath:
 
         assert decision.verified is False
         assert decision.reason == "partner_key_not_found"
+
+    async def test_real_db_outage_propagates(self, mock_db: AsyncMock) -> None:
+        """A real DB outage (connection refused, OperationalError) MUST
+        propagate up to the endpoint layer so it returns 503
+        ``cache_unavailable`` — not silently masquerade as a partner-key
+        rejection.
+
+        Polish guard added 2026-05-06: the previous bare ``except Exception``
+        in ``_resolve_partner_key_org_slug`` was tightened to ``DataError``
+        only. Without this test, a future regression that re-broadens the
+        catch could silently downgrade a 503 to a 403 partner_key_not_found.
+        """
+        from sqlalchemy.exc import OperationalError
+
+        mock_db.execute = AsyncMock(side_effect=OperationalError("SELECT ...", {}, Exception("connection refused")))
+
+        with pytest.raises(OperationalError):
+            await verify_identity_claim(
+                db=mock_db,
+                jwks_resolver=_FakeJwksResolver(),
+                caller_service="portal-api",
+                claimed_user_id="partner:abc-123",
+                claimed_org_id="zitadel-org-acme",
+                bearer_jwt=None,
+            )
 
     async def test_deny_on_org_slug_mismatch_after_allow(self, mock_db: AsyncMock) -> None:
         # Key + org match, but caller asserts a different X-Org-Slug than the
@@ -667,3 +703,49 @@ class TestPartnerKeyPath:
 
         assert decision.verified is True
         assert decision.org_slug == "canonical"
+
+
+class TestLibraryPortalSymmetry:
+    """Polish guard added 2026-05-06: the consumer-side library
+    (``klai_identity_assert``) must accept every ``Evidence`` and
+    ``ReasonCode`` value that portal-side ``identity_verifier`` can emit.
+
+    Without this guard a future PR can extend portal's Literal without
+    extending the library's, and the library's Pydantic-style response
+    parsing would silently drop the new value into a generic deny — or
+    worse, fail JSON parsing at runtime against a real prod payload.
+    """
+
+    def test_evidence_literal_is_identical(self) -> None:
+        """``Evidence`` is what portal emits — both sides MUST agree."""
+        from typing import get_args
+
+        from klai_identity_assert.models import Evidence as LibEvidence
+
+        from app.services.identity_verifier import Evidence as PortalEvidence
+
+        assert set(get_args(PortalEvidence)) == set(get_args(LibEvidence)), (
+            "Evidence Literal drift between portal-side identity_verifier "
+            "and klai_identity_assert library. The library will silently "
+            "miss any new evidence the portal starts emitting."
+        )
+
+    def test_portal_reason_codes_are_subset_of_library(self) -> None:
+        """``ReasonCode`` from portal is what gets returned over the wire.
+        The library extends it with consumer-side codes (`portal_unreachable`,
+        `library_misconfigured`, `cache_unavailable`) but MUST contain every
+        portal-emitted code."""
+        from typing import get_args
+
+        from klai_identity_assert.models import ReasonCode as LibReasonCode
+
+        from app.services.identity_verifier import ReasonCode as PortalReasonCode
+
+        portal_codes = set(get_args(PortalReasonCode))
+        lib_codes = set(get_args(LibReasonCode))
+
+        missing = portal_codes - lib_codes
+        assert not missing, (
+            f"Portal emits ReasonCodes the library does not accept: {sorted(missing)}. "
+            "Add them to klai-libs/identity-assert/klai_identity_assert/models.py."
+        )

--- a/klai-retrieval-api/tests/test_api.py
+++ b/klai-retrieval-api/tests/test_api.py
@@ -356,16 +356,35 @@ class TestLinkExpandInstrumentation:
             resp = client.post("/retrieve", json=sample_retrieve_request)
 
         assert resp.status_code == 200
-        # Find the retrieval_decision_record structlog event
-        rec = next(
-            (r for r in caplog.records if "retrieval_decision_record" in r.getMessage()),
-            None,
+
+        # The retrieval_decision_record structlog event MUST be present.
+        # Polish 2026-05-06: dropped the previous `or` in the assertion that
+        # let the test pass when `rec is None`. structlog routes through
+        # stdlib `logging` via ProcessorFormatter, so caplog DOES capture
+        # these records — if it doesn't, the F3 instrumentation contract is
+        # broken and we want the test to fail loudly.
+        record_messages = [r.getMessage() for r in caplog.records]
+        decision_records = [m for m in record_messages if "retrieval_decision_record" in m]
+        assert decision_records, (
+            "retrieval_decision_record log line missing from caplog. "
+            f"Captured records: {record_messages}"
         )
-        # structlog emits as plain log message; verify the key fields are
-        # in the record's structured-data attrs.
-        assert rec is not None or any("link_expand" in r.getMessage() for r in caplog.records), (
-            "decision_record log should contain a link_expand block"
-        )
+
+        # Verify the link_expand block actually appears with its required keys.
+        # The structlog kwargs end up in the record's attribute dict via
+        # ProcessorFormatter — search the record's __dict__ for our keys.
+        rec = next(r for r in caplog.records if "retrieval_decision_record" in r.getMessage())
+        rec_attrs = " ".join(f"{k}={v}" for k, v in rec.__dict__.items())
+        for required_key in (
+            "link_expand",
+            "expanded_in_top_k",
+            "seed_in_top_k",
+            "served_top_k",
+        ):
+            assert required_key in rec_attrs, (
+                f"link_expand block missing required key '{required_key}'. "
+                f"Record attrs: {rec.__dict__}"
+            )
 
     def test_link_expanded_flag_survives_evidence_tier_deep_copy(self):
         """The instrumentation tag MUST survive `copy.deepcopy(reranked)`


### PR DESCRIPTION
## Summary

Four small post-audit polishes flagged during my own honesty-check after the retrieval coupling audit work landed. Each is a defense-in-depth tightening — none changes runtime behaviour for happy-path traffic.

## Changes

### 1. `identity_verifier._resolve_partner_key_org_slug` — narrow the except

The previous bare `except Exception` masked **real DB outages** (OperationalError, connection refused) as `partner_key_not_found` 403. Now catches only `sqlalchemy.exc.DataError` (malformed-UUID input from caller). Real outages propagate to the /internal/identity/verify endpoint and convert to HTTP 503 — matching the JWT and membership paths' contract.

- Renamed `test_deny_on_db_error_fails_closed` → `test_deny_on_data_error_returns_not_found` with a real `DataError` instance.
- Added `test_real_db_outage_propagates` — regression guard: `OperationalError` MUST bubble up. A future PR re-broadening the catch fails this test.

### 2. F3 `test_decision_record_link_expand_block_emitted` — tighten

The previous assertion was `rec is not None or any(...)`. The `or` let it pass when no structured event was captured. Now: MUST find the event AND it MUST contain `link_expand` + `expanded_in_top_k` + `seed_in_top_k` + `served_top_k` keys.

### 3. Library/portal `Literal` symmetry tests

Two new tests in `TestLibraryPortalSymmetry`:

- `Evidence` Literal MUST be **identical** between `klai_identity_assert.models.Evidence` and `app.services.identity_verifier.Evidence`.
- `ReasonCode`: portal-side MUST be a **subset** of library-side. The library legitimately extends with consumer-side codes (`portal_unreachable`, `library_misconfigured`, `cache_unavailable`).

Without these, a future PR could extend one side without the other and the library's response parser would silently drop unknown values.

### 4. Cross-document anchor verification (no code change)

Verified all new Markdown anchor links from #400 resolve correctly — `#step-6-evidence-tier-scoring-shadow-mode` and `#identity-verification-on-every-retrieve-call` both match GitHub's auto-anchor convention. Documented in commit message.

## Tests

- 29 portal-api identity_verifier tests pass (incl. 2 new symmetry + tightened DataError test + new outage-propagates test)
- 3 retrieval-api F3 instrumentation tests pass (incl. tightened decision_record test)
- Ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)