### PR TITLE
feat(SPEC-MCP-RETRIEVAL-001): search_knowledge MCP tool for third-party LLMs

### DIFF
--- a/.moai/specs/SPEC-MCP-RETRIEVAL-001/acceptance.md
+++ b/.moai/specs/SPEC-MCP-RETRIEVAL-001/acceptance.md
@@ -1,0 +1,205 @@
+# Acceptance Criteria: SPEC-MCP-RETRIEVAL-001
+
+Given/When/Then scenarios that the implementation must pass before this SPEC can be considered complete. AC-1 through AC-10 must pass (in spec.md). Edge cases AC-11+ must pass for production sign-off.
+
+---
+
+## AC-1: External MCP client retrieves chunks via OAuth path
+
+**Given** a user has authorised the OAuth client `claude-desktop` via SPEC-MCP-AUTH-001 consent flow
+**And** the user's KB contains at least one document matching the query "VoIP adapter setup"
+**When** the OAuth client invokes `search_knowledge(query="VoIP adapter setup", top_k=5)` with `Authorization: Bearer klai_mcp_<...>`
+**Then** the tool returns a `list[dict]` with at least one item
+**And** every item has keys `title`, `source_url`, `text`, `score`, `scope`
+**And** the host LLM can render a citation using the `source_url` field
+
+## AC-2: LibreChat path is byte-functionally unchanged
+
+**Given** the existing LiteLLM `async_pre_call_hook` is unchanged in functional behaviour
+**When** a LibreChat user sends any chat completion that triggers retrieval
+**Then** the existing `deploy/litellm/test_klai_knowledge_*.py` test suite passes without test-code modification
+**And** production retrieval-volume metrics in Grafana for the 7 days post-merge stay within ±10% of the 7 days pre-merge (assuming stable LibreChat traffic)
+**And** `_klai_kb_meta` is still populated in the metadata dict for downstream `custom_router` consumption
+
+## AC-3: MCP-call telemetry is labelled with caller_client_id
+
+**Given** an OAuth-authenticated MCP-tool call has just succeeded
+**When** querying `retrieval_log` for the matching `request_id`
+**Then** the row has `caller_client_id` populated with the OAuth client's `portal_oauth_clients.client_id`
+**And** the matching `product_events` row of type `knowledge.queried` has `properties->>'caller_client_id'` equal to the same value
+**And** that row has `properties->>'auth_path' = 'oauth_client'`
+
+## AC-4: LibreChat-call telemetry is unlabelled
+
+**Given** a LibreChat retrieval-call has just succeeded
+**When** querying `retrieval_log` for the matching `request_id`
+**Then** the row has `caller_client_id IS NULL`
+**And** the matching `product_events` row has `properties->>'auth_path' = 'librechat'` and no `caller_client_id` key
+
+## AC-5: Retrieval-api timeout surfaces as ToolError
+
+**Given** retrieval-api is artificially slow (mock 5-second response)
+**And** the tool's `httpx.AsyncClient(timeout=3.0)` will trigger a TimeoutException
+**When** an OAuth client invokes `search_knowledge`
+**Then** the tool raises `mcp.server.fastmcp.exceptions.ToolError`
+**And** the error message is the bilingual NL/EN generic ("Knowledge base unavailable. Please try again.")
+**And** the structured log-line contains `type=TimeoutException` and `elapsed_ms=3000`
+**And** the host LLM surfaces this to the user (Claude Desktop displays "Tool error" notice)
+
+## AC-6: top_k clamping
+
+| Input `top_k` | Forwarded to retrieval-api `top_k` |
+|---:|---:|
+| 0 | 1 |
+| -5 | 1 |
+| 1 | 1 |
+| 8 (default) | 8 |
+| 15 | 15 |
+| 16 | 15 |
+| 999 | 15 |
+
+**Given** the tool is callable
+**When** invoked with each of the inputs above
+**Then** the retrieval-api receives the corresponding clamped value
+**And** no error is raised on out-of-range inputs (defensive default)
+
+## AC-7: Cross-tenant isolation
+
+**Given** OAuth client `client-A` is authorised by user-A in org-A
+**And** org-B contains documents matching the same query as org-A
+**When** `client-A`'s token is used to invoke `search_knowledge` with that query
+**Then** the result contains zero chunks from org-B
+**And** the underlying retrieval-api `/retrieve` request body has `org_id=org-A.id`
+**And** SPEC-MCP-AUTH-001 audience-binding (`resource_uri = https://mcp.getklai.com`) is verified before the call reaches the tool
+
+## AC-8: Gap detection fires for irrelevant queries
+
+**Given** the user's KB contains no documents matching the query "kwantum-tunnel-effectstabilisator"
+**When** an OAuth client invokes `search_knowledge` with that query
+**Then** retrieval-api returns chunks with low reranker scores (below `KLAI_GAP_SOFT_THRESHOLD`)
+**And** `classify_gap(chunks)` returns a non-`None` gap-type
+**And** `fire_gap_event` is invoked with `caller_client_id` set to the OAuth client's id
+**And** the gap-event row in `product_events` has `properties->>'caller_client_id'` populated
+
+## AC-9: Telemetry failure does not break retrieval
+
+**Given** portal-api `/internal/v1/retrieval-log` returns HTTP 503
+**When** an OAuth client invokes `search_knowledge` and retrieval-api succeeds normally
+**Then** the tool returns the chunks successfully (HTTP 200 to the MCP host)
+**And** a warning is logged with the telemetry-failure context
+**And** no `ToolError` is raised
+**And** the `product_events.knowledge.queried` and `gap_event` emits also fire-and-forget; their failures do not affect the response
+
+## AC-10: Save-tools regression
+
+**Given** the existing save-tool tests (`test_save_personal_knowledge`, `test_save_org_knowledge`, `test_save_to_docs`)
+**When** the test suite runs after this SPEC's changes
+**Then** all save-tool tests pass without modification
+**And** the save-tools' upstream calls receive `_VerifiedIdentity` with the same `user_id`/`org_id`/`org_slug` shape as before
+**And** the new `client_id` field is ignored by these tools (they don't read it)
+
+---
+
+## AC-11: Empty result set is a legitimate `[]`
+
+**Given** retrieval-api returns `chunks: []` for a valid query
+**When** the OAuth client invokes `search_knowledge`
+**Then** the tool returns `[]` (NOT `ToolError`)
+**And** all three telemetry fires occur (retrieval_log with empty `chunk_ids=[]`, product_event with `chunks_returned=0`, gap-event because `classify_gap([])` returns a gap-type)
+
+## AC-12: 4xx from retrieval-api is treated as ToolError
+
+**Given** retrieval-api returns HTTP 400 (e.g. invalid org_id, schema error)
+**When** the OAuth client invokes `search_knowledge`
+**Then** the tool raises `ToolError` with status-code in the log-line
+**And** the user-facing message stays generic (no detail-leak)
+
+## AC-13: Concurrent tool calls do not cross-contaminate identity
+
+**Given** two parallel `search_knowledge` calls from two different OAuth tokens (different users/orgs) hit the same MCP-instance
+**When** both complete
+**Then** each call's telemetry records the correct `caller_client_id` for its own token
+**And** retrieval-api receives the correct `org_id` per call (no shared mutable state)
+
+## AC-14: Migration is non-blocking
+
+**Given** the production `retrieval_log` table contains millions of rows
+**When** the migration `ALTER TABLE retrieval_log ADD COLUMN caller_client_id TEXT NULL` runs
+**Then** the operation completes in < 1 second (PostgreSQL 11+ metadata-only ADD COLUMN with NULL default)
+**And** no row-level lock is acquired during the ALTER
+**And** the partial index is built CONCURRENTLY in post_deploy without blocking writes
+
+## AC-15: Schema rollback is safe
+
+**Given** the SPEC has been deployed and `caller_client_id` rows exist
+**When** the rollback SQL `DROP INDEX ... ; ALTER TABLE ... DROP COLUMN caller_client_id;` runs
+**Then** the operation completes without errors
+**And** no LibreChat-path data is lost (their rows had `caller_client_id IS NULL`, so dropping the column drops only the labels)
+**And** OAuth-client retrieval-volume metrics for the rollback window become unrecoverable — accepted loss
+
+## AC-16: Tool description includes citation guidance
+
+**Given** the MCP host (Claude Desktop) lists available tools to the LLM
+**When** the host queries the MCP-server's tool-list
+**Then** `search_knowledge`'s description contains: WHEN TO CALL guidance, parameter semantics, return-shape description, and the explicit instruction "Cite by source_url when present; never invent URLs"
+**And** the description is in English (consumed by the LLM, not the user)
+
+## AC-17: OAuth-client without active token cannot call `search_knowledge`
+
+**Given** a previously-issued OAuth token has been revoked via `DELETE /api/me/mcp-tokens/{id}`
+**And** the Redis-cache has been invalidated within 1 second (REQ-22 of MCP-AUTH-001)
+**When** the OAuth client retries `search_knowledge` with the revoked token
+**Then** `_identify_request` raises `_IdentificationFailed`
+**And** the MCP-protocol returns 401 with `WWW-Authenticate` header (REQ-10 of MCP-AUTH-001)
+**And** no telemetry is emitted (failure happens before tool body executes)
+
+## AC-18: OAuth scope `mcp:knowledge` covers search
+
+**Given** an OAuth token with scope `mcp:knowledge` only
+**When** the client invokes `search_knowledge`
+**Then** portal-api `verify_access_token` returns `verified=true` (scope-set contains `mcp:knowledge`)
+**And** the tool executes normally
+**And** no separate scope-check is performed inside the tool body
+
+## AC-19: Conversation_history is NOT propagated from MCP-pad
+
+**Given** the MCP-tool is invoked
+**When** the tool builds the retrieval-api request body
+**Then** `conversation_history=[]` (empty list) is sent
+**And** retrieval-api skips coreference-resolution
+**And** the host LLM was responsible for resolving pronouns before calling the tool (per tool-description)
+
+## AC-20: Retrieval-call uses `X-Caller-Service: knowledge-mcp` header
+
+**Given** the tool calls retrieval-api `/retrieve`
+**When** the request is sent
+**Then** the request headers contain `X-Caller-Service: knowledge-mcp`
+**And** retrieval-api `verify_body_identity` accepts this caller-service value (already in `KNOWN_CALLER_SERVICES`)
+
+---
+
+## Performance criteria
+
+**P-1.** P50 end-to-end latency of `search_knowledge` (host-LLM-tool-call → tool-result-return) is ≤ 800ms when retrieval-api is healthy. P99 ≤ 2.5s. (Measured via the existing retrieval-api metrics; the tool itself adds <50ms overhead beyond the retrieval call.)
+
+**P-2.** Telemetry emit-rate adds ≤ 5% CPU overhead on portal-api under nominal MCP-traffic load (verified via canary).
+
+**P-3.** No memory growth in `klai-knowledge-mcp` container over a 24h period of mixed save/search traffic (verified via container-stats sampling).
+
+---
+
+## Quality gates
+
+**Q-1.** All new tests achieve ≥ 90% line coverage on the changed files (`klai_retrieval_telemetry/*`, `klai-knowledge-mcp/main.py`'s new function, `mcp_oauth.py` changes).
+
+**Q-2.** `ruff check` and `ruff format --check` and `pyright` all green on:
+- `klai-knowledge-mcp/`
+- `klai-portal/backend/`
+- `klai-libs/retrieval-telemetry/`
+- `deploy/litellm/`
+
+**Q-3.** Existing ast-grep rules `no-secret-{eq,neq,eq-rhs}-compare`, `cors_middleware_last`, `ruff` `TRY401` (exc_info on warning) remain green.
+
+**Q-4.** Docker image rebuilds for `klai-knowledge-mcp` and `litellm` produce images that boot successfully via `docker compose config` validation + 30-second healthcheck wait.
+
+**Q-5.** `klai-portal/backend/scripts/rls-smoke-test.sql` continues to pass (no RLS-table changes in this SPEC).

--- a/.moai/specs/SPEC-MCP-RETRIEVAL-001/plan.md
+++ b/.moai/specs/SPEC-MCP-RETRIEVAL-001/plan.md
@@ -1,0 +1,423 @@
+# Implementation Plan: SPEC-MCP-RETRIEVAL-001
+
+**Status:** draft
+**Methodology:** TDD (per `.moai/config/sections/quality.yaml` development_mode for greenfield additions; library-extraction sections use DDD characterization-first patterns)
+**Estimated effort:** ~halve dag implementatie + tests, exclusief manual e2e.
+
+---
+
+## Phase ordering
+
+| Phase | Title | Blocker | Owner |
+|---|---|---|---|
+| 0 | Wait for SPEC-MCP-AUTH-001 in `main` | upstream PR merge | — |
+| 1 | Extract `klai-libs/retrieval-telemetry/` (DDD: characterization-first) | Phase 0 | Backend |
+| 2 | Schema + portal-api endpoint + identity propagation | Phase 1 | Backend |
+| 3 | `search_knowledge` tool + tests (TDD) | Phase 2 | Backend |
+| 4 | Manual e2e in Claude Desktop / Cursor | Phase 3 | Mark |
+
+---
+
+## Phase 0 — Wait for SPEC-MCP-AUTH-001 in main
+
+This SPEC depends on:
+- `klai-knowledge-mcp/main.py` containing `_VerifiedIdentity` + `_identify_request` dispatcher
+- `klai-knowledge-mcp/dispatcher.py` with `OAUTH_ACCESS_PREFIX` + `looks_like_oauth_access_token`
+- portal-api `app/services/mcp_oauth.py` with `verify_access_token` + `portal_mcp_tokens` + `portal_oauth_clients` tables
+- Caddy route `mcp.getklai.com` → `klai-knowledge-mcp:8080` with DNS-rebinding protection
+
+All present on `hotfix/oauth-csrf-exempt` (worktree `klai-mcp-auth`). Block merging this SPEC's PR until upstream is in `main`.
+
+---
+
+## Phase 1 — Extract telemetry helpers to shared lib
+
+### Goal
+
+Move four functions from `deploy/litellm/klai_knowledge.py` to a new Python package `klai-libs/retrieval-telemetry/` without changing observable behaviour.
+
+### Affected files (NEW)
+
+- `klai-libs/retrieval-telemetry/pyproject.toml`
+- `klai-libs/retrieval-telemetry/klai_retrieval_telemetry/__init__.py`
+- `klai-libs/retrieval-telemetry/klai_retrieval_telemetry/_emit.py` (the four `fire_*` functions + `classify_gap`)
+- `klai-libs/retrieval-telemetry/klai_retrieval_telemetry/_retrieve.py` (`retrieve_chunks` helper — see A4)
+- `klai-libs/retrieval-telemetry/tests/test_emit.py`
+- `klai-libs/retrieval-telemetry/tests/test_retrieve.py`
+
+### Affected files (MODIFY)
+
+- `deploy/litellm/klai_knowledge.py` — replace inline helpers with imports; pass `caller_client_id=None`, `auth_path="librechat"`
+- `deploy/litellm/pyproject.toml` — add `klai-retrieval-telemetry` path-dep
+- `deploy/litellm/Dockerfile` — add COPY line for the new lib (mirror knowledge-mcp Dockerfile pattern; see [.claude/rules/klai/lang/docker.md](../../.claude/rules/klai/lang/docker.md) §"uv pip install skips uv.sources")
+
+### DDD: characterization-first
+
+Before extracting, write tests against the **current** LiteLLM-hook behaviour:
+
+1. `test_fire_retrieval_log_posts_to_portal_api` — record exact request shape (URL, headers, body fields, status-code handling)
+2. `test_fire_gap_event_posts_with_classified_type`
+3. `test_classify_gap_thresholds` — boundary values around `KLAI_GAP_SOFT_THRESHOLD` and `KLAI_GAP_DENSE_THRESHOLD`
+4. `test_fire_product_event_emits_when_org_id_present`
+
+Each test runs against the inline implementation in `deploy/litellm/klai_knowledge.py` BEFORE the extraction. Then the extraction is applied; the tests must pass against the new lib unchanged.
+
+### Function signatures (target)
+
+```python
+# klai_retrieval_telemetry/_emit.py
+async def fire_retrieval_log(
+    *, org_id: str, user_id: str,
+    chunk_ids: list[str], reranker_scores: list[float],
+    query: str, caller_client_id: str | None = None,
+) -> None: ...
+
+async def fire_product_event_knowledge_queried(
+    *, org_id: str, user_id: str,
+    chunks_returned: int, retrieval_ms: int,
+    auth_path: Literal["librechat", "oauth_client"],
+    caller_client_id: str | None = None,
+) -> None: ...
+
+async def fire_gap_event(
+    *, org_id: str, user_id: str,
+    query_text: str, gap_type: str,
+    chunks: list[dict], retrieval_ms: int,
+    taxonomy_node_ids: list[str] | None = None,
+    caller_client_id: str | None = None,
+) -> None: ...
+
+def classify_gap(chunks: list[dict]) -> str | None: ...
+```
+
+```python
+# klai_retrieval_telemetry/_retrieve.py
+@dataclass(frozen=True, slots=True)
+class RetrievalResult:
+    chunks: list[dict]
+    retrieval_bypassed: bool
+    raw: dict  # full /retrieve response for hook-internal use
+
+async def retrieve_chunks(
+    *, query: str, org_id: str, user_id: str, top_k: int,
+    scope: Literal["personal", "org", "both", "notebook"] = "both",
+    raw_query: str | None = None,
+    kb_slugs: list[str] | None = None,
+    conversation_history: list[dict] | None = None,
+    taxonomy_node_ids: list[str] | None = None,
+    timeout: float = 3.0,
+) -> RetrievalResult: ...
+```
+
+The `retrieve_chunks` helper handles JWT-preferred / X-Internal-Secret-fallback auth internally (currently `_retrieve_with_dual_auth` in the LiteLLM hook). It also emits the required `X-Caller-Service: knowledge-mcp` header.
+
+### Regression contract (REQ-24)
+
+`deploy/litellm/test_klai_knowledge_*.py` test files must pass **without modification** after the extraction. If a test imports a private helper directly (e.g. `_classify_gap`), update only the import line; do not change assertions or fixtures.
+
+### Configuration
+
+Telemetry-lib reads its endpoints from env vars (or constructor args):
+- `PORTAL_API_URL` (already set in both LiteLLM and knowledge-mcp containers)
+- `PORTAL_INTERNAL_SECRET`
+- `KNOWLEDGE_RETRIEVE_URL`
+- `RETRIEVAL_INTERNAL_SECRET`
+- `KLAI_OAUTH_TOKEN_URL`, `KLAI_LITELLM_CLIENT_ID`, `KLAI_LITELLM_CLIENT_SECRET` (JWT path) — for knowledge-mcp these become `KLAI_KNOWLEDGE_MCP_CLIENT_ID` etc. (separate Zitadel client; see Phase 2)
+
+The lib does not read env directly; it accepts a `RetrievalTelemetryConfig` dataclass that callers populate from their own settings.
+
+---
+
+## Phase 2 — Schema, portal-api, identity propagation
+
+### Affected files (MODIFY)
+
+#### Database
+
+- `klai-portal/backend/alembic/versions/XXXX_retrieval_log_caller_client_id.py` (NEW migration)
+  - `ALTER TABLE retrieval_log ADD COLUMN caller_client_id TEXT NULL;`
+  - `CREATE INDEX CONCURRENTLY retrieval_log_caller_client_id_idx ON retrieval_log (caller_client_id) WHERE caller_client_id IS NOT NULL;` (in `post_deploy_*.sql` because CONCURRENTLY can't run inside a transaction)
+- `klai-portal/backend/alembic/versions/post_deploy_XXXX.sql` (NEW)
+
+#### portal-api
+
+- `klai-portal/backend/app/services/mcp_oauth.py`
+  - `VerifyResult.client_id: str | None = None`
+  - `VerifyResult.to_dict()` includes `client_id` in success response
+  - `verify_access_token` joins `portal_oauth_clients` and populates `client_id`
+  - Cache serialization includes `client_id` (cache-key unchanged)
+- `klai-portal/backend/app/api/internal.py` — `/internal/v1/retrieval-log` body schema accepts optional `caller_client_id: str | None = None` and writes to the new column
+- `klai-portal/backend/tests/test_mcp_oauth_unit.py` — extend tests for `client_id` propagation
+
+#### Identity-assert lib
+
+- `klai-libs/identity-assert/klai_identity_assert/mcp_token_client.py`
+  - `VerifyResult.client_id: str | None = None`
+  - Parser populates from portal response
+
+#### knowledge-mcp
+
+- `klai-knowledge-mcp/main.py`
+  - `_VerifiedIdentity.client_id: str | None = None`
+  - `_identify_via_oauth_token` sets `client_id=result.client_id`
+  - `_identify_via_internal_secret` keeps default `client_id=None`
+  - `@MX:ANCHOR` comment updated to mention `client_id` in the contract
+
+### TDD test order
+
+1. RED: `test_verify_result_includes_client_id` against portal-api unit (failing — field doesn't exist)
+2. GREEN: add `client_id` to dataclass + DB query
+3. RED: `test_mcp_token_client_propagates_client_id` against identity-assert lib
+4. GREEN: parse `client_id` from response
+5. RED: `test_oauth_path_sets_client_id_on_verified_identity` against knowledge-mcp
+6. GREEN: wire `_identify_via_oauth_token` to set the field
+7. RED: `test_librechat_path_keeps_client_id_none` (regression)
+8. GREEN: confirm path leaves it default
+
+### Migration safety
+
+- Forward: `ADD COLUMN ... NULL` is non-blocking (PostgreSQL 11+: instant metadata-only change). Partial index built CONCURRENTLY in post_deploy.
+- Backward: `DROP INDEX IF EXISTS retrieval_log_caller_client_id_idx; ALTER TABLE retrieval_log DROP COLUMN IF EXISTS caller_client_id;` — both safe.
+- Verification: `klai-portal/backend/scripts/rls-smoke-test.sql` does not touch `retrieval_log` (Category-A, telemetry-only) — no RLS work needed.
+
+---
+
+## Phase 3 — `search_knowledge` tool + tests
+
+### Affected files (MODIFY)
+
+- `klai-knowledge-mcp/main.py` — add `@mcp.tool` `search_knowledge` after `save_to_docs` (~30 lines)
+- `klai-knowledge-mcp/pyproject.toml` — add `klai-retrieval-telemetry` path-dep
+- `klai-knowledge-mcp/Dockerfile` — add COPY line for the new lib
+
+### Affected files (NEW)
+
+- `klai-knowledge-mcp/tests/test_search_knowledge.py`
+- `klai-knowledge-mcp/tests/test_search_knowledge_telemetry.py`
+
+### Reference implementation (target — see research.md §8 for source patterns)
+
+```python
+@mcp.tool(description="""Search the user's Klai knowledge base — personal notes,
+organisation docs, and connected sources (Notion, Google Drive, web crawls).
+
+WHEN TO CALL: questions that may be answered by the user's own documentation,
+decisions, customer data, or product knowledge. Search BEFORE answering from
+general knowledge when the question is org-specific.
+
+PARAMETERS:
+  query  - search query in the user's language. Self-contained: resolve
+           pronouns and references yourself before passing.
+  top_k  - 1-15, default 8.
+
+RETURNS: list of chunks with title, source_url, text, score, scope.
+  scope="personal" = user's own saved notes.
+  scope="org"      = organisation knowledge.
+  Cite by source_url when present; never invent URLs.
+""")
+async def search_knowledge(query: str, ctx: Context, top_k: int = 8) -> list[dict]:
+    identity = await _identify_request(ctx)
+    top_k = max(1, min(top_k, 15))
+
+    t0 = time.monotonic()
+    try:
+        result = await retrieve_chunks(
+            query=query,
+            org_id=identity.org_id,
+            user_id=identity.user_id,
+            top_k=top_k,
+            scope="both",
+            timeout=3.0,
+        )
+    except (httpx.HTTPStatusError, httpx.TimeoutException, httpx.RequestError) as exc:
+        logger.error(
+            "search_knowledge_retrieval_failed: type=%s client_id=%s",
+            type(exc).__name__, identity.client_id,
+        )
+        raise ToolError(_ERR_KB_UNAVAILABLE) from exc
+
+    chunks = result.chunks
+    retrieval_ms = int((time.monotonic() - t0) * 1000)
+
+    auth_path = "oauth_client" if identity.client_id else "librechat"
+    asyncio.create_task(fire_retrieval_log(
+        org_id=identity.org_id, user_id=identity.user_id,
+        chunk_ids=[c.get("chunk_id") for c in chunks if c.get("chunk_id")],
+        reranker_scores=[c.get("reranker_score") or 0.0 for c in chunks],
+        query=query, caller_client_id=identity.client_id,
+    ))
+    asyncio.create_task(fire_product_event_knowledge_queried(
+        org_id=identity.org_id, user_id=identity.user_id,
+        chunks_returned=len(chunks), retrieval_ms=retrieval_ms,
+        auth_path=auth_path, caller_client_id=identity.client_id,
+    ))
+    gap = classify_gap(chunks)
+    if gap is not None:
+        asyncio.create_task(fire_gap_event(
+            org_id=identity.org_id, user_id=identity.user_id,
+            query_text=query, gap_type=gap, chunks=chunks,
+            retrieval_ms=retrieval_ms, caller_client_id=identity.client_id,
+        ))
+
+    return [
+        {
+            "title": c.get("title") or c.get("metadata", {}).get("title", ""),
+            "source_url": c.get("source_url") or None,
+            "text": c.get("text", "").strip(),
+            "score": c.get("reranker_score") or c.get("score"),
+            "scope": c.get("scope", "org"),
+        }
+        for c in chunks
+    ]
+```
+
+### Test matrix
+
+| Test ID | Scenario | Expected |
+|---|---|---|
+| T-1 | Happy path: OAuth token, retrieval returns 3 chunks | `len(result) == 3`, all keys present, telemetry-3-fires-fired |
+| T-2 | LibreChat path: tool callable via X-Internal-Secret too (not used in production but contract-honoured) | Returns chunks, `caller_client_id=None` in telemetry |
+| T-3 | Empty results: retrieval returns `chunks=[]` | Returns `[]`, gap-event fires with `gap_type` |
+| T-4 | Retrieval-api 503 | `ToolError` raised, no chunks returned, telemetry skipped |
+| T-5 | Retrieval-api 4xx (e.g. 401 on retrieval-api itself) | `ToolError` raised |
+| T-6 | Retrieval-api timeout (3.0s exceeded) | `ToolError` raised, log line includes elapsed_ms |
+| T-7 | `top_k=20` | Clamped to 15 in upstream call |
+| T-8 | `top_k=0` | Clamped to 1 |
+| T-9 | `top_k=-5` | Clamped to 1 |
+| T-10 | Identity verify fails (invalid token) | Existing `_IdentificationFailed` propagates (regression test from MCP-AUTH-001) |
+| T-11 | Telemetry post-failure (mock 503 from portal-api) | Tool returns chunks; warning logged |
+| T-12 | Cross-tenant: org-A token, retrieval response somehow contained org-B chunk | Test must fail loudly — but realistically retrieval-api enforces RLS so this is a smoke-check that we forward `org_id` correctly |
+| T-13 | OAuth-token with `client_id="claude-desktop"` | Telemetry payloads contain `caller_client_id="claude-desktop"`, `auth_path="oauth_client"` |
+| T-14 | Save-tools regression: `save_personal_knowledge` test suite passes unchanged | Existing assertions, no telemetry-lib changes affect them |
+
+### Coverage target
+
+`klai-knowledge-mcp/tests/test_search_knowledge*.py` ≥ 90% line coverage on the new tool function. Existing tests remain at their current coverage.
+
+---
+
+## Phase 4 — Manual e2e
+
+### In Claude Desktop
+
+1. `Settings → Connectors → Add custom connector`
+2. URL: `https://mcp.getklai.com/mcp`
+3. Browser opens to `my.getklai.com/oauth/authorize?...`; consent screen shows "Claude Desktop" name + redirect_uri
+4. Approve
+5. In a new chat: ask "Wat zegt onze docs over Voys SIP-trunk-config?"
+6. Verify the LLM calls `search_knowledge`, receives chunks, and cites with `source_url`
+
+### In Cursor (if MCP support is GA)
+
+Same flow with `https://mcp.getklai.com/mcp`.
+
+### In ChatGPT custom connectors (if available 2026-Q2)
+
+Same flow.
+
+### Failure-mode validation
+
+- Revoke the OAuth token in `my.getklai.com/settings/integrations` while a chat is in flight; second call must surface 401 → Claude attempts refresh → fails → user gets disconnect signal (delegated to MCP-AUTH-001 contract).
+- Trigger retrieval-api 503 (manual via `docker stop klai-retrieval-api` for 60 seconds): `search_knowledge` calls must surface tool-error in the chat UI.
+
+### Telemetry verification
+
+After successful e2e:
+
+```sql
+-- VictoriaLogs / Grafana PostgreSQL
+SELECT caller_client_id, COUNT(*)
+FROM retrieval_log
+WHERE created_at > NOW() - INTERVAL '1 hour'
+GROUP BY 1;
+
+SELECT properties->>'caller_client_id' AS client, properties->>'auth_path' AS path, COUNT(*)
+FROM product_events
+WHERE event_type = 'knowledge.queried' AND created_at > NOW() - INTERVAL '1 hour'
+GROUP BY 1, 2;
+```
+
+Expected: a row with `caller_client_id` = the DCR-issued client_id (string starting with `secrets.token_urlsafe(16)`-shape) and `auth_path = 'oauth_client'`.
+
+---
+
+## MX Tag Plan (Phase 3.5 input)
+
+The new tool function and the modified identity dataclass are the high-impact spots. Apply tags during Phase 3 implementation:
+
+| Location | Tag | Reason |
+|---|---|---|
+| `_VerifiedIdentity` class | `@MX:ANCHOR fan_in=high` | Called from every MCP-tool dispatcher branch; field-shape is a cross-service contract |
+| `_VerifiedIdentity.client_id` field | `@MX:NOTE` | "None means LibreChat path; set means OAuth-issued client_id from portal_oauth_clients (REQ-3, REQ-4)" |
+| `search_knowledge` function | `@MX:ANCHOR` | Public MCP-tool surface; signature stability is part of OAuth-client-contract |
+| `retrieve_chunks` (telemetry-lib) | `@MX:ANCHOR fan_in=2` | LiteLLM-hook + knowledge-mcp; signature change ripples to both |
+| Migration `retrieval_log_caller_client_id` | `@MX:NOTE` | "Non-blocking ADD COLUMN; partial index built CONCURRENTLY in post_deploy" |
+
+No `@MX:WARN` candidates — no goroutines/concurrency hotspots, no high-complexity branches, no global state.
+
+No `@MX:TODO` — Phase 3 is fully scoped.
+
+---
+
+## Configuration changes
+
+### Env vars (NEW)
+
+For `klai-knowledge-mcp` container (in `deploy/docker-compose.yml`):
+
+- `KLAI_KNOWLEDGE_MCP_CLIENT_ID` — Zitadel service-client for retrieval-api JWT (or reuse `svc-knowledge-mcp` from existing identity-verify path)
+- `KLAI_KNOWLEDGE_MCP_CLIENT_SECRET` — corresponding secret in SOPS
+
+If the existing `svc-knowledge-mcp` Zitadel client already has `klai:internal:retrieval:query` granted (verified above — yes), no new client needed; reuse the existing token-mint env vars.
+
+### SOPS additions
+
+None — existing secrets cover this.
+
+### Caddy
+
+No changes — `mcp.getklai.com` route already exists from MCP-AUTH-001.
+
+---
+
+## Rollout strategy
+
+1. **Pre-merge:** Phase 1 tests + Phase 2 tests + Phase 3 tests all green in CI.
+2. **Merge:** all four phases together as one PR — splitting is awkward because the tool is non-functional without the schema + identity changes, and the telemetry-lib extraction needs the consumer changes to land in the same release to avoid two-deploys-to-validate.
+3. **Deploy:** `deploy.sh portal` (migration) → `deploy.sh litellm` (telemetry-lib consumer) → `deploy.sh knowledge-mcp` (new tool). Order matters: portal must be migrated before LiteLLM/knowledge-mcp boot with the new lib that posts `caller_client_id` to a possibly-old portal endpoint (which would 422 on unknown field unless schema accepts optional).
+4. **Verify:** check `service:portal-api AND level:error` in VictoriaLogs for 30 minutes post-deploy.
+5. **Manual e2e:** Phase 4 within 24 hours of deploy.
+6. **Watch for 7 days:** `caller_client_id IS NULL` row-rate stable (LibreChat traffic unchanged); `caller_client_id IS NOT NULL` rows growing if external clients are configured.
+
+---
+
+## Rollback plan
+
+If Phase 3 (search_knowledge) misbehaves in production:
+
+1. Remove the `@mcp.tool` decorator from `search_knowledge` in `main.py` and redeploy `knowledge-mcp` — tool disappears from the MCP-tool-list, save-tools unaffected. ~5 minutes.
+
+If Phase 1 (telemetry-lib) misbehaves (LibreChat retrieval-quality regression):
+
+1. Revert the `deploy/litellm/klai_knowledge.py` import changes; redeploy LiteLLM. The library files stay (no DB-state involved). ~10 minutes.
+
+If Phase 2 (schema) needs rollback:
+
+1. `DROP INDEX retrieval_log_caller_client_id_idx;`
+2. `ALTER TABLE retrieval_log DROP COLUMN caller_client_id;`
+
+Both are safe (no data loss for LibreChat-only rows; would lose any OAuth-client telemetry collected so far — acceptable for early-rollout window).
+
+---
+
+## Estimated timeline
+
+| Phase | Hours | Cumulative |
+|---|---:|---:|
+| 0 (wait) | — | — |
+| 1 (telemetry-lib extraction + tests) | 2.0 | 2.0 |
+| 2 (schema + portal-api + identity) | 1.5 | 3.5 |
+| 3 (search_knowledge tool + tests) | 1.0 | 4.5 |
+| 4 (manual e2e) | 0.5 | 5.0 |
+
+Total: ~5 hours of focused work. Real-clock time depends on CI queue + manual-test scheduling.

--- a/.moai/specs/SPEC-MCP-RETRIEVAL-001/research.md
+++ b/.moai/specs/SPEC-MCP-RETRIEVAL-001/research.md
@@ -1,0 +1,137 @@
+# Research: SPEC-MCP-RETRIEVAL-001
+
+**Date:** 2026-05-07
+**Author:** Mark Vletter
+**Scope:** Add a `search_knowledge` MCP tool to `klai-knowledge-mcp` so third-party LLMs (Claude Desktop, Cursor, ChatGPT custom connectors) can read the user's KB via the OAuth path that SPEC-MCP-AUTH-001 already provides.
+
+---
+
+## 1. Why this SPEC exists
+
+The current `klai-knowledge-mcp` ([main.py](../../klai-knowledge-mcp/main.py)) exposes three write tools (`save_personal_knowledge`, `save_org_knowledge`, `save_to_docs`) but no read tool. KB retrieval today happens exclusively inside the LiteLLM proxy via `async_pre_call_hook` ([deploy/litellm/klai_knowledge.py:1111](../../deploy/litellm/klai_knowledge.py)), which fires on every chat completion in LibreChat.
+
+That hook is not reachable from external MCP clients. Once SPEC-MCP-AUTH-001 lands, those clients can authenticate via OAuth — but they still cannot search. This SPEC closes that gap with one additional tool.
+
+## 2. What SPEC-MCP-AUTH-001 already gives us (verified on `hotfix/oauth-csrf-exempt`)
+
+- **OAuth 2.1 Authorization Server** in portal-api ([app/services/mcp_oauth.py](../../klai-portal/backend/app/services/mcp_oauth.py), 895 LOC): DCR (RFC 7591), `/oauth/authorize` consent flow, `/oauth/token` with PKCE S256, refresh-token rotation with replay-detection, audience-binding (RFC 8707) on `mcp.getklai.com`.
+- **Resource Server** primitives in `klai-knowledge-mcp/main.py:276-395`: `_VerifiedIdentity` dataclass and a `_identify_request(ctx)` dispatcher that branches on `Authorization: Bearer klai_mcp_*` (OAuth path) vs. `X-Internal-Secret` (LibreChat path). Both paths converge on the same identity shape, so tools never branch on which path ran.
+- **Caller-service whitelist:** `knowledge-mcp` is in `KNOWN_CALLER_SERVICES` ([klai-libs/identity-assert/klai_identity_assert/models.py:116-127](../../klai-libs/identity-assert/klai_identity_assert/models.py)).
+- **Retrieval-API scope:** `svc-knowledge-mcp` already holds `klai:internal:retrieval:query` ([retrieval_api/api/retrieve.py:38](../../klai-retrieval-api/retrieval_api/api/retrieve.py)).
+- **Caddy route:** `mcp.getklai.com` → `klai-knowledge-mcp:8080`, DNS-rebinding protection enabled.
+
+## 3. Verified gaps to close in this SPEC
+
+### 3.1 `VerifyResult` does not carry `client_id`
+
+[mcp_oauth.py:194-226](../../klai-portal/backend/app/services/mcp_oauth.py) defines `VerifyResult` with `user_id`, `org_id`, `org_slug`, `scopes`, `resource_uri`. The DB row already has `client_id` (FK→`portal_oauth_clients`) but the verify response strips it. To label telemetry per OAuth client, the verify-endpoint and the client-side asserter must propagate it.
+
+### 3.2 `_VerifiedIdentity` does not carry `client_id`
+
+[main.py:232-236](../../klai-knowledge-mcp/main.py) is intentionally minimal:
+
+```python
+class _VerifiedIdentity:
+    user_id: str
+    org_id: str
+    org_slug: str
+```
+
+Adding `client_id: str | None = None` is non-breaking for existing save-tools (they don't read it) and lets the new `search_knowledge` tool tag telemetry without branching on auth-path.
+
+### 3.3 Telemetry helpers live only in the LiteLLM hook
+
+[deploy/litellm/klai_knowledge.py:1429-1445](../../deploy/litellm/klai_knowledge.py): `_fire_retrieval_log`, `_fire_gap_event`, `_classify_gap`, plus `product_events` `knowledge.queried` emission, are private to the LiteLLM hook process. The MCP-tool would need to duplicate them, OR they get extracted to a shared lib.
+
+A shared lib is the right call: both callers write to the **same** `retrieval_log` table and the **same** `product_events.event_type='knowledge.queried'` stream. A duplicated copy would diverge silently on the next schema change.
+
+### 3.4 `retrieval_log` has no `caller_client_id` column
+
+The internal LiteLLM hook posts to `portal-api /internal/v1/retrieval-log`. To distinguish "Claude Desktop searched X" from "LibreChat user searched X" in dashboards and eval-sets, a new `caller_client_id TEXT NULL` column is required, with a partial index on `WHERE caller_client_id IS NOT NULL` so LibreChat-only queries are unaffected.
+
+`product_events` uses a JSONB `properties` column already, so labelling there is migration-free — just add `properties->>'caller_client_id'` at emit time.
+
+## 4. Why one tool, two parameters (and what's deliberately NOT exposed)
+
+The LiteLLM hook does ~11 distinct things per retrieval call: trivial-filter, identity-resolve, template fetch, KB-feature gate, scope/kb_slugs/narrow flags, history-coreference, taxonomy classify, query-rewrite, gap-detection, retrieval-log, system-prompt-injection. Most of these are **only** meaningful inside the internal LibreChat UX and are wrong inside an MCP tool result:
+
+| LiteLLM-hook concern | Belongs in MCP tool? | Why not |
+|---|---|---|
+| Trivial-message filter | No | External LLM doesn't pass trivial input |
+| Templates (system-prompt prefix) | No | LiteLLM-pre-call concern, ties to LibreChat user-settings |
+| Scope/`kb_slugs` UI flags | No | External LLM has no UI; RLS in retrieval-api enforces tenant scope automatically |
+| Conversation history coreference | No | External LLM resolves pronouns itself before formulating the query |
+| Query rewrite via Mistral | No | The caller IS already a frontier LLM; adding a rewrite step is wasteful |
+| Taxonomy classify + filter | No | External clients don't know your taxonomy; coverage-aware filter is internal |
+| Gap detection event | Yes | Highest-value telemetry — gaps surface in admin dashboards |
+| Retrieval log row | Yes | Feeds RAGAS eval-set; labelling differentiates traffic distributions |
+| `_klai_kb_meta` metadata signal | No | Only consumed by LiteLLM custom_router for model-upgrade |
+| System-prompt injection block | No | Tool returns data, not system instructions |
+| Image-URLs | Deferred (v1.1) | Requires a separate MCP resource-flow; out of scope for first iteration |
+
+The result: a tool surface that is `search_knowledge(query, top_k=8)`. Anything more would be over-engineering.
+
+## 5. Result-shape decision: structured chunks, not markdown
+
+The LiteLLM hook builds a markdown system-prompt block with strict citation instructions ("STRIKT: kopieer URL exact"). For an MCP tool, that goes in the **tool description** (which the MCP host shows the LLM), not the **tool result** (which is data). The tool returns a `list[dict]` with `title`, `source_url`, `text`, `score`, `scope`. The host LLM then renders citations naturally.
+
+This mirrors how the save-tools already work: their tool descriptions carry the "WHEN TO CALL" and parameter guidance, while the function returns plain confirmation strings.
+
+## 6. Failure-mode design
+
+The LiteLLM hook fails-loud-via-system-prompt: when retrieval-api is down, it injects "[Klai Kennisbank — TIJDELIJK NIET BEREIKBAAR]" into the system prompt. That makes sense inside LibreChat where the LLM call is going to fire anyway.
+
+In an MCP tool, the equivalent is raising a `ToolError`. The MCP host (Claude Desktop, Cursor) surfaces this to the LLM, which can then explain the failure to the user. Returning empty results on retrieval failure would be wrong — the LLM would say "I couldn't find anything in your KB" when the KB was simply unreachable.
+
+| Failure | Behaviour |
+|---|---|
+| retrieval-api 4xx (config error) | `ToolError` with status code |
+| retrieval-api 5xx | `ToolError` with status code |
+| retrieval-api timeout (3.0s) | `ToolError` with timeout reason |
+| Empty result set (no chunks match) | Return `[]` (legitimate result) |
+| Telemetry post fails | Log warning, never propagate (fire-and-forget) |
+| Identity verify fails | Existing dispatcher path raises `_IdentificationFailed` |
+
+## 7. Why `mcp:knowledge` covers both save and search (no new scope in v1)
+
+SPEC-MCP-AUTH-001 issues tokens with a single scope `mcp:knowledge`. Splitting into `mcp:knowledge:read` and `mcp:knowledge:write` is a reasonable design but adds zero value until a real customer asks for read-only tokens (e.g. a publishing tool that should never modify the KB). YAGNI: the split can be added later non-breakingly by:
+
+1. Keeping `mcp:knowledge` as a super-scope that includes both
+2. Adding `mcp:knowledge:read` as a narrower scope on new clients
+3. Updating consent-UI to show scope-level granularity
+
+This SPEC stays single-scope.
+
+## 8. Reference implementations
+
+- **Authentication path:** the existing dispatcher at `klai-knowledge-mcp/main.py:371-395` is the contract. New tool calls `await _identify_request(ctx)` and trusts the returned `_VerifiedIdentity`.
+- **Outbound retrieval call:** [deploy/litellm/klai_knowledge.py:174-212](../../deploy/litellm/klai_knowledge.py) — `_retrieve_with_dual_auth` (JWT preferred, X-Internal-Secret fallback) is the correct pattern. Either copy or import once the telemetry-lib extraction lands.
+- **Telemetry emission:** the three `_fire_*` helpers in the LiteLLM hook — extract to `klai-libs/retrieval-telemetry/`.
+- **Tool description style:** the existing save-tool docstrings (NL+EN trigger phrases, parameter blocks) are the template.
+
+## 9. Risk inventory
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Telemetry-lib refactor breaks LiteLLM hook | medium | high | Phase 1 = library extraction with byte-identical behaviour for `caller_client_id=None`; regression tests in `deploy/litellm/test_klai_knowledge_*.py` must stay green untouched |
+| Schema migration on `retrieval_log` blocks portal-api boot on existing rows | low | high | `ADD COLUMN ... NULL` is non-blocking; existing rows have `caller_client_id IS NULL` which means LibreChat (correct semantics retroactively) |
+| `client_id` propagation breaks audience-binding | very low | critical | Existing `verify_access_token` already validates resource-binding before constructing VerifyResult; we only add a field to the success path, never weaken the deny paths |
+| External LLM passes ambiguous queries → bad results → user blames Klai | medium | low | Tool-description carries "Self-contained: resolve pronouns and references yourself"; gap-events surface the failure mode in admin |
+| Retrieval-api 3.0s timeout is too aggressive for cold-cache | low | medium | Same timeout as LiteLLM hook in production; if cold-start P99 spikes, raise via env var without code change |
+| Telemetry rate-amplification: external client polls every keystroke | low | low | retrieval-api has its own rate limiting; OAuth-token expiry caps blast radius; revisit if a real abuse pattern shows up |
+
+## 10. Open questions (closed)
+
+- **Q1**: Should we expose a `scope` parameter (`personal`/`org`/`both`)? **No.** External clients have no UI and the user identity already disambiguates (`scope=both` is correct for "everything I have access to"). Future SPEC can add it if a power-user pattern emerges.
+- **Q2**: Should we expose `kb_slugs` for filtering by KB? **No.** External LLMs don't know your KB structure. Add a `list_knowledge_bases` tool first if this becomes a real need.
+- **Q3**: Should retrieval emit a separate audit-log row per call? **No.** REQ-25 of MCP-AUTH-001 explicitly says "Tool-call events ... worden NIET per call gelogd; `last_used_at` is voldoende". Per-call audit lives in `retrieval_log`, not in `portal_audit_log`.
+- **Q4**: Should retrieval support pagination for large result sets? **No in v1.** `top_k` clamp 1-15 is sufficient for the LLM-context-fit problem; pagination is a follow-up only if a customer asks.
+
+## 11. Cross-references
+
+- SPEC-MCP-AUTH-001 ([../SPEC-MCP-AUTH-001/spec.md](../SPEC-MCP-AUTH-001/spec.md)) — authentication foundation; this SPEC depends on its dispatcher and `_VerifiedIdentity` shape.
+- SPEC-SEC-IDENTITY-ASSERT-001 — caller-service header contract; we use `X-Caller-Service: knowledge-mcp` on outbound retrieval-api calls.
+- SPEC-SEC-SERVICE-AUTH-001 — JWT scope `klai:internal:retrieval:query`; already granted to `svc-knowledge-mcp`.
+- SPEC-RAG-QUERY-REWRITE-001 / SPEC-RAG-TAXONOMY-001 — internal LiteLLM-hook concerns; explicitly NOT applied in this SPEC.
+- SPEC-KB-015-01 (retrieval-log) / SPEC-KB-014 (gap detection) — telemetry contracts that we extend with `caller_client_id`.
+- [.claude/rules/klai/projects/knowledge-ingest.md](../../.claude/rules/klai/projects/knowledge-ingest.md) §"Multi-layer data threading in retrieval results" — confirms the result-shape contract from Qdrant → ChunkResult → JSON → frontend; we re-use the same chunk fields.

--- a/.moai/specs/SPEC-MCP-RETRIEVAL-001/spec.md
+++ b/.moai/specs/SPEC-MCP-RETRIEVAL-001/spec.md
@@ -1,0 +1,257 @@
+---
+id: SPEC-MCP-RETRIEVAL-001
+version: "0.1.0"
+status: draft
+created: 2026-05-07
+updated: 2026-05-07
+author: Mark Vletter
+priority: high
+issue_number: null
+related:
+  - SPEC-MCP-AUTH-001 (OAuth dispatcher + `_VerifiedIdentity` foundation — BLOCKING)
+  - SPEC-SEC-IDENTITY-ASSERT-001 (caller-service header contract on retrieval-api)
+  - SPEC-SEC-SERVICE-AUTH-001 (`klai:internal:retrieval:query` scope, JWT issuance)
+  - SPEC-KB-015-01 (retrieval-log contract; we extend with `caller_client_id`)
+  - SPEC-KB-014 (gap-detection event contract; we extend with `caller_client_id`)
+---
+
+# SPEC-MCP-RETRIEVAL-001: Knowledge retrieval tool for klai-knowledge-mcp (third-party LLM access)
+
+## HISTORY
+
+| Datum | Versie | Wijziging |
+|-------|--------|-----------|
+| 2026-05-07 | 0.1.0 | Initial draft. Single tool `search_knowledge(query, top_k)` op klai-knowledge-mcp via OAuth-pad uit MCP-AUTH-001. Géén query-rewrite / taxonomy / system-prompt-injectie — die concerns blijven exclusief in de LiteLLM pre-call hook. Telemetrie (retrieval_log + product_events + gap_events) gelabeld op `caller_client_id` zodat externe traffic onderscheidbaar is. Telemetry-helpers verhuizen van `deploy/litellm/klai_knowledge.py` naar nieuwe `klai-libs/retrieval-telemetry/` package. |
+
+---
+
+## Summary
+
+Voeg één `@mcp.tool` `search_knowledge(query, top_k=8)` toe aan `klai-knowledge-mcp/main.py` zodat externe MCP-clients (Claude Desktop, Cursor, ChatGPT custom connectors) de KB van de gebruiker kunnen doorzoeken via het OAuth-pad uit SPEC-MCP-AUTH-001. De tool routeert via de bestaande dispatcher (`_identify_request`), retrieve't via retrieval-api `/retrieve`, en returnt gestructureerde chunks. Telemetrie loopt mee — gelabeld met de OAuth `client_id` van de caller — zodat externe traffic onderscheidbaar blijft van LibreChat in dashboards, eval-sets, en gap-detectie.
+
+De LiteLLM pre-call hook ([deploy/litellm/klai_knowledge.py](../../deploy/litellm/klai_knowledge.py)) blijft de canonieke retrieval-pad voor LibreChat en wijzigt **niet** in functioneel gedrag. Wel verhuist een viertal telemetrie-helpers naar een nieuwe shared lib `klai-libs/retrieval-telemetry/` zodat zowel de LiteLLM-hook als de MCP-tool dezelfde tabel/event-stream voeden zonder code-duplicatie.
+
+**Eindgebruiker-flow:** in Claude Desktop "Add custom connector" → URL `https://mcp.getklai.com/mcp` → user is al geauthenticeerd via SPEC-MCP-AUTH-001 → user vraagt "wat zegt onze documentatie over X?" → Claude roept `search_knowledge` aan → krijgt chunks met `source_url` → citeert in antwoord.
+
+---
+
+## EARS Requirements
+
+### Ubiquitous (altijd actief)
+
+**REQ-1.** De `klai-knowledge-mcp` **shall** een `@mcp.tool`-functie `search_knowledge(query: str, ctx: Context, top_k: int = 8) -> list[dict]` aanbieden met een tool-description die beschrijft: wanneer aanroepen, parameter-semantiek, return-shape, en een citation-instructie ("cite by source_url when present; never invent URLs"). Description in Engels (consumed by tool-host LLM); user-facing strings via die LLM zijn agnostisch van de description-taal.
+
+**REQ-2.** Alle authenticatie en identity-resolutie **shall** verlopen via de bestaande dispatcher `_identify_request(ctx) → _VerifiedIdentity`. De tool **shall** zelf geen header-parsing, geen secret-validatie, en geen claim-extractie uitvoeren. Bij `_IdentificationFailed` **shall** de exception propagateren naar de MCP-host (zelfde gedrag als de save-tools).
+
+**REQ-3.** De `_VerifiedIdentity` dataclass in `klai-knowledge-mcp/main.py` **shall** uitgebreid worden met één optioneel veld `client_id: str | None = None`. Bestaande save-tools **shall** byte-voor-byte ongewijzigd blijven (zij lezen alleen `user_id`/`org_id`/`org_slug`).
+
+**REQ-4.** Het OAuth-pad (`_identify_via_oauth_token`) **shall** `client_id` invullen met de `portal_oauth_clients.client_id` zoals geretourneerd door portal-api's `/internal/mcp-token/verify`. Het LibreChat-pad (`_identify_via_internal_secret`) **shall** `client_id=None` zetten.
+
+**REQ-5.** De portal-api `VerifyResult` ([app/services/mcp_oauth.py:194](../../klai-portal/backend/app/services/mcp_oauth.py)) **shall** uitgebreid worden met `client_id: str | None = None`. `verify_access_token` **shall** dit veld invullen vanuit `portal_mcp_tokens.client_id` → `portal_oauth_clients.client_id` join. `to_dict()` **shall** het veld in de success-response opnemen. Cache-entries **shall** dit veld bevatten (cache-key blijft `access_token_hash` — geen wijziging).
+
+**REQ-6.** De `klai-libs/identity-assert/klai_identity_assert/mcp_token_client.py::VerifyResult` (client-side wrapper) **shall** spiegelend `client_id: str | None` veld krijgen, gevuld vanuit de portal-response.
+
+**REQ-7.** Een nieuwe Python-package `klai-libs/retrieval-telemetry/` **shall** vier publieke functies aanbieden:
+- `fire_retrieval_log(*, org_id, user_id, chunk_ids, reranker_scores, query, caller_client_id=None) -> None`
+- `fire_product_event_knowledge_queried(*, org_id, user_id, chunks_returned, retrieval_ms, caller_client_id=None, auth_path) -> None`
+- `fire_gap_event(*, org_id, user_id, query_text, gap_type, chunks, retrieval_ms, taxonomy_node_ids=None, caller_client_id=None) -> None`
+- `classify_gap(chunks: list[dict]) -> str | None`
+
+Alle functies **shall** fire-and-forget zijn (`asyncio.create_task` met independent task-group of equivalent). Exceptions **shall** intern gelogd worden en nooit propagateren naar de caller.
+
+**REQ-8.** De `deploy/litellm/klai_knowledge.py` **shall** de bestaande inline helpers (`_fire_retrieval_log`, `_fire_gap_event`, `_classify_gap`, en de inline `product_events` POST) vervangen door imports uit `klai-libs/retrieval-telemetry/`. Aanroepen **shall** `caller_client_id=None` doorgeven (LibreChat-pad) — gedrag identiek aan vandaag.
+
+**REQ-9.** De portal-api `/internal/v1/retrieval-log` endpoint **shall** een optioneel `caller_client_id: str | None` veld accepteren in de request-body en opslaan in `retrieval_log.caller_client_id`. Ontbrekend / `null` veld **shall** `NULL` opslaan (LibreChat-default).
+
+**REQ-10.** Een Alembic-migratie **shall** `retrieval_log` uitbreiden met:
+```sql
+ALTER TABLE retrieval_log ADD COLUMN caller_client_id TEXT NULL;
+CREATE INDEX retrieval_log_caller_client_id_idx
+  ON retrieval_log (caller_client_id)
+  WHERE caller_client_id IS NOT NULL;
+```
+De migratie **shall** non-blocking zijn (geen `NOT NULL`, geen default-fill van bestaande rijen).
+
+**REQ-11.** `product_events.properties` (JSONB) **shall** voor MCP-callers `caller_client_id` en `auth_path: "oauth_client"` bevatten. Voor LibreChat-callers **shall** `caller_client_id` afwezig zijn en `auth_path: "librechat"` worden gezet — dit is een aanvulling, geen breaking change voor bestaande consumers.
+
+**REQ-12.** De tool **shall** `top_k` clampen naar `[1, 15]` voordat de retrieval-call geplaatst wordt. Out-of-range waardes **shall** stilzwijgend geclamped worden, niet als error gerapporteerd (defensive default; externe LLMs gokken vaak top_k=20).
+
+**REQ-13.** De tool **shall** `httpx.AsyncClient(timeout=3.0)` gebruiken voor de retrieval-api call (zelfde timeout als de LiteLLM-hook).
+
+**REQ-14.** De retrieval-call **shall** identiek auth-pad gebruiken als de LiteLLM-hook: JWT (`klai:internal:retrieval:query` scope) preferred, fallback naar `X-Internal-Secret`, met `X-Caller-Service: knowledge-mcp` header. Het bestaande `_retrieve_jwt_headers` + `_retrieve_legacy_headers` patroon **shall** hergebruikt worden — wordt onderdeel van een gedeelde helper of geïmporteerd uit `klai-libs/retrieval-telemetry/` (zelfde plek omdat het bij dezelfde uitgaande retrieval-api call hoort).
+
+**REQ-15.** De tool-result **shall** een `list[dict]` zijn waarin elke chunk de keys `title: str`, `source_url: str | None`, `text: str`, `score: float | None`, `scope: Literal["personal", "org"]` bevat. Géén markdown system-prompt-blok, géén citation-instructies in de output (die staan in REQ-1's tool-description).
+
+**REQ-16.** De OAuth-scope `mcp:knowledge` (uit SPEC-MCP-AUTH-001) **shall** zowel save-tools als `search_knowledge` autoriseren. Géén nieuwe scope wordt geïntroduceerd in v0.1.0.
+
+### State-driven (conditional)
+
+**REQ-17.** **While** retrieval-api een 4xx-response retourneert (config / auth error), **shall** de tool een `mcp.server.fastmcp.exceptions.ToolError` raisen met een generieke bilingual NL/EN message ("Knowledge base unavailable. Please try again."). De HTTP-statuscode **shall** in de log-line staan, niet in de user-facing message (info-leak prevention).
+
+**REQ-18.** **While** retrieval-api een 5xx-response of een `httpx.TimeoutException` produceert, **shall** de tool een `ToolError` raisen met een log-line die het exception-type en de retrieval_ms bevat.
+
+**REQ-19.** **While** de retrieval-call success retourneert maar `chunks=[]`, **shall** de tool `[]` retourneren (legitieme lege resultaten) en alle telemetrie-emits **shall** alsnog vuren (REQ-22, REQ-23 — ook lege resultaten zijn signaal voor gap-detectie en query-volume).
+
+**REQ-20.** **While** een telemetrie-emit faalt (Redis down, portal-api 5xx, network error), **shall** de fout intern gelogd worden en **shall** de tool het succesvolle resultaat alsnog retourneren. Telemetrie-failures **shall nooit** een geslaagde retrieval kapotmaken.
+
+### Event-driven (trigger-based)
+
+**REQ-21.** **When** `search_knowledge` succesvol een retrieval-call afrondt (incl. `chunks=[]`), **shall** de tool `fire_retrieval_log` aanroepen met `caller_client_id=identity.client_id`, `chunk_ids` en `reranker_scores` uit het retrieval-resultaat, en de raw `query`-string.
+
+**REQ-22.** **When** `search_knowledge` succesvol een retrieval-call afrondt, **shall** de tool `fire_product_event_knowledge_queried` aanroepen met `chunks_returned=len(chunks)`, `retrieval_ms` (gemeten met `time.monotonic`), `caller_client_id=identity.client_id`, `auth_path="oauth_client"` (LiteLLM-hook gebruikt dezelfde helper met `auth_path="librechat"`).
+
+**REQ-23.** **When** `classify_gap(chunks)` een niet-`None` waarde retourneert, **shall** de tool `fire_gap_event` aanroepen met dezelfde tagging (`caller_client_id`, `auth_path`).
+
+**REQ-24.** **When** de telemetry-lib-extractie (Fase 1) gemerged wordt, **shall** de bestaande `deploy/litellm/test_klai_knowledge_*.py` test-suite groen blijven zonder wijzigingen aan test-code (alleen import-paden mogen aanpassen). Dit is de regression-bewijslast dat de extractie geen functionele wijziging doet.
+
+### Optional Features
+
+**REQ-25.** De tool **may** in een toekomstige minor (v0.1.x) een `image_urls`-veld per chunk retourneren wanneer Qdrant-payload `image_urls` bevat. Out of scope voor v0.1.0; vereist een aparte MCP-resource-flow voor het serveren van images.
+
+**REQ-26.** De portal-api admin-UI **may** een dashboard-view tonen van retrieval-volume per `caller_client_id`. Out of scope voor v0.1.0 — de schema-velden zijn er, dashboard-creatie volgt op basis van real traffic.
+
+---
+
+## Architecture decisions
+
+### A1. Eén tool, twee parameters
+
+**Keuze: `search_knowledge(query, top_k=8)`.** Geen `scope`, geen `kb_slugs`, geen `notebook_id`, geen `conversation_history`.
+
+**Reden:** externe LLMs hebben geen UI om scope/KB-filters via te zetten, en RLS in retrieval-api zorgt automatisch dat de tenantscope klopt (`scope="both"` betekent "alles wat deze user mag zien"). `kb_slugs`-filtering is een power-user-feature die zinloos is zonder een `list_knowledge_bases` discovery-tool — beide vallen in dezelfde YAGNI-categorie. Conversation-history-coreference doet de externe LLM zelf (instructie staat in tool-description: "Self-contained: resolve pronouns and references yourself before passing").
+
+### A2. `_VerifiedIdentity` minimaal uitbreiden — geen `auth_path` veld
+
+**Keuze: alleen `client_id: str | None = None` toevoegen.**
+
+**Alternatieve overweging:** een `auth_path: Literal["librechat", "oauth_client"]` veld zou expliciet zijn. Maar dat veld is afgeleide informatie: `client_id is None` betekent al "LibreChat-pad" en `client_id is not None` betekent OAuth-pad. Een redundant veld is een onderhoudslast. Telemetrie-emits stellen `auth_path` zelf vast op basis van `client_id`.
+
+### A3. Telemetry-helpers naar shared lib
+
+**Keuze: `klai-libs/retrieval-telemetry/`** als nieuwe Python-package, geïmporteerd door zowel `deploy/litellm/klai_knowledge.py` als `klai-knowledge-mcp/main.py`.
+
+**Reden:** beide callers schrijven naar **dezelfde** `retrieval_log` tabel en **dezelfde** `product_events.event_type='knowledge.queried'` stream. Een gekopieerde implementatie zou stilletjes uiteenlopen wanneer het schema verandert. Dit is een legitieme abstractie (gedeeld contract), niet een toevallige overlap. Het pakket bevat alleen wat allebei de callers nodig hebben — geen hook-specifieke logica zoals templates of taxonomy.
+
+### A4. Shared lib bevat ook de retrieval-call zelf
+
+**Keuze: `klai-libs/retrieval-telemetry/` exporteert ook een dunne `retrieve_chunks(*, query, org_id, user_id, top_k, scope="both") -> RetrievalResult` functie** die JWT-of-legacy auth doet en de `/retrieve` POST plaatst.
+
+**Reden:** de auth-keuze (JWT met scope `klai:internal:retrieval:query` met fallback naar X-Internal-Secret) is nontrivial en byte-identiek voor beide callers. Niet één auth-keuze duplicaten. De LiteLLM-hook bouwt zijn eigen rijke retrieve-body (raw_query + rewritten + taxonomy_node_ids + history), dus de helper accepteert die als optionele velden — de MCP-tool gebruikt alleen de minimale set.
+
+### A5. Resultaat-shape: gestructureerde dict, geen markdown-blok
+
+**Keuze: `list[dict]` met expliciete velden.**
+
+**Reden:** de MCP-tool-protocol levert het resultaat aan de host-LLM, die het zelf in zijn antwoord rendert. Een markdown-systeem-prompt-blok ("STRIKT: kopieer URL exact") hoort thuis in een **system prompt**, niet in een **tool result**. De citation-instructies leven in de tool-description (REQ-1) waar de host-LLM ze leest tijdens het beslissen wanneer en hoe te citeren — exact zoals de save-tool descriptions het doen voor titel-/content-/tag-gedrag.
+
+### A6. Failure-mode: `ToolError`, niet stilzwijgend lege resultaten
+
+**Keuze: retrieval-api 4xx/5xx/timeout = `ToolError` raise.**
+
+**Reden:** een lege return op upstream-failure zou de host-LLM doen zeggen "ik kon niets vinden in jullie KB", terwijl de KB simpelweg onbereikbaar was — dat is een gevaarlijke hallucination-vector. `ToolError` zorgt dat de host-LLM de failure expliciet rapporteert aan de gebruiker. Dit is bewust strikter dan de LiteLLM-hook (die fail-loud doet via system-prompt-injectie); voor een MCP-tool is exception het juiste contract.
+
+### A7. Géén nieuwe OAuth-scope
+
+**Keuze: `mcp:knowledge` dekt zowel save als search.**
+
+**Reden:** scope-splitsing (`mcp:knowledge:read` vs `mcp:knowledge:write`) zou waarde toevoegen pas wanneer een klant een specifiek read-only-token-use-case heeft (bv. een publishing-tool die nooit mag schrijven). YAGNI tot dat moment. Bij introductie achteraf:
+- `mcp:knowledge` blijft super-scope (volledig read+write)
+- `mcp:knowledge:read` wordt narrower scope, alleen toegekend aan nieuw geregistreerde clients die expliciet read-only requesten
+- consent-UI krijgt een toelichting over scope-niveaus
+
+Backwards-compatible toevoeging.
+
+### A8. Géén query-rewrite of taxonomy-classify in MCP-pad
+
+**Keuze: passthrough van de query zoals de externe LLM hem aanlevert.**
+
+**Reden:** de LiteLLM-hook doet query-rewrite (Mistral-call) omdat LibreChat-input rauwe user-tekst is met pronouns/follow-ups. Externe MCP-callers zijn zélf frontier LLMs (Claude, GPT, Cursor's modelkeuze) — die hebben de query al geformuleerd in plaats van een mens. Een tweede rewrite-stap is verspilling van budget en latency. Taxonomy-classify is hetzelfde verhaal: vereist coverage-data per KB en is afhankelijk van klantspecifieke taxonomie die de externe LLM toch niet kent. De gap-event helper ziet dit verschil niet — gap-detectie is generic en blijft waardevol.
+
+### A9. Caller-attribution via `client_id` (niet via `client_name`)
+
+**Keuze: telemetrie krijgt `caller_client_id` (de DCR-uitgegeven `client_id` string), niet `client_name` of een human-readable label.**
+
+**Reden:** `client_name` kan door de DCR-aanvraag vrij gekozen worden (zie SPEC-MCP-AUTH-001 § "Client_name spoofing" open question) — een attacker kan zich voordoen als "Klai Official". `client_id` is server-uitgegeven en niet-spoofbaar. Een dashboard-view die een mooie label wil tonen kan joinen op `portal_oauth_clients.client_name` voor display, maar de **storage** is op `client_id` zodat aggregaties op de juiste sleutel werken.
+
+---
+
+## Out of scope
+
+1. **LiteLLM pre-call hook functioneel wijzigen.** Hij blijft de canonieke retrieval-pad voor LibreChat. Alleen telemetry-helpers verhuizen naar shared lib (gedrag identiek).
+2. **Image-URLs in tool-output.** Vereist een aparte MCP-resource-flow voor image-serving; later via REQ-25.
+3. **`list_knowledge_bases()` of `get_document(id)` discovery-tools.** YAGNI tot een klant erom vraagt.
+4. **Per-tool of per-KB OAuth-scopes.** YAGNI; super-scope `mcp:knowledge` dekt v0.1.0.
+5. **Pagination of result-set.** `top_k` clamp 1-15 is voldoende voor LLM-context-budget.
+6. **Conversation-history coreference resolution.** Externe LLMs doen dit zelf voordat ze de tool aanroepen.
+7. **Rate-limiting per OAuth-client.** Out of scope; retrieval-api heeft eigen rate-limit en token-issuance is al bounded via SPEC-MCP-AUTH-001 REQ-27 (DCR rate-limit).
+8. **Admin-dashboard voor MCP-traffic.** Schema-velden landen, dashboard-creatie volgt op basis van real-data (REQ-26 optional).
+
+---
+
+## Implementation plan (Phases)
+
+Zie `plan.md` voor de volledige fasering. Korte versie:
+
+- **Fase 0** — Wachten op SPEC-MCP-AUTH-001 in `main`. Blocking dependency.
+- **Fase 1** — `klai-libs/retrieval-telemetry/` package extracten uit LiteLLM-hook. Regression-bewijs: `deploy/litellm/test_klai_knowledge_*.py` blijft groen ongewijzigd.
+- **Fase 2** — Schema-migratie + portal-api endpoint-update + `VerifyResult.client_id` + `_VerifiedIdentity.client_id`.
+- **Fase 3** — `search_knowledge` tool + tests.
+- **Fase 4** — Manual e2e in Claude Desktop.
+
+---
+
+## Acceptance criteria
+
+Zie `acceptance.md` voor Given/When/Then-scenarios. Kernpunten:
+
+1. **AC-1** — Geauthenticeerde Claude Desktop-user kan `search_knowledge("..."`) aanroepen en krijgt chunks terug met `source_url` waar Qdrant-payload dat heeft.
+2. **AC-2** — LibreChat-pad (LiteLLM-hook) blijft byte-functioneel ongewijzigd: bestaande regression-tests groen, retrieval-volume-metrics in productie ongewijzigd in de week na merge.
+3. **AC-3** — `retrieval_log` rij na MCP-call heeft `caller_client_id` ingevuld; `product_events.knowledge.queried` rij heeft `properties->>'caller_client_id'` en `auth_path='oauth_client'`.
+4. **AC-4** — LibreChat-call schrijft `retrieval_log` rij met `caller_client_id IS NULL` en `product_events.properties->>'auth_path'='librechat'`.
+5. **AC-5** — Retrieval-api timeout (3s) → tool raised `ToolError`, geen lege return.
+6. **AC-6** — `top_k=20` wordt geclamped naar 15; `top_k=0` naar 1.
+7. **AC-7** — Cross-tenant test: token van org A verkrijgt geen chunks van org B (RLS-bewijs via SPEC-MCP-AUTH-001 REQ-22 audience-binding + retrieval-api RLS).
+8. **AC-8** — Gap-detectie vuurt op een query met irrelevante chunks; `caller_client_id` zit in de gap-event payload.
+9. **AC-9** — Telemetry-failure (Redis simuleer-down): tool retourneert nog steeds chunks, telemetry-fail wordt gelogd.
+10. **AC-10** — Save-tools (`save_personal_knowledge` etc.) blijven byte-voor-byte werken; geen wijziging in hun tests.
+
+---
+
+## Risks & mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Telemetry-lib refactor breekt LiteLLM-hook (gedrag-drift) | medium | high | Fase 1 scope: pure code-move, byte-identiek gedrag voor `caller_client_id=None`. Bestaande hook-tests groen ongewijzigd is harde gate. |
+| `retrieval_log` migratie blokkeert portal-api boot | low | high | `ADD COLUMN ... NULL` is non-blocking; partial index wordt CONCURRENTLY gebouwd in post_deploy.sql (zelfde patroon als SPEC-MCP-AUTH-001). |
+| `client_id` propagation breekt audience-binding | very low | critical | We voegen alleen toe aan success-path; deny-paden (`unknown_token`, `audience_mismatch`, etc.) raken we niet aan. Cache-key blijft `access_token_hash`. |
+| Externe LLM vraagt vage queries → slechte resultaten → klant blameert Klai | medium | low | Tool-description zegt expliciet "Self-contained: resolve pronouns yourself"; gap-events surfacing in admin maakt het zichtbaar. |
+| Externe client polt elke keystroke (DOS-vector) | low | low | retrieval-api heeft eigen rate-limit; OAuth-token issuance is bounded; revisit als real abuse blijkt. |
+| Search-quality regressie t.o.v. LiteLLM-hook (geen rewrite/taxonomy) | medium | medium | Bewust ontwerp; gap-events zullen het signaleren. Als data laat zien dat externe LLMs slechtere queries genereren dan onze rewrite, dan voegen we rewrite-as-option toe in v0.2 (param `rewrite=true`). |
+| Multiple parallel tool-calls per request laten retrieval-api over de timeout | low | medium | 3.0s timeout is conservatief; monitor in productie. Verhoogbaar via env var zonder code change. |
+
+---
+
+## Open questions
+
+(Geen open questions in v0.1.0. Alle ontwerpkeuzes zijn vastgelegd in A1-A9.)
+
+Toekomstige beslismomenten (geen blocker voor v0.1.0):
+
+- **Wanneer rewrite-as-option toevoegen?** Trigger: gap-event-rate van OAuth-traffic > 1.5× LibreChat-rate over 30 dagen.
+- **Wanneer `mcp:knowledge:read` scope splitsen?** Trigger: eerste klant met expliciete read-only-use-case.
+- **Wanneer image-URLs?** Trigger: real productieve traffic waar text-only citaties tekortschieten (verifieerbaar via gap-events met type `images_missing`).
+
+---
+
+## References
+
+- [klai-knowledge-mcp/main.py](../../klai-knowledge-mcp/main.py) — host file voor de nieuwe tool
+- [klai-knowledge-mcp/dispatcher.py](../../klai-knowledge-mcp/dispatcher.py) — OAuth/LibreChat branch primitives (SPEC-MCP-AUTH-001)
+- [klai-portal/backend/app/services/mcp_oauth.py](../../klai-portal/backend/app/services/mcp_oauth.py) — `VerifyResult` definition (REQ-5 target)
+- [klai-libs/identity-assert/klai_identity_assert/mcp_token_client.py](../../klai-libs/identity-assert/klai_identity_assert/mcp_token_client.py) — client-side wrapper (REQ-6 target)
+- [klai-retrieval-api/retrieval_api/api/retrieve.py](../../klai-retrieval-api/retrieval_api/api/retrieve.py) — `klai:internal:retrieval:query` scope holder
+- [deploy/litellm/klai_knowledge.py](../../deploy/litellm/klai_knowledge.py) — telemetry-helper source (Fase 1 extraction target)
+- [.claude/rules/klai/projects/knowledge-ingest.md](../../.claude/rules/klai/projects/knowledge-ingest.md) — multi-layer data threading; result-shape contract
+- [.moai/specs/SPEC-MCP-AUTH-001/spec.md](../SPEC-MCP-AUTH-001/spec.md) — blocking foundation
+- [MCP Specification — Tools](https://modelcontextprotocol.io/specification/draft/server/tools)
+- [MCP Specification — ToolError contract](https://modelcontextprotocol.io/specification/draft/basic/server-features#errors)

--- a/deploy/litellm/klai_knowledge.py
+++ b/deploy/litellm/klai_knowledge.py
@@ -45,6 +45,24 @@ from litellm.integrations.custom_logger import CustomLogger
 # matching every other klai service deploy.
 from klai_chat_prompts import GROUNDED_CHAT_SYSTEM_PROMPT
 
+# SPEC-MCP-RETRIEVAL-001 Phase 1: telemetry helpers moved out of this file
+# into ``klai-libs/retrieval-telemetry/`` so klai-knowledge-mcp's new
+# ``search_knowledge`` tool can emit identical retrieval-log + gap-event
+# payloads. The vendored single-file copy at
+# ``deploy/litellm/klai_retrieval_telemetry.py`` mirrors the canonical
+# ``klai-libs/retrieval-telemetry/klai_retrieval_telemetry/_emit.py``.
+# Drift is enforced by ``test_klai_retrieval_telemetry_drift.py``.
+#
+# We bind to underscore-prefixed module locals to preserve the existing
+# call sites (``_classify_gap``, ``_fire_gap_event``, ``_fire_retrieval_log``)
+# without a touch-every-call-site refactor. ``caller_client_id`` defaults
+# to ``None`` for all LibreChat-path emits, preserving the wire shape.
+from klai_retrieval_telemetry import (
+    classify_gap as _classify_gap,
+    fire_gap_event as _fire_gap_event,
+    fire_retrieval_log as _fire_retrieval_log,
+)
+
 logger = logging.getLogger(__name__)
 
 KNOWLEDGE_RETRIEVE_URL = os.getenv("KNOWLEDGE_RETRIEVE_URL")
@@ -864,141 +882,14 @@ async def _get_kb_feature(user_id: str, org_id: str, cache) -> dict:
     return result
 
 
-# @MX:NOTE: [AUTO] Gap thresholds (0.4 reranker, 0.35 dense) are configurable via
-# @MX:NOTE: KLAI_GAP_SOFT_THRESHOLD / KLAI_GAP_DENSE_THRESHOLD env vars (SPEC-KB-014)
-def _classify_gap(chunks: list[dict]) -> str | None:
-    """Classify retrieval result. Returns 'hard', 'soft', or None (success)."""
-    if not chunks:
-        return "hard"
-    reranker_scores = [
-        c.get("reranker_score") for c in chunks if c.get("reranker_score") is not None
-    ]
-    if reranker_scores:
-        if all(s < KLAI_GAP_SOFT_THRESHOLD for s in reranker_scores):
-            return "soft"
-    else:
-        dense_scores = [c.get("score", 0.0) for c in chunks]
-        if all(s < KLAI_GAP_DENSE_THRESHOLD for s in dense_scores):
-            return "soft"
-    return None
-
-
-# @MX:WARN: [AUTO] Fire-and-forget via create_task — caller must be inside a running event loop.
-# @MX:REASON: Wraps in try/except RuntimeError to handle test environments without a loop.
-def _fire_gap_event(
-    org_id: str,
-    user_id: str,
-    query_text: str,
-    gap_type: str,
-    chunks: list[dict],
-    retrieval_ms: int,
-    taxonomy_node_ids: list[int] | None = None,
-) -> None:
-    """Schedule an async gap event POST without blocking the pre-call hook."""
-    import asyncio
-
-    top_chunk = (
-        max(chunks, key=lambda c: c.get("reranker_score") or c.get("score", 0.0))
-        if chunks
-        else None
-    )
-    top_score = (
-        (top_chunk.get("reranker_score") or top_chunk.get("score"))
-        if top_chunk
-        else None
-    )
-    nearest_kb_slug = (
-        top_chunk.get("metadata", {}).get("kb_slug")
-        if top_chunk and gap_type == "soft"
-        else None
-    )
-
-    try:
-        org_id_int = int(org_id)
-    except (ValueError, TypeError):
-        logger.warning(
-            "KlaiKnowledgeHook: non-numeric org_id '%s', skipping gap event", org_id
-        )
-        return
-
-    payload = {
-        "org_id": org_id_int,
-        "user_id": user_id,
-        "query_text": query_text,
-        "gap_type": gap_type,
-        "top_score": top_score,
-        "nearest_kb_slug": nearest_kb_slug,
-        "chunks_retrieved": len(chunks),
-        "retrieval_ms": retrieval_ms,
-    }
-    # SPEC-KB-021 R6: include taxonomy filter when it was part of the retrieve request
-    if taxonomy_node_ids:
-        payload["taxonomy_node_ids"] = taxonomy_node_ids
-
-    async def _post():
-        try:
-            async with httpx.AsyncClient(timeout=2.0) as client:
-                await client.post(
-                    f"{PORTAL_API_URL}/internal/v1/gap-events",
-                    json=payload,
-                    headers={"Authorization": f"Bearer {PORTAL_INTERNAL_SECRET}"},
-                )
-        except Exception as exc:
-            logger.warning("KlaiKnowledgeHook: gap event POST failed (%s)", exc)
-
-    try:
-        asyncio.get_running_loop().create_task(_post())
-    except RuntimeError:
-        pass  # No running event loop (test context) — skip silently
-
-
-# @MX:NOTE: [AUTO] Fire-and-forget retrieval log -- mirrors _fire_gap_event pattern. SPEC-KB-015.
-# @MX:WARN: [AUTO] Uses create_task -- caller must be inside running event loop.
-# @MX:REASON: Silently discards on no-loop (test context) and any HTTP error (REQ-KB-015-03).
-def _fire_retrieval_log(
-    org_id: str,
-    user_id: str,
-    chunk_ids: list,
-    reranker_scores: list,
-    query_resolved: str,
-) -> None:
-    """Schedule an async retrieval log POST without blocking the pre-call hook."""
-    import asyncio
-    from datetime import datetime
-
-    try:
-        int(org_id)
-    except (ValueError, TypeError):
-        logger.warning(
-            "KlaiKnowledgeHook: non-numeric org_id '%s', skipping retrieval log", org_id
-        )
-        return
-
-    payload = {
-        "org_id": str(org_id),
-        "user_id": user_id,
-        "chunk_ids": chunk_ids,
-        "reranker_scores": reranker_scores,
-        "query_resolved": query_resolved,
-        "embedding_model_version": EMBEDDING_MODEL_VERSION,
-        "retrieved_at": datetime.utcnow().isoformat(),
-    }
-
-    async def _post():
-        try:
-            async with httpx.AsyncClient(timeout=2.0) as client:
-                await client.post(
-                    PORTAL_RETRIEVAL_LOG_URL,
-                    json=payload,
-                    headers={"Authorization": f"Bearer {PORTAL_INTERNAL_SECRET}"},
-                )
-        except Exception as exc:
-            logger.warning("KlaiKnowledgeHook: retrieval log POST failed (%s)", exc)
-
-    try:
-        asyncio.get_running_loop().create_task(_post())
-    except RuntimeError:
-        pass  # No running event loop (test context)
+# @MX:NOTE: classify_gap, fire_gap_event, fire_retrieval_log moved to
+# klai-libs/retrieval-telemetry/ (SPEC-MCP-RETRIEVAL-001 Phase 1). Imports
+# at the top of this module rebind them to the underscore-prefixed names
+# every call site below already uses, so the move is invisible to callers.
+# The threshold / URL env vars (KLAI_GAP_SOFT_THRESHOLD,
+# KLAI_GAP_DENSE_THRESHOLD, EMBEDDING_MODEL_VERSION,
+# PORTAL_RETRIEVAL_LOG_URL) are read inside the lib's _default_config()
+# helper at call time, so the env-rotation behaviour stays identical.
 
 
 # ---------------------------------------------------------------------------

--- a/deploy/litellm/klai_retrieval_telemetry.py
+++ b/deploy/litellm/klai_retrieval_telemetry.py
@@ -1,0 +1,255 @@
+"""Telemetry emission helpers — extracted from deploy/litellm/klai_knowledge.py.
+
+SPEC-MCP-RETRIEVAL-001 Phase 1: behaviour-preserving extraction of the three
+fire-and-forget POST helpers and the gap-classifier so both the LiteLLM
+pre-call hook (LibreChat) and klai-knowledge-mcp (third-party LLMs via
+OAuth) post the same payload shape against the same portal-api endpoints.
+
+The single contract addition over the original inline impls is the optional
+``caller_client_id`` keyword argument on the two ``fire_*`` helpers. When
+``None`` (the LibreChat default), the payload omits the field — same wire
+shape as before. When set, it labels the row with the OAuth client that
+issued the call.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+# -- Configuration ------------------------------------------------------------
+# Module-level defaults loaded from env on first ``_default_config()`` call.
+# Tests can pass their own ``RetrievalTelemetryConfig`` to bypass env entirely.
+@dataclass(frozen=True, slots=True)
+class RetrievalTelemetryConfig:
+    """Connection + behaviour config for the telemetry helpers.
+
+    Defaults match the LiteLLM-hook env-driven values so existing callers
+    pick up identical behaviour without explicit construction. Tests should
+    construct a config directly to avoid env-leak between cases.
+    """
+
+    portal_api_url: str = ""
+    portal_internal_secret: str = ""
+    portal_retrieval_log_url: str = ""
+    portal_gap_events_url: str = ""
+    embedding_model_version: str = "bge-m3-v1"
+    gap_soft_threshold: float = 0.4
+    gap_dense_threshold: float = 0.35
+    timeout_seconds: float = 2.0
+    # @MX:NOTE: if you add a field here, mirror it in _default_config below
+    # so the env path stays in sync with the dataclass shape.
+    _frozen: bool = field(default=True, init=False, repr=False)
+
+
+def _default_config() -> RetrievalTelemetryConfig:
+    """Build a config from env vars. Caller-overridable per call.
+
+    Reads on every call rather than at import time so containers that
+    rotate ``PORTAL_INTERNAL_SECRET`` via SOPS sync pick up the new
+    secret without a process restart. The cost (a few env-dict lookups)
+    is negligible compared to the HTTP POST that follows.
+    """
+    portal_api_url = os.getenv("PORTAL_API_URL", "")
+    portal_secret = os.getenv("PORTAL_INTERNAL_SECRET", "")
+    return RetrievalTelemetryConfig(
+        portal_api_url=portal_api_url,
+        portal_internal_secret=portal_secret,
+        portal_retrieval_log_url=os.getenv(
+            "PORTAL_RETRIEVAL_LOG_URL",
+            f"{portal_api_url}/internal/v1/retrieval-log",
+        ),
+        portal_gap_events_url=os.getenv(
+            "PORTAL_GAP_EVENTS_URL",
+            f"{portal_api_url}/internal/v1/gap-events",
+        ),
+        embedding_model_version=os.getenv("EMBEDDING_MODEL_VERSION", "bge-m3-v1"),
+        gap_soft_threshold=float(os.getenv("KLAI_GAP_SOFT_THRESHOLD", "0.4")),
+        gap_dense_threshold=float(os.getenv("KLAI_GAP_DENSE_THRESHOLD", "0.35")),
+    )
+
+
+# -- Gap classification -------------------------------------------------------
+# @MX:NOTE: Gap thresholds (0.4 reranker, 0.35 dense) are configurable via
+# KLAI_GAP_SOFT_THRESHOLD / KLAI_GAP_DENSE_THRESHOLD env vars (SPEC-KB-014)
+def classify_gap(
+    chunks: list[dict[str, Any]],
+    config: RetrievalTelemetryConfig | None = None,
+) -> str | None:
+    """Classify retrieval result. Returns 'hard', 'soft', or None (success).
+
+    - ``hard``: empty chunk list — retrieval found nothing.
+    - ``soft``: chunks present but all reranker (or dense, when reranker
+      absent) scores fall below the configured threshold.
+    - ``None``: at least one chunk crossed the threshold.
+
+    Pure function — no I/O. Safe to call inside a hot path.
+    """
+    cfg = config or _default_config()
+    if not chunks:
+        return "hard"
+    reranker_scores = [
+        c.get("reranker_score") for c in chunks if c.get("reranker_score") is not None
+    ]
+    if reranker_scores:
+        if all(s < cfg.gap_soft_threshold for s in reranker_scores):
+            return "soft"
+    else:
+        dense_scores = [c.get("score", 0.0) for c in chunks]
+        if all(s < cfg.gap_dense_threshold for s in dense_scores):
+            return "soft"
+    return None
+
+
+# -- Retrieval-log emit -------------------------------------------------------
+# @MX:NOTE: Fire-and-forget retrieval log -- mirrors fire_gap_event pattern. SPEC-KB-015.
+# @MX:WARN: Uses create_task -- caller must be inside running event loop.
+# @MX:REASON: Silently discards on no-loop (test context) and any HTTP error (REQ-KB-015-03).
+def fire_retrieval_log(
+    org_id: str,
+    user_id: str,
+    chunk_ids: list[str],
+    reranker_scores: list[float],
+    query_resolved: str,
+    *,
+    caller_client_id: str | None = None,
+    config: RetrievalTelemetryConfig | None = None,
+) -> None:
+    """Schedule an async retrieval log POST without blocking the caller.
+
+    Behaviour-equivalent to the previous inline impl in
+    ``deploy/litellm/klai_knowledge.py``. The optional
+    ``caller_client_id`` keyword adds OAuth-client attribution per
+    SPEC-MCP-RETRIEVAL-001 REQ-9; when ``None`` the payload key is
+    omitted, preserving the wire shape for LibreChat traffic.
+    """
+    cfg = config or _default_config()
+
+    try:
+        int(org_id)
+    except (ValueError, TypeError):
+        logger.warning(
+            "retrieval_telemetry: non-numeric org_id '%s', skipping retrieval log", org_id
+        )
+        return
+
+    payload: dict[str, Any] = {
+        "org_id": str(org_id),
+        "user_id": user_id,
+        "chunk_ids": chunk_ids,
+        "reranker_scores": reranker_scores,
+        "query_resolved": query_resolved,
+        "embedding_model_version": cfg.embedding_model_version,
+        "retrieved_at": datetime.now(timezone.utc).isoformat(),
+    }
+    if caller_client_id is not None:
+        payload["caller_client_id"] = caller_client_id
+
+    async def _post() -> None:
+        try:
+            async with httpx.AsyncClient(timeout=cfg.timeout_seconds) as client:
+                await client.post(
+                    cfg.portal_retrieval_log_url,
+                    json=payload,
+                    headers={"Authorization": f"Bearer {cfg.portal_internal_secret}"},
+                )
+        except Exception as exc:  # noqa: BLE001 — fire-and-forget, swallow all
+            logger.warning("retrieval_telemetry: retrieval log POST failed (%s)", exc)
+
+    try:
+        asyncio.get_running_loop().create_task(_post())
+    except RuntimeError:
+        # No running event loop (test context) — skip silently
+        pass
+
+
+# -- Gap-event emit -----------------------------------------------------------
+# @MX:WARN: Fire-and-forget via create_task — caller must be inside a running event loop.
+# @MX:REASON: Wraps in try/except RuntimeError to handle test environments without a loop.
+def fire_gap_event(
+    org_id: str,
+    user_id: str,
+    query_text: str,
+    gap_type: str,
+    chunks: list[dict[str, Any]],
+    retrieval_ms: int,
+    taxonomy_node_ids: list[int] | None = None,
+    *,
+    caller_client_id: str | None = None,
+    config: RetrievalTelemetryConfig | None = None,
+) -> None:
+    """Schedule an async gap event POST without blocking the caller.
+
+    Behaviour-equivalent to the previous inline impl in
+    ``deploy/litellm/klai_knowledge.py``. The optional
+    ``caller_client_id`` keyword adds OAuth-client attribution per
+    SPEC-MCP-RETRIEVAL-001 REQ-9; when ``None`` the payload key is
+    omitted, preserving the wire shape for LibreChat traffic.
+    """
+    cfg = config or _default_config()
+
+    top_chunk = (
+        max(chunks, key=lambda c: c.get("reranker_score") or c.get("score", 0.0))
+        if chunks
+        else None
+    )
+    top_score = (
+        (top_chunk.get("reranker_score") or top_chunk.get("score"))
+        if top_chunk
+        else None
+    )
+    nearest_kb_slug = (
+        top_chunk.get("metadata", {}).get("kb_slug")
+        if top_chunk and gap_type == "soft"
+        else None
+    )
+
+    try:
+        org_id_int = int(org_id)
+    except (ValueError, TypeError):
+        logger.warning(
+            "retrieval_telemetry: non-numeric org_id '%s', skipping gap event", org_id
+        )
+        return
+
+    payload: dict[str, Any] = {
+        "org_id": org_id_int,
+        "user_id": user_id,
+        "query_text": query_text,
+        "gap_type": gap_type,
+        "top_score": top_score,
+        "nearest_kb_slug": nearest_kb_slug,
+        "chunks_retrieved": len(chunks),
+        "retrieval_ms": retrieval_ms,
+    }
+    # SPEC-KB-021 R6: include taxonomy filter when it was part of the retrieve request
+    if taxonomy_node_ids:
+        payload["taxonomy_node_ids"] = taxonomy_node_ids
+    if caller_client_id is not None:
+        payload["caller_client_id"] = caller_client_id
+
+    async def _post() -> None:
+        try:
+            async with httpx.AsyncClient(timeout=cfg.timeout_seconds) as client:
+                await client.post(
+                    cfg.portal_gap_events_url,
+                    json=payload,
+                    headers={"Authorization": f"Bearer {cfg.portal_internal_secret}"},
+                )
+        except Exception as exc:  # noqa: BLE001 — fire-and-forget, swallow all
+            logger.warning("retrieval_telemetry: gap event POST failed (%s)", exc)
+
+    try:
+        asyncio.get_running_loop().create_task(_post())
+    except RuntimeError:
+        # No running event loop (test context) — skip silently
+        pass

--- a/deploy/litellm/klai_retrieval_telemetry.py
+++ b/deploy/litellm/klai_retrieval_telemetry.py
@@ -18,7 +18,7 @@ import asyncio
 import logging
 import os
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 import httpx
@@ -97,14 +97,19 @@ def classify_gap(
     cfg = config or _default_config()
     if not chunks:
         return "hard"
-    reranker_scores = [
-        c.get("reranker_score") for c in chunks if c.get("reranker_score") is not None
+    # The list-comprehension filter guarantees ``s is not None``, but pyright
+    # cannot narrow the inferred element-type from ``object | None`` to
+    # ``object`` after the predicate. Make it explicit with a typed cast.
+    reranker_scores: list[float] = [
+        float(c["reranker_score"])
+        for c in chunks
+        if c.get("reranker_score") is not None
     ]
     if reranker_scores:
         if all(s < cfg.gap_soft_threshold for s in reranker_scores):
             return "soft"
     else:
-        dense_scores = [c.get("score", 0.0) for c in chunks]
+        dense_scores: list[float] = [float(c.get("score", 0.0)) for c in chunks]
         if all(s < cfg.gap_dense_threshold for s in dense_scores):
             return "soft"
     return None
@@ -137,9 +142,7 @@ def fire_retrieval_log(
     try:
         int(org_id)
     except (ValueError, TypeError):
-        logger.warning(
-            "retrieval_telemetry: non-numeric org_id '%s', skipping retrieval log", org_id
-        )
+        logger.warning("retrieval_telemetry: non-numeric org_id '%s', skipping retrieval log", org_id)
         return
 
     payload: dict[str, Any] = {
@@ -149,7 +152,7 @@ def fire_retrieval_log(
         "reranker_scores": reranker_scores,
         "query_resolved": query_resolved,
         "embedding_model_version": cfg.embedding_model_version,
-        "retrieved_at": datetime.now(timezone.utc).isoformat(),
+        "retrieved_at": datetime.now(UTC).isoformat(),
     }
     if caller_client_id is not None:
         payload["caller_client_id"] = caller_client_id
@@ -162,7 +165,7 @@ def fire_retrieval_log(
                     json=payload,
                     headers={"Authorization": f"Bearer {cfg.portal_internal_secret}"},
                 )
-        except Exception as exc:  # noqa: BLE001 — fire-and-forget, swallow all
+        except Exception as exc:
             logger.warning("retrieval_telemetry: retrieval log POST failed (%s)", exc)
 
     try:
@@ -197,28 +200,14 @@ def fire_gap_event(
     """
     cfg = config or _default_config()
 
-    top_chunk = (
-        max(chunks, key=lambda c: c.get("reranker_score") or c.get("score", 0.0))
-        if chunks
-        else None
-    )
-    top_score = (
-        (top_chunk.get("reranker_score") or top_chunk.get("score"))
-        if top_chunk
-        else None
-    )
-    nearest_kb_slug = (
-        top_chunk.get("metadata", {}).get("kb_slug")
-        if top_chunk and gap_type == "soft"
-        else None
-    )
+    top_chunk = max(chunks, key=lambda c: c.get("reranker_score") or c.get("score", 0.0)) if chunks else None
+    top_score = (top_chunk.get("reranker_score") or top_chunk.get("score")) if top_chunk else None
+    nearest_kb_slug = top_chunk.get("metadata", {}).get("kb_slug") if top_chunk and gap_type == "soft" else None
 
     try:
         org_id_int = int(org_id)
     except (ValueError, TypeError):
-        logger.warning(
-            "retrieval_telemetry: non-numeric org_id '%s', skipping gap event", org_id
-        )
+        logger.warning("retrieval_telemetry: non-numeric org_id '%s', skipping gap event", org_id)
         return
 
     payload: dict[str, Any] = {
@@ -245,7 +234,7 @@ def fire_gap_event(
                     json=payload,
                     headers={"Authorization": f"Bearer {cfg.portal_internal_secret}"},
                 )
-        except Exception as exc:  # noqa: BLE001 — fire-and-forget, swallow all
+        except Exception as exc:
             logger.warning("retrieval_telemetry: gap event POST failed (%s)", exc)
 
     try:

--- a/deploy/litellm/tests/test_klai_retrieval_telemetry_drift.py
+++ b/deploy/litellm/tests/test_klai_retrieval_telemetry_drift.py
@@ -1,0 +1,136 @@
+"""Detect drift between vendored ``deploy/litellm/klai_retrieval_telemetry.py``
+and the canonical ``klai-libs/retrieval-telemetry/klai_retrieval_telemetry/_emit.py``.
+
+SPEC-MCP-RETRIEVAL-001 Phase 1. The vendored copy exists because the LiteLLM
+container is a stock upstream image without a path-dep mechanism, mirroring
+the pattern from ``klai_chat_prompts.py`` and ``klai_service_auth.py``.
+
+Phase D plan: replace the vendored file with a proper ``pip install`` of
+``klai-retrieval-telemetry`` in a custom litellm Dockerfile, and delete this
+test alongside the vendored module.
+
+Implementation note
+-------------------
+
+Python's import system deduplicates by module name, so we cannot ``import
+klai_retrieval_telemetry`` once for the vendored copy and once for the
+canonical package and expect to get two different namespaces. We use
+explicit ``importlib.util.spec_from_file_location`` to load each file under
+a unique synthetic name (``_drift_vendored_telemetry``,
+``_drift_canonical_telemetry``).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_CANONICAL_PATH = (
+    _REPO_ROOT
+    / "klai-libs"
+    / "retrieval-telemetry"
+    / "klai_retrieval_telemetry"
+    / "_emit.py"
+)
+_VENDORED_PATH = _REPO_ROOT / "deploy" / "litellm" / "klai_retrieval_telemetry.py"
+
+
+def _load(name: str, path: Path) -> ModuleType:
+    """Load ``path`` as a fresh module under ``name`` (no sys.path dedup).
+
+    Note: we register the module in ``sys.modules`` BEFORE ``exec_module``
+    because Python 3.12+ dataclass decorators look up ``cls.__module__`` in
+    sys.modules during class processing. Without the pre-registration,
+    ``@dataclass(frozen=True, slots=True)`` on a class defined inside the
+    loaded file raises ``AttributeError: 'NoneType' object has no attribute
+    '__dict__'`` at import time.
+    """
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:  # pragma: no cover
+        raise RuntimeError(f"could not build module spec for {path}")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except Exception:
+        sys.modules.pop(name, None)
+        raise
+    return mod
+
+
+def test_vendored_source_is_byte_identical_to_canonical() -> None:
+    """The vendored single-file copy MUST be byte-identical to the canonical
+    ``_emit.py``. Drift here would mean LibreChat path (LiteLLM hook) and
+    knowledge-mcp path emit different telemetry payload shapes — the exact
+    failure mode SPEC-MCP-RETRIEVAL-001 Phase 1 prevents.
+    """
+    vendored_text = _VENDORED_PATH.read_text(encoding="utf-8")
+    canonical_text = _CANONICAL_PATH.read_text(encoding="utf-8")
+    assert vendored_text == canonical_text, (
+        "Source drift between vendored and canonical klai_retrieval_telemetry.\n"
+        f"  Update {_VENDORED_PATH.relative_to(_REPO_ROOT)} to match "
+        f"{_CANONICAL_PATH.relative_to(_REPO_ROOT)}.\n"
+        "  Easiest: cp <canonical> <vendored>"
+    )
+
+
+def test_vendored_public_api_matches_canonical() -> None:
+    """Public function/class names on the vendored module MUST match the
+    canonical module. Catches accidental refactors that delete a function
+    only in one place.
+    """
+    vendored = _load("_drift_vendored_telemetry", _VENDORED_PATH)
+    canonical = _load("_drift_canonical_telemetry", _CANONICAL_PATH)
+
+    vendored_public = {n for n in dir(vendored) if not n.startswith("_")}
+    canonical_public = {n for n in dir(canonical) if not n.startswith("_")}
+
+    # Drop module-level imports that aren't part of the public surface
+    # (httpx, asyncio, etc. land in dir() but are not what we mean by
+    # "public API"). We pin only the symbols defined in this file.
+    expected = {
+        "RetrievalTelemetryConfig",
+        "classify_gap",
+        "fire_gap_event",
+        "fire_retrieval_log",
+    }
+    assert expected.issubset(vendored_public)
+    assert expected.issubset(canonical_public)
+    assert vendored_public == canonical_public, (
+        "Public-symbol drift between vendored and canonical telemetry.\n"
+        f"  vendored - canonical: {vendored_public - canonical_public}\n"
+        f"  canonical - vendored: {canonical_public - vendored_public}\n"
+        f"  Update deploy/litellm/klai_retrieval_telemetry.py to match "
+        f"klai-libs/retrieval-telemetry/klai_retrieval_telemetry/_emit.py."
+    )
+
+
+def test_vendored_classify_gap_pure_function_signature() -> None:
+    """``classify_gap`` must remain a pure function — same signature on both."""
+    import inspect
+
+    vendored = _load("_drift_vendored_telemetry_sig", _VENDORED_PATH)
+    canonical = _load("_drift_canonical_telemetry_sig", _CANONICAL_PATH)
+
+    v_sig = inspect.signature(vendored.classify_gap)
+    c_sig = inspect.signature(canonical.classify_gap)
+    assert v_sig.parameters.keys() == c_sig.parameters.keys()
+
+
+def test_vendored_fire_helpers_accept_caller_client_id_kwarg() -> None:
+    """REQ-9: both ``fire_*`` helpers MUST expose ``caller_client_id`` as a
+    keyword argument so MCP-tool callers can label telemetry without a
+    positional-argument refactor."""
+    import inspect
+
+    vendored = _load("_drift_vendored_telemetry_kwargs", _VENDORED_PATH)
+    for helper_name in ("fire_retrieval_log", "fire_gap_event"):
+        helper = getattr(vendored, helper_name)
+        params = inspect.signature(helper).parameters
+        assert "caller_client_id" in params, f"{helper_name} missing caller_client_id"
+        assert params["caller_client_id"].kind == inspect.Parameter.KEYWORD_ONLY, (
+            f"{helper_name}.caller_client_id must be keyword-only"
+        )

--- a/klai-knowledge-mcp/Dockerfile
+++ b/klai-knowledge-mcp/Dockerfile
@@ -17,6 +17,9 @@ COPY --chown=app:app klai-libs/identity-assert klai-libs/identity-assert
 # SPEC-SEC-INTERNAL-001 B2: klai-log-utils path-dep (sanitize_response_body +
 # verify_shared_secret). Same pattern as identity-assert.
 COPY --chown=app:app klai-libs/log-utils klai-libs/log-utils
+# SPEC-MCP-RETRIEVAL-001 Phase 1: klai-retrieval-telemetry path-dep
+# (classify_gap, fire_retrieval_log, fire_gap_event). Used by search_knowledge.
+COPY --chown=app:app klai-libs/retrieval-telemetry klai-libs/retrieval-telemetry
 COPY --chown=app:app klai-knowledge-mcp/pyproject.toml klai-knowledge-mcp/pyproject.toml
 COPY --chown=app:app klai-knowledge-mcp/uv.lock klai-knowledge-mcp/uv.lock
 

--- a/klai-knowledge-mcp/main.py
+++ b/klai-knowledge-mcp/main.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+import time
 import uuid
 from dataclasses import dataclass
 from datetime import date
@@ -31,8 +32,16 @@ from klai_identity_assert import (
     McpTokenAsserter,
     VerifyResult,
 )
+from klai_retrieval_telemetry import (
+    classify_gap as _classify_gap,
+)
+from klai_retrieval_telemetry import (
+    fire_gap_event,
+    fire_retrieval_log,
+)
 from log_utils import sanitize_response_body, verify_shared_secret
 from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
 from mcp.server.transport_security import TransportSecuritySettings
 
 from logging_setup import setup_logging
@@ -45,6 +54,11 @@ logger = logging.getLogger(__name__)
 KLAI_DOCS_API_BASE = os.environ["KLAI_DOCS_API_BASE"]  # http://docs-app:3000
 DOCS_INTERNAL_SECRET = os.environ["DOCS_INTERNAL_SECRET"]
 KNOWLEDGE_INGEST_URL = os.environ["KNOWLEDGE_INGEST_URL"]  # http://knowledge-ingest:8000
+# SPEC-MCP-RETRIEVAL-001: retrieval-api endpoint for the search_knowledge tool.
+# Default targets the Docker-internal hostname; SOPS sets this in production.
+KNOWLEDGE_RETRIEVE_URL = os.environ.get(
+    "KNOWLEDGE_RETRIEVE_URL", "http://retrieval-api:8040/retrieve"
+)
 # SPEC-SEC-INTERNAL-001 REQ-9.5: KNOWLEDGE_INGEST_SECRET is now mandatory.
 # Empty / missing causes module-load failure rather than silently omitting
 # the X-Internal-Secret header on outbound calls (the previous "gradual
@@ -114,6 +128,14 @@ _ERR_IDENTITY_REJECTED = (
 _ERR_ASSERTION_MODE = (
     "Error: invalid assertion_mode '{}'. "
     f"Valid values: {', '.join(sorted(VALID_ASSERTION_MODES))}"
+)
+# SPEC-MCP-RETRIEVAL-001 REQ-17/REQ-18: bilingual generic for retrieval failures.
+# Status codes + correlation context land in structlog; the user-facing string
+# stays generic so the MCP host (Claude Desktop) does not surface internal
+# upstream details to the LLM.
+_ERR_KB_UNAVAILABLE = (
+    "Kennisbank tijdelijk niet bereikbaar. Probeer het later opnieuw.\n"
+    "(Knowledge base unavailable. Please try again.)"
 )
 
 
@@ -844,6 +866,145 @@ async def save_to_docs(
         )
 
     return f"✓ Opgeslagen in kennisbank **{kb_name}**: {title} (pad: {page_path})"
+
+
+# -- Tool: search_knowledge ---------------------------------------------------
+# SPEC-MCP-RETRIEVAL-001: lets third-party MCP clients (Claude Desktop,
+# Cursor, ChatGPT custom connectors) read from the same KB the LiteLLM
+# pre-call hook already serves to LibreChat. The tool is a thin wrapper
+# around retrieval-api `/retrieve`:
+#   1. dispatcher resolves identity (LibreChat or OAuth path)
+#   2. clamp top_k to [1,15], 3.0s timeout (same as the LiteLLM hook)
+#   3. POST to retrieval-api with the verified org_id+user_id
+#   4. fire retrieval-log + (conditional) gap-event telemetry, labelled
+#      with identity.client_id when the caller is an OAuth client
+#   5. return list[dict] of chunks with title/source_url/text/score/scope
+#
+# Failure modes raise ToolError so the MCP host (Claude Desktop) surfaces
+# the failure to the LLM rather than letting it claim "no results found"
+# when the KB was unreachable. See spec.md REQ-17/18.
+@mcp.tool(
+    description="""Search the user's Klai knowledge base — personal notes,
+organisation docs, and connected sources (Notion, Google Drive, web crawls).
+
+WHEN TO CALL: questions that may be answered by the user's own documentation,
+decisions, customer data, or product knowledge. Search BEFORE answering from
+general knowledge when the question is org-specific.
+
+PARAMETERS:
+  query  - search query in the user's language. Self-contained: resolve
+           pronouns and references yourself before passing.
+  top_k  - 1-15, default 8. Higher values for broad questions.
+
+RETURNS: list of chunks with title, source_url, text, score, scope.
+  scope="personal" = user's own saved notes.
+  scope="org"      = organisation knowledge.
+  Cite by source_url when present; never invent URLs.
+"""
+)
+async def search_knowledge(
+    query: str,
+    ctx: Context,
+    top_k: int = 8,
+) -> list[dict]:
+    # Identity dispatcher (SPEC-MCP-AUTH-001 REQ-15). Either path raises
+    # _IdentificationFailed on auth failure; we propagate it untouched so
+    # the MCP host returns a 401 + WWW-Authenticate to the client.
+    identity = await _identify_request(ctx)
+
+    # SPEC-MCP-RETRIEVAL-001 REQ-12: clamp silently rather than 400 — external
+    # LLMs frequently overshoot; defensively bounding is friendlier than an
+    # input-validation error that the LLM has to debug.
+    top_k = max(1, min(int(top_k), 15))
+
+    # SPEC-MCP-RETRIEVAL-001 REQ-13: same 3.0s ceiling as the LiteLLM hook.
+    # Configurable via env in a future iteration if cold-start P99 spikes.
+    body: dict = {
+        "query": query,
+        "raw_query": query,
+        "org_id": identity.org_id,
+        "user_id": identity.user_id,
+        "scope": "both",
+        "top_k": top_k,
+        "conversation_history": [],
+    }
+
+    # SPEC-SEC-IDENTITY-ASSERT-001 REQ-4.2: caller-service header is mandatory
+    # on /retrieve. ``knowledge-mcp`` is whitelisted in KNOWN_CALLER_SERVICES
+    # and granted the ``klai:internal:retrieval:query`` scope on the JWT path.
+    #
+    # SPEC-SEC-INTERNAL-001 REQ-9.5: KNOWLEDGE_INGEST_SECRET is enforced
+    # non-empty at module-load — no conditional inclusion allowed (silent-
+    # omit anti-pattern). Always send the header; let upstream auth fail
+    # loudly if the env was misconfigured at deploy time.
+    headers: dict[str, str] = {
+        "X-Caller-Service": "knowledge-mcp",
+        "X-Internal-Secret": KNOWLEDGE_INGEST_SECRET,
+    }
+
+    t0 = time.monotonic()
+    try:
+        async with httpx.AsyncClient(timeout=3.0) as client:
+            resp = await client.post(KNOWLEDGE_RETRIEVE_URL, json=body, headers=headers)
+            resp.raise_for_status()
+            result = resp.json()
+    except httpx.HTTPStatusError as exc:
+        logger.error(
+            "search_knowledge_retrieval_failed: type=HTTPStatusError status=%d client_id=%s",
+            exc.response.status_code,
+            identity.client_id,
+        )
+        raise ToolError(_ERR_KB_UNAVAILABLE) from exc
+    except (httpx.TimeoutException, httpx.RequestError) as exc:
+        logger.error(
+            "search_knowledge_retrieval_failed: type=%s client_id=%s",
+            type(exc).__name__,
+            identity.client_id,
+        )
+        raise ToolError(_ERR_KB_UNAVAILABLE) from exc
+
+    chunks = result.get("chunks", [])
+    retrieval_ms = int((time.monotonic() - t0) * 1000)
+
+    # SPEC-MCP-RETRIEVAL-001 REQ-21 / REQ-23: telemetry is fire-and-forget
+    # (helpers schedule asyncio.create_task internally) and any failure
+    # is swallowed, so wrapping in a broad except keeps the success path
+    # robust against e.g. a transient portal-api 5xx during emit.
+    try:
+        fire_retrieval_log(
+            org_id=identity.org_id,
+            user_id=identity.user_id,
+            chunk_ids=[c.get("chunk_id") for c in chunks if c.get("chunk_id")],
+            reranker_scores=[c.get("reranker_score") or 0.0 for c in chunks],
+            query_resolved=query,
+            caller_client_id=identity.client_id,
+        )
+        gap = _classify_gap(chunks)
+        if gap is not None:
+            fire_gap_event(
+                org_id=identity.org_id,
+                user_id=identity.user_id,
+                query_text=query,
+                gap_type=gap,
+                chunks=chunks,
+                retrieval_ms=retrieval_ms,
+                caller_client_id=identity.client_id,
+            )
+    except Exception as exc:
+        logger.warning("search_knowledge_telemetry_failed: %s", exc)
+
+    return [
+        {
+            "title": c.get("title") or c.get("metadata", {}).get("title", ""),
+            "source_url": c.get("source_url"),
+            "text": (c.get("text") or "").strip(),
+            "score": c.get("reranker_score")
+            if c.get("reranker_score") is not None
+            else c.get("score"),
+            "scope": c.get("scope", "org"),
+        }
+        for c in chunks
+    ]
 
 
 # -- ASGI app -----------------------------------------------------------------

--- a/klai-knowledge-mcp/main.py
+++ b/klai-knowledge-mcp/main.py
@@ -59,6 +59,16 @@ KNOWLEDGE_INGEST_URL = os.environ["KNOWLEDGE_INGEST_URL"]  # http://knowledge-in
 KNOWLEDGE_RETRIEVE_URL = os.environ.get(
     "KNOWLEDGE_RETRIEVE_URL", "http://retrieval-api:8040/retrieve"
 )
+# SPEC-MCP-RETRIEVAL-001: secret for the X-Internal-Secret header on outbound
+# /retrieve calls. retrieval-api validates against its own INTERNAL_SECRET env
+# (mapped from RETRIEVAL_API_INTERNAL_SECRET in SOPS) — DIFFERENT from
+# KNOWLEDGE_INGEST_SECRET (knowledge-ingest service) and PORTAL_INTERNAL_SECRET
+# (portal-api). Using the wrong one yields HTTP 401 invalid_internal_secret.
+# When unset (older deploys), fall back to PORTAL_INTERNAL_SECRET so the
+# header still ships — same fallback the LiteLLM hook uses.
+RETRIEVAL_INTERNAL_SECRET = (
+    os.environ.get("RETRIEVAL_INTERNAL_SECRET") or os.environ.get("PORTAL_INTERNAL_SECRET", "")
+)
 # SPEC-SEC-INTERNAL-001 REQ-9.5: KNOWLEDGE_INGEST_SECRET is now mandatory.
 # Empty / missing causes module-load failure rather than silently omitting
 # the X-Internal-Secret header on outbound calls (the previous "gradual
@@ -933,13 +943,13 @@ async def search_knowledge(
     # on /retrieve. ``knowledge-mcp`` is whitelisted in KNOWN_CALLER_SERVICES
     # and granted the ``klai:internal:retrieval:query`` scope on the JWT path.
     #
-    # SPEC-SEC-INTERNAL-001 REQ-9.5: KNOWLEDGE_INGEST_SECRET is enforced
-    # non-empty at module-load — no conditional inclusion allowed (silent-
-    # omit anti-pattern). Always send the header; let upstream auth fail
-    # loudly if the env was misconfigured at deploy time.
+    # SPEC-MCP-RETRIEVAL-001: RETRIEVAL_INTERNAL_SECRET is the right secret
+    # for the X-Internal-Secret header on /retrieve. Using the historic
+    # KNOWLEDGE_INGEST_SECRET here would 401 against retrieval-api in
+    # production — different services hold different secrets in SOPS.
     headers: dict[str, str] = {
         "X-Caller-Service": "knowledge-mcp",
-        "X-Internal-Secret": KNOWLEDGE_INGEST_SECRET,
+        "X-Internal-Secret": RETRIEVAL_INTERNAL_SECRET,
     }
 
     t0 = time.monotonic()

--- a/klai-knowledge-mcp/main.py
+++ b/klai-knowledge-mcp/main.py
@@ -66,8 +66,8 @@ KNOWLEDGE_RETRIEVE_URL = os.environ.get(
 # (portal-api). Using the wrong one yields HTTP 401 invalid_internal_secret.
 # When unset (older deploys), fall back to PORTAL_INTERNAL_SECRET so the
 # header still ships — same fallback the LiteLLM hook uses.
-RETRIEVAL_INTERNAL_SECRET = (
-    os.environ.get("RETRIEVAL_INTERNAL_SECRET") or os.environ.get("PORTAL_INTERNAL_SECRET", "")
+RETRIEVAL_INTERNAL_SECRET = os.environ.get("RETRIEVAL_INTERNAL_SECRET") or os.environ.get(
+    "PORTAL_INTERNAL_SECRET", ""
 )
 # SPEC-SEC-INTERNAL-001 REQ-9.5: KNOWLEDGE_INGEST_SECRET is now mandatory.
 # Empty / missing causes module-load failure rather than silently omitting

--- a/klai-knowledge-mcp/main.py
+++ b/klai-knowledge-mcp/main.py
@@ -229,11 +229,17 @@ _mcp_token_asserter = McpTokenAsserter(
 # SPEC-MCP-AUTH-001 REQ-12: unified verified-identity shape for both auth
 # paths. Tools never branch on which pad provided the identity — they just
 # receive a frozen ``_VerifiedIdentity`` and forward upstream.
+#
+# SPEC-MCP-RETRIEVAL-001 REQ-3: ``client_id`` carries the OAuth client
+# attribution for telemetry labelling. ``None`` on the LibreChat path
+# (existing tools never read it); set on the OAuth path so the upcoming
+# ``search_knowledge`` tool can label retrieval-log + gap-event entries.
 @dataclass(frozen=True, slots=True)
 class _VerifiedIdentity:
     user_id: str
     org_id: str
     org_slug: str
+    client_id: str | None = None
 
 
 async def _verify_identity(ctx: Context, claimed: _ClaimedIdentity) -> VerifyResult:
@@ -342,6 +348,11 @@ async def _identify_via_oauth_token(ctx: Context, raw_token: str) -> _VerifiedId
         user_id=result.user_id,
         org_id=result.org_id,
         org_slug=result.org_slug,
+        # SPEC-MCP-RETRIEVAL-001 REQ-4: propagate OAuth client_id from the
+        # mcp-token verify response. ``None`` if portal returns it null
+        # (older portal builds may not include the field) — the tool that
+        # consumes it must treat None as "no caller attribution".
+        client_id=result.client_id,
     )
 
 

--- a/klai-knowledge-mcp/pyproject.toml
+++ b/klai-knowledge-mcp/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     # SPEC-SEC-INTERNAL-001 REQ-4 / REQ-8: shared sanitize_response_body +
     # secret-introspection helpers used by every upstream-error log/return path.
     "klai-log-utils",
+    "klai-retrieval-telemetry",
 ]
 
 [project.optional-dependencies]
@@ -27,6 +28,10 @@ dev = [
 [tool.uv.sources]
 klai-identity-assert = { path = "../klai-libs/identity-assert", editable = true }
 klai-log-utils = { path = "../klai-libs/log-utils", editable = true }
+# SPEC-MCP-RETRIEVAL-001 Phase 1: shared retrieval telemetry helpers used
+# by the search_knowledge tool (gap-events, retrieval-log POSTs). Editable
+# path-dep so changes to the canonical lib propagate without a republish.
+klai-retrieval-telemetry = { path = "../klai-libs/retrieval-telemetry", editable = true }
 
 [tool.ruff]
 line-length = 100

--- a/klai-knowledge-mcp/tests/test_search_knowledge.py
+++ b/klai-knowledge-mcp/tests/test_search_knowledge.py
@@ -436,6 +436,62 @@ class TestIdentityFailurePropagation:
                 await main.search_knowledge(query="q", ctx=ctx)
 
 
+# ─── Outbound auth header regression guard ────────────────────────────────
+
+
+class TestRetrievalSecretUsedForUpstream:
+    """Regression guard: retrieval-api validates against its own secret
+    (RETRIEVAL_API_INTERNAL_SECRET in SOPS), NOT KNOWLEDGE_INGEST_SECRET.
+    Using the wrong env-var name silently 401s every search_knowledge call
+    in production.
+    """
+
+    @pytest.mark.asyncio
+    async def test_retrieval_internal_secret_is_used_in_outbound_header(self) -> None:
+        from main import search_knowledge
+
+        ctx = _librechat_ctx()
+        captured: dict[str, Any] = {}
+
+        async def _capture_post(self: Any, url: str, **kwargs: Any) -> MagicMock:
+            captured["headers"] = kwargs.get("headers", {})
+            return _make_retrieve_response([])
+
+        with patch(
+            "main._asserter.verify",
+            new_callable=AsyncMock,
+            return_value=allow_verify_result(),
+        ), patch.object(httpx.AsyncClient, "post", new=_capture_post), patch(
+            "main.RETRIEVAL_INTERNAL_SECRET", "retrieval-specific-secret"
+        ):
+            await search_knowledge(query="q", ctx=ctx)
+
+        assert captured["headers"]["X-Internal-Secret"] == "retrieval-specific-secret"
+        # Ensure we are NOT sending the knowledge-ingest secret (different service)
+        assert captured["headers"]["X-Internal-Secret"] != "test-secret"
+
+    @pytest.mark.asyncio
+    async def test_caller_service_header_is_knowledge_mcp(self) -> None:
+        """AC-20: SPEC-SEC-IDENTITY-ASSERT-001 REQ-4.2 guard."""
+        from main import search_knowledge
+
+        ctx = _librechat_ctx()
+        captured: dict[str, Any] = {}
+
+        async def _capture_post(self: Any, url: str, **kwargs: Any) -> MagicMock:
+            captured["headers"] = kwargs.get("headers", {})
+            return _make_retrieve_response([])
+
+        with patch(
+            "main._asserter.verify",
+            new_callable=AsyncMock,
+            return_value=allow_verify_result(),
+        ), patch.object(httpx.AsyncClient, "post", new=_capture_post):
+            await search_knowledge(query="q", ctx=ctx)
+
+        assert captured["headers"]["X-Caller-Service"] == "knowledge-mcp"
+
+
 # ─── T-12: org_id forwarding (cross-tenant smoke) ─────────────────────────
 
 

--- a/klai-knowledge-mcp/tests/test_search_knowledge.py
+++ b/klai-knowledge-mcp/tests/test_search_knowledge.py
@@ -457,12 +457,14 @@ class TestRetrievalSecretUsedForUpstream:
             captured["headers"] = kwargs.get("headers", {})
             return _make_retrieve_response([])
 
-        with patch(
-            "main._asserter.verify",
-            new_callable=AsyncMock,
-            return_value=allow_verify_result(),
-        ), patch.object(httpx.AsyncClient, "post", new=_capture_post), patch(
-            "main.RETRIEVAL_INTERNAL_SECRET", "retrieval-specific-secret"
+        with (
+            patch(
+                "main._asserter.verify",
+                new_callable=AsyncMock,
+                return_value=allow_verify_result(),
+            ),
+            patch.object(httpx.AsyncClient, "post", new=_capture_post),
+            patch("main.RETRIEVAL_INTERNAL_SECRET", "retrieval-specific-secret"),
         ):
             await search_knowledge(query="q", ctx=ctx)
 
@@ -482,11 +484,14 @@ class TestRetrievalSecretUsedForUpstream:
             captured["headers"] = kwargs.get("headers", {})
             return _make_retrieve_response([])
 
-        with patch(
-            "main._asserter.verify",
-            new_callable=AsyncMock,
-            return_value=allow_verify_result(),
-        ), patch.object(httpx.AsyncClient, "post", new=_capture_post):
+        with (
+            patch(
+                "main._asserter.verify",
+                new_callable=AsyncMock,
+                return_value=allow_verify_result(),
+            ),
+            patch.object(httpx.AsyncClient, "post", new=_capture_post),
+        ):
             await search_knowledge(query="q", ctx=ctx)
 
         assert captured["headers"]["X-Caller-Service"] == "knowledge-mcp"

--- a/klai-knowledge-mcp/tests/test_search_knowledge.py
+++ b/klai-knowledge-mcp/tests/test_search_knowledge.py
@@ -1,0 +1,472 @@
+"""SPEC-MCP-RETRIEVAL-001 Phase 3: search_knowledge MCP tool tests.
+
+Covers all 14 testcases T-1..T-14 from
+``.moai/specs/SPEC-MCP-RETRIEVAL-001/plan.md`` § "Test matrix".
+
+The tool is a thin wrapper around retrieval-api ``/retrieve`` that:
+  - identifies the caller via the existing dispatcher (LibreChat or OAuth)
+  - clamps top_k to [1, 15]
+  - posts to retrieval-api with a 3.0s timeout
+  - returns a list[dict] of chunks with title/source_url/text/score/scope
+  - fires retrieval-log + (optional) gap-event telemetry tagged with the
+    OAuth client_id when the caller is an OAuth client
+  - raises ToolError on retrieval-api 4xx/5xx/timeout
+
+These tests stay pure-unit: the retrieval-api HTTP call and all telemetry
+emits are mocked. Cross-tenant RLS isolation is verified at the
+retrieval-api layer (out of scope here); we only verify that org_id is
+forwarded correctly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from tests._helpers import allow_verify_result
+
+# ─── ctx + mock builders ──────────────────────────────────────────────────
+
+
+def _make_ctx(headers: dict[str, str] | None = None) -> MagicMock:
+    ctx = MagicMock()
+    ctx.request_context.request.headers = headers or {}
+    return ctx
+
+
+def _librechat_ctx() -> MagicMock:
+    """ctx that triggers the LibreChat dispatcher pad."""
+    return _make_ctx(
+        {
+            "x-user-id": "user1",
+            "x-org-id": "org1",
+            "x-org-slug": "testorg",
+            "x-internal-secret": "test-secret",
+        }
+    )
+
+
+def _oauth_ctx(token: str = "klai_mcp_oauth_test_token_123") -> MagicMock:  # noqa: S107 — test fixture token
+    """ctx that triggers the OAuth dispatcher pad."""
+    return _make_ctx({"authorization": f"Bearer {token}"})
+
+
+def _make_retrieve_response(
+    chunks: list[dict[str, Any]] | None = None, status: int = 200
+) -> MagicMock:
+    """Build a fake httpx.Response for retrieval-api /retrieve."""
+    resp = MagicMock()
+    resp.status_code = status
+    resp.json = MagicMock(
+        return_value={
+            "query_resolved": "test",
+            "retrieval_bypassed": False,
+            "chunks": chunks or [],
+        }
+    )
+    if status >= 400:
+        resp.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                f"HTTP {status}",
+                request=MagicMock(),
+                response=resp,
+            )
+        )
+    else:
+        resp.raise_for_status = MagicMock()
+    return resp
+
+
+def _chunk(
+    title: str = "Sample doc",
+    source_url: str | None = "https://example.com/doc",
+    text: str = "Sample content",
+    reranker_score: float | None = 0.9,
+    scope: str = "org",
+    chunk_id: str = "chunk-1",
+) -> dict[str, Any]:
+    return {
+        "chunk_id": chunk_id,
+        "title": title,
+        "source_url": source_url,
+        "text": text,
+        "reranker_score": reranker_score,
+        "scope": scope,
+        "metadata": {"kb_slug": "support"},
+    }
+
+
+# ─── Tool surface basics ──────────────────────────────────────────────────
+
+
+class TestToolSurface:
+    """The tool must be importable as an @mcp.tool function from main."""
+
+    def test_search_knowledge_function_exists(self) -> None:
+        from main import search_knowledge
+
+        assert callable(search_knowledge)
+
+    @pytest.mark.asyncio
+    async def test_tool_description_contains_citation_guidance(self) -> None:
+        """REQ-1 + REQ-15: tool-description carries the citation rule.
+
+        FastMCP stores the description on the registered Tool object,
+        not on the wrapped function. Source via ``mcp.list_tools()`` —
+        same path the MCP host LLM consumes.
+        """
+        import main
+
+        tools = await main.mcp.list_tools()
+        descriptions = [t.description or "" for t in tools if t.name == "search_knowledge"]
+        assert descriptions, "search_knowledge must be registered as an MCP tool"
+        joined = descriptions[0].lower()
+        # Must contain the source_url citation rule
+        assert "source_url" in joined or "source url" in joined
+        assert "never invent" in joined or "do not invent" in joined
+
+
+# ─── T-1, T-13: Happy path with OAuth + caller_client_id ──────────────────
+
+
+class TestOAuthHappyPath:
+    @pytest.mark.asyncio
+    async def test_oauth_path_returns_chunks_with_expected_shape(self) -> None:
+        from klai_identity_assert.mcp_token_client import McpTokenVerifyResult
+
+        from main import search_knowledge
+
+        ctx = _oauth_ctx()
+        chunks_in = [_chunk(chunk_id=f"c{i}") for i in range(3)]
+
+        with (
+            patch(
+                "main._mcp_token_asserter.verify",
+                new_callable=AsyncMock,
+                return_value=McpTokenVerifyResult.allow(
+                    user_id="zit-user-1",
+                    org_id="42",
+                    org_slug="acme",
+                    scopes=("mcp:knowledge",),
+                    resource_uri="https://mcp.getklai.com",
+                    client_id="claude-desktop",
+                ),
+            ),
+            patch(
+                "httpx.AsyncClient.post",
+                new_callable=AsyncMock,
+                return_value=_make_retrieve_response(chunks_in),
+            ),
+        ):
+            result = await search_knowledge(query="how do I X?", ctx=ctx, top_k=5)
+
+        assert isinstance(result, list)
+        assert len(result) == 3
+        for item in result:
+            assert set(item.keys()) >= {"title", "source_url", "text", "score", "scope"}
+
+    @pytest.mark.asyncio
+    async def test_oauth_path_fires_retrieval_log_with_client_id(self) -> None:
+        """REQ-9 + AC-3: telemetry labelled with caller_client_id."""
+        from klai_identity_assert.mcp_token_client import McpTokenVerifyResult
+
+        from main import search_knowledge
+
+        ctx = _oauth_ctx()
+
+        with (
+            patch(
+                "main._mcp_token_asserter.verify",
+                new_callable=AsyncMock,
+                return_value=McpTokenVerifyResult.allow(
+                    user_id="zit-user-1",
+                    org_id="42",
+                    org_slug="acme",
+                    scopes=("mcp:knowledge",),
+                    resource_uri="https://mcp.getklai.com",
+                    client_id="claude-desktop",
+                ),
+            ),
+            patch(
+                "httpx.AsyncClient.post",
+                new_callable=AsyncMock,
+                return_value=_make_retrieve_response([_chunk()]),
+            ),
+            patch("main.fire_retrieval_log") as mock_log,
+        ):
+            await search_knowledge(query="how do I X?", ctx=ctx, top_k=5)
+
+        # fire_retrieval_log called with caller_client_id="claude-desktop"
+        mock_log.assert_called_once()
+        kwargs = mock_log.call_args.kwargs
+        assert kwargs.get("caller_client_id") == "claude-desktop"
+
+
+# ─── T-2: LibreChat path uses caller_client_id=None ───────────────────────
+
+
+class TestLibreChatPath:
+    @pytest.mark.asyncio
+    async def test_librechat_path_works_and_omits_client_id(self) -> None:
+        """REQ-9 + AC-4: LibreChat path passes caller_client_id=None."""
+        from main import search_knowledge
+
+        ctx = _librechat_ctx()
+
+        with (
+            patch(
+                "main._asserter.verify",
+                new_callable=AsyncMock,
+                return_value=allow_verify_result(),
+            ),
+            patch(
+                "httpx.AsyncClient.post",
+                new_callable=AsyncMock,
+                return_value=_make_retrieve_response([_chunk()]),
+            ),
+            patch("main.fire_retrieval_log") as mock_log,
+        ):
+            result = await search_knowledge(query="q", ctx=ctx, top_k=3)
+
+        assert len(result) == 1
+        assert mock_log.call_args.kwargs.get("caller_client_id") is None
+
+
+# ─── T-3, T-11: Empty / non-error edge cases ──────────────────────────────
+
+
+class TestEmptyResults:
+    @pytest.mark.asyncio
+    async def test_empty_chunks_returns_empty_list_and_fires_gap(self) -> None:
+        """REQ-19 + AC-11: empty chunks = legitimate [], gap-event fires."""
+        from main import search_knowledge
+
+        ctx = _librechat_ctx()
+
+        with (
+            patch(
+                "main._asserter.verify",
+                new_callable=AsyncMock,
+                return_value=allow_verify_result(),
+            ),
+            patch(
+                "httpx.AsyncClient.post",
+                new_callable=AsyncMock,
+                return_value=_make_retrieve_response([]),
+            ),
+            patch("main.fire_retrieval_log"),
+            patch("main.fire_gap_event") as mock_gap,
+        ):
+            result = await search_knowledge(query="q", ctx=ctx)
+
+        assert result == []
+        mock_gap.assert_called_once()
+        assert mock_gap.call_args.kwargs.get("gap_type") == "hard"
+
+
+class TestTelemetryFailureSwallowed:
+    @pytest.mark.asyncio
+    async def test_telemetry_post_failure_does_not_break_tool(self) -> None:
+        """REQ-20 + AC-9: telemetry failure swallowed."""
+        from main import search_knowledge
+
+        ctx = _librechat_ctx()
+
+        with (
+            patch(
+                "main._asserter.verify",
+                new_callable=AsyncMock,
+                return_value=allow_verify_result(),
+            ),
+            patch(
+                "httpx.AsyncClient.post",
+                new_callable=AsyncMock,
+                return_value=_make_retrieve_response([_chunk()]),
+            ),
+            patch(
+                "main.fire_retrieval_log",
+                side_effect=RuntimeError("simulated telemetry failure"),
+            ),
+        ):
+            # MUST NOT raise — telemetry-failure is non-fatal
+            result = await search_knowledge(query="q", ctx=ctx)
+
+        assert len(result) == 1
+
+
+# ─── T-4, T-5, T-6: ToolError on retrieval failure ────────────────────────
+
+
+class TestRetrievalFailures:
+    @pytest.mark.asyncio
+    async def test_503_raises_tool_error(self) -> None:
+        """REQ-18 + AC-5."""
+        from mcp.server.fastmcp.exceptions import ToolError
+
+        from main import search_knowledge
+
+        ctx = _librechat_ctx()
+
+        with (
+            patch(
+                "main._asserter.verify",
+                new_callable=AsyncMock,
+                return_value=allow_verify_result(),
+            ),
+            patch(
+                "httpx.AsyncClient.post",
+                new_callable=AsyncMock,
+                return_value=_make_retrieve_response([], status=503),
+            ),
+        ):
+            with pytest.raises(ToolError):
+                await search_knowledge(query="q", ctx=ctx)
+
+    @pytest.mark.asyncio
+    async def test_4xx_raises_tool_error(self) -> None:
+        """REQ-17 + AC-12."""
+        from mcp.server.fastmcp.exceptions import ToolError
+
+        from main import search_knowledge
+
+        ctx = _librechat_ctx()
+
+        with (
+            patch(
+                "main._asserter.verify",
+                new_callable=AsyncMock,
+                return_value=allow_verify_result(),
+            ),
+            patch(
+                "httpx.AsyncClient.post",
+                new_callable=AsyncMock,
+                return_value=_make_retrieve_response([], status=400),
+            ),
+        ):
+            with pytest.raises(ToolError):
+                await search_knowledge(query="q", ctx=ctx)
+
+    @pytest.mark.asyncio
+    async def test_timeout_raises_tool_error(self) -> None:
+        """REQ-18 + AC-5: TimeoutException maps to ToolError."""
+        from mcp.server.fastmcp.exceptions import ToolError
+
+        from main import search_knowledge
+
+        ctx = _librechat_ctx()
+
+        with (
+            patch(
+                "main._asserter.verify",
+                new_callable=AsyncMock,
+                return_value=allow_verify_result(),
+            ),
+            patch(
+                "httpx.AsyncClient.post",
+                new_callable=AsyncMock,
+                side_effect=httpx.TimeoutException("simulated timeout"),
+            ),
+        ):
+            with pytest.raises(ToolError):
+                await search_knowledge(query="q", ctx=ctx)
+
+
+# ─── T-7, T-8, T-9: top_k clamping ────────────────────────────────────────
+
+
+class TestTopKClamping:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "input_top_k,expected",
+        [(20, 15), (16, 15), (15, 15), (8, 8), (1, 1), (0, 1), (-5, 1), (-100, 1)],
+    )
+    async def test_clamps_top_k_to_range(self, input_top_k: int, expected: int) -> None:
+        """REQ-12 + AC-6."""
+        from main import search_knowledge
+
+        ctx = _librechat_ctx()
+        captured: dict[str, Any] = {}
+
+        async def _capture_post(self: Any, url: str, **kwargs: Any) -> MagicMock:
+            captured["url"] = url
+            captured["json"] = kwargs.get("json")
+            return _make_retrieve_response([])
+
+        with (
+            patch(
+                "main._asserter.verify",
+                new_callable=AsyncMock,
+                return_value=allow_verify_result(),
+            ),
+            patch.object(httpx.AsyncClient, "post", new=_capture_post),
+        ):
+            await search_knowledge(query="q", ctx=ctx, top_k=input_top_k)
+
+        assert captured["json"]["top_k"] == expected
+
+
+# ─── T-10: Identity verify failure propagates ─────────────────────────────
+
+
+class TestIdentityFailurePropagation:
+    @pytest.mark.asyncio
+    async def test_oauth_invalid_token_propagates_error(self) -> None:
+        """REQ-2 + AC-17: invalid OAuth token = identification failure.
+
+        The dispatcher raises ``main._IdentificationFailed`` on a denied
+        verify; the tool must not silently swallow it into an empty list.
+        We assert the exception is the dispatcher's specific class so a
+        future refactor that unwraps it accidentally would fail loudly.
+        """
+        from klai_identity_assert.mcp_token_client import McpTokenVerifyResult
+
+        import main
+
+        ctx = _oauth_ctx()
+
+        with patch(
+            "main._mcp_token_asserter.verify",
+            new_callable=AsyncMock,
+            return_value=McpTokenVerifyResult.deny("token_revoked"),
+        ):
+            with pytest.raises(main._IdentificationFailed):
+                await main.search_knowledge(query="q", ctx=ctx)
+
+
+# ─── T-12: org_id forwarding (cross-tenant smoke) ─────────────────────────
+
+
+class TestOrgIdForwarding:
+    @pytest.mark.asyncio
+    async def test_request_body_carries_verified_org_id(self) -> None:
+        """AC-7: forward verified.org_id to retrieval-api, not body-supplied."""
+        from main import search_knowledge
+
+        ctx = _librechat_ctx()
+        captured: dict[str, Any] = {}
+
+        async def _capture_post(self: Any, url: str, **kwargs: Any) -> MagicMock:
+            captured["url"] = url
+            captured["json"] = kwargs.get("json")
+            return _make_retrieve_response([])
+
+        with (
+            patch(
+                "main._asserter.verify",
+                new_callable=AsyncMock,
+                return_value=allow_verify_result(org_id="42"),
+            ),
+            patch.object(httpx.AsyncClient, "post", new=_capture_post),
+        ):
+            await search_knowledge(query="q", ctx=ctx)
+
+        assert captured["json"]["org_id"] == "42"
+        assert "/retrieve" in captured["url"]
+
+
+# ─── Save-tools regression (T-14) lives in existing tests/ — no new test
+# needed. The save_personal_knowledge / save_org_knowledge / save_to_docs
+# suites in tests/ continue to pass under the Phase 1+2 changes.

--- a/klai-knowledge-mcp/uv.lock
+++ b/klai-knowledge-mcp/uv.lock
@@ -340,6 +340,7 @@ dependencies = [
     { name = "httpx" },
     { name = "klai-identity-assert" },
     { name = "klai-log-utils" },
+    { name = "klai-retrieval-telemetry" },
     { name = "mcp", extra = ["cli"] },
     { name = "structlog" },
     { name = "uvicorn", extra = ["standard"] },
@@ -358,6 +359,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "klai-identity-assert", editable = "../klai-libs/identity-assert" },
     { name = "klai-log-utils", editable = "../klai-libs/log-utils" },
+    { name = "klai-retrieval-telemetry", editable = "../klai-libs/retrieval-telemetry" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.9.0" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
@@ -392,6 +394,34 @@ provides-extras = ["dev"]
 [package.metadata.requires-dev]
 dev = [
     { name = "httpx", specifier = ">=0.28" },
+    { name = "pyright", specifier = ">=1.1.390" },
+    { name = "pytest", specifier = ">=8" },
+    { name = "pytest-asyncio", specifier = ">=0.24" },
+    { name = "ruff", specifier = ">=0.8" },
+]
+
+[[package]]
+name = "klai-retrieval-telemetry"
+version = "0.1.0"
+source = { editable = "../klai-libs/retrieval-telemetry" }
+dependencies = [
+    { name = "httpx" },
+    { name = "structlog" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.28" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.390" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8" },
+    { name = "structlog", specifier = ">=25.0" },
+]
+provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
     { name = "pyright", specifier = ">=1.1.390" },
     { name = "pytest", specifier = ">=8" },
     { name = "pytest-asyncio", specifier = ">=0.24" },

--- a/klai-libs/identity-assert/klai_identity_assert/mcp_token_client.py
+++ b/klai-libs/identity-assert/klai_identity_assert/mcp_token_client.py
@@ -57,6 +57,12 @@ class McpTokenVerifyResult:
     org_slug: str | None = None
     scopes: tuple[str, ...] = ()
     resource_uri: str | None = None
+    # SPEC-MCP-RETRIEVAL-001 REQ-6: OAuth client_id (the DCR-issued
+    # ``portal_oauth_clients.client_id`` string) for telemetry attribution
+    # in downstream consumers (knowledge-mcp's search_knowledge tool).
+    # ``None`` means the portal-side resolution didn't find a matching
+    # client row — defensive default; in practice the FK exists.
+    client_id: str | None = None
     reason: str | None = None
 
     @classmethod
@@ -68,6 +74,7 @@ class McpTokenVerifyResult:
         org_slug: str | None,
         scopes: tuple[str, ...],
         resource_uri: str | None,
+        client_id: str | None = None,
     ) -> McpTokenVerifyResult:
         return cls(
             verified=True,
@@ -76,6 +83,7 @@ class McpTokenVerifyResult:
             org_slug=org_slug,
             scopes=scopes,
             resource_uri=resource_uri,
+            client_id=client_id,
         )
 
     @classmethod
@@ -115,12 +123,18 @@ def _interpret_response(payload: Any) -> McpTokenVerifyResult:
     org_slug = body.get("org_slug")
     scopes = body.get("scopes") or []
     resource_uri = body.get("resource_uri")
+    client_id = body.get("client_id")
 
     if not isinstance(user_id, str) or not isinstance(org_id, str):
         return McpTokenVerifyResult.deny("portal_unreachable")
     if org_slug is not None and not isinstance(org_slug, str):
         return McpTokenVerifyResult.deny("portal_unreachable")
     if not isinstance(scopes, list):
+        return McpTokenVerifyResult.deny("portal_unreachable")
+    # client_id is optional in the wire shape (older portal builds may
+    # omit the key entirely). Reject only if the type is wrong, not if
+    # the value is None.
+    if client_id is not None and not isinstance(client_id, str):
         return McpTokenVerifyResult.deny("portal_unreachable")
 
     return McpTokenVerifyResult.allow(
@@ -129,6 +143,7 @@ def _interpret_response(payload: Any) -> McpTokenVerifyResult:
         org_slug=org_slug,
         scopes=tuple(str(s) for s in scopes),
         resource_uri=resource_uri if isinstance(resource_uri, str) else None,
+        client_id=client_id if isinstance(client_id, str) else None,
     )
 
 

--- a/klai-libs/retrieval-telemetry/README.md
+++ b/klai-libs/retrieval-telemetry/README.md
@@ -1,0 +1,69 @@
+# klai-retrieval-telemetry
+
+Shared retrieval telemetry helpers for Klai services. Extracted from
+`deploy/litellm/klai_knowledge.py` per SPEC-MCP-RETRIEVAL-001 so both the
+LiteLLM pre-call hook (LibreChat) and `klai-knowledge-mcp` (third-party
+LLMs via OAuth) can emit `retrieval_log` and `gap_events` against the
+same portal-api endpoints with the same payload contract.
+
+## What this lib does
+
+Three fire-and-forget telemetry helpers that POST to portal-api after a
+successful retrieval:
+
+- `classify_gap(chunks)` — pure function. Returns `"hard"` (no chunks),
+  `"soft"` (low scores), or `None` (success).
+- `fire_retrieval_log(...)` — POST to `/internal/v1/retrieval-log`.
+  Records the chunk_ids and reranker_scores returned for an executed query.
+- `fire_gap_event(...)` — POST to `/internal/v1/gap-events`. Records a
+  classified gap and the top chunk metadata for triage in admin.
+
+All helpers are fire-and-forget: they schedule the POST via
+`asyncio.create_task` and silently swallow HTTP and network errors. A
+failed telemetry emit must never break the retrieval pipeline.
+
+## Caller-attribution: `caller_client_id`
+
+The optional `caller_client_id` keyword on the `fire_*` helpers labels
+the telemetry row with the OAuth client that made the request:
+
+- `caller_client_id=None` — LibreChat path (the default).
+- `caller_client_id="<client_id>"` — third-party MCP client (Claude
+  Desktop, Cursor, ChatGPT). The DB-side `client_id` from
+  `portal_oauth_clients`, set by SPEC-MCP-AUTH-001 token verification.
+
+Dashboards can split-by `caller_client_id` to compare external traffic
+against LibreChat without mixing the two streams.
+
+## Configuration
+
+The helpers read these environment variables on import:
+
+| Variable | Required | Default | Purpose |
+|---|---|---|---|
+| `PORTAL_API_URL` | yes | — | Base URL for `/internal/v1/{retrieval-log,gap-events}` |
+| `PORTAL_INTERNAL_SECRET` | yes | — | Bearer used to authenticate inbound at portal-api |
+| `KLAI_GAP_SOFT_THRESHOLD` | no | `0.4` | Reranker-score below = soft gap |
+| `KLAI_GAP_DENSE_THRESHOLD` | no | `0.35` | Dense-score below = soft gap (when no reranker scores) |
+| `EMBEDDING_MODEL_VERSION` | no | `bge-m3-v1` | Recorded on each retrieval-log row |
+
+Override via `RetrievalTelemetryConfig` for callers that want to inject
+their own values (recommended in tests).
+
+## Why a separate package
+
+Both consumers (LiteLLM hook + knowledge-mcp) write to the **same**
+`retrieval_log` table and `gap_events` stream. A duplicated copy in
+each consumer would diverge silently when the schema or the gap-classifier
+threshold changes. Sharing one package makes the contract explicit.
+
+The retrieval-call helper itself (JWT-or-legacy auth + POST to
+`/retrieve`) is **not** in this package — it has different config
+requirements per consumer (LiteLLM has its own Zitadel client, MCP has
+another) and is small enough to live inline in each.
+
+## Reference
+
+- SPEC-MCP-RETRIEVAL-001 (`.moai/specs/SPEC-MCP-RETRIEVAL-001/`)
+- SPEC-KB-015 (retrieval log)
+- SPEC-KB-014 (gap detection)

--- a/klai-libs/retrieval-telemetry/klai_retrieval_telemetry/__init__.py
+++ b/klai-libs/retrieval-telemetry/klai_retrieval_telemetry/__init__.py
@@ -1,0 +1,27 @@
+"""klai-retrieval-telemetry — shared retrieval telemetry helpers.
+
+Public surface:
+    classify_gap(chunks) -> Optional[str]
+    fire_retrieval_log(...) -> None  (fire-and-forget)
+    fire_gap_event(...) -> None      (fire-and-forget)
+    RetrievalTelemetryConfig         (override default env-driven config)
+
+Behaviour preservation: the three helpers are byte-identical in observable
+behaviour to the inline implementations in deploy/litellm/klai_knowledge.py
+prior to SPEC-MCP-RETRIEVAL-001 Phase 1 extraction. The optional
+``caller_client_id`` keyword is the only contract addition.
+"""
+
+from klai_retrieval_telemetry._emit import (
+    RetrievalTelemetryConfig,
+    classify_gap,
+    fire_gap_event,
+    fire_retrieval_log,
+)
+
+__all__ = [
+    "RetrievalTelemetryConfig",
+    "classify_gap",
+    "fire_gap_event",
+    "fire_retrieval_log",
+]

--- a/klai-libs/retrieval-telemetry/klai_retrieval_telemetry/_emit.py
+++ b/klai-libs/retrieval-telemetry/klai_retrieval_telemetry/_emit.py
@@ -1,0 +1,255 @@
+"""Telemetry emission helpers — extracted from deploy/litellm/klai_knowledge.py.
+
+SPEC-MCP-RETRIEVAL-001 Phase 1: behaviour-preserving extraction of the three
+fire-and-forget POST helpers and the gap-classifier so both the LiteLLM
+pre-call hook (LibreChat) and klai-knowledge-mcp (third-party LLMs via
+OAuth) post the same payload shape against the same portal-api endpoints.
+
+The single contract addition over the original inline impls is the optional
+``caller_client_id`` keyword argument on the two ``fire_*`` helpers. When
+``None`` (the LibreChat default), the payload omits the field — same wire
+shape as before. When set, it labels the row with the OAuth client that
+issued the call.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+# -- Configuration ------------------------------------------------------------
+# Module-level defaults loaded from env on first ``_default_config()`` call.
+# Tests can pass their own ``RetrievalTelemetryConfig`` to bypass env entirely.
+@dataclass(frozen=True, slots=True)
+class RetrievalTelemetryConfig:
+    """Connection + behaviour config for the telemetry helpers.
+
+    Defaults match the LiteLLM-hook env-driven values so existing callers
+    pick up identical behaviour without explicit construction. Tests should
+    construct a config directly to avoid env-leak between cases.
+    """
+
+    portal_api_url: str = ""
+    portal_internal_secret: str = ""
+    portal_retrieval_log_url: str = ""
+    portal_gap_events_url: str = ""
+    embedding_model_version: str = "bge-m3-v1"
+    gap_soft_threshold: float = 0.4
+    gap_dense_threshold: float = 0.35
+    timeout_seconds: float = 2.0
+    # @MX:NOTE: if you add a field here, mirror it in _default_config below
+    # so the env path stays in sync with the dataclass shape.
+    _frozen: bool = field(default=True, init=False, repr=False)
+
+
+def _default_config() -> RetrievalTelemetryConfig:
+    """Build a config from env vars. Caller-overridable per call.
+
+    Reads on every call rather than at import time so containers that
+    rotate ``PORTAL_INTERNAL_SECRET`` via SOPS sync pick up the new
+    secret without a process restart. The cost (a few env-dict lookups)
+    is negligible compared to the HTTP POST that follows.
+    """
+    portal_api_url = os.getenv("PORTAL_API_URL", "")
+    portal_secret = os.getenv("PORTAL_INTERNAL_SECRET", "")
+    return RetrievalTelemetryConfig(
+        portal_api_url=portal_api_url,
+        portal_internal_secret=portal_secret,
+        portal_retrieval_log_url=os.getenv(
+            "PORTAL_RETRIEVAL_LOG_URL",
+            f"{portal_api_url}/internal/v1/retrieval-log",
+        ),
+        portal_gap_events_url=os.getenv(
+            "PORTAL_GAP_EVENTS_URL",
+            f"{portal_api_url}/internal/v1/gap-events",
+        ),
+        embedding_model_version=os.getenv("EMBEDDING_MODEL_VERSION", "bge-m3-v1"),
+        gap_soft_threshold=float(os.getenv("KLAI_GAP_SOFT_THRESHOLD", "0.4")),
+        gap_dense_threshold=float(os.getenv("KLAI_GAP_DENSE_THRESHOLD", "0.35")),
+    )
+
+
+# -- Gap classification -------------------------------------------------------
+# @MX:NOTE: Gap thresholds (0.4 reranker, 0.35 dense) are configurable via
+# KLAI_GAP_SOFT_THRESHOLD / KLAI_GAP_DENSE_THRESHOLD env vars (SPEC-KB-014)
+def classify_gap(
+    chunks: list[dict[str, Any]],
+    config: RetrievalTelemetryConfig | None = None,
+) -> str | None:
+    """Classify retrieval result. Returns 'hard', 'soft', or None (success).
+
+    - ``hard``: empty chunk list — retrieval found nothing.
+    - ``soft``: chunks present but all reranker (or dense, when reranker
+      absent) scores fall below the configured threshold.
+    - ``None``: at least one chunk crossed the threshold.
+
+    Pure function — no I/O. Safe to call inside a hot path.
+    """
+    cfg = config or _default_config()
+    if not chunks:
+        return "hard"
+    reranker_scores = [
+        c.get("reranker_score") for c in chunks if c.get("reranker_score") is not None
+    ]
+    if reranker_scores:
+        if all(s < cfg.gap_soft_threshold for s in reranker_scores):
+            return "soft"
+    else:
+        dense_scores = [c.get("score", 0.0) for c in chunks]
+        if all(s < cfg.gap_dense_threshold for s in dense_scores):
+            return "soft"
+    return None
+
+
+# -- Retrieval-log emit -------------------------------------------------------
+# @MX:NOTE: Fire-and-forget retrieval log -- mirrors fire_gap_event pattern. SPEC-KB-015.
+# @MX:WARN: Uses create_task -- caller must be inside running event loop.
+# @MX:REASON: Silently discards on no-loop (test context) and any HTTP error (REQ-KB-015-03).
+def fire_retrieval_log(
+    org_id: str,
+    user_id: str,
+    chunk_ids: list[str],
+    reranker_scores: list[float],
+    query_resolved: str,
+    *,
+    caller_client_id: str | None = None,
+    config: RetrievalTelemetryConfig | None = None,
+) -> None:
+    """Schedule an async retrieval log POST without blocking the caller.
+
+    Behaviour-equivalent to the previous inline impl in
+    ``deploy/litellm/klai_knowledge.py``. The optional
+    ``caller_client_id`` keyword adds OAuth-client attribution per
+    SPEC-MCP-RETRIEVAL-001 REQ-9; when ``None`` the payload key is
+    omitted, preserving the wire shape for LibreChat traffic.
+    """
+    cfg = config or _default_config()
+
+    try:
+        int(org_id)
+    except (ValueError, TypeError):
+        logger.warning(
+            "retrieval_telemetry: non-numeric org_id '%s', skipping retrieval log", org_id
+        )
+        return
+
+    payload: dict[str, Any] = {
+        "org_id": str(org_id),
+        "user_id": user_id,
+        "chunk_ids": chunk_ids,
+        "reranker_scores": reranker_scores,
+        "query_resolved": query_resolved,
+        "embedding_model_version": cfg.embedding_model_version,
+        "retrieved_at": datetime.now(timezone.utc).isoformat(),
+    }
+    if caller_client_id is not None:
+        payload["caller_client_id"] = caller_client_id
+
+    async def _post() -> None:
+        try:
+            async with httpx.AsyncClient(timeout=cfg.timeout_seconds) as client:
+                await client.post(
+                    cfg.portal_retrieval_log_url,
+                    json=payload,
+                    headers={"Authorization": f"Bearer {cfg.portal_internal_secret}"},
+                )
+        except Exception as exc:  # noqa: BLE001 — fire-and-forget, swallow all
+            logger.warning("retrieval_telemetry: retrieval log POST failed (%s)", exc)
+
+    try:
+        asyncio.get_running_loop().create_task(_post())
+    except RuntimeError:
+        # No running event loop (test context) — skip silently
+        pass
+
+
+# -- Gap-event emit -----------------------------------------------------------
+# @MX:WARN: Fire-and-forget via create_task — caller must be inside a running event loop.
+# @MX:REASON: Wraps in try/except RuntimeError to handle test environments without a loop.
+def fire_gap_event(
+    org_id: str,
+    user_id: str,
+    query_text: str,
+    gap_type: str,
+    chunks: list[dict[str, Any]],
+    retrieval_ms: int,
+    taxonomy_node_ids: list[int] | None = None,
+    *,
+    caller_client_id: str | None = None,
+    config: RetrievalTelemetryConfig | None = None,
+) -> None:
+    """Schedule an async gap event POST without blocking the caller.
+
+    Behaviour-equivalent to the previous inline impl in
+    ``deploy/litellm/klai_knowledge.py``. The optional
+    ``caller_client_id`` keyword adds OAuth-client attribution per
+    SPEC-MCP-RETRIEVAL-001 REQ-9; when ``None`` the payload key is
+    omitted, preserving the wire shape for LibreChat traffic.
+    """
+    cfg = config or _default_config()
+
+    top_chunk = (
+        max(chunks, key=lambda c: c.get("reranker_score") or c.get("score", 0.0))
+        if chunks
+        else None
+    )
+    top_score = (
+        (top_chunk.get("reranker_score") or top_chunk.get("score"))
+        if top_chunk
+        else None
+    )
+    nearest_kb_slug = (
+        top_chunk.get("metadata", {}).get("kb_slug")
+        if top_chunk and gap_type == "soft"
+        else None
+    )
+
+    try:
+        org_id_int = int(org_id)
+    except (ValueError, TypeError):
+        logger.warning(
+            "retrieval_telemetry: non-numeric org_id '%s', skipping gap event", org_id
+        )
+        return
+
+    payload: dict[str, Any] = {
+        "org_id": org_id_int,
+        "user_id": user_id,
+        "query_text": query_text,
+        "gap_type": gap_type,
+        "top_score": top_score,
+        "nearest_kb_slug": nearest_kb_slug,
+        "chunks_retrieved": len(chunks),
+        "retrieval_ms": retrieval_ms,
+    }
+    # SPEC-KB-021 R6: include taxonomy filter when it was part of the retrieve request
+    if taxonomy_node_ids:
+        payload["taxonomy_node_ids"] = taxonomy_node_ids
+    if caller_client_id is not None:
+        payload["caller_client_id"] = caller_client_id
+
+    async def _post() -> None:
+        try:
+            async with httpx.AsyncClient(timeout=cfg.timeout_seconds) as client:
+                await client.post(
+                    cfg.portal_gap_events_url,
+                    json=payload,
+                    headers={"Authorization": f"Bearer {cfg.portal_internal_secret}"},
+                )
+        except Exception as exc:  # noqa: BLE001 — fire-and-forget, swallow all
+            logger.warning("retrieval_telemetry: gap event POST failed (%s)", exc)
+
+    try:
+        asyncio.get_running_loop().create_task(_post())
+    except RuntimeError:
+        # No running event loop (test context) — skip silently
+        pass

--- a/klai-libs/retrieval-telemetry/klai_retrieval_telemetry/_emit.py
+++ b/klai-libs/retrieval-telemetry/klai_retrieval_telemetry/_emit.py
@@ -18,7 +18,7 @@ import asyncio
 import logging
 import os
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 import httpx
@@ -97,14 +97,19 @@ def classify_gap(
     cfg = config or _default_config()
     if not chunks:
         return "hard"
-    reranker_scores = [
-        c.get("reranker_score") for c in chunks if c.get("reranker_score") is not None
+    # The list-comprehension filter guarantees ``s is not None``, but pyright
+    # cannot narrow the inferred element-type from ``object | None`` to
+    # ``object`` after the predicate. Make it explicit with a typed cast.
+    reranker_scores: list[float] = [
+        float(c["reranker_score"])
+        for c in chunks
+        if c.get("reranker_score") is not None
     ]
     if reranker_scores:
         if all(s < cfg.gap_soft_threshold for s in reranker_scores):
             return "soft"
     else:
-        dense_scores = [c.get("score", 0.0) for c in chunks]
+        dense_scores: list[float] = [float(c.get("score", 0.0)) for c in chunks]
         if all(s < cfg.gap_dense_threshold for s in dense_scores):
             return "soft"
     return None
@@ -137,9 +142,7 @@ def fire_retrieval_log(
     try:
         int(org_id)
     except (ValueError, TypeError):
-        logger.warning(
-            "retrieval_telemetry: non-numeric org_id '%s', skipping retrieval log", org_id
-        )
+        logger.warning("retrieval_telemetry: non-numeric org_id '%s', skipping retrieval log", org_id)
         return
 
     payload: dict[str, Any] = {
@@ -149,7 +152,7 @@ def fire_retrieval_log(
         "reranker_scores": reranker_scores,
         "query_resolved": query_resolved,
         "embedding_model_version": cfg.embedding_model_version,
-        "retrieved_at": datetime.now(timezone.utc).isoformat(),
+        "retrieved_at": datetime.now(UTC).isoformat(),
     }
     if caller_client_id is not None:
         payload["caller_client_id"] = caller_client_id
@@ -162,7 +165,7 @@ def fire_retrieval_log(
                     json=payload,
                     headers={"Authorization": f"Bearer {cfg.portal_internal_secret}"},
                 )
-        except Exception as exc:  # noqa: BLE001 — fire-and-forget, swallow all
+        except Exception as exc:
             logger.warning("retrieval_telemetry: retrieval log POST failed (%s)", exc)
 
     try:
@@ -197,28 +200,14 @@ def fire_gap_event(
     """
     cfg = config or _default_config()
 
-    top_chunk = (
-        max(chunks, key=lambda c: c.get("reranker_score") or c.get("score", 0.0))
-        if chunks
-        else None
-    )
-    top_score = (
-        (top_chunk.get("reranker_score") or top_chunk.get("score"))
-        if top_chunk
-        else None
-    )
-    nearest_kb_slug = (
-        top_chunk.get("metadata", {}).get("kb_slug")
-        if top_chunk and gap_type == "soft"
-        else None
-    )
+    top_chunk = max(chunks, key=lambda c: c.get("reranker_score") or c.get("score", 0.0)) if chunks else None
+    top_score = (top_chunk.get("reranker_score") or top_chunk.get("score")) if top_chunk else None
+    nearest_kb_slug = top_chunk.get("metadata", {}).get("kb_slug") if top_chunk and gap_type == "soft" else None
 
     try:
         org_id_int = int(org_id)
     except (ValueError, TypeError):
-        logger.warning(
-            "retrieval_telemetry: non-numeric org_id '%s', skipping gap event", org_id
-        )
+        logger.warning("retrieval_telemetry: non-numeric org_id '%s', skipping gap event", org_id)
         return
 
     payload: dict[str, Any] = {
@@ -245,7 +234,7 @@ def fire_gap_event(
                     json=payload,
                     headers={"Authorization": f"Bearer {cfg.portal_internal_secret}"},
                 )
-        except Exception as exc:  # noqa: BLE001 — fire-and-forget, swallow all
+        except Exception as exc:
             logger.warning("retrieval_telemetry: gap event POST failed (%s)", exc)
 
     try:

--- a/klai-libs/retrieval-telemetry/pyproject.toml
+++ b/klai-libs/retrieval-telemetry/pyproject.toml
@@ -1,0 +1,64 @@
+[project]
+name = "klai-retrieval-telemetry"
+version = "0.1.0"
+description = "Shared retrieval telemetry helpers for Klai services (SPEC-MCP-RETRIEVAL-001)."
+requires-python = ">=3.12"
+readme = "README.md"
+license = { text = "Proprietary" }
+authors = [{ name = "Klai" }]
+
+# Runtime dependencies. httpx for the fire-and-forget POSTs to portal-api.
+# structlog kept compatible with klai-log-utils so callers stay on one
+# logging stack across services.
+dependencies = [
+    "httpx>=0.28",
+    "structlog>=25.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8",
+    "pytest-asyncio>=0.24",
+    "ruff>=0.8",
+    "pyright>=1.1.390",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=8",
+    "pytest-asyncio>=0.24",
+    "ruff>=0.8",
+    "pyright>=1.1.390",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["klai_retrieval_telemetry"]
+
+[tool.hatch.build.targets.wheel.sources]
+"klai_retrieval_telemetry/py.typed" = "klai_retrieval_telemetry/py.typed"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+
+[tool.ruff]
+line-length = 120
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "S", "RUF", "G", "LOG", "TRY"]
+ignore = [
+    "S101",  # asserts are fine in tests
+    "TRY003", # external-exception messages can be longer
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["S105", "S106"]
+
+[tool.pyright]
+pythonVersion = "3.12"
+typeCheckingMode = "strict"

--- a/klai-libs/retrieval-telemetry/tests/test_classify_gap.py
+++ b/klai-libs/retrieval-telemetry/tests/test_classify_gap.py
@@ -1,0 +1,73 @@
+"""classify_gap pure-function tests.
+
+Pinned behaviour from the original inline impl in
+deploy/litellm/klai_knowledge.py. SPEC-KB-014 thresholds.
+"""
+
+from __future__ import annotations
+
+from klai_retrieval_telemetry import RetrievalTelemetryConfig, classify_gap
+
+
+def _cfg() -> RetrievalTelemetryConfig:
+    return RetrievalTelemetryConfig(
+        portal_api_url="http://portal-api:8000",
+        portal_internal_secret="test-secret",
+        portal_retrieval_log_url="http://portal-api:8000/internal/v1/retrieval-log",
+        portal_gap_events_url="http://portal-api:8000/internal/v1/gap-events",
+        gap_soft_threshold=0.4,
+        gap_dense_threshold=0.35,
+    )
+
+
+def test_empty_chunks_is_hard_gap() -> None:
+    assert classify_gap([], _cfg()) == "hard"
+
+
+def test_all_reranker_below_soft_threshold_is_soft() -> None:
+    chunks = [
+        {"reranker_score": 0.1},
+        {"reranker_score": 0.2},
+        {"reranker_score": 0.3},
+    ]
+    assert classify_gap(chunks, _cfg()) == "soft"
+
+
+def test_at_least_one_reranker_above_soft_threshold_is_none() -> None:
+    chunks = [
+        {"reranker_score": 0.1},
+        {"reranker_score": 0.5},  # above 0.4
+        {"reranker_score": 0.3},
+    ]
+    assert classify_gap(chunks, _cfg()) is None
+
+
+def test_no_reranker_falls_back_to_dense_score() -> None:
+    chunks = [
+        {"score": 0.1},
+        {"score": 0.2},
+    ]
+    assert classify_gap(chunks, _cfg()) == "soft"
+
+
+def test_no_reranker_one_dense_above_threshold_is_none() -> None:
+    chunks = [
+        {"score": 0.1},
+        {"score": 0.4},  # above 0.35
+    ]
+    assert classify_gap(chunks, _cfg()) is None
+
+
+def test_reranker_present_overrides_dense() -> None:
+    """If reranker_score is set on any chunk, dense scores are ignored."""
+    chunks = [
+        {"reranker_score": 0.1, "score": 0.99},  # dense high but reranker low
+        {"reranker_score": 0.2, "score": 0.99},
+    ]
+    assert classify_gap(chunks, _cfg()) == "soft"
+
+
+def test_threshold_boundary_exact_match_is_not_soft() -> None:
+    """Score == threshold is NOT below threshold (strict less-than)."""
+    chunks = [{"reranker_score": 0.4}]
+    assert classify_gap(chunks, _cfg()) is None

--- a/klai-libs/retrieval-telemetry/tests/test_fire_gap_event.py
+++ b/klai-libs/retrieval-telemetry/tests/test_fire_gap_event.py
@@ -1,0 +1,175 @@
+"""fire_gap_event behaviour tests.
+
+SPEC-KB-014 + SPEC-MCP-RETRIEVAL-001 REQ-9.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from klai_retrieval_telemetry import RetrievalTelemetryConfig, fire_gap_event
+
+
+def _cfg() -> RetrievalTelemetryConfig:
+    return RetrievalTelemetryConfig(
+        portal_api_url="http://portal-api:8000",
+        portal_internal_secret="test-secret",
+        portal_retrieval_log_url="http://portal-api:8000/internal/v1/retrieval-log",
+        portal_gap_events_url="http://portal-api:8000/internal/v1/gap-events",
+    )
+
+
+def test_skip_silently_when_no_event_loop() -> None:
+    fire_gap_event(
+        org_id="42",
+        user_id="user-1",
+        query_text="test",
+        gap_type="hard",
+        chunks=[],
+        retrieval_ms=42,
+        config=_cfg(),
+    )
+
+
+def test_skip_silently_when_org_id_non_numeric() -> None:
+    with patch("asyncio.get_running_loop") as mock_loop:
+        fire_gap_event(
+            org_id="bogus",
+            user_id="user-1",
+            query_text="test",
+            gap_type="hard",
+            chunks=[],
+            retrieval_ms=42,
+            config=_cfg(),
+        )
+    mock_loop.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_payload_shape_hard_gap_no_chunks() -> None:
+    captured: dict = {}
+
+    async def _fake_post(self, url, **kwargs):
+        captured["url"] = url
+        captured["json"] = kwargs.get("json")
+        return MagicMock(status_code=201)
+
+    with patch("httpx.AsyncClient.post", new=_fake_post):
+        fire_gap_event(
+            org_id="42",
+            user_id="user-1",
+            query_text="impossible question",
+            gap_type="hard",
+            chunks=[],
+            retrieval_ms=123,
+            config=_cfg(),
+        )
+        await asyncio.sleep(0)
+
+    assert captured["url"] == "http://portal-api:8000/internal/v1/gap-events"
+    assert captured["json"]["org_id"] == 42  # int, not str
+    assert captured["json"]["gap_type"] == "hard"
+    assert captured["json"]["chunks_retrieved"] == 0
+    assert captured["json"]["retrieval_ms"] == 123
+    assert captured["json"]["top_score"] is None
+    assert captured["json"]["nearest_kb_slug"] is None
+    assert "caller_client_id" not in captured["json"]
+
+
+@pytest.mark.asyncio
+async def test_payload_shape_soft_gap_with_chunks() -> None:
+    captured: dict = {}
+
+    async def _fake_post(self, url, **kwargs):
+        captured["json"] = kwargs.get("json")
+        return MagicMock(status_code=201)
+
+    chunks = [
+        {"reranker_score": 0.1, "metadata": {"kb_slug": "support"}},
+        {"reranker_score": 0.2, "metadata": {"kb_slug": "support"}},
+    ]
+    with patch("httpx.AsyncClient.post", new=_fake_post):
+        fire_gap_event(
+            org_id="42",
+            user_id="user-1",
+            query_text="weak match",
+            gap_type="soft",
+            chunks=chunks,
+            retrieval_ms=200,
+            config=_cfg(),
+        )
+        await asyncio.sleep(0)
+
+    # Top-chunk highest reranker = 0.2
+    assert captured["json"]["top_score"] == 0.2
+    assert captured["json"]["nearest_kb_slug"] == "support"
+    assert captured["json"]["chunks_retrieved"] == 2
+
+
+@pytest.mark.asyncio
+async def test_caller_client_id_propagates_to_payload() -> None:
+    captured: dict = {}
+
+    async def _fake_post(self, url, **kwargs):
+        captured["json"] = kwargs.get("json")
+        return MagicMock(status_code=201)
+
+    with patch("httpx.AsyncClient.post", new=_fake_post):
+        fire_gap_event(
+            org_id="42",
+            user_id="user-1",
+            query_text="q",
+            gap_type="hard",
+            chunks=[],
+            retrieval_ms=42,
+            caller_client_id="cursor",
+            config=_cfg(),
+        )
+        await asyncio.sleep(0)
+
+    assert captured["json"]["caller_client_id"] == "cursor"
+
+
+@pytest.mark.asyncio
+async def test_taxonomy_node_ids_propagate_when_present() -> None:
+    captured: dict = {}
+
+    async def _fake_post(self, url, **kwargs):
+        captured["json"] = kwargs.get("json")
+        return MagicMock(status_code=201)
+
+    with patch("httpx.AsyncClient.post", new=_fake_post):
+        fire_gap_event(
+            org_id="42",
+            user_id="user-1",
+            query_text="q",
+            gap_type="hard",
+            chunks=[],
+            retrieval_ms=42,
+            taxonomy_node_ids=[7, 11],
+            config=_cfg(),
+        )
+        await asyncio.sleep(0)
+
+    assert captured["json"]["taxonomy_node_ids"] == [7, 11]
+
+
+@pytest.mark.asyncio
+async def test_post_failure_swallowed() -> None:
+    async def _failing_post(self, url, **kwargs):
+        raise RuntimeError("simulated network error")
+
+    with patch("httpx.AsyncClient.post", new=_failing_post):
+        fire_gap_event(
+            org_id="42",
+            user_id="user-1",
+            query_text="q",
+            gap_type="hard",
+            chunks=[],
+            retrieval_ms=42,
+            config=_cfg(),
+        )
+        await asyncio.sleep(0)

--- a/klai-libs/retrieval-telemetry/tests/test_fire_gap_event.py
+++ b/klai-libs/retrieval-telemetry/tests/test_fire_gap_event.py
@@ -1,6 +1,10 @@
+# pyright: basic
 """fire_gap_event behaviour tests.
 
 SPEC-KB-014 + SPEC-MCP-RETRIEVAL-001 REQ-9.
+
+Pyright basic mode for tests: MagicMock + monkey-patched ``httpx.AsyncClient.post``
+produces unsolvable strict-mode types. Production code stays strict-typed.
 """
 
 from __future__ import annotations

--- a/klai-libs/retrieval-telemetry/tests/test_fire_retrieval_log.py
+++ b/klai-libs/retrieval-telemetry/tests/test_fire_retrieval_log.py
@@ -1,0 +1,130 @@
+"""fire_retrieval_log behaviour tests.
+
+SPEC-KB-015 + SPEC-MCP-RETRIEVAL-001 REQ-9.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from klai_retrieval_telemetry import RetrievalTelemetryConfig, fire_retrieval_log
+
+
+def _cfg() -> RetrievalTelemetryConfig:
+    return RetrievalTelemetryConfig(
+        portal_api_url="http://portal-api:8000",
+        portal_internal_secret="test-secret",
+        portal_retrieval_log_url="http://portal-api:8000/internal/v1/retrieval-log",
+        portal_gap_events_url="http://portal-api:8000/internal/v1/gap-events",
+    )
+
+
+def test_skip_silently_when_no_event_loop() -> None:
+    """Outside a running loop, the helper must NOT raise."""
+    fire_retrieval_log(
+        org_id="42",
+        user_id="user-1",
+        chunk_ids=["c1"],
+        reranker_scores=[0.9],
+        query_resolved="test",
+        config=_cfg(),
+    )
+
+
+def test_skip_silently_when_org_id_non_numeric() -> None:
+    """Non-numeric org_id is logged + skipped, no scheduling attempt."""
+    with patch("asyncio.get_running_loop") as mock_loop:
+        fire_retrieval_log(
+            org_id="not-a-number",
+            user_id="user-1",
+            chunk_ids=["c1"],
+            reranker_scores=[0.9],
+            query_resolved="test",
+            config=_cfg(),
+        )
+    # get_running_loop must NOT be called when org_id is bogus
+    mock_loop.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_payload_shape_without_caller_client_id() -> None:
+    """LibreChat path: caller_client_id absent from payload."""
+    captured: dict = {}
+
+    async def _fake_post(self, url, **kwargs):
+        captured["url"] = url
+        captured["json"] = kwargs.get("json")
+        captured["headers"] = kwargs.get("headers")
+        return MagicMock(status_code=201)
+
+    with patch("httpx.AsyncClient.post", new=_fake_post):
+        fire_retrieval_log(
+            org_id="42",
+            user_id="user-1",
+            chunk_ids=["c1", "c2"],
+            reranker_scores=[0.9, 0.8],
+            query_resolved="test query",
+            config=_cfg(),
+        )
+        # Let the create_task fire
+        await asyncio.sleep(0)
+
+    assert captured["url"] == "http://portal-api:8000/internal/v1/retrieval-log"
+    assert captured["json"]["org_id"] == "42"
+    assert captured["json"]["user_id"] == "user-1"
+    assert captured["json"]["chunk_ids"] == ["c1", "c2"]
+    assert captured["json"]["reranker_scores"] == [0.9, 0.8]
+    assert captured["json"]["query_resolved"] == "test query"
+    assert captured["json"]["embedding_model_version"] == "bge-m3-v1"
+    assert "retrieved_at" in captured["json"]
+    # Critical: caller_client_id must be absent on LibreChat path
+    assert "caller_client_id" not in captured["json"]
+    # Auth header
+    assert captured["headers"] == {"Authorization": "Bearer test-secret"}
+
+
+@pytest.mark.asyncio
+async def test_payload_includes_caller_client_id_when_set() -> None:
+    """OAuth path: caller_client_id labels the row."""
+    captured: dict = {}
+
+    async def _fake_post(self, url, **kwargs):
+        captured["json"] = kwargs.get("json")
+        return MagicMock(status_code=201)
+
+    with patch("httpx.AsyncClient.post", new=_fake_post):
+        fire_retrieval_log(
+            org_id="42",
+            user_id="user-1",
+            chunk_ids=["c1"],
+            reranker_scores=[0.9],
+            query_resolved="test",
+            caller_client_id="claude-desktop",
+            config=_cfg(),
+        )
+        await asyncio.sleep(0)
+
+    assert captured["json"]["caller_client_id"] == "claude-desktop"
+
+
+@pytest.mark.asyncio
+async def test_post_failure_swallowed() -> None:
+    """Network error during POST must NOT propagate to caller."""
+    async def _failing_post(self, url, **kwargs):
+        raise RuntimeError("simulated network error")
+
+    with patch("httpx.AsyncClient.post", new=_failing_post):
+        # Must not raise
+        fire_retrieval_log(
+            org_id="42",
+            user_id="user-1",
+            chunk_ids=["c1"],
+            reranker_scores=[0.9],
+            query_resolved="test",
+            config=_cfg(),
+        )
+        await asyncio.sleep(0)

--- a/klai-libs/retrieval-telemetry/tests/test_fire_retrieval_log.py
+++ b/klai-libs/retrieval-telemetry/tests/test_fire_retrieval_log.py
@@ -1,13 +1,17 @@
+# pyright: basic
 """fire_retrieval_log behaviour tests.
 
 SPEC-KB-015 + SPEC-MCP-RETRIEVAL-001 REQ-9.
+
+Pyright basic mode for tests: MagicMock + monkey-patched ``httpx.AsyncClient.post``
+produces unsolvable strict-mode types (mock fixtures, partial unknown args). The
+production code in ``klai_retrieval_telemetry/_emit.py`` stays strict-typed.
 """
 
 from __future__ import annotations
 
 import asyncio
-import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -55,7 +59,7 @@ async def test_payload_shape_without_caller_client_id() -> None:
     """LibreChat path: caller_client_id absent from payload."""
     captured: dict = {}
 
-    async def _fake_post(self, url, **kwargs):
+    async def _fake_post(self: object, url: str, **kwargs: object) -> MagicMock:
         captured["url"] = url
         captured["json"] = kwargs.get("json")
         captured["headers"] = kwargs.get("headers")
@@ -114,6 +118,7 @@ async def test_payload_includes_caller_client_id_when_set() -> None:
 @pytest.mark.asyncio
 async def test_post_failure_swallowed() -> None:
     """Network error during POST must NOT propagate to caller."""
+
     async def _failing_post(self, url, **kwargs):
         raise RuntimeError("simulated network error")
 

--- a/klai-libs/retrieval-telemetry/uv.lock
+++ b/klai-libs/retrieval-telemetry/uv.lock
@@ -1,0 +1,254 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.4.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "klai-retrieval-telemetry"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "httpx" },
+    { name = "structlog" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "ruff" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.28" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.390" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8" },
+    { name = "structlog", specifier = ">=25.0" },
+]
+provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pyright", specifier = ">=1.1.390" },
+    { name = "pytest", specifier = ">=8" },
+    { name = "pytest-asyncio", specifier = ">=0.24" },
+    { name = "ruff", specifier = ">=0.8" },
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.409"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/4e/3aa27f74211522dba7e9cbc3e74de779c6d4b654c54e50a4840623be8014/pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93", size = 4430434, upload-time = "2026-04-23T11:02:03.799Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/6b/330d8ebae582b30c2959a1ef4c3bc344ebde48c2ff0c3f113c4710735e11/pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3", size = 6438161, upload-time = "2026-04-23T11:02:01.309Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]
+
+[[package]]
+name = "structlog"
+version = "25.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830, upload-time = "2025-10-27T08:28:23.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510, upload-time = "2025-10-27T08:28:21.535Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]

--- a/klai-portal/backend/alembic/versions/a5b8c2d6e1f3_retrieval_gaps_caller_client_id.py
+++ b/klai-portal/backend/alembic/versions/a5b8c2d6e1f3_retrieval_gaps_caller_client_id.py
@@ -1,0 +1,38 @@
+"""add caller_client_id to portal_retrieval_gaps (SPEC-MCP-RETRIEVAL-001 Phase 2)
+
+Optional ``caller_client_id`` column lets the gap-events stream
+distinguish OAuth-client traffic (Claude Desktop / Cursor / ChatGPT) from
+LibreChat traffic. ``NULL`` rows = LibreChat (the historic semantics).
+
+Non-blocking ADD COLUMN with NULL default. PostgreSQL 11+ does this as
+metadata-only; existing rows are not rewritten. No RLS policy changes
+needed — ``portal_retrieval_gaps`` is already RLS Category-D, and adding
+a column does not affect the policy expression.
+
+Partial index (WHERE caller_client_id IS NOT NULL) is created
+CONCURRENTLY in ``post_deploy_a5b8c2d6e1f3.sql`` because CONCURRENTLY
+cannot run inside a transaction.
+
+Revision ID: a5b8c2d6e1f3
+Revises: e84a10348987
+Create Date: 2026-05-07
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "a5b8c2d6e1f3"
+down_revision = "e84a10348987"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "portal_retrieval_gaps",
+        sa.Column("caller_client_id", sa.String(64), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("portal_retrieval_gaps", "caller_client_id")

--- a/klai-portal/backend/alembic/versions/post_deploy_a5b8c2d6e1f3.sql
+++ b/klai-portal/backend/alembic/versions/post_deploy_a5b8c2d6e1f3.sql
@@ -1,0 +1,19 @@
+-- post_deploy_a5b8c2d6e1f3.sql
+-- SPEC-MCP-RETRIEVAL-001 Phase 2: partial index on portal_retrieval_gaps.caller_client_id.
+--
+-- Run as klai superuser (NOT portal_api) so the CONCURRENTLY index build is
+-- allowed regardless of pool state. Partial index keeps LibreChat-only
+-- queries (the dominant path) unaffected — the index only stores rows where
+-- caller_client_id IS NOT NULL.
+--
+-- CONCURRENTLY cannot run inside an explicit transaction; this script must
+-- be executed outside a BEGIN/COMMIT wrapper. The deploy-runbook calls it
+-- via `psql -v ON_ERROR_STOP=1` which preserves implicit single-statement
+-- transactions per statement.
+--
+-- Idempotent via IF NOT EXISTS so repeated runs (e.g. retried deploys)
+-- are no-ops after the first success.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS portal_retrieval_gaps_caller_client_id_idx
+    ON portal_retrieval_gaps (caller_client_id)
+    WHERE caller_client_id IS NOT NULL;

--- a/klai-portal/backend/app/api/internal.py
+++ b/klai-portal/backend/app/api/internal.py
@@ -758,6 +758,10 @@ class RetrievalLogIn(BaseModel):
     query_resolved: str
     embedding_model_version: str
     retrieved_at: datetime
+    # SPEC-MCP-RETRIEVAL-001 REQ-9: optional OAuth client attribution.
+    # ``None`` (the default) = LibreChat traffic; populated = third-party
+    # MCP client (Claude Desktop / Cursor / ChatGPT).
+    caller_client_id: str | None = None
 
 
 @router.post("/v1/retrieval-log", status_code=status.HTTP_201_CREATED)
@@ -791,6 +795,7 @@ async def post_retrieval_log(
             query_resolved=body.query_resolved,
             embedding_model_version=body.embedding_model_version,
             retrieved_at=body.retrieved_at,
+            caller_client_id=body.caller_client_id,
         )
     except HTTPException:
         raise
@@ -919,6 +924,10 @@ class GapEventIn(BaseModel):
     chunks_retrieved: int = 0
     retrieval_ms: int = 0
     taxonomy_node_ids: list[int] | None = None  # SPEC-KB-022 R6: from LiteLLM hook
+    # SPEC-MCP-RETRIEVAL-001 REQ-9: optional OAuth client attribution.
+    # ``None`` (the default) = LibreChat traffic; populated = third-party
+    # MCP client (Claude Desktop / Cursor / ChatGPT).
+    caller_client_id: str | None = None
 
 
 @router.post("/v1/gap-events", status_code=status.HTTP_201_CREATED)
@@ -947,6 +956,7 @@ async def create_gap_event(
         chunks_retrieved=payload.chunks_retrieved,
         retrieval_ms=payload.retrieval_ms,
         taxonomy_node_ids=payload.taxonomy_node_ids,
+        caller_client_id=payload.caller_client_id,
     )
     db.add(gap)
     await db.commit()

--- a/klai-portal/backend/app/models/retrieval_gaps.py
+++ b/klai-portal/backend/app/models/retrieval_gaps.py
@@ -45,5 +45,9 @@ class PortalRetrievalGap(Base):
     chunks_retrieved: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
     retrieval_ms: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
     taxonomy_node_ids: Mapped[list[int] | None] = mapped_column(ARRAY(Integer), nullable=True)
+    # SPEC-MCP-RETRIEVAL-001 REQ-9: optional OAuth client_id for caller
+    # attribution. ``None`` = LibreChat traffic; populated = third-party
+    # MCP client (Claude Desktop / Cursor / ChatGPT).
+    caller_client_id: Mapped[str | None] = mapped_column(String(64), nullable=True, default=None)
     occurred_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
     resolved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True, default=None)

--- a/klai-portal/backend/app/services/mcp_oauth.py
+++ b/klai-portal/backend/app/services/mcp_oauth.py
@@ -210,6 +210,14 @@ class VerifyResult:
     org_slug: str | None = None
     scopes: tuple[str, ...] = ()
     resource_uri: str | None = None
+    # SPEC-MCP-RETRIEVAL-001 REQ-5: OAuth client_id (the DCR-issued
+    # ``portal_oauth_clients.client_id`` string, NOT the FK integer). Lets
+    # downstream services (knowledge-mcp search_knowledge tool) label
+    # telemetry per OAuth-client. ``None`` for paths that don't carry an
+    # OAuth client (the LibreChat path uses /internal/identity/verify
+    # which has its own VerifyResult — this field is only populated by
+    # the mcp-token verify path).
+    client_id: str | None = None
     cache_ttl_seconds: int = _CACHE_TTL_VERIFY_SECONDS
     reason: str | None = None  # populated only when verified=False
 
@@ -222,6 +230,7 @@ class VerifyResult:
                 "org_slug": self.org_slug,
                 "scopes": list(self.scopes),
                 "resource_uri": self.resource_uri,
+                "client_id": self.client_id,
                 "cache_ttl_seconds": self.cache_ttl_seconds,
             }
         return {"verified": False, "reason": self.reason or "unknown"}
@@ -345,6 +354,7 @@ async def verify_access_token(
                     org_slug=cached.get("org_slug"),
                     scopes=tuple(cached.get("scopes", [])),
                     resource_uri=cached.get("resource_uri"),
+                    client_id=cached.get("client_id"),
                 )
             return VerifyResult(verified=False, reason=cached.get("reason", "unknown"))
 
@@ -400,6 +410,12 @@ async def verify_access_token(
         await _cache_verify_result(redis, cache_key, deny)
         return deny
 
+    # SPEC-MCP-RETRIEVAL-001 REQ-5: resolve the DCR-issued client_id string
+    # for telemetry attribution. ``token_row.client_id`` is the FK integer
+    # to portal_oauth_clients.id; we want the public ``client_id`` string.
+    client_row = await db.get(PortalOAuthClient, token_row.client_id)
+    client_id_str: str | None = client_row.client_id if client_row is not None else None
+
     success = VerifyResult(
         verified=True,
         # portal_users.zitadel_user_id is the canonical identifier downstream
@@ -411,6 +427,7 @@ async def verify_access_token(
         org_slug=org_row.slug,
         scopes=tuple(token_row.scopes or [DEFAULT_SCOPE]),
         resource_uri=token_row.resource_uri,
+        client_id=client_id_str,
     )
     await _cache_verify_result(redis, cache_key, success)
     return success

--- a/klai-portal/backend/app/services/retrieval_log.py
+++ b/klai-portal/backend/app/services/retrieval_log.py
@@ -29,12 +29,18 @@ async def write_retrieval_log(
     query_resolved: str,
     embedding_model_version: str,
     retrieved_at: datetime,
+    caller_client_id: str | None = None,
 ) -> None:
     """Write a retrieval log entry to Redis sorted set.
 
     Key: rl:{org_id}:{user_id}
     Score: epoch timestamp of retrieved_at
     Member: JSON blob with retrieval context
+
+    SPEC-MCP-RETRIEVAL-001 REQ-9: ``caller_client_id`` is the OAuth client_id
+    that triggered the retrieval (Claude Desktop / Cursor / ChatGPT), or
+    ``None`` for LibreChat traffic. Written into the JSON blob so dashboards
+    can split traffic by caller.
 
     Silently discards on any error (REQ-KB-015-03).
     """
@@ -46,15 +52,18 @@ async def write_retrieval_log(
         key = f"rl:{org_id}:{user_id}"
         epoch = retrieved_at.timestamp()
 
-        entry = json.dumps(
-            {
-                "chunk_ids": chunk_ids,
-                "reranker_scores": reranker_scores,
-                "query_resolved": query_resolved,
-                "embedding_model_version": embedding_model_version,
-                "retrieved_at": epoch,
-            }
-        )
+        entry_dict: dict[str, object] = {
+            "chunk_ids": chunk_ids,
+            "reranker_scores": reranker_scores,
+            "query_resolved": query_resolved,
+            "embedding_model_version": embedding_model_version,
+            "retrieved_at": epoch,
+        }
+        # Only include caller_client_id when set so the wire shape stays
+        # backwards-compatible with pre-SPEC-MCP-RETRIEVAL-001 readers.
+        if caller_client_id is not None:
+            entry_dict["caller_client_id"] = caller_client_id
+        entry = json.dumps(entry_dict)
 
         await pool.zadd(key, {entry: epoch})
         await pool.expire(key, _TTL_SECONDS)
@@ -64,6 +73,7 @@ async def write_retrieval_log(
             org_id=org_id,
             user_id=user_id,
             chunk_count=len(chunk_ids),
+            caller_client_id=caller_client_id,
         )
     except Exception:
         logger.warning("retrieval_log_write_failed", org_id=org_id, exc_info=True)

--- a/klai-portal/backend/tests/test_mcp_oauth_unit.py
+++ b/klai-portal/backend/tests/test_mcp_oauth_unit.py
@@ -21,6 +21,7 @@ import hashlib
 from app.services.mcp_oauth import (
     ACCESS_TOKEN_PREFIX,
     REFRESH_TOKEN_PREFIX,
+    VerifyResult,
     is_redirect_uri_allowed,
     looks_like_access_token,
     verify_pkce_s256,
@@ -156,3 +157,60 @@ def test_redirect_uri_uppercase_host_normalized() -> None:
     """Hostnames are case-insensitive per RFC 3986."""
     assert is_redirect_uri_allowed("http://LOCALHOST:54321/cb", "native") is True
     assert is_redirect_uri_allowed("https://CHAT.OPENAI.COM/cb", "web") is True
+
+
+# ─── VerifyResult.client_id propagation (SPEC-MCP-RETRIEVAL-001 REQ-5) ────
+
+
+def test_verify_result_to_dict_includes_client_id_on_success() -> None:
+    """VerifyResult success serialisation MUST include the client_id field
+    so knowledge-mcp can label retrieval-log + gap-event telemetry.
+    """
+    r = VerifyResult(
+        verified=True,
+        user_id="zit-user-1",
+        org_id="42",
+        org_slug="acme",
+        scopes=("mcp:knowledge",),
+        resource_uri="https://mcp.getklai.com",
+        client_id="claude-desktop",
+    )
+    d = r.to_dict()
+    assert d["verified"] is True
+    assert d["client_id"] == "claude-desktop"
+
+
+def test_verify_result_to_dict_client_id_none_serialises_as_null() -> None:
+    """Pre-Phase-2 OAuth tokens (issued before this SPEC) won't have a
+    client_id resolution path. The field must serialise as ``null`` so
+    the cache round-trip preserves the None semantic instead of dropping
+    the key.
+    """
+    r = VerifyResult(
+        verified=True,
+        user_id="zit-user-1",
+        org_id="42",
+        org_slug="acme",
+        scopes=("mcp:knowledge",),
+        resource_uri="https://mcp.getklai.com",
+        client_id=None,
+    )
+    d = r.to_dict()
+    assert d["client_id"] is None
+
+
+def test_verify_result_default_client_id_is_none() -> None:
+    """Backwards-compat: callers that don't pass client_id (e.g. older
+    test harnesses) get None by default — same wire shape as a deny."""
+    r = VerifyResult(verified=False, reason="invalid_format")
+    assert r.client_id is None
+
+
+def test_verify_result_deny_to_dict_does_not_carry_client_id() -> None:
+    """Deny path returns only ``{verified: False, reason: ...}``. Adding
+    a client_id key would leak token-row metadata to a caller whose
+    token failed validation."""
+    r = VerifyResult(verified=False, reason="token_revoked")
+    d = r.to_dict()
+    assert d == {"verified": False, "reason": "token_revoked"}
+    assert "client_id" not in d


### PR DESCRIPTION
## Summary

Adds the `search_knowledge` MCP tool to `klai-knowledge-mcp` so third-party LLMs (Claude Desktop, Cursor, ChatGPT custom connectors) can read from the same knowledge base the LiteLLM pre-call hook already serves to LibreChat. Builds on the OAuth foundation from SPEC-MCP-AUTH-001.

**Single tool, two parameters** — `search_knowledge(query, top_k=8)`. RLS in retrieval-api enforces tenant scope; external LLMs don't need scope/kb_slugs UI-knobs.

**`caller_client_id` telemetry attribution** — every retrieval-log + gap-event row carries the OAuth client_id (Claude Desktop / Cursor / ChatGPT) so dashboards can split external traffic from LibreChat. `NULL` = LibreChat (the default).

**Telemetry-lib extraction** — `klai-libs/retrieval-telemetry/` shared between the LiteLLM hook (LibreChat path) and the new MCP tool. Single source of truth for `retrieval_log` + `gap_events` payload contract. Vendored single-file copy in `deploy/litellm/`; drift enforced by test.

## Phases

### Phase 1 — Telemetry library extraction
- New `klai-libs/retrieval-telemetry/` package with `classify_gap`, `fire_retrieval_log`, `fire_gap_event`
- Vendored single-file copy in `deploy/litellm/klai_retrieval_telemetry.py`
- Drift test (`test_klai_retrieval_telemetry_drift.py`) bewaakt byte-identity + public API
- `deploy/litellm/klai_knowledge.py` rebound naar de lib via underscore-aliases — geen call-site refactor

### Phase 2 — `caller_client_id` end-to-end propagation
- Alembic migration `a5b8c2d6e1f3` adds `portal_retrieval_gaps.caller_client_id` (non-blocking ADD COLUMN + CONCURRENT partial index in post_deploy.sql)
- `RetrievalLogIn` + `GapEventIn` Pydantic schemas accept optional `caller_client_id`
- `write_retrieval_log` + `PortalRetrievalGap` propagate the field
- `mcp_oauth.VerifyResult.client_id` field + JOIN to `portal_oauth_clients` in `verify_access_token`; cache round-trip preserves it
- `klai-libs/identity-assert/.../mcp_token_client.VerifyResult.client_id` mirrors the wire shape
- `klai-knowledge-mcp` `_VerifiedIdentity.client_id` field; OAuth pad sets it, LibreChat pad keeps `None`

### Phase 3 — `search_knowledge` tool
- Thin wrapper around retrieval-api `/retrieve`
- Dispatcher resolves identity (LibreChat or OAuth) — same path as save tools
- `top_k` clamped to [1, 15] (defensive); 3.0s timeout (parity with LiteLLM hook)
- HTTPStatusError (4xx/5xx) + TimeoutException → `ToolError` (host LLM surfaces failure to user; never silent empty list)
- Empty results = `[]` (legitimate) + gap-event still fires
- Telemetry failures swallowed (fire-and-forget)
- Result shape: `list[dict]` with `title/source_url/text/score/scope`. No system-prompt-injection in output; citation rules live in tool description

## Test plan

- [x] **20 new tests** in `klai-knowledge-mcp/tests/test_search_knowledge.py` covering happy path (OAuth + LibreChat), top_k clamping (8 parametrised), retrieval failures (4xx/5xx/timeout), empty results + gap-event firing, telemetry-failure swallow, identity-failure propagation, org_id forwarding, tool-description citation guidance.
- [x] **REQ-24 regression**: 116/116 `deploy/litellm/tests/` pass without test-code modification (LiteLLM hook unchanged in observable behaviour)
- [x] 85/85 `klai-knowledge-mcp` suite (incl. existing save-tools — bewijs T-14)
- [x] 19/19 new `klai-libs/retrieval-telemetry/tests/`
- [x] 54/54 `klai-libs/identity-assert/tests/`
- [x] 23/23 `klai-portal/backend/tests/test_mcp_oauth_unit.py` (4 nieuwe + 19 bestaande)
- [x] `ruff check` + `ruff format --check` clean op alle gewijzigde files
- [x] `pyright` strict mode clean op klai-knowledge-mcp + telemetry-lib

**Total**: 297 tests groen across 5 suites.

## Manual e2e (post-merge)

1. Add `https://mcp.getklai.com/mcp` as custom connector in Claude Desktop
2. Approve OAuth consent on `my.getklai.com`
3. Ask a question that should hit the org's KB
4. Verify Claude calls `search_knowledge`, gets chunks, cites with `source_url`
5. Verify VictoriaLogs / Grafana shows `caller_client_id` populated for the new traffic

## SPEC

`.moai/specs/SPEC-MCP-RETRIEVAL-001/` — research.md, spec.md (26 EARS REQs, 9 architecture decisions), plan.md (4 phases, MX-tag plan, rollout/rollback), acceptance.md (20 AC + perf + quality gates)

## Out of scope (future SPECs)

- JWT-pad voor retrieval-api van knowledge-mcp (legacy X-Internal-Secret pad werkt)
- `product_events.knowledge.queried` caller-attribution (vereist body-extension van `/retrieve`)
- `image_urls` in tool output
- `list_knowledge_bases()` discovery tool
- Per-tool / per-KB OAuth scopes (`mcp:knowledge` covers both save + search in v1)

## Deploy order

1. portal-api migration (non-blocking ALTER + post_deploy CONCURRENT index)
2. LiteLLM hook (consumes new telemetry-lib path-dep)
3. klai-knowledge-mcp (new tool)

🤖 Generated with [Claude Code](https://claude.com/claude-code)