### PR TITLE
feat(portal): RBAC Phase 2b — admin/{audit,deprovision_org,join_requests} sweep

### DIFF
--- a/klai-portal/backend/app/api/admin/audit.py
+++ b/klai-portal/backend/app/api/admin/audit.py
@@ -3,15 +3,13 @@
 from datetime import datetime
 
 from fastapi import APIRouter, Depends
-from fastapi.security import HTTPAuthorizationCredentials
 from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import get_db
+from app.core.permissions import ProfileRole, UserPermissions, get_caller_at_least
 from app.models.audit import PortalAuditLog
-
-from . import _get_caller_org, _require_admin, bearer
 
 router = APIRouter()
 
@@ -47,7 +45,7 @@ class AuditLogResponse(BaseModel):
 
 @router.get("/audit-log", response_model=AuditLogResponse)
 async def get_audit_log(
-    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
     page: int = 1,
     size: int = 20,
@@ -60,11 +58,8 @@ async def get_audit_log(
     - action: exact match (e.g. "meeting.created")
     - resource_type: exact match (e.g. "group", "meeting", "product", "user")
     """
-    _, org, caller_user = await _get_caller_org(credentials, db)
-    _require_admin(caller_user)
-
-    query = select(PortalAuditLog).where(PortalAuditLog.org_id == org.id)
-    count_query = select(func.count(PortalAuditLog.id)).where(PortalAuditLog.org_id == org.id)
+    query = select(PortalAuditLog).where(PortalAuditLog.org_id == perms.org_id)
+    count_query = select(func.count(PortalAuditLog.id)).where(PortalAuditLog.org_id == perms.org_id)
 
     if action:
         query = query.where(PortalAuditLog.action == action)

--- a/klai-portal/backend/app/api/admin/deprovision_org.py
+++ b/klai-portal/backend/app/api/admin/deprovision_org.py
@@ -18,12 +18,17 @@ from __future__ import annotations
 
 import structlog
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
-from fastapi.security import HTTPAuthorizationCredentials
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.admin import _get_caller_org, _require_admin, _require_platform_admin, bearer
 from app.core.database import get_db
+from app.core.permissions import (
+    ProfileRole,
+    UserPermissions,
+    get_caller_at_least,
+    get_caller_during_deprovisioning,
+    require_platform_admin,
+)
 from app.models.portal import PortalOrg
 from app.services.provisioning.deprovisioning_orchestrator import deprovision_tenant
 
@@ -134,7 +139,7 @@ def _guard_entry_state(org: PortalOrg) -> None:
     status_code=status.HTTP_200_OK,
 )
 async def get_own_org(
-    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    perms: UserPermissions = Depends(get_caller_during_deprovisioning),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, str]:
     """Owner-readable metadata for the caller's current organisation.
@@ -149,20 +154,24 @@ async def get_own_org(
     the GET counterpart. SPEC-INFRA-TENANT-DELETE-001 R10.
 
     # @MX:NOTE: SPEC-INFRA-TENANT-DELETE-001 R10. Read-only sibling of the
-    # DELETE /org/me endpoint. Same auth pattern. No state-machine guard:
-    # if the org is already in a deprovisioning state the modal still
-    # needs slug+name to render the polling UI.
+    # DELETE /org/me endpoint. Uses ``get_caller_during_deprovisioning`` so
+    # the danger-zone modal stays renderable while the org is being deleted.
+    # Inline admin-role check below — `get_caller_during_deprovisioning`
+    # accepts any role; only admins should see this metadata.
     """
-    _, caller_org, caller_user = await _get_caller_org(
-        credentials,
-        db,
-        allow_during_deprovisioning=True,
-    )
-    _require_admin(caller_user)
+    if perms.effective_role != ProfileRole.ADMIN:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied: admin role required",
+        )
 
+    # Re-fetch the PortalOrg row for `name` — UserPermissions does not carry it.
+    org = await db.get(PortalOrg, perms.org_id)
+    if org is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Organisation not found")
     return {
-        "slug": caller_org.slug,
-        "name": caller_org.name,
+        "slug": org.slug,
+        "name": org.name,
     }
 
 
@@ -177,7 +186,7 @@ async def get_own_org(
 )
 async def deprovision_own_org(
     background_tasks: BackgroundTasks,
-    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, str]:
     """Owner-initiated tenant deletion.
@@ -187,11 +196,8 @@ async def deprovision_own_org(
 
     # @MX:NOTE: SPEC-INFRA-TENANT-DELETE-001 R1. deprovisioner_type='owner'.
     """
-    zitadel_user_id, caller_org, caller_user = await _get_caller_org(credentials, db)
-    _require_admin(caller_user)
-
     # Lock the row and verify state before transitioning.
-    locked_org = await _lock_org_for_deprovision(caller_org.id, db)
+    locked_org = await _lock_org_for_deprovision(perms.org_id, db)
     _guard_entry_state(locked_org)
 
     # Transition to 'deprovisioning' so auth-flow returns 403 for all subsequent requests.
@@ -205,13 +211,13 @@ async def deprovision_own_org(
         org_id=org_id,
         slug=org_slug,
         deprovisioner_type="owner",
-        actor=zitadel_user_id,
+        actor=perms.user_id,
     )
 
     background_tasks.add_task(
         deprovision_tenant,
         org_id,
-        zitadel_user_id,
+        perms.user_id,
         "owner",
     )
 
@@ -230,7 +236,7 @@ async def deprovision_own_org(
 async def deprovision_org_by_slug(
     slug: str,
     background_tasks: BackgroundTasks,
-    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    perms: UserPermissions = Depends(require_platform_admin()),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, str]:
     """Platform-admin tenant deletion by slug.
@@ -241,10 +247,6 @@ async def deprovision_org_by_slug(
 
     # @MX:NOTE: SPEC-INFRA-TENANT-DELETE-001 R1. deprovisioner_type='platform_admin'.
     """
-    zitadel_user_id, caller_org, caller_user = await _get_caller_org(credentials, db)
-    _require_admin(caller_user)
-    _require_platform_admin(caller_org)
-
     target_org = await _find_org_by_slug(slug, db)
     if target_org is None:
         raise HTTPException(
@@ -266,13 +268,13 @@ async def deprovision_org_by_slug(
         org_id=org_id,
         slug=org_slug,
         deprovisioner_type="platform_admin",
-        actor=zitadel_user_id,
+        actor=perms.user_id,
     )
 
     background_tasks.add_task(
         deprovision_tenant,
         org_id,
-        zitadel_user_id,
+        perms.user_id,
         "platform_admin",
     )
 
@@ -291,7 +293,7 @@ async def deprovision_org_by_slug(
 async def retry_deprovisioning(
     slug: str,
     background_tasks: BackgroundTasks,
-    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    perms: UserPermissions = Depends(require_platform_admin()),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, str]:
     """Retry deprovisioning from failed_deprovisioning state.
@@ -304,10 +306,6 @@ async def retry_deprovisioning(
     #   re-queueing so admin knows the retry is fresh. Step idempotency ensures
     #   already-deleted resources are skipped harmlessly.
     """
-    zitadel_user_id, caller_org, caller_user = await _get_caller_org(credentials, db)
-    _require_admin(caller_user)
-    _require_platform_admin(caller_org)
-
     target_org = await _find_org_by_slug(slug, db)
     if target_org is None:
         raise HTTPException(
@@ -339,13 +337,13 @@ async def retry_deprovisioning(
         "deprovision_retry_queued",
         org_id=org_id,
         slug=slug,
-        actor=zitadel_user_id,
+        actor=perms.user_id,
     )
 
     background_tasks.add_task(
         deprovision_tenant,
         org_id,
-        zitadel_user_id,
+        perms.user_id,
         "platform_admin",
     )
 
@@ -362,38 +360,39 @@ async def retry_deprovisioning(
     status_code=status.HTTP_200_OK,
 )
 async def get_deprovision_status(
-    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    perms: UserPermissions = Depends(get_caller_during_deprovisioning),
     db: AsyncSession = Depends(get_db),
 ) -> dict:
     """Owner polling endpoint for deprovisioning progress.
 
-    Uses allow_during_deprovisioning=True so the 403 guard in _get_caller_org
-    does not fire while the org is being deleted. Returns:
+    Uses ``get_caller_during_deprovisioning`` so the 403 ``tenant_deleting``
+    guard does not fire while the org is being deleted. Returns:
     - 200 + {"status": "deprovisioning"} while in progress.
     - 200 + {"status": "failed_deprovisioning", "last_failure": {...}} on failure.
     - 200 + {"status": <other>} for orgs not currently being deprovisioned.
     - 404 if the org row is gone (successful deprovisioning).
 
-    # @MX:NOTE: SPEC-INFRA-TENANT-DELETE-001 R10. allow_during_deprovisioning=True
+    # @MX:NOTE: SPEC-INFRA-TENANT-DELETE-001 R10. ``get_caller_during_deprovisioning``
     #   is the ONE exception to the standard 403 deprovisioning guard. Do not add
-    #   other endpoints with this flag without SPEC justification.
+    #   other endpoints with this dep without SPEC justification.
     """
-    try:
-        _, org, caller_user = await _get_caller_org(credentials, db, allow_during_deprovisioning=True)
-    except HTTPException as exc:
-        if exc.status_code == status.HTTP_404_NOT_FOUND:
-            # Org row is gone — successful deprovisioning completed.
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="Organisation has been deleted",
-            ) from exc
-        raise
-
     # SEC: only org-owner (admin role) may poll deprovisioning status. Without
     # this guard, members/group-admins could see step names + (previously) full
     # error strings during a failed deprovision — info disclosure of internal
     # infrastructure (container hostnames, step orchestration internals).
-    _require_admin(caller_user)
+    if perms.effective_role != ProfileRole.ADMIN:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied: admin role required",
+        )
+
+    org = await db.get(PortalOrg, perms.org_id)
+    if org is None:
+        # Org row is gone — successful deprovisioning completed.
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Organisation has been deleted",
+        )
 
     payload: dict = {"status": org.provisioning_status}
     if org.provisioning_status == "failed_deprovisioning" and org.last_failure:

--- a/klai-portal/backend/app/api/admin/join_requests.py
+++ b/klai-portal/backend/app/api/admin/join_requests.py
@@ -15,9 +15,15 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.admin import _get_caller_org, _require_admin, bearer
+from app.api.admin import bearer
 from app.core.config import settings
 from app.core.database import get_db
+from app.core.permissions import (
+    ProfileRole,
+    UserPermissions,
+    _resolve_caller_with_options,
+    get_caller_at_least,
+)
 from app.models.portal import PortalJoinRequest, PortalUser
 from app.services.join_request_token import verify_approval_token
 from app.services.notifications import notify_user_join_approved
@@ -56,17 +62,14 @@ class ApproveResponse(BaseModel):
 
 @router.get("/join-requests", response_model=JoinRequestsResponse)
 async def list_join_requests(
-    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
 ) -> JoinRequestsResponse:
     """List pending join requests for the caller's org."""
-    _zitadel_user_id, org, caller_user = await _get_caller_org(credentials, db)
-    _require_admin(caller_user)
-
     result = await db.execute(
         select(PortalJoinRequest)
         .where(
-            PortalJoinRequest.org_id == org.id,
+            PortalJoinRequest.org_id == perms.org_id,
             PortalJoinRequest.status == "pending",
         )
         .order_by(PortalJoinRequest.requested_at.desc())
@@ -127,16 +130,23 @@ async def approve_join_request(
                 detail="This request has no organisation assigned. Approve it from the admin panel.",
             )
     else:
-        # Bearer-based approval (admin UI)
+        # Bearer-based approval (admin UI). The endpoint accepts an OPTIONAL
+        # Bearer (the token-based path needs no auth) so we can't use a
+        # `Depends(get_caller_at_least(ADMIN))` on the signature; resolve
+        # caller explicitly via the shared core helper.
         if not credentials:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
-        zitadel_user_id, org, caller_user = await _get_caller_org(credentials, db)
-        _require_admin(caller_user)
+        perms = await _resolve_caller_with_options(credentials, db, allow_during_deprovisioning=False)
+        if perms.effective_role != ProfileRole.ADMIN:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Role {ProfileRole.ADMIN.value!r} or higher required",
+            )
 
         jr_result = await db.execute(
             select(PortalJoinRequest).where(
                 PortalJoinRequest.id == request_id,
-                PortalJoinRequest.org_id == org.id,
+                PortalJoinRequest.org_id == perms.org_id,
                 PortalJoinRequest.status == "pending",
             )
         )
@@ -144,8 +154,8 @@ async def approve_join_request(
         if not jr:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Request not found")
 
-        reviewer = zitadel_user_id
-        org_id = org.id
+        reviewer = perms.user_id
+        org_id = perms.org_id
 
     # Create portal_users row
     new_user = PortalUser(
@@ -190,17 +200,14 @@ async def approve_join_request(
 @router.post("/join-requests/{request_id}/deny", status_code=status.HTTP_204_NO_CONTENT)
 async def deny_join_request(
     request_id: int,
-    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
 ) -> None:
     """Deny a join request."""
-    zitadel_user_id, org, caller_user = await _get_caller_org(credentials, db)
-    _require_admin(caller_user)
-
     jr_result = await db.execute(
         select(PortalJoinRequest).where(
             PortalJoinRequest.id == request_id,
-            PortalJoinRequest.org_id == org.id,
+            PortalJoinRequest.org_id == perms.org_id,
             PortalJoinRequest.status == "pending",
         )
     )
@@ -210,13 +217,13 @@ async def deny_join_request(
 
     jr.status = "denied"
     jr.reviewed_at = datetime.now(tz=UTC)
-    jr.reviewed_by = zitadel_user_id
+    jr.reviewed_by = perms.user_id
     await db.commit()
 
     logger.info(
         "Join request denied",
         request_id=request_id,
         zitadel_user_id=jr.zitadel_user_id,
-        org_id=org.id,
-        reviewer=zitadel_user_id,
+        org_id=perms.org_id,
+        reviewer=perms.user_id,
     )

--- a/klai-portal/backend/app/core/permissions.py
+++ b/klai-portal/backend/app/core/permissions.py
@@ -177,22 +177,17 @@ async def resolve_user_permissions(zitadel_user_id: str, db: AsyncSession) -> Us
 # ---------------------------------------------------------------------------
 
 
-# @MX:ANCHOR fan_in=8+ — primary FastAPI dependency for portal endpoints.
-# Phase 2 sweeps `_get_caller_org` callers to this; treat as stable.
-async def get_caller(
-    credentials: HTTPAuthorizationCredentials = Depends(bearer),
-    db: AsyncSession = Depends(get_db),
+async def _resolve_caller_with_options(
+    credentials: HTTPAuthorizationCredentials,
+    db: AsyncSession,
+    *,
+    allow_during_deprovisioning: bool,
 ) -> UserPermissions:
-    """Validate the bearer token and return a frozen ``UserPermissions``.
+    """Shared body for ``get_caller`` and ``get_caller_during_deprovisioning``.
 
-    Mirrors the existing ``admin/__init__::_get_caller_org`` semantics:
-    - 401 if the token is invalid
-    - 401 if the token has no `sub` claim
-    - 404 if the zitadel user has no portal row
-    - 403 (``error=tenant_deleting``) if the org is in deprovisioning state
-    - sets the RLS tenant GUC for this connection
-    - sets ``app.is_platform_admin`` GUC for callers in the platform org
-    - binds ``org_id`` + ``user_id`` into structlog contextvars
+    Both gates do the exact same token-validation + RLS tenant binding +
+    structlog binding; they differ only in whether the
+    SPEC-INFRA-TENANT-DELETE-001 R1 ``tenant_deleting`` 403 is enforced.
     """
     try:
         info = await zitadel.get_userinfo(credentials.credentials)
@@ -208,10 +203,7 @@ async def get_caller(
     if perms is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Organisation not found")
 
-    # SPEC-INFRA-TENANT-DELETE-001 R1: block all admin actions while the org is
-    # being deleted. ``provisioning_status`` was carried out of the resolver's
-    # single query — no extra roundtrip.
-    if perms.provisioning_status == "deprovisioning":
+    if not allow_during_deprovisioning and perms.provisioning_status == "deprovisioning":
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail={
@@ -230,6 +222,41 @@ async def get_caller(
 
     structlog.contextvars.bind_contextvars(org_id=str(perms.org_id), user_id=zitadel_user_id)
     return perms
+
+
+# @MX:ANCHOR fan_in=8+ — primary FastAPI dependency for portal endpoints.
+# Phase 2 sweeps `_get_caller_org` callers to this; treat as stable.
+async def get_caller(
+    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    db: AsyncSession = Depends(get_db),
+) -> UserPermissions:
+    """Validate the bearer token and return a frozen ``UserPermissions``.
+
+    Mirrors the existing ``admin/__init__::_get_caller_org`` semantics:
+    - 401 if the token is invalid
+    - 401 if the token has no `sub` claim
+    - 404 if the zitadel user has no portal row
+    - 403 (``error=tenant_deleting``) if the org is in deprovisioning state
+    - sets the RLS tenant GUC for this connection
+    - sets ``app.is_platform_admin`` GUC for callers in the platform org
+    - binds ``org_id`` + ``user_id`` into structlog contextvars
+    """
+    return await _resolve_caller_with_options(credentials, db, allow_during_deprovisioning=False)
+
+
+async def get_caller_during_deprovisioning(
+    credentials: HTTPAuthorizationCredentials = Depends(bearer),
+    db: AsyncSession = Depends(get_db),
+) -> UserPermissions:
+    """Variant of ``get_caller`` that does NOT block on deprovisioning state.
+
+    SPEC-INFRA-TENANT-DELETE-001 R1 narrow exception: the
+    ``GET /api/admin/orgs/{slug}/deprovision-status`` endpoint must keep
+    surfacing progress while the tenant is being deleted, otherwise admins
+    can't observe the orchestrator finishing. All other admin actions
+    still hit the 403 via ``get_caller``. Use sparingly.
+    """
+    return await _resolve_caller_with_options(credentials, db, allow_during_deprovisioning=True)
 
 
 def get_caller_at_least(min_role: ProfileRole):

--- a/klai-portal/backend/tests/test_admin_join_requests.py
+++ b/klai-portal/backend/tests/test_admin_join_requests.py
@@ -5,6 +5,13 @@ Covers:
 - GET /api/admin/join-requests (list pending)
 - POST /api/admin/join-requests/{id}/approve
 - POST /api/admin/join-requests/{id}/deny
+
+SPEC-PORTAL-RBAC-REFACTOR-001 Phase 2b:
+- list_join_requests + deny_join_request use ``Depends(get_caller_at_least(ADMIN))``;
+  non-admin 403 is pinned in test_permissions.py.
+- approve_join_request keeps an OPTIONAL Bearer (token-based path needs no
+  auth) and resolves the caller via the shared `_resolve_caller_with_options`
+  helper. The non-admin 403 lives inside the endpoint and is tested here.
 """
 
 from datetime import UTC, datetime
@@ -13,18 +20,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import HTTPException
 
-
-def _mock_org(org_id: int = 1) -> MagicMock:
-    org = MagicMock()
-    org.id = org_id
-    org.slug = "acme"
-    return org
-
-
-def _mock_admin_user() -> MagicMock:
-    user = MagicMock()
-    user.role = "admin"
-    return user
+from tests.conftest import make_perms
 
 
 def _mock_join_request(request_id: int = 1, status: str = "pending") -> MagicMock:
@@ -57,11 +53,10 @@ class TestListJoinRequests:
         mock_db = AsyncMock()
         mock_db.execute = AsyncMock(return_value=mock_result)
 
-        mock_credentials = MagicMock()
-
-        with patch("app.api.admin.join_requests._get_caller_org") as mock_get_org:
-            mock_get_org.return_value = ("admin-1", _mock_org(), _mock_admin_user())
-            response = await list_join_requests(credentials=mock_credentials, db=mock_db)
+        response = await list_join_requests(
+            perms=make_perms(role="admin", org_id=1),
+            db=mock_db,
+        )
 
         assert len(response.requests) == 1
         assert response.requests[0].email == "test@company.com"
@@ -72,40 +67,62 @@ class TestApproveJoinRequest:
 
     @pytest.mark.asyncio
     async def test_non_admin_rejected(self) -> None:
+        """Bearer-based approval must reject non-admin callers.
+
+        approve_join_request takes an OPTIONAL Bearer (the token-based
+        email-link path needs no auth), so the role check is inline in
+        the endpoint, not via `get_caller_at_least`. We mock the resolver
+        helper to return a non-admin perms snapshot.
+        """
         from app.api.admin.join_requests import approve_join_request
 
         mock_db = AsyncMock()
         mock_credentials = MagicMock()
-        member = MagicMock()
-        member.role = "member"
+        non_admin_perms = make_perms(role="company", org_id=1)
 
-        with (
-            patch("app.api.admin.join_requests._get_caller_org") as mock_get_org,
-            pytest.raises(HTTPException) as exc_info,
+        with patch(
+            "app.api.admin.join_requests._resolve_caller_with_options",
+            new=AsyncMock(return_value=non_admin_perms),
         ):
-            mock_get_org.return_value = ("admin-1", _mock_org(), member)
-            await approve_join_request(request_id=1, credentials=mock_credentials, db=mock_db, token=None)
+            with pytest.raises(HTTPException) as exc_info:
+                await approve_join_request(
+                    request_id=1,
+                    credentials=mock_credentials,
+                    db=mock_db,
+                    token=None,
+                )
 
         assert exc_info.value.status_code == 403
 
 
 class TestDenyJoinRequest:
-    """POST /api/admin/join-requests/{id}/deny marks request as denied."""
+    """POST /api/admin/join-requests/{id}/deny marks request as denied.
+
+    Phase 2b: the non-admin 403 branch is now enforced by
+    ``Depends(get_caller_at_least(ProfileRole.ADMIN))`` and pinned in
+    `test_permissions.py::test_get_caller_at_least_role_matrix`. The
+    test here was a duplicate of that role-matrix coverage; it has been
+    removed in favour of a happy-path smoke test that exercises the
+    actual deny flow against a pending request.
+    """
 
     @pytest.mark.asyncio
-    async def test_non_admin_rejected(self) -> None:
+    async def test_admin_marks_request_denied(self) -> None:
         from app.api.admin.join_requests import deny_join_request
 
+        jr = _mock_join_request()
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = jr
+
         mock_db = AsyncMock()
-        mock_credentials = MagicMock()
-        member = MagicMock()
-        member.role = "member"
+        mock_db.execute = AsyncMock(return_value=result)
 
-        with (
-            patch("app.api.admin.join_requests._get_caller_org") as mock_get_org,
-            pytest.raises(HTTPException) as exc_info,
-        ):
-            mock_get_org.return_value = ("admin-1", _mock_org(), member)
-            await deny_join_request(request_id=1, credentials=mock_credentials, db=mock_db)
+        await deny_join_request(
+            request_id=1,
+            perms=make_perms(role="admin", user_id="admin-1", org_id=1),
+            db=mock_db,
+        )
 
-        assert exc_info.value.status_code == 403
+        assert jr.status == "denied"
+        assert jr.reviewed_by == "admin-1"
+        mock_db.commit.assert_awaited_once()

--- a/klai-portal/backend/tests/test_deprovision_endpoints.py
+++ b/klai-portal/backend/tests/test_deprovision_endpoints.py
@@ -5,6 +5,13 @@ Tests cover:
 - DELETE /orgs/{slug}/deprovision: platform-admin auth, slug 404, 409 states, 202
 - POST /orgs/{slug}/retry-deprovisioning: platform-admin, wrong state 409, 202
 - GET /org/me/deprovision-status: polling, 404 on gone, failed_deprovisioning + last_failure
+
+SPEC-PORTAL-RBAC-REFACTOR-001 Phase 2b: endpoints take ``perms`` directly.
+``_require_platform_admin`` is no longer imported by `deprovision_org.py`;
+the role+platform-org gate is enforced by `Depends(require_platform_admin())`
+and pinned in `tests/test_permissions.py`. The `get_own_org` and
+`get_deprovision_status` endpoints use `Depends(get_caller_during_deprovisioning)`
+so the tenant-deleting 403 doesn't fire on the polling/danger-zone path.
 """
 
 from __future__ import annotations
@@ -13,19 +20,18 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
-from helpers import FakeResult, setup_db
 
 from app.api.admin.deprovision_org import (
     _find_org_by_slug,
     _guard_entry_state,
     _lock_org_for_deprovision,
-    _require_platform_admin,
     deprovision_org_by_slug,
     deprovision_own_org,
     get_deprovision_status,
     get_own_org,
     retry_deprovisioning,
 )
+from tests.conftest import make_perms
 
 # ---------------------------------------------------------------------------
 # Shared factories
@@ -49,35 +55,6 @@ def _make_org(
     return org
 
 
-def _make_user(role: str = "admin") -> MagicMock:
-    user = MagicMock()
-    user.role = role
-    user.zitadel_user_id = "zit-user-1"
-    return user
-
-
-def _make_db(rows: list | None = None) -> AsyncMock:
-    db = AsyncMock()
-    db.add = MagicMock()
-    if rows is not None:
-        setup_db(db, [FakeResult(rows=rows)])
-    return db
-
-
-def _make_credentials(token: str = "tok") -> MagicMock:
-    creds = MagicMock()
-    creds.credentials = token
-    return creds
-
-
-def _caller_org_patch(org: MagicMock, user: MagicMock, zitadel_user_id: str = "zit-user-1"):
-    """Patch _get_caller_org to return (zitadel_user_id, org, user)."""
-    return patch(
-        "app.api.admin.deprovision_org._get_caller_org",
-        AsyncMock(return_value=(zitadel_user_id, org, user)),
-    )
-
-
 # ---------------------------------------------------------------------------
 # Unit tests — helpers
 # ---------------------------------------------------------------------------
@@ -87,11 +64,9 @@ class TestLockOrgForDeprovision:
     @pytest.mark.asyncio
     async def test_returns_locked_org(self):
         org = _make_org()
-        db = AsyncMock()
-        db.execute = AsyncMock(return_value=FakeResult(rows=[org]))
-        # scalar_one() is called on the result
         result_mock = MagicMock()
         result_mock.scalar_one.return_value = org
+        db = AsyncMock()
         db.execute = AsyncMock(return_value=result_mock)
 
         locked = await _lock_org_for_deprovision(1, db)
@@ -147,24 +122,8 @@ class TestGuardEntryState:
         assert exc_info.value.detail["error"] == "not_in_deprovisionable_state"
 
 
-class TestRequirePlatformAdmin:
-    def test_allows_platform_org(self):
-        org = _make_org(slug="getklai")
-        with patch("app.api.admin._app_settings") as mock_settings:
-            mock_settings.platform_org_slug = "getklai"
-            _require_platform_admin(org)  # no exception
-
-    def test_raises_403_for_non_platform_org(self):
-        org = _make_org(slug="acme")
-        with patch("app.api.admin._app_settings") as mock_settings:
-            mock_settings.platform_org_slug = "getklai"
-            with pytest.raises(HTTPException) as exc_info:
-                _require_platform_admin(org)
-        assert exc_info.value.status_code == 403
-
-
 # ---------------------------------------------------------------------------
-# DELETE /org/me — owner self-service
+# DELETE /org/me — owner self-service (admin role gate via Depends)
 # ---------------------------------------------------------------------------
 
 
@@ -172,18 +131,19 @@ class TestDeprovisionOwnOrg:
     @pytest.mark.asyncio
     async def test_returns_202_queued(self):
         org = _make_org(provisioning_status="ready")
-        user = _make_user(role="admin")
         db = AsyncMock()
         db.add = MagicMock()
-        creds = _make_credentials()
         background_tasks = MagicMock()
 
         locked_result = MagicMock()
         locked_result.scalar_one.return_value = org
         db.execute = AsyncMock(return_value=locked_result)
 
-        with _caller_org_patch(org, user):
-            result = await deprovision_own_org(background_tasks, creds, db)
+        result = await deprovision_own_org(
+            background_tasks,
+            perms=make_perms(role="admin", user_id="zit-user-1", org_id=1),
+            db=db,
+        )
 
         assert result == {"status": "queued", "org_slug": "acme"}
         assert org.provisioning_status == "deprovisioning"
@@ -192,23 +152,20 @@ class TestDeprovisionOwnOrg:
     @pytest.mark.asyncio
     async def test_schedules_background_task(self):
         org = _make_org(provisioning_status="ready")
-        user = _make_user(role="admin")
         db = AsyncMock()
         db.add = MagicMock()
-        creds = _make_credentials()
         background_tasks = MagicMock()
 
         locked_result = MagicMock()
         locked_result.scalar_one.return_value = org
         db.execute = AsyncMock(return_value=locked_result)
 
-        with (
-            _caller_org_patch(org, user),
-            patch(
-                "app.api.admin.deprovision_org.deprovision_tenant",
-            ) as mock_dt,
-        ):
-            await deprovision_own_org(background_tasks, creds, db)
+        with patch("app.api.admin.deprovision_org.deprovision_tenant") as mock_dt:
+            await deprovision_own_org(
+                background_tasks,
+                perms=make_perms(role="admin", user_id="zit-user-1", org_id=1),
+                db=db,
+            )
 
         background_tasks.add_task.assert_called_once_with(
             mock_dt,
@@ -218,36 +175,22 @@ class TestDeprovisionOwnOrg:
         )
 
     @pytest.mark.asyncio
-    async def test_raises_403_for_non_admin_user(self):
-        org = _make_org(provisioning_status="ready")
-        user = _make_user(role="member")
-        db = AsyncMock()
-        db.add = MagicMock()
-        creds = _make_credentials()
-        background_tasks = MagicMock()
-
-        with _caller_org_patch(org, user):
-            with pytest.raises(HTTPException) as exc_info:
-                await deprovision_own_org(background_tasks, creds, db)
-
-        assert exc_info.value.status_code == 403
-
-    @pytest.mark.asyncio
     async def test_raises_409_when_already_deprovisioning(self):
         org = _make_org(provisioning_status="deprovisioning")
-        user = _make_user(role="admin")
         db = AsyncMock()
         db.add = MagicMock()
-        creds = _make_credentials()
         background_tasks = MagicMock()
 
         locked_result = MagicMock()
         locked_result.scalar_one.return_value = org
         db.execute = AsyncMock(return_value=locked_result)
 
-        with _caller_org_patch(org, user):
-            with pytest.raises(HTTPException) as exc_info:
-                await deprovision_own_org(background_tasks, creds, db)
+        with pytest.raises(HTTPException) as exc_info:
+            await deprovision_own_org(
+                background_tasks,
+                perms=make_perms(role="admin", user_id="zit-user-1", org_id=1),
+                db=db,
+            )
 
         assert exc_info.value.status_code == 409
         assert exc_info.value.detail["error"] == "already_deprovisioning"
@@ -261,72 +204,46 @@ class TestDeprovisionOwnOrg:
 class TestDeprovisionOrgBySlug:
     @pytest.mark.asyncio
     async def test_returns_202_queued(self):
-        caller_org = _make_org(slug="getklai", provisioning_status="ready")
         target_org = _make_org(org_id=2, slug="acme", provisioning_status="ready")
-        user = _make_user(role="admin")
         db = AsyncMock()
         db.add = MagicMock()
-        creds = _make_credentials()
         background_tasks = MagicMock()
 
-        # First execute: _find_org_by_slug, second: _lock_org_for_deprovision
         find_result = MagicMock()
         find_result.scalar_one_or_none.return_value = target_org
         lock_result = MagicMock()
         lock_result.scalar_one.return_value = target_org
         db.execute = AsyncMock(side_effect=[find_result, lock_result])
 
-        with (
-            _caller_org_patch(caller_org, user),
-            patch("app.api.admin._app_settings") as mock_settings,
-        ):
-            mock_settings.platform_org_slug = "getklai"
-            result = await deprovision_org_by_slug("acme", background_tasks, creds, db)
+        result = await deprovision_org_by_slug(
+            "acme",
+            background_tasks,
+            perms=make_perms(role="admin", user_id="zit-user-1", org_slug="getklai", is_platform_admin=True),
+            db=db,
+        )
 
         assert result == {"status": "queued", "org_slug": "acme"}
         assert target_org.provisioning_status == "deprovisioning"
 
     @pytest.mark.asyncio
     async def test_raises_404_when_slug_not_found(self):
-        caller_org = _make_org(slug="getklai", provisioning_status="ready")
-        user = _make_user(role="admin")
         db = AsyncMock()
         db.add = MagicMock()
-        creds = _make_credentials()
         background_tasks = MagicMock()
 
         find_result = MagicMock()
         find_result.scalar_one_or_none.return_value = None
         db.execute = AsyncMock(return_value=find_result)
 
-        with (
-            _caller_org_patch(caller_org, user),
-            patch("app.api.admin._app_settings") as mock_settings,
-        ):
-            mock_settings.platform_org_slug = "getklai"
-            with pytest.raises(HTTPException) as exc_info:
-                await deprovision_org_by_slug("nonexistent", background_tasks, creds, db)
+        with pytest.raises(HTTPException) as exc_info:
+            await deprovision_org_by_slug(
+                "nonexistent",
+                background_tasks,
+                perms=make_perms(role="admin", org_slug="getklai", is_platform_admin=True),
+                db=db,
+            )
 
         assert exc_info.value.status_code == 404
-
-    @pytest.mark.asyncio
-    async def test_raises_403_for_non_platform_admin(self):
-        caller_org = _make_org(slug="acme", provisioning_status="ready")
-        user = _make_user(role="admin")
-        db = AsyncMock()
-        db.add = MagicMock()
-        creds = _make_credentials()
-        background_tasks = MagicMock()
-
-        with (
-            _caller_org_patch(caller_org, user),
-            patch("app.api.admin._app_settings") as mock_settings,
-        ):
-            mock_settings.platform_org_slug = "getklai"
-            with pytest.raises(HTTPException) as exc_info:
-                await deprovision_org_by_slug("acme", background_tasks, creds, db)
-
-        assert exc_info.value.status_code == 403
 
 
 # ---------------------------------------------------------------------------
@@ -337,12 +254,9 @@ class TestDeprovisionOrgBySlug:
 class TestRetryDeprovisioning:
     @pytest.mark.asyncio
     async def test_returns_202_queued_from_failed_state(self):
-        caller_org = _make_org(slug="getklai", provisioning_status="ready")
         target_org = _make_org(org_id=2, slug="acme", provisioning_status="failed_deprovisioning")
-        user = _make_user(role="admin")
         db = AsyncMock()
         db.add = MagicMock()
-        creds = _make_credentials()
         background_tasks = MagicMock()
 
         find_result = MagicMock()
@@ -351,24 +265,21 @@ class TestRetryDeprovisioning:
         lock_result.scalar_one.return_value = target_org
         db.execute = AsyncMock(side_effect=[find_result, lock_result, MagicMock()])
 
-        with (
-            _caller_org_patch(caller_org, user),
-            patch("app.api.admin._app_settings") as mock_settings,
-        ):
-            mock_settings.platform_org_slug = "getklai"
-            result = await retry_deprovisioning("acme", background_tasks, creds, db)
+        result = await retry_deprovisioning(
+            "acme",
+            background_tasks,
+            perms=make_perms(role="admin", user_id="zit-user-1", org_slug="getklai", is_platform_admin=True),
+            db=db,
+        )
 
         assert result == {"status": "queued"}
         assert target_org.provisioning_status == "deprovisioning"
 
     @pytest.mark.asyncio
     async def test_raises_409_when_not_in_failed_state(self):
-        caller_org = _make_org(slug="getklai", provisioning_status="ready")
         target_org = _make_org(org_id=2, slug="acme", provisioning_status="deprovisioning")
-        user = _make_user(role="admin")
         db = AsyncMock()
         db.add = MagicMock()
-        creds = _make_credentials()
         background_tasks = MagicMock()
 
         find_result = MagicMock()
@@ -377,43 +288,40 @@ class TestRetryDeprovisioning:
         lock_result.scalar_one.return_value = target_org
         db.execute = AsyncMock(side_effect=[find_result, lock_result])
 
-        with (
-            _caller_org_patch(caller_org, user),
-            patch("app.api.admin._app_settings") as mock_settings,
-        ):
-            mock_settings.platform_org_slug = "getklai"
-            with pytest.raises(HTTPException) as exc_info:
-                await retry_deprovisioning("acme", background_tasks, creds, db)
+        with pytest.raises(HTTPException) as exc_info:
+            await retry_deprovisioning(
+                "acme",
+                background_tasks,
+                perms=make_perms(role="admin", org_slug="getklai", is_platform_admin=True),
+                db=db,
+            )
 
         assert exc_info.value.status_code == 409
         assert exc_info.value.detail["error"] == "not_in_retryable_deprovision_state"
 
     @pytest.mark.asyncio
     async def test_raises_404_when_slug_not_found(self):
-        caller_org = _make_org(slug="getklai", provisioning_status="ready")
-        user = _make_user(role="admin")
         db = AsyncMock()
         db.add = MagicMock()
-        creds = _make_credentials()
         background_tasks = MagicMock()
 
         find_result = MagicMock()
         find_result.scalar_one_or_none.return_value = None
         db.execute = AsyncMock(return_value=find_result)
 
-        with (
-            _caller_org_patch(caller_org, user),
-            patch("app.api.admin._app_settings") as mock_settings,
-        ):
-            mock_settings.platform_org_slug = "getklai"
-            with pytest.raises(HTTPException) as exc_info:
-                await retry_deprovisioning("nonexistent", background_tasks, creds, db)
+        with pytest.raises(HTTPException) as exc_info:
+            await retry_deprovisioning(
+                "nonexistent",
+                background_tasks,
+                perms=make_perms(role="admin", org_slug="getklai", is_platform_admin=True),
+                db=db,
+            )
 
         assert exc_info.value.status_code == 404
 
 
 # ---------------------------------------------------------------------------
-# GET /org/me/deprovision-status
+# GET /org/me/deprovision-status (uses get_caller_during_deprovisioning)
 # ---------------------------------------------------------------------------
 
 
@@ -421,16 +329,13 @@ class TestGetDeprovisionStatus:
     @pytest.mark.asyncio
     async def test_returns_deprovisioning_status(self):
         org = _make_org(provisioning_status="deprovisioning")
-        user = _make_user()
         db = AsyncMock()
-        db.add = MagicMock()
-        creds = _make_credentials()
+        db.get = AsyncMock(return_value=org)
 
-        with patch(
-            "app.api.admin.deprovision_org._get_caller_org",
-            AsyncMock(return_value=("zit-user-1", org, user)),
-        ):
-            result = await get_deprovision_status(creds, db)
+        result = await get_deprovision_status(
+            perms=make_perms(role="admin", org_id=1, provisioning_status="deprovisioning"),
+            db=db,
+        )
 
         assert result == {"status": "deprovisioning"}
 
@@ -446,16 +351,13 @@ class TestGetDeprovisionStatus:
             "failed_at": "2026-05-03T12:00:00+00:00",
         }
         org = _make_org(provisioning_status="failed_deprovisioning", last_failure=last_failure)
-        user = _make_user()
         db = AsyncMock()
-        db.add = MagicMock()
-        creds = _make_credentials()
+        db.get = AsyncMock(return_value=org)
 
-        with patch(
-            "app.api.admin.deprovision_org._get_caller_org",
-            AsyncMock(return_value=("zit-user-1", org, user)),
-        ):
-            result = await get_deprovision_status(creds, db)
+        result = await get_deprovision_status(
+            perms=make_perms(role="admin", org_id=1, provisioning_status="failed_deprovisioning"),
+            db=db,
+        )
 
         assert result["status"] == "failed_deprovisioning"
         # Sanitized: only step + failed_at exposed, NOT error string or attempt.
@@ -467,67 +369,48 @@ class TestGetDeprovisionStatus:
         assert "attempt" not in result["last_failure"]
 
     @pytest.mark.asyncio
-    async def test_non_admin_member_blocked_by_require_admin(self):
-        """Members and group-admins MUST NOT see deprovision status — admin only."""
-        org = _make_org(provisioning_status="deprovisioning")
-        user = _make_user(role="member")  # not admin
-        db = AsyncMock()
-        db.add = MagicMock()
-        creds = _make_credentials()
+    async def test_non_admin_member_blocked(self):
+        """Members and group-admins MUST NOT see deprovision status — admin only.
 
-        with patch(
-            "app.api.admin.deprovision_org._get_caller_org",
-            AsyncMock(return_value=("zit-user-1", org, user)),
-        ):
-            with pytest.raises(HTTPException) as exc_info:
-                await get_deprovision_status(creds, db)
+        get_caller_during_deprovisioning passes any role (no min-role check),
+        so the inline admin guard inside the endpoint is what enforces this.
+        """
+        db = AsyncMock()
+        db.get = AsyncMock(return_value=_make_org(provisioning_status="deprovisioning"))
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_deprovision_status(
+                perms=make_perms(role="company", org_id=1, provisioning_status="deprovisioning"),
+                db=db,
+            )
 
         assert exc_info.value.status_code == 403
 
     @pytest.mark.asyncio
     async def test_returns_ready_when_not_deprovisioning(self):
         org = _make_org(provisioning_status="ready")
-        user = _make_user()
         db = AsyncMock()
-        db.add = MagicMock()
-        creds = _make_credentials()
+        db.get = AsyncMock(return_value=org)
 
-        with patch(
-            "app.api.admin.deprovision_org._get_caller_org",
-            AsyncMock(return_value=("zit-user-1", org, user)),
-        ):
-            result = await get_deprovision_status(creds, db)
+        result = await get_deprovision_status(
+            perms=make_perms(role="admin", org_id=1, provisioning_status="ready"),
+            db=db,
+        )
 
         assert result == {"status": "ready"}
 
     @pytest.mark.asyncio
-    async def test_passes_allow_during_deprovisioning_true(self):
-        """Verifies the status endpoint calls _get_caller_org with allow_during_deprovisioning=True."""
-        org = _make_org(provisioning_status="deprovisioning")
-        user = _make_user()
+    async def test_raises_404_when_org_row_gone(self):
+        """A successfully-deprovisioned org has its row deleted; ``db.get``
+        returns None and the endpoint returns 404."""
         db = AsyncMock()
-        db.add = MagicMock()
-        creds = _make_credentials()
-        mock_get_caller_org = AsyncMock(return_value=("zit-user-1", org, user))
+        db.get = AsyncMock(return_value=None)
 
-        with patch("app.api.admin.deprovision_org._get_caller_org", mock_get_caller_org):
-            await get_deprovision_status(creds, db)
-
-        mock_get_caller_org.assert_called_once_with(creds, db, allow_during_deprovisioning=True)
-
-    @pytest.mark.asyncio
-    async def test_raises_404_when_org_not_found(self):
-        """_get_caller_org raises 404 when org row is gone (successful deprovisioning)."""
-        db = AsyncMock()
-        db.add = MagicMock()
-        creds = _make_credentials()
-
-        with patch(
-            "app.api.admin.deprovision_org._get_caller_org",
-            AsyncMock(side_effect=HTTPException(status_code=404, detail="Organisation not found")),
-        ):
-            with pytest.raises(HTTPException) as exc_info:
-                await get_deprovision_status(creds, db)
+        with pytest.raises(HTTPException) as exc_info:
+            await get_deprovision_status(
+                perms=make_perms(role="admin", org_id=1, provisioning_status="deprovisioning"),
+                db=db,
+            )
 
         assert exc_info.value.status_code == 404
 
@@ -539,52 +422,56 @@ class TestGetOwnOrg:
     danger-zone page issued GET /api/admin/org/me and got 405 because
     only DELETE was registered. Added the GET handler to render the
     delete-modal precondition (org slug + name).
+
+    Phase 2b: uses ``get_caller_during_deprovisioning`` so the modal
+    stays renderable while the org is being deleted. Inline admin guard
+    prevents members from seeing this.
     """
 
     @pytest.mark.asyncio
     async def test_returns_slug_and_name_for_admin(self):
         org = _make_org(slug="voys")
         org.name = "Voys"
-        user = _make_user(role="admin")
         db = AsyncMock()
-        creds = _make_credentials()
+        db.get = AsyncMock(return_value=org)
 
-        with _caller_org_patch(org, user):
-            result = await get_own_org(creds, db)
+        result = await get_own_org(
+            perms=make_perms(role="admin", org_id=1, org_slug="voys"),
+            db=db,
+        )
 
         assert result == {"slug": "voys", "name": "Voys"}
 
     @pytest.mark.asyncio
     async def test_raises_403_for_non_admin(self):
-        org = _make_org(slug="voys")
-        org.name = "Voys"
-        user = _make_user(role="member")
         db = AsyncMock()
-        creds = _make_credentials()
-
-        with _caller_org_patch(org, user):
-            with pytest.raises(HTTPException) as exc_info:
-                await get_own_org(creds, db)
+        with pytest.raises(HTTPException) as exc_info:
+            await get_own_org(
+                perms=make_perms(role="company", org_id=1, org_slug="voys"),
+                db=db,
+            )
 
         assert exc_info.value.status_code == 403
 
     @pytest.mark.asyncio
     async def test_allows_during_deprovisioning(self):
-        # The modal needs slug+name to render the polling UI even after
-        # deprovisioning has started. allow_during_deprovisioning=True is
-        # the contract — verify _get_caller_org is called with that flag.
+        """The danger-zone modal needs slug+name to render the polling UI
+        even while deprovisioning is in progress. The endpoint depends on
+        ``get_caller_during_deprovisioning``, so the perms snapshot can
+        carry ``provisioning_status='deprovisioning'`` and still pass."""
         org = _make_org(slug="voys", provisioning_status="deprovisioning")
         org.name = "Voys"
-        user = _make_user(role="admin")
         db = AsyncMock()
-        creds = _make_credentials()
+        db.get = AsyncMock(return_value=org)
 
-        with patch(
-            "app.api.admin.deprovision_org._get_caller_org",
-            AsyncMock(return_value=("zit-user-1", org, user)),
-        ) as mock_caller:
-            result = await get_own_org(creds, db)
+        result = await get_own_org(
+            perms=make_perms(
+                role="admin",
+                org_id=1,
+                org_slug="voys",
+                provisioning_status="deprovisioning",
+            ),
+            db=db,
+        )
 
-        # First positional or keyword arg lands on credentials/db, then the flag.
-        mock_caller.assert_awaited_once_with(creds, db, allow_during_deprovisioning=True)
         assert result == {"slug": "voys", "name": "Voys"}


### PR DESCRIPTION
## Summary

SPEC-PORTAL-RBAC-REFACTOR-001 Phase 2b. Negen endpoints in drie files gemigreerd.

| File | Endpoints | Gates |
|---|---|---|
| `admin/audit.py` | 1 | `get_caller_at_least(ADMIN)` |
| `admin/deprovision_org.py` | 5 | `get_caller_at_least(ADMIN)` × 1, `require_platform_admin()` × 2, `get_caller_during_deprovisioning` + inline admin × 2 |
| `admin/join_requests.py` | 3 | `get_caller_at_least(ADMIN)` × 2; approve_join_request houdt optionele Bearer (email-token-pad) en doet inline admin-check via `_resolve_caller_with_options` |

## Phase 1 follow-up refactor

`core/permissions.py` heeft nu een private `_resolve_caller_with_options(credentials, db, *, allow_during_deprovisioning)` als gedeelde body voor twee public deps:

- `get_caller` — default, raised 403 ``tenant_deleting`` als de org in deprovisioning state is
- `get_caller_during_deprovisioning` — narrow exception voor de R10 status-polling + danger-zone modal

## Test plan

- [x] `pytest` — 2206 passed, 3 deselected
- [x] `ruff check` + `ruff format --check` schoon
- [x] `git grep "_require_admin(" app/api/admin/{audit,deprovision_org,join_requests}.py` → 0
- [x] `git grep "_get_caller_org(" app/api/admin/{audit,deprovision_org,join_requests}.py` → 0
- [ ] CI groen na push
- [ ] Post-deploy verificatie: /api/admin/audit-log, /api/admin/join-requests, /api/admin/org/me op Voys

## Refs

- Vorige PRs: #524, #527, #532, #533
- SPEC: https://github.com/GetKlai/klai/blob/main/.moai/specs/SPEC-PORTAL-RBAC-REFACTOR-001/spec.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)