### PR TITLE
feat(rag): expose Graphiti entity names as per-chunk Qdrant payload

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/graph.py
+++ b/klai-knowledge-ingest/knowledge_ingest/graph.py
@@ -584,11 +584,20 @@ async def ingest_episode(
                             error=str(wt_exc),
                         )
 
-                # Store entity UUIDs + PageRank scores in Qdrant for retrieval boosting
+                # Store entity UUIDs + names + PageRank scores in Qdrant.
+                # entity_uuids + entity_pagerank_max → document-level (all chunks).
+                # entity_names → chunk-level: each chunk only gets names that
+                # literally appear in its own text (per-chunk substring filter
+                # in qdrant_store).
                 entity_uuids_list = [
                     str(getattr(n, "uuid", "")) for n in nodes if getattr(n, "uuid", None)
                 ]
-                if entity_uuids_list:
+                entity_names_list = [
+                    str(getattr(n, "name", "")).strip()
+                    for n in nodes
+                    if getattr(n, "name", None) and str(getattr(n, "name", "")).strip()
+                ]
+                if entity_uuids_list or entity_names_list:
                     try:
                         pagerank_scores = await compute_entity_pagerank(org_id)
                         await qdrant_store.set_entity_graph_data(
@@ -596,12 +605,12 @@ async def ingest_episode(
                             org_id=org_id,
                             entity_uuids=entity_uuids_list,
                             pagerank_scores=pagerank_scores,
+                            entity_names=entity_names_list,
                         )
-                    except Exception as eg_exc:
-                        logger.warning(
+                    except Exception:
+                        logger.exception(
                             "entity_graph_data_failed",
                             artifact_id=artifact_id,
-                            error=str(eg_exc),
                         )
 
                 break

--- a/klai-knowledge-ingest/knowledge_ingest/qdrant_store.py
+++ b/klai-knowledge-ingest/knowledge_ingest/qdrant_store.py
@@ -86,6 +86,7 @@ async def ensure_collection() -> None:
         "content_type",
         "user_id",
         "entity_uuids",
+        "entity_names",
         "taxonomy_node_id",
         "source_connector_id",
         "taxonomy_node_ids",
@@ -516,45 +517,181 @@ async def search(
     ]
 
 
+# Minimum entity-name length for chunk-level substring matching. Two-character
+# names produce false positives ("AI" inside "fail", "stair") that pollute BM25.
+# Three is the smallest safe threshold for brand/product names while still
+# catching common short ones (CRM, ERP, SSO).
+_ENTITY_NAME_MIN_LEN = 3
+
+
+def filter_entity_names_for_chunk(
+    chunk_text: str,
+    doc_entity_names: list[str],
+) -> list[str]:
+    """Return the subset of doc_entity_names that literally appear in chunk_text.
+
+    Case-insensitive substring match. Names shorter than _ENTITY_NAME_MIN_LEN
+    are skipped to suppress false-positive matches inside unrelated words.
+    Duplicate names (e.g. Graphiti emitted both "Voys" and "voys") collapse to
+    a single canonical form (lowercased preferred when both casings appear).
+
+    Pure function — kept top-level for testability.
+    """
+    if not doc_entity_names or not chunk_text:
+        return []
+    chunk_lower = chunk_text.lower()
+    seen: set[str] = set()
+    result: list[str] = []
+    for name in doc_entity_names:
+        if not name or not isinstance(name, str):
+            continue
+        cleaned = name.strip()
+        if len(cleaned) < _ENTITY_NAME_MIN_LEN:
+            continue
+        key = cleaned.lower()
+        if key in seen:
+            continue
+        if key in chunk_lower:
+            seen.add(key)
+            result.append(cleaned)
+    return result
+
+
 async def set_entity_graph_data(
     artifact_id: str,
     org_id: str,
     entity_uuids: list[str],
     pagerank_scores: dict[str, float],
+    entity_names: list[str] | None = None,
 ) -> None:
-    """Set entity UUIDs and max PageRank score on all chunks of an artifact.
+    """Set entity UUIDs, entity names, and max PageRank score on chunks of an artifact.
 
-    Called after Graphiti episode ingestion completes. All chunks of the same
-    artifact get the same entity list (extracted at document level).
-    entity_pagerank_max is the highest PageRank score among this artifact's entities.
+    Called after Graphiti episode ingestion completes.
+
+    entity_uuids + entity_pagerank_max are document-level (set on all chunks of
+    the artifact via a single artifact_id-scoped set_payload).
+
+    entity_names is filtered per-chunk: each chunk only carries the subset of
+    document-level names that literally appear in its own text. This keeps
+    BM25/sparse from being polluted by entity names that belong to a different
+    section of the same long document. When entity_names is None or empty, only
+    the document-level fields are written (back-compat with callers that don't
+    yet provide names).
     """
-    if not entity_uuids:
+    if not entity_uuids and not entity_names:
         return
 
     client = get_client()
-    scores = [pagerank_scores.get(uid, 0.0) for uid in entity_uuids]
+    scores = [pagerank_scores.get(uid, 0.0) for uid in entity_uuids] if entity_uuids else []
     pagerank_max = max(scores) if scores else 0.0
 
-    await client.set_payload(
-        COLLECTION,
-        payload={
-            "entity_uuids": entity_uuids,
-            "entity_pagerank_max": pagerank_max,
-        },
-        points=Filter(
-            must=[
-                FieldCondition(key="artifact_id", match=MatchValue(value=artifact_id)),
-                FieldCondition(key="org_id", match=MatchValue(value=org_id)),
-            ]
-        ),
-    )
+    # Document-level write: same payload across every chunk of the artifact.
+    if entity_uuids:
+        await client.set_payload(
+            COLLECTION,
+            payload={
+                "entity_uuids": entity_uuids,
+                "entity_pagerank_max": pagerank_max,
+            },
+            points=Filter(
+                must=[
+                    FieldCondition(key="artifact_id", match=MatchValue(value=artifact_id)),
+                    FieldCondition(key="org_id", match=MatchValue(value=org_id)),
+                ]
+            ),
+        )
+
+    # Chunk-level write: per-chunk substring filter against chunk text.
+    chunks_with_names = 0
+    if entity_names:
+        chunks_with_names = await _set_per_chunk_entity_names(
+            client=client,
+            artifact_id=artifact_id,
+            org_id=org_id,
+            doc_entity_names=entity_names,
+        )
+
     logger.info(
         "entity_graph_data_set",
         artifact_id=artifact_id,
         org_id=org_id,
         entity_count=len(entity_uuids),
+        entity_name_count=len(entity_names) if entity_names else 0,
+        chunks_with_names=chunks_with_names,
         pagerank_max=round(pagerank_max, 6),
     )
+
+
+_ENTITY_NAMES_CHUNK_BATCH = 100
+
+
+async def _set_per_chunk_entity_names(
+    client: AsyncQdrantClient,
+    artifact_id: str,
+    org_id: str,
+    doc_entity_names: list[str],
+) -> int:
+    """Scroll all chunks of an artifact and write the per-chunk entity_names
+    subset. Returns the number of chunks that received a non-empty list.
+    """
+    artifact_filter = Filter(
+        must=[
+            FieldCondition(key="artifact_id", match=MatchValue(value=artifact_id)),
+            FieldCondition(key="org_id", match=MatchValue(value=org_id)),
+        ]
+    )
+
+    offset = None
+    chunks_with_names = 0
+    while True:
+        try:
+            points, next_offset = await client.scroll(
+                collection_name=COLLECTION,
+                scroll_filter=artifact_filter,
+                limit=_ENTITY_NAMES_CHUNK_BATCH,
+                offset=offset,
+                with_payload=["text"],
+                with_vectors=False,
+            )
+        except Exception:
+            logger.exception(
+                "entity_names_scroll_failed",
+                artifact_id=artifact_id,
+                org_id=org_id,
+            )
+            return chunks_with_names
+
+        if not points:
+            break
+
+        for point in points:
+            chunk_text = (point.payload or {}).get("text", "")
+            if not isinstance(chunk_text, str):
+                continue
+            names = filter_entity_names_for_chunk(chunk_text, doc_entity_names)
+            if not names:
+                # Qdrant strips empty-list keys on upsert; absent == empty.
+                continue
+            try:
+                await client.set_payload(
+                    COLLECTION,
+                    payload={"entity_names": names},
+                    points=[point.id],
+                )
+                chunks_with_names += 1
+            except Exception:
+                logger.exception(
+                    "entity_names_set_payload_failed",
+                    artifact_id=artifact_id,
+                    org_id=org_id,
+                    chunk_id=str(point.id),
+                )
+
+        if next_offset is None:
+            break
+        offset = next_offset
+
+    return chunks_with_names
 
 
 _LINK_COUNT_CONCURRENCY = 20  # max parallel set_payload calls per bulk crawl

--- a/klai-knowledge-ingest/scripts/backfill_entity_names.py
+++ b/klai-knowledge-ingest/scripts/backfill_entity_names.py
@@ -1,0 +1,226 @@
+"""Backfill entity_names on Qdrant chunks for already-ingested artifacts.
+
+For every artifact that has entity_uuids stored on its chunks (set by Graphiti
+on first ingest), this script:
+  1. Resolves the UUIDs to entity names via FalkorDB (Cypher MATCH).
+  2. Calls qdrant_store.set_entity_graph_data with the names — which scrolls
+     all chunks of the artifact and writes per-chunk entity_names filtered by
+     literal substring presence in chunk text.
+
+Usage (in a knowledge-ingest container):
+
+    docker exec klai-core-knowledge-ingest-1 \
+        python -m scripts.backfill_entity_names --org-id <org_id> [--kb-slug <slug>] [--dry-run]
+
+Without --kb-slug, all KBs of the org are backfilled.
+
+Resumability: the script is idempotent. set_payload overwrites whatever was
+there, so re-running on a partially-completed backfill is safe. If a chunk
+already has entity_names, they get re-derived from the same source-of-truth
+(FalkorDB) and overwritten.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from collections import defaultdict
+
+import structlog
+from qdrant_client.models import FieldCondition, Filter, MatchValue
+
+from knowledge_ingest import qdrant_store
+from knowledge_ingest.config import settings
+from knowledge_ingest.qdrant_store import COLLECTION
+
+logger = structlog.get_logger()
+
+_SCROLL_BATCH = 200
+
+
+async def _collect_artifacts_with_uuids(
+    org_id: str,
+    kb_slug: str | None,
+) -> dict[str, set[str]]:
+    """Scroll Qdrant once and return {artifact_id: {entity_uuid, ...}}.
+
+    Each artifact's full UUID set is the union over its chunks (every chunk of
+    an artifact gets the same entity_uuids list at write time, but defensive).
+    """
+    client = qdrant_store.get_client()
+
+    must = [FieldCondition(key="org_id", match=MatchValue(value=org_id))]
+    if kb_slug:
+        must.append(FieldCondition(key="kb_slug", match=MatchValue(value=kb_slug)))
+    scroll_filter = Filter(must=must)
+
+    artifact_uuids: dict[str, set[str]] = defaultdict(set)
+    offset = None
+    seen_chunks = 0
+    while True:
+        points, next_offset = await client.scroll(
+            collection_name=COLLECTION,
+            scroll_filter=scroll_filter,
+            limit=_SCROLL_BATCH,
+            offset=offset,
+            with_payload=["artifact_id", "entity_uuids"],
+            with_vectors=False,
+        )
+        if not points:
+            break
+        for point in points:
+            payload = point.payload or {}
+            artifact_id = payload.get("artifact_id")
+            uuids = payload.get("entity_uuids")
+            if not artifact_id or not uuids:
+                continue
+            if not isinstance(uuids, list):
+                continue
+            artifact_uuids[str(artifact_id)].update(str(u) for u in uuids if u)
+            seen_chunks += 1
+        if next_offset is None:
+            break
+        offset = next_offset
+
+    logger.info(
+        "backfill_collect_artifacts_done",
+        org_id=org_id,
+        kb_slug=kb_slug,
+        artifacts_with_entities=len(artifact_uuids),
+        chunks_scanned=seen_chunks,
+    )
+    return artifact_uuids
+
+
+async def _resolve_uuids_to_names(
+    org_id: str,
+    uuids: set[str],
+) -> dict[str, str]:
+    """Resolve entity UUIDs to names via FalkorDB. Returns {uuid: name}."""
+    if not uuids or not settings.graphiti_enabled:
+        return {}
+
+    try:
+        from falkordb import FalkorDB as FalkorDBClient
+    except ImportError:
+        logger.warning("falkordb_client_unavailable", org_id=org_id)
+        return {}
+
+    client = FalkorDBClient(host=settings.falkordb_host, port=settings.falkordb_port)
+    graph = client.select_graph(org_id)
+
+    uuid_list = list(uuids)
+    result = graph.query(
+        "MATCH (n:Entity) WHERE n.uuid IN $uuids RETURN n.uuid AS uuid, n.name AS name",
+        params={"uuids": uuid_list},
+    )
+
+    name_map: dict[str, str] = {}
+    for row in result.result_set or []:
+        if not row or len(row) < 2:
+            continue
+        uid = str(row[0]) if row[0] is not None else None
+        name = str(row[1]).strip() if row[1] is not None else None
+        if uid and name:
+            name_map[uid] = name
+    return name_map
+
+
+async def _backfill_artifact(
+    artifact_id: str,
+    org_id: str,
+    entity_names: list[str],
+    dry_run: bool,
+) -> int:
+    """Run set_entity_graph_data for one artifact. Returns chunks written."""
+    if not entity_names:
+        return 0
+
+    if dry_run:
+        logger.info(
+            "backfill_dry_run",
+            artifact_id=artifact_id,
+            org_id=org_id,
+            entity_names_sample=entity_names[:5],
+            entity_name_count=len(entity_names),
+        )
+        return 0
+
+    # Pass empty entity_uuids so the document-level write is skipped — uuids
+    # are already on the chunks. We only want to add the per-chunk name field.
+    await qdrant_store.set_entity_graph_data(
+        artifact_id=artifact_id,
+        org_id=org_id,
+        entity_uuids=[],
+        pagerank_scores={},
+        entity_names=entity_names,
+    )
+    return len(entity_names)
+
+
+async def run_backfill(
+    org_id: str,
+    kb_slug: str | None,
+    dry_run: bool,
+) -> None:
+    artifact_uuids = await _collect_artifacts_with_uuids(org_id, kb_slug)
+    if not artifact_uuids:
+        logger.info("backfill_nothing_to_do", org_id=org_id, kb_slug=kb_slug)
+        return
+
+    all_uuids: set[str] = set()
+    for uuids in artifact_uuids.values():
+        all_uuids.update(uuids)
+    name_map = await _resolve_uuids_to_names(org_id, all_uuids)
+
+    logger.info(
+        "backfill_resolved_names",
+        org_id=org_id,
+        unique_uuids=len(all_uuids),
+        resolved=len(name_map),
+        unresolved=len(all_uuids) - len(name_map),
+    )
+
+    successes = 0
+    failures = 0
+    for artifact_id, uuids in artifact_uuids.items():
+        names = [name_map[u] for u in uuids if u in name_map]
+        if not names:
+            continue
+        try:
+            await _backfill_artifact(artifact_id, org_id, names, dry_run)
+            successes += 1
+        except Exception:
+            logger.exception("backfill_artifact_failed", artifact_id=artifact_id)
+            failures += 1
+
+    logger.info(
+        "backfill_done",
+        org_id=org_id,
+        kb_slug=kb_slug,
+        artifacts_processed=successes,
+        artifacts_failed=failures,
+        dry_run=dry_run,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Backfill entity_names on Qdrant chunks from FalkorDB graph."
+    )
+    parser.add_argument("--org-id", required=True, help="Org ID to backfill.")
+    parser.add_argument("--kb-slug", default=None, help="Optional: limit to a single KB.")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="List artifacts that would be touched without writing to Qdrant.",
+    )
+    args = parser.parse_args()
+
+    asyncio.run(run_backfill(args.org_id, args.kb_slug, args.dry_run))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/klai-knowledge-ingest/tests/test_entity_names_filter.py
+++ b/klai-knowledge-ingest/tests/test_entity_names_filter.py
@@ -1,0 +1,106 @@
+"""Unit tests for filter_entity_names_for_chunk in qdrant_store.
+
+The pure helper decides which document-level entity names belong on a specific
+chunk. Pollution of BM25 with off-section names is exactly what this filter is
+designed to prevent — these tests lock in the expected behavior.
+"""
+
+from knowledge_ingest.qdrant_store import filter_entity_names_for_chunk
+
+
+def test_returns_only_names_present_in_chunk() -> None:
+    chunk = "Voys Freedom koppelen aan Bubble via RedCactus integratie."
+    doc_names = ["Voys", "Bubble", "RedCactus", "Salesforce", "WhatsApp"]
+
+    result = filter_entity_names_for_chunk(chunk, doc_names)
+
+    # Salesforce and WhatsApp belong to a different section of the same doc.
+    assert "Voys" in result
+    assert "Bubble" in result
+    assert "RedCactus" in result
+    assert "Salesforce" not in result
+    assert "WhatsApp" not in result
+
+
+def test_case_insensitive_match() -> None:
+    chunk = "Configure your salesforce instance with VOYS api credentials."
+    doc_names = ["Salesforce", "Voys"]
+
+    result = filter_entity_names_for_chunk(chunk, doc_names)
+
+    assert "Salesforce" in result
+    assert "Voys" in result
+
+
+def test_skips_short_names_to_avoid_false_positives() -> None:
+    chunk = "If you fail to authenticate, the AI assistant explains the error."
+    # "AI" appears in "fail" — without min-length filter we'd false-positive.
+    doc_names = ["AI", "OK", "ZZ", "Salesforce"]
+
+    result = filter_entity_names_for_chunk(chunk, doc_names)
+
+    assert "AI" not in result
+    assert "OK" not in result
+    assert "ZZ" not in result
+    assert "Salesforce" not in result  # not in this chunk
+
+
+def test_three_char_names_are_kept() -> None:
+    chunk = "Configure CRM and ERP integrations with SSO."
+    doc_names = ["CRM", "ERP", "SSO"]
+
+    result = filter_entity_names_for_chunk(chunk, doc_names)
+
+    assert result == ["CRM", "ERP", "SSO"]
+
+
+def test_dedupe_when_graphiti_emitted_multiple_casings() -> None:
+    chunk = "Voys Freedom integration with Voys phone systems."
+    doc_names = ["Voys", "voys", "VOYS"]
+
+    result = filter_entity_names_for_chunk(chunk, doc_names)
+
+    assert len(result) == 1
+    assert result[0].lower() == "voys"
+
+
+def test_multi_word_entities_match_via_substring() -> None:
+    chunk = "We support Microsoft Teams via the Vexa connector."
+    doc_names = ["Microsoft Teams", "Vexa"]
+
+    result = filter_entity_names_for_chunk(chunk, doc_names)
+
+    assert "Microsoft Teams" in result
+    assert "Vexa" in result
+
+
+def test_empty_chunk_returns_empty() -> None:
+    result = filter_entity_names_for_chunk("", ["Voys", "Salesforce"])
+    assert result == []
+
+
+def test_empty_doc_names_returns_empty() -> None:
+    result = filter_entity_names_for_chunk("Some text about Voys.", [])
+    assert result == []
+
+
+def test_skips_blank_or_whitespace_names() -> None:
+    chunk = "Voys integration documentation."
+    doc_names = ["Voys", "", "   ", "  Voys  "]
+
+    result = filter_entity_names_for_chunk(chunk, doc_names)
+
+    # Strip + dedup yields one canonical "Voys".
+    assert len(result) == 1
+    assert result[0].lower() == "voys"
+
+
+def test_skips_non_string_inputs() -> None:
+    chunk = "Voys integration documentation."
+    # Defensive: graphiti results have always been strings, but type defensiveness
+    # is cheap and prevents a future bug from blowing up the ingest path.
+    doc_names = ["Voys", None, 42, ["nested"]]  # type: ignore[list-item]
+
+    result = filter_entity_names_for_chunk(chunk, doc_names)  # type: ignore[arg-type]
+
+    assert result == ["Voys"]

--- a/klai-retrieval-api/retrieval_api/services/search.py
+++ b/klai-retrieval-api/retrieval_api/services/search.py
@@ -89,10 +89,12 @@ def _scope_filter(request: RetrieveRequest) -> list[FieldCondition | Filter]:
         visibility_should: list[Filter] = [not_private]
         if request.user_id:
             visibility_should.append(
-                Filter(must=[
-                    FieldCondition(key="visibility", match=MatchValue(value="private")),
-                    FieldCondition(key="user_id", match=MatchValue(value=request.user_id)),
-                ])
+                Filter(
+                    must=[
+                        FieldCondition(key="visibility", match=MatchValue(value="private")),
+                        FieldCondition(key="user_id", match=MatchValue(value=request.user_id)),
+                    ]
+                )
             )
         conditions.append(Filter(should=visibility_should))
     if request.kb_slugs:
@@ -100,14 +102,16 @@ def _scope_filter(request: RetrieveRequest) -> list[FieldCondition | Filter]:
             # kb_slugs is an org-only filter. When scope=both, personal chunks must not be
             # excluded by the slug filter — a chunk passes if it matches a slug OR belongs
             # to the requesting user (personal ownership bypass).
-            conditions.append(Filter(should=[
-                FieldCondition(key="kb_slug", match=MatchAny(any=request.kb_slugs)),
-                FieldCondition(key="user_id", match=MatchValue(value=request.user_id)),
-            ]))
-        else:
             conditions.append(
-                FieldCondition(key="kb_slug", match=MatchAny(any=request.kb_slugs))
+                Filter(
+                    should=[
+                        FieldCondition(key="kb_slug", match=MatchAny(any=request.kb_slugs)),
+                        FieldCondition(key="user_id", match=MatchValue(value=request.user_id)),
+                    ]
+                )
             )
+        else:
+            conditions.append(FieldCondition(key="kb_slug", match=MatchAny(any=request.kb_slugs)))
     return conditions
 
 
@@ -210,6 +214,7 @@ async def _search_knowledge(
             "ingested_at": r.payload.get("ingested_at"),
             "assertion_mode": r.payload.get("assertion_mode"),
             "entity_pagerank_max": r.payload.get("entity_pagerank_max"),
+            "entity_names": payload_list(r.payload, "entity_names"),
             "source_url": r.payload.get("source_url"),
             "source_ref": r.payload.get("source_ref"),
             "source_connector_id": r.payload.get("source_connector_id"),
@@ -282,6 +287,7 @@ async def fetch_chunks_by_urls(
             "ingested_at": r.payload.get("ingested_at"),
             "assertion_mode": r.payload.get("assertion_mode"),
             "entity_pagerank_max": r.payload.get("entity_pagerank_max"),
+            "entity_names": payload_list(r.payload, "entity_names"),
             "source_url": r.payload.get("source_url"),
             "source_ref": r.payload.get("source_ref"),
             "source_connector_id": r.payload.get("source_connector_id"),


### PR DESCRIPTION
## Summary

Surface Graphiti's existing entity-extraction output as a searchable Qdrant payload field. Today we discard the entity NAMES that Graphiti's `add_episode()` already returns — only opaque UUIDs and the max PageRank score get persisted. This change keeps Graphiti's extraction unchanged and exposes the readable strings for retrieval, filtering, and LLM citation.

- New `entity_names` keyword-indexed field on `klai_knowledge` chunks
- Per-chunk substring filter (case-insensitive, 3-char minimum) so a long doc with separate sections about Bubble pricing AND Salesforce integration AND WhatsApp doesn't pollute every chunk with all three names
- Surfaced in retrieval-api on both `_search_knowledge` and `fetch_chunks_by_urls`
- Idempotent backfill script: `scripts/backfill_entity_names.py --org-id <org> [--kb-slug <slug>] [--dry-run]`
- 10 unit tests on the pure filter helper

The Graphiti coverage gap (e.g. "Salesforce" not extracted on Voys, only generic "CRM") is intentionally out of scope here — tracked in `SPEC-RAG-GRAPHITI-NER-COVERAGE-001`. This PR makes whatever Graphiti DOES extract finally usable.

## Test plan

- [x] Unit tests on filter_entity_names_for_chunk (10 cases — substring, casing, short-name reject, dedupe, multi-word, empty, defensive)
- [x] ruff check + format clean on both knowledge-ingest and retrieval-api
- [ ] Post-deploy: `docker exec klai-core-knowledge-ingest-1 python -m scripts.backfill_entity_names --org-id <voys-org-id>` and verify Qdrant shows entity_names on a sample chunk
- [ ] Voys query smoke: `mcp__victorialogs__query` for `service:knowledge-ingest AND message:entity_graph_data_set` to confirm chunks_with_names > 0
- [ ] Confirm RetrieveResponse chunks now include `entity_names: [...]` for chunks where Graphiti extracted names that appear in the chunk text

## Out of scope (separate SPECs)

- Graphiti entity-extraction prompt tuning to catch brand names → SPEC-RAG-GRAPHITI-NER-COVERAGE-001
- BM25 sparse-corpus addition of entity_names → can be revisited once we measure the retrieval lift from filterable + LLM-visible names alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)