### PR TITLE
fix(SPEC-INGEST-LOGIN-WALL-DETECT-001): tighten NL canonical phrases (FP-rate 2.6%→0%)

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/utils/auth_wall_detector.py
+++ b/klai-knowledge-ingest/knowledge_ingest/utils/auth_wall_detector.py
@@ -83,11 +83,21 @@ _CANONICAL_EN: tuple[str, ...] = (
     "please log in",
 )
 
+# NL phrases must include a continuation token ("om verder", "om door", "om dit
+# te lezen") to distinguish a wall ("you must log in to continue") from
+# instructional content ("Log in to the Bubble web portal" as a setup step).
+# Production canary on voys/support found 4 false positives at 2.6% FP-rate
+# when using bare phrases like "meld u aan" or "in te loggen" — they matched
+# legitimate tutorials. The continuation tokens enforce the wall-specific
+# meaning. See test_auth_wall_detector_nl_continuation.py for the regression
+# fixtures captured directly from production.
 _CANONICAL_NL: tuple[str, ...] = (
-    "in te loggen",  # covers "u dient in te loggen"
-    "log in om",  # covers "log in om dit te lezen"
-    "meld u aan",  # covers "meld u aan om verder te gaan"
-    "aanmelden om",  # covers "aanmelden om verder te gaan"
+    "u dient in te loggen",  # explicit Dutch wall ("you must log in")
+    "log in om dit",  # "log in om dit te lezen / te zien"
+    "meld u aan om verder",  # "meld u aan om verder te gaan / te lezen"
+    "meld u aan om door",  # "meld u aan om door te gaan"
+    "aanmelden om verder",  # "aanmelden om verder te gaan / te lezen"
+    "aanmelden om door",  # "aanmelden om door te gaan"
 )
 
 # Condition B — substring count threshold.

--- a/klai-knowledge-ingest/tests/fixtures/clean_pages/redcactus_zoom_setup_nl.md
+++ b/klai-knowledge-ingest/tests/fixtures/clean_pages/redcactus_zoom_setup_nl.md
@@ -1,0 +1,142 @@
+##  Handleiding - Zoom 
+Beschikbaar voor: 
+Bubble Desktop beschikbaar voor: Windows 
+Bubble Desktop beschikbaar voor: MacOS 
+Bubble Cloud beschikbaar voor: Bubble365 Apps 
+Bubble Mobile beschikbaar voor: iOS/Android 
+# Zoom Phone-configuratie
+## Opmerkingen
+  * Deze integratie werkt uitsluitend met Zoom **Phone**.
+  * Het e-mailadres van de gebruikers dat in Zoom wordt gebruikt, moet overeenkomen met het e-mailadres dat in Bubble wordt gebruikt.
+
+
+## Configuratie in het Partnerportaal
+**De app autoriseren**
+De autorisatie wordt **organisatiebreed** uitgevoerd door een Zoom-beheerder.
+  1. Meld u aan bij het **Bubble-webportaal**.
+  2. Navigeer naar: **Mijn account → Bubble → Telefoonconnectoren → Zoom**
+  3. Klik op **Autoriseren**.
+  4. U wordt doorgestuurd naar Zoom om de gevraagde machtigingen goed te keuren.
+  5. Keur het autorisatieverzoek goed.
+
+
+Zodra de autorisatie is voltooid, kunnen de gebruikers van die organisatie de Zoom-integratie in Bubble gebruiken.Indien u problemen ondervindt tijdens de autorisatie of configuratie, raadpleeg dan de [FAQ-sectie](https://wiki.redcactus.cloud/en/phone-software/5edb6ac6-b858-4cfa-8fa1-f78b4b65cd4a#tab-faqs).
+**De volgende secties bevatten aanvullende details over de Bubble Zoom-integratie:**
+
+
+## Configuratie in Webconfigurator
+Ga in de Webconfigurator naar Telefoonconnectoren en activeer de Zoom-telefoonconnector door de schuifregelaar op de stand **Aan** te zetten.Er is geen aanvullende authenticatie vereist voor eindgebruikers.De connector functioneert automatisch zolang:
+  * De Zoom-app is geautoriseerd door een beheerder
+  * Het e-mailadres van de Bubble-gebruiker overeenkomt met het Zoom-gebruikersadres
+
+
+## Kenmerken
+Call control
+  * Beantwoorden knop
+Met de call control knop kunt u een oproep direct beantwoorden via een knop in de pop-up melding. 
+  * Beëindigen knop
+Met call control knop kun je een gesprek direct beëindigen via een knop in de pop-up melding. 
+  * Gespreks initiatie
+Gespreksinitiatie wordt ondersteund door deze integratie. Dat betekent dat u gemakkelijk een uitgaand telefoongesprek kunt starten met één muisklik (click to dial), kiesknop op uw toetsenbord (select to dial) of gebruik de Bubble remote dialer en SearchBar. 
+  * In de wacht/hervatten knop
+Zet een gesprek met één muisklik eenvoudig on hold tijdens een gesprek 
+  * Koud doorverbinden knop
+Met de koud doorverbinden functie kun je het gesprek direct doorzetten naar een telefoonnummer zonder ruggespraak. 
+  * Aangekondigd doorverbinden knop
+Met de aangekondigd doorverbinden functie kun je het gesprek doorzetten naar een telefoonnummer met ruggespraak. 
+  * DTMF-ondersteuning
+Met DTMF-support kun je tijdens een telefoongesprek via de Bubble- en Bubble365-apps een toets indrukken om een keuze te maken in bijvoorbeeld het keuzemenu aan de andere kant van de lijn. 
+
+AI-gesprektranscripties
+  * Ondersteund via telefonieplatform
+Transcripties worden door het telefonieplatform zelf gegenereerd en via Bubble naar het gekoppelde CRM weggeschreven (indien ondersteund). 
+
+Gespreks events
+  * Inkomende events
+Hiermee kan Bubble gegevens voor inkomende gesprekken tonen. 
+  * Uitgaande events
+Hiermee kan Bubble gegevens voor uitgaande gesprekken tonen. 
+  * Doorverbonden events
+Bubble toont ook de gegevens bij doorverbonden gesprekken. 
+  * Extern nummer (inkomend)
+De parameter $external_number is beschikbaar voor inkomende gesprekken. 
+  * Extern nummer (uitgaand)
+De parameter $external_number is beschikbaar voor uitgaande gesprekken. 
+
+Integratie type
+  * Bedrijfsniveau
+Deze telefooncentrale ondersteunt verificatie op bedrijfsniveau. Het is alleen nodig om de interne telefoonnummers/extensies toe te voegen aan de gebruiker(s) in het partnerportaal. 
+  * Clone template
+Er moet een template worden gebruikt bij het clonen van de profielen omdat er een user authorisatie plaatsvindt die niet meegecloned kan worden. 
+
+Implementatietype
+  * Bubble Desktop
+Bubble is geïnstalleerd op elke gebruiker/werkstation en draait lokaal op de computer van de gebruiker. 
+  * Bubble Cloud
+Bubble wordt gehost in de cloud, dus lokale installatie is niet nodig. Let op: Deze optie vereist de Bubble Cloud-add-on licentie. Voor cloudhosting is het altijd noodzakelijk dat onze cloud-IP-adressen toegang hebben tot de CRM-/telefonieomgeving. 
+
+
+Selected article: 
+Ondersteuning voor Zoom Phone-integratie Hoe verwijder ik de app? Hoe gebruikt u de app?
+[ Ondersteuning voor Zoom Phone-integratie](https://wiki.redcactus.cloud/nl/phone-software/zoom#tab-faq-da104de6-9e03-451c-97ed-7e712184fd91) [ Hoe verwijder ik de app?](https://wiki.redcactus.cloud/nl/phone-software/zoom#tab-faq-76b16271-c247-483d-a6dd-0d587058d351) [ Hoe gebruikt u de app?](https://wiki.redcactus.cloud/nl/phone-software/zoom#tab-faq-c5ce3034-bcb0-4721-9922-eb21db23cb69)
+### Ondersteuning voor Zoom Phone-integratie
+Indien u hulp nodig heeft met de Bubble Zoom Phone-integratie, vindt u hieronder informatie over hoe u contact kunt opnemen met de ondersteuning en toegang krijgt tot relevante bronnen.
+**Neem contact op met uw partner**
+Voor configuratie, onboarding en algemene ondersteuning kunt u contact opnemen met uw gecertificeerde Bubble-partner.Vind partners [hier.](https://www.redcactus.cloud/partnerlijst)
+**Documentatie**
+Klik [hier](https://wiki.redcactus.cloud/phone-software/5edb6ac6-b858-4cfa-8fa1-f78b4b65cd4a) om de handleiding voor de Zoom Phone-integratie te bekijken.
+**Een Bubble-licentie nodig?**
+Vraag een gratis proefperiode van 30 dagen aan via een van onze partners. De volledige lijst vindt u [hier](https://www.redcactus.cloud/partnerlijst).
+**Contact opnemen met leverancier**
+Voor partners die contact met ons willen opnemen:**Tiket aanmaken** : <https://www.redcactus.cloud/contact>**E-mail** : support@redcactus.cloud**Telefoon** :Nederlands: [+31113405065](tel:+31113405065)Engels: [+443302367088](tel:+443302367088)
+Openingstijden: maandag - vrijdag, 08:30 - 17:00 CETEerste reactie SLA: binnen 3 werkdagen
+### Hoe verwijder ik de app?
+**De app verwijderen**
+De Bubble Zoom-integratie kan te allen tijde worden verwijderd door een Zoom-beheerder.
+**Verwijderen uit Zoom**
+  1. Meld u aan bij uw Zoom-account.
+  2. Ga naar de Zoom App Marketplace.
+  3. Navigeer naar **Beheren → Toegevoegde apps**.
+  4. Selecteer **Bubble**.
+  5. Klik op **Verwijderen**.
+
+
+**Gevolgen van verwijdering**
+  * Bubble verliest onmiddellijk de toegang tot Zoom.
+  * Zoom Phone-gebeurtenissen worden niet langer naar Bubble verzonden.
+  * Zoom-gerelateerde functionaliteit in Bubble werkt niet meer.
+
+
+**Gegevensverwerking na verwijdering**
+  * Bubble slaat geen Zoom-belgegevens of opnamen op.
+  * Bubble bewaart Zoom-account-ID’s en OAuth-tokens die tijdens de autorisatie zijn aangemaakt.
+  * De autorisatie (OAuth-tokens) moet handmatig worden verwijderd in het Bubble-webportaal:**Mijn account → Bubble → Telefoonconnectoren → Zoom**
+
+
+### Hoe gebruikt u de app?
+#### **Vereisten**
+Beheerder (Zoom-beheerder)
+  * Zoom-app geautoriseerd op organisatieniveau
+
+
+Eindgebruiker
+  * Zoom Phone ingeschakeld op het Zoom-account
+  * Zoom Phone-connector geactiveerd voor de gebruiker in Bubble
+  * Het Zoom-gebruikersadres komt overeen met het Bubble-gebruikersadres
+
+
+#### **Overzicht**
+Wanneer de Zoom Phone-connector is ingeschakeld, ontvangt Bubble Zoom Phone-gespreksgebeurtenissen en verrijkt deze met gegevens van een ingeschakelde **CRM-connector**. Hierdoor kunnen gebruikers bellers identificeren, interactie hebben met klantrecords en gespreksgerelateerde informatie opslaan in het CRM tijdens en na gesprekken.
+**Identificatie van inkomende en uitgaande gesprekken** Wanneer een gebruiker een Zoom Phone-gesprek maakt of ontvangt, gebruikt Bubble het telefoongebeurtenis om verwante klantinformatie op te zoeken via de ingeschakelde CRM-connector. Hierdoor kan de gebruiker direct zien wie er belt.
+**CRM-interactie tijdens een gesprek** Tijdens een actief gesprek kunnen gebruikers rechtstreeks vanuit Bubble acties uitvoeren die betrekking hebben op het CRM. 
+  * Gebruikers kunnen naar het klantrecord navigeren
+  * Aangepaste knoppen kunnen worden gebruikt om:
+    * Terugbelfa notities aan te maken
+    * CRM-gerelateerde acties te starten
+  * Acties zijn gekoppeld aan de context van het lopende gesprek
+  * Wilt u weten wat er beschikbaar is voor uw specifieke CRM? [Bekijk de Marketplace](https://marketplace.redcactus.cloud/en)
+
+
+**Gespreksnotities en CRM-registratie** Gebruikers kunnen tijdens een gesprek notities maken en deze automatisch opslaan in het gekoppelde CRM zodra het gesprek is beëindigd.
+**AI-transcriptiebeheer** Als Zoom AI-transcripties zijn ingeschakeld, kunnen gespreks transcripties in Bubble worden bekeken en aangepast voordat ze naar het CRM worden verzonden.
+

--- a/klai-knowledge-ingest/tests/fixtures/clean_pages/voys_account_toegang.md
+++ b/klai-knowledge-ingest/tests/fixtures/clean_pages/voys_account_toegang.md
@@ -1,0 +1,75 @@
+# Account & Toegang
+## Ik kan niet inloggen
+Lees verder om te zien wat je kunt doen als je je wachtwoord of gebruikersnaam bent vergeten, of als de persoon die de informatie had niet meer bij het bedrijf werkt.
+## **Ik ben mijn wachtwoord vergeten**
+  * Ga naar 
+  * Klik op **Wachtwoord vergeten**.
+  * Vul je **e-mailadres** in zoals bij ons bekend.
+  * Klik op **Herstel mijn wachtwoord**.
+
+
+### Ik ontvang de e-mail niet
+  * Staat de e-mail in je spamfolder?
+  * Staat de e-mail in je ongewenste e-mail?
+  * Heb je het juiste e-mailadres ingevuld?
+  * Niet zeker welk e-mailadres gebruikt wordt? Lees verder.
+
+
+## **Ik ben mijn gebruikersnaam vergeten of mijn e-mailadres bestaat niet meer**
+Kun je niet meer herinneren welk e-mailadres je gebruikte om in te loggen of heb je geen toegang meer tot de inbox van het oude e-mailadres? Vanwege privacy kunnen we het e-mailadres dat aan je account gekoppeld is niet delen. Neem contact op met ons team via de onderstaande gegevens.
+## Mijn collega werkt hier niet meer
+Kun je niet meer herinneren welk e-mailadres je gebruikte om in te loggen of heb je geen toegang meer tot de inbox van je voormalige collega? Vanwege privacy kunnen we niet delen welk e-mailadres we hebben. Neem contact op via de knop hieronder.
+## Mijn collega kan niet inloggen, maar ik wel
+**Gebruikersnaam opvragen**
+  * Log in op je .
+  * Klik op Beheer.
+  * Klik op **Gebruikers**.
+  * Hier staan alle e-mailadressen die bij ons bekend zijn. Lees  hoe je een gebruiker toevoegt.
+
+
+**Wachtwoord resetten**
+  * Log in op je .
+  * Klik op Beheer
+  * Klik op **Gebruikers**.
+  * Klik op het e-mailadres van je collega.
+  * Je bent nu meteen bij **persoonlijke gegevens**.
+  * Zoek het gedeelte **wachtwoord**.
+
+
+**Optie 1:** Stuur een e-mail en laat de gebruiker zelf een wachtwoord instellen.
+**Optie 2:** Verzin zelf een wachtwoord en vink 'Vereis wachtwoordwijziging na volgende login' aan als je wilt dat alleen je collega het wachtwoord kent.
+Je collega kan nu inloggen op Freedom, en ook op de Voys App of Webphone met deze inloggegevens.
+## FAQ
+Hoe wijzig je je adresgegevens?
+Ben je klant bij ons in Zuid-Afrika? Neem dan contact op om je adresgegevens te wijzigen.
+Je kunt je adresgegevens direct aanpassen op het platform.
+  * Log in op .
+  * Ga naar **Account**.
+  * Selecteer **Administratie**.
+  * Klik op **Facturatiegegevens**.
+  * Loop je ergens tegenaan? Neem contact op.
+
+
+Hoe wijzig ik de taal in Freedom?
+  * Log in op .
+  * Ga naar **Persoonlijk** rechtsboven.
+  * Klik op **Persoonlijke Instellingen**.
+  * Scroll naar **Voorkeuren** en kies je gewenste taal.
+  * Klik op **Opslaan**.
+
+
+Ik wil mijn account opzeggen
+Als admin kun je je telefoniediensten dagelijks opzeggen binnen ons platform met een simpele klik.
+  * Log in op je portal
+  * Ga naar **Account**
+  * Selecteer **Beheer**
+  * Klik op **Abonnement opzeggen**
+  * Je krijgt een bevestigingsvraag en klikt op "Opzegging bevestigen"
+  * De opzegging gaat in vanaf de datum dat je hem indient.
+  * Je krijgt binnen 1 werkdag een bevestiging van ons.
+
+
+## Gerelateerde pagina's
+Tweefactorauthenticatie instellen in Freedom
+Freedom: Je eerste keer
+

--- a/klai-knowledge-ingest/tests/test_auth_wall_detector_nl_continuation.py
+++ b/klai-knowledge-ingest/tests/test_auth_wall_detector_nl_continuation.py
@@ -1,0 +1,106 @@
+"""Regression tests for SPEC-INGEST-LOGIN-WALL-DETECT-001 NL FP fix.
+
+Production canary on 2026-05-06 (voys/support, 422 pages) found 4 false
+positives at 2.6% FP-rate from the original NL canonical phrases:
+  - "meld u aan"   matched "Meld u aan bij het Bubble-webportaal"
+                   (tutorial step, not a wall)
+  - "in te loggen" matched "om in te loggen of heb je geen toegang"
+                   (password-recovery FAQ, not a wall)
+
+The fix: tighten NL phrases to require a continuation token ("om verder",
+"om door", "om dit") that distinguishes a wall from instructional text. This
+test pins the production fixtures so the issue cannot regress silently.
+
+Walls SHOULD still fire:
+  - "u dient in te loggen om verder te gaan."
+  - "log in om dit te lezen"
+  - "meld u aan om verder te gaan"
+  - "aanmelden om door te gaan"
+
+Tutorial / instructional NL content MUST NOT fire:
+  - "Meld u aan bij het Bubble-webportaal" (Bubble setup step)
+  - "om in te loggen of heb je geen toegang" (password recovery FAQ)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from knowledge_ingest.utils.auth_wall_detector import detect_anonymous_auth_wall
+
+FIXTURES = Path(__file__).parent / "fixtures"
+CLEAN = FIXTURES / "clean_pages"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+class TestNlFalsePositiveRegression:
+    """Production fixtures that previously fired must now stay quiet."""
+
+    def test_redcactus_zoom_setup_does_not_fire(self) -> None:
+        """https://wiki.redcactus.cloud/nl/phone-software/zoom — Bubble-webportaal
+        setup tutorial. Contains "Meld u aan bij het Bubble-webportaal" multiple
+        times as STEP 1 of the integration setup. NOT a wall."""
+        text = _read(CLEAN / "redcactus_zoom_setup_nl.md")
+        result = detect_anonymous_auth_wall(text)
+        assert result is None, (
+            f"redcactus_zoom_setup_nl flagged as {result!r} — "
+            "this is instructional content, not a wall"
+        )
+
+    def test_voys_account_toegang_does_not_fire(self) -> None:
+        """https://help.voys.nl/account-toegang — password-recovery / account-
+        access FAQ. Contains "om in te loggen of heb je geen toegang"
+        in the body. NOT a wall."""
+        text = _read(CLEAN / "voys_account_toegang.md")
+        result = detect_anonymous_auth_wall(text)
+        assert result is None, (
+            f"voys_account_toegang flagged as {result!r} — this is a recovery FAQ, not a wall"
+        )
+
+
+class TestNlContinuationTokensStillFire:
+    """The tightened phrases must still catch real NL walls."""
+
+    @pytest.mark.parametrize(
+        "wall_text",
+        [
+            "U dient in te loggen om verder te gaan.",
+            "Log in om dit artikel te lezen.",
+            "Meld u aan om verder te lezen.",
+            "Meld u aan om door te gaan.",
+            "Aanmelden om verder te gaan.",
+            "Aanmelden om door te lezen.",
+        ],
+    )
+    def test_real_wall_phrases_fire(self, wall_text: str) -> None:
+        result = detect_anonymous_auth_wall(wall_text)
+        assert result is not None
+        assert result.pattern == "canonical_phrase_nl"
+        assert result.confidence >= 0.9
+
+
+class TestPureInstructionalNlNeverFires:
+    """Synthetic instructional content must not trip the detector."""
+
+    @pytest.mark.parametrize(
+        "instructional_text",
+        [
+            # Setup step
+            "Meld u aan bij het Bubble-webportaal en navigeer naar instellingen.",
+            # Recovery FAQ
+            "Het e-mailadres dat u gebruikt om in te loggen kunt u wijzigen "
+            "via uw accountinstellingen.",
+            # Tutorial
+            "Klik op 'Aanmelden' om uw account aan te maken.",
+            # Generic mention
+            "Vergeet niet uw wachtwoord op te slaan zodat u kunt in te loggen.",
+        ],
+    )
+    def test_instructional_text_does_not_fire(self, instructional_text: str) -> None:
+        result = detect_anonymous_auth_wall(instructional_text)
+        assert result is None, f"instructional text {instructional_text!r} fired as {result!r}"


### PR DESCRIPTION
## Why

Production canary on 2026-05-06 (voys/support, 422 pages running with \`audit_only\`) caught 4 NL false positives at 2.6% FP-rate:

| Source | URL | Bare phrase that fired | Context |
|---|---|---|---|
| RedCactus | \`/nl/phone-software/zoom\` | \`meld u aan\` | "Meld u aan bij het Bubble-webportaal" — setup step |
| RedCactus | \`/nl/phone-software/zoom-embedded\` | \`meld u aan\` | same content (different URL) |
| RedCactus | \`/nl/phone-software/5edb6ac6-...\` | \`meld u aan\` | same content (UUID URL) |
| Voys | \`/account-toegang\` | \`in te loggen\` | "om in te loggen of heb je geen toegang" — password-recovery FAQ |

Bare phrases were too permissive — instructional NL content that happens to mention authentication (Bubble setup steps, recovery FAQs) tripped them. EN canonical phrases were unaffected — they have specific wall-only constructions like "you will have to log in with your X account".

## Fix

Require a continuation token specific to walls:

\`\`\`diff
-  "in te loggen",         # too broad
-  "log in om",            # too broad
-  "meld u aan",           # too broad — fires on setup tutorials
-  "aanmelden om",         # too broad
+  "u dient in te loggen", # explicit Dutch wall
+  "log in om dit",        # "log in om dit te lezen / te zien"
+  "meld u aan om verder", # "meld u aan om verder te gaan / te lezen"
+  "meld u aan om door",   # "meld u aan om door te gaan"
+  "aanmelden om verder",  # "aanmelden om verder te gaan / te lezen"
+  "aanmelden om door",    # "aanmelden om door te gaan"
\`\`\`

## Tests

12 new tests in \`test_auth_wall_detector_nl_continuation.py\`:
- **2 production FP regression fixtures** captured directly from voys's \`knowledge.crawled_pages\`:
  - \`redcactus_zoom_setup_nl.md\` (142 lines)
  - \`voys_account_toegang.md\` (75 lines)
  Both MUST NOT fire — pinned so the original FPs cannot regress.
- **6 tightened-phrase wall fixtures** (parametrised) — all MUST fire.
- **4 synthetic instructional NL fixtures** — all MUST NOT fire.

All 29 existing detector tests still pass — EN phrases (which caught 150 of 154 production hits) are unchanged.

## Expected impact post-deploy

- voys/support: 154 → 150 detections (4 FPs eliminated)
- Detector TP rate: 100% on voys's data (up from ~97.4%)
- Backfill counts adjusted accordingly — no need to re-run the scan after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)