### PR TITLE
docs(mcp): correct Playwright seed flow — browser_run_code_unsafe, not browser_storage_state

### DIFF
--- a/.claude/rules/klai/pitfalls/process-rules.md
+++ b/.claude/rules/klai/pitfalls/process-rules.md
@@ -1461,15 +1461,20 @@ cookies expire (~3 weeks).
 
 **The canonical answer for this use case:**
 `--isolated --storage-state ~/.claude/mcp-storageState.json`. Seed the
-storage-state file via the **in-session `browser_storage_state` MCP tool**
-(available in `@playwright/mcp >= 0.0.67`) — NOT via `npx playwright
-codegen --save-storage=...`. The codegen path looks correct in Microsoft's
-docs but is flaky on macOS (the file only writes on a specific Inspector-
-side close event; closing the browser the wrong way means no file ever
-appears). PR #354's first attempt used codegen and produced a dead-end
-that cost a full day of debugging on 2026-05-06/07. The MCP-tool seed
-path writes the file directly from the running MCP server — no external
-tooling, no Inspector window, no Ctrl+C dance.
+storage-state file via `browser_run_code_unsafe` with one Playwright
+snippet that calls `page.context().storageState({ path })` — verified
+working on 2026-05-07. Do NOT use `npx playwright codegen
+--save-storage=...`: that path is flaky on macOS (the file only writes
+on a specific Inspector-side close event; closing the browser the
+wrong way means no file appears). PR #354 shipped codegen as the seed
+and lost a week of debugging before the 2026-05-07 retry confirmed
+the failure mode. Note: there is **no** separate `browser_storage_state`
+MCP tool in `@playwright/mcp@latest` — earlier drafts of this entry
+referenced one that does not exist. The functionality lives in the
+generic `browser_run_code_unsafe` tool, which executes Playwright code
+server-side; calling `page.context().storageState({ path: '...' })`
+writes the cookies + localStorage directly. No external tooling, no
+Inspector window, no Ctrl+C dance.
 
 **Anti-patterns — do NOT propose any of these without re-reading this entry:**
 
@@ -1506,8 +1511,9 @@ tooling, no Inspector window, no Ctrl+C dance.
    close event; close the browser the wrong way and the file never
    appears. PR #354 (apr 2026) shipped this as the documented seed step
    and lost a full week of "but it should work" debugging before the
-   2026-05-07 retry confirmed the failure mode. Use the in-session
-   `browser_storage_state` MCP tool instead.
+   2026-05-07 retry confirmed the failure mode. Use `browser_run_code_unsafe`
+   with `page.context().storageState({ path })` instead (see canonical
+   answer above).
 
 **The current working setup (do not change without strong cause):**
 
@@ -1536,9 +1542,18 @@ tooling, no Inspector window, no Ctrl+C dance.
      `https://voys.getklai.com`).
   3. Log in by hand (Google SSO + 2FA), wait until you're on the
      post-login workspace.
-  4. Have the AI call the MCP tool `browser_storage_state` — it writes
-     the current cookies + localStorage to
-     `~/.claude/mcp-storageState.json`.
+  4. Have the AI call `browser_run_code_unsafe` with this snippet (it
+     writes the current cookies + localStorage to disk):
+     ```js
+     async (page) => {
+       await page.context().storageState({
+         path: '/Users/<you>/.claude/mcp-storageState.json'
+       });
+       return { url: page.url(), cookieCount: (await page.context().cookies()).length };
+     }
+     ```
+     The tool returns immediately with the new cookie count. Verify the
+     file mtime/size with `ls -la ~/.claude/mcp-storageState.json`.
   5. Restart Claude Code so the launcher picks the new file up via
      `--storage-state` at startup.
   6. From now on all MCP sessions, including parallel Claude Code
@@ -1548,13 +1563,13 @@ tooling, no Inspector window, no Ctrl+C dance.
 
 | Symptom | Correct response | Wrong response |
 |---|---|---|
-| Sessions start logged-out | Verify `~/.claude/mcp-storageState.json` exists and is recent. Re-seed via the `browser_storage_state` MCP tool (see "Login seed/refresh" above). | Add `--user-data-dir` back (anti-pattern 2); fall back to `playwright codegen --save-storage` (anti-pattern 8). |
+| Sessions start logged-out | Verify `~/.claude/mcp-storageState.json` exists and is recent. If missing/stale, re-seed by running `browser_run_code_unsafe` with `page.context().storageState({ path })` after a fresh login (see "Login seed/refresh" above). | Add `--user-data-dir` back (anti-pattern 2); fall back to `playwright codegen --save-storage` (anti-pattern 8); search for a non-existent `browser_storage_state` tool. |
 | `Browser is already in use` on a second session | Confirm `.mcp.json` uses `--isolated` not `--user-data-dir`. Each session must get its own ephemeral profile. | Add a slot-pool launcher (anti-pattern 6) |
 | AI cannot see what the browser is doing | Confirm no `--headless` flag in the primary server. | Tell the user to "just check the browser themselves" — defeats the point |
 | User says "iedere keer hetzelfde probleem" | Stop. Re-read this entry. Do not propose a config change before identifying which anti-pattern you are about to commit. | Propose another config edit |
-| `browser_storage_state` tool not visible in current session | Tool-schema-cache is from an older `@playwright/mcp` pin. Restart Claude Code so it reloads the schema list from `@latest`. | Try `browser_evaluate` to read cookies (HttpOnly cookies are invisible) or write a homegrown seed script (anti-pattern 6 territory). |
-| `--browser chromium` rejected on launch | `@playwright/mcp >= 0.0.74` dropped `chromium` as a valid value. Use `--browser chrome`. | Pin back to `@0.0.70` (loses `browser_storage_state` tool — anti-pattern 8 territory). |
-| Storage state file is hand-edited / non-standard | Delete it, re-seed via the `browser_storage_state` MCP tool. | Hand-edit JSON in storageState |
+| `browser_run_code_unsafe` tool not visible in current session | Tool-schema-cache is from an older `@playwright/mcp` pin (pre `0.0.74` exposed `browser_run_code` instead). Restart Claude Code so it reloads the schema list from `@latest`. | Try `browser_evaluate` to read cookies (HttpOnly cookies are invisible) or write a homegrown seed script (anti-pattern 6 territory). |
+| `--browser chromium` rejected on launch | `@playwright/mcp >= 0.0.74` dropped `chromium` as a valid value. Use `--browser chrome`. | Pin back to `@0.0.70` (loses `browser_run_code_unsafe` — anti-pattern 8 territory). |
+| Storage state file is hand-edited / non-standard | Delete it, re-seed via `browser_run_code_unsafe` after a fresh login. | Hand-edit JSON in storageState |
 
 If a future @playwright/mcp version introduces auto-write-back of storage
 state on session close, the manual refresh step can be removed. Until

--- a/.claude/scripts/playwright-launcher.mjs
+++ b/.claude/scripts/playwright-launcher.mjs
@@ -21,20 +21,35 @@
  *     the seed step relied on `npx playwright codegen --save-storage`,
  *     which is flaky on macOS.
  *
- * The seed step (May 2026):
- *   In @playwright/mcp >= 0.0.67 there is an MCP tool
- *   `browser_storage_state` that, when invoked from a running session,
- *   writes the current cookies + localStorage to the storage-state
- *   file. No external codegen, no Inspector window, no Ctrl+C dance.
+ * The seed step (verified 2026-05-07):
+ *   `@playwright/mcp >= 0.0.74` exposes `browser_run_code_unsafe`,
+ *   which executes a Playwright snippet server-side with a `page`
+ *   handle. Calling `page.context().storageState({ path })` from
+ *   inside such a snippet writes the current cookies + localStorage
+ *   to the storage-state file directly. No external codegen, no
+ *   Inspector window, no Ctrl+C dance.
  *
  *   1. With this launcher in place but no storage-state file yet,
  *      open a Playwright MCP session — the browser starts logged out.
  *   2. `browser_navigate` to a login URL, log in by hand.
- *   3. Have the AI call `browser_storage_state` — file is written.
+ *   3. Have the AI call `browser_run_code_unsafe` with this snippet:
+ *        async (page) => {
+ *          await page.context().storageState({
+ *            path: '/Users/<you>/.claude/mcp-storageState.json',
+ *          });
+ *          return { url: page.url(),
+ *                   cookies: (await page.context().cookies()).length };
+ *        }
+ *      The tool returns immediately with the new cookie count.
  *   4. Restart Claude Code (so the launcher picks the file up at
  *      startup via the `--storage-state` flag).
  *   5. Refresh the same way every ~3 weeks when Google's session
  *      cookies expire.
+ *
+ *   NOTE: there is no separate `browser_storage_state` MCP tool. An
+ *   earlier draft of this launcher and its docs claimed there was;
+ *   that was a hallucination. The functionality lives in the generic
+ *   `browser_run_code_unsafe` tool, as shown above.
  *
  * Why CLI flags instead of a JSON config file:
  *   microsoft/playwright-mcp#1446 — `userDataDir` set in a JSON
@@ -70,7 +85,8 @@ if (existsSync(STATE_FILE)) {
     `playwright-launcher: ${STATE_FILE} not found.\n` +
     `Browser starts logged-out. To seed the file from inside a running\n` +
     `MCP session: open a login URL via browser_navigate, log in by hand,\n` +
-    `then have the AI call the browser_storage_state MCP tool. Restart\n` +
+    `then have the AI call browser_run_code_unsafe with a snippet that\n` +
+    `runs page.context().storageState({path: STATE_FILE}). Restart\n` +
     `Claude Code afterwards so the launcher picks up the file.\n`
   );
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -16,7 +16,7 @@
       "env": {}
     },
     "playwright": {
-      "$comment": "Headed Chrome with `--isolated --storage-state ~/.claude/mcp-storageState.json`. Parallel-safe (every session gets its own ephemeral profile) and all sessions start authenticated by preloading the storage-state file. Seed via the MCP tool `browser_storage_state` from inside a running session (NOT external `npx playwright codegen` — that path is flaky on macOS and was the trap in PR #354's first try). See process-rules.md::playwright-mcp-config-cycle for the full failure-mode history.",
+      "$comment": "Headed Chrome with `--isolated --storage-state ~/.claude/mcp-storageState.json`. Parallel-safe (every session gets its own ephemeral profile) and all sessions start authenticated by preloading the storage-state file. Seed by calling `browser_run_code_unsafe` from a logged-in session with `await page.context().storageState({path: '~/.claude/mcp-storageState.json'})` — verified working 2026-05-07. NOT via external `npx playwright codegen` (flaky on macOS, the PR #354 trap). There is no separate `browser_storage_state` MCP tool. See docs/setup/mcp-servers.md Section 3 for the full flow.",
       "type": "stdio",
       "command": "node",
       "args": [".claude/scripts/playwright-launcher.mjs"],

--- a/docs/setup/mcp-servers.md
+++ b/docs/setup/mcp-servers.md
@@ -134,10 +134,14 @@ when Google's session cookies expire (~3 weeks, see seed flow below).
 The reason this pattern looked broken for weeks in April 2026: PR #354 used
 `npx playwright codegen --save-storage` as the seed step. On macOS that save
 only fires on a specific Inspector-side close event; if you closed the
-browser the wrong way, the file never appeared. Solved May 2026 by switching
-the seed to the in-session `browser_storage_state` MCP tool (available in
-`@playwright/mcp >= 0.0.67`), which writes the file directly from the running
-MCP server — no external tooling, no Inspector window, no Ctrl+C dance.
+browser the wrong way, the file never appeared. Solved 2026-05-07 by
+switching the seed to a server-side Playwright snippet via the
+`browser_run_code_unsafe` MCP tool: `await page.context().storageState({
+path })` writes cookies + localStorage directly from the running MCP
+server's BrowserContext — no external codegen, no Inspector window, no
+Ctrl+C dance. Note: an earlier draft of these docs referenced a
+non-existent `browser_storage_state` tool. The functionality always lived
+in `browser_run_code_unsafe`; only the wording was off.
 
 ### Why a launcher script and not a JSON `--config` file
 
@@ -151,25 +155,46 @@ vehicle for those flags.
 1. With the launcher in place but no storage-state file yet (or after deleting
    it for a refresh), restart Claude Code so the MCP server picks up the new
    config. Open a new Playwright MCP session — the browser starts logged-out.
-2. Have the AI `browser_navigate` to a login URL, e.g. `https://voys.getklai.com`.
-3. Log in by hand (Google SSO + 2FA), wait until you're on the chat home.
-4. Have the AI call the MCP tool `browser_storage_state` — it writes the
-   current cookies + localStorage to `~/.claude/mcp-storageState.json`.
-5. Restart Claude Code so the launcher picks the file up via `--storage-state`.
+2. Ask Claude: **"navigate naar voys.getklai.com en seed de storage-state na
+   mijn login"**. Claude calls `browser_navigate` to open the login URL.
+3. Log in by hand in the browser-window (Google SSO + 2FA). Wait until you're
+   on `https://voys.getklai.com/app` (or `my.getklai.com` workspace).
+4. Tell Claude **"klaar"** (or "done"). Claude calls `browser_run_code_unsafe`
+   with this snippet:
+   ```js
+   async (page) => {
+     await page.context().storageState({
+       path: '/Users/<you>/.claude/mcp-storageState.json'
+     });
+     const cookies = await page.context().cookies();
+     return {
+       url: page.url(),
+       cookieCount: cookies.length,
+       klaiCookies: cookies.filter(c => c.domain.includes('getklai')).length,
+     };
+   }
+   ```
+   The tool returns immediately with the new cookie count. Sanity-check:
+   `klaiCookies` should be ≥ 6 (PARAGLIDE_LOCALE × 2, zitadel.useragent,
+   klai_sso, __Secure-klai_session, __Secure-klai_csrf).
+5. Restart Claude Code so the launcher picks the file up via `--storage-state`
+   on the next MCP-server spawn.
 6. From now on all MCP sessions, including parallel Claude Code instances,
    start authenticated.
 
-Refresh the same way every ~3 weeks when Google's session cookies expire.
+Refresh the same way every ~3 weeks when Google's session cookies expire (you
+notice because new sessions start logged-out again).
 
-For the full failure-mode cycle and anti-patterns to avoid, see
+For the full failure-mode history and anti-patterns to avoid, see
 `playwright-mcp-config-cycle (HIGH)` in
-`.claude/rules/klai/pitfalls/process-rules.md` (8 anti-patterns and many
-"fixes" since April 2026 — this section is the May 2026 canonical, anchored
-on Microsoft Issue #1530's outcome).
+`.claude/rules/klai/pitfalls/process-rules.md` (8 anti-patterns accumulated
+across many "fixes" since April 2026 — this section is the verified
+2026-05-07 canonical, anchored on Microsoft Issue #1530's outcome).
 
 ### Starting from scratch (logged-out state)
 
-Delete the storage-state file, then re-run the codegen command above:
+Delete the storage-state file, restart Claude Code, then re-run the seed
+flow above (steps 2–5):
 
 ```powershell
 # Windows (PowerShell)
@@ -180,8 +205,6 @@ Remove-Item -Force "$env:USERPROFILE\.claude\mcp-storageState.json"
 # macOS / Linux
 rm -f ~/.claude/mcp-storageState.json
 ```
-
-Then re-run the codegen command above to regenerate the file.
 
 For session management rules (when to open/close the browser), see
 `.claude/rules/klai/lang/testing.md`.
@@ -384,10 +407,10 @@ uvx mcp-grafana --help
 3. **MCP timeout** — Serena takes too long to index. Check `.serena/project.yml` for overly broad
    file patterns.
 4. **Playwright launcher fails to start** — `node` not on PATH or the launcher script missing. Fix: verify `node --version` works in your shell and `.claude/scripts/playwright-launcher.mjs` exists. Restart Claude Code.
-5. **Playwright sessions start logged-out** — `~/.claude/mcp-storageState.json` is missing or its cookies have expired. Fix: re-run the codegen command in Section 3 to regenerate the file, then restart Claude Code.
+5. **Playwright sessions start logged-out** — `~/.claude/mcp-storageState.json` is missing or its cookies have expired. Fix: re-run the seed flow in Section 3 (one-time login + `browser_run_code_unsafe` snippet), then restart Claude Code.
 6. **Playwright fails with `Browser is already in use`** — should not happen with `--isolated`. If it does, confirm `.mcp.json` still uses `--isolated --storage-state` and not a `--user-data-dir` flag. A leftover Chromium process can be killed with `taskkill /F /IM chrome.exe` (Windows) or `pkill -f playwright` (Mac/Linux).
-7. **Playwright window opens but immediately closes** — storage-state file is corrupt or in a non-Playwright format. Fix: delete `~/.claude/mcp-storageState.json` and re-run the codegen command.
-8. **Login state visible in one site but missing in another** — codegen capture only saved the sites you visited during the login dance. Fix: re-run codegen and visit + log in to every site you need before closing the window.
+7. **Playwright window opens but immediately closes** — storage-state file is corrupt or in a non-Playwright format. Fix: `rm ~/.claude/mcp-storageState.json` and re-run the seed flow in Section 3.
+8. **Login state visible in one site but missing in another** — the seed only captured cookies from the sites you actually visited before triggering `browser_run_code_unsafe`. Fix: re-seed and visit + log in to every site you need (Google, voys, my.getklai.com, etc.) BEFORE asking Claude to write the storage-state file.
 9. **CodeIndex not found** — `codeindex` command not available. Fix: `npm install -g klai-private/tools/codeindex-1.3.56.tgz`
 10. **CodeIndex stale index** — Index behind HEAD. Symptoms: impact analysis misses recent code. Fix: `codeindex update && node scripts/codeindex-enrich.mjs`
 11. **VictoriaLogs tunnel not running** — MCP queries fail silently or timeout. Fix: `./scripts/victorialogs-tunnel.sh` then restart Claude Code.


### PR DESCRIPTION
## Summary

PR #490 (merged 2026-05-07 14:43) shipped the Playwright MCP setup with a documented seed step that referenced an MCP tool that does not exist: `browser_storage_state`. End-to-end verification later that day (this PR's verifier-of-record) showed the actual seed path is `browser_run_code_unsafe` with a Playwright snippet that calls `page.context().storageState({ path })`. The functionality is identical, only the tool name and call shape differ.

This PR corrects all four locations that referenced the non-existent tool. **No production code changes. No new pitfalls.** Per request: "documenteer hoe het wel moet" — positive correction, not yet-another-anti-pattern.

## Files

| File | Change |
|---|---|
| [`.claude/scripts/playwright-launcher.mjs`](.claude/scripts/playwright-launcher.mjs) | Comment block: seed step shows the verbatim snippet; explicit "no separate `browser_storage_state` tool" disclaimer; stderr-warning string updated. |
| [`.mcp.json`](.mcp.json) | `playwright` server `$comment` updated: inline snippet + correct pointer to docs. |
| [`docs/setup/mcp-servers.md`](docs/setup/mcp-servers.md) | Section 3 "One-time login (and refresh)" fully rewritten with the exact snippet you ask Claude to run. Common Failure Modes #5/#7/#8 point to the seed flow, not codegen. |
| [`.claude/rules/klai/pitfalls/process-rules.md`](.claude/rules/klai/pitfalls/process-rules.md) | `playwright-mcp-config-cycle`: canonical-answer paragraph corrected; anti-pattern #8 closing pointer corrected; current-working-setup step 4 shows snippet; prevention table rows fixed. |

## Verified end-to-end (2026-05-07)

- Browser navigated to `https://voys.getklai.com` → redirected to Google SSO
- Manual login + 2FA, landed on `https://voys.getklai.com/app` (logged-in workspace)
- `browser_run_code_unsafe` called with `page.context().storageState({ path: '/Users/.../mcp-storageState.json' })`
- File written: 14521 bytes, 46 cookies, 6 Klai cookies (klai_sso, __Secure-klai_session, __Secure-klai_csrf, zitadel.useragent, 2× PARAGLIDE_LOCALE), 29 Google cookies
- All future Claude Code sessions started after this seed get the file pre-loaded via `--storage-state` and start authenticated

## What this PR does NOT do

- No new anti-patterns added to `playwright-mcp-config-cycle`
- No production code changes (the launcher's runtime behaviour is identical)
- No changes to `playwright-isolated` server
- No changes to other MCP servers

🤖 Generated with [Claude Code](https://claude.com/claude-code)