### PR TITLE
docs(knowledge): pitfall — HDBSCAN on raw high-dim embeddings fails

### DIFF
--- a/.claude/rules/klai/projects/knowledge.md
+++ b/.claude/rules/klai/projects/knowledge.md
@@ -108,6 +108,10 @@ any row that reads from it gets processed. See
 `knowledge_ingest/adapters/crawler.py` and
 `docs/architecture/knowledge-ingest-flow.md` § Part 2.
 
+## HDBSCAN on raw high-dim embeddings fails (HIGH)
+
+Density-based clustering (HDBSCAN) on raw 1024-dim bge-m3 embeddings is unreliable in practice — the curse of dimensionality makes "density" meaningless. Empirical: V2 bootstrap on `voys/support` (501 docs) gave 2 huge clusters + 26.5% outliers instead of an expected 5-15. **Always UMAP-reduce to 5-15 dimensions before HDBSCAN** (defaults: `n_components=10`, `n_neighbors=15`, UMAP metric `cosine`, HDBSCAN metric `euclidean` post-UMAP). Synthetic test fixtures hide this — only real bge-m3 exposes it. See `reports/taxonomy-v2-baseline-2026-05-06/baseline.md` and SPEC-TAXONOMY-V2-001-FOLLOWUP-001.
+
 ## Qdrant empty-list == absent (MED)
 
 Qdrant strips empty-list payload keys (`[]`) on upsert. A page with no inbound links


### PR DESCRIPTION
## Summary

Add domain-pitfall to \`projects/knowledge.md\` based on empirical measurement of SPEC-TAXONOMY-V2-001 V2 bootstrap on \`voys/support\` (Phase A of SPEC-TAXONOMY-V2-001-FOLLOWUP-001):

- 2 clusters / 501 docs / 26.5% outliers without UMAP-pre-reduction
- Warns future agents that sklearn HDBSCAN with \`metric=\"cosine\"\` does NOT compensate on 1024-dim bge-m3
- Synthetic test fixtures hide the problem — only real-data triggers expose it

## Why this matters

PR #408 merged with 30 passing synthetic-fixture tests but produced near-useless clustering on real bge-m3 embeddings. This rule prevents the next refactor from silently dropping the UMAP step (\"sklearn HDBSCAN supports cosine metric, so we don't need UMAP\").

## Why only knowledge.md and not process-rules

The two corresponding process-rules entries (\`agent-output-without-self-review\` HIGH) are held back from this PR pending merge of SPEC-RULES-PITFALL-REORG-001 — that SPEC migrates \`pitfalls/process-rules.md\` from the current 1560-line layout to a compact 1-liner-per-rule layout. Once it lands, the entries can be slotted into the new compact structure cleanly. Adding them now would either land in the old layout (and need re-porting later) or risk overwriting the in-progress reorg (which I already accidentally did once on this branch — caught in pre-commit review and reverted).

## Test plan

- [x] Diff stat: 1 file, +4 lines (no accidental overwrites)
- [x] knowledge.md line count 289 → 293 (still over 220 cap; pre-existing, tracked in SPEC-RULES-KNOWLEDGE-CLEANUP-001)
- [ ] Phase B implementation (UMAP integration) will reference this rule for code-comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)