### PR TITLE
feat(ci): activate STRICT-tier Trivy gate — PR #3/4 of SPEC-CI-TRIVY-POLICY-001

### DIFF
--- a/.github/workflows/caddy.yml
+++ b/.github/workflows/caddy.yml
@@ -63,6 +63,10 @@ jobs:
       security-events: write
       packages: read
     steps:
+      # Checkout is required so trivy-action can find .trivy.yaml + the
+      # service's .trivyignore.yaml (paths are relative to repo root).
+      - uses: actions/checkout@v6
+
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:
@@ -70,19 +74,29 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Trivy policy lives in .trivy.yaml at repo root (SPEC-CI-TRIVY-POLICY-001 REQ-1).
-      # PR #1 wires the config; inline `severity` + `ignore-unfixed` stay until PR #3
-      # removes them with `exit-code: '1'` + `limit-severities-for-sarif: 'true'`.
+      # STRICT-tier scan per SPEC-CI-TRIVY-POLICY-001:
+      # severity / ignore-unfixed / scanners come from .trivy.yaml (REQ-1).
+      # exit-code: '1' blocks the build on unfixed HIGH/CRITICAL (REQ-2).
+      # limit-severities-for-sarif: 'true' makes the severity filter actually
+      # apply (neutralises trivy-action 0.35.0 SARIF severity-filter unset).
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ghcr.io/getklai/caddy-hetzner:${{ github.sha }}
           trivy-config: .trivy.yaml
-          format: 'sarif'
-          output: 'trivy-results.sarif'
+          trivyignores: deploy/caddy/.trivyignore.yaml
+          # Inline duplicates are required: trivy-action 0.35.0's
+          # `limit-severities-for-sarif: true` only acts on INPUT_SEVERITY,
+          # not on config-file severity. Same for scanners. Keep .trivy.yaml
+          # as the canonical policy reference; remove these inlines once
+          # trivy-action lands proper config-file precedence.
+          scanners: 'vuln'
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
-          exit-code: '0'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          exit-code: '1'
+          limit-severities-for-sarif: 'true'
 
       - name: Upload Trivy SARIF to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -54,6 +54,10 @@ jobs:
       security-events: write
       packages: read
     steps:
+      # Checkout is required so trivy-action can find .trivy.yaml + the
+      # service's .trivyignore.yaml (paths are relative to repo root).
+      - uses: actions/checkout@v6
+
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:
@@ -61,19 +65,28 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Trivy policy lives in .trivy.yaml at repo root (SPEC-CI-TRIVY-POLICY-001 REQ-1).
-      # PR #1 wires the config; inline `severity` + `ignore-unfixed` stay until PR #3
-      # removes them with `exit-code: '1'` + `limit-severities-for-sarif: 'true'`.
+      # STRICT-tier scan per SPEC-CI-TRIVY-POLICY-001:
+      # severity / ignore-unfixed / scanners come from .trivy.yaml (REQ-1).
+      # exit-code: '1' blocks the build on unfixed HIGH/CRITICAL (REQ-2).
+      # limit-severities-for-sarif: 'true' makes the severity filter actually
+      # apply (neutralises trivy-action 0.35.0 SARIF severity-filter unset).
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
           trivy-config: .trivy.yaml
-          format: 'sarif'
-          output: 'trivy-results.sarif'
+          # Inline duplicates are required: trivy-action 0.35.0's
+          # `limit-severities-for-sarif: true` only acts on INPUT_SEVERITY,
+          # not on config-file severity. Same for scanners. Keep .trivy.yaml
+          # as the canonical policy reference; remove these inlines once
+          # trivy-action lands proper config-file precedence.
+          scanners: 'vuln'
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
-          exit-code: '0'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          exit-code: '1'
+          limit-severities-for-sarif: 'true'
 
       - name: Upload Trivy SARIF to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4
@@ -82,7 +95,10 @@ jobs:
           sarif_file: 'trivy-results.sarif'
 
   deploy:
-    needs: build-and-push
+    # `needs: scan` ensures Trivy gate from SPEC-CI-TRIVY-POLICY-001 REQ-2
+    # actually blocks production deploy: if scan job exits 1 on a HIGH/CRIT
+    # finding, deploy is skipped.
+    needs: [build-and-push, scan]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/klai-connector.yml
+++ b/.github/workflows/klai-connector.yml
@@ -134,6 +134,10 @@ jobs:
       security-events: write
       packages: read
     steps:
+      # Checkout is required so trivy-action can find .trivy.yaml + the
+      # service's .trivyignore.yaml (paths are relative to repo root).
+      - uses: actions/checkout@v6
+
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:
@@ -141,19 +145,29 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Trivy policy lives in .trivy.yaml at repo root (SPEC-CI-TRIVY-POLICY-001 REQ-1).
-      # PR #1 wires the config; inline `severity` + `ignore-unfixed` stay until PR #3
-      # removes them with `exit-code: '1'` + `limit-severities-for-sarif: 'true'`.
+      # STRICT-tier scan per SPEC-CI-TRIVY-POLICY-001:
+      # severity / ignore-unfixed / scanners come from .trivy.yaml (REQ-1).
+      # exit-code: '1' blocks the build on unfixed HIGH/CRITICAL (REQ-2).
+      # limit-severities-for-sarif: 'true' makes the severity filter actually
+      # apply (neutralises trivy-action 0.35.0 SARIF severity-filter unset).
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ghcr.io/getklai/klai-connector:${{ github.sha }}
           trivy-config: .trivy.yaml
-          format: 'sarif'
-          output: 'trivy-results.sarif'
+          trivyignores: klai-connector/.trivyignore.yaml
+          # Inline duplicates are required: trivy-action 0.35.0's
+          # `limit-severities-for-sarif: true` only acts on INPUT_SEVERITY,
+          # not on config-file severity. Same for scanners. Keep .trivy.yaml
+          # as the canonical policy reference; remove these inlines once
+          # trivy-action lands proper config-file precedence.
+          scanners: 'vuln'
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
-          exit-code: '0'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          exit-code: '1'
+          limit-severities-for-sarif: 'true'
 
       - name: Upload Trivy SARIF to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4

--- a/.github/workflows/klai-knowledge-mcp.yml
+++ b/.github/workflows/klai-knowledge-mcp.yml
@@ -103,6 +103,10 @@ jobs:
       security-events: write
       packages: read
     steps:
+      # Checkout is required so trivy-action can find .trivy.yaml + the
+      # service's .trivyignore.yaml (paths are relative to repo root).
+      - uses: actions/checkout@v6
+
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:
@@ -110,19 +114,28 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Trivy policy lives in .trivy.yaml at repo root (SPEC-CI-TRIVY-POLICY-001 REQ-1).
-      # PR #1 wires the config; inline `severity` + `ignore-unfixed` stay until PR #3
-      # removes them with `exit-code: '1'` + `limit-severities-for-sarif: 'true'`.
+      # STRICT-tier scan per SPEC-CI-TRIVY-POLICY-001:
+      # severity / ignore-unfixed / scanners come from .trivy.yaml (REQ-1).
+      # exit-code: '1' blocks the build on unfixed HIGH/CRITICAL (REQ-2).
+      # limit-severities-for-sarif: 'true' makes the severity filter actually
+      # apply (neutralises trivy-action 0.35.0 SARIF severity-filter unset).
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ghcr.io/getklai/klai-knowledge-mcp:${{ github.sha }}
           trivy-config: .trivy.yaml
-          format: 'sarif'
-          output: 'trivy-results.sarif'
+          # Inline duplicates are required: trivy-action 0.35.0's
+          # `limit-severities-for-sarif: true` only acts on INPUT_SEVERITY,
+          # not on config-file severity. Same for scanners. Keep .trivy.yaml
+          # as the canonical policy reference; remove these inlines once
+          # trivy-action lands proper config-file precedence.
+          scanners: 'vuln'
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
-          exit-code: '0'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          exit-code: '1'
+          limit-severities-for-sarif: 'true'
 
       - name: Upload Trivy SARIF to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4

--- a/.github/workflows/klai-mailer.yml
+++ b/.github/workflows/klai-mailer.yml
@@ -111,6 +111,10 @@ jobs:
       security-events: write
       packages: read
     steps:
+      # Checkout is required so trivy-action can find .trivy.yaml + the
+      # service's .trivyignore.yaml (paths are relative to repo root).
+      - uses: actions/checkout@v6
+
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:
@@ -118,19 +122,28 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Trivy policy lives in .trivy.yaml at repo root (SPEC-CI-TRIVY-POLICY-001 REQ-1).
-      # PR #1 wires the config; inline `severity` + `ignore-unfixed` stay until PR #3
-      # removes them with `exit-code: '1'` + `limit-severities-for-sarif: 'true'`.
+      # STRICT-tier scan per SPEC-CI-TRIVY-POLICY-001:
+      # severity / ignore-unfixed / scanners come from .trivy.yaml (REQ-1).
+      # exit-code: '1' blocks the build on unfixed HIGH/CRITICAL (REQ-2).
+      # limit-severities-for-sarif: 'true' makes the severity filter actually
+      # apply (neutralises trivy-action 0.35.0 SARIF severity-filter unset).
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ghcr.io/getklai/klai-mailer:${{ github.sha }}
           trivy-config: .trivy.yaml
-          format: 'sarif'
-          output: 'trivy-results.sarif'
+          # Inline duplicates are required: trivy-action 0.35.0's
+          # `limit-severities-for-sarif: true` only acts on INPUT_SEVERITY,
+          # not on config-file severity. Same for scanners. Keep .trivy.yaml
+          # as the canonical policy reference; remove these inlines once
+          # trivy-action lands proper config-file precedence.
+          scanners: 'vuln'
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
-          exit-code: '0'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          exit-code: '1'
+          limit-severities-for-sarif: 'true'
 
       - name: Upload Trivy SARIF to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4

--- a/.github/workflows/knowledge-ingest.yml
+++ b/.github/workflows/knowledge-ingest.yml
@@ -107,6 +107,10 @@ jobs:
       security-events: write
       packages: read
     steps:
+      # Checkout is required so trivy-action can find .trivy.yaml + the
+      # service's .trivyignore.yaml (paths are relative to repo root).
+      - uses: actions/checkout@v6
+
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:
@@ -114,19 +118,28 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Trivy policy lives in .trivy.yaml at repo root (SPEC-CI-TRIVY-POLICY-001 REQ-1).
-      # PR #1 wires the config; inline `severity` + `ignore-unfixed` stay until PR #3
-      # removes them with `exit-code: '1'` + `limit-severities-for-sarif: 'true'`.
+      # STRICT-tier scan per SPEC-CI-TRIVY-POLICY-001:
+      # severity / ignore-unfixed / scanners come from .trivy.yaml (REQ-1).
+      # exit-code: '1' blocks the build on unfixed HIGH/CRITICAL (REQ-2).
+      # limit-severities-for-sarif: 'true' makes the severity filter actually
+      # apply (neutralises trivy-action 0.35.0 SARIF severity-filter unset).
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ghcr.io/getklai/knowledge-ingest:${{ github.sha }}
           trivy-config: .trivy.yaml
-          format: 'sarif'
-          output: 'trivy-results.sarif'
+          # Inline duplicates are required: trivy-action 0.35.0's
+          # `limit-severities-for-sarif: true` only acts on INPUT_SEVERITY,
+          # not on config-file severity. Same for scanners. Keep .trivy.yaml
+          # as the canonical policy reference; remove these inlines once
+          # trivy-action lands proper config-file precedence.
+          scanners: 'vuln'
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
-          exit-code: '0'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          exit-code: '1'
+          limit-severities-for-sarif: 'true'
 
       - name: Upload Trivy SARIF to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4

--- a/.github/workflows/portal-api.yml
+++ b/.github/workflows/portal-api.yml
@@ -291,6 +291,10 @@ jobs:
       security-events: write
       packages: read
     steps:
+      # Checkout is required so trivy-action can find .trivy.yaml + the
+      # service's .trivyignore.yaml (paths are relative to repo root).
+      - uses: actions/checkout@v6
+
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:
@@ -298,34 +302,39 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Trivy policy reference lives in .trivy.yaml at repo root
-      # (SPEC-CI-TRIVY-POLICY-001 REQ-1). PR #1 wires every workflow to it.
-      # Inline `severity` + `ignore-unfixed` stay during PR #1 to guarantee
-      # zero behaviour change. PR #3 removes them together with `exit-code: '1'`
-      # + `limit-severities-for-sarif: 'true'` (the latter neutralises the
-      # trivy-action 0.35.0 SARIF severity-filter unset).
+      # STRICT-tier scan per SPEC-CI-TRIVY-POLICY-001:
+      # - severity / ignore-unfixed / scanners come from .trivy.yaml (REQ-1)
+      # - exit-code: '1' blocks the build on any unfixed HIGH/CRITICAL not
+      #   listed in klai-portal/backend/.trivyignore.yaml (REQ-2)
+      # - limit-severities-for-sarif: 'true' makes the severity filter
+      #   actually apply to both the SARIF output AND the exit-code check.
+      #   Without it, trivy-action 0.35.0's entrypoint unsets TRIVY_SEVERITY
+      #   for `format: sarif`, causing exit-code 1 to fire on MEDIUM/LOW too.
       #
-      # `scanners: 'vuln'` matters specifically here: Trivy's secret scanner
-      # runs against the BUILT image and matches strings inside third-party
-      # Python libraries shipped under /repo/.../site-packages. yt-dlp's
-      # site-extractor modules embed dozens of public API tokens
-      # (NBC, Vice, ESPN, Shahid, …) that consistently flag as CRITICAL
-      # aws-access-key-id / HIGH jwt-token — false positives that clutter
-      # the GitHub Security tab. Source-level secret scanning is covered
-      # separately by Semgrep + Gitleaks. After PR #3 this is enforced via
-      # `.trivy.yaml`'s `scan.scanners: [vuln]` for every internal workflow,
-      # not only portal-api.
+      # vuln-only matters because Trivy's secret scanner matches strings
+      # inside third-party Python libraries shipped under /repo/.../site-
+      # packages — yt-dlp's per-streaming-service extractors hardcode
+      # public API tokens (NBC, Vice, ESPN, Shahid, …) that flag as
+      # CRITICAL aws-access-key-id / HIGH jwt-token false positives.
+      # Source-level secret scanning is covered by Semgrep + Gitleaks.
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ghcr.io/getklai/portal-api:${{ github.sha }}
           trivy-config: .trivy.yaml
+          trivyignores: klai-portal/backend/.trivyignore.yaml
+          # Inline duplicates are required: trivy-action 0.35.0's
+          # `limit-severities-for-sarif: true` only acts on INPUT_SEVERITY,
+          # not on config-file severity. Same for scanners. Keep .trivy.yaml
+          # as the canonical policy reference; remove these inlines once
+          # trivy-action lands proper config-file precedence.
           scanners: 'vuln'
-          format: 'sarif'
-          output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-results.sarif'
           exit-code: '1'
+          limit-severities-for-sarif: 'true'
 
       - name: Upload Trivy SARIF to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4
@@ -334,7 +343,11 @@ jobs:
           sarif_file: 'trivy-results.sarif'
 
   deploy:
-    needs: [build-push]
+    # `needs: scan` ensures Trivy gate from SPEC-CI-TRIVY-POLICY-001 REQ-2
+    # actually blocks production deploy: if scan job exits 1 on a HIGH/CRIT
+    # finding, deploy is skipped. Previously deploy only depended on
+    # build-push, so a failed scan would still let the image roll out.
+    needs: [build-push, scan]
     runs-on: ubuntu-latest
     steps:
       # Audit 2026-05-05: defence-in-depth gate. The deploy job is gated

--- a/.github/workflows/retrieval-api.yml
+++ b/.github/workflows/retrieval-api.yml
@@ -94,6 +94,10 @@ jobs:
       security-events: write
       packages: read
     steps:
+      # Checkout is required so trivy-action can find .trivy.yaml + the
+      # service's .trivyignore.yaml (paths are relative to repo root).
+      - uses: actions/checkout@v6
+
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:
@@ -101,19 +105,28 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Trivy policy lives in .trivy.yaml at repo root (SPEC-CI-TRIVY-POLICY-001 REQ-1).
-      # PR #1 wires the config; inline `severity` + `ignore-unfixed` stay until PR #3
-      # removes them with `exit-code: '1'` + `limit-severities-for-sarif: 'true'`.
+      # STRICT-tier scan per SPEC-CI-TRIVY-POLICY-001:
+      # severity / ignore-unfixed / scanners come from .trivy.yaml (REQ-1).
+      # exit-code: '1' blocks the build on unfixed HIGH/CRITICAL (REQ-2).
+      # limit-severities-for-sarif: 'true' makes the severity filter actually
+      # apply (neutralises trivy-action 0.35.0 SARIF severity-filter unset).
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ghcr.io/getklai/retrieval-api:${{ github.sha }}
           trivy-config: .trivy.yaml
-          format: 'sarif'
-          output: 'trivy-results.sarif'
+          # Inline duplicates are required: trivy-action 0.35.0's
+          # `limit-severities-for-sarif: true` only acts on INPUT_SEVERITY,
+          # not on config-file severity. Same for scanners. Keep .trivy.yaml
+          # as the canonical policy reference; remove these inlines once
+          # trivy-action lands proper config-file precedence.
+          scanners: 'vuln'
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
-          exit-code: '0'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          exit-code: '1'
+          limit-severities-for-sarif: 'true'
 
       - name: Upload Trivy SARIF to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4

--- a/.github/workflows/scan-pinned-images.yml
+++ b/.github/workflows/scan-pinned-images.yml
@@ -75,6 +75,10 @@ jobs:
         image: ${{ fromJSON(needs.enumerate.outputs.images) }}
       fail-fast: false  # One bad image shouldn't skip the rest
     steps:
+      # Checkout is required so trivy-action can find .trivy.yaml
+      # (`trivy-config:` resolves relative to repo root).
+      - uses: actions/checkout@v6
+
       - name: Sanitize image name for artefact
         id: safe
         run: |
@@ -83,18 +87,25 @@ jobs:
           SAFE=$(echo '${{ matrix.image }}' | tr '/:' '__')
           echo "name=$SAFE" >> "$GITHUB_OUTPUT"
 
-      # Trivy policy lives in .trivy.yaml at repo root (SPEC-CI-TRIVY-POLICY-001 REQ-1).
-      # External-pin scans stay warn-only (REQ-3): Renovate handles upgrade
-      # pressure. Inline `severity` + `ignore-unfixed` stay until PR #3 cleanup.
+      # WARN-tier scan per SPEC-CI-TRIVY-POLICY-001 REQ-3.
+      # severity / ignore-unfixed / scanners come from .trivy.yaml (REQ-1).
+      # exit-code: '0' keeps this warn-only — Renovate handles upgrade pressure
+      # on the external base-images we pin in compose.
       - name: Trivy scan
         uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ${{ matrix.image }}
           trivy-config: .trivy.yaml
-          format: 'sarif'
-          output: 'trivy-${{ steps.safe.outputs.name }}.sarif'
+          # Inline duplicates are required: trivy-action 0.35.0's
+          # `limit-severities-for-sarif: true` only acts on INPUT_SEVERITY,
+          # not on config-file severity. Keep .trivy.yaml as the canonical
+          # policy reference; remove these inlines once trivy-action lands
+          # proper config-file precedence.
+          scanners: 'vuln'
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-${{ steps.safe.outputs.name }}.sarif'
           exit-code: '0'  # Don't fail the job — Security tab is the alert surface
 
       - name: Upload SARIF

--- a/.github/workflows/scribe-api.yml
+++ b/.github/workflows/scribe-api.yml
@@ -107,6 +107,10 @@ jobs:
       security-events: write
       packages: read
     steps:
+      # Checkout is required so trivy-action can find .trivy.yaml + the
+      # service's .trivyignore.yaml (paths are relative to repo root).
+      - uses: actions/checkout@v6
+
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:
@@ -114,19 +118,28 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Trivy policy lives in .trivy.yaml at repo root (SPEC-CI-TRIVY-POLICY-001 REQ-1).
-      # PR #1 wires the config; inline `severity` + `ignore-unfixed` stay until PR #3
-      # removes them with `exit-code: '1'` + `limit-severities-for-sarif: 'true'`.
+      # STRICT-tier scan per SPEC-CI-TRIVY-POLICY-001:
+      # severity / ignore-unfixed / scanners come from .trivy.yaml (REQ-1).
+      # exit-code: '1' blocks the build on unfixed HIGH/CRITICAL (REQ-2).
+      # limit-severities-for-sarif: 'true' makes the severity filter actually
+      # apply (neutralises trivy-action 0.35.0 SARIF severity-filter unset).
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ghcr.io/getklai/scribe-api:${{ github.sha }}
           trivy-config: .trivy.yaml
-          format: 'sarif'
-          output: 'trivy-results.sarif'
+          # Inline duplicates are required: trivy-action 0.35.0's
+          # `limit-severities-for-sarif: true` only acts on INPUT_SEVERITY,
+          # not on config-file severity. Same for scanners. Keep .trivy.yaml
+          # as the canonical policy reference; remove these inlines once
+          # trivy-action lands proper config-file precedence.
+          scanners: 'vuln'
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
-          exit-code: '0'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          exit-code: '1'
+          limit-severities-for-sarif: 'true'
 
       - name: Upload Trivy SARIF to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4

--- a/.github/workflows/whisper-server.yml
+++ b/.github/workflows/whisper-server.yml
@@ -45,6 +45,63 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  scan:
+    needs: build-push
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+    steps:
+      # Checkout is required so trivy-action can find .trivy.yaml + the
+      # service's .trivyignore.yaml (paths are relative to repo root).
+      - uses: actions/checkout@v6
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # STRICT-tier scan per SPEC-CI-TRIVY-POLICY-001:
+      # severity / ignore-unfixed / scanners come from .trivy.yaml (REQ-1).
+      # exit-code: '1' blocks the build on unfixed HIGH/CRITICAL (REQ-2).
+      # limit-severities-for-sarif: 'true' makes the severity filter actually
+      # apply (neutralises trivy-action 0.35.0 SARIF severity-filter unset).
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.35.0
+        with:
+          image-ref: ghcr.io/getklai/whisper-server:${{ github.sha }}
+          trivy-config: .trivy.yaml
+          # Inline duplicates are required: trivy-action 0.35.0's
+          # `limit-severities-for-sarif: true` only acts on INPUT_SEVERITY,
+          # not on config-file severity. Same for scanners. Keep .trivy.yaml
+          # as the canonical policy reference; remove these inlines once
+          # trivy-action lands proper config-file precedence.
+          scanners: 'vuln'
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          exit-code: '1'
+          limit-severities-for-sarif: 'true'
+
+      - name: Upload Trivy SARIF to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v4
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'
+
+  deploy:
+    # Split out of build-push so the scan job (above) can gate the deploy.
+    # Previously the deploy step lived inside build-push, which meant a
+    # gpu-01 deploy failure would skip the scan job entirely (since scan
+    # `needs: build-push`). After SPEC-CI-TRIVY-POLICY-001 PR #3 the gate
+    # actually gates: deploy only runs if both build AND scan succeed.
+    needs: [build-push, scan]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
       - name: Deploy to gpu-01 (via core-01 jump host)
         uses: appleboy/ssh-action@v1
         with:
@@ -55,37 +112,3 @@ jobs:
             set -e
             ssh -i /opt/klai/gpu-tunnel-key -o StrictHostKeyChecking=yes root@5.9.10.215 \
               "docker pull ghcr.io/getklai/whisper-server:latest && cd /opt/klai-gpu && docker compose up -d whisper-server"
-
-  scan:
-    needs: build-push
-    runs-on: ubuntu-latest
-    permissions:
-      security-events: write
-      packages: read
-    steps:
-      - name: Log in to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      # Trivy policy lives in .trivy.yaml at repo root (SPEC-CI-TRIVY-POLICY-001 REQ-1).
-      # PR #1 wires the config; inline `severity` + `ignore-unfixed` stay until PR #3
-      # removes them with `exit-code: '1'` + `limit-severities-for-sarif: 'true'`.
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.35.0
-        with:
-          image-ref: ghcr.io/getklai/whisper-server:${{ github.sha }}
-          trivy-config: .trivy.yaml
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH'
-          ignore-unfixed: true
-          exit-code: '0'
-
-      - name: Upload Trivy SARIF to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v4
-        if: always()
-        with:
-          sarif_file: 'trivy-results.sarif'

--- a/.trivy.yaml
+++ b/.trivy.yaml
@@ -1,7 +1,7 @@
-# .trivy.yaml — single source of truth for klai's CVE scanning policy.
+# .trivy.yaml — canonical reference for klai's CVE scanning policy.
 #
 # Referenced by every CI Trivy invocation via `trivy-config: .trivy.yaml`.
-# Defined and enforced by SPEC-CI-TRIVY-POLICY-001 (REQ-1).
+# Defined by SPEC-CI-TRIVY-POLICY-001 (REQ-1).
 #
 # Tier model (see .claude/rules/klai/infra/deploy.md):
 #   STRICT — 10 internal `ghcr.io/getklai/*` workflows. Block CI on
@@ -13,7 +13,19 @@
 #            (per `infra/container-hygiene.md`). Filtered out of
 #            `scan-pinned-images.yml` enumerate matrix.
 #
-# Schema reference: https://trivy.dev/v0.69/docs/references/configuration/config-file/
+# IMPORTANT — current limitation:
+# trivy-action 0.35.0 only honours `severity` / `scanners` / `ignore-unfixed`
+# from its INPUT layer (workflow `with:` keys), NOT from this config-file.
+# `limit-severities-for-sarif: true` operates on INPUT_SEVERITY, so without
+# inline duplication the SARIF includes ALL severities and the gate fires
+# on LOW/MEDIUM. Until trivy-action lands proper config-file precedence
+# (tracking issue: trivy-action #...), every workflow's Trivy step keeps
+# inline `scanners: 'vuln'`, `severity: 'CRITICAL,HIGH'`, `ignore-unfixed: true`
+# alongside `trivy-config: .trivy.yaml`. This file remains the canonical
+# reference: when the action is upgraded, the inline duplicates can be
+# dropped in one PR without changing policy.
+#
+# Schema reference: https://trivy.dev/latest/docs/references/configuration/config-file/
 
 severity:
   - CRITICAL

--- a/deploy/caddy/.trivyignore.yaml
+++ b/deploy/caddy/.trivyignore.yaml
@@ -1,0 +1,29 @@
+# Per-service Trivy ignore-list for caddy-hetzner.
+# Schema: SPEC-CI-TRIVY-POLICY-001 REQ-5 (id + ≥40-char statement + expired_at).
+# Referenced from .github/workflows/caddy.yml via `trivyignores:`.
+
+vulnerabilities:
+  - id: CVE-2026-29181
+    statement: |
+      go.opentelemetry.io/otel v1.40.0 → fixed in v1.41.0. Caddy 2.11.2's
+      go.mod still pins v1.40.0 transitively. Telemetry surface in our
+      Caddy build is disabled (no OTLP exporter, no telemetry endpoints
+      configured in Caddyfile) so the vulnerable codepath has no live
+      reach. Renovate watches the Caddy image; we expect Caddy 2.11.3 or
+      2.12.x to bump otel within the expiry window. Re-evaluate then.
+    expired_at: 2026-08-01
+    purls:
+      - "pkg:golang/go.opentelemetry.io/otel@v1.40.0"
+
+  - id: CVE-2026-27135
+    statement: |
+      nghttp2-libs 1.68.0-r0 → fixed in 1.68.1. Caddy 2.11.2-alpine ships
+      Alpine 3.21 which still has 1.68.0-r0 in its package index. Alpine's
+      next package-set update (typically every ~6 weeks) will pick up
+      1.68.1. Caddy uses nghttp2 only for HTTP/2 backend transport; our
+      reverse-proxy upstreams are local Docker network HTTP/1.1 services,
+      so the H2-DoS attack surface is upstream-side TLS terminator only.
+      Renovate watches caddy:* tags for new patches.
+    expired_at: 2026-08-01
+    purls:
+      - "pkg:apk/alpine/nghttp2-libs@1.68.0-r0"

--- a/klai-connector/.trivyignore.yaml
+++ b/klai-connector/.trivyignore.yaml
@@ -1,0 +1,35 @@
+# Per-service Trivy ignore-list for klai-connector.
+# Schema: SPEC-CI-TRIVY-POLICY-001 REQ-5 (id + ≥40-char statement + expired_at).
+
+vulnerabilities:
+  - id: CVE-2025-69720
+    statement: |
+      ncurses out-of-bounds read in tic compiler (terminfo description
+      compiler). Affects ncurses-bin / ncurses-base / libtinfo6 /
+      libncursesw6 in Debian 12/13 base of python:3.12-slim. Fixes are
+      pending in Debian's security update channel. klai-connector runs
+      uvicorn as the only entrypoint and never invokes the tic compiler
+      or any ncurses-using TUI; the library ships transitively via the
+      python:3.12-slim base. Upstream Debian package update will resolve
+      this within the expiry window — Renovate watches python:3.12-slim
+      for new builds.
+    expired_at: 2026-08-01
+
+  - id: CVE-2026-29111
+    statement: |
+      systemd path canonicalization issue in libsystemd0 / libudev1.
+      klai-connector runs as a single uvicorn process inside Docker and
+      never communicates with systemd / udev (no privileged mounts, no
+      hostnetwork, no /run/systemd access). Library ships transitively via
+      the python:3.12-slim base. Renovate-tracked base-image update will
+      pick up the Debian patch within the expiry window.
+    expired_at: 2026-08-01
+
+  - id: CVE-2026-4878
+    statement: |
+      libcap2 capability-string parsing issue. klai-connector container
+      runs without CAP_SYS_ADMIN / CAP_NET_ADMIN / file capabilities —
+      the libcap2 library ships transitively via python:3.12-slim and is
+      not exercised at runtime. Debian patch via Renovate-tracked base
+      bump within the expiry window.
+    expired_at: 2026-08-01


### PR DESCRIPTION
## Summary

The gate flip. PR #3 of [SPEC-CI-TRIVY-POLICY-001](https://github.com/GetKlai/klai/blob/main/.moai/specs/SPEC-CI-TRIVY-POLICY-001/spec.md). Depends on PR #1 (#410) and PR #2 (#411), both merged. Independent of PR #4 (#415, merged).

This PR went through several iterations to handle two trivy-action 0.35.0 limitations that surfaced under live CI:

1. **trivy-action does NOT honour config-file `severity` / `scanners` / `ignore-unfixed`** — only the inline `with:` keys go through to the SARIF severity-filter. Without inline duplication the gate fires on LOW/MEDIUM and secret-scanner false positives in third-party Python libraries (yt-dlp). All 11 Trivy steps now pass `scanners: 'vuln'`, `severity: 'CRITICAL,HIGH'`, `ignore-unfixed: true` inline alongside `trivy-config: .trivy.yaml`. Limitation documented in `.trivy.yaml`'s comment block — the inlines can be dropped once trivy-action lands proper config-file precedence.

2. **scan jobs lacked `actions/checkout`** — meaning `.trivy.yaml` and per-service `.trivyignore.yaml` paths could not be resolved. Trivy logged `cannot find ignorefile`. Added `- uses: actions/checkout@v6` as the first step of every scan job (10 internal + scan-pinned-images). This is also why the original `severity` filter never worked even before this SPEC: the workflow files referenced files that weren't on disk.

## Per-workflow changes

| Workflow | Inline keys | Checkout | trivyignores | Job restructure |
|---|---|---|---|---|
| `portal-api.yml` | added back | added | `klai-portal/backend/.trivyignore.yaml` | deploy now `needs: [build-push, scan]` |
| `caddy.yml` | added back | added | NEW `deploy/caddy/.trivyignore.yaml` (CVE-2026-29181 otel + CVE-2026-27135 nghttp2-libs, both `expired_at: 2026-08-01`) | — |
| `whisper-server.yml` | added back | added | none (gnupg purged in PR #2) | **split build-push / scan / deploy** into 3 independent jobs; deploy now `needs: [build-push, scan]` |
| `docs.yml` | added back | added | none | deploy now `needs: [build-and-push, scan]` |
| `klai-connector.yml` | added back | added | NEW `klai-connector/.trivyignore.yaml` (CVE-2025-69720 ncurses-family + CVE-2026-29111 systemd + CVE-2026-4878 libcap2 — all transitive in `python:3.12-slim` base, no runtime exposure, `expired_at: 2026-08-01`) | — |
| `klai-mailer.yml`, `knowledge-ingest.yml`, `klai-knowledge-mcp.yml`, `retrieval-api.yml`, `scribe-api.yml` | added back | added | none — clean scans | — |
| `scan-pinned-images.yml` | added back | added | not applicable | stays exit-code 0 (WARN-tier per REQ-3) |

`.trivy.yaml` itself updated with a comment block documenting the trivy-action 0.35.0 limitation and the path forward (drop inlines when action upgrades).

## What this PR does NOT change

- No service Dockerfile or dep changes — those are in PR #2 (merged)
- `scan-pinned-images.yml` enumerate-step regex extension stays in PR #4 (merged)

## Why deploy-gate matters

Three workflows have a `deploy` job (portal-api, docs, whisper-server). Pre-PR #3 their `deploy` only depended on `build-push`, so a failing `scan` would still let the image roll out. PR #3 makes deploy `needs: [build-push, scan]` for all three.

## Why whisper-server.yml needed restructuring

Pre-PR #3 the deploy step was inside the `build-push` job. Since `scan` had `needs: build-push`, a gpu-01 deploy failure (which has happened repeatedly with "no such service: whisper-server") would skip the scan job entirely → gate had zero effect. PR #3 splits into three independent jobs: `build-push` → `scan` → `deploy`.

## Verification (post-merge)

Per-service expectation:
- portal-api scan: green (CVE-2026-6357 suppressed via trivyignores)
- caddy scan: green (2 HIGH suppressed via trivyignores)
- whisper-server scan: green for the first time ever (was always skipped before due to deploy-step failure inside build-push)
- klai-connector scan: green (3 base-image HIGH families suppressed via trivyignores)
- mailer / knowledge-ingest / klai-knowledge-mcp / retrieval-api / scribe-api scans: green (clean)
- docs scan: green
- scan-pinned-images: continues warn-only

Smoke test of the gate (per `docs/runbooks/trivy-policy.md` recipe 4): manual verification post-merge with a deliberately ancient Dockerfile base.

## Rollback

Single revert. The flip is contained.

## Related

- SPEC: `.moai/specs/SPEC-CI-TRIVY-POLICY-001/spec.md`
- PR #1: #410 (merged)
- PR #2: #411 (merged)
- PR #4: #415 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)