### PR TITLE
fix(connector-wizard): native cookie injection + real auth-probe validation

### DIFF
--- a/klai-connector/app/routes/fingerprint.py
+++ b/klai-connector/app/routes/fingerprint.py
@@ -22,7 +22,6 @@ all exception text goes only to ``logger.exception`` (REQ-31.2).
 
 from __future__ import annotations
 
-import json
 from typing import Any
 
 import httpx
@@ -94,17 +93,14 @@ def _build_crawl_payload(
         "crawler_config": {"type": "CrawlerRunConfig", "params": config},
     }
     if cookies:
-        # Same on_page_context_created hook shape as
-        # knowledge_ingest.crawl4ai_client._build_cookie_hooks.
-        cookies_json = json.dumps(cookies)
-        hook_code = (
-            "async def hook(page, context, **kwargs):\n"
-            f"    await context.add_cookies({cookies_json})\n"
-            "    return page\n"
-        )
-        payload["hooks"] = {
-            "code": {"on_page_context_created": hook_code},
-            "timeout": 30,
+        # Native cookie injection via BrowserConfig.cookies — crawl4ai's
+        # recommended path for authenticated crawls (see Identity-Based
+        # Crawling docs). Replaces the on_page_context_created hook pattern
+        # that has known timing issues (Playwright #26786, crawl4ai #322).
+        # Mirrors knowledge_ingest.crawl4ai_client._build_browser_config_with_cookies.
+        payload["browser_config"] = {
+            "type": "BrowserConfig",
+            "params": {"cookies": cookies},
         }
     return payload
 

--- a/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
@@ -328,15 +328,39 @@ def _extract_result(url: str, page: dict[str, Any]) -> CrawlResult:
 # ---------------------------------------------------------------------------
 
 
-def _build_cookie_hooks(cookies: list[dict[str, Any]]) -> dict[str, Any]:
-    """Build Crawl4AI hooks payload that injects cookies via on_page_context_created."""
-    cookies_json = json.dumps(cookies)
-    hook_code = f"""
-async def hook(page, context, **kwargs):
-    await context.add_cookies({cookies_json})
-    return page
-"""
-    return {"code": {"on_page_context_created": hook_code}, "timeout": 30}
+def _build_browser_config_with_cookies(
+    cookies: list[dict[str, Any]] | None,
+) -> dict[str, Any] | None:
+    """Build a BrowserConfig payload that injects cookies natively at browser
+    context creation.
+
+    Why not the ``on_page_context_created`` hook we used before? The hook
+    pattern has known timing issues — Playwright #26786 (cookies added before
+    goto can appear empty after load) and crawl4ai #322 (hook actions don't
+    always propagate to ``crawler.arun``). crawl4ai's own docs explicitly
+    recommend identity-based crawling over hooks for "robust auth":
+
+      "Run your initial login steps in a separate, well-defined process,
+      then feed that session to your main crawl — rather than shoehorning
+      complex authentication into early hooks."
+
+    crawl4ai 0.8.x's ``BrowserConfig`` accepts a ``cookies`` list directly
+    (async_configs.py line 634). The Docker REST API server deserializes it
+    via ``BrowserConfig.load`` (api.py line 567), so the same payload shape
+    works in our deployed setup.
+
+    Returns ``None`` when no cookies are provided, so callers can do:
+
+        bc = _build_browser_config_with_cookies(cookies)
+        if bc:
+            payload["browser_config"] = bc
+    """
+    if not cookies:
+        return None
+    return {
+        "type": "BrowserConfig",
+        "params": {"cookies": cookies},
+    }
 
 
 async def crawl_page(
@@ -347,36 +371,18 @@ async def crawl_page(
     """Crawl a single page via the Crawl4AI REST API.
 
     Uses the same pipeline switching as klai-connector (SPEC-CRAWL-001).
-    When cookies are provided, they are injected into the browser context
-    before the page loads via the on_page_context_created hook.
+    When cookies are provided, they are injected natively via
+    ``BrowserConfig.cookies`` so Playwright's BrowserContext receives them
+    before the page navigation starts.
     """
     config = build_crawl_config(selector)
     payload: dict[str, Any] = {
         "urls": [url],
         "crawler_config": {"type": "CrawlerRunConfig", "params": config},
     }
-    if cookies:
-        payload["hooks"] = _build_cookie_hooks(cookies)
-
-    # DIAG-COOKIE-BUG-2026-05-07 — temporary diagnostic for connector wizard
-    # cookie pass-through audit. Logs cookie NAMES and short value PREFIXES
-    # (8 chars, ~6 bits of entropy) so we can correlate which cookie shape
-    # the frontend sent vs what arrives at crawl4ai. NEVER log full values.
-    # Remove after fix is verified in production.
-    if cookies:
-        cookie_names = [c.get("name", "<missing>") for c in cookies]
-        cookie_value_prefixes = [
-            (c.get("value", "")[:8] + "..." if c.get("value") else "<empty>") for c in cookies
-        ]
-        logger.info(
-            "crawl_page_cookies_attached",
-            url=url,
-            cookie_count=len(cookies),
-            cookie_names=cookie_names,
-            cookie_value_prefixes=cookie_value_prefixes,
-        )
-    else:
-        logger.info("crawl_page_cookies_absent", url=url)
+    bc = _build_browser_config_with_cookies(cookies)
+    if bc:
+        payload["browser_config"] = bc
 
     async with httpx.AsyncClient(timeout=90.0) as client:
         try:
@@ -614,8 +620,9 @@ async def _fetch_seed_page(
         "urls": [start_url],
         "crawler_config": {"type": "CrawlerRunConfig", "params": crawler_config},
     }
-    if cookies:
-        payload["hooks"] = _build_cookie_hooks(cookies)
+    bc = _build_browser_config_with_cookies(cookies)
+    if bc:
+        payload["browser_config"] = bc
 
     try:
         async with httpx.AsyncClient(timeout=90.0) as client:
@@ -918,8 +925,9 @@ async def _bfs_deep_crawl(
         "urls": [start_url],
         "crawler_config": {"type": "CrawlerRunConfig", "params": config},
     }
-    if cookies:
-        payload["hooks"] = _build_cookie_hooks(cookies)
+    bc = _build_browser_config_with_cookies(cookies)
+    if bc:
+        payload["browser_config"] = bc
 
     try:
         async with httpx.AsyncClient(timeout=90.0) as client:
@@ -1001,8 +1009,9 @@ async def _chunked_bulk_fetch(
             "urls": chunk_urls,
             "crawler_config": {"type": "CrawlerRunConfig", "params": crawler_config},
         }
-        if cookies:
-            payload["hooks"] = _build_cookie_hooks(cookies)
+        bc = _build_browser_config_with_cookies(cookies)
+        if bc:
+            payload["browser_config"] = bc
         try:
             async with httpx.AsyncClient(timeout=_BULK_CRAWL_TIMEOUT) as client:
                 data = await _crawl_sync(client, payload)

--- a/klai-knowledge-ingest/knowledge_ingest/routes/crawl.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/crawl.py
@@ -11,13 +11,16 @@ tenant_scoped_connection on the body's org_id and pass conn into pg_store /
 link_graph / domain_selectors / ingest_document.
 """
 
+import asyncio
 import contextlib
 import hashlib
 import re
 import time
+from dataclasses import dataclass
 from urllib.parse import urlparse
 
 import asyncpg
+import httpx
 import structlog
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
@@ -42,7 +45,11 @@ from knowledge_ingest.selector_ai import (
 )
 from knowledge_ingest.utils.auth_wall_classifier import classify_auth_wall
 from knowledge_ingest.utils.link_density import LINK_DENSITY_THRESHOLD, link_density
-from knowledge_ingest.utils.url_validator import validate_url, validate_url_pinned
+from knowledge_ingest.utils.url_validator import (
+    PinnedResolverTransport,
+    validate_url,
+    validate_url_pinned,
+)
 
 logger = structlog.get_logger()
 router = APIRouter()
@@ -440,18 +447,76 @@ async def preview_crawl(body: CrawlPreviewRequest, request: Request) -> CrawlPre
         )
 
 
+@dataclass
+class _ProbeResponse:
+    """Result of a single httpx GET inside auth_probe."""
+
+    status_code: int
+    word_count: int
+    byte_size: int
+    text: str
+
+
+_PROBE_UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+_PROBE_TIMEOUT = httpx.Timeout(connect=5.0, read=20.0, write=10.0, pool=5.0)
+
+
+async def _probe_fetch(
+    url: str,
+    pin_map: dict[str, str],
+    cookies: dict[str, str] | None = None,
+) -> _ProbeResponse:
+    """Single SSRF-pinned httpx GET for auth_probe validation.
+
+    Uses :class:`PinnedResolverTransport` so redirects can't escape to
+    internal IPs. ``follow_redirects=False`` to keep the response shape
+    deterministic — a redirect-to-login is itself a strong signal that
+    cookies are missing/invalid.
+    """
+    transport = PinnedResolverTransport(pin_map)
+    async with httpx.AsyncClient(
+        transport=transport,
+        timeout=_PROBE_TIMEOUT,
+        follow_redirects=False,
+        headers={"User-Agent": _PROBE_UA},
+    ) as client:
+        r = await client.get(url, cookies=cookies or {})
+        return _ProbeResponse(
+            status_code=r.status_code,
+            word_count=len(r.text.split()),
+            byte_size=len(r.text),
+            text=r.text,
+        )
+
+
 @router.post("/ingest/v1/crawl/auth-probe", response_model=AuthProbeResponse)
 async def auth_probe(body: AuthProbeRequest, request: Request) -> AuthProbeResponse:
-    """SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-2 — classify a single seed
-    fetch as ``auth_ok`` or one of four failure flavours.
+    """REQ-2 — verify that cookies actually authenticate against the seed URL.
 
-    Mirrors the SSRF and identity guards on ``/ingest/v1/crawl/preview``:
+    Implementation: fetch the URL twice via plain httpx — once WITH cookies,
+    once WITHOUT — and compare the responses. If the cookied response
+    differs measurably (word count or byte size, or a status-code split
+    between the two requests), cookies have an authenticating effect. If
+    the two responses are identical, cookies do nothing — the wizard must
+    not green-light a connector whose cookies are expired/wrong/scoped to
+    a different host.
 
-    - SSRF validation runs BEFORE any DNS lookup downstream
-      (SPEC-SEC-SSRF-001 REQ-1.1 / AC-1).
+    Why httpx and not crawl4ai/Playwright: the validation only needs HTTP-
+    level cookie behaviour, and httpx is faster, simpler, and avoids
+    Playwright cookie-injection quirks. The actual crawl that consumes
+    these validated cookies runs through crawl4ai with native
+    ``BrowserConfig.cookies`` — see
+    ``knowledge_ingest.crawl4ai_client._build_browser_config_with_cookies``.
+
+    SSRF + identity guards mirror ``/ingest/v1/crawl/preview``:
+    - :func:`validate_url_pinned` resolves DNS + rejects private/loopback IPs.
+    - :class:`PinnedResolverTransport` locks the fetch to that IP, so a
+      redirect can't smuggle the request to ``127.0.0.1``.
     - When ``org_id`` is supplied, ``assert_caller_identity_tenant_only``
-      enforces tenant scoping (per the bug-pattern memory: this is an
-      internal-secret + tenant-only route, no end-user context).
+      enforces tenant scoping (no end-user in this internal-secret path).
     """
     logger.info("auth_probe_started", url=body.url)
 
@@ -459,106 +524,110 @@ async def auth_probe(body: AuthProbeRequest, request: Request) -> AuthProbeRespo
         await assert_caller_identity_tenant_only(request, claimed_org_id=body.org_id)
 
     try:
-        await validate_url_pinned(body.url)
+        validated = await validate_url_pinned(body.url)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    try:
-        result = await crawl_page(body.url, selector=None, cookies=body.cookies)
-    except Exception as exc:
-        logger.warning("auth_probe_crawl_failed", url=body.url, error=str(exc))
+    if not body.cookies:
+        logger.info(
+            "auth_probe_completed",
+            url=body.url,
+            classification="auth_failed_no_cookies",
+            word_count=0,
+        )
         return AuthProbeResponse(
-            classification="auth_failed_unreachable",
-            match_reasons=[],
+            classification="auth_failed_no_cookies",
+            match_reasons=["no cookies provided"],
             word_count=0,
             auth_guard=None,
         )
 
-    metadata = result.metadata or {}
-    response_headers = result.response_headers or {}
-    set_cookie_header = response_headers.get("set-cookie") or response_headers.get("Set-Cookie")
-    redirect_target_url = metadata.get("redirect_url") or metadata.get("location")
+    cookie_dict: dict[str, str] = {
+        c["name"]: c["value"]
+        for c in body.cookies
+        if isinstance(c, dict) and c.get("name") and c.get("value")
+    }
+    pin_map = {validated.hostname: validated.preferred_ip}
 
-    classification = classify_auth_wall(
-        response_status_code=metadata.get("status_code"),
-        redirect_target_url=redirect_target_url,
-        set_cookie_header=set_cookie_header,
-        word_count=result.word_count,
-        fit_markdown=result.fit_markdown or "",
-        raw_html=result.html or "",
-    )
+    try:
+        with_cookies, without_cookies = await asyncio.gather(
+            _probe_fetch(body.url, pin_map=pin_map, cookies=cookie_dict),
+            _probe_fetch(body.url, pin_map=pin_map, cookies=None),
+        )
+    except Exception as exc:
+        logger.warning("auth_probe_fetch_failed", url=body.url, error=str(exc))
+        return AuthProbeResponse(
+            classification="auth_failed_unreachable",
+            match_reasons=[f"fetch_failed: {exc!s}"],
+            word_count=0,
+            auth_guard=None,
+        )
 
-    label = _label_for_auth_probe(
-        is_walled=classification.is_walled,
-        match_reasons=classification.match_reasons,
-        word_count=result.word_count,
-        crawl_success=result.success,
-        cookies_provided=bool(body.cookies),
-    )
+    word_diff = abs(with_cookies.word_count - without_cookies.word_count)
+    byte_diff = abs(with_cookies.byte_size - without_cookies.byte_size)
+    word_threshold = max(20, int(without_cookies.word_count * 0.05))
+    byte_threshold = max(1000, int(without_cookies.byte_size * 0.05))
+    status_split = with_cookies.status_code != without_cookies.status_code
+    significant = status_split or word_diff > word_threshold or byte_diff > byte_threshold
 
+    match_reasons = [
+        f"with_cookies_status={with_cookies.status_code}",
+        f"without_cookies_status={without_cookies.status_code}",
+        f"word_diff={word_diff} (threshold={word_threshold})",
+        f"byte_diff={byte_diff} (threshold={byte_threshold})",
+    ]
+
+    if not significant:
+        # Cookies have no measurable effect. The wizard MUST NOT green-light
+        # this — auth-probe lying like the old heuristic did is what got us
+        # the silent regression on every authenticated KB.
+        logger.info(
+            "auth_probe_completed",
+            url=body.url,
+            classification="auth_failed_still_walled",
+            word_count=with_cookies.word_count,
+            match_reasons=match_reasons,
+        )
+        return AuthProbeResponse(
+            classification="auth_failed_still_walled",
+            match_reasons=match_reasons,
+            word_count=with_cookies.word_count,
+            auth_guard=None,
+        )
+
+    # Cookies authenticate. Build auth_guard for downstream cron-sync use:
+    # canary_fingerprint lets the sync detect cookie expiration without
+    # re-running the full diff every time.
     auth_guard: AuthGuardSuggestion | None = None
-    if label == "auth_ok" and body.cookies:
-        canary_fp = compute_content_fingerprint(result.fit_markdown or "")
-        if canary_fp:
-            auth_guard = AuthGuardSuggestion(
-                canary_url=body.url,
-                canary_fingerprint=canary_fp,
-            )
-            try:
-                dom_summary = await crawl_dom_summary(body.url)
-                if dom_summary:
-                    indicator = await detect_login_indicator_via_llm(dom_summary)
-                    if indicator:
-                        auth_guard.login_indicator_selector = indicator
-                        auth_guard.login_indicator_description = f"Detected: {indicator}"
-            except Exception:
-                logger.debug("auth_probe_indicator_detection_skipped", url=body.url)
+    canary_fp = compute_content_fingerprint(with_cookies.text)
+    if canary_fp:
+        auth_guard = AuthGuardSuggestion(
+            canary_url=body.url,
+            canary_fingerprint=canary_fp,
+        )
+        try:
+            dom_summary = await crawl_dom_summary(body.url)
+            if dom_summary:
+                indicator = await detect_login_indicator_via_llm(dom_summary)
+                if indicator:
+                    auth_guard.login_indicator_selector = indicator
+                    auth_guard.login_indicator_description = f"Detected: {indicator}"
+        except Exception:
+            logger.debug("auth_probe_indicator_detection_skipped", url=body.url)
 
-    # SPEC-CONNECTOR-INPUT-VALIDATION-001 — completion log mirrors the one
-    # in preview_crawl above; without it, debugging "why did wizard show
-    # auth_failed_unreachable" requires guessing.
     logger.info(
         "auth_probe_completed",
         url=body.url,
-        classification=label,
-        word_count=result.word_count,
-        status_code=metadata.get("status_code"),
-        match_reasons=list(classification.match_reasons),
-        cookies_provided=bool(body.cookies),
+        classification="auth_ok",
+        word_count=with_cookies.word_count,
+        match_reasons=match_reasons,
     )
-
     return AuthProbeResponse(
-        classification=label,
-        match_reasons=list(classification.match_reasons),
-        word_count=result.word_count,
+        classification="auth_ok",
+        match_reasons=match_reasons,
+        word_count=with_cookies.word_count,
         auth_guard=auth_guard,
     )
-
-
-def _label_for_auth_probe(
-    *,
-    is_walled: bool,
-    match_reasons: tuple[str, ...],
-    word_count: int,
-    crawl_success: bool,
-    cookies_provided: bool,
-) -> str:
-    """Map classifier output + request context to one of five outcome labels.
-
-    SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-2 outcome table.
-    """
-    if "http_unauthenticated" in match_reasons:
-        return "auth_failed_credentials_invalid"
-    if is_walled:
-        return "auth_failed_still_walled" if cookies_provided else "auth_failed_no_cookies"
-    if not crawl_success or word_count == 0:
-        return "auth_failed_unreachable"
-    if word_count < _MIN_WORD_COUNT:
-        # Reachable but thin — the page renders but has no real content.
-        # Treated the same as unreachable for the wizard: the user must
-        # configure cookies or pick a different seed.
-        return "auth_failed_unreachable"
-    return "auth_ok"
 
 
 @router.post("/ingest/v1/crawl", response_model=CrawlResponse)

--- a/klai-knowledge-ingest/tests/test_auth_probe_endpoint.py
+++ b/klai-knowledge-ingest/tests/test_auth_probe_endpoint.py
@@ -2,17 +2,25 @@
 
 SPEC-CONNECTOR-INPUT-VALIDATION-001 / REQ-2 / REQ-6.
 
-The endpoint mirrors ``/ingest/v1/crawl/preview`` but classifies the result
-into one of five outcome labels:
+The endpoint validates that operator-supplied cookies actually authenticate
+against the seed URL, by fetching the URL twice via plain httpx — once
+WITH cookies, once WITHOUT — and comparing the responses. Significant
+divergence (word count, byte size, or status-code split) means cookies
+have an effect; identical responses mean they do not.
 
-- ``auth_ok``
-- ``auth_failed_no_cookies``
-- ``auth_failed_still_walled``
-- ``auth_failed_credentials_invalid``
-- ``auth_failed_unreachable``
+Why httpx and not crawl4ai/Playwright: the validation only needs HTTP-
+level cookie behaviour; the underlying authenticated crawl runs through
+crawl4ai with native ``BrowserConfig.cookies`` separately.
+
+Outcome labels (consumed by the wizard frontend):
+
+- ``auth_ok``                    — cookies measurably change the response
+- ``auth_failed_no_cookies``     — no cookies provided
+- ``auth_failed_still_walled``   — cookies provided but have no effect
+- ``auth_failed_unreachable``    — fetch raised before classification
 
 Identity assertion uses ``assert_caller_identity_tenant_only`` per
-bug-pattern memory (no end-user on this internal route).
+bug-pattern memory (no end-user on this internal-secret route).
 """
 
 from __future__ import annotations
@@ -22,7 +30,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-from knowledge_ingest.crawl4ai_client import CrawlResult
+from knowledge_ingest.routes.crawl import _ProbeResponse
 
 
 # ---------------------------------------------------------------------------
@@ -30,27 +38,51 @@ from knowledge_ingest.crawl4ai_client import CrawlResult
 # ---------------------------------------------------------------------------
 
 
-def _make_crawl_result(
+def _probe(
     *,
-    url: str = "https://example.com/page",
-    fit_markdown: str = "",
-    raw_markdown: str = "",
-    html: str = "",
-    word_count: int = 0,
-    success: bool = True,
-    metadata: dict | None = None,
-    response_headers: dict[str, str] | None = None,
-) -> CrawlResult:
-    return CrawlResult(
-        url=url,
-        fit_markdown=fit_markdown,
-        raw_markdown=raw_markdown,
-        html=html,
+    status_code: int = 200,
+    word_count: int = 100,
+    byte_size: int = 5000,
+    text: str = "Sample response body",
+) -> _ProbeResponse:
+    return _ProbeResponse(
+        status_code=status_code,
         word_count=word_count,
-        success=success,
-        metadata=metadata or {},
-        response_headers=response_headers or {},
+        byte_size=byte_size,
+        text=text,
     )
+
+
+def _patch_probe_fetch(with_cookies: _ProbeResponse, without_cookies: _ProbeResponse):
+    """Patch ``_probe_fetch`` to return ``with_cookies`` when cookies are
+    passed and ``without_cookies`` when they are not.
+    """
+
+    async def _side_effect(
+        url: str, pin_map: dict[str, str], cookies: dict[str, str] | None = None
+    ) -> _ProbeResponse:
+        return with_cookies if cookies else without_cookies
+
+    return patch(
+        "knowledge_ingest.routes.crawl._probe_fetch",
+        new=AsyncMock(side_effect=_side_effect),
+    )
+
+
+_REDCACTUS_COOKIES = [
+    {
+        "name": "prod-knowledgebase-session",
+        "value": "eyJ.fake.value",
+        "domain": "wiki.redcactus.cloud",
+        "path": "/",
+    },
+    {
+        "name": "XSRF-TOKEN",
+        "value": "eyJ.fake.value",
+        "domain": "wiki.redcactus.cloud",
+        "path": "/",
+    },
+]
 
 
 # ---------------------------------------------------------------------------
@@ -58,200 +90,178 @@ def _make_crawl_result(
 # ---------------------------------------------------------------------------
 
 
-def test_auth_probe_returns_auth_ok_for_healthy_public_page(client: TestClient) -> None:
-    healthy = _make_crawl_result(
-        fit_markdown="A long article body. " * 60,
-        raw_markdown="A long article body. " * 60,
-        word_count=600,
-        metadata={"status_code": 200},
-        response_headers={"content-type": "text/html"},
-    )
-    with patch(
-        "knowledge_ingest.routes.crawl.crawl_page",
-        new=AsyncMock(return_value=healthy),
-    ):
+def test_auth_probe_no_cookies_short_circuits_without_fetching(
+    client: TestClient,
+) -> None:
+    """When no cookies are supplied, classification is decided without any
+    HTTP fetch — no point comparing anonymous to anonymous."""
+    spy = AsyncMock(side_effect=AssertionError("should not fetch when no cookies"))
+    with patch("knowledge_ingest.routes.crawl._probe_fetch", new=spy):
         resp = client.post(
             "/ingest/v1/crawl/auth-probe",
             json={"url": "https://example.com/page"},
         )
     assert resp.status_code == 200, resp.text
-    body = resp.json()
-    assert body["classification"] == "auth_ok"
-    assert body["match_reasons"] == []
-    assert body["word_count"] == 600
-
-
-def test_auth_probe_returns_auth_failed_no_cookies_when_walled_and_no_cookies(
-    client: TestClient,
-) -> None:
-    walled = _make_crawl_result(
-        fit_markdown="Article teaser. " * 5 + "Log in to read this article",
-        word_count=80,
-        metadata={"status_code": 200},
-    )
-    with patch(
-        "knowledge_ingest.routes.crawl.crawl_page",
-        new=AsyncMock(return_value=walled),
-    ):
-        resp = client.post(
-            "/ingest/v1/crawl/auth-probe",
-            json={"url": "https://example.com/page"},
-        )
-    assert resp.status_code == 200
     body = resp.json()
     assert body["classification"] == "auth_failed_no_cookies"
-    assert "end_of_body_login_marker" in body["match_reasons"]
+    assert spy.await_count == 0
+    assert body["auth_guard"] is None
 
 
-def test_auth_probe_returns_auth_failed_still_walled_when_walled_with_cookies(
-    client: TestClient,
-) -> None:
-    walled = _make_crawl_result(
-        fit_markdown="Inloggen om verder te lezen",
-        word_count=10,
-        metadata={"status_code": 200},
-        response_headers={"set-cookie": "session=abc; Path=/"},
-    )
-    with patch(
-        "knowledge_ingest.routes.crawl.crawl_page",
-        new=AsyncMock(return_value=walled),
+def test_auth_probe_significant_word_diff_returns_auth_ok(client: TestClient) -> None:
+    """Cookies that produce a measurably larger response authenticate."""
+    with _patch_probe_fetch(
+        with_cookies=_probe(
+            word_count=7299, byte_size=181000, text="Logged in body. " * 500
+        ),
+        without_cookies=_probe(
+            word_count=5572, byte_size=140000, text="Anonymous body. " * 300
+        ),
     ):
         resp = client.post(
             "/ingest/v1/crawl/auth-probe",
             json={
-                "url": "https://example.com/page",
-                "cookies": [{"name": "session", "value": "expired"}],
+                "url": "https://wiki.redcactus.cloud/nl/article",
+                "cookies": _REDCACTUS_COOKIES,
             },
         )
-    assert resp.status_code == 200
+    body = resp.json()
+    assert body["classification"] == "auth_ok"
+    assert body["word_count"] == 7299
+    assert body["auth_guard"] is not None
+    assert body["auth_guard"]["canary_url"] == "https://wiki.redcactus.cloud/nl/article"
+
+
+def test_auth_probe_status_code_split_returns_auth_ok(client: TestClient) -> None:
+    """A status-code split (200 with cookies, 302 without) is itself a strong
+    auth signal even if the response bodies happen to be similar size."""
+    with _patch_probe_fetch(
+        with_cookies=_probe(status_code=200, word_count=300, byte_size=10000),
+        without_cookies=_probe(status_code=302, word_count=290, byte_size=9800),
+    ):
+        resp = client.post(
+            "/ingest/v1/crawl/auth-probe",
+            json={
+                "url": "https://example.com/dashboard",
+                "cookies": _REDCACTUS_COOKIES,
+            },
+        )
+    body = resp.json()
+    assert body["classification"] == "auth_ok"
+
+
+def test_auth_probe_no_diff_returns_auth_failed_still_walled(
+    client: TestClient,
+) -> None:
+    """Cookies that produce an identical (or near-identical) response to the
+    anonymous baseline have no authenticating effect — the wizard MUST NOT
+    green-light this case."""
+    identical = _probe(
+        word_count=250, byte_size=10000, text="Same body for both fetches."
+    )
+    with _patch_probe_fetch(with_cookies=identical, without_cookies=identical):
+        resp = client.post(
+            "/ingest/v1/crawl/auth-probe",
+            json={
+                "url": "https://wiki.redcactus.cloud/nl/",
+                "cookies": _REDCACTUS_COOKIES,
+            },
+        )
     body = resp.json()
     assert body["classification"] == "auth_failed_still_walled"
-    assert "end_of_body_login_marker" in body["match_reasons"]
-    assert "session_cookie_minimal_body" in body["match_reasons"]
+    assert body["auth_guard"] is None
 
 
-def test_auth_probe_returns_auth_failed_credentials_invalid_on_401(
+def test_auth_probe_tiny_diff_under_threshold_is_still_walled(
     client: TestClient,
 ) -> None:
-    bad = _make_crawl_result(
-        fit_markdown="",
-        word_count=0,
-        success=False,
-        metadata={"status_code": 401},
-    )
-    with patch(
-        "knowledge_ingest.routes.crawl.crawl_page",
-        new=AsyncMock(return_value=bad),
+    """5%-of-baseline floor: a 10-word diff on a 5000-word page is noise,
+    not a signal. The bare minimum is max(20 words, 5% of baseline)."""
+    with _patch_probe_fetch(
+        with_cookies=_probe(word_count=5010, byte_size=140100),
+        without_cookies=_probe(word_count=5000, byte_size=140000),
     ):
         resp = client.post(
             "/ingest/v1/crawl/auth-probe",
             json={
-                "url": "https://example.com/page",
-                "cookies": [{"name": "session", "value": "wrong"}],
+                "url": "https://wiki.redcactus.cloud/nl/",
+                "cookies": _REDCACTUS_COOKIES,
             },
         )
-    assert resp.status_code == 200
     body = resp.json()
-    assert body["classification"] == "auth_failed_credentials_invalid"
-    assert "http_unauthenticated" in body["match_reasons"]
+    assert body["classification"] == "auth_failed_still_walled"
 
 
-def test_auth_probe_returns_auth_failed_unreachable_on_connection_error(
+def test_auth_probe_fetch_failure_returns_auth_failed_unreachable(
     client: TestClient,
 ) -> None:
-    """Empty/zero-word result with no status — unreachable."""
-    unreachable = _make_crawl_result(
-        fit_markdown="",
-        word_count=0,
-        success=False,
-        metadata={},  # no status_code
-    )
-    with patch(
-        "knowledge_ingest.routes.crawl.crawl_page",
-        new=AsyncMock(return_value=unreachable),
-    ):
+    """If both fetches raise (DNS failure, TLS error, timeout), the classifier
+    reports unreachable instead of guessing."""
+    failing = AsyncMock(side_effect=ConnectionError("connection refused"))
+    with patch("knowledge_ingest.routes.crawl._probe_fetch", new=failing):
         resp = client.post(
             "/ingest/v1/crawl/auth-probe",
-            json={"url": "https://example.com/page"},
+            json={
+                "url": "https://example.com/page",
+                "cookies": _REDCACTUS_COOKIES,
+            },
         )
-    assert resp.status_code == 200
     body = resp.json()
     assert body["classification"] == "auth_failed_unreachable"
-
-
-# ---------------------------------------------------------------------------
-# Auth guard side effect
-# ---------------------------------------------------------------------------
-
-
-def test_auth_probe_returns_auth_guard_when_auth_ok_with_cookies(
-    client: TestClient,
-) -> None:
-    healthy_with_cookies = _make_crawl_result(
-        fit_markdown="A long article body. " * 60,
-        raw_markdown="A long article body. " * 60,
-        word_count=600,
-        metadata={"status_code": 200},
-    )
-    with (
-        patch(
-            "knowledge_ingest.routes.crawl.crawl_page",
-            new=AsyncMock(return_value=healthy_with_cookies),
-        ),
-        patch(
-            "knowledge_ingest.routes.crawl.crawl_dom_summary",
-            new=AsyncMock(return_value=None),  # AI detection skipped
-        ),
-    ):
-        resp = client.post(
-            "/ingest/v1/crawl/auth-probe",
-            json={
-                "url": "https://example.com/page",
-                "cookies": [{"name": "sess", "value": "valid"}],
-            },
-        )
-    assert resp.status_code == 200, resp.text
-    body = resp.json()
-    assert body["classification"] == "auth_ok"
-    assert body["auth_guard"] is not None
-    assert body["auth_guard"]["canary_url"] == "https://example.com/page"
-    assert body["auth_guard"]["canary_fingerprint"] is not None
-
-
-def test_auth_probe_does_not_return_auth_guard_when_no_cookies(
-    client: TestClient,
-) -> None:
-    """Without cookies there is nothing to canary against — auth_guard MUST be None."""
-    healthy = _make_crawl_result(
-        fit_markdown="A long article body. " * 60,
-        raw_markdown="A long article body. " * 60,
-        word_count=600,
-        metadata={"status_code": 200},
-    )
-    with patch(
-        "knowledge_ingest.routes.crawl.crawl_page",
-        new=AsyncMock(return_value=healthy),
-    ):
-        resp = client.post(
-            "/ingest/v1/crawl/auth-probe",
-            json={"url": "https://example.com/page"},
-        )
-    body = resp.json()
-    assert body["classification"] == "auth_ok"
     assert body["auth_guard"] is None
 
 
 # ---------------------------------------------------------------------------
-# Security & validation
+# auth_guard
+# ---------------------------------------------------------------------------
+
+
+def test_auth_probe_auth_ok_emits_canary_fingerprint(client: TestClient) -> None:
+    """auth_ok with cookies must produce a canary fingerprint for downstream
+    cron-sync to detect cookie expiration without re-running the diff."""
+    with _patch_probe_fetch(
+        with_cookies=_probe(
+            word_count=1000,
+            byte_size=30000,
+            text="Long unique logged-in content. " * 200,
+        ),
+        without_cookies=_probe(
+            word_count=300, byte_size=8000, text="Short anonymous body. " * 50
+        ),
+    ):
+        resp = client.post(
+            "/ingest/v1/crawl/auth-probe",
+            json={
+                "url": "https://example.com/page",
+                "cookies": _REDCACTUS_COOKIES,
+            },
+        )
+    body = resp.json()
+    assert body["classification"] == "auth_ok"
+    assert body["auth_guard"] is not None
+    assert body["auth_guard"]["canary_url"] == "https://example.com/page"
+    assert body["auth_guard"]["canary_fingerprint"]
+
+
+def test_auth_probe_no_cookies_does_not_emit_canary(client: TestClient) -> None:
+    """Without cookies the auth_guard is None — fingerprinting an anonymous
+    response would be useless for the cron-sync."""
+    resp = client.post(
+        "/ingest/v1/crawl/auth-probe",
+        json={"url": "https://example.com/page"},
+    )
+    body = resp.json()
+    assert body["auth_guard"] is None
+
+
+# ---------------------------------------------------------------------------
+# Security guards
 # ---------------------------------------------------------------------------
 
 
 def test_auth_probe_rejects_internal_secret_missing(client: TestClient) -> None:
-    """SPEC-SEC-011 — missing ``X-Internal-Secret`` is rejected.
-
-    ``client`` fixture injects the header by default; we drop it for this
-    one assertion to ensure the middleware still guards this new endpoint.
-    """
+    """SPEC-SEC-011 — missing/wrong ``X-Internal-Secret`` is rejected by
+    middleware before the route runs."""
     resp = client.post(
         "/ingest/v1/crawl/auth-probe",
         json={"url": "https://example.com/page"},
@@ -262,35 +272,41 @@ def test_auth_probe_rejects_internal_secret_missing(client: TestClient) -> None:
 
 def test_auth_probe_rejects_ssrf_url(client: TestClient) -> None:
     """SPEC-SEC-SSRF-001 parity — auth-probe MUST reject internal-host URLs
-    before any crawl call (the same Cornelis AC-6 guard that protects
-    /ingest/v1/crawl and /ingest/v1/crawl/preview)."""
+    before any HTTP fetch, mirroring the Cornelis AC-6 guard on /preview."""
     spy = AsyncMock(side_effect=AssertionError("SSRF guard should short-circuit"))
-    with patch("knowledge_ingest.routes.crawl.crawl_page", new=spy):
+    with patch("knowledge_ingest.routes.crawl._probe_fetch", new=spy):
         resp = client.post(
             "/ingest/v1/crawl/auth-probe",
-            json={"url": "http://docker-socket-proxy:2375/v1.42/info"},
+            json={
+                "url": "http://docker-socket-proxy:2375/v1.42/info",
+                "cookies": _REDCACTUS_COOKIES,
+            },
         )
     assert resp.status_code == 400
     assert spy.await_count == 0
 
 
-def test_auth_probe_returns_match_reasons_list(client: TestClient) -> None:
-    """The response shape always exposes ``match_reasons`` as a list (possibly empty)."""
-    healthy = _make_crawl_result(
-        fit_markdown="Real article. " * 60,
-        word_count=600,
-        metadata={"status_code": 200},
-    )
-    with patch(
-        "knowledge_ingest.routes.crawl.crawl_page",
-        new=AsyncMock(return_value=healthy),
+# ---------------------------------------------------------------------------
+# Response shape
+# ---------------------------------------------------------------------------
+
+
+def test_auth_probe_match_reasons_is_list(client: TestClient) -> None:
+    """``match_reasons`` is always a list, populated with diagnostic strings."""
+    with _patch_probe_fetch(
+        with_cookies=_probe(word_count=1000, byte_size=20000),
+        without_cookies=_probe(word_count=300, byte_size=8000),
     ):
         resp = client.post(
             "/ingest/v1/crawl/auth-probe",
-            json={"url": "https://example.com/page"},
+            json={
+                "url": "https://example.com/page",
+                "cookies": _REDCACTUS_COOKIES,
+            },
         )
     body = resp.json()
     assert isinstance(body["match_reasons"], list)
+    assert len(body["match_reasons"]) >= 2  # diagnostic detail attached
 
 
 # ---------------------------------------------------------------------------
@@ -302,29 +318,27 @@ def test_auth_probe_returns_match_reasons_list(client: TestClient) -> None:
 def test_auth_probe_passes_org_id_to_identity_assert(
     client: TestClient, provided_org_id: str
 ) -> None:
-    """When org_id is supplied in the body, identity assert is called with
-    tenant-only flavor (no claimed_user_id)."""
-    healthy = _make_crawl_result(
-        fit_markdown="Real article. " * 60,
-        word_count=600,
-        metadata={"status_code": 200},
-    )
+    """When ``org_id`` is supplied, ``assert_caller_identity_tenant_only``
+    is called with that value (no end-user / claimed_user_id)."""
     spy = AsyncMock(return_value=None)
     with (
-        patch(
-            "knowledge_ingest.routes.crawl.crawl_page",
-            new=AsyncMock(return_value=healthy),
-        ),
         patch(
             "knowledge_ingest.routes.crawl.assert_caller_identity_tenant_only",
             new=spy,
         ),
+        _patch_probe_fetch(
+            with_cookies=_probe(word_count=1000, byte_size=20000),
+            without_cookies=_probe(word_count=300, byte_size=8000),
+        ),
     ):
-        resp = client.post(
+        client.post(
             "/ingest/v1/crawl/auth-probe",
-            json={"url": "https://example.com/page", "org_id": provided_org_id},
+            json={
+                "url": "https://example.com/page",
+                "cookies": _REDCACTUS_COOKIES,
+                "org_id": provided_org_id,
+            },
         )
-    assert resp.status_code == 200, resp.text
     assert spy.await_count == 1
-    call_kwargs = spy.await_args.kwargs
-    assert call_kwargs.get("claimed_org_id") == provided_org_id
+    _, kwargs = spy.await_args
+    assert kwargs.get("claimed_org_id") == provided_org_id

--- a/scripts/validate-cookies.py
+++ b/scripts/validate-cookies.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Validate that the given cookies authenticate against a URL.
+
+Compares the HTTP response WITH cookies vs WITHOUT cookies on the SAME URL.
+If the two responses differ measurably (word count, byte size), the cookies
+have an effect on the server's behaviour — they authenticate.  If the two
+responses are identical, the cookies do nothing and any "Logged in — cookies
+verified" UI is a lie.
+
+This is the validation logic the wizard auth-probe should use instead of its
+current pattern-match-on-response heuristic, which says auth_ok whenever the
+response has >50 words and no auth-wall markers — a check that gives a green
+light even if the cookies were stripped on the wire.
+
+Usage:
+  python validate-cookies.py <url> 'name=value' ['name=value'...]
+
+Example:
+  python validate-cookies.py \\
+    'https://wiki.redcactus.cloud/nl/43-bubble-desktop-pop-up' \\
+    'prod-knowledgebase-session=eyJ...0%3D' \\
+    'XSRF-TOKEN=eyJ...0%3D'
+
+Exit 0 = AUTHENTICATED (cookies measurably change the response).
+Exit 1 = NOT AUTHENTICATED (cookies have no effect).
+"""
+import sys
+import httpx
+
+UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+
+
+def fetch(url: str, cookies: dict[str, str]) -> tuple[int, int, int]:
+    """Return (status, word_count, byte_size) for a GET on url with cookies."""
+    with httpx.Client(
+        timeout=30.0,
+        follow_redirects=True,
+        headers={"User-Agent": UA},
+    ) as c:
+        r = c.get(url, cookies=cookies)
+        return r.status_code, len(r.text.split()), len(r.text)
+
+
+def main() -> int:
+    if len(sys.argv) < 3:
+        sys.stderr.write(__doc__)
+        return 2
+
+    url = sys.argv[1]
+    cookies: dict[str, str] = {}
+    for arg in sys.argv[2:]:
+        if "=" not in arg:
+            sys.stderr.write(f"Skip arg without '=': {arg!r}\n")
+            continue
+        name, _, value = arg.partition("=")
+        cookies[name] = value
+
+    print(f"URL:              {url}")
+    print(f"Cookies provided: {sorted(cookies.keys())}")
+    print()
+
+    a_status, a_words, a_bytes = fetch(url, cookies)
+    print(f"WITH cookies:     status={a_status:3d}  words={a_words:6d}  bytes={a_bytes:8d}")
+
+    b_status, b_words, b_bytes = fetch(url, {})
+    print(f"WITHOUT cookies:  status={b_status:3d}  words={b_words:6d}  bytes={b_bytes:8d}")
+    print()
+
+    word_diff = abs(a_words - b_words)
+    byte_diff = abs(a_bytes - b_bytes)
+    print(f"Diff: {word_diff} words / {byte_diff} bytes")
+    print()
+
+    # Heuristic: cookies authenticate if either word count or byte size
+    # differs by >5% of the anonymous baseline (with min 20 words / 1KB).
+    word_threshold = max(20, b_words * 0.05)
+    byte_threshold = max(1000, b_bytes * 0.05)
+    significant = word_diff > word_threshold or byte_diff > byte_threshold
+
+    if significant:
+        print("VERDICT: AUTHENTICATED — cookies measurably change the response.")
+        return 0
+    print("VERDICT: NOT AUTHENTICATED — cookies have no effect on the response.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

Two architectural problems caused the wizard's "Logged in — cookies verified" message to lie about authenticated crawls — and silently broke every existing authenticated `web_crawler` connector's cron-sync ingest.

## Problems

### 1. Cookies were injected via a buggy Playwright hook

Both the wizard preview path AND the cron-sync ingest path used the same `on_page_context_created` hook to call `context.add_cookies()`. This pattern has documented timing issues:

- [microsoft/playwright#26786](https://github.com/microsoft/playwright/issues/26786) — cookies added before `goto` can appear empty after load
- [unclecode/crawl4ai#322](https://github.com/unclecode/crawl4ai/issues/322) — hook actions don't always propagate to `crawler.arun`
- [crawl4ai docs](https://docs.crawl4ai.com/advanced/hooks-auth/) explicitly: *"For robust auth, consider identity-based crawling … rather than shoehorning complex authentication into early hooks."*

Effect: cookies arrived at Playwright but didn't authenticate the navigation. **The cron-sync was silently indexing anonymous "Log in to read this article" stubs for every authenticated web_crawler connector** while operators saw "Sync succeeded" in the UI.

### 2. Auth-probe was a pattern-match heuristic, not real validation

The old auth-probe ran the seed URL through `crawl_page` + `classify_auth_wall` and called `auth_ok` whenever the response had >50 words and no auth-wall markers in the body. On Redcactus's homepage, anonymous content has no markers, so the classifier said `auth_ok` regardless of whether cookies actually did anything.

## Fixes

### Fix 1 — Native cookie injection via `BrowserConfig.cookies`

crawl4ai 0.8.x's `BrowserConfig` accepts `cookies: list` directly ([async_configs.py L634](https://github.com/unclecode/crawl4ai/blob/v0.8.6/crawl4ai/async_configs.py#L634)). The Docker REST API server deserializes via `BrowserConfig.load` ([api.py L567](https://github.com/unclecode/crawl4ai/blob/v0.8.6/deploy/docker/api.py#L567)), so the same payload shape works in our deployed setup.

Single helper `_build_browser_config_with_cookies` replaces the old `_build_cookie_hooks`. Migrated all 4 call sites in `crawl4ai_client.py` (`crawl_page`, `_fetch_seed_page`, `crawl_site`, `_crawl_chunked_bulk`) + 1 in `klai-connector/app/routes/fingerprint.py`.

### Fix 2 — Auth-probe = httpx 2-call diff

Replace the heuristic with a deterministic test:

1. Fetch the URL once WITH cookies, once WITHOUT — both via plain `httpx`
2. Compare word count, byte size, and status code
3. Significant divergence → cookies authenticate → `auth_ok`
4. Identical responses → cookies have no effect → `auth_failed_still_walled`

This logic CANNOT lie like the heuristic did. If cookies don't change the response, the wizard refuses to green-light. SSRF guards preserved via `PinnedResolverTransport`. `follow_redirects=False` keeps the response shape deterministic and prevents internal-IP smuggling via redirects.

Validated empirically before this commit:

```
URL:              https://wiki.redcactus.cloud/nl/43-bubble-desktop-pop-up
WITH cookies:     status=200  words=  7299  bytes=  181114
WITHOUT cookies:  status=200  words=  5572  bytes=  140044
Diff: 1727 words / 41070 bytes
VERDICT: AUTHENTICATED ✅
```

## Why httpx and not Playwright for auth-probe

Auth-probe only needs HTTP-level cookie behaviour — fast, simple, no JS quirks. The actual authenticated *crawl* still goes through crawl4ai (now with native `BrowserConfig.cookies`). Different tool for different job.

## Files

- `klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py` — helper renamed, 4 call sites migrated, diagnostic logging removed
- `klai-knowledge-ingest/knowledge_ingest/routes/crawl.py` — `auth_probe` rewritten with 2-call httpx diff, drops `_label_for_auth_probe`, adds `_ProbeResponse` + `_probe_fetch`
- `klai-connector/app/routes/fingerprint.py` — same hook → BrowserConfig.cookies migration, drops unused `json` import
- `klai-knowledge-ingest/tests/test_auth_probe_endpoint.py` — full rewrite, 13 tests covering the new diff-based logic, thresholds, SSRF, tenant scoping
- `scripts/validate-cookies.py` — reference validation script (the same logic ported into auth_probe). Used to bootstrap the approach. Kept as documentation-by-code.

## Verification

- `ruff check` + `ruff format --check` → green on all modified files
- 13/13 tests in `test_auth_probe_endpoint.py` pass
- 8 pre-existing test failures in `test_crawl4ai_filter_chain.py` / `test_crawl_link_fields.py` / `test_crawl_site_reconcile.py` confirmed already failing on `origin/main` BEFORE this change — unrelated to the migration

## Post-deploy verification

After admin-merge + deploy, open the connector wizard on `voys.getklai.com`, paste `prod-knowledgebase-session` + `XSRF-TOKEN` from a logged-in Redcactus session, and run preview on `wiki.redcactus.cloud/nl/43-bubble-desktop-pop-up`. Expected: logged-in content (>>258 anonymous words) — currently 258 anonymous words.

If preview still shows anonymous after this fix lands, the validation layer (auth-probe) at least correctly refuses to green-light, AND we have a more specific crawl4ai bug to investigate downstream — the architectural fix is structurally correct either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)