### PR TITLE
fix(kb/stats): cast properties to jsonb (column is json not jsonb)

### DIFF
--- a/klai-portal/backend/app/api/app_knowledge_bases.py
+++ b/klai-portal/backend/app/api/app_knowledge_bases.py
@@ -407,6 +407,13 @@ async def knowledge_bases_stats_summary(
     # Each event carries a kb_slugs[] array (a single retrieve call may target
     # multiple KBs); jsonb_array_elements_text fans the array out so a query
     # against KBs A and B counts once for A and once for B.
+    #
+    # NOTE: product_events.properties is declared JSONB in the SQLAlchemy
+    # model but the live column is `json` (schema drift, see ProductEvent).
+    # Cast properties::jsonb everywhere it touches jsonb operators/functions
+    # until that column type is migrated. The WHERE jsonb_typeof filter
+    # also guards against legacy events that lack kb_slugs (which would
+    # otherwise raise on jsonb_array_elements_text).
     usage_result = await db.execute(
         text("""
             SELECT
@@ -416,11 +423,12 @@ async def knowledge_bases_stats_summary(
                 COUNT(DISTINCT date_trunc('day', pe.created_at)) AS active_days
             FROM product_events pe
             CROSS JOIN LATERAL jsonb_array_elements_text(
-                COALESCE(pe.properties->'kb_slugs', '[]'::jsonb)
+                (pe.properties::jsonb)->'kb_slugs'
             ) AS s(kb_slug)
             WHERE pe.org_id = :org_id
               AND pe.event_type = 'knowledge.queried'
               AND pe.created_at >= :cutoff
+              AND jsonb_typeof((pe.properties::jsonb)->'kb_slugs') = 'array'
               AND s.kb_slug = ANY(:slugs)
             GROUP BY s.kb_slug
         """),
@@ -775,6 +783,8 @@ async def get_kb_stats(
     active_days_30d: int | None = None
     try:
         cutoff = datetime.now(tz=dt.UTC) - timedelta(days=30)
+        # NOTE: properties::jsonb cast — see stats-summary helper above for
+        # the schema-drift backstory.
         usage_result = await db.execute(
             text("""
                 SELECT
@@ -785,7 +795,7 @@ async def get_kb_stats(
                 WHERE org_id = :org_id
                   AND event_type = 'knowledge.queried'
                   AND created_at >= :cutoff
-                  AND properties->'kb_slugs' @> to_jsonb(:slug::text)
+                  AND (properties::jsonb)->'kb_slugs' @> to_jsonb(:slug::text)
             """),
             {"org_id": org.id, "cutoff": cutoff, "slug": kb.slug},
         )


### PR DESCRIPTION
## Summary

Hotfix for #508. The new `knowledge.queried` stats queries failed silently in production:
- Bulk endpoint: `COALESCE could not convert type jsonb to json`
- Per-KB endpoint: `operator does not exist: json @> jsonb`

Both errors swallowed by the try/except — hence "Usage unavailable" tiles even though 13 events were freshly emitted with `kb_slugs: [\"support\"]`.

## Root cause

`product_events.properties` is declared `JSONB` in the SQLAlchemy model but the live column is `json`. Schema drift that no prior code noticed: every existing `emit_event` call only WRITES the column. The new stats queries are the first READ path that uses jsonb operators (`@>`, `jsonb_array_elements_text`), so the mismatch surfaced here for the first time.

## Fix

Cast `properties::jsonb` everywhere it touches a jsonb operator. Also add a `jsonb_typeof(...) = 'array'` guard on the bulk query so events lacking `kb_slugs` skip cleanly without erroring on `jsonb_array_elements_text`.

## Verified

Live DB:
```sql
SELECT COUNT(*), COUNT(DISTINCT user_id),
       COUNT(DISTINCT date_trunc('day', created_at))
FROM product_events
WHERE org_id = 8 AND event_type = 'knowledge.queried'
  AND created_at >= NOW() - INTERVAL '30 days'
  AND (properties::jsonb)->'kb_slugs' @> to_jsonb('support'::text);
-- 7 | 1 | 1
```

## Follow-up

Separate SPEC: `ALTER TABLE product_events ALTER COLUMN properties TYPE jsonb USING properties::jsonb`. After that migration the casts can be removed. Filed as a follow-up so this hotfix does not need an alembic step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)