### PR TITLE
fix(rag): cleanup of SPEC-RAG-LOW-CONFIDENCE-ABSTAIN-001 follow-up gaps

### DIFF
--- a/deploy/grafana/provisioning/dashboards/rag-quality.json
+++ b/deploy/grafana/provisioning/dashboards/rag-quality.json
@@ -322,8 +322,8 @@
                         "type": "prometheus",
                         "uid": "victoriametrics"
                     },
-                    "expr": "sum by (reason) (rate(litellm_low_confidence_injection_total{org_id=\"$org_id\"}[$__rate_interval]))",
-                    "legendFormat": "{{reason}}",
+                    "expr": "sum(rate(retrieval_confidence_band_total{band=~\"low|unknown\",org_id=\"$org_id\"}[$__rate_interval])) / sum(rate(retrieval_confidence_band_total{org_id=\"$org_id\"}[$__rate_interval]))",
+                    "legendFormat": "low+unknown share",
                     "refId": "C"
                 }
             ]

--- a/klai-retrieval-api/tests/test_api.py
+++ b/klai-retrieval-api/tests/test_api.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
 
 class TestRetrieveEndpoint:
     def test_retrieve_scope_personal_without_user_id(self, client):
@@ -119,6 +121,10 @@ class TestRetrieveEndpoint:
             mock_settings.source_quota_enabled = True
             mock_settings.source_quota_max_per_source = 2
             mock_settings.router_enabled = False
+            # SPEC-INGEST-LOGIN-WALL-DETECT-001 REQ-07: pre-existing mock gap
+            # — fixture didn't set this, so quality_floor compared a real
+            # float to a MagicMock and crashed. Locked in by the cleanup PR.
+            mock_settings.retrieval_quality_floor = 0.05
             # SPEC-RAG-LOW-CONFIDENCE-ABSTAIN-001 REQ-1 / REQ-3
             mock_settings.confidence_band_high_threshold = 0.60
             mock_settings.confidence_band_low_threshold = 0.30
@@ -134,6 +140,230 @@ class TestRetrieveEndpoint:
         assert data["chunks"][0]["reranker_score"] == 0.95
         assert data["metadata"]["candidates_retrieved"] == 1
         assert data["metadata"]["retrieval_ms"] > 0
+        # SPEC-RAG-LOW-CONFIDENCE-ABSTAIN-001 REQ-1: confidence_band must
+        # be present on every retrieval-path response. reranker_score=0.95
+        # ≥ high_threshold=0.60 → 'high'.
+        assert data["confidence_band"] == "high", (
+            f"reranker_score=0.95 should map to 'high', got {data.get('confidence_band')!r}"
+        )
+
+
+class TestConfidenceBandEndToEnd:
+    """SPEC-RAG-LOW-CONFIDENCE-ABSTAIN-001 REQ-1: confidence_band emit
+    through the full /retrieve pipeline (helper tests in
+    test_confidence_band.py cover the pure function in isolation).
+
+    These tests verify the band lands correctly on the response after
+    rerank → quality-floor → source-aware-select → quality-boost — i.e.
+    that the wiring in retrieve.py picks up the right ``serving`` list.
+    """
+
+    @pytest.mark.parametrize(
+        ("rerank_score", "expected_band"),
+        [
+            (0.95, "high"),  # well above 0.60
+            (0.45, "medium"),  # between thresholds
+            (0.18, "low"),  # the 2026-05-07 Voys-Salesforce incident score
+        ],
+    )
+    def test_band_lands_on_response(
+        self, client, sample_retrieve_request, rerank_score, expected_band
+    ):
+        """End-to-end: synthetic /retrieve with controlled reranker_score
+        produces the expected confidence_band on the response.
+
+        Locks in the wiring contract: future refactors of retrieve.py
+        that move the band-emit point or change the input list to
+        ``_compute_confidence_band`` are caught here.
+        """
+        chunk_payload = {
+            "chunk_id": "c1",
+            "text": "Some text",
+            "score": 0.9,
+            "artifact_id": "a1",
+            "content_type": "policy",
+            "context_prefix": "Doc: ",
+            "scope": "org",
+            "valid_at": None,
+            "invalid_at": None,
+            "ingested_at": None,
+            "assertion_mode": None,
+        }
+        with (
+            patch(
+                "retrieval_api.api.retrieve.coreference.resolve",
+                new_callable=AsyncMock,
+                return_value=sample_retrieve_request["query"],
+            ),
+            patch(
+                "retrieval_api.api.retrieve.embed_single",
+                new_callable=AsyncMock,
+                return_value=[0.1] * 1024,
+            ),
+            patch(
+                "retrieval_api.api.retrieve.embed_sparse",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "retrieval_api.api.retrieve.gate.should_bypass",
+                new_callable=AsyncMock,
+                return_value=(False, 0.05),
+            ),
+            patch(
+                "retrieval_api.api.retrieve.search.hybrid_search",
+                new_callable=AsyncMock,
+                return_value=[chunk_payload],
+            ),
+            patch(
+                "retrieval_api.api.retrieve.reranker.rerank",
+                new_callable=AsyncMock,
+                return_value=[{**chunk_payload, "reranker_score": rerank_score}],
+            ),
+            patch("retrieval_api.api.retrieve.settings") as mock_settings,
+        ):
+            mock_settings.reranker_enabled = True
+            mock_settings.retrieval_candidates = 60
+            mock_settings.reranker_candidates = 20
+            mock_settings.graphiti_enabled = False
+            mock_settings.link_expand_enabled = True
+            mock_settings.link_expand_seed_k = 10
+            mock_settings.link_expand_max_urls = 30
+            mock_settings.link_expand_candidates = 20
+            mock_settings.link_authority_boost = 0.05
+            mock_settings.source_quota_enabled = True
+            mock_settings.source_quota_max_per_source = 2
+            mock_settings.router_enabled = False
+            mock_settings.retrieval_quality_floor = 0.05
+            mock_settings.confidence_band_high_threshold = 0.60
+            mock_settings.confidence_band_low_threshold = 0.30
+            mock_settings.link_expand_score_boost = 1.00
+            resp = client.post("/retrieve", json=sample_retrieve_request)
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["confidence_band"] == expected_band, (
+            f"rerank={rerank_score} expected {expected_band}, got {data.get('confidence_band')!r}"
+        )
+
+    def test_band_unknown_when_reranker_disabled(self, client, sample_retrieve_request):
+        """When reranker is disabled the served list still has chunks, but
+        none of them have a meaningful reranker_score — band must be
+        ``unknown`` so the litellm-hook falls through to the safety
+        injection rather than trusting raw qdrant scores.
+        """
+        chunk_payload = {
+            "chunk_id": "c1",
+            "text": "Some text",
+            "score": 0.9,
+            "artifact_id": "a1",
+            "content_type": "policy",
+            "context_prefix": "Doc: ",
+            "scope": "org",
+            "valid_at": None,
+            "invalid_at": None,
+            "ingested_at": None,
+            "assertion_mode": None,
+        }
+        with (
+            patch(
+                "retrieval_api.api.retrieve.coreference.resolve",
+                new_callable=AsyncMock,
+                return_value=sample_retrieve_request["query"],
+            ),
+            patch(
+                "retrieval_api.api.retrieve.embed_single",
+                new_callable=AsyncMock,
+                return_value=[0.1] * 1024,
+            ),
+            patch(
+                "retrieval_api.api.retrieve.embed_sparse",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "retrieval_api.api.retrieve.gate.should_bypass",
+                new_callable=AsyncMock,
+                return_value=(False, 0.05),
+            ),
+            patch(
+                "retrieval_api.api.retrieve.search.hybrid_search",
+                new_callable=AsyncMock,
+                return_value=[chunk_payload],
+            ),
+            patch("retrieval_api.api.retrieve.settings") as mock_settings,
+        ):
+            mock_settings.reranker_enabled = False  # the difference
+            mock_settings.retrieval_candidates = 60
+            mock_settings.reranker_candidates = 20
+            mock_settings.graphiti_enabled = False
+            mock_settings.link_expand_enabled = True
+            mock_settings.link_expand_seed_k = 10
+            mock_settings.link_expand_max_urls = 30
+            mock_settings.link_expand_candidates = 20
+            mock_settings.link_authority_boost = 0.05
+            mock_settings.source_quota_enabled = True
+            mock_settings.source_quota_max_per_source = 2
+            mock_settings.router_enabled = False
+            mock_settings.retrieval_quality_floor = 0.05
+            mock_settings.confidence_band_high_threshold = 0.60
+            mock_settings.confidence_band_low_threshold = 0.30
+            mock_settings.link_expand_score_boost = 1.00
+            resp = client.post("/retrieve", json=sample_retrieve_request)
+
+        assert resp.status_code == 200
+        assert resp.json()["confidence_band"] == "unknown"
+
+    def test_band_none_on_bypass(self, client, sample_retrieve_request):
+        """Gate-bypassed retrieval (smalltalk / out-of-scope query) does
+        not run rerank, so band is ``None`` (not ``unknown``). The hook
+        treats None as "no signal — leave injection untouched".
+        """
+        with (
+            patch(
+                "retrieval_api.api.retrieve.coreference.resolve",
+                new_callable=AsyncMock,
+                return_value=sample_retrieve_request["query"],
+            ),
+            patch(
+                "retrieval_api.api.retrieve.embed_single",
+                new_callable=AsyncMock,
+                return_value=[0.1] * 1024,
+            ),
+            patch(
+                "retrieval_api.api.retrieve.embed_sparse",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "retrieval_api.api.retrieve.gate.should_bypass",
+                new_callable=AsyncMock,
+                return_value=(True, 0.5),  # gate bypasses retrieval
+            ),
+            patch("retrieval_api.api.retrieve.settings") as mock_settings,
+        ):
+            mock_settings.reranker_enabled = True
+            mock_settings.retrieval_candidates = 60
+            mock_settings.reranker_candidates = 20
+            mock_settings.graphiti_enabled = False
+            mock_settings.link_expand_enabled = True
+            mock_settings.link_expand_seed_k = 10
+            mock_settings.link_expand_max_urls = 30
+            mock_settings.link_expand_candidates = 20
+            mock_settings.link_authority_boost = 0.05
+            mock_settings.source_quota_enabled = True
+            mock_settings.source_quota_max_per_source = 2
+            mock_settings.router_enabled = False
+            mock_settings.retrieval_quality_floor = 0.05
+            mock_settings.confidence_band_high_threshold = 0.60
+            mock_settings.confidence_band_low_threshold = 0.30
+            mock_settings.link_expand_score_boost = 1.00
+            resp = client.post("/retrieve", json=sample_retrieve_request)
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["retrieval_bypassed"] is True
+        assert data["confidence_band"] is None
 
 
 class TestGraphMetadata:
@@ -184,6 +414,10 @@ class TestGraphMetadata:
             mock_settings.source_quota_enabled = True
             mock_settings.source_quota_max_per_source = 2
             mock_settings.router_enabled = False
+            # SPEC-INGEST-LOGIN-WALL-DETECT-001 REQ-07: pre-existing mock gap
+            # — fixture didn't set this, so quality_floor compared a real
+            # float to a MagicMock and crashed. Locked in by the cleanup PR.
+            mock_settings.retrieval_quality_floor = 0.05
             # SPEC-RAG-LOW-CONFIDENCE-ABSTAIN-001 REQ-1 / REQ-3
             mock_settings.confidence_band_high_threshold = 0.60
             mock_settings.confidence_band_low_threshold = 0.30
@@ -298,6 +532,10 @@ class TestLinkExpandInstrumentation:
             mock_settings.source_quota_enabled = True
             mock_settings.source_quota_max_per_source = 2
             mock_settings.router_enabled = False
+            # SPEC-INGEST-LOGIN-WALL-DETECT-001 REQ-07: pre-existing mock gap
+            # — fixture didn't set this, so quality_floor compared a real
+            # float to a MagicMock and crashed. Locked in by the cleanup PR.
+            mock_settings.retrieval_quality_floor = 0.05
             # SPEC-RAG-LOW-CONFIDENCE-ABSTAIN-001 REQ-1 / REQ-3
             mock_settings.confidence_band_high_threshold = 0.60
             mock_settings.confidence_band_low_threshold = 0.30
@@ -365,6 +603,10 @@ class TestLinkExpandInstrumentation:
             mock_settings.source_quota_enabled = True
             mock_settings.source_quota_max_per_source = 2
             mock_settings.router_enabled = False
+            # SPEC-INGEST-LOGIN-WALL-DETECT-001 REQ-07: pre-existing mock gap
+            # — fixture didn't set this, so quality_floor compared a real
+            # float to a MagicMock and crashed. Locked in by the cleanup PR.
+            mock_settings.retrieval_quality_floor = 0.05
             # SPEC-RAG-LOW-CONFIDENCE-ABSTAIN-001 REQ-1 / REQ-3
             mock_settings.confidence_band_high_threshold = 0.60
             mock_settings.confidence_band_low_threshold = 0.30


### PR DESCRIPTION
## Summary

Three concrete fixes that surfaced during post-merge self-review of #516:

1. **Grafana panel third series was dead-by-deploy** — fixed PromQL.
2. **`test_retrieve_happy_path` + 1 sibling were red on main** — fixed the pre-existing mock-setup gap.
3. **`confidence_band` had no end-to-end coverage** — added 5 integration tests.

## What changes

### Grafana panel (`deploy/grafana/provisioning/dashboards/rag-quality.json`)

The `Low-Confidence` panel's third series was querying
`litellm_low_confidence_injection_total`, a Prometheus counter that
**does not exist** (the litellm-hook does not depend on
`prometheus_client`; injection visibility lives in VictoriaLogs as the
structured event `low_confidence_injection_applied`).

Replaced with:

```promql
sum(rate(retrieval_confidence_band_total{band=~"low|unknown",org_id="$org_id"}[$__rate_interval]))
/
sum(rate(retrieval_confidence_band_total{org_id="$org_id"}[$__rate_interval]))
```

Same operational signal (share of requests where the safety injection
fires) using the counter that DOES exist from REQ-8 of the parent SPEC.
Plus this is now the exact expression the alert rule evaluates against,
so the panel and alert are visually aligned.

### test_api.py mock_settings completeness

Added `mock_settings.retrieval_quality_floor = 0.05` to all four
`mock_settings` blocks. The pre-existing failure was: SPEC-INGEST-LOGIN-WALL-DETECT-001
REQ-07 added the quality-floor pass to `retrieve.py` but never updated
the test fixture. Result: `qs < floor` compared a real float to a
`MagicMock` and crashed. Fixed in passing now that the parent SPEC's
PR brought confidence_band/boost mocks to the same blocks.

### End-to-end `confidence_band` integration test

New class `TestConfidenceBandEndToEnd` with 5 tests:

- `test_band_lands_on_response[0.95→high]` — top of the band range
- `test_band_lands_on_response[0.45→medium]` — between thresholds
- `test_band_lands_on_response[0.18→low]` — the 2026-05-07 Voys-Salesforce
  incident score; locks in that future threshold tuning that moves 0.18
  out of `low` is caught here
- `test_band_unknown_when_reranker_disabled` — fallback path
- `test_band_none_on_bypass` — gate bypassed → no band emit

Plus `test_retrieve_happy_path` now asserts on `data["confidence_band"]`.

## Test results

```
retrieval-api: 422 pass (parent PR landed at 415), 2 fail
  - test_health_all_ok: needs falkordb network access (env-specific)
  - test_missing_zitadel_audience_fails_import: pre-existing, unrelated
ruff: clean on all changed files
JSON validation: rag-quality.json parses
```

## Why a follow-up PR instead of fixing in #516

Because #516 was already on track to merge and these three issues
surfaced during honest post-merge review. Splitting them off makes the
diff easy to review and lets the original SPEC's history stay clean.

## Rollback

Pure additive / fix-up. Revert is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)