### PR TITLE
fix(taxonomy): show Suggest CTA in empty-state coverage widget

### DIFF
--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/taxonomy.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/taxonomy.tsx
@@ -84,10 +84,31 @@ function CoverageWidget({
   }
 
   if (coverage.nodes.length === 0) {
+    // Empty-state: KB has no taxonomy nodes yet. When chunks exist (>= 10) we
+    // surface the Suggest CTA here too — without it the user faces a catch-22:
+    // no Suggest button until nodes exist, no nodes until Suggest is clicked.
+    // Threshold mirrors the populated-coverage Suggest gate below (>= 10
+    // untagged chunks); for an empty KB every chunk counts as untagged.
     return (
-      <p className="text-sm text-[var(--color-muted-foreground)]">
-        {m.knowledge_taxonomy_coverage_empty()}
-      </p>
+      <div className="space-y-3">
+        <p className="text-sm text-[var(--color-muted-foreground)]">
+          {m.knowledge_taxonomy_coverage_empty()}
+        </p>
+        {onSuggest && total >= 10 && (
+          <button
+            type="button"
+            onClick={onSuggest}
+            disabled={isSuggesting}
+            className="inline-flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full font-medium bg-[var(--color-accent)] text-[var(--color-accent-foreground)] hover:opacity-90 transition-opacity disabled:opacity-50"
+          >
+            {isSuggesting
+              ? <Loader2 className="h-3 w-3 animate-spin" />
+              : <Sparkles className="h-3 w-3" />
+            }
+            {m.knowledge_taxonomy_suggest_categories()}
+          </button>
+        )}
+      </div>
     )
   }
 


### PR DESCRIPTION
## Summary

- Fixes a catch-22 on the KB taxonomy page: the **Suggest categories** button was hidden whenever \`coverage.nodes.length === 0\`, so empty KBs (= the ones that need it most) had no UI path to bootstrap.
- Concrete case: \`voys/support\` has 6967 indexed chunks but 0 taxonomy nodes — there is currently no in-UI way to trigger \`/taxonomy/bootstrap\` from that page.

## Change

In \`klai-portal/frontend/src/routes/app/knowledge/\$kbSlug/taxonomy.tsx\` the \`CoverageWidget\` empty-state early-return now also renders the Suggest button when \`coverage.total_chunks >= 10\`. Same threshold as the populated-coverage Suggest gate (≥ 10 untagged chunks); for an empty KB every chunk is effectively untagged.

No backend changes — \`bootstrapMutation\` and \`POST /api/app/knowledge-bases/<slug>/taxonomy/bootstrap\` already exist.

## Test plan

- [ ] Open \`/app/knowledge/<empty-kb>/taxonomy\` as KB editor — Suggest button visible
- [ ] Click → spinner → bootstrap proposals appear
- [ ] Open \`/app/knowledge/<populated-kb>/taxonomy\` — existing layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)