### PR TITLE
feat(tools): add Agent Browser CLI alongside Playwright MCP

### DIFF
--- a/.claude/rules/klai/lang/agent-browser.md
+++ b/.claude/rules/klai/lang/agent-browser.md
@@ -1,0 +1,143 @@
+---
+paths:
+  - "**"
+---
+# Agent Browser
+
+> AI-driven browser CLI by vercel-labs. Naast (niet vervang) Playwright MCP.
+> Source: https://github.com/vercel-labs/agent-browser
+> Installed: `npm i -g agent-browser && agent-browser install`
+
+## Tool selection — Agent Browser vs Playwright MCP
+
+| Use case | Tool | Reden |
+|---|---|---|
+| Verify-changes-landed (bekende selectors, deterministisch) | Playwright MCP | Stable, snapshot-driven asserts, headed visible browser |
+| Smoke test na deploy (intent: "klop service aan, niets stuk?") | **Agent Browser** | AI-navigatie tolereert UI-drift, geen selector-onderhoud |
+| Onboarding/signup regression (intent-stable, UI-volatile) | **Agent Browser** | Idem |
+| Audit-style runs (a11y, copy-consistency, design checks) | **Agent Browser** | Past bij exploratory scoring door evaluator-active |
+| One-off CSS/visual check zonder login | playwright-isolated MCP | Headed, ephemeral profile |
+| Authenticated portal regression met vaste selectors | Playwright MCP | Storage-state via `~/.claude/mcp-storageState.json` |
+
+Default: voor alles met "verify dat X werkt" → Playwright. Voor alles met "explore of er iets stuk is" → Agent Browser.
+
+## Parallel sessions [HARD]
+
+Elke Claude sessie MOET een unieke `--session` naam gebruiken. Anders leakt cookies/localStorage tussen sessies (issue [#1068](https://github.com/vercel-labs/agent-browser/issues/1068)).
+
+```bash
+# CORRECT — per Claude sessie eigen browser-instance
+SESSION="klai-${CLAUDE_SESSION_ID:-$(date +%s)}"
+npx agent-browser --session "$SESSION" open https://app.getklai.com
+npx agent-browser --session "$SESSION" snapshot -i -c
+npx agent-browser --session "$SESSION" close
+
+# FOUT — leakt cookies tussen parallelle agents
+npx agent-browser --auto-connect snapshot
+```
+
+Resource cost: elke unieke session = eigen Chromium-proces (~100MB). **Practical limit: max 3 parallelle sessies.** Bij meer: serialize of accepteer geheugendruk.
+
+## Command chaining (zelfde sessie binnen één Bash call)
+
+`$$` of `$RANDOM` expanderen per shell-invocation; gebruik een vaste env var:
+
+```bash
+# CORRECT
+SESSION="klai-smoke" \
+  && npx agent-browser --session "$SESSION" open https://getklai.com \
+  && npx agent-browser --session "$SESSION" wait --load networkidle \
+  && npx agent-browser --session "$SESSION" snapshot -i -c
+
+# FOUT — elke command wordt nieuwe sessie
+npx agent-browser --session "klai-$$" open https://getklai.com
+npx agent-browser --session "klai-$$" snapshot   # andere $$, andere sessie!
+```
+
+## Auth handoff voor portal flows
+
+Agent Browser kan **niet** de Playwright `~/.claude/mcp-storageState.json` direct laden. Eigen format via `state save` / `--state`.
+
+**One-time setup** (eenmalig, of refresh wanneer sessie verloopt):
+
+```bash
+# 1. Open portal headed (zonder --session-name = ephemeral, dan via state save)
+agent-browser open https://app.getklai.com
+# 2. Log in handmatig in geopende browser
+# 3. Save state
+agent-browser state save ~/.claude/agent-browser-state.json
+chmod 600 ~/.claude/agent-browser-state.json
+agent-browser close
+```
+
+**Daily use** in scripts/agents:
+
+```bash
+SESSION="klai-portal-${CLAUDE_SESSION_ID:-$(date +%s)}"
+agent-browser --session "$SESSION" \
+              --state ~/.claude/agent-browser-state.json \
+              open https://app.getklai.com/dashboard
+```
+
+Refresh storage-state om de paar weken (zelfde cadans als Playwright). Als sessies "logged-out" starten: state file is verlopen → opnieuw `state save`.
+
+## Cleanup [HARD]
+
+Net als Playwright: tabs/sessie sluiten ná elke run. Daemon laat anders Chromium-procs hangen.
+
+```bash
+agent-browser --session "$SESSION" close          # sluit één sessie
+agent-browser close --all                          # sluit alles (gebruik bij stuck procs)
+```
+
+Een hook-equivalent voor `playwright-browser-cleanup.sh` is **niet nodig** zolang agents zelf afsluiten — agent-browser sessies zijn isolated, dus een vergeten Chromium-proc blokkeert geen volgende sessie (anders dan Brave's `SingletonLock`).
+
+## Concrete patterns per use case
+
+### 1. Smoke test na deploy
+
+```bash
+SESSION="klai-deploy-smoke-${CLAUDE_SESSION_ID:-$(date +%s)}"
+agent-browser --session "$SESSION" open https://getklai.com \
+  && agent-browser --session "$SESSION" wait --load networkidle \
+  && agent-browser --session "$SESSION" snapshot -i -c -d 3 \
+  && agent-browser --session "$SESSION" close
+```
+
+Pass-criterium: snapshot bevat verwachte top-level navigatie (`PRODUCT`, `BLOG`, `PRICING`, `JOIN KLAI`). Als snapshot leeg of error: deploy issue.
+
+### 2. Onboarding regression (signup tot eerste vraag)
+
+```bash
+SESSION="klai-onboarding"
+agent-browser --session "$SESSION" open https://getklai.com \
+  && agent-browser --session "$SESSION" find role button click --name "JOIN KLAI" \
+  && agent-browser --session "$SESSION" wait --load networkidle \
+  && agent-browser --session "$SESSION" snapshot -i -c
+# AI agent navigeert verder; intent: "kom tot eerste antwoord"
+```
+
+### 3. Audit run (a11y / copy / design)
+
+```bash
+SESSION="klai-audit"
+agent-browser --session "$SESSION" open https://getklai.com \
+  && agent-browser --session "$SESSION" snapshot --json > /tmp/snapshot.json
+# Parse JSON voor heading-hiërarchie, missing alt-text, button labels
+agent-browser --session "$SESSION" eval "
+  const buttons = [...document.querySelectorAll('button')];
+  return buttons.filter(b => !b.textContent.trim() && !b.getAttribute('aria-label'));
+"
+```
+
+## Pitfalls
+
+- **agent-browser-no-shared-chrome** — Nooit `--auto-connect` voor parallelle Claude sessies. Cookies leaken (issue #1068). Use `--session "<unique>"`.
+- **agent-browser-session-shell-expansion** — `$$` of `$RANDOM` per command-aanroep = nieuwe sessie elke keer. Gebruik een env var die je vóór de chain set.
+- **agent-browser-storage-state-mismatch** — Niet de Playwright `~/.claude/mcp-storageState.json` proberen te laden. Eigen file `~/.claude/agent-browser-state.json` aanmaken via `state save`.
+- **agent-browser-stale-refs** — `@e1`, `@e2` zijn **fresh per snapshot**. Re-snapshot na elke navigation/click die de DOM wijzigt.
+
+## See also
+
+- `lang/testing.md` — Playwright MCP workflow (canonical voor verify-flows)
+- `pitfalls/process-rules.md` — `playwright-mcp-config-cycle` (waarom we Playwright config niet aanraken)

--- a/docs/setup/mcp-servers.md
+++ b/docs/setup/mcp-servers.md
@@ -310,7 +310,39 @@ curl -s -H "Authorization: Basic $VICTORIALOGS_BASIC_AUTH_B64" \
 
 For usage patterns and LogsQL queries, see `.claude/rules/klai/infra/observability.md`.
 
-## 9. Grafana MCP (dashboards and metrics only)
+## 9. Install Agent Browser (CLI, not MCP)
+
+Agent Browser is a Rust-based browser CLI by vercel-labs. **Not an MCP server** — agents call
+it directly via Bash. Used alongside (not instead of) Playwright MCP. Routing rules and
+parallel-session patterns: `.claude/rules/klai/lang/agent-browser.md`.
+
+```bash
+npm install -g agent-browser   # installs CLI globally
+agent-browser install          # downloads bundled Chrome (~170MB, one-time)
+```
+
+Verify: `npx agent-browser --version`.
+
+For authenticated portal flows, generate a state file once:
+
+```bash
+agent-browser open https://app.getklai.com   # log in manually in opened window
+agent-browser state save ~/.claude/agent-browser-state.json
+chmod 600 ~/.claude/agent-browser-state.json
+agent-browser close
+```
+
+Refresh when sessions start logged-out (cookie expiry, ~weeks).
+
+**When to use which browser tool:**
+
+| You know exactly what to verify? | Tool |
+|---|---|
+| Yes — bekende selectors, regression test | `playwright` MCP |
+| No — exploratory, smoke check, a11y/copy audit | Agent Browser CLI |
+| One-off CSS check, no auth needed | `playwright-isolated` MCP |
+
+## 10. Grafana MCP (dashboards and metrics only)
 
 Grafana MCP provides read-only access to dashboards, Prometheus/VictoriaMetrics queries, and
 alerts. It **cannot query VictoriaLogs** — the `query_loki_logs` tool speaks Loki protocol,
@@ -358,4 +390,4 @@ uvx mcp-grafana --help
 11. **VictoriaLogs tunnel not running** — MCP queries fail silently or timeout. Fix: `./scripts/victorialogs-tunnel.sh` then restart Claude Code.
 12. **VictoriaLogs auth missing** — `VICTORIALOGS_BASIC_AUTH_B64` not set in `~/.zshrc`. Symptoms: MCP connects but queries return 401. Fix: get the base64 value from SOPS and export it.
 13. **VictoriaLogs container IP changed** — Tunnel connects but queries fail. Cause: VictoriaLogs container restarted, got a new IP. Fix: `./scripts/victorialogs-tunnel.sh --stop && ./scripts/victorialogs-tunnel.sh` (re-resolves IP).
-14. **Grafana token missing** — `GRAFANA_SERVICE_ACCOUNT_TOKEN` not set. Symptoms: Grafana MCP fails to connect. Fix: create a per-developer service account in Grafana (see section 9) and export the token in your shell profile.
+14. **Grafana token missing** — `GRAFANA_SERVICE_ACCOUNT_TOKEN` not set. Symptoms: Grafana MCP fails to connect. Fix: create a per-developer service account in Grafana (see section 10) and export the token in your shell profile.


### PR DESCRIPTION
## Summary

Adds [vercel-labs/agent-browser](https://github.com/vercel-labs/agent-browser) as a second browser automation tool, complementing (not replacing) Playwright MCP.

**Routing rule:** if you know exactly what to verify → Playwright MCP. If you're exploring → Agent Browser.

| Use case | Tool |
|---|---|
| Verify-changes-landed (deterministic, known selectors, auth) | Playwright MCP |
| Smoke test after deploy ("is the service up?") | Agent Browser |
| Onboarding regression where UI drifts | Agent Browser |
| Audit runs (a11y, copy, design consistency) | Agent Browser |
| One-off CSS check, no auth | playwright-isolated MCP |

## Files

- **NEW** `.claude/rules/klai/lang/agent-browser.md` (143 lines, paths: `**`) — tool selection matrix, parallel session pattern (`--session "klai-${CLAUDE_SESSION_ID}"`), auth handoff procedure, 4 pitfalls
- **MOD** `docs/setup/mcp-servers.md` — section 9 added (CLI install, auth setup); existing Grafana section renumbered to 10; cross-reference updated

## Validation

- Smoke test on `getklai.com`: ~50 elements snapshot in ~600 tokens ✅
- Real a11y audit on homepage found **2 actual WCAG violations** (heading hierarchy: `h1 → h3`, `h2 → h4`) — separate issue for the website team

## Notable design choices

- **No MCP server installed** — Agent Browser is a CLI with persistent daemon, agents call it via Bash. No `.mcp.json` mutation (avoids `playwright-mcp-config-cycle` pitfall).
- **Per Claude session unique `--session`** to prevent cookie leakage between parallel sessions ([issue #1068](https://github.com/vercel-labs/agent-browser/issues/1068)).
- **Separate auth state file** at `~/.claude/agent-browser-state.json` — Agent Browser cannot load the Playwright storage-state JSON, has its own format. One-time manual login needed.

## Companion change (lives elsewhere)

The `agent-browser-no-shared-chrome` one-liner pitfall belongs in the new compact `pitfalls/process-rules.md` structure introduced on `docs/audit-ti-2026-05-05`. It is committed on that branch and will arrive on main when the rules-reorg merges. Until then the pitfall is fully documented inside `lang/agent-browser.md` itself.

## Test plan

- [x] Smoke test getklai.com (homepage snapshot)
- [x] A11y audit (eval-based heading/button/link/image checks)
- [ ] Authenticated portal flow (requires manual `state save` — documented procedure, not yet run)
- [ ] 5+ parallel Claude sessions stress test (resource cost not measured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)