### PR TITLE
spec(SPEC-INFRA-CADDY-CONFIG-DEPLOY-001): close Caddyfile sync gap

### DIFF
--- a/.github/workflows/caddy-validate.yml
+++ b/.github/workflows/caddy-validate.yml
@@ -42,15 +42,31 @@ jobs:
 
       - name: Validate Caddyfile syntax
         run: |
-          # Dummy env vars match the {$ADMIN_EMAIL} + {$DOMAIN}
-          # placeholders in deploy/caddy/Caddyfile. Empty tenants dir
-          # is mounted to resolve the `import /etc/caddy/tenants/*.caddyfile`
-          # glob to zero matches (Caddy 2 silently OK on no-match).
+          # Dummy env vars cover all six {$VAR} placeholders in
+          # deploy/caddy/Caddyfile. Use `--env-file` with a quoted
+          # heredoc so the bcrypt-shaped CADDY_DEV_PASSWORD_HASH (which
+          # contains literal `$` chars) is not subject to shell
+          # expansion. Empty tenants dir is mounted to resolve the
+          # `import /etc/caddy/tenants/*.caddyfile` glob to zero
+          # matches (Caddy 2 silently OK on no-match).
+          #
+          # CADDY_DEV_PASSWORD_HASH must be bcrypt-shaped — Caddy's
+          # basic_auth directive parses the hash format at validate
+          # time. The value below is a real bcrypt hash with cost 14
+          # (it never matches any password we care about; this is a
+          # validate-only credential).
           mkdir -p /tmp/empty-tenants
+          cat > /tmp/caddy-validate.env <<'EOF'
+          ADMIN_EMAIL=ci@example.com
+          DOMAIN=example.com
+          HETZNER_AUTH_API_TOKEN=validate-only-dummy-token
+          VICTORIALOGS_INGEST_TOKEN=validate-only-dummy-token
+          CADDY_DEV_USERNAME=ci-validate
+          CADDY_DEV_PASSWORD_HASH=$2a$14$8K1p/a0dqbPzNDIJKMlj3eLvhR0DWNmgKnHr0gZxhkNH88nF.gzqK
+          EOF
           docker run --rm \
+            --env-file /tmp/caddy-validate.env \
             -v "$PWD/deploy/caddy/Caddyfile:/etc/caddy/Caddyfile:ro" \
             -v "/tmp/empty-tenants:/etc/caddy/tenants:ro" \
-            -e ADMIN_EMAIL=ci@example.com \
-            -e DOMAIN=example.com \
             ghcr.io/getklai/caddy-hetzner:latest \
             caddy validate --adapter caddyfile --config /etc/caddy/Caddyfile

--- a/.github/workflows/caddy-validate.yml
+++ b/.github/workflows/caddy-validate.yml
@@ -1,0 +1,56 @@
+name: Validate Caddyfile
+
+# SPEC-INFRA-CADDY-CONFIG-DEPLOY-001 R3 — pre-merge syntax-gate.
+# Runs `caddy validate` in the same image that serves prod, so the
+# validate sees the same xcaddy plugins (Hetzner DNS, ratelimit). A
+# Caddyfile syntax error here blocks the PR before the post-merge
+# `deploy-compose.yml` workflow can sync the broken config to
+# /opt/klai/caddy/Caddyfile. Without this gate, a typo merged to main
+# would force-recreate caddy with bad config and trigger the post-
+# recreate health check (R4) failure path — recoverable but louder
+# than necessary.
+
+on:
+  pull_request:
+    paths:
+      - 'deploy/caddy/Caddyfile'
+      - 'deploy/caddy/Dockerfile'
+      - 'deploy/caddy/build.sh'
+      - '.github/workflows/caddy-validate.yml'
+
+permissions:
+  contents: read
+  packages: read
+
+env:
+  # Opt in early to Node 24 for all JS-based actions (Node 20 EOL Sept 2026)
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate Caddyfile syntax
+        run: |
+          # Dummy env vars match the {$ADMIN_EMAIL} + {$DOMAIN}
+          # placeholders in deploy/caddy/Caddyfile. Empty tenants dir
+          # is mounted to resolve the `import /etc/caddy/tenants/*.caddyfile`
+          # glob to zero matches (Caddy 2 silently OK on no-match).
+          mkdir -p /tmp/empty-tenants
+          docker run --rm \
+            -v "$PWD/deploy/caddy/Caddyfile:/etc/caddy/Caddyfile:ro" \
+            -v "/tmp/empty-tenants:/etc/caddy/tenants:ro" \
+            -e ADMIN_EMAIL=ci@example.com \
+            -e DOMAIN=example.com \
+            ghcr.io/getklai/caddy-hetzner:latest \
+            caddy validate --adapter caddyfile --config /etc/caddy/Caddyfile

--- a/.github/workflows/caddy.yml
+++ b/.github/workflows/caddy.yml
@@ -4,7 +4,14 @@ on:
   push:
     branches: [main]
     paths:
-      - 'deploy/caddy/**'
+      # SPEC-INFRA-CADDY-CONFIG-DEPLOY-001 R2 — paths reduced from
+      # `deploy/caddy/**` to image-relevant files only. Caddyfile sync
+      # moved to deploy-compose.yml so config-only edits no longer
+      # trigger a 5-10 min image rebuild. Pre-merge syntax validation
+      # of the Caddyfile is in caddy-validate.yml (R3).
+      - 'deploy/caddy/Dockerfile'
+      - 'deploy/caddy/build.sh'
+      - 'deploy/caddy/.trivyignore.yaml'
       - '.github/workflows/caddy.yml'
   workflow_dispatch:
 

--- a/.github/workflows/deploy-compose.yml
+++ b/.github/workflows/deploy-compose.yml
@@ -141,11 +141,21 @@ jobs:
               # to running within 10s. Operator's recovery is `git revert
               # + push`, which triggers another sync run that rsyncs the
               # previous Caddyfile back and force-recreates caddy.
+              #
+              # Uses `docker inspect` with a Go-template (built-in to
+              # docker, no external `jq` needed). `docker compose ps -q`
+              # resolves the container ID stably regardless of compose
+              # naming convention.
               echo "::group::Caddy post-recreate health check"
               HEALTHY=0
               for i in 1 2 3 4 5; do
                 sleep 2
-                STATUS=$(docker compose --project-directory /opt/klai ps caddy --format json 2>/dev/null | jq -r '.[0].State // "missing"')
+                CID=$(docker compose --project-directory /opt/klai ps -q caddy 2>/dev/null || true)
+                if [ -z "$CID" ]; then
+                  echo "Caddy container not found (attempt ${i}/5)"
+                  continue
+                fi
+                STATUS=$(docker inspect --format '{{.State.Status}}' "$CID" 2>/dev/null || echo "missing")
                 if [ "$STATUS" = "running" ]; then
                   echo "Caddy is running (attempt ${i})"
                   HEALTHY=1

--- a/.github/workflows/deploy-compose.yml
+++ b/.github/workflows/deploy-compose.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'deploy/docker-compose.yml'
       - 'deploy/docker-compose.override.yml'
+      - 'deploy/caddy/Caddyfile'                  # SPEC-INFRA-CADDY-CONFIG-DEPLOY-001 R1 — sync Caddyfile to bind-mount source
       - 'deploy/grafana/provisioning/**'          # SPEC-SEC-024 M4.2 — alert rule + dashboard
       - 'deploy/scripts/**'                       # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3 — compose-up wrapper + audit-orphan-snapshot
       - 'scripts/smoke-docker-socket-proxy.sh'    # SPEC-SEC-024 M4.3 — smoke-test
@@ -58,6 +59,7 @@ jobs:
             git sparse-checkout set --skip-checks \
               deploy/docker-compose.yml \
               deploy/docker-compose.override.yml \
+              deploy/caddy/Caddyfile \
               deploy/grafana/provisioning \
               deploy/scripts \
               deploy/systemd \
@@ -111,6 +113,54 @@ jobs:
             else
               echo "Grafana provisioning unchanged; using plain up -d (recreates only on service-definition diff)"
               docker compose --project-directory /opt/klai up -d grafana
+            fi
+
+            # SPEC-INFRA-CADDY-CONFIG-DEPLOY-001 R1+R4 — sync Caddyfile to
+            # bind-mount source. The compose file mounts ./caddy/Caddyfile
+            # (resolved as /opt/klai/caddy/Caddyfile) into the caddy
+            # container at /etc/caddy/Caddyfile. Without this sync, an
+            # image rebuild + container recreate via caddy.yml leaves the
+            # container reading the OLD Caddyfile from the bind-mount.
+            #
+            # Content-aware: only force-recreate when content changed
+            # (mirrors the grafana provisioning sync above). A bind-mount-
+            # only change does not trigger compose recreate via plain
+            # `up -d`. Caddy has `admin off`, so `caddy reload --config`
+            # is unavailable — container restart (~1s TLS interruption)
+            # is the canonical reload, identical to `_reload_caddy()` in
+            # portal-api provisioning. See plan.md for the full rationale.
+            mkdir -p /opt/klai/caddy
+            RSYNC_CADDY_CHANGES=$(rsync -ac --itemize-changes deploy/caddy/Caddyfile /opt/klai/caddy/Caddyfile | grep -E '^[<>*]' || true)
+            if [ -n "$RSYNC_CADDY_CHANGES" ]; then
+              echo "Caddyfile content changed:"
+              echo "$RSYNC_CADDY_CHANGES"
+              docker compose --project-directory /opt/klai up -d --force-recreate caddy
+
+              # SPEC-INFRA-CADDY-CONFIG-DEPLOY-001 R4 — post-recreate
+              # health check. Fail the workflow if caddy doesn't return
+              # to running within 10s. Operator's recovery is `git revert
+              # + push`, which triggers another sync run that rsyncs the
+              # previous Caddyfile back and force-recreates caddy.
+              echo "::group::Caddy post-recreate health check"
+              HEALTHY=0
+              for i in 1 2 3 4 5; do
+                sleep 2
+                STATUS=$(docker compose --project-directory /opt/klai ps caddy --format json 2>/dev/null | jq -r '.[0].State // "missing"')
+                if [ "$STATUS" = "running" ]; then
+                  echo "Caddy is running (attempt ${i})"
+                  HEALTHY=1
+                  break
+                fi
+                echo "Caddy state: $STATUS (attempt ${i}/5)"
+              done
+              if [ "$HEALTHY" -ne 1 ]; then
+                echo "::error::Caddy did not reach running state within 10s after recreate"
+                docker compose --project-directory /opt/klai logs --tail 50 caddy || true
+                exit 1
+              fi
+              echo "::endgroup::"
+            else
+              echo "Caddyfile unchanged; skipping caddy recreate."
             fi
 
             # SPEC-SEC-024 M4.3 — sync smoke-test script. `chmod +x` because

--- a/.moai/specs/SPEC-INFRA-CADDY-CONFIG-DEPLOY-001/acceptance.md
+++ b/.moai/specs/SPEC-INFRA-CADDY-CONFIG-DEPLOY-001/acceptance.md
@@ -1,0 +1,118 @@
+# SPEC-INFRA-CADDY-CONFIG-DEPLOY-001 — Acceptance Criteria
+
+Zeven Given/When/Then scenarios. Elke AC is mechanisch verifieerbaar
+via tool-output, exit-codes, en file-comparison.
+
+## AC-1 — Caddyfile sync vindt plaats bij main-merge
+
+- **Given** R1 is uitgevoerd (deploy-compose.yml uitgebreid met
+  `deploy/caddy/Caddyfile` paths-trigger + sparse-checkout + rsync
+  blok),
+- **When** een commit naar `main` `deploy/caddy/Caddyfile` wijzigt,
+- **Then** `gh run list --workflow deploy-compose.yml -L 1 --json
+  conclusion --jq '.[0].conclusion'` returns `"success"` binnen 5 minuten,
+  EN `ssh core-01 "sha256sum /opt/klai/caddy/Caddyfile"` matched
+  `git -C ~/Developer/Klai show HEAD:deploy/caddy/Caddyfile | sha256sum`.
+
+**Test:** trigger een no-op comment-edit op `deploy/caddy/Caddyfile`
+post-merge, runt de workflow, vergelijk hashes.
+
+## AC-2 — Container leest gesyncte Caddyfile
+
+- **Given** AC-1 hold,
+- **When** `ssh core-01 "docker exec klai-core-caddy-1 sha256sum
+  /etc/caddy/Caddyfile"` draait,
+- **Then** de hash matched die uit AC-1 (host file).
+
+**Test:** zelfde no-op comment-PR; verifieer dat de comment ook
+binnen de container zichtbaar is.
+
+## AC-3 — Image rebuild blijft uitsluitend op binary-changes triggeren
+
+- **Given** R2 is uitgevoerd (caddy.yml paths reduced),
+- **When** een PR alléén `deploy/caddy/Caddyfile` wijzigt,
+- **Then** `gh pr checks <pr>` listet `caddy / build-push` NIET als
+  een check-run; alleen `Validate Caddyfile / validate` (R3) verschijnt.
+
+**Test:** maak een PR met enkel een Caddyfile comment-toevoeging;
+inspect `gh pr checks`.
+
+## AC-4 — Pre-merge syntax validatie blokkeert kapotte Caddyfile
+
+- **Given** R3 is uitgevoerd (`caddy-validate.yml` bestaat),
+- **When** een PR een syntactisch ongeldige regel toevoegt aan
+  `deploy/caddy/Caddyfile` (bijv. `not_a_directive { broken }`),
+- **Then** `caddy-validate.yml` faalt met exit-code 1 en de PR-status
+  toont `Validate Caddyfile / validate` als `failed`. De PR kan niet
+  gemerged worden zonder admin override.
+
+**Test:** experimentele PR met geforceerde syntax-fout; assertie via
+`gh pr checks` op `failure` status.
+
+## AC-5 — Geldige Caddyfile passeert pre-merge validate
+
+- **Given** R3 is uitgevoerd,
+- **When** een PR een geldige wijziging toevoegt (bijv. extra header
+  in een handle-block),
+- **Then** `caddy-validate.yml` exit-code 0; PR-check `success`.
+
+**Test:** PR met deze SPEC zelf (Caddyfile is ongewijzigd, validate
+moet passeren).
+
+## AC-6 — Post-recreate health check vangt failures
+
+- **Given** R4 is uitgevoerd,
+- **When** een hypothetische Caddyfile change leidt tot een container
+  die niet binnen 10s `running` is (bijv. een runtime-error die de
+  validate niet vangt),
+- **Then** de `deploy-compose.yml` workflow faalt met exit-code 1
+  en de log dump bevat de laatste 50 caddy-regels via
+  `docker compose ... logs --tail 50 caddy`.
+
+**Test:** lokaal handmatig met een gefabriceerde fault. Niet in CI
+eisbaar — verificatie van het code-pad in de YAML-diff is voldoende
+voor merge.
+
+## AC-7 — Tenant Caddyfile mechanisme blijft ongewijzigd
+
+- **Given** R5 is gerespecteerd (geen wijzigingen aan
+  `_write_tenant_caddyfile`, `_reload_caddy`, of de `caddy-tenants`
+  volume mounts),
+- **When** een nieuwe tenant geprovisioned wordt na deze SPEC's merge
+  (test-fixture in dev-stack),
+- **Then** alle bestaande tests groen blijven:
+  - `tests/services/provisioning/test_infrastructure.py
+    ::test_writes_caddyfile_with_correct_content`
+  - `tests/services/provisioning/test_infrastructure.py
+    ::test_restarts_caddy_container`
+  - `tests/services/provisioning/test_orchestrator.py
+    ::test_caddy_lock_exists`
+  - `tests/services/provisioning/test_orchestrator.py
+    ::test_caddy_lock_is_module_level_singleton`
+  - `tests/services/provisioning/test_orchestrator.py
+    ::test_compensate_caddy_is_noop_when_not_written`
+
+**Test:** `cd klai-portal/backend && uv run pytest -k "caddy"` runt
+groen op de feature branch (geen testfile changed).
+
+## Verification commands (post-merge)
+
+```bash
+# AC-1: workflow groen
+gh run list --workflow deploy-compose.yml -L 1 \
+  --json conclusion --jq '.[0].conclusion'
+# expect: "success"
+
+# AC-1+2: file synced + container sees it
+LOCAL=$(git show main:deploy/caddy/Caddyfile | sha256sum | awk '{print $1}')
+HOST=$(ssh core-01 "sha256sum /opt/klai/caddy/Caddyfile" | awk '{print $1}')
+CTR=$(ssh core-01 "docker exec klai-core-caddy-1 sha256sum /etc/caddy/Caddyfile" | awk '{print $1}')
+[ "$LOCAL" = "$HOST" ] && [ "$HOST" = "$CTR" ] && echo "PASS" || echo "FAIL"
+
+# AC-3: caddy.yml didn't run on Caddyfile-only PR
+gh pr checks <pr-number> --json name --jq '.[].name' | grep -c "caddy / build-push"
+# expect: 0
+
+# AC-7: provisioning tests still green
+cd klai-portal/backend && uv run pytest -k "caddy" -v
+```

--- a/.moai/specs/SPEC-INFRA-CADDY-CONFIG-DEPLOY-001/plan.md
+++ b/.moai/specs/SPEC-INFRA-CADDY-CONFIG-DEPLOY-001/plan.md
@@ -1,0 +1,229 @@
+# SPEC-INFRA-CADDY-CONFIG-DEPLOY-001 — Implementation Plan
+
+## Strategie
+
+Eén PR. Drie file-changes (één new, twee edited). Geen runtime code
+geraakt; alleen CI workflow YAML.
+
+## Files
+
+### NEW: `.github/workflows/caddy-validate.yml`
+
+PR-trigger workflow die `caddy validate` runt tegen de Caddyfile in
+een Docker container. Implementeert R3.
+
+Volledige inhoud:
+
+```yaml
+name: Validate Caddyfile
+
+on:
+  pull_request:
+    paths:
+      - 'deploy/caddy/Caddyfile'
+      - 'deploy/caddy/Dockerfile'
+      - 'deploy/caddy/build.sh'
+      - '.github/workflows/caddy-validate.yml'
+
+permissions:
+  contents: read
+  packages: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate Caddyfile syntax
+        run: |
+          # SPEC-INFRA-CADDY-CONFIG-DEPLOY-001 R3
+          # Run `caddy validate` in the same image that serves prod, so
+          # the validate sees the same xcaddy plugins (Hetzner DNS,
+          # ratelimit). Dummy env vars match the {$ADMIN_EMAIL} +
+          # {$DOMAIN} placeholders. Empty tenants dir is mounted to
+          # resolve the `import /etc/caddy/tenants/*.caddyfile` glob to
+          # zero matches (Caddy 2 silently OK on no-match).
+          mkdir -p /tmp/empty-tenants
+          docker run --rm \
+            -v "$PWD/deploy/caddy/Caddyfile:/etc/caddy/Caddyfile:ro" \
+            -v "/tmp/empty-tenants:/etc/caddy/tenants:ro" \
+            -e ADMIN_EMAIL=ci@example.com \
+            -e DOMAIN=example.com \
+            ghcr.io/getklai/caddy-hetzner:latest \
+            caddy validate --adapter caddyfile --config /etc/caddy/Caddyfile
+```
+
+### EDIT: `.github/workflows/caddy.yml`
+
+Paths-set reduceren — `deploy/caddy/**` wordt te breed; we willen
+alleen image-relevante triggers. Implementeert R2.
+
+Diff (paths-blok):
+
+```diff
+ on:
+   push:
+     branches: [main]
+     paths:
+-      - 'deploy/caddy/**'
++      - 'deploy/caddy/Dockerfile'
++      - 'deploy/caddy/build.sh'
++      - 'deploy/caddy/.trivyignore.yaml'
+       - '.github/workflows/caddy.yml'
+   workflow_dispatch:
+```
+
+Geen andere wijzigingen aan dit bestand. De `Deploy to core-01` step
+blijft `compose-up.sh caddy` aanroepen; dat is correct voor het
+service-definition / image-pull pad.
+
+### EDIT: `.github/workflows/deploy-compose.yml`
+
+Paths uitbreiden, sparse-checkout uitbreiden, en de rsync + recreate +
+health check toevoegen voor Caddyfile. Implementeert R1 + R4.
+
+Diff 1 — paths-trigger:
+
+```diff
+ on:
+   push:
+     branches: [main]
+     paths:
+       - 'deploy/docker-compose.yml'
+       - 'deploy/docker-compose.override.yml'
++      - 'deploy/caddy/Caddyfile'                  # SPEC-INFRA-CADDY-CONFIG-DEPLOY-001 R1
+       - 'deploy/grafana/provisioning/**'
+       - 'deploy/scripts/**'
+       - 'scripts/smoke-docker-socket-proxy.sh'
+       - '.github/workflows/deploy-compose.yml'
+```
+
+Diff 2 — sparse-checkout (binnen het ssh-action `script:` blok):
+
+```diff
+             git sparse-checkout set --skip-checks \
+               deploy/docker-compose.yml \
+               deploy/docker-compose.override.yml \
++              deploy/caddy/Caddyfile \
+               deploy/grafana/provisioning \
+               deploy/scripts \
+               deploy/systemd \
+               scripts
+```
+
+Diff 3 — nieuwe rsync + recreate + health check blok, geplaatst NA de
+grafana provisioning sync (regel ~114) en VOOR de smoke-test sync
+(regel ~119):
+
+```bash
+# SPEC-INFRA-CADDY-CONFIG-DEPLOY-001 R1+R4 — sync Caddyfile to bind-mount source.
+#
+# The compose file mounts ./caddy/Caddyfile (resolved as
+# /opt/klai/caddy/Caddyfile) into the caddy container at
+# /etc/caddy/Caddyfile. Without this sync, an image rebuild + container
+# recreate via caddy.yml leaves the container reading the OLD Caddyfile
+# from the bind-mount.
+#
+# Content-aware: only force-recreate when content changed (mirrors
+# grafana provisioning sync above). A bind-mount-only change does not
+# trigger compose recreate via plain `up -d`. Caddy has `admin off`,
+# so `caddy reload --config` is not available — container restart
+# (~1s TLS interruption) is the canonical reload, identical to
+# `_reload_caddy()` in portal-api provisioning.
+mkdir -p /opt/klai/caddy
+RSYNC_CADDY_CHANGES=$(rsync -ac --itemize-changes deploy/caddy/Caddyfile /opt/klai/caddy/Caddyfile | grep -E '^[<>*]' || true)
+if [ -n "$RSYNC_CADDY_CHANGES" ]; then
+  echo "Caddyfile content changed:"
+  echo "$RSYNC_CADDY_CHANGES"
+  docker compose --project-directory /opt/klai up -d --force-recreate caddy
+
+  # SPEC-INFRA-CADDY-CONFIG-DEPLOY-001 R4 — post-recreate health check.
+  # Fail the workflow if caddy doesn't return to running within 10s.
+  # The operator's recovery is `git revert + push`, which triggers
+  # another sync run that rsyncs the previous Caddyfile back.
+  echo "::group::Caddy post-recreate health check"
+  HEALTHY=0
+  for i in 1 2 3 4 5; do
+    sleep 2
+    STATUS=$(docker compose --project-directory /opt/klai ps caddy --format json 2>/dev/null | jq -r '.[0].State // "missing"')
+    if [ "$STATUS" = "running" ]; then
+      echo "Caddy is running (attempt ${i})"
+      HEALTHY=1
+      break
+    fi
+    echo "Caddy state: $STATUS (attempt ${i}/5)"
+  done
+  if [ "$HEALTHY" -ne 1 ]; then
+    echo "::error::Caddy did not reach running state within 10s after recreate"
+    docker compose --project-directory /opt/klai logs --tail 50 caddy || true
+    exit 1
+  fi
+  echo "::endgroup::"
+else
+  echo "Caddyfile unchanged; skipping caddy recreate."
+fi
+```
+
+## Test plan
+
+### Pre-merge (in PR CI)
+
+- T1: `caddy-validate.yml` SHALL run en groen worden op deze PR.
+  De Caddyfile is hier ongewijzigd, dus syntax-validate moet passeren.
+- T2: `caddy.yml` SHALL NIET runnen op deze PR. Bevestigen via
+  `gh pr checks` — het mag niet listed zijn (paths matched niet).
+- T3: `deploy-compose.yml` SHALL NIET runnen op deze PR (push-only,
+  not pull_request).
+
+### Post-merge (verificatie procedure)
+
+- V1: Direct na merge: `gh run list --workflow deploy-compose.yml -L 1`
+  toont de run als `success`.
+- V2: `ssh core-01 "diff -q /opt/klai/caddy/Caddyfile <(curl -fsSL
+  https://raw.githubusercontent.com/GetKlai/klai/main/deploy/caddy/Caddyfile)"`
+  returns 0.
+- V3: Open een opvolg-PR die een onschuldige comment toevoegt aan
+  `deploy/caddy/Caddyfile`, merge naar main, en herhaal V1+V2. De
+  zojuist gewijzigde regel SHALL nu in `/opt/klai/caddy/Caddyfile`
+  EN in `docker exec klai-core-caddy-1 cat /etc/caddy/Caddyfile` staan.
+
+### Rollback plan
+
+`git revert <merge-sha> + git push` — dit hertriggert
+`deploy-compose.yml`, dat de oude Caddyfile rsynct + force-recreates.
+Geen handmatige interventie nodig op core-01.
+
+## Quality gates
+
+- YAML lint: `actionlint .github/workflows/*.yml`
+- Plan compleet: SPEC + plan + acceptance + research aanwezig in
+  `.moai/specs/SPEC-INFRA-CADDY-CONFIG-DEPLOY-001/`.
+- Geen runtime/code regressies: deze SPEC raakt geen Python / TS / Go
+  code, geen migrations, geen tests-die-bestaande-symbols-aanraken.
+
+## Out-of-scope follow-ups
+
+Deze SPEC houdt het strikt bij de drie file-changes. Volgende
+mogelijke verbeteringen die expliciet NIET in deze PR landen:
+
+1. `compose-up.sh` uitbreiden met een `--force-recreate` flag zodat
+   ook deze pad door de wrapper gaat (nu duplicaat `docker compose
+   ... up -d --force-recreate` direct, identiek aan grafana). Kleine
+   refactor; aparte SPEC.
+2. Image-baked Caddyfile als secondary safety net (multiple-source-of-
+   truth schade groter dan baten — niet doen).
+3. Caddy admin-API enable + `caddy reload` ipv container restart —
+   security-trade-off die buiten dit SPEC valt.
+4. `actionlint` als verplichte CI-check op alle workflow-changes —
+   waardevol maar bredere scope.

--- a/.moai/specs/SPEC-INFRA-CADDY-CONFIG-DEPLOY-001/research.md
+++ b/.moai/specs/SPEC-INFRA-CADDY-CONFIG-DEPLOY-001/research.md
@@ -1,0 +1,259 @@
+# SPEC-INFRA-CADDY-CONFIG-DEPLOY-001 — Research
+
+## 1. Het gat (huidige staat)
+
+### 1.1 caddy.yml workflow (post-merge image rebuild)
+
+`.github/workflows/caddy.yml` triggert op:
+```yaml
+push:
+  branches: [main]
+  paths:
+    - 'deploy/caddy/**'              # te breed
+    - '.github/workflows/caddy.yml'
+```
+
+Deploy step:
+```yaml
+- name: Deploy to core-01
+  uses: appleboy/ssh-action@v1
+  ...
+  script: |
+    docker pull ghcr.io/getklai/caddy-hetzner:latest
+    /opt/klai/scripts/compose-up.sh caddy   # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3
+```
+
+Geen sync-stap voor de Caddyfile zelf. Dat is het gat.
+
+### 1.2 Compose mount
+
+`deploy/docker-compose.yml`:
+```yaml
+caddy:
+  image: ghcr.io/getklai/caddy-hetzner:latest
+  volumes:
+    - ./caddy/Caddyfile:/etc/caddy/Caddyfile      # bind-mount HOST
+    - caddy-tenants:/etc/caddy/tenants            # named volume
+    - caddy-data:/data
+    - caddy-config:/config
+    - /opt/klai/caddy-logs:/var/log/caddy
+```
+
+`./caddy/Caddyfile` resolved via compose's CWD `/opt/klai/`, dus
+host-pad is `/opt/klai/caddy/Caddyfile`. Dit pad wordt door geen
+enkele workflow gepopuleerd of geüpdatet — alleen handmatig via scp.
+
+### 1.3 Dockerfile
+
+```dockerfile
+FROM caddy:2.11.2-alpine
+RUN apk update && apk upgrade --no-cache nghttp2 nghttp2-libs
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy
+```
+
+Geen `COPY Caddyfile`. De Caddyfile is puur een bind-mount in runtime.
+Image-baked is op dit moment fysiek niet geïmplementeerd.
+
+### 1.4 Caddyfile globals
+
+`deploy/caddy/Caddyfile`:
+```caddyfile
+{
+    email {$ADMIN_EMAIL}
+    admin off                  # ← Admin API uit; reload via API niet mogelijk
+    ...
+}
+```
+
+`admin off` is de canonieke Klai-config. Bevestigd in
+`klai-portal/backend/app/services/provisioning/infrastructure.py
+::_reload_caddy`:
+```python
+def _reload_caddy() -> None:
+    """admin off disables the Admin API so caddy reload cannot work.
+    Restart is the correct approach — ~1s TLS interruption,
+    acceptable at current scale."""
+    client = docker.from_env()
+    caddy = client.containers.get(settings.caddy_container_name)
+    caddy.restart(timeout=10)
+```
+
+Implicatie: het "fast config reload" voordeel van image-baked + admin-
+API valt voor Klai weg. Container-recreate is sowieso de reload-route.
+
+## 2. Bestaande precedent: Grafana provisioning sync
+
+`.github/workflows/deploy-compose.yml` heeft het gewenste patroon al
+voor Grafana (toegevoegd in SPEC-OBS-001 Phase C):
+
+```bash
+mkdir -p /opt/klai/grafana/provisioning
+RSYNC_PROV_CHANGES=$(rsync -ac --itemize-changes deploy/grafana/provisioning/ /opt/klai/grafana/provisioning/ | grep -E '^[<>*]' || true)
+if [ -n "$RSYNC_PROV_CHANGES" ]; then
+  echo "Grafana provisioning content changed:"
+  echo "$RSYNC_PROV_CHANGES"
+  docker compose --project-directory /opt/klai up -d --force-recreate grafana
+else
+  echo "Grafana provisioning unchanged; using plain up -d ..."
+  docker compose --project-directory /opt/klai up -d grafana
+fi
+```
+
+Belangrijke observaties:
+- `rsync -ac --itemize-changes` gebruikt content-checksums (`-c`),
+  niet mtime. Een fresh git clone op core-01 heeft willekeurige mtime;
+  zonder `-c` zou elke run "veranderd" rapporteren.
+- `--force-recreate` is nodig voor bind-mount content changes; plain
+  `up -d` is dan een no-op.
+- Direct `docker compose ... --force-recreate` ipv `compose-up.sh`
+  bypass'ed de SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3 wrapper.
+  Trade-off geaccepteerd in Grafana-precedent; dezelfde logic geldt
+  voor Caddy.
+
+## 3. Industry standards onderzocht
+
+### 3.1 Image-baked Caddyfile (school 1)
+
+Voorkomt op kubernetes + GitOps stacks (ArgoCD, Flux) waar de image-
+hash de single source of truth is voor "deployed config".
+
+Pros bij Klai:
+- Volledig reproduceerbaar (image == config + binary).
+- Trivy scan dekt ook config-syntax indirect (via build).
+
+Cons bij Klai:
+- Caddy `admin off` policy: geen `caddy reload` voordeel.
+- Tenant Caddyfiles MOETEN extern blijven (volume, runtime door
+  portal-api geschreven). Resultaat: split tussen image-baked main
+  Caddyfile en volume-baked tenant Caddyfiles. Inconsistent mental
+  model.
+- Image rebuild voor elke comment-toevoeging is 5-10 minuten waste.
+- Env vars (`{$ADMIN_EMAIL}`, `{$DOMAIN}`) MOETEN nog steeds runtime
+  geleverd worden via `.env` — image-baked verlost niet van runtime
+  config-injection.
+
+Conclusie: voor Klai meer kosten dan baten.
+
+### 3.2 External config + sync (school 2)
+
+Standaard patroon op single-host docker-compose deploys met CI-
+controlled config files. Bekend van bv. nginx/traefik deploys op
+DigitalOcean/Hetzner stacks.
+
+Pros bij Klai:
+- Identiek patroon aan Grafana provisioning (precedent bestaat,
+  bewezen stabiel sinds april 2026).
+- Snel (rsync ~30s vs 5-10 min image rebuild).
+- Tenant Caddyfile architectuur is uniform extern (volume) →
+  consistente mental model.
+- Image lifecycle ontkoppeld van config lifecycle (Renovate driven
+  upgrades vs daily-config-tweaks).
+
+Cons:
+- Sync stap is een moving part (kan falen).
+- Reload-failure mode moet expliciet afgedekt (R4 health check).
+- Bind-mount-only changes triggeren geen recreate via plain `up -d`
+  → R1 expliciet `--force-recreate`.
+
+Conclusie: aansluiten bij bestaande precedent. Trade-offs zijn
+hanteerbaar via R3 (validate) + R4 (health check).
+
+### 3.3 Hybride (image-baked + Admin API reload)
+
+Niet onderzocht voor Klai — `admin off` is bewust beleid (security:
+expose admin endpoint = risk surface vergroten). Een hybride zou een
+SPEC over admin-API expose vereisen, separate scope.
+
+## 4. Tenant Caddyfile mechanisme (verkenning)
+
+`klai-portal/backend/app/services/provisioning/infrastructure.py
+::_write_tenant_caddyfile`:
+```python
+def _write_tenant_caddyfile(slug: str) -> None:
+    domain = settings.domain
+    tenants_path = Path(settings.caddy_tenants_path)
+    tenants_path.mkdir(parents=True, exist_ok=True)
+    content = f"""# Tenant: {slug}
+chat-{slug}.{domain} {{
+    ...
+    reverse_proxy librechat-{slug}:3080
+}}
+"""
+    tenant_file = tenants_path / f"{slug}.caddyfile"
+    tenant_file.write_text(content)
+```
+
+- `settings.caddy_tenants_path` resolved naar `/caddy/tenants` in de
+  portal-api container.
+- portal-api heeft `caddy-tenants:/caddy/tenants` mount.
+- caddy heeft `caddy-tenants:/etc/caddy/tenants` mount.
+- Hoofd-Caddyfile importeert via `import /etc/caddy/tenants/*.caddyfile`.
+
+Architectuur is zelf-besloten en runtime. Sync van een statische
+versie via CI is hier ongewenst (per-tenant bestanden, dynamic). R5
+expliciet out-of-scope.
+
+## 5. Caddy validate semantiek
+
+`caddy validate --adapter caddyfile --config <file>` parsed het bestand,
+expandeert env-vars (`{$VAR}` → empty string of env-value), en
+faalt op syntax fouten. Vereist:
+
+- Caddy binary met dezelfde xcaddy plugins als prod (Hetzner DNS,
+  ratelimit) — anders weigert validate plugin-directives. Daarom
+  validate via de prod-image (`ghcr.io/getklai/caddy-hetzner:latest`).
+- Niet-resolvbare `import /path/*.caddyfile` met geen-matches: Caddy
+  2 silently OK. Bevestigd in Caddy v2.7+ source en docs.
+  Mitigation: mount expliciet een lege tmp-dir om semantiek te
+  pinnen.
+
+## 6. Workflow-trigger specifieke overwegingen
+
+### `caddy.yml` blijft op `push: branches: [main]`
+
+Image build + push is post-merge. PR-side validatie van Dockerfile
+gebeurt niet via deze workflow. Trivy scan (post-build) is een
+afzonderlijke job; gate-functie ontbreekt nu pre-merge. Niet in scope
+van deze SPEC.
+
+### `caddy-validate.yml` op `pull_request:`
+
+Pre-merge syntax-gate. Triggert ook op Dockerfile/build.sh changes
+(plugin-removal kan bestaande Caddyfile breken). Trade-off: ~30s
+extra CI per PR die de paths raakt. Acceptabel.
+
+### `deploy-compose.yml` op `push: branches: [main]`
+
+Sync-only, post-merge. Geen pre-merge gate; daar dient
+`caddy-validate.yml` voor. Health check (R4) draait wel post-merge,
+faalt CI als caddy niet recover. Operator's recovery: `git revert`.
+
+## 7. Failure modes overwogen
+
+| Mode | Detection | Response |
+|---|---|---|
+| Caddyfile syntax error | `caddy-validate.yml` (R3) pre-merge | PR check fails, blokkeert merge |
+| Sync to host fails (rsync error) | exit-code in CI | Workflow fails, geen container-restart, oude config blijft draaien |
+| Caddy crash na recreate | R4 health check (5x 2s loop) | Workflow fails, log-dump, operator runs `git revert` |
+| Caddy alive maar verkeerde config (semantically wrong) | Externe Kuma uptime monitor | Buiten SPEC scope; bestaande alert-stack |
+| Race tussen `caddy.yml` en `deploy-compose.yml` | n.v.t. | Beiden eindigen op `up -d`-style; laatste wint, max ~2s downtime |
+| `:latest` validate-image vs deploy-image drift | n.v.t. | Window is 1 PR; klein risico geaccepteerd |
+
+## 8. Sources
+
+- `.github/workflows/caddy.yml` (huidige workflow)
+- `.github/workflows/deploy-compose.yml` (Grafana precedent)
+- `deploy/caddy/Dockerfile` (image-baked status)
+- `deploy/caddy/Caddyfile` (`admin off` directive)
+- `deploy/docker-compose.yml` (mount config)
+- `klai-portal/backend/app/services/provisioning/infrastructure.py`
+  `_write_tenant_caddyfile`, `_reload_caddy` (tenant mechanisme)
+- `.claude/rules/klai/pitfalls/process-rules.md`
+  `docker-compose-restart-vs-recreate (CRIT)` — `up -d --force-recreate`
+  vs `restart` semantiek
+- SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3 — `compose-up.sh` als
+  canonieke wrapper
+- SPEC-OBS-001 Phase C — content-aware Grafana provisioning sync
+  patroon
+- Caddy v2 docs — `import` met glob, `caddy validate` semantiek,
+  `admin off`

--- a/.moai/specs/SPEC-INFRA-CADDY-CONFIG-DEPLOY-001/spec.md
+++ b/.moai/specs/SPEC-INFRA-CADDY-CONFIG-DEPLOY-001/spec.md
@@ -1,0 +1,233 @@
+---
+id: SPEC-INFRA-CADDY-CONFIG-DEPLOY-001
+version: "0.1.0"
+status: ready-for-implementation
+created: "2026-05-07"
+updated: "2026-05-07"
+author: MoAI
+priority: high
+issue_number: 0
+---
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 0.1.0 | 2026-05-07 | MoAI | Initial. Closes the Caddyfile sync gap discovered during SPEC-MCP-AUTH-001. |
+
+# SPEC-INFRA-CADDY-CONFIG-DEPLOY-001 — Sluit de Caddyfile sync gap
+
+## Overview
+
+Vandaag tijdens SPEC-MCP-AUTH-001 ontdekt: `.github/workflows/caddy.yml`
+rebuildt de `caddy-hetzner` Docker image bij wijzigingen onder
+`deploy/caddy/**` en recreate de container, maar geen workflow synct
+`deploy/caddy/Caddyfile` naar de bind-mount source op
+`/opt/klai/caddy/Caddyfile`. De Dockerfile heeft geen `COPY Caddyfile`
+— de file zit puur als bind-mount in de runtime. Resultaat: een
+Caddyfile-wijziging die naar `main` merget bereikt nooit de draaiende
+Caddy-container, totdat iemand het bestand handmatig scp't. Dat is
+gebeurd vanmiddag en het schendt de just-gecodificeerde
+`no-docker-cp-for-permanent-fixes` regel.
+
+Deze SPEC sluit het gat met **één PR**, geen multi-phase rollout.
+Aanpak: external config + sync, identiek aan de bestaande Grafana
+provisioning sync in `deploy-compose.yml` (SPEC-OBS-001 Phase C). Image
+rebuild blijft bij `caddy.yml` voor binary-changes; config-sync gaat
+naar `deploy-compose.yml` voor Caddyfile-only changes.
+
+Tenant Caddyfiles (`caddy/tenants/*.caddyfile`, runtime geschreven door
+portal-api `_write_tenant_caddyfile()` naar de `caddy-tenants` Docker
+named volume) blijven **out-of-scope**. Hun volume + restart-on-write
+mechanisme is autonoom en werkt — mengen vergroot blast radius zonder
+ROI.
+
+## Environment
+
+- **Affected workflow files:**
+  - `.github/workflows/caddy.yml` — paths-trigger reduce (Caddyfile uit
+    de set; alleen Dockerfile/build.sh/.trivyignore.yaml + workflow zelf
+    triggeren image rebuild).
+  - `.github/workflows/deploy-compose.yml` — paths-trigger uitbreiden
+    met `deploy/caddy/Caddyfile`; sparse-checkout uitbreiden; rsync +
+    content-aware recreate-block toevoegen, identiek patroon aan de
+    bestaande grafana provisioning sync.
+  - `.github/workflows/caddy-validate.yml` — NIEUW. PR-trigger op
+    `deploy/caddy/**`; runt `caddy validate` in een
+    `ghcr.io/getklai/caddy-hetzner:latest` container met de Caddyfile
+    bind-gemount. Faalt op syntax errors vóór merge.
+
+- **Affected files (none modified, only referenced):**
+  - `deploy/caddy/Caddyfile` — wordt voortaan via `deploy-compose.yml`
+    gesynct; geen wijziging aan inhoud zelf in deze SPEC.
+  - `deploy/caddy/Dockerfile` — ongewijzigd; image rebuild keten blijft
+    in `caddy.yml`.
+  - `klai-portal/backend/app/services/provisioning/infrastructure.py`
+    `_write_tenant_caddyfile` + `_reload_caddy` — ongewijzigd. Tenant
+    Caddyfile mechanisme valt buiten scope.
+  - `deploy/scripts/compose-up.sh` (klai-infra) — ongewijzigd. SPEC
+    gebruikt direct `docker compose up -d --force-recreate caddy` voor
+    de bind-mount-content-only recreate path, identiek aan
+    grafana-precedent. `compose-up.sh` blijft de standaard voor de
+    service-definition path elders in `caddy.yml`.
+
+- **Affected production paths on core-01:**
+  - `/opt/klai/caddy/Caddyfile` — bind-mount source. Wordt voortaan
+    automatisch door CI bijgewerkt.
+
+## Assumptions
+
+- A1: De Grafana provisioning sync in `deploy-compose.yml` (SPEC-OBS-001
+  Phase C) werkt productie-stabiel sinds april 2026 en is daarmee een
+  bewezen patroon om te kopiëren.
+- A2: Caddy's `admin off` in de Caddyfile blijft beleid. Daardoor is
+  `caddy reload --config` via Admin API geen optie; container-recreate
+  (~1s TLS-onderbreking) is de enige reload-route. Die is acceptabel
+  bij Klai's huidige schaal — bevestigd in de comment van `_reload_caddy`.
+- A3: De Caddy image bevat `caddy validate` als CLI-subcommand, en
+  validatie tegen een Caddyfile met ongeresolvde `{$ADMIN_EMAIL}` /
+  `{$DOMAIN}` env-vars werkt (vars worden tot lege strings of
+  ge-injecteerde dummy-vars).
+- A4: De `import /etc/caddy/tenants/*.caddyfile` directive met een
+  glob die niets matcht (lege `tenants/` dir bij validate) is in
+  Caddy 2.x silently OK — niet een validate-fout. Komt overeen met
+  Caddy 2 docs.
+- A5: `compose-up.sh` (REQ-3 in SPEC-INFRA-CONTAINER-HYGIENE-001) is
+  geïnstalleerd op core-01 en blijft de standaard voor service-deploys.
+  Deze SPEC bypassed het alleen voor de `--force-recreate` pad in
+  `deploy-compose.yml`, identiek aan grafana, niet in `caddy.yml`.
+- A6: `ghcr.io/getklai/caddy-hetzner:latest` blijft beschikbaar als
+  validatie-image. De PR-validate workflow heeft `packages: read` permissie
+  om die te pullen.
+
+## Requirements
+
+### R1 — Ubiquitous: `deploy/caddy/Caddyfile` veranderingen syncen automatisch naar `/opt/klai/caddy/Caddyfile`
+
+WHEN een commit naar `main` wijzigingen bevat aan `deploy/caddy/Caddyfile`,
+THEN binnen één GitHub Actions run:
+
+1. `.github/workflows/deploy-compose.yml` SHALL triggeren.
+2. Het workflow SHALL via `git sparse-checkout` op core-01 het
+   bijgewerkte bestand binnenhalen samen met de bestaande compose +
+   grafana provisioning paden.
+3. `rsync -ac --itemize-changes deploy/caddy/Caddyfile
+   /opt/klai/caddy/Caddyfile` SHALL het bestand bijwerken EN de set van
+   gewijzigde files rapporteren via stdout.
+4. Indien het rsync diff niet-leeg is, SHALL de workflow
+   `docker compose --project-directory /opt/klai up -d --force-recreate caddy`
+   uitvoeren om de container te recreaten met de nieuwe Caddyfile.
+5. Indien het rsync diff leeg is (de gesyncte file matched al; gebeurt
+   bij workflow_dispatch zonder content-change), SHALL de workflow
+   `up -d` zónder `--force-recreate` runnen (no-op voor
+   bind-mount-only path).
+
+### R2 — Ubiquitous: Image-rebuild blijft gescheiden van config-sync
+
+`.github/workflows/caddy.yml` SHALL na deze SPEC alléén triggeren op
+binary- of image-relevante wijzigingen:
+
+```yaml
+paths:
+  - 'deploy/caddy/Dockerfile'
+  - 'deploy/caddy/build.sh'
+  - 'deploy/caddy/.trivyignore.yaml'
+  - '.github/workflows/caddy.yml'
+```
+
+`deploy/caddy/Caddyfile` SHALL NIET in deze paths-set staan. Resultaat:
+een Caddyfile-only PR triggert geen image rebuild (5-10 min besparing
+per config-edit) en de image push frequency daalt naar de werkelijke
+binary-upgrade cadans (Renovate driven).
+
+### R3 — Event-driven: PR-trigger pre-merge Caddyfile validatie
+
+WHEN een Pull Request files onder `deploy/caddy/**` raakt, THEN
+`.github/workflows/caddy-validate.yml` SHALL automatisch draaien en:
+
+1. De Caddyfile bind-mounten in een
+   `ghcr.io/getklai/caddy-hetzner:latest` container.
+2. `caddy validate --adapter caddyfile --config /etc/caddy/Caddyfile`
+   uitvoeren met dummy `ADMIN_EMAIL=ci@example.com` en
+   `DOMAIN=example.com` env-vars.
+3. Een lege `/etc/caddy/tenants` directory mounten zodat de
+   `import /etc/caddy/tenants/*.caddyfile` glob-resolve geen onverwacht
+   bestand inleest.
+4. Bij niet-zero exit-code SHALL de PR-status `failed` zijn (vóór
+   merge). Bij zero exit-code SHALL de status `success` zijn.
+
+Deze workflow vangt 99% van syntax fouten vóór merge en daarmee voordat
+de sync uit R1 ze naar productie kan brengen.
+
+### R4 — Ubiquitous: Post-recreate health check
+
+NA de `--force-recreate caddy` actie uit R1, SHALL de workflow:
+
+1. Tot 5 keer met 2 seconden interval `docker compose ... ps caddy` runnen
+   en de `State` veld inspecteren.
+2. Op `running` (of, indien een healthcheck gedefinieerd is, `healthy`)
+   doorgaan naar de volgende stap.
+3. Indien na 10 seconden de container niet `running` is, SHALL de
+   workflow `::error::` uitsturen, de laatste 50 caddy log-regels
+   dumpen via `docker compose ... logs --tail 50 caddy`, en met
+   exit-code 1 falen.
+
+Een gefaalde health check in CI is het signaal voor de operator om een
+`git revert` te triggeren — de volgende workflow-run rsynct dan de
+oude Caddyfile terug en force-recreates Caddy opnieuw.
+
+### R5 — Out-of-scope: tenant Caddyfile mechanisme
+
+Tenant Caddyfiles (`*.caddyfile` in de `caddy-tenants` Docker named
+volume, runtime geschreven door
+`klai-portal/backend/app/services/provisioning/infrastructure.py
+::_write_tenant_caddyfile`) SHALL NIET door deze SPEC geraakt worden.
+Het bestaande `_reload_caddy()` (container restart, geen Admin API)
+blijft de canonieke reload na tenant-provisioning. Bestaande tests
+(`test_writes_caddyfile_with_correct_content`, `test_caddy_lock_*`,
+`test_restarts_caddy_container`) SHALL groen blijven.
+
+Argumentatie: tenant Caddyfiles zijn dynamisch (per tenant, runtime),
+volume-gemount en daarmee architectuur-incompatibel met een file-sync
+patroon dat naar `main` gepushed wordt. Mengen vergroot blast radius
+zonder ROI.
+
+## Non-Goals
+
+- Caddy upgrade naar 2.12+ (separate Renovate-PR).
+- Admin-API enable + `caddy reload` (separate veiligheidsanalyse;
+  expose van het admin-vlak is een security-vraag, geen deploy-vraag).
+- Tenant Caddyfile sync mechanisme (zie R5).
+- Generieke vervanging van bind-mounts door image-baked configs voor
+  andere services (nvt; dit is een Caddy-specifieke fix omdat Caddy
+  de enige service is met deze gap).
+- Health check observability beyond CI (geen Grafana-alert voor
+  "caddy failed to recreate"; bestaande Caddy uptime alerts in Kuma
+  vangen runtime fouten).
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| `caddy validate` weigert config met ongeresolvde env vars | R3 injecteert dummy env-vars `ADMIN_EMAIL=ci@example.com` + `DOMAIN=example.com`. Test in eerste run; bij regression alternatief `caddy adapt`. |
+| `--force-recreate caddy` causes ~1s TLS-onderbreking op productie | Acceptabel per A2 + bestaand precedent in `_reload_caddy()`. Identiek aan tenant-provisioning runtime gedrag. |
+| Race tussen `caddy.yml` (image rebuild) en `deploy-compose.yml` (config sync) als beiden tegelijk triggeren | Beide eindigen op `up -d` resp. `up -d --force-recreate caddy`; volgorde maakt niet uit, laatste wint. Maximaal twee opeenvolgende ~1s downtimes — negligible. |
+| Een `:latest` tag drift tussen validate-image en deploy-image | `caddy.yml` post-merge bouwt `:latest`; volgende validate-PR gebruikt die. Drift-window is één PR. Klein risico geaccepteerd. |
+| Glob `import /etc/caddy/tenants/*.caddyfile` faalt validate met lege dir | R3 mount expliciet een lege tmp-dir om de import te resolven naar 0 matches; Caddy 2 silently OK per A4. |
+| Health check timeout te kort (10s) bij trage core-01 | Bij regressie: configureer `for i in 1..10; sleep 2` in R4, totaal 20s. SPEC laat 10s als initial; bij PR review aanpassen indien nodig. |
+
+## Implementation order
+
+1. Schrijf SPEC artefacten (deze + plan + acceptance + research).
+2. Implementeer in deze branch:
+   a. Nieuwe `.github/workflows/caddy-validate.yml`.
+   b. Edit `.github/workflows/caddy.yml` (paths reduce).
+   c. Edit `.github/workflows/deploy-compose.yml` (paths add + sparse-checkout uitbreiden + rsync block + health check).
+3. Open PR. CI runs:
+   a. `caddy-validate.yml` runt op deze PR (zelf-test van R3) en moet groen worden.
+   b. `caddy.yml` runt NIET (paths matched niet).
+   c. `deploy-compose.yml` runt NIET op PR (alleen op push to main); manueel post-merge te verifiëren.
+4. Post-merge verificatie: trigger een no-op Caddyfile change (bijv. een comment), verifieer A1-A7 acceptance criteria.
+
+Zie `plan.md` voor exacte file-edits en `acceptance.md` voor de
+verificatieprocedure.


### PR DESCRIPTION
## Why

`.github/workflows/caddy.yml` rebuilds the `caddy-hetzner` Docker image on every change to `deploy/caddy/**` and recreates the container — but no workflow syncs `deploy/caddy/Caddyfile` to its bind-mount source at `/opt/klai/caddy/Caddyfile`. The Dockerfile has no `COPY Caddyfile`; the file is purely a runtime bind-mount. Result: a Caddyfile change merged to main never reaches the running Caddy container until someone scp's it manually.

Discovered today during SPEC-MCP-AUTH-001; mitigation was a manual scp, which violates the just-codified `no-docker-cp-for-permanent-fixes` rule. The gap pre-dates SPEC-MCP-AUTH-001.

## What this PR does

External config + sync, mirroring the existing Grafana provisioning sync pattern (SPEC-OBS-001 Phase C). One PR, three files changed.

| File | Change |
|---|---|
| `.github/workflows/caddy.yml` | Reduce paths-trigger to image-relevant files only (Dockerfile/build.sh/.trivyignore.yaml). Caddyfile-only PRs no longer rebuild the image. |
| `.github/workflows/caddy-validate.yml` (NEW) | PR-trigger on `deploy/caddy/**`. Runs `caddy validate` in `ghcr.io/getklai/caddy-hetzner:latest` against the Caddyfile. Catches syntax errors before merge. |
| `.github/workflows/deploy-compose.yml` | Add `deploy/caddy/Caddyfile` to paths + sparse-checkout. Rsync with `--itemize-changes` to detect content changes; on change, `docker compose ... up -d --force-recreate caddy`. Post-recreate health check fails the workflow if caddy doesn't return to `running` state within 10s. |

## Why School 2 (external sync) over School 1 (image-baked)

Tradeoffs in `.moai/specs/SPEC-INFRA-CADDY-CONFIG-DEPLOY-001/research.md` § 3.

Short version:
- Caddy has `admin off` → `caddy reload --config` is unavailable, so the "fast reload" advantage of image-baked vanishes (container recreate is the only reload route, identical to `_reload_caddy()` in portal-api).
- Tenant Caddyfiles MUST stay external (volume, runtime-written by portal-api). Image-baked main + volume tenant = inconsistent mental model.
- `deploy-compose.yml` already does this exact pattern for Grafana provisioning — bewezen stabiel sinds april 2026.
- Image rebuild for a comment-edit is 5-10 min waste vs ~30s rsync.

## Out of scope (R5)

Tenant Caddyfile mechanism (`caddy/tenants/*.caddyfile` written by `klai-portal/backend/app/services/provisioning/infrastructure.py::_write_tenant_caddyfile`) is unchanged. Existing tests (`test_writes_caddyfile_with_correct_content`, `test_caddy_lock_*`, `test_restarts_caddy_container`) remain green — no portal-api code touched.

## Risk + rollback

| Risk | Mitigation |
|---|---|
| `caddy validate` rejects config with unresolved env vars | R3 injects dummy `ADMIN_EMAIL=ci@example.com` + `DOMAIN=example.com` |
| `--force-recreate caddy` causes ~1s TLS interruption | Acceptable per existing `_reload_caddy()` precedent |
| Race between caddy.yml + deploy-compose.yml | Both end on `up -d`-style; last wins, max ~2s downtime |

**Rollback** = `git revert <merge-sha> + git push`. Re-triggers `deploy-compose.yml`, rsyncs old Caddyfile back, force-recreates caddy. No manual core-01 intervention.

## Acceptance verification (post-merge)

Full procedure in `.moai/specs/SPEC-INFRA-CADDY-CONFIG-DEPLOY-001/acceptance.md` (AC-1 through AC-7). Quickcheck:

```bash
# AC-1: workflow groen
gh run list --workflow deploy-compose.yml -L 1 \
  --json conclusion --jq '.[0].conclusion'

# AC-1+2: file synced + container sees it
LOCAL=\$(git show main:deploy/caddy/Caddyfile | sha256sum | awk '{print \$1}')
HOST=\$(ssh core-01 "sha256sum /opt/klai/caddy/Caddyfile" | awk '{print \$1}')
CTR=\$(ssh core-01 "docker exec klai-core-caddy-1 sha256sum /etc/caddy/Caddyfile" | awk '{print \$1}')
[ "\$LOCAL" = "\$HOST" ] && [ "\$HOST" = "\$CTR" ] && echo "PASS"
```

## CI expectations on this PR

- ✅ `Validate Caddyfile / validate` (NEW, R3 self-test) — should pass; Caddyfile is unchanged
- ❌ `caddy / build-push` — should NOT run (R2 paths-trigger doesn't match this PR)
- ❌ `Sync docker-compose.yml...` — should NOT run on PR (push-only trigger)

Refs: SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3 (compose-up.sh wrapper), SPEC-OBS-001 Phase C (content-aware grafana provisioning sync), `process-rules.md::docker-compose-restart-vs-recreate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)