### PR TITLE
fix(taxonomy): switch HDBSCAN cluster_selection_method 'eom' → 'leaf'

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/clustering.py
+++ b/klai-knowledge-ingest/knowledge_ingest/clustering.py
@@ -245,6 +245,7 @@ def cluster_documents_hdbscan(
     embeddings: Any,
     min_cluster_size: int = 5,
     pre_reduce: bool = True,
+    cluster_selection_method: str = "leaf",
 ) -> tuple[Any, dict]:
     """Run HDBSCAN on document embeddings and return (labels, metrics).
 
@@ -253,6 +254,11 @@ def cluster_documents_hdbscan(
     SPEC-TAXONOMY-V2-001-FOLLOWUP-001 B5: cluster_probability_mean replaces dbcv_score.
         sklearn 1.8 HDBSCAN does NOT expose relative_validity_ (confirmed in production via
         hasattr() returning False). Use cluster_persistence_ (always available) instead.
+    SPEC-TAXONOMY-V2-CONSOLIDATION-003: cluster_selection_method default 'eom' → 'leaf'.
+        EOM under-fitted at typical KB sizes (e.g. Voys/support 154 docs → 3 clusters even
+        with min_cluster_size_floor=3) because EOM rejects smaller stable sub-clusters in
+        favour of bigger 'most stable' merges. Leaf returns the leaves of the cluster
+        hierarchy → typically 2-4× more clusters, lands in the 5-9 IA sweet spot.
 
     Args:
         embeddings: (n_docs, dim) float32 array of unit-normalised embeddings.
@@ -260,6 +266,8 @@ def cluster_documents_hdbscan(
         pre_reduce: when True (default), reduce embeddings via UMAP before HDBSCAN
                     and switch HDBSCAN metric to "euclidean" (UMAP output is not cosine-meaningful).
                     When False, run HDBSCAN directly with metric="cosine" (legacy behaviour).
+        cluster_selection_method: 'eom' (excess of mass — fewer, more stable clusters)
+                    or 'leaf' (default — finer-grained leaves of the cluster hierarchy).
 
     Returns:
         labels: (n_docs,) int array; -1 = outlier/noise.
@@ -293,7 +301,11 @@ def cluster_documents_hdbscan(
     else:
         hdbscan_metric = "cosine"
 
-    hdb = HDBSCAN(min_cluster_size=min_cluster_size, metric=hdbscan_metric)
+    hdb = HDBSCAN(
+        min_cluster_size=min_cluster_size,
+        metric=hdbscan_metric,
+        cluster_selection_method=cluster_selection_method,
+    )
     labels = hdb.fit_predict(embeddings)
 
     cluster_ids = set(int(lbl) for lbl in labels if lbl >= 0)

--- a/klai-knowledge-ingest/knowledge_ingest/config.py
+++ b/klai-knowledge-ingest/knowledge_ingest/config.py
@@ -119,6 +119,24 @@ class Settings(BaseSettings):
     taxonomy_bootstrap_max_clusters: int = 20
     taxonomy_bootstrap_top_n_per_cluster: int = 8
 
+    # SPEC-TAXONOMY-V2-CONSOLIDATION-003 — HDBSCAN cluster-selection method.
+    # Default sklearn HDBSCAN uses ``'eom'`` (excess of mass): finds fewer,
+    # more stable clusters by trading sub-structure for stability. On the
+    # Voys/support 154-doc corpus EOM landed on 3 clusters even after
+    # lowering the min_cluster_size floor 5 → 3 (V2-CONSOLIDATION-002),
+    # because EOM rejects the smaller stable sub-clusters HDBSCAN's tree
+    # actually contains.
+    #
+    # ``'leaf'`` returns the leaves of the cluster hierarchy — finer-grained,
+    # typically 2-4× more clusters than EOM on the same input. Targets the
+    # 5-9 IA sweet spot at typical KB sizes; needs revisiting if the corpus
+    # grows >300 docs (then the leaf count may climb past the comfortable
+    # browsing range and hierarchical taxonomy becomes warranted).
+    #
+    # Configurable via env so we can revert without redeploying if leaf-
+    # mode turns out to over-segment a different corpus shape.
+    taxonomy_bootstrap_cluster_selection_method: str = "leaf"
+
     # SPEC-TAXONOMY-V2-001-FOLLOWUP-001: UMAP pre-reduction settings (B1)
     taxonomy_bootstrap_umap_n_components: int = 10
     taxonomy_bootstrap_umap_n_neighbors: int = 15

--- a/klai-knowledge-ingest/knowledge_ingest/proposal_generator.py
+++ b/klai-knowledge-ingest/knowledge_ingest/proposal_generator.py
@@ -492,6 +492,7 @@ async def generate_bootstrap_proposals_v2(
         document_embeddings,
         min_cluster_size=min_cluster_size,
         pre_reduce=True,
+        cluster_selection_method=settings.taxonomy_bootstrap_cluster_selection_method,
     )
     clusters_found: int = metrics["clusters_found"]
     outlier_count: int = metrics["outlier_count"]

--- a/klai-knowledge-ingest/tests/test_clustering_umap.py
+++ b/klai-knowledge-ingest/tests/test_clustering_umap.py
@@ -224,6 +224,7 @@ class TestDescriptionGenerationInV2Bootstrap:
         m.taxonomy_classification_model = "klai-fast"
         m.taxonomy_classification_timeout = 30.0
         m.taxonomy_bootstrap_min_cluster_size_floor = 5
+        m.taxonomy_bootstrap_cluster_selection_method = "leaf"
         m.taxonomy_bootstrap_max_clusters = 20
         m.taxonomy_bootstrap_top_n_per_cluster = 8
         return m
@@ -573,6 +574,7 @@ class TestBatchedNaming:
         mock_settings.taxonomy_classification_model = "klai-fast"
         mock_settings.taxonomy_classification_timeout = 30.0
         mock_settings.taxonomy_bootstrap_min_cluster_size_floor = 5
+        mock_settings.taxonomy_bootstrap_cluster_selection_method = "leaf"
         mock_settings.taxonomy_bootstrap_max_clusters = 20
         mock_settings.taxonomy_bootstrap_top_n_per_cluster = 8
 
@@ -679,6 +681,7 @@ class TestBatchedNaming:
         mock_settings.taxonomy_classification_model = "klai-fast"
         mock_settings.taxonomy_classification_timeout = 30.0
         mock_settings.taxonomy_bootstrap_min_cluster_size_floor = 5
+        mock_settings.taxonomy_bootstrap_cluster_selection_method = "leaf"
         mock_settings.taxonomy_bootstrap_max_clusters = 20
         mock_settings.taxonomy_bootstrap_top_n_per_cluster = 8
 
@@ -828,6 +831,7 @@ class TestClusterPersistenceMeanFieldRename:
         mock_settings.taxonomy_classification_model = "klai-fast"
         mock_settings.taxonomy_classification_timeout = 30.0
         mock_settings.taxonomy_bootstrap_min_cluster_size_floor = 5
+        mock_settings.taxonomy_bootstrap_cluster_selection_method = "leaf"
         mock_settings.taxonomy_bootstrap_max_clusters = 20
         mock_settings.taxonomy_bootstrap_top_n_per_cluster = 8
 

--- a/klai-knowledge-ingest/tests/test_naming_batched.py
+++ b/klai-knowledge-ingest/tests/test_naming_batched.py
@@ -71,6 +71,7 @@ def _make_mock_settings() -> MagicMock:
     m.taxonomy_classification_model = "klai-fast"
     m.taxonomy_classification_timeout = 30.0
     m.taxonomy_bootstrap_min_cluster_size_floor = 5
+    m.taxonomy_bootstrap_cluster_selection_method = "leaf"
     m.taxonomy_bootstrap_max_clusters = 20
     m.taxonomy_bootstrap_top_n_per_cluster = 8
     return m
@@ -232,6 +233,13 @@ class TestBatchedNaming:
         embeddings = _make_clusterable_embeddings(n_clusters=3, n_per_cluster=20)
         doc_summaries = _make_doc_summaries(len(embeddings))
         mock_settings = _make_mock_settings()
+        # Pin EOM here — the fixture is engineered to produce exactly 3
+        # clusters and the assertion below counts proposals. Leaf-mode (the
+        # production default since SPEC-TAXONOMY-V2-CONSOLIDATION-003) finds
+        # the 3 plus 1 sub-structure cluster on this fixture, breaking the
+        # count-equality. The test is about FALLBACK behaviour, not cluster
+        # count, so EOM is the right pin here.
+        mock_settings.taxonomy_bootstrap_cluster_selection_method = "eom"
 
         batched_call_done = {"done": False}
 

--- a/klai-knowledge-ingest/tests/test_taxonomy_v2_bootstrap.py
+++ b/klai-knowledge-ingest/tests/test_taxonomy_v2_bootstrap.py
@@ -259,6 +259,7 @@ class TestBootstrapProposalsV2Integration:
         m.taxonomy_classification_model = "klai-fast"
         m.taxonomy_classification_timeout = 30.0
         m.taxonomy_bootstrap_min_cluster_size_floor = 5
+        m.taxonomy_bootstrap_cluster_selection_method = "leaf"
         m.taxonomy_bootstrap_max_clusters = 20
         m.taxonomy_bootstrap_top_n_per_cluster = 8
         return m
@@ -706,6 +707,7 @@ class TestBootstrapLatency:
         m.taxonomy_classification_model = "klai-fast"
         m.taxonomy_classification_timeout = 30.0
         m.taxonomy_bootstrap_min_cluster_size_floor = 5
+        m.taxonomy_bootstrap_cluster_selection_method = "leaf"
         m.taxonomy_bootstrap_max_clusters = 20
         m.taxonomy_bootstrap_top_n_per_cluster = 8
         return m
@@ -877,6 +879,7 @@ class TestDuplicatePreventionRegression:
         mock_settings.taxonomy_classification_model = "klai-fast"
         mock_settings.taxonomy_classification_timeout = 30.0
         mock_settings.taxonomy_bootstrap_min_cluster_size_floor = 5
+        mock_settings.taxonomy_bootstrap_cluster_selection_method = "leaf"
         mock_settings.taxonomy_bootstrap_max_clusters = 20
         mock_settings.taxonomy_bootstrap_top_n_per_cluster = 8
 
@@ -1004,6 +1007,58 @@ class TestAC17AdaptiveClusterCount:
         assert compute_min_cluster_size(1000) == 20  # 1000//50=20, max(3,20)=20
 
 
+class TestClusterSelectionMethod:
+    """SPEC-TAXONOMY-V2-CONSOLIDATION-003: cluster_selection_method default 'eom' → 'leaf'.
+
+    EOM under-fitted at typical KB sizes — Voys/support 154 docs landed on 3 clusters
+    even with min_cluster_size_floor=3 (V2-CONSOLIDATION-002), because EOM trades sub-
+    structure for stability. Leaf returns the leaves of the cluster hierarchy → finer
+    output that targets the IA-norm 5-9 sweet spot.
+    """
+
+    def test_leaf_mode_is_never_coarser_than_eom_on_same_corpus(self):
+        """Shape invariant: leaf returns >= as many clusters as eom on identical input."""
+        from knowledge_ingest.clustering import cluster_documents_hdbscan
+
+        rng = np.random.RandomState(42)
+        n_per_cluster = 10
+        centers = np.zeros((5, 64), dtype=np.float32)
+        for i in range(5):
+            centers[i, i * 10 : (i + 1) * 10] = 1.0
+            centers[i] /= np.linalg.norm(centers[i])
+        members = []
+        for i in range(5):
+            noise = rng.randn(n_per_cluster, 64).astype(np.float32) * 0.05
+            vecs = centers[i] + noise
+            vecs /= np.linalg.norm(vecs, axis=1, keepdims=True)
+            members.append(vecs)
+        embeddings = np.vstack(members)
+
+        _, eom_metrics = cluster_documents_hdbscan(
+            embeddings, min_cluster_size=3, pre_reduce=False, cluster_selection_method="eom"
+        )
+        _, leaf_metrics = cluster_documents_hdbscan(
+            embeddings, min_cluster_size=3, pre_reduce=False, cluster_selection_method="leaf"
+        )
+        assert leaf_metrics["clusters_found"] >= eom_metrics["clusters_found"]
+
+    def test_default_method_is_leaf(self):
+        """Function-parameter default and production-config default agree on 'leaf'.
+
+        The Voys/support regression we're guarding against is someone bumping the
+        config back to 'eom' without thinking — which would silently re-introduce
+        the under-fitting issue.
+        """
+        import inspect
+
+        from knowledge_ingest.clustering import cluster_documents_hdbscan
+        from knowledge_ingest.config import settings
+
+        sig = inspect.signature(cluster_documents_hdbscan)
+        assert sig.parameters["cluster_selection_method"].default == "leaf"
+        assert settings.taxonomy_bootstrap_cluster_selection_method == "leaf"
+
+
 # ---------------------------------------------------------------------------
 # AC-18: Integration test with mocked LiteLLM
 # ---------------------------------------------------------------------------
@@ -1041,6 +1096,7 @@ class TestAC18IntegrationWithMockedLitellm:
         mock_settings.taxonomy_classification_model = "klai-fast"
         mock_settings.taxonomy_classification_timeout = 30.0
         mock_settings.taxonomy_bootstrap_min_cluster_size_floor = 5
+        mock_settings.taxonomy_bootstrap_cluster_selection_method = "leaf"
         mock_settings.taxonomy_bootstrap_max_clusters = 20
         mock_settings.taxonomy_bootstrap_top_n_per_cluster = 8
 
@@ -1118,6 +1174,7 @@ class TestAC19VoysRegressionNoNewDuplicates:
         mock_settings.taxonomy_classification_model = "klai-fast"
         mock_settings.taxonomy_classification_timeout = 30.0
         mock_settings.taxonomy_bootstrap_min_cluster_size_floor = 5
+        mock_settings.taxonomy_bootstrap_cluster_selection_method = "leaf"
         mock_settings.taxonomy_bootstrap_max_clusters = 20
         mock_settings.taxonomy_bootstrap_top_n_per_cluster = 8
 


### PR DESCRIPTION
## Why

After [PR #505](https://github.com/GetKlai/klai/pull/505) (V2-CONSOLIDATION-002) lowered `min_cluster_size_floor` 5 → 3, Voys/support 154-doc bootstrap STILL produced only 3 clusters. HDBSCAN's default `cluster_selection_method='eom'` (Excess of Mass) trades sub-structure for stability — even when smaller stable clusters exist, EOM merges them into 3 huge "most stable" clusters. Lowering the floor only gave EOM permission to form smaller clusters; it never gave EOM the preference.

Switching to `'leaf'` returns the leaves of HDBSCAN's cluster hierarchy — typically 2-4× more clusters on the same input, landing the bootstrap output in the 5-9 IA sweet spot.

## Changes (6 files, 101 lines)

- `config.py`: new `taxonomy_bootstrap_cluster_selection_method: str = "leaf"`. Configurable via env so reverting to `'eom'` doesn't require redeploy.
- `clustering.py::cluster_documents_hdbscan`: new optional `cluster_selection_method` parameter, default `'leaf'`.
- `proposal_generator.py`: production caller reads the setting and passes it through.
- 9 mock-settings setups in 3 test files updated (otherwise MagicMock auto-generates a Mock that sklearn rejects with `InvalidParameterError`).
- New `TestClusterSelectionMethod` class in `test_taxonomy_v2_bootstrap.py`: shape invariant (leaf >= eom on same corpus) + default pinned to "leaf".
- `test_naming_batched.py::test_batched_naming_partial_response_falls_back_for_missing` pinned to `'eom'` — fixture is engineered for exactly 3 clusters and asserts proposal-count equality. Test is about fallback behaviour, not cluster count.

## Verification

- 64/64 tests pass across taxonomy/clustering test files
- Modified files lint clean

## Post-deploy

Operator triggers regenerate. Expected: 5-9 fine-grained clusters (specific brand/product groupings instead of broad merged buckets). Naming still common-theme-correct (criteria-base from #502 intact, no Unify-bug regression).

If overshoot (15+ clusters) → hierarchical taxonomy is the architecturally correct next step (separate SPEC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)