### PR TITLE
Fix public docs BlockNote rendering

### DIFF
--- a/klai-docs/app/(reader)/[...path]/page.tsx
+++ b/klai-docs/app/(reader)/[...path]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound, redirect } from "next/navigation";
 import { headers } from "next/headers";
 import { db } from "@/lib/db";
-import { buildNavTree } from "@/lib/gitea";
+import { buildNavTree, type NavNode } from "@/lib/gitea";
 import * as gitea from "@/lib/gitea";
 import { parsePage, parseSidebar } from "@/lib/markdown";
 import type { SidebarEntry } from "@/lib/markdown";
@@ -18,6 +18,15 @@ function collectSlugs(entries: SidebarEntry[]): string[] {
     if (e.children?.length) result.push(...collectSlugs(e.children));
   }
   return result;
+}
+
+function findFirstPageSlug(nodes: NavNode[]): string | null {
+  for (const node of nodes) {
+    if (node.type === "file") return node.slug;
+    const childSlug = node.children?.length ? findFirstPageSlug(node.children) : null;
+    if (childSlug) return childSlug;
+  }
+  return null;
 }
 
 /**
@@ -117,6 +126,11 @@ export default async function ReaderPage({
     articleSegments.length > 0
       ? `${articleSegments.join("/")}.md`
       : null;
+
+  if (!articlePath) {
+    const firstSlug = findFirstPageSlug(navTree);
+    if (firstSlug) redirect(`/${kbSlug}/${firstSlug}`);
+  }
 
   let content = "";
   let title = kb.name;

--- a/klai-docs/components/reader/PageRenderer.tsx
+++ b/klai-docs/components/reader/PageRenderer.tsx
@@ -4,6 +4,7 @@ import rehypeSlug from "rehype-slug";
 import rehypeHighlight from "rehype-highlight";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize from "rehype-sanitize";
+import { blockNoteJsonToMarkdown } from "@/lib/blocknote-markdown";
 import { sanitizeSchema } from "@/lib/sanitize-schema";
 
 export type PageIndexEntry = {
@@ -42,10 +43,13 @@ function resolveWikilinks(
 }
 
 export function PageRenderer({ content, pageIndex, kbSlug }: Props) {
+  const markdownContent =
+    blockNoteJsonToMarkdown(content, pageIndex ?? [], kbSlug ?? "") ?? content;
+
   const resolvedContent =
     pageIndex && pageIndex.length > 0 && kbSlug
-      ? resolveWikilinks(content, pageIndex, kbSlug)
-      : content;
+      ? resolveWikilinks(markdownContent, pageIndex, kbSlug)
+      : markdownContent;
 
   return (
     <article className="prose max-w-none klai-prose">

--- a/klai-docs/lib/blocknote-markdown.ts
+++ b/klai-docs/lib/blocknote-markdown.ts
@@ -1,0 +1,254 @@
+export type PageIndexEntry = {
+  id: string;
+  slug: string;
+  title?: string;
+};
+
+type InlineText = {
+  type: "text";
+  text: string;
+  styles?: Record<string, boolean | string>;
+};
+
+type InlineLink = {
+  type: "link";
+  href?: string;
+  content?: InlineContent[];
+};
+
+type InlineWikiLink = {
+  type: "wikilink";
+  props?: {
+    pageId?: string;
+    title?: string;
+    icon?: string;
+  };
+};
+
+type InlineContent = string | InlineText | InlineLink | InlineWikiLink;
+
+type BlockNoteBlock = {
+  type?: string;
+  props?: Record<string, unknown>;
+  content?: InlineContent[] | string;
+  children?: BlockNoteBlock[];
+};
+
+const LIST_TYPES = new Set(["bulletListItem", "numberedListItem", "checkListItem"]);
+
+export function blockNoteJsonToMarkdown(
+  content: string,
+  pageIndex: PageIndexEntry[] = [],
+  kbSlug = ""
+): string | null {
+  const trimmed = content.trimStart();
+  if (!trimmed.startsWith("[")) return null;
+
+  let blocks: unknown;
+  try {
+    blocks = JSON.parse(content);
+  } catch {
+    return null;
+  }
+
+  if (!Array.isArray(blocks) || !blocks.every(isBlockNoteBlock)) return null;
+  return renderBlocks(blocks, pageIndex, kbSlug).trim();
+}
+
+function isBlockNoteBlock(value: unknown): value is BlockNoteBlock {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as { type?: unknown; content?: unknown; children?: unknown };
+  if (candidate.type !== undefined && typeof candidate.type !== "string") return false;
+  if (candidate.children !== undefined && !Array.isArray(candidate.children)) return false;
+  return true;
+}
+
+function renderBlocks(
+  blocks: BlockNoteBlock[],
+  pageIndex: PageIndexEntry[],
+  kbSlug: string,
+  depth = 0
+): string {
+  const rendered: string[] = [];
+
+  for (let i = 0; i < blocks.length; i += 1) {
+    const block = blocks[i];
+    if (LIST_TYPES.has(block.type ?? "")) {
+      const list: string[] = [];
+      let number = 1;
+      while (i < blocks.length && blocks[i].type === block.type) {
+        list.push(renderListItem(blocks[i], pageIndex, kbSlug, depth, number));
+        number += 1;
+        i += 1;
+      }
+      i -= 1;
+      rendered.push(list.join("\n"));
+      continue;
+    }
+
+    const markdown = renderBlock(block, pageIndex, kbSlug, depth);
+    if (markdown) rendered.push(markdown);
+  }
+
+  return rendered.join("\n\n");
+}
+
+function renderBlock(
+  block: BlockNoteBlock,
+  pageIndex: PageIndexEntry[],
+  kbSlug: string,
+  depth: number
+): string {
+  const text = renderInlineContent(block.content, pageIndex, kbSlug);
+  const children = block.children?.length
+    ? renderBlocks(block.children, pageIndex, kbSlug, depth + 1)
+    : "";
+
+  switch (block.type) {
+    case "heading": {
+      const level = clampHeadingLevel(block.props?.level);
+      return joinBlockParts(`${"#".repeat(level)} ${text}`.trim(), children);
+    }
+    case "codeBlock": {
+      const language = typeof block.props?.language === "string" ? block.props.language : "";
+      return joinBlockParts(`\`\`\`${language}\n${extractPlainText(block.content)}\n\`\`\``, children);
+    }
+    case "quote": {
+      const quote = text
+        .split("\n")
+        .map((line) => `> ${line}`)
+        .join("\n");
+      return joinBlockParts(quote, children);
+    }
+    case "image": {
+      const url = typeof block.props?.url === "string" ? block.props.url : "";
+      const caption = text || (typeof block.props?.caption === "string" ? block.props.caption : "");
+      return isSafeHref(url) ? joinBlockParts(`![${escapeMarkdown(caption)}](${escapeHref(url)})`, children) : children;
+    }
+    case "file": {
+      const url = typeof block.props?.url === "string" ? block.props.url : "";
+      const name = text || (typeof block.props?.name === "string" ? block.props.name : "Download");
+      return isSafeHref(url) ? joinBlockParts(`[${escapeMarkdown(name)}](${escapeHref(url)})`, children) : children;
+    }
+    case "paragraph":
+    default:
+      return joinBlockParts(text, children);
+  }
+}
+
+function renderListItem(
+  block: BlockNoteBlock,
+  pageIndex: PageIndexEntry[],
+  kbSlug: string,
+  depth: number,
+  number: number
+): string {
+  const indent = "  ".repeat(depth);
+  const text = renderInlineContent(block.content, pageIndex, kbSlug);
+  const marker =
+    block.type === "numberedListItem"
+      ? `${number}.`
+      : block.type === "checkListItem"
+        ? `- [${block.props?.checked ? "x" : " "}]`
+        : "-";
+  const firstLine = `${indent}${marker} ${text}`.trimEnd();
+  const children = block.children?.length
+    ? `\n${renderBlocks(block.children, pageIndex, kbSlug, depth + 1)}`
+    : "";
+  return `${firstLine}${children}`;
+}
+
+function renderInlineContent(
+  content: InlineContent[] | string | undefined,
+  pageIndex: PageIndexEntry[],
+  kbSlug: string
+): string {
+  if (!content) return "";
+  if (typeof content === "string") return escapeMarkdown(content);
+  if (!Array.isArray(content)) return "";
+  return content.map((item) => renderInline(item, pageIndex, kbSlug)).join("");
+}
+
+function renderInline(
+  item: InlineContent,
+  pageIndex: PageIndexEntry[],
+  kbSlug: string
+): string {
+  if (typeof item === "string") return escapeMarkdown(item);
+
+  if (item.type === "text") {
+    return applyStyles(escapeMarkdown(item.text), item.styles ?? {});
+  }
+
+  if (item.type === "link") {
+    const label = renderInlineContent(item.content, pageIndex, kbSlug);
+    if (!item.href || !isSafeHref(item.href)) return label;
+    return `[${label}](${escapeHref(item.href)})`;
+  }
+
+  if (item.type === "wikilink") {
+    const pageId = item.props?.pageId;
+    const page = pageId ? pageIndex.find((entry) => entry.id === pageId || entry.slug === pageId) : undefined;
+    const title = item.props?.title ?? page?.title ?? page?.slug ?? "Untitled";
+    if (!page || !kbSlug) return escapeMarkdown(title);
+    return `[${escapeMarkdown(title)}](/docs/${kbSlug}/${page.slug})`;
+  }
+
+  return "";
+}
+
+function applyStyles(text: string, styles: Record<string, boolean | string>): string {
+  let value = text;
+  if (styles.code) value = `\`${value.replace(/`/g, "\\`")}\``;
+  if (styles.bold) value = `**${value}**`;
+  if (styles.italic) value = `_${value}_`;
+  if (styles.strike) value = `~~${value}~~`;
+  if (styles.underline) value = `<u>${value}</u>`;
+  return value;
+}
+
+function extractPlainText(content: InlineContent[] | string | undefined): string {
+  if (!content) return "";
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((item) => {
+      if (typeof item === "string") return item;
+      if (item.type === "text") return item.text;
+      if (item.type === "link") return extractPlainText(item.content);
+      if (item.type === "wikilink") return item.props?.title ?? "";
+      return "";
+    })
+    .join("");
+}
+
+function clampHeadingLevel(level: unknown): number {
+  if (typeof level !== "number" || !Number.isFinite(level)) return 2;
+  return Math.min(6, Math.max(1, Math.trunc(level)));
+}
+
+function joinBlockParts(primary: string, children: string): string {
+  if (primary && children) return `${primary}\n\n${children}`;
+  return primary || children;
+}
+
+function isSafeHref(href: string): boolean {
+  const trimmed = href.trim();
+  if (!trimmed) return false;
+  if (trimmed.startsWith("/") || trimmed.startsWith("#")) return true;
+  if (!/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return true;
+  try {
+    const url = new URL(trimmed);
+    return ["http:", "https:", "mailto:", "tel:"].includes(url.protocol);
+  } catch {
+    return false;
+  }
+}
+
+function escapeHref(href: string): string {
+  return href.trim().replace(/\)/g, "%29").replace(/\s/g, "%20");
+}
+
+function escapeMarkdown(text: string): string {
+  return text.replace(/([\\`*_{}\[\]#+\-.!|>])/g, "\\$1");
+}

--- a/klai-docs/tests/blocknote-markdown.test.ts
+++ b/klai-docs/tests/blocknote-markdown.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { blockNoteJsonToMarkdown } from "../lib/blocknote-markdown";
+
+describe("blockNoteJsonToMarkdown", () => {
+  it("renders BlockNote JSON blocks as markdown instead of raw JSON text", () => {
+    const content = JSON.stringify([
+      {
+        type: "paragraph",
+        content: [{ type: "text", text: "Start here.", styles: {} }],
+        children: [],
+      },
+      {
+        type: "heading",
+        props: { level: 2 },
+        content: [{ type: "text", text: "Create your account", styles: {} }],
+        children: [],
+      },
+      {
+        type: "paragraph",
+        content: [
+          { type: "text", text: "Go to ", styles: {} },
+          {
+            type: "link",
+            href: "https://my.getklai.com",
+            content: [{ type: "text", text: "my.getklai.com", styles: {} }],
+          },
+          { type: "text", text: " and sign up.", styles: {} },
+        ],
+        children: [],
+      },
+      {
+        type: "numberedListItem",
+        content: [
+          { type: "text", text: "Open ", styles: {} },
+          { type: "text", text: "Knowledge", styles: { bold: true } },
+          { type: "text", text: ".", styles: {} },
+        ],
+        children: [],
+      },
+    ]);
+
+    const markdown = blockNoteJsonToMarkdown(content);
+
+    expect(markdown).toContain("Start here\\.");
+    expect(markdown).toContain("## Create your account");
+    expect(markdown).toContain("[my\\.getklai\\.com](https://my.getklai.com)");
+    expect(markdown).toContain("1. Open **Knowledge**\\.");
+    expect(markdown).not.toContain('"type":"paragraph"');
+  });
+
+  it("resolves BlockNote wikilinks through the page index", () => {
+    const content = JSON.stringify([
+      {
+        type: "paragraph",
+        content: [
+          { type: "text", text: "Read ", styles: {} },
+          {
+            type: "wikilink",
+            props: { pageId: "page-1", title: "Welcome" },
+          },
+          { type: "text", text: ".", styles: {} },
+        ],
+        children: [],
+      },
+    ]);
+
+    const markdown = blockNoteJsonToMarkdown(
+      content,
+      [{ id: "page-1", slug: "welcome", title: "Welcome" }],
+      "klai-help"
+    );
+
+    expect(markdown).toBe("Read [Welcome](/docs/klai-help/welcome)\\.");
+  });
+
+  it("falls back for non-JSON legacy markdown or invalid JSON", () => {
+    expect(blockNoteJsonToMarkdown("## Legacy markdown")).toBeNull();
+    expect(blockNoteJsonToMarkdown("[not json")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Restore public reader support for BlockNote JSON content by converting stored BlockNote blocks to Markdown before the existing sanitized ReactMarkdown pipeline.
- Preserve legacy Markdown/HTML rendering for older pages.
- Redirect KB root URLs like `/docs/klai-help` to the first page in the nav tree, e.g. `/docs/klai-help/welcome`.
- Add unit coverage for BlockNote JSON rendering, links, wikilinks, and legacy fallback.

## Root Cause
The docs editor switched to lossless BlockNote JSON persistence in `2908c276` after previously saving `blocksToHTMLLossy(...)`. The public reader still assumed content was Markdown/HTML, so newly saved pages rendered the raw JSON array as article text.

## Validation
- `npm test -- tests/blocknote-markdown.test.ts tests/sanitize.test.ts`
- `npm run build`
- `git diff --check -- klai-docs/app/(reader)/[...path]/page.tsx klai-docs/components/reader/PageRenderer.tsx klai-docs/lib/blocknote-markdown.ts klai-docs/tests/blocknote-markdown.test.ts`

Note: `npm run lint` is currently broken in this package because the script still runs `next lint`, which Next 16 no longer supports. Direct `npx eslint .` also fails before linting due the current ESLint config/dependency circular-config issue.
