### PR TITLE
fix(rag): wire entity_names through ChunkResult + bake backfill into image

### DIFF
--- a/klai-knowledge-ingest/Dockerfile
+++ b/klai-knowledge-ingest/Dockerfile
@@ -34,6 +34,9 @@ COPY --chown=app:app klai-knowledge-ingest/knowledge_ingest knowledge_ingest
 # SPEC-INGEST-ALEMBIC-001: alembic migration definitions
 COPY --chown=app:app klai-knowledge-ingest/alembic alembic
 COPY --chown=app:app klai-knowledge-ingest/alembic.ini alembic.ini
+# Operator scripts (e.g. backfill_entity_names.py) — runnable inside the
+# container via `docker exec ... python scripts/<file>` for one-shot ops.
+COPY --chown=app:app klai-knowledge-ingest/scripts scripts
 # SPEC-INGEST-ALEMBIC-001: entrypoint runs alembic upgrade head before uvicorn
 COPY --chown=app:app klai-knowledge-ingest/entrypoint.sh entrypoint.sh
 RUN chmod +x /repo/klai-knowledge-ingest/entrypoint.sh

--- a/klai-retrieval-api/retrieval_api/api/retrieve.py
+++ b/klai-retrieval-api/retrieval_api/api/retrieve.py
@@ -499,6 +499,7 @@ async def retrieve(
                     source_label=r.get("source_label"),
                     title=r.get("title"),
                     image_urls=payload_list(r, "image_urls") or None,
+                    entity_names=payload_list(r, "entity_names") or None,
                     is_parent_text=is_parent,
                 )
             )

--- a/klai-retrieval-api/retrieval_api/models.py
+++ b/klai-retrieval-api/retrieval_api/models.py
@@ -64,6 +64,11 @@ class ChunkResult(BaseModel):
     source_label: str | None = None  # Human-readable source label (SPEC-KB-021)
     title: str | None = None  # Document title from Qdrant payload
     image_urls: list[str] | None = None  # Presigned S3 URLs for images in this document
+    # Specific brand/product entity names extracted by Graphiti at document ingest
+    # and filtered per-chunk by literal substring presence in chunk text. Lets the
+    # LLM cite "this chunk mentions Bubble Cloud" as evidence and lets clients
+    # filter by entity_names server-side. Empty/absent for chunks without coverage.
+    entity_names: list[str] | None = None
     # SPEC-RAG-PARENT-CHILD-001: when present, ``text`` already carries the
     # parent's broader-context text (matched on the smaller child chunk).
     # Clients can use this flag for debugging / display hints.


### PR DESCRIPTION
## Summary

Follow-up to #519. Two gaps surfaced in live verification:

1. **ChunkResult Pydantic model dropped `entity_names`** — the field reached `search.py`'s chunk dict but was filtered out at the response-model boundary. Adds `entity_names: list[str] | None` to `ChunkResult` AND threads it through the constructor in `api/retrieve.py:480` alongside the existing `image_urls`/`source_url`/etc. Per the "Multi-layer data threading in retrieval results" rule in `.claude/rules/klai/projects/knowledge.md` — every layer is a serialization boundary; dropping a field at any single one silently loses it downstream.

2. **`scripts/backfill_entity_names.py` wasn't included in the knowledge-ingest image.** Adds `COPY --chown=app:app klai-knowledge-ingest/scripts scripts` to the Dockerfile so future operators can run the backfill via plain `docker exec ... python scripts/backfill_entity_names.py --org-id <X>` without docker cp.

## Validation

Pre-fix live test (against #519 deployed) returned `entity_names: None` on every chunk — confirmed the field was being dropped at ChunkResult.

Post-fix expectation: chunks with Graphiti-extracted brand mentions return `entity_names: ["Bubble Cloud", "RedCactus Support", "Voys", ...]` in the retrieve response.

## Test plan

- [x] ruff + format clean on changed files
- [ ] Post-deploy: re-run the Voys "Bubble Cloud add-on licentie" query and confirm `entity_names` is non-null on at least 1 of 3 returned chunks
- [ ] Future-operator UX: `docker exec klai-core-knowledge-ingest-1 python scripts/backfill_entity_names.py --help` resolves without docker cp

🤖 Generated with [Claude Code](https://claude.com/claude-code)