### PR TITLE
fix(connector): X-Caller-Service must be 'connector' not 'klai-connector'

### DIFF
--- a/klai-connector/app/clients/knowledge_ingest.py
+++ b/klai-connector/app/clients/knowledge_ingest.py
@@ -131,7 +131,7 @@ class KnowledgeIngestClient:
         # binding is enforceable.
         headers: dict[str, str] = {
             "x-internal-secret": self._internal_secret,
-            "x-caller-service": "klai-connector",
+            "x-caller-service": "connector",
         }
 
         payload = _build_payload(
@@ -192,7 +192,7 @@ class CrawlSyncClient:
             return {}
         return {
             "x-internal-secret": self._internal_secret,
-            "x-caller-service": "klai-connector",
+            "x-caller-service": "connector",
         }
 
     async def crawl_sync(


### PR DESCRIPTION
PR #457 set the header with the wrong value. Whitelist accepts 'connector', client was sending 'klai-connector'. Every adapter sync (Notion / GitHub / Airtable) and every web_crawler delegation got rejected with 400 missing_caller_service — same end-result as PR #457 not happening at all.

Symptom on prod: Voys Notion sync 2026-05-07 → 120/0/79 with 41 correct content_too_short skips and all 79 remaining 400'd at the receiver. Logs show identity_assert_missing_caller_service with caller_service='klai-connector' in the log payload — header was sent, value was unrecognised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF