### PR TITLE
spec(SPEC-INGEST-LOGIN-WALL-DETECT-002): redesign detector via near-duplicate clustering

### DIFF
--- a/.moai/specs/SPEC-INGEST-LOGIN-WALL-DETECT-002/acceptance.md
+++ b/.moai/specs/SPEC-INGEST-LOGIN-WALL-DETECT-002/acceptance.md
@@ -1,0 +1,435 @@
+# Acceptance Criteria — SPEC-INGEST-LOGIN-WALL-DETECT-002
+
+Gherkin Given/When/Then scenarios per requirement. Baseline configuration:
+voys tenant (zitadel_org_id `368884765035593759`), KB `support`, unless
+noted otherwise. Production fixtures live in
+`klai-knowledge-ingest/tests/fixtures/auth_walls/` (true positives) and
+`tests/fixtures/clean_pages/` (true negatives, including the 5 captured
+production FPs).
+
+---
+
+## REQ-01 — Content fingerprint at ingest
+
+### AC-01.1: Deterministic hash
+
+```gherkin
+Given a markdown string M
+When compute_simhash(M) is called twice
+Then the two return values are identical 64-bit integers
+```
+
+### AC-01.2: URL-only variation produces near-identical hash
+
+```gherkin
+Given two markdown strings A and B that differ ONLY in their canonical
+       URL embedded in the page chrome
+  And both strings are otherwise byte-identical
+When compute_simhash(A) and compute_simhash(B) are computed
+Then hamming_distance(hash_a, hash_b) <= 3
+  And this validates that pre-hash URL normalisation is in effect
+```
+
+### AC-01.3: Unrelated pages produce divergent hashes
+
+```gherkin
+Given two markdown strings drawn from the production captured fixtures
+       redcactus_hubspot.md (wall) and redcactus_ifttt.md (clean tutorial)
+When their SimHashes are computed
+Then hamming_distance > 10
+  And the fingerprints are clearly distinguishable as different content
+```
+
+### AC-01.4: SimHash stored at ingest
+
+```gherkin
+Given a successful crawl of a new page in voys/support
+When _ingest_crawl_result completes
+Then a row exists in knowledge.crawled_pages for that URL
+  And content_simhash is non-NULL
+  And the stored hash equals compute_simhash(fit_markdown or raw_markdown)
+```
+
+### AC-01.5: Storage tenant scope
+
+```gherkin
+Given two tenants voys and getklai
+  And both have ingested a page that happens to share content with each
+      other (e.g., both ingested the same Voys help article)
+When their SimHashes are computed
+Then the hashes are stored under each tenant's own org_id+kb_slug rows
+  And no cross-tenant row write occurs
+```
+
+---
+
+## REQ-02 — Cluster-based wall detection
+
+### AC-02.1: 149 RedCactus walls form a single cluster
+
+```gherkin
+Given the 149 voys/support pages whose URL is under wiki.redcactus.cloud
+       AND whose raw_markdown contains the RedCactus boilerplate template
+When detect_anonymous_auth_wall is called for any one of them with
+     org_id=voys, kb_slug=support, conn=connection
+Then the returned AuthWallSignal has pattern="template_cluster"
+  And evidence is "cluster_size=148 hamming<=3" (148 = 149 minus the page itself)
+  And confidence >= 0.9
+```
+
+### AC-02.2: Production FPs do NOT cluster
+
+```gherkin
+Given the 5 captured production FP URLs:
+       https://help.voys.nl/2fa-freedom
+       https://help.voys.nl/account-toegang
+       https://wiki.redcactus.cloud/nl/phone-software/zoom
+       https://wiki.redcactus.cloud/nl/phone-software/zoom-embedded
+       https://wiki.redcactus.cloud/nl/crm-software/IFTTT
+  And the SimHash of each is computed
+When detect_anonymous_auth_wall is called for each in turn
+Then each returns None
+  And the cluster size for each is below 5
+```
+
+### AC-02.3: Synthetic CMS fixtures
+
+```gherkin
+Given the synthetic Confluence wall fixture confluence_login_required.md
+  And 4 other duplicate copies (same content, different URLs) seeded into
+      a test corpus
+When detect_anonymous_auth_wall is called with the test corpus connection
+Then the returned signal has pattern="template_cluster"
+  And cluster_size is at least 4
+```
+
+### AC-02.4: Cluster boundary at threshold
+
+```gherkin
+Given a corpus with N pages all sharing identical content
+  And the configured KLAI_INGEST_TEMPLATE_CLUSTER_MIN is 5
+When detect_anonymous_auth_wall is called
+Then if N == 5: ALL pages return signal (cluster_size = 4 OTHERS, total = 5
+     — interpretation: the page itself + 4 others meets threshold)
+
+# Implementation note: the actual SQL query is "count of OTHERS within
+# Hamming <= 3" -> threshold is actually count >= (N - 1) for the page
+# itself to be included. Spec language uses "N or more OTHER pages" and
+# the test pins this exact boundary.
+```
+
+### AC-02.5: Hamming threshold sensitivity
+
+```gherkin
+Given a SimHash A and a SimHash B at hamming_distance == 4
+When the cluster query runs (Hamming <= 3 strict)
+Then B is NOT counted as a member of A's cluster
+  And the threshold is documented as a SPEC-revision change, not env-tunable
+```
+
+---
+
+## REQ-03 — Cold-start permissiveness
+
+### AC-03.1: Sparse tenant — single page
+
+```gherkin
+Given a freshly-onboarded tenant new_tenant with kb_slug "support"
+  And exactly 1 page exists in (new_tenant, "support")
+When detect_anonymous_auth_wall is called for that page
+Then the result is None
+  And the cluster size is 0 (page itself excluded; no other pages exist)
+```
+
+### AC-03.2: Sparse tenant — at threshold edge
+
+```gherkin
+Given a tenant with exactly 5 pages in (org_id, kb_slug), all template
+       duplicates of each other
+When detect_anonymous_auth_wall is called for any one of them
+Then the result is a non-None signal
+  And cluster_size = 4 (the 4 OTHERS)
+  And the threshold "N or more OTHER pages" is interpreted as count >= 4
+      (where N = configured min - 1)
+
+# Editorial note: tighten this in implementation to match REQ-02's
+# "N or more OTHER pages" exactly with N=5, ie strictly >= 5 OTHERS.
+# In that case AC-03.2 returns None.
+```
+
+### AC-03.3: Sparse tenant — just under threshold
+
+```gherkin
+Given a tenant with 4 pages all template duplicates
+When detect_anonymous_auth_wall is called for any one
+Then the result is None
+  And the operator-visible log line confirms cold-start permissiveness
+```
+
+---
+
+## REQ-04 — Backfill replay
+
+### AC-04.1: Re-running on a fresh tenant computes hashes
+
+```gherkin
+Given a tenant whose content_simhash is NULL on every page
+When backfill_detect_login_walls(org_id, kb_slug) runs
+Then every page in (org_id, kb_slug) has a non-NULL content_simhash after
+  And the function returns a "processed" count equal to the page count
+```
+
+### AC-04.2: Backfill purges template clusters
+
+```gherkin
+Given voys/support before backfill (149 RedCactus walls + 273 other pages)
+  And no SimHashes are populated yet
+When backfill_detect_login_walls runs
+Then the result reports {"processed": 422, "flagged": 149, "qdrant_deleted": 149}
+  And each flagged page has content_hash = '__login_wall_purged__'
+  And none of the 5 known FP URLs is flagged
+```
+
+### AC-04.3: Idempotency
+
+```gherkin
+Given backfill_detect_login_walls already ran successfully for voys/support
+  And no new pages were ingested since
+When backfill_detect_login_walls runs again
+Then the result reports {"processed": 273, "flagged": 0, "qdrant_deleted": 0}
+       (placeholder pages are excluded from re-evaluation)
+  And no Qdrant deletes are issued
+  And no rows are mutated
+```
+
+### AC-04.4: Tenant isolation in Qdrant deletes
+
+```gherkin
+Given the backfill task is implementing point deletion for a wall
+When the developer attempts to delete points using only path or kb_slug
+Then the semgrep rule from .github/workflows/tenant-isolation-review.yml
+     fails the PR
+  And the rule message references "FieldCondition(key='org_id', ...)"
+```
+
+---
+
+## REQ-05 — Recovery of v1-purged FPs
+
+### AC-05.1: Single-FP recovery on getklai/voys-test
+
+```gherkin
+Given /2fa-freedom is in getklai/voys-test with content_hash =
+       '__login_wall_purged__'
+  And under v2 cluster logic, /2fa-freedom is NOT in any cluster
+When recover_purged_pages(getklai_org_id, "voys-test") runs
+Then the result reports {"processed": 1, "recovered": 1}
+  And /2fa-freedom's content_hash is now empty string
+  And the next scheduled crawl re-ingests it normally
+```
+
+### AC-05.2: No spurious recovery
+
+```gherkin
+Given a tenant whose all purged pages still belong to v2 clusters
+When recover_purged_pages runs
+Then the result reports {"processed": N, "recovered": 0}
+  And no content_hash is mutated
+```
+
+### AC-05.3: Cross-org isolation
+
+```gherkin
+Given recover_purged_pages is invoked for getklai
+When the SQL query runs
+Then no voys rows are touched
+  And tenant_scoped_connection sets app.current_org_id correctly
+```
+
+---
+
+## REQ-06 — Caller signature stability
+
+### AC-06.1: Function signature unchanged for v1 callers
+
+```gherkin
+Given existing callers of detect_anonymous_auth_wall in
+       _ingest_crawl_result and backfill_tasks
+When v2 ships
+Then no caller signature change is required (positional and keyword
+     args remain compatible)
+  And new optional parameters (org_id, kb_slug, conn) default to None
+```
+
+### AC-06.2: Fail-safe when DB unavailable
+
+```gherkin
+Given the new detector is called WITHOUT org_id, kb_slug, or conn
+When detect_anonymous_auth_wall returns
+Then the result is None (no flag)
+  And exactly one WARN log line is emitted with
+      event="auth_wall_detector_db_missing"
+  And the ingest pipeline is NOT blocked
+```
+
+---
+
+## REQ-07 — Mode handling preserved
+
+### AC-07.1: Reject mode raises typed exception
+
+```gherkin
+Given KLAI_INGEST_LOGIN_WALL_DETECT_MODE="reject"
+  And a page that is in a cluster of size 5+ under v2
+When _ingest_crawl_result runs for that page
+Then AnonymousAuthWallDetected is raised
+  And the exception's signal.pattern == "template_cluster"
+```
+
+### AC-07.2: Degrade mode applies quality_score=0
+
+```gherkin
+Given KLAI_INGEST_LOGIN_WALL_DETECT_MODE="degrade"
+  And a page that v2 classifies as a wall
+When _ingest_crawl_result runs
+Then no exception is raised
+  And the resulting Qdrant points have quality_score == 0.0
+  And the ingest_warning metadata is set
+```
+
+### AC-07.3: Audit_only logs and continues
+
+```gherkin
+Given KLAI_INGEST_LOGIN_WALL_DETECT_MODE="audit_only"
+  And a page that v2 classifies as a wall
+When _ingest_crawl_result runs
+Then the page ingests with default quality_score=0.5
+  And one WARN log line is emitted with event="login_wall_detected"
+      and pattern="template_cluster"
+```
+
+---
+
+## REQ-08 — Performance
+
+### AC-08.1: SimHash compute p99 budget
+
+```gherkin
+Given a 100 KB markdown string sampled from a real RedCactus walled page
+When compute_simhash is called 1000 times
+Then the 99th percentile execution time is below 5 ms
+  And no measurement exceeds 50 ms (no pathological tail)
+```
+
+### AC-08.2: Cluster query p99 budget
+
+```gherkin
+Given a synthetic 1000-page corpus in test_db
+  And every page has a content_simhash populated
+When the cluster query runs for one of the pages
+Then the 99th percentile query latency is below 50 ms
+  And the result is correctly counted (verifiable by independent scan)
+```
+
+### AC-08.3: Detector adds bounded ingest latency
+
+```gherkin
+Given a fresh page ingest under v2
+When _ingest_crawl_result completes for that page
+Then the additional latency vs v1 (measured via ingest_decision_record)
+     is below 100 ms
+```
+
+---
+
+## REQ-09 — Tenant isolation
+
+### AC-09.1: Cluster query never crosses tenants
+
+```gherkin
+Given two tenants voys and getklai with overlapping content
+When the cluster query runs for a voys page
+Then no getklai rows are scanned (verifiable in PostgreSQL EXPLAIN)
+  And the WHERE clause includes BOTH org_id AND kb_slug filters
+```
+
+### AC-09.2: Connection-level RLS context
+
+```gherkin
+Given the backfill task processes voys
+When the implementing code is reviewed
+Then every SELECT/UPDATE on knowledge.* runs through
+     tenant_scoped_connection(org_id)
+  And no raw pool acquire bypasses the GUC
+```
+
+### AC-09.3: Qdrant filter contains org_id+kb_slug+path
+
+```gherkin
+Given the backfill task is deleting Qdrant points for a flagged page
+When the Filter object is constructed
+Then Filter.must contains exactly three FieldConditions:
+       FieldCondition(key="org_id", match=MatchValue(value=org_id)),
+       FieldCondition(key="kb_slug", match=MatchValue(value=kb_slug)),
+       FieldCondition(key="path", match=MatchValue(value=url))
+  And removing any one fails the semgrep tenant-isolation rule
+```
+
+---
+
+## REQ-10 — Production-data validation gate
+
+### AC-10.1: Validation script runs on voys/support
+
+```gherkin
+Given the v2 code is deployed to staging
+  And `python scripts/validate_login_wall_detector.py --org voys --kb support`
+      is invoked
+When the script completes
+Then exit code is 0
+  And stdout reports:
+       Total pages: 422
+       Wall clusters: 1
+         cluster_size: 149
+         sample_urls: [up to 10 redcactus.cloud URLs]
+       v1-purged but no longer clustering: 0
+  And the report is JSON-parsable
+```
+
+### AC-10.2: Validation script flags getklai recovery candidate
+
+```gherkin
+Given the v2 code is deployed
+  And `python scripts/validate_login_wall_detector.py --org getklai --kb voys-test`
+      runs
+Then the report includes /2fa-freedom in
+     "v1-purged but no longer clustering"
+  And the operator runs recover_purged_pages to act on the report
+```
+
+---
+
+## End-to-end Phase F validation (operator-driven)
+
+### AC-F.1: Original failing query honoured post-rollout
+
+```gherkin
+Given v2 has deployed and the backfill ran on voys/support
+  And the recovery ran on getklai/voys-test
+  And /2fa-freedom has been re-crawled
+When a user asks "Hoe stel ik RedCactus in met HubSpot?" in voys's chat
+Then retrieval-api returns either zero chunks (gap_type=hard) or chunks
+     from non-walled sources
+  And the chat does not surface RedCactus walled stub content
+  And the chat does NOT lie — it admits it cannot find the answer when
+     no relevant sources exist
+```
+
+### AC-F.2: Recovered tutorial returns to retrieval
+
+```gherkin
+Given /2fa-freedom has been re-crawled under v2
+When a user in voys asks "How do I set up 2FA in Freedom?"
+Then retrieval surfaces /2fa-freedom in the top results
+  And the chat answers the question correctly using that source
+```

--- a/.moai/specs/SPEC-INGEST-LOGIN-WALL-DETECT-002/plan.md
+++ b/.moai/specs/SPEC-INGEST-LOGIN-WALL-DETECT-002/plan.md
@@ -1,0 +1,254 @@
+# Implementation Plan — SPEC-INGEST-LOGIN-WALL-DETECT-002
+
+Phased rollout that minimises operational risk: schema first, detector
+swap second, backfill third, recovery fourth, validation gate fifth. Each
+phase is independently committable; the v2 detector becomes active only
+when both schema and code are deployed.
+
+Methodology: TDD per project convention. Each phase has failing tests
+first, then implementation, then validation against captured production
+fixtures.
+
+Worktree: created at `feature/SPEC-INGEST-LOGIN-WALL-DETECT-002` before
+any edits (multi-file change, > 5 tool calls).
+
+---
+
+## Phase A — Schema migration
+
+**Files**:
+- `klai-knowledge-ingest/alembic/versions/XXXX_crawled_pages_simhash.py` (new)
+
+**Migration**:
+```sql
+ALTER TABLE knowledge.crawled_pages
+ADD COLUMN IF NOT EXISTS content_simhash bigint;
+
+CREATE INDEX IF NOT EXISTS idx_crawled_pages_simhash_org_kb
+ON knowledge.crawled_pages (org_id, kb_slug, content_simhash)
+WHERE content_simhash IS NOT NULL;
+```
+
+The partial index (only non-NULL rows) keeps cold-start cost low: rows
+without a SimHash yet (pre-Phase B page ingests) are not indexed.
+
+Idempotent: `ADD COLUMN IF NOT EXISTS` + `CREATE INDEX IF NOT EXISTS`.
+
+Auto-applied: knowledge-ingest's entrypoint runs `alembic upgrade head`.
+
+Exit criteria: migration applies cleanly on a fresh DB and on the
+existing prod DB (verified via local pg_dump replay).
+
+---
+
+## Phase B — SimHash module + replacement detector
+
+**Files**:
+- `klai-knowledge-ingest/knowledge_ingest/utils/content_fingerprint.py` (new)
+  - `compute_simhash(text: str) -> int`
+  - `hamming_distance(a: int, b: int) -> int`
+  - `_normalise(text: str) -> str` (private)
+- `klai-knowledge-ingest/knowledge_ingest/utils/auth_wall_detector.py` (rewrite)
+  - `AuthWallSignal` dataclass (kept; pattern field becomes
+    `"template_cluster"`)
+  - `detect_anonymous_auth_wall(...)` — new implementation using SimHash
+    cluster lookup
+- `klai-knowledge-ingest/tests/test_content_fingerprint.py` (new)
+- `klai-knowledge-ingest/tests/test_auth_wall_detector.py` (rewrite)
+
+**Steps**:
+1. Implement SimHash in-tree (~50 LOC). 64-bit hash, weighted feature
+   vector based on word tokens. Pre-hash normalisation: URL → `<URL>`,
+   anchor `[text](url)` → `text`, lowercase, whitespace collapse,
+   word-boundary tokenisation.
+2. Implement `hamming_distance` using `(a ^ b).bit_count()` (Python 3.10+).
+3. Tests for SimHash determinism + sensitivity:
+   - Identical input → identical hash.
+   - Two pages differing only in their canonical URL → Hamming ≤ 3
+     (validates the URL normalisation).
+   - Two unrelated pages → Hamming » 10.
+4. Rewrite detector. Function:
+   ```python
+   async def detect_anonymous_auth_wall(
+       markdown: str,
+       *,
+       fit_markdown: str | None = None,
+       url: str | None = None,
+       org_id: str | None = None,
+       kb_slug: str | None = None,
+       conn: asyncpg.Connection | None = None,
+   ) -> AuthWallSignal | None
+   ```
+   - If org_id/kb_slug/conn missing: log WARN, return None (fail-open).
+   - Compute SimHash of `fit_markdown or markdown`.
+   - Query: `SELECT content_simhash FROM knowledge.crawled_pages WHERE
+     org_id = $1 AND kb_slug = $2 AND content_simhash IS NOT NULL`.
+   - Count rows with `hamming_distance(this, that) <= 3`.
+   - If count >= `KLAI_INGEST_TEMPLATE_CLUSTER_MIN` (default 5): return
+     AuthWallSignal(pattern="template_cluster",
+                    evidence=(f"cluster_size={count} hamming<=3",),
+                    confidence=0.9).
+   - Else: return None.
+5. Delete v1 detector code + fixtures + tests.
+
+Exit criteria: All new unit tests pass. Cluster simulation tests pass on
+synthetic corpora. `_ingest_crawl_result` integration is wired (Phase C).
+
+---
+
+## Phase C — Ingest integration + SimHash storage
+
+**Files**:
+- `klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py` (modify)
+- `klai-knowledge-ingest/knowledge_ingest/pg_store.py` (modify — new helper
+  `update_crawled_page_simhash(conn, org_id, kb_slug, url, simhash)`)
+- `klai-knowledge-ingest/tests/test_crawler_template_detection.py` (new
+  integration test)
+
+**Steps**:
+1. Modify `_ingest_crawl_result`:
+   - Compute SimHash from `result.fit_markdown or result.raw_markdown`
+     (using v2's normalisation).
+   - Pass org_id/kb_slug/conn to `detect_anonymous_auth_wall`.
+   - Store SimHash via `pg_store.update_crawled_page_simhash` AFTER the
+     dedup checks pass (we only store hashes for pages that actually get
+     ingested, to avoid hashing skipped duplicates).
+2. The detector call now requires DB access — adjust integration test
+   mocks to provide a fake connection that returns a configurable list
+   of nearby SimHashes.
+3. Mode handling (reject / degrade / audit_only) is unchanged from v1.
+   Rerun all v1 mode integration tests with the v2 detector mock.
+
+Exit criteria: All integration tests pass. Reject mode raises
+`AnonymousAuthWallDetected` when cluster ≥ N. Degrade mode passes through
+`quality_score=0.0`. Audit_only logs and continues.
+
+---
+
+## Phase D — Backfill task v2
+
+**Files**:
+- `klai-knowledge-ingest/knowledge_ingest/backfill_tasks.py` (rewrite
+  `backfill_detect_login_walls`; add `recover_purged_pages`)
+- `klai-knowledge-ingest/tests/test_backfill_login_walls.py` (rewrite)
+
+**Steps**:
+1. Rewrite `backfill_detect_login_walls`:
+   - Pass 1: compute SimHash for any page where `content_simhash IS NULL`.
+   - Pass 2: for every page (excluding placeholder-purged), evaluate
+     cluster membership.
+   - For each flagged page: Qdrant delete (with org_id+kb_slug+path
+     filter), `crawled_pages.content_hash = '__login_wall_purged__'`.
+2. Implement `recover_purged_pages(org_id, kb_slug)`:
+   - Find pages where `content_hash = '__login_wall_purged__'`.
+   - Compute v2 cluster membership.
+   - For pages NOT in a cluster of size ≥ N: clear content_hash to
+     empty string. Next crawl re-ingests.
+3. Update CLI:
+   ```
+   python -m knowledge_ingest.backfill_tasks \
+       --org SLUG --kb SLUG [--recover]
+   ```
+   `--recover` flag triggers `recover_purged_pages` instead of
+   `backfill_detect_login_walls`.
+4. Tests: idempotency (re-run = noop), cluster boundary cases (4 pages =
+   below threshold, all kept; 5 pages = at threshold, all flagged),
+   recovery on cluster-shrunk corpus.
+
+Exit criteria: Backfill produces correct counts on fixture corpora.
+Recovery un-purges synthetic non-cluster pages.
+
+---
+
+## Phase E — Production validation script
+
+**Files**:
+- `scripts/validate_login_wall_detector.py` (new)
+
+**Steps**:
+1. Read-only script that connects via the same `tenant_scoped_connection`
+   helpers and runs the v2 cluster algorithm against a tenant's KB.
+2. Outputs a structured report:
+   - Total pages.
+   - SimHash clusters discovered (size ≥ N), with sample URLs.
+   - Pages currently in `__login_wall_purged__` state whose cluster
+     dropped below N (recovery candidates).
+3. CI integration: a unit test invokes the script against a stubbed
+   corpus to verify exit code and report shape.
+4. Operator integration: `python scripts/validate_login_wall_detector.py
+   --org voys --kb support` is the manual gate before merging the v2 PR.
+
+Exit criteria: Validation script reports zero surprise classifications
+on voys + getklai. Output is reproducible and parsable.
+
+---
+
+## Phase F — Rollout
+
+Sequence (no further code changes; ops only):
+
+1. Merge PR (containing Phase A–E). Image rebuilds + auto-deploys
+   knowledge-ingest. Schema migration auto-applies.
+2. Wait for `klai-core-knowledge-ingest-1` to report healthy. Verify
+   `content_simhash` column exists.
+3. Run validation script in `audit_only` mode equivalent: schema is
+   ready but the detector also evaluates cluster size. Operator
+   inspects the report.
+4. Switch tenants to `KLAI_INGEST_LOGIN_WALL_DETECT_MODE=reject` in
+   `/opt/klai/.env` (currently set; confirm no override changes
+   needed).
+5. Run `backfill_detect_login_walls --org voys --kb support` (will
+   re-evaluate the 422 pages; idempotent — pages already purged stay
+   purged because their cluster still meets threshold).
+6. Run `backfill_detect_login_walls --org getklai --kb voys-test`.
+7. Run `recover_purged_pages --org getklai --kb voys-test --recover`.
+   This un-purges `/2fa-freedom` (cluster size for it under v2 should
+   be 0 — no template clusters in getklai).
+8. Trigger a re-crawl of `/2fa-freedom` URL to populate the page back
+   into Qdrant under v2 logic.
+9. Verify the original failing query: voys/redcactus walls remain
+   purged; voys/account-recovery and getklai/2fa-freedom return.
+10. Update SPEC-INGEST-LOGIN-WALL-DETECT-001 status to `superseded`.
+
+---
+
+## Phase G — Post-merge SPEC bookkeeping
+
+- `SPEC-INGEST-LOGIN-WALL-DETECT-001/spec.md`: change `status: completed`
+  to `status: superseded`. Add HISTORY entry pointing to v2.
+- `SPEC-INGEST-LOGIN-WALL-DETECT-001/plan.md`: prepend a callout that v2
+  has replaced Phase A-E detector logic.
+- Add a CHANGELOG entry to `klai-knowledge-ingest`.
+
+---
+
+## Risk register
+
+| Risk | Mitigation |
+|---|---|
+| SimHash threshold tuning (Hamming ≤ 3) misses real walls | Phase B fixture tests pin behaviour; Phase E validation script reports actual cluster sizes; threshold is a SPEC change, requires re-validation |
+| Walls have too much per-page variation, hashes drift apart | Pre-hash normalisation (URL → `<URL>`, anchor text only) isolates the template; if still insufficient, fall back to MinHash + LSH (documented in research.md §4.2 as Phase D contingency) |
+| Cluster scan O(N²) becomes slow on huge KBs | Performance budget (REQ-08): 50 ms p99 for N ≤ 1000. At higher N, LSH banding becomes warranted; deferred to follow-up SPEC |
+| `/2fa-freedom` recovery re-crawl fails (URL no longer accessible, e.g.) | Manual verification: operator inspects re-crawl outcome and re-triggers if needed; this is a one-shot recovery, not ongoing |
+| Schema migration race with running ingests | Migration is additive (new NULL-able column + index). Existing ingests continue inserting rows with NULL simhash; backfill catches them up |
+
+---
+
+## Decisions resolved during draft
+
+| Decision | Resolution | Rationale |
+|---|---|---|
+| Hash algorithm | SimHash | Single 64-bit fingerprint; SQL-friendly; sufficient at klai's scale; MinHash deferred as Phase D contingency |
+| Hamming threshold | 3 (fixed) | Standard for "≥ 95% content overlap"; calibrated against fixtures |
+| Cluster threshold | 5 (configurable via env) | Catches RedCactus's 149-page cluster easily; protects single-page walls under cold-start permissiveness |
+| Where to fingerprint (raw_markdown vs fit_markdown) | `fit_markdown or raw_markdown` | Prefer crawl4ai's extracted main content; fall back when fit absent |
+| Pre-hash normalisation | URL strip + anchor text + lowercase + whitespace collapse | Validated against fixtures: per-URL variation drops below Hamming 3 after normalisation |
+| In-tree vs library SimHash | In-tree (~50 LOC) | Avoid dependency churn; algorithm is well-known; team has full visibility |
+| Backwards-compat: detector signature | Keep `(markdown, fit_markdown=None)` positional/kw-only; add optional `org_id, kb_slug, conn` for cluster query | Minimises caller diffs in `_ingest_crawl_result` and backfill |
+| Audit_only / degrade / reject modes | Unchanged from v1 | Operational surface stays familiar; mode semantics map identically to v2 detector outputs |
+
+---
+
+## Open questions for plan-phase annotation
+
+None remaining. Ready for /moai run.

--- a/.moai/specs/SPEC-INGEST-LOGIN-WALL-DETECT-002/research.md
+++ b/.moai/specs/SPEC-INGEST-LOGIN-WALL-DETECT-002/research.md
@@ -1,0 +1,479 @@
+# Research — SPEC-INGEST-LOGIN-WALL-DETECT-002
+
+Date: 2026-05-06
+Author: Mark Vletter
+Status: foundational — informs spec.md and plan.md
+
+This document captures the research and the design journey behind v2. It
+deliberately documents the approaches considered AND REJECTED, with the
+reasoning. Future maintainers should be able to read this and understand
+why we did not, for example, use the soft404 library or stick with phrase
+matching.
+
+---
+
+## 1. Why v1 needed redesigning
+
+### 1.1 v1 design summary
+
+`SPEC-INGEST-LOGIN-WALL-DETECT-001` (Phase A, shipped in PR #419) used a
+two-tier rule:
+
+- **Tier 1 (STRONG)**: substring match against a list of "canonical phrases"
+  (12 EN + 4 NL). A single match flagged the page as a wall regardless of
+  surrounding context. The FP-guard explicitly did NOT override Tier 1.
+- **Tier 2 (WEAK)**: structural conditions (B/C/D — redirect density ≥ 5,
+  login-link repetition ≥ 5, content-to-login ratio).
+
+The premise was that canonical phrases are unambiguous wall markers.
+Production data proved that wrong.
+
+### 1.2 Production canary findings (2026-05-06)
+
+Read-only application of the v1 detector on voys/support corpus
+(422 pages):
+
+| Outcome | Count | Examples |
+|---|---|---|
+| True positives | 150 | All `wiki.redcactus.cloud/*` walled stubs |
+| False positives | 4 (NL) | `meld u aan`, `in te loggen` matched on Bubble setup tutorials and the Voys account-recovery FAQ |
+
+After PR #432 attempted to fix the NL FPs by tightening NL phrases, a
+re-scan caught 1 additional EN FP:
+
+| FP URL | Matched phrase | Actual content |
+|---|---|---|
+| `https://help.voys.nl/2fa-freedom` | `log in with your` | 2FA setup tutorial; "Log in with your username and password" appears as STEP 2 of a numbered list |
+
+Empirical phrase-level audit:
+
+```
+Phrase distribution across 150 voys/support flagged pages
+  149  "have to log in"          (matched first per evaluation order)
+    1  "log in with your"        (only on /2fa-freedom — confirmed FP)
+    0  All other 10 EN phrases   (zero unique TPs)
+```
+
+**Key finding**: of the 12 EN canonical phrases, only `"have to log in"`
+contributed unique TPs in production. The other 11 phrases collectively
+produced 1 TP and 1 FP — net negative signal.
+
+### 1.3 The deeper problem v1 missed
+
+The 149 `have to log in` matches are not 149 distinct examples. They are
+149 copies of the same RedCactus boilerplate template:
+
+> "If you want to read this article, you will have to log in with your Red
+> Cactus account."
+
+So v1 was effectively validated on **one wall pattern × 149 instances** —
+one datapoint, not 149.
+
+This reveals what walls *actually are*:
+
+> A login wall is a page where the source CMS serves a TEMPLATED STUB to
+> anonymous visitors INSTEAD of the article's real content. The page is
+> not the article — it is a substitute, by definition lacking unique
+> content of its own.
+
+The structural fact ("this page is a template repeated across many
+URLs") is the wall. The phrasing ("have to log in") is incidental — a
+side-effect of the CMS template being lexically similar across copies.
+
+v1 detected a side-effect, not the cause. That is why every adjustment
+(NL fix in PR #432, EN fix proposed) was a patch on the wrong abstraction.
+
+### 1.4 Conditions B/C/D were noise
+
+The Tier-2 structural conditions in v1 (redirect density ≥ 5, login-link
+repetition ≥ 5, content-to-login ratio) were intended as fallbacks. Production data:
+
+| Feature | Real walls (median) | v1 threshold | Fires? |
+|---|---|---|---|
+| `redirect_to=` count | 2 | ≥ 5 | NO |
+| Login-anchor repetition | 2 | ≥ 5 | NO |
+| Content/login ratio | n/a (long boilerplate) | varied | NO |
+
+**No real wall in production triggers Conditions B/C/D.** They contributed
+zero TPs and added FP risk on legitimate tutorials with sign-in chrome.
+Pure noise.
+
+---
+
+## 2. The right framing — template detection, not phrase matching
+
+### 2.1 What walls actually are
+
+Walls are templates served INSTEAD of content. Their distinguishing feature
+is that the SAME content is served across many URLs:
+
+| Property | Wall | Real article |
+|---|---|---|
+| Content variation across pages | minimal (URL + 1-2 lines) | substantial (different topic, different prose) |
+| Cluster behaviour in corpus | tight (149 near-identical copies) | dispersed (each unique) |
+| Phrase content | side-effect of template | reflects topic |
+
+A detector that targets the *cause* (templated content) rather than the
+*side-effect* (phrasing) generalises across CMS, language, and tenant.
+
+### 2.2 What the field actually does at scale
+
+The field of soft-404 / boilerplate / paywall detection at scale uses
+**near-duplicate detection over a corpus**:
+
+- **Google "template match"** (public soft-404 documentation): detects when
+  page content matches a site's known error-page template. Pages clustered
+  by content similarity within the same site.
+- **Boilerpipe** (Kohlschütter et al., 2010, "Boilerplate Detection using
+  Shallow Text Features"): uses text-density features per DOM block, but at
+  corpus scale combines with cross-page block-similarity to identify
+  recurring boilerplate.
+- **MinHash / SimHash** (Charikar 2002, Broder 1997): the standard
+  near-duplicate detection primitives. Used by Google web index (for
+  duplicate URL collapsing), Common Crawl, and ArchiveTeam for
+  deduplication at billions-of-pages scale.
+- **Trafilatura** (Barbaresi 2021, ACL Demo): rule-based content extractor
+  with per-block link-density penalties, but its handling of templated
+  content includes recommending corpus-level dedup as a downstream filter.
+
+The common pattern: **a page is a template stub if N+ other pages in the
+same source share its content fingerprint**. The fingerprint is a hash
+that is robust to small per-page variations (URL, timestamp, etc.) but
+sensitive to wholesale content differences.
+
+### 2.3 Why this fits klai's actual problem
+
+klai's symptom: 149 RedCactus pages return the same content with different
+URLs. That is the textbook MinHash near-duplicate cluster.
+
+klai's data: each KB has 100s–1000s of pages, well within brute-force
+similarity scan range (no need for LSH bucketing infrastructure).
+
+klai's environment: knowledge-ingest already computes `content_hash` (sha256
+of fit_markdown text) per page. Adding a similarity-tolerant fingerprint
+alongside it is a small extension.
+
+---
+
+## 3. Alternatives considered and rejected
+
+This section is the most important part of this document. Each alternative
+below was a serious candidate; documenting why each was rejected prevents
+repeated rediscovery of dead ends.
+
+### 3.1 Substring phrase matching (v1, rejected)
+
+Approach: a list of "canonical phrases"; substring match flags a wall.
+
+Why rejected:
+- Production canary on 422 voys pages: 5 FPs (4 NL + 1 EN) at 2.6% rate.
+- Phrase tightening (PR #432) reduced FP-rate but did not eliminate the
+  category. Each tightening risks losing TPs while still leaving FP holes.
+- v1 was empirically validated on **one wall pattern × 149 instances**, not
+  149 distinct examples. "100% precision on voys" is misleading.
+- Phrases are language-specific. Each new tenant onboarding could require
+  curating new phrases per language and per CMS — unbounded maintenance.
+- Phrases detect a SIDE-EFFECT of templating, not the cause. The wall is
+  the structural fact "same content, many URLs", not the words.
+
+Verdict: brittle by design. The right abstraction is the structural fact.
+
+### 3.2 Multi-feature deterministic scorer (rejected)
+
+Approach: combine 4–5 weak signals (obligation phrase, link density,
+redirect density, fit_markdown brevity, chrome dominance) into a tiered
+score (Tier 1 phrase, Tier 2 structural).
+
+Why rejected:
+- Solves a different problem than klai has. This pattern is appropriate
+  for unsupervised classification of arbitrary pages where corpus access
+  is not available (e.g., a search engine indexing 10^9 unique URLs).
+- klai HAS corpus access. Every page is ingested into a tenant's KB; we
+  can compare a page to its siblings in the same KB.
+- Adds 5 features × thresholds × calibration framework — engineering
+  theatre for what is fundamentally a clustering problem.
+- Empirical data on real walls: structural features (link density,
+  redirect density) do NOT fire on RedCactus walls (median 2 redirects,
+  not 5). The features were chosen by analogy to soft-404 research that
+  targets a different page distribution.
+- "Per-page deterministic scoring" cannot beat "compare to other pages in
+  the same source" when the latter is available.
+
+Verdict: overengineering for a corpus-aware setting.
+
+### 3.3 ML classifier — soft404 pip library (rejected)
+
+Approach: `pip install soft404; soft404.probability(html) > 0.7`.
+
+Why rejected:
+- Library appears unmaintained (TeamHG-Memex/soft404 README itself points
+  to "an alternative fork with newer Python and library versions").
+- Trained on 120k pages with English-heavy bias. klai content is
+  Dutch-primary; performance on non-English content is unmeasured.
+- Black-box ML — explaining a TP/FP decision to a tenant operator
+  requires reverse-engineering the model output. Not aligned with
+  klai's preference for explainable systems.
+- Requires HTML input. klai stores `raw_markdown` in
+  `knowledge.crawled_pages`, not raw HTML. Backfill compatibility would
+  require either re-fetching HTML through crawl4ai (slow) or schema
+  extension to store HTML (storage cost).
+- Adds runtime ML dependency (scikit-learn + serialised model file) to a
+  service that currently does not load any ML libraries on the ingest
+  path. Increases image size and cold-start time.
+- Solves the classification problem in the same per-page deterministic
+  way as 3.2 above — does not exploit corpus access.
+
+Verdict: black-box dependency for a problem we can solve transparently.
+
+### 3.4 Trafilatura content extractor (rejected as primary signal)
+
+Approach: run `trafilatura.extract(html, min_extracted_size=N)`; if extraction
+returns less than N words, treat as wall.
+
+Why rejected as primary signal:
+- crawl4ai already performs content extraction (`fit_markdown`) using a
+  similar rule-based density approach. Layering trafilatura on top is
+  duplicate work.
+- We do not store HTML, only `raw_markdown`. Trafilatura's pruning
+  algorithms work best on HTML DOM, not on already-extracted markdown.
+- A length-only filter is too coarse: legitimate short pages (FAQs,
+  redirect notices, glossary entries) would be flagged. We measured this:
+  the production tutorial /2fa-freedom has only 364 words after stripping
+  anchors — below a 500-word threshold.
+
+Why considered: as a secondary check, trafilatura's quality filter can
+provide an additional signal. We do not use it in v2 because crawl4ai's
+`fit_markdown` already provides this signal when available.
+
+Verdict: redundant with crawl4ai; length-only filter has high FP rate.
+
+### 3.5 Structural features only (rejected)
+
+Approach: keep v1's Tier-2 conditions (redirect density, link repetition,
+content/login ratio) without phrase matching.
+
+Why rejected:
+- Empirical data: real RedCactus walls have median 2 redirects and 2
+  login-anchors. v1's threshold of ≥ 5 caught zero walls. Lowering the
+  threshold to ≥ 2 would catch walls AND many tutorials with sign-in
+  chrome (e.g., a tutorial linking to Bubble + Outlook + Slack login
+  pages would trigger).
+- These features are "what does a wall look like in isolation" features.
+  They are useful when corpus access is unavailable. With corpus access,
+  cross-page similarity is dramatically more discriminative.
+
+Verdict: weak signal compared to corpus clustering when corpus is
+available.
+
+### 3.6 Length-only filter on fit_markdown (rejected)
+
+Approach: if `fit_markdown` word count below threshold N, treat as wall.
+
+Why rejected:
+- Single signal: legitimate short pages (FAQ entries, redirect notices,
+  glossary stubs) get flagged. Measurement: the production tutorial
+  /2fa-freedom has 364 words content; threshold tuning is fragile.
+- Misses walls with substantial template text (e.g., a CMS that fills the
+  page with a "what is this site?" essay alongside the login prompt).
+- Does not exploit the cross-page redundancy that is the actual wall
+  signal.
+
+Verdict: too noisy alone; works only as a secondary signal.
+
+### 3.7 Authenticated re-crawl (out of scope)
+
+Approach: crawl with credentials; pages that show different content
+authenticated vs anonymous = wall.
+
+Why out of scope for v2:
+- Requires per-tenant credential management and secure cookie storage
+  across the crawler.
+- Solves a different problem: "make walled content available", not
+  "detect that a page is a wall".
+- Complementary to v2 but a separate effort. Tracked under the
+  `klai-libs/connector-credentials` follow-up issue.
+
+---
+
+## 4. Adopted design — corpus-level near-duplicate detection
+
+### 4.1 Core mechanism
+
+Detect template stubs by their cross-page near-duplicate behaviour:
+
+1. At ingest, compute a similarity-preserving fingerprint of each page's
+   normalised text content (URLs, anchors, and per-page variation
+   stripped).
+2. Store the fingerprint in `knowledge.crawled_pages` alongside the
+   existing `content_hash` (which is exact-match only).
+3. At detection time, count how many pages in the same `(org_id,
+   kb_slug)` have a fingerprint near-identical to the current page's.
+4. If the cluster size is ≥ a threshold N (default 5), the page is
+   classified as a template stub — i.e., a wall.
+
+### 4.2 Fingerprint choice
+
+SimHash (Charikar 2002) is the default. Properties relevant here:
+
+- 64-bit hash; near-duplicate test via Hamming distance.
+- Documented threshold: Hamming ≤ 3 ≈ 95%+ content overlap; Hamming ≤ 5
+  ≈ 90%+ overlap. We adopt Hamming ≤ 3 as the default near-duplicate
+  threshold and validate against production fixtures.
+- SQL-friendly: stored as `bigint`, distance computed via XOR + popcount
+  (`bit_count(a # b)` in PostgreSQL 14+).
+- Linear-scan within a single KB is sub-millisecond at klai's scale
+  (low thousands of pages per KB). Bucketing infrastructure (LSH banding)
+  is not needed at this scale.
+
+MinHash is a viable alternative for set-based Jaccard similarity. We
+prefer SimHash because:
+- One scalar fingerprint per page (vs MinHash's signature vector).
+- Simpler PostgreSQL storage and query.
+- Equally effective for "this content is the same template" detection at
+  klai's content lengths.
+
+If empirical validation reveals that SimHash misses real-world walls due
+to per-page variation (URL substitution dominating the hash), we fall
+back to MinHash with banded LSH. This is documented as a Phase D
+contingency.
+
+### 4.3 Pre-fingerprint normalisation
+
+Walls share a template but each instance contains a unique URL (the
+page's own canonical URL appears in the boilerplate). Without
+normalisation, the URL variation reduces similarity below threshold.
+
+Normalisation steps before hashing:
+1. Replace all URLs with a placeholder `<URL>`.
+2. Replace all markdown anchor text with the inner text only (drop the
+   URL).
+3. Lowercase and collapse whitespace.
+4. Tokenise on word boundaries.
+
+This isolates the textual template from per-page accidents.
+
+### 4.4 Cluster-size threshold
+
+Default: a page is flagged as wall if ≥ 5 OTHER pages in the same KB have
+a fingerprint within Hamming distance 3 of its own.
+
+Rationale for ≥ 5:
+- Real RedCactus walls: 149 instances, easily clears 5.
+- Single-page wall (a tenant onboarding with one walled URL): NOT
+  flagged. Acceptable: one stub does not pollute retrieval; the
+  detection accumulates as the corpus grows.
+- Real templates that are NOT walls (consistent header/footer): even if
+  the boilerplate dominates, these pages also have substantial unique
+  content (the article body), pushing fingerprints apart. We validate
+  this empirically against the captured FP fixtures.
+
+Threshold is configurable per-tenant via env var
+`KLAI_INGEST_TEMPLATE_CLUSTER_MIN`. Operators can tune for tenants with
+unusual content distributions.
+
+### 4.5 Cold-start behaviour
+
+A new tenant with few pages cannot form clusters. The detector returns
+"not a wall" for all pages until a cluster forms. This is the right
+behaviour:
+
+- Single-page walls do not pollute retrieval at cold-start.
+- As the tenant's corpus grows, walled pages accumulate; the first time
+  a cluster forms, all members are simultaneously flagged.
+- Backfill task re-runs detection across the whole KB, so retroactive
+  cluster discovery happens automatically.
+
+Cold-start protection: NO phrase fallback. The system explicitly
+declines to detect walls in tenants with ≤ 4 same-template pages, on
+the principle that one or two stub pages do not constitute a retrieval
+problem.
+
+### 4.6 Recovery for FP-purged pages
+
+The /2fa-freedom page was purged by the v1 detector with placeholder
+`content_hash = '__login_wall_purged__'`. Recovery under v2:
+
+1. Clear the placeholder hash for any page whose v2 fingerprint does NOT
+   appear in a wall cluster.
+2. Trigger re-ingest at next scheduled crawl (the placeholder ≠ live
+   content_hash forces re-fetch).
+3. The page returns to the KB with a fresh fingerprint, classified
+   correctly under v2.
+
+---
+
+## 5. Operational implications
+
+### 5.1 New dependencies
+
+- Python `simhash` library OR a small in-tree implementation (~50 LOC).
+  Recommendation: in-tree implementation to avoid dependency churn.
+- No new database engine. PostgreSQL `bit_count` exists since v14;
+  klai-postgres is on v17.
+
+### 5.2 Schema changes
+
+Single new column on `knowledge.crawled_pages`:
+
+```sql
+ALTER TABLE knowledge.crawled_pages
+ADD COLUMN content_simhash bigint;
+
+CREATE INDEX idx_crawled_pages_simhash_org_kb
+ON knowledge.crawled_pages (org_id, kb_slug, content_simhash);
+```
+
+The index supports the cluster-size scan within a tenant's KB.
+
+### 5.3 Backfill cost
+
+Compute SimHash for all existing pages: ~422 pages voys + ~5 pages
+getklai = ~430 pages. SimHash compute is < 10ms per page; full backfill
+runs in seconds.
+
+Cluster scan: O(N²) within each KB. For voys's 422 pages: ~178k pairwise
+comparisons, sub-second.
+
+### 5.4 Removed code
+
+The v1 detector and its dependents (`_OBLIGATION_EN`, `_OBLIGATION_NL`,
+`_match_canonical`, conditions B/C/D code paths, fixture sets for
+phrase-based testing) are deleted. The replaced public symbol is
+`detect_anonymous_auth_wall`; the new function takes the same inputs and
+returns the same `AuthWallSignal | None` shape, so callers
+(`_ingest_crawl_result`, `backfill_tasks`) need no signature changes.
+
+---
+
+## 6. References
+
+### Implementations
+- TeamHG-Memex/soft404 — https://github.com/TeamHG-Memex/soft404
+- Mozilla Readability — https://github.com/mozilla/readability
+- Internet Archive tarb_soft404 — https://github.com/internetarchive/tarb_soft404
+- Trafilatura — https://trafilatura.readthedocs.io/
+- `simhash` Python library — https://github.com/seomoz/simhash-py
+
+### Foundational research
+- Charikar 2002, "Similarity Estimation Techniques from Rounding Algorithms"
+  (introduces SimHash) — STOC 2002.
+- Broder 1997, "On the Resemblance and Containment of Documents" (introduces
+  MinHash) — Compression and Complexity of Sequences.
+- Manku, Jain, Sarma 2007, "Detecting Near-Duplicates for Web Crawling" —
+  WWW 2007. (Google-internal report; SimHash + LSH banding for the web
+  index.)
+- Kohlschütter, Fankhauser, Nejdl 2010, "Boilerplate Detection using
+  Shallow Text Features" — WSDM 2010 (Boilerpipe origin).
+- Sun, Wu, Yang, Zhang 2011, "Content Extraction via Text Density" —
+  SIGIR 2011.
+- Barbaresi 2021, "Trafilatura: A Web Scraping Library and Command-Line
+  Tool for Text Discovery and Extraction" — ACL Demo 2021.
+- "An Empirical Comparison of Web Content Extraction Algorithms" — SIGIR
+  2023, https://dl.acm.org/doi/10.1145/3539618.3591920.
+
+### Klai-specific
+- SPEC-INGEST-LOGIN-WALL-DETECT-001 (the v1 detector this SPEC supersedes).
+- PR #419 (Phase A–E shipping v1).
+- PR #432 (NL phrase tightening — superseded by v2's structural approach).
+- 2026-05-06 production canary on voys/support — finding 5 FPs at 2.6%
+  rate, leading to this redesign.

--- a/.moai/specs/SPEC-INGEST-LOGIN-WALL-DETECT-002/spec-compact.md
+++ b/.moai/specs/SPEC-INGEST-LOGIN-WALL-DETECT-002/spec-compact.md
@@ -1,0 +1,113 @@
+# SPEC-INGEST-LOGIN-WALL-DETECT-002 — compact form
+
+Auto-generated extract for /moai run token efficiency. Full context in
+spec.md, plan.md, acceptance.md, research.md.
+
+## Requirements
+
+### REQ-01 — Content fingerprint at ingest
+
+Every successfully-ingested page SHALL have a 64-bit SimHash stored in
+`knowledge.crawled_pages.content_simhash`. Pre-hash normalisation
+(URL → `<URL>`, anchor `[text](url)` → `text`, lowercase, whitespace
+collapse, word-boundary tokenisation) ensures per-page URL variation
+does not dominate the hash.
+
+### REQ-02 — Cluster-based wall detection
+
+The detector SHALL classify a page as a wall when N or more OTHER pages
+in the same `(org_id, kb_slug)` have a SimHash within Hamming distance 3
+of the page's own. Default N=5, configurable via
+`KLAI_INGEST_TEMPLATE_CLUSTER_MIN`. Hamming threshold of 3 is fixed.
+
+### REQ-03 — Cold-start permissiveness
+
+When fewer than (N+1) pages exist in `(org_id, kb_slug)`, the detector
+returns `None` for every page. Single or few-page walls are not flagged.
+
+### REQ-04 — Backfill replay
+
+`backfill_detect_login_walls(org_id, kb_slug)`: compute SimHashes for
+NULL rows, evaluate cluster membership, delete Qdrant points + mark
+`__login_wall_purged__` for cluster members. Idempotent.
+
+### REQ-05 — Recovery of v1-purged FPs
+
+`recover_purged_pages(org_id, kb_slug)`: re-evaluate placeholder pages;
+clear `content_hash` to empty string for those NOT in v2 clusters.
+Forces re-ingest at next crawl.
+
+### REQ-06 — Caller signature stability
+
+`detect_anonymous_auth_wall(markdown, fit_markdown=None, url=None,
+org_id=None, kb_slug=None, conn=None) -> AuthWallSignal | None`. Fail-safe
+on missing DB args (return None + WARN log).
+
+### REQ-07 — Mode handling preserved
+
+Three modes from SPEC-001 (reject / degrade / audit_only) apply
+unchanged. v2 detector returns `AuthWallSignal(pattern="template_cluster",
+evidence=("cluster_size=N hamming<=3",), confidence=0.9)` instead of
+`canonical_phrase_*`.
+
+### REQ-08 — Performance
+
+- SimHash compute p99 < 5 ms on 100 KB markdown.
+- Cluster query p99 < 50 ms on 1000-page KB.
+- Per-page ingest latency added < 100 ms.
+
+### REQ-09 — Tenant isolation
+
+All SQL filters by `org_id + kb_slug`. Qdrant deletes use
+`Filter.must` with `org_id + kb_slug + path`. Semgrep tenant-isolation
+rule must continue to pass.
+
+### REQ-10 — Production-data validation gate
+
+`scripts/validate_login_wall_detector.py --org SLUG --kb SLUG`. Reports
+clusters + recovery candidates. Merge gate: 0 surprise classifications
+on voys + getklai.
+
+## Acceptance summary
+
+- 149 RedCactus walls in voys/support form one cluster (size 149).
+- 5 captured production FPs do NOT cluster.
+- 4 synthetic CMS walls (Confluence/WordPress/Notion + 3 dupes each)
+  cluster correctly.
+- Backfill is idempotent. Recovery un-purges /2fa-freedom.
+- Reject/degrade/audit_only modes unchanged.
+- Tenant isolation enforced via SQL + Qdrant filters.
+- p99 budgets met (5 ms compute, 50 ms cluster query).
+
+## Files to modify
+
+- `klai-knowledge-ingest/alembic/versions/XXXX_crawled_pages_simhash.py` (new)
+- `klai-knowledge-ingest/knowledge_ingest/utils/content_fingerprint.py` (new)
+- `klai-knowledge-ingest/knowledge_ingest/utils/auth_wall_detector.py` (rewrite)
+- `klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py` (modify)
+- `klai-knowledge-ingest/knowledge_ingest/pg_store.py` (modify — `update_crawled_page_simhash`)
+- `klai-knowledge-ingest/knowledge_ingest/backfill_tasks.py` (rewrite + add `recover_purged_pages`)
+- `klai-knowledge-ingest/tests/test_content_fingerprint.py` (new)
+- `klai-knowledge-ingest/tests/test_auth_wall_detector.py` (rewrite)
+- `klai-knowledge-ingest/tests/test_crawler_template_detection.py` (new)
+- `klai-knowledge-ingest/tests/test_backfill_login_walls.py` (rewrite)
+- `klai-knowledge-ingest/tests/fixtures/auth_walls/` (replace fixtures with cluster-corpus fixtures)
+- `klai-knowledge-ingest/tests/fixtures/clean_pages/` (keep 5 production FPs as anti-fixtures)
+- `scripts/validate_login_wall_detector.py` (new)
+- `.moai/specs/SPEC-INGEST-LOGIN-WALL-DETECT-001/spec.md` (status: superseded)
+
+## Exclusions (What NOT to Build)
+
+- ML-based classifier (soft404 pip library) — see research.md §3.3.
+- Per-page deterministic multi-feature scorer (link density, brevity,
+  redirect density) — see research.md §3.2.
+- Authenticated re-crawl with cookies — separate effort under
+  `klai-libs/connector-credentials`.
+- LSH banding infrastructure — deferred until brute-force scan
+  measurably under-performs (none expected at klai's scale).
+- Cross-KB or cross-tenant cluster detection — tenant-isolation hazard.
+- Trafilatura integration — duplicate of crawl4ai's fit_markdown.
+- Modifications to retrieval-side `quality_floor` filter — unchanged
+  from v1 Phase E.
+- Modifications to mode flags or rollout operational model — unchanged
+  from v1 Phase B.

--- a/.moai/specs/SPEC-INGEST-LOGIN-WALL-DETECT-002/spec.md
+++ b/.moai/specs/SPEC-INGEST-LOGIN-WALL-DETECT-002/spec.md
@@ -1,0 +1,388 @@
+---
+id: SPEC-INGEST-LOGIN-WALL-DETECT-002
+version: "1.0"
+status: draft
+created: 2026-05-06
+updated: 2026-05-06
+author: Mark Vletter
+priority: high
+issue_number: TBD
+supersedes:
+  - SPEC-INGEST-LOGIN-WALL-DETECT-001 (Phase A detector logic; retains
+    Phase B mode flags, Phase C BFS handling, Phase D backfill task
+    skeleton, Phase E retrieval-side floor)
+related_specs:
+  - SPEC-CRAWLER-004 (authenticated cookie-based AuthWallDetected guard;
+    complementary, untouched by v2)
+  - SPEC-KB-014 (gap detection on retrieval; complementary)
+  - SPEC-KB-015 (quality_boost feedback loop; complementary)
+---
+
+## HISTORY
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| 1.0 | 2026-05-06 | Mark Vletter | Redesign after 2026-05-06 production canary on voys/support exposed v1's substring-matching design as fundamentally wrong. v1 detected the lexical side-effect of templating; v2 detects the structural cause via near-duplicate clustering. See research.md for the full design journey and rejected alternatives. |
+
+---
+
+# SPEC-INGEST-LOGIN-WALL-DETECT-002: Template-stub detection via near-duplicate clustering
+
+## Context
+
+A login wall is a page where the source CMS serves a templated stub to
+anonymous visitors INSTEAD of the article's real content. The
+distinguishing structural feature is that the SAME content is served
+across many URLs.
+
+`SPEC-INGEST-LOGIN-WALL-DETECT-001` v1 attempted to detect walls via
+substring matching of "canonical phrases". This was wrong by abstraction:
+phrases are a side-effect of templating, not the cause. Production
+validation (2026-05-06 canary on voys/support, 422 pages) found 5 false
+positives at 2.6% rate, all on legitimate Dutch and English instructional
+content that happens to mention authentication.
+
+**v2 changes the detection mechanism**: instead of matching phrases, the
+detector identifies pages whose normalised content fingerprint is
+near-identical to N or more other pages in the same `(org_id, kb_slug)`.
+This targets the templating CAUSE rather than the phrasing SYMPTOM, is
+language-agnostic, and generalises to any CMS.
+
+For full design rationale, alternatives considered, and rejected approaches,
+see `research.md`. That document is mandatory reading before modifying
+this SPEC.
+
+### What v2 keeps from v1
+
+- `AuthWallSignal` return type (caller-compatible).
+- `detect_anonymous_auth_wall(markdown, fit_markdown=None)` function
+  signature (caller-compatible).
+- `KLAI_INGEST_LOGIN_WALL_DETECT_ENABLED` and
+  `KLAI_INGEST_LOGIN_WALL_DETECT_MODE` env flags (reject / degrade /
+  audit_only modes unchanged).
+- `_ingest_crawl_result` integration point (no caller changes needed).
+- BFS continuity in `run_crawl_job` (`AnonymousAuthWallDetected`
+  exception, `auth_wall_pages` list, `error_summary` JSONB, `failed_partial`
+  status — all unchanged).
+- Backfill task `backfill_detect_login_walls(org_id, kb_slug)` and CLI
+  entry-point (re-implemented internally to use v2 detector).
+- Retrieval-side `quality_floor` filter (untouched, complementary).
+- Three-mode rollout (`reject`/`degrade`/`audit_only`).
+
+### What v2 replaces
+
+- The substring matching detector logic (`_match_canonical`,
+  `_OBLIGATION_EN`, `_OBLIGATION_NL`).
+- Conditions B/C/D (`_match_redirect_density`, `_match_login_link_repetition`,
+  `_match_content_login_ratio`) and the `_fp_guard_vetoes` machinery.
+- All v1 phrase fixtures in `tests/fixtures/auth_walls/` and the bare-phrase
+  test parametrisations.
+
+The v1 module file is replaced wholesale; the public function name is
+preserved for caller compatibility.
+
+---
+
+## Scope
+
+### In scope
+
+1. Schema migration: add `content_simhash bigint NULL` column to
+   `knowledge.crawled_pages`, with a covering index for
+   `(org_id, kb_slug, content_simhash)`.
+2. In-tree SimHash implementation in
+   `knowledge_ingest/utils/content_fingerprint.py`. ~50 LOC, no external
+   dependency. Includes pre-hash text normalisation (URL stripping, anchor
+   text extraction, whitespace collapse) so that per-page URL variation
+   does not dominate the hash.
+3. Replace `knowledge_ingest/utils/auth_wall_detector.py`. New
+   implementation:
+   - Takes `(markdown, fit_markdown, org_id, kb_slug, conn)` — same
+     signature plus DB connection for cluster lookup.
+   - Computes the page's SimHash from normalised content.
+   - Queries the cluster size: count of pages in same `(org_id, kb_slug)`
+     with Hamming distance ≤ 3.
+   - Returns `AuthWallSignal` if cluster size ≥ threshold, else `None`.
+4. Integration in `_ingest_crawl_result`:
+   - Compute SimHash, store in `crawled_pages`, then call detector with
+     the connection.
+   - Existing mode handling (reject / degrade / audit_only) unchanged.
+5. Backfill task v2: re-implement `backfill_detect_login_walls` to:
+   - Compute SimHash for any page missing one.
+   - For each page, evaluate cluster membership.
+   - Delete Qdrant points + mark `__login_wall_purged__` placeholder for
+     pages in clusters of size ≥ threshold.
+   - Idempotent (placeholder pages are not re-evaluated).
+6. Recovery task: `recover_purged_pages(org_id, kb_slug)`. Re-evaluates
+   any page with placeholder content_hash under v2 logic. If a page is no
+   longer a cluster member (e.g., the whole cluster has been purged or
+   v2 disagrees), clear the placeholder so the next crawl re-ingests.
+7. Production-data validation script:
+   `scripts/validate_login_wall_detector.py --org SLUG --kb SLUG`. Read-only.
+   Reports: pages flagged, cluster sizes, samples of flagged URLs. Required
+   to run before merge.
+8. Test suite refactor:
+   - Unit tests for SimHash determinism and Hamming distance behaviour.
+   - Cluster-detection tests with synthetic page corpora.
+   - Regression fixtures: 5 production FPs (must NOT cluster) + 2
+     production walls (must cluster) + 3 synthetic CMS wall corpora.
+   - Production-data integration test gated behind a `--prod` flag.
+9. Recovery for `/2fa-freedom` (1 production FP page already purged by
+   v1): clear its placeholder hash so the next crawl re-ingests it.
+10. Update SPEC-001 status to `superseded-by SPEC-INGEST-LOGIN-WALL-DETECT-002`.
+
+### Out of scope (What NOT to Build)
+
+- ML-based classifier (e.g., `soft404` pip library). See research.md §3.3
+  for rationale.
+- Per-page deterministic multi-feature scorer (link density, brevity,
+  redirect density). See research.md §3.2.
+- Authenticated re-crawl of `wiki.redcactus.cloud` with cookies. Separate
+  effort, tracked under `klai-libs/connector-credentials`.
+- LSH banding / locality-sensitive hashing infrastructure. Brute-force
+  pairwise scan within a single KB is sub-second at klai's scale (low
+  thousands of pages per KB). Banding is a Phase D contingency only if
+  the brute-force approach measurably under-performs.
+- Cross-KB or cross-tenant cluster detection. Walls cluster within a
+  source CMS; clustering across KBs would conflate unrelated tenants
+  and is a tenant-isolation hazard.
+- Trafilatura integration. crawl4ai's `fit_markdown` already provides
+  rule-based content extraction.
+- Modifying the `quality_floor` retrieval-side filter (Phase E of v1).
+  It remains as a defence-in-depth layer, untouched.
+- Modifying the `audit_only` / `degrade` / `reject` rollout flags. The
+  three-mode operational model carries over unchanged.
+
+---
+
+## Requirements (EARS)
+
+### REQ-INGEST-LOGIN-WALL-DETECT-002-01 — Content fingerprint at ingest
+
+The system SHALL compute a 64-bit SimHash of every successfully-ingested
+page's normalised content and store it in
+`knowledge.crawled_pages.content_simhash`.
+
+Normalisation steps before hashing (in order):
+1. Replace every URL (`https?://[^\s)]+`) with the literal token `<URL>`.
+2. For every markdown anchor `[text](url)`, replace with the bare anchor
+   text (drop the URL).
+3. Lowercase the result.
+4. Collapse runs of whitespace to a single space.
+5. Tokenise on word boundaries (`\b[\w]+\b`).
+
+The fingerprint MUST be deterministic: identical normalised input
+produces identical hashes across runs.
+
+Hash storage: `bigint` column. SimHash values fitting in 64-bit signed
+range MUST be stored as-is (not converted to unsigned).
+
+### REQ-INGEST-LOGIN-WALL-DETECT-002-02 — Cluster-based wall detection
+
+The system SHALL classify a page as a login-wall stub when N or more
+OTHER pages in the same `(org_id, kb_slug)` have a SimHash within Hamming
+distance 3 of the page's own SimHash, where N is the configured cluster
+threshold.
+
+Default N is 5. The threshold is configurable via env var
+`KLAI_INGEST_TEMPLATE_CLUSTER_MIN`.
+
+Hamming distance threshold of 3 is fixed in v2 and not user-configurable
+(adjusting it requires re-validation against fixtures and is a SPEC
+revision, not an env tweak).
+
+### REQ-INGEST-LOGIN-WALL-DETECT-002-03 — Cold-start permissiveness
+
+When fewer than `(N + 1)` pages exist in `(org_id, kb_slug)`, the
+detector SHALL classify all pages as not-walls (return `None`).
+
+Rationale: single or few-page walls do not pollute retrieval. Premature
+classification at cold-start risks suppressing legitimate sparse content.
+
+### REQ-INGEST-LOGIN-WALL-DETECT-002-04 — Backfill replay
+
+The Procrastinate task `backfill_detect_login_walls(org_id, kb_slug)`
+SHALL:
+
+1. For every page in `(org_id, kb_slug)` whose `content_simhash` is NULL,
+   compute and store the SimHash.
+2. For every page (excluding those whose `content_hash` already equals
+   `__login_wall_purged__`), evaluate cluster membership under
+   REQ-INGEST-LOGIN-WALL-DETECT-002-02.
+3. For every page classified as a wall:
+   a. Delete Qdrant points filtered by
+      `org_id + kb_slug + path` (REQ-INGEST-LOGIN-WALL-DETECT-002-09
+      tenant isolation).
+   b. Set the page's `content_hash` to `__login_wall_purged__`.
+4. Return `{"processed": N, "flagged": M, "qdrant_deleted": K}`.
+
+The task MUST be idempotent: running it twice on the same tenant yields
+the same final database state.
+
+### REQ-INGEST-LOGIN-WALL-DETECT-002-05 — Recovery of v1-purged FPs
+
+A new operator-triggered task `recover_purged_pages(org_id, kb_slug)`
+SHALL:
+
+1. Find all pages where `content_hash = '__login_wall_purged__'` AND a
+   non-NULL `content_simhash` exists.
+2. Re-evaluate each under v2 cluster logic.
+3. For pages NOT classified as walls under v2, clear `content_hash` to
+   the empty string (forces re-ingest at next crawl).
+4. Return `{"processed": N, "recovered": M}`.
+
+Designed for one-shot operator use immediately after v2 deploys, to undo
+v1 FPs.
+
+### REQ-INGEST-LOGIN-WALL-DETECT-002-06 — Caller signature stability
+
+The public function in
+`klai-knowledge-ingest/knowledge_ingest/utils/auth_wall_detector.py`
+SHALL retain the signature:
+
+```python
+def detect_anonymous_auth_wall(
+    markdown: str,
+    *,
+    fit_markdown: str | None = None,
+    url: str | None = None,
+) -> AuthWallSignal | None
+```
+
+Callers SHALL NOT need modification. The v2 implementation extends with
+keyword-only DB-access parameters (`org_id`, `kb_slug`, `conn`) for
+cluster lookup, defaulting to None for backwards-compat. When DB access
+parameters are absent, the detector returns `None` — fail-open with a
+single WARNING log line.
+
+### REQ-INGEST-LOGIN-WALL-DETECT-002-07 — Mode handling preserved
+
+The three operating modes from
+`SPEC-INGEST-LOGIN-WALL-DETECT-001 REQ-05` (reject / degrade / audit_only)
+SHALL apply unchanged in v2. The detector's return value semantics are
+identical (`AuthWallSignal | None`); modes determine post-detection
+behaviour (raise exception / continue with `quality_score=0` / log only).
+
+The `pattern` field on `AuthWallSignal` SHALL be `"template_cluster"` in
+v2 (was `"canonical_phrase_en/nl"` in v1). The `evidence` tuple SHALL
+contain a single string of the form
+`"cluster_size={N} hamming_threshold=3"`.
+
+### REQ-INGEST-LOGIN-WALL-DETECT-002-08 — Performance
+
+SimHash compute on a 100 KB markdown input SHALL complete in p99 < 5 ms.
+
+Cluster query within a single KB of N pages SHALL complete in p99 < 50 ms
+for N ≤ 1000 (which covers all current klai tenants by orders of
+magnitude). Implementation may use brute-force scan; LSH banding is not
+required at this scale and is deferred to a follow-up SPEC if scale
+demands it.
+
+### REQ-INGEST-LOGIN-WALL-DETECT-002-09 — Tenant isolation
+
+All v2 database operations SHALL respect tenant scope:
+
+- SimHash store/retrieve: SQL filtered by `org_id` AND `kb_slug`.
+- Cluster query: SQL filtered by `org_id` AND `kb_slug`. Cross-tenant
+  cluster lookup is FORBIDDEN.
+- Qdrant deletes (in backfill / recovery): `Filter.must` MUST include
+  `org_id`, `kb_slug`, and `path` field conditions, identical to v1's
+  REQ-09. The semgrep rule in
+  `.github/workflows/tenant-isolation-review.yml` MUST continue to pass.
+
+### REQ-INGEST-LOGIN-WALL-DETECT-002-10 — Production-data validation gate
+
+A read-only validation script
+`scripts/validate_login_wall_detector.py --org SLUG --kb SLUG` SHALL
+exist and SHALL be runnable against any production tenant.
+
+The script reports:
+- Total pages scanned.
+- SimHash clusters discovered (size ≥ N).
+- Sample URLs from each cluster (up to 10 per cluster).
+- Any page currently flagged as wall whose cluster size dropped below N
+  under v2 (potential v1 FP that should be recovered).
+
+Merge gate: the script MUST report 0 unexpected wall classifications on
+voys + getklai before v2 ships to production.
+
+---
+
+## Non-functional requirements
+
+### Performance
+
+- SimHash compute p99 < 5 ms on 100 KB markdown.
+- Cluster query p99 < 50 ms within a 1000-page KB.
+- Backfill throughput: ≥ 50 pages/second (limited by Qdrant delete API
+  for flagged pages).
+- Detector adds ≤ 100 ms to per-page ingest latency.
+
+### Security
+
+- Tenant isolation per REQ-09 (no cross-tenant data flow).
+- No new authentication paths introduced.
+
+### Reliability
+
+- Detector failure (e.g., DB connection error during cluster lookup) MUST
+  fail-safe: log a warning, return `None`, allow ingest to proceed
+  unflagged. A detector outage MUST NOT block ingest.
+- Backfill task MUST be re-runnable. Partial failure MUST leave the
+  remaining pages for the next run.
+- Schema migration MUST be additive (new column NULL-able, indexed; no
+  destructive changes).
+
+### Observability
+
+- Prometheus counter `klai_ingest_login_wall_detected_total{org_id, kb_slug, mode}`
+  inherited from v1 Phase F SHALL increment under v2 logic.
+- A new gauge `klai_ingest_template_cluster_size{org_id, kb_slug}`
+  SHALL track the largest cluster per KB for operator visibility.
+- Detector log entries SHALL include the cluster size in their `evidence`
+  field for diagnostic traceability.
+
+---
+
+## Success criteria
+
+1. v2 detector classifies all 149 voys/support RedCactus walls correctly
+   (cluster size ≥ 5 under SimHash + Hamming ≤ 3).
+2. v2 detector classifies all 5 captured production FP fixtures correctly
+   as NOT walls (`/2fa-freedom`, account-toegang, IFTTT, zoom_setup,
+   auth_documentation_tutorial).
+3. Production validation script reports 0 surprise classifications on
+   voys + getklai.
+4. SPEC-INGEST-LOGIN-WALL-DETECT-001 status updated to `superseded`.
+5. PR #432 (NL phrase tightening) reverted in spirit by v2 deletion of
+   the phrase list. The fix in PR #432 remains in main as a no-op (no
+   v2 code path uses phrases) — no need for a revert PR.
+6. Recovery task run on getklai/voys-test successfully un-purges
+   `/2fa-freedom`. After the next scheduled crawl, the page returns to
+   the KB and is correctly NOT classified as a wall.
+7. The original failing chat query *"Hoe stel ik RedCactus in met
+   HubSpot?"* in voys's chat continues to honestly say "I cannot find
+   this in the knowledge base" (because the redcactus walls remain
+   purged) AND the recovered tutorial content (`/2fa-freedom`,
+   `/account-toegang`) returns to retrieval results.
+
+---
+
+## Migration plan summary
+
+Detailed phasing in `plan.md`. Operationally, v2 ships in a single PR:
+
+1. Schema migration applied at container restart (knowledge-ingest
+   auto-migrates).
+2. New detector code replaces old in same file.
+3. Backfill task v2 invocation: `python -m
+   knowledge_ingest.backfill_tasks --org voys --kb support` recomputes
+   under v2.
+4. Recovery task invocation: `python -m
+   knowledge_ingest.backfill_tasks --org getklai --kb voys-test
+   --recover` un-purges `/2fa-freedom`.
+5. Production validation script confirms zero surprises.
+6. Mark SPEC-001 as superseded.
+
+No customer-facing API changes. No portal-frontend changes. No portal-api
+changes. No retrieval-api changes (the quality_floor remains unchanged).


### PR DESCRIPTION
## TL;DR

The 2026-05-06 production canary on voys/support exposed v1 (PR #419) as fundamentally wrong. v1 detected the **lexical side-effect** of templating; v2 detects the **structural cause** via SimHash near-duplicate clustering.

This PR is **SPEC documentation only** — no code changes. After review/approval, /moai run on SPEC-002 implements it.

## What changed in thinking

| | v1 (PR #419) | v2 (this SPEC) |
|---|---|---|
| **Theory of walls** | "Walls contain canonical phrases" | "Walls are template stubs served instead of content" |
| **Signal** | Substring match of obligation phrases | SimHash near-duplicate clustering within (org_id, kb_slug) |
| **Language** | Per-language phrase lists | Language-agnostic |
| **Generalises to new CMS?** | No — needs phrase additions | Yes — any templated stub clusters |
| **Production validation** | 5 FPs at 2.6% rate (canary 2026-05-06) | TBD (validation script in plan Phase E) |

## Why not... (research.md §3 documents this fully)

- **Phrase matching**: detects side-effect, not cause. v1's canary already broke.
- **Multi-feature scoring** (link density + brevity + redirect density): solves a different problem class. Works for unsupervised single-page classification when corpus access is unavailable. We HAVE corpus access; cross-page similarity is dramatically more discriminative.
- **soft404 pip library**: unmaintained, English-trained, black-box, requires HTML we don't store, doesn't exploit corpus.
- **Trafilatura**: duplicate of crawl4ai's fit_markdown.
- **Length-only filter**: too coarse, FPs on legitimate short pages.
- **Authenticated re-crawl**: separate effort, doesn't detect walls.
- **LSH banding / Cross-tenant clustering**: tenant-isolation hazards, deferred.

## What stays from v1

v2 supersedes v1's Phase A detector logic only. **Kept and reused by v2**:
- AuthWallSignal return type + detect_anonymous_auth_wall function signature
- Three operating modes: reject / degrade / audit_only
- _ingest_crawl_result integration point
- BFS continuity in run_crawl_job (AnonymousAuthWallDetected, error_summary, failed_partial)
- Backfill task skeleton + CLI
- Retrieval-side quality_floor filter (untouched, complementary)

## Document set

| File | Size | Purpose |
|---|---|---|
| [research.md](.moai/specs/SPEC-INGEST-LOGIN-WALL-DETECT-002/research.md) | 20K | Full design journey: production canary findings, industry research (SimHash, MinHash, Boilerpipe, Trafilatura, Readability), 7 alternatives considered + rejected with rationale |
| [spec.md](.moai/specs/SPEC-INGEST-LOGIN-WALL-DETECT-002/spec.md) | 16K | 10 EARS requirements |
| [plan.md](.moai/specs/SPEC-INGEST-LOGIN-WALL-DETECT-002/plan.md) | 11K | 7 phases A–G with risk register and decisions-resolved table |
| [acceptance.md](.moai/specs/SPEC-INGEST-LOGIN-WALL-DETECT-002/acceptance.md) | 13K | Gherkin scenarios per requirement |
| [spec-compact.md](.moai/specs/SPEC-INGEST-LOGIN-WALL-DETECT-002/spec-compact.md) | 5K | Auto-extract for /moai run |

## Operational impact

- New schema column: `knowledge.crawled_pages.content_simhash bigint NULL`
- Backfill task replays cluster detection on existing data
- New recovery task: un-purges /2fa-freedom (the 1 v1 FP we already deleted)
- Validation script gates the merge: `scripts/validate_login_wall_detector.py --org SLUG --kb SLUG`
- Same three modes, same env flags, same callers

## Status

Draft. After review/approval, run `/moai run SPEC-INGEST-LOGIN-WALL-DETECT-002`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)