### PR TITLE
hotfix(ingest): tenant-only identity on preview_crawl + crawl_url

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/routes/crawl.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/crawl.py
@@ -32,7 +32,6 @@ from knowledge_ingest.domain_selectors import (
 )
 from knowledge_ingest.fingerprint import compute_content_fingerprint
 from knowledge_ingest.identity import (
-    assert_caller_identity,
     assert_caller_identity_tenant_only,
 )
 from knowledge_ingest.models import CrawlRequest, CrawlResponse, IngestRequest
@@ -255,11 +254,22 @@ async def _maybe_tenant_conn(org_id: str):
 async def preview_crawl(body: CrawlPreviewRequest, request: Request) -> CrawlPreviewResponse:
     """Fetch a URL with PruningContentFilter and return the filtered markdown preview.
     SPEC-TI-003 AC-6: identity assertion when org_id is provided.
+
+    SPEC-CONNECTOR-INPUT-VALIDATION-001 hotfix: this is a service-to-service
+    pass-through (called by portal-api with X-Internal-Secret + X-Caller-Service:
+    portal-api). There is NO end-user in the request context, so we MUST use
+    the tenant-only identity flavour. Calling the user-bound
+    ``assert_caller_identity`` here raises TypeError at runtime because the
+    required ``claimed_user_id`` arg has no source. The OLD wizard never hit
+    this path because it sent an empty ``body.org_id``; the NEW wizard always
+    sends one.
+
+    Same fix pattern as PR #448 applied to ``enqueue_connector_purge_route``.
     """
     logger.info("crawl_preview_started", url=body.url)
-    # SPEC-TI-003 AC-6: assert identity when caller provides org_id
+    # SPEC-TI-003 AC-6: assert tenant identity when caller provides org_id
     if body.org_id:
-        await assert_caller_identity(request, claimed_org_id=body.org_id)
+        await assert_caller_identity_tenant_only(request, claimed_org_id=body.org_id)
     # SPEC-SEC-SSRF-001 / REQ-1.1 / AC-1 / AC-6: SSRF validation MUST
     # run before any DNS lookup triggered by downstream crawl4ai /
     # get_domain_selector / crawl_dom_summary logic. It runs outside
@@ -560,8 +570,12 @@ async def crawl_url(request: CrawlRequest, http_request: Request) -> CrawlRespon
     consistent across all crawl paths.
     SPEC-TI-003 AC-6: identity assertion on body org_id.
     """
+    # SPEC-CONNECTOR-INPUT-VALIDATION-001 hotfix: same fix-pattern as
+    # preview_crawl above — service-to-service pass-through has no end-user,
+    # use tenant-only flavour. PR #448 first-aid for purge routes; same
+    # bug-shape exists here.
     if request.org_id:
-        await assert_caller_identity(http_request, claimed_org_id=request.org_id)
+        await assert_caller_identity_tenant_only(http_request, claimed_org_id=request.org_id)
     try:
         await validate_url(request.url)
     except ValueError as exc:

--- a/klai-knowledge-ingest/tests/test_preview_crawl_tenant_only_identity.py
+++ b/klai-knowledge-ingest/tests/test_preview_crawl_tenant_only_identity.py
@@ -1,0 +1,192 @@
+"""SPEC-CONNECTOR-INPUT-VALIDATION-001 hotfix — pin tenant-only identity
+on the preview/crawl routes.
+
+Both ``preview_crawl`` and ``crawl_url`` are service-to-service pass-throughs
+(called by portal-api with X-Internal-Secret + X-Caller-Service: portal-api).
+There is no end-user in the request context, so they MUST use the
+``assert_caller_identity_tenant_only`` flavour.
+
+Same regression-test pattern as ``test_ingest_endpoints_identity_assertion.py``
+(introduced after PR #448 fixed the same TypeError pattern in purge routes).
+
+The test uses a strict-signature mock so any future revert to the user-bound
+``assert_caller_identity`` (which requires ``claimed_user_id``) fails fast
+with TypeError instead of bleeding into a 500 in production.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+
+def _strict_tenant_only_identity_signature():
+    """Mock that ONLY accepts the tenant-only signature.
+
+    If the route ever reverts to the user-bound ``assert_caller_identity``
+    (which would also pass ``claimed_user_id``), this raises TypeError and
+    the test fails — exactly the bug we're guarding against.
+    """
+
+    async def _ok(request, *, claimed_org_id):
+        return claimed_org_id
+
+    return AsyncMock(side_effect=_ok)
+
+
+def test_preview_crawl_uses_tenant_only_identity(client: TestClient) -> None:
+    """REGRESSION: preview_crawl MUST use assert_caller_identity_tenant_only.
+
+    The OLD wizard sent body.org_id="" (empty) so the broken
+    ``assert_caller_identity`` call never fired. The NEW wizard always sends
+    a non-empty org_id, so the bug surfaced as a 500 in production
+    (TypeError: missing 1 required positional argument 'claimed_user_id').
+    """
+    strict_mock = _strict_tenant_only_identity_signature()
+
+    with (
+        patch(
+            "knowledge_ingest.routes.crawl.assert_caller_identity_tenant_only",
+            new=strict_mock,
+        ),
+        patch(
+            "knowledge_ingest.routes.crawl.crawl_page",
+            new=AsyncMock(
+                return_value=type(
+                    "R",
+                    (),
+                    {
+                        "url": "https://example.com",
+                        "fit_markdown": "Real article content. " * 60,
+                        "raw_markdown": "Real article content. " * 60,
+                        "html": "<html></html>",
+                        "word_count": 600,
+                        "success": True,
+                        "metadata": {"status_code": 200},
+                        "response_headers": {},
+                        "links": {},
+                        "media": {},
+                        "error_message": None,
+                    },
+                )(),
+            ),
+        ),
+    ):
+        resp = client.post(
+            "/ingest/v1/crawl/preview",
+            json={"url": "https://example.com", "org_id": "368884765035593759"},
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert strict_mock.await_count == 1, "tenant-only identity assert MUST run"
+    # Pin the call shape — no claimed_user_id positional or kwarg.
+    call_kwargs = strict_mock.await_args.kwargs
+    assert call_kwargs == {"claimed_org_id": "368884765035593759"}
+
+
+def test_crawl_url_uses_tenant_only_identity(client: TestClient) -> None:
+    """REGRESSION: same fix applied to /ingest/v1/crawl (crawl_url)."""
+    strict_mock = _strict_tenant_only_identity_signature()
+
+    with (
+        patch(
+            "knowledge_ingest.routes.crawl.assert_caller_identity_tenant_only",
+            new=strict_mock,
+        ),
+        # Stub everything downstream so the route returns 200 cleanly.
+        patch("knowledge_ingest.routes.crawl.validate_url", new=AsyncMock(return_value=None)),
+        patch(
+            "knowledge_ingest.routes.crawl.get_domain_selector",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "knowledge_ingest.routes.crawl.crawl_page",
+            new=AsyncMock(
+                return_value=type(
+                    "R",
+                    (),
+                    {
+                        "url": "https://example.com",
+                        "fit_markdown": "x" * 100,
+                        "raw_markdown": "x" * 100,
+                        "html": "<html></html>",
+                        "word_count": 100,
+                        "success": True,
+                        "metadata": {},
+                        "response_headers": {},
+                        "links": {},
+                        "media": {},
+                        "error_message": None,
+                    },
+                )(),
+            ),
+        ),
+        patch(
+            "knowledge_ingest.routes.crawl.pg_store.get_crawled_page_stored",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "knowledge_ingest.routes.crawl.pg_store.upsert_crawled_page",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "knowledge_ingest.routes.crawl.ingest_document",
+            new=AsyncMock(return_value={"chunks": 0}),
+        ),
+    ):
+        resp = client.post(
+            "/ingest/v1/crawl",
+            json={
+                "org_id": "368884765035593759",
+                "kb_slug": "test-kb",
+                "url": "https://example.com",
+            },
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert strict_mock.await_count == 1
+    call_kwargs = strict_mock.await_args.kwargs
+    assert call_kwargs == {"claimed_org_id": "368884765035593759"}
+
+
+def test_preview_crawl_skips_identity_when_org_id_empty(client: TestClient) -> None:
+    """When org_id is empty (anonymous preview), identity assert MUST NOT
+    run — that's the legitimate fallthrough for the older anonymous flow."""
+    spy = _strict_tenant_only_identity_signature()
+
+    with (
+        patch(
+            "knowledge_ingest.routes.crawl.assert_caller_identity_tenant_only",
+            new=spy,
+        ),
+        patch(
+            "knowledge_ingest.routes.crawl.crawl_page",
+            new=AsyncMock(
+                return_value=type(
+                    "R",
+                    (),
+                    {
+                        "url": "https://example.com",
+                        "fit_markdown": "x" * 100,
+                        "raw_markdown": "x" * 100,
+                        "html": "<html></html>",
+                        "word_count": 100,
+                        "success": True,
+                        "metadata": {},
+                        "response_headers": {},
+                        "links": {},
+                        "media": {},
+                        "error_message": None,
+                    },
+                )(),
+            ),
+        ),
+    ):
+        resp = client.post(
+            "/ingest/v1/crawl/preview",
+            json={"url": "https://example.com"},  # no org_id
+        )
+
+    assert resp.status_code == 200
+    assert spy.await_count == 0, "identity assert must NOT run for anonymous preview"


### PR DESCRIPTION
## Root cause

VictoriaLogs trace from production after PR #481 deploy:
```
TypeError: assert_caller_identity() missing 1 required positional argument: 'claimed_user_id'
    await assert_caller_identity(request, claimed_org_id=body.org_id)
```

Same bug-shape that PR #448 fixed for the connector purge routes — the user-bound `assert_caller_identity` requires `claimed_user_id`, but `preview_crawl` and `crawl_url` are service-to-service pass-throughs with no end-user in the request context.

The OLD wizard sent `body.org_id=""` (empty) so the broken call never fired. The NEW wizard always sends a non-empty org_id → triggers TypeError → 500 → wizard correctly shows the fail-closed `unknown` classification with "Preview service did not respond" message. The UX is right; the cause was MY 500.

## Fix

`assert_caller_identity` → `assert_caller_identity_tenant_only` on both `preview_crawl` and `crawl_url`. Same pattern as PR #448.

## Regression guard

3 tests in `test_preview_crawl_tenant_only_identity.py` using a strict-signature mock — any future revert raises TypeError in CI instead of bleeding to a 500 in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)