### PR TITLE
fix(litellm-hook): emit low_confidence_injection_applied at warning level

### DIFF
--- a/deploy/litellm/klai_knowledge.py
+++ b/deploy/litellm/klai_knowledge.py
@@ -1549,7 +1549,18 @@ class KlaiKnowledgeHook(CustomLogger):
         # escape hatch — toggle off without redeploying retrieval-api).
         if low_confidence_inject and not _LOW_CONFIDENCE_INJECTION_DISABLED:
             lines.append(_LOW_CONFIDENCE_INJECTION_TEXT)
-            logger.info(
+            # NOTE: warning-level (not info) is deliberate. The litellm
+            # container's root logger filters info-level emits from
+            # non-uvicorn modules (verified 2026-05-08 via VictoriaLogs:
+            # zero info-level klai_knowledge events visible despite
+            # the code path being reached). Other warning-level events
+            # in this module (`KlaiKnowledgeHook: jwt rejected ...`,
+            # `query_rewrite_and_classify_failed`) DO surface, so the
+            # injection event uses the same level for parity with
+            # observable hook events. Lets operators query
+            # `service:litellm AND _msg:"low_confidence_injection_applied"`
+            # for incident triage on a per-request_id basis.
+            logger.warning(
                 "low_confidence_injection_applied org_id=%s confidence_band=%s chunks_injected=%d",
                 org_id,
                 confidence_band,


### PR DESCRIPTION
## Summary

One-line follow-up to #517 / #516. The ``low_confidence_injection_applied`` event
landed as ``logger.info`` and was therefore invisible in VictoriaLogs and Docker
logs, because the litellm container's root logger filters info-level emits from
non-uvicorn modules.

Verified empirically: three test conversations on chat-voys.getklai.com today
(Voys-Salesforce, Acme Foo Connector, vakantie) produced the expected
gedragsmatige uitkomst (Acme → "Dat staat niet in de kennisbank") but produced
**zero** ``klai_knowledge`` info-level events in VictoriaLogs.

## Fix

``logger.info`` → ``logger.warning`` for the injection event.

Severity choice: ``warning`` matches the level of existing visible hook events
(``KlaiKnowledgeHook: jwt rejected ...``, ``query_rewrite_and_classify_failed``).
Lower than ``error`` because the injection is the safety-net engaging, not a
fault.

After this lands, operators can run:

```
service:litellm AND _msg:"low_confidence_injection_applied"
```

in VictoriaLogs to triage individual incidents.

## Test results

135/135 deploy/litellm/tests pass. No code-flow changes; only the log level.

## Out of scope

The deeper fix — proper structlog → VL pipeline for all info-level klai_knowledge
events — would touch litellm's logging config and risk noisier logs across
unrelated modules. This one-line change is the minimum to restore the SPEC's
REQ-8 observability promise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)