### PR TITLE
refactor(privacy): tighten SPEC-PRIVACY-QUERY-SHADOW-001 cleanup (5 items)

### DIFF
--- a/klai-knowledge-mcp/main.py
+++ b/klai-knowledge-mcp/main.py
@@ -981,13 +981,13 @@ async def search_knowledge(
         "conversation_history": [],
         # SPEC-PRIVACY-QUERY-SHADOW-001 REQ-4: third-party MCP traffic
         # (Claude Desktop / Cursor / ChatGPT) is privacy-by-default — we
-        # always send 'shadow' so raw query content never persists in
-        # operational stores, regardless of the tenant's litellm-hook
-        # level. Operators who need full-mode debug visibility for an MCP
-        # caller can flip the same kb_feature toggle for their LibreChat
-        # users; the MCP path stays private. Future enhancement: fetch
-        # the per-tenant level via a small portal-api lookup if business
-        # need arises.
+        # always send 'shadow' as the upper bound. Retrieval-api applies
+        # ``min(client_requested, canonical_tenant_level)``, so a tenant
+        # configured 'off' will see zero shadow rows from MCP traffic
+        # (the canonical 'off' wins). A tenant on 'full' caps MCP at
+        # 'shadow' (we don't escalate third-party traffic to full-mode
+        # debug; full mode is reserved for the LibreChat path operators
+        # actively investigate).
         "telemetry_level": "shadow",
     }
 

--- a/klai-libs/log-utils/tests/test_strip_query_fields.py
+++ b/klai-libs/log-utils/tests/test_strip_query_fields.py
@@ -139,3 +139,48 @@ def test_does_not_explode_on_non_string_event() -> None:
     )
     # Non-string event → processor is a no-op (defensive).
     assert out["raw_query"] == "untouched because event isn't a string"
+
+
+def test_contextvar_binding_propagates_into_event_dict() -> None:
+    """Integration: ``telemetry_level`` bound via structlog.contextvars
+    must reach the processor's view of the event dict (via the
+    ``merge_contextvars`` processor that runs upstream in setup_logging).
+
+    Caller (retrieval-api/api/retrieve.py) does
+    ``structlog.contextvars.bind_contextvars(telemetry_level=req.telemetry_level)``
+    once per request. From that moment, every subsequent log line in
+    the same async-task carries the level — even ones that don't pass
+    it as a kwarg. This test pins that contract because REQ-13's safety
+    net depends on it.
+    """
+    import structlog
+
+    structlog.contextvars.clear_contextvars()
+    try:
+        # Simulate retrieve.py binding the level once per request.
+        structlog.contextvars.bind_contextvars(telemetry_level="full")
+
+        # Simulate structlog's merge_contextvars processor running
+        # upstream of ours: it merges contextvars into the event_dict.
+        merged: dict = dict(structlog.contextvars.get_contextvars())
+        merged["event"] = "retrieval_decision_record"
+        merged["coreference_rewrite"] = {"original": "S3CR3T", "resolved": "..."}
+
+        out = _run(merged)
+        assert out["coreference_rewrite"]["original"] == "S3CR3T", (
+            "contextvar telemetry_level=full should preserve the field"
+        )
+
+        # Flip to shadow and re-merge — same event must now be stripped.
+        structlog.contextvars.bind_contextvars(telemetry_level="shadow")
+        merged2: dict = dict(structlog.contextvars.get_contextvars())
+        merged2["event"] = "retrieval_decision_record"
+        merged2["coreference_rewrite"] = {"original": "S3CR3T", "resolved": "..."}
+
+        out2 = _run(merged2)
+        assert "coreference_rewrite" not in out2, (
+            "contextvar telemetry_level=shadow must strip the field even when "
+            "the caller did not explicitly pass telemetry_level as a kwarg"
+        )
+    finally:
+        structlog.contextvars.clear_contextvars()

--- a/klai-portal/backend/app/services/telemetry_purge.py
+++ b/klai-portal/backend/app/services/telemetry_purge.py
@@ -52,7 +52,10 @@ async def _purge_once() -> dict[str, int]:
                 text("DELETE FROM telemetry.query_shadow WHERE created_at < :cutoff"),
                 {"cutoff": cutoff},
             )
-            counts["query_shadow"] = (result.rowcount or 0) if hasattr(result, "rowcount") else 0  # type: ignore[attr-defined]
+            # SQLAlchemy's stub does not expose ``rowcount`` on ``Result``,
+            # but every DELETE/UPDATE result carries it at runtime — see
+            # https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.CursorResult.rowcount
+            counts["query_shadow"] = result.rowcount or 0  # type: ignore[attr-defined]
         except Exception:
             logger.warning("telemetry_purge_query_shadow_failed", exc_info=True)
 
@@ -71,7 +74,7 @@ async def _purge_once() -> dict[str, int]:
                 ),
                 {"cutoff": cutoff},
             )
-            counts["retrieval_gaps"] = (result.rowcount or 0) if hasattr(result, "rowcount") else 0  # type: ignore[attr-defined]
+            counts["retrieval_gaps"] = result.rowcount or 0  # type: ignore[attr-defined]
         except Exception:
             logger.warning("telemetry_purge_retrieval_gaps_failed", exc_info=True)
 

--- a/klai-retrieval-api/retrieval_api/api/retrieve.py
+++ b/klai-retrieval-api/retrieval_api/api/retrieve.py
@@ -7,6 +7,7 @@ import copy
 import math
 import os
 import time
+import uuid
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -38,6 +39,7 @@ from retrieval_api.services.features import extract_features
 from retrieval_api.services.router import fetch_source_catalog, route_to_sources
 from retrieval_api.services.tei import embed_single, embed_sparse
 from retrieval_api.services.telemetry import write_shadow
+from retrieval_api.services.tenant_telemetry import get_canonical_level, resolve_effective_level
 from retrieval_api.util.payload import payload_list
 
 logger = structlog.get_logger(__name__)
@@ -164,6 +166,24 @@ async def retrieve(
     # On allow this also pins request.state.verified_caller, which is what
     # emit_event below sources for product_events integrity (REQ-6).
     await verify_body_identity(request, req.org_id, req.user_id)
+
+    # SPEC-PRIVACY-QUERY-SHADOW-001 — canonical-level enforcement.
+    # The body's ``telemetry_level`` is treated as a *requested upper
+    # bound*; the effective level is ``min(client_requested, canonical)``
+    # where canonical is portal_orgs.telemetry_level (5-minute cached
+    # lookup). This closes the gap where a buggy / malicious caller
+    # could send 'full' while the tenant has flipped to 'off', AND
+    # makes the knowledge-mcp's hardcoded 'shadow' correct under all
+    # tenant configurations (a tenant on 'off' will never see shadow
+    # rows from MCP traffic).
+    canonical_level = await get_canonical_level(req.org_id)
+    effective_level = resolve_effective_level(req.telemetry_level, canonical_level)
+
+    # REQ-13: bind effective_level on the structlog contextvar so the
+    # shared anti-leakage processor (in klai-libs/log-utils) sees the
+    # right value on EVERY log line in this request — not only the
+    # explicit ``decision_record`` event that passes it as a kwarg.
+    structlog.contextvars.bind_contextvars(telemetry_level=effective_level)
 
     t0 = time.perf_counter()
     # @MX:NOTE: [AUTO] Shadow log for parameter tuning (SPEC-KB-021 Change 4).
@@ -548,13 +568,13 @@ async def retrieve(
     # 'content' events to a 7d-retention stream and 'metadata' events
     # to the existing 30d stream (operator-side VictoriaLogs config —
     # follow-up runbook in Unit 8).
-    if req.telemetry_level != "full" and "coreference_rewrite" in decision_record:
+    if effective_level != "full" and "coreference_rewrite" in decision_record:
         decision_record.pop("coreference_rewrite", None)
         decision_record["retention_class"] = "metadata"
         telemetry_level_decisions_total.labels(
-            level=req.telemetry_level, decision="metadata_only"
+            level=effective_level, decision="metadata_only"
         ).inc()
-    elif req.telemetry_level == "full":
+    elif effective_level == "full":
         decision_record["retention_class"] = "content"
         telemetry_level_decisions_total.labels(level="full", decision="content_emitted").inc()
     else:
@@ -566,7 +586,7 @@ async def retrieve(
             "retrieval_decision_record",
             org_id=req.org_id,
             scope=req.scope,
-            telemetry_level=req.telemetry_level,
+            telemetry_level=effective_level,
             **decision_record,
         )
     except Exception:
@@ -577,27 +597,32 @@ async def retrieve(
     # telemetry_shadow_drop_total, not propagated. ``request_id`` is
     # bound by RequestContextMiddleware (logging_setup.py); read back
     # from structlog contextvars so we don't have to plumb it through
-    # the entire pipeline.
-    if req.telemetry_level in ("shadow", "full"):
-        ctx_request_id = structlog.contextvars.get_contextvars().get("request_id")
-        if ctx_request_id:
-            chunk_ids_for_shadow = [c.chunk_id for c in chunks_out]
-            reranker_scores = [c.reranker_score for c in chunks_out if c.reranker_score is not None]
-            reranker_top1 = max(reranker_scores) if reranker_scores else None
-            features_dict = extract_features(req.query)
-            write_shadow(
-                request_id=ctx_request_id,
-                org_id=req.org_id,
-                embedding=list(query_vector) if query_vector is not None else None,
-                features=features_dict,
-                band=confidence_band,
-                chunk_ids=chunk_ids_for_shadow,
-                reranker_top1=reranker_top1,
-            )
-            telemetry_level_decisions_total.labels(
-                level=req.telemetry_level, decision="shadow_inserted"
-            ).inc()
-        if req.telemetry_level == "full":
+    # the entire pipeline. If the contextvar is missing (e.g. middleware
+    # didn't run, or upstream dropped a malformed X-Request-ID), generate
+    # a server-side UUID4 so every retrieve call still produces a row —
+    # missing rows would silently degrade observability and bias the
+    # dashboards' decision counters.
+    if effective_level in ("shadow", "full"):
+        request_id_for_shadow = structlog.contextvars.get_contextvars().get("request_id") or str(
+            uuid.uuid4()
+        )
+        chunk_ids_for_shadow = [c.chunk_id for c in chunks_out]
+        reranker_scores = [c.reranker_score for c in chunks_out if c.reranker_score is not None]
+        reranker_top1 = max(reranker_scores) if reranker_scores else None
+        features_dict = extract_features(req.query)
+        write_shadow(
+            request_id=request_id_for_shadow,
+            org_id=req.org_id,
+            embedding=list(query_vector) if query_vector is not None else None,
+            features=features_dict,
+            band=confidence_band,
+            chunk_ids=chunk_ids_for_shadow,
+            reranker_top1=reranker_top1,
+        )
+        telemetry_level_decisions_total.labels(
+            level=effective_level, decision="shadow_inserted"
+        ).inc()
+        if effective_level == "full":
             telemetry_level_decisions_total.labels(level="full", decision="full_logged").inc()
 
     logger.info(

--- a/klai-retrieval-api/retrieval_api/services/telemetry.py
+++ b/klai-retrieval-api/retrieval_api/services/telemetry.py
@@ -37,11 +37,17 @@ def _format_vector(values: list[float] | None) -> str | None:
     pgvector accepts either binary or text input; we use text so the
     asyncpg driver doesn't need a custom codec. Returns None for
     a missing embedding (still allowed by the schema's nullable column).
+
+    Precision: ``.9g`` preserves the full float32 mantissa (~7-8
+    significant digits with safety margin) so BGE-M3 embeddings round-
+    trip through text serialization without measurable cosine-similarity
+    drift. ``.7g`` was on the edge and could degrade nearest-neighbour
+    accuracy in cluster queries.
     """
     if values is None:
         return None
     # Use repr-friendly fast path; pgvector parses scientific notation.
-    return "[" + ",".join(format(v, ".7g") for v in values) + "]"
+    return "[" + ",".join(format(v, ".9g") for v in values) + "]"
 
 
 async def _do_insert(

--- a/klai-retrieval-api/retrieval_api/services/tenant_telemetry.py
+++ b/klai-retrieval-api/retrieval_api/services/tenant_telemetry.py
@@ -1,0 +1,129 @@
+"""SPEC-PRIVACY-QUERY-SHADOW-001 — canonical tenant-level lookup.
+
+Retrieval-api must enforce the canonical ``portal_orgs.telemetry_level``
+on every /retrieve call rather than trust the upstream-supplied
+``req.telemetry_level``. The body field is treated as a *requested
+upper bound* — the effective level is ``min(client_requested, canonical)``
+where ``off < shadow < full``.
+
+This closes the gap where:
+
+- A buggy / malicious caller could send ``full`` while the tenant has
+  flipped to ``off`` and still get raw query content persisted.
+- The knowledge-mcp path is privacy-by-default ``shadow`` regardless
+  of tenant choice — but a tenant on ``off`` would still see shadow
+  rows from third-party MCP traffic. With server-side enforcement the
+  canonical ``off`` wins and zero rows are written.
+
+Cache strategy:
+
+- 5-minute in-process TTL keyed by ``zitadel_org_id``. A tenant-flip
+  has up to 5-minute propagation delay to the retrieval-api fleet —
+  acceptable because flips are rare and the canonical lookup error
+  case is a privacy regression (we'd over-strip on a stale ``off``,
+  not under-strip).
+- On cache miss + DB error, fail-OPEN to ``shadow`` (privacy-friendly
+  default). Never default to ``full`` even on error.
+
+Lookup is best-effort: a transient DB blip should not break /retrieve.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Literal
+
+import structlog
+
+from retrieval_api.services.events import get_pool
+
+logger = structlog.get_logger()
+
+TelemetryLevel = Literal["off", "shadow", "full"]
+
+# Total ordering used for the min-resolution.
+# off < shadow < full
+_LEVEL_RANK: dict[TelemetryLevel, int] = {"off": 0, "shadow": 1, "full": 2}
+_RANK_TO_LEVEL: dict[int, TelemetryLevel] = {0: "off", 1: "shadow", 2: "full"}
+
+CACHE_TTL_SECONDS = 300  # 5 minutes
+_CACHE: dict[str, tuple[float, TelemetryLevel]] = {}
+_CACHE_LOCK = asyncio.Lock()
+
+_LOOKUP_SQL = "SELECT telemetry_level::text FROM portal_orgs WHERE zitadel_org_id = $1"
+
+
+async def _fetch_canonical(zitadel_org_id: str) -> TelemetryLevel:
+    """Fetch the org's canonical level from portal_orgs.
+
+    Returns 'shadow' on any error (privacy-friendly default).
+    """
+    pool = get_pool()
+    if pool is None:
+        return "shadow"
+    try:
+        row = await pool.fetchrow(_LOOKUP_SQL, zitadel_org_id)
+    except Exception:
+        logger.warning(
+            "tenant_telemetry_lookup_failed",
+            zitadel_org_id=zitadel_org_id,
+            exc_info=True,
+        )
+        return "shadow"
+    if row is None:
+        # Unknown tenant — privacy-friendly default rather than 'full'.
+        return "shadow"
+    level = row["telemetry_level"]
+    if level not in _LEVEL_RANK:
+        # Defense-in-depth: a future enum value we don't know about
+        # collapses to the safest known mode.
+        logger.warning(
+            "tenant_telemetry_unknown_level",
+            zitadel_org_id=zitadel_org_id,
+            level=level,
+        )
+        return "shadow"
+    return level  # type: ignore[return-value]
+
+
+async def get_canonical_level(zitadel_org_id: str) -> TelemetryLevel:
+    """Cached canonical-level lookup, 5-minute TTL.
+
+    Multiple concurrent calls for the same org coalesce on the cache
+    lock so a cold cache produces exactly one DB hit per tenant per
+    TTL window.
+    """
+    now = time.monotonic()
+    cached = _CACHE.get(zitadel_org_id)
+    if cached is not None and now - cached[0] < CACHE_TTL_SECONDS:
+        return cached[1]
+
+    async with _CACHE_LOCK:
+        # Re-check inside the lock — another waiter may have refreshed.
+        cached = _CACHE.get(zitadel_org_id)
+        if cached is not None and time.monotonic() - cached[0] < CACHE_TTL_SECONDS:
+            return cached[1]
+        level = await _fetch_canonical(zitadel_org_id)
+        _CACHE[zitadel_org_id] = (time.monotonic(), level)
+        return level
+
+
+def resolve_effective_level(
+    client_requested: TelemetryLevel,
+    canonical: TelemetryLevel,
+) -> TelemetryLevel:
+    """Compute the effective level as min(client_requested, canonical).
+
+    The body field is an upper bound, never an override. A caller that
+    sends 'full' against a tenant on 'off' gets 'off'. A caller that
+    sends 'shadow' against a tenant on 'full' stays at 'shadow' (the
+    caller's stricter privacy preference wins).
+    """
+    rank = min(_LEVEL_RANK[client_requested], _LEVEL_RANK[canonical])
+    return _RANK_TO_LEVEL[rank]
+
+
+def _reset_cache_for_tests() -> None:
+    """Clear the in-process cache. Tests only — not exported."""
+    _CACHE.clear()

--- a/klai-retrieval-api/tests/test_telemetry_writer.py
+++ b/klai-retrieval-api/tests/test_telemetry_writer.py
@@ -97,5 +97,9 @@ def test_format_vector_handles_none_and_list() -> None:
 
     assert _format_vector(None) is None
     assert _format_vector([0.1, 0.2]) == "[0.1,0.2]"
-    # Verify the format string strips trailing zeros (more compact wire size).
+    # ``.9g`` strips trailing zeros for compact wire size.
     assert _format_vector([1.0, 2.5e-3]) == "[1,0.0025]"
+    # ``.9g`` preserves the full float32 mantissa: a 7-significant-digit
+    # value round-trips byte-for-byte. ``.7g`` (the previous setting)
+    # would have truncated to "0.123456" and dropped the trailing 8.
+    assert _format_vector([0.12345678]) == "[0.12345678]"

--- a/klai-retrieval-api/tests/test_tenant_telemetry.py
+++ b/klai-retrieval-api/tests/test_tenant_telemetry.py
@@ -1,0 +1,125 @@
+"""SPEC-PRIVACY-QUERY-SHADOW-001 cleanup — canonical level lookup + resolver.
+
+Pure unit tests with mocked asyncpg pool. The cache is module-global,
+so each test resets it via ``_reset_cache_for_tests`` to keep tests
+order-independent.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    from retrieval_api.services import tenant_telemetry as tt
+
+    tt._reset_cache_for_tests()
+    yield
+    tt._reset_cache_for_tests()
+
+
+def test_resolve_min_off_wins_over_full() -> None:
+    """A tenant on 'off' caps any caller-requested level."""
+    from retrieval_api.services.tenant_telemetry import resolve_effective_level
+
+    assert resolve_effective_level("full", "off") == "off"
+    assert resolve_effective_level("shadow", "off") == "off"
+    assert resolve_effective_level("off", "off") == "off"
+
+
+def test_resolve_min_caller_can_be_stricter_than_canonical() -> None:
+    """A privacy-conscious caller's stricter request wins over a permissive tenant."""
+    from retrieval_api.services.tenant_telemetry import resolve_effective_level
+
+    assert resolve_effective_level("shadow", "full") == "shadow"
+    assert resolve_effective_level("off", "full") == "off"
+    assert resolve_effective_level("off", "shadow") == "off"
+
+
+def test_resolve_passthrough_when_levels_match() -> None:
+    from retrieval_api.services.tenant_telemetry import resolve_effective_level
+
+    assert resolve_effective_level("shadow", "shadow") == "shadow"
+    assert resolve_effective_level("full", "full") == "full"
+
+
+@pytest.mark.asyncio
+async def test_canonical_level_returns_db_value(monkeypatch):
+    from retrieval_api.services import tenant_telemetry as tt
+
+    fake_pool = AsyncMock()
+    fake_pool.fetchrow = AsyncMock(return_value={"telemetry_level": "off"})
+    monkeypatch.setattr(tt, "get_pool", lambda: fake_pool)
+
+    level = await tt.get_canonical_level("voys-zit-id")
+    assert level == "off"
+    fake_pool.fetchrow.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_canonical_level_caches_within_ttl(monkeypatch):
+    """A second lookup within TTL hits the cache, not the DB."""
+    from retrieval_api.services import tenant_telemetry as tt
+
+    fake_pool = AsyncMock()
+    fake_pool.fetchrow = AsyncMock(return_value={"telemetry_level": "full"})
+    monkeypatch.setattr(tt, "get_pool", lambda: fake_pool)
+
+    level1 = await tt.get_canonical_level("voys-zit-id")
+    level2 = await tt.get_canonical_level("voys-zit-id")
+    assert level1 == level2 == "full"
+    fake_pool.fetchrow.assert_awaited_once()  # cached on second call
+
+
+@pytest.mark.asyncio
+async def test_canonical_level_fail_open_to_shadow_when_pool_missing(monkeypatch):
+    """No pool (test / cold start) → privacy-friendly default."""
+    from retrieval_api.services import tenant_telemetry as tt
+
+    monkeypatch.setattr(tt, "get_pool", lambda: None)
+
+    level = await tt.get_canonical_level("any-org")
+    assert level == "shadow"
+
+
+@pytest.mark.asyncio
+async def test_canonical_level_fail_open_to_shadow_on_db_error(monkeypatch):
+    """Postgres blip → privacy-friendly default. Never default to 'full' on error."""
+    from retrieval_api.services import tenant_telemetry as tt
+
+    fake_pool = AsyncMock()
+    fake_pool.fetchrow = AsyncMock(side_effect=RuntimeError("connection refused"))
+    monkeypatch.setattr(tt, "get_pool", lambda: fake_pool)
+
+    level = await tt.get_canonical_level("any-org")
+    assert level == "shadow"
+
+
+@pytest.mark.asyncio
+async def test_canonical_level_unknown_org_defaults_to_shadow(monkeypatch):
+    """Tenant not in portal_orgs → privacy-friendly default."""
+    from retrieval_api.services import tenant_telemetry as tt
+
+    fake_pool = AsyncMock()
+    fake_pool.fetchrow = AsyncMock(return_value=None)
+    monkeypatch.setattr(tt, "get_pool", lambda: fake_pool)
+
+    level = await tt.get_canonical_level("unknown-org")
+    assert level == "shadow"
+
+
+@pytest.mark.asyncio
+async def test_canonical_level_unknown_enum_value_collapses_to_shadow(monkeypatch):
+    """Defense-in-depth: a future enum value the code doesn't know about
+    must NOT silently grant 'full'-tier behaviour."""
+    from retrieval_api.services import tenant_telemetry as tt
+
+    fake_pool = AsyncMock()
+    fake_pool.fetchrow = AsyncMock(return_value={"telemetry_level": "future_mode"})
+    monkeypatch.setattr(tt, "get_pool", lambda: fake_pool)
+
+    level = await tt.get_canonical_level("any-org")
+    assert level == "shadow"


### PR DESCRIPTION
## Summary

Post-merge review cleanup of #526. Tightens the privacy contract, makes the anti-leakage processor (REQ-13) actually catch what it advertises, and removes a precision bug in the shadow-store wire format.

## Items addressed (from my own review)

| # | Item | Risk | Files |
|---|---|---|---|
| 1 | **Canonical-level enforcement in retrieval-api** — the body's `telemetry_level` is now treated as a *requested upper bound*; effective level = `min(client_requested, canonical_from_portal_orgs)`. Closes the gap where a buggy caller could send `full` against a tenant on `off`. Also makes the MCP's hardcoded `shadow` correct under all tenant configurations. | MEDIUM | retrieval-api: new `services/tenant_telemetry.py` (cached lookup + resolver), `api/retrieve.py` updated to use `effective_level` everywhere |
| 2 | **UUID4 fallback when `request_id` contextvar missing** — previously silently skipped `write_shadow`, biasing dashboards. Now generates a server-side UUID. | LOW | `api/retrieve.py` |
| 3 | **`_format_vector` precision `.7g` → `.9g`** — `.7g` was on the edge of float32 precision and could degrade cosine similarity in cluster queries. | LOW | `services/telemetry.py` + test |
| 4 | **Bind `telemetry_level` on structlog contextvar** in retrieve.py so REQ-13's anti-leakage processor sees it on every log line, not only the explicit `decision_record` event. | MEDIUM | `api/retrieve.py` + new integration test in log-utils |
| 5 | **Simplify pyright workaround** in `telemetry_purge.py` — drop the redundant `hasattr` guard. | STYLE | `services/telemetry_purge.py` |

## Architectural note on #1 (the meaningful change)

Before this PR, every gating decision in retrieval-api used `req.telemetry_level` from the body. Three risks:

- **Trust boundary**: caller-supplied input drives a privacy decision. A bug or malicious actor in the litellm-hook could send `full` while the tenant sits at `off`.
- **MCP inconsistency**: knowledge-mcp hardcodes `shadow` regardless of tenant level. A tenant on `off` would still get shadow rows from MCP traffic — violation of the contract documented to that tenant.
- **Defense-in-depth**: spec.md REQ-8 explicitly says "double check — never trust an upstream-supplied value for security gates that depend on tenant config" for portal-api's gap-events handler. Retrieval-api had the same exposure but didn't enforce.

The fix introduces a tiny module:

```
async def get_canonical_level(zitadel_org_id) -> TelemetryLevel
def resolve_effective_level(client_requested, canonical) -> TelemetryLevel
```

with `min` ordering (`off < shadow < full`), 5-minute in-process cache (TTL acceptable because flips are rare and the error case is "we over-strip on stale `off`", which is the privacy-friendly direction).

Fail-open behavior: DB error / unknown tenant / unknown enum value → `shadow`. **Never** defaults to `full` on error.

## Test results

- retrieval-api: **21/21** privacy tests (incl. **9 new** for tenant_telemetry)
- portal-api SPEC: **19/19**
- log-utils: **8/8** (incl. **1 new** integration test for contextvar → processor binding)
- litellm-hook: **65/65**
- knowledge-mcp: **25/25**

ruff + format + pyright clean on changed files.

## Pre-existing pyright errors (NOT introduced here)

`klai-retrieval-api/retrieval_api/api/retrieve.py:522 / 535` — `serving` and `expanded_in_top_k_ids` possibly unbound. Verified present on `main` independent of this PR. Out of scope here; flag for separate cleanup.

## Rollback

Each fix is independent. Reverting the whole PR is safe — gating falls back to body-driven (as before #526), MCP returns to "always shadow body", precision returns to `.7g`. No data loss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)