### PR TITLE
polish(SPEC-MCP-RETRIEVAL-001): query length clamp + NL/EN parity + sync-compose auto-recreate

### DIFF
--- a/.github/workflows/deploy-compose.yml
+++ b/.github/workflows/deploy-compose.yml
@@ -206,6 +206,21 @@ jobs:
             cd /tmp && rm -rf klai-compose-sync
             echo "docker-compose.yml + grafana provisioning + scripts synced to /opt/klai/"
 
+            # SPEC-MCP-RETRIEVAL-001 follow-up — auto-recreate on env-only changes.
+            #
+            # Without this, an env-var change in docker-compose.yml lands on
+            # disk but never reaches the running container — only discovered
+            # via a 401 in production (PR #493 was exactly this trap).
+            #
+            # ``compose up -d`` (no service argument, no --force-recreate) is
+            # idempotent: Compose recreates only services whose declaration
+            # changed, leaves the rest untouched. Service-specific build-push
+            # workflows use the same compose-up.sh wrapper, so this is safe
+            # against parallel runs — both paths converge on the same yaml.
+            echo "::group::SPEC-MCP-RETRIEVAL-001 follow-up — compose up -d for env-drift recreate"
+            cd /opt/klai && docker compose up -d --remove-orphans 2>&1 | tail -50 || echo "compose up -d returned non-zero; check logs"
+            echo "::endgroup::"
+
             # SPEC-SEC-024 M4.3 — non-blocking post-deploy smoke-test. Prints
             # [OK]/[FAIL] per probe; warns on non-zero exit but does NOT
             # fail the workflow (initial rollout per SPEC). Flip this to

--- a/klai-knowledge-mcp/main.py
+++ b/klai-knowledge-mcp/main.py
@@ -924,10 +924,15 @@ organisation docs, and connected sources (Notion, Google Drive, web crawls).
 WHEN TO CALL: questions that may be answered by the user's own documentation,
 decisions, customer data, or product knowledge. Search BEFORE answering from
 general knowledge when the question is org-specific.
+NL trigger: "zoek in mijn kennisbank", "wat staat er in onze docs over",
+"check de kennisbank".
+EN trigger: "search my knowledge base", "what do our docs say about",
+"check the knowledge base".
 
 PARAMETERS:
-  query  - search query in the user's language. Self-contained: resolve
-           pronouns and references yourself before passing.
+  query  - search query in the user's language (any language; bge-m3
+           embeddings are multilingual). Self-contained: resolve pronouns
+           and references yourself before passing. Maximum 2000 characters.
   top_k  - 1-15, default 8. Higher values for broad questions.
 
 RETURNS: list of chunks with title, source_url, text, score, scope.
@@ -950,6 +955,19 @@ async def search_knowledge(
     # LLMs frequently overshoot; defensively bounding is friendlier than an
     # input-validation error that the LLM has to debug.
     top_k = max(1, min(int(top_k), 15))
+
+    # Query-length clamp: defense-in-depth against runaway prompts (a buggy
+    # caller looping on a 100k-char query would otherwise multiply retrieval-
+    # api load). 2000 chars is generous — typical KB queries are 5-50 words.
+    # Truncate silently rather than 400; the calling LLM is the offender,
+    # not the user, and a well-behaved LLM never hits this ceiling.
+    if len(query) > 2000:
+        logger.warning(
+            "search_knowledge_query_truncated: original_len=%d client_id=%s",
+            len(query),
+            identity.client_id,
+        )
+        query = query[:2000]
 
     # SPEC-MCP-RETRIEVAL-001 REQ-13: same 3.0s ceiling as the LiteLLM hook.
     # Configurable via env in a future iteration if cold-start P99 spikes.

--- a/klai-knowledge-mcp/tests/test_search_knowledge.py
+++ b/klai-knowledge-mcp/tests/test_search_knowledge.py
@@ -436,6 +436,63 @@ class TestIdentityFailurePropagation:
                 await main.search_knowledge(query="q", ctx=ctx)
 
 
+# ─── Query length clamp ───────────────────────────────────────────────────
+
+
+class TestQueryLengthClamp:
+    """Defense-in-depth: a runaway 100k-char query gets truncated to 2000
+    rather than slamming retrieval-api with the full payload.
+    """
+
+    @pytest.mark.asyncio
+    async def test_query_under_limit_passes_through_unchanged(self) -> None:
+        from main import search_knowledge
+
+        ctx = _librechat_ctx()
+        captured: dict[str, Any] = {}
+
+        async def _capture_post(self: Any, url: str, **kwargs: Any) -> MagicMock:
+            captured["json"] = kwargs.get("json")
+            return _make_retrieve_response([])
+
+        with (
+            patch(
+                "main._asserter.verify",
+                new_callable=AsyncMock,
+                return_value=allow_verify_result(),
+            ),
+            patch.object(httpx.AsyncClient, "post", new=_capture_post),
+        ):
+            await search_knowledge(query="short query", ctx=ctx)
+
+        assert captured["json"]["query"] == "short query"
+
+    @pytest.mark.asyncio
+    async def test_query_over_2000_chars_is_truncated(self) -> None:
+        from main import search_knowledge
+
+        ctx = _librechat_ctx()
+        captured: dict[str, Any] = {}
+
+        async def _capture_post(self: Any, url: str, **kwargs: Any) -> MagicMock:
+            captured["json"] = kwargs.get("json")
+            return _make_retrieve_response([])
+
+        long_query = "x" * 5000
+        with (
+            patch(
+                "main._asserter.verify",
+                new_callable=AsyncMock,
+                return_value=allow_verify_result(),
+            ),
+            patch.object(httpx.AsyncClient, "post", new=_capture_post),
+        ):
+            await search_knowledge(query=long_query, ctx=ctx)
+
+        assert len(captured["json"]["query"]) == 2000
+        assert len(captured["json"]["raw_query"]) == 2000
+
+
 # ─── Outbound auth header regression guard ────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Three follow-ups closing the rough edges from PR #489 / #493:

1. **Query length clamp (≤ 2000 chars)** in \`search_knowledge\` — defense-in-depth against runaway prompts. Logs structlog warning with original length + caller_client_id; truncates silently rather than 400.
2. **NL+EN trigger phrases** in tool description — parity met save-tools. Plus melding dat bge-m3 multilingual is.
3. **\`deploy-compose.yml\` auto-recreate** — runs \`docker compose up -d --remove-orphans\` na yaml sync zodat env-only changes automatisch propageren naar containers (PR #493 deed dit handmatig).

## Test plan

- [x] 89/89 search_knowledge suite green (24 own + 65 regression)
- [x] 2 nieuwe tests in \`TestQueryLengthClamp\`
- [x] \`ruff check\` + \`ruff format --check\` clean
- [x] Diff is +92/-2 over 3 files — geen onbedoelde reverts (eerste commit had per ongeluk security-audit comment block weggehaald, dat is nu hersteld)

🤖 Generated with [Claude Code](https://claude.com/claude-code)