### PR TITLE
fix(ingest-reconcile): same-domain guard on positional fallback

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
@@ -725,7 +725,12 @@ def _combine_bulk_responses(
         # Redirect fallback: positional alignment when canonical match
         # missed AND the response at this index hasn't been claimed AND
         # its URL doesn't canonical-match a DIFFERENT candidate (which
-        # would be ambiguous).
+        # would be ambiguous) AND the response stays on the same origin
+        # domain. The same-domain guard makes the fallback safe even if
+        # crawl4ai's MemoryAdaptiveDispatcher reorders the response list
+        # under load — at worst we miss a redirect classification and
+        # surface UNKNOWN_EXCEPTION (visible to operators) rather than
+        # silently mislabel an unrelated URL.
         if (
             page is None
             and len(raw_results) == len(candidates)
@@ -734,9 +739,14 @@ def _combine_bulk_responses(
         ):
             positional = raw_results[i]
             if positional and positional.get("url"):
-                pos_canonical = _canonicalise_url(positional["url"])
+                pos_url = positional["url"]
+                pos_canonical = _canonicalise_url(pos_url)
                 pos_owner_idx = canonical_to_idx.get(pos_canonical)
-                if pos_owner_idx is None or pos_owner_idx == i:
+                pos_domain = urlparse(pos_url).netloc.lower()
+                if (
+                    (pos_owner_idx is None or pos_owner_idx == i)
+                    and pos_domain == base_domain
+                ):
                     page = positional
                     claimed_response_indices.add(i)
 

--- a/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
+++ b/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
@@ -27,6 +27,7 @@ from knowledge_ingest.crawl4ai_client import (
     _build_candidate_set,
     _canonicalise_url,
     _classify_fetch_outcome,
+    _combine_bulk_responses,
 )
 from knowledge_ingest.reason_codes import FetchReasonCode
 
@@ -595,3 +596,103 @@ class TestBuildCandidateSetExcludeStartUrl:
                 "HTTPS://Example.com",
                 "https://example.com#frag",
             ), f"start_url variant {candidate} leaked through include_start_url=False"
+
+
+# ---------------------------------------------------------------------------
+# _combine_bulk_responses — same-domain guard on positional fallback
+# ---------------------------------------------------------------------------
+
+
+class TestCombineBulkResponsesPositionalGuard:
+    """The positional fallback only matches a same-origin response.
+
+    Without the guard, an out-of-order or mis-routed response from
+    crawl4ai's MemoryAdaptiveDispatcher could silently shadow a candidate
+    with content from a completely different site, surfacing as a fake
+    SUCCESS/HTTP_5XX outcome on the wrong URL. The same-domain check
+    forces such corruption to fall through to UNKNOWN_EXCEPTION (visible
+    to operators) rather than mislabel.
+    """
+
+    def test_positional_match_accepted_for_same_domain_redirect(self) -> None:
+        """A canonical-miss + same-domain positional response = redirect.
+        That response is accepted, and the outcome's reason_code reflects
+        the redirected page's success state."""
+        candidates = ["https://example.com/old-page"]
+        raw_results = [
+            {
+                "url": "https://example.com/new-page",  # redirected
+                "success": True,
+                "status_code": 200,
+                "html": "<html>content</html>",
+                "markdown": "content",
+                "links": {"internal": []},
+                "media": {},
+            }
+        ]
+        results, outcomes = _combine_bulk_responses(
+            candidates=candidates,
+            raw_results=raw_results,
+            transport_error=None,
+            base_domain="example.com",
+        )
+        assert len(outcomes) == 1
+        assert outcomes[0]["url"] == "https://example.com/old-page"
+        assert outcomes[0]["reason_code"] == FetchReasonCode.SUCCESS.value
+        assert outcomes[0]["status_code"] == 200
+        # The CrawlResult inherits the response's URL (post-redirect),
+        # which is correct — the ingest pipeline ingests the resolved page.
+        assert len(results) == 1
+
+    def test_positional_match_rejected_for_cross_domain_response(self) -> None:
+        """If the positional response is on a different domain (e.g. crawl4ai
+        reordered the response list under load), the fallback MUST refuse
+        to claim it. The candidate falls through to UNKNOWN_EXCEPTION."""
+        candidates = ["https://example.com/old-page"]
+        raw_results = [
+            {
+                # WRONG site — out-of-order response from a parallel batch.
+                "url": "https://attacker.com/exploit",
+                "success": True,
+                "status_code": 200,
+                "html": "<html>not ours</html>",
+                "markdown": "not ours",
+                "links": {"internal": []},
+                "media": {},
+            }
+        ]
+        results, outcomes = _combine_bulk_responses(
+            candidates=candidates,
+            raw_results=raw_results,
+            transport_error=None,
+            base_domain="example.com",
+        )
+        # Outcome surfaces as UNKNOWN_EXCEPTION, NOT as a fake SUCCESS on
+        # the candidate URL with attacker.com's content.
+        assert outcomes[0]["url"] == "https://example.com/old-page"
+        assert outcomes[0]["reason_code"] == FetchReasonCode.UNKNOWN_EXCEPTION.value
+        # No CrawlResult — we refused to fabricate one from cross-domain data.
+        assert results == []
+
+    def test_canonical_match_unaffected_by_same_domain_guard(self) -> None:
+        """Direct canonical match still works regardless of domain logic."""
+        candidates = ["https://example.com/page"]
+        raw_results = [
+            {
+                "url": "https://example.com/page",
+                "success": True,
+                "status_code": 200,
+                "html": "<html>content</html>",
+                "markdown": "content",
+                "links": {"internal": []},
+                "media": {},
+            }
+        ]
+        results, outcomes = _combine_bulk_responses(
+            candidates=candidates,
+            raw_results=raw_results,
+            transport_error=None,
+            base_domain="example.com",
+        )
+        assert outcomes[0]["reason_code"] == FetchReasonCode.SUCCESS.value
+        assert len(results) == 1


### PR DESCRIPTION
## Adversarial-pass hardening — #1 of the three open items from PR #444's post-mortem

### Problem

\`_combine_bulk_responses\` does canonical-URL lookup first; on a miss it falls back to positional alignment with crawl4ai's response list (one response per submitted URL, same order). That fallback fixes the redirect classification gap (\`/old\` → \`/new\` redirect makes the response \`url\` field disagree with the candidate's canonical) but silently trusts crawl4ai's MemoryAdaptiveDispatcher to preserve submission order under all conditions.

If the dispatcher reorders under memory pressure (or a future crawl4ai version returns mixed-batch responses), candidate A could be paired with response B's content. Result: a synthetic \`SUCCESS\` outcome on candidate A's URL backed by content from a completely different site. Hard to detect from \`fetch_outcomes\` JSONB alone — it looks like a normal success.

### Fix

Add a same-origin check on positional match: the candidate gets paired with \`raw_results[i]\` only when \`urlparse(response.url).netloc == base_domain\`. Anything else falls through to \`UNKNOWN_EXCEPTION\` so the operator sees an explicit "didn't match" signal rather than a fabricated success.

Same-domain redirects (the only case the fallback was actually designed to handle) still match. Cross-domain reordering corruption now produces a visible UNKNOWN_EXCEPTION instead of silent garbage.

### Tests

\`tests/test_crawl_site_reconcile.py::TestCombineBulkResponsesPositionalGuard\`:

- \`test_positional_match_accepted_for_same_domain_redirect\` — \`/old-page\` candidate ↔ \`/new-page\` response (same domain). Outcome: SUCCESS, ingest result captured.
- \`test_positional_match_rejected_for_cross_domain_response\` — \`example.com/old-page\` candidate ↔ \`attacker.com/exploit\` response. Outcome: UNKNOWN_EXCEPTION, no ingest result.
- \`test_canonical_match_unaffected_by_same_domain_guard\` — direct hit still works.

35/35 reconcile + filter_chain tests pass; ruff clean on touched files.

### Out of scope (deliberately punted)

- DB-level CHECK constraint test for \`sync_runs.skip_reasons\` — covered indirectly by the next Voys Notion sync (any typo in migration 009's allowed list would surface as an \`IntegrityError\` in connector logs immediately).
- Empirical AC-5 / AC-8 validation — requires a Voys-tenant trigger which only the operator can run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)