### PR TITLE
fix(mcp): align AssertionMode taxonomy with ingest + add tests to CI

### DIFF
--- a/.github/workflows/klai-knowledge-mcp.yml
+++ b/.github/workflows/klai-knowledge-mcp.yml
@@ -28,7 +28,29 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: klai-knowledge-mcp
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies (incl. dev extras)
+        # `uv sync` resolves the path-deps `klai-identity-assert` and
+        # `klai-log-utils` from ../klai-libs/ — same pattern as the runtime
+        # Dockerfile uses for editable installs.
+        run: uv sync --extra dev
+
+      - name: Test (pytest)
+        run: uv run pytest -q --tb=short
+
   build-push:
+    needs: test
     runs-on: ubuntu-latest
 
     steps:

--- a/klai-knowledge-mcp/main.py
+++ b/klai-knowledge-mcp/main.py
@@ -79,7 +79,13 @@ _KNOWN_SECRETS: frozenset[str] = frozenset(
 # Path validation patterns
 _KB_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
 
-AssertionMode = Literal["factual", "procedural", "quoted", "belief", "hypothesis"]
+# SPEC-TAXONOMY-001 (revised): vocabulary matches the live DB constraint
+# (artifacts_assertion_mode_check) and klai-knowledge-ingest. ``unknown`` is
+# the system default for content with no epistemic classification — keeps
+# untagged content out of the (future) feit-boost in retrieval scoring
+# (DD-2 in spec.md). See the Realignment Note in
+# .moai/specs/SPEC-TAXONOMY-001/spec.md.
+AssertionMode = Literal["factual", "belief", "hypothesis", "procedural", "quoted", "unknown"]
 VALID_ASSERTION_MODES: frozenset[str] = frozenset(get_args(AssertionMode))
 
 # Error messages (bilingual NL/EN)
@@ -379,8 +385,10 @@ something for their own reference.
 PARAMETERS:
   title          - short, descriptive title (max 80 chars); you generate this
   content        - the text to save; may be a summary, quote, or elaboration
-  assertion_mode - pick the best fit: "factual", "procedural", "quoted",
-                   "belief", or "hypothesis"
+  assertion_mode - pick the best fit: "factual", "belief", "hypothesis",
+                   "procedural", "quoted", or "unknown" (use "unknown" if
+                   the epistemic status is unclear; it is also the system
+                   default for missing values)
   tags           - 1-5 tags; free-form or from seed list
   source_note    - (optional) source reference if mentioned by user
 """
@@ -405,7 +413,9 @@ async def save_personal_knowledge(
         return _ERR_IDENTITY_REJECTED
 
     if not assertion_mode:
-        assertion_mode = "factual"
+        # SPEC-TAXONOMY-001 DD-2: missing → "unknown", not "factual".
+        # Avoids an unwarranted feit-boost in (future) retrieval scoring.
+        assertion_mode = "unknown"
     elif assertion_mode not in VALID_ASSERTION_MODES:
         return _ERR_ASSERTION_MODE.format(assertion_mode)
 
@@ -448,8 +458,10 @@ or expresses intent to share knowledge with the whole organisation.
 PARAMETERS:
   title          - short, descriptive title (max 80 chars); you generate this
   content        - the text to save; may be a summary, quote, or elaboration
-  assertion_mode - pick the best fit: "factual", "procedural", "quoted",
-                   "belief", or "hypothesis"
+  assertion_mode - pick the best fit: "factual", "belief", "hypothesis",
+                   "procedural", "quoted", or "unknown" (use "unknown" if
+                   the epistemic status is unclear; it is also the system
+                   default for missing values)
   tags           - 1-5 tags; free-form or from seed list
   source_note    - (optional) source reference if mentioned by user
 """
@@ -474,7 +486,9 @@ async def save_org_knowledge(
         return _ERR_IDENTITY_REJECTED
 
     if not assertion_mode:
-        assertion_mode = "factual"
+        # SPEC-TAXONOMY-001 DD-2: missing → "unknown", not "factual".
+        # Avoids an unwarranted feit-boost in (future) retrieval scoring.
+        assertion_mode = "unknown"
     elif assertion_mode not in VALID_ASSERTION_MODES:
         return _ERR_ASSERTION_MODE.format(assertion_mode)
 

--- a/klai-knowledge-mcp/tests/test_assertion_mode_taxonomy.py
+++ b/klai-knowledge-mcp/tests/test_assertion_mode_taxonomy.py
@@ -1,10 +1,21 @@
-"""Tests for SPEC-TAXONOMY-001: assertion_mode taxonomy alignment in knowledge-mcp.
+"""Tests for SPEC-TAXONOMY-001 (revised): assertion_mode taxonomy in knowledge-mcp.
 
-RED phase: these tests define the expected behavior for the new 6-value taxonomy.
+The 6-value vocabulary uses the original DB-flavoured names + ``unknown``,
+matching the live ``artifacts_assertion_mode_check`` constraint and the
+``VALID_ASSERTION_MODES`` set in ``klai-knowledge-ingest``. See the
+Realignment Note in ``.moai/specs/SPEC-TAXONOMY-001/spec.md`` for why
+DD-1's ``fact/claim/speculation`` rename was reverted.
+
+Identity verification (SPEC-SEC-IDENTITY-ASSERT-001 REQ-2) sits in front of
+every save_* tool. These tests mock ``main._asserter.verify`` with an
+allow-result so the assertion_mode validation path is actually reached.
+Without the mock the tests pass through ``_ERR_IDENTITY_REJECTED`` and
+silently never exercise the taxonomy logic.
 """
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from klai_identity_assert import VerifyResult
 
 
 def _make_ctx(headers: dict | None = None):
@@ -19,6 +30,8 @@ def _patch_env(monkeypatch):
     monkeypatch.setenv("DOCS_INTERNAL_SECRET", "docs-secret")
     monkeypatch.setenv("KNOWLEDGE_INGEST_URL", "http://knowledge-ingest:8000")
     monkeypatch.setenv("KNOWLEDGE_INGEST_SECRET", "test-secret")
+    monkeypatch.setenv("PORTAL_API_URL", "http://portal-api:8010")
+    monkeypatch.setenv("PORTAL_INTERNAL_SECRET", "portal-test-secret")
 
 
 def _valid_ctx():
@@ -30,6 +43,14 @@ def _valid_ctx():
     })
 
 
+def _allow() -> VerifyResult:
+    """Mirror of the helper in test_identity_assert.py — keeps every taxonomy
+    test focused on assertion_mode behaviour, not the identity-verify chain."""
+    return VerifyResult.allow(
+        user_id="user1", org_id="org1", org_slug="testorg", evidence="jwt"
+    )  # type: ignore[arg-type]
+
+
 class TestAssertionModeType:
     """The AssertionMode Literal and VALID_ASSERTION_MODES frozenset must exist."""
 
@@ -37,7 +58,7 @@ class TestAssertionModeType:
         from main import VALID_ASSERTION_MODES
 
         assert VALID_ASSERTION_MODES == frozenset(
-            {"fact", "claim", "speculation", "procedural", "quoted", "unknown"}
+            {"factual", "belief", "hypothesis", "procedural", "quoted", "unknown"}
         )
 
     def test_assertion_mode_literal_exists(self, _patch_env):
@@ -45,7 +66,7 @@ class TestAssertionModeType:
         from typing import get_args
 
         args = set(get_args(AssertionMode))
-        assert args == {"fact", "claim", "speculation", "procedural", "quoted", "unknown"}
+        assert args == {"factual", "belief", "hypothesis", "procedural", "quoted", "unknown"}
 
 
 class TestAssertionModeValidation:
@@ -56,13 +77,14 @@ class TestAssertionModeValidation:
         from main import save_personal_knowledge
 
         ctx = _valid_ctx()
-        result = await save_personal_knowledge(
-            title="Test",
-            content="content",
-            assertion_mode="invalid_mode",
-            tags=["test"],
-            ctx=ctx,
-        )
+        with patch("main._asserter.verify", new_callable=AsyncMock, return_value=_allow()):
+            result = await save_personal_knowledge(
+                title="Test",
+                content="content",
+                assertion_mode="invalid_mode",
+                tags=["test"],
+                ctx=ctx,
+            )
         # Must return an error string, not silently fallback
         assert "Error" in result or "invalid" in result.lower()
 
@@ -72,13 +94,14 @@ class TestAssertionModeValidation:
         from main import save_personal_knowledge
 
         ctx = _valid_ctx()
-        result = await save_personal_knowledge(
-            title="Test",
-            content="content",
-            assertion_mode="note",
-            tags=["test"],
-            ctx=ctx,
-        )
+        with patch("main._asserter.verify", new_callable=AsyncMock, return_value=_allow()):
+            result = await save_personal_knowledge(
+                title="Test",
+                content="content",
+                assertion_mode="note",
+                tags=["test"],
+                ctx=ctx,
+            )
         assert "Error" in result or "invalid" in result.lower()
 
 
@@ -86,12 +109,15 @@ class TestAssertionModeValidValues:
     """All 6 valid assertion_mode values must be accepted."""
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("mode", ["fact", "claim", "speculation", "procedural", "quoted", "unknown"])
+    @pytest.mark.parametrize("mode", ["factual", "belief", "hypothesis", "procedural", "quoted", "unknown"])
     async def test_valid_mode_accepted(self, _patch_env, mode):
         from main import save_personal_knowledge
 
         ctx = _valid_ctx()
-        with patch("main._save_to_ingest", new_callable=AsyncMock, return_value=True):
+        with (
+            patch("main._asserter.verify", new_callable=AsyncMock, return_value=_allow()),
+            patch("main._save_to_ingest", new_callable=AsyncMock, return_value=True),
+        ):
             result = await save_personal_knowledge(
                 title="Test",
                 content="content",
@@ -100,6 +126,8 @@ class TestAssertionModeValidValues:
                 ctx=ctx,
             )
         assert "Error" not in result
+        # Positive assertion: the success path must actually be reached.
+        assert "Opgeslagen" in result
 
 
 class TestMissingAssertionModeDefaultsToUnknown:
@@ -116,7 +144,10 @@ class TestMissingAssertionModeDefaultsToUnknown:
             captured_mode["value"] = assertion_mode
             return True
 
-        with patch("main._save_to_ingest", side_effect=_capture_ingest):
+        with (
+            patch("main._asserter.verify", new_callable=AsyncMock, return_value=_allow()),
+            patch("main._save_to_ingest", side_effect=_capture_ingest),
+        ):
             # Pass empty string to simulate missing/empty assertion_mode
             await save_personal_knowledge(
                 title="Test",


### PR DESCRIPTION
Closes #413.

## Wat dit fixt

Vier samenhangende drifts in `klai-knowledge-mcp` die opdoken tijdens [PR #412](https://github.com/GetKlai/klai/pull/412) (SPEC-TAXONOMY-001 realignment).

### 1. `main.py:82` — Literal vocabulary uitgebreid

```diff
- AssertionMode = Literal[\"factual\", \"procedural\", \"quoted\", \"belief\", \"hypothesis\"]
+ AssertionMode = Literal[\"factual\", \"belief\", \"hypothesis\", \"procedural\", \"quoted\", \"unknown\"]
```

Matcht nu de live DB-constraint en `klai-knowledge-ingest`. MCP kan nu `assertion_mode=\"unknown\"` accepteren.

### 2. `main.py:407,476` — default `factual` → `unknown`

Conform DD-2 uit SPEC-TAXONOMY-001. Voorkomt onterechte feit-boost in (toekomstige) retrieval scoring.

### 3. Tests aligned met productie

- `tests/test_assertion_mode_taxonomy.py` verwachtte de nieuwe vocab (`fact/claim/speculation`) die nooit geland is. Aangepast naar productie-vocab.
- Drie tests die door identity-rejection werden short-circuited (`test_invalid_assertion_mode_returns_error`, `test_old_note_value_returns_error`, `test_none_assertion_mode_defaults_to_unknown`) krijgen nu een mock op `main._asserter.verify` met een allow-result. Patroon overgenomen uit `test_identity_assert.py`.
- `test_valid_mode_accepted` heeft nu een positive assertion (`\"Opgeslagen\" in result`), niet alleen negatief (\"Error\" not in).
- Tool-descriptions voor `save_personal_knowledge` en `save_org_knowledge` updaten: alle 6 valid values + expliciete guidance voor `unknown`.

### 4. CI runt nu pytest

`.github/workflows/klai-knowledge-mcp.yml` was alleen build-and-push. Nieuwe `test` job draait `uv sync --extra dev && uv run pytest`. `build-push` heeft nu `needs: test`. **Dit is waarom drift #1-3 ~5 weken onzichtbaar bleef.**

## Verificatie

Lokaal in worktree:

```
$ uv run pytest -q --tb=short
.....................................................                    [100%]
53 passed in 1.74s
```

11/11 specifiek voor taxonomy, 0 regressies in de overige 42 tests.

## Niet aangeraakt

- `uv.lock` — mijn lokale uv schreef hem in revision 3, maar de rest van de repo is op revision 1. Reverted om consistent te blijven.
- `pyproject.toml` — geen dependency-wijzigingen nodig (`pytest` + `pytest-asyncio` zaten al in `[project.optional-dependencies] dev`).
- Andere services — alleen MCP raakt deze drifts.