### PR TITLE
fix(ingest-reconcile): alembic merge + jsonb-text[] CHECK form

### DIFF
--- a/klai-connector/alembic/versions/009_sync_runs_skip_reasons.py
+++ b/klai-connector/alembic/versions/009_sync_runs_skip_reasons.py
@@ -71,27 +71,27 @@ def upgrade() -> None:
         $$;
         """
     )
+    # Postgres rejects subqueries inside CHECK constraints
+    # ("cannot use subquery in check constraint"). The membership test
+    # is expressed via JSONB key-removal: ``skip_reasons - allowed[]``
+    # strips every allowed key from the object; if the result is
+    # ``'{}'`` then every original key was in the allowed list. Empty
+    # input is also ``'{}'`` which trivially passes.
     op.execute(
         """
         ALTER TABLE connector.sync_runs
         ADD CONSTRAINT sync_runs_skip_reasons_valid_keys
         CHECK (
             jsonb_typeof(skip_reasons) = 'object'
-            AND (
-                skip_reasons = '{}'::jsonb
-                OR (
-                    SELECT bool_and(key IN (
-                        'content_too_short',
-                        'auth_wall_detected',
-                        'dedupe_content_hash_match',
-                        'dedupe_raw_html_hash_match',
-                        'non_text_content',
-                        'excluded_by_kb_config',
-                        'taxonomy_classify_failed'
-                    ))
-                    FROM jsonb_object_keys(skip_reasons) AS key
-                )
-            )
+            AND (skip_reasons - ARRAY[
+                'content_too_short',
+                'auth_wall_detected',
+                'dedupe_content_hash_match',
+                'dedupe_raw_html_hash_match',
+                'non_text_content',
+                'excluded_by_kb_config',
+                'taxonomy_classify_failed'
+            ]::text[]) = '{}'::jsonb
         )
         """
     )

--- a/klai-knowledge-ingest/alembic/versions/0006_merge_fetch_outcomes_simhash.py
+++ b/klai-knowledge-ingest/alembic/versions/0006_merge_fetch_outcomes_simhash.py
@@ -1,0 +1,32 @@
+"""Merge SPEC-INGEST-RECONCILE-001 (a8c5e1d2f3b4) and SPEC-INGEST-LOGIN-WALL-DETECT-002 (7f2e8a1c5b4d).
+
+Both 0005 migrations branched from ``603787256fb8`` in parallel PRs that
+landed within minutes of each other (PR #440 + PR #441). On their own
+each migration is correct; alembic refuses ``upgrade head`` because two
+heads exist.
+
+This is a no-op merge — both predecessor migrations are independent
+schema additions (``knowledge.crawl_jobs.fetch_outcomes`` jsonb vs
+``knowledge.crawled_pages.content_simhash`` bigint + index). No
+upgrade/downgrade body is needed beyond declaring the merge ancestry.
+
+Revision ID: c1d4e7f2a8b6
+Revises: a8c5e1d2f3b4, 7f2e8a1c5b4d
+Create Date: 2026-05-06
+SPEC: SPEC-INGEST-RECONCILE-001 (alembic-heads recovery)
+"""
+
+from collections.abc import Sequence
+
+revision: str = "c1d4e7f2a8b6"
+down_revision: tuple[str, ...] = ("a8c5e1d2f3b4", "7f2e8a1c5b4d")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Hotfix for SPEC-INGEST-RECONCILE-001 (PR #440)

Two production blockers exposed by the post-merge deploy on core-01.
Both crash on container start, before any user traffic.

### 1. knowledge-ingest — multiple alembic heads

Symptom (looped in the container):

\`\`\`
Multiple head revisions are present for given argument 'head'; please
specify a specific target revision, '<branchname>@head' to narrow to
a specific head, or 'heads' for all heads
\`\`\`

PR #441 (SPEC-INGEST-LOGIN-WALL-DETECT-002) added \`0005_crawled_pages_simhash\` (\`revision = 7f2e8a1c5b4d\`) with \`down_revision = 603787256fb8\`. PR #440 (this SPEC) added \`0005_crawl_jobs_fetch_outcomes\` (\`revision = a8c5e1d2f3b4\`) with the same \`down_revision\`. Both migrations passed CI in their own branches; the dual-head only became visible after the second one merged.

Fix: \`0006_merge_fetch_outcomes_simhash.py\` — alembic merge migration with \`down_revision = ("a8c5e1d2f3b4", "7f2e8a1c5b4d")\`. No-op upgrade/downgrade body — both predecessor migrations touch independent columns (\`crawl_jobs.fetch_outcomes\` jsonb vs \`crawled_pages.content_simhash\` bigint).

### 2. klai-connector — Postgres rejects subquery in CHECK

Symptom (loop on \`alembic upgrade head\`):

\`\`\`
asyncpg.exceptions.FeatureNotSupportedError: cannot use subquery in
check constraint
[SQL: ALTER TABLE connector.sync_runs ADD CONSTRAINT
      sync_runs_skip_reasons_valid_keys CHECK (... SELECT bool_and(...) ...)]
\`\`\`

Migration 009's CHECK used \`SELECT bool_and(key IN (...)) FROM jsonb_object_keys(skip_reasons) AS key\`. Postgres has rejected scalar subqueries in CHECK since 9.x. The local pytest didn't catch it because no local test runs alembic against a real Postgres in this repo.

Fix: rewrite the CHECK using JSONB key-removal — \`skip_reasons - ARRAY[<allowed>]::text[] = '{}'::jsonb\`. \`jsonb - text[]\` strips every listed key; the result equals \`'{}'\` iff every original key was in the allowed list. Empty input also normalises to \`'{}'\`, so the explicit \`= '{}'::jsonb\` branch is redundant in the new form.

The migration is rewritten in place rather than appended-to — production never committed any state from 009 (the constraint creation failed before COMMIT inside alembic's per-migration transaction), so the existing semantics on prod = "still at revision 008".

## Validation

- \`tests/test_reason_codes_parity.py\` still asserts every PersistSkipReason value appears in the migration text. Updated migration text contains all seven values in the new CHECK form.
- \`tests/test_sync_engine_skip_reasons.py\` 5/5 pass — application layer is unchanged.
- Local alembic-bootstrap test (\`klai-knowledge-ingest/tests/test_alembic_bootstrap.py\`) covers the merge migration.

## Rollout

After merge:
1. CI deploys new \`klai-knowledge-ingest\` and \`klai-connector\` images.
2. The fixed entrypoint \`alembic upgrade head\` lands both columns + the CHECK constraint without a crash loop.
3. AC-5 / AC-8 empirical validation can then run against my.getklai.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)