### PR TITLE
fix(ingest): tenant-only assertion on KB delete + connector purge routes

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
@@ -40,7 +40,7 @@ from knowledge_ingest.config import settings
 from knowledge_ingest.content_labeler import generate_content_label
 from knowledge_ingest.content_profiles import get_profile
 from knowledge_ingest.db import tenant_scoped_connection
-from knowledge_ingest.identity import assert_caller_identity
+from knowledge_ingest.identity import assert_caller_identity, assert_caller_identity_tenant_only
 from knowledge_ingest.models import (
     BulkSyncRequest,
     GiteaPushEvent,
@@ -873,9 +873,13 @@ async def delete_kb_route(request: Request, org_id: str, kb_slug: str) -> dict:
     """Delete all data for a knowledge base: graph nodes + Qdrant chunks + PostgreSQL records.
     Called by the portal on KB deletion. Scoped to (org_id, kb_slug).
     SPEC-TI-003 AC-6: identity assertion on query-param org_id.
+
+    Tenant-only assertion: KB delete is a tenant-scoped operation; no end-user is
+    bound to the request. Using ``assert_caller_identity`` here would crash with
+    TypeError on the missing ``claimed_user_id`` arg.
     """
     _verify_internal_secret(request)
-    await assert_caller_identity(request, claimed_org_id=org_id)
+    await assert_caller_identity_tenant_only(request, claimed_org_id=org_id)
     # Fetch episode IDs before PG deletion — graph cleanup requires them.
     async with tenant_scoped_connection(org_id) as conn:
         episode_ids = await pg_store.get_episode_ids(conn, org_id, kb_slug)
@@ -900,9 +904,12 @@ async def enqueue_connector_purge_route(
     (``connector_cleanup.purge_connector``) and finally calls back to
     ``/api/internal/connectors/{id}/finalize-delete`` on the portal to
     hard-delete the row.
+
+    Tenant-only assertion: connector purge is initiated by the portal on behalf of
+    an already-authenticated user; no end-user identity is forwarded.
     """
     _verify_internal_secret(request)
-    await assert_caller_identity(request, claimed_org_id=org_id)
+    await assert_caller_identity_tenant_only(request, claimed_org_id=org_id)
     from knowledge_ingest import enrichment_tasks
 
     proc_app = enrichment_tasks.get_app()
@@ -931,9 +938,11 @@ async def delete_connector_route(
     flow (REQ-11). New portal-side calls go through
     ``POST /ingest/v1/connector/purge`` (async, returns 202).
     SPEC-TI-003 AC-6: identity assertion on query-param org_id.
+
+    Tenant-only assertion: synchronous admin force-purge has no end-user binding.
     """
     _verify_internal_secret(request)
-    await assert_caller_identity(request, claimed_org_id=org_id)
+    await assert_caller_identity_tenant_only(request, claimed_org_id=org_id)
     from knowledge_ingest import enrichment_tasks
     from knowledge_ingest.connector_cleanup import purge_connector
 

--- a/klai-knowledge-ingest/tests/test_ingest_endpoints_identity_assertion.py
+++ b/klai-knowledge-ingest/tests/test_ingest_endpoints_identity_assertion.py
@@ -389,7 +389,7 @@ class TestAssertCallerIdentityUnit:
         request = StarletteRequest(scope)
 
         with pytest.raises(Exception) as exc_info:
-            await assert_caller_identity(request, claimed_org_id="org-1")
+            await assert_caller_identity(request, claimed_org_id="org-1", claimed_user_id="user-1")
         exc = exc_info.value
         assert hasattr(exc, "status_code"), f"Expected HTTPException, got {type(exc)}"
         assert exc.status_code == 400
@@ -410,7 +410,7 @@ class TestAssertCallerIdentityUnit:
         request = StarletteRequest(scope)
 
         with pytest.raises(Exception) as exc_info:
-            await assert_caller_identity(request, claimed_org_id="org-1")
+            await assert_caller_identity(request, claimed_org_id="org-1", claimed_user_id="user-1")
         exc = exc_info.value
         assert hasattr(exc, "status_code"), f"Expected HTTPException, got {type(exc)}"
         assert exc.status_code == 400
@@ -438,7 +438,9 @@ class TestAssertCallerIdentityUnit:
         request = StarletteRequest(scope)
 
         with pytest.raises(Exception) as exc_info:
-            await mod.assert_caller_identity(request, claimed_org_id="org-attacker")
+            await mod.assert_caller_identity(
+                request, claimed_org_id="org-attacker", claimed_user_id="user-1"
+            )
         exc = exc_info.value
         assert hasattr(exc, "status_code"), f"Expected HTTPException, got {type(exc)}"
         assert exc.status_code == 403
@@ -467,5 +469,149 @@ class TestAssertCallerIdentityUnit:
         }
         request = StarletteRequest(scope)
 
-        verified_org_id = await mod.assert_caller_identity(request, claimed_org_id="org-1")
+        verified_org_id = await mod.assert_caller_identity(
+            request, claimed_org_id="org-1", claimed_user_id="user-1"
+        )
         assert verified_org_id == "org-confirmed"
+
+
+# ---------------------------------------------------------------------------
+# Regression: tenant-only routes must NOT use the user-bound assert_caller_identity
+# ---------------------------------------------------------------------------
+
+
+class TestTenantOnlyRoutesUseTenantAssertion:
+    """Regression for the assert_caller_identity vs tenant-only mix-up.
+
+    Routes that have no end-user context (KB delete, connector purge — both async
+    and sync admin variants) MUST call ``assert_caller_identity_tenant_only``.
+    Calling ``assert_caller_identity(request, claimed_org_id=...)`` without
+    ``claimed_user_id`` raises ``TypeError`` at runtime because the user-bound
+    function requires it (no default). The bug surfaced as portal-side delete
+    returning 500 → connector stuck in state='deleting'.
+
+    These tests fail-fast if a future PR re-introduces the user-bound call on
+    these endpoints.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _patches(self, mock_pool, monkeypatch):
+        monkeypatch.setattr("knowledge_ingest.db.get_pool", AsyncMock(return_value=mock_pool))
+        monkeypatch.setattr("knowledge_ingest.db.close_pool", AsyncMock())
+        monkeypatch.setattr("knowledge_ingest.qdrant_store.ensure_collection", AsyncMock())
+        monkeypatch.setattr("knowledge_ingest.config.settings.enrichment_enabled", False)
+
+    @pytest.fixture()
+    def _strict_user_bound_identity(self, monkeypatch):
+        """Mock that mirrors the real signature: claimed_user_id is REQUIRED.
+
+        Previous mocks gave ``claimed_user_id=None`` a default, hiding the production
+        TypeError. This fixture re-injects the strict signature so any route that
+        forgets ``claimed_user_id`` blows up under the test client just like in prod.
+        """
+
+        async def _strict(request, claimed_org_id, claimed_user_id):  # no default
+            return claimed_org_id
+
+        async def _strict_tenant_only(request, *, claimed_org_id):
+            return claimed_org_id
+
+        for path in [
+            "knowledge_ingest.identity.assert_caller_identity",
+            "knowledge_ingest.routes.ingest.assert_caller_identity",
+        ]:
+            try:
+                monkeypatch.setattr(path, _strict)
+            except AttributeError:
+                pass
+        for path in [
+            "knowledge_ingest.identity.assert_caller_identity_tenant_only",
+            "knowledge_ingest.routes.ingest.assert_caller_identity_tenant_only",
+        ]:
+            try:
+                monkeypatch.setattr(path, _strict_tenant_only)
+            except AttributeError:
+                pass
+
+    def test_delete_kb_uses_tenant_only(self, _strict_user_bound_identity, client):
+        """DELETE /ingest/v1/kb is tenant-scoped — must not require user_id.
+
+        Before the fix this returned 500 with TypeError on missing claimed_user_id.
+        """
+        # Stub graph + qdrant + pg_store so the route body doesn't try to talk
+        # to FalkorDB / Qdrant / a real pool during the assertion-path test.
+        from unittest.mock import patch
+
+        with (
+            patch(
+                "knowledge_ingest.routes.ingest.pg_store.get_episode_ids",
+                AsyncMock(return_value=[]),
+            ),
+            patch(
+                "knowledge_ingest.routes.ingest.graph_module.delete_kb_episodes",
+                AsyncMock(),
+            ),
+            patch("knowledge_ingest.routes.ingest.qdrant_store.delete_kb", AsyncMock()),
+            patch("knowledge_ingest.routes.ingest.pg_store.delete_kb", AsyncMock()),
+        ):
+            resp = client.delete(
+                "/ingest/v1/kb",
+                headers=_CALLER,
+                params={"org_id": "org-1", "kb_slug": "kb-1"},
+            )
+        assert resp.status_code == 200, (
+            f"Got {resp.status_code} — tenant-only assertion regression. body={resp.text}"
+        )
+
+    def test_enqueue_connector_purge_uses_tenant_only(self, _strict_user_bound_identity, client):
+        """POST /ingest/v1/connector/purge — async path, tenant-only.
+
+        Reproduces the original bug: portal-api → 500 on delete because the route
+        called ``assert_caller_identity(request, claimed_org_id=...)`` without
+        ``claimed_user_id``. After the fix it must return 202.
+        """
+        from unittest.mock import patch
+
+        mock_app = MagicMock()
+        mock_app.connector_purge_task.defer_async = AsyncMock(return_value=None)
+        with patch("knowledge_ingest.enrichment_tasks.get_app", return_value=mock_app):
+            resp = client.post(
+                "/ingest/v1/connector/purge",
+                headers=_CALLER,
+                params={
+                    "org_id": "org-1",
+                    "kb_slug": "kb-1",
+                    "connector_id": "00000000-0000-0000-0000-000000000001",
+                },
+            )
+        assert resp.status_code == 202, (
+            f"Got {resp.status_code} — connector purge tenant-only regression. body={resp.text}"
+        )
+
+    def test_delete_connector_uses_tenant_only(self, _strict_user_bound_identity, client):
+        """DELETE /ingest/v1/connector — sync admin path, tenant-only."""
+        from unittest.mock import patch
+
+        from knowledge_ingest.connector_cleanup import CleanupReport
+
+        empty_report = CleanupReport()
+        mock_app = MagicMock()
+        with (
+            patch("knowledge_ingest.enrichment_tasks.get_app", return_value=mock_app),
+            patch(
+                "knowledge_ingest.connector_cleanup.purge_connector",
+                AsyncMock(return_value=empty_report),
+            ),
+        ):
+            resp = client.delete(
+                "/ingest/v1/connector",
+                headers=_CALLER,
+                params={
+                    "org_id": "org-1",
+                    "kb_slug": "kb-1",
+                    "connector_id": "00000000-0000-0000-0000-000000000001",
+                },
+            )
+        assert resp.status_code == 200, (
+            f"Got {resp.status_code} — admin purge tenant-only regression. body={resp.text}"
+        )


### PR DESCRIPTION
## Summary

Connector delete via portal UI returned 500 Internal Server Error because the receiver `POST /ingest/v1/connector/purge` (and two siblings) called `assert_caller_identity` without the required `claimed_user_id` argument. The user-bound function has no default for `claimed_user_id` (became required post SPEC-TI-003), so every invocation raised `TypeError` at runtime. Tests using a permissive mock that defaulted `claimed_user_id=None` masked the regression.

Symptom on prod: portal flipped `portal_connectors.state='deleting'` and committed, then crashed on the `/purge` response → connector row stuck in 'deleting' state. Reproduced live on Voys support KB.

## Fix

Three tenant-scoped service-to-service routes now use `assert_caller_identity_tenant_only` per the user-bound function's own docstring guidance:

- `DELETE /ingest/v1/kb`
- `POST   /ingest/v1/connector/purge` (async — the one portal UI delete hits)
- `DELETE /ingest/v1/connector` (sync admin force-purge)

Plus 4 pre-existing `TestAssertCallerIdentityUnit` cases that called the user-bound function without `claimed_user_id` are fixed (same family of signature mismatch).

A new regression class `TestTenantOnlyRoutesUseTenantAssertion` mocks the user-bound function with the real required-positional signature so any future PR that re-introduces the user-bound call on a tenant-only route fails fast in CI rather than at production runtime.

## Test plan

- [x] `uv run pytest tests/test_ingest_endpoints_identity_assertion.py::TestTenantOnlyRoutesUseTenantAssertion -v` passes 3/3
- [x] `uv run pytest tests/test_ingest_endpoints_identity_assertion.py` 15/16 passes (1 pre-existing unrelated source-count test failure — out of scope)
- [x] `uv run pytest tests/test_connector_cleanup.py tests/test_connector_state.py` 9/9 passes
- [x] `uv run ruff check` + `uv run ruff format --check` clean
- [ ] Post-merge: verify Voys support connector delete via UI completes (state transition deleting → hard-deleted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)