### PR TITLE
feat(privacy): SPEC-PRIVACY-QUERY-SHADOW-001 — three-mode telemetry (off/shadow/full)

### DIFF
--- a/deploy/alloy/config.alloy
+++ b/deploy/alloy/config.alloy
@@ -57,6 +57,24 @@ loki.process "extract_level" {
     values = { level = "" }
   }
 
+  // SPEC-PRIVACY-QUERY-SHADOW-001 REQ-10: extract retention_class so
+  // VictoriaLogs can route metadata-only events (default 30d retention)
+  // and content events (raw query text under 'full' mode, 7d retention)
+  // to different streams. The application emits "metadata" or "content"
+  // on retrieval_decision_record + query_rewrite events. Other events
+  // are unaffected — the label simply isn't set, so they fall through
+  // to the default retention class.
+  //
+  // Operator runbook (deploy/victorialogs/retention.md, Unit 8) wires
+  // the per-stream retention on the VL side via -retention.streamConfig
+  // once this label is live in production logs.
+  stage.json {
+    expressions = { retention_class = "retention_class" }
+  }
+  stage.labels {
+    values = { retention_class = "" }
+  }
+
   forward_to = [loki.write.victorialogs.receiver]
 }
 

--- a/deploy/grafana/provisioning/alerting/privacy-rules.yaml
+++ b/deploy/grafana/provisioning/alerting/privacy-rules.yaml
@@ -1,0 +1,195 @@
+# Privacy-layer health alerts (SPEC-PRIVACY-QUERY-SHADOW-001 REQ-14).
+#
+# Routed via spec=SPEC-PRIVACY-QUERY-SHADOW-001 -> klai-ops-alerts-email.
+#
+#   R1  privacy_tenant_stuck_in_full   WARN  any tenant has been in 'full'
+#                                            telemetry mode for >14 days
+#   R2  privacy_shadow_drop_burst      WARN  shadow-store drop rate > 1/s
+#                                            sustained for 5m (cron job
+#                                            broken or DB pool exhausted)
+#
+# Why these alerts:
+#   - 'full' mode is opt-in for active debug. Operators should reset
+#     within days, not weeks. A 14d window catches the "forgot to flip
+#     back" case while still tolerating multi-day investigations.
+#   - Shadow-store INSERT failures degrade observability silently. A
+#     persistent drop-rate > 1/s indicates the writer or the DB pool is
+#     misconfigured; raw-traffic-rate is in the 100s/s range so 1/s is
+#     a clear signal of a fault rather than transient noise.
+#
+# Pitfall avoidance:
+#   - Both UIDs stay well under the 40-char Grafana limit (see
+#     `pitfalls/process-rules.md#grafana-uid-40-char-limit`).
+#   - R1 uses Postgres (portal-audit-log) because it's the source of
+#     truth for level changes. R2 uses Prometheus because that's where
+#     the drop counter lives.
+
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: privacy-telemetry
+    folder: Klai
+    interval: 5m
+    rules:
+
+      # ── R1: privacy_tenant_stuck_in_full ───────────────────────────────
+      - uid: spec-priv-001-tenant-stuck-full
+        title: privacy_tenant_stuck_in_full
+        condition: threshold
+        data:
+          - refId: query
+            datasourceUid: portal-postgres
+            queryType: ''
+            relativeTimeRange:
+              from: 0
+              to: 0
+            model:
+              refId: query
+              datasource:
+                type: postgres
+                uid: portal-postgres
+              format: table
+              rawSql: |
+                SELECT count(*) AS value
+                  FROM portal_orgs
+                 WHERE telemetry_level = 'full'
+                   AND deleted_at IS NULL
+                   AND id IN (
+                     SELECT org_id
+                       FROM portal_audit_log
+                      WHERE action = 'telemetry_level_changed'
+                        AND (details->>'new_level') = 'full'
+                        AND created_at < now() - interval '14 days'
+                   )
+          - refId: reduce
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 0
+              to: 0
+            model:
+              refId: reduce
+              type: reduce
+              reducer: last
+              expression: query
+          - refId: threshold
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 0
+              to: 0
+            model:
+              refId: threshold
+              type: threshold
+              expression: reduce
+              conditions:
+                - evaluator: { params: [0], type: gt }
+                  operator: { type: and }
+                  reducer: { params: [], type: last }
+                  type: query
+        noDataState: OK
+        execErrState: OK
+        for: 0s
+        keepFiringFor: 1d
+        isPaused: false
+        labels:
+          severity: warning
+          spec: SPEC-PRIVACY-QUERY-SHADOW-001
+          domain: privacy
+        annotations:
+          summary: 'Tenant in full telemetry mode for >14 days'
+          runbook_url: 'docs/runbooks/telemetry-mode-toggle.md'
+          description: |
+            One or more tenants have been in 'full' telemetry mode for
+            longer than 14 days. Full mode persists raw query text in
+            operational stores for 7 days per row; an indefinitely-on
+            full mode means a rolling 7-day window of raw queries is
+            always available to operators.
+
+            Triage:
+              1. List the affected tenants:
+                   SELECT slug, name FROM portal_orgs
+                    WHERE telemetry_level = 'full' AND deleted_at IS NULL;
+              2. Check the audit-log for the original "switched to full"
+                 reason:
+                   SELECT details FROM portal_audit_log
+                    WHERE action = 'telemetry_level_changed'
+                      AND org_id = <id>
+                    ORDER BY created_at DESC LIMIT 5;
+              3. Confirm with the operator (or tenant-admin via the
+                 audit row's operator_kind) whether the debug session is
+                 still active. If not, flip back via:
+                   curl -X POST .../internal/admin/orgs/<id>/telemetry-level
+                     -d '{"level":"shadow","reason":"closing stale debug session"}'
+
+      # ── R2: privacy_shadow_drop_burst ──────────────────────────────────
+      - uid: spec-priv-001-shadow-drop-burst
+        title: privacy_shadow_drop_burst
+        condition: threshold
+        data:
+          - refId: query
+            datasourceUid: victoriametrics
+            queryType: ''
+            relativeTimeRange:
+              from: 300
+              to: 0
+            model:
+              refId: query
+              datasource:
+                type: prometheus
+                uid: victoriametrics
+              expr: 'sum(rate(telemetry_shadow_drop_total[5m]))'
+              instant: true
+          - refId: reduce
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 300
+              to: 0
+            model:
+              refId: reduce
+              type: reduce
+              reducer: last
+              expression: query
+          - refId: threshold
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 300
+              to: 0
+            model:
+              refId: threshold
+              type: threshold
+              expression: reduce
+              conditions:
+                - evaluator: { params: [1], type: gt }
+                  operator: { type: and }
+                  reducer: { params: [], type: last }
+                  type: query
+        noDataState: OK
+        execErrState: OK
+        for: 5m
+        keepFiringFor: 15m
+        isPaused: false
+        labels:
+          severity: warning
+          spec: SPEC-PRIVACY-QUERY-SHADOW-001
+          domain: privacy
+        annotations:
+          summary: 'Shadow-store INSERT drop-rate > 1/s for 5m'
+          runbook_url: 'docs/runbooks/telemetry-mode-toggle.md'
+          description: |
+            ``telemetry_shadow_drop_total`` is incrementing at >1/s
+            sustained over 5m. The shadow-store INSERT path is
+            fire-and-forget so users are unaffected, but observability
+            is degraded — embedding-cluster analysis + per-tenant
+            gap-distribution dashboards will under-count.
+
+            Triage:
+              1. Group drops by reason:
+                   sum(rate(telemetry_shadow_drop_total[15m])) by (reason)
+                 Common values:
+                   * no_pool      → init_pool() failed at startup
+                   * db_error     → asyncpg errors; check Postgres health
+                   * no_loop      → asyncio loop missing (test-only path)
+              2. Check retrieval-api logs:
+                   service:retrieval-api AND message:"telemetry_shadow_insert_failed"
+              3. If db_error: verify the post-deploy SQL ran (telemetry
+                 schema + table + GRANTs); see runbook.

--- a/deploy/grafana/provisioning/dashboards/klai-privacy.json
+++ b/deploy/grafana/provisioning/dashboards/klai-privacy.json
@@ -1,0 +1,94 @@
+{
+  "annotations": { "list": [] },
+  "description": "Klai privacy posture: telemetry-mode distribution, gating decisions, shadow-store health (SPEC-PRIVACY-QUERY-SHADOW-001).",
+  "editable": false,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "id": 1,
+      "title": "Telemetry mode distribution (per-tenant)",
+      "type": "piechart",
+      "datasource": { "type": "postgres", "uid": "portal-postgres" },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 0 },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "pieType": "pie",
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "postgres", "uid": "portal-postgres" },
+          "rawSql": "SELECT telemetry_level::text AS metric, COUNT(*) AS value FROM portal_orgs WHERE deleted_at IS NULL GROUP BY 1 ORDER BY 1",
+          "format": "table",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Gating decisions over time (retrieve calls per tenant level)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 0 },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "expr": "sum(rate(telemetry_level_decisions_total[5m])) by (level, decision)",
+          "legendFormat": "{{level}} / {{decision}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Shadow-store INSERT drops (failures per reason)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 9 },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "victoriametrics" },
+          "expr": "sum(rate(telemetry_shadow_drop_total[5m])) by (reason)",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Tenants currently in 'full' mode (potential audit-tail risk)",
+      "type": "table",
+      "datasource": { "type": "postgres", "uid": "portal-postgres" },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 9 },
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "postgres", "uid": "portal-postgres" },
+          "rawSql": "SELECT slug, name, telemetry_level, (SELECT MAX(created_at) FROM portal_audit_log WHERE org_id = portal_orgs.id AND action = 'telemetry_level_changed') AS last_changed_at FROM portal_orgs WHERE telemetry_level = 'full' AND deleted_at IS NULL ORDER BY 2",
+          "format": "table",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["privacy", "telemetry", "klai"],
+  "templating": { "list": [] },
+  "time": { "from": "now-24h", "to": "now" },
+  "timezone": "Europe/Amsterdam",
+  "title": "Privacy — Telemetry mode distribution",
+  "uid": "klai-privacy",
+  "version": 1
+}

--- a/deploy/litellm/klai_knowledge.py
+++ b/deploy/litellm/klai_knowledge.py
@@ -85,7 +85,9 @@ PORTAL_INTERNAL_SECRET = os.getenv("PORTAL_INTERNAL_SECRET", "")
 # When unset (e.g. older deploys), falls back to PORTAL_INTERNAL_SECRET so the
 # hook keeps shipping headers, but in production both secrets must be set or
 # the legacy auth path on /retrieve 401s with `invalid_internal_secret`.
-RETRIEVAL_INTERNAL_SECRET = os.getenv("RETRIEVAL_INTERNAL_SECRET", "") or PORTAL_INTERNAL_SECRET
+RETRIEVAL_INTERNAL_SECRET = (
+    os.getenv("RETRIEVAL_INTERNAL_SECRET", "") or PORTAL_INTERNAL_SECRET
+)
 
 # SPEC-SEC-SERVICE-AUTH-001 Phase C-1: Zitadel client_credentials JWT auth
 # replaces the shared X-Internal-Secret. The token client is constructed lazily
@@ -119,7 +121,9 @@ def _get_token_client() -> object | None:
         return None
 
     _token_client_init_attempted = True
-    if not (KLAI_OAUTH_TOKEN_URL and KLAI_LITELLM_CLIENT_ID and KLAI_LITELLM_CLIENT_SECRET):
+    if not (
+        KLAI_OAUTH_TOKEN_URL and KLAI_LITELLM_CLIENT_ID and KLAI_LITELLM_CLIENT_SECRET
+    ):
         logger.info(
             "KlaiKnowledgeHook: jwt auth env vars missing — using legacy "
             "X-Internal-Secret path (SPEC-SEC-SERVICE-AUTH-001 Phase C-1 fallback)"
@@ -207,7 +211,9 @@ def _retrieve_legacy_headers() -> dict[str, str]:
     }
 
 
-async def _retrieve_with_dual_auth(http: httpx.AsyncClient, body: dict[str, Any]) -> httpx.Response:
+async def _retrieve_with_dual_auth(
+    http: httpx.AsyncClient, body: dict[str, Any]
+) -> httpx.Response:
     """POST to ``/retrieve`` preferring JWT, falling back to X-Internal-Secret.
 
     Phase C-1 dual-auth (REQ-5 safe rollout):
@@ -311,7 +317,9 @@ def _last_user_message(messages: list[dict]) -> str | None:
                 return content
             if isinstance(content, list):
                 # Multi-modal message — extract text parts
-                return " ".join(p.get("text", "") for p in content if p.get("type") == "text")
+                return " ".join(
+                    p.get("text", "") for p in content if p.get("type") == "text"
+                )
     return None
 
 
@@ -356,7 +364,9 @@ _RETRIEVAL_BASE_URL = (KNOWLEDGE_RETRIEVE_URL or "").rsplit("/retrieve", 1)[0]
 TAXONOMY_ENABLED = os.getenv("TAXONOMY_ENABLED", "true").lower() == "true"
 # Coverage threshold: if < this fraction of KB chunks are tagged, skip filter.
 # Default 0.30 — only skip when KB is mostly untagged (REQ-2 coverage-stats fallback).
-KLAI_TAXONOMY_COVERAGE_THRESHOLD = float(os.getenv("KLAI_TAXONOMY_COVERAGE_THRESHOLD", "0.30"))
+KLAI_TAXONOMY_COVERAGE_THRESHOLD = float(
+    os.getenv("KLAI_TAXONOMY_COVERAGE_THRESHOLD", "0.30")
+)
 # Timeout for each taxonomy HTTP call (tree fetch + coverage fetch).
 TAXONOMY_FETCH_TIMEOUT = float(os.getenv("TAXONOMY_FETCH_TIMEOUT", "0.8"))
 
@@ -533,7 +543,9 @@ def _format_taxonomy_for_prompt(
     if isinstance(trees, list):
         if not trees:
             return "(none)"
-        lines = [f"- id={node['id']}: {node['name']}" for node in trees[:max_nodes_per_kb]]
+        lines = [
+            f"- id={node['id']}: {node['name']}" for node in trees[:max_nodes_per_kb]
+        ]
         if len(trees) > max_nodes_per_kb:
             lines.append(f"... ({len(trees) - max_nodes_per_kb} more nodes omitted)")
         return "\n".join(lines)
@@ -697,7 +709,9 @@ async def _fetch_taxonomy_coverage(
     coverage = {slug: float(data.get(slug, 0.0)) for slug in kb_slugs}
     if cache is not None:
         try:
-            await cache.async_set_cache(cache_key, coverage, ttl=_TAXONOMY_COVERAGE_TTL_S)
+            await cache.async_set_cache(
+                cache_key, coverage, ttl=_TAXONOMY_COVERAGE_TTL_S
+            )
         except Exception:
             pass
     return coverage
@@ -751,7 +765,9 @@ async def _rewrite_and_classify(
 
     # Fall back to plain text prompt when no taxonomy is available
     if not flat_tree:
-        rewritten, rewrite_meta = await _rewrite_query(raw_query, history, _transport=_transport)
+        rewritten, rewrite_meta = await _rewrite_query(
+            raw_query, history, _transport=_transport
+        )
         return rewritten, [], rewrite_meta
 
     # Build combined prompt
@@ -836,7 +852,9 @@ async def _get_kb_feature(user_id: str, org_id: str, cache) -> dict:
     Backward compatible: handles old {"enabled": bool} portal responses gracefully.
     """
     if not PORTAL_INTERNAL_SECRET:
-        logger.warning("KlaiKnowledgeHook: PORTAL_INTERNAL_SECRET not set — fail-closed")
+        logger.warning(
+            "KlaiKnowledgeHook: PORTAL_INTERNAL_SECRET not set — fail-closed"
+        )
         return {
             "enabled": False,
             "kb_retrieval_enabled": True,
@@ -845,6 +863,8 @@ async def _get_kb_feature(user_id: str, org_id: str, cache) -> dict:
             "kb_narrow": False,
             "version": 0,
             "zitadel_user_id": None,
+            # SPEC-PRIVACY-QUERY-SHADOW-001 REQ-4: fail-open to 'shadow', never 'off'.
+            "telemetry_level": "shadow",
         }
 
     # Step 1: check version pointer (short-lived — invalidated by preference changes)
@@ -868,7 +888,9 @@ async def _get_kb_feature(user_id: str, org_id: str, cache) -> dict:
             resp.raise_for_status()
             data = resp.json()
     except Exception as exc:
-        logger.warning("KlaiKnowledgeHook: portal feature fetch failed (%s) — fail-closed", exc)
+        logger.warning(
+            "KlaiKnowledgeHook: portal feature fetch failed (%s) — fail-closed", exc
+        )
         return {
             "enabled": False,
             "kb_retrieval_enabled": True,
@@ -877,6 +899,9 @@ async def _get_kb_feature(user_id: str, org_id: str, cache) -> dict:
             "kb_narrow": False,
             "version": 0,
             "zitadel_user_id": None,
+            # SPEC-PRIVACY-QUERY-SHADOW-001 REQ-4: fail-open to 'shadow', never 'off'.
+            # Silent telemetry is the wrong default during outages.
+            "telemetry_level": "shadow",
         }
 
     version = data.get("kb_pref_version", 0)
@@ -893,11 +918,17 @@ async def _get_kb_feature(user_id: str, org_id: str, cache) -> dict:
         # personal-KB qdrant filter, and the verify-cache key all match on
         # zitadel_user_id — using the LibreChat ObjectId would 403 every call.
         "zitadel_user_id": data.get("zitadel_user_id"),
+        # SPEC-PRIVACY-QUERY-SHADOW-001 REQ-2: per-tenant telemetry mode.
+        # Older portal-api builds without the field land in the default
+        # 'shadow' (REQ-4 fail-open) so a mid-deploy state is privacy-safe.
+        "telemetry_level": data.get("telemetry_level", "shadow"),
     }
 
     # Store version pointer (30s) and feature data (300s) separately
     await cache.async_set_cache(version_key, str(version), ttl=30)
-    await cache.async_set_cache(f"kb_feature:{org_id}:{user_id}:{version}", result, ttl=300)
+    await cache.async_set_cache(
+        f"kb_feature:{org_id}:{user_id}:{version}", result, ttl=300
+    )
     return result
 
 
@@ -1002,7 +1033,9 @@ def _prepend_system_prefix(messages: list[dict], prefix: str) -> None:
     """
     if not prefix:
         return
-    sys_idx = next((i for i, m in enumerate(messages) if m.get("role") == "system"), None)
+    sys_idx = next(
+        (i for i, m in enumerate(messages) if m.get("role") == "system"), None
+    )
     if sys_idx is not None:
         existing = messages[sys_idx].get("content", "")
         messages[sys_idx] = {
@@ -1027,7 +1060,9 @@ def _build_template_instructions_block(instructions: list[dict]) -> str:
     # detected by GROUNDED_CHAT_SYSTEM_PROMPT (prepended above this block at
     # the call site). Template `name` and `text` themselves are tenant-defined
     # — they may already be in any language; we don't translate them.
-    parts: list[str] = ["[Klai Templates — apply the following instructions to your answer]"]
+    parts: list[str] = [
+        "[Klai Templates — apply the following instructions to your answer]"
+    ]
     for inst in instructions:
         name = inst.get("name") or "template"
         text = (inst.get("text") or "").strip()
@@ -1124,14 +1159,18 @@ class KlaiKnowledgeHook(CustomLogger):
         if not feature["enabled"]:
             # No KB entitlement. Templates still apply. Multilingual foundation
             # still applies — REQ-10: every LibreChat path is multilingual.
-            _prepend_system_prefix(messages, _compose_libre_chat_prefix(templates_block))
+            _prepend_system_prefix(
+                messages, _compose_libre_chat_prefix(templates_block)
+            )
             data["messages"] = messages
             return data
 
         if not feature["kb_retrieval_enabled"]:
             # User disabled KB retrieval. Templates still apply. Multilingual
             # foundation still applies — REQ-10.
-            _prepend_system_prefix(messages, _compose_libre_chat_prefix(templates_block))
+            _prepend_system_prefix(
+                messages, _compose_libre_chat_prefix(templates_block)
+            )
             data["messages"] = messages
             return data
 
@@ -1202,7 +1241,9 @@ class KlaiKnowledgeHook(CustomLogger):
         # Multilingual foundation still applies — REQ-10 (the language
         # contract is shared between GROUNDED and GENERAL prompts).
         if not kb_personal and kb_slugs == []:
-            _prepend_system_prefix(messages, _compose_general_chat_prefix(templates_block))
+            _prepend_system_prefix(
+                messages, _compose_general_chat_prefix(templates_block)
+            )
             data["messages"] = messages
             return data
 
@@ -1229,7 +1270,9 @@ class KlaiKnowledgeHook(CustomLogger):
         #     full set client-side, so taxonomy is skipped (no_kbs_in_scope).
         #     Fail-open: retrieval-api still applies its org/scope filters.
         #   * personal-only scope ("personal") → no org KBs → skip taxonomy.
-        kbs_in_scope: list[str] = list(kb_slugs_for_request) if kb_slugs_for_request else []
+        kbs_in_scope: list[str] = (
+            list(kb_slugs_for_request) if kb_slugs_for_request else []
+        )
         taxonomy_trees: dict[str, list[dict]] = {}
         taxonomy_coverage_map: dict[str, float] = {}
         if kbs_in_scope and TAXONOMY_ENABLED and scope in ("org", "both"):
@@ -1261,18 +1304,34 @@ class KlaiKnowledgeHook(CustomLogger):
             classified_node_ids,
             rewrite_meta,
         ) = await _rewrite_and_classify(query, conversation_history, trees_for_classify)
+        # SPEC-PRIVACY-QUERY-SHADOW-001 REQ-6: gate raw query content out of
+        # the query_rewrite log line in 'off' / 'shadow' mode. Operators keep
+        # full-shape diagnostics (timing, was_changed, skip reason) but never
+        # see literal customer text.
+        telemetry_level = feature.get("telemetry_level", "shadow")
         try:
-            logger.info(
-                "query_rewrite org_id=%s user_id=%s raw_query=%r rewritten_query=%r "
-                "rewrite_ms=%d was_changed=%s skipped=%s",
-                org_id,
-                user_id,
-                query,
-                rewritten_query,
-                rewrite_meta.get("rewrite_ms", 0),
-                rewrite_meta.get("was_changed", False),
-                rewrite_meta.get("skipped", ""),
-            )
+            if telemetry_level == "full":
+                logger.info(
+                    "query_rewrite org_id=%s user_id=%s raw_query=%r rewritten_query=%r "
+                    "rewrite_ms=%d was_changed=%s skipped=%s",
+                    org_id,
+                    user_id,
+                    query,
+                    rewritten_query,
+                    rewrite_meta.get("rewrite_ms", 0),
+                    rewrite_meta.get("was_changed", False),
+                    rewrite_meta.get("skipped", ""),
+                )
+            else:
+                logger.info(
+                    "query_rewrite_metadata org_id=%s user_id=%s "
+                    "rewrite_ms=%d was_changed=%s skipped=%s",
+                    org_id,
+                    user_id,
+                    rewrite_meta.get("rewrite_ms", 0),
+                    rewrite_meta.get("was_changed", False),
+                    rewrite_meta.get("skipped", ""),
+                )
         except Exception:
             # Logging itself must never abort the hook (REQ-2 fail-open).
             pass
@@ -1298,7 +1357,8 @@ class KlaiKnowledgeHook(CustomLogger):
         if TAXONOMY_ENABLED and kbs_in_scope:
             try:
                 coverage_repr = ",".join(
-                    f"{slug}={taxonomy_coverage_map.get(slug, 0.0):.2f}" for slug in kbs_in_scope
+                    f"{slug}={taxonomy_coverage_map.get(slug, 0.0):.2f}"
+                    for slug in kbs_in_scope
                 )
                 logger.info(
                     "taxonomy_classify org_id=%s kb_slugs=%s coverage=%s "
@@ -1326,6 +1386,11 @@ class KlaiKnowledgeHook(CustomLogger):
             "scope": scope,
             "top_k": RETRIEVE_TOP_K,
             "conversation_history": conversation_history,
+            # SPEC-PRIVACY-QUERY-SHADOW-001 REQ-4: forward the per-tenant
+            # telemetry mode so retrieval-api can gate its content emission
+            # + shadow-store INSERT accordingly. Default 'shadow' on cache
+            # miss + portal outage (fail-open per REQ-4).
+            "telemetry_level": telemetry_level,
         }
         if kb_slugs_for_request:
             retrieve_body["kb_slugs"] = kb_slugs_for_request
@@ -1401,7 +1466,9 @@ class KlaiKnowledgeHook(CustomLogger):
         # If the retrieval-gate determined no KB context is needed, skip injection.
         # Multilingual foundation still applies — REQ-10.
         if result.get("retrieval_bypassed"):
-            _prepend_system_prefix(messages, _compose_libre_chat_prefix(templates_block))
+            _prepend_system_prefix(
+                messages, _compose_libre_chat_prefix(templates_block)
+            )
             data["messages"] = messages
             data.setdefault("metadata", {})["_klai_kb_meta"] = {
                 "org_id": org_id,
@@ -1440,7 +1507,9 @@ class KlaiKnowledgeHook(CustomLogger):
         if not chunks:
             # Zero chunks but templates may still apply. Multilingual
             # foundation still applies — REQ-10.
-            _prepend_system_prefix(messages, _compose_libre_chat_prefix(templates_block))
+            _prepend_system_prefix(
+                messages, _compose_libre_chat_prefix(templates_block)
+            )
             data["messages"] = messages
             return data
 
@@ -1525,7 +1594,8 @@ class KlaiKnowledgeHook(CustomLogger):
             image_urls = chunk.get("image_urls") or []
             if image_urls:
                 absolute_urls = [
-                    f"{KB_IMAGES_BASE_URL}{u}" if u.startswith("/") else u for u in image_urls
+                    f"{KB_IMAGES_BASE_URL}{u}" if u.startswith("/") else u
+                    for u in image_urls
                 ]
                 for i, img_url in enumerate(absolute_urls, 1):
                     lines.append(f"![afbeelding {i}]({img_url})")

--- a/deploy/litellm/tests/test_telemetry_level_forwarding.py
+++ b/deploy/litellm/tests/test_telemetry_level_forwarding.py
@@ -1,0 +1,227 @@
+"""SPEC-PRIVACY-QUERY-SHADOW-001 Unit 5 — telemetry-level forwarding tests.
+
+The LiteLLM hook MUST:
+- Read ``telemetry_level`` from the kb_feature cache / portal response
+- Default to ``shadow`` when the field is absent (REQ-4 fail-open)
+- Pass ``telemetry_level`` in every ``/retrieve`` body (REQ-4)
+- Gate the ``query_rewrite`` log line per REQ-6: in 'off' / 'shadow' the
+  raw_query / rewritten_query kwargs MUST NOT appear in the log line
+
+We re-use the existing test_klai_knowledge_hook test infrastructure —
+``_load_hook``, ``_make_cache``, ``_make_user_api_key``, ``_make_resp``,
+``_mock_litellm`` — so the privacy tests run under the exact same harness
+as the rest of the hook tests.
+"""
+
+# noqa: I001
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+def _load_test_helpers():
+    """Load the existing test_klai_knowledge_hook module so we can reuse its
+    fixtures + helpers without copying them. The autouse `_mock_litellm`
+    fixture from that module is what makes ``import klai_knowledge`` work
+    inside the docker-only LiteLLM environment.
+    """
+    helpers_path = Path(__file__).parent / "test_klai_knowledge_hook.py"
+    spec = importlib.util.spec_from_file_location(
+        "_klai_hook_test_helpers", helpers_path
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_klai_hook_test_helpers"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_helpers = _load_test_helpers()
+_load_hook = _helpers._load_hook
+_make_cache = _helpers._make_cache
+_make_user_api_key = _helpers._make_user_api_key
+_make_resp = _helpers._make_resp
+
+
+@pytest.fixture(autouse=True)
+def _mock_litellm():
+    """Identical to test_klai_knowledge_hook's autouse fixture.
+
+    Inlined here because pytest does not auto-apply autouse fixtures from
+    a sibling test module; importing the helpers does not propagate the
+    fixture registration.
+    """
+    litellm_mod = types.ModuleType("litellm")
+    integrations_mod = types.ModuleType("litellm.integrations")
+    custom_logger_mod = types.ModuleType("litellm.integrations.custom_logger")
+
+    class CustomLogger:
+        async def async_pre_call_hook(self, *args, **kwargs):
+            pass
+
+        async def async_post_call_success_hook(self, *args, **kwargs):
+            pass
+
+        async def async_post_call_failure_hook(self, *args, **kwargs):
+            pass
+
+    custom_logger_mod.CustomLogger = CustomLogger
+    litellm_mod.integrations = integrations_mod
+    integrations_mod.custom_logger = custom_logger_mod
+
+    sys.modules["litellm"] = litellm_mod
+    sys.modules["litellm.integrations"] = integrations_mod
+    sys.modules["litellm.integrations.custom_logger"] = custom_logger_mod
+
+    yield
+
+    for mod_name in [
+        "litellm",
+        "litellm.integrations",
+        "litellm.integrations.custom_logger",
+    ]:
+        sys.modules.pop(mod_name, None)
+    sys.modules.pop("klai_knowledge", None)
+
+
+def _data_payload() -> dict:
+    return {
+        "user": "aabbcc112233445566778899",
+        "messages": [
+            {"role": "user", "content": "Hoe stel ik vakantie aan?"},
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_retrieve_body_includes_telemetry_level_from_cache(monkeypatch):
+    """Cache-hit path: the level from the cached feature dict reaches the
+    /retrieve POST body verbatim."""
+    mod = _load_hook(monkeypatch)
+    hook = mod.KlaiKnowledgeHook()
+    cache = _make_cache(feature_enabled=True, feature={"telemetry_level": "full"})
+
+    mock_resp = _make_resp({"chunks": [], "retrieval_bypassed": False})
+    with patch("klai_knowledge.httpx.AsyncClient") as cls:
+        mc = AsyncMock()
+        mc.post = AsyncMock(return_value=mock_resp)
+        mc.get = AsyncMock(return_value=_make_resp({"enabled": True}))
+        mc.__aenter__ = AsyncMock(return_value=mc)
+        mc.__aexit__ = AsyncMock(return_value=None)
+        cls.return_value = mc
+
+        await hook.async_pre_call_hook(
+            _make_user_api_key(), cache, _data_payload(), "completion"
+        )
+
+        post_call = mc.post.call_args
+        assert post_call is not None, "expected /retrieve POST to fire"
+        body = post_call.kwargs.get("json") or {}
+        assert body.get("telemetry_level") == "full"
+
+
+@pytest.mark.asyncio
+async def test_retrieve_body_defaults_to_shadow_when_field_absent(monkeypatch):
+    """REQ-4 fail-open: a cache hit from an older portal-api build that
+    pre-dates this SPEC has no telemetry_level field. The hook MUST
+    default to 'shadow', never 'off'."""
+    mod = _load_hook(monkeypatch)
+    hook = mod.KlaiKnowledgeHook()
+    cache = _make_cache(feature_enabled=True)  # no telemetry_level in feature
+
+    mock_resp = _make_resp({"chunks": [], "retrieval_bypassed": False})
+    with patch("klai_knowledge.httpx.AsyncClient") as cls:
+        mc = AsyncMock()
+        mc.post = AsyncMock(return_value=mock_resp)
+        mc.get = AsyncMock(return_value=_make_resp({"enabled": True}))
+        mc.__aenter__ = AsyncMock(return_value=mc)
+        mc.__aexit__ = AsyncMock(return_value=None)
+        cls.return_value = mc
+
+        await hook.async_pre_call_hook(
+            _make_user_api_key(), cache, _data_payload(), "completion"
+        )
+
+        post_call = mc.post.call_args
+        assert post_call is not None
+        body = post_call.kwargs.get("json") or {}
+        # REQ-4: default is 'shadow', never 'off'.
+        assert body.get("telemetry_level") == "shadow"
+
+
+@pytest.mark.asyncio
+async def test_query_rewrite_log_redacts_in_shadow_mode(monkeypatch, caplog):
+    """REQ-6: the literal raw_query / rewritten_query MUST NOT appear in
+    the query_rewrite log line when telemetry_level != 'full'."""
+    mod = _load_hook(monkeypatch)
+    hook = mod.KlaiKnowledgeHook()
+    cache = _make_cache(feature_enabled=True, feature={"telemetry_level": "shadow"})
+
+    mock_resp = _make_resp({"chunks": [], "retrieval_bypassed": False})
+    secret_query = "ZEER_GEHEIME_KLANTVRAAG_OVER_SALARIS"
+    data = {
+        "user": "aabbcc112233445566778899",
+        "messages": [{"role": "user", "content": secret_query}],
+    }
+
+    with patch("klai_knowledge.httpx.AsyncClient") as cls:
+        mc = AsyncMock()
+        mc.post = AsyncMock(return_value=mock_resp)
+        mc.get = AsyncMock(return_value=_make_resp({"enabled": True}))
+        mc.__aenter__ = AsyncMock(return_value=mc)
+        mc.__aexit__ = AsyncMock(return_value=None)
+        cls.return_value = mc
+
+        with caplog.at_level("INFO"):
+            await hook.async_pre_call_hook(
+                _make_user_api_key(), cache, data, "completion"
+            )
+
+    rendered = " ".join(record.getMessage() for record in caplog.records)
+    # The metadata-only log line is allowed.
+    assert "query_rewrite_metadata" in rendered or "query_rewrite" in rendered
+    # The raw query MUST NOT have been logged.
+    assert secret_query not in rendered, (
+        "REQ-6 regression: raw query leaked into query_rewrite log in shadow mode"
+    )
+
+
+@pytest.mark.asyncio
+async def test_query_rewrite_log_keeps_text_in_full_mode(monkeypatch, caplog):
+    """Positive control: in 'full' mode, the raw query DOES appear in the
+    log line (operators explicitly opted into raw-text retention)."""
+    mod = _load_hook(monkeypatch)
+    hook = mod.KlaiKnowledgeHook()
+    cache = _make_cache(feature_enabled=True, feature={"telemetry_level": "full"})
+
+    mock_resp = _make_resp({"chunks": [], "retrieval_bypassed": False})
+    sample_query = "Hoe configureer ik de Salesforce-koppeling?"
+    data = {
+        "user": "aabbcc112233445566778899",
+        "messages": [{"role": "user", "content": sample_query}],
+    }
+
+    with patch("klai_knowledge.httpx.AsyncClient") as cls:
+        mc = AsyncMock()
+        mc.post = AsyncMock(return_value=mock_resp)
+        mc.get = AsyncMock(return_value=_make_resp({"enabled": True}))
+        mc.__aenter__ = AsyncMock(return_value=mc)
+        mc.__aexit__ = AsyncMock(return_value=None)
+        cls.return_value = mc
+
+        with caplog.at_level("INFO"):
+            await hook.async_pre_call_hook(
+                _make_user_api_key(), cache, data, "completion"
+            )
+
+    rendered = " ".join(record.getMessage() for record in caplog.records)
+    # In 'full' mode the raw query is allowed in the log line. We assert
+    # the canonical log shape rather than the literal query because the
+    # rewriter may collapse / reshape the text.
+    assert "query_rewrite" in rendered
+    # Verify it's NOT the metadata-only variant (that's the redacted form).
+    assert "query_rewrite_metadata" not in rendered

--- a/docs/privacy/dpa-telemetry-addendum.md
+++ b/docs/privacy/dpa-telemetry-addendum.md
@@ -1,0 +1,128 @@
+# DPA addendum — telemetry modes
+
+**Status:** add to the standard Klai DPA from 2026-05-08 onwards
+(SPEC-PRIVACY-QUERY-SHADOW-001).
+
+This is the wording the tenant agrees to when they sign the Klai DPA.
+It defines the contract for each telemetry mode, the retention
+windows, and the tenant's responsibility for `full`-mode debug
+sessions.
+
+---
+
+## Article — Telemetry modes for query content (Klai)
+
+The Tenant ("Controller") and Klai BV ("Processor") acknowledge that
+Klai's chat platform processes queries submitted by the Tenant's
+end-users in order to produce knowledge-base-grounded answers. Klai
+records aggregate telemetry about these queries to maintain service
+quality and detect retrieval regressions. The level of detail recorded
+is configurable per-tenant via the `telemetry_level` setting in the
+Tenant's admin console at
+`https://<tenant>.getklai.com/admin/settings`.
+
+### Mode definitions
+
+The following three modes are available; the default is `shadow`.
+
+1. **`off`** — Klai records no telemetry derived from the literal
+   content of a Tenant query. Aggregate operational logs (latency,
+   HTTP status codes, container health) continue to be recorded
+   independent of this setting.
+
+2. **`shadow`** (default) — Klai records, per query:
+   - a 1024-dimensional dense vector embedding of the query
+     (BGE-M3 model);
+   - a small set of derived symbolic features: integer token count,
+     language tag (`nl` / `en` / `other`), counts of brand-keyword
+     mentions, and boolean flags for question-word / URL / email
+     pattern occurrence;
+   - aggregate retrieval data: confidence band, returned chunk IDs,
+     top reranker score.
+
+   The literal query text is **not** stored in any operational
+   surface in this mode. Rows are deleted automatically 7 days after
+   creation.
+
+3. **`full`** — Klai additionally records the literal text of the
+   query in (a) operational logs; (b) the `portal_retrieval_gaps`
+   table (when applicable); (c) the in-memory retrieval-log Redis
+   blob. All three locations apply a 7-day TTL.
+
+### Retention
+
+Under all three modes, no record derived from the literal content of
+a query persists longer than **7 days** in any operational store
+managed by Klai.
+
+The 30-day operational-log retention applies only to logs that do not
+carry query content (e.g. Caddy access logs, container health, error
+traces, metadata-only retrieval events).
+
+The Tenant audit log (`portal_audit_log`) records every
+`telemetry_level` change with operator identity and reason; this log
+is retained for at least one year as part of the standard audit
+trail.
+
+### Default mode
+
+Newly provisioned tenants are configured at `shadow` by default. No
+tenant action is required to obtain default privacy posture.
+
+### Switching modes
+
+Either the Tenant (via the admin console) or Klai (via an internal
+operator endpoint, with an audit row recording the operator's
+identity and a free-text reason) can change the level at any time.
+Cache propagation is typically less than one minute.
+
+When Klai initiates a switch to `full` for diagnostic purposes, Klai
+will document the reason in the audit row and inform the Tenant
+contact within five business days unless the diagnostic relates to
+an active security incident, in which case Klai may defer
+notification per the standard incident-handling addendum.
+
+### Tenant responsibility under `full`
+
+The Tenant agrees that switching to `full` mode constitutes an
+informed decision to retain literal query content (which may include
+end-user PII) for 7 days in Klai's operational stores. The Tenant
+remains the Controller of this data and is responsible for
+documenting the lawful basis under which their end-users' literal
+queries are processed by Klai during a `full`-mode session.
+
+Klai will fire an internal alert if a tenant remains in `full` mode
+for longer than 14 days; Klai operators will reach out to the Tenant
+contact within five business days to confirm whether the debug
+session should remain active. The Tenant may close the session at
+any time via the admin console.
+
+### Sub-processors and data residency
+
+Klai operates entirely within EU data residency. All shadow-store
+records, retrieval-gap rows, retrieval-log blobs, and operational
+logs are stored on Klai-managed Postgres / Redis / VictoriaLogs
+instances in the EU. No personal data leaves the EU as part of this
+processing.
+
+### Right to erasure
+
+The 7-day TTL is the primary privacy fence and applies automatically
+to every record under all modes. For `shadow` mode there is no
+automated DSAR-purge endpoint because no literal content is stored
+to begin with. For `full`-mode records, faster-than-7-day purges
+can be requested by contacting Klai's data-protection point of
+contact at the address listed in the main DPA.
+
+### Embedding-leakage acknowledgement
+
+The Tenant acknowledges that under `shadow` mode, the stored 1024-
+dimensional embedding vector is not perfectly opaque: an attacker
+with access to the same model and significant compute could recover
+topic-level signal (e.g. "this query was about CRM integrations")
+from the vector, but not the literal text. Klai operators have read
+access to the embedding column but not to a model-inference pipeline
+that reverses embeddings; Klai represents this as "industrial-strength
+privacy", not "zero-knowledge". The Tenant agrees that this trade-off
+is acceptable for the operational benefit of `shadow`-mode telemetry,
+or chooses `off` to eliminate the trade-off entirely.

--- a/docs/privacy/telemetry-modes.md
+++ b/docs/privacy/telemetry-modes.md
@@ -1,0 +1,132 @@
+# Privacy modes — what Klai records about your users' queries
+
+**Status:** live since 2026-05-08 (SPEC-PRIVACY-QUERY-SHADOW-001).
+This page is normative — the wording here defines the contract between
+Klai and our tenants about each telemetry mode.
+
+## Why three modes
+
+A privacy-friendly EU-only AI platform has to balance two real
+requirements:
+
+- **Data minimization** (GDPR Article 5(1)(c)) — operators should not
+  hold customer-facing query content longer than necessary.
+- **Operational visibility** — we need *some* signal about how
+  retrieval is performing, otherwise a regression at one tenant can go
+  undetected for weeks (we lived this in April 2026, see PR #517).
+
+The compromise: per-tenant choice between three modes, with a
+privacy-friendly default. **The literal text of your users' queries is
+never persisted by Klai for longer than 7 days under any mode**, and in
+the default mode it is never persisted at all.
+
+## The modes
+
+### `off` — minimum surface
+
+Klai stores **nothing** about the queries your users submit. No vector
+fingerprint, no length statistics, no gap-event row. We cannot do
+quality monitoring, support-team incident triage, or any kind of
+aggregate analysis for your tenant.
+
+The Klai chat product still works fully (retrieval, answer synthesis,
+template injection); only the operator-side observability is removed.
+Thumbs-up / thumbs-down feedback is unaffected — that lives on
+different data and is keyed to the response, not the query.
+
+**Use when:** your end-users' queries contain content you cannot
+share with any third-party operator, even in anonymised form.
+
+### `shadow` (default) — anonymous fingerprint, 7d
+
+Klai stores, for each `/retrieve` call:
+
+- **Embedding vector** (1024 floats from BGE-M3 — a multilingual
+  multimodal text embedder). The vector represents the query in a
+  high-dimensional semantic space; with access to the same model and
+  significant compute, an attacker can recover topic-level signal
+  ("this query was about CRM integrations") but not literal PII.
+- **Symbolic features**: integer token count, language-detection tag
+  (`nl` / `en` / `other`), boolean flags for whether a brand keyword
+  appeared (and how many), whether the query started with a question
+  word, whether a URL was mentioned, whether an email-shaped substring
+  was mentioned.
+- **Aggregate retrieval data**: confidence band, retrieved chunk IDs,
+  top reranker score.
+
+**The literal query text is never persisted** in this mode. The
+shadow row is keyed by request-ID and tagged with the tenant's org-ID;
+all rows are deleted automatically after **7 days**. The deletion is
+mechanical (a daily cron) — no operator action is required to trigger
+it.
+
+What we can do with this data:
+- Detect retrieval-quality regressions (band distribution shifts)
+- Cluster failure cases by topic (find systematic gaps without seeing
+  what any single user asked)
+- Match a new query to known-failing-cluster nearest neighbours
+
+What we cannot do:
+- Reconstruct the literal text of a specific query
+- Answer "what did user X ask on date Y" — by design
+
+**Use when:** you want default-good observability without
+literal-text retention. Recommended for every tenant unless you have
+a specific reason to pick a different mode.
+
+### `full` — opt-in debug mode, 7d, audit-trailed
+
+Klai stores everything `shadow` records, **plus** the literal query
+text in:
+
+- The `decision_record` event in our log pipeline (VictoriaLogs)
+- The `query_text` column of `portal_retrieval_gaps` (when retrieval
+  produces a low-confidence result)
+- The `query_resolved` field of the in-Redis retrieval-log JSON blob
+
+All three with **7-day TTL**. Nothing under any mode survives 7 days.
+
+`full` mode is opt-in:
+
+- Either the tenant flips it themselves via
+  `https://<your-tenant>.getklai.com/admin/settings`, or
+- A Klai operator flips it explicitly in response to a debug request,
+  and the audit-log records the operator's identity + reason.
+
+Both paths produce a row in `portal_audit_log`. After 14 days, our
+operations team gets a `privacy_tenant_stuck_in_full` alert if a
+tenant is still in `full` mode — operators are expected to either
+confirm the debug session is still active or flip the tenant back.
+
+**Use when:** you or Klai are actively investigating a specific issue
+and need to see the literal text of failing queries. Don't forget to
+flip back when done.
+
+## What is *never* recorded — under any mode
+
+- Authentication credentials, tokens, OAuth refresh tokens
+- LibreChat conversation history (the chat UI's own data lives in your
+  tenant's MongoDB; Klai operators do not access it)
+- Anything that would normally be classed as PII outside the query
+  itself (we don't enrich with IP geolocation, user-agent strings, etc.
+  on the privacy-sensitive paths)
+
+## Where this is enforced
+
+- Application code: every retrieval-pipeline log site that touches
+  query content is gated on `telemetry_level`. A defense-in-depth
+  structlog processor strips raw-query-shaped fields from any future
+  log line that was not explicitly gated.
+- Database: a daily cron job deletes rows older than 7 days from the
+  shadow store and from `portal_retrieval_gaps`.
+- Audit: every level change is recorded in `portal_audit_log` with
+  the operator (or tenant-admin) identity and the reason.
+- Observability: a per-tenant privacy dashboard lets us spot tenants
+  whose retention diverges from policy.
+
+## Questions or audit requests
+
+For SARs and similar GDPR-driven requests, see the standard SAR
+endpoint exposed under `/api/me/sar-export`. The 7-day TTL is the
+primary privacy fence; faster purges for `full`-mode tenants can be
+arranged out-of-band (no automated DSAR-purge endpoint in v1).

--- a/docs/runbooks/telemetry-mode-toggle.md
+++ b/docs/runbooks/telemetry-mode-toggle.md
@@ -1,0 +1,147 @@
+# Runbook — Toggling a tenant's telemetry mode
+
+Status: live since 2026-05-08 (SPEC-PRIVACY-QUERY-SHADOW-001).
+
+## What this runbook covers
+
+How a Klai operator switches a tenant between `off` / `shadow` / `full`
+telemetry modes for active debug, post-deploy validation, or to recover
+from a tenant who flipped to `full` and forgot to reset.
+
+This is the operator escape hatch for the same toggle that tenant-admins
+own via `https://<tenant>.getklai.com/admin/settings`. Both paths share
+the same DB-write + audit-log + cache-invalidation behaviour.
+
+## Mode reference (canonical)
+
+| Mode | What it persists | When to use |
+|------|------------------|-------------|
+| `off` | Nothing — no shadow row, no gap-event, no query log | Tenant has explicit data-minimization requirement and accepts losing operational telemetry |
+| `shadow` (default) | Embedding + symbolic features (tokens, lang, has_brand, …); 7d TTL. Raw query NEVER persisted | Default for all tenants. Lets Klai do quality monitoring without raw-text retention |
+| `full` | Everything: raw query in `decision_record` log, raw `query_text` in `portal_retrieval_gaps`, raw `query_resolved` in retrieval-log Redis blob — all 7d TTL | Active debug only. Audit-log row records the operator and reason; alert fires after 14 days |
+
+## How to toggle (operator path — internal admin)
+
+```bash
+ssh core-01
+TOKEN="$(printenv PORTAL_INTERNAL_SECRET)"
+
+# Check current state
+curl -sS http://portal-api:8010/internal/admin/orgs/<org_id>/telemetry-level \
+  -H "Authorization: Bearer $TOKEN" | jq .
+
+# Switch to 'full' for active debug
+curl -sS -X POST \
+  http://portal-api:8010/internal/admin/orgs/<org_id>/telemetry-level \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"level":"full","reason":"Investigating ticket #1234"}'
+
+# Switch back to 'shadow' when done
+curl -sS -X POST \
+  http://portal-api:8010/internal/admin/orgs/<org_id>/telemetry-level \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"level":"shadow","reason":"Closing debug session for ticket #1234"}'
+```
+
+Cache propagation: the LiteLLM hook picks up the new level within ~30s
+via the `kb_ver:{org_id}:*` Redis-key invalidation. No restart needed.
+
+## How to toggle (tenant path — self-service)
+
+A tenant-admin opens
+`https://<tenant>.getklai.com/admin/settings`, scrolls to the
+"Privacy & telemetrie" card, picks the level from the dropdown, clicks
+Save. The audit-log records `operator_kind='tenant_admin'`,
+`reason='tenant self-service via admin UI'`,
+`operator_user_id=<zitadel sub>`.
+
+Operator action: usually NONE. Self-service is the preferred path for
+non-emergency toggles.
+
+## Verifying the change took effect
+
+```bash
+# 1. DB state
+ssh core-01 "docker exec klai-core-postgres-1 psql -U klai -d klai \
+  -c \"SELECT slug, telemetry_level FROM portal_orgs WHERE id = <org_id>;\""
+
+# 2. Cache state (kb_ver pointer should be deleted)
+ssh core-01 "docker exec klai-core-redis-1 redis-cli \
+  KEYS 'kb_ver:<org_id>:*'"
+
+# 3. Audit row
+ssh core-01 "docker exec klai-core-postgres-1 psql -U klai -d klai \
+  -c \"SELECT details FROM portal_audit_log
+        WHERE org_id = <org_id> AND action = 'telemetry_level_changed'
+        ORDER BY created_at DESC LIMIT 3;\""
+
+# 4. Live behavior — wait 60s, then run a /retrieve and tail VictoriaLogs:
+#    service:retrieval-api AND request_id:<your_test_id>
+#    In 'full' mode the decision_record event has coreference_rewrite.{original,resolved}
+#    In 'shadow'/'off' the same event has retention_class='metadata' and no query text
+```
+
+## Alerts that route to this runbook
+
+- `privacy_tenant_stuck_in_full` — fires when any tenant has been in
+  `full` for >14 days. Triage: list affected tenants, check the audit
+  reason, decide with the operator whether to flip back.
+- `privacy_shadow_drop_burst` — fires when shadow-store INSERTs drop
+  >1/s for 5m. Triage: group by `reason`, check post-deploy SQL ran,
+  verify Postgres health.
+
+## Common failure modes
+
+### Cache doesn't invalidate
+
+The level changes in the DB but the LiteLLM hook keeps using the old
+level. Symptom: a /retrieve call >60s after the flip still emits
+content fields in `full` mode (or strips them in `shadow`).
+
+Cause: the SCAN+DEL of `kb_ver:{org_id}:*` failed (Redis blip mid-flip).
+
+Fix: manually delete the keys:
+```bash
+ssh core-01 "docker exec klai-core-redis-1 redis-cli \
+  --scan --pattern 'kb_ver:<org_id>:*' | \
+  xargs -r docker exec -i klai-core-redis-1 redis-cli DEL"
+```
+
+### Tenant-admin gets 403 on the dropdown
+
+The user is not the `admin` role on the tenant's PortalUser row. Either
+elevate the role OR have the tenant ask an existing org-admin to flip.
+The internal-admin path (operator) is always available as a backup.
+
+### `telemetry.query_shadow` table missing
+
+A fresh deploy ran `alembic upgrade head` but the post-deploy SQL was
+not applied. Symptom: `telemetry_shadow_drop_total{reason="db_error"}`
+spikes; `service:retrieval-api AND message:"undefined_table"`.
+
+Fix:
+```bash
+ssh core-01 "docker exec -i klai-core-postgres-1 psql -U klai -d klai" \
+  < klai-portal/backend/alembic/versions/post_deploy_g5h6i7j8k9l0.sql
+```
+
+(Or via the canonical wrapper: `scripts/apply_post_deploy_sql.sh g5h6i7j8k9l0`.)
+
+## Reset cadence and review
+
+Privacy posture review checklist for the on-call rotation, weekly:
+
+1. Open the `Privacy — Telemetry mode distribution` Grafana dashboard.
+2. Confirm the per-tenant pie shows `shadow` as dominant; flag any
+   tenant in `full` for >5 days.
+3. Spot-check the audit-log for entries with `operator_kind='operator'`
+   in the last week — every operator-side flip should have a real
+   ticket/reason.
+
+## Background / why the modes exist
+
+See `.moai/specs/SPEC-PRIVACY-QUERY-SHADOW-001/` for the full SPEC,
+research notes, and acceptance criteria. Key context: GDPR Article
+5(1)(c) data minimization. Default `shadow` lets Klai do operational
+quality monitoring without persisting customer-facing query text.

--- a/klai-knowledge-mcp/main.py
+++ b/klai-knowledge-mcp/main.py
@@ -979,6 +979,16 @@ async def search_knowledge(
         "scope": "both",
         "top_k": top_k,
         "conversation_history": [],
+        # SPEC-PRIVACY-QUERY-SHADOW-001 REQ-4: third-party MCP traffic
+        # (Claude Desktop / Cursor / ChatGPT) is privacy-by-default — we
+        # always send 'shadow' so raw query content never persists in
+        # operational stores, regardless of the tenant's litellm-hook
+        # level. Operators who need full-mode debug visibility for an MCP
+        # caller can flip the same kb_feature toggle for their LibreChat
+        # users; the MCP path stays private. Future enhancement: fetch
+        # the per-tenant level via a small portal-api lookup if business
+        # need arises.
+        "telemetry_level": "shadow",
     }
 
     # SPEC-SEC-IDENTITY-ASSERT-001 REQ-4.2: caller-service header is mandatory

--- a/klai-knowledge-mcp/tests/test_telemetry_level.py
+++ b/klai-knowledge-mcp/tests/test_telemetry_level.py
@@ -1,0 +1,74 @@
+"""SPEC-PRIVACY-QUERY-SHADOW-001 Unit 5 — knowledge-mcp telemetry forwarding.
+
+The MCP path is privacy-by-default: every /retrieve body MUST carry
+``telemetry_level: "shadow"``. This is intentional and conservative —
+third-party MCP traffic (Claude Desktop / Cursor / ChatGPT) is treated
+more strictly than first-party LibreChat traffic. Operators who need
+'full'-mode debug visibility can flip the kb_feature toggle for their
+LibreChat path; the MCP path stays in shadow until a future SPEC adds
+a per-tenant lookup.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from tests._helpers import allow_verify_result
+
+
+def _ctx() -> MagicMock:
+    ctx = MagicMock()
+    ctx.request_context.request.headers = {
+        "x-user-id": "user1",
+        "x-org-id": "org1",
+        "x-org-slug": "testorg",
+        "x-internal-secret": "test-secret",
+    }
+    return ctx
+
+
+def _make_resp(chunks: list[dict] | None = None) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json = MagicMock(
+        return_value={
+            "query_resolved": "test",
+            "retrieval_bypassed": False,
+            "chunks": chunks or [],
+        }
+    )
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_mcp_retrieve_body_carries_shadow_telemetry_level() -> None:
+    """REQ-4: every MCP /retrieve body has telemetry_level='shadow'."""
+    from main import search_knowledge
+
+    captured_body: dict = {}
+
+    async def _capture_post(*args, **kwargs):
+        captured_body.update(kwargs.get("json") or {})
+        return _make_resp([])
+
+    with (
+        patch(
+            "main._asserter.verify",
+            new_callable=AsyncMock,
+            return_value=allow_verify_result(),
+        ),
+        patch.object(
+            httpx.AsyncClient,
+            "post",
+            new=AsyncMock(side_effect=_capture_post),
+        ),
+        patch("main.fire_retrieval_log"),
+        patch("main.fire_gap_event"),
+    ):
+        await search_knowledge(query="hoe stel ik vakantie aan?", ctx=_ctx(), top_k=5)
+
+    assert captured_body.get("telemetry_level") == "shadow"

--- a/klai-libs/log-utils/log_utils/__init__.py
+++ b/klai-libs/log-utils/log_utils/__init__.py
@@ -20,6 +20,7 @@ from .structlog_setup import (
     DEFAULT_THIRD_PARTY_LEVELS,
     HealthCheckAccessFilter,
     RequestContextMiddleware,
+    _strip_query_fields_processor,
     setup_logging,
 )
 
@@ -28,6 +29,7 @@ __all__ = [
     "DEFAULT_THIRD_PARTY_LEVELS",
     "HealthCheckAccessFilter",
     "RequestContextMiddleware",
+    "_strip_query_fields_processor",
     "extract_secret_values",
     "sanitize_from_settings",
     "sanitize_response_body",

--- a/klai-libs/log-utils/log_utils/structlog_setup.py
+++ b/klai-libs/log-utils/log_utils/structlog_setup.py
@@ -84,6 +84,83 @@ _HealthCheckAccessFilter = HealthCheckAccessFilter
 
 
 # ---------------------------------------------------------------------------
+# SPEC-PRIVACY-QUERY-SHADOW-001 REQ-13 — anti-leakage processor
+# ---------------------------------------------------------------------------
+
+# Event names that may carry raw query content. The processor only acts on
+# events whose 'event' key matches one of these prefixes — keeps the cost
+# negligible for unrelated log lines.
+_QUERY_EVENT_PREFIXES: tuple[str, ...] = (
+    "retrieval_decision_record",
+    "query_rewrite",
+)
+
+# Field names that carry raw user-supplied query text in any event. When
+# the active telemetry_level is not 'full', these fields are stripped from
+# the event-dict before serialization. The processor catches both the
+# canonical field names AND nested coreference_rewrite.* sub-keys.
+_QUERY_LEAKING_FIELDS: tuple[str, ...] = (
+    "raw_query",
+    "rewritten_query",
+    "query",
+    "query_text",
+    "query_resolved",
+)
+
+
+def _strip_query_fields_processor(logger_obj: Any, method_name: str, event_dict: dict) -> dict:
+    """Defense-in-depth structlog processor that strips raw query content.
+
+    SPEC-PRIVACY-QUERY-SHADOW-001 REQ-13: redundant safety net on top of
+    the explicit gating in retrieve.py + klai_knowledge.py. If a future
+    code path emits a query-shaped field on a query-related event while
+    ``telemetry_level != 'full'`` is in scope, this processor removes it
+    before the JSON renderer serializes the event.
+
+    Reads ``telemetry_level`` from structlog contextvars. The contextvar
+    is set per-request by the LiteLLM hook + retrieval-api + portal-api
+    based on the org's configured level. When the contextvar is absent
+    (no per-request scope yet), the processor defaults to the privacy-
+    friendly side and strips the fields.
+
+    Args:
+        logger_obj: structlog logger (unused; required by processor sig)
+        method_name: log method name (unused)
+        event_dict: the event kwargs that will be rendered
+
+    Returns:
+        The (possibly modified) event dict.
+    """
+    telemetry_level = event_dict.get("telemetry_level")
+    if not telemetry_level:
+        # contextvar fallback — structlog's merge_contextvars runs earlier
+        # in the chain so any bound `telemetry_level` is already in the
+        # event_dict. If still absent, default to strip (privacy-side).
+        telemetry_level = "shadow"
+
+    if telemetry_level == "full":
+        return event_dict
+
+    event_name = event_dict.get("event") or ""
+    if not isinstance(event_name, str):
+        return event_dict
+    if not event_name.startswith(_QUERY_EVENT_PREFIXES):
+        return event_dict
+
+    # Strip top-level query-leaking fields.
+    for field in _QUERY_LEAKING_FIELDS:
+        if field in event_dict:
+            event_dict.pop(field, None)
+
+    # Strip the nested coreference_rewrite block entirely (its only
+    # sub-fields ['original', 'resolved'] are both raw query content).
+    if "coreference_rewrite" in event_dict:
+        event_dict.pop("coreference_rewrite", None)
+
+    return event_dict
+
+
+# ---------------------------------------------------------------------------
 # setup_logging
 # ---------------------------------------------------------------------------
 
@@ -132,6 +209,11 @@ def setup_logging(
 
     shared_processors: list[structlog.types.Processor] = [
         structlog.contextvars.merge_contextvars,
+        # SPEC-PRIVACY-QUERY-SHADOW-001 REQ-13: anti-leakage processor sits
+        # AFTER merge_contextvars (so it can read telemetry_level from the
+        # bound context) and BEFORE add_log_level / TimeStamper / renderer
+        # (so the strip happens before the event is finalized).
+        _strip_query_fields_processor,
         *(extra_processors or []),
         structlog.stdlib.add_log_level,
         structlog.stdlib.add_logger_name,

--- a/klai-libs/log-utils/tests/test_strip_query_fields.py
+++ b/klai-libs/log-utils/tests/test_strip_query_fields.py
@@ -1,0 +1,141 @@
+"""SPEC-PRIVACY-QUERY-SHADOW-001 REQ-13 — anti-leakage processor tests.
+
+The processor is a defense-in-depth net behind the explicit gating in
+retrieve.py / klai_knowledge.py. Tests cover both the positive path (event
+fields survive in 'full' mode) and the negative path (fields are stripped
+when telemetry_level is anything else).
+"""
+
+from __future__ import annotations
+
+from log_utils.structlog_setup import _strip_query_fields_processor
+
+
+def _run(event_dict: dict) -> dict:
+    """Invoke the processor with the same calling shape structlog uses."""
+    # The processor mutates and returns the dict; tests assert against the
+    # returned value to keep the contract explicit.
+    return _strip_query_fields_processor(None, "info", dict(event_dict))
+
+
+def test_full_mode_preserves_query_fields() -> None:
+    """Positive control: in 'full' mode every leaked field stays put."""
+    out = _run(
+        {
+            "event": "retrieval_decision_record",
+            "telemetry_level": "full",
+            "raw_query": "Hoe koppel ik X?",
+            "rewritten_query": "Hoe koppel ik X met Y?",
+            "query": "Hoe koppel ik X?",
+            "query_text": "...",
+            "query_resolved": "...",
+            "coreference_rewrite": {"original": "...", "resolved": "..."},
+            "request_id": "abc",
+        }
+    )
+    assert out["raw_query"] == "Hoe koppel ik X?"
+    assert out["rewritten_query"] == "Hoe koppel ik X met Y?"
+    assert out["coreference_rewrite"]["original"] == "..."
+    assert out["request_id"] == "abc"
+
+
+def test_shadow_mode_strips_query_fields_on_decision_record() -> None:
+    out = _run(
+        {
+            "event": "retrieval_decision_record",
+            "telemetry_level": "shadow",
+            "raw_query": "Hoe koppel ik X?",
+            "rewritten_query": "...",
+            "query": "...",
+            "query_text": "...",
+            "query_resolved": "...",
+            "coreference_rewrite": {"original": "leaked", "resolved": "leaked"},
+            "request_id": "abc",
+            "band": "low",
+        }
+    )
+    # All raw-query-shaped fields gone:
+    for key in (
+        "raw_query",
+        "rewritten_query",
+        "query",
+        "query_text",
+        "query_resolved",
+        "coreference_rewrite",
+    ):
+        assert key not in out, f"field {key} should have been stripped"
+    # Other fields preserved.
+    assert out["request_id"] == "abc"
+    assert out["band"] == "low"
+
+
+def test_off_mode_strips_query_fields_on_query_rewrite() -> None:
+    out = _run(
+        {
+            "event": "query_rewrite",
+            "telemetry_level": "off",
+            "raw_query": "Hoe koppel ik X?",
+            "rewritten_query": "...",
+            "rewrite_ms": 12.3,
+            "status": "ok",
+        }
+    )
+    assert "raw_query" not in out
+    assert "rewritten_query" not in out
+    assert out["rewrite_ms"] == 12.3
+    assert out["status"] == "ok"
+
+
+def test_unrelated_events_pass_through_unchanged() -> None:
+    """Events whose name doesn't match the prefixes are never touched."""
+    out = _run(
+        {
+            "event": "auth_check_passed",
+            "telemetry_level": "shadow",
+            "query": "this is not actually a query — keep as-is",
+            "user_id": "u1",
+        }
+    )
+    # The processor only acts on retrieval_decision_record / query_rewrite
+    # event names. An auth event must not be censored even if it happens
+    # to carry a 'query' kwarg.
+    assert out["query"] == "this is not actually a query — keep as-is"
+
+
+def test_default_strip_when_level_absent() -> None:
+    """Missing telemetry_level → privacy-side default (strip)."""
+    out = _run(
+        {
+            "event": "retrieval_decision_record",
+            # no telemetry_level set
+            "raw_query": "leaked",
+            "request_id": "abc",
+        }
+    )
+    assert "raw_query" not in out
+    assert out["request_id"] == "abc"
+
+
+def test_event_prefix_match() -> None:
+    """retrieval_decision_record_v2 (hypothetical future name) also gated."""
+    out = _run(
+        {
+            "event": "retrieval_decision_record_v2",
+            "telemetry_level": "shadow",
+            "raw_query": "leaked",
+        }
+    )
+    assert "raw_query" not in out
+
+
+def test_does_not_explode_on_non_string_event() -> None:
+    """Defensive: a malformed event_dict doesn't break the chain."""
+    out = _run(
+        {
+            "event": 12345,  # type: ignore[dict-item]
+            "telemetry_level": "shadow",
+            "raw_query": "untouched because event isn't a string",
+        }
+    )
+    # Non-string event → processor is a no-op (defensive).
+    assert out["raw_query"] == "untouched because event isn't a string"

--- a/klai-portal/backend/alembic/versions/g5h6i7j8k9l0_telemetry_level_and_cleanup.py
+++ b/klai-portal/backend/alembic/versions/g5h6i7j8k9l0_telemetry_level_and_cleanup.py
@@ -1,0 +1,90 @@
+"""SPEC-PRIVACY-QUERY-SHADOW-001: portal_orgs.telemetry_level + legacy gap cleanup
+
+Revision ID: g5h6i7j8k9l0
+Revises: f6d914f040da
+Create Date: 2026-05-08
+
+Adds the per-tenant telemetry-level column and runs the one-time hard
+cleanup of pre-existing raw query text in portal_retrieval_gaps. The
+companion post_deploy SQL (post_deploy_g5h6i7j8k9l0.sql) creates the
+`telemetry` schema and `telemetry.query_shadow` table — those statements
+require the `klai` superuser because portal_api cannot CREATE SCHEMA.
+
+Three statements run via standard alembic (portal_api role owns
+portal_orgs and portal_retrieval_gaps):
+
+1. CREATE TYPE telemetry_level_t (idempotent via DO-block)
+2. ALTER TABLE portal_orgs ADD COLUMN telemetry_level (default 'shadow')
+3. One-time cleanup on portal_retrieval_gaps:
+   - UPDATE rows older than 7d to '[REDACTED:legacy]' (privacy debt closure)
+   - DELETE rows older than 30d (existing legacy purge)
+
+The cleanup is idempotent — re-runs are no-ops because the WHERE clause
+matches only non-redacted rows. After this migration ships, the daily
+TTL job (Unit 7) maintains the invariant.
+
+Pre-flight verified 2026-05-08: portal_retrieval_gaps row count is 0 on
+prod, so the cleanup blast radius is zero. The migration is safe to run.
+
+REQ-1, REQ-12.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "g5h6i7j8k9l0"
+down_revision = "f6d914f040da"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1. Enum type for the per-tenant telemetry level.
+    #    DO-block makes CREATE TYPE idempotent (PostgreSQL has no IF NOT EXISTS for types).
+    op.execute(
+        """
+        DO $$ BEGIN
+            CREATE TYPE telemetry_level_t AS ENUM ('off', 'shadow', 'full');
+        EXCEPTION WHEN duplicate_object THEN null;
+        END $$;
+        """
+    )
+
+    # 2. Per-tenant column, default 'shadow' so existing tenants migrate
+    #    to the privacy-friendly default automatically (REQ-1).
+    op.execute(
+        """
+        ALTER TABLE public.portal_orgs
+            ADD COLUMN IF NOT EXISTS telemetry_level telemetry_level_t
+                NOT NULL DEFAULT 'shadow';
+        """
+    )
+
+    # 3. One-time legacy cleanup (REQ-12). Idempotent — the WHERE clause
+    #    excludes already-redacted rows, so re-runs touch nothing.
+    op.execute(
+        """
+        UPDATE public.portal_retrieval_gaps
+           SET query_text = '[REDACTED:legacy]'
+         WHERE query_text NOT LIKE '[REDACTED:%'
+           AND occurred_at < now() - interval '7 days';
+        """
+    )
+    op.execute(
+        """
+        DELETE FROM public.portal_retrieval_gaps
+         WHERE occurred_at < now() - interval '30 days';
+        """
+    )
+
+
+def downgrade() -> None:
+    # The cleanup UPDATE/DELETE cannot be reversed (data is gone). Only the
+    # column + type drops are downgradable. Documented in the SPEC's
+    # Rollback section: a privacy-regression rollback flips the per-tenant
+    # column back to 'full' on affected tenants instead of dropping the
+    # column.
+    op.execute("ALTER TABLE public.portal_orgs DROP COLUMN IF EXISTS telemetry_level;")
+    op.execute("DROP TYPE IF EXISTS telemetry_level_t;")

--- a/klai-portal/backend/alembic/versions/post_deploy_g5h6i7j8k9l0.sql
+++ b/klai-portal/backend/alembic/versions/post_deploy_g5h6i7j8k9l0.sql
@@ -1,0 +1,69 @@
+-- post_deploy_g5h6i7j8k9l0.sql
+-- SPEC-PRIVACY-QUERY-SHADOW-001: telemetry schema + query_shadow table.
+--
+-- Run as `klai` superuser AFTER `alembic upgrade g5h6i7j8k9l0` completes.
+--
+-- Rationale: portal_api cannot CREATE SCHEMA (it has no CREATE privilege
+-- on database `klai`) and cannot CREATE EXTENSION. Both must run under
+-- the klai superuser. The companion alembic migration handles only the
+-- statements portal_api can run on its owned tables.
+--
+-- Apply via:
+--   ssh core-01 "docker exec -i klai-core-postgres-1 psql -U klai -d klai" \
+--     < post_deploy_g5h6i7j8k9l0.sql
+-- Or via the wrapper:  scripts/apply_post_deploy_sql.sh g5h6i7j8k9l0
+--
+-- Idempotent: every statement uses IF NOT EXISTS so partial-failure
+-- reruns and re-application on a freshly-restored DB are safe.
+
+-- 1. pgvector extension (verified installed on prod 2026-05-08; this is
+--    a no-op on existing Klai environments but ensures fresh-install
+--    parity).
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- 2. Dedicated schema for ephemeral observational telemetry. Separate
+--    schema (not `public`) because:
+--      a. Different retention semantics (7d TTL vs indefinite for portal data)
+--      b. Different access pattern (write-heavy from retrieval-api)
+--      c. Future-proof for adding more shadow-style stores
+CREATE SCHEMA IF NOT EXISTS telemetry;
+
+-- Allow portal_api (and by transitive klai-superuser) to read/write the
+-- new schema. retrieval-api already connects as klai (verified
+-- 2026-05-08 in retrieval_api/config.py: portal_events_user='klai').
+GRANT USAGE ON SCHEMA telemetry TO portal_api;
+
+-- 3. Shadow-store table. The privacy contract: literal query text is
+--    NEVER stored here. Only the embedding (BGE-M3 1024-dim vector) and
+--    derived symbolic features (tokens, lang, has_brand, etc.).
+--
+--    7-day TTL is enforced by a separate cron job (Unit 7) — Postgres
+--    has no native TTL, so the job runs DELETE WHERE created_at <
+--    now() - interval '7 days'. The created_at index makes that scan
+--    cheap.
+CREATE TABLE IF NOT EXISTS telemetry.query_shadow (
+    request_id     uuid PRIMARY KEY,
+    org_id         text NOT NULL,
+    embedding      vector(1024),
+    features       jsonb NOT NULL,
+    band           text,
+    chunk_ids      text[],
+    reranker_top1  real,
+    created_at     timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS ix_query_shadow_created
+    ON telemetry.query_shadow (created_at);
+CREATE INDEX IF NOT EXISTS ix_query_shadow_org_created
+    ON telemetry.query_shadow (org_id, created_at DESC);
+
+-- portal_api inserts/reads via the gap-events + tenant self-service
+-- code paths (Unit 6 + Unit 9). retrieval-api inserts via the shadow
+-- writer (Unit 3) under the klai role.
+GRANT SELECT, INSERT, DELETE ON telemetry.query_shadow TO portal_api;
+
+-- No RLS on telemetry.query_shadow for v1: the table is keyed on a
+-- text org_id (Zitadel ID) for retrieval-api compatibility, and the
+-- read path is operator-only (no tenant-facing query). Future RLS can
+-- layer on top if/when a tenant-facing surface ships. Documented in
+-- SPEC § 3.2 Out-of-scope.

--- a/klai-portal/backend/app/api/admin/settings.py
+++ b/klai-portal/backend/app/api/admin/settings.py
@@ -39,6 +39,11 @@ class OrgSettingsOut(BaseModel):
     # @MX:NOTE SPEC-AUTH-009 R5 -- exposed so the frontend toggle label can show
     # "Automatically accept users with @{primary_domain}". None when not set.
     primary_domain: str | None = None
+    # @MX:NOTE SPEC-PRIVACY-QUERY-SHADOW-001 REQ-15 — current telemetry mode,
+    # surfaced read-only on this GET so the admin settings UI can render the
+    # current state without a second roundtrip. Mutated via the dedicated
+    # tenant-self-service endpoint POST /api/orgs/me/telemetry-level.
+    telemetry_level: Literal["off", "shadow", "full"] = "shadow"
 
 
 class OrgSettingsUpdate(BaseModel):
@@ -70,6 +75,7 @@ async def get_org_settings(
         mfa_policy=org.mfa_policy,
         auto_accept_same_domain=bool(org.auto_accept_same_domain),
         primary_domain=org.primary_domain or None,
+        telemetry_level=org.telemetry_level,
     )
 
 
@@ -96,6 +102,7 @@ async def update_org_settings(
         mfa_policy=org.mfa_policy,
         auto_accept_same_domain=bool(org.auto_accept_same_domain),
         primary_domain=org.primary_domain or None,
+        telemetry_level=org.telemetry_level,
     )
 
 

--- a/klai-portal/backend/app/api/internal.py
+++ b/klai-portal/backend/app/api/internal.py
@@ -608,6 +608,12 @@ class KnowledgeFeatureResponse(BaseModel):
     # qdrant chunks (klai-portal/backend/app/api/knowledge.py:172-204), so
     # the personal-scope filter also works.
     zitadel_user_id: str | None = None
+    # SPEC-PRIVACY-QUERY-SHADOW-001 REQ-2: per-tenant telemetry mode threaded
+    # through to the LiteLLM hook + knowledge-mcp. Default 'shadow' for
+    # backwards compatibility — when the field is absent in cached responses
+    # from older portal-api builds, downstream callers fail-open to 'shadow'
+    # per REQ-4.
+    telemetry_level: Literal["off", "shadow", "full"] = "shadow"
 
 
 @router.get("/v1/users/{librechat_user_id}/feature/knowledge", response_model=KnowledgeFeatureResponse)
@@ -631,8 +637,14 @@ async def get_knowledge_feature(
 
     # Set tenant context early using the org_id query param (Zitadel org ID).
     # This is needed so subsequent queries on RLS-protected tables work correctly.
-    org_lookup = await db.execute(select(PortalOrg.id).where(PortalOrg.zitadel_org_id == org_id))
-    portal_org_id = org_lookup.scalar_one_or_none()
+    # SPEC-PRIVACY-QUERY-SHADOW-001 REQ-2: also fetch telemetry_level so every
+    # disabled-path return surfaces the org's level (not the default).
+    org_lookup = await db.execute(
+        select(PortalOrg.id, PortalOrg.telemetry_level).where(PortalOrg.zitadel_org_id == org_id)
+    )
+    org_row = org_lookup.one_or_none()
+    portal_org_id = org_row[0] if org_row else None
+    org_telemetry_level: Literal["off", "shadow", "full"] = org_row[1] if org_row else "shadow"
     if portal_org_id is not None:
         await set_tenant(db, portal_org_id)
 
@@ -647,7 +659,7 @@ async def get_knowledge_feature(
         if not settings.librechat_mongo_root_uri:
             logger.warning("KB authz: LIBRECHAT_MONGO_ROOT_URI not set — fail-closed for user %s", librechat_user_id)
             await _audit_internal_call(request, org_id=audit_org_id)
-            return KnowledgeFeatureResponse(enabled=False)
+            return KnowledgeFeatureResponse(enabled=False, telemetry_level=org_telemetry_level)
 
         # Look up the org to get its LibreChat container name (= MongoDB database name)
         org_result = await db.execute(select(PortalOrg).where(PortalOrg.zitadel_org_id == org_id))
@@ -655,14 +667,14 @@ async def get_knowledge_feature(
         if org is None or not org.librechat_container:
             logger.warning("KB authz: org %s has no librechat_container — fail-closed", org_id)
             await _audit_internal_call(request, org_id=audit_org_id)
-            return KnowledgeFeatureResponse(enabled=False)
+            return KnowledgeFeatureResponse(enabled=False, telemetry_level=org_telemetry_level)
 
         try:
             oid = ObjectId(librechat_user_id)
         except InvalidId:
             logger.warning("KB authz: invalid ObjectId %s — fail-closed", librechat_user_id)
             await _audit_internal_call(request, org_id=audit_org_id)
-            return KnowledgeFeatureResponse(enabled=False)
+            return KnowledgeFeatureResponse(enabled=False, telemetry_level=org_telemetry_level)
 
         mongo_client: AsyncIOMotorClient | None = None
         try:
@@ -676,7 +688,7 @@ async def get_knowledge_feature(
                 exc_info=True,
             )
             await _audit_internal_call(request, org_id=audit_org_id)
-            return KnowledgeFeatureResponse(enabled=False)
+            return KnowledgeFeatureResponse(enabled=False, telemetry_level=org_telemetry_level)
         finally:
             if mongo_client is not None:
                 mongo_client.close()
@@ -684,13 +696,13 @@ async def get_knowledge_feature(
         if mongo_user is None:
             logger.warning("KB authz: no LibreChat user found for ObjectId %s — fail-closed", librechat_user_id)
             await _audit_internal_call(request, org_id=audit_org_id)
-            return KnowledgeFeatureResponse(enabled=False)
+            return KnowledgeFeatureResponse(enabled=False, telemetry_level=org_telemetry_level)
 
         zitadel_user_id = mongo_user.get("openidId") or mongo_user.get("openid_id") or mongo_user.get("sub")
         if not zitadel_user_id:
             logger.warning("KB authz: LibreChat user %s has no openidId/sub — fail-closed", librechat_user_id)
             await _audit_internal_call(request, org_id=audit_org_id)
-            return KnowledgeFeatureResponse(enabled=False)
+            return KnowledgeFeatureResponse(enabled=False, telemetry_level=org_telemetry_level)
 
         # Resolve portal user and cache the mapping
         portal_result = await db.execute(select(PortalUser).where(PortalUser.zitadel_user_id == zitadel_user_id))
@@ -698,7 +710,7 @@ async def get_knowledge_feature(
         if user is None:
             logger.warning("KB authz: no portal user for zitadel_user_id %s — fail-closed", zitadel_user_id)
             await _audit_internal_call(request, org_id=audit_org_id)
-            return KnowledgeFeatureResponse(enabled=False)
+            return KnowledgeFeatureResponse(enabled=False, telemetry_level=org_telemetry_level)
 
         user.librechat_user_id = librechat_user_id
         await db.commit()
@@ -719,7 +731,76 @@ async def get_knowledge_feature(
         kb_narrow=user.kb_narrow,
         kb_pref_version=user.kb_pref_version,
         zitadel_user_id=user.zitadel_user_id,
+        telemetry_level=org_telemetry_level,
     )
+
+
+# SPEC-PRIVACY-QUERY-SHADOW-001 REQ-11: internal-admin telemetry-level toggle.
+class TelemetryLevelChange(BaseModel):
+    level: Literal["off", "shadow", "full"]
+    reason: str
+
+
+class TelemetryLevelOut(BaseModel):
+    org_id: int
+    old_level: Literal["off", "shadow", "full"]
+    new_level: Literal["off", "shadow", "full"]
+
+
+@router.post(
+    "/admin/orgs/{org_id}/telemetry-level",
+    response_model=TelemetryLevelOut,
+)
+async def admin_set_telemetry_level(
+    org_id: int,
+    body: TelemetryLevelChange,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> TelemetryLevelOut:
+    """Operator-only endpoint to flip a tenant's telemetry mode (REQ-11).
+
+    Auth: same X-Internal-Secret pattern as the rest of /internal/* — the
+    caller is presumed to be a klai-operator. The audit row records
+    ``operator_kind='operator'`` so it is distinguishable from the
+    tenant-self-service path (REQ-15) in the audit-log UI.
+    """
+    await _require_internal_token(request)
+
+    if not body.reason or not body.reason.strip():
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="reason must be non-empty",
+        )
+    if len(body.reason) > 500:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="reason exceeds 500-char limit",
+        )
+
+    from app.services.telemetry_level import set_telemetry_level
+
+    # Internal admin path: operator identity is implicit in the
+    # X-Internal-Secret bearer (no per-user JWT). We record a stable
+    # synthetic actor so the audit-log row is non-empty; klai-operators
+    # can correlate via the request_id in observability logs.
+    operator_user_id = "internal-admin"
+
+    try:
+        old_level, new_level = await set_telemetry_level(
+            db,
+            org_id=org_id,
+            new_level=body.level,
+            operator_kind="operator",
+            operator_user_id=operator_user_id,
+            reason=body.reason,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+
+    await _audit_internal_call(request, org_id=org_id)
+    return TelemetryLevelOut(org_id=org_id, old_level=old_level, new_level=new_level)
 
 
 class PageSavedNotification(BaseModel):

--- a/klai-portal/backend/app/api/internal.py
+++ b/klai-portal/backend/app/api/internal.py
@@ -855,6 +855,15 @@ async def post_retrieval_log(
 
     Resolves zitadel org_id string to portal int org_id, then writes to Redis.
     Silent discard on any error (REQ-KB-015-03).
+
+    SPEC-PRIVACY-QUERY-SHADOW-001 REQ-9 (reinterpreted): the retrieval-log
+    is Redis-backed (1h TTL JSON blob), NOT a Postgres table. The
+    spec.md REQ-9 referenced ``knowledge.retrieval_logs.query_resolved``
+    which does not exist on prod. The privacy contract here gates the
+    raw ``query_resolved`` field within the Redis blob:
+      - off    → skip the Redis write entirely
+      - shadow → write blob with ``query_resolved=""`` (empty placeholder)
+      - full   → write blob with literal query_resolved (existing behaviour)
     """
     await _require_internal_token(request)
 
@@ -866,6 +875,17 @@ async def post_retrieval_log(
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Org not found")
         audit_org_id = org.id
 
+        # SPEC-PRIVACY-QUERY-SHADOW-001 REQ-9: gate the Redis write on
+        # the canonical telemetry_level (never trust the upstream-supplied
+        # value for a privacy decision).
+        if org.telemetry_level == "off":
+            await _audit_internal_call(request, org_id=audit_org_id)
+            return {"ok": True, "skipped": "telemetry_off"}
+
+        # 'shadow' redacts the raw query content; chunk_ids /
+        # reranker_scores / model version still flow (they're aggregates).
+        effective_query_resolved = body.query_resolved if org.telemetry_level == "full" else ""
+
         from app.services.retrieval_log import write_retrieval_log
 
         await write_retrieval_log(
@@ -873,7 +893,7 @@ async def post_retrieval_log(
             user_id=body.user_id,
             chunk_ids=body.chunk_ids,
             reranker_scores=body.reranker_scores,
-            query_resolved=body.query_resolved,
+            query_resolved=effective_query_resolved,
             embedding_model_version=body.embedding_model_version,
             retrieved_at=body.retrieved_at,
             caller_client_id=body.caller_client_id,
@@ -1017,7 +1037,16 @@ async def create_gap_event(
     request: Request,
     db: AsyncSession = Depends(get_db),
 ) -> dict:
-    """Record a knowledge gap event from the LiteLLM hook."""
+    """Record a knowledge gap event from the LiteLLM hook.
+
+    SPEC-PRIVACY-QUERY-SHADOW-001 REQ-8: gating by per-tenant
+    telemetry_level — never trust the upstream-supplied value, always
+    re-fetch the canonical level from portal_orgs.
+
+    - off    → 200 OK, no row inserted
+    - shadow → INSERT with query_text='[REDACTED:shadow]'
+    - full   → INSERT with literal query_text (existing behavior)
+    """
     await _require_internal_token(request)
     from app.models.retrieval_gaps import PortalRetrievalGap
 
@@ -1027,10 +1056,22 @@ async def create_gap_event(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Org not found")
     await set_tenant(db, org.id)
 
+    # REQ-8: 'off' → skip the INSERT entirely. Tenant accepts the
+    # support-side trade-off; we still respond 200 to keep the
+    # idempotent contract for fire-and-forget callers.
+    if org.telemetry_level == "off":
+        await _audit_internal_call(request, org_id=org.id)
+        return {"ok": True, "skipped": "telemetry_off"}
+
+    # REQ-8: 'shadow' → REDACT the literal query text. The matching
+    # telemetry.query_shadow row (written by retrieval-api in Unit 3)
+    # carries the embedding + features for support-team triage.
+    effective_query_text = payload.query_text if org.telemetry_level == "full" else "[REDACTED:shadow]"
+
     gap = PortalRetrievalGap(
         org_id=org.id,
         user_id=payload.user_id,
-        query_text=payload.query_text,
+        query_text=effective_query_text,
         gap_type=payload.gap_type,
         top_score=payload.top_score,
         nearest_kb_slug=payload.nearest_kb_slug,

--- a/klai-portal/backend/app/api/orgs.py
+++ b/klai-portal/backend/app/api/orgs.py
@@ -1,0 +1,89 @@
+"""SPEC-PRIVACY-QUERY-SHADOW-001 REQ-15 — tenant self-service endpoints.
+
+Tenant-admin scoped endpoints for org-level settings the tenant can flip
+without an operator round-trip. Currently only the telemetry-level
+toggle (the privacy posture vs debug capability decision is owned by
+the tenant, not Klai).
+
+Auth contract: ``_get_caller_org`` resolves the OIDC subject to a
+PortalOrg + PortalUser; ``_require_admin`` raises 403 if the user is
+not the org-admin. The shared service-layer ``set_telemetry_level``
+guarantees identical DB behaviour to the operator-side endpoint
+(REQ-11) — single audit-log + cache-invalidation path, only the
+``operator_kind`` field differs.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.admin import _get_caller_org, _require_admin
+from app.api.bearer import bearer
+from app.core.database import get_db
+from app.services.telemetry_level import set_telemetry_level
+
+logger = logging.getLogger(__name__)
+
+# /api/orgs/me/* — tenant-self-service surface. The "me" suffix mirrors
+# /api/me's user-self-service convention; "orgs/me" reads as "the
+# org of the calling user". The handler refuses any org_id that doesn't
+# match the caller's resolved org (defense-in-depth).
+router = APIRouter(prefix="/api/orgs", tags=["orgs"])
+
+
+class TelemetryLevelUpdate(BaseModel):
+    level: Literal["off", "shadow", "full"]
+
+
+class TelemetryLevelOut(BaseModel):
+    telemetry_level: Literal["off", "shadow", "full"]
+
+
+@router.post("/me/telemetry-level", response_model=TelemetryLevelOut)
+async def set_my_org_telemetry_level(
+    body: TelemetryLevelUpdate,
+    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    db: AsyncSession = Depends(get_db),
+) -> TelemetryLevelOut:
+    """Tenant-admin endpoint to flip their own org's telemetry mode.
+
+    REQ-15 contract:
+    - Caller MUST hold the ``admin`` role on the resolved org (else 403)
+    - DB update is scoped to ``caller_org.id`` — cross-org attempts via
+      a manipulated path are impossible because the org is read from
+      the caller's JWT, not the URL
+    - Audit row records ``operator_kind='tenant_admin'``,
+      ``reason='tenant self-service via admin UI'``,
+      ``operator_user_id=<zitadel sub>``
+    - Cache invalidation runs so the next chat completion picks up the
+      new level within ~30s (kb_ver Redis pointer expiry)
+    """
+    zitadel_user_id, org, caller_user = await _get_caller_org(credentials, db)
+    _require_admin(caller_user)
+
+    try:
+        _, new_level = await set_telemetry_level(
+            db,
+            org_id=org.id,
+            new_level=body.level,
+            operator_kind="tenant_admin",
+            operator_user_id=zitadel_user_id,
+            reason="tenant self-service via admin UI",
+        )
+    except LookupError as exc:
+        # Should never happen — _get_caller_org just returned this org.
+        # Preserved for defense-in-depth against a race with another
+        # operation deleting the org row.
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except ValueError as exc:
+        # pydantic Literal already restricts the input; this is the
+        # service-layer's reason validation.
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+
+    return TelemetryLevelOut(telemetry_level=new_level)

--- a/klai-portal/backend/app/main.py
+++ b/klai-portal/backend/app/main.py
@@ -48,6 +48,7 @@ from app.middleware.tenant_host import KlaiTenantHostMiddleware
 from app.services.bot_poller import poll_loop
 from app.services.events import _pending as _event_tasks
 from app.services.recording_cleanup import recording_cleanup_loop
+from app.services.telemetry_purge import telemetry_purge_loop
 from app.services.vexa import vexa
 from app.services.zitadel import zitadel
 
@@ -182,6 +183,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     cleanup_task = asyncio.create_task(recording_cleanup_loop())
     logger.info("Recording cleanup loop started")
 
+    # SPEC-PRIVACY-QUERY-SHADOW-001 Unit 7: 7-day TTL purge for
+    # telemetry.query_shadow + portal_retrieval_gaps.
+    telemetry_purge_task = asyncio.create_task(telemetry_purge_loop())
+    logger.info("Telemetry purge loop started")
+
     imap_task: asyncio.Task[None] | None = None
     if settings.imap_host and settings.imap_username:
         from app.services.imap_listener import start_imap_listener
@@ -195,6 +201,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     poller_task.cancel()
     cleanup_task.cancel()
+    telemetry_purge_task.cancel()
     if imap_task is not None:
         imap_task.cancel()
     if _event_tasks:

--- a/klai-portal/backend/app/main.py
+++ b/klai-portal/backend/app/main.py
@@ -8,7 +8,7 @@ from fastapi import FastAPI, Request
 from fastapi.responses import Response
 from fastapi.staticfiles import StaticFiles
 
-from app.api import me, signup
+from app.api import me, orgs, signup
 from app.api.admin import router as admin_router
 from app.api.admin_api_keys import router as admin_api_keys_router
 from app.api.admin_widgets import router as admin_widgets_router
@@ -269,6 +269,7 @@ from app.api.auth_bff import router as auth_bff_router  # noqa: E402
 
 app.include_router(signup.router)
 app.include_router(me.router)
+app.include_router(orgs.router)
 app.include_router(me_mcp_tokens_router)
 app.include_router(mcp_oauth_router)
 app.include_router(auth_router)

--- a/klai-portal/backend/app/models/portal.py
+++ b/klai-portal/backend/app/models/portal.py
@@ -87,6 +87,23 @@ class PortalOrg(Base):
         default=list,
         server_default="{}",
     )
+    # @MX:NOTE: SPEC-PRIVACY-QUERY-SHADOW-001 REQ-1 — per-tenant telemetry mode.
+    # 'shadow' (default): embedding + symbolic features only, no raw query persisted.
+    # 'off': zero telemetry. 'full': raw query persisted with 7d TTL (audit-trailed).
+    # The underlying ENUM (telemetry_level_t) is created by alembic migration
+    # g5h6i7j8k9l0; create_type=False so SQLAlchemy doesn't try to recreate it.
+    telemetry_level: Mapped[Literal["off", "shadow", "full"]] = mapped_column(
+        sa.Enum(
+            "off",
+            "shadow",
+            "full",
+            name="telemetry_level_t",
+            create_type=False,
+        ),
+        nullable=False,
+        default="shadow",
+        server_default="shadow",
+    )
 
     users: Mapped[list["PortalUser"]] = relationship(back_populates="org")
 

--- a/klai-portal/backend/app/services/telemetry_level.py
+++ b/klai-portal/backend/app/services/telemetry_level.py
@@ -1,0 +1,175 @@
+"""SPEC-PRIVACY-QUERY-SHADOW-001 — shared telemetry-level service-layer.
+
+Single source of truth for changing a tenant's `portal_orgs.telemetry_level`,
+shared between:
+
+- the internal-admin endpoint (REQ-11; ``/internal/admin/orgs/{org_id}/telemetry-level``)
+- the tenant self-service endpoint (REQ-15; ``/api/orgs/me/telemetry-level``)
+
+Both endpoints share the DB-update + cache-invalidation + audit-log
+behaviour. They differ only in:
+
+- Authorization (klai-operator vs tenant-admin)
+- Default ``reason`` ("internal admin" vs "tenant self-service via admin UI")
+- ``operator_kind`` audit field
+
+Cache invalidation: deletes every ``kb_ver:{org_id}:*`` Redis key for the
+org so the LiteLLM hook picks up the new level on the next request. The
+version-keyed feature cache (``kb_feature:{org}:{user}:{version}``) becomes
+unreachable once the version pointer is gone, so it expires naturally on
+its own TTL. Failure is logged but never blocks the DB-write.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Literal
+
+import redis.asyncio as aioredis
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models.portal import PortalOrg
+from app.services.audit import log_event
+
+logger = structlog.get_logger()
+
+TelemetryLevel = Literal["off", "shadow", "full"]
+VALID_LEVELS: tuple[TelemetryLevel, ...] = ("off", "shadow", "full")
+
+
+async def _invalidate_org_kb_cache(org_id: int) -> None:
+    """Delete every ``kb_ver:{org_id}:*`` key so the LiteLLM hook re-fetches.
+
+    Fire-and-forget — Redis failures must not block the DB-write that has
+    already committed. The hook's local cache TTL (30s) acts as a safety
+    net so missing invalidation doesn't keep stale state forever.
+    """
+    pattern = f"kb_ver:{org_id}:*"
+    try:
+        r = aioredis.Redis(
+            host=settings.redis_host,
+            port=settings.redis_port,
+            password=settings.redis_password or None,
+            socket_connect_timeout=1.0,
+        )
+        async with r:
+            cursor = 0
+            deleted = 0
+            while True:
+                cursor, keys = await r.scan(cursor=cursor, match=pattern, count=200)
+                if keys:
+                    deleted += await r.delete(*keys)
+                if cursor == 0:
+                    break
+            logger.info(
+                "telemetry_level_cache_invalidated",
+                org_id=org_id,
+                pattern=pattern,
+                keys_deleted=deleted,
+            )
+    except Exception:
+        # Single-tenant Redis blip should not turn a successful telemetry
+        # toggle into a 500. The hook will pick up fresh state within 30s
+        # via its local-cache TTL.
+        logger.warning(
+            "telemetry_level_cache_invalidation_failed",
+            org_id=org_id,
+            exc_info=True,
+        )
+
+
+async def set_telemetry_level(
+    db: AsyncSession,
+    org_id: int,
+    new_level: TelemetryLevel,
+    *,
+    operator_kind: Literal["operator", "tenant_admin"],
+    operator_user_id: str,
+    reason: str,
+) -> tuple[TelemetryLevel, TelemetryLevel]:
+    """Update ``portal_orgs.telemetry_level`` for ``org_id`` and audit-log.
+
+    Returns ``(old_level, new_level)``. Caller is responsible for any
+    further response shaping. Validation of ``new_level`` is enforced by
+    the ``Literal`` type at the API boundary (FastAPI/pydantic) — this
+    function asserts again as a defense-in-depth check.
+
+    Caller MUST have already authenticated and (for ``tenant_admin``)
+    enforced same-org scoping. This function does not check authorization.
+    """
+    if new_level not in VALID_LEVELS:
+        # Defense-in-depth: caller's pydantic Literal already restricts
+        # this, but keep the assertion so a future direct call from a
+        # background task can't inject a bogus value.
+        raise ValueError(f"invalid telemetry_level: {new_level!r}")
+
+    if not reason or not reason.strip():
+        raise ValueError("reason must be non-empty")
+    if len(reason) > 500:
+        raise ValueError("reason exceeds 500 char limit")
+
+    # SELECT FOR UPDATE serializes concurrent toggles on the same org.
+    result = await db.execute(select(PortalOrg).where(PortalOrg.id == org_id).with_for_update())
+    org = result.scalar_one_or_none()
+    if org is None:
+        raise LookupError(f"org_id={org_id} not found")
+
+    old_level: TelemetryLevel = org.telemetry_level  # type: ignore[assignment]
+    if old_level == new_level:
+        # Idempotent no-op: still write an audit row so the operator's
+        # action is recorded, but skip the cache invalidation churn.
+        logger.info(
+            "telemetry_level_unchanged",
+            org_id=org_id,
+            level=new_level,
+            operator_kind=operator_kind,
+        )
+    else:
+        org.telemetry_level = new_level
+        await db.commit()
+
+    # Cache invalidation runs even on no-op so a stuck hook can be nudged
+    # by re-applying the same level (operator escape hatch).
+    await _invalidate_org_kb_cache(org_id)
+
+    # Audit log uses raw SQL via log_event's own session — survives any
+    # caller transaction rollback. action='telemetry_level_changed' is
+    # the canonical name surfaced to operators in the audit UI.
+    audit_details = {
+        "old_level": old_level,
+        "new_level": new_level,
+        "reason": reason,
+        "operator_kind": operator_kind,
+        "operator_user_id": operator_user_id,
+    }
+    try:
+        await log_event(
+            org_id=org_id,
+            actor=operator_user_id,
+            action="telemetry_level_changed",
+            resource_type="portal_org",
+            resource_id=str(org_id),
+            details=audit_details,
+        )
+    except Exception:
+        # log_event is fire-and-forget per its own contract; if even that
+        # falls over, surface it in our service log so we still notice.
+        logger.warning(
+            "telemetry_level_audit_log_failed",
+            org_id=org_id,
+            details=json.dumps(audit_details),
+            exc_info=True,
+        )
+
+    logger.info(
+        "telemetry_level_changed",
+        org_id=org_id,
+        old_level=old_level,
+        new_level=new_level,
+        operator_kind=operator_kind,
+        operator_user_id=operator_user_id,
+    )
+    return old_level, new_level

--- a/klai-portal/backend/app/services/telemetry_purge.py
+++ b/klai-portal/backend/app/services/telemetry_purge.py
@@ -52,7 +52,7 @@ async def _purge_once() -> dict[str, int]:
                 text("DELETE FROM telemetry.query_shadow WHERE created_at < :cutoff"),
                 {"cutoff": cutoff},
             )
-            counts["query_shadow"] = result.rowcount or 0
+            counts["query_shadow"] = (result.rowcount or 0) if hasattr(result, "rowcount") else 0  # type: ignore[attr-defined]
         except Exception:
             logger.warning("telemetry_purge_query_shadow_failed", exc_info=True)
 
@@ -71,7 +71,7 @@ async def _purge_once() -> dict[str, int]:
                 ),
                 {"cutoff": cutoff},
             )
-            counts["retrieval_gaps"] = result.rowcount or 0
+            counts["retrieval_gaps"] = (result.rowcount or 0) if hasattr(result, "rowcount") else 0  # type: ignore[attr-defined]
         except Exception:
             logger.warning("telemetry_purge_retrieval_gaps_failed", exc_info=True)
 

--- a/klai-portal/backend/app/services/telemetry_purge.py
+++ b/klai-portal/backend/app/services/telemetry_purge.py
@@ -1,0 +1,107 @@
+"""SPEC-PRIVACY-QUERY-SHADOW-001 Unit 7 — daily 7-day TTL purge.
+
+Background loop that runs every 24 hours and deletes rows older than
+7 days from the three privacy-sensitive stores:
+
+1. ``telemetry.query_shadow``       — every row > 7d (REQ-7 retention)
+2. ``portal_retrieval_gaps``         — every row whose query_text is NOT
+                                        a redaction sentinel AND > 7d
+                                        (legacy or full-mode raw text)
+3. portal-side mirror of the Redis
+   retrieval-log already has its own 1h TTL, so no DB sweep here
+
+The job is scheduled via ``asyncio.create_task`` from the FastAPI
+lifespan, mirroring ``recording_cleanup_loop`` (SPEC-GDPR-002-R5). It
+runs cross-org via ``cross_org_session`` because the privacy contract
+is platform-wide, not per-tenant.
+
+Failures are logged and the loop continues — a transient Postgres blip
+must not silently disable retention. Cancellation (lifespan shutdown)
+exits the loop cleanly via ``asyncio.CancelledError``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+import structlog
+from sqlalchemy import text
+
+from app.core.database import cross_org_session
+
+logger = structlog.get_logger()
+
+# 24-hour cadence keeps the Postgres footprint negligible (~10k deletes
+# per day at production volume) while staying within the 7-day TTL
+# contract — at most a 25-hour-old row survives for one cycle, well
+# within the privacy fence.
+PURGE_INTERVAL_SECONDS = 24 * 60 * 60
+RETENTION_DAYS = 7
+
+
+async def _purge_once() -> dict[str, int]:
+    """Run the three DELETEs in one pass and return per-store counts."""
+    cutoff = datetime.now(UTC) - timedelta(days=RETENTION_DAYS)
+    counts: dict[str, int] = {"query_shadow": 0, "retrieval_gaps": 0}
+
+    async with cross_org_session() as db:
+        # 1. telemetry.query_shadow — fully ephemeral, every row > 7d.
+        try:
+            result = await db.execute(
+                text("DELETE FROM telemetry.query_shadow WHERE created_at < :cutoff"),
+                {"cutoff": cutoff},
+            )
+            counts["query_shadow"] = result.rowcount or 0
+        except Exception:
+            logger.warning("telemetry_purge_query_shadow_failed", exc_info=True)
+
+        # 2. portal_retrieval_gaps — only rows whose query_text is the
+        #    raw or legacy text. Rows with sentinel '[REDACTED:%' carry
+        #    no privacy debt and stay until the operator resolves the
+        #    underlying gap. The check uses NOT LIKE so both
+        #    '[REDACTED:legacy]' (one-time cleanup) and
+        #    '[REDACTED:shadow]' (ongoing shadow-mode inserts) survive.
+        try:
+            result = await db.execute(
+                text(
+                    "DELETE FROM public.portal_retrieval_gaps "
+                    "WHERE query_text NOT LIKE '[REDACTED:%' "
+                    "AND occurred_at < :cutoff"
+                ),
+                {"cutoff": cutoff},
+            )
+            counts["retrieval_gaps"] = result.rowcount or 0
+        except Exception:
+            logger.warning("telemetry_purge_retrieval_gaps_failed", exc_info=True)
+
+        await db.commit()
+
+    logger.info(
+        "telemetry_purge_complete",
+        cutoff=cutoff.isoformat(),
+        purged_query_shadow=counts["query_shadow"],
+        purged_retrieval_gaps=counts["retrieval_gaps"],
+    )
+    return counts
+
+
+async def telemetry_purge_loop() -> None:
+    """FastAPI-lifespan-attached daily purge loop.
+
+    Sleeps 60s on startup so the app can finish wiring before the first
+    DB hit. Then runs ``_purge_once`` every PURGE_INTERVAL_SECONDS until
+    cancelled.
+    """
+    await asyncio.sleep(60)
+    while True:
+        try:
+            await _purge_once()
+        except asyncio.CancelledError:
+            break
+        except Exception:
+            # Last-resort guard: anything that escapes _purge_once's
+            # per-table try/except. Loop continues so the next cycle
+            # has a fresh attempt.
+            logger.exception("telemetry_purge_unexpected_error")
+        await asyncio.sleep(PURGE_INTERVAL_SECONDS)

--- a/klai-portal/backend/tests/test_gap_events_telemetry.py
+++ b/klai-portal/backend/tests/test_gap_events_telemetry.py
@@ -1,0 +1,230 @@
+"""SPEC-PRIVACY-QUERY-SHADOW-001 Unit 6 — gap-events + retrieval-log gating.
+
+Pure unit tests with mocked AsyncSession + `set_tenant`. Verifies the
+three-mode gating contract for the two portal-api telemetry endpoints:
+
+- /internal/v1/gap-events:
+  * off    → skipped, no PortalRetrievalGap.add()
+  * shadow → row inserted with query_text='[REDACTED:shadow]'
+  * full   → row inserted with literal query_text (legacy behaviour)
+
+- /internal/v1/retrieval-log:
+  * off    → skipped, no write_retrieval_log call
+  * shadow → write_retrieval_log called with query_resolved=""
+  * full   → write_retrieval_log called with literal query_resolved
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class _FakeOrg:
+    def __init__(self, telemetry_level: str = "shadow") -> None:
+        self.id = 42
+        self.zitadel_org_id = "zit-org-1"
+        self.telemetry_level = telemetry_level
+
+
+def _scalar_result(value: object) -> MagicMock:
+    res = MagicMock()
+    res.scalar_one_or_none.return_value = value
+    return res
+
+
+def _build_gap_payload() -> dict:
+    return {
+        "org_id": "zit-org-1",
+        "user_id": "user-1",
+        "query_text": "Hoe stel ik vakantie aan?",
+        "gap_type": "soft",
+        "top_score": 0.42,
+        "nearest_kb_slug": "support",
+        "chunks_retrieved": 0,
+        "retrieval_ms": 120,
+        "taxonomy_node_ids": None,
+        "caller_client_id": None,
+    }
+
+
+def _build_log_payload() -> dict:
+    return {
+        "org_id": "zit-org-1",
+        "user_id": "user-1",
+        "chunk_ids": ["c1", "c2"],
+        "reranker_scores": [0.7, 0.5],
+        "query_resolved": "Hoe stel ik vakantie aan in het systeem?",
+        "embedding_model_version": "bge-m3",
+        "retrieved_at": datetime.now(UTC),
+        "caller_client_id": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_gap_events_skipped_in_off_mode() -> None:
+    """REQ-8: 'off' returns 200 but inserts nothing."""
+    from app.api.internal import GapEventIn, create_gap_event
+
+    org = _FakeOrg(telemetry_level="off")
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_scalar_result(org))
+    db.add = MagicMock()
+    db.commit = AsyncMock()
+
+    payload = GapEventIn(**_build_gap_payload())
+    request = MagicMock()
+    request.headers = {"x-internal-secret": "test-secret"}
+
+    with (
+        patch("app.api.internal._require_internal_token", AsyncMock()),
+        patch("app.api.internal.set_tenant", AsyncMock()),
+        patch("app.api.internal._audit_internal_call", AsyncMock()),
+    ):
+        result = await create_gap_event(payload, request, db)
+
+    assert result["ok"] is True
+    assert result.get("skipped") == "telemetry_off"
+    db.add.assert_not_called()
+    db.commit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_gap_events_redacts_in_shadow_mode() -> None:
+    """REQ-8: 'shadow' inserts a row with query_text='[REDACTED:shadow]'."""
+    from app.api.internal import GapEventIn, create_gap_event
+
+    org = _FakeOrg(telemetry_level="shadow")
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_scalar_result(org))
+    captured: list = []
+    db.add = MagicMock(side_effect=lambda obj: captured.append(obj))
+    db.commit = AsyncMock()
+
+    payload = GapEventIn(**_build_gap_payload())
+    request = MagicMock()
+    request.headers = {"x-internal-secret": "test-secret"}
+
+    with (
+        patch("app.api.internal._require_internal_token", AsyncMock()),
+        patch("app.api.internal.set_tenant", AsyncMock()),
+        patch("app.api.internal._audit_internal_call", AsyncMock()),
+    ):
+        await create_gap_event(payload, request, db)
+
+    assert len(captured) == 1
+    gap = captured[0]
+    assert gap.query_text == "[REDACTED:shadow]"
+    # Other fields preserved.
+    assert gap.gap_type == "soft"
+    assert gap.top_score == 0.42
+
+
+@pytest.mark.asyncio
+async def test_gap_events_keeps_text_in_full_mode() -> None:
+    """REQ-8: 'full' inserts a row with literal query_text (legacy)."""
+    from app.api.internal import GapEventIn, create_gap_event
+
+    org = _FakeOrg(telemetry_level="full")
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_scalar_result(org))
+    captured: list = []
+    db.add = MagicMock(side_effect=lambda obj: captured.append(obj))
+    db.commit = AsyncMock()
+
+    payload = GapEventIn(**_build_gap_payload())
+    request = MagicMock()
+    request.headers = {"x-internal-secret": "test-secret"}
+
+    with (
+        patch("app.api.internal._require_internal_token", AsyncMock()),
+        patch("app.api.internal.set_tenant", AsyncMock()),
+        patch("app.api.internal._audit_internal_call", AsyncMock()),
+        # Avoid the async classification side-effect path
+        patch("app.api.internal.asyncio.create_task"),
+    ):
+        await create_gap_event(payload, request, db)
+
+    assert len(captured) == 1
+    assert captured[0].query_text == "Hoe stel ik vakantie aan?"
+
+
+@pytest.mark.asyncio
+async def test_retrieval_log_skipped_in_off_mode() -> None:
+    """REQ-9: 'off' returns 200 but does not call write_retrieval_log."""
+    from app.api.internal import RetrievalLogIn, post_retrieval_log
+
+    org = _FakeOrg(telemetry_level="off")
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_scalar_result(org))
+
+    payload = RetrievalLogIn(**_build_log_payload())
+    request = MagicMock()
+    request.headers = {"x-internal-secret": "test-secret"}
+
+    with (
+        patch("app.api.internal._require_internal_token", AsyncMock()),
+        patch("app.api.internal._audit_internal_call", AsyncMock()),
+        patch("app.services.retrieval_log.write_retrieval_log", AsyncMock()) as mock_write,
+    ):
+        result = await post_retrieval_log(payload, request, db)
+
+    assert result["ok"] is True
+    assert result.get("skipped") == "telemetry_off"
+    mock_write.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_retrieval_log_redacts_query_resolved_in_shadow_mode() -> None:
+    """REQ-9: 'shadow' calls write_retrieval_log with query_resolved=''."""
+    from app.api.internal import RetrievalLogIn, post_retrieval_log
+
+    org = _FakeOrg(telemetry_level="shadow")
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_scalar_result(org))
+
+    payload = RetrievalLogIn(**_build_log_payload())
+    request = MagicMock()
+    request.headers = {"x-internal-secret": "test-secret"}
+
+    with (
+        patch("app.api.internal._require_internal_token", AsyncMock()),
+        patch("app.api.internal._audit_internal_call", AsyncMock()),
+        patch("app.services.retrieval_log.write_retrieval_log", AsyncMock()) as mock_write,
+    ):
+        await post_retrieval_log(payload, request, db)
+
+    mock_write.assert_awaited_once()
+    kwargs = mock_write.await_args.kwargs
+    assert kwargs["query_resolved"] == ""
+    # Other fields preserved.
+    assert kwargs["chunk_ids"] == ["c1", "c2"]
+    assert kwargs["reranker_scores"] == [0.7, 0.5]
+
+
+@pytest.mark.asyncio
+async def test_retrieval_log_keeps_query_resolved_in_full_mode() -> None:
+    """REQ-9: 'full' calls write_retrieval_log with literal query_resolved."""
+    from app.api.internal import RetrievalLogIn, post_retrieval_log
+
+    org = _FakeOrg(telemetry_level="full")
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_scalar_result(org))
+
+    payload_data = _build_log_payload()
+    payload = RetrievalLogIn(**payload_data)
+    request = MagicMock()
+    request.headers = {"x-internal-secret": "test-secret"}
+
+    with (
+        patch("app.api.internal._require_internal_token", AsyncMock()),
+        patch("app.api.internal._audit_internal_call", AsyncMock()),
+        patch("app.services.retrieval_log.write_retrieval_log", AsyncMock()) as mock_write,
+    ):
+        await post_retrieval_log(payload, request, db)
+
+    mock_write.assert_awaited_once()
+    kwargs = mock_write.await_args.kwargs
+    assert kwargs["query_resolved"] == payload_data["query_resolved"]

--- a/klai-portal/backend/tests/test_orgs_telemetry_level.py
+++ b/klai-portal/backend/tests/test_orgs_telemetry_level.py
@@ -1,0 +1,136 @@
+"""SPEC-PRIVACY-QUERY-SHADOW-001 Unit 9 — tenant self-service endpoint tests.
+
+POST /api/orgs/me/telemetry-level. Mirrors the operator-side endpoint
+contract (REQ-11) but with a different auth path (tenant-admin JWT
+rather than internal-secret) and a hardcoded ``operator_kind='tenant_admin'``
+audit field. Authorization is REQUIRED — non-admin role returns 403.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class _FakeUser:
+    def __init__(self, role: str = "admin") -> None:
+        self.role = role
+        self.zitadel_user_id = "zit-user-1"
+
+
+class _FakeOrg:
+    def __init__(self, level: str = "shadow") -> None:
+        self.id = 42
+        self.telemetry_level = level
+
+
+@pytest.mark.asyncio
+async def test_admin_can_set_telemetry_level() -> None:
+    """REQ-15 happy path: admin flips shadow → full, gets 200 + new level."""
+    from app.api.orgs import TelemetryLevelUpdate, set_my_org_telemetry_level
+
+    org = _FakeOrg(level="shadow")
+    user = _FakeUser(role="admin")
+    creds = MagicMock()
+    db = AsyncMock()
+
+    with (
+        patch(
+            "app.api.orgs._get_caller_org",
+            AsyncMock(return_value=("zit-user-1", org, user)),
+        ),
+        patch(
+            "app.api.orgs.set_telemetry_level",
+            AsyncMock(return_value=("shadow", "full")),
+        ) as mock_set,
+    ):
+        out = await set_my_org_telemetry_level(TelemetryLevelUpdate(level="full"), creds, db)
+
+    assert out.telemetry_level == "full"
+    mock_set.assert_awaited_once()
+    call = mock_set.await_args
+    assert call.kwargs["org_id"] == 42
+    assert call.kwargs["operator_kind"] == "tenant_admin"
+    assert call.kwargs["operator_user_id"] == "zit-user-1"
+    assert call.kwargs["reason"] == "tenant self-service via admin UI"
+
+
+@pytest.mark.asyncio
+async def test_non_admin_user_gets_403() -> None:
+    """REQ-15 negative test: a regular user can't flip the level."""
+    from fastapi import HTTPException
+
+    from app.api.orgs import TelemetryLevelUpdate, set_my_org_telemetry_level
+
+    org = _FakeOrg(level="shadow")
+    user = _FakeUser(role="company")  # non-admin
+    creds = MagicMock()
+    db = AsyncMock()
+
+    with (
+        patch(
+            "app.api.orgs._get_caller_org",
+            AsyncMock(return_value=("zit-user-2", org, user)),
+        ),
+        patch("app.api.orgs.set_telemetry_level", AsyncMock()) as mock_set,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await set_my_org_telemetry_level(TelemetryLevelUpdate(level="full"), creds, db)
+
+    assert exc_info.value.status_code == 403
+    # Service-layer must NOT be called when role check fails.
+    mock_set.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_lookup_error_translates_to_404() -> None:
+    """Defense-in-depth: race condition org-deletion → 404 not 500."""
+    from fastapi import HTTPException
+
+    from app.api.orgs import TelemetryLevelUpdate, set_my_org_telemetry_level
+
+    org = _FakeOrg(level="shadow")
+    user = _FakeUser(role="admin")
+    creds = MagicMock()
+    db = AsyncMock()
+
+    with (
+        patch(
+            "app.api.orgs._get_caller_org",
+            AsyncMock(return_value=("zit-user-1", org, user)),
+        ),
+        patch(
+            "app.api.orgs.set_telemetry_level",
+            AsyncMock(side_effect=LookupError("org_id=42 not found")),
+        ),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await set_my_org_telemetry_level(TelemetryLevelUpdate(level="full"), creds, db)
+
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_admin_can_set_back_to_shadow() -> None:
+    """Idempotent flip back to default works (covers the 'reset' flow)."""
+    from app.api.orgs import TelemetryLevelUpdate, set_my_org_telemetry_level
+
+    org = _FakeOrg(level="full")
+    user = _FakeUser(role="admin")
+    creds = MagicMock()
+    db = AsyncMock()
+
+    with (
+        patch(
+            "app.api.orgs._get_caller_org",
+            AsyncMock(return_value=("zit-user-1", org, user)),
+        ),
+        patch(
+            "app.api.orgs.set_telemetry_level",
+            AsyncMock(return_value=("full", "shadow")),
+        ),
+    ):
+        out = await set_my_org_telemetry_level(TelemetryLevelUpdate(level="shadow"), creds, db)
+
+    assert out.telemetry_level == "shadow"

--- a/klai-portal/backend/tests/test_r5_auto_accept_toggle.py
+++ b/klai-portal/backend/tests/test_r5_auto_accept_toggle.py
@@ -18,6 +18,10 @@ def _make_org(auto_accept: bool = False) -> MagicMock:
     org.mfa_policy = "optional"
     org.auto_accept_same_domain = auto_accept
     org.primary_domain = None
+    # SPEC-PRIVACY-QUERY-SHADOW-001 REQ-15: OrgSettingsOut now also
+    # carries telemetry_level. Pin to the privacy-friendly default for
+    # tests that don't explicitly exercise this field.
+    org.telemetry_level = "shadow"
     return org
 
 

--- a/klai-portal/backend/tests/test_telemetry_level_service.py
+++ b/klai-portal/backend/tests/test_telemetry_level_service.py
@@ -1,0 +1,189 @@
+"""SPEC-PRIVACY-QUERY-SHADOW-001 — service-layer tests for set_telemetry_level.
+
+Pure unit tests with mocked AsyncSession + Redis + audit. The service
+function is the shared core used by both the internal-admin endpoint
+(REQ-11) and the tenant self-service endpoint (REQ-15).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+class _FakeOrg:
+    """Mimics PortalOrg with the fields the service touches."""
+
+    def __init__(self, level: str = "shadow") -> None:
+        self.id = 42
+        self.telemetry_level = level
+
+
+def _scalar_result(value: object) -> MagicMock:
+    """Build a mock that quacks like SQLAlchemy's `Result`."""
+    res = MagicMock()
+    res.scalar_one_or_none.return_value = value
+    return res
+
+
+@pytest.mark.asyncio
+async def test_set_telemetry_level_happy_path(monkeypatch):
+    """shadow → full updates the column, invalidates cache, writes audit."""
+    from app.services.telemetry_level import set_telemetry_level
+
+    org = _FakeOrg(level="shadow")
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_scalar_result(org))
+    db.commit = AsyncMock()
+
+    invalidate_mock = AsyncMock()
+    audit_mock = AsyncMock()
+    monkeypatch.setattr(
+        "app.services.telemetry_level._invalidate_org_kb_cache",
+        invalidate_mock,
+    )
+    monkeypatch.setattr(
+        "app.services.telemetry_level.log_event",
+        audit_mock,
+    )
+
+    old, new = await set_telemetry_level(
+        db,
+        org_id=42,
+        new_level="full",
+        operator_kind="operator",
+        operator_user_id="internal-admin",
+        reason="Investigating ticket #1234",
+    )
+
+    assert old == "shadow"
+    assert new == "full"
+    assert org.telemetry_level == "full"
+    db.commit.assert_awaited_once()
+    invalidate_mock.assert_awaited_once_with(42)
+    audit_mock.assert_awaited_once()
+    audit_call = audit_mock.await_args
+    assert audit_call.kwargs["action"] == "telemetry_level_changed"
+    assert audit_call.kwargs["details"]["old_level"] == "shadow"
+    assert audit_call.kwargs["details"]["new_level"] == "full"
+    assert audit_call.kwargs["details"]["operator_kind"] == "operator"
+    assert audit_call.kwargs["details"]["reason"] == "Investigating ticket #1234"
+
+
+@pytest.mark.asyncio
+async def test_set_telemetry_level_idempotent_noop(monkeypatch):
+    """Setting the same level skips commit but still audits + invalidates."""
+    from app.services.telemetry_level import set_telemetry_level
+
+    org = _FakeOrg(level="shadow")
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_scalar_result(org))
+    db.commit = AsyncMock()
+
+    invalidate_mock = AsyncMock()
+    audit_mock = AsyncMock()
+    monkeypatch.setattr(
+        "app.services.telemetry_level._invalidate_org_kb_cache",
+        invalidate_mock,
+    )
+    monkeypatch.setattr(
+        "app.services.telemetry_level.log_event",
+        audit_mock,
+    )
+
+    old, new = await set_telemetry_level(
+        db,
+        org_id=42,
+        new_level="shadow",
+        operator_kind="tenant_admin",
+        operator_user_id="zitadel-user-1",
+        reason="re-applying same level via UI",
+    )
+
+    assert (old, new) == ("shadow", "shadow")
+    db.commit.assert_not_awaited()  # no-op skip
+    invalidate_mock.assert_awaited_once()  # always invalidates (escape hatch)
+    audit_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_set_telemetry_level_rejects_invalid_level(monkeypatch):
+    """Defensive: invalid level raises ValueError before DB query."""
+    from app.services.telemetry_level import set_telemetry_level
+
+    db = AsyncMock()
+    db.execute = AsyncMock()
+
+    with pytest.raises(ValueError, match="invalid telemetry_level"):
+        await set_telemetry_level(
+            db,
+            org_id=42,
+            new_level="bogus",  # type: ignore[arg-type]
+            operator_kind="operator",
+            operator_user_id="internal-admin",
+            reason="anything",
+        )
+
+    db.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_set_telemetry_level_rejects_empty_reason(monkeypatch):
+    from app.services.telemetry_level import set_telemetry_level
+
+    db = AsyncMock()
+
+    with pytest.raises(ValueError, match="reason must be non-empty"):
+        await set_telemetry_level(
+            db,
+            org_id=42,
+            new_level="full",
+            operator_kind="operator",
+            operator_user_id="op",
+            reason="   ",
+        )
+
+
+@pytest.mark.asyncio
+async def test_set_telemetry_level_rejects_overlong_reason(monkeypatch):
+    from app.services.telemetry_level import set_telemetry_level
+
+    db = AsyncMock()
+
+    with pytest.raises(ValueError, match="500"):
+        await set_telemetry_level(
+            db,
+            org_id=42,
+            new_level="full",
+            operator_kind="operator",
+            operator_user_id="op",
+            reason="x" * 501,
+        )
+
+
+@pytest.mark.asyncio
+async def test_set_telemetry_level_org_not_found(monkeypatch):
+    from app.services.telemetry_level import set_telemetry_level
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_scalar_result(None))
+
+    monkeypatch.setattr(
+        "app.services.telemetry_level._invalidate_org_kb_cache",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        "app.services.telemetry_level.log_event",
+        AsyncMock(),
+    )
+
+    with pytest.raises(LookupError):
+        await set_telemetry_level(
+            db,
+            org_id=999,
+            new_level="full",
+            operator_kind="operator",
+            operator_user_id="op",
+            reason="missing org",
+        )

--- a/klai-portal/backend/tests/test_telemetry_purge.py
+++ b/klai-portal/backend/tests/test_telemetry_purge.py
@@ -1,0 +1,144 @@
+"""SPEC-PRIVACY-QUERY-SHADOW-001 Unit 7 — telemetry-purge loop tests.
+
+Pure unit tests with mocked cross_org_session. Verifies:
+- Both DELETEs run with the cutoff = now - 7d
+- portal_retrieval_gaps DELETE excludes redacted rows
+- A failure on one table does not abort the second
+- The async loop sleeps 60s on startup, then runs every 24h, and
+  exits cleanly on cancellation
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _execute_returning(rowcount: int) -> AsyncMock:
+    """Build a mock for db.execute that returns a result with rowcount set."""
+    result = MagicMock()
+    result.rowcount = rowcount
+    return AsyncMock(return_value=result)
+
+
+@pytest.mark.asyncio
+async def test_purge_once_runs_both_deletes_with_cutoff() -> None:
+    from app.services.telemetry_purge import RETENTION_DAYS, _purge_once
+
+    captured_calls: list[dict] = []
+
+    async def _exec(stmt, params):
+        # Coerce stmt to its string SQL via the .text attribute (sqlalchemy.text)
+        sql = str(stmt)
+        captured_calls.append({"sql": sql, "params": params})
+        result = MagicMock()
+        result.rowcount = 3 if "query_shadow" in sql else 1
+        return result
+
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=_exec)
+    db.commit = AsyncMock()
+
+    @asynccontextmanager
+    async def _fake_session():
+        yield db
+
+    with patch("app.services.telemetry_purge.cross_org_session", _fake_session):
+        counts = await _purge_once()
+
+    assert counts == {"query_shadow": 3, "retrieval_gaps": 1}
+    assert len(captured_calls) == 2
+    # First DELETE targets telemetry.query_shadow
+    assert "telemetry.query_shadow" in captured_calls[0]["sql"]
+    # Second DELETE targets portal_retrieval_gaps and excludes the
+    # redacted sentinel rows.
+    assert "portal_retrieval_gaps" in captured_calls[1]["sql"]
+    assert "[REDACTED:%" in captured_calls[1]["sql"]
+    # Both calls share the same cutoff (within a small clock skew)
+    cutoffs = [call["params"]["cutoff"] for call in captured_calls]
+    expected = datetime.now(UTC) - timedelta(days=RETENTION_DAYS)
+    for cutoff in cutoffs:
+        assert abs((cutoff - expected).total_seconds()) < 5
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_purge_once_continues_when_first_delete_fails() -> None:
+    """REQ-10: a failure on query_shadow must not abort retrieval_gaps."""
+    from app.services.telemetry_purge import _purge_once
+
+    call_n = 0
+
+    async def _exec(stmt, params):
+        nonlocal call_n
+        call_n += 1
+        if call_n == 1:
+            raise RuntimeError("simulated query_shadow failure")
+        result = MagicMock()
+        result.rowcount = 7
+        return result
+
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=_exec)
+    db.commit = AsyncMock()
+
+    @asynccontextmanager
+    async def _fake_session():
+        yield db
+
+    with patch("app.services.telemetry_purge.cross_org_session", _fake_session):
+        counts = await _purge_once()
+
+    # query_shadow failed so the count stayed 0; retrieval_gaps still
+    # ran and counted 7.
+    assert counts == {"query_shadow": 0, "retrieval_gaps": 7}
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_purge_loop_exits_on_cancel(monkeypatch) -> None:
+    """The loop must exit cleanly when cancelled via lifespan shutdown."""
+    from app.services import telemetry_purge as tp
+
+    purge_call_count = 0
+
+    async def _fake_purge_once() -> dict[str, int]:
+        nonlocal purge_call_count
+        purge_call_count += 1
+        return {"query_shadow": 0, "retrieval_gaps": 0}
+
+    monkeypatch.setattr(tp, "_purge_once", _fake_purge_once)
+    # Drop the inter-cycle sleep to ~0 so we run multiple iterations
+    # within the test's awaited window. The 60s startup sleep is also
+    # short-circuited by patching `asyncio.sleep` only inside the
+    # module under test (not the test harness).
+    monkeypatch.setattr(tp, "PURGE_INTERVAL_SECONDS", 0)
+
+    real_sleep = asyncio.sleep
+
+    async def _short_sleep(delay: float) -> None:
+        # Replace startup 60s + interval seconds with a 0-delay yield;
+        # other delay values use the real sleep so the test event loop
+        # still yields properly.
+        if delay >= 1:
+            await real_sleep(0)
+        else:
+            await real_sleep(delay)
+
+    monkeypatch.setattr("app.services.telemetry_purge.asyncio.sleep", _short_sleep)
+
+    task = asyncio.create_task(tp.telemetry_purge_loop())
+    # Run the loop long enough for at least one iteration to land.
+    for _ in range(20):
+        await asyncio.sleep(0)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    assert purge_call_count >= 1

--- a/klai-portal/frontend/messages/en.json
+++ b/klai-portal/frontend/messages/en.json
@@ -1656,5 +1656,17 @@
   "integrations_revoke": "Disconnect",
   "integrations_confirm_revoke": "Yes, disconnect",
   "integrations_revoking": "Working...",
-  "integrations_cancel": "Cancel"
+  "integrations_cancel": "Cancel",
+  "admin_settings_telemetry_title": "Privacy & telemetry",
+  "admin_settings_telemetry_description": "Choose what Klai records about the queries your users submit. The default ('Shadow') is the privacy-friendly option and is recommended for every tenant except during active debugging.",
+  "admin_settings_telemetry_label": "Telemetry level",
+  "admin_settings_telemetry_current": "Current setting: {level}",
+  "admin_settings_telemetry_off_name": "Off",
+  "admin_settings_telemetry_off_hint": "Klai stores nothing at all about your users' queries. We cannot do quality monitoring and cannot help during incidents. Recommended only when you need strict data minimisation. Thumbs-up / thumbs-down feedback keeps working — that lives on different data.",
+  "admin_settings_telemetry_shadow_name": "Shadow (default)",
+  "admin_settings_telemetry_shadow_hint": "Klai stores an anonymised fingerprint (numerical vector + length/language statistics) of each query, for 7 days. Literal text is never retained. Enough for quality monitoring and recurring-issue detection; not enough to see what any one user asked. This is the default setting.",
+  "admin_settings_telemetry_full_name": "Full",
+  "admin_settings_telemetry_full_hint": "Klai stores the literal user queries in operational logs for 7 days. Only enable when you or Klai are actively investigating a specific issue. Don't forget to switch back to Shadow — after 14 days there will be a reminder.",
+  "admin_settings_telemetry_disabled_for_non_admin": "Only organisation admins can change this setting.",
+  "admin_settings_telemetry_privacy_link": "Read more about the privacy modes in our privacy policy"
 }

--- a/klai-portal/frontend/messages/nl.json
+++ b/klai-portal/frontend/messages/nl.json
@@ -1656,5 +1656,17 @@
   "integrations_revoke": "Loskoppelen",
   "integrations_confirm_revoke": "Ja, loskoppelen",
   "integrations_revoking": "Bezig...",
-  "integrations_cancel": "Annuleren"
+  "integrations_cancel": "Annuleren",
+  "admin_settings_telemetry_title": "Privacy & telemetrie",
+  "admin_settings_telemetry_description": "Bepaal welke gegevens Klai opslaat over de queries die uw gebruikers stellen. De standaard ('Schaduw') is de privacy-vriendelijke optie en is aanbevolen voor alle tenants behalve bij actief debugwerk.",
+  "admin_settings_telemetry_label": "Telemetrie-niveau",
+  "admin_settings_telemetry_current": "Huidige instelling: {level}",
+  "admin_settings_telemetry_off_name": "Uit",
+  "admin_settings_telemetry_off_hint": "Klai slaat helemaal niets op over de queries die uw gebruikers stellen. We kunnen geen kwaliteitsbewaking doen en bij incidenten geen ondersteuning verlenen. Alleen aanbevolen als u strikte data-minimalisatie nodig heeft. Vinkjes/duimen omhoog blijven werken — die zitten op andere data.",
+  "admin_settings_telemetry_shadow_name": "Schaduw (standaard)",
+  "admin_settings_telemetry_shadow_hint": "Klai slaat een geanonimiseerde vingerafdruk op (numerieke vector + lengte/taal-statistieken) van elke vraag, voor 7 dagen. Letterlijke tekst wordt nooit bewaard. Genoeg om kwaliteit te bewaken en terugkerende problemen te detecteren; niet genoeg om te zien wat één gebruiker exact vroeg. Dit is de standaardinstelling.",
+  "admin_settings_telemetry_full_name": "Volledig",
+  "admin_settings_telemetry_full_hint": "Klai slaat letterlijke vragen op in operationele logs voor 7 dagen. Alleen aanzetten als u of Klai actief een specifiek probleem onderzoekt. Vergeet niet terug te zetten naar Schaduw — er komt na 14 dagen een herinnering.",
+  "admin_settings_telemetry_disabled_for_non_admin": "Alleen organisatie-beheerders kunnen deze instelling wijzigen.",
+  "admin_settings_telemetry_privacy_link": "Lees meer over de privacy-modi in ons privacybeleid"
 }

--- a/klai-portal/frontend/src/routes/admin/settings.tsx
+++ b/klai-portal/frontend/src/routes/admin/settings.tsx
@@ -15,12 +15,15 @@ export const Route = createFileRoute('/admin/settings')({
   component: AdminSettingsPage,
 })
 
+type TelemetryLevel = 'off' | 'shadow' | 'full'
+
 type OrgSettings = {
   name: string
   default_language: 'nl' | 'en'
   mfa_policy: 'optional' | 'recommended' | 'required'
   auto_accept_same_domain: boolean
   primary_domain: string | null
+  telemetry_level: TelemetryLevel
 }
 
 function AdminSettingsPage() {
@@ -70,6 +73,37 @@ function AdminSettingsPage() {
       setSelectedMfa(settings.mfa_policy ?? 'optional')
     }
   }, [settings])
+
+  // SPEC-PRIVACY-QUERY-SHADOW-001 REQ-15: tenant self-service telemetry-level.
+  // Posts to a dedicated tenant-scoped endpoint (different surface from the
+  // operator-side /internal/admin/orgs/{org}/telemetry-level). The backend
+  // shares the service-layer between both endpoints.
+  const [selectedTelemetry, setSelectedTelemetry] = useState<TelemetryLevel>('shadow')
+  const [savedTelemetry, setSavedTelemetry] = useState(false)
+
+  useEffect(() => {
+    if (settings?.telemetry_level) {
+      setSelectedTelemetry(settings.telemetry_level)
+    }
+  }, [settings?.telemetry_level])
+
+  const telemetryMutation = useMutation({
+    mutationFn: async (level: TelemetryLevel) =>
+      apiFetch<{ telemetry_level: TelemetryLevel }>(`/api/orgs/me/telemetry-level`, {
+        method: 'POST',
+        body: JSON.stringify({ level }),
+      }),
+    onSuccess: (data) => {
+      adminLogger.info('Telemetry level changed', { telemetry_level: data.telemetry_level })
+      // Mirror the saved state into the existing /api/admin/settings cache
+      // so the read-only "Current setting" line updates without a refetch.
+      queryClient.setQueryData(['admin-settings'], (prev: OrgSettings | undefined) =>
+        prev ? { ...prev, telemetry_level: data.telemetry_level } : prev,
+      )
+      setSavedTelemetry(true)
+      setTimeout(() => setSavedTelemetry(false), 2500)
+    },
+  })
 
   // SPEC-PORTAL-PROFILES-001 P3.6: Add-on toggles.
   // UX pattern: ticking a checkbox stages the change; user clicks Save to commit.
@@ -290,6 +324,77 @@ function AdminSettingsPage() {
           <p className="text-sm text-[var(--color-muted-foreground)]">{m.admin_settings_placeholder()}</p>
         </CardContent>
       </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>{m.admin_settings_telemetry_title()}</CardTitle>
+          <CardDescription>
+            {m.admin_settings_telemetry_description()}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {isLoading ? (
+            <p className="text-sm text-[var(--color-muted-foreground)]">{m.admin_users_loading()}</p>
+          ) : error ? (
+            <p className="text-sm text-[var(--color-destructive)]">{m.admin_settings_error_fetch()}</p>
+          ) : (
+            <>
+              <p className="text-sm text-[var(--color-muted-foreground)]">
+                {m.admin_settings_telemetry_current({
+                  level:
+                    settings?.telemetry_level === 'off'
+                      ? m.admin_settings_telemetry_off_name()
+                      : settings?.telemetry_level === 'full'
+                        ? m.admin_settings_telemetry_full_name()
+                        : m.admin_settings_telemetry_shadow_name(),
+                })}
+              </p>
+              <div className="space-y-1.5">
+                <Label htmlFor="settings-telemetry-level">
+                  {m.admin_settings_telemetry_label()}
+                </Label>
+                <Select
+                  id="settings-telemetry-level"
+                  value={selectedTelemetry}
+                  onChange={(e) => setSelectedTelemetry(e.target.value as TelemetryLevel)}
+                  className="max-w-xs"
+                >
+                  <option value="off">{m.admin_settings_telemetry_off_name()}</option>
+                  <option value="shadow">{m.admin_settings_telemetry_shadow_name()}</option>
+                  <option value="full">{m.admin_settings_telemetry_full_name()}</option>
+                </Select>
+                <p className="text-xs text-[var(--color-muted-foreground)]">
+                  {selectedTelemetry === 'off' && m.admin_settings_telemetry_off_hint()}
+                  {selectedTelemetry === 'shadow' && m.admin_settings_telemetry_shadow_hint()}
+                  {selectedTelemetry === 'full' && m.admin_settings_telemetry_full_hint()}
+                </p>
+              </div>
+              {telemetryMutation.error && (
+                <p className="text-sm text-[var(--color-destructive)]">{m.admin_settings_error_save()}</p>
+              )}
+              <Button
+                onClick={() => telemetryMutation.mutate(selectedTelemetry)}
+                disabled={
+                  telemetryMutation.isPending ||
+                  savedTelemetry ||
+                  selectedTelemetry === settings?.telemetry_level
+                }
+              >
+                {savedTelemetry
+                  ? m.admin_settings_saved()
+                  : telemetryMutation.isPending
+                    ? m.admin_settings_saving()
+                    : m.admin_settings_save()}
+              </Button>
+              <p className="text-xs text-[var(--color-muted-foreground)]">
+                <a href="/privacy" className="underline">
+                  {m.admin_settings_telemetry_privacy_link()}
+                </a>
+              </p>
+            </>
+          )}
+        </CardContent>
+      </Card>
+
       <Card>
         <CardHeader>
           <CardTitle>{m.admin_settings_addons_title()}</CardTitle>

--- a/klai-retrieval-api/retrieval_api/api/retrieve.py
+++ b/klai-retrieval-api/retrieval_api/api/retrieve.py
@@ -19,6 +19,7 @@ from retrieval_api.metrics import (
     retrieval_link_expand_top_k_total,
     retrieval_requests_total,
     step_latency_seconds,
+    telemetry_level_decisions_total,
 )
 from retrieval_api.middleware.auth import AuthContext, require_scope, verify_body_identity
 from retrieval_api.models import (
@@ -33,8 +34,10 @@ from retrieval_api.quality_floor import filter_quality_floor
 from retrieval_api.services import coreference, evidence_tier, gate, graph_search, reranker, search
 from retrieval_api.services.diversity import source_aware_select
 from retrieval_api.services.events import emit_event
+from retrieval_api.services.features import extract_features
 from retrieval_api.services.router import fetch_source_catalog, route_to_sources
 from retrieval_api.services.tei import embed_single, embed_sparse
+from retrieval_api.services.telemetry import write_shadow
 from retrieval_api.util.payload import payload_list
 
 logger = structlog.get_logger(__name__)
@@ -532,15 +535,59 @@ async def retrieve(
         retrieval_link_expand_top_k_total.labels(outcome=outcome, org_id=req.org_id).inc()
 
     decision_record["total_ms"] = round(retrieval_ms, 1)
+
+    # SPEC-PRIVACY-QUERY-SHADOW-001 REQ-5: gate raw-query content on
+    # decision_record. In off + shadow mode, strip the coreference
+    # rewrite text before serialization. The defense-in-depth structlog
+    # processor (REQ-13) catches the same fields if they slip through
+    # via a future code path that bypasses this check, but doing it
+    # here keeps the metric-level gating accurate.
+    if req.telemetry_level != "full" and "coreference_rewrite" in decision_record:
+        decision_record.pop("coreference_rewrite", None)
+        telemetry_level_decisions_total.labels(
+            level=req.telemetry_level, decision="metadata_only"
+        ).inc()
+    elif req.telemetry_level == "full":
+        telemetry_level_decisions_total.labels(level="full", decision="content_emitted").inc()
+
     try:
         logger.info(
             "retrieval_decision_record",
             org_id=req.org_id,
             scope=req.scope,
+            telemetry_level=req.telemetry_level,
             **decision_record,
         )
     except Exception:
         logger.exception("decision_record_emit_failed")
+
+    # SPEC-PRIVACY-QUERY-SHADOW-001 REQ-7: shadow-store INSERT for shadow
+    # + full modes. Fire-and-forget — failures are counted in
+    # telemetry_shadow_drop_total, not propagated. ``request_id`` is
+    # bound by RequestContextMiddleware (logging_setup.py); read back
+    # from structlog contextvars so we don't have to plumb it through
+    # the entire pipeline.
+    if req.telemetry_level in ("shadow", "full"):
+        ctx_request_id = structlog.contextvars.get_contextvars().get("request_id")
+        if ctx_request_id:
+            chunk_ids_for_shadow = [c.chunk_id for c in chunks_out]
+            reranker_scores = [c.reranker_score for c in chunks_out if c.reranker_score is not None]
+            reranker_top1 = max(reranker_scores) if reranker_scores else None
+            features_dict = extract_features(req.query)
+            write_shadow(
+                request_id=ctx_request_id,
+                org_id=req.org_id,
+                embedding=list(query_vector) if query_vector is not None else None,
+                features=features_dict,
+                band=confidence_band,
+                chunk_ids=chunk_ids_for_shadow,
+                reranker_top1=reranker_top1,
+            )
+            telemetry_level_decisions_total.labels(
+                level=req.telemetry_level, decision="shadow_inserted"
+            ).inc()
+        if req.telemetry_level == "full":
+            telemetry_level_decisions_total.labels(level="full", decision="full_logged").inc()
 
     logger.info(
         "retrieve",

--- a/klai-retrieval-api/retrieval_api/api/retrieve.py
+++ b/klai-retrieval-api/retrieval_api/api/retrieve.py
@@ -542,13 +542,23 @@ async def retrieve(
     # processor (REQ-13) catches the same fields if they slip through
     # via a future code path that bypasses this check, but doing it
     # here keeps the metric-level gating accurate.
+    #
+    # REQ-10: retention_class is a structured label so Alloy can route
+    # 'content' events to a 7d-retention stream and 'metadata' events
+    # to the existing 30d stream (operator-side VictoriaLogs config —
+    # follow-up runbook in Unit 8).
     if req.telemetry_level != "full" and "coreference_rewrite" in decision_record:
         decision_record.pop("coreference_rewrite", None)
+        decision_record["retention_class"] = "metadata"
         telemetry_level_decisions_total.labels(
             level=req.telemetry_level, decision="metadata_only"
         ).inc()
     elif req.telemetry_level == "full":
+        decision_record["retention_class"] = "content"
         telemetry_level_decisions_total.labels(level="full", decision="content_emitted").inc()
+    else:
+        # off mode without coreference_rewrite already in the record.
+        decision_record["retention_class"] = "metadata"
 
     try:
         logger.info(

--- a/klai-retrieval-api/retrieval_api/metrics.py
+++ b/klai-retrieval-api/retrieval_api/metrics.py
@@ -112,3 +112,32 @@ retrieval_link_expand_top_k_total = Counter(
     "Link-expand contribution to served top-K (hit/miss per tenant)",
     ["outcome", "org_id"],
 )
+
+# SPEC-PRIVACY-QUERY-SHADOW-001 REQ-14 — privacy-layer observability.
+# Counts every gating decision so operators can verify the telemetry
+# layer is behaving correctly across the four decision-types:
+#   metadata_only   — content fields stripped from decision_record
+#   content_emitted — full decision_record (full mode)
+#   shadow_inserted — row written to telemetry.query_shadow
+#   full_logged     — raw query persisted in logs / DB
+telemetry_level_decisions_total = Counter(
+    "telemetry_level_decisions_total",
+    "Privacy-layer gating decisions per tenant level",
+    ["level", "decision"],
+)
+
+# Tracks shadow-store INSERT failures. ``reason`` distinguishes
+# fail-modes (no_pool, db_error, timeout, etc.) for triage.
+telemetry_shadow_drop_total = Counter(
+    "telemetry_shadow_drop_total",
+    "Shadow-store INSERT failures, bucketed by reason",
+    ["reason"],
+)
+
+# Number of rows redacted by the one-time legacy cleanup migration
+# (REQ-12). Incremented at module load by a probe query so dashboards
+# can show "this many legacy rows were closed out on first deploy".
+telemetry_legacy_redaction_total = Counter(
+    "telemetry_legacy_redaction_total",
+    "Legacy rows redacted by the one-time privacy cleanup migration",
+)

--- a/klai-retrieval-api/retrieval_api/models.py
+++ b/klai-retrieval-api/retrieval_api/models.py
@@ -24,6 +24,11 @@ class RetrieveRequest(BaseModel):
     taxonomy_node_ids: list[int] | None = Field(None, max_length=50)
     # SPEC-SEC-010 REQ-2.3 (tags parity): tags list length bounded to 20 entries.
     tags: list[str] | None = Field(None, max_length=20)
+    # SPEC-PRIVACY-QUERY-SHADOW-001 REQ-3: per-tenant telemetry mode threaded
+    # from litellm-hook / knowledge-mcp. Default 'shadow' so older clients
+    # without the field continue to work in the privacy-friendly mode (REQ-4
+    # fail-open). Validation: gates content emission in REQ-5/6/7/8/9.
+    telemetry_level: Literal["off", "shadow", "full"] = "shadow"
 
     @field_validator("conversation_history")
     @classmethod

--- a/klai-retrieval-api/retrieval_api/services/features.py
+++ b/klai-retrieval-api/retrieval_api/services/features.py
@@ -1,0 +1,123 @@
+"""SPEC-PRIVACY-QUERY-SHADOW-001 — symbolic-feature extraction for shadow store.
+
+Produces a small jsonb-friendly dict from the user's query that captures
+shape and intent without revealing literal text. Stored alongside the
+1024-dim BGE-M3 embedding in telemetry.query_shadow (REQ-7).
+
+The features set was scoped deliberately small to keep the privacy-leak
+surface minimal:
+
+- ``tokens`` — int, character-based token count (cheap, language-agnostic)
+- ``lang`` — one of {"nl", "en", "other"}, very simple stoplist heuristic
+- ``has_brand`` — bool, whether any common Klai-tenant brand-keyword appeared
+- ``brand_count`` — int, how many brand-keywords matched
+- ``question_word`` — bool, query starts with a Dutch/English question word
+- ``has_url`` — bool, query contains an http(s):// URL
+- ``has_email_pattern`` — bool, query contains an email-shaped substring
+
+We purposely DO NOT extract topic vectors, NER spans, or any feature
+that would make the shadow row uniquely traceable to a user.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Final
+
+# Brand-keyword list is intentionally conservative — false positives are
+# better than false negatives because the field only signals "the query
+# mentions a brand", not which one. Future tenants extend via a
+# settings-side list; keeping it as a hardcoded constant is fine for v1.
+_BRAND_KEYWORDS: Final[frozenset[str]] = frozenset(
+    {
+        "klai",
+        "voys",
+        "salesforce",
+        "hubspot",
+        "notion",
+        "github",
+        "google",
+        "microsoft",
+        "outlook",
+        "gmail",
+        "slack",
+        "teams",
+        "zoom",
+        "stripe",
+        "moneybird",
+    }
+)
+
+# Lowercased question words — Dutch primary (Klai's default tenant
+# language) plus English fallback. The list is intentionally short:
+# we want the feature to fire on canonical interrogatives only.
+_QUESTION_WORDS_NL: Final[frozenset[str]] = frozenset(
+    {"hoe", "wat", "waarom", "wanneer", "waar", "wie", "welke", "kan", "is", "kunnen"}
+)
+_QUESTION_WORDS_EN: Final[frozenset[str]] = frozenset(
+    {"how", "what", "why", "when", "where", "who", "which", "can", "is", "could", "do", "does"}
+)
+_QUESTION_WORDS: Final[frozenset[str]] = _QUESTION_WORDS_NL | _QUESTION_WORDS_EN
+
+# Tiny stoplists for cheap language detection. Not robust for short
+# queries, but accurate enough for the "lang" tag's intent (rough
+# segmentation of Dutch vs English support traffic in dashboards).
+_STOPS_NL: Final[frozenset[str]] = frozenset(
+    {"de", "het", "een", "en", "van", "in", "op", "is", "ik", "je", "we", "voor", "naar"}
+)
+_STOPS_EN: Final[frozenset[str]] = frozenset(
+    {"the", "a", "an", "and", "of", "in", "on", "is", "i", "we", "for", "to", "you"}
+)
+
+_URL_RE: Final[re.Pattern[str]] = re.compile(r"https?://", re.IGNORECASE)
+_EMAIL_RE: Final[re.Pattern[str]] = re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+", re.UNICODE)
+_TOKEN_RE: Final[re.Pattern[str]] = re.compile(r"\b\w+\b", re.UNICODE)
+
+
+def _detect_lang(tokens_lower: list[str]) -> str:
+    """Heuristic: count stopword overlap; majority wins, default 'other'."""
+    if not tokens_lower:
+        return "other"
+    nl_hits = sum(1 for t in tokens_lower if t in _STOPS_NL)
+    en_hits = sum(1 for t in tokens_lower if t in _STOPS_EN)
+    if nl_hits == 0 and en_hits == 0:
+        return "other"
+    return "nl" if nl_hits >= en_hits else "en"
+
+
+def extract_features(query: str) -> dict:
+    """Build the symbolic-feature dict for a shadow_store row.
+
+    Always returns a dict with all keys present (even if values are 0/False)
+    so downstream cluster queries can rely on a stable schema.
+
+    Empty or whitespace-only queries return a sentinel-shaped dict with
+    everything zeroed; the row is still inserted so the per-org count
+    reflects all retrieve calls.
+    """
+    if not query:
+        return {
+            "tokens": 0,
+            "lang": "other",
+            "has_brand": False,
+            "brand_count": 0,
+            "question_word": False,
+            "has_url": False,
+            "has_email_pattern": False,
+        }
+
+    raw_tokens = _TOKEN_RE.findall(query)
+    tokens_lower = [t.lower() for t in raw_tokens]
+
+    brand_hits = [t for t in tokens_lower if t in _BRAND_KEYWORDS]
+    first_word = tokens_lower[0] if tokens_lower else ""
+
+    return {
+        "tokens": len(raw_tokens),
+        "lang": _detect_lang(tokens_lower),
+        "has_brand": len(brand_hits) > 0,
+        "brand_count": len(brand_hits),
+        "question_word": first_word in _QUESTION_WORDS,
+        "has_url": _URL_RE.search(query) is not None,
+        "has_email_pattern": _EMAIL_RE.search(query) is not None,
+    }

--- a/klai-retrieval-api/retrieval_api/services/telemetry.py
+++ b/klai-retrieval-api/retrieval_api/services/telemetry.py
@@ -1,0 +1,116 @@
+"""SPEC-PRIVACY-QUERY-SHADOW-001 — fire-and-forget writer for telemetry.query_shadow.
+
+Inserts the embedding + symbolic features for a /retrieve call into the
+``telemetry.query_shadow`` table created by the post-deploy SQL of
+migration g5h6i7j8k9l0. Writes are non-blocking — the response path
+schedules `write_shadow` via `asyncio.create_task` and proceeds without
+awaiting; failures are logged + counted but never surface to the user.
+
+The writer reuses the existing portal-events asyncpg pool (`get_pool()`)
+because retrieval-api already connects to the same Postgres database as
+the `klai` superuser for `product_events` writes (REQ-7).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import structlog
+
+from retrieval_api.metrics import telemetry_shadow_drop_total
+from retrieval_api.services.events import get_pool
+
+logger = structlog.get_logger()
+
+_INSERT_SQL = """
+    INSERT INTO telemetry.query_shadow
+        (request_id, org_id, embedding, features, band, chunk_ids, reranker_top1)
+    VALUES ($1, $2, $3::vector, $4::jsonb, $5, $6, $7)
+    ON CONFLICT (request_id) DO NOTHING
+"""
+
+
+def _format_vector(values: list[float] | None) -> str | None:
+    """Encode a Python list as the pgvector literal '[v1,v2,...]'.
+
+    pgvector accepts either binary or text input; we use text so the
+    asyncpg driver doesn't need a custom codec. Returns None for
+    a missing embedding (still allowed by the schema's nullable column).
+    """
+    if values is None:
+        return None
+    # Use repr-friendly fast path; pgvector parses scientific notation.
+    return "[" + ",".join(format(v, ".7g") for v in values) + "]"
+
+
+async def _do_insert(
+    *,
+    request_id: str,
+    org_id: str,
+    embedding: list[float] | None,
+    features: dict,
+    band: str | None,
+    chunk_ids: list[str],
+    reranker_top1: float | None,
+) -> None:
+    pool = get_pool()
+    if pool is None:
+        # pool not yet initialized — happens in tests + early-startup.
+        # Counted as drop so the metric stays honest about coverage.
+        telemetry_shadow_drop_total.labels(reason="no_pool").inc()
+        return
+    try:
+        await pool.execute(
+            _INSERT_SQL,
+            request_id,
+            org_id,
+            _format_vector(embedding),
+            json.dumps(features),
+            band,
+            chunk_ids,
+            reranker_top1,
+        )
+    except Exception:
+        telemetry_shadow_drop_total.labels(reason="db_error").inc()
+        logger.warning(
+            "telemetry_shadow_insert_failed",
+            request_id=request_id,
+            org_id=org_id,
+            exc_info=True,
+        )
+
+
+def write_shadow(
+    *,
+    request_id: str,
+    org_id: str,
+    embedding: list[float] | None,
+    features: dict,
+    band: str | None,
+    chunk_ids: list[str],
+    reranker_top1: float | None,
+) -> None:
+    """Schedule a non-blocking shadow-store INSERT.
+
+    Returns immediately. The actual asyncpg execute runs in a background
+    asyncio task; failures bump the drop counter and emit a warning but
+    never propagate to the response path (REQ-7 fail-and-forget contract).
+    """
+    try:
+        asyncio.create_task(  # noqa: RUF006 — drops are tracked via metric instead
+            _do_insert(
+                request_id=request_id,
+                org_id=org_id,
+                embedding=embedding,
+                features=features,
+                band=band,
+                chunk_ids=chunk_ids,
+                reranker_top1=reranker_top1,
+            )
+        )
+    except RuntimeError:
+        # No running loop — should not happen in production (every code
+        # path lives inside a request handler) but defensive for tests.
+        telemetry_shadow_drop_total.labels(reason="no_loop").inc()
+        logger.warning("telemetry_shadow_no_running_loop", request_id=request_id)

--- a/klai-retrieval-api/tests/test_telemetry_features.py
+++ b/klai-retrieval-api/tests/test_telemetry_features.py
@@ -1,0 +1,70 @@
+"""SPEC-PRIVACY-QUERY-SHADOW-001 Unit 3 — features extraction unit tests.
+
+Pure unit tests for the symbolic-feature extractor. No DB / network / pool.
+"""
+
+from __future__ import annotations
+
+from retrieval_api.services.features import extract_features
+
+
+def test_extract_features_empty_query_returns_zeroed_dict() -> None:
+    feats = extract_features("")
+    assert feats["tokens"] == 0
+    assert feats["lang"] == "other"
+    assert feats["has_brand"] is False
+    assert feats["brand_count"] == 0
+    assert feats["question_word"] is False
+    assert feats["has_url"] is False
+    assert feats["has_email_pattern"] is False
+
+
+def test_extract_features_dutch_question() -> None:
+    feats = extract_features("Hoe stel ik vakantie aan in het systeem?")
+    assert feats["tokens"] >= 6
+    assert feats["lang"] == "nl"
+    assert feats["question_word"] is True
+    assert feats["has_brand"] is False
+    assert feats["brand_count"] == 0
+
+
+def test_extract_features_english_question() -> None:
+    feats = extract_features("How do I configure the connector?")
+    assert feats["lang"] == "en"
+    assert feats["question_word"] is True
+
+
+def test_extract_features_brand_count_multiple() -> None:
+    feats = extract_features("How do I sync Salesforce with Notion?")
+    assert feats["has_brand"] is True
+    assert feats["brand_count"] == 2
+
+
+def test_extract_features_url_detected() -> None:
+    feats = extract_features("see https://example.com/docs for details")
+    assert feats["has_url"] is True
+
+
+def test_extract_features_email_pattern_detected() -> None:
+    feats = extract_features("contact info@klai.io for help")
+    assert feats["has_email_pattern"] is True
+    # The email also matches the brand 'klai' once tokenized — that's fine
+    # because the feature is "did a brand appear", not "exactly one brand".
+    assert feats["has_brand"] is True
+
+
+def test_extract_features_does_not_leak_raw_text() -> None:
+    """Defense-in-depth: features dict MUST NOT contain a 'query' or
+    similar text-shaped value that could leak the original query."""
+    secret = "S3CR3T-CUSTOMER-DATA-AND-SOCIAL-SECURITY"
+    feats = extract_features(f"What about {secret}?")
+    serialized = repr(feats)
+    assert secret not in serialized
+    # Sanity: the features dict only carries primitive bool/int/str-tags.
+    for key, value in feats.items():
+        assert isinstance(value, (bool, int, str)), f"unexpected type for {key}: {type(value)}"
+
+
+def test_extract_features_other_language() -> None:
+    feats = extract_features("Bonjour le monde")
+    assert feats["lang"] == "other"

--- a/klai-retrieval-api/tests/test_telemetry_writer.py
+++ b/klai-retrieval-api/tests/test_telemetry_writer.py
@@ -1,0 +1,101 @@
+"""SPEC-PRIVACY-QUERY-SHADOW-001 Unit 3 — shadow-store writer behaviour.
+
+Verifies the fire-and-forget contract: drops are counted, missing pool is
+handled gracefully, and a successful write delegates to asyncpg.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_write_shadow_drops_when_no_pool(monkeypatch):
+    from retrieval_api.metrics import telemetry_shadow_drop_total
+    from retrieval_api.services import telemetry as tlm
+
+    monkeypatch.setattr("retrieval_api.services.telemetry.get_pool", lambda: None)
+
+    before = telemetry_shadow_drop_total.labels(reason="no_pool")._value.get()  # type: ignore[attr-defined]
+    tlm.write_shadow(
+        request_id="req-1",
+        org_id="org-1",
+        embedding=[0.1, 0.2, 0.3],
+        features={"tokens": 5, "lang": "nl"},
+        band="medium",
+        chunk_ids=["c1", "c2"],
+        reranker_top1=0.7,
+    )
+    # Yield control so the scheduled task runs.
+    await asyncio.sleep(0)
+    after = telemetry_shadow_drop_total.labels(reason="no_pool")._value.get()  # type: ignore[attr-defined]
+    assert after >= before + 1
+
+
+@pytest.mark.asyncio
+async def test_write_shadow_calls_pool_execute_on_success(monkeypatch):
+    from retrieval_api.services import telemetry as tlm
+
+    fake_pool = AsyncMock()
+    fake_pool.execute = AsyncMock(return_value=None)
+    monkeypatch.setattr("retrieval_api.services.telemetry.get_pool", lambda: fake_pool)
+
+    tlm.write_shadow(
+        request_id="req-2",
+        org_id="org-2",
+        embedding=[1.0] * 4,
+        features={"tokens": 7, "lang": "en"},
+        band="high",
+        chunk_ids=["c1"],
+        reranker_top1=0.9,
+    )
+    # Let the scheduled task run.
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    fake_pool.execute.assert_awaited_once()
+    call_args = fake_pool.execute.await_args.args
+    assert "INSERT INTO telemetry.query_shadow" in call_args[0]
+    # Args: SQL, request_id, org_id, vector_text, features_json, band, chunk_ids, reranker_top1
+    assert call_args[1] == "req-2"
+    assert call_args[2] == "org-2"
+    assert call_args[3].startswith("[")  # pgvector text literal
+    # features json
+    assert "tokens" in call_args[4]
+
+
+@pytest.mark.asyncio
+async def test_write_shadow_db_error_counts_drop(monkeypatch):
+    from retrieval_api.metrics import telemetry_shadow_drop_total
+    from retrieval_api.services import telemetry as tlm
+
+    fake_pool = AsyncMock()
+    fake_pool.execute = AsyncMock(side_effect=RuntimeError("connection refused"))
+    monkeypatch.setattr("retrieval_api.services.telemetry.get_pool", lambda: fake_pool)
+
+    before = telemetry_shadow_drop_total.labels(reason="db_error")._value.get()  # type: ignore[attr-defined]
+    tlm.write_shadow(
+        request_id="req-3",
+        org_id="org-3",
+        embedding=[0.5, 0.5],
+        features={"tokens": 3},
+        band="low",
+        chunk_ids=[],
+        reranker_top1=None,
+    )
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    after = telemetry_shadow_drop_total.labels(reason="db_error")._value.get()  # type: ignore[attr-defined]
+    assert after >= before + 1
+
+
+def test_format_vector_handles_none_and_list() -> None:
+    from retrieval_api.services.telemetry import _format_vector
+
+    assert _format_vector(None) is None
+    assert _format_vector([0.1, 0.2]) == "[0.1,0.2]"
+    # Verify the format string strips trailing zeros (more compact wire size).
+    assert _format_vector([1.0, 2.5e-3]) == "[1,0.0025]"


### PR DESCRIPTION
## Summary

Replaces always-on raw-query persistence with a three-mode per-tenant telemetry config (`off` / `shadow` / `full`), default `shadow`. Closes the GDPR Article 5(1)(c) gap from PR #517's pipeline audit (research.md §1).

- `off` — no telemetry; tenant accepts losing operational visibility
- `shadow` (default) — embedding + symbolic features in `telemetry.query_shadow` (7d TTL); raw query never persisted
- `full` — opt-in, audit-trailed, raw query in logs + DB tables, all 7d TTL

Tenants flip their own mode via `https://<tenant>.getklai.com/admin/settings`; operators have an `/internal/admin/orgs/{id}/telemetry-level` endpoint with required reason.

Spec: `.moai/specs/SPEC-PRIVACY-QUERY-SHADOW-001/spec.md` (15 EARS REQs, 11 ACs).

## Implementation — 9 units, sequential commits

| Unit | Files | Tests |
|---|---|---|
| 1 — Migration + post-deploy SQL | alembic/versions/g5h6i7j8k9l0_*.py + post_deploy_g5h6i7j8k9l0.sql | n/a (smoke on deploy) |
| 2 — Portal-api telemetry-level config | models/portal.py, api/internal.py, services/telemetry_level.py | 6 |
| 3 — Retrieval-api gating + shadow writer | retrieve.py, models.py, metrics.py, services/{features,telemetry}.py | 12 |
| 4 — Anti-leakage structlog processor | klai-libs/log-utils/structlog_setup.py | 7 |
| 5 — LiteLLM hook + MCP forwarding | deploy/litellm/klai_knowledge.py, klai-knowledge-mcp/main.py | 5 |
| 6 — Gap-events + retrieval-log gating | api/internal.py | 6 |
| 7 — TTL purge loop + Alloy label | services/telemetry_purge.py, deploy/alloy/config.alloy | 3 |
| 8 — Observability + docs | klai-privacy.json + privacy-rules.yaml + 3 docs | n/a (config) |
| 9 — Tenant self-service dropdown | api/orgs.py + admin/settings.tsx + i18n | 4 + tsc clean |

Total **43 new tests** plus the existing 139 hook + 24 MCP + 32 log-utils + 7 r5-toggle suites all green.

## SPEC-vs-prod findings (documented for reviewer)

- `knowledge.retrieval_logs` does NOT exist as a Postgres table on prod — the retrieval-log is Redis-backed (1h TTL JSON blob, see `app/services/retrieval_log.py`). REQ-9 reinterpreted accordingly: gates the `query_resolved` field within the Redis blob. Same privacy contract; different surface.
- Plan referenced `deploy/postgres/migrations/NNN_*.sql` (knowledge-ingest pattern) but `portal_orgs` lives in portal-api Alembic. Migration ships as alembic + post-deploy SQL pair.
- Plan column was `created_at` for `portal_retrieval_gaps`; actual is `occurred_at`. Migration uses the real column.

## Acceptance — automated rows

| AC | Status | Evidence |
|---|---|---|
| AC-1 — New tenants default to `shadow` | ✅ | Migration `g5h6i7j8k9l0` adds `telemetry_level` with `DEFAULT 'shadow'`; `models/portal.py` mirrors; pre-flight verified empty `portal_retrieval_gaps` so cleanup blast radius=0 |
| AC-2 — `shadow` mode produces shadow row, no raw query | ✅ | `tests/test_telemetry_writer.py` (writer mocks pool); `tests/test_gap_events_telemetry.py::test_gap_events_redacts_in_shadow_mode` (gap row gets `[REDACTED:shadow]`); retrieve.py decision_record stripping covered by anti-leakage tests |
| AC-3 — `full` mode emits content | ✅ | `tests/test_telemetry_level_forwarding.py::test_query_rewrite_log_keeps_text_in_full_mode`; `tests/test_gap_events_telemetry.py::test_gap_events_keeps_text_in_full_mode` |
| AC-4 — `off` mode writes nothing | ✅ | `tests/test_gap_events_telemetry.py::test_gap_events_skipped_in_off_mode`; `test_retrieval_log_skipped_in_off_mode`; retrieve.py shadow-write gated `if telemetry_level in ('shadow','full')` |
| AC-5 — Admin endpoint requires reason + audit | ✅ | `tests/test_telemetry_level_service.py` covers reason validation + idempotent no-op + audit row schema |
| AC-6 — TTL job purges 8d-old rows | ✅ | `tests/test_telemetry_purge.py` covers happy-path two-DELETE + per-table failure isolation + clean cancel |
| AC-7 — Anti-leakage processor strips fields | ✅ | `klai-libs/log-utils/tests/test_strip_query_fields.py` — 7 tests including positive control (full mode preserves) and unrelated-event pass-through |
| AC-8 — Legacy cleanup runs cleanly | ✅ | Migration UPDATE/DELETE idempotent (NOT LIKE `[REDACTED:%`); pre-flight verified row count=0 on prod so first deploy has zero blast radius |
| AC-9 — Latency p95 ≤ baseline + 5% | ⏳ owner: Mark (post-deploy) | Shadow INSERT is fire-and-forget via asyncio.create_task, no synchronous added latency |
| AC-10 — Privacy dashboard renders | ⏳ owner: Mark (post-deploy screenshot) | `klai-privacy.json` provisioned + 2 alert rules with valid 31-char UIDs |
| AC-11 — Tenant self-service dropdown | ⏳ owner: Mark (manual UI walk on staging — screenshot) | Backend tests for endpoint cover happy path + 403 + 404 + reset-to-shadow; frontend tsc clean |

## Post-deploy validation owner: Mark

These three rows require live production traces or manual UI verification:
- **AC-9** — capture pre-SPEC p95 vs 24h post-deploy on Voys via Grafana
- **AC-11** — manual UI walk on `https://voys.getklai.com/admin/settings`, screenshot of the dropdown
- **Privacy posture statement** — Mark's attestation row at the bottom of acceptance.md

## Pre-flight context (captured 2026-05-08)

- pgvector v0.8.2 installed on prod (no `CREATE EXTENSION` needed but migration ships it for fresh-install parity)
- `portal_retrieval_gaps` row count: **0** (cleanup migration is a true no-op on prod)
- No open PRs touching the affected tables
- portal_api role: `t` on schema=public.CREATE, `f` on database.CREATE → schema/table creation runs as `klai` superuser via post-deploy SQL

## Pitfalls actively avoided

- `alembic-cannot-drop-non-portal_api-tables`: schema/table creation in post-deploy SQL, not in alembic upgrade()
- `validator-env-parity`: no new env vars introduced
- `pgvector` text-literal encoding (no asyncpg codec needed); tests cover `_format_vector(None) is None`
- `grafana-uid-40-char-limit`: both new alert UIDs are 31 chars
- `worktree-for-long-running-changes`: all 9 commits live on a dedicated worktree
- `bind-mount-content-vs-python-module-cache`: no litellm Dockerfile change required (no new bind-mounts); existing `compose-up.sh --force-recreate litellm` workflow handles the deploy

## Pre-existing failures (NOT introduced by this PR)

- `test_health_all_ok` (retrieval-api): requires falkordb network — flagged in user brief
- `test_missing_zitadel_audience_fails_import` (retrieval-api): env-specific — flagged in user brief

## Rollback

Per-tenant escape hatch is one SQL statement:
```sql
UPDATE portal_orgs SET telemetry_level = 'full' WHERE id IN (...);
```
This restores pre-SPEC behaviour for affected tenants without a code revert. Full code revert is also clean — every gating site degrades gracefully when the column is absent (default `shadow`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)