### PR TITLE
feat(rbac): Phase 3 — close enforcement gaps REQ-6/7/12/13 (SPEC-PORTAL-RBAC-REFACTOR-001)

### DIFF
--- a/klai-portal/backend/app/api/admin/users.py
+++ b/klai-portal/backend/app/api/admin/users.py
@@ -19,6 +19,7 @@ from app.core.permissions import (
     get_caller,
     get_caller_at_least,
 )
+from app.core.profiles import assert_role_allowed_for_plan
 from app.models.groups import PortalGroup, PortalGroupMembership
 from app.models.portal import PortalOrg, PortalUser
 from app.services.audit import log_event
@@ -163,6 +164,11 @@ async def invite_user(
     # Seat enforcement: lock the org row to prevent concurrent invites
     locked_result = await db.execute(select(PortalOrg).where(PortalOrg.id == perms.org_id).with_for_update())
     org = locked_result.scalar_one()
+
+    # REQ-12 / REQ-13: plan ceiling on assignable role. Check after the org
+    # lock so concurrent plan-downgrades cannot widen the role ladder
+    # mid-invite.
+    assert_role_allowed_for_plan(body.role, org.plan)
 
     # TODO: filter by status == 'active' once AUTH-001 adds status column
     active_count = await db.scalar(select(func.count()).select_from(PortalUser).where(PortalUser.org_id == org.id))
@@ -320,6 +326,12 @@ async def update_user_role(
     # patches that both see admin_count=2 can each succeed and leave the
     # workspace with zero admins.
     await _lock_org_for_role_change(db, perms.org_id)
+
+    # REQ-12 / REQ-13: plan ceiling on assignable role. ``perms.plan`` is
+    # the plan resolved by ``get_caller_at_least`` for this transaction;
+    # the row was locked by ``_lock_org_for_role_change`` so a concurrent
+    # plan downgrade cannot race the role assignment.
+    assert_role_allowed_for_plan(body.role, perms.plan)
 
     result = await db.execute(
         select(PortalUser).where(
@@ -555,6 +567,12 @@ async def promote_admin(
     db: AsyncSession = Depends(get_db),
 ) -> MessageResponse:
     """C6.1: Promote an active member to admin. No max-admin limit."""
+    # REQ-12: plan ceiling. ``admin`` is in every plan's allow-set so this is
+    # a defensive guard — but keeping it makes the policy auditable in one
+    # place: any plan that ever drops "admin" from its allow-set will reject
+    # promotion immediately instead of silently succeeding.
+    assert_role_allowed_for_plan("admin", perms.plan)
+
     result = await db.execute(
         select(PortalUser).where(
             PortalUser.zitadel_user_id == zitadel_user_id,

--- a/klai-portal/backend/app/api/app_knowledge_bases.py
+++ b/klai-portal/backend/app/api/app_knowledge_bases.py
@@ -1560,7 +1560,9 @@ async def list_kbs_with_access(
     )
     all_kbs = result.scalars().all()
 
-    accessible_slugs = set(await get_accessible_kb_slugs(perms.user_id, db))
+    # REQ-6: pass effective_role so personal-role callers do not see org slug
+    # / default_org_role KBs in the access list.
+    accessible_slugs = set(await get_accessible_kb_slugs(perms.user_id, db, user_role=perms.effective_role.value))
 
     return [
         KBWithAccessOut(

--- a/klai-portal/backend/app/api/app_knowledge_sources.py
+++ b/klai-portal/backend/app/api/app_knowledge_sources.py
@@ -36,6 +36,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.api.dependencies import _load_org_or_500
 from app.core.database import get_db
 from app.core.permissions import UserPermissions, get_caller
+from app.core.profiles import ProfileRole
 from app.models.knowledge_bases import PortalKnowledgeBase
 from app.services import knowledge_ingest_client
 from app.services.access import get_user_role_for_kb
@@ -94,6 +95,16 @@ async def _get_writable_kb_or_raise(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Knowledge base not found",
+        )
+
+    # REQ-7: personal effective_role MUST NOT write to org-owned KBs.
+    # The check fires before role lookup because effective_role already
+    # encodes the plan-vs-profile decision; "personal" cannot earn write
+    # access via group/user grants on an org-owned KB.
+    if kb.owner_type == "org" and perms.effective_role == ProfileRole.PERSONAL:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={"error_code": "org_kb_write_requires_company"},
         )
 
     role = await get_user_role_for_kb(

--- a/klai-portal/backend/app/api/connectors.py
+++ b/klai-portal/backend/app/api/connectors.py
@@ -14,7 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.api.dependencies import _load_org_or_500, get_effective_capabilities, require_capability
 from app.core.database import get_db
 from app.core.permissions import UserPermissions, get_caller
-from app.core.profiles import Capability, check_connector_allowed
+from app.core.profiles import Capability, ProfileRole, check_connector_allowed
 from app.models.connectors import PortalConnector
 from app.models.knowledge_bases import PortalKnowledgeBase
 from app.services import knowledge_ingest_client
@@ -433,6 +433,18 @@ async def create_connector(
     db: AsyncSession = Depends(get_db),
 ) -> ConnectorOut:
     """Create a connector for a KB. Requires contributor access."""
+    # Resolve KB once — REQ-7 needs ``owner_type`` BEFORE other validation so
+    # a personal caller gets the explicit ``org_kb_write_requires_company``
+    # error_code instead of a downstream message.
+    kb = await _get_kb_with_owner_check(kb_slug, perms.user_id, perms.org_id, db)
+
+    # REQ-7: personal effective_role MUST NOT create connectors on org-owned KBs.
+    if kb.owner_type == "org" and perms.effective_role == ProfileRole.PERSONAL:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={"error_code": "org_kb_write_requires_company"},
+        )
+
     # REQ-3: personal/company roles may only use url/upload connector types
     check_connector_allowed(perms, body.connector_type)
     # G1: Plan-ceiling on external connectors. The role-level check above already
@@ -448,7 +460,6 @@ async def create_connector(
                     "plan": perms.plan,
                 },
             )
-    kb = await _get_kb_with_owner_check(kb_slug, perms.user_id, perms.org_id, db)
     resolved_content_type = body.content_type or CONTENT_TYPE_DEFAULTS.get(body.connector_type, "unknown")
     if body.allowed_assertion_modes is not None:
         invalid = set(body.allowed_assertion_modes) - VALID_ASSERTION_MODES

--- a/klai-portal/backend/app/api/knowledge.py
+++ b/klai-portal/backend/app/api/knowledge.py
@@ -64,9 +64,13 @@ async def get_knowledge_stats(
     org = await _load_org_or_500(db, perms.org_id)
     zitadel_org_id = org.zitadel_org_id
 
-    # Resolve accessible kb_slugs (personal + org + group:{id} for each membership)
+    # Resolve accessible kb_slugs (personal + org + group:{id} for each membership).
+    # REQ-6: pass effective_role so personal-role callers do not see "org" or
+    # default_org_role KBs in the slug list.
     user_id = perms.user_id
-    accessible_slugs = await get_accessible_kb_slugs(user_id, db) if user_id else ["org"]
+    accessible_slugs = (
+        await get_accessible_kb_slugs(user_id, db, user_role=perms.effective_role.value) if user_id else ["org"]
+    )
     group_slugs = [s for s in accessible_slugs if s.startswith("group:")]
 
     org_filter = {

--- a/klai-portal/backend/app/core/profiles.py
+++ b/klai-portal/backend/app/core/profiles.py
@@ -65,6 +65,52 @@ PROFILE_LADDER: list[str] = [
 # C2: SPEC-PORTAL-PROFILES-001 Phase 1.6.
 PROFILE_RANK: dict[str, int] = {role: idx for idx, role in enumerate(PROFILE_LADDER)}
 
+
+# SPEC-PORTAL-RBAC-REFACTOR-001 REQ-12 / REQ-13: plan-tier ceiling on which
+# role-strings are assignable to portal users on a given plan. Admin endpoints
+# (``invite_user``, ``update_user_role``, ``promote_admin``) MUST validate the
+# requested role against this map and reject with HTTP 403
+# ``role_not_allowed_for_plan`` when out-of-range.
+#
+# Tiers (ascending):
+#   "free"     -- single-user self-service; no group/admin features
+#   "core"     -- multi-user collaboration; group_manager exists, kb_manager does not
+#   "complete" -- full feature set; kb_manager unlocked (REQ-13)
+#
+# Why a separate map (instead of deriving from ``PLAN_LIMITS``): plan-limits
+# express runtime capabilities of an existing assignment; this map expresses
+# the assignment policy. They share the same plan keys but answer different
+# questions, so keeping them separate avoids accidentally widening the role
+# ladder when a capability is added to a plan.
+ALLOWED_PROFILES_PER_PLAN: dict[str, frozenset[str]] = {
+    "free": frozenset({"personal", "admin"}),
+    "core": frozenset({"personal", "company", "group_manager", "admin"}),
+    "complete": frozenset({"personal", "company", "kb_manager", "group_manager", "admin"}),
+}
+
+
+def assert_role_allowed_for_plan(role: str, plan: str) -> None:
+    """Raise HTTP 403 with ``role_not_allowed_for_plan`` if the requested role
+    is outside the plan's ceiling.
+
+    Unknown plans fall through to the most-restrictive ``free`` set rather
+    than fail-open. This mirrors the convention in ``get_plan_limits``.
+
+    SPEC-PORTAL-RBAC-REFACTOR-001 REQ-12 / REQ-13.
+    """
+    allowed = ALLOWED_PROFILES_PER_PLAN.get(plan, ALLOWED_PROFILES_PER_PLAN["free"])
+    if role not in allowed:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "error_code": "role_not_allowed_for_plan",
+                "role": role,
+                "plan": plan,
+                "allowed": sorted(allowed),
+            },
+        )
+
+
 # Capability strings for SPEC v0.2.0: only capabilities that are actually checked
 # via require_capability() on endpoints.  Direct-role checks (org-KB read filter,
 # append-via-chat, groups manage, billing, settings) are NOT capability strings.

--- a/klai-portal/backend/tests/test_admin_users.py
+++ b/klai-portal/backend/tests/test_admin_users.py
@@ -138,7 +138,11 @@ async def test_invite_user_grants_portal_role_to_zitadel(
     org = MagicMock()
     org.id = 101
     org.seats = 100  # plenty of headroom; do not trip seat limit
-    org.plan = "free"
+    # The role→Zitadel-grant mapping does not depend on plan; pick the plan
+    # that allows every role in the parametrize matrix so the role-mapping
+    # assertion is the one under test, not the plan ceiling. REQ-12/REQ-13
+    # plan-ceiling behaviour is covered by ``test_admin_users_plan_ceiling.py``.
+    org.plan = "complete"
 
     mock_db = AsyncMock()
     locked_org_result = MagicMock()
@@ -154,7 +158,7 @@ async def test_invite_user_grants_portal_role_to_zitadel(
         preferred_language="nl",
     )
 
-    perms = make_perms(role="admin", user_id="admin-1", org_id=101, plan="free")
+    perms = make_perms(role="admin", user_id="admin-1", org_id=101, plan="complete")
 
     with (
         patch("app.api.admin.users.zitadel") as mock_zitadel,
@@ -214,7 +218,9 @@ async def test_invite_user_creates_personal_kb_before_commit() -> None:
     org = MagicMock()
     org.id = 8  # arbitrary
     org.seats = 100
-    org.plan = "free"
+    # Plan must allow ``kb_manager`` for the role-mapping branch to be the
+    # one under test; REQ-12/REQ-13 plan ceiling is covered separately.
+    org.plan = "complete"
 
     call_order: list[str] = []
 
@@ -239,7 +245,7 @@ async def test_invite_user_creates_personal_kb_before_commit() -> None:
         preferred_language="nl",
     )
 
-    perms = make_perms(role="admin", user_id="admin-1", org_id=8, plan="free")
+    perms = make_perms(role="admin", user_id="admin-1", org_id=8, plan="complete")
 
     with (
         patch("app.api.admin.users.zitadel") as mock_zitadel,

--- a/klai-portal/backend/tests/test_rbac_phase3_enforcement.py
+++ b/klai-portal/backend/tests/test_rbac_phase3_enforcement.py
@@ -1,0 +1,440 @@
+"""SPEC-PORTAL-RBAC-REFACTOR-001 Phase 3 — enforcement gap tests.
+
+Pins three classes of enforcement that close the Phase 2 architecture gates:
+
+- REQ-6: ``personal`` effective_role MUST NOT see "org" / default_org_role
+  KBs in the access list returned by ``get_accessible_kb_slugs``. The
+  service-layer behaviour is already covered by ``test_profiles.py``;
+  this file pins that the two API endpoints (``list_kbs_with_access``,
+  ``get_knowledge_stats``) actually pass the caller's role through.
+- REQ-7: ``personal`` effective_role MUST NOT write to org-owned KBs.
+  Both ``_get_writable_kb_or_raise`` (URL/Text source POST) and
+  ``connectors.create_connector`` MUST raise HTTP 403 with
+  ``error_code=org_kb_write_requires_company``.
+- REQ-12 / REQ-13: admin-side role-assignment endpoints MUST validate
+  the requested role against ``ALLOWED_PROFILES_PER_PLAN[org.plan]``
+  and reject with HTTP 403 ``error_code=role_not_allowed_for_plan`` when
+  out-of-range. Pins all three endpoints (``invite_user``,
+  ``update_user_role``, ``promote_admin``) and the ``kb_manager``
+  vs ``free``/``core`` plan invariant.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.core.profiles import (
+    ALLOWED_PROFILES_PER_PLAN,
+    ProfileRole,
+    assert_role_allowed_for_plan,
+)
+from tests.conftest import make_perms
+
+# ---------------------------------------------------------------------------
+# Constant + helper invariants
+# ---------------------------------------------------------------------------
+
+
+class TestAllowedProfilesPerPlan:
+    """REQ-12 / REQ-13: locks the canonical plan→role allow-set so an
+    accidental edit cannot widen or narrow the policy without a test
+    failure surfacing it."""
+
+    def test_free_admin_only_plus_personal(self):
+        assert ALLOWED_PROFILES_PER_PLAN["free"] == frozenset({"personal", "admin"})
+
+    def test_core_excludes_kb_manager(self):
+        # REQ-13: kb_manager is unlocked only on ``complete``.
+        assert "kb_manager" not in ALLOWED_PROFILES_PER_PLAN["core"]
+        assert "group_manager" in ALLOWED_PROFILES_PER_PLAN["core"]
+
+    def test_complete_includes_all_five_roles(self):
+        assert ALLOWED_PROFILES_PER_PLAN["complete"] == frozenset(
+            {"personal", "company", "kb_manager", "group_manager", "admin"}
+        )
+
+
+class TestAssertRoleAllowedForPlan:
+    def test_admin_passes_on_every_plan(self):
+        # ``admin`` is a billing-decision role; it must always be assignable.
+        for plan in ("free", "core", "complete"):
+            assert_role_allowed_for_plan("admin", plan)
+
+    def test_kb_manager_rejected_on_free_with_correct_error_shape(self):
+        with pytest.raises(HTTPException) as exc:
+            assert_role_allowed_for_plan("kb_manager", "free")
+        assert exc.value.status_code == 403
+        detail = exc.value.detail
+        assert isinstance(detail, dict)
+        assert detail["error_code"] == "role_not_allowed_for_plan"
+        assert detail["role"] == "kb_manager"
+        assert detail["plan"] == "free"
+        assert "admin" in detail["allowed"]
+
+    def test_kb_manager_rejected_on_core(self):
+        with pytest.raises(HTTPException) as exc:
+            assert_role_allowed_for_plan("kb_manager", "core")
+        assert exc.value.status_code == 403
+        assert exc.value.detail["error_code"] == "role_not_allowed_for_plan"
+
+    def test_kb_manager_passes_on_complete(self):
+        assert_role_allowed_for_plan("kb_manager", "complete")
+
+    def test_unknown_plan_falls_back_to_free_set(self):
+        # Defensive: a typo in a plan field MUST NOT widen the role ladder.
+        with pytest.raises(HTTPException) as exc:
+            assert_role_allowed_for_plan("kb_manager", "totally-not-a-plan")
+        assert exc.value.detail["error_code"] == "role_not_allowed_for_plan"
+
+
+# ---------------------------------------------------------------------------
+# REQ-7 — personal cannot write to org-owned KBs
+# ---------------------------------------------------------------------------
+
+
+def _kb_mock(*, slug: str = "shared", owner_type: str = "org") -> MagicMock:
+    kb = MagicMock()
+    kb.id = 7
+    kb.slug = slug
+    kb.org_id = 1
+    kb.owner_type = owner_type
+    kb.default_org_role = None
+    kb.created_by = "owner-1"
+    return kb
+
+
+def _kb_query_db_mock(kb: MagicMock) -> AsyncMock:
+    db = AsyncMock()
+    db.add = MagicMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = kb
+    db.execute.return_value = result
+    return db
+
+
+class TestPersonalCannotWriteToOrgKB:
+    """REQ-7: ``_get_writable_kb_or_raise`` and ``create_connector`` raise
+    HTTP 403 ``org_kb_write_requires_company`` when a personal-role caller
+    targets an org-owned KB."""
+
+    @pytest.mark.asyncio
+    async def test_get_writable_kb_or_raise_403_for_personal_on_org_kb(self):
+        from app.api.app_knowledge_sources import _get_writable_kb_or_raise
+
+        kb = _kb_mock(owner_type="org")
+        db = _kb_query_db_mock(kb)
+        perms = make_perms(role="personal", user_id="alice", org_id=1)
+
+        with pytest.raises(HTTPException) as exc:
+            await _get_writable_kb_or_raise("shared", perms, db)
+
+        assert exc.value.status_code == 403
+        assert exc.value.detail == {"error_code": "org_kb_write_requires_company"}
+
+    @pytest.mark.asyncio
+    async def test_get_writable_kb_or_raise_403_fires_before_role_lookup(self):
+        """The 403 fires synchronously after the KB query — no expensive
+        ``get_user_role_for_kb`` call is made for personal callers (avoids
+        leaking signal that an org-KB exists or computing role in vain).
+        """
+        from app.api.app_knowledge_sources import _get_writable_kb_or_raise
+
+        kb = _kb_mock(owner_type="org")
+        db = _kb_query_db_mock(kb)
+        perms = make_perms(role="personal", user_id="alice", org_id=1)
+
+        with patch(
+            "app.api.app_knowledge_sources.get_user_role_for_kb",
+            new=AsyncMock(),
+        ) as mock_role:
+            with pytest.raises(HTTPException):
+                await _get_writable_kb_or_raise("shared", perms, db)
+        mock_role.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_writable_kb_or_raise_passes_for_personal_on_user_kb(self):
+        """Personal-owned KBs (``owner_type="user"``) MUST still be writable
+        by the owner — the gate is org-KB-specific."""
+        from app.api.app_knowledge_sources import _get_writable_kb_or_raise
+
+        kb = _kb_mock(owner_type="user")
+        db = _kb_query_db_mock(kb)
+        perms = make_perms(role="personal", user_id="alice", org_id=1)
+
+        with (
+            patch(
+                "app.api.app_knowledge_sources.get_user_role_for_kb",
+                new=AsyncMock(return_value="owner"),
+            ),
+            patch(
+                "app.api.app_knowledge_sources._load_org_or_500",
+                new=AsyncMock(return_value=MagicMock()),
+            ),
+            patch(
+                "app.api.app_knowledge_sources.assert_can_add_item_to_kb",
+                new=AsyncMock(),
+            ),
+        ):
+            result = await _get_writable_kb_or_raise("personal", perms, db)
+        assert result is kb
+
+    @pytest.mark.asyncio
+    async def test_get_writable_kb_or_raise_passes_for_company_on_org_kb(self):
+        """Company effective_role MAY write to org-owned KBs (gate is
+        personal-specific). Confirms the new check does not over-block."""
+        from app.api.app_knowledge_sources import _get_writable_kb_or_raise
+
+        kb = _kb_mock(owner_type="org")
+        db = _kb_query_db_mock(kb)
+        perms = make_perms(role="company", user_id="bob", org_id=1)
+
+        with (
+            patch(
+                "app.api.app_knowledge_sources.get_user_role_for_kb",
+                new=AsyncMock(return_value="contributor"),
+            ),
+            patch(
+                "app.api.app_knowledge_sources._load_org_or_500",
+                new=AsyncMock(return_value=MagicMock()),
+            ),
+            patch(
+                "app.api.app_knowledge_sources.assert_can_add_item_to_kb",
+                new=AsyncMock(),
+            ),
+        ):
+            result = await _get_writable_kb_or_raise("shared", perms, db)
+        assert result is kb
+
+    @pytest.mark.asyncio
+    async def test_create_connector_403_for_personal_on_org_kb(self):
+        """Same REQ-7 gate must fire on the connector-create path."""
+        from app.api.connectors import ConnectorCreateRequest, create_connector
+
+        kb = _kb_mock(owner_type="org")
+        db = AsyncMock()
+
+        body = ConnectorCreateRequest(
+            name="GitHub",
+            connector_type="github",
+            config={"repo": "klai/portal"},
+            schedule="manual",
+        )
+        perms = make_perms(role="personal", user_id="alice", org_id=1)
+
+        with patch(
+            "app.api.connectors._get_kb_with_owner_check",
+            new=AsyncMock(return_value=kb),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await create_connector(kb_slug="shared", body=body, perms=perms, db=db)
+
+        assert exc.value.status_code == 403
+        assert exc.value.detail == {"error_code": "org_kb_write_requires_company"}
+
+
+# ---------------------------------------------------------------------------
+# REQ-12 / REQ-13 — plan-ceiling on admin endpoints
+# ---------------------------------------------------------------------------
+
+
+class TestPlanCeilingOnRoleAssignment:
+    """REQ-12: invite_user / update_user_role / promote_admin reject roles
+    outside the org plan's allow-set with HTTP 403 ``role_not_allowed_for_plan``."""
+
+    @pytest.mark.asyncio
+    async def test_invite_user_rejects_kb_manager_on_core(self):
+        from app.api.admin.users import InviteRequest, invite_user
+
+        org = MagicMock()
+        org.id = 101
+        org.seats = 100
+        org.plan = "core"  # REQ-13: kb_manager NOT allowed on core
+
+        mock_db = AsyncMock()
+        locked_org_result = MagicMock()
+        locked_org_result.scalar_one.return_value = org
+        mock_db.execute.return_value = locked_org_result
+        mock_db.scalar.return_value = 0
+
+        body = InviteRequest(
+            email="km@example.com",
+            first_name="K",
+            last_name="M",
+            role="kb_manager",
+            preferred_language="nl",
+        )
+        perms = make_perms(role="admin", user_id="admin-1", org_id=101, plan="core")
+
+        with pytest.raises(HTTPException) as exc:
+            await invite_user(body=body, perms=perms, db=mock_db)
+
+        assert exc.value.status_code == 403
+        assert exc.value.detail["error_code"] == "role_not_allowed_for_plan"
+        assert exc.value.detail["role"] == "kb_manager"
+        assert exc.value.detail["plan"] == "core"
+
+    @pytest.mark.asyncio
+    async def test_invite_user_accepts_kb_manager_on_complete(self):
+        """The mirror case: ``complete`` plan accepts ``kb_manager``.
+
+        We rely on the existing ``test_invite_user_grants_portal_role_to_zitadel``
+        parametrize for full role-mapping coverage; this test pins the
+        plan-ceiling path specifically does not over-block.
+        """
+        from app.api.admin.users import InviteRequest, invite_user
+
+        org = MagicMock()
+        org.id = 101
+        org.seats = 100
+        org.plan = "complete"
+
+        mock_db = AsyncMock()
+        locked_org_result = MagicMock()
+        locked_org_result.scalar_one.return_value = org
+        mock_db.execute.return_value = locked_org_result
+        mock_db.scalar.return_value = 0
+
+        body = InviteRequest(
+            email="km@example.com",
+            first_name="K",
+            last_name="M",
+            role="kb_manager",
+            preferred_language="nl",
+        )
+        perms = make_perms(role="admin", user_id="admin-1", org_id=101, plan="complete")
+
+        with (
+            patch("app.api.admin.users.zitadel") as mock_zitadel,
+            patch(
+                "app.services.default_knowledge_bases.create_default_personal_kb",
+                new=AsyncMock(),
+            ),
+        ):
+            mock_zitadel.invite_user = AsyncMock(return_value={"userId": "new-km"})
+            mock_zitadel.grant_user_role = AsyncMock()
+            # Should not raise — plan permits the role.
+            await invite_user(body=body, perms=perms, db=mock_db)
+
+    @pytest.mark.asyncio
+    async def test_update_user_role_rejects_company_on_free(self):
+        from app.api.admin.users import RoleUpdateRequest, update_user_role
+
+        mock_db = AsyncMock()
+        body = RoleUpdateRequest(role="company")
+        perms = make_perms(role="admin", user_id="admin-1", org_id=42, plan="free")
+
+        with patch(
+            "app.api.admin.users._lock_org_for_role_change",
+            new=AsyncMock(),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await update_user_role(zitadel_user_id="zit-2", body=body, perms=perms, db=mock_db)
+
+        assert exc.value.status_code == 403
+        assert exc.value.detail["error_code"] == "role_not_allowed_for_plan"
+        assert exc.value.detail["role"] == "company"
+        assert exc.value.detail["plan"] == "free"
+
+    @pytest.mark.asyncio
+    async def test_promote_admin_passes_on_every_plan(self):
+        """``admin`` is the one role every plan must accept; this guards
+        against an accidental tightening (e.g. dropping admin from the
+        ``free`` set) silently breaking owner-self-promote flows.
+        """
+        from app.api.admin.users import promote_admin
+
+        for plan in ("free", "core", "complete"):
+            mock_db = AsyncMock()
+            target = MagicMock()
+            target.role = "company"
+            target.zitadel_user_id = "zit-target"
+            execute_result = MagicMock()
+            execute_result.scalar_one_or_none.return_value = target
+            mock_db.execute.return_value = execute_result
+            mock_db.commit = AsyncMock()
+
+            perms = make_perms(role="admin", user_id="admin-1", org_id=10, plan=plan)
+
+            with (
+                patch("app.api.admin.users.emit_event"),
+                patch(
+                    "app.api.admin.users.log_event",
+                    new=AsyncMock(),
+                ),
+                patch(
+                    "app.api.admin.users.zitadel.grant_user_role",
+                    new=AsyncMock(),
+                ),
+            ):
+                # Must not raise on any plan — admin is always allowed.
+                await promote_admin(zitadel_user_id="zit-target", perms=perms, db=mock_db)
+
+
+# ---------------------------------------------------------------------------
+# REQ-6 — endpoint passes effective_role through to get_accessible_kb_slugs
+# ---------------------------------------------------------------------------
+
+
+class TestEndpointsPassRoleToAccessFilter:
+    """REQ-6: the API layer must hand the caller's effective_role down to
+    ``get_accessible_kb_slugs`` so the personal-role exclusion fires.
+
+    The service-layer filtering itself is already covered by
+    ``tests/test_profiles.py::test_personal_role_skips_default_org_role_kbs``.
+    These tests pin the wiring contract.
+    """
+
+    @pytest.mark.asyncio
+    async def test_list_kbs_with_access_forwards_effective_role(self):
+        from app.api.app_knowledge_bases import list_kbs_with_access
+
+        db = AsyncMock()
+        empty_result = MagicMock()
+        empty_result.scalars.return_value.all.return_value = []
+        db.execute.return_value = empty_result
+        perms = make_perms(role="personal", user_id="alice", org_id=1)
+
+        with patch(
+            "app.services.access.get_accessible_kb_slugs",
+            new=AsyncMock(return_value=[]),
+        ) as mock_slugs:
+            await list_kbs_with_access(perms=perms, db=db)
+
+        mock_slugs.assert_awaited_once()
+        kwargs = mock_slugs.await_args.kwargs
+        assert kwargs.get("user_role") == ProfileRole.PERSONAL.value, (
+            "list_kbs_with_access MUST pass user_role=perms.effective_role.value to "
+            "get_accessible_kb_slugs so personal-role callers do not see the org slug."
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_knowledge_stats_forwards_effective_role(self):
+        from app.api.knowledge import get_knowledge_stats
+
+        org = MagicMock()
+        org.zitadel_org_id = "zit-org-1"
+        db = AsyncMock()
+        perms = make_perms(role="personal", user_id="alice", org_id=1)
+
+        with (
+            patch(
+                "app.api.knowledge._load_org_or_500",
+                new=AsyncMock(return_value=org),
+            ),
+            patch(
+                "app.api.knowledge.get_accessible_kb_slugs",
+                new=AsyncMock(return_value=["personal-alice"]),
+            ) as mock_slugs,
+            patch(
+                "app.api.knowledge.asyncio.gather",
+                new=AsyncMock(return_value=[0, 0]),
+            ),
+        ):
+            await get_knowledge_stats(perms=perms, db=db)
+
+        mock_slugs.assert_awaited_once()
+        kwargs = mock_slugs.await_args.kwargs
+        assert kwargs.get("user_role") == ProfileRole.PERSONAL.value


### PR DESCRIPTION
## Summary

Phase 3 closes the four security-relevant enforcement gaps that the Phase 2 architecture refactor enabled but didn't yet fire on:

| REQ | Gate |
|---|---|
| **REQ-6** | Personal effective_role MUST NOT see org / default_org_role KBs in the access list |
| **REQ-7** | Personal effective_role MUST NOT write to org-owned KBs |
| **REQ-12** | Admin role-assignment endpoints MUST validate against plan ceiling |
| **REQ-13** | `kb_manager` MUST only be assignable on `complete`-plan orgs |

## Production code

**REQ-6 (read filter):** `list_kbs_with_access` and `get_knowledge_stats` now pass `user_role=perms.effective_role.value` to `get_accessible_kb_slugs`. The service-layer filtering was already implemented in `app/services/access.py` — this PR hooks the API layer through.

**REQ-7 (write block):**
- `app_knowledge_sources.py::_get_writable_kb_or_raise` raises HTTP 403 `org_kb_write_requires_company` when a personal-role caller targets an org-owned KB. Fires BEFORE the role lookup so signal isn't leaked.
- `connectors.py::create_connector` mirrors the same gate. Refactored to call `_get_kb_with_owner_check` once (was called twice on the happy path).

**REQ-12 / REQ-13 (plan ceiling):**
- `app/core/profiles.py` adds `ALLOWED_PROFILES_PER_PLAN` constant + `assert_role_allowed_for_plan(role, plan)` helper. Unknown plans fall back to the `free` set (fail-closed).
- `admin/users.py::invite_user` validates after locking the org row.
- `admin/users.py::update_user_role` validates after `_lock_org_for_role_change`.
- `admin/users.py::promote_admin` validates as a defensive guard.

## Tests

`tests/test_rbac_phase3_enforcement.py` — 19 new tests:
- 3 invariant tests on `ALLOWED_PROFILES_PER_PLAN` (locks the policy)
- 5 helper tests on `assert_role_allowed_for_plan` (incl. unknown-plan fail-closed)
- 5 REQ-7 tests (personal-blocks-on-org, personal-passes-on-user-KB, company-passes, before-role-lookup short-circuit, create_connector)
- 4 REQ-12/13 tests (kb_manager rejected on core, accepted on complete, company rejected on free, admin promotion every plan)
- 2 REQ-6 wiring tests (both endpoints forward effective_role)

`test_admin_users.py` parametrized invite tests: orgs switched from `plan="free"` to `plan="complete"` because they cover role→Zitadel-mapping (now distinct from plan-ceiling), plus 2 helper-fixture updates.

## Test plan

- [x] Full pytest: 2233 passed, 0 failed
- [x] `ruff check` + `ruff format --check`: clean
- [x] `pyright app/api/ app/core/profiles.py`: 0 errors
- [ ] CI green
- [ ] Live verification on Voys after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)