### PR TITLE
chore(deploy): wire KLAI_INGEST_LOGIN_WALL_DETECT_* env passthrough

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1290,6 +1290,14 @@ services:
       # via POST /ingest/v1/crawl/sync. Shares portal-api's KEK so every
       # service decrypts the same blobs. Empty disables the endpoint.
       ENCRYPTION_KEY: ${PORTAL_API_ENCRYPTION_KEY}
+      # SPEC-INGEST-LOGIN-WALL-DETECT-001 — anonymous-crawl auth-wall
+      # detection. Production target: enabled=true + mode=reject. Override
+      # KLAI_INGEST_LOGIN_WALL_DETECT_MODE=audit_only in /opt/klai/.env
+      # for the canary window, then remove the override to fall back to
+      # "reject" once FP-rate is verified. The default values in
+      # knowledge_ingest/config.py match the compose defaults below.
+      KLAI_INGEST_LOGIN_WALL_DETECT_ENABLED: ${KLAI_INGEST_LOGIN_WALL_DETECT_ENABLED:-true}
+      KLAI_INGEST_LOGIN_WALL_DETECT_MODE: ${KLAI_INGEST_LOGIN_WALL_DETECT_MODE:-reject}
     networks:
       - klai-net
       - net-postgres


### PR DESCRIPTION
## Why

SPEC-INGEST-LOGIN-WALL-DETECT-001 follow-up. PR #419 added the new env vars to \`knowledge_ingest/config.py\` but knowledge-ingest in compose uses an explicit \`environment:\` block — vars added to \`.env\` alone are NOT auto-forwarded to the container.

Without this PR, setting the env in \`/opt/klai/.env\` has zero effect (verified by re-reading the docker-rules pitfall: "portal-api uses explicit \`environment:\` block — env vars are NOT auto-forwarded from \`.env\`").

## What

Adds two lines to the knowledge-ingest \`environment:\` block:

\`\`\`yaml
KLAI_INGEST_LOGIN_WALL_DETECT_ENABLED: \${KLAI_INGEST_LOGIN_WALL_DETECT_ENABLED:-true}
KLAI_INGEST_LOGIN_WALL_DETECT_MODE: \${KLAI_INGEST_LOGIN_WALL_DETECT_MODE:-reject}
\`\`\`

Defaults match \`knowledge_ingest/config.py\` so behaviour is unchanged when neither var is set in \`.env\`. SOPS doesn't need to be touched — the production target (\`reject\`) IS the compose default.

## Canary procedure (operator)

After this PR merges and \`deploy-compose.yml\` syncs (~1-2 min):

\`\`\`bash
# Enter canary mode (audit_only — log + ingest unchanged)
ssh core-01
echo "KLAI_INGEST_LOGIN_WALL_DETECT_MODE=audit_only" >> /opt/klai/.env
cd /opt/klai && docker compose up -d knowledge-ingest

# Monitor 1-2h via VictoriaLogs:
#   service:knowledge-ingest AND event:login_wall_detected
#   | stats by(org_id, kb_slug, pattern) count() | sort desc

# After FP-rate < 1%, switch to reject (production target):
sed -i '/^KLAI_INGEST_LOGIN_WALL_DETECT_MODE=/d' /opt/klai/.env
cd /opt/klai && docker compose up -d knowledge-ingest

# Verify mode active in container:
docker exec klai-core-knowledge-ingest-1 printenv KLAI_INGEST_LOGIN_WALL_DETECT_MODE
# (prints "reject" — the compose default)
\`\`\`

## No code or test impact

Pure compose env-passthrough. No tests; the runtime behaviour was already covered by Phase B integration tests (\`test_ingest_login_wall_integration.py\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)