### PR TITLE
chore(config): enable Agent Teams

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
   "permissions": {
     "allow": [
       "mcp__playwright__browser_evaluate",

--- a/.moai/config/sections/workflow.yaml
+++ b/.moai/config/sections/workflow.yaml
@@ -21,7 +21,7 @@ workflow:
             min_files_for_team: 10
         default_model: sonnet
         delegate_mode: true
-        enabled: false
+        enabled: true
         max_teammates: 10
         patterns:
             design_implementation:


### PR DESCRIPTION
## Summary

Two-line config change to enable Agent Teams in the project.

- `.claude/settings.json`: add `env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`
- `.moai/config/sections/workflow.yaml`: flip `team.enabled: false → true`

The settings have been live in Mark's local working tree since the
2026-05-07 SPEC-RAG-LOW-CONFIDENCE-ABSTAIN-001 session but never got
their own commit. This makes them official so a fresh checkout (or a
new operator joining the project) has Agent Teams available.

## Test results

No code changes; pure config. CI semgrep passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)