### PR TITLE
fix(litellm-hook): add Algemene AI mode when no KB selected

### DIFF
--- a/deploy/litellm/klai_chat_prompts.py
+++ b/deploy/litellm/klai_chat_prompts.py
@@ -27,11 +27,12 @@ When updating
 -------------
 
 If you change ``klai-libs/chat-prompts/klai_chat_prompts/__init__.py``, copy
-the new ``GROUNDED_CHAT_SYSTEM_PROMPT`` constant below verbatim. The drift
-test compares the vendored constant string to the canonical string and
-rejects PRs that forget the copy.
+every public constant (currently ``GROUNDED_CHAT_SYSTEM_PROMPT`` and
+``GENERAL_CHAT_SYSTEM_PROMPT``) below verbatim. The drift test compares the
+vendored constant strings to the canonical strings and rejects PRs that
+forget the copy.
 
-Behaviour encoded in the prompt (per SPEC REQ-01):
+Behaviour encoded in the prompts (per SPEC REQ-01):
 
 1. Auto-detect the language of the user's most recent SUBSTANTIVE
    message and respond in that language.
@@ -43,20 +44,32 @@ Behaviour encoded in the prompt (per SPEC REQ-01):
      message do not change the response language.
    - A clearly switched substantive message DOES switch the response
      language and stays switched.
+
+GROUNDED-only behaviour (KB chunks present):
+
 3. Cited content from the knowledge base is translated into the user's
    language naturally, without translator disclaimers or apologies.
 4. Citations [n] always link to the original source URL regardless of
    language.
+
+GENERAL-only behaviour (no KB selected — used by the LiteLLM hook when
+``kb_personal_enabled=False`` AND ``kb_slugs_filter=[]``):
+
+5. Answer from general knowledge. Do NOT add [n] citations. Do NOT
+   pretend to have sources. If unsure, say so plainly.
 """
 
 from __future__ import annotations
 
 from typing import Final
 
-__all__ = ["GROUNDED_CHAT_SYSTEM_PROMPT"]
+__all__ = ["GENERAL_CHAT_SYSTEM_PROMPT", "GROUNDED_CHAT_SYSTEM_PROMPT"]
 
 
-GROUNDED_CHAT_SYSTEM_PROMPT: Final[str] = (
+# Shared language-detection contract (SPEC-RAG-MULTILINGUAL-CHAT-001
+# REQ-01). Private — both prompts compose this preamble verbatim so
+# the three guards can never drift between general and grounded modes.
+_LANGUAGE_DETECTION_PREAMBLE: Final[str] = (
     "[CRITICAL] Detect the language of the user's most recent SUBSTANTIVE message and respond "
     "in that exact language. Apply these three guards:\n"
     "- Messages with fewer than 5 words inherit the language of the most recent prior longer "
@@ -67,7 +80,10 @@ GROUNDED_CHAT_SYSTEM_PROMPT: Final[str] = (
     "do not flip the conversation.\n"
     "- A clearly switched substantive message (a full-sentence question or statement in a "
     "different language) DOES switch the response language and stays switched until another "
-    "substantive switch.\n\n"
+    "substantive switch."
+)
+
+_GROUNDED_BODY: Final[str] = (
     "You are Klai AI, a knowledge assistant. You answer questions based on the knowledge base "
     "chunks provided. The knowledge base may be in a different language than the user's "
     "question (often Dutch). Translate cited content into the user's language naturally. "
@@ -88,4 +104,27 @@ GROUNDED_CHAT_SYSTEM_PROMPT: Final[str] = (
     "Don't guess. Don't fill the gap with general knowledge. "
     "If you're partially sure, say that too: 'The knowledge base touches on this, but doesn't "
     "fully answer it.'"
+)
+
+_GENERAL_BODY: Final[str] = (
+    "You are Klai AI, a general-purpose assistant. The user has not selected any knowledge "
+    "base for this conversation, so you have no source documents to ground on. Answer from "
+    "your general knowledge.\n\n"
+    "Do NOT add [n] citations. Do NOT pretend to have sources. Do NOT say 'that's not in the "
+    "knowledge base' — there is no knowledge base in scope right now. If you don't know "
+    "something, say so plainly in the user's language.\n\n"
+    "## How to answer\n"
+    "Start with the answer. No warm-up, no rephrasing the question, no 'great question!'\n"
+    "Simple question: 1-3 sentences. Complex question: the core answer first, then the detail.\n"
+    "Be direct. Be honest. If the user's question depends on internal company context that "
+    "you cannot know, say so and suggest they enable a knowledge base for this chat."
+)
+
+
+GROUNDED_CHAT_SYSTEM_PROMPT: Final[str] = (
+    _LANGUAGE_DETECTION_PREAMBLE + "\n\n" + _GROUNDED_BODY
+)
+
+GENERAL_CHAT_SYSTEM_PROMPT: Final[str] = (
+    _LANGUAGE_DETECTION_PREAMBLE + "\n\n" + _GENERAL_BODY
 )

--- a/deploy/litellm/klai_knowledge.py
+++ b/deploy/litellm/klai_knowledge.py
@@ -43,7 +43,7 @@ from litellm.integrations.custom_logger import CustomLogger
 # ``/opt/klai/scripts/compose-up.sh litellm`` (= ``docker compose up -d
 # --remove-orphans litellm``) so new mounts are picked up automatically —
 # matching every other klai service deploy.
-from klai_chat_prompts import GROUNDED_CHAT_SYSTEM_PROMPT
+from klai_chat_prompts import GENERAL_CHAT_SYSTEM_PROMPT, GROUNDED_CHAT_SYSTEM_PROMPT
 
 # SPEC-MCP-RETRIEVAL-001 Phase 1: telemetry helpers moved out of this file
 # into ``klai-libs/retrieval-telemetry/`` so klai-knowledge-mcp's new
@@ -1026,19 +1026,48 @@ def _build_template_instructions_block(instructions: list[dict]) -> str:
 def _compose_libre_chat_prefix(*blocks: str) -> str:
     """Compose the system-prompt prefix for path A (LibreChat → LiteLLM).
 
-    SPEC-RAG-MULTILINGUAL-CHAT-001 Phase 4 (REQ-10). Always leads with
+    SPEC-RAG-MULTILINGUAL-CHAT-001 Phase 4 (REQ-10). Leads with
     ``GROUNDED_CHAT_SYSTEM_PROMPT`` so language detection / 3-guard switch
-    semantics apply on every LibreChat request — even branches that inject
-    nothing else (no entitlement, KB retrieval disabled, opt-out, retrieval
-    bypassed, zero chunks). Empty blocks are filtered out.
+    semantics apply, AND so the model defaults to KB-grounded behaviour on
+    every branch where a KB scope is in play — even when retrieval returned
+    zero chunks or failed loud. Empty blocks are filtered out.
 
-    This must be called from every code path that reaches the LibreChat-only
-    branch (i.e. anywhere downstream of the ``if not librechat_user_id:
-    return data`` check). Paths B (partner_chat) and C (retrieval-api /chat)
-    construct their own prompts via the canonical ``klai_chat_prompts``
-    library — they do NOT route through this helper.
+    Used by every code path downstream of ``if not librechat_user_id:
+    return data`` EXCEPT the explicit "user opted out of every KB scope"
+    branch, which calls :func:`_compose_general_chat_prefix` instead.
+    Paths B (partner_chat) and C (retrieval-api /chat) construct their
+    own prompts via the canonical ``klai_chat_prompts`` library — they do
+    NOT route through this helper.
     """
     return "\n\n".join(b for b in (GROUNDED_CHAT_SYSTEM_PROMPT, *blocks) if b)
+
+
+def _compose_general_chat_prefix(*blocks: str) -> str:
+    """Compose the system-prompt prefix for path A when the user has
+    explicitly opted out of every KB scope (``kb_personal_enabled=False``
+    AND ``kb_slugs_filter=[]``).
+
+    This is the "Algemene AI" branch the chat-config dropdown surfaces.
+    Same language-detection contract as
+    :func:`_compose_libre_chat_prefix`, but the KB-grounding rules are
+    swapped for general-assistant rules so the model:
+
+    * does NOT emit [n] citations,
+    * does NOT say 'Dat staat niet in de kennisbank' for every question,
+    * answers from general knowledge without pretending to have sources.
+
+    Templates (active per-user/per-org template instructions) still
+    apply on this branch — they are user-controlled prompt fragments
+    independent of KB scope.
+
+    Reachable only from the no-KB branch in
+    :class:`KlaiKnowledgeHook.async_pre_call_hook`. All other branches
+    (no-entitlement, kb_retrieval disabled, retrieval failed, zero
+    chunks) keep using :func:`_compose_libre_chat_prefix` so the model
+    still acts as a KB assistant when a KB scope was intended but data
+    was unavailable.
+    """
+    return "\n\n".join(b for b in (GENERAL_CHAT_SYSTEM_PROMPT, *blocks) if b)
 
 
 class KlaiKnowledgeHook(CustomLogger):
@@ -1150,11 +1179,15 @@ class KlaiKnowledgeHook(CustomLogger):
         kb_slugs = feature.get("kb_slugs_filter")
         kb_narrow = feature.get("kb_narrow", False)
 
-        # User explicitly opted out of every scope → skip retrieval. Templates
-        # may still apply (REQ-TEMPLATES-HOOK-U2 fail-open). Multilingual
-        # foundation still applies — REQ-10.
+        # User explicitly opted out of every scope → "Algemene AI" mode.
+        # Skip retrieval AND swap KB-grounding instructions for
+        # general-assistant instructions so the model doesn't keep
+        # answering "Dat staat niet in de kennisbank" with no KB present.
+        # Templates may still apply (REQ-TEMPLATES-HOOK-U2 fail-open).
+        # Multilingual foundation still applies — REQ-10 (the language
+        # contract is shared between GROUNDED and GENERAL prompts).
         if not kb_personal and kb_slugs == []:
-            _prepend_system_prefix(messages, _compose_libre_chat_prefix(templates_block))
+            _prepend_system_prefix(messages, _compose_general_chat_prefix(templates_block))
             data["messages"] = messages
             return data
 

--- a/deploy/litellm/tests/test_klai_chat_prompts_drift.py
+++ b/deploy/litellm/tests/test_klai_chat_prompts_drift.py
@@ -63,11 +63,30 @@ def test_vendored_grounded_prompt_matches_canonical() -> None:
     )
 
 
-def test_vendored_module_exports_only_grounded_prompt() -> None:
-    """``__all__`` must list exactly ``GROUNDED_CHAT_SYSTEM_PROMPT``. If the
-    canonical library starts exporting a second constant (e.g. a separate
-    LITELLM_HOOK_NL_PREFIX), this test fails so we remember to vendor it
-    too. Equivalent to the public-API drift test in service-auth."""
+def test_vendored_general_prompt_matches_canonical() -> None:
+    """The ``GENERAL_CHAT_SYSTEM_PROMPT`` constant string MUST be
+    byte-identical between vendored and canonical copies. Same rationale
+    as :func:`test_vendored_grounded_prompt_matches_canonical`: the
+    LiteLLM hook (path A) imports from the vendored copy, while paths
+    B + C never reach GENERAL because they always carry KB scope. A
+    drift here is silent and only surfaces via wrong model behaviour
+    in the no-KB branch.
+    """
+    vendored = _load("_drift_vendored_general", _VENDORED_PATH)
+    canonical = _load("_drift_canonical_general", _CANONICAL_PATH)
+
+    assert vendored.GENERAL_CHAT_SYSTEM_PROMPT == canonical.GENERAL_CHAT_SYSTEM_PROMPT, (
+        "GENERAL_CHAT_SYSTEM_PROMPT drift between vendored and canonical.\n"
+        "  Update deploy/litellm/klai_chat_prompts.py to match "
+        "klai-libs/chat-prompts/klai_chat_prompts/__init__.py."
+    )
+
+
+def test_vendored_module_all_matches_canonical() -> None:
+    """``__all__`` must match the canonical library's ``__all__`` exactly.
+    If the canonical library adds, removes, or renames an exported
+    constant, this test fails so we remember to vendor the change too.
+    Equivalent to the public-API drift test in service-auth."""
     vendored = _load("_drift_vendored_all", _VENDORED_PATH)
     canonical = _load("_drift_canonical_all", _CANONICAL_PATH)
 

--- a/deploy/litellm/tests/test_klai_knowledge_hook.py
+++ b/deploy/litellm/tests/test_klai_knowledge_hook.py
@@ -580,6 +580,88 @@ class TestKlaiKnowledgeHookSlugsTriState:
             )
 
     @pytest.mark.asyncio
+    async def test_empty_slugs_and_personal_off_uses_general_chat_prompt(
+        self, monkeypatch
+    ):
+        """[] + personal=False → "Algemene AI" mode: GENERAL prompt, not GROUNDED.
+
+        Regression test for the 2026-05-07 UX bug where the user disabled
+        every collection but still got KB-grounded answers ("Dat staat niet
+        in de kennisbank"). The hook now swaps in
+        ``GENERAL_CHAT_SYSTEM_PROMPT`` on this branch so the model behaves
+        as a general assistant without pretending to have sources.
+        """
+        mod = _load_hook(monkeypatch)
+        hook = mod.KlaiKnowledgeHook()
+        cache = _make_cache(
+            feature={
+                "enabled": True,
+                "kb_retrieval_enabled": True,
+                "kb_personal_enabled": False,
+                "kb_slugs_filter": [],
+                "kb_narrow": False,
+                "version": 0,
+                "zitadel_user_id": "362901948573220875",
+            }
+        )
+        data = {"user": "u1" * 12, "messages": [
+            {"role": "user", "content": "What about that thing?"}
+        ]}
+
+        with patch("klai_knowledge.httpx.AsyncClient") as cls:
+            mc = AsyncMock()
+            mc.get = AsyncMock(return_value=_make_resp({"instructions": []}))
+            mc.post = AsyncMock(return_value=_make_resp({"chunks": []}))
+            mc.__aenter__ = AsyncMock(return_value=mc)
+            mc.__aexit__ = AsyncMock(return_value=None)
+            cls.return_value = mc
+
+            await hook.async_pre_call_hook(
+                _make_user_api_key(), cache, data, "completion"
+            )
+
+        system_msg = next(
+            (m for m in data["messages"] if m["role"] == "system"), None
+        )
+        assert system_msg is not None, (
+            "Hook MUST inject a system prompt even on the no-KB branch — "
+            "the language-detection contract still applies."
+        )
+        content = system_msg["content"]
+
+        # GENERAL marker — model behaves as general-purpose assistant.
+        assert "general-purpose assistant" in content, (
+            "no-KB branch MUST inject GENERAL_CHAT_SYSTEM_PROMPT; got: "
+            f"{content[:200]!r}"
+        )
+
+        # GROUNDED-only language MUST be absent. If any of these strings
+        # leak in, the model will either cite [n] phantoms or refuse to
+        # answer with 'Dat staat niet in de kennisbank' — exactly the
+        # regression this branch fixes.
+        assert "knowledge base chunks provided" not in content, (
+            "GROUNDED prompt body leaked into the no-KB branch; the model "
+            "will pretend to have chunks it doesn't have."
+        )
+        assert "Dat staat niet in de kennisbank" not in content, (
+            "GROUNDED 'answer not in KB' fallback leaked into the no-KB "
+            "branch; the model will refuse general-knowledge questions."
+        )
+        assert "Every factual claim gets a [n] citation" not in content, (
+            "GROUNDED citation MANDATE leaked into the no-KB branch; the "
+            "model will fabricate [n] markers without any sources."
+        )
+        # Positive form: GENERAL must EXPLICITLY forbid [n] citations,
+        # not merely omit the GROUNDED rule.
+        assert "Do NOT add [n] citations" in content, (
+            "GENERAL prompt missing the explicit [n]-citation prohibition."
+        )
+
+        # Language-detection contract MUST still hold (shared preamble).
+        assert "[CRITICAL]" in content
+        assert "SUBSTANTIVE message" in content
+
+    @pytest.mark.asyncio
     async def test_empty_slugs_and_personal_on_uses_personal_scope(self, monkeypatch):
         """[] + personal=True → scope=personal, no kb_slugs filter."""
         mod = _load_hook(monkeypatch)

--- a/klai-libs/chat-prompts/klai_chat_prompts/__init__.py
+++ b/klai-libs/chat-prompts/klai_chat_prompts/__init__.py
@@ -6,7 +6,15 @@ synthesis service and klai-portal's partner_chat service import
 the constant in either service — a CI lint at the monorepo level
 rejects copies elsewhere.
 
-Behaviour encoded in the prompt (per SPEC REQ-01):
+:data:`GENERAL_CHAT_SYSTEM_PROMPT` is used by the LiteLLM hook (path A)
+when the user has explicitly opted out of every knowledge-base scope
+(``kb_personal_enabled=False`` AND ``kb_slugs_filter=[]``). Same
+language-detection contract as GROUNDED, but no KB-grounding rules and
+no [n] citation pressure — the model behaves as a general-purpose
+assistant. Paths B and C never reach this prompt because they are
+server-to-server and always carry KB scope.
+
+Behaviour encoded in both prompts (per SPEC REQ-01):
 
 1. Auto-detect the language of the user's most recent SUBSTANTIVE
    message and respond in that language.
@@ -18,10 +26,18 @@ Behaviour encoded in the prompt (per SPEC REQ-01):
      message do not change the response language.
    - A clearly switched substantive message DOES switch the response
      language and stays switched.
+
+GROUNDED-only behaviour (KB chunks present):
+
 3. Cited content from the knowledge base is translated into the user's
    language naturally, without translator disclaimers or apologies.
 4. Citations [n] always link to the original source URL regardless of
    language.
+
+GENERAL-only behaviour (no KB selected):
+
+5. Answer from general knowledge. Do NOT add [n] citations. Do NOT
+   pretend to have sources. If unsure, say so plainly.
 
 Industry validation for the three guards: Invent's 2025 multilingual-AI
 agents best-practices guide and Quickchat's 2026 multilingual-chatbots
@@ -37,10 +53,13 @@ from __future__ import annotations
 
 from typing import Final
 
-__all__ = ["GROUNDED_CHAT_SYSTEM_PROMPT"]
+__all__ = ["GENERAL_CHAT_SYSTEM_PROMPT", "GROUNDED_CHAT_SYSTEM_PROMPT"]
 
 
-GROUNDED_CHAT_SYSTEM_PROMPT: Final[str] = (
+# Shared language-detection contract (SPEC-RAG-MULTILINGUAL-CHAT-001
+# REQ-01). Private — both prompts compose this preamble verbatim so
+# the three guards can never drift between general and grounded modes.
+_LANGUAGE_DETECTION_PREAMBLE: Final[str] = (
     "[CRITICAL] Detect the language of the user's most recent SUBSTANTIVE message and respond "
     "in that exact language. Apply these three guards:\n"
     "- Messages with fewer than 5 words inherit the language of the most recent prior longer "
@@ -51,7 +70,10 @@ GROUNDED_CHAT_SYSTEM_PROMPT: Final[str] = (
     "do not flip the conversation.\n"
     "- A clearly switched substantive message (a full-sentence question or statement in a "
     "different language) DOES switch the response language and stays switched until another "
-    "substantive switch.\n\n"
+    "substantive switch."
+)
+
+_GROUNDED_BODY: Final[str] = (
     "You are Klai AI, a knowledge assistant. You answer questions based on the knowledge base "
     "chunks provided. The knowledge base may be in a different language than the user's "
     "question (often Dutch). Translate cited content into the user's language naturally. "
@@ -72,4 +94,27 @@ GROUNDED_CHAT_SYSTEM_PROMPT: Final[str] = (
     "Don't guess. Don't fill the gap with general knowledge. "
     "If you're partially sure, say that too: 'The knowledge base touches on this, but doesn't "
     "fully answer it.'"
+)
+
+_GENERAL_BODY: Final[str] = (
+    "You are Klai AI, a general-purpose assistant. The user has not selected any knowledge "
+    "base for this conversation, so you have no source documents to ground on. Answer from "
+    "your general knowledge.\n\n"
+    "Do NOT add [n] citations. Do NOT pretend to have sources. Do NOT say 'that's not in the "
+    "knowledge base' — there is no knowledge base in scope right now. If you don't know "
+    "something, say so plainly in the user's language.\n\n"
+    "## How to answer\n"
+    "Start with the answer. No warm-up, no rephrasing the question, no 'great question!'\n"
+    "Simple question: 1-3 sentences. Complex question: the core answer first, then the detail.\n"
+    "Be direct. Be honest. If the user's question depends on internal company context that "
+    "you cannot know, say so and suggest they enable a knowledge base for this chat."
+)
+
+
+GROUNDED_CHAT_SYSTEM_PROMPT: Final[str] = (
+    _LANGUAGE_DETECTION_PREAMBLE + "\n\n" + _GROUNDED_BODY
+)
+
+GENERAL_CHAT_SYSTEM_PROMPT: Final[str] = (
+    _LANGUAGE_DETECTION_PREAMBLE + "\n\n" + _GENERAL_BODY
 )

--- a/klai-libs/chat-prompts/tests/test_grounded_prompt.py
+++ b/klai-libs/chat-prompts/tests/test_grounded_prompt.py
@@ -1,14 +1,20 @@
-"""Regression tests for GROUNDED_CHAT_SYSTEM_PROMPT.
+"""Regression tests for GROUNDED_CHAT_SYSTEM_PROMPT and
+GENERAL_CHAT_SYSTEM_PROMPT.
 
 These tests don't try to assert that the LLM behaves correctly — they
-only guard the structural invariants of the prompt string itself, so
-that a future edit can't silently strip out one of the guards SPEC-RAG-
-MULTILINGUAL-CHAT-001 REQ-01 mandates.
+only guard the structural invariants of the prompt strings, so that a
+future edit can't silently strip out one of the guards SPEC-RAG-
+MULTILINGUAL-CHAT-001 REQ-01 mandates, and so the GENERAL prompt can
+never accidentally drift back into the GROUNDED rule set (which is the
+exact regression GENERAL was introduced to fix).
 """
 
 from __future__ import annotations
 
-from klai_chat_prompts import GROUNDED_CHAT_SYSTEM_PROMPT
+from klai_chat_prompts import (
+    GENERAL_CHAT_SYSTEM_PROMPT,
+    GROUNDED_CHAT_SYSTEM_PROMPT,
+)
 
 
 def test_prompt_is_non_empty():
@@ -81,3 +87,80 @@ def test_prompt_describes_not_in_kb_fallback_multilingual():
     assert "knowledge base" in text.lower()
     assert "kennisbank" in text.lower()
     assert "Wissensdatenbank" in text
+
+
+# ─── GENERAL_CHAT_SYSTEM_PROMPT regression tests ─────────────────────
+
+
+def test_general_prompt_is_non_empty():
+    assert isinstance(GENERAL_CHAT_SYSTEM_PROMPT, str)
+    assert len(GENERAL_CHAT_SYSTEM_PROMPT) > 200
+
+
+def test_general_prompt_carries_critical_marker():
+    # The shared language-detection preamble starts with [CRITICAL].
+    assert "[CRITICAL]" in GENERAL_CHAT_SYSTEM_PROMPT
+
+
+def test_general_prompt_inherits_three_guards_from_preamble():
+    # The 3-guard contract is shared between GROUNDED and GENERAL via
+    # the private _LANGUAGE_DETECTION_PREAMBLE. If a refactor breaks
+    # that share, this test fails loud instead of silently drifting.
+    text = GENERAL_CHAT_SYSTEM_PROMPT.lower()
+    assert "substantive" in text
+    assert "5 words" in GENERAL_CHAT_SYSTEM_PROMPT
+    assert "single foreign-language words" in text or "single foreign" in text
+    assert "stays switched" in text
+
+
+def test_general_prompt_identifies_as_general_purpose_assistant():
+    # The whole point of this prompt: model behaves as a general AI,
+    # not a KB-grounded assistant.
+    assert "general-purpose assistant" in GENERAL_CHAT_SYSTEM_PROMPT
+
+
+def test_general_prompt_forbids_kb_grounding_phrases():
+    # If any of these strings reappear in GENERAL, the model will fall
+    # back to KB-RAG behaviour even though the user explicitly opted
+    # out of every scope. This is the exact regression the prompt was
+    # introduced to prevent.
+    text = GENERAL_CHAT_SYSTEM_PROMPT
+    assert "Dat staat niet in de kennisbank" not in text, (
+        "GENERAL prompt MUST NOT include the GROUNDED 'answer not in KB' "
+        "fallback — it instructs the model to refuse general-knowledge "
+        "questions when no KB is in scope."
+    )
+    assert "knowledge base chunks provided" not in text, (
+        "GENERAL prompt MUST NOT promise KB chunks — there are none."
+    )
+    assert "Every factual claim gets a [n] citation" not in text, (
+        "GENERAL prompt MUST NOT mandate [n] citations — without sources "
+        "the model will fabricate citation markers."
+    )
+
+
+def test_general_prompt_explicitly_disables_citations_and_kb_pretense():
+    # Positive form of the previous test: GENERAL must SAY 'no citations,
+    # no pretending', not just omit the GROUNDED rules.
+    text = GENERAL_CHAT_SYSTEM_PROMPT
+    assert "Do NOT add [n] citations" in text
+    assert "Do NOT pretend to have sources" in text
+
+
+def test_general_prompt_includes_klai_ai_identity():
+    assert "Klai AI" in GENERAL_CHAT_SYSTEM_PROMPT
+
+
+def test_general_and_grounded_share_language_preamble_byte_for_byte():
+    # Both prompts MUST start with the identical language-detection
+    # preamble. Drift here means the 3 guards behave differently in
+    # general-mode than in grounded-mode — that asymmetry is exactly
+    # what SPEC-RAG-MULTILINGUAL-CHAT-001 forbids.
+    preamble_end = GROUNDED_CHAT_SYSTEM_PROMPT.find("\n\nYou are Klai AI")
+    assert preamble_end > 0, "GROUNDED prompt structure changed unexpectedly"
+    grounded_preamble = GROUNDED_CHAT_SYSTEM_PROMPT[:preamble_end]
+    assert GENERAL_CHAT_SYSTEM_PROMPT.startswith(grounded_preamble + "\n\n"), (
+        "GENERAL and GROUNDED must share an identical language-detection "
+        "preamble. Refactor _LANGUAGE_DETECTION_PREAMBLE if you need to "
+        "change it — never edit one of the public constants in isolation."
+    )

--- a/klai-portal/frontend/messages/en.json
+++ b/klai-portal/frontend/messages/en.json
@@ -1492,6 +1492,7 @@
   "sidebar_rules": "Rules",
   "sidebar_team": "Team",
   "sidebar_mcps": "MCPs",
+  "chatbar_collections_general_ai": "General AI",
   "chatbar_templates_label": "Templates",
   "chatbar_templates_empty": "None",
   "chatbar_templates_clear": "Clear all",

--- a/klai-portal/frontend/messages/nl.json
+++ b/klai-portal/frontend/messages/nl.json
@@ -1492,6 +1492,7 @@
   "sidebar_rules": "Regels",
   "sidebar_team": "Team",
   "sidebar_mcps": "MCP's",
+  "chatbar_collections_general_ai": "Algemene AI",
   "chatbar_templates_label": "Templates",
   "chatbar_templates_empty": "Geen",
   "chatbar_templates_clear": "Alles uit",

--- a/klai-portal/frontend/src/routes/app/_components/ChatConfigBar.tsx
+++ b/klai-portal/frontend/src/routes/app/_components/ChatConfigBar.tsx
@@ -154,7 +154,7 @@ export function ChatConfigBar() {
             className="flex items-center gap-1.5 text-[14px] font-semibold text-gray-700 hover:text-gray-900 transition-colors truncate"
           >
             <span className="truncate">
-              {activeNames.length > 0 ? activeNames.join(', ') : 'Geen kennis geselecteerd'}
+              {activeNames.length > 0 ? activeNames.join(', ') : m.chatbar_collections_general_ai()}
             </span>
             <ChevronDown className="h-3.5 w-3.5 shrink-0 opacity-40" />
           </button>


### PR DESCRIPTION
## Why

When the chat-config dropdown showed "Geen kennis geselecteerd" (every collection off, both personal and org KBs), the LiteLLM hook correctly skipped `/retrieve` but still injected `GROUNDED_CHAT_SYSTEM_PROMPT` verbatim. That prompt instructs the model to "answer from the knowledge base chunks provided" and to fall back to "Dat staat niet in de kennisbank" when nothing is found. With zero chunks and that system prompt, the model faithfully refused every general-knowledge question — exactly the regression Mark hit on voys.getklai.com/app/chat:

> *"wat is legermaat 96 in s of m of l"* → *"Dat staat niet in de kennisbank. Leegermaten zoals 96 worden niet omgezet naar S/M/L in de beschikbare bronnen."*

The toggle exists, the user expected it to honour "no KB → behave as general AI", and the prompt architecture (single GROUNDED prompt for every Path A branch) didn't have an exit lane.

## What

Introduce `GENERAL_CHAT_SYSTEM_PROMPT` next to GROUNDED in **both** the canonical `klai-libs/chat-prompts` library and the vendored `deploy/litellm/klai_chat_prompts.py` copy. Both prompts share a private `_LANGUAGE_DETECTION_PREAMBLE` so the 3-guard multilingual contract (SPEC-RAG-MULTILINGUAL-CHAT-001 REQ-01) cannot drift between modes; only the body differs (KB grounding vs general assistant).

`GROUNDED_CHAT_SYSTEM_PROMPT` published string is **byte-identical to before** — paths B (`partner_chat.py`) and C (`retrieval-api /chat`) are not affected. Verified live with a string-equality probe before commit.

In `klai_knowledge.py`:
- Add `_compose_general_chat_prefix(*blocks)` next to `_compose_libre_chat_prefix`.
- Swap **only** the "user opted out of every scope" branch (the `if not kb_personal and kb_slugs == []:` block) to use the new helper. All other branches (no entitlement, `kb_retrieval_enabled=False`, retrieval failed, zero chunks, identity failed) keep GROUNDED so the model still acts as a KB assistant when KB scope was intended but data was unavailable.

Frontend:
- Replace the hardcoded NL label `"Geen kennis geselecteerd"` with i18n key `chatbar_collections_general_ai` (NL: "Algemene AI", EN: "General AI"). The no-KB state now reads as an active mode rather than an error.

## Tests

Canonical library (`klai-libs/chat-prompts/tests/test_grounded_prompt.py`):
- 8 new regression tests for GENERAL: non-empty, [CRITICAL] marker, 3 guards inherited from preamble, "general-purpose assistant" identity, KB-grounding phrases forbidden ("Dat staat niet in de kennisbank", "knowledge base chunks provided", "Every factual claim gets a [n] citation"), explicit citation prohibition, byte-for-byte preamble share with GROUNDED.

Drift (`deploy/litellm/tests/test_klai_chat_prompts_drift.py`):
- New `test_vendored_general_prompt_matches_canonical` byte-equality assert.
- Renamed the `__all__` test to reflect both constants.

Hook (`deploy/litellm/tests/test_klai_knowledge_hook.py`):
- New `test_empty_slugs_and_personal_off_uses_general_chat_prompt` — pins the no-KB branch to GENERAL content (`"general-purpose assistant"`, `"Do NOT add [n] citations"`) and asserts GROUNDED leakage strings are absent.

All ran green locally:
- `klai-libs/chat-prompts`: 19 passed
- `deploy/litellm/tests/`: 118 passed (including new + drift)
- `scripts/lint-no-duplicate-chat-prompt.sh`: OK
- `ruff check` clean on both touched packages.

## Out of scope

- Path B/C: never reach this code (server-to-server, always carry KB scope).
- Pre-existing ruff `F401` issues in `deploy/litellm/tests/test_retrieval_log.py` (not touched by this PR).
- Long-term move from vendored single-file copy to a custom litellm Dockerfile that `pip install`s `klai-chat-prompts`. Same plan as `klai_service_auth`; tracked elsewhere.

## Risks / things to know

- The `GROUNDED_CHAT_SYSTEM_PROMPT` constant is now built via `_LANGUAGE_DETECTION_PREAMBLE + "\n\n" + _GROUNDED_BODY`. The drift test (`test_vendored_grounded_prompt_matches_canonical`) and a new structural test (`test_general_and_grounded_share_language_preamble_byte_for_byte`) jointly guarantee no drift.
- Frontend i18n key needs paraglide compile on CI (`npm run build` runs `i18n:compile` automatically). If the portal-deploy pipeline regenerates messages and finds the key in both `nl.json` and `en.json` it slots in cleanly — same pattern as the surrounding `chatbar_*` keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)