### PR TITLE
fix(security): personal-KB owner-binding (B2) + FastMCP session-state docs (B3)

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
@@ -666,6 +666,30 @@ async def ingest_document_route(req: IngestRequest, request: Request) -> dict:
         )
     else:
         await assert_caller_identity_tenant_only(request, claimed_org_id=req.org_id)
+
+    # Personal-KB owner-binding (klai-security-audit 2026-05-07 finding B2).
+    # Personal-KB slugs follow ``personal-{zitadel_user_id}``. Identity
+    # assertion only proves user X is a real member of org O — it does NOT
+    # prove user X owns kb_slug=personal-Y. Without this guard, user A
+    # could call the endpoint with body {user_id: A, kb_slug: "personal-B"}
+    # and silently corrupt user B's personal-KB namespace (Postgres RLS
+    # filters on org_id only; the Qdrant retrieve-time user_id filter is
+    # the only existing defence and is one layer deep — see B2 audit).
+    if req.kb_slug.startswith("personal-"):
+        expected_slug = f"personal-{req.user_id}" if req.user_id else None
+        if expected_slug is None or req.kb_slug != expected_slug:
+            logger.warning(
+                "personal_kb_owner_mismatch",
+                claimed_user_id=req.user_id,
+                requested_kb_slug=req.kb_slug,
+                org_id=req.org_id,
+                source_connector_id=req.source_connector_id,
+            )
+            raise HTTPException(
+                status_code=403,
+                detail="personal_kb_owner_mismatch",
+            )
+
     async with tenant_scoped_connection(req.org_id) as conn:
         return await ingest_document(conn, req)
 

--- a/klai-knowledge-ingest/tests/test_ingest_personal_kb_owner_binding.py
+++ b/klai-knowledge-ingest/tests/test_ingest_personal_kb_owner_binding.py
@@ -1,0 +1,159 @@
+"""SPEC-MCP-AUTH-001 follow-up — personal-KB owner-binding regression suite.
+
+Audit-finding B2 (klai-security-audit 2026-05-07): user A authenticated
+via OAuth could call POST /ingest/v1/document with body
+``{user_id: A, kb_slug: "personal-B"}`` — identity-assertion only proves
+A is a real user in the org, NOT that A owns ``personal-B``. Result was
+silent corruption of B's personal-KB namespace; one regression in the
+Qdrant retrieve-time user_id filter would turn this into a confidentiality
+breach.
+
+The route handler now guards: when ``kb_slug`` starts with ``personal-``,
+it MUST equal ``f"personal-{user_id}"`` or the request is rejected 403
+``personal_kb_owner_mismatch`` before any DB write.
+
+Test pattern mirrors ``test_ingest_endpoints_identity_assertion.py`` —
+identity is mocked OK so we exclusively exercise the new guard.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+# Reuse the same caller-service header gate as the sibling identity test.
+_CALLER = {"X-Caller-Service": "portal-api"}
+
+
+@pytest.fixture()
+def _identity_ok(monkeypatch):
+    """Identity assertion passes through with the claimed org_id / user_id."""
+
+    async def _ok(request, claimed_org_id, claimed_user_id=None):
+        return claimed_org_id
+
+    for module_path in [
+        "knowledge_ingest.identity.assert_caller_identity",
+        "knowledge_ingest.routes.ingest.assert_caller_identity",
+        "knowledge_ingest.identity.assert_caller_identity_tenant_only",
+        "knowledge_ingest.routes.ingest.assert_caller_identity_tenant_only",
+    ]:
+        monkeypatch.setattr(module_path, _ok)
+
+
+# ---------------------------------------------------------------------------
+# B2 cross-user write rejection
+# ---------------------------------------------------------------------------
+
+
+class TestPersonalKbOwnerBinding:
+    """B2: ``personal-{X}`` writes by user Y MUST be rejected."""
+
+    def test_user_a_writing_to_personal_b_returns_403(self, _identity_ok, client):
+        """User A's request to personal-B namespace blocked at the route."""
+        resp = client.post(
+            "/ingest/v1/document",
+            headers=_CALLER,
+            json={
+                "org_id": "org-1",
+                "kb_slug": "personal-bob",
+                "user_id": "alice",  # mismatched: alice ≠ bob
+                "path": "stolen-namespace.md",
+                "content": "this should not be persisted",
+                "content_type": "text/markdown",
+            },
+        )
+        assert resp.status_code == 403, resp.text
+        assert "personal_kb_owner_mismatch" in resp.text
+
+    def test_personal_kb_without_user_id_returns_403(self, _identity_ok, client):
+        """Service-to-service caller (no user_id) cannot target personal-X.
+
+        The connector path is service-to-service and never carries a
+        ``user_id``. A connector trying to write to a personal-* slug is
+        either a misconfiguration or a confused-deputy attack — fail
+        closed regardless of intent.
+        """
+        resp = client.post(
+            "/ingest/v1/document",
+            headers=_CALLER,
+            json={
+                "org_id": "org-1",
+                "kb_slug": "personal-anyone",
+                # no user_id — tenant-only assertion path
+                "path": "from-connector.md",
+                "content": "...",
+                "content_type": "text/markdown",
+            },
+        )
+        assert resp.status_code == 403, resp.text
+        assert "personal_kb_owner_mismatch" in resp.text
+
+    def test_user_a_writing_to_own_personal_kb_passes_guard(self, _identity_ok, client, mock_pool):
+        """Owner writing to their own personal-X passes the route-level guard.
+
+        The downstream pipeline may still 4xx for unrelated reasons (no
+        embedder in the test stub, etc.) — we just assert the guard does
+        NOT itself raise the owner-mismatch 403.
+        """
+        mock_pool.fetchrow = AsyncMock(return_value=None)
+        mock_pool.execute = AsyncMock(return_value=None)
+        resp = client.post(
+            "/ingest/v1/document",
+            headers=_CALLER,
+            json={
+                "org_id": "org-1",
+                "kb_slug": "personal-alice",
+                "user_id": "alice",
+                "path": "my-note.md",
+                "content": "Hello world",
+                "content_type": "text/markdown",
+            },
+        )
+        # Either pass-through (downstream may itself 4xx for non-auth reasons),
+        # but it must NOT be the owner-mismatch 403.
+        assert "personal_kb_owner_mismatch" not in resp.text, (
+            f"Owner-match write was wrongly rejected: {resp.text}"
+        )
+
+    def test_org_kb_write_unaffected_by_guard(self, _identity_ok, client, mock_pool):
+        """Non-personal kb_slugs are not subject to the owner-binding guard."""
+        mock_pool.fetchrow = AsyncMock(return_value=None)
+        mock_pool.execute = AsyncMock(return_value=None)
+        resp = client.post(
+            "/ingest/v1/document",
+            headers=_CALLER,
+            json={
+                "org_id": "org-1",
+                "kb_slug": "team-handbook",  # not a personal- slug
+                "user_id": "alice",
+                "path": "intro.md",
+                "content": "Hello",
+                "content_type": "text/markdown",
+            },
+        )
+        assert "personal_kb_owner_mismatch" not in resp.text, resp.text
+
+    def test_plain_personal_slug_without_dash_unaffected(self, _identity_ok, client, mock_pool):
+        """``kb_slug='personal'`` (no trailing dash) is a generic slug, not owner-bound.
+
+        Anyone using the literal slug ``personal`` (no user-id suffix) bypasses
+        the guard. This documents the expected matcher boundary: the guard
+        only fires on the ``personal-`` PREFIX, not on the bare word.
+        """
+        mock_pool.fetchrow = AsyncMock(return_value=None)
+        mock_pool.execute = AsyncMock(return_value=None)
+        resp = client.post(
+            "/ingest/v1/document",
+            headers=_CALLER,
+            json={
+                "org_id": "org-1",
+                "kb_slug": "personal",
+                "user_id": "alice",
+                "path": "x.md",
+                "content": "y",
+                "content_type": "text/markdown",
+            },
+        )
+        assert "personal_kb_owner_mismatch" not in resp.text, resp.text

--- a/klai-knowledge-mcp/main.py
+++ b/klai-knowledge-mcp/main.py
@@ -489,6 +489,22 @@ def _slugify(text: str) -> str:
 
 
 # -- MCP server ---------------------------------------------------------------
+# klai-security-audit 2026-05-07 finding B3 (CANNOT-VERIFY → reviewed
+# 2026-05-07): FastMCP's Streamable HTTP transport binds session state to
+# the server-generated ``Mcp-Session-Id`` (uuid4, 128-bit). Per-session
+# state is transport-only (request streams, SSE writers); identity is
+# re-derived from the ``Authorization`` header on every tool call (see
+# ``_identify_request`` invocations in each tool body) and the
+# ``_WWWAuthenticateMiddleware`` runs BEFORE FastMCP touches the request.
+# Net: a hijacked session-id cannot read another user's data today.
+#
+# Latent caveat: the GET-SSE notification stream binds to session-id only.
+# If anyone in the future wires up server-pushed notifications via that
+# stream that carry identity-scoped payloads (org_id-specific events,
+# per-user alerts, etc.), the emitter MUST re-derive identity from the
+# live ``Authorization`` header on every emit — NOT from cached session
+# state. Without that discipline the GEEL caveat in finding B3 turns
+# into a real cross-token leak.
 mcp = FastMCP(
     "klai-knowledge",
     transport_security=TransportSecuritySettings(


### PR DESCRIPTION
## Summary

Closes the two remaining findings from klai-security-audit on SPEC-MCP-AUTH-001:

### B2 (HIGH) — personal-KB cross-user write rejection

User A authenticated via OAuth could call `POST /ingest/v1/document` with body `{user_id: A, kb_slug: "personal-B"}`. Identity-assertion only proves A is a real user in the org; it does NOT prove A owns kb_slug `personal-B`. Result: silent corruption of B's personal-KB namespace. Postgres RLS scopes on org_id only; the Qdrant retrieve-time user_id filter was the only existing defence — one layer deep.

**Fix**: route-level guard in `ingest_document_route` after identity-assertion. When `kb_slug` starts with `personal-` it MUST equal `f"personal-{user_id}"` or 403 `personal_kb_owner_mismatch` before any DB write. Service-to-service callers (no user_id) targeting `personal-*` slugs are also rejected.

5 regression tests cover: A→personal-B = 403, no user_id+personal-X = 403, A→personal-A passes, non-personal slugs unaffected, plain `personal` (no dash) unaffected.

### B3 (GEEL latent) — FastMCP session-state docs comment

Reviewed FastMCP source: per-session state is transport-only; identity is re-derived per request via `_identify_request` + `_WWWAuthenticateMiddleware`. Hijacked session-id can't read another user's data today. Latent caveat: the GET-SSE notification stream binds to session-id only — any future identity-scoped notification must re-derive identity from the live `Authorization` header.

Added a docs comment above `mcp = FastMCP(...)` to make this contract explicit.

## Tests

5/5 pass locally (`tests/test_ingest_personal_kb_owner_binding.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)