### PR TITLE
chore(rag): entity_names follow-up — chunks_total log + scripts/__init__.py + skip-test fix

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/qdrant_store.py
+++ b/klai-knowledge-ingest/knowledge_ingest/qdrant_store.py
@@ -603,20 +603,25 @@ async def set_entity_graph_data(
 
     # Chunk-level write: per-chunk substring filter against chunk text.
     chunks_with_names = 0
+    chunks_total = 0
     if entity_names:
-        chunks_with_names = await _set_per_chunk_entity_names(
+        chunks_with_names, chunks_total = await _set_per_chunk_entity_names(
             client=client,
             artifact_id=artifact_id,
             org_id=org_id,
             doc_entity_names=entity_names,
         )
 
+    # chunks_total + chunks_with_names lets Grafana compute the per-tenant
+    # coverage rate from VictoriaLogs: stats by(org_id) sum(chunks_with_names)
+    # / sum(chunks_total) over event:entity_graph_data_set.
     logger.info(
         "entity_graph_data_set",
         artifact_id=artifact_id,
         org_id=org_id,
         entity_count=len(entity_uuids),
         entity_name_count=len(entity_names) if entity_names else 0,
+        chunks_total=chunks_total,
         chunks_with_names=chunks_with_names,
         pagerank_max=round(pagerank_max, 6),
     )
@@ -630,9 +635,10 @@ async def _set_per_chunk_entity_names(
     artifact_id: str,
     org_id: str,
     doc_entity_names: list[str],
-) -> int:
+) -> tuple[int, int]:
     """Scroll all chunks of an artifact and write the per-chunk entity_names
-    subset. Returns the number of chunks that received a non-empty list.
+    subset. Returns (chunks_with_names, chunks_total) — the coverage ratio
+    consumer can compute the per-artifact filter-acceptance rate.
     """
     artifact_filter = Filter(
         must=[
@@ -643,6 +649,7 @@ async def _set_per_chunk_entity_names(
 
     offset = None
     chunks_with_names = 0
+    chunks_total = 0
     while True:
         try:
             points, next_offset = await client.scroll(
@@ -659,12 +666,13 @@ async def _set_per_chunk_entity_names(
                 artifact_id=artifact_id,
                 org_id=org_id,
             )
-            return chunks_with_names
+            return chunks_with_names, chunks_total
 
         if not points:
             break
 
         for point in points:
+            chunks_total += 1
             chunk_text = (point.payload or {}).get("text", "")
             if not isinstance(chunk_text, str):
                 continue
@@ -691,7 +699,7 @@ async def _set_per_chunk_entity_names(
             break
         offset = next_offset
 
-    return chunks_with_names
+    return chunks_with_names, chunks_total
 
 
 _LINK_COUNT_CONCURRENCY = 20  # max parallel set_payload calls per bulk crawl

--- a/klai-knowledge-ingest/scripts/__init__.py
+++ b/klai-knowledge-ingest/scripts/__init__.py
@@ -1,0 +1,11 @@
+"""Operator scripts for klai-knowledge-ingest.
+
+Marker file so the package can be invoked as a module:
+
+    docker exec klai-core-knowledge-ingest-1 \
+        python -m scripts.backfill_entity_names --org-id <org_id>
+
+Without __init__.py, only `python scripts/<file>.py` worked, which forces
+the operator to remember the file path. The -m form follows the project's
+existing convention (e.g. python -m knowledge_ingest.eval ...).
+"""

--- a/klai-knowledge-ingest/tests/test_qdrant_link_counts.py
+++ b/klai-knowledge-ingest/tests/test_qdrant_link_counts.py
@@ -1,4 +1,5 @@
 """Tests for link-count payload indexes and update_link_counts() (SPEC-CRAWLER-003)."""
+
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -28,7 +29,14 @@ def _mock_collection_entry(collection_name: str):
 @pytest.mark.asyncio
 async def test_ensure_collection_creates_source_url_index_when_missing():
     """source_url keyword index should be created when not yet indexed."""
-    existing_fields = {"org_id", "kb_slug", "artifact_id", "content_type", "user_id", "entity_uuids"}
+    existing_fields = {
+        "org_id",
+        "kb_slug",
+        "artifact_id",
+        "content_type",
+        "user_id",
+        "entity_uuids",
+    }
 
     with patch("knowledge_ingest.qdrant_store.get_client") as mock_get_client:
         mock_client = MagicMock()
@@ -36,9 +44,7 @@ async def test_ensure_collection_creates_source_url_index_when_missing():
         mock_client.get_collections = AsyncMock(
             return_value=MagicMock(collections=[_mock_collection_entry("klai_knowledge")])
         )
-        mock_client.get_collection = AsyncMock(
-            return_value=_mock_collection_info(existing_fields)
-        )
+        mock_client.get_collection = AsyncMock(return_value=_mock_collection_info(existing_fields))
         mock_client.create_payload_index = AsyncMock()
 
         await ensure_collection()
@@ -46,7 +52,8 @@ async def test_ensure_collection_creates_source_url_index_when_missing():
         # Find the call that created the source_url index
         calls = mock_client.create_payload_index.call_args_list
         source_url_calls = [
-            c for c in calls
+            c
+            for c in calls
             if c.kwargs.get("field_name") == "source_url"
             or (len(c.args) >= 2 and c.args[1] == "source_url")
         ]
@@ -58,7 +65,14 @@ async def test_ensure_collection_creates_source_url_index_when_missing():
 @pytest.mark.asyncio
 async def test_ensure_collection_creates_incoming_link_count_index_when_missing():
     """incoming_link_count integer index should be created when not yet indexed."""
-    existing_fields = {"org_id", "kb_slug", "artifact_id", "content_type", "user_id", "entity_uuids"}
+    existing_fields = {
+        "org_id",
+        "kb_slug",
+        "artifact_id",
+        "content_type",
+        "user_id",
+        "entity_uuids",
+    }
 
     with patch("knowledge_ingest.qdrant_store.get_client") as mock_get_client:
         mock_client = MagicMock()
@@ -66,16 +80,15 @@ async def test_ensure_collection_creates_incoming_link_count_index_when_missing(
         mock_client.get_collections = AsyncMock(
             return_value=MagicMock(collections=[_mock_collection_entry("klai_knowledge")])
         )
-        mock_client.get_collection = AsyncMock(
-            return_value=_mock_collection_info(existing_fields)
-        )
+        mock_client.get_collection = AsyncMock(return_value=_mock_collection_info(existing_fields))
         mock_client.create_payload_index = AsyncMock()
 
         await ensure_collection()
 
         calls = mock_client.create_payload_index.call_args_list
         ilc_calls = [
-            c for c in calls
+            c
+            for c in calls
             if c.kwargs.get("field_name") == "incoming_link_count"
             or (len(c.args) >= 2 and c.args[1] == "incoming_link_count")
         ]
@@ -88,9 +101,22 @@ async def test_ensure_collection_creates_incoming_link_count_index_when_missing(
 async def test_ensure_collection_skips_indexes_when_already_present():
     """When source_url and incoming_link_count are already indexed, skip creation."""
     all_fields = {
-        "org_id", "kb_slug", "artifact_id", "content_type", "user_id", "entity_uuids",
-        "source_url", "incoming_link_count", "taxonomy_node_id", "source_connector_id",
-        "taxonomy_node_ids", "tags", "content_label", "source_label", "chunk_type",
+        "org_id",
+        "kb_slug",
+        "artifact_id",
+        "content_type",
+        "user_id",
+        "entity_uuids",
+        "entity_names",
+        "source_url",
+        "incoming_link_count",
+        "taxonomy_node_id",
+        "source_connector_id",
+        "taxonomy_node_ids",
+        "tags",
+        "content_label",
+        "source_label",
+        "chunk_type",
     }
 
     with patch("knowledge_ingest.qdrant_store.get_client") as mock_get_client:
@@ -99,9 +125,7 @@ async def test_ensure_collection_skips_indexes_when_already_present():
         mock_client.get_collections = AsyncMock(
             return_value=MagicMock(collections=[_mock_collection_entry("klai_knowledge")])
         )
-        mock_client.get_collection = AsyncMock(
-            return_value=_mock_collection_info(all_fields)
-        )
+        mock_client.get_collection = AsyncMock(return_value=_mock_collection_info(all_fields))
         mock_client.create_payload_index = AsyncMock()
 
         await ensure_collection()
@@ -156,7 +180,12 @@ async def test_update_link_counts_uses_correct_filter():
             assert call_args[0] == "klai_knowledge"
         else:
             # Verify payload contains incoming_link_count
-            payload = call_kwargs.get("payload", mock_client.set_payload.call_args.args[1] if len(mock_client.set_payload.call_args.args) > 1 else None)
+            payload = call_kwargs.get(
+                "payload",
+                mock_client.set_payload.call_args.args[1]
+                if len(mock_client.set_payload.call_args.args) > 1
+                else None,
+            )
             assert payload == {"incoming_link_count": 7}
 
         # Verify the filter structure by inspecting the points argument


### PR DESCRIPTION
## Summary

Three loose ends from the entity_names rollout (#519/#520):

1. **`chunks_total` in log event** — `entity_graph_data_set` now emits both `chunks_with_names` AND `chunks_total`, so Grafana/VictoriaLogs can compute per-tenant coverage rate (today the field had no denominator). Backfill log lines and live-ingest log lines both carry it.

2. **`scripts/__init__.py`** — backfill is now invocable as `python -m scripts.backfill_entity_names --org-id <X>` (matches the existing `python -m knowledge_ingest.eval` pattern). The bare-file form still works.

3. **`test_ensure_collection_skips_indexes_when_already_present`** — broken by #519 (added `entity_names` to the index loop without updating the test's `all_fields` mock). Documented exactly this regression in the "Qdrant skip-if-present index test" pitfall in `projects/knowledge.md`. Slipped past CI because knowledge-ingest's PR workflow doesn't run that test file on diffs that don't touch crawl paths.

## 31% gap analysis (data only, no code change)

```
Voys total:                          4,484 chunks
  has entity_uuids (Graphiti ran):   3,091 (68.9%)
  has entity_names (post-backfill):  2,977 (66.4%)
  has uuids but no names (filter):     114 ( 2.5%)
  no uuids at all (Graphiti gap):    1,393 (31.1%)
```

All 1,393 "no uuids" chunks are in the `support` KB. The per-chunk filter is rejecting only 2.5% — fine. The 31% gap is purely Graphiti coverage. Re-running enrichment on those artifacts is operator action; the underlying brand-name extraction quality is tracked in `SPEC-RAG-GRAPHITI-NER-COVERAGE-001`.

## Test plan

- [x] `pytest tests/test_qdrant_link_counts.py` — 6 passed
- [x] `pytest tests/test_entity_names_filter.py` — 10 still green
- [x] ruff + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)