### PR TITLE
hotfix(SPEC-MCP-AUTH-001): FastMCP allowed_hosts + Caddy /oauth/* routes

### DIFF
--- a/deploy/caddy/Caddyfile
+++ b/deploy/caddy/Caddyfile
@@ -338,6 +338,20 @@
         }
     }
 
+    # SPEC-MCP-AUTH-001: OAuth 2.1 authorization-server endpoints live
+    # at root level (not under /api) per RFC 8414 / RFC 6749 conventions.
+    # Routes: /.well-known/oauth-authorization-server, /oauth/authorize,
+    # /oauth/token, /oauth/register. portal-api handles them.
+    @oauth-mcp path /oauth/authorize /oauth/token /oauth/register /.well-known/oauth-authorization-server
+    handle @oauth-mcp {
+        reverse_proxy portal-api:8010 {
+            header_up -X-Internal-Secret
+            header_up -X-Caller-Service
+            header_up -X-Org-ID
+            header_up -X-User-ID
+        }
+    }
+
     # SEC-023 / F-038 — Scribe/Docs are no longer publicly routed.
     # Frontend calls /api/scribe/*, /api/docs/* which hit the BFF proxy in
     # portal-api (app/api/proxy.py). That handler pulls the Zitadel

--- a/klai-knowledge-mcp/main.py
+++ b/klai-knowledge-mcp/main.py
@@ -503,6 +503,19 @@ mcp = FastMCP(
         # accepted. The two-line lift here is the entire defense.
         # @MX:SPEC SPEC-MCP-AUTH-001 REQ-A6
         enable_dns_rebinding_protection=True,
+        # Without an explicit allowlist FastMCP rejects every Host (HTTP 421
+        # "Misdirected Request"). Public route comes in via Caddy with
+        # Host: mcp.getklai.com. LibreChat still reaches the same container
+        # via the Docker-internal hostname klai-knowledge-mcp:8080.
+        allowed_hosts=[
+            "mcp.getklai.com",
+            "klai-knowledge-mcp",
+            "klai-knowledge-mcp:8080",
+            "localhost",
+            "localhost:8080",
+            "127.0.0.1",
+            "127.0.0.1:8080",
+        ],
     ),
     instructions=(
         "Je hebt toegang tot de kennisbank van de gebruiker en de organisatie.\n\n"


### PR DESCRIPTION
Two prod-smoke-test fixes