### PR TITLE
chore(SPEC-002): MX annotations on detector + backfill + validation modules

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/backfill_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/backfill_tasks.py
@@ -86,6 +86,14 @@ def _count_cluster_siblings(
     fingerprints, but legacy rows from before that guard could still
     surface here. Filter both directions: a 0-target returns 0, and
     0-siblings are not counted.
+
+    @MX:NOTE — the 0-skip is a defensive double-check. The crawler and
+    backfill ``_ensure_simhashes`` already skip persisting hash=0, so in
+    a clean DB no zero-siblings exist. This filter handles legacy rows
+    + any future caller that bypasses the storage guards. Removing the
+    filter would let a tenant with several rendered-but-empty crawl
+    results false-positive cluster as walls.
+    Reason: SPEC-INGEST-LOGIN-WALL-DETECT-002 follow-up (PR #445).
     """
     if target_hash == 0:
         return 0
@@ -161,6 +169,20 @@ async def backfill_detect_login_walls(
     so RLS enforces ``org_id`` server-side. Qdrant deletes carry an
     ``org_id + kb_slug + path`` triple in ``Filter.must`` to comply with the
     tenant-isolation semgrep rule.
+
+    @MX:ANCHOR — invariant. Operator-triggered task. The Qdrant filter
+    triple (``org_id + kb_slug + path``) is enforced by the semgrep rule
+    in ``.github/workflows/tenant-isolation-review.yml``. Removing any
+    field is a tenant-isolation breach (would let a delete cross
+    tenants).
+    @MX:WARN — concurrent crawl race. Running this task while a
+    ``run_crawl_job`` is executing on the same ``(org_id, kb_slug)`` can
+    leave new pages without simhashes (read-then-write split): pass-1
+    snapshots rows; concurrent ingest inserts new rows AFTER the
+    snapshot; pass-2 evaluates the snapshot. Operators MUST ensure no
+    crawl is in flight before triggering. @MX:REASON — Procrastinate's
+    queueing_lock would help but is not wired in this task.
+    Reason: SPEC-INGEST-LOGIN-WALL-DETECT-002 REQ-04, REQ-09.
     """
     qdrant = get_qdrant_client()
     log = logger.bind(org_id=org_id, kb_slug=kb_slug)
@@ -263,6 +285,20 @@ async def recover_purged_pages(
 
     Designed for one-shot operator use immediately after v2 deploys — to
     undo v1 phrase-detector FPs that v2's cluster mechanism exonerates.
+
+    @MX:ANCHOR — invariant. Recovery sets ``content_hash = ''`` (empty
+    string), NOT NULL. The empty string is the "force re-fetch" sentinel
+    that the crawler's dedup-skip branch relies on (``stored_content !=
+    None and stored_content == content_hash``). NULL would be treated as
+    "never crawled" and fall through to the regular crawl path with a
+    spurious initial state.
+    @MX:NOTE — recovered pages with template-stub content WILL re-purge
+    after the next crawl: crawl4ai re-fetches current source content; if
+    it's still a wall stub, the v2 ingest detector re-flags via cluster
+    membership. Operators see "recovered: N" but expect that count to
+    shrink toward "true FPs" after re-crawl. Documented in
+    ``acceptance.md`` AC-05.1 recovery semantics note.
+    Reason: SPEC-INGEST-LOGIN-WALL-DETECT-002 REQ-05.
     """
     log = logger.bind(org_id=org_id, kb_slug=kb_slug)
 

--- a/klai-knowledge-ingest/knowledge_ingest/pg_store.py
+++ b/klai-knowledge-ingest/knowledge_ingest/pg_store.py
@@ -728,6 +728,17 @@ async def update_crawled_page_simhash(
     while the rest of the ingest path assumed the fingerprint is stored.
     Logs a structlog warning instead of raising — fingerprint storage is
     not critical-path; the next backfill pass populates the value.
+
+    @MX:ANCHOR — invariant. ``RETURNING url`` is load-bearing for race
+    detection. Reverting to bare ``conn.execute`` would re-introduce the
+    silent-zero-row failure the SPEC-002 follow-ups (PR #445) added this
+    helper to fix. The structlog event name
+    ``crawled_pages_simhash_update_no_row`` is the contract for any
+    Grafana alert hooked to this signal.
+    @MX:NOTE — fail-soft on race: warn + continue. Fingerprint storage is
+    non-critical (next backfill catches up). Raising would convert a
+    benign delete-during-ingest race into a 500 on the crawler.
+    Reason: SPEC-INGEST-LOGIN-WALL-DETECT-002 REQ-01 + follow-up.
     """
     returned = await conn.fetchval(
         "UPDATE knowledge.crawled_pages "

--- a/klai-knowledge-ingest/knowledge_ingest/utils/auth_wall_detector.py
+++ b/klai-knowledge-ingest/knowledge_ingest/utils/auth_wall_detector.py
@@ -140,6 +140,18 @@ async def detect_anonymous_auth_wall(
     via fail-open; their warning log surfaces the misconfiguration without
     blocking the ingest pipeline.
 
+    @MX:ANCHOR — invariant. Two callers depend on this exact contract:
+    ``crawler._ingest_crawl_result`` (passes ``conn`` for live cluster
+    lookup at ingest time) and ``backfill_tasks._ensure_simhashes``
+    consumers via the validation report. Removing the fail-open branch
+    would break boot scenarios where the DB pool isn't ready yet; raising
+    on missing args would convert a wiring bug into a 100% ingest outage.
+    @MX:NOTE — pattern field is pinned to ``"template_cluster"`` and
+    confidence to ``0.9``. Mode handlers in crawler.py (reject/degrade/
+    audit_only) rely on these strings for log formatting and downstream
+    quality_score=0.0 decisions; renaming requires coordinated update.
+    Reason: SPEC-INGEST-LOGIN-WALL-DETECT-002 REQ-02, REQ-06, REQ-07.
+
     Args:
         markdown: ``raw_markdown`` from the crawl result.
         fit_markdown: ``crawl4ai.fit_markdown`` (chrome-stripped). Preferred

--- a/klai-knowledge-ingest/knowledge_ingest/utils/content_fingerprint.py
+++ b/klai-knowledge-ingest/knowledge_ingest/utils/content_fingerprint.py
@@ -122,6 +122,18 @@ def compute_simhash(text: str) -> int:
     Empty input returns 0. The function is deterministic across runs and
     Python interpreters: blake2b is content-only and Python's hash
     randomisation does not affect us.
+
+    @MX:ANCHOR — invariant. Output bits MUST stay deterministic across
+    process restarts and host hardware. Every persisted ``content_simhash``
+    in ``knowledge.crawled_pages`` is an anchor: changing the hash function,
+    the normalisation order, or the bit-accumulation order silently breaks
+    every existing cluster (Hamming distance to old hashes becomes random).
+    A breaking change requires a SPEC and a full re-hash backfill.
+    @MX:NOTE — empty/whitespace input returns 0 as a sentinel. Callers
+    persisting hashes MUST skip 0 (the crawler and backfill do — see
+    SPEC-002 follow-ups). 0 is left in the int range because filtering it
+    out at compute-time would mask legitimate empty-text edge cases.
+    Reason: SPEC-INGEST-LOGIN-WALL-DETECT-002 REQ-01.
     """
     if not text:
         return 0
@@ -169,5 +181,13 @@ def hamming_distance(a: int, b: int) -> int:
     Inputs may be signed (post round-trip from PostgreSQL bigint) or unsigned;
     masking to 64 bits before XOR avoids Python's arbitrary-precision negative
     bit semantics.
+
+    @MX:ANCHOR — invariant. The 64-bit signed/unsigned mask is load-bearing
+    for cluster correctness. PostgreSQL ``bigint`` round-trips negatives, so
+    a naive ``(a ^ b).bit_count()`` on a negative input gives a count that
+    includes Python's sign-extension bits — wildly wrong distance. Removing
+    the ``& _UINT64_MASK`` would cause every cluster query against a
+    previously-stored negative simhash to return 0 matches. SPEC REQ-02
+    fixes the threshold at 3; SPEC REQ-09 audits the SQL filter.
     """
     return ((a & _UINT64_MASK) ^ (b & _UINT64_MASK)).bit_count()

--- a/klai-knowledge-ingest/knowledge_ingest/validation.py
+++ b/klai-knowledge-ingest/knowledge_ingest/validation.py
@@ -62,6 +62,18 @@ async def validate_login_wall_detector(
     graph whose size meets ``cluster_min`` + 1 (= the threshold +
     self). ``recovery_candidates`` are URLs currently at the placeholder
     hash whose cluster size has dropped below threshold under v2.
+
+    @MX:ANCHOR — invariant. This is the merge-gate report consumed by
+    ``scripts/validate_login_wall_detector.py`` and operator dashboards.
+    The schema (top-level keys + cluster shape) is the contract; new
+    fields can be added but existing names/types MUST NOT change without
+    updating the script's ``_print_human`` formatter and any downstream
+    JSON consumers.
+    @MX:NOTE — read-only. NULL ``content_simhash`` rows have their hash
+    computed in memory but NOT written back to the DB. Persistence is
+    the backfill task's job (REQ-04); the validation script must not
+    mutate state because operators run it before deciding to backfill.
+    Reason: SPEC-INGEST-LOGIN-WALL-DETECT-002 REQ-10.
     """
     async with tenant_scoped_connection(org_id) as conn:
         rows = await conn.fetch(


### PR DESCRIPTION
## Summary

Documentation-only PR. 15 MX tags across 5 modules to surface SPEC-002 load-bearing invariants for future agents/humans.

| Module | Tags | Topics |
|---|---|---|
| content_fingerprint.py | 3 | hash determinism, 0-sentinel, int64 mask |
| auth_wall_detector.py | 2 | fail-open contract, signal pattern pin |
| backfill_tasks.py | 6 | Qdrant filter triple, concurrent-crawl WARN, recovery semantics, 0-skip |
| validation.py | 2 | read-only contract, JSON schema stability |
| pg_store.py | 2 | RETURNING race detection, fail-soft |

Per ``.claude/rules/moai/core/moai-constitution.md`` MX rules: fan_in ≥ 3 → MUST ``@MX:ANCHOR``. The 6 anchor candidates all get one.

## Test plan

- [x] 96 SPEC-002 tests pass (no behaviour change)
- [x] Ruff clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)