### PR TITLE
spec(SPEC-INFRA-CONFIG-SYNC-001): expand bind-mount sync to alloy/searxng/vexa

### DIFF
--- a/.claude/rules/klai/infra/deploy.md
+++ b/.claude/rules/klai/infra/deploy.md
@@ -31,6 +31,115 @@ CI service workflows do NOT copy compose to server — only pull image + restart
 `deploy-compose.yml` auto-syncs when `deploy/docker-compose.yml` changes on main.
 Manual: `scp deploy/docker-compose.yml core-01:/opt/klai/docker-compose.yml`
 
+## Bind-mount config sync — required pattern (HIGH)
+
+> Closes the bind-mount-without-sync-workflow class of bugs that the
+> Caddyfile incident (2026-05-07, SPEC-INFRA-CADDY-CONFIG-DEPLOY-001)
+> exposed. Codified by SPEC-INFRA-CONFIG-SYNC-001.
+
+### The class
+
+When `deploy/docker-compose.yml` declares a relative bind-mount of
+the shape `- ./<svc>/<file>:/etc/...`, the host source resolves to
+`/opt/klai/<svc>/<file>`. Without a workflow that syncs the file
+from the repo to that host path, edits to the repo never reach the
+running container. The bind-mount silently uses whatever was scp'd
+manually long ago — sometimes drifting for months without anyone
+noticing.
+
+The Caddyfile incident was a concrete instance: image rebuilds via
+`caddy.yml` recreated the container correctly, but the bind-mount
+source on `/opt/klai/caddy/Caddyfile` had not been touched since
+the last manual `scp`. A new Caddyfile change merged to main was
+invisible to production for an unknown number of days until someone
+asked "why does this directive not work?".
+
+### The fix
+
+`.github/workflows/deploy-compose.yml` ships a bash helper
+`sync_and_recreate <compose-service> <repo-src> <host-dst>` that:
+
+1. Adds the source path to its `paths:` trigger and sparse-checkout
+2. Rsyncs with `-ac --itemize-changes` (content-checksum, ignores
+   mtime churn from a fresh git clone)
+3. On content change: `docker compose ... up -d --force-recreate
+   <service>` + 5×2s health check loop using `docker inspect
+   --format '{{.State.Status}}'`. Workflow fails on timeout.
+4. On no change: idempotent skip (no recreate, no log noise)
+
+### Required when adding a new bind-mount (3-step checklist)
+
+When you add a new line of the form `- ./<svc>/<file>:/...` to
+`deploy/docker-compose.yml`, you MUST in the same PR:
+
+1. Add `'deploy/<svc>/<file>'` to `deploy-compose.yml`'s `paths:`
+   trigger
+2. Add the same path to the `git sparse-checkout set` invocation in
+   the workflow's script
+3. Add a `sync_and_recreate <compose-service> deploy/<svc>/<file>
+   /opt/klai/<svc>/<file>` call alongside the existing four
+
+If the bind-mount is a directory (not a single file), use a
+directory-rsync block in the style of the existing grafana
+provisioning sync — the helper is single-file only.
+
+### Inventory (as of SPEC-INFRA-CONFIG-SYNC-001)
+
+#### Class A — synced via `sync_and_recreate` helper
+
+- `deploy/caddy/Caddyfile` → compose service `caddy`
+- `deploy/alloy/config.alloy` → compose service `alloy`
+- `deploy/searxng/settings.yml` → compose service `searxng`
+- `deploy/vexa/profiles.yaml` → compose service `runtime-api`
+  (note the asymmetry: NOT a service named "vexa" — the file is
+  consumed by runtime-api)
+
+#### Class A-dir — synced via directory rsync (predates helper)
+
+- `deploy/grafana/provisioning/` → compose service `grafana`
+  (SPEC-OBS-001 Phase C, kept inline because helper is single-file
+  only; refactor only if a second dir bind-mount appears)
+
+#### Class B — own dedicated workflow
+
+- `deploy/litellm/*.{py,yaml}` → `litellm-hook-deploy.yml`
+- `deploy/librechat/...` → `deploy-librechat-config.yml`
+- Tenant Caddyfiles (`caddy/tenants/*.caddyfile`) → portal-api
+  `_write_tenant_caddyfile` runtime (NOT CI — per-tenant, dynamic)
+
+#### Class C — one-shot init, no drift risk
+
+- `deploy/postgres/init.sql` — read once on DB volume init
+- `deploy/firecrawl-nuq-init.sql` — read once on DB volume init
+
+### When you change a Class A file
+
+Just `git push`. The workflow rsyncs + force-recreates. ~30s end-
+to-end. Health check fails the workflow on container-not-running;
+operator's recovery is `git revert + push`.
+
+### When you change a Class A-dir file
+
+Same — directory rsync handles it. ~30s end to end.
+
+### When you change a Class B file
+
+Use the dedicated workflow — see the workflow's own paths-trigger
+and follow that contract.
+
+### When you change a Class C file
+
+Don't bother editing the existing file directly — it only affects
+fresh DB-volume bootstraps. For existing prod, write a migration.
+
+### Adding a new service with a bind-mount config?
+
+Default to Class A. Class B is justified only when the service has
+a non-trivial reload mechanism that recreate cannot replace, or
+when its deploy cadence differs strongly from the rest of compose.
+Class C is rare — only for true one-shot init that cannot be a
+migration.
+
 ## Atomic env writes (CRIT)
 Never `cat >` or `echo >` to a live `.env`. Write-to-temp + validate + `mv`:
 ```bash

--- a/.github/workflows/deploy-compose.yml
+++ b/.github/workflows/deploy-compose.yml
@@ -7,6 +7,9 @@ on:
       - 'deploy/docker-compose.yml'
       - 'deploy/docker-compose.override.yml'
       - 'deploy/caddy/Caddyfile'                  # SPEC-INFRA-CADDY-CONFIG-DEPLOY-001 R1 — sync Caddyfile to bind-mount source
+      - 'deploy/alloy/config.alloy'               # SPEC-INFRA-CONFIG-SYNC-001 R3 — alloy log-pipeline config
+      - 'deploy/searxng/settings.yml'             # SPEC-INFRA-CONFIG-SYNC-001 R3 — searxng search config
+      - 'deploy/vexa/profiles.yaml'               # SPEC-INFRA-CONFIG-SYNC-001 R3 — vexa runtime-api meeting-bot profiles
       - 'deploy/grafana/provisioning/**'          # SPEC-SEC-024 M4.2 — alert rule + dashboard
       - 'deploy/scripts/**'                       # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3 — compose-up wrapper + audit-orphan-snapshot
       - 'scripts/smoke-docker-socket-proxy.sh'    # SPEC-SEC-024 M4.3 — smoke-test
@@ -60,6 +63,9 @@ jobs:
               deploy/docker-compose.yml \
               deploy/docker-compose.override.yml \
               deploy/caddy/Caddyfile \
+              deploy/alloy/config.alloy \
+              deploy/searxng/settings.yml \
+              deploy/vexa/profiles.yaml \
               deploy/grafana/provisioning \
               deploy/scripts \
               deploy/systemd \
@@ -115,63 +121,80 @@ jobs:
               docker compose --project-directory /opt/klai up -d grafana
             fi
 
-            # SPEC-INFRA-CADDY-CONFIG-DEPLOY-001 R1+R4 — sync Caddyfile to
-            # bind-mount source. The compose file mounts ./caddy/Caddyfile
-            # (resolved as /opt/klai/caddy/Caddyfile) into the caddy
-            # container at /etc/caddy/Caddyfile. Without this sync, an
-            # image rebuild + container recreate via caddy.yml leaves the
-            # container reading the OLD Caddyfile from the bind-mount.
+            # SPEC-INFRA-CONFIG-SYNC-001 R1 — bash helper for bind-mount
+            # config sync. Replaces the inline Caddyfile block from
+            # SPEC-INFRA-CADDY-CONFIG-DEPLOY-001 (which is now one of
+            # four call-sites). See infra/deploy.md "Bind-mount config
+            # sync — required pattern" for the canonical reference.
             #
-            # Content-aware: only force-recreate when content changed
-            # (mirrors the grafana provisioning sync above). A bind-mount-
-            # only change does not trigger compose recreate via plain
-            # `up -d`. Caddy has `admin off`, so `caddy reload --config`
-            # is unavailable — container restart (~1s TLS interruption)
-            # is the canonical reload, identical to `_reload_caddy()` in
-            # portal-api provisioning. See plan.md for the full rationale.
-            mkdir -p /opt/klai/caddy
-            RSYNC_CADDY_CHANGES=$(rsync -ac --itemize-changes deploy/caddy/Caddyfile /opt/klai/caddy/Caddyfile | grep -E '^[<>*]' || true)
-            if [ -n "$RSYNC_CADDY_CHANGES" ]; then
-              echo "Caddyfile content changed:"
-              echo "$RSYNC_CADDY_CHANGES"
-              docker compose --project-directory /opt/klai up -d --force-recreate caddy
+            # Args:
+            #   $1 = compose service name (for force-recreate + ps -q)
+            #   $2 = source path in this sparse-checkout
+            #   $3 = destination path on host (will mkdir -p its parent)
+            #
+            # Behaviour:
+            #   - If rsync content diff is non-empty → force-recreate
+            #     the service + run a 5×2s health check loop. Fail the
+            #     workflow if the container does not reach `running`
+            #     within 10s.
+            #   - If rsync content diff is empty → skip (idempotent).
+            #
+            # Caddy has `admin off`, so `caddy reload --config` is not
+            # available — container restart is the canonical reload.
+            # Same applies to alloy/searxng/runtime-api: all four read
+            # their config at startup and need a recreate to pick up
+            # changes.
+            sync_and_recreate() {
+              local svc="$1"
+              local src="$2"
+              local dst="$3"
+              mkdir -p "$(dirname "$dst")"
+              local changes
+              changes=$(rsync -ac --itemize-changes "$src" "$dst" | grep -E '^[<>*]' || true)
+              if [ -z "$changes" ]; then
+                echo "$svc config unchanged; skipping recreate."
+                return 0
+              fi
+              echo "$svc config content changed:"
+              echo "$changes"
+              docker compose --project-directory /opt/klai up -d --force-recreate "$svc"
 
-              # SPEC-INFRA-CADDY-CONFIG-DEPLOY-001 R4 — post-recreate
-              # health check. Fail the workflow if caddy doesn't return
-              # to running within 10s. Operator's recovery is `git revert
-              # + push`, which triggers another sync run that rsyncs the
-              # previous Caddyfile back and force-recreates caddy.
-              #
-              # Uses `docker inspect` with a Go-template (built-in to
-              # docker, no external `jq` needed). `docker compose ps -q`
-              # resolves the container ID stably regardless of compose
-              # naming convention.
-              echo "::group::Caddy post-recreate health check"
-              HEALTHY=0
+              echo "::group::$svc post-recreate health check"
+              local healthy=0
+              local i cid status
               for i in 1 2 3 4 5; do
                 sleep 2
-                CID=$(docker compose --project-directory /opt/klai ps -q caddy 2>/dev/null || true)
-                if [ -z "$CID" ]; then
-                  echo "Caddy container not found (attempt ${i}/5)"
+                cid=$(docker compose --project-directory /opt/klai ps -q "$svc" 2>/dev/null || true)
+                if [ -z "$cid" ]; then
+                  echo "$svc container not found (attempt ${i}/5)"
                   continue
                 fi
-                STATUS=$(docker inspect --format '{{.State.Status}}' "$CID" 2>/dev/null || echo "missing")
-                if [ "$STATUS" = "running" ]; then
-                  echo "Caddy is running (attempt ${i})"
-                  HEALTHY=1
+                status=$(docker inspect --format '{{.State.Status}}' "$cid" 2>/dev/null || echo "missing")
+                if [ "$status" = "running" ]; then
+                  echo "$svc is running (attempt ${i})"
+                  healthy=1
                   break
                 fi
-                echo "Caddy state: $STATUS (attempt ${i}/5)"
+                echo "$svc state: $status (attempt ${i}/5)"
               done
-              if [ "$HEALTHY" -ne 1 ]; then
-                echo "::error::Caddy did not reach running state within 10s after recreate"
-                docker compose --project-directory /opt/klai logs --tail 50 caddy || true
+              if [ "$healthy" -ne 1 ]; then
+                echo "::error::$svc did not reach running state within 10s after recreate"
+                docker compose --project-directory /opt/klai logs --tail 50 "$svc" || true
                 exit 1
               fi
               echo "::endgroup::"
-            else
-              echo "Caddyfile unchanged; skipping caddy recreate."
-            fi
+            }
+
+            # SPEC-INFRA-CONFIG-SYNC-001 R2 — apply helper to all four
+            # single-file relative bind-mounts that lack a dedicated
+            # service-deploy workflow. Note vexa's profiles.yaml is
+            # mounted into the runtime-api compose service, NOT a
+            # service named "vexa" — the asymmetry matters for the
+            # force-recreate target.
+            sync_and_recreate caddy       deploy/caddy/Caddyfile        /opt/klai/caddy/Caddyfile
+            sync_and_recreate alloy       deploy/alloy/config.alloy     /opt/klai/alloy/config.alloy
+            sync_and_recreate searxng     deploy/searxng/settings.yml   /opt/klai/searxng/settings.yml
+            sync_and_recreate runtime-api deploy/vexa/profiles.yaml     /opt/klai/vexa/profiles.yaml
 
             # SPEC-SEC-024 M4.3 — sync smoke-test script. `chmod +x` because
             # git clone on a Linux runner usually preserves the execute bit,

--- a/.moai/specs/SPEC-INFRA-CONFIG-SYNC-001/acceptance.md
+++ b/.moai/specs/SPEC-INFRA-CONFIG-SYNC-001/acceptance.md
@@ -1,0 +1,110 @@
+# SPEC-INFRA-CONFIG-SYNC-001 — Acceptance Criteria
+
+Vijf Given/When/Then scenarios. Elke AC is mechanisch verifieerbaar.
+
+## AC-1 — Helper-refactor preserves caddy behaviour
+
+- **Given** R1 + R2 zijn uitgevoerd (helper geëxtract, caddy-call via
+  helper),
+- **When** een commit naar `main` `deploy/caddy/Caddyfile` wijzigt,
+- **Then** de log toont `caddy config content changed:` of `caddy
+  config unchanged; skipping recreate.` afhankelijk van content-diff.
+  Bij content change: caddy wordt force-recreated en gaat binnen 10s
+  terug naar `running`. Functionaliteit identiek aan SPEC-INFRA-CADDY-
+  CONFIG-DEPLOY-001 — verificatie via 3-way sha256 match (zie AC-4).
+
+**Test:** Caddyfile is in deze SPEC niet aangeraakt — eerste post-merge
+run zal `caddy config unchanged; skipping recreate.` echoen. Bevestigt
+de no-op pad. Een latere Caddyfile-edit in een aparte PR test het
+content-change pad.
+
+## AC-2 — Alloy config sync
+
+- **Given** R2 + R3 uitgevoerd (alloy in helper-call set + paths +
+  sparse-checkout),
+- **When** een commit naar `main` `deploy/alloy/config.alloy` wijzigt,
+- **Then** `gh run list --workflow deploy-compose.yml -L 1 --json
+  conclusion --jq '.[0].conclusion'` returns `"success"` binnen 5
+  minuten, EN `ssh core-01 "sha256sum /opt/klai/alloy/config.alloy"`
+  matched `git show main:deploy/alloy/config.alloy | sha256sum`, EN
+  `ssh core-01 "docker exec klai-core-alloy-1 sha256sum
+  /etc/alloy/config.alloy"` matched dezelfde sha.
+
+**Test:** post-merge: trigger `workflow_dispatch` op deploy-compose.yml
+om de eerste run te forceren. Verifieer log + sha256.
+
+## AC-3 — Searxng config sync
+
+- **Given** R2 + R3 uitgevoerd voor searxng,
+- **When** identiek scenario als AC-2 maar voor `deploy/searxng/
+  settings.yml`,
+- **Then** identieke 3-way sha256 verificatie tegen `/opt/klai/searxng/
+  settings.yml` en `klai-core-searxng-1:/etc/searxng/settings.yml`.
+
+## AC-4 — Vexa profiles sync (asymmetric service name)
+
+- **Given** R2 + R3 uitgevoerd voor `runtime-api` service (NB: NIET
+  een `vexa` service),
+- **When** een commit `deploy/vexa/profiles.yaml` wijzigt,
+- **Then** sha256 match tegen `/opt/klai/vexa/profiles.yaml` en
+  `klai-core-runtime-api-1:/app/profiles.yaml`. De service-naam in
+  `docker compose ps` is `runtime-api`, NIET `vexa` — bevestigt dat
+  R2's expliciete service-naam-parameter werkt.
+
+## AC-5 — Documentatie geupdated en checklist machine-leesbaar
+
+- **Given** R4 uitgevoerd,
+- **When** een ontwikkelaar de regels-set leest via
+  `cat .claude/rules/klai/infra/deploy.md`,
+- **Then** de sectie "Bind-mount config sync — required pattern" is
+  aanwezig met:
+  - Het probleem en de canonieke fix
+  - De 3-stap checklist voor nieuwe bind-mounts (paths +
+    sparse-checkout + helper-call)
+  - De inventaris van Class A/A-dir/B/C bind-mounts inclusief de
+    asymmetrie-noot voor vexa/runtime-api
+
+**Test:** `grep -c "sync_and_recreate" .claude/rules/klai/infra/deploy.md`
+returns >= 2 (helper genoemd in fix-beschrijving + checklist).
+`grep -c "runtime-api" .claude/rules/klai/infra/deploy.md` returns
+>= 1 (asymmetrie-noot expliciet gedocumenteerd).
+
+## Verification commands (post-merge)
+
+```bash
+# AC-1: workflow groen + caddy idempotent (omdat we Caddyfile niet
+# wijzigen in deze PR, verwacht "config unchanged")
+gh run list --workflow deploy-compose.yml -L 1 \
+  --json conclusion --jq '.[0].conclusion'
+# expect: "success"
+
+gh run view <run-id> --log | grep -E "caddy config (unchanged|content changed)"
+# expect: één regel matching
+
+# AC-2/3/4: 3-way sha256 per nieuwe service
+for spec in \
+  "alloy:/opt/klai/alloy/config.alloy:deploy/alloy/config.alloy:/etc/alloy/config.alloy:klai-core-alloy-1" \
+  "searxng:/opt/klai/searxng/settings.yml:deploy/searxng/settings.yml:/etc/searxng/settings.yml:klai-core-searxng-1" \
+  "runtime-api:/opt/klai/vexa/profiles.yaml:deploy/vexa/profiles.yaml:/app/profiles.yaml:klai-core-runtime-api-1"; do
+  svc=$(echo "$spec" | cut -d: -f1)
+  host=$(echo "$spec" | cut -d: -f2)
+  repo=$(echo "$spec" | cut -d: -f3)
+  ctr_path=$(echo "$spec" | cut -d: -f4)
+  ctr_name=$(echo "$spec" | cut -d: -f5)
+  HEAD=$(git show main:"$repo" | sha256sum | awk '{print $1}')
+  HOST=$(ssh core-01 "sha256sum $host" 2>/dev/null | awk '{print $1}')
+  CTR=$(ssh core-01 "docker exec $ctr_name sha256sum $ctr_path" 2>/dev/null | awk '{print $1}')
+  if [ "$HEAD" = "$HOST" ] && [ "$HOST" = "$CTR" ]; then
+    echo "$svc: PASS"
+  else
+    echo "$svc: FAIL — HEAD=$HEAD HOST=$HOST CTR=$CTR"
+  fi
+done
+
+# AC-5: doc-checklist aanwezig
+grep -c "sync_and_recreate" .claude/rules/klai/infra/deploy.md
+# expect: >= 2
+
+grep -c "runtime-api" .claude/rules/klai/infra/deploy.md
+# expect: >= 1
+```

--- a/.moai/specs/SPEC-INFRA-CONFIG-SYNC-001/plan.md
+++ b/.moai/specs/SPEC-INFRA-CONFIG-SYNC-001/plan.md
@@ -1,0 +1,306 @@
+# SPEC-INFRA-CONFIG-SYNC-001 — Implementation Plan
+
+## Strategie
+
+Eén PR. Twee file-changes (één refactor, één nieuwe doc-sectie).
+
+## Files
+
+### EDIT: `.github/workflows/deploy-compose.yml`
+
+Drie wijzigingen in dit bestand:
+
+#### Wijziging 1 — paths-trigger
+
+```diff
+     paths:
+       - 'deploy/docker-compose.yml'
+       - 'deploy/docker-compose.override.yml'
+       - 'deploy/caddy/Caddyfile'                  # SPEC-INFRA-CADDY-CONFIG-DEPLOY-001 R1
++      - 'deploy/alloy/config.alloy'               # SPEC-INFRA-CONFIG-SYNC-001 R3
++      - 'deploy/searxng/settings.yml'             # SPEC-INFRA-CONFIG-SYNC-001 R3
++      - 'deploy/vexa/profiles.yaml'               # SPEC-INFRA-CONFIG-SYNC-001 R3
+       - 'deploy/grafana/provisioning/**'
+       - 'deploy/scripts/**'
+       - 'scripts/smoke-docker-socket-proxy.sh'
+       - '.github/workflows/deploy-compose.yml'
+```
+
+#### Wijziging 2 — sparse-checkout
+
+```diff
+             git sparse-checkout set --skip-checks \
+               deploy/docker-compose.yml \
+               deploy/docker-compose.override.yml \
+               deploy/caddy/Caddyfile \
++              deploy/alloy/config.alloy \
++              deploy/searxng/settings.yml \
++              deploy/vexa/profiles.yaml \
+               deploy/grafana/provisioning \
+               deploy/scripts \
+               deploy/systemd \
+               scripts
+```
+
+#### Wijziging 3 — helper-extract + 4 calls
+
+Het bestaande inline Caddyfile-block (regel ~115-166 sinds de caddy
+SPEC merge) wordt vervangen door:
+
+```bash
+            # SPEC-INFRA-CONFIG-SYNC-001 R1 — bash helper for bind-mount
+            # config sync. Replaces the inline Caddyfile block from
+            # SPEC-INFRA-CADDY-CONFIG-DEPLOY-001 (which is now one of
+            # four call-sites). See infra/deploy.md "Bind-mount config
+            # sync — required pattern" for the canonical reference.
+            #
+            # Args:
+            #   $1 = compose service name (for force-recreate + ps -q)
+            #   $2 = source path in this sparse-checkout
+            #   $3 = destination path on host (will mkdir -p its parent)
+            #
+            # Behaviour:
+            #   - If rsync content diff is non-empty → force-recreate
+            #     the service + run a 5×2s health check loop. Fail the
+            #     workflow if the container does not reach `running`
+            #     within 10s.
+            #   - If rsync content diff is empty → skip (idempotent).
+            #
+            # Caddy has `admin off`, so `caddy reload --config` is not
+            # available — container restart is the canonical reload.
+            # Same applies to alloy/searxng/runtime-api: all four read
+            # their config at startup and need a recreate to pick up
+            # changes.
+            sync_and_recreate() {
+              local svc="$1"
+              local src="$2"
+              local dst="$3"
+              mkdir -p "$(dirname "$dst")"
+              local changes
+              changes=$(rsync -ac --itemize-changes "$src" "$dst" | grep -E '^[<>*]' || true)
+              if [ -z "$changes" ]; then
+                echo "$svc config unchanged; skipping recreate."
+                return 0
+              fi
+              echo "$svc config content changed:"
+              echo "$changes"
+              docker compose --project-directory /opt/klai up -d --force-recreate "$svc"
+
+              echo "::group::$svc post-recreate health check"
+              local healthy=0
+              local i cid status
+              for i in 1 2 3 4 5; do
+                sleep 2
+                cid=$(docker compose --project-directory /opt/klai ps -q "$svc" 2>/dev/null || true)
+                if [ -z "$cid" ]; then
+                  echo "$svc container not found (attempt ${i}/5)"
+                  continue
+                fi
+                status=$(docker inspect --format '{{.State.Status}}' "$cid" 2>/dev/null || echo "missing")
+                if [ "$status" = "running" ]; then
+                  echo "$svc is running (attempt ${i})"
+                  healthy=1
+                  break
+                fi
+                echo "$svc state: $status (attempt ${i}/5)"
+              done
+              if [ "$healthy" -ne 1 ]; then
+                echo "::error::$svc did not reach running state within 10s after recreate"
+                docker compose --project-directory /opt/klai logs --tail 50 "$svc" || true
+                exit 1
+              fi
+              echo "::endgroup::"
+            }
+
+            # SPEC-INFRA-CONFIG-SYNC-001 R2 — apply helper to all four
+            # single-file relative bind-mounts that lack a dedicated
+            # service-deploy workflow. Note vexa's profiles.yaml is
+            # mounted into the runtime-api compose service, NOT a
+            # service named "vexa" — the asymmetry matters for the
+            # force-recreate target.
+            sync_and_recreate caddy       deploy/caddy/Caddyfile        /opt/klai/caddy/Caddyfile
+            sync_and_recreate alloy       deploy/alloy/config.alloy     /opt/klai/alloy/config.alloy
+            sync_and_recreate searxng     deploy/searxng/settings.yml   /opt/klai/searxng/settings.yml
+            sync_and_recreate runtime-api deploy/vexa/profiles.yaml     /opt/klai/vexa/profiles.yaml
+```
+
+Dit blok vervangt het hele bestaande SPEC-INFRA-CADDY-CONFIG-
+DEPLOY-001 inline-block. Functioneel identiek voor caddy; nieuw werk
+voor de andere drie services.
+
+### EDIT: `.claude/rules/klai/infra/deploy.md`
+
+Nieuwe sectie toevoegen na de bestaande "docker-compose.yml sync"
+sectie:
+
+```markdown
+## Bind-mount config sync — required pattern
+
+> Closes the bind-mount-without-sync-workflow class of bugs that the
+> librechat-voys + Caddyfile incidents both belong to. Codified by
+> SPEC-INFRA-CONFIG-SYNC-001 (refactored from SPEC-INFRA-CADDY-
+> CONFIG-DEPLOY-001).
+
+### The class
+
+When `deploy/docker-compose.yml` declares a relative bind-mount
+(`./<svc>/<file>:/etc/...`), the host source resolves to
+`/opt/klai/<svc>/<file>`. Without a workflow that syncs the file from
+the repo to that host path, edits to the repo never reach the
+running container. The bind-mount silently uses whatever was scp'd
+manually long ago — sometimes drifting for months without notice.
+
+### The fix
+
+`.github/workflows/deploy-compose.yml` ships a bash helper
+`sync_and_recreate <service> <repo-src> <host-dst>` that:
+
+1. Adds the source path to its `paths:` trigger and sparse-checkout
+2. Rsyncs with `-ac --itemize-changes` (content-checksum, ignores
+   mtime churn from a fresh git clone)
+3. On content change: `docker compose ... up -d --force-recreate
+   <service>` + 5×2s health check loop using `docker inspect`
+4. On no change: idempotent skip
+
+### Required when adding a new bind-mount
+
+When you add a new line of the form `- ./<svc>/<file>:/...` to
+`deploy/docker-compose.yml`, you MUST in the same PR:
+
+1. Add `'deploy/<svc>/<file>'` to `deploy-compose.yml`'s `paths:`
+   trigger
+2. Add the same path to the `git sparse-checkout set` invocation
+3. Add a `sync_and_recreate <compose-service> deploy/<svc>/<file>
+   /opt/klai/<svc>/<file>` call alongside the existing four
+
+If the bind-mount is a directory (not a single file), use a
+directory-rsync block in the style of the existing grafana
+provisioning sync — the helper is single-file only.
+
+### Inventory
+
+#### Class A — synced via deploy-compose.yml `sync_and_recreate`
+
+- `deploy/caddy/Caddyfile` → `caddy` service
+- `deploy/alloy/config.alloy` → `alloy` service
+- `deploy/searxng/settings.yml` → `searxng` service
+- `deploy/vexa/profiles.yaml` → `runtime-api` service (note: NOT a
+  service named "vexa" — the file is consumed by runtime-api)
+
+#### Class A-dir — synced via deploy-compose.yml directory rsync
+
+- `deploy/grafana/provisioning/` → `grafana` service (SPEC-OBS-001
+  Phase C, predates the helper; kept inline for now)
+
+#### Class B — own dedicated workflow
+
+- `deploy/litellm/*.{py,yaml}` → `litellm-hook-deploy.yml`
+- `deploy/librechat/...` → `deploy-librechat-config.yml`
+- Tenant Caddyfiles (`caddy/tenants/*.caddyfile`) → portal-api
+  `_write_tenant_caddyfile` runtime (NOT CI; per-tenant)
+
+#### Class C — one-shot init, no drift risk
+
+- `deploy/postgres/init.sql` — read once on DB volume init
+- `deploy/firecrawl-nuq-init.sql` — read once on DB volume init
+
+### When you change a Class A file
+
+Just `git push`. The workflow rsyncs + force-recreates. ~30s end to
+end.
+
+### When you change a Class A-dir file
+
+Same — directory rsync handles it. ~30s end to end.
+
+### When you change a Class B file
+
+Use the dedicated workflow — see the workflow's own paths-trigger
+and follow that contract.
+
+### When you change a Class C file
+
+Don't bother editing the existing file directly — it only affects
+fresh DB-volume bootstraps. For existing prod, write a migration.
+
+### Adding a new service with a bind-mount config?
+
+Default to Class A. Class B is justified only when the service has a
+non-trivial reload mechanism that recreate cannot replace, or when
+its deploy cadence differs strongly from the rest of compose.
+Class C is rare — only for true one-shot init that cannot be a
+migration.
+```
+
+## Test plan
+
+### Pre-merge (in PR CI)
+
+- T1: Geen workflow runs verwacht. `caddy / build-push` triggert niet
+  (geen Dockerfile change). `caddy-validate` triggert niet (geen
+  Caddyfile/Dockerfile/build.sh change). `deploy-compose.yml` is
+  push-only. PR-checks lijst zal leeg zijn.
+
+### Post-merge (verificatie procedure)
+
+- V1: `gh run list --workflow deploy-compose.yml -L 1 --json
+  conclusion --jq '.[0].conclusion'` returns `"success"` binnen 5
+  minuten.
+- V2: Workflow-log toont per service ofwel `<svc> config unchanged;
+  skipping recreate.` (idempotent — als de file op core-01 al matched
+  HEAD) ofwel `<svc> is running (attempt N)` (recreate-and-recover —
+  als de file daadwerkelijk wijzigde).
+- V3: 3-way sha256 match per service:
+  ```bash
+  for pair in \
+    "alloy:/opt/klai/alloy/config.alloy:deploy/alloy/config.alloy" \
+    "searxng:/opt/klai/searxng/settings.yml:deploy/searxng/settings.yml" \
+    "runtime-api:/opt/klai/vexa/profiles.yaml:deploy/vexa/profiles.yaml"; do
+    svc="${pair%%:*}"
+    rest="${pair#*:}"
+    host_path="${rest%%:*}"
+    repo_path="${rest##*:}"
+    HEAD=$(curl -fsSL "https://raw.githubusercontent.com/GetKlai/klai/main/$repo_path" | sha256sum | awk '{print $1}')
+    HOST=$(ssh core-01 "sha256sum $host_path" | awk '{print $1}')
+    CTR_PATH=$(case "$svc" in
+      alloy) echo "/etc/alloy/config.alloy";;
+      searxng) echo "/etc/searxng/settings.yml";;
+      runtime-api) echo "/app/profiles.yaml";;
+    esac)
+    CTR=$(ssh core-01 "docker exec klai-core-${svc}-1 sha256sum $CTR_PATH" 2>/dev/null | awk '{print $1}')
+    [ "$HEAD" = "$HOST" ] && [ "$HOST" = "$CTR" ] && echo "$svc PASS" || echo "$svc FAIL — HEAD=$HEAD HOST=$HOST CTR=$CTR"
+  done
+  ```
+
+### Rollback plan
+
+Identiek aan SPEC-INFRA-CADDY-CONFIG-DEPLOY-001: `git revert <merge-
+sha> + git push` triggert opnieuw `deploy-compose.yml`. Alle services
+syncen terug naar oude versies + recreate. Geen handmatige interventie
+op core-01.
+
+## Quality gates
+
+- YAML lint: `python3 -c "import yaml; yaml.safe_load(...)"` op
+  deploy-compose.yml.
+- Bash syntax: `bash -n` op een geëxtraheerde versie van het script
+  (alleen het ssh-action script-blok).
+- SPEC compleet: 4 artefacten in `.moai/specs/SPEC-INFRA-CONFIG-
+  SYNC-001/`.
+- Geen runtime/code regressies: alleen workflow YAML + .md docs
+  geraakt; geen Python/TS/Go.
+
+## Out-of-scope follow-ups
+
+1. Pre-merge syntax-validate workflows voor alloy/searxng/vexa. Per
+   service een eigen `<svc>-validate.yml` met een service-specifieke
+   `<tool> validate` of `<tool> fmt --check`. ROI te bekijken na
+   eerste config-change-incident.
+2. Refactor van grafana provisioning sync naar de helper (vereist
+   directory-mode toevoegen aan helper). Geen ROI tot een andere
+   directory-bind-mount opduikt.
+3. Audit van LiteLLM en LibreChat deploy-workflows — elk hun eigen
+   verhaal, niet hier oplossen.
+4. Per-service health check tuning (10s grace period kan te kort
+   blijken voor één service onder zware load) — adressering bij
+   eerste false-negative incident.

--- a/.moai/specs/SPEC-INFRA-CONFIG-SYNC-001/research.md
+++ b/.moai/specs/SPEC-INFRA-CONFIG-SYNC-001/research.md
@@ -1,0 +1,184 @@
+# SPEC-INFRA-CONFIG-SYNC-001 — Research
+
+## 1. Context: closure van een latente klasse
+
+SPEC-INFRA-CADDY-CONFIG-DEPLOY-001 (gemerged 2026-05-07,
+`a2a090a5`) sloot het Caddyfile-sync gat. Direct na merge bleek bij
+audit van `deploy/docker-compose.yml` dat hetzelfde patroon nog 3
+keer onbeveiligd zit:
+
+```bash
+$ grep -E "^\s+- \./" deploy/docker-compose.yml | sort -u
+      - ./alloy/config.alloy:/etc/alloy/config.alloy:ro            # gat
+      - ./caddy/Caddyfile:/etc/caddy/Caddyfile                      # net dichtgemaakt
+      - ./firecrawl-nuq-init.sql:/docker-entrypoint-initdb.d/...   # one-shot init
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro         # gesynct (SPEC-OBS-001)
+      - ./librechat/getklai/.env                                   # eigen workflow
+      - ./librechat/getklai/images:...                             # eigen workflow
+      - ./librechat/getklai/librechat.yaml:...                     # eigen workflow
+      - ./librechat/patches/format.cjs:...                         # eigen workflow
+      - ./librechat:/librechat                                      # eigen workflow
+      - ./litellm/config.yaml:/app/config.yaml:ro                  # eigen workflow
+      - ./litellm/custom_router.py:...                             # eigen workflow
+      - ./litellm/klai_*.py:...                                    # eigen workflow
+      - ./postgres/init.sql:/docker-entrypoint-initdb.d/...        # one-shot init
+      - ./searxng/settings.yml:/etc/searxng/settings.yml:ro        # gat
+      - ./vexa/profiles.yaml:/app/profiles.yaml:ro                  # gat
+```
+
+Drie gaten:
+- `alloy/config.alloy` — log-pipeline config.
+- `searxng/settings.yml` — search-engine config.
+- `vexa/profiles.yaml` — meeting-bot profielen.
+
+Workflow-trigger audit:
+
+```bash
+$ for path in alloy/config.alloy searxng/settings.yml vexa/profiles.yaml; do
+    grep -lr "deploy/$path" .github/workflows/ 2>/dev/null
+  done
+# alloy: niets
+# searxng: niets
+# vexa: niets
+```
+
+Alle drie zonder eigen sync-workflow.
+
+## 2. Compose service-namen — asymmetrie bij vexa
+
+Bind-mount → compose-service mapping:
+
+| Bind-mount | Compose service |
+|---|---|
+| `./alloy/config.alloy` | `alloy` |
+| `./caddy/Caddyfile` | `caddy` |
+| `./searxng/settings.yml` | `searxng` |
+| `./vexa/profiles.yaml` | **`runtime-api`** (niet `vexa`) |
+
+Bevestigd via `awk` parse van compose:
+```bash
+awk '/^  [a-zA-Z0-9_-]+:$/{svc=$1; sub(":", "", svc)}
+     /\.\/(alloy|searxng|vexa)/{print svc, "→", $0}' deploy/docker-compose.yml
+# alloy →   - ./alloy/config.alloy:/etc/alloy/config.alloy:ro
+# searxng → - ./searxng/settings.yml:/etc/searxng/settings.yml:ro
+# runtime-api → - ./vexa/profiles.yaml:/app/profiles.yaml:ro
+```
+
+De helper accepteert daarom de compose-service-naam als expliciete
+parameter — niet automatisch afgeleid van de bind-mount-path.
+
+## 3. Reload semantiek per service
+
+| Service | Hot-reload mogelijk? | Klai-keuze |
+|---|---|---|
+| caddy | Nee — `admin off` blokkeert reload via Admin API | container-recreate (~1s TLS-onderbreking) |
+| alloy | Ja — HTTP `/-/reload` of SIGHUP signaal | container-recreate (~2-3s observability-blackout, simpler in CI) |
+| searxng | Nee — settings.yml gelezen bij startup | container-recreate (geen alternatief) |
+| runtime-api (vexa) | Onbekend / niet onderzocht | container-recreate (universeel werkend) |
+
+Conclusie: container-recreate is de gemeenschappelijke noemer. Het
+vereenvoudigt de helper en de mental-model. Als toekomstige tuning
+hot-reload voor één service nodig blijkt (bijv. alloy moet onder een
+zware log-load niet herstarten), kan dat per-service als follow-up
+SPEC. Niet voorbarig optimaliseren.
+
+## 4. Helper-design overwegingen
+
+### 4.1 Bash function vs inline copies
+
+Vier inline kopieën van het sync-block (~30 regels per stuk = 120
+regels) zou een onleesbare diff zijn voor reviewers. Eén helper +
+4 calls = ~50 regels totaal en de calls zijn 3-veld-tabellen (svc /
+src / dst). Reviewer kan in één oogopslag valideren.
+
+### 4.2 Bash function placement
+
+Helper definitie binnen het ssh-action `script:` blok, na `set -e`,
+vóór de eerste call. Functie is local in de bash-sessie van de
+SSH-action — geen state-verlies, geen externe import.
+
+### 4.3 Variable scoping
+
+`local svc="$1"` etc. om name-clashes te voorkomen met outer-scope
+variabelen (de bestaande `RSYNC_PROV_CHANGES`, `SMOKE_EXIT`, etc.
+elders in het script). `local` is bash-only; werkt in
+`appleboy/ssh-action`'s remote bash.
+
+### 4.4 Error handling
+
+`set -e` is al actief. Helper kan dus rsync of docker compose
+faillures laten propageren naar workflow-fail. Voor de health check
+loop: expliciete `exit 1` na 10s timeout, met log-dump er voor om
+diagnose te versnellen.
+
+### 4.5 Idempotency
+
+`rsync -ac --itemize-changes`:
+- `-a` archive mode (preserve metadata)
+- `-c` content-checksum (negeert mtime; cruciaal voor fresh git
+  clones met willekeurige mtime)
+- `--itemize-changes` print één regel per file met change-flags
+
+`grep -E '^[<>*]'` filtert change-indicators (`<` = transfer,
+`>` = receive, `*` = special). Als geen matches: bestand was al
+identiek → skip.
+
+## 5. Out-of-scope: andere bind-mount klassen
+
+### 5.1 Klasse A-dir (directory bind-mounts)
+
+- `deploy/grafana/provisioning/` is een dir-rsync (`rsync -ac dir1/
+  dir2/`) — andere flag-set dan single-file rsync. De helper zou twee
+  paden moeten ondersteunen (file vs dir) of we hebben een tweede
+  helper. Niet de moeite tot er een tweede dir-bind-mount bijkomt.
+
+### 5.2 Klasse B (eigen deploy-workflows)
+
+- `litellm-hook-deploy.yml` synct `deploy/litellm/*.{py,yaml}` naar
+  `/opt/klai/litellm/`. Eigen contract; deze SPEC raakt het niet.
+- `deploy-librechat-config.yml` synct
+  `deploy/librechat/{patches,getklai/...}` naar core-01. Eigen
+  contract.
+
+Audit van die twee workflows op vergelijkbare gaps is een aparte SPEC
+indien gewenst.
+
+### 5.3 Klasse C (one-shot init)
+
+- `deploy/postgres/init.sql` en `deploy/firecrawl-nuq-init.sql`
+  worden alleen gelezen door Postgres bij volume-bootstrap. Eenmalige
+  read; geen drift-risico in lopende productie. Migrations zijn de
+  juiste tool voor schema-changes na bootstrap.
+
+## 6. Risk model — eerste post-merge run
+
+Bij de Caddyfile SPEC bleek de host-versie al byte-identiek aan main
+HEAD (manueel-scp van diezelfde dag). Helper zou alleen drie nieuwe
+"unchanged; skipping recreate." messages echoen plus de bestaande caddy
+no-op. Geen recreates → geen downtime. Idempotent.
+
+Mogelijk scenario: één van alloy/searxng/vexa op core-01 verschilt
+toch met main HEAD (bijv. door een handmatige tweak die nooit naar de
+repo gepusht is). Dan recreate die service. Verwacht impact:
+
+| Service | Recreate-window | User-impact |
+|---|---|---|
+| alloy | ~2-3s | log-pipeline gat (logs geboekt na recreate; niets verloren omdat Alloy een persistent volume heeft) |
+| searxng | ~1s | search-degradation, internal-only |
+| runtime-api | ~3-5s | meeting-bot orchestrator API kort niet bereikbaar; actieve meetings raken niet geïnterrumpeerd (eigen containers per meeting) |
+
+Geen catastrofale fail-modes. Acceptabel.
+
+## 7. Sources
+
+- `.github/workflows/deploy-compose.yml` (SPEC-INFRA-CADDY-CONFIG-
+  DEPLOY-001 versie als startpunt)
+- `deploy/docker-compose.yml` (bind-mount inventaris)
+- `.claude/rules/klai/pitfalls/process-rules.md`
+  `docker-compose-restart-vs-recreate (CRIT)`,
+  `bind-mount-content-without-sync` (toe te voegen indirect via deploy.md
+  in deze SPEC)
+- SPEC-INFRA-CADDY-CONFIG-DEPLOY-001 (proof-of-concept, 1× pattern)
+- SPEC-OBS-001 Phase C (grafana provisioning sync, dir-shape)
+- Caddy 2 docs (`admin off` semantiek)
+- Alloy docs (HTTP reload + SIGHUP support, niet gebruikt in Klai)

--- a/.moai/specs/SPEC-INFRA-CONFIG-SYNC-001/spec.md
+++ b/.moai/specs/SPEC-INFRA-CONFIG-SYNC-001/spec.md
@@ -1,0 +1,254 @@
+---
+id: SPEC-INFRA-CONFIG-SYNC-001
+version: "0.1.0"
+status: ready-for-implementation
+created: "2026-05-07"
+updated: "2026-05-07"
+author: MoAI
+priority: high
+issue_number: 0
+---
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 0.1.0 | 2026-05-07 | MoAI | Initial. Generalises the SPEC-INFRA-CADDY-CONFIG-DEPLOY-001 pattern to alloy / searxng / vexa, refactors the rsync block into a reusable bash helper, and codifies the rule for future bind-mounts. |
+
+# SPEC-INFRA-CONFIG-SYNC-001 — Bind-mount config sync expansion
+
+## Overview
+
+SPEC-INFRA-CADDY-CONFIG-DEPLOY-001 (merged 2026-05-07, commit
+`a2a090a5`) sloot het Caddyfile-sync gat. Tijdens de post-merge
+review werd duidelijk dat het gat een **klasse** is, niet een
+incidenteel probleem voor één service. `deploy/docker-compose.yml`
+bevat zeven relative bind-mounts naar config-files; zonder
+sync-workflow blijft de host-versie steken bij wat ooit handmatig
+gescpt werd. Vier daarvan vallen ONDER deze SPEC; drie hebben hun
+eigen aparte mechanismes en blijven buiten scope.
+
+| Bind-mount | Compose service | Status vóór deze SPEC | Status na |
+|---|---|---|---|
+| `./caddy/Caddyfile` | `caddy` | gesynct (SPEC-INFRA-CADDY-CONFIG-DEPLOY-001) | idem (gerefactored naar helper) |
+| `./alloy/config.alloy` | `alloy` | NIET gesynct — gat | gesynct |
+| `./searxng/settings.yml` | `searxng` | NIET gesynct — gat | gesynct |
+| `./vexa/profiles.yaml` | `runtime-api` | NIET gesynct — gat | gesynct |
+| `./grafana/provisioning/` | `grafana` | gesynct (SPEC-OBS-001 Phase C) | ongewijzigd (dir-rsync, andere shape) |
+| `./litellm/*.{py,yaml}` | `litellm` | eigen workflow (`litellm-hook-deploy.yml`) | buiten scope |
+| `./librechat/...` | meerdere | eigen workflow (`deploy-librechat-config.yml`) | buiten scope |
+
+## Doel
+
+1. **Refactor** de Caddyfile-sync inline-block uit
+   `.github/workflows/deploy-compose.yml` naar een reusable bash-helper
+   `sync_and_recreate()`. Eén service was nog te tolereren als inline
+   block; vier identieke kopieën zou een code-smell zijn.
+2. **Apply** de helper op alloy, searxng, en vexa — same shape, same
+   rsync semantics, same content-aware force-recreate, same health
+   check.
+3. **Codify** de regel in `.claude/rules/klai/infra/deploy.md` zodat de
+   volgende ontwikkelaar (mens of AI) die een nieuwe relative
+   bind-mount aan compose toevoegt, mechanisch herinnerd wordt aan de
+   sync-verplichting.
+
+## Environment
+
+- **Affected workflow files:**
+  - `.github/workflows/deploy-compose.yml` — refactor naar helper
+    function; paths-trigger uitbreiden met de drie nieuwe paths;
+    helper aanroepen voor caddy + alloy + searxng + runtime-api.
+
+- **Affected rule files:**
+  - `.claude/rules/klai/infra/deploy.md` — nieuwe sectie "Bind-mount
+    config sync — required pattern" met checklist voor nieuwe
+    bind-mounts.
+
+- **Out-of-scope (geen wijziging):**
+  - Caddy validate workflow (`.github/workflows/caddy-validate.yml`)
+    — alloy/searxng/vexa hebben geen pre-merge validate-step in deze
+    SPEC. Reden: alloy heeft een complexe HCL-achtige config die
+    `alloy fmt` zou willen, searxng's settings.yml is YAML zonder
+    custom validate, vexa's profiles.yaml is YAML. Een generieke
+    YAML-lint zou trivieel zijn maar voegt weinig toe omdat de
+    post-recreate health check de werkelijke runtime-fouten al vangt.
+    Validate-PR-stappen kunnen alsnog komen als follow-up SPECs per
+    service indien dat ROI biedt; out-of-scope voor deze sync-fix.
+  - Grafana provisioning sync — werkt prima, dir-rsync ipv file-rsync,
+    niet de moeite om in dezelfde helper te wringen.
+  - LiteLLM en LibreChat — eigen deploy-workflows; aparte audits.
+
+- **Affected production paths op core-01 (na deze SPEC):**
+  - `/opt/klai/alloy/config.alloy`
+  - `/opt/klai/searxng/settings.yml`
+  - `/opt/klai/vexa/profiles.yaml`
+
+  De directories `/opt/klai/{alloy,searxng,vexa}/` worden door de
+  helper aangemaakt indien afwezig (`mkdir -p`).
+
+## Assumptions
+
+- A1: Alloy ondersteunt clean container restart (~2-3s observability-
+  blackout tijdens recreate). Geen log-data verloren omdat Alloy de
+  Docker socket positie persistert in zijn data volume.
+- A2: Searxng leest `settings.yml` bij startup; recreate is de
+  canonieke reload-route. Geen hot-reload nodig.
+- A3: Vexa runtime-api leest `profiles.yaml` bij startup en bij
+  expliciete profile-load API-calls. Recreate vangt beide gevallen.
+- A4: De caddy SPEC's force-recreate pattern (`docker compose
+  --project-directory /opt/klai up -d --force-recreate <svc>`) werkt
+  voor alle vier services identiek. Bevestigd door grafana-precedent
+  (zelfde flag, zelfde shape).
+- A5: Vexa profiles.yaml-mount zit op compose-service `runtime-api`
+  (NIET `vexa`). De helper accepteert de compose-service-naam als
+  parameter, niet de file-path-derived naam.
+- A6: De drie nieuwe bind-mounts hebben eerder via handmatige scp /
+  initial-bootstrap een file op core-01 staan. Eerste sync na merge
+  rsynct met content-checksum vergelijking; identieke files = geen
+  recreate (idempotent).
+
+## Requirements
+
+### R1 — Ubiquitous: bash-helper voor sync-and-recreate
+
+`.github/workflows/deploy-compose.yml` SHALL een bash function
+`sync_and_recreate()` definiëren die de volgende parameters accepteert:
+
+- `$1` = compose service name (e.g., `caddy`, `alloy`, `searxng`,
+  `runtime-api`)
+- `$2` = source path in checkout (e.g., `deploy/caddy/Caddyfile`)
+- `$3` = destination path op host (e.g., `/opt/klai/caddy/Caddyfile`)
+
+De helper SHALL:
+
+1. `mkdir -p "$(dirname "$3")"` zodat de dest-directory bestaat.
+2. `rsync -ac --itemize-changes "$2" "$3"` runnen en de content-
+   change-output capturen.
+3. Indien content-change non-empty:
+   a. Echo `<svc> config content changed:` + de rsync-output.
+   b. `docker compose --project-directory /opt/klai up -d
+      --force-recreate "$1"` runnen.
+   c. Health check loop (5×2s) via `docker compose ps -q "$1"` +
+      `docker inspect --format '{{.State.Status}}'`. Op `running`
+      breken + success. Anders na 10s `::error::`, log-dump van laatste
+      50 regels, en `exit 1`.
+4. Indien content-change empty:
+   a. Echo `<svc> config unchanged; skipping recreate.`
+   b. Geen verdere actie.
+
+De helper SHALL geen externe afhankelijkheden hebben anders dan
+`rsync`, `docker`, en de docker compose CLI.
+
+### R2 — Ubiquitous: pas helper toe op alle vier de single-file bind-mounts
+
+Het workflow-script SHALL de helper aanroepen voor:
+
+```bash
+sync_and_recreate caddy       deploy/caddy/Caddyfile        /opt/klai/caddy/Caddyfile
+sync_and_recreate alloy       deploy/alloy/config.alloy     /opt/klai/alloy/config.alloy
+sync_and_recreate searxng     deploy/searxng/settings.yml   /opt/klai/searxng/settings.yml
+sync_and_recreate runtime-api deploy/vexa/profiles.yaml     /opt/klai/vexa/profiles.yaml
+```
+
+Deze vier calls vervangen het bestaande inline caddy-block in
+`deploy-compose.yml` (geïntroduceerd door SPEC-INFRA-CADDY-CONFIG-
+DEPLOY-001). Functioneel resultaat voor caddy is identiek; verschil is
+alleen de structurele DRY.
+
+### R3 — Ubiquitous: paths-trigger uitbreiden
+
+`.github/workflows/deploy-compose.yml` SHALL triggeren op pushes naar
+main die enige van deze files raken:
+
+```yaml
+paths:
+  - 'deploy/docker-compose.yml'
+  - 'deploy/docker-compose.override.yml'
+  - 'deploy/caddy/Caddyfile'                  # bestaand
+  - 'deploy/alloy/config.alloy'               # nieuw
+  - 'deploy/searxng/settings.yml'             # nieuw
+  - 'deploy/vexa/profiles.yaml'               # nieuw
+  - 'deploy/grafana/provisioning/**'
+  - 'deploy/scripts/**'
+  - 'scripts/smoke-docker-socket-proxy.sh'
+  - '.github/workflows/deploy-compose.yml'
+```
+
+De sparse-checkout in het script SHALL deze paths ook bevatten.
+
+### R4 — Ubiquitous: regel-codificatie in `infra/deploy.md`
+
+`.claude/rules/klai/infra/deploy.md` SHALL een nieuwe sectie krijgen
+"Bind-mount config sync — required pattern" met:
+
+1. Het probleem (host-bind-mount zonder sync-workflow = config drift)
+2. De canonieke fix (helper + paths-trigger + sparse-checkout +
+   helper-call)
+3. Een checklist voor nieuwe relative bind-mounts in compose
+4. Verwijzingen naar de SPECs (CADDY-CONFIG-DEPLOY + deze)
+5. De huidige inventaris van klasse-A (gesynct) vs klasse-B (eigen
+   workflow) vs klasse-C (one-shot init, geen sync nodig) bind-mounts
+
+Dit is het mechanische voorkomen van het volgende bind-mount-zonder-
+sync-incident.
+
+### R5 — Out-of-scope: pre-merge validate per service
+
+Pre-merge syntax-validate voor alloy/searxng/vexa SHALL NIET in deze
+SPEC opgenomen worden. Reden: shape per service verschilt (HCL-achtig
+vs YAML-met-schema vs YAML-zonder-schema), en de post-recreate health
+check (R1.3.c) vangt al runtime-fouten met een acceptabele false-
+negative-rate. Toekomstige per-service SPECs kunnen dit alsnog
+toevoegen indien ROI dat rechtvaardigt.
+
+## Non-Goals
+
+- Pre-merge validate workflows voor alloy/searxng/vexa (zie R5).
+- Refactor van grafana provisioning sync (dir-rsync, andere shape,
+  werkt; geen waarde uit forceren in dezelfde helper).
+- Audit van LiteLLM / LibreChat deploy workflows (eigen workflows,
+  aparte SPECs indien nodig).
+- Audit van one-shot init bind-mounts (`./postgres/init.sql`,
+  `./firecrawl-nuq-init.sql`) — die worden alleen op DB-volume-create
+  gelezen, geen drift-risico in lopende productie.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Eerste post-merge run recreate alle 3 services tegelijk → cumulatieve downtime | Health check na elke recreate; failure stopt de loop. In praktijk: rsync content-vergelijking → idempotent skip als de scp-versies al in sync zijn. Plan om dit te bevestigen via post-merge verificatie. |
+| Vexa runtime-api recreate breekt actieve meeting-bots | Acceptabel: actieve meetings hebben hun eigen container per meeting; runtime-api is alleen de orchestrator-API. Zelfde semantiek als vandaag bij elke vexa-deploy. |
+| Bash helper-syntax fouten | YAML lint + GitHub Actions parses bash op runtime; first run zou meteen een fout signaleren. Verkleind door geen exotische bash-features te gebruiken. |
+| Helper crasht halverwege → workflow hangt | `set -e` bovenaan het ssh-action `script:` is al aanwezig. Helper exits non-zero op health failure → workflow exits → operator gealerteerd. |
+| Een service heeft een healthcheck-grace-period van >10s na recreate | Health check loop wacht max 10s. Als een service stiller-start, false negative. Mitigation: configureerbaar maken of per-service uitgebreid (out-of-scope follow-up). Voor caddy/alloy/searxng/vexa is 10s ruim voldoende. |
+
+## Implementation order
+
+1. SPEC artefacten schrijven (deze + plan + acceptance + research).
+2. Refactor `deploy-compose.yml`:
+   a. Helper function definiëren bovenin het ssh-action script (na
+      `set -e`).
+   b. Bestaande inline caddy-block vervangen door
+      `sync_and_recreate caddy ...` call.
+   c. Drie nieuwe calls voor alloy, searxng, runtime-api toevoegen.
+   d. Paths-trigger en sparse-checkout uitbreiden met de drie nieuwe
+      paths.
+3. Update `infra/deploy.md` met de nieuwe sectie + checklist + bind-
+   mount inventaris.
+4. Lokale YAML lint, Markdown review.
+5. Open PR. CI runs:
+   a. `caddy / build-push` — niet (geen Dockerfile change)
+   b. `Validate Caddyfile / validate` — niet (Caddyfile niet aangeraakt
+      in deze PR)
+   c. `Sync docker-compose.yml...` — niet pre-merge (push-only)
+6. Admin merge na review.
+7. Post-merge verificatie:
+   a. `gh run list --workflow deploy-compose.yml -L 1` → success.
+   b. 3-way sha256 match per service:
+      - main HEAD vs `/opt/klai/<svc>/<file>` vs container's view.
+   c. Workflow log inspect: viermaal `<svc> config unchanged;
+      skipping recreate.` (idempotent eerste run) of `<svc> is running
+      (attempt N)` (recreate-and-recover).
+
+Zie `plan.md` voor exacte file-edits en `acceptance.md` voor de
+verificatie-procedure per service.


### PR DESCRIPTION
## Why

SPEC-INFRA-CADDY-CONFIG-DEPLOY-001 (merged earlier today, `a2a090a5`) closed the Caddyfile sync gap. Post-merge audit of `deploy/docker-compose.yml` revealed **three identical gaps** in the same class:

| Bind-mount | Compose service | Status |
|---|---|---|
| `./alloy/config.alloy` | `alloy` | not synced — same gap as Caddyfile had |
| `./searxng/settings.yml` | `searxng` | not synced — same gap |
| `./vexa/profiles.yaml` | `runtime-api` (note: not `vexa`) | not synced — same gap |

Same shape. Same risk. Same fix.

## Why one SPEC, not three

The pattern-design is settled (caddy SPEC). Three separate SPECs would duplicate the rationale + acceptance-criteria + risk-analysis three times for what is structurally a copy-paste with parameter substitution. One SPEC + one PR is the right scope:

- DRY refactor (helper function) ROI requires ≥2 services
- Common rule (`bind-mount-without-sync = bug`) is best codified once, referenced everywhere
- Verification matrix is identical across services (3-way sha256 match)

## What this PR does

| File | Change |
|---|---|
| `.github/workflows/deploy-compose.yml` | (1) paths trigger + sparse-checkout extended for alloy/searxng/vexa. (2) Inline Caddyfile sync block extracted into reusable `sync_and_recreate <svc> <src> <dst>` bash helper. (3) Helper applied 4× — caddy (refactored), alloy (new), searxng (new), runtime-api (new, mounts vexa profiles). |
| `.claude/rules/klai/infra/deploy.md` | New section "Bind-mount config sync — required pattern" with the 3-step checklist for new bind-mounts and a Class A/A-dir/B/C inventory of all current ones. |
| `.moai/specs/SPEC-INFRA-CONFIG-SYNC-001/` | spec.md + plan.md + acceptance.md + research.md (compact — pattern was uitgekauwd in vorige SPEC). |

## Vexa asymmetry — important

`deploy/vexa/profiles.yaml` is bind-mounted into the **`runtime-api`** compose service (not a service named `vexa`). The helper takes the compose-service name as an explicit parameter to handle this. Documented in deploy.md inventory.

## Out of scope

- Pre-merge syntax-validate workflows for alloy/searxng/vexa — post-recreate health check catches runtime errors with acceptable false-negative rate. Per-service validate is its own ROI question.
- Grafana provisioning sync refactor — dir-rsync, different shape, works fine.
- LiteLLM (`litellm-hook-deploy.yml`) and LibreChat (`deploy-librechat-config.yml`) bind-mount audits — own workflows, separate audits if needed.

## Risk

| Risk | Mitigation |
|---|---|
| First post-merge run recreates 3 services tegelijk → cumulatieve downtime | Per-service health check; failure stopt loop. In praktijk: rsync content-vergelijking is idempotent, dus als de manual scp's al matched zijn = no-op skip. |
| Vexa runtime-api recreate breekt actieve meeting-bots | Acceptabel: actieve meetings hebben eigen containers per meeting; runtime-api is alleen orchestrator-API. Zelfde semantiek als bestaande vexa-deploys. |
| Health check 10s te kort onder zware load | False-negative pad → operator gealerteerd via `::error::`. Tuning is per-service follow-up. |

**Rollback** = `git revert <merge-sha> + git push`. Re-triggers `deploy-compose.yml`, rsync's vorige versies terug, recreates. Geen handmatige core-01 actie.

## Acceptance verification (post-merge)

Full procedure in `.moai/specs/SPEC-INFRA-CONFIG-SYNC-001/acceptance.md`. Snelle versie:

```bash
gh run list --workflow deploy-compose.yml -L 1 --json conclusion --jq '.[0].conclusion'
# expect: "success"

# 3-way sha256 per service (alloy/searxng/runtime-api)
for spec in \
  "alloy:/opt/klai/alloy/config.alloy:deploy/alloy/config.alloy:/etc/alloy/config.alloy:klai-core-alloy-1" \
  "searxng:/opt/klai/searxng/settings.yml:deploy/searxng/settings.yml:/etc/searxng/settings.yml:klai-core-searxng-1" \
  "runtime-api:/opt/klai/vexa/profiles.yaml:deploy/vexa/profiles.yaml:/app/profiles.yaml:klai-core-runtime-api-1"; do
  ...
done
```

## CI expectations on this PR

- ❌ `caddy / build-push` — should NOT run (no Dockerfile change)
- ❌ `Validate Caddyfile / validate` — should NOT run (no Caddyfile/Dockerfile change)
- ❌ `Sync docker-compose.yml...` — should NOT run on PR (push-only)

PR-checks lijst zal leeg zijn. Hopelijk geen surprises.

Refs: SPEC-INFRA-CADDY-CONFIG-DEPLOY-001 (proof-of-concept), SPEC-OBS-001 Phase C (grafana provisioning sync — sibling pattern, dir-shape), `process-rules.md::docker-compose-restart-vs-recreate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)