### PR TITLE
docs(rules): agent-browser headless-default + workspace URL fixes

### DIFF
--- a/.claude/rules/klai/lang/agent-browser.md
+++ b/.claude/rules/klai/lang/agent-browser.md
@@ -21,6 +21,26 @@ paths:
 
 Default: voor alles met "verify dat X werkt" → Playwright. Voor alles met "explore of er iets stuk is" → Agent Browser.
 
+## Headless is default — `--headed` alleen bij human-in-the-loop
+
+Agent Browser draait headless tenzij je `--headed` (of `AGENT_BROWSER_HEADED=1`)
+meegeeft. Headless is voor AI-runs juist gewenst: lichter, geen dock-icoon,
+geen focus-stealing, en de AI ziet het DOM via `snapshot` — niet via pixels.
+
+Gebruik `--headed` ALLEEN als de mens iets in het venster moet doen:
+
+| Situatie | Headed nodig? |
+|---|---|
+| Smoke test, audit, snapshot-driven flow door AI | **Nee** — headless |
+| Authenticated session draaien met `--state` | **Nee** — cookies werken headless prima |
+| Eenmalige login om `state save` te doen | **Ja** — mens moet typen in venster |
+| Captcha / 2FA-prompt die je niet kunt scripten | **Ja** |
+| Live debugging waarbij je over de schouder van de AI mee wilt kijken | **Ja** |
+
+Anti-pattern: `--headed` als default in scripts/agents zetten. Dat opent een
+Chrome-venster bij élke AI-actie en steelt focus midden in een werksessie van
+de mens. Reserveer headed voor expliciet menselijk handelen.
+
 ## Parallel sessions [HARD]
 
 Elke Claude sessie MOET een unieke `--session` naam gebruiken. Anders leakt cookies/localStorage tussen sessies (issue [#1068](https://github.com/vercel-labs/agent-browser/issues/1068)).
@@ -61,23 +81,29 @@ Agent Browser kan **niet** de Playwright `~/.claude/mcp-storageState.json` direc
 **One-time setup** (eenmalig, of refresh wanneer sessie verloopt):
 
 ```bash
-# 1. Open portal headed (zonder --session-name = ephemeral, dan via state save)
-agent-browser open https://app.getklai.com
-# 2. Log in handmatig in geopende browser
-# 3. Save state
+# 1. Open portal HEADED — mens moet inloggen, dus venster moet zichtbaar zijn
+agent-browser --headed open https://app.getklai.com
+# 2. Log in handmatig in geopende browser (Google SSO + 2FA)
+# 3. Save state (gebruikt huidige sessie, --headed flag niet nodig)
 agent-browser state save ~/.claude/agent-browser-state.json
 chmod 600 ~/.claude/agent-browser-state.json
 agent-browser close
 ```
 
-**Daily use** in scripts/agents:
+**Daily use** in scripts/agents (headless, geen `--headed`):
 
 ```bash
 SESSION="klai-portal-${CLAUDE_SESSION_ID:-$(date +%s)}"
 agent-browser --session "$SESSION" \
               --state ~/.claude/agent-browser-state.json \
-              open https://app.getklai.com/dashboard
+              open https://voys.getklai.com   # workspace-URL, niet app.getklai.com
 ```
+
+**Belangrijk: navigeer naar de workspace-URL (`<slug>.getklai.com`), niet naar
+`app.getklai.com`.** Een ingelogde request op `app.getklai.com` retourneert een
+`/api/me`-style JSON-payload (handig voor introspect, nutteloos voor SPA-flows).
+De SPA leeft op de tenant-subdomein. Workspace-URL staat in dezelfde JSON onder
+`workspace_url`.
 
 Refresh storage-state om de paar weken (zelfde cadans als Playwright). Als sessies "logged-out" starten: state file is verlopen → opnieuw `state save`.
 
@@ -136,6 +162,8 @@ agent-browser --session "$SESSION" eval "
 - **agent-browser-session-shell-expansion** — `$$` of `$RANDOM` per command-aanroep = nieuwe sessie elke keer. Gebruik een env var die je vóór de chain set.
 - **agent-browser-storage-state-mismatch** — Niet de Playwright `~/.claude/mcp-storageState.json` proberen te laden. Eigen file `~/.claude/agent-browser-state.json` aanmaken via `state save`.
 - **agent-browser-stale-refs** — `@e1`, `@e2` zijn **fresh per snapshot**. Re-snapshot na elke navigation/click die de DOM wijzigt.
+- **agent-browser-headed-as-default** — `--headed` toevoegen aan elk script omdat "de mens dan kan meekijken" steelt focus en is voor AI-runs onnodig. Headless is correct default; `--headed` alleen voor login + interactieve debug.
+- **agent-browser-app-getklai-returns-json** — Een ingelogde sessie die `https://app.getklai.com` opent landt op een JSON-payload, niet de SPA. Voor authenticated flows: gebruik `<workspace>.getklai.com` (uit `/api/me` `workspace_url`).
 
 ## See also
 


### PR DESCRIPTION
## Summary

Two corrections after operationalizing vercel-labs/agent-browser locally (smoke-tested against `voys.getklai.com` with `~/.claude/agent-browser-state.json`):

1. **Headless is the correct default; `--headed` only for human-in-the-loop.** Adding `--headed` to every script steals focus during work and is unnecessary for AI-driven snapshot flows that read DOM, not pixels. New explicit decision table:

   | Situatie | Headed nodig? |
   |---|---|
   | Smoke test, audit, snapshot-driven flow door AI | Nee — headless |
   | Authenticated session draaien met `--state` | Nee — cookies werken headless prima |
   | Eenmalige login om `state save` te doen | Ja — mens moet typen |
   | Captcha / 2FA / live debug | Ja |

2. **`app.getklai.com` returns `/api/me` JSON for authenticated requests, not the SPA.** Daily-use examples now point at `<workspace>.getklai.com`. The JSON payload contains `workspace_url` for programmatic discovery.

## Files

- `.claude/rules/klai/lang/agent-browser.md` (+34 / -6)
  - New section: "Headless is default — `--headed` alleen bij human-in-the-loop"
  - Auth-handoff one-time setup: `--headed` toegevoegd aan login-stap (was missing — bug die ik live tegenkwam)
  - Daily-use voorbeeld gewijzigd van `app.getklai.com/dashboard` → `voys.getklai.com`
  - Twee nieuwe pitfalls: `agent-browser-headed-as-default` + `agent-browser-app-getklai-returns-json`

## Validation

- Local install: `agent-browser 0.27.0` via `npm i -g agent-browser`
- Login flow: `--headed open` → manual SSO → `state save` → 16KB file at `~/.claude/agent-browser-state.json` (chmod 600)
- Smoke test: headless `open https://voys.getklai.com` met `--state` → snapshot toont `Good morning, there` + nav (Chat/Knowledge/Admin/Log out) — auth werkt
- Anti-test: headless `open https://app.getklai.com` met `--state` → JSON payload `{user_id: ..., email: "mark.vletter@voys.nl", roles: ["org:owner"], ...}` — bevestigt de SPA-vs-JSON pitfall

## Test plan

- [x] Rule file linted (geen broken markdown)
- [x] Examples werken zoals beschreven (smoke + auth flow geverifieerd)
- [ ] Volgende keer dat een agent agent-browser gebruikt: check of de nieuwe defaults gevolgd worden

🤖 Generated with [Claude Code](https://claude.com/claude-code)