### PR TITLE
fix(rbac): plan-ceiling reads from FOR UPDATE-locked org row, not perms.plan snapshot (SPEC-PORTAL-RBAC-REFACTOR-001 follow-up)

### DIFF
--- a/klai-portal/backend/app/api/admin/users.py
+++ b/klai-portal/backend/app/api/admin/users.py
@@ -324,14 +324,18 @@ async def update_user_role(
     # @MX:ANCHOR SPEC-PORTAL-ADMIN-UI-001 REQ-2 — min-1-admin invariant.
     # @MX:REASON Without serialised role changes two concurrent admin->X
     # patches that both see admin_count=2 can each succeed and leave the
-    # workspace with zero admins.
-    await _lock_org_for_role_change(db, perms.org_id)
+    # workspace with zero admins. We need both the lock AND the org's
+    # current plan; ``_lock_org_for_role_change`` only locks by id, so
+    # we replicate the FOR UPDATE query here to read ``plan`` from the
+    # locked row.
+    locked_org_result = await db.execute(select(PortalOrg).where(PortalOrg.id == perms.org_id).with_for_update())
+    locked_org = locked_org_result.scalar_one()
 
-    # REQ-12 / REQ-13: plan ceiling on assignable role. ``perms.plan`` is
-    # the plan resolved by ``get_caller_at_least`` for this transaction;
-    # the row was locked by ``_lock_org_for_role_change`` so a concurrent
-    # plan downgrade cannot race the role assignment.
-    assert_role_allowed_for_plan(body.role, perms.plan)
+    # REQ-12 / REQ-13: plan ceiling on assignable role. Read ``plan`` from
+    # the locked row, NOT ``perms.plan`` — the latter is a snapshot from
+    # request start and a concurrent platform-admin plan downgrade between
+    # request start and now would let an out-of-range role through.
+    assert_role_allowed_for_plan(body.role, locked_org.plan)
 
     result = await db.execute(
         select(PortalUser).where(
@@ -567,11 +571,17 @@ async def promote_admin(
     db: AsyncSession = Depends(get_db),
 ) -> MessageResponse:
     """C6.1: Promote an active member to admin. No max-admin limit."""
-    # REQ-12: plan ceiling. ``admin`` is in every plan's allow-set so this is
-    # a defensive guard — but keeping it makes the policy auditable in one
-    # place: any plan that ever drops "admin" from its allow-set will reject
-    # promotion immediately instead of silently succeeding.
-    assert_role_allowed_for_plan("admin", perms.plan)
+    # Lock the org row first so the plan we validate against can't change
+    # mid-request. ``perms.plan`` is a snapshot from request start; reading
+    # from the locked row mirrors invite_user / update_user_role.
+    locked_org_result = await db.execute(select(PortalOrg).where(PortalOrg.id == perms.org_id).with_for_update())
+    locked_org = locked_org_result.scalar_one()
+
+    # REQ-12: plan ceiling. ``admin`` is in every plan's allow-set so this
+    # is a defensive guard — but keeping it makes the policy auditable in
+    # one place: any plan that ever drops "admin" from its allow-set will
+    # reject promotion immediately instead of silently succeeding.
+    assert_role_allowed_for_plan("admin", locked_org.plan)
 
     result = await db.execute(
         select(PortalUser).where(

--- a/klai-portal/backend/tests/test_r6_admin_handover.py
+++ b/klai-portal/backend/tests/test_r6_admin_handover.py
@@ -24,23 +24,34 @@ def _make_user(uid: str = "u1", role: str = "company") -> MagicMock:
     return u
 
 
-def _make_db(target: MagicMock | None = None, admin_count: int = 2) -> AsyncMock:
-    """Return an AsyncMock DB:
-    - every execute() returns a result whose scalar_one_or_none() == target
-      (the demote-admin handler issues an extra SELECT ... FOR UPDATE on
-      portal_orgs to serialise concurrent role changes; that lock query
-      consumes a result the handler does not read, so always returning
-      `target` is safe — only the target-lookup call inspects the result).
-    - scalar() for admin count returns admin_count.
+def _make_db(target: MagicMock | None = None, admin_count: int = 2, plan: str = "complete") -> AsyncMock:
+    """Return an AsyncMock DB shaped for ``promote_admin`` / ``demote_admin``:
+
+    - First ``execute()`` is the locked-org SELECT...FOR UPDATE (added by
+      Phase 3 fix #2 so plan-ceiling reads the locked plan, not the
+      ``perms.plan`` request-start snapshot). Returns a synthetic
+      PortalOrg whose ``plan`` is configurable (defaults to ``complete``).
+    - Subsequent ``execute()`` calls are the target-user lookup; their
+      result's ``scalar_one_or_none()`` returns ``target``.
+    - ``scalar()`` returns ``admin_count`` (admin-count COUNT query).
     """
     db = AsyncMock()
     db.add = MagicMock()
 
+    locked_org = MagicMock()
+    locked_org.plan = plan
+
+    locked_result = MagicMock()
+    locked_result.scalar_one.return_value = locked_org
+
+    user_result = MagicMock()
+    user_result.scalar_one_or_none.return_value = target
+
+    call_count = {"n": 0}
+
     async def _execute(stmt, *args, **kwargs):
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = target
-        mock_result.scalar_one.return_value = target
-        return mock_result
+        call_count["n"] += 1
+        return locked_result if call_count["n"] == 1 else user_result
 
     async def _scalar(stmt, *args, **kwargs):
         return admin_count

--- a/klai-portal/backend/tests/test_rbac_phase3_enforcement.py
+++ b/klai-portal/backend/tests/test_rbac_phase3_enforcement.py
@@ -320,23 +320,69 @@ class TestPlanCeilingOnRoleAssignment:
 
     @pytest.mark.asyncio
     async def test_update_user_role_rejects_company_on_free(self):
+        """REQ-12: free plan does not allow ``company`` — even if ``perms.plan``
+        from the request-start snapshot says otherwise (the locked org row
+        is the authoritative source of truth)."""
         from app.api.admin.users import RoleUpdateRequest, update_user_role
 
+        # Locked org row from the FOR UPDATE select reports plan='free'.
+        locked_org = MagicMock()
+        locked_org.plan = "free"
         mock_db = AsyncMock()
-        body = RoleUpdateRequest(role="company")
-        perms = make_perms(role="admin", user_id="admin-1", org_id=42, plan="free")
+        locked_result = MagicMock()
+        locked_result.scalar_one.return_value = locked_org
+        mock_db.execute.return_value = locked_result
 
-        with patch(
-            "app.api.admin.users._lock_org_for_role_change",
-            new=AsyncMock(),
-        ):
-            with pytest.raises(HTTPException) as exc:
-                await update_user_role(zitadel_user_id="zit-2", body=body, perms=perms, db=mock_db)
+        body = RoleUpdateRequest(role="company")
+        # perms.plan deliberately MISMATCHES locked_org.plan to prove the
+        # endpoint reads the locked row, not the snapshot.
+        perms = make_perms(role="admin", user_id="admin-1", org_id=42, plan="complete")
+
+        with pytest.raises(HTTPException) as exc:
+            await update_user_role(zitadel_user_id="zit-2", body=body, perms=perms, db=mock_db)
 
         assert exc.value.status_code == 403
         assert exc.value.detail["error_code"] == "role_not_allowed_for_plan"
         assert exc.value.detail["role"] == "company"
+        # CRITICAL: must be 'free' (locked row), not 'complete' (perms snapshot).
         assert exc.value.detail["plan"] == "free"
+
+    @pytest.mark.asyncio
+    async def test_update_user_role_uses_locked_plan_not_perms_snapshot(self):
+        """Regression guard: ``update_user_role`` MUST read ``plan`` from the
+        FOR UPDATE-locked org row, not from ``perms.plan`` (which is a
+        snapshot from request start that a concurrent platform-admin
+        downgrade could have invalidated).
+
+        Reverse case of the test above: locked plan permits the role even
+        though ``perms.plan`` (snapshot) would forbid it. Endpoint must
+        accept — proving it ignores the snapshot."""
+        from app.api.admin.users import RoleUpdateRequest, update_user_role
+
+        # Locked plan = complete (allows kb_manager).
+        locked_org = MagicMock()
+        locked_org.plan = "complete"
+        target_user = MagicMock()
+        target_user.role = "company"
+        target_user.zitadel_user_id = "zit-2"
+        mock_db = AsyncMock()
+        # Two SELECTs: locked org, then PortalUser lookup.
+        locked_result = MagicMock()
+        locked_result.scalar_one.return_value = locked_org
+        user_result = MagicMock()
+        user_result.scalar_one_or_none.return_value = target_user
+        mock_db.execute = AsyncMock(side_effect=[locked_result, user_result])
+        mock_db.commit = AsyncMock()
+
+        body = RoleUpdateRequest(role="kb_manager")
+        # perms.plan = free FORBIDS kb_manager — the test fails if the
+        # endpoint reads from perms.
+        perms = make_perms(role="admin", user_id="admin-1", org_id=42, plan="free")
+
+        await update_user_role(zitadel_user_id="zit-2", body=body, perms=perms, db=mock_db)
+
+        # The role assignment landed (no exception raised + target.role mutated).
+        assert target_user.role == "kb_manager"
 
     @pytest.mark.asyncio
     async def test_promote_admin_passes_on_every_plan(self):

--- a/klai-portal/backend/tests/test_spec_portal_admin_ui_001.py
+++ b/klai-portal/backend/tests/test_spec_portal_admin_ui_001.py
@@ -28,20 +28,41 @@ def _make_user(uid: str = "u1", role: str = "company") -> MagicMock:
     return user
 
 
-def _make_db(target: MagicMock | None, admin_count: int = 2) -> AsyncMock:
-    """AsyncMock DB that returns `target` from every scalar_one_or_none and
-    `admin_count` from scalar() (for the COUNT query). Sufficient because
-    update_user_role only reads two results: the target lookup and the
-    admin-count COUNT. The lock SELECT consumes a result the handler never
-    inspects.
+def _make_db(target: MagicMock | None, admin_count: int = 2, plan: str = "complete") -> AsyncMock:
+    """AsyncMock DB used by ``update_user_role``.
+
+    Returns three things in order across the two ``db.execute`` calls + one
+    ``db.scalar`` call the handler issues:
+
+    1. First ``db.execute`` (locked org SELECT...FOR UPDATE) yields a result
+       whose ``scalar_one()`` is a synthetic ``PortalOrg`` carrying ``plan``.
+       This is the row read by ``assert_role_allowed_for_plan`` after Phase
+       3 fix #2 (plan-from-locked-row, not from ``perms.plan`` snapshot).
+    2. Second ``db.execute`` (user lookup) yields a result whose
+       ``scalar_one_or_none()`` is ``target``.
+    3. ``db.scalar`` (admin-count COUNT) returns ``admin_count``.
+
+    Plan defaults to ``complete`` so the role-ceiling never blocks the
+    test path; specify a more restrictive plan to exercise the gate.
     """
     db = AsyncMock()
     db.add = MagicMock()
 
+    locked_org = MagicMock()
+    locked_org.plan = plan
+
+    locked_result = MagicMock()
+    locked_result.scalar_one.return_value = locked_org
+
+    user_result = MagicMock()
+    user_result.scalar_one_or_none.return_value = target
+
+    # First execute -> locked org. Second + later -> target user lookup.
+    call_count = {"n": 0}
+
     async def _execute(_stmt, *_args, **_kwargs):
-        result = MagicMock()
-        result.scalar_one_or_none.return_value = target
-        return result
+        call_count["n"] += 1
+        return locked_result if call_count["n"] == 1 else user_result
 
     async def _scalar(_stmt, *_args, **_kwargs):
         return admin_count


### PR DESCRIPTION
## Summary

Phase 3 follow-up — closes a race condition in the plan-ceiling check on three admin endpoints.

## The bug

`assert_role_allowed_for_plan(body.role, perms.plan)` reads `plan` from the `UserPermissions` snapshot built by `get_caller` at request start. A concurrent platform-admin plan downgrade (`PATCH /api/admin/orgs/{slug}` or the new `/platform-unlocks` route) between request start and the role assignment would let an out-of-range role through.

`invite_user` was already correct — it reads `org.plan` from the FOR UPDATE-locked row. This PR aligns `update_user_role` and `promote_admin` with the same pattern.

## Code change

- `update_user_role`: replaces `_lock_org_for_role_change` (locks by id only) with inline `select(PortalOrg)...with_for_update()`. `assert_role_allowed_for_plan` now reads from `locked_org.plan`.
- `promote_admin`: adds the FOR UPDATE select before the assertion. Defensive only (admin is in every plan today) but documents the invariant.

## Tests

- Existing `test_update_user_role_rejects_company_on_free` rewritten to use `perms.plan != locked_org.plan` mismatch — proves the locked row wins.
- NEW `test_update_user_role_uses_locked_plan_not_perms_snapshot` — reverse regression guard: locked plan permits, snapshot would block. Endpoint must accept.
- `test_spec_portal_admin_ui_001.py::_make_db` and `test_r6_admin_handover.py::_make_db` updated to seed a locked PortalOrg with configurable `plan` on the first execute call.

## Test plan

- [x] Full pytest: 2265 passed, 0 failed (was 2264, +1 regression guard)
- [x] `ruff check` + `ruff format --check`: clean
- [x] `pyright app/api/admin/users.py`: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)