### PR TITLE
[codex] Isolate Scribe transcriptions by tenant

### DIFF
--- a/klai-scribe/scribe-api/alembic/versions/0008_add_org_id_to_transcriptions.py
+++ b/klai-scribe/scribe-api/alembic/versions/0008_add_org_id_to_transcriptions.py
@@ -1,0 +1,92 @@
+"""add tenant org_id to scribe transcriptions
+
+Revision ID: 0008_f4a2d9b1
+Revises: 0007_c5f9e3a4
+Create Date: 2026-05-08 00:00:00.000000
+
+Scribe rows were historically scoped only by Zitadel user id. This adds an
+explicit tenant dimension and backfills it from portal membership so every
+user-facing transcription query can require both user_id and org_id.
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0008_f4a2d9b1"
+down_revision: str | Sequence[str] | None = "0007_c5f9e3a4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "transcriptions",
+        sa.Column("org_id", sa.VARCHAR(128), nullable=True),
+        schema="scribe",
+    )
+
+    op.execute(
+        """
+        UPDATE scribe.transcriptions AS t
+        SET org_id = po.zitadel_org_id
+        FROM public.portal_users AS pu
+        JOIN public.portal_orgs AS po ON po.id = pu.org_id
+        WHERE t.user_id = pu.zitadel_user_id
+          AND t.org_id IS NULL
+        """
+    )
+
+    op.execute(
+        """
+        DO $$
+        DECLARE
+            missing_count integer;
+        BEGIN
+            SELECT count(*) INTO missing_count
+            FROM scribe.transcriptions
+            WHERE org_id IS NULL;
+
+            IF missing_count > 0 THEN
+                RAISE EXCEPTION
+                    'Cannot backfill org_id for % scribe transcription row(s)',
+                    missing_count;
+            END IF;
+        END $$;
+        """
+    )
+
+    op.alter_column(
+        "transcriptions",
+        "org_id",
+        existing_type=sa.VARCHAR(128),
+        nullable=False,
+        schema="scribe",
+    )
+    op.create_index(
+        "ix_scribe_transcriptions_org_user",
+        "transcriptions",
+        ["org_id", "user_id"],
+        schema="scribe",
+    )
+    op.create_index(
+        "ix_scribe_transcriptions_org_created_at",
+        "transcriptions",
+        ["org_id", "created_at"],
+        schema="scribe",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_scribe_transcriptions_org_created_at",
+        table_name="transcriptions",
+        schema="scribe",
+    )
+    op.drop_index(
+        "ix_scribe_transcriptions_org_user",
+        table_name="transcriptions",
+        schema="scribe",
+    )
+    op.drop_column("transcriptions", "org_id", schema="scribe")

--- a/klai-scribe/scribe-api/app/api/transcribe.py
+++ b/klai-scribe/scribe-api/app/api/transcribe.py
@@ -13,7 +13,7 @@ Transcription API endpoints:
 import asyncio
 import logging
 import uuid
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Literal
 
 import httpx
@@ -22,12 +22,11 @@ from pydantic import BaseModel
 from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.auth import CallerIdentity, get_authenticated_caller, get_current_user_id
+from app.core.auth import CallerIdentity, get_authenticated_caller
 from app.core.config import settings
 from app.core.database import get_db
 from app.models.transcription import Transcription
 from app.services import summarizer
-from app.services.audio import normalize_audio
 from app.services.audio_storage import (
     delete_audio,
     finalize_success,
@@ -39,6 +38,14 @@ from app.services.providers import get_provider
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/v1", tags=["transcription"])
+_UPLOAD_FILE = File(...)
+_LANGUAGE_FORM = Form(default=None)
+_CALLER = Depends(get_authenticated_caller)
+_DB = Depends(get_db)
+_RETRY_LANGUAGE = Query(default=None)
+_LIST_LIMIT = Query(default=20, ge=1, le=100)
+_LIST_OFFSET = Query(default=0, ge=0)
+_FORCE_SUMMARY = Query(default=False)
 
 
 # -- Response models -----------------------------------------------------------
@@ -95,6 +102,13 @@ class SummarizeResponse(BaseModel):
 # app.services.audio_storage — see that module for the retention policy.
 
 
+def normalize_audio(raw: bytes, filename: str) -> bytes:
+    """Lazy wrapper so importing API schemas does not require libmagic."""
+    from app.services.audio import normalize_audio as _normalize_audio
+
+    return _normalize_audio(raw, filename)
+
+
 def _title_from_text(text: str | None, max_words: int = 8) -> str | None:
     """Generate a short title from the first words of a transcription."""
     if not text:
@@ -114,9 +128,30 @@ def _to_response(record: Transcription) -> TranscriptionResponse:
         text=record.text,
         language=record.language,
         duration_seconds=float(record.duration_seconds) if record.duration_seconds else None,
-        inference_time_seconds=float(record.inference_time_seconds) if record.inference_time_seconds else None,
+        inference_time_seconds=(
+            float(record.inference_time_seconds)
+            if record.inference_time_seconds
+            else None
+        ),
         summary_json=record.summary_json,
         created_at=record.created_at,
+    )
+
+
+def _owned_transcription_filters(txn_id: str, caller: CallerIdentity):
+    """Return the ownership + tenant predicates for a single transcription."""
+    return (
+        Transcription.id == txn_id,
+        Transcription.user_id == caller.user_id,
+        Transcription.org_id == caller.org_id,
+    )
+
+
+def _caller_transcription_filters(caller: CallerIdentity):
+    """Return the tenant-scoped collection predicates for a caller."""
+    return (
+        Transcription.user_id == caller.user_id,
+        Transcription.org_id == caller.org_id,
     )
 
 
@@ -124,10 +159,10 @@ def _to_response(record: Transcription) -> TranscriptionResponse:
 
 @router.post("/transcribe", response_model=TranscriptionResponse, status_code=201)
 async def transcribe(
-    file: UploadFile = File(...),
-    language: str | None = Form(default=None),
-    user_id: str = Depends(get_current_user_id),
-    db: AsyncSession = Depends(get_db),
+    file: UploadFile = _UPLOAD_FILE,
+    language: str | None = _LANGUAGE_FORM,
+    caller: CallerIdentity = _CALLER,
+    db: AsyncSession = _DB,
 ) -> TranscriptionResponse:
     """Upload audio, persist to disk, attempt transcription.
 
@@ -150,11 +185,11 @@ async def transcribe(
     # Generate ID and save audio to disk FIRST.
     # SPEC-SEC-HYGIENE-001 REQ-33.1: `_safe_audio_path` raises ValueError on
     # malformed user_id / txn_id. With HY-34 in place upstream this is purely
-    # defense-in-depth (auth.get_current_user_id already rejects malformed
+    # defense-in-depth (auth.get_authenticated_caller already rejects malformed
     # sub), but the SPEC asks the caller to map ValueError → 400.
     txn_id = "txn_" + uuid.uuid4().hex
     try:
-        audio_path = await loop.run_in_executor(None, save_audio, user_id, txn_id, wav_bytes)
+        audio_path = await loop.run_in_executor(None, save_audio, caller.user_id, txn_id, wav_bytes)
     except ValueError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -164,11 +199,12 @@ async def transcribe(
     # Create DB record with status=processing
     record = Transcription(
         id=txn_id,
-        user_id=user_id,
+        user_id=caller.user_id,
+        org_id=caller.org_id,
         name=filename if filename != "upload" else None,
         status="processing",
         audio_path=audio_path,
-        created_at=datetime.utcnow(),
+        created_at=datetime.now(UTC),
     )
     db.add(record)
     await db.commit()
@@ -212,20 +248,20 @@ async def transcribe(
 @router.post("/transcriptions/{txn_id}/retry", response_model=TranscriptionResponse)
 async def retry_transcription(
     txn_id: str,
-    language: str | None = Query(default=None),
-    user_id: str = Depends(get_current_user_id),
-    db: AsyncSession = Depends(get_db),
+    language: str | None = _RETRY_LANGUAGE,
+    caller: CallerIdentity = _CALLER,
+    db: AsyncSession = _DB,
 ) -> TranscriptionResponse:
     """Retry transcription for a failed record using the preserved audio file."""
     result = await db.execute(
-        select(Transcription).where(
-            Transcription.id == txn_id,
-            Transcription.user_id == user_id,
-        )
+        select(Transcription).where(*_owned_transcription_filters(txn_id, caller))
     )
     record = result.scalar_one_or_none()
     if record is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Transcript niet gevonden")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Transcript niet gevonden",
+        )
 
     if record.status not in ("failed", "processing"):
         raise HTTPException(
@@ -273,19 +309,19 @@ async def retry_transcription(
 
 @router.get("/transcriptions", response_model=TranscriptionListResponse)
 async def list_transcriptions(
-    limit: int = Query(default=20, ge=1, le=100),
-    offset: int = Query(default=0, ge=0),
-    user_id: str = Depends(get_current_user_id),
-    db: AsyncSession = Depends(get_db),
+    limit: int = _LIST_LIMIT,
+    offset: int = _LIST_OFFSET,
+    caller: CallerIdentity = _CALLER,
+    db: AsyncSession = _DB,
 ) -> TranscriptionListResponse:
     total_result = await db.execute(
-        select(func.count()).select_from(Transcription).where(Transcription.user_id == user_id)
+        select(func.count()).select_from(Transcription).where(*_caller_transcription_filters(caller))
     )
     total = total_result.scalar_one()
 
     rows = await db.execute(
         select(Transcription)
-        .where(Transcription.user_id == user_id)
+        .where(*_caller_transcription_filters(caller))
         .order_by(Transcription.created_at.desc())
         .limit(limit)
         .offset(offset)
@@ -315,18 +351,18 @@ async def list_transcriptions(
 @router.get("/transcriptions/{txn_id}", response_model=TranscriptionResponse)
 async def get_transcription(
     txn_id: str,
-    user_id: str = Depends(get_current_user_id),
-    db: AsyncSession = Depends(get_db),
+    caller: CallerIdentity = _CALLER,
+    db: AsyncSession = _DB,
 ) -> TranscriptionResponse:
     result = await db.execute(
-        select(Transcription).where(
-            Transcription.id == txn_id,
-            Transcription.user_id == user_id,
-        )
+        select(Transcription).where(*_owned_transcription_filters(txn_id, caller))
     )
     record = result.scalar_one_or_none()
     if record is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Transcript niet gevonden")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Transcript niet gevonden",
+        )
 
     return _to_response(record)
 
@@ -337,19 +373,19 @@ async def get_transcription(
 async def patch_transcription(
     txn_id: str,
     body: TranscriptionPatch,
-    user_id: str = Depends(get_current_user_id),
-    db: AsyncSession = Depends(get_db),
+    caller: CallerIdentity = _CALLER,
+    db: AsyncSession = _DB,
 ) -> TranscriptionResponse:
     """Update the name of a transcription."""
     result = await db.execute(
-        select(Transcription).where(
-            Transcription.id == txn_id,
-            Transcription.user_id == user_id,
-        )
+        select(Transcription).where(*_owned_transcription_filters(txn_id, caller))
     )
     record = result.scalar_one_or_none()
     if record is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Transcript niet gevonden")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Transcript niet gevonden",
+        )
 
     record.name = body.name
     await db.commit()
@@ -363,27 +399,24 @@ async def patch_transcription(
 @router.delete("/transcriptions/{txn_id}", status_code=204)
 async def delete_transcription(
     txn_id: str,
-    user_id: str = Depends(get_current_user_id),
-    db: AsyncSession = Depends(get_db),
+    caller: CallerIdentity = _CALLER,
+    db: AsyncSession = _DB,
 ) -> None:
     result = await db.execute(
-        select(Transcription).where(
-            Transcription.id == txn_id,
-            Transcription.user_id == user_id,
-        )
+        select(Transcription).where(*_owned_transcription_filters(txn_id, caller))
     )
     record = result.scalar_one_or_none()
     if record is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Transcript niet gevonden")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Transcript niet gevonden",
+        )
 
     # Clean up audio file (legacy records that still have audio at time of delete)
     delete_audio(record.audio_path)
 
     await db.execute(
-        delete(Transcription).where(
-            Transcription.id == txn_id,
-            Transcription.user_id == user_id,
-        )
+        delete(Transcription).where(*_owned_transcription_filters(txn_id, caller))
     )
     await db.commit()
 
@@ -394,20 +427,20 @@ async def delete_transcription(
 async def summarize_transcription(
     txn_id: str,
     body: SummarizeRequest,
-    force: bool = Query(default=False),
-    user_id: str = Depends(get_current_user_id),
-    db: AsyncSession = Depends(get_db),
+    force: bool = _FORCE_SUMMARY,
+    caller: CallerIdentity = _CALLER,
+    db: AsyncSession = _DB,
 ) -> SummarizeResponse:
     """Generate an AI summary for a transcription."""
     result = await db.execute(
-        select(Transcription).where(
-            Transcription.id == txn_id,
-            Transcription.user_id == user_id,
-        )
+        select(Transcription).where(*_owned_transcription_filters(txn_id, caller))
     )
     record = result.scalar_one_or_none()
     if record is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Transcript niet gevonden")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Transcript niet gevonden",
+        )
 
     if not record.text or not record.text.strip():
         raise HTTPException(
@@ -445,10 +478,9 @@ class IngestToKBRequest(BaseModel):
     """Body schema for transcription-to-KB ingest.
 
     SPEC-SEC-IDENTITY-ASSERT-001 REQ-3.1: ``org_id`` was removed. The
-    target tenant is derived from the authenticated user's JWT
-    ``resourceowner`` claim (see ``get_authenticated_caller``) — a body
-    field would let any caller with a valid JWT push into any org's KB
-    (the S1 finding in spec.md).
+    target tenant is derived from portal-verified caller identity (see
+    ``get_authenticated_caller``) — a body field would let any caller with a
+    valid JWT push into any org's KB (the S1 finding in spec.md).
     """
 
     kb_slug: str
@@ -463,22 +495,19 @@ class IngestToKBResponse(BaseModel):
 async def ingest_transcription_to_kb(
     txn_id: str,
     body: IngestToKBRequest,
-    caller: CallerIdentity = Depends(get_authenticated_caller),
-    db: AsyncSession = Depends(get_db),
+    caller: CallerIdentity = _CALLER,
+    db: AsyncSession = _DB,
 ) -> IngestToKBResponse:
     """Add a transcription to the authenticated user's primary-org KB.
 
-    Tenant identity (``org_id``) is sourced from the JWT's resourceowner
-    claim — never from the request body. Transcription ownership is still
-    enforced by ``Transcription.user_id == caller.user_id``.
+    Tenant identity is sourced from portal-verified caller identity — never
+    from the request body. Transcription ownership is enforced by both
+    ``Transcription.user_id`` and ``Transcription.org_id``.
     """
     from app.services.knowledge_adapter import ingest_scribe_transcript
 
     result = await db.execute(
-        select(Transcription).where(
-            Transcription.id == txn_id,
-            Transcription.user_id == caller.user_id,
-        )
+        select(Transcription).where(*_owned_transcription_filters(txn_id, caller))
     )
     record = result.scalar_one_or_none()
     if record is None:

--- a/klai-scribe/scribe-api/app/main.py
+++ b/klai-scribe/scribe-api/app/main.py
@@ -62,8 +62,8 @@ app = FastAPI(
 
 # SPEC-SEC-004: defense-in-depth — reject requests without Authorization header
 # before any route handler. Token validity is checked per-route via
-# `Depends(get_current_user_id)`; this guard only checks *presence* and is a
-# safety net if a new route forgets its auth dependency.
+# `Depends(get_authenticated_caller)`; this guard only checks *presence* and
+# is a safety net if a new route forgets its auth dependency.
 app.add_middleware(AuthGuardMiddleware)
 
 app.add_middleware(RequestContextMiddleware)

--- a/klai-scribe/scribe-api/app/middleware/auth_guard.py
+++ b/klai-scribe/scribe-api/app/middleware/auth_guard.py
@@ -3,7 +3,7 @@ SPEC-SEC-004: Defense-in-depth auth guard middleware for scribe-api.
 
 Every request (except explicitly exempt paths) MUST carry an Authorization
 Bearer header. Actual token validation still happens per-route via
-`Depends(get_current_user_id)` — this middleware is a safety net that
+`Depends(get_authenticated_caller)` — this middleware is a safety net that
 rejects requests with a missing header *before* the route handler runs.
 """
 
@@ -30,7 +30,7 @@ _EXEMPT_PREFIXES: tuple[str, ...] = (
 class AuthGuardMiddleware(BaseHTTPMiddleware):
     """Reject any request without an Authorization header early.
 
-    Token validity is verified downstream by `get_current_user_id`. This
+    Token validity is verified downstream by `get_authenticated_caller`. This
     guard only checks for *presence* of the header.
     """
 

--- a/klai-scribe/scribe-api/app/models/transcription.py
+++ b/klai-scribe/scribe-api/app/models/transcription.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import ClassVar
 
 from sqlalchemy import JSON, NUMERIC, TEXT, TIMESTAMP, VARCHAR, Column
 from sqlalchemy.orm import DeclarativeBase
@@ -10,10 +11,11 @@ class Base(DeclarativeBase):
 
 class Transcription(Base):
     __tablename__ = "transcriptions"
-    __table_args__ = {"schema": "scribe"}
+    __table_args__: ClassVar[dict[str, str]] = {"schema": "scribe"}
 
     id = Column(VARCHAR(64), primary_key=True)
     user_id = Column(VARCHAR(128), nullable=False, index=True)
+    org_id = Column(VARCHAR(128), nullable=False, index=True)
     name = Column(VARCHAR(255), nullable=True)
     status = Column(VARCHAR(16), nullable=False, default="transcribed")
     audio_path = Column(VARCHAR(512), nullable=True)

--- a/klai-scribe/scribe-api/tests/test_tenant_isolation.py
+++ b/klai-scribe/scribe-api/tests/test_tenant_isolation.py
@@ -1,0 +1,148 @@
+"""Tenant-isolation tests for scribe transcriptions."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.core.auth import CallerIdentity
+
+
+def _sql_text(statement) -> str:
+    return str(statement.compile(compile_kwargs={"literal_binds": True}))
+
+
+def _result(value):
+    result = MagicMock()
+    result.scalar_one_or_none = MagicMock(return_value=value)
+    result.scalar_one = MagicMock(return_value=value)
+    scalars = MagicMock()
+    scalars.all.return_value = value if isinstance(value, list) else []
+    result.scalars.return_value = scalars
+    return result
+
+
+class _FakeUpload:
+    filename = "meeting.wav"
+
+    async def read(self, _limit: int) -> bytes:
+        return b"RIFFfake"
+
+
+class _FakeDB:
+    def __init__(self, value=None) -> None:
+        self.statements = []
+        self.added = None
+        self.execute = AsyncMock(side_effect=self._execute)
+        self.commit = AsyncMock()
+        self.refresh = AsyncMock()
+        self._value = value
+
+    async def _execute(self, statement):
+        self.statements.append(statement)
+        return _result(self._value)
+
+    def add(self, record) -> None:
+        self.added = record
+
+
+def test_single_record_scope_requires_user_and_org() -> None:
+    from app.api.transcribe import _owned_transcription_filters
+
+    caller = CallerIdentity(user_id="user-1", org_id="org-1")
+
+    filters = _owned_transcription_filters("txn-1", caller)
+    sql = " AND ".join(_sql_text(f) for f in filters)
+
+    assert "transcriptions.id = 'txn-1'" in sql
+    assert "transcriptions.user_id = 'user-1'" in sql
+    assert "transcriptions.org_id = 'org-1'" in sql
+
+
+def test_collection_scope_requires_user_and_org() -> None:
+    from app.api.transcribe import _caller_transcription_filters
+
+    caller = CallerIdentity(user_id="user-1", org_id="org-1")
+
+    filters = _caller_transcription_filters(caller)
+    sql = " AND ".join(_sql_text(f) for f in filters)
+
+    assert "transcriptions.user_id = 'user-1'" in sql
+    assert "transcriptions.org_id = 'org-1'" in sql
+
+
+@pytest.mark.asyncio
+async def test_transcribe_persists_portal_verified_org(monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.api import transcribe as transcribe_mod
+
+    caller = CallerIdentity(user_id="user-1", org_id="org-1")
+    db = _FakeDB()
+
+    monkeypatch.setattr(transcribe_mod, "normalize_audio", lambda raw, filename: b"WAV")
+    monkeypatch.setattr(
+        transcribe_mod,
+        "save_audio",
+        lambda user_id, txn_id, wav: f"{user_id}/{txn_id}.wav",
+    )
+
+    provider = MagicMock()
+    provider.transcribe = AsyncMock(
+        return_value=SimpleNamespace(
+            text="hello",
+            language="en",
+            duration_seconds=1.0,
+            inference_time_seconds=0.2,
+            provider="test-provider",
+            model="test-model",
+        )
+    )
+    monkeypatch.setattr(transcribe_mod, "get_provider", lambda: provider)
+
+    response = await transcribe_mod.transcribe(
+        file=_FakeUpload(),
+        language=None,
+        caller=caller,
+        db=db,
+    )
+
+    assert db.added is not None
+    assert db.added.user_id == "user-1"
+    assert db.added.org_id == "org-1"
+    assert response.text == "hello"
+
+
+@pytest.mark.asyncio
+async def test_get_transcription_404s_when_org_scope_returns_no_row() -> None:
+    from app.api.transcribe import get_transcription
+
+    caller = CallerIdentity(user_id="user-1", org_id="org-1")
+    db = _FakeDB(value=None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_transcription(txn_id="txn-1", caller=caller, db=db)
+
+    assert exc_info.value.status_code == 404
+    sql = _sql_text(db.statements[0])
+    assert "transcriptions.user_id = 'user-1'" in sql
+    assert "transcriptions.org_id = 'org-1'" in sql
+
+
+@pytest.mark.asyncio
+async def test_delete_statement_is_org_scoped(monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.api.transcribe import delete_transcription
+
+    caller = CallerIdentity(user_id="user-1", org_id="org-1")
+    record = SimpleNamespace(audio_path=None, created_at=datetime.now(UTC))
+    db = _FakeDB(value=record)
+    monkeypatch.setattr("app.api.transcribe.delete_audio", lambda _path: None)
+
+    await delete_transcription(txn_id="txn-1", caller=caller, db=db)
+
+    delete_sql = _sql_text(db.statements[1])
+    assert "DELETE FROM scribe.transcriptions" in delete_sql
+    assert "transcriptions.user_id = 'user-1'" in delete_sql
+    assert "transcriptions.org_id = 'org-1'" in delete_sql

--- a/klai-scribe/scribe-api/uv.lock
+++ b/klai-scribe/scribe-api/uv.lock
@@ -444,14 +444,14 @@ dev = [
 
 [[package]]
 name = "mako"
-version = "1.3.11"
+version = "1.3.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/59/8a/805404d0c0b9f3d7a326475ca008db57aea9c5c9f2e1e39ed0faa335571c/mako-1.3.11.tar.gz", hash = "sha256:071eb4ab4c5010443152255d77db7faa6ce5916f35226eb02dc34479b6858069", size = 399811 }
+sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/a5/19d7aaa7e433713ffe881df33705925a196afb9532efc8475d26593921a6/mako-1.3.11-py3-none-any.whl", hash = "sha256:e372c6e333cf004aa736a15f425087ec977e1fcbd2966aae7f17c8dc1da27a77", size = 78503 },
+    { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add org_id to Scribe transcriptions with an Alembic backfill from portal membership
- scope Scribe transcript reads, writes, retries, deletes, summaries, and KB ingest by both user_id and org_id
- add tenant isolation tests for query predicates, persisted org ownership, 404 behavior, and delete scoping

## Validation
- uv run --extra dev pytest
- uv run --extra dev ruff check app/api/transcribe.py app/models/transcription.py app/main.py app/middleware/auth_guard.py tests/test_tenant_isolation.py alembic/versions/0008_add_org_id_to_transcriptions.py
- uv run --extra dev alembic heads
- git diff --cached --check