### PR TITLE
fix(ingest-reconcile followup): four crawl_site cleanups

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
@@ -401,53 +401,78 @@ async def crawl_site(
     @MX:NOTE SPEC-INGEST-RECONCILE-001 Fix 1 — replaces the old BFS-with-
     post-supplement design that silently dropped sitemap URLs in an
     unbounded ``asyncio.gather`` loop (Bug A: 41/208 ingested for
-    help.voys.nl). Discovery and fetch are now decoupled:
+    help.voys.nl). Discovery and fetch are decoupled:
 
-    1. **Discovery** — union(sitemap_xml_urls, BFS_seeds_from_homepage),
-       canonicalised + deduped + capped at ``max_pages``. Sitemap takes
-       priority on cap (AC-2: site-owner truth beats best-effort BFS).
+    1. **Seed** — fetch ``start_url`` once via ``_fetch_seed_page`` using the
+       same crawler config as the bulk path (login_indicator + cookies
+       included). The result is the homepage CrawlResult AND the source of
+       the BFS link list. The seed is NOT re-fetched in step 3.
+    2. **Discovery** — union(sitemap_xml_urls, BFS_seeds_from_homepage),
+       canonicalised + deduped + capped, EXCLUDING ``start_url`` (already
+       fetched as the seed). Sitemap takes priority on cap (AC-2).
        AC-3: missing sitemap → BFS-only fallback, never crawl failure.
-    2. **Fetch** — single ``POST /crawl`` bulk call with the candidate
-       URL list. crawl4ai's server-side ``MemoryAdaptiveDispatcher``
+    3. **Bulk fetch** — single ``POST /crawl`` call for all non-seed
+       candidates. crawl4ai's server-side ``MemoryAdaptiveDispatcher``
        handles concurrency.
-    3. **Outcome capture** — every candidate URL produces one entry in
-       the returned ``outcomes`` list (AC-4) keyed by ``FetchReasonCode``.
+    4. **Outcome capture** — every candidate URL (seed + bulk) produces one
+       entry in ``outcomes`` (AC-4) keyed by ``FetchReasonCode``.
+
+    Candidate ↔ response matching is canonical-URL first, with a positional
+    fallback for redirect cases where crawl4ai's ``response.url`` reflects
+    the redirect TARGET rather than the submitted candidate (e.g.
+    ``/old-page`` → ``/new-page``). The fallback is bounded to candidates
+    whose canonical key is unmatched after the first pass; positional index
+    is trusted because crawl4ai's bulk endpoint preserves submission order.
 
     Returns ``(crawl_results, outcomes)``:
     - ``crawl_results``: same-domain pages with non-empty markdown (the
       caller's old contract: pages worth ingesting).
     - ``outcomes``: per-URL records ``{"url", "reason_code", "status_code",
-      "content_length"}`` — written to ``crawl_jobs.fetch_outcomes`` JSONB
-      so operators can answer "where did the missing pages go?".
+      "content_length"}`` written to ``crawl_jobs.fetch_outcomes`` JSONB so
+      operators can answer "where did the missing pages go?".
 
     ``max_depth`` is accepted for caller-signature compatibility but no
-    longer drives discovery (we explicitly enumerate candidates instead
-    of recursing). ``include_patterns``, when set, is applied as a
-    candidate-side substring filter against the union before submission.
+    longer drives discovery (we explicitly enumerate candidates instead of
+    recursing). ``include_patterns``, when set, is applied as a candidate-
+    side substring filter against the union before submission.
     """
-    config = build_crawl_config(selector, login_indicator_selector=login_indicator_selector)
     parsed = urlparse(start_url)
     base_domain = parsed.netloc.lower()
-
-    # ------------------------------------------------------------------
-    # Discovery — sitemap + shallow BFS seed, union, dedup, cap.
-    # ------------------------------------------------------------------
-    sitemap_urls = await _fetch_sitemap_urls(start_url)
-
-    bfs_seed_urls = await _bfs_discover_seed_urls(
-        start_url=start_url,
-        selector=selector,
+    crawler_config = build_crawl_config(
+        selector,
         login_indicator_selector=login_indicator_selector,
+    )
+
+    # ------------------------------------------------------------------
+    # Step 1 — Seed: one fetch of start_url with the FULL config (incl.
+    # login_indicator). Re-using ``crawl_page`` here would silently drop
+    # the indicator (it builds its own config without the kwarg) — that
+    # produced a latent bug where auth-walled homepages were treated as
+    # successful "content" and their login-form anchors became BFS seeds.
+    # ------------------------------------------------------------------
+    seed_result = await _fetch_seed_page(
+        start_url=start_url,
+        crawler_config=crawler_config,
         cookies=cookies,
     )
 
-    candidates = _build_candidate_set(
+    bfs_seed_urls = _extract_bfs_seeds(seed_result, base_domain=base_domain)
+
+    # ------------------------------------------------------------------
+    # Step 2 — Discovery union, EXCLUDING start_url (already in results).
+    # Reserve one slot of max_pages for the seed itself.
+    # ------------------------------------------------------------------
+    sitemap_urls = await _fetch_sitemap_urls(start_url)
+
+    bulk_max = max(0, max_pages - 1)
+    bulk_candidates = _build_candidate_set(
         start_url=start_url,
         sitemap_urls=sitemap_urls,
         bfs_seed_urls=bfs_seed_urls,
         base_domain=base_domain,
-        max_pages=max_pages,
+        max_pages=bulk_max,
         include_patterns=include_patterns,
+        include_start_url=False,
     )
 
     logger.info(
@@ -455,118 +480,281 @@ async def crawl_site(
         start_url=start_url,
         sitemap_urls=len(sitemap_urls),
         bfs_seed_urls=len(bfs_seed_urls),
-        candidates=len(candidates),
+        bulk_candidates=len(bulk_candidates),
         max_pages=max_pages,
     )
 
-    if not candidates:
-        logger.warning("crawl_site_no_candidates", start_url=start_url)
-        return [], []
+    # ------------------------------------------------------------------
+    # Step 3 — Bulk fetch. crawl4ai's MemoryAdaptiveDispatcher handles
+    # concurrency server-side; we get per-URL ``success`` + ``error_message``
+    # in the response body.
+    # ------------------------------------------------------------------
+    raw_results: list[dict[str, Any]] = []
+    transport_error: BaseException | None = None
+
+    if bulk_candidates:
+        payload: dict[str, Any] = {
+            "urls": bulk_candidates,
+            "crawler_config": {"type": "CrawlerRunConfig", "params": crawler_config},
+        }
+        if cookies:
+            payload["hooks"] = _build_cookie_hooks(cookies)
+        try:
+            async with httpx.AsyncClient(timeout=_BULK_CRAWL_TIMEOUT) as client:
+                data = await _crawl_sync(client, payload)
+            raw_results = _normalise_results_block(data)
+        except Exception as exc:
+            transport_error = exc
+            logger.warning(
+                "crawl_site_bulk_request_failed",
+                start_url=start_url,
+                candidates=len(bulk_candidates),
+                error=str(exc),
+            )
 
     # ------------------------------------------------------------------
-    # Fetch — single bulk POST /crawl. Server-side dispatcher handles
-    # concurrency; we get per-URL ``success`` + ``error_message`` in
-    # the response body.
+    # Step 4 — Combine seed + bulk into ``crawl_results`` and ``outcomes``.
     # ------------------------------------------------------------------
+    crawl_results: list[CrawlResult] = []
+    outcomes: list[FetchOutcome] = []
+
+    seed_outcome = _build_outcome_from_result(start_url, seed_result)
+    outcomes.append(seed_outcome)
+    if _result_is_ingestable(seed_result, base_domain=base_domain):
+        crawl_results.append(seed_result)
+
+    bulk_results, bulk_outcomes = _combine_bulk_responses(
+        candidates=bulk_candidates,
+        raw_results=raw_results,
+        transport_error=transport_error,
+        base_domain=base_domain,
+    )
+    crawl_results.extend(bulk_results)
+    outcomes.extend(bulk_outcomes)
+
+    success_count = sum(1 for o in outcomes if o["reason_code"] == FetchReasonCode.SUCCESS.value)
+    logger.info(
+        "crawl_site_complete",
+        start_url=start_url,
+        candidates=len(outcomes),
+        results=len(crawl_results),
+        success_outcomes=success_count,
+        non_success_outcomes=len(outcomes) - success_count,
+    )
+
+    return crawl_results, outcomes
+
+
+# ---------------------------------------------------------------------------
+# crawl_site internals — kept module-private for testability.
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_seed_page(
+    *,
+    start_url: str,
+    crawler_config: dict[str, Any],
+    cookies: list[dict[str, Any]] | None,
+) -> CrawlResult:
+    """Fetch ``start_url`` once with the SAME config the bulk path uses.
+
+    Distinct from ``crawl_page`` because crawl_page rebuilds config from
+    ``selector`` only — it has no knob for ``login_indicator_selector``,
+    so reusing it for the seed would silently strip auth-wall detection
+    and let the seed succeed on a login page (extracting login-form
+    anchors as BFS seeds, then auth-failing every URL in the bulk).
+    """
     payload: dict[str, Any] = {
-        "urls": candidates,
-        "crawler_config": {"type": "CrawlerRunConfig", "params": config},
+        "urls": [start_url],
+        "crawler_config": {"type": "CrawlerRunConfig", "params": crawler_config},
     }
     if cookies:
         payload["hooks"] = _build_cookie_hooks(cookies)
 
-    raw_results: list[dict[str, Any]] = []
-    transport_error: BaseException | None = None
-
     try:
-        async with httpx.AsyncClient(timeout=_BULK_CRAWL_TIMEOUT) as client:
+        async with httpx.AsyncClient(timeout=90.0) as client:
             data = await _crawl_sync(client, payload)
-        raw_results = _normalise_results_block(data)
     except Exception as exc:
-        # Whole-batch transport failure: every candidate gets the same
-        # transport-classified outcome (AC-4: no candidate is "lost",
-        # they all surface a reason). The caller's existing failure
-        # path then reads the outcomes to decide.
-        transport_error = exc
         logger.warning(
-            "crawl_site_bulk_request_failed",
+            "crawl_site_seed_request_failed",
             start_url=start_url,
-            candidates=len(candidates),
             error=str(exc),
         )
+        return CrawlResult(
+            url=start_url,
+            fit_markdown="",
+            raw_markdown="",
+            html="",
+            word_count=0,
+            success=False,
+            error_message=str(exc),
+        )
 
-    # Map results back to candidates by URL (canonicalised). crawl4ai
-    # keeps URL ordering but we don't rely on it.
-    by_url: dict[str, dict[str, Any]] = {}
+    pages = _normalise_results_block(data)
+    if not pages:
+        logger.warning("crawl_site_seed_empty_response", start_url=start_url)
+        return CrawlResult(
+            url=start_url,
+            fit_markdown="",
+            raw_markdown="",
+            html="",
+            word_count=0,
+            success=False,
+            error_message="empty response",
+        )
+
+    return _extract_result(start_url, pages[0])
+
+
+def _extract_bfs_seeds(seed_result: CrawlResult, *, base_domain: str) -> list[str]:
+    """Extract same-domain internal links from the seed page.
+
+    Returns an empty list when the seed itself failed (auth wall, 5xx,
+    etc.) — the candidate set then degrades cleanly to sitemap-only.
+    """
+    if not seed_result.success:
+        return []
+    internal = (seed_result.links or {}).get("internal") or []
+    seeds: list[str] = []
+    for entry in internal:
+        href = entry.get("href") if isinstance(entry, dict) else None
+        if not href:
+            continue
+        if urlparse(href).netloc.lower() != base_domain:
+            continue
+        seeds.append(href)
+    return seeds
+
+
+def _build_outcome_from_result(url: str, result: CrawlResult) -> FetchOutcome:
+    """Map a CrawlResult (the seed path) to a fetch_outcomes JSONB entry."""
+    if result.success:
+        reason_code = FetchReasonCode.SUCCESS.value
+    else:
+        # Synthesise a page-shape dict for the classifier so the same
+        # error_message → FetchReasonCode mapping applies as for the
+        # bulk path.
+        reason_code = _classify_fetch_outcome(
+            {
+                "success": False,
+                "status_code": None,
+                "error_message": result.error_message or "",
+            },
+        )
+    return {
+        "url": url,
+        "reason_code": reason_code,
+        "status_code": None,
+        "content_length": len(result.html or ""),
+    }
+
+
+def _result_is_ingestable(result: CrawlResult, *, base_domain: str) -> bool:
+    """Same-domain + non-empty + success — the legacy ingest-loop contract."""
+    if not result.success:
+        return False
+    if not (result.fit_markdown or result.raw_markdown):
+        return False
+    return urlparse(result.url).netloc.lower() == base_domain
+
+
+def _combine_bulk_responses(
+    *,
+    candidates: list[str],
+    raw_results: list[dict[str, Any]],
+    transport_error: BaseException | None,
+    base_domain: str,
+) -> tuple[list[CrawlResult], list[FetchOutcome]]:
+    """Match bulk candidates to crawl4ai responses; produce results + outcomes.
+
+    Matching uses canonical-URL lookup first. For unmatched candidates we
+    fall back to positional alignment with the response list — crawl4ai's
+    bulk endpoint preserves submission order, and a redirect (``/old-page``
+    → ``/new-page``) is the only common reason for a candidate's canonical
+    to disappear from the response set. The fallback only claims a
+    positional response that has not already been canonical-matched to a
+    different candidate, so a redirect doesn't silently shadow a legitimate
+    direct hit.
+    """
+    crawl_results: list[CrawlResult] = []
+    outcomes: list[FetchOutcome] = []
+
+    if not candidates:
+        return crawl_results, outcomes
+
+    # Canonical-URL → response, populated from the bulk response body.
+    by_canonical: dict[str, dict[str, Any]] = {}
     for page in raw_results:
         if not page:
             continue
         result_url = page.get("url") or ""
         if not result_url:
             continue
-        by_url[_canonicalise_url(result_url)] = page
+        by_canonical[_canonicalise_url(result_url)] = page
 
-    crawl_results: list[CrawlResult] = []
-    outcomes: list[FetchOutcome] = []
+    candidate_canonicals = [_canonicalise_url(c) for c in candidates]
+    canonical_to_idx: dict[str, int] = {c: i for i, c in enumerate(candidate_canonicals)}
+    # Track which positional response has already been claimed by canonical
+    # match. Prevents the redirect-fallback from re-claiming.
+    claimed_response_indices: set[int] = set()
+    for canonical in candidate_canonicals:
+        page = by_canonical.get(canonical)
+        if page is None:
+            continue
+        # Locate the positional index of this matched response so the
+        # redirect fallback won't claim it again.
+        for j, raw in enumerate(raw_results):
+            if raw is page:
+                claimed_response_indices.add(j)
+                break
 
-    for url in candidates:
-        canonical = _canonicalise_url(url)
-        page = by_url.get(canonical)
+    for i, url in enumerate(candidates):
         if transport_error is not None:
-            reason_code = _classify_fetch_outcome(None, error=transport_error)
             outcomes.append(
                 {
                     "url": url,
-                    "reason_code": reason_code,
+                    "reason_code": _classify_fetch_outcome(None, error=transport_error),
                     "status_code": None,
                     "content_length": 0,
                 }
             )
             continue
 
-        reason_code = _classify_fetch_outcome(page)
-        content_length = len((page or {}).get("html", "") or "")
+        page = by_canonical.get(candidate_canonicals[i])
+
+        # Redirect fallback: positional alignment when canonical match
+        # missed AND the response at this index hasn't been claimed AND
+        # its URL doesn't canonical-match a DIFFERENT candidate (which
+        # would be ambiguous).
+        if (
+            page is None
+            and len(raw_results) == len(candidates)
+            and i < len(raw_results)
+            and i not in claimed_response_indices
+        ):
+            positional = raw_results[i]
+            if positional and positional.get("url"):
+                pos_canonical = _canonicalise_url(positional["url"])
+                pos_owner_idx = canonical_to_idx.get(pos_canonical)
+                if pos_owner_idx is None or pos_owner_idx == i:
+                    page = positional
+                    claimed_response_indices.add(i)
+
         outcomes.append(
             {
                 "url": url,
-                "reason_code": reason_code,
+                "reason_code": _classify_fetch_outcome(page),
                 "status_code": (page or {}).get("status_code"),
-                "content_length": content_length,
+                "content_length": len((page or {}).get("html", "") or ""),
             }
         )
 
         if page is None:
-            # crawl4ai didn't return this URL — uncommon, but record it.
             continue
 
         result = _extract_result(url, page)
-        # Same-domain filter as the legacy BFS path: external links
-        # discovered via sitemap noise or rewrites stay out.
-        if urlparse(result.url).netloc != parsed.netloc:
-            continue
-        # Only successful, non-empty pages reach the ingest loop. Failed
-        # fetches stay in ``outcomes`` (where operators look for the
-        # breakdown via ``crawl_jobs.fetch_outcomes``) so the caller's
-        # ``pages_total`` reflects pages that actually have content. This
-        # also preserves the legacy login_indicator semantics: a single
-        # ``success=False`` result that the indicator caller sees triggers
-        # ``AuthWallDetected`` — surfacing transient 5xx noise as
-        # auth-walled would be a regression.
-        if not result.success:
-            continue
-        if not (result.fit_markdown or result.raw_markdown):
-            continue
-        crawl_results.append(result)
-
-    success_count = sum(1 for o in outcomes if o["reason_code"] == FetchReasonCode.SUCCESS.value)
-    logger.info(
-        "crawl_site_complete",
-        start_url=start_url,
-        candidates=len(candidates),
-        results=len(crawl_results),
-        success_outcomes=success_count,
-        non_success_outcomes=len(outcomes) - success_count,
-    )
+        if _result_is_ingestable(result, base_domain=base_domain):
+            crawl_results.append(result)
 
     return crawl_results, outcomes
 
@@ -588,55 +776,6 @@ def _normalise_results_block(data: dict[str, Any]) -> list[dict[str, Any]]:
     return []
 
 
-async def _bfs_discover_seed_urls(
-    *,
-    start_url: str,
-    selector: str | None,
-    login_indicator_selector: str | None,
-    cookies: list[dict[str, Any]] | None,
-) -> list[str]:
-    """Shallow BFS — fetch start_url once, return its same-domain internal links.
-
-    @MX:NOTE Replaces the previous deep-BFS via ``/crawl/job``. We only
-    need the homepage's link set as the BFS contribution to the union;
-    the rest of crawl4ai's BFS (recursive expansion) is the layer that
-    duplicated work in the old design and produced no coverage signal.
-    """
-    base_domain = urlparse(start_url).netloc.lower()
-
-    seed_result = await crawl_page(
-        start_url,
-        selector=selector,
-        cookies=cookies,
-    )
-    if not seed_result.success:
-        if login_indicator_selector:
-            logger.warning(
-                "crawl_site_seed_login_indicator_triggered",
-                start_url=start_url,
-                login_indicator_selector=login_indicator_selector,
-            )
-        else:
-            logger.warning(
-                "crawl_site_seed_fetch_failed",
-                start_url=start_url,
-                error=seed_result.error_message,
-            )
-        return []
-
-    # crawl4ai links shape: {"internal": [{"href": "...", "text": "..."}], "external": [...]}.
-    internal = seed_result.links.get("internal") or []
-    seeds: list[str] = []
-    for entry in internal:
-        href = entry.get("href") if isinstance(entry, dict) else None
-        if not href:
-            continue
-        if urlparse(href).netloc.lower() != base_domain:
-            continue
-        seeds.append(href)
-    return seeds
-
-
 def _build_candidate_set(
     *,
     start_url: str,
@@ -645,17 +784,23 @@ def _build_candidate_set(
     base_domain: str,
     max_pages: int,
     include_patterns: list[str] | None,
+    include_start_url: bool = True,
 ) -> list[str]:
     """Union(sitemap, BFS-seeds), filtered to same-domain, deduped, capped.
 
-    AC-2: when union exceeds max_pages, sitemap entries take priority
+    AC-2: when union exceeds ``max_pages``, sitemap entries take priority
     over BFS-discovered URLs. ``include_patterns`` (when set) restricts
-    candidates by simple substring match on the path — same semantics
-    as the old crawl4ai URLPatternFilter without the deserialisation
+    candidates by simple substring match on the path — same semantics as
+    the old crawl4ai URLPatternFilter without the deserialisation
     fragility (SPEC-CRAWL-001 v0.8.6 issue).
 
-    The starting URL is always included as candidate index 0 so the
-    homepage is in the bulk fetch and never silently dropped on cap.
+    ``include_start_url`` controls whether ``start_url`` is added as the
+    first candidate. ``crawl_site`` sets it to ``False`` because the seed
+    is fetched separately (with full config including login_indicator) and
+    re-submitting it in the bulk would be a redundant fetch. Even when
+    excluded, ``start_url``'s canonical form is recorded in the dedupe
+    ``seen`` set so a sitemap entry that points back to the homepage
+    doesn't sneak in as a duplicate.
     """
 
     def _same_domain(u: str) -> bool:
@@ -682,9 +827,14 @@ def _build_candidate_set(
         seen.add(canonical)
         ordered.append(u)
 
-    # Priority order: start_url first, then sitemap (site-owner truth),
-    # then BFS-discovered (best-effort).
-    _add(start_url)
+    # Priority order: start_url first (when included), then sitemap (site-
+    # owner truth), then BFS-discovered (best-effort).
+    if include_start_url:
+        _add(start_url)
+    elif start_url:
+        # Reserve start_url's canonical so dedupe excludes it without
+        # adding it to the candidate list.
+        seen.add(_canonicalise_url(start_url))
     for u in sitemap_urls:
         _add(u)
     for u in bfs_seed_urls:

--- a/klai-knowledge-ingest/tests/test_crawl4ai_filter_chain.py
+++ b/klai-knowledge-ingest/tests/test_crawl4ai_filter_chain.py
@@ -9,7 +9,9 @@ substring filter. These tests pin the new behaviour:
 - When ``include_patterns`` is set, only matching candidates reach the
   bulk request body.
 - When ``include_patterns`` is None, every same-domain candidate from
-  sitemap+BFS-union reaches the request body.
+  sitemap + BFS-union reaches the request body — but ``start_url`` is
+  NOT in the bulk submission (it is fetched separately as the seed; see
+  followup PR §"redundant start_url fetch").
 - The crawler_config payload no longer carries a ``deep_crawl_strategy``
   key (regression guard against the legacy BFS path being reintroduced
   alongside the bulk path).
@@ -40,11 +42,24 @@ def _seed_result(url: str, internal_hrefs: list[str]) -> CrawlResult:
     )
 
 
+def _patch_seed(monkeypatch: pytest.MonkeyPatch, seed_result: CrawlResult) -> None:
+    """Stub ``_fetch_seed_page`` so the seed call doesn't hit httpx.
+
+    The bulk path (the focus of these tests) still goes through the real
+    ``httpx.AsyncClient.post`` so the test can capture its payload.
+    """
+
+    async def _fake_seed(*, start_url: str, **_kwargs: Any) -> CrawlResult:
+        return seed_result
+
+    monkeypatch.setattr(crawl4ai_client, "_fetch_seed_page", _fake_seed)
+
+
 @pytest.mark.asyncio
 async def test_crawl_site_applies_include_patterns_to_candidates(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """include_patterns acts as a substring filter on the candidate URL set."""
+    """include_patterns acts as a substring filter on the bulk candidate set."""
     sitemap_urls = [
         "https://wiki.redcactus.cloud/nl/getting-started",
         "https://wiki.redcactus.cloud/en/getting-started",
@@ -58,11 +73,8 @@ async def test_crawl_site_applies_include_patterns_to_candidates(
     async def _fake_sitemap(_base: str) -> list[str]:
         return sitemap_urls
 
-    async def _fake_seed(url: str, **_kwargs: Any) -> CrawlResult:
-        return _seed_result(url, bfs_links)
-
     monkeypatch.setattr(crawl4ai_client, "_fetch_sitemap_urls", _fake_sitemap)
-    monkeypatch.setattr(crawl4ai_client, "crawl_page", _fake_seed)
+    _patch_seed(monkeypatch, _seed_result("https://wiki.redcactus.cloud", bfs_links))
 
     captured: dict[str, Any] = {}
 
@@ -80,13 +92,18 @@ async def test_crawl_site_applies_include_patterns_to_candidates(
             include_patterns=["/nl/"],
         )
 
-    assert results == []
+    # Seed (start_url) is included in results because the synthesised seed
+    # is success + has content + same-domain.
+    assert any(r.url == "https://wiki.redcactus.cloud" for r in results)
+
     payload = captured["payload"]
     urls_submitted = payload["urls"]
     # include_patterns is a substring filter — start_url with empty path
-    # does NOT contain "/nl/" so it is correctly excluded. Every URL that
-    # made it through MUST match.
-    assert urls_submitted, "expected at least one /nl/ candidate to survive"
+    # does not match "/nl/" anyway, but the more important guard is that
+    # it never reaches the bulk request because the seed already covered it.
+    assert "https://wiki.redcactus.cloud" not in urls_submitted, (
+        "start_url must not be in the bulk submission (it is the seed)"
+    )
     for u in urls_submitted:
         assert "/nl/" in u, f"include_patterns leaked a non-/nl/ URL: {u}"
     assert "https://wiki.redcactus.cloud/nl/getting-started" in urls_submitted
@@ -95,29 +112,26 @@ async def test_crawl_site_applies_include_patterns_to_candidates(
     assert "https://wiki.redcactus.cloud/en/getting-started" not in urls_submitted
     assert "https://wiki.redcactus.cloud/en/blog" not in urls_submitted
     assert "deep_crawl_strategy" not in payload["crawler_config"]["params"]
-    # AC-4: every candidate produces an outcome record.
-    assert len(outcomes) == len(urls_submitted)
+    # AC-4: every candidate produces an outcome record. Seed + bulk.
+    assert len(outcomes) == 1 + len(urls_submitted)
 
 
 @pytest.mark.asyncio
 async def test_crawl_site_no_include_patterns_passes_all_same_domain(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Without include_patterns, every same-domain candidate reaches /crawl."""
+    """Without include_patterns, every same-domain non-seed candidate reaches /crawl."""
     sitemap_urls = [
         "https://example.com/page-a",
         "https://example.com/page-b",
-        "https://other.com/skipped",  # cross-domain, must be filtered out by candidate-set
+        "https://other.com/skipped",  # cross-domain, must be filtered out
     ]
 
     async def _fake_sitemap(_base: str) -> list[str]:
         return sitemap_urls
 
-    async def _fake_seed(url: str, **_kwargs: Any) -> CrawlResult:
-        return _seed_result(url, ["https://example.com/page-c"])
-
     monkeypatch.setattr(crawl4ai_client, "_fetch_sitemap_urls", _fake_sitemap)
-    monkeypatch.setattr(crawl4ai_client, "crawl_page", _fake_seed)
+    _patch_seed(monkeypatch, _seed_result("https://example.com", ["https://example.com/page-c"]))
 
     captured: dict[str, Any] = {}
 
@@ -135,7 +149,10 @@ async def test_crawl_site_no_include_patterns_passes_all_same_domain(
 
     payload = captured["payload"]
     urls_submitted = payload["urls"]
-    assert "https://example.com" in urls_submitted
+    # start_url is the seed — not in the bulk submission.
+    assert "https://example.com" not in urls_submitted, (
+        "start_url must not be in the bulk submission (it is the seed)"
+    )
     assert "https://example.com/page-a" in urls_submitted
     assert "https://example.com/page-b" in urls_submitted
     assert "https://example.com/page-c" in urls_submitted

--- a/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
+++ b/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
@@ -248,12 +248,32 @@ class TestClassifyFetchOutcome:
 # ---------------------------------------------------------------------------
 
 
+def _seed(url: str, *, success: bool = True, internal: list[str] | None = None) -> CrawlResult:
+    """Build a CrawlResult shaped like a seed-page response."""
+    return CrawlResult(
+        url=url,
+        fit_markdown="seed" if success else "",
+        raw_markdown="seed" if success else "",
+        html="<html></html>" if success else "",
+        word_count=1 if success else 0,
+        success=success,
+        links={"internal": [{"href": h, "text": ""} for h in (internal or [])]},
+    )
+
+
+def _patch_seed(monkeypatch: pytest.MonkeyPatch, seed_result: CrawlResult) -> None:
+    async def _fake(*, start_url: str, **_kwargs: Any) -> CrawlResult:
+        return seed_result
+
+    monkeypatch.setattr(crawl4ai_client, "_fetch_seed_page", _fake)
+
+
 @pytest.mark.asyncio
 async def test_crawl_site_bulk_transport_failure_records_one_outcome_per_candidate(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """AC-4: even when the whole bulk request fails, every candidate URL
-    gets an outcome record. No URL is silently lost."""
+    (seed + bulk) gets an outcome record. No URL is silently lost."""
 
     async def _fake_sitemap(_base: str) -> list[str]:
         return [
@@ -262,19 +282,8 @@ async def test_crawl_site_bulk_transport_failure_records_one_outcome_per_candida
             "https://example.com/page-c",
         ]
 
-    async def _fake_seed(url: str, **_kwargs: Any) -> CrawlResult:
-        return CrawlResult(
-            url=url,
-            fit_markdown="seed",
-            raw_markdown="seed",
-            html="<html></html>",
-            word_count=1,
-            success=True,
-            links={"internal": []},
-        )
-
     monkeypatch.setattr(crawl4ai_client, "_fetch_sitemap_urls", _fake_sitemap)
-    monkeypatch.setattr(crawl4ai_client, "crawl_page", _fake_seed)
+    _patch_seed(monkeypatch, _seed("https://example.com"))
 
     async def _fake_post(self: httpx.AsyncClient, url: str, **_kwargs: Any) -> httpx.Response:
         raise httpx.ReadTimeout("simulated bulk timeout")
@@ -285,14 +294,20 @@ async def test_crawl_site_bulk_transport_failure_records_one_outcome_per_candida
             max_pages=10,
         )
 
-    # Whole-batch transport failure: no successful CrawlResults but every
-    # candidate (start_url + 3 sitemap entries) gets a TIMEOUT outcome.
-    assert results == []
+    # Seed (start_url) succeeded → 1 result, 1 SUCCESS outcome.
+    # Bulk timed out → 3 candidates each get a TIMEOUT outcome.
+    assert len(results) == 1
+    assert results[0].url == "https://example.com"
     assert len(outcomes) == 4
+
+    by_url = {o["url"]: o for o in outcomes}
+    assert by_url["https://example.com"]["reason_code"] == FetchReasonCode.SUCCESS.value
+    for url in ("https://example.com/page-a", "https://example.com/page-b", "https://example.com/page-c"):
+        assert by_url[url]["reason_code"] == FetchReasonCode.TIMEOUT.value
+        assert by_url[url]["status_code"] is None
+
+    # Shape sanity — all four required keys present on every outcome.
     for outcome in outcomes:
-        assert outcome["reason_code"] == FetchReasonCode.TIMEOUT.value
-        assert outcome["status_code"] is None
-        # Shape sanity — all four required keys present.
         assert set(outcome.keys()) == {"url", "reason_code", "status_code", "content_length"}
 
 
@@ -300,7 +315,8 @@ async def test_crawl_site_bulk_transport_failure_records_one_outcome_per_candida
 async def test_crawl_site_returns_one_outcome_per_candidate_on_partial_success(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """AC-4 + AC-5: per-URL outcomes classify each candidate distinctly."""
+    """AC-4 + AC-5: per-URL outcomes classify each candidate distinctly,
+    including the seed."""
 
     async def _fake_sitemap(_base: str) -> list[str]:
         return [
@@ -309,31 +325,13 @@ async def test_crawl_site_returns_one_outcome_per_candidate_on_partial_success(
             "https://example.com/server-error",
         ]
 
-    async def _fake_seed(url: str, **_kwargs: Any) -> CrawlResult:
-        return CrawlResult(
-            url=url,
-            fit_markdown="x",
-            raw_markdown="x",
-            html="<html></html>",
-            word_count=1,
-            success=True,
-            links={"internal": []},
-        )
-
     monkeypatch.setattr(crawl4ai_client, "_fetch_sitemap_urls", _fake_sitemap)
-    monkeypatch.setattr(crawl4ai_client, "crawl_page", _fake_seed)
+    _patch_seed(monkeypatch, _seed("https://example.com"))
 
-    response_body = {
+    # Bulk response — start_url is NOT in the request body, so the response
+    # body MUST NOT include it either.
+    bulk_response = {
         "results": [
-            {
-                "url": "https://example.com",
-                "success": True,
-                "status_code": 200,
-                "html": "<html>seed</html>",
-                "markdown": "seed",
-                "links": {"internal": []},
-                "media": {},
-            },
             {
                 "url": "https://example.com/ok",
                 "success": True,
@@ -368,7 +366,7 @@ async def test_crawl_site_returns_one_outcome_per_candidate_on_partial_success(
 
     async def _fake_post(self: httpx.AsyncClient, url: str, **_kwargs: Any) -> httpx.Response:
         request = httpx.Request("POST", url)
-        return httpx.Response(200, json=response_body, request=request)
+        return httpx.Response(200, json=bulk_response, request=request)
 
     with patch("httpx.AsyncClient.post", new=_fake_post):
         results, outcomes = await crawl4ai_client.crawl_site(
@@ -381,8 +379,219 @@ async def test_crawl_site_returns_one_outcome_per_candidate_on_partial_success(
     assert by_url["https://example.com"]["reason_code"] == FetchReasonCode.SUCCESS.value
     assert by_url["https://example.com/ok"]["reason_code"] == FetchReasonCode.SUCCESS.value
     assert by_url["https://example.com/missing"]["reason_code"] == FetchReasonCode.HTTP_4XX.value
-    server_error_outcome = by_url["https://example.com/server-error"]
-    assert server_error_outcome["reason_code"] == FetchReasonCode.HTTP_5XX.value
-    # Two same-domain successful pages reach the ingest loop.
-    assert len(results) == 2
+    assert (
+        by_url["https://example.com/server-error"]["reason_code"]
+        == FetchReasonCode.HTTP_5XX.value
+    )
+    # Two same-domain successful pages reach the ingest loop: seed + /ok.
     assert {r.url for r in results} == {"https://example.com", "https://example.com/ok"}
+
+
+# ---------------------------------------------------------------------------
+# Followup PR — start_url is fetched once (no bulk re-fetch)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_crawl_site_does_not_double_fetch_start_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The seed call covers ``start_url``; the bulk submission MUST NOT include it."""
+
+    async def _fake_sitemap(_base: str) -> list[str]:
+        return ["https://example.com/page-a"]
+
+    monkeypatch.setattr(crawl4ai_client, "_fetch_sitemap_urls", _fake_sitemap)
+    _patch_seed(monkeypatch, _seed("https://example.com"))
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_post(self: httpx.AsyncClient, url: str, **kwargs: Any) -> httpx.Response:
+        captured["payload"] = kwargs.get("json")
+        request = httpx.Request("POST", url)
+        return httpx.Response(200, json={"results": []}, request=request)
+
+    with patch("httpx.AsyncClient.post", new=_fake_post):
+        await crawl4ai_client.crawl_site(start_url="https://example.com", max_pages=10)
+
+    urls_submitted = captured["payload"]["urls"]
+    assert "https://example.com" not in urls_submitted, (
+        "start_url must not appear in the bulk submission — that would re-fetch the seed"
+    )
+    assert urls_submitted == ["https://example.com/page-a"]
+
+
+# ---------------------------------------------------------------------------
+# Followup PR — login_indicator_selector is propagated to the seed config.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_seed_config_carries_login_indicator(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Seed fetch MUST use the same crawler_config (incl. login_indicator) as bulk.
+
+    Regression guard: an earlier implementation used ``crawl_page(start_url)``
+    for the seed, and ``crawl_page`` builds its own config without the
+    login_indicator kwarg. That meant for auth-walled sites the seed
+    "succeeded" on the login page, the BFS link list became
+    login-form anchors, and the bulk ran into AUTH_ERROR on every URL.
+    """
+    captured_seed_config: dict[str, Any] = {}
+
+    async def _fake_seed_call(
+        *,
+        start_url: str,
+        crawler_config: dict[str, Any],
+        cookies: Any,
+    ) -> CrawlResult:
+        captured_seed_config.update(crawler_config)
+        return _seed(start_url)
+
+    monkeypatch.setattr(crawl4ai_client, "_fetch_seed_page", _fake_seed_call)
+    monkeypatch.setattr(
+        crawl4ai_client, "_fetch_sitemap_urls", lambda _base: _async_return([])
+    )
+
+    async def _fake_post(self: httpx.AsyncClient, url: str, **_kwargs: Any) -> httpx.Response:
+        request = httpx.Request("POST", url)
+        return httpx.Response(200, json={"results": []}, request=request)
+
+    with patch("httpx.AsyncClient.post", new=_fake_post):
+        await crawl4ai_client.crawl_site(
+            start_url="https://wiki.example",
+            login_indicator_selector="#loginForm",
+        )
+
+    # The captured seed config MUST reflect the login_indicator: build_crawl_config
+    # negates the wait_for expression with the indicator selector when set.
+    wait_for = captured_seed_config.get("wait_for", "")
+    assert "#loginForm" in wait_for, (
+        f"seed config did not propagate login_indicator_selector — wait_for was {wait_for!r}"
+    )
+
+
+def _async_return(value: Any):
+    """Wrap a value in an awaitable so it can be used as an async stub return."""
+
+    async def _coro(*_args: Any, **_kwargs: Any) -> Any:
+        return value
+
+    return _coro()
+
+
+# ---------------------------------------------------------------------------
+# Followup PR — redirect-aware response matching (positional fallback)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_crawl_site_matches_redirect_response_positionally(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A candidate that gets redirected (response.url != candidate.url)
+    MUST still match — not become UNKNOWN_EXCEPTION via canonical miss."""
+
+    async def _fake_sitemap(_base: str) -> list[str]:
+        return [
+            "https://example.com/old-page",  # this one will redirect
+            "https://example.com/stable",  # direct hit
+        ]
+
+    monkeypatch.setattr(crawl4ai_client, "_fetch_sitemap_urls", _fake_sitemap)
+    _patch_seed(monkeypatch, _seed("https://example.com"))
+
+    bulk_response = {
+        "results": [
+            # response[0].url is the REDIRECT TARGET, not the candidate
+            {
+                "url": "https://example.com/new-page",
+                "success": True,
+                "status_code": 200,
+                "html": "<html>redirected content</html>",
+                "markdown": "redirected content",
+                "links": {"internal": []},
+                "media": {},
+            },
+            # response[1] matches the candidate directly
+            {
+                "url": "https://example.com/stable",
+                "success": True,
+                "status_code": 200,
+                "html": "<html>stable</html>",
+                "markdown": "stable",
+                "links": {"internal": []},
+                "media": {},
+            },
+        ]
+    }
+
+    async def _fake_post(self: httpx.AsyncClient, url: str, **_kwargs: Any) -> httpx.Response:
+        request = httpx.Request("POST", url)
+        return httpx.Response(200, json=bulk_response, request=request)
+
+    with patch("httpx.AsyncClient.post", new=_fake_post):
+        results, outcomes = await crawl4ai_client.crawl_site(
+            start_url="https://example.com",
+            max_pages=10,
+        )
+
+    by_url = {o["url"]: o for o in outcomes}
+    # The redirected candidate MUST be classified as SUCCESS, not UNKNOWN_EXCEPTION.
+    assert by_url["https://example.com/old-page"]["reason_code"] == FetchReasonCode.SUCCESS.value
+    assert by_url["https://example.com/stable"]["reason_code"] == FetchReasonCode.SUCCESS.value
+    # Both bulk candidates produced ingestable results (plus the seed).
+    result_urls = {r.url for r in results}
+    assert "https://example.com/new-page" in result_urls  # post-redirect URL preserved
+    assert "https://example.com/stable" in result_urls
+
+
+# ---------------------------------------------------------------------------
+# Followup PR — _build_candidate_set with include_start_url=False
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCandidateSetExcludeStartUrl:
+    def test_excludes_start_url_from_output(self) -> None:
+        candidates = _build_candidate_set(
+            start_url="https://example.com",
+            sitemap_urls=["https://example.com/page-a"],
+            bfs_seed_urls=["https://example.com/page-b"],
+            base_domain="example.com",
+            max_pages=10,
+            include_patterns=None,
+            include_start_url=False,
+        )
+        assert "https://example.com" not in candidates
+        assert candidates == [
+            "https://example.com/page-a",
+            "https://example.com/page-b",
+        ]
+
+    def test_excludes_start_url_alias_in_dedupe(self) -> None:
+        """A sitemap entry that canonical-equals start_url is also excluded
+        when include_start_url=False — guards against re-introducing the
+        double fetch via a sitemap that lists the homepage."""
+        candidates = _build_candidate_set(
+            start_url="https://example.com",
+            # Variant spellings of start_url that all canonicalise to it.
+            sitemap_urls=[
+                "https://example.com/",  # trailing slash on root → canonical "/"
+                "HTTPS://Example.com",  # mixed case
+                "https://example.com#frag",  # fragment
+                "https://example.com/page",  # legitimate non-homepage
+            ],
+            bfs_seed_urls=[],
+            base_domain="example.com",
+            max_pages=10,
+            include_patterns=None,
+            include_start_url=False,
+        )
+        assert "https://example.com/page" in candidates
+        # None of the start_url-variant spellings should leak through.
+        for candidate in candidates:
+            assert candidate not in (
+                "https://example.com",
+                "https://example.com/",
+                "HTTPS://Example.com",
+                "https://example.com#frag",
+            ), f"start_url variant {candidate} leaked through include_start_url=False"

--- a/klai-knowledge-ingest/tests/test_reason_codes_parity.py
+++ b/klai-knowledge-ingest/tests/test_reason_codes_parity.py
@@ -1,0 +1,61 @@
+"""SPEC-INGEST-RECONCILE-001 AC-9 — symmetric parity test (knowledge-ingest side).
+
+Mirrors :mod:`klai-connector/tests/test_reason_codes_parity.py`. The two
+service copies of ``reason_codes.py`` MUST stay aligned: a value added
+to one without the other turns into either a silent dashboard category
+(if the connector writes a key knowledge-ingest doesn't recognise) or a
+Postgres CHECK violation at runtime (if knowledge-ingest writes a key
+connector's migration 009 doesn't allow).
+
+The connector-side test fails when run from the connector test suite;
+this test fails when run from knowledge-ingest. Either entry point in
+CI catches drift — there is no "tested only by the other guy" gap.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+from knowledge_ingest.reason_codes import (
+    FETCH_REASON_VALUES as KI_FETCH,
+)
+from knowledge_ingest.reason_codes import (
+    PERSIST_SKIP_REASON_VALUES as KI_PERSIST,
+)
+
+
+def _load_connector_reason_codes():
+    """Import the klai-connector copy from the sibling service path."""
+    repo_root = Path(__file__).resolve().parents[2]
+    target = repo_root / "klai-connector" / "app" / "reason_codes.py"
+    if not target.exists():  # pragma: no cover — repo layout invariant
+        pytest.skip(f"klai-connector reason_codes.py not found at {target}")
+    spec = importlib.util.spec_from_file_location("_connector_reason_codes", target)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_connector_reason_codes"] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_fetch_reason_values_match_connector_copy() -> None:
+    connector = _load_connector_reason_codes()
+    assert KI_FETCH == connector.FETCH_REASON_VALUES, (
+        "FetchReasonCode drift between klai-knowledge-ingest and klai-connector. "
+        f"Knowledge-ingest-only: {KI_FETCH - connector.FETCH_REASON_VALUES}; "
+        f"Connector-only: {connector.FETCH_REASON_VALUES - KI_FETCH}"
+    )
+
+
+def test_persist_skip_reason_values_match_connector_copy() -> None:
+    connector = _load_connector_reason_codes()
+    assert KI_PERSIST == connector.PERSIST_SKIP_REASON_VALUES, (
+        "PersistSkipReason drift between klai-knowledge-ingest and klai-connector. "
+        f"Knowledge-ingest-only: {KI_PERSIST - connector.PERSIST_SKIP_REASON_VALUES}; "
+        f"Connector-only: {connector.PERSIST_SKIP_REASON_VALUES - KI_PERSIST}"
+    )


### PR DESCRIPTION
## Followup to SPEC-INGEST-RECONCILE-001 (PRs #440 + #443)

Adversarial pass over the freshly-shipped SPEC surfaced three latent issues + one regression. None of these are reported in production yet — fixing now is cheaper than after the next auth-walled connector or redirect-heavy sitemap hits.

### 1. \`start_url\` was fetched twice per \`crawl_site\` call

\`_bfs_discover_seed_urls\` called \`crawl_page(start_url)\` to extract internal links, AND \`_build_candidate_set\` re-included \`start_url\` as candidate index 0. crawl4ai fetched the homepage a second time via the bulk \`/crawl\` request.

Cost: ~0.5% on a 200-page Voys/support crawl, ~20% on a 5-page connector. Plus duplicate dispatcher slot.

**Fix:** \`_fetch_seed_page\` returns the seed \`CrawlResult\` directly; \`_build_candidate_set\` takes \`include_start_url=False\` to exclude start_url AND record its canonical in the dedupe \`seen\` set so a sitemap entry pointing back to the homepage doesn't sneak in.

### 2. \`login_indicator_selector\` silently dropped on the seed (regression)

The seed went through \`crawl_page\` which builds its config from \`selector\` only — no \`login_indicator_selector\` kwarg. For auth-walled sites:

- Seed returned the **login page** as \`success=True\`
- BFS link list became **login-form anchors**
- Bulk \`/crawl\` ran with the correct config and returned \`AUTH_ERROR\` for every URL
- Operator saw "all candidates auth-walled" but no signal that the seed itself was misclassified

This is latent because no production connector with \`login_indicator_selector\` + sitemap has been triggered post-SPEC. Voys' Kayako connector ships with \`login_indicator_selector\` and would have hit this on next sync.

**Fix:** \`_fetch_seed_page\` calls \`_crawl_sync\` directly with the same \`crawler_config\` (incl. \`login_indicator_selector\`) that the bulk path uses. Regression test \`test_seed_config_carries_login_indicator\` pins it.

### 3. Redirected candidates classified \`UNKNOWN_EXCEPTION\`

crawl4ai's bulk response sets \`response.url\` to the **redirect target**. Building \`by_url\` keyed on \`canonical(response.url)\` and looking up by \`canonical(candidate)\` misses any candidate that 30x-redirected, producing a fake silent failure (\`page=None\` → \`UNKNOWN_EXCEPTION\`).

**Fix:** \`_combine_bulk_responses\` adds a positional fallback — when canonical lookup misses AND \`len(raw_results) == len(candidates)\` AND that response index hasn't been claimed by canonical match AND its URL doesn't canonical-match a different candidate, match by index. Bounded to one claim per index so redirects don't shadow legitimate direct hits. Regression test \`test_crawl_site_matches_redirect_response_positionally\` pins it.

### 4. Reason-code parity test was asymmetric

The connector-side test loaded knowledge-ingest's \`reason_codes.py\`. If knowledge-ingest's enums drifted and only knowledge-ingest tests ran, drift went undetected.

**Fix:** symmetric mirror at \`klai-knowledge-ingest/tests/test_reason_codes_parity.py\` — loads connector's copy from sibling path. CI now catches drift from either entry point.

## Refactor — module-private helpers

\`crawl_site\`'s body shrank to four discrete steps; the moving parts moved into named helpers for testability and review-clarity:

| Helper | Role |
|---|---|
| \`_fetch_seed_page\` | One bulk-config-aware fetch of \`start_url\`, returns CrawlResult |
| \`_extract_bfs_seeds\` | Same-domain internal-link extraction from a seed CrawlResult |
| \`_build_outcome_from_result\` | CrawlResult → fetch_outcomes JSONB entry (seed path) |
| \`_result_is_ingestable\` | The legacy ingest-loop contract (success + non-empty + same-domain) |
| \`_combine_bulk_responses\` | Canonical + positional matching of candidates → responses |

\`_build_candidate_set\` now takes \`include_start_url: bool = True\` (default preserves existing call-sites if any).

## Test status

- 69 touched-path tests pass (was 47 before the followup added 7 new tests + 22 from the existing suite)
- Ruff clean on all modified files
- Connector-side parity test still 5/5

## Rollout

After merge:
1. CI deploys new \`klai-knowledge-ingest\` image.
2. Next auth-walled connector sync correctly surfaces auth-walled seed via \`fetch_outcomes\` instead of poisoning BFS with login-form anchors.
3. Redirect-heavy connectors (any site with rewrites or canonical-URL redirects) classify outcomes correctly instead of false UNKNOWN_EXCEPTION.

🤖 Generated with [Claude Code](https://claude.com/claude-code)