### PR TITLE
fix(taxonomy): consolidate naming prompts to one criteria base + drop V1 dead code

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/config.py
+++ b/klai-knowledge-ingest/knowledge_ingest/config.py
@@ -99,11 +99,14 @@ class Settings(BaseSettings):
     taxonomy_cluster_trigger_count: int = 20
     taxonomy_centroid_max_age_hours: int = 48
 
-    # SPEC-TAXONOMY-V2-001 bootstrap settings
+    # SPEC-TAXONOMY-V2-001 bootstrap settings.
+    # ``taxonomy_bootstrap_v2_enabled`` flag was deleted in
+    # SPEC-TAXONOMY-V2-CONSOLIDATION-001 along with the V1 fallback path —
+    # V2 had been the default since PR #408 and the fallback was never used
+    # in production.
     taxonomy_bootstrap_min_cluster_size_floor: int = 5
     taxonomy_bootstrap_max_clusters: int = 20
     taxonomy_bootstrap_top_n_per_cluster: int = 8
-    taxonomy_bootstrap_v2_enabled: bool = True
 
     # SPEC-TAXONOMY-V2-001-FOLLOWUP-001: UMAP pre-reduction settings (B1)
     taxonomy_bootstrap_umap_n_components: int = 10

--- a/klai-knowledge-ingest/knowledge_ingest/proposal_generator.py
+++ b/klai-knowledge-ingest/knowledge_ingest/proposal_generator.py
@@ -1,11 +1,61 @@
 """
-Proposal generator — suggests new taxonomy categories based on unmatched documents.
+Proposal generator — suggests taxonomy category names from clusters of documents.
 
-Called after a batch ingest when >= 3 documents had taxonomy_node_id = null.
-Uses klai-fast to suggest a category name for the cluster, then submits via portal_client.
-Deduplication: checks existing pending proposals before submitting (24h window enforced by portal).
+Two callers, three LLM-prompt strategies, one shared naming-criteria base.
 
-SPEC-TAXONOMY-V2-001: adds generate_bootstrap_proposals_v2 (Clio-style density-driven bootstrap).
+──────────────────────────────────────────────────────────────────────────────
+Evolution history (read this BEFORE adding a fourth strategy)
+──────────────────────────────────────────────────────────────────────────────
+
+  SPEC-KB-021    : ``maybe_generate_proposal`` — post-ingest, when >= 3 docs
+                   land that don't fit existing taxonomy nodes, suggest one
+                   new category for them. Single LLM call, single name out.
+
+  SPEC-KB-022    : ``generate_bootstrap_proposals`` (V1) — single-shot 50-doc
+                   bootstrap where the LLM did *both* clustering AND naming
+                   in one call. Replaced by V2 below; kept for a feature-flag
+                   window then deleted (SPEC-TAXONOMY-V2-CONSOLIDATION-001).
+
+  SPEC-TAXONOMY-V2-001 : ``generate_bootstrap_proposals_v2`` — Clio-style.
+                   Pre-cluster documents with HDBSCAN, then ask the LLM to
+                   *only* name (not cluster). One LLM call per cluster, in
+                   parallel. New prompt: ``_BOOTSTRAP_V2_SYSTEM_PROMPT``.
+
+  SPEC-TAXONOMY-V2-001-FOLLOWUP-001 B4 : V2 in prod produced 7 near-duplicate
+                   names around "CRM integraties" (HDBSCAN found valid sub-
+                   clusters per CRM product, but per-cluster naming had no
+                   awareness of siblings). Added ``_BATCHED_NAMING_SYSTEM_PROMPT``
+                   — single LLM call sees all clusters, enforces distinct
+                   names. Single-cluster prompt kept as fallback when batched
+                   times out or returns nothing for a cluster_id.
+
+  SPEC-TAXONOMY-V2-CONSOLIDATION-001 : the Unify-bug discovery — the batched
+                   prompt's "differentiate by what's UNIQUE about each
+                   cluster" rule biased the LLM to pick the most salient
+                   brand-noun (e.g. "Unify-telefoons") even when only one of
+                   eight docs in the cluster mentioned that brand. Two parallel
+                   prompts had silently drifted (single said "prefer domain
+                   language", batched said "differentiate by unique"), giving
+                   different output bias depending on which path fired.
+
+                   Fix-forward: extracted ``_NAMING_CRITERIA`` as a shared
+                   base. Each prompt composes the base + its strategy-specific
+                   framing (incremental / single / batched). The Unify-bug fix
+                   ("name common theme, NOT salient minority brand") lands
+                   in the base — applies to all prompts automatically. V1
+                   bootstrap path + feature flag deleted.
+
+──────────────────────────────────────────────────────────────────────────────
+
+Why three prompts (not one): the *strategies* genuinely differ.
+
+- Incremental: adds one node to an existing taxonomy. Must avoid existing names.
+- Single-cluster: names one cluster, no siblings visible. (Batched fallback.)
+- Batched: names N clusters in one call, must produce distinct names.
+
+But the *naming criteria* are identical across strategies — and that's what
+the shared base captures. Sibling-distinctness in batched is enforced *on top*
+of the base, not by overriding the base's "common theme" rule.
 """
 
 from __future__ import annotations
@@ -34,11 +84,37 @@ class DocumentSummary:
     content_preview: str
 
 
+# ---------------------------------------------------------------------------
+# Shared naming criteria — single source of truth for what makes a good name.
+# ---------------------------------------------------------------------------
+# Every cluster-naming prompt below composes this block. Bug-fixes to the
+# rules land HERE and apply everywhere automatically. Do not duplicate or
+# override these rules in a strategy-specific prompt — extend, don't fork.
+
+_NAMING_CRITERIA = (
+    "Apply these rules to every cluster name:\n\n"
+    "- The name MUST describe what is COMMON across ALL documents in the cluster.\n"
+    "  Look for the shared theme, NOT the most prominent or branded item.\n"
+    "- If documents span multiple brands, products, or providers, use a generic\n"
+    '  descriptor (e.g., "Telefoonconfiguratie - diverse providers"), NOT the\n'
+    "  most salient brand appearing in only some docs.\n"
+    "- Use specific terms (brand, product, tool) ONLY when they apply to ALL\n"
+    "  documents in the cluster.\n"
+    "- 2-5 words, in the user's domain language (Dutch if docs are in Dutch).\n"
+)
+
+
+# ---------------------------------------------------------------------------
+# Strategy 1: incremental — name ONE cluster of post-ingest unmatched docs.
+# Used by ``maybe_generate_proposal``. Existing-node names are avoided
+# at the call site (post-LLM dedup), not enforced in the prompt.
+# ---------------------------------------------------------------------------
+
 _PROPOSAL_SYSTEM_PROMPT = (
-    "You are a knowledge taxonomy assistant. "
-    "Given a list of documents that don't fit existing categories, "
-    "suggest a concise category name (2-5 words) that would cover them. "
-    "\n\nReply with ONLY a JSON object, no markdown, no explanation: "
+    "You are a knowledge taxonomy assistant. You are proposing a NEW "
+    "category for documents that don't fit any existing category.\n\n"
+    f"{_NAMING_CRITERIA}"
+    "\nReply with ONLY a JSON object, no markdown, no explanation: "
     '{"category_name": "<string>"}'
 )
 
@@ -124,145 +200,11 @@ async def maybe_generate_proposal(
     )
 
 
-_BOOTSTRAP_SYSTEM_PROMPT = (
-    "You are a knowledge taxonomy assistant. "
-    "Given a list of documents from a knowledge base, identify the 3-8 most logical, "
-    "non-overlapping top-level categories that together cover all documents. "
-    "Each category name should be concise (2-5 words) and distinct. "
-    "If existing categories are listed, do NOT repeat them — only propose NEW categories "
-    "that cover documents not fitting the existing ones. "
-    "Return an empty list if no new categories are needed."
-    "\n\nReply with ONLY a JSON object, no markdown, no explanation: "
-    '{"categories": ["<string>", ...]}'
-)
-
-
-async def generate_bootstrap_proposals(
-    org_id: str,
-    kb_slug: str,
-    documents: list[DocumentSummary],
-    existing_category_names: list[str] | None = None,
-) -> int:
-    """Scan existing documents and generate bootstrap taxonomy proposals.
-
-    Sends up to 50 document summaries to klai-fast, asks it to identify
-    3-8 top-level categories, then submits one proposal per category.
-    Returns number of proposals submitted.
-
-    Skips silently when PORTAL_INTERNAL_TOKEN is not configured.
-    """
-    if not documents:
-        return 0
-    if not settings.portal_internal_token:
-        logger.warning(
-            "bootstrap_proposals_skipped",
-            reason="missing PORTAL_INTERNAL_TOKEN",
-            kb_slug=kb_slug,
-        )
-        return 0
-
-    try:
-        categories = await asyncio.wait_for(
-            _suggest_multiple_categories(documents[:50], existing_category_names or []),
-            timeout=30.0,
-        )
-    except Exception as exc:
-        logger.warning(
-            "bootstrap_proposals_generation_failed",
-            kb_slug=kb_slug,
-            error=str(exc),
-        )
-        return 0
-
-    if not categories:
-        return 0
-
-    # Filter out names that already exist (case-insensitive) as a safety net,
-    # even though the prompt tells the LLM not to propose them.
-    existing_lower = {n.lower() for n in (existing_category_names or [])}
-    categories = [c for c in categories if c.lower() not in existing_lower]
-
-    if not categories:
-        logger.info(
-            "bootstrap_proposals_all_filtered",
-            kb_slug=kb_slug,
-            reason="all proposed categories already exist",
-        )
-        return 0
-
-    # Generate descriptions for each proposed category in parallel
-    sample_titles = [doc.title for doc in documents[:10]]
-    desc_tasks = [
-        generate_node_description(name, None, sample_titles) for name in categories if name
-    ]
-    descriptions = await asyncio.gather(*desc_tasks, return_exceptions=True)
-
-    submitted = 0
-    for i, name in enumerate(categories):
-        desc = descriptions[i] if i < len(descriptions) and isinstance(descriptions[i], str) else ""
-        proposal = TaxonomyProposal(
-            proposal_type="new_node",
-            suggested_name=name,
-            document_count=len(documents),
-            sample_titles=[doc.title for doc in documents[:5]],
-            description=desc,
-        )
-        await submit_taxonomy_proposal(kb_slug=kb_slug, org_id=org_id, proposal=proposal)
-        submitted += 1
-        logger.info(
-            "bootstrap_proposal_submitted",
-            kb_slug=kb_slug,
-            suggested_name=name,
-            description=desc,
-        )
-
-    logger.info(
-        "bootstrap_proposals_complete",
-        kb_slug=kb_slug,
-        document_count=len(documents),
-        proposals_submitted=submitted,
-    )
-    return submitted
-
-
-async def _suggest_multiple_categories(
-    documents: list[DocumentSummary],
-    existing_names: list[str],
-) -> list[str]:
-    """Use klai-fast to suggest multiple category names for a set of documents."""
-    doc_summaries = "\n".join(f"- {doc.title}: {doc.content_preview[:150]}" for doc in documents)
-    user_message = f"Documents in this knowledge base:\n{doc_summaries}"
-    if existing_names:
-        user_message += (
-            f"\n\nExisting categories (do NOT propose these again): {', '.join(existing_names)}"
-        )
-
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        resp = await client.post(
-            f"{settings.litellm_url}/chat/completions",
-            headers={
-                "Authorization": f"Bearer {settings.litellm_api_key}",
-                "Content-Type": "application/json",
-            },
-            json={
-                "model": settings.taxonomy_classification_model,
-                "messages": [
-                    {"role": "system", "content": _BOOTSTRAP_SYSTEM_PROMPT},
-                    {"role": "user", "content": user_message},
-                ],
-                "temperature": 0.3,
-                "max_tokens": 200,
-            },
-        )
-        resp.raise_for_status()
-        data = resp.json()
-        content = data["choices"][0]["message"]["content"]
-        content = (content or "").strip()
-        # Strip markdown code fences if present
-        if content.startswith("```"):
-            content = content.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
-        parsed = json.loads(content)
-        return [c for c in parsed.get("categories", []) if isinstance(c, str) and c.strip()]
+# V1 ``generate_bootstrap_proposals`` (single-shot LLM clustering+naming) +
+# its prompt + helper were deleted in SPEC-TAXONOMY-V2-CONSOLIDATION-001.
+# V2 (HDBSCAN pre-clustering + per-cluster LLM naming) has been the default
+# (``taxonomy_bootstrap_v2_enabled=True``) since SPEC-TAXONOMY-V2-001 shipped
+# in PR #408. The fallback was never re-enabled in production.
 
 
 @dataclass
@@ -279,17 +221,19 @@ class BootstrapResult:
 
 
 # ---------------------------------------------------------------------------
-# V2 bootstrap system prompt (per cluster)
+# Strategy 2: V2 single-cluster — name ONE pre-clustered (HDBSCAN) group.
+# Used as fallback when batched naming below times out or returns nothing
+# for a cluster_id. Shares ``_NAMING_CRITERIA`` with batched, so the rules
+# the LLM applies don't depend on which path fired.
 # ---------------------------------------------------------------------------
 
 _BOOTSTRAP_V2_SYSTEM_PROMPT_TEMPLATE = (
     "You are a knowledge taxonomy assistant. You are naming a cluster of "
     "documents from a knowledge base."
     "{kb_description_block}"
-    "\n\nGiven example documents that thematically belong together, suggest a "
-    "concise category name (2-5 words) that captures their shared theme. "
-    "Prefer the user's domain language over generic labels."
-    '\n\nReply with ONLY a JSON object: {{"category_name": "<string>"}}'
+    "\n\n"
+    f"{_NAMING_CRITERIA}"
+    '\nReply with ONLY a JSON object: {{"category_name": "<string>"}}'
 )
 
 
@@ -335,18 +279,33 @@ async def _suggest_cluster_name(
         return parsed.get("category_name") or None
 
 
+# ---------------------------------------------------------------------------
+# Strategy 3: V2 batched — name N pre-clustered groups in ONE LLM call.
+# Cross-cluster awareness lets the LLM enforce distinct names when HDBSCAN
+# finds related sub-clusters (B4: prevents "7 variants of CRM integraties").
+#
+# IMPORTANT: the sibling-distinctness rule must NOT override the criteria
+# base's "common theme" rule. The pre-Consolidation prompt said "differentiate
+# by what's UNIQUE about each cluster (specific tool/use-case/audience)" —
+# that biased the LLM toward picking the most salient minority brand as the
+# label (the Unify-bug). The current formulation differentiates by COMMON-
+# WITHIN-each-cluster-more-specifically, preserving distinctness without the
+# salient-brand bias.
+# ---------------------------------------------------------------------------
+
 _BATCHED_NAMING_SYSTEM_PROMPT_TEMPLATE = (
     "You are naming N pre-clustered groups of documents from a knowledge base."
     "{kb_description_block}"
-    "\n\nThe clustering algorithm has already identified these as DISTINCT topics — "
-    "your job is to label each one with a concise, DIFFERENTIATED name.\n\n"
-    "Constraints:\n"
-    "- Each name 2-5 words\n"
-    "- All N names MUST be DISTINCT — no near-duplicates, no overlapping concepts\n"
-    "- Use the user's domain language (Dutch terms if docs are in Dutch)\n"
-    '- If clusters appear thematically related (e.g., multiple sub-types of "X"), '
-    "differentiate by what's UNIQUE about each "
-    "(specific tool, specific use-case, specific audience)\n\n"
+    "\n\nThe clustering algorithm has already identified these as DISTINCT "
+    "topics — your job is to label each one with a concise, DIFFERENTIATED "
+    "name.\n\n"
+    f"{_NAMING_CRITERIA}"
+    "\nAdditional cross-cluster constraint:\n"
+    "- All N names MUST be DISTINCT — no near-duplicates, no overlapping concepts.\n"
+    "- When clusters share an overarching theme but differ in scope, "
+    "differentiate by what is COMMON within each cluster at a more specific "
+    "level (the shared sub-theme of those docs), NOT by picking the most "
+    "unique-looking item per cluster.\n\n"
     "Reply ONLY with JSON, no markdown:\n"
     '{{"names": [{{"cluster_id": <int>, "name": "<string>"}}, ...]}}'
 )

--- a/klai-knowledge-ingest/knowledge_ingest/routes/taxonomy.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/taxonomy.py
@@ -40,7 +40,6 @@ from knowledge_ingest.config import settings  # noqa: E402
 from knowledge_ingest.portal_client import fetch_taxonomy_nodes  # noqa: E402
 from knowledge_ingest.proposal_generator import (  # noqa: E402
     DocumentSummary,
-    generate_bootstrap_proposals,
     generate_bootstrap_proposals_v2,
 )
 from knowledge_ingest.taxonomy_classifier import classify_document  # noqa: E402
@@ -217,16 +216,19 @@ async def taxonomy_bootstrap_proposals(
 ) -> BootstrapResponse:
     """Scan existing Qdrant chunks and generate bootstrap taxonomy proposals.
 
-    SPEC-TAXONOMY-V2-001: when taxonomy_bootstrap_v2_enabled=True (default), uses the
-    new Clio-style density-driven path that:
+    SPEC-TAXONOMY-V2-001: Clio-style density-driven path that:
     - Samples ALL documents (not just first 50)
     - Uses HDBSCAN clustering to determine category count
-    - Names each cluster with a separate focused LLM call
-
-    Falls back to v1 (single-shot LLM) when flag is False.
+    - Names each cluster with a focused LLM call (batched cross-cluster aware,
+      with per-cluster fallback). Naming criteria are shared across the two
+      strategies via ``proposal_generator._NAMING_CRITERIA``.
 
     Use this to bootstrap a KB taxonomy from scratch when no nodes exist yet.
     After accepting proposals in the portal, run /backfill to tag all chunks.
+
+    The V1 single-shot fallback (LLM doing both clustering and naming) was
+    deleted in SPEC-TAXONOMY-V2-CONSOLIDATION-001 — V2 had been the default
+    in production since PR #408 and the fallback path was never re-enabled.
     """
     import numpy as np
 
@@ -246,57 +248,6 @@ async def taxonomy_bootstrap_proposals(
 
     # Fetch existing taxonomy nodes for dedup
     existing_nodes = await fetch_taxonomy_nodes(req.kb_slug, req.org_id)
-
-    if not settings.taxonomy_bootstrap_v2_enabled:
-        # V1 fallback: scroll up to 50 docs, single-shot LLM
-        seen_artifacts: set[str] = set()
-        documents_v1: list[DocumentSummary] = []
-        offset = None
-
-        while len(documents_v1) < 50:
-            points, next_offset = await asyncio.wait_for(
-                qdrant_client.scroll(
-                    collection_name=COLLECTION,
-                    scroll_filter=scroll_filter,
-                    limit=req.batch_size,
-                    offset=offset,
-                    with_payload=True,
-                    with_vectors=False,
-                ),
-                timeout=30.0,
-            )
-            if not points:
-                break
-            for point in points:
-                payload = point.payload or {}
-                artifact_id = payload.get("artifact_id") or str(point.id)
-                if artifact_id in seen_artifacts:
-                    continue
-                seen_artifacts.add(artifact_id)
-                title = payload.get("title") or payload.get("path") or artifact_id
-                preview = payload.get("text", "")[:300]
-                documents_v1.append(DocumentSummary(title=title, content_preview=preview))
-                if len(documents_v1) >= 50:
-                    break
-            if next_offset is None:
-                break
-            offset = next_offset
-
-        if not documents_v1:
-            logger.info("bootstrap_proposals_no_documents", kb_slug=req.kb_slug, org_id=req.org_id)
-            return BootstrapResponse(documents_scanned=0, proposals_submitted=0)
-
-        existing_names = [n.name for n in existing_nodes]
-        proposals_submitted = await generate_bootstrap_proposals(
-            org_id=req.org_id,
-            kb_slug=req.kb_slug,
-            documents=documents_v1,
-            existing_category_names=existing_names,
-        )
-        return BootstrapResponse(
-            documents_scanned=len(documents_v1),
-            proposals_submitted=proposals_submitted,
-        )
 
     # V2 path: scroll ALL docs with vectors, group by artifact_id, average vectors
     seen_artifacts_v2: set[str] = set()

--- a/klai-knowledge-ingest/tests/test_clustering_umap.py
+++ b/klai-knowledge-ingest/tests/test_clustering_umap.py
@@ -223,7 +223,6 @@ class TestDescriptionGenerationInV2Bootstrap:
         m.litellm_api_key = "key"
         m.taxonomy_classification_model = "klai-fast"
         m.taxonomy_classification_timeout = 30.0
-        m.taxonomy_bootstrap_v2_enabled = True
         m.taxonomy_bootstrap_min_cluster_size_floor = 5
         m.taxonomy_bootstrap_max_clusters = 20
         m.taxonomy_bootstrap_top_n_per_cluster = 8
@@ -828,7 +827,6 @@ class TestClusterPersistenceMeanFieldRename:
         mock_settings.litellm_api_key = "key"
         mock_settings.taxonomy_classification_model = "klai-fast"
         mock_settings.taxonomy_classification_timeout = 30.0
-        mock_settings.taxonomy_bootstrap_v2_enabled = True
         mock_settings.taxonomy_bootstrap_min_cluster_size_floor = 5
         mock_settings.taxonomy_bootstrap_max_clusters = 20
         mock_settings.taxonomy_bootstrap_top_n_per_cluster = 8

--- a/klai-knowledge-ingest/tests/test_naming_batched.py
+++ b/klai-knowledge-ingest/tests/test_naming_batched.py
@@ -70,7 +70,6 @@ def _make_mock_settings() -> MagicMock:
     m.litellm_api_key = "key"
     m.taxonomy_classification_model = "klai-fast"
     m.taxonomy_classification_timeout = 30.0
-    m.taxonomy_bootstrap_v2_enabled = True
     m.taxonomy_bootstrap_min_cluster_size_floor = 5
     m.taxonomy_bootstrap_max_clusters = 20
     m.taxonomy_bootstrap_top_n_per_cluster = 8

--- a/klai-knowledge-ingest/tests/test_proposal_generator.py
+++ b/klai-knowledge-ingest/tests/test_proposal_generator.py
@@ -1,4 +1,5 @@
 """Tests for proposal_generator — batch unmatched document proposal logic."""
+
 from __future__ import annotations
 
 import json
@@ -19,9 +20,7 @@ def _make_nodes(*names: str) -> list[TaxonomyNode]:
 
 
 def _mock_litellm_category(name: str) -> AsyncMock:
-    response_json = {
-        "choices": [{"message": {"content": json.dumps({"category_name": name})}}]
-    }
+    response_json = {"choices": [{"message": {"content": json.dumps({"category_name": name})}}]}
     mock_resp = MagicMock()
     mock_resp.raise_for_status = MagicMock()
     mock_resp.json = MagicMock(return_value=response_json)
@@ -70,9 +69,13 @@ class TestMaybeGenerateProposal:
 
         mock_client = _mock_litellm_category("API Documentation")
 
-        with patch("knowledge_ingest.proposal_generator.httpx.AsyncClient", return_value=mock_client), \
-             patch("knowledge_ingest.proposal_generator.submit_taxonomy_proposal") as mock_submit, \
-             patch("knowledge_ingest.proposal_generator.settings") as mock_settings:
+        with (
+            patch(
+                "knowledge_ingest.proposal_generator.httpx.AsyncClient", return_value=mock_client
+            ),
+            patch("knowledge_ingest.proposal_generator.submit_taxonomy_proposal") as mock_submit,
+            patch("knowledge_ingest.proposal_generator.settings") as mock_settings,
+        ):
             mock_settings.portal_internal_token = "secret"
             mock_settings.taxonomy_classification_timeout = 5.0
             mock_settings.litellm_url = "http://litellm:4000"
@@ -90,9 +93,16 @@ class TestMaybeGenerateProposal:
 
         mock_client = _mock_litellm_category("Developer Resources")
 
-        with patch("knowledge_ingest.proposal_generator.httpx.AsyncClient", return_value=mock_client), \
-             patch("knowledge_ingest.proposal_generator.submit_taxonomy_proposal", new_callable=AsyncMock) as mock_submit, \
-             patch("knowledge_ingest.proposal_generator.settings") as mock_settings:
+        with (
+            patch(
+                "knowledge_ingest.proposal_generator.httpx.AsyncClient", return_value=mock_client
+            ),
+            patch(
+                "knowledge_ingest.proposal_generator.submit_taxonomy_proposal",
+                new_callable=AsyncMock,
+            ) as mock_submit,
+            patch("knowledge_ingest.proposal_generator.settings") as mock_settings,
+        ):
             mock_settings.portal_internal_token = "secret"
             mock_settings.taxonomy_classification_timeout = 5.0
             mock_settings.litellm_url = "http://litellm:4000"
@@ -105,3 +115,106 @@ class TestMaybeGenerateProposal:
         assert proposal.suggested_name == "Developer Resources"
         assert proposal.proposal_type == "new_node"
         assert proposal.document_count == 4
+
+
+# ---------------------------------------------------------------------------
+# Architectural regression tests — SPEC-TAXONOMY-V2-CONSOLIDATION-001.
+#
+# These don't call the LLM. They lock in *structural* properties of the
+# prompt module so future drift gets caught at unit-test time:
+#
+# - All three active prompts compose the shared ``_NAMING_CRITERIA`` base
+#   (the "common-theme over salient-brand" rule lands in one place).
+# - The pre-Consolidation Unify-bug bias ("differentiate by what's UNIQUE")
+#   is absent from the batched prompt — replaced by common-within-each-cluster
+#   differentiation.
+# - The deleted V1 symbols stay deleted (no accidental re-introduction).
+# ---------------------------------------------------------------------------
+
+
+class TestPromptArchitecture:
+    def test_naming_criteria_states_common_theme_rule(self) -> None:
+        from knowledge_ingest.proposal_generator import _NAMING_CRITERIA
+
+        assert "COMMON across ALL documents" in _NAMING_CRITERIA, (
+            "_NAMING_CRITERIA must explicitly state the common-theme rule"
+        )
+        assert "diverse providers" in _NAMING_CRITERIA, (
+            "_NAMING_CRITERIA must give the multi-brand example so the LLM has a concrete pattern"
+        )
+        assert (
+            "salient brand" in _NAMING_CRITERIA.lower()
+            or "minority" in _NAMING_CRITERIA.lower()
+            or "salient" in _NAMING_CRITERIA.lower()
+        ), "_NAMING_CRITERIA must explicitly warn against salient-brand bias"
+
+    def test_all_three_prompts_compose_naming_criteria(self) -> None:
+        """Every active naming prompt must include the shared criteria base.
+
+        Catches drift: if someone adds rules to one prompt without putting
+        them in the base, this test fails.
+        """
+        from knowledge_ingest.proposal_generator import (
+            _BATCHED_NAMING_SYSTEM_PROMPT_TEMPLATE,
+            _BOOTSTRAP_V2_SYSTEM_PROMPT_TEMPLATE,
+            _NAMING_CRITERIA,
+            _PROPOSAL_SYSTEM_PROMPT,
+        )
+
+        # Pick a distinctive substring from the criteria base — if any prompt
+        # rebuilds its rules locally instead of composing the base, this fails.
+        marker = "COMMON across ALL documents"
+        assert marker in _PROPOSAL_SYSTEM_PROMPT, "incremental prompt must compose criteria base"
+        assert marker in _BOOTSTRAP_V2_SYSTEM_PROMPT_TEMPLATE, (
+            "single-cluster prompt must compose criteria base"
+        )
+        assert marker in _BATCHED_NAMING_SYSTEM_PROMPT_TEMPLATE, (
+            "batched prompt must compose criteria base"
+        )
+        # Sanity: the marker comes from the base, not coincidentally present elsewhere.
+        assert marker in _NAMING_CRITERIA
+
+    def test_batched_prompt_no_longer_has_unique_per_cluster_bias(self) -> None:
+        """The Unify-bug came from this exact phrase. It must stay deleted."""
+        from knowledge_ingest.proposal_generator import _BATCHED_NAMING_SYSTEM_PROMPT_TEMPLATE
+
+        assert "what's UNIQUE about each" not in _BATCHED_NAMING_SYSTEM_PROMPT_TEMPLATE, (
+            "batched prompt must not tell the LLM to label by what's UNIQUE per cluster — "
+            "that biased it toward the most salient minority brand (Unify-bug)"
+        )
+        assert (
+            "specific tool, specific use-case, specific audience"
+            not in _BATCHED_NAMING_SYSTEM_PROMPT_TEMPLATE
+        ), "batched prompt must not invite specific-item-per-cluster labels"
+
+    def test_batched_prompt_keeps_distinctness_constraint(self) -> None:
+        """The legitimate B4 fix (cross-cluster distinctness) must still be in
+        the batched prompt — only the over-correction bias got removed."""
+        from knowledge_ingest.proposal_generator import _BATCHED_NAMING_SYSTEM_PROMPT_TEMPLATE
+
+        assert "DISTINCT" in _BATCHED_NAMING_SYSTEM_PROMPT_TEMPLATE, (
+            "batched prompt must still enforce sibling distinctness — "
+            "that's the original SPEC-TAXONOMY-V2-001-FOLLOWUP-001 B4 fix"
+        )
+
+    def test_v1_symbols_are_deleted(self) -> None:
+        """V1 single-shot bootstrap path was deleted in
+        SPEC-TAXONOMY-V2-CONSOLIDATION-001. No accidental re-introduction."""
+        from knowledge_ingest import proposal_generator
+
+        for forbidden in (
+            "_BOOTSTRAP_SYSTEM_PROMPT",
+            "generate_bootstrap_proposals",  # the v1 (non-_v2) function
+            "_suggest_multiple_categories",
+        ):
+            attr = getattr(proposal_generator, forbidden, None)
+            # generate_bootstrap_proposals_v2 is the v2 function, the bare name
+            # is the deleted v1 — getattr returns the v2 if asked for v2, but
+            # the v1 bare name should not exist.
+            if forbidden == "generate_bootstrap_proposals":
+                assert attr is None, (
+                    f"V1 {forbidden} was deleted — do not re-introduce. "
+                    "If you need the legacy single-shot path back, write a SPEC for it."
+                )
+            else:
+                assert attr is None, f"V1 {forbidden} was deleted — do not re-introduce"

--- a/klai-knowledge-ingest/tests/test_taxonomy_v2_bootstrap.py
+++ b/klai-knowledge-ingest/tests/test_taxonomy_v2_bootstrap.py
@@ -261,7 +261,6 @@ class TestBootstrapProposalsV2Integration:
         m.litellm_api_key = "key"
         m.taxonomy_classification_model = "klai-fast"
         m.taxonomy_classification_timeout = 30.0
-        m.taxonomy_bootstrap_v2_enabled = True
         m.taxonomy_bootstrap_min_cluster_size_floor = 5
         m.taxonomy_bootstrap_max_clusters = 20
         m.taxonomy_bootstrap_top_n_per_cluster = 8
@@ -710,7 +709,6 @@ class TestBootstrapLatency:
         m.litellm_api_key = "key"
         m.taxonomy_classification_model = "klai-fast"
         m.taxonomy_classification_timeout = 30.0
-        m.taxonomy_bootstrap_v2_enabled = True
         m.taxonomy_bootstrap_min_cluster_size_floor = 5
         m.taxonomy_bootstrap_max_clusters = 20
         m.taxonomy_bootstrap_top_n_per_cluster = 8
@@ -882,7 +880,6 @@ class TestDuplicatePreventionRegression:
         mock_settings.litellm_api_key = "key"
         mock_settings.taxonomy_classification_model = "klai-fast"
         mock_settings.taxonomy_classification_timeout = 30.0
-        mock_settings.taxonomy_bootstrap_v2_enabled = True
         mock_settings.taxonomy_bootstrap_min_cluster_size_floor = 5
         mock_settings.taxonomy_bootstrap_max_clusters = 20
         mock_settings.taxonomy_bootstrap_top_n_per_cluster = 8
@@ -1029,7 +1026,6 @@ class TestAC18IntegrationWithMockedLitellm:
         mock_settings.litellm_api_key = "key"
         mock_settings.taxonomy_classification_model = "klai-fast"
         mock_settings.taxonomy_classification_timeout = 30.0
-        mock_settings.taxonomy_bootstrap_v2_enabled = True
         mock_settings.taxonomy_bootstrap_min_cluster_size_floor = 5
         mock_settings.taxonomy_bootstrap_max_clusters = 20
         mock_settings.taxonomy_bootstrap_top_n_per_cluster = 8
@@ -1107,7 +1103,6 @@ class TestAC19VoysRegressionNoNewDuplicates:
         mock_settings.litellm_api_key = "key"
         mock_settings.taxonomy_classification_model = "klai-fast"
         mock_settings.taxonomy_classification_timeout = 30.0
-        mock_settings.taxonomy_bootstrap_v2_enabled = True
         mock_settings.taxonomy_bootstrap_min_cluster_size_floor = 5
         mock_settings.taxonomy_bootstrap_max_clusters = 20
         mock_settings.taxonomy_bootstrap_top_n_per_cluster = 8


### PR DESCRIPTION
## Why

Voys/support taxonomy bootstrap produced "Unify-telefoons en providers configureren" as a label for an 8-document cluster where only 1/8 docs mentioned Unify. Root cause: prompt drift between the two V2 cluster-naming paths.

## The drift

The proposal_generator had four prompts for the same fundamental job ("given a cluster of documents, suggest a category name"). Each grew its own rules over time:

- The pre-Consolidation batched prompt said *"differentiate by what's UNIQUE about each cluster (specific tool, specific use-case, specific audience)"* — added in [SPEC-TAXONOMY-V2-001-FOLLOWUP-001 B4](https://github.com/GetKlai/klai/pull/426) to fix sibling-duplication ("7 variants of CRM integraties"), but it over-corrected → LLM grabbed the most salient brand.
- The V2 single-cluster prompt said *"prefer the user's domain language over generic labels"* — different bias entirely.
- Which bias the operator saw depended on whether the batched call timed out (→ fallback) or succeeded (→ batched).

## Fix-forward

Researched [Anthropic Clio](https://arxiv.org/html/2412.13678v1) (the SPEC's stated inspiration) and the established [prompt-template-inheritance pattern](https://arxiv.org/html/2504.02052v2). Both point at the same shape: **shared base + strategy-specific overlays**. Each strategy keeps its legitimate functional purpose; the shared rules live in one place.

### Added: `_NAMING_CRITERIA` shared base

```python
_NAMING_CRITERIA = (
    "Apply these rules to every cluster name:\n\n"
    "- The name MUST describe what is COMMON across ALL documents in the cluster.\n"
    "  Look for the shared theme, NOT the most prominent or branded item.\n"
    "- If documents span multiple brands, products, or providers, use a generic\n"
    '  descriptor (e.g., "Telefoonconfiguratie - diverse providers"), NOT the\n'
    "  most salient brand appearing in only some docs.\n"
    "- Use specific terms (brand, product, tool) ONLY when they apply to ALL\n"
    "  documents in the cluster.\n"
    "- 2-5 words, in the user's domain language (Dutch if docs are in Dutch).\n"
)
```

### Refactored: three active prompts now compose the base

| Prompt | Strategy | Composes base |
|---|---|---|
| `_PROPOSAL_SYSTEM_PROMPT` | post-ingest incremental | ✓ |
| `_BOOTSTRAP_V2_SYSTEM_PROMPT_TEMPLATE` | V2 single-cluster fallback | ✓ |
| `_BATCHED_NAMING_SYSTEM_PROMPT_TEMPLATE` | V2 batched cross-cluster | ✓ |

### Replaced in batched prompt

- ❌ "differentiate by what's UNIQUE about each cluster (specific tool, specific use-case, specific audience)"
- ✅ "differentiate by what is COMMON within each cluster at a more specific level (the shared sub-theme of those docs), NOT by picking the most unique-looking item per cluster"

Preserves the B4 sibling-distinctness goal, drops the salient-brand bias.

### Deleted

- `generate_bootstrap_proposals` (V1 single-shot bootstrap)
- `_suggest_multiple_categories` (V1 helper)
- `_BOOTSTRAP_SYSTEM_PROMPT` (V1 prompt)
- The V1 fallback branch in `routes/taxonomy.py::taxonomy_bootstrap_proposals`
- The `taxonomy_bootstrap_v2_enabled` feature flag (V2 has been default since PR #408; fallback was never re-enabled)
- `taxonomy_bootstrap_v2_enabled = True` setup-noise in 4 test files

### Module-level evolution comment

Added a 60-line genealogy block at the top of `proposal_generator.py` that documents WHY the 3 strategies exist — so the next person who reads this code sees the SPEC chain (KB-021 → KB-022 → V2-001 → V2-001-FOLLOWUP-001 B4 → V2-CONSOLIDATION-001) and doesn't add a fourth strategy without understanding what the existing three already cover.

## Architectural regression tests

Five new structural tests in `TestPromptArchitecture`, no LLM calls, deterministic. Each one prevents a specific drift mode that this PR closes:

1. `_NAMING_CRITERIA` explicitly states the common-theme rule + multi-brand example
2. All three active prompts compose `_NAMING_CRITERIA` (catches drift if a future PR adds rules to one prompt without putting them in the base)
3. The "differentiate by what's UNIQUE" phrase is absent from batched prompt (catches Unify-bug regression)
4. Batched prompt still enforces sibling distinctness (catches accidental B4 regression)
5. V1 symbols stay deleted (no accidental re-introduction)

## Verification

- `ruff check` + `ruff format --check` → clean on all modified files
- 61/61 tests pass across 4 affected test files (test_proposal_generator, test_naming_batched, test_taxonomy_v2_bootstrap, test_clustering_umap)

## Post-deploy verification

After admin-merge + deploy: re-run bootstrap on Voys/support. Expected for the Unify-mixed cluster: generic descriptor like "Telefoonconfiguratie - diverse providers" instead of "Unify-telefoons en providers configureren".

## What did NOT change

- The HDBSCAN clustering algorithm
- The batched-vs-single-cluster strategy split
- The post-ingest incremental flow
- All existing call-sites and signatures

This is fix-forward: the architecture stays, only the drift gets neutralized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)