### PR TITLE
docs(SPEC-RAG-MULTILINGUAL-CHAT-001): sync CHANGELOG + product.md + tech.md

### DIFF
--- a/.moai/project/product.md
+++ b/.moai/project/product.md
@@ -32,7 +32,7 @@
 ## Core Products
 
 ### Chat
-AI chat interface powered by LibreChat. Each customer gets an isolated subdomain (e.g., `acme.getklai.com`) with their own data store. Model routing via LiteLLM: simple queries routed to fast models, complex queries to large models. Automatic fallback from Mistral API to Ollama CPU on failure. Web search via SearxNG + Firecrawl for full-page content extraction. Reranking via self-hosted Infinity (BGE-reranker-v2-m3).
+AI chat interface powered by LibreChat. Each customer gets an isolated subdomain (e.g., `acme.getklai.com`) with their own data store. Model routing via LiteLLM: simple queries routed to fast models, complex queries to large models. Automatic fallback from Mistral API to Ollama CPU on failure. Web search via SearxNG + Firecrawl for full-page content extraction. Reranking via self-hosted Infinity (BGE-reranker-v2-m3). **Multilingual chat (NL/EN/DE/FR/PT/ES)** — per-message language auto-detection across all three chat surfaces (LibreChat, embeddable widget, partner API): a German colleague querying a Dutch knowledge base receives a German answer with citations to the Dutch source. Three industry-standard guards (≥5-word substantive threshold, single-foreign-word tolerance, substantive-switch persistence) prevent spurious language switches. Pre-merge eval gate enforces ≥95% per-language correctness.
 
 ### Knowledge
 Organization-scoped knowledge bases with document management. Hybrid retrieval pipeline combining vector search (Qdrant) and knowledge graph (FalkorDB/Graphiti) with Reciprocal Rank Fusion. Document ingestion via knowledge-ingest service with dense + sparse embeddings (BGE-M3 via TEI + custom sparse server). External source connectors (klai-connector): GitHub repos, websites via Crawl4AI. Knowledge-augmented chat responses via LiteLLM retrieval hook. MCP server (klai-knowledge-mcp) for LibreChat tool integration. **Knowledge Gaps dashboard** tracks unanswered questions (zero chunks or low-confidence retrieval) so admins can identify and fill content gaps in their knowledge bases. Per-user KB scope control bar lets users enable/disable KB retrieval, toggle personal KB inclusion, and filter which org knowledge bases are searched — preferences persist via portal API and propagate to the LiteLLM hook within 30 seconds via version-based cache invalidation.
@@ -63,7 +63,7 @@ Each org has a plan that determines which products are available: `free` (none),
 ## Core Features
 
 **Customer-Facing**
-- Private chat with Klai LLM models (isolated per tenant)
+- Private chat with Klai LLM models (isolated per tenant), multilingual answers in NL/EN/DE/FR/PT/ES against the same knowledge base
 - Knowledge bases: upload documents, connect GitHub/websites, ask questions with cited sources; gap dashboard shows admins which questions the KB can't answer
 - Docs: per-tenant documentation sites with markdown editing
 - Focus: deep research with web search and document analysis

--- a/.moai/project/tech.md
+++ b/.moai/project/tech.md
@@ -232,6 +232,62 @@ endpoint; consumers migrate one PR each.
 | HTTP Client | httpx | >=0.28 |
 | Structured Logging | structlog | >=25.0 |
 
+### klai-libs/chat-prompts
+
+**Purpose:** Single source of truth for the multilingual chat system
+prompt (SPEC-RAG-MULTILINGUAL-CHAT-001). Exports
+`GROUNDED_CHAT_SYSTEM_PROMPT` — the language-detection foundation with
+three industry-standard guards (≥5-word substantive threshold, single-
+foreign-word tolerance, substantive-switch persistence) that gates
+per-message language detection across all chat surfaces.
+
+**Consumers:** `klai-portal/backend` (path B — partner_chat / Widget /
+Partner API), `klai-retrieval-api` (path C — dormant `/chat`), and
+`deploy/litellm/klai_knowledge.py` (path A — LibreChat hook, via
+vendored single-file copy at `deploy/litellm/klai_chat_prompts.py`
+with drift test at `deploy/litellm/tests/test_klai_chat_prompts_drift.py`).
+
+| Module | Purpose |
+|---|---|
+| `__init__` | `GROUNDED_CHAT_SYSTEM_PROMPT: Final[str]` constant |
+
+A CI lint (`scripts/lint-no-duplicate-chat-prompt.sh`) rejects any PR
+re-introducing the prompt anchors outside the canonical lib + drift-
+tested vendor copy + permitted doc paths.
+
+The vendored single-file pattern at `deploy/litellm/` exists because
+the LiteLLM container is a stock upstream image without `pip install`
+hooks. SPEC-LITELLM-CUSTOM-IMAGE-001 (drafted) replaces it with a
+custom Dockerfile that pip-installs `klai-chat-prompts` directly.
+
+### klai-libs/service-auth
+
+**Purpose:** Outbound Zitadel JWT token client for service-to-service
+auth (SPEC-SEC-SERVICE-AUTH-001 Phase C-1). Exports
+`ZitadelTokenClient` — minted short-lived JWT via OAuth 2.0 Client
+Credentials grant (RFC 6749 §4.4), with refresh at 80% of advertised
+TTL, fail-recovery window, and per-service identity in the `sub`
+claim. Replaces the long-lived shared `X-Internal-Secret` header
+(legacy fallback path retained per REQ-5; removal blocked on
+SPEC-LITELLM-CUSTOM-IMAGE-001 + SEC-SERVICE-AUTH-001 Phase D).
+
+**Consumers:** `deploy/litellm/klai_knowledge.py` (path A — via
+vendored single-file copy at `deploy/litellm/klai_service_auth.py`
+with drift test at
+`deploy/litellm/tests/test_klai_service_auth_drift.py`); future Phase
+C2-Cn migrations will adopt the same library across remaining
+service pairs.
+
+| Module | Purpose |
+|---|---|
+| `client` | `ZitadelTokenClient` — async httpx token mint + cache |
+| `scopes` | Per-endpoint scope constants (`RETRIEVAL_QUERY`, etc.) |
+
+| Layer | Technology | Version |
+|-------|-----------|---------|
+| HTTP Client | httpx | >=0.28 |
+| Structured Logging | structlog | >=25.0 |
+
 ---
 
 ## Garage S3 (deploy/garage/)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,130 @@
 # Changelog
 
+## [Unreleased] — 2026-05-07 — SPEC-RAG-MULTILINGUAL-CHAT-001: Language-agnostic chat answer layer
+
+Klai chat now auto-detects the language of the user's most recent substantive
+message and responds in that language across all three production chat paths
+(LibreChat → LiteLLM hook → Mistral, portal-api `/partner/v1/chat/completions`,
+retrieval-api `/chat`). Six target languages: NL, EN, DE, FR, PT, ES. Cross-
+lingual retrieval was already working via bge-m3 (multilingual embedding —
+75.5% Recall@100 on MKQA); the bottleneck was the synthesis layer, which
+hardcoded a NL/EN switch. Three industry-standard guards prevent spurious
+language switches: minimum-message-length (≥5 words substantive), single-
+foreign-word tolerance ("merci!" doesn't flip the conversation), and
+substantive-switch persistence (a full sentence in another language flips and
+stays flipped). Verified live on Voys-tenant LibreChat with all 6 target
+languages.
+
+### Added
+
+- **`klai-libs/chat-prompts`** — new shared library exporting
+  `GROUNDED_CHAT_SYSTEM_PROMPT`. Single source of truth for the multilingual
+  prompt foundation. Imported by `klai-portal/backend/app/services/partner_chat.py`
+  (path B), `klai-retrieval-api/retrieval_api/services/synthesis.py` (path C),
+  and `deploy/litellm/klai_knowledge.py` (path A — via vendored single-file
+  copy with drift test).
+- **Cross-lingual eval-suite** —
+  `klai-retrieval-api/evaluation/cross_lingual_runner.py` runs each test query
+  against the synthesis service and computes `language_correctness` per
+  language. Pre-merge gate floor: ≥95% per language for all six targets.
+- **`chat_synthesis_complete` log event** — emitted by paths B + C with
+  `query_language_detected`, `response_language_detected`,
+  `language_correctness`, `response_length_chars`, `org_id`, `request_id`.
+  Path A emit deferred to SPEC-LITELLM-CUSTOM-IMAGE-001 (lingua not in stock
+  litellm image; documented in
+  `docs/runbooks/multilingual-chat-observability.md`).
+- **Lint script** `scripts/lint-no-duplicate-chat-prompt.sh` — CI gate that
+  rejects any PR re-introducing prompt anchors outside their canonical
+  location. Catches both grounded-prompt anchors (canonical in chat-prompts
+  lib) and LiteLLM-hook prefix anchors (canonical in `klai_knowledge.py`).
+- **English chat-prompt anchors in LiteLLM hook** — Phase 4 rewrote the
+  four NL prefix blocks in `deploy/litellm/klai_knowledge.py` (Klai
+  Templates wrapper, KB-unavailable notice, KB header narrow + broad,
+  ANSWER FORMAT) to English-prefixed multilingual instructions. Model
+  receives English instructions but answers in the user's detected language.
+- **Multilingual coverage tests** — 9 new tests in
+  `deploy/litellm/tests/test_klai_knowledge_hook.py` cover DE/FR/PT/ES
+  query → multilingual-foundation prepended invariant.
+- **Documentation** —
+  `docs/architecture/knowledge-ingest-flow.md` (three-paths description),
+  `docs/runbooks/multilingual-chat-observability.md` (operator runbook for
+  `language_correctness` telemetry),
+  `.claude/rules/klai/projects/knowledge.md` ("chat system prompt — three
+  locations, never duplicate" pitfall),
+  `docs/retros/2026-05-07-litellm-restart-vs-recreate.md` (incident retro),
+  `.claude/rules/klai/pitfalls/process-rules.md`
+  (`docker-compose-restart-vs-recreate` CRIT entry),
+  `.moai/specs/SPEC-LITELLM-CUSTOM-IMAGE-001/` (follow-up SPEC for custom
+  litellm Dockerfile + path-A telemetry + vendored-files removal).
+
+### Changed
+
+- **Synthesis system prompt** —
+  `klai-retrieval-api/retrieval_api/services/synthesis.py` and
+  `klai-portal/backend/app/services/partner_chat.py` now import
+  `GROUNDED_CHAT_SYSTEM_PROMPT` from `klai-libs/chat-prompts` instead of
+  inlining a NL/EN switch. v1.1 introduced this for paths B + C; v1.2
+  Phase 4 extended it to path A.
+- **`deploy/litellm/klai_knowledge.py`** — imports the multilingual
+  foundation via vendored single-file copy at
+  `deploy/litellm/klai_chat_prompts.py` (drift-tested against canonical
+  `klai-libs/chat-prompts`). New helper `_compose_libre_chat_prefix(*blocks)`
+  guarantees the foundation leads every LibreChat-only system message
+  across all 8 hook code paths (no entitlement, KB disabled, opt-out,
+  identity-resolve-failed, retrieval-bypassed, no chunks, KB-unavailable,
+  success).
+- **`.github/workflows/litellm-hook-deploy.yml`** — switched from
+  `docker compose restart litellm` to
+  `/opt/klai/scripts/compose-up.sh litellm` (canonical wrapper from
+  SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3). Fixes a deploy bug discovered
+  during the Phase 4 ship: `restart` silently ignores new bind-mounts and
+  env-vars, only `up -d --remove-orphans` picks them up.
+- **Chunk-scope labels in LiteLLM hook system prompt** — `[persoonlijk]` →
+  `[personal]`, `### [Bron]` → `### [Source]`, `### Kennisbank` →
+  `### Knowledge Base`, `[Einde kennisbank-context]` →
+  `[End knowledge base context]`. English labels for consistency with the
+  English-prefixed instructions; never echoed verbatim by the model so
+  user-facing language is unaffected.
+
+### Configuration
+
+No new environment variables. Existing `KNOWLEDGE_RETRIEVE_URL`,
+`PORTAL_INTERNAL_SECRET`, `RETRIEVAL_INTERNAL_SECRET`, etc. unchanged.
+
+`docker-compose.yml` adds one new bind-mount for the litellm service:
+```
+- ./litellm/klai_chat_prompts.py:/app/klai_chat_prompts.py:ro
+```
+
+### Migration
+
+No database migration required. New mount + new lib become active on next
+LiteLLM container recreate (handled automatically by
+`compose-up.sh litellm` in the deploy workflow).
+
+### Verification
+
+Production smoke test (Voys-tenant LibreChat, 2026-05-07): six languages
+verified — DE / FR / PT / ES (target multilingual) all return
+target-language answers with citations to the NL Notion knowledge base;
+NL / EN regression checks unchanged. Container health verified via
+VictoriaLogs (`Application startup complete`, `/health/liveliness 200`,
+zero `ImportError`).
+
+### Follow-ups
+
+- **SPEC-LITELLM-CUSTOM-IMAGE-001** (drafted, not implemented) — replace
+  the two vendored single-files (`klai_service_auth.py`,
+  `klai_chat_prompts.py`) with a custom litellm Dockerfile that
+  `pip install`s the canonical libraries + `lingua-language-detector`.
+  Closes the path-A `chat_synthesis_complete` emit gap and eliminates
+  the vendored single-file pattern entirely.
+- **SPEC-SEC-SERVICE-AUTH-001 REQ-5** — remove the legacy
+  `X-Internal-Secret` auth fallback path. Unblocked by the planned custom
+  litellm image.
+
+---
+
 ## [Unreleased] — 2026-05-06 — SPEC-INGEST-RECONCILE-001: Coverage-complete + observable connector ingestion
 
 Two empirical silent-drop bugs (Voys Help NL: 41/208 sitemap pages ingested;


### PR DESCRIPTION
## Summary

Pure doc-sync. Three meta-doc files were behind the code that already shipped:

- **CHANGELOG.md** — no entry for SPEC-RAG-MULTILINGUAL-CHAT-001 (latest was SPEC-INGEST-RECONCILE-001 from 2026-05-06)
- **\`.moai/project/product.md\`** — "Chat" product description didn't mention multilingual (customer-visible enterprise capability worth one sentence)
- **\`.moai/project/tech.md\`** — "Shared Libraries (klai-libs/)" missing \`klai-libs/chat-prompts\` and \`klai-libs/service-auth\` (both shipped weeks ago)

No code, no SPEC changes, no infra. Just catching meta-docs up.

## Test plan

- [x] CHANGELOG entry follows the existing per-SPEC format (Added / Changed / Configuration / Migration / Verification / Follow-ups)
- [x] product.md change is one targeted sentence in Chat section + Customer-Facing list
- [x] tech.md additions match the surrounding klai-libs entry pattern (Purpose / Consumers / Module table / Layer table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)