### PR TITLE
test(portal): RBAC pre-phase characterization snapshots

### DIFF
--- a/klai-portal/backend/tests/role_matrix_helpers.py
+++ b/klai-portal/backend/tests/role_matrix_helpers.py
@@ -1,0 +1,190 @@
+"""Characterization-test helpers for SPEC-PORTAL-RBAC-REFACTOR-001 Pre-phase.
+
+Pins the current behaviour of imperative `_require_admin` gates as
+HTTP-status snapshots (200/403/401) so the Phase 1+2 refactor to declarative
+`Depends(get_caller_at_least(...))` cannot silently change role-enforcement.
+
+# TEMPORARY: vervangen door Phase 1 fixture
+SPEC-PORTAL-RBAC-REFACTOR-001 Phase 1 ships a definitive
+`make_user(role=...)` factory in `tests/conftest.py` that yields a real
+`PortalUser` with a typed `ProfileRole` enum + a tenant-scoped helper.
+This module is intentionally minimal — it is replaced by that helper, and
+the snapshot tests below stay (they become the regression-suite for the
+uniform gate-laag).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException, status
+
+from app.models.portal import PortalOrg, PortalUser
+
+# All non-admin profile-roles that exist in PROFILES-001 5-rung ladder.
+# An admin endpoint MUST 403 each of these.
+NON_ADMIN_ROLES: tuple[str, ...] = ("personal", "company", "kb_manager", "group_manager")
+
+
+def make_user(
+    *,
+    role: str,
+    zitadel_user_id: str = "uid-test",
+    org_id: int = 101,
+    user_pk: int = 9001,
+) -> MagicMock:
+    """Synthetic `PortalUser` mock with the chosen role.
+
+    Phase 1 will replace this with a typed `ProfileRole` enum + real DB row.
+    """
+    user = MagicMock(spec=PortalUser)
+    user.role = role
+    user.zitadel_user_id = zitadel_user_id
+    user.org_id = org_id
+    user.id = user_pk
+    user.email = f"{role}@example.com"
+    user.first_name = role.capitalize()
+    user.last_name = "Tester"
+    return user
+
+
+def make_org(
+    *,
+    org_id: int = 101,
+    slug: str = "voys",
+    plan: str = "complete",
+) -> MagicMock:
+    """Synthetic `PortalOrg` mock with sensible defaults for admin-gated tests."""
+    org = MagicMock(spec=PortalOrg)
+    org.id = org_id
+    org.slug = slug
+    org.plan = plan
+    org.zitadel_org_id = f"zitadel-org-{org_id}"
+    org.enabled_addons = []
+    org.platform_unlocked_features = []
+    org.provisioning_status = "active"
+    org.moneybird_subscription_id = "ms-test-123"
+    org.moneybird_contact_id = "mc-test-123"
+    org.billing_cycle = "monthly"
+    org.seats = 5
+    org.billing_status = "active"
+    org.name = slug.capitalize()
+    org.mcp_servers = []
+    return org
+
+
+@contextmanager
+def patch_caller(module_path: str, *, role: str | None):
+    """Patch `_get_caller_org` in the endpoint module's namespace.
+
+    role=None  → simulate unauthenticated (`_get_caller_org` raises 401).
+    role=str   → simulate authenticated user with that role.
+    """
+    target = f"{module_path}._get_caller_org"
+    if role is None:
+        with patch(
+            target,
+            side_effect=HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid token",
+            ),
+        ) as mock_:
+            yield mock_
+    else:
+        org = make_org()
+        user = make_user(role=role)
+        with patch(target, return_value=("uid-test", org, user)) as mock_:
+            yield mock_
+
+
+class _PostGateSentinel(Exception):
+    """Synchronous sentinel raised at the first DB call after the role gate.
+
+    Using a synchronous raise (via ``MagicMock(side_effect=...)``) avoids
+    creating awaitable coroutines that would otherwise leak as
+    ``coroutine '...' was never awaited`` RuntimeWarnings when an admin-pass
+    test short-circuits before fully consuming all stubbed awaits.
+    """
+
+
+def make_db_mock() -> MagicMock:
+    """Return a generic AsyncSession-shaped mock that fires _PostGateSentinel
+    synchronously on the first DB call.
+
+    For non-admin / unauthenticated callers, the gate raises HTTP 401/403
+    BEFORE any DB call — so the sentinel never fires. For an admin caller,
+    the gate passes, the endpoint reaches the first DB call, the sentinel
+    fires synchronously, and the helper's ``except Exception: pass`` swallows
+    it as proof of gate-pass.
+    """
+    db = MagicMock()
+    db.execute = MagicMock(side_effect=_PostGateSentinel("post-gate db.execute"))
+    db.scalar = MagicMock(side_effect=_PostGateSentinel("post-gate db.scalar"))
+    db.get = MagicMock(side_effect=_PostGateSentinel("post-gate db.get"))
+    db.flush = MagicMock(side_effect=_PostGateSentinel("post-gate db.flush"))
+    db.commit = MagicMock(side_effect=_PostGateSentinel("post-gate db.commit"))
+    db.refresh = MagicMock(side_effect=_PostGateSentinel("post-gate db.refresh"))
+    db.add = MagicMock()  # add() is sync in SQLAlchemy; let it succeed
+    db.rollback = MagicMock()
+    return db
+
+
+async def assert_admin_passes_gate(
+    endpoint: Callable[..., Awaitable[Any]],
+    module_path: str,
+    **kwargs: Any,
+) -> None:
+    """Pin: an `admin`-role caller MUST NOT receive 401 or 403.
+
+    The endpoint may explode on post-gate work because we do not deeply mock
+    its dependencies; that is expected and acceptable. The only forbidden
+    outcomes for an admin caller are HTTP 401 (auth) and HTTP 403 (role).
+    """
+    with patch_caller(module_path, role="admin"):
+        try:
+            await endpoint(**kwargs)
+        except HTTPException as e:
+            assert e.status_code not in (
+                status.HTTP_401_UNAUTHORIZED,
+                status.HTTP_403_FORBIDDEN,
+            ), f"admin role unexpectedly blocked at gate: status={e.status_code} detail={e.detail!r}"
+        except Exception:  # noqa: S110 — see docstring; gate-pass is the only assertion
+            # Post-gate explosion (TypeError, AttributeError on under-mocked DB,
+            # custom sentinel, …) is acceptable — the gate let admin through.
+            pass
+
+
+async def assert_role_blocked_at_gate(
+    endpoint: Callable[..., Awaitable[Any]],
+    module_path: str,
+    role: str,
+    **kwargs: Any,
+) -> None:
+    """Pin: a non-admin role MUST receive HTTP 403 from the role gate."""
+    with patch_caller(module_path, role=role):
+        with pytest.raises(HTTPException) as exc:
+            await endpoint(**kwargs)
+        assert exc.value.status_code == status.HTTP_403_FORBIDDEN, (
+            f"role={role!r} expected HTTP 403 from gate, got status={exc.value.status_code} detail={exc.value.detail!r}"
+        )
+
+
+async def assert_unauthenticated_blocked(
+    endpoint: Callable[..., Awaitable[Any]],
+    module_path: str,
+    **kwargs: Any,
+) -> None:
+    """Pin: an unauthenticated caller MUST receive HTTP 401.
+
+    The 401 comes from `_get_caller_org` itself before any role check runs.
+    """
+    with patch_caller(module_path, role=None):
+        with pytest.raises(HTTPException) as exc:
+            await endpoint(**kwargs)
+        assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED, (
+            f"unauthenticated call expected HTTP 401, got status={exc.value.status_code} detail={exc.value.detail!r}"
+        )

--- a/klai-portal/backend/tests/test_admin_api_keys_role_matrix.py
+++ b/klai-portal/backend/tests/test_admin_api_keys_role_matrix.py
@@ -1,0 +1,247 @@
+"""Characterization snapshots for `admin_api_keys.py` admin gate.
+
+SPEC-PORTAL-RBAC-REFACTOR-001 Pre-phase. Pins the role matrix for all five
+partner-API-key admin endpoints (create/list/get/update/delete).
+
+  - admin                          → gate passes
+  - personal/company/kb_manager/group_manager → 403
+  - unauthenticated                → 401
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.api.admin_api_keys import (
+    CreateApiKeyRequest,
+    KbAccessEntry,
+    UpdateApiKeyRequest,
+    create_api_key,
+    delete_api_key,
+    get_api_key_detail,
+    list_api_keys,
+    update_api_key,
+)
+from tests.role_matrix_helpers import (
+    NON_ADMIN_ROLES,
+    assert_admin_passes_gate,
+    assert_role_blocked_at_gate,
+    assert_unauthenticated_blocked,
+    make_db_mock,
+)
+
+_MODULE = "app.api.admin_api_keys"
+
+
+def _create_body() -> CreateApiKeyRequest:
+    return CreateApiKeyRequest(
+        name="Test Key",
+        description=None,
+        permissions={"chat": True, "feedback": False, "knowledge_append": False},
+        kb_access=[KbAccessEntry(kb_id=1, access_level="read")],
+        rate_limit_rpm=60,
+    )
+
+
+def _update_body() -> UpdateApiKeyRequest:
+    return UpdateApiKeyRequest(name="Renamed Key")
+
+
+# ---------------------------------------------------------------------------
+# create_api_key — POST /api/admin/api-keys
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_api_key_admin_passes_gate() -> None:
+    await assert_admin_passes_gate(
+        create_api_key,
+        _MODULE,
+        body=_create_body(),
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.parametrize("role", NON_ADMIN_ROLES)
+@pytest.mark.asyncio
+async def test_create_api_key_non_admin_blocked(role: str) -> None:
+    await assert_role_blocked_at_gate(
+        create_api_key,
+        _MODULE,
+        role,
+        body=_create_body(),
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_api_key_unauthenticated() -> None:
+    await assert_unauthenticated_blocked(
+        create_api_key,
+        _MODULE,
+        body=_create_body(),
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# list_api_keys — GET /api/admin/api-keys
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_api_keys_admin_passes_gate() -> None:
+    await assert_admin_passes_gate(
+        list_api_keys,
+        _MODULE,
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.parametrize("role", NON_ADMIN_ROLES)
+@pytest.mark.asyncio
+async def test_list_api_keys_non_admin_blocked(role: str) -> None:
+    await assert_role_blocked_at_gate(
+        list_api_keys,
+        _MODULE,
+        role,
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_api_keys_unauthenticated() -> None:
+    await assert_unauthenticated_blocked(
+        list_api_keys,
+        _MODULE,
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_api_key_detail — GET /api/admin/api-keys/{key_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_api_key_detail_admin_passes_gate() -> None:
+    await assert_admin_passes_gate(
+        get_api_key_detail,
+        _MODULE,
+        key_id="key-test",
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.parametrize("role", NON_ADMIN_ROLES)
+@pytest.mark.asyncio
+async def test_get_api_key_detail_non_admin_blocked(role: str) -> None:
+    await assert_role_blocked_at_gate(
+        get_api_key_detail,
+        _MODULE,
+        role,
+        key_id="key-test",
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_api_key_detail_unauthenticated() -> None:
+    await assert_unauthenticated_blocked(
+        get_api_key_detail,
+        _MODULE,
+        key_id="key-test",
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# update_api_key — PATCH /api/admin/api-keys/{key_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_api_key_admin_passes_gate() -> None:
+    await assert_admin_passes_gate(
+        update_api_key,
+        _MODULE,
+        key_id="key-test",
+        body=_update_body(),
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.parametrize("role", NON_ADMIN_ROLES)
+@pytest.mark.asyncio
+async def test_update_api_key_non_admin_blocked(role: str) -> None:
+    await assert_role_blocked_at_gate(
+        update_api_key,
+        _MODULE,
+        role,
+        key_id="key-test",
+        body=_update_body(),
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_api_key_unauthenticated() -> None:
+    await assert_unauthenticated_blocked(
+        update_api_key,
+        _MODULE,
+        key_id="key-test",
+        body=_update_body(),
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# delete_api_key — DELETE /api/admin/api-keys/{key_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_api_key_admin_passes_gate() -> None:
+    await assert_admin_passes_gate(
+        delete_api_key,
+        _MODULE,
+        key_id="key-test",
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.parametrize("role", NON_ADMIN_ROLES)
+@pytest.mark.asyncio
+async def test_delete_api_key_non_admin_blocked(role: str) -> None:
+    await assert_role_blocked_at_gate(
+        delete_api_key,
+        _MODULE,
+        role,
+        key_id="key-test",
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_api_key_unauthenticated() -> None:
+    await assert_unauthenticated_blocked(
+        delete_api_key,
+        _MODULE,
+        key_id="key-test",
+        credentials=None,
+        db=make_db_mock(),
+    )

--- a/klai-portal/backend/tests/test_admin_widgets_role_matrix.py
+++ b/klai-portal/backend/tests/test_admin_widgets_role_matrix.py
@@ -1,0 +1,251 @@
+"""Characterization snapshots for `admin_widgets.py` admin gate.
+
+SPEC-PORTAL-RBAC-REFACTOR-001 Pre-phase. Pins the current behaviour of the
+five widget endpoints (create/list/get/update/delete) against the role
+matrix:
+
+  - admin                          → gate passes (no 401/403)
+  - personal/company/kb_manager/group_manager → 403 from `_require_admin`
+  - unauthenticated                → 401 from `_get_caller_org`
+
+Snapshots stay after the refactor lands as the regression-suite for the
+uniform `Depends(get_caller_at_least(ProfileRole.ADMIN))` gate.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.api.admin_widgets import (
+    CreateWidgetRequest,
+    UpdateWidgetRequest,
+    WidgetConfig,
+    create_widget,
+    delete_widget,
+    get_widget_detail,
+    list_widgets,
+    update_widget,
+)
+from tests.role_matrix_helpers import (
+    NON_ADMIN_ROLES,
+    assert_admin_passes_gate,
+    assert_role_blocked_at_gate,
+    assert_unauthenticated_blocked,
+    make_db_mock,
+)
+
+_MODULE = "app.api.admin_widgets"
+
+
+def _create_body() -> CreateWidgetRequest:
+    return CreateWidgetRequest(
+        name="Help Bot",
+        description=None,
+        kb_ids=[1],
+        rate_limit_rpm=60,
+        widget_config=WidgetConfig(),
+    )
+
+
+def _update_body() -> UpdateWidgetRequest:
+    return UpdateWidgetRequest(name="Renamed Bot")
+
+
+# ---------------------------------------------------------------------------
+# create_widget — POST /api/admin/widgets
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_widget_admin_passes_gate() -> None:
+    await assert_admin_passes_gate(
+        create_widget,
+        _MODULE,
+        body=_create_body(),
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.parametrize("role", NON_ADMIN_ROLES)
+@pytest.mark.asyncio
+async def test_create_widget_non_admin_blocked(role: str) -> None:
+    await assert_role_blocked_at_gate(
+        create_widget,
+        _MODULE,
+        role,
+        body=_create_body(),
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_widget_unauthenticated() -> None:
+    await assert_unauthenticated_blocked(
+        create_widget,
+        _MODULE,
+        body=_create_body(),
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# list_widgets — GET /api/admin/widgets
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_widgets_admin_passes_gate() -> None:
+    await assert_admin_passes_gate(
+        list_widgets,
+        _MODULE,
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.parametrize("role", NON_ADMIN_ROLES)
+@pytest.mark.asyncio
+async def test_list_widgets_non_admin_blocked(role: str) -> None:
+    await assert_role_blocked_at_gate(
+        list_widgets,
+        _MODULE,
+        role,
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_widgets_unauthenticated() -> None:
+    await assert_unauthenticated_blocked(
+        list_widgets,
+        _MODULE,
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_widget_detail — GET /api/admin/widgets/{widget_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_widget_detail_admin_passes_gate() -> None:
+    await assert_admin_passes_gate(
+        get_widget_detail,
+        _MODULE,
+        widget_id="wgt_test",
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.parametrize("role", NON_ADMIN_ROLES)
+@pytest.mark.asyncio
+async def test_get_widget_detail_non_admin_blocked(role: str) -> None:
+    await assert_role_blocked_at_gate(
+        get_widget_detail,
+        _MODULE,
+        role,
+        widget_id="wgt_test",
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_widget_detail_unauthenticated() -> None:
+    await assert_unauthenticated_blocked(
+        get_widget_detail,
+        _MODULE,
+        widget_id="wgt_test",
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# update_widget — PATCH /api/admin/widgets/{widget_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_widget_admin_passes_gate() -> None:
+    await assert_admin_passes_gate(
+        update_widget,
+        _MODULE,
+        widget_id="wgt_test",
+        body=_update_body(),
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.parametrize("role", NON_ADMIN_ROLES)
+@pytest.mark.asyncio
+async def test_update_widget_non_admin_blocked(role: str) -> None:
+    await assert_role_blocked_at_gate(
+        update_widget,
+        _MODULE,
+        role,
+        widget_id="wgt_test",
+        body=_update_body(),
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_widget_unauthenticated() -> None:
+    await assert_unauthenticated_blocked(
+        update_widget,
+        _MODULE,
+        widget_id="wgt_test",
+        body=_update_body(),
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# delete_widget — DELETE /api/admin/widgets/{widget_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_widget_admin_passes_gate() -> None:
+    await assert_admin_passes_gate(
+        delete_widget,
+        _MODULE,
+        widget_id="wgt_test",
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.parametrize("role", NON_ADMIN_ROLES)
+@pytest.mark.asyncio
+async def test_delete_widget_non_admin_blocked(role: str) -> None:
+    await assert_role_blocked_at_gate(
+        delete_widget,
+        _MODULE,
+        role,
+        widget_id="wgt_test",
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_widget_unauthenticated() -> None:
+    await assert_unauthenticated_blocked(
+        delete_widget,
+        _MODULE,
+        widget_id="wgt_test",
+        credentials=None,
+        db=make_db_mock(),
+    )

--- a/klai-portal/backend/tests/test_app_gaps_role_matrix.py
+++ b/klai-portal/backend/tests/test_app_gaps_role_matrix.py
@@ -1,0 +1,164 @@
+"""Characterization snapshots for `app_gaps.py` admin gate.
+
+SPEC-PORTAL-RBAC-REFACTOR-001 Pre-phase. Pins the role matrix for the three
+admin-gated gap endpoints (`list_gaps`, `get_gap_summary`, `get_gaps_by_taxonomy`).
+
+  - admin                          → gate passes
+  - personal/company/kb_manager/group_manager → 403
+  - unauthenticated                → 401
+
+Note: the router itself carries `dependencies=[Depends(require_capability(KB_GAPS))]`,
+which is enforced by FastAPI BEFORE the endpoint body runs in real HTTP. These
+snapshots call the endpoint functions directly so the router-level capability
+gate is bypassed; only the inner `_require_admin` gate is exercised. That is
+exactly what the SPEC's Phase 1+2 refactor changes — the capability gate is
+out of scope here and pinned elsewhere.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.api.app_gaps import (
+    get_gap_summary,
+    get_gaps_by_taxonomy,
+    list_gaps,
+)
+from tests.role_matrix_helpers import (
+    NON_ADMIN_ROLES,
+    assert_admin_passes_gate,
+    assert_role_blocked_at_gate,
+    assert_unauthenticated_blocked,
+    make_db_mock,
+)
+
+_MODULE = "app.api.app_gaps"
+
+
+# ---------------------------------------------------------------------------
+# list_gaps — GET /api/app/gaps
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_gaps_admin_passes_gate() -> None:
+    await assert_admin_passes_gate(
+        list_gaps,
+        _MODULE,
+        days=30,
+        gap_type=None,
+        taxonomy_node_id=None,
+        limit=50,
+        include_resolved=False,
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.parametrize("role", NON_ADMIN_ROLES)
+@pytest.mark.asyncio
+async def test_list_gaps_non_admin_blocked(role: str) -> None:
+    await assert_role_blocked_at_gate(
+        list_gaps,
+        _MODULE,
+        role,
+        days=30,
+        gap_type=None,
+        taxonomy_node_id=None,
+        limit=50,
+        include_resolved=False,
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_gaps_unauthenticated() -> None:
+    await assert_unauthenticated_blocked(
+        list_gaps,
+        _MODULE,
+        days=30,
+        gap_type=None,
+        taxonomy_node_id=None,
+        limit=50,
+        include_resolved=False,
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_gap_summary — GET /api/app/gaps/summary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_gap_summary_admin_passes_gate() -> None:
+    await assert_admin_passes_gate(
+        get_gap_summary,
+        _MODULE,
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.parametrize("role", NON_ADMIN_ROLES)
+@pytest.mark.asyncio
+async def test_get_gap_summary_non_admin_blocked(role: str) -> None:
+    await assert_role_blocked_at_gate(
+        get_gap_summary,
+        _MODULE,
+        role,
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_gap_summary_unauthenticated() -> None:
+    await assert_unauthenticated_blocked(
+        get_gap_summary,
+        _MODULE,
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_gaps_by_taxonomy — GET /api/app/gaps/by-taxonomy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_gaps_by_taxonomy_admin_passes_gate() -> None:
+    await assert_admin_passes_gate(
+        get_gaps_by_taxonomy,
+        _MODULE,
+        days=30,
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.parametrize("role", NON_ADMIN_ROLES)
+@pytest.mark.asyncio
+async def test_get_gaps_by_taxonomy_non_admin_blocked(role: str) -> None:
+    await assert_role_blocked_at_gate(
+        get_gaps_by_taxonomy,
+        _MODULE,
+        role,
+        days=30,
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_gaps_by_taxonomy_unauthenticated() -> None:
+    await assert_unauthenticated_blocked(
+        get_gaps_by_taxonomy,
+        _MODULE,
+        days=30,
+        credentials=None,
+        db=make_db_mock(),
+    )

--- a/klai-portal/backend/tests/test_billing_role_matrix.py
+++ b/klai-portal/backend/tests/test_billing_role_matrix.py
@@ -1,0 +1,143 @@
+"""Characterization snapshots for `billing.py` admin gate.
+
+SPEC-PORTAL-RBAC-REFACTOR-001 Pre-phase. Pins the current behaviour of the
+two admin-gated billing endpoints (`create_mandate`, `cancel_subscription`)
+against the role matrix:
+
+  - admin                          → gate passes (no 401/403)
+  - personal/company/kb_manager/group_manager → 403 from `_require_admin`
+  - unauthenticated                → 401 from `_get_caller_org`
+
+The other three endpoints in `billing.py` (`mock_complete`, `billing_status`,
+`invoice_portal`) only require authentication, not admin, so they are out
+of scope for this snapshot.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.api.billing import (
+    MandateRequest,
+    cancel_subscription,
+    create_mandate,
+)
+from tests.helpers import make_request
+from tests.role_matrix_helpers import (
+    NON_ADMIN_ROLES,
+    assert_admin_passes_gate,
+    assert_role_blocked_at_gate,
+    assert_unauthenticated_blocked,
+    make_db_mock,
+)
+
+_MODULE = "app.api.billing"
+
+
+def _mandate_body() -> MandateRequest:
+    return MandateRequest(
+        plan="complete",
+        billing_cycle="monthly",
+        seats=2,
+        address="Teststraat 1",
+        zipcode="1011AA",
+        city="Amsterdam",
+        country="NL",
+    )
+
+
+def _moneybird_mock() -> AsyncMock:
+    """Stand-in for the MoneybirdService dependency."""
+    m = AsyncMock()
+    m.create_contact = AsyncMock(return_value={"id": "mc-9001"})
+    m.get_mandate_url = AsyncMock(return_value="https://example.com/mandate")
+    m.cancel_subscription = AsyncMock()
+    return m
+
+
+# ---------------------------------------------------------------------------
+# create_mandate — POST /api/billing/mandate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_mandate_admin_passes_gate() -> None:
+    await assert_admin_passes_gate(
+        create_mandate,
+        _MODULE,
+        request=make_request(method="POST", path="/api/billing/mandate"),
+        body=_mandate_body(),
+        credentials=MagicMock(credentials="tok"),
+        db=make_db_mock(),
+        moneybird=_moneybird_mock(),
+    )
+
+
+@pytest.mark.parametrize("role", NON_ADMIN_ROLES)
+@pytest.mark.asyncio
+async def test_create_mandate_non_admin_blocked(role: str) -> None:
+    await assert_role_blocked_at_gate(
+        create_mandate,
+        _MODULE,
+        role,
+        request=make_request(method="POST", path="/api/billing/mandate"),
+        body=_mandate_body(),
+        credentials=MagicMock(credentials="tok"),
+        db=make_db_mock(),
+        moneybird=_moneybird_mock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_mandate_unauthenticated() -> None:
+    await assert_unauthenticated_blocked(
+        create_mandate,
+        _MODULE,
+        request=make_request(method="POST", path="/api/billing/mandate"),
+        body=_mandate_body(),
+        credentials=MagicMock(credentials="tok"),
+        db=make_db_mock(),
+        moneybird=_moneybird_mock(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# cancel_subscription — POST /api/billing/cancel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancel_subscription_admin_passes_gate() -> None:
+    await assert_admin_passes_gate(
+        cancel_subscription,
+        _MODULE,
+        credentials=MagicMock(credentials="tok"),
+        db=make_db_mock(),
+        moneybird=_moneybird_mock(),
+    )
+
+
+@pytest.mark.parametrize("role", NON_ADMIN_ROLES)
+@pytest.mark.asyncio
+async def test_cancel_subscription_non_admin_blocked(role: str) -> None:
+    await assert_role_blocked_at_gate(
+        cancel_subscription,
+        _MODULE,
+        role,
+        credentials=MagicMock(credentials="tok"),
+        db=make_db_mock(),
+        moneybird=_moneybird_mock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancel_subscription_unauthenticated() -> None:
+    await assert_unauthenticated_blocked(
+        cancel_subscription,
+        _MODULE,
+        credentials=MagicMock(credentials="tok"),
+        db=make_db_mock(),
+        moneybird=_moneybird_mock(),
+    )

--- a/klai-portal/backend/tests/test_groups_role_matrix.py
+++ b/klai-portal/backend/tests/test_groups_role_matrix.py
@@ -1,0 +1,178 @@
+"""Characterization snapshots for `groups.py` admin gate.
+
+SPEC-PORTAL-RBAC-REFACTOR-001 Pre-phase. Pins the role matrix for the three
+admin-gated group endpoints called out in the SPEC pre-phase scope:
+
+  - update_group       (PATCH  /api/admin/groups/{id})
+  - delete_group       (DELETE /api/admin/groups/{id})
+  - toggle_group_admin (PATCH  /api/admin/groups/{id}/members/{user_id})
+
+  - admin                          → gate passes
+  - personal/company/kb_manager/group_manager → 403
+  - unauthenticated                → 401
+
+Note: REQ-8/9 of the SPEC explicitly REQUIRES that after the refactor a
+`group_manager` user can rename / delete / toggle membership in groups
+within their own org. The current code returns 403 — that is the bug the
+SPEC fixes. These snapshots pin TODAY's (broken) behaviour so the Phase
+2h refactor can demonstrate the change is intentional. Phase 3C will add
+new tests asserting `group_manager` → 200 / 204.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.api.groups import (
+    GroupAdminToggleRequest,
+    GroupUpdateRequest,
+    delete_group,
+    toggle_group_admin,
+    update_group,
+)
+from tests.role_matrix_helpers import (
+    NON_ADMIN_ROLES,
+    assert_admin_passes_gate,
+    assert_role_blocked_at_gate,
+    assert_unauthenticated_blocked,
+    make_db_mock,
+)
+
+_MODULE = "app.api.groups"
+
+
+def _update_body() -> GroupUpdateRequest:
+    return GroupUpdateRequest(name="Renamed Group")
+
+
+def _toggle_body(*, is_group_admin: bool = True) -> GroupAdminToggleRequest:
+    return GroupAdminToggleRequest(is_group_admin=is_group_admin)
+
+
+# ---------------------------------------------------------------------------
+# update_group — PATCH /api/admin/groups/{group_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_group_admin_passes_gate() -> None:
+    await assert_admin_passes_gate(
+        update_group,
+        _MODULE,
+        group_id=1,
+        body=_update_body(),
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.parametrize("role", NON_ADMIN_ROLES)
+@pytest.mark.asyncio
+async def test_update_group_non_admin_blocked(role: str) -> None:
+    await assert_role_blocked_at_gate(
+        update_group,
+        _MODULE,
+        role,
+        group_id=1,
+        body=_update_body(),
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_group_unauthenticated() -> None:
+    await assert_unauthenticated_blocked(
+        update_group,
+        _MODULE,
+        group_id=1,
+        body=_update_body(),
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# delete_group — DELETE /api/admin/groups/{group_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_group_admin_passes_gate() -> None:
+    await assert_admin_passes_gate(
+        delete_group,
+        _MODULE,
+        group_id=1,
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.parametrize("role", NON_ADMIN_ROLES)
+@pytest.mark.asyncio
+async def test_delete_group_non_admin_blocked(role: str) -> None:
+    await assert_role_blocked_at_gate(
+        delete_group,
+        _MODULE,
+        role,
+        group_id=1,
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_group_unauthenticated() -> None:
+    await assert_unauthenticated_blocked(
+        delete_group,
+        _MODULE,
+        group_id=1,
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# toggle_group_admin — PATCH /api/admin/groups/{group_id}/members/{user_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_toggle_group_admin_admin_passes_gate() -> None:
+    await assert_admin_passes_gate(
+        toggle_group_admin,
+        _MODULE,
+        group_id=1,
+        user_id="uid-target",
+        body=_toggle_body(),
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.parametrize("role", NON_ADMIN_ROLES)
+@pytest.mark.asyncio
+async def test_toggle_group_admin_non_admin_blocked(role: str) -> None:
+    await assert_role_blocked_at_gate(
+        toggle_group_admin,
+        _MODULE,
+        role,
+        group_id=1,
+        user_id="uid-target",
+        body=_toggle_body(),
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_toggle_group_admin_unauthenticated() -> None:
+    await assert_unauthenticated_blocked(
+        toggle_group_admin,
+        _MODULE,
+        group_id=1,
+        user_id="uid-target",
+        body=_toggle_body(),
+        credentials=None,
+        db=make_db_mock(),
+    )

--- a/klai-portal/backend/tests/test_mcp_servers_role_matrix.py
+++ b/klai-portal/backend/tests/test_mcp_servers_role_matrix.py
@@ -1,0 +1,161 @@
+"""Characterization snapshots for `mcp_servers.py` admin gate.
+
+SPEC-PORTAL-RBAC-REFACTOR-001 Pre-phase. Pins the role matrix for the three
+admin-gated MCP-server endpoints (list/update/test).
+
+  - admin                          → gate passes
+  - personal/company/kb_manager/group_manager → 403
+  - unauthenticated                → 401
+
+Phase 5 of the SPEC adds an additional `require_platform_unlocked("custom_mcps")`
+gate on `update_mcp_server` for non-managed catalog entries. That layer is NOT
+exercised here — these snapshots only pin the existing admin-role gate. After
+Phase 5 lands, an additional set of tests pins the platform-unlock layer.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# Aliased import for `test_mcp_server` so pytest doesn't collect the imported
+# endpoint function as a test (any module-level callable starting with `test_`
+# is collected).
+from app.api.mcp_servers import (
+    McpServerUpdateRequest,
+    list_mcp_servers,
+    update_mcp_server,
+)
+from app.api.mcp_servers import test_mcp_server as _test_mcp_server_endpoint
+from tests.role_matrix_helpers import (
+    NON_ADMIN_ROLES,
+    assert_admin_passes_gate,
+    assert_role_blocked_at_gate,
+    assert_unauthenticated_blocked,
+    make_db_mock,
+)
+
+_MODULE = "app.api.mcp_servers"
+
+
+def _update_body() -> McpServerUpdateRequest:
+    return McpServerUpdateRequest(enabled=False, env={})
+
+
+# ---------------------------------------------------------------------------
+# list_mcp_servers — GET /api/mcp-servers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_mcp_servers_admin_passes_gate() -> None:
+    await assert_admin_passes_gate(
+        list_mcp_servers,
+        _MODULE,
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.parametrize("role", NON_ADMIN_ROLES)
+@pytest.mark.asyncio
+async def test_list_mcp_servers_non_admin_blocked(role: str) -> None:
+    await assert_role_blocked_at_gate(
+        list_mcp_servers,
+        _MODULE,
+        role,
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_mcp_servers_unauthenticated() -> None:
+    await assert_unauthenticated_blocked(
+        list_mcp_servers,
+        _MODULE,
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# update_mcp_server — PUT /api/mcp-servers/{server_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_mcp_server_admin_passes_gate() -> None:
+    await assert_admin_passes_gate(
+        update_mcp_server,
+        _MODULE,
+        server_id="some-server",
+        body=_update_body(),
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.parametrize("role", NON_ADMIN_ROLES)
+@pytest.mark.asyncio
+async def test_update_mcp_server_non_admin_blocked(role: str) -> None:
+    await assert_role_blocked_at_gate(
+        update_mcp_server,
+        _MODULE,
+        role,
+        server_id="some-server",
+        body=_update_body(),
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_mcp_server_unauthenticated() -> None:
+    await assert_unauthenticated_blocked(
+        update_mcp_server,
+        _MODULE,
+        server_id="some-server",
+        body=_update_body(),
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# test_mcp_server — POST /api/mcp-servers/{server_id}/test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_probe_endpoint_admin_passes_gate() -> None:
+    await assert_admin_passes_gate(
+        _test_mcp_server_endpoint,
+        _MODULE,
+        server_id="some-server",
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.parametrize("role", NON_ADMIN_ROLES)
+@pytest.mark.asyncio
+async def test_probe_endpoint_non_admin_blocked(role: str) -> None:
+    await assert_role_blocked_at_gate(
+        _test_mcp_server_endpoint,
+        _MODULE,
+        role,
+        server_id="some-server",
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_probe_endpoint_unauthenticated() -> None:
+    await assert_unauthenticated_blocked(
+        _test_mcp_server_endpoint,
+        _MODULE,
+        server_id="some-server",
+        credentials=None,
+        db=make_db_mock(),
+    )

--- a/klai-portal/backend/tests/test_taxonomy_role_matrix.py
+++ b/klai-portal/backend/tests/test_taxonomy_role_matrix.py
@@ -1,0 +1,67 @@
+"""Characterization snapshot for `taxonomy.py` admin gate.
+
+SPEC-PORTAL-RBAC-REFACTOR-001 Pre-phase. Pins the role matrix for the only
+admin-gated endpoint in `taxonomy.py`: `taxonomy_coverage`. The other
+taxonomy endpoints are gated via `Depends(require_capability(KB_TAXONOMY))`
+at the router level (or are member-readable like `taxonomy_top_tags`); they
+are out of scope for the imperative-`_require_admin` snapshot.
+
+  - admin                          → gate passes
+  - personal/company/kb_manager/group_manager → 403
+  - unauthenticated                → 401
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.api.taxonomy import taxonomy_coverage
+from tests.role_matrix_helpers import (
+    NON_ADMIN_ROLES,
+    assert_admin_passes_gate,
+    assert_role_blocked_at_gate,
+    assert_unauthenticated_blocked,
+    make_db_mock,
+)
+
+_MODULE = "app.api.taxonomy"
+
+
+# ---------------------------------------------------------------------------
+# taxonomy_coverage — GET /api/app/knowledge-bases/{kb_slug}/taxonomy/coverage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_taxonomy_coverage_admin_passes_gate() -> None:
+    await assert_admin_passes_gate(
+        taxonomy_coverage,
+        _MODULE,
+        kb_slug="general",
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.parametrize("role", NON_ADMIN_ROLES)
+@pytest.mark.asyncio
+async def test_taxonomy_coverage_non_admin_blocked(role: str) -> None:
+    await assert_role_blocked_at_gate(
+        taxonomy_coverage,
+        _MODULE,
+        role,
+        kb_slug="general",
+        credentials=None,
+        db=make_db_mock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_taxonomy_coverage_unauthenticated() -> None:
+    await assert_unauthenticated_blocked(
+        taxonomy_coverage,
+        _MODULE,
+        kb_slug="general",
+        credentials=None,
+        db=make_db_mock(),
+    )


### PR DESCRIPTION
## Summary

SPEC-PORTAL-RBAC-REFACTOR-001 **Pre-phase**. 132 characterization snapshots pinnen het huidige `_require_admin`-gate gedrag voor 22 endpoints over 7 files. Alleen test-code; nul productie-code aangeraakt.

De snapshots blijven ná de Phase 1+2 refactor staan als regression-suite voor de uniforme declaratieve gate-laag (`Depends(get_caller_at_least(...))`).

### Coverage per file

| File | Endpoints | Tests |
|---|---|---|
| `admin_widgets.py` | create/list/get/update/delete | 30 |
| `admin_api_keys.py` | create/list/get/update/delete | 30 |
| `mcp_servers.py` | list/update/test | 18 |
| `groups.py` | update_group/delete_group/toggle_group_admin | 18 |
| `app_gaps.py` | list_gaps/get_gap_summary/get_gaps_by_taxonomy | 18 |
| `billing.py` | create_mandate/cancel_subscription | 12 |
| `taxonomy.py` | taxonomy_coverage | 6 |
| **Totaal** | **22 endpoints** | **132 tests** |

### Pattern

Direct function-call met `_get_caller_org` gepatcht in de endpoint-module namespace + een synchrone `_PostGateSentinel` op de AsyncSession-mock. Geeft (a) deterministische gate-pass-detectie voor admin, (b) geen unawaited-coroutine warnings, (c) onafhankelijk van router-level `Depends(require_capability(...))` — die laag verandert niet door de refactor en is dus geen onderdeel van de snapshot.

### Bewuste keuzes

- **`billing.py`**: alleen de 2 endpoints die `_require_admin` gebruiken (`create_mandate`, `cancel_subscription`). De andere 3 (`mock_complete`, `billing_status`, `invoice_portal`) zijn auth-only en vallen niet onder de gate-refactor.
- **`taxonomy.py`**: alleen `taxonomy_coverage` (de enige `_require_admin`-gated). De rest gaat via `require_capability(KB_TAXONOMY)` en blijft.
- **`groups.py`**: snapshot pint `group_manager → 403` als TODAY's gedrag. SPEC REQ-8/9 gaat dit in Phase 2h omdraaien naar `group_manager → 200`. Phase 2h moet deze drie tests dus bewust updaten — gedocumenteerd in de file-docstring.

### Helper

`tests/role_matrix_helpers.py` is **TEMPORARY**. Phase 1 vervangt de minimale `make_user(role=...)` / `make_org(...)` factories door een definitieve typed-`ProfileRole`-fixture in `conftest.py`. Marker staat in de module-docstring.

## Test plan

- [x] `pytest tests/test_*_role_matrix.py` — 132 passed
- [x] Volledige backend-suite — 2156 passed, 3 deselected
- [x] `ruff check` + `ruff format --check` schoon op nieuwe files
- [ ] CI groen na push

## Refs

- `.moai/specs/SPEC-PORTAL-RBAC-REFACTOR-001/spec.md` — Pre-phase sectie
- `.moai/specs/SPEC-PORTAL-RBAC-REFACTOR-001/research.md` — Thread F (test-strategie)

## Niet in deze PR

- Geen productie-code (geen `_require_admin` rewrites, geen Alembic, geen klai-knowledge-mcp / klai-retrieval-api wijzigingen)
- Geen Voys-tenant verificatie via Playwright (komt vanaf Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)