### PR TITLE
chore(SPEC-002 polish): pitfall typo + uv-pinned guard + fixture adoption

### DIFF
--- a/.claude/rules/klai/pitfalls/process-rules.md
+++ b/.claude/rules/klai/pitfalls/process-rules.md
@@ -1574,7 +1574,7 @@ into two heads. `alembic upgrade head` refuses to proceed because the
 target is ambiguous; the entrypoint loops on `FAILED` and the container
 restartloops.
 
-Klai hit this twice on 2026-05-06 inside one hour:
+Klai hit this once on 2026-05-06:
 
 1. PR #440 (SPEC-INGEST-RECONCILE-001) added `0005_crawl_jobs_fetch_outcomes`
    chained on `603787256fb8`.
@@ -1582,10 +1582,12 @@ Klai hit this twice on 2026-05-06 inside one hour:
    chained on the same `603787256fb8`.
 
 #440 merged 7 minutes before #441. Production deployed `:latest` after
-#441 and the knowledge-ingest container restartlooped for ~5 minutes
-until hotfix #442 rebased the second migration onto the first
-(`down_revision`: `603787256fb8` → `a8c5e1d2f3b4`). #443 added a no-op
-merge migration in parallel for belt-and-braces.
+#441 and the knowledge-ingest container restartlooped for ~5 minutes.
+The recovery used both available remediations in parallel: hotfix #442
+rebased the second migration onto the first (`down_revision`:
+`603787256fb8` → `a8c5e1d2f3b4`) AND hotfix #443 shipped a no-op merge
+migration declaring both heads as parents. Either alone would have
+unblocked the entrypoint; doing both is safe (one becomes redundant).
 
 The schema columns themselves were independent (`crawl_jobs.fetch_outcomes`
 vs `crawled_pages.content_simhash` — different tables) so no data

--- a/.github/workflows/knowledge-ingest.yml
+++ b/.github/workflows/knowledge-ingest.yml
@@ -61,15 +61,30 @@ jobs:
       # alembic heads, blocking `alembic upgrade head` at container
       # start. This offline guard runs on every PR + push and rejects
       # any state with > 1 head before merge instead of in production.
+      #
+      # The guard runs alembic via ``uv run`` so it uses the version
+      # pinned in ``pyproject.toml`` / ``uv.lock`` — keeps the CI check
+      # in lockstep with the version that runs at container entrypoint
+      # rather than drifting against a hardcoded pin.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
       - name: Guard — single alembic head (knowledge schema)
+        working-directory: klai-knowledge-ingest
+        env:
+          # Alembic's env.py loads sqlalchemy.url from DATABASE_URL but only
+          # ``alembic heads`` (script-graph walk) is offline and never opens
+          # a connection. Stub URL keeps env.py from crashing on missing var.
+          DATABASE_URL: postgresql://x:x@localhost/x
         run: |
           set -euo pipefail
-          cd klai-knowledge-ingest
-          pipx install --quiet alembic==1.16.5
-          heads=$(alembic heads 2>&1 | grep -E "\(head\)$" | wc -l | tr -d ' ')
+          uv sync --frozen --quiet
+          heads=$(uv run --frozen alembic heads 2>&1 | grep -E "\(head\)$" | wc -l | tr -d ' ')
           if [ "$heads" -ne 1 ]; then
             echo "::error::Multiple alembic heads detected (got $heads, expected 1)"
-            alembic heads
+            uv run --frozen alembic heads
             echo
             echo "Hotfix: rebase the second-merging migration's down_revision"
             echo "onto the first head, OR add a no-op merge migration with"

--- a/klai-knowledge-ingest/tests/test_crawler_link_fields.py
+++ b/klai-knowledge-ingest/tests/test_crawler_link_fields.py
@@ -52,8 +52,15 @@ async def test_ingest_crawl_result_populates_link_fields():
     result = _make_crawl_result()
 
     outbound_urls = ["https://example.com/b"]
+    # ``make_pg_store_mock`` from conftest returns
+    # ``AsyncMock(spec=pg_store)`` — every helper auto-mocked, no per-method
+    # AsyncMock assignment needed. Future pg_store helper additions don't
+    # silently break this test.
+    from tests.conftest import make_pg_store_mock
+
+    mock_pg = make_pg_store_mock()
     with (
-        patch("knowledge_ingest.adapters.crawler.pg_store") as mock_pg,
+        patch("knowledge_ingest.adapters.crawler.pg_store", mock_pg),
         patch.object(
             link_graph, "get_outbound_urls",
             new_callable=AsyncMock, return_value=outbound_urls,
@@ -71,11 +78,6 @@ async def test_ingest_crawl_result_populates_link_fields():
             new_callable=AsyncMock,
         ) as mock_ingest,
     ):
-        mock_pg.get_crawled_page_stored = AsyncMock(return_value=None)
-        mock_pg.upsert_crawled_page = AsyncMock()
-        mock_pg.update_crawled_page_simhash = AsyncMock()
-        mock_pg.upsert_page_links = AsyncMock()
-
         mock_ingest.return_value = {"chunks": 2}
 
         from knowledge_ingest.adapters.crawler import _ingest_crawl_result
@@ -104,8 +106,11 @@ async def test_ingest_crawl_result_graceful_on_link_graph_error():
     mock_conn = _make_mock_conn()
     result = _make_crawl_result()
 
+    from tests.conftest import make_pg_store_mock
+
+    mock_pg = make_pg_store_mock()
     with (
-        patch("knowledge_ingest.adapters.crawler.pg_store") as mock_pg,
+        patch("knowledge_ingest.adapters.crawler.pg_store", mock_pg),
         patch.object(
             link_graph, "get_outbound_urls",
             new_callable=AsyncMock, side_effect=Exception("DB down"),
@@ -123,11 +128,6 @@ async def test_ingest_crawl_result_graceful_on_link_graph_error():
             new_callable=AsyncMock,
         ) as mock_ingest,
     ):
-        mock_pg.get_crawled_page_stored = AsyncMock(return_value=None)
-        mock_pg.upsert_crawled_page = AsyncMock()
-        mock_pg.update_crawled_page_simhash = AsyncMock()
-        mock_pg.upsert_page_links = AsyncMock()
-
         mock_ingest.return_value = {"chunks": 1}
 
         from knowledge_ingest.adapters.crawler import _ingest_crawl_result

--- a/klai-knowledge-ingest/tests/test_crawler_template_detection.py
+++ b/klai-knowledge-ingest/tests/test_crawler_template_detection.py
@@ -73,10 +73,14 @@ def _patch_chain(*, cluster_simhashes: list[int] | None = None):
     rows = [{"content_simhash": h} for h in (cluster_simhashes or [])]
     pool.fetch = AsyncMock(return_value=rows)
 
-    pg_store_mock = MagicMock()
-    pg_store_mock.get_crawled_page_stored = AsyncMock(return_value=None)
-    pg_store_mock.upsert_crawled_page = AsyncMock(return_value=None)
-    pg_store_mock.update_crawled_page_simhash = AsyncMock(return_value=None)
+    # ``make_pg_store_mock`` from conftest returns ``AsyncMock(spec=pg_store)``
+    # so every helper — current AND any future addition — is auto-mocked
+    # as an async no-op. Replaces the previous MagicMock + per-method
+    # AsyncMock-assignment pattern that broke whenever a new pg_store
+    # helper landed (e.g. ``update_crawled_page_simhash`` from this SPEC).
+    from tests.conftest import make_pg_store_mock
+
+    pg_store_mock = make_pg_store_mock()
 
     ingest_document_mock = AsyncMock(return_value=None)
 

--- a/klai-knowledge-ingest/tests/test_ingest_login_wall_integration.py
+++ b/klai-knowledge-ingest/tests/test_ingest_login_wall_integration.py
@@ -80,11 +80,15 @@ def _patch_chain(*, cluster_simhashes: list[int] | None = None):
     rows = [{"content_simhash": h} for h in (cluster_simhashes or [])]
     pool.fetch = AsyncMock(return_value=rows)
 
-    pg_store_mock = MagicMock()
-    pg_store_mock.get_crawled_page_stored = AsyncMock(return_value=None)
-    pg_store_mock.upsert_crawled_page = AsyncMock(return_value=None)
-    # SPEC-INGEST-LOGIN-WALL-DETECT-002: SimHash store helper called after upsert.
-    pg_store_mock.update_crawled_page_simhash = AsyncMock(return_value=None)
+    # ``make_pg_store_mock`` from conftest returns
+    # ``AsyncMock(spec=pg_store)`` so every helper — current AND any
+    # future addition — is auto-mocked as an async no-op. Avoids the
+    # fragility of manually re-listing AsyncMock assignments per helper
+    # (which silently breaks when a new pg_store helper is added — the
+    # case that hit ``update_crawled_page_simhash`` in this SPEC).
+    from tests.conftest import make_pg_store_mock
+
+    pg_store_mock = make_pg_store_mock()
 
     ingest_document_mock = AsyncMock(return_value=None)
 


### PR DESCRIPTION
## Summary

Three small gaps from the second adversarial review:

1. **Pitfall typo** — said "twice on 2026-05-06" but it was once.
2. **CI guard pin drift** — ``pipx install alembic==1.16.5`` was independent from pyproject's alembic; replaced with ``uv run --frozen alembic heads``.
3. **Fixture adoption** — the ``pg_store_mock`` fixture from #445 was opt-in but not adopted. Migrated 3 test files (5 manual MagicMock-with-per-method-AsyncMock blocks). The next pg_store helper addition no longer breaks these tests.

## Test plan

- [x] 96 SPEC-002 tests pass
- [x] Ruff clean on all migrated files
- [x] ``uv run --frozen alembic heads`` returns single head locally
- [ ] CI green (incl. self-validation of the new alembic-head step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)