### PR TITLE
chore(SPEC-002): adversarial-review follow-ups (pitfall, CI guard, defensiveness)

### DIFF
--- a/.claude/rules/klai/pitfalls/process-rules.md
+++ b/.claude/rules/klai/pitfalls/process-rules.md
@@ -1558,3 +1558,84 @@ deze guard nodig — refuse-by-default + getypte-string-override-input.
 Niet alleen voor SOPS env: ook voor migrations die DROP TABLE doen,
 voor terraform destroy, voor docker prune in CI. De pattern is
 generic: destructieve ops moeten een getypte intent-bewijs hebben.
+
+## alembic-multi-pr-head-split (CRIT)
+
+When two PRs each add an Alembic migration with the same `down_revision`,
+both PR builds pass green (each migration in isolation is valid) but
+production crashes on `alembic upgrade head` with:
+
+```
+Multiple head revisions are present for given argument 'head'
+```
+
+The merge-first PR lands cleanly. The second-merging PR turns the chain
+into two heads. `alembic upgrade head` refuses to proceed because the
+target is ambiguous; the entrypoint loops on `FAILED` and the container
+restartloops.
+
+Klai hit this twice on 2026-05-06 inside one hour:
+
+1. PR #440 (SPEC-INGEST-RECONCILE-001) added `0005_crawl_jobs_fetch_outcomes`
+   chained on `603787256fb8`.
+2. PR #441 (SPEC-INGEST-LOGIN-WALL-DETECT-002) added `0005_crawled_pages_simhash`
+   chained on the same `603787256fb8`.
+
+#440 merged 7 minutes before #441. Production deployed `:latest` after
+#441 and the knowledge-ingest container restartlooped for ~5 minutes
+until hotfix #442 rebased the second migration onto the first
+(`down_revision`: `603787256fb8` → `a8c5e1d2f3b4`). #443 added a no-op
+merge migration in parallel for belt-and-braces.
+
+The schema columns themselves were independent (`crawl_jobs.fetch_outcomes`
+vs `crawled_pages.content_simhash` — different tables) so no data
+corruption happened; only the alembic graph needed linearisation.
+
+**Prevention (process):**
+
+1. **Before merging an alembic migration, rebase if main has moved.** A
+   PR built on yesterday's `main` whose chain still references the
+   yesterday-head is NOT mergeable today if another migration landed on
+   the same parent. Treat alembic as a serial resource: the moment a
+   migration lands on main, ALL other open PRs with an alembic
+   migration are stale.
+
+2. **Run `alembic heads` in CI on every PR build.** The check is offline
+   (no DB needed) and catches the head split at PR-build time, not at
+   container-start time. Add to the existing build-push workflow:
+   ```yaml
+   - name: Verify single alembic head
+     run: |
+       cd klai-knowledge-ingest
+       heads=$(alembic heads | wc -l)
+       if [ "$heads" -ne 1 ]; then
+         echo "::error::Multiple alembic heads detected (got $heads, expected 1)"
+         alembic heads
+         exit 1
+       fi
+   ```
+   This is the only protection that doesn't depend on developer
+   discipline. Same pattern applies to all 4 services with alembic
+   migrations: knowledge-ingest, connector, portal-api, scribe.
+
+3. **When the head split DOES land in production**, two equally valid
+   recoveries:
+   - **Rebase** the second-merging migration onto the first head
+     (preferred when the migration files are still recent and rename
+     is cheap). What #442 did.
+   - **Merge migration** that declares both heads as parents with a
+     no-op body. What #443 did. Useful when the rebase would require
+     coordinating across teams or downgrade safety matters.
+
+   Both are safe and additive. Doing both at once is also safe (one
+   becomes redundant); pick one.
+
+4. **The compose-up restart loop is the loud signal.** If a
+   `:latest`-image deploy puts a container in `Restarting` state with
+   `failed: alembic upgrade head` in logs, the head-split is the most
+   common cause for any service with > 1 alembic migration in flight.
+   Check `alembic heads` first before debugging any other symptom.
+
+Reference: PR #441 → crashloop → hotfix #442 (rebase) + #443 (merge
+migration). Operator timeline: 5 minutes from deploy to crashloop, 13
+minutes from crashloop to recovered deploy.

--- a/.github/workflows/knowledge-ingest.yml
+++ b/.github/workflows/knowledge-ingest.yml
@@ -55,6 +55,31 @@ jobs:
           config: sgconfig.yml
           paths: klai-knowledge-ingest/knowledge_ingest/
 
+      # Pitfall: alembic-multi-pr-head-split (process-rules.md). Two PRs
+      # each adding a migration with the same down_revision both build
+      # green individually but the second-merging one creates two
+      # alembic heads, blocking `alembic upgrade head` at container
+      # start. This offline guard runs on every PR + push and rejects
+      # any state with > 1 head before merge instead of in production.
+      - name: Guard — single alembic head (knowledge schema)
+        run: |
+          set -euo pipefail
+          cd klai-knowledge-ingest
+          pipx install --quiet alembic==1.16.5
+          heads=$(alembic heads 2>&1 | grep -E "\(head\)$" | wc -l | tr -d ' ')
+          if [ "$heads" -ne 1 ]; then
+            echo "::error::Multiple alembic heads detected (got $heads, expected 1)"
+            alembic heads
+            echo
+            echo "Hotfix: rebase the second-merging migration's down_revision"
+            echo "onto the first head, OR add a no-op merge migration with"
+            echo "down_revision = (head_a, head_b). See"
+            echo ".claude/rules/klai/pitfalls/process-rules.md"
+            echo "(alembic-multi-pr-head-split)."
+            exit 1
+          fi
+          echo "OK — single alembic head"
+
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:

--- a/.moai/specs/SPEC-INGEST-LOGIN-WALL-DETECT-002/acceptance.md
+++ b/.moai/specs/SPEC-INGEST-LOGIN-WALL-DETECT-002/acceptance.md
@@ -182,13 +182,42 @@ Then every page in (org_id, kb_slug) has a non-NULL content_simhash after
 ### AC-04.2: Backfill purges template clusters
 
 ```gherkin
-Given voys/support before backfill (149 RedCactus walls + 273 other pages)
+Given voys/support before backfill (template-stub pages + non-stub pages)
   And no SimHashes are populated yet
 When backfill_detect_login_walls runs
-Then the result reports {"processed": 422, "flagged": 149, "qdrant_deleted": 149}
+Then the result reports the cluster members as flagged
   And each flagged page has content_hash = '__login_wall_purged__'
   And none of the 5 known FP URLs is flagged
 ```
+
+**Production result (2026-05-06 rollout, voys/support):**
+
+The SQL pre-filters rows already at ``__login_wall_purged__`` (= 150
+v1-purged rows from PR #419). The remaining 272 active rows ran through
+v2 clustering. 199 of those 272 hit the cluster threshold and were
+flagged + Qdrant-deleted + placeholder-set:
+
+```
+{"processed": 272, "flagged": 199, "qdrant_deleted": 199}
+```
+
+The validation script (read-only, sees ALL rows including v1-purged)
+reports the larger union — 4 connected components of sizes
+``[214, 74, 25, 3]`` totalling **316 wall pages**, all under
+``wiki.redcactus.cloud``. The 117 difference (316 − 199) is the v1-
+purged subset already at placeholder; backfill leaves them alone.
+
+**v2 vs v1 effectiveness:** v1's phrase-substring detector found 150;
+v2's clustering finds 316. The 166 extra pages have the same boilerplate
+template as v1's 150 but their phrasing varies enough that no canonical
+phrase matched. v2's structural detection generalises across phrasing
+variants. The SPEC's drafted "149 walls" estimate was pulled from the
+v1 phrase-distribution count, not the v2 cluster count.
+
+The exact ``flagged`` number depends on how many pages are already at
+the placeholder hash on the day backfill runs; tests pin behaviour for
+a synthetic 6-page cluster (see ``tests/test_backfill_login_walls.py``)
+rather than a fixed production count.
 
 ### AC-04.3: Idempotency
 
@@ -227,6 +256,34 @@ Then the result reports {"processed": 1, "recovered": 1}
   And /2fa-freedom's content_hash is now empty string
   And the next scheduled crawl re-ingests it normally
 ```
+
+**Recovery semantics — re-purge after re-crawl (operational note):**
+
+A "recovered" placeholder does NOT mean the page is permanently a
+not-wall. It means the page's STORED ``raw_markdown`` (frozen from the
+v1-purge era) is no longer in a cluster under v2 — the cluster of
+matching pages either shrank (other members were purged or evolved) or
+the stored markdown predates the current template.
+
+When the next scheduled crawl re-fetches the URL, crawl4ai returns the
+CURRENT page content. If the source CMS still serves a templated stub
+to anonymous visitors, the new ``raw_markdown`` will fingerprint into
+the active wall cluster and v2's ingest-time detector will re-flag the
+page (mode=reject by default). Net effect: the page transitions from
+purged-stale → temporarily un-purged → re-purged-with-current-data.
+
+**Production observation (2026-05-06 rollout):** voys/support recovery
+returned ``{"processed": 349, "recovered": 33}``. Of those 33 recovery
+candidates, 32 are ``wiki.redcactus.cloud/...`` URLs whose stored
+markdown predates the current v2-detected wall cluster — they will
+re-purge after re-crawl. 1 is ``https://help.voys.nl/2fa-freedom``, a
+real Voys tutorial that v1 mistakenly phrase-matched and v2 correctly
+exonerates; this one will stay un-purged after re-crawl.
+
+Operators should expect the apparent recovered-count to shrink toward
+the "true FPs" count (roughly 1-of-33 here) as scheduled crawls
+re-evaluate the candidates. This is correct, self-healing behaviour;
+NOT a regression in v2.
 
 ### AC-05.2: No spurious recovery
 

--- a/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
+++ b/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
@@ -429,7 +429,15 @@ async def _ingest_crawl_result(
     # cluster against it. Computed unconditionally — even with detection
     # disabled, the fingerprint is needed for the operator-triggered
     # backfill / validation script.
-    page_simhash = compute_simhash(text)
+    #
+    # Empty / whitespace-only content yields ``compute_simhash == 0``. Storing
+    # 0 would let "empty" pages cluster together (all match Hamming 0), which
+    # would falsely flag a tenant whose crawl results were 5+ rendered-but-
+    # empty pages. We treat the missing-content case as "no fingerprint" by
+    # leaving content_simhash NULL, matching the cold-start contract.
+    page_simhash: int | None = compute_simhash(text)
+    if page_simhash == 0:
+        page_simhash = None
 
     # SPEC-INGEST-LOGIN-WALL-DETECT-002 REQ-02 — anonymous-crawl auth-wall
     # detection by SimHash near-duplicate clustering. Runs AFTER dedup (don't
@@ -572,14 +580,16 @@ async def _ingest_crawl_result(
     # SPEC-INGEST-LOGIN-WALL-DETECT-002 REQ-01 — persist the page's SimHash
     # so the next crawl in this KB can include it in cluster lookups. Done
     # AFTER upsert_crawled_page so the row exists; the helper does an UPDATE
-    # by (org_id, kb_slug, url).
-    await pg_store.update_crawled_page_simhash(
-        conn,
-        org_id=org_id,
-        kb_slug=kb_slug,
-        url=url,
-        content_simhash=page_simhash,
-    )
+    # by (org_id, kb_slug, url). Skipped for empty/whitespace-only content
+    # (page_simhash is None) so 0-fingerprints never reach the DB.
+    if page_simhash is not None:
+        await pg_store.update_crawled_page_simhash(
+            conn,
+            org_id=org_id,
+            kb_slug=kb_slug,
+            url=url,
+            content_simhash=page_simhash,
+        )
 
 
 async def _update_job(

--- a/klai-knowledge-ingest/knowledge_ingest/backfill_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/backfill_tasks.py
@@ -79,11 +79,21 @@ def _count_cluster_siblings(
     O(N) per call, O(N^2) over the whole KB. Acceptable at klai's scale
     (low thousands per KB; SPEC REQ-08 budgets 50 ms per cluster query at
     1000-page KB). LSH banding is deferred — see research.md §4.2.
+
+    ``compute_simhash`` returns 0 for empty / whitespace-only normalised
+    content. Pages with hash 0 share "nothing" rather than a template, so
+    they MUST NOT cluster with each other; the crawler skips storing 0
+    fingerprints, but legacy rows from before that guard could still
+    surface here. Filter both directions: a 0-target returns 0, and
+    0-siblings are not counted.
     """
+    if target_hash == 0:
+        return 0
     return sum(
         1
         for other_url, other_hash in url_to_hash.items()
         if other_url != target_url
+        and other_hash != 0
         and hamming_distance(target_hash, other_hash) <= hamming_max
     )
 
@@ -112,13 +122,17 @@ async def _ensure_simhashes(
         sh = row["content_simhash"]
         if sh is None:
             sh = compute_simhash(row["raw_markdown"] or "")
-            await pg_store.update_crawled_page_simhash(
-                conn,
-                org_id=org_id,
-                kb_slug=kb_slug,
-                url=row["url"],
-                content_simhash=sh,
-            )
+            # 0 is the empty-content sentinel; do not persist it (would let
+            # rendered-but-empty crawl results falsely cluster). Match the
+            # crawler's ingest-time behaviour and leave the column NULL.
+            if sh != 0:
+                await pg_store.update_crawled_page_simhash(
+                    conn,
+                    org_id=org_id,
+                    kb_slug=kb_slug,
+                    url=row["url"],
+                    content_simhash=sh,
+                )
         url_to_hash[row["url"]] = sh
     return url_to_hash
 

--- a/klai-knowledge-ingest/knowledge_ingest/pg_store.py
+++ b/klai-knowledge-ingest/knowledge_ingest/pg_store.py
@@ -721,16 +721,31 @@ async def update_crawled_page_simhash(
     Called after ``upsert_crawled_page`` (so the row exists). Idempotent: a
     re-run with the same hash is a no-op write. Tenant-scoped: the WHERE
     clause filters by ``org_id`` AND ``kb_slug`` AND ``url``.
+
+    Uses ``RETURNING url`` so we notice the race where the row was deleted
+    or never inserted between ``upsert_crawled_page`` and this call. A
+    silent zero-row UPDATE would leave ``content_simhash`` NULL forever
+    while the rest of the ingest path assumed the fingerprint is stored.
+    Logs a structlog warning instead of raising — fingerprint storage is
+    not critical-path; the next backfill pass populates the value.
     """
-    await conn.execute(
+    returned = await conn.fetchval(
         "UPDATE knowledge.crawled_pages "
         "SET content_simhash = $1 "
-        "WHERE org_id = $2 AND kb_slug = $3 AND url = $4",
+        "WHERE org_id = $2 AND kb_slug = $3 AND url = $4 "
+        "RETURNING url",
         content_simhash,
         org_id,
         kb_slug,
         url,
     )
+    if returned is None:
+        logger.warning(
+            "crawled_pages_simhash_update_no_row",
+            org_id=org_id,
+            kb_slug=kb_slug,
+            url=url,
+        )
 
 
 async def upsert_crawled_page(

--- a/klai-knowledge-ingest/tests/conftest.py
+++ b/klai-knowledge-ingest/tests/conftest.py
@@ -93,6 +93,27 @@ def mock_pool():
     return _make_mock_pool()
 
 
+def make_pg_store_mock():
+    """All-async mock for the ``knowledge_ingest.pg_store`` module.
+
+    Returns an :class:`AsyncMock` with ``spec=pg_store`` so every helper
+    (existing AND any future addition) is auto-mocked as an async no-op.
+    Use this in new tests instead of ``MagicMock()`` plus manual per-method
+    ``AsyncMock`` assignments — that pattern silently breaks every time a
+    new pg_store helper is added (e.g.
+    ``update_crawled_page_simhash`` from SPEC-INGEST-LOGIN-WALL-DETECT-002).
+    Existing tests are not retroactively migrated; the helper is opt-in.
+    """
+    import knowledge_ingest.pg_store as _pg_store_module
+
+    return AsyncMock(spec=_pg_store_module)
+
+
+@pytest.fixture
+def pg_store_mock():
+    return make_pg_store_mock()
+
+
 @pytest.fixture(autouse=True)
 def _mock_db_helpers(request):
     """Autouse: replace tenant_scoped_connection + cross_org_admin_connection

--- a/klai-knowledge-ingest/tests/test_backfill_login_walls.py
+++ b/klai-knowledge-ingest/tests/test_backfill_login_walls.py
@@ -26,6 +26,7 @@ import pytest
 
 from knowledge_ingest.backfill_tasks import (
     PURGED_PLACEHOLDER_HASH,
+    _count_cluster_siblings,
     backfill_detect_login_walls,
     recover_purged_pages,
 )
@@ -69,7 +70,9 @@ def _walled_cluster(count: int) -> list[dict]:
 
 def _make_conn(rows: list[dict]):
     """asyncpg-like connection mock: ``fetch`` returns ``rows``; ``execute``
-    is recorded for assertion."""
+    + ``fetchval`` are recorded for assertion. ``fetchval`` is required
+    because ``pg_store.update_crawled_page_simhash`` uses ``RETURNING url``
+    to detect race-deleted rows (SPEC-LOGIN-WALL-002 follow-up)."""
     conn = MagicMock()
 
     async def fetch_side_effect(_sql: str, *_args):
@@ -77,6 +80,9 @@ def _make_conn(rows: list[dict]):
 
     conn.fetch = AsyncMock(side_effect=fetch_side_effect)
     conn.execute = AsyncMock(return_value=None)
+    # Default: row found (return any non-None URL). Tests that need to
+    # exercise the no-row warning path override this per-call.
+    conn.fetchval = AsyncMock(return_value="https://x/dummy")
     return conn
 
 
@@ -236,10 +242,11 @@ class TestSimhashBackfillPass:
             kb_slug="support",
         )
 
-        # Each row triggers an UPDATE ... SET content_simhash = $1.
+        # Each row triggers an UPDATE ... SET content_simhash = $1
+        # ... RETURNING url (via conn.fetchval, not conn.execute).
         update_calls = [
             c
-            for c in conn.execute.await_args_list
+            for c in conn.fetchval.await_args_list
             if c.args and "SET content_simhash" in c.args[0]
         ]
         assert len(update_calls) == 6
@@ -266,12 +273,80 @@ class TestSimhashBackfillPass:
 
         update_calls = [
             c
-            for c in conn.execute.await_args_list
+            for c in conn.fetchval.await_args_list
             if c.args and "SET content_simhash" in c.args[0]
         ]
         assert update_calls == [], (
             "content_simhash UPDATE should not run when already populated"
         )
+
+    @pytest.mark.asyncio()
+    async def test_empty_raw_markdown_does_not_store_zero_hash(
+        self, patched_externals
+    ) -> None:
+        """Pages with empty/whitespace raw_markdown produce simhash=0; the
+        backfill MUST NOT persist 0 (would let empty pages cluster across a
+        tenant). Row stays content_simhash=NULL.
+        """
+        conn, _qdrant, set_rows = patched_externals
+        set_rows(
+            [
+                _row(url="https://x/empty-1", raw=""),
+                _row(url="https://x/whitespace", raw="\n\t  "),
+                _row(url="https://x/empty-3", raw=""),
+            ]
+        )
+
+        result = await backfill_detect_login_walls(
+            org_id="368884765035593759",
+            kb_slug="support",
+        )
+
+        assert result["flagged"] == 0
+        update_calls = [
+            c
+            for c in conn.fetchval.await_args_list
+            if c.args and "SET content_simhash" in c.args[0]
+        ]
+        assert update_calls == [], (
+            "Empty-content rows must not have content_simhash=0 written"
+        )
+
+
+class TestZeroHashSafeguard:
+    """The 0 SimHash sentinel must never cluster — neither as target nor
+    as a sibling. Otherwise empty/whitespace pages across a tenant would
+    falsely surface as a "wall" cluster.
+    """
+
+    def test_zero_target_returns_zero_count(self) -> None:
+        url_to_hash = {f"https://x/{i}": 0 for i in range(10)}
+        url_to_hash["https://x/target"] = 0
+        siblings = _count_cluster_siblings(
+            "https://x/target",
+            0,
+            url_to_hash,
+            hamming_max=3,
+        )
+        assert siblings == 0
+
+    def test_zero_siblings_filtered_for_real_target(self) -> None:
+        target_hash = compute_simhash("real content with words")
+        url_to_hash = {
+            "https://x/target": target_hash,
+            "https://x/zero-1": 0,
+            "https://x/zero-2": 0,
+            "https://x/match-1": target_hash,
+            "https://x/match-2": target_hash,
+        }
+        siblings = _count_cluster_siblings(
+            "https://x/target",
+            target_hash,
+            url_to_hash,
+            hamming_max=3,
+        )
+        # 2 zero-siblings filtered out; 2 matching siblings counted.
+        assert siblings == 2
 
 
 # ---------------------------------------------------------------------------

--- a/klai-knowledge-ingest/tests/test_pg_store_simhash_update.py
+++ b/klai-knowledge-ingest/tests/test_pg_store_simhash_update.py
@@ -1,0 +1,95 @@
+"""Unit tests for ``pg_store.update_crawled_page_simhash``.
+
+Pin the behaviour added in the SPEC-INGEST-LOGIN-WALL-DETECT-002
+follow-ups: the helper uses ``RETURNING url`` and emits a structlog
+warning when 0 rows are affected (= the row was deleted between
+``upsert_crawled_page`` and the simhash UPDATE — typically a race with
+``delete_kb`` / ``delete_connector_artifacts``).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from structlog.testing import capture_logs
+
+from knowledge_ingest import pg_store
+
+
+@pytest.mark.asyncio
+async def test_update_returns_url_on_success() -> None:
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value="https://x/page-1")
+
+    await pg_store.update_crawled_page_simhash(
+        conn,
+        org_id="org-1",
+        kb_slug="kb-1",
+        url="https://x/page-1",
+        content_simhash=42,
+    )
+
+    conn.fetchval.assert_awaited_once()
+    sql = conn.fetchval.await_args.args[0]
+    assert "UPDATE knowledge.crawled_pages" in sql
+    assert "RETURNING url" in sql, "RETURNING clause missing — race-detection broken"
+
+
+@pytest.mark.asyncio
+async def test_update_warns_when_no_row() -> None:
+    """fetchval returns None → structlog warning event, no exception raised.
+
+    Uses ``structlog.testing.capture_logs`` so the test does not depend on
+    structlog's stdlib-logging routing (which is configured per-process and
+    can be silenced by other tests).
+    """
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value=None)
+
+    with capture_logs() as logs:
+        # Must not raise — fingerprint storage is non-critical.
+        await pg_store.update_crawled_page_simhash(
+            conn,
+            org_id="org-1",
+            kb_slug="kb-1",
+            url="https://x/missing-row",
+            content_simhash=42,
+        )
+
+    matched = [
+        log
+        for log in logs
+        if log.get("event") == "crawled_pages_simhash_update_no_row"
+        and log.get("log_level") == "warning"
+    ]
+    assert matched, (
+        "expected structlog warning event crawled_pages_simhash_update_no_row"
+    )
+    assert matched[0]["url"] == "https://x/missing-row"
+    assert matched[0]["org_id"] == "org-1"
+    assert matched[0]["kb_slug"] == "kb-1"
+
+
+@pytest.mark.asyncio
+async def test_update_passes_tenant_filters() -> None:
+    """SQL filters by org_id AND kb_slug AND url — REQ-09 isolation."""
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value="https://x/page-1")
+
+    await pg_store.update_crawled_page_simhash(
+        conn,
+        org_id="org-voys",
+        kb_slug="support",
+        url="https://x/page-1",
+        content_simhash=42,
+    )
+
+    sql, *args = conn.fetchval.await_args.args
+    assert "WHERE org_id = $2" in sql
+    assert "AND kb_slug = $3" in sql
+    assert "AND url = $4" in sql
+    # Args bound positionally: (sql, content_simhash, org_id, kb_slug, url)
+    assert args[1] == "org-voys"
+    assert args[2] == "support"
+    assert args[3] == "https://x/page-1"


### PR DESCRIPTION
## Summary

Six small fixes from re-reading SPEC-INGEST-LOGIN-WALL-DETECT-002 after the production rollout. None are critical — the v2 detector works correctly in prod — but each plugs a real gap.

## What's in

1. **Pitfall capture (process-rules.md)** — multi-PR alembic head split. Documents the failure mode that bit klai twice on 2026-05-06 (PRs #440 + #441) plus both recovery paths.
2. **CI guard** — new `Guard - single alembic head` step in `knowledge-ingest.yml`. Runs `alembic heads` offline on PR + push, rejects > 1 head before merge. Catches the next PR #441-class collision at PR-build time.
3. **Empty-text + 0-hash defensiveness** — `compute_simhash("")` returns `0`. Storing `0` would let rendered-but-empty crawl results falsely cluster as a wall. Crawler skips storage; backfill mirrors; `_count_cluster_siblings` filters zero sentinels.
4. **SPEC AC-04.2 update** — replace the v1 "149 walls" estimate with the v2 production numbers (199 active, 316 total) plus a note on recovery semantics: 32 of 33 voys recovery candidates will re-purge after re-crawl, only `/2fa-freedom` stays un-purged.
5. **Conftest `pg_store_mock` fixture** — opt-in `AsyncMock(spec=pg_store)` for new tests so adding the next pg_store helper doesn't silently break a fleet of manually-assigned mocks.
6. **RETURNING-check in `update_crawled_page_simhash`** — was a silent `conn.execute()` that updated 0 rows on race-deletes. Now `RETURNING url` via `fetchval` + structlog warning `crawled_pages_simhash_update_no_row`. Fail-soft.

## Test plan

- [x] 96 SPEC-002 tests pass (was 90; +3 zero-hash safeguards, +3 RETURNING-contract tests)
- [x] Ruff clean on all changed files
- [x] `alembic heads` returns single head locally (`c1d4e7f2a8b6` from #443) — verifies the new CI guard would have passed
- [ ] CI green
- [ ] Tenant-isolation semgrep job green

## Out of scope

- Re-crawl `/2fa-freedom` and verify chat queries — still operator follow-up from #441 / #442 rollout
- Retroactive migration of pre-existing tests to the `pg_store_mock` fixture — opt-in to avoid disturbing things that work

🤖 Generated with [Claude Code](https://claude.com/claude-code)