### PR TITLE
feat(taxonomy): auto-consolidate bootstrap proposals to 5-9 parents (SPEC-TAXONOMY-MERGE-DETECT-001)

### DIFF
--- a/.moai/specs/SPEC-TAXONOMY-MERGE-DETECT-001/spec.md
+++ b/.moai/specs/SPEC-TAXONOMY-MERGE-DETECT-001/spec.md
@@ -1,0 +1,392 @@
+---
+id: SPEC-TAXONOMY-MERGE-DETECT-001
+version: "1.0.0"
+status: approved
+created: 2026-05-07
+updated: 2026-05-07
+author: Mark Vletter
+priority: medium
+related:
+  - SPEC-TAXONOMY-V2-001 (HDBSCAN-based bootstrap — direct parent)
+  - SPEC-TAXONOMY-V2-001-FOLLOWUP-001 (UMAP pre-reduce, batched naming)
+---
+
+# SPEC-TAXONOMY-MERGE-DETECT-001: Auto-consolidate bootstrap proposals to 5-9 parents
+
+## Summary
+
+Wijzig de bestaande `generate_bootstrap_proposals_v2` zodat hij de 14-15
+fijnmazige clusters die HDBSCAN+naming oplevert automatisch consolideert tot
+5-9 broadere parent-categorieën **vóór** het submit-moment. Operator ziet in
+de portal-UI alleen de geconsolideerde set — geen extra knop, geen extra
+review-stap. De feature is een Clio-stijl top-down hiërarchie-reductie
+([Anthropic Clio paper](https://arxiv.org/html/2412.13678v1)) met
+percentage-gebaseerde balans-constraints.
+
+## Motivation
+
+V2 bootstrap produceert technisch correcte clusters (zie SPEC-TAXONOMY-V2-001),
+maar voor een KB met diverse content levert dat 14-15 fijnmazige nodes op.
+[Miller's Law](https://lawsofux.com/millers-law/) en navigatie-best-practices
+adviseren 5-9 hoofdcategorieën voor browsing. De gap zit in semantische
+overlap die HDBSCAN niet detecteert (clustert op vector-density, niet op
+concept-coherentie).
+
+**Gevalideerd op Voys/support** (zie §Validated results): bestaande 15 base
+clusters worden via één LLM-judge call geconsolideerd tot 7-8 parents binnen
+de 5-9 doelband. Per-parent descriptions zijn productie-kwaliteit (gegenereerd
+via dezelfde `generate_node_description` die nu al voor base clusters draait).
+
+## Scope
+
+### In scope
+
+1. Eén nieuwe helper `_consolidate_to_parents` in `proposal_generator.py`:
+   - Input: lijst van `(cluster_id, name, description, sample_titles, doc_count, centroid)`
+     plus KB-description, target_min, target_max
+   - Output: lijst van `ParentCategory` met `name`, `description`,
+     `child_cluster_ids`, `rationale`, gecombineerde `sample_titles` en
+     samengetelde `document_count`
+   - Eén LLM-call (Clio-stijl group-and-assign) + parallelle
+     `generate_node_description`-calls per parent
+2. Wijziging in `generate_bootstrap_proposals_v2`:
+   - Na huidige Step 7 (dedup duplicates) en vóór huidige Step 8 (submit): nieuwe
+     Step 7.5 die `_consolidate_to_parents` aanroept
+   - Submit-loop submit **parents** ipv **base clusters**
+   - Payload van elke parent-proposal bevat `child_cluster_names` voor
+     operator-transparantie ("samengevoegd uit: ['CRM-configuratie - diverse
+     platforms', 'CRM-configuratie - sector-specifieke oplossingen', ...]")
+3. Bestaande `BootstrapResult` houdt huidige velden, krijgt
+   `base_clusters_found: int` extra (om verschil tussen pre-consolidate en
+   post-consolidate te kunnen loggen)
+4. Settings in `config.py`:
+   - `taxonomy_consolidate_target_min: int = 5`
+   - `taxonomy_consolidate_target_max: int = 9`
+   - `taxonomy_consolidate_enabled: bool = True` (kill-switch)
+5. Failure-handling: als consolidate-call faalt (LLM timeout, parse error)
+   → fall back op de oorspronkelijke base clusters submitten, log warning.
+   Bootstrap mag niet falen op consolidate-fout.
+6. Logging: één extra structured event `bootstrap_consolidate_complete`
+   met `base_clusters`, `parents`, `largest_parent_pct`, `largest_parent_clusters`
+7. Tests:
+   - Unit-test op `_consolidate_to_parents` met gemockte LLM
+   - Integratietest: synthetic 12-cluster fixture → ~5-9 parents, balance
+     constraints toegepast
+   - Failure-fallback test: LLM timeout → base clusters submitted
+   - Skip-test: als base_clusters ≤ target_max → consolidate wordt
+     overgeslagen, base clusters direct submitted
+
+### Out of scope
+
+- Geen nieuwe endpoints. Geen frontend-wijzigingen. Geen DB-migratie.
+- Geen "Maak er minder van"-knop. Operator klikt de bestaande bootstrap-knop;
+  het systeem doet de consolidatie automatisch.
+- Geen hiërarchische taxonomie (parent_id linked sub-nodes). Alle
+  geconsolideerde nodes blijven plat in de DB; child cluster names komen
+  alleen in de payload als metadata, niet als afzonderlijke nodes.
+- Geen wijziging aan de approve-flow. Operator approved een parent-proposal
+  zoals elke andere new_node-proposal — er is geen verschil aan portal-side.
+
+## Validated results (from dry-run iterations)
+
+Het dry-run script `klai-knowledge-ingest/knowledge_ingest/scripts/dry_run_merge_consolidate.py`
+heeft de techniek geverifieerd in vier iteraties:
+
+| Versie | Aanpak | Resultaat op Voys/support |
+|---|---|---|
+| v0.2 | Pairwise centroid similarity + per-pair LLM judge | 15 → 13 (te conservatief — judge zei 22x KEEP_SEPARATE op pairs > 0.79 sim) |
+| v0.3 | Clio-stijl: group-and-assign single-call met name + samples | 15 → 7, maar parent #1 had 7 children + 133 docs (30% van totaal) |
+| v0.4 | + percentage-based balance (max 25% docs / 33% clusters per parent) | 15 → 7, grootste parent 17% docs / 5 children — binnen caps |
+| v0.5 | + per-parent descriptions via `generate_node_description` | 15 → 8, descriptions productie-kwaliteit |
+
+**Voorbeeld output v0.5** (compleet rapport in run-output van 2026-05-07 19:11):
+
+```
+Telefonie-instellingen en -configuratie    (6 clusters, 99 docs, 22%)
+  Vragen en handleidingen over het instellen en configureren
+  van telefoonsystemen en -diensten.
+
+CRM-configuratie en -integratie            (3 clusters, 44 docs, 10%)
+  Vragen en handleidingen over het instellen en koppelen van
+  CRM-systemen aan andere software.
+
+Gespreksbeheer en notificaties             (1 cluster, 8 docs, 2%)
+Accountbeheer en fraudepreventie           (1 cluster, 13 docs, 3%)
+Nummerbeheer en -overdracht                (1 cluster, 26 docs, 6%)
+App- en webphone-ondersteuning             (1 cluster, 27 docs, 6%)
+Netwerkconfiguratie voor VoIP              (1 cluster, 34 docs, 8%)
+Partnerprogramma's en samenwerkingen       (1 cluster, 13 docs, 3%)
+```
+
+**Stochasticiteit**: bij `temperature=0.2` varieert het exact aantal parents
+±1 tussen runs (vorige run gaf 7, deze 8). Operator review absorbeert die
+variatie. Geen reden om naar `temperature=0.0` te gaan — dat zou ook fouten
+reproduceren.
+
+## Acceptance criteria
+
+### Functional (EARS)
+
+1. **AC-1 (Ubiquitous)** — When `generate_bootstrap_proposals_v2` produces
+   `proposals_to_submit` with `len > settings.taxonomy_consolidate_target_max`,
+   the system shall call `_consolidate_to_parents` between Step 7 and Step 8
+   instead of submitting base clusters directly.
+
+2. **AC-2 (Optional feature)** — Where `proposals_to_submit` count
+   `<= settings.taxonomy_consolidate_target_max`, the system shall skip
+   consolidation and submit base clusters directly.
+
+3. **AC-3 (Ubiquitous)** — `_consolidate_to_parents` shall produce parents
+   such that:
+   - Total count is between `target_min` and `target_max + 2` (hard cap)
+   - No single parent contains more than ~25% of total docs OR more than
+     ~33% of base clusters (soft caps; quality > balance per the prompt)
+   - Each base cluster is assigned to exactly one parent
+
+4. **AC-4 (Ubiquitous)** — Each parent shall receive a description via
+   `generate_node_description(parent.name, None, sample_titles_from_children)`
+   running in parallel after the group-and-assign call.
+
+5. **AC-5 (Event-driven)** — When the consolidate LLM-call fails (timeout,
+   parse error, HTTP error), the system shall log
+   `bootstrap_consolidate_failed` with the error and fall back to submitting
+   base clusters as proposals (existing behavior). Bootstrap MUST NOT fail
+   on consolidate failure.
+
+6. **AC-6 (State-driven)** — While `settings.taxonomy_consolidate_enabled
+   is False`, the system shall behave bit-identical to pre-MERGE-DETECT
+   (no consolidate call, base clusters submitted directly). This is the
+   documented kill-switch.
+
+7. **AC-7 (Ubiquitous)** — Each parent-proposal payload shall include:
+   - `suggested_name`: parent.name
+   - `description`: parent.description (LLM-generated, user-facing)
+   - `document_count`: sum of children's doc_count
+   - `sample_titles`: union of children's top sample titles, capped at 10
+   - `child_cluster_names`: list of original base cluster names
+     (for operator transparency)
+   - `cluster_centroid`: weighted mean of children's centroids
+     (doc-count-weighted, unit-normalised)
+
+8. **AC-8 (Ubiquitous)** — The system shall emit one VictoriaLogs entry
+   per consolidate call with stable key `bootstrap_consolidate_complete`
+   containing `kb_slug`, `org_id`, `base_clusters`, `parents`,
+   `largest_parent_doc_pct`, `largest_parent_cluster_count`, `latency_ms`.
+
+9. **AC-9 (Backward compatibility)** — `BootstrapResult` shall keep its
+   existing fields (`documents_scanned`, `proposals_submitted`,
+   `clusters_found`, `reason`). New optional field `base_clusters_found: int`
+   is added — equals `clusters_found` when no consolidation happened, or
+   the pre-consolidate count when it did.
+
+### Non-functional
+
+10. **AC-10** — End-to-end bootstrap latency for a KB with 1000 docs that
+    triggers consolidation SHALL stay within the existing 60-second budget
+    from SPEC-TAXONOMY-V2-001 AC-10. Budget split: bootstrap ≤ 50s,
+    consolidate ≤ 10s.
+
+11. **AC-11** — The consolidate LLM-call SHALL add at most ~2x the base
+    naming-call's token cost (one group-and-assign call ≈ same tokens as
+    one batched naming call, plus K parent description calls run in parallel).
+
+### Testing
+
+12. **AC-12** — Unit test: `_consolidate_to_parents` with mocked LLM
+    returning a valid grouping → ParentCategory list with correct
+    aggregated `document_count`, correct `child_cluster_ids` set,
+    correct `sample_titles` union (capped at 10).
+
+13. **AC-13** — Unit test: malformed LLM response (missing `parents` key,
+    invalid `child_cluster_ids`) → raises ValueError; caller catches and
+    falls back to base clusters per AC-5.
+
+14. **AC-14** — Unit test: LLM forgets to assign some clusters →
+    `_consolidate_to_parents` collects unassigned clusters under an
+    "Overig" parent (mirroring the dry-run script's defensive behavior).
+
+15. **AC-15** — Integration test (mocked LLM): synthetic 12-cluster
+    fixture → ≥ target_min parents, ≤ hard_cap parents (target_max + 2),
+    every base cluster assigned exactly once, balance caps respected.
+
+16. **AC-16** — Skip-test: `proposals_to_submit` with len 4 (below
+    target_max=9) → `_consolidate_to_parents` is NOT called, base clusters
+    submitted directly. Verifies AC-2.
+
+17. **AC-17** — Failure-fallback test: mocked LLM raises Exception →
+    bootstrap completes successfully, base clusters submitted as
+    proposals, warning log emitted. Verifies AC-5.
+
+## Technical approach
+
+### File-by-file changes
+
+| File | Change | Est. LoC |
+|---|---|---|
+| `klai-knowledge-ingest/knowledge_ingest/proposal_generator.py` | Add `_MERGE_CONSOLIDATE_SYSTEM_PROMPT_TEMPLATE` (mirror of script's `_GROUP_AND_ASSIGN_SYSTEM_PROMPT_TEMPLATE`). Add `_consolidate_to_parents` async helper. Modify `generate_bootstrap_proposals_v2` Step 7→8 to insert Step 7.5 (with skip + fallback per AC-2/AC-5). Add `ParentCategory` dataclass alongside `BootstrapResult`. | ~250 |
+| `klai-knowledge-ingest/knowledge_ingest/portal_client.py` | `TaxonomyProposal` dataclass already supports proposal_type='new_node' as a string + cluster_centroid; add optional `child_cluster_names: list[str] \| None = None` field. `submit_taxonomy_proposal` includes `child_cluster_names` in payload when non-null. | ~10 |
+| `klai-knowledge-ingest/knowledge_ingest/config.py` | Add `taxonomy_consolidate_target_min: int = 5`, `taxonomy_consolidate_target_max: int = 9`, `taxonomy_consolidate_enabled: bool = True`. | ~3 |
+| `klai-knowledge-ingest/knowledge_ingest/routes/taxonomy.py` | `BootstrapResponse` adds `base_clusters_found: int = 0`. | ~3 |
+| `klai-knowledge-ingest/tests/test_taxonomy_v2_bootstrap.py` | Add `TestConsolidate` class for AC-12 through AC-17. Reuse existing fixtures + mock-litellm pattern. | ~250 |
+| `klai-knowledge-ingest/knowledge_ingest/scripts/dry_run_merge_consolidate.py` | KEEP — useful for ongoing prompt-tuning + threshold-experimentation on different KBs without redeploying. | unchanged |
+
+**Total**: ~516 LoC (~266 production + ~250 tests). Geen frontend, geen
+DB-migratie, geen schema-wijziging. Eén PR.
+
+### Insertion point in `generate_bootstrap_proposals_v2`
+
+Huidige flow ([proposal_generator.py:418-697](klai-knowledge-ingest/knowledge_ingest/proposal_generator.py#L418-L697)):
+
+```
+... Step 7 (dedup duplicates) ends at line ~614 with proposals_to_submit ...
+... Step 8 (description-gen + submit) starts at line ~624 ...
+```
+
+Nieuwe Step 7.5 zit precies daartussen:
+
+```python
+# Step 7.5: consolidate to 5-9 parents (SPEC-TAXONOMY-MERGE-DETECT-001)
+if (
+    settings.taxonomy_consolidate_enabled
+    and len(proposals_to_submit) > settings.taxonomy_consolidate_target_max
+):
+    try:
+        parents = await _consolidate_to_parents(
+            base_clusters=proposals_to_submit,  # list of (cid, name) pairs
+            cluster_doc_lists=cluster_doc_lists,
+            cluster_map=cluster_map,
+            document_embeddings=document_embeddings,
+            kb_description=kb_description,
+            target_min=settings.taxonomy_consolidate_target_min,
+            target_max=settings.taxonomy_consolidate_target_max,
+        )
+        # Replace proposals_to_submit with parents
+        proposals_to_submit = parents  # type now: list[ParentCategory]
+        consolidate_succeeded = True
+    except Exception as exc:
+        logger.warning(
+            "bootstrap_consolidate_failed",
+            kb_slug=kb_slug,
+            error=str(exc),
+            base_clusters=len(proposals_to_submit),
+        )
+        # AC-5: fall back to base clusters
+        consolidate_succeeded = False
+else:
+    consolidate_succeeded = False
+```
+
+De daaropvolgende submit-loop check op `consolidate_succeeded` om de juiste
+shape op te bouwen voor `TaxonomyProposal`.
+
+### Prompt design
+
+Hergebruik van het exact-gevalideerde prompt uit
+`scripts/dry_run_merge_consolidate.py`. De prompt bevat:
+- `_NAMING_CRITERIA` shared base (bug-fixes blijven gesynchroniseerd)
+- Miller's Law-context voor target_min/target_max
+- Anti-name-disagreement guard
+- Percentage-gebaseerde balans-caps die scaleren met `total_docs` en
+  `n_clusters`
+- Hard cap op `target_max + 2`
+
+Prompt-tekst staat in het script, wordt 1-op-1 overgenomen naar
+`proposal_generator.py::_MERGE_CONSOLIDATE_SYSTEM_PROMPT_TEMPLATE`. **Geen
+duplicatie** — het script kan ofwel verwijderd worden ofwel zijn prompt
+importeren uit `proposal_generator`.
+
+Aanbeveling: het script importeert vanuit `proposal_generator` (single
+source of truth). Toekomstige tuning gebeurt aan productie-prompt; script
+test automatisch wat productie doet.
+
+### Per-parent description generation
+
+Hergebruik van de exact-gevalideerde flow uit het script:
+
+```python
+async def _generate_parent_descriptions(
+    parents: list[ParentCategory],
+    cluster_doc_lists: dict[int, list[DocumentSummary]],
+) -> None:
+    desc_tasks = [
+        generate_node_description(
+            p.name,
+            None,
+            _round_robin_titles(p, cluster_doc_lists),
+        )
+        for p in parents
+    ]
+    descriptions = await asyncio.gather(*desc_tasks, return_exceptions=True)
+    for p, desc in zip(parents, descriptions, strict=True):
+        p.description = desc if isinstance(desc, str) else ""
+```
+
+Round-robin titles: 2 titles per child, capped at 10 totaal. Mirror van
+de logic in het script.
+
+### Approve-flow op portal-side: ongewijzigd
+
+Operator approveert een parent-proposal exact zoals een gewone new_node:
+- API: `POST /api/app/knowledge-bases/{slug}/taxonomy/proposals/{id}/approve`
+- Functie: `_execute_proposal_action` ([taxonomy.py:511-556](klai-portal/backend/app/api/taxonomy.py#L511-L556))
+- Action voor `proposal_type='new_node'`: maakt `PortalTaxonomyNode`
+  met `name`, `description`, `created_by`. Werkt ongewijzigd voor parent-proposals.
+
+`child_cluster_names` in de payload wordt **niet uitgevoerd** bij approve —
+het is puur metadata voor de operator om te zien waar deze parent uit komt.
+Frontend kan dit later zichtbaar maken (out of scope deze SPEC).
+
+## Risks
+
+| Risk | Impact | Mitigatie |
+|---|---|---|
+| LLM-judge faalt midden in consolidate | Bootstrap zou kunnen falen | AC-5: fallback naar base clusters submit. Bootstrap voltooit altijd. |
+| Stochastische output: aantal parents wisselt tussen runs | Verwarring voor operator op regenerate | Operator review absorbeert variatie. Variatie is ±1 parent bij temperature=0.2 (gevalideerd in script-runs). |
+| LLM hallucineert child_cluster_ids die niet bestaan | Crash op type validatie | Defensieve filter in helper: `if cid not in valid_cids: drop + log`. Mirror van script-implementatie. |
+| LLM laat clusters ongetoegewezen | Verlies van content in proposal-set | Defensieve "Overig"-bucket per script-pattern (AC-14). Operator ziet log + kan reviewen. |
+| Latency over 60s voor zeer grote KBs | Caller-timeout | Existing budget gehouden; consolidate is single-call (~5-10s). Worst-case: 50s bootstrap + 10s consolidate = exact budget. |
+| Kill-switch nodig in productie als prompt regression veroorzaakt | Klanten met draaiende KBs raken nieuwe bootstrap kwijt | `taxonomy_consolidate_enabled=False` env override. AC-6. |
+| Script-prompt en productie-prompt gaan drift | Tuning op script werkt niet op productie | Script importeert prompt uit productie. Single source of truth. |
+
+## Deployment
+
+1. Code-deploy met `taxonomy_consolidate_enabled=True` (default).
+2. Smoke-test op `getklai/voys-help-notion` (14 nodes, al approved): bootstrap
+   produceert 0 nieuwe proposals (al bestaande nodes — dedup filter werkt vóór
+   consolidate).
+3. Smoke-test op `voys/support`: verwacht 5-9 parent proposals (ipv huidige 15).
+4. Monitor `bootstrap_consolidate_complete` event over 1 week — kijk naar:
+   - Distribution van `parents` count (verwacht: 5-9 voor de meeste KBs)
+   - Distribution van `largest_parent_doc_pct` (verwacht: < 30%)
+   - `bootstrap_consolidate_failed` rate (verwacht: < 5%)
+5. Als regressie: `taxonomy_consolidate_enabled=False` in env, container restart
+   herstelt oude gedrag binnen 30s.
+
+## References
+
+- [proposal_generator.py:418-697](klai-knowledge-ingest/knowledge_ingest/proposal_generator.py#L418-L697)
+  — `generate_bootstrap_proposals_v2` (insertion point)
+- [proposal_generator.py:94-104](klai-knowledge-ingest/knowledge_ingest/proposal_generator.py#L94-L104)
+  — `_NAMING_CRITERIA` shared base
+- [scripts/dry_run_merge_consolidate.py](klai-knowledge-ingest/knowledge_ingest/scripts/dry_run_merge_consolidate.py)
+  — gevalideerd reference-implementation. Prompt + helper-flow worden 1-op-1
+  overgenomen naar productie.
+- [Anthropic Clio paper (arxiv 2412.13678)](https://arxiv.org/html/2412.13678v1)
+  — top-down hiërarchie inspiratie
+- [OpenClio prompts.py](https://github.com/Phylliida/OpenClio/blob/main/openclio/prompts.py)
+  — pattern-spiegel
+- [Laws of UX — Miller's Law](https://lawsofux.com/millers-law/) — backup voor 5-9 doel
+- [LLM-Assisted Topic Reduction for BERTopic (arxiv 2509.19365)](https://arxiv.org/html/2509.19365v1)
+  — alternatief overwogen (iterative agglomerative) maar afgewezen ten gunste
+  van Clio-stijl single-call
+
+## History
+
+- **v0.1.0** (2026-05-07): originele SPEC met first-class `proposal_type='merge'`
+  proposals + `_execute_premerge` flow + 27 acceptance criteria. Verworpen
+  als overengineered voor het werkelijke testdoel.
+- **v0.2.0** (2026-05-07): dry-run script-only SPEC. Doel: techniek
+  valideren zonder productiecode te raken.
+- **v1.0.0** (2026-05-07): integratie SPEC. Techniek gevalideerd via vier
+  script-iteraties (zie §Validated results). Implementatie volgt deze SPEC
+  als handleiding.

--- a/klai-knowledge-ingest/knowledge_ingest/config.py
+++ b/klai-knowledge-ingest/knowledge_ingest/config.py
@@ -142,6 +142,16 @@ class Settings(BaseSettings):
     taxonomy_bootstrap_umap_n_neighbors: int = 15
     taxonomy_bootstrap_umap_random_state: int = 42  # for reproducibility
 
+    # SPEC-TAXONOMY-MERGE-DETECT-001 — Clio-style consolidation of base
+    # clusters into IA-friendly parent categories (Miller's Law 5-9 range).
+    # Triggered automatically inside generate_bootstrap_proposals_v2 when
+    # the post-dedup count exceeds ``taxonomy_consolidate_target_max``.
+    # Kill-switch: set ``taxonomy_consolidate_enabled=False`` to fall back
+    # to submitting base clusters directly.
+    taxonomy_consolidate_enabled: bool = True
+    taxonomy_consolidate_target_min: int = 5
+    taxonomy_consolidate_target_max: int = 9
+
     # SPEC-CRAWLER-004 Fase A — Garage S3 for consolidated crawl image pipeline.
     # Feature-flagged via empty endpoint: when ``garage_s3_endpoint`` is blank
     # the crawler skips image upload and writes no ``image_urls`` into Qdrant.

--- a/klai-knowledge-ingest/knowledge_ingest/portal_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/portal_client.py
@@ -37,6 +37,11 @@ class TaxonomyProposal:
     sample_titles: list[str]
     description: str = ""
     cluster_centroid: list[float] | None = None
+    # SPEC-TAXONOMY-MERGE-DETECT-001: when a parent-proposal results from
+    # consolidating multiple base clusters, list the original base cluster
+    # names here for operator transparency. None for non-consolidated
+    # (single-cluster) proposals.
+    child_cluster_names: list[str] | None = None
 
 
 async def fetch_taxonomy_nodes(kb_slug: str, org_id: str) -> list[TaxonomyNode]:
@@ -129,6 +134,7 @@ async def submit_taxonomy_proposal(
                         "sample_titles": proposal.sample_titles[:5],
                         "description": proposal.description,
                         "cluster_centroid": proposal.cluster_centroid,
+                        "child_cluster_names": proposal.child_cluster_names,
                     },
                 },
             )

--- a/klai-knowledge-ingest/knowledge_ingest/proposal_generator.py
+++ b/klai-knowledge-ingest/knowledge_ingest/proposal_generator.py
@@ -62,7 +62,8 @@ from __future__ import annotations
 
 import asyncio
 import json
-from dataclasses import dataclass
+import time
+from dataclasses import dataclass, field
 
 import httpx
 import numpy as np
@@ -212,12 +213,38 @@ class BootstrapResult:
     """Result from generate_bootstrap_proposals_v2.
 
     SPEC-TAXONOMY-V2-001 AC-8, AC-13.
+    SPEC-TAXONOMY-MERGE-DETECT-001 AC-9: base_clusters_found added.
     """
 
     documents_scanned: int
     proposals_submitted: int
     clusters_found: int
+    # When consolidate ran, clusters_found = post-consolidate parent count
+    # and base_clusters_found = pre-consolidate base count. When consolidate
+    # was skipped or fell back, base_clusters_found = clusters_found.
+    base_clusters_found: int = 0
     reason: str | None = None
+
+
+@dataclass
+class ParentCategory:
+    """One LLM-proposed parent category from consolidate step (SPEC-TAXONOMY-MERGE-DETECT-001).
+
+    Built by ``_consolidate_to_parents``; consumed by the submit-loop in
+    ``generate_bootstrap_proposals_v2`` to produce TaxonomyProposal payloads.
+    """
+
+    name: str
+    rationale: str
+    child_cluster_ids: list[int]
+    # Description is generated AFTER group-and-assign via generate_node_description
+    # — same path that production new_node proposals use.
+    description: str = ""
+    # Aggregated fields (populated by _consolidate_to_parents):
+    document_count: int = 0
+    sample_titles: list[str] = field(default_factory=list)
+    centroid: list[float] | None = None
+    child_cluster_names: list[str] = field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -414,6 +441,313 @@ async def _suggest_cluster_names_batched(
         result[cid] = name.strip()
 
     return result
+
+
+# ---------------------------------------------------------------------------
+# Strategy 4 (SPEC-TAXONOMY-MERGE-DETECT-001): Clio-style consolidation.
+# After base clusters have been named (Strategy 3) and dedupped, this step
+# groups them into 5-9 IA-friendly parent categories in a SINGLE LLM call.
+#
+# Inspired by Anthropic Clio (arxiv 2412.13678): "propose higher-level names
+# that encompass these clusters" + "assign each base cluster to one parent",
+# but collapsed to one call because we have 5-30 clusters (no neighborhood
+# k-means step needed). Reuses _NAMING_CRITERIA so naming rules stay
+# consistent across all strategies.
+#
+# Validated on Voys/support via the dry-run script
+# (knowledge_ingest/scripts/dry_run_merge_consolidate.py): 15 base clusters
+# → 7-8 parents within target_min/target_max, parent descriptions of
+# production quality.
+# ---------------------------------------------------------------------------
+
+_MERGE_CONSOLIDATE_SYSTEM_PROMPT_TEMPLATE = (
+    "You are a knowledge taxonomy assistant. You will see {n_clusters} "
+    "fine-grained document clusters from a knowledge base. Your job: "
+    "organise them into between {target_min} and {target_max} broader parent "
+    "categories suitable for browsing/navigation."
+    "{kb_description_block}"
+    "\n\nThis is information architecture, not classification. The target "
+    "count of {target_min}-{target_max} follows Miller's Law: more would "
+    "overwhelm a sidebar, fewer would lose meaningful distinctions."
+    "\n\n"
+    f"{_NAMING_CRITERIA}"
+    "\nAdditional rules for parent categories:\n"
+    "- Each parent category SHOULD encompass 1-5 base clusters that share an "
+    "  overarching theme.\n"
+    "- A parent category MAY contain a single base cluster if that cluster "
+    "  is genuinely distinct from all others — do not force-group unrelated "
+    "  things just to lower the count.\n"
+    "- Each base cluster MUST be assigned to exactly one parent category.\n"
+    "- Parent names follow the same naming criteria as base clusters: name "
+    "  the SHARED theme, not the most salient sub-item.\n"
+    "- DO NOT keep clusters separate solely because their base names differ — "
+    "  the base names came from a per-cluster naming step instructed to "
+    "  differentiate, so naming-disagreement is expected and not a signal "
+    "  that the clusters belong apart.\n"
+    "- Aim for {target_min}-{target_max} parents. If you genuinely cannot "
+    "  reach {target_max} without grouping unrelated things, fewer is OK. "
+    "  If staying under {target_max} forces you to lump unrelated topics "
+    "  together, slightly more is OK.\n"
+    "\nBalance constraints (avoid one over-large parent — these scale with "
+    "the actual corpus, not absolute numbers):\n"
+    "- Total documents across all base clusters: {total_docs}. "
+    "Total base clusters: {n_clusters}.\n"
+    "- Soft cap on parent size: a single parent SHOULD NOT hold more than "
+    "  ~25% of total documents (~{doc_cap} docs) OR more than ~33% of base "
+    "  clusters (~{cluster_cap} clusters). If EITHER threshold is "
+    "  exceeded, prefer to split that parent into more specific "
+    "  sub-themes.\n"
+    "- These caps are SOFT — quality of grouping outranks balance. If the "
+    "  only sensible split would mix unrelated themes (e.g. forcing a "
+    "  cohesive 'CRM' parent to split into arbitrary halves), keep it "
+    "  together and accept the imbalance. Bias toward splitting when an "
+    "  internal split-line is meaningful (configuration vs hardware vs "
+    "  network), bias toward keeping when no clean split exists.\n"
+    "- Aim for roughly balanced parent sizes — no one parent should "
+    "  dominate sidebar browsing.\n"
+    "- Splitting MAY push the parent count slightly above {target_max} — "
+    "  that's acceptable. Hard cap at {hard_cap} parents.\n"
+    "\nReply ONLY with JSON, no markdown:\n"
+    '{{"parents": [{{"name": "<parent name>", "rationale": "<why these '
+    'belong together, max 200 chars>", "child_cluster_ids": [<int>, ...]}}, '
+    "...]}}"
+)
+
+
+async def _consolidate_to_parents(
+    base_proposals: list[tuple[int, str]],
+    cluster_doc_lists: dict[int, list[DocumentSummary]],
+    cluster_map: dict[int, list[int]],
+    document_embeddings: np.ndarray,
+    kb_description: str,
+    target_min: int,
+    target_max: int,
+) -> list[ParentCategory]:
+    """Single-call Clio-style group-and-assign + parallel parent descriptions.
+
+    Args:
+        base_proposals: list of (cluster_id, name) tuples from the post-dedup set.
+        cluster_doc_lists: cluster_id → list of DocumentSummary (for sample titles
+            and base-cluster description input).
+        cluster_map: cluster_id → list of doc indices into document_embeddings
+            (for centroid computation).
+        document_embeddings: (n_docs, dim) unit-normalised embedding matrix.
+        kb_description: KB description for prompt context (may be empty).
+        target_min: desired minimum number of parent categories.
+        target_max: desired maximum number of parent categories.
+
+    Returns:
+        List of ParentCategory with name, description, child_cluster_ids,
+        document_count, sample_titles (union, capped at 10), centroid
+        (doc-count-weighted unit-normalised mean), and child_cluster_names.
+
+    Raises:
+        ValueError: malformed LLM response.
+        Exception: any HTTP / timeout / JSON parsing error from the LLM call.
+
+    Caller (generate_bootstrap_proposals_v2) catches these and falls back
+    to submitting base clusters per AC-5.
+    """
+    import json as _json
+
+    if len(base_proposals) <= 1:
+        # Trivial case: nothing to consolidate.
+        return []
+
+    # We need per-cluster descriptions as input to the LLM (matches the
+    # validated dry-run script behaviour). Generate them in parallel.
+    desc_tasks_pre = [
+        generate_node_description(
+            name,
+            None,
+            [doc.title for doc in cluster_doc_lists.get(cid, [])[:5]],
+        )
+        for cid, name in base_proposals
+    ]
+    base_descriptions_results = await asyncio.gather(*desc_tasks_pre, return_exceptions=True)
+    base_descriptions: dict[int, str] = {}
+    for (cid, _), desc in zip(base_proposals, base_descriptions_results, strict=True):
+        base_descriptions[cid] = desc if isinstance(desc, str) else ""
+
+    # Build prompt context
+    kb_description_block = ""
+    if kb_description and kb_description.strip():
+        kb_description_block = f"\n\nThe knowledge base is described as:\n{kb_description.strip()}"
+
+    total_docs = sum(len(cluster_map[cid]) for cid, _ in base_proposals)
+    n_clusters = len(base_proposals)
+    doc_cap = max(1, total_docs // 4)
+    cluster_cap = max(1, n_clusters // 3)
+    hard_cap = target_max + 2
+
+    system_prompt = _MERGE_CONSOLIDATE_SYSTEM_PROMPT_TEMPLATE.format(
+        n_clusters=n_clusters,
+        total_docs=total_docs,
+        target_min=target_min,
+        target_max=target_max,
+        doc_cap=doc_cap,
+        cluster_cap=cluster_cap,
+        hard_cap=hard_cap,
+        kb_description_block=kb_description_block,
+    )
+
+    cluster_lines: list[str] = []
+    for cid, name in base_proposals:
+        docs = cluster_doc_lists.get(cid, [])
+        title_lines = "\n".join(f"      - {d.title[:140]}" for d in docs[:5])
+        descr = base_descriptions.get(cid) or "(no description)"
+        cluster_lines.append(
+            f'Cluster {cid} "{name}" ({len(cluster_map[cid])} docs):\n'
+            f"  Description: {descr}\n"
+            f"  Sample titles:\n{title_lines}"
+        )
+    user_message = "\n\n".join(cluster_lines)
+
+    max_tokens = 600 + 80 * n_clusters
+
+    async with httpx.AsyncClient(timeout=settings.taxonomy_classification_timeout) as client:
+        resp = await client.post(
+            f"{settings.litellm_url}/chat/completions",
+            headers={
+                "Authorization": f"Bearer {settings.litellm_api_key}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": settings.taxonomy_classification_model,
+                "messages": [
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_message},
+                ],
+                "temperature": 0.2,
+                "max_tokens": max_tokens,
+            },
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+    content = (data["choices"][0]["message"]["content"] or "").strip()
+    if content.startswith("```"):
+        content = content.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
+    parsed = _json.loads(content)
+    if not isinstance(parsed, dict) or "parents" not in parsed:
+        raise ValueError("Consolidate response missing 'parents' key")
+
+    parents_list = parsed["parents"]
+    if not isinstance(parents_list, list):
+        raise ValueError("'parents' is not a list")
+
+    valid_cids = {cid for cid, _ in base_proposals}
+    name_by_cid = {cid: name for cid, name in base_proposals}
+    parents: list[ParentCategory] = []
+    seen_cids: set[int] = set()
+
+    for item in parents_list:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        rationale = item.get("rationale") or ""
+        if not isinstance(rationale, str):
+            rationale = str(rationale)
+        children_raw = item.get("child_cluster_ids", [])
+        if not isinstance(children_raw, list):
+            children_raw = []
+        children: list[int] = []
+        for cid in children_raw:
+            if not isinstance(cid, int):
+                continue
+            if cid not in valid_cids or cid in seen_cids:
+                continue
+            seen_cids.add(cid)
+            children.append(cid)
+        if children:
+            parents.append(
+                ParentCategory(
+                    name=name.strip(),
+                    rationale=rationale.strip(),
+                    child_cluster_ids=children,
+                )
+            )
+
+    # AC-14: collect any unassigned clusters under an "Overig" parent so no
+    # content silently disappears. Operator can review and merge/split.
+    unassigned = sorted(cid for cid in valid_cids if cid not in seen_cids)
+    if unassigned:
+        logger.warning(
+            "bootstrap_consolidate_unassigned_clusters",
+            count=len(unassigned),
+            cluster_ids=unassigned,
+        )
+        parents.append(
+            ParentCategory(
+                name="Overig",
+                rationale="Niet door LLM toegewezen — operator review required.",
+                child_cluster_ids=unassigned,
+            )
+        )
+
+    # Aggregate fields per parent: document_count, sample_titles, centroid,
+    # child_cluster_names. These are what the submit-loop turns into a
+    # TaxonomyProposal payload.
+    for p in parents:
+        # document_count = sum of children's doc_count
+        p.document_count = sum(len(cluster_map[cid]) for cid in p.child_cluster_ids)
+        # sample_titles = round-robin from children, capped at 10
+        p.sample_titles = _round_robin_titles(p.child_cluster_ids, cluster_doc_lists)
+        # centroid = doc-count-weighted unit-normalised mean of children's centroids
+        p.centroid = _weighted_centroid(p.child_cluster_ids, cluster_map, document_embeddings)
+        # child_cluster_names for operator transparency
+        p.child_cluster_names = [name_by_cid[cid] for cid in p.child_cluster_ids]
+
+    # Generate user-facing descriptions per parent in parallel — same path
+    # as production new_node proposals (generate_node_description on
+    # parent_name + round-robin sample titles).
+    desc_tasks = [generate_node_description(p.name, None, p.sample_titles[:10]) for p in parents]
+    descriptions = await asyncio.gather(*desc_tasks, return_exceptions=True)
+    for p, desc in zip(parents, descriptions, strict=True):
+        p.description = desc if isinstance(desc, str) else ""
+
+    return parents
+
+
+def _round_robin_titles(
+    child_cluster_ids: list[int],
+    cluster_doc_lists: dict[int, list[DocumentSummary]],
+) -> list[str]:
+    """2 titles per child, capped at 10 total. Mirrors the dry-run script."""
+    if not child_cluster_ids:
+        return []
+    per_child = max(2, 10 // max(1, len(child_cluster_ids)))
+    titles: list[str] = []
+    for cid in child_cluster_ids:
+        for doc in cluster_doc_lists.get(cid, [])[:per_child]:
+            titles.append(doc.title)
+            if len(titles) >= 10:
+                return titles
+    return titles[:10]
+
+
+def _weighted_centroid(
+    child_cluster_ids: list[int],
+    cluster_map: dict[int, list[int]],
+    document_embeddings: np.ndarray,
+) -> list[float] | None:
+    """Doc-count-weighted unit-normalised mean of child centroids.
+
+    Returns None if all children have zero-norm centroids (defensive — should
+    not happen with bge-m3, but guards against pathological input).
+    """
+    indices: list[int] = []
+    for cid in child_cluster_ids:
+        indices.extend(cluster_map.get(cid, []))
+    if not indices:
+        return None
+    centroid = document_embeddings[indices].mean(axis=0)
+    norm = float(np.linalg.norm(centroid))
+    if norm == 0:
+        return None
+    return (centroid / norm).tolist()
 
 
 async def generate_bootstrap_proposals_v2(
@@ -638,55 +972,120 @@ async def generate_bootstrap_proposals_v2(
                 reason="all_duplicates",
             )
 
-    # SPEC-TAXONOMY-V2-001-FOLLOWUP-001 B2: generate descriptions in parallel
-    # (V1 had this; V2 dropped it — this restores it).
-    desc_tasks = [
-        generate_node_description(
-            name,
-            None,
-            [doc.title for doc in cluster_doc_lists.get(cid, [])[:5]],
-        )
-        for cid, name in proposals_to_submit
-    ]
-    desc_results = await asyncio.gather(*desc_tasks, return_exceptions=True)
-
-    # Step 8: submit proposals (AC-18)
-    submitted = 0
-    for i, (cid, name) in enumerate(proposals_to_submit):
-        cluster_doc_list = cluster_doc_lists.get(cid, [])
-        sample_titles = [doc.title for doc in cluster_doc_list[:5]]
-
-        # Use generated description if available; fall back to "" on failure (AC-7)
-        raw_desc = desc_results[i] if i < len(desc_results) else Exception("index out of range")
-        if isinstance(raw_desc, str):
-            description = raw_desc
-        else:
-            description = ""
-            logger.warning(
-                "bootstrap_description_generation_failed",
-                kb_slug=kb_slug,
-                cluster_id=cid,
-                error=str(raw_desc) if raw_desc is not None else None,
+    # Step 7.5: Clio-style consolidation to 5-9 parents (SPEC-TAXONOMY-MERGE-DETECT-001).
+    # Runs only if there are MORE base clusters than the IA target_max — for
+    # smaller post-dedup sets (≤ target_max) consolidation has no value.
+    # AC-5: any consolidate failure falls back to submitting base clusters.
+    base_clusters_count = len(proposals_to_submit)
+    parents: list[ParentCategory] | None = None
+    if (
+        settings.taxonomy_consolidate_enabled
+        and base_clusters_count > settings.taxonomy_consolidate_target_max
+    ):
+        consolidate_t0 = time.monotonic()
+        try:
+            parents = await _consolidate_to_parents(
+                base_proposals=proposals_to_submit,
+                cluster_doc_lists=cluster_doc_lists,
+                cluster_map=cluster_map,
+                document_embeddings=document_embeddings,
+                kb_description=kb_description,
+                target_min=settings.taxonomy_consolidate_target_min,
+                target_max=settings.taxonomy_consolidate_target_max,
             )
+            consolidate_latency_ms = int((time.monotonic() - consolidate_t0) * 1000)
+            if parents:
+                largest = max(parents, key=lambda p: p.document_count)
+                largest_doc_pct = (
+                    100.0 * largest.document_count / max(1, sum(p.document_count for p in parents))
+                )
+                logger.info(
+                    "bootstrap_consolidate_complete",
+                    kb_slug=kb_slug,
+                    org_id=org_id,
+                    base_clusters=base_clusters_count,
+                    parents=len(parents),
+                    largest_parent_doc_pct=round(largest_doc_pct, 1),
+                    largest_parent_cluster_count=len(largest.child_cluster_ids),
+                    latency_ms=consolidate_latency_ms,
+                )
+        except Exception as exc:
+            # AC-5: fall back to base clusters. Bootstrap MUST NOT fail on consolidate failure.
+            logger.warning(
+                "bootstrap_consolidate_failed",
+                kb_slug=kb_slug,
+                org_id=org_id,
+                error=str(exc),
+                base_clusters=base_clusters_count,
+                exc_info=True,
+            )
+            parents = None
 
-        proposal = TaxonomyProposal(
-            proposal_type="new_node",
-            suggested_name=name,
-            document_count=len(cluster_doc_list),
-            sample_titles=sample_titles,
-            description=description,
-        )
-        await submit_taxonomy_proposal(kb_slug=kb_slug, org_id=org_id, proposal=proposal)
-        submitted += 1
+    # Step 8: submit proposals (AC-18 base path / AC-7 consolidate path).
+    submitted = 0
+    if parents:
+        # Consolidate path: descriptions and aggregated fields are already
+        # populated inside _consolidate_to_parents.
+        for p in parents:
+            proposal = TaxonomyProposal(
+                proposal_type="new_node",
+                suggested_name=p.name,
+                document_count=p.document_count,
+                sample_titles=p.sample_titles[:5],
+                description=p.description,
+                cluster_centroid=p.centroid,
+                child_cluster_names=p.child_cluster_names,
+            )
+            await submit_taxonomy_proposal(kb_slug=kb_slug, org_id=org_id, proposal=proposal)
+            submitted += 1
+    else:
+        # Base path: SPEC-TAXONOMY-V2-001-FOLLOWUP-001 B2 (generate descriptions in parallel).
+        desc_tasks = [
+            generate_node_description(
+                name,
+                None,
+                [doc.title for doc in cluster_doc_lists.get(cid, [])[:5]],
+            )
+            for cid, name in proposals_to_submit
+        ]
+        desc_results = await asyncio.gather(*desc_tasks, return_exceptions=True)
 
-    # Step 9: AC-9 log
-    # SPEC-TAXONOMY-V2-001-FOLLOWUP-001 B5: log cluster_probability_mean instead of dbcv_score.
-    # dbcv_score assumed relative_validity_ which sklearn 1.8 does not expose.
+        for i, (cid, name) in enumerate(proposals_to_submit):
+            cluster_doc_list = cluster_doc_lists.get(cid, [])
+            sample_titles = [doc.title for doc in cluster_doc_list[:5]]
+
+            raw_desc = desc_results[i] if i < len(desc_results) else Exception("index out of range")
+            if isinstance(raw_desc, str):
+                description = raw_desc
+            else:
+                description = ""
+                logger.warning(
+                    "bootstrap_description_generation_failed",
+                    kb_slug=kb_slug,
+                    cluster_id=cid,
+                    error=str(raw_desc) if raw_desc is not None else None,
+                )
+
+            proposal = TaxonomyProposal(
+                proposal_type="new_node",
+                suggested_name=name,
+                document_count=len(cluster_doc_list),
+                sample_titles=sample_titles,
+                description=description,
+            )
+            await submit_taxonomy_proposal(kb_slug=kb_slug, org_id=org_id, proposal=proposal)
+            submitted += 1
+
+    # Step 9: AC-9 log + SPEC-TAXONOMY-MERGE-DETECT-001 base_clusters_found.
+    # When consolidate ran, clusters_found = post-consolidate parent count.
+    # When consolidate skipped/failed, clusters_found = base count (back-compat).
+    final_clusters_found = len(parents) if parents else base_clusters_count
     logger.info(
         "bootstrap_proposals_complete",
         org_id=org_id,
         kb_slug=kb_slug,
-        clusters_found=clusters_found,
+        clusters_found=final_clusters_found,
+        base_clusters_found=base_clusters_count,
         outlier_count=outlier_count,
         cluster_probability_mean=cluster_probability_mean,
         proposals_submitted=submitted,
@@ -695,7 +1094,8 @@ async def generate_bootstrap_proposals_v2(
     return BootstrapResult(
         documents_scanned=doc_count,
         proposals_submitted=submitted,
-        clusters_found=clusters_found,
+        clusters_found=final_clusters_found,
+        base_clusters_found=base_clusters_count,
     )
 
 

--- a/klai-knowledge-ingest/knowledge_ingest/routes/taxonomy.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/taxonomy.py
@@ -77,6 +77,11 @@ class BootstrapResponse(BaseModel):
     documents_scanned: int
     proposals_submitted: int
     clusters_found: int | None = None
+    # SPEC-TAXONOMY-MERGE-DETECT-001: when consolidate ran, clusters_found
+    # equals the post-consolidate parent count and base_clusters_found
+    # equals the pre-consolidate base count. When consolidate was skipped
+    # or fell back, base_clusters_found equals clusters_found.
+    base_clusters_found: int | None = None
     reason: str | None = None
 
 
@@ -323,6 +328,7 @@ async def taxonomy_bootstrap_proposals(
         documents_scanned=result.documents_scanned,
         proposals_submitted=result.proposals_submitted,
         clusters_found=result.clusters_found,
+        base_clusters_found=result.base_clusters_found,
         reason=result.reason,
     )
 

--- a/klai-knowledge-ingest/knowledge_ingest/scripts/dry_run_merge_consolidate.py
+++ b/klai-knowledge-ingest/knowledge_ingest/scripts/dry_run_merge_consolidate.py
@@ -1,0 +1,799 @@
+"""Dry-run taxonomy consolidation (Clio-style top-down hierarchy).
+
+SPEC-TAXONOMY-MERGE-DETECT-001 v0.5.
+
+Runs the existing V2 bootstrap pipeline (HDBSCAN + UMAP + batched naming +
+description generation) and then asks an LLM to organise the resulting
+fine-grained clusters into 5-9 broader parent categories — the count target
+follows Miller's Law for IA-friendly browsing structures.
+
+Inspired by Anthropic's Clio paper (arxiv 2412.13678) which uses
+"propose higher-level names that encompass these clusters" + "assign each
+base cluster to one parent" rather than pairwise merge judging.
+
+Pipeline:
+    1. Qdrant scroll + HDBSCAN cluster + batched naming + base descriptions
+    2. Group-and-assign LLM call: 15 base clusters → 5-9 parents with
+       balance constraints (no parent > 25% docs / 33% clusters)
+    3. Per-parent description generation via generate_node_description
+       (same path used by production new_node proposals).
+
+Two modes:
+    live     Run full pipeline. Writes a cache file with cluster info.
+    replay   Skip Qdrant + naming + describing, replay group + assign on a
+             cached cluster state. Faster iteration on the prompts.
+
+Usage (live, on core-01 because Qdrant + LiteLLM are docker-internal):
+    ssh core-01 "docker exec klai-core-knowledge-ingest-1 python -m \\
+        knowledge_ingest.scripts.dry_run_merge_consolidate \\
+        --org-id <zitadel_org_id> --kb-slug support"
+
+Usage (replay):
+    python -m knowledge_ingest.scripts.dry_run_merge_consolidate \\
+        --mode replay --from /tmp/merge-consolidate-support-...json \\
+        --target-min 5 --target-max 9
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import httpx
+import numpy as np
+from qdrant_client import AsyncQdrantClient
+from qdrant_client.http.models import FieldCondition, Filter, MatchValue
+
+from knowledge_ingest.clustering import (
+    closest_to_centroid,
+    cluster_documents_hdbscan,
+    compute_min_cluster_size,
+)
+from knowledge_ingest.config import settings
+from knowledge_ingest.description_generator import generate_node_description
+from knowledge_ingest.portal_client import (
+    fetch_kb_metadata,
+    fetch_taxonomy_nodes,
+)
+from knowledge_ingest.proposal_generator import (
+    _NAMING_CRITERIA,
+    DocumentSummary,
+    _suggest_cluster_names_batched,
+)
+from knowledge_ingest.routes.taxonomy import COLLECTION
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+    stream=sys.stderr,
+)
+logger = logging.getLogger("dry_run_merge_consolidate")
+
+
+# ---------------------------------------------------------------------------
+# Group-and-assign prompt — Clio-style top-down hierarchy with percentage-
+# based balance caps that scale with the actual corpus.
+# ---------------------------------------------------------------------------
+
+_GROUP_AND_ASSIGN_SYSTEM_PROMPT_TEMPLATE = (
+    "You are a knowledge taxonomy assistant. You will see {n_clusters} "
+    "fine-grained document clusters from a knowledge base. Your job: "
+    "organise them into between {target_min} and {target_max} broader parent "
+    "categories suitable for browsing/navigation."
+    "{kb_description_block}"
+    "\n\nThis is information architecture, not classification. The target "
+    "count of {target_min}-{target_max} follows Miller's Law: more would "
+    "overwhelm a sidebar, fewer would lose meaningful distinctions."
+    "\n\n"
+    f"{_NAMING_CRITERIA}"
+    "\nAdditional rules for parent categories:\n"
+    "- Each parent category SHOULD encompass 1-5 base clusters that share an "
+    "  overarching theme.\n"
+    "- A parent category MAY contain a single base cluster if that cluster "
+    "  is genuinely distinct from all others — do not force-group unrelated "
+    "  things just to lower the count.\n"
+    "- Each base cluster MUST be assigned to exactly one parent category.\n"
+    "- Parent names follow the same naming criteria as base clusters: name "
+    "  the SHARED theme, not the most salient sub-item.\n"
+    "- DO NOT keep clusters separate solely because their base names differ — "
+    "  the base names came from a per-cluster naming step instructed to "
+    "  differentiate, so naming-disagreement is expected and not a signal "
+    "  that the clusters belong apart.\n"
+    "- Aim for {target_min}-{target_max} parents. If you genuinely cannot "
+    "  reach {target_max} without grouping unrelated things, fewer is OK. "
+    "  If staying under {target_max} forces you to lump unrelated topics "
+    "  together, slightly more is OK.\n"
+    "\nBalance constraints (avoid one over-large parent — these scale with "
+    "the actual corpus, not absolute numbers):\n"
+    "- Total documents across all base clusters: {total_docs}. "
+    "Total base clusters: {n_clusters}.\n"
+    "- Soft cap on parent size: a single parent SHOULD NOT hold more than "
+    "  ~25% of total documents (~{doc_cap} docs) OR more than ~33% of base "
+    "  clusters (~{cluster_cap} clusters). If EITHER threshold is "
+    "  exceeded, prefer to split that parent into more specific "
+    "  sub-themes.\n"
+    "- These caps are SOFT — quality of grouping outranks balance. If the "
+    "  only sensible split would mix unrelated themes (e.g. forcing a "
+    "  cohesive 'CRM' parent to split into arbitrary halves), keep it "
+    "  together and accept the imbalance. Bias toward splitting when an "
+    "  internal split-line is meaningful (configuration vs hardware vs "
+    "  network), bias toward keeping when no clean split exists.\n"
+    "- Aim for roughly balanced parent sizes — no one parent should "
+    "  dominate sidebar browsing.\n"
+    "- Splitting MAY push the parent count slightly above {target_max} — "
+    "  that's acceptable. Hard cap at {hard_cap} parents.\n"
+    "\nReply ONLY with JSON, no markdown:\n"
+    '{{"parents": [{{"name": "<parent name>", "rationale": "<why these '
+    'belong together, max 200 chars>", "child_cluster_ids": [<int>, ...]}}, '
+    "...]}}"
+)
+
+
+# ---------------------------------------------------------------------------
+# Data classes.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ClusterInfo:
+    """One named cluster with description (the way the LLM needs to see it)."""
+
+    cluster_id: int
+    name: str
+    description: str
+    doc_count: int
+    sample_titles: list[str]
+    centroid: list[float]  # unit-normalised; kept for potential future use
+
+
+@dataclass
+class CacheBundle:
+    """What we serialise to disk after a live run."""
+
+    kb_slug: str
+    org_id: str
+    kb_description: str
+    documents_scanned: int
+    outlier_count: int
+    clusters: list[ClusterInfo]
+
+
+@dataclass
+class ParentCategory:
+    """One LLM-proposed parent category."""
+
+    name: str
+    rationale: str
+    child_cluster_ids: list[int] = field(default_factory=list)
+    # Description is generated AFTER group-and-assign via generate_node_description
+    # — same path that production new_node proposals use, so the integration is
+    # consistent with current node descriptions.
+    description: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Live mode — repeats taxonomy_bootstrap_proposals up to (and including)
+# naming + description, but does NOT call submit_taxonomy_proposal.
+# Returns a CacheBundle.
+# ---------------------------------------------------------------------------
+
+
+async def _scroll_kb_embeddings(
+    org_id: str, kb_slug: str
+) -> tuple[list[DocumentSummary], np.ndarray]:
+    """Mirror the scroll loop from taxonomy_bootstrap_proposals."""
+    qdrant_client = AsyncQdrantClient(
+        url=settings.qdrant_url,
+        api_key=settings.qdrant_api_key or None,
+    )
+
+    scroll_filter = Filter(
+        must=[
+            FieldCondition(key="org_id", match=MatchValue(value=org_id)),
+            FieldCondition(key="kb_slug", match=MatchValue(value=kb_slug)),
+        ]
+    )
+
+    seen_artifacts: set[str] = set()
+    doc_summaries: list[DocumentSummary] = []
+    doc_vecs: list[list[float]] = []
+    offset: Any = None
+
+    while True:
+        points, next_offset = await asyncio.wait_for(
+            qdrant_client.scroll(
+                collection_name=COLLECTION,
+                scroll_filter=scroll_filter,
+                limit=100,
+                offset=offset,
+                with_payload=True,
+                with_vectors=["vector_chunk"],
+            ),
+            timeout=60.0,
+        )
+        if not points:
+            break
+
+        for point in points:
+            payload = point.payload or {}
+            artifact_id = payload.get("artifact_id") or str(point.id)
+            if artifact_id in seen_artifacts:
+                continue
+            seen_artifacts.add(artifact_id)
+
+            vec = None
+            if hasattr(point, "vector") and point.vector:
+                if isinstance(point.vector, dict):
+                    vec = point.vector.get("vector_chunk")
+                elif isinstance(point.vector, list):
+                    vec = point.vector
+            if vec is None:
+                continue
+
+            title = payload.get("title") or payload.get("path") or artifact_id
+            preview = payload.get("text", "")[:300]
+            doc_summaries.append(DocumentSummary(title=title, content_preview=preview))
+            doc_vecs.append(vec)
+
+        if next_offset is None:
+            break
+        offset = next_offset
+
+    if not doc_vecs:
+        return doc_summaries, np.empty((0, 0), dtype=np.float32)
+
+    embeddings = np.array(doc_vecs, dtype=np.float32)
+    norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
+    norms = np.where(norms == 0, 1.0, norms)
+    embeddings = embeddings / norms
+    return doc_summaries, embeddings
+
+
+async def _build_cache_live(org_id: str, kb_slug: str) -> CacheBundle:
+    """Run the full bootstrap pipeline up to naming+describing. No DB writes."""
+    logger.info("Scrolling Qdrant for org=%s kb=%s …", org_id, kb_slug)
+    doc_summaries, embeddings = await _scroll_kb_embeddings(org_id, kb_slug)
+    if len(doc_summaries) == 0:
+        logger.warning("No documents found in Qdrant for this KB.")
+        return CacheBundle(
+            kb_slug=kb_slug,
+            org_id=org_id,
+            kb_description="",
+            documents_scanned=0,
+            outlier_count=0,
+            clusters=[],
+        )
+
+    logger.info("Got %d documents. Fetching KB metadata + existing nodes …", len(doc_summaries))
+    kb_meta = await fetch_kb_metadata(kb_slug, org_id)
+    kb_description = (kb_meta or {}).get("description") or ""
+    existing_nodes = await fetch_taxonomy_nodes(kb_slug, org_id)
+
+    logger.info("Running HDBSCAN (UMAP-pre-reduced) …")
+    min_cluster_size = compute_min_cluster_size(
+        len(doc_summaries),
+        floor=settings.taxonomy_bootstrap_min_cluster_size_floor,
+    )
+    labels, metrics = cluster_documents_hdbscan(
+        embeddings,
+        min_cluster_size=min_cluster_size,
+        pre_reduce=True,
+    )
+    clusters_found: int = metrics["clusters_found"]
+    outlier_count: int = metrics["outlier_count"]
+    logger.info("Found %d clusters (%d outliers).", clusters_found, outlier_count)
+
+    if clusters_found == 0:
+        return CacheBundle(
+            kb_slug=kb_slug,
+            org_id=org_id,
+            kb_description=kb_description,
+            documents_scanned=len(doc_summaries),
+            outlier_count=outlier_count,
+            clusters=[],
+        )
+
+    cluster_map: dict[int, list[int]] = {}
+    for idx, lbl in enumerate(labels):
+        if int(lbl) >= 0:
+            cluster_map.setdefault(int(lbl), []).append(idx)
+
+    max_clusters = settings.taxonomy_bootstrap_max_clusters
+    if len(cluster_map) > max_clusters:
+        sorted_clusters = sorted(cluster_map.items(), key=lambda x: len(x[1]), reverse=True)
+        cluster_map = dict(sorted_clusters[:max_clusters])
+        logger.info("Capped to %d largest clusters.", max_clusters)
+
+    top_n = settings.taxonomy_bootstrap_top_n_per_cluster
+
+    cluster_doc_lists: dict[int, list[DocumentSummary]] = {}
+    for cid, indices in cluster_map.items():
+        top_indices = closest_to_centroid(indices, embeddings, n=top_n)
+        cluster_docs = [
+            doc_summaries[i]
+            for i in top_indices
+            if len(doc_summaries[i].content_preview.strip()) >= 50
+        ]
+        if not cluster_docs:
+            cluster_docs = [doc_summaries[i] for i in top_indices]
+        cluster_doc_lists[cid] = cluster_docs
+
+    logger.info("Running batched LLM-naming over %d clusters …", len(cluster_doc_lists))
+    batched_names = await _suggest_cluster_names_batched(cluster_doc_lists, kb_description)
+    existing_names_lower = {node.name.lower() for node in existing_nodes}
+
+    kept_clusters: list[tuple[int, str, list[int]]] = []
+    for cid in sorted(cluster_doc_lists):
+        name = batched_names.get(cid)
+        if not name:
+            logger.info("Skipping cluster %d: batched-naming returned no name.", cid)
+            continue
+        if name.lower() in existing_names_lower:
+            logger.info("Skipping cluster %d (%r): duplicate of existing node.", cid, name)
+            continue
+        kept_clusters.append((cid, name, cluster_map[cid]))
+
+    if not kept_clusters:
+        return CacheBundle(
+            kb_slug=kb_slug,
+            org_id=org_id,
+            kb_description=kb_description,
+            documents_scanned=len(doc_summaries),
+            outlier_count=outlier_count,
+            clusters=[],
+        )
+
+    logger.info("Generating descriptions for %d clusters in parallel …", len(kept_clusters))
+    desc_tasks = [
+        generate_node_description(
+            name,
+            None,
+            [doc.title for doc in cluster_doc_lists[cid][:5]],
+        )
+        for cid, name, _ in kept_clusters
+    ]
+    descriptions = await asyncio.gather(*desc_tasks, return_exceptions=True)
+
+    clusters: list[ClusterInfo] = []
+    for (cid, name, indices), desc in zip(kept_clusters, descriptions, strict=True):
+        if isinstance(desc, str):
+            description = desc
+        else:
+            description = ""
+            logger.warning("Description failed for cluster %d: %s", cid, desc)
+        centroid = embeddings[indices].mean(axis=0)
+        norm = float(np.linalg.norm(centroid))
+        if norm == 0:
+            logger.warning("Cluster %d has zero-norm centroid — skipping.", cid)
+            continue
+        centroid_unit = (centroid / norm).tolist()
+        clusters.append(
+            ClusterInfo(
+                cluster_id=cid,
+                name=name,
+                description=description,
+                doc_count=len(indices),
+                sample_titles=[doc.title for doc in cluster_doc_lists[cid][:8]],
+                centroid=centroid_unit,
+            )
+        )
+
+    return CacheBundle(
+        kb_slug=kb_slug,
+        org_id=org_id,
+        kb_description=kb_description,
+        documents_scanned=len(doc_summaries),
+        outlier_count=outlier_count,
+        clusters=clusters,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Group-and-assign LLM call.
+# ---------------------------------------------------------------------------
+
+
+async def _group_and_assign(
+    bundle: CacheBundle,
+    target_min: int,
+    target_max: int,
+    print_prompt: bool = False,
+) -> list[ParentCategory]:
+    """One LLM call: propose parents + assign each base cluster.
+
+    Returns a list of ParentCategory. May raise on judge failure; caller
+    handles by reporting and exiting.
+    """
+    if not bundle.clusters:
+        return []
+
+    kb_description_block = ""
+    if bundle.kb_description and bundle.kb_description.strip():
+        kb_description_block = (
+            f"\n\nThe knowledge base is described as:\n{bundle.kb_description.strip()}"
+        )
+
+    total_docs = sum(c.doc_count for c in bundle.clusters)
+    n_clusters = len(bundle.clusters)
+    # Soft caps: 25% of docs, 33% of clusters; hard cap: target_max + 2
+    doc_cap = max(1, total_docs // 4)
+    cluster_cap = max(1, n_clusters // 3)
+    hard_cap = target_max + 2
+    system_prompt = _GROUP_AND_ASSIGN_SYSTEM_PROMPT_TEMPLATE.format(
+        n_clusters=n_clusters,
+        total_docs=total_docs,
+        target_min=target_min,
+        target_max=target_max,
+        doc_cap=doc_cap,
+        cluster_cap=cluster_cap,
+        hard_cap=hard_cap,
+        kb_description_block=kb_description_block,
+    )
+
+    cluster_lines: list[str] = []
+    for c in bundle.clusters:
+        title_lines = "\n".join(f"      - {t[:140]}" for t in c.sample_titles[:5])
+        descr = c.description or "(no description)"
+        cluster_lines.append(
+            f"Cluster {c.cluster_id} \"{c.name}\" ({c.doc_count} docs):\n"
+            f"  Description: {descr}\n"
+            f"  Sample titles:\n{title_lines}"
+        )
+    user_message = "\n\n".join(cluster_lines)
+
+    if print_prompt:
+        print("--- SYSTEM PROMPT ---", file=sys.stderr)
+        print(system_prompt, file=sys.stderr)
+        print("--- USER MESSAGE ---", file=sys.stderr)
+        print(user_message, file=sys.stderr)
+        print("---------------------", file=sys.stderr)
+
+    max_tokens = 600 + 80 * len(bundle.clusters)
+    logger.info(
+        "Calling LLM group-and-assign: %d clusters → %d-%d parents, max_tokens=%d",
+        len(bundle.clusters),
+        target_min,
+        target_max,
+        max_tokens,
+    )
+    t0 = time.monotonic()
+    async with httpx.AsyncClient(timeout=settings.taxonomy_classification_timeout) as client:
+        resp = await client.post(
+            f"{settings.litellm_url}/chat/completions",
+            headers={
+                "Authorization": f"Bearer {settings.litellm_api_key}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": settings.taxonomy_classification_model,
+                "messages": [
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_message},
+                ],
+                "temperature": 0.2,
+                "max_tokens": max_tokens,
+            },
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    latency = time.monotonic() - t0
+    logger.info("Group-and-assign call returned in %.2fs", latency)
+
+    content = (data["choices"][0]["message"]["content"] or "").strip()
+    if content.startswith("```"):
+        content = content.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
+    parsed = json.loads(content)
+    if not isinstance(parsed, dict) or "parents" not in parsed:
+        raise ValueError(f"Group response missing 'parents' key. Got: {content[:200]}")
+
+    parents_list = parsed["parents"]
+    if not isinstance(parents_list, list):
+        raise ValueError("'parents' is not a list")
+
+    valid_cids = {c.cluster_id for c in bundle.clusters}
+    parents: list[ParentCategory] = []
+    seen_cids: set[int] = set()
+    for item in parents_list:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name")
+        if not isinstance(name, str) or not name.strip():
+            logger.warning("Dropping parent without name: %r", item)
+            continue
+        rationale = item.get("rationale") or ""
+        if not isinstance(rationale, str):
+            rationale = str(rationale)
+        children_raw = item.get("child_cluster_ids", [])
+        if not isinstance(children_raw, list):
+            logger.warning("Parent %r has invalid child_cluster_ids: %r", name, children_raw)
+            children_raw = []
+        children: list[int] = []
+        for cid in children_raw:
+            if not isinstance(cid, int):
+                continue
+            if cid not in valid_cids:
+                logger.warning("Parent %r references unknown cluster %d", name, cid)
+                continue
+            if cid in seen_cids:
+                logger.warning("Cluster %d already assigned to another parent — skipping", cid)
+                continue
+            seen_cids.add(cid)
+            children.append(cid)
+        parents.append(
+            ParentCategory(name=name.strip(), rationale=rationale.strip(), child_cluster_ids=children)
+        )
+
+    unassigned = [cid for cid in valid_cids if cid not in seen_cids]
+    if unassigned:
+        logger.warning("LLM forgot to assign %d clusters — collecting as 'Overig'", len(unassigned))
+        parents.append(
+            ParentCategory(
+                name="Overig (niet door LLM toegewezen)",
+                rationale="Deze clusters werden door de LLM niet aan een parent toegewezen.",
+                child_cluster_ids=unassigned,
+            )
+        )
+
+    return parents
+
+
+async def _generate_parent_descriptions(
+    bundle: CacheBundle, parents: list[ParentCategory]
+) -> None:
+    """Populate parent.description in-place via generate_node_description.
+
+    Uses the SAME path as production new_node proposals so the integration
+    will be consistent with existing node descriptions.
+
+    For each parent: 2 titles per child (round-robin), capped at 10 total.
+    generate_node_description internally caps at 10 anyway.
+    """
+    logger.info("Generating descriptions for %d parents in parallel …", len(parents))
+
+    def _titles_for_parent(p: ParentCategory) -> list[str]:
+        per_child = max(2, 10 // max(1, len(p.child_cluster_ids)))
+        titles: list[str] = []
+        for cid in p.child_cluster_ids:
+            cluster = next((c for c in bundle.clusters if c.cluster_id == cid), None)
+            if cluster is None:
+                continue
+            titles.extend(cluster.sample_titles[:per_child])
+            if len(titles) >= 10:
+                break
+        return titles[:10]
+
+    desc_tasks = [
+        generate_node_description(p.name, None, _titles_for_parent(p)) for p in parents
+    ]
+    descriptions = await asyncio.gather(*desc_tasks, return_exceptions=True)
+    for p, desc in zip(parents, descriptions, strict=True):
+        if isinstance(desc, str):
+            p.description = desc
+        else:
+            logger.warning("Parent description failed for %r: %s", p.name, desc)
+            p.description = ""
+
+
+# ---------------------------------------------------------------------------
+# Pretty-print rapport.
+# ---------------------------------------------------------------------------
+
+
+def _print_rapport(
+    bundle: CacheBundle,
+    parents: list[ParentCategory],
+    target_min: int,
+    target_max: int,
+    cache_path: Path | None,
+) -> None:
+    print()
+    print("=== Bootstrap output ===")
+    print(f"KB:           {bundle.kb_slug} (org={bundle.org_id})")
+    print(f"Documents:    {bundle.documents_scanned}")
+    print(f"Outliers:     {bundle.outlier_count}")
+    print(f"Base clusters: {len(bundle.clusters)} (post-dedup)")
+    if bundle.kb_description:
+        print(f"KB description: {bundle.kb_description[:140]}{'…' if len(bundle.kb_description) > 140 else ''}")
+    print()
+    for c in bundle.clusters:
+        descr = c.description or "(no description)"
+        descr_short = descr[:120] + "…" if len(descr) > 120 else descr
+        print(f"  [#{c.cluster_id:>2}] {c.name:<55s} ({c.doc_count} docs)")
+        print(f"          {descr_short}")
+
+    print()
+    if not parents:
+        print("=== Group-and-assign ===")
+        print("  (no clusters to consolidate)")
+        return
+
+    print("=== Voorgestelde parent-categorieën ===")
+    print(f"Doel: {target_min}-{target_max} parents   Resultaat: {len(parents)} parents")
+    print()
+    for i, p in enumerate(parents, start=1):
+        children_str = ", ".join(f"#{cid}" for cid in p.child_cluster_ids)
+        total_docs = sum(_doccount_of(bundle, cid) for cid in p.child_cluster_ids)
+        print(f"  {i}. {p.name:<55s} ({len(p.child_cluster_ids)} clusters, {total_docs} docs)")
+        if p.description:
+            print(f"        Description: {p.description}")
+        if p.rationale:
+            print(f"        Rationale (debug): {p.rationale}")
+        print(f"        Children: {children_str}")
+        for cid in p.child_cluster_ids:
+            child_name = _name_of(bundle, cid)
+            print(f"          [#{cid:>2}] {child_name}")
+        print()
+
+    print("=== Samenvatting ===")
+    print(f"  {len(bundle.clusters)} → {len(parents)} categorieën")
+    if len(parents) < target_min:
+        print(f"  ! Onder doel-min ({target_min}). Mogelijk te grof gegroepeerd.")
+    elif len(parents) > target_max:
+        print(f"  ! Boven doel-max ({target_max}). Mogelijk te fijn gegroepeerd.")
+    else:
+        print(f"  OK: binnen doel-range {target_min}-{target_max}")
+
+    if cache_path is not None:
+        print()
+        print(f"Cache written: {cache_path}")
+        print(f"Replay: python -m knowledge_ingest.scripts.dry_run_merge_consolidate \\")
+        print(f"          --mode replay --from {cache_path}")
+
+
+def _name_of(bundle: CacheBundle, cluster_id: int) -> str:
+    for c in bundle.clusters:
+        if c.cluster_id == cluster_id:
+            return c.name
+    return f"cluster#{cluster_id}"
+
+
+def _doccount_of(bundle: CacheBundle, cluster_id: int) -> int:
+    for c in bundle.clusters:
+        if c.cluster_id == cluster_id:
+            return c.doc_count
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Cache I/O.
+# ---------------------------------------------------------------------------
+
+
+def _serialise_bundle(bundle: CacheBundle) -> dict:
+    return {
+        "kb_slug": bundle.kb_slug,
+        "org_id": bundle.org_id,
+        "kb_description": bundle.kb_description,
+        "documents_scanned": bundle.documents_scanned,
+        "outlier_count": bundle.outlier_count,
+        "clusters": [asdict(c) for c in bundle.clusters],
+    }
+
+
+def _deserialise_bundle(data: dict) -> CacheBundle:
+    return CacheBundle(
+        kb_slug=data["kb_slug"],
+        org_id=data["org_id"],
+        kb_description=data.get("kb_description", ""),
+        documents_scanned=data.get("documents_scanned", 0),
+        outlier_count=data.get("outlier_count", 0),
+        clusters=[
+            ClusterInfo(
+                cluster_id=c["cluster_id"],
+                name=c["name"],
+                description=c.get("description", ""),
+                doc_count=c["doc_count"],
+                sample_titles=c["sample_titles"],
+                centroid=c["centroid"],
+            )
+            for c in data["clusters"]
+        ],
+    )
+
+
+def _default_cache_path(kb_slug: str) -> Path:
+    ts = datetime.now(tz=timezone.utc).strftime("%Y%m%dT%H%M%S")
+    return Path("/tmp") / f"merge-consolidate-{kb_slug}-{ts}.json"
+
+
+# ---------------------------------------------------------------------------
+# Main.
+# ---------------------------------------------------------------------------
+
+
+async def amain(args: argparse.Namespace) -> int:
+    if args.target_min < 1 or args.target_max < args.target_min:
+        print("Invalid --target-min / --target-max range", file=sys.stderr)
+        return 1
+
+    if args.mode == "live":
+        if not args.org_id or not args.kb_slug:
+            print("--mode live requires --org-id and --kb-slug", file=sys.stderr)
+            return 1
+        if not settings.litellm_api_key:
+            print("LITELLM_API_KEY is not set — calls will fail. Aborting.", file=sys.stderr)
+            return 1
+        bundle = await _build_cache_live(args.org_id, args.kb_slug)
+        cache_path = Path(args.cache) if args.cache else _default_cache_path(args.kb_slug)
+        cache_path.write_text(json.dumps(_serialise_bundle(bundle), indent=2))
+    else:
+        if not args.from_path:
+            print("--mode replay requires --from <cache.json>", file=sys.stderr)
+            return 1
+        cache_path = Path(args.from_path)
+        if not cache_path.exists():
+            print(f"Cache file not found: {cache_path}", file=sys.stderr)
+            return 1
+        bundle = _deserialise_bundle(json.loads(cache_path.read_text()))
+        cache_path = None
+
+    if not bundle.clusters:
+        _print_rapport(bundle, [], args.target_min, args.target_max, cache_path)
+        return 0
+
+    try:
+        parents = await _group_and_assign(
+            bundle,
+            target_min=args.target_min,
+            target_max=args.target_max,
+            print_prompt=args.print_prompt,
+        )
+    except Exception as exc:
+        logger.exception("Group-and-assign call failed: %s", exc)
+        return 2
+
+    if parents:
+        await _generate_parent_descriptions(bundle, parents)
+
+    _print_rapport(bundle, parents, args.target_min, args.target_max, cache_path)
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Dry-run taxonomy consolidation (Clio-style top-down hierarchy).",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("--mode", choices=["live", "replay"], default="live")
+    parser.add_argument("--org-id", help="Zitadel org ID (live mode only)")
+    parser.add_argument("--kb-slug", help="KB slug (live mode only)")
+    parser.add_argument(
+        "--from",
+        dest="from_path",
+        help="Cache file to replay (replay mode only)",
+    )
+    parser.add_argument(
+        "--cache",
+        help="Path to write cache file (default: /tmp/merge-consolidate-<kb>-<ts>.json)",
+    )
+    parser.add_argument(
+        "--target-min",
+        type=int,
+        default=5,
+        help="Minimum desired number of parent categories (default: 5)",
+    )
+    parser.add_argument(
+        "--target-max",
+        type=int,
+        default=9,
+        help="Maximum desired number of parent categories (default: 9)",
+    )
+    parser.add_argument(
+        "--print-prompt",
+        action="store_true",
+        help="Print the full LLM prompt to stderr (debug)",
+    )
+    args = parser.parse_args()
+    return asyncio.run(amain(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/klai-knowledge-ingest/knowledge_ingest/scripts/dry_run_merge_consolidate.py
+++ b/klai-knowledge-ingest/knowledge_ingest/scripts/dry_run_merge_consolidate.py
@@ -33,6 +33,7 @@ Usage (replay):
         --mode replay --from /tmp/merge-consolidate-support-...json \\
         --target-min 5 --target-max 9
 """
+
 from __future__ import annotations
 
 import argparse
@@ -42,7 +43,7 @@ import logging
 import sys
 import time
 from dataclasses import asdict, dataclass, field
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -63,7 +64,7 @@ from knowledge_ingest.portal_client import (
     fetch_taxonomy_nodes,
 )
 from knowledge_ingest.proposal_generator import (
-    _NAMING_CRITERIA,
+    _MERGE_CONSOLIDATE_SYSTEM_PROMPT_TEMPLATE,
     DocumentSummary,
     _suggest_cluster_names_batched,
 )
@@ -77,63 +78,11 @@ logging.basicConfig(
 logger = logging.getLogger("dry_run_merge_consolidate")
 
 
-# ---------------------------------------------------------------------------
-# Group-and-assign prompt — Clio-style top-down hierarchy with percentage-
-# based balance caps that scale with the actual corpus.
-# ---------------------------------------------------------------------------
-
-_GROUP_AND_ASSIGN_SYSTEM_PROMPT_TEMPLATE = (
-    "You are a knowledge taxonomy assistant. You will see {n_clusters} "
-    "fine-grained document clusters from a knowledge base. Your job: "
-    "organise them into between {target_min} and {target_max} broader parent "
-    "categories suitable for browsing/navigation."
-    "{kb_description_block}"
-    "\n\nThis is information architecture, not classification. The target "
-    "count of {target_min}-{target_max} follows Miller's Law: more would "
-    "overwhelm a sidebar, fewer would lose meaningful distinctions."
-    "\n\n"
-    f"{_NAMING_CRITERIA}"
-    "\nAdditional rules for parent categories:\n"
-    "- Each parent category SHOULD encompass 1-5 base clusters that share an "
-    "  overarching theme.\n"
-    "- A parent category MAY contain a single base cluster if that cluster "
-    "  is genuinely distinct from all others — do not force-group unrelated "
-    "  things just to lower the count.\n"
-    "- Each base cluster MUST be assigned to exactly one parent category.\n"
-    "- Parent names follow the same naming criteria as base clusters: name "
-    "  the SHARED theme, not the most salient sub-item.\n"
-    "- DO NOT keep clusters separate solely because their base names differ — "
-    "  the base names came from a per-cluster naming step instructed to "
-    "  differentiate, so naming-disagreement is expected and not a signal "
-    "  that the clusters belong apart.\n"
-    "- Aim for {target_min}-{target_max} parents. If you genuinely cannot "
-    "  reach {target_max} without grouping unrelated things, fewer is OK. "
-    "  If staying under {target_max} forces you to lump unrelated topics "
-    "  together, slightly more is OK.\n"
-    "\nBalance constraints (avoid one over-large parent — these scale with "
-    "the actual corpus, not absolute numbers):\n"
-    "- Total documents across all base clusters: {total_docs}. "
-    "Total base clusters: {n_clusters}.\n"
-    "- Soft cap on parent size: a single parent SHOULD NOT hold more than "
-    "  ~25% of total documents (~{doc_cap} docs) OR more than ~33% of base "
-    "  clusters (~{cluster_cap} clusters). If EITHER threshold is "
-    "  exceeded, prefer to split that parent into more specific "
-    "  sub-themes.\n"
-    "- These caps are SOFT — quality of grouping outranks balance. If the "
-    "  only sensible split would mix unrelated themes (e.g. forcing a "
-    "  cohesive 'CRM' parent to split into arbitrary halves), keep it "
-    "  together and accept the imbalance. Bias toward splitting when an "
-    "  internal split-line is meaningful (configuration vs hardware vs "
-    "  network), bias toward keeping when no clean split exists.\n"
-    "- Aim for roughly balanced parent sizes — no one parent should "
-    "  dominate sidebar browsing.\n"
-    "- Splitting MAY push the parent count slightly above {target_max} — "
-    "  that's acceptable. Hard cap at {hard_cap} parents.\n"
-    "\nReply ONLY with JSON, no markdown:\n"
-    '{{"parents": [{{"name": "<parent name>", "rationale": "<why these '
-    'belong together, max 200 chars>", "child_cluster_ids": [<int>, ...]}}, '
-    "...]}}"
-)
+# Group-and-assign prompt is imported from proposal_generator
+# (single source of truth — bug fixes / tuning land in production prompt and
+# automatically apply here too). The prompt's format() variables are:
+#   n_clusters, total_docs, target_min, target_max, doc_cap, cluster_cap,
+#   hard_cap, kb_description_block.
 
 
 # ---------------------------------------------------------------------------
@@ -426,7 +375,7 @@ async def _group_and_assign(
     doc_cap = max(1, total_docs // 4)
     cluster_cap = max(1, n_clusters // 3)
     hard_cap = target_max + 2
-    system_prompt = _GROUP_AND_ASSIGN_SYSTEM_PROMPT_TEMPLATE.format(
+    system_prompt = _MERGE_CONSOLIDATE_SYSTEM_PROMPT_TEMPLATE.format(
         n_clusters=n_clusters,
         total_docs=total_docs,
         target_min=target_min,
@@ -442,7 +391,7 @@ async def _group_and_assign(
         title_lines = "\n".join(f"      - {t[:140]}" for t in c.sample_titles[:5])
         descr = c.description or "(no description)"
         cluster_lines.append(
-            f"Cluster {c.cluster_id} \"{c.name}\" ({c.doc_count} docs):\n"
+            f'Cluster {c.cluster_id} "{c.name}" ({c.doc_count} docs):\n'
             f"  Description: {descr}\n"
             f"  Sample titles:\n{title_lines}"
         )
@@ -527,7 +476,11 @@ async def _group_and_assign(
             seen_cids.add(cid)
             children.append(cid)
         parents.append(
-            ParentCategory(name=name.strip(), rationale=rationale.strip(), child_cluster_ids=children)
+            ParentCategory(
+                name=name.strip(),
+                rationale=rationale.strip(),
+                child_cluster_ids=children,
+            )
         )
 
     unassigned = [cid for cid in valid_cids if cid not in seen_cids]
@@ -544,9 +497,7 @@ async def _group_and_assign(
     return parents
 
 
-async def _generate_parent_descriptions(
-    bundle: CacheBundle, parents: list[ParentCategory]
-) -> None:
+async def _generate_parent_descriptions(bundle: CacheBundle, parents: list[ParentCategory]) -> None:
     """Populate parent.description in-place via generate_node_description.
 
     Uses the SAME path as production new_node proposals so the integration
@@ -569,9 +520,7 @@ async def _generate_parent_descriptions(
                 break
         return titles[:10]
 
-    desc_tasks = [
-        generate_node_description(p.name, None, _titles_for_parent(p)) for p in parents
-    ]
+    desc_tasks = [generate_node_description(p.name, None, _titles_for_parent(p)) for p in parents]
     descriptions = await asyncio.gather(*desc_tasks, return_exceptions=True)
     for p, desc in zip(parents, descriptions, strict=True):
         if isinstance(desc, str):
@@ -600,7 +549,9 @@ def _print_rapport(
     print(f"Outliers:     {bundle.outlier_count}")
     print(f"Base clusters: {len(bundle.clusters)} (post-dedup)")
     if bundle.kb_description:
-        print(f"KB description: {bundle.kb_description[:140]}{'…' if len(bundle.kb_description) > 140 else ''}")
+        kbdesc = bundle.kb_description
+        suffix = "…" if len(kbdesc) > 140 else ""
+        print(f"KB description: {kbdesc[:140]}{suffix}")
     print()
     for c in bundle.clusters:
         descr = c.description or "(no description)"
@@ -643,7 +594,7 @@ def _print_rapport(
     if cache_path is not None:
         print()
         print(f"Cache written: {cache_path}")
-        print(f"Replay: python -m knowledge_ingest.scripts.dry_run_merge_consolidate \\")
+        print("Replay: python -m knowledge_ingest.scripts.dry_run_merge_consolidate \\")
         print(f"          --mode replay --from {cache_path}")
 
 
@@ -699,8 +650,10 @@ def _deserialise_bundle(data: dict) -> CacheBundle:
 
 
 def _default_cache_path(kb_slug: str) -> Path:
-    ts = datetime.now(tz=timezone.utc).strftime("%Y%m%dT%H%M%S")
-    return Path("/tmp") / f"merge-consolidate-{kb_slug}-{ts}.json"
+    ts = datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%S")
+    # /tmp is intentional — script is operator-tool, runs inside container,
+    # cache is throwaway. Operator passes the path back via --from for replay.
+    return Path("/tmp") / f"merge-consolidate-{kb_slug}-{ts}.json"  # noqa: S108
 
 
 # ---------------------------------------------------------------------------

--- a/klai-knowledge-ingest/tests/test_taxonomy_v2_bootstrap.py
+++ b/klai-knowledge-ingest/tests/test_taxonomy_v2_bootstrap.py
@@ -14,6 +14,7 @@ import json
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import numpy as np
 import pytest
 
@@ -262,6 +263,9 @@ class TestBootstrapProposalsV2Integration:
         m.taxonomy_bootstrap_cluster_selection_method = "leaf"
         m.taxonomy_bootstrap_max_clusters = 20
         m.taxonomy_bootstrap_top_n_per_cluster = 8
+        m.taxonomy_consolidate_enabled = False  # base-path tests; new TestConsolidate enables
+        m.taxonomy_consolidate_target_min = 5
+        m.taxonomy_consolidate_target_max = 9
         return m
 
     @pytest.mark.asyncio
@@ -710,6 +714,9 @@ class TestBootstrapLatency:
         m.taxonomy_bootstrap_cluster_selection_method = "leaf"
         m.taxonomy_bootstrap_max_clusters = 20
         m.taxonomy_bootstrap_top_n_per_cluster = 8
+        m.taxonomy_consolidate_enabled = False  # base-path tests; new TestConsolidate enables
+        m.taxonomy_consolidate_target_min = 5
+        m.taxonomy_consolidate_target_max = 9
         return m
 
     @pytest.mark.asyncio
@@ -882,6 +889,9 @@ class TestDuplicatePreventionRegression:
         mock_settings.taxonomy_bootstrap_cluster_selection_method = "leaf"
         mock_settings.taxonomy_bootstrap_max_clusters = 20
         mock_settings.taxonomy_bootstrap_top_n_per_cluster = 8
+        mock_settings.taxonomy_consolidate_enabled = False  # base-path tests; new TestConsolidate enables
+        mock_settings.taxonomy_consolidate_target_min = 5
+        mock_settings.taxonomy_consolidate_target_max = 9
 
         embeddings, _ = _make_synthetic_embeddings()
         doc_summaries = _make_doc_summaries(len(embeddings))
@@ -1099,6 +1109,9 @@ class TestAC18IntegrationWithMockedLitellm:
         mock_settings.taxonomy_bootstrap_cluster_selection_method = "leaf"
         mock_settings.taxonomy_bootstrap_max_clusters = 20
         mock_settings.taxonomy_bootstrap_top_n_per_cluster = 8
+        mock_settings.taxonomy_consolidate_enabled = False  # base-path tests; new TestConsolidate enables
+        mock_settings.taxonomy_consolidate_target_min = 5
+        mock_settings.taxonomy_consolidate_target_max = 9
 
         call_count = {"n": 0}
         submitted_proposals = []
@@ -1177,6 +1190,9 @@ class TestAC19VoysRegressionNoNewDuplicates:
         mock_settings.taxonomy_bootstrap_cluster_selection_method = "leaf"
         mock_settings.taxonomy_bootstrap_max_clusters = 20
         mock_settings.taxonomy_bootstrap_top_n_per_cluster = 8
+        mock_settings.taxonomy_consolidate_enabled = False  # base-path tests; new TestConsolidate enables
+        mock_settings.taxonomy_consolidate_target_min = 5
+        mock_settings.taxonomy_consolidate_target_max = 9
 
         embeddings, _ = _make_synthetic_embeddings()
         doc_summaries = _make_doc_summaries(len(embeddings))
@@ -1327,3 +1343,390 @@ class TestFetchKbMetadata:
             result = await fetch_kb_metadata("test-kb", "org1")
 
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# SPEC-TAXONOMY-MERGE-DETECT-001 — Clio-style consolidation tests.
+# ---------------------------------------------------------------------------
+
+
+class TestConsolidate:
+    """Cover AC-12 through AC-17 of SPEC-TAXONOMY-MERGE-DETECT-001."""
+
+    @pytest.fixture
+    def base_proposals(self):
+        # 12 base clusters — above target_max=9 so consolidate triggers.
+        return [(i, f"Cluster {i} name") for i in range(12)]
+
+    @pytest.fixture
+    def cluster_doc_lists(self, base_proposals):
+        from knowledge_ingest.proposal_generator import DocumentSummary
+        return {
+            cid: [
+                DocumentSummary(title=f"Doc {cid}.{j}", content_preview=f"Content for cluster {cid} doc {j}" * 5)
+                for j in range(5)
+            ]
+            for cid, _name in base_proposals
+        }
+
+    @pytest.fixture
+    def cluster_map(self, base_proposals):
+        # Each base cluster owns 5 doc-indices into a shared embeddings array.
+        return {cid: list(range(cid * 5, (cid + 1) * 5)) for cid, _name in base_proposals}
+
+    @pytest.fixture
+    def document_embeddings(self, base_proposals):
+        # 12 clusters × 5 docs = 60 unit-norm vectors.
+        rng = np.random.RandomState(42)
+        embs = rng.randn(60, DIM).astype(np.float32)
+        embs = embs / np.linalg.norm(embs, axis=1, keepdims=True)
+        return embs
+
+    @pytest.fixture
+    def mock_consolidate_settings(self):
+        m = MagicMock()
+        m.portal_internal_token = "test-token"
+        m.litellm_url = "http://litellm:4000"
+        m.litellm_api_key = "key"
+        m.taxonomy_classification_model = "klai-fast"
+        m.taxonomy_classification_timeout = 30.0
+        m.taxonomy_bootstrap_min_cluster_size_floor = 3
+        m.taxonomy_bootstrap_cluster_selection_method = "leaf"
+        m.taxonomy_bootstrap_max_clusters = 20
+        m.taxonomy_bootstrap_top_n_per_cluster = 8
+        m.taxonomy_consolidate_enabled = True
+        m.taxonomy_consolidate_target_min = 5
+        m.taxonomy_consolidate_target_max = 9
+        return m
+
+    def _mock_llm_judgment_response(self, parents_payload):
+        """Build a fake LiteLLM HTTP 200 chat-completion response containing the
+        given parents payload as the assistant message JSON content."""
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.raise_for_status = MagicMock()
+        resp.json = MagicMock(return_value={
+            "choices": [{"message": {"content": json.dumps({"parents": parents_payload})}}]
+        })
+        return resp
+
+    @pytest.mark.asyncio
+    async def test_ac12_valid_response_produces_correct_aggregations(
+        self, base_proposals, cluster_doc_lists, cluster_map, document_embeddings, mock_consolidate_settings
+    ):
+        """AC-12: Valid LLM response → ParentCategory list with correct aggregated
+        document_count, child_cluster_ids, sample_titles, child_cluster_names."""
+        from knowledge_ingest.proposal_generator import _consolidate_to_parents
+
+        # 3 parents grouping the 12 base clusters: [0,1,2,3], [4,5,6,7], [8,9,10,11]
+        parents_payload = [
+            {"name": "Group A", "rationale": "first four", "child_cluster_ids": [0, 1, 2, 3]},
+            {"name": "Group B", "rationale": "second four", "child_cluster_ids": [4, 5, 6, 7]},
+            {"name": "Group C", "rationale": "last four", "child_cluster_ids": [8, 9, 10, 11]},
+        ]
+
+        # Mock generate_node_description to return predictable strings
+        async def fake_desc(name, parent, titles):
+            return f"Description for {name}"
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.post = AsyncMock(return_value=self._mock_llm_judgment_response(parents_payload))
+
+        with (
+            patch("knowledge_ingest.proposal_generator.settings", mock_consolidate_settings),
+            patch("knowledge_ingest.proposal_generator.httpx.AsyncClient", return_value=mock_client),
+            patch("knowledge_ingest.proposal_generator.generate_node_description", side_effect=fake_desc),
+        ):
+            parents = await _consolidate_to_parents(
+                base_proposals=base_proposals,
+                cluster_doc_lists=cluster_doc_lists,
+                cluster_map=cluster_map,
+                document_embeddings=document_embeddings,
+                kb_description="Test KB",
+                target_min=5,
+                target_max=9,
+            )
+
+        assert len(parents) == 3
+        assert all(p.document_count == 20 for p in parents)  # 4 children × 5 docs
+        # Child cluster names propagated
+        assert parents[0].child_cluster_names == [
+            "Cluster 0 name", "Cluster 1 name", "Cluster 2 name", "Cluster 3 name"
+        ]
+        # Sample titles cap at 10
+        for p in parents:
+            assert len(p.sample_titles) <= 10
+        # Centroid present and unit-normalised
+        for p in parents:
+            assert p.centroid is not None
+            assert abs(np.linalg.norm(np.array(p.centroid)) - 1.0) < 1e-5
+        # Description set via mocked generate_node_description
+        assert parents[0].description == "Description for Group A"
+
+    @pytest.mark.asyncio
+    async def test_ac13_malformed_response_raises(
+        self, base_proposals, cluster_doc_lists, cluster_map, document_embeddings, mock_consolidate_settings
+    ):
+        """AC-13: Malformed LLM response (missing 'parents' key) → ValueError."""
+        from knowledge_ingest.proposal_generator import _consolidate_to_parents
+
+        bad_resp = MagicMock()
+        bad_resp.status_code = 200
+        bad_resp.raise_for_status = MagicMock()
+        bad_resp.json = MagicMock(return_value={
+            "choices": [{"message": {"content": json.dumps({"oops": "no parents key"})}}]
+        })
+
+        async def fake_desc(name, parent, titles):
+            return ""
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.post = AsyncMock(return_value=bad_resp)
+
+        with (
+            patch("knowledge_ingest.proposal_generator.settings", mock_consolidate_settings),
+            patch("knowledge_ingest.proposal_generator.httpx.AsyncClient", return_value=mock_client),
+            patch("knowledge_ingest.proposal_generator.generate_node_description", side_effect=fake_desc),
+        ):
+            with pytest.raises(ValueError, match="parents"):
+                await _consolidate_to_parents(
+                    base_proposals=base_proposals,
+                    cluster_doc_lists=cluster_doc_lists,
+                    cluster_map=cluster_map,
+                    document_embeddings=document_embeddings,
+                    kb_description="",
+                    target_min=5,
+                    target_max=9,
+                )
+
+    @pytest.mark.asyncio
+    async def test_ac14_unassigned_clusters_collected_under_overig(
+        self, base_proposals, cluster_doc_lists, cluster_map, document_embeddings, mock_consolidate_settings
+    ):
+        """AC-14: LLM assigns only some clusters → unassigned go under 'Overig' parent."""
+        from knowledge_ingest.proposal_generator import _consolidate_to_parents
+
+        # LLM only assigns 6 of the 12 clusters; the other 6 should land in Overig.
+        parents_payload = [
+            {"name": "Group A", "rationale": "first three", "child_cluster_ids": [0, 1, 2]},
+            {"name": "Group B", "rationale": "next three", "child_cluster_ids": [3, 4, 5]},
+        ]
+
+        async def fake_desc(name, parent, titles):
+            return f"Description for {name}"
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.post = AsyncMock(return_value=self._mock_llm_judgment_response(parents_payload))
+
+        with (
+            patch("knowledge_ingest.proposal_generator.settings", mock_consolidate_settings),
+            patch("knowledge_ingest.proposal_generator.httpx.AsyncClient", return_value=mock_client),
+            patch("knowledge_ingest.proposal_generator.generate_node_description", side_effect=fake_desc),
+        ):
+            parents = await _consolidate_to_parents(
+                base_proposals=base_proposals,
+                cluster_doc_lists=cluster_doc_lists,
+                cluster_map=cluster_map,
+                document_embeddings=document_embeddings,
+                kb_description="",
+                target_min=5,
+                target_max=9,
+            )
+
+        assert len(parents) == 3  # 2 LLM-proposed + 1 Overig
+        overig = [p for p in parents if p.name == "Overig"]
+        assert len(overig) == 1
+        assert sorted(overig[0].child_cluster_ids) == [6, 7, 8, 9, 10, 11]
+
+    @pytest.mark.asyncio
+    async def test_ac15_balance_caps_present_in_prompt(
+        self, base_proposals, cluster_doc_lists, cluster_map, document_embeddings, mock_consolidate_settings
+    ):
+        """AC-15 (proxy): the prompt sent to the LLM includes percentage-based
+        balance caps + total_docs + total_clusters context."""
+        from knowledge_ingest.proposal_generator import _consolidate_to_parents
+
+        parents_payload = [
+            {"name": "All", "rationale": "everything", "child_cluster_ids": list(range(12))},
+        ]
+        captured_system_prompt = {}
+
+        async def fake_desc(name, parent, titles):
+            return ""
+
+        async def fake_post(url, headers, json):
+            captured_system_prompt["text"] = json["messages"][0]["content"]
+            return self._mock_llm_judgment_response(parents_payload)
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.post = AsyncMock(side_effect=fake_post)
+
+        with (
+            patch("knowledge_ingest.proposal_generator.settings", mock_consolidate_settings),
+            patch("knowledge_ingest.proposal_generator.httpx.AsyncClient", return_value=mock_client),
+            patch("knowledge_ingest.proposal_generator.generate_node_description", side_effect=fake_desc),
+        ):
+            await _consolidate_to_parents(
+                base_proposals=base_proposals,
+                cluster_doc_lists=cluster_doc_lists,
+                cluster_map=cluster_map,
+                document_embeddings=document_embeddings,
+                kb_description="",
+                target_min=5,
+                target_max=9,
+            )
+
+        prompt = captured_system_prompt["text"]
+        # Total docs = 12 clusters × 5 = 60 → doc_cap = 60 // 4 = 15
+        assert "60" in prompt  # total docs
+        assert "12" in prompt  # n_clusters
+        assert "15" in prompt or "~15" in prompt  # doc_cap
+        assert "4" in prompt  # cluster_cap = 12 // 3 = 4
+        assert "Miller" in prompt
+        assert "25%" in prompt
+        assert "33%" in prompt
+
+    @pytest.mark.asyncio
+    async def test_ac16_skip_when_below_target_max(self, mock_consolidate_settings):
+        """AC-2/AC-16: When proposals_to_submit count <= target_max, consolidate is NOT called.
+
+        Verified by hooking into _consolidate_to_parents and asserting it never runs."""
+        from unittest.mock import patch as _patch
+
+        from knowledge_ingest.proposal_generator import generate_bootstrap_proposals_v2, DocumentSummary
+
+        # Build a fixture that yields exactly 4 base clusters (well under target_max=9)
+        # using the existing pipeline. We mock the naming step to return distinct names,
+        # which skips per-cluster fallback and leaves us with exactly 4 clusters.
+        rng = np.random.RandomState(42)
+        # 60 docs across 4 well-separated synthetic clusters
+        embs_list = []
+        for cluster_idx in range(4):
+            cluster_center = np.zeros(DIM)
+            cluster_center[cluster_idx * 64] = 1.0
+            for _ in range(15):
+                vec = cluster_center + rng.randn(DIM).astype(np.float32) * 0.05
+                vec = vec / np.linalg.norm(vec)
+                embs_list.append(vec)
+        embeddings = np.array(embs_list, dtype=np.float32)
+        doc_summaries = [
+            DocumentSummary(title=f"doc {i}", content_preview=f"content sufficiently long {i}" * 5)
+            for i in range(60)
+        ]
+
+        consolidate_called = {"value": False}
+        async def fake_consolidate(*args, **kwargs):
+            consolidate_called["value"] = True
+            return []
+
+        async def fake_naming(cluster_doc_lists, kb_description):
+            # Return one distinct name per cluster_id present
+            return {cid: f"Test Name {cid}" for cid in cluster_doc_lists}
+
+        async def fake_desc(name, parent, titles):
+            return f"description for {name}"
+
+        async def fake_submit(kb_slug, org_id, proposal):
+            return None
+
+        async def fake_fetch_meta(kb_slug, org_id):
+            return {"description": ""}
+
+        with (
+            _patch("knowledge_ingest.proposal_generator.settings", mock_consolidate_settings),
+            _patch("knowledge_ingest.proposal_generator._consolidate_to_parents", side_effect=fake_consolidate),
+            _patch("knowledge_ingest.proposal_generator._suggest_cluster_names_batched", side_effect=fake_naming),
+            _patch("knowledge_ingest.proposal_generator.generate_node_description", side_effect=fake_desc),
+            _patch("knowledge_ingest.proposal_generator.submit_taxonomy_proposal", side_effect=fake_submit),
+        ):
+            result = await generate_bootstrap_proposals_v2(
+                org_id="o",
+                kb_slug="k",
+                document_summaries=doc_summaries,
+                document_embeddings=embeddings,
+                existing_nodes=[],
+                kb_description="",
+            )
+
+        assert consolidate_called["value"] is False, (
+            "Consolidate should NOT run when base count <= target_max"
+        )
+        # Should have submitted N proposals (where N = clusters HDBSCAN found, ≤ 4)
+        assert result.proposals_submitted >= 1
+        assert result.base_clusters_found == result.proposals_submitted
+        assert result.clusters_found == result.proposals_submitted
+
+    @pytest.mark.asyncio
+    async def test_ac17_consolidate_failure_falls_back_to_base(self, mock_consolidate_settings):
+        """AC-5/AC-17: When _consolidate_to_parents raises, bootstrap completes
+        successfully with base clusters submitted (not parents)."""
+        from unittest.mock import patch as _patch
+
+        from knowledge_ingest.proposal_generator import generate_bootstrap_proposals_v2, DocumentSummary
+
+        # Build a fixture with > target_max=9 base clusters so consolidate WOULD trigger.
+        # 12 well-separated clusters × 5 docs = 60 docs.
+        rng = np.random.RandomState(7)
+        embs_list = []
+        for cluster_idx in range(12):
+            cluster_center = np.zeros(DIM)
+            cluster_center[cluster_idx * 8] = 1.0
+            for _ in range(5):
+                vec = cluster_center + rng.randn(DIM).astype(np.float32) * 0.02
+                vec = vec / np.linalg.norm(vec)
+                embs_list.append(vec)
+        embeddings = np.array(embs_list, dtype=np.float32)
+        doc_summaries = [
+            DocumentSummary(title=f"doc {i}", content_preview=f"content for doc {i} long enough" * 3)
+            for i in range(60)
+        ]
+
+        async def fake_naming(cluster_doc_lists, kb_description):
+            return {cid: f"Cluster {cid}" for cid in cluster_doc_lists}
+
+        async def fake_consolidate_fail(*args, **kwargs):
+            raise httpx.ConnectError("simulated LLM failure")
+
+        async def fake_desc(name, parent, titles):
+            return f"description for {name}"
+
+        submitted_proposals = []
+        async def fake_submit(kb_slug, org_id, proposal):
+            submitted_proposals.append(proposal)
+
+        # Use loose patching with side_effect for description so _consolidate_to_parents
+        # internal description call also routes through fake. But since we patch
+        # _consolidate_to_parents itself, its internals don't run — fake_desc only
+        # serves the base-path fallback.
+        with (
+            _patch("knowledge_ingest.proposal_generator.settings", mock_consolidate_settings),
+            _patch("knowledge_ingest.proposal_generator._consolidate_to_parents", side_effect=fake_consolidate_fail),
+            _patch("knowledge_ingest.proposal_generator._suggest_cluster_names_batched", side_effect=fake_naming),
+            _patch("knowledge_ingest.proposal_generator.generate_node_description", side_effect=fake_desc),
+            _patch("knowledge_ingest.proposal_generator.submit_taxonomy_proposal", side_effect=fake_submit),
+        ):
+            result = await generate_bootstrap_proposals_v2(
+                org_id="o",
+                kb_slug="k",
+                document_summaries=doc_summaries,
+                document_embeddings=embeddings,
+                existing_nodes=[],
+                kb_description="",
+            )
+
+        # Bootstrap completed successfully despite the consolidate failure
+        assert result.proposals_submitted > 0
+        # base_clusters_found > target_max (consolidate was attempted)
+        assert result.base_clusters_found > mock_consolidate_settings.taxonomy_consolidate_target_max
+        # clusters_found == base_clusters_found (consolidate fell back)
+        assert result.clusters_found == result.base_clusters_found
+        # Submitted proposals are base clusters (no child_cluster_names set)
+        assert all(p.child_cluster_names is None for p in submitted_proposals)


### PR DESCRIPTION
## Summary

After HDBSCAN+naming produces N base clusters, when N exceeds the IA browsing target (default 9), call a Clio-style group-and-assign LLM step that consolidates them into 5-9 broader parent categories. Operator sees only the consolidated set in the existing portal proposals UI — no extra knop, no extra click.

Validated on Voys/support (440 docs) via the dry-run script in 4 iterations: **15 base clusters → 7-8 parents** within target, parent descriptions production-quality.

## What changes

- `proposal_generator.py`: new `ParentCategory` dataclass, `_MERGE_CONSOLIDATE_SYSTEM_PROMPT_TEMPLATE`, `_consolidate_to_parents` helper, Step 7.5 in `generate_bootstrap_proposals_v2` with skip-when-small + LLM-failure-fallback
- `portal_client.py`: `TaxonomyProposal` gains optional `child_cluster_names` field for operator transparency
- `config.py`: `taxonomy_consolidate_enabled` (kill-switch), `taxonomy_consolidate_target_min/max`
- `routes/taxonomy.py`: `BootstrapResponse` adds `base_clusters_found`
- `scripts/dry_run_merge_consolidate.py`: refactored to import prompt from `proposal_generator` (single source of truth)
- `tests/`: 6 new tests in `TestConsolidate` covering AC-12 through AC-17

No DB migration. No frontend changes. No new endpoints.

## Validated results (Voys/support)

| Iteration | Approach | Result |
|---|---|---|
| v0.2 | Pairwise centroid similarity + per-pair LLM judge | 15 → 13 (too conservative) |
| v0.3 | Clio top-down group-and-assign | 15 → 7 (one parent had 7 children, 30% docs) |
| v0.4 | + percentage-based balance caps | 15 → 7, largest parent 17% docs |
| v0.5 | + per-parent descriptions via `generate_node_description` | 15 → 8, descriptions production-quality |

## Test plan

- [x] 39/39 unit + integration tests pass (33 existing v2 + 6 new TestConsolidate)
- [x] `ruff check` clean on all touched production files
- [x] `ruff format --check` clean
- [ ] Smoke-test on `getklai/voys-help-notion` (14 already-approved nodes) — expect 0 new proposals (all dedup-filtered before consolidate)
- [ ] Smoke-test on `voys/support` post-deploy — expect ~7-8 parent proposals (was 15 base)
- [ ] Monitor `bootstrap_consolidate_complete` event in VictoriaLogs over 1 week (distribution of `parents` count, `largest_parent_doc_pct`, `bootstrap_consolidate_failed` rate)

## Rollback

Set `TAXONOMY_CONSOLIDATE_ENABLED=False` in env, container restart. Bootstrap reverts to submitting base clusters within 30s.

## SPEC

[SPEC-TAXONOMY-MERGE-DETECT-001 v1.0.0](.moai/specs/SPEC-TAXONOMY-MERGE-DETECT-001/spec.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)