### PR TITLE
infra(litellm-hook-deploy): force-recreate to drop Python module cache

### DIFF
--- a/.claude/rules/klai/pitfalls/process-rules.md
+++ b/.claude/rules/klai/pitfalls/process-rules.md
@@ -355,6 +355,72 @@ directory-rsync block in the style of grafana provisioning sync.
 pattern" for the full Class A/A-dir/B/C inventory of current
 bind-mounts and the helper's behavioural contract.
 
+## bind-mount-content-vs-python-module-cache (HIGH)
+
+Sibling-class to `bind-mount-without-sync-workflow` and
+`docker-compose-restart-vs-recreate`. When a service imports its
+business logic from bind-mounted Python files (litellm is the only
+current example: `klai_knowledge.py`, `klai_chat_prompts.py`,
+`klai_retrieval_telemetry.py`, `klai_service_auth.py`,
+`custom_router.py` all live in `deploy/litellm/` and mount onto
+`/app/`), a deploy that ONLY changes file content — no compose
+definition diff — silently runs the old code in production.
+
+The chain:
+
+1. `litellm-hook-deploy.yml` rsyncs the new `.py` files to
+   `/opt/klai/litellm/` on core-01. The bind-mount serves them live
+   on the container's filesystem immediately.
+2. `compose-up.sh litellm` (the canonical wrapper) runs
+   `docker compose up -d --remove-orphans litellm`. Compose only
+   recreates when the compose DEFINITION diffs (volume list, env-vars,
+   image tag). File content is invisible to compose. Result: no-op.
+3. The container keeps running the same uvicorn process from the
+   previous boot. Python's `sys.modules` already cached
+   `klai_knowledge` (and friends) from that boot — re-imports return
+   the cached module object regardless of what's now on disk.
+4. CI workflow turns green, repo + host filesystem agree, but the
+   running container ignores the change.
+
+**Reference incidents:** PR #497 (no-KB GENERAL prompt) deployed
+green; live container kept the old `__all__` and old prompt body.
+Required manual `docker compose up -d --force-recreate litellm` on
+core-01. PR #501 (telemetry mount + anti-hallucination prompt)
+landed the same problem twice in two days.
+
+**Prevention (mechanical, codified in
+`deploy/scripts/compose-up.sh` + the litellm workflow):**
+
+`compose-up.sh` accepts `--force-recreate` as a flag and passes it
+through to `docker compose up -d`. Use it from any service-deploy
+workflow whose service imports bind-mounted Python (or any other
+language whose runtime caches modules — Node `require.cache`, JVM
+class loaders, etc.):
+
+```yaml
+- name: Recreate LiteLLM container
+  run: ssh core-01 "/opt/klai/scripts/compose-up.sh --force-recreate litellm"
+```
+
+For services whose code lives entirely in the image (no bind-mount
+of source files), `--force-recreate` is unnecessary and the bare
+`compose-up.sh <service>` form is correct — image-tag changes already
+trigger a recreate.
+
+**Audit (2026-05-07):** the only klai service today that imports
+bind-mounted Python at module load is litellm. If a future service
+adopts the same pattern, its deploy workflow MUST use
+`--force-recreate` from day one. Adding the flag retroactively after
+a "container runs old code" incident is the standard ramp pattern,
+but the cleaner default is to set it at workflow-create time.
+
+**Why not `docker restart <ctr>`:** equivalent effect (drops
+process, drops module cache) and lighter, BUT `restart` ignores
+compose definition diffs landed in the same deploy window
+(`docker-compose-restart-vs-recreate` pitfall). `--force-recreate`
+catches both bind-mount content AND compose definition changes in
+one pass — strictly safer.
+
 ## worktree-for-long-running-changes (HIGH)
 When you will make working-tree edits that span more than a single tool call
 — especially test fixes, refactors, or anything that produces an in-flight

--- a/.github/workflows/litellm-hook-deploy.yml
+++ b/.github/workflows/litellm-hook-deploy.yml
@@ -37,9 +37,19 @@ jobs:
       # crashlooped on ImportError until a follow-up commit inlined the
       # constant to remove the new-mount dependency.
       #
-      # `compose-up.sh` does `docker compose up -d --remove-orphans
-      # litellm` which detects compose-file diffs (new mounts, env-vars,
-      # image tags) and recreates only when needed. No-op when nothing
-      # in the service definition changed.
+      # Why --force-recreate: stock `docker compose up -d` only recreates
+      # when the compose DEFINITION diffs (volume list, env-vars, image
+      # tag). It does NOT detect bind-mount FILE CONTENT changes. The
+      # litellm container imports klai_knowledge.py / klai_chat_prompts.py
+      # / klai_retrieval_telemetry.py / klai_service_auth.py /
+      # custom_router.py at module load — without --force-recreate, an
+      # rsync of a new Python file is followed by a no-op `up -d` and
+      # Python keeps the cached module from the previous boot. Net
+      # effect: PR merged → CI green → live container still runs the
+      # OLD code until someone manually recreates. Hit twice in a row
+      # on PR #497 (no-KB GENERAL prompt) and PR #501 (telemetry mount
+      # + anti-hallucination); each required a manual
+      # `docker compose up -d --force-recreate litellm` to land. See
+      # pitfall `bind-mount-content-vs-python-module-cache`.
       - name: Recreate LiteLLM container
-        run: ssh klai@${{ secrets.CORE01_HOST }} "/opt/klai/scripts/compose-up.sh litellm"
+        run: ssh klai@${{ secrets.CORE01_HOST }} "/opt/klai/scripts/compose-up.sh --force-recreate litellm"

--- a/deploy/scripts/compose-up.sh
+++ b/deploy/scripts/compose-up.sh
@@ -16,9 +16,26 @@
 # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3.
 #
 # Usage:
-#   compose-up.sh                   — pull + up all services
-#   compose-up.sh <service-name>    — pull + up single service
-#   compose-up.sh --no-deps <svc>   — pull + up without service deps
+#   compose-up.sh                          — pull + up all services
+#   compose-up.sh <service-name>           — pull + up single service
+#   compose-up.sh --no-deps <svc>          — pull + up without service deps
+#   compose-up.sh --force-recreate <svc>   — pull + up with --force-recreate
+#                                            (drops Python module cache for
+#                                            services whose code lives in
+#                                            bind-mounted .py files)
+#
+# When to use --force-recreate:
+#   `docker compose up -d` only recreates a container when the compose
+#   DEFINITION changed (volume list, env-vars, image tag). Bind-mount
+#   FILE CONTENT changes are invisible to compose. For services that
+#   import bind-mounted Python files at module load (e.g. litellm with
+#   klai_knowledge.py / klai_chat_prompts.py / klai_retrieval_telemetry.py
+#   / klai_service_auth.py / custom_router.py vendored on /app/), a
+#   bind-mount-content rsync followed by `up -d` is a no-op: Python keeps
+#   the cached module from the previous boot and the new code never runs.
+#   --force-recreate forces a fresh container, which drops the cache and
+#   reimports from disk. Tracked under
+#   `bind-mount-content-vs-python-module-cache` in the process pitfalls.
 #
 # Exit code mirrors the underlying `docker compose` exit code; on
 # successful compose-up, a non-zero exit from audit-orphan-snapshot.sh
@@ -37,6 +54,7 @@ fi
 cd /opt/klai
 
 NO_DEPS_FLAG=""
+FORCE_RECREATE_FLAG=""
 SERVICE=""
 
 while [[ $# -gt 0 ]]; do
@@ -45,11 +63,15 @@ while [[ $# -gt 0 ]]; do
             NO_DEPS_FLAG="--no-deps"
             shift
             ;;
+        --force-recreate)
+            FORCE_RECREATE_FLAG="--force-recreate"
+            shift
+            ;;
         *)
             if [[ -z "$SERVICE" ]]; then
                 SERVICE="$1"
             else
-                echo "ERROR: unexpected argument '$1' — usage: compose-up.sh [--no-deps] [service]" >&2
+                echo "ERROR: unexpected argument '$1' — usage: compose-up.sh [--no-deps] [--force-recreate] [service]" >&2
                 exit 2
             fi
             shift
@@ -70,16 +92,25 @@ if [[ -n "$SERVICE" ]]; then
     if ! docker compose pull "$SERVICE" 2>&1; then
         echo "WARN: pull failed for $SERVICE (likely a locally-tagged image like klai/<svc>:local) — proceeding with existing local image"
     fi
-    echo "Recreating $SERVICE with --remove-orphans..."
+    if [[ -n "$FORCE_RECREATE_FLAG" ]]; then
+        echo "Recreating $SERVICE with --remove-orphans --force-recreate..."
+    else
+        echo "Recreating $SERVICE with --remove-orphans..."
+    fi
     # shellcheck disable=SC2086
-    docker compose up -d --remove-orphans $NO_DEPS_FLAG "$SERVICE"
+    docker compose up -d --remove-orphans $NO_DEPS_FLAG $FORCE_RECREATE_FLAG "$SERVICE"
 else
     echo "Pulling all services..."
     if ! docker compose pull 2>&1; then
         echo "WARN: bulk pull had failures (likely klai/<svc>:local-tagged services) — proceeding with existing local images"
     fi
-    echo "Recreating all services with --remove-orphans..."
-    docker compose up -d --remove-orphans
+    if [[ -n "$FORCE_RECREATE_FLAG" ]]; then
+        echo "Recreating all services with --remove-orphans --force-recreate..."
+    else
+        echo "Recreating all services with --remove-orphans..."
+    fi
+    # shellcheck disable=SC2086
+    docker compose up -d --remove-orphans $FORCE_RECREATE_FLAG
 fi
 
 # REQ-2d post-deploy orphan snapshot. Best-effort — snapshot failure


### PR DESCRIPTION
## Why

Closes the structural gap behind PR #497 (no-KB GENERAL prompt) and PR #501 (telemetry mount + anti-hallucination). Both shipped green CI but ran the OLD code in production until I manually `docker compose up -d --force-recreate litellm`'d on core-01.

**Failure chain:**

1. `litellm-hook-deploy.yml` rsyncs new `klai_*.py` to `/opt/klai/litellm/`
2. `compose-up.sh litellm` runs `docker compose up -d --remove-orphans litellm` — compose only recreates on DEFINITION diff (volume list, env-vars, image tag); bind-mount file content is invisible
3. uvicorn keeps the previous boot's `sys.modules` cache → re-imports return the OLD module object
4. CI green, repo + host filesystem agree, live container ignores the change

The litellm container is the only klai service today that imports its hook code from bind-mounted Python files. So this trap is litellm-specific, not a fleet-wide refactor.

## What

Three changes, smallest possible scope:

**1. `deploy/scripts/compose-up.sh` — add `--force-recreate` flag**
Symmetric with the existing `--no-deps` flag (parser pattern unchanged). No behaviour change for callers that don't pass it. Header comment explains the bind-mount-vs-module-cache rationale.

**2. `.github/workflows/litellm-hook-deploy.yml` — pass the flag**
`compose-up.sh --force-recreate litellm`. The why-comment in the YAML lists both fail-modes (Python module cache + compose no-op) so a future cleanup-PR doesn't innocently strip the flag.

**3. New pitfall: `bind-mount-content-vs-python-module-cache (HIGH)`**
In `.claude/rules/klai/pitfalls/process-rules.md`, sibling-class to `bind-mount-without-sync-workflow` and `docker-compose-restart-vs-recreate`. Documents the chain, the canonical fix, the audit note (litellm-only today; future services should set `--force-recreate` at workflow-create time), and why not `docker restart <ctr>` (ignores same-deploy compose diffs).

## Risk

Zero. The only behavioural delta is on the next push to `deploy/litellm/**`, where the container will recreate cleanly without manual intervention. `--force-recreate` adds ~5-10s to deploy time (one extra container stop/start) — acceptable for the litellm hook deploy cadence.

## Verification plan

After merge, the next litellm-hook-deploy workflow run will use the new flag. Confirm by:
- `gh run view <run-id> --log` shows `Recreating litellm with --remove-orphans --force-recreate...`
- `ssh core-01 "docker ps --filter name=litellm --format '{{.Status}}'"` shows fresh "Up X seconds" timestamp matching deploy completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)