### PR TITLE
chore(mcp-tests): move helpers to tests/_helpers + add helper tests

### DIFF
--- a/klai-knowledge-mcp/tests/_helpers.py
+++ b/klai-knowledge-mcp/tests/_helpers.py
@@ -1,0 +1,39 @@
+"""Shared test helpers for klai-knowledge-mcp.
+
+Lives next to ``conftest.py`` but as its own module so callers can use a
+plain ``from tests._helpers import allow_verify_result`` import. Conftest
+is reserved for pytest fixture / hook registration; mixing helpers in
+there relies on pytest's import side-effects rather than a real module
+contract.
+"""
+
+from __future__ import annotations
+
+from klai_identity_assert import VerifyResult
+from klai_identity_assert.models import Evidence
+
+
+def allow_verify_result(
+    *,
+    user_id: str = "user1",
+    org_id: str = "org1",
+    org_slug: str = "testorg",
+    evidence: Evidence = "jwt",
+) -> VerifyResult:
+    """Build an allow-style ``VerifyResult`` for tests that mock ``_asserter.verify``.
+
+    Defaults match the standard test fixture (``user1/org1/testorg``) used by
+    every taxonomy/security/sec-internal test. Identity-assert tests pass
+    explicit kwargs (different ``user_id``/``org_id``/``org_slug``/``evidence``)
+    to exercise spoof and membership-fallback scenarios.
+
+    Returns a properly-typed ``VerifyResult`` — no ``# type: ignore`` needed
+    at the call sites because ``evidence`` is constrained to the ``Evidence``
+    Literal at the function boundary.
+    """
+    return VerifyResult.allow(
+        user_id=user_id,
+        org_id=org_id,
+        org_slug=org_slug,
+        evidence=evidence,
+    )

--- a/klai-knowledge-mcp/tests/conftest.py
+++ b/klai-knowledge-mcp/tests/conftest.py
@@ -1,8 +1,4 @@
-"""Stable env for module-level config capture (SPEC-SEC-INTERNAL-001 REQ-9.5)
-and shared test helpers.
-
-Module-level env capture
-------------------------
+"""Stable env for module-level config capture (SPEC-SEC-INTERNAL-001 REQ-9.5).
 
 ``main.py`` captures every required secret env var at import time so a missing
 value fails the process loudly at startup. The previous test fixtures use
@@ -17,22 +13,13 @@ in place for documentation -- they happen to be no-ops once the module-level
 constants are correct, but they also keep the env values visible at test
 read-time.
 
-Shared helpers
---------------
-
-``allow_verify_result`` returns a ``VerifyResult.allow(...)`` for tests that
-need to bypass identity verification (SPEC-SEC-IDENTITY-ASSERT-001 REQ-2)
-without rolling their own helper. Defaults match the standard
-``user1/org1/testorg`` fixture used by every taxonomy/security test; pass
-explicit kwargs for spoof scenarios in test_identity_assert.py.
+Shared test helpers (``allow_verify_result`` etc.) live in
+``tests/_helpers.py`` — keeping conftest focused on fixtures + hooks.
 """
 
 from __future__ import annotations
 
 import os
-
-from klai_identity_assert import VerifyResult
-from klai_identity_assert.models import Evidence
 
 # Use unconditional assignment (not setdefault) so a stale value inherited
 # from the parent shell does not corrupt the test fixture chain.
@@ -42,25 +29,3 @@ os.environ["KNOWLEDGE_INGEST_URL"] = "http://knowledge-ingest:8000"
 os.environ["KNOWLEDGE_INGEST_SECRET"] = "test-secret"
 os.environ["PORTAL_API_URL"] = "http://portal-api:8010"
 os.environ["PORTAL_INTERNAL_SECRET"] = "portal-test-secret"
-
-
-def allow_verify_result(
-    *,
-    user_id: str = "user1",
-    org_id: str = "org1",
-    org_slug: str = "testorg",
-    evidence: Evidence = "jwt",
-) -> VerifyResult:
-    """Build an allow-style VerifyResult for tests that mock ``_asserter.verify``.
-
-    Defaults match the standard test fixture (``user1/org1/testorg``) used by
-    taxonomy, security, and sec-internal tests. Identity-assert tests pass
-    explicit kwargs (different user_id/org_id/org_slug/evidence) to exercise
-    spoof and membership-fallback scenarios.
-    """
-    return VerifyResult.allow(
-        user_id=user_id,
-        org_id=org_id,
-        org_slug=org_slug,
-        evidence=evidence,
-    )

--- a/klai-knowledge-mcp/tests/test_assertion_mode_taxonomy.py
+++ b/klai-knowledge-mcp/tests/test_assertion_mode_taxonomy.py
@@ -17,7 +17,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from tests.conftest import allow_verify_result
+from tests._helpers import allow_verify_result
 
 
 def _make_ctx(headers: dict | None = None):

--- a/klai-knowledge-mcp/tests/test_helpers.py
+++ b/klai-knowledge-mcp/tests/test_helpers.py
@@ -1,0 +1,64 @@
+"""Tests for the shared test helpers in ``tests/_helpers.py``.
+
+These tests guard the contract that 53+ other tests rely on:
+- Default identity tuple is ``user1/org1/testorg`` with ``jwt`` evidence
+- Override via kwargs works for spoof / membership scenarios
+- Result is a properly-typed ``VerifyResult`` allow-result
+"""
+
+from __future__ import annotations
+
+from klai_identity_assert import VerifyResult
+
+from tests._helpers import allow_verify_result
+
+
+class TestAllowVerifyResultDefaults:
+    """The no-args call must produce the standard test fixture identity."""
+
+    def test_returns_verify_result_instance(self):
+        result = allow_verify_result()
+        assert isinstance(result, VerifyResult)
+
+    def test_default_identity_tuple(self):
+        result = allow_verify_result()
+        # Defaults match the standard fixture used by taxonomy / security /
+        # sec-internal tests. Changing these silently would shift the
+        # identity surface for ~50 tests.
+        assert result.user_id == "user1"
+        assert result.org_id == "org1"
+        assert result.org_slug == "testorg"
+
+    def test_default_evidence_is_jwt(self):
+        result = allow_verify_result()
+        assert result.evidence == "jwt"
+
+    def test_verified_is_true(self):
+        # An allow-result MUST set ``verified=True`` — otherwise the helper
+        # is silently behaving like a deny-result and tests would short-
+        # circuit through ``_ERR_IDENTITY_REJECTED`` instead of the path
+        # they meant to exercise.
+        result = allow_verify_result()
+        assert result.verified is True
+
+
+class TestAllowVerifyResultOverrides:
+    """Identity-specific tests (spoof / membership) override via kwargs."""
+
+    def test_user_id_override(self):
+        result = allow_verify_result(user_id="VERIFIED-USER")
+        assert result.user_id == "VERIFIED-USER"
+        # Other defaults stay intact.
+        assert result.org_id == "org1"
+
+    def test_full_override(self):
+        result = allow_verify_result(
+            user_id="u-1",
+            org_id="o-1",
+            org_slug="acme",
+            evidence="membership",
+        )
+        assert result.user_id == "u-1"
+        assert result.org_id == "o-1"
+        assert result.org_slug == "acme"
+        assert result.evidence == "membership"

--- a/klai-knowledge-mcp/tests/test_identity_assert.py
+++ b/klai-knowledge-mcp/tests/test_identity_assert.py
@@ -21,7 +21,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from klai_identity_assert import VerifyResult  # used for VerifyResult.deny() below
 
-from tests.conftest import allow_verify_result
+from tests._helpers import allow_verify_result
 
 # ---------------------------------------------------------------------------
 # Fixtures and helpers

--- a/klai-knowledge-mcp/tests/test_mcp_security.py
+++ b/klai-knowledge-mcp/tests/test_mcp_security.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from tests.conftest import allow_verify_result
+from tests._helpers import allow_verify_result
 
 
 # Minimal mock for FastMCP Context

--- a/klai-knowledge-mcp/tests/test_sec_internal_001.py
+++ b/klai-knowledge-mcp/tests/test_sec_internal_001.py
@@ -18,7 +18,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from tests.conftest import allow_verify_result
+from tests._helpers import allow_verify_result
 
 
 def _make_ctx(headers: dict | None = None) -> MagicMock:


### PR DESCRIPTION
Tidy follow-up to [PR #425](https://github.com/GetKlai/klai/pull/425) (closed #423). Addresses the post-merge zelfreview-punten 1 en 3.

## Wijzigingen

### 1. Helper verplaatst naar dedicated module

\`allow_verify_result\` zat in \`conftest.py\`, maar conftest is bedoeld voor pytest fixture/hook registration. Importing van helpers eruit werkt door pytest's import side-effects, niet door een echt module-contract.

Nieuw: \`tests/_helpers.py\` met de helper. Imports in 4 test-files aangepast:

\`\`\`diff
- from tests.conftest import allow_verify_result
+ from tests._helpers import allow_verify_result
\`\`\`

### 2. Nieuwe \`tests/test_helpers.py\`

6 tests die het contract bewaken waar 53+ andere tests op leunen:
- Returns properly-typed \`VerifyResult\`
- Default identity tuple is \`user1/org1/testorg\`
- Default evidence is \`jwt\`
- \`verified\` flag is True (allow, niet stilletjes deny)
- Kwarg overrides werken voor spoof/membership scenarios
- Full override zet alle 4 velden onafhankelijk

## Bewust NIET in deze PR (zelfreview-punt 2)

\`user_id\` en \`org_id\` blijven defaults houden. Required maken zou 5 no-arg call-sites in taxonomy/mcp_security/sec_internal_001 forceren naar expliciete kwargs zonder echte safety-winst — die tests bedoelen \"de standaard fixture identity\".

## Verificatie (lokaal)

\`\`\`
$ uv run ruff check .            → All checks passed!
$ uv run ruff format --check .   → 13 files already formatted
$ uv run --with pyright pyright  → 0 errors, 0 warnings, 0 informations
$ uv run pytest -q               → 59 passed in 3.48s
\`\`\`

(53 bestaande tests + 6 nieuwe helper-tests)