### PR TITLE
SPEC-SEC-IDENTITY-ASSERT-003 — retrieval-api + klai-connector membership-authoritative auth

### DIFF
--- a/.moai/specs/SPEC-SEC-IDENTITY-ASSERT-003/acceptance.md
+++ b/.moai/specs/SPEC-SEC-IDENTITY-ASSERT-003/acceptance.md
@@ -1,0 +1,429 @@
+# SPEC-SEC-IDENTITY-ASSERT-003 — Acceptance Criteria
+
+Each scenario maps to one or more REQs in `spec.md`. All scenarios
+MUST pass before the SPEC is considered complete.
+
+The structure mirrors SPEC-SEC-IDENTITY-ASSERT-002's group-letter
+convention: A. for the retrieval-api fix, B. for the klai-connector
+fix, C. for the ast-grep glob extension, D. for Grafana alerts, E.
+for migration / rollout.
+
+---
+
+## A. retrieval-api JWT path — REQ-1
+
+### A1. JWT lacks resourceowner, X-Org-Id present, single active membership → allow
+
+- Given a Zitadel JWT with valid signature, valid audience, valid expiry,
+  `sub=U1`, AND no `urn:zitadel:iam:user:resourceowner:id` claim
+- And `portal_users` has an active row `(zitadel_user_id=U1, org_id=O1)`
+- And `portal_orgs` has `(id=O1, zitadel_org_id=Z1, slug='voys',
+  deleted_at IS NULL)`
+- And the request includes `X-Org-Id: Z1`
+- When retrieval-api receives `POST /retrieve` with
+  `Authorization: Bearer <the_jwt>` and the body for a normal retrieve
+- Then the response is HTTP 200
+- AND `request.state.verified_caller` equals
+  `VerifiedCaller(user_id=U1, org_id=Z1)` from the portal response
+- AND `IdentityAsserter.verify` was called with
+  `caller_service="retrieval-api"`, `claimed_user_id=U1`,
+  `claimed_org_id=Z1`, `bearer_jwt=<the_jwt>`
+- AND no code path read `_ZITADEL_RESOURCEOWNER_CLAIM` (verified by
+  static check: `_ZITADEL_RESOURCEOWNER_CLAIM` symbol is deleted from
+  `klai-retrieval-api/retrieval_api/middleware/auth.py`)
+
+### A2. JWT lacks resourceowner, X-Org-Id missing → 400
+
+- Given the same JWT as A1
+- And the request omits `X-Org-Id` (or sends an empty string)
+- When retrieval-api receives the request
+- Then the response is HTTP 400 with `{"error": "missing_org_id"}`
+- AND `IdentityAsserter.verify` is NOT called (verified via mock)
+- AND a structlog warning with `event="missing_org_id"` is emitted
+
+### A3. JWT INCLUDES legacy resourceowner claim that does NOT match X-Org-Id → allow (claim ignored)
+
+- Given a JWT with `sub=U1` AND
+  `urn:zitadel:iam:user:resourceowner:id="OTHER_ORG"` (a custom-Zitadel
+  emission case)
+- And `portal_users` has active `(U1, Z1)` and the request sends
+  `X-Org-Id: Z1`
+- When retrieval-api receives the request
+- Then the response is HTTP 200
+- AND `IdentityAsserter.verify` was called with `claimed_org_id=Z1`,
+  NOT with the resourceowner value
+- AND no log line mentions `OTHER_ORG`
+- AND `request.state.verified_caller.org_id == Z1` from the portal
+  response
+
+### A4. portal verify denies (no membership) → 403
+
+- Given a valid JWT for U1 and a request with `X-Org-Id=Z2`
+- And `IdentityAsserter.verify` returns
+  `verified=false, reason="no_membership"`
+- When retrieval-api receives the request
+- Then the response is HTTP 403 with
+  `{"error": "identity_assertion_failed"}`
+- AND `cross_org_rejected_total` is incremented
+- AND a structlog warning with `event="identity_assertion_failed"`
+  and `reason="no_membership"` is emitted
+- AND `request.state.verified_caller` is NOT set
+
+### A5. JWT signature invalid → 401 (existing behaviour preserved)
+
+- Given a JWT signed with a key not in Zitadel JWKS
+- When retrieval-api receives the request
+- Then the response is HTTP 401 with `{"error": "unauthorized"}`
+- AND `IdentityAsserter.verify` is NOT called
+- AND no membership lookup is executed
+- AND the `_decode_jwt` rejection path (`error="invalid_jwt_signature"`)
+  is unchanged from the pre-SPEC implementation
+
+### A6. JWT expired → 401 (existing behaviour preserved)
+
+- Given a JWT with valid signature but `exp` in the past
+- When retrieval-api receives the request
+- Then the response is HTTP 401 with `{"error": "unauthorized"}`
+- AND `IdentityAsserter.verify` is NOT called
+
+### A7. Internal-secret path unaffected (regression guard)
+
+- Given a request with `X-Internal-Secret: <correct>`,
+  `X-Caller-Service: knowledge-mcp`, and a body containing
+  `org_id` + `user_id`
+- When retrieval-api receives `POST /retrieve`
+- Then the existing internal-secret path executes per SPEC-001 REQ-3
+- AND `verify_body_identity` calls `IdentityAsserter.verify` with
+  `bearer_jwt=None` (unchanged from pre-SPEC)
+- AND the JWT-path code added in REQ-1 is NOT exercised
+
+### A8. Cache hit on second JWT call (REQ-1.5 cache TTL)
+
+- Given A1 succeeded and the `IdentityAsserter` cache holds the
+  decision
+- When retrieval-api receives a second identical request within 60s
+- Then the response is HTTP 200
+- AND `IdentityAsserter.verify` is called but the cache short-circuits
+  to the cached decision (verified by no outbound HTTP call to
+  portal-api on the second request)
+- AND no DB query against `portal_users` is observed at portal-api
+  for the second call
+
+### A9. Multi-org user picks correct org via X-Org-Id
+
+- Given user U1 has TWO active memberships:
+  `(U1, O1)` slug=voys, `(U1, O2)` slug=acme
+- And the JWT has `sub=U1` and no resourceowner
+- When retrieval-api receives a request with `X-Org-Id=Z2` (Acme)
+- Then `verified_caller.org_id == Z2`
+- When the same user retries with `X-Org-Id=Z1` (Voys)
+- Then `verified_caller.org_id == Z1`
+- (Both flows succeed; the JWT alone does not pick one over the
+  other.)
+
+### A10. Static check — resourceowner symbol gone from retrieval-api
+
+- Given the diff for the retrieval-api PR
+- When CI runs the static check
+  `grep -rn "_ZITADEL_RESOURCEOWNER_CLAIM\|urn:zitadel:iam:user:resourceowner" klai-retrieval-api/retrieval_api/`
+- Then the result is empty
+- AND `klai-retrieval-api/retrieval_api/middleware/auth.py`'s
+  `AuthContext` dataclass no longer has a `resourceowner` field
+
+---
+
+## B. klai-connector middleware — REQ-2
+
+### B1. JWT lacks resourceowner, X-Org-Id present, valid membership → allow
+
+- Given a Zitadel access token whose introspection returns
+  `active=true`, `sub=U1`, valid `aud`, AND no
+  `urn:zitadel:iam:user:resourceowner:id` claim
+- And `portal_users` has active `(U1, Z1)`
+- And the request sends `X-Org-Id: Z1`
+- When klai-connector middleware processes the request
+- Then introspection runs (cached for 5 min thereafter)
+- AND `IdentityAsserter.verify` is called with
+  `caller_service="klai-connector"`, `claimed_user_id=U1`,
+  `claimed_org_id=Z1`, `bearer_jwt=<the_token>`
+- AND the response is HTTP 200 (or whatever the route handler returns)
+- AND `request.state.org_id == "Z1"` from the portal response
+- AND no code path reads
+  `claims.get("urn:zitadel:iam:user:resourceowner:id")`
+
+### B2. JWT lacks resourceowner, X-Org-Id missing → 400
+
+- Given the same introspection result as B1
+- And the request omits `X-Org-Id`
+- And the request is NOT a portal-bypass call (no
+  `_portal_secret` match)
+- When klai-connector middleware processes the request
+- Then the response is HTTP 400 with `{"error": "missing_org_id"}`
+- AND `IdentityAsserter.verify` is NOT called
+
+### B3. portal verify denies → 403 (NOT 401)
+
+- Given a valid Zitadel token (introspection passes) and
+  `X-Org-Id: Z9` for which the user has no membership
+- And `IdentityAsserter.verify` returns
+  `verified=false, reason="no_membership"`
+- When klai-connector middleware processes the request
+- Then the response is HTTP 403 with
+  `{"error": "identity_assertion_failed"}`
+- AND a structlog warning is emitted
+- AND the response is NOT 401 (the user has a valid token; this is
+  authorization, not authentication)
+
+### B4. Token introspection fails → 401 (existing behaviour preserved)
+
+- Given a Zitadel token whose introspection returns
+  `active=false`
+- When klai-connector middleware processes the request
+- Then the response is HTTP 401 with `{"error": "unauthorized"}`
+- AND `IdentityAsserter.verify` is NOT called
+- AND the introspection cache does NOT receive the failed result
+  (existing code at lines 121-141, unchanged)
+
+### B5. Audience mismatch → 401 (existing behaviour preserved)
+
+- Given a Zitadel token whose introspection succeeds but `aud` does
+  NOT match `settings.zitadel_api_audience`
+- When klai-connector middleware processes the request
+- Then the response is HTTP 401
+- AND the cache is NOT populated with the wrong-audience claims
+  (the existing pre-cache audience check at lines 129-134 is
+  preserved)
+
+### B6. Portal-bypass path unaffected
+
+- Given a request with `Authorization: Bearer <portal_caller_secret>`
+  (the portal service-to-service secret)
+- When klai-connector middleware processes the request
+- Then the existing bypass at lines 107-116 takes effect
+- AND `request.state.from_portal == True`
+- AND `request.state.org_id == None`
+- AND `IdentityAsserter.verify` is NOT called
+- AND the `X-Org-Id` header is NOT required for this path
+
+### B7. OAuth callback flow with resourceowner-less JWT
+
+- Given Mark logs into Klai (Zitadel JWT lacks resourceowner per
+  SPEC-002 §1.1 evidence) and clicks "Connect Google Drive"
+- When the user completes Google's consent screen and is redirected
+  back to klai-connector's OAuth callback
+- And the redirect carries the user's portal-issued
+  `Authorization: Bearer <jwt>` and `X-Org-Id: <his-org>`
+- Then the callback succeeds (no 401 on the resourceowner-missing
+  read, because that read is gone)
+- AND `request.state.org_id` is set from the portal verify response
+- AND the connector setup flow continues to the next step
+- (This is the user-visible motivation for REQ-2.)
+
+### B8. Cache hit on second introspection (REQ-2.6 cache preserved)
+
+- Given B1 succeeded and the introspection token cache holds the
+  result
+- When klai-connector receives a second request with the same
+  bearer token within 5 min
+- Then introspection is NOT called again (cache hit)
+- AND `IdentityAsserter.verify` IS called again, but its own
+  60s cache short-circuits to the cached decision
+- AND the response is HTTP 200
+
+### B9. Static check — resourceowner literal gone from klai-connector
+
+- Given the diff for the klai-connector PR
+- When CI runs
+  `grep -rn "urn:zitadel:iam:user:resourceowner" klai-connector/app/`
+- Then the result is empty (test fixtures live under
+  `klai-connector/tests/`, not `app/`)
+
+---
+
+## C. ast-grep glob extension — REQ-3
+
+### C1. Glob extension lands in the same PR as the service refactor
+
+- Given a PR that refactors `klai-retrieval-api/retrieval_api/middleware/auth.py`
+  per REQ-1
+- When the PR is opened
+- Then the same PR diff also includes:
+  - `rules/no-zitadel-resourceowner-claim.yml` `files:` adds
+    `klai-retrieval-api/retrieval_api/**/*.py`
+  - `rules/no-zitadel-resourceowner-claim.yml` `ignores:` adds
+    `klai-retrieval-api/tests/**/*.py`
+- AND CI ast-grep job passes on the PR (no surviving resourceowner
+  reads in retrieval-api source after the refactor)
+
+### C2. Same for klai-connector
+
+- Given a PR that refactors `klai-connector/app/middleware/auth.py`
+  per REQ-2
+- When the PR is opened
+- Then the same PR diff also includes:
+  - `rules/no-zitadel-resourceowner-claim.yml` `files:` adds
+    `klai-connector/app/**/*.py`
+  - `rules/no-zitadel-resourceowner-claim.yml` `ignores:` adds
+    `klai-connector/tests/**/*.py`
+- AND CI ast-grep job passes on the PR
+
+### C3. Future reintroduction blocked at PR time
+
+- Given a hypothetical future PR that adds
+  `claims.get("urn:zitadel:iam:user:resourceowner:id")` anywhere in
+  `klai-retrieval-api/retrieval_api/` or `klai-connector/app/`
+- When the PR is opened
+- Then the CI ast-grep job fails with a clear error pointing to this
+  SPEC and SPEC-002 REQ-5
+- AND the PR cannot merge until the offending read is removed
+
+### C4. Cross-service grep returns only test fixtures and historical SPECs
+
+- Given both PRs (REQ-1 + REQ-2) have landed on main
+- When the audit grep runs:
+  ```
+  grep -rn "urn:zitadel:iam:user:resourceowner" \
+    klai-portal/backend/ klai-scribe/ klai-retrieval-api/ \
+    klai-connector/ klai-knowledge-mcp/ klai-libs/ \
+    klai-mailer/
+  ```
+- Then ALL hits fall into ONE of these categories:
+  - Test fixtures under `tests/` directories
+  - Historical SPEC documents (none in source paths)
+  - The `.claude/rules/klai/platform/zitadel.md` rule file
+- AND no active source-code line in any service references the claim
+
+---
+
+## D. Grafana alerts — REQ-4
+
+### D1. retrieval-api identity-assertion-failure alert exists
+
+- Given the deploy of REQ-4
+- When `deploy/grafana/provisioning/alerting/` is synced via the
+  `deploy-compose.yml` workflow
+- Then a file named `identity-verify-failures-iam-003.yml` (or a
+  similarly-named file) exists with a Grafana alert rule
+- AND the rule UID begins with `spec-iam-003-` and is at most 40
+  characters
+- AND the rule fires at threshold > 5 events/minute over a 5-minute
+  rolling window for the retrieval-api stream
+
+### D2. klai-connector identity-assertion-failure alert exists
+
+- Same as D1 but for the klai-connector stream
+- AND the rule UID is distinct from the retrieval-api UID and also
+  prefixed `spec-iam-003-`
+- AND both UIDs pass the canary-CI check
+  `scripts/audit-alert-uid-length.sh`
+
+### D3. Alert payloads include service / caller_service / reason
+
+- Given the alert fires on staging
+- When the on-call engineer opens the alert detail
+- Then the payload includes `service`, `caller_service`, and
+  `reason` fields drawn from the structlog event (or labelled
+  Prometheus counter, depending on REQ-4.5 implementation choice)
+- AND the engineer can immediately see whether the deny is
+  `no_membership` (legitimate, but unexpected at scale) versus
+  `invalid_jwt` (likely deploy issue) without opening VictoriaLogs
+  separately
+
+### D4. Existing Prometheus counter still ticks
+
+- Given retrieval-api has been live with REQ-1 for at least 1 hour
+- When `cross_org_rejected_total{reason="identity_assertion_failed"}`
+  is queried via Prometheus
+- Then the metric increments on every `verified=false` decision
+  (unchanged from pre-SPEC behaviour, line 420 of
+  `klai-retrieval-api/retrieval_api/middleware/auth.py`)
+
+---
+
+## E. Migration / rollout — REQ-6
+
+### E1. SPEC-002 must be live first
+
+- Given a clean staging environment
+- When step 1 (retrieval-api REQ-1) is deployed BEFORE SPEC-002
+  portal-api changes are live
+- Then the deploy succeeds (the code itself runs)
+- BUT every JWT-bound retrieve request returns HTTP 403
+  `identity_assertion_failed` because portal-api still rejects on the
+  resourceowner equality check
+- AND the operator MUST verify SPEC-002 portal-api is on main + deployed
+  before proceeding (REQ-6.1 step 1)
+- AND attempting to deploy this SPEC against pre-SPEC-002 portal-api
+  is a hard incompatibility that is observed within 1 minute via the
+  REQ-4 alert
+
+### E2. Deploy order: retrieval-api first
+
+- Given SPEC-002 is live in production
+- When step 2 (retrieval-api REQ-1 + REQ-3 + REQ-5.1-5.3) is deployed
+- Then retrieval-api restarts cleanly
+- AND existing internal-secret callers continue to work (regression
+  guard A7)
+- AND the JWT path begins routing through portal verify
+- AND the REQ-4 alert remains green for a 30-minute observation window
+- (REQ-6.3 mandates this observation window before step 3.)
+
+### E3. Deploy order: klai-connector second
+
+- Given step 2 has been observed green for 30 minutes
+- When step 3 (klai-connector REQ-2 + REQ-3 + REQ-5.4-5.6) is deployed
+- Then klai-connector restarts cleanly
+- AND `alembic upgrade head` runs successfully on the connector
+  entrypoint (per the auto-migrate pattern documented in
+  `process-rules.md` `scribe-deploy-no-alembic`); this SPEC adds no
+  migrations of its own, so the alembic head should match
+  pre-deploy
+- AND existing portal-bypass calls work (B6)
+- AND OAuth callback flow works for resourceowner-less JWTs (B7)
+
+### E4. Rollback procedure works (per service)
+
+- Given step 3 has just deployed and a regression is observed
+- When the operator runs `git revert <step-3-commit> && gh run watch`
+- Then klai-connector reverts to the pre-SPEC behaviour
+- AND retrieval-api (still on REQ-1) keeps working — no
+  co-dependency between the two services
+- AND SPEC-002 portal-api stays untouched
+- (Mirror: rolling back step 2 leaves klai-connector unaffected
+  because step 3 only deploys after step 2 is green for 30 min,
+  so a rollback of step 2 happens before step 3 ships.)
+
+### E5. No DB migration
+
+- The diff in `klai-retrieval-api/.../alembic/` (if any) is empty
+  for this SPEC
+- The diff in `klai-connector/.../alembic/versions/` is empty for
+  this SPEC
+
+### E6. No SOPS env change
+
+- The diff in `klai-infra/core-01/.env.sops` is empty for this SPEC
+- The deploy-compose workflow does NOT run with
+  `allow_removal=I-CONFIRM-REMOVAL` for any commit in this SPEC
+
+### E7. Step 3 PR fails CI if SPEC-002 not on main
+
+- Given a PR for step 3 that depends on SPEC-002 + step 2 having
+  landed
+- And SPEC-002 is somehow missing from main (test scenario via
+  rebase against an older base)
+- Then the klai-connector integration test that exercises the
+  `IdentityAsserter` path fails because portal-api's
+  `/internal/identity/verify` still enforces the resourceowner
+  equality check
+- AND the PR cannot merge until SPEC-002 is on main
+
+### E8. Cross-service ast-grep CI guard
+
+- Given both services have shipped REQ-1 + REQ-2 + REQ-3
+- When CI runs the ast-grep job on a clean main checkout
+- Then the job passes
+- AND the audit grep from C4 returns only test fixtures and historical
+  SPEC documents
+- AND adding `urn:zitadel:iam:user:resourceowner` to any active
+  source path fails CI on the next PR

--- a/.moai/specs/SPEC-SEC-IDENTITY-ASSERT-003/spec.md
+++ b/.moai/specs/SPEC-SEC-IDENTITY-ASSERT-003/spec.md
@@ -1,0 +1,471 @@
+# SPEC-SEC-IDENTITY-ASSERT-003 — retrieval-api + klai-connector membership-authoritative auth
+
+Status: Draft
+Author: Mark Vletter (with assistant)
+Follow-up to: SPEC-SEC-IDENTITY-ASSERT-002 (PR #545)
+Related: SPEC-SEC-IDENTITY-ASSERT-001, SPEC-AUTH-008, SPEC-SEC-INTERNAL-001
+Created: 2026-05-08
+
+---
+
+## 1. Background
+
+SPEC-SEC-IDENTITY-ASSERT-002 retired the
+`urn:zitadel:iam:user:resourceowner:id` JWT claim as a source of truth
+inside `portal-api` (REQ-1) and `scribe-api` (REQ-3). Membership lookup
+in `portal_users` is now the canonical authority for "which orgs can
+this user act on", aligned with `.claude/rules/klai/platform/zitadel.md`
+lines 99-100 ("Never use `urn:zitadel:iam:user:resourceowner:id` —
+not always present. Use `sub` (OIDC subject) → `portal_users` →
+`portal_orgs` join for reliable org resolution").
+
+Two services were not yet covered by SPEC-002 because they are not
+proxied through portal-api BFF and therefore needed a different fix
+shape. Both still read the resourceowner claim from the inbound JWT
+and reject the request when the claim is absent. After SPEC-002 landed,
+they are the only two remaining latent occurrences of the same bug
+class:
+
+1. **`klai-retrieval-api`**:
+   `klai-retrieval-api/retrieval_api/middleware/auth.py` line 61 defines
+   `_ZITADEL_RESOURCEOWNER_CLAIM` and lines 339-353 read it into
+   `AuthContext.resourceowner` for every JWT-bound request. Lines
+   478-490 in `verify_body_identity` then reject any call where
+   `body_org_id != auth.resourceowner`. For Klai users whose JWT lacks
+   the claim (the production reality per SPEC-002 §1.1), the field is
+   `None` and the equality check silently skips — but the JWT path
+   never populates `request.state.verified_caller` for those users
+   (line 508 requires `auth.resourceowner is not None`), so any
+   downstream code that relies on `verified_caller` runs with no
+   identity and either crashes or denies. End-state: JWT-bound
+   retrieve calls hit a fail-soft / fail-loud edge that is not
+   load-bearing security and breaks legitimate users.
+
+2. **`klai-connector`**:
+   `klai-connector/app/middleware/auth.py` line 138 reads
+   `claims.get("urn:zitadel:iam:user:resourceowner:id")` after Zitadel
+   token introspection and returns HTTP 401 when the claim is missing
+   (lines 139-141). This is a hard 401: the OAuth callback flow for
+   Google Drive, Microsoft 365, Notion, etc. fails outright for any
+   user whose JWT lacks the claim. It is the strongest form of the
+   bug: not a soft skip, an outright deny.
+
+Production evidence already documented in SPEC-002 §1.3
+(VictoriaLogs 2026-04-01 → 2026-05-08, zero `verified=true`
+events for `caller_service:scribe`) generalises to these two
+services: anywhere the resourceowner claim is required, it isn't
+emitted, so the path is dead code in the success direction and a
+reject path in the failure direction.
+
+Internal-secret callers into retrieval-api are NOT affected by the
+bug fixed here (they use `verify_body_identity` with `bearer_jwt=None`
+which already routes through the membership-authoritative
+`/internal/identity/verify` after SPEC-002 REQ-1). This SPEC fixes
+ONLY the JWT-bound paths.
+
+## 2. Why retire the claim from these two services
+
+SPEC-002 §2 establishes that the resourceowner-equality check is
+non-load-bearing for Klai's threat model: it does not close any
+in-scope attack vector and conflates **identity** (`sub`) with
+**active org context** (`claimed_org_id`). That entire argument
+applies verbatim to retrieval-api and klai-connector — there is no
+service-specific reason to keep reading the claim in either of
+them.
+
+Additional service-specific motivation:
+
+- `klai-retrieval-api` is on the chat hot path. Every LibreChat or
+  partner-API completion flows through here. Soft-failing on
+  resourceowner-absence means a class of legitimate end-users get
+  empty retrieval responses with no actionable error.
+- `klai-connector` is the OAuth callback target. Failing 401 here
+  means a user clicks "Connect Google Drive", goes through Google's
+  consent screen, is redirected back to Klai, and the connector
+  setup fails with no visible cause. The user has no path forward
+  except to ask support.
+
+The fix is structurally identical to SPEC-002 REQ-1: route the JWT
+path through `portal-api /internal/identity/verify` and let the
+already-deployed membership-authoritative resolver decide which org
+the user is acting on. Both services already import the
+`klai_identity_assert.IdentityAsserter` library; the change is to
+extend its usage from the internal-secret path to the JWT path.
+
+## 3. Goals
+
+1. Make every JWT-bound entry-point on `klai-retrieval-api` and
+   `klai-connector` work for every authenticated portal user,
+   regardless of Zitadel claim emission.
+2. Remove the last two in-tree consumers of
+   `urn:zitadel:iam:user:resourceowner:id` (per the
+   2026-05-08 audit — see REQ-7).
+3. Extend the `rules/no-zitadel-resourceowner-claim.yml` ast-grep
+   rule's `files:` glob to cover both services so future
+   reintroduction is blocked at CI time.
+4. Extend Grafana alerting so the equivalent of SPEC-002 REQ-6.2
+   (`bff_proxy_verify_failures`) covers retrieval-api and
+   klai-connector deny rates.
+5. Preserve all in-scope threat coverage from
+   SPEC-SEC-IDENTITY-ASSERT-001 §"Threat Model".
+
+## 4. Threat-model addendum
+
+This SPEC inherits the threat model from
+SPEC-SEC-IDENTITY-ASSERT-001 §"Threat Model" verbatim and
+SPEC-SEC-IDENTITY-ASSERT-002 §4 (BFF-as-identity-boundary,
+scribe direct-mode removal) where it applies.
+
+After SPEC-003 ships, the
+`urn:zitadel:iam:user:resourceowner:id` claim has zero consumers
+in active Klai service code. The only remaining references are
+test fixtures that build JWTs INCLUDING this claim to verify it is
+harmless when present (regression guard), historical SPEC documents,
+and the `.claude/rules/klai/platform/zitadel.md` rule itself. The
+ast-grep rule from SPEC-002 REQ-5.2 prevents reintroduction.
+
+Service-specific addenda:
+
+### Addendum-1: retrieval-api JWT path trust boundary
+
+retrieval-api's JWT path verifies the JWT signature, issuer,
+audience, and `sub` cryptographically (unchanged by this SPEC).
+After this SPEC, the org-resolution step delegates to portal-api
+membership lookup over a portal-internal HTTP call authenticated
+by `INTERNAL_SECRET`. The trust boundary stays where it already
+was for the internal-secret path: portal-api is the authoritative
+membership store, retrieval-api is a downstream that asks.
+
+### Addendum-2: klai-connector JWT path trust boundary
+
+klai-connector receives Zitadel access tokens that the Zitadel
+introspection endpoint already validates (signature, expiry,
+audience). After this SPEC, the org-resolution step delegates to
+portal-api membership lookup. The introspection cache (5 minute
+TTL, lines 32-72 of `auth.py`) is preserved; portal-api adds a
+~5-15ms steady-state cost on cache miss, but the existing
+`klai_identity_assert.IdentityAsserter` cache (60s TTL) absorbs
+near-equivalents.
+
+## 5. Requirements
+
+### REQ-1: retrieval-api — JWT path drops resourceowner read
+
+The system SHALL retire `_ZITADEL_RESOURCEOWNER_CLAIM` consumption from
+`klai-retrieval-api/retrieval_api/middleware/auth.py` and route every
+JWT-bound identity decision through `portal-api /internal/identity/verify`.
+
+- **REQ-1.1:** WHEN `AuthMiddleware.dispatch` (lines 318-392 of
+  `klai-retrieval-api/retrieval_api/middleware/auth.py`) decodes a JWT,
+  THE middleware SHALL stop reading
+  `payload.get(_ZITADEL_RESOURCEOWNER_CLAIM)`. The `resourceowner`
+  field on `AuthContext` (line 86) SHALL be deleted; downstream
+  consumers in `verify_body_identity` SHALL be rewritten per REQ-1.3.
+- **REQ-1.2:** THE constant `_ZITADEL_RESOURCEOWNER_CLAIM` (line 61)
+  SHALL be deleted. No code path SHALL read the claim string from the
+  JWT payload after this REQ lands.
+- **REQ-1.3:** WHEN `verify_body_identity` (line 431) is called for a
+  JWT-bound caller (`auth.method == "jwt"`), THE function SHALL call
+  `klai_identity_assert.IdentityAsserter.verify` with
+  `caller_service="retrieval-api"`,
+  `claimed_user_id=auth.sub`,
+  `claimed_org_id=<org-id-from-header>`,
+  `bearer_jwt=<the-bearer-token>`,
+  `request_headers=dict(request.headers)`.
+  The `claimed_org_id` SHALL be sourced from the inbound
+  `X-Org-Id` request header set by the caller (LibreChat hook,
+  knowledge-mcp proxy, docs-app). Sourcing claimed_org_id from a
+  caller-set header is symmetrical with the existing internal-secret
+  path on the same middleware (which sources `caller_service` from
+  `X-Caller-Service`, lines 525-544) and keeps the trust boundary
+  identical: portal-api is the authority, the header is a hint.
+- **REQ-1.4:** IF the inbound JWT path lacks a non-empty `X-Org-Id`
+  header, THE middleware SHALL return HTTP 400 with
+  `{"error": "missing_org_id"}` and emit a structlog warning with
+  `event="missing_org_id"`. This is a loud config error rather than
+  a silent fail-open.
+- **REQ-1.5:** IF `IdentityAsserter.verify` returns
+  `verified=false`, THE middleware SHALL return HTTP 403 with
+  `{"error": "identity_assertion_failed"}` (matching the existing
+  internal-secret deny shape, lines 425-428) AND SHALL increment
+  `cross_org_rejected_total` AND SHALL emit
+  `event="identity_assertion_failed"` with the portal-side reason.
+- **REQ-1.6:** WHEN `IdentityAsserter.verify` returns
+  `verified=true`, THE middleware SHALL pin
+  `request.state.verified_caller = VerifiedCaller(
+    user_id=result.user_id, org_id=result.org_id)` from the portal
+  response, NOT from JWT claims. This replaces lines 508-511 of
+  the current implementation.
+- **REQ-1.7:** Existing JWT validity checks (signature, audience,
+  issuer, `sub` presence — `_decode_jwt`, lines 189-238) SHALL be
+  preserved unchanged. The fix is org-resolution only; the JWT itself
+  is still cryptographically verified against Zitadel JWKS.
+- **REQ-1.8:** Rate-limiting (`_rate_limit_key`, lines 303-306) SHALL
+  be preserved unchanged. The JWT path key still hashes
+  `auth.sub`; no change to the rate-limit identity.
+
+### REQ-2: klai-connector — middleware drops resourceowner read
+
+The system SHALL retire the `urn:zitadel:iam:user:resourceowner:id`
+read from `klai-connector/app/middleware/auth.py` line 138 and route
+the JWT path through `portal-api /internal/identity/verify`.
+
+- **REQ-2.1:** WHEN `AuthMiddleware.dispatch`
+  (`klai-connector/app/middleware/auth.py` line 95) processes a Zitadel
+  introspection result, THE middleware SHALL stop reading
+  `claims.get("urn:zitadel:iam:user:resourceowner:id")` (line 138).
+  The literal string SHALL be deleted from the file.
+- **REQ-2.2:** AFTER token introspection succeeds AND the audience
+  check passes (lines 121-135, unchanged), THE middleware SHALL call
+  `klai_identity_assert.IdentityAsserter.verify` with
+  `caller_service="klai-connector"`,
+  `claimed_user_id=claims.get("sub")`,
+  `claimed_org_id=<org-id-from-header>`,
+  `bearer_jwt=<the-bearer-token>`,
+  `request_headers=dict(request.headers)`.
+  The `claimed_org_id` SHALL be sourced from the inbound `X-Org-Id`
+  request header set by the caller (portal-api when proxying OAuth
+  callbacks; the connector UI when invoking sync endpoints). Same
+  rationale as REQ-1.3.
+- **REQ-2.3:** IF the request lacks a non-empty `X-Org-Id` header on
+  any non-`/health` non-portal-bypass path, THE middleware SHALL
+  return HTTP 400 with `{"error": "missing_org_id"}`. Portal-bypass
+  callers (line 113, `from_portal=True`) are exempt because they
+  already set `org_id=None` per the existing contract.
+- **REQ-2.4:** IF `IdentityAsserter.verify` returns
+  `verified=false`, THE middleware SHALL return HTTP 403 with
+  `{"error": "identity_assertion_failed"}` (NOT 401 — the user has
+  a valid Zitadel token, but no membership for the claimed org;
+  that is an authorization failure, not authentication).
+- **REQ-2.5:** WHEN `IdentityAsserter.verify` returns
+  `verified=true`, THE middleware SHALL set
+  `request.state.org_id = str(result.org_id)` from the portal
+  response, NOT from the JWT claim. This replaces line 143.
+- **REQ-2.6:** THE token introspection cache (lines 32-72) SHALL be
+  preserved unchanged. The cache stores Zitadel introspection
+  results, not portal verify results; the `IdentityAsserter` library
+  has its own 60s cache for the verify call.
+- **REQ-2.7:** THE `_portal_secret` bypass (lines 107-116) SHALL be
+  preserved unchanged. Portal-api service-to-service calls continue
+  to bypass the verify path because portal-api IS the verifier; a
+  self-recursion would be circular.
+- **REQ-2.8:** THE `IdentityAsserter` SHALL be instantiated at module
+  level following the same lazy pattern as
+  `klai-retrieval-api/retrieval_api/middleware/auth.py` lines 400-410
+  (singleton, constructed on first use). Settings already expose
+  `portal_api_url` and `portal_caller_secret`; reuse those.
+
+### REQ-3: ast-grep rule glob extension
+
+The system SHALL extend the `files:` glob in
+`rules/no-zitadel-resourceowner-claim.yml` (the file introduced by
+SPEC-002 REQ-5.2) to include `klai-retrieval-api/` and
+`klai-connector/` source paths AFTER REQ-1 and REQ-2 land.
+
+- **REQ-3.1:** THE `files:` list SHALL add:
+  - `klai-retrieval-api/retrieval_api/**/*.py`
+  - `klai-connector/app/**/*.py`
+- **REQ-3.2:** THE `ignores:` list SHALL add:
+  - `klai-retrieval-api/tests/**/*.py`
+  - `klai-connector/tests/**/*.py`
+- **REQ-3.3:** THE rule extension SHALL land in the SAME PR as the
+  service refactor for that service. Landing the glob extension
+  before the service refactor breaks CI on the existing
+  resourceowner reads; landing it after creates a temporal window
+  where reintroduction is undetected.
+- **REQ-3.4:** AFTER both REQs ship, a final cross-service grep
+  `grep -rn "urn:zitadel:iam:user:resourceowner" \
+   klai-portal/backend/ klai-scribe/ klai-retrieval-api/ \
+   klai-connector/ klai-knowledge-mcp/ klai-libs/` SHALL return ONLY
+  test fixtures and historical SPEC document references. Any active
+  code reference SHALL fail the CI ast-grep job.
+
+### REQ-4: Grafana alerts — extend identity-verify failure observability
+
+The system SHALL extend the Grafana alert family introduced by
+SPEC-002 REQ-6.2 to cover deny rates on the two new caller-services.
+
+- **REQ-4.1:** A new alert rule with UID prefix `spec-iam-003-`
+  (compliant with the 40-char limit per
+  `.claude/rules/klai/pitfalls/process-rules.md`
+  `grafana-uid-40-char-limit`) SHALL be added at
+  `deploy/grafana/provisioning/alerting/identity-verify-failures-iam-003.yml`.
+- **REQ-4.2:** THE alert SHALL fire WHEN the rate of
+  `event="identity_assertion_failed" AND service:retrieval-api`
+  events exceeds 5 per minute over a 5-minute rolling window.
+- **REQ-4.3:** A second rule SHALL fire WHEN the rate of
+  `event="identity_assertion_failed" AND service:klai-connector`
+  events exceeds 5 per minute over a 5-minute rolling window.
+  klai-connector deny rates are typically 0; a sudden non-zero rate
+  signals either deploy-window misconfiguration or a probing
+  attacker.
+- **REQ-4.4:** Alert payloads SHALL include the
+  `service`, `caller_service`, and `reason` fields so the on-call
+  engineer can immediately see whether the deny is `no_membership`
+  (legitimate, but unexpected at scale) versus `invalid_jwt`
+  (likely deploy or Zitadel issue).
+- **REQ-4.5:** Existing
+  `cross_org_rejected_total{reason=identity_assertion_failed}`
+  Prometheus counter on retrieval-api (line 420) SHALL stay. The
+  Grafana rule MAY use either the structlog event stream
+  (VictoriaLogs) or the Prometheus counter; prefer the counter for
+  alerting because it does not depend on log retention.
+
+### REQ-5: Tests — JWT-without-resourceowner regression coverage
+
+The system SHALL ship a regression test on every JWT-bound entry
+path that currently consumes the resourceowner claim.
+
+- **REQ-5.1:** `klai-retrieval-api/tests/` SHALL contain a test that
+  POSTs to `/retrieve` with:
+  - A Zitadel JWT that has valid signature, valid audience, valid
+    `sub`, AND lacks `urn:zitadel:iam:user:resourceowner:id`
+  - Header `X-Org-Id: <user-org-id>`
+  - Mock `IdentityAsserter.verify` to return
+    `verified=true, user_id=<sub>, org_id=<expected>`
+  - Assert HTTP 200
+  - Assert `request.state.verified_caller` is pinned from the
+    portal response, NOT from the JWT
+- **REQ-5.2:** `klai-retrieval-api/tests/` SHALL contain a test where
+  the same JWT (no resourceowner) is sent WITHOUT `X-Org-Id`
+  header. Assert HTTP 400 `{"error": "missing_org_id"}`.
+- **REQ-5.3:** `klai-retrieval-api/tests/` SHALL contain a test where
+  the JWT INCLUDES a (legacy) resourceowner claim that DOES NOT
+  match the `X-Org-Id` header. Assert the claim is ignored and the
+  membership lookup runs (mock the asserter to return verified=true
+  for the header value). Mirror SPEC-002 acceptance scenario A6.
+- **REQ-5.4:** `klai-connector/tests/` SHALL contain a test that
+  exercises the OAuth callback path with a Zitadel-introspected
+  token whose claims dict lacks `urn:zitadel:iam:user:resourceowner:id`.
+  Mock the introspection and the IdentityAsserter; assert HTTP 200
+  and `request.state.org_id == result.org_id` from the asserter.
+- **REQ-5.5:** `klai-connector/tests/` SHALL contain a test that
+  asserts HTTP 400 when `X-Org-Id` is missing on a non-portal-bypass
+  call.
+- **REQ-5.6:** `klai-connector/tests/` SHALL preserve the existing
+  portal-bypass test (no `X-Org-Id` required when
+  `from_portal=True`).
+- **REQ-5.7:** Test fixtures that build JWTs SHALL NOT include the
+  resourceowner claim except in the SPEC-002 A6-mirror regression
+  test (REQ-5.3).
+
+### REQ-6: Migration / rollout
+
+- **REQ-6.1:** Land in this order on `main`:
+  1. SPEC-002 must be live in production (PR #545 deployed) before
+     any work in this SPEC starts. SPEC-002 portal-api changes are
+     the prerequisite — REQ-1 and REQ-2 below depend on
+     `/internal/identity/verify` resolving via membership.
+  2. retrieval-api: REQ-1 + REQ-3 (the glob extension for retrieval
+     paths only) + REQ-5.1-5.3 in a single PR.
+  3. klai-connector: REQ-2 + REQ-3 (the glob extension for connector
+     paths) + REQ-5.4-5.6 in a single PR.
+  4. REQ-4 Grafana alerts as a follow-up commit on klai-infra (or
+     wherever `deploy/grafana/provisioning/alerting/` is tracked).
+- **REQ-6.2:** Service deploys: retrieval-api FIRST (it is stateless;
+  rollback is a revert + redeploy with no data implications);
+  klai-connector SECOND (it has Alembic migrations queued in normal
+  development that are unrelated to this SPEC, but the deploy
+  workflow ordering matters because the connector entrypoint
+  auto-runs `alembic upgrade head` per the
+  `alembic-stamped-past-skipped-migration` lesson — a failed deploy
+  here can stall later infra work).
+- **REQ-6.3:** Each service deploy SHALL be observed for at least 30
+  minutes before the next service deploys, to ensure the per-service
+  identity-assertion-failure metric (REQ-4) does not spike.
+- **REQ-6.4:** Rollback procedure: per service, revert the merge
+  commit and redeploy. The two services do not share any files; no
+  co-dependency between them. SPEC-002 must remain live for the
+  rolled-back service to keep working — never roll back SPEC-002
+  while SPEC-003 is partially deployed.
+- **REQ-6.5:** No DB migration. No SOPS env-var change. No Zitadel
+  console operation.
+
+### REQ-7: Out-of-scope inventory + audit attestation
+
+The system SHALL document the cross-service audit completed during
+this SPEC's authoring.
+
+- **REQ-7.1:** As of 2026-05-08, the only two active in-tree
+  consumers of `urn:zitadel:iam:user:resourceowner:id` outside test
+  fixtures and historical SPEC documents are
+  `klai-retrieval-api/retrieval_api/middleware/auth.py` (this SPEC,
+  REQ-1) and `klai-connector/app/middleware/auth.py` (this SPEC,
+  REQ-2). No other Klai service references the claim in a
+  load-bearing path. SPEC-002 already removed the references from
+  portal-api, scribe-api, knowledge-mcp, and the
+  `klai_identity_assert` library.
+- **REQ-7.2:** AFTER this SPEC's REQ-1, REQ-2, and REQ-3 land, the
+  ast-grep rule SHALL prevent reintroduction at PR time. Future
+  audits MAY rely on the rule and skip a manual cross-service grep.
+- **REQ-7.3:** Out of scope for this SPEC:
+  - Migrating retrieval-api or klai-connector behind portal-api BFF
+    (analogous to SPEC-002 REQ-2 for scribe). That is a separate
+    architecture decision that may or may not happen; the current
+    SPEC's design preserves direct-mode for both services.
+  - Removing the `klai_identity_assert` library dependency from
+    either service. Both services USE it more after this SPEC, not
+    less.
+  - Adding the `urn:zitadel:iam:user:resourceowner` scope to BFF
+    authorize requests. Explicitly NOT done — would re-introduce
+    dependency on an IdP-specific claim that the rule (and now
+    SPEC-002) says not to use.
+
+## 6. Risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Adding a portal `/internal/identity/verify` round-trip on every retrieval-api JWT request adds latency to the chat hot path | Med | Cache (60s TTL via `IdentityAsserter`) absorbs >99% of calls. First-hit cost ≈ 5-15ms (single membership query at portal-api; cached locally for 60s). Measure on staging under realistic load before production deploy; rollback via REQ-6.4 if p95 increases by >10ms. |
+| klai-connector OAuth callback adds verify roundtrip on top of the existing OAuth provider roundtrip | Low | OAuth callbacks are user-initiated, infrequent (one per provider connect), and already round-trip Google/Microsoft/Notion. One extra portal call is negligible. The `IdentityAsserter` cache is irrelevant here because callbacks are first-time. |
+| `X-Org-Id` header sourcing means a misconfigured caller (LibreChat hook, docs-app) sends the wrong header | Low | The header is a hint; portal-api still validates membership against the JWT's `sub`. A wrong `X-Org-Id` produces `verified=false` (no_membership for that user against that org), not a privilege escalation. The deny path is loud (REQ-4 alert). |
+| Multi-org users discover edge cases in `_resolve_active_membership_org_slug` they couldn't reach before from these surfaces | Low | Helper has been in production since SPEC-001 and is exercised by every internal-secret call into retrieval-api today. SPEC-002 also exercises it for portal-api JWT paths. Behaviour is well-understood. |
+| Partial deploy: SPEC-003 retrieval-api deployed but ast-grep glob extension forgotten | Low | REQ-3.3 makes the glob extension a same-PR concern. CI fails the PR if the rule is not extended. |
+| ast-grep rule glob extension lands BEFORE the service refactor | Low | REQ-3.3 explicitly orders glob-after-refactor. Any PR that lands the glob first will fail the rule on its own diff. |
+
+## 7. Out of scope
+
+- Migrating retrieval-api / klai-connector to BFF-proxy mode
+  (SPEC-002 REQ-2 pattern). Tracked as future work; not needed
+  to fix the bug class addressed here.
+- Removing the local Zitadel introspection cache from
+  klai-connector. The cache is independent of the org-resolution
+  fix; touching it is a separate optimisation.
+- Removing the local Zitadel JWKS cache from retrieval-api. Same
+  rationale.
+- Adding new `caller_service` allowlist entries beyond
+  `retrieval-api` and `klai-connector` to
+  `klai_identity_assert.KNOWN_CALLER_SERVICES`. They are already
+  present (used by the existing internal-secret path).
+- Zitadel-side configuration changes. None required.
+- SOPS env / deploy-compose changes. None required.
+- Renaming `X-Org-Id` to a verified header (e.g.
+  `X-Klai-Verified-Org-Id` per SPEC-002 REQ-2.3). The verified
+  header pattern only applies behind the BFF; for direct-mode
+  services the inbound header is a hint, not a verified value.
+
+## 8. Traceability
+
+| REQ | Files affected | Test files |
+|---|---|---|
+| REQ-1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8 | `klai-retrieval-api/retrieval_api/middleware/auth.py` (lines 61, 86, 339-353, 431-512) | `klai-retrieval-api/tests/test_auth_middleware.py` (new or extended), `klai-retrieval-api/tests/test_request_id_validation.py` (header propagation regression check) |
+| REQ-2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8 | `klai-connector/app/middleware/auth.py` (lines 32-144) | `klai-connector/tests/test_auth_middleware.py` (new or extended) |
+| REQ-3 | `rules/no-zitadel-resourceowner-claim.yml` (created by SPEC-002 REQ-5.2) | CI ast-grep job |
+| REQ-4 | `deploy/grafana/provisioning/alerting/identity-verify-failures-iam-003.yml` (new) | manual Grafana review on staging |
+| REQ-5 | `klai-retrieval-api/tests/test_auth_middleware.py`, `klai-connector/tests/test_auth_middleware.py` | (the tests themselves) |
+| REQ-6 | `.github/workflows/retrieval-api.yml`, `.github/workflows/klai-connector.yml` | manual deploy observation |
+| REQ-7 | this SPEC (audit attestation only) | none |
+
+## 9. References
+
+- SPEC-SEC-IDENTITY-ASSERT-002 (`.moai/specs/SPEC-SEC-IDENTITY-ASSERT-002/spec.md`) — predecessor; PR #545
+- SPEC-SEC-IDENTITY-ASSERT-001 (`.moai/specs/SPEC-SEC-IDENTITY-ASSERT-001/spec.md`) — original threat model
+- SPEC-AUTH-008 — BFF model (referenced for trust-boundary alignment, not extended)
+- `.claude/rules/klai/platform/zitadel.md` lines 99-100 — claim unreliability rule
+- `.claude/rules/klai/pitfalls/process-rules.md` `grafana-uid-40-char-limit` — UID convention for REQ-4.1
+- `.claude/rules/klai/pitfalls/process-rules.md` `alembic-stamped-past-skipped-migration` — referenced in REQ-6.2
+- `klai-retrieval-api/retrieval_api/middleware/auth.py` — REQ-1 target
+- `klai-connector/app/middleware/auth.py` — REQ-2 target
+- `klai-portal/backend/app/services/identity_verifier.py` — `verify_identity_claim` and `_resolve_active_membership_org_slug` consumed via `IdentityAsserter` library
+- `klai-libs/identity-assert/...` — the `IdentityAsserter` library both services already depend on
+- Zitadel docs: https://zitadel.com/docs/apis/openidoauth/scopes
+- Zitadel docs: https://zitadel.com/docs/apis/openidoauth/claims

--- a/deploy/grafana/provisioning/alerting/identity-assert-003-rules.yaml
+++ b/deploy/grafana/provisioning/alerting/identity-assert-003-rules.yaml
@@ -1,0 +1,211 @@
+# SPEC-SEC-IDENTITY-ASSERT-003 REQ-4 — alerts that catch the same
+# regression class for retrieval-api and klai-connector.
+#
+# Routed via spec=SPEC-SEC-IDENTITY-ASSERT-003 → klai-ops-alerts-email
+# (see policies.yaml).
+#
+# UID convention: spec-iam-003-* (per
+# .claude/rules/klai/pitfalls/process-rules.md grafana-uid-40-char-limit).
+#
+# Mirrors SPEC-002's identity-assert-rules.yaml shape — count-based
+# thresholds on deny events, not ratios.
+
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: spec-iam-003-identity-assert
+    folder: Klai
+    interval: 1m
+    rules:
+
+      # ── retrieval-api JWT-path identity-assert failures ────────────
+      # SPEC-003 REQ-1 regression guard. Counts deny events on the
+      # retrieval-api JWT-bound verify_body_identity path. At baseline
+      # this is zero; non-zero means either a tenant is broken (the
+      # SPEC-001/002 latent-bug class) or a legitimate auth attempt is
+      # being rejected. Either way ops needs visibility within minutes.
+      - uid: spec-iam-003-retrieval-verify-fail
+        title: retrieval_api_identity_assert_failures
+        condition: threshold
+        data:
+          - refId: query
+            datasourceUid: victorialogs
+            queryType: instant
+            relativeTimeRange:
+              from: 600
+              to: 0
+            model:
+              refId: query
+              datasource:
+                type: victoriametrics-logs-datasource
+                uid: victorialogs
+              expr: 'service:retrieval-api AND event:identity_assertion_failed'
+              queryType: instant
+          - refId: reduce
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 600
+              to: 0
+            model:
+              refId: reduce
+              type: reduce
+              reducer: count
+              expression: query
+          - refId: threshold
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 600
+              to: 0
+            model:
+              refId: threshold
+              type: threshold
+              expression: reduce
+              conditions:
+                - evaluator: { params: [3], type: gt }
+                  operator: { type: and }
+                  reducer: { params: [], type: last }
+                  type: query
+        noDataState: OK
+        execErrState: OK
+        for: 5m
+        labels:
+          severity: warning
+          spec: SPEC-SEC-IDENTITY-ASSERT-003
+        annotations:
+          summary: |
+            >3 retrieval-api identity_assertion_failed events in 10 min.
+          description: |
+            retrieval-api is rejecting JWT-bound calls at the
+            verify_body_identity gate. After SPEC-003 this fires on:
+              - portal denies (no_membership for the X-Org-Id claim)
+              - body org_id mismatch against portal-resolved org
+
+            Investigation:
+              service:retrieval-api AND event:identity_assertion_failed
+
+      # ── retrieval-api missing X-Org-Id header ──────────────────────
+      # SPEC-003 REQ-1.4 fail-loud guard. Any non-zero count means a
+      # caller is sending a Bearer JWT to /retrieve without the
+      # X-Org-Id header — most likely a deploy-side mismatch where
+      # the caller hasn't been updated for the new contract.
+      - uid: spec-iam-003-retrieval-no-org-id
+        title: retrieval_api_missing_org_id
+        condition: threshold
+        data:
+          - refId: query
+            datasourceUid: victorialogs
+            queryType: instant
+            relativeTimeRange:
+              from: 600
+              to: 0
+            model:
+              refId: query
+              datasource:
+                type: victoriametrics-logs-datasource
+                uid: victorialogs
+              expr: 'service:retrieval-api AND event:missing_org_id'
+              queryType: instant
+          - refId: reduce
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 600
+              to: 0
+            model:
+              refId: reduce
+              type: reduce
+              reducer: count
+              expression: query
+          - refId: threshold
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 600
+              to: 0
+            model:
+              refId: threshold
+              type: threshold
+              expression: reduce
+              conditions:
+                - evaluator: { params: [0], type: gt }
+                  operator: { type: and }
+                  reducer: { params: [], type: last }
+                  type: query
+        noDataState: OK
+        execErrState: OK
+        for: 2m
+        labels:
+          severity: warning
+          spec: SPEC-SEC-IDENTITY-ASSERT-003
+        annotations:
+          summary: |
+            retrieval-api 400 missing_org_id — caller not sending header.
+          description: |
+            A caller is hitting /retrieve with a Bearer JWT but no
+            X-Org-Id header. Identify the caller via the request_id
+            chain and update its outbound to set the header.
+
+            Investigation:
+              service:retrieval-api AND event:missing_org_id
+
+      # ── klai-connector JWT-path identity-assert failures ───────────
+      # SPEC-003 REQ-2 regression guard. Same shape as the retrieval
+      # alert; klai-connector logs identity_assertion_failed when the
+      # post-introspect portal verify denies.
+      - uid: spec-iam-003-connector-verify-fail
+        title: klai_connector_identity_assert_failures
+        condition: threshold
+        data:
+          - refId: query
+            datasourceUid: victorialogs
+            queryType: instant
+            relativeTimeRange:
+              from: 600
+              to: 0
+            model:
+              refId: query
+              datasource:
+                type: victoriametrics-logs-datasource
+                uid: victorialogs
+              expr: 'service:klai-connector AND event:identity_assertion_failed'
+              queryType: instant
+          - refId: reduce
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 600
+              to: 0
+            model:
+              refId: reduce
+              type: reduce
+              reducer: count
+              expression: query
+          - refId: threshold
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 600
+              to: 0
+            model:
+              refId: threshold
+              type: threshold
+              expression: reduce
+              conditions:
+                - evaluator: { params: [3], type: gt }
+                  operator: { type: and }
+                  reducer: { params: [], type: last }
+                  type: query
+        noDataState: OK
+        execErrState: OK
+        for: 5m
+        labels:
+          severity: warning
+          spec: SPEC-SEC-IDENTITY-ASSERT-003
+        annotations:
+          summary: |
+            >3 klai-connector identity_assertion_failed events in 10 min.
+          description: |
+            klai-connector is rejecting JWT-bound calls at the portal
+            verify gate. Common causes: portal_users membership row
+            missing for the user/org pair (real deny), or a deploy-side
+            X-Org-Id mismatch from the caller.
+
+            Investigation:
+              service:klai-connector AND event:identity_assertion_failed

--- a/klai-connector/Dockerfile
+++ b/klai-connector/Dockerfile
@@ -19,6 +19,10 @@ COPY klai-libs/image-storage klai-libs/image-storage
 # SPEC-SEC-INTERNAL-001 B3: klai-log-utils path-dep (sync_engine.error_details
 # sanitiser + portal_client / knowledge_ingest secret guards).
 COPY klai-libs/log-utils klai-libs/log-utils
+# SPEC-SEC-IDENTITY-ASSERT-003 REQ-2: klai-identity-assert path-dep —
+# AuthMiddleware calls portal /internal/identity/verify via this lib
+# instead of reading the JWT resourceowner claim.
+COPY klai-libs/identity-assert klai-libs/identity-assert
 COPY klai-connector/pyproject.toml klai-connector/pyproject.toml
 COPY klai-connector/uv.lock klai-connector/uv.lock
 

--- a/klai-connector/app/middleware/auth.py
+++ b/klai-connector/app/middleware/auth.py
@@ -1,4 +1,11 @@
-"""Zitadel OIDC token introspection middleware with TTL cache."""
+"""Zitadel OIDC token introspection middleware with TTL cache.
+
+SPEC-SEC-IDENTITY-ASSERT-003 REQ-2: org-resolution flows through
+portal-api ``/internal/identity/verify`` instead of reading the JWT
+``urn:zitadel:iam:user:resourceowner:id`` claim. The introspection
+remains the authentication gate; portal becomes the authorization
+authority for org-membership.
+"""
 
 import hashlib
 import hmac
@@ -7,6 +14,7 @@ from collections import OrderedDict
 from typing import Any
 
 import httpx
+from klai_identity_assert import IdentityAsserter
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
@@ -15,6 +23,24 @@ from app.core.config import Settings
 from app.core.logging import get_logger
 
 logger = get_logger(__name__)
+
+
+# SPEC-SEC-IDENTITY-ASSERT-003 REQ-2.8: lazy module-level IdentityAsserter
+# singleton, mirroring the retrieval-api pattern. Constructed on first use
+# so tests that don't exercise the verify path don't pay the cost of an
+# httpx.AsyncClient. Settings are passed at construction time via the
+# AuthMiddleware (which already takes Settings).
+_asserter: IdentityAsserter | None = None
+
+
+def _get_asserter(settings: Settings) -> IdentityAsserter:
+    global _asserter
+    if _asserter is None:
+        _asserter = IdentityAsserter(
+            portal_base_url=settings.portal_api_url,
+            internal_secret=settings.portal_internal_secret,
+        )
+    return _asserter
 
 
 def _audience_matches(claim: Any, expected: str) -> bool:  # noqa: ANN401
@@ -91,6 +117,9 @@ class AuthMiddleware(BaseHTTPMiddleware):
         # guarantees this is non-empty at startup (fail-closed). The conditional
         # warn-only fallback that allowed empty audience has been removed.
         self._expected_audience = settings.zitadel_api_audience
+        # SPEC-SEC-IDENTITY-ASSERT-003 REQ-2.8: hold the Settings instance so
+        # _get_asserter can construct the singleton lazily on first verify call.
+        self._settings = settings
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         """Process the request through authentication."""
@@ -134,13 +163,42 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 return JSONResponse({"error": "unauthorized"}, status_code=401)
             _cache_put(token_hash, claims)
 
-        # Use raw Zitadel resourceowner ID — must match what knowledge-ingest uses
-        zitadel_org_id = claims.get("urn:zitadel:iam:user:resourceowner:id")
-        if zitadel_org_id is None:
-            logger.warning("Token introspection succeeded but resourceowner:id claim is missing")
+        # SPEC-SEC-IDENTITY-ASSERT-003 REQ-2.1 + REQ-2.2: org-resolution
+        # flows through portal /internal/identity/verify. The
+        # urn:zitadel:iam:user:resourceowner:id claim is no longer read.
+        # claimed_org_id sourced from X-Org-Id header (REQ-2.2 — symmetric
+        # with retrieval-api JWT path).
+        sub = claims.get("sub")
+        if not isinstance(sub, str) or not sub:
+            logger.warning("Token introspection succeeded but sub claim is missing")
             return JSONResponse({"error": "unauthorized"}, status_code=401)
 
-        request.state.org_id = str(zitadel_org_id)
+        header_org_id = request.headers.get("x-org-id", "").strip()
+        if not header_org_id:
+            # REQ-2.3: loud config error rather than silent fail-open.
+            logger.warning("Missing X-Org-Id header on JWT path", extra={"path": request.url.path})
+            return JSONResponse({"error": "missing_org_id"}, status_code=400)
+
+        asserter = _get_asserter(self._settings)
+        result = await asserter.verify(
+            caller_service="klai-connector",
+            claimed_user_id=sub,
+            claimed_org_id=header_org_id,
+            bearer_jwt=token,
+            request_headers=dict(request.headers),
+        )
+        if not result.verified:
+            # REQ-2.4: 403 not 401 — the user has a valid Zitadel token but
+            # no membership for the claimed org; that is an authorization
+            # failure, not authentication.
+            logger.warning(
+                "identity_assertion_failed",
+                extra={"reason": result.reason, "path": request.url.path},
+            )
+            return JSONResponse({"error": "identity_assertion_failed"}, status_code=403)
+
+        # REQ-2.5: pin the portal-resolved org_id, NOT the JWT claim.
+        request.state.org_id = str(result.org_id) if result.org_id else header_org_id
         return await call_next(request)
 
     async def _introspect(self, token: str) -> dict[str, Any] | None:

--- a/klai-connector/pyproject.toml
+++ b/klai-connector/pyproject.toml
@@ -39,12 +39,18 @@ dependencies = [
     "atlassian-python-api>=4.0.7",
     "html2text>=2025.4.15",
     "redis>=5.0",
+    # SPEC-SEC-IDENTITY-ASSERT-003 REQ-2: replace JWT resourceowner trust
+    # with portal /internal/identity/verify. IdentityAsserter provides
+    # the canonical caller pattern (60s LRU cache, fail-closed,
+    # structlog telemetry).
+    "klai-identity-assert",
 ]
 
 [tool.uv.sources]
 klai-connector-credentials = { path = "../klai-libs/connector-credentials", editable = true }
 klai-image-storage = { path = "../klai-libs/image-storage", editable = true }
 klai-log-utils = { path = "../klai-libs/log-utils", editable = true }
+klai-identity-assert = { path = "../klai-libs/identity-assert", editable = true }
 
 [project.optional-dependencies]
 dev = [

--- a/klai-connector/tests/test_audit_2026_04_b2.py
+++ b/klai-connector/tests/test_audit_2026_04_b2.py
@@ -82,14 +82,25 @@ def _build_app(
     audience: str,
     introspect_return: dict[str, Any] | None,
     monkeypatch: pytest.MonkeyPatch,
+    *,
+    asserter_org_id: str = "org-abc",
+    asserter_denies: bool = False,
 ) -> TestClient:
-    """Return a TestClient with AuthMiddleware configured for the given audience."""
+    """Return a TestClient with AuthMiddleware configured for the given audience.
+
+    SPEC-SEC-IDENTITY-ASSERT-003 REQ-2: post-introspect, the middleware
+    calls portal /internal/identity/verify via IdentityAsserter. Tests
+    receive a stub asserter that returns allow with ``asserter_org_id``
+    (or deny when ``asserter_denies=True``).
+    """
     settings = SimpleNamespace(
         zitadel_introspection_url="https://example.test/oauth/v2/introspect",
         zitadel_client_id="cid",
         zitadel_client_secret="csecret",
         portal_caller_secret="",
         zitadel_api_audience=audience,
+        portal_api_url="http://portal-api.test:8100",
+        portal_internal_secret="test-internal-secret",  # noqa: S106
     )
     app = FastAPI()
 
@@ -99,6 +110,27 @@ def _build_app(
 
     app.add_middleware(AuthMiddleware, settings=settings)
     monkeypatch.setattr(AuthMiddleware, "_introspect", _AsyncIntrospectStub(introspect_return))
+
+    # SPEC-003 REQ-2.8: stub the IdentityAsserter so tests don't reach a
+    # real portal-api. Reset the module-level singleton on every build so
+    # one test's stub doesn't leak into the next.
+    from klai_identity_assert import VerifyResult
+
+    from app.middleware import auth as auth_module
+
+    class _StubAsserter:
+        async def verify(self, **_kwargs: Any) -> VerifyResult:
+            if asserter_denies:
+                return VerifyResult.deny("no_membership")
+            return VerifyResult.allow(
+                user_id="test-user-sub",
+                org_id=asserter_org_id,
+                org_slug="test-slug",
+                evidence="membership",
+            )
+
+    monkeypatch.setattr(auth_module, "_asserter", None)
+    monkeypatch.setattr(auth_module, "_get_asserter", lambda _settings: _StubAsserter())
     return TestClient(app)
 
 
@@ -206,11 +238,12 @@ class TestAudienceMatchAccepted:
             introspect_return={
                 "active": True,
                 "aud": "klai-connector",
+                "sub": "test-user-sub",
                 "urn:zitadel:iam:user:resourceowner:id": "org-abc",
             },
             monkeypatch=monkeypatch,
         )
-        resp = client.get("/resource", headers={"Authorization": "Bearer valid-token"})
+        resp = client.get("/resource", headers={"Authorization": "Bearer valid-token", "X-Org-Id": "org-abc"})
         assert resp.status_code == 200
 
     def test_correct_audience_in_list_accepted(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -220,15 +253,23 @@ class TestAudienceMatchAccepted:
             introspect_return={
                 "active": True,
                 "aud": ["klai-api", "klai-connector"],  # connector present in list
+                "sub": "test-user-sub",
                 "urn:zitadel:iam:user:resourceowner:id": "org-abc",
             },
             monkeypatch=monkeypatch,
         )
-        resp = client.get("/resource", headers={"Authorization": "Bearer list-aud-token"})
+        resp = client.get("/resource", headers={"Authorization": "Bearer list-aud-token", "X-Org-Id": "org-abc"})
         assert resp.status_code == 200
 
     def test_org_id_attached_to_request_state(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """org_id is extracted from the resourceowner claim after audience pass."""
+        """SPEC-SEC-IDENTITY-ASSERT-003 REQ-2.5: org_id is the
+        portal-resolved value, NOT the JWT resourceowner claim. The
+        introspection result may carry resourceowner but the middleware
+        ignores it; the asserter's response is authoritative."""
+        from klai_identity_assert import VerifyResult
+
+        from app.middleware import auth as auth_module
+
         app = FastAPI()
         settings = SimpleNamespace(
             zitadel_introspection_url="https://example.test/oauth/v2/introspect",
@@ -236,6 +277,8 @@ class TestAudienceMatchAccepted:
             zitadel_client_secret="csecret",
             portal_caller_secret="",
             zitadel_api_audience="klai-connector",
+            portal_api_url="http://portal-api.test:8100",
+            portal_internal_secret="test-internal-secret",  # noqa: S106
         )
 
         @app.get("/resource")
@@ -250,11 +293,26 @@ class TestAudienceMatchAccepted:
                 {
                     "active": True,
                     "aud": "klai-connector",
-                    "urn:zitadel:iam:user:resourceowner:id": "expected-org-id",
+                    "sub": "test-user-sub",
                 }
             ),
         )
+
+        class _StubAsserter:
+            async def verify(self, **_kwargs: Any) -> VerifyResult:
+                return VerifyResult.allow(
+                    user_id="test-user-sub",
+                    org_id="expected-org-id",
+                    org_slug="test-slug",
+                    evidence="membership",
+                )
+
+        monkeypatch.setattr(auth_module, "_asserter", None)
+        monkeypatch.setattr(auth_module, "_get_asserter", lambda _settings: _StubAsserter())
         client = TestClient(app)
-        resp = client.get("/resource", headers={"Authorization": "Bearer good-token"})
+        resp = client.get(
+            "/resource",
+            headers={"Authorization": "Bearer good-token", "X-Org-Id": "expected-org-id"},
+        )
         assert resp.status_code == 200
         assert resp.json()["org_id"] == "expected-org-id"

--- a/klai-connector/tests/test_auth_middleware_sec008.py
+++ b/klai-connector/tests/test_auth_middleware_sec008.py
@@ -43,6 +43,10 @@ def _make_settings(
     makes audience mandatory (Settings validator rejects empty). Middleware
     tests that explicitly test empty audience use the SimpleNamespace bypass
     (they test middleware behavior directly, not the Settings validator).
+
+    SPEC-SEC-IDENTITY-ASSERT-003 REQ-2: portal_api_url + portal_internal_secret
+    are now required because the post-introspect path calls portal
+    /internal/identity/verify via IdentityAsserter.
     """
     return SimpleNamespace(
         zitadel_introspection_url="https://example.test/oauth/v2/introspect",
@@ -50,6 +54,8 @@ def _make_settings(
         zitadel_client_secret="csecret",
         portal_caller_secret=portal_secret,
         zitadel_api_audience=audience,
+        portal_api_url="http://portal-api.test:8100",
+        portal_internal_secret="test-internal-secret",
     )
 
 
@@ -77,7 +83,8 @@ def _build_app(
     introspect_return: dict[str, Any] | None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> tuple[TestClient, _Recorder]:
-    """Create a FastAPI app with a class-level stub of ``_introspect``."""
+    """Create a FastAPI app with a class-level stub of ``_introspect`` and
+    a stub IdentityAsserter (SPEC-SEC-IDENTITY-ASSERT-003 REQ-2)."""
     app = FastAPI()
 
     @app.get("/ping")
@@ -89,6 +96,29 @@ def _build_app(
     recorder = _Recorder()
     recorder.return_value = introspect_return
     monkeypatch.setattr(AuthMiddleware, "_introspect", recorder)
+
+    # SPEC-003 REQ-2.8: stub IdentityAsserter to allow with the introspect
+    # response's resourceowner if present (back-compat with existing test
+    # fixtures that put it there) or "test-org" otherwise.
+    from klai_identity_assert import VerifyResult
+
+    org_id_default = "test-org"
+    if isinstance(introspect_return, dict):
+        # Best effort: use whatever org id the test put in the introspect
+        # response so its `request.state.org_id` assertion passes.
+        org_id_default = introspect_return.get("urn:zitadel:iam:user:resourceowner:id") or "test-org"
+
+    class _StubAsserter:
+        async def verify(self, **_kwargs: Any) -> VerifyResult:
+            return VerifyResult.allow(
+                user_id="test-user-sub",
+                org_id=str(org_id_default),
+                org_slug="test-slug",
+                evidence="membership",
+            )
+
+    monkeypatch.setattr(auth_module, "_asserter", None)
+    monkeypatch.setattr(auth_module, "_get_asserter", lambda _settings: _StubAsserter())
 
     client = TestClient(app)
     return client, recorder
@@ -174,11 +204,12 @@ class TestPortalBypass:
             introspect_return={
                 "active": True,
                 "aud": "klai-connector",
+                "sub": "test-user-sub",
                 "urn:zitadel:iam:user:resourceowner:id": "org-123",
             },
             monkeypatch=monkeypatch,
         )
-        resp = client.get("/ping", headers={"Authorization": "Bearer some-other-token"})
+        resp = client.get("/ping", headers={"Authorization": "Bearer some-other-token", "X-Org-Id": "org-123"})
         assert resp.status_code == 200
         assert recorder.calls == 1
 
@@ -200,11 +231,12 @@ class TestPortalBypass:
             introspect_return={
                 "active": True,
                 "aud": "klai-connector-test",  # matches _make_settings default audience
+                "sub": "test-user-sub",
                 "urn:zitadel:iam:user:resourceowner:id": "org-x",
             },
             monkeypatch=monkeypatch,
         )
-        resp = client.get("/ping", headers={"Authorization": "Bearer anything"})
+        resp = client.get("/ping", headers={"Authorization": "Bearer anything", "X-Org-Id": "org-x"})
         assert resp.status_code == 200
         assert recorder.calls == 1, "empty portal_secret must not short-circuit to bypass"
 
@@ -222,11 +254,12 @@ class TestAudienceVerification:
             introspect_return={
                 "active": True,
                 "aud": "klai-connector",
+                "sub": "test-user-sub",
                 "urn:zitadel:iam:user:resourceowner:id": "org-xyz",
             },
             monkeypatch=monkeypatch,
         )
-        resp = client.get("/ping", headers={"Authorization": "Bearer good-token"})
+        resp = client.get("/ping", headers={"Authorization": "Bearer good-token", "X-Org-Id": "org-xyz"})
         assert resp.status_code == 200
 
     def test_wrong_audience_string_is_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -264,11 +297,12 @@ class TestAudienceVerification:
             introspect_return={
                 "active": True,
                 "aud": ["klai-scribe", "klai-connector"],
+                "sub": "test-user-sub",
                 "urn:zitadel:iam:user:resourceowner:id": "org-xyz",
             },
             monkeypatch=monkeypatch,
         )
-        resp = client.get("/ping", headers={"Authorization": "Bearer ok-list"})
+        resp = client.get("/ping", headers={"Authorization": "Bearer ok-list", "X-Org-Id": "org-xyz"})
         assert resp.status_code == 200
 
     def test_missing_audience_claim_rejected_when_configured(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/klai-connector/tests/test_spec003_resourceowner_dropped.py
+++ b/klai-connector/tests/test_spec003_resourceowner_dropped.py
@@ -1,0 +1,159 @@
+"""SPEC-SEC-IDENTITY-ASSERT-003 REQ-2 regression guards for klai-connector.
+
+Pinned invariants:
+- B1: a token whose introspection response lacks the resourceowner claim
+  but has a valid sub + matching X-Org-Id → 200 (org_id resolved by portal).
+- B2: missing X-Org-Id header on JWT path → 400 missing_org_id.
+- B3: portal denies → 403 identity_assertion_failed (NOT 401).
+- B4: portal-resolved org_id (NOT JWT claim) is pinned on request.state.
+- B5: literal claim string is gone from production source.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.requests import Request
+
+from app.middleware import auth as auth_module
+from app.middleware.auth import AuthMiddleware
+
+
+class _AsyncIntrospectStub:
+    def __init__(self, return_value: dict[str, Any] | None) -> None:
+        self._rv = return_value
+
+    async def __call__(self, token: str) -> dict[str, Any] | None:  # noqa: ARG002
+        return self._rv
+
+
+def _settings() -> SimpleNamespace:
+    return SimpleNamespace(
+        zitadel_introspection_url="https://example.test/oauth/v2/introspect",
+        zitadel_client_id="cid",
+        zitadel_client_secret="csecret",
+        portal_caller_secret="",
+        zitadel_api_audience="klai-connector",
+        portal_api_url="http://portal-api.test:8100",
+        portal_internal_secret="test-internal-secret",  # noqa: S106
+    )
+
+
+def _build_app(monkeypatch: pytest.MonkeyPatch, *, deny: bool = False, org_id: str = "org-resolved"):
+    app = FastAPI()
+
+    @app.get("/resource")
+    async def resource(request: Request) -> dict[str, str]:
+        return {"org_id": str(getattr(request.state, "org_id", "<unset>"))}
+
+    app.add_middleware(AuthMiddleware, settings=_settings())
+
+    monkeypatch.setattr(
+        AuthMiddleware,
+        "_introspect",
+        _AsyncIntrospectStub(
+            {
+                "active": True,
+                "aud": "klai-connector",
+                "sub": "test-user-sub",
+                # Deliberately NO urn:zitadel:iam:user:resourceowner:id —
+                # this is the regression-guard scenario that failed
+                # silently before SPEC-003.
+            }
+        ),
+    )
+
+    from klai_identity_assert import VerifyResult
+
+    class _StubAsserter:
+        async def verify(self, **_kwargs: Any) -> VerifyResult:
+            if deny:
+                return VerifyResult.deny("no_membership")
+            return VerifyResult.allow(
+                user_id="test-user-sub",
+                org_id=org_id,
+                org_slug="test-slug",
+                evidence="membership",
+            )
+
+    monkeypatch.setattr(auth_module, "_asserter", None)
+    monkeypatch.setattr(auth_module, "_get_asserter", lambda _settings: _StubAsserter())
+    return TestClient(app)
+
+
+class TestSpec003ResourceownerDropped:
+    def test_jwt_without_resourceowner_works_when_portal_allows(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = _build_app(monkeypatch, org_id="org-resolved")
+        resp = client.get(
+            "/resource",
+            headers={"Authorization": "Bearer good-token", "X-Org-Id": "org-resolved"},
+        )
+        assert resp.status_code == 200
+        # B4: pinned org_id is the portal-resolved value.
+        assert resp.json()["org_id"] == "org-resolved"
+
+    def test_missing_x_org_id_returns_400_missing_org_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = _build_app(monkeypatch)
+        resp = client.get("/resource", headers={"Authorization": "Bearer good-token"})
+        assert resp.status_code == 400
+        assert resp.json()["error"] == "missing_org_id"
+
+    def test_empty_x_org_id_returns_400(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = _build_app(monkeypatch)
+        resp = client.get(
+            "/resource",
+            headers={"Authorization": "Bearer good-token", "X-Org-Id": ""},
+        )
+        assert resp.status_code == 400
+
+    def test_portal_deny_returns_403_identity_assertion_failed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = _build_app(monkeypatch, deny=True)
+        resp = client.get(
+            "/resource",
+            headers={"Authorization": "Bearer good-token", "X-Org-Id": "org-victim"},
+        )
+        assert resp.status_code == 403
+        assert resp.json()["error"] == "identity_assertion_failed"
+
+    def test_no_resourceowner_claim_string_in_module_source(self) -> None:
+        """B5: the literal claim string is removed from production source.
+        Comments may still mention the claim; this regression guard checks
+        the actual code paths."""
+        import importlib
+
+        mod = importlib.import_module("app.middleware.auth")
+        with open(mod.__file__, encoding="utf-8") as f:
+            src = f.read()
+        assert 'claims.get("urn:zitadel:iam:user:resourceowner:id"' not in src
+
+    def test_portal_bypass_path_unchanged(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """REQ-2.7: portal-api service-to-service bypass unchanged."""
+        app = FastAPI()
+
+        @app.get("/resource")
+        async def resource(request: Request) -> dict[str, Any]:
+            return {
+                "from_portal": getattr(request.state, "from_portal", False),
+                "org_id": getattr(request.state, "org_id", "<unset>"),
+            }
+
+        s = SimpleNamespace(
+            zitadel_introspection_url="https://example.test/oauth/v2/introspect",
+            zitadel_client_id="cid",
+            zitadel_client_secret="csecret",
+            portal_caller_secret="portal-shared",
+            zitadel_api_audience="klai-connector",
+            portal_api_url="http://portal-api.test:8100",
+            portal_internal_secret="test-internal",  # noqa: S106
+        )
+        app.add_middleware(AuthMiddleware, settings=s)
+        client = TestClient(app)
+        resp = client.get("/resource", headers={"Authorization": "Bearer portal-shared"})
+        assert resp.status_code == 200
+        assert resp.json()["from_portal"] is True
+        # Bypass keeps org_id unset (None) per existing contract.
+        assert resp.json()["org_id"] in (None, "None")

--- a/klai-connector/uv.lock
+++ b/klai-connector/uv.lock
@@ -939,6 +939,7 @@ dependencies = [
     { name = "html2text" },
     { name = "httpx", extra = ["http2"] },
     { name = "klai-connector-credentials" },
+    { name = "klai-identity-assert" },
     { name = "klai-image-storage" },
     { name = "klai-log-utils" },
     { name = "lxml" },
@@ -985,6 +986,7 @@ requires-dist = [
     { name = "html2text", specifier = ">=2025.4.15" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.28.0" },
     { name = "klai-connector-credentials", editable = "../klai-libs/connector-credentials" },
+    { name = "klai-identity-assert", editable = "../klai-libs/identity-assert" },
     { name = "klai-image-storage", editable = "../klai-libs/image-storage" },
     { name = "klai-log-utils", editable = "../klai-libs/log-utils" },
     { name = "lxml", specifier = ">=6.1.0" },
@@ -1040,6 +1042,36 @@ dev = [
     { name = "pyright", specifier = ">=1.1.390" },
     { name = "pytest", specifier = ">=8" },
     { name = "pytest-asyncio", specifier = ">=1" },
+    { name = "ruff", specifier = ">=0.8" },
+]
+
+[[package]]
+name = "klai-identity-assert"
+version = "0.1.0"
+source = { editable = "../klai-libs/identity-assert" }
+dependencies = [
+    { name = "httpx" },
+    { name = "structlog" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.28" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.390" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1" },
+    { name = "respx", marker = "extra == 'dev'", specifier = ">=0.22" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8" },
+    { name = "structlog", specifier = ">=25.0" },
+]
+provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pyright", specifier = ">=1.1.390" },
+    { name = "pytest", specifier = ">=8" },
+    { name = "pytest-asyncio", specifier = ">=1" },
+    { name = "respx", specifier = ">=0.22" },
     { name = "ruff", specifier = ">=0.8" },
 ]
 

--- a/klai-portal/backend/tests/test_grafana_identity_alerts_003.py
+++ b/klai-portal/backend/tests/test_grafana_identity_alerts_003.py
@@ -19,14 +19,7 @@ from pathlib import Path
 import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-ALERT_PATH = (
-    REPO_ROOT
-    / "deploy"
-    / "grafana"
-    / "provisioning"
-    / "alerting"
-    / "identity-assert-003-rules.yaml"
-)
+ALERT_PATH = REPO_ROOT / "deploy" / "grafana" / "provisioning" / "alerting" / "identity-assert-003-rules.yaml"
 
 
 def test_alert_yaml_syntactically_valid() -> None:
@@ -39,9 +32,7 @@ def test_alert_yaml_syntactically_valid() -> None:
 def test_all_uids_under_40_chars() -> None:
     parsed = yaml.safe_load(ALERT_PATH.read_text(encoding="utf-8"))
     for rule in parsed["groups"][0]["rules"]:
-        assert len(rule["uid"]) <= 40, (
-            f"UID {rule['uid']!r} exceeds 40-char Grafana limit ({len(rule['uid'])} chars)"
-        )
+        assert len(rule["uid"]) <= 40, f"UID {rule['uid']!r} exceeds 40-char Grafana limit ({len(rule['uid'])} chars)"
 
 
 def test_all_uids_use_klai_prefix_convention() -> None:

--- a/klai-portal/backend/tests/test_grafana_identity_alerts_003.py
+++ b/klai-portal/backend/tests/test_grafana_identity_alerts_003.py
@@ -1,0 +1,88 @@
+"""SPEC-SEC-IDENTITY-ASSERT-003 REQ-4 — syntax + invariant tests for the
+SPEC-003 Grafana alert rules.
+
+Pinned invariants:
+- The YAML parses without error.
+- Group name + UID prefix follow the klai convention
+  (`spec-iam-003-`, per process-rules.md grafana-uid-40-char-limit).
+- All UIDs stay under 40 chars (Grafana hard limit).
+- All rules carry `spec=SPEC-SEC-IDENTITY-ASSERT-003` for routing.
+- Each rule queries the matching log shape that the production
+  middleware emits (event:identity_assertion_failed,
+  event:missing_org_id).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+ALERT_PATH = (
+    REPO_ROOT
+    / "deploy"
+    / "grafana"
+    / "provisioning"
+    / "alerting"
+    / "identity-assert-003-rules.yaml"
+)
+
+
+def test_alert_yaml_syntactically_valid() -> None:
+    parsed = yaml.safe_load(ALERT_PATH.read_text(encoding="utf-8"))
+    assert parsed["apiVersion"] == 1
+    assert len(parsed["groups"]) == 1
+    assert parsed["groups"][0]["name"] == "spec-iam-003-identity-assert"
+
+
+def test_all_uids_under_40_chars() -> None:
+    parsed = yaml.safe_load(ALERT_PATH.read_text(encoding="utf-8"))
+    for rule in parsed["groups"][0]["rules"]:
+        assert len(rule["uid"]) <= 40, (
+            f"UID {rule['uid']!r} exceeds 40-char Grafana limit ({len(rule['uid'])} chars)"
+        )
+
+
+def test_all_uids_use_klai_prefix_convention() -> None:
+    parsed = yaml.safe_load(ALERT_PATH.read_text(encoding="utf-8"))
+    for rule in parsed["groups"][0]["rules"]:
+        assert rule["uid"].startswith("spec-iam-003-"), (
+            f"UID {rule['uid']!r} does not follow the spec-iam-003- convention"
+        )
+
+
+def test_retrieval_verify_failures_rule_present() -> None:
+    parsed = yaml.safe_load(ALERT_PATH.read_text(encoding="utf-8"))
+    rule = next(r for r in parsed["groups"][0]["rules"] if r["uid"] == "spec-iam-003-retrieval-verify-fail")
+    assert rule["title"] == "retrieval_api_identity_assert_failures"
+    expr = rule["data"][0]["model"]["expr"]
+    assert "service:retrieval-api" in expr
+    assert "event:identity_assertion_failed" in expr
+
+
+def test_retrieval_missing_org_id_rule_present() -> None:
+    parsed = yaml.safe_load(ALERT_PATH.read_text(encoding="utf-8"))
+    rule = next(r for r in parsed["groups"][0]["rules"] if r["uid"] == "spec-iam-003-retrieval-no-org-id")
+    assert rule["title"] == "retrieval_api_missing_org_id"
+    expr = rule["data"][0]["model"]["expr"]
+    assert "service:retrieval-api" in expr
+    assert "event:missing_org_id" in expr
+
+
+def test_connector_verify_failures_rule_present() -> None:
+    parsed = yaml.safe_load(ALERT_PATH.read_text(encoding="utf-8"))
+    rule = next(r for r in parsed["groups"][0]["rules"] if r["uid"] == "spec-iam-003-connector-verify-fail")
+    assert rule["title"] == "klai_connector_identity_assert_failures"
+    expr = rule["data"][0]["model"]["expr"]
+    assert "service:klai-connector" in expr
+    assert "event:identity_assertion_failed" in expr
+
+
+def test_every_rule_carries_spec_label() -> None:
+    parsed = yaml.safe_load(ALERT_PATH.read_text(encoding="utf-8"))
+    for rule in parsed["groups"][0]["rules"]:
+        labels = rule.get("labels", {})
+        assert labels.get("spec") == "SPEC-SEC-IDENTITY-ASSERT-003", (
+            f"Rule {rule['uid']!r} missing or wrong `spec` label: {labels.get('spec')!r}"
+        )

--- a/klai-retrieval-api/retrieval_api/middleware/auth.py
+++ b/klai-retrieval-api/retrieval_api/middleware/auth.py
@@ -58,7 +58,12 @@ logger = structlog.get_logger(__name__)
 # matches every other Klai service.
 _UNAUTH_PATHS: frozenset[str] = frozenset({"/health", "/metrics"})
 
-_ZITADEL_RESOURCEOWNER_CLAIM = "urn:zitadel:iam:user:resourceowner:id"
+# SPEC-SEC-IDENTITY-ASSERT-003 REQ-1.2: the
+# `urn:zitadel:iam:user:resourceowner:id` claim is no longer consulted.
+# Klai BFF never requests the scope that emits it (see SPEC-002 §1).
+# Authoritative org-resolution flows through portal /internal/identity/verify
+# which membership-checks the Zitadel sub against portal_users. CI rule
+# `rules/no-zitadel-resourceowner-claim.yml` blocks reintroduction.
 _ZITADEL_ROLES_CLAIM = "urn:zitadel:iam:org:project:roles"
 
 # JWKS in-memory cache (REQ-NFR performance). Mirrors research-api pattern;
@@ -70,22 +75,27 @@ _jwks_cache: dict[str, Any] | None = None
 class AuthContext:
     """Represents the authenticated principal for the current request.
 
-    method    -- "internal" or "jwt" (service principal vs. user principal).
-    sub       -- JWT ``sub`` claim (user id) when method == "jwt", else None.
-    resourceowner -- JWT Zitadel ``resourceowner`` claim (org id) when method == "jwt".
-    role      -- Highest-privilege role name from the JWT (e.g. "admin"), or None /
-                 "service" for internal callers. Used by REQ-3 admin bypass.
-    scopes    -- SPEC-SEC-SERVICE-AUTH-001 REQ-3: parsed OAuth 2.0 ``scope`` claim
-                 (space-separated string in the JWT) split into a frozenset of
-                 individual scopes. Empty for internal-secret callers (legacy
-                 path); they get a Phase B/C migration bypass via ``require_scope``.
+    method        -- "internal" or "jwt" (service principal vs. user principal).
+    sub           -- JWT ``sub`` claim (user id) when method == "jwt", else None.
+    role          -- Highest-privilege role name from the JWT (e.g. "admin"), or
+                     None / "service" for internal callers. Used by REQ-3 admin
+                     bypass.
+    scopes        -- SPEC-SEC-SERVICE-AUTH-001 REQ-3: parsed OAuth 2.0 ``scope``
+                     claim (space-separated string in the JWT) split into a
+                     frozenset of individual scopes. Empty for internal-secret
+                     callers (legacy path); they get a Phase B/C migration
+                     bypass via ``require_scope``.
+    bearer_token  -- The raw JWT string when method == "jwt", else None.
+                     Carried so :func:`verify_body_identity` can forward it to
+                     portal `/internal/identity/verify` for membership-side
+                     org resolution (SPEC-SEC-IDENTITY-ASSERT-003 REQ-1.3).
     """
 
     method: str
     sub: str | None
-    resourceowner: str | None
     role: str | None
     scopes: frozenset[str] = field(default_factory=frozenset)
+    bearer_token: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -99,9 +109,12 @@ class VerifiedCaller:
     body — so a tampered body cannot poison product_events even if the
     middleware-level guard is ever weakened.
 
-    For JWT callers the values come from ``auth.sub`` / ``auth.resourceowner``
-    (already cryptographically verified). For internal-secret callers they
-    come from a portal-api ``/internal/identity/verify`` round-trip.
+    Both JWT and internal-secret callers now go through portal-api
+    ``/internal/identity/verify`` for org-resolution
+    (SPEC-SEC-IDENTITY-ASSERT-003 REQ-1.3): the JWT path passes
+    ``bearer_jwt`` so portal can validate the signature, and the
+    canonical org_id flows back through ``VerifiedCaller`` rather than
+    being lifted from a JWT-side claim.
     """
 
     user_id: str
@@ -336,7 +349,6 @@ class AuthMiddleware(BaseHTTPMiddleware):
             if error is not None:
                 return _unauthorized(error)
             sub = payload.get("sub")
-            resourceowner = payload.get(_ZITADEL_RESOURCEOWNER_CLAIM)
             if not sub:
                 return _unauthorized("invalid_jwt_signature")
             # SPEC-SEC-SERVICE-AUTH-001 REQ-3: parse OAuth 2.0 scope claim
@@ -344,12 +356,18 @@ class AuthMiddleware(BaseHTTPMiddleware):
             # Missing claim → empty set → endpoints with require_scope reject.
             scopes_claim = payload.get("scope") or ""
             scopes = frozenset(s for s in str(scopes_claim).split() if s)
+            # SPEC-SEC-IDENTITY-ASSERT-003 REQ-1.1: do NOT lift
+            # `urn:zitadel:iam:user:resourceowner:id` from the JWT — the
+            # claim is unreliable per Klai's zitadel.md rule. Org-resolution
+            # is delegated to portal /internal/identity/verify in
+            # verify_body_identity (REQ-1.3). The bearer_token is carried
+            # on AuthContext so the verify call can pass it along.
             auth = AuthContext(
                 method="jwt",
                 sub=str(sub),
-                resourceowner=str(resourceowner) if resourceowner is not None else None,
                 role=_extract_role(payload),
                 scopes=scopes,
+                bearer_token=bearer_token,
             )
         elif internal_header is not None:
             if not _constant_time_secret_match(internal_header, settings.internal_secret):
@@ -357,9 +375,9 @@ class AuthMiddleware(BaseHTTPMiddleware):
             auth = AuthContext(
                 method="internal",
                 sub=None,
-                resourceowner=None,
                 role="service",
                 scopes=frozenset(),
+                bearer_token=None,
             )
         else:
             return _unauthorized("missing_credentials")
@@ -475,20 +493,6 @@ async def verify_body_identity(
                 )
             return
 
-        if auth.resourceowner is not None and str(body_org_id) != str(auth.resourceowner):
-            cross_org_rejected_total.inc()
-            logger.warning(
-                "cross_org_rejected",
-                reason="org_mismatch",
-                auth_method=auth.method,
-                jwt_sub_hash=_hash_sub(auth.sub or ""),
-                path=request.url.path,
-            )
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail={"error": "org_mismatch"},
-            )
-
         if body_user_id is not None and auth.sub is not None and str(body_user_id) != str(auth.sub):
             cross_user_rejected_total.inc()
             logger.warning(
@@ -503,12 +507,61 @@ async def verify_body_identity(
                 detail={"error": "user_mismatch"},
             )
 
-        # JWT path verified the (sub, resourceowner) tuple cryptographically;
-        # body matched. Pin auth values as the verified identity.
-        if auth.sub is not None and auth.resourceowner is not None:
-            request.state.verified_caller = VerifiedCaller(
-                user_id=auth.sub, org_id=auth.resourceowner
+        # SPEC-SEC-IDENTITY-ASSERT-003 REQ-1.3: resolve and verify the
+        # JWT-bound caller's org via portal /internal/identity/verify.
+        # claimed_org_id comes from the inbound X-Org-Id header (set by
+        # LibreChat hook / knowledge-mcp proxy / docs-app); portal-side
+        # membership lookup is authoritative.
+        header_org_id = request.headers.get("x-org-id", "").strip()
+        if not header_org_id:
+            # REQ-1.4: loud config error rather than silent fail-open.
+            logger.warning("missing_org_id", path=request.url.path)
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={"error": "missing_org_id"},
             )
+
+        if auth.sub is None or auth.bearer_token is None:
+            # Programming bug: dispatch always populates these for JWT path.
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail={"error": "internal_auth_state"},
+            )
+
+        asserter = _get_asserter()
+        result = await asserter.verify(
+            caller_service="retrieval-api",
+            claimed_user_id=auth.sub,
+            claimed_org_id=header_org_id,
+            bearer_jwt=auth.bearer_token,
+            request_headers=dict(request.headers),
+        )
+        if not result.verified:
+            raise _identity_assertion_failed(result.reason or "unknown")
+
+        # REQ-1.5 defence-in-depth: the body's org_id MUST match the
+        # portal-verified org. A mismatch means the body was forged
+        # against a JWT for a different tenant.
+        if str(body_org_id) != str(result.org_id):
+            cross_org_rejected_total.inc()
+            logger.warning(
+                "cross_org_rejected",
+                reason="org_mismatch",
+                auth_method=auth.method,
+                jwt_sub_hash=_hash_sub(auth.sub),
+                path=request.url.path,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={"error": "org_mismatch"},
+            )
+
+        # Pin the portal-verified identity. Downstream emit_event /
+        # audit logs source from request.state.verified_caller.
+        request.state.verified_caller = VerifiedCaller(
+            user_id=str(result.user_id) if result.user_id else auth.sub,
+            org_id=str(result.org_id) if result.org_id else header_org_id,
+        )
         return
 
     # auth.method == "internal" — REQ-4.2 portal-side verification.

--- a/klai-retrieval-api/tests/test_auth.py
+++ b/klai-retrieval-api/tests/test_auth.py
@@ -257,10 +257,15 @@ class TestJwtPath:
                 return_value=(True, 0.5),
             ),
         ):
+            # SPEC-SEC-IDENTITY-ASSERT-003 REQ-1.3: JWT path now requires
+            # the X-Org-Id header for portal-side membership lookup.
             resp = client.post(
                 "/retrieve",
                 json=sample_retrieve_request,
-                headers={"Authorization": "Bearer faketoken"},
+                headers={
+                    "Authorization": "Bearer faketoken",
+                    "X-Org-Id": "362757920133283846",
+                },
             )
         assert resp.status_code == 200
 
@@ -303,12 +308,21 @@ class TestJwtPath:
         assert resp.status_code == 401
 
     def test_both_credentials_prefers_jwt(self):
-        """Both valid → JWT path taken (cross-user/org guard applies)."""
+        """Both valid → JWT path taken (X-Org-Id-driven portal verify applies).
+
+        SPEC-SEC-IDENTITY-ASSERT-003 REQ-1: JWT-bound calls source
+        claimed_org_id from X-Org-Id and resolve org via portal. Body
+        org_id MUST match the portal-verified org. Mismatch → 403.
+
+        Test scenario: JWT for user_a + X-Org-Id=org_x (portal allows,
+        echoes org_x back) but body claims org_y → 403 org_mismatch.
+        If the internal-secret path were taken instead, the body
+        org_id would have been the claimed value to portal and the
+        check would not fire.
+        """
         from retrieval_api.main import app
 
         client = TestClient(app)
-        # JWT resourceowner='org_x' but body org_id='org_y' — JWT path rejects.
-        # If internal-secret path were taken instead, the request would succeed.
         payload = _make_jwt_payload(sub="user_a", resourceowner="org_x")
         with _patch_jwt(payload):
             resp = client.post(
@@ -317,6 +331,7 @@ class TestJwtPath:
                 headers={
                     "X-Internal-Secret": os.environ["INTERNAL_SECRET"],
                     "Authorization": "Bearer valid",
+                    "X-Org-Id": "org_x",
                 },
             )
         assert resp.status_code == 403
@@ -330,7 +345,8 @@ class TestJwtPath:
 
 class TestCrossUserOrgGuard:
     def test_cross_org_rejected_403(self):
-        """REQ-8.4: JWT resourceowner=org_x, body org_id=org_y → 403."""
+        """REQ-8.4 + SPEC-003 REQ-1.5: X-Org-Id=org_x (portal allows),
+        body org_id=org_y → 403 org_mismatch (defence-in-depth body check)."""
         from retrieval_api.main import app
 
         client = TestClient(app)
@@ -339,7 +355,7 @@ class TestCrossUserOrgGuard:
             resp = client.post(
                 "/retrieve",
                 json={"query": "q", "org_id": "org_y", "user_id": "user_a"},
-                headers={"Authorization": "Bearer valid"},
+                headers={"Authorization": "Bearer valid", "X-Org-Id": "org_x"},
             )
         assert resp.status_code == 403
         assert resp.json()["detail"] == {"error": "org_mismatch"}
@@ -390,9 +406,7 @@ class TestCrossUserOrgGuard:
         from retrieval_api.main import app
 
         client = TestClient(app)
-        payload = _make_jwt_payload(
-            sub="admin_user", resourceowner="org_admin", role="admin"
-        )
+        payload = _make_jwt_payload(sub="admin_user", resourceowner="org_admin", role="admin")
         sample_retrieve_request["org_id"] = "other_org"
         with (
             _patch_jwt(payload),
@@ -442,9 +456,7 @@ class TestCrossUserOrgGuard:
         # role=None ⇒ helper omits the urn:zitadel:iam:org:project:roles key
         # entirely. This matches the production v0.5.0 shape for invitees
         # whose portal_users.role is "group-admin" or "member".
-        payload = _make_jwt_payload(
-            sub="user-member-1", resourceowner="org-a", role=None
-        )
+        payload = _make_jwt_payload(sub="user-member-1", resourceowner="org-a", role=None)
         with _patch_jwt(payload):
             resp = client.post(
                 "/retrieve",
@@ -453,7 +465,10 @@ class TestCrossUserOrgGuard:
                     "org_id": "org-b",
                     "user_id": "user-member-1",
                 },
-                headers={"Authorization": "Bearer valid"},
+                # X-Org-Id=org-a (caller asserts they want to act on org-a;
+                # portal stub allows). Body claims org-b → defence-in-depth
+                # body-vs-verified mismatch fires.
+                headers={"Authorization": "Bearer valid", "X-Org-Id": "org-a"},
             )
         assert resp.status_code == 403
         assert resp.json()["detail"] == {"error": "org_mismatch"}
@@ -476,9 +491,7 @@ class TestCrossUserOrgGuard:
         from retrieval_api.main import app
 
         client = TestClient(app)
-        payload = _make_jwt_payload(
-            sub="user-x", resourceowner="org-a", role="org_admin"
-        )
+        payload = _make_jwt_payload(sub="user-x", resourceowner="org-a", role="org_admin")
         with _patch_jwt(payload):
             resp = client.post(
                 "/retrieve",
@@ -487,7 +500,7 @@ class TestCrossUserOrgGuard:
                     "org_id": "org-b",
                     "user_id": "user-x",
                 },
-                headers={"Authorization": "Bearer valid"},
+                headers={"Authorization": "Bearer valid", "X-Org-Id": "org-a"},
             )
         assert resp.status_code == 403
         assert resp.json()["detail"] == {"error": "org_mismatch"}
@@ -645,9 +658,7 @@ class TestRateLimit:
         async def _deny(*_a, **_kw):
             return False, 42
 
-        with patch(
-            "retrieval_api.middleware.auth.check_and_increment", side_effect=_deny
-        ):
+        with patch("retrieval_api.middleware.auth.check_and_increment", side_effect=_deny):
             resp = client.post("/retrieve", json=sample_retrieve_request)
         assert resp.status_code == 429
         assert resp.json() == {"error": "rate_limit_exceeded"}
@@ -683,3 +694,167 @@ def test_auth_module_uses_hmac_compare_digest():
     # No ``==`` comparison against settings.internal_secret anywhere.
     assert "== settings.internal_secret" not in src
     assert "settings.internal_secret ==" not in src
+
+
+# --------------------------------------------------------------------------- #
+# SPEC-SEC-IDENTITY-ASSERT-003 — JWT-without-resourceowner regression guards
+# --------------------------------------------------------------------------- #
+
+
+class TestSpec003JwtWithoutResourceowner:
+    """SPEC-SEC-IDENTITY-ASSERT-003 acceptance group A.
+
+    The Klai BFF requests scope `openid profile email offline_access`
+    which does NOT emit `urn:zitadel:iam:user:resourceowner:id`. After
+    SPEC-003 the retrieval-api JWT path no longer reads the claim;
+    org-resolution flows through portal /internal/identity/verify
+    keyed on Zitadel sub + portal_users membership.
+    """
+
+    def test_jwt_lacking_resourceowner_claim_works(self, sample_retrieve_request):
+        """A1: JWT without the resourceowner claim → 200 when X-Org-Id
+        names a real membership and the portal stub allows."""
+        from retrieval_api.main import app
+
+        client = TestClient(app)
+        # Build a JWT payload that does NOT include the
+        # urn:zitadel:iam:user:resourceowner:id claim.
+        payload = {
+            "sub": "user_a",
+            "aud": "test-audience",
+            "iss": "https://auth.test.local",
+            "scope": "klai:internal:retrieval:query",
+        }
+        sample_retrieve_request["org_id"] = "362757920133283846"
+        with (
+            _patch_jwt(payload),
+            patch(
+                "retrieval_api.api.retrieve.coreference.resolve",
+                new_callable=AsyncMock,
+                return_value="resolved",
+            ),
+            patch(
+                "retrieval_api.api.retrieve.embed_single",
+                new_callable=AsyncMock,
+                return_value=[0.0],
+            ),
+            patch(
+                "retrieval_api.api.retrieve.embed_sparse",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "retrieval_api.api.retrieve.gate.should_bypass",
+                new_callable=AsyncMock,
+                return_value=(True, 0.5),
+            ),
+        ):
+            resp = client.post(
+                "/retrieve",
+                json=sample_retrieve_request,
+                headers={
+                    "Authorization": "Bearer faketoken",
+                    "X-Org-Id": "362757920133283846",
+                },
+            )
+        assert resp.status_code == 200
+
+    def test_missing_x_org_id_header_returns_400(self):
+        """REQ-1.4: JWT path without X-Org-Id is a config error, not a
+        silent fail-open. Must be 400 with `missing_org_id`."""
+        from retrieval_api.main import app
+
+        client = TestClient(app)
+        payload = _make_jwt_payload(sub="user_a")
+        with _patch_jwt(payload):
+            resp = client.post(
+                "/retrieve",
+                json={
+                    "query": "q",
+                    "org_id": "362757920133283846",
+                    "user_id": "user_a",
+                },
+                headers={"Authorization": "Bearer valid"},
+            )
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == {"error": "missing_org_id"}
+
+    def test_empty_x_org_id_header_returns_400(self):
+        """Empty-string X-Org-Id treated identically to missing."""
+        from retrieval_api.main import app
+
+        client = TestClient(app)
+        payload = _make_jwt_payload(sub="user_a")
+        with _patch_jwt(payload):
+            resp = client.post(
+                "/retrieve",
+                json={
+                    "query": "q",
+                    "org_id": "362757920133283846",
+                    "user_id": "user_a",
+                },
+                headers={"Authorization": "Bearer valid", "X-Org-Id": ""},
+            )
+        assert resp.status_code == 400
+
+    def test_portal_deny_returns_403_identity_assertion_failed(self):
+        """REQ-1.5: portal returns deny → 403 identity_assertion_failed."""
+        from retrieval_api.main import app
+
+        client = TestClient(app)
+
+        class _DenyAsserter:
+            async def verify(self, **_kwargs):
+                from klai_identity_assert import VerifyResult
+
+                return VerifyResult.deny("no_membership")
+
+        payload = _make_jwt_payload(sub="user_a")
+        with (
+            _patch_jwt(payload),
+            patch(
+                "retrieval_api.middleware.auth._get_asserter",
+                lambda: _DenyAsserter(),
+            ),
+        ):
+            resp = client.post(
+                "/retrieve",
+                json={
+                    "query": "q",
+                    "org_id": "362757920133283846",
+                    "user_id": "user_a",
+                },
+                headers={
+                    "Authorization": "Bearer valid",
+                    "X-Org-Id": "362757920133283846",
+                },
+            )
+        assert resp.status_code == 403
+        assert resp.json()["detail"] == {"error": "identity_assertion_failed"}
+
+    def test_no_resourceowner_constant_in_module(self):
+        """REQ-1.2 + REQ-3 ast-grep guard: the literal claim string MUST
+        NOT appear in the production source. Fixtures and comments in
+        tests are exempt; this test scans the production module only."""
+        import importlib
+
+        mod = importlib.import_module("retrieval_api.middleware.auth")
+        with open(mod.__file__, encoding="utf-8") as f:
+            src = f.read()
+        # Acceptable: comment lines explaining WHY we don't read the
+        # claim. Unacceptable: any actual `claims.get(...)` of the claim
+        # or `_ZITADEL_RESOURCEOWNER_CLAIM` constant assignment.
+        assert "_ZITADEL_RESOURCEOWNER_CLAIM = " not in src
+        assert 'payload.get("urn:zitadel:iam:user:resourceowner:id"' not in src
+        assert 'claims.get("urn:zitadel:iam:user:resourceowner:id"' not in src
+
+    def test_authcontext_has_no_resourceowner_field(self):
+        """REQ-1.1: AuthContext.resourceowner is gone."""
+        from dataclasses import fields
+
+        from retrieval_api.middleware.auth import AuthContext
+
+        names = {f.name for f in fields(AuthContext)}
+        assert "resourceowner" not in names
+        # Sanity: the rest of the contract is intact.
+        assert {"method", "sub", "role", "scopes", "bearer_token"}.issubset(names)

--- a/klai-retrieval-api/tests/test_identity_assert.py
+++ b/klai-retrieval-api/tests/test_identity_assert.py
@@ -347,7 +347,10 @@ class TestJwtPathStillRejectsBodyMismatch:
             resp = app_client.post(
                 "/retrieve",
                 json={"query": "q", "org_id": "org_y", "user_id": "user_a"},
-                headers={"Authorization": "Bearer valid"},
+                # SPEC-SEC-IDENTITY-ASSERT-003: claimed_org_id sourced from
+                # X-Org-Id; body org_id mismatch fires the defence-in-depth
+                # check.
+                headers={"Authorization": "Bearer valid", "X-Org-Id": "org_x"},
             )
         assert resp.status_code == 403
         assert resp.json()["detail"] == {"error": "org_mismatch"}

--- a/klai-retrieval-api/tests/test_source_ip_xff_spoof.py
+++ b/klai-retrieval-api/tests/test_source_ip_xff_spoof.py
@@ -91,13 +91,13 @@ class TestRateLimitKeyDerivationFromSourceIp:
 
     def test_internal_bucket_key_is_tcp_peer_for_internal_auth(self) -> None:
         req = _make_request(tcp_peer="172.18.0.42", xff="1.2.3.4")
-        auth = AuthContext(method="internal", sub=None, resourceowner=None, role=None)
+        auth = AuthContext(method="internal", sub=None, role=None)
         assert _rate_limit_key(auth, req) == "retrieval:rl:internal:172.18.0.42"
 
     def test_internal_bucket_ignores_spoofed_xff(self) -> None:
         """Two requests from the same TCP peer with different forged XFF values
         MUST map to the same bucket — otherwise the rate-limit is bypassable."""
-        auth = AuthContext(method="internal", sub=None, resourceowner=None, role=None)
+        auth = AuthContext(method="internal", sub=None, role=None)
         req1 = _make_request(tcp_peer="172.18.0.42", xff="1.2.3.4")
         req2 = _make_request(tcp_peer="172.18.0.42", xff="evil-spoof-attempt")
         assert _rate_limit_key(auth, req1) == _rate_limit_key(auth, req2)
@@ -106,7 +106,7 @@ class TestRateLimitKeyDerivationFromSourceIp:
         """JWT-authenticated requests use a hashed sub for the bucket, independent
         of both TCP peer and XFF. Regression check: the JWT path is unchanged by
         this SPEC."""
-        auth = AuthContext(method="jwt", sub="user-123", resourceowner=None, role=None)
+        auth = AuthContext(method="jwt", sub="user-123", role=None)
         req = _make_request(tcp_peer="172.18.0.42", xff="anything")
         key = _rate_limit_key(auth, req)
         assert key.startswith("retrieval:rl:jwt:")

--- a/rules/no-zitadel-resourceowner-claim.yml
+++ b/rules/no-zitadel-resourceowner-claim.yml
@@ -1,5 +1,6 @@
-# SPEC-SEC-IDENTITY-ASSERT-002 REQ-5.2 — block reintroduction of the
-# urn:zitadel:iam:user:resourceowner:id JWT claim in production code.
+# SPEC-SEC-IDENTITY-ASSERT-002 REQ-5.2 + SPEC-003 REQ-3 — block
+# reintroduction of the urn:zitadel:iam:user:resourceowner:id JWT claim
+# in production code.
 #
 # Why: per .claude/rules/klai/platform/zitadel.md:99-100 the claim is not
 # always present in Klai access tokens (the BFF never requests the scope
@@ -26,24 +27,18 @@ message: |
 rule:
   pattern: '"urn:zitadel:iam:user:resourceowner:id"'
 
-# Apply to services that have been refactored under SPEC-002 to no
-# longer trust the claim. Two services still consume it (legacy direct
-# JWT paths) and are scoped OUT of this rule until a follow-up SPEC
-# refactors them onto the membership-authoritative pattern:
-#
-#   klai-retrieval-api  retrieval_api/middleware/auth.py
-#   klai-connector      app/middleware/auth.py
-#
-# Adding either to `files:` below requires first replacing those
-# call sites with a portal_users-based org resolution (analogous to
-# what SPEC-002 REQ-3 did for scribe and SPEC-002 REQ-5 did for
-# klai-portal/backend/app/api/me.py).
+# Apply to all Klai service production code. SPEC-002 cleaned
+# portal-api + scribe-api + portal /api/me; SPEC-003 cleaned
+# klai-retrieval-api + klai-connector. After SPEC-003 this rule has
+# FULL coverage of the active codebase — no service is scoped out.
 files:
   - klai-portal/backend/app/**/*.py
   - klai-scribe/scribe-api/app/**/*.py
   - klai-knowledge-mcp/**/*.py
   - klai-libs/identity-assert/klai_identity_assert/**/*.py
   - klai-mailer/app/**/*.py
+  - klai-retrieval-api/retrieval_api/**/*.py
+  - klai-connector/app/**/*.py
 
 # Test fixtures + regression guards may name the claim string to verify
 # that production code IGNORES it. Keep this list narrow.


### PR DESCRIPTION
## Summary

Closes the same latent-bug class that SPEC-002 (PR #545) fixed for scribe-api, but for the two services with direct JWT-introspect paths instead of BFF-proxied paths: **klai-retrieval-api** and **klai-connector**. Both services were silently 401-ing every Klai user whose JWT lacked `urn:zitadel:iam:user:resourceowner:id` — the same claim that SPEC-002 retired from portal-api.

After this PR ships, the resourceowner claim has zero active consumers in Klai service code. The Klai zitadel.md rule is enforced by both code and CI ast-grep.

> **Base branch:** This PR is stacked on `feature/SPEC-SEC-IDENTITY-ASSERT-002` (PR #545). When PR #545 merges to main, this PR will auto-rebase onto main and only the SPEC-003 commits will remain in the diff.

Full SPEC: `.moai/specs/SPEC-SEC-IDENTITY-ASSERT-003/spec.md`

## REQ-1 — retrieval-api JWT path

`retrieval_api/middleware/auth.py`:
- Drop `_ZITADEL_RESOURCEOWNER_CLAIM` constant.
- Drop `AuthContext.resourceowner` field; add `bearer_token` field so `verify_body_identity` can forward the JWT to portal.
- AuthMiddleware.dispatch no longer reads the claim from JWT.
- `verify_body_identity` JWT branch: read `X-Org-Id` (400 if missing), call `IdentityAsserter.verify` with bearer_jwt + sub + header_org_id. Defence-in-depth body-vs-verified org_id check preserved.
- Existing internal-secret path unchanged.

## REQ-2 — klai-connector OAuth-callback middleware

`klai-connector/app/middleware/auth.py`:
- After successful Zitadel introspection + audience check, call `IdentityAsserter.verify` with bearer_jwt + sub + X-Org-Id-from-header.
- Drop `claims.get("urn:zitadel:iam:user:resourceowner:id")` read.
- 403 `identity_assertion_failed` on portal deny (NOT 401 — user has valid token but no membership; that is authorization, not authentication).
- Pin `request.state.org_id` from portal response, never from JWT.
- Portal-api service-to-service bypass and token-introspection cache preserved unchanged.
- New dependency on `klai-identity-assert` library.

## REQ-3 — ast-grep CI rule

`rules/no-zitadel-resourceowner-claim.yml` `files:` glob extended to include `klai-retrieval-api/retrieval_api/**/*.py` and `klai-connector/app/**/*.py`. After this PR the rule has full coverage of active Klai service code; no service is scoped out.

## REQ-4 — Grafana alerts

`deploy/grafana/provisioning/alerting/identity-assert-003-rules.yaml`:
- `spec-iam-003-retrieval-verify-fail` — `service:retrieval-api AND event:identity_assertion_failed` count > 3 in 10 min.
- `spec-iam-003-retrieval-no-org-id` — `service:retrieval-api AND event:missing_org_id` count > 0 in 10 min (catches caller-side deploy mismatch).
- `spec-iam-003-connector-verify-fail` — `service:klai-connector AND event:identity_assertion_failed` count > 3 in 10 min.

All UIDs honour the 40-char Grafana limit + `spec-iam-003-` klai-prefix convention. All carry `spec=SPEC-SEC-IDENTITY-ASSERT-003` for notification routing.

## REQ-5 — Regression tests

- retrieval-api: 6 new tests covering JWT-without-resourceowner success path, missing/empty `X-Org-Id` → 400, portal-deny → 403, source-scan regression guard, AuthContext-shape regression guard.
- klai-connector: 6 new tests with the same pattern + portal-bypass-unchanged regression guard.
- 7 new Grafana-alert-YAML invariant tests (UID limits, prefix convention, query expressions, label routing).

## REQ-7 — Audit attestation

After REQ-1 + REQ-2 land, every remaining mention of the claim string in Klai service code is a comment explaining why it is NOT read. Zero active reads. Verified via:

```bash
grep -rn "urn:zitadel:iam:user:resourceowner:id" \
  klai-portal/backend/app/ klai-scribe/scribe-api/app/ \
  klai-retrieval-api/retrieval_api/ klai-connector/app/ \
  klai-knowledge-mcp/ klai-mailer/app/ \
  klai-libs/identity-assert/klai_identity_assert/
```

Result: 8 matches, all in comments. ast-grep CI rule with full glob coverage passes against the worktree.

## Tests

- portal-api: 2282 + 7 (Grafana-003) = **2289 passed**.
- scribe-api: 103 passed (no change in this PR).
- klai-retrieval-api: 449 passed, 1 skipped (excluding 2 pre-existing env-only failures: falkordb health check, zitadel-audience config validator under cpython 3.14).
- klai-connector: 395 passed, 1 skipped (excluding 4 pre-existing env-only failures: sync_engine `_image_transport`).
- klai-libs/identity-assert: 54 passed (no change).
- knowledge-mcp: 90 passed (no change).
- ast-grep `rules/no-zitadel-resourceowner-claim.yml` against full worktree: zero matches.
- Grafana alert YAML lint: passes.
- Ruff + ruff-format clean on every changed file.

## Test plan (production verification after merge + deploy)

- [ ] User on `getklai.getklai.com/app/connectors` adds a Google Drive connector — OAuth callback completes, no 401.
- [ ] User on `getklai.getklai.com` triggers a knowledge sync — connector returns 200.
- [ ] LiteLLM hook → retrieval-api `/retrieve` continues to work for all tenants (regression check).
- [ ] knowledge-mcp `save_to_docs` continues to work (regression check).
- [ ] VictoriaLogs queries:
  - `service:klai-connector AND event:identity_assertion_failed` → expected near zero
  - `service:retrieval-api AND event:missing_org_id` → expected near zero
  - `service:klai-connector AND event:scribe_auth_internal_secret_mismatch` → no entries (alert sanity)
- [ ] Grafana → Alerting → spec-iam-003-identity-assert group shows OK on all three rules.

## Rollback

Per service, revert the merge commit. The two services do not share files; no co-dependency. No DB migration. No SOPS env. No Zitadel config change.

## Deploy order

Per SPEC REQ-6:

1. retrieval-api deploy (covers REQ-1 + part of REQ-3 + part of REQ-4).
2. klai-connector deploy (REQ-2 + part of REQ-3 + part of REQ-4).
3. Grafana provisioning auto-syncs via `deploy-compose.yml` workflow.
4. CI ast-grep coverage extension is automatic (file-glob extension only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)