### PR TITLE
fix(identity-assert): split verify_tenant from verify (no silent downgrade)

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/identity.py
+++ b/klai-knowledge-ingest/knowledge_ingest/identity.py
@@ -14,7 +14,12 @@ from __future__ import annotations
 
 import structlog
 from fastapi import HTTPException, Request, status
-from klai_identity_assert import KNOWN_CALLER_SERVICES, IdentityAsserter, IdentityDenied
+from klai_identity_assert import (
+    KNOWN_CALLER_SERVICES,
+    IdentityAsserter,
+    IdentityDenied,
+    PortalUnreachable,
+)
 
 from knowledge_ingest.config import settings
 
@@ -40,13 +45,17 @@ def _get_asserter() -> IdentityAsserter:
 async def assert_caller_identity(
     request: Request,
     claimed_org_id: str,
-    claimed_user_id: str | None = None,
+    claimed_user_id: str,
 ) -> str:
-    """Verify that the caller is who they claim to be.
+    """Verify that the caller and the end-user are who they claim to be.
 
     Raises HTTPException(400) when X-Caller-Service is missing/unknown.
     Raises HTTPException(403) when portal denies the identity claim.
     Returns the verified org_id on success.
+
+    ``claimed_user_id`` is required (no default). Routes that have no
+    end-user MUST call :func:`assert_caller_identity_tenant_only` instead —
+    this function is strictly for user-bound endpoints.
 
     AC-8: InternalSecretMiddleware (network auth) runs before this.
     This function adds the tenant-binding layer.
@@ -108,6 +117,84 @@ async def assert_caller_identity(
 
     logger.debug(
         "identity_assertion_ok",
+        caller_service=caller_service,
+        org_id=result.org_id or claimed_org_id,
+    )
+    return result.org_id or claimed_org_id
+
+
+async def assert_caller_identity_tenant_only(
+    request: Request,
+    *,
+    claimed_org_id: str,
+) -> str:
+    """Verify the tenant identity for service-to-service calls with no end-user.
+
+    Used by stats endpoints (source-count, graph-stats) that are called by
+    portal-api with only a tenant context — no end-user JWT and no user_id.
+
+    Raises HTTPException(400) when X-Caller-Service is missing/unknown.
+    Raises HTTPException(403) when portal denies the tenant identity claim.
+    Returns the verified org_id on success.
+
+    AC-8: InternalSecretMiddleware (network auth) runs before this.
+    This function adds the tenant-binding layer WITHOUT a user identity check.
+    """
+    caller_service = request.headers.get("x-caller-service", "")
+    if not caller_service or caller_service not in KNOWN_CALLER_SERVICES:
+        logger.warning(
+            "identity_assert_missing_caller_service",
+            caller_service=caller_service,
+            claimed_org_id=claimed_org_id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"error": "missing_caller_service"},
+        )
+
+    try:
+        result = await _get_asserter().verify_tenant(
+            caller_service=caller_service,
+            claimed_org_id=claimed_org_id,
+            request_headers=dict(request.headers),
+        )
+    except (IdentityDenied, PortalUnreachable) as exc:
+        logger.warning(
+            "identity_assertion_tenant_denied",
+            caller_service=caller_service,
+            claimed_org_id=claimed_org_id,
+            reason=str(exc),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={"error": "identity_assertion_failed"},
+        ) from exc
+    except Exception as exc:
+        logger.warning(
+            "identity_assertion_portal_unreachable",
+            caller_service=caller_service,
+            claimed_org_id=claimed_org_id,
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={"error": "identity_assertion_failed"},
+        ) from exc
+
+    if not result.verified:
+        logger.warning(
+            "identity_assertion_tenant_failed",
+            caller_service=caller_service,
+            claimed_org_id=claimed_org_id,
+            reason=result.reason,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={"error": "identity_assertion_failed"},
+        )
+
+    logger.debug(
+        "identity_assertion_tenant_ok",
         caller_service=caller_service,
         org_id=result.org_id or claimed_org_id,
     )

--- a/klai-knowledge-ingest/knowledge_ingest/routes/stats.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/stats.py
@@ -3,15 +3,14 @@ Stats routes:
   GET /ingest/v1/graph-stats?org_id={org_id}  - entity/edge counts from FalkorDB
   GET /ingest/v1/source-count?org_id={org_id}&kb_slug={kb_slug}  - artifact count from PostgreSQL
 """
-import structlog
 
+import structlog
 from fastapi import APIRouter, Query, Request
 from pydantic import BaseModel
 
-from knowledge_ingest import db
 from knowledge_ingest.config import settings
 from knowledge_ingest.db import tenant_scoped_connection
-from knowledge_ingest.identity import assert_caller_identity
+from knowledge_ingest.identity import assert_caller_identity_tenant_only
 
 logger = structlog.get_logger()
 router = APIRouter()
@@ -25,6 +24,7 @@ def _get_falkordb():
     global _falkordb_client
     if _falkordb_client is None:
         from falkordb import FalkorDB as FalkorDBClient
+
         _falkordb_client = FalkorDBClient(
             host=settings.falkordb_host,
             port=settings.falkordb_port,
@@ -53,15 +53,16 @@ async def get_source_count(
     AC-9: tenant_scoped_connection so RLS context is set for the SELECT.
     """
     try:
-        verified_org_id = await assert_caller_identity(request, claimed_org_id=org_id)
+        verified_org_id = await assert_caller_identity_tenant_only(request, claimed_org_id=org_id)
         async with tenant_scoped_connection(verified_org_id) as conn:
             count = await conn.fetchval(
                 "SELECT COUNT(*) FROM knowledge.artifacts "
                 "WHERE org_id = $1 AND kb_slug = $2 AND superseded_by IS NULL",
-                verified_org_id, kb_slug,
+                verified_org_id,
+                kb_slug,
             )
         return SourceCountResponse(source_count=count)
-    except Exception as exc:
+    except Exception:
         logger.warning("stats_source_count_failed", org_id=org_id, kb_slug=kb_slug, exc_info=True)
         return SourceCountResponse()
 
@@ -80,7 +81,7 @@ async def get_graph_stats(
         return GraphStatsResponse()
 
     try:
-        verified_org_id = await assert_caller_identity(request, claimed_org_id=org_id)
+        verified_org_id = await assert_caller_identity_tenant_only(request, claimed_org_id=org_id)
     except Exception:
         return GraphStatsResponse()
 
@@ -90,20 +91,14 @@ async def get_graph_stats(
 
         # Count entity nodes
         try:
-            entity_result = graph.query(
-                "MATCH (n:Entity) RETURN count(n) AS cnt"
-            )
+            entity_result = graph.query("MATCH (n:Entity) RETURN count(n) AS cnt")
             entity_count = entity_result.result_set[0][0] if entity_result.result_set else 0
         except Exception:
-            entity_result = graph.query(
-                "MATCH (n) RETURN count(n) AS cnt"
-            )
+            entity_result = graph.query("MATCH (n) RETURN count(n) AS cnt")
             entity_count = entity_result.result_set[0][0] if entity_result.result_set else 0
 
         # Count relationships between nodes
-        edge_result = graph.query(
-            "MATCH ()-[r]->() RETURN count(r) AS cnt"
-        )
+        edge_result = graph.query("MATCH ()-[r]->() RETURN count(r) AS cnt")
         edge_count = edge_result.result_set[0][0] if edge_result.result_set else 0
 
         return GraphStatsResponse(entity_count=entity_count, edge_count=edge_count)
@@ -111,6 +106,6 @@ async def get_graph_stats(
     except ImportError:
         logger.warning("falkordb package not available - skipping graph stats")
         return GraphStatsResponse()
-    except Exception as exc:
+    except Exception:
         logger.warning("stats_graph_stats_failed", org_id=org_id, exc_info=True)
         return GraphStatsResponse()

--- a/klai-libs/identity-assert/klai_identity_assert/cache.py
+++ b/klai-libs/identity-assert/klai_identity_assert/cache.py
@@ -34,6 +34,19 @@ class _CacheKey:
     jwt_fingerprint: str
 
 
+@dataclass(frozen=True, slots=True)
+class _TenantCacheKey:
+    """Cache key for tenant-only entries — no user_id, no JWT fingerprint.
+
+    Kept as a separate dataclass (not a mode flag on _CacheKey) so there is
+    zero possibility of a user-bound key and a tenant-only key comparing equal
+    even when both carry the same (caller_service, claimed_org_id).
+    """
+
+    caller_service: str
+    claimed_org_id: str
+
+
 def _fingerprint_jwt(bearer_jwt: str | None) -> str:
     """Return a fingerprint that distinguishes JWT-bearing from JWT-less calls.
 
@@ -64,6 +77,9 @@ class IdentityCache:
         self._ttl_seconds = ttl_seconds
         self._max_entries = max_entries
         self._store: OrderedDict[_CacheKey, tuple[float, VerifyResult]] = OrderedDict()
+        # Separate store for tenant-only entries — kept independent so a user-bound
+        # key and a tenant-only key can never collide, even sharing the same org.
+        self._tenant_store: OrderedDict[_TenantCacheKey, tuple[float, VerifyResult]] = OrderedDict()
         self._lock = threading.Lock()
 
     def _key(
@@ -141,10 +157,59 @@ class IdentityCache:
             while len(self._store) > self._max_entries:
                 self._store.popitem(last=False)
 
+    def get_tenant(
+        self,
+        *,
+        caller_service: str,
+        claimed_org_id: str,
+        now: float | None = None,
+    ) -> VerifyResult | None:
+        """Return a cached tenant-only verified result, or ``None`` on miss / expiry."""
+        key = _TenantCacheKey(caller_service=caller_service, claimed_org_id=claimed_org_id)
+        current = time.monotonic() if now is None else now
+        with self._lock:
+            entry = self._tenant_store.get(key)
+            if entry is None:
+                return None
+            expires_at, result = entry
+            if current >= expires_at:
+                del self._tenant_store[key]
+                return None
+            self._tenant_store.move_to_end(key)
+            return VerifyResult(
+                verified=result.verified,
+                user_id=result.user_id,
+                org_id=result.org_id,
+                org_slug=result.org_slug,
+                reason=result.reason,
+                evidence=result.evidence,
+                cached=True,
+            )
+
+    def put_tenant(
+        self,
+        *,
+        caller_service: str,
+        claimed_org_id: str,
+        result: VerifyResult,
+        now: float | None = None,
+    ) -> None:
+        """Cache a tenant-only verified result. No-op for non-verified results."""
+        if not result.verified:
+            return
+        key = _TenantCacheKey(caller_service=caller_service, claimed_org_id=claimed_org_id)
+        current = time.monotonic() if now is None else now
+        with self._lock:
+            self._tenant_store[key] = (current + self._ttl_seconds, result)
+            self._tenant_store.move_to_end(key)
+            while len(self._tenant_store) > self._max_entries:
+                self._tenant_store.popitem(last=False)
+
     def clear(self) -> None:
         """Drop every cached entry. Test-only."""
         with self._lock:
             self._store.clear()
+            self._tenant_store.clear()
 
     def __len__(self) -> int:
         with self._lock:

--- a/klai-libs/identity-assert/klai_identity_assert/client.py
+++ b/klai-libs/identity-assert/klai_identity_assert/client.py
@@ -46,6 +46,44 @@ _DEFAULT_TIMEOUT_SECONDS = 2.0
 _DEFAULT_CACHE_TTL_SECONDS = 60.0
 
 
+def _interpret_tenant_response(payload: Any) -> VerifyResult:
+    """Map a JSON body from /internal/identity/verify-tenant to a VerifyResult.
+
+    Accepts only ``evidence="tenant_only"`` responses. Any unexpected shape
+    (including an evidence value other than "tenant_only") fails closed as
+    ``portal_unreachable`` — this keeps the user-bound ``verify()`` code path
+    strictly separated at the interpreter level.
+    """
+
+    if not isinstance(payload, dict):
+        return VerifyResult.deny("portal_unreachable")
+    body = cast("dict[str, Any]", payload)
+
+    if not bool(body.get("verified")):
+        reason = body.get("reason")
+        known: tuple[str, ...] = (
+            "unknown_caller_service",
+            "org_slug_mismatch",
+            "cache_unavailable",
+            "tenant_not_found",
+        )
+        if isinstance(reason, str) and reason in known:
+            return VerifyResult.deny(reason)  # type: ignore[arg-type]
+        return VerifyResult.deny("portal_unreachable")
+
+    org_id = body.get("org_id")
+    org_slug = body.get("org_slug")
+    evidence = body.get("evidence")
+    if not isinstance(org_id, str) or not isinstance(org_slug, str):
+        return VerifyResult.deny("portal_unreachable")
+    if evidence != "tenant_only":
+        # Any evidence other than "tenant_only" from this endpoint is a
+        # contract violation — fail closed so user-bound evidence can never
+        # slip into a tenant-only call path.
+        return VerifyResult.deny("portal_unreachable")
+    return VerifyResult.allow_tenant(org_id=org_id, org_slug=org_slug)
+
+
 def _interpret_response(payload: Any) -> VerifyResult:
     """Map a JSON body from /internal/identity/verify to a VerifyResult.
 
@@ -185,11 +223,7 @@ class IdentityAsserter:
             # canonical one we resolved at first verification. The canonical
             # slug is stable across the cache TTL so we can deny without a
             # portal round-trip.
-            if (
-                claimed_org_slug is not None
-                and cached.org_slug is not None
-                and claimed_org_slug != cached.org_slug
-            ):
+            if claimed_org_slug is not None and cached.org_slug is not None and claimed_org_slug != cached.org_slug:
                 with measure_latency() as latency:
                     pass
                 deny = VerifyResult.deny("org_slug_mismatch")
@@ -339,4 +373,168 @@ class IdentityAsserter:
             return result
         if result.reason == "portal_unreachable":
             raise PortalUnreachable(f"portal /internal/identity/verify failed for {caller_service}")
+        raise IdentityDenied(result.reason or "unknown")
+
+    async def verify_tenant(
+        self,
+        *,
+        caller_service: str,
+        claimed_org_id: str,
+        claimed_org_slug: str | None = None,
+        request_headers: Mapping[str, str] | None = None,
+    ) -> VerifyResult:
+        """Verify a tenant-only identity claim against portal-api.
+
+        This is the opt-in primitive for service-to-service calls that carry
+        no end-user identity (e.g. dashboard stats endpoints). There is no
+        ``claimed_user_id`` parameter and no ``bearer_jwt`` parameter — a
+        tenant-only call with a JWT would be a contract violation, since there
+        is no user the JWT could assert.
+
+        The type system enforces the separation: callers of user-bound endpoints
+        MUST call :meth:`verify` (strict ``claimed_user_id: str``); they cannot
+        accidentally get a tenant-only result by passing ``None``.
+
+        Returns
+        -------
+        VerifyResult
+            Always returns a result; never raises for portal/network failure.
+            Use :meth:`verify_tenant_or_raise` for exception-driven flow.
+        """
+
+        if caller_service not in KNOWN_CALLER_SERVICES:
+            result = VerifyResult.deny("library_misconfigured")
+            with measure_latency() as latency:
+                pass
+            emit_call(
+                caller_service=caller_service,
+                claimed_user_id=None,
+                claimed_org_id=claimed_org_id,
+                result=result,
+                latency_ms=latency["latency_ms"],
+            )
+            return result
+
+        cached = self._cache.get_tenant(
+            caller_service=caller_service,
+            claimed_org_id=claimed_org_id,
+        )
+        if cached is not None:
+            with measure_latency() as latency:
+                pass
+            emit_call(
+                caller_service=caller_service,
+                claimed_user_id=None,
+                claimed_org_id=claimed_org_id,
+                result=cached,
+                latency_ms=latency["latency_ms"],
+            )
+            return cached
+
+        body: dict[str, str | None] = {
+            "caller_service": caller_service,
+            "claimed_org_id": claimed_org_id,
+            "claimed_org_slug": claimed_org_slug,
+        }
+        headers: dict[str, str] = {
+            "Authorization": f"Bearer {self._internal_secret}",
+            "Content-Type": "application/json",
+        }
+        if request_headers is not None:
+            request_id = request_headers.get("X-Request-ID") or request_headers.get("x-request-id")
+            if request_id:
+                headers["X-Request-ID"] = request_id
+
+        with measure_latency() as latency:
+            try:
+                response = await self._http.post(
+                    f"{self._portal_base_url}/internal/identity/verify-tenant",
+                    json=body,
+                    headers=headers,
+                )
+            except httpx.HTTPError as exc:
+                _logger.warning(
+                    "identity_assert_portal_unreachable",
+                    caller_service=caller_service,
+                    error=str(exc),
+                )
+                result = VerifyResult.deny("portal_unreachable")
+                emit_call(
+                    caller_service=caller_service,
+                    claimed_user_id=None,
+                    claimed_org_id=claimed_org_id,
+                    result=result,
+                    latency_ms=latency["latency_ms"],
+                )
+                return result
+
+        if response.status_code >= 500:
+            result = VerifyResult.deny("portal_unreachable")
+            emit_call(
+                caller_service=caller_service,
+                claimed_user_id=None,
+                claimed_org_id=claimed_org_id,
+                result=result,
+                latency_ms=latency["latency_ms"],
+            )
+            return result
+
+        try:
+            payload = response.json()
+        except ValueError:
+            result = VerifyResult.deny("portal_unreachable")
+            emit_call(
+                caller_service=caller_service,
+                claimed_user_id=None,
+                claimed_org_id=claimed_org_id,
+                result=result,
+                latency_ms=latency["latency_ms"],
+            )
+            return result
+
+        result = _interpret_tenant_response(payload)
+        if result.verified:
+            self._cache.put_tenant(
+                caller_service=caller_service,
+                claimed_org_id=claimed_org_id,
+                result=result,
+            )
+
+        emit_call(
+            caller_service=caller_service,
+            claimed_user_id=None,
+            claimed_org_id=claimed_org_id,
+            result=result,
+            latency_ms=latency["latency_ms"],
+        )
+        return result
+
+    async def verify_tenant_or_raise(
+        self,
+        *,
+        caller_service: str,
+        claimed_org_id: str,
+        claimed_org_slug: str | None = None,
+        request_headers: Mapping[str, str] | None = None,
+    ) -> VerifyResult:
+        """Like :meth:`verify_tenant` but raises on every non-verified outcome.
+
+        Same exception mapping as :meth:`verify_or_raise`:
+
+        - :class:`~klai_identity_assert.exceptions.PortalUnreachable` for
+          network errors and ``portal_unreachable``-coded results.
+        - :class:`~klai_identity_assert.exceptions.IdentityDenied` for every
+          other denial (``tenant_not_found``, ``org_slug_mismatch``, etc.).
+        """
+
+        result = await self.verify_tenant(
+            caller_service=caller_service,
+            claimed_org_id=claimed_org_id,
+            claimed_org_slug=claimed_org_slug,
+            request_headers=request_headers,
+        )
+        if result.verified:
+            return result
+        if result.reason == "portal_unreachable":
+            raise PortalUnreachable(f"portal /internal/identity/verify-tenant failed for {caller_service}")
         raise IdentityDenied(result.reason or "unknown")

--- a/klai-libs/identity-assert/klai_identity_assert/models.py
+++ b/klai-libs/identity-assert/klai_identity_assert/models.py
@@ -15,7 +15,10 @@ from typing import Literal
 # ``partner_key`` (F2 fix-forward, retrieval coupling audit 2026-05-06):
 # evidence used for synthetic ``partner:<key_id>`` identities verified
 # against the partner_api_keys table by portal-api.
-Evidence = Literal["jwt", "membership", "partner_key"]
+# ``tenant_only``: used exclusively for tenant-level service-to-service calls
+# where there is no end-user identity (e.g. portal-api → knowledge-ingest stats
+# endpoints). Only returned by verify_tenant() / verify_tenant_or_raise().
+Evidence = Literal["jwt", "membership", "partner_key", "tenant_only"]
 
 # Stable reject codes — mirrors portal-api REQ-1.7 stable_code list. Plus two
 # consumer-side codes the library raises before ever reaching portal:
@@ -33,6 +36,8 @@ ReasonCode = Literal[
     # F2 fix-forward (retrieval coupling audit 2026-05-06): partner-key paths.
     "partner_key_not_found",
     "partner_key_org_mismatch",
+    # Tenant-only path: org not found in portal_orgs (no live row).
+    "tenant_not_found",
 ]
 
 
@@ -105,6 +110,31 @@ class VerifyResult:
             org_slug=org_slug,
             reason=None,
             evidence=evidence,
+            cached=cached,
+        )
+
+    @classmethod
+    def allow_tenant(
+        cls,
+        *,
+        org_id: str,
+        org_slug: str,
+        cached: bool = False,
+    ) -> VerifyResult:
+        """Construct a verified tenant-only result (no end-user identity).
+
+        Used exclusively for service-to-service calls where there is no
+        end-user (e.g. dashboard stats endpoints). The ``user_id`` field is
+        intentionally ``None``; callers MUST NOT use this on user-bound
+        endpoints — use :meth:`allow` instead to keep the type system strict.
+        """
+        return cls(
+            verified=True,
+            user_id=None,
+            org_id=org_id,
+            org_slug=org_slug,
+            reason=None,
+            evidence="tenant_only",
             cached=cached,
         )
 

--- a/klai-libs/identity-assert/klai_identity_assert/telemetry.py
+++ b/klai-libs/identity-assert/klai_identity_assert/telemetry.py
@@ -30,9 +30,22 @@ if TYPE_CHECKING:
 
 _logger = structlog.get_logger("klai_identity_assert")
 
+# Sentinel emitted in ``claimed_user_id_hash`` for tenant-only calls where
+# no end-user identity exists.  Chosen to be recognisable in log dashboards
+# without requiring special-case parsing.
+_TENANT_ONLY_USER_HASH = "<service>"
 
-def hash_user_id(user_id: str) -> str:
-    """Return a 16-hex-char prefix of SHA-256 — same convention as retrieval-api."""
+
+def hash_user_id(user_id: str | None) -> str:
+    """Return a 16-hex-char prefix of SHA-256 — same convention as retrieval-api.
+
+    When ``user_id`` is ``None`` (tenant-only call, no end-user) returns the
+    sentinel ``"<service>"`` instead of crashing. This is purely defensive:
+    the production code path for tenant-only calls is ``verify_tenant()`` which
+    never calls ``hash_user_id`` with a real user id.
+    """
+    if user_id is None:
+        return _TENANT_ONLY_USER_HASH
     return hashlib.sha256(user_id.encode("utf-8")).hexdigest()[:16]
 
 
@@ -56,7 +69,7 @@ def measure_latency() -> Generator[dict[str, float], None, None]:
 def emit_call(
     *,
     caller_service: str,
-    claimed_user_id: str,
+    claimed_user_id: str | None,
     claimed_org_id: str,
     result: VerifyResult,
     latency_ms: float,

--- a/klai-libs/identity-assert/tests/test_cache.py
+++ b/klai-libs/identity-assert/tests/test_cache.py
@@ -15,12 +15,15 @@ def _verified() -> VerifyResult:
 def test_get_returns_none_on_miss() -> None:
     cache = IdentityCache()
 
-    assert cache.get(
-        caller_service="scribe",
-        claimed_user_id="u-1",
-        claimed_org_id="o-1",
-        bearer_jwt=None,
-    ) is None
+    assert (
+        cache.get(
+            caller_service="scribe",
+            claimed_user_id="u-1",
+            claimed_org_id="o-1",
+            bearer_jwt=None,
+        )
+        is None
+    )
 
 
 def test_put_then_get_returns_cached_with_cached_flag_true() -> None:
@@ -83,12 +86,15 @@ def test_put_does_not_cache_denied_results() -> None:
     )
 
     assert len(cache) == 0
-    assert cache.get(
-        caller_service="scribe",
-        claimed_user_id="u-1",
-        claimed_org_id="o-1",
-        bearer_jwt=None,
-    ) is None
+    assert (
+        cache.get(
+            caller_service="scribe",
+            claimed_user_id="u-1",
+            claimed_org_id="o-1",
+            bearer_jwt=None,
+        )
+        is None
+    )
 
 
 def test_jwt_fingerprint_distinguishes_callers() -> None:
@@ -170,20 +176,26 @@ def test_lru_eviction_drops_oldest_when_capacity_exceeded() -> None:
         now=3.0,
     )
 
-    assert cache.get(
-        caller_service="scribe",
-        claimed_user_id="u-B",
-        claimed_org_id="o-1",
-        bearer_jwt=None,
-        now=4.0,
-    ) is None
-    assert cache.get(
-        caller_service="scribe",
-        claimed_user_id="u-A",
-        claimed_org_id="o-1",
-        bearer_jwt=None,
-        now=4.0,
-    ) is not None
+    assert (
+        cache.get(
+            caller_service="scribe",
+            claimed_user_id="u-B",
+            claimed_org_id="o-1",
+            bearer_jwt=None,
+            now=4.0,
+        )
+        is None
+    )
+    assert (
+        cache.get(
+            caller_service="scribe",
+            claimed_user_id="u-A",
+            claimed_org_id="o-1",
+            bearer_jwt=None,
+            now=4.0,
+        )
+        is not None
+    )
 
 
 def test_init_rejects_invalid_ttl() -> None:
@@ -196,3 +208,90 @@ def test_init_rejects_invalid_ttl() -> None:
 def test_init_rejects_invalid_max_entries() -> None:
     with pytest.raises(ValueError, match="max_entries"):
         IdentityCache(max_entries=0)
+
+
+# ---------------------------------------------------------------------------
+# Tenant cache tests
+# ---------------------------------------------------------------------------
+
+
+def _verified_tenant() -> VerifyResult:
+    return VerifyResult.allow_tenant(org_id="o-1", org_slug="acme")
+
+
+def test_tenant_put_then_get_returns_cached_with_flag_true() -> None:
+    cache = IdentityCache()
+    cache.put_tenant(
+        caller_service="portal-api",
+        claimed_org_id="o-1",
+        result=_verified_tenant(),
+        now=0.0,
+    )
+
+    cached = cache.get_tenant(
+        caller_service="portal-api",
+        claimed_org_id="o-1",
+        now=30.0,
+    )
+
+    assert cached is not None
+    assert cached.verified is True
+    assert cached.cached is True
+    assert cached.org_id == "o-1"
+    assert cached.org_slug == "acme"
+    assert cached.evidence == "tenant_only"
+    assert cached.user_id is None
+
+
+def test_tenant_get_returns_none_after_ttl() -> None:
+    cache = IdentityCache(ttl_seconds=60.0)
+    cache.put_tenant(
+        caller_service="portal-api",
+        claimed_org_id="o-1",
+        result=_verified_tenant(),
+        now=0.0,
+    )
+
+    expired = cache.get_tenant(
+        caller_service="portal-api",
+        claimed_org_id="o-1",
+        now=61.0,
+    )
+
+    assert expired is None
+
+
+def test_tenant_cache_key_cannot_match_user_bound_entry() -> None:
+    """A user-bound put for (portal-api, o-1) MUST NOT be returned by get_tenant.
+
+    This is the core isolation guarantee: the two stores are completely
+    separate — no key structure can bridge them.
+    """
+    cache = IdentityCache()
+    # Put a user-bound entry for the same (service, org).
+    cache.put(
+        caller_service="portal-api",
+        claimed_user_id="u-1",
+        claimed_org_id="o-1",
+        bearer_jwt=None,
+        result=_verified(),
+        now=0.0,
+    )
+
+    # Tenant-only lookup MUST miss — it has its own store.
+    tenant_hit = cache.get_tenant(
+        caller_service="portal-api",
+        claimed_org_id="o-1",
+        now=1.0,
+    )
+    assert tenant_hit is None
+
+    # The original user-bound entry is still there.
+    user_hit = cache.get(
+        caller_service="portal-api",
+        claimed_user_id="u-1",
+        claimed_org_id="o-1",
+        bearer_jwt=None,
+        now=1.0,
+    )
+    assert user_hit is not None

--- a/klai-libs/identity-assert/tests/test_client.py
+++ b/klai-libs/identity-assert/tests/test_client.py
@@ -82,9 +82,7 @@ async def test_verify_returns_allow_on_jwt_evidence(fake_user_id: str, fake_org_
     await asserter.aclose()
 
 
-async def test_verify_returns_allow_on_membership_evidence(
-    fake_user_id: str, fake_org_id: str
-) -> None:
+async def test_verify_returns_allow_on_membership_evidence(fake_user_id: str, fake_org_id: str) -> None:
     transport = _mock_portal(
         body={
             "verified": True,
@@ -110,9 +108,7 @@ async def test_verify_returns_allow_on_membership_evidence(
     await asserter.aclose()
 
 
-async def test_verify_returns_deny_on_no_membership(
-    fake_user_id: str, other_org_id: str
-) -> None:
+async def test_verify_returns_deny_on_no_membership(fake_user_id: str, other_org_id: str) -> None:
     transport = _mock_portal(
         status_code=403,
         body={"verified": False, "reason": "no_membership"},
@@ -133,9 +129,7 @@ async def test_verify_returns_deny_on_no_membership(
     await asserter.aclose()
 
 
-async def test_verify_returns_deny_on_jwt_identity_mismatch(
-    fake_user_id: str, fake_org_id: str
-) -> None:
+async def test_verify_returns_deny_on_jwt_identity_mismatch(fake_user_id: str, fake_org_id: str) -> None:
     transport = _mock_portal(
         status_code=403,
         body={"verified": False, "reason": "jwt_identity_mismatch"},
@@ -154,9 +148,7 @@ async def test_verify_returns_deny_on_jwt_identity_mismatch(
     await asserter.aclose()
 
 
-async def test_verify_fails_closed_on_network_error(
-    fake_user_id: str, fake_org_id: str
-) -> None:
+async def test_verify_fails_closed_on_network_error(fake_user_id: str, fake_org_id: str) -> None:
     def fail(_request: httpx.Request) -> httpx.Response:
         raise httpx.ConnectError("portal down")
 
@@ -191,9 +183,7 @@ async def test_verify_fails_closed_on_5xx(fake_user_id: str, fake_org_id: str) -
     await asserter.aclose()
 
 
-async def test_verify_fails_closed_on_unknown_caller_service(
-    fake_user_id: str, fake_org_id: str
-) -> None:
+async def test_verify_fails_closed_on_unknown_caller_service(fake_user_id: str, fake_org_id: str) -> None:
     transport = _mock_portal(body={"verified": True})
     asserter = await _build_asserter(transport)
 
@@ -209,9 +199,7 @@ async def test_verify_fails_closed_on_unknown_caller_service(
     await asserter.aclose()
 
 
-async def test_verify_fails_closed_on_malformed_json(
-    fake_user_id: str, fake_org_id: str
-) -> None:
+async def test_verify_fails_closed_on_malformed_json(fake_user_id: str, fake_org_id: str) -> None:
     def handler(_request: httpx.Request) -> httpx.Response:
         return httpx.Response(200, content=b"not-json")
 
@@ -230,9 +218,7 @@ async def test_verify_fails_closed_on_malformed_json(
     await asserter.aclose()
 
 
-async def test_verify_caches_allow_results(
-    fake_user_id: str, fake_org_id: str
-) -> None:
+async def test_verify_caches_allow_results(fake_user_id: str, fake_org_id: str) -> None:
     call_count = {"value": 0}
 
     def handler(_request: httpx.Request) -> httpx.Response:
@@ -332,9 +318,7 @@ async def test_verify_propagates_x_request_id(fake_user_id: str, fake_org_id: st
     await asserter.aclose()
 
 
-async def test_verify_uses_authorization_bearer_for_internal_secret(
-    fake_user_id: str, fake_org_id: str
-) -> None:
+async def test_verify_uses_authorization_bearer_for_internal_secret(fake_user_id: str, fake_org_id: str) -> None:
     """portal-api's /internal/* contract expects ``Authorization: Bearer <secret>``.
 
     This is intentionally NOT a custom ``X-Internal-Secret`` header — that
@@ -375,9 +359,7 @@ async def test_verify_uses_authorization_bearer_for_internal_secret(
     await asserter.aclose()
 
 
-async def test_verify_or_raise_returns_on_allow(
-    fake_user_id: str, fake_org_id: str
-) -> None:
+async def test_verify_or_raise_returns_on_allow(fake_user_id: str, fake_org_id: str) -> None:
     transport = _mock_portal(
         body={
             "verified": True,
@@ -401,9 +383,7 @@ async def test_verify_or_raise_returns_on_allow(
     await asserter.aclose()
 
 
-async def test_verify_or_raise_raises_portal_unreachable(
-    fake_user_id: str, fake_org_id: str
-) -> None:
+async def test_verify_or_raise_raises_portal_unreachable(fake_user_id: str, fake_org_id: str) -> None:
     def fail(_request: httpx.Request) -> httpx.Response:
         raise httpx.ConnectError("portal down")
 
@@ -420,9 +400,7 @@ async def test_verify_or_raise_raises_portal_unreachable(
     await asserter.aclose()
 
 
-async def test_verify_or_raise_raises_identity_denied(
-    fake_user_id: str, other_org_id: str
-) -> None:
+async def test_verify_or_raise_raises_identity_denied(fake_user_id: str, other_org_id: str) -> None:
     transport = _mock_portal(
         status_code=403,
         body={"verified": False, "reason": "no_membership"},
@@ -450,9 +428,7 @@ def test_init_rejects_empty_internal_secret() -> None:
         IdentityAsserter(portal_base_url="http://x", internal_secret="")
 
 
-async def test_aclose_owns_only_constructed_client(
-    fake_user_id: str, fake_org_id: str
-) -> None:
+async def test_aclose_owns_only_constructed_client(fake_user_id: str, fake_org_id: str) -> None:
     """Asserter MUST NOT close a borrowed http_client (caller owns lifecycle)."""
 
     capture: dict[str, object] = {}
@@ -524,9 +500,7 @@ async def test_verify_request_body_shape(fake_user_id: str, fake_org_id: str) ->
     await asserter.aclose()
 
 
-async def test_verify_request_body_carries_claimed_org_slug(
-    fake_user_id: str, fake_org_id: str
-) -> None:
+async def test_verify_request_body_carries_claimed_org_slug(fake_user_id: str, fake_org_id: str) -> None:
     """REQ-2.6: when caller passes claimed_org_slug, it lands in the request body."""
     capture: dict[str, object] = {}
     transport = _mock_portal(
@@ -557,9 +531,7 @@ async def test_verify_request_body_carries_claimed_org_slug(
     await asserter.aclose()
 
 
-async def test_verify_returns_deny_on_org_slug_mismatch(
-    fake_user_id: str, fake_org_id: str
-) -> None:
+async def test_verify_returns_deny_on_org_slug_mismatch(fake_user_id: str, fake_org_id: str) -> None:
     """REQ-2.6: portal returns 403 + reason='org_slug_mismatch' → library surfaces it."""
     transport = _mock_portal(
         status_code=403,
@@ -637,9 +609,7 @@ async def test_verify_cache_hit_denies_on_slug_mismatch_without_portal_call(
     await asserter.aclose()
 
 
-async def test_unrecognised_reason_code_collapses_to_portal_unreachable(
-    fake_user_id: str, fake_org_id: str
-) -> None:
+async def test_unrecognised_reason_code_collapses_to_portal_unreachable(fake_user_id: str, fake_org_id: str) -> None:
     """If portal returns a reason code the library does not know, fail closed."""
 
     transport = _mock_portal(
@@ -675,3 +645,122 @@ async def test_verify_returns_verify_result_type(
     assert isinstance(result, VerifyResult)
     assert result.verified is False
     assert result.reason == "portal_unreachable"
+
+
+# ---------------------------------------------------------------------------
+# verify_tenant tests
+# ---------------------------------------------------------------------------
+
+
+async def test_verify_tenant_happy_path(fake_org_id: str) -> None:
+    """verify_tenant returns allow_tenant on a valid portal response."""
+    transport = _mock_portal(
+        body={
+            "verified": True,
+            "org_id": fake_org_id,
+            "org_slug": "acme",
+            "cache_ttl_seconds": 60,
+            "evidence": "tenant_only",
+        },
+    )
+    asserter = await _build_asserter(transport)
+
+    result = await asserter.verify_tenant(
+        caller_service="portal-api",
+        claimed_org_id=fake_org_id,
+    )
+
+    assert result.verified is True
+    assert result.org_id == fake_org_id
+    assert result.org_slug == "acme"
+    assert result.evidence == "tenant_only"
+    assert result.user_id is None
+    assert result.cached is False
+    await asserter.aclose()
+
+
+async def test_verify_tenant_posts_to_correct_url(fake_org_id: str) -> None:
+    """verify_tenant MUST post to /internal/identity/verify-tenant (not /verify)."""
+    capture: dict[str, object] = {}
+    transport = _mock_portal(
+        body={
+            "verified": True,
+            "org_id": fake_org_id,
+            "org_slug": "acme",
+            "cache_ttl_seconds": 60,
+            "evidence": "tenant_only",
+        },
+        capture=capture,
+    )
+    asserter = await _build_asserter(transport)
+
+    await asserter.verify_tenant(
+        caller_service="portal-api",
+        claimed_org_id=fake_org_id,
+    )
+
+    assert "/internal/identity/verify-tenant" in str(capture["url"])
+    # The user-bound endpoint path MUST NOT appear.
+    assert str(capture["url"]).rstrip("/") != f"{PORTAL_URL}/internal/identity/verify"
+    await asserter.aclose()
+
+
+async def test_verify_tenant_deny_on_tenant_not_found(fake_org_id: str) -> None:
+    """verify_tenant deny on portal returning tenant_not_found reason."""
+    transport = _mock_portal(
+        status_code=403,
+        body={"verified": False, "reason": "tenant_not_found"},
+    )
+    asserter = await _build_asserter(transport)
+
+    result = await asserter.verify_tenant(
+        caller_service="portal-api",
+        claimed_org_id=fake_org_id,
+    )
+
+    assert result.verified is False
+    assert result.reason == "tenant_not_found"
+    await asserter.aclose()
+
+
+async def test_verify_tenant_fails_closed_on_5xx(fake_org_id: str) -> None:
+    """verify_tenant returns portal_unreachable on 5xx responses."""
+    transport = _mock_portal(status_code=503, body={"detail": "down"})
+    asserter = await _build_asserter(transport)
+
+    result = await asserter.verify_tenant(
+        caller_service="portal-api",
+        claimed_org_id=fake_org_id,
+    )
+
+    assert result.verified is False
+    assert result.reason == "portal_unreachable"
+    await asserter.aclose()
+
+
+async def test_verify_tenant_rejects_non_tenant_only_evidence(fake_org_id: str) -> None:
+    """verify_tenant fails closed if portal returns evidence != 'tenant_only'.
+
+    A user-bound evidence ('jwt', 'membership') on the tenant-only endpoint
+    is a contract violation — the interpreter must reject it rather than
+    silently accept it.
+    """
+    transport = _mock_portal(
+        body={
+            "verified": True,
+            "org_id": fake_org_id,
+            "org_slug": "acme",
+            "cache_ttl_seconds": 60,
+            "evidence": "membership",  # wrong evidence type for this endpoint
+        },
+    )
+    asserter = await _build_asserter(transport)
+
+    result = await asserter.verify_tenant(
+        caller_service="portal-api",
+        claimed_org_id=fake_org_id,
+    )
+
+    assert result.verified is False
+    assert result.reason == "portal_unreachable"
+    await asserter.aclose()

--- a/klai-libs/identity-assert/tests/test_models.py
+++ b/klai-libs/identity-assert/tests/test_models.py
@@ -22,9 +22,7 @@ def test_allow_factory_sets_verified_true_with_canonical_identity() -> None:
 
 
 def test_allow_factory_supports_membership_evidence() -> None:
-    result = VerifyResult.allow(
-        user_id="u-1", org_id="o-1", org_slug="acme", evidence="membership", cached=True
-    )
+    result = VerifyResult.allow(user_id="u-1", org_id="o-1", org_slug="acme", evidence="membership", cached=True)
 
     assert result.evidence == "membership"
     assert result.org_slug == "acme"

--- a/klai-libs/identity-assert/tests/test_telemetry.py
+++ b/klai-libs/identity-assert/tests/test_telemetry.py
@@ -77,3 +77,39 @@ def test_emit_call_logs_at_warning_level_with_reason_on_deny() -> None:
     assert entry["verified"] is False
     assert entry["reason"] == "no_membership"
     assert "evidence" not in entry  # only present on allow
+
+
+def test_hash_user_id_returns_sentinel_for_none() -> None:
+    """hash_user_id(None) must return the '<service>' sentinel, not crash."""
+    result = hash_user_id(None)
+    assert result == "<service>"
+
+
+def test_hash_user_id_still_works_for_real_user_id() -> None:
+    """Regression guard: real user_id still produces a 16-char hex hash."""
+    result = hash_user_id("user-123")
+    assert len(result) == 16
+    assert result != "<service>"
+
+
+def test_emit_call_with_none_user_id_emits_sentinel() -> None:
+    """emit_call with claimed_user_id=None must emit '<service>' as the hash.
+
+    This is the exact scenario that crashed production: knowledge-ingest stats
+    endpoint passed claimed_user_id=None into verify(), which then called
+    emit_call() with None, which crashed in hash_user_id(None).
+    """
+    result = VerifyResult.deny("portal_unreachable")
+
+    with capture_logs() as captured:
+        emit_call(
+            caller_service="portal-api",
+            claimed_user_id=None,
+            claimed_org_id="o-1",
+            result=result,
+            latency_ms=1.0,
+        )
+
+    assert len(captured) == 1
+    entry = captured[0]
+    assert entry["claimed_user_id_hash"] == "<service>"

--- a/klai-portal/backend/app/api/internal.py
+++ b/klai-portal/backend/app/api/internal.py
@@ -22,7 +22,7 @@ import json
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Literal
+from typing import Literal, cast
 
 import redis.asyncio as aioredis
 import structlog
@@ -1370,6 +1370,7 @@ async def verify_identity(
 
     from app.services.identity_verifier import (
         KNOWN_CALLER_SERVICES,
+        UserBoundEvidence,
         verify_identity_claim,
     )
     from app.services.identity_verify_cache import (
@@ -1487,7 +1488,9 @@ async def verify_identity(
                 org_id=cached.org_id,
                 org_slug=cached.org_slug,
                 cache_ttl_seconds=60,
-                evidence=cached.evidence,
+                # cached.evidence is UserBoundEvidence — the user-bound cache
+                # only stores "jwt" / "membership" / "partner_key" values.
+                evidence=cast("UserBoundEvidence", cached.evidence),
             ).model_dump_json(),
             status_code=status.HTTP_200_OK,
             media_type="application/json",
@@ -1573,7 +1576,249 @@ async def verify_identity(
             org_id=decision.org_id,
             org_slug=decision.org_slug,
             cache_ttl_seconds=60,
-            evidence=decision.evidence,
+            # decision.evidence is UserBoundEvidence here — verify_identity_claim
+            # only produces "jwt", "membership", or "partner_key" for the
+            # user-bound path.
+            evidence=cast("UserBoundEvidence", decision.evidence),
+        ).model_dump_json(),
+        status_code=status.HTTP_200_OK,
+        media_type="application/json",
+    )
+
+
+# ---------------------------------------------------------------------------
+# SPEC-SEC-IDENTITY-ASSERT-001 tenant-only path: /internal/identity/verify-tenant
+# ---------------------------------------------------------------------------
+#
+# Opt-in primitive for service-to-service calls that carry no end-user identity
+# (e.g. portal-api → knowledge-ingest stats endpoints). Separated from
+# /internal/identity/verify so the type system prevents a user-bound endpoint
+# from accidentally receiving a tenant-only result when claimed_user_id=None.
+# See the architecture decision in identity.py and the retro entry for the
+# 2026-05-06 crash.
+
+
+class IdentityVerifyTenantRequest(BaseModel):
+    """Request body for POST /internal/identity/verify-tenant.
+
+    Intentionally has NO ``claimed_user_id`` and NO ``bearer_jwt`` fields.
+    A tenant-only call with a JWT would be a contract violation — the JWT
+    asserts an end-user, which is precisely what this path does not have.
+    """
+
+    caller_service: str
+    claimed_org_id: str
+    claimed_org_slug: str | None = None
+
+
+class IdentityVerifyTenantSuccess(BaseModel):
+    """200 response body for the tenant-only verification endpoint.
+
+    Intentionally has NO ``user_id`` field — there is no end-user on this path.
+    """
+
+    verified: Literal[True] = True
+    org_id: str
+    org_slug: str
+    cache_ttl_seconds: int
+    evidence: Literal["tenant_only"]
+
+
+@router.post(
+    "/identity/verify-tenant",
+    response_model=None,
+)
+async def verify_tenant_identity(
+    request: Request,
+    body: IdentityVerifyTenantRequest,
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """Verify a tenant-only service-asserted identity claim.
+
+    Implements the tenant-only split from SPEC-SEC-IDENTITY-ASSERT-001. Used
+    by knowledge-ingest stats endpoints (and any future tenant-level endpoints)
+    where there is no end-user. The response body carries no ``user_id`` field.
+
+    Failure modes:
+    - ``unknown_caller_service`` → HTTP 400.
+    - ``tenant_not_found``       → HTTP 403 (org_id has no live portal_orgs row).
+    - ``org_slug_mismatch``      → HTTP 403 (REQ-2.6: slug mismatch).
+    - ``cache_unavailable``      → HTTP 503 (Redis call failed; fails closed).
+    """
+
+    from app.services.identity_verifier import (
+        KNOWN_CALLER_SERVICES,
+        verify_tenant_claim,
+    )
+    from app.services.identity_verify_cache import (
+        CacheUnavailable,
+        cache_verified_tenant_decision,
+        get_cached_tenant_decision,
+    )
+
+    await _require_internal_token(request)
+
+    if body.caller_service not in KNOWN_CALLER_SERVICES:
+        await _audit_internal_call(request, org_id=0)
+        structlog_logger.warning(
+            "identity_verify_tenant_decision",
+            caller_service=body.caller_service,
+            claimed_user_id_hash="<service>",
+            claimed_org_id=body.claimed_org_id,
+            verified=False,
+            reason="unknown_caller_service",
+        )
+        return Response(
+            content=IdentityVerifyDeny(reason="unknown_caller_service").model_dump_json(),
+            status_code=status.HTTP_400_BAD_REQUEST,
+            media_type="application/json",
+        )
+
+    redis_pool = await get_redis_pool()
+
+    if redis_pool is None:
+        await _audit_internal_call(request, org_id=0)
+        structlog_logger.warning(
+            "identity_verify_tenant_decision",
+            caller_service=body.caller_service,
+            claimed_user_id_hash="<service>",
+            claimed_org_id=body.claimed_org_id,
+            verified=False,
+            reason="cache_unavailable",
+        )
+        return Response(
+            content=IdentityVerifyDeny(reason="cache_unavailable").model_dump_json(),
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            media_type="application/json",
+        )
+
+    try:
+        cached = await get_cached_tenant_decision(
+            redis=redis_pool,
+            caller_service=body.caller_service,
+            claimed_org_id=body.claimed_org_id,
+        )
+    except CacheUnavailable:
+        await _audit_internal_call(request, org_id=0)
+        structlog_logger.warning(
+            "identity_verify_tenant_decision",
+            caller_service=body.caller_service,
+            claimed_user_id_hash="<service>",
+            claimed_org_id=body.claimed_org_id,
+            verified=False,
+            reason="cache_unavailable",
+        )
+        return Response(
+            content=IdentityVerifyDeny(reason="cache_unavailable").model_dump_json(),
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            media_type="application/json",
+        )
+
+    if cached is not None and cached.org_id is not None and cached.org_slug is not None:
+        if body.claimed_org_slug is not None and body.claimed_org_slug != cached.org_slug:
+            await _audit_internal_call(request, org_id=0)
+            structlog_logger.warning(
+                "identity_verify_tenant_decision",
+                caller_service=body.caller_service,
+                claimed_user_id_hash="<service>",
+                claimed_org_id=body.claimed_org_id,
+                verified=False,
+                reason="org_slug_mismatch",
+                cache_hit=True,
+            )
+            return Response(
+                content=IdentityVerifyDeny(reason="org_slug_mismatch").model_dump_json(),
+                status_code=status.HTTP_403_FORBIDDEN,
+                media_type="application/json",
+            )
+
+        await _audit_internal_call(request, org_id=0)
+        structlog_logger.info(
+            "identity_verify_tenant_decision",
+            caller_service=body.caller_service,
+            claimed_user_id_hash="<service>",
+            claimed_org_id=body.claimed_org_id,
+            verified=True,
+            evidence="tenant_only",
+            cache_hit=True,
+        )
+        return Response(
+            content=IdentityVerifyTenantSuccess(
+                org_id=cached.org_id,
+                org_slug=cached.org_slug,
+                cache_ttl_seconds=60,
+                evidence="tenant_only",
+            ).model_dump_json(),
+            status_code=status.HTTP_200_OK,
+            media_type="application/json",
+        )
+
+    # Cache miss: run the verifier.
+    decision = await verify_tenant_claim(
+        db=db,
+        caller_service=body.caller_service,
+        claimed_org_id=body.claimed_org_id,
+        claimed_org_slug=body.claimed_org_slug,
+    )
+
+    if not decision.verified:
+        await _audit_internal_call(request, org_id=0)
+        structlog_logger.warning(
+            "identity_verify_tenant_decision",
+            caller_service=body.caller_service,
+            claimed_user_id_hash="<service>",
+            claimed_org_id=body.claimed_org_id,
+            verified=False,
+            reason=decision.reason,
+            cache_hit=False,
+        )
+        return Response(
+            content=IdentityVerifyDeny(reason=decision.reason or "unknown").model_dump_json(),
+            status_code=status.HTTP_403_FORBIDDEN,
+            media_type="application/json",
+        )
+
+    # Verified: cache and return 200.
+    try:
+        await cache_verified_tenant_decision(
+            redis=redis_pool,
+            caller_service=body.caller_service,
+            claimed_org_id=body.claimed_org_id,
+            decision=decision,
+        )
+    except CacheUnavailable:
+        await _audit_internal_call(request, org_id=0)
+        structlog_logger.warning(
+            "identity_verify_tenant_decision",
+            caller_service=body.caller_service,
+            claimed_user_id_hash="<service>",
+            claimed_org_id=body.claimed_org_id,
+            verified=False,
+            reason="cache_unavailable",
+        )
+        return Response(
+            content=IdentityVerifyDeny(reason="cache_unavailable").model_dump_json(),
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            media_type="application/json",
+        )
+
+    await _audit_internal_call(request, org_id=0)
+    assert decision.org_id is not None and decision.org_slug is not None
+    structlog_logger.info(
+        "identity_verify_tenant_decision",
+        caller_service=body.caller_service,
+        claimed_user_id_hash="<service>",
+        claimed_org_id=body.claimed_org_id,
+        verified=True,
+        evidence="tenant_only",
+        cache_hit=False,
+    )
+    return Response(
+        content=IdentityVerifyTenantSuccess(
+            org_id=decision.org_id,
+            org_slug=decision.org_slug,
+            cache_ttl_seconds=60,
+            evidence="tenant_only",
         ).model_dump_json(),
         status_code=status.HTTP_200_OK,
         media_type="application/json",

--- a/klai-portal/backend/app/services/identity_verifier.py
+++ b/klai-portal/backend/app/services/identity_verifier.py
@@ -92,8 +92,11 @@ ReasonCode = Literal[
     # F2 fix-forward (retrieval coupling audit 2026-05-06): partner-key paths.
     "partner_key_not_found",
     "partner_key_org_mismatch",
+    # Tenant-only path: org not found in portal_orgs (no live row).
+    "tenant_not_found",
 ]
-Evidence = Literal["jwt", "membership", "partner_key"]
+UserBoundEvidence = Literal["jwt", "membership", "partner_key"]
+Evidence = Literal["jwt", "membership", "partner_key", "tenant_only"]
 
 # Synthetic identity prefix used by partner_chat for org-level RAG calls.
 # SPEC-API-001 explicitly states partners "have no concept of end users",
@@ -137,6 +140,24 @@ class VerifyDecision:
             org_slug=org_slug,
             reason=None,
             evidence=evidence,
+        )
+
+    @classmethod
+    def allow_tenant(cls, *, org_id: str, org_slug: str) -> VerifyDecision:
+        """Construct a verified tenant-only decision (no end-user identity).
+
+        Used exclusively for service-to-service calls where there is no
+        end-user (e.g. dashboard stats endpoints). The ``user_id`` field is
+        intentionally ``None``; callers MUST NOT use this on user-bound
+        endpoints — use :meth:`allow` instead.
+        """
+        return cls(
+            verified=True,
+            user_id=None,
+            org_id=org_id,
+            org_slug=org_slug,
+            reason=None,
+            evidence="tenant_only",
         )
 
 
@@ -478,3 +499,38 @@ async def _resolve_org_slug(
     )
     result = await db.execute(stmt)
     return result.scalar_one_or_none()
+
+
+async def verify_tenant_claim(
+    *,
+    db: AsyncSession,
+    caller_service: str,
+    claimed_org_id: str,
+    claimed_org_slug: str | None = None,
+) -> VerifyDecision:
+    """Resolve a tenant-only identity claim to an authoritative allow/deny decision.
+
+    No JWT and no ``claimed_user_id`` — this path is for service-to-service
+    calls where there is no end-user (e.g. portal-api → knowledge-ingest stats
+    endpoints). The function is HTTP- and cache-agnostic; the endpoint layer
+    wraps it.
+
+    Does NOT touch ``verify_identity_claim`` — the two code paths are fully
+    independent so a future caller that accidentally passes ``None`` as
+    ``claimed_user_id`` cannot silently fall through to a tenant-only result.
+    """
+
+    if caller_service not in KNOWN_CALLER_SERVICES:
+        logger.info(
+            "identity_verify_tenant_unknown_caller",
+            extra={"caller_service": caller_service},
+        )
+        return VerifyDecision.deny("unknown_caller_service")
+
+    org_slug = await _resolve_org_slug(db=db, zitadel_org_id=claimed_org_id)
+    if org_slug is None:
+        return VerifyDecision.deny("tenant_not_found")
+    if claimed_org_slug is not None and claimed_org_slug != org_slug:
+        return VerifyDecision.deny("org_slug_mismatch")
+
+    return VerifyDecision.allow_tenant(org_id=claimed_org_id, org_slug=org_slug)

--- a/klai-portal/backend/app/services/identity_verify_cache.py
+++ b/klai-portal/backend/app/services/identity_verify_cache.py
@@ -46,6 +46,11 @@ logger = logging.getLogger(__name__)
 # Distinct key namespace from other Klai Redis consumers (rate-limit, sessions).
 _KEY_PREFIX = "identity_verify:"
 
+# Separate namespace for tenant-only cache entries — no user_id slot.
+# Kept distinct from _KEY_PREFIX so a tenant entry can never collide with
+# a user-bound entry even when sharing the same (caller_service, org_id).
+_TENANT_KEY_PREFIX = "identity_verify_tenant:"
+
 # REQ-1.5: 60-second TTL. Cap at 60 — caller-side worst case for revocation
 # propagation. Lowering the TTL is allowed (faster revocation), raising is not.
 _TTL_SECONDS = 60
@@ -184,4 +189,91 @@ async def cache_verified_decision(
         await redis.set(key, payload, ex=_TTL_SECONDS)
     except RedisError as exc:
         logger.warning("identity_verify_cache_set_failed", extra={"error": str(exc)})
+        raise CacheUnavailable("redis_set_failed") from exc
+
+
+def _build_tenant_key(*, caller_service: str, claimed_org_id: str) -> str:
+    """Build a Redis key for a tenant-only cache entry.
+
+    No user_id slot — the tenant-only path has no end-user identity.
+    Kept in a separate namespace (``_TENANT_KEY_PREFIX``) so it cannot
+    collide with the user-bound key space even when caller_service and
+    claimed_org_id are identical.
+    """
+    return f"{_TENANT_KEY_PREFIX}{caller_service}:{claimed_org_id}"
+
+
+async def get_cached_tenant_decision(
+    *,
+    redis: Redis,
+    caller_service: str,
+    claimed_org_id: str,
+) -> VerifyDecision | None:
+    """Return a cached tenant-only verified decision, or ``None`` on miss.
+
+    Raises
+    ------
+    CacheUnavailable
+        On any Redis error. The endpoint MUST translate this to HTTP 503.
+    """
+    key = _build_tenant_key(caller_service=caller_service, claimed_org_id=claimed_org_id)
+    try:
+        raw: bytes | str | None = await redis.get(key)
+    except RedisError as exc:
+        logger.warning("identity_verify_tenant_cache_get_failed", extra={"error": str(exc)})
+        raise CacheUnavailable("redis_get_failed") from exc
+
+    if raw is None:
+        return None
+    payload_str = raw.decode("utf-8") if isinstance(raw, bytes) else raw
+    try:
+        payload = json.loads(payload_str)
+    except json.JSONDecodeError:
+        logger.warning("identity_verify_tenant_cache_corrupt", extra={"key": key})
+        return None
+    if not isinstance(payload, dict):
+        return None
+    org_id = payload.get("org_id")
+    org_slug = payload.get("org_slug")
+    evidence = payload.get("evidence")
+    if not isinstance(org_id, str) or not isinstance(org_slug, str):
+        return None
+    if evidence != "tenant_only":
+        return None
+    return VerifyDecision.allow_tenant(org_id=org_id, org_slug=org_slug)
+
+
+async def cache_verified_tenant_decision(
+    *,
+    redis: Redis,
+    caller_service: str,
+    claimed_org_id: str,
+    decision: VerifyDecision,
+) -> None:
+    """Cache a tenant-only verified decision. No-op for denials.
+
+    Raises
+    ------
+    CacheUnavailable
+        On any Redis error. The endpoint MUST translate this to HTTP 503.
+    """
+    if (
+        not decision.verified
+        or decision.evidence != "tenant_only"
+        or decision.org_id is None
+        or decision.org_slug is None
+    ):
+        return
+    key = _build_tenant_key(caller_service=caller_service, claimed_org_id=claimed_org_id)
+    payload = json.dumps(
+        {
+            "org_id": decision.org_id,
+            "org_slug": decision.org_slug,
+            "evidence": decision.evidence,
+        }
+    )
+    try:
+        await redis.set(key, payload, ex=_TTL_SECONDS)
+    except RedisError as exc:
+        logger.warning("identity_verify_tenant_cache_set_failed", extra={"error": str(exc)})
         raise CacheUnavailable("redis_set_failed") from exc

--- a/klai-portal/backend/tests/test_identity_verifier.py
+++ b/klai-portal/backend/tests/test_identity_verifier.py
@@ -30,6 +30,7 @@ from app.services.identity_verifier import (
     KNOWN_CALLER_SERVICES,
     VerifyDecision,
     verify_identity_claim,
+    verify_tenant_claim,
 )
 
 
@@ -703,6 +704,84 @@ class TestPartnerKeyPath:
 
         assert decision.verified is True
         assert decision.org_slug == "canonical"
+
+
+class TestVerifyTenantClaim:
+    """Tests for verify_tenant_claim — the tenant-only service-to-service path."""
+
+    async def test_allow_tenant_when_org_exists(self, mock_db: AsyncMock) -> None:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none = MagicMock(return_value="acme")
+        mock_db.execute.return_value = mock_result
+
+        decision = await verify_tenant_claim(
+            db=mock_db,
+            caller_service="portal-api",
+            claimed_org_id="o-1",
+        )
+
+        assert decision.verified is True
+        assert decision.evidence == "tenant_only"
+        assert decision.org_id == "o-1"
+        assert decision.org_slug == "acme"
+        assert decision.user_id is None
+        assert decision.reason is None
+
+    async def test_deny_tenant_not_found_when_org_missing(self, mock_db: AsyncMock) -> None:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none = MagicMock(return_value=None)
+        mock_db.execute.return_value = mock_result
+
+        decision = await verify_tenant_claim(
+            db=mock_db,
+            caller_service="portal-api",
+            claimed_org_id="o-missing",
+        )
+
+        assert decision.verified is False
+        assert decision.reason == "tenant_not_found"
+
+    async def test_deny_org_slug_mismatch_when_slug_differs(self, mock_db: AsyncMock) -> None:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none = MagicMock(return_value="acme")
+        mock_db.execute.return_value = mock_result
+
+        decision = await verify_tenant_claim(
+            db=mock_db,
+            caller_service="portal-api",
+            claimed_org_id="o-1",
+            claimed_org_slug="wrong-slug",
+        )
+
+        assert decision.verified is False
+        assert decision.reason == "org_slug_mismatch"
+
+    async def test_deny_unknown_caller_service(self, mock_db: AsyncMock) -> None:
+        decision = await verify_tenant_claim(
+            db=mock_db,
+            caller_service="unknown-service",
+            claimed_org_id="o-1",
+        )
+
+        assert decision.verified is False
+        assert decision.reason == "unknown_caller_service"
+        # No DB call should have happened — allowlist check is the first gate.
+        mock_db.execute.assert_not_called()
+
+    async def test_allow_when_org_slug_matches(self, mock_db: AsyncMock) -> None:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none = MagicMock(return_value="acme")
+        mock_db.execute.return_value = mock_result
+
+        decision = await verify_tenant_claim(
+            db=mock_db,
+            caller_service="portal-api",
+            claimed_org_id="o-1",
+            claimed_org_slug="acme",
+        )
+
+        assert decision.verified is True
+        assert decision.org_slug == "acme"
 
 
 class TestLibraryPortalSymmetry:

--- a/klai-portal/backend/tests/test_internal_identity_verify_tenant.py
+++ b/klai-portal/backend/tests/test_internal_identity_verify_tenant.py
@@ -1,0 +1,236 @@
+"""Tests for the POST /internal/identity/verify-tenant HTTP endpoint.
+
+Mirrors the style of test_internal_identity_verify.py. Each test isolates
+one decision branch by mocking DB, Redis, and the verifier service layer.
+
+Coverage:
+- 200 + evidence='tenant_only' on happy-path verification
+- 401 on invalid internal token
+- 400 + unknown_caller_service when caller not in allowlist
+- 403 + tenant_not_found when the org has no live portal_orgs row
+- 503 + cache_unavailable when Redis is not available
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import status as http_status
+
+from app.api.internal import IdentityVerifyTenantRequest, verify_tenant_identity
+
+# ---------------------------------------------------------------------------
+# Helpers — mirrors test_internal_identity_verify.py patterns exactly
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _patched_internal_settings(monkeypatch: pytest.MonkeyPatch, *, secret: str = "test-secret"):
+    from app.api import internal as internal_mod
+
+    monkeypatch.setattr(internal_mod.settings, "internal_secret", secret)
+    yield
+
+
+def _make_request(*, token: str = "test-secret", caller_ip: str = "172.18.0.5") -> MagicMock:
+    """Mock FastAPI Request that satisfies _require_internal_token + audit context."""
+    request = MagicMock()
+    headers = {"Authorization": f"Bearer {token}"}
+    request.headers = MagicMock()
+    request.headers.get = lambda key, default="": next(
+        (v for k, v in headers.items() if k.lower() == key.lower()),
+        default,
+    )
+    request.client = MagicMock()
+    request.client.host = caller_ip
+    request.method = "POST"
+
+    url = MagicMock()
+    url.path = "/internal/identity/verify-tenant"
+    request.url = url
+
+    scope: dict = {}
+    request.scope = scope
+    request.state = MagicMock()
+    return request
+
+
+def _make_redis_mock() -> AsyncMock:
+    """In-memory Redis mock supporting ``get`` and ``set`` (with ex)."""
+    store: dict[str, str] = {}
+
+    async def fake_get(key: str) -> str | None:
+        return store.get(key)
+
+    async def fake_set(key: str, value: str, ex: int | None = None) -> bool:
+        store[key] = value
+        return True
+
+    redis = AsyncMock()
+    redis.get = AsyncMock(side_effect=fake_get)
+    redis.set = AsyncMock(side_effect=fake_set)
+    redis._store = store
+    return redis
+
+
+def _allow_tenant_db_mock(slug: str = "acme") -> AsyncMock:
+    """DB mock that returns a slug from any execute() call (org exists)."""
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none = MagicMock(return_value=slug)
+    db.execute = AsyncMock(return_value=result)
+    return db
+
+
+def _missing_org_db_mock() -> AsyncMock:
+    """DB mock that returns None (org does not exist)."""
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none = MagicMock(return_value=None)
+    db.execute = AsyncMock(return_value=result)
+    return db
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyTenantHappyPath:
+    """200 response with evidence='tenant_only' when org is live."""
+
+    async def test_returns_200_with_tenant_only_evidence(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        redis = _make_redis_mock()
+        monkeypatch.setattr("app.api.internal.get_redis_pool", AsyncMock(return_value=redis))
+        monkeypatch.setattr("app.api.internal._check_rate_limit_internal", AsyncMock())
+
+        with _patched_internal_settings(monkeypatch):
+            response = await verify_tenant_identity(
+                request=_make_request(),
+                body=IdentityVerifyTenantRequest(
+                    caller_service="portal-api",
+                    claimed_org_id="o-1",
+                ),
+                db=_allow_tenant_db_mock(),
+            )
+
+        assert response.status_code == http_status.HTTP_200_OK
+        body = json.loads(response.body)
+        assert body["verified"] is True
+        assert body["evidence"] == "tenant_only"
+        assert body["org_id"] == "o-1"
+        assert body["org_slug"] == "acme"
+        # user_id must NOT appear in the tenant-only response.
+        assert "user_id" not in body
+
+    async def test_caches_verified_decision_on_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A successful verification MUST write to Redis so the next call is a cache hit."""
+        redis = _make_redis_mock()
+        monkeypatch.setattr("app.api.internal.get_redis_pool", AsyncMock(return_value=redis))
+        monkeypatch.setattr("app.api.internal._check_rate_limit_internal", AsyncMock())
+
+        with _patched_internal_settings(monkeypatch):
+            await verify_tenant_identity(
+                request=_make_request(),
+                body=IdentityVerifyTenantRequest(
+                    caller_service="portal-api",
+                    claimed_org_id="o-1",
+                ),
+                db=_allow_tenant_db_mock(),
+            )
+
+        # At least one key should have been written to the mock Redis store.
+        assert len(redis._store) >= 1
+
+
+class TestVerifyTenantInvalidToken:
+    """401 when the internal bearer token is wrong."""
+
+    async def test_returns_401_on_bad_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("app.api.internal._check_rate_limit_internal", AsyncMock())
+
+        with _patched_internal_settings(monkeypatch, secret="correct-secret"):
+            from fastapi import HTTPException
+
+            with pytest.raises(HTTPException) as exc_info:
+                await verify_tenant_identity(
+                    request=_make_request(token="wrong-secret"),
+                    body=IdentityVerifyTenantRequest(
+                        caller_service="portal-api",
+                        claimed_org_id="o-1",
+                    ),
+                    db=_allow_tenant_db_mock(),
+                )
+
+        assert exc_info.value.status_code == http_status.HTTP_401_UNAUTHORIZED
+
+
+class TestVerifyTenantUnknownCallerService:
+    """400 when caller_service is not in the allowlist."""
+
+    async def test_returns_400_for_unknown_caller(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        redis = _make_redis_mock()
+        monkeypatch.setattr("app.api.internal.get_redis_pool", AsyncMock(return_value=redis))
+        monkeypatch.setattr("app.api.internal._check_rate_limit_internal", AsyncMock())
+
+        with _patched_internal_settings(monkeypatch):
+            response = await verify_tenant_identity(
+                request=_make_request(),
+                body=IdentityVerifyTenantRequest(
+                    caller_service="rogue-service",
+                    claimed_org_id="o-1",
+                ),
+                db=_allow_tenant_db_mock(),
+            )
+
+        assert response.status_code == http_status.HTTP_400_BAD_REQUEST
+        body = json.loads(response.body)
+        assert body == {"verified": False, "reason": "unknown_caller_service"}
+
+
+class TestVerifyTenantNotFound:
+    """403 + tenant_not_found when the org has no live portal_orgs row."""
+
+    async def test_returns_403_on_missing_org(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        redis = _make_redis_mock()
+        monkeypatch.setattr("app.api.internal.get_redis_pool", AsyncMock(return_value=redis))
+        monkeypatch.setattr("app.api.internal._check_rate_limit_internal", AsyncMock())
+
+        with _patched_internal_settings(monkeypatch):
+            response = await verify_tenant_identity(
+                request=_make_request(),
+                body=IdentityVerifyTenantRequest(
+                    caller_service="portal-api",
+                    claimed_org_id="o-does-not-exist",
+                ),
+                db=_missing_org_db_mock(),
+            )
+
+        assert response.status_code == http_status.HTTP_403_FORBIDDEN
+        body = json.loads(response.body)
+        assert body == {"verified": False, "reason": "tenant_not_found"}
+
+
+class TestVerifyTenantCacheUnavailable:
+    """503 + cache_unavailable when Redis pool is not available."""
+
+    async def test_returns_503_when_redis_pool_is_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("app.api.internal.get_redis_pool", AsyncMock(return_value=None))
+        monkeypatch.setattr("app.api.internal._check_rate_limit_internal", AsyncMock())
+
+        with _patched_internal_settings(monkeypatch):
+            response = await verify_tenant_identity(
+                request=_make_request(),
+                body=IdentityVerifyTenantRequest(
+                    caller_service="portal-api",
+                    claimed_org_id="o-1",
+                ),
+                db=_allow_tenant_db_mock(),
+            )
+
+        assert response.status_code == http_status.HTTP_503_SERVICE_UNAVAILABLE
+        body = json.loads(response.body)
+        assert body == {"verified": False, "reason": "cache_unavailable"}


### PR DESCRIPTION
## Summary

- Fixes the KB overview showing **Sources: Not available** + **Relations: Not available** on production (voys.getklai.com).
- Root cause: `hash_user_id(None)` crashes in `klai-libs/identity-assert/telemetry.py` because stats endpoints in knowledge-ingest call identity-assert tenant-only (no end-user) and the lib hardcoded `claimed_user_id: str`.
- Architectural choice: instead of relaxing `verify(claimed_user_id: str)` to `str | None` (silent-downgrade risk), split tenant-only into a parallel primitive at every layer so the type system enforces opt-in discipline.

## Production stack trace

```
File "/repo/klai-knowledge-ingest/knowledge_ingest/routes/stats.py", line 56, in get_source_count
    verified_org_id = await assert_caller_identity(request, claimed_org_id=org_id)
File "/repo/klai-knowledge-ingest/knowledge_ingest/identity.py", line 67, in assert_caller_identity
    result = await _get_asserter().verify(...)
File "/repo/klai-libs/identity-assert/klai_identity_assert/client.py", line 297, in verify
    emit_call(...)
File "/repo/klai-libs/identity-assert/klai_identity_assert/telemetry.py", line 36, in hash_user_id
    return hashlib.sha256(user_id.encode("utf-8")).hexdigest()[:16]
AttributeError: 'NoneType' object has no attribute 'encode'
```

## Architecture

| Layer | User-bound (existing, unchanged) | Tenant-only (new) |
|---|---|---|
| Lib | `IdentityAsserter.verify(claimed_user_id: str, ...)` | `IdentityAsserter.verify_tenant(claimed_org_id, ...)` — no user param |
| Lib cache | `_CacheKey` (with user_id + jwt fingerprint) | `_TenantCacheKey` (caller_service + org_id) — no collision possible |
| Portal endpoint | `POST /internal/identity/verify` | `POST /internal/identity/verify-tenant` |
| Portal service | `verify_identity_claim` | `verify_tenant_claim` (no JWT/jwks args) |
| Portal Redis | `identity_verify:` namespace | `identity_verify_tenant:` namespace |
| Knowledge-ingest | `assert_caller_identity` (now strict — `claimed_user_id: str`) | `assert_caller_identity_tenant_only` |

The `UserBoundEvidence = Literal["jwt", "membership", "partner_key"]` alias on the user-bound endpoint prevents `tenant_only` from ever leaking into that response shape.

## Threat model

Tenant-only verification confirms:
- caller_service is in `KNOWN_CALLER_SERVICES` allowlist
- claimed_org_id resolves to a live (non-deleted) `portal_orgs` row
- optional `claimed_org_slug` matches the canonical slug

It does **not** verify user membership — by design, because the calling path has no end-user to bind. Per-endpoint opt-in (which helper the route calls) prevents user-bound endpoints from accidentally falling through to the weaker path. The two paths cannot mix at runtime: types differ, cache namespaces differ, HTTP endpoints differ, and the existing `verify()` signature is unchanged.

## Files changed

- `klai-libs/identity-assert/klai_identity_assert/`: `models.py`, `telemetry.py`, `cache.py`, `client.py` + 4 test files
- `klai-portal/backend/app/`: `api/internal.py`, `services/identity_verifier.py`, `services/identity_verify_cache.py` + 1 expanded test + 1 new test file
- `klai-knowledge-ingest/knowledge_ingest/`: `identity.py`, `routes/stats.py`

## Test plan

- [x] `klai-libs/identity-assert`: ruff + ruff format + pytest — 54 passed (8 new)
- [x] `klai-portal/backend`: ruff + ruff format + pyright + pytest — 40 passed
- [x] `klai-knowledge-ingest`: ruff + ruff format clean
- [ ] Post-deploy: verify KB overview at https://voys.getklai.com/app/knowledge/support/overview shows Sources count + Relations count instead of "Not available"
- [ ] Post-deploy: confirm no `stats_source_count_failed` / `stats_graph_stats_failed` in VictoriaLogs (`service:knowledge-ingest AND level:warning`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)