### PR TITLE
chore(taxonomy): FOLLOWUP-001 close-out — cluster_probability_mean + status:implemented

### DIFF
--- a/.moai/specs/SPEC-TAXONOMY-V2-001-FOLLOWUP-001/spec.md
+++ b/.moai/specs/SPEC-TAXONOMY-V2-001-FOLLOWUP-001/spec.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-TAXONOMY-V2-001-FOLLOWUP-001
 version: "0.1.0"
-status: draft
+status: implemented
 created: 2026-05-06
 updated: 2026-05-06
 author: Mark Vletter

--- a/klai-knowledge-ingest/knowledge_ingest/clustering.py
+++ b/klai-knowledge-ingest/knowledge_ingest/clustering.py
@@ -240,7 +240,7 @@ def cluster_documents_hdbscan(
 
     SPEC-TAXONOMY-V2-001 AC-1, AC-16.
     SPEC-TAXONOMY-V2-001-FOLLOWUP-001 B1: UMAP pre-reduction (pre_reduce=True by default).
-    SPEC-TAXONOMY-V2-001-FOLLOWUP-001 B5: cluster_persistence_mean replaces dbcv_score.
+    SPEC-TAXONOMY-V2-001-FOLLOWUP-001 B5: cluster_probability_mean replaces dbcv_score.
         sklearn 1.8 HDBSCAN does NOT expose relative_validity_ (confirmed in production via
         hasattr() returning False). Use cluster_persistence_ (always available) instead.
 
@@ -253,8 +253,8 @@ def cluster_documents_hdbscan(
 
     Returns:
         labels: (n_docs,) int array; -1 = outlier/noise.
-        metrics: dict with keys clusters_found, outlier_count, cluster_persistence_mean.
-                 cluster_persistence_mean is None when 0 clusters found or attribute unavailable.
+        metrics: dict with keys clusters_found, outlier_count, cluster_probability_mean.
+                 cluster_probability_mean is None when 0 clusters found or attribute unavailable.
     """
     import numpy as np
 
@@ -267,7 +267,7 @@ def cluster_documents_hdbscan(
         return np.full(n, -1, dtype=np.int32), {
             "clusters_found": 0,
             "outlier_count": n,
-            "cluster_persistence_mean": None,
+            "cluster_probability_mean": None,
         }
 
     if pre_reduce:
@@ -290,23 +290,28 @@ def cluster_documents_hdbscan(
     clusters_found = len(cluster_ids)
     outlier_count = int((labels == -1).sum())
 
-    # Cluster persistence — sklearn HDBSCAN's native per-cluster quality metric.
-    # Mean across clusters is a meaningful quality summary.
-    # (replaces dbcv_score which assumed relative_validity_; sklearn 1.8 doesn't
-    #  expose it — confirmed via hasattr() returning False in production.)
-    cluster_persistence_mean: float | None = None
-    if clusters_found >= 1 and hasattr(hdb, "cluster_persistence_"):
+    # Mean cluster-membership probability — sklearn HDBSCAN's actually-available
+    # quality proxy. Higher = more confident clustering (per-point probability of
+    # belonging to its assigned cluster, averaged over non-outlier points).
+    #
+    # Note: sklearn 1.8's HDBSCAN port does NOT expose either `relative_validity_`
+    # (DBCV, B3 attempt) or `cluster_persistence_` (B5 attempt). Both attributes
+    # exist only in the standalone `hdbscan` package. We use `probabilities_`
+    # which sklearn does populate. SPEC-TAXONOMY-V2-001-FOLLOWUP-001 cleanup.
+    cluster_probability_mean: float | None = None
+    if clusters_found >= 1 and hasattr(hdb, "probabilities_"):
         try:
-            persistence = hdb.cluster_persistence_
-            if persistence is not None and len(persistence) > 0:
-                cluster_persistence_mean = float(persistence.mean())
+            probs = hdb.probabilities_
+            mask = labels >= 0
+            if probs is not None and mask.sum() > 0:
+                cluster_probability_mean = float(probs[mask].mean())
         except Exception:
-            cluster_persistence_mean = None
+            cluster_probability_mean = None
 
     return labels, {
         "clusters_found": clusters_found,
         "outlier_count": outlier_count,
-        "cluster_persistence_mean": cluster_persistence_mean,
+        "cluster_probability_mean": cluster_probability_mean,
     }
 
 

--- a/klai-knowledge-ingest/knowledge_ingest/proposal_generator.py
+++ b/klai-knowledge-ingest/knowledge_ingest/proposal_generator.py
@@ -536,7 +536,7 @@ async def generate_bootstrap_proposals_v2(
     )
     clusters_found: int = metrics["clusters_found"]
     outlier_count: int = metrics["outlier_count"]
-    cluster_persistence_mean: float | None = metrics["cluster_persistence_mean"]
+    cluster_probability_mean: float | None = metrics["cluster_probability_mean"]
 
     if clusters_found == 0:
         logger.info(
@@ -545,7 +545,7 @@ async def generate_bootstrap_proposals_v2(
             kb_slug=kb_slug,
             clusters_found=0,
             outlier_count=outlier_count,
-            cluster_persistence_mean=cluster_persistence_mean,
+            cluster_probability_mean=cluster_probability_mean,
             proposals_submitted=0,
         )
         return BootstrapResult(
@@ -668,7 +668,7 @@ async def generate_bootstrap_proposals_v2(
                 kb_slug=kb_slug,
                 clusters_found=clusters_found,
                 outlier_count=outlier_count,
-                cluster_persistence_mean=cluster_persistence_mean,
+                cluster_probability_mean=cluster_probability_mean,
                 proposals_submitted=0,
             )
             return BootstrapResult(
@@ -720,7 +720,7 @@ async def generate_bootstrap_proposals_v2(
         submitted += 1
 
     # Step 9: AC-9 log
-    # SPEC-TAXONOMY-V2-001-FOLLOWUP-001 B5: log cluster_persistence_mean instead of dbcv_score.
+    # SPEC-TAXONOMY-V2-001-FOLLOWUP-001 B5: log cluster_probability_mean instead of dbcv_score.
     # dbcv_score assumed relative_validity_ which sklearn 1.8 does not expose.
     logger.info(
         "bootstrap_proposals_complete",
@@ -728,7 +728,7 @@ async def generate_bootstrap_proposals_v2(
         kb_slug=kb_slug,
         clusters_found=clusters_found,
         outlier_count=outlier_count,
-        cluster_persistence_mean=cluster_persistence_mean,
+        cluster_probability_mean=cluster_probability_mean,
         proposals_submitted=submitted,
     )
 

--- a/klai-knowledge-ingest/tests/test_clustering_umap.py
+++ b/klai-knowledge-ingest/tests/test_clustering_umap.py
@@ -4,7 +4,7 @@ Tests for SPEC-TAXONOMY-V2-001-FOLLOWUP-001 Phase B fixes.
 B1: UMAP pre-reduction for HDBSCAN (AC-4, AC-5)
 B2: Description-generation restored in v2 bootstrap (AC-6, AC-7)
 B4: Cross-cluster aware batched naming (_suggest_cluster_names_batched)
-B5: cluster_persistence_mean replaces dbcv_score (field rename)
+B5: cluster_probability_mean replaces dbcv_score (field rename)
 """
 
 from __future__ import annotations
@@ -759,19 +759,19 @@ class TestBatchedNaming:
 
 
 # ---------------------------------------------------------------------------
-# B5 — cluster_persistence_mean field rename (was B3/dbcv_score)
+# B5 — cluster_probability_mean field rename (was B3/dbcv_score)
 # ---------------------------------------------------------------------------
 
 
 class TestClusterPersistenceMeanFieldRename:
-    """B5: cluster_persistence_mean replaces dbcv_score in cluster_documents_hdbscan and bootstrap log.
+    """B5: cluster_probability_mean replaces dbcv_score in cluster_documents_hdbscan and bootstrap log.
 
     dbcv_score assumed relative_validity_; sklearn 1.8 does not expose it (confirmed
     via hasattr() returning False in production). cluster_persistence_ is always available.
     """
 
-    def test_cluster_hdbscan_returns_cluster_persistence_mean_not_dbcv_or_silhouette(self):
-        """cluster_documents_hdbscan metrics dict has 'cluster_persistence_mean'.
+    def test_cluster_hdbscan_returns_cluster_probability_mean_not_dbcv_or_silhouette(self):
+        """cluster_documents_hdbscan metrics dict has 'cluster_probability_mean'.
 
         Must NOT contain 'dbcv_score' or 'silhouette_score'.
         SPEC-TAXONOMY-V2-001-FOLLOWUP-001 B5.
@@ -797,23 +797,23 @@ class TestClusterPersistenceMeanFieldRename:
             embeddings, min_cluster_size=5, pre_reduce=False
         )
 
-        assert "cluster_persistence_mean" in metrics, (
-            "cluster_persistence_mean must be present in metrics dict (B5)"
+        assert "cluster_probability_mean" in metrics, (
+            "cluster_probability_mean must be present in metrics dict (B5)"
         )
         assert "dbcv_score" not in metrics, (
-            "dbcv_score must NOT be present — B5 replaces it with cluster_persistence_mean"
+            "dbcv_score must NOT be present — B5 replaces it with cluster_probability_mean"
         )
         assert "silhouette_score" not in metrics, (
             "silhouette_score must NOT be present — renamed/removed in B3/B5"
         )
         # Value must be float or None
-        assert metrics["cluster_persistence_mean"] is None or isinstance(
-            metrics["cluster_persistence_mean"], float
+        assert metrics["cluster_probability_mean"] is None or isinstance(
+            metrics["cluster_probability_mean"], float
         )
 
     @pytest.mark.asyncio
-    async def test_completion_log_includes_cluster_persistence_mean_field(self):
-        """bootstrap_proposals_complete log event has 'cluster_persistence_mean'.
+    async def test_completion_log_includes_cluster_probability_mean_field(self):
+        """bootstrap_proposals_complete log event has 'cluster_probability_mean'.
 
         Must NOT contain 'dbcv_score' or 'silhouette_score'.
         SPEC-TAXONOMY-V2-001-FOLLOWUP-001 B5 (field propagation to logs).
@@ -891,8 +891,8 @@ class TestClusterPersistenceMeanFieldRename:
         )
 
         event = complete_events[0]
-        assert "cluster_persistence_mean" in event, (
-            "bootstrap_proposals_complete log must contain 'cluster_persistence_mean' field (B5)"
+        assert "cluster_probability_mean" in event, (
+            "bootstrap_proposals_complete log must contain 'cluster_probability_mean' field (B5)"
         )
         assert "dbcv_score" not in event, (
             "bootstrap_proposals_complete must NOT contain 'dbcv_score' (B5 replaces it)"
@@ -901,6 +901,6 @@ class TestClusterPersistenceMeanFieldRename:
             "bootstrap_proposals_complete must NOT contain 'silhouette_score'"
         )
         # Value must be float or None
-        assert event["cluster_persistence_mean"] is None or isinstance(
-            event["cluster_persistence_mean"], float
+        assert event["cluster_probability_mean"] is None or isinstance(
+            event["cluster_probability_mean"], float
         )

--- a/klai-knowledge-ingest/tests/test_naming_batched.py
+++ b/klai-knowledge-ingest/tests/test_naming_batched.py
@@ -2,14 +2,14 @@
 Tests for SPEC-TAXONOMY-V2-001-FOLLOWUP-001 B4 and B5.
 
 B4: Cross-cluster aware batched naming (_suggest_cluster_names_batched)
-B5: cluster_persistence_mean replaces dbcv_score in clustering metrics
+B5: cluster_probability_mean replaces dbcv_score in clustering metrics
 
 Six new tests:
 1. test_batched_naming_happy_path
 2. test_batched_naming_falls_back_when_parse_fails
 3. test_batched_naming_partial_response_falls_back_for_missing
 4. test_batched_naming_skipped_for_too_many_clusters
-5. test_cluster_persistence_mean_is_float_or_none
+5. test_cluster_probability_mean_is_float_or_none
 6. test_cluster_persistence_field_present_in_completion_log
 """
 
@@ -360,15 +360,15 @@ class TestBatchedNaming:
 
 
 # ---------------------------------------------------------------------------
-# B5 — cluster_persistence_mean
+# B5 — cluster_probability_mean
 # ---------------------------------------------------------------------------
 
 
 class TestClusterPersistenceMean:
-    """B5: cluster_persistence_mean metric tests."""
+    """B5: cluster_probability_mean metric tests."""
 
-    def test_cluster_persistence_mean_is_float_or_none(self):
-        """cluster_documents_hdbscan metrics dict has cluster_persistence_mean (float or None).
+    def test_cluster_probability_mean_is_float_or_none(self):
+        """cluster_documents_hdbscan metrics dict has cluster_probability_mean (float or None).
 
         NOT dbcv_score. NOT silhouette_score.
         SPEC-TAXONOMY-V2-001-FOLLOWUP-001 B5.
@@ -393,25 +393,25 @@ class TestClusterPersistenceMean:
             embeddings, min_cluster_size=5, pre_reduce=False
         )
 
-        # B5: cluster_persistence_mean present, dbcv_score absent
-        assert "cluster_persistence_mean" in metrics, (
-            "cluster_persistence_mean must be in metrics (B5)"
+        # B5: cluster_probability_mean present, dbcv_score absent
+        assert "cluster_probability_mean" in metrics, (
+            "cluster_probability_mean must be in metrics (B5)"
         )
         assert "dbcv_score" not in metrics, (
-            "dbcv_score must NOT be in metrics (replaced by cluster_persistence_mean in B5)"
+            "dbcv_score must NOT be in metrics (replaced by cluster_probability_mean in B5)"
         )
         assert "silhouette_score" not in metrics, (
             "silhouette_score must NOT be in metrics (removed in B3)"
         )
 
-        val = metrics["cluster_persistence_mean"]
+        val = metrics["cluster_probability_mean"]
         assert val is None or isinstance(val, float), (
-            f"cluster_persistence_mean must be float or None, got {type(val)}"
+            f"cluster_probability_mean must be float or None, got {type(val)}"
         )
 
     @pytest.mark.asyncio
     async def test_cluster_persistence_field_present_in_completion_log(self):
-        """bootstrap_proposals_complete log event contains cluster_persistence_mean.
+        """bootstrap_proposals_complete log event contains cluster_probability_mean.
 
         dbcv_score and silhouette_score must NOT be present.
         Full regression guard for B3 + B5.
@@ -489,9 +489,9 @@ class TestClusterPersistenceMean:
         assert len(complete_events) >= 1, "Expected at least one bootstrap_proposals_complete event"
 
         event = complete_events[0]
-        # B5: cluster_persistence_mean present
-        assert "cluster_persistence_mean" in event, (
-            "bootstrap_proposals_complete must contain cluster_persistence_mean (B5)"
+        # B5: cluster_probability_mean present
+        assert "cluster_probability_mean" in event, (
+            "bootstrap_proposals_complete must contain cluster_probability_mean (B5)"
         )
         # Full regression: neither old field must appear
         assert "dbcv_score" not in event, (
@@ -501,7 +501,7 @@ class TestClusterPersistenceMean:
             "silhouette_score must NOT appear in bootstrap_proposals_complete (removed in B3)"
         )
         # Type check
-        val = event["cluster_persistence_mean"]
+        val = event["cluster_probability_mean"]
         assert val is None or isinstance(val, float), (
-            f"cluster_persistence_mean in log must be float or None, got {type(val)}"
+            f"cluster_probability_mean in log must be float or None, got {type(val)}"
         )

--- a/klai-knowledge-ingest/tests/test_taxonomy_v2_bootstrap.py
+++ b/klai-knowledge-ingest/tests/test_taxonomy_v2_bootstrap.py
@@ -143,10 +143,10 @@ class TestClusterDocumentsHdbscan:
         assert outlier_mask.sum() >= 5, f"Expected >= 5 outliers, got {outlier_mask.sum()}"
 
     def test_hdbscan_metrics_dict_contains_required_keys(self):
-        """Metrics dict must contain clusters_found, outlier_count, cluster_persistence_mean.
+        """Metrics dict must contain clusters_found, outlier_count, cluster_probability_mean.
 
-        SPEC-TAXONOMY-V2-001-FOLLOWUP-001 B5: cluster_persistence_mean replaces dbcv_score.
-        B3: silhouette_score was renamed; B5: dbcv_score replaced by cluster_persistence_mean.
+        SPEC-TAXONOMY-V2-001-FOLLOWUP-001 B5: cluster_probability_mean replaces dbcv_score.
+        B3: silhouette_score was renamed; B5: dbcv_score replaced by cluster_probability_mean.
         """
         from knowledge_ingest.clustering import cluster_documents_hdbscan
 
@@ -155,13 +155,13 @@ class TestClusterDocumentsHdbscan:
 
         assert "clusters_found" in metrics
         assert "outlier_count" in metrics
-        assert "cluster_persistence_mean" in metrics
+        assert "cluster_probability_mean" in metrics
         # Regression: neither silhouette_score nor dbcv_score must be present
         assert "silhouette_score" not in metrics
         assert "dbcv_score" not in metrics
 
-    def test_hdbscan_cluster_persistence_mean_is_float_or_none(self):
-        """cluster_persistence_mean is a float or None for multi-cluster results.
+    def test_hdbscan_cluster_probability_mean_is_float_or_none(self):
+        """cluster_probability_mean is a float or None for multi-cluster results.
 
         SPEC-TAXONOMY-V2-001-FOLLOWUP-001 B5: replaces dbcv_score (which assumed
         relative_validity_; sklearn 1.8 does not expose it).
@@ -171,16 +171,16 @@ class TestClusterDocumentsHdbscan:
         embeddings, _ = _make_synthetic_embeddings()
         _labels, metrics = cluster_documents_hdbscan(embeddings, min_cluster_size=5)
 
-        # With 3 clear clusters, cluster_persistence_mean should be a float
+        # With 3 clear clusters, cluster_probability_mean should be a float
         # (or None if cluster_persistence_ unavailable — both are acceptable)
-        assert metrics["cluster_persistence_mean"] is None or isinstance(
-            metrics["cluster_persistence_mean"], float
+        assert metrics["cluster_probability_mean"] is None or isinstance(
+            metrics["cluster_probability_mean"], float
         )
 
     def test_hdbscan_zero_clusters_persistence_mean_is_none(self):
-        """When HDBSCAN returns 0 clusters, cluster_persistence_mean must be None.
+        """When HDBSCAN returns 0 clusters, cluster_probability_mean must be None.
 
-        SPEC-TAXONOMY-V2-001-FOLLOWUP-001 B5: cluster_persistence_mean replaces dbcv_score.
+        SPEC-TAXONOMY-V2-001-FOLLOWUP-001 B5: cluster_probability_mean replaces dbcv_score.
         """
         from knowledge_ingest.clustering import cluster_documents_hdbscan
 
@@ -196,9 +196,9 @@ class TestClusterDocumentsHdbscan:
 
         _labels, metrics = cluster_documents_hdbscan(embeddings, min_cluster_size=5)
 
-        # 0 clusters → cluster_persistence_mean is undefined (None)
+        # 0 clusters → cluster_probability_mean is undefined (None)
         if metrics["clusters_found"] == 0:
-            assert metrics["cluster_persistence_mean"] is None
+            assert metrics["cluster_probability_mean"] is None
 
 
 # ---------------------------------------------------------------------------
@@ -659,11 +659,11 @@ class TestBootstrapProposalsV2Integration:
         assert len(complete_events) == 1, "Expected exactly one bootstrap_proposals_complete event"
 
         event = complete_events[0]
-        # SPEC-TAXONOMY-V2-001-FOLLOWUP-001 B5: cluster_persistence_mean replaces dbcv_score
+        # SPEC-TAXONOMY-V2-001-FOLLOWUP-001 B5: cluster_probability_mean replaces dbcv_score
         required_fields = [
             "clusters_found",
             "outlier_count",
-            "cluster_persistence_mean",
+            "cluster_probability_mean",
             "proposals_submitted",
             "kb_slug",
             "org_id",
@@ -674,7 +674,7 @@ class TestBootstrapProposalsV2Integration:
             )
         assert "silhouette_score" not in event, "silhouette_score must not appear (removed in B3)"
         assert "dbcv_score" not in event, (
-            "dbcv_score must not appear (replaced by cluster_persistence_mean in B5)"
+            "dbcv_score must not appear (replaced by cluster_probability_mean in B5)"
         )
 
 


### PR DESCRIPTION
## Summary

Close-out of SPEC-TAXONOMY-V2-001-FOLLOWUP-001 after Phase C live evaluation.

### Replace cluster_persistence_mean with cluster_probability_mean

Phase C diagnostic (live container) revealed sklearn 1.8 HDBSCAN port lacks both \`relative_validity_\` (B3) and \`cluster_persistence_\` (B5) — both attempted quality metrics always returned None. Use sklearn's actually-populated \`probabilities_\` attribute instead; take mean over non-outlier points as a proxy for cluster confidence.

Functional: higher = clustering was more confident per-point. Real metric, no longer silent-None.

### SPEC status

\`status: draft\` → \`status: implemented\`. All phases (A baseline + B1-B5 + C comparison) complete. See \`reports/taxonomy-v2.1-evaluation-2026-05-06/comparison.md\` for the AC-12 evaluation.

### Tests

52 passing (no regression). Field rename only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)