### PR TITLE
fix(ingest): rebase SPEC-002 alembic migration onto a8c5e1d2f3b4 (multi-head hotfix)

### DIFF
--- a/klai-knowledge-ingest/alembic/versions/0006_crawled_pages_simhash.py
+++ b/klai-knowledge-ingest/alembic/versions/0006_crawled_pages_simhash.py
@@ -18,9 +18,18 @@ alembic_version table is separate from portal-api's ``public.alembic_version``
 and connector's ``connector.alembic_version`` (see ``alembic/env.py``).
 
 Revision ID: 7f2e8a1c5b4d
-Revises: 603787256fb8
+Revises: a8c5e1d2f3b4
 Create Date: 2026-05-06
 SPEC: SPEC-INGEST-LOGIN-WALL-DETECT-002 REQ-01
+
+Note: rebased from down_revision=603787256fb8 to a8c5e1d2f3b4 in the
+hotfix branch fix/login-wall-detect-002-alembic-head — PR #440
+(SPEC-INGEST-RECONCILE-001) merged with revision a8c5e1d2f3b4 chained
+on the same parent (603787256fb8) ~7 minutes before this migration
+landed, leaving alembic with two heads. Re-chaining onto a8c5e1d2f3b4
+serialises the chain. The two columns added (crawl_jobs.fetch_outcomes
+in 0005, crawled_pages.content_simhash in 0006) target different
+tables; no schema conflict.
 """
 
 from collections.abc import Sequence
@@ -28,7 +37,7 @@ from collections.abc import Sequence
 from alembic import op
 
 revision: str = "7f2e8a1c5b4d"
-down_revision: str | None = "603787256fb8"
+down_revision: str | None = "a8c5e1d2f3b4"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/klai-knowledge-ingest/tests/test_alembic_simhash_migration.py
+++ b/klai-knowledge-ingest/tests/test_alembic_simhash_migration.py
@@ -1,9 +1,15 @@
 """SPEC-INGEST-LOGIN-WALL-DETECT-002 Phase A -- content_simhash migration.
 
-Validates that ``alembic/versions/0005_crawled_pages_simhash.py`` exists with
+Validates that ``alembic/versions/0006_crawled_pages_simhash.py`` exists with
 the correct revision chain, adds the ``content_simhash bigint`` column on
 ``knowledge.crawled_pages``, creates the partial index supporting cluster
 lookups, is idempotent on re-run, and reverses cleanly on downgrade.
+
+The migration was renamed from 0005 to 0006 in the hotfix branch
+``fix/login-wall-detect-002-alembic-head`` after PR #440
+(SPEC-INGEST-RECONCILE-001) merged its own ``0005_crawl_jobs_fetch_outcomes``
+chained on the same parent, leaving alembic with two heads. Re-chaining
+on a8c5e1d2f3b4 serialises the chain.
 
 These are static-content tests (no live DB required) following the pattern set
 by ``test_alembic_bootstrap.py``. A live-DB integration test would belong in
@@ -18,17 +24,21 @@ from pathlib import Path
 
 SERVICE_ROOT = Path(__file__).resolve().parents[1]
 VERSIONS_DIR = SERVICE_ROOT / "alembic" / "versions"
-MIGRATION = VERSIONS_DIR / "0005_crawled_pages_simhash.py"
+MIGRATION = VERSIONS_DIR / "0006_crawled_pages_simhash.py"
 
 
 def test_migration_file_exists() -> None:
-    assert MIGRATION.exists(), f"0005_crawled_pages_simhash.py missing in {VERSIONS_DIR}"
+    assert MIGRATION.exists(), f"0006_crawled_pages_simhash.py missing in {VERSIONS_DIR}"
 
 
-def test_revision_chains_after_0004() -> None:
+def test_revision_chains_after_0005_fetch_outcomes() -> None:
+    """Chains on a8c5e1d2f3b4 (0005_crawl_jobs_fetch_outcomes) — PR #440 merged
+    with that revision before this migration landed; rebasing avoids the
+    "multiple alembic heads" failure that broke the entrypoint.
+    """
     content = MIGRATION.read_text()
-    assert 'down_revision: str | None = "603787256fb8"' in content, (
-        "0005 must chain after 0004_crawl_jobs_error_summary (revision 603787256fb8)"
+    assert 'down_revision: str | None = "a8c5e1d2f3b4"' in content, (
+        "0006 must chain after 0005_crawl_jobs_fetch_outcomes (revision a8c5e1d2f3b4)"
     )
 
 
@@ -42,9 +52,13 @@ def test_revision_id_is_distinct_uuid_style() -> None:
         f"revision id {rev!r} must be 12 lowercase hex chars, matching "
         "the pattern set by 0002-0004"
     )
-    assert rev not in {"603787256fb8", "9a3c4d5e6f7b", "dd1b439a57d0", "0001_baseline"}, (
-        f"revision id {rev!r} collides with an existing migration"
-    )
+    assert rev not in {
+        "603787256fb8",
+        "9a3c4d5e6f7b",
+        "dd1b439a57d0",
+        "0001_baseline",
+        "a8c5e1d2f3b4",  # 0005_crawl_jobs_fetch_outcomes
+    }, f"revision id {rev!r} collides with an existing migration"
 
 
 def test_adds_content_simhash_column() -> None:


### PR DESCRIPTION
## Summary

Production hotfix. PRs #440 and #441 both shipped a migration revision chained on \`603787256fb8\`, so \`alembic upgrade head\` is now failing in the knowledge-ingest entrypoint with:

\`\`\`
Multiple head revisions are present for given argument 'head'
\`\`\`

The container has been restartlooping since the SPEC-002 deploy. This rebases my migration onto the head that merged first (\`a8c5e1d2f3b4\` from PR #440 / SPEC-INGEST-RECONCILE-001), serialising the chain.

## Why this is safe

The two columns target different tables — \`crawl_jobs.fetch_outcomes\` (PR #440) vs \`crawled_pages.content_simhash\` (PR #441). No schema collision; only the alembic revision graph needed to be linearised.

## Changes

- Rename \`alembic/versions/0005_crawled_pages_simhash.py\` → \`0006_crawled_pages_simhash.py\`
- Update \`down_revision\`: \`603787256fb8\` → \`a8c5e1d2f3b4\`
- Update \`test_alembic_simhash_migration.py\` to assert the new chain

## Verified offline

\`\`\`
alembic upgrade head --sql\` walks: 0001 → dd1b → 9a3c → 603787 → a8c5 (fetch_outcomes) → 7f2e (simhash)
\`\`\`

## Test plan

- [x] 8/8 alembic-static tests pass
- [ ] CI green
- [ ] After deploy: \`docker logs klai-core-knowledge-ingest-1\` shows \`Running upgrade 603787256fb8 -> a8c5e1d2f3b4\` then \`-> 7f2e8a1c5b4d\`, container reaches \`Up\` state

## Followup pitfall

When two PRs each add an alembic migration with the same \`down_revision\`, the head split is silent at PR-build time and only surfaces in production entrypoint. Capturing as a process-rules pitfall in a separate retro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)