### PR TITLE
fix(rbac): grandfather platform_unlocked_features for getklai (post-deploy SQL — SPEC-PORTAL-RBAC-REFACTOR-001 Phase 5 follow-up)

### DIFF
--- a/klai-portal/backend/alembic/versions/post_deploy_h1i2j3k4l5m6_grandfather_platform_unlocks.sql
+++ b/klai-portal/backend/alembic/versions/post_deploy_h1i2j3k4l5m6_grandfather_platform_unlocks.sql
@@ -1,0 +1,60 @@
+-- Post-deploy data backfill for SPEC-PORTAL-RBAC-REFACTOR-001 Phase 5
+-- (migration h1i2j3k4l5m6 added the platform_unlocked_features column).
+--
+-- Run as the `klai` superuser AFTER `alembic upgrade h1i2j3k4l5m6`
+-- completes. Safe to re-run — the WHERE clauses make every UPDATE
+-- idempotent.
+--
+-- Why post-deploy and not part of the alembic migration itself:
+-- This is a tenant-specific data fix, not a schema change. Encoding
+-- "tenant slug = 'getklai' starts with widgets+custom_mcps unlocked"
+-- directly inside an alembic upgrade body is not how klai handles
+-- tenant-config seeding. Other tenant-config seeding follows the
+-- same `alembic/versions/post_deploy_*.sql` convention used by
+-- SPEC-SEC-PORTAL-RLS-001 (see post_deploy_2f7d1eae1198.sql header).
+--
+-- Why this fix exists:
+-- Phase 5 added the gate `assert_platform_unlocked(org, "<feature>")` to
+-- partner_dependencies / admin_widgets / mcp_servers without
+-- grandfathering. The SPEC body (lines 169-201) said "geen actieve
+-- gebruikers met partner_api_keys; custom-MCP-feature kan nog niet door
+-- tenants gebruikt worden — dus niets om te grandfatheren". That is true
+-- for tenant orgs (Voys at the time of writing has neither widgets nor
+-- custom MCPs configured). It was NOT true for the platform org
+-- ('getklai'):
+--   - 'getklai' has 2 widgets in `widgets`
+--   - 'getklai' has the 'twenty-crm' custom MCP enabled
+--     (`portal_orgs.mcp_servers->>twenty-crm.enabled = true`)
+-- After Phase 5 deploy these endpoints started returning HTTP 403
+-- `feature_not_unlocked` for getklai-admin operations on widgets or
+-- on toggling the existing custom MCP. The user-visible incident was
+-- detected and fixed via a manual UPDATE on prod the same day. This
+-- migration captures that fix in source so:
+--   1. Fresh staging / dev / disaster-recovery DBs reach the same end
+--      state without operator intervention.
+--   2. The unlock state for the platform org is documented in code,
+--      not in shell history.
+--   3. Future post-incident audits can locate the fix via grep.
+--
+-- The audit-trail (tenant_lifecycle_events with event_type =
+-- 'platform_features_updated') is intentionally NOT emitted by this
+-- migration — that audit type is for runtime PATCH /platform-unlocks
+-- changes by a platform-admin actor. A migration is not an actor.
+-- Forensic reconstruction of "when did getklai get these unlocks" is
+-- via this migration file in git history + the post-deploy SQL apply
+-- log on core-01.
+--
+-- The hardcoded 'getklai' slug is correct: it is the platform org
+-- (single, never multi-instance) per `settings.platform_org_slug`. Other
+-- tenants legitimately start with `'{}'` — they do not have widgets or
+-- custom MCPs and unlocking either feature for a tenant must go through
+-- the audited `PATCH /api/admin/orgs/{slug}/platform-unlocks` route.
+
+BEGIN;
+
+UPDATE portal_orgs
+SET platform_unlocked_features = ARRAY['widgets', 'custom_mcps']::text[]
+WHERE slug = 'getklai'
+  AND NOT (platform_unlocked_features @> ARRAY['widgets', 'custom_mcps']::text[]);
+
+COMMIT;


### PR DESCRIPTION
## Summary

Captures in source the manual UPDATE that ran on production 2026-05-08 to fix the Phase 5 deploy regression on the platform org.

## Background

Phase 5 added platform-locked feature gates without grandfathering. The SPEC body said "niets om te grandfatheren" — true for tenant orgs (Voys had no widgets/custom MCPs) but **NOT** for the platform org `getklai`, which had:
- 2 widgets in `widgets` table
- `twenty-crm` custom MCP with `enabled=true`

After Phase 5 deployed these endpoints started returning HTTP 403 `feature_not_unlocked` for getklai-admin operations. Fixed via manual UPDATE on prod. **This commit captures that fix in source.**

## Why this matters

Without this commit:
- Fresh staging / dev / disaster-recovery DBs ship in a broken state
- The unlock state lives only in shell history
- Future audits cannot grep for the fix

## File

`klai-portal/backend/alembic/versions/post_deploy_h1i2j3k4l5m6_grandfather_platform_unlocks.sql`

Pattern follows existing `post_deploy_*.sql` files (RLS setup, etc.). Applied via `klai-portal/backend/scripts/apply_post_deploy_sql.sh` (manual operator step, same workflow as RLS post-deploy SQL).

## Audit trail caveat

The migration intentionally does NOT emit `tenant_lifecycle_events` with `event_type='platform_features_updated'`. That audit type is for runtime PATCH `/platform-unlocks` changes by a platform-admin actor. A migration is not an actor. Forensic reconstruction = this commit + the apply log.

## Test plan

- [x] Idempotent: re-applied on prod against current state → `UPDATE 0` (no-op, expected because the manual fix already set the same value)
- [x] WHERE clause uses `@>` array-containment so partial unlocks (e.g. `{widgets}` only) are still grandfathered to `{widgets, custom_mcps}`
- [ ] CI green
- [ ] Operator runs `apply_post_deploy_sql.sh` on staging to verify pickup

🤖 Generated with [Claude Code](https://claude.com/claude-code)