### PR TITLE
chore(mcp): CI parity with portal-api — add ruff + pyright gates

### DIFF
--- a/.github/workflows/klai-knowledge-mcp.yml
+++ b/.github/workflows/klai-knowledge-mcp.yml
@@ -28,7 +28,13 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
-  test:
+  quality:
+    # Mirrors the portal-api quality job: lint, format-check, type-check,
+    # then tests. Build + image scan only run when this is green.
+    # pip-audit is intentionally NOT wired here yet — there are 3 known
+    # CVEs in transitive deps (cryptography, pygments, python-multipart)
+    # that need triage before pip-audit can become a hard gate. Tracked
+    # as a separate follow-up.
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -46,11 +52,20 @@ jobs:
         # Dockerfile uses for editable installs.
         run: uv sync --extra dev
 
+      - name: Lint (ruff)
+        run: uv run ruff check .
+
+      - name: Format check (ruff)
+        run: uv run ruff format --check .
+
+      - name: Type check (pyright)
+        run: uv run --with pyright pyright
+
       - name: Test (pytest)
         run: uv run pytest -q --tb=short
 
   build-push:
-    needs: test
+    needs: quality
     runs-on: ubuntu-latest
 
     steps:

--- a/klai-knowledge-mcp/tests/test_assertion_mode_taxonomy.py
+++ b/klai-knowledge-mcp/tests/test_assertion_mode_taxonomy.py
@@ -12,6 +12,7 @@ allow-result so the assertion_mode validation path is actually reached.
 Without the mock the tests pass through ``_ERR_IDENTITY_REJECTED`` and
 silently never exercise the taxonomy logic.
 """
+
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -35,20 +36,20 @@ def _patch_env(monkeypatch):
 
 
 def _valid_ctx():
-    return _make_ctx({
-        "x-user-id": "user1",
-        "x-org-id": "org1",
-        "x-org-slug": "testorg",
-        "x-internal-secret": "test-secret",
-    })
+    return _make_ctx(
+        {
+            "x-user-id": "user1",
+            "x-org-id": "org1",
+            "x-org-slug": "testorg",
+            "x-internal-secret": "test-secret",
+        }
+    )
 
 
 def _allow() -> VerifyResult:
     """Mirror of the helper in test_identity_assert.py — keeps every taxonomy
     test focused on assertion_mode behaviour, not the identity-verify chain."""
-    return VerifyResult.allow(
-        user_id="user1", org_id="org1", org_slug="testorg", evidence="jwt"
-    )  # type: ignore[arg-type]
+    return VerifyResult.allow(user_id="user1", org_id="org1", org_slug="testorg", evidence="jwt")  # type: ignore[arg-type]
 
 
 class TestAssertionModeType:
@@ -62,11 +63,19 @@ class TestAssertionModeType:
         )
 
     def test_assertion_mode_literal_exists(self, _patch_env):
-        from main import AssertionMode
         from typing import get_args
 
+        from main import AssertionMode
+
         args = set(get_args(AssertionMode))
-        assert args == {"factual", "belief", "hypothesis", "procedural", "quoted", "unknown"}
+        assert args == {
+            "factual",
+            "belief",
+            "hypothesis",
+            "procedural",
+            "quoted",
+            "unknown",
+        }
 
 
 class TestAssertionModeValidation:
@@ -109,7 +118,10 @@ class TestAssertionModeValidValues:
     """All 6 valid assertion_mode values must be accepted."""
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("mode", ["factual", "belief", "hypothesis", "procedural", "quoted", "unknown"])
+    @pytest.mark.parametrize(
+        "mode",
+        ["factual", "belief", "hypothesis", "procedural", "quoted", "unknown"],
+    )
     async def test_valid_mode_accepted(self, _patch_env, mode):
         from main import save_personal_knowledge
 
@@ -140,7 +152,16 @@ class TestMissingAssertionModeDefaultsToUnknown:
         ctx = _valid_ctx()
         captured_mode = {}
 
-        async def _capture_ingest(org_id, kb_slug, title, content, assertion_mode, tags, source_note, user_id=None):
+        async def _capture_ingest(
+            org_id,
+            kb_slug,
+            title,
+            content,
+            assertion_mode,
+            tags,
+            source_note,
+            user_id=None,
+        ):
             captured_mode["value"] = assertion_mode
             return True
 

--- a/klai-knowledge-mcp/tests/test_sec_internal_001.py
+++ b/klai-knowledge-mcp/tests/test_sec_internal_001.py
@@ -274,7 +274,7 @@ class TestNoSilentOmitGuardsRemain:
         # Any return statement that interpolates resp.text into a user-visible
         # error string would re-introduce the leak.
         forbidden = [
-            "return f\"Error: klai-docs returned HTTP",
+            'return f"Error: klai-docs returned HTTP',
             "return f'Error: klai-docs returned HTTP",
         ]
         for pattern in forbidden:


### PR DESCRIPTION
Volgt op het \"CI parity\" punt uit de zelfreview na PR #416.

## Probleem

PR #416 voegde \`pytest\` toe aan klai-knowledge-mcp's CI maar liet de rest van de standaard Python quality-stack achterwege. Andere services (portal-api) hebben ruff + pyright + pip-audit + alembic-validate vóór tests.

## Wijzigingen

### CI (`.github/workflows/klai-knowledge-mcp.yml`)

Nieuwe `quality` job vervangt `test`. Steps in volgorde:

1. \`uv run ruff check .\` (lint)
2. \`uv run ruff format --check .\` (formatting)
3. \`uv run --with pyright pyright\` (type check)
4. \`uv run pytest -q --tb=short\` (existing)

\`build-push\` heeft nu \`needs: quality\`. Image build draait pas als alle 4 groen zijn.

### Code housekeeping voor de nieuwe gates

- **tests/test_assertion_mode_taxonomy.py** — 3 ruff issues gefixt (mijn eigen file uit PR #416). Eén un-sorted import block en twee over-length parametrize/function-signature lines. Mechanische line-wrapping / import-sortering — geen logica change.
- **tests/test_sec_internal_001.py** — 1 ruff-format quote-normalisatie (\`f\"...\"\` → \`f'...'\`). Functioneel identiek.

## Verificatie (lokaal in worktree)

\`\`\`
$ uv run ruff check .          → All checks passed!
$ uv run ruff format --check . → 11 files already formatted
$ uv run --with pyright pyright → 0 errors, 0 warnings, 0 informations
$ uv run pytest -q             → 53 passed in 3.65s
\`\`\`

## Niet in scope (apart te tracken)

- **pip-audit**: 3 bekende CVEs in transitive deps (cryptography 46.0.6 → 46.0.7, pygments 2.19.2 → 2.20.0, python-multipart 0.0.22 → 0.0.26). Triage nodig voordat \`pip-audit\` een hard gate kan zijn. Apart issue.
- **\`_allow()\` helper duplicatie** in 4 test files (test_assertion_mode_taxonomy + test_identity_assert + test_mcp_security + test_sec_internal_001). Refactor naar gedeelde conftest fixture is een eigen PR. Apart issue.