### PR TITLE
chore(SPEC-RAG-MULTILINGUAL-CHAT-001): clean up Phase 4 hotfix detour

### DIFF
--- a/.github/workflows/litellm-hook-deploy.yml
+++ b/.github/workflows/litellm-hook-deploy.yml
@@ -25,5 +25,21 @@ jobs:
       - name: Sync hook files to core-01
         run: rsync -av deploy/litellm/ klai@${{ secrets.CORE01_HOST }}:/opt/klai/litellm/
 
-      - name: Restart LiteLLM
-        run: ssh klai@${{ secrets.CORE01_HOST }} "cd /opt/klai && docker compose restart litellm"
+      # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3 — use the canonical
+      # compose-up wrapper (already used by caddy, klai-connector,
+      # klai-mailer, knowledge-ingest, klai-knowledge-mcp, docs-app).
+      #
+      # Why not `docker compose restart litellm`: `restart` keeps the
+      # existing container env intact — it ignores docker-compose.yml
+      # mount + env-var changes. SPEC-RAG-MULTILINGUAL-CHAT-001 Phase 4
+      # added a new bind-mount (klai_chat_prompts.py) that the previous
+      # `restart` deploy silently dropped on the floor — the proxy
+      # crashlooped on ImportError until a follow-up commit inlined the
+      # constant to remove the new-mount dependency.
+      #
+      # `compose-up.sh` does `docker compose up -d --remove-orphans
+      # litellm` which detects compose-file diffs (new mounts, env-vars,
+      # image tags) and recreates only when needed. No-op when nothing
+      # in the service definition changed.
+      - name: Recreate LiteLLM container
+        run: ssh klai@${{ secrets.CORE01_HOST }} "/opt/klai/scripts/compose-up.sh litellm"

--- a/deploy/litellm/klai_knowledge.py
+++ b/deploy/litellm/klai_knowledge.py
@@ -26,78 +26,26 @@ from typing import Any
 import httpx
 from litellm.integrations.custom_logger import CustomLogger
 
+# SPEC-RAG-MULTILINGUAL-CHAT-001 Phase 4 (REQ-10): the language-detection
+# foundation that this hook prepends to every LibreChat system message,
+# matching what synthesis.py (path C) and partner_chat.py (path B) already
+# do. Imported from the vendored single-file copy at
+# deploy/litellm/klai_chat_prompts.py — see that file's docstring for the
+# vendoring rationale (mirrors klai_service_auth.py from Phase C-1). Drift
+# vs the canonical klai-libs/chat-prompts is enforced by
+# deploy/litellm/tests/test_klai_chat_prompts_drift.py.
+#
+# Note (re-introduced 2026-05-07 after the inline-hotfix detour): the
+# original Phase 4 commit imported this and broke production because the
+# old ``Deploy LiteLLM hooks`` workflow used ``docker compose restart
+# litellm``, which silently ignores new bind-mounts. The cleanup PR that
+# restored this import ALSO switched the workflow to
+# ``/opt/klai/scripts/compose-up.sh litellm`` (= ``docker compose up -d
+# --remove-orphans litellm``) so new mounts are picked up automatically —
+# matching every other klai service deploy.
+from klai_chat_prompts import GROUNDED_CHAT_SYSTEM_PROMPT
+
 logger = logging.getLogger(__name__)
-
-
-# SPEC-RAG-MULTILINGUAL-CHAT-001 Phase 4 (REQ-10) — HOTFIX 2026-05-07:
-#
-# The language-detection foundation that this hook prepends to every
-# LibreChat system message, matching what synthesis.py (path C) and
-# partner_chat.py (path B) already do.
-#
-# Originally Phase 4 imported this constant from a vendored single-file
-# copy at ``deploy/litellm/klai_chat_prompts.py`` (mirrors
-# ``klai_service_auth.py`` from SPEC-SEC-SERVICE-AUTH-001 Phase C-1).
-# That works locally because pytest puts ``deploy/litellm`` on
-# sys.path, but it does NOT work on production: the
-# ``Deploy LiteLLM hooks`` GitHub workflow (.github/workflows/
-# deploy-litellm-hooks.yml) only runs ``docker compose restart litellm``.
-# ``restart`` does NOT re-read docker-compose.yml volume mounts — only
-# ``up -d --force-recreate`` does. So even after Phase 4 merged, the
-# container kept running with its previous mount config (which did not
-# yet include the new ``klai_chat_prompts.py`` mount), the import
-# failed, and the proxy crashlooped.
-#
-# Hotfix: inline the constant here so the hot path has zero
-# cross-file dependencies. The vendored copy at
-# ``deploy/litellm/klai_chat_prompts.py`` and its drift test stay in
-# the repo — both still test that the canonical
-# ``klai-libs/chat-prompts/klai_chat_prompts/__init__.py`` and the
-# vendored copy are byte-identical. Drift here in this inlined copy is
-# instead caught by the lint script
-# ``scripts/lint-no-duplicate-chat-prompt.sh`` (HOOK_ALLOWED includes
-# this file) — anyone editing the canonical library must edit both
-# the canonical AND this inline copy AND the vendored single-file.
-#
-# Phase D plan (already documented in deploy/litellm/klai_chat_prompts.py
-# and in SPEC-SEC-SERVICE-AUTH-001 Phase D notes): replace BOTH vendored
-# files with a custom litellm Dockerfile that ``pip install``s
-# ``klai-chat-prompts`` AND fixes the deploy workflow to use
-# ``up -d --force-recreate``. After that the inline below can be
-# replaced with ``from klai_chat_prompts import GROUNDED_CHAT_SYSTEM_PROMPT``.
-GROUNDED_CHAT_SYSTEM_PROMPT: str = (
-    "[CRITICAL] Detect the language of the user's most recent SUBSTANTIVE message and respond "
-    "in that exact language. Apply these three guards:\n"
-    "- Messages with fewer than 5 words inherit the language of the most recent prior longer "
-    "message in the conversation. The first user message is always treated as substantive "
-    "regardless of length.\n"
-    "- Single foreign-language words inside an otherwise consistent-language message do NOT "
-    "change the response language. Brief acknowledgements ('thanks!', 'merci', 'ok gracias') "
-    "do not flip the conversation.\n"
-    "- A clearly switched substantive message (a full-sentence question or statement in a "
-    "different language) DOES switch the response language and stays switched until another "
-    "substantive switch.\n\n"
-    "You are Klai AI, a knowledge assistant. You answer questions based on the knowledge base "
-    "chunks provided. The knowledge base may be in a different language than the user's "
-    "question (often Dutch). Translate cited content into the user's language naturally. "
-    "Do NOT apologize for source-language differences. Do NOT add translator disclaimers. "
-    "Do NOT transliterate proper names — keep them as written in the source.\n\n"
-    "## How to answer\n"
-    "Start with the answer. No warm-up, no rephrasing the question, no 'great question!'\n"
-    "Simple question: 1-3 sentences. Complex question: the core answer first, then the detail.\n"
-    "Be direct. Be honest. If the sources say something unexpected, say it.\n\n"
-    "## How to cite\n"
-    "Every factual claim gets a [n] citation where n is the chunk number. "
-    "If a chunk includes a URL or help page link, include it: [n] (https://...). "
-    "Citations [n] always link to the original source URL regardless of source language. "
-    "If sources contradict each other, say so — don't pick a side silently.\n\n"
-    "## When the answer isn't there\n"
-    "Say it plainly, in the user's language: e.g. 'That's not in the knowledge base' / "
-    "'Dat staat niet in de kennisbank' / 'Das steht nicht in der Wissensdatenbank'. "
-    "Don't guess. Don't fill the gap with general knowledge. "
-    "If you're partially sure, say that too: 'The knowledge base touches on this, but doesn't "
-    "fully answer it.'"
-)
 
 KNOWLEDGE_RETRIEVE_URL = os.getenv("KNOWLEDGE_RETRIEVE_URL")
 if not KNOWLEDGE_RETRIEVE_URL:

--- a/scripts/lint-no-duplicate-chat-prompt.sh
+++ b/scripts/lint-no-duplicate-chat-prompt.sh
@@ -56,14 +56,20 @@ cd "$REPO_ROOT"
 #   - the LiteLLM-vendored copy (Phase 4 REQ-10 — sync enforced by
 #     deploy/litellm/tests/test_klai_chat_prompts_drift.py, same pattern
 #     as klai_service_auth.py from SPEC-SEC-SERVICE-AUTH-001 Phase C-1)
-#   - the LiteLLM hook itself (Phase 4 hotfix 2026-05-07 inlined the
-#     constant to bypass the docker-compose-restart-vs-recreate gap;
-#     see klai_knowledge.py for full rationale + Phase D plan to
-#     un-inline)
 #   - the SPEC documentation
 #   - this script
 #   - klai .claude rules + docs
-GROUNDED_ALLOWED='^(klai-libs/chat-prompts/|deploy/litellm/klai_chat_prompts\.py|deploy/litellm/klai_knowledge\.py|deploy/litellm/tests/|\.moai/specs/SPEC-RAG-MULTILINGUAL-CHAT-001/|scripts/lint-no-duplicate-chat-prompt\.sh|\.claude/rules/klai/|docs/architecture/|docs/runbooks/|docs/retros/|docs/audit-|docs/research/kb-chat-system-prompts\.md)'
+#
+# NOT allowed: deploy/litellm/klai_knowledge.py — the hook imports
+# ``GROUNDED_CHAT_SYSTEM_PROMPT`` from the vendored copy, never inlines.
+# The 2026-05-07 inline-hotfix was reverted by the cleanup PR after the
+# deploy workflow was switched from ``docker compose restart litellm`` to
+# ``/opt/klai/scripts/compose-up.sh litellm`` (= ``docker compose up -d
+# --remove-orphans litellm``), which picks up new bind-mounts
+# automatically. Two canonical homes for this anchor: canonical library
+# and vendored copy. Drift between them is enforced by
+# test_klai_chat_prompts_drift.py.
+GROUNDED_ALLOWED='^(klai-libs/chat-prompts/|deploy/litellm/klai_chat_prompts\.py|deploy/litellm/tests/|\.moai/specs/SPEC-RAG-MULTILINGUAL-CHAT-001/|scripts/lint-no-duplicate-chat-prompt\.sh|\.claude/rules/klai/|docs/architecture/|docs/runbooks/|docs/retros/|docs/audit-|docs/research/kb-chat-system-prompts\.md)'
 
 # Allowed paths for the HOOK anchors (set 2):
 #   - the LiteLLM hook itself (canonical home)


### PR DESCRIPTION
## Summary

Closes out the Phase 4 → hotfix detour with three small, paired changes (net **-30 LoC**):

1. **Fix `litellm-hook-deploy.yml`** — switch from `docker compose restart litellm` to the canonical `/opt/klai/scripts/compose-up.sh litellm` wrapper that every other klai service-deploy already uses (caddy, klai-connector, klai-mailer, knowledge-ingest, klai-knowledge-mcp, docs-app). This is the underlying bug that caused the Phase 4 crashloop: `restart` ignores new bind-mounts and env-vars, only `up -d --remove-orphans` picks them up.

2. **Un-inline `GROUNDED_CHAT_SYSTEM_PROMPT`** — `klai_knowledge.py` imports from the vendored `klai_chat_prompts` again, exactly as Phase 4 originally designed. Three copies of the constant collapse back to two (canonical + vendored, drift-test enforced).

3. **Lint allowlist cleanup** — `deploy/litellm/klai_knowledge.py` removed from `GROUNDED_ALLOWED`. Any future re-introduction of the inline constant will fail CI.

## Why this is safe

After this lands, all three chat paths import \`GROUNDED_CHAT_SYSTEM_PROMPT\` from the **same canonical name**:

\`\`\`
path A (LiteLLM hook):  deploy/litellm/klai_knowledge.py:46
path B (partner_chat):  klai-portal/backend/app/services/partner_chat.py:25
path C (synthesis):     klai-retrieval-api/retrieval_api/services/synthesis.py:23
\`\`\`

For path A, the name resolves via the vendored single-file mount at `/app/klai_chat_prompts.py`. For paths B + C via the `klai-chat-prompts` package install. Drift between canonical lib and vendored single-file is enforced by `test_klai_chat_prompts_drift.py`.

## Tests

- 112 LiteLLM tests pass (multilingual contract preserved — `_compose_libre_chat_prefix` still wraps all 8 LibreChat-only call sites)
- 11 klai-libs/chat-prompts tests pass
- 2 drift tests pass (canonical ↔ vendored byte-identity)
- `lint-no-duplicate-chat-prompt.sh` clean
- YAML parses OK

## Deploy validation

This commit triggers the **now-fixed** `litellm-hook-deploy.yml` workflow (path filter matches both itself and `deploy/litellm/**`). The new workflow runs `/opt/klai/scripts/compose-up.sh litellm` which:
1. Detects the new `klai_chat_prompts.py` bind-mount that has been on disk since Phase 4
2. Detects the un-inlined `klai_knowledge.py` content
3. Recreates the litellm container with both
4. Container starts cleanly (no `ImportError`), import succeeds

Production smoke (DE/FR/PT/ES/NL/EN via Playwright in LibreChat) gets re-run after this lands.

## Phase D follow-up (separate scope, separate SPEC)

Replace BOTH vendored single-file copies (`klai_service_auth.py` and `klai_chat_prompts.py`) with a custom litellm Dockerfile that `pip install`s `klai-service-auth` and `klai-chat-prompts`. After that the vendored files + drift tests can be deleted entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)