### PR TITLE
feat(ci): SKIP-tier filter, .trivyignore validator, runbook + rule rewrite — PR #4/4 of SPEC-CI-TRIVY-POLICY-001

### DIFF
--- a/.claude/rules/klai/infra/deploy.md
+++ b/.claude/rules/klai/infra/deploy.md
@@ -93,17 +93,39 @@ Rule `python.lang.security.audit.logging.logger-credential-leak.python-logger-cr
 Schedule: Monday 05:00 Amsterdam. Automerge: patch (any), minor (devDeps only).
 Docker images: grouped manual PR. Trigger: `gh workflow run renovate.yml`.
 
-## Trivy scanning
-Every Docker build workflow needs `scan` job after `build-push` with `security-events: write`.
+## Trivy scanning (CRIT)
 
-**Vulnerability scanning only — set `scanners: 'vuln'` on the trivy-action.**
-Built images contain third-party Python/JS libraries that embed public API
-tokens in their source files (e.g. yt-dlp's per-streaming-service extractors
-hardcode NBC, Vice, ESPN, Shahid tokens). Trivy's secret scanner classifies
-those as CRITICAL `aws-access-key-id` / HIGH `jwt-token` and breaks the scan
-job — false positives, every time. Source-level secret scanning is covered
-separately by Semgrep (`SAST — Semgrep` workflow) and Gitleaks. If a service
-ever needs a CVE allowlist, prefer a `.trivyignore` over disabling the gate.
+Defined and enforced by SPEC-CI-TRIVY-POLICY-001. Three-tier model based on
+who can fix the finding:
+
+| Tier | Workflows | Behaviour |
+|---|---|---|
+| **STRICT** | 10 internal `ghcr.io/getklai/*` builds (portal-api, caddy, whisper-server, knowledge-ingest, klai-knowledge-mcp, retrieval-api, klai-connector, klai-mailer, docs, scribe-api) | `exit-code: '1'` blocks the build on any unfixed HIGH/CRITICAL not listed in the service's `.trivyignore.yaml`. `limit-severities-for-sarif: 'true'` neutralises the trivy-action 0.35.0 quirk that otherwise unsets `TRIVY_SEVERITY` for SARIF format. |
+| **WARN** | `scan-pinned-images.yml` (external compose pins) | `exit-code: '0'` — SARIF only. We can't fix upstream, Renovate handles upgrade pressure on Monday-morning cadence. |
+| **SKIP** | Locally-built tags (`*-local-YYMMDD-HHMM` per `infra/container-hygiene.md`) | Excluded from the `scan-pinned-images.yml` enumerate matrix — they don't exist on any registry so a manifest-fetch always 404s. |
+
+**Severity policy lives in one place: `.trivy.yaml` at repo root.** Every CI Trivy invocation references it via `trivy-config: .trivy.yaml`. No workflow inlines `severity` / `ignore-unfixed` / `scanners`.
+
+**Vulnerability-scanner only.** `.trivy.yaml` sets `scan.scanners: [vuln]`. Built images contain third-party Python/JS libraries that embed public API tokens (e.g. yt-dlp's per-streaming-service extractors hardcode NBC, Vice, ESPN, Shahid tokens). Trivy's secret scanner classifies those as CRITICAL `aws-access-key-id` / HIGH `jwt-token` — false positives, every time. Source-level secret scanning is covered separately by Semgrep (`SAST — Semgrep` workflow) and Gitleaks.
+
+**Documented exemptions live in per-service `.trivyignore.yaml`.** Each entry MUST carry `id`, ≥40-char `statement` (rationale, no boilerplate like "low priority"), and `expired_at` (YYYY-MM-DD within 12 months). Mechanically enforced at commit time via `.githooks/pre-commit` and at PR time via `.github/workflows/validate-trivyignore.yml`. Implementation: `scripts/validate-trivyignore.sh` + `scripts/_validate_trivyignore.py`.
+
+**Recipes** — adding an exemption, rotating expired entries, running the smoke-test, reading the Security tab: see `docs/runbooks/trivy-policy.md`.
+
+**Adding a new internal-image workflow.** Required Trivy step:
+```yaml
+- name: Run Trivy vulnerability scanner
+  uses: aquasecurity/trivy-action@0.35.0
+  with:
+    image-ref: ghcr.io/getklai/<svc>:${{ github.sha }}
+    trivy-config: .trivy.yaml
+    trivyignores: <service-relative-path>/.trivyignore.yaml  # only if file exists
+    format: 'sarif'
+    output: 'trivy-results.sarif'
+    exit-code: '1'
+    limit-severities-for-sarif: 'true'
+```
+Plus the `Upload Trivy SARIF` step (`github/codeql-action/upload-sarif@v4`) and `permissions: security-events: write` on the scan job. The scan job MUST `needs: build-push` so it runs against the freshly built image.
 
 ## No manual server edits (CRIT)
 Never edit compose/env on server — repo is source of truth. CI overwrites on next push.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,17 +1,22 @@
 #!/bin/bash
-# Pre-commit hook — run image-tag validators when deploy compose files change.
+# Pre-commit hook — runs targeted validators based on which files are staged.
 #
 # Activate locally with: git config core.hooksPath .githooks
 #
-# Catches the PR #269 class of bug at commit time: a vexaai/* image
-# reference that is not pullable from Docker Hub and does not match a
-# locally-built convention.
+# Triggers:
+#   1. deploy/ image-tag validators — when compose files / image-tag scripts
+#      / VERSIONS.md change. Catches PR #269-class bugs (unpullable
+#      vexaai/* tags). See docs/retros/2026-05-03-vexa-transcription-tag.md.
+#   2. .trivyignore.yaml validator — when any **/.trivyignore.yaml is staged.
+#      Enforces SPEC-CI-TRIVY-POLICY-001 REQ-5 (id + ≥40-char statement
+#      + expired_at within 12 months). See docs/runbooks/trivy-policy.md.
 
 set -e
 
 CHANGED=$(git diff --cached --name-only --diff-filter=ACM)
 
-# Only run when relevant files are staged.
+# ---- Trigger 1: deploy/ image-tag validators ----
+
 if echo "$CHANGED" | grep -qE '^deploy/(docker-compose.*\.ya?ml|check-image-.*\.sh|VERSIONS\.md)$'; then
     echo "[pre-commit] deploy/ change detected — validating image tags..."
 
@@ -27,6 +32,18 @@ if echo "$CHANGED" | grep -qE '^deploy/(docker-compose.*\.ya?ml|check-image-.*\.
         else
             echo "[pre-commit] docker not available — skipping pullable check (CI will catch)."
         fi
+    fi
+fi
+
+# ---- Trigger 2: .trivyignore.yaml validator ----
+
+if echo "$CHANGED" | grep -qE '(^|/)\.trivyignore\.ya?ml$'; then
+    echo "[pre-commit] .trivyignore.yaml change detected — validating REQ-5 fields..."
+
+    if [ -x scripts/validate-trivyignore.sh ]; then
+        sh scripts/validate-trivyignore.sh
+    else
+        echo "[pre-commit] WARN: scripts/validate-trivyignore.sh not found / not executable. Skipping (CI will catch)."
     fi
 fi
 

--- a/.github/workflows/scan-pinned-images.yml
+++ b/.github/workflows/scan-pinned-images.yml
@@ -48,17 +48,24 @@ jobs:
           # internal + local builds we scan via per-service workflows.
           #
           # Excluded patterns (with rationale):
-          #   ghcr.io/getklai/*     — our own CI-built images; scanned per service
-          #   */klai                — on-server local builds (vexa-*:klai)
-          #   */local               — on-server local builds (retrieval-api:local)
-          #   mendableai/firecrawl  — built locally from source on the server
+          #   ghcr.io/getklai/*                — our own CI-built images; scanned per service
+          #   */klai                           — legacy on-server local builds (vexa-*:klai)
+          #   */local                          — legacy on-server local builds (retrieval-api:local)
+          #   *:*-local-YYMMDD-HHMM            — current convention for locally-built tags
+          #                                      per .claude/rules/klai/infra/container-hygiene.md
+          #                                      "Verify image pullable before pinning a tag" rule
+          #                                      (e.g. vexaai/transcription-service:0.10.6-local-260503-0858).
+          #                                      SKIP-tier of SPEC-CI-TRIVY-POLICY-001 REQ-4: these
+          #                                      images do not exist on Docker Hub so a `docker
+          #                                      manifest inspect` always 404s.
+          #   mendableai/firecrawl             — built locally from source on the server
           IMAGES=$(yq eval-all '.services[].image' \
             deploy/docker-compose.yml \
             deploy/docker-compose.gpu.yml \
             docker-compose.dev.yml \
             2>/dev/null \
             | sort -u \
-            | grep -vE '^(ghcr\.io/getklai/|ghcr\.io/mendableai/firecrawl|[^:]+:klai$|[^:]+:local$|---)' \
+            | grep -vE '^(ghcr\.io/getklai/|ghcr\.io/mendableai/firecrawl|[^:]+:klai$|[^:]+:local$|[^:]+:.*-local-[0-9]{6}-[0-9]{4}$|---)' \
             | grep -vE '^(null|~)$' \
             | jq -R . | jq -sc .)
 

--- a/.github/workflows/validate-trivyignore.yml
+++ b/.github/workflows/validate-trivyignore.yml
@@ -1,0 +1,57 @@
+name: Validate .trivyignore.yaml
+
+# Mechanical guard for SPEC-CI-TRIVY-POLICY-001 REQ-5: every entry in any
+# `.trivyignore.yaml` MUST carry `id`, ≥40-char `statement`, and `expired_at`
+# (YYYY-MM-DD, within 12 months). Stops perpetual / boilerplate exemptions
+# at PR-time before they reach main.
+#
+# Logic lives in scripts/validate-trivyignore.sh (mode-detected: ci here)
+# which delegates to scripts/_validate_trivyignore.py for parsing.
+#
+# Why a separate workflow: the per-service Trivy `scan` jobs only run on
+# their respective image-build workflows (path-filtered). A `.trivyignore.yaml`
+# can be added in a PR that touches *no* image-build paths (e.g. a documentation
+# PR adding a future ignore-entry), so we need an independent guard.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '**/.trivyignore.yaml'
+      - '**/.trivyignore.yml'
+      - 'scripts/validate-trivyignore.sh'
+      - 'scripts/_validate_trivyignore.py'
+      - '.github/workflows/validate-trivyignore.yml'
+  push:
+    branches: [main]
+    paths:
+      - '**/.trivyignore.yaml'
+      - '**/.trivyignore.yml'
+      - 'scripts/validate-trivyignore.sh'
+      - 'scripts/_validate_trivyignore.py'
+      - '.github/workflows/validate-trivyignore.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  validate:
+    name: Validate REQ-5 fields
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install pyyaml
+        run: pip install --no-cache-dir pyyaml
+
+      - name: Run validator
+        run: ./scripts/validate-trivyignore.sh

--- a/docs/runbooks/trivy-policy.md
+++ b/docs/runbooks/trivy-policy.md
@@ -1,0 +1,241 @@
+# Runbook — Trivy CVE policy
+
+> Operational recipes for SPEC-CI-TRIVY-POLICY-001. Policy itself lives in
+> `.claude/rules/klai/infra/deploy.md` § Trivy scanning. This runbook is the
+> "how do I do X" companion.
+
+## Quick reference
+
+| Question | Answer |
+|---|---|
+| Where is severity policy defined? | `.trivy.yaml` at repo root |
+| Where do exemptions live? | `<service>/.trivyignore.yaml` (e.g. `klai-portal/backend/.trivyignore.yaml`) |
+| Who blocks me at commit time? | `.githooks/pre-commit` (after `git config core.hooksPath .githooks`) |
+| Who blocks me at PR time? | `.github/workflows/validate-trivyignore.yml` |
+| Who blocks me at scan time? | `<service>.yml` workflow's `scan` job (STRICT-tier, exit-code 1) |
+
+---
+
+## Recipe 1 — A new HIGH/CRITICAL CVE breaks my service's CI
+
+### 1.1 Identify the finding
+
+After CI failure on a `Build and push <service>` workflow `scan` job:
+
+1. Open the failed run on GitHub Actions
+2. Open the Security tab → Code scanning → filter by `analysis_key = .github/workflows/<service>.yml:scan`
+3. Note: `id` (CVE / GHSA), `severity`, `package name`, and **fixed_version**
+
+### 1.2 Decide: dep-bump or exemption
+
+**Default to dep-bump.** Exemptions are friction by design — every entry needs rationale and expiry.
+
+| Situation | Action |
+|---|---|
+| Fix-version exists in your dep tree | Bump the dep. For Python: `uv lock --upgrade-package <pkg>`. For Node: `npm update <pkg>` or bump in `package.json`. |
+| Fix-version exists upstream but blocked by transitive | Try `npm-force-resolutions` / npm `overrides` / uv `[tool.uv.sources]` constraint |
+| No fix-version yet (`ignore-unfixed: true` already filters these — but if it surfaces) | This is a Trivy DB lag; usually self-resolves within 24h. Re-run the workflow before doing anything. |
+| Fix-version exists but exploiting requires conditions our deployment does not have | Document as exemption (recipe 2) |
+
+### 1.3 If bumping: verify the bump cleared everything
+
+After the dep-bump commit, push and watch the same workflow:
+
+```bash
+gh run watch $(gh run list --workflow <service>.yml --limit 1 --json databaseId --jq '.[0].databaseId')
+```
+
+Re-check the Security tab — the alert should move to `state: fixed`.
+
+---
+
+## Recipe 2 — Add a documented exemption
+
+Use this when a HIGH/CRITICAL is genuinely non-exploitable in our deployment context AND a dep-bump is not possible.
+
+### 2.1 Create or edit the service's `.trivyignore.yaml`
+
+Path convention: `<service-source-root>/.trivyignore.yaml`. Examples:
+- `klai-portal/backend/.trivyignore.yaml`
+- `klai-connector/.trivyignore.yaml`
+- `klai-scribe/whisper-server/.trivyignore.yaml`
+- `deploy/caddy/.trivyignore.yaml`
+- `klai-docs/.trivyignore.yaml`
+
+Required schema:
+
+```yaml
+vulnerabilities:
+  - id: CVE-XXXX-NNNNN
+    statement: |
+      Concrete rationale ≥40 chars. Describe WHY this finding is non-
+      exploitable in our deployment. State the attack vector and explain
+      why it does not apply (e.g. "binary is unused at runtime", "user
+      input never reaches this code path", "library is sandboxed").
+      Boilerplate like "low priority" or "acceptable risk" is rejected
+      mechanically — be specific.
+    expired_at: 2026-09-01    # YYYY-MM-DD, max 12 months from today
+    purls:                    # optional, lets Trivy match the right package version
+      - "pkg:pypi/<pkg>@<version>"
+```
+
+Other valid sections (same per-entry rules): `secrets`, `misconfigurations`, `licenses`.
+
+### 2.2 Reference the file from the workflow
+
+If this is the first `.trivyignore.yaml` for the service, also add to the workflow's Trivy step:
+
+```yaml
+trivyignores: <path>/.trivyignore.yaml
+```
+
+### 2.3 Commit + verify
+
+`.githooks/pre-commit` runs `scripts/validate-trivyignore.sh` automatically and rejects entries that don't carry the required fields. Same script runs in CI on `pull_request` via `validate-trivyignore.yml`.
+
+To validate manually before committing:
+
+```sh
+./scripts/validate-trivyignore.sh klai-portal/backend/.trivyignore.yaml
+```
+
+Expected output: `[validate-trivyignore] <path>: <N> entries OK`.
+
+---
+
+## Recipe 3 — Rotate expired entries
+
+The `expired_at` field exists to force re-evaluation. Once the date passes, the next workflow run treats the CVE as un-suppressed and CI goes red.
+
+### 3.1 Find soon-expiring entries
+
+```sh
+# Lists every entry with expired_at within the next 30 days.
+find . -name '.trivyignore.yaml' \
+       -not -path './.git/*' -not -path './node_modules/*' -not -path './.venv/*' \
+  | while read f; do
+      python3 -c "
+import yaml, sys, datetime
+d = yaml.safe_load(open('$f')) or {}
+for sec in ('vulnerabilities', 'secrets', 'misconfigurations', 'licenses'):
+    for e in d.get(sec, []) or []:
+        exp = e.get('expired_at')
+        if exp:
+            exp_d = datetime.date.fromisoformat(str(exp))
+            days = (exp_d - datetime.date.today()).days
+            if days < 30:
+                print(f'$f :: {sec} :: {e[\"id\"]} :: {days} days left')
+"
+    done
+```
+
+### 3.2 For each soon-expiring entry, decide
+
+- **Fix landed upstream?** → dep-bump (recipe 1.2/1.3) and remove the entry
+- **Still un-fixable?** → renew with new `expired_at` (still ≤12 months) and update the `statement` to reflect why it remains un-exploitable
+- **Was added in error?** → remove the entry; let CI block, then dep-bump
+
+Never bulk-renew without re-evaluation. The friction is the feature.
+
+---
+
+## Recipe 4 — Run the smoke-test (proves the gate actually gates)
+
+Periodically you want proof that STRICT-tier really blocks. Recommended cadence: once after any change to `.trivy.yaml` or the workflow Trivy step pattern.
+
+### 4.1 Synthetic-CVE smoke-test
+
+```sh
+# Create throwaway branch
+git checkout -b smoke/trivy-gate-test main
+
+# Add a Dockerfile with a deliberately ancient base in any internal-image
+# workflow's source tree. Example: append to klai-portal/backend/Dockerfile
+# (you'll revert after the test).
+#
+# Use a base that Trivy DB definitely flags HIGH/CRITICAL on, e.g.:
+#   FROM debian:11.4-slim AS smoke-test-base
+#   RUN apt-get update && apt-get install -y --no-install-recommends openssl=1.1.1n-0+deb11u3 \
+#       && rm -rf /var/lib/apt/lists/*
+# (The pinned openssl version has known HIGH CVEs.)
+
+git add klai-portal/backend/Dockerfile
+git commit -m "smoke: synthetic HIGH CVE for Trivy gate verification — DO NOT MERGE"
+git push -u origin smoke/trivy-gate-test
+gh pr create --base main --draft --title "[SMOKE] Trivy gate verification" --body "Verifies SPEC-CI-TRIVY-POLICY-001 STRICT-tier blocks HIGH/CRITICAL. Auto-close after verification."
+```
+
+Expected outcome on the PR's `Build and push portal-api` workflow:
+- `quality` job: SUCCESS
+- `build-push` job: SUCCESS (image builds fine)
+- `scan` job: **FAILURE** with exit-code 1 and SARIF showing the HIGH
+
+If `scan` returns SUCCESS: the gate is broken. Investigate `trivy-config:` plumbing, `limit-severities-for-sarif:`, or `exit-code:` settings in the workflow. Do NOT merge anything until the gate is fixed.
+
+### 4.2 Cleanup
+
+Close the PR without merging. Delete the smoke branch:
+
+```sh
+gh pr close <PR-number>
+git checkout main
+git branch -D smoke/trivy-gate-test
+git push origin --delete smoke/trivy-gate-test
+```
+
+---
+
+## Recipe 5 — A new internal service needs a Trivy scan job
+
+When adding `.github/workflows/<new-svc>.yml`:
+
+1. Copy the scan-job pattern from any existing internal workflow (e.g. `knowledge-ingest.yml`)
+2. Required step config:
+   ```yaml
+   - name: Run Trivy vulnerability scanner
+     uses: aquasecurity/trivy-action@0.35.0
+     with:
+       image-ref: ghcr.io/getklai/<new-svc>:${{ github.sha }}
+       trivy-config: .trivy.yaml
+       format: 'sarif'
+       output: 'trivy-results.sarif'
+       exit-code: '1'
+       limit-severities-for-sarif: 'true'
+   - name: Upload Trivy SARIF to GitHub Security tab
+     uses: github/codeql-action/upload-sarif@v4
+     if: always()
+     with:
+       sarif_file: 'trivy-results.sarif'
+   ```
+3. Job-level `permissions: security-events: write` and `needs: build-push`
+4. Push and verify the first run goes green (or red with documented findings → recipe 1 or 2)
+
+If the new image has open HIGH/CRITICAL findings on first scan: do not weaken the workflow. Add a `<svc>/.trivyignore.yaml` per recipe 2 with each finding rationalised and an `expired_at` date.
+
+---
+
+## Recipe 6 — A pinned external image (compose) introduces HIGH/CRITICAL
+
+External images go through `scan-pinned-images.yml` (WARN-tier — never blocks CI). Surfaced via Security tab.
+
+1. Wait for next Renovate Monday cycle — most external base-images are auto-bumped
+2. If urgent (active exploit in the wild): manual bump in `deploy/docker-compose*.yml`, then `gh workflow run scan-pinned-images.yml --ref main` to re-scan
+3. If image is locally-built (e.g. `vexaai/transcription-service:0.10.6-local-260503-0858`): not scannable — already filtered by SKIP-tier regex in `scan-pinned-images.yml` enumerate-step
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| pre-commit hook does nothing | Run `git config core.hooksPath .githooks` once per clone |
+| `validate-trivyignore.yml` fails with "yaml module not available" | Workflow's `setup-python` step missing or `pip install pyyaml` failed — check workflow logs |
+| Scan job is SUCCESS but the Security tab shows the CVE | This is correct behaviour — `ignore-unfixed: true` filters CVEs without fix-version from gating but still uploads them to SARIF for visibility |
+| Scan job is SUCCESS for a CVE you expected to fail | Check `.trivyignore.yaml` doesn't have a stale matching entry; verify `trivy-config: .trivy.yaml` is set on the workflow's Trivy step |
+| `[^:]+:.*-local-[0-9]{6}-[0-9]{4}$` regex doesn't match my locally-built image | Tag must match the `infra/container-hygiene.md` convention exactly; legacy `<semver>-YYMMDD-HHMM` (no `-local-` infix) is NOT excluded by this regex |
+
+## See also
+
+- `.claude/rules/klai/infra/deploy.md` — § Trivy scanning (the rule)
+- `.claude/rules/klai/infra/container-hygiene.md` — locally-built tag convention
+- `.moai/specs/SPEC-CI-TRIVY-POLICY-001/` — original SPEC, plan, acceptance scenarios

--- a/scripts/_validate_trivyignore.py
+++ b/scripts/_validate_trivyignore.py
@@ -1,0 +1,178 @@
+"""Validate a single .trivyignore.yaml file per SPEC-CI-TRIVY-POLICY-001 REQ-5.
+
+Called by scripts/validate-trivyignore.sh. Not intended for direct use.
+
+Required per entry:
+  - id          (string, non-empty)
+  - statement   (string, ≥40 chars to prevent boilerplate)
+  - expired_at  (YYYY-MM-DD, future, ≤365 days)
+
+Sections checked: vulnerabilities, secrets, misconfigurations, licenses.
+
+Usage:
+    python3 _validate_trivyignore.py <path-to-yaml> <today YYYY-MM-DD> \
+            <max-future-days> <min-statement-len>
+
+Reads YAML content from stdin (lets the shell wrapper pass either staged
+content via `git show :path` or the working-tree file). Writes
+::error annotations to stderr (GitHub-Actions-aware) on violations.
+
+Exit codes:
+    0  all entries valid (or no entries)
+    1  one or more violations
+    2  fatal (missing yaml module, malformed YAML, bad invocation)
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import date, timedelta
+
+try:
+    import yaml
+except ImportError:
+    print(
+        "[validate-trivyignore] FATAL: python3 yaml module not available. "
+        "Install with `pip install pyyaml` or `uv pip install pyyaml`.",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+def main() -> int:
+    if len(sys.argv) != 5:
+        print(
+            "Usage: _validate_trivyignore.py <path> <today YYYY-MM-DD> "
+            "<max-future-days> <min-statement-len>",
+            file=sys.stderr,
+        )
+        return 2
+
+    path = sys.argv[1]
+    today = date.fromisoformat(sys.argv[2])
+    max_future_days = int(sys.argv[3])
+    min_statement_len = int(sys.argv[4])
+
+    raw = sys.stdin.read()
+    if not raw.strip():
+        print(f"[validate-trivyignore] {path}: empty file — skipping.")
+        return 0
+
+    try:
+        data = yaml.safe_load(raw) or {}
+    except yaml.YAMLError as exc:
+        print(f"::error file={path}::malformed YAML: {exc}", file=sys.stderr)
+        return 1
+
+    if not isinstance(data, dict):
+        print(
+            f"::error file={path}::top-level must be a YAML mapping (got "
+            f"{type(data).__name__})",
+            file=sys.stderr,
+        )
+        return 1
+
+    violations: list[tuple[str, int | None, str]] = []
+    sections = ("vulnerabilities", "secrets", "misconfigurations", "licenses")
+    total_entries = 0
+
+    for section in sections:
+        entries = data.get(section)
+        if entries is None:
+            continue
+        if not isinstance(entries, list):
+            violations.append((section, None, f"`{section}` must be a list"))
+            continue
+
+        for idx, entry in enumerate(entries):
+            total_entries += 1
+            if not isinstance(entry, dict):
+                violations.append((section, idx, "entry must be a mapping"))
+                continue
+
+            # id
+            entry_id = entry.get("id")
+            if not entry_id or not isinstance(entry_id, str):
+                violations.append(
+                    (section, idx, "missing or empty `id` (CVE / GHSA / rule identifier)"),
+                )
+
+            # statement
+            statement = entry.get("statement")
+            if not isinstance(statement, str) or len(statement.strip()) < min_statement_len:
+                got_len = len(statement.strip()) if isinstance(statement, str) else 0
+                violations.append(
+                    (
+                        section,
+                        idx,
+                        f"missing or too-short `statement` (need ≥{min_statement_len} chars; "
+                        f"got {got_len}). Boilerplate like 'low priority' / 'acceptable risk' "
+                        "is rejected by design — describe WHY this finding is non-exploitable "
+                        "in our deployment context.",
+                    ),
+                )
+
+            # expired_at
+            expired_at = entry.get("expired_at")
+            if expired_at is None:
+                violations.append((section, idx, "missing `expired_at` (YYYY-MM-DD)"))
+            else:
+                # PyYAML auto-parses YYYY-MM-DD → date.
+                if isinstance(expired_at, date):
+                    exp_date = expired_at
+                elif isinstance(expired_at, str):
+                    try:
+                        exp_date = date.fromisoformat(expired_at)
+                    except ValueError:
+                        violations.append(
+                            (
+                                section,
+                                idx,
+                                f"`expired_at` must be ISO date (YYYY-MM-DD), got: "
+                                f"{expired_at!r}",
+                            ),
+                        )
+                        continue
+                else:
+                    violations.append(
+                        (
+                            section,
+                            idx,
+                            f"`expired_at` must be ISO date or string, got "
+                            f"{type(expired_at).__name__}",
+                        ),
+                    )
+                    continue
+
+                if exp_date <= today:
+                    violations.append(
+                        (
+                            section,
+                            idx,
+                            f"`expired_at: {exp_date}` is in the past — entry is no "
+                            "longer valid. Renew with new `expired_at` or remove.",
+                        ),
+                    )
+                elif exp_date > today + timedelta(days=max_future_days):
+                    violations.append(
+                        (
+                            section,
+                            idx,
+                            f"`expired_at: {exp_date}` is more than {max_future_days} days "
+                            "in the future — keep within 12 months for the SPEC's "
+                            "re-evaluation cadence.",
+                        ),
+                    )
+
+    if violations:
+        for section, idx, msg in violations:
+            loc = f"{section}[{idx}]" if idx is not None else section
+            print(f"::error file={path}::{loc}: {msg}", file=sys.stderr)
+        return 1
+
+    print(f"[validate-trivyignore] {path}: {total_entries} entries OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate-trivyignore.sh
+++ b/scripts/validate-trivyignore.sh
@@ -1,0 +1,115 @@
+#!/bin/sh
+# Forcing function — fail loud at commit / CI time when a `.trivyignore.yaml`
+# entry omits required fields per SPEC-CI-TRIVY-POLICY-001 REQ-5.
+#
+# Why this exists: a Trivy ignore-list without rationale + expiry is just a
+# silent allowlist. Industry-standard CVE management requires every exemption
+# to carry both WHY (statement) and UNTIL WHEN (expired_at) so it bubbles
+# back into the review queue on a known cadence.
+#
+# Validation logic lives in scripts/_validate_trivyignore.py for readability;
+# this shell wrapper handles file discovery and mode detection.
+#
+# Modes (auto-detected):
+#   - ci          : $GITHUB_ACTIONS=true → validate every .trivyignore.yaml
+#                   in the working tree (GitHub Actions runs after checkout)
+#   - pre-commit  : invoked from .githooks/pre-commit → validate only the
+#                   files currently staged, reading their staged content
+#                   via `git show :<path>`
+#   - manual      : developer runs the script directly with paths as args
+
+set -eu
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+PY="$REPO_ROOT/scripts/_validate_trivyignore.py"
+
+if [ ! -f "$PY" ]; then
+    echo "[validate-trivyignore] FATAL: $PY not found." >&2
+    exit 2
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "[validate-trivyignore] FATAL: python3 not available." >&2
+    exit 2
+fi
+
+# ---- Resolve mode + file list ----
+
+MODE="manual"
+if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+    MODE="ci"
+elif [ -n "${GIT_INDEX_FILE:-}" ] || git rev-parse --git-dir >/dev/null 2>&1 \
+     && git diff --cached --name-only --diff-filter=ACM 2>/dev/null \
+        | grep -qE '(^|/)\.trivyignore\.ya?ml$'; then
+    MODE="pre-commit"
+fi
+
+FILES=""
+case "$MODE" in
+    pre-commit)
+        FILES=$(git diff --cached --name-only --diff-filter=ACM \
+                | grep -E '(^|/)\.trivyignore\.ya?ml$' || true)
+        ;;
+    ci)
+        FILES=$(find . -name '.trivyignore.yaml' \
+                  -not -path './.venv/*' \
+                  -not -path './node_modules/*' \
+                  -not -path './*/node_modules/*' \
+                  -not -path './*/.venv/*' \
+                  -not -path './.git/*' 2>/dev/null \
+                | sed 's|^\./||' || true)
+        ;;
+    manual)
+        if [ "$#" -gt 0 ]; then
+            FILES="$*"
+        else
+            echo "Usage: $0 <path/to/.trivyignore.yaml> [...]" >&2
+            exit 2
+        fi
+        ;;
+esac
+
+if [ -z "$FILES" ]; then
+    echo "[validate-trivyignore] no .trivyignore.yaml files to validate — pass."
+    exit 0
+fi
+
+# ---- Per-file validation ----
+
+TODAY=$(date -u +%Y-%m-%d)
+MAX_FUTURE_DAYS=365
+MIN_STATEMENT_LEN=40
+
+FAIL=0
+
+for F in $FILES; do
+    if [ "$MODE" = "pre-commit" ]; then
+        # Staged content — may differ from working tree.
+        if ! CONTENT=$(git show ":$F" 2>/dev/null); then
+            echo "[validate-trivyignore] WARN: could not read staged content of $F — skipping."
+            continue
+        fi
+    else
+        if [ ! -f "$F" ]; then
+            echo "[validate-trivyignore] WARN: $F not found — skipping."
+            continue
+        fi
+        CONTENT=$(cat "$F")
+    fi
+
+    if ! printf '%s' "$CONTENT" | python3 "$PY" "$F" "$TODAY" "$MAX_FUTURE_DAYS" "$MIN_STATEMENT_LEN"; then
+        FAIL=1
+    fi
+done
+
+if [ "$FAIL" = "1" ]; then
+    echo "" >&2
+    echo "[validate-trivyignore] one or more .trivyignore.yaml files failed validation." >&2
+    echo "Required per SPEC-CI-TRIVY-POLICY-001 REQ-5:" >&2
+    echo "  - id           (CVE / GHSA / rule identifier)" >&2
+    echo "  - statement    (≥${MIN_STATEMENT_LEN} chars rationale, no boilerplate)" >&2
+    echo "  - expired_at   (YYYY-MM-DD, future, ≤${MAX_FUTURE_DAYS} days)" >&2
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Final PR of [SPEC-CI-TRIVY-POLICY-001](https://github.com/GetKlai/klai/blob/main/.moai/specs/SPEC-CI-TRIVY-POLICY-001/spec.md). Independent of PR #3 (gate-flip) — they touch different files, either can merge first.

Four pieces:

1. **SKIP-tier filter (REQ-4)** — `scan-pinned-images.yml` enumerate-step regex extension excludes `<name>:<semver>-local-YYMMDD-HHMM` tags from the scan matrix. Concretely: `vexaai/transcription-service:0.10.6-local-260503-0858` no longer triggers a 404 manifest fetch. Confirmed via local regex testing.

2. **REQ-5 validator** — `scripts/validate-trivyignore.sh` + `scripts/_validate_trivyignore.py` enforces `id` + ≥40-char `statement` + `expired_at` (within 12 months) on every `.trivyignore.yaml` entry. Wired into `.githooks/pre-commit` (commit-time) and `.github/workflows/validate-trivyignore.yml` (PR-time). Smoke-tested against 5 cases — 1 valid, 4 invalid each producing specific error messages.

3. **Runbook (`docs/runbooks/trivy-policy.md`)** — recipe-level companion to the rule. Covers: adding exemptions, dep-bump vs exemption decision tree, rotating expired entries, synthetic-CVE smoke-test, adding a new internal-image workflow, troubleshooting.

4. **Rule rewrite (`infra/deploy.md` § Trivy scanning)** — replaces the previous 12-line section with a three-tier table and pointers to all the new pieces.

## What this PR does NOT change

- No workflow flip (no `exit-code: '1'` / `limit-severities-for-sarif: 'true'`) — that's PR #3
- No service Dockerfile or dep changes — those are in PR #2 (#411, merged)
- No new `.trivyignore.yaml` exemptions — only the validator. Adding new exemptions is a separate workflow per recipe in the runbook.

## Verification

After merge, expect:
- Next `scan-pinned-images.yml` run (Monday 07:00 cron, or manual `gh workflow run scan-pinned-images.yml`) to skip `vexaai/transcription-service:0.10.6-local-260503-0858` from the matrix
- Any future PR adding a `.trivyignore.yaml` entry without `id` / `statement≥40` / `expired_at≤12mo` to fail the `Validate .trivyignore.yaml` status check
- Local commits adding `.trivyignore.yaml` to fail at pre-commit (after `git config core.hooksPath .githooks`)

## Smoke-test of the validator

The `scripts/validate-trivyignore.sh` smoke-test was run locally before commit — see commit message for the 5 cases. Reproducible:

```sh
./scripts/validate-trivyignore.sh klai-portal/backend/.trivyignore.yaml
# → [validate-trivyignore] klai-portal/backend/.trivyignore.yaml: 1 entries OK
```

A bad-input smoke-test (`statement: "low priority"`) produces:

```
::error file=...::vulnerabilities[0]: missing or too-short `statement`
(need ≥40 chars; got 12). Boilerplate like 'low priority' / 'acceptable
risk' is rejected by design — describe WHY this finding is non-
exploitable in our deployment context.
```

## Related

- SPEC: `.moai/specs/SPEC-CI-TRIVY-POLICY-001/spec.md`
- PR #1: #410 (centralised .trivy.yaml plumbing) — merged
- PR #2: #411 (per-service findings dispositie) — merged
- PR #3: gate flip — separate PR, independent of this one

🤖 Generated with [Claude Code](https://claude.com/claude-code)