### PR TITLE
Fix public docs Caddy route

### DIFF
--- a/deploy/caddy/Caddyfile
+++ b/deploy/caddy/Caddyfile
@@ -387,12 +387,29 @@
         }
     }
 
-    # SEC-023 / F-038 — Scribe/Docs are no longer publicly routed.
-    # Frontend calls /api/scribe/*, /api/docs/* which hit the BFF proxy in
-    # portal-api (app/api/proxy.py). That handler pulls the Zitadel
-    # access_token from the BFF session and forwards to the internal service
-    # with Authorization: Bearer injected. The services listen only on the
-    # klai-net Docker network now — no Caddy exposure.
+    # Public Klai Docs reader. The editor/API remains behind portal-api's BFF
+    # at /api/docs/*; do not expose docs-app's /docs/api/* directly.
+    @docs-api path /docs/api/*
+    handle @docs-api {
+        respond 404
+    }
+
+    @docs-reader path /docs /docs/*
+    handle @docs-reader {
+        reverse_proxy docs-app:3010 {
+            header_up -X-Internal-Secret
+            header_up -X-Caller-Service
+            header_up -X-Org-ID
+            header_up -X-Org-Slug
+            header_up -X-User-ID
+        }
+    }
+
+    # SEC-023 / F-038 — Scribe remains non-publicly routed.
+    # Frontend calls /api/scribe/* and authenticated docs editor calls use
+    # /api/docs/*, which hit the BFF proxy in portal-api (app/api/proxy.py).
+    # That handler pulls the Zitadel access_token from the BFF session and
+    # forwards to the internal service with Authorization: Bearer injected.
 
     # Vexa meeting bot gateway (SEC-013 F-030 — fix dead route from VEXA-003 migration)
     # Route maps /bots/<path> → api-gateway:8000/<path>. The old `vexa-bot-manager`

--- a/klai-portal/backend/tests/test_caddyfile_static_route_position.py
+++ b/klai-portal/backend/tests/test_caddyfile_static_route_position.py
@@ -74,3 +74,49 @@ def test_static_route_precedes_catchall() -> None:
         "/static/* requests and the OAuth consent page CSS will silently "
         "fail. Move /static/* back above the catch-all."
     )
+
+
+def test_public_docs_reader_route_precedes_catchall_and_api_block() -> None:
+    """Public `/docs/*` reader must not be swallowed by the portal SPA."""
+    if not _CADDYFILE.exists():
+        pytest.skip(f"Caddyfile not found at {_CADDYFILE}")
+
+    text = _CADDYFILE.read_text(encoding="utf-8")
+    lines = text.splitlines()
+
+    docs_api_matcher_line: int | None = None
+    docs_api_handle_line: int | None = None
+    docs_reader_matcher_line: int | None = None
+    docs_reader_handle_line: int | None = None
+    catchall_line: int | None = None
+
+    docs_api_matcher_re = re.compile(r"^\s*@docs-api\s+path\s+/docs/api/\*")
+    docs_api_handle_re = re.compile(r"^\s*handle\s+@docs-api\s*\{")
+    docs_reader_matcher_re = re.compile(r"^\s*@docs-reader\s+path\s+/docs\s+/docs/\*")
+    docs_reader_handle_re = re.compile(r"^\s*handle\s+@docs-reader\s*\{")
+    catchall_re = re.compile(r"^\s*handle\s*\{")
+
+    for i, line in enumerate(lines, start=1):
+        if docs_api_matcher_line is None and docs_api_matcher_re.match(line):
+            docs_api_matcher_line = i
+        if docs_api_handle_line is None and docs_api_handle_re.match(line):
+            docs_api_handle_line = i
+        if docs_reader_matcher_line is None and docs_reader_matcher_re.match(line):
+            docs_reader_matcher_line = i
+        if docs_reader_handle_line is None and docs_reader_handle_re.match(line):
+            docs_reader_handle_line = i
+        if catchall_line is None and catchall_re.match(line):
+            catchall_line = i
+
+    assert docs_api_matcher_line is not None, "Caddyfile must define @docs-api for /docs/api/*."
+    assert docs_api_handle_line is not None, "Caddyfile must block public /docs/api/* before /docs/*."
+    assert docs_reader_matcher_line is not None, "Caddyfile must define @docs-reader for /docs and /docs/*."
+    assert docs_reader_handle_line is not None, "Caddyfile must route public /docs/* to docs-app."
+    assert catchall_line is not None, "Caddyfile must keep an explicit portal SPA catch-all."
+    assert docs_api_handle_line < docs_reader_handle_line, (
+        "Caddyfile order regression: public /docs/api/* must be blocked before the broader /docs/* reader route."
+    )
+    assert docs_reader_handle_line < catchall_line, (
+        "Caddyfile order regression: /docs/* reader route must come before "
+        "the portal SPA catch-all, otherwise public docs URLs hit the login wall."
+    )


### PR DESCRIPTION
## Summary
- Route public `/docs` and `/docs/*` requests to `docs-app:3010` instead of letting them fall through to the portal SPA.
- Keep `/docs/api/*` blocked publicly so docs editor/API traffic remains behind the portal BFF at `/api/docs/*`.
- Add a Caddyfile lint regression test for the reader route ordering and API block.

## Root Cause
`/docs/klai-help` was not routed to `docs-app` at the edge, so Caddy served the portal SPA fallback. The SPA then sent unauthenticated users to the login flow.

## Validation
- `uv run pytest tests/test_caddyfile_static_route_position.py`
- `uv run pytest ../../tests/caddy/test_caddyfile_strips_internal_headers.py`
- `uv run ruff check tests/test_caddyfile_static_route_position.py`
- `git diff --check -- deploy/caddy/Caddyfile klai-portal/backend/tests/test_caddyfile_static_route_position.py`

Local note: `caddy validate` could not be run locally because Docker/Caddy are not installed in this workspace; the PR Caddy validation workflow uses the production Caddy image.
