### PR TITLE
[codex] Harden webhook auth and response logging

### DIFF
--- a/.claude/skills/codeindex/codeindex-cli/SKILL.md
+++ b/.claude/skills/codeindex/codeindex-cli/SKILL.md
@@ -15,7 +15,7 @@ All commands work via `npx` — no global install required.
 npx codeindex analyze
 ```
 
-Run from the project root. This parses all source files, builds the knowledge graph, writes it to `.codeindex/`, and generates CLAUDE.md / AGENTS.md context files.
+Run from the project root. This parses all source files, builds the knowledge graph, writes it to `~/.codeindex/<ProjectName>/` (global cache — NEVER inside the working copy), and generates CLAUDE.md / AGENTS.md context files in the project root.
 
 | Flag           | Effect                                                           |
 | -------------- | ---------------------------------------------------------------- |
@@ -38,7 +38,9 @@ Shows whether the current repo has a CodeIndex index, when it was last updated, 
 npx codeindex clean
 ```
 
-Deletes the `.codeindex/` directory and unregisters the repo from the global registry. Use before re-indexing if the index is corrupt or after removing CodeIndex from a project.
+Deletes the repo's entry under `~/.codeindex/<ProjectName>/` and unregisters it from the global registry. Use before re-indexing if the index is corrupt or after removing CodeIndex from a project. Never deletes anything inside the working copy.
+
+> If you find a stray `.codeindex/` directory inside a project root it is leftover from an older CodeIndex version. Safe to delete — the current version never writes there.
 
 | Flag      | Effect                                            |
 | --------- | ------------------------------------------------- |

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -3,21 +3,26 @@ project_name: "klai"
 
 
 # list of languages for which language servers are started; choose from:
-#   al                  bash                clojure             cpp                 csharp
-#   csharp_omnisharp    dart                elixir              elm                 erlang
-#   fortran             fsharp              go                  groovy              haskell
-#   java                julia               kotlin              lua                 markdown
-#   matlab              nix                 pascal              perl                php
-#   php_phpactor        powershell          python              python_jedi         r
-#   rego                ruby                ruby_solargraph     rust                scala
-#   swift               terraform           toml                typescript          typescript_vts
-#   vue                 yaml                zig
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   swift               systemverilog       terraform           toml                typescript
+#   typescript_vts      vue                 yaml                zig
 #   (This list may be outdated. For the current list, see values of Language enum here:
 #   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
 #   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
 # Note:
 #   - For C, use cpp
 #   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
 #   - For Free Pascal/Lazarus, use pascal
 # Special requirements:
 #   Some languages require additional setup/installations.
@@ -51,8 +56,6 @@ ignore_all_files_in_gitignore: true
 # list of additional paths to ignore in this project.
 # Same syntax as gitignore, so you can use * and **.
 # Note: global ignored_paths from serena_config.yml are also applied additively.
-# These dirs contain specs, reports, and docs — not code. Excluding them prevents
-# search_for_pattern from matching hundreds of irrelevant markdown files.
 ignored_paths:
 - ".moai/specs/**"
 - ".moai/reports/**"
@@ -68,53 +71,17 @@ read_only: false
 
 # list of tool names to exclude.
 # This extends the existing exclusions (e.g. from the global configuration)
-#
-# Below is the complete list of tools for convenience.
-# To make sure you have the latest list of tools, and to view their descriptions, 
-# execute `uv run scripts/print_tool_overview.py`.
-#
-#  * `activate_project`: Activates a project by name.
-#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
-#  * `create_text_file`: Creates/overwrites a file in the project directory.
-#  * `delete_lines`: Deletes a range of lines within a file.
-#  * `delete_memory`: Deletes a memory from Serena's project-specific memory store.
-#  * `execute_shell_command`: Executes a shell command.
-#  * `find_referencing_code_snippets`: Finds code snippets in which the symbol at the given location is referenced.
-#  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
-#  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
-#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
-#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
-#  * `initial_instructions`: Gets the initial instructions for the current project.
-#     Should only be used in settings where the system prompt cannot be set,
-#     e.g. in clients you have no control over, like Claude Desktop.
-#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
-#  * `insert_at_line`: Inserts content at a given line in a file.
-#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
-#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
-#  * `list_memories`: Lists memories in Serena's project-specific memory store.
-#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
-#  * `prepare_for_new_conversation`: Provides instructions for preparing for a new conversation (in order to continue with the necessary context).
-#  * `read_file`: Reads a file within the project directory.
-#  * `read_memory`: Reads the memory with the given name from Serena's project-specific memory store.
-#  * `remove_project`: Removes a project from the Serena configuration.
-#  * `replace_lines`: Replaces a range of lines within a file with new content.
-#  * `replace_symbol_body`: Replaces the full definition of a symbol.
-#  * `restart_language_server`: Restarts the language server, may be necessary when edits not through Serena happen.
-#  * `search_for_pattern`: Performs a search for a pattern in the project.
-#  * `summarize_changes`: Provides instructions for summarizing the changes made to the codebase.
-#  * `switch_modes`: Activates modes by providing a list of their names
-#  * `think_about_collected_information`: Thinking tool for pondering the completeness of collected information.
-#  * `think_about_task_adherence`: Thinking tool for determining whether the agent is still on track with the current task.
-#  * `think_about_whether_you_are_done`: Thinking tool for determining whether the task is truly completed.
-#  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 excluded_tools: []
 
 # list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
 # This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 included_optional_tools: []
 
 # fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
 # This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 fixed_tools: []
 
 # list of mode names to that are always to be included in the set of active modes
@@ -125,11 +92,14 @@ fixed_tools: []
 # Set this to a list of mode names to always include the respective modes for this project.
 base_modes:
 
-# list of mode names that are to be activated by default.
-# The full set of modes to be activated is base_modes + default_modes.
-# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
 # Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
 # This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
 default_modes:
 
 # initial prompt for the project. It will always be given to the LLM upon activating the project
@@ -171,3 +141,19 @@ ignored_memory_patterns: []
 # Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
 # No documentation on options means no options are available.
 ls_specific_settings: {}
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- codeindex:start -->
 # CodeIndex MCP
 
-This project is indexed by CodeIndex as **klai** (7475 symbols, 16741 relationships, 300 execution flows).
+This project is indexed by CodeIndex as **klai** (10656 symbols, 24578 relationships, 267 execution flows).
 
 ## Rules (MUST follow)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- codeindex:start -->
 # CodeIndex MCP
 
-This project is indexed by CodeIndex as **klai** (10656 symbols, 24578 relationships, 267 execution flows).
+This project is indexed by CodeIndex as **klai** (10656 symbols, 25372 relationships, 267 execution flows).
 
 ## Rules (MUST follow)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -574,7 +574,7 @@ For detailed patterns on plugins, sandboxing, headless mode, and version managem
 <!-- codeindex:start -->
 # CodeIndex MCP
 
-This project is indexed by CodeIndex as **klai** (10656 symbols, 24578 relationships, 267 execution flows).
+This project is indexed by CodeIndex as **klai** (10656 symbols, 25372 relationships, 267 execution flows).
 
 ## Rules (MUST follow)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -574,7 +574,7 @@ For detailed patterns on plugins, sandboxing, headless mode, and version managem
 <!-- codeindex:start -->
 # CodeIndex MCP
 
-This project is indexed by CodeIndex as **klai** (7475 symbols, 16741 relationships, 300 execution flows).
+This project is indexed by CodeIndex as **klai** (10656 symbols, 24578 relationships, 267 execution flows).
 
 ## Rules (MUST follow)
 

--- a/deploy/litellm/klai_knowledge.py
+++ b/deploy/litellm/klai_knowledge.py
@@ -95,6 +95,21 @@ KLAI_OAUTH_TOKEN_URL = os.getenv("KLAI_OAUTH_TOKEN_URL", "")
 KLAI_LITELLM_CLIENT_ID = os.getenv("KLAI_LITELLM_CLIENT_ID", "")
 KLAI_LITELLM_CLIENT_SECRET = os.getenv("KLAI_LITELLM_CLIENT_SECRET", "")
 
+
+def _sanitize_upstream_body(body: str, *, max_len: int = 200) -> str:
+    """Redact local service secrets before logging an upstream error body."""
+    if not body:
+        return ""
+    safe = body
+    secret_values = (
+        PORTAL_INTERNAL_SECRET,
+        RETRIEVAL_INTERNAL_SECRET,
+        KLAI_LITELLM_CLIENT_SECRET,
+    )
+    for secret in sorted({s for s in secret_values if len(s) >= 8}, key=len, reverse=True):
+        safe = safe.replace(secret, "<redacted>")
+    return safe[:max_len]
+
 # Lazy-built ZitadelTokenClient instance. None when env vars are missing —
 # the retrieve call site handles that by falling back to the legacy
 # X-Internal-Secret path (Phase C-1 REQ-5 safe rollout).
@@ -1353,11 +1368,10 @@ class KlaiKnowledgeHook(CustomLogger):
             # caller-service-header regression in production for 7 days.
             # @MX:REASON: SPEC-SEC-IDENTITY-ASSERT-001 Phase D + the
             # `retrieve-caller-service-header-mismatch` pitfall.
-            body_snippet = ""
-            try:
-                body_snippet = exc.response.text[:200]
-            except Exception:
-                pass
+            body_snippet = _sanitize_upstream_body(
+                getattr(exc.response, "text", ""),
+                max_len=200,
+            )
             logger.error(
                 "KlaiKnowledgeHook: retrieval HTTP %d — body=%r — failing loud",
                 exc.response.status_code,

--- a/deploy/litellm/klai_service_auth.py
+++ b/deploy/litellm/klai_service_auth.py
@@ -74,6 +74,20 @@ _REFRESH_FRACTION: float = 0.8
 _MIN_TTL_SECONDS: int = 60
 
 
+def _sanitize_body_excerpt(
+    body: str,
+    secret_values: tuple[str, ...],
+    *,
+    max_len: int = 500,
+) -> str:
+    if not body:
+        return ""
+    safe = body
+    for secret in sorted({s for s in secret_values if len(s) >= 8}, key=len, reverse=True):
+        safe = safe.replace(secret, "<redacted>")
+    return safe[:max_len]
+
+
 # --- canonical scope constants (subset needed by LiteLLM hook) -------------
 # Mirrors klai-libs/service-auth/klai_service_auth/scopes.py. Only the scopes
 # this caller (svc-litellm) might request are vendored — adding more is fine
@@ -169,7 +183,11 @@ class ZitadelTokenClient:
             raise ServiceAuthError(f"token mint network error: {exc}") from exc
 
         if resp.status_code != 200:
-            body_excerpt = resp.text[:500] if resp.text else ""
+            body_excerpt = _sanitize_body_excerpt(
+                resp.text,
+                (self._client_secret,),
+                max_len=500,
+            )
             # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
             logger.warning(
                 "service_auth_token_mint_failed client_id=%s status_code=%d "

--- a/deploy/litellm/tests/test_klai_service_auth_drift.py
+++ b/deploy/litellm/tests/test_klai_service_auth_drift.py
@@ -85,6 +85,21 @@ def test_vendored_constants_match():
     )
 
 
+def test_vendored_body_excerpt_sanitizer_matches_canonical():
+    """The vendored copy must redact client secrets from IdP error bodies."""
+    vendored = _load("_drift_vendored_sanitize", _VENDORED_PATH)
+    canonical = _load("_drift_canonical_sanitize", _CANONICAL_DIR / "client.py")
+
+    body = "invalid client_secret=super-secret-client-value"
+    secrets = ("super-secret-client-value",)
+
+    assert vendored._sanitize_body_excerpt(body, secrets) == canonical._sanitize_body_excerpt(
+        body,
+        secrets,
+    )
+    assert "super-secret-client-value" not in vendored._sanitize_body_excerpt(body, secrets)
+
+
 def test_vendored_scope_constant_matches_library():
     """The retrieval-query scope constant must match across vendored copy
     and canonical scopes module — receivers compare to a single string."""

--- a/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
@@ -704,17 +704,16 @@ async def gitea_webhook(request: Request) -> dict:
     # Must read raw bytes before json.loads; body stream is consumed after first read
     raw_body = await request.body()
 
-    if settings.gitea_webhook_secret:
-        signature = request.headers.get("x-gitea-signature", "")
-        if not signature:
-            raise HTTPException(status_code=401, detail="Missing X-Gitea-Signature header")
-        expected = hmac.new(
-            settings.gitea_webhook_secret.encode(),
-            raw_body,
-            hashlib.sha256,
-        ).hexdigest()
-        if not hmac.compare_digest(signature, expected):
-            raise HTTPException(status_code=401, detail="Invalid webhook signature")
+    signature = request.headers.get("x-gitea-signature", "")
+    if not signature:
+        raise HTTPException(status_code=401, detail="Missing X-Gitea-Signature header")
+    expected = hmac.new(
+        settings.gitea_webhook_secret.encode(),
+        raw_body,
+        hashlib.sha256,
+    ).hexdigest()
+    if not hmac.compare_digest(signature, expected):
+        raise HTTPException(status_code=401, detail="Invalid webhook signature")
 
     try:
         body = json.loads(raw_body)
@@ -1061,9 +1060,11 @@ async def _list_gitea_md_files(repo_full_name: str) -> list[str]:
 
 async def _register_gitea_webhook(gitea_repo: str, webhook_url: str) -> None:
     """Register a push webhook on a Gitea repo."""
-    config: dict = {"url": webhook_url, "content_type": "json"}
-    if settings.gitea_webhook_secret:
-        config["secret"] = settings.gitea_webhook_secret
+    config: dict = {
+        "url": webhook_url,
+        "content_type": "json",
+        "secret": settings.gitea_webhook_secret,
+    }
     async with httpx.AsyncClient(
         base_url=settings.gitea_url,
         headers={"Authorization": f"token {settings.gitea_token}"},

--- a/klai-libs/service-auth/klai_service_auth/client.py
+++ b/klai-libs/service-auth/klai_service_auth/client.py
@@ -66,6 +66,21 @@ _REFRESH_FRACTION: float = 0.8
 _MIN_TTL_SECONDS: int = 60
 
 
+def _sanitize_body_excerpt(
+    body: str,
+    secret_values: tuple[str, ...],
+    *,
+    max_len: int = 500,
+) -> str:
+    """Redact known local secrets from an IdP error body before logging."""
+    if not body:
+        return ""
+    safe = body
+    for secret in sorted({s for s in secret_values if len(s) >= 8}, key=len, reverse=True):
+        safe = safe.replace(secret, "<redacted>")
+    return safe[:max_len]
+
+
 class ZitadelTokenClient:
     """Async OAuth 2.0 Client Credentials token client.
 
@@ -194,7 +209,11 @@ class ZitadelTokenClient:
 
         if resp.status_code != 200:
             # Trim the body so we don't log a megabyte of HTML on a misrouted call.
-            body_excerpt = resp.text[:500] if resp.text else ""
+            body_excerpt = _sanitize_body_excerpt(
+                resp.text,
+                (self._client_secret,),
+                max_len=500,
+            )
             logger.warning(
                 "service_auth_token_mint_failed",
                 client_id=self._client_id,

--- a/klai-libs/service-auth/tests/test_token_client.py
+++ b/klai-libs/service-auth/tests/test_token_client.py
@@ -204,6 +204,25 @@ async def test_idp_returns_401_raises_service_auth_error():
 
 
 @pytest.mark.asyncio
+async def test_idp_error_body_redacts_client_secret():
+    client = _build_client(client_secret="super-secret-client-value")
+    bad_resp = MagicMock(spec=httpx.Response)
+    bad_resp.status_code = 401
+    bad_resp.text = '{"error":"invalid_client","echo":"super-secret-client-value"}'
+
+    with patch("httpx.AsyncClient") as mock_async_client:
+        mock_async_client.return_value.__aenter__.return_value.post = AsyncMock(
+            return_value=bad_resp
+        )
+        with pytest.raises(ServiceAuthError) as exc_info:
+            await client.get_token()
+
+    message = str(exc_info.value)
+    assert "super-secret-client-value" not in message
+    assert "<redacted>" in message
+
+
+@pytest.mark.asyncio
 async def test_network_error_raises_service_auth_error():
     client = _build_client()
     with patch("httpx.AsyncClient") as mock_async_client:

--- a/klai-portal/backend/app/api/internal_connectors.py
+++ b/klai-portal/backend/app/api/internal_connectors.py
@@ -26,7 +26,7 @@ from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
-from app.core.database import get_db
+from app.core.database import get_db, set_tenant
 from app.models.connectors import PortalConnector
 
 logger = logging.getLogger(__name__)
@@ -95,7 +95,13 @@ async def finalize_connector_delete(
             detail=f"Connector is in state {connector.state!r}, expected 'deleting'",
         )
 
-    await db.execute(delete(PortalConnector).where(PortalConnector.id == connector_id))
+    await set_tenant(db, connector.org_id)
+    await db.execute(
+        delete(PortalConnector).where(
+            PortalConnector.id == connector_id,
+            PortalConnector.org_id == connector.org_id,
+        )
+    )
     await db.commit()
     logger.info(
         "finalize_connector_delete_completed",

--- a/klai-portal/backend/app/api/kb_images.py
+++ b/klai-portal/backend/app/api/kb_images.py
@@ -31,11 +31,13 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import StreamingResponse
 from minio import Minio
 from minio.error import S3Error
+from sqlalchemy import select
 
 from app.api.partner_dependencies import PartnerAuthContext, get_partner_key
 from app.api.session_deps import get_optional_session
 from app.core.config import settings
 from app.core.session import SessionContext
+from app.models.knowledge_bases import PortalKnowledgeBase
 
 logger = structlog.get_logger()
 
@@ -106,6 +108,7 @@ async def _stream_object(client: Minio, bucket: str, object_key: str) -> AsyncIt
 async def _resolve_caller_org_id(
     request: Request,
     session: SessionContext | None,
+    kb_slug: str,
 ) -> int:
     """Resolve the org_id of the caller from session or partner key.
 
@@ -132,6 +135,20 @@ async def _resolve_caller_org_id(
     db = await db_gen.__anext__()
     try:
         auth_ctx: PartnerAuthContext = await get_partner_key(request, db)
+        kb_result = await db.execute(
+            select(PortalKnowledgeBase.id).where(
+                PortalKnowledgeBase.org_id == auth_ctx.org_id,
+                PortalKnowledgeBase.slug == kb_slug,
+            )
+        )
+        kb_id = kb_result.scalar_one_or_none()
+        if kb_id is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Image not found",
+            )
+        if kb_id not in auth_ctx.kb_access:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
         return auth_ctx.org_id
     except HTTPException:
         raise
@@ -165,11 +182,12 @@ async def get_kb_image(
     """Auth-proxied KB-image read (SPEC-TI-009 AC-1).
 
     Authorization: session.org_id or partner key org_id must equal path org_id.
+    Partner/widget callers must also have KB access for the path kb_slug.
     Streams from Garage S3 API (private, authenticated).
     Cache-Control: private, max-age=86400.
     """
     # Step 1: Resolve caller identity
-    caller_org_id = await _resolve_caller_org_id(request, session)
+    caller_org_id = await _resolve_caller_org_id(request, session, kb_slug)
 
     # Step 2: Authorize -- caller org MUST match path org_id (AC-5)
     if caller_org_id != org_id:

--- a/klai-portal/backend/app/services/provisioning/deprovisioning_steps.py
+++ b/klai-portal/backend/app/services/provisioning/deprovisioning_steps.py
@@ -32,6 +32,7 @@ from app.services.provisioning.infrastructure import (
     _sync_drop_mongodb_tenant_user,
     _sync_remove_container,
 )
+from app.utils.response_sanitizer import sanitize_response_body
 
 if TYPE_CHECKING:
     from app.services.provisioning.deprovisioning_orchestrator import _DeprovisionState
@@ -416,7 +417,7 @@ async def _wipe_knowledge_postgres(state: _DeprovisionState) -> None:
                 zitadel_org_id=state.zitadel_org_id,
                 slug=state.slug,
                 status=resp.status_code,
-                body=resp.text[:500],
+                body=sanitize_response_body(resp, max_len=500),
             )
         resp.raise_for_status()
         data = resp.json()
@@ -491,7 +492,7 @@ async def _wipe_klai_connector_state(state: _DeprovisionState) -> None:
                 zitadel_org_id=state.zitadel_org_id,
                 slug=state.slug,
                 status=resp.status_code,
-                body=resp.text[:500],
+                body=sanitize_response_body(resp, max_len=500),
             )
         resp.raise_for_status()
         data = resp.json()

--- a/klai-portal/backend/tests/test_connector_lifecycle.py
+++ b/klai-portal/backend/tests/test_connector_lifecycle.py
@@ -23,9 +23,10 @@ from app.api.internal_connectors import finalize_connector_delete
 class _FakeConnector:
     """Minimal stand-in for ``PortalConnector`` in unit tests."""
 
-    def __init__(self, *, id: str, kb_id: int, state: str = "active") -> None:
+    def __init__(self, *, id: str, kb_id: int, org_id: int = 8, state: str = "active") -> None:
         self.id = id
         self.kb_id = kb_id
+        self.org_id = org_id
         self.state = state
 
 
@@ -226,6 +227,8 @@ async def test_finalize_delete_drops_row_when_state_deleting(
     )
     connector = _FakeConnector(id="conn-uuid", kb_id=42, state="deleting")
     db = _FakeDB(fetch_value=connector)
+    set_tenant = AsyncMock()
+    monkeypatch.setattr("app.api.internal_connectors.set_tenant", set_tenant)
 
     result = await finalize_connector_delete(
         connector_id="conn-uuid",
@@ -236,6 +239,7 @@ async def test_finalize_delete_drops_row_when_state_deleting(
     assert result is None  # 204 No Content
     # Two executes: SELECT then DELETE
     assert len(db.executes) == 2
+    set_tenant.assert_awaited_once_with(db, 8)
     assert db.commits == 1
 
 

--- a/klai-portal/backend/tests/test_kb_images_auth_proxy.py
+++ b/klai-portal/backend/tests/test_kb_images_auth_proxy.py
@@ -115,7 +115,15 @@ async def test_unauthenticated_request_rejected(kb_app):
     assert resp.status_code == 401
 
 
-def _mock_get_db():
+class _FakeScalarResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+def _mock_get_db(kb_id=7):
     """Callable that returns an async generator yielding a MagicMock db session.
 
     Mirrors the signature of get_db(): called as get_db(), returns an
@@ -128,6 +136,7 @@ def _mock_get_db():
 
     async def _gen():
         db = MagicMock()
+        db.execute = AsyncMock(return_value=_FakeScalarResult(kb_id))
         db.aclose = AsyncMock()
         yield db
 
@@ -149,7 +158,7 @@ async def test_widget_public_image_works(kb_app):
         org_id=ORG_ID,
         zitadel_org_id="z",
         permissions={"chat": True},
-        kb_access={},
+        kb_access={7: "read"},
         rate_limit_rpm=60,
     )
     kb_app.dependency_overrides[get_optional_session] = lambda: None
@@ -179,7 +188,7 @@ async def test_partner_api_key_image_access(kb_app):
         org_id=ORG_ID,
         zitadel_org_id="z",
         permissions={},
-        kb_access={},
+        kb_access={7: "read"},
         rate_limit_rpm=120,
     )
     kb_app.dependency_overrides[get_optional_session] = lambda: None
@@ -196,6 +205,33 @@ async def test_partner_api_key_image_access(kb_app):
                 headers={"Authorization": "Bearer pk_live_testkey"},
             )
     assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_partner_api_key_without_kb_access_rejected(kb_app):
+    """Partner/widget callers must have explicit access to the requested KB."""
+    from app.api.partner_dependencies import PartnerAuthContext
+    from app.api.session_deps import get_optional_session
+
+    ctx = PartnerAuthContext(
+        key_id="pk_live_x",
+        org_id=ORG_ID,
+        zitadel_org_id="z",
+        permissions={},
+        kb_access={8: "read"},
+        rate_limit_rpm=120,
+    )
+    kb_app.dependency_overrides[get_optional_session] = lambda: None
+    with (
+        patch("app.api.kb_images.get_partner_key", new=AsyncMock(return_value=ctx)),
+        patch("app.core.database.get_db", new=_mock_get_db(kb_id=7)),
+    ):
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=kb_app), base_url="http://test") as client:
+            resp = await client.get(
+                f"/kb-images/{ORG_ID}/{KB_SLUG}/{FILENAME}",
+                headers={"Authorization": "Bearer pk_live_testkey"},
+            )
+    assert resp.status_code == 403
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

- Make Gitea webhook HMAC verification and webhook registration unconditionally use the configured secret now that startup validation is fail-closed.
- Redact local service secrets from upstream HTTP error bodies before logging or surfacing them in service-auth, LiteLLM, and portal deprovisioning paths.
- Keep Vexa treated as an external moving dependency: this PR changes our side of trust boundaries/logging only and does not modify Vexa behavior or disable private callbacks.

## Why

The security audit found remaining hardening gaps after earlier fail-closed secret validators landed. The main low-risk fixes are to remove route-level conditional auth remnants and replace raw upstream response-body logging with sanitized excerpts.

## Validation

- `uv run pytest tests/test_token_client.py` in `klai-libs/service-auth`
- `uv run pytest tests/test_webhook_hmac.py tests/test_gitea_webhook_secret_validator.py` in `klai-knowledge-ingest`
- `uv run pytest tests/test_deprovisioning_steps.py -k 'WipeKnowledgePostgres or WipeKlaiConnectorState'` in `klai-portal/backend`
- `uv run --with pytest --with httpx --with structlog pytest deploy/litellm/tests/test_klai_service_auth_drift.py`
- `uv run ruff check ...` for changed knowledge-ingest, service-auth, portal files
- `uv run --with ruff ruff check deploy/litellm/klai_knowledge.py deploy/litellm/klai_service_auth.py deploy/litellm/tests/test_klai_service_auth_drift.py`

Note: CodeIndex `detect_changes` on staged changes returned no affected indexed symbols, despite staged git diff being present.
