### PR TITLE
feat(SPEC-INGEST-LOGIN-WALL-DETECT-001): Phase F — observability (Prometheus + alerts + runbook)

### DIFF
--- a/deploy/grafana/provisioning/alerting/login-wall-rules.yaml
+++ b/deploy/grafana/provisioning/alerting/login-wall-rules.yaml
@@ -34,7 +34,7 @@ groups:
       #
       # for: 0s — once across, fire immediately. The 10m lookback already
       # smooths out single-job spikes.
-      - uid: spec-login-wall-detect-001-burst
+      - uid: spec-lwd-001-burst
         title: login_wall_burst
         condition: threshold
         data:
@@ -118,7 +118,7 @@ groups:
       # Fires on ANY log line indicating a typo in
       # KLAI_INGEST_LOGIN_WALL_DETECT_MODE. Detector falls back to audit_only
       # so the pipeline keeps running, but operators must fix the env value.
-      - uid: spec-login-wall-detect-001-config-invalid
+      - uid: spec-lwd-001-config-invalid
         title: login_wall_detector_config_invalid
         condition: threshold
         data:

--- a/deploy/grafana/provisioning/alerting/login-wall-rules.yaml
+++ b/deploy/grafana/provisioning/alerting/login-wall-rules.yaml
@@ -1,0 +1,184 @@
+# SPEC-INGEST-LOGIN-WALL-DETECT-001 REQ-08 — alert rules.
+#
+# Two rules, both VictoriaLogs-based (knowledge-ingest is a logs-only service
+# without Prometheus exposure):
+#
+#   R1  login_wall_burst                  HIGH   >50 detections in 10m
+#   R2  login_wall_detector_misconfigured WARN   any "config_invalid" log
+#
+# Routed via spec=SPEC-INGEST-LOGIN-WALL-DETECT-001 → klai-ops-alerts-email.
+#
+# Field shape verified against the structured logs emitted by Phase B:
+#   service:knowledge-ingest
+#   event:login_wall_reject     (mode=reject)
+#   event:login_wall_degrade    (mode=degrade)
+#   event:login_wall_detected   (mode=audit_only)
+#   event:login_wall_detector_config_invalid (fail-safe trigger)
+
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: spec-login-wall-detect-001-ingest
+    folder: Klai
+    interval: 1m
+    rules:
+
+      # ── R1: login_wall_burst ─────────────────────────────────────────────
+      # Looks back 10m, fires when total login-wall detections (across all
+      # three modes) exceed 50. Threshold deliberately generous: voys's first
+      # backfill processes ~150 walls in one go and we don't want a noisy
+      # alert during normal cleanup. A sustained 50-per-10-min rate AFTER
+      # backfill = 300/hr = a connector misconfigured on a freshly-onboarded
+      # tenant or a vendor that changed their auth model.
+      #
+      # for: 0s — once across, fire immediately. The 10m lookback already
+      # smooths out single-job spikes.
+      - uid: spec-login-wall-detect-001-burst
+        title: login_wall_burst
+        condition: threshold
+        data:
+          - refId: query
+            datasourceUid: victorialogs
+            queryType: instant
+            relativeTimeRange:
+              from: 600
+              to: 0
+            model:
+              refId: query
+              datasource:
+                type: victoriametrics-logs-datasource
+                uid: victorialogs
+              expr: 'service:knowledge-ingest AND (event:login_wall_reject OR event:login_wall_degrade OR event:login_wall_detected)'
+              queryType: instant
+          - refId: count
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 600
+              to: 0
+            model:
+              refId: count
+              type: reduce
+              reducer: count
+              expression: query
+          - refId: threshold
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 600
+              to: 0
+            model:
+              refId: threshold
+              type: threshold
+              expression: count
+              conditions:
+                - evaluator: { params: [50], type: gt }
+                  operator: { type: and }
+                  reducer: { params: [], type: last }
+                  type: query
+        noDataState: OK
+        execErrState: Alerting
+        for: 0s
+        keepFiringFor: 30m
+        isPaused: false
+        labels:
+          severity: warning
+          spec: SPEC-INGEST-LOGIN-WALL-DETECT-001
+          service_group: ingest
+        annotations:
+          summary: 'knowledge-ingest detected >50 login-wall pages in 10 min'
+          runbook_url: 'docs/runbooks/login-wall-burst.md'
+          description: |
+            knowledge-ingest is logging more than 50 login-wall detections
+            in the last 10 minutes. Common causes:
+
+              - **Backfill is running** — expected the first time a tenant
+                runs `python -m knowledge_ingest.backfill_tasks --org X`.
+                Voys's first backfill alone processes ~150 walls. Wait for
+                the task to finish and check that the rate drops.
+
+              - **Newly-onboarded tenant with credential-less crawl** — the
+                new connector is hitting 35-40% walled pages. Configure
+                cookies via the existing connector wizard (SPEC-CRAWLER-004
+                cookie path) and re-crawl.
+
+              - **Vendor changed login model** — a previously-public site
+                added a paywall. Investigate which `org_id` + page domains
+                dominate and decide between adding cookies or accepting
+                the loss.
+
+            Triage:
+              1. VictoriaLogs:
+                   service:knowledge-ingest AND (event:login_wall_reject OR event:login_wall_degrade OR event:login_wall_detected)
+                   | stats by(org_id, kb_slug) count() | sort desc
+              2. Top org_id → check connector_id for that tenant's KB.
+              3. If backfill: confirm `event=backfill_login_walls_complete`
+                 logged within the last hour.
+
+      # ── R2: login_wall_detector_config_invalid ───────────────────────────
+      # Fires on ANY log line indicating a typo in
+      # KLAI_INGEST_LOGIN_WALL_DETECT_MODE. Detector falls back to audit_only
+      # so the pipeline keeps running, but operators must fix the env value.
+      - uid: spec-login-wall-detect-001-config-invalid
+        title: login_wall_detector_config_invalid
+        condition: threshold
+        data:
+          - refId: query
+            datasourceUid: victorialogs
+            queryType: instant
+            relativeTimeRange:
+              from: 600
+              to: 0
+            model:
+              refId: query
+              datasource:
+                type: victoriametrics-logs-datasource
+                uid: victorialogs
+              expr: 'service:knowledge-ingest AND event:login_wall_detector_config_invalid'
+              queryType: instant
+          - refId: count
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 600
+              to: 0
+            model:
+              refId: count
+              type: reduce
+              reducer: count
+              expression: query
+          - refId: threshold
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 600
+              to: 0
+            model:
+              refId: threshold
+              type: threshold
+              expression: count
+              conditions:
+                - evaluator: { params: [0], type: gt }
+                  operator: { type: and }
+                  reducer: { params: [], type: last }
+                  type: query
+        noDataState: OK
+        execErrState: Alerting
+        for: 0s
+        keepFiringFor: 30m
+        isPaused: false
+        labels:
+          severity: warning
+          spec: SPEC-INGEST-LOGIN-WALL-DETECT-001
+          service_group: ingest
+        annotations:
+          summary: 'login-wall detector mode is mis-configured'
+          description: |
+            knowledge-ingest's KLAI_INGEST_LOGIN_WALL_DETECT_MODE env var
+            contains an unrecognised value. The detector has fallen back
+            to "audit_only" (fail-safe) so no crawls are blocked, but the
+            intended behaviour (reject / degrade) is NOT in effect.
+
+            Triage:
+              1. ssh core-01 "docker exec klai-core-knowledge-ingest-1 \
+                                printenv KLAI_INGEST_LOGIN_WALL_DETECT_MODE"
+              2. Valid values: reject | degrade | audit_only
+              3. Fix in SOPS .env, redeploy via:
+                   /opt/klai/scripts/compose-up.sh knowledge-ingest

--- a/deploy/grafana/provisioning/alerting/policies.yaml
+++ b/deploy/grafana/provisioning/alerting/policies.yaml
@@ -86,3 +86,20 @@ policies:
         group_interval: 5m
         repeat_interval: 24h
         continue: false
+
+      # SPEC-INGEST-LOGIN-WALL-DETECT-001 REQ-08 — login-wall detection
+      # alerts. Burst alert (R1) fires on >50 detections in 10m; config-
+      # invalid alert (R2) fires on any mis-configured mode env. Both are
+      # warning-severity and route to ops with a 4h repeat — long enough to
+      # avoid noise while a tenant's first backfill drains, short enough to
+      # keep on-call aware if the rate doesn't drop.
+      - receiver: klai-ops-alerts-email
+        matchers:
+          - spec = SPEC-INGEST-LOGIN-WALL-DETECT-001
+        group_by:
+          - alertname
+          - service_group
+        group_wait: 30s
+        group_interval: 5m
+        repeat_interval: 4h
+        continue: false

--- a/docs/runbooks/login-wall-burst.md
+++ b/docs/runbooks/login-wall-burst.md
@@ -1,0 +1,104 @@
+# Runbook: login-wall burst alert
+
+**Alert**: `login_wall_burst`
+**Severity**: warning
+**Spec**: [SPEC-INGEST-LOGIN-WALL-DETECT-001](../../.moai/specs/SPEC-INGEST-LOGIN-WALL-DETECT-001/spec.md)
+
+## What this means
+
+knowledge-ingest's anonymous-crawl auth-wall detector emitted more than 50
+detections in the last 10 minutes. The detector flags pages whose markdown
+matches one of:
+
+- canonical login phrase ("you will have to log in with your X account",
+  "log in to read", etc.)
+- 5+ `redirect_to=` URL parameters
+- 5+ repetitions of the same `/login` href
+- short content + 3+ login anchors
+
+A sustained burst means **the system is currently catching a lot of walled
+pages**. That is good behaviour; this alert is meant to flag *unexpected*
+volumes so an operator can decide whether they're expected (backfill running,
+new tenant onboarding) or a regression (vendor changed auth, connector
+mis-configured).
+
+## Triage
+
+### Step 1 — Are we mid-backfill?
+
+```bash
+# VictoriaLogs query (paste in Grafana → Explore → victorialogs):
+service:knowledge-ingest AND event:backfill_login_walls_complete _time:[now-1h, now]
+```
+
+If a `backfill_login_walls_complete` event fired within the last hour AND
+the burst window matches the backfill timing → **expected**, no action.
+Wait for the rate to drop after the backfill finishes.
+
+### Step 2 — Which tenant is dominant?
+
+```
+service:knowledge-ingest AND (event:login_wall_reject OR event:login_wall_degrade OR event:login_wall_detected)
+| stats by(org_id, kb_slug) count()
+| sort desc
+| limit 5
+```
+
+If a single `org_id` accounts for > 80% of detections:
+
+- Check if it's a newly-onboarded tenant (created in the last 24h):
+  ```sql
+  SELECT id, slug, created_at FROM portal_orgs
+  WHERE zitadel_org_id = '<org_id_from_log>';
+  ```
+- New tenant + high rate = their first crawl is hitting login-walls. Likely
+  causes:
+  1. **Source site requires login** but their connector was set up without
+     cookies. Configure cookies via the existing connector wizard
+     ([SPEC-CRAWLER-004](../../.moai/specs/SPEC-CRAWLER-004/spec.md) cookie
+     path) and re-crawl.
+  2. **Stale crawl that already-walled pages were re-fetched**. Run the
+     backfill CLI to clean them out:
+     ```bash
+     ssh core-01 "docker exec klai-core-knowledge-ingest-1 \
+       python -m knowledge_ingest.backfill_tasks --org <slug> --kb <slug>"
+     ```
+
+### Step 3 — Did a vendor change their auth model?
+
+If the burst comes from a tenant that has been on the system for weeks +
+their existing connector hasn't been touched → the upstream vendor likely
+gated previously-public content.
+
+- Identify the page domain dominating the detections:
+  ```
+  service:knowledge-ingest AND event:login_wall_reject
+  | extract regex 'url=(?P<domain>https?://[^/ ]+)' from _msg
+  | stats by(domain) count() | sort desc
+  ```
+- Decide:
+  - Configure cookies + re-crawl (preferred if the content is essential).
+  - Accept the loss + run backfill to remove the walled chunks from Qdrant
+    so retrieval doesn't surface them.
+  - Reach out to the customer to discuss alternatives (manual upload,
+    different source, etc.).
+
+## False positives
+
+If a single tenant insists their pages are NOT login-walled:
+
+1. Pull the actual stored markdown:
+   ```sql
+   SELECT raw_markdown FROM knowledge.crawled_pages
+   WHERE org_id = '<org>' AND url = '<exact-url>';
+   ```
+2. Read the markdown. The detector logs the matching pattern:
+   `pattern=canonical_phrase_en` etc.
+3. If the pattern looks like a false positive, capture the markdown to
+   `klai-knowledge-ingest/tests/fixtures/clean_pages/<source>.md` as a
+   negative-case fixture and open a follow-up SPEC to refine the detector.
+
+## Resolution
+
+The alert auto-resolves when the rate drops below 50/10m. There is no
+manual close action.

--- a/klai-retrieval-api/retrieval_api/api/retrieve.py
+++ b/klai-retrieval-api/retrieval_api/api/retrieve.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 
 from retrieval_api.config import settings
 from retrieval_api.metrics import (
+    quality_floor_filtered_total,
     retrieval_chunks_total,
     retrieval_requests_total,
     step_latency_seconds,
@@ -282,6 +283,14 @@ async def retrieve(
             reranked, floor=settings.retrieval_quality_floor
         )
         decision_record["quality_floor_filtered"] = quality_floor_filtered
+        if quality_floor_filtered > 0:
+            # SPEC-INGEST-LOGIN-WALL-DETECT-001 REQ-08 — labelled by org_id so
+            # per-tenant pollution is visible in Grafana. Only increment on
+            # non-zero to keep metric cardinality predictable for tenants
+            # whose chunks never trip the floor.
+            quality_floor_filtered_total.labels(org_id=req.org_id).inc(
+                quality_floor_filtered
+            )
 
         # 5b. Source-aware selection (SPEC-KB-021)
         # Replaces separate router + quota: uses reranker scores to decide.

--- a/klai-retrieval-api/retrieval_api/metrics.py
+++ b/klai-retrieval-api/retrieval_api/metrics.py
@@ -74,3 +74,18 @@ retrieval_events_dropped_total = Counter(
     "retrieval_events_dropped_total",
     "Product events dropped because the pending-tasks cap was reached",
 )
+
+# SPEC-INGEST-LOGIN-WALL-DETECT-001 REQ-08 — chunks removed by the hard
+# quality-score floor (Phase E). Most increments are zero in steady state;
+# spikes signal either:
+#   - degrade-mode tenants whose backfill is still running (expected),
+#   - or an ingest-time detector miss (regression alert).
+# Labelled by org_id so per-tenant pollution is distinguishable from a
+# system-wide regression. We do NOT label by chunk_id (high-cardinality);
+# the chunk IDs are still emitted at DEBUG level in the per-request logs
+# for forensic lookup.
+quality_floor_filtered_total = Counter(
+    "klai_retrieval_quality_floor_filtered_total",
+    "Chunks removed by the quality-floor filter (SPEC-INGEST-LOGIN-WALL-DETECT-001)",
+    ["org_id"],
+)


### PR DESCRIPTION
## Why

Follow-up to PR #419 (Phases A-E). Adds the observability layer for the
login-wall detector: metrics, alerts, and a triage runbook. Decoupled from
the implementation PR to keep review scope manageable and to allow Phase F
to land in parallel with the canary rollout.

## What changed

- **\`klai_retrieval_quality_floor_filtered_total{org_id}\`** Counter on
  retrieval-api's existing \`/metrics\` endpoint. Increments only when the
  filter drops chunks (idle retrievals don't touch the counter — keeps
  cardinality predictable).

- **Two VictoriaLogs alerts** (knowledge-ingest is logs-only):
  - \`login_wall_burst\` — >50 detections in 10m. Threshold intentionally
    generous so voys's first 150-page backfill doesn't page on-call.
  - \`login_wall_detector_config_invalid\` — fires on any "config_invalid"
    log. Detector fail-safes to audit_only on bad mode env so pipeline
    keeps running, but operators must fix the env value.

- **Policy routing** for \`spec=SPEC-INGEST-LOGIN-WALL-DETECT-001\` →
  \`klai-ops-alerts-email\` with 4h repeat.

- **\`docs/runbooks/login-wall-burst.md\`** — triage steps: backfill check
  → tenant attribution → vendor-auth change → false-positive capture path.

## What's deliberately NOT in this PR

- Dedicated Grafana panel — current ingest dashboard is full; a follow-up
  PR will add a "login-walls per tenant" panel after canary produces
  sample data we can shape the visualisation around.
- Detector latency histogram — Phase A's p99 < 1ms test pin is sufficient
  proof; live histogram adds noise without operational signal.

## Tests

- 24/24 retrieval-api tests still green (\`test_quality_boost\` +
  \`test_quality_floor\`).
- Both YAML files parsed via \`yaml.safe_load\`.
- ruff clean on the modified Python files.

## Risk

- Alert thresholds (50/10m, 4h repeat) are educated guesses based on
  voys's 150-page backfill volume. Adjustable in a follow-up if first
  canary data shows them wrong.
- Counter \`org_id\` label is high but bounded (we have 2 production
  tenants right now). If we onboard 100+ tenants, this stays sub-1k
  unique label combinations — well within Prometheus comfort zone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)