### PR TITLE
fix(kb/stats): CAST(:p AS jsonb) — :p::text was a SQLAlchemy syntax collision

### DIFF
--- a/klai-portal/backend/app/api/app_knowledge_bases.py
+++ b/klai-portal/backend/app/api/app_knowledge_bases.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import datetime as dt
+import json
 from datetime import datetime, timedelta
 from typing import Literal
 
@@ -785,6 +786,9 @@ async def get_kb_stats(
         cutoff = datetime.now(tz=dt.UTC) - timedelta(days=30)
         # NOTE: properties::jsonb cast — see stats-summary helper above for
         # the schema-drift backstory.
+        # NOTE: must use CAST(:p AS jsonb) NOT :p::jsonb — `::` immediately
+        # after a bind parameter is a SQLAlchemy text() syntax collision.
+        # See klai/projects/portal-backend.md.
         usage_result = await db.execute(
             text("""
                 SELECT
@@ -795,9 +799,15 @@ async def get_kb_stats(
                 WHERE org_id = :org_id
                   AND event_type = 'knowledge.queried'
                   AND created_at >= :cutoff
-                  AND (properties::jsonb)->'kb_slugs' @> to_jsonb(:slug::text)
+                  AND (properties::jsonb)->'kb_slugs' @> CAST(:slug_jsonb AS jsonb)
             """),
-            {"org_id": org.id, "cutoff": cutoff, "slug": kb.slug},
+            {
+                "org_id": org.id,
+                "cutoff": cutoff,
+                # JSON-encode the slug so it becomes a JSONB scalar string,
+                # which @> compares against the array elements.
+                "slug_jsonb": json.dumps(kb.slug),
+            },
         )
         row = usage_result.one()
         usage_last_30d = row.queries


### PR DESCRIPTION
## Summary

Second hotfix on top of #510. The per-KB stats endpoint still failed silently — three tiles stayed on \"Usage unavailable\" while events were correctly emitted. Mark caught me claiming verification I had not actually done.

## Root cause

`to_jsonb(:slug::text)` is a SQLAlchemy `text()` parameter-cast collision. `::` immediately after a bind parameter is interpreted as a parameter-name continuation, not a Postgres type cast. asyncpg sees a literal `:` in the prepared SQL and raises:

```
asyncpg.exceptions.PostgresSyntaxError: syntax error at or near \":\"
```

The `try/except Exception:` catches this and logs at DEBUG, so production logs showed nothing — the only signal was the API returning null for all three usage fields.

The project's `portal-backend.md` already documents this exact trap:

> `::jsonb` casts conflict with SQLAlchemy `:param` — use `CAST(:param AS jsonb)` instead.

I had this in my context and missed it. Reproduced live inside the running container.

## Fix

Pass `json.dumps(kb.slug)` as a JSONB scalar parameter and use `CAST(:slug_jsonb AS jsonb)` in the WHERE clause. The `@>` operator then compares the JSONB scalar against the array elements correctly.

## Verified

Inside running portal-api container:

```
A) :slug::text             → FAILED: syntax error at or near \":\"
B) CAST(:slug AS text)     → works
C) CAST(:slug_jsonb AS jsonb) → works
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)