### PR TITLE
fix(mcp): pin playwright @latest + chrome, switch seed to browser_storage_state MCP tool

### DIFF
--- a/.claude/rules/klai/pitfalls/process-rules.md
+++ b/.claude/rules/klai/pitfalls/process-rules.md
@@ -1424,10 +1424,16 @@ auth) read-only is fine — refresh the file once when Google's session
 cookies expire (~3 weeks).
 
 **The canonical answer for this use case:**
-`--isolated --storage-state ~/.claude/mcp-storageState.json`. Generate the
-file with `npx playwright codegen --save-storage=...`. This is the standard
-Playwright multi-session authentication pattern (also what `globalSetup` +
-`storageState` does in Playwright Test). Do not invent something else.
+`--isolated --storage-state ~/.claude/mcp-storageState.json`. Seed the
+storage-state file via the **in-session `browser_storage_state` MCP tool**
+(available in `@playwright/mcp >= 0.0.67`) — NOT via `npx playwright
+codegen --save-storage=...`. The codegen path looks correct in Microsoft's
+docs but is flaky on macOS (the file only writes on a specific Inspector-
+side close event; closing the browser the wrong way means no file ever
+appears). PR #354's first attempt used codegen and produced a dead-end
+that cost a full day of debugging on 2026-05-06/07. The MCP-tool seed
+path writes the file directly from the running MCP server — no external
+tooling, no Inspector window, no Ctrl+C dance.
 
 **Anti-patterns — do NOT propose any of these without re-reading this entry:**
 
@@ -1459,36 +1465,60 @@ Playwright multi-session authentication pattern (also what `globalSetup` +
 7. "Just remove all profile config and let Playwright pick its default" —
    default IS persistent `--user-data-dir`, so this re-triggers
    anti-pattern (2) from the other direction.
+8. `npx playwright codegen --save-storage=...` as the seed step on macOS.
+   The codegen process only writes the file on a specific Inspector-side
+   close event; close the browser the wrong way and the file never
+   appears. PR #354 (apr 2026) shipped this as the documented seed step
+   and lost a full week of "but it should work" debugging before the
+   2026-05-07 retry confirmed the failure mode. Use the in-session
+   `browser_storage_state` MCP tool instead.
 
 **The current working setup (do not change without strong cause):**
 
 - Primary `playwright` server in `.mcp.json` invokes
   `.claude/scripts/playwright-launcher.mjs`, which spawns
-  `npx @playwright/mcp@0.0.70 --browser chromium --isolated
+  `npx @playwright/mcp@latest --browser chrome --isolated
   --storage-state ~/.claude/mcp-storageState.json`. Headed (no `--headless`).
   Multi-session safe (each launch gets its own ephemeral profile).
-  All sessions preload the same login state.
+  All sessions preload the same login state. **Note**: on
+  `@playwright/mcp >= 0.0.74` the valid `--browser` values are
+  `chrome|firefox|webkit|msedge`. `chromium` was dropped — passing it
+  silently breaks the launcher. Use `chrome` (system Google Chrome
+  install; combined with `--isolated`, gets its own ephemeral profile
+  per session and does not collide with the user's regular Chrome).
 - Secondary `playwright-isolated` server in `.mcp.json` runs `--browser
-  chromium --isolated` with NO storage-state. Headed. For one-off CSS or
+  chrome --isolated` with NO storage-state. Headed. For one-off CSS or
   unauthenticated checks where login state would just be noise.
-- Login refresh (run when storage state is missing or Google cookies have
-  expired):
-  ```
-  npx --yes playwright codegen \
-    --save-storage="$HOME/.claude/mcp-storageState.json" \
-    --browser=chromium https://voys.getklai.com
-  ```
-  Log in to all sites you need, close the codegen window, file is written.
+- Login seed/refresh (run when `~/.claude/mcp-storageState.json` is
+  missing, or when Google cookies have expired and sessions start
+  logged-out):
+  1. With the launcher in place but no storage-state file (or after
+     deleting it), restart Claude Code so the MCP server picks up the
+     new config. Open a new Playwright MCP session — the browser starts
+     logged-out.
+  2. Have the AI `browser_navigate` to a login URL (e.g.
+     `https://voys.getklai.com`).
+  3. Log in by hand (Google SSO + 2FA), wait until you're on the
+     post-login workspace.
+  4. Have the AI call the MCP tool `browser_storage_state` — it writes
+     the current cookies + localStorage to
+     `~/.claude/mcp-storageState.json`.
+  5. Restart Claude Code so the launcher picks the new file up via
+     `--storage-state` at startup.
+  6. From now on all MCP sessions, including parallel Claude Code
+     instances, start authenticated.
 
 **Prevention — symptom → correct response:**
 
 | Symptom | Correct response | Wrong response |
 |---|---|---|
-| Sessions start logged-out | Verify `~/.claude/mcp-storageState.json` exists and is recent. Run the codegen refresh command. | Add `--user-data-dir` back (anti-pattern 2) |
+| Sessions start logged-out | Verify `~/.claude/mcp-storageState.json` exists and is recent. Re-seed via the `browser_storage_state` MCP tool (see "Login seed/refresh" above). | Add `--user-data-dir` back (anti-pattern 2); fall back to `playwright codegen --save-storage` (anti-pattern 8). |
 | `Browser is already in use` on a second session | Confirm `.mcp.json` uses `--isolated` not `--user-data-dir`. Each session must get its own ephemeral profile. | Add a slot-pool launcher (anti-pattern 6) |
 | AI cannot see what the browser is doing | Confirm no `--headless` flag in the primary server. | Tell the user to "just check the browser themselves" — defeats the point |
 | User says "iedere keer hetzelfde probleem" | Stop. Re-read this entry. Do not propose a config change before identifying which anti-pattern you are about to commit. | Propose another config edit |
-| Storage state file is hand-edited / non-standard | Re-generate via `playwright codegen --save-storage`. The file format is Playwright-defined, not yours. | Hand-edit JSON in storageState |
+| `browser_storage_state` tool not visible in current session | Tool-schema-cache is from an older `@playwright/mcp` pin. Restart Claude Code so it reloads the schema list from `@latest`. | Try `browser_evaluate` to read cookies (HttpOnly cookies are invisible) or write a homegrown seed script (anti-pattern 6 territory). |
+| `--browser chromium` rejected on launch | `@playwright/mcp >= 0.0.74` dropped `chromium` as a valid value. Use `--browser chrome`. | Pin back to `@0.0.70` (loses `browser_storage_state` tool — anti-pattern 8 territory). |
+| Storage state file is hand-edited / non-standard | Delete it, re-seed via the `browser_storage_state` MCP tool. | Hand-edit JSON in storageState |
 
 If a future @playwright/mcp version introduces auto-write-back of storage
 state on session close, the manual refresh step can be removed. Until

--- a/.claude/scripts/playwright-launcher.mjs
+++ b/.claude/scripts/playwright-launcher.mjs
@@ -2,33 +2,51 @@
 /**
  * Cross-platform Playwright MCP launcher.
  *
- * Pattern: --isolated + --storage-state (canonical Playwright multi-session
- * authentication). Each Claude Code session gets its own ephemeral Chromium
- * profile that is preloaded with login cookies/localStorage from a shared
- * storageState file. So:
+ * Pattern: `--isolated --storage-state ~/.claude/mcp-storageState.json`.
+ * Each Claude Code session gets its own ephemeral Chrome profile that is
+ * preloaded with login cookies + localStorage from the storage-state JSON.
+ * Multiple parallel Claude Code sessions are safe (no profile lock) and
+ * all start authenticated.
  *
- *   - Multiple sessions run side-by-side without profile-lock conflicts
- *   - All sessions start authenticated (Google, getklai, etc.)
- *   - Browser windows are visible (not headless)
- *   - No file-copy bookkeeping; storage-state is read-only at startup
+ * Why this pattern (May 2026, post-research):
+ *   - Microsoft has no officially-supported "parallel + shared login"
+ *     CLI option besides this. Issue #1530 (named session management)
+ *     was closed as "not planned".
+ *   - The browser extension is the alternative Microsoft pushes; we
+ *     reject it because it grants the AI full access to every other
+ *     site the user is logged in to in their daily Chrome.
+ *   - PR #346's `--user-data-dir` is single-instance, so it cannot
+ *     serve parallel sessions.
+ *   - The April 2026 attempt at this pattern (PR #354) failed because
+ *     the seed step relied on `npx playwright codegen --save-storage`,
+ *     which is flaky on macOS.
  *
- * One-time login (run when storage-state is missing or expired, ~once every
- * few weeks for Google):
+ * The seed step (May 2026):
+ *   In @playwright/mcp >= 0.0.67 there is an MCP tool
+ *   `browser_storage_state` that, when invoked from a running session,
+ *   writes the current cookies + localStorage to the storage-state
+ *   file. No external codegen, no Inspector window, no Ctrl+C dance.
  *
- *   npx --yes playwright codegen \
- *     --save-storage="$HOME/.claude/mcp-storageState.json" \
- *     --browser=chromium https://voys.getklai.com
- *
- * Log in to all sites you need, then close the browser window. The file is
- * written automatically.
+ *   1. With this launcher in place but no storage-state file yet,
+ *      open a Playwright MCP session — the browser starts logged out.
+ *   2. `browser_navigate` to a login URL, log in by hand.
+ *   3. Have the AI call `browser_storage_state` — file is written.
+ *   4. Restart Claude Code (so the launcher picks the file up at
+ *      startup via the `--storage-state` flag).
+ *   5. Refresh the same way every ~3 weeks when Google's session
+ *      cookies expire.
  *
  * Why CLI flags instead of a JSON config file:
- *   microsoft/playwright-mcp#1446 — `userDataDir` set in a JSON --config
- *   file is silently ignored on @playwright/mcp@0.0.70.
+ *   microsoft/playwright-mcp#1446 — `userDataDir` set in a JSON
+ *   --config file is silently ignored on @playwright/mcp@0.0.70.
+ *   CLI flag works correctly.
  *
- * Why bundled Chromium (no --executable-path):
- *   Brave/Chrome on Windows cannot run two simultaneous instances with
- *   different user profiles. Bundled Chromium has no such constraint.
+ * Why `--browser chrome`:
+ *   On @>=0.0.74 the valid `--browser` values are
+ *   chrome|firefox|webkit|msedge. `chromium` was dropped. `chrome`
+ *   uses the system Google Chrome installation but, combined with
+ *   `--isolated`, gets its own ephemeral profile per session — no
+ *   collision with the user's regular Chrome browser.
  */
 import { spawn } from 'child_process';
 import { homedir, platform } from 'os';
@@ -40,8 +58,8 @@ const STATE_FILE = join(homedir(), '.claude', 'mcp-storageState.json');
 
 const args = [
   '--yes',
-  '@playwright/mcp@0.0.70',
-  '--browser', 'chromium',
+  '@playwright/mcp@latest',
+  '--browser', 'chrome',
   '--isolated',
 ];
 
@@ -50,9 +68,10 @@ if (existsSync(STATE_FILE)) {
 } else {
   process.stderr.write(
     `playwright-launcher: ${STATE_FILE} not found.\n` +
-    `Run once to generate it:\n` +
-    `  npx --yes playwright codegen --save-storage="${STATE_FILE}" --browser=chromium https://voys.getklai.com\n` +
-    `Browser will start without preloaded login state.\n`
+    `Browser starts logged-out. To seed the file from inside a running\n` +
+    `MCP session: open a login URL via browser_navigate, log in by hand,\n` +
+    `then have the AI call the browser_storage_state MCP tool. Restart\n` +
+    `Claude Code afterwards so the launcher picks up the file.\n`
   );
 }
 

--- a/.mcp.json
+++ b/.mcp.json
@@ -16,19 +16,19 @@
       "env": {}
     },
     "playwright": {
-      "$comment": "Headed Chromium with shared login state across parallel Claude Code sessions. Uses --isolated + --storage-state (canonical Playwright multi-session auth). Log in once via `npx playwright codegen --save-storage=~/.claude/mcp-storageState.json --browser=chromium <url>`; every session preloads that state. No browser-lock conflicts because each session uses its own ephemeral profile. AI-driven sessions don't mutate login state, so read-only storage-state is sufficient.",
+      "$comment": "Headed Chrome with `--isolated --storage-state ~/.claude/mcp-storageState.json`. Parallel-safe (every session gets its own ephemeral profile) and all sessions start authenticated by preloading the storage-state file. Seed via the MCP tool `browser_storage_state` from inside a running session (NOT external `npx playwright codegen` — that path is flaky on macOS and was the trap in PR #354's first try). See process-rules.md::playwright-mcp-config-cycle for the full failure-mode history.",
       "type": "stdio",
       "command": "node",
       "args": [".claude/scripts/playwright-launcher.mjs"],
       "env": {}
     },
     "playwright-isolated": {
-      "$comment": "Ephemeral headed Chromium for one-off CSS/visual checks where login state is not needed. Window is visible (not headless) so you can see what is happening; profile is in-memory and discarded on close.",
+      "$comment": "Ephemeral headed Chrome for one-off CSS/visual checks where login state is not needed. Window is visible (not headless) so you can see what is happening; profile is in-memory and discarded on close. Tracks @latest — the original 0.0.70 pin caused the months-long codegen-seed failure mode (process-rules.md::playwright-mcp-config-cycle anti-pattern 8). Note: @latest dropped `--browser chromium`; valid values are chrome|firefox|webkit|msedge.",
       "type": "stdio",
       "command": "npx",
       "args": [
-        "@playwright/mcp@0.0.70",
-        "--browser", "chromium",
+        "@playwright/mcp@latest",
+        "--browser", "chrome",
         "--isolated"
       ],
       "env": {}

--- a/docs/setup/mcp-servers.md
+++ b/docs/setup/mcp-servers.md
@@ -106,8 +106,9 @@ It is **cross-platform** — all platform-specific settings live in local config
 
 No per-machine setup beyond a one-time login. The `playwright` server in `.mcp.json`
 invokes `.claude/scripts/playwright-launcher.mjs` (committed, cross-platform). The launcher
-spawns `@playwright/mcp@0.0.70` with `--browser chromium --isolated --storage-state
-~/.claude/mcp-storageState.json`. Bundled Chromium, no Brave/Chrome.
+spawns `@playwright/mcp@latest` with `--browser chrome --isolated --storage-state
+~/.claude/mcp-storageState.json`. Parallel-safe (every session gets its own ephemeral
+profile) and all sessions start authenticated by preloading the same storage-state file.
 
 ### Use case this is built for
 
@@ -116,18 +117,27 @@ Playwright MCP. You log in once; the AI takes over from there. Multiple coding s
 can run in parallel — each gets a visible browser window with the same login already
 loaded.
 
-### Why `--isolated` + `--storage-state` instead of a persistent profile
+### Why `--isolated` + `--storage-state` (and not `--user-data-dir`)
 
-A persistent Chromium profile (`--user-data-dir`) is single-instance: a second simultaneous
-session fails with `Browser is already in use`. `--isolated` gives every session its own
-ephemeral profile (no lock conflicts), and `--storage-state <file>` preloads cookies and
-localStorage at startup so the session is already authenticated. This is the canonical
-Playwright multi-session authentication pattern (also what Playwright Test does via
-`globalSetup` + `storageState`).
+A persistent `--user-data-dir` is single-instance-locked: a second concurrent
+Claude Code session that needs the same profile fails with `Browser is already
+in use`. The `--isolated --storage-state` pattern dodges that lock — every
+session gets its own ephemeral profile, all preloaded with the same login
+state at startup. This is Microsoft's recommended path for parallel + login
+without the browser extension (Issue #1530, the alternative "named session
+management" feature, was closed by Microsoft as `not planned`).
 
-Storage state is read-only at startup — nothing writes it back. That is fine for this use
-case because the AI does not log out, change passwords, or otherwise mutate auth. Refresh
-the file when Google's session cookies expire (~3 weeks).
+Storage state is read-only at startup. The AI does not log out, change
+passwords, or otherwise mutate auth, so read-only is fine. Refresh the file
+when Google's session cookies expire (~3 weeks, see seed flow below).
+
+The reason this pattern looked broken for weeks in April 2026: PR #354 used
+`npx playwright codegen --save-storage` as the seed step. On macOS that save
+only fires on a specific Inspector-side close event; if you closed the
+browser the wrong way, the file never appeared. Solved May 2026 by switching
+the seed to the in-session `browser_storage_state` MCP tool (available in
+`@playwright/mcp >= 0.0.67`), which writes the file directly from the running
+MCP server — no external tooling, no Inspector window, no Ctrl+C dance.
 
 ### Why a launcher script and not a JSON `--config` file
 
@@ -138,31 +148,24 @@ vehicle for those flags.
 
 ### One-time login (and refresh)
 
-Run this once, and again whenever Google's session cookies expire (you'll know because
-sessions start logged-out):
+1. With the launcher in place but no storage-state file yet (or after deleting
+   it for a refresh), restart Claude Code so the MCP server picks up the new
+   config. Open a new Playwright MCP session — the browser starts logged-out.
+2. Have the AI `browser_navigate` to a login URL, e.g. `https://voys.getklai.com`.
+3. Log in by hand (Google SSO + 2FA), wait until you're on the chat home.
+4. Have the AI call the MCP tool `browser_storage_state` — it writes the
+   current cookies + localStorage to `~/.claude/mcp-storageState.json`.
+5. Restart Claude Code so the launcher picks the file up via `--storage-state`.
+6. From now on all MCP sessions, including parallel Claude Code instances,
+   start authenticated.
 
-```powershell
-# Windows (PowerShell)
-npx --yes playwright codegen `
-  --save-storage="$env:USERPROFILE\.claude\mcp-storageState.json" `
-  --browser=chromium `
-  https://voys.getklai.com
-```
-
-```bash
-# macOS / Linux
-npx --yes playwright codegen \
-  --save-storage="$HOME/.claude/mcp-storageState.json" \
-  --browser=chromium \
-  https://voys.getklai.com
-```
-
-A Chromium window opens. Log in to all sites you need (Google SSO, getklai, etc.). When
-done, close the codegen window. The storage-state file is written automatically. Restart
-Claude Code; every Playwright MCP session now starts authenticated.
+Refresh the same way every ~3 weeks when Google's session cookies expire.
 
 For the full failure-mode cycle and anti-patterns to avoid, see
-`playwright-mcp-config-cycle (HIGH)` in `.claude/rules/klai/pitfalls/process-rules.md`.
+`playwright-mcp-config-cycle (HIGH)` in
+`.claude/rules/klai/pitfalls/process-rules.md` (8 anti-patterns and many
+"fixes" since April 2026 — this section is the May 2026 canonical, anchored
+on Microsoft Issue #1530's outcome).
 
 ### Starting from scratch (logged-out state)
 


### PR DESCRIPTION
## Summary

Salvages the implementation half of wip-commit `8889c19f` (which lived on `docs/audit-ti-2026-05-05` and was never landable as-is). Cherry-picks only the four MCP-relevant files; leaves the rules-tree restructure for a separate PR.

## Why

PR #354 (2026-05-05) shipped the `--isolated + --storage-state` pattern with an **external** `npx playwright codegen --save-storage` seed step. On macOS that codegen path only writes the file on a specific Inspector close event — closing the browser the wrong way means no file ever appears. Result: every Claude Code session started logged-out, forcing a Google SSO + 2FA dance on every session start. Multiple debugging sessions over April–May 2026 chased it as a config bug; it was the seed flow.

## Changes

| File | What changed |
|---|---|
| [`.claude/scripts/playwright-launcher.mjs`](.claude/scripts/playwright-launcher.mjs) | Pin `@playwright/mcp@0.0.70` → `@latest` (0.0.74). `--browser chromium` → `--browser chrome` (chromium was dropped in @>=0.0.74). Updated comment to describe the in-session `browser_storage_state` seed. |
| [`.mcp.json`](.mcp.json) | Comments updated for both `playwright` and `playwright-isolated` servers. `playwright-isolated` also moved to `@latest + chrome` for parity. |
| [`docs/setup/mcp-servers.md`](docs/setup/mcp-servers.md) | Section 3 rewrite: seed flow via `browser_storage_state` MCP tool. Common Failure Modes #5–#8 updated. |
| [`.claude/rules/klai/pitfalls/process-rules.md`](.claude/rules/klai/pitfalls/process-rules.md) | `playwright-mcp-config-cycle` updated: anti-pattern #8 added (codegen-as-seed-on-macOS). Canonical seed flow rewritten. |

## After merge — one-time seed step

Required from a **fresh Claude Code session** that has loaded the new MCP config:

1. Have the AI `browser_navigate` to a login URL (e.g. `https://voys.getklai.com`).
2. Log in by hand (Google SSO + 2FA) — last time.
3. Have the AI call the MCP tool `browser_storage_state`. It writes `~/.claude/mcp-storageState.json` directly from the running MCP server.
4. Restart Claude Code so the launcher picks the file up via `--storage-state`.
5. From then on all sessions, including parallel Claude Code instances, start authenticated.

Refresh the same way every ~3 weeks when Google session cookies expire.

## What this PR does NOT include

- The full rules-tree restructure that lived alongside this fix in `8889c19f` (87 files). That belongs in a separate PR.
- Any changes to `playwright.config.ts` (frontend e2e) — different concern.
- Any changes to the `agent-browser` CLI rules.

## Verified

- ✅ Worktree branched fresh from `origin/main` (`1727a7dd`).
- ✅ `git diff --stat`: only the 4 MCP files (133+, 81-).
- ✅ `npx @playwright/mcp@latest --help` confirms `--storage-state` and `--browser chrome` are valid flags on 0.0.74.
- ✅ Google Chrome installed at `/Applications/Google Chrome.app`.
- ⚠️ The seed step (`browser_storage_state` tool call) cannot be executed inside the existing Claude Code session that triggered this PR — that session's tool-schema cache predates the upgrade. Must be done from a session started after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)