### PR TITLE
feat(ingest-reconcile): SPEC-INGEST-RECONCILE-001 — coverage-complete + observable connector ingestion

### DIFF
--- a/klai-connector/alembic/versions/009_sync_runs_skip_reasons.py
+++ b/klai-connector/alembic/versions/009_sync_runs_skip_reasons.py
@@ -1,0 +1,115 @@
+"""SPEC-INGEST-RECONCILE-001 — add connector.sync_runs.skip_reasons.
+
+Adds a JSONB column ``skip_reasons`` mapping ``{reason_code: count}`` for
+docs that were fetched/parsed but NOT persisted as artifacts. Populated by
+``sync_engine._execute_sync`` at the end of every sync run.
+
+A CHECK constraint validates that every key is a member of the
+:class:`PersistSkipReason` enum (kept in sync via parity test
+``klai-connector/tests/test_reason_codes_parity.py``). Adding a new reason
+requires:
+
+  1. Append to ``PersistSkipReason`` in both services.
+  2. Write a follow-up migration that drops + re-adds this CHECK with the
+     new key in the IN (...) list.
+
+This is the mechanical guard against typo-introduced silent reasons that
+SPEC §"Fix 3" depends on.
+
+``documents_ok`` arithmetic is corrected in the application layer
+(sync_engine), not the schema. Existing column semantics: previously
+"submitted to ingest", now "documents_persisted = total - failed -
+sum(skip_reasons.values())". No backfill — existing rows keep their
+old (over-counted) ``documents_ok`` value and ``skip_reasons = '{}'``.
+
+Revision ID: 009_sync_runs_skip_reasons
+Revises: 008_rls_tenant_isolation
+Create Date: 2026-05-06
+SPEC: SPEC-INGEST-RECONCILE-001 AC-6, AC-7, AC-10
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "009_sync_runs_skip_reasons"
+down_revision: str | None = "008_rls_tenant_isolation"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# Mirror of PersistSkipReason values — kept in this string list (not imported)
+# so a future rename in app code does not silently change historical
+# migration behaviour. Update in lockstep with reason_codes.py.
+_ALLOWED_SKIP_REASONS: tuple[str, ...] = (
+    "content_too_short",
+    "auth_wall_detected",
+    "dedupe_content_hash_match",
+    "dedupe_raw_html_hash_match",
+    "non_text_content",
+    "excluded_by_kb_config",
+    "taxonomy_classify_failed",
+)
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE connector.sync_runs "
+        "ADD COLUMN IF NOT EXISTS skip_reasons jsonb NOT NULL DEFAULT '{}'::jsonb"
+    )
+
+    # Membership CHECK: empty object passes, non-empty must have every key
+    # be a member of the allowed set.
+    allowed_sql = ", ".join(f"'{r}'" for r in _ALLOWED_SKIP_REASONS)
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'sync_runs_skip_reasons_valid_keys'
+                  AND conrelid = 'connector.sync_runs'::regclass
+            ) THEN
+                ALTER TABLE connector.sync_runs
+                DROP CONSTRAINT sync_runs_skip_reasons_valid_keys;
+            END IF;
+        END
+        $$;
+        """
+    )
+    op.execute(
+        f"""
+        ALTER TABLE connector.sync_runs
+        ADD CONSTRAINT sync_runs_skip_reasons_valid_keys
+        CHECK (
+            jsonb_typeof(skip_reasons) = 'object'
+            AND (
+                skip_reasons = '{{}}'::jsonb
+                OR (
+                    SELECT bool_and(key IN ({allowed_sql}))
+                    FROM jsonb_object_keys(skip_reasons) AS key
+                )
+            )
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'sync_runs_skip_reasons_valid_keys'
+                  AND conrelid = 'connector.sync_runs'::regclass
+            ) THEN
+                ALTER TABLE connector.sync_runs
+                DROP CONSTRAINT sync_runs_skip_reasons_valid_keys;
+            END IF;
+        END
+        $$;
+        """
+    )
+    op.execute("ALTER TABLE connector.sync_runs DROP COLUMN IF EXISTS skip_reasons")

--- a/klai-connector/alembic/versions/009_sync_runs_skip_reasons.py
+++ b/klai-connector/alembic/versions/009_sync_runs_skip_reasons.py
@@ -38,18 +38,15 @@ branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
 
-# Mirror of PersistSkipReason values — kept in this string list (not imported)
-# so a future rename in app code does not silently change historical
-# migration behaviour. Update in lockstep with reason_codes.py.
-_ALLOWED_SKIP_REASONS: tuple[str, ...] = (
-    "content_too_short",
-    "auth_wall_detected",
-    "dedupe_content_hash_match",
-    "dedupe_raw_html_hash_match",
-    "non_text_content",
-    "excluded_by_kb_config",
-    "taxonomy_classify_failed",
-)
+# Mirror of ``PersistSkipReason`` values — hardcoded as a static SQL
+# literal below. Keeping the list visible here (and grep-able by the
+# parity test ``klai-connector/tests/test_reason_codes_parity.py``)
+# ensures any future enum addition is caught at PR time rather than
+# at production INSERT time. The SQL string is intentionally static
+# (no f-string composition) so semgrep's ``formatted-sql-query`` /
+# ``sqlalchemy-execute-raw-query`` rules don't flag this migration —
+# the values are not user input and never could be at this layer,
+# but the static form is simpler than a suppression annotation.
 
 
 def upgrade() -> None:
@@ -58,9 +55,6 @@ def upgrade() -> None:
         "ADD COLUMN IF NOT EXISTS skip_reasons jsonb NOT NULL DEFAULT '{}'::jsonb"
     )
 
-    # Membership CHECK: empty object passes, non-empty must have every key
-    # be a member of the allowed set.
-    allowed_sql = ", ".join(f"'{r}'" for r in _ALLOWED_SKIP_REASONS)
     op.execute(
         """
         DO $$
@@ -78,15 +72,23 @@ def upgrade() -> None:
         """
     )
     op.execute(
-        f"""
+        """
         ALTER TABLE connector.sync_runs
         ADD CONSTRAINT sync_runs_skip_reasons_valid_keys
         CHECK (
             jsonb_typeof(skip_reasons) = 'object'
             AND (
-                skip_reasons = '{{}}'::jsonb
+                skip_reasons = '{}'::jsonb
                 OR (
-                    SELECT bool_and(key IN ({allowed_sql}))
+                    SELECT bool_and(key IN (
+                        'content_too_short',
+                        'auth_wall_detected',
+                        'dedupe_content_hash_match',
+                        'dedupe_raw_html_hash_match',
+                        'non_text_content',
+                        'excluded_by_kb_config',
+                        'taxonomy_classify_failed'
+                    ))
                     FROM jsonb_object_keys(skip_reasons) AS key
                 )
             )

--- a/klai-connector/app/models/sync_run.py
+++ b/klai-connector/app/models/sync_run.py
@@ -42,6 +42,13 @@ class SyncRun(Base):
         cursor_state: JSONB -- bookmark for incremental sync
         quality_status: VARCHAR(20) -- 'healthy' | 'degraded' | 'failed' | NULL
             Added by SPEC-CRAWL-003 migration 005. NULL on historical rows (no backfill).
+        skip_reasons: JSONB -- {reason_code: count} for docs not persisted
+            Added by SPEC-INGEST-RECONCILE-001 migration 009. Default '{}'.
+            Keys must be members of PersistSkipReason (CHECK constraint
+            ``sync_runs_skip_reasons_valid_keys``). Populated by
+            ``sync_engine._execute_sync`` at run completion. Historical rows
+            keep '{}' (no backfill — pointless and migration-risky per
+            SPEC §"Not migrating existing sync_runs rows").
     """
 
     __tablename__ = "sync_runs"
@@ -72,3 +79,13 @@ class SyncRun(Base):
     # SPEC-CRAWL-003 REQ-2: content quality guardrail result per sync run.
     # Values: 'healthy' | 'degraded' | 'failed' | NULL (historical rows keep NULL).
     quality_status: Mapped[str | None] = mapped_column(String(20), nullable=True)
+
+    # SPEC-INGEST-RECONCILE-001 AC-6: per-sync skip-reason aggregation.
+    # JSONB ``{reason_code: count}``; keys validated by Postgres CHECK
+    # against ``PersistSkipReason`` (see migration 009). Defaults to ``{}``.
+    skip_reasons: Mapped[dict] = mapped_column(  # type: ignore[type-arg]
+        JSONB,
+        nullable=False,
+        server_default="{}",
+        default=dict,
+    )

--- a/klai-connector/app/reason_codes.py
+++ b/klai-connector/app/reason_codes.py
@@ -1,0 +1,52 @@
+"""Stable reason-code registry — connector-side copy.
+
+SPEC-INGEST-RECONCILE-001 Fix 3 / AC-9.
+
+Mirrors :mod:`knowledge_ingest.reason_codes`. The two services are
+independent deployables, so the enum is duplicated rather than imported
+from a shared package. Drift between the two copies is caught by the
+test ``klai-connector/tests/test_reason_codes_parity.py`` which asserts
+identical value sets.
+
+If you change values here, update the knowledge-ingest copy AND both
+service alembic migrations whose CHECK constraints reference these
+values:
+
+  - ``klai-knowledge-ingest/.../0005_crawl_jobs_fetch_outcomes.py``
+  - ``klai-connector/alembic/versions/009_sync_runs_skip_reasons.py``
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class FetchReasonCode(StrEnum):
+    """See knowledge_ingest.reason_codes.FetchReasonCode."""
+
+    SUCCESS = "success"
+    HTTP_4XX = "http_4xx"
+    HTTP_5XX = "http_5xx"
+    TIMEOUT = "timeout"
+    DNS_ERROR = "dns_error"
+    CONNECTION_ERROR = "connection_error"
+    AUTH_ERROR = "auth_error"
+    PARSE_ERROR = "parse_error"
+    RATE_LIMITED = "rate_limited"
+    UNKNOWN_EXCEPTION = "unknown_exception"
+
+
+class PersistSkipReason(StrEnum):
+    """See knowledge_ingest.reason_codes.PersistSkipReason."""
+
+    CONTENT_TOO_SHORT = "content_too_short"
+    AUTH_WALL_DETECTED = "auth_wall_detected"
+    DEDUPE_CONTENT_HASH_MATCH = "dedupe_content_hash_match"
+    DEDUPE_RAW_HTML_HASH_MATCH = "dedupe_raw_html_hash_match"
+    NON_TEXT_CONTENT = "non_text_content"
+    EXCLUDED_BY_KB_CONFIG = "excluded_by_kb_config"
+    TAXONOMY_CLASSIFY_FAILED = "taxonomy_classify_failed"
+
+
+FETCH_REASON_VALUES: frozenset[str] = frozenset(c.value for c in FetchReasonCode)
+PERSIST_SKIP_REASON_VALUES: frozenset[str] = frozenset(r.value for r in PersistSkipReason)

--- a/klai-connector/app/services/sync_engine.py
+++ b/klai-connector/app/services/sync_engine.py
@@ -35,6 +35,7 @@ from app.core.enums import SyncStatus
 from app.core.logging import get_logger
 from app.core.sanitize import sanitize_response_body  # SPEC-SEC-INTERNAL-001 REQ-4 + REQ-10
 from app.models.sync_run import SyncRun
+from app.reason_codes import PersistSkipReason  # SPEC-INGEST-RECONCILE-001 AC-9
 from app.services.parser import parse_document_with_images
 from app.services.portal_client import PortalClient
 from app.services.url_guard import (
@@ -152,11 +153,26 @@ class SyncEngine:
         documents_total = 0
         documents_ok = 0
         documents_failed = 0
-        # Docs whose parsed text was below the 50-char ingest threshold
-        # (Notion containers, empty Confluence pages, ms_docs placeholders).
-        # Tracked separately so ``documents_ok`` accurately reflects what is
-        # actually persisted in knowledge.artifacts.
-        documents_short_skipped = 0
+        # SPEC-INGEST-RECONCILE-001 AC-6 — per-sync skip-reason aggregation
+        # ``{PersistSkipReason: count}``. Persisted to
+        # ``connector.sync_runs.skip_reasons`` JSONB at the end of the run
+        # (CHECK-constrained to PersistSkipReason enum values via migration
+        # 009). Replaces the previous ``documents_short_skipped`` counter
+        # that only ever reached structlog and was lost after the 5-day
+        # retention window.
+        #
+        # ``documents_ok`` arithmetic note (SPEC AC-7): the SPEC defines
+        #   documents_ok = documents_total - documents_failed - sum(skip_reasons.values())
+        # In this codebase the per-loop counter already excludes short-skip
+        # (the ``continue`` branch never reaches the ``documents_ok += 1``
+        # line) and excludes failures (separate ``except`` branch), so the
+        # formula is a no-op for the only skip reason emitted today
+        # (content_too_short). It will become a meaningful correction once
+        # adapter-side handlers start incrementing other PersistSkipReason
+        # codes (auth_wall_detected, dedupe_*, ...) — at that point the
+        # counter and the formula stay aligned because every increment is
+        # accompanied by a ``continue`` that skips the success branch.
+        skip_reasons: dict[str, int] = {}
         bytes_processed = 0
         error_details: list[dict[str, str]] = []
 
@@ -334,7 +350,13 @@ class SyncEngine:
                                 ref.path,
                                 len(text.strip()),
                             )
-                            documents_short_skipped += 1
+                            # SPEC-INGEST-RECONCILE-001 AC-6 — replaces the
+                            # legacy ``documents_short_skipped`` int counter.
+                            # Same site (~30+ events on Voys Notion); now
+                            # observable via sync_runs.skip_reasons JSONB.
+                            skip_reasons[PersistSkipReason.CONTENT_TOO_SHORT.value] = (
+                                skip_reasons.get(PersistSkipReason.CONTENT_TOO_SHORT.value, 0) + 1
+                            )
                             resume_ingested_refs.add(ref_key)
                             continue
 
@@ -466,6 +488,11 @@ class SyncEngine:
             sync_run.documents_failed = documents_failed
             sync_run.bytes_processed = bytes_processed
             sync_run.error_details = error_details if error_details else None
+            # SPEC-INGEST-RECONCILE-001 AC-6: persist per-reason skip counts.
+            # Empty dict (no skips) is the default '{}' from the migration —
+            # we still write it explicitly so the operator-visible row is
+            # always JSONB rather than a stale server_default.
+            sync_run.skip_reasons = skip_reasons
             # Store all discovered refs for reconciliation on the next sync.
             # This is the full set from the adapter — new refs appear here, deleted
             # refs disappear. The sync engine compares against this on the next run.
@@ -487,7 +514,13 @@ class SyncEngine:
                     "documents_total": documents_total,
                     "documents_ok": documents_ok,
                     "documents_failed": documents_failed,
-                    "documents_short_skipped": documents_short_skipped,
+                    # Backwards-compat alias for log consumers (Grafana panels
+                    # still query ``documents_short_skipped``); ``skip_reasons``
+                    # is the structured form added by SPEC-INGEST-RECONCILE-001.
+                    "documents_short_skipped": skip_reasons.get(
+                        PersistSkipReason.CONTENT_TOO_SHORT.value, 0
+                    ),
+                    "skip_reasons": dict(skip_reasons),
                     "bytes_processed": bytes_processed,
                 },
             )

--- a/klai-connector/tests/test_reason_codes_parity.py
+++ b/klai-connector/tests/test_reason_codes_parity.py
@@ -1,0 +1,89 @@
+"""SPEC-INGEST-RECONCILE-001 AC-9 — connector / knowledge-ingest enum parity.
+
+The two services hold independent copies of the reason-code enums to
+avoid an import-time dependency between deployables (rationale:
+SPEC §"Stable reason-code registry"). Drift is dangerous:
+
+- A reason added to one side but missing from the other lets the
+  Postgres CHECK constraint reject what the other side writes.
+- A typo on either side becomes a silent dashboard category — the
+  exact failure mode this SPEC is designed to prevent.
+
+This test compares enum value sets between the two copies and FAILS
+loudly on any divergence. It runs as part of the connector test suite
+because the connector is the authoritative writer of skip_reasons; the
+mirror test in knowledge-ingest is symmetric.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+from app.reason_codes import FETCH_REASON_VALUES as CONNECTOR_FETCH
+from app.reason_codes import PERSIST_SKIP_REASON_VALUES as CONNECTOR_PERSIST
+
+
+def _load_knowledge_ingest_reason_codes():
+    """Import the knowledge-ingest copy from the sibling service path."""
+    repo_root = Path(__file__).resolve().parents[2]
+    target = repo_root / "klai-knowledge-ingest" / "knowledge_ingest" / "reason_codes.py"
+    if not target.exists():  # pragma: no cover — repo layout invariant
+        pytest.skip(f"knowledge-ingest reason_codes.py not found at {target}")
+    spec = importlib.util.spec_from_file_location("_ki_reason_codes", target)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_ki_reason_codes"] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_fetch_reason_values_match_across_services() -> None:
+    ki = _load_knowledge_ingest_reason_codes()
+    assert CONNECTOR_FETCH == ki.FETCH_REASON_VALUES, (
+        "FetchReasonCode drift between klai-connector and klai-knowledge-ingest. "
+        f"Connector-only: {CONNECTOR_FETCH - ki.FETCH_REASON_VALUES}; "
+        f"Knowledge-ingest-only: {ki.FETCH_REASON_VALUES - CONNECTOR_FETCH}"
+    )
+
+
+def test_persist_skip_reason_values_match_across_services() -> None:
+    ki = _load_knowledge_ingest_reason_codes()
+    assert CONNECTOR_PERSIST == ki.PERSIST_SKIP_REASON_VALUES, (
+        "PersistSkipReason drift between klai-connector and klai-knowledge-ingest. "
+        f"Connector-only: {CONNECTOR_PERSIST - ki.PERSIST_SKIP_REASON_VALUES}; "
+        f"Knowledge-ingest-only: {ki.PERSIST_SKIP_REASON_VALUES - CONNECTOR_PERSIST}"
+    )
+
+
+def test_persist_skip_reason_values_match_migration_check_constraint() -> None:
+    """SPEC AC-10: migration's CHECK constraint and the enum stay aligned.
+
+    A reason added to the enum without a follow-up migration would still
+    pass at write time on dev DBs (no CHECK enforcement) but fail in
+    production (where the CHECK is in force) — the worst kind of
+    asymmetric bug. Pin both ends here.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    migration = (
+        repo_root
+        / "klai-connector"
+        / "alembic"
+        / "versions"
+        / "009_sync_runs_skip_reasons.py"
+    )
+    assert migration.exists(), f"Migration 009 missing at {migration}"
+    text = migration.read_text(encoding="utf-8")
+    for reason in CONNECTOR_PERSIST:
+        # The literal lives in the ``_ALLOWED_SKIP_REASONS`` tuple
+        # (double-quoted Python source). At runtime the migration's
+        # f-string composes it into single-quoted SQL. We accept either
+        # form so the test stays robust to source-style refactors.
+        assert (f'"{reason}"' in text) or (f"'{reason}'" in text), (
+            f"PersistSkipReason value '{reason}' missing from migration 009 "
+            "CHECK constraint allowed-set. Add it to _ALLOWED_SKIP_REASONS."
+        )

--- a/klai-connector/tests/test_sync_engine_skip_reasons.py
+++ b/klai-connector/tests/test_sync_engine_skip_reasons.py
@@ -1,0 +1,213 @@
+"""SPEC-INGEST-RECONCILE-001 — sync_engine skip_reasons persistence.
+
+Acceptance criteria covered:
+
+- AC-6: ``connector.sync_runs.skip_reasons`` is populated by
+  ``_execute_sync`` with ``{reason_code: count}`` for persist-stage
+  drops.
+- AC-7: ``documents_ok = documents_total - documents_failed -
+  sum(skip_reasons.values())`` (corrected arithmetic).
+- AC-8 (mechanism): a synthetic short doc increments
+  ``skip_reasons["content_too_short"]`` and excludes it from
+  ``documents_ok``.
+
+Tests run the existing _execute_sync code path with mocked adapters
+and assert on the SyncRun model state and portal report payload — the
+two operator-facing surfaces of the SPEC.
+"""
+
+# ruff: noqa: S106  -- placeholder tokens for test config
+
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.adapters.base import DocumentRef
+from app.core.enums import SyncStatus
+from app.reason_codes import PersistSkipReason
+from app.services.portal_client import PortalConnectorConfig
+from app.services.sync_engine import SyncEngine
+
+
+def _portal_config() -> PortalConnectorConfig:
+    return PortalConnectorConfig(
+        connector_id="conn-skip-reasons",
+        kb_id=42,
+        kb_slug="support",
+        zitadel_org_id="org-test",
+        connector_type="notion",
+        config={"token": "placeholder"},
+        schedule=None,
+        is_enabled=True,
+    )
+
+
+def _mock_session_maker(sync_run: MagicMock) -> tuple[Any, AsyncMock]:
+    session = AsyncMock()
+    session.get = AsyncMock(return_value=sync_run)
+    session.commit = AsyncMock()
+
+    # ``_get_last_successful_run`` / ``_get_last_pending_run`` use
+    # ``result.scalars().first()`` — return a result where the scalar
+    # iterator yields nothing (no prior run).
+    scalars = MagicMock()
+    scalars.first = MagicMock(return_value=None)
+    scalars.scalar_one_or_none = MagicMock(return_value=None)
+    exec_result = MagicMock()
+    exec_result.scalars = MagicMock(return_value=scalars)
+    session.execute = AsyncMock(return_value=exec_result)
+
+    @asynccontextmanager
+    async def _ctx() -> Any:
+        yield session
+
+    return MagicMock(side_effect=_ctx), session
+
+
+def _short_doc_ref(path: str = "/short.md") -> DocumentRef:
+    return DocumentRef(
+        path=path,
+        ref=path,
+        size=4,  # tiny content; size is metadata only, doesn't gate the ingest path.
+        content_type="text/markdown",
+        source_ref=path,
+        source_url=f"https://notion.example/{path}",
+        last_edited="2026-05-06T00:00:00Z",
+    )
+
+
+@pytest.mark.asyncio
+async def test_short_doc_increments_skip_reasons_and_excludes_documents_ok() -> None:
+    """AC-6 + AC-7 + AC-8 mechanism: short doc → skip_reasons.content_too_short = 1
+    and the corrected documents_ok arithmetic excludes it from "ok"."""
+    sync_run = MagicMock()
+    sync_run.status = SyncStatus.PENDING
+    sync_run.cursor_state = None
+    sync_run.error_details = None
+    sync_run.quality_status = None
+    sync_run.skip_reasons = {}
+
+    session_maker_mock, _session = _mock_session_maker(sync_run)
+
+    portal_client = MagicMock()
+    portal_client.get_connector_config = AsyncMock(return_value=_portal_config())
+    portal_client.report_sync_status = AsyncMock()
+
+    # Adapter returns a single ref; the parser will produce <50-char text
+    # so the short-skip branch fires.
+    adapter = MagicMock()
+    adapter.get_cursor_state = AsyncMock(return_value={})
+    adapter.list_documents = AsyncMock(return_value=[_short_doc_ref()])
+    adapter.fetch_document = AsyncMock(return_value=b"<bytes>")
+    adapter.post_sync = AsyncMock(return_value=None)
+
+    registry = MagicMock()
+    registry.get = MagicMock(return_value=adapter)
+
+    ingest_client = MagicMock()
+    ingest_client.ingest_document = AsyncMock()  # never called for short docs
+    crawl_sync_client = MagicMock()
+
+    engine = SyncEngine(
+        session_maker=session_maker_mock,
+        registry=registry,
+        ingest_client=ingest_client,
+        portal_client=portal_client,
+        settings=MagicMock(),
+        image_store=None,
+        crawl_sync_client=crawl_sync_client,
+    )
+
+    # Patch the parser so the engine sees text shorter than the 50-char
+    # threshold without actually invoking unstructured.io.
+    short_text_result = MagicMock()
+    short_text_result.text = "tiny"
+    short_text_result.images = []
+
+    def _fake_parser(_content: bytes, _filename: str) -> Any:  # noqa: ANN401
+        return short_text_result
+
+    import app.services.sync_engine as engine_module
+
+    original_parser = engine_module.parse_document_with_images
+    engine_module.parse_document_with_images = _fake_parser
+    try:
+        await engine.run_sync(
+            uuid.UUID("11111111-1111-1111-1111-111111111111"),
+            uuid.UUID("22222222-2222-2222-2222-222222222222"),
+        )
+    finally:
+        engine_module.parse_document_with_images = original_parser
+
+    # AC-6: skip_reasons populated with content_too_short=1.
+    assert sync_run.skip_reasons == {PersistSkipReason.CONTENT_TOO_SHORT.value: 1}
+    # AC-7: documents_ok excludes the short-skipped doc. With 1 short doc
+    # and zero failures, documents_ok must NOT have been incremented for
+    # this ref (only the resume-already-ingested branch sets it pre-loop).
+    assert sync_run.documents_ok == 0
+    # documents_total counts all refs that entered the loop (1 short doc).
+    assert sync_run.documents_total == 1
+    assert sync_run.documents_failed == 0
+    # The ingest path must never be reached for short docs.
+    ingest_client.ingest_document.assert_not_awaited()
+    # Portal call still receives the corrected counters (consumer contract
+    # in AC-7 second sentence: "Existing API consumers continue reading
+    # documents_ok and get the corrected value").
+    portal_client.report_sync_status.assert_awaited_once()
+    kwargs = portal_client.report_sync_status.await_args.kwargs
+    assert kwargs["documents_ok"] == 0
+    assert kwargs["documents_total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_no_short_docs_keeps_skip_reasons_empty() -> None:
+    """Negative case: a sync with zero drops persists ``skip_reasons={}``.
+
+    Regression guard against accidentally setting a default-non-empty
+    dict that would trip the JSONB CHECK constraint or pollute
+    dashboards with phantom zero-count keys.
+    """
+    sync_run = MagicMock()
+    sync_run.status = SyncStatus.PENDING
+    sync_run.cursor_state = None
+    sync_run.error_details = None
+    sync_run.quality_status = None
+    sync_run.skip_reasons = {}
+
+    session_maker_mock, _session = _mock_session_maker(sync_run)
+
+    portal_client = MagicMock()
+    portal_client.get_connector_config = AsyncMock(return_value=_portal_config())
+    portal_client.report_sync_status = AsyncMock()
+
+    # No refs at all — list_documents returns empty.
+    adapter = MagicMock()
+    adapter.get_cursor_state = AsyncMock(return_value={})
+    adapter.list_documents = AsyncMock(return_value=[])
+    adapter.fetch_document = AsyncMock()
+    adapter.post_sync = AsyncMock(return_value=None)
+
+    registry = MagicMock()
+    registry.get = MagicMock(return_value=adapter)
+
+    engine = SyncEngine(
+        session_maker=session_maker_mock,
+        registry=registry,
+        ingest_client=MagicMock(),
+        portal_client=portal_client,
+        settings=MagicMock(),
+        image_store=None,
+        crawl_sync_client=MagicMock(),
+    )
+
+    await engine.run_sync(
+        uuid.UUID("33333333-3333-3333-3333-333333333333"),
+        uuid.UUID("44444444-4444-4444-4444-444444444444"),
+    )
+
+    assert sync_run.skip_reasons == {}

--- a/klai-knowledge-ingest/alembic/versions/0005_crawl_jobs_fetch_outcomes.py
+++ b/klai-knowledge-ingest/alembic/versions/0005_crawl_jobs_fetch_outcomes.py
@@ -1,0 +1,87 @@
+"""SPEC-INGEST-RECONCILE-001 — add knowledge.crawl_jobs.fetch_outcomes.
+
+Adds a JSONB column to capture per-URL fetch outcomes from crawl4ai's
+``POST /crawl`` bulk endpoint. Each entry has shape::
+
+    {"url": str, "reason_code": str, "status_code": int|null, "content_length": int}
+
+``reason_code`` MUST be a member of
+:class:`knowledge_ingest.reason_codes.FetchReasonCode`. The CHECK
+constraint enforces that ``fetch_outcomes`` is a JSONB array (or NULL);
+per-element ``reason_code`` validation is done application-side because
+inline jsonb-element CHECKs require subqueries that Postgres rejects in
+a column-level constraint.
+
+Idempotent: ADD COLUMN uses IF NOT EXISTS; constraint is wrapped in a DO
+block that DROPs by name before re-adding, so re-running on a partially
+migrated DB is safe.
+
+Revision ID: a8c5e1d2f3b4
+Revises: 603787256fb8
+Create Date: 2026-05-06
+SPEC: SPEC-INGEST-RECONCILE-001 AC-4, AC-11
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "a8c5e1d2f3b4"
+down_revision: str | None = "603787256fb8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE knowledge.crawl_jobs "
+        "ADD COLUMN IF NOT EXISTS fetch_outcomes jsonb NOT NULL DEFAULT '[]'::jsonb"
+    )
+
+    # Shape guard only — element-level reason_code validation is application-side
+    # (the StrEnum FetchReasonCode + classifier in crawl4ai_client._classify_fetch_outcome).
+    # Postgres rejects subquery-based CHECKs inline; a function-based CHECK would
+    # add a migration-management burden disproportionate to the gain at Voys-scale.
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'crawl_jobs_fetch_outcomes_is_array'
+                  AND conrelid = 'knowledge.crawl_jobs'::regclass
+            ) THEN
+                ALTER TABLE knowledge.crawl_jobs
+                DROP CONSTRAINT crawl_jobs_fetch_outcomes_is_array;
+            END IF;
+        END
+        $$;
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE knowledge.crawl_jobs
+        ADD CONSTRAINT crawl_jobs_fetch_outcomes_is_array
+        CHECK (jsonb_typeof(fetch_outcomes) = 'array')
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'crawl_jobs_fetch_outcomes_is_array'
+                  AND conrelid = 'knowledge.crawl_jobs'::regclass
+            ) THEN
+                ALTER TABLE knowledge.crawl_jobs
+                DROP CONSTRAINT crawl_jobs_fetch_outcomes_is_array;
+            END IF;
+        END
+        $$;
+        """
+    )
+    op.execute("ALTER TABLE knowledge.crawl_jobs DROP COLUMN IF EXISTS fetch_outcomes")

--- a/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
+++ b/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
@@ -210,7 +210,12 @@ async def run_crawl_job(
     auth_wall_pages: list[str] = []
 
     try:
-        results = await crawl_site(
+        # SPEC-INGEST-RECONCILE-001 AC-4: crawl_site now returns
+        # ``(results, outcomes)``. ``outcomes`` is a JSONB-shaped list with
+        # one entry per discovered candidate URL — written to
+        # ``crawl_jobs.fetch_outcomes`` so operators can answer "where did
+        # the missing pages go?" without log forensics.
+        results, fetch_outcomes = await crawl_site(
             start_url=start_url,
             selector=content_selector,
             max_depth=max_depth,
@@ -226,9 +231,16 @@ async def run_crawl_job(
         # keeps the public signature stable for Fase D delegation.
         _ = (canary_url, canary_fingerprint)
 
+        # SPEC-INGEST-RECONCILE-001 AC-4: persist per-URL outcomes alongside
+        # the page-count rollup. ``pages_total`` keeps its existing semantics
+        # ("how many CrawlResults reached the ingest loop"); the JSONB
+        # ``fetch_outcomes`` is the per-candidate breakdown.
         await conn.execute(
-            "UPDATE knowledge.crawl_jobs SET pages_total=$1, updated_at=$2 WHERE id=$3",
+            "UPDATE knowledge.crawl_jobs "
+            "SET pages_total=$1, fetch_outcomes=$2::jsonb, updated_at=$3 "
+            "WHERE id=$4",
             len(results),
+            json.dumps(fetch_outcomes),
             int(time.time()),
             job_id,
         )

--- a/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
@@ -7,19 +7,28 @@ the crawl4ai package (or a local Chromium install) as a dependency.
 
 from __future__ import annotations
 
-import asyncio
 import json
 import re
 from dataclasses import dataclass, field
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import urldefrag, urlparse, urlunparse
 
 import httpx
 import structlog
 
 from knowledge_ingest.config import settings
+from knowledge_ingest.reason_codes import FetchReasonCode
 
 logger = structlog.get_logger()
+
+
+# ---------------------------------------------------------------------------
+# Shape of the per-URL outcome captured for crawl_jobs.fetch_outcomes JSONB.
+# Keys match the migration shape: {"url", "reason_code", "status_code",
+# "content_length"}. ``reason_code`` MUST be a FetchReasonCode value.
+# ---------------------------------------------------------------------------
+
+FetchOutcome = dict[str, Any]
 
 # ---------------------------------------------------------------------------
 # JS scripts — single source of truth for content filtering
@@ -145,10 +154,6 @@ def build_crawl_config(
 # REST API helpers
 # ---------------------------------------------------------------------------
 
-_DEEP_POLL_INTERVAL = 5.0  # seconds between polls (bulk/deep crawl)
-_MAX_DEEP_POLL = 30 * 60   # max seconds for bulk/deep crawl (30 minutes)
-
-
 def _auth_headers() -> dict[str, str]:
     if settings.crawl4ai_api_key:
         return {"Authorization": f"Bearer {settings.crawl4ai_api_key}"}
@@ -158,7 +163,10 @@ def _auth_headers() -> dict[str, str]:
 async def _fetch_sitemap_urls(base_url: str) -> list[str]:
     """Fetch same-domain URLs from sitemap.xml.
 
-    Best-effort — returns [] on any error (sitemap is optional).
+    Best-effort — returns [] on any error (sitemap is optional). The
+    caller decides whether absent sitemap is fatal or fallback-worthy
+    (SPEC-INGEST-RECONCILE-001 AC-3 requires fallback to BFS-only,
+    not crawl failure).
     """
     sitemap_url = base_url.rstrip("/") + "/sitemap.xml"
     base_domain = urlparse(base_url).netloc.lower()
@@ -168,8 +176,98 @@ async def _fetch_sitemap_urls(base_url: str) -> list[str]:
             resp.raise_for_status()
             locs = re.findall(r"<loc>\s*(.*?)\s*</loc>", resp.text)
             return [u for u in locs if urlparse(u).netloc.lower() == base_domain]
-    except Exception:
+    except Exception as exc:
+        # AC-3: log unavailability at warning level; caller falls back.
+        logger.warning(
+            "crawl_discovery_sitemap_unavailable",
+            sitemap_url=sitemap_url,
+            error=str(exc),
+        )
         return []
+
+
+# SPEC-INGEST-RECONCILE-001 — URL canonicalisation for set-union dedup.
+# Trailing slash + fragment + scheme/host casing are common false-negatives
+# in the previous "exact-string match" supplement loop dedup (Bug A defect 3).
+def _canonicalise_url(url: str) -> str:
+    """Normalise a URL for set-union dedup.
+
+    - Lowercase scheme + host
+    - Strip URL fragment (#section)
+    - Strip trailing slash from path (but keep root "/" as-is)
+
+    Query string is preserved — different ?foo=bar variants are
+    different pages by convention.
+    """
+    if not url:
+        return url
+    defragged, _ = urldefrag(url)
+    parsed = urlparse(defragged)
+    path = parsed.path or "/"
+    if len(path) > 1 and path.endswith("/"):
+        path = path.rstrip("/")
+    return urlunparse(
+        (
+            parsed.scheme.lower(),
+            parsed.netloc.lower(),
+            path,
+            parsed.params,
+            parsed.query,
+            "",  # fragment
+        )
+    )
+
+
+def _classify_fetch_outcome(
+    page_result: dict[str, Any] | None,
+    *,
+    error: BaseException | None = None,
+) -> str:
+    """Map a crawl4ai per-URL result (or transport exception) to FetchReasonCode.
+
+    Stable mapping — used to populate ``crawl_jobs.fetch_outcomes`` JSONB
+    keyed by FetchReasonCode value (AC-4, AC-11). New cases here MUST
+    correspond to an existing enum member; if none fits, add one to
+    ``reason_codes.py`` AND extend the migration's allowed set first.
+    """
+    if error is not None:
+        msg = str(error).lower()
+        if isinstance(error, httpx.TimeoutException) or "timeout" in msg:
+            return FetchReasonCode.TIMEOUT.value
+        if isinstance(error, httpx.ConnectError) or "connection" in msg:
+            return FetchReasonCode.CONNECTION_ERROR.value
+        if "name or service not known" in msg or "dns" in msg or "nodename" in msg:
+            return FetchReasonCode.DNS_ERROR.value
+        return FetchReasonCode.UNKNOWN_EXCEPTION.value
+
+    if not page_result:
+        return FetchReasonCode.UNKNOWN_EXCEPTION.value
+
+    if page_result.get("success"):
+        return FetchReasonCode.SUCCESS.value
+
+    status = page_result.get("status_code")
+    err_msg = (page_result.get("error_message") or "").lower()
+
+    if status == 429:
+        return FetchReasonCode.RATE_LIMITED.value
+    if status in (401, 403):
+        return FetchReasonCode.AUTH_ERROR.value
+    if isinstance(status, int) and 400 <= status < 500:
+        return FetchReasonCode.HTTP_4XX.value
+    if isinstance(status, int) and 500 <= status < 600:
+        return FetchReasonCode.HTTP_5XX.value
+
+    if "timeout" in err_msg:
+        return FetchReasonCode.TIMEOUT.value
+    if "dns" in err_msg or "name or service not known" in err_msg:
+        return FetchReasonCode.DNS_ERROR.value
+    if "connection" in err_msg:
+        return FetchReasonCode.CONNECTION_ERROR.value
+    if "parse" in err_msg or "decode" in err_msg or "html" in err_msg:
+        return FetchReasonCode.PARSE_ERROR.value
+
+    return FetchReasonCode.UNKNOWN_EXCEPTION.value
 
 
 async def _crawl_sync(
@@ -292,146 +390,309 @@ async def crawl_page(
 async def crawl_site(
     start_url: str,
     selector: str | None = None,
-    max_depth: int = 2,
+    max_depth: int = 2,  # kept for caller-signature compat — see docstring
     max_pages: int = 200,
     include_patterns: list[str] | None = None,
     login_indicator_selector: str | None = None,
     cookies: list[dict[str, Any]] | None = None,
-) -> list[CrawlResult]:
-    """Deep-crawl a website using BFS strategy via the Crawl4AI REST API.
+) -> tuple[list[CrawlResult], list[FetchOutcome]]:
+    """Crawl a site via sitemap+BFS UNION submitted to crawl4ai's bulk /crawl.
 
-    Crawls from start_url using BFS up to max_depth and max_pages.
+    @MX:NOTE SPEC-INGEST-RECONCILE-001 Fix 1 — replaces the old BFS-with-
+    post-supplement design that silently dropped sitemap URLs in an
+    unbounded ``asyncio.gather`` loop (Bug A: 41/208 ingested for
+    help.voys.nl). Discovery and fetch are now decoupled:
 
-    Aligned with klai-connector's webcrawler (SPEC-CRAWL-001).
-    Uses POST /crawl/job → GET /crawl/job/{task_id} (bulk/deep-crawl endpoint).
+    1. **Discovery** — union(sitemap_xml_urls, BFS_seeds_from_homepage),
+       canonicalised + deduped + capped at ``max_pages``. Sitemap takes
+       priority on cap (AC-2: site-owner truth beats best-effort BFS).
+       AC-3: missing sitemap → BFS-only fallback, never crawl failure.
+    2. **Fetch** — single ``POST /crawl`` bulk call with the candidate
+       URL list. crawl4ai's server-side ``MemoryAdaptiveDispatcher``
+       handles concurrency.
+    3. **Outcome capture** — every candidate URL produces one entry in
+       the returned ``outcomes`` list (AC-4) keyed by ``FetchReasonCode``.
 
-    Note: exclude_patterns is not supported by Crawl4AI's filter_chain; pass
-    include_patterns to restrict crawling to specific URL path prefixes.
+    Returns ``(crawl_results, outcomes)``:
+    - ``crawl_results``: same-domain pages with non-empty markdown (the
+      caller's old contract: pages worth ingesting).
+    - ``outcomes``: per-URL records ``{"url", "reason_code", "status_code",
+      "content_length"}`` — written to ``crawl_jobs.fetch_outcomes`` JSONB
+      so operators can answer "where did the missing pages go?".
 
-    ``login_indicator_selector`` (SPEC-CRAWLER-004 Fase B / REQ-02.3) is
-    injected into the wait_for expression — when it matches on a page,
-    crawl4ai times out and returns ``success=False`` for that result.
-    Callers of ``crawl_site`` can then treat any success=False outcome
-    that fired with a non-None selector as an auth-wall event.
+    ``max_depth`` is accepted for caller-signature compatibility but no
+    longer drives discovery (we explicitly enumerate candidates instead
+    of recursing). ``include_patterns``, when set, is applied as a
+    candidate-side substring filter against the union before submission.
     """
     config = build_crawl_config(selector, login_indicator_selector=login_indicator_selector)
-
-    # Derive origin domain for post-crawl filtering.
     parsed = urlparse(start_url)
+    base_domain = parsed.netloc.lower()
 
-    deep_crawl_params: dict[str, Any] = {
-        "max_depth": max_depth,
-        "max_pages": max_pages,
-    }
-    if include_patterns:
-        # Crawl4AI 0.8.6 only reconstructs nested objects when they are wrapped
-        # in {"type": "<ClassName>", "params": {...}} — a bare list stays a list
-        # and BFSDeepCrawlStrategy crashes with
-        # `AttributeError: 'list' object has no attribute 'apply'`
-        # the moment it walks past depth 0.  Pinned by
-        # tests/test_crawl4ai_filter_chain.py.
-        deep_crawl_params["filter_chain"] = {
-            "type": "FilterChain",
-            "params": {
-                "filters": [
-                    {
-                        "type": "URLPatternFilter",
-                        "params": {"patterns": include_patterns},
-                    },
-                ],
-            },
-        }
+    # ------------------------------------------------------------------
+    # Discovery — sitemap + shallow BFS seed, union, dedup, cap.
+    # ------------------------------------------------------------------
+    sitemap_urls = await _fetch_sitemap_urls(start_url)
 
-    config["deep_crawl_strategy"] = {
-        "type": "BFSDeepCrawlStrategy",
-        "params": deep_crawl_params,
-    }
+    bfs_seed_urls = await _bfs_discover_seed_urls(
+        start_url=start_url,
+        selector=selector,
+        login_indicator_selector=login_indicator_selector,
+        cookies=cookies,
+    )
 
+    candidates = _build_candidate_set(
+        start_url=start_url,
+        sitemap_urls=sitemap_urls,
+        bfs_seed_urls=bfs_seed_urls,
+        base_domain=base_domain,
+        max_pages=max_pages,
+        include_patterns=include_patterns,
+    )
+
+    logger.info(
+        "crawl_site_discovery_complete",
+        start_url=start_url,
+        sitemap_urls=len(sitemap_urls),
+        bfs_seed_urls=len(bfs_seed_urls),
+        candidates=len(candidates),
+        max_pages=max_pages,
+    )
+
+    if not candidates:
+        logger.warning("crawl_site_no_candidates", start_url=start_url)
+        return [], []
+
+    # ------------------------------------------------------------------
+    # Fetch — single bulk POST /crawl. Server-side dispatcher handles
+    # concurrency; we get per-URL ``success`` + ``error_message`` in
+    # the response body.
+    # ------------------------------------------------------------------
     payload: dict[str, Any] = {
-        "urls": [start_url],
+        "urls": candidates,
         "crawler_config": {"type": "CrawlerRunConfig", "params": config},
     }
     if cookies:
-        # SPEC-CRAWLER-004 Fase C — inject browser cookies via the same
-        # on_page_context_created hook crawl_page() uses. Shared _build_cookie_hooks
-        # keeps the injection identical across single-page and BFS crawls.
         payload["hooks"] = _build_cookie_hooks(cookies)
 
-    async with httpx.AsyncClient(timeout=90.0) as client:
-        resp = await client.post(
-            f"{settings.crawl4ai_api_url}/crawl/job",
-            json=payload,
-            headers=_auth_headers(),
+    raw_results: list[dict[str, Any]] = []
+    transport_error: BaseException | None = None
+
+    try:
+        async with httpx.AsyncClient(timeout=_BULK_CRAWL_TIMEOUT) as client:
+            data = await _crawl_sync(client, payload)
+        raw_results = _normalise_results_block(data)
+    except Exception as exc:
+        # Whole-batch transport failure: every candidate gets the same
+        # transport-classified outcome (AC-4: no candidate is "lost",
+        # they all surface a reason). The caller's existing failure
+        # path then reads the outcomes to decide.
+        transport_error = exc
+        logger.warning(
+            "crawl_site_bulk_request_failed",
+            start_url=start_url,
+            candidates=len(candidates),
+            error=str(exc),
         )
-        resp.raise_for_status()
-        task_id: str = resp.json()["task_id"]
-        logger.info("crawl_site_job_submitted", start_url=start_url, task_id=task_id)
 
-        elapsed = 0.0
-        result_data: dict[str, Any] = {}
-        while elapsed < _MAX_DEEP_POLL:
-            await asyncio.sleep(_DEEP_POLL_INTERVAL)
-            elapsed += _DEEP_POLL_INTERVAL
-            resp = await client.get(
-                f"{settings.crawl4ai_api_url}/crawl/job/{task_id}",
-                headers=_auth_headers(),
+    # Map results back to candidates by URL (canonicalised). crawl4ai
+    # keeps URL ordering but we don't rely on it.
+    by_url: dict[str, dict[str, Any]] = {}
+    for page in raw_results:
+        if not page:
+            continue
+        result_url = page.get("url") or ""
+        if not result_url:
+            continue
+        by_url[_canonicalise_url(result_url)] = page
+
+    crawl_results: list[CrawlResult] = []
+    outcomes: list[FetchOutcome] = []
+
+    for url in candidates:
+        canonical = _canonicalise_url(url)
+        page = by_url.get(canonical)
+        if transport_error is not None:
+            reason_code = _classify_fetch_outcome(None, error=transport_error)
+            outcomes.append(
+                {
+                    "url": url,
+                    "reason_code": reason_code,
+                    "status_code": None,
+                    "content_length": 0,
+                }
             )
-            resp.raise_for_status()
-            data = resp.json()
-            status = data.get("status", "").lower()
-            if status == "completed":
-                result_data = data["result"]
-                break
-            if status == "failed":
-                raise RuntimeError(
-                    f"Crawl job {task_id} failed: {data.get('error', 'unknown')}"
-                )
-        else:
-            raise TimeoutError(f"Crawl job {task_id} did not complete within {_MAX_DEEP_POLL}s")
+            continue
 
-    results = result_data.get("results", result_data.get("result", []))
-    if isinstance(results, dict):
-        results = [results]
+        reason_code = _classify_fetch_outcome(page)
+        content_length = len((page or {}).get("html", "") or "")
+        outcomes.append(
+            {
+                "url": url,
+                "reason_code": reason_code,
+                "status_code": (page or {}).get("status_code"),
+                "content_length": content_length,
+            }
+        )
 
-    all_results = [_extract_result(start_url, page) for page in results if page]
+        if page is None:
+            # crawl4ai didn't return this URL — uncommon, but record it.
+            continue
 
-    # Always restrict to origin domain — Crawl4AI may follow external links during BFS.
-    crawl_results = [r for r in all_results if urlparse(r.url).netloc == parsed.netloc]
-    skipped = len(all_results) - len(crawl_results)
+        result = _extract_result(url, page)
+        # Same-domain filter as the legacy BFS path: external links
+        # discovered via sitemap noise or rewrites stay out.
+        if urlparse(result.url).netloc != parsed.netloc:
+            continue
+        # Only successful, non-empty pages reach the ingest loop. Failed
+        # fetches stay in ``outcomes`` (where operators look for the
+        # breakdown via ``crawl_jobs.fetch_outcomes``) so the caller's
+        # ``pages_total`` reflects pages that actually have content. This
+        # also preserves the legacy login_indicator semantics: a single
+        # ``success=False`` result that the indicator caller sees triggers
+        # ``AuthWallDetected`` — surfacing transient 5xx noise as
+        # auth-walled would be a regression.
+        if not result.success:
+            continue
+        if not (result.fit_markdown or result.raw_markdown):
+            continue
+        crawl_results.append(result)
+
+    success_count = sum(1 for o in outcomes if o["reason_code"] == FetchReasonCode.SUCCESS.value)
     logger.info(
-        "crawl_site_bfs_complete",
+        "crawl_site_complete",
         start_url=start_url,
-        pages=len(crawl_results),
-        skipped_external=skipped,
+        candidates=len(candidates),
+        results=len(crawl_results),
+        success_outcomes=success_count,
+        non_success_outcomes=len(outcomes) - success_count,
     )
 
-    # Phase 2: supplement with sitemap URLs if BFS returned fewer pages than requested.
-    # BFS only finds pages reachable via links; orphaned pages (in sitemap but not linked)
-    # would be missed without this step.
-    if len(crawl_results) < max_pages:
-        remaining = max_pages - len(crawl_results)
-        seen_urls = {r.url for r in crawl_results}
-        sitemap_urls = await _fetch_sitemap_urls(start_url)
-        supplement_urls = [u for u in sitemap_urls if u not in seen_urls][:remaining]
-        if supplement_urls:
-            logger.info(
-                "crawl_site_supplement",
-                start_url=start_url,
-                bfs_pages=len(crawl_results),
-                supplement_count=len(supplement_urls),
-            )
-            supplement_results = await asyncio.gather(
-                *[crawl_page(u, selector=selector) for u in supplement_urls],
-                return_exceptions=True,
-            )
-            for result in supplement_results:
-                if isinstance(result, CrawlResult) and result.success and (
-                    result.fit_markdown or result.raw_markdown
-                ):
-                    crawl_results.append(result)
+    return crawl_results, outcomes
 
-    logger.info("crawl_site_complete", start_url=start_url, pages=len(crawl_results))
-    return crawl_results
+
+# Single bulk-crawl request budget. crawl4ai's MemoryAdaptiveDispatcher
+# handles in-batch concurrency server-side; the client just waits for
+# the whole batch. Voys-scale Voys/support (~500 candidates) completes
+# well under 90s on the production container — tuned to give 5x headroom.
+_BULK_CRAWL_TIMEOUT = 5 * 60.0
+
+
+def _normalise_results_block(data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Flatten the various shapes crawl4ai returns into a list of dicts."""
+    results = data.get("results", data.get("result", []))
+    if isinstance(results, dict):
+        return [results]
+    if isinstance(results, list):
+        return [r for r in results if isinstance(r, dict)]
+    return []
+
+
+async def _bfs_discover_seed_urls(
+    *,
+    start_url: str,
+    selector: str | None,
+    login_indicator_selector: str | None,
+    cookies: list[dict[str, Any]] | None,
+) -> list[str]:
+    """Shallow BFS — fetch start_url once, return its same-domain internal links.
+
+    @MX:NOTE Replaces the previous deep-BFS via ``/crawl/job``. We only
+    need the homepage's link set as the BFS contribution to the union;
+    the rest of crawl4ai's BFS (recursive expansion) is the layer that
+    duplicated work in the old design and produced no coverage signal.
+    """
+    base_domain = urlparse(start_url).netloc.lower()
+
+    seed_result = await crawl_page(
+        start_url,
+        selector=selector,
+        cookies=cookies,
+    )
+    if not seed_result.success:
+        if login_indicator_selector:
+            logger.warning(
+                "crawl_site_seed_login_indicator_triggered",
+                start_url=start_url,
+                login_indicator_selector=login_indicator_selector,
+            )
+        else:
+            logger.warning(
+                "crawl_site_seed_fetch_failed",
+                start_url=start_url,
+                error=seed_result.error_message,
+            )
+        return []
+
+    # crawl4ai links shape: {"internal": [{"href": "...", "text": "..."}], "external": [...]}.
+    internal = seed_result.links.get("internal") or []
+    seeds: list[str] = []
+    for entry in internal:
+        href = entry.get("href") if isinstance(entry, dict) else None
+        if not href:
+            continue
+        if urlparse(href).netloc.lower() != base_domain:
+            continue
+        seeds.append(href)
+    return seeds
+
+
+def _build_candidate_set(
+    *,
+    start_url: str,
+    sitemap_urls: list[str],
+    bfs_seed_urls: list[str],
+    base_domain: str,
+    max_pages: int,
+    include_patterns: list[str] | None,
+) -> list[str]:
+    """Union(sitemap, BFS-seeds), filtered to same-domain, deduped, capped.
+
+    AC-2: when union exceeds max_pages, sitemap entries take priority
+    over BFS-discovered URLs. ``include_patterns`` (when set) restricts
+    candidates by simple substring match on the path — same semantics
+    as the old crawl4ai URLPatternFilter without the deserialisation
+    fragility (SPEC-CRAWL-001 v0.8.6 issue).
+
+    The starting URL is always included as candidate index 0 so the
+    homepage is in the bulk fetch and never silently dropped on cap.
+    """
+
+    def _same_domain(u: str) -> bool:
+        return urlparse(u).netloc.lower() == base_domain
+
+    def _matches_include(u: str) -> bool:
+        if not include_patterns:
+            return True
+        return any(p in u for p in include_patterns)
+
+    seen: set[str] = set()
+    ordered: list[str] = []
+
+    def _add(u: str) -> None:
+        if not u:
+            return
+        if not _same_domain(u):
+            return
+        if not _matches_include(u):
+            return
+        canonical = _canonicalise_url(u)
+        if canonical in seen:
+            return
+        seen.add(canonical)
+        ordered.append(u)
+
+    # Priority order: start_url first, then sitemap (site-owner truth),
+    # then BFS-discovered (best-effort).
+    _add(start_url)
+    for u in sitemap_urls:
+        _add(u)
+    for u in bfs_seed_urls:
+        _add(u)
+
+    if max_pages > 0 and len(ordered) > max_pages:
+        ordered = ordered[:max_pages]
+    return ordered
 
 
 async def crawl_dom_summary(url: str) -> list[dict] | None:

--- a/klai-knowledge-ingest/knowledge_ingest/reason_codes.py
+++ b/klai-knowledge-ingest/knowledge_ingest/reason_codes.py
@@ -1,0 +1,75 @@
+"""Stable reason-code registry for ingestion observability.
+
+SPEC-INGEST-RECONCILE-001 Fix 3 / AC-9, AC-10, AC-11.
+
+Two enums:
+
+- ``FetchReasonCode`` — outcome of an HTTP fetch attempt by the crawler.
+  Written per-URL into ``knowledge.crawl_jobs.fetch_outcomes`` (JSONB).
+- ``PersistSkipReason`` — reason a fetched/extracted document was NOT
+  persisted into ``knowledge.artifacts``. Aggregated per sync into
+  ``connector.sync_runs.skip_reasons`` (JSONB ``{reason: count}``).
+
+Both are ``str``-valued (``StrEnum``) so a Postgres CHECK constraint can
+validate JSONB values against the same vocabulary the application writes.
+A new reason MUST land in the enum AND in the matching CHECK constraint
+before it can be persisted — mechanical guard against typo-introduced
+silent reasons (rationale: SPEC §"Fix 3 — Stable reason-code registry").
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+# @MX:ANCHOR — referenced by sync_engine, crawl4ai_client, alembic migrations,
+#   ast-grep CI rules, and any future connector adapter that records skips.
+#   Adding a new reason: append to enum, extend Postgres CHECK constraint
+#   in the next alembic migration, document the meaning in the relevant
+#   adapter. See SPEC-INGEST-RECONCILE-001.
+
+
+class FetchReasonCode(StrEnum):
+    """Per-URL outcome of an HTTP fetch via crawl4ai.
+
+    Mapped from crawl4ai ``/crawl`` response (``result.success``,
+    ``result.status_code``, ``result.error_message``). The classifier lives
+    in :func:`knowledge_ingest.crawl4ai_client._classify_fetch_outcome`.
+
+    Stable values — used as JSONB keys in dashboards and as CHECK constraint
+    members in migrations. Renaming requires a coordinated migration.
+    """
+
+    SUCCESS = "success"
+    HTTP_4XX = "http_4xx"
+    HTTP_5XX = "http_5xx"
+    TIMEOUT = "timeout"
+    DNS_ERROR = "dns_error"
+    CONNECTION_ERROR = "connection_error"
+    AUTH_ERROR = "auth_error"
+    PARSE_ERROR = "parse_error"
+    RATE_LIMITED = "rate_limited"
+    UNKNOWN_EXCEPTION = "unknown_exception"
+
+
+class PersistSkipReason(StrEnum):
+    """Reason a fetched/extracted document was not persisted as artifact.
+
+    Aggregated per sync as ``{reason: count}`` JSONB on
+    ``connector.sync_runs.skip_reasons``. Each adapter increments the
+    appropriate counter from inside its existing flow — no contract change
+    on ``BaseAdapter.list_documents`` (rationale: SPEC §"Not changing
+    BaseAdapter.list_documents contract").
+    """
+
+    CONTENT_TOO_SHORT = "content_too_short"
+    AUTH_WALL_DETECTED = "auth_wall_detected"
+    DEDUPE_CONTENT_HASH_MATCH = "dedupe_content_hash_match"
+    DEDUPE_RAW_HTML_HASH_MATCH = "dedupe_raw_html_hash_match"
+    NON_TEXT_CONTENT = "non_text_content"
+    EXCLUDED_BY_KB_CONFIG = "excluded_by_kb_config"
+    TAXONOMY_CLASSIFY_FAILED = "taxonomy_classify_failed"
+
+
+# Convenience sets — handy for migrations or runtime validation.
+FETCH_REASON_VALUES: frozenset[str] = frozenset(c.value for c in FetchReasonCode)
+PERSIST_SKIP_REASON_VALUES: frozenset[str] = frozenset(r.value for r in PersistSkipReason)

--- a/klai-knowledge-ingest/tests/test_crawl4ai_filter_chain.py
+++ b/klai-knowledge-ingest/tests/test_crawl4ai_filter_chain.py
@@ -1,80 +1,144 @@
-"""Test that crawl_site builds a JSON-deserialisable filter_chain payload.
+"""SPEC-INGEST-RECONCILE-001 Fix 1 — include_patterns filtering on candidates.
 
-Crawl4AI v0.8.6's `from_serializable_dict` only instantiates nested strategy
-objects when they are wrapped in `{"type": "<ClassName>", "params": {...}}`.
-A bare list of filter dicts stays a list, and BFSDeepCrawlStrategy then crashes
-with `AttributeError: 'list' object has no attribute 'apply'` the moment
-`self.filter_chain.apply(url)` is called for depth > 0.
+The legacy test (pre-Reconcile-001) asserted that ``filter_chain`` was
+JSON-wrapped correctly inside crawl4ai's ``deep_crawl_strategy`` payload.
+That payload no longer exists: ``crawl_site`` now hands a flat URL list
+to ``POST /crawl`` and applies ``include_patterns`` as a candidate-side
+substring filter. These tests pin the new behaviour:
 
-This test pins the payload structure so any regression surfaces in CI instead
-of a live sync failure (as happened on wiki.redcactus.cloud /nl/).
+- When ``include_patterns`` is set, only matching candidates reach the
+  bulk request body.
+- When ``include_patterns`` is None, every same-domain candidate from
+  sitemap+BFS-union reaches the request body.
+- The crawler_config payload no longer carries a ``deep_crawl_strategy``
+  key (regression guard against the legacy BFS path being reintroduced
+  alongside the bulk path).
 """
 
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
+import httpx
 import pytest
 
 from knowledge_ingest import crawl4ai_client
+from knowledge_ingest.crawl4ai_client import CrawlResult
+
+
+def _seed_result(url: str, internal_hrefs: list[str]) -> CrawlResult:
+    """Synthesise the start_url's CrawlResult with internal links."""
+    return CrawlResult(
+        url=url,
+        fit_markdown="Seed page",
+        raw_markdown="Seed page",
+        html="<html></html>",
+        word_count=2,
+        success=True,
+        links={"internal": [{"href": h, "text": ""} for h in internal_hrefs]},
+    )
 
 
 @pytest.mark.asyncio
-async def test_crawl_site_wraps_filter_chain_when_include_patterns_set() -> None:
+async def test_crawl_site_applies_include_patterns_to_candidates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """include_patterns acts as a substring filter on the candidate URL set."""
+    sitemap_urls = [
+        "https://wiki.redcactus.cloud/nl/getting-started",
+        "https://wiki.redcactus.cloud/en/getting-started",
+        "https://wiki.redcactus.cloud/nl/advanced",
+    ]
+    bfs_links = [
+        "https://wiki.redcactus.cloud/nl/blog",
+        "https://wiki.redcactus.cloud/en/blog",
+    ]
+
+    async def _fake_sitemap(_base: str) -> list[str]:
+        return sitemap_urls
+
+    async def _fake_seed(url: str, **_kwargs: Any) -> CrawlResult:
+        return _seed_result(url, bfs_links)
+
+    monkeypatch.setattr(crawl4ai_client, "_fetch_sitemap_urls", _fake_sitemap)
+    monkeypatch.setattr(crawl4ai_client, "crawl_page", _fake_seed)
+
     captured: dict[str, Any] = {}
 
-    async def _fake_post(self, url: str, json: dict[str, Any], headers: dict[str, str]):
-        captured["payload"] = json
-        # Surface-level status ok so _DEEP_POLL flow can start; we raise afterwards
-        # so the test does not need to simulate the poll loop.
-        raise RuntimeError("short-circuit after capturing payload")
+    async def _fake_post(self: httpx.AsyncClient, url: str, **kwargs: Any) -> httpx.Response:
+        captured["url"] = url
+        captured["payload"] = kwargs.get("json")
+        request = httpx.Request("POST", url)
+        return httpx.Response(200, json={"results": []}, request=request)
 
     with patch("httpx.AsyncClient.post", new=_fake_post):
-        with pytest.raises(RuntimeError, match="short-circuit"):
-            await crawl4ai_client.crawl_site(
-                start_url="https://wiki.redcactus.cloud",
-                selector="main",
-                max_depth=2,
-                max_pages=50,
-                include_patterns=["/nl/"],
-            )
+        results, outcomes = await crawl4ai_client.crawl_site(
+            start_url="https://wiki.redcactus.cloud",
+            selector="main",
+            max_pages=50,
+            include_patterns=["/nl/"],
+        )
+
+    assert results == []
+    payload = captured["payload"]
+    urls_submitted = payload["urls"]
+    # include_patterns is a substring filter — start_url with empty path
+    # does NOT contain "/nl/" so it is correctly excluded. Every URL that
+    # made it through MUST match.
+    assert urls_submitted, "expected at least one /nl/ candidate to survive"
+    for u in urls_submitted:
+        assert "/nl/" in u, f"include_patterns leaked a non-/nl/ URL: {u}"
+    assert "https://wiki.redcactus.cloud/nl/getting-started" in urls_submitted
+    assert "https://wiki.redcactus.cloud/nl/advanced" in urls_submitted
+    assert "https://wiki.redcactus.cloud/nl/blog" in urls_submitted
+    assert "https://wiki.redcactus.cloud/en/getting-started" not in urls_submitted
+    assert "https://wiki.redcactus.cloud/en/blog" not in urls_submitted
+    assert "deep_crawl_strategy" not in payload["crawler_config"]["params"]
+    # AC-4: every candidate produces an outcome record.
+    assert len(outcomes) == len(urls_submitted)
+
+
+@pytest.mark.asyncio
+async def test_crawl_site_no_include_patterns_passes_all_same_domain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without include_patterns, every same-domain candidate reaches /crawl."""
+    sitemap_urls = [
+        "https://example.com/page-a",
+        "https://example.com/page-b",
+        "https://other.com/skipped",  # cross-domain, must be filtered out by candidate-set
+    ]
+
+    async def _fake_sitemap(_base: str) -> list[str]:
+        return sitemap_urls
+
+    async def _fake_seed(url: str, **_kwargs: Any) -> CrawlResult:
+        return _seed_result(url, ["https://example.com/page-c"])
+
+    monkeypatch.setattr(crawl4ai_client, "_fetch_sitemap_urls", _fake_sitemap)
+    monkeypatch.setattr(crawl4ai_client, "crawl_page", _fake_seed)
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_post(self: httpx.AsyncClient, url: str, **kwargs: Any) -> httpx.Response:
+        captured["payload"] = kwargs.get("json")
+        request = httpx.Request("POST", url)
+        return httpx.Response(200, json={"results": []}, request=request)
+
+    with patch("httpx.AsyncClient.post", new=_fake_post):
+        await crawl4ai_client.crawl_site(
+            start_url="https://example.com",
+            max_pages=10,
+            include_patterns=None,
+        )
 
     payload = captured["payload"]
-    deep = payload["crawler_config"]["params"]["deep_crawl_strategy"]
-
-    assert deep["type"] == "BFSDeepCrawlStrategy"
-    filter_chain = deep["params"].get("filter_chain")
-
-    # RED assertion: filter_chain MUST be wrapped in {type:FilterChain, params:{filters:[...]}}
-    # so crawl4ai's from_serializable_dict builds a real FilterChain object.
-    assert isinstance(filter_chain, dict), (
-        f"filter_chain must be a typed object wrapper, got {type(filter_chain).__name__}"
-    )
-    assert filter_chain.get("type") == "FilterChain"
-    filters = filter_chain["params"]["filters"]
-    assert isinstance(filters, list) and len(filters) == 1
-    assert filters[0]["type"] == "URLPatternFilter"
-    assert filters[0]["params"]["patterns"] == ["/nl/"]
-
-
-@pytest.mark.asyncio
-async def test_crawl_site_omits_filter_chain_when_no_include_patterns() -> None:
-    captured: dict[str, Any] = {}
-
-    async def _fake_post(self, url: str, json: dict[str, Any], headers: dict[str, str]):
-        captured["payload"] = json
-        raise RuntimeError("short-circuit")
-
-    with patch("httpx.AsyncClient.post", new=_fake_post):
-        with pytest.raises(RuntimeError):
-            await crawl4ai_client.crawl_site(
-                start_url="https://example.com",
-                max_depth=1,
-                max_pages=10,
-                include_patterns=None,
-            )
-
-    deep = captured["payload"]["crawler_config"]["params"]["deep_crawl_strategy"]
-    # When no include_patterns, no filter_chain should be emitted at all.
-    assert "filter_chain" not in deep["params"]
+    urls_submitted = payload["urls"]
+    assert "https://example.com" in urls_submitted
+    assert "https://example.com/page-a" in urls_submitted
+    assert "https://example.com/page-b" in urls_submitted
+    assert "https://example.com/page-c" in urls_submitted
+    # Cross-domain entry from sitemap MUST NOT leak through.
+    assert "https://other.com/skipped" not in urls_submitted
+    assert "deep_crawl_strategy" not in payload["crawler_config"]["params"]

--- a/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
+++ b/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
@@ -1,0 +1,388 @@
+"""SPEC-INGEST-RECONCILE-001 — unit tests for the new crawl_site helpers.
+
+Covers:
+
+- ``_canonicalise_url``: dedup-key normalisation (AC-1, AC-2 dedup column).
+- ``_build_candidate_set``: sitemap-priority on cap, include_patterns
+  filter, cross-domain filter, dedup (AC-1, AC-2).
+- ``_classify_fetch_outcome``: stable mapping of crawl4ai response
+  shapes + transport exceptions to FetchReasonCode (AC-4, AC-11).
+- ``crawl_site`` bulk-path on a transport failure: every candidate gets
+  a non-success outcome (AC-4 — no candidate is "lost").
+- ``crawl_site`` returns the new ``(results, outcomes)`` tuple shape
+  with one outcome per candidate.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from knowledge_ingest import crawl4ai_client
+from knowledge_ingest.crawl4ai_client import (
+    CrawlResult,
+    _build_candidate_set,
+    _canonicalise_url,
+    _classify_fetch_outcome,
+)
+from knowledge_ingest.reason_codes import FetchReasonCode
+
+# ---------------------------------------------------------------------------
+# _canonicalise_url
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicaliseUrl:
+    def test_strips_trailing_slash_on_non_root_path(self) -> None:
+        assert _canonicalise_url("https://example.com/page/") == "https://example.com/page"
+
+    def test_keeps_root_slash(self) -> None:
+        # Empty path becomes "/" by URL contract — we keep it as "/".
+        assert _canonicalise_url("https://example.com/").endswith("/")
+
+    def test_strips_fragment(self) -> None:
+        assert (
+            _canonicalise_url("https://example.com/page#section")
+            == "https://example.com/page"
+        )
+
+    def test_lowercases_scheme_and_host(self) -> None:
+        assert (
+            _canonicalise_url("HTTPS://Example.COM/Page")
+            == "https://example.com/Page"
+        )
+
+    def test_preserves_query(self) -> None:
+        # Query string variants are different pages by convention; we keep them.
+        assert (
+            _canonicalise_url("https://example.com/page?foo=bar")
+            == "https://example.com/page?foo=bar"
+        )
+
+    def test_dedups_trailing_slash_against_no_slash(self) -> None:
+        a = _canonicalise_url("https://example.com/page/")
+        b = _canonicalise_url("https://example.com/page")
+        c = _canonicalise_url("https://example.com/page#section")
+        assert a == b == c
+
+
+# ---------------------------------------------------------------------------
+# _build_candidate_set
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCandidateSet:
+    def test_start_url_is_first_candidate(self) -> None:
+        candidates = _build_candidate_set(
+            start_url="https://example.com",
+            sitemap_urls=["https://example.com/page-a"],
+            bfs_seed_urls=["https://example.com/page-b"],
+            base_domain="example.com",
+            max_pages=10,
+            include_patterns=None,
+        )
+        assert candidates[0] == "https://example.com"
+
+    def test_sitemap_takes_priority_on_cap(self) -> None:
+        # max_pages=3: start_url + 2 sitemap entries should win over
+        # any BFS-discovered URL even if BFS came first lexically.
+        candidates = _build_candidate_set(
+            start_url="https://example.com",
+            sitemap_urls=[
+                "https://example.com/sitemap-1",
+                "https://example.com/sitemap-2",
+                "https://example.com/sitemap-3",
+            ],
+            bfs_seed_urls=[
+                "https://example.com/bfs-1",
+                "https://example.com/bfs-2",
+            ],
+            base_domain="example.com",
+            max_pages=3,
+            include_patterns=None,
+        )
+        assert candidates == [
+            "https://example.com",
+            "https://example.com/sitemap-1",
+            "https://example.com/sitemap-2",
+        ]
+
+    def test_dedup_via_canonicalisation(self) -> None:
+        candidates = _build_candidate_set(
+            start_url="https://example.com",
+            sitemap_urls=[
+                "https://example.com/page",
+                "https://example.com/page/",  # same canonical key
+                "https://example.com/page#frag",  # same canonical key
+            ],
+            bfs_seed_urls=[],
+            base_domain="example.com",
+            max_pages=10,
+            include_patterns=None,
+        )
+        # Only one canonical /page entry, plus start_url.
+        assert candidates == [
+            "https://example.com",
+            "https://example.com/page",
+        ]
+
+    def test_cross_domain_filtered_out(self) -> None:
+        candidates = _build_candidate_set(
+            start_url="https://example.com",
+            sitemap_urls=["https://other.com/external"],
+            bfs_seed_urls=["https://example.com/local"],
+            base_domain="example.com",
+            max_pages=10,
+            include_patterns=None,
+        )
+        assert "https://other.com/external" not in candidates
+        assert "https://example.com/local" in candidates
+
+    def test_include_patterns_filters_substrings(self) -> None:
+        candidates = _build_candidate_set(
+            start_url="https://wiki.example/nl",  # start_url survives even if it doesn't match
+            sitemap_urls=[
+                "https://wiki.example/nl/getting-started",
+                "https://wiki.example/en/getting-started",
+            ],
+            bfs_seed_urls=[
+                "https://wiki.example/nl/blog",
+                "https://wiki.example/en/blog",
+            ],
+            base_domain="wiki.example",
+            max_pages=10,
+            include_patterns=["/nl/"],
+        )
+        # start_url itself doesn't match "/nl/" (it's "/nl"), so it's filtered.
+        # All other candidates MUST match "/nl/".
+        assert "https://wiki.example/en/getting-started" not in candidates
+        assert "https://wiki.example/en/blog" not in candidates
+        assert "https://wiki.example/nl/getting-started" in candidates
+        assert "https://wiki.example/nl/blog" in candidates
+
+
+# ---------------------------------------------------------------------------
+# _classify_fetch_outcome
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyFetchOutcome:
+    def test_success_when_result_success_true(self) -> None:
+        assert (
+            _classify_fetch_outcome({"success": True, "status_code": 200})
+            == FetchReasonCode.SUCCESS.value
+        )
+
+    def test_429_classifies_rate_limited(self) -> None:
+        assert (
+            _classify_fetch_outcome({"success": False, "status_code": 429})
+            == FetchReasonCode.RATE_LIMITED.value
+        )
+
+    @pytest.mark.parametrize("status", [401, 403])
+    def test_auth_codes_classify_auth_error(self, status: int) -> None:
+        assert (
+            _classify_fetch_outcome({"success": False, "status_code": status})
+            == FetchReasonCode.AUTH_ERROR.value
+        )
+
+    def test_other_4xx_classifies_http_4xx(self) -> None:
+        assert (
+            _classify_fetch_outcome({"success": False, "status_code": 404})
+            == FetchReasonCode.HTTP_4XX.value
+        )
+
+    def test_5xx_classifies_http_5xx(self) -> None:
+        assert (
+            _classify_fetch_outcome({"success": False, "status_code": 503})
+            == FetchReasonCode.HTTP_5XX.value
+        )
+
+    def test_timeout_message_classifies_timeout(self) -> None:
+        assert (
+            _classify_fetch_outcome(
+                {"success": False, "status_code": None, "error_message": "Operation timeout"}
+            )
+            == FetchReasonCode.TIMEOUT.value
+        )
+
+    def test_dns_message_classifies_dns_error(self) -> None:
+        assert (
+            _classify_fetch_outcome(
+                {"success": False, "status_code": None, "error_message": "DNS lookup failed"}
+            )
+            == FetchReasonCode.DNS_ERROR.value
+        )
+
+    def test_unknown_falls_through_to_unknown_exception(self) -> None:
+        assert (
+            _classify_fetch_outcome({"success": False, "status_code": None, "error_message": ""})
+            == FetchReasonCode.UNKNOWN_EXCEPTION.value
+        )
+
+    def test_transport_timeout_exception_classifies_timeout(self) -> None:
+        assert (
+            _classify_fetch_outcome(None, error=httpx.ReadTimeout("timed out"))
+            == FetchReasonCode.TIMEOUT.value
+        )
+
+    def test_transport_connect_error_classifies_connection_error(self) -> None:
+        assert (
+            _classify_fetch_outcome(None, error=httpx.ConnectError("refused"))
+            == FetchReasonCode.CONNECTION_ERROR.value
+        )
+
+    def test_transport_dns_message_classifies_dns_error(self) -> None:
+        # Generic exception with DNS-flavoured message — common in glibc errors.
+        assert (
+            _classify_fetch_outcome(None, error=RuntimeError("nodename nor servname provided"))
+            == FetchReasonCode.DNS_ERROR.value
+        )
+
+
+# ---------------------------------------------------------------------------
+# crawl_site — outcomes shape on transport failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_crawl_site_bulk_transport_failure_records_one_outcome_per_candidate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC-4: even when the whole bulk request fails, every candidate URL
+    gets an outcome record. No URL is silently lost."""
+
+    async def _fake_sitemap(_base: str) -> list[str]:
+        return [
+            "https://example.com/page-a",
+            "https://example.com/page-b",
+            "https://example.com/page-c",
+        ]
+
+    async def _fake_seed(url: str, **_kwargs: Any) -> CrawlResult:
+        return CrawlResult(
+            url=url,
+            fit_markdown="seed",
+            raw_markdown="seed",
+            html="<html></html>",
+            word_count=1,
+            success=True,
+            links={"internal": []},
+        )
+
+    monkeypatch.setattr(crawl4ai_client, "_fetch_sitemap_urls", _fake_sitemap)
+    monkeypatch.setattr(crawl4ai_client, "crawl_page", _fake_seed)
+
+    async def _fake_post(self: httpx.AsyncClient, url: str, **_kwargs: Any) -> httpx.Response:
+        raise httpx.ReadTimeout("simulated bulk timeout")
+
+    with patch("httpx.AsyncClient.post", new=_fake_post):
+        results, outcomes = await crawl4ai_client.crawl_site(
+            start_url="https://example.com",
+            max_pages=10,
+        )
+
+    # Whole-batch transport failure: no successful CrawlResults but every
+    # candidate (start_url + 3 sitemap entries) gets a TIMEOUT outcome.
+    assert results == []
+    assert len(outcomes) == 4
+    for outcome in outcomes:
+        assert outcome["reason_code"] == FetchReasonCode.TIMEOUT.value
+        assert outcome["status_code"] is None
+        # Shape sanity — all four required keys present.
+        assert set(outcome.keys()) == {"url", "reason_code", "status_code", "content_length"}
+
+
+@pytest.mark.asyncio
+async def test_crawl_site_returns_one_outcome_per_candidate_on_partial_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC-4 + AC-5: per-URL outcomes classify each candidate distinctly."""
+
+    async def _fake_sitemap(_base: str) -> list[str]:
+        return [
+            "https://example.com/ok",
+            "https://example.com/missing",
+            "https://example.com/server-error",
+        ]
+
+    async def _fake_seed(url: str, **_kwargs: Any) -> CrawlResult:
+        return CrawlResult(
+            url=url,
+            fit_markdown="x",
+            raw_markdown="x",
+            html="<html></html>",
+            word_count=1,
+            success=True,
+            links={"internal": []},
+        )
+
+    monkeypatch.setattr(crawl4ai_client, "_fetch_sitemap_urls", _fake_sitemap)
+    monkeypatch.setattr(crawl4ai_client, "crawl_page", _fake_seed)
+
+    response_body = {
+        "results": [
+            {
+                "url": "https://example.com",
+                "success": True,
+                "status_code": 200,
+                "html": "<html>seed</html>",
+                "markdown": "seed",
+                "links": {"internal": []},
+                "media": {},
+            },
+            {
+                "url": "https://example.com/ok",
+                "success": True,
+                "status_code": 200,
+                "html": "<html>ok</html>",
+                "markdown": "ok",
+                "links": {"internal": []},
+                "media": {},
+            },
+            {
+                "url": "https://example.com/missing",
+                "success": False,
+                "status_code": 404,
+                "error_message": "Not Found",
+                "html": "",
+                "markdown": "",
+                "links": {"internal": []},
+                "media": {},
+            },
+            {
+                "url": "https://example.com/server-error",
+                "success": False,
+                "status_code": 503,
+                "error_message": "Service Unavailable",
+                "html": "",
+                "markdown": "",
+                "links": {"internal": []},
+                "media": {},
+            },
+        ]
+    }
+
+    async def _fake_post(self: httpx.AsyncClient, url: str, **_kwargs: Any) -> httpx.Response:
+        request = httpx.Request("POST", url)
+        return httpx.Response(200, json=response_body, request=request)
+
+    with patch("httpx.AsyncClient.post", new=_fake_post):
+        results, outcomes = await crawl4ai_client.crawl_site(
+            start_url="https://example.com",
+            max_pages=10,
+        )
+
+    assert len(outcomes) == 4
+    by_url = {o["url"]: o for o in outcomes}
+    assert by_url["https://example.com"]["reason_code"] == FetchReasonCode.SUCCESS.value
+    assert by_url["https://example.com/ok"]["reason_code"] == FetchReasonCode.SUCCESS.value
+    assert by_url["https://example.com/missing"]["reason_code"] == FetchReasonCode.HTTP_4XX.value
+    server_error_outcome = by_url["https://example.com/server-error"]
+    assert server_error_outcome["reason_code"] == FetchReasonCode.HTTP_5XX.value
+    # Two same-domain successful pages reach the ingest loop.
+    assert len(results) == 2
+    assert {r.url for r in results} == {"https://example.com", "https://example.com/ok"}

--- a/klai-knowledge-ingest/tests/test_crawler_anonymous_auth_wall.py
+++ b/klai-knowledge-ingest/tests/test_crawler_anonymous_auth_wall.py
@@ -47,11 +47,25 @@ def patched_pool():
 def _patch_crawler_externals(crawl_results: list[CrawlResult], ingest_side_effect):
     """Helper that returns a context-manager bundle patching all externals
     of run_crawl_job — crawl_site, get_pool, pg_store, _ingest_crawl_result.
+
+    SPEC-INGEST-RECONCILE-001 AC-4: crawl_site now returns the tuple
+    ``(results, fetch_outcomes)``. We synthesise an outcomes list from
+    the crawl_results so the adapter's JSONB persistence path is
+    exercised by the same fixture.
     """
+    fetch_outcomes = [
+        {
+            "url": r.url,
+            "reason_code": "success" if r.success else "unknown_exception",
+            "status_code": 200 if r.success else None,
+            "content_length": len(r.html or ""),
+        }
+        for r in crawl_results
+    ]
     return [
         patch(
             "knowledge_ingest.adapters.crawler.crawl_site",
-            new=AsyncMock(return_value=crawl_results),
+            new=AsyncMock(return_value=(crawl_results, fetch_outcomes)),
         ),
         patch(
             "knowledge_ingest.adapters.crawler.pg_store.upsert_page_links",

--- a/klai-knowledge-ingest/tests/test_crawler_link_fields.py
+++ b/klai-knowledge-ingest/tests/test_crawler_link_fields.py
@@ -178,7 +178,19 @@ async def test_run_crawl_job_calls_build_link_graph_before_ingest():
         patch(
             "knowledge_ingest.adapters.crawler.crawl_site",
             new_callable=AsyncMock,
-            return_value=[mock_result],
+            # SPEC-INGEST-RECONCILE-001 AC-4: crawl_site returns
+            # ``(results, fetch_outcomes)``.
+            return_value=(
+                [mock_result],
+                [
+                    {
+                        "url": mock_result.url,
+                        "reason_code": "success",
+                        "status_code": 200,
+                        "content_length": len(mock_result.html or ""),
+                    }
+                ],
+            ),
         ),
         patch.object(
             link_graph,

--- a/klai-knowledge-ingest/tests/test_crawler_link_fields_complete.py
+++ b/klai-knowledge-ingest/tests/test_crawler_link_fields_complete.py
@@ -146,7 +146,21 @@ async def test_run_crawl_job_populates_link_fields_on_every_page():
         patch(
             "knowledge_ingest.adapters.crawler.crawl_site",
             new_callable=AsyncMock,
-            return_value=results,
+            # SPEC-INGEST-RECONCILE-001 AC-4: crawl_site returns
+            # ``(results, fetch_outcomes)`` — synthesise a success outcome
+            # per CrawlResult so the adapter persists fetch_outcomes JSONB.
+            return_value=(
+                results,
+                [
+                    {
+                        "url": r.url,
+                        "reason_code": "success" if r.success else "unknown_exception",
+                        "status_code": 200 if r.success else None,
+                        "content_length": len(r.html or ""),
+                    }
+                    for r in results
+                ],
+            ),
         ),
         patch(
             "knowledge_ingest.adapters.crawler._update_job",
@@ -245,7 +259,21 @@ async def test_run_crawl_job_no_post_crawl_link_counts_call():
         patch(
             "knowledge_ingest.adapters.crawler.crawl_site",
             new_callable=AsyncMock,
-            return_value=results,
+            # SPEC-INGEST-RECONCILE-001 AC-4: crawl_site returns
+            # ``(results, fetch_outcomes)`` — synthesise a success outcome
+            # per CrawlResult so the adapter persists fetch_outcomes JSONB.
+            return_value=(
+                results,
+                [
+                    {
+                        "url": r.url,
+                        "reason_code": "success" if r.success else "unknown_exception",
+                        "status_code": 200 if r.success else None,
+                        "content_length": len(r.html or ""),
+                    }
+                    for r in results
+                ],
+            ),
         ),
         patch(
             "knowledge_ingest.adapters.crawler._update_job",

--- a/klai-knowledge-ingest/tests/test_crawler_login_indicator.py
+++ b/klai-knowledge-ingest/tests/test_crawler_login_indicator.py
@@ -136,10 +136,33 @@ class TestRunCrawlJobAuthWall:
         mock_conn.fetchval = AsyncMock(return_value=None)
         mock_conn.fetchrow = AsyncMock(return_value=None)
 
+        # SPEC-INGEST-RECONCILE-001 AC-4: crawl_site returns
+        # ``(results, fetch_outcomes)``. Synthesise the outcomes that
+        # would correspond to these CrawlResults.
+        _login_outcomes = [
+            {
+                "url": happy.url,
+                "reason_code": "success",
+                "status_code": 200,
+                "content_length": len(happy.html),
+            },
+            {
+                "url": walled.url,
+                "reason_code": "auth_error",
+                "status_code": 401,
+                "content_length": 0,
+            },
+            {
+                "url": never_reached.url,
+                "reason_code": "success",
+                "status_code": 200,
+                "content_length": len(never_reached.html),
+            },
+        ]
         with (
             patch(
                 "knowledge_ingest.adapters.crawler.crawl_site",
-                new=AsyncMock(return_value=[happy, walled, never_reached]),
+                new=AsyncMock(return_value=([happy, walled, never_reached], _login_outcomes)),
             ),
             patch(
                 "knowledge_ingest.adapters.crawler.pg_store.get_crawled_page_hashes",

--- a/rules/no-unbounded-gather-crawl-page.yml
+++ b/rules/no-unbounded-gather-crawl-page.yml
@@ -1,0 +1,55 @@
+# SPEC-INGEST-RECONCILE-001 Fix 4 / AC-12 — block reintroduction of the
+# unbounded ``asyncio.gather`` supplement loop on ``crawl_page`` calls.
+#
+# Why: the old supplement loop in ``crawl4ai_client.crawl_site`` fanned out
+# 167 parallel ``crawl_page`` calls without a Semaphore, overwhelming the
+# crawl4ai Playwright pool and dropping ~80% of pages with mass timeouts —
+# AND with ``return_exceptions=True`` swallowing every individual outcome
+# so the operator saw ``crawl_jobs.pages_total`` shrink silently from 208
+# to 41 (Bug A on help.voys.nl, 2026-05-06).
+#
+# This is the third recurrence of the same anti-pattern at Klai (see
+# SPEC-CRAWLER-005, SPEC-CRAWLER-006). Mechanical guard, not code review,
+# per pitfalls/process-rules.md::adversarial-at-high-confidence.
+#
+# A new place that legitimately needs unbounded gather of ``crawl_page``
+# must add a surrounding ``asyncio.Semaphore`` context (which serialises
+# the gather behind the semaphore acquire) — or explicitly suppress this
+# rule with ``# nosgrep: no-unbounded-gather-crawl-page  # <reason>``.
+
+id: no-unbounded-gather-crawl-page
+language: python
+severity: error
+message: |
+  Unbounded ``asyncio.gather`` over ``crawl_page`` is forbidden
+  (SPEC-INGEST-RECONCILE-001 Fix 4). The supplement loop this guards
+  against silently dropped 80% of pages on help.voys.nl (Bug A).
+
+  Fix: use ``crawl_site``'s bulk-/crawl path, or wrap each ``crawl_page``
+  in an ``asyncio.Semaphore`` (or async-pool primitive) and DO NOT pass
+  ``return_exceptions=True`` without a per-result outcome handler.
+
+  See: rules/no-unbounded-gather-crawl-page.yml
+
+# Pattern matches ``asyncio.gather`` calls whose positional argument is a
+# splatted list/generator-comprehension over ``crawl_page(...)`` calls.
+# The ``$$$REST`` tail allows trailing kwargs like ``return_exceptions=True``
+# (which the legacy supplement loop used to swallow individual outcomes —
+# the worst part of the bug). Without ``$$$REST`` ast-grep matches only
+# the no-extra-args form and misses the historical pattern.
+rule:
+  any:
+    - pattern: asyncio.gather(*[crawl_page($$$ARGS) for $X in $ITER], $$$REST)
+    - pattern: asyncio.gather(*(crawl_page($$$ARGS) for $X in $ITER), $$$REST)
+    - pattern: asyncio.gather(*[crawl_page($$$ARGS) for $X in $ITER])
+    - pattern: asyncio.gather(*(crawl_page($$$ARGS) for $X in $ITER))
+
+# No ``files:`` allow-list. The pattern (``asyncio.gather`` over
+# ``crawl_page(...)``) is unique enough that scoping by path adds nothing —
+# ``crawl_page`` is only imported in ``klai-knowledge-ingest``. Ast-grep
+# 0.42 evaluates ``files:`` against the workspace-relative path, and
+# narrow patterns (single specific file paths) silently exclude rule
+# fixtures under ``rules/tests/fixtures/`` even when scanned directly.
+# Empirically validated:
+# ``rules/tests/test_no_unbounded_gather_crawl_page_lint.py`` passes
+# without ``files:`` and would fail with it.

--- a/rules/tests/fixtures/bad_unbounded_gather_crawl_page.py
+++ b/rules/tests/fixtures/bad_unbounded_gather_crawl_page.py
@@ -1,0 +1,20 @@
+# SPEC-INGEST-RECONCILE-001 Fix 4 — synthetic fixture: this is what the
+# old supplement loop in crawl4ai_client.crawl_site looked like before
+# Fix 1. The ast-grep rule MUST flag this pattern. Three observable
+# defects (no Semaphore, no per-result outcome, exact-string dedup) all
+# follow once unbounded gather over crawl_page is allowed back in.
+
+import asyncio
+
+
+async def crawl_page(url, selector=None):  # local stub for the fixture
+    return None
+
+
+async def supplement_pages(supplement_urls, selector=None):
+    # BAD: unbounded asyncio.gather over crawl_page — exactly the pattern
+    # that produced Bug A on help.voys.nl (167 parallel calls, ~0 ingested).
+    return await asyncio.gather(
+        *[crawl_page(u, selector=selector) for u in supplement_urls],
+        return_exceptions=True,
+    )

--- a/rules/tests/fixtures/good_bulk_crawl.py
+++ b/rules/tests/fixtures/good_bulk_crawl.py
@@ -1,0 +1,18 @@
+# SPEC-INGEST-RECONCILE-001 Fix 4 — synthetic fixture: this is the
+# canonical post-Fix-1 shape. The ast-grep rule MUST NOT flag this:
+# no asyncio.gather over crawl_page calls anywhere in the file.
+
+import httpx
+
+
+async def fetch_bulk(candidates, crawler_config):
+    # GOOD: single bulk request to crawl4ai's /crawl endpoint —
+    # server-side MemoryAdaptiveDispatcher handles concurrency and
+    # we get per-URL outcomes back in the response body.
+    async with httpx.AsyncClient(timeout=300.0) as client:
+        resp = await client.post(
+            "https://crawl4ai.example/crawl",
+            json={"urls": candidates, "crawler_config": crawler_config},
+        )
+        resp.raise_for_status()
+        return resp.json()

--- a/rules/tests/test_no_unbounded_gather_crawl_page_lint.py
+++ b/rules/tests/test_no_unbounded_gather_crawl_page_lint.py
@@ -1,0 +1,120 @@
+"""SPEC-INGEST-RECONCILE-001 Fix 4 / AC-12 — regression tests for the
+``no-unbounded-gather-crawl-page`` ast-grep rule.
+
+The rule lives at ``rules/no-unbounded-gather-crawl-page.yml`` and is
+discovered via the repo-root ``sgconfig.yml``. We invoke ast-grep
+directly (via ``uvx --from ast-grep-cli ast-grep``) on two fixture
+files:
+
+- ``fixtures/bad_unbounded_gather_crawl_page.py`` — contains exactly the
+  legacy supplement-loop pattern (Bug A). The lint MUST exit non-zero
+  and name the fixture file.
+- ``fixtures/good_bulk_crawl.py`` — bulk POST /crawl path with no
+  ``asyncio.gather`` over ``crawl_page`` anywhere. The lint MUST exit
+  zero.
+
+We also assert the knowledge-ingest CI workflow includes an
+``ast-grep/action`` step so the lint runs on every PR that touches the
+package (per AC-12 "CI-enforced" clause).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RULES_DIR = REPO_ROOT / "rules"
+FIXTURES_DIR = RULES_DIR / "tests" / "fixtures"
+SGCONFIG = REPO_ROOT / "sgconfig.yml"
+RULE_FILE = RULES_DIR / "no-unbounded-gather-crawl-page.yml"
+
+
+def _ast_grep_command() -> list[str]:
+    """Resolve a runnable ast-grep CLI invocation.
+
+    Order:
+    1. ``ast-grep`` on PATH (developer machines via brew/apt).
+    2. ``sg`` on PATH (the alternate name shipped on some platforms).
+    3. ``uvx --from ast-grep-cli ast-grep`` (CI fallback — no global install).
+    """
+    for name in ("ast-grep", "sg"):
+        if shutil.which(name):
+            return [name]
+    if shutil.which("uvx"):
+        return ["uvx", "--from", "ast-grep-cli", "ast-grep"]
+    pytest.skip("ast-grep / sg / uvx not available on PATH — skipping lint regression test")
+
+
+@pytest.fixture(scope="module")
+def ast_grep_cmd() -> list[str]:
+    return _ast_grep_command()
+
+
+def test_rule_file_is_valid_yaml() -> None:
+    """The rule file MUST be loadable as YAML and declare the expected id."""
+    with RULE_FILE.open(encoding="utf-8") as fh:
+        rule = yaml.safe_load(fh)
+    assert rule["id"] == "no-unbounded-gather-crawl-page"
+    assert rule["language"] == "python"
+    assert rule["severity"] == "error"
+    # Intentionally no ``files:`` allow-list — see docstring in the rule
+    # file. The pattern is unique enough that path scoping adds nothing
+    # and breaks the regression-test fixture path.
+    assert "files" not in rule
+
+
+def test_bad_fixture_is_flagged(ast_grep_cmd: list[str]) -> None:
+    """The unbounded-gather supplement-loop pattern MUST be flagged."""
+    fixture = FIXTURES_DIR / "bad_unbounded_gather_crawl_page.py"
+    assert fixture.exists()
+
+    proc = subprocess.run(
+        [*ast_grep_cmd, "scan", "--config", str(SGCONFIG), str(fixture)],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        check=False,
+    )
+    combined = (proc.stdout or "") + (proc.stderr or "")
+    assert proc.returncode != 0, (
+        f"ast-grep returned 0 on the BAD fixture — rule did not fire.\n"
+        f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )
+    assert "no-unbounded-gather-crawl-page" in combined or "asyncio.gather" in combined, (
+        f"ast-grep flagged something else on the BAD fixture — output was:\n{combined}"
+    )
+
+
+def test_good_fixture_is_not_flagged(ast_grep_cmd: list[str]) -> None:
+    """The bulk-crawl shape MUST pass the lint cleanly."""
+    fixture = FIXTURES_DIR / "good_bulk_crawl.py"
+    assert fixture.exists()
+
+    proc = subprocess.run(
+        [*ast_grep_cmd, "scan", "--config", str(SGCONFIG), str(fixture)],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        check=False,
+    )
+    assert proc.returncode == 0, (
+        f"ast-grep returned non-zero on the GOOD fixture — rule false-positive.\n"
+        f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )
+
+
+def test_knowledge_ingest_workflow_invokes_ast_grep() -> None:
+    """AC-12 CI-enforced clause: the knowledge-ingest workflow MUST
+    include the ast-grep action so the rule fires on every PR."""
+    workflow = REPO_ROOT / ".github" / "workflows" / "knowledge-ingest.yml"
+    assert workflow.exists(), "Missing CI workflow .github/workflows/knowledge-ingest.yml"
+    text = workflow.read_text(encoding="utf-8")
+    assert "ast-grep/action" in text, (
+        "knowledge-ingest CI workflow does not call ast-grep/action — "
+        "the no-unbounded-gather-crawl-page rule has no CI hook."
+    )

--- a/rules/tests/test_no_unbounded_gather_crawl_page_lint.py
+++ b/rules/tests/test_no_unbounded_gather_crawl_page_lint.py
@@ -34,17 +34,42 @@ SGCONFIG = REPO_ROOT / "sgconfig.yml"
 RULE_FILE = RULES_DIR / "no-unbounded-gather-crawl-page.yml"
 
 
+def _is_ast_grep_binary(path: str) -> bool:
+    """Return True iff ``path`` is actually ast-grep.
+
+    Ubuntu ships ``/usr/bin/sg`` (set-group ID command from util-linux) which
+    has nothing to do with ast-grep, and ``shutil.which("sg")`` finds it on
+    default GHA runners. Verify by running ``<bin> --version`` and looking
+    for "ast-grep" in the output. Falls back gracefully on FileNotFoundError
+    or non-zero exit. Pattern copied from
+    ``rules/tests/test_cors_middleware_last_lint.py`` for parity.
+    """
+    try:
+        result = subprocess.run(
+            [path, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+    blob = (result.stdout or "") + (result.stderr or "")
+    return "ast-grep" in blob.lower()
+
+
 def _ast_grep_command() -> list[str]:
     """Resolve a runnable ast-grep CLI invocation.
 
     Order:
-    1. ``ast-grep`` on PATH (developer machines via brew/apt).
-    2. ``sg`` on PATH (the alternate name shipped on some platforms).
+    1. ``ast-grep`` on PATH (developer machines via brew/apt) — verified.
+    2. ``sg`` on PATH (the alternate name) — verified to actually be ast-grep.
     3. ``uvx --from ast-grep-cli ast-grep`` (CI fallback — no global install).
     """
     for name in ("ast-grep", "sg"):
-        if shutil.which(name):
-            return [name]
+        path = shutil.which(name)
+        if path and _is_ast_grep_binary(path):
+            return [path]
     if shutil.which("uvx"):
         return ["uvx", "--from", "ast-grep-cli", "ast-grep"]
     pytest.skip("ast-grep / sg / uvx not available on PATH — skipping lint regression test")


### PR DESCRIPTION
## SPEC

[SPEC-INGEST-RECONCILE-001](.moai/specs/SPEC-INGEST-RECONCILE-001/spec.md) — Coverage-complete + observable connector ingestion.

Two empirical silent-drop bugs (Voys Help NL: 41/208 sitemap pages ingested; Voys Notion: 79/120 pages persisted) and the underlying recurrence pattern. Four bundled fixes.

## Fixes in this PR

### Fix 1 — `crawl_site` rewrite: sitemap+BFS UNION via crawl4ai bulk `/crawl`

Discovery and fetch are decoupled. Candidates are discovered first (sitemap-priority on cap, BFS shallow seed for orphan-link coverage, canonicalised dedup), then submitted to crawl4ai in **one bulk call** whose server-side `MemoryAdaptiveDispatcher` handles concurrency.

Removes the unbounded `asyncio.gather` supplement loop that dropped ~80% of pages on `help.voys.nl` (Bug A). Same-domain filter, `include_patterns` substring filter, and `login_indicator` semantics preserved.

`crawl_site` now returns `(results, outcomes)` — outcomes is a per-URL JSONB-shaped list (AC-4). Five test files updated to handle the tuple.

### Fix 2 — `connector.sync_runs.skip_reasons` JSONB persistence

`{reason_code: count}` populated by `sync_engine._execute_sync` at run completion. Replaces the `documents_short_skipped` int counter that only ever reached 5-day-retention structlog (Bug B was invisible in DB). JSONB key membership enforced by Postgres CHECK constraint against `PersistSkipReason` enum values (migration 009).

### Fix 3 — Stable reason-code registry

`FetchReasonCode` (10 values: success, http_4xx, http_5xx, timeout, dns_error, connection_error, auth_error, parse_error, rate_limited, unknown_exception) and `PersistSkipReason` (7 values: content_too_short, auth_wall_detected, dedupe_content_hash_match, dedupe_raw_html_hash_match, non_text_content, excluded_by_kb_config, taxonomy_classify_failed) live as `StrEnum` in both `klai-knowledge-ingest` and `klai-connector`, with a parity test guarding drift.

Per-URL fetch outcomes → `knowledge.crawl_jobs.fetch_outcomes` JSONB (migration 0005). Per-sync skip aggregates → `connector.sync_runs.skip_reasons`.

### Fix 4 — CI-enforced ast-grep rule

`rules/no-unbounded-gather-crawl-page.yml` blocks reintroduction of the supplement-loop pattern (`asyncio.gather` over `crawl_page`). Regression-test fixtures cover both flagged and unflagged shapes; rule auto-discovered via `sgconfig.yml` and runs in existing per-service `ast-grep/action` steps.

## Schema changes

```sql
-- knowledge.crawl_jobs (alembic 0005_crawl_jobs_fetch_outcomes)
ADD COLUMN fetch_outcomes jsonb NOT NULL DEFAULT '[]'
ADD CONSTRAINT crawl_jobs_fetch_outcomes_is_array CHECK (jsonb_typeof(fetch_outcomes) = 'array')

-- connector.sync_runs (alembic 009_sync_runs_skip_reasons)
ADD COLUMN skip_reasons jsonb NOT NULL DEFAULT '{}'
ADD CONSTRAINT sync_runs_skip_reasons_valid_keys CHECK (
  jsonb_typeof(skip_reasons) = 'object'
  AND (skip_reasons = '{}'::jsonb OR every key ∈ PersistSkipReason)
)
```

Both default-non-NULL, no backfill of historical rows (per SPEC §"Not migrating existing sync_runs rows").

## Acceptance criteria coverage

- AC-1 — sitemap+BFS UNION via `/crawl` bulk: implemented in `crawl_site`
- AC-2 — sitemap takes priority on cap: `_build_candidate_set` test
- AC-3 — sitemap-fail → BFS-only fallback: `_fetch_sitemap_urls` warning, no crawl failure
- AC-4 — per-URL `crawl_jobs.fetch_outcomes`: persistence in `adapters/crawler.py`, classification in `_classify_fetch_outcome`
- AC-5 — empirical (live trigger ≥ 200 outcomes Voys): pending production verification post-merge
- AC-6 — `sync_runs.skip_reasons` populated: `test_sync_engine_skip_reasons.py`
- AC-7 — `documents_ok` arithmetic: SPEC formula equivalent to existing per-loop counter (documented inline in `_execute_sync`)
- AC-8 — empirical (Notion → skip_reasons.content_too_short ≥ 30): pending production verification post-merge
- AC-9 — enums in both services: `reason_codes.py` × 2, parity test
- AC-10 — Postgres CHECK on `sync_runs.skip_reasons`: migration 009
- AC-11 — Postgres CHECK on `crawl_jobs.fetch_outcomes`: migration 0005 (array shape; element-level reason_code check application-side per migration docstring)
- AC-12 — ast-grep rule: `rules/no-unbounded-gather-crawl-page.yml` + regression test
- AC-13/14 — non-functional perf: bulk `/crawl` is one HTTP call (< 90s on Voys/support); JSONB write is single UPDATE
- AC-15 — UI panel: backend support in this PR; frontend change deliberately out of scope (SPEC: "Implementation in a follow-up frontend PR")
- AC-16 — MX tags: applied to `crawl_site` (`@MX:NOTE` SPEC-INGEST-RECONCILE-001 Fix 1), `_execute_sync` skip_reasons block, `reason_codes.py` (`@MX:ANCHOR`)

## Test status

- knowledge-ingest touched-path: 47/47 pass
- connector touched-path: 11/11 pass (incl. `test_sync_engine_reconnect`, `test_sync_engine_web_delegation`)
- ast-grep rule regression: 4/4 pass
- ruff: clean on modified files (pre-existing F841/I001 in `test_crawler_link_fields_complete.py` verified on `main`, unaffected by this PR)
- Pre-existing repo-wide failures (~40 in eval/middleware/wipe suites) verified unrelated on `main`

## Migration plan

1. Merge → CI deploys new `klai-knowledge-ingest` + `klai-connector` images
2. Run `alembic upgrade head` on `klai-core-portal-api-1`-equivalent containers (knowledge-ingest + connector)
3. Empirical validation: trigger a Voys/support crawl + Notion sync → assert AC-5 (≥ 200 fetch_outcomes, ≥ 180 success) and AC-8 (skip_reasons.content_too_short ≥ 30, documents_ok ≤ 80)

## References

- `reports/taxonomy-v2.1-evaluation-2026-05-06/comparison.md` — origin signal (FOLLOWUP-001 close-out)
- crawl4ai REST `/crawl` docs (verified openapi.json on production container)
- Apache Nutch fetch status taxonomy (FetchReasonCode shape inspiration)
- Scrapy `item_dropped` signal (PersistSkipReason pattern inspiration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)