### PR TITLE
fix(wizard): restore upfront 'Let AI find selector' button

### DIFF
--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
@@ -1053,22 +1053,42 @@ function AddConnectorPage() {
                           </div>
                         )}
                     </>
-                    {/* Single run preview button */}
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="outline"
-                      disabled={previewMutation.isPending || !wcPreviewUrl}
-                      onClick={() => {
-                        invalidatePreview()
-                        previewMutation.mutate({ url: wcPreviewUrl, content_selector: webcrawlerConfig.content_selector, cookies: parseCookies() })
-                      }}
-                    >
-                      {previewMutation.isPending
-                        ? <><Loader2 className="h-3.5 w-3.5 animate-spin mr-1" />{m.admin_connectors_webcrawler_preview_loading()}</>
-                        : m.admin_connectors_webcrawler_run_preview()
-                      }
-                    </Button>
+                    {/* Run preview + AI-find buttons.
+                        SPEC-CONNECTOR-INPUT-VALIDATION-001: AI find is an upfront
+                        affordance (operators expect to see it before running anything,
+                        not buried inside a failure message). It composes with the
+                        classification feedback below — does not contradict it. */}
+                    <div className="flex flex-wrap gap-2 items-center">
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        disabled={previewMutation.isPending || !wcPreviewUrl}
+                        onClick={() => {
+                          invalidatePreview()
+                          previewMutation.mutate({ url: wcPreviewUrl, content_selector: webcrawlerConfig.content_selector, cookies: parseCookies() })
+                        }}
+                      >
+                        {previewMutation.isPending
+                          ? <><Loader2 className="h-3.5 w-3.5 animate-spin mr-1" />{m.admin_connectors_webcrawler_preview_loading()}</>
+                          : m.admin_connectors_webcrawler_run_preview()
+                        }
+                      </Button>
+                      {!webcrawlerConfig.content_selector && (
+                        <button
+                          type="button"
+                          className="flex items-center gap-1 text-xs text-[var(--color-muted-foreground)] hover:text-[var(--color-accent)] transition-colors disabled:opacity-50"
+                          disabled={previewMutation.isPending || !wcPreviewUrl}
+                          onClick={() => {
+                            invalidatePreview()
+                            previewMutation.mutate({ url: wcPreviewUrl, try_ai: true, cookies: parseCookies() })
+                          }}
+                        >
+                          <Sparkles className="h-3 w-3" />
+                          {m.admin_connectors_webcrawler_try_ai()}
+                        </button>
+                      )}
+                    </div>
                     {/* Error state */}
                     {previewError && !previewMutation.isPending && (
                       <p className="text-sm text-[var(--color-destructive)]">{previewError}</p>

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
@@ -715,25 +715,46 @@ function EditConnectorPage() {
                   )}
 
                   {/* Run preview button */}
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    disabled={previewMutation.isPending || !wcPreviewUrl}
-                    onClick={() => {
-                      invalidatePreview()
-                      previewMutation.mutate({
-                        url: wcPreviewUrl,
-                        content_selector: webcrawlerConfig.content_selector,
-                        cookies: parseCookies(),
-                      })
-                    }}
-                  >
-                    {previewMutation.isPending
-                      ? <><Loader2 className="h-3.5 w-3.5 animate-spin mr-1" />{m.admin_connectors_webcrawler_preview_loading()}</>
-                      : m.admin_connectors_webcrawler_run_preview()
-                    }
-                  </Button>
+                  {/* Run preview + AI-find — same upfront affordance as add-connector. */}
+                  <div className="flex flex-wrap gap-2 items-center">
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      disabled={previewMutation.isPending || !wcPreviewUrl}
+                      onClick={() => {
+                        invalidatePreview()
+                        previewMutation.mutate({
+                          url: wcPreviewUrl,
+                          content_selector: webcrawlerConfig.content_selector,
+                          cookies: parseCookies(),
+                        })
+                      }}
+                    >
+                      {previewMutation.isPending
+                        ? <><Loader2 className="h-3.5 w-3.5 animate-spin mr-1" />{m.admin_connectors_webcrawler_preview_loading()}</>
+                        : m.admin_connectors_webcrawler_run_preview()
+                      }
+                    </Button>
+                    {!webcrawlerConfig.content_selector && (
+                      <button
+                        type="button"
+                        className="flex items-center gap-1 text-xs text-[var(--color-muted-foreground)] hover:text-[var(--color-accent)] transition-colors disabled:opacity-50"
+                        disabled={previewMutation.isPending || !wcPreviewUrl}
+                        onClick={() => {
+                          invalidatePreview()
+                          previewMutation.mutate({
+                            url: wcPreviewUrl,
+                            try_ai: true,
+                            cookies: parseCookies(),
+                          })
+                        }}
+                      >
+                        <Sparkles className="h-3 w-3" />
+                        {m.admin_connectors_webcrawler_try_ai()}
+                      </button>
+                    )}
+                  </div>
 
                   {/* Preview feedback — classification-driven single source of truth */}
                   {previewError && !previewMutation.isPending && (


### PR DESCRIPTION
Previous refactor moved AI-find CTA inline INSIDE failure messages. Operators expect it visible upfront, not buried after a failure.

Restored as a sibling button next to Run preview, only visible when no manual selector is set. Still composes cleanly with classification feedback (no return of contradicting boxes).

Applied to add-connector AND edit-connector. 30/30 tests green, ESLint+TSC clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)