### PR TITLE
refactor(mcp-tests): consolidate _allow() helper into shared conftest

### DIFF
--- a/klai-knowledge-mcp/tests/conftest.py
+++ b/klai-knowledge-mcp/tests/conftest.py
@@ -1,4 +1,8 @@
-"""Stable env for module-level config capture (SPEC-SEC-INTERNAL-001 REQ-9.5).
+"""Stable env for module-level config capture (SPEC-SEC-INTERNAL-001 REQ-9.5)
+and shared test helpers.
+
+Module-level env capture
+------------------------
 
 ``main.py`` captures every required secret env var at import time so a missing
 value fails the process loudly at startup. The previous test fixtures use
@@ -12,11 +16,23 @@ are also what main.py captures on first import. The per-test fixtures stay
 in place for documentation -- they happen to be no-ops once the module-level
 constants are correct, but they also keep the env values visible at test
 read-time.
+
+Shared helpers
+--------------
+
+``allow_verify_result`` returns a ``VerifyResult.allow(...)`` for tests that
+need to bypass identity verification (SPEC-SEC-IDENTITY-ASSERT-001 REQ-2)
+without rolling their own helper. Defaults match the standard
+``user1/org1/testorg`` fixture used by every taxonomy/security test; pass
+explicit kwargs for spoof scenarios in test_identity_assert.py.
 """
 
 from __future__ import annotations
 
 import os
+
+from klai_identity_assert import VerifyResult
+from klai_identity_assert.models import Evidence
 
 # Use unconditional assignment (not setdefault) so a stale value inherited
 # from the parent shell does not corrupt the test fixture chain.
@@ -26,3 +42,25 @@ os.environ["KNOWLEDGE_INGEST_URL"] = "http://knowledge-ingest:8000"
 os.environ["KNOWLEDGE_INGEST_SECRET"] = "test-secret"
 os.environ["PORTAL_API_URL"] = "http://portal-api:8010"
 os.environ["PORTAL_INTERNAL_SECRET"] = "portal-test-secret"
+
+
+def allow_verify_result(
+    *,
+    user_id: str = "user1",
+    org_id: str = "org1",
+    org_slug: str = "testorg",
+    evidence: Evidence = "jwt",
+) -> VerifyResult:
+    """Build an allow-style VerifyResult for tests that mock ``_asserter.verify``.
+
+    Defaults match the standard test fixture (``user1/org1/testorg``) used by
+    taxonomy, security, and sec-internal tests. Identity-assert tests pass
+    explicit kwargs (different user_id/org_id/org_slug/evidence) to exercise
+    spoof and membership-fallback scenarios.
+    """
+    return VerifyResult.allow(
+        user_id=user_id,
+        org_id=org_id,
+        org_slug=org_slug,
+        evidence=evidence,
+    )

--- a/klai-knowledge-mcp/tests/test_assertion_mode_taxonomy.py
+++ b/klai-knowledge-mcp/tests/test_assertion_mode_taxonomy.py
@@ -16,7 +16,8 @@ silently never exercise the taxonomy logic.
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from klai_identity_assert import VerifyResult
+
+from tests.conftest import allow_verify_result
 
 
 def _make_ctx(headers: dict | None = None):
@@ -44,12 +45,6 @@ def _valid_ctx():
             "x-internal-secret": "test-secret",
         }
     )
-
-
-def _allow() -> VerifyResult:
-    """Mirror of the helper in test_identity_assert.py — keeps every taxonomy
-    test focused on assertion_mode behaviour, not the identity-verify chain."""
-    return VerifyResult.allow(user_id="user1", org_id="org1", org_slug="testorg", evidence="jwt")  # type: ignore[arg-type]
 
 
 class TestAssertionModeType:
@@ -86,7 +81,9 @@ class TestAssertionModeValidation:
         from main import save_personal_knowledge
 
         ctx = _valid_ctx()
-        with patch("main._asserter.verify", new_callable=AsyncMock, return_value=_allow()):
+        with patch(
+            "main._asserter.verify", new_callable=AsyncMock, return_value=allow_verify_result()
+        ):
             result = await save_personal_knowledge(
                 title="Test",
                 content="content",
@@ -103,7 +100,9 @@ class TestAssertionModeValidation:
         from main import save_personal_knowledge
 
         ctx = _valid_ctx()
-        with patch("main._asserter.verify", new_callable=AsyncMock, return_value=_allow()):
+        with patch(
+            "main._asserter.verify", new_callable=AsyncMock, return_value=allow_verify_result()
+        ):
             result = await save_personal_knowledge(
                 title="Test",
                 content="content",
@@ -127,7 +126,9 @@ class TestAssertionModeValidValues:
 
         ctx = _valid_ctx()
         with (
-            patch("main._asserter.verify", new_callable=AsyncMock, return_value=_allow()),
+            patch(
+                "main._asserter.verify", new_callable=AsyncMock, return_value=allow_verify_result()
+            ),
             patch("main._save_to_ingest", new_callable=AsyncMock, return_value=True),
         ):
             result = await save_personal_knowledge(
@@ -166,7 +167,9 @@ class TestMissingAssertionModeDefaultsToUnknown:
             return True
 
         with (
-            patch("main._asserter.verify", new_callable=AsyncMock, return_value=_allow()),
+            patch(
+                "main._asserter.verify", new_callable=AsyncMock, return_value=allow_verify_result()
+            ),
             patch("main._save_to_ingest", side_effect=_capture_ingest),
         ):
             # Pass empty string to simulate missing/empty assertion_mode

--- a/klai-knowledge-mcp/tests/test_identity_assert.py
+++ b/klai-knowledge-mcp/tests/test_identity_assert.py
@@ -19,7 +19,9 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from klai_identity_assert import VerifyResult
+from klai_identity_assert import VerifyResult  # used for VerifyResult.deny() below
+
+from tests.conftest import allow_verify_result
 
 # ---------------------------------------------------------------------------
 # Fixtures and helpers
@@ -46,12 +48,6 @@ def _patch_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("KNOWLEDGE_INGEST_SECRET", "test-secret")
     monkeypatch.setenv("PORTAL_API_URL", "http://portal-api:8010")
     monkeypatch.setenv("PORTAL_INTERNAL_SECRET", "portal-test-secret")
-
-
-def _allow(
-    *, user_id: str, org_id: str, org_slug: str = "acme", evidence: str = "jwt"
-) -> VerifyResult:
-    return VerifyResult.allow(user_id=user_id, org_id=org_id, org_slug=org_slug, evidence=evidence)  # type: ignore[arg-type]
 
 
 def _spoof_headers(
@@ -183,7 +179,9 @@ class TestVerifiedIdentityForwarded:
 
         # Verifier returns canonical (user_id, org_id) values different from
         # whatever the headers asserted — proves we're sourcing from verified.
-        verified = _allow(user_id="VERIFIED-USER", org_id="VERIFIED-ORG", org_slug="acme")
+        verified = allow_verify_result(
+            user_id="VERIFIED-USER", org_id="VERIFIED-ORG", org_slug="acme"
+        )
 
         with (
             patch("main._asserter.verify", new_callable=AsyncMock, return_value=verified),
@@ -221,7 +219,9 @@ class TestVerifiedIdentityForwarded:
         """REQ-2.3: outgoing klai-docs PUT carries verified X-User-ID / X-Org-ID."""
         from main import save_to_docs
 
-        verified = _allow(user_id="VERIFIED-USER", org_id="VERIFIED-ORG", org_slug="acme")
+        verified = allow_verify_result(
+            user_id="VERIFIED-USER", org_id="VERIFIED-ORG", org_slug="acme"
+        )
 
         # Capture the outgoing headers from httpx PUT.
         captured: dict[str, dict[str, str]] = {}
@@ -372,7 +372,7 @@ class TestHappyPath:
     async def test_save_personal_knowledge_happy_path(self) -> None:
         from main import save_personal_knowledge
 
-        verified = _allow(user_id="u-1", org_id="o-1", org_slug="acme", evidence="jwt")
+        verified = allow_verify_result(user_id="u-1", org_id="o-1", org_slug="acme", evidence="jwt")
         with (
             patch("main._asserter.verify", new_callable=AsyncMock, return_value=verified),
             patch("main._save_to_ingest", new_callable=AsyncMock, return_value=True) as ingest_mock,
@@ -397,7 +397,9 @@ class TestHappyPath:
     async def test_save_org_knowledge_happy_path(self) -> None:
         from main import save_org_knowledge
 
-        verified = _allow(user_id="u-1", org_id="o-1", org_slug="acme", evidence="membership")
+        verified = allow_verify_result(
+            user_id="u-1", org_id="o-1", org_slug="acme", evidence="membership"
+        )
         with (
             patch("main._asserter.verify", new_callable=AsyncMock, return_value=verified),
             patch("main._save_to_ingest", new_callable=AsyncMock, return_value=True) as ingest_mock,

--- a/klai-knowledge-mcp/tests/test_mcp_security.py
+++ b/klai-knowledge-mcp/tests/test_mcp_security.py
@@ -3,7 +3,8 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from klai_identity_assert import VerifyResult
+
+from tests.conftest import allow_verify_result
 
 
 # Minimal mock for FastMCP Context
@@ -11,17 +12,6 @@ def _make_ctx(headers: dict | None = None):
     ctx = MagicMock()
     ctx.request_context.request.headers = headers or {}
     return ctx
-
-
-def _verified_allow() -> VerifyResult:
-    """Default 'identity verified' stub for tests not exercising the verify gate.
-
-    SPEC-SEC-IDENTITY-ASSERT-001 REQ-2 routes every tool through portal-api
-    /internal/identity/verify before any upstream call. Tests focused on
-    OTHER concerns (path traversal, secret validation) substitute this stub
-    so the verify gate doesn't shadow what they're really testing.
-    """
-    return VerifyResult.allow(user_id="user1", org_id="org1", org_slug="testorg", evidence="jwt")
 
 
 @pytest.fixture(autouse=True)
@@ -56,7 +46,9 @@ class TestPathTraversalValidation:
         from main import save_to_docs
 
         ctx = _make_ctx(_VALID_HEADERS)
-        with patch("main._asserter.verify", new_callable=AsyncMock, return_value=_verified_allow()):
+        with patch(
+            "main._asserter.verify", new_callable=AsyncMock, return_value=allow_verify_result()
+        ):
             result = await save_to_docs(
                 title="Test",
                 content="content",
@@ -72,7 +64,9 @@ class TestPathTraversalValidation:
         from main import save_to_docs
 
         ctx = _make_ctx(_VALID_HEADERS)
-        with patch("main._asserter.verify", new_callable=AsyncMock, return_value=_verified_allow()):
+        with patch(
+            "main._asserter.verify", new_callable=AsyncMock, return_value=allow_verify_result()
+        ):
             result = await save_to_docs(
                 title="Test",
                 content="content",
@@ -87,7 +81,9 @@ class TestPathTraversalValidation:
         from main import save_to_docs
 
         ctx = _make_ctx(_VALID_HEADERS)
-        with patch("main._asserter.verify", new_callable=AsyncMock, return_value=_verified_allow()):
+        with patch(
+            "main._asserter.verify", new_callable=AsyncMock, return_value=allow_verify_result()
+        ):
             result = await save_to_docs(
                 title="Test",
                 content="content",
@@ -103,7 +99,9 @@ class TestPathTraversalValidation:
         from main import save_to_docs
 
         ctx = _make_ctx(_VALID_HEADERS)
-        with patch("main._asserter.verify", new_callable=AsyncMock, return_value=_verified_allow()):
+        with patch(
+            "main._asserter.verify", new_callable=AsyncMock, return_value=allow_verify_result()
+        ):
             result = await save_to_docs(
                 title="Test",
                 content="content",
@@ -118,7 +116,9 @@ class TestPathTraversalValidation:
         from main import save_to_docs
 
         ctx = _make_ctx(_VALID_HEADERS)
-        with patch("main._asserter.verify", new_callable=AsyncMock, return_value=_verified_allow()):
+        with patch(
+            "main._asserter.verify", new_callable=AsyncMock, return_value=allow_verify_result()
+        ):
             result = await save_to_docs(
                 title="Test",
                 content="content",
@@ -134,7 +134,9 @@ class TestPathTraversalValidation:
 
         ctx = _make_ctx(_VALID_HEADERS)
         with (
-            patch("main._asserter.verify", new_callable=AsyncMock, return_value=_verified_allow()),
+            patch(
+                "main._asserter.verify", new_callable=AsyncMock, return_value=allow_verify_result()
+            ),
             patch("main.httpx.AsyncClient") as mock_client_cls,
         ):
             mock_resp = MagicMock()
@@ -209,7 +211,9 @@ class TestIncomingAuth:
 
         ctx = _make_ctx(_VALID_HEADERS)
         with (
-            patch("main._asserter.verify", new_callable=AsyncMock, return_value=_verified_allow()),
+            patch(
+                "main._asserter.verify", new_callable=AsyncMock, return_value=allow_verify_result()
+            ),
             patch("main._save_to_ingest", new_callable=AsyncMock, return_value=True),
         ):
             result = await save_personal_knowledge(

--- a/klai-knowledge-mcp/tests/test_sec_internal_001.py
+++ b/klai-knowledge-mcp/tests/test_sec_internal_001.py
@@ -17,17 +17,14 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from klai_identity_assert import VerifyResult
+
+from tests.conftest import allow_verify_result
 
 
 def _make_ctx(headers: dict | None = None) -> MagicMock:
     ctx = MagicMock()
     ctx.request_context.request.headers = headers or {}
     return ctx
-
-
-def _verified_allow() -> VerifyResult:
-    return VerifyResult.allow(user_id="user1", org_id="org1", org_slug="testorg", evidence="jwt")
 
 
 _VALID_HEADERS = {
@@ -63,7 +60,9 @@ class TestSaveToDocsDoesNotEchoUpstreamBody:
 
         ctx = _make_ctx(_VALID_HEADERS)
         with (
-            patch("main._asserter.verify", new_callable=AsyncMock, return_value=_verified_allow()),
+            patch(
+                "main._asserter.verify", new_callable=AsyncMock, return_value=allow_verify_result()
+            ),
             patch("main.httpx.AsyncClient") as mock_client_cls,
         ):
             list_resp = MagicMock()
@@ -108,7 +107,9 @@ class TestSaveToDocsDoesNotEchoUpstreamBody:
 
         ctx = _make_ctx(_VALID_HEADERS)
         with (
-            patch("main._asserter.verify", new_callable=AsyncMock, return_value=_verified_allow()),
+            patch(
+                "main._asserter.verify", new_callable=AsyncMock, return_value=allow_verify_result()
+            ),
             patch("main.httpx.AsyncClient") as mock_client_cls,
         ):
             list_resp = MagicMock()


### PR DESCRIPTION
Closes #423.

## Probleem

Het \`VerifyResult.allow(...)\` test-helper patroon stond als duplicaat in 4 MCP test files met twee licht verschillende signatures:

| File | Function | Signature |
|---|---|---|
| \`test_assertion_mode_taxonomy.py\` | \`_allow()\` | no-args |
| \`test_mcp_security.py\` | \`_verified_allow()\` | no-args |
| \`test_sec_internal_001.py\` | \`_verified_allow()\` | no-args |
| \`test_identity_assert.py\` | \`_allow(*, user_id, org_id, ...)\` | kwargs vereist |

Alle vier zijn nu vervangen door één \`allow_verify_result(...)\` in \`tests/conftest.py\` met defaults die matchen met de standaard fixture (user1/org1/testorg/jwt). Tests die andere identity tuples nodig hebben (spoof scenarios in \`test_identity_assert.py\`) overschrijven via expliciete kwargs.

## Bonus tijdens migratie

- \`conftest.py\` importeert nu de \`Evidence\` Literal type uit \`klai_identity_assert.models\` zodat de helper-signatuur volledig getype-checked is. De vorige helpers hadden \`# type: ignore[arg-type]\` om dezelfde warning te onderdrukken — die comment is niet meer nodig.
- \`ruff format\` heeft quote-escapes en line-wrapping cosmetisch genormaliseerd in alle 4 test files (geen logica change).

## Verificatie (lokaal in worktree)

\`\`\`
$ uv run ruff check .            → All checks passed!
$ uv run ruff format --check .   → 11 files already formatted
$ uv run --with pyright pyright  → 0 errors, 0 warnings, 0 informations
$ uv run pytest -q               → 53 passed in 1.54s
\`\`\`

## Impact

- Eén plek om de helper te onderhouden i.p.v. vier
- Eén type-correcte signature i.p.v. twee licht verschillende
- Voorkomt dat \`# type: ignore[arg-type]\` opnieuw verspreid wordt over copies