### PR TITLE
fix(ci): direct trivy CLI + correct ignores + nghttp2 apk-upgrade — hotfix to PR #3

### DIFF
--- a/.github/workflows/caddy.yml
+++ b/.github/workflows/caddy.yml
@@ -74,29 +74,39 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # STRICT-tier scan per SPEC-CI-TRIVY-POLICY-001:
-      # severity / ignore-unfixed / scanners come from .trivy.yaml (REQ-1).
-      # exit-code: '1' blocks the build on unfixed HIGH/CRITICAL (REQ-2).
-      # limit-severities-for-sarif: 'true' makes the severity filter actually
-      # apply (neutralises trivy-action 0.35.0 SARIF severity-filter unset).
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.35.0
+      # STRICT-tier scan per SPEC-CI-TRIVY-POLICY-001 (REQ-2).
+      #
+      # We invoke Trivy CLI directly instead of via aquasecurity/trivy-action
+      # because that wrapper has a bug in 0.35.0 / 0.36.0 with `format: sarif`:
+      # the `severity` filter is honoured for the SARIF body but NOT for the
+      # exit-code — meaning a MEDIUM/LOW finding still triggers exit-code 1
+      # even when we asked for CRITICAL+HIGH gating only. Caddy / docs /
+      # whisper-server hit this bug on PR #3's first main run (e2303848)
+      # because they had findings in the SARIF that the wrapper let through
+      # to the exit-code check.
+      #
+      # Direct trivy CLI honours `--severity` for both detection and
+      # exit-code, so the filter actually applies. Same flags map 1:1 to
+      # `.trivy.yaml` keys and per-service `.trivyignore.yaml`. When
+      # trivy-action lands a fix (issue: aquasecurity/trivy-action ?), we
+      # can collapse this back to the wrapper.
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@e6c2c5e321ed9123bda567646e2f96565e34abe1  # v0.2.5
         with:
-          image-ref: ghcr.io/getklai/caddy-hetzner:${{ github.sha }}
-          trivy-config: .trivy.yaml
-          trivyignores: deploy/caddy/.trivyignore.yaml
-          # Inline duplicates are required: trivy-action 0.35.0's
-          # `limit-severities-for-sarif: true` only acts on INPUT_SEVERITY,
-          # not on config-file severity. Same for scanners. Keep .trivy.yaml
-          # as the canonical policy reference; remove these inlines once
-          # trivy-action lands proper config-file precedence.
-          scanners: 'vuln'
-          severity: 'CRITICAL,HIGH'
-          ignore-unfixed: true
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          exit-code: '1'
-          limit-severities-for-sarif: 'true'
+          version: v0.69.3
+          cache: true
+
+      - name: Run Trivy vulnerability scanner
+        run: |
+          trivy image \
+            --format sarif \
+            --output trivy-results.sarif \
+            --severity CRITICAL,HIGH \
+            --ignore-unfixed \
+            --scanners vuln \
+            --exit-code 1 \
+            --ignorefile deploy/caddy/.trivyignore.yaml \
+            ghcr.io/getklai/caddy-hetzner:${{ github.sha }}
 
       - name: Upload Trivy SARIF to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -65,29 +65,33 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # STRICT-tier scan per SPEC-CI-TRIVY-POLICY-001:
-      # severity / ignore-unfixed / scanners come from .trivy.yaml (REQ-1).
-      # exit-code: '1' blocks the build on unfixed HIGH/CRITICAL (REQ-2).
-      # limit-severities-for-sarif: 'true' makes the severity filter actually
-      # apply (neutralises trivy-action 0.35.0 SARIF severity-filter unset).
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.35.0
+      # STRICT-tier scan per SPEC-CI-TRIVY-POLICY-001 (REQ-2).
+      #
+      # Direct CLI invocation bypasses an aquasecurity/trivy-action
+      # bug (0.35.0/0.36.0): with `format: sarif` the `severity` filter
+      # is honoured for the SARIF body but NOT for the exit-code, so
+      # a MEDIUM/LOW finding triggers exit-code 1 even when we asked
+      # for CRITICAL+HIGH gating. trivy CLI's `--severity` flag is
+      # honoured for both detection AND exit-code. .trivy.yaml stays
+      # in the repo as the canonical policy reference until the
+      # action lands proper config-file precedence.
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@e6c2c5e321ed9123bda567646e2f96565e34abe1  # v0.2.5
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
-          trivy-config: .trivy.yaml
-          # Inline duplicates are required: trivy-action 0.35.0's
-          # `limit-severities-for-sarif: true` only acts on INPUT_SEVERITY,
-          # not on config-file severity. Same for scanners. Keep .trivy.yaml
-          # as the canonical policy reference; remove these inlines once
-          # trivy-action lands proper config-file precedence.
-          scanners: 'vuln'
-          severity: 'CRITICAL,HIGH'
-          ignore-unfixed: true
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          exit-code: '1'
-          limit-severities-for-sarif: 'true'
+          version: v0.69.3
+          cache: true
 
+      - name: Run Trivy vulnerability scanner
+        run: |
+          trivy image \
+            --format sarif \
+            --output trivy-results.sarif \
+            --severity CRITICAL,HIGH \
+            --ignore-unfixed \
+            --scanners vuln \
+            --exit-code 1 \
+            --ignorefile klai-docs/.trivyignore.yaml \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
       - name: Upload Trivy SARIF to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4
         if: always()

--- a/.github/workflows/klai-connector.yml
+++ b/.github/workflows/klai-connector.yml
@@ -145,30 +145,33 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # STRICT-tier scan per SPEC-CI-TRIVY-POLICY-001:
-      # severity / ignore-unfixed / scanners come from .trivy.yaml (REQ-1).
-      # exit-code: '1' blocks the build on unfixed HIGH/CRITICAL (REQ-2).
-      # limit-severities-for-sarif: 'true' makes the severity filter actually
-      # apply (neutralises trivy-action 0.35.0 SARIF severity-filter unset).
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.35.0
+      # STRICT-tier scan per SPEC-CI-TRIVY-POLICY-001 (REQ-2).
+      #
+      # Direct CLI invocation bypasses an aquasecurity/trivy-action
+      # bug (0.35.0/0.36.0): with `format: sarif` the `severity` filter
+      # is honoured for the SARIF body but NOT for the exit-code, so
+      # a MEDIUM/LOW finding triggers exit-code 1 even when we asked
+      # for CRITICAL+HIGH gating. trivy CLI's `--severity` flag is
+      # honoured for both detection AND exit-code. .trivy.yaml stays
+      # in the repo as the canonical policy reference until the
+      # action lands proper config-file precedence.
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@e6c2c5e321ed9123bda567646e2f96565e34abe1  # v0.2.5
         with:
-          image-ref: ghcr.io/getklai/klai-connector:${{ github.sha }}
-          trivy-config: .trivy.yaml
-          trivyignores: klai-connector/.trivyignore.yaml
-          # Inline duplicates are required: trivy-action 0.35.0's
-          # `limit-severities-for-sarif: true` only acts on INPUT_SEVERITY,
-          # not on config-file severity. Same for scanners. Keep .trivy.yaml
-          # as the canonical policy reference; remove these inlines once
-          # trivy-action lands proper config-file precedence.
-          scanners: 'vuln'
-          severity: 'CRITICAL,HIGH'
-          ignore-unfixed: true
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          exit-code: '1'
-          limit-severities-for-sarif: 'true'
+          version: v0.69.3
+          cache: true
 
+      - name: Run Trivy vulnerability scanner
+        run: |
+          trivy image \
+            --format sarif \
+            --output trivy-results.sarif \
+            --severity CRITICAL,HIGH \
+            --ignore-unfixed \
+            --scanners vuln \
+            --exit-code 1 \
+            --ignorefile klai-connector/.trivyignore.yaml \
+            ghcr.io/getklai/klai-connector:${{ github.sha }}
       - name: Upload Trivy SARIF to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4
         if: always()

--- a/.github/workflows/klai-knowledge-mcp.yml
+++ b/.github/workflows/klai-knowledge-mcp.yml
@@ -160,29 +160,32 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # STRICT-tier scan per SPEC-CI-TRIVY-POLICY-001:
-      # severity / ignore-unfixed / scanners come from .trivy.yaml (REQ-1).
-      # exit-code: '1' blocks the build on unfixed HIGH/CRITICAL (REQ-2).
-      # limit-severities-for-sarif: 'true' makes the severity filter actually
-      # apply (neutralises trivy-action 0.35.0 SARIF severity-filter unset).
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.35.0
+      # STRICT-tier scan per SPEC-CI-TRIVY-POLICY-001 (REQ-2).
+      #
+      # Direct CLI invocation bypasses an aquasecurity/trivy-action
+      # bug (0.35.0/0.36.0): with `format: sarif` the `severity` filter
+      # is honoured for the SARIF body but NOT for the exit-code, so
+      # a MEDIUM/LOW finding triggers exit-code 1 even when we asked
+      # for CRITICAL+HIGH gating. trivy CLI's `--severity` flag is
+      # honoured for both detection AND exit-code. .trivy.yaml stays
+      # in the repo as the canonical policy reference until the
+      # action lands proper config-file precedence.
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@e6c2c5e321ed9123bda567646e2f96565e34abe1  # v0.2.5
         with:
-          image-ref: ghcr.io/getklai/klai-knowledge-mcp:${{ github.sha }}
-          trivy-config: .trivy.yaml
-          # Inline duplicates are required: trivy-action 0.35.0's
-          # `limit-severities-for-sarif: true` only acts on INPUT_SEVERITY,
-          # not on config-file severity. Same for scanners. Keep .trivy.yaml
-          # as the canonical policy reference; remove these inlines once
-          # trivy-action lands proper config-file precedence.
-          scanners: 'vuln'
-          severity: 'CRITICAL,HIGH'
-          ignore-unfixed: true
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          exit-code: '1'
-          limit-severities-for-sarif: 'true'
+          version: v0.69.3
+          cache: true
 
+      - name: Run Trivy vulnerability scanner
+        run: |
+          trivy image \
+            --format sarif \
+            --output trivy-results.sarif \
+            --severity CRITICAL,HIGH \
+            --ignore-unfixed \
+            --scanners vuln \
+            --exit-code 1 \
+            ghcr.io/getklai/klai-knowledge-mcp:${{ github.sha }}
       - name: Upload Trivy SARIF to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4
         if: always()

--- a/.github/workflows/klai-mailer.yml
+++ b/.github/workflows/klai-mailer.yml
@@ -122,29 +122,32 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # STRICT-tier scan per SPEC-CI-TRIVY-POLICY-001:
-      # severity / ignore-unfixed / scanners come from .trivy.yaml (REQ-1).
-      # exit-code: '1' blocks the build on unfixed HIGH/CRITICAL (REQ-2).
-      # limit-severities-for-sarif: 'true' makes the severity filter actually
-      # apply (neutralises trivy-action 0.35.0 SARIF severity-filter unset).
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.35.0
+      # STRICT-tier scan per SPEC-CI-TRIVY-POLICY-001 (REQ-2).
+      #
+      # Direct CLI invocation bypasses an aquasecurity/trivy-action
+      # bug (0.35.0/0.36.0): with `format: sarif` the `severity` filter
+      # is honoured for the SARIF body but NOT for the exit-code, so
+      # a MEDIUM/LOW finding triggers exit-code 1 even when we asked
+      # for CRITICAL+HIGH gating. trivy CLI's `--severity` flag is
+      # honoured for both detection AND exit-code. .trivy.yaml stays
+      # in the repo as the canonical policy reference until the
+      # action lands proper config-file precedence.
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@e6c2c5e321ed9123bda567646e2f96565e34abe1  # v0.2.5
         with:
-          image-ref: ghcr.io/getklai/klai-mailer:${{ github.sha }}
-          trivy-config: .trivy.yaml
-          # Inline duplicates are required: trivy-action 0.35.0's
-          # `limit-severities-for-sarif: true` only acts on INPUT_SEVERITY,
-          # not on config-file severity. Same for scanners. Keep .trivy.yaml
-          # as the canonical policy reference; remove these inlines once
-          # trivy-action lands proper config-file precedence.
-          scanners: 'vuln'
-          severity: 'CRITICAL,HIGH'
-          ignore-unfixed: true
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          exit-code: '1'
-          limit-severities-for-sarif: 'true'
+          version: v0.69.3
+          cache: true
 
+      - name: Run Trivy vulnerability scanner
+        run: |
+          trivy image \
+            --format sarif \
+            --output trivy-results.sarif \
+            --severity CRITICAL,HIGH \
+            --ignore-unfixed \
+            --scanners vuln \
+            --exit-code 1 \
+            ghcr.io/getklai/klai-mailer:${{ github.sha }}
       - name: Upload Trivy SARIF to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4
         if: always()

--- a/.github/workflows/knowledge-ingest.yml
+++ b/.github/workflows/knowledge-ingest.yml
@@ -118,29 +118,32 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # STRICT-tier scan per SPEC-CI-TRIVY-POLICY-001:
-      # severity / ignore-unfixed / scanners come from .trivy.yaml (REQ-1).
-      # exit-code: '1' blocks the build on unfixed HIGH/CRITICAL (REQ-2).
-      # limit-severities-for-sarif: 'true' makes the severity filter actually
-      # apply (neutralises trivy-action 0.35.0 SARIF severity-filter unset).
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.35.0
+      # STRICT-tier scan per SPEC-CI-TRIVY-POLICY-001 (REQ-2).
+      #
+      # Direct CLI invocation bypasses an aquasecurity/trivy-action
+      # bug (0.35.0/0.36.0): with `format: sarif` the `severity` filter
+      # is honoured for the SARIF body but NOT for the exit-code, so
+      # a MEDIUM/LOW finding triggers exit-code 1 even when we asked
+      # for CRITICAL+HIGH gating. trivy CLI's `--severity` flag is
+      # honoured for both detection AND exit-code. .trivy.yaml stays
+      # in the repo as the canonical policy reference until the
+      # action lands proper config-file precedence.
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@e6c2c5e321ed9123bda567646e2f96565e34abe1  # v0.2.5
         with:
-          image-ref: ghcr.io/getklai/knowledge-ingest:${{ github.sha }}
-          trivy-config: .trivy.yaml
-          # Inline duplicates are required: trivy-action 0.35.0's
-          # `limit-severities-for-sarif: true` only acts on INPUT_SEVERITY,
-          # not on config-file severity. Same for scanners. Keep .trivy.yaml
-          # as the canonical policy reference; remove these inlines once
-          # trivy-action lands proper config-file precedence.
-          scanners: 'vuln'
-          severity: 'CRITICAL,HIGH'
-          ignore-unfixed: true
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          exit-code: '1'
-          limit-severities-for-sarif: 'true'
+          version: v0.69.3
+          cache: true
 
+      - name: Run Trivy vulnerability scanner
+        run: |
+          trivy image \
+            --format sarif \
+            --output trivy-results.sarif \
+            --severity CRITICAL,HIGH \
+            --ignore-unfixed \
+            --scanners vuln \
+            --exit-code 1 \
+            ghcr.io/getklai/knowledge-ingest:${{ github.sha }}
       - name: Upload Trivy SARIF to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4
         if: always()

--- a/.github/workflows/portal-api.yml
+++ b/.github/workflows/portal-api.yml
@@ -302,40 +302,33 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # STRICT-tier scan per SPEC-CI-TRIVY-POLICY-001:
-      # - severity / ignore-unfixed / scanners come from .trivy.yaml (REQ-1)
-      # - exit-code: '1' blocks the build on any unfixed HIGH/CRITICAL not
-      #   listed in klai-portal/backend/.trivyignore.yaml (REQ-2)
-      # - limit-severities-for-sarif: 'true' makes the severity filter
-      #   actually apply to both the SARIF output AND the exit-code check.
-      #   Without it, trivy-action 0.35.0's entrypoint unsets TRIVY_SEVERITY
-      #   for `format: sarif`, causing exit-code 1 to fire on MEDIUM/LOW too.
+      # STRICT-tier scan per SPEC-CI-TRIVY-POLICY-001 (REQ-2).
       #
-      # vuln-only matters because Trivy's secret scanner matches strings
-      # inside third-party Python libraries shipped under /repo/.../site-
-      # packages — yt-dlp's per-streaming-service extractors hardcode
-      # public API tokens (NBC, Vice, ESPN, Shahid, …) that flag as
-      # CRITICAL aws-access-key-id / HIGH jwt-token false positives.
-      # Source-level secret scanning is covered by Semgrep + Gitleaks.
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.35.0
+      # Direct CLI invocation bypasses an aquasecurity/trivy-action
+      # bug (0.35.0/0.36.0): with `format: sarif` the `severity` filter
+      # is honoured for the SARIF body but NOT for the exit-code, so
+      # a MEDIUM/LOW finding triggers exit-code 1 even when we asked
+      # for CRITICAL+HIGH gating. trivy CLI's `--severity` flag is
+      # honoured for both detection AND exit-code. .trivy.yaml stays
+      # in the repo as the canonical policy reference until the
+      # action lands proper config-file precedence.
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@e6c2c5e321ed9123bda567646e2f96565e34abe1  # v0.2.5
         with:
-          image-ref: ghcr.io/getklai/portal-api:${{ github.sha }}
-          trivy-config: .trivy.yaml
-          trivyignores: klai-portal/backend/.trivyignore.yaml
-          # Inline duplicates are required: trivy-action 0.35.0's
-          # `limit-severities-for-sarif: true` only acts on INPUT_SEVERITY,
-          # not on config-file severity. Same for scanners. Keep .trivy.yaml
-          # as the canonical policy reference; remove these inlines once
-          # trivy-action lands proper config-file precedence.
-          scanners: 'vuln'
-          severity: 'CRITICAL,HIGH'
-          ignore-unfixed: true
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          exit-code: '1'
-          limit-severities-for-sarif: 'true'
+          version: v0.69.3
+          cache: true
 
+      - name: Run Trivy vulnerability scanner
+        run: |
+          trivy image \
+            --format sarif \
+            --output trivy-results.sarif \
+            --severity CRITICAL,HIGH \
+            --ignore-unfixed \
+            --scanners vuln \
+            --exit-code 1 \
+            --ignorefile klai-portal/backend/.trivyignore.yaml \
+            ghcr.io/getklai/portal-api:${{ github.sha }}
       - name: Upload Trivy SARIF to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4
         if: always()

--- a/.github/workflows/retrieval-api.yml
+++ b/.github/workflows/retrieval-api.yml
@@ -105,29 +105,32 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # STRICT-tier scan per SPEC-CI-TRIVY-POLICY-001:
-      # severity / ignore-unfixed / scanners come from .trivy.yaml (REQ-1).
-      # exit-code: '1' blocks the build on unfixed HIGH/CRITICAL (REQ-2).
-      # limit-severities-for-sarif: 'true' makes the severity filter actually
-      # apply (neutralises trivy-action 0.35.0 SARIF severity-filter unset).
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.35.0
+      # STRICT-tier scan per SPEC-CI-TRIVY-POLICY-001 (REQ-2).
+      #
+      # Direct CLI invocation bypasses an aquasecurity/trivy-action
+      # bug (0.35.0/0.36.0): with `format: sarif` the `severity` filter
+      # is honoured for the SARIF body but NOT for the exit-code, so
+      # a MEDIUM/LOW finding triggers exit-code 1 even when we asked
+      # for CRITICAL+HIGH gating. trivy CLI's `--severity` flag is
+      # honoured for both detection AND exit-code. .trivy.yaml stays
+      # in the repo as the canonical policy reference until the
+      # action lands proper config-file precedence.
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@e6c2c5e321ed9123bda567646e2f96565e34abe1  # v0.2.5
         with:
-          image-ref: ghcr.io/getklai/retrieval-api:${{ github.sha }}
-          trivy-config: .trivy.yaml
-          # Inline duplicates are required: trivy-action 0.35.0's
-          # `limit-severities-for-sarif: true` only acts on INPUT_SEVERITY,
-          # not on config-file severity. Same for scanners. Keep .trivy.yaml
-          # as the canonical policy reference; remove these inlines once
-          # trivy-action lands proper config-file precedence.
-          scanners: 'vuln'
-          severity: 'CRITICAL,HIGH'
-          ignore-unfixed: true
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          exit-code: '1'
-          limit-severities-for-sarif: 'true'
+          version: v0.69.3
+          cache: true
 
+      - name: Run Trivy vulnerability scanner
+        run: |
+          trivy image \
+            --format sarif \
+            --output trivy-results.sarif \
+            --severity CRITICAL,HIGH \
+            --ignore-unfixed \
+            --scanners vuln \
+            --exit-code 1 \
+            ghcr.io/getklai/retrieval-api:${{ github.sha }}
       - name: Upload Trivy SARIF to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4
         if: always()

--- a/.github/workflows/scan-pinned-images.yml
+++ b/.github/workflows/scan-pinned-images.yml
@@ -95,25 +95,30 @@ jobs:
           echo "name=$SAFE" >> "$GITHUB_OUTPUT"
 
       # WARN-tier scan per SPEC-CI-TRIVY-POLICY-001 REQ-3.
-      # severity / ignore-unfixed / scanners come from .trivy.yaml (REQ-1).
-      # exit-code: '0' keeps this warn-only — Renovate handles upgrade pressure
-      # on the external base-images we pin in compose.
-      - name: Trivy scan
-        uses: aquasecurity/trivy-action@0.35.0
+      # `--exit-code 0` keeps this warn-only — Renovate handles upgrade
+      # pressure on the external base-images we pin in compose.
+      #
+      # Direct CLI invocation bypasses an aquasecurity/trivy-action bug
+      # (0.35.0/0.36.0): with `format: sarif` the `severity` filter is
+      # honoured for the SARIF body but NOT for the exit-code. Keeping
+      # the invocation consistent with STRICT-tier scans simplifies
+      # operations.
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@e6c2c5e321ed9123bda567646e2f96565e34abe1  # v0.2.5
         with:
-          image-ref: ${{ matrix.image }}
-          trivy-config: .trivy.yaml
-          # Inline duplicates are required: trivy-action 0.35.0's
-          # `limit-severities-for-sarif: true` only acts on INPUT_SEVERITY,
-          # not on config-file severity. Keep .trivy.yaml as the canonical
-          # policy reference; remove these inlines once trivy-action lands
-          # proper config-file precedence.
-          scanners: 'vuln'
-          severity: 'CRITICAL,HIGH'
-          ignore-unfixed: true
-          format: 'sarif'
-          output: 'trivy-${{ steps.safe.outputs.name }}.sarif'
-          exit-code: '0'  # Don't fail the job — Security tab is the alert surface
+          version: v0.69.3
+          cache: true
+
+      - name: Trivy scan
+        run: |
+          trivy image \
+            --format sarif \
+            --output trivy-${{ steps.safe.outputs.name }}.sarif \
+            --severity CRITICAL,HIGH \
+            --ignore-unfixed \
+            --scanners vuln \
+            --exit-code 0 \
+            ${{ matrix.image }}
 
       - name: Upload SARIF
         uses: github/codeql-action/upload-sarif@v4

--- a/.github/workflows/scribe-api.yml
+++ b/.github/workflows/scribe-api.yml
@@ -118,29 +118,32 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # STRICT-tier scan per SPEC-CI-TRIVY-POLICY-001:
-      # severity / ignore-unfixed / scanners come from .trivy.yaml (REQ-1).
-      # exit-code: '1' blocks the build on unfixed HIGH/CRITICAL (REQ-2).
-      # limit-severities-for-sarif: 'true' makes the severity filter actually
-      # apply (neutralises trivy-action 0.35.0 SARIF severity-filter unset).
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.35.0
+      # STRICT-tier scan per SPEC-CI-TRIVY-POLICY-001 (REQ-2).
+      #
+      # Direct CLI invocation bypasses an aquasecurity/trivy-action
+      # bug (0.35.0/0.36.0): with `format: sarif` the `severity` filter
+      # is honoured for the SARIF body but NOT for the exit-code, so
+      # a MEDIUM/LOW finding triggers exit-code 1 even when we asked
+      # for CRITICAL+HIGH gating. trivy CLI's `--severity` flag is
+      # honoured for both detection AND exit-code. .trivy.yaml stays
+      # in the repo as the canonical policy reference until the
+      # action lands proper config-file precedence.
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@e6c2c5e321ed9123bda567646e2f96565e34abe1  # v0.2.5
         with:
-          image-ref: ghcr.io/getklai/scribe-api:${{ github.sha }}
-          trivy-config: .trivy.yaml
-          # Inline duplicates are required: trivy-action 0.35.0's
-          # `limit-severities-for-sarif: true` only acts on INPUT_SEVERITY,
-          # not on config-file severity. Same for scanners. Keep .trivy.yaml
-          # as the canonical policy reference; remove these inlines once
-          # trivy-action lands proper config-file precedence.
-          scanners: 'vuln'
-          severity: 'CRITICAL,HIGH'
-          ignore-unfixed: true
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          exit-code: '1'
-          limit-severities-for-sarif: 'true'
+          version: v0.69.3
+          cache: true
 
+      - name: Run Trivy vulnerability scanner
+        run: |
+          trivy image \
+            --format sarif \
+            --output trivy-results.sarif \
+            --severity CRITICAL,HIGH \
+            --ignore-unfixed \
+            --scanners vuln \
+            --exit-code 1 \
+            ghcr.io/getklai/scribe-api:${{ github.sha }}
       - name: Upload Trivy SARIF to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4
         if: always()

--- a/.github/workflows/whisper-server.yml
+++ b/.github/workflows/whisper-server.yml
@@ -63,29 +63,33 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # STRICT-tier scan per SPEC-CI-TRIVY-POLICY-001:
-      # severity / ignore-unfixed / scanners come from .trivy.yaml (REQ-1).
-      # exit-code: '1' blocks the build on unfixed HIGH/CRITICAL (REQ-2).
-      # limit-severities-for-sarif: 'true' makes the severity filter actually
-      # apply (neutralises trivy-action 0.35.0 SARIF severity-filter unset).
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.35.0
+      # STRICT-tier scan per SPEC-CI-TRIVY-POLICY-001 (REQ-2).
+      #
+      # Direct CLI invocation bypasses an aquasecurity/trivy-action
+      # bug (0.35.0/0.36.0): with `format: sarif` the `severity` filter
+      # is honoured for the SARIF body but NOT for the exit-code, so
+      # a MEDIUM/LOW finding triggers exit-code 1 even when we asked
+      # for CRITICAL+HIGH gating. trivy CLI's `--severity` flag is
+      # honoured for both detection AND exit-code. .trivy.yaml stays
+      # in the repo as the canonical policy reference until the
+      # action lands proper config-file precedence.
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@e6c2c5e321ed9123bda567646e2f96565e34abe1  # v0.2.5
         with:
-          image-ref: ghcr.io/getklai/whisper-server:${{ github.sha }}
-          trivy-config: .trivy.yaml
-          # Inline duplicates are required: trivy-action 0.35.0's
-          # `limit-severities-for-sarif: true` only acts on INPUT_SEVERITY,
-          # not on config-file severity. Same for scanners. Keep .trivy.yaml
-          # as the canonical policy reference; remove these inlines once
-          # trivy-action lands proper config-file precedence.
-          scanners: 'vuln'
-          severity: 'CRITICAL,HIGH'
-          ignore-unfixed: true
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          exit-code: '1'
-          limit-severities-for-sarif: 'true'
+          version: v0.69.3
+          cache: true
 
+      - name: Run Trivy vulnerability scanner
+        run: |
+          trivy image \
+            --format sarif \
+            --output trivy-results.sarif \
+            --severity CRITICAL,HIGH \
+            --ignore-unfixed \
+            --scanners vuln \
+            --exit-code 1 \
+            --ignorefile klai-scribe/whisper-server/.trivyignore.yaml \
+            ghcr.io/getklai/whisper-server:${{ github.sha }}
       - name: Upload Trivy SARIF to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4
         if: always()

--- a/deploy/caddy/.trivyignore.yaml
+++ b/deploy/caddy/.trivyignore.yaml
@@ -1,29 +1,64 @@
 # Per-service Trivy ignore-list for caddy-hetzner.
 # Schema: SPEC-CI-TRIVY-POLICY-001 REQ-5 (id + ≥40-char statement + expired_at).
 # Referenced from .github/workflows/caddy.yml via `trivyignores:`.
+#
+# Caddy 2.11.2 still ships several vulnerable Go deps that have upstream
+# fixes but haven't been bumped in Caddy's go.mod yet. xcaddy builds use
+# Caddy's go.sum verbatim, so we can't override versions without forking
+# Caddy. All entries here have a 2-month expiry — Renovate watches the
+# `caddy:*-alpine` tag and the action.yaml of `xcaddy` will pick up
+# upstream Caddy patches that bump these deps.
 
 vulnerabilities:
+  - id: CVE-2026-34986
+    statement: |
+      Go JOSE DoS via crafted JWE on go-jose v3.0.4 + v4.1.3
+      (fix in v3.0.5 / v4.1.4). Caddy uses go-jose only for ACME-style
+      flows (Let's Encrypt JWS-signed orders); our deployment terminates
+      ACME via Hetzner DNS-01 and never accepts user-supplied JWE,
+      so the DoS attack surface (crafted external JWE → CPU starvation)
+      has no path. Re-evaluate when Caddy 2.11.3+ bumps go-jose.
+    expired_at: 2026-08-01
+
+  - id: CVE-2026-30836
+    statement: |
+      smallstep/certificates v0.30.0-rc3 (fix in 0.30.0): unauthenticated
+      cert issuance via SCEP Update Request. Caddy bundles smallstep as
+      its ACME backend implementation. Our Caddy is a reverse-proxy
+      issuing client certs ONLY through Let's Encrypt's ACME
+      (DNS-01 challenge with Hetzner). SCEP is not enabled, no SCEP
+      endpoint exists, no SCEP requests can reach the running Caddy
+      container. CRITICAL severity reflects worst-case ACME-CA
+      deployment, not our reverse-proxy use. Re-evaluate when Caddy
+      bumps smallstep.
+    expired_at: 2026-08-01
+
+  - id: CVE-2026-39883
+    statement: |
+      OpenTelemetry Go SDK PATH hijack via BSD kenv on v1.40.0 (fix in
+      v1.43.0). Caddy uses OTEL only for outbound telemetry export when
+      configured; our Caddyfile has NO `tracing` directive and NO OTLP
+      exporter, so the SDK code path that calls `kenv` is never reached.
+      Compile-time inclusion via Caddy's go.mod doesn't expose the
+      kenv-call site at runtime when the tracing feature is unused.
+    expired_at: 2026-08-01
+
+  - id: CVE-2026-33186
+    statement: |
+      google.golang.org/grpc v1.79.1 (fix in v1.79.3): DoS in HTTP/2
+      handler. grpc is in Caddy's transitive dep tree via OTEL gRPC
+      exporter — same OTEL story above: no tracing directive, no gRPC
+      endpoint exposed, no inbound HTTP/2 to grpc handler possible
+      from our compose Caddyfile. CRITICAL severity reflects worst-case
+      gRPC service exposure, not transitively-bundled-but-unused.
+    expired_at: 2026-08-01
+
   - id: CVE-2026-29181
     statement: |
-      go.opentelemetry.io/otel v1.40.0 → fixed in v1.41.0. Caddy 2.11.2's
-      go.mod still pins v1.40.0 transitively. Telemetry surface in our
-      Caddy build is disabled (no OTLP exporter, no telemetry endpoints
-      configured in Caddyfile) so the vulnerable codepath has no live
-      reach. Renovate watches the Caddy image; we expect Caddy 2.11.3 or
-      2.12.x to bump otel within the expiry window. Re-evaluate then.
+      go.opentelemetry.io/otel HIGH (advisory variant of the otel
+      family). Same exposure analysis as CVE-2026-39883 above: our
+      Caddyfile has no `tracing` directive and no OTLP exporter, so
+      the OTEL SDK code path is not exercised at runtime. Renovate
+      watches caddy:* tags for upstream go.mod bumps.
     expired_at: 2026-08-01
-    purls:
-      - "pkg:golang/go.opentelemetry.io/otel@v1.40.0"
 
-  - id: CVE-2026-27135
-    statement: |
-      nghttp2-libs 1.68.0-r0 → fixed in 1.68.1. Caddy 2.11.2-alpine ships
-      Alpine 3.21 which still has 1.68.0-r0 in its package index. Alpine's
-      next package-set update (typically every ~6 weeks) will pick up
-      1.68.1. Caddy uses nghttp2 only for HTTP/2 backend transport; our
-      reverse-proxy upstreams are local Docker network HTTP/1.1 services,
-      so the H2-DoS attack surface is upstream-side TLS terminator only.
-      Renovate watches caddy:* tags for new patches.
-    expired_at: 2026-08-01
-    purls:
-      - "pkg:apk/alpine/nghttp2-libs@1.68.0-r0"

--- a/deploy/caddy/Dockerfile
+++ b/deploy/caddy/Dockerfile
@@ -1,12 +1,12 @@
-# Pinned Caddy versions — closes two gaps simultaneously:
-# 1. SPEC-CI-TRIVY-POLICY-001 PR #2: clears 6 HIGH/CRITICAL findings in
-#    smallstep/certificates (CVE-2026-30836), grpc (CVE-2026-33186),
-#    go-jose v3+v4 (CVE-2026-34986), otel (CVE-2026-39883), and
-#    nghttp2-libs (CVE-2026-27135) by rebuilding against Caddy 2.11.2's
-#    refreshed go.mod tree.
-# 2. infra/servers.md "never :latest in production" rule — the previous
-#    `caddy:latest` and `caddy:builder` references were unpinned and
-#    non-reproducible. Renovate now watches both tags for new patches.
+# Pinned Caddy versions per SPEC-CI-TRIVY-POLICY-001 + infra/servers.md
+# "never :latest in production". Renovate watches caddy:* tags for new
+# patches.
+#
+# Note: Caddy 2.11.2's go.mod still ships several vulnerable Go deps
+# (smallstep/certificates, grpc, go-jose v3+v4, otel/sdk). Those have
+# upstream fixes but no Caddy release with the bumps yet. They are
+# documented exemptions in deploy/caddy/.trivyignore.yaml with 2-month
+# expiry — Renovate-driven Caddy bumps will close them.
 FROM caddy:2.11.2-builder-alpine AS builder
 
 RUN xcaddy build \
@@ -14,6 +14,16 @@ RUN xcaddy build \
     --with github.com/mholt/caddy-ratelimit
 
 FROM caddy:2.11.2-alpine
+
+# Apply Alpine package security updates that landed AFTER the
+# `caddy:2.11.2-alpine` image was published. Specifically pulls in
+# nghttp2 1.69.0-r0 (in v3.23 main since 2026-04-28) which closes
+# CVE-2026-27135 (H2-DoS in nghttp2). nghttp2 is exposed via Caddy's
+# HTTPS edge (clients use HTTP/2 by default), so a real fix is
+# preferred over an ignore-entry. Pinned to `nghttp2 nghttp2-libs`
+# specifically so the build stays reproducible — bumping the Alpine
+# base image globally is a separate concern handled by Renovate.
+RUN apk update && apk upgrade --no-cache nghttp2 nghttp2-libs
 
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy
 

--- a/klai-docs/.trivyignore.yaml
+++ b/klai-docs/.trivyignore.yaml
@@ -1,0 +1,20 @@
+# Per-service Trivy ignore-list for klai-docs.
+# Schema: SPEC-CI-TRIVY-POLICY-001 REQ-5 (id + ≥40-char statement + expired_at).
+# Referenced from .github/workflows/docs.yml via `trivyignores:`.
+
+vulnerabilities:
+  - id: CVE-2026-33671
+    statement: |
+      Trivy DB false-positive: per NVD (nvd.nist.gov/vuln/detail/
+      CVE-2026-33671), picomatch 4.0.4 IS the fix-version for this
+      CVE — affected range is 4.0.0..<4.0.4. PR #411 of
+      SPEC-CI-TRIVY-POLICY-001 bumped picomatch to 4.0.4 (and 2.3.2
+      for the chokidar tier), so per upstream advisory we are on the
+      patched version. Trivy's vulnerability database still flags
+      4.0.4 instances — this is a Trivy DB lag, not a real exposure.
+      As secondary defense, picomatch is build-tooling only
+      (chokidar / tinyglobby file-watching, Vite glob resolution);
+      runtime app code never invokes `picomatch.compile()` on user
+      input. Re-evaluate when Trivy DB recategorises 4.0.4 as fixed
+      OR when picomatch 4.1.x ships.
+    expired_at: 2026-08-01

--- a/klai-scribe/whisper-server/.trivyignore.yaml
+++ b/klai-scribe/whisper-server/.trivyignore.yaml
@@ -1,0 +1,24 @@
+# Per-service Trivy ignore-list for whisper-server.
+# Schema: SPEC-CI-TRIVY-POLICY-001 REQ-5 (id + ≥40-char statement + expired_at).
+# Referenced from .github/workflows/whisper-server.yml via `trivyignores:`.
+
+vulnerabilities:
+  - id: CVE-2025-68973
+    statement: |
+      gnupg keybox parser out-of-bounds write. PR #411 of
+      SPEC-CI-TRIVY-POLICY-001 added `apt purge -y --auto-remove gnupg
+      gnupg2` to the Dockerfile, which removes most of the gnupg
+      family (gpg, gpg-agent, gpgsm, dirmngr, etc.). However, `gpgv`
+      remains because it's a hard dependency of `apt` itself — apt
+      uses gpgv to verify package signatures during install, so it
+      cannot be auto-removed without breaking apt.
+
+      Exposure analysis: gpgv only runs when apt-get install/update
+      executes against signed repositories. The whisper-server runtime
+      container never runs apt — it runs uvicorn for inference.
+      The vulnerable keybox parser code in gpgv requires being invoked
+      with a malicious keybox file, which has no path in our deployed
+      image (no apt invocation, no keybox file ingest, no user-supplied
+      keys). Re-evaluate when Ubuntu 24.04 ships gpgv ≥ 2.4.4-2ubuntu17.4
+      via Renovate's CUDA base-image bumps.
+    expired_at: 2026-08-01


### PR DESCRIPTION
## Summary

Hotfix to PR #3 (#417) of [SPEC-CI-TRIVY-POLICY-001](https://github.com/GetKlai/klai/blob/main/.moai/specs/SPEC-CI-TRIVY-POLICY-001/spec.md). Three workflows (caddy / docs / whisper-server) failed on PR #3's first main run. Two distinct problems surfaced:

### Problem 1: trivy-action 0.35.0 SARIF severity-filter bug

`aquasecurity/trivy-action@0.35.0` (and 0.36.0) honours the `severity` filter for the SARIF body but NOT for the exit-code. A MEDIUM/LOW finding still triggers exit-code 1 when the workflow asks for CRITICAL+HIGH gating. Confirmed via diagnostic table-format run: trivy CLI direct shows `Total: 5 (HIGH: 3, CRITICAL: 2)` for caddy, but the wrapper's exit-code fired even on workflows where the SARIF was empty after filtering.

**Fix:** all 11 scan jobs now invoke trivy CLI directly via `aquasecurity/setup-trivy@v0.2.5` + `run: trivy image ...`. CLI honours `--severity` for both detection AND exit-code. Same flag mapping 1:1 from the action's input keys.

### Problem 2: PR #3 ignore-list had wrong CVE-ids + 2 services lacked ignore-files

Diagnostic runs revealed:

| Service | What I assumed in PR #2/#3 | What Trivy actually finds |
|---|---|---|
| caddy | Caddy 2.11.2 fixes 6 HIGH/CRIT | Caddy 2.11.2's `go.mod` still ships **5 vulnerable Go deps**: smallstep CRITICAL, grpc CRITICAL, otel/sdk HIGH, go-jose v3+v4 HIGH. Plus 2 latent HIGHs from earlier audit (otel CVE-2026-29181 + nghttp2 CVE-2026-27135) re-classified by Trivy DB. |
| whisper | `apt purge gnupg gnupg2 --auto-remove` clears all 10 gnupg-family packages | `gpgv` remains because apt itself depends on it for signature verification. Auto-remove can't touch it. |
| docs | `npm update picomatch` to 4.0.4 closes the CVE | NVD confirms 4.0.4 IS the fix-version, but Trivy DB still flags it (DB lag false-positive). |

## What this PR does

**Real fixes (no ignore):**
- `deploy/caddy/Dockerfile`: add `RUN apk update && apk upgrade --no-cache nghttp2 nghttp2-libs` after `FROM caddy:2.11.2-alpine`. Alpine v3.23 main has nghttp2 1.69.0-r0 (since 2026-04-28) which closes CVE-2026-27135. nghttp2 is exposed via Caddy's HTTPS edge (clients use HTTP/2 by default), so a real fix is preferred over an ignore.

**Documented exemptions (with concrete runtime-exposure analysis):**
- `deploy/caddy/.trivyignore.yaml`: 5 entries for Go-deps Caddy 2.11.2 hasn't bumped yet (CVE-2026-30836 smallstep, CVE-2026-33186 grpc, CVE-2026-34986 go-jose, CVE-2026-39883 otel/sdk, CVE-2026-29181 otel). Each entry explains why the runtime path doesn't exist (no SCEP enabled, no tracing directive, no inbound JWE). Renovate-watched 2-month expiry.
- `klai-scribe/whisper-server/.trivyignore.yaml`: CVE-2025-68973 in gpgv. apt hard-dep, not removable. Runtime container doesn't run apt — vulnerable code-path requires `docker exec apt install` which we don't do.
- `klai-docs/.trivyignore.yaml`: CVE-2026-33671 in picomatch. **Trivy DB false-positive** — NVD confirms 4.0.4 is the fix-version. Secondary defense: build-tooling only.

**Workflow refactor (all 11):**
- Replace `aquasecurity/trivy-action@0.35.0` with `aquasecurity/setup-trivy@v0.2.5` + direct `run: trivy image` invocation
- Same flags, same exit-code semantics, but `--severity` is now actually honoured for the gate
- `.trivy.yaml` stays in repo as canonical policy reference + doc

## Verification

3 verification runs on this branch:
- Caddy: should pass with 0 unfilterable findings (4 Go-deps ignored, nghttp2 patched via apk)
- Docs: should pass (1 picomatch DB-lag ignored)
- Whisper: should pass (gpgv ignored, no runtime path)

Other 8 workflows already passed on PR #3's first main run with `severity: CRITICAL,HIGH` (because they had 0 findings post `ignore-unfixed`). Direct CLI refactor is preventive: future findings on those services will be filtered correctly.

## Risk analysis

After this PR, no ignore-entry has a real runtime exposure path:

- Caddy Go-deps: no SCEP / no tracing / no JWE incoming = vulnerable code paths unreachable
- Whisper gpgv: only invoked by apt; runtime image doesn't run apt
- Docs picomatch: NVD-confirmed at fix-version; build-tooling only as backup

The one entry that DID have a real risk path (caddy nghttp2 — internet-exposed HTTPS edge handles H2 incoming) is now actively patched via the apk upgrade, not ignored.

## Related

- SPEC: `.moai/specs/SPEC-CI-TRIVY-POLICY-001/spec.md`
- PR #3: #417 (gate flip — merged, this hotfix follows)
- Memory: trivy-action 0.35.0 limitations + scan-job checkout requirement saved to CodeIndex

🤖 Generated with [Claude Code](https://claude.com/claude-code)
