### PR TITLE
feat(portal): RBAC Phase 2a — admin/{users,settings,products,retry_provisioning} sweep

### DIFF
--- a/klai-portal/backend/app/api/admin/products.py
+++ b/klai-portal/backend/app/api/admin/products.py
@@ -10,17 +10,15 @@ them for the assignable-products list and the per-user effective view.
 from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from fastapi.security import HTTPAuthorizationCredentials
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import get_db
 from app.core.features import derive_user_products
+from app.core.permissions import ProfileRole, UserPermissions, get_caller_at_least
 from app.models.portal import PortalUser
 from app.services.entitlements import get_effective_products
-
-from . import _get_caller_org, _require_admin, bearer
 
 router = APIRouter()
 
@@ -56,41 +54,57 @@ class EffectiveProductsResponse(BaseModel):
 
 @router.get("/products", response_model=ProductsResponse)
 async def list_available_products(
-    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
 ) -> ProductsResponse:
-    """Return products available to the caller given (profile, org plan, enabled add-ons)."""
-    _, org, caller_user = await _get_caller_org(credentials, db)
-    _require_admin(caller_user)
-    products = derive_user_products(
-        role=caller_user.role,
-        plan=org.plan,
-        enabled_addons=list(org.enabled_addons or []),
-    )
-    return ProductsResponse(products=sorted(products))
+    """Return products available to the caller given (profile, org plan, enabled add-ons).
+
+    UserPermissions already carries `effective_products` derived from the
+    same (role, plan, enabled_addons) input — return that instead of
+    re-deriving. Equivalent to calling `derive_user_products` from this
+    handler in earlier code, just sourced one layer up.
+    """
+    return ProductsResponse(products=sorted(perms.effective_products))
 
 
 @router.get("/users/{zitadel_user_id}/effective-products", response_model=EffectiveProductsResponse)
 async def get_user_effective_products(
     zitadel_user_id: str,
-    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
 ) -> EffectiveProductsResponse:
     """Return effective products for a user with source attribution (plan or addon)."""
-    _, org, caller_user = await _get_caller_org(credentials, db)
-    _require_admin(caller_user)
-
     target = await db.scalar(
         select(PortalUser).where(
             PortalUser.zitadel_user_id == zitadel_user_id,
-            PortalUser.org_id == org.id,
+            PortalUser.org_id == perms.org_id,
         )
     )
     if not target:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
-    effective = await get_effective_products(zitadel_user_id, db)
-    enabled_addons = set(org.enabled_addons or [])
+    # Derive products specifically for the TARGET user with the caller's
+    # tenant config — same shape `get_effective_products` would return,
+    # but routed through `derive_user_products` so we can also classify
+    # each product as plan- vs addon-sourced for the response.
+    effective = sorted(
+        derive_user_products(
+            role=target.role,
+            plan=perms.plan,
+            enabled_addons=list(perms.enabled_addons),
+        )
+    )
+    enabled_addons = set(perms.enabled_addons)
+    # Keep the canonical resolver as a sanity sentinel so any future drift
+    # between derive_user_products and get_effective_products surfaces here
+    # rather than at the user-visible response.
+    canonical = await get_effective_products(zitadel_user_id, db)
+    if set(canonical) != set(effective):
+        # Resolver disagreement is a developer-facing bug, not user input.
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="effective products derivation mismatch",
+        )
     return EffectiveProductsResponse(
         products=[
             EffectiveProductOut(

--- a/klai-portal/backend/app/api/admin/retry_provisioning.py
+++ b/klai-portal/backend/app/api/admin/retry_provisioning.py
@@ -26,12 +26,11 @@ from __future__ import annotations
 
 import structlog
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
-from fastapi.security import HTTPAuthorizationCredentials
 from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.admin import _get_caller_org, _require_admin, _require_platform_admin, bearer
 from app.core.database import get_db
+from app.core.permissions import UserPermissions, require_platform_admin
 from app.models.portal import PortalOrg
 from app.services.audit import log_event
 from app.services.provisioning.orchestrator import provision_tenant
@@ -48,7 +47,7 @@ router = APIRouter()
 async def retry_provisioning(
     slug: str,
     background_tasks: BackgroundTasks,
-    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    perms: UserPermissions = Depends(require_platform_admin()),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, str]:
     """Retry provisioning for an org in `failed_rollback_complete` state.
@@ -58,15 +57,14 @@ async def retry_provisioning(
         - `manual_cleanup_required` (failed_rollback_pending)
         - `not_in_retryable_state` (any other non-failed state)
         - `slug_in_use_by_new_org` (another active row claimed this slug)
-    Returns 403 if caller is not an admin.
+    Returns 403 if caller is not a platform-admin.
     Returns 404 if no failed row with this slug exists.
+
+    audit-tenant-isolation-2026-05-05 finding C-2: this endpoint operates on
+    an arbitrary tenant `slug` (the failed-row may belong to ANY tenant, not
+    just the caller's). The `require_platform_admin()` dependency enforces
+    the cross-tenant gate (admin role + platform-admin org).
     """
-    _, _caller_org, caller_user = await _get_caller_org(credentials, db)
-    _require_admin(caller_user)
-    # audit-tenant-isolation-2026-05-05 finding C-2: this endpoint operates on
-    # an arbitrary tenant `slug` (the failed-row may belong to ANY tenant, not
-    # just the caller's). Gate cross-tenant actions on platform-admin org.
-    _require_platform_admin(_caller_org)
 
     # Find the failed row for this slug. Because the partial unique index only
     # enforces uniqueness over active rows, there MAY be multiple rows sharing
@@ -164,8 +162,8 @@ async def retry_provisioning(
         "provisioning_retry_queued",
         org_id=failed_org.id,
         slug=slug,
-        admin_user=caller_user.zitadel_user_id,
-        platform_admin_org_id=_caller_org.id,
+        admin_user=perms.user_id,
+        platform_admin_org_id=perms.org_id,
     )
 
     # Audit-trail (audit-tenant-isolation-2026-05-05 C-2): platform-admin
@@ -174,14 +172,14 @@ async def retry_provisioning(
     # path raises later.
     await log_event(
         org_id=failed_org.id,
-        actor=caller_user.zitadel_user_id,
+        actor=perms.user_id,
         action="retry_provisioning",
         resource_type="portal_org",
         resource_id=str(failed_org.id),
         details={
             "slug": slug,
-            "platform_admin_org_id": _caller_org.id,
-            "platform_admin_org_slug": _caller_org.slug,
+            "platform_admin_org_id": perms.org_id,
+            "platform_admin_org_slug": perms.org_slug,
         },
     )
 

--- a/klai-portal/backend/app/api/admin/settings.py
+++ b/klai-portal/backend/app/api/admin/settings.py
@@ -4,16 +4,15 @@ import logging
 from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from fastapi.security import HTTPAuthorizationCredentials
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import get_db
 from app.core.features import ADDON_FEATURES, PLAN_FEATURES
+from app.core.permissions import ProfileRole, UserPermissions, get_caller_at_least
+from app.models.portal import PortalOrg
 from app.services.audit import log_event
 from app.services.events import emit_event
-
-from . import _get_caller_org, _require_admin, bearer
 
 logger = logging.getLogger(__name__)
 
@@ -62,13 +61,30 @@ class PlanChangeRequest(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+async def _load_org_or_500(db: AsyncSession, org_id: int) -> PortalOrg:
+    """Fetch the caller's PortalOrg ORM row.
+
+    UserPermissions only carries `org_id`/`org_slug`/`plan`/`enabled_addons`/
+    `platform_unlocked_features`. Endpoints that need other PortalOrg fields
+    (name, default_language, mfa_policy, primary_domain, telemetry_level,
+    auto_accept_same_domain) re-fetch the row through this helper. The
+    tenant GUC is already set by `get_caller`, so RLS on portal_orgs is fine.
+    """
+    org = await db.get(PortalOrg, org_id)
+    if org is None:
+        # get_caller resolved the org just before this; a missing row means
+        # something deleted it mid-request. Treat as 500 — the resolver and
+        # this endpoint disagree on reality.
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Organisation row vanished")
+    return org
+
+
 @router.get("/settings", response_model=OrgSettingsOut)
 async def get_org_settings(
-    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
 ) -> OrgSettingsOut:
-    _, org, caller_user = await _get_caller_org(credentials, db)
-    _require_admin(caller_user)
+    org = await _load_org_or_500(db, perms.org_id)
     return OrgSettingsOut(
         name=org.name,
         default_language=org.default_language,
@@ -82,11 +98,10 @@ async def get_org_settings(
 @router.patch("/settings", response_model=OrgSettingsOut)
 async def update_org_settings(
     body: OrgSettingsUpdate,
-    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
 ) -> OrgSettingsOut:
-    _, org, caller_user = await _get_caller_org(credentials, db)
-    _require_admin(caller_user)
+    org = await _load_org_or_500(db, perms.org_id)
     if body.default_language is not None:
         org.default_language = body.default_language
     if body.mfa_policy is not None:
@@ -95,7 +110,7 @@ async def update_org_settings(
     if body.auto_accept_same_domain is not None:
         org.auto_accept_same_domain = body.auto_accept_same_domain
     await db.commit()
-    logger.info("Org settings updated: org_id=%d", org.id)
+    logger.info("Org settings updated: org_id=%d", perms.org_id)
     return OrgSettingsOut(
         name=org.name,
         default_language=org.default_language,
@@ -109,7 +124,7 @@ async def update_org_settings(
 @router.patch("/plan", response_model=MessageResponse)
 async def change_plan(
     body: PlanChangeRequest,
-    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
 ) -> MessageResponse:
     """Upgrade or downgrade org plan.
@@ -119,14 +134,12 @@ async def change_plan(
     feature set on the next request. No per-user/group product cleanup
     needed -- those tables are no longer the source of truth.
     """
-    _, org, caller_user = await _get_caller_org(credentials, db)
-    _require_admin(caller_user)
-
     new_plan = body.plan
 
     if new_plan not in PLAN_FEATURES:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Unknown plan: {new_plan}")
 
+    org = await _load_org_or_500(db, perms.org_id)
     org.plan = new_plan
     await db.commit()
     return MessageResponse(message=f"Plan bijgewerkt naar {new_plan}.")
@@ -147,19 +160,17 @@ class AddonsUpdate(BaseModel):
 
 @router.get("/settings/addons", response_model=AddonsOut)
 async def get_addons(
-    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
 ) -> AddonsOut:
     """Return the tenant's currently enabled add-ons."""
-    _, org, caller_user = await _get_caller_org(credentials, db)
-    _require_admin(caller_user)
-    return AddonsOut(enabled_addons=list(org.enabled_addons or []))
+    return AddonsOut(enabled_addons=list(perms.enabled_addons))
 
 
 @router.patch("/settings/addons", response_model=AddonsOut)
 async def update_addons(
     body: AddonsUpdate,
-    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
 ) -> AddonsOut:
     """Enable or disable tenant-level add-ons.
@@ -171,9 +182,6 @@ async def update_addons(
     # entitlement tables to keep in sync. Disabling an add-on simply
     # stops surfacing it to the derivation function on the next request.
     """
-    admin_user_id, org, caller_user = await _get_caller_org(credentials, db)
-    _require_admin(caller_user)
-
     unknown = [p for p in body.enabled_addons if p not in ADDON_FEATURES]
     if unknown:
         raise HTTPException(
@@ -181,6 +189,7 @@ async def update_addons(
             detail=f"Unknown add-on product(s): {unknown}. Valid: {sorted(ADDON_FEATURES)}",
         )
 
+    org = await _load_org_or_500(db, perms.org_id)
     before = list(org.enabled_addons or [])
     after = list(body.enabled_addons)
 
@@ -190,19 +199,19 @@ async def update_addons(
     removed = sorted(set(before) - set(after))
 
     await log_event(
-        org_id=org.id,
-        actor=admin_user_id,
+        org_id=perms.org_id,
+        actor=perms.user_id,
         action="addons.updated",
         resource_type="org",
-        resource_id=str(org.id),
+        resource_id=str(perms.org_id),
         details={"before": before, "after": after, "added": added, "removed": removed},
     )
     await db.commit()
 
     emit_event(
         "tenant.addons_updated",
-        org_id=org.id,
-        user_id=admin_user_id,
+        org_id=perms.org_id,
+        user_id=perms.user_id,
         properties={"enabled_addons": after, "added": added, "removed": removed},
     )
 

--- a/klai-portal/backend/app/api/admin/users.py
+++ b/klai-portal/backend/app/api/admin/users.py
@@ -7,20 +7,23 @@ from typing import Final, Literal
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, status
-from fastapi.security import HTTPAuthorizationCredentials
 from pydantic import BaseModel, EmailStr
 from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.core.database import get_db
+from app.core.permissions import (
+    ProfileRole,
+    UserPermissions,
+    get_caller,
+    get_caller_at_least,
+)
 from app.models.groups import PortalGroup, PortalGroupMembership
 from app.models.portal import PortalOrg, PortalUser
 from app.services.audit import log_event
 from app.services.github import remove_github_org_member
 from app.services.zitadel import zitadel
-
-from . import _get_caller_org, _require_admin, bearer
 
 logger = logging.getLogger(__name__)
 # Structured-event logger for VictoriaLogs queryability — follows the
@@ -111,14 +114,13 @@ class MessageResponse(BaseModel):
 
 @router.get("/users", response_model=UsersResponse)
 async def list_users(
-    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
 ) -> UsersResponse:
-    _, org, caller_user = await _get_caller_org(credentials, db)
-    _require_admin(caller_user)
-
     # Get portal membership records (mapping + created_at + role)
-    result = await db.execute(select(PortalUser).where(PortalUser.org_id == org.id).order_by(PortalUser.created_at))
+    result = await db.execute(
+        select(PortalUser).where(PortalUser.org_id == perms.org_id).order_by(PortalUser.created_at)
+    )
     portal_users = {u.zitadel_user_id: u for u in result.scalars().all()}
 
     if not portal_users:
@@ -155,14 +157,11 @@ async def list_users(
 @router.post("/users/invite", response_model=InviteResponse, status_code=status.HTTP_201_CREATED)
 async def invite_user(
     body: InviteRequest,
-    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
 ) -> InviteResponse:
-    _, org, caller_user = await _get_caller_org(credentials, db)
-    _require_admin(caller_user)
-
     # Seat enforcement: lock the org row to prevent concurrent invites
-    locked_result = await db.execute(select(PortalOrg).where(PortalOrg.id == org.id).with_for_update())
+    locked_result = await db.execute(select(PortalOrg).where(PortalOrg.id == perms.org_id).with_for_update())
     org = locked_result.scalar_one()
 
     # TODO: filter by status == 'active' once AUTH-001 adds status column
@@ -270,16 +269,13 @@ async def invite_user(
 async def update_user(
     zitadel_user_id: str,
     body: UserUpdateRequest,
-    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
 ) -> MessageResponse:
-    _, org, caller_user = await _get_caller_org(credentials, db)
-    _require_admin(caller_user)
-
     result = await db.execute(
         select(PortalUser).where(
             PortalUser.zitadel_user_id == zitadel_user_id,
-            PortalUser.org_id == org.id,
+            PortalUser.org_id == perms.org_id,
         )
     )
     user = result.scalar_one_or_none()
@@ -310,7 +306,7 @@ async def update_user(
 async def update_user_role(
     zitadel_user_id: str,
     body: RoleUpdateRequest,
-    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
 ) -> MessageResponse:
     """SPEC-PORTAL-ADMIN-UI-001 REQ-2: unified change-profile endpoint.
@@ -319,19 +315,16 @@ async def update_user_role(
     the new admin UI cannot lock a tenant out of its own workspace. Mirrors
     the invariant that POST /demote-admin already enforces.
     """
-    _, org, caller_user = await _get_caller_org(credentials, db)
-    _require_admin(caller_user)
-
     # @MX:ANCHOR SPEC-PORTAL-ADMIN-UI-001 REQ-2 — min-1-admin invariant.
     # @MX:REASON Without serialised role changes two concurrent admin->X
     # patches that both see admin_count=2 can each succeed and leave the
     # workspace with zero admins.
-    await _lock_org_for_role_change(db, org.id)
+    await _lock_org_for_role_change(db, perms.org_id)
 
     result = await db.execute(
         select(PortalUser).where(
             PortalUser.zitadel_user_id == zitadel_user_id,
-            PortalUser.org_id == org.id,
+            PortalUser.org_id == perms.org_id,
         )
     )
     user = result.scalar_one_or_none()
@@ -344,7 +337,7 @@ async def update_user_role(
             select(func.count())
             .select_from(PortalUser)
             .where(
-                PortalUser.org_id == org.id,
+                PortalUser.org_id == perms.org_id,
                 PortalUser.role == "admin",
             )
         )
@@ -356,7 +349,7 @@ async def update_user_role(
 
     user.role = body.role
     await db.commit()
-    logger.info("Role changed: user_id=%s, new_role=%s, org_id=%d", zitadel_user_id, body.role, org.id)
+    logger.info("Role changed: user_id=%s, new_role=%s, org_id=%d", zitadel_user_id, body.role, perms.org_id)
 
     return MessageResponse(message="Rol bijgewerkt.")
 
@@ -364,16 +357,13 @@ async def update_user_role(
 @router.post("/users/{zitadel_user_id}/resend-invite", response_model=MessageResponse)
 async def resend_invite(
     zitadel_user_id: str,
-    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
 ) -> MessageResponse:
-    _, org, caller_user = await _get_caller_org(credentials, db)
-    _require_admin(caller_user)
-
     result = await db.execute(
         select(PortalUser).where(
             PortalUser.zitadel_user_id == zitadel_user_id,
-            PortalUser.org_id == org.id,
+            PortalUser.org_id == perms.org_id,
         )
     )
     if not result.scalar_one_or_none():
@@ -396,17 +386,14 @@ async def resend_invite(
 @router.delete("/users/{zitadel_user_id}", response_model=MessageResponse)
 async def remove_user(
     zitadel_user_id: str,
-    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
 ) -> MessageResponse:
-    _, org, caller_user = await _get_caller_org(credentials, db)
-    _require_admin(caller_user)
-
     # Verify user belongs to this org before deleting
     result = await db.execute(
         select(PortalUser).where(
             PortalUser.zitadel_user_id == zitadel_user_id,
-            PortalUser.org_id == org.id,
+            PortalUser.org_id == perms.org_id,
         )
     )
     user = result.scalar_one_or_none()
@@ -431,17 +418,14 @@ async def remove_user(
 @router.post("/users/{zitadel_user_id}/suspend", response_model=MessageResponse)
 async def suspend_user(
     zitadel_user_id: str,
-    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
 ) -> MessageResponse:
     """Suspend an active user. Preserves group memberships and products."""
-    caller_id, org, caller_user = await _get_caller_org(credentials, db)
-    _require_admin(caller_user)
-
     result = await db.execute(
         select(PortalUser).where(
             PortalUser.zitadel_user_id == zitadel_user_id,
-            PortalUser.org_id == org.id,
+            PortalUser.org_id == perms.org_id,
         )
     )
     user = result.scalar_one_or_none()
@@ -455,8 +439,8 @@ async def suspend_user(
 
     user.status = "suspended"
     await log_event(
-        org_id=org.id,
-        actor=caller_id,
+        org_id=perms.org_id,
+        actor=perms.user_id,
         action="user.suspended",
         resource_type="user",
         resource_id=zitadel_user_id,
@@ -468,17 +452,14 @@ async def suspend_user(
 @router.post("/users/{zitadel_user_id}/reactivate", response_model=MessageResponse)
 async def reactivate_user(
     zitadel_user_id: str,
-    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
 ) -> MessageResponse:
     """Reactivate a suspended user."""
-    _, org, caller_user = await _get_caller_org(credentials, db)
-    _require_admin(caller_user)
-
     result = await db.execute(
         select(PortalUser).where(
             PortalUser.zitadel_user_id == zitadel_user_id,
-            PortalUser.org_id == org.id,
+            PortalUser.org_id == perms.org_id,
         )
     )
     user = result.scalar_one_or_none()
@@ -498,17 +479,14 @@ async def reactivate_user(
 @router.post("/users/{zitadel_user_id}/offboard", response_model=MessageResponse)
 async def offboard_user(
     zitadel_user_id: str,
-    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
 ) -> MessageResponse:
     """Offboard a user: remove memberships + products, deactivate in Zitadel, set status."""
-    caller_id, org, caller_user = await _get_caller_org(credentials, db)
-    _require_admin(caller_user)
-
     result = await db.execute(
         select(PortalUser).where(
             PortalUser.zitadel_user_id == zitadel_user_id,
-            PortalUser.org_id == org.id,
+            PortalUser.org_id == perms.org_id,
         )
     )
     user = result.scalar_one_or_none()
@@ -528,7 +506,7 @@ async def offboard_user(
     membership_delete_result = await db.execute(
         delete(PortalGroupMembership).where(
             PortalGroupMembership.zitadel_user_id == zitadel_user_id,
-            PortalGroupMembership.group_id.in_(select(PortalGroup.id).where(PortalGroup.org_id == org.id)),
+            PortalGroupMembership.group_id.in_(select(PortalGroup.id).where(PortalGroup.org_id == perms.org_id)),
         )
     )
     # AsyncSession.execute() is typed as Result[Any]; the rowcount attribute
@@ -543,13 +521,13 @@ async def offboard_user(
     # `memberships_removed_count:<n>` in LogsQL) — not under an `extra` blob.
     _slog.info(
         "user_offboarded",
-        org_id=org.id,
+        org_id=perms.org_id,
         zitadel_user_id=zitadel_user_id,
         memberships_removed_count=memberships_removed_count,
     )
     await log_event(
-        org_id=org.id,
-        actor=caller_id,
+        org_id=perms.org_id,
+        actor=perms.user_id,
         action="user.offboarded",
         resource_type="user",
         resource_id=zitadel_user_id,
@@ -573,17 +551,14 @@ from app.services.events import emit_event  # noqa: E402 -- late import to avoid
 @router.post("/users/{zitadel_user_id}/promote-admin", response_model=MessageResponse)
 async def promote_admin(
     zitadel_user_id: str,
-    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
 ) -> MessageResponse:
     """C6.1: Promote an active member to admin. No max-admin limit."""
-    caller_id, org, caller_user = await _get_caller_org(credentials, db)
-    _require_admin(caller_user)
-
     result = await db.execute(
         select(PortalUser).where(
             PortalUser.zitadel_user_id == zitadel_user_id,
-            PortalUser.org_id == org.id,
+            PortalUser.org_id == perms.org_id,
         )
     )
     target = result.scalar_one_or_none()
@@ -594,11 +569,11 @@ async def promote_admin(
     await db.commit()
     logger.info(
         "promote_admin: actor=%s promoted user=%s in org=%d",
-        caller_id,
+        perms.user_id,
         zitadel_user_id,
-        org.id,
+        perms.org_id,
     )
-    emit_event("user.role_promoted", org_id=org.id, user_id=zitadel_user_id)
+    emit_event("user.role_promoted", org_id=perms.org_id, user_id=zitadel_user_id)
     return MessageResponse(message=f"User {zitadel_user_id} promoted to admin.")
 
 
@@ -619,20 +594,17 @@ async def _lock_org_for_role_change(db: AsyncSession, org_id: int) -> None:
 @router.post("/users/{zitadel_user_id}/demote-admin", response_model=MessageResponse)
 async def demote_admin(
     zitadel_user_id: str,
-    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
 ) -> MessageResponse:
     """C6.2: Demote an admin to member. Refuses if this would leave zero admins."""
-    caller_id, org, caller_user = await _get_caller_org(credentials, db)
-    _require_admin(caller_user)
-
     # Serialise concurrent role changes for this org (see _lock_org_for_role_change).
-    await _lock_org_for_role_change(db, org.id)
+    await _lock_org_for_role_change(db, perms.org_id)
 
     result = await db.execute(
         select(PortalUser).where(
             PortalUser.zitadel_user_id == zitadel_user_id,
-            PortalUser.org_id == org.id,
+            PortalUser.org_id == perms.org_id,
         )
     )
     target = result.scalar_one_or_none()
@@ -649,7 +621,7 @@ async def demote_admin(
         select(func.count())
         .select_from(PortalUser)
         .where(
-            PortalUser.org_id == org.id,
+            PortalUser.org_id == perms.org_id,
             PortalUser.role == "admin",
         )
     )
@@ -666,33 +638,31 @@ async def demote_admin(
     await db.commit()
     logger.info(
         "demote_admin: actor=%s demoted user=%s in org=%d",
-        caller_id,
+        perms.user_id,
         zitadel_user_id,
-        org.id,
+        perms.org_id,
     )
-    emit_event("user.role_demoted", org_id=org.id, user_id=zitadel_user_id)
+    emit_event("user.role_demoted", org_id=perms.org_id, user_id=zitadel_user_id)
     return MessageResponse(message=f"User {zitadel_user_id} demoted to company.")
 
 
 @router.delete("/users/me", response_model=MessageResponse)
 async def leave_workspace(
-    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    perms: UserPermissions = Depends(get_caller),
     db: AsyncSession = Depends(get_db),
 ) -> MessageResponse:
     """C6.3: Leave the workspace (self-removal). Refuses if caller is last admin.
     C6.7: Refuses if this would leave the workspace with zero users (last-member case).
     """
-    caller_id, org, caller_user = await _get_caller_org(credentials, db)
-
-    if caller_user.role == "admin":
+    if perms.role == ProfileRole.ADMIN:
         # Serialise concurrent role changes for this org (see _lock_org_for_role_change).
-        await _lock_org_for_role_change(db, org.id)
+        await _lock_org_for_role_change(db, perms.org_id)
 
         admin_count = await db.scalar(
             select(func.count())
             .select_from(PortalUser)
             .where(
-                PortalUser.org_id == org.id,
+                PortalUser.org_id == perms.org_id,
                 PortalUser.role == "admin",
             )
         )
@@ -702,8 +672,17 @@ async def leave_workspace(
                 detail="Promote another admin or delete the workspace before leaving.",
             )
 
+    # Re-fetch the caller's PortalUser ORM-object for db.delete. UserPermissions
+    # is a snapshot, not the ORM row.
+    caller_row_result = await db.execute(
+        select(PortalUser).where(
+            PortalUser.zitadel_user_id == perms.user_id,
+            PortalUser.org_id == perms.org_id,
+        )
+    )
+    caller_user = caller_row_result.scalar_one()
     await db.delete(caller_user)
     await db.commit()
-    logger.info("leave_workspace: user=%s left org=%d", caller_id, org.id)
-    emit_event("user.left_workspace", org_id=org.id, user_id=caller_id)
+    logger.info("leave_workspace: user=%s left org=%d", perms.user_id, perms.org_id)
+    emit_event("user.left_workspace", org_id=perms.org_id, user_id=perms.user_id)
     return MessageResponse(message="You have left the workspace.")

--- a/klai-portal/backend/app/core/permissions.py
+++ b/klai-portal/backend/app/core/permissions.py
@@ -290,12 +290,16 @@ def require_capability(capability: Capability):
 
 
 def require_platform_admin():
-    """Factory: dependency that requires the caller to be in the platform org
-    (``settings.platform_org_slug``).
+    """Factory: dependency that requires the caller to be an ADMIN in the
+    platform org (``settings.platform_org_slug``).
 
-    Equivalent of ``admin/__init__::_require_platform_admin(caller_org)`` for
-    declarative use. Sub-domain endpoints (retry-provisioning, deprovision,
-    platform-locked feature toggles) call this.
+    Equivalent of the imperative pair ``_require_admin(caller_user) +
+    _require_platform_admin(caller_org)`` that every callsite uses today
+    (`retry_provisioning`, `deprovision_org`, future Phase 5 platform-unlock
+    endpoints). Both checks must pass: a non-admin user inside the platform
+    org gets 403 just like an admin in a regular tenant — the SPEC's intent
+    is "Klai staff acting administratively", not "anyone in the Klai
+    workspace".
     """
 
     async def _dep(perms: UserPermissions = Depends(get_caller)) -> UserPermissions:
@@ -303,6 +307,11 @@ def require_platform_admin():
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Access denied: platform admin org required",
+            )
+        if perms.effective_role != ProfileRole.ADMIN:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Access denied: admin role required for platform actions",
             )
         return perms
 

--- a/klai-portal/backend/tests/conftest.py
+++ b/klai-portal/backend/tests/conftest.py
@@ -210,3 +210,57 @@ def make_org(
     org.billing_status = "active"
     org.mcp_servers = []
     return org
+
+
+def make_perms(
+    *,
+    role: object = "admin",
+    user_id: str = "uid-test",
+    org_id: int = 101,
+    org_slug: str = "voys",
+    plan: str = "complete",
+    enabled_addons: list[str] | None = None,
+    platform_unlocked_features: list[str] | None = None,
+    is_platform_admin: bool = False,
+    provisioning_status: str = "active",
+):
+    """Synthetic UserPermissions for endpoints that take ``perms=`` directly.
+
+    Replaces the legacy ``patch("..._get_caller_org", return_value=(uid, org,
+    user))`` test pattern. Produces a frozen ``UserPermissions`` with derived
+    capabilities + products consistent with the other inputs.
+    """
+    from app.core.features import derive_user_products
+    from app.core.permissions import UserPermissions
+    from app.core.plan_limits import get_plan_limits
+    from app.core.profiles import PROFILE_CAPABILITIES, Capability, ProfileRole
+
+    role_enum = role if isinstance(role, ProfileRole) else ProfileRole(str(role))
+    addons = frozenset(enabled_addons or [])
+    plat_features = frozenset(platform_unlocked_features or [])
+
+    if role_enum == ProfileRole.ADMIN:
+        complete_caps = get_plan_limits("complete").capabilities
+        eff_caps = frozenset(Capability(c) for c in complete_caps)
+    else:
+        role_caps = PROFILE_CAPABILITIES.get(role_enum.value, frozenset())
+        plan_caps = get_plan_limits(plan).capabilities
+        eff_caps = frozenset(Capability(c) for c in (set(role_caps) & set(plan_caps)))
+
+    eff_products = frozenset(derive_user_products(role_enum.value, plan, list(addons)))
+
+    return UserPermissions(
+        user_id=user_id,
+        org_id=org_id,
+        org_slug=org_slug,
+        role=role_enum,
+        plan=plan,
+        enabled_addons=addons,
+        platform_unlocked_features=plat_features,
+        effective_role=role_enum,
+        effective_capabilities=eff_caps,
+        effective_products=eff_products,
+        effective_kb_limits=get_plan_limits(plan),
+        is_platform_admin=is_platform_admin,
+        provisioning_status=provisioning_status,
+    )

--- a/klai-portal/backend/tests/test_admin_addons.py
+++ b/klai-portal/backend/tests/test_admin_addons.py
@@ -3,12 +3,20 @@
 After RBAC-001, the add-on toggles are the *only* state needed -- no
 group-membership / per-user-product side-effects on update_addons. These
 tests cover the get + patch endpoints.
+
+SPEC-PORTAL-RBAC-REFACTOR-001 Phase 2a: endpoints now take
+``perms: UserPermissions`` directly (no more ``_get_caller_org`` patch).
+The rol-gate (admin-only) is enforced declaratively by
+``Depends(get_caller_at_least(ProfileRole.ADMIN))`` — that branch is
+covered in `test_permissions.py::test_get_caller_at_least_role_matrix`.
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
+
+from tests.conftest import make_perms
 
 
 def _mock_org(enabled_addons: list[str] | None = None, plan: str = "core") -> MagicMock:
@@ -19,31 +27,21 @@ def _mock_org(enabled_addons: list[str] | None = None, plan: str = "core") -> Ma
     return org
 
 
-def _mock_caller(role: str = "admin") -> MagicMock:
-    caller = MagicMock()
-    caller.role = role
-    return caller
-
-
 class TestGetAddons:
     @pytest.mark.asyncio
     async def test_returns_current_state(self) -> None:
         from app.api.admin.settings import get_addons
 
-        org = _mock_org(enabled_addons=["scribe"])
-        caller = _mock_caller()
-        with patch("app.api.admin.settings._get_caller_org", return_value=("admin-1", org, caller)):
-            result = await get_addons(credentials=MagicMock(), db=AsyncMock())
+        perms = make_perms(role="admin", org_id=42, enabled_addons=["scribe"])
+        result = await get_addons(perms=perms, db=AsyncMock())
         assert result.enabled_addons == ["scribe"]
 
     @pytest.mark.asyncio
     async def test_returns_empty_list_by_default(self) -> None:
         from app.api.admin.settings import get_addons
 
-        org = _mock_org(enabled_addons=[])
-        caller = _mock_caller()
-        with patch("app.api.admin.settings._get_caller_org", return_value=("admin-1", org, caller)):
-            result = await get_addons(credentials=MagicMock(), db=AsyncMock())
+        perms = make_perms(role="admin", org_id=42, enabled_addons=[])
+        result = await get_addons(perms=perms, db=AsyncMock())
         assert result.enabled_addons == []
 
 
@@ -53,15 +51,15 @@ class TestUpdateAddons:
         from app.api.admin.settings import AddonsUpdate, update_addons
 
         org = _mock_org(enabled_addons=[])
-        caller = _mock_caller()
+        perms = make_perms(role="admin", org_id=42, enabled_addons=[])
         mock_db = AsyncMock()
+        mock_db.get = AsyncMock(return_value=org)
         body = AddonsUpdate(enabled_addons=["scribe"])
         with (
-            patch("app.api.admin.settings._get_caller_org", return_value=("admin-1", org, caller)),
             patch("app.api.admin.settings.log_event", new=AsyncMock()),
             patch("app.api.admin.settings.emit_event") as mock_emit,
         ):
-            result = await update_addons(body=body, credentials=MagicMock(), db=mock_db)
+            result = await update_addons(body=body, perms=perms, db=mock_db)
         assert result.enabled_addons == ["scribe"]
         assert org.enabled_addons == ["scribe"]
         mock_db.commit.assert_called_once()
@@ -71,12 +69,10 @@ class TestUpdateAddons:
     async def test_patch_unknown_addon_returns_400(self) -> None:
         from app.api.admin.settings import AddonsUpdate, update_addons
 
-        org = _mock_org()
-        caller = _mock_caller()
+        perms = make_perms(role="admin", org_id=42)
         body = AddonsUpdate(enabled_addons=["hacker_product"])
-        with patch("app.api.admin.settings._get_caller_org", return_value=("admin-1", org, caller)):
-            with pytest.raises(HTTPException) as exc_info:
-                await update_addons(body=body, credentials=MagicMock(), db=AsyncMock())
+        with pytest.raises(HTTPException) as exc_info:
+            await update_addons(body=body, perms=perms, db=AsyncMock())
         assert exc_info.value.status_code == 400
         assert "hacker_product" in str(exc_info.value.detail)
 
@@ -85,14 +81,15 @@ class TestUpdateAddons:
         from app.api.admin.settings import AddonsUpdate, update_addons
 
         org = _mock_org()
-        caller = _mock_caller()
+        perms = make_perms(role="admin", org_id=42)
+        mock_db = AsyncMock()
+        mock_db.get = AsyncMock(return_value=org)
         body = AddonsUpdate(enabled_addons=["scribe", "docs"])
         with (
-            patch("app.api.admin.settings._get_caller_org", return_value=("admin-1", org, caller)),
             patch("app.api.admin.settings.log_event", new=AsyncMock()),
             patch("app.api.admin.settings.emit_event"),
         ):
-            result = await update_addons(body=body, credentials=MagicMock(), db=AsyncMock())
+            result = await update_addons(body=body, perms=perms, db=mock_db)
         assert set(result.enabled_addons) == {"scribe", "docs"}
 
     @pytest.mark.asyncio
@@ -100,24 +97,22 @@ class TestUpdateAddons:
         from app.api.admin.settings import AddonsUpdate, update_addons
 
         org = _mock_org(enabled_addons=["scribe"])
-        caller = _mock_caller()
+        perms = make_perms(role="admin", org_id=42, enabled_addons=["scribe"])
+        mock_db = AsyncMock()
+        mock_db.get = AsyncMock(return_value=org)
         body = AddonsUpdate(enabled_addons=[])
         with (
-            patch("app.api.admin.settings._get_caller_org", return_value=("admin-1", org, caller)),
             patch("app.api.admin.settings.log_event", new=AsyncMock()),
             patch("app.api.admin.settings.emit_event"),
         ):
-            result = await update_addons(body=body, credentials=MagicMock(), db=AsyncMock())
+            result = await update_addons(body=body, perms=perms, db=mock_db)
         assert result.enabled_addons == []
 
-    @pytest.mark.asyncio
-    async def test_non_admin_rejected(self) -> None:
-        from app.api.admin.settings import AddonsUpdate, update_addons
-
-        org = _mock_org()
-        caller = _mock_caller(role="company")
-        body = AddonsUpdate(enabled_addons=["scribe"])
-        with patch("app.api.admin.settings._get_caller_org", return_value=("user-1", org, caller)):
-            with pytest.raises(HTTPException) as exc_info:
-                await update_addons(body=body, credentials=MagicMock(), db=AsyncMock())
-        assert exc_info.value.status_code == 403
+    # NOTE: `test_non_admin_rejected` was removed in SPEC-PORTAL-RBAC-REFACTOR-001
+    # Phase 2a. The role gate is now enforced via
+    # `Depends(get_caller_at_least(ProfileRole.ADMIN))` and pinned in
+    # `tests/test_permissions.py::test_get_caller_at_least_role_matrix`
+    # for every (caller_role, required_role) pair. Keeping a copy here
+    # would test the FastAPI dependency-injection wiring, not endpoint
+    # behaviour — that lives in the FastAPI/Starlette test layer
+    # (`tests/test_app_chat.py` style), not unit tests.

--- a/klai-portal/backend/tests/test_admin_users.py
+++ b/klai-portal/backend/tests/test_admin_users.py
@@ -29,6 +29,9 @@ def _compile(stmt: ClauseElement) -> str:
 # @MX:ANCHOR REQ-5.1 — must remain coupled to offboard_user's delete shape.
 # @MX:REASON: regression guard for finding #5 (cross-tenant IDOR via
 # PortalGroupMembership delete keyed only on zitadel_user_id).
+from tests.conftest import make_perms  # noqa: E402
+
+
 @pytest.mark.asyncio
 async def test_offboard_user_does_not_wipe_other_org_memberships() -> None:
     """REQ-1 / REQ-5.1: offboard for org A must scope membership delete to org A.
@@ -47,12 +50,6 @@ async def test_offboard_user_does_not_wipe_other_org_memberships() -> None:
     """
     from app.api.admin.users import offboard_user
 
-    org = MagicMock()
-    org.id = 101  # caller is admin of org A
-
-    caller = MagicMock()
-    caller.role = "admin"
-
     target_user = MagicMock()
     target_user.status = "active"
     target_user.org_id = 101
@@ -64,16 +61,15 @@ async def test_offboard_user_does_not_wipe_other_org_memberships() -> None:
     select_user_result.scalar_one_or_none.return_value = target_user
     mock_db.execute.return_value = select_user_result
 
-    mock_credentials = MagicMock()
+    perms = make_perms(role="admin", user_id="admin-1", org_id=101)
 
     with (
-        patch("app.api.admin.users._get_caller_org", return_value=("admin-1", org, caller)),
         patch("app.api.admin.users.zitadel") as mock_zitadel,
         patch("app.api.admin.users.log_event", new=AsyncMock()),
         patch("app.api.admin.users.remove_github_org_member", new=AsyncMock()),
     ):
         mock_zitadel.deactivate_user = AsyncMock()
-        await offboard_user(zitadel_user_id="user-U", credentials=mock_credentials, db=mock_db)
+        await offboard_user(zitadel_user_id="user-U", perms=perms, db=mock_db)
 
     # Locate the DELETE on portal_group_memberships among all executed statements.
     membership_delete = None
@@ -144,16 +140,11 @@ async def test_invite_user_grants_portal_role_to_zitadel(
     org.seats = 100  # plenty of headroom; do not trip seat limit
     org.plan = "free"
 
-    caller = MagicMock()
-    caller.role = "admin"
-
     mock_db = AsyncMock()
     locked_org_result = MagicMock()
     locked_org_result.scalar_one.return_value = org
     mock_db.execute.return_value = locked_org_result
     mock_db.scalar.return_value = 0  # active_count under seat limit
-
-    mock_credentials = MagicMock()
 
     body = InviteRequest(
         email=f"{portal_role}@example.com",
@@ -163,8 +154,9 @@ async def test_invite_user_grants_portal_role_to_zitadel(
         preferred_language="nl",
     )
 
+    perms = make_perms(role="admin", user_id="admin-1", org_id=101, plan="free")
+
     with (
-        patch("app.api.admin.users._get_caller_org", return_value=("admin-1", org, caller)),
         patch("app.api.admin.users.zitadel") as mock_zitadel,
         patch(
             "app.services.default_knowledge_bases.create_default_personal_kb",
@@ -173,7 +165,7 @@ async def test_invite_user_grants_portal_role_to_zitadel(
     ):
         mock_zitadel.invite_user = AsyncMock(return_value={"userId": f"new-user-{portal_role}"})
         mock_zitadel.grant_user_role = AsyncMock()
-        await invite_user(body=body, credentials=mock_credentials, db=mock_db)
+        await invite_user(body=body, perms=perms, db=mock_db)
 
     if expected_zitadel_role is None:
         # v0.5.0 invariant for non-admins: no Zitadel grant call at all.
@@ -224,9 +216,6 @@ async def test_invite_user_creates_personal_kb_before_commit() -> None:
     org.seats = 100
     org.plan = "free"
 
-    caller = MagicMock()
-    caller.role = "admin"
-
     call_order: list[str] = []
 
     async def _record_commit(*_args, **_kwargs):
@@ -242,8 +231,6 @@ async def test_invite_user_creates_personal_kb_before_commit() -> None:
     mock_db.execute.return_value = locked_org_result
     mock_db.scalar.return_value = 0
 
-    mock_credentials = MagicMock()
-
     body = InviteRequest(
         email="alpha@example.com",
         first_name="A",
@@ -252,8 +239,9 @@ async def test_invite_user_creates_personal_kb_before_commit() -> None:
         preferred_language="nl",
     )
 
+    perms = make_perms(role="admin", user_id="admin-1", org_id=8, plan="free")
+
     with (
-        patch("app.api.admin.users._get_caller_org", return_value=("admin-1", org, caller)),
         patch("app.api.admin.users.zitadel") as mock_zitadel,
         patch(
             "app.services.default_knowledge_bases.create_default_personal_kb",
@@ -262,7 +250,7 @@ async def test_invite_user_creates_personal_kb_before_commit() -> None:
     ):
         mock_zitadel.invite_user = AsyncMock(return_value={"userId": "new-user-id"})
         mock_zitadel.grant_user_role = AsyncMock()
-        await invite_user(body=body, credentials=mock_credentials, db=mock_db)
+        await invite_user(body=body, perms=perms, db=mock_db)
 
     assert "create_personal_kb" in call_order, (
         f"invite_user MUST call create_default_personal_kb. Observed call order: {call_order}"

--- a/klai-portal/backend/tests/test_permissions.py
+++ b/klai-portal/backend/tests/test_permissions.py
@@ -470,15 +470,32 @@ async def test_require_capability_403_when_missing() -> None:
 
 
 @pytest.mark.asyncio
-async def test_require_platform_admin_passes_for_platform_org() -> None:
-    perms = _perms_with(is_platform_admin=True)
+async def test_require_platform_admin_passes_for_admin_in_platform_org() -> None:
+    perms = _perms_with(role=ProfileRole.ADMIN, is_platform_admin=True)
     dep = require_platform_admin()
     assert await dep(perms=perms) is perms
 
 
 @pytest.mark.asyncio
 async def test_require_platform_admin_403_for_tenant_org() -> None:
-    perms = _perms_with(is_platform_admin=False)
+    perms = _perms_with(role=ProfileRole.ADMIN, is_platform_admin=False)
+    dep = require_platform_admin()
+    with pytest.raises(HTTPException) as exc:
+        await dep(perms=perms)
+    assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.parametrize(
+    "role",
+    [ProfileRole.PERSONAL, ProfileRole.COMPANY, ProfileRole.KB_MANAGER, ProfileRole.GROUP_MANAGER],
+)
+@pytest.mark.asyncio
+async def test_require_platform_admin_403_for_non_admin_in_platform_org(role: ProfileRole) -> None:
+    """Phase 1 follow-up: the imperative pattern that this gate replaces is
+    `_require_admin(caller_user) + _require_platform_admin(caller_org)`.
+    Both must hold. A `company`-rol user IN the platform org must NOT pass
+    this gate — that would be permissiver dan vandaag."""
+    perms = _perms_with(role=role, is_platform_admin=True)
     dep = require_platform_admin()
     with pytest.raises(HTTPException) as exc:
         await dep(perms=perms)

--- a/klai-portal/backend/tests/test_products.py
+++ b/klai-portal/backend/tests/test_products.py
@@ -10,12 +10,13 @@ the 410 contract). This file keeps:
   * change_plan: simple plan update, no product-row cleanup
 """
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi import HTTPException
 
 from app.core.features import PLAN_FEATURES
+from tests.conftest import make_perms
 
 # ---------------------------------------------------------------------------
 # PLAN_FEATURES mapping (canonical post-SPEC-PORTAL-RBAC-REFACTOR-001 Phase 1)
@@ -59,50 +60,36 @@ class TestPlanProducts:
 
 
 class TestListAvailableProducts:
-    def _mocks(self, role: str = "admin", plan: str = "core", enabled_addons: list[str] | None = None):
-        org = MagicMock()
-        org.plan = plan
-        org.enabled_addons = enabled_addons or []
-        caller = MagicMock()
-        caller.role = role
-        return org, caller
+    """Endpoint returns derived products from the caller's UserPermissions.
+
+    Phase 2a: ``list_available_products`` reads `perms.effective_products`
+    directly (same value the resolver would derive from role+plan+addons).
+    The non-admin 403 branch is now in `Depends(get_caller_at_least(ADMIN))`
+    and pinned in `tests/test_permissions.py`.
+    """
 
     @pytest.mark.asyncio
     async def test_returns_plan_features_for_core(self) -> None:
         from app.api.admin.products import list_available_products
 
-        org, caller = self._mocks(role="admin", plan="core", enabled_addons=[])
-        with patch("app.api.admin.products._get_caller_org", return_value=("admin-1", org, caller)):
-            result = await list_available_products(credentials=MagicMock(), db=AsyncMock())
+        perms = make_perms(role="admin", plan="core", enabled_addons=[])
+        result = await list_available_products(perms=perms, db=AsyncMock())
         assert sorted(result.products) == ["chat", "knowledge"]
 
     @pytest.mark.asyncio
     async def test_returns_plan_plus_enabled_addons_for_admin(self) -> None:
         from app.api.admin.products import list_available_products
 
-        org, caller = self._mocks(role="admin", plan="core", enabled_addons=["scribe", "docs"])
-        with patch("app.api.admin.products._get_caller_org", return_value=("admin-1", org, caller)):
-            result = await list_available_products(credentials=MagicMock(), db=AsyncMock())
+        perms = make_perms(role="admin", plan="core", enabled_addons=["scribe", "docs"])
+        result = await list_available_products(perms=perms, db=AsyncMock())
         assert set(result.products) == {"chat", "knowledge", "scribe", "docs"}
-
-    @pytest.mark.asyncio
-    async def test_non_admin_caller_rejected(self) -> None:
-        """Endpoint is admin-only -- non-admin calls return 403."""
-        from app.api.admin.products import list_available_products
-
-        org, caller = self._mocks(role="personal", plan="core", enabled_addons=["scribe"])
-        with patch("app.api.admin.products._get_caller_org", return_value=("admin-1", org, caller)):
-            with pytest.raises(HTTPException) as exc_info:
-                await list_available_products(credentials=MagicMock(), db=AsyncMock())
-        assert exc_info.value.status_code == 403
 
     @pytest.mark.asyncio
     async def test_free_plan_returns_empty_when_no_addons(self) -> None:
         from app.api.admin.products import list_available_products
 
-        org, caller = self._mocks(role="admin", plan="free", enabled_addons=[])
-        with patch("app.api.admin.products._get_caller_org", return_value=("admin-1", org, caller)):
-            result = await list_available_products(credentials=MagicMock(), db=AsyncMock())
+        perms = make_perms(role="admin", plan="free", enabled_addons=[])
+        result = await list_available_products(perms=perms, db=AsyncMock())
         assert result.products == []
 
 
@@ -157,15 +144,13 @@ class TestPlanChange:
 
         org = MagicMock()
         org.plan = "core"
-        caller = MagicMock()
-        caller.role = "admin"
 
         mock_db = AsyncMock()
+        mock_db.get = AsyncMock(return_value=org)
         body = MagicMock()
         body.plan = "professional"
 
-        with patch("app.api.admin.settings._get_caller_org", return_value=("admin-1", org, caller)):
-            await change_plan(body=body, credentials=MagicMock(), db=mock_db)
+        await change_plan(body=body, perms=make_perms(role="admin"), db=mock_db)
 
         assert org.plan == "professional"
         # No product-row cleanup queries -- products derive from (role, plan, enabled_addons).
@@ -176,14 +161,9 @@ class TestPlanChange:
     async def test_change_to_unknown_plan_returns_400(self) -> None:
         from app.api.admin.settings import change_plan
 
-        org = MagicMock()
-        org.plan = "core"
-        caller = MagicMock()
-        caller.role = "admin"
         body = MagicMock()
         body.plan = "enterprise_xl"
 
-        with patch("app.api.admin.settings._get_caller_org", return_value=("admin-1", org, caller)):
-            with pytest.raises(HTTPException) as exc_info:
-                await change_plan(body=body, credentials=MagicMock(), db=AsyncMock())
+        with pytest.raises(HTTPException) as exc_info:
+            await change_plan(body=body, perms=make_perms(role="admin"), db=AsyncMock())
         assert exc_info.value.status_code == 400

--- a/klai-portal/backend/tests/test_r5_auto_accept_toggle.py
+++ b/klai-portal/backend/tests/test_r5_auto_accept_toggle.py
@@ -1,13 +1,19 @@
 """
 R5 tests -- PATCH /api/admin/settings auto_accept_same_domain toggle
 (SPEC-AUTH-009 R5 + C5.1/C5.2).
+
+SPEC-PORTAL-RBAC-REFACTOR-001 Phase 2a: settings endpoints take
+``perms: UserPermissions`` directly. The PortalOrg row is loaded via
+``db.get(PortalOrg, perms.org_id)`` inside the endpoint.
 """
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+
+from tests.conftest import make_perms
 
 
 def _make_org(auto_accept: bool = False) -> MagicMock:
@@ -23,12 +29,6 @@ def _make_org(auto_accept: bool = False) -> MagicMock:
     # tests that don't explicitly exercise this field.
     org.telemetry_level = "shadow"
     return org
-
-
-def _make_admin_user() -> MagicMock:
-    u = MagicMock()
-    u.role = "admin"
-    return u
 
 
 class TestAutoAcceptToggleInSettings:
@@ -66,16 +66,15 @@ class TestPatchSettingsAutoAccept:
         from app.api.admin.settings import OrgSettingsUpdate, update_org_settings
 
         org = _make_org(auto_accept=False)
-        caller = _make_admin_user()
+        perms = make_perms(role="admin", org_id=1)
+        db = AsyncMock()
+        db.get = AsyncMock(return_value=org)
 
-        with patch("app.api.admin.settings._get_caller_org", AsyncMock(return_value=(None, org, caller))):
-            creds = MagicMock()
-            db = AsyncMock()
-            result = await update_org_settings(
-                body=OrgSettingsUpdate(auto_accept_same_domain=True),
-                credentials=creds,
-                db=db,
-            )
+        result = await update_org_settings(
+            body=OrgSettingsUpdate(auto_accept_same_domain=True),
+            perms=perms,
+            db=db,
+        )
 
         assert org.auto_accept_same_domain is True
         assert result.auto_accept_same_domain is True
@@ -86,16 +85,15 @@ class TestPatchSettingsAutoAccept:
         from app.api.admin.settings import OrgSettingsUpdate, update_org_settings
 
         org = _make_org(auto_accept=True)
-        caller = _make_admin_user()
+        perms = make_perms(role="admin", org_id=1)
+        db = AsyncMock()
+        db.get = AsyncMock(return_value=org)
 
-        with patch("app.api.admin.settings._get_caller_org", AsyncMock(return_value=(None, org, caller))):
-            creds = MagicMock()
-            db = AsyncMock()
-            result = await update_org_settings(
-                body=OrgSettingsUpdate(auto_accept_same_domain=False),
-                credentials=creds,
-                db=db,
-            )
+        result = await update_org_settings(
+            body=OrgSettingsUpdate(auto_accept_same_domain=False),
+            perms=perms,
+            db=db,
+        )
 
         assert org.auto_accept_same_domain is False
         assert result.auto_accept_same_domain is False
@@ -106,16 +104,15 @@ class TestPatchSettingsAutoAccept:
         from app.api.admin.settings import OrgSettingsUpdate, update_org_settings
 
         org = _make_org(auto_accept=True)
-        caller = _make_admin_user()
+        perms = make_perms(role="admin", org_id=1)
+        db = AsyncMock()
+        db.get = AsyncMock(return_value=org)
 
-        with patch("app.api.admin.settings._get_caller_org", AsyncMock(return_value=(None, org, caller))):
-            creds = MagicMock()
-            db = AsyncMock()
-            result = await update_org_settings(
-                body=OrgSettingsUpdate(default_language="en"),
-                credentials=creds,
-                db=db,
-            )
+        result = await update_org_settings(
+            body=OrgSettingsUpdate(default_language="en"),
+            perms=perms,
+            db=db,
+        )
 
         assert org.auto_accept_same_domain is True
         assert result.auto_accept_same_domain is True
@@ -126,11 +123,10 @@ class TestPatchSettingsAutoAccept:
         from app.api.admin.settings import get_org_settings
 
         org = _make_org(auto_accept=True)
-        caller = _make_admin_user()
+        perms = make_perms(role="admin", org_id=1)
+        db = AsyncMock()
+        db.get = AsyncMock(return_value=org)
 
-        with patch("app.api.admin.settings._get_caller_org", AsyncMock(return_value=(None, org, caller))):
-            creds = MagicMock()
-            db = AsyncMock()
-            result = await get_org_settings(credentials=creds, db=db)
+        result = await get_org_settings(perms=perms, db=db)
 
         assert result.auto_accept_same_domain is True

--- a/klai-portal/backend/tests/test_r6_admin_handover.py
+++ b/klai-portal/backend/tests/test_r6_admin_handover.py
@@ -1,6 +1,8 @@
 """
 R6 tests -- admin handover: promote-admin, demote-admin, DELETE /api/admin/users/me
 (SPEC-AUTH-009 R6 + C6.1/C6.2/C6.3/C6.7).
+
+SPEC-PORTAL-RBAC-REFACTOR-001 Phase 2a: endpoints take ``perms: UserPermissions``.
 """
 
 from __future__ import annotations
@@ -10,8 +12,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import HTTPException
 
+from tests.conftest import make_perms
 
-def _make_user(uid: str = "u1", role: str = "member") -> MagicMock:
+
+def _make_user(uid: str = "u1", role: str = "company") -> MagicMock:
     u = MagicMock()
     u.zitadel_user_id = uid
     u.org_id = 1
@@ -20,28 +24,14 @@ def _make_user(uid: str = "u1", role: str = "member") -> MagicMock:
     return u
 
 
-def _make_org(org_id: int = 1) -> MagicMock:
-    org = MagicMock()
-    org.id = org_id
-    org.name = "Acme"
-    org.seats = 10
-    return org
-
-
-def _make_db(
-    caller: MagicMock,
-    org: MagicMock,
-    target: MagicMock | None = None,
-    admin_count: int = 2,
-) -> AsyncMock:
-    """Return an AsyncMock DB where:
-    - _get_caller_org returns (caller.zitadel_user_id, org, caller)
+def _make_db(target: MagicMock | None = None, admin_count: int = 2) -> AsyncMock:
+    """Return an AsyncMock DB:
     - every execute() returns a result whose scalar_one_or_none() == target
       (the demote-admin handler issues an extra SELECT ... FOR UPDATE on
       portal_orgs to serialise concurrent role changes; that lock query
       consumes a result the handler does not read, so always returning
-      `target` is safe — only the target-lookup call inspects the result)
-    - scalar() for admin count returns admin_count
+      `target` is safe — only the target-lookup call inspects the result).
+    - scalar() for admin count returns admin_count.
     """
     db = AsyncMock()
     db.add = MagicMock()
@@ -49,6 +39,7 @@ def _make_db(
     async def _execute(stmt, *args, **kwargs):
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = target
+        mock_result.scalar_one.return_value = target
         return mock_result
 
     async def _scalar(stmt, *args, **kwargs):
@@ -65,19 +56,14 @@ class TestPromoteAdmin:
         """C6.1: POST promote-admin sets target.role = 'admin'."""
         from app.api.admin.users import promote_admin
 
-        caller = _make_user("admin1", role="admin")
-        target = _make_user("u2", role="member")
-        org = _make_org()
-
-        db = _make_db(caller, org, target=target)
-        with patch("app.api.admin.users._get_caller_org", AsyncMock(return_value=("admin1", org, caller))):
-            with patch("app.api.admin.users.emit_event", MagicMock()):
-                creds = MagicMock()
-                result = await promote_admin(
-                    zitadel_user_id=target.zitadel_user_id,
-                    credentials=creds,
-                    db=db,
-                )
+        target = _make_user("u2", role="company")
+        db = _make_db(target=target)
+        with patch("app.api.admin.users.emit_event", MagicMock()):
+            result = await promote_admin(
+                zitadel_user_id=target.zitadel_user_id,
+                perms=make_perms(role="admin", user_id="admin1"),
+                db=db,
+            )
 
         assert target.role == "admin"
         assert "promoted" in result.message.lower() or result.message
@@ -87,40 +73,30 @@ class TestPromoteAdmin:
         """C6.1: Promoting a user not in the org raises 404."""
         from app.api.admin.users import promote_admin
 
-        caller = _make_user("admin1", role="admin")
-        org = _make_org()
-
-        db = _make_db(caller, org, target=None)  # no target found
-        with patch("app.api.admin.users._get_caller_org", AsyncMock(return_value=("admin1", org, caller))):
-            creds = MagicMock()
-            with pytest.raises(HTTPException) as exc_info:
-                await promote_admin(
-                    zitadel_user_id="ghost",
-                    credentials=creds,
-                    db=db,
-                )
+        db = _make_db(target=None)
+        with pytest.raises(HTTPException) as exc_info:
+            await promote_admin(
+                zitadel_user_id="ghost",
+                perms=make_perms(role="admin"),
+                db=db,
+            )
         assert exc_info.value.status_code == 404
 
 
 class TestDemoteAdmin:
     @pytest.mark.asyncio
-    async def test_demote_sets_role_member(self) -> None:
-        """C6.2: POST demote-admin sets target.role = 'member'."""
+    async def test_demote_sets_role_company(self) -> None:
+        """C6.2: POST demote-admin sets target.role = 'company'."""
         from app.api.admin.users import demote_admin
 
-        caller = _make_user("admin1", role="admin")
         target = _make_user("admin2", role="admin")
-        org = _make_org()
-
-        db = _make_db(caller, org, target=target, admin_count=2)
-        with patch("app.api.admin.users._get_caller_org", AsyncMock(return_value=("admin1", org, caller))):
-            with patch("app.api.admin.users.emit_event", MagicMock()):
-                creds = MagicMock()
-                result = await demote_admin(
-                    zitadel_user_id=target.zitadel_user_id,
-                    credentials=creds,
-                    db=db,
-                )
+        db = _make_db(target=target, admin_count=2)
+        with patch("app.api.admin.users.emit_event", MagicMock()):
+            result = await demote_admin(
+                zitadel_user_id=target.zitadel_user_id,
+                perms=make_perms(role="admin", user_id="admin1"),
+                db=db,
+            )
 
         # Post profile-ladder migration: demoted admin lands on "company"
         # rung (formerly "member"). See SPEC-PORTAL-PROFILES-001.
@@ -132,19 +108,14 @@ class TestDemoteAdmin:
         """C6.2: Demoting last admin raises HTTP 409 Conflict."""
         from app.api.admin.users import demote_admin
 
-        caller = _make_user("admin1", role="admin")
-        target = _make_user("admin1", role="admin")  # same person, only admin
-        org = _make_org()
-
-        db = _make_db(caller, org, target=target, admin_count=1)
-        with patch("app.api.admin.users._get_caller_org", AsyncMock(return_value=("admin1", org, caller))):
-            creds = MagicMock()
-            with pytest.raises(HTTPException) as exc_info:
-                await demote_admin(
-                    zitadel_user_id=target.zitadel_user_id,
-                    credentials=creds,
-                    db=db,
-                )
+        target = _make_user("admin1", role="admin")  # only admin
+        db = _make_db(target=target, admin_count=1)
+        with pytest.raises(HTTPException) as exc_info:
+            await demote_admin(
+                zitadel_user_id=target.zitadel_user_id,
+                perms=make_perms(role="admin", user_id="admin1"),
+                db=db,
+            )
         assert exc_info.value.status_code == 409
 
     @pytest.mark.asyncio
@@ -152,19 +123,14 @@ class TestDemoteAdmin:
         """C6.2: Target must be admin; demoting a member raises HTTP 400."""
         from app.api.admin.users import demote_admin
 
-        caller = _make_user("admin1", role="admin")
-        target = _make_user("u2", role="member")
-        org = _make_org()
-
-        db = _make_db(caller, org, target=target, admin_count=2)
-        with patch("app.api.admin.users._get_caller_org", AsyncMock(return_value=("admin1", org, caller))):
-            creds = MagicMock()
-            with pytest.raises(HTTPException) as exc_info:
-                await demote_admin(
-                    zitadel_user_id=target.zitadel_user_id,
-                    credentials=creds,
-                    db=db,
-                )
+        target = _make_user("u2", role="company")
+        db = _make_db(target=target, admin_count=2)
+        with pytest.raises(HTTPException) as exc_info:
+            await demote_admin(
+                zitadel_user_id=target.zitadel_user_id,
+                perms=make_perms(role="admin", user_id="admin1"),
+                db=db,
+            )
         assert exc_info.value.status_code == 400
 
 
@@ -174,17 +140,25 @@ class TestLeaveWorkspace:
         """C6.3: A non-admin member can leave without restriction."""
         from app.api.admin.users import leave_workspace
 
-        caller = _make_user("u1", role="member")
-        org = _make_org()
-
+        caller = _make_user("u1", role="company")
         db = AsyncMock()
         db.add = MagicMock()
         db.delete = AsyncMock()
 
-        with patch("app.api.admin.users._get_caller_org", AsyncMock(return_value=("u1", org, caller))):
-            with patch("app.api.admin.users.emit_event", MagicMock()):
-                creds = MagicMock()
-                result = await leave_workspace(credentials=creds, db=db)
+        # leave_workspace re-fetches the caller's PortalUser ORM row for
+        # `db.delete`. Mock the SELECT result to return the caller mock.
+        async def _execute(stmt, *args, **kwargs):
+            mock_result = MagicMock()
+            mock_result.scalar_one.return_value = caller
+            return mock_result
+
+        db.execute = _execute
+
+        with patch("app.api.admin.users.emit_event", MagicMock()):
+            result = await leave_workspace(
+                perms=make_perms(role="company", user_id="u1"),
+                db=db,
+            )
 
         db.delete.assert_awaited_once_with(caller)
         assert result.message
@@ -194,21 +168,23 @@ class TestLeaveWorkspace:
         """C6.3 + C6.7: Last admin leaving raises 409."""
         from app.api.admin.users import leave_workspace
 
-        caller = _make_user("admin1", role="admin")
-        org = _make_org()
-
         db = AsyncMock()
         db.add = MagicMock()
         db.delete = AsyncMock()
 
+        async def _execute(stmt, *args, **kwargs):
+            return MagicMock()
+
         async def _scalar(stmt, *args, **kwargs):
             return 1  # only one admin
 
+        db.execute = _execute
         db.scalar = _scalar
 
-        with patch("app.api.admin.users._get_caller_org", AsyncMock(return_value=("admin1", org, caller))):
-            creds = MagicMock()
-            with pytest.raises(HTTPException) as exc_info:
-                await leave_workspace(credentials=creds, db=db)
+        with pytest.raises(HTTPException) as exc_info:
+            await leave_workspace(
+                perms=make_perms(role="admin", user_id="admin1"),
+                db=db,
+            )
 
         assert exc_info.value.status_code == 409

--- a/klai-portal/backend/tests/test_retry_provisioning.py
+++ b/klai-portal/backend/tests/test_retry_provisioning.py
@@ -1,8 +1,10 @@
 """SPEC-PROV-001 M4 — admin retry endpoint unit tests.
 
-Authorization tests cover both the admin-role gate (`_require_admin`) and
-the platform-admin-org gate (`_require_platform_admin`) added in
-audit-tenant-isolation-2026-05-05 finding C-2.
+SPEC-PORTAL-RBAC-REFACTOR-001 Phase 2a: the gate is now declarative —
+``Depends(require_platform_admin())`` enforces both the admin-role and
+the platform-admin-org check. The role/platform-org rejection branches
+are pinned in `tests/test_permissions.py` (test_require_platform_admin_*),
+so this file only covers the post-gate happy and 4xx paths.
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -10,7 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import HTTPException
 
-from app.core.config import settings
+from tests.conftest import make_perms
 
 
 def _make_failed_org(slug: str = "acme", org_id: int = 42) -> MagicMock:
@@ -22,20 +24,9 @@ def _make_failed_org(slug: str = "acme", org_id: int = 42) -> MagicMock:
     return org
 
 
-def _make_platform_caller_org() -> MagicMock:
-    """Caller's own org with slug==platform_org_slug so the platform-admin gate passes."""
-    caller_org = MagicMock()
-    caller_org.id = 1
-    caller_org.slug = settings.platform_org_slug
-    return caller_org
-
-
-def _make_tenant_caller_org(slug: str = "voys") -> MagicMock:
-    """Caller's own org with a non-platform slug — must trigger 403."""
-    caller_org = MagicMock()
-    caller_org.id = 17
-    caller_org.slug = slug
-    return caller_org
+def _platform_admin_perms() -> object:
+    """Caller is admin in the platform org — passes require_platform_admin()."""
+    return make_perms(role="admin", org_id=1, org_slug="getklai", is_platform_admin=True)
 
 
 def _mock_db_returning(*, failed_org, collision_org=None, existing_org=None):
@@ -75,82 +66,20 @@ def _mock_db_returning(*, failed_org, collision_org=None, existing_org=None):
 
 
 @pytest.mark.asyncio
-async def test_retry_non_admin_returns_403() -> None:
-    from app.api.admin.retry_provisioning import retry_provisioning
-
-    caller_user = MagicMock()
-    caller_user.role = "member"
-
-    async def _fake_caller_resolver(*args, **kwargs):
-        return ("zit-user", _make_platform_caller_org(), caller_user)
-
-    with (
-        patch("app.api.admin.retry_provisioning._get_caller_org", new=_fake_caller_resolver),
-    ):
-        with pytest.raises(HTTPException) as excinfo:
-            await retry_provisioning(
-                slug="acme",
-                background_tasks=MagicMock(),
-                credentials=MagicMock(),
-                db=AsyncMock(),
-            )
-
-    assert excinfo.value.status_code == 403
-
-
-@pytest.mark.asyncio
-async def test_retry_non_platform_admin_org_returns_403() -> None:
-    """audit-tenant-isolation-2026-05-05 finding C-2 regression test.
-
-    A regular tenant-admin (admin role, but non-platform-admin org) MUST NOT
-    be able to retry-provision another tenant's org. Without this gate, any
-    admin in any tenant could revive any other tenant's failed-rollback row.
-    """
-    from app.api.admin.retry_provisioning import retry_provisioning
-
-    admin = MagicMock()
-    admin.role = "admin"
-    admin.zitadel_user_id = "zit-tenant-admin"
-    tenant_caller_org = _make_tenant_caller_org(slug="voys")
-
-    async def _fake_caller_resolver(*args, **kwargs):
-        return ("zit-tenant-admin", tenant_caller_org, admin)
-
-    with patch("app.api.admin.retry_provisioning._get_caller_org", new=_fake_caller_resolver):
-        with pytest.raises(HTTPException) as excinfo:
-            await retry_provisioning(
-                slug="some-other-tenant",
-                background_tasks=MagicMock(),
-                credentials=MagicMock(),
-                db=AsyncMock(),
-            )
-
-    assert excinfo.value.status_code == 403
-    assert "platform admin" in str(excinfo.value.detail).lower()
-
-
-@pytest.mark.asyncio
 async def test_retry_happy_path_returns_202_and_queues_task() -> None:
     from app.api.admin.retry_provisioning import retry_provisioning
 
-    admin = MagicMock()
-    admin.role = "admin"
-    admin.zitadel_user_id = "zit-admin"
     failed_org = _make_failed_org()
     db = _mock_db_returning(failed_org=failed_org)
     background_tasks = MagicMock()
 
-    async def _fake_caller_resolver(*args, **kwargs):
-        return ("zit-admin", _make_platform_caller_org(), admin)
-
     with (
-        patch("app.api.admin.retry_provisioning._get_caller_org", new=_fake_caller_resolver),
         patch("app.api.admin.retry_provisioning.log_event", new=AsyncMock()) as mock_log,
     ):
         response = await retry_provisioning(
             slug="acme",
             background_tasks=background_tasks,
-            credentials=MagicMock(),
+            perms=_platform_admin_perms(),
             db=db,
         )
 
@@ -165,30 +94,24 @@ async def test_retry_happy_path_returns_202_and_queues_task() -> None:
     assert log_kwargs["action"] == "retry_provisioning"
     assert log_kwargs["resource_type"] == "portal_org"
     assert log_kwargs["resource_id"] == str(failed_org.id)
-    assert log_kwargs["actor"] == "zit-admin"
+    assert log_kwargs["actor"] == "uid-test"
 
 
 @pytest.mark.asyncio
 async def test_retry_pending_rollback_returns_409_manual_cleanup() -> None:
     from app.api.admin.retry_provisioning import retry_provisioning
 
-    admin = MagicMock()
-    admin.role = "admin"
     pending = MagicMock()
     pending.provisioning_status = "failed_rollback_pending"
     db = _mock_db_returning(failed_org=None, existing_org=pending)
 
-    async def _fake_caller_resolver(*args, **kwargs):
-        return ("zit-admin", _make_platform_caller_org(), admin)
-
-    with patch("app.api.admin.retry_provisioning._get_caller_org", new=_fake_caller_resolver):
-        with pytest.raises(HTTPException) as excinfo:
-            await retry_provisioning(
-                slug="acme",
-                background_tasks=MagicMock(),
-                credentials=MagicMock(),
-                db=db,
-            )
+    with pytest.raises(HTTPException) as excinfo:
+        await retry_provisioning(
+            slug="acme",
+            background_tasks=MagicMock(),
+            perms=_platform_admin_perms(),
+            db=db,
+        )
 
     assert excinfo.value.status_code == 409
     assert excinfo.value.detail == {
@@ -201,23 +124,17 @@ async def test_retry_pending_rollback_returns_409_manual_cleanup() -> None:
 async def test_retry_ready_org_returns_409_not_in_retryable_state() -> None:
     from app.api.admin.retry_provisioning import retry_provisioning
 
-    admin = MagicMock()
-    admin.role = "admin"
     ready = MagicMock()
     ready.provisioning_status = "ready"
     db = _mock_db_returning(failed_org=None, existing_org=ready)
 
-    async def _fake_caller_resolver(*args, **kwargs):
-        return ("zit-admin", _make_platform_caller_org(), admin)
-
-    with patch("app.api.admin.retry_provisioning._get_caller_org", new=_fake_caller_resolver):
-        with pytest.raises(HTTPException) as excinfo:
-            await retry_provisioning(
-                slug="acme",
-                background_tasks=MagicMock(),
-                credentials=MagicMock(),
-                db=db,
-            )
+    with pytest.raises(HTTPException) as excinfo:
+        await retry_provisioning(
+            slug="acme",
+            background_tasks=MagicMock(),
+            perms=_platform_admin_perms(),
+            db=db,
+        )
 
     assert excinfo.value.status_code == 409
     assert excinfo.value.detail == {
@@ -230,24 +147,18 @@ async def test_retry_ready_org_returns_409_not_in_retryable_state() -> None:
 async def test_retry_slug_collision_returns_409_slug_in_use() -> None:
     from app.api.admin.retry_provisioning import retry_provisioning
 
-    admin = MagicMock()
-    admin.role = "admin"
     failed_org = _make_failed_org()
     collision = MagicMock()
     collision.id = 99
     db = _mock_db_returning(failed_org=failed_org, collision_org=collision)
 
-    async def _fake_caller_resolver(*args, **kwargs):
-        return ("zit-admin", _make_platform_caller_org(), admin)
-
-    with patch("app.api.admin.retry_provisioning._get_caller_org", new=_fake_caller_resolver):
-        with pytest.raises(HTTPException) as excinfo:
-            await retry_provisioning(
-                slug="acme",
-                background_tasks=MagicMock(),
-                credentials=MagicMock(),
-                db=db,
-            )
+    with pytest.raises(HTTPException) as excinfo:
+        await retry_provisioning(
+            slug="acme",
+            background_tasks=MagicMock(),
+            perms=_platform_admin_perms(),
+            db=db,
+        )
 
     assert excinfo.value.status_code == 409
     assert excinfo.value.detail == {
@@ -264,20 +175,14 @@ async def test_retry_slug_collision_returns_409_slug_in_use() -> None:
 async def test_retry_unknown_slug_returns_404() -> None:
     from app.api.admin.retry_provisioning import retry_provisioning
 
-    admin = MagicMock()
-    admin.role = "admin"
     db = _mock_db_returning(failed_org=None, existing_org=None)
 
-    async def _fake_caller_resolver(*args, **kwargs):
-        return ("zit-admin", _make_platform_caller_org(), admin)
-
-    with patch("app.api.admin.retry_provisioning._get_caller_org", new=_fake_caller_resolver):
-        with pytest.raises(HTTPException) as excinfo:
-            await retry_provisioning(
-                slug="nonexistent",
-                background_tasks=MagicMock(),
-                credentials=MagicMock(),
-                db=db,
-            )
+    with pytest.raises(HTTPException) as excinfo:
+        await retry_provisioning(
+            slug="nonexistent",
+            background_tasks=MagicMock(),
+            perms=_platform_admin_perms(),
+            db=db,
+        )
 
     assert excinfo.value.status_code == 404

--- a/klai-portal/backend/tests/test_rls_audit.py
+++ b/klai-portal/backend/tests/test_rls_audit.py
@@ -63,6 +63,13 @@ _TENANT_MARKERS: tuple[str, ...] = (
     "require_partner_context(",
     "require_admin_api_key(",
     "get_effective_products(",  # self-heals tenant internally
+    # SPEC-PORTAL-RBAC-REFACTOR-001 Phase 1+: declarative dependencies that
+    # resolve through `get_caller`, which calls `set_tenant` for the caller's
+    # org. Any module that imports/uses these has tenant context established.
+    "get_caller_at_least(",
+    "require_platform_admin(",
+    "require_platform_unlocked(",
+    "Depends(get_caller)",  # bare get_caller (no min-role)
 )
 
 # Modules that legitimately query RLS models without a direct tenant marker

--- a/klai-portal/backend/tests/test_rls_callsite_audit.py
+++ b/klai-portal/backend/tests/test_rls_callsite_audit.py
@@ -44,7 +44,13 @@ TENANT_ESTABLISHING_CALLS: frozenset[str] = frozenset(
         "set_tenant",
         "tenant_scoped_session",
         "cross_org_session",
-        "_get_caller_org",  # FastAPI dependency that calls set_tenant internally
+        "_get_caller_org",  # legacy imperative helper — calls set_tenant internally
+        "get_caller",  # SPEC-PORTAL-RBAC-REFACTOR-001 declarative dependency
+        "get_caller_at_least",  # role-bounded variant; resolves through get_caller
+        "require_platform_admin",  # platform-admin gate; resolves through get_caller
+        "require_product",  # product gate; resolves through get_caller
+        "require_capability",  # capability gate; resolves through get_caller
+        "require_platform_unlocked",  # phase 5 platform-feature gate
         "get_partner_key",  # same, for partner auth
         "get_partner_auth_context",  # widget session token path
     }

--- a/klai-portal/backend/tests/test_spec_portal_admin_ui_001.py
+++ b/klai-portal/backend/tests/test_spec_portal_admin_ui_001.py
@@ -5,14 +5,18 @@ This SPEC merges the legacy promote-admin / demote-admin paths into a single
 endpoint. The min-1-admin invariant from POST /demote-admin must therefore
 also live on PATCH /role; otherwise the new admin UI can demote the last
 admin and lock a tenant out of its own workspace.
+
+SPEC-PORTAL-RBAC-REFACTOR-001 Phase 2a: endpoint takes ``perms``.
 """
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi import HTTPException
+
+from tests.conftest import make_perms
 
 
 def _make_user(uid: str = "u1", role: str = "company") -> MagicMock:
@@ -22,14 +26,6 @@ def _make_user(uid: str = "u1", role: str = "company") -> MagicMock:
     user.role = role
     user.status = "active"
     return user
-
-
-def _make_org(org_id: int = 1) -> MagicMock:
-    org = MagicMock()
-    org.id = org_id
-    org.name = "Acme"
-    org.seats = 10
-    return org
 
 
 def _make_db(target: MagicMock | None, admin_count: int = 2) -> AsyncMock:
@@ -62,23 +58,15 @@ class TestUpdateUserRoleMinAdminInvariant:
     async def test_demoting_last_admin_to_company_raises_409(self) -> None:
         from app.api.admin.users import RoleUpdateRequest, update_user_role
 
-        caller = _make_user("admin1", role="admin")
-        target = _make_user("admin1", role="admin")  # same person, only admin
-        org = _make_org()
-
+        target = _make_user("admin1", role="admin")  # only admin
         db = _make_db(target=target, admin_count=1)
-        with patch(
-            "app.api.admin.users._get_caller_org",
-            AsyncMock(return_value=("admin1", org, caller)),
-        ):
-            creds = MagicMock()
-            with pytest.raises(HTTPException) as exc_info:
-                await update_user_role(
-                    zitadel_user_id=target.zitadel_user_id,
-                    body=RoleUpdateRequest(role="company"),
-                    credentials=creds,
-                    db=db,
-                )
+        with pytest.raises(HTTPException) as exc_info:
+            await update_user_role(
+                zitadel_user_id=target.zitadel_user_id,
+                body=RoleUpdateRequest(role="company"),
+                perms=make_perms(role="admin", user_id="admin1"),
+                db=db,
+            )
         assert exc_info.value.status_code == 409
         # Target unchanged because the handler raised before assigning.
         assert target.role == "admin"
@@ -87,22 +75,14 @@ class TestUpdateUserRoleMinAdminInvariant:
     async def test_demoting_admin_when_two_remain_succeeds(self) -> None:
         from app.api.admin.users import RoleUpdateRequest, update_user_role
 
-        caller = _make_user("admin1", role="admin")
         target = _make_user("admin2", role="admin")
-        org = _make_org()
-
         db = _make_db(target=target, admin_count=2)
-        with patch(
-            "app.api.admin.users._get_caller_org",
-            AsyncMock(return_value=("admin1", org, caller)),
-        ):
-            creds = MagicMock()
-            result = await update_user_role(
-                zitadel_user_id=target.zitadel_user_id,
-                body=RoleUpdateRequest(role="company"),
-                credentials=creds,
-                db=db,
-            )
+        result = await update_user_role(
+            zitadel_user_id=target.zitadel_user_id,
+            body=RoleUpdateRequest(role="company"),
+            perms=make_perms(role="admin", user_id="admin1"),
+            db=db,
+        )
         assert target.role == "company"
         assert result.message
 
@@ -111,46 +91,30 @@ class TestUpdateUserRoleMinAdminInvariant:
         """Promoting any user to admin must never touch the min-admin guard."""
         from app.api.admin.users import RoleUpdateRequest, update_user_role
 
-        caller = _make_user("admin1", role="admin")
         target = _make_user("u2", role="company")
-        org = _make_org()
-
         # admin_count=1 here is irrelevant — we're promoting, not demoting.
         db = _make_db(target=target, admin_count=1)
-        with patch(
-            "app.api.admin.users._get_caller_org",
-            AsyncMock(return_value=("admin1", org, caller)),
-        ):
-            creds = MagicMock()
-            result = await update_user_role(
-                zitadel_user_id=target.zitadel_user_id,
-                body=RoleUpdateRequest(role="admin"),
-                credentials=creds,
-                db=db,
-            )
+        result = await update_user_role(
+            zitadel_user_id=target.zitadel_user_id,
+            body=RoleUpdateRequest(role="admin"),
+            perms=make_perms(role="admin", user_id="admin1"),
+            db=db,
+        )
         assert target.role == "admin"
         assert result.message
 
     @pytest.mark.asyncio
     async def test_changing_non_admin_to_other_non_admin_succeeds(self) -> None:
-        """A company → kb_manager move should never trip the admin guard."""
+        """A company -> kb_manager move should never trip the admin guard."""
         from app.api.admin.users import RoleUpdateRequest, update_user_role
 
-        caller = _make_user("admin1", role="admin")
         target = _make_user("u2", role="company")
-        org = _make_org()
-
         db = _make_db(target=target, admin_count=1)
-        with patch(
-            "app.api.admin.users._get_caller_org",
-            AsyncMock(return_value=("admin1", org, caller)),
-        ):
-            creds = MagicMock()
-            result = await update_user_role(
-                zitadel_user_id=target.zitadel_user_id,
-                body=RoleUpdateRequest(role="kb_manager"),
-                credentials=creds,
-                db=db,
-            )
+        result = await update_user_role(
+            zitadel_user_id=target.zitadel_user_id,
+            body=RoleUpdateRequest(role="kb_manager"),
+            perms=make_perms(role="admin", user_id="admin1"),
+            db=db,
+        )
         assert target.role == "kb_manager"
         assert result.message

--- a/klai-portal/backend/tests/test_user_lifecycle.py
+++ b/klai-portal/backend/tests/test_user_lifecycle.py
@@ -9,6 +9,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import HTTPException
 
+from tests.conftest import make_perms
+
 
 def _mock_org(org_id: int = 1) -> MagicMock:
     org = MagicMock()
@@ -40,18 +42,15 @@ class TestSuspendUser:
     async def test_suspend_active_user_succeeds(self) -> None:
         from app.api.admin.users import suspend_user
 
-        org = _mock_org()
-        caller = _mock_caller()
         user = _mock_user(status="active")
 
         mock_db = AsyncMock()
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = user
         mock_db.execute.return_value = mock_result
-        mock_credentials = MagicMock()
-
-        with patch("app.api.admin.users._get_caller_org", return_value=("admin-1", org, caller)):
-            result = await suspend_user(zitadel_user_id="user-1", credentials=mock_credentials, db=mock_db)
+        result = await suspend_user(
+            zitadel_user_id="user-1", perms=make_perms(role="admin", user_id="admin-1", org_id=1), db=mock_db
+        )
 
         assert user.status == "suspended"
         assert "suspended" in result.message.lower()
@@ -61,19 +60,16 @@ class TestSuspendUser:
     async def test_suspend_offboarded_user_returns_409(self) -> None:
         from app.api.admin.users import suspend_user
 
-        org = _mock_org()
-        caller = _mock_caller()
         user = _mock_user(status="offboarded")
 
         mock_db = AsyncMock()
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = user
         mock_db.execute.return_value = mock_result
-        mock_credentials = MagicMock()
-
-        with patch("app.api.admin.users._get_caller_org", return_value=("admin-1", org, caller)):
-            with pytest.raises(HTTPException) as exc_info:
-                await suspend_user(zitadel_user_id="user-1", credentials=mock_credentials, db=mock_db)
+        with pytest.raises(HTTPException) as exc_info:
+            await suspend_user(
+                zitadel_user_id="user-1", perms=make_perms(role="admin", user_id="admin-1", org_id=1), db=mock_db
+            )
 
         assert exc_info.value.status_code == 409
 
@@ -81,19 +77,16 @@ class TestSuspendUser:
     async def test_suspend_already_suspended_returns_409(self) -> None:
         from app.api.admin.users import suspend_user
 
-        org = _mock_org()
-        caller = _mock_caller()
         user = _mock_user(status="suspended")
 
         mock_db = AsyncMock()
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = user
         mock_db.execute.return_value = mock_result
-        mock_credentials = MagicMock()
-
-        with patch("app.api.admin.users._get_caller_org", return_value=("admin-1", org, caller)):
-            with pytest.raises(HTTPException) as exc_info:
-                await suspend_user(zitadel_user_id="user-1", credentials=mock_credentials, db=mock_db)
+        with pytest.raises(HTTPException) as exc_info:
+            await suspend_user(
+                zitadel_user_id="user-1", perms=make_perms(role="admin", user_id="admin-1", org_id=1), db=mock_db
+            )
 
         assert exc_info.value.status_code == 409
 
@@ -108,18 +101,15 @@ class TestReactivateUser:
     async def test_reactivate_suspended_user_succeeds(self) -> None:
         from app.api.admin.users import reactivate_user
 
-        org = _mock_org()
-        caller = _mock_caller()
         user = _mock_user(status="suspended")
 
         mock_db = AsyncMock()
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = user
         mock_db.execute.return_value = mock_result
-        mock_credentials = MagicMock()
-
-        with patch("app.api.admin.users._get_caller_org", return_value=("admin-1", org, caller)):
-            result = await reactivate_user(zitadel_user_id="user-1", credentials=mock_credentials, db=mock_db)
+        result = await reactivate_user(
+            zitadel_user_id="user-1", perms=make_perms(role="admin", user_id="admin-1", org_id=1), db=mock_db
+        )
 
         assert user.status == "active"
         assert "reactivated" in result.message.lower()
@@ -129,19 +119,16 @@ class TestReactivateUser:
     async def test_reactivate_active_user_returns_409(self) -> None:
         from app.api.admin.users import reactivate_user
 
-        org = _mock_org()
-        caller = _mock_caller()
         user = _mock_user(status="active")
 
         mock_db = AsyncMock()
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = user
         mock_db.execute.return_value = mock_result
-        mock_credentials = MagicMock()
-
-        with patch("app.api.admin.users._get_caller_org", return_value=("admin-1", org, caller)):
-            with pytest.raises(HTTPException) as exc_info:
-                await reactivate_user(zitadel_user_id="user-1", credentials=mock_credentials, db=mock_db)
+        with pytest.raises(HTTPException) as exc_info:
+            await reactivate_user(
+                zitadel_user_id="user-1", perms=make_perms(role="admin", user_id="admin-1", org_id=1), db=mock_db
+            )
 
         assert exc_info.value.status_code == 409
 
@@ -149,19 +136,16 @@ class TestReactivateUser:
     async def test_reactivate_offboarded_user_returns_409(self) -> None:
         from app.api.admin.users import reactivate_user
 
-        org = _mock_org()
-        caller = _mock_caller()
         user = _mock_user(status="offboarded")
 
         mock_db = AsyncMock()
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = user
         mock_db.execute.return_value = mock_result
-        mock_credentials = MagicMock()
-
-        with patch("app.api.admin.users._get_caller_org", return_value=("admin-1", org, caller)):
-            with pytest.raises(HTTPException) as exc_info:
-                await reactivate_user(zitadel_user_id="user-1", credentials=mock_credentials, db=mock_db)
+        with pytest.raises(HTTPException) as exc_info:
+            await reactivate_user(
+                zitadel_user_id="user-1", perms=make_perms(role="admin", user_id="admin-1", org_id=1), db=mock_db
+            )
 
         assert exc_info.value.status_code == 409
 
@@ -182,8 +166,6 @@ class TestOffboardUser:
         """
         from app.api.admin.users import offboard_user
 
-        org = _mock_org()
-        caller = _mock_caller()
         user = _mock_user(status="active")
 
         mock_db = AsyncMock()
@@ -192,17 +174,16 @@ class TestOffboardUser:
         # First execute: user lookup
         # Second execute: delete memberships
         mock_db.execute.side_effect = [mock_result, MagicMock()]
-        mock_credentials = MagicMock()
-
         mock_zitadel = AsyncMock()
 
         with (
-            patch("app.api.admin.users._get_caller_org", return_value=("admin-1", org, caller)),
             patch("app.api.admin.users.zitadel", mock_zitadel),
             patch("app.api.admin.users.settings") as mock_settings,
         ):
             mock_settings.zitadel_portal_org_id = "org-id"
-            result = await offboard_user(zitadel_user_id="user-1", credentials=mock_credentials, db=mock_db)
+            result = await offboard_user(
+                zitadel_user_id="user-1", perms=make_perms(role="admin", user_id="admin-1", org_id=1), db=mock_db
+            )
 
         assert user.status == "offboarded"
         assert "offboarded" in result.message
@@ -215,19 +196,16 @@ class TestOffboardUser:
     async def test_offboard_offboarded_user_returns_409(self) -> None:
         from app.api.admin.users import offboard_user
 
-        org = _mock_org()
-        caller = _mock_caller()
         user = _mock_user(status="offboarded")
 
         mock_db = AsyncMock()
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = user
         mock_db.execute.return_value = mock_result
-        mock_credentials = MagicMock()
-
-        with patch("app.api.admin.users._get_caller_org", return_value=("admin-1", org, caller)):
-            with pytest.raises(HTTPException) as exc_info:
-                await offboard_user(zitadel_user_id="user-1", credentials=mock_credentials, db=mock_db)
+        with pytest.raises(HTTPException) as exc_info:
+            await offboard_user(
+                zitadel_user_id="user-1", perms=make_perms(role="admin", user_id="admin-1", org_id=1), db=mock_db
+            )
 
         assert exc_info.value.status_code == 409
 
@@ -236,25 +214,22 @@ class TestOffboardUser:
         """Suspended users can be offboarded (terminal state from any non-offboarded state)."""
         from app.api.admin.users import offboard_user
 
-        org = _mock_org()
-        caller = _mock_caller()
         user = _mock_user(status="suspended")
 
         mock_db = AsyncMock()
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = user
         mock_db.execute.side_effect = [mock_result, MagicMock(), MagicMock()]
-        mock_credentials = MagicMock()
-
         mock_zitadel = AsyncMock()
 
         with (
-            patch("app.api.admin.users._get_caller_org", return_value=("admin-1", org, caller)),
             patch("app.api.admin.users.zitadel", mock_zitadel),
             patch("app.api.admin.users.settings") as mock_settings,
         ):
             mock_settings.zitadel_portal_org_id = "org-id"
-            await offboard_user(zitadel_user_id="user-1", credentials=mock_credentials, db=mock_db)
+            await offboard_user(
+                zitadel_user_id="user-1", perms=make_perms(role="admin", user_id="admin-1", org_id=1), db=mock_db
+            )
 
         assert user.status == "offboarded"
 
@@ -262,18 +237,14 @@ class TestOffboardUser:
     async def test_offboard_user_not_found_returns_404(self) -> None:
         from app.api.admin.users import offboard_user
 
-        org = _mock_org()
-        caller = _mock_caller()
-
         mock_db = AsyncMock()
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = None
         mock_db.execute.return_value = mock_result
-        mock_credentials = MagicMock()
-
-        with patch("app.api.admin.users._get_caller_org", return_value=("admin-1", org, caller)):
-            with pytest.raises(HTTPException) as exc_info:
-                await offboard_user(zitadel_user_id="user-999", credentials=mock_credentials, db=mock_db)
+        with pytest.raises(HTTPException) as exc_info:
+            await offboard_user(
+                zitadel_user_id="user-999", perms=make_perms(role="admin", user_id="admin-1", org_id=1), db=mock_db
+            )
 
         assert exc_info.value.status_code == 404
 
@@ -289,18 +260,15 @@ class TestSuspendPreservesMemberships:
         """Suspending a user should NOT remove their group memberships."""
         from app.api.admin.users import suspend_user
 
-        org = _mock_org()
-        caller = _mock_caller()
         user = _mock_user(status="active")
 
         mock_db = AsyncMock()
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = user
         mock_db.execute.return_value = mock_result
-        mock_credentials = MagicMock()
-
-        with patch("app.api.admin.users._get_caller_org", return_value=("admin-1", org, caller)):
-            await suspend_user(zitadel_user_id="user-1", credentials=mock_credentials, db=mock_db)
+        await suspend_user(
+            zitadel_user_id="user-1", perms=make_perms(role="admin", user_id="admin-1", org_id=1), db=mock_db
+        )
 
         # Only 1 execute call (user lookup), no delete calls
         assert mock_db.execute.await_count == 1


### PR DESCRIPTION
## Summary

SPEC-PORTAL-RBAC-REFACTOR-001 **Phase 2a**. Twintig endpoints in vier files
gemigreerd van imperatief `_get_caller_org` + `_require_admin(...)` naar
declaratief `Depends(get_caller_at_least(ProfileRole.ADMIN))`.

| File | Endpoints | Bijzonderheden |
|---|---|---|
| `admin/users.py` | 12 | `leave_workspace` gebruikt `Depends(get_caller)` (alle rollen). Alle andere admin-only. |
| `admin/settings.py` | 5 | Helper `_load_org_or_500` voor PortalOrg-velden niet op UserPermissions. |
| `admin/products.py` | 2 | `list_available_products` leest `perms.effective_products`. `get_user_effective_products` cross-checkt met canonical resolver als sentinel. |
| `admin/retry_provisioning.py` | 1 | `Depends(require_platform_admin())` — combined admin-role + platform-org gate. |

## Phase 1 follow-up bug fix

`require_platform_admin()` checkt nu **ook** `ProfileRole.ADMIN` naast `is_platform_admin`. Voorheen had een `personal`-rol user binnen de `getklai` org de gate kunnen passeren — de imperatieve pattern die deze gate vervangt is altijd de combinatie `_require_admin(caller_user) + _require_platform_admin(caller_org)`. Pinned via vier nieuwe parametrised tests in `test_permissions.py`.

## Static-analysis updates

`tests/test_rls_audit.py` en `tests/test_rls_callsite_audit.py` herkennen nu de declaratieve gate-factories (`get_caller_at_least`, `require_platform_admin`, `require_platform_unlocked`, `Depends(get_caller)`) als legitieme tenant-binders.

## Test migrations

Acht test-bestanden gemigreerd van het oude `patch("..._get_caller_org", return_value=...)` patroon naar de nieuwe `perms=make_perms(...)` kwarg (helper toegevoegd aan `tests/conftest.py`):

- `test_admin_addons.py` (6)
- `test_admin_users.py` (3)
- `test_products.py` (16)
- `test_r5_auto_accept_toggle.py` (7)
- `test_r6_admin_handover.py` (7)
- `test_retry_provisioning.py` (5 — twee role-rejection tests verwijderd; coverage zit in `test_permissions.py`)
- `test_spec_portal_admin_ui_001.py` (4)
- `test_user_lifecycle.py` (15 — gemigreerd via gescript regex-transform; `TestRequireAtLeast` tests intact)

## Test plan

- [x] `pytest tests/test_permissions.py` — 40 passed (was 36, +4 voor de `require_platform_admin` rol-check)
- [x] Volledige backend-suite — 2211 passed (was 2192, +19), 3 deselected
- [x] `ruff check` + `ruff format --check` schoon
- [x] `git grep "_require_admin(" app/api/admin/{users,settings,products,retry_provisioning}.py` → 0 matches
- [x] `git grep "_get_caller_org(" app/api/admin/{users,settings,products,retry_provisioning}.py` → 0 matches
- [ ] CI groen na push
- [ ] Post-deploy verificatie op core-01: `/api/admin/users`, `/api/admin/settings`, `/api/admin/products` op Voys via Playwright MCP

## Niet in deze PR

- `app/api/admin/__init__.py` houdt `_get_caller_org`, `_require_admin`, `_require_platform_admin` als helpers tot Phase 2b-2h alle imperative call-sites hebben omgezet. Phase 6 verwijdert ze.
- Endpoint files voor Phase 2b (audit, deprovision_org, join_requests) en verder.

## Refs

- `.moai/specs/SPEC-PORTAL-RBAC-REFACTOR-001/spec.md` — Phase 2a in de Migration & deploy tabel
- Vorige PRs: #524 (Pre-phase characterization), #527 (Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)