### PR TITLE
feat(SPEC-TI-003-FOLLOWUP-001): explicit conn passing in knowledge-ingest pg_store

### DIFF
--- a/klai-knowledge-ingest/alembic/versions/post_deploy_dd1b439a57d0.sql
+++ b/klai-knowledge-ingest/alembic/versions/post_deploy_dd1b439a57d0.sql
@@ -115,17 +115,24 @@ CREATE POLICY tenant_isolation ON knowledge.artifact_images
     )
   );
 
+-- SPEC-TI-003-FOLLOWUP-001 AC-8: knowledge.derivations has columns (child_id,
+-- parent_id) -- there is no source_id column. The original SPEC-TI-003 SQL
+-- referenced source_id, which would have failed at apply-time; a hot-fix on
+-- 2026-05-06 reapplied the policy with child_id directly on prod. This back-
+-- fills that hot-fix into source. child_id is the new artifact in a
+-- derivation pair; gating reads/writes on child_id ownership matches how the
+-- pipeline produces derivations (always for the local org's child).
 DROP POLICY IF EXISTS tenant_isolation ON knowledge.derivations;
 CREATE POLICY tenant_isolation ON knowledge.derivations
   AS RESTRICTIVE
   USING (
-    source_id IN (
+    child_id IN (
       SELECT id FROM knowledge.artifacts
       WHERE org_id = knowledge._rls_current_org_id()
     )
   )
   WITH CHECK (
-    source_id IN (
+    child_id IN (
       SELECT id FROM knowledge.artifacts
       WHERE org_id = knowledge._rls_current_org_id()
     )

--- a/klai-knowledge-ingest/alembic/versions/post_deploy_dd1b439a57d0_force.sql
+++ b/klai-knowledge-ingest/alembic/versions/post_deploy_dd1b439a57d0_force.sql
@@ -1,0 +1,67 @@
+-- SPEC-TI-003-FOLLOWUP-001 AC-7: re-apply FORCE ROW LEVEL SECURITY on all
+-- knowledge.* tables, restoring the hardening that the 2026-05-06 hot-fix
+-- temporarily disabled (the asyncpg-pool-guc-not-shared pitfall would have
+-- caused application errors with FORCE on while pg_store still grabbed pool
+-- connections without the GUC).
+--
+-- Operator preconditions
+-- ----------------------
+-- 1. The companion code change is deployed: every knowledge.* SQL caller
+--    threads the conn from a tenant_scoped_connection or
+--    cross_org_admin_connection block. Verify by sampling
+--    klai-knowledge-ingest/knowledge_ingest/pg_store.py -- every function
+--    must take ``conn`` as its first non-self argument.
+--
+-- 2. SPEC-TI-011 has migrated knowledge-ingest off the ``klai`` superuser
+--    DSN. Until then ``klai`` bypasses RLS entirely (Postgres super-user
+--    semantics), so FORCE has no effect. Running this SQL before
+--    SPEC-TI-011 is harmless but also delivers no isolation benefit.
+--
+-- Apply (operator-run, AS klai):
+--   ssh core-01 "docker exec -i klai-core-postgres-1 psql -U klai -d klai" \
+--       < klai-knowledge-ingest/alembic/versions/post_deploy_dd1b439a57d0_force.sql
+--
+-- Verification (post-apply):
+--   SELECT relname, relrowsecurity, relforcerowsecurity
+--     FROM pg_class
+--    WHERE relnamespace = 'knowledge'::regnamespace
+--      AND relkind = 'r'
+--    ORDER BY relname;
+-- Every row should show relrowsecurity = t AND relforcerowsecurity = t.
+--
+-- Then watch VictoriaLogs for an hour for new 42501 errors:
+--   service:knowledge-ingest AND message:"42501"
+-- Zero hits = wiring is complete.
+--
+-- Rollback (if a regression surfaces):
+--   ALTER TABLE knowledge.<name> NO FORCE ROW LEVEL SECURITY;
+-- for the affected table, then triage the offending caller. Do NOT
+-- disable RLS itself (DISABLE ROW LEVEL SECURITY) -- that would let any
+-- caller without a GUC read every tenant's data.
+
+BEGIN;
+
+-- 1. Tables with their own org_id column (Cat-D direct policy).
+ALTER TABLE knowledge.artifacts FORCE ROW LEVEL SECURITY;
+ALTER TABLE knowledge.entities FORCE ROW LEVEL SECURITY;
+ALTER TABLE knowledge.crawl_domains FORCE ROW LEVEL SECURITY;
+ALTER TABLE knowledge.crawl_jobs FORCE ROW LEVEL SECURITY;
+ALTER TABLE knowledge.crawled_pages FORCE ROW LEVEL SECURITY;
+ALTER TABLE knowledge.kb_config FORCE ROW LEVEL SECURITY;
+ALTER TABLE knowledge.org_config FORCE ROW LEVEL SECURITY;
+ALTER TABLE knowledge.page_links FORCE ROW LEVEL SECURITY;
+ALTER TABLE knowledge.parent_chunks FORCE ROW LEVEL SECURITY;
+
+-- 2. Junction tables scoped via the artifacts FK (Cat-D subquery policy).
+ALTER TABLE knowledge.artifact_entities FORCE ROW LEVEL SECURITY;
+ALTER TABLE knowledge.artifact_images FORCE ROW LEVEL SECURITY;
+ALTER TABLE knowledge.derivations FORCE ROW LEVEL SECURITY;
+
+-- 3. embedding_queue currently carries a permissive draft policy
+-- (see post_deploy_dd1b439a57d0.sql section 4). FORCE makes the policy
+-- the only path even for table owners; permissive USING(true) means it
+-- still admits everything until the FK-scoped policy lands. Listed here
+-- so the FORCE rollout matches the SPEC's "all 13 knowledge.* tables".
+ALTER TABLE knowledge.embedding_queue FORCE ROW LEVEL SECURITY;
+
+COMMIT;

--- a/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
+++ b/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
@@ -1,26 +1,27 @@
 """
 Web crawler adapter: bulk-crawls a website and ingests each page.
 Uses the Crawl4AI REST API (shared Docker container) for all crawling.
+
+SPEC-TI-003-FOLLOWUP-001 AC-1: ``run_crawl_job`` and its helpers take the
+GUC-pinned ``asyncpg.Connection`` from the calling task's
+``tenant_scoped_connection(org_id)`` block. Every knowledge.* read or write
+runs on that same connection so RLS sees the tenant context.
 """
+
 from __future__ import annotations
 
 import asyncio
 import hashlib
 import time
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    import asyncpg
-
+import asyncpg
 import httpx
 import structlog
-
 from klai_image_storage import ImageStore, download_and_upload_crawl_images
 
 from knowledge_ingest import pg_store
 from knowledge_ingest.config import settings
 from knowledge_ingest.crawl4ai_client import CrawlResult, crawl_site
-from knowledge_ingest.db import get_pool
 from knowledge_ingest.models import IngestRequest
 
 logger = structlog.get_logger()
@@ -69,10 +70,10 @@ def _build_image_store() -> ImageStore | None:
 #   guarantee that get_anchor_texts() and get_incoming_count() return final values.
 # @MX:SPEC: SPEC-CRAWLER-005 REQ-01.2
 async def _build_link_graph(
+    conn: asyncpg.Connection,
     results: list[CrawlResult],
     org_id: str,
     kb_slug: str,
-    pool: asyncpg.Pool,
 ) -> None:
     """Phase 1 of the two-phase crawl pipeline: upsert every page's
     outbound links BEFORE any page is ingested. This guarantees that
@@ -92,6 +93,7 @@ async def _build_link_graph(
         if not internal:
             continue
         await pg_store.upsert_page_links(
+            conn,
             org_id=org_id,
             kb_slug=kb_slug,
             from_url=result.url,
@@ -103,6 +105,7 @@ _UNSET = object()  # sentinel: stored_hash not yet fetched from DB
 
 
 async def run_crawl_job(
+    conn: asyncpg.Connection,
     job_id: str,
     org_id: str,
     kb_slug: str,
@@ -135,8 +138,12 @@ async def run_crawl_job(
     page. If any page is flagged as auth-walled the job is marked failed
     with ``error='auth_wall_detected: {selector}'`` and no further pages
     are ingested.
+
+    SPEC-TI-003-FOLLOWUP-001 AC-1: ``conn`` carries the RLS GUC from the
+    caller's ``tenant_scoped_connection(org_id)`` block. Every knowledge.*
+    statement below runs on this same connection.
     """
-    await _update_job(job_id, status="running")
+    await _update_job(conn, job_id, status="running")
 
     pages_done = 0
     pages_failed = 0
@@ -158,19 +165,20 @@ async def run_crawl_job(
         # keeps the public signature stable for Fase D delegation.
         _ = (canary_url, canary_fingerprint)
 
-        pool = await get_pool()
-        await pool.execute(
+        await conn.execute(
             "UPDATE knowledge.crawl_jobs SET pages_total=$1, updated_at=$2 WHERE id=$3",
-            len(results), int(time.time()), job_id,
+            len(results),
+            int(time.time()),
+            job_id,
         )
 
         # SPEC-CRAWLER-005 Fase 1: build link graph BEFORE per-page ingest so
         # late pages don't read an empty graph. REQ-01.1.
-        await _build_link_graph(results, org_id, kb_slug, pool)
+        await _build_link_graph(conn, results, org_id, kb_slug)
 
         # Batch-fetch all known content hashes in a single query
         urls = [r.url for r in results]
-        known_hashes = await pg_store.get_crawled_page_hashes(org_id, kb_slug, urls)
+        known_hashes = await pg_store.get_crawled_page_hashes(conn, org_id, kb_slug, urls)
 
         for result in results:
             url = result.url
@@ -182,8 +190,11 @@ async def run_crawl_job(
                 raise AuthWallDetected(login_indicator_selector)
             try:
                 await _ingest_crawl_result(
-                    result, url, org_id, kb_slug,
-                    pool=pool,
+                    conn,
+                    result,
+                    url,
+                    org_id,
+                    kb_slug,
                     stored=known_hashes.get(url),
                     login_indicator_selector=login_indicator_selector,
                     connector_id=connector_id,
@@ -197,35 +208,41 @@ async def run_crawl_job(
                 logger.warning("crawl_page_failed", url=url, job_id=job_id, error=str(exc))
                 pages_failed += 1
 
-            await pool.execute(
+            await conn.execute(
                 "UPDATE knowledge.crawl_jobs SET pages_done=$1, updated_at=$2 WHERE id=$3",
-                pages_done, int(time.time()), job_id,
+                pages_done,
+                int(time.time()),
+                job_id,
             )
 
-        await _update_job(job_id, status="completed")
+        await _update_job(conn, job_id, status="completed")
         logger.info(
-            "crawl_job_complete", job_id=job_id,
-            pages_done=pages_done, pages_failed=pages_failed,
+            "crawl_job_complete",
+            job_id=job_id,
+            pages_done=pages_done,
+            pages_failed=pages_failed,
         )
 
     except AuthWallDetected as exc:
         # SPEC-CRAWLER-004 REQ-02.3: one structured error per sync, no artifacts.
         logger.error(
             "crawl_job_auth_wall",
-            job_id=job_id, selector=exc.selector, pages_ingested=pages_done,
+            job_id=job_id,
+            selector=exc.selector,
+            pages_ingested=pages_done,
         )
-        await _update_job(job_id, status="failed", error=str(exc))
+        await _update_job(conn, job_id, status="failed", error=str(exc))
     except Exception as exc:
         logger.exception("crawl_job_error", job_id=job_id, error=str(exc))
-        await _update_job(job_id, status="failed", error=str(exc))
+        await _update_job(conn, job_id, status="failed", error=str(exc))
 
 
 async def _ingest_crawl_result(
+    conn: asyncpg.Connection,
     result: CrawlResult,
     url: str,
     org_id: str,
     kb_slug: str,
-    pool: object | None = None,
     stored: pg_store.PageHashes | None | object = _UNSET,
     login_indicator_selector: str | None = None,
     connector_id: str | None = None,
@@ -258,7 +275,7 @@ async def _ingest_crawl_result(
 
     # Dual-hash dedup (see migration 012)
     if stored is _UNSET:
-        stored = await pg_store.get_crawled_page_stored(org_id, kb_slug, url)
+        stored = await pg_store.get_crawled_page_stored(conn, org_id, kb_slug, url)
 
     raw_html = result.html or ""
     raw_html_hash = hashlib.sha256(raw_html.encode()).hexdigest()
@@ -277,6 +294,7 @@ async def _ingest_crawl_result(
         _, stored_content = stored  # type: ignore[misc]
         if stored_content is not None and stored_content == content_hash:
             await pg_store.upsert_crawled_page(
+                conn,
                 org_id=org_id,
                 kb_slug=kb_slug,
                 url=url,
@@ -304,9 +322,9 @@ async def _ingest_crawl_result(
         from knowledge_ingest import link_graph
 
         outbound, anchors, incoming = await asyncio.gather(
-            link_graph.get_outbound_urls(url, org_id, kb_slug, pool),
-            link_graph.get_anchor_texts(url, org_id, kb_slug, pool),
-            link_graph.get_incoming_count(url, org_id, kb_slug, pool),
+            link_graph.get_outbound_urls(conn, url, org_id, kb_slug),
+            link_graph.get_anchor_texts(conn, url, org_id, kb_slug),
+            link_graph.get_incoming_count(conn, url, org_id, kb_slug),
         )
         extra["links_to"] = outbound[:20]
         extra["anchor_texts"] = anchors
@@ -341,18 +359,22 @@ async def _ingest_crawl_result(
     # SPEC-CRAWLER-005 Fase 6 follow-up: was "connector"; crawl chunks now carry
     # source_type="crawl" so retrieval + assertions can distinguish them from
     # non-crawl connector artifacts (notion, github, gdrive).
-    await ingest_document(IngestRequest(
-        org_id=org_id,
-        kb_slug=kb_slug,
-        path=url,
-        content=text,
-        source_type="crawl",
-        content_type=content_type,
-        synthesis_depth=1,
-        extra=extra,
-    ))
+    await ingest_document(
+        conn,
+        IngestRequest(
+            org_id=org_id,
+            kb_slug=kb_slug,
+            path=url,
+            content=text,
+            source_type="crawl",
+            content_type=content_type,
+            synthesis_depth=1,
+            extra=extra,
+        ),
+    )
 
     await pg_store.upsert_crawled_page(
+        conn,
         org_id=org_id,
         kb_slug=kb_slug,
         url=url,
@@ -363,9 +385,13 @@ async def _ingest_crawl_result(
     )
 
 
-async def _update_job(job_id: str, status: str, error: str | None = None) -> None:
-    pool = await get_pool()
-    await pool.execute(
+async def _update_job(
+    conn: asyncpg.Connection, job_id: str, status: str, error: str | None = None
+) -> None:
+    await conn.execute(
         "UPDATE knowledge.crawl_jobs SET status=$1, error=$2, updated_at=$3 WHERE id=$4",
-        status, error, int(time.time()), job_id,
+        status,
+        error,
+        int(time.time()),
+        job_id,
     )

--- a/klai-knowledge-ingest/knowledge_ingest/backfill.py
+++ b/klai-knowledge-ingest/knowledge_ingest/backfill.py
@@ -7,6 +7,14 @@ Usage:
 Reads artifacts from PostgreSQL, fetches chunks from Qdrant, and calls
 ingest_episode() for each. Resume-safe: checks for graphiti_episode_id
 in artifact.extra before processing.
+
+SPEC-TI-003-FOLLOWUP-001 AC-2: this is an operator one-shot that does
+cross-org admin work (it picks the org via DISTINCT on first run, then
+mass-updates artifacts.extra for every artifact in that org). It uses
+``cross_org_admin_connection`` so the GUC marks the connection as a
+deliberate admin caller. Once SPEC-TI-011 lands per-service roles, the
+RLS policies will recognise the bypass; until then the klai superuser
+connection bypasses RLS regardless.
 """
 
 import argparse
@@ -18,7 +26,7 @@ import time
 from qdrant_client import AsyncQdrantClient
 
 from knowledge_ingest.config import settings
-from knowledge_ingest.db import get_pool
+from knowledge_ingest.db import cross_org_admin_connection
 from knowledge_ingest.graph import ingest_episode
 
 # ---------------------------------------------------------------------------
@@ -35,161 +43,186 @@ log = logging.getLogger("backfill")
 
 
 async def main(limit: int | None = None) -> None:
-    pool = await get_pool()
     qdrant = AsyncQdrantClient(
         url=settings.qdrant_url,
         api_key=settings.qdrant_api_key or None,
     )
 
-    # ---- Discover org --------------------------------------------------
-    org = await pool.fetchrow("SELECT DISTINCT org_id FROM knowledge.artifacts LIMIT 1")
-    if not org:
-        log.error("No artifacts found — nothing to backfill")
-        return
-    org_id = str(org["org_id"])
-    log.info("Org: %s", org_id)
+    async with cross_org_admin_connection() as conn:
+        # ---- Discover org --------------------------------------------------
+        org = await conn.fetchrow("SELECT DISTINCT org_id FROM knowledge.artifacts LIMIT 1")
+        if not org:
+            log.error("No artifacts found — nothing to backfill")
+            return
+        org_id = str(org["org_id"])
+        log.info("Org: %s", org_id)
 
-    # ---- Get artifacts -------------------------------------------------
-    rows = await pool.fetch(
-        """
-        SELECT id, path, content_type, created_at, extra
-        FROM knowledge.artifacts
-        WHERE org_id = $1
-        ORDER BY created_at
-        """,
-        org_id,
-    )
-    total = len(rows)
-    already = sum(
-        1 for r in rows
-        if r["extra"] and json.loads(r["extra"]).get("graphiti_episode_id")
-    )
-    to_process = [
-        r for r in rows
-        if not (r["extra"] and json.loads(r["extra"]).get("graphiti_episode_id"))
-    ]
-    log.info(
-        "Found %d artifacts, %d already processed, %d to backfill",
-        total, already, len(to_process),
-    )
-    if not to_process:
-        log.info("Nothing to do")
-        return
-
-    if limit is not None:
-        to_process = to_process[:limit]
-        log.info("Limiting to %d artifact(s)", limit)
-
-    # ---- Fetch all chunks from Qdrant (paginated) ----------------------
-    log.info("Fetching chunks from Qdrant collection '%s'...", settings.qdrant_collection)
-    chunks_by_artifact: dict[str, list[str]] = {}
-    total_points = 0
-    offset = None
-    while True:
-        batch, next_offset = await qdrant.scroll(
-            collection_name=settings.qdrant_collection,
-            offset=offset,
-            limit=1000,
-            with_payload=True,
-            with_vectors=False,
+        # ---- Get artifacts -------------------------------------------------
+        rows = await conn.fetch(
+            """
+            SELECT id, path, content_type, created_at, extra
+            FROM knowledge.artifacts
+            WHERE org_id = $1
+            ORDER BY created_at
+            """,
+            org_id,
         )
-        for pt in batch:
-            aid = (pt.payload or {}).get("artifact_id", "")
-            text = (pt.payload or {}).get("text", "")
-            if aid and text:
-                chunks_by_artifact.setdefault(aid, []).append(text)
-        total_points += len(batch)
-        if next_offset is None:
-            break
-        offset = next_offset
-    log.info(
-        "Loaded %d chunks for %d artifacts from Qdrant",
-        total_points, len(chunks_by_artifact),
-    )
+        total = len(rows)
+        already = sum(
+            1 for r in rows if r["extra"] and json.loads(r["extra"]).get("graphiti_episode_id")
+        )
+        to_process = [
+            r
+            for r in rows
+            if not (r["extra"] and json.loads(r["extra"]).get("graphiti_episode_id"))
+        ]
+        log.info(
+            "Found %d artifacts, %d already processed, %d to backfill",
+            total,
+            already,
+            len(to_process),
+        )
+        if not to_process:
+            log.info("Nothing to do")
+            return
 
-    # ---- Process (sequential) ------------------------------------------
-    # ingest_episode() owns concurrency control via its own semaphore.
-    # Sequential processing here avoids creating 57 queued coroutines at once
-    # and makes progress logging easier to follow.
-    ok_count = 0
-    err_count = 0
-    t_start = time.time()
-    total_to_process = len(to_process)
+        if limit is not None:
+            to_process = to_process[:limit]
+            log.info("Limiting to %d artifact(s)", limit)
 
-    for idx, row in enumerate(to_process, 1):
-        artifact_id = str(row["id"])
-        title = row["path"] or artifact_id
-        content_type = row["content_type"] or "text"
-        created_epoch = row["created_at"] or int(time.time())
+        # ---- Fetch all chunks from Qdrant (paginated) ----------------------
+        log.info("Fetching chunks from Qdrant collection '%s'...", settings.qdrant_collection)
+        chunks_by_artifact: dict[str, list[str]] = {}
+        total_points = 0
+        offset = None
+        while True:
+            batch, next_offset = await qdrant.scroll(
+                collection_name=settings.qdrant_collection,
+                offset=offset,
+                limit=1000,
+                with_payload=True,
+                with_vectors=False,
+            )
+            for pt in batch:
+                aid = (pt.payload or {}).get("artifact_id", "")
+                text = (pt.payload or {}).get("text", "")
+                if aid and text:
+                    chunks_by_artifact.setdefault(aid, []).append(text)
+            total_points += len(batch)
+            if next_offset is None:
+                break
+            offset = next_offset
+        log.info(
+            "Loaded %d chunks for %d artifacts from Qdrant",
+            total_points,
+            len(chunks_by_artifact),
+        )
 
-        chunks = chunks_by_artifact.get(artifact_id, [])
-        if not chunks:
-            log.warning("[%d/%d] %s — no chunks, marking as skipped", idx, total_to_process, title)
-            await pool.execute(
+        # ---- Process (sequential) ------------------------------------------
+        # ingest_episode() owns concurrency control via its own semaphore.
+        # Sequential processing here avoids creating 57 queued coroutines at once
+        # and makes progress logging easier to follow.
+        ok_count = 0
+        err_count = 0
+        t_start = time.time()
+        total_to_process = len(to_process)
+
+        for idx, row in enumerate(to_process, 1):
+            artifact_id = str(row["id"])
+            title = row["path"] or artifact_id
+            content_type = row["content_type"] or "text"
+            created_epoch = row["created_at"] or int(time.time())
+
+            chunks = chunks_by_artifact.get(artifact_id, [])
+            if not chunks:
+                log.warning(
+                    "[%d/%d] %s — no chunks, marking as skipped",
+                    idx,
+                    total_to_process,
+                    title,
+                )
+                await conn.execute(
+                    "UPDATE knowledge.artifacts "
+                    "SET extra = COALESCE(extra, '{}'::jsonb) || $1::jsonb "
+                    "WHERE id = $2::uuid",
+                    json.dumps({"graphiti_episode_id": "no-chunks"}),
+                    artifact_id,
+                )
+                continue
+
+            full_text = "\n\n".join(chunks)
+            if len(full_text) > MAX_TEXT_CHARS:
+                full_text = full_text[:MAX_TEXT_CHARS]
+
+            try:
+                episode_id = await asyncio.wait_for(
+                    ingest_episode(
+                        artifact_id=artifact_id,
+                        document_text=full_text,
+                        org_id=org_id,
+                        content_type=content_type,
+                        belief_time_start=created_epoch,
+                    ),
+                    timeout=EPISODE_TIMEOUT,
+                )
+            except TimeoutError:
+                err_count += 1
+                log.error(
+                    "[%d/%d] %s — TIMEOUT after %ds",
+                    idx,
+                    total_to_process,
+                    title,
+                    EPISODE_TIMEOUT,
+                )
+                continue
+            except Exception as exc:
+                err_count += 1
+                log.error("[%d/%d] %s — %s", idx, total_to_process, title, exc)
+                continue
+
+            if episode_id is None:
+                err_count += 1
+                log.error(
+                    "[%d/%d] %s — returned None (LLM issue?)",
+                    idx,
+                    total_to_process,
+                    title,
+                )
+                continue
+
+            # Success — persist for resume
+            ok_count += 1
+            await conn.execute(
                 "UPDATE knowledge.artifacts "
                 "SET extra = COALESCE(extra, '{}'::jsonb) || $1::jsonb "
                 "WHERE id = $2::uuid",
-                json.dumps({"graphiti_episode_id": "no-chunks"}),
+                json.dumps(
+                    {
+                        "graphiti_episode_id": episode_id,
+                        "graphiti_model": settings.graphiti_llm_model,
+                    }
+                ),
                 artifact_id,
             )
-            continue
 
-        full_text = "\n\n".join(chunks)
-        if len(full_text) > MAX_TEXT_CHARS:
-            full_text = full_text[:MAX_TEXT_CHARS]
-
-        try:
-            episode_id = await asyncio.wait_for(
-                ingest_episode(
-                    artifact_id=artifact_id,
-                    document_text=full_text,
-                    org_id=org_id,
-                    content_type=content_type,
-                    belief_time_start=created_epoch,
-                ),
-                timeout=EPISODE_TIMEOUT,
+            elapsed = time.time() - t_start
+            rate = ok_count / (elapsed / 3600) if elapsed > 0 else 0
+            log.info(
+                "[%d/%d] %s — OK episode=%s (%d/hr, %ds elapsed)",
+                idx,
+                total_to_process,
+                title,
+                episode_id,
+                int(rate),
+                int(elapsed),
             )
-        except asyncio.TimeoutError:
-            err_count += 1
-            log.error(
-                "[%d/%d] %s — TIMEOUT after %ds",
-                idx, total_to_process, title, EPISODE_TIMEOUT,
-            )
-            continue
-        except Exception as exc:
-            err_count += 1
-            log.error("[%d/%d] %s — %s", idx, total_to_process, title, exc)
-            continue
 
-        if episode_id is None:
-            err_count += 1
-            log.error("[%d/%d] %s — returned None (LLM issue?)", idx, total_to_process, title)
-            continue
-
-        # Success — persist for resume
-        ok_count += 1
-        await pool.execute(
-            "UPDATE knowledge.artifacts "
-            "SET extra = COALESCE(extra, '{}'::jsonb) || $1::jsonb "
-            "WHERE id = $2::uuid",
-            json.dumps({
-                "graphiti_episode_id": episode_id,
-                "graphiti_model": settings.graphiti_llm_model,
-            }),
-            artifact_id,
-        )
-
-        elapsed = time.time() - t_start
-        rate = ok_count / (elapsed / 3600) if elapsed > 0 else 0
         log.info(
-            "[%d/%d] %s — OK episode=%s (%d/hr, %ds elapsed)",
-            idx, total_to_process, title, episode_id, int(rate), int(elapsed),
+            "Backfill complete: %d OK, %d errors out of %d",
+            ok_count,
+            err_count,
+            total_to_process,
         )
-
-    log.info(
-        "Backfill complete: %d OK, %d errors out of %d",
-        ok_count, err_count, total_to_process,
-    )
 
 
 if __name__ == "__main__":

--- a/klai-knowledge-ingest/knowledge_ingest/connector_cleanup.py
+++ b/klai-knowledge-ingest/knowledge_ingest/connector_cleanup.py
@@ -23,11 +23,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+import asyncpg
 import structlog
 
 from knowledge_ingest import graph as graph_module
 from knowledge_ingest import pg_store, qdrant_store
-from knowledge_ingest.db import get_pool
+from knowledge_ingest.db import get_pool, tenant_scoped_connection
 
 logger = structlog.get_logger()
 
@@ -68,28 +69,30 @@ class CleanupReport:
         }
 
 
-async def _list_artifact_ids(org_id: str, kb_slug: str, connector_id: str) -> list[str]:
+async def _list_artifact_ids(
+    conn: asyncpg.Connection, org_id: str, kb_slug: str, connector_id: str
+) -> list[str]:
     """Return artifact UUIDs for a connector, BEFORE we delete them.
 
     Needed because the graphiti-cancel step filters procrastinate-jobs by
     artifact_id (the graphiti task signature does not include
     ``source_connector_id``). We capture the set before
     ``delete_connector_artifacts`` removes the rows.
+
+    SPEC-TI-003-FOLLOWUP-001 AC-1: caller passes the GUC-pinned ``conn``.
     """
-    pool = await get_pool()
-    async with pool.acquire() as conn:
-        rows = await conn.fetch(
-            """
-            SELECT id::text AS id FROM knowledge.artifacts
-             WHERE org_id = $1
-               AND kb_slug = $2
-               AND extra IS NOT NULL
-               AND extra::jsonb->>'source_connector_id' = $3
-            """,
-            org_id,
-            kb_slug,
-            connector_id,
-        )
+    rows = await conn.fetch(
+        """
+        SELECT id::text AS id FROM knowledge.artifacts
+         WHERE org_id = $1
+           AND kb_slug = $2
+           AND extra IS NOT NULL
+           AND extra::jsonb->>'source_connector_id' = $3
+        """,
+        org_id,
+        kb_slug,
+        connector_id,
+    )
     return [r["id"] for r in rows]
 
 
@@ -103,6 +106,10 @@ async def _cancel_enrichment_jobs(proc_app: Any, connector_id: str) -> int:
     ``abort=True`` marks running jobs for asyncio.CancelledError delivery
     via Postgres NOTIFY (Procrastinate native). ``delete_job=True`` purges
     the row from the queue table after cancellation so it never replays.
+
+    SPEC-TI-003-FOLLOWUP-001 AC-2 exception: this query targets the
+    procrastinate_jobs table, not knowledge.*, so a raw pool acquire
+    is allowed here.
     """
     pool = await get_pool()
     async with pool.acquire() as conn:
@@ -143,6 +150,10 @@ async def _cancel_graphiti_jobs(proc_app: Any, artifact_ids: list[str]) -> int:
     it accepts ``artifact_id`` as an arg. We pass the artifact-id set
     captured BEFORE artifact deletion (``_list_artifact_ids``) so the
     filter still resolves.
+
+    SPEC-TI-003-FOLLOWUP-001 AC-2 exception: this query targets the
+    procrastinate_jobs table, not knowledge.*, so a raw pool acquire
+    is allowed here.
     """
     if not artifact_ids:
         return 0
@@ -206,165 +217,176 @@ async def purge_connector(
     log = logger.bind(org_id=org_id, kb_slug=kb_slug, connector_id=connector_id)
     log.info("connector_purge_started")
 
-    # Step 1: capture artifact UUIDs before they vanish.
-    artifact_ids = await _list_artifact_ids(org_id, kb_slug, connector_id)
-    log.info("connector_purge_step_artifacts_listed", count=len(artifact_ids))
+    # SPEC-TI-003-FOLLOWUP-001 AC-1: tenant_scoped_connection so every
+    # knowledge.* read/write below sees the RLS GUC. The procrastinate-cancel
+    # steps use their own pool (they target procrastinate_jobs, AC-2 exception).
+    async with tenant_scoped_connection(org_id) as conn:
+        # Step 1: capture artifact UUIDs before they vanish.
+        artifact_ids = await _list_artifact_ids(conn, org_id, kb_slug, connector_id)
+        log.info("connector_purge_step_artifacts_listed", count=len(artifact_ids))
 
-    # Step 2: cancel enrichment jobs (uses extra_payload.source_connector_id).
-    enrichment_cancelled = await _cancel_enrichment_jobs(proc_app, connector_id)
-    log.info(
-        "connector_purge_step_enrichment_jobs_cancelled",
-        cancelled=enrichment_cancelled,
-    )
-
-    # Step 3: cancel graphiti jobs (uses artifact_id list from step 1).
-    graphiti_cancelled = await _cancel_graphiti_jobs(proc_app, artifact_ids)
-    log.info(
-        "connector_purge_step_graphiti_jobs_cancelled",
-        cancelled=graphiti_cancelled,
-    )
-
-    # Step 4: snapshot graphiti episode-ids so we can clean FalkorDB even
-    # after artifacts are gone (the join-key is artifact->episode in pg).
-    episode_ids = await pg_store.get_connector_episode_ids(org_id, kb_slug, connector_id)
-    log.info("connector_purge_step_episodes_listed", count=len(episode_ids))
-
-    # Step 4b: snapshot orphan S3 image keys BEFORE the artifact delete
-    # cascades the artifact_images rows away. Refcount on content_hash so
-    # we only return keys not referenced by any other artifact.
-    # SPEC-CONNECTOR-DELETE-LIFECYCLE-001 REQ-06.3.
-    orphan_image_keys = await pg_store.get_orphan_image_keys_for_connector(
-        org_id, kb_slug, connector_id
-    )
-    log.info(
-        "connector_purge_step_orphan_images_listed",
-        count=len(orphan_image_keys),
-    )
-
-    # Step 5: pg artifacts (and cascade — see function docstring).
-    artifacts_deleted = await pg_store.delete_connector_artifacts(org_id, kb_slug, connector_id)
-    log.info("connector_purge_step_artifacts_deleted", count=artifacts_deleted)
-
-    # Step 6: pg crawl_jobs.
-    crawl_jobs_deleted = await pg_store.delete_connector_crawl_jobs(org_id, kb_slug, connector_id)
-    log.info("connector_purge_step_crawl_jobs_deleted", count=crawl_jobs_deleted)
-
-    # Step 7: FalkorDB episodes (using the snapshot we just took).
-    await graph_module.delete_kb_episodes(org_id, episode_ids)
-    log.info(
-        "connector_purge_step_falkor_episodes_deleted",
-        count=len(episode_ids),
-    )
-
-    # Step 8: Qdrant vectors.
-    await qdrant_store.delete_connector(org_id, kb_slug, connector_id)
-    log.info("connector_purge_step_qdrant_deleted")
-
-    # Step 9: Garage S3 image keys — orchestrator-scoped ones from step 4b.
-    s3_images_deleted = 0
-    image_store = None
-    try:
-        from knowledge_ingest.adapters.crawler import _build_image_store
-
-        image_store = _build_image_store()
-    except Exception:
-        logger.exception("connector_purge_step_image_store_init_failed")
-
-    if orphan_image_keys and image_store is not None:
-        s3_images_deleted = await image_store.delete_keys(orphan_image_keys)
+        # Step 2: cancel enrichment jobs (uses extra_payload.source_connector_id).
+        # Runs against procrastinate_jobs -- own pool acquire inside the helper.
+        enrichment_cancelled = await _cancel_enrichment_jobs(proc_app, connector_id)
         log.info(
-            "connector_purge_step_s3_images_deleted",
-            count=s3_images_deleted,
-            requested=len(orphan_image_keys),
+            "connector_purge_step_enrichment_jobs_cancelled",
+            cancelled=enrichment_cancelled,
         )
 
-    # Step 10 (JANITOR): catch the cleanup-misses that the per-connector
-    # logic above structurally cannot find:
-    #   a) FalkorDB episodes written AFTER our cancel — graphiti tasks
-    #      with sync LLM calls don't honour asyncio cancellation, so
-    #      mid-flight episodes can land between cancel + delete. The
-    #      artifact-id snapshot we took in step 1 still applies — any
-    #      episode in FalkorDB referencing those artifact-ids is now
-    #      orphan because the artifact rows are gone (step 5).
-    #   b) Garage keys that lost their last reference at step 5's CASCADE
-    #      on artifact_images. Refcount on content_hash: a key is orphan
-    #      iff no artifact in this KB still references its hash.
-    # Both run unconditionally — even when steps 4b/7 returned zero,
-    # because their inputs depend on rows that no longer exist.
-    # Org-wide sweep: catches both this connector's late-arrivers AND
-    # historical orphans from previous failed purges. Computes alive
-    # episode-uuid set from postgres
-    # (``artifacts.extra->>'graphiti_episode_id'`` — the FalkorDB
-    # ``Episodic.uuid`` value the ingest pipeline persists) and
-    # intersects against the org's FalkorDB graph.
-    alive_episode_uuids = await pg_store.get_alive_episode_uuids_for_org(org_id)
-    falkor_orphans_deleted = await graph_module.sweep_orphan_episodes_org_wide(
-        org_id, alive_episode_uuids
-    )
-    log.info(
-        "connector_purge_step_falkor_orphans_swept",
-        count=falkor_orphans_deleted,
-        alive_episode_count=len(alive_episode_uuids),
-    )
+        # Step 3: cancel graphiti jobs (uses artifact_id list from step 1).
+        graphiti_cancelled = await _cancel_graphiti_jobs(proc_app, artifact_ids)
+        log.info(
+            "connector_purge_step_graphiti_jobs_cancelled",
+            cancelled=graphiti_cancelled,
+        )
 
-    janitor_s3_deleted = 0
-    if image_store is not None:
+        # Step 4: snapshot graphiti episode-ids so we can clean FalkorDB even
+        # after artifacts are gone (the join-key is artifact->episode in pg).
+        episode_ids = await pg_store.get_connector_episode_ids(conn, org_id, kb_slug, connector_id)
+        log.info("connector_purge_step_episodes_listed", count=len(episode_ids))
+
+        # Step 4b: snapshot orphan S3 image keys BEFORE the artifact delete
+        # cascades the artifact_images rows away. Refcount on content_hash so
+        # we only return keys not referenced by any other artifact.
+        # SPEC-CONNECTOR-DELETE-LIFECYCLE-001 REQ-06.3.
+        orphan_image_keys = await pg_store.get_orphan_image_keys_for_connector(
+            conn, org_id, kb_slug, connector_id
+        )
+        log.info(
+            "connector_purge_step_orphan_images_listed",
+            count=len(orphan_image_keys),
+        )
+
+        # Step 5: pg artifacts (and cascade — see function docstring).
+        artifacts_deleted = await pg_store.delete_connector_artifacts(
+            conn, org_id, kb_slug, connector_id
+        )
+        log.info("connector_purge_step_artifacts_deleted", count=artifacts_deleted)
+
+        # Step 6: pg crawl_jobs.
+        crawl_jobs_deleted = await pg_store.delete_connector_crawl_jobs(
+            conn, org_id, kb_slug, connector_id
+        )
+        log.info("connector_purge_step_crawl_jobs_deleted", count=crawl_jobs_deleted)
+
+        # Step 7: FalkorDB episodes (using the snapshot we just took).
+        await graph_module.delete_kb_episodes(org_id, episode_ids)
+        log.info(
+            "connector_purge_step_falkor_episodes_deleted",
+            count=len(episode_ids),
+        )
+
+        # Step 8: Qdrant vectors.
+        await qdrant_store.delete_connector(org_id, kb_slug, connector_id)
+        log.info("connector_purge_step_qdrant_deleted")
+
+        # Step 9: Garage S3 image keys — orchestrator-scoped ones from step 4b.
+        s3_images_deleted = 0
+        image_store = None
         try:
-            from minio import Minio
-
             from knowledge_ingest.adapters.crawler import _build_image_store
-            from knowledge_ingest.config import settings as ki_settings
 
-            active_hashes = await pg_store.get_active_image_hashes_for_kb(org_id, kb_slug)
-            # List all S3 keys under {org}/images/{kb_slug}/, derive the
-            # content_hash from each filename, and propose for delete the
-            # ones whose hash isn't in active_hashes.
-            prefix = f"{org_id}/images/{kb_slug}/"
-            from minio import Minio  # noqa: F811
-
-            mc = Minio(
-                ki_settings.garage_s3_endpoint,
-                access_key=ki_settings.garage_access_key,
-                secret_key=ki_settings.garage_secret_key,
-                region=ki_settings.garage_region,
-                secure=False,
-            )
-            orphan_under_prefix: list[str] = []
-            for obj in mc.list_objects(ki_settings.garage_bucket, prefix=prefix, recursive=True):
-                key = obj.object_name
-                basename = key.rsplit("/", 1)[-1]
-                content_hash = basename.rsplit(".", 1)[0]
-                if content_hash and content_hash not in active_hashes:
-                    orphan_under_prefix.append(key)
-            if orphan_under_prefix:
-                janitor_s3_deleted = await image_store.delete_keys(orphan_under_prefix)
-            log.info(
-                "connector_purge_step_garage_orphans_swept",
-                count=janitor_s3_deleted,
-                scanned=len(orphan_under_prefix),
-                active_hashes=len(active_hashes),
-            )
+            image_store = _build_image_store()
         except Exception:
-            logger.exception("connector_purge_step_garage_janitor_failed")
+            logger.exception("connector_purge_step_image_store_init_failed")
 
-    s3_images_deleted += janitor_s3_deleted
+        if orphan_image_keys and image_store is not None:
+            s3_images_deleted = await image_store.delete_keys(orphan_image_keys)
+            log.info(
+                "connector_purge_step_s3_images_deleted",
+                count=s3_images_deleted,
+                requested=len(orphan_image_keys),
+            )
 
-    # NOTE: connector.sync_runs cleanup is invoked by the portal-side
-    # delete-orchestration BEFORE it asks knowledge-ingest to purge. That
-    # keeps cross-service auth + tenant-scoping aligned with how the rest
-    # of klai-connector's API is gated. When SPEC-CONNECTOR-CLEANUP-001
-    # REQ-04 lands the cross-schema FK CASCADE, even that explicit call
-    # becomes redundant (the portal_connectors row delete cascades).
+        # Step 10 (JANITOR): catch the cleanup-misses that the per-connector
+        # logic above structurally cannot find:
+        #   a) FalkorDB episodes written AFTER our cancel — graphiti tasks
+        #      with sync LLM calls don't honour asyncio cancellation, so
+        #      mid-flight episodes can land between cancel + delete. The
+        #      artifact-id snapshot we took in step 1 still applies — any
+        #      episode in FalkorDB referencing those artifact-ids is now
+        #      orphan because the artifact rows are gone (step 5).
+        #   b) Garage keys that lost their last reference at step 5's CASCADE
+        #      on artifact_images. Refcount on content_hash: a key is orphan
+        #      iff no artifact in this KB still references its hash.
+        # Both run unconditionally — even when steps 4b/7 returned zero,
+        # because their inputs depend on rows that no longer exist.
+        # Org-wide sweep: catches both this connector's late-arrivers AND
+        # historical orphans from previous failed purges. Computes alive
+        # episode-uuid set from postgres
+        # (``artifacts.extra->>'graphiti_episode_id'`` — the FalkorDB
+        # ``Episodic.uuid`` value the ingest pipeline persists) and
+        # intersects against the org's FalkorDB graph.
+        alive_episode_uuids = await pg_store.get_alive_episode_uuids_for_org(conn, org_id)
+        falkor_orphans_deleted = await graph_module.sweep_orphan_episodes_org_wide(
+            org_id, alive_episode_uuids
+        )
+        log.info(
+            "connector_purge_step_falkor_orphans_swept",
+            count=falkor_orphans_deleted,
+            alive_episode_count=len(alive_episode_uuids),
+        )
 
-    report = CleanupReport(
-        enrichment_jobs_cancelled=enrichment_cancelled,
-        graphiti_jobs_cancelled=graphiti_cancelled,
-        artifacts_deleted=artifacts_deleted,
-        crawl_jobs_deleted=crawl_jobs_deleted,
-        qdrant_chunks_deleted=0,  # qdrant_store.delete_connector doesn't return a count today
-        falkor_episodes_deleted=len(episode_ids) + falkor_orphans_deleted,
-        s3_images_deleted=s3_images_deleted,
-        sync_runs_deleted=None,
-    )
+        janitor_s3_deleted = 0
+        if image_store is not None:
+            try:
+                from minio import Minio
+
+                from knowledge_ingest.adapters.crawler import _build_image_store
+                from knowledge_ingest.config import settings as ki_settings
+
+                active_hashes = await pg_store.get_active_image_hashes_for_kb(conn, org_id, kb_slug)
+                # List all S3 keys under {org}/images/{kb_slug}/, derive the
+                # content_hash from each filename, and propose for delete the
+                # ones whose hash isn't in active_hashes.
+                prefix = f"{org_id}/images/{kb_slug}/"
+                from minio import Minio  # noqa: F811
+
+                mc = Minio(
+                    ki_settings.garage_s3_endpoint,
+                    access_key=ki_settings.garage_access_key,
+                    secret_key=ki_settings.garage_secret_key,
+                    region=ki_settings.garage_region,
+                    secure=False,
+                )
+                orphan_under_prefix: list[str] = []
+                for obj in mc.list_objects(
+                    ki_settings.garage_bucket, prefix=prefix, recursive=True
+                ):
+                    key = obj.object_name
+                    basename = key.rsplit("/", 1)[-1]
+                    content_hash = basename.rsplit(".", 1)[0]
+                    if content_hash and content_hash not in active_hashes:
+                        orphan_under_prefix.append(key)
+                if orphan_under_prefix:
+                    janitor_s3_deleted = await image_store.delete_keys(orphan_under_prefix)
+                log.info(
+                    "connector_purge_step_garage_orphans_swept",
+                    count=janitor_s3_deleted,
+                    scanned=len(orphan_under_prefix),
+                    active_hashes=len(active_hashes),
+                )
+            except Exception:
+                logger.exception("connector_purge_step_garage_janitor_failed")
+
+        s3_images_deleted += janitor_s3_deleted
+
+        # NOTE: connector.sync_runs cleanup is invoked by the portal-side
+        # delete-orchestration BEFORE it asks knowledge-ingest to purge. That
+        # keeps cross-service auth + tenant-scoping aligned with how the rest
+        # of klai-connector's API is gated. When SPEC-CONNECTOR-CLEANUP-001
+        # REQ-04 lands the cross-schema FK CASCADE, even that explicit call
+        # becomes redundant (the portal_connectors row delete cascades).
+
+        report = CleanupReport(
+            enrichment_jobs_cancelled=enrichment_cancelled,
+            graphiti_jobs_cancelled=graphiti_cancelled,
+            artifacts_deleted=artifacts_deleted,
+            crawl_jobs_deleted=crawl_jobs_deleted,
+            qdrant_chunks_deleted=0,  # qdrant_store.delete_connector doesn't return a count today
+            falkor_episodes_deleted=len(episode_ids) + falkor_orphans_deleted,
+            s3_images_deleted=s3_images_deleted,
+            sync_runs_deleted=None,
+        )
     log.info("connector_purge_completed", **report.as_dict())
     return report

--- a/klai-knowledge-ingest/knowledge_ingest/crawl_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/crawl_tasks.py
@@ -1,4 +1,5 @@
 """Procrastinate task for async bulk web crawling."""
+
 from __future__ import annotations
 
 from typing import Any
@@ -57,10 +58,17 @@ def register_crawl_tasks(procrastinate_app: Any) -> None:
             )
 
         from knowledge_ingest.adapters.crawler import run_crawl_job
-        # SPEC-TI-003 AC-9: set RLS GUC for all knowledge.* writes inside run_crawl_job
-        async with tenant_scoped_connection(org_id) as _conn:
-            del _conn  # connection held open to keep GUC set; pg_store uses pool
+
+        # SPEC-TI-003-FOLLOWUP-001 AC-1: pass the GUC-pinned connection down
+        # into run_crawl_job so every knowledge.* query inside (crawl_jobs
+        # progress updates, page hash dedup, link graph, ingest) sees the
+        # tenant context. The previous shape (``del _conn``) was the bug
+        # this SPEC-FOLLOWUP fixes -- pg_store.* would grab a different
+        # pool connection without the GUC, leaving RLS silently default-deny
+        # once SPEC-TI-011 lands FORCE.
+        async with tenant_scoped_connection(org_id) as conn:
             await run_crawl_job(
+                conn,
                 job_id=job_id,
                 org_id=org_id,
                 kb_slug=kb_slug,

--- a/klai-knowledge-ingest/knowledge_ingest/db.py
+++ b/klai-knowledge-ingest/knowledge_ingest/db.py
@@ -7,6 +7,11 @@ parsing when the password contains special chars like +, /, =.
 SPEC-TI-003: Added tenant_scoped_connection() context manager for RLS-enabled
 queries. Mirrors klai-portal/backend/app/core/database.py set_tenant pattern
 adapted for asyncpg pool (no SQLAlchemy session -- raw asyncpg Connection).
+
+SPEC-TI-003-FOLLOWUP-001: Added cross_org_admin_connection() context manager
+for startup reapers and deprovision sweeps that legitimately span tenants.
+Mirrors klai-connector/app/core/database.py::cross_org_session() but with the
+asyncpg.Connection shape used here.
 """
 
 from __future__ import annotations
@@ -51,35 +56,60 @@ async def close_pool() -> None:
 
 # @MX:ANCHOR: tenant RLS entry point for knowledge-ingest background tasks
 # @MX:REASON: Every Procrastinate task + background worker that touches
-#             RLS-protected knowledge.* tables MUST use this helper.
-#             SPEC-TI-003 AC-9.
+#             RLS-protected knowledge.* tables MUST use this helper AND
+#             pass the yielded connection down to every query.
+#             SPEC-TI-003 AC-9 + SPEC-TI-003-FOLLOWUP-001 AC-1/AC-4.
 @asynccontextmanager
 async def tenant_scoped_connection(org_id: str) -> AsyncIterator[asyncpg.Connection]:
     """Pin a connection from the pool, set RLS tenant context, yield, then reset.
 
-    SPEC-TI-003 -- RLS Cat-D: knowledge.* tables require app.current_org_id GUC
-    to be set on the connection before any DML. This helper:
+    SPEC-TI-003 -- RLS Cat-D: knowledge.* tables require ``app.current_org_id``
+    GUC to be set on the connection before any DML.
 
-      1. Acquires a dedicated connection from the pool (pin -- prevents the GUC
-         from bleeding to another coroutine via connection reuse).
-      2. Sets app.current_org_id = org_id via set_config (local=False so the
-         setting persists for the connection lifetime, not just one transaction).
-      3. Yields the pinned connection for caller use.
-      4. Resets the GUC to empty and clears app.cross_org_admin on exit (even on
-         exception) before returning the connection to the pool.
+    GUC locality (SPEC-TI-003-FOLLOWUP-001 AC-4)
+    ------------------------------------------
+    The GUC applies ONLY to queries issued via the YIELDED connection.
+    asyncpg's ``set_config(..., is_local=false)`` is session-level, but each
+    pool ``acquire()`` returns a different physical connection -- the GUC is
+    NOT shared across the pool. So:
 
-    Pattern mirrors portal-api tenant_scoped_session in
-    klai-portal/backend/app/core/database.py. Must be used for all
-    Procrastinate tasks and background workers that touch RLS-protected tables.
+      * DO pass ``conn`` down to every helper that issues SQL against
+        ``knowledge.*``::
+
+            async with tenant_scoped_connection(org_id) as conn:
+                await pg_store.create_artifact(conn, ...)
+
+      * DO NOT rely on "pinning" the GUC by holding the connection open while
+        another helper grabs its own pool connection -- that helper's
+        connection has no GUC and queries either fail with 42501 (when FORCE
+        RLS lands per SPEC-TI-011) or silently return zero rows.
+
+    Pattern mirrors portal-api ``tenant_scoped_session`` in
+    ``klai-portal/backend/app/core/database.py`` and connector
+    ``tenant_scoped_session`` in
+    ``klai-connector/app/core/database.py``. Used for all Procrastinate tasks
+    and background workers that touch RLS-protected tables.
+
+    Implementation:
+
+      1. Acquires a dedicated connection from the pool.
+      2. Sets ``app.current_org_id = org_id`` via ``set_config`` (``is_local=False``
+         so the setting persists for the connection lifetime, not just one
+         transaction).
+      3. Clears any lingering ``app.cross_org_admin`` bypass.
+      4. Yields the pinned connection for caller use.
+      5. Resets both GUCs to empty on exit (even on exception) before
+         returning the connection to the pool.
 
     Usage::
 
         async with tenant_scoped_connection(org_id) as conn:
             await conn.execute("INSERT INTO knowledge.artifacts (...) VALUES (...)")
+            await pg_store.create_artifact(conn, ...)  # pass conn down
     """
     pool = await get_pool()
     async with pool.acquire() as conn:
-        # Set tenant context -- local=False means the GUC persists for the
+        # Set tenant context -- is_local=False means the GUC persists for the
         # connection lifetime (not just the current transaction).
         await conn.execute("SELECT set_config('app.current_org_id', $1, false)", org_id)
         # Ensure any lingering cross_org_admin bypass is cleared.
@@ -88,5 +118,51 @@ async def tenant_scoped_connection(org_id: str) -> AsyncIterator[asyncpg.Connect
             yield conn
         finally:
             # Reset on exit so the connection is clean when returned to pool.
+            await conn.execute("SELECT set_config('app.current_org_id', '', false)")
+            await conn.execute("SELECT set_config('app.cross_org_admin', 'false', false)")
+
+
+# @MX:ANCHOR: cross-org admin entry point for knowledge-ingest startup/sweeps
+# @MX:REASON: Startup reapers, org-wide janitors, and deprovision sweeps need
+#             to read/write across tenants without a single org_id. They MUST
+#             use this helper instead of the raw pool so RLS policies (once
+#             FORCE lands per SPEC-TI-011) recognise the bypass.
+#             SPEC-TI-003-FOLLOWUP-001 AC-3.
+@asynccontextmanager
+async def cross_org_admin_connection() -> AsyncIterator[asyncpg.Connection]:
+    """Pin a connection, set the cross-org admin bypass GUC, yield, then reset.
+
+    For startup reapers, org-wide janitors, and deprovision sweeps that
+    legitimately span tenants. Mirrors
+    ``klai-connector/app/core/database.py::cross_org_session()``.
+
+    The bypass works in concert with the RLS policies: a future
+    ``OR current_setting('app.cross_org_admin', true) = 'true'`` clause on the
+    ``USING`` filter (planned for SPEC-TI-011 when services move off the
+    ``klai`` superuser DSN) reads this GUC and admits the query.
+
+    Until SPEC-TI-011 lands, the GUC is informational -- the ``klai``
+    superuser bypasses RLS regardless. Setting it now means audit logs already
+    show "this query was bewust admin" instead of "no GUC at all", and the
+    RLS policy upgrade in SPEC-TI-011 doesn't need a parallel caller refactor.
+
+    Usage::
+
+        async with cross_org_admin_connection() as conn:
+            await conn.execute("DELETE FROM knowledge.crawl_jobs WHERE state = 'stuck'")
+
+    Do NOT use for tenant-scoped work -- use ``tenant_scoped_connection(org_id)``
+    instead so per-tenant policies fire correctly.
+    """
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        # Clear any lingering tenant context from a prior connection-recycle.
+        await conn.execute("SELECT set_config('app.current_org_id', '', false)")
+        # Mark this connection as a bewust cross-org admin caller.
+        await conn.execute("SELECT set_config('app.cross_org_admin', 'true', false)")
+        try:
+            yield conn
+        finally:
+            # Reset both on exit so the connection is clean when returned.
             await conn.execute("SELECT set_config('app.current_org_id', '', false)")
             await conn.execute("SELECT set_config('app.cross_org_admin', 'false', false)")

--- a/klai-knowledge-ingest/knowledge_ingest/domain_selectors.py
+++ b/klai-knowledge-ingest/knowledge_ingest/domain_selectors.py
@@ -5,10 +5,14 @@ Stores and retrieves the best known CSS selector per (domain, org_id) pair so
 that repeat crawls of the same domain do not need manual selector entry.
 
 SPEC-CRAWL-001 / R-2, R-3
+SPEC-TI-003-FOLLOWUP-001 AC-1: helpers take an asyncpg.Connection from a
+tenant_scoped_connection(org_id) block instead of acquiring a fresh pool
+connection (which would not see the RLS GUC).
 """
+
 from urllib.parse import urlparse
 
-from knowledge_ingest.db import get_pool
+import asyncpg
 
 
 def extract_domain(url: str) -> str:
@@ -16,13 +20,14 @@ def extract_domain(url: str) -> str:
     return urlparse(url).netloc
 
 
-async def get_domain_selector(domain: str, org_id: str) -> tuple[str, str] | None:
+async def get_domain_selector(
+    conn: asyncpg.Connection, domain: str, org_id: str
+) -> tuple[str, str] | None:
     """Return (css_selector, selector_source) for the given domain+org, or None.
 
     selector_source is 'user' or 'ai'.
     """
-    pool = await get_pool()
-    row = await pool.fetchrow(
+    row = await conn.fetchrow(
         """
         SELECT css_selector, selector_source
         FROM knowledge.crawl_domains
@@ -37,6 +42,7 @@ async def get_domain_selector(domain: str, org_id: str) -> tuple[str, str] | Non
 
 
 async def upsert_domain_selector(
+    conn: asyncpg.Connection,
     domain: str,
     org_id: str,
     css_selector: str,
@@ -48,8 +54,7 @@ async def upsert_domain_selector(
     A user selector always overwrites an AI selector (enforced by caller — no
     special logic needed here since the caller only calls this when appropriate).
     """
-    pool = await get_pool()
-    await pool.execute(
+    await conn.execute(
         """
         INSERT INTO knowledge.crawl_domains
             (domain, org_id, css_selector, selector_source, created_at, updated_at)

--- a/klai-knowledge-ingest/knowledge_ingest/enrichment_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/enrichment_tasks.py
@@ -32,7 +32,7 @@ import structlog
 
 from knowledge_ingest import embedder, enrichment, kb_config, qdrant_store, queues, sparse_embedder
 from knowledge_ingest.content_profiles import get_profile
-from knowledge_ingest.db import get_pool
+from knowledge_ingest.db import tenant_scoped_connection
 
 logger = structlog.get_logger()
 
@@ -198,33 +198,40 @@ def _register_tasks(procrastinate_app: Any) -> None:
         Closes the regrow window — graphiti tasks have no
         ``source_connector_id`` arg, so the artifact-presence check is the
         canonical signal here.
+
+        SPEC-TI-003-FOLLOWUP-001 AC-1: opens a tenant_scoped_connection on
+        ``org_id`` so artifact_exists + update_artifact_extra both run with
+        the RLS GUC pinned to this tenant.
         """
         from knowledge_ingest import pg_store
 
-        if not await pg_store.artifact_exists(artifact_id):
+        async with tenant_scoped_connection(org_id) as conn:
+            if not await pg_store.artifact_exists(conn, artifact_id):
+                logger.info(
+                    "graphiti_aborted_artifact_missing",
+                    artifact_id=artifact_id,
+                    org_id=org_id,
+                )
+                return
             logger.info(
-                "graphiti_aborted_artifact_missing",
+                "graphiti_episode_started",
                 artifact_id=artifact_id,
                 org_id=org_id,
+                content_type=content_type,
             )
-            return
-        logger.info(
-            "graphiti_episode_started",
-            artifact_id=artifact_id,
-            org_id=org_id,
-            content_type=content_type,
-        )
-        from knowledge_ingest import graph as graph_module
+            from knowledge_ingest import graph as graph_module
 
-        episode_id = await graph_module.ingest_episode(
-            artifact_id=artifact_id,
-            document_text=document_text,
-            org_id=org_id,
-            content_type=content_type,
-            belief_time_start=belief_time_start,
-        )
-        if episode_id:
-            await pg_store.update_artifact_extra(artifact_id, {"graphiti_episode_id": episode_id})
+            episode_id = await graph_module.ingest_episode(
+                artifact_id=artifact_id,
+                document_text=document_text,
+                org_id=org_id,
+                content_type=content_type,
+                belief_time_start=belief_time_start,
+            )
+            if episode_id:
+                await pg_store.update_artifact_extra(
+                    conn, artifact_id, {"graphiti_episode_id": episode_id}
+                )
 
     procrastinate_app.ingest_graphiti_episode = ingest_graphiti_episode  # type: ignore[attr-defined]
 
@@ -386,26 +393,29 @@ async def _enrich_document(
 
         # Refresh visibility from kb_config at write time — catches any visibility
         # change that happened while this task was queued or running.
-        pool = await get_pool()
-        extra_payload["visibility"] = await kb_config.get_kb_visibility(org_id, kb_slug, pool)
+        # SPEC-TI-003-FOLLOWUP-001 AC-1: tenant_scoped_connection so kb_config +
+        # insert_parent_chunks see the RLS GUC for this org.
+        async with tenant_scoped_connection(org_id) as conn:
+            extra_payload["visibility"] = await kb_config.get_kb_visibility(conn, org_id, kb_slug)
 
-        # SPEC-RAG-PARENT-CHILD-001: persist parents to Postgres NOW so the
-        # generated row ids can be threaded into each child's Qdrant payload.
-        # Skipped (parent_chunk_ids list of None) when this ingest path was
-        # called without parents — keeps backward-compat for any caller that
-        # hasn't been switched to chunk_markdown_with_parents yet.
-        parent_chunk_ids: list[int | None] = [None] * len(enriched_chunks)
-        if parents and parent_index_per_child:
-            from knowledge_ingest import pg_store
+            # SPEC-RAG-PARENT-CHILD-001: persist parents to Postgres NOW so the
+            # generated row ids can be threaded into each child's Qdrant payload.
+            # Skipped (parent_chunk_ids list of None) when this ingest path was
+            # called without parents — keeps backward-compat for any caller that
+            # hasn't been switched to chunk_markdown_with_parents yet.
+            parent_chunk_ids: list[int | None] = [None] * len(enriched_chunks)
+            if parents and parent_index_per_child:
+                from knowledge_ingest import pg_store
 
-            inserted_ids = await pg_store.insert_parent_chunks(
-                artifact_id=artifact_id,
-                org_id=org_id,
-                parents=parents,
-            )
-            for i, parent_idx in enumerate(parent_index_per_child):
-                if parent_idx is not None and 0 <= parent_idx < len(inserted_ids):
-                    parent_chunk_ids[i] = inserted_ids[parent_idx]
+                inserted_ids = await pg_store.insert_parent_chunks(
+                    conn,
+                    artifact_id=artifact_id,
+                    org_id=org_id,
+                    parents=parents,
+                )
+                for i, parent_idx in enumerate(parent_index_per_child):
+                    if parent_idx is not None and 0 <= parent_idx < len(inserted_ids):
+                        parent_chunk_ids[i] = inserted_ids[parent_idx]
 
         # Step 4: Upsert enriched chunks to Qdrant
         t0 = time.monotonic()
@@ -455,14 +465,13 @@ async def _enrich_document(
         # After max_attempts the job lands in permanent-failed state — visible in
         # logs and the Procrastinate dashboard.
         total_ms = int((time.monotonic() - t_total) * 1000)
-        logger.error(
+        logger.exception(
             "enrichment_failed_will_retry",
             kb_slug=kb_slug,
             path=path,
             org_id=org_id,
             artifact_id=artifact_id,
             total_ms=total_ms,
-            exc_info=True,
         )
         raise  # Procrastinate retry handles this
 
@@ -472,12 +481,11 @@ async def _enrich_document(
         # basic embeddings.  These are infrastructure issues, not data quality
         # issues, so retrying the enrichment LLM call would not help.
         total_ms = int((time.monotonic() - t_total) * 1000)
-        logger.error(
+        logger.exception(
             "enrichment_infra_failed",
             kb_slug=kb_slug,
             path=path,
             org_id=org_id,
             artifact_id=artifact_id,
             total_ms=total_ms,
-            exc_info=True,
         )

--- a/klai-knowledge-ingest/knowledge_ingest/kb_config.py
+++ b/klai-knowledge-ingest/knowledge_ingest/kb_config.py
@@ -5,14 +5,20 @@ Visibility values: "public" | "internal" | "private"
 Default: "internal" (org-only, no per-user restriction).
 
 Cache TTL: 60 seconds. NOTIFY evicts specific KB immediately on config change.
+
+SPEC-TI-003-FOLLOWUP-001 AC-1/AC-2: read/write helpers take an
+asyncpg.Connection (from tenant_scoped_connection); the LISTEN/NOTIFY
+``start_listener`` keeps the pool because it does not issue knowledge.*
+SQL -- it pins one connection for the lifetime of the service.
 """
+
 from __future__ import annotations
 
 import asyncio
-import structlog
 
 import asyncpg
 import cachetools
+import structlog
 
 logger = structlog.get_logger()
 
@@ -23,14 +29,14 @@ def _cache_key(org_id: str, kb_slug: str) -> str:
     return f"{org_id}:{kb_slug}"
 
 
-async def get_kb_visibility(org_id: str, kb_slug: str, pool: asyncpg.Pool) -> str:
+async def get_kb_visibility(conn: asyncpg.Connection, org_id: str, kb_slug: str) -> str:
     """Return the visibility for this KB. Defaults to 'internal' when not configured."""
     key = _cache_key(org_id, kb_slug)
     if key in _cache:
         return str(_cache[key])
 
     try:
-        row = await pool.fetchrow(
+        row = await conn.fetchrow(
             "SELECT visibility FROM knowledge.kb_config WHERE org_id = $1 AND kb_slug = $2",
             org_id,
             kb_slug,
@@ -47,9 +53,11 @@ async def get_kb_visibility(org_id: str, kb_slug: str, pool: asyncpg.Pool) -> st
     return visibility
 
 
-async def set_kb_visibility(org_id: str, kb_slug: str, visibility: str, pool: asyncpg.Pool) -> None:
+async def set_kb_visibility(
+    conn: asyncpg.Connection, org_id: str, kb_slug: str, visibility: str
+) -> None:
     """Upsert KB visibility config. Evicts cache immediately."""
-    await pool.execute(
+    await conn.execute(
         """
         INSERT INTO knowledge.kb_config (org_id, kb_slug, visibility, updated_at)
         VALUES ($1, $2, $3, NOW())
@@ -70,6 +78,9 @@ async def start_listener(pool: asyncpg.Pool) -> None:
     Listen on kb_config_changed channel.
     Evicts the specific KB from the TTL cache when its config changes.
     Runs indefinitely as a background task — cancel to stop.
+
+    Pool-acquire is permitted here per SPEC-TI-003-FOLLOWUP-001 AC-2:
+    LISTEN/NOTIFY does not emit SQL against knowledge.* tables.
     """
     conn: asyncpg.Connection = await pool.acquire()  # type: ignore[assignment]
     try:
@@ -81,7 +92,7 @@ async def start_listener(pool: asyncpg.Pool) -> None:
         try:
             await conn.remove_listener("kb_config_changed", _on_kb_config_changed)
         except Exception:
-            pass
+            logger.exception("kb_config_listener_cleanup_failed")
         await pool.release(conn)
 
 

--- a/klai-knowledge-ingest/knowledge_ingest/link_graph.py
+++ b/klai-knowledge-ingest/knowledge_ingest/link_graph.py
@@ -1,7 +1,10 @@
 """
 Async query helpers for the page_links link graph (SPEC-CRAWLER-003).
 
-All queries are org- and kb-scoped for tenant isolation.
+All queries are org- and kb-scoped for tenant isolation. Per
+SPEC-TI-003-FOLLOWUP-001 AC-1 every helper takes the GUC-pinned
+``asyncpg.Connection`` as its first argument; callers obtain it via
+``tenant_scoped_connection(org_id)``.
 """
 
 import asyncpg
@@ -11,10 +14,10 @@ logger = structlog.get_logger()
 
 
 async def get_outbound_urls(
-    url: str, org_id: str, kb_slug: str, pool: asyncpg.Pool
+    conn: asyncpg.Connection, url: str, org_id: str, kb_slug: str
 ) -> list[str]:
     """Return all URLs that `url` links to within this org/kb."""
-    rows = await pool.fetch(
+    rows = await conn.fetch(
         "SELECT to_url FROM knowledge.page_links "
         "WHERE org_id = $1 AND kb_slug = $2 AND from_url = $3",
         org_id,
@@ -25,10 +28,10 @@ async def get_outbound_urls(
 
 
 async def get_anchor_texts(
-    url: str, org_id: str, kb_slug: str, pool: asyncpg.Pool
+    conn: asyncpg.Connection, url: str, org_id: str, kb_slug: str
 ) -> list[str]:
     """Return non-empty anchor texts from pages linking TO `url`."""
-    rows = await pool.fetch(
+    rows = await conn.fetch(
         "SELECT link_text FROM knowledge.page_links "
         "WHERE org_id = $1 AND kb_slug = $2 AND to_url = $3",
         org_id,
@@ -38,11 +41,9 @@ async def get_anchor_texts(
     return [r["link_text"] for r in rows if r["link_text"] and r["link_text"].strip()]
 
 
-async def get_incoming_count(
-    url: str, org_id: str, kb_slug: str, pool: asyncpg.Pool
-) -> int:
+async def get_incoming_count(conn: asyncpg.Connection, url: str, org_id: str, kb_slug: str) -> int:
     """Return the number of pages linking TO `url` within this org/kb."""
-    count = await pool.fetchval(
+    count = await conn.fetchval(
         "SELECT COUNT(*) FROM knowledge.page_links "
         "WHERE org_id = $1 AND kb_slug = $2 AND to_url = $3",
         org_id,
@@ -57,7 +58,7 @@ async def get_incoming_count(
 #   with enrichment. The two-phase pipeline (SPEC-CRAWLER-005) makes
 #   incoming_link_count final at first Qdrant write via get_incoming_count() per-page.
 async def compute_incoming_counts(
-    org_id: str, kb_slug: str, pool: asyncpg.Pool
+    conn: asyncpg.Connection, org_id: str, kb_slug: str
 ) -> dict[str, int]:
     """DEPRECATED (SPEC-CRAWLER-005 REQ-05.1): No production caller since the
     two-phase pipeline makes incoming_link_count final at first Qdrant write.
@@ -66,7 +67,7 @@ async def compute_incoming_counts(
 
     Return a dict mapping each to_url to its incoming link count.
     """
-    rows = await pool.fetch(
+    rows = await conn.fetch(
         "SELECT to_url, COUNT(*) AS cnt FROM knowledge.page_links "
         "WHERE org_id = $1 AND kb_slug = $2 "
         "GROUP BY to_url",

--- a/klai-knowledge-ingest/knowledge_ingest/org_config.py
+++ b/klai-knowledge-ingest/knowledge_ingest/org_config.py
@@ -4,12 +4,17 @@ Per-org enrichment configuration with TTL cache and PostgreSQL NOTIFY-based evic
 Global kill switch: ENRICHMENT_ENABLED env var (settings.enrichment_enabled).
 Per-org override: knowledge.org_config table. NULL = use global default (enabled).
 Cache TTL: 60 seconds. NOTIFY evicts specific org immediately on config change.
+
+SPEC-TI-003-FOLLOWUP-001 AC-1/AC-2: ``is_enrichment_enabled`` takes an
+asyncpg.Connection (from tenant_scoped_connection); ``start_listener`` keeps
+the pool because LISTEN/NOTIFY does not emit SQL against knowledge.* tables.
 """
+
 import asyncio
-import structlog
 
 import asyncpg
 import cachetools
+import structlog
 
 from knowledge_ingest.config import settings
 
@@ -18,7 +23,7 @@ logger = structlog.get_logger()
 _cache: cachetools.TTLCache = cachetools.TTLCache(maxsize=20_000, ttl=60)
 
 
-async def is_enrichment_enabled(org_id: str, pool: asyncpg.Pool) -> bool:
+async def is_enrichment_enabled(conn: asyncpg.Connection, org_id: str) -> bool:
     """Check if enrichment is enabled for this org. Global kill switch takes priority."""
     if not settings.enrichment_enabled:
         return False
@@ -26,15 +31,11 @@ async def is_enrichment_enabled(org_id: str, pool: asyncpg.Pool) -> bool:
     if org_id in _cache:
         return bool(_cache[org_id])
 
-    row = await pool.fetchrow(
+    row = await conn.fetchrow(
         "SELECT enrichment_enabled FROM knowledge.org_config WHERE org_id = $1",
         org_id,
     )
-    enabled = (
-        row["enrichment_enabled"]
-        if row and row["enrichment_enabled"] is not None
-        else True
-    )
+    enabled = row["enrichment_enabled"] if row and row["enrichment_enabled"] is not None else True
     _cache[org_id] = enabled
     return enabled
 
@@ -44,6 +45,9 @@ async def start_listener(pool: asyncpg.Pool) -> None:
     Listen on org_config_changed channel.
     Evicts the specific org from the TTL cache when its config changes.
     Runs indefinitely as a background task — cancel to stop.
+
+    Pool-acquire is permitted here per SPEC-TI-003-FOLLOWUP-001 AC-2:
+    LISTEN/NOTIFY does not emit SQL against knowledge.* tables.
     """
     conn: asyncpg.Connection = await pool.acquire()  # type: ignore[assignment]
     try:
@@ -55,7 +59,7 @@ async def start_listener(pool: asyncpg.Pool) -> None:
         try:
             await conn.remove_listener("org_config_changed", _on_org_config_changed)
         except Exception:
-            pass
+            logger.exception("org_config_listener_cleanup_failed")
         await pool.release(conn)
 
 

--- a/klai-knowledge-ingest/knowledge_ingest/pg_store.py
+++ b/klai-knowledge-ingest/knowledge_ingest/pg_store.py
@@ -1,20 +1,31 @@
 """
 PostgreSQL artifact tracking for knowledge-ingest.
+
+SPEC-TI-003-FOLLOWUP-001 AC-1/AC-2:
+Every function in this module that issues SQL against ``knowledge.*`` tables
+takes an ``asyncpg.Connection`` as its first argument and uses it for all
+query execution. Callers obtain the connection via
+``tenant_scoped_connection(org_id)`` (per-tenant work) or
+``cross_org_admin_connection()`` (org-wide janitor / startup work) from
+``knowledge_ingest.db``. Pool acquisition is no longer permitted inside this
+module -- the GUC pinned by the helper would not be visible to a fresh pool
+checkout.
 """
 
 import json
 import time
 import uuid
 
-from knowledge_ingest.db import get_pool
+import asyncpg
 
 _SENTINEL = 253402300800  # 9999-12-31 — sentinel value for "still active"
 
 
-async def get_active_content_hash(org_id: str, kb_slug: str, path: str) -> str | None:
+async def get_active_content_hash(
+    conn: asyncpg.Connection, org_id: str, kb_slug: str, path: str
+) -> str | None:
     """Return the content_hash of the current active artifact for this path, or None."""
-    pool = await get_pool()
-    row = await pool.fetchval(
+    row = await conn.fetchval(
         """
         SELECT content_hash
         FROM knowledge.artifacts
@@ -32,6 +43,7 @@ async def get_active_content_hash(org_id: str, kb_slug: str, path: str) -> str |
 
 
 async def create_artifact(
+    conn: asyncpg.Connection,
     org_id: str,
     kb_slug: str,
     path: str,
@@ -49,9 +61,8 @@ async def create_artifact(
     """Create a knowledge artifact record. Returns the artifact UUID."""
     artifact_id = str(uuid.uuid4())
     now = int(time.time())
-    pool = await get_pool()
     extra_json = json.dumps(extra) if extra else "{}"
-    await pool.execute(
+    await conn.execute(
         """
         INSERT INTO knowledge.artifacts
           (id, org_id, user_id, kb_slug, path,
@@ -87,14 +98,14 @@ def _personal_slug(user_id: str) -> str:
 
 
 async def list_personal_artifacts(
+    conn: asyncpg.Connection,
     org_id: str,
     user_id: str,
     limit: int = 50,
     offset: int = 0,
 ) -> list[dict]:
     """List active personal artifacts for a user, newest first."""
-    pool = await get_pool()
-    rows = await pool.fetch(
+    rows = await conn.fetch(
         """
         SELECT id, path, assertion_mode, created_at
         FROM knowledge.artifacts
@@ -114,10 +125,9 @@ async def list_personal_artifacts(
     return [dict(r) for r in rows]
 
 
-async def count_personal_artifacts(org_id: str, user_id: str) -> int:
+async def count_personal_artifacts(conn: asyncpg.Connection, org_id: str, user_id: str) -> int:
     """Count active personal artifacts for a user."""
-    pool = await get_pool()
-    row = await pool.fetchval(
+    row = await conn.fetchval(
         """
         SELECT COUNT(*)
         FROM knowledge.artifacts
@@ -134,13 +144,13 @@ async def count_personal_artifacts(org_id: str, user_id: str) -> int:
 
 
 async def get_personal_artifact(
+    conn: asyncpg.Connection,
     artifact_id: str,
     org_id: str,
     user_id: str,
 ) -> dict | None:
     """Get a single active personal artifact, or None if not found / wrong user."""
-    pool = await get_pool()
-    row = await pool.fetchrow(
+    row = await conn.fetchrow(
         """
         SELECT id, path
         FROM knowledge.artifacts
@@ -157,11 +167,12 @@ async def get_personal_artifact(
     return dict(row) if row else None
 
 
-async def soft_delete_artifact(org_id: str, kb_slug: str, path: str) -> None:
+async def soft_delete_artifact(
+    conn: asyncpg.Connection, org_id: str, kb_slug: str, path: str
+) -> None:
     """Set belief_time_end = now for all active artifacts matching this path."""
     now = int(time.time())
-    pool = await get_pool()
-    await pool.execute(
+    await conn.execute(
         """
         UPDATE knowledge.artifacts
         SET belief_time_end = $1
@@ -176,27 +187,25 @@ async def soft_delete_artifact(org_id: str, kb_slug: str, path: str) -> None:
     )
 
 
-async def get_episode_ids(org_id: str, kb_slug: str) -> list[str]:
+async def get_episode_ids(conn: asyncpg.Connection, org_id: str, kb_slug: str) -> list[str]:
     """Return Graphiti episode UUIDs for all artifacts in a KB.
 
     Reads the graphiti_episode_id from the extra JSON field before deletion.
     Excludes the 'no-chunks' sentinel (artifacts with no text content).
     """
-    pool = await get_pool()
-    async with pool.acquire() as conn:
-        rows = await conn.fetch(
-            """SELECT extra::jsonb->>'graphiti_episode_id' AS episode_id
-               FROM knowledge.artifacts
-               WHERE org_id = $1 AND kb_slug = $2
-                 AND extra IS NOT NULL
-                 AND extra::jsonb->>'graphiti_episode_id' IS NOT NULL""",
-            org_id,
-            kb_slug,
-        )
+    rows = await conn.fetch(
+        """SELECT extra::jsonb->>'graphiti_episode_id' AS episode_id
+           FROM knowledge.artifacts
+           WHERE org_id = $1 AND kb_slug = $2
+             AND extra IS NOT NULL
+             AND extra::jsonb->>'graphiti_episode_id' IS NOT NULL""",
+        org_id,
+        kb_slug,
+    )
     return [r["episode_id"] for r in rows if r["episode_id"] != "no-chunks"]
 
 
-async def delete_kb(org_id: str, kb_slug: str) -> None:
+async def delete_kb(conn: asyncpg.Connection, org_id: str, kb_slug: str) -> None:
     """Hard-delete all PostgreSQL records for a knowledge base.
 
     Removes: artifacts, artifact_entities, derivations, embedding_queue,
@@ -205,85 +214,85 @@ async def delete_kb(org_id: str, kb_slug: str) -> None:
     Does NOT delete knowledge.entities: entities are org-scoped and may be
     shared across multiple KBs within the same org.
     """
-    pool = await get_pool()
-    async with pool.acquire() as conn:
-        async with conn.transaction():
-            # Nullify self-references first to avoid FK violations when deleting artifacts
-            await conn.execute(
-                "UPDATE knowledge.artifacts SET superseded_by = NULL"
-                " WHERE org_id = $1 AND kb_slug = $2",
-                org_id,
-                kb_slug,
-            )
-            await conn.execute(
-                """DELETE FROM knowledge.embedding_queue WHERE artifact_id IN (
-                     SELECT id FROM knowledge.artifacts WHERE org_id = $1 AND kb_slug = $2
-                   )""",
-                org_id,
-                kb_slug,
-            )
-            await conn.execute(
-                """DELETE FROM knowledge.artifact_entities WHERE artifact_id IN (
-                     SELECT id FROM knowledge.artifacts WHERE org_id = $1 AND kb_slug = $2
-                   )""",
-                org_id,
-                kb_slug,
-            )
-            await conn.execute(
-                """DELETE FROM knowledge.derivations WHERE child_id IN (
-                     SELECT id FROM knowledge.artifacts WHERE org_id = $1 AND kb_slug = $2
-                   ) OR parent_id IN (
-                     SELECT id FROM knowledge.artifacts WHERE org_id = $1 AND kb_slug = $2
-                   )""",
-                org_id,
-                kb_slug,
-            )
-            await conn.execute(
-                "DELETE FROM knowledge.artifacts WHERE org_id = $1 AND kb_slug = $2",
-                org_id,
-                kb_slug,
-            )
-            await conn.execute(
-                "DELETE FROM knowledge.kb_config WHERE org_id = $1 AND kb_slug = $2",
-                org_id,
-                kb_slug,
-            )
-            await conn.execute(
-                "DELETE FROM knowledge.crawl_jobs WHERE org_id = $1 AND kb_slug = $2",
-                org_id,
-                kb_slug,
-            )
-            await conn.execute(
-                "DELETE FROM knowledge.crawled_pages WHERE org_id = $1 AND kb_slug = $2",
-                org_id,
-                kb_slug,
-            )
-            await conn.execute(
-                "DELETE FROM knowledge.page_links WHERE org_id = $1 AND kb_slug = $2",
-                org_id,
-                kb_slug,
-            )
-
-
-async def get_connector_episode_ids(org_id: str, kb_slug: str, connector_id: str) -> list[str]:
-    """Return Graphiti episode UUIDs for artifacts ingested by a specific connector."""
-    pool = await get_pool()
-    async with pool.acquire() as conn:
-        rows = await conn.fetch(
-            """SELECT extra::jsonb->>'graphiti_episode_id' AS episode_id
-               FROM knowledge.artifacts
-               WHERE org_id = $1 AND kb_slug = $2
-                 AND extra IS NOT NULL
-                 AND extra::jsonb->>'source_connector_id' = $3
-                 AND extra::jsonb->>'graphiti_episode_id' IS NOT NULL""",
+    async with conn.transaction():
+        # Nullify self-references first to avoid FK violations when deleting artifacts
+        await conn.execute(
+            "UPDATE knowledge.artifacts SET superseded_by = NULL"
+            " WHERE org_id = $1 AND kb_slug = $2",
             org_id,
             kb_slug,
-            connector_id,
         )
+        await conn.execute(
+            """DELETE FROM knowledge.embedding_queue WHERE artifact_id IN (
+                 SELECT id FROM knowledge.artifacts WHERE org_id = $1 AND kb_slug = $2
+               )""",
+            org_id,
+            kb_slug,
+        )
+        await conn.execute(
+            """DELETE FROM knowledge.artifact_entities WHERE artifact_id IN (
+                 SELECT id FROM knowledge.artifacts WHERE org_id = $1 AND kb_slug = $2
+               )""",
+            org_id,
+            kb_slug,
+        )
+        await conn.execute(
+            """DELETE FROM knowledge.derivations WHERE child_id IN (
+                 SELECT id FROM knowledge.artifacts WHERE org_id = $1 AND kb_slug = $2
+               ) OR parent_id IN (
+                 SELECT id FROM knowledge.artifacts WHERE org_id = $1 AND kb_slug = $2
+               )""",
+            org_id,
+            kb_slug,
+        )
+        await conn.execute(
+            "DELETE FROM knowledge.artifacts WHERE org_id = $1 AND kb_slug = $2",
+            org_id,
+            kb_slug,
+        )
+        await conn.execute(
+            "DELETE FROM knowledge.kb_config WHERE org_id = $1 AND kb_slug = $2",
+            org_id,
+            kb_slug,
+        )
+        await conn.execute(
+            "DELETE FROM knowledge.crawl_jobs WHERE org_id = $1 AND kb_slug = $2",
+            org_id,
+            kb_slug,
+        )
+        await conn.execute(
+            "DELETE FROM knowledge.crawled_pages WHERE org_id = $1 AND kb_slug = $2",
+            org_id,
+            kb_slug,
+        )
+        await conn.execute(
+            "DELETE FROM knowledge.page_links WHERE org_id = $1 AND kb_slug = $2",
+            org_id,
+            kb_slug,
+        )
+
+
+async def get_connector_episode_ids(
+    conn: asyncpg.Connection, org_id: str, kb_slug: str, connector_id: str
+) -> list[str]:
+    """Return Graphiti episode UUIDs for artifacts ingested by a specific connector."""
+    rows = await conn.fetch(
+        """SELECT extra::jsonb->>'graphiti_episode_id' AS episode_id
+           FROM knowledge.artifacts
+           WHERE org_id = $1 AND kb_slug = $2
+             AND extra IS NOT NULL
+             AND extra::jsonb->>'source_connector_id' = $3
+             AND extra::jsonb->>'graphiti_episode_id' IS NOT NULL""",
+        org_id,
+        kb_slug,
+        connector_id,
+    )
     return [r["episode_id"] for r in rows if r["episode_id"] != "no-chunks"]
 
 
-async def delete_connector_artifacts(org_id: str, kb_slug: str, connector_id: str) -> int:
+async def delete_connector_artifacts(
+    conn: asyncpg.Connection, org_id: str, kb_slug: str, connector_id: str
+) -> int:
     """Hard-delete all PostgreSQL artifact records for a specific connector.
 
     Follows the same cascade order as delete_kb():
@@ -297,112 +306,111 @@ async def delete_connector_artifacts(org_id: str, kb_slug: str, connector_id: st
 
     Returns the number of artifacts deleted.
     """
-    pool = await get_pool()
-    async with pool.acquire() as conn:
-        async with conn.transaction():
-            await conn.execute(
-                """UPDATE knowledge.artifacts SET superseded_by = NULL
-                   WHERE superseded_by IN (
-                     SELECT id FROM knowledge.artifacts
-                     WHERE org_id = $1 AND kb_slug = $2
-                       AND extra IS NOT NULL
-                       AND extra::jsonb->>'source_connector_id' = $3
-                   )""",
-                org_id,
-                kb_slug,
-                connector_id,
-            )
-            await conn.execute(
-                """DELETE FROM knowledge.embedding_queue WHERE artifact_id IN (
-                     SELECT id FROM knowledge.artifacts
-                     WHERE org_id = $1 AND kb_slug = $2
-                       AND extra IS NOT NULL
-                       AND extra::jsonb->>'source_connector_id' = $3
-                   )""",
-                org_id,
-                kb_slug,
-                connector_id,
-            )
-            await conn.execute(
-                """DELETE FROM knowledge.artifact_entities WHERE artifact_id IN (
-                     SELECT id FROM knowledge.artifacts
-                     WHERE org_id = $1 AND kb_slug = $2
-                       AND extra IS NOT NULL
-                       AND extra::jsonb->>'source_connector_id' = $3
-                   )""",
-                org_id,
-                kb_slug,
-                connector_id,
-            )
-            await conn.execute(
-                """DELETE FROM knowledge.derivations WHERE child_id IN (
-                     SELECT id FROM knowledge.artifacts
-                     WHERE org_id = $1 AND kb_slug = $2
-                       AND extra IS NOT NULL
-                       AND extra::jsonb->>'source_connector_id' = $3
-                   ) OR parent_id IN (
-                     SELECT id FROM knowledge.artifacts
-                     WHERE org_id = $1 AND kb_slug = $2
-                       AND extra IS NOT NULL
-                       AND extra::jsonb->>'source_connector_id' = $3
-                   )""",
-                org_id,
-                kb_slug,
-                connector_id,
-            )
-            # SPEC-CRAWLER-005 Fase 6 follow-up: scrub crawled_pages + page_links
-            # for URLs owned by this connector. Scoped via the artifact path-URL
-            # set (web_crawler/crawl adapters write artifacts with path=URL).
-            # Must run BEFORE the artifacts DELETE so the URL set is still
-            # reachable. Other connectors in the same KB remain untouched — their
-            # URLs don't appear in this connector's artifact set.
-            await conn.execute(
-                """DELETE FROM knowledge.crawled_pages
-                   WHERE org_id = $1 AND kb_slug = $2 AND url IN (
-                     SELECT path FROM knowledge.artifacts
-                     WHERE org_id = $1 AND kb_slug = $2
-                       AND extra IS NOT NULL
-                       AND extra::jsonb->>'source_connector_id' = $3
-                   )""",
-                org_id,
-                kb_slug,
-                connector_id,
-            )
-            await conn.execute(
-                """DELETE FROM knowledge.page_links
-                   WHERE org_id = $1 AND kb_slug = $2 AND (
-                     from_url IN (
-                       SELECT path FROM knowledge.artifacts
-                       WHERE org_id = $1 AND kb_slug = $2
-                         AND extra IS NOT NULL
-                         AND extra::jsonb->>'source_connector_id' = $3
-                     ) OR to_url IN (
-                       SELECT path FROM knowledge.artifacts
-                       WHERE org_id = $1 AND kb_slug = $2
-                         AND extra IS NOT NULL
-                         AND extra::jsonb->>'source_connector_id' = $3
-                     )
-                   )""",
-                org_id,
-                kb_slug,
-                connector_id,
-            )
-            result = await conn.fetchval(
-                """WITH deleted AS (
-                     DELETE FROM knowledge.artifacts
-                     WHERE org_id = $1 AND kb_slug = $2
-                       AND extra IS NOT NULL
-                       AND extra::jsonb->>'source_connector_id' = $3
-                     RETURNING id
-                   ) SELECT COUNT(*) FROM deleted""",
-                org_id,
-                kb_slug,
-                connector_id,
-            )
+    async with conn.transaction():
+        await conn.execute(
+            """UPDATE knowledge.artifacts SET superseded_by = NULL
+               WHERE superseded_by IN (
+                 SELECT id FROM knowledge.artifacts
+                 WHERE org_id = $1 AND kb_slug = $2
+                   AND extra IS NOT NULL
+                   AND extra::jsonb->>'source_connector_id' = $3
+               )""",
+            org_id,
+            kb_slug,
+            connector_id,
+        )
+        await conn.execute(
+            """DELETE FROM knowledge.embedding_queue WHERE artifact_id IN (
+                 SELECT id FROM knowledge.artifacts
+                 WHERE org_id = $1 AND kb_slug = $2
+                   AND extra IS NOT NULL
+                   AND extra::jsonb->>'source_connector_id' = $3
+               )""",
+            org_id,
+            kb_slug,
+            connector_id,
+        )
+        await conn.execute(
+            """DELETE FROM knowledge.artifact_entities WHERE artifact_id IN (
+                 SELECT id FROM knowledge.artifacts
+                 WHERE org_id = $1 AND kb_slug = $2
+                   AND extra IS NOT NULL
+                   AND extra::jsonb->>'source_connector_id' = $3
+               )""",
+            org_id,
+            kb_slug,
+            connector_id,
+        )
+        await conn.execute(
+            """DELETE FROM knowledge.derivations WHERE child_id IN (
+                 SELECT id FROM knowledge.artifacts
+                 WHERE org_id = $1 AND kb_slug = $2
+                   AND extra IS NOT NULL
+                   AND extra::jsonb->>'source_connector_id' = $3
+               ) OR parent_id IN (
+                 SELECT id FROM knowledge.artifacts
+                 WHERE org_id = $1 AND kb_slug = $2
+                   AND extra IS NOT NULL
+                   AND extra::jsonb->>'source_connector_id' = $3
+               )""",
+            org_id,
+            kb_slug,
+            connector_id,
+        )
+        # SPEC-CRAWLER-005 Fase 6 follow-up: scrub crawled_pages + page_links
+        # for URLs owned by this connector. Scoped via the artifact path-URL
+        # set (web_crawler/crawl adapters write artifacts with path=URL).
+        # Must run BEFORE the artifacts DELETE so the URL set is still
+        # reachable. Other connectors in the same KB remain untouched — their
+        # URLs don't appear in this connector's artifact set.
+        await conn.execute(
+            """DELETE FROM knowledge.crawled_pages
+               WHERE org_id = $1 AND kb_slug = $2 AND url IN (
+                 SELECT path FROM knowledge.artifacts
+                 WHERE org_id = $1 AND kb_slug = $2
+                   AND extra IS NOT NULL
+                   AND extra::jsonb->>'source_connector_id' = $3
+               )""",
+            org_id,
+            kb_slug,
+            connector_id,
+        )
+        await conn.execute(
+            """DELETE FROM knowledge.page_links
+               WHERE org_id = $1 AND kb_slug = $2 AND (
+                 from_url IN (
+                   SELECT path FROM knowledge.artifacts
+                   WHERE org_id = $1 AND kb_slug = $2
+                     AND extra IS NOT NULL
+                     AND extra::jsonb->>'source_connector_id' = $3
+                 ) OR to_url IN (
+                   SELECT path FROM knowledge.artifacts
+                   WHERE org_id = $1 AND kb_slug = $2
+                     AND extra IS NOT NULL
+                     AND extra::jsonb->>'source_connector_id' = $3
+                 )
+               )""",
+            org_id,
+            kb_slug,
+            connector_id,
+        )
+        result = await conn.fetchval(
+            """WITH deleted AS (
+                 DELETE FROM knowledge.artifacts
+                 WHERE org_id = $1 AND kb_slug = $2
+                   AND extra IS NOT NULL
+                   AND extra::jsonb->>'source_connector_id' = $3
+                 RETURNING id
+               ) SELECT COUNT(*) FROM deleted""",
+            org_id,
+            kb_slug,
+            connector_id,
+        )
     return int(result or 0)
 
 
 async def insert_artifact_image_refs(
+    conn: asyncpg.Connection,
     artifact_id: str,
     image_keys: list[tuple[str, str]],
 ) -> None:
@@ -420,20 +428,18 @@ async def insert_artifact_image_refs(
     """
     if not image_keys:
         return
-    pool = await get_pool()
-    async with pool.acquire() as conn:
-        await conn.executemany(
-            """
-            INSERT INTO knowledge.artifact_images (artifact_id, s3_key, content_hash)
-            VALUES ($1::uuid, $2, $3)
-            ON CONFLICT (artifact_id, s3_key) DO NOTHING
-            """,
-            [(artifact_id, key, content_hash) for key, content_hash in image_keys],
-        )
+    await conn.executemany(
+        """
+        INSERT INTO knowledge.artifact_images (artifact_id, s3_key, content_hash)
+        VALUES ($1::uuid, $2, $3)
+        ON CONFLICT (artifact_id, s3_key) DO NOTHING
+        """,
+        [(artifact_id, key, content_hash) for key, content_hash in image_keys],
+    )
 
 
 async def get_orphan_image_keys_for_connector(
-    org_id: str, kb_slug: str, connector_id: str
+    conn: asyncpg.Connection, org_id: str, kb_slug: str, connector_id: str
 ) -> list[str]:
     """Return S3 keys that will become orphan when this connector's artifacts are deleted.
 
@@ -447,38 +453,36 @@ async def get_orphan_image_keys_for_connector(
     CASCADE on ``artifact_images`` will remove the rows we need to query.
     Returns an empty list if no images exist for this connector.
     """
-    pool = await get_pool()
-    async with pool.acquire() as conn:
-        rows = await conn.fetch(
-            """
-            SELECT DISTINCT ai.s3_key
-            FROM knowledge.artifact_images ai
-            JOIN knowledge.artifacts a ON a.id = ai.artifact_id
-            WHERE a.org_id = $1
-              AND a.kb_slug = $2
-              AND a.extra IS NOT NULL
-              AND a.extra::jsonb->>'source_connector_id' = $3
-              AND NOT EXISTS (
-                  SELECT 1
-                  FROM knowledge.artifact_images other_ai
-                  JOIN knowledge.artifacts other_a ON other_a.id = other_ai.artifact_id
-                  WHERE other_ai.content_hash = ai.content_hash
-                    AND (
-                        other_a.org_id != $1
-                        OR other_a.kb_slug != $2
-                        OR other_a.extra IS NULL
-                        OR other_a.extra::jsonb->>'source_connector_id' IS DISTINCT FROM $3
-                    )
-              )
-            """,
-            org_id,
-            kb_slug,
-            connector_id,
-        )
+    rows = await conn.fetch(
+        """
+        SELECT DISTINCT ai.s3_key
+        FROM knowledge.artifact_images ai
+        JOIN knowledge.artifacts a ON a.id = ai.artifact_id
+        WHERE a.org_id = $1
+          AND a.kb_slug = $2
+          AND a.extra IS NOT NULL
+          AND a.extra::jsonb->>'source_connector_id' = $3
+          AND NOT EXISTS (
+              SELECT 1
+              FROM knowledge.artifact_images other_ai
+              JOIN knowledge.artifacts other_a ON other_a.id = other_ai.artifact_id
+              WHERE other_ai.content_hash = ai.content_hash
+                AND (
+                    other_a.org_id != $1
+                    OR other_a.kb_slug != $2
+                    OR other_a.extra IS NULL
+                    OR other_a.extra::jsonb->>'source_connector_id' IS DISTINCT FROM $3
+                )
+          )
+        """,
+        org_id,
+        kb_slug,
+        connector_id,
+    )
     return [r["s3_key"] for r in rows]
 
 
-async def get_alive_episode_uuids_for_org(org_id: str) -> set[str]:
+async def get_alive_episode_uuids_for_org(conn: asyncpg.Connection, org_id: str) -> set[str]:
     """Return every Graphiti episode UUID still referenced by an artifact for this org.
 
     Read from ``knowledge.artifacts.extra->>'graphiti_episode_id'`` —
@@ -490,22 +494,22 @@ async def get_alive_episode_uuids_for_org(org_id: str) -> set[str]:
     Excludes the ``no-chunks`` sentinel that artifacts use when an
     article had no extractable text.
     """
-    pool = await get_pool()
-    async with pool.acquire() as conn:
-        rows = await conn.fetch(
-            """
-            SELECT extra::jsonb->>'graphiti_episode_id' AS episode_uuid
-              FROM knowledge.artifacts
-             WHERE org_id = $1
-               AND extra IS NOT NULL
-               AND extra::jsonb->>'graphiti_episode_id' IS NOT NULL
-            """,
-            org_id,
-        )
+    rows = await conn.fetch(
+        """
+        SELECT extra::jsonb->>'graphiti_episode_id' AS episode_uuid
+          FROM knowledge.artifacts
+         WHERE org_id = $1
+           AND extra IS NOT NULL
+           AND extra::jsonb->>'graphiti_episode_id' IS NOT NULL
+        """,
+        org_id,
+    )
     return {r["episode_uuid"] for r in rows if r["episode_uuid"] != "no-chunks"}
 
 
-async def get_active_image_hashes_for_kb(org_id: str, kb_slug: str) -> set[str]:
+async def get_active_image_hashes_for_kb(
+    conn: asyncpg.Connection, org_id: str, kb_slug: str
+) -> set[str]:
     """Return content_hashes still referenced by any artifact in a KB.
 
     SPEC-CONNECTOR-DELETE-LIFECYCLE-001 janitor support. The Garage
@@ -516,22 +520,20 @@ async def get_active_image_hashes_for_kb(org_id: str, kb_slug: str) -> set[str]:
 
     Returns an empty set when the KB has no images / no artifacts.
     """
-    pool = await get_pool()
-    async with pool.acquire() as conn:
-        rows = await conn.fetch(
-            """
-            SELECT DISTINCT ai.content_hash
-              FROM knowledge.artifact_images ai
-              JOIN knowledge.artifacts a ON a.id = ai.artifact_id
-             WHERE a.org_id = $1 AND a.kb_slug = $2
-            """,
-            org_id,
-            kb_slug,
-        )
+    rows = await conn.fetch(
+        """
+        SELECT DISTINCT ai.content_hash
+          FROM knowledge.artifact_images ai
+          JOIN knowledge.artifacts a ON a.id = ai.artifact_id
+         WHERE a.org_id = $1 AND a.kb_slug = $2
+        """,
+        org_id,
+        kb_slug,
+    )
     return {r["content_hash"] for r in rows}
 
 
-async def artifact_exists(artifact_id: str) -> bool:
+async def artifact_exists(conn: asyncpg.Connection, artifact_id: str) -> bool:
     """SPEC-CONNECTOR-DELETE-LIFECYCLE-001 REQ-07: existence-guard helper.
 
     Returns True iff a row in ``knowledge.artifacts`` matches the given
@@ -546,18 +548,18 @@ async def artifact_exists(artifact_id: str) -> bool:
     if not artifact_id:
         return False
     try:
-        pool = await get_pool()
-        async with pool.acquire() as conn:
-            row = await conn.fetchrow(
-                "SELECT 1 FROM knowledge.artifacts WHERE id = $1::uuid",
-                artifact_id,
-            )
+        row = await conn.fetchrow(
+            "SELECT 1 FROM knowledge.artifacts WHERE id = $1::uuid",
+            artifact_id,
+        )
         return row is not None
     except Exception:
         return False
 
 
-async def delete_connector_crawl_jobs(org_id: str, kb_slug: str, connector_id: str) -> int:
+async def delete_connector_crawl_jobs(
+    conn: asyncpg.Connection, org_id: str, kb_slug: str, connector_id: str
+) -> int:
     """Hard-delete crawl_jobs rows owned by a specific connector.
 
     knowledge.crawl_jobs has no native ``connector_id`` column — every row
@@ -571,25 +573,24 @@ async def delete_connector_crawl_jobs(org_id: str, kb_slug: str, connector_id: s
     UI cannot reach but that the next deployment Sentry alert / dashboard
     audit treats as live history. Returns the number of rows deleted.
     """
-    pool = await get_pool()
-    async with pool.acquire() as conn:
-        result = await conn.fetchval(
-            """WITH deleted AS (
-                 DELETE FROM knowledge.crawl_jobs
-                 WHERE org_id = $1
-                   AND kb_slug = $2
-                   AND config IS NOT NULL
-                   AND config->>'connector_id' = $3
-                 RETURNING id
-               ) SELECT COUNT(*) FROM deleted""",
-            org_id,
-            kb_slug,
-            connector_id,
-        )
+    result = await conn.fetchval(
+        """WITH deleted AS (
+             DELETE FROM knowledge.crawl_jobs
+             WHERE org_id = $1
+               AND kb_slug = $2
+               AND config IS NOT NULL
+               AND config->>'connector_id' = $3
+             RETURNING id
+           ) SELECT COUNT(*) FROM deleted""",
+        org_id,
+        kb_slug,
+        connector_id,
+    )
     return int(result or 0)
 
 
 async def upsert_crawled_page(
+    conn: asyncpg.Connection,
     org_id: str,
     kb_slug: str,
     url: str,
@@ -603,8 +604,7 @@ async def upsert_crawled_page(
     Stores both raw_html_hash (pre-extraction) and content_hash (post-extraction)
     to support dual-hash deduplication — see migration 012 for the skip logic.
     """
-    pool = await get_pool()
-    await pool.execute(
+    await conn.execute(
         """
         INSERT INTO knowledge.crawled_pages
             (org_id, kb_slug, url, raw_html_hash, content_hash, raw_markdown, crawled_at)
@@ -630,10 +630,11 @@ async def upsert_crawled_page(
 PageHashes = tuple[str | None, str | None]
 
 
-async def get_crawled_page_stored(org_id: str, kb_slug: str, url: str) -> PageHashes | None:
+async def get_crawled_page_stored(
+    conn: asyncpg.Connection, org_id: str, kb_slug: str, url: str
+) -> PageHashes | None:
     """Return (raw_html_hash, content_hash) for this URL, or None if not yet crawled."""
-    pool = await get_pool()
-    row = await pool.fetchrow(
+    row = await conn.fetchrow(
         "SELECT raw_html_hash, content_hash FROM knowledge.crawled_pages "
         "WHERE org_id = $1 AND kb_slug = $2 AND url = $3",
         org_id,
@@ -644,6 +645,7 @@ async def get_crawled_page_stored(org_id: str, kb_slug: str, url: str) -> PageHa
 
 
 async def get_crawled_page_hashes(
+    conn: asyncpg.Connection,
     org_id: str,
     kb_slug: str,
     urls: list[str],
@@ -651,8 +653,7 @@ async def get_crawled_page_hashes(
     """Return {url: (raw_html_hash, content_hash)} for all known URLs (single query)."""
     if not urls:
         return {}
-    pool = await get_pool()
-    rows = await pool.fetch(
+    rows = await conn.fetch(
         "SELECT url, raw_html_hash, content_hash FROM knowledge.crawled_pages "
         "WHERE org_id = $1 AND kb_slug = $2 AND url = ANY($3::text[])",
         org_id,
@@ -663,6 +664,7 @@ async def get_crawled_page_hashes(
 
 
 async def upsert_page_links(
+    conn: asyncpg.Connection,
     org_id: str,
     kb_slug: str,
     from_url: str,
@@ -687,8 +689,7 @@ async def upsert_page_links(
         )
     if not rows:
         return
-    pool = await get_pool()
-    await pool.executemany(
+    await conn.executemany(
         """
         INSERT INTO knowledge.page_links
             (org_id, kb_slug, from_url, to_url, link_text)
@@ -700,14 +701,15 @@ async def upsert_page_links(
     )
 
 
-async def get_page_episode_ids(org_id: str, kb_slug: str, path: str) -> list[str]:
+async def get_page_episode_ids(
+    conn: asyncpg.Connection, org_id: str, kb_slug: str, path: str
+) -> list[str]:
     """Return Graphiti episode UUIDs for artifacts matching a specific page path.
 
     Like get_episode_ids() but scoped to a single page. Used during page deletion
     to clean up Graphiti graph nodes before soft-deleting the artifact.
     """
-    pool = await get_pool()
-    rows = await pool.fetch(
+    rows = await conn.fetch(
         """SELECT extra::jsonb->>'graphiti_episode_id' AS episode_id
            FROM knowledge.artifacts
            WHERE org_id = $1 AND kb_slug = $2 AND path = $3
@@ -720,63 +722,64 @@ async def get_page_episode_ids(org_id: str, kb_slug: str, path: str) -> list[str
     return [r["episode_id"] for r in rows if r["episode_id"] != "no-chunks"]
 
 
-async def cleanup_page_metadata(org_id: str, kb_slug: str, path: str) -> None:
+async def cleanup_page_metadata(
+    conn: asyncpg.Connection, org_id: str, kb_slug: str, path: str
+) -> None:
     """Hard-delete metadata records (derivations, artifact_entities, embedding_queue)
     for all artifacts matching this page path.
 
     Must be called BEFORE soft_delete_artifact to avoid FK issues.
     Follows the same pattern as delete_kb() but scoped to a single page.
     """
-    pool = await get_pool()
-    async with pool.acquire() as conn:
-        async with conn.transaction():
-            # Nullify self-references first to avoid FK violations
-            await conn.execute(
-                """UPDATE knowledge.artifacts SET superseded_by = NULL
-                   WHERE superseded_by IN (
-                     SELECT id FROM knowledge.artifacts
-                     WHERE org_id = $1 AND kb_slug = $2 AND path = $3
-                   )""",
-                org_id,
-                kb_slug,
-                path,
-            )
-            await conn.execute(
-                """DELETE FROM knowledge.embedding_queue WHERE artifact_id IN (
-                     SELECT id FROM knowledge.artifacts
-                     WHERE org_id = $1 AND kb_slug = $2 AND path = $3
-                   )""",
-                org_id,
-                kb_slug,
-                path,
-            )
-            await conn.execute(
-                """DELETE FROM knowledge.artifact_entities WHERE artifact_id IN (
-                     SELECT id FROM knowledge.artifacts
-                     WHERE org_id = $1 AND kb_slug = $2 AND path = $3
-                   )""",
-                org_id,
-                kb_slug,
-                path,
-            )
-            await conn.execute(
-                """DELETE FROM knowledge.derivations WHERE child_id IN (
-                     SELECT id FROM knowledge.artifacts
-                     WHERE org_id = $1 AND kb_slug = $2 AND path = $3
-                   ) OR parent_id IN (
-                     SELECT id FROM knowledge.artifacts
-                     WHERE org_id = $1 AND kb_slug = $2 AND path = $3
-                   )""",
-                org_id,
-                kb_slug,
-                path,
-            )
+    async with conn.transaction():
+        # Nullify self-references first to avoid FK violations
+        await conn.execute(
+            """UPDATE knowledge.artifacts SET superseded_by = NULL
+               WHERE superseded_by IN (
+                 SELECT id FROM knowledge.artifacts
+                 WHERE org_id = $1 AND kb_slug = $2 AND path = $3
+               )""",
+            org_id,
+            kb_slug,
+            path,
+        )
+        await conn.execute(
+            """DELETE FROM knowledge.embedding_queue WHERE artifact_id IN (
+                 SELECT id FROM knowledge.artifacts
+                 WHERE org_id = $1 AND kb_slug = $2 AND path = $3
+               )""",
+            org_id,
+            kb_slug,
+            path,
+        )
+        await conn.execute(
+            """DELETE FROM knowledge.artifact_entities WHERE artifact_id IN (
+                 SELECT id FROM knowledge.artifacts
+                 WHERE org_id = $1 AND kb_slug = $2 AND path = $3
+               )""",
+            org_id,
+            kb_slug,
+            path,
+        )
+        await conn.execute(
+            """DELETE FROM knowledge.derivations WHERE child_id IN (
+                 SELECT id FROM knowledge.artifacts
+                 WHERE org_id = $1 AND kb_slug = $2 AND path = $3
+               ) OR parent_id IN (
+                 SELECT id FROM knowledge.artifacts
+                 WHERE org_id = $1 AND kb_slug = $2 AND path = $3
+               )""",
+            org_id,
+            kb_slug,
+            path,
+        )
 
 
-async def update_artifact_extra(artifact_id: str, extra_patch: dict) -> None:
+async def update_artifact_extra(
+    conn: asyncpg.Connection, artifact_id: str, extra_patch: dict
+) -> None:
     """Merge extra_patch into knowledge.artifacts.extra (JSONB merge, AC-2)."""
-    pool = await get_pool()
-    await pool.execute(
+    await conn.execute(
         """
         UPDATE knowledge.artifacts
         SET extra = COALESCE(extra::jsonb, '{}'::jsonb) || $1::jsonb
@@ -791,6 +794,7 @@ async def update_artifact_extra(artifact_id: str, extra_patch: dict) -> None:
 
 
 async def insert_parent_chunks(
+    conn: asyncpg.Connection,
     artifact_id: str,
     org_id: str,
     parents: list[dict],
@@ -804,9 +808,8 @@ async def insert_parent_chunks(
     """
     if not parents:
         return []
-    pool = await get_pool()
     ids: list[int] = []
-    async with pool.acquire() as conn, conn.transaction():
+    async with conn.transaction():
         for p in parents:
             row_id = await conn.fetchval(
                 """
@@ -825,7 +828,7 @@ async def insert_parent_chunks(
     return ids
 
 
-async def fetch_parent_chunks(parent_ids: list[int]) -> dict[int, str]:
+async def fetch_parent_chunks(conn: asyncpg.Connection, parent_ids: list[int]) -> dict[int, str]:
     """Return ``{parent_id: text}`` for the requested ids.
 
     Missing ids are simply absent from the returned dict — callers (the
@@ -834,23 +837,21 @@ async def fetch_parent_chunks(parent_ids: list[int]) -> dict[int, str]:
     """
     if not parent_ids:
         return {}
-    pool = await get_pool()
-    rows = await pool.fetch(
+    rows = await conn.fetch(
         "SELECT id, text FROM knowledge.parent_chunks WHERE id = ANY($1::bigint[])",
         list(parent_ids),
     )
     return {int(row["id"]): row["text"] for row in rows}
 
 
-async def delete_parent_chunks_for_artifact(artifact_id: str) -> int:
+async def delete_parent_chunks_for_artifact(conn: asyncpg.Connection, artifact_id: str) -> int:
     """Drop all parent rows for one artifact. Returns the row count.
 
     The FK on parent_chunks.artifact_id is ON DELETE CASCADE, so this is
     only needed when an artifact is being re-chunked but kept in place
     (e.g. recontextualize / rechunk operator tasks).
     """
-    pool = await get_pool()
-    result = await pool.execute(
+    result = await conn.execute(
         "DELETE FROM knowledge.parent_chunks WHERE artifact_id = $1",
         artifact_id,
     )

--- a/klai-knowledge-ingest/knowledge_ingest/rebuild_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/rebuild_tasks.py
@@ -319,9 +319,12 @@ async def _rebuild_artifact(
             # _enrich_document re-inserts them. Without this, the prior
             # rebuild's parent rows pile up and child→parent lookup at retrieval
             # time hits the wrong target.
+            # SPEC-TI-003-FOLLOWUP-001 AC-1: pin RLS GUC on org_id for the
+            # delete; _enrich_document opens its own tsc internally.
             from knowledge_ingest import pg_store as _pg_store
 
-            await _pg_store.delete_parent_chunks_for_artifact(artifact_id)
+            async with tenant_scoped_connection(org_id) as conn:
+                await _pg_store.delete_parent_chunks_for_artifact(conn, artifact_id)
 
             # Steps 2-3: enrichment + TEI/sparse embedding + Qdrant
             # delete-then-upsert. _enrich_document inserts parent_chunks rows

--- a/klai-knowledge-ingest/knowledge_ingest/routes/crawl.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/crawl.py
@@ -5,27 +5,34 @@ Crawl route:
 
 All crawling goes through the shared Crawl4AI Docker container via crawl4ai_client.
 Pipeline selection (SPEC-CRAWL-001 / R-1) is handled by crawl4ai_client.build_crawl_config().
+
+SPEC-TI-003-FOLLOWUP-001 AC-1: handlers that touch knowledge.* open a
+tenant_scoped_connection on the body's org_id and pass conn into pg_store /
+link_graph / domain_selectors / ingest_document.
 """
+
 import asyncio
+import contextlib
 import hashlib
 import re
 import time
 from urllib.parse import urlparse
 
+import asyncpg
 import structlog
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
 from knowledge_ingest import pg_store
-from knowledge_ingest.identity import assert_caller_identity
 from knowledge_ingest.crawl4ai_client import crawl_dom_summary, crawl_page
-from knowledge_ingest.db import get_pool
+from knowledge_ingest.db import tenant_scoped_connection
 from knowledge_ingest.domain_selectors import (
     extract_domain,
     get_domain_selector,
     upsert_domain_selector,
 )
 from knowledge_ingest.fingerprint import compute_content_fingerprint
+from knowledge_ingest.identity import assert_caller_identity
 from knowledge_ingest.models import CrawlRequest, CrawlResponse, IngestRequest
 from knowledge_ingest.routes.ingest import ingest_document
 from knowledge_ingest.selector_ai import (
@@ -123,6 +130,21 @@ async def _run_crawl(
     return fit_md, result.word_count, result.html
 
 
+@contextlib.asynccontextmanager
+async def _maybe_tenant_conn(org_id: str):
+    """Yield a GUC-pinned conn when org_id is present, else None.
+
+    preview_crawl is the only handler that may legitimately run without
+    org_id (anonymous preview); all other paths must have org_id and use
+    tenant_scoped_connection directly.
+    """
+    if not org_id:
+        yield None
+        return
+    async with tenant_scoped_connection(org_id) as conn:
+        yield conn
+
+
 @router.post("/ingest/v1/crawl/preview", response_model=CrawlPreviewResponse)
 async def preview_crawl(body: CrawlPreviewRequest, request: Request) -> CrawlPreviewResponse:
     """Fetch a URL with PruningContentFilter and return the filtered markdown preview.
@@ -148,55 +170,76 @@ async def preview_crawl(body: CrawlPreviewRequest, request: Request) -> CrawlPre
         effective_selector = body.content_selector
         selector_source = "user" if effective_selector else None
 
-        if not effective_selector and body.org_id:
-            stored = await get_domain_selector(extract_domain(body.url), body.org_id)
-            if stored:
-                effective_selector, selector_source = stored
+        async with _maybe_tenant_conn(body.org_id) as conn:
+            if not effective_selector and conn is not None:
+                stored = await get_domain_selector(conn, extract_domain(body.url), body.org_id)
+                if stored:
+                    effective_selector, selector_source = stored
 
-        # Initial crawl
-        fit_md, word_count, _ = await _run_crawl(body.url, effective_selector, cookies=body.cookies)
-        warnings: list[str] = _detect_nav_contamination(fit_md)
+            # Initial crawl (HTTP, no DB)
+            fit_md, word_count, _ = await _run_crawl(
+                body.url, effective_selector, cookies=body.cookies
+            )
+            warnings: list[str] = _detect_nav_contamination(fit_md)
 
-        # AI-assisted selector detection — only when explicitly requested via try_ai flag
-        # SPEC-CRAWL-001 / R-4
-        if body.try_ai and word_count < _MIN_WORD_COUNT and not effective_selector and body.org_id:
-            dom_summary = await crawl_dom_summary(body.url)
-            if dom_summary:
-                ai_selector = await detect_selector_via_llm(dom_summary)
-                if ai_selector:
-                    try:
-                        recrawl_md, recrawl_wc, _ = await _run_crawl(
-                            body.url, ai_selector, cookies=body.cookies,
-                        )
-                        if recrawl_wc >= _MIN_WORD_COUNT:
-                            await upsert_domain_selector(
-                                extract_domain(body.url), body.org_id, ai_selector, "ai"
+            # AI-assisted selector detection — only when explicitly requested via try_ai flag
+            # SPEC-CRAWL-001 / R-4
+            if (
+                body.try_ai
+                and word_count < _MIN_WORD_COUNT
+                and not effective_selector
+                and conn is not None
+            ):
+                dom_summary = await crawl_dom_summary(body.url)
+                if dom_summary:
+                    ai_selector = await detect_selector_via_llm(dom_summary)
+                    if ai_selector:
+                        try:
+                            recrawl_md, recrawl_wc, _ = await _run_crawl(
+                                body.url, ai_selector, cookies=body.cookies
                             )
-                            fit_md = recrawl_md
-                            word_count = recrawl_wc
-                            warnings = _detect_nav_contamination(fit_md)
-                            effective_selector = ai_selector
-                            selector_source = "ai"
-                        else:
-                            # Re-crawl also thin — return original, do not store
+                            if recrawl_wc >= _MIN_WORD_COUNT:
+                                await upsert_domain_selector(
+                                    conn,
+                                    extract_domain(body.url),
+                                    body.org_id,
+                                    ai_selector,
+                                    "ai",
+                                )
+                                fit_md = recrawl_md
+                                word_count = recrawl_wc
+                                warnings = _detect_nav_contamination(fit_md)
+                                effective_selector = ai_selector
+                                selector_source = "ai"
+                            else:
+                                # Re-crawl also thin — return original, do not store
+                                if "low_word_count" not in warnings:
+                                    warnings.append("low_word_count")
+                        except Exception as exc:
+                            logger.warning(
+                                "crawl_ai_recrawl_failed",
+                                url=body.url,
+                                ai_selector=ai_selector,
+                                error=str(exc),
+                            )
                             if "low_word_count" not in warnings:
                                 warnings.append("low_word_count")
-                    except Exception as exc:
-                        logger.warning(
-                            "crawl_ai_recrawl_failed",
-                            url=body.url,
-                            ai_selector=ai_selector,
-                            error=str(exc),
-                        )
-                        if "low_word_count" not in warnings:
-                            warnings.append("low_word_count")
 
-        # Persist selector after a successful crawl (>= 100 words), if we have one
-        # SPEC-CRAWL-001 / R-3
-        if word_count >= _MIN_WORD_COUNT and effective_selector and body.org_id and selector_source:
-            await upsert_domain_selector(
-                extract_domain(body.url), body.org_id, effective_selector, selector_source
-            )
+            # Persist selector after a successful crawl (>= 100 words), if we have one
+            # SPEC-CRAWL-001 / R-3
+            if (
+                word_count >= _MIN_WORD_COUNT
+                and effective_selector
+                and conn is not None
+                and selector_source
+            ):
+                await upsert_domain_selector(
+                    conn,
+                    extract_domain(body.url),
+                    body.org_id,
+                    effective_selector,
+                    selector_source,
+                )
 
         # SPEC-CRAWL-004: auto-detect auth guard when cookies are present and
         # the crawl succeeded with real content. The preview URL becomes the
@@ -216,9 +259,7 @@ async def preview_crawl(body: CrawlPreviewRequest, request: Request) -> CrawlPre
                         indicator = await detect_login_indicator_via_llm(dom_summary)
                         if indicator:
                             auth_guard.login_indicator_selector = indicator
-                            auth_guard.login_indicator_description = (
-                                f"Detected: {indicator}"
-                            )
+                            auth_guard.login_indicator_description = f"Detected: {indicator}"
                 except Exception:
                     logger.debug(
                         "auth_guard_login_indicator_detection_skipped",
@@ -262,97 +303,106 @@ async def crawl_url(request: CrawlRequest, http_request: Request) -> CrawlRespon
         slug = parsed.path.strip("/").replace("/", "-") or parsed.netloc
         return f"{slug}.md"
 
-    # Resolve stored domain selector so the right pipeline is used
-    # SPEC-CRAWL-001 / R-2
-    effective_selector: str | None = None
-    if request.org_id:
-        stored_sel = await get_domain_selector(extract_domain(request.url), request.org_id)
-        if stored_sel:
-            effective_selector, _ = stored_sel
-
-    # WARNING (pipeline config change): modifying crawl4ai settings in
-    # crawl4ai_client.build_crawl_config() changes content_hash for every page
-    # even when the actual page content has not changed.  After such a change,
-    # force a full re-ingest by clearing content_hash:
-    #   UPDATE knowledge.crawled_pages
-    #      SET content_hash = ''
-    #    WHERE org_id = '<org>' AND kb_slug = '<slug>';
-    fit_md, _word_count, raw_html = await _run_crawl(request.url, effective_selector)
-
-    # Dual-hash dedup (see migration 012):
-    #   1. raw_html_hash unchanged → skip everything (fast path)
-    #   2. raw_html_hash changed, content_hash unchanged → JS/tracking update, skip ingest
-    #   3. both changed → real content change → full ingest
-    raw_html_hash = hashlib.sha256(raw_html.encode()).hexdigest()
-    stored = await pg_store.get_crawled_page_stored(
-        request.org_id, request.kb_slug, request.url
-    )
-
-    if stored is not None:
-        stored_raw, _stored_content = stored
-        if stored_raw is not None and stored_raw == raw_html_hash:
-            logger.info("crawl_skipped_unchanged", url=request.url)
-            return CrawlResponse(url=request.url, path=_derive_path(), chunks_ingested=0)
-
-    content_hash = hashlib.sha256(fit_md.encode()).hexdigest()
-
-    if stored is not None:
-        _, stored_content = stored
-        if stored_content is not None and stored_content == content_hash:
-            # HTML changed (JS / tracking pixel) but article content is identical
-            # → update raw_html_hash so future crawls hit the fast path, skip ingest
-            await pg_store.upsert_crawled_page(
-                org_id=request.org_id,
-                kb_slug=request.kb_slug,
-                url=request.url,
-                raw_html_hash=raw_html_hash,
-                content_hash=content_hash,
-                raw_markdown=fit_md,
-                crawled_at=int(time.time()),
+    async with tenant_scoped_connection(request.org_id) as conn:
+        # Resolve stored domain selector so the right pipeline is used
+        # SPEC-CRAWL-001 / R-2
+        effective_selector: str | None = None
+        if request.org_id:
+            stored_sel = await get_domain_selector(
+                conn, extract_domain(request.url), request.org_id
             )
-            logger.info("crawl_skipped_html_noise", url=request.url)
-            return CrawlResponse(url=request.url, path=_derive_path(), chunks_ingested=0)
+            if stored_sel:
+                effective_selector, _ = stored_sel
 
-    await pg_store.upsert_crawled_page(
-        org_id=request.org_id,
-        kb_slug=request.kb_slug,
-        url=request.url,
-        raw_html_hash=raw_html_hash,
-        content_hash=content_hash,
-        raw_markdown=fit_md,
-        crawled_at=int(time.time()),
-    )
+        # WARNING (pipeline config change): modifying crawl4ai settings in
+        # crawl4ai_client.build_crawl_config() changes content_hash for every page
+        # even when the actual page content has not changed.  After such a change,
+        # force a full re-ingest by clearing content_hash:
+        #   UPDATE knowledge.crawled_pages
+        #      SET content_hash = ''
+        #    WHERE org_id = '<org>' AND kb_slug = '<slug>';
+        fit_md, _word_count, raw_html = await _run_crawl(request.url, effective_selector)
 
-    path = _derive_path()
-
-    # Ingest using existing pipeline (expects IngestRequest, returns dict)
-    # SPEC-CRAWL-001 / R-5: include source_url in extra
-    # SPEC-CRAWLER-003 R11: populate link graph fields when source_url present
-    extra: dict = {"source_url": request.url}
-    try:
-        from knowledge_ingest import link_graph
-        pool = await get_pool()
-        outbound, anchors, incoming = await asyncio.gather(
-            link_graph.get_outbound_urls(request.url, request.org_id, request.kb_slug, pool),
-            link_graph.get_anchor_texts(request.url, request.org_id, request.kb_slug, pool),
-            link_graph.get_incoming_count(request.url, request.org_id, request.kb_slug, pool),
+        # Dual-hash dedup (see migration 012):
+        #   1. raw_html_hash unchanged → skip everything (fast path)
+        #   2. raw_html_hash changed, content_hash unchanged → JS/tracking update, skip ingest
+        #   3. both changed → real content change → full ingest
+        raw_html_hash = hashlib.sha256(raw_html.encode()).hexdigest()
+        stored = await pg_store.get_crawled_page_stored(
+            conn, request.org_id, request.kb_slug, request.url
         )
-        extra["links_to"] = outbound[:20]
-        extra["anchor_texts"] = anchors
-        extra["incoming_link_count"] = incoming
-    except Exception as exc:
-        logger.warning("link_graph_query_failed", url=request.url, error=str(exc))
-    ingest_req = IngestRequest(
-        org_id=request.org_id,
-        kb_slug=request.kb_slug,
-        path=path,
-        content=fit_md,
-        source_type="crawl",
-        source_domain=urlparse(request.url).netloc,
-        extra=extra,
-    )
-    result = await ingest_document(ingest_req)
-    n_chunks = result.get("chunks", 0)
+
+        if stored is not None:
+            stored_raw, _stored_content = stored
+            if stored_raw is not None and stored_raw == raw_html_hash:
+                logger.info("crawl_skipped_unchanged", url=request.url)
+                return CrawlResponse(url=request.url, path=_derive_path(), chunks_ingested=0)
+
+        content_hash = hashlib.sha256(fit_md.encode()).hexdigest()
+
+        if stored is not None:
+            _, stored_content = stored
+            if stored_content is not None and stored_content == content_hash:
+                # HTML changed (JS / tracking pixel) but article content is identical
+                # → update raw_html_hash so future crawls hit the fast path, skip ingest
+                await pg_store.upsert_crawled_page(
+                    conn,
+                    org_id=request.org_id,
+                    kb_slug=request.kb_slug,
+                    url=request.url,
+                    raw_html_hash=raw_html_hash,
+                    content_hash=content_hash,
+                    raw_markdown=fit_md,
+                    crawled_at=int(time.time()),
+                )
+                logger.info("crawl_skipped_html_noise", url=request.url)
+                return CrawlResponse(url=request.url, path=_derive_path(), chunks_ingested=0)
+
+        await pg_store.upsert_crawled_page(
+            conn,
+            org_id=request.org_id,
+            kb_slug=request.kb_slug,
+            url=request.url,
+            raw_html_hash=raw_html_hash,
+            content_hash=content_hash,
+            raw_markdown=fit_md,
+            crawled_at=int(time.time()),
+        )
+
+        path = _derive_path()
+
+        # Ingest using existing pipeline (expects IngestRequest, returns dict)
+        # SPEC-CRAWL-001 / R-5: include source_url in extra
+        # SPEC-CRAWLER-003 R11: populate link graph fields when source_url present
+        extra: dict = {"source_url": request.url}
+        try:
+            from knowledge_ingest import link_graph
+
+            outbound, anchors, incoming = await asyncio.gather(
+                link_graph.get_outbound_urls(conn, request.url, request.org_id, request.kb_slug),
+                link_graph.get_anchor_texts(conn, request.url, request.org_id, request.kb_slug),
+                link_graph.get_incoming_count(conn, request.url, request.org_id, request.kb_slug),
+            )
+            extra["links_to"] = outbound[:20]
+            extra["anchor_texts"] = anchors
+            extra["incoming_link_count"] = incoming
+        except Exception as exc:
+            logger.warning("link_graph_query_failed", url=request.url, error=str(exc))
+        ingest_req = IngestRequest(
+            org_id=request.org_id,
+            kb_slug=request.kb_slug,
+            path=path,
+            content=fit_md,
+            source_type="crawl",
+            source_domain=urlparse(request.url).netloc,
+            extra=extra,
+        )
+        result = await ingest_document(conn, ingest_req)
+        n_chunks = result.get("chunks", 0)
 
     logger.info("crawl_ingest_complete", url=request.url, path=path, chunks=n_chunks)
     return CrawlResponse(url=request.url, path=path, chunks_ingested=n_chunks)
+
+
+# Type-only import to silence unused warning for asyncpg.Connection
+_ = asyncpg.Connection

--- a/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
@@ -5,6 +5,11 @@ Ingest routes:
   POST /ingest/v1/kb/webhook      — register Gitea webhook for a KB
   DELETE /ingest/v1/kb/webhook    — de-register Gitea webhook for a KB
   POST /ingest/v1/kb/sync         — bulk re-index all pages of a KB
+
+SPEC-TI-003-FOLLOWUP-001 AC-1: ``ingest_document`` and the route handlers
+take an ``asyncpg.Connection`` from a ``tenant_scoped_connection(org_id)``
+block; every pg_store / kb_config / org_config call is threaded through it
+so RLS sees the tenant context.
 """
 
 import hashlib
@@ -13,6 +18,7 @@ import json
 import time
 from datetime import UTC, datetime
 
+import asyncpg
 import httpx
 import structlog
 import yaml
@@ -33,7 +39,8 @@ from knowledge_ingest.clustering import classify_by_centroid, load_centroids
 from knowledge_ingest.config import settings
 from knowledge_ingest.content_labeler import generate_content_label
 from knowledge_ingest.content_profiles import get_profile
-from knowledge_ingest.db import get_pool
+from knowledge_ingest.db import tenant_scoped_connection
+from knowledge_ingest.identity import assert_caller_identity
 from knowledge_ingest.models import (
     BulkSyncRequest,
     GiteaPushEvent,
@@ -41,7 +48,6 @@ from knowledge_ingest.models import (
     KBWebhookRequest,
     UpdateKBVisibilityRequest,
 )
-from knowledge_ingest.identity import assert_caller_identity
 from knowledge_ingest.portal_client import fetch_taxonomy_nodes
 from knowledge_ingest.taxonomy_classifier import classify_document
 
@@ -221,13 +227,20 @@ def _parse_image_refs(image_urls: list) -> list[tuple[str, str]]:
 
 
 async def _graphiti_background(
+    conn: asyncpg.Connection,
     artifact_id: str,
     document_text: str,
     org_id: str,
     content_type: str,
     belief_time_start: int,
 ) -> None:
-    """Background task: ingest document into Graphiti, then store episode_id (AC-1, AC-2)."""
+    """Background task: ingest document into Graphiti, then store episode_id (AC-1, AC-2).
+
+    Currently dead code -- the graphiti pipeline runs through the procrastinate
+    task ``ingest_graphiti_episode`` in enrichment_tasks.py. Kept for now with
+    the SPEC-TI-003-FOLLOWUP-001 conn signature so an accidental revival picks
+    up the right contract.
+    """
     episode_id = await graph_module.ingest_episode(
         artifact_id=artifact_id,
         document_text=document_text,
@@ -236,11 +249,17 @@ async def _graphiti_background(
         belief_time_start=belief_time_start,
     )
     if episode_id:
-        await pg_store.update_artifact_extra(artifact_id, {"graphiti_episode_id": episode_id})
+        await pg_store.update_artifact_extra(conn, artifact_id, {"graphiti_episode_id": episode_id})
 
 
-async def ingest_document(req: IngestRequest) -> dict:
-    """Core ingest pipeline: chunk -> embed -> upsert."""
+async def ingest_document(conn: asyncpg.Connection, req: IngestRequest) -> dict:
+    """Core ingest pipeline: chunk -> embed -> upsert.
+
+    SPEC-TI-003-FOLLOWUP-001 AC-1: ``conn`` carries the RLS GUC for
+    ``req.org_id``. All pg_store / kb_config / org_config calls below run on
+    this same connection. Callers must wrap this function in
+    ``tenant_scoped_connection(req.org_id)``.
+    """
     t_ingest = time.monotonic()
 
     # SPEC-CONNECTOR-DELETE-LIFECYCLE-001 REQ-07: existence-guard for the
@@ -274,7 +293,7 @@ async def ingest_document(req: IngestRequest) -> dict:
 
     # Early exit if content is unchanged since last ingest
     content_hash = hashlib.sha256(req.content.encode()).hexdigest()
-    stored_hash = await pg_store.get_active_content_hash(req.org_id, req.kb_slug, req.path)
+    stored_hash = await pg_store.get_active_content_hash(conn, req.org_id, req.kb_slug, req.path)
     if stored_hash is not None and stored_hash == content_hash:
         logger.info(
             "ingest_skipped",
@@ -401,7 +420,7 @@ async def ingest_document(req: IngestRequest) -> dict:
         merged_tags = llm_tags
 
     # Soft-delete previous artifact for this path (AC-5: re-ingest creates new row)
-    await pg_store.soft_delete_artifact(req.org_id, req.kb_slug, req.path)
+    await pg_store.soft_delete_artifact(conn, req.org_id, req.kb_slug, req.path)
 
     # Merge connector provenance fields into extra so PG tracks the same metadata as Qdrant.
     # This enables delete_connector_artifacts() to find and remove PG records by connector.
@@ -420,6 +439,7 @@ async def ingest_document(req: IngestRequest) -> dict:
         pg_extra["document_text"] = req.content
 
     artifact_id = await pg_store.create_artifact(
+        conn,
         org_id=req.org_id,
         kb_slug=req.kb_slug,
         path=req.path,
@@ -447,7 +467,7 @@ async def ingest_document(req: IngestRequest) -> dict:
         image_refs = _parse_image_refs(image_urls)
         if image_refs:
             try:
-                await pg_store.insert_artifact_image_refs(artifact_id, image_refs)
+                await pg_store.insert_artifact_image_refs(conn, artifact_id, image_refs)
             except Exception:
                 # Bookkeeping failure must not block ingest. The image
                 # is in S3; if we ever lose this row the worst case is
@@ -458,8 +478,7 @@ async def ingest_document(req: IngestRequest) -> dict:
                     count=len(image_refs),
                 )
 
-    pool = await get_pool()
-    visibility = await kb_config.get_kb_visibility(req.org_id, req.kb_slug, pool)
+    visibility = await kb_config.get_kb_visibility(conn, req.org_id, req.kb_slug)
 
     extra_payload: dict = {"title": title, "artifact_id": artifact_id}
 
@@ -531,7 +550,7 @@ async def ingest_document(req: IngestRequest) -> dict:
     # SPEC-KB-027 R2 cleanup (PR #90 obsolete; harvested as standalone fix).
 
     # Enqueue enrichment as async Procrastinate task (non-blocking)
-    if await org_config.is_enrichment_enabled(req.org_id, pool):
+    if await org_config.is_enrichment_enabled(conn, req.org_id):
         from knowledge_ingest import enrichment_tasks
 
         proc_app = enrichment_tasks.get_app()
@@ -619,10 +638,9 @@ async def ingest_document(req: IngestRequest) -> dict:
 @router.post("/ingest/v1/document")
 async def ingest_document_route(req: IngestRequest, request: Request) -> dict:
     """Ingest a document. SPEC-TI-003 AC-6: identity assertion on body org_id."""
-    await assert_caller_identity(
-        request, claimed_org_id=req.org_id, claimed_user_id=req.user_id
-    )
-    return await ingest_document(req)
+    await assert_caller_identity(request, claimed_org_id=req.org_id, claimed_user_id=req.user_id)
+    async with tenant_scoped_connection(req.org_id) as conn:
+        return await ingest_document(conn, req)
 
 
 @router.post("/ingest/v1/webhook/gitea")
@@ -752,7 +770,8 @@ async def gitea_webhook(request: Request) -> dict:
                 user_id=webhook_user_id,
             )
             try:
-                await ingest_document(req)
+                async with tenant_scoped_connection(org_id) as conn:
+                    await ingest_document(conn, req)
                 queued += 1
             except Exception as exc:
                 logger.warning("ingest_failed", path=path, error=str(exc))
@@ -760,56 +779,60 @@ async def gitea_webhook(request: Request) -> dict:
     # Delete removed files — immediate, no debounce needed
     # Order: Qdrant → fetch episode IDs → Graphiti → PG metadata → PG soft-delete
     # Each step has its own try/except so partial failures don't block subsequent steps.
-    for path in removed:
-        try:
-            await qdrant_store.delete_document(org_id, kb_slug, path)
-        except Exception as exc:
-            logger.warning(
-                "page_qdrant_delete_failed",
-                org_id=org_id,
-                kb_slug=kb_slug,
-                path=path,
-                error=str(exc),
-            )
+    if removed:
+        async with tenant_scoped_connection(org_id) as conn:
+            for path in removed:
+                try:
+                    await qdrant_store.delete_document(org_id, kb_slug, path)
+                except Exception as exc:
+                    logger.warning(
+                        "page_qdrant_delete_failed",
+                        org_id=org_id,
+                        kb_slug=kb_slug,
+                        path=path,
+                        error=str(exc),
+                    )
 
-        # Graphiti cleanup: fetch episode IDs before soft-delete (reads extra field)
-        if settings.graphiti_enabled:
-            try:
-                episode_ids = await pg_store.get_page_episode_ids(org_id, kb_slug, path)
-                if episode_ids:
-                    await graph_module.delete_kb_episodes(org_id, episode_ids)
-            except Exception as exc:
-                logger.warning(
-                    "page_graph_cleanup_failed",
-                    org_id=org_id,
-                    kb_slug=kb_slug,
-                    path=path,
-                    error=str(exc),
-                )
+                # Graphiti cleanup: fetch episode IDs before soft-delete (reads extra field)
+                if settings.graphiti_enabled:
+                    try:
+                        episode_ids = await pg_store.get_page_episode_ids(
+                            conn, org_id, kb_slug, path
+                        )
+                        if episode_ids:
+                            await graph_module.delete_kb_episodes(org_id, episode_ids)
+                    except Exception as exc:
+                        logger.warning(
+                            "page_graph_cleanup_failed",
+                            org_id=org_id,
+                            kb_slug=kb_slug,
+                            path=path,
+                            error=str(exc),
+                        )
 
-        # Metadata cleanup: derivations, artifact_entities, embedding_queue
-        try:
-            await pg_store.cleanup_page_metadata(org_id, kb_slug, path)
-        except Exception as exc:
-            logger.warning(
-                "page_metadata_cleanup_failed",
-                org_id=org_id,
-                kb_slug=kb_slug,
-                path=path,
-                error=str(exc),
-            )
+                # Metadata cleanup: derivations, artifact_entities, embedding_queue
+                try:
+                    await pg_store.cleanup_page_metadata(conn, org_id, kb_slug, path)
+                except Exception as exc:
+                    logger.warning(
+                        "page_metadata_cleanup_failed",
+                        org_id=org_id,
+                        kb_slug=kb_slug,
+                        path=path,
+                        error=str(exc),
+                    )
 
-        try:
-            await pg_store.soft_delete_artifact(org_id, kb_slug, path)
-            deleted += 1
-        except Exception as exc:
-            logger.warning(
-                "page_soft_delete_failed",
-                org_id=org_id,
-                kb_slug=kb_slug,
-                path=path,
-                error=str(exc),
-            )
+                try:
+                    await pg_store.soft_delete_artifact(conn, org_id, kb_slug, path)
+                    deleted += 1
+                except Exception as exc:
+                    logger.warning(
+                        "page_soft_delete_failed",
+                        org_id=org_id,
+                        kb_slug=kb_slug,
+                        path=path,
+                        error=str(exc),
+                    )
 
     return {"status": "ok", "queued": queued, "deleted": deleted, "org_slug": org_slug}
 
@@ -844,10 +867,11 @@ async def delete_kb_route(request: Request, org_id: str, kb_slug: str) -> dict:
     _verify_internal_secret(request)
     await assert_caller_identity(request, claimed_org_id=org_id)
     # Fetch episode IDs before PG deletion — graph cleanup requires them.
-    episode_ids = await pg_store.get_episode_ids(org_id, kb_slug)
-    await graph_module.delete_kb_episodes(org_id, episode_ids)
-    await qdrant_store.delete_kb(org_id, kb_slug)
-    await pg_store.delete_kb(org_id, kb_slug)
+    async with tenant_scoped_connection(org_id) as conn:
+        episode_ids = await pg_store.get_episode_ids(conn, org_id, kb_slug)
+        await graph_module.delete_kb_episodes(org_id, episode_ids)
+        await qdrant_store.delete_kb(org_id, kb_slug)
+        await pg_store.delete_kb(conn, org_id, kb_slug)
     logger.info("kb_deleted", org_id=org_id, kb_slug=kb_slug, episodes_deleted=len(episode_ids))
     return {"status": "ok"}
 
@@ -925,8 +949,8 @@ async def delete_connector_route(
 async def update_kb_visibility_route(request: Request, req: UpdateKBVisibilityRequest) -> dict:
     """Update visibility for a KB: persists to kb_config table and backfills all Qdrant chunks."""
     _verify_internal_secret(request)
-    pool = await get_pool()
-    await kb_config.set_kb_visibility(req.org_id, req.kb_slug, req.visibility, pool)
+    async with tenant_scoped_connection(req.org_id) as conn:
+        await kb_config.set_kb_visibility(conn, req.org_id, req.kb_slug, req.visibility)
     await qdrant_store.update_kb_visibility(req.org_id, req.kb_slug, req.visibility)
     return {"status": "ok"}
 
@@ -1036,23 +1060,24 @@ async def bulk_sync_kb_route(request: Request, req: BulkSyncRequest) -> dict:
     _verify_internal_secret(request)
     pages = await _list_gitea_md_files(req.gitea_repo)
     ingested = 0
-    for path in pages:
-        content = await _fetch_gitea_file(req.gitea_repo, path)
-        if content is None:
-            logger.warning("gitea_fetch_failed", path=path, repo=req.gitea_repo)
-            continue
-        ingest_req = IngestRequest(
-            org_id=req.org_id,
-            kb_slug=req.kb_slug,
-            path=path,
-            content=content,
-            source_type="docs",
-            content_type="kb_article",
-        )
-        try:
-            await ingest_document(ingest_req)
-            ingested += 1
-        except Exception as exc:
-            logger.warning("bulk_sync_failed", path=path, error=str(exc))
+    async with tenant_scoped_connection(req.org_id) as conn:
+        for path in pages:
+            content = await _fetch_gitea_file(req.gitea_repo, path)
+            if content is None:
+                logger.warning("gitea_fetch_failed", path=path, repo=req.gitea_repo)
+                continue
+            ingest_req = IngestRequest(
+                org_id=req.org_id,
+                kb_slug=req.kb_slug,
+                path=path,
+                content=content,
+                source_type="docs",
+                content_type="kb_article",
+            )
+            try:
+                await ingest_document(conn, ingest_req)
+                ingested += 1
+            except Exception as exc:
+                logger.warning("bulk_sync_failed", path=path, error=str(exc))
     logger.info("bulk_sync_complete", org_id=req.org_id, kb_slug=req.kb_slug, pages=ingested)
     return {"status": "ok", "pages": ingested}

--- a/klai-knowledge-ingest/knowledge_ingest/routes/personal.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/personal.py
@@ -2,13 +2,19 @@
 Personal knowledge item routes:
   GET    /knowledge/v1/personal/items              — list personal artifacts
   DELETE /knowledge/v1/personal/items/{artifact_id} — soft-delete a personal artifact
-"""
-import structlog
-from datetime import datetime, timezone
 
+SPEC-TI-003-FOLLOWUP-001 AC-1: each handler opens a tenant_scoped_connection
+on the caller's org_id and threads the conn into every pg_store call so RLS
+sees the tenant context.
+"""
+
+from datetime import UTC, datetime
+
+import structlog
 from fastapi import APIRouter, HTTPException, Query
 
 from knowledge_ingest import pg_store, qdrant_store
+from knowledge_ingest.db import tenant_scoped_connection
 from knowledge_ingest.models import ArtifactSummary, PersonalItemsResponse
 
 logger = structlog.get_logger()
@@ -17,7 +23,7 @@ router = APIRouter()
 
 def _unix_to_iso(ts: int) -> str:
     """Convert a Unix timestamp (int) to ISO 8601 string."""
-    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+    return datetime.fromtimestamp(ts, tz=UTC).isoformat()
 
 
 @router.get("/knowledge/v1/personal/items", response_model=PersonalItemsResponse)
@@ -31,8 +37,9 @@ async def list_personal_items(
     if not org_id or not user_id:
         raise HTTPException(status_code=400, detail="org_id and user_id are required")
 
-    rows = await pg_store.list_personal_artifacts(org_id, user_id, limit, offset)
-    total = await pg_store.count_personal_artifacts(org_id, user_id)
+    async with tenant_scoped_connection(org_id) as conn:
+        rows = await pg_store.list_personal_artifacts(conn, org_id, user_id, limit, offset)
+        total = await pg_store.count_personal_artifacts(conn, org_id, user_id)
 
     items = [
         ArtifactSummary(
@@ -58,16 +65,22 @@ async def delete_personal_item(
     if not org_id or not user_id:
         raise HTTPException(status_code=400, detail="org_id and user_id are required")
 
-    artifact = await pg_store.get_personal_artifact(artifact_id, org_id, user_id)
-    if artifact is None:
-        raise HTTPException(status_code=404, detail="Artifact not found")
+    async with tenant_scoped_connection(org_id) as conn:
+        artifact = await pg_store.get_personal_artifact(conn, artifact_id, org_id, user_id)
+        if artifact is None:
+            raise HTTPException(status_code=404, detail="Artifact not found")
 
-    path = artifact["path"]
-    await pg_store.soft_delete_artifact(org_id, "personal", path)
+        path = artifact["path"]
+        await pg_store.soft_delete_artifact(conn, org_id, "personal", path)
+
+    # Qdrant is outside the tenant_scoped_connection -- it has its own auth.
     await qdrant_store.delete_document(org_id, "personal", path)
 
     logger.info(
         "personal_artifact_deleted",
-        artifact_id=artifact_id, path=path, user_id=user_id, org_id=org_id,
+        artifact_id=artifact_id,
+        path=path,
+        user_id=user_id,
+        org_id=org_id,
     )
     return {"status": "ok"}

--- a/klai-knowledge-ingest/tests/conftest.py
+++ b/klai-knowledge-ingest/tests/conftest.py
@@ -5,6 +5,13 @@ variable — ``Settings()`` raises ``ValidationError`` when it is missing.
 We set a test value before any ``knowledge_ingest`` module is imported so
 ``config.py``'s module-level ``settings = Settings()`` succeeds during
 test collection. The real production deploy injects this via SOPS.
+
+SPEC-TI-003-FOLLOWUP-001: ``tenant_scoped_connection`` now does
+``pool.acquire()`` and yields the connection to callers. The mock pool
+fixture exposes ``acquire()`` as an async context manager yielding a
+mock connection so unit tests that exercise the FastAPI app via
+``TestClient`` -- and therefore go through ``tenant_scoped_connection``
+-- still work without a real Postgres.
 """
 
 from __future__ import annotations
@@ -19,6 +26,7 @@ os.environ.setdefault("GITEA_WEBHOOK_SECRET", "test-gitea-webhook-secret-789")
 # Imports below need the env vars above — keep this order to allow the
 # module-level ``settings = Settings()`` call in ``knowledge_ingest.config``
 # to succeed under the SPEC-SEC-011 / SEC-014 validators.
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -30,18 +38,141 @@ from fastapi.testclient import TestClient
 _INTERNAL_HEADER = {"X-Internal-Secret": os.environ["KNOWLEDGE_INGEST_SECRET"]}
 
 
+def _make_mock_conn():
+    """Return a mock asyncpg.Connection that returns benign defaults.
+
+    Tests that need specific behaviour patch the pg_store helper directly
+    (e.g. ``patch("knowledge_ingest.pg_store.create_artifact", AsyncMock(...))``)
+    rather than reaching through this stub.
+    """
+    conn = MagicMock()
+    conn.execute = AsyncMock(return_value=None)
+    conn.executemany = AsyncMock(return_value=None)
+    conn.fetch = AsyncMock(return_value=[])
+    conn.fetchrow = AsyncMock(return_value=None)
+    conn.fetchval = AsyncMock(return_value=None)
+
+    # Transaction context manager (used by pg_store helpers like delete_kb).
+    @asynccontextmanager
+    async def _tx():
+        yield None
+
+    conn.transaction = MagicMock(side_effect=_tx)
+    return conn
+
+
 def _make_mock_pool():
-    """Return a mock asyncpg pool that does nothing."""
+    """Return a mock asyncpg pool that yields a mock conn from acquire().
+
+    Mirrors the asyncpg.Pool surface that ``tenant_scoped_connection`` and
+    ``cross_org_admin_connection`` exercise: ``async with pool.acquire() as
+    conn`` must yield something the caller can ``execute`` / ``fetch`` /
+    ``fetchval`` against without raising.
+    """
     pool = MagicMock()
     pool.execute = AsyncMock(return_value=None)
     pool.fetch = AsyncMock(return_value=[])
+    pool.fetchval = AsyncMock(return_value=None)
+    pool.fetchrow = AsyncMock(return_value=None)
     pool.close = AsyncMock(return_value=None)
+
+    conn = _make_mock_conn()
+
+    @asynccontextmanager
+    async def _acquire():
+        yield conn
+
+    pool.acquire = MagicMock(side_effect=_acquire)
+    # Expose the conn so tests can assert against it if needed.
+    pool._mock_conn = conn  # type: ignore[attr-defined]
     return pool
 
 
 @pytest.fixture
 def mock_pool():
     return _make_mock_pool()
+
+
+@pytest.fixture(autouse=True)
+def _mock_db_helpers(request):
+    """Autouse: replace tenant_scoped_connection + cross_org_admin_connection
+    with no-op async context managers yielding a mock conn.
+
+    SPEC-TI-003-FOLLOWUP-001 turned every pg_store / kb_config / org_config
+    call into a ``conn``-passing call, and the route / task entry points
+    now wrap each request in ``tenant_scoped_connection``. Tests that hit
+    the FastAPI app via TestClient would otherwise need a real Postgres
+    just to satisfy the helper's ``pool.acquire()`` call. This fixture
+    intercepts both helpers so tests can run without one.
+
+    Tests that exercise the real helper (``test_db_rls_wiring.py``) opt out
+    by adding the ``no_mock_db_helpers`` marker, e.g.::
+
+        @pytest.mark.no_mock_db_helpers
+        async def test_real_postgres_thing(): ...
+    """
+    if request.node.get_closest_marker("no_mock_db_helpers"):
+        yield
+        return
+
+    @asynccontextmanager
+    async def _fake_tenant(org_id: str):  # noqa: ARG001
+        yield _make_mock_conn()
+
+    @asynccontextmanager
+    async def _fake_admin():
+        yield _make_mock_conn()
+
+    # Reset the module-level pool global so a prior test that triggered
+    # the real get_pool() does not leak a half-connected pool into this
+    # test's patched view.
+    try:
+        import knowledge_ingest.db as _db_mod
+
+        _db_mod._pool = None
+    except Exception:
+        pass
+
+    targets = [
+        "knowledge_ingest.db.tenant_scoped_connection",
+        "knowledge_ingest.routes.ingest.tenant_scoped_connection",
+        "knowledge_ingest.routes.crawl.tenant_scoped_connection",
+        "knowledge_ingest.routes.personal.tenant_scoped_connection",
+        "knowledge_ingest.crawl_tasks.tenant_scoped_connection",
+        "knowledge_ingest.rebuild_tasks.tenant_scoped_connection",
+        "knowledge_ingest.enrichment_tasks.tenant_scoped_connection",
+        "knowledge_ingest.connector_cleanup.tenant_scoped_connection",
+    ]
+    admin_targets = [
+        "knowledge_ingest.db.cross_org_admin_connection",
+        "knowledge_ingest.backfill.cross_org_admin_connection",
+    ]
+
+    patchers = []
+    for target in targets:
+        try:
+            p = patch(target, _fake_tenant)
+            p.start()
+            patchers.append(p)
+        except (ImportError, AttributeError, ModuleNotFoundError):
+            # Module not yet imported by this test session; harmless.
+            continue
+    for target in admin_targets:
+        try:
+            p = patch(target, _fake_admin)
+            p.start()
+            patchers.append(p)
+        except (ImportError, AttributeError, ModuleNotFoundError):
+            continue
+
+    try:
+        yield
+    finally:
+        for p in patchers:
+            try:
+                p.stop()
+            except RuntimeError:
+                pass
 
 
 @pytest.fixture

--- a/klai-knowledge-ingest/tests/conftest.py
+++ b/klai-knowledge-ingest/tests/conftest.py
@@ -146,6 +146,7 @@ def _mock_db_helpers(request):
     admin_targets = [
         "knowledge_ingest.db.cross_org_admin_connection",
         "knowledge_ingest.backfill.cross_org_admin_connection",
+        "knowledge_ingest.enrichment_tasks.cross_org_admin_connection",
     ]
 
     patchers = []

--- a/klai-knowledge-ingest/tests/test_artifact_unique_constraint.py
+++ b/klai-knowledge-ingest/tests/test_artifact_unique_constraint.py
@@ -13,11 +13,15 @@ These tests exercise the error-handling branch directly via ``asyncpg``
 mocking. The migration itself is not exercised (it requires a real PG
 instance with the partial-unique-index applied) — manual smoke test on
 deploy is acceptance criterion 2 of the SPEC.
+
+SPEC-TI-003-FOLLOWUP-001: ``create_artifact`` now takes
+``asyncpg.Connection`` as its first argument. Tests pass a mock conn
+instead of patching pg_store.get_pool.
 """
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import asyncpg
 import pytest
@@ -25,33 +29,61 @@ import structlog.testing
 
 
 def _build_unique_violation(constraint_name: str) -> asyncpg.UniqueViolationError:
-    """Construct a UniqueViolationError carrying the given constraint name.
-
-    ``asyncpg.UniqueViolationError`` accepts an optional message and reads
-    constraint_name from the args — but the asyncpg public path sets it
-    via ``__init__`` of PostgresError. The simplest portable approach is
-    to construct the exception then attach the attribute directly.
-    """
+    """Construct a UniqueViolationError carrying the given constraint name."""
     err = asyncpg.UniqueViolationError("simulated unique violation")
-    # asyncpg stores constraint_name as a Python attribute on the
-    # exception instance (read by getattr in production code).
     err.constraint_name = constraint_name  # type: ignore[attr-defined]
     return err
+
+
+def _make_mock_conn() -> MagicMock:
+    conn = MagicMock()
+    conn.execute = AsyncMock(return_value=None)
+    conn.fetch = AsyncMock(return_value=[])
+    conn.fetchval = AsyncMock(return_value=None)
+    conn.fetchrow = AsyncMock(return_value=None)
+    return conn
 
 
 @pytest.mark.asyncio
 async def test_happy_path_returns_new_artifact_id():
     """No race: INSERT succeeds, function returns the freshly-generated id."""
-    mock_pool = MagicMock()
-    mock_pool.execute = AsyncMock(return_value=None)
-    mock_pool.fetchval = AsyncMock()  # not called on happy path
+    conn = _make_mock_conn()
 
-    with patch(
-        "knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock, return_value=mock_pool
-    ):
-        from knowledge_ingest.pg_store import create_artifact
+    from knowledge_ingest.pg_store import create_artifact
 
-        artifact_id = await create_artifact(
+    artifact_id = await create_artifact(
+        conn,
+        org_id="org1",
+        kb_slug="kb1",
+        path="docs/page.md",
+        provenance_type="extracted",
+        assertion_mode="factual",
+        synthesis_depth=0,
+        confidence=None,
+        belief_time_start=0,
+        belief_time_end=253402300800,
+    )
+
+    assert isinstance(artifact_id, str)
+    assert len(artifact_id) == 36  # uuid4 hex with dashes
+    conn.execute.assert_awaited_once()
+    conn.fetchval.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_race_returns_winning_artifact_id_and_logs_error():
+    """UniqueViolation from uq_artifacts_active_path: SELECT winner, log, return."""
+    winning_id = "11111111-2222-3333-4444-555555555555"
+
+    conn = _make_mock_conn()
+    conn.execute = AsyncMock(side_effect=_build_unique_violation("uq_artifacts_active_path"))
+    conn.fetchval = AsyncMock(return_value=winning_id)
+
+    from knowledge_ingest.pg_store import create_artifact
+
+    with structlog.testing.capture_logs() as captured:
+        returned = await create_artifact(
+            conn,
             org_id="org1",
             kb_slug="kb1",
             path="docs/page.md",
@@ -62,39 +94,6 @@ async def test_happy_path_returns_new_artifact_id():
             belief_time_start=0,
             belief_time_end=253402300800,
         )
-
-    assert isinstance(artifact_id, str)
-    assert len(artifact_id) == 36  # uuid4 hex with dashes
-    mock_pool.execute.assert_awaited_once()
-    mock_pool.fetchval.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_race_returns_winning_artifact_id_and_logs_error():
-    """UniqueViolation from uq_artifacts_active_path: SELECT winner, log, return."""
-    winning_id = "11111111-2222-3333-4444-555555555555"
-
-    mock_pool = MagicMock()
-    mock_pool.execute = AsyncMock(side_effect=_build_unique_violation("uq_artifacts_active_path"))
-    mock_pool.fetchval = AsyncMock(return_value=winning_id)
-
-    with patch(
-        "knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock, return_value=mock_pool
-    ):
-        from knowledge_ingest.pg_store import create_artifact
-
-        with structlog.testing.capture_logs() as captured:
-            returned = await create_artifact(
-                org_id="org1",
-                kb_slug="kb1",
-                path="docs/page.md",
-                provenance_type="extracted",
-                assertion_mode="factual",
-                synthesis_depth=0,
-                confidence=None,
-                belief_time_start=0,
-                belief_time_end=253402300800,
-            )
 
     assert returned == winning_id
 
@@ -116,99 +115,15 @@ async def test_race_returns_winning_artifact_id_and_logs_error():
 
 @pytest.mark.asyncio
 async def test_unrelated_unique_violation_reraises():
-    """A unique violation from a different constraint must NOT be swallowed.
+    """A unique violation from a different constraint must NOT be swallowed."""
+    conn = _make_mock_conn()
+    conn.execute = AsyncMock(side_effect=_build_unique_violation("artifacts_pkey"))
 
-    The race-handling logic is scoped to ``uq_artifacts_active_path``. If
-    a future schema change introduces another unique constraint (e.g. on
-    artifact_id PK), a violation there is a real bug, not a race — the
-    caller must see the exception.
-    """
-    mock_pool = MagicMock()
-    mock_pool.execute = AsyncMock(side_effect=_build_unique_violation("artifacts_pkey"))
-    mock_pool.fetchval = AsyncMock()
+    from knowledge_ingest.pg_store import create_artifact
 
-    with patch(
-        "knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock, return_value=mock_pool
-    ):
-        from knowledge_ingest.pg_store import create_artifact
-
-        with pytest.raises(asyncpg.UniqueViolationError):
-            await create_artifact(
-                org_id="org1",
-                kb_slug="kb1",
-                path="docs/page.md",
-                provenance_type="extracted",
-                assertion_mode="factual",
-                synthesis_depth=0,
-                confidence=None,
-                belief_time_start=0,
-                belief_time_end=253402300800,
-            )
-
-    mock_pool.fetchval.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_race_with_vanished_winner_logs_and_reraises():
-    """Edge case: winning row was soft-deleted between INSERT and SELECT.
-
-    If fetchval returns None (no active row matches the path anymore), we
-    must NOT return None and let the caller hit a downstream NULL — log
-    the anomaly at error level and re-raise the original violation so the
-    caller knows something is off.
-    """
-    violation = _build_unique_violation("uq_artifacts_active_path")
-    mock_pool = MagicMock()
-    mock_pool.execute = AsyncMock(side_effect=violation)
-    mock_pool.fetchval = AsyncMock(return_value=None)  # winner vanished
-
-    with patch(
-        "knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock, return_value=mock_pool
-    ):
-        from knowledge_ingest.pg_store import create_artifact
-
-        with structlog.testing.capture_logs() as captured:
-            with pytest.raises(asyncpg.UniqueViolationError):
-                await create_artifact(
-                    org_id="org1",
-                    kb_slug="kb1",
-                    path="docs/page.md",
-                    provenance_type="extracted",
-                    assertion_mode="factual",
-                    synthesis_depth=0,
-                    confidence=None,
-                    belief_time_start=0,
-                    belief_time_end=253402300800,
-                )
-
-    # The "no winner" anomaly must be loud
-    no_winner_events = [
-        e for e in captured if e.get("event") == "artifact_create_race_lost_no_winner"
-    ]
-    assert len(no_winner_events) == 1
-    assert no_winner_events[0]["log_level"] == "error"
-
-
-@pytest.mark.asyncio
-async def test_race_returns_string_not_uuid_object():
-    """asyncpg can return a UUID object; ingest_document expects a str.
-    Without explicit str() conversion the artifact_id propagates as a UUID
-    and downstream JSON serialisation in extra_payload silently fails.
-    """
-    import uuid as _uuid
-
-    winning_uuid = _uuid.UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
-
-    mock_pool = MagicMock()
-    mock_pool.execute = AsyncMock(side_effect=_build_unique_violation("uq_artifacts_active_path"))
-    mock_pool.fetchval = AsyncMock(return_value=winning_uuid)
-
-    with patch(
-        "knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock, return_value=mock_pool
-    ):
-        from knowledge_ingest.pg_store import create_artifact
-
-        returned = await create_artifact(
+    with pytest.raises(asyncpg.UniqueViolationError):
+        await create_artifact(
+            conn,
             org_id="org1",
             kb_slug="kb1",
             path="docs/page.md",
@@ -220,8 +135,69 @@ async def test_race_returns_string_not_uuid_object():
             belief_time_end=253402300800,
         )
 
+    conn.fetchval.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_race_with_vanished_winner_logs_and_reraises():
+    """Edge case: winning row was soft-deleted between INSERT and SELECT."""
+    violation = _build_unique_violation("uq_artifacts_active_path")
+    conn = _make_mock_conn()
+    conn.execute = AsyncMock(side_effect=violation)
+    conn.fetchval = AsyncMock(return_value=None)  # winner vanished
+
+    from knowledge_ingest.pg_store import create_artifact
+
+    with structlog.testing.capture_logs() as captured:
+        with pytest.raises(asyncpg.UniqueViolationError):
+            await create_artifact(
+                conn,
+                org_id="org1",
+                kb_slug="kb1",
+                path="docs/page.md",
+                provenance_type="extracted",
+                assertion_mode="factual",
+                synthesis_depth=0,
+                confidence=None,
+                belief_time_start=0,
+                belief_time_end=253402300800,
+            )
+
+    no_winner_events = [
+        e for e in captured if e.get("event") == "artifact_create_race_lost_no_winner"
+    ]
+    assert len(no_winner_events) == 1
+    assert no_winner_events[0]["log_level"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_race_returns_string_not_uuid_object():
+    """asyncpg can return a UUID object; ingest_document expects a str."""
+    import uuid as _uuid
+
+    winning_uuid = _uuid.UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+
+    conn = _make_mock_conn()
+    conn.execute = AsyncMock(side_effect=_build_unique_violation("uq_artifacts_active_path"))
+    conn.fetchval = AsyncMock(return_value=winning_uuid)
+
+    from knowledge_ingest.pg_store import create_artifact
+
+    returned = await create_artifact(
+        conn,
+        org_id="org1",
+        kb_slug="kb1",
+        path="docs/page.md",
+        provenance_type="extracted",
+        assertion_mode="factual",
+        synthesis_depth=0,
+        confidence=None,
+        belief_time_start=0,
+        belief_time_end=253402300800,
+    )
+
     assert isinstance(returned, str), (
-        "create_artifact must return str even when asyncpg returns UUID — "
+        "create_artifact must return str even when asyncpg returns UUID -- "
         "downstream code (extra_payload, JSON in Procrastinate args) "
         "depends on string identity."
     )

--- a/klai-knowledge-ingest/tests/test_build_link_graph.py
+++ b/klai-knowledge-ingest/tests/test_build_link_graph.py
@@ -4,7 +4,11 @@ Tests for _build_link_graph helper in adapters/crawler.py (SPEC-CRAWLER-005).
 Phase 1 of the two-phase crawl pipeline: build the full link graph BEFORE
 any per-page ingest begins. This guarantees get_anchor_texts() and
 get_incoming_count() return final values during Phase 2.
+
+SPEC-TI-003-FOLLOWUP-001: ``_build_link_graph`` now takes
+``asyncpg.Connection`` as its first arg.
 """
+
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -12,12 +16,14 @@ import pytest
 from knowledge_ingest.crawl4ai_client import CrawlResult
 
 
-def _make_mock_pool() -> MagicMock:
-    pool = MagicMock()
-    pool.execute = AsyncMock(return_value=None)
-    pool.fetch = AsyncMock(return_value=[])
-    pool.fetchval = AsyncMock(return_value=0)
-    return pool
+def _make_mock_conn() -> MagicMock:
+    conn = MagicMock()
+    conn.execute = AsyncMock(return_value=None)
+    conn.executemany = AsyncMock(return_value=None)
+    conn.fetch = AsyncMock(return_value=[])
+    conn.fetchval = AsyncMock(return_value=0)
+    conn.fetchrow = AsyncMock(return_value=None)
+    return conn
 
 
 def _make_crawl_result(
@@ -46,18 +52,20 @@ async def test_build_link_graph_calls_upsert_for_each_result_with_internal_links
     results = [
         _make_crawl_result(
             url=f"https://example.com/page-{i}",
-            links={"internal": [{"href": f"https://example.com/page-{i+1}", "text": f"Link {i}"}]},
+            links={
+                "internal": [{"href": f"https://example.com/page-{i + 1}", "text": f"Link {i}"}]
+            },
         )
         for i in range(3)
     ]
-    mock_pool = _make_mock_pool()
+    mock_conn = _make_mock_conn()
 
     with patch("knowledge_ingest.adapters.crawler.pg_store") as mock_pg:
         mock_pg.upsert_page_links = AsyncMock()
 
         from knowledge_ingest.adapters.crawler import _build_link_graph
 
-        await _build_link_graph(results, "org-1", "kb-slug", mock_pool)
+        await _build_link_graph(mock_conn, results, "org-1", "kb-slug")
 
     assert mock_pg.upsert_page_links.call_count == 3
     # Verify correct from_url and links for each call
@@ -95,14 +103,14 @@ async def test_build_link_graph_skips_failed_results():
             links={"internal": [{"href": "https://example.com/d", "text": "D"}]},
         ),
     ]
-    mock_pool = _make_mock_pool()
+    mock_conn = _make_mock_conn()
 
     with patch("knowledge_ingest.adapters.crawler.pg_store") as mock_pg:
         mock_pg.upsert_page_links = AsyncMock()
 
         from knowledge_ingest.adapters.crawler import _build_link_graph
 
-        await _build_link_graph(results, "org-1", "kb-slug", mock_pool)
+        await _build_link_graph(mock_conn, results, "org-1", "kb-slug")
 
     # Only 2 successful results should trigger upsert
     assert mock_pg.upsert_page_links.call_count == 2
@@ -132,14 +140,14 @@ async def test_build_link_graph_skips_empty_internal_links():
             links={"external": [{"href": "https://other.com/page", "text": "Other"}]},
         ),
     ]
-    mock_pool = _make_mock_pool()
+    mock_conn = _make_mock_conn()
 
     with patch("knowledge_ingest.adapters.crawler.pg_store") as mock_pg:
         mock_pg.upsert_page_links = AsyncMock()
 
         from knowledge_ingest.adapters.crawler import _build_link_graph
 
-        await _build_link_graph(results, "org-1", "kb-slug", mock_pool)
+        await _build_link_graph(mock_conn, results, "org-1", "kb-slug")
 
     # No upsert calls — no result has non-empty internal links
     mock_pg.upsert_page_links.assert_not_called()
@@ -154,7 +162,7 @@ async def test_build_link_graph_no_qdrant_no_ingest():
             links={"internal": [{"href": "https://example.com/b", "text": "B"}]},
         ),
     ]
-    mock_pool = _make_mock_pool()
+    mock_conn = _make_mock_conn()
 
     with (
         patch("knowledge_ingest.adapters.crawler.pg_store") as mock_pg,
@@ -171,7 +179,7 @@ async def test_build_link_graph_no_qdrant_no_ingest():
 
         from knowledge_ingest.adapters.crawler import _build_link_graph
 
-        await _build_link_graph(results, "org-1", "kb-slug", mock_pool)
+        await _build_link_graph(mock_conn, results, "org-1", "kb-slug")
 
     # crawl_site should not be called from _build_link_graph
     mock_crawl.assert_not_called()

--- a/klai-knowledge-ingest/tests/test_crawl_link_fields.py
+++ b/klai-knowledge-ingest/tests/test_crawl_link_fields.py
@@ -6,28 +6,20 @@ Verifies that `POST /ingest/v1/crawl` populates `ingest_req.extra` with
 `links_to`, `anchor_texts`, and `incoming_link_count` when link_graph data
 is available.
 
-Diagnosis (SPEC-CRAWLER-005 Fase 2):
-  The original tests patched `knowledge_ingest.routes.crawl.httpx.AsyncClient`.
-  `routes/crawl.py` was refactored to use `crawl4ai_client._run_crawl` /
-  `crawl_page` instead of direct httpx calls, so the patch target no longer
-  exists on that module. The ingest-side contract these tests protect
-  (link_graph fields in extra) is unchanged — only the mock wiring needs
-  to match the current implementation.
+SPEC-TI-003-FOLLOWUP-001: ``crawl_url(request, http_request)`` opens a
+``tenant_scoped_connection`` and threads conn into pg_store + link_graph
++ ingest_document. The autouse ``_mock_db_helpers`` fixture in
+conftest.py replaces the helper with a stub-yielding context manager so
+these tests don't need a real Postgres.
 """
-from unittest.mock import AsyncMock, MagicMock, patch
+
+from unittest.mock import AsyncMock, patch
 
 import pytest
+from fastapi import Request
 
 from knowledge_ingest import link_graph
 from knowledge_ingest.models import CrawlRequest
-
-
-def _make_mock_pool():
-    pool = MagicMock()
-    pool.execute = AsyncMock(return_value=None)
-    pool.fetch = AsyncMock(return_value=[])
-    pool.fetchval = AsyncMock(return_value=0)
-    return pool
 
 
 def _make_run_crawl_result(
@@ -40,29 +32,55 @@ def _make_run_crawl_result(
     return fit_markdown, word_count, html
 
 
+def _make_http_request() -> Request:
+    scope = {"type": "http", "method": "POST", "path": "/", "headers": []}
+    return Request(scope=scope)
+
+
 @pytest.mark.asyncio
 async def test_crawl_url_populates_link_fields():
     """When link_graph returns data, extra contains links_to, anchor_texts,
     incoming_link_count."""
-    mock_pool = _make_mock_pool()
-
-    with patch("knowledge_ingest.routes.crawl._run_crawl", new_callable=AsyncMock,
-               return_value=_make_run_crawl_result()), \
-         patch("knowledge_ingest.routes.crawl.pg_store") as mock_pg, \
-         patch("knowledge_ingest.routes.crawl.ingest_document",
-               new_callable=AsyncMock) as mock_ingest, \
-         patch("knowledge_ingest.routes.crawl.validate_url", new_callable=AsyncMock), \
-         patch("knowledge_ingest.routes.crawl.get_domain_selector",
-               new_callable=AsyncMock, return_value=None), \
-         patch.object(link_graph, "get_outbound_urls", new_callable=AsyncMock,
-                      return_value=["https://example.com/b", "https://example.com/c"]), \
-         patch.object(link_graph, "get_anchor_texts", new_callable=AsyncMock,
-                      return_value=["Page B", "Page C"]), \
-         patch.object(link_graph, "get_incoming_count", new_callable=AsyncMock,
-                      return_value=5), \
-         patch("knowledge_ingest.routes.crawl.get_pool", new_callable=AsyncMock,
-               return_value=mock_pool):
-
+    with (
+        patch(
+            "knowledge_ingest.routes.crawl._run_crawl",
+            new_callable=AsyncMock,
+            return_value=_make_run_crawl_result(),
+        ),
+        patch("knowledge_ingest.routes.crawl.pg_store") as mock_pg,
+        patch(
+            "knowledge_ingest.routes.crawl.ingest_document",
+            new_callable=AsyncMock,
+        ) as mock_ingest,
+        patch("knowledge_ingest.routes.crawl.validate_url", new_callable=AsyncMock),
+        patch(
+            "knowledge_ingest.routes.crawl.assert_caller_identity",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "knowledge_ingest.routes.crawl.get_domain_selector",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch.object(
+            link_graph,
+            "get_outbound_urls",
+            new_callable=AsyncMock,
+            return_value=["https://example.com/b", "https://example.com/c"],
+        ),
+        patch.object(
+            link_graph,
+            "get_anchor_texts",
+            new_callable=AsyncMock,
+            return_value=["Page B", "Page C"],
+        ),
+        patch.object(
+            link_graph,
+            "get_incoming_count",
+            new_callable=AsyncMock,
+            return_value=5,
+        ),
+    ):
         mock_pg.get_crawled_page_stored = AsyncMock(return_value=None)
         mock_pg.upsert_crawled_page = AsyncMock()
 
@@ -75,13 +93,17 @@ async def test_crawl_url_populates_link_fields():
             org_id="org-1",
             kb_slug="docs",
         )
-        result = await crawl_url(request)
+        result = await crawl_url(request, _make_http_request())
 
         # Verify ingest was called with link fields in extra
         mock_ingest.assert_called_once()
-        ingest_req = mock_ingest.call_args[0][0]
+        # SPEC-TI-003-FOLLOWUP-001: ingest_document(conn, req); req is args[1]
+        ingest_req = mock_ingest.call_args[0][1]
         assert ingest_req.extra["source_url"] == "https://example.com/a"
-        assert ingest_req.extra["links_to"] == ["https://example.com/b", "https://example.com/c"]
+        assert ingest_req.extra["links_to"] == [
+            "https://example.com/b",
+            "https://example.com/c",
+        ]
         assert ingest_req.extra["anchor_texts"] == ["Page B", "Page C"]
         assert ingest_req.extra["incoming_link_count"] == 5
         assert result.chunks_ingested == 3
@@ -90,23 +112,40 @@ async def test_crawl_url_populates_link_fields():
 @pytest.mark.asyncio
 async def test_crawl_url_caps_links_to_at_20():
     """When link_graph returns >20 outbound URLs, links_to is capped at 20."""
-    mock_pool = _make_mock_pool()
-
-    with patch("knowledge_ingest.routes.crawl._run_crawl", new_callable=AsyncMock,
-               return_value=_make_run_crawl_result()), \
-         patch("knowledge_ingest.routes.crawl.pg_store") as mock_pg, \
-         patch("knowledge_ingest.routes.crawl.ingest_document",
-               new_callable=AsyncMock) as mock_ingest, \
-         patch("knowledge_ingest.routes.crawl.validate_url", new_callable=AsyncMock), \
-         patch("knowledge_ingest.routes.crawl.get_domain_selector",
-               new_callable=AsyncMock, return_value=None), \
-         patch.object(link_graph, "get_outbound_urls", new_callable=AsyncMock,
-                      return_value=[f"https://example.com/page-{i}" for i in range(25)]), \
-         patch.object(link_graph, "get_anchor_texts", new_callable=AsyncMock, return_value=[]), \
-         patch.object(link_graph, "get_incoming_count", new_callable=AsyncMock, return_value=0), \
-         patch("knowledge_ingest.routes.crawl.get_pool", new_callable=AsyncMock,
-               return_value=mock_pool):
-
+    with (
+        patch(
+            "knowledge_ingest.routes.crawl._run_crawl",
+            new_callable=AsyncMock,
+            return_value=_make_run_crawl_result(),
+        ),
+        patch("knowledge_ingest.routes.crawl.pg_store") as mock_pg,
+        patch(
+            "knowledge_ingest.routes.crawl.ingest_document",
+            new_callable=AsyncMock,
+        ) as mock_ingest,
+        patch("knowledge_ingest.routes.crawl.validate_url", new_callable=AsyncMock),
+        patch(
+            "knowledge_ingest.routes.crawl.assert_caller_identity",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "knowledge_ingest.routes.crawl.get_domain_selector",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch.object(
+            link_graph,
+            "get_outbound_urls",
+            new_callable=AsyncMock,
+            return_value=[f"https://example.com/page-{i}" for i in range(25)],
+        ),
+        patch.object(
+            link_graph, "get_anchor_texts", new_callable=AsyncMock, return_value=[]
+        ),
+        patch.object(
+            link_graph, "get_incoming_count", new_callable=AsyncMock, return_value=0
+        ),
+    ):
         mock_pg.get_crawled_page_stored = AsyncMock(return_value=None)
         mock_pg.upsert_crawled_page = AsyncMock()
 
@@ -119,9 +158,9 @@ async def test_crawl_url_caps_links_to_at_20():
             org_id="org-1",
             kb_slug="docs",
         )
-        await crawl_url(request)
+        await crawl_url(request, _make_http_request())
 
-        ingest_req = mock_ingest.call_args[0][0]
+        ingest_req = mock_ingest.call_args[0][1]
         assert len(ingest_req.extra["links_to"]) == 20
 
 
@@ -129,23 +168,40 @@ async def test_crawl_url_caps_links_to_at_20():
 async def test_crawl_url_graceful_degradation_on_link_graph_error():
     """When link_graph.get_outbound_urls raises, crawl still succeeds with
     source_url only (no link fields in extra)."""
-    mock_pool = _make_mock_pool()
-
-    with patch("knowledge_ingest.routes.crawl._run_crawl", new_callable=AsyncMock,
-               return_value=_make_run_crawl_result()), \
-         patch("knowledge_ingest.routes.crawl.pg_store") as mock_pg, \
-         patch("knowledge_ingest.routes.crawl.ingest_document",
-               new_callable=AsyncMock) as mock_ingest, \
-         patch("knowledge_ingest.routes.crawl.validate_url", new_callable=AsyncMock), \
-         patch("knowledge_ingest.routes.crawl.get_domain_selector",
-               new_callable=AsyncMock, return_value=None), \
-         patch.object(link_graph, "get_outbound_urls", new_callable=AsyncMock,
-                      side_effect=Exception("DB connection failed")), \
-         patch.object(link_graph, "get_anchor_texts", new_callable=AsyncMock, return_value=[]), \
-         patch.object(link_graph, "get_incoming_count", new_callable=AsyncMock, return_value=0), \
-         patch("knowledge_ingest.routes.crawl.get_pool", new_callable=AsyncMock,
-               return_value=mock_pool):
-
+    with (
+        patch(
+            "knowledge_ingest.routes.crawl._run_crawl",
+            new_callable=AsyncMock,
+            return_value=_make_run_crawl_result(),
+        ),
+        patch("knowledge_ingest.routes.crawl.pg_store") as mock_pg,
+        patch(
+            "knowledge_ingest.routes.crawl.ingest_document",
+            new_callable=AsyncMock,
+        ) as mock_ingest,
+        patch("knowledge_ingest.routes.crawl.validate_url", new_callable=AsyncMock),
+        patch(
+            "knowledge_ingest.routes.crawl.assert_caller_identity",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "knowledge_ingest.routes.crawl.get_domain_selector",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch.object(
+            link_graph,
+            "get_outbound_urls",
+            new_callable=AsyncMock,
+            side_effect=Exception("DB connection failed"),
+        ),
+        patch.object(
+            link_graph, "get_anchor_texts", new_callable=AsyncMock, return_value=[]
+        ),
+        patch.object(
+            link_graph, "get_incoming_count", new_callable=AsyncMock, return_value=0
+        ),
+    ):
         mock_pg.get_crawled_page_stored = AsyncMock(return_value=None)
         mock_pg.upsert_crawled_page = AsyncMock()
 
@@ -158,12 +214,12 @@ async def test_crawl_url_graceful_degradation_on_link_graph_error():
             org_id="org-1",
             kb_slug="docs",
         )
-        result = await crawl_url(request)
+        result = await crawl_url(request, _make_http_request())
 
         # Crawl should still succeed
         assert result.chunks_ingested == 2
 
-        ingest_req = mock_ingest.call_args[0][0]
+        ingest_req = mock_ingest.call_args[0][1]
         assert ingest_req.extra["source_url"] == "https://example.com/a"
         # Link fields should NOT be present since the gather failed
         assert "links_to" not in ingest_req.extra

--- a/klai-knowledge-ingest/tests/test_crawl_registry_dedup.py
+++ b/klai-knowledge-ingest/tests/test_crawl_registry_dedup.py
@@ -7,19 +7,30 @@ Covers _ingest_crawl_result (bulk crawler) and crawl_url (single-URL route):
 - Content changed           → ingest_document IS called and crawled_pages updated
 - New URL                   → insert + ingest
 - crawled_pages keyed on request.url, not derived path
+
+SPEC-TI-003-FOLLOWUP-001: ``_ingest_crawl_result``, ``delete_kb`` and the
+crawl-route handlers all take ``asyncpg.Connection`` as their first arg
+now. Tests pass mock conns directly; routes go through the autouse
+``_mock_db_helpers`` fixture in conftest.py so the
+``tenant_scoped_connection`` they open internally yields a stub conn.
 """
+
 from __future__ import annotations
 
 import hashlib
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import Request
 
 from knowledge_ingest.crawl4ai_client import CrawlResult
+
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _sha256(text: str) -> str:
     return hashlib.sha256(text.encode()).hexdigest()
@@ -45,9 +56,32 @@ def _make_crawl_result(
     )
 
 
+def _make_mock_conn() -> MagicMock:
+    conn = MagicMock()
+    conn.execute = AsyncMock(return_value=None)
+    conn.executemany = AsyncMock(return_value=None)
+    conn.fetch = AsyncMock(return_value=[])
+    conn.fetchval = AsyncMock(return_value=0)
+    conn.fetchrow = AsyncMock(return_value=None)
+
+    @asynccontextmanager
+    async def _tx():
+        yield None
+
+    conn.transaction = MagicMock(side_effect=_tx)
+    return conn
+
+
+def _make_http_request() -> Request:
+    """Minimal Starlette Request stub for routes that take http_request."""
+    scope = {"type": "http", "method": "POST", "path": "/", "headers": []}
+    return Request(scope=scope)
+
+
 # ---------------------------------------------------------------------------
 # Bulk crawler: _ingest_crawl_result
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.asyncio
 async def test_bulk_crawl_skip_unchanged() -> None:
@@ -57,17 +91,26 @@ async def test_bulk_crawl_skip_unchanged() -> None:
     stored = (_sha256(html), _sha256(text))  # (raw_html_hash, content_hash)
 
     result = _make_crawl_result(text=text, html=html)
+    mock_conn = _make_mock_conn()
 
-    with patch(
-        "knowledge_ingest.pg_store.upsert_crawled_page",
-        new_callable=AsyncMock,
-    ) as mock_upsert, patch(
-        "knowledge_ingest.routes.ingest.ingest_document",
-        new_callable=AsyncMock,
-    ) as mock_ingest:
+    with (
+        patch(
+            "knowledge_ingest.pg_store.upsert_crawled_page",
+            new_callable=AsyncMock,
+        ) as mock_upsert,
+        patch(
+            "knowledge_ingest.routes.ingest.ingest_document",
+            new_callable=AsyncMock,
+        ) as mock_ingest,
+    ):
         from knowledge_ingest.adapters.crawler import _ingest_crawl_result
+
         await _ingest_crawl_result(
-            result, "https://example.com/page", "org1", "kb1",
+            mock_conn,
+            result,
+            "https://example.com/page",
+            "org1",
+            "kb1",
             stored=stored,
         )
 
@@ -84,17 +127,26 @@ async def test_bulk_crawl_skip_html_noise() -> None:
     stored = (_sha256(old_html), _sha256(text))
 
     result = _make_crawl_result(text=text, html=new_html)
+    mock_conn = _make_mock_conn()
 
-    with patch(
-        "knowledge_ingest.pg_store.upsert_crawled_page",
-        new_callable=AsyncMock,
-    ) as mock_upsert, patch(
-        "knowledge_ingest.routes.ingest.ingest_document",
-        new_callable=AsyncMock,
-    ) as mock_ingest:
+    with (
+        patch(
+            "knowledge_ingest.pg_store.upsert_crawled_page",
+            new_callable=AsyncMock,
+        ) as mock_upsert,
+        patch(
+            "knowledge_ingest.routes.ingest.ingest_document",
+            new_callable=AsyncMock,
+        ) as mock_ingest,
+    ):
         from knowledge_ingest.adapters.crawler import _ingest_crawl_result
+
         await _ingest_crawl_result(
-            result, "https://example.com/page", "org1", "kb1",
+            mock_conn,
+            result,
+            "https://example.com/page",
+            "org1",
+            "kb1",
             stored=stored,
         )
 
@@ -111,21 +163,31 @@ async def test_bulk_crawl_reingest_on_change() -> None:
     old_stored = (_sha256("old html"), _sha256("# Old content"))
 
     result = _make_crawl_result(text=text, html=html)
+    mock_conn = _make_mock_conn()
 
-    with patch(
-        "knowledge_ingest.pg_store.upsert_crawled_page",
-        new_callable=AsyncMock,
-    ) as mock_upsert, patch(
-        "knowledge_ingest.pg_store.upsert_page_links",
-        new_callable=AsyncMock,
-    ), patch(
-        "knowledge_ingest.routes.ingest.ingest_document",
-        new_callable=AsyncMock,
-        return_value={"status": "ok", "chunks": 3},
-    ) as mock_ingest:
+    with (
+        patch(
+            "knowledge_ingest.pg_store.upsert_crawled_page",
+            new_callable=AsyncMock,
+        ) as mock_upsert,
+        patch(
+            "knowledge_ingest.pg_store.upsert_page_links",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "knowledge_ingest.routes.ingest.ingest_document",
+            new_callable=AsyncMock,
+            return_value={"status": "ok", "chunks": 3},
+        ) as mock_ingest,
+    ):
         from knowledge_ingest.adapters.crawler import _ingest_crawl_result
+
         await _ingest_crawl_result(
-            result, "https://example.com/page", "org1", "kb1",
+            mock_conn,
+            result,
+            "https://example.com/page",
+            "org1",
+            "kb1",
             stored=old_stored,
         )
 
@@ -140,21 +202,31 @@ async def test_bulk_crawl_new_page() -> None:
     html = "<html><body>New</body></html>"
 
     result = _make_crawl_result(text=text, html=html)
+    mock_conn = _make_mock_conn()
 
-    with patch(
-        "knowledge_ingest.pg_store.upsert_crawled_page",
-        new_callable=AsyncMock,
-    ) as mock_upsert, patch(
-        "knowledge_ingest.pg_store.upsert_page_links",
-        new_callable=AsyncMock,
-    ), patch(
-        "knowledge_ingest.routes.ingest.ingest_document",
-        new_callable=AsyncMock,
-        return_value={"status": "ok", "chunks": 2},
-    ) as mock_ingest:
+    with (
+        patch(
+            "knowledge_ingest.pg_store.upsert_crawled_page",
+            new_callable=AsyncMock,
+        ) as mock_upsert,
+        patch(
+            "knowledge_ingest.pg_store.upsert_page_links",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "knowledge_ingest.routes.ingest.ingest_document",
+            new_callable=AsyncMock,
+            return_value={"status": "ok", "chunks": 2},
+        ) as mock_ingest,
+    ):
         from knowledge_ingest.adapters.crawler import _ingest_crawl_result
+
         await _ingest_crawl_result(
-            result, "https://example.com/new", "org1", "kb1",
+            mock_conn,
+            result,
+            "https://example.com/new",
+            "org1",
+            "kb1",
             stored=None,
         )
 
@@ -170,6 +242,7 @@ async def test_bulk_crawl_new_page() -> None:
 # Single-URL crawl: crawl_url
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_single_url_skip_unchanged() -> None:
     """crawl_url returns chunks_ingested=0 when raw HTML hash matches stored."""
@@ -177,22 +250,43 @@ async def test_single_url_skip_unchanged() -> None:
     fit_md = "# Hello"
     stored = (_sha256(raw_html), "some-content-hash")
 
-    with patch("knowledge_ingest.routes.crawl.validate_url", new_callable=AsyncMock), \
-         patch("knowledge_ingest.routes.crawl.get_domain_selector",
-               new_callable=AsyncMock, return_value=None), \
-         patch("knowledge_ingest.routes.crawl._run_crawl",
-               new_callable=AsyncMock, return_value=(fit_md, 2, raw_html)), \
-         patch("knowledge_ingest.routes.crawl.pg_store.get_crawled_page_stored",
-               new_callable=AsyncMock, return_value=stored), \
-         patch("knowledge_ingest.routes.crawl.pg_store.upsert_crawled_page",
-               new_callable=AsyncMock) as mock_upsert, \
-         patch("knowledge_ingest.routes.crawl.ingest_document",
-               new_callable=AsyncMock) as mock_ingest:
+    with (
+        patch("knowledge_ingest.routes.crawl.validate_url", new_callable=AsyncMock),
+        patch(
+            "knowledge_ingest.routes.crawl.assert_caller_identity",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "knowledge_ingest.routes.crawl.get_domain_selector",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "knowledge_ingest.routes.crawl._run_crawl",
+            new_callable=AsyncMock,
+            return_value=(fit_md, 2, raw_html),
+        ),
+        patch(
+            "knowledge_ingest.routes.crawl.pg_store.get_crawled_page_stored",
+            new_callable=AsyncMock,
+            return_value=stored,
+        ),
+        patch(
+            "knowledge_ingest.routes.crawl.pg_store.upsert_crawled_page",
+            new_callable=AsyncMock,
+        ) as mock_upsert,
+        patch(
+            "knowledge_ingest.routes.crawl.ingest_document",
+            new_callable=AsyncMock,
+        ) as mock_ingest,
+    ):
         from knowledge_ingest.models import CrawlRequest
         from knowledge_ingest.routes.crawl import crawl_url
-        result = await crawl_url(CrawlRequest(
-            org_id="org1", kb_slug="kb1", url="https://example.com/page"
-        ))
+
+        result = await crawl_url(
+            CrawlRequest(org_id="org1", kb_slug="kb1", url="https://example.com/page"),
+            _make_http_request(),
+        )
 
     assert result.chunks_ingested == 0
     mock_ingest.assert_not_called()
@@ -207,19 +301,41 @@ async def test_single_url_url_key() -> None:
     fit_md = "Content"
     mock_upsert = AsyncMock()
 
-    with patch("knowledge_ingest.routes.crawl.validate_url", new_callable=AsyncMock), \
-         patch("knowledge_ingest.routes.crawl.get_domain_selector",
-               new_callable=AsyncMock, return_value=None), \
-         patch("knowledge_ingest.routes.crawl._run_crawl",
-               new_callable=AsyncMock, return_value=(fit_md, 1, raw_html)), \
-         patch("knowledge_ingest.routes.crawl.pg_store.get_crawled_page_stored",
-               new_callable=AsyncMock, return_value=None), \
-         patch("knowledge_ingest.routes.crawl.pg_store.upsert_crawled_page", mock_upsert), \
-         patch("knowledge_ingest.routes.crawl.ingest_document",
-               new_callable=AsyncMock, return_value={"status": "ok", "chunks": 1}):
+    with (
+        patch("knowledge_ingest.routes.crawl.validate_url", new_callable=AsyncMock),
+        patch(
+            "knowledge_ingest.routes.crawl.assert_caller_identity",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "knowledge_ingest.routes.crawl.get_domain_selector",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "knowledge_ingest.routes.crawl._run_crawl",
+            new_callable=AsyncMock,
+            return_value=(fit_md, 1, raw_html),
+        ),
+        patch(
+            "knowledge_ingest.routes.crawl.pg_store.get_crawled_page_stored",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch("knowledge_ingest.routes.crawl.pg_store.upsert_crawled_page", mock_upsert),
+        patch(
+            "knowledge_ingest.routes.crawl.ingest_document",
+            new_callable=AsyncMock,
+            return_value={"status": "ok", "chunks": 1},
+        ),
+    ):
         from knowledge_ingest.models import CrawlRequest
         from knowledge_ingest.routes.crawl import crawl_url
-        await crawl_url(CrawlRequest(org_id="org1", kb_slug="kb1", url=url))
+
+        await crawl_url(
+            CrawlRequest(org_id="org1", kb_slug="kb1", url=url),
+            _make_http_request(),
+        )
 
     mock_upsert.assert_called_once()
     assert mock_upsert.call_args.kwargs["url"] == url
@@ -229,31 +345,16 @@ async def test_single_url_url_key() -> None:
 # KB cleanup
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_delete_kb_cleans_registry() -> None:
     """delete_kb removes rows from crawled_pages and page_links."""
-    mock_conn = AsyncMock()
-    mock_conn.execute = AsyncMock()
-    mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
-    mock_conn.__aexit__ = AsyncMock(return_value=False)
+    mock_conn = _make_mock_conn()
 
-    mock_tx = AsyncMock()
-    mock_tx.__aenter__ = AsyncMock(return_value=mock_tx)
-    mock_tx.__aexit__ = AsyncMock(return_value=False)
-    mock_conn.transaction = MagicMock(return_value=mock_tx)
+    from knowledge_ingest.pg_store import delete_kb
 
-    mock_pool = MagicMock()
-    mock_pool.acquire = MagicMock(return_value=mock_conn)
-
-    get_pool_patch = patch(
-        "knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock, return_value=mock_pool
-    )
-    with get_pool_patch:
-        from knowledge_ingest.pg_store import delete_kb
-        await delete_kb("org1", "kb1")
+    await delete_kb(mock_conn, "org1", "kb1")
 
     executed_sqls = [call.args[0] for call in mock_conn.execute.call_args_list]
-    assert any("crawled_pages" in sql for sql in executed_sqls), \
-        "crawled_pages not deleted"
-    assert any("page_links" in sql for sql in executed_sqls), \
-        "page_links not deleted"
+    assert any("crawled_pages" in sql for sql in executed_sqls), "crawled_pages not deleted"
+    assert any("page_links" in sql for sql in executed_sqls), "page_links not deleted"

--- a/klai-knowledge-ingest/tests/test_crawler_link_fields.py
+++ b/klai-knowledge-ingest/tests/test_crawler_link_fields.py
@@ -14,12 +14,15 @@ from knowledge_ingest import link_graph
 from knowledge_ingest.crawl4ai_client import CrawlResult
 
 
-def _make_mock_pool():
-    pool = MagicMock()
-    pool.execute = AsyncMock(return_value=None)
-    pool.fetch = AsyncMock(return_value=[])
-    pool.fetchval = AsyncMock(return_value=0)
-    return pool
+def _make_mock_conn():
+    """SPEC-TI-003-FOLLOWUP-001: helpers take asyncpg.Connection directly."""
+    conn = MagicMock()
+    conn.execute = AsyncMock(return_value=None)
+    conn.executemany = AsyncMock(return_value=None)
+    conn.fetch = AsyncMock(return_value=[])
+    conn.fetchval = AsyncMock(return_value=0)
+    conn.fetchrow = AsyncMock(return_value=None)
+    return conn
 
 
 def _make_crawl_result(
@@ -45,7 +48,7 @@ def _make_crawl_result(
 @pytest.mark.asyncio
 async def test_ingest_crawl_result_populates_link_fields():
     """_ingest_crawl_result populates extra with links_to, anchor_texts, incoming_link_count."""
-    mock_pool = _make_mock_pool()
+    mock_conn = _make_mock_conn()
     result = _make_crawl_result()
 
     outbound_urls = ["https://example.com/b"]
@@ -77,17 +80,18 @@ async def test_ingest_crawl_result_populates_link_fields():
         from knowledge_ingest.adapters.crawler import _ingest_crawl_result
 
         await _ingest_crawl_result(
+            mock_conn,
             result,
             url="https://example.com/a",
             org_id="org-1",
             kb_slug="docs",
-            pool=mock_pool,
             stored=None,
         )
 
         # Verify ingest_document was called with link fields
         mock_ingest.assert_called_once()
-        ingest_req = mock_ingest.call_args[0][0]
+        # SPEC-TI-003-FOLLOWUP-001: ingest_document(conn, req); req is args[1]
+        ingest_req = mock_ingest.call_args[0][1]
         assert ingest_req.extra["links_to"] == ["https://example.com/b"]
         assert ingest_req.extra["anchor_texts"] == ["Link to B"]
         assert ingest_req.extra["incoming_link_count"] == 3
@@ -96,7 +100,7 @@ async def test_ingest_crawl_result_populates_link_fields():
 @pytest.mark.asyncio
 async def test_ingest_crawl_result_graceful_on_link_graph_error():
     """When link_graph raises, _ingest_crawl_result still ingests without link fields."""
-    mock_pool = _make_mock_pool()
+    mock_conn = _make_mock_conn()
     result = _make_crawl_result()
 
     with (
@@ -127,16 +131,17 @@ async def test_ingest_crawl_result_graceful_on_link_graph_error():
         from knowledge_ingest.adapters.crawler import _ingest_crawl_result
 
         await _ingest_crawl_result(
+            mock_conn,
             result,
             url="https://example.com/a",
             org_id="org-1",
             kb_slug="docs",
-            pool=mock_pool,
             stored=None,
         )
 
         mock_ingest.assert_called_once()
-        ingest_req = mock_ingest.call_args[0][0]
+        # SPEC-TI-003-FOLLOWUP-001: ingest_document(conn, req); req is args[1]
+        ingest_req = mock_ingest.call_args[0][1]
         assert ingest_req.extra["source_url"] == "https://example.com/a"
         assert "links_to" not in ingest_req.extra
 
@@ -150,25 +155,21 @@ async def test_run_crawl_job_calls_build_link_graph_before_ingest():
     is called for all pages before any page is ingested, so link graph queries
     in _ingest_crawl_result always see the full graph.
     """
-    mock_pool = _make_mock_pool()
+    mock_conn = _make_mock_conn()
     mock_result = _make_crawl_result(
         links={"internal": [{"href": "https://example.com/b", "text": "B"}]},
     )
 
     call_order: list[str] = []
 
-    async def _fake_upsert_links(**kwargs):  # type: ignore[no-untyped-def]
+    async def _fake_upsert_links(*args, **kwargs):  # type: ignore[no-untyped-def]
         call_order.append("upsert_page_links")
 
-    async def _fake_ingest(req):  # type: ignore[no-untyped-def]
+    async def _fake_ingest(*args, **kwargs):  # type: ignore[no-untyped-def]
         call_order.append("ingest_document")
         return {"chunks": 1}
 
     with (
-        patch(
-            "knowledge_ingest.adapters.crawler.get_pool",
-            new_callable=AsyncMock, return_value=mock_pool,
-        ),
         patch(
             "knowledge_ingest.adapters.crawler._update_job",
             new_callable=AsyncMock,
@@ -176,19 +177,26 @@ async def test_run_crawl_job_calls_build_link_graph_before_ingest():
         patch("knowledge_ingest.adapters.crawler.pg_store") as mock_pg,
         patch(
             "knowledge_ingest.adapters.crawler.crawl_site",
-            new_callable=AsyncMock, return_value=[mock_result],
+            new_callable=AsyncMock,
+            return_value=[mock_result],
         ),
         patch.object(
-            link_graph, "get_outbound_urls",
-            new_callable=AsyncMock, return_value=[],
+            link_graph,
+            "get_outbound_urls",
+            new_callable=AsyncMock,
+            return_value=[],
         ),
         patch.object(
-            link_graph, "get_anchor_texts",
-            new_callable=AsyncMock, return_value=[],
+            link_graph,
+            "get_anchor_texts",
+            new_callable=AsyncMock,
+            return_value=[],
         ),
         patch.object(
-            link_graph, "get_incoming_count",
-            new_callable=AsyncMock, return_value=0,
+            link_graph,
+            "get_incoming_count",
+            new_callable=AsyncMock,
+            return_value=0,
         ),
         patch(
             "knowledge_ingest.routes.ingest.ingest_document",
@@ -203,6 +211,7 @@ async def test_run_crawl_job_calls_build_link_graph_before_ingest():
         from knowledge_ingest.adapters.crawler import run_crawl_job
 
         await run_crawl_job(
+            mock_conn,
             job_id="job-1",
             org_id="org-1",
             kb_slug="docs",

--- a/klai-knowledge-ingest/tests/test_crawler_link_fields_complete.py
+++ b/klai-knowledge-ingest/tests/test_crawler_link_fields_complete.py
@@ -87,7 +87,7 @@ def _get_outbound_urls_from_graph(
     graph: dict[str, list[dict]],
 ) -> AsyncMock:
     """Return an AsyncMock for link_graph.get_outbound_urls backed by in-memory graph."""
-    async def _impl(url: str, org_id: str, kb_slug: str, pool: object) -> list[str]:
+    async def _impl(conn: object, url: str, org_id: str, kb_slug: str) -> list[str]:
         return [link["href"] for link in graph.get(url, [])]
     return AsyncMock(side_effect=_impl)
 
@@ -96,7 +96,7 @@ def _get_anchor_texts_from_graph(
     graph: dict[str, list[dict]],
 ) -> AsyncMock:
     """Return an AsyncMock for link_graph.get_anchor_texts backed by in-memory graph."""
-    async def _impl(url: str, org_id: str, kb_slug: str, pool: object) -> list[str]:
+    async def _impl(conn: object, url: str, org_id: str, kb_slug: str) -> list[str]:
         texts = []
         for _from_url, links in graph.items():
             for link in links:
@@ -110,7 +110,7 @@ def _get_incoming_count_from_graph(
     graph: dict[str, list[dict]],
 ) -> AsyncMock:
     """Return an AsyncMock for link_graph.get_incoming_count backed by in-memory graph."""
-    async def _impl(url: str, org_id: str, kb_slug: str, pool: object) -> int:
+    async def _impl(conn: object, url: str, org_id: str, kb_slug: str) -> int:
         count = 0
         for _from_url, links in graph.items():
             for link in links:
@@ -136,7 +136,9 @@ async def test_run_crawl_job_populates_link_fields_on_every_page():
     # Capture all ingest calls to verify extra dicts
     captured_ingest_calls: list[dict] = []
 
-    async def _fake_ingest(req):  # type: ignore[no-untyped-def]
+    async def _fake_ingest(*args, **kwargs):  # type: ignore[no-untyped-def]
+        # SPEC-TI-003-FOLLOWUP-001: ingest_document(conn, req); req is args[1]
+        req = args[1] if len(args) > 1 else kwargs.get("req")
         captured_ingest_calls.append({"url": req.path, "extra": dict(req.extra)})
         return {"chunks": 1}
 
@@ -145,11 +147,6 @@ async def test_run_crawl_job_populates_link_fields_on_every_page():
             "knowledge_ingest.adapters.crawler.crawl_site",
             new_callable=AsyncMock,
             return_value=results,
-        ),
-        patch(
-            "knowledge_ingest.adapters.crawler.get_pool",
-            new_callable=AsyncMock,
-            return_value=mock_pool,
         ),
         patch(
             "knowledge_ingest.adapters.crawler._update_job",
@@ -171,7 +168,10 @@ async def test_run_crawl_job_populates_link_fields_on_every_page():
 
         from knowledge_ingest.adapters.crawler import run_crawl_job
 
+        from tests.test_crawl_registry_dedup import _make_mock_conn as _make_conn
+
         await run_crawl_job(
+            _make_conn(),
             job_id="job-test",
             org_id="org-1",
             kb_slug="docs",
@@ -248,11 +248,6 @@ async def test_run_crawl_job_no_post_crawl_link_counts_call():
             return_value=results,
         ),
         patch(
-            "knowledge_ingest.adapters.crawler.get_pool",
-            new_callable=AsyncMock,
-            return_value=mock_pool,
-        ),
-        patch(
             "knowledge_ingest.adapters.crawler._update_job",
             new_callable=AsyncMock,
         ),
@@ -278,7 +273,10 @@ async def test_run_crawl_job_no_post_crawl_link_counts_call():
         ) as mock_update_link_counts:
             from knowledge_ingest.adapters.crawler import run_crawl_job
 
+            from tests.test_crawl_registry_dedup import _make_mock_conn as _make_conn
+
             await run_crawl_job(
+                _make_conn(),
                 job_id="job-test",
                 org_id="org-1",
                 kb_slug="docs",

--- a/klai-knowledge-ingest/tests/test_crawler_login_indicator.py
+++ b/klai-knowledge-ingest/tests/test_crawler_login_indicator.py
@@ -62,8 +62,10 @@ class TestIngestCrawlResultAuthWall:
             success=False,
             error_message="wait_for timeout",
         )
+        mock_conn = MagicMock()
         with pytest.raises(AuthWallDetected) as excinfo:
             await _ingest_crawl_result(
+                mock_conn,
                 failed,
                 url=failed.url,
                 org_id="org",
@@ -84,8 +86,10 @@ class TestIngestCrawlResultAuthWall:
             success=False,
             error_message="network timeout",
         )
+        mock_conn = MagicMock()
         with pytest.raises(ValueError, match="Crawl failed"):
             await _ingest_crawl_result(
+                mock_conn,
                 failed,
                 url=failed.url,
                 org_id="org",
@@ -126,17 +130,16 @@ class TestRunCrawlJobAuthWall:
             success=True,
         )
 
-        pool = MagicMock()
-        pool.execute = AsyncMock(return_value=None)
+        mock_conn = MagicMock()
+        mock_conn.execute = AsyncMock(return_value=None)
+        mock_conn.fetch = AsyncMock(return_value=[])
+        mock_conn.fetchval = AsyncMock(return_value=None)
+        mock_conn.fetchrow = AsyncMock(return_value=None)
 
         with (
             patch(
                 "knowledge_ingest.adapters.crawler.crawl_site",
                 new=AsyncMock(return_value=[happy, walled, never_reached]),
-            ),
-            patch(
-                "knowledge_ingest.adapters.crawler.get_pool",
-                new=AsyncMock(return_value=pool),
             ),
             patch(
                 "knowledge_ingest.adapters.crawler.pg_store.get_crawled_page_hashes",
@@ -148,6 +151,7 @@ class TestRunCrawlJobAuthWall:
             ) as ingest_mock,
         ):
             await run_crawl_job(
+                mock_conn,
                 job_id="job-1",
                 org_id="org",
                 kb_slug="support",
@@ -157,19 +161,20 @@ class TestRunCrawlJobAuthWall:
 
         # The happy page must have been ingested exactly once.
         assert ingest_mock.call_count == 1
+        # SPEC-TI-003-FOLLOWUP-001: _ingest_crawl_result(conn, result, url, org, kb, ...)
         ingest_mock.assert_awaited_with(
+            mock_conn,
             happy,
             happy.url,
             "org",
             "support",
-            pool=pool,
             stored=None,
             login_indicator_selector="#login-form",
             connector_id=None,
         )
 
         # Verify at least one UPDATE marked the job as failed with auth_wall_detected.
-        update_calls = pool.execute.await_args_list
+        update_calls = mock_conn.execute.await_args_list
         failed_updates = [
             c
             for c in update_calls
@@ -183,6 +188,5 @@ class TestRunCrawlJobAuthWall:
             and "#login-form" in c.args[2]
         ]
         assert failed_updates, (
-            f"Expected a failed status update with auth_wall_detected, "
-            f"got {update_calls}"
+            f"Expected a failed status update with auth_wall_detected, got {update_calls}"
         )

--- a/klai-knowledge-ingest/tests/test_db_rls_wiring.py
+++ b/klai-knowledge-ingest/tests/test_db_rls_wiring.py
@@ -1,0 +1,194 @@
+"""SPEC-TI-003-FOLLOWUP-001 — RLS wiring regression tests.
+
+Two complementary tests cover the contract introduced by this SPEC:
+
+* **AC-5** (concurrent isolation): two ``tenant_scoped_connection`` blocks
+  for different orgs run on real Postgres at the same time. Each block
+  reads back ``app.current_org_id`` via ``SELECT current_setting(...)`` and
+  must see its own value -- proves that the GUC is connection-local and
+  that the helper does not bleed between concurrent acquirers.
+
+* **AC-6** (type-time + run-time guard): calling a refactored pg_store
+  function without the leading ``conn`` argument raises ``TypeError`` at
+  run-time. The accompanying ``# type: ignore`` comment is the only place
+  in the test file that suppresses pyright/mypy -- in production code the
+  same call will fail the type checker, which is the structural contract
+  AC-6 protects.
+
+The integration test is gated behind ``RUN_INTEGRATION=1`` so the default
+fast suite stays mock-only. CI can opt in by setting the env var and
+providing ``POSTGRES_DSN`` pointing at a database where post-deploy SQL
+has been applied (see
+``alembic/versions/post_deploy_dd1b439a57d0.sql``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+_REQUIRES_INTEGRATION = os.getenv("RUN_INTEGRATION") != "1"
+
+
+# ---------------------------------------------------------------------------
+# AC-5: concurrent tenant_scoped_connection blocks see their own GUC.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    _REQUIRES_INTEGRATION,
+    reason=(
+        "Integration test requires a real Postgres reachable via "
+        "POSTGRES_DSN. Run with RUN_INTEGRATION=1."
+    ),
+)
+@pytest.mark.asyncio
+async def test_concurrent_tenant_scoped_connections_no_guc_bleed() -> None:
+    """SPEC-TI-003-FOLLOWUP-001 AC-5.
+
+    Two parallel ``tenant_scoped_connection`` blocks for different orgs
+    must each read back THEIR OWN ``app.current_org_id`` -- proves that
+    the GUC is pinned per connection and survives concurrent acquirers
+    from the same pool.
+    """
+    from knowledge_ingest.db import close_pool, tenant_scoped_connection
+
+    org_a = "rls-test-org-a-2026-05-06"
+    org_b = "rls-test-org-b-2026-05-06"
+
+    a_observed: list[str] = []
+    b_observed: list[str] = []
+
+    async def _read_back(org_id: str, observed: list[str]) -> None:
+        async with tenant_scoped_connection(org_id) as conn:
+            # SELECT inside the block must see the GUC the helper set.
+            value = await conn.fetchval("SELECT current_setting('app.current_org_id', true)")
+            observed.append(value or "")
+            # Sleep briefly so both blocks overlap in time -- if they
+            # somehow shared a connection the second SET would clobber
+            # the first.
+            await asyncio.sleep(0.05)
+            value_after_sleep = await conn.fetchval(
+                "SELECT current_setting('app.current_org_id', true)"
+            )
+            observed.append(value_after_sleep or "")
+
+    try:
+        await asyncio.gather(
+            _read_back(org_a, a_observed),
+            _read_back(org_b, b_observed),
+        )
+    finally:
+        await close_pool()
+
+    assert a_observed == [org_a, org_a], (
+        f"Expected org A's block to see its own GUC twice; got {a_observed!r}. "
+        "Possible regression: tenant_scoped_connection no longer pins the GUC "
+        "per-connection, or the pool returned the same physical conn to both "
+        "blocks (which the asyncpg pool does not do, but worth diagnosing)."
+    )
+    assert b_observed == [org_b, org_b], (
+        f"Expected org B's block to see its own GUC twice; got {b_observed!r}."
+    )
+
+
+@pytest.mark.skipif(
+    _REQUIRES_INTEGRATION,
+    reason=(
+        "Integration test requires a real Postgres reachable via "
+        "POSTGRES_DSN. Run with RUN_INTEGRATION=1."
+    ),
+)
+@pytest.mark.asyncio
+async def test_tenant_scoped_connection_resets_guc_on_exit() -> None:
+    """SPEC-TI-003-FOLLOWUP-001 AC-5 follow-on.
+
+    After the ``async with tenant_scoped_connection`` block exits the
+    pinned conn is returned to the pool. The next acquire from that pool
+    must NOT see the previous tenant's GUC -- otherwise a follow-up
+    request reusing the same physical conn would silently inherit the
+    wrong tenant context.
+    """
+    from knowledge_ingest.db import close_pool, get_pool, tenant_scoped_connection
+
+    org_id = "rls-test-org-reset-2026-05-06"
+
+    try:
+        async with tenant_scoped_connection(org_id) as conn:
+            inside = await conn.fetchval("SELECT current_setting('app.current_org_id', true)")
+            assert inside == org_id
+
+        # Acquire raw pool conn and inspect the GUC: it should be empty
+        # because the helper reset it on exit.
+        pool = await get_pool()
+        async with pool.acquire() as raw_conn:
+            after = await raw_conn.fetchval("SELECT current_setting('app.current_org_id', true)")
+            assert after in (None, ""), (
+                f"GUC not reset on exit -- pool returned a conn carrying "
+                f"app.current_org_id={after!r} from a prior tenant. This is "
+                f"the pool-GUC pollution pitfall the helper guards against."
+            )
+    finally:
+        await close_pool()
+
+
+# ---------------------------------------------------------------------------
+# AC-6: pg_store functions require conn at call-time.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pg_store_function_without_conn_raises_typeerror() -> None:
+    """SPEC-TI-003-FOLLOWUP-001 AC-6.
+
+    Calling a refactored pg_store helper without the leading ``conn``
+    argument must raise ``TypeError`` at run-time. The matching
+    ``# type: ignore[call-arg]`` below is the only place we suppress the
+    type checker -- in production code the same shape fails pyright/mypy
+    BEFORE the code runs, which is the structural contract this AC
+    protects.
+    """
+    from knowledge_ingest import pg_store
+
+    # ``create_artifact`` is one of the 26 functions reshaped by AC-1.
+    # The current signature is:
+    #     async def create_artifact(conn, org_id, kb_slug, path, ...)
+    # Calling it with org_id as the first positional binds org_id to the
+    # ``conn`` parameter, leaving the actual ``org_id`` keyword unfilled.
+    # Both pyright and a runtime call see that as a missing-argument /
+    # type error.
+    with pytest.raises(TypeError):
+        await pg_store.create_artifact(  # type: ignore[call-arg]
+            org_id="dummy-org",
+            kb_slug="dummy-kb",
+            path="dummy/path.md",
+            provenance_type="observed",
+            assertion_mode="unknown",
+            synthesis_depth=0,
+            confidence=None,
+            belief_time_start=0,
+            belief_time_end=0,
+        )
+
+
+def test_pg_store_module_does_not_import_get_pool() -> None:
+    """SPEC-TI-003-FOLLOWUP-001 AC-2 follow-on.
+
+    A static guard against future regressions: pg_store must not import
+    ``get_pool`` (or call ``pool.acquire``) at all. The module only ever
+    runs SQL via the caller-supplied ``conn``. Re-introducing the pool
+    import in pg_store is the exact regression the SPEC closed.
+    """
+    from pathlib import Path
+
+    src = Path(__file__).parent.parent / "knowledge_ingest" / "pg_store.py"
+    text = src.read_text(encoding="utf-8")
+    assert "from knowledge_ingest.db import get_pool" not in text, (
+        "pg_store.py re-introduced get_pool. AC-2 forbids pool.acquire() inside "
+        "pg_store -- caller MUST hand down the GUC-pinned conn."
+    )
+    assert "get_pool()" not in text, (
+        "pg_store.py calls get_pool(). AC-2 forbids pool acquisition inside this module."
+    )

--- a/klai-knowledge-ingest/tests/test_db_rls_wiring.py
+++ b/klai-knowledge-ingest/tests/test_db_rls_wiring.py
@@ -37,6 +37,7 @@ _REQUIRES_INTEGRATION = os.getenv("RUN_INTEGRATION") != "1"
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.no_mock_db_helpers
 @pytest.mark.skipif(
     _REQUIRES_INTEGRATION,
     reason=(
@@ -94,6 +95,7 @@ async def test_concurrent_tenant_scoped_connections_no_guc_bleed() -> None:
     )
 
 
+@pytest.mark.no_mock_db_helpers
 @pytest.mark.skipif(
     _REQUIRES_INTEGRATION,
     reason=(

--- a/klai-knowledge-ingest/tests/test_enrichment_dedup.py
+++ b/klai-knowledge-ingest/tests/test_enrichment_dedup.py
@@ -38,16 +38,30 @@ def _make_mock_app(side_effect=None):
     return mock_app, task_fn, configured
 
 
+def _make_mock_conn() -> MagicMock:
+    conn = MagicMock()
+    conn.execute = AsyncMock(return_value=None)
+    conn.fetch = AsyncMock(return_value=[])
+    conn.fetchval = AsyncMock(return_value=None)
+    conn.fetchrow = AsyncMock(return_value=None)
+    return conn
+
+
 def _base_patches(mock_app):
-    """Return a context manager stack with all ingest_document dependencies mocked."""
+    """Return a context manager stack with all ingest_document dependencies mocked.
+
+    SPEC-TI-003-FOLLOWUP-001: ingest_document now takes conn explicitly,
+    so we no longer patch knowledge_ingest.routes.ingest.get_pool (it does
+    not exist after the refactor).
+    """
     import contextlib
 
     @contextlib.asynccontextmanager
     async def _stack():
         with (
             patch(
-                "knowledge_ingest.routes.ingest.chunker.chunk_markdown",
-                return_value=[MagicMock(text="chunk text")],
+                "knowledge_ingest.routes.ingest.chunker.chunk_markdown_with_parents",
+                return_value=([MagicMock(text="chunk text", parent_index=0)], []),
             ),
             patch(
                 "knowledge_ingest.routes.ingest.embedder.embed",
@@ -72,7 +86,6 @@ def _base_patches(mock_app):
                 "knowledge_ingest.routes.ingest.qdrant_store.upsert_chunks",
                 new_callable=AsyncMock,
             ),
-            patch("knowledge_ingest.routes.ingest.get_pool", new_callable=AsyncMock),
             patch(
                 "knowledge_ingest.routes.ingest.org_config.is_enrichment_enabled",
                 new_callable=AsyncMock,
@@ -83,11 +96,27 @@ def _base_patches(mock_app):
                 new_callable=AsyncMock,
                 return_value="internal",
             ),
-            patch.dict(
-                sys.modules,
-                {"knowledge_ingest.enrichment_tasks": types.SimpleNamespace(get_app=lambda: mock_app)},
+            patch(
+                "knowledge_ingest.portal_client.fetch_taxonomy_nodes",
+                new_callable=AsyncMock,
+                return_value=[],
             ),
+            patch(
+                "knowledge_ingest.content_labeler.generate_content_label",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch(
+                "knowledge_ingest.enrichment_tasks.get_app",
+                return_value=mock_app,
+            ),
+            patch("knowledge_ingest.routes.ingest.settings") as mock_settings,
         ):
+            mock_settings.graphiti_enabled = False
+            mock_settings.chunk_size = 1500
+            mock_settings.chunk_overlap = 200
+            mock_settings.enrichment_enabled = True
+            mock_settings.taxonomy_centroid_match_threshold = 0.85
             yield
 
     return _stack()
@@ -100,6 +129,7 @@ async def test_queueing_lock_uses_org_kb_path():
     from knowledge_ingest.routes.ingest import ingest_document
 
     mock_app, task_fn, _ = _make_mock_app()
+    conn = _make_mock_conn()
     req = IngestRequest(
         org_id="org-1",
         kb_slug="my-kb",
@@ -110,7 +140,7 @@ async def test_queueing_lock_uses_org_kb_path():
     )
 
     async with _base_patches(mock_app):
-        result = await ingest_document(req)
+        result = await ingest_document(conn, req)
 
     assert result["status"] == "ok"
     task_fn.configure.assert_called_once_with(queueing_lock="org-1:my-kb:docs/page.md")
@@ -123,6 +153,7 @@ async def test_already_enqueued_does_not_propagate():
     from knowledge_ingest.routes.ingest import ingest_document
 
     mock_app, task_fn, _ = _make_mock_app(side_effect=_AlreadyEnqueued())
+    conn = _make_mock_conn()
     req = IngestRequest(
         org_id="org-1",
         kb_slug="my-kb",
@@ -133,7 +164,7 @@ async def test_already_enqueued_does_not_propagate():
     )
 
     async with _base_patches(mock_app):
-        result = await ingest_document(req)
+        result = await ingest_document(conn, req)
 
     assert result["status"] == "ok"
     # configure was still called (lock was set)
@@ -154,6 +185,7 @@ async def test_two_ingests_same_path_only_one_enrichment():
     mock_app = MagicMock()
     mock_app.enrich_document_bulk = task_fn
 
+    conn = _make_mock_conn()
     req = IngestRequest(
         org_id="org-2",
         kb_slug="kb-slug",
@@ -164,8 +196,8 @@ async def test_two_ingests_same_path_only_one_enrichment():
     )
 
     async with _base_patches(mock_app):
-        result1 = await ingest_document(req)
-        result2 = await ingest_document(req)
+        result1 = await ingest_document(conn, req)
+        result2 = await ingest_document(conn, req)
 
     assert result1["status"] == "ok"
     assert result2["status"] == "ok"

--- a/klai-knowledge-ingest/tests/test_enrichment_loads_from_pg.py
+++ b/klai-knowledge-ingest/tests/test_enrichment_loads_from_pg.py
@@ -9,6 +9,10 @@ Pin the contract:
   ``extra.document_text``, not from any frozen task arg.
 - Procrastinate task variants accept only ``artifact_id``; all other
   fields flow through PG.
+
+SPEC-TI-003-FOLLOWUP-001: ``read_artifact_for_enrichment`` now takes
+``conn`` as its first argument; ``_load_and_enrich`` opens a
+``cross_org_admin_connection`` to look up the org_id from artifact_id.
 """
 
 from __future__ import annotations
@@ -42,6 +46,15 @@ def _install_procrastinate_stub() -> None:
 _install_procrastinate_stub()
 
 
+def _make_mock_conn() -> MagicMock:
+    conn = MagicMock()
+    conn.execute = AsyncMock(return_value=None)
+    conn.fetch = AsyncMock(return_value=[])
+    conn.fetchval = AsyncMock(return_value=None)
+    conn.fetchrow = AsyncMock(return_value=None)
+    return conn
+
+
 # ---------------------------------------------------------------------------
 # read_artifact_for_enrichment
 # ---------------------------------------------------------------------------
@@ -49,14 +62,12 @@ _install_procrastinate_stub()
 
 @pytest.mark.asyncio
 async def test_read_artifact_returns_none_for_missing():
-    mock_pool = MagicMock()
-    mock_pool.fetchrow = AsyncMock(return_value=None)
-    with patch(
-        "knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock, return_value=mock_pool
-    ):
-        from knowledge_ingest.pg_store import read_artifact_for_enrichment
+    conn = _make_mock_conn()
+    conn.fetchrow = AsyncMock(return_value=None)
 
-        result = await read_artifact_for_enrichment("00000000-0000-0000-0000-000000000000")
+    from knowledge_ingest.pg_store import read_artifact_for_enrichment
+
+    result = await read_artifact_for_enrichment(conn, "00000000-0000-0000-0000-000000000000")
 
     assert result is None
 
@@ -64,11 +75,12 @@ async def test_read_artifact_returns_none_for_missing():
 @pytest.mark.asyncio
 async def test_read_artifact_returns_none_for_empty_id():
     """Defensive: empty/None id short-circuits without a DB hit."""
-    with patch("knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock) as get_pool:
-        from knowledge_ingest.pg_store import read_artifact_for_enrichment
+    conn = _make_mock_conn()
 
-        assert await read_artifact_for_enrichment("") is None
-        get_pool.assert_not_called()
+    from knowledge_ingest.pg_store import read_artifact_for_enrichment
+
+    assert await read_artifact_for_enrichment(conn, "") is None
+    conn.fetchrow.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -89,15 +101,12 @@ async def test_read_artifact_returns_dict_with_parsed_extra():
         "belief_time_end": 253402300800,
         "extra": '{"document_text": "# Hi", "title": "Hi", "tags": ["onboarding"]}',
     }
-    mock_pool = MagicMock()
-    mock_pool.fetchrow = AsyncMock(return_value=fake_row)
+    conn = _make_mock_conn()
+    conn.fetchrow = AsyncMock(return_value=fake_row)
 
-    with patch(
-        "knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock, return_value=mock_pool
-    ):
-        from knowledge_ingest.pg_store import read_artifact_for_enrichment
+    from knowledge_ingest.pg_store import read_artifact_for_enrichment
 
-        result = await read_artifact_for_enrichment("11111111-2222-3333-4444-555555555555")
+    result = await read_artifact_for_enrichment(conn, "11111111-2222-3333-4444-555555555555")
 
     assert result is not None
     assert result["org_id"] == "org1"
@@ -130,15 +139,12 @@ async def test_read_artifact_handles_dict_extra():
         "belief_time_end": 253402300800,
         "extra": {"document_text": "body", "title": "T"},
     }
-    mock_pool = MagicMock()
-    mock_pool.fetchrow = AsyncMock(return_value=fake_row)
+    conn = _make_mock_conn()
+    conn.fetchrow = AsyncMock(return_value=fake_row)
 
-    with patch(
-        "knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock, return_value=mock_pool
-    ):
-        from knowledge_ingest.pg_store import read_artifact_for_enrichment
+    from knowledge_ingest.pg_store import read_artifact_for_enrichment
 
-        result = await read_artifact_for_enrichment("11111111-2222-3333-4444-555555555555")
+    result = await read_artifact_for_enrichment(conn, "11111111-2222-3333-4444-555555555555")
 
     assert isinstance(result["extra"], dict)
     assert result["extra"]["document_text"] == "body"
@@ -292,10 +298,6 @@ def test_task_variants_have_single_arg_signature():
 
     from knowledge_ingest import enrichment_tasks
 
-    # We can introspect the underlying functions via _register_tasks's
-    # inner closures. The simplest contract: the enrich variants are
-    # exposed on the procrastinate app object after init. Here we only
-    # verify the inner shim signature, which the task wrappers call.
     sig = inspect.signature(enrichment_tasks._load_and_enrich)
     params = list(sig.parameters.values())
     assert len(params) == 1, f"_load_and_enrich must take 1 param, got {params}"

--- a/klai-knowledge-ingest/tests/test_extra_payload_contract.py
+++ b/klai-knowledge-ingest/tests/test_extra_payload_contract.py
@@ -178,11 +178,14 @@ def _build_request(
 async def _run_with_mocks(req: IngestRequest, mock_proc_app: _MockProcApp) -> dict:
     """Run ``ingest_document`` with all I/O mocked so the test only
     exercises the Phase-1 extra_payload assembly + defer_async wiring.
+
+    SPEC-TI-003-FOLLOWUP-001: ingest_document takes conn as first arg.
     """
-    mock_pool = MagicMock()
-    mock_pool.execute = AsyncMock(return_value=None)
-    mock_pool.fetchval = AsyncMock(return_value=None)
-    mock_pool.fetchrow = AsyncMock(return_value=None)
+    conn = MagicMock()
+    conn.execute = AsyncMock(return_value=None)
+    conn.fetch = AsyncMock(return_value=[])
+    conn.fetchval = AsyncMock(return_value=None)
+    conn.fetchrow = AsyncMock(return_value=None)
 
     with (
         patch(
@@ -198,6 +201,10 @@ async def _run_with_mocks(req: IngestRequest, mock_proc_app: _MockProcApp) -> di
             "knowledge_ingest.pg_store.create_artifact",
             new_callable=AsyncMock,
             return_value="artifact-uuid-contract",
+        ),
+        patch(
+            "knowledge_ingest.pg_store.update_artifact_extra",
+            new_callable=AsyncMock,
         ),
         patch(
             "knowledge_ingest.embedder.embed",
@@ -217,11 +224,6 @@ async def _run_with_mocks(req: IngestRequest, mock_proc_app: _MockProcApp) -> di
             "knowledge_ingest.routes.ingest.kb_config.get_kb_visibility",
             new_callable=AsyncMock,
             return_value="internal",
-        ),
-        patch(
-            "knowledge_ingest.routes.ingest.get_pool",
-            new_callable=AsyncMock,
-            return_value=mock_pool,
         ),
         patch(
             "knowledge_ingest.routes.ingest.fetch_taxonomy_nodes",
@@ -254,7 +256,7 @@ async def _run_with_mocks(req: IngestRequest, mock_proc_app: _MockProcApp) -> di
 
         from knowledge_ingest.routes.ingest import ingest_document
 
-        return await ingest_document(req)
+        return await ingest_document(conn, req)
 
 
 # ---------------------------------------------------------------------------

--- a/klai-knowledge-ingest/tests/test_ingest_content_hash_dedup.py
+++ b/klai-knowledge-ingest/tests/test_ingest_content_hash_dedup.py
@@ -5,7 +5,12 @@ When the SHA-256 of req.content matches the stored content_hash of the
 current active artifact, ingest_document() must return early with
 {"status": "skipped", "reason": "content unchanged"} without performing
 any chunking, embedding, or Qdrant upserts.
+
+SPEC-TI-003-FOLLOWUP-001: ingest_document now takes asyncpg.Connection
+as its first argument. The patches below address the helpers it calls
+on that conn -- conn itself is a mock instance.
 """
+
 from __future__ import annotations
 
 import hashlib
@@ -15,10 +20,6 @@ import pytest
 
 from knowledge_ingest.models import IngestRequest
 
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
 
 def _make_request(content: str = "# Hello\nWorld") -> IngestRequest:
     return IngestRequest(
@@ -31,30 +32,37 @@ def _make_request(content: str = "# Hello\nWorld") -> IngestRequest:
     )
 
 
+def _make_mock_conn() -> MagicMock:
+    conn = MagicMock()
+    conn.execute = AsyncMock(return_value=None)
+    conn.fetch = AsyncMock(return_value=[])
+    conn.fetchval = AsyncMock(return_value=None)
+    conn.fetchrow = AsyncMock(return_value=None)
+    return conn
+
+
 def _sha256(text: str) -> str:
     return hashlib.sha256(text.encode()).hexdigest()
 
-
-# ---------------------------------------------------------------------------
-# Tests
-# ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
 async def test_skips_when_content_unchanged():
     """ingest_document returns 'skipped' without calling embed when hash matches."""
     req = _make_request()
     stored_hash = _sha256(req.content)
+    conn = _make_mock_conn()
 
-    with patch(
-        "knowledge_ingest.pg_store.get_active_content_hash",
-        new_callable=AsyncMock,
-        return_value=stored_hash,
-    ), patch(
-        "knowledge_ingest.embedder.embed",
-        new_callable=AsyncMock,
-    ) as mock_embed:
+    with (
+        patch(
+            "knowledge_ingest.pg_store.get_active_content_hash",
+            new_callable=AsyncMock,
+            return_value=stored_hash,
+        ),
+        patch("knowledge_ingest.embedder.embed", new_callable=AsyncMock) as mock_embed,
+    ):
         from knowledge_ingest.routes.ingest import ingest_document
-        result = await ingest_document(req)
+
+        result = await ingest_document(conn, req)
 
     assert result["status"] == "skipped"
     assert result["reason"] == "content unchanged"
@@ -66,52 +74,56 @@ async def test_proceeds_when_content_changed():
     """ingest_document runs the full pipeline when content hash differs."""
     req = _make_request("# New content\nDifferent text")
     old_hash = _sha256("# Old content\nOriginal text")
+    conn = _make_mock_conn()
 
-    mock_pool = MagicMock()
-    mock_pool.execute = AsyncMock(return_value=None)
-    mock_pool.fetchval = AsyncMock(return_value=None)
-    mock_pool.fetchrow = AsyncMock(return_value=None)
-
-    with patch(
-        "knowledge_ingest.pg_store.get_active_content_hash",
-        new_callable=AsyncMock,
-        return_value=old_hash,  # different from current content
-    ), patch(
-        "knowledge_ingest.pg_store.soft_delete_artifact",
-        new_callable=AsyncMock,
-    ), patch(
-        "knowledge_ingest.pg_store.create_artifact",
-        new_callable=AsyncMock,
-        return_value="artifact-uuid-1",
-    ), patch(
-        "knowledge_ingest.embedder.embed",
-        new_callable=AsyncMock,
-        return_value=[[0.1] * 10],
-    ), patch(
-        "knowledge_ingest.qdrant_store.upsert_chunks",
-        new_callable=AsyncMock,
-    ), patch(
-        "knowledge_ingest.org_config.is_enrichment_enabled",
-        new_callable=AsyncMock,
-        return_value=False,
-    ), patch(
-        "knowledge_ingest.routes.ingest.kb_config.get_kb_visibility",
-        new_callable=AsyncMock,
-        return_value="internal",
-    ), patch(
-        "knowledge_ingest.routes.ingest.get_pool",
-        new_callable=AsyncMock,
-        return_value=mock_pool,
-    ), patch(
-        "knowledge_ingest.routes.ingest.settings"
-    ) as mock_settings:
+    with (
+        patch(
+            "knowledge_ingest.pg_store.get_active_content_hash",
+            new_callable=AsyncMock,
+            return_value=old_hash,  # different from current content
+        ),
+        patch("knowledge_ingest.pg_store.soft_delete_artifact", new_callable=AsyncMock),
+        patch(
+            "knowledge_ingest.pg_store.create_artifact",
+            new_callable=AsyncMock,
+            return_value="artifact-uuid-1",
+        ),
+        patch(
+            "knowledge_ingest.embedder.embed",
+            new_callable=AsyncMock,
+            return_value=[[0.1] * 10],
+        ),
+        patch("knowledge_ingest.qdrant_store.upsert_chunks", new_callable=AsyncMock),
+        patch(
+            "knowledge_ingest.org_config.is_enrichment_enabled",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "knowledge_ingest.routes.ingest.kb_config.get_kb_visibility",
+            new_callable=AsyncMock,
+            return_value="internal",
+        ),
+        patch(
+            "knowledge_ingest.portal_client.fetch_taxonomy_nodes",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "knowledge_ingest.content_labeler.generate_content_label",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch("knowledge_ingest.routes.ingest.settings") as mock_settings,
+    ):
         mock_settings.graphiti_enabled = False
         mock_settings.chunk_size = 1500
         mock_settings.chunk_overlap = 200
         mock_settings.enrichment_enabled = False
 
         from knowledge_ingest.routes.ingest import ingest_document
-        result = await ingest_document(req)
+
+        result = await ingest_document(conn, req)
 
     assert result["status"] == "ok"
 
@@ -120,52 +132,56 @@ async def test_proceeds_when_content_changed():
 async def test_proceeds_when_no_previous_artifact():
     """ingest_document runs the full pipeline when there is no stored hash (first ingest)."""
     req = _make_request()
+    conn = _make_mock_conn()
 
-    mock_pool = MagicMock()
-    mock_pool.execute = AsyncMock(return_value=None)
-    mock_pool.fetchval = AsyncMock(return_value=None)
-    mock_pool.fetchrow = AsyncMock(return_value=None)
-
-    with patch(
-        "knowledge_ingest.pg_store.get_active_content_hash",
-        new_callable=AsyncMock,
-        return_value=None,  # no previous artifact
-    ), patch(
-        "knowledge_ingest.pg_store.soft_delete_artifact",
-        new_callable=AsyncMock,
-    ), patch(
-        "knowledge_ingest.pg_store.create_artifact",
-        new_callable=AsyncMock,
-        return_value="artifact-uuid-2",
-    ), patch(
-        "knowledge_ingest.embedder.embed",
-        new_callable=AsyncMock,
-        return_value=[[0.1] * 10],
-    ), patch(
-        "knowledge_ingest.qdrant_store.upsert_chunks",
-        new_callable=AsyncMock,
-    ), patch(
-        "knowledge_ingest.org_config.is_enrichment_enabled",
-        new_callable=AsyncMock,
-        return_value=False,
-    ), patch(
-        "knowledge_ingest.routes.ingest.kb_config.get_kb_visibility",
-        new_callable=AsyncMock,
-        return_value="internal",
-    ), patch(
-        "knowledge_ingest.routes.ingest.get_pool",
-        new_callable=AsyncMock,
-        return_value=mock_pool,
-    ), patch(
-        "knowledge_ingest.routes.ingest.settings"
-    ) as mock_settings:
+    with (
+        patch(
+            "knowledge_ingest.pg_store.get_active_content_hash",
+            new_callable=AsyncMock,
+            return_value=None,  # no previous artifact
+        ),
+        patch("knowledge_ingest.pg_store.soft_delete_artifact", new_callable=AsyncMock),
+        patch(
+            "knowledge_ingest.pg_store.create_artifact",
+            new_callable=AsyncMock,
+            return_value="artifact-uuid-2",
+        ),
+        patch(
+            "knowledge_ingest.embedder.embed",
+            new_callable=AsyncMock,
+            return_value=[[0.1] * 10],
+        ),
+        patch("knowledge_ingest.qdrant_store.upsert_chunks", new_callable=AsyncMock),
+        patch(
+            "knowledge_ingest.org_config.is_enrichment_enabled",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "knowledge_ingest.routes.ingest.kb_config.get_kb_visibility",
+            new_callable=AsyncMock,
+            return_value="internal",
+        ),
+        patch(
+            "knowledge_ingest.portal_client.fetch_taxonomy_nodes",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "knowledge_ingest.content_labeler.generate_content_label",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch("knowledge_ingest.routes.ingest.settings") as mock_settings,
+    ):
         mock_settings.graphiti_enabled = False
         mock_settings.chunk_size = 1500
         mock_settings.chunk_overlap = 200
         mock_settings.enrichment_enabled = False
 
         from knowledge_ingest.routes.ingest import ingest_document
-        result = await ingest_document(req)
+
+        result = await ingest_document(conn, req)
 
     assert result["status"] == "ok"
 
@@ -175,53 +191,54 @@ async def test_content_hash_stored_on_create():
     """create_artifact is called with the correct content_hash on new ingest."""
     req = _make_request("# Fresh content")
     expected_hash = _sha256(req.content)
-
-    mock_pool = MagicMock()
-    mock_pool.execute = AsyncMock(return_value=None)
-    mock_pool.fetchval = AsyncMock(return_value=None)
-    mock_pool.fetchrow = AsyncMock(return_value=None)
+    conn = _make_mock_conn()
 
     mock_create = AsyncMock(return_value="artifact-uuid-3")
 
-    with patch(
-        "knowledge_ingest.pg_store.get_active_content_hash",
-        new_callable=AsyncMock,
-        return_value=None,
-    ), patch(
-        "knowledge_ingest.pg_store.soft_delete_artifact",
-        new_callable=AsyncMock,
-    ), patch(
-        "knowledge_ingest.pg_store.create_artifact",
-        mock_create,
-    ), patch(
-        "knowledge_ingest.embedder.embed",
-        new_callable=AsyncMock,
-        return_value=[[0.1] * 10],
-    ), patch(
-        "knowledge_ingest.qdrant_store.upsert_chunks",
-        new_callable=AsyncMock,
-    ), patch(
-        "knowledge_ingest.org_config.is_enrichment_enabled",
-        new_callable=AsyncMock,
-        return_value=False,
-    ), patch(
-        "knowledge_ingest.routes.ingest.kb_config.get_kb_visibility",
-        new_callable=AsyncMock,
-        return_value="internal",
-    ), patch(
-        "knowledge_ingest.routes.ingest.get_pool",
-        new_callable=AsyncMock,
-        return_value=mock_pool,
-    ), patch(
-        "knowledge_ingest.routes.ingest.settings"
-    ) as mock_settings:
+    with (
+        patch(
+            "knowledge_ingest.pg_store.get_active_content_hash",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch("knowledge_ingest.pg_store.soft_delete_artifact", new_callable=AsyncMock),
+        patch("knowledge_ingest.pg_store.create_artifact", mock_create),
+        patch(
+            "knowledge_ingest.embedder.embed",
+            new_callable=AsyncMock,
+            return_value=[[0.1] * 10],
+        ),
+        patch("knowledge_ingest.qdrant_store.upsert_chunks", new_callable=AsyncMock),
+        patch(
+            "knowledge_ingest.org_config.is_enrichment_enabled",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "knowledge_ingest.routes.ingest.kb_config.get_kb_visibility",
+            new_callable=AsyncMock,
+            return_value="internal",
+        ),
+        patch(
+            "knowledge_ingest.portal_client.fetch_taxonomy_nodes",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "knowledge_ingest.content_labeler.generate_content_label",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch("knowledge_ingest.routes.ingest.settings") as mock_settings,
+    ):
         mock_settings.graphiti_enabled = False
         mock_settings.chunk_size = 1500
         mock_settings.chunk_overlap = 200
         mock_settings.enrichment_enabled = False
 
         from knowledge_ingest.routes.ingest import ingest_document
-        await ingest_document(req)
+
+        await ingest_document(conn, req)
 
     call_kwargs = mock_create.call_args.kwargs
     assert call_kwargs["content_hash"] == expected_hash

--- a/klai-knowledge-ingest/tests/test_knowledge_rls.py
+++ b/klai-knowledge-ingest/tests/test_knowledge_rls.py
@@ -11,6 +11,10 @@ These tests verify:
 All tests use asyncpg mocks — no live DB required. The mock captures
 the sequence of SET CONFIG calls to verify the tenant-pinning contract.
 
+SPEC-TI-003-FOLLOWUP-001: this file exercises ``tenant_scoped_connection``
+itself, so it opts out of the autouse ``_mock_db_helpers`` fixture (which
+patches the helper to a no-op for every other test).
+
 For live-DB integration tests, see tests/integration/ (not committed here).
 """
 
@@ -18,6 +22,10 @@ from __future__ import annotations
 
 from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.no_mock_db_helpers
 
 import pytest
 

--- a/klai-knowledge-ingest/tests/test_link_graph.py
+++ b/klai-knowledge-ingest/tests/test_link_graph.py
@@ -1,18 +1,22 @@
 """
 Tests for link_graph async query helpers (SPEC-CRAWLER-003, TASK-002).
+
+SPEC-TI-003-FOLLOWUP-001: helpers now take asyncpg.Connection (not Pool).
 """
-import pytest
+
 from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from knowledge_ingest import link_graph
 
 
-def _make_pool():
-    pool = MagicMock()
-    pool.execute = AsyncMock(return_value=None)
-    pool.fetch = AsyncMock(return_value=[])
-    pool.fetchval = AsyncMock(return_value=0)
-    return pool
+def _make_conn() -> MagicMock:
+    conn = MagicMock()
+    conn.execute = AsyncMock(return_value=None)
+    conn.fetch = AsyncMock(return_value=[])
+    conn.fetchval = AsyncMock(return_value=0)
+    return conn
 
 
 # -- Scenario 1.1: get_outbound_urls returns correct URLs --
@@ -20,17 +24,16 @@ def _make_pool():
 
 @pytest.mark.asyncio
 async def test_get_outbound_urls_returns_to_urls():
-    pool = _make_pool()
-    pool.fetch = AsyncMock(return_value=[
-        {"to_url": "https://docs.example.com/b"},
-        {"to_url": "https://docs.example.com/c"},
-    ])
+    conn = _make_conn()
+    conn.fetch = AsyncMock(
+        return_value=[
+            {"to_url": "https://docs.example.com/b"},
+            {"to_url": "https://docs.example.com/c"},
+        ]
+    )
 
     result = await link_graph.get_outbound_urls(
-        url="https://docs.example.com/a",
-        org_id="org-1",
-        kb_slug="docs",
-        pool=pool,
+        conn, url="https://docs.example.com/a", org_id="org-1", kb_slug="docs"
     )
 
     assert result == [
@@ -41,14 +44,11 @@ async def test_get_outbound_urls_returns_to_urls():
 
 @pytest.mark.asyncio
 async def test_get_outbound_urls_empty_when_no_links():
-    pool = _make_pool()
-    pool.fetch = AsyncMock(return_value=[])
+    conn = _make_conn()
+    conn.fetch = AsyncMock(return_value=[])
 
     result = await link_graph.get_outbound_urls(
-        url="https://docs.example.com/orphan",
-        org_id="org-1",
-        kb_slug="docs",
-        pool=pool,
+        conn, url="https://docs.example.com/orphan", org_id="org-1", kb_slug="docs"
     )
 
     assert result == []
@@ -59,20 +59,19 @@ async def test_get_outbound_urls_empty_when_no_links():
 
 @pytest.mark.asyncio
 async def test_get_anchor_texts_returns_non_empty_texts():
-    pool = _make_pool()
-    pool.fetch = AsyncMock(return_value=[
-        {"link_text": "Pagina B"},
-        {"link_text": ""},
-        {"link_text": "   "},
-        {"link_text": "Pagina C"},
-        {"link_text": None},
-    ])
+    conn = _make_conn()
+    conn.fetch = AsyncMock(
+        return_value=[
+            {"link_text": "Pagina B"},
+            {"link_text": ""},
+            {"link_text": "   "},
+            {"link_text": "Pagina C"},
+            {"link_text": None},
+        ]
+    )
 
     result = await link_graph.get_anchor_texts(
-        url="https://docs.example.com/target",
-        org_id="org-1",
-        kb_slug="docs",
-        pool=pool,
+        conn, url="https://docs.example.com/target", org_id="org-1", kb_slug="docs"
     )
 
     assert result == ["Pagina B", "Pagina C"]
@@ -80,18 +79,17 @@ async def test_get_anchor_texts_returns_non_empty_texts():
 
 @pytest.mark.asyncio
 async def test_get_anchor_texts_empty_when_all_blank():
-    pool = _make_pool()
-    pool.fetch = AsyncMock(return_value=[
-        {"link_text": ""},
-        {"link_text": "   "},
-        {"link_text": None},
-    ])
+    conn = _make_conn()
+    conn.fetch = AsyncMock(
+        return_value=[
+            {"link_text": ""},
+            {"link_text": "   "},
+            {"link_text": None},
+        ]
+    )
 
     result = await link_graph.get_anchor_texts(
-        url="https://docs.example.com/target",
-        org_id="org-1",
-        kb_slug="docs",
-        pool=pool,
+        conn, url="https://docs.example.com/target", org_id="org-1", kb_slug="docs"
     )
 
     assert result == []
@@ -102,14 +100,11 @@ async def test_get_anchor_texts_empty_when_all_blank():
 
 @pytest.mark.asyncio
 async def test_get_incoming_count_returns_integer():
-    pool = _make_pool()
-    pool.fetchval = AsyncMock(return_value=7)
+    conn = _make_conn()
+    conn.fetchval = AsyncMock(return_value=7)
 
     result = await link_graph.get_incoming_count(
-        url="https://docs.example.com/popular",
-        org_id="org-1",
-        kb_slug="docs",
-        pool=pool,
+        conn, url="https://docs.example.com/popular", org_id="org-1", kb_slug="docs"
     )
 
     assert result == 7
@@ -118,14 +113,11 @@ async def test_get_incoming_count_returns_integer():
 
 @pytest.mark.asyncio
 async def test_get_incoming_count_returns_zero_when_none():
-    pool = _make_pool()
-    pool.fetchval = AsyncMock(return_value=None)
+    conn = _make_conn()
+    conn.fetchval = AsyncMock(return_value=None)
 
     result = await link_graph.get_incoming_count(
-        url="https://docs.example.com/orphan",
-        org_id="org-1",
-        kb_slug="docs",
-        pool=pool,
+        conn, url="https://docs.example.com/orphan", org_id="org-1", kb_slug="docs"
     )
 
     assert result == 0
@@ -136,67 +128,54 @@ async def test_get_incoming_count_returns_zero_when_none():
 
 @pytest.mark.asyncio
 async def test_get_outbound_urls_passes_org_and_kb_to_query():
-    pool = _make_pool()
+    conn = _make_conn()
 
     await link_graph.get_outbound_urls(
-        url="https://example.com/page",
-        org_id="org-42",
-        kb_slug="help-center",
-        pool=pool,
+        conn, url="https://example.com/page", org_id="org-42", kb_slug="help-center"
     )
 
-    pool.fetch.assert_called_once()
-    call_args = pool.fetch.call_args[0]
+    conn.fetch.assert_called_once()
+    call_args = conn.fetch.call_args[0]
     assert "org-42" in call_args
     assert "help-center" in call_args
 
 
 @pytest.mark.asyncio
 async def test_get_anchor_texts_passes_org_and_kb_to_query():
-    pool = _make_pool()
+    conn = _make_conn()
 
     await link_graph.get_anchor_texts(
-        url="https://example.com/page",
-        org_id="org-42",
-        kb_slug="help-center",
-        pool=pool,
+        conn, url="https://example.com/page", org_id="org-42", kb_slug="help-center"
     )
 
-    pool.fetch.assert_called_once()
-    call_args = pool.fetch.call_args[0]
+    conn.fetch.assert_called_once()
+    call_args = conn.fetch.call_args[0]
     assert "org-42" in call_args
     assert "help-center" in call_args
 
 
 @pytest.mark.asyncio
 async def test_get_incoming_count_passes_org_and_kb_to_query():
-    pool = _make_pool()
+    conn = _make_conn()
 
     await link_graph.get_incoming_count(
-        url="https://example.com/page",
-        org_id="org-42",
-        kb_slug="help-center",
-        pool=pool,
+        conn, url="https://example.com/page", org_id="org-42", kb_slug="help-center"
     )
 
-    pool.fetchval.assert_called_once()
-    call_args = pool.fetchval.call_args[0]
+    conn.fetchval.assert_called_once()
+    call_args = conn.fetchval.call_args[0]
     assert "org-42" in call_args
     assert "help-center" in call_args
 
 
 @pytest.mark.asyncio
 async def test_compute_incoming_counts_passes_org_and_kb_to_query():
-    pool = _make_pool()
+    conn = _make_conn()
 
-    await link_graph.compute_incoming_counts(
-        org_id="org-42",
-        kb_slug="help-center",
-        pool=pool,
-    )
+    await link_graph.compute_incoming_counts(conn, org_id="org-42", kb_slug="help-center")
 
-    pool.fetch.assert_called_once()
-    call_args = pool.fetch.call_args[0]
+    conn.fetch.assert_called_once()
+    call_args = conn.fetch.call_args[0]
     assert "org-42" in call_args
     assert "help-center" in call_args
 
@@ -206,18 +185,16 @@ async def test_compute_incoming_counts_passes_org_and_kb_to_query():
 
 @pytest.mark.asyncio
 async def test_compute_incoming_counts_returns_url_count_dict():
-    pool = _make_pool()
-    pool.fetch = AsyncMock(return_value=[
-        {"to_url": "https://docs.example.com/a", "cnt": 5},
-        {"to_url": "https://docs.example.com/b", "cnt": 1},
-        {"to_url": "https://docs.example.com/c", "cnt": 12},
-    ])
-
-    result = await link_graph.compute_incoming_counts(
-        org_id="org-1",
-        kb_slug="docs",
-        pool=pool,
+    conn = _make_conn()
+    conn.fetch = AsyncMock(
+        return_value=[
+            {"to_url": "https://docs.example.com/a", "cnt": 5},
+            {"to_url": "https://docs.example.com/b", "cnt": 1},
+            {"to_url": "https://docs.example.com/c", "cnt": 12},
+        ]
     )
+
+    result = await link_graph.compute_incoming_counts(conn, org_id="org-1", kb_slug="docs")
 
     assert result == {
         "https://docs.example.com/a": 5,
@@ -228,13 +205,9 @@ async def test_compute_incoming_counts_returns_url_count_dict():
 
 @pytest.mark.asyncio
 async def test_compute_incoming_counts_empty_when_no_links():
-    pool = _make_pool()
-    pool.fetch = AsyncMock(return_value=[])
+    conn = _make_conn()
+    conn.fetch = AsyncMock(return_value=[])
 
-    result = await link_graph.compute_incoming_counts(
-        org_id="org-1",
-        kb_slug="docs",
-        pool=pool,
-    )
+    result = await link_graph.compute_incoming_counts(conn, org_id="org-1", kb_slug="docs")
 
     assert result == {}

--- a/klai-knowledge-ingest/tests/test_org_config.py
+++ b/klai-knowledge-ingest/tests/test_org_config.py
@@ -1,4 +1,9 @@
-"""Tests for knowledge_ingest/org_config.py"""
+"""Tests for knowledge_ingest/org_config.py.
+
+SPEC-TI-003-FOLLOWUP-001: ``is_enrichment_enabled`` now takes
+asyncpg.Connection (not Pool).
+"""
+
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -6,10 +11,10 @@ import pytest
 import knowledge_ingest.org_config as oc
 
 
-def _make_pool(row=None):
-    pool = MagicMock()
-    pool.fetchrow = AsyncMock(return_value=row)
-    return pool
+def _make_conn(row=None):
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=row)
+    return conn
 
 
 @pytest.fixture(autouse=True)
@@ -22,49 +27,49 @@ def clear_cache():
 
 @pytest.mark.asyncio
 async def test_global_kill_switch_overrides_db():
-    pool = _make_pool()
+    conn = _make_conn()
     with patch.object(oc.settings, "enrichment_enabled", False):
-        result = await oc.is_enrichment_enabled("org-123", pool)
+        result = await oc.is_enrichment_enabled(conn, "org-123")
     assert result is False
-    pool.fetchrow.assert_not_called()
+    conn.fetchrow.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_default_enabled_when_no_db_row():
-    pool = _make_pool(row=None)
+    conn = _make_conn(row=None)
     with patch.object(oc.settings, "enrichment_enabled", True):
-        result = await oc.is_enrichment_enabled("org-new", pool)
+        result = await oc.is_enrichment_enabled(conn, "org-new")
     assert result is True
 
 
 @pytest.mark.asyncio
 async def test_db_row_false_disables_org():
     row = {"enrichment_enabled": False}
-    pool = _make_pool(row=row)
+    conn = _make_conn(row=row)
     with patch.object(oc.settings, "enrichment_enabled", True):
-        result = await oc.is_enrichment_enabled("org-disabled", pool)
+        result = await oc.is_enrichment_enabled(conn, "org-disabled")
     assert result is False
 
 
 @pytest.mark.asyncio
 async def test_db_row_null_defaults_to_enabled():
     row = {"enrichment_enabled": None}
-    pool = _make_pool(row=row)
+    conn = _make_conn(row=row)
     with patch.object(oc.settings, "enrichment_enabled", True):
-        result = await oc.is_enrichment_enabled("org-null", pool)
+        result = await oc.is_enrichment_enabled(conn, "org-null")
     assert result is True
 
 
 @pytest.mark.asyncio
 async def test_cache_hit_skips_db():
-    pool = _make_pool()
+    conn = _make_conn()
     oc._cache["org-cached"] = True
 
     with patch.object(oc.settings, "enrichment_enabled", True):
-        result = await oc.is_enrichment_enabled("org-cached", pool)
+        result = await oc.is_enrichment_enabled(conn, "org-cached")
 
     assert result is True
-    pool.fetchrow.assert_not_called()
+    conn.fetchrow.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -83,11 +88,11 @@ async def test_cache_eviction_unknown_org_is_noop():
 @pytest.mark.asyncio
 async def test_result_cached_after_db_query():
     row = {"enrichment_enabled": True}
-    pool = _make_pool(row=row)
+    conn = _make_conn(row=row)
 
     with patch.object(oc.settings, "enrichment_enabled", True):
-        await oc.is_enrichment_enabled("org-store", pool)
+        await oc.is_enrichment_enabled(conn, "org-store")
         # Second call should use cache
-        await oc.is_enrichment_enabled("org-store", pool)
+        await oc.is_enrichment_enabled(conn, "org-store")
 
-    assert pool.fetchrow.call_count == 1
+    assert conn.fetchrow.call_count == 1

--- a/klai-knowledge-ingest/tests/test_page_links.py
+++ b/klai-knowledge-ingest/tests/test_page_links.py
@@ -6,45 +6,51 @@ Covers:
 - link_text truncated at 500 characters
 - Empty href entries are skipped
 - Absolute URLs stored as-is
+
+SPEC-TI-003-FOLLOWUP-001: pg_store helpers take asyncpg.Connection.
 """
+
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 
-def _make_mock_pool() -> MagicMock:
-    pool = MagicMock()
-    pool.executemany = AsyncMock(return_value=None)
-    return pool
+def _make_mock_conn() -> MagicMock:
+    conn = MagicMock()
+    conn.execute = AsyncMock(return_value=None)
+    conn.executemany = AsyncMock(return_value=None)
+    conn.fetch = AsyncMock(return_value=[])
+    conn.fetchval = AsyncMock(return_value=0)
+    conn.fetchrow = AsyncMock(return_value=None)
+    return conn
 
 
-def _first_row(mock_pool: MagicMock) -> tuple:
+def _first_row(mock_conn: MagicMock) -> tuple:
     """Return the first row tuple from the executemany call."""
-    rows = mock_pool.executemany.call_args.args[1]
+    rows = mock_conn.executemany.call_args.args[1]
     return rows[0]
 
 
 @pytest.mark.asyncio
 async def test_page_links_relative_url_resolution() -> None:
     """Relative hrefs are resolved against from_url before storing."""
-    mock_pool = _make_mock_pool()
+    mock_conn = _make_mock_conn()
 
-    get_pool_patch = patch(
-        "knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock, return_value=mock_pool
+    from knowledge_ingest.pg_store import upsert_page_links
+
+    await upsert_page_links(
+        mock_conn,
+        org_id="org1",
+        kb_slug="kb1",
+        from_url="https://help.example.com/docs/guide",
+        links=[{"href": "../api/overview", "text": "API Overview"}],
     )
-    with get_pool_patch:
-        from knowledge_ingest.pg_store import upsert_page_links
-        await upsert_page_links(
-            org_id="org1",
-            kb_slug="kb1",
-            from_url="https://help.example.com/docs/guide",
-            links=[{"href": "../api/overview", "text": "API Overview"}],
-        )
 
-    mock_pool.executemany.assert_called_once()
-    to_url = _first_row(mock_pool)[3]  # index 3 = to_url
+    mock_conn.executemany.assert_called_once()
+    to_url = _first_row(mock_conn)[3]  # index 3 = to_url
     assert to_url in (
         "https://help.example.com/docs/../api/overview",
         "https://help.example.com/api/overview",
@@ -54,63 +60,57 @@ async def test_page_links_relative_url_resolution() -> None:
 @pytest.mark.asyncio
 async def test_page_links_absolute_url_stored_as_is() -> None:
     """Absolute hrefs are stored without modification."""
-    mock_pool = _make_mock_pool()
+    mock_conn = _make_mock_conn()
 
-    get_pool_patch = patch(
-        "knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock, return_value=mock_pool
+    from knowledge_ingest.pg_store import upsert_page_links
+
+    await upsert_page_links(
+        mock_conn,
+        org_id="org1",
+        kb_slug="kb1",
+        from_url="https://help.example.com/docs/guide",
+        links=[{"href": "https://other.example.com/page", "text": "External"}],
     )
-    with get_pool_patch:
-        from knowledge_ingest.pg_store import upsert_page_links
-        await upsert_page_links(
-            org_id="org1",
-            kb_slug="kb1",
-            from_url="https://help.example.com/docs/guide",
-            links=[{"href": "https://other.example.com/page", "text": "External"}],
-        )
 
-    to_url = _first_row(mock_pool)[3]
+    to_url = _first_row(mock_conn)[3]
     assert to_url == "https://other.example.com/page"
 
 
 @pytest.mark.asyncio
 async def test_page_links_empty_href_skipped() -> None:
     """Links with empty href are silently skipped."""
-    mock_pool = _make_mock_pool()
+    mock_conn = _make_mock_conn()
 
-    get_pool_patch = patch(
-        "knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock, return_value=mock_pool
+    from knowledge_ingest.pg_store import upsert_page_links
+
+    await upsert_page_links(
+        mock_conn,
+        org_id="org1",
+        kb_slug="kb1",
+        from_url="https://help.example.com/page",
+        links=[{"href": "", "text": "Bad link"}, {"href": None, "text": "Also bad"}],
     )
-    with get_pool_patch:
-        from knowledge_ingest.pg_store import upsert_page_links
-        await upsert_page_links(
-            org_id="org1",
-            kb_slug="kb1",
-            from_url="https://help.example.com/page",
-            links=[{"href": "", "text": "Bad link"}, {"href": None, "text": "Also bad"}],
-        )
 
-    mock_pool.executemany.assert_not_called()
+    mock_conn.executemany.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_page_links_link_text_truncated() -> None:
     """link_text is truncated to 500 characters."""
-    mock_pool = _make_mock_pool()
+    mock_conn = _make_mock_conn()
     long_text = "x" * 600
 
-    get_pool_patch = patch(
-        "knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock, return_value=mock_pool
-    )
-    with get_pool_patch:
-        from knowledge_ingest.pg_store import upsert_page_links
-        await upsert_page_links(
-            org_id="org1",
-            kb_slug="kb1",
-            from_url="https://help.example.com/page",
-            links=[{"href": "/other", "text": long_text}],
-        )
+    from knowledge_ingest.pg_store import upsert_page_links
 
-    link_text_stored = _first_row(mock_pool)[4]  # index 4 = link_text
+    await upsert_page_links(
+        mock_conn,
+        org_id="org1",
+        kb_slug="kb1",
+        from_url="https://help.example.com/page",
+        links=[{"href": "/other", "text": long_text}],
+    )
+
+    link_text_stored = _first_row(mock_conn)[4]  # index 4 = link_text
     assert len(link_text_stored) == 500
 
 
@@ -123,6 +123,9 @@ async def test_page_links_not_saved_in_ingest_crawl_result() -> None:
     (_build_link_graph), not Phase 2 (_ingest_crawl_result).
     upsert_page_links is called by _build_link_graph BEFORE the per-page
     ingest loop runs, ensuring the full graph is available for all pages.
+
+    SPEC-TI-003-FOLLOWUP-001: _ingest_crawl_result now takes conn as
+    first arg.
     """
     from knowledge_ingest.crawl4ai_client import CrawlResult
 
@@ -143,20 +146,30 @@ async def test_page_links_not_saved_in_ingest_crawl_result() -> None:
     )
 
     mock_upsert_links = AsyncMock()
-    mock_pool = MagicMock()
-    mock_pool.fetch = AsyncMock(return_value=[])
-    mock_pool.fetchval = AsyncMock(return_value=0)
+    mock_conn = _make_mock_conn()
 
-    with patch("knowledge_ingest.pg_store.upsert_crawled_page",
-               new_callable=AsyncMock), \
-         patch("knowledge_ingest.pg_store.upsert_page_links", mock_upsert_links), \
-         patch("knowledge_ingest.routes.ingest.ingest_document",
-               new_callable=AsyncMock, return_value={"status": "ok", "chunks": 1}):
+    # _ingest_crawl_result calls _build_image_store internally; stub it out.
+    @asynccontextmanager
+    async def _no_image_store():
+        yield None
+
+    with (
+        patch("knowledge_ingest.pg_store.upsert_crawled_page", new_callable=AsyncMock),
+        patch("knowledge_ingest.pg_store.upsert_page_links", mock_upsert_links),
+        patch(
+            "knowledge_ingest.routes.ingest.ingest_document",
+            new_callable=AsyncMock,
+            return_value={"status": "ok", "chunks": 1},
+        ),
+    ):
         from knowledge_ingest.adapters.crawler import _ingest_crawl_result
+
         await _ingest_crawl_result(
+            mock_conn,
             result,
-            "https://help.example.com/page", "org1", "kb1",
-            pool=mock_pool,
+            "https://help.example.com/page",
+            "org1",
+            "kb1",
             stored=None,
         )
 

--- a/klai-knowledge-ingest/tests/test_pg_store.py
+++ b/klai-knowledge-ingest/tests/test_pg_store.py
@@ -1,38 +1,47 @@
 """
 Tests for pg_store functions.
+
+SPEC-TI-003-FOLLOWUP-001: pg_store helpers no longer acquire pool
+connections themselves -- callers pass the GUC-pinned ``asyncpg.Connection``
+in. These unit tests therefore construct a mock conn and assert against
+``conn.execute`` / ``conn.fetch`` / ``conn.fetchval`` / ``conn.fetchrow``
+directly.
 """
+
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
 
 from knowledge_ingest import pg_store
 
 _SENTINEL = 253402300800
 
 
-def _make_pool():
-    pool = MagicMock()
-    pool.execute = AsyncMock(return_value=None)
-    pool.fetch = AsyncMock(return_value=[])
-    pool.fetchval = AsyncMock(return_value=0)
-    pool.fetchrow = AsyncMock(return_value=None)
-    return pool
+def _make_conn() -> MagicMock:
+    conn = MagicMock()
+    conn.execute = AsyncMock(return_value=None)
+    conn.executemany = AsyncMock(return_value=None)
+    conn.fetch = AsyncMock(return_value=[])
+    conn.fetchval = AsyncMock(return_value=0)
+    conn.fetchrow = AsyncMock(return_value=None)
+    return conn
 
 
 @pytest.mark.asyncio
 async def test_create_artifact_returns_uuid():
-    pool = _make_pool()
-    with patch("knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock, return_value=pool):
-        artifact_id = await pg_store.create_artifact(
-            org_id="362757920133283846",
-            kb_slug="personal-user456",
-            path="note.md",
-            provenance_type="observed",
-            assertion_mode="factual",
-            synthesis_depth=0,
-            confidence=None,
-            belief_time_start=1705276800,
-            belief_time_end=_SENTINEL,
-        )
+    conn = _make_conn()
+    artifact_id = await pg_store.create_artifact(
+        conn,
+        org_id="362757920133283846",
+        kb_slug="personal-user456",
+        path="note.md",
+        provenance_type="observed",
+        assertion_mode="factual",
+        synthesis_depth=0,
+        confidence=None,
+        belief_time_start=1705276800,
+        belief_time_end=_SENTINEL,
+    )
     assert isinstance(artifact_id, str)
     assert len(artifact_id) == 36  # UUID format
     assert artifact_id.count("-") == 4
@@ -40,22 +49,22 @@ async def test_create_artifact_returns_uuid():
 
 @pytest.mark.asyncio
 async def test_create_artifact_executes_insert():
-    pool = _make_pool()
-    with patch("knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock, return_value=pool):
-        await pg_store.create_artifact(
-            org_id="org123",
-            kb_slug="docs",
-            path="spec.md",
-            provenance_type="synthesized",
-            assertion_mode="belief",
-            synthesis_depth=3,
-            confidence="high",
-            belief_time_start=1705276800,
-            belief_time_end=_SENTINEL,
-            user_id="user456",
-        )
-    pool.execute.assert_called_once()
-    call_args = pool.execute.call_args[0]
+    conn = _make_conn()
+    await pg_store.create_artifact(
+        conn,
+        org_id="org123",
+        kb_slug="docs",
+        path="spec.md",
+        provenance_type="synthesized",
+        assertion_mode="belief",
+        synthesis_depth=3,
+        confidence="high",
+        belief_time_start=1705276800,
+        belief_time_end=_SENTINEL,
+        user_id="user456",
+    )
+    conn.execute.assert_called_once()
+    call_args = conn.execute.call_args[0]
     # Verify all values are passed in correct order
     assert "INSERT INTO knowledge.artifacts" in call_args[0]
     values = call_args[1:]
@@ -71,20 +80,22 @@ async def test_create_artifact_executes_insert():
 
 @pytest.mark.asyncio
 async def test_create_artifact_generates_unique_ids():
-    pool = _make_pool()
-    with patch("knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock, return_value=pool):
-        id1 = await pg_store.create_artifact("o", "kb", "p1.md", "observed", "factual", 0, None, 0, _SENTINEL)
-        id2 = await pg_store.create_artifact("o", "kb", "p2.md", "observed", "factual", 0, None, 0, _SENTINEL)
+    conn = _make_conn()
+    id1 = await pg_store.create_artifact(
+        conn, "o", "kb", "p1.md", "observed", "factual", 0, None, 0, _SENTINEL
+    )
+    id2 = await pg_store.create_artifact(
+        conn, "o", "kb", "p2.md", "observed", "factual", 0, None, 0, _SENTINEL
+    )
     assert id1 != id2
 
 
 @pytest.mark.asyncio
 async def test_soft_delete_updates_belief_time_end():
-    pool = _make_pool()
-    with patch("knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock, return_value=pool):
-        await pg_store.soft_delete_artifact("org123", "personal", "note.md")
-    pool.execute.assert_called_once()
-    call_args = pool.execute.call_args[0]
+    conn = _make_conn()
+    await pg_store.soft_delete_artifact(conn, "org123", "personal", "note.md")
+    conn.execute.assert_called_once()
+    call_args = conn.execute.call_args[0]
     assert "UPDATE knowledge.artifacts" in call_args[0]
     assert "belief_time_end" in call_args[0]
     values = call_args[1:]
@@ -97,10 +108,9 @@ async def test_soft_delete_updates_belief_time_end():
 @pytest.mark.asyncio
 async def test_soft_delete_only_updates_active_records():
     """Verifies the WHERE belief_time_end = SENTINEL constraint is present."""
-    pool = _make_pool()
-    with patch("knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock, return_value=pool):
-        await pg_store.soft_delete_artifact("org", "kb", "path.md")
-    sql = pool.execute.call_args[0][0]
+    conn = _make_conn()
+    await pg_store.soft_delete_artifact(conn, "org", "kb", "path.md")
+    sql = conn.execute.call_args[0][0]
     # Must filter on sentinel to avoid touching already-deleted records
     assert str(_SENTINEL) in sql or "$5" in sql
 
@@ -110,13 +120,12 @@ async def test_soft_delete_only_updates_active_records():
 
 @pytest.mark.asyncio
 async def test_list_personal_artifacts_queries_correct_params():
-    pool = _make_pool()
-    pool.fetch = AsyncMock(return_value=[])
-    with patch("knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock, return_value=pool):
-        result = await pg_store.list_personal_artifacts("org1", "user1", limit=10, offset=5)
+    conn = _make_conn()
+    conn.fetch = AsyncMock(return_value=[])
+    result = await pg_store.list_personal_artifacts(conn, "org1", "user1", limit=10, offset=5)
     assert result == []
-    pool.fetch.assert_called_once()
-    call_args = pool.fetch.call_args[0]
+    conn.fetch.assert_called_once()
+    call_args = conn.fetch.call_args[0]
     sql = call_args[0]
     assert "knowledge.artifacts" in sql
     assert "kb_slug = $3" in sql
@@ -131,16 +140,18 @@ async def test_list_personal_artifacts_queries_correct_params():
 
 @pytest.mark.asyncio
 async def test_list_personal_artifacts_returns_dicts():
-    fake_row = MagicMock()
-    fake_row.__iter__ = MagicMock(return_value=iter([("id", "abc"), ("path", "note.md")]))
-    fake_row.items = MagicMock(return_value=[("id", "abc"), ("path", "note.md")])
-    fake_row.keys = MagicMock(return_value=["id", "path"])
-    fake_row.__getitem__ = lambda self, key: {"id": "abc", "path": "note.md"}[key]
-
-    pool = _make_pool()
-    pool.fetch = AsyncMock(return_value=[{"id": "abc", "path": "note.md", "assertion_mode": "fact", "created_at": 1700000000}])
-    with patch("knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock, return_value=pool):
-        result = await pg_store.list_personal_artifacts("org1", "user1")
+    conn = _make_conn()
+    conn.fetch = AsyncMock(
+        return_value=[
+            {
+                "id": "abc",
+                "path": "note.md",
+                "assertion_mode": "fact",
+                "created_at": 1700000000,
+            }
+        ]
+    )
+    result = await pg_store.list_personal_artifacts(conn, "org1", "user1")
     assert len(result) == 1
     assert result[0]["id"] == "abc"
 
@@ -150,23 +161,21 @@ async def test_list_personal_artifacts_returns_dicts():
 
 @pytest.mark.asyncio
 async def test_count_personal_artifacts_returns_int():
-    pool = _make_pool()
-    pool.fetchval = AsyncMock(return_value=42)
-    with patch("knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock, return_value=pool):
-        count = await pg_store.count_personal_artifacts("org1", "user1")
+    conn = _make_conn()
+    conn.fetchval = AsyncMock(return_value=42)
+    count = await pg_store.count_personal_artifacts(conn, "org1", "user1")
     assert count == 42
-    pool.fetchval.assert_called_once()
-    sql = pool.fetchval.call_args[0][0]
+    conn.fetchval.assert_called_once()
+    sql = conn.fetchval.call_args[0][0]
     assert "COUNT(*)" in sql
     assert "kb_slug = $3" in sql
 
 
 @pytest.mark.asyncio
 async def test_count_personal_artifacts_returns_zero_on_none():
-    pool = _make_pool()
-    pool.fetchval = AsyncMock(return_value=None)
-    with patch("knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock, return_value=pool):
-        count = await pg_store.count_personal_artifacts("org1", "user1")
+    conn = _make_conn()
+    conn.fetchval = AsyncMock(return_value=None)
+    count = await pg_store.count_personal_artifacts(conn, "org1", "user1")
     assert count == 0
 
 
@@ -175,37 +184,34 @@ async def test_count_personal_artifacts_returns_zero_on_none():
 
 @pytest.mark.asyncio
 async def test_get_personal_artifact_returns_dict_when_found():
-    pool = _make_pool()
-    pool.fetchrow = AsyncMock(return_value={"id": "abc-123", "path": "note.md"})
-    with patch("knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock, return_value=pool):
-        result = await pg_store.get_personal_artifact("abc-123", "org1", "user1")
+    conn = _make_conn()
+    conn.fetchrow = AsyncMock(return_value={"id": "abc-123", "path": "note.md"})
+    result = await pg_store.get_personal_artifact(conn, "abc-123", "org1", "user1")
     assert result is not None
     assert result["id"] == "abc-123"
     assert result["path"] == "note.md"
-    sql = pool.fetchrow.call_args[0][0]
+    sql = conn.fetchrow.call_args[0][0]
     assert "kb_slug = $4" in sql
 
 
 @pytest.mark.asyncio
 async def test_get_personal_artifact_returns_none_when_not_found():
-    pool = _make_pool()
-    pool.fetchrow = AsyncMock(return_value=None)
-    with patch("knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock, return_value=pool):
-        result = await pg_store.get_personal_artifact("nonexistent", "org1", "user1")
+    conn = _make_conn()
+    conn.fetchrow = AsyncMock(return_value=None)
+    result = await pg_store.get_personal_artifact(conn, "nonexistent", "org1", "user1")
     assert result is None
 
 
 @pytest.mark.asyncio
-async def test_update_artifact_extra_merges_jsonb(monkeypatch):
+async def test_update_artifact_extra_merges_jsonb():
     """update_artifact_extra issues a JSONB merge UPDATE (AC-2)."""
     import json as json_mod
 
-    pool = _make_pool()
-    with patch("knowledge_ingest.pg_store.get_pool", new_callable=AsyncMock, return_value=pool):
-        await pg_store.update_artifact_extra("art-001", {"graphiti_episode_id": "ep-xyz"})
+    conn = _make_conn()
+    await pg_store.update_artifact_extra(conn, "art-001", {"graphiti_episode_id": "ep-xyz"})
 
-    pool.execute.assert_called_once()
-    call_args = pool.execute.call_args[0]
+    conn.execute.assert_called_once()
+    call_args = conn.execute.call_args[0]
     sql = call_args[0]
     assert "UPDATE knowledge.artifacts" in sql
     assert "COALESCE" in sql


### PR DESCRIPTION
## Summary

Implements **SPEC-TI-003-FOLLOWUP-001** — restores tenant-isolation hardening by making the connection-locality of the RLS GUC explicit at the API surface. Every function in knowledge-ingest that issues SQL against `knowledge.*` now takes an `asyncpg.Connection` as its first argument; callers obtain it from `tenant_scoped_connection(org_id)` (per-tenant work) or the new `cross_org_admin_connection()` (org-wide janitor / startup work).

The bug was latent on prod because the `klai` superuser bypasses RLS regardless. SPEC-TI-011 will move services to non-superuser roles; this SPEC is its prerequisite.

## All 9 acceptance criteria implemented

- **AC-1 + AC-2**: Every `knowledge.*` SQL caller threads `conn` through. Pool-acquire only in `db.py`, LISTEN/NOTIFY hooks (documented exception), and procrastinate-internal queries (procrastinate_jobs is not knowledge.*).
- **AC-3**: New `cross_org_admin_connection()` helper, mirrored from `klai-connector::cross_org_session()`.
- **AC-4**: `tenant_scoped_connection` docstring spells out GUC locality and the pass-conn-down contract.
- **AC-5**: Two integration tests in `tests/test_db_rls_wiring.py`, gated behind `RUN_INTEGRATION=1` (real-Postgres concurrent-pinning + GUC-reset-on-exit).
- **AC-6**: Type-error test that asserts `pg_store.create_artifact()` without `conn` raises `TypeError` (passes in default suite); pyright/mypy structurally fail any caller that drops `conn`.
- **AC-7**: New `post_deploy_dd1b439a57d0_force.sql` re-applies `FORCE ROW LEVEL SECURITY` on all 13 `knowledge.*` tables. Operator-run AS klai, idempotent, with explicit preconditions documented in the SQL preamble.
- **AC-8**: Back-fills the 2026-05-06 hot-fix on `derivations` (was `source_id` which doesn't exist; now `child_id` matching the schema and the live policy on prod).
- **AC-9**: `_rls_current_org_id()` keeps `RAISE 42501` on missing GUC. Silent default-deny remains explicitly out of scope.

## Files refactored

**Production code (15 modules):**
- `db.py` — new helper + docstring
- `pg_store.py` — 26 functions
- `link_graph.py` — 4 helpers
- `domain_selectors.py` — get/upsert
- `kb_config.py` — get/set (start_listener keeps pool, AC-2 exception)
- `org_config.py` — is_enrichment_enabled (start_listener exception)
- `crawl_tasks.py` — fixes the literal `del _conn` bug from the SPEC's Background section
- `adapters/crawler.py` — run_crawl_job + _build_link_graph + _ingest_crawl_result + _update_job
- `routes/personal.py` + `routes/crawl.py` + `routes/ingest.py` — handlers open `tenant_scoped_connection` and pass `conn` down
- `enrichment_tasks.py` + `rebuild_tasks.py` — tasks open tsc on org_id
- `connector_cleanup.py` — purge_connector wraps in tsc; procrastinate-cancel keeps pool (AC-2 exception)
- `backfill.py` — operator script uses cross_org_admin_connection
- `alembic/versions/post_deploy_dd1b439a57d0.sql` — derivations policy fix
- `alembic/versions/post_deploy_dd1b439a57d0_force.sql` — new FORCE SQL

**Tests rewritten (6 files):**
- `tests/conftest.py` — autouse `_mock_db_helpers` patches tsc + cross_org_admin to no-op for tests not opting out
- `tests/test_pg_store.py` — 12 tests pass mock conn directly
- `tests/test_link_graph.py` — 12 tests
- `tests/test_org_config.py` — 8 tests
- `tests/test_page_links.py` — 5 tests
- `tests/test_build_link_graph.py` — 4 tests
- `tests/test_crawl_registry_dedup.py` — 7 tests
- `tests/test_knowledge_rls.py` — opts out of autouse mock so it can verify the real helper

**New tests:**
- `tests/test_db_rls_wiring.py` — AC-5 (RUN_INTEGRATION-gated) + AC-6 + AC-2 static guard

## Test status

- 558 tests passing (up from 507 before refactor)
- 44 failures + 51 errors remaining
  - 51 cascade errors are pre-existing on origin/main (procrastinate.PsycopgConnector module attribute issue, unrelated to this SPEC)
  - ~26 of the 44 failures are mock-pattern issues in test files I have not yet rewritten (`test_ingest_content_hash_dedup`, `test_enrichment_dedup`, `test_crawler_*`, `test_auth_middleware`). All same shape: tests patch removed `pg_store.get_pool` or call refactored helpers with old positional shape.
  - The remaining ~18 are pre-existing on origin/main (`test_assertion_mode_taxonomy`, `test_ragas_runner`, `test_clustering`, `test_grafana_assets`, `test_wipe_graph`).

Continued cleanup of the mock-pattern tests will land in follow-up commits to this branch.

## Operator step (after merge + SPEC-TI-011)

```bash
ssh core-01 "docker exec -i klai-core-postgres-1 psql -U klai -d klai" \
    < klai-knowledge-ingest/alembic/versions/post_deploy_dd1b439a57d0_force.sql
```

Verify zero 42501 errors in VictoriaLogs over the next hour. **Do NOT run before SPEC-TI-011 lands per-service roles** — until then the klai superuser bypasses RLS so FORCE delivers no isolation benefit, only the failure surface if any caller is still wrong.

## Alpha sequencing note (sparring outcome)

SPEC-TI-011 (per-service DB roles) is the natural follow-up. While we are in alpha there is no klant-impact risk if SPEC-TI-011 slips — the latent bug is masked by superuser. **However**: SPEC-TI-011 should ship before the first real beta-tenant onboards. After that, "we mitigate via NO FORCE" stops being acceptable.

## Test plan
- [x] `uv run ruff check` + `uv run ruff format --check` all touched files (clean)
- [x] `uv run pytest tests/test_db_rls_wiring.py` — AC-5/AC-6 (passes; AC-5 integration tests skip without RUN_INTEGRATION)
- [x] `uv run pytest tests/test_pg_store.py tests/test_link_graph.py tests/test_org_config.py tests/test_page_links.py tests/test_build_link_graph.py tests/test_crawl_registry_dedup.py tests/test_knowledge_rls.py` — all green (54 passed)
- [ ] Remaining mock-pattern tests refactored (in-progress on this branch)
- [ ] CI green on this branch
- [ ] Operator runs `post_deploy_dd1b439a57d0_force.sql` AFTER SPEC-TI-011 deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)