### PR TITLE
fix(taxonomy): show loading state on Suggest categories button

### DIFF
--- a/klai-portal/frontend/messages/en.json
+++ b/klai-portal/frontend/messages/en.json
@@ -1281,6 +1281,7 @@
   "knowledge_taxonomy_filter_clear_all": "Clear all filters",
   "knowledge_taxonomy_suggest_categories": "Suggest categories",
   "knowledge_taxonomy_suggest_generating": "Analysing knowledge base...",
+  "knowledge_taxonomy_suggest_loading_hint": "This may take up to a minute for larger knowledge bases.",
   "knowledge_taxonomy_suggest_ready": "{count} category suggestions ready - review and apply below",
   "knowledge_taxonomy_suggest_apply_all": "Apply to knowledge base",
   "knowledge_taxonomy_retag": "Re-tag documents",

--- a/klai-portal/frontend/messages/nl.json
+++ b/klai-portal/frontend/messages/nl.json
@@ -1281,6 +1281,7 @@
   "knowledge_taxonomy_filter_clear_all": "Alle filters wissen",
   "knowledge_taxonomy_suggest_categories": "Categorieën voorstellen",
   "knowledge_taxonomy_suggest_generating": "Kennisbank analyseren...",
+  "knowledge_taxonomy_suggest_loading_hint": "Dit kan tot een minuut duren bij grotere kennisbanken.",
   "knowledge_taxonomy_suggest_ready": "{count} categorievoorstellen klaar - bekijk en activeer hieronder",
   "knowledge_taxonomy_suggest_apply_all": "Toepassen op kennisbank",
   "knowledge_taxonomy_retag": "Opnieuw taggen",

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/taxonomy.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/taxonomy.tsx
@@ -95,18 +95,24 @@ function CoverageWidget({
           {m.knowledge_taxonomy_coverage_empty()}
         </p>
         {onSuggest && total >= 10 && (
-          <button
-            type="button"
-            onClick={onSuggest}
-            disabled={isSuggesting}
-            className="inline-flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full font-medium bg-[var(--color-accent)] text-[var(--color-accent-foreground)] hover:opacity-90 transition-opacity disabled:opacity-50"
-          >
-            {isSuggesting
-              ? <Loader2 className="h-3 w-3 animate-spin" />
-              : <Sparkles className="h-3 w-3" />
-            }
-            {m.knowledge_taxonomy_suggest_categories()}
-          </button>
+          <div className="space-y-1.5">
+            <button
+              type="button"
+              onClick={onSuggest}
+              disabled={isSuggesting}
+              className="inline-flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-full font-medium bg-[var(--color-accent)] text-[var(--color-accent-foreground)] hover:opacity-90 transition-opacity disabled:opacity-50"
+            >
+              {isSuggesting
+                ? <><Loader2 className="h-3 w-3 animate-spin" />{m.knowledge_taxonomy_suggest_generating()}</>
+                : <><Sparkles className="h-3 w-3" />{m.knowledge_taxonomy_suggest_categories()}</>
+              }
+            </button>
+            {isSuggesting && (
+              <p className="text-xs text-[var(--color-muted-foreground)]">
+                {m.knowledge_taxonomy_suggest_loading_hint()}
+              </p>
+            )}
+          </div>
         )}
       </div>
     )
@@ -698,7 +704,7 @@ function TaxonomyTab() {
               coverage={coverageQuery.data}
               activeNodeId={activeNodeId}
               onNodeClick={toggleNode}
-              onSuggest={canEdit && suggestState === 'idle' ? () => bootstrapMutation.mutate() : undefined}
+              onSuggest={canEdit && (suggestState === 'idle' || suggestState === 'generating') ? () => bootstrapMutation.mutate() : undefined}
               isSuggesting={bootstrapMutation.isPending}
               canEdit={canEdit}
               onRename={(nodeId, newName, description) => renameNodeMutation.mutate({ nodeId, name: newName, description })}


### PR DESCRIPTION
## Summary

- **Root cause**: `onSuggest` prop werd `undefined` zodra `bootstrapMutation.mutate()` werd aangeroepen, omdat `suggestState` direct van `'idle'` naar `'generating'` springt (via `onMutate`). De `CoverageWidget` toont de knop alleen als `onSuggest` truthy is — waardoor de knop meteen verdween.
- **Fix**: `onSuggest` wordt nu ook doorgegeven tijdens `suggestState === 'generating'`, zodat de knop zichtbaar blijft zolang de mutation loopt.
- Knop-label wisselt naar `knowledge_taxonomy_suggest_generating` ("Kennisbank analyseren...") tijdens pending state — zelfde patroon als de connector-wizard "Test authentication" knop.
- Hint-tekst ("Dit kan tot een minuut duren bij grotere kennisbanken.") verschijnt inline onder de knop tijdens loading.
- Nieuwe i18n-key `knowledge_taxonomy_suggest_loading_hint` toegevoegd in `nl.json` en `en.json`.

## Gewijzigde bestanden (3)

- `klai-portal/frontend/src/routes/app/knowledge/$kbSlug/taxonomy.tsx` — knop-logica en CoverageWidget render
- `klai-portal/frontend/messages/nl.json` — nieuwe hint-key
- `klai-portal/frontend/messages/en.json` — nieuwe hint-key

## Test plan

- [ ] Open een KB met ≥ 10 chunks en geen taxonomy-nodes (empty-state pad)
- [ ] Klik "Categorieën voorstellen" — knop blijft zichtbaar, toont spinner + "Kennisbank analyseren..."
- [ ] Hint-tekst verschijnt direct onder de knop
- [ ] Na afloop (succes of fout) verdwijnt de knop correct of wisselt naar proposals-state
- [ ] Geen double-click mogelijk terwijl pending (knop is `disabled`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)