### PR TITLE
feat(ci): centralise Trivy CVE policy via .trivy.yaml — PR #1/3 of SPEC-CI-TRIVY-POLICY-001

### DIFF
--- a/.github/workflows/caddy.yml
+++ b/.github/workflows/caddy.yml
@@ -70,10 +70,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Trivy policy lives in .trivy.yaml at repo root (SPEC-CI-TRIVY-POLICY-001 REQ-1).
+      # PR #1 wires the config; inline `severity` + `ignore-unfixed` stay until PR #3
+      # removes them with `exit-code: '1'` + `limit-severities-for-sarif: 'true'`.
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ghcr.io/getklai/caddy-hetzner:${{ github.sha }}
+          trivy-config: .trivy.yaml
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,10 +61,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Trivy policy lives in .trivy.yaml at repo root (SPEC-CI-TRIVY-POLICY-001 REQ-1).
+      # PR #1 wires the config; inline `severity` + `ignore-unfixed` stay until PR #3
+      # removes them with `exit-code: '1'` + `limit-severities-for-sarif: 'true'`.
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          trivy-config: .trivy.yaml
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'

--- a/.github/workflows/klai-connector.yml
+++ b/.github/workflows/klai-connector.yml
@@ -141,10 +141,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Trivy policy lives in .trivy.yaml at repo root (SPEC-CI-TRIVY-POLICY-001 REQ-1).
+      # PR #1 wires the config; inline `severity` + `ignore-unfixed` stay until PR #3
+      # removes them with `exit-code: '1'` + `limit-severities-for-sarif: 'true'`.
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ghcr.io/getklai/klai-connector:${{ github.sha }}
+          trivy-config: .trivy.yaml
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'

--- a/.github/workflows/klai-knowledge-mcp.yml
+++ b/.github/workflows/klai-knowledge-mcp.yml
@@ -110,10 +110,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Trivy policy lives in .trivy.yaml at repo root (SPEC-CI-TRIVY-POLICY-001 REQ-1).
+      # PR #1 wires the config; inline `severity` + `ignore-unfixed` stay until PR #3
+      # removes them with `exit-code: '1'` + `limit-severities-for-sarif: 'true'`.
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ghcr.io/getklai/klai-knowledge-mcp:${{ github.sha }}
+          trivy-config: .trivy.yaml
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'

--- a/.github/workflows/klai-mailer.yml
+++ b/.github/workflows/klai-mailer.yml
@@ -118,10 +118,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Trivy policy lives in .trivy.yaml at repo root (SPEC-CI-TRIVY-POLICY-001 REQ-1).
+      # PR #1 wires the config; inline `severity` + `ignore-unfixed` stay until PR #3
+      # removes them with `exit-code: '1'` + `limit-severities-for-sarif: 'true'`.
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ghcr.io/getklai/klai-mailer:${{ github.sha }}
+          trivy-config: .trivy.yaml
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'

--- a/.github/workflows/knowledge-ingest.yml
+++ b/.github/workflows/knowledge-ingest.yml
@@ -114,10 +114,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Trivy policy lives in .trivy.yaml at repo root (SPEC-CI-TRIVY-POLICY-001 REQ-1).
+      # PR #1 wires the config; inline `severity` + `ignore-unfixed` stay until PR #3
+      # removes them with `exit-code: '1'` + `limit-severities-for-sarif: 'true'`.
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ghcr.io/getklai/knowledge-ingest:${{ github.sha }}
+          trivy-config: .trivy.yaml
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'

--- a/.github/workflows/portal-api.yml
+++ b/.github/workflows/portal-api.yml
@@ -298,21 +298,28 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # scanners: vuln-only — secret scanning is handled separately by
-      # Semgrep and Gitleaks against our SOURCE code. Trivy's secret scanner
-      # runs against the BUILT image and matches strings in third-party
+      # Trivy policy reference lives in .trivy.yaml at repo root
+      # (SPEC-CI-TRIVY-POLICY-001 REQ-1). PR #1 wires every workflow to it.
+      # Inline `severity` + `ignore-unfixed` stay during PR #1 to guarantee
+      # zero behaviour change. PR #3 removes them together with `exit-code: '1'`
+      # + `limit-severities-for-sarif: 'true'` (the latter neutralises the
+      # trivy-action 0.35.0 SARIF severity-filter unset).
+      #
+      # `scanners: 'vuln'` matters specifically here: Trivy's secret scanner
+      # runs against the BUILT image and matches strings inside third-party
       # Python libraries shipped under /repo/.../site-packages. yt-dlp's
-      # site-extractor modules embed dozens of public API tokens for
-      # streaming services (NBC, Vice, ESPN, Shahid, …) that consistently
-      # flag as CRITICAL aws-access-key-id / HIGH jwt-token hits — false
-      # positives that clutter the GitHub Security tab and break this job.
-      # Vulnerability scanning (the actual reason this job exists per
-      # .claude/rules/klai/infra/deploy.md) runs unchanged: severity
-      # CRITICAL+HIGH, ignore-unfixed, fail-on-find.
+      # site-extractor modules embed dozens of public API tokens
+      # (NBC, Vice, ESPN, Shahid, …) that consistently flag as CRITICAL
+      # aws-access-key-id / HIGH jwt-token — false positives that clutter
+      # the GitHub Security tab. Source-level secret scanning is covered
+      # separately by Semgrep + Gitleaks. After PR #3 this is enforced via
+      # `.trivy.yaml`'s `scan.scanners: [vuln]` for every internal workflow,
+      # not only portal-api.
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ghcr.io/getklai/portal-api:${{ github.sha }}
+          trivy-config: .trivy.yaml
           scanners: 'vuln'
           format: 'sarif'
           output: 'trivy-results.sarif'

--- a/.github/workflows/retrieval-api.yml
+++ b/.github/workflows/retrieval-api.yml
@@ -101,10 +101,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Trivy policy lives in .trivy.yaml at repo root (SPEC-CI-TRIVY-POLICY-001 REQ-1).
+      # PR #1 wires the config; inline `severity` + `ignore-unfixed` stay until PR #3
+      # removes them with `exit-code: '1'` + `limit-severities-for-sarif: 'true'`.
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ghcr.io/getklai/retrieval-api:${{ github.sha }}
+          trivy-config: .trivy.yaml
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'

--- a/.github/workflows/scan-pinned-images.yml
+++ b/.github/workflows/scan-pinned-images.yml
@@ -83,10 +83,14 @@ jobs:
           SAFE=$(echo '${{ matrix.image }}' | tr '/:' '__')
           echo "name=$SAFE" >> "$GITHUB_OUTPUT"
 
+      # Trivy policy lives in .trivy.yaml at repo root (SPEC-CI-TRIVY-POLICY-001 REQ-1).
+      # External-pin scans stay warn-only (REQ-3): Renovate handles upgrade
+      # pressure. Inline `severity` + `ignore-unfixed` stay until PR #3 cleanup.
       - name: Trivy scan
         uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ${{ matrix.image }}
+          trivy-config: .trivy.yaml
           format: 'sarif'
           output: 'trivy-${{ steps.safe.outputs.name }}.sarif'
           severity: 'CRITICAL,HIGH'

--- a/.github/workflows/scribe-api.yml
+++ b/.github/workflows/scribe-api.yml
@@ -114,10 +114,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Trivy policy lives in .trivy.yaml at repo root (SPEC-CI-TRIVY-POLICY-001 REQ-1).
+      # PR #1 wires the config; inline `severity` + `ignore-unfixed` stay until PR #3
+      # removes them with `exit-code: '1'` + `limit-severities-for-sarif: 'true'`.
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ghcr.io/getklai/scribe-api:${{ github.sha }}
+          trivy-config: .trivy.yaml
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'

--- a/.github/workflows/whisper-server.yml
+++ b/.github/workflows/whisper-server.yml
@@ -70,10 +70,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Trivy policy lives in .trivy.yaml at repo root (SPEC-CI-TRIVY-POLICY-001 REQ-1).
+      # PR #1 wires the config; inline `severity` + `ignore-unfixed` stay until PR #3
+      # removes them with `exit-code: '1'` + `limit-severities-for-sarif: 'true'`.
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ghcr.io/getklai/whisper-server:${{ github.sha }}
+          trivy-config: .trivy.yaml
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'

--- a/.moai/specs/SPEC-CI-TRIVY-POLICY-001/acceptance.md
+++ b/.moai/specs/SPEC-CI-TRIVY-POLICY-001/acceptance.md
@@ -1,0 +1,92 @@
+# Acceptance Criteria — SPEC-CI-TRIVY-POLICY-001
+
+Each scenario is `Given / When / Then`. A scenario passes when the observed CI behaviour matches the `Then` clause.
+
+## Scenario 1 — STRICT gate fires on a fresh HIGH CVE in an internal image
+
+**Given** PR #3 has merged so all 10 internal-image workflows carry `exit-code: '1'` + `limit-severities-for-sarif: 'true'` + `trivy-config: .trivy.yaml`
+**And** a developer pushes a commit to main that introduces a new dependency (or updates an existing one) carrying a HIGH-severity unfixed-vulnerability-with-fixed-version
+**When** the workflow's `scan` job runs against the freshly built image
+**Then** Trivy SHALL exit with code 1, the workflow's status check SHALL be `failure`, the deploy job SHALL not run (gated on `needs: build-push` which itself is gated on the workflow as a whole), and the SARIF SHALL upload to the GitHub Security tab containing exactly one `error`-severity finding for the new HIGH.
+
+## Scenario 2 — STRICT gate stays green when an unfixed HIGH appears with no patch upstream
+
+**Given** all 10 internal-image workflows are STRICT-tier
+**And** Trivy DB updates introduce a new HIGH for which no fix-version exists yet
+**When** the next workflow run scans the unchanged image
+**Then** because `vulnerability.ignore-unfixed: true` is set in `.trivy.yaml`, Trivy SHALL report 0 errors, the workflow SHALL stay green, and the SARIF SHALL still contain the finding for visibility (Security tab) but the SARIF severity-level for that entry SHALL be downgraded per `limit-severities-for-sarif` filter.
+
+## Scenario 3 — Documented exemption suppresses the finding
+
+**Given** `klai-portal/backend/.trivyignore.yaml` contains a valid entry for CVE-2026-6357 (id + statement + `expired_at: 2026-09-01`)
+**And** `portal-api.yml` workflow passes `trivyignores: klai-portal/backend/.trivyignore.yaml`
+**When** Trivy scans the portal-api image and detects pip 26.0.1 / CVE-2026-6357
+**Then** Trivy SHALL skip the finding from the exit-code calculation, the workflow `scan` job SHALL exit 0, and SARIF SHALL still include the CVE marked as suppressed for audit-trail purposes.
+
+## Scenario 4 — Expired exemption is no longer suppressed
+
+**Given** an entry in `klai-portal/backend/.trivyignore.yaml` with `expired_at: 2026-09-01`
+**And** the wall-clock date is 2026-09-02 or later
+**When** the next portal-api workflow run scans the image
+**Then** Trivy SHALL no longer suppress the matching CVE, the `scan` job SHALL exit 1 (assuming the CVE is still HIGH/CRITICAL and unfixed), and CI SHALL block until either the exemption is renewed (with new `expired_at`) or the dep is bumped.
+
+## Scenario 5 — Pre-merge guard rejects malformed `.trivyignore.yaml`
+
+**Given** PR #4 has landed `scripts/validate-trivyignore.sh` and wired it into pre-commit + the workflow trigger on `**/.trivyignore.yaml` paths
+**And** a developer opens a PR adding an entry like `{ id: CVE-2099-12345, paths: [...] }` (missing both `statement` and `expired_at`)
+**When** the validation guard runs
+**Then** the guard SHALL exit non-zero with stderr message naming the offending file + line + missing fields, the PR's status check SHALL be `failure`, and the merge button SHALL be disabled by branch protection.
+
+## Scenario 6 — `scan-pinned-images.yml` skips locally-built tags
+
+**Given** `deploy/docker-compose.gpu.yml` contains `image: vexaai/transcription-service:0.10.6-local-260503-0858`
+**And** PR #4 has updated the enumerate-step exclude regex to `[^:]+:.*-local-[0-9]{6}-[0-9]{4}$`
+**When** `scan-pinned-images.yml` runs (cron or compose-file change)
+**Then** the produced matrix SHALL not include `vexaai/transcription-service:0.10.6-local-260503-0858`, the workflow SHALL not attempt a `docker manifest inspect` for that image, and no UNAUTHORIZED scan-job failure SHALL appear in the run summary.
+
+## Scenario 7 — `scan-pinned-images.yml` stays warn-only on external HIGH
+
+**Given** an external image like `redis:8-alpine` carries 5 HIGH-severity unfixed-with-fix-available CVEs in the Trivy DB
+**When** `scan-pinned-images.yml` runs
+**Then** the per-image `scan` job SHALL upload SARIF, the job SHALL exit 0 (warn-only because `exit-code: '0'`), the GitHub Security tab SHALL contain the 5 findings, and the workflow SHALL not block any merge.
+
+## Scenario 8 — Single source of truth for severity policy
+
+**Given** `.trivy.yaml` is committed to repo root with `severity: [CRITICAL, HIGH]`
+**And** all 11 Trivy invocations across CI workflows pass `trivy-config: .trivy.yaml`
+**When** an audit script greps every workflow file for inline `severity:`, `ignore-unfixed:`, or `scanners:` keys
+**Then** the script SHALL find zero matches outside `.trivy.yaml` itself (REQ-1 enforcement: no per-workflow duplication of severity policy).
+
+## Scenario 9 — Whisper-server gnupg attack-surface removed
+
+**Given** PR #2's whisper-server Dockerfile change has merged (`nvidia/cuda:12.9.1-cudnn-runtime-ubuntu24.04` + `apt purge -y --auto-remove gnupg gnupg2`)
+**When** the new image is built and Trivy scans it
+**Then** Trivy SHALL NOT report any CVE in `gnupg2`, `gpg`, `gpgv`, `gpgsm`, `dirmngr`, `keyboxd`, `gnupg-utils`, `gnupg-l10n`, `gpg-agent`, `gpgconf`, `gpg-wks-server`, or `gpg-wks-client` packages, because those packages SHALL not be installed in the image. CVE-2025-68973 family count = 0.
+
+## Scenario 10 — Caddy go-deps refresh via image pin
+
+**Given** PR #2's Caddy Dockerfile change has merged (`caddy:2.11.2-builder-alpine` + `caddy:2.11.2-alpine`)
+**When** xcaddy rebuilds and Trivy scans the resulting image
+**Then** the 2 CRITICAL findings (CVE-2026-30836 in smallstep/certificates, CVE-2026-33186 in google.golang.org/grpc) SHALL be 0 because Caddy 2.11.2's `go.mod` SHALL pin patched versions; if any of the 4 HIGH findings (CVE-2026-39883 otel, CVE-2026-34986 go-jose v3, CVE-2026-34986 go-jose v4, CVE-2026-27135 nghttp2-libs) persist, they SHALL be documented in `deploy/caddy/.trivyignore.yaml` with rationale and `expired_at` ≤ 2026-08-01.
+
+## Quality gate criteria (rollup)
+
+A SPEC implementation is considered acceptable only when:
+
+1. All 10 internal-image workflows show `conclusion: success` for the latest `scan` job on `main` for at least 3 consecutive runs
+2. `gh api '/repos/getklai/klai/code-scanning/alerts?state=open&tool_name=Trivy' --jq '[.[] | select(.most_recent_instance.analysis_key | contains("scan-pinned-images") | not) | select(.rule.security_severity_level == "high" or .rule.security_severity_level == "critical")] | length'` returns 0 OR every non-zero result has a matching valid entry in some `.trivyignore.yaml`
+3. `.trivy.yaml` is the only file in the repo containing `severity: [CRITICAL, HIGH]` AND `ignore-unfixed: true` AND `scanners: [vuln]` together
+4. Smoke-test (PR #4) demonstrates a synthetic HIGH triggers exit-code 1
+5. `scan-pinned-images.yml` next run does not attempt any image with tag matching `[^:]+:.*-local-[0-9]{6}-[0-9]{4}$`
+6. `scripts/validate-trivyignore.sh` exits non-zero on a deliberately malformed entry and exits zero on a valid one
+
+## Performance criteria
+
+- Trivy scan job duration ≤ 60 seconds median per workflow (current ~10s for portal-api; flipping `exit-code` doesn't change duration)
+- Trivy DB download cached via `aquasecurity/setup-trivy@e6c2c5e3` (already in scan-pinned-images.yml; consistency for internal-image workflows is a follow-up, not blocking)
+
+## Security criteria
+
+- After PR #3, no internal `ghcr.io/getklai/*` image SHALL deploy if it contains an unfixed HIGH or CRITICAL not listed under a valid `.trivyignore.yaml` entry
+- Each `.trivyignore.yaml` entry SHALL carry rationale + expiry; no perpetual "set and forget" exemptions
+- The branch-protection rule on `main` SHALL keep the scan job as a required status check (already in place per `infra/deploy.md`); this SPEC does not weaken it

--- a/.moai/specs/SPEC-CI-TRIVY-POLICY-001/plan.md
+++ b/.moai/specs/SPEC-CI-TRIVY-POLICY-001/plan.md
@@ -1,0 +1,209 @@
+# Implementation Plan — SPEC-CI-TRIVY-POLICY-001
+
+## Strategy
+
+Three sequential PRs against `main`. Each independently revert-safe.
+
+PR #1 lays the centralised plumbing without flipping any gate. PR #2 resolves the existing 10 HIGH/CRITICAL findings across 5 services. PR #3 flips the gate atomically across all 10 internal-image workflows. Optional PR #4 finishes scan-pinned-images filter + docs + smoke-test.
+
+Worktree: `/Users/mvletter/Developer/klai-trivy-policy/` on branch `feature/SPEC-CI-TRIVY-POLICY-001` from `origin/main`.
+
+## PR #1 — Centralised config (no behaviour change)
+
+### Tasks
+
+1. Create `.trivy.yaml` at repo root:
+   ```yaml
+   # .trivy.yaml — single source of truth for klai's CVE policy
+   # Referenced by all CI Trivy invocations via `trivy-config: .trivy.yaml`
+   # Schema: https://trivy.dev/v0.69/docs/references/configuration/config-file/
+   severity:
+     - CRITICAL
+     - HIGH
+   vulnerability:
+     ignore-unfixed: true
+   scan:
+     scanners:
+       - vuln
+   ```
+2. Modify all 10 internal-image workflows: add `trivy-config: .trivy.yaml`, remove inline `severity:` / `ignore-unfixed:` / `scanners:` keys.
+3. Modify `scan-pinned-images.yml`: add `trivy-config: .trivy.yaml`, remove inline `severity:` / `ignore-unfixed:`. Keep `exit-code: '0'`.
+4. Verify each workflow's next CI run is green with same outcomes as before (still warn-only).
+
+### Quality gate
+
+- `gh run list --workflow <each>.yml --limit 3` per workflow shows green
+- portal-api remains red on its scan job (unchanged from current state) — to be fixed by PR #2
+
+### Files touched
+
+11 files: `.trivy.yaml` (new), 10 workflow modifications.
+
+### Estimated diff size
+
+~40 lines added (`.trivy.yaml` + 4 lines modified per workflow × 11).
+
+## PR #2 — Per-service findings dispositie
+
+### Tasks per service
+
+#### portal-api
+- Create `klai-portal/backend/.trivyignore.yaml`:
+  ```yaml
+  vulnerabilities:
+    - id: CVE-2026-6357
+      statement: |
+        Affects pip 26.0.1 — the CI runner image's bootstrap pip, NOT an app
+        dependency resolved by uv at runtime. uv handles all package resolution
+        post-build; the container never invokes pip after the build completes.
+        Re-evaluate when actions/runner-images ships a default pip ≥26.1.
+      expired_at: 2026-09-01
+  ```
+
+#### klai-connector
+- Bump `lxml` in `klai-connector/pyproject.toml` to a version that fixes CVE-2026-41066. Lookup latest patched lxml version at PR-creation time.
+- Re-run `klai-connector.yml` workflow against new image SHA, verify HIGH/CRIT count = 0.
+- No `.trivyignore.yaml` needed if dep-bump succeeds.
+
+#### klai-docs
+- Bump `next` in `klai-docs/package.json` to a version fixing GHSA-q4gf-8mx6-v5v3. Update `package-lock.json`.
+- Bump `picomatch` (likely transitive) by running `npm audit fix` or by adding it as direct dep with patched version.
+- Re-run `docs.yml` workflow against new image SHA, verify HIGH/CRIT count = 0.
+- No `.trivyignore.yaml` needed if dep-bumps succeed.
+
+#### caddy
+- Modify `deploy/caddy/Dockerfile`:
+  ```dockerfile
+  FROM caddy:2.11.2-builder-alpine AS builder
+
+  RUN xcaddy build \
+      --with github.com/caddy-dns/hetzner/v2 \
+      --with github.com/mholt/caddy-ratelimit
+
+  FROM caddy:2.11.2-alpine
+
+  COPY --from=builder /usr/bin/caddy /usr/bin/caddy
+
+  # SEC-018 F-029: Caddy deliberately runs as root. ...
+  ```
+- Re-run `caddy.yml` workflow, verify all 6 HIGH/CRITICAL clear (smallstep/certificates, grpc, otel, go-jose v3, go-jose v4, nghttp2-libs).
+- If residuals remain (≤2 expected for upstream stragglers), create `deploy/caddy/.trivyignore.yaml` with rationale and `expired_at: 2026-08-01`.
+
+#### whisper-server
+- Modify `klai-scribe/whisper-server/Dockerfile`:
+  ```dockerfile
+  FROM nvidia/cuda:12.9.1-cudnn-runtime-ubuntu24.04
+
+  RUN apt-get update && apt-get install -y --no-install-recommends \
+      python3 python3-pip python3-venv \
+      ffmpeg \
+      libsndfile1 \
+      && apt-get purge -y --auto-remove gnupg gnupg2 \
+      && rm -rf /var/lib/apt/lists/*
+
+  WORKDIR /app
+  ...
+  ```
+- Verify GPU smoke-test on gpu-01: `docker compose up -d whisper-server`, then transcribe a known audio file, verify output matches baseline.
+- Re-run `whisper-server.yml` workflow against new image SHA, verify all 10 HIGH alerts clear.
+- If CVE-2025-68973 family lingers (unlikely given purge), add one ignore-entry `klai-scribe/whisper-server/.trivyignore.yaml`.
+
+### Quality gate
+
+- All 5 services' next scan runs show 0 HIGH/CRITICAL OR all residuals are documented in their `.trivyignore.yaml`
+- whisper-server passes GPU smoke-test on gpu-01
+
+### Files touched
+
+~7-9 files: 4 Dockerfile / pyproject.toml / package.json modifications, 1-5 `.trivyignore.yaml` files.
+
+## PR #3 — Activate STRICT gating
+
+### Tasks
+
+For each of 10 internal-image workflows, modify the Trivy step to:
+```yaml
+- name: Run Trivy vulnerability scanner
+  uses: aquasecurity/trivy-action@0.35.0
+  with:
+    image-ref: ghcr.io/getklai/<svc>:${{ github.sha }}
+    trivy-config: .trivy.yaml
+    trivyignores: <service-relative-path>/.trivyignore.yaml  # only if file exists
+    format: 'sarif'
+    output: 'trivy-results.sarif'
+    exit-code: '1'
+    limit-severities-for-sarif: 'true'
+```
+
+Note: `trivyignores:` is only added for services that have a `.trivyignore.yaml` (portal-api, possibly caddy/whisper-server/docs depending on PR #2 outcome). Services with 0 HIGH/CRIT findings post-PR #2 don't need a `.trivyignore.yaml` and don't add the `trivyignores:` line.
+
+### Quality gate
+
+- All 10 workflows green on next push to main
+- A test PR with a synthetically introduced HIGH CVE (smoke-test, manual) gets blocked
+
+### Files touched
+
+10 workflow modifications. ~30 lines diff.
+
+### Rollback
+
+`git revert <PR#3 merge commit>` removes `exit-code: '1'` + `limit-severities-for-sarif: 'true'` everywhere; `.trivy.yaml` + ignore-files stay (no behaviour without the gate flip).
+
+## PR #4 — SKIP filter + docs + smoke-test (optional)
+
+### Tasks
+
+1. Modify `scan-pinned-images.yml` enumerate-step:
+   ```bash
+   IMAGES=$(yq eval-all '.services[].image' \
+     deploy/docker-compose.yml \
+     deploy/docker-compose.gpu.yml \
+     docker-compose.dev.yml \
+     2>/dev/null \
+     | sort -u \
+     | grep -vE '^(ghcr\.io/getklai/|ghcr\.io/mendableai/firecrawl|[^:]+:klai$|[^:]+:local$|[^:]+:.*-local-[0-9]{6}-[0-9]{4}$|---)' \
+     | grep -vE '^(null|~)$' \
+     | jq -R . | jq -sc .)
+   ```
+2. Rewrite `.claude/rules/klai/infra/deploy.md` Trivy section with three-tier model + references.
+3. Create `docs/runbooks/trivy-policy.md` with: how to add an ignore-entry, expiry-rotation cadence, smoke-test recipe.
+4. Create `scripts/validate-trivyignore.sh` (REQ-5 enforcement: rejects entries missing `id` / `statement` / `expired_at`).
+5. Wire `scripts/validate-trivyignore.sh` into pre-commit and into a CI check (lightweight, runs on any PR touching `**/.trivyignore.yaml`).
+6. Run smoke-test once: build a test image with a deliberately old base (e.g. `debian:11.4`), push to a branch, verify scan blocks merge.
+
+### Quality gate
+
+- `scan-pinned-images.yml` next run no longer attempts vexaai locally-built tags
+- `validate-trivyignore.sh` rejects a synthetic bad entry
+- Smoke-test on a test branch produces the expected red CI
+
+## Reference implementations
+
+- **EARS pattern**: `SPEC-INFRA-CONTAINER-HYGIENE-001/spec.md` — mechanical guard model (REQ-1 hooks, REQ-2 labels, REQ-5 audit). Closest analogue for "rule that blocks at commit/CI time".
+- **Per-service config files**: existing `klai-portal/backend/pyproject.toml` pip-audit ignore-list (lines 73-74 of `portal-api.yml`) shows how rationale-comments document deferred CVEs. We're upgrading from inline workflow comments to per-service `.trivyignore.yaml` with mandatory `expired_at`.
+- **Pre-commit guard pattern**: `deploy/check-image-pullable.sh` (called from pre-commit per `infra/container-hygiene.md`). `validate-trivyignore.sh` follows the same shape: shell script, fails fast, clear error message.
+- **CI uniform-pattern apply**: SPEC-INFRA-001 history shows mass-modify-workflows pattern (one PR touching 10+ workflow files with identical diff shape).
+
+## MX tag plan
+
+Workflow YAML files don't carry MX tags. The single new shell script (`scripts/validate-trivyignore.sh`) gets:
+- `@MX:NOTE` at the top: rationale for why `.trivyignore.yaml` entries require `id` + `statement` + `expired_at` (references REQ-5 of this SPEC).
+- `@MX:ANCHOR` on the validation function if it gains call-sites beyond pre-commit + CI.
+
+`.trivy.yaml` and `.trivyignore.yaml` files don't carry MX tags (declarative config).
+
+## Open questions resolved during planning
+
+- **Phase ordering**: 3 separate PRs (decided 2026-05-06 with user)
+- **Whisper-server CVE-2025-68973**: base image bump to CUDA 12.9.1 + apt purge gnupg (decided 2026-05-06 with user)
+- **Caddy 6 HIGH/CRIT**: pin caddy:2.11.2-builder-alpine + caddy:2.11.2-alpine (decided 2026-05-06 with user)
+- **Rule + runbook split**: both files (decided 2026-05-06 with user)
+- **SPEC-id**: SPEC-CI-TRIVY-POLICY-001 (decided 2026-05-06 with user)
+
+## Effort estimate (priority, not time)
+
+- PR #1: priority HIGH (unblocks everything else, low risk)
+- PR #2: priority HIGH (covers existing finding gap)
+- PR #3: priority MEDIUM (the gate flip itself; gated on PR #2 verification)
+- PR #4: priority MEDIUM (docs + smoke-test; can lag PR #3 by a few days)

--- a/.moai/specs/SPEC-CI-TRIVY-POLICY-001/spec-compact.md
+++ b/.moai/specs/SPEC-CI-TRIVY-POLICY-001/spec-compact.md
@@ -1,0 +1,74 @@
+# SPEC-CI-TRIVY-POLICY-001 — Compact reference
+
+Auto-extracted from spec.md + acceptance.md for run-phase token efficiency.
+
+## Requirements (EARS)
+
+**REQ-1** — The system SHALL define `severity: [CRITICAL, HIGH]`, `vulnerability.ignore-unfixed: true`, and `scan.scanners: [vuln]` in **one** file `.trivy.yaml` at repo root. All CI Trivy invocations SHALL reference it via `trivy-config: .trivy.yaml`. No CI workflow SHALL inline these three keys.
+
+**REQ-2** — WHEN a CI workflow scans a `ghcr.io/getklai/*` image, the Trivy step SHALL exit non-zero if Trivy reports at least one unfixed HIGH/CRITICAL not listed under an unexpired `.trivyignore.yaml` entry. The step SHALL pass `exit-code: '1'` AND `limit-severities-for-sarif: 'true'`.
+
+**REQ-3** — `scan-pinned-images.yml` SHALL pass `exit-code: '0'` (warn-only), upload SARIF to Security tab, and reference `trivy-config: .trivy.yaml`. External images SHALL never block CI.
+
+**REQ-4** — WHEN `scan-pinned-images.yml`'s enumerate-step builds the matrix, it SHALL exclude tags matching `[^:]+:.*-local-[0-9]{6}-[0-9]{4}$` per `infra/container-hygiene.md` locally-built convention.
+
+**REQ-5** — WHILE a `.trivyignore.yaml` entry exists, it SHALL contain `id`, `statement` (rationale, no boilerplate), and `expired_at` (`YYYY-MM-DD`, ≤12 months from `created`). A pre-merge guard SHALL reject PRs with entries missing one of these fields.
+
+## Acceptance scenarios (Given / When / Then)
+
+1. **STRICT gate fires on fresh HIGH** — Given STRICT-tier active; When new HIGH dep landed; Then Trivy exit 1 + workflow failure + deploy gated.
+2. **Unfixed HIGH stays green** — Given `ignore-unfixed: true` in .trivy.yaml; When upstream HIGH appears with no fix; Then 0 errors, workflow green, SARIF still uploaded.
+3. **Documented exemption suppresses** — Given valid `.trivyignore.yaml` entry; When matching CVE detected; Then exit 0, SARIF marks suppressed.
+4. **Expired exemption is no longer suppressed** — Given `expired_at` past; When workflow runs; Then suppression lifted, CI blocks.
+5. **Pre-merge guard rejects malformed entry** — Given entry missing `statement` or `expired_at`; When validate-trivyignore.sh runs; Then exit non-zero + status failure.
+6. **scan-pinned-images skips locally-built tags** — Given `vexaai/transcription-service:0.10.6-local-260503-0858` in compose; When enumerate runs; Then matrix excludes it.
+7. **scan-pinned-images stays warn-only** — Given external image with HIGH; When workflow runs; Then SARIF uploaded, exit 0, no merge block.
+8. **Single source of truth** — Given `.trivy.yaml` committed; When grep audit runs; Then 0 inline `severity:` matches outside `.trivy.yaml`.
+9. **Whisper-server gnupg removed** — Given Dockerfile bumped to `cuda:12.9.1` + apt purge gnupg; When scan runs; Then 0 CVEs in gnupg family.
+10. **Caddy go-deps refreshed via pin** — Given Dockerfile pinned to `caddy:2.11.2-*`; When xcaddy rebuilds; Then 2 CRITICAL = 0; residuals (≤4 HIGH max) documented in `.trivyignore.yaml` ≤ 2026-08-01.
+
+## Files to modify
+
+**New:**
+- `.trivy.yaml`
+- `klai-portal/backend/.trivyignore.yaml`
+- `klai-scribe/whisper-server/.trivyignore.yaml` (conditional on PR #2 outcome)
+- `deploy/caddy/.trivyignore.yaml` (conditional on PR #2 outcome)
+- `klai-docs/.trivyignore.yaml` (conditional on PR #2 outcome)
+- `scripts/validate-trivyignore.sh`
+- `docs/runbooks/trivy-policy.md`
+
+**Modified workflows (11):**
+- `.github/workflows/portal-api.yml` (PR #1 + PR #3)
+- `.github/workflows/caddy.yml` (PR #1 + PR #3)
+- `.github/workflows/whisper-server.yml` (PR #1 + PR #3)
+- `.github/workflows/knowledge-ingest.yml` (PR #1 + PR #3)
+- `.github/workflows/klai-knowledge-mcp.yml` (PR #1 + PR #3)
+- `.github/workflows/retrieval-api.yml` (PR #1 + PR #3)
+- `.github/workflows/klai-connector.yml` (PR #1 + PR #3)
+- `.github/workflows/klai-mailer.yml` (PR #1 + PR #3)
+- `.github/workflows/docs.yml` (PR #1 + PR #3)
+- `.github/workflows/scribe-api.yml` (PR #1 + PR #3)
+- `.github/workflows/scan-pinned-images.yml` (PR #1 + PR #4)
+
+**Modified Dockerfiles / pyproject.toml (PR #2):**
+- `klai-scribe/whisper-server/Dockerfile`
+- `deploy/caddy/Dockerfile`
+- `klai-connector/pyproject.toml`
+- `klai-docs/package.json` + `package-lock.json`
+
+**Modified rules:**
+- `.claude/rules/klai/infra/deploy.md` (Trivy section rewrite — PR #4)
+
+## Exclusions (out of scope)
+
+- Cosign image signing / SLSA-Level-3 attestations
+- Runtime vulnerability scanning (Falco / Trivy K8s admission webhook)
+- Multi-scanner combos (Grype, Snyk on top of Trivy)
+- pip-audit consolidation into Trivy ignore-list (separate concern)
+- Renovate `vulnerabilityAlerts: enabled: true` config (separate concern)
+- trivy-action upgrade to ≥0.36 (separate Renovate-track)
+- klai-portal/frontend npm scan via Trivy-fs (covered by frontend pipeline)
+- Pre-commit Trivy hook for local development (possible follow-up SPEC)
+- klai-mailer current CI failure (workflow file issue, not Trivy)
+- CUDA 13.x bump for whisper-server (major version risk; out of scope here)

--- a/.moai/specs/SPEC-CI-TRIVY-POLICY-001/spec.md
+++ b/.moai/specs/SPEC-CI-TRIVY-POLICY-001/spec.md
@@ -1,0 +1,195 @@
+---
+id: SPEC-CI-TRIVY-POLICY-001
+version: "0.1.0"
+status: draft
+created: "2026-05-06"
+updated: "2026-05-06"
+author: MoAI
+priority: high
+issue_number: 0
+---
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 0.1.0 | 2026-05-06 | MoAI | Initial draft. Triggered by `Build and push portal-api` workflow failing on every push to main since 2026-05-06 morning. Root cause analysis surfaced two issues: (1) `portal-api.yml :scan` step omits `exit-code: '0'` so trivy-action 0.35.0's default `1` applies, and (2) trivy-action 0.35.0 unsets `TRIVY_SEVERITY` when `format: sarif` is used without `limit-severities-for-sarif: true` — meaning the documented `severity: 'CRITICAL,HIGH'` filter has been silently disabled across all 10 internal scan jobs since the workflows were written. Result: scan jobs upload SARIF but never gate. The `infra/deploy.md` rule and the inline workflow comment in `portal-api.yml` both state the policy is "fail-on-find for CRITICAL+HIGH" — actual behaviour is fail-open across the board. SPEC fixes the policy gap by introducing a centralised `.trivy.yaml` plus per-service `.trivyignore.yaml` (with mandatory `expired_at`) and flips `exit-code: '1'` + `limit-severities-for-sarif: 'true'` on all 10 internal-image workflows simultaneously. External-pin scans stay warn-only. Locally-built tags (`*-local-YYMMDD-HHMM`) get filtered out of `scan-pinned-images.yml`. |
+
+# SPEC-CI-TRIVY-POLICY-001: Industry-standard Trivy CVE scanning policy (three-tier: STRICT / WARN / SKIP)
+
+## Overview
+
+Klai's CI Trivy scans currently behave as security theater: every internal-image workflow uploads SARIF to the GitHub Security tab but never blocks merges. Two latent bugs caused this:
+
+1. **`exit-code` defaults to `'1'`** in trivy-action 0.35.0 when not set explicitly. Nine of the ten internal-image workflows compensated by setting `exit-code: '0'` (warn-only). One — `portal-api.yml` — forgot, and on 2026-05-06 a new pip MEDIUM CVE on the runner image broke its scan job for every push to main.
+2. **The `severity: 'CRITICAL,HIGH'` filter is silently dropped** for SARIF format. trivy-action 0.35.0's entrypoint unsets `TRIVY_SEVERITY` when `format: sarif` is used without `limit-severities-for-sarif: 'true'`. Visible in CI logs as `Building SARIF report with all severities`. Consequence: even when a workflow uses `exit-code: '1'`, it would fire on MEDIUM/LOW findings — not just HIGH/CRITICAL as the policy comment claims.
+
+These two interact: the workflow that wanted to fail on HIGH/CRITICAL ended up failing on MEDIUM, and the workflows that wanted to fail on HIGH/CRITICAL ended up failing on nothing.
+
+This SPEC replaces the broken setup with three explicit tiers:
+
+- **STRICT** — every `ghcr.io/getklai/*` image we build. CI fails the build on any unfixed HIGH/CRITICAL not listed in the service's `.trivyignore.yaml`. This is what `infra/deploy.md` already promises but never delivered.
+- **WARN** — every external image we pin in compose (nginx, postgres, qdrant, …). SARIF goes to Security tab; CI never blocks. Upgrade pressure runs through Renovate. We can't fix upstream so blocking would just stall every merge.
+- **SKIP** — locally-built non-pullable tags (`vexaai/*-local-YYMMDD-HHMM` per `infra/container-hygiene.md`'s convention). No registry, no scan, no false failures.
+
+The policy lives in **one** place: `.trivy.yaml` at repo root. Documented exemptions live in **per-service** `.trivyignore.yaml` files with mandatory `expired_at` dates so no exemption survives forever without active renewal.
+
+## Three-tier scan model
+
+### STRICT tier — internal images we build
+
+Applies to: `caddy.yml`, `klai-connector.yml`, `klai-mailer.yml`, `knowledge-ingest.yml`, `klai-knowledge-mcp.yml`, `portal-api.yml`, `retrieval-api.yml`, `scribe-api.yml`, `whisper-server.yml`, `docs.yml` (10 workflows).
+
+Trivy step pattern after this SPEC:
+
+```yaml
+- name: Run Trivy vulnerability scanner
+  uses: aquasecurity/trivy-action@0.35.0
+  with:
+    image-ref: ghcr.io/getklai/<svc>:${{ github.sha }}
+    trivy-config: .trivy.yaml
+    trivyignores: <service-relative-path>/.trivyignore.yaml
+    format: 'sarif'
+    output: 'trivy-results.sarif'
+    exit-code: '1'
+    limit-severities-for-sarif: 'true'
+```
+
+The four lines that change behaviour: `trivy-config`, `trivyignores`, `exit-code: '1'`, `limit-severities-for-sarif: 'true'`. The first two share policy. The third actually gates. The fourth makes the severity filter functional.
+
+### WARN tier — external pinned images
+
+Applies to: `scan-pinned-images.yml` matrix scan against ~25 external images.
+
+Trivy step keeps `exit-code: '0'` and adds `trivy-config: .trivy.yaml` for severity-policy consistency. SARIF still uploads. This stays warn-only because we don't own those images and Renovate handles upgrade pressure on a Monday-morning cadence.
+
+### SKIP tier — locally-built non-pullable tags
+
+`scan-pinned-images.yml`'s `enumerate` step extracts every `image:` ref from `deploy/docker-compose*.yml` and `docker-compose.dev.yml`. The current exclude regex catches `:klai$` and `:local$` but not the canonical `<semver>-local-YYMMDD-HHMM` convention from `infra/container-hygiene.md` ("Verify image pullable before pinning a tag"). The 2026-04-22 run failed on `vexaai/transcription-service:0.10.6-local-260503-0858` for exactly this reason.
+
+Updated exclude regex pattern: `[^:]+:.*-local-[0-9]{6}-[0-9]{4}$`.
+
+## Requirements (EARS format)
+
+### REQ-1 — Centralised severity policy
+The system SHALL define `severity: [CRITICAL, HIGH]`, `vulnerability.ignore-unfixed: true`, and `scan.scanners: [vuln]` in **one** file `.trivy.yaml` at the repository root. All CI Trivy invocations SHALL reference this file via `trivy-config: .trivy.yaml`. No CI workflow SHALL inline these three keys.
+
+### REQ-2 — STRICT-tier gating for internal images
+WHEN a CI workflow scans a `ghcr.io/getklai/*` image, the Trivy step SHALL exit with non-zero status if Trivy reports at least one unfixed HIGH or CRITICAL vulnerability not listed under an unexpired `.trivyignore.yaml` entry. The step SHALL pass `exit-code: '1'` and `limit-severities-for-sarif: 'true'` (the latter neutralises trivy-action 0.35.0's SARIF severity-filter unset).
+
+### REQ-3 — WARN-tier preserved for external images
+`scan-pinned-images.yml` SHALL pass `exit-code: '0'` (warn-only), upload SARIF to the GitHub Security tab, and reference `trivy-config: .trivy.yaml` for severity-policy consistency. External images SHALL never block CI; upgrade pressure runs through Renovate.
+
+### REQ-4 — SKIP-tier filter for locally-built tags
+WHEN the `enumerate` job of `scan-pinned-images.yml` builds the matrix of external images, the system SHALL exclude any image tag matching `[^:]+:.*-local-[0-9]{6}-[0-9]{4}$`. The exclusion SHALL carry an inline comment referencing `infra/container-hygiene.md`'s locally-built convention.
+
+### REQ-5 — `.trivyignore.yaml` discipline (mandatory fields)
+WHILE a `.trivyignore.yaml` entry exists, it SHALL contain three required fields per entry: `id` (CVE / GHSA / rule identifier), `statement` (rationale describing why the finding is non-exploitable in this context — boilerplate "low priority" or "acceptable risk" SHALL be rejected), and `expired_at` (date in `YYYY-MM-DD` format, no more than 12 months from the entry's `created` date). A pre-merge guard script SHALL reject any PR whose `.trivyignore.yaml` files contain entries missing one of those three fields.
+
+## Affected files
+
+**New (config + initial exemptions):**
+
+- `.trivy.yaml` — root policy file (REQ-1)
+- `klai-portal/backend/.trivyignore.yaml` — initial known exemption: CVE-2026-6357 (pip 26.0.1, CI runner bootstrap, `expired_at: 2026-09-01`)
+- `klai-scribe/whisper-server/.trivyignore.yaml` — interim residual entries IF the gnupg purge doesn't fully clear CVE-2025-68973 family
+- `deploy/caddy/.trivyignore.yaml` — interim residual entries IF Caddy 2.11.2 base bump doesn't fully clear all 6 HIGH/CRITICAL findings (smallstep/certificates, grpc, otel, go-jose v3, go-jose v4, nghttp2-libs)
+- `klai-docs/.trivyignore.yaml` — interim residual entries IF Renovate-managed npm bumps for `next` and `picomatch` haven't landed yet at flip-time
+- `scripts/validate-trivyignore.sh` — pre-commit / CI guard script enforcing REQ-5
+- `docs/runbooks/trivy-policy.md` — recipe for adding entries, rotating expired ones, running smoke-test, reading Security tab
+
+**Modified workflows:**
+
+- `.github/workflows/portal-api.yml` (REQ-2: 4 args added to Trivy step)
+- `.github/workflows/caddy.yml` (REQ-2)
+- `.github/workflows/whisper-server.yml` (REQ-2)
+- `.github/workflows/knowledge-ingest.yml` (REQ-2)
+- `.github/workflows/klai-knowledge-mcp.yml` (REQ-2)
+- `.github/workflows/retrieval-api.yml` (REQ-2)
+- `.github/workflows/klai-connector.yml` (REQ-2)
+- `.github/workflows/klai-mailer.yml` (REQ-2)
+- `.github/workflows/docs.yml` (REQ-2)
+- `.github/workflows/scribe-api.yml` (REQ-2)
+- `.github/workflows/scan-pinned-images.yml` (REQ-3 + REQ-4: enumerate-step regex extension)
+
+**Modified Dockerfiles (PR #2 dep-bumps):**
+
+- `klai-scribe/whisper-server/Dockerfile` — bump `nvidia/cuda:12.6.3-cudnn-runtime-ubuntu24.04` to `nvidia/cuda:12.9.1-cudnn-runtime-ubuntu24.04`, add `apt-get purge -y --auto-remove gnupg gnupg2` to remove unused gpg attack surface
+- `deploy/caddy/Dockerfile` — pin `caddy:builder` to `caddy:2.11.2-builder-alpine` and `caddy:latest` to `caddy:2.11.2-alpine` (also resolves an existing violation of `infra/servers.md`'s "never `:latest` in production" rule)
+
+**Modified rules:**
+
+- `.claude/rules/klai/infra/deploy.md` — Trivy section rewritten with three-tier model, severity-policy reference, expiry-discipline reference, and pointers to `.trivy.yaml` + `.trivyignore.yaml`
+
+## Implementation phases (three PRs)
+
+This SPEC is delivered through three sequential PRs. Each PR is independently mergeable and revert-safe.
+
+### PR #1 — Centralised config (no behaviour change)
+
+Adds `.trivy.yaml` and modifies all 11 workflows to reference it via `trivy-config:`. Workflow `exit-code` values stay as-is (`0` everywhere except portal-api which still has the implicit `1` default that's currently failing). `severity:` and `ignore-unfixed:` are removed from per-workflow inputs (they now come from `.trivy.yaml`).
+
+Goal: prove central policy works; no gating change yet. portal-api's scan job remains red until PR #2 lands.
+
+### PR #2 — Per-service findings dispositie
+
+Five services have open HIGH/CRITICAL findings. This PR resolves them through dep-bumps where possible and documented `.trivyignore.yaml` entries where not.
+
+| Service | Finding(s) | Resolution |
+|---|---|---|
+| portal-api | CVE-2026-6357 MEDIUM (pip 26.0.1) | `klai-portal/backend/.trivyignore.yaml` with `expired_at: 2026-09-01` |
+| klai-connector | CVE-2026-41066 HIGH (lxml) | dep-bump in `pyproject.toml` |
+| klai-docs | GHSA-q4gf-8mx6-v5v3 HIGH (next), CVE-2026-33671 HIGH (picomatch) | npm bumps via `package-lock.json` updates (Renovate-style, manual here) |
+| caddy | 6 HIGH/CRITICAL across smallstep/certificates, grpc, go-jose v3+v4, otel, nghttp2-libs | Pin `caddy:2.11.2-builder-alpine` + `caddy:2.11.2-alpine` (also fixes existing `:latest` rule violation); xcaddy rebuild pulls fresh Go deps; residuals (if any) get `.trivyignore.yaml` entries |
+| whisper-server | 10 HIGH (all CVE-2025-68973 in gnupg family) | Bump base to `nvidia/cuda:12.9.1-cudnn-runtime-ubuntu24.04`; `apt purge -y --auto-remove gnupg gnupg2` to remove unused attack surface |
+
+Each finding's resolution is verified by re-running its workflow against the new image SHA. Residual findings that genuinely cannot be fixed at this time get a `.trivyignore.yaml` entry with `expired_at` set to a near-term date (≤3 months) so they bubble up for re-evaluation.
+
+### PR #3 — Activate STRICT gating
+
+Single PR that flips all 10 internal-image workflows simultaneously: `exit-code: '1'` + `limit-severities-for-sarif: 'true'` + `trivyignores: <path>` (where applicable). After this PR, REQ-2 is in force.
+
+Verification: `gh run list --workflow <each>.yml --limit 3` shows green for the latest run on main.
+
+Rollback path: single revert commit reverts the workflow changes; `.trivy.yaml` and `.trivyignore.yaml` files stay (they're harmless without `exit-code: 1`).
+
+### PR #4 — SKIP filter + docs + smoke-test (optional follow-up)
+
+Updates `scan-pinned-images.yml` enumerate-step regex (REQ-4), rewrites `infra/deploy.md` Trivy section, adds `docs/runbooks/trivy-policy.md`, and runs the smoke-test once to demonstrate the gate is real (REQ-6 informally).
+
+This PR could be folded into PR #3 for atomicity, or split for review-load reduction. Default plan: split.
+
+## Risks and mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| PR #3 breaks CI on a service whose findings weren't fully cleared by PR #2 | Medium | High | Strict separation: PR #2 must land + verify all 10 services' next scan-runs are clean (or have ignore-entry coverage) before PR #3 opens. PR #1 provides the trivy-config plumbing without flipping the gate. |
+| Trivy DB updates introduce a fresh HIGH on a base image post-flip | Medium | Medium | 80% of base-image-driven CVEs auto-bump via Renovate (pinned base images get PRs). Remainder is documented `.trivyignore.yaml` with `expired_at` ≤3 months for forced re-evaluation. |
+| Caddy 2.11.2 doesn't actually clear all 6 findings | Low | Medium | PR #2 verifies on actual scan; residuals get documented `.trivyignore.yaml` entries with rationale. Worst case: 6 entries with valid `statement` + `expired_at` ≤3 months. |
+| Whisper-server CUDA 12.9.1 bump breaks GPU inference | Low | High | Same major (12.x), patch-level CUDA bump. Smoke test on gpu-01 before merging PR #2's whisper Dockerfile change. Major-version (CUDA 13) bump explicitly out of scope. |
+| `.trivyignore.yaml` becomes copy-paste cargo cult without rationale | Medium | Medium | REQ-5 enforced mechanically by `scripts/validate-trivyignore.sh`. Entries missing `statement` or with boilerplate like "low priority" SHALL be rejected at pre-commit / CI. |
+| trivy-action ≥0.36 release changes SARIF behaviour again | Low | Medium | Action version is pinned at `0.35.0`. Renovate group keeps trivy-action upgrades behind manual approval. |
+| Branch-protection bypass via `--no-verify` push | Low | High | Branch protection on main already requires green status checks per `infra/deploy.md`. Verify before PR #3 merge. |
+
+## Out of scope (explicit)
+
+- Cosign image signing / SLSA-Level-3 attestations
+- Runtime vulnerability scanning (Falco, Trivy K8s admission webhook) — Klai runs Compose, not K8s
+- Multi-scanner combos (Grype, Snyk on top of Trivy) — diminishing returns
+- pip-audit consolidation into Trivy ignore-list — separate concern, follow-up SPEC
+- Renovate `vulnerabilityAlerts: enabled: true` auto-merge configuration — separate concern
+- trivy-action upgrade to ≥0.36 — separate Renovate-track
+- klai-portal/frontend npm scan via Trivy-fs — already covered by frontend pipeline
+- Pre-commit Trivy hook for local development — possible follow-up SPEC
+- klai-mailer current CI failure (workflow file issue, not Trivy)
+
+## References
+
+- `.claude/rules/klai/infra/deploy.md` — current Trivy rule (to be rewritten by REQ-7 doc work)
+- `.claude/rules/klai/infra/container-hygiene.md` — locally-built tag convention referenced by REQ-4
+- `.claude/rules/klai/infra/servers.md` — "never `:latest` in production" rule (Caddy fix in PR #2 also closes this gap)
+- `docs/retros/2026-05-03-vexa-transcription-tag.md` — origin of the locally-built convention
+- `aquasecurity/trivy-action@0.35.0` — entrypoint logic at `entrypoint.sh` (the `Building SARIF report with all severities` branch)
+- Trivy filtering docs — `.trivyignore.yaml` schema (top-level keys: `vulnerabilities`, `secrets`, `misconfigurations`, `licenses`; per-entry: `id`, `paths`, `purls`, `statement`, `expired_at` in `YYYY-MM-DD`)
+- Existing CI-domain SPECs: `SPEC-CI-E2E-GATE-001`, `SPEC-CI-PG-FIXTURE-001`
+- Existing INFRA-domain SPEC pattern: `SPEC-INFRA-CONTAINER-HYGIENE-001` (mechanical guards model)

--- a/.trivy.yaml
+++ b/.trivy.yaml
@@ -1,0 +1,27 @@
+# .trivy.yaml — single source of truth for klai's CVE scanning policy.
+#
+# Referenced by every CI Trivy invocation via `trivy-config: .trivy.yaml`.
+# Defined and enforced by SPEC-CI-TRIVY-POLICY-001 (REQ-1).
+#
+# Tier model (see .claude/rules/klai/infra/deploy.md):
+#   STRICT — 10 internal `ghcr.io/getklai/*` workflows. Block CI on
+#            unfixed HIGH/CRITICAL not listed in service-level
+#            `.trivyignore.yaml`. exit-code: 1, limit-severities-for-sarif: true.
+#   WARN   — `scan-pinned-images.yml` (external compose pins).
+#            exit-code: 0, SARIF only. Upgrade pressure via Renovate.
+#   SKIP   — locally-built tags `<name>:<semver>-local-YYMMDD-HHMM`
+#            (per `infra/container-hygiene.md`). Filtered out of
+#            `scan-pinned-images.yml` enumerate matrix.
+#
+# Schema reference: https://trivy.dev/v0.69/docs/references/configuration/config-file/
+
+severity:
+  - CRITICAL
+  - HIGH
+
+vulnerability:
+  ignore-unfixed: true
+
+scan:
+  scanners:
+    - vuln


### PR DESCRIPTION
## Summary

PR #1 of three for [SPEC-CI-TRIVY-POLICY-001](.moai/specs/SPEC-CI-TRIVY-POLICY-001/spec.md). Adds `.trivy.yaml` at repo root as the single source of truth for Klai's CVE scanning policy and wires all 11 CI Trivy invocations to it.

This PR is **zero-behaviour-change by design**. Inline `severity:` and `ignore-unfixed:` stay in every workflow; `exit-code` values stay as they are. After merge, every workflow does exactly what it does today, but reads `.trivy.yaml` for policy. PR #2 will resolve the existing 10 HIGH/CRITICAL findings across 5 services through dep-bumps and documented exemptions. PR #3 will remove the inline duplicates and flip `exit-code: '1'` + `limit-severities-for-sarif: 'true'` to actually activate the gate.

## Background — why we need this

The repo's documented Trivy policy says "fail on CRITICAL+HIGH" (per `.claude/rules/klai/infra/deploy.md` and a long inline comment in `portal-api.yml`). Audit on 2026-05-06 showed actual CI behaviour is fail-open across all 10 internal-image workflows because:

1. trivy-action 0.35.0's default `exit-code` is `'1'`. Nine of ten workflows compensated with explicit `exit-code: '0'`. portal-api forgot — and on 2026-05-06 a fresh pip MEDIUM CVE broke its scan job for every push to main.
2. trivy-action 0.35.0 unsets `TRIVY_SEVERITY` for `format: sarif` unless `limit-severities-for-sarif: 'true'` is set. The CI logs show `Building SARIF report with all severities` — meaning the documented `severity: 'CRITICAL,HIGH'` filter has never actually been applied. So the workflows that wanted to fail on HIGH/CRITICAL ended up failing on nothing, and the one that wanted to fail on HIGH/CRITICAL ended up failing on MEDIUM.

Three-tier model from the SPEC:

| Tier | Workflows | Behaviour after full SPEC merged |
|---|---|---|
| **STRICT** | 10 internal `ghcr.io/getklai/*` builds | `exit-code: 1` + `limit-severities-for-sarif: true` + per-service `.trivyignore.yaml` |
| **WARN** | `scan-pinned-images.yml` | `exit-code: 0`, SARIF only — Renovate handles upgrade pressure |
| **SKIP** | Locally-built tags (`*-local-YYMMDD-HHMM`) | Excluded from `scan-pinned-images.yml` matrix (PR #4) |

## What this PR changes

**New:**
- `.trivy.yaml` — root config with `severity: [CRITICAL, HIGH]`, `vulnerability.ignore-unfixed: true`, `scan.scanners: [vuln]` and a comment-block explaining the tier model

**Modified workflows (11 files, +57/-10 across them):**
- 10 internal-image workflows: each gets a 3-line comment + `trivy-config: .trivy.yaml` after `image-ref:`
- `scan-pinned-images.yml`: same pattern
- `portal-api.yml`: a slightly larger diff (-11/+18) because its inline comment about `scanners: 'vuln'` was rewritten to reflect the new SPEC reference

## What this PR does NOT change

- No `exit-code` flip — that's PR #3
- No removal of inline `severity:` / `ignore-unfixed:` — that's PR #3
- No `limit-severities-for-sarif: 'true'` — that's PR #3
- No `trivyignores: <path>` references — those land alongside PR #2's `.trivyignore.yaml` files
- No dep-bumps, no Dockerfile changes — that's PR #2
- portal-api's CI scan job stays red on CVE-2026-6357 until PR #2 — this is expected

## Verification

After merge, expect:
- Every internal-image workflow's next push-to-main run to show the same conclusion as before this PR (8 of 10 green, portal-api red on CVE-2026-6357, klai-mailer red on its existing workflow-file issue which is unrelated)
- `gh api '/repos/getklai/klai/code-scanning/alerts' --tool_name Trivy` results unchanged
- SARIF still uploads to the GitHub Security tab from each workflow

If a workflow turns red unexpectedly post-merge, that means `trivy-config: .trivy.yaml` is interacting with inline keys differently than expected — revert this single PR and we investigate.

## Rollback

`git revert <merge-sha>` reverts the workflow changes. `.trivy.yaml` stays in main but is no longer referenced — harmless.

## Related

- SPEC: `.moai/specs/SPEC-CI-TRIVY-POLICY-001/spec.md`
- Plan: `.moai/specs/SPEC-CI-TRIVY-POLICY-001/plan.md`
- Acceptance: `.moai/specs/SPEC-CI-TRIVY-POLICY-001/acceptance.md`
- Follow-up PRs: PR #2 (per-service findings dispositie), PR #3 (gate activation), PR #4 (skip filter + docs + smoke-test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)