### PR TITLE
hotfix(SPEC-MCP-AUTH-001): docker-compose env-block + Dockerfile dispatcher.py COPY

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -460,6 +460,10 @@ services:
       # ─── Billing — Moneybird ────────────────────────────────────
       # Validator in config.py requires MONEYBIRD_WEBHOOK_TOKEN at boot.
       MONEYBIRD_WEBHOOK_TOKEN: ${MONEYBIRD_WEBHOOK_TOKEN}
+      # ─── MCP OAuth surface (SPEC-MCP-AUTH-001) ──────────────────
+      # Validators in config.py require both URLs at boot (REQ-7 + REQ-14).
+      MCP_OAUTH_ISSUER_BASE_URL: ${MCP_OAUTH_ISSUER_BASE_URL}
+      MCP_OAUTH_RESOURCE_URL: ${MCP_OAUTH_RESOURCE_URL}
       # ─── Meeting ingress — IMAP calendar-invite listener ────────
       IMAP_HOST: mail.getklai.com
       IMAP_PORT: "993"

--- a/klai-knowledge-mcp/Dockerfile
+++ b/klai-knowledge-mcp/Dockerfile
@@ -29,6 +29,7 @@ ENV UV_COMPILE_BYTECODE=1 \
 RUN uv sync --frozen --no-dev --no-install-project
 
 COPY --chown=app:app klai-knowledge-mcp/logging_setup.py logging_setup.py
+COPY --chown=app:app klai-knowledge-mcp/dispatcher.py dispatcher.py
 COPY --chown=app:app klai-knowledge-mcp/main.py main.py
 
 ENV PATH="/repo/klai-knowledge-mcp/.venv/bin:${PATH}" \


### PR DESCRIPTION
Two deploy fixes that surfaced post-merge of #455:

1. **portal-api**: forward MCP_OAUTH_* env-vars from .env to the explicit container environment block. Klai's portal-api uses an explicit env-block; .env keys are NOT auto-forwarded.
2. **knowledge-mcp**: Dockerfile was missing `COPY dispatcher.py` for the new module added in SPEC-MCP-AUTH-001 Fase 3. ModuleNotFoundError on every container start.

Both containers crash-loop without these fixes.