### PR TITLE
feat: SPEC-CONNECTOR-INPUT-VALIDATION-001 — connector wizard validation + sync-time guard

### DIFF
--- a/.moai/specs/SPEC-CONNECTOR-INPUT-VALIDATION-001/HANDOFF-frontend.md
+++ b/.moai/specs/SPEC-CONNECTOR-INPUT-VALIDATION-001/HANDOFF-frontend.md
@@ -1,0 +1,193 @@
+# SPEC-CONNECTOR-INPUT-VALIDATION-001 — Frontend Handoff
+
+**Status as of 2026-05-07:** Backend (REQ-2, REQ-3, REQ-4, REQ-1 backend half, REQ-7 backend half) shipped on branch `feature/SPEC-CONNECTOR-INPUT-VALIDATION-001` (worktree `/Users/mvletter/Developer/klai-connector-validation`).
+
+**Frontend remaining:** REQ-1 wizard rewire + REQ-5 InvestigateDialog/badge. Both depend exclusively on the contracts that are now live in this branch.
+
+---
+
+## What's already wired (verify these contracts before frontend work)
+
+### Backend endpoint: `POST /api/app/knowledge-bases/{kb_slug}/connectors/auth-probe`
+
+Request:
+```json
+{
+  "url": "https://wiki.redcactus.cloud/nl/45-bubble-api-van-derden",
+  "cookies": [{"name": "prod-knowledgebase-session", "value": "..."}]
+}
+```
+
+Response (5 outcomes):
+```json
+{
+  "classification": "auth_ok | auth_failed_no_cookies | auth_failed_still_walled | auth_failed_credentials_invalid | auth_failed_unreachable",
+  "match_reasons": ["http_unauthenticated", "session_cookie_minimal_body", "end_of_body_login_marker", ...],
+  "word_count": 600,
+  "auth_guard": {
+    "canary_url": "...",
+    "canary_fingerprint": "..."
+  }
+}
+```
+
+Owner role required. Cookies pass through to the wizard's existing `parseCookies()` then through to klai-knowledge-ingest.
+
+### Backend endpoint extension: `POST /api/app/knowledge-bases/{kb_slug}/connectors/crawl-preview`
+
+Existing endpoint, now also returns:
+```json
+{
+  "classification": "success | selector_required | selector_returns_empty | requires_javascript | auth_wall_detected",
+  "classification_reason": "80% of the text is links. Configure a Content Selector."
+}
+```
+
+The wizard MUST gate the "Add connector" button on `classification === "success"`.
+
+### `ConnectorOut.needs_reconfiguration: bool`
+
+Already returned by `GET /api/app/knowledge-bases/{kb_slug}/connectors/`. True when the connector is a `web_crawler` and `last_sync_status === 'failed'`. Use this to render the red "Needs reconfiguration" badge.
+
+---
+
+## Frontend work plan
+
+### REQ-1 — Wizard reorder (web_crawler only)
+
+**Files:**
+- `klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx`
+- `klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx`
+
+**State machine:**
+
+```typescript
+type WizardState = {
+  step: 1 | 2 | 3 | 4 | 5 | 6
+  details: { name: string; baseUrl: string; pathPrefix: string }
+  authQuestion: 'public' | 'private' | null
+  cookies: string  // raw textarea, parsed via existing parseCookies()
+  authProbeResult: AuthProbeResponse | null
+  contentSelector: string
+  previewResult: CrawlPreviewResponse | null
+}
+
+function canAdvanceFrom(step: WizardStep, state: WizardState): boolean {
+  switch (step) {
+    case 2: return Boolean(state.details.baseUrl && state.details.name)
+    case 3: return state.authQuestion !== null
+    case 4: return state.authProbeResult?.classification === 'auth_ok'
+    case 5: return state.previewResult?.classification === 'success'
+  }
+  return true
+}
+```
+
+**Cache invalidation (D-10):** `authProbeResult = null` whenever `baseUrl | pathPrefix | cookies` changes. `previewResult = null` whenever `baseUrl | pathPrefix | cookies | contentSelector` changes.
+
+**Step 4 render rules** (per `classification`):
+- `auth_ok` — green check, "You're in. Continue to Selector."
+- `auth_failed_no_cookies` — "This page requires authentication. Go back and answer Yes to step 3."
+- `auth_failed_still_walled` — "Cookies didn't unlock the content. Re-paste a fresh session cookie. Detected: {match_reasons.join(', ')}"
+- `auth_failed_credentials_invalid` — "401/403 — credentials rejected."
+- `auth_failed_unreachable` — "Could not reach the page. Check the Base URL."
+
+**Step 5 render rules** (per `classification`):
+- `success` — green check, "Add connector" button enables.
+- `selector_required` — show `classification_reason` verbatim.
+- `selector_returns_empty` — "Selector matched no content. Try a different selector or click 'Let AI find'."
+- `requires_javascript` — "Page renders via JavaScript. Configure a wait_for or selector for the post-render DOM."
+- `auth_wall_detected` — "This page requires authentication. Go back to step 4." Auto-jump to step 4.
+
+**Edit-route step deep-link (D-11):**
+
+```typescript
+// $kbSlug_.edit-connector.$connectorId.tsx
+const search = useSearch({ from: '/_app/app/knowledge/$kbSlug_/edit-connector/$connectorId' })
+const initialStep = search.step === 'auth' ? 4 : search.step === 'selector' ? 5 : 1
+```
+
+Add `step: z.enum(['auth', 'selector']).optional()` to the route's search-param schema.
+
+### REQ-5 — Connectors list error state
+
+**File:** `klai-portal/frontend/src/routes/app/knowledge/$kbSlug.tsx` (the connectors table component).
+
+**Render rules:**
+- When `connector.needs_reconfiguration === true`: render red `Badge` with text "Needs reconfiguration".
+- Click badge OR explicit "Investigate" link → open `<InvestigateDialog connectorId={c.id} kbSlug={kbSlug} />`.
+
+**InvestigateDialog (new component):**
+- Title: "Connector needs reconfiguration"
+- Body: explanatory text from a static map (the actual `error_details.suggestion` will become available once the cross-DB join lands).
+- Three buttons:
+  - "Edit Authentication" → `navigate({ to: '/app/knowledge/$kbSlug/edit-connector/$connectorId', search: { step: 'auth' }, params: { kbSlug, connectorId: c.id } })`
+  - "Edit Selector" → same with `step: 'selector'`
+  - "Run Preview" → `step: 'selector'` + `?autoPreview=1` (the wizard's onMount inspects this and triggers the preview button programmatically)
+
+### REQ-6 — Frontend tests
+
+**Files (new):**
+- `klai-portal/frontend/src/routes/app/knowledge/__tests__/wizard-add-connector.test.tsx`
+- `klai-portal/frontend/src/routes/app/knowledge/__tests__/wizard-edit-connector.test.tsx`
+- `klai-portal/frontend/src/routes/app/knowledge/__tests__/connectors-list-error-state.test.tsx`
+
+**Test list:**
+- `test_wizard_cannot_skip_auth_step` — fill details, attempt step-5 advance → blocked.
+- `test_wizard_disabled_add_button_until_step_5_success`.
+- `test_wizard_re_verifies_when_base_url_changed_after_auth_ok`.
+- `test_wizard_shows_match_reasons_on_auth_failed_still_walled`.
+- `test_wizard_shows_match_reasons_on_selector_required` (Redcactus case).
+- `test_edit_route_step_param_opens_at_correct_step` — `?step=auth` → wizard at 4.
+- `test_edit_pre_populates_state_from_existing_connector`.
+- `test_connectors_list_shows_failed_badge_for_dirty_content_reason`.
+- `test_investigate_dialog_renders_suggestion_text`.
+- `test_edit_authentication_button_navigates_with_step_param`.
+
+Use Vitest + Testing Library. Mock `fetch` with the contracts above.
+
+---
+
+## Acceptance verification (post-frontend)
+
+When the frontend lands, run these against the live Voys/support tenant:
+
+1. **AC-2** — Configure web_crawler at the Redcactus URL with step 3 = "No, public". REQ-2 returns `auth_failed_no_cookies`; wizard refuses to advance.
+2. **AC-3** — Same URL, step 3 = "Yes" + valid cookie. REQ-2 returns `auth_ok`. Wizard advances.
+3. **AC-5** — Public site, no `content_selector`. REQ-3 returns `selector_required`.
+4. **AC-7** — Trigger sync on a connector whose seed is now auth-walled. Sync ends `failed` with `error_summary.reason='boilerplate_or_authwall_dominant'` (REQ-4 backend already does this).
+5. **AC-8** — Connectors list shows red badge for the failed Redcactus connector. "Edit Authentication" navigates to `?step=auth`.
+6. **AC-9** — Existing Voys/support Redcactus connector (id `e7fac358-…`) flagged on first list-page view post-deploy.
+
+---
+
+## Trade-offs to flag
+
+1. **`needs_reconfiguration` proxy** — the SPEC's full predicate (`error_details.reason == 'boilerplate_or_authwall_dominant'`) requires querying `connector.sync_runs` in klai-connector's schema. The proxy `connector_type == 'web_crawler' AND last_sync_status == 'failed'` is correct for AC-9 (the Redcactus connector currently has `last_sync_status='failed'`) but will surface false positives if a web_crawler fails for unrelated reasons. The "Investigate" dialog's deep-links into the wizard will surface the real problem on the next user click — so false positives have a recovery path; not a hard blocker for shipping.
+
+2. **`error_details.suggestion` text** — REQ-4 writes this server-side, but portal does not currently fetch it (would require either a sync-status callback extension to persist `error_summary` JSONB on `portal_connectors`, OR an HTTP round-trip per connector to klai-connector's `/sync-runs?limit=1` endpoint). For MVP frontend, a static map of suggestion text per `last_sync_status` is acceptable; the live `error_summary` integration is a follow-up SPEC.
+
+3. **REQ-6 backend integration test for `crawl_site` dirty-content guard** — covered by 8 pure-function unit tests in `tests/test_crawl_site_dirty_content_guard.py`. A full integration test would require a live crawl4ai container and is out of scope for unit-test CI; the integration is one call-site in `run_crawl_job` with no branching logic.
+
+---
+
+## Branch / commits
+
+```
+feature/SPEC-CONNECTOR-INPUT-VALIDATION-001 (worktree at /Users/mvletter/Developer/klai-connector-validation)
+├── 33af111d  feat(ingest): REQ-2 — auth-wall classifier + /auth-probe endpoint
+├── a55a4cf8  feat(ingest): REQ-3 — link-density helper + preview classification
+├── ffd87ad5  feat(ingest): REQ-4 — sync-time hard-fail on dirty content
+└── ff4ded8e  feat(portal): REQ-1/7 backend — auth-probe pass-through + needs_reconfiguration
+```
+
+Test totals shipped this branch:
+- 41 auth_wall_classifier unit tests
+- 12 auth-probe endpoint tests
+- 9 link_density unit tests
+- 7 preview-classification tests
+- 12 dirty-content guard unit tests
+- 8 needs_reconfiguration predicate tests
+- 1 neighbor regression fix
+
+**~90 net new tests, all green; pre-existing main-branch failures (test_crawl_url_ssrf_parity, test_request_with_correct_secret_passes) untouched.**

--- a/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
+++ b/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
@@ -37,6 +37,74 @@ logger = structlog.get_logger()
 _VALID_LOGIN_WALL_MODES = ("reject", "degrade", "audit_only")
 
 
+# SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-4: structured reason code written
+# into ``crawl_jobs.error_summary`` and ``connector.sync_runs.error_details``
+# when the dirty-content guard trips. REQ-5 surfaces this exact string in the
+# UI badge query, so it MUST stay stable.
+DIRTY_CONTENT_REASON = "boilerplate_or_authwall_dominant"
+
+_DIRTY_CONTENT_SUGGESTION = (
+    "Re-run preview from the connector edit page. The site likely now requires "
+    "authentication or the content_selector is no longer matching."
+)
+
+
+def decide_terminal_status(
+    *,
+    auth_wall_count: int,
+    total_count: int,
+    has_cookies: bool,
+    has_login_indicator: bool,
+    threshold: float,
+) -> tuple[str, dict | None]:
+    """SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-4 — pure decision function.
+
+    Decide whether a finished crawl_site run should be marked
+    ``failed_partial`` because too many pages classified as auth-walled
+    while the operator did not configure cookies or a login indicator.
+
+    @MX:NOTE — Threshold defaults to 0.30 in ``settings``; env var
+    ``KLAI_INGEST_AUTHWALL_DIRTY_TRIP_RATE`` overrides per-deployment.
+    Default calibrated against Voys help (0% trip-rate post-PR-#459)
+    and Redcactus pre-fix (70% trip-rate).
+    @MX:REASON — Loud failure beats silent skip. Operator gets actionable
+    error in connector.sync_runs.error_details; UI surfaces via REQ-5.
+
+    Args:
+        auth_wall_count: Pages that classified as auth-walled.
+        total_count: Total pages reaching the post-fetch decision.
+        has_cookies: True when the connector has cookies configured (the
+            operator EXPECTED auth-walled content; do not trip).
+        has_login_indicator: True when ``login_indicator_selector`` is
+            configured (same rationale as cookies).
+        threshold: Trip-rate at or above which the guard fires. Inclusive
+            (0.30 trips when 30/100 pages are walled).
+
+    Returns:
+        ``(terminal_status, summary_dict_or_None)``. ``summary_dict`` is
+        the JSONB payload to write into ``crawl_jobs.error_summary`` when
+        ``terminal_status == "failed_partial"`` and the guard fired.
+        Returns ``(None, None)`` semantics are NOT used — when the guard
+        does not fire, returns ``("", None)`` so the caller falls through
+        to its existing terminal-status logic.
+    """
+    if total_count <= 0:
+        return ("", None)
+    if has_cookies or has_login_indicator:
+        return ("", None)
+    trip_rate = round(auth_wall_count / total_count, 3)
+    if trip_rate < threshold:
+        return ("", None)
+    summary: dict = {
+        "reason": DIRTY_CONTENT_REASON,
+        "trip_rate": trip_rate,
+        "auth_wall_count": auth_wall_count,
+        "total_count": total_count,
+        "suggestion": _DIRTY_CONTENT_SUGGESTION,
+    }
+    return ("failed_partial", summary)
+
+
 # @MX:ANCHOR: AuthWallDetected -- propagates login-indicator triggers from _ingest_crawl_result
 #   back up to run_crawl_job, which converts them into a single structured
 #   crawl_jobs.error entry and halts the remaining BFS pages.
@@ -300,19 +368,56 @@ async def run_crawl_job(
                 job_id,
             )
 
-        # SPEC-INGEST-LOGIN-WALL-DETECT-001 REQ-04.2/04.3 — terminal status:
-        # - failed_partial when 0 pages ingested AND >= 1 wall skipped (no real
-        #   content reached Qdrant; surface that to operators distinctly from
-        #   plain "completed but no walls" or "failed catastrophically").
-        # - completed otherwise (legacy alias retained for back-compat with
-        #   existing UI / Grafana queries during rollout; future SPEC may
-        #   migrate the alias to "succeeded").
-        if auth_wall_pages and pages_done == 0:
-            terminal_status = "failed_partial"
-        else:
-            terminal_status = "completed"
+        # SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-4 — dirty-content guard.
+        # Evaluate FIRST: if too many pages classified as auth-walled while
+        # no cookies / login_indicator are configured, mark failed_partial
+        # with the structured reason that REQ-5's UI badge keys on.
+        dirty_status, dirty_summary = decide_terminal_status(
+            auth_wall_count=len(auth_wall_pages),
+            total_count=len(results),
+            has_cookies=bool(cookies),
+            has_login_indicator=bool(login_indicator_selector),
+            threshold=settings.ingest_authwall_dirty_trip_rate,
+        )
 
-        if auth_wall_pages:
+        # SPEC-INGEST-LOGIN-WALL-DETECT-001 REQ-04.2/04.3 — terminal status:
+        # - failed_partial when REQ-4 dirty-content guard tripped (loud failure)
+        # - failed_partial when 0 pages ingested AND >= 1 wall skipped
+        # - completed otherwise
+        if dirty_status:
+            terminal_status = dirty_status
+            summary_payload = dirty_summary or {}
+            # Preserve the existing wall-tracking diagnostics alongside the
+            # REQ-4 reason for forensic logs.
+            summary_payload.setdefault("login_walls_skipped", len(auth_wall_pages))
+            summary_payload.setdefault("sample_urls", auth_wall_pages[:10])
+            summary_json = json.dumps(summary_payload)
+            await conn.execute(
+                "UPDATE knowledge.crawl_jobs SET status=$1, error_summary=$2::jsonb, "
+                "updated_at=$3 WHERE id=$4",
+                terminal_status,
+                summary_json,
+                int(time.time()),
+                job_id,
+            )
+        elif auth_wall_pages and pages_done == 0:
+            terminal_status = "failed_partial"
+            summary_json = json.dumps(
+                {
+                    "login_walls_skipped": len(auth_wall_pages),
+                    "sample_urls": auth_wall_pages[:10],
+                }
+            )
+            await conn.execute(
+                "UPDATE knowledge.crawl_jobs SET status=$1, error_summary=$2::jsonb, "
+                "updated_at=$3 WHERE id=$4",
+                terminal_status,
+                summary_json,
+                int(time.time()),
+                job_id,
+            )
+        elif auth_wall_pages:
+            terminal_status = "completed"
             summary_json = json.dumps(
                 {
                     "login_walls_skipped": len(auth_wall_pages),
@@ -328,6 +433,7 @@ async def run_crawl_job(
                 job_id,
             )
         else:
+            terminal_status = "completed"
             await _update_job(conn, job_id, status=terminal_status)
 
         logger.info(

--- a/klai-knowledge-ingest/knowledge_ingest/config.py
+++ b/klai-knowledge-ingest/knowledge_ingest/config.py
@@ -34,6 +34,19 @@ class Settings(BaseSettings):
     # own. Default 5 catches RedCactus's 149-page cluster easily and protects
     # single/few-page pseudo-walls under cold-start permissiveness (REQ-03).
     ingest_template_cluster_min: int = 5
+    # SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-4 / D-7 — sync-time hard-fail
+    # threshold. A crawl_site run with auth_wall_count / total_count above
+    # this ratio AND no cookies AND no login_indicator_selector configured
+    # MUST end with status='failed_partial' and a structured error_summary
+    # so operators see the connector is broken — instead of the silent
+    # "synced 5 days ago, 25 docs indexed" UI lie that this SPEC fixes.
+    # 0.30 is calibrated against Voys help (0% trip-rate post-PR-#459) and
+    # Redcactus 2026-05-07 morning (70% trip-rate). Env-tunable so prod
+    # can adjust if a legitimate edge case emerges without code change.
+    ingest_authwall_dirty_trip_rate: float = Field(
+        default=0.30,
+        validation_alias=AliasChoices("KLAI_INGEST_AUTHWALL_DIRTY_TRIP_RATE"),
+    )
     # LLM enrichment (contextual prefix + HyPE questions via LiteLLM proxy)
     litellm_url: str = "http://litellm:4000"
     litellm_api_key: str = ""

--- a/klai-knowledge-ingest/knowledge_ingest/routes/crawl.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/crawl.py
@@ -42,6 +42,7 @@ from knowledge_ingest.selector_ai import (
     detect_selector_via_llm,
 )
 from knowledge_ingest.utils.auth_wall_classifier import classify_auth_wall
+from knowledge_ingest.utils.link_density import LINK_DENSITY_THRESHOLD, link_density
 from knowledge_ingest.utils.url_validator import validate_url, validate_url_pinned
 
 logger = structlog.get_logger()
@@ -113,6 +114,18 @@ class CrawlPreviewResponse(BaseModel):
     content_selector: str | None = None
     selector_source: str | None = None  # "user" | "ai" | None
     auth_guard: AuthGuardSuggestion | None = None  # SPEC-CRAWL-004
+    # SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-3 — five-way classification
+    # used by the wizard to gate step-5 → step-6 advance.
+    classification: str = "success"
+    classification_reason: str | None = None
+
+
+# SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-3 — distinguish "selector matched
+# nothing" (raw HTML present, content_selector wrong) from "page is JS-only"
+# (raw HTML minimal, no JS execution path). 5KB is the empirical anchor:
+# server-rendered pages with any content exceed 5KB; SPA shells with a single
+# ``<div id="root">`` stay under.
+_RAW_HTML_SPA_THRESHOLD_BYTES = 5000
 
 
 class AuthProbeRequest(BaseModel):
@@ -166,6 +179,59 @@ async def _run_crawl(
     return fit_md, result.word_count, result.html
 
 
+def _classify_preview_outcome(
+    *,
+    fit_markdown: str,
+    raw_html: str,
+    word_count: int,
+    response_status_code: int | None,
+    redirect_target_url: str | None,
+    set_cookie_header: str | None,
+) -> tuple[str, str | None]:
+    """REQ-3 — return ``(classification, classification_reason)`` for the preview.
+
+    Order of checks matters:
+      1. auth-wall heuristic wins over everything else (we never want to
+         hand a "success" verdict on a 401 page just because it has many
+         words).
+      2. If word_count is sufficient: link-density gate.
+      3. If word_count is thin: distinguish empty-selector vs SPA via raw
+         HTML size.
+    """
+    auth_wall = classify_auth_wall(
+        response_status_code=response_status_code,
+        redirect_target_url=redirect_target_url,
+        set_cookie_header=set_cookie_header,
+        word_count=word_count,
+        fit_markdown=fit_markdown,
+        raw_html=raw_html,
+    )
+    if auth_wall.is_walled:
+        return ("auth_wall_detected", "Page requires authentication.")
+
+    if word_count >= _MIN_WORD_COUNT:
+        density = link_density(fit_markdown)
+        if density > LINK_DENSITY_THRESHOLD:
+            pct = int(density * 100)
+            return (
+                "selector_required",
+                f"{pct}% of the text is links. Configure a Content Selector.",
+            )
+        return ("success", None)
+
+    if raw_html and len(raw_html) > _RAW_HTML_SPA_THRESHOLD_BYTES:
+        return (
+            "selector_returns_empty",
+            "Selector matched no content. Try a different selector or click 'Let AI find'.",
+        )
+
+    return (
+        "requires_javascript",
+        "Page renders via JavaScript. Configure a wait_for condition or "
+        "selector for the post-render DOM.",
+    )
+
+
 @contextlib.asynccontextmanager
 async def _maybe_tenant_conn(org_id: str):
     """Yield a GUC-pinned conn when org_id is present, else None.
@@ -212,10 +278,16 @@ async def preview_crawl(body: CrawlPreviewRequest, request: Request) -> CrawlPre
                 if stored:
                     effective_selector, selector_source = stored
 
-            # Initial crawl (HTTP, no DB)
-            fit_md, word_count, _ = await _run_crawl(
+            # Initial crawl (HTTP, no DB). Capture full CrawlResult so we
+            # can run the REQ-3 classifier with HTTP-level metadata
+            # (status_code, redirect URL, response headers).
+            initial_result = await crawl_page(
                 body.url, effective_selector, cookies=body.cookies
             )
+            fit_md = initial_result.fit_markdown or initial_result.raw_markdown
+            word_count = initial_result.word_count
+            raw_html = initial_result.html
+            last_result = initial_result
             warnings: list[str] = _detect_nav_contamination(fit_md)
 
             # AI-assisted selector detection — only when explicitly requested via try_ai flag
@@ -231,9 +303,13 @@ async def preview_crawl(body: CrawlPreviewRequest, request: Request) -> CrawlPre
                     ai_selector = await detect_selector_via_llm(dom_summary)
                     if ai_selector:
                         try:
-                            recrawl_md, recrawl_wc, _ = await _run_crawl(
+                            recrawl_result = await crawl_page(
                                 body.url, ai_selector, cookies=body.cookies
                             )
+                            recrawl_md = (
+                                recrawl_result.fit_markdown or recrawl_result.raw_markdown
+                            )
+                            recrawl_wc = recrawl_result.word_count
                             if recrawl_wc >= _MIN_WORD_COUNT:
                                 await upsert_domain_selector(
                                     conn,
@@ -244,6 +320,8 @@ async def preview_crawl(body: CrawlPreviewRequest, request: Request) -> CrawlPre
                                 )
                                 fit_md = recrawl_md
                                 word_count = recrawl_wc
+                                raw_html = recrawl_result.html
+                                last_result = recrawl_result
                                 warnings = _detect_nav_contamination(fit_md)
                                 effective_selector = ai_selector
                                 selector_source = "ai"
@@ -302,6 +380,21 @@ async def preview_crawl(body: CrawlPreviewRequest, request: Request) -> CrawlPre
                         url=body.url,
                     )
 
+        # SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-3 — classification
+        metadata = last_result.metadata or {}
+        response_headers = last_result.response_headers or {}
+        set_cookie_header = response_headers.get("set-cookie") or response_headers.get(
+            "Set-Cookie"
+        )
+        classification, classification_reason = _classify_preview_outcome(
+            fit_markdown=fit_md,
+            raw_html=raw_html,
+            word_count=word_count,
+            response_status_code=metadata.get("status_code"),
+            redirect_target_url=metadata.get("redirect_url") or metadata.get("location"),
+            set_cookie_header=set_cookie_header,
+        )
+
         return CrawlPreviewResponse(
             url=body.url,
             fit_markdown=fit_md,
@@ -310,10 +403,18 @@ async def preview_crawl(body: CrawlPreviewRequest, request: Request) -> CrawlPre
             content_selector=effective_selector,
             selector_source=selector_source,
             auth_guard=auth_guard,
+            classification=classification,
+            classification_reason=classification_reason,
         )
     except Exception as exc:
         logger.warning("crawl_preview_failed", url=body.url, error=str(exc))
-        return CrawlPreviewResponse(url=body.url, fit_markdown="", word_count=0)
+        return CrawlPreviewResponse(
+            url=body.url,
+            fit_markdown="",
+            word_count=0,
+            classification="requires_javascript",
+            classification_reason="Crawl failed — see service logs.",
+        )
 
 
 @router.post("/ingest/v1/crawl/auth-probe", response_model=AuthProbeResponse)

--- a/klai-knowledge-ingest/knowledge_ingest/routes/crawl.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/crawl.py
@@ -281,9 +281,7 @@ async def preview_crawl(body: CrawlPreviewRequest, request: Request) -> CrawlPre
             # Initial crawl (HTTP, no DB). Capture full CrawlResult so we
             # can run the REQ-3 classifier with HTTP-level metadata
             # (status_code, redirect URL, response headers).
-            initial_result = await crawl_page(
-                body.url, effective_selector, cookies=body.cookies
-            )
+            initial_result = await crawl_page(body.url, effective_selector, cookies=body.cookies)
             fit_md = initial_result.fit_markdown or initial_result.raw_markdown
             word_count = initial_result.word_count
             raw_html = initial_result.html
@@ -306,9 +304,7 @@ async def preview_crawl(body: CrawlPreviewRequest, request: Request) -> CrawlPre
                             recrawl_result = await crawl_page(
                                 body.url, ai_selector, cookies=body.cookies
                             )
-                            recrawl_md = (
-                                recrawl_result.fit_markdown or recrawl_result.raw_markdown
-                            )
+                            recrawl_md = recrawl_result.fit_markdown or recrawl_result.raw_markdown
                             recrawl_wc = recrawl_result.word_count
                             if recrawl_wc >= _MIN_WORD_COUNT:
                                 await upsert_domain_selector(
@@ -383,9 +379,7 @@ async def preview_crawl(body: CrawlPreviewRequest, request: Request) -> CrawlPre
         # SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-3 — classification
         metadata = last_result.metadata or {}
         response_headers = last_result.response_headers or {}
-        set_cookie_header = response_headers.get("set-cookie") or response_headers.get(
-            "Set-Cookie"
-        )
+        set_cookie_header = response_headers.get("set-cookie") or response_headers.get("Set-Cookie")
         classification, classification_reason = _classify_preview_outcome(
             fit_markdown=fit_md,
             raw_html=raw_html,
@@ -453,9 +447,7 @@ async def auth_probe(body: AuthProbeRequest, request: Request) -> AuthProbeRespo
 
     metadata = result.metadata or {}
     response_headers = result.response_headers or {}
-    set_cookie_header = response_headers.get("set-cookie") or response_headers.get(
-        "Set-Cookie"
-    )
+    set_cookie_header = response_headers.get("set-cookie") or response_headers.get("Set-Cookie")
     redirect_target_url = metadata.get("redirect_url") or metadata.get("location")
 
     classification = classify_auth_wall(

--- a/klai-knowledge-ingest/knowledge_ingest/routes/crawl.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/crawl.py
@@ -31,13 +31,17 @@ from knowledge_ingest.domain_selectors import (
     upsert_domain_selector,
 )
 from knowledge_ingest.fingerprint import compute_content_fingerprint
-from knowledge_ingest.identity import assert_caller_identity
+from knowledge_ingest.identity import (
+    assert_caller_identity,
+    assert_caller_identity_tenant_only,
+)
 from knowledge_ingest.models import CrawlRequest, CrawlResponse, IngestRequest
 from knowledge_ingest.routes.ingest import ingest_document
 from knowledge_ingest.selector_ai import (
     detect_login_indicator_via_llm,
     detect_selector_via_llm,
 )
+from knowledge_ingest.utils.auth_wall_classifier import classify_auth_wall
 from knowledge_ingest.utils.url_validator import validate_url, validate_url_pinned
 
 logger = structlog.get_logger()
@@ -109,6 +113,39 @@ class CrawlPreviewResponse(BaseModel):
     content_selector: str | None = None
     selector_source: str | None = None  # "user" | "ai" | None
     auth_guard: AuthGuardSuggestion | None = None  # SPEC-CRAWL-004
+
+
+class AuthProbeRequest(BaseModel):
+    """SPEC-CONNECTOR-INPUT-VALIDATION-001 / REQ-2.
+
+    Same payload shape as ``CrawlPreviewRequest`` minus the selector
+    fields — the auth probe is run against the seed URL only, no
+    ``content_selector`` and no AI fallback.
+    """
+
+    url: str
+    org_id: str = ""
+    cookies: list[dict] | None = None
+
+
+class AuthProbeResponse(BaseModel):
+    """SPEC-CONNECTOR-INPUT-VALIDATION-001 / REQ-2.
+
+    Five-way classification of the seed-page fetch outcome.
+
+    Possible ``classification`` values:
+
+    - ``auth_ok``
+    - ``auth_failed_no_cookies``
+    - ``auth_failed_still_walled``
+    - ``auth_failed_credentials_invalid``
+    - ``auth_failed_unreachable``
+    """
+
+    classification: str
+    match_reasons: list[str] = []
+    word_count: int
+    auth_guard: AuthGuardSuggestion | None = None
 
 
 # Minimum word count for a crawl result to be considered usable content.
@@ -277,6 +314,116 @@ async def preview_crawl(body: CrawlPreviewRequest, request: Request) -> CrawlPre
     except Exception as exc:
         logger.warning("crawl_preview_failed", url=body.url, error=str(exc))
         return CrawlPreviewResponse(url=body.url, fit_markdown="", word_count=0)
+
+
+@router.post("/ingest/v1/crawl/auth-probe", response_model=AuthProbeResponse)
+async def auth_probe(body: AuthProbeRequest, request: Request) -> AuthProbeResponse:
+    """SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-2 — classify a single seed
+    fetch as ``auth_ok`` or one of four failure flavours.
+
+    Mirrors the SSRF and identity guards on ``/ingest/v1/crawl/preview``:
+
+    - SSRF validation runs BEFORE any DNS lookup downstream
+      (SPEC-SEC-SSRF-001 REQ-1.1 / AC-1).
+    - When ``org_id`` is supplied, ``assert_caller_identity_tenant_only``
+      enforces tenant scoping (per the bug-pattern memory: this is an
+      internal-secret + tenant-only route, no end-user context).
+    """
+    logger.info("auth_probe_started", url=body.url)
+
+    if body.org_id:
+        await assert_caller_identity_tenant_only(request, claimed_org_id=body.org_id)
+
+    try:
+        await validate_url_pinned(body.url)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    try:
+        result = await crawl_page(body.url, selector=None, cookies=body.cookies)
+    except Exception as exc:
+        logger.warning("auth_probe_crawl_failed", url=body.url, error=str(exc))
+        return AuthProbeResponse(
+            classification="auth_failed_unreachable",
+            match_reasons=[],
+            word_count=0,
+            auth_guard=None,
+        )
+
+    metadata = result.metadata or {}
+    response_headers = result.response_headers or {}
+    set_cookie_header = response_headers.get("set-cookie") or response_headers.get(
+        "Set-Cookie"
+    )
+    redirect_target_url = metadata.get("redirect_url") or metadata.get("location")
+
+    classification = classify_auth_wall(
+        response_status_code=metadata.get("status_code"),
+        redirect_target_url=redirect_target_url,
+        set_cookie_header=set_cookie_header,
+        word_count=result.word_count,
+        fit_markdown=result.fit_markdown or "",
+        raw_html=result.html or "",
+    )
+
+    label = _label_for_auth_probe(
+        is_walled=classification.is_walled,
+        match_reasons=classification.match_reasons,
+        word_count=result.word_count,
+        crawl_success=result.success,
+        cookies_provided=bool(body.cookies),
+    )
+
+    auth_guard: AuthGuardSuggestion | None = None
+    if label == "auth_ok" and body.cookies:
+        canary_fp = compute_content_fingerprint(result.fit_markdown or "")
+        if canary_fp:
+            auth_guard = AuthGuardSuggestion(
+                canary_url=body.url,
+                canary_fingerprint=canary_fp,
+            )
+            try:
+                dom_summary = await crawl_dom_summary(body.url)
+                if dom_summary:
+                    indicator = await detect_login_indicator_via_llm(dom_summary)
+                    if indicator:
+                        auth_guard.login_indicator_selector = indicator
+                        auth_guard.login_indicator_description = f"Detected: {indicator}"
+            except Exception:
+                logger.debug("auth_probe_indicator_detection_skipped", url=body.url)
+
+    return AuthProbeResponse(
+        classification=label,
+        match_reasons=list(classification.match_reasons),
+        word_count=result.word_count,
+        auth_guard=auth_guard,
+    )
+
+
+def _label_for_auth_probe(
+    *,
+    is_walled: bool,
+    match_reasons: tuple[str, ...],
+    word_count: int,
+    crawl_success: bool,
+    cookies_provided: bool,
+) -> str:
+    """Map classifier output + request context to one of five outcome labels.
+
+    SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-2 outcome table.
+    """
+    if "http_unauthenticated" in match_reasons:
+        return "auth_failed_credentials_invalid"
+    if is_walled:
+        return "auth_failed_still_walled" if cookies_provided else "auth_failed_no_cookies"
+    if not crawl_success or word_count == 0:
+        return "auth_failed_unreachable"
+    if word_count < _MIN_WORD_COUNT:
+        # Reachable but thin — the page renders but has no real content.
+        # Treated the same as unreachable for the wizard: the user must
+        # configure cookies or pick a different seed.
+        return "auth_failed_unreachable"
+    return "auth_ok"
 
 
 @router.post("/ingest/v1/crawl", response_model=CrawlResponse)

--- a/klai-knowledge-ingest/knowledge_ingest/utils/auth_wall_classifier.py
+++ b/klai-knowledge-ingest/knowledge_ingest/utils/auth_wall_classifier.py
@@ -1,0 +1,213 @@
+"""Pure-function auth-wall classifier shared across three call-sites.
+
+SPEC-CONNECTOR-INPUT-VALIDATION-001 / REQ-2.
+
+@MX:ANCHOR fan_in=3 — invariant. Three call-sites depend on the contract of
+``classify_auth_wall``:
+
+1. ``routes/crawl.py::auth_probe`` — REQ-2 step-4 wizard validation.
+2. ``routes/crawl.py::preview_crawl`` — REQ-3 step-5 selector validation
+   (calls the classifier alongside link-density to decide success vs
+   ``auth_wall_detected``).
+3. ``adapters/crawler.py`` post-fetch guard — REQ-4 sync-time defense in
+   depth.
+
+Reason: collapsing the three would silently re-introduce the failure
+mode that produced this SPEC (a connector ingesting nav stubs because
+the front door checked one thing and the back door checked another).
+The classifier is the single source of truth.
+
+@MX:NOTE — ``AUTH_WALL_END_OF_BODY_MARKERS`` is a localised marker list.
+Adding DE/FR is a one-line append. Do not refactor the regex shape
+without checking every entry — markers are written to match end-of-body
+patterns; reshaping them risks false positives in nav menus (D-13).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from urllib.parse import urlparse
+
+__all__ = [
+    "AUTH_WALL_END_OF_BODY_MARKERS",
+    "AuthWallClassification",
+    "LOGIN_PATH_REGEX",
+    "SESSION_COOKIE_REGEX",
+    "classify_auth_wall",
+]
+
+
+# ---------------------------------------------------------------------------
+# Module-level constants (D-12, D-13)
+# ---------------------------------------------------------------------------
+
+# REQ-2 D-12: NL + EN initial coverage. DE/FR can be appended without
+# restructuring. Each pattern is a regex matched case-insensitively at the
+# tail of ``fit_markdown``.
+AUTH_WALL_END_OF_BODY_MARKERS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(p, re.IGNORECASE)
+    for p in (
+        # English "log/sign in to <verb>" — trailing "this|more" is optional
+        # (e.g. "log in to continue" without trailing object).
+        r"(log|sign) in to (read|view|continue|see)(?:\s+(this|more))?",
+        # English imperative — "please log in", "even sign in"
+        r"(please|even) (log|sign) in",
+        # English long-form
+        r"log in when you want to (read|view) this article",
+        # Dutch — "even inloggen" / "even aanmelden" (informal "please log in")
+        r"(even|graag)\s+(inloggen|aanmelden)",
+        # Dutch — full clause "inloggen om verder te lezen"
+        r"inloggen om (verder|dit) (te lezen|te bekijken)",
+        r"aanmelden om (verder|dit) (te lezen|te bekijken)",
+    )
+)
+
+# Match a login path component anywhere in a redirect URL path. Allows
+# leading path segments (``/users/login``) and trailing query/fragment
+# (``/login?return_to=...``). Boundaries prevent matching prefixes like
+# ``/blogin`` or substrings like ``/sublogin/foo``.
+LOGIN_PATH_REGEX: re.Pattern[str] = re.compile(
+    r"(?:^|/)(login|signin|sign-?in|aanmelden|inloggen|anmelden|connexion|accedi)(?:/|$|\?|#)",
+    re.IGNORECASE,
+)
+
+# A "session cookie" is anything whose name contains session/sid/auth_token.
+# Matched against the FULL ``Set-Cookie`` header; the header is not parsed
+# semantically because we only need a boolean signal.
+SESSION_COOKIE_REGEX: re.Pattern[str] = re.compile(
+    r"(?:^|;\s*)([\w\-]*(session|sid|auth_?token)[\w\-]*)\s*=", re.IGNORECASE
+)
+
+# REQ-2: shared with ``routes/crawl.py`` (kept in-sync; that module already
+# defines its own ``_MIN_WORD_COUNT = 100`` per D-5 rationale).
+_MIN_WORD_COUNT_FOR_AUTH_HEURISTIC = 100
+
+# REQ-2 D-13: only inspect the END of the body for login markers. A nav
+# header containing "Log in" anywhere on the page must NOT trip the
+# heuristic. 200 chars is roughly two short paragraphs of trailing text.
+_END_OF_BODY_WINDOW_CHARS = 200
+
+# Password-form HTML signature. Lower-cased substring search is fine — we
+# only care about the presence of a password input on a near-empty page.
+_PASSWORD_INPUT_PATTERN = re.compile(
+    r'<input[^>]*type\s*=\s*["\']?password["\']?', re.IGNORECASE
+)
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AuthWallClassification:
+    """Outcome of a single auth-wall classification.
+
+    Attributes:
+        is_walled: True when ANY sub-rule matched.
+        match_reasons: Tuple of sub-rule identifiers that matched. Returned
+            even when ``is_walled`` is True so callers can render specific
+            user feedback ("session cookie + minimal body" vs "401 status").
+    """
+
+    is_walled: bool
+    match_reasons: tuple[str, ...] = field(default_factory=tuple)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def classify_auth_wall(
+    *,
+    response_status_code: int | None,
+    redirect_target_url: str | None,
+    set_cookie_header: str | None,
+    word_count: int,
+    fit_markdown: str,
+    raw_html: str,
+) -> AuthWallClassification:
+    """Apply six sub-rules and return the aggregate classification.
+
+    Sub-rules (any match flips ``is_walled`` to True):
+
+    1. ``http_unauthenticated`` — HTTP 401 / 403.
+    2. ``redirect_to_login`` — HTTP 30x where ``Location`` path matches
+       ``LOGIN_PATH_REGEX`` (login, signin, aanmelden, inloggen,
+       anmelden, connexion, accedi).
+    3. ``session_cookie_minimal_body`` — ``Set-Cookie`` matches
+       ``SESSION_COOKIE_REGEX`` AND ``word_count`` is below the auth
+       heuristic threshold.
+    4. ``end_of_body_login_marker`` — last
+       ``_END_OF_BODY_WINDOW_CHARS`` of ``fit_markdown`` matches any
+       pattern in ``AUTH_WALL_END_OF_BODY_MARKERS``.
+    5. ``password_form_minimal_body`` — ``raw_html`` contains an
+       ``<input type="password">`` AND ``word_count`` is below the
+       threshold.
+
+    Args:
+        response_status_code: HTTP status of the original page request.
+            ``None`` when the upstream did not record a status (e.g. raw
+            connection error). Treated as "no signal".
+        redirect_target_url: Full URL of the final redirect target if any
+            (the page request followed a 30x). ``None`` when no redirect
+            occurred.
+        set_cookie_header: Raw ``Set-Cookie`` response header value as a
+            single string. Multiple cookies separated by ``,`` or ``;``
+            are treated as concatenated text — we only need a regex hit.
+        word_count: Word count of the page after content extraction.
+        fit_markdown: ``fit_markdown`` from the crawl result (post
+            ``PruningContentFilter``).
+        raw_html: Raw HTML body. Used only for the password-form
+            sub-rule.
+
+    Returns:
+        ``AuthWallClassification`` with all matching reasons.
+    """
+    reasons: list[str] = []
+
+    # Rule 1 — HTTP unauthenticated
+    if response_status_code in (401, 403):
+        reasons.append("http_unauthenticated")
+
+    # Rule 2 — redirect to login path
+    if redirect_target_url:
+        try:
+            parsed = urlparse(redirect_target_url)
+            if parsed.path and LOGIN_PATH_REGEX.search(parsed.path):
+                reasons.append("redirect_to_login")
+        except (ValueError, AttributeError):
+            # Malformed URL — never raise from a classifier; just don't
+            # match this rule.
+            pass
+
+    # Rule 3 — session cookie + minimal body
+    if (
+        set_cookie_header
+        and SESSION_COOKIE_REGEX.search(set_cookie_header)
+        and word_count < _MIN_WORD_COUNT_FOR_AUTH_HEURISTIC
+    ):
+        reasons.append("session_cookie_minimal_body")
+
+    # Rule 4 — end-of-body login marker (D-13: tail-only, not anywhere)
+    if fit_markdown:
+        tail = fit_markdown[-_END_OF_BODY_WINDOW_CHARS:]
+        for pattern in AUTH_WALL_END_OF_BODY_MARKERS:
+            if pattern.search(tail):
+                reasons.append("end_of_body_login_marker")
+                break
+
+    # Rule 5 — password form on a thin page
+    if (
+        raw_html
+        and word_count < _MIN_WORD_COUNT_FOR_AUTH_HEURISTIC
+        and _PASSWORD_INPUT_PATTERN.search(raw_html)
+    ):
+        reasons.append("password_form_minimal_body")
+
+    return AuthWallClassification(
+        is_walled=bool(reasons),
+        match_reasons=tuple(reasons),
+    )

--- a/klai-knowledge-ingest/knowledge_ingest/utils/auth_wall_classifier.py
+++ b/klai-knowledge-ingest/knowledge_ingest/utils/auth_wall_classifier.py
@@ -31,9 +31,9 @@ from urllib.parse import urlparse
 
 __all__ = [
     "AUTH_WALL_END_OF_BODY_MARKERS",
-    "AuthWallClassification",
     "LOGIN_PATH_REGEX",
     "SESSION_COOKIE_REGEX",
+    "AuthWallClassification",
     "classify_auth_wall",
 ]
 
@@ -90,9 +90,7 @@ _END_OF_BODY_WINDOW_CHARS = 200
 
 # Password-form HTML signature. Lower-cased substring search is fine — we
 # only care about the presence of a password input on a near-empty page.
-_PASSWORD_INPUT_PATTERN = re.compile(
-    r'<input[^>]*type\s*=\s*["\']?password["\']?', re.IGNORECASE
-)
+_PASSWORD_INPUT_PATTERN = re.compile(r'<input[^>]*type\s*=\s*["\']?password["\']?', re.IGNORECASE)
 
 
 # ---------------------------------------------------------------------------

--- a/klai-knowledge-ingest/knowledge_ingest/utils/link_density.py
+++ b/klai-knowledge-ingest/knowledge_ingest/utils/link_density.py
@@ -1,0 +1,57 @@
+"""Markdown link-density helper for the preview classifier (REQ-3).
+
+SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-3 / D-6.
+
+@MX:WARN — heuristic threshold (40%). Calibrated against Voys help
+(~5-10% link density on real articles) and the Redcactus broken output
+(80%+ link density on nav-only pages). Lower threshold means more false
+positives on legitimate link-heavy index pages; higher threshold misses
+real nav-leak. 40% sits cleanly between the two anchors. Adjust only
+with new calibration data — do not "tune" arbitrarily.
+
+@MX:REASON — This is the link-density signal that ``preview_crawl``
+uses to decide ``selector_required`` vs ``success``. The auth-wall
+classifier is a separate signal (see ``auth_wall_classifier.py``);
+both run on every preview.
+"""
+
+from __future__ import annotations
+
+import re
+
+__all__ = ["LINK_DENSITY_THRESHOLD", "link_density"]
+
+
+# REQ-3 D-6: 0.40 (40%). See module docstring for calibration anchors.
+LINK_DENSITY_THRESHOLD: float = 0.40
+
+
+# Markdown link: ``[anchor text](url)``. Captures the anchor text only —
+# the url is discarded for density calculation.
+_MD_LINK_RE = re.compile(r"\[([^\]]*)\]\(([^)]+)\)")
+
+
+def link_density(markdown: str) -> float:
+    """Return the ratio of anchor-text characters to total markdown text.
+
+    The numerator is the sum of all ``[anchor]`` text lengths. The
+    denominator is the full markdown length (including link syntax) —
+    using the anchor text for the numerator keeps the metric in [0, 1]
+    while still rewarding "this page is mostly link labels".
+
+    Args:
+        markdown: ``fit_markdown`` from a crawl result.
+
+    Returns:
+        Float in [0.0, 1.0]. Returns 0.0 for empty input.
+    """
+    if not markdown:
+        return 0.0
+    link_text_chars = sum(len(m.group(1)) for m in _MD_LINK_RE.finditer(markdown))
+    total_chars = len(markdown)
+    if total_chars == 0:
+        return 0.0
+    ratio = link_text_chars / total_chars
+    if ratio > 1.0:
+        return 1.0
+    return ratio

--- a/klai-knowledge-ingest/tests/test_auth_probe_endpoint.py
+++ b/klai-knowledge-ingest/tests/test_auth_probe_endpoint.py
@@ -1,0 +1,330 @@
+"""Tests for ``POST /ingest/v1/crawl/auth-probe`` (REQ-2 endpoint).
+
+SPEC-CONNECTOR-INPUT-VALIDATION-001 / REQ-2 / REQ-6.
+
+The endpoint mirrors ``/ingest/v1/crawl/preview`` but classifies the result
+into one of five outcome labels:
+
+- ``auth_ok``
+- ``auth_failed_no_cookies``
+- ``auth_failed_still_walled``
+- ``auth_failed_credentials_invalid``
+- ``auth_failed_unreachable``
+
+Identity assertion uses ``assert_caller_identity_tenant_only`` per
+bug-pattern memory (no end-user on this internal route).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from knowledge_ingest.crawl4ai_client import CrawlResult
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_crawl_result(
+    *,
+    url: str = "https://example.com/page",
+    fit_markdown: str = "",
+    raw_markdown: str = "",
+    html: str = "",
+    word_count: int = 0,
+    success: bool = True,
+    metadata: dict | None = None,
+    response_headers: dict[str, str] | None = None,
+) -> CrawlResult:
+    return CrawlResult(
+        url=url,
+        fit_markdown=fit_markdown,
+        raw_markdown=raw_markdown,
+        html=html,
+        word_count=word_count,
+        success=success,
+        metadata=metadata or {},
+        response_headers=response_headers or {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Outcome labels
+# ---------------------------------------------------------------------------
+
+
+def test_auth_probe_returns_auth_ok_for_healthy_public_page(client: TestClient) -> None:
+    healthy = _make_crawl_result(
+        fit_markdown="A long article body. " * 60,
+        raw_markdown="A long article body. " * 60,
+        word_count=600,
+        metadata={"status_code": 200},
+        response_headers={"content-type": "text/html"},
+    )
+    with patch(
+        "knowledge_ingest.routes.crawl.crawl_page",
+        new=AsyncMock(return_value=healthy),
+    ):
+        resp = client.post(
+            "/ingest/v1/crawl/auth-probe",
+            json={"url": "https://example.com/page"},
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["classification"] == "auth_ok"
+    assert body["match_reasons"] == []
+    assert body["word_count"] == 600
+
+
+def test_auth_probe_returns_auth_failed_no_cookies_when_walled_and_no_cookies(
+    client: TestClient,
+) -> None:
+    walled = _make_crawl_result(
+        fit_markdown="Article teaser. " * 5 + "Log in to read this article",
+        word_count=80,
+        metadata={"status_code": 200},
+    )
+    with patch(
+        "knowledge_ingest.routes.crawl.crawl_page",
+        new=AsyncMock(return_value=walled),
+    ):
+        resp = client.post(
+            "/ingest/v1/crawl/auth-probe",
+            json={"url": "https://example.com/page"},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["classification"] == "auth_failed_no_cookies"
+    assert "end_of_body_login_marker" in body["match_reasons"]
+
+
+def test_auth_probe_returns_auth_failed_still_walled_when_walled_with_cookies(
+    client: TestClient,
+) -> None:
+    walled = _make_crawl_result(
+        fit_markdown="Inloggen om verder te lezen",
+        word_count=10,
+        metadata={"status_code": 200},
+        response_headers={"set-cookie": "session=abc; Path=/"},
+    )
+    with patch(
+        "knowledge_ingest.routes.crawl.crawl_page",
+        new=AsyncMock(return_value=walled),
+    ):
+        resp = client.post(
+            "/ingest/v1/crawl/auth-probe",
+            json={
+                "url": "https://example.com/page",
+                "cookies": [{"name": "session", "value": "expired"}],
+            },
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["classification"] == "auth_failed_still_walled"
+    assert "end_of_body_login_marker" in body["match_reasons"]
+    assert "session_cookie_minimal_body" in body["match_reasons"]
+
+
+def test_auth_probe_returns_auth_failed_credentials_invalid_on_401(
+    client: TestClient,
+) -> None:
+    bad = _make_crawl_result(
+        fit_markdown="",
+        word_count=0,
+        success=False,
+        metadata={"status_code": 401},
+    )
+    with patch(
+        "knowledge_ingest.routes.crawl.crawl_page",
+        new=AsyncMock(return_value=bad),
+    ):
+        resp = client.post(
+            "/ingest/v1/crawl/auth-probe",
+            json={
+                "url": "https://example.com/page",
+                "cookies": [{"name": "session", "value": "wrong"}],
+            },
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["classification"] == "auth_failed_credentials_invalid"
+    assert "http_unauthenticated" in body["match_reasons"]
+
+
+def test_auth_probe_returns_auth_failed_unreachable_on_connection_error(
+    client: TestClient,
+) -> None:
+    """Empty/zero-word result with no status — unreachable."""
+    unreachable = _make_crawl_result(
+        fit_markdown="",
+        word_count=0,
+        success=False,
+        metadata={},  # no status_code
+    )
+    with patch(
+        "knowledge_ingest.routes.crawl.crawl_page",
+        new=AsyncMock(return_value=unreachable),
+    ):
+        resp = client.post(
+            "/ingest/v1/crawl/auth-probe",
+            json={"url": "https://example.com/page"},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["classification"] == "auth_failed_unreachable"
+
+
+# ---------------------------------------------------------------------------
+# Auth guard side effect
+# ---------------------------------------------------------------------------
+
+
+def test_auth_probe_returns_auth_guard_when_auth_ok_with_cookies(
+    client: TestClient,
+) -> None:
+    healthy_with_cookies = _make_crawl_result(
+        fit_markdown="A long article body. " * 60,
+        raw_markdown="A long article body. " * 60,
+        word_count=600,
+        metadata={"status_code": 200},
+    )
+    with (
+        patch(
+            "knowledge_ingest.routes.crawl.crawl_page",
+            new=AsyncMock(return_value=healthy_with_cookies),
+        ),
+        patch(
+            "knowledge_ingest.routes.crawl.crawl_dom_summary",
+            new=AsyncMock(return_value=None),  # AI detection skipped
+        ),
+    ):
+        resp = client.post(
+            "/ingest/v1/crawl/auth-probe",
+            json={
+                "url": "https://example.com/page",
+                "cookies": [{"name": "sess", "value": "valid"}],
+            },
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["classification"] == "auth_ok"
+    assert body["auth_guard"] is not None
+    assert body["auth_guard"]["canary_url"] == "https://example.com/page"
+    assert body["auth_guard"]["canary_fingerprint"] is not None
+
+
+def test_auth_probe_does_not_return_auth_guard_when_no_cookies(
+    client: TestClient,
+) -> None:
+    """Without cookies there is nothing to canary against — auth_guard MUST be None."""
+    healthy = _make_crawl_result(
+        fit_markdown="A long article body. " * 60,
+        raw_markdown="A long article body. " * 60,
+        word_count=600,
+        metadata={"status_code": 200},
+    )
+    with patch(
+        "knowledge_ingest.routes.crawl.crawl_page",
+        new=AsyncMock(return_value=healthy),
+    ):
+        resp = client.post(
+            "/ingest/v1/crawl/auth-probe",
+            json={"url": "https://example.com/page"},
+        )
+    body = resp.json()
+    assert body["classification"] == "auth_ok"
+    assert body["auth_guard"] is None
+
+
+# ---------------------------------------------------------------------------
+# Security & validation
+# ---------------------------------------------------------------------------
+
+
+def test_auth_probe_rejects_internal_secret_missing(client: TestClient) -> None:
+    """SPEC-SEC-011 — missing ``X-Internal-Secret`` is rejected.
+
+    ``client`` fixture injects the header by default; we drop it for this
+    one assertion to ensure the middleware still guards this new endpoint.
+    """
+    resp = client.post(
+        "/ingest/v1/crawl/auth-probe",
+        json={"url": "https://example.com/page"},
+        headers={"X-Internal-Secret": "wrong-secret"},
+    )
+    assert resp.status_code in (401, 403)
+
+
+def test_auth_probe_rejects_ssrf_url(client: TestClient) -> None:
+    """SPEC-SEC-SSRF-001 parity — auth-probe MUST reject internal-host URLs
+    before any crawl call (the same Cornelis AC-6 guard that protects
+    /ingest/v1/crawl and /ingest/v1/crawl/preview)."""
+    spy = AsyncMock(side_effect=AssertionError("SSRF guard should short-circuit"))
+    with patch("knowledge_ingest.routes.crawl.crawl_page", new=spy):
+        resp = client.post(
+            "/ingest/v1/crawl/auth-probe",
+            json={"url": "http://docker-socket-proxy:2375/v1.42/info"},
+        )
+    assert resp.status_code == 400
+    assert spy.await_count == 0
+
+
+def test_auth_probe_returns_match_reasons_list(client: TestClient) -> None:
+    """The response shape always exposes ``match_reasons`` as a list (possibly empty)."""
+    healthy = _make_crawl_result(
+        fit_markdown="Real article. " * 60,
+        word_count=600,
+        metadata={"status_code": 200},
+    )
+    with patch(
+        "knowledge_ingest.routes.crawl.crawl_page",
+        new=AsyncMock(return_value=healthy),
+    ):
+        resp = client.post(
+            "/ingest/v1/crawl/auth-probe",
+            json={"url": "https://example.com/page"},
+        )
+    body = resp.json()
+    assert isinstance(body["match_reasons"], list)
+
+
+# ---------------------------------------------------------------------------
+# Tenant scoping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("provided_org_id", ["org-test-123", "org-test-456"])
+def test_auth_probe_passes_org_id_to_identity_assert(
+    client: TestClient, provided_org_id: str
+) -> None:
+    """When org_id is supplied in the body, identity assert is called with
+    tenant-only flavor (no claimed_user_id)."""
+    healthy = _make_crawl_result(
+        fit_markdown="Real article. " * 60,
+        word_count=600,
+        metadata={"status_code": 200},
+    )
+    spy = AsyncMock(return_value=None)
+    with (
+        patch(
+            "knowledge_ingest.routes.crawl.crawl_page",
+            new=AsyncMock(return_value=healthy),
+        ),
+        patch(
+            "knowledge_ingest.routes.crawl.assert_caller_identity_tenant_only",
+            new=spy,
+        ),
+    ):
+        resp = client.post(
+            "/ingest/v1/crawl/auth-probe",
+            json={"url": "https://example.com/page", "org_id": provided_org_id},
+        )
+    assert resp.status_code == 200, resp.text
+    assert spy.await_count == 1
+    call_kwargs = spy.await_args.kwargs
+    assert call_kwargs.get("claimed_org_id") == provided_org_id

--- a/klai-knowledge-ingest/tests/test_auth_wall_classifier.py
+++ b/klai-knowledge-ingest/tests/test_auth_wall_classifier.py
@@ -1,0 +1,361 @@
+"""Tests for the pure-function auth-wall classifier (REQ-2).
+
+SPEC-CONNECTOR-INPUT-VALIDATION-001 / REQ-2 / REQ-6.
+
+The classifier is the single source of truth for "is this page authenticated
+content or an auth-wall stub?" — used by:
+
+- ``/ingest/v1/crawl/auth-probe`` (REQ-2 endpoint): step-4 wizard validation
+- ``/ingest/v1/crawl/preview`` (REQ-3 endpoint): step-5 selector validation
+- ``crawl_site`` post-fetch guard (REQ-4): defense-in-depth at sync time
+
+These tests pin the contract for all three call-sites. Adding a new sub-rule
+or relaxing an existing one MUST be paired with a test here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from knowledge_ingest.utils.auth_wall_classifier import (
+    AUTH_WALL_END_OF_BODY_MARKERS,
+    AuthWallClassification,
+    classify_auth_wall,
+)
+
+
+# ---------------------------------------------------------------------------
+# HTTP-status sub-rules
+# ---------------------------------------------------------------------------
+
+
+def test_http_401_classified_as_walled() -> None:
+    result = classify_auth_wall(
+        response_status_code=401,
+        redirect_target_url=None,
+        set_cookie_header=None,
+        word_count=0,
+        fit_markdown="",
+        raw_html="",
+    )
+    assert result.is_walled is True
+    assert "http_unauthenticated" in result.match_reasons
+
+
+def test_http_403_classified_as_walled() -> None:
+    result = classify_auth_wall(
+        response_status_code=403,
+        redirect_target_url=None,
+        set_cookie_header=None,
+        word_count=0,
+        fit_markdown="",
+        raw_html="",
+    )
+    assert result.is_walled is True
+    assert "http_unauthenticated" in result.match_reasons
+
+
+def test_http_200_does_not_match_unauthenticated() -> None:
+    result = classify_auth_wall(
+        response_status_code=200,
+        redirect_target_url=None,
+        set_cookie_header=None,
+        word_count=500,
+        fit_markdown="A real article body with plenty of words.",
+        raw_html="<html></html>",
+    )
+    assert "http_unauthenticated" not in result.match_reasons
+
+
+# ---------------------------------------------------------------------------
+# Redirect sub-rules
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "redirect_path",
+    [
+        "https://example.com/login",
+        "https://example.com/signin",
+        "https://example.com/sign-in",
+        "https://example.com/aanmelden",
+        "https://example.com/inloggen",
+        "https://example.com/anmelden",
+        "https://example.com/connexion",
+        "https://example.com/accedi",
+        "https://example.com/users/login?return_to=/foo",  # nested path
+    ],
+)
+def test_redirect_to_login_path_classified_as_walled(redirect_path: str) -> None:
+    result = classify_auth_wall(
+        response_status_code=302,
+        redirect_target_url=redirect_path,
+        set_cookie_header=None,
+        word_count=0,
+        fit_markdown="",
+        raw_html="",
+    )
+    assert result.is_walled is True
+    assert "redirect_to_login" in result.match_reasons
+
+
+def test_redirect_to_unrelated_url_does_not_match_redirect_rule() -> None:
+    result = classify_auth_wall(
+        response_status_code=302,
+        redirect_target_url="https://example.com/articles/welcome",
+        set_cookie_header=None,
+        word_count=500,
+        fit_markdown="A real article.",
+        raw_html="",
+    )
+    assert "redirect_to_login" not in result.match_reasons
+
+
+# ---------------------------------------------------------------------------
+# Session-cookie sub-rule
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "set_cookie",
+    [
+        "prod-knowledgebase-session=abc; Path=/",
+        "PHPSESSID=xyz; Path=/",
+        "auth_token=xxx; Path=/",
+        "sid=qqq; Path=/",
+        "some-thing-session-id=abc; Path=/",
+    ],
+)
+def test_session_cookie_with_minimal_body_classified_as_walled(set_cookie: str) -> None:
+    result = classify_auth_wall(
+        response_status_code=200,
+        redirect_target_url=None,
+        set_cookie_header=set_cookie,
+        word_count=20,
+        fit_markdown="Please log in",
+        raw_html="<html></html>",
+    )
+    assert result.is_walled is True
+    assert "session_cookie_minimal_body" in result.match_reasons
+
+
+def test_session_cookie_with_full_body_does_not_match() -> None:
+    """Logged-in pages also set session cookies; only flag when body is thin."""
+    result = classify_auth_wall(
+        response_status_code=200,
+        redirect_target_url=None,
+        set_cookie_header="sid=xyz; Path=/",
+        word_count=500,
+        fit_markdown="A complete article with many words " * 30,
+        raw_html="<html></html>",
+    )
+    assert "session_cookie_minimal_body" not in result.match_reasons
+
+
+def test_non_session_cookie_does_not_match() -> None:
+    result = classify_auth_wall(
+        response_status_code=200,
+        redirect_target_url=None,
+        set_cookie_header="theme=dark; Path=/",
+        word_count=20,
+        fit_markdown="Short page",
+        raw_html="<html></html>",
+    )
+    assert "session_cookie_minimal_body" not in result.match_reasons
+
+
+# ---------------------------------------------------------------------------
+# End-of-body marker sub-rule (REQ-2 + D-13)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "tail",
+    [
+        "Log in to read this article",
+        "Log in to view this",
+        "log in to continue",
+        "Sign in to read this",
+        "sign in to view more",
+        "Please log in",
+        "Even inloggen",
+        "Inloggen om verder te lezen",
+        "Inloggen om dit te bekijken",
+        "Aanmelden om verder te lezen",
+        "Log in when you want to read this article",
+    ],
+)
+def test_end_of_body_login_marker_classified_as_walled(tail: str) -> None:
+    fit_markdown = "This is a teaser of an article body. " * 5 + " " + tail
+    result = classify_auth_wall(
+        response_status_code=200,
+        redirect_target_url=None,
+        set_cookie_header=None,
+        word_count=80,  # short stub typical of teaser pages
+        fit_markdown=fit_markdown,
+        raw_html="<html></html>",
+    )
+    assert result.is_walled is True
+    assert "end_of_body_login_marker" in result.match_reasons
+
+
+def test_long_article_with_login_link_in_nav_does_not_match_marker() -> None:
+    """D-13: marker must be at END of body, not anywhere.
+
+    Healthy SaaS pages have a "Log in" link in the global nav header. Those
+    must NOT trip the auth-wall heuristic. The marker check looks at the LAST
+    ~200 chars of the body only.
+    """
+    body = (
+        "Log in | Sign up | Help\n\n"  # nav header text up front
+        + "Welcome to our article. This article is about how to use the API. "
+        * 60
+        + "Read more at the end of the article. The conclusion is left as an "
+        + "exercise to the reader.\n"
+    )
+    result = classify_auth_wall(
+        response_status_code=200,
+        redirect_target_url=None,
+        set_cookie_header=None,
+        word_count=800,
+        fit_markdown=body,
+        raw_html="<html></html>",
+    )
+    assert "end_of_body_login_marker" not in result.match_reasons
+    assert result.is_walled is False
+
+
+def test_marker_in_middle_of_body_does_not_match() -> None:
+    body = (
+        "Article start, lots of content. "
+        "log in to read this article in the middle of the body. "
+        + "More content following the supposed marker, plenty of words. " * 30
+    )
+    result = classify_auth_wall(
+        response_status_code=200,
+        redirect_target_url=None,
+        set_cookie_header=None,
+        word_count=500,
+        fit_markdown=body,
+        raw_html="<html></html>",
+    )
+    # The marker MUST NOT trigger because the body continues for many words
+    # after it. The end-of-body region is clean prose.
+    assert "end_of_body_login_marker" not in result.match_reasons
+
+
+# ---------------------------------------------------------------------------
+# Password-form sub-rule
+# ---------------------------------------------------------------------------
+
+
+def test_password_form_with_minimal_body_classified_as_walled() -> None:
+    result = classify_auth_wall(
+        response_status_code=200,
+        redirect_target_url=None,
+        set_cookie_header=None,
+        word_count=15,
+        fit_markdown="Please enter your password",
+        raw_html='<html><body><form><input type="password" name="pw"></form></body></html>',
+    )
+    assert result.is_walled is True
+    assert "password_form_minimal_body" in result.match_reasons
+
+
+def test_password_form_with_full_article_does_not_match() -> None:
+    """A long article that happens to embed a password change form is not a wall."""
+    result = classify_auth_wall(
+        response_status_code=200,
+        redirect_target_url=None,
+        set_cookie_header=None,
+        word_count=600,
+        fit_markdown="A long article body. " * 80,
+        raw_html='<html><body><form><input type="password" name="pw"></form></body></html>',
+    )
+    assert "password_form_minimal_body" not in result.match_reasons
+
+
+# ---------------------------------------------------------------------------
+# Negative case
+# ---------------------------------------------------------------------------
+
+
+def test_healthy_public_page_not_classified_as_walled() -> None:
+    result = classify_auth_wall(
+        response_status_code=200,
+        redirect_target_url=None,
+        set_cookie_header=None,
+        word_count=600,
+        fit_markdown=(
+            "This is a real, long article body with plenty of words and no "
+            "auth markers anywhere. " * 30
+        ),
+        raw_html="<html><body><article>...</article></body></html>",
+    )
+    assert result.is_walled is False
+    assert result.match_reasons == ()
+
+
+# ---------------------------------------------------------------------------
+# Combination cases
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_subrules_match_returns_all() -> None:
+    """The classifier must return ALL matching reasons for diagnostic UI."""
+    result = classify_auth_wall(
+        response_status_code=401,
+        redirect_target_url=None,
+        set_cookie_header="sid=xxx; Path=/",
+        word_count=30,
+        fit_markdown="Some short text. Please log in",
+        raw_html='<html><body><form><input type="password"></form></body></html>',
+    )
+    assert result.is_walled is True
+    assert "http_unauthenticated" in result.match_reasons
+    assert "session_cookie_minimal_body" in result.match_reasons
+    assert "password_form_minimal_body" in result.match_reasons
+    assert "end_of_body_login_marker" in result.match_reasons
+
+
+def test_classification_is_immutable() -> None:
+    """The result dataclass is frozen — callers cannot mutate diagnostic data."""
+    result = classify_auth_wall(
+        response_status_code=401,
+        redirect_target_url=None,
+        set_cookie_header=None,
+        word_count=0,
+        fit_markdown="",
+        raw_html="",
+    )
+    with pytest.raises(Exception):  # FrozenInstanceError or AttributeError
+        result.is_walled = False  # type: ignore[misc]
+    with pytest.raises(Exception):
+        result.match_reasons = ()  # type: ignore[misc]
+
+
+def test_empty_input_is_not_walled() -> None:
+    """Edge: every input empty/None — no signal, no false positive."""
+    result = classify_auth_wall(
+        response_status_code=None,
+        redirect_target_url=None,
+        set_cookie_header=None,
+        word_count=0,
+        fit_markdown="",
+        raw_html="",
+    )
+    assert result.is_walled is False
+    assert result.match_reasons == ()
+
+
+def test_marker_list_is_module_level_constant() -> None:
+    """REQ-2 D-12: marker list MUST be a module-level constant for easy DE/FR
+    addition without code restructuring."""
+    assert isinstance(AUTH_WALL_END_OF_BODY_MARKERS, (list, tuple))
+    assert len(AUTH_WALL_END_OF_BODY_MARKERS) >= 5  # NL + EN starter set
+
+
+def test_classification_dataclass_shape() -> None:
+    result = AuthWallClassification(is_walled=True, match_reasons=("http_unauthenticated",))
+    assert result.is_walled is True
+    assert result.match_reasons == ("http_unauthenticated",)

--- a/klai-knowledge-ingest/tests/test_crawl_preview_classification.py
+++ b/klai-knowledge-ingest/tests/test_crawl_preview_classification.py
@@ -1,0 +1,204 @@
+"""Tests for ``CrawlPreviewResponse.classification`` (REQ-3).
+
+SPEC-CONNECTOR-INPUT-VALIDATION-001 / REQ-3 / REQ-6.
+
+The preview endpoint returns a ``classification`` field that the wizard
+uses to decide whether to enable the "Add connector" button at step 6.
+Five outcomes:
+
+- ``success``
+- ``selector_required`` (link-density too high)
+- ``selector_returns_empty`` (word_count too low, raw HTML > 5KB)
+- ``requires_javascript`` (word_count low, raw HTML < 5KB — SPA)
+- ``auth_wall_detected`` (REQ-2 heuristic matched)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from knowledge_ingest.crawl4ai_client import CrawlResult
+
+
+def _result(
+    *,
+    fit_markdown: str,
+    raw_markdown: str = "",
+    html: str = "",
+    word_count: int = 0,
+    metadata: dict | None = None,
+    response_headers: dict[str, str] | None = None,
+) -> CrawlResult:
+    return CrawlResult(
+        url="https://example.com/page",
+        fit_markdown=fit_markdown,
+        raw_markdown=raw_markdown or fit_markdown,
+        html=html,
+        word_count=word_count,
+        success=True,
+        metadata=metadata or {"status_code": 200},
+        response_headers=response_headers or {},
+    )
+
+
+def test_preview_classification_success_for_clean_article(client: TestClient) -> None:
+    md = "Real article with proper prose. " * 60
+    healthy = _result(fit_markdown=md, raw_markdown=md, word_count=600)
+    with patch(
+        "knowledge_ingest.routes.crawl.crawl_page",
+        new=AsyncMock(return_value=healthy),
+    ):
+        resp = client.post(
+            "/ingest/v1/crawl/preview",
+            json={"url": "https://example.com/page", "content_selector": "article"},
+        )
+    body = resp.json()
+    assert body["classification"] == "success"
+
+
+def test_preview_classification_selector_required_for_nav_dominated(
+    client: TestClient,
+) -> None:
+    """Word count is high enough but link-density crosses 40% — wizard MUST
+    redirect the user back to step 5 to refine the selector."""
+    nav_md = (
+        "[Home Page](/h) [About Us](/a) [Contact Information](/c) "
+        "[Our Products](/p) [Login Now](/l) [Signup Free](/s) "
+        "[Documentation](/d) [Help Center](/help) [Pricing](/pricing) "
+        "[Support](/support) [Knowledge Base](/kb) [Resources](/r) "
+        "[Blog Articles](/blog) [Latest News](/news) [Career Jobs](/jobs)"
+    ) * 5
+    nav_dominated = _result(
+        fit_markdown=nav_md,
+        raw_markdown=nav_md,
+        word_count=200,  # high enough word count, but mostly link text
+    )
+    with patch(
+        "knowledge_ingest.routes.crawl.crawl_page",
+        new=AsyncMock(return_value=nav_dominated),
+    ):
+        resp = client.post(
+            "/ingest/v1/crawl/preview",
+            json={"url": "https://example.com/page"},
+        )
+    body = resp.json()
+    assert body["classification"] == "selector_required"
+
+
+def test_preview_classification_selector_returns_empty_with_thin_md_rich_html(
+    client: TestClient,
+) -> None:
+    thin = _result(
+        fit_markdown="Just a tiny stub.",
+        raw_markdown="Just a tiny stub.",
+        html="<html>" + ("<div>x</div>" * 1000) + "</html>",
+        word_count=4,
+    )
+    with patch(
+        "knowledge_ingest.routes.crawl.crawl_page",
+        new=AsyncMock(return_value=thin),
+    ):
+        resp = client.post(
+            "/ingest/v1/crawl/preview",
+            json={
+                "url": "https://example.com/page",
+                "content_selector": ".never-matches",
+            },
+        )
+    body = resp.json()
+    assert body["classification"] == "selector_returns_empty"
+
+
+def test_preview_classification_requires_javascript_when_html_minimal(
+    client: TestClient,
+) -> None:
+    spa = _result(
+        fit_markdown="",
+        raw_markdown="",
+        html="<html><div id='root'></div></html>",  # < 5KB
+        word_count=0,
+    )
+    with patch(
+        "knowledge_ingest.routes.crawl.crawl_page",
+        new=AsyncMock(return_value=spa),
+    ):
+        resp = client.post(
+            "/ingest/v1/crawl/preview",
+            json={"url": "https://example.com/spa"},
+        )
+    body = resp.json()
+    assert body["classification"] == "requires_javascript"
+
+
+def test_preview_classification_auth_wall_detected_redirects_to_step_4(
+    client: TestClient,
+) -> None:
+    """Page has enough words but the auth-wall heuristic fires anyway —
+    classifier MUST surface ``auth_wall_detected`` so the wizard sends the
+    user back to step 4 (auth setup), not step 5."""
+    walled = _result(
+        fit_markdown="A short teaser. " * 5 + "Inloggen om verder te lezen",
+        raw_markdown="A short teaser. " * 5 + "Inloggen om verder te lezen",
+        word_count=80,
+        metadata={"status_code": 200},
+    )
+    with patch(
+        "knowledge_ingest.routes.crawl.crawl_page",
+        new=AsyncMock(return_value=walled),
+    ):
+        resp = client.post(
+            "/ingest/v1/crawl/preview",
+            json={"url": "https://example.com/walled"},
+        )
+    body = resp.json()
+    assert body["classification"] == "auth_wall_detected"
+
+
+def test_preview_classification_auth_wall_detected_when_walled_with_high_word_count(
+    client: TestClient,
+) -> None:
+    """Edge: even with high word_count, if the auth-wall classifier fires
+    (e.g., HTTP 401 + body present), the classification MUST be auth_wall_detected,
+    NOT success — auth wins over selector check."""
+    walled_with_words = _result(
+        fit_markdown="Some content. " * 60,
+        raw_markdown="Some content. " * 60,
+        word_count=600,
+        metadata={"status_code": 401},  # 401 trips http_unauthenticated
+    )
+    with patch(
+        "knowledge_ingest.routes.crawl.crawl_page",
+        new=AsyncMock(return_value=walled_with_words),
+    ):
+        resp = client.post(
+            "/ingest/v1/crawl/preview",
+            json={"url": "https://example.com/walled-with-words"},
+        )
+    body = resp.json()
+    assert body["classification"] == "auth_wall_detected"
+
+
+def test_preview_classification_field_always_present(client: TestClient) -> None:
+    """Even on the failure path the classification field must exist
+    (UI relies on it for branching)."""
+    healthy = _result(
+        fit_markdown="Real article. " * 60, raw_markdown="Real article. " * 60, word_count=600
+    )
+    with patch(
+        "knowledge_ingest.routes.crawl.crawl_page",
+        new=AsyncMock(return_value=healthy),
+    ):
+        resp = client.post(
+            "/ingest/v1/crawl/preview", json={"url": "https://example.com/page"}
+        )
+    body = resp.json()
+    assert "classification" in body
+    assert body["classification"] in {
+        "success",
+        "selector_required",
+        "selector_returns_empty",
+        "requires_javascript",
+        "auth_wall_detected",
+    }

--- a/klai-knowledge-ingest/tests/test_crawl_site_dirty_content_guard.py
+++ b/klai-knowledge-ingest/tests/test_crawl_site_dirty_content_guard.py
@@ -1,0 +1,152 @@
+"""Tests for REQ-4 sync-time dirty-content guard.
+
+SPEC-CONNECTOR-INPUT-VALIDATION-001 / REQ-4 / REQ-6.
+
+The guard is a pure decision function — given the post-fetch counters
+plus the connector configuration (cookies / login_indicator), it returns
+whether the crawl_job should end with ``failed_partial`` plus a
+structured ``error_summary`` payload.
+
+Pure unit tests are sufficient — the integration into ``run_crawl_job``
+is a single call-site that constructs the inputs from existing local
+variables.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from knowledge_ingest.adapters.crawler import (
+    DIRTY_CONTENT_REASON,
+    decide_terminal_status,
+)
+
+
+def test_dirty_content_above_threshold_marks_failed_partial() -> None:
+    """REQ-4: 70% trip-rate, no cookies, no indicator → failed_partial."""
+    status, summary = decide_terminal_status(
+        auth_wall_count=70,
+        total_count=100,
+        has_cookies=False,
+        has_login_indicator=False,
+        threshold=0.30,
+    )
+    assert status == "failed_partial"
+    assert summary is not None
+    assert summary["reason"] == DIRTY_CONTENT_REASON
+    assert summary["reason"] == "boilerplate_or_authwall_dominant"
+    assert summary["trip_rate"] == 0.7
+    assert summary["auth_wall_count"] == 70
+    assert summary["total_count"] == 100
+    assert "Re-run preview" in summary["suggestion"]
+
+
+def test_dirty_content_above_threshold_with_cookies_does_not_trip_guard() -> None:
+    """Operator configured cookies — they EXPECTED auth-walled content. The
+    REQ-4 guard MUST NOT fire. Existing per-page wall handling still applies."""
+    status, summary = decide_terminal_status(
+        auth_wall_count=70,
+        total_count=100,
+        has_cookies=True,
+        has_login_indicator=False,
+        threshold=0.30,
+    )
+    assert status != "failed_partial" or (summary or {}).get("reason") != DIRTY_CONTENT_REASON
+
+
+def test_dirty_content_above_threshold_with_login_indicator_does_not_trip_guard() -> None:
+    status, summary = decide_terminal_status(
+        auth_wall_count=70,
+        total_count=100,
+        has_cookies=False,
+        has_login_indicator=True,
+        threshold=0.30,
+    )
+    assert status != "failed_partial" or (summary or {}).get("reason") != DIRTY_CONTENT_REASON
+
+
+def test_dirty_content_below_threshold_succeeds() -> None:
+    status, summary = decide_terminal_status(
+        auth_wall_count=10,
+        total_count=100,
+        has_cookies=False,
+        has_login_indicator=False,
+        threshold=0.30,
+    )
+    assert status != "failed_partial" or (summary or {}).get("reason") != DIRTY_CONTENT_REASON
+
+
+def test_threshold_inclusive_at_exactly_thirty_percent() -> None:
+    """EC-4: trip_rate exactly 0.30 → guard MUST trip (>= is inclusive)."""
+    status, summary = decide_terminal_status(
+        auth_wall_count=30,
+        total_count=100,
+        has_cookies=False,
+        has_login_indicator=False,
+        threshold=0.30,
+    )
+    assert status == "failed_partial"
+    assert summary is not None
+    assert summary["reason"] == DIRTY_CONTENT_REASON
+
+
+def test_threshold_configurable_at_fifty_percent() -> None:
+    """EC-5: env-var raises threshold to 0.50, 40% trip-rate must NOT trip."""
+    status, summary = decide_terminal_status(
+        auth_wall_count=40,
+        total_count=100,
+        has_cookies=False,
+        has_login_indicator=False,
+        threshold=0.50,
+    )
+    assert status != "failed_partial" or (summary or {}).get("reason") != DIRTY_CONTENT_REASON
+
+
+def test_zero_total_does_not_divide_by_zero() -> None:
+    """Defensive: empty crawl (no candidates) → no guard trip, no exception."""
+    status, summary = decide_terminal_status(
+        auth_wall_count=0,
+        total_count=0,
+        has_cookies=False,
+        has_login_indicator=False,
+        threshold=0.30,
+    )
+    assert status != "failed_partial" or (summary or {}).get("reason") != DIRTY_CONTENT_REASON
+
+
+def test_summary_contains_actionable_suggestion() -> None:
+    """REQ-5 hooks into this exact text — pin the wording."""
+    _, summary = decide_terminal_status(
+        auth_wall_count=70,
+        total_count=100,
+        has_cookies=False,
+        has_login_indicator=False,
+        threshold=0.30,
+    )
+    assert summary is not None
+    suggestion = summary["suggestion"]
+    # Must reference both possible operator actions: re-run preview AND
+    # acknowledge the source may have changed.
+    assert "preview" in suggestion.lower()
+    assert (
+        "authentication" in suggestion.lower()
+        or "content_selector" in suggestion.lower()
+    )
+
+
+@pytest.mark.parametrize("trip_rate_input", [0.31, 0.5, 0.7, 1.0])
+def test_trip_rate_rounded_to_three_decimals(trip_rate_input: float) -> None:
+    auth_wall_count = int(trip_rate_input * 100)
+    _, summary = decide_terminal_status(
+        auth_wall_count=auth_wall_count,
+        total_count=100,
+        has_cookies=False,
+        has_login_indicator=False,
+        threshold=0.30,
+    )
+    assert summary is not None
+    # Must be a finite float, not a Decimal or numpy type.
+    assert isinstance(summary["trip_rate"], float)
+    # Must round to 3 decimals or fewer for clean log output.
+    rounded = round(summary["trip_rate"], 3)
+    assert summary["trip_rate"] == rounded

--- a/klai-knowledge-ingest/tests/test_crawler_anonymous_auth_wall.py
+++ b/klai-knowledge-ingest/tests/test_crawler_anonymous_auth_wall.py
@@ -257,8 +257,14 @@ class TestFailedPartial:
 
     @pytest.mark.asyncio()
     async def test_some_ingested_succeeds_despite_walls(self, patched_pool) -> None:
-        clean = _result("https://example.com/clean")
-        walls = [_result(f"https://example.com/wall-{i}") for i in range(2)]
+        # SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-4: when wall ratio exceeds
+        # KLAI_INGEST_AUTHWALL_DIRTY_TRIP_RATE (default 0.30) and no cookies /
+        # login_indicator are configured, the run is intentionally marked
+        # failed_partial. Below the threshold, the existing "some content got
+        # through → completed" semantic still holds.
+        # Ratio here: 1 wall / 9 total = 11% — comfortably below default 30%.
+        clean_pages = [_result(f"https://example.com/clean-{i}") for i in range(8)]
+        walls = [_result("https://example.com/wall-0")]
 
         async def ingest_side_effect(*args, **kwargs):
             url = args[2] if len(args) >= 3 else kwargs.get("url")
@@ -268,7 +274,7 @@ class TestFailedPartial:
                     AuthWallSignal(pattern="template_cluster", confidence=0.9),
                 )
 
-        patches = _patch_crawler_externals([clean, *walls], ingest_side_effect)
+        patches = _patch_crawler_externals([*clean_pages, *walls], ingest_side_effect)
         for p in patches:
             p.start()
         try:

--- a/klai-knowledge-ingest/tests/test_link_density.py
+++ b/klai-knowledge-ingest/tests/test_link_density.py
@@ -1,0 +1,87 @@
+"""Tests for the markdown link-density helper (REQ-3).
+
+SPEC-CONNECTOR-INPUT-VALIDATION-001 / REQ-3.
+
+Pure-function regex helper used by the preview classifier to detect
+nav-dominated output ("80% of the text is links" → ``selector_required``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from knowledge_ingest.utils.link_density import (
+    LINK_DENSITY_THRESHOLD,
+    link_density,
+)
+
+
+def test_no_links_returns_zero() -> None:
+    md = "This is plain prose with no links at all. " * 5
+    assert link_density(md) == 0.0
+
+
+def test_empty_string_returns_zero() -> None:
+    assert link_density("") == 0.0
+
+
+def test_pure_link_navigation_returns_high_density() -> None:
+    """Redcactus-style nav-only output: link density should exceed threshold.
+
+    The fixture mimics a real failing nav-dominated page: many links with
+    longer anchor texts and short URLs. Real Redcactus broken output had
+    80%+ link density.
+    """
+    md = (
+        "[Home Page](/h) [About Us](/a) [Contact Information](/c) "
+        "[Our Products](/p) [Login Now](/l) [Signup Free](/s) "
+        "[Documentation](/d) [Help Center](/help) [Pricing Plans](/pricing) "
+        "[Customer Support](/support) [Knowledge Base](/kb) [Resources](/r) "
+        "[Blog Articles](/blog) [Latest News](/news) [Career Opportunities](/jobs)"
+    )
+    density = link_density(md)
+    assert density > LINK_DENSITY_THRESHOLD
+
+
+def test_real_article_with_few_links_returns_low_density() -> None:
+    """Voys-help-style article: long prose with one or two inline links.
+
+    Calibration anchor: real articles cluster around 5-10% link density.
+    """
+    md = (
+        "This is a long article body with many sentences explaining how to "
+        "configure the system. There are detailed instructions and tips "
+        "throughout. Once in a while we [link to something](/something) "
+        "for context. The article continues with more prose for several "
+        "paragraphs, sharing knowledge about the topic in a way that does "
+        "not depend on heavy linking. " * 3
+    )
+    density = link_density(md)
+    assert 0 < density <= 0.10
+
+
+def test_threshold_is_zero_point_four() -> None:
+    """REQ-3 D-6: threshold is 0.40 (40% link density), calibrated against
+    Voys help (~5-10%) and Redcactus broken nav (80%+)."""
+    assert LINK_DENSITY_THRESHOLD == 0.40
+
+
+def test_link_density_handles_empty_anchor_text() -> None:
+    """Edge: ``[](http://x)`` has zero anchor text. Must not crash; counts as
+    zero contribution to link density."""
+    md = "Some real article body. [](http://hidden) more body content."
+    density = link_density(md)
+    assert 0.0 <= density < 0.5
+
+
+@pytest.mark.parametrize(
+    "md",
+    [
+        "[a](b)",
+        "Text and [link](url) and more text.",
+        "[Outer](/o) wrapping [Inner](/i) bracket.",
+    ],
+)
+def test_link_density_returns_float_in_zero_one_range(md: str) -> None:
+    density = link_density(md)
+    assert 0.0 <= density <= 1.0

--- a/klai-portal/backend/app/api/app_knowledge_bases.py
+++ b/klai-portal/backend/app/api/app_knowledge_bases.py
@@ -1265,9 +1265,7 @@ class AuthProbeResponse(BaseModel):
     auth_guard: dict | None = None
 
 
-@router.post(
-    "/knowledge-bases/{kb_slug}/connectors/auth-probe", response_model=AuthProbeResponse
-)
+@router.post("/knowledge-bases/{kb_slug}/connectors/auth-probe", response_model=AuthProbeResponse)
 async def auth_probe(
     kb_slug: str,
     body: AuthProbeRequest,

--- a/klai-portal/backend/app/api/app_knowledge_bases.py
+++ b/klai-portal/backend/app/api/app_knowledge_bases.py
@@ -1209,6 +1209,10 @@ class CrawlPreviewResponse(BaseModel):
     warnings: list[str] = []
     content_selector: str | None = None
     selector_source: str | None = None
+    # SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-3 — five-way classification
+    # used by the wizard to gate step-5 → step-6 advance.
+    classification: str = "success"
+    classification_reason: str | None = None
 
 
 @router.post("/knowledge-bases/{kb_slug}/connectors/crawl-preview", response_model=CrawlPreviewResponse)
@@ -1236,6 +1240,59 @@ async def crawl_preview(
         warnings=result.get("warnings", []),
         content_selector=result.get("content_selector"),
         selector_source=result.get("selector_source"),
+        classification=result.get("classification", "success"),
+        classification_reason=result.get("classification_reason"),
+    )
+
+
+# -- Auth probe (SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-2) -------------------
+
+
+class AuthProbeRequest(BaseModel):
+    url: str
+    cookies: list[dict] | None = None
+
+
+class AuthProbeResponse(BaseModel):
+    """Five-way classification of the seed-page fetch outcome.
+
+    See SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-2 for full semantics.
+    """
+
+    classification: str
+    match_reasons: list[str] = []
+    word_count: int = 0
+    auth_guard: dict | None = None
+
+
+@router.post(
+    "/knowledge-bases/{kb_slug}/connectors/auth-probe", response_model=AuthProbeResponse
+)
+async def auth_probe(
+    kb_slug: str,
+    body: AuthProbeRequest,
+    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    db: AsyncSession = Depends(get_db),
+) -> AuthProbeResponse:
+    """SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-2 — wizard step-4 auth probe.
+
+    Validates that supplied cookies actually unlock the seed URL before the
+    wizard allows the user to advance to the selector step. Owner role
+    required (mirrors crawl_preview).
+    """
+    caller_id, org, _ = await _get_caller_org(credentials, db)
+    kb = await _get_kb_or_404(kb_slug, org.id, db)
+    await _require_owner(kb, caller_id, db)
+    result = await knowledge_ingest_client.auth_probe(
+        url=body.url,
+        org_id=str(org.id),
+        cookies=body.cookies,
+    )
+    return AuthProbeResponse(
+        classification=result.get("classification", "auth_failed_unreachable"),
+        match_reasons=result.get("match_reasons", []),
+        word_count=result.get("word_count", 0),
+        auth_guard=result.get("auth_guard"),
     )
 
 

--- a/klai-portal/backend/app/api/connectors.py
+++ b/klai-portal/backend/app/api/connectors.py
@@ -311,6 +311,15 @@ class ConnectorOut(BaseModel):
     created_by: str
     content_type: str | None
     allowed_assertion_modes: list[str] | None
+    # SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-7 — UI badge signal.
+    # Approximation in the absence of cross-DB join: a web_crawler whose
+    # latest sync ended 'failed' is flagged. The SPEC's stronger predicate
+    # (error_details.reason == 'boilerplate_or_authwall_dominant') requires
+    # querying connector.sync_runs in the klai-connector schema, which
+    # portal-api cannot reach without an HTTP round-trip per connector.
+    # Existing Redcactus connector (id e7fac358-…) currently has
+    # last_sync_status='failed' and IS surfaced by this approximation.
+    needs_reconfiguration: bool = False
 
 
 # -- Helpers ------------------------------------------------------------------
@@ -354,6 +363,16 @@ async def _get_kb_for_org(
     return kb
 
 
+def _compute_needs_reconfiguration(c: PortalConnector) -> bool:
+    """SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-7 — UI signal predicate.
+
+    See ConnectorOut.needs_reconfiguration docstring for the trade-off
+    rationale. This proxy fires for any web_crawler whose most recent
+    sync ended 'failed' (covers AC-9: existing Redcactus connector).
+    """
+    return c.connector_type == "web_crawler" and c.last_sync_status == "failed"
+
+
 def _connector_out(c: PortalConnector) -> ConnectorOut:
     # Mask sensitive fields so they never appear in public API responses
     masked_config = dict(c.config) if c.config else {}
@@ -375,6 +394,7 @@ def _connector_out(c: PortalConnector) -> ConnectorOut:
         created_by=c.created_by,
         content_type=c.content_type,
         allowed_assertion_modes=c.allowed_assertion_modes,
+        needs_reconfiguration=_compute_needs_reconfiguration(c),
     )
 
 

--- a/klai-portal/backend/app/services/knowledge_ingest_client.py
+++ b/klai-portal/backend/app/services/knowledge_ingest_client.py
@@ -181,6 +181,44 @@ async def preview_crawl(
         return {"fit_markdown": "", "word_count": 0, "url": url}
 
 
+async def auth_probe(
+    url: str,
+    org_id: str = "",
+    cookies: list[dict] | None = None,
+) -> dict:
+    """SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-2 — call knowledge-ingest
+    auth-probe endpoint.
+
+    Returns the five-way classification + match_reasons + auth_guard. Falls
+    back to ``auth_failed_unreachable`` on transport error so the wizard
+    UI always has a stable shape to render.
+    """
+    payload: dict = {"url": url, "org_id": org_id}
+    if cookies:
+        payload["cookies"] = cookies
+    try:
+        async with httpx.AsyncClient(
+            base_url=settings.knowledge_ingest_url,
+            headers={
+                "X-Internal-Secret": settings.knowledge_ingest_secret,
+                "X-Caller-Service": "portal-api",
+                **get_trace_headers(),
+            },
+            timeout=35.0,  # PC-1 budget: REQ-2 p95 < 30s
+        ) as client:
+            resp = await client.post("/ingest/v1/crawl/auth-probe", json=payload)
+            resp.raise_for_status()
+            return resp.json()  # type: ignore[no-any-return]
+    except Exception:
+        logger.warning("auth_probe failed", extra={"url": url}, exc_info=True)
+        return {
+            "classification": "auth_failed_unreachable",
+            "match_reasons": [],
+            "word_count": 0,
+            "auth_guard": None,
+        }
+
+
 async def trigger_taxonomy_bootstrap(org_id: str, kb_slug: str) -> dict:
     """Trigger bootstrap proposal generation for a KB.
 

--- a/klai-portal/backend/tests/test_connectors_needs_reconfiguration.py
+++ b/klai-portal/backend/tests/test_connectors_needs_reconfiguration.py
@@ -1,0 +1,78 @@
+"""Tests for the needs_reconfiguration predicate (REQ-7).
+
+SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-7 — UI badge signal.
+
+Per the implementation note in ``api/connectors.py::ConnectorOut``, this
+flag is an approximation of the SPEC's full predicate. The full SPEC
+predicate joins ``portal_connectors`` to ``connector.sync_runs.error_details``
+which lives in klai-connector's separate database. The proxy used here:
+
+    needs_reconfiguration = (
+        connector_type == "web_crawler"
+        AND last_sync_status == "failed"
+    )
+
+Covers AC-9: the existing Redcactus connector with last_sync_status='failed'
+gets surfaced. False positives (a web_crawler that failed for an unrelated
+reason) are acceptable: clicking "Investigate" will still drop the user
+into the wizard, which now has the REQ-2 / REQ-3 gates to surface the real
+problem.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from app.api.connectors import _compute_needs_reconfiguration
+
+
+def _conn(connector_type: str, last_sync_status: str | None) -> SimpleNamespace:
+    """Minimal duck-typed PortalConnector shim — the predicate only reads
+    two attributes."""
+    return SimpleNamespace(
+        connector_type=connector_type,
+        last_sync_status=last_sync_status,
+    )
+
+
+def test_web_crawler_with_failed_status_is_flagged() -> None:
+    assert _compute_needs_reconfiguration(_conn("web_crawler", "failed")) is True
+
+
+def test_web_crawler_with_success_status_is_not_flagged() -> None:
+    assert _compute_needs_reconfiguration(_conn("web_crawler", "success")) is False
+
+
+def test_web_crawler_with_completed_status_is_not_flagged() -> None:
+    assert _compute_needs_reconfiguration(_conn("web_crawler", "completed")) is False
+
+
+def test_web_crawler_with_running_status_is_not_flagged() -> None:
+    assert _compute_needs_reconfiguration(_conn("web_crawler", "running")) is False
+
+
+def test_web_crawler_with_null_status_is_not_flagged() -> None:
+    """Brand-new connector that hasn't synced yet must not be flagged."""
+    assert _compute_needs_reconfiguration(_conn("web_crawler", None)) is False
+
+
+def test_notion_connector_with_failed_status_is_not_flagged() -> None:
+    """The badge predicate intentionally narrows to web_crawler — that's
+    the connector type this SPEC's failure mode applies to. Other
+    connectors with failed syncs surface via existing UI paths."""
+    assert _compute_needs_reconfiguration(_conn("notion", "failed")) is False
+
+
+def test_github_connector_with_failed_status_is_not_flagged() -> None:
+    assert _compute_needs_reconfiguration(_conn("github", "failed")) is False
+
+
+def test_web_crawler_with_failed_partial_status_is_not_flagged() -> None:
+    """REQ-4 writes 'failed_partial' on knowledge.crawl_jobs in the
+    knowledge-ingest DB. Per REQ-4 spec the wrapping connector.sync_runs
+    rolls up to 'failed' (not 'failed_partial') when the dirty-content
+    guard trips, and that 'failed' is what bubbles back to portal_connectors
+    via the existing sync-status callback. Portal therefore never observes
+    'failed_partial' on last_sync_status — but encode the assumption here
+    so a future contract change is loud."""
+    assert _compute_needs_reconfiguration(_conn("web_crawler", "failed_partial")) is False

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-kb-types.ts
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-kb-types.ts
@@ -26,6 +26,8 @@ export interface ConnectorSummary {
   last_sync_at: string | null
   last_sync_documents_ok: number | null
   allowed_assertion_modes: string[] | null
+  // SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-7 — backend predicate; UI badge.
+  needs_reconfiguration?: boolean
 }
 
 export interface KBStats {

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/connectors.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/connectors.tsx
@@ -72,6 +72,8 @@ function ConnectorsTab() {
   // which failed so the UI can show a spinner / error message without stale
   // state bleeding to other rows.
   const [reconnectingId, setReconnectingId] = useState<string | null>(null)
+  // SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-5 — InvestigateDialog state.
+  const [investigatingConnector, setInvestigatingConnector] = useState<ConnectorSummary | null>(null)
   const [reconnectErrorId, setReconnectErrorId] = useState<string | null>(null)
 
   const { data: kb } = useQuery<KnowledgeBase>({
@@ -287,6 +289,17 @@ function ConnectorsTab() {
                         {c.last_sync_documents_ok.toLocaleString()} {m.connectors_documents_indexed()}
                       </p>
                     )}
+                    {/* SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-5/REQ-7 — actionable error badge. */}
+                    {c.needs_reconfiguration && (
+                      <button
+                        type="button"
+                        onClick={() => setInvestigatingConnector(c)}
+                        className="mt-1.5 inline-flex items-center gap-1 rounded-md border border-[var(--color-destructive)]/30 bg-[var(--color-destructive)]/5 px-2 py-1 text-xs font-medium text-[var(--color-destructive)] hover:bg-[var(--color-destructive)]/10 transition-colors"
+                      >
+                        <AlertTriangle className="h-3 w-3" />
+                        Needs reconfiguration
+                      </button>
+                    )}
                   </td>
                   {isOwner && (
                     <td className="py-4 align-top text-right w-28">
@@ -354,6 +367,56 @@ function ConnectorsTab() {
             >
               {m.admin_connectors_action_delete()}
             </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-5 — InvestigateDialog. */}
+      <AlertDialog open={investigatingConnector !== null} onOpenChange={(open) => { if (!open) setInvestigatingConnector(null) }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Connector needs reconfiguration</AlertDialogTitle>
+            <AlertDialogDescription asChild>
+              <div className="space-y-2 text-left">
+                <p>
+                  This connector&apos;s last sync failed. The site likely now requires
+                  authentication, or the content selector no longer matches.
+                </p>
+                <p className="text-xs text-[var(--color-muted-foreground)]">
+                  Re-run the wizard to verify authentication and selector. The wizard
+                  refuses to save until both checks pass — no more silent broken syncs.
+                </p>
+              </div>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="!justify-start gap-2 flex-wrap">
+            <AlertDialogCancel>Close</AlertDialogCancel>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => {
+                if (investigatingConnector) {
+                  window.location.href = `/app/knowledge/${encodeURIComponent(kbSlug)}/edit-connector/${encodeURIComponent(investigatingConnector.id)}?step=auth`
+                }
+                setInvestigatingConnector(null)
+              }}
+            >
+              Edit Authentication
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => {
+                if (investigatingConnector) {
+                  window.location.href = `/app/knowledge/${encodeURIComponent(kbSlug)}/edit-connector/${encodeURIComponent(investigatingConnector.id)}?step=selector`
+                }
+                setInvestigatingConnector(null)
+              }}
+            >
+              Edit Selector
+            </Button>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
@@ -22,7 +22,32 @@ type ConnectorType =
   | 'github' | 'web_crawler' | 'google_drive' | 'notion' | 'ms_docs'
   | 'airtable' | 'confluence'
   | 'google_docs' | 'google_sheets' | 'google_slides'
-type WcStep = 'details' | 'preview' | 'settings'
+// SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-1: web_crawler wizard step order is
+// Details → AuthQuestion → AuthSetup (only if requires login) → Selector → Settings.
+// AuthSetup runs the REQ-2 auth-probe; Selector gates on the REQ-3 success
+// classification. Other connector types (github/notion/...) are unaffected.
+type WcStep = 'details' | 'auth-question' | 'auth-setup' | 'selector' | 'settings'
+
+type AuthProbeClassification =
+  | 'auth_ok'
+  | 'auth_failed_no_cookies'
+  | 'auth_failed_still_walled'
+  | 'auth_failed_credentials_invalid'
+  | 'auth_failed_unreachable'
+
+interface AuthProbeResult {
+  classification: AuthProbeClassification
+  match_reasons: string[]
+  word_count: number
+  auth_guard: AuthGuardSuggestion | null
+}
+
+type PreviewClassification =
+  | 'success'
+  | 'selector_required'
+  | 'selector_returns_empty'
+  | 'requires_javascript'
+  | 'auth_wall_detected'
 
 interface GitHubConfig {
   installation_id: string
@@ -155,8 +180,14 @@ function AddConnectorPage() {
     fit_markdown: string; word_count: number; warnings: string[]
     content_selector: string | null; selector_source: string | null
     auth_guard: AuthGuardSuggestion | null
+    // SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-3
+    classification: PreviewClassification
+    classification_reason: string | null
   } | null>(null)
   const [showAdvancedAuthGuard, setShowAdvancedAuthGuard] = useState(false)
+  // SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-2: auth-probe state.
+  const [authProbeResult, setAuthProbeResult] = useState<AuthProbeResult | null>(null)
+  const [authProbeError, setAuthProbeError] = useState<string | null>(null)
 
   function parseCookies(): unknown[] | undefined {
     const raw = webcrawlerConfig.cookies.trim()
@@ -318,6 +349,8 @@ function AddConnectorPage() {
         fit_markdown: string; word_count: number; warnings: string[]; url: string
         content_selector: string | null; selector_source: string | null
         auth_guard: AuthGuardSuggestion | null
+        classification: PreviewClassification
+        classification_reason: string | null
       }>(`/api/app/knowledge-bases/${kbSlug}/connectors/crawl-preview`, {
         method: 'POST',
         body: JSON.stringify({ url, content_selector: content_selector || null, try_ai: try_ai ?? false, cookies: cookies || null }),
@@ -326,13 +359,54 @@ function AddConnectorPage() {
     onSuccess: (data) => {
       setPreviewResult(data)
       setPreviewError(null)
-      // Auto-expand CSS selector section when there are problems
-      if (data.word_count === 0 || (data.warnings ?? []).length > 0) {
+      // SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-3: when the page is auth-walled
+      // the wizard MUST send the user back to the auth step, not show "configure
+      // your selector". Hard-jump rather than letting the user stare at amber.
+      if (data.classification === 'auth_wall_detected') {
+        setRequiresLogin(true)
+        setWcStep('auth-setup')
+        setAuthProbeResult(null)
+        return
+      }
+      // Auto-expand CSS selector section when classification points at it.
+      if (data.classification === 'selector_required' || data.classification === 'selector_returns_empty') {
         setShowAdvancedSelector(true)
       }
     },
     onError: (err) => { setPreviewError(err instanceof Error ? err.message : 'Preview failed'); setPreviewResult(null) },
   })
+
+  // SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-2: hits /connectors/auth-probe.
+  const authProbeMutation = useMutation({
+    mutationFn: async ({ url, cookies }: { url: string; cookies?: unknown[] }) => {
+      return apiFetch<AuthProbeResult>(
+        `/api/app/knowledge-bases/${kbSlug}/connectors/auth-probe`,
+        {
+          method: 'POST',
+          body: JSON.stringify({ url, cookies: cookies || null }),
+        },
+      )
+    },
+    onSuccess: (data) => {
+      setAuthProbeResult(data)
+      setAuthProbeError(null)
+    },
+    onError: (err) => {
+      setAuthProbeError(err instanceof Error ? err.message : 'Auth probe failed')
+      setAuthProbeResult(null)
+    },
+  })
+
+  // SPEC-CONNECTOR-INPUT-VALIDATION-001 D-10: cache invalidation. Re-verify
+  // on any config change that affects the probe / preview outcome.
+  function invalidateAuthProbe() {
+    setAuthProbeResult(null)
+    setAuthProbeError(null)
+  }
+  function invalidatePreview() {
+    setPreviewResult(null)
+    setPreviewError(null)
+  }
 
   return (
     <div className="mx-auto max-w-xl px-6 py-10">
@@ -359,13 +433,21 @@ function AddConnectorPage() {
               { label: m.admin_connectors_step_configure() },
             ]
           : [
+              // SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-1: 5-step web_crawler wizard.
               { label: m.admin_connectors_step_type(),                onClick: () => setSelectedType(null) },
               { label: m.admin_connectors_webcrawler_step_details(),  onClick: () => setWcStep('details') },
-              { label: m.admin_connectors_webcrawler_step_preview(),  onClick: () => setWcStep('preview') },
+              { label: 'Authentication',                              onClick: () => setWcStep('auth-question') },
+              { label: m.admin_connectors_webcrawler_step_preview(),  onClick: () => setWcStep('selector') },
               { label: m.admin_connectors_webcrawler_step_settings() },
             ]
 
-        const WC_STEP_INDEX: Record<WcStep, number> = { details: 1, preview: 2, settings: 3 }
+        const WC_STEP_INDEX: Record<WcStep, number> = {
+          details: 1,
+          'auth-question': 2,
+          'auth-setup': 2,
+          selector: 3,
+          settings: 4,
+        }
         const currentIndex = !selectedType
           ? 0
           : isSimple
@@ -734,9 +816,9 @@ function AddConnectorPage() {
                         disabled={!name || !webcrawlerConfig.base_url}
                         onClick={() => {
                           setWcPreviewUrl(webcrawlerConfig.base_url)
-                          setPreviewResult(null)
-                          setPreviewError(null)
-                          setWcStep('preview')
+                          invalidateAuthProbe()
+                          invalidatePreview()
+                          setWcStep('auth-question')
                         }}
                       >
                         {m.admin_connectors_webcrawler_next()}
@@ -748,57 +830,163 @@ function AddConnectorPage() {
                   </div>
                 )}
 
-                {/* Step 2: Preview — auth question first, then preview */}
-                {wcStep === 'preview' && (
+                {/* Step 3: Authentication question — Yes/No only, no other state. */}
+                {wcStep === 'auth-question' && (
                   <div className="space-y-4">
-                    {/* Authentication question — asked once, determines cookies visibility */}
-                    {requiresLogin === null && (
-                      <div className="rounded-lg border border-[var(--color-border)] p-4 space-y-3">
-                        <p className="text-sm font-medium text-[var(--color-foreground)]">
-                          Is this site behind a login?
-                        </p>
-                        <p className="text-xs text-[var(--color-muted-foreground)]">
-                          Some knowledge bases require you to be logged in to see the content.
-                        </p>
-                        <div className="flex gap-2">
-                          <Button type="button" size="sm" variant="outline" onClick={() => setRequiresLogin(false)}>
-                            No, it&apos;s public
-                          </Button>
-                          <Button type="button" size="sm" variant="outline" onClick={() => setRequiresLogin(true)}>
-                            Yes, login required
-                          </Button>
-                        </div>
+                    <div className="rounded-lg border border-[var(--color-border)] p-4 space-y-3">
+                      <p className="text-sm font-medium text-[var(--color-foreground)]">
+                        Is this site behind a login?
+                      </p>
+                      <p className="text-xs text-[var(--color-muted-foreground)]">
+                        Some knowledge bases require you to be logged in to see the content.
+                        We&apos;ll verify either way before letting you save.
+                      </p>
+                      <div className="flex gap-2">
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant={requiresLogin === false ? 'default' : 'outline'}
+                          onClick={() => {
+                            setRequiresLogin(false)
+                            setWebcrawlerConfig((p) => ({ ...p, cookies: '' }))
+                            invalidateAuthProbe()
+                            invalidatePreview()
+                          }}
+                        >
+                          No, it&apos;s public
+                        </Button>
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant={requiresLogin === true ? 'default' : 'outline'}
+                          onClick={() => {
+                            setRequiresLogin(true)
+                            invalidateAuthProbe()
+                            invalidatePreview()
+                          }}
+                        >
+                          Yes, login required
+                        </Button>
                       </div>
+                    </div>
+                    <div className="flex gap-2 pt-1">
+                      <Button
+                        type="button"
+                        size="sm"
+                        disabled={requiresLogin === null}
+                        onClick={() => {
+                          // Public path skips auth-setup; private path runs the probe.
+                          setWcStep(requiresLogin ? 'auth-setup' : 'selector')
+                        }}
+                      >
+                        {m.admin_connectors_webcrawler_next()}
+                      </Button>
+                      <Button type="button" size="sm" variant="ghost" onClick={() => setWcStep('details')}>
+                        {m.admin_connectors_webcrawler_back()}
+                      </Button>
+                    </div>
+                  </div>
+                )}
+
+                {/* Step 4: Auth setup — only reached when requiresLogin === true.
+                    Hits REQ-2 /connectors/auth-probe; gates on classification === auth_ok. */}
+                {wcStep === 'auth-setup' && (
+                  <div className="space-y-4">
+                    <div className="rounded-lg border border-[var(--color-border)] p-4 space-y-3">
+                      <p className="text-sm font-medium text-[var(--color-foreground)]">
+                        Authentication cookies
+                      </p>
+                      <textarea
+                        id="wc-cookies"
+                        className="flex min-h-[80px] w-full rounded-md border border-[var(--color-border)] bg-[var(--color-input)] px-3 py-2 text-xs font-mono placeholder:text-[var(--color-muted-foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)]"
+                        placeholder={m.admin_connectors_webcrawler_cookies_placeholder()}
+                        value={webcrawlerConfig.cookies}
+                        onChange={(e) => {
+                          setWebcrawlerConfig((p) => ({ ...p, cookies: e.target.value }))
+                          invalidateAuthProbe()
+                          invalidatePreview()
+                        }}
+                      />
+                      <p className="text-xs text-[var(--color-muted-foreground)]">
+                        Open the site in your browser, log in, then copy the Cookie value from your
+                        browser&apos;s developer tools (Network tab &rarr; any request &rarr; Cookie header).
+                      </p>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        disabled={authProbeMutation.isPending || !webcrawlerConfig.base_url}
+                        onClick={() => {
+                          setAuthProbeResult(null)
+                          setAuthProbeError(null)
+                          authProbeMutation.mutate({
+                            url: webcrawlerConfig.base_url + (webcrawlerConfig.path_prefix || ''),
+                            cookies: parseCookies(),
+                          })
+                        }}
+                      >
+                        {authProbeMutation.isPending ? (
+                          <><Loader2 className="h-3.5 w-3.5 animate-spin mr-1" />Testing...</>
+                        ) : (
+                          'Test authentication'
+                        )}
+                      </Button>
+                    </div>
+
+                    {authProbeError && (
+                      <p className="text-sm text-[var(--color-destructive)]">{authProbeError}</p>
                     )}
 
-                    {/* Cookies field — only shown after "Yes, login required" */}
-                    {requiresLogin === true && (
-                      <div className="rounded-lg border border-[var(--color-border)] p-4 space-y-3">
-                        <div className="flex items-center justify-between">
-                          <p className="text-sm font-medium text-[var(--color-foreground)]">Authentication cookies</p>
-                          <button
-                            type="button"
-                            className="text-xs text-[var(--color-muted-foreground)] hover:text-[var(--color-foreground)]"
-                            onClick={() => { setRequiresLogin(false); setWebcrawlerConfig((p) => ({ ...p, cookies: '' })) }}
-                          >
-                            Switch to public
-                          </button>
-                        </div>
-                        <textarea
-                          id="wc-cookies"
-                          className="flex min-h-[80px] w-full rounded-md border border-[var(--color-border)] bg-[var(--color-input)] px-3 py-2 text-xs font-mono placeholder:text-[var(--color-muted-foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)]"
-                          placeholder={m.admin_connectors_webcrawler_cookies_placeholder()}
-                          value={webcrawlerConfig.cookies}
-                          onChange={(e) => setWebcrawlerConfig((p) => ({ ...p, cookies: e.target.value }))}
-                        />
-                        <p className="text-xs text-[var(--color-muted-foreground)]">
-                          Open the site in your browser, log in, then copy the Cookie value from your
-                          browser&apos;s developer tools (Network tab &rarr; any request &rarr; Cookie header).
-                        </p>
-                      </div>
+                    {authProbeResult && (
+                      <AuthProbeFeedback result={authProbeResult} />
                     )}
 
-                    {/* Public site confirmation — minimal, allows changing mind */}
+                    <div className="flex gap-2 pt-1">
+                      <Button
+                        type="button"
+                        size="sm"
+                        disabled={authProbeResult?.classification !== 'auth_ok'}
+                        onClick={() => {
+                          // Carry the auth_guard forward to the selector step;
+                          // selector will need it for AC-3 connector save.
+                          if (authProbeResult?.auth_guard) {
+                            setPreviewResult((p) =>
+                              p
+                                ? p
+                                : {
+                                    fit_markdown: '',
+                                    word_count: authProbeResult.word_count,
+                                    warnings: [],
+                                    content_selector: null,
+                                    selector_source: null,
+                                    auth_guard: authProbeResult.auth_guard,
+                                    classification: 'success',
+                                    classification_reason: null,
+                                  },
+                            )
+                          }
+                          setWcStep('selector')
+                        }}
+                      >
+                        {m.admin_connectors_webcrawler_next()}
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => setWcStep('auth-question')}
+                      >
+                        {m.admin_connectors_webcrawler_back()}
+                      </Button>
+                    </div>
+                  </div>
+                )}
+
+                {/* Step 5: Selector — runs preview, gates on REQ-3 classification === success. */}
+                {wcStep === 'selector' && (
+                  <div className="space-y-4">
+                    {/* Auth status reminder — public sites get a banner here, authenticated
+                        sites land here only after auth-setup returned auth_ok. */}
                     {requiresLogin === false && (
                       <div className="flex items-center justify-between rounded-lg border border-[var(--color-border)] px-4 py-3">
                         <div className="flex items-center gap-2 text-xs text-[var(--color-muted-foreground)]">
@@ -808,16 +996,30 @@ function AddConnectorPage() {
                         <button
                           type="button"
                           className="text-xs text-[var(--color-muted-foreground)] hover:text-[var(--color-foreground)]"
-                          onClick={() => setRequiresLogin(true)}
+                          onClick={() => setWcStep('auth-question')}
                         >
                           Actually, it needs login
                         </button>
                       </div>
                     )}
+                    {requiresLogin === true && authProbeResult?.classification === 'auth_ok' && (
+                      <div className="flex items-center justify-between rounded-lg border border-[var(--color-success)]/30 bg-[var(--color-success)]/5 px-4 py-3">
+                        <div className="flex items-center gap-2 text-xs text-[var(--color-success)]">
+                          <CheckCircle2 className="h-3.5 w-3.5" />
+                          Logged in — cookies verified
+                        </div>
+                        <button
+                          type="button"
+                          className="text-xs text-[var(--color-muted-foreground)] hover:text-[var(--color-foreground)]"
+                          onClick={() => setWcStep('auth-setup')}
+                        >
+                          Edit cookies
+                        </button>
+                      </div>
+                    )}
 
-                    {/* Preview URL — shown after auth question is answered */}
-                    {requiresLogin !== null && (
-                      <>
+                    {/* Preview URL */}
+                    <>
                         <div className="space-y-1.5">
                           <Label htmlFor="wc-preview-url">{m.admin_connectors_webcrawler_preview_url()}</Label>
                           <Input
@@ -853,8 +1055,7 @@ function AddConnectorPage() {
                             </p>
                           </div>
                         )}
-                      </>
-                    )}
+                    </>
                     {!webcrawlerConfig.content_selector && (
                       <button
                         type="button"
@@ -877,8 +1078,7 @@ function AddConnectorPage() {
                       variant="outline"
                       disabled={previewMutation.isPending || !wcPreviewUrl}
                       onClick={() => {
-                        setPreviewResult(null)
-                        setPreviewError(null)
+                        invalidatePreview()
                         previewMutation.mutate({ url: wcPreviewUrl, content_selector: webcrawlerConfig.content_selector, cookies: parseCookies() })
                       }}
                     >
@@ -887,6 +1087,13 @@ function AddConnectorPage() {
                         : m.admin_connectors_webcrawler_run_preview()
                       }
                     </Button>
+                    {/* SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-3 — classification feedback. */}
+                    {previewResult && !previewMutation.isPending && (
+                      <PreviewClassificationFeedback
+                        classification={previewResult.classification}
+                        reason={previewResult.classification_reason}
+                      />
+                    )}
                     {/* Error / Result */}
                     {previewError && !previewMutation.isPending && (
                       <p className="text-sm text-[var(--color-destructive)]">{previewError}</p>
@@ -1024,13 +1231,29 @@ function AddConnectorPage() {
                       </div>
                     )}
                     <div className="flex gap-2 pt-1">
-                      <Button type="button" size="sm" onClick={() => setWcStep('settings')}>{m.admin_connectors_webcrawler_next()}</Button>
-                      <Button type="button" size="sm" variant="ghost" onClick={() => setWcStep('details')}>{m.admin_connectors_webcrawler_back()}</Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        disabled={previewResult?.classification !== 'success'}
+                        onClick={() => setWcStep('settings')}
+                      >
+                        {m.admin_connectors_webcrawler_next()}
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        onClick={() =>
+                          setWcStep(requiresLogin ? 'auth-setup' : 'auth-question')
+                        }
+                      >
+                        {m.admin_connectors_webcrawler_back()}
+                      </Button>
                     </div>
                   </div>
                 )}
 
-                {/* Step 3: Settings */}
+                {/* Step 6: Settings */}
                 {wcStep === 'settings' && (
                   <form onSubmit={(e) => { e.preventDefault(); createMutation.mutate() }} className="space-y-3">
                     <div className="space-y-1.5">
@@ -1050,7 +1273,7 @@ function AddConnectorPage() {
                       <Button type="submit" size="sm" disabled={createMutation.isPending}>
                         {createMutation.isPending ? m.admin_connectors_create_submit_loading() : m.admin_connectors_create_submit()}
                       </Button>
-                      <Button type="button" size="sm" variant="ghost" onClick={() => setWcStep('preview')}>{m.admin_connectors_webcrawler_back()}</Button>
+                      <Button type="button" size="sm" variant="ghost" onClick={() => setWcStep('selector')}>{m.admin_connectors_webcrawler_back()}</Button>
                     </div>
                   </form>
                 )}
@@ -1058,6 +1281,94 @@ function AddConnectorPage() {
             )}
 
       </div>
+    </div>
+  )
+}
+
+// -- Helper components -------------------------------------------------------
+
+/**
+ * SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-2 — render auth-probe outcome.
+ * Shared by add-connector and edit-connector flows.
+ */
+export function AuthProbeFeedback({ result }: { result: AuthProbeResult }) {
+  if (result.classification === 'auth_ok') {
+    return (
+      <div className="flex gap-2 items-center rounded-lg border border-[var(--color-success)]/30 bg-[var(--color-success)]/5 p-3 text-xs text-[var(--color-success)]">
+        <CheckCircle2 className="h-3.5 w-3.5 shrink-0" />
+        <span>You&apos;re in. Continue to Selector.</span>
+      </div>
+    )
+  }
+  const reasons = result.match_reasons.length > 0
+    ? ` Detected: ${result.match_reasons.join(', ')}`
+    : ''
+  let message: string
+  switch (result.classification) {
+    case 'auth_failed_no_cookies':
+      message = 'This page requires authentication. Go back to step 3 and answer Yes.'
+      break
+    case 'auth_failed_still_walled':
+      message = `Cookies didn't unlock the content. Re-paste a fresh session cookie.${reasons}`
+      break
+    case 'auth_failed_credentials_invalid':
+      message = '401/403 — credentials rejected.'
+      break
+    case 'auth_failed_unreachable':
+      message = 'Could not reach the page. Check the Base URL.'
+      break
+    default:
+      message = `Authentication check failed.${reasons}`
+  }
+  return (
+    <div className="flex gap-2 items-start rounded-lg border border-amber-200 bg-amber-50 p-3 text-xs text-amber-800">
+      <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+      <span>{message}</span>
+    </div>
+  )
+}
+
+/**
+ * SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-3 — render preview classification outcome.
+ */
+export function PreviewClassificationFeedback({
+  classification,
+  reason,
+}: {
+  classification: PreviewClassification
+  reason: string | null
+}) {
+  if (classification === 'success') {
+    return (
+      <div className="flex gap-2 items-center rounded-lg border border-[var(--color-success)]/30 bg-[var(--color-success)]/5 p-3 text-xs text-[var(--color-success)]">
+        <CheckCircle2 className="h-3.5 w-3.5 shrink-0" />
+        <span>Selector matches real article content. You can save the connector.</span>
+      </div>
+    )
+  }
+  let message: string
+  switch (classification) {
+    case 'selector_required':
+      message =
+        reason ?? 'The output looks like a navigation menu. Configure a Content Selector.'
+      break
+    case 'selector_returns_empty':
+      message = "Selector matched no content. Try a different selector or click 'Let AI find'."
+      break
+    case 'requires_javascript':
+      message =
+        'Page renders via JavaScript. Configure a wait_for condition or selector for the post-render DOM.'
+      break
+    case 'auth_wall_detected':
+      message = 'This page requires authentication. Go back to step 4.'
+      break
+    default:
+      message = reason ?? 'Selector check failed.'
+  }
+  return (
+    <div className="flex gap-2 items-start rounded-lg border border-amber-200 bg-amber-50 p-3 text-xs text-amber-800">
+      <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+      <span>{message}</span>
     </div>
   )
 }

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
@@ -20,12 +20,28 @@ import type { ConnectorSummary, GitHubConfig, WebCrawlerConfig } from './$kbSlug
 type WcTabId = 'details' | 'preview' | 'auth'
 const VALID_WC_TABS = new Set<WcTabId>(['details', 'preview', 'auth'])
 
-type EditSearch = { tab?: WcTabId }
+// SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-1 / REQ-5: step search param
+// supplied by the connectors-list "Investigate" deep-links. Maps to the
+// existing tab system: ``step=auth`` lands on the auth tab, ``step=selector``
+// lands on the preview tab.
+type StepDeepLink = 'auth' | 'selector'
+const VALID_STEPS = new Set<StepDeepLink>(['auth', 'selector'])
+
+function _stepToTab(step: StepDeepLink | undefined): WcTabId | undefined {
+  if (step === 'auth') return 'auth'
+  if (step === 'selector') return 'preview'
+  return undefined
+}
+
+type EditSearch = { tab?: WcTabId; step?: StepDeepLink }
 
 export const Route = createFileRoute('/app/knowledge/$kbSlug_/edit-connector/$connectorId')({
   validateSearch: (search: Record<string, unknown>): EditSearch => ({
     tab: (VALID_WC_TABS as Set<string>).has(search.tab as string)
       ? (search.tab as WcTabId)
+      : undefined,
+    step: (VALID_STEPS as Set<string>).has(search.step as string)
+      ? (search.step as StepDeepLink)
       : undefined,
   }),
   component: EditConnectorPage,
@@ -349,7 +365,10 @@ function EditConnectorPage() {
 
           {/* Web crawler — tabbed layout (widget pattern: URL-driven, border-b underline) */}
           {connector?.connector_type === 'web_crawler' && (() => {
-            const activeTab: WcTabId = search.tab ?? 'details'
+            // SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-1 — honour ?step=auth|selector
+            // as a deep-link alias for the existing tab system.
+            const activeTab: WcTabId =
+              search.tab ?? _stepToTab(search.step) ?? 'details'
             const wcTabs: { id: WcTabId; label: string; icon: React.ElementType }[] = [
               { id: 'details', label: 'Details', icon: Info },
               { id: 'preview', label: 'Preview', icon: Eye },

--- a/klai-portal/frontend/src/routes/app/knowledge/__tests__/wizard-feedback.test.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/__tests__/wizard-feedback.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-6 — wizard feedback components.
+ *
+ * Tests cover the pure render helpers ``AuthProbeFeedback`` (REQ-2)
+ * and ``PreviewClassificationFeedback`` (REQ-3). These components are
+ * exported from the add-connector route so they can be unit-tested in
+ * isolation (no router/query-client setup needed).
+ */
+
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import {
+  AuthProbeFeedback,
+  PreviewClassificationFeedback,
+} from '../$kbSlug_.add-connector'
+
+describe('AuthProbeFeedback', () => {
+  it('renders success state for auth_ok', () => {
+    render(
+      <AuthProbeFeedback
+        result={{
+          classification: 'auth_ok',
+          match_reasons: [],
+          word_count: 600,
+          auth_guard: null,
+        }}
+      />,
+    )
+    expect(screen.getByText(/you're in/i)).toBeTruthy()
+  })
+
+  it('tells user to go back to step 3 on auth_failed_no_cookies', () => {
+    render(
+      <AuthProbeFeedback
+        result={{
+          classification: 'auth_failed_no_cookies',
+          match_reasons: ['end_of_body_login_marker'],
+          word_count: 80,
+          auth_guard: null,
+        }}
+      />,
+    )
+    expect(screen.getByText(/go back to step 3 and answer yes/i)).toBeTruthy()
+  })
+
+  it('exposes match_reasons on auth_failed_still_walled', () => {
+    render(
+      <AuthProbeFeedback
+        result={{
+          classification: 'auth_failed_still_walled',
+          match_reasons: ['session_cookie_minimal_body', 'end_of_body_login_marker'],
+          word_count: 10,
+          auth_guard: null,
+        }}
+      />,
+    )
+    expect(
+      screen.getByText(/session_cookie_minimal_body/),
+    ).toBeTruthy()
+    expect(screen.getByText(/end_of_body_login_marker/)).toBeTruthy()
+  })
+
+  it('shows credentials rejected message on 401/403', () => {
+    render(
+      <AuthProbeFeedback
+        result={{
+          classification: 'auth_failed_credentials_invalid',
+          match_reasons: ['http_unauthenticated'],
+          word_count: 0,
+          auth_guard: null,
+        }}
+      />,
+    )
+    expect(screen.getByText(/401\/403/i)).toBeTruthy()
+  })
+
+  it('shows base-url hint on auth_failed_unreachable', () => {
+    render(
+      <AuthProbeFeedback
+        result={{
+          classification: 'auth_failed_unreachable',
+          match_reasons: [],
+          word_count: 0,
+          auth_guard: null,
+        }}
+      />,
+    )
+    expect(screen.getByText(/check the base url/i)).toBeTruthy()
+  })
+})
+
+describe('PreviewClassificationFeedback', () => {
+  it('renders success message and references saving the connector', () => {
+    render(<PreviewClassificationFeedback classification="success" reason={null} />)
+    expect(screen.getByText(/you can save the connector/i)).toBeTruthy()
+  })
+
+  it('shows the server-supplied reason for selector_required', () => {
+    render(
+      <PreviewClassificationFeedback
+        classification="selector_required"
+        reason="80% of the text is links. Configure a Content Selector."
+      />,
+    )
+    expect(
+      screen.getByText(/80% of the text is links/i),
+    ).toBeTruthy()
+  })
+
+  it('shows AI-find suggestion for selector_returns_empty', () => {
+    render(
+      <PreviewClassificationFeedback
+        classification="selector_returns_empty"
+        reason={null}
+      />,
+    )
+    expect(screen.getByText(/let ai find/i)).toBeTruthy()
+  })
+
+  it('shows JS hint for requires_javascript', () => {
+    render(
+      <PreviewClassificationFeedback
+        classification="requires_javascript"
+        reason={null}
+      />,
+    )
+    expect(screen.getByText(/javascript/i)).toBeTruthy()
+  })
+
+  it('redirects user to step 4 on auth_wall_detected', () => {
+    render(
+      <PreviewClassificationFeedback
+        classification="auth_wall_detected"
+        reason={null}
+      />,
+    )
+    expect(screen.getByText(/go back to step 4/i)).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary

Implements SPEC-CONNECTOR-INPUT-VALIDATION-001 — fixes the silent-failure chain that surfaced during the Voys connector lifecycle test 2026-05-06/07.

A connector either ingests real content correctly OR refuses to be created / refuses to sync, with a message the user can act on. No more "Synced 5 days ago, 25 docs indexed" UI lies while the connector is functionally broken.

## What changed

### Backend (knowledge-ingest)
- **REQ-2** — pure-function ``classify_auth_wall`` with 5 sub-rules + ``POST /ingest/v1/crawl/auth-probe`` endpoint returning 5 outcome labels
- **REQ-3** — ``link_density`` helper + ``CrawlPreviewResponse.classification`` field (success / selector_required / selector_returns_empty / requires_javascript / auth_wall_detected)
- **REQ-4** — ``decide_terminal_status`` sync-time guard wired into ``run_crawl_job``: when wall ratio >= 30% AND no cookies/login_indicator configured, mark crawl_job ``failed_partial`` with structured ``boilerplate_or_authwall_dominant`` reason. Env-tunable via ``KLAI_INGEST_AUTHWALL_DIRTY_TRIP_RATE``.

### Backend (portal-api)
- ``POST /knowledge-bases/{slug}/connectors/auth-probe`` pass-through (owner role gated)
- ``CrawlPreviewResponse`` extended with ``classification`` + ``classification_reason``
- ``ConnectorOut.needs_reconfiguration`` derived field for the UI badge

### Frontend (portal)
- Wizard rewire for ``web_crawler``: 5-step flow (details → auth-question → auth-setup → selector → settings), gating Next button on REQ-2/REQ-3 success classifications
- ``AuthProbeFeedback`` + ``PreviewClassificationFeedback`` pure render components for actionable error messages with ``match_reasons`` exposure
- Edit route ``?step=auth|selector`` deep-link search-param
- Connectors list red "Needs reconfiguration" badge + ``InvestigateDialog`` with "Edit Authentication" / "Edit Selector" deep-link buttons

## Test plan

- [x] 41 auth_wall_classifier unit tests
- [x] 12 auth-probe endpoint tests
- [x] 9 link_density unit tests
- [x] 7 preview-classification tests
- [x] 8 dirty-content guard unit tests + 1 neighbor regression fix
- [x] 8 needs_reconfiguration predicate tests
- [x] 10 wizard-feedback frontend tests
- [x] ruff/ruff format clean on knowledge-ingest + portal-backend
- [x] tsc + eslint clean on portal-frontend
- [ ] Manual AC verification on Voys/support tenant (live):
  - [ ] AC-2 — Configure web_crawler at Redcactus URL, step 3="No, public" → wizard refuses to advance with ``auth_failed_no_cookies``
  - [ ] AC-3 — Same URL, step 3="Yes" + valid cookie → wizard advances after ``auth_ok``
  - [ ] AC-5 — Public site, no content_selector → wizard refuses with ``selector_required``
  - [ ] AC-7 — Trigger sync on a connector with expired cookies → ``connector.sync_runs.status='failed'`` with ``boilerplate_or_authwall_dominant`` reason
  - [ ] AC-8 — Failed Redcactus connector shows red badge; "Edit Authentication" deep-links to ``?step=auth``
  - [ ] AC-9 — Existing Voys/support Redcactus connector flagged on first list-page view post-deploy

## Trade-offs

- ``needs_reconfiguration`` is an approximation (``connector_type='web_crawler' AND last_sync_status='failed'``). Full SPEC predicate (``error_details.reason='boilerplate_or_authwall_dominant'``) requires either a sync-status callback extension to persist ``error_summary`` JSONB, or N+1 HTTP calls to klai-connector. Documented in code; covers AC-9 (Redcactus connector currently has ``last_sync_status='failed'``).

## SPEC trail

- Plan: ``.moai/specs/SPEC-CONNECTOR-INPUT-VALIDATION-001/plan.md``
- Acceptance: ``.moai/specs/SPEC-CONNECTOR-INPUT-VALIDATION-001/acceptance.md``
- Frontend handoff (now resolved): ``.moai/specs/SPEC-CONNECTOR-INPUT-VALIDATION-001/HANDOFF-frontend.md``

🤖 Generated with [Claude Code](https://claude.com/claude-code)