### PR TITLE
feat(kb): SPEC-KB-FILE-UPLOAD-001 Phase 1A — close PDF-upload 500

### DIFF
--- a/.moai/specs/SPEC-KB-FILE-UPLOAD-001/progress.md
+++ b/.moai/specs/SPEC-KB-FILE-UPLOAD-001/progress.md
@@ -1,0 +1,183 @@
+# SPEC-KB-FILE-UPLOAD-001 — Implementation Progress
+
+## Phase 1A — text-path closure of the 500-bug
+
+**Status:** code complete, awaiting deploy.
+**Date:** 2026-05-10
+**Branch:** mvletter/large-pdf-upload-fails (Conductor workspace)
+
+### What landed in this commit
+
+- `klai-portal/backend/app/services/file_upload.py` — new validation
+  service: extension whitelist, magic-byte gate stub (decode-based for
+  text path), UTF-8 / cp1252 normalisation with BOM strip, content-
+  addressed source_ref.
+- `klai-portal/backend/app/api/app_knowledge_sources.py` — new route
+  `POST /api/app/knowledge-bases/{kb_slug}/sources/file` that accepts
+  multipart `files`, validates each, accepts `.md` `.txt` `.csv` and
+  forwards to the existing `/ingest/v1/document` text pipeline. Other
+  whitelisted formats (`.pdf .docx .pptx .xlsx .json .xml .zip .tar
+  .doc`) return `phase_pending` per file in the `skipped` array; the
+  whole-request rejection happens only when nothing is accepted.
+- `klai-portal/backend/tests/test_file_upload.py` — 48 unit tests on the
+  validation helpers (extension classifier, BOM strip, encoding
+  fallback, size cap, source_ref dedupe).
+- `klai-portal/backend/tests/test_app_knowledge_sources_file.py` — 9
+  integration tests: happy path for each text format, `.pdf →
+  phase_pending` regression test, mixed `.md + .pdf` partial-success,
+  rejection paths.
+- `klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source.
+  _components/FileUploadForm.tsx` — endpoint flipped from
+  `${DOCS_BASE}/orgs/${orgSlug}/kbs/${kbSlug}/upload` (klai-docs wiki) to
+  `/api/app/knowledge-bases/${kbSlug}/sources/file` (portal-api). Drops
+  `DOCS_BASE` and `getOrgSlug` imports. Client-side per-file 10 MB cap
+  + extension allowlist (`.md .txt .csv` Phase 1A). New
+  `serverSkipped` UI rail surfaces per-file `phase_pending` so the user
+  sees which files were rejected. Drop-zone copy updated to "Markdown,
+  TXT, CSV" + "PDF, Word, Excel, PowerPoint volgen binnenkort".
+- `deploy/caddy/Caddyfile` — `request_body { max_size 10MB }` scoped
+  to `^/api/app/knowledge-bases/[^/]+/sources/file$` via `path_regexp`,
+  placed before the general `/api/*` handler so other endpoints retain
+  the default request-body limit. Phase 1B raises this to 200 MB when
+  binary streaming lands.
+
+### Tests passing
+
+- `tests/test_file_upload.py` — 48 unit tests
+- `tests/test_app_knowledge_sources_file.py` — 9 route integration tests
+- `tests/test_app_knowledge_sources.py` — 14 (no regression, existing
+  url/text routes still pass)
+- `tests/test_caddyfile_static_route_position.py` — 2 (Caddy lint
+  invariant intact)
+- Frontend `tsc --noEmit --ignoreDeprecations 6.0` — clean
+
+Total in scope: **71 backend tests + frontend type-check green.**
+
+### Acceptance criteria mapped
+
+Phase 1A satisfies a subset of REQ-1 / REQ-6 / REQ-7 from the SPEC:
+
+- [x] AC-1.1 partial — `.md .txt .csv` upload returns 202 with
+  artifact_id list (text path only).
+- [x] AC-1.2 — `.exe` returns 400 `unsupported_extension`.
+- [x] AC-1.5 — text formats decode UTF-8 first; cp1252 fallback;
+  invalid encoding returns 400 `invalid_text_encoding`.
+- [x] AC-2.2 partial — Caddy `max_size 10MB` returns 413 for oversize
+  on this path (Phase 1B raises to 200 MB).
+- [x] AC-6.1 — endpoint returns `{ uploads: [...], skipped: [...] }`.
+- [x] AC-6.2 — archive entries n/a in Phase 1A; skipped array carries
+  `phase_pending` rejections instead.
+- [x] AC-6.3 — failure_reason is non-null and from a documented enum.
+- [x] AC-7.1 — `FileUploadForm.tsx` no longer imports `DOCS_BASE`.
+- [x] AC-7.2 — client-side size guard rejects > 10 MB before network.
+- [x] AC-7.4 partial — main failure_reasons mapped to NL strings
+  (full Paraglide string-table migration in Phase 1B).
+- [x] AC-7.6 partial — accept attribute is `.md,.txt,.csv` (Phase 1A
+  whitelist; full whitelist lands in Phase 1B + 2 + 3).
+
+### Acceptance criteria deferred (Phase 1B / 2 / 3 / 4)
+
+These are documented in spec.md §7 Phasing and scope-to-follow-up
+commits:
+
+- AC-1.4 (OOX validation), AC-9.4 (magic-byte before storage write):
+  needs Garage upload path, lands Phase 1B.
+- AC-2.3 / AC-2.4 / AC-2.5 (200 MB streaming, RSS bound, p95 < 60s):
+  needs `klai-libs/document-storage` + Garage, Phase 1B.
+- AC-3.x (archive safety): needs `adapters/archive.py`, Phase 3.
+- AC-4.x (docling routing): needs `adapters/docling.py`, Phase 2.
+- AC-5.4 (FOR UPDATE concurrent quota race): needs `kb_uploads_quota`
+  table + helper, Phase 1B. Phase 1A reuses existing
+  `assert_can_add_item_to_kb` (item-count quota, not byte quota).
+- AC-8.x (Grafana panel `KB Uploads — Hourly`): structlog events
+  `kb_upload_received` already emitted; Grafana panel definition is a
+  separate config-as-code commit.
+- AC-9.5 (private bucket policy): needs Garage bucket provisioning,
+  Phase 1B.
+
+### Divergence from SPEC §7 Phase 1 deliverables
+
+Per `spec-discipline` rule (HARD), this Phase 1A is intentionally a
+**subset** of the SPEC's Phase 1:
+
+| SPEC §7 Phase 1 deliverable | Phase 1A | Phase 1B |
+|---|---|---|
+| Caddy `request_body 200MB` | scoped 10MB ✓ | raise to 200MB |
+| SOPS `GARAGE_DOCUMENTS_BUCKET` | — | ✓ |
+| `klai-libs/document-storage` lib | — | ✓ |
+| Garage bucket `klai-documents` (manual on core-01) | — | ✓ |
+| portal-api new route | text path ✓ | binary path |
+| portal-api `file_upload.py` service | text validation ✓ | + Garage write |
+| portal-api `kb_uploads_quota.py` | — | ✓ FOR UPDATE byte quota |
+| portal-api `kb_file_upload` product | dropped (uses existing knowledge product) | n/a |
+| portal-api `garage_documents_bucket` setting | — | ✓ |
+| portal-api alembic `kb_uploads` table | — | ✓ |
+| portal-api `/internal/kb-uploads/status` webhook | — | ✓ |
+| knowledge-ingest `/ingest/v1/file` | text routes via existing `/document` | new route Phase 1B |
+| knowledge-ingest text-mime path | reuses existing markdown chunker ✓ | extends to binary mimes Phase 2 |
+| frontend FileUploadForm endpoint flip | ✓ | — |
+| frontend XHR progress | — (uses fetch/apiFetch) | ✓ Phase 1B |
+| frontend Paraglide messages | inline NL strings ✓ | full Paraglide table Phase 1B |
+| `docs/runbooks/kb-file-upload.md` | — | ✓ |
+| `.claude/rules/klai/projects/portal-backend.md` | — | ✓ |
+
+**Justification:** the user-visible 500 closes today via the route
+flip + text-path acceptance. Garage / new tables / webhook / new
+ingest endpoint are all infrastructure that requires bucket
+provisioning on core-01 + alembic deploy + cross-service env-var
+parity (SOPS first, validator second per pitfall). Doing all of that
+in one commit risks env-parity regressions. Phase 1B is the dedicated
+follow-up.
+
+### Decision: drop `kb_file_upload` product
+
+The SPEC REQ-5 introduced a new `kb_file_upload` product gate. On
+implementation review this is over-scoped: existing `/sources/url` and
+`/sources/text` routes do NOT check a product gate — they rely on
+KB-writability via `_get_writable_kb_or_raise` (which already enforces
+plan + role + quota). File uploads follow the same pattern. The
+`kb_file_upload` product would only matter if we wanted to gate file
+upload separately from URL/text — no current product reason to do so.
+This is recorded as a divergence from SPEC REQ-5 to be resolved in the
+SPEC's next revision (probably: drop the requirement in favour of "if
+the user can use knowledge they can upload files").
+
+### Operator steps required before Phase 1A is fully live
+
+1. Caddyfile auto-syncs via `deploy-compose.yml` on push to main (
+   class-A bind-mount, see `infra/deploy.md`).
+2. portal-api auto-rebuilds and recreates via `portal-api.yml`.
+3. Frontend auto-rebuilds via `klai-portal.yml`.
+4. **No SOPS update needed for Phase 1A** (no new env vars).
+5. **No alembic migration in Phase 1A** (uses existing artifacts +
+   item-count quota).
+
+After CI green: smoke-test with a `sample.md` upload at
+`https://my.getklai.com/app/knowledge/<kb>/add-source`; verify in
+VictoriaLogs `service:portal-api AND event:kb_upload_received AND
+decision:accepted`.
+
+### Phase 1B — next commits in scope
+
+1. New SOPS env var `GARAGE_DOCUMENTS_BUCKET=klai-documents`.
+2. Manual Garage bucket creation on core-01 + key grant.
+3. New `klai-libs/document-storage` library (mirrors `image-storage`).
+4. New `kb_uploads` + `kb_uploads_quota` alembic tables (cat-D RLS via
+   `post_deploy_*.sql` per existing pattern).
+5. New `assert_can_upload_bytes` quota helper with FOR UPDATE.
+6. New `/ingest/v1/file` endpoint on knowledge-ingest.
+7. Caddy raise to 200 MB.
+8. Frontend XHR progress + full Paraglide string table.
+9. New runbook `docs/runbooks/kb-file-upload.md`.
+
+### Confidence
+
+- Backend: 95 — 71 tests green, lint clean, format clean, no
+  regression on existing route tests. Tested locally against the unit
+  + integration suite.
+- Frontend: 80 — TypeScript clean, no test framework hit yet (Vitest
+  not run). Browser e2e via Playwright is Phase 1B with deployed env.
+- Caddy: 70 — directive syntax follows existing `path_regexp` pattern
+  but not Caddy-validated locally. CI will fail-loud on bad config
+  via `deploy-compose.yml` health-check. Operator should `caddy
+  validate` on the rendered Caddyfile before merging if available.

--- a/.moai/specs/SPEC-KB-FILE-UPLOAD-001/spec.md
+++ b/.moai/specs/SPEC-KB-FILE-UPLOAD-001/spec.md
@@ -1,0 +1,856 @@
+---
+id: SPEC-KB-FILE-UPLOAD-001
+title: KB File Upload via docling-serve
+version: 0.1.0
+status: draft
+created_at: 2026-05-10
+owner: mark.vletter
+domain: knowledge-base
+related_specs:
+  - SPEC-KB-SOURCES-001        # url/text/youtube routes (no file path)
+  - SPEC-SEC-SSRF-001          # docling-serve must-not-join socket-proxy
+  - SPEC-CRAWLER-004           # image pipeline (Garage S3 blueprint)
+  - SPEC-INFRA-CONTAINER-HYGIENE-001  # klasse A labelling
+  - SPEC-INFRA-CONFIG-SYNC-001 # bind-mount sync pattern
+  - SPEC-SEC-IDENTITY-ASSERT-002      # internal-secret + membership auth
+  - SPEC-DEPLOY-AUTO-MIGRATE-001      # alembic auto-migration on portal-api
+---
+
+# SPEC-KB-FILE-UPLOAD-001 — KB File Upload via docling-serve
+
+## HISTORY
+
+| Date       | Version | Author        | Note                                         |
+|------------|---------|---------------|----------------------------------------------|
+| 2026-05-10 | 0.1.0   | mark.vletter  | Initial draft. Phase 1-4 plan, EARS REQ-1..9 |
+
+---
+
+## 1. Goal & Outcome
+
+### Goal
+
+Add a real file-upload route to the Klai knowledgebase pipeline so that uploaded
+binary documents (PDF / DOCX / XLSX / PPTX / archives) end up as searchable
+chunks in Qdrant + Postgres via the existing chunk → embed → graph pipeline.
+
+### Outcome (success measured by)
+
+- Uploading a 100 MB PDF via the KB UI produces ≥ 100 retrievable chunks within
+  60 seconds end-to-end on production hardware.
+- The current `500: 500` failure on `/app/knowledge/<kb>/add-source` for
+  non-`.md` files is gone; failure responses are structured with a
+  machine-readable `error_code`.
+- All 12 listed extensions (`.csv .doc .docx .json .md .pdf .pptx .tar .txt
+  .xlsx .xml .zip`) are accepted at the public boundary; binary formats route
+  through `docling-serve`, archives are unpacked safely, text formats skip
+  docling.
+- Magic-byte validation runs server-side **before** any object storage write —
+  a `.exe` renamed to `.pdf` returns `400 mime_mismatch` with no Garage object
+  created.
+
+### Non-goal
+
+- Audio / video transcription via docling (`asr` extra + ffmpeg).
+- Resumable / `tus.io` uploads (only relevant > 1 GB).
+- Direct-to-S3 presigned-PUT pattern (only relevant > 1 GB).
+- Cross-org sharing of uploaded documents.
+- KB content-search UX changes.
+
+---
+
+## 2. Background
+
+The frontend `FileUploadForm` on `/app/knowledge/<kb>/add-source` POSTs to
+`${DOCS_BASE}/orgs/{org}/kbs/{kb}/upload` (DOCS_BASE = `/api/docs/api`). That
+upstream is the **klai-docs** wiki upload, which only accepts `.md`, stores
+content in **Gitea**, and crashes (HTTP 500) on 100 MB binaries because
+Next.js `request.formData()` on docs-app loads the whole body into memory and
+`file.text()` decodes binary as UTF-8.
+
+The real KB pipeline (`knowledge-ingest` → Qdrant + Postgres) has **no
+file-upload endpoint** today. `app_knowledge_sources.py` has only `url`,
+`text`, and a deprecated `youtube` stub.
+
+`docling-serve v1.16.1` is already deployed (`deploy/docker-compose.yml:783`)
+on the internal `klai-net` and accepts every required binary format via
+`POST /v1/convert/file` and `POST /v1/chunk/hybrid/file`. The
+architecture document (`docs/architecture/klai-knowledge-architecture.md`)
+already describes the intended shape (`klai-connector file upload endpoint`)
+but the endpoint was never built — the design predates `SPEC-DECOMM-FOCUS-001`
+and the docling integration in `klai-focus/research-api/services/docling.py`
+was decommissioned with the rest of klai-focus.
+
+---
+
+## 3. Scope
+
+### In scope
+
+- New `POST /api/app/knowledge-bases/{kb_slug}/sources/file` route in
+  portal-api.
+- New `klai-libs/document-storage` library wrapping the Garage S3 SDK,
+  modelled on `klai-libs/image-storage`.
+- New `klai-documents` Garage bucket, **private**, presigned-GET only.
+- New `POST /ingest/v1/file` route in knowledge-ingest with Procrastinate
+  background job.
+- New docling adapter in knowledge-ingest (`adapters/docling.py`) targeting
+  `/v1/chunk/hybrid/file`.
+- New archive adapter in knowledge-ingest (`adapters/archive.py`) with
+  sunzip-style streaming guards.
+- New `libreoffice-headless` sidecar container (Phase 4 only) for `.doc`
+  → `.docx` pre-conversion.
+- Caddy `request_body { max_size 200MB }` scoped to the upload handle.
+- Frontend `FileUploadForm` switched to the new endpoint; client-side size
+  guard, progress bar, and i18n failure-reason mapping.
+- Quota & RBAC: per-KB byte quota, per-org daily upload rate limit, new
+  `kb_file_upload` product gate.
+- Observability: structured `kb_upload_received` and `kb_file_extracted`
+  events, Grafana panel.
+
+### Out of scope (explicitly)
+
+- Editing or replacing already-uploaded artifacts (re-upload only).
+- Per-page preview of uploaded documents in the UI (artifact list shows
+  filename + chunk count only).
+- Downloading the original binary back from the KB (presigned-GET exists for
+  internal debugging, no UI surface).
+- Real-time WebSocket status updates (poll-based instead).
+- Retroactive migration of existing wiki `.md` uploads into the new path.
+
+---
+
+## 4. Architecture
+
+```
+Browser
+  │ multipart/form-data, max 200MB
+  ▼
+Caddy   request_body { max_size 200MB } scoped to /api/app/knowledge-bases/*/sources/file
+  │ session cookie, X-Request-ID, BFF-auth headers
+  ▼
+portal-api  POST /api/app/knowledge-bases/{kb_slug}/sources/file
+  │  1. _get_kb_or_404(kb_slug, perms.org_id, db)        — RLS guard
+  │  2. require_capability("kb_file_upload")             — RBAC
+  │  3. for each multipart "file":
+  │     a. extension whitelist + filetype magic-byte check
+  │     b. if archive (.zip/.tar):
+  │           streaming-extract via klai_archive_safe (sunzip-style)
+  │           each entry → recurse step 3.a (no nesting)
+  │     c. assert_can_upload_bytes(kb, total_uncompressed) — FOR UPDATE
+  │     d. content-addressed S3 write to garage://klai-documents/<sha256>
+  │     e. INSERT INTO kb_uploads (artifact_id, s3_key, bytes, mime, status='pending')
+  │     f. emit knowledge.uploaded event per artifact
+  │     g. POST http://knowledge-ingest:8000/ingest/v1/file
+  │        body: { artifact_id, org_id, kb_slug, s3_key, mime, bytes, filename }
+  │        headers: X-Internal-Secret + X-Caller-Service: portal-api + trace
+  │  4. return 202 { uploads: [...] }
+  ▼
+knowledge-ingest  POST /ingest/v1/file        (Procrastinate enqueue → 202)
+  │
+  └── background job: process_file_upload(artifact_id)
+        │
+        ├── fetch from Garage (streaming GET via s3_key)
+        ├── route by mime:
+        │   ├── text-path  (.md .txt simple .csv non-schema .json non-schema .xml):
+        │   │     normalize-encoding → markdown_chunker
+        │   ├── docling-path (.pdf .docx .pptx .xlsx schema-.json schema-.xml):
+        │   │     POST docling-serve /v1/chunk/hybrid/file
+        │   │     → chunks with page_numbers, headings, num_tokens
+        │   └── doc-path (.doc, Phase 4 only):
+        │         POST libreoffice-headless /convert (doc → docx)
+        │         → docling-path
+        ├── embed BGE-M3 dense (TEI) + sparse (bge-m3-sparse)
+        ├── INSERT artifacts + parent_chunks + chunks (existing pg_store)
+        ├── upsert Qdrant vectors (existing index_chunks)
+        ├── Graphiti graph extraction (existing, GRAPHITI_ENABLED)
+        ├── emit kb_file_extracted event with chunks_count + duration_ms
+        └── update kb_uploads.status = 'done' | 'failed' + failure_reason
+  ▼
+portal-api artifact-status polling                      (existing pattern)
+```
+
+Data flow invariants:
+
+- `kb_uploads.s3_key` is the only durable pointer to the binary. The binary is
+  never copied to local disk.
+- The artifact_id chosen by portal-api is reused as the knowledge-ingest
+  artifact id — same UUID across services, matches existing trace pattern.
+- Magic-byte validation happens **once**, in portal-api, before the Garage
+  write. Downstream services trust the validated mime.
+
+---
+
+## 5. Decisions
+
+| ID | Question | Decision | Rationale |
+|----|----------|----------|-----------|
+| D-1 | Per-KB quota | org KB = 5 GB, personal KB = 1 GB. Plan-driven override later via FEATURE_MIN_PROFILE. | Aligns with existing `kb_quota` item-count model; gives 50 × 100 MB headroom per org KB which covers normal seeded course books. Not plan-gated yet to avoid plan-config churn during rollout. |
+| D-2 | `.doc` legacy support | Phase 4 (libreoffice-headless sidecar). Phases 1-3 reject `.doc` with `error_code: "doc_format_not_yet_supported"` and message "Converteer naar .docx — .doc komt later". | `.doc` requires a 400 MB libreoffice image and a long-running sidecar with its own deploy cadence. Phase 1 ships value (PDF, DOCX, XLSX, PPTX) without that overhead. |
+| D-3 | Generic JSON / XML | Index as plaintext (Markdown chunker fallback). Schema detection (json_docling / JATS / USPTO / XBRL) routes to docling. | Strict schema-only would reject every legitimate `.xml` and `.json` Klai customers actually have. Plaintext indexing is the lossy-but-useful default; schema detection upgrades the path when applicable. |
+| D-4 | Async UX | Poll-based artifact status (existing connector pattern). | WebSocket adds infra surface for marginal UX win; poll already works for connector syncs which have similar runtime. |
+| D-5 | Garage bucket policy | `klai-documents` is **private**, presigned-GET only, TTL 1 h. **Different from `kb-images`** which uses website-mode + Caddy reverse-proxy. | Documents may contain sensitive content (legal, HR). URL-guessing on a website-mode bucket leaks content. Presigned-GET requires authenticated portal-api session. |
+| D-6 | New table vs. extend | Extend knowledge-ingest artifacts via existing `extra` jsonb (add `source_kind: "file"`, `s3_key`, `original_filename`). New `kb_uploads` table on portal-api side for s3_key tracking + per-KB byte quota counter. | Existing artifacts table (with `source_connector_id` pattern) is the authoritative chunk system; mirroring that on portal-api would create dual-write. portal-api owns only what it needs to route status / quota. |
+
+---
+
+## 6. Requirements (EARS)
+
+### REQ-1 — Endpoint and accepted formats
+
+**Ubiquitous.** The system shall expose `POST /api/app/knowledge-bases/{kb_slug}/sources/file`
+accepting `multipart/form-data` with one or more `file` parts.
+
+**Event-driven.** WHEN the request body contains a file part whose extension is in
+the whitelist `{.csv, .doc, .docx, .json, .md, .pdf, .pptx, .tar, .txt, .xlsx, .xml, .zip}`
+AND whose magic-byte content type matches the extension, THE SYSTEM SHALL accept
+the part for further processing.
+
+**Event-driven.** WHEN a file part has an extension NOT in the whitelist,
+THE SYSTEM SHALL return HTTP 400 with `error_code: "unsupported_extension"`
+and reject the entire request without writing to Garage.
+
+**Event-driven.** WHEN a file part has a whitelisted extension but the
+magic-byte content type disagrees, THE SYSTEM SHALL return HTTP 400 with
+`error_code: "mime_mismatch"` and reject the entire request without writing to
+Garage.
+
+**Unwanted behaviour.** IF a text-format file (`.md .txt .csv .json .xml`)
+fails UTF-8 decode AND charset-detect cannot recover a confidence ≥ 0.9
+encoding, THEN THE SYSTEM SHALL reject with `error_code: "invalid_text_encoding"`.
+
+**Acceptance criteria:**
+- AC-1.1: Whitelisted-extension + matching-magic-byte upload returns HTTP 202
+  with `{ uploads: [{ artifact_id, status: "pending" }] }`.
+- AC-1.2: `.exe` file returns 400 `unsupported_extension`.
+- AC-1.3: `.pdf` containing PNG magic bytes returns 400 `mime_mismatch`.
+- AC-1.4: Office Open XML formats (`.docx .xlsx .pptx`) are validated as a
+  zip containing `[Content_Types].xml` before accepting.
+- AC-1.5: Plain-text formats skip magic-byte content check; instead the
+  first 1 MB must decode as UTF-8 OR via charset-detect ≥ 0.9 confidence.
+- AC-1.6: Garage object count does NOT increase for any rejected upload
+  (verified via Garage stats before/after).
+
+---
+
+### REQ-2 — Size and streaming
+
+**Ubiquitous.** The system shall enforce a 200 MB per-file limit at the
+edge (Caddy) and stream multipart parts to disk-backed temp files at
+portal-api without loading them fully into memory.
+
+**Event-driven.** WHEN a request body exceeds 200 MB, THE SYSTEM SHALL
+respond with HTTP 413 from Caddy before the request reaches portal-api.
+
+**State-driven.** WHILE portal-api is processing a 200 MB upload, the
+container's RSS shall stay below 100 MB delta over baseline (verified via
+container metrics).
+
+**Acceptance criteria:**
+- AC-2.1: A 200 MB file uploads successfully end-to-end (Caddy →
+  portal-api → Garage).
+- AC-2.2: A 201 MB file is rejected at Caddy with HTTP 413.
+- AC-2.3: portal-api Starlette `request.form()` is called with
+  `max_part_size=200*1024*1024`, `max_files=10`, `max_fields=10`.
+- AC-2.4: Garage write uses `boto3.upload_fileobj` (auto-multipart at 8 MB
+  parts) — verified by code inspection of `klai_document_storage.client`.
+- AC-2.5: A 100 MB PDF completes Caddy → portal-api → Garage in < 60 s on
+  the production hardware profile.
+
+---
+
+### REQ-3 — Archive safety
+
+**Ubiquitous.** Archives (`.zip`, `.tar`) shall be unpacked with streaming
+guards that abort early on adversarial content.
+
+**Event-driven.** WHEN an archive entry's compression ratio exceeds 10:1,
+THE SYSTEM SHALL abort extraction and return `error_code:
+"archive_compression_ratio"` within 10 MB of decompression progress.
+
+**Event-driven.** WHEN cumulative uncompressed size exceeds 500 MB OR
+per-entry uncompressed size exceeds 50 MB, THE SYSTEM SHALL abort with
+`error_code: "archive_total_size"` or `error_code:
+"archive_entry_too_large"`.
+
+**Event-driven.** WHEN an archive contains more than 50 entries, THE SYSTEM
+SHALL abort with `error_code: "archive_too_many_entries"` after counting the
+51st entry header.
+
+**Event-driven.** WHEN an entry name contains `..`, an absolute path, or a
+backslash separator, THE SYSTEM SHALL abort with `error_code:
+"archive_path_traversal"`.
+
+**Event-driven.** WHEN an entry's extension is `.zip` or `.tar` (nested
+archive), THE SYSTEM SHALL abort with `error_code: "archive_nested"`.
+
+**Event-driven.** WHEN a tar entry has type other than REGTYPE / AREGTYPE,
+THE SYSTEM SHALL abort with `error_code: "archive_unsafe_entry"`.
+
+**Event-driven.** WHEN an entry's extension is whitelisted but its
+magic-byte content fails REQ-1 validation, THE SYSTEM SHALL skip the entry
+(not the entire archive) and record `entry_skipped` reason in the artifact
+log.
+
+**Acceptance criteria:**
+- AC-3.1: A canonical 42 KB → 4 GB zip-bomb fixture aborts within 10 MB
+  decompression.
+- AC-3.2: A `.zip` with 51 valid `.md` entries returns 400
+  `archive_too_many_entries`.
+- AC-3.3: A `.tar` containing `../../etc/passwd` returns 400
+  `archive_path_traversal`.
+- AC-3.4: A `.zip` containing `nested.zip` rejects that entry with
+  `archive_nested`; the rest of the archive proceeds.
+- AC-3.5: A `.tar` symlink entry returns 400 `archive_unsafe_entry`.
+- AC-3.6: A `.zip` with mixed `[1.md, 2.pdf, 3.exe]` produces 2 artifacts
+  (md, pdf) and 1 entry log line `entry_skipped: unsupported_extension` for
+  the `.exe`.
+
+---
+
+### REQ-4 — Pipeline routing
+
+**Ubiquitous.** The knowledge-ingest pipeline shall route each artifact to one
+of three paths based on validated mime + content sniff: text-path,
+docling-path, or doc-path.
+
+**Decision table:**
+
+| Detected content | Path | docling format param |
+|------------------|------|----------------------|
+| `text/markdown` (.md) | text | — |
+| `text/plain` (.txt) | text | — |
+| `text/csv` (.csv) | text | — |
+| `application/json` without DoclingDocument schema | text | — |
+| `application/xml` without JATS / USPTO / XBRL root | text | — |
+| `application/pdf` | docling | `pdf` |
+| `application/vnd.openxmlformats-...wordprocessingml.document` | docling | `docx` |
+| `application/vnd.openxmlformats-...spreadsheetml.sheet` | docling | `xlsx` |
+| `application/vnd.openxmlformats-...presentationml.presentation` | docling | `pptx` |
+| `application/json` matching DoclingDocument schema | docling | `json_docling` |
+| `application/xml` with `<article>` JATS root | docling | `xml_jats` |
+| `application/xml` with `<us-patent-application>` root | docling | `xml_uspto` |
+| `application/xml` with XBRL namespace | docling | `xml_xbrl` |
+| `application/msword` (.doc) — Phase ≤ 3 | reject | `error_code: doc_format_not_yet_supported` |
+| `application/msword` (.doc) — Phase 4 | doc → docling | `docx` after libreoffice |
+
+**Event-driven.** WHEN a file routes to docling-path, THE SYSTEM SHALL POST
+the binary to `http://docling-serve:5001/v1/chunk/hybrid/file` with the
+correct format parameter and `target_type=md` AND parse the chunked response
+into `(text, headings, page_numbers, num_tokens)` per chunk.
+
+**Event-driven.** WHEN docling-serve returns non-2xx OR times out (≥ 600 s),
+THE SYSTEM SHALL mark the artifact `failed` with `failure_reason:
+"docling_timeout"` or `"extraction_failed"` and NOT retry automatically.
+
+**Acceptance criteria:**
+- AC-4.1: `.md` upload produces chunks via the existing Markdown chunker
+  (verified by absence of HTTP call to docling-serve in test).
+- AC-4.2: `.pdf` upload produces chunks via docling `/v1/chunk/hybrid/file`
+  with `format=pdf`.
+- AC-4.3: A 5-page sample PDF produces ≥ 5 chunks each with non-null
+  `page_numbers` payload field.
+- AC-4.4: An `.xml` file whose root local-name is `article` (JATS) routes
+  with `format=xml_jats`.
+- AC-4.5 (Phase ≤ 3): `.doc` returns 400 `doc_format_not_yet_supported`.
+- AC-4.6 (Phase 4): `.doc` is converted via libreoffice-headless and
+  produces docling chunks.
+
+---
+
+### REQ-5 — Quota and RBAC
+
+**Ubiquitous.** Uploads shall be gated by (a) the `kb_file_upload` product
+in `UserPermissions.effective_products`, (b) per-KB byte quota, (c) per-org
+daily upload-count rate limit.
+
+**Event-driven.** WHEN the caller's `effective_products` does NOT include
+`kb_file_upload`, THE SYSTEM SHALL return 403 with `error_code:
+"not_entitled"`.
+
+**Event-driven.** WHEN the upload would push the KB's total uploaded
+bytes over its quota (5 GB org, 1 GB personal), THE SYSTEM SHALL return 413
+with `error_code: "kb_quota_bytes_exceeded"`.
+
+**Event-driven.** WHEN the org has already accepted ≥ 100 file uploads in
+the rolling 24-hour window, THE SYSTEM SHALL return 429 with
+`error_code: "rate_limit_exceeded"` and a `Retry-After` header.
+
+**Ubiquitous.** Quota enforcement shall use `SELECT ... FOR UPDATE` on the
+`kb_uploads_quota` row in the same transaction as the artifact insert
+(per `portal-backend.md` SELECT FOR UPDATE pattern).
+
+**Acceptance criteria:**
+- AC-5.1: User without `kb_file_upload` → 403 `not_entitled` (verified
+  via integration test with capability-stripped fixture).
+- AC-5.2: A KB at 4.5 GB used + 600 MB upload → 413
+  `kb_quota_bytes_exceeded` (since 4.5 + 0.6 = 5.1 > 5).
+- AC-5.3: 101st upload in 24 h returns 429.
+- AC-5.4: 10 parallel 600 MB uploads into a fresh 5 GB KB → exactly 8
+  accepted (5000 / 600 ≈ 8.33), 2 rejected with `kb_quota_bytes_exceeded`,
+  no over-quota state.
+- AC-5.5: `kb_file_upload` is added to `FEATURE_MIN_PROFILE` with
+  `ProfileRole.PERSONAL` (any authenticated member of an org with the
+  product enabled).
+
+---
+
+### REQ-6 — Status and structured errors
+
+**Ubiquitous.** Every accepted upload shall produce one or more artifacts;
+each artifact shall be polled to completion via the existing artifact
+status endpoint.
+
+**Failure-reason enum (machine-readable):**
+```
+unsupported_extension
+mime_mismatch
+invalid_text_encoding
+oox_validation_failed
+file_too_large
+archive_compression_ratio
+archive_total_size
+archive_entry_too_large
+archive_too_many_entries
+archive_path_traversal
+archive_nested
+archive_unsafe_entry
+kb_quota_bytes_exceeded
+rate_limit_exceeded
+not_entitled
+storage_unavailable
+extraction_failed
+docling_timeout
+internal_error
+doc_format_not_yet_supported
+```
+
+**Event-driven.** WHEN the endpoint accepts a request, THE SYSTEM SHALL
+return HTTP 202 with body `{ uploads: [{ artifact_id: UUID, source_ref:
+str, source_type: "file", filename: str, status: "pending" }, ...] }`.
+
+**Event-driven.** WHEN any artifact reaches a terminal state, the artifact
+row shall record exactly one of `status ∈ {done, failed}`. If `failed`,
+`failure_reason` shall be a non-null value from the enum above.
+
+**Acceptance criteria:**
+- AC-6.1: Single-file POST returns one artifact in the response.
+- AC-6.2: Archive POST returns N artifacts (one per accepted entry) plus
+  a `skipped: [{ filename, reason }]` array for rejected entries.
+- AC-6.3: After all artifacts reach `done`, retrieval-api `/retrieve`
+  with the same kb_slug returns chunks owned by those artifacts.
+- AC-6.4: The status enum and failure_reason enum are exported from a
+  single shared schema module imported by both portal-api and
+  knowledge-ingest (no string drift).
+
+---
+
+### REQ-7 — UI fix on FileUploadForm
+
+**Ubiquitous.** `FileUploadForm.tsx` shall POST to
+`/api/app/knowledge-bases/${kbSlug}/sources/file` (NOT to `${DOCS_BASE}`),
+validate file size client-side, surface per-file progress, and map every
+failure_reason to a localized NL message.
+
+**Acceptance criteria:**
+- AC-7.1: `FileUploadForm.tsx` no longer imports `DOCS_BASE`. `tree-utils.ts`
+  comment clarifies that `DOCS_BASE` is for the wiki/docs editor only.
+- AC-7.2: Client-side size guard rejects per-file > 200 MB before any
+  network request, with a NL error string.
+- AC-7.3: Each upload shows a progress bar 0–100 % via XHR `upload.onprogress`.
+- AC-7.4: Each `error_code` from REQ-6 maps to a Paraglide message:
+  - `unsupported_extension` → "Bestandstype niet ondersteund. Toegestane
+    formaten: PDF, Word, Excel, PowerPoint, CSV, JSON, XML, ZIP, TAR, MD,
+    TXT."
+  - `file_too_large` → "Bestand te groot (max 200 MB). Splits het bestand of
+    gebruik een connector."
+  - `mime_mismatch` → "Bestand lijkt geen geldige {extension} te zijn.
+    Controleer of het bestand niet beschadigd is."
+  - `kb_quota_bytes_exceeded` → "Geen ruimte meer in deze kennisbank.
+    Verwijder oude bronnen of upgrade je plan."
+  - `rate_limit_exceeded` → "Te veel uploads vandaag. Probeer het over een
+    uur opnieuw."
+  - `not_entitled` → "Bestanden uploaden is niet beschikbaar in jouw plan."
+  - `archive_*` → "Archief bevat een onveilig of te groot bestand. Bekijk
+    de details en probeer opnieuw."
+  - `extraction_failed`, `docling_timeout` → "Kon dit bestand niet
+    verwerken. Probeer opnieuw of converteer naar PDF."
+  - `doc_format_not_yet_supported` → "Converteer naar .docx — `.doc`
+    wordt binnenkort ondersteund."
+  - default → "Upload mislukt. Probeer opnieuw of neem contact op."
+- AC-7.5: After all uploads succeed, the form shows a 1.5 s success banner
+  and navigates to `/app/knowledge/{kb}/overview`.
+- AC-7.6: The `accept` attribute is exactly
+  `.csv,.doc,.docx,.json,.md,.pdf,.pptx,.tar,.txt,.xlsx,.xml,.zip`.
+
+---
+
+### REQ-8 — Observability
+
+**Ubiquitous.** Every upload shall produce structured log events queryable in
+VictoriaLogs and a Grafana panel.
+
+**Events:**
+
+- `kb_upload_received` (portal-api):
+  ```
+  service=portal-api event=kb_upload_received
+  org_id, kb_slug, filename, mime, bytes,
+  archive_entries (0 if not archive),
+  decision in {accepted, rejected},
+  failure_reason if rejected,
+  request_id
+  ```
+
+- `kb_file_extracted` (knowledge-ingest):
+  ```
+  service=knowledge-ingest event=kb_file_extracted
+  artifact_id, org_id, kb_slug, mime, bytes,
+  chunks_count, docling_used in {true, false},
+  duration_ms, status in {done, failed},
+  failure_reason if failed,
+  request_id
+  ```
+
+- `knowledge.uploaded` (product_events):
+  Existing event extended with `properties.file_type` and `properties.bytes`.
+
+**Acceptance criteria:**
+- AC-8.1: Every POST to `/sources/file` produces exactly one
+  `kb_upload_received` log line (verified by VictoriaLogs query in
+  integration test).
+- AC-8.2: Every successful artifact produces exactly one
+  `kb_file_extracted` log line with `status: "done"`.
+- AC-8.3: VictoriaLogs query `service:portal-api AND event:kb_upload_received
+  AND decision:rejected | stats count() by failure_reason` returns the
+  rejection histogram.
+- AC-8.4: Grafana panel `KB Uploads — Hourly` exists in the Klai dashboard,
+  showing accepted vs rejected counts and bytes by failure_reason.
+- AC-8.5: Cross-service trace correlation: a single `request_id` query
+  shows Caddy → portal-api → knowledge-ingest → docling-serve chain.
+
+---
+
+### REQ-9 — Security gates
+
+**Ubiquitous.** The endpoint shall accept NO URL field; only multipart
+file. docling-serve and libreoffice-headless shall remain on `klai-net`
+only, never on the docker-socket-proxy network. Magic-byte validation
+shall happen server-side **before** any object-storage write.
+
+**Event-driven.** WHEN the BFF session cookie is missing or invalid,
+THE SYSTEM SHALL return 401 (no information leak about KB existence).
+
+**Event-driven.** WHEN the kb_slug exists but in a different org than
+`perms.org_id`, THE SYSTEM SHALL return 404 (NOT 403 — info-leak
+prevention).
+
+**Ubiquitous.** The `klai-documents` Garage bucket shall have no public-read
+ACL. Read access is via presigned-GET URL only, generated server-side, with
+TTL ≤ 1 hour.
+
+**Ubiquitous.** The `/ingest/v1/file` endpoint on knowledge-ingest shall
+enforce both `X-Internal-Secret` and identity assertion via
+`klai-identity-assert` middleware (per `SPEC-SEC-IDENTITY-ASSERT-002`).
+
+**Acceptance criteria:**
+- AC-9.1: `docker network inspect socket-proxy` does NOT contain
+  `docling-serve`, `libreoffice-headless` (Phase 4), `knowledge-ingest`,
+  `portal-api`, `garage` (per `SPEC-SEC-SSRF-001` REQ-5 must-not-list).
+- AC-9.2: POST without session cookie → 401.
+- AC-9.3: POST with valid session for a kb_slug in another org → 404 (not
+  403).
+- AC-9.4: A `.exe` renamed to `.pdf` returns 400 `mime_mismatch` AND no
+  Garage object is created (verified via Garage stats delta).
+- AC-9.5: `mc anonymous get-status garage/klai-documents` reports `none`.
+- AC-9.6: Concurrent quota-race test: 10 × 600 MB uploads into a fresh 5 GB
+  KB → exactly 8 accepted, 2 rejected, no double-spend.
+- AC-9.7: POST to `/ingest/v1/file` without `X-Internal-Secret` → 401.
+- AC-9.8: portal-api `MIME magic-byte check` runs before
+  `klai_document_storage.put_object` — verified by ordered call assertion
+  in unit test.
+
+---
+
+## 7. Phasing
+
+Each phase is independently shippable. Phase 1 already replaces the broken
+500 with a working text-only path; binary support, archives and `.doc` add
+in subsequent phases.
+
+### Phase 1 — text-only path + plumbing
+
+Deliverables:
+- Caddy `request_body { max_size 200MB }` on the upload handle.
+- New env var `GARAGE_DOCUMENTS_BUCKET=klai-documents` in SOPS, validated
+  via pydantic.
+- New `klai-libs/document-storage` library (Garage S3 wrapper, presigned-GET).
+- New Garage bucket `klai-documents` (private; provisioned manually on
+  core-01 via `garage bucket create` + key grant).
+- New portal-api route `POST /api/app/knowledge-bases/{kb_slug}/sources/file`
+  accepting only `.md`, `.txt`, `.csv`. Other extensions return
+  `error_code: "phase_pending"`.
+- New `kb_uploads` + `kb_uploads_quota` tables in portal-api (alembic).
+- New knowledge-ingest route `POST /ingest/v1/file` for text mimes only.
+- Frontend `FileUploadForm` switched to the new endpoint; size guard,
+  progress bar, i18n failure-reason map.
+- Tests: unit (storage, magic-byte, quota race), integration (.md happy
+  path), Playwright (.md upload e2e).
+
+Phase 1 closes the immediate 500-bug for `.md`, `.txt`, `.csv`. Other
+formats fail-fast with a clear message instead of a silent Gitea write.
+
+### Phase 2 — docling structuur-pad
+
+Deliverables:
+- New `knowledge-ingest/adapters/docling.py` (httpx client to docling-serve
+  with timeout + structured chunk parsing).
+- knowledge-ingest mime whitelist extends to PDF, DOCX, XLSX, PPTX,
+  json_docling, xml_jats, xml_uspto, xml_xbrl.
+- portal-api whitelist extends to `.pdf .docx .pptx .xlsx .json .xml`.
+- JSON / XML schema detection (heuristic root-element).
+- Tests: unit (docling adapter mock), integration (real docling-serve in CI
+  compose with sample PDF), Playwright (real `.pdf` end-to-end).
+
+### Phase 3 — archives
+
+Deliverables:
+- New `knowledge-ingest/adapters/archive.py` (sunzip-style streaming
+  extractor with all REQ-3 guards).
+- portal-api whitelist extends to `.zip .tar`.
+- Per-entry quota counts uncompressed bytes.
+- Tests: zip-bomb fixture, path-traversal fixture, nested-archive,
+  symlink-in-tar, mixed-content (md + pdf + exe → 2 + 1 skipped),
+  Playwright real `.zip` upload.
+
+### Phase 4 — `.doc` legacy support
+
+Deliverables:
+- New `libreoffice-headless` sidecar container on `klai-net` (NOT on
+  socket-proxy). Custom thin HTTP wrapper around `soffice --headless
+  --convert-to docx`.
+- New `knowledge-ingest/adapters/libreoffice.py` (HTTP client → docx →
+  docling).
+- portal-api whitelist extends to `.doc`.
+- Tests: integration (.doc → .docx → docling chunks), smoke
+  (libreoffice-headless restart-resilience).
+
+---
+
+## 8. Risks & mitigations
+
+| ID | Risk | Severity | Mitigation |
+|----|------|----------|------------|
+| R-1 | Zip-bomb (42 KB → 4 GB OOM in knowledge-ingest) | HIGH | Streaming decompress with byte counter; abort within 10 MB on ratio > 10:1 OR per-entry > 50 MB OR total > 500 MB. Canary fixture in unit tests. |
+| R-2 | docling-serve timeout / hang on large OCR PDF | MED | httpx timeout 600 s; on timeout artifact.failed + failure_reason=docling_timeout; Grafana alert on docling p95 > 300 s. |
+| R-3 | Garage S3 unavailable during upload | MED | boto3 retries (3 × exponential backoff). On persistent failure 503 + `storage_unavailable`. Grafana alert on 503-rate. No local-disk fallback (drift risk). |
+| R-4 | RLS bypass — IDOR on kb_slug | CRIT | Mandatory `_get_kb_or_404(kb_slug, perms.org_id, db)` before any artifact insert. Integration test for cross-org POST → 404. |
+| R-5 | Quota bypass via concurrent uploads | HIGH | `SELECT … FOR UPDATE` on `kb_uploads_quota` row in same tx as artifact insert. Race-test in AC-9.6. |
+| R-6 | Mime-spoof (.exe renamed .pdf served via presigned URL → browser exec) | HIGH | Magic-byte validation BEFORE Garage write. Garage Content-Type set from validated mime. Presigned-GET serves Content-Disposition: attachment for non-PDF. |
+| R-7 | Fail-open auth on /ingest/v1/file | HIGH | Reuse klai-identity-assert + X-Internal-Secret. Failing tests for missing headers (per fail-open-auth + empty-secret-fail-open pitfalls). |
+| R-8 | Caddy 200 MB limit scoped wrong path | MED | Place `request_body` inside path-scoped `handle /api/app/knowledge-bases/*/sources/file`. Test: 200 MB POST to `/api/me` → 413 (still default cap). |
+| R-9 | alembic head split | HIGH | `alembic heads` CI guard already enforced. Rebase before merge if main moved (per alembic-multi-pr-head-split pitfall). |
+| R-10 | env-var parity gap (GARAGE_DOCUMENTS_BUCKET validator added before SOPS var) | HIGH | SOPS update FIRST; verify decrypt; THEN merge code (per validator-env-parity pitfall). PR body checklist. |
+| R-11 | Bind-mount config sync forgotten on libreoffice (Phase 4) | MED | If a libreoffice config file is bind-mounted, follow `infra/deploy.md` § "Bind-mount config sync — required pattern": paths trigger + sparse-checkout + sync_and_recreate. Image-only config = N/A. |
+| R-12 | CSV / TXT non-UTF-8 encoding rejected though valid (cp1252) | MED | Best-effort UTF-8 → fallback charset-detect ≥ 0.9 confidence → re-encode to UTF-8 before chunking. Document detected encoding in artifact metadata. |
+| R-13 | docling-serve resource exhaustion on multiple large PDFs concurrently | MED | Procrastinate worker concurrency cap at 2 docling-jobs/worker. Monitor docling-serve memory in Grafana. |
+| R-14 | Frontend uploads many small files at once → 100/24h rate limit hit fast | LOW | Client batches ≤ 10 files per submit; per-org rate is per-artifact, archives count entries individually. Phase 5 may relax to per-byte quota. |
+| R-15 | `kb-documents` bucket reachable from internet via DNS-leak | MED | Garage `klai-documents` bucket has no website-mode binding; only S3 API on internal port 3900 (not exposed via Caddy). Verified by AC-9.5. |
+
+---
+
+## 9. Code impact
+
+| File | Phase | Shape |
+|------|-------|-------|
+| `deploy/caddy/Caddyfile` | 1 | +`request_body { max_size 200MB }` inside path-scoped `handle /api/app/knowledge-bases/*/sources/file`, before `reverse_proxy portal-api:8010`. |
+| `deploy/docker-compose.yml` | 1 | New env `GARAGE_DOCUMENTS_BUCKET: ${GARAGE_DOCUMENTS_BUCKET}` on `portal-api` and `knowledge-ingest`. |
+| `deploy/docker-compose.yml` | 4 | New service `libreoffice-headless` on `klai-net` only; klasse-A labels via compose. |
+| `klai-libs/document-storage/{__init__.py, pyproject.toml, klai_document_storage/{client.py, content_addr.py, presign.py, errors.py}}` | 1 | NEW lib (~300 LOC). Public API `DocumentStore.put(stream, mime, bytes) → s3_key`, `presigned_get(s3_key, ttl) → url`. Mirrors klai-libs/image-storage. |
+| `klai-portal/backend/app/api/app_knowledge_sources.py` | 1 | +`POST /knowledge-bases/{kb_slug}/sources/file` (~120 LOC). Calls `services/file_upload.py`. |
+| `klai-portal/backend/app/services/file_upload.py` | 1-3 | NEW (~200 LOC growth across phases): orchestration, multipart streaming, magic-byte, archive (Phase 3), Garage write, ingest enqueue. |
+| `klai-portal/backend/app/services/kb_uploads_quota.py` | 1 | NEW (~80 LOC): `assert_can_upload_bytes(kb_id, bytes_to_add)` with FOR UPDATE. |
+| `klai-portal/backend/app/core/features.py` | 1 | +`"kb_file_upload": ProfileRole.PERSONAL` in `FEATURE_MIN_PROFILE`. |
+| `klai-portal/backend/app/core/config.py` | 1 | +`garage_documents_bucket: str` setting with `_require_garage_documents_bucket` validator. |
+| `klai-portal/backend/alembic/versions/<rev>_kb_uploads.py` | 1 | NEW table `kb_uploads(artifact_id UUID PK, kb_id, org_id, s3_key, filename, mime, bytes, status, failure_reason, created_at, updated_at)` + `kb_uploads_quota(kb_id PK, bytes_used)` + RLS policies (cat-D) + indexes. |
+| `klai-portal/backend/app/api/internal.py` (or new) | 1 | Webhook receiver for knowledge-ingest status updates: `POST /internal/kb-uploads/status`. |
+| `klai-knowledge-ingest/knowledge_ingest/routes/ingest.py` | 1, 2, 3, 4 | +`POST /ingest/v1/file` (~80 LOC initial; grows per phase). |
+| `klai-knowledge-ingest/knowledge_ingest/adapters/docling.py` | 2 | NEW (~150 LOC): httpx client to docling-serve, schema detection, chunk normalization. |
+| `klai-knowledge-ingest/knowledge_ingest/adapters/archive.py` | 3 | NEW (~200 LOC): streaming sunzip with all REQ-3 guards. |
+| `klai-knowledge-ingest/knowledge_ingest/adapters/libreoffice.py` | 4 | NEW (~80 LOC): HTTP client → docx → docling. |
+| `klai-knowledge-ingest/knowledge_ingest/config.py` | 1, 4 | +`docling_url: str`, `libreoffice_url: str` (Phase 4). |
+| `klai-knowledge-ingest/alembic/versions/<rev>_artifact_file_source.py` | 1 | If existing artifacts table needs new jsonb fields (`source_kind`, `s3_key`, `original_filename`), add via `extra` jsonb (no schema change). May be a no-op if jsonb is already free-form. |
+| `klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source._components/FileUploadForm.tsx` | 1 | Endpoint flip; drop DOCS_BASE; client-side size guard; XHR progress; i18n error map. |
+| `klai-portal/frontend/src/lib/kb-editor/tree-utils.ts` | 1 | Comment clarifying DOCS_BASE is wiki-only. |
+| `klai-portal/frontend/src/paraglide/messages/{nl,en}/*` | 1 | New i18n strings per AC-7.4. |
+| `.claude/rules/klai/projects/portal-backend.md` | 1 | New entry: "KB file upload — magic-byte before storage, Garage presigned-GET, FOR UPDATE quota". |
+| `docs/runbooks/kb-file-upload.md` | 1 | NEW runbook: rollout order, debug failed uploads via VictoriaLogs, quota override, Garage bucket recreate. |
+| `docs/architecture/klai-knowledge-architecture.md` | 1 | Update §4 ingestion architecture to reference the file path. |
+| `klai-infra/core-01/.env.sops` | 1 | +`GARAGE_DOCUMENTS_BUCKET=klai-documents`. |
+
+---
+
+## 10. Test plan
+
+### Phase 1
+
+**Unit (portal-api):**
+- `test_document_storage.py` — Garage `put` round-trip, presigned-GET TTL,
+  content-address sha256.
+- `test_magic_byte_validation.py` — extension/mime mismatch matrix (12
+  legit + 12 spoofed cases).
+- `test_kb_uploads_quota.py` — FOR UPDATE serializes, daily rate limit,
+  per-KB byte cap.
+- `test_file_upload_orchestrator.py` — text path: `.md` → ingest call;
+  `.pdf` (Phase 1) → 400 phase_pending.
+
+**Unit (knowledge-ingest):**
+- `test_ingest_v1_file_text.py` — `.md` body → markdown chunker → pg_store
+  + Qdrant index call (mocked).
+
+**Integration:**
+- portal-api → knowledge-ingest happy path with stub Qdrant: upload `.md`,
+  poll status, assert `done`.
+- Cross-org RLS: caller_org=A POST kb_slug from org=B → 404.
+- Quota race: 10 × 600 MB into fresh 5 GB KB → 8/2 split.
+
+**Playwright e2e:**
+- Login as test user → /app/knowledge/test-kb/add-source → drag `sample.md`
+  → click Upload → wait for success banner → assert redirect to overview →
+  assert sample.md row in source list with status "Verwerkt".
+- Drag `oversized.md` (210 MB stub via repeating string) → assert client-side
+  rejection with NL message before any network call.
+
+### Phase 2
+
+**Unit (knowledge-ingest):**
+- `test_docling_adapter.py` — mock httpx; assert correct format param per
+  extension; schema detection fixtures (json_docling, JATS XML).
+
+**Integration:**
+- Real `docling-serve` in CI compose. 5-page sample PDF → ≥ 5 chunks with
+  `page_numbers` populated.
+- Real DOCX → docling → chunks.
+
+**Playwright e2e:**
+- Upload **real chemie-PDF fixture** (small, ~5 MB; full 105 MB only in
+  manual production smoke). Poll until `done`. Assert kennisbank-overview
+  shows ≥ 100 chunks attributed to that artifact via API.
+
+### Phase 3
+
+**Unit (knowledge-ingest):**
+- `test_archive_zip_bomb.py` — canonical 42 KB → 4 GB fixture; assert abort
+  within 10 MB.
+- `test_archive_path_traversal.py` — entries `../../etc/passwd`, absolute
+  paths, backslashes.
+- `test_archive_nested.py` — `nested.zip` inside `outer.zip` rejected.
+- `test_archive_symlink.py` — tar symlink REGTYPE check.
+- `test_archive_mixed.py` — `[1.md, 2.pdf, 3.exe]` → 2 artifacts + 1 skipped.
+
+**Integration:**
+- Upload real `.zip` with 5 mixed valid entries → 5 artifacts each with own
+  chunks.
+
+**Playwright e2e:**
+- Upload `chapters.zip` → 5 sources appear in KB overview within 60 s.
+
+### Phase 4
+
+**Integration:**
+- Real `legacy.doc` → libreoffice → `.docx` → docling chunks → Qdrant
+  searchable.
+
+**Smoke:**
+- `docker restart libreoffice-headless` while upload in flight → conversion
+  retried successfully.
+
+---
+
+## 11. Rollout sequence
+
+Per phase, follow this order to satisfy `validator-env-parity` and
+`bind-mount-without-sync-workflow` pitfalls.
+
+### Phase 1
+
+1. **SOPS** — add `GARAGE_DOCUMENTS_BUCKET=klai-documents` to
+   `klai-infra/core-01/.env.sops`. Push klai-infra; CI sync-env workflow
+   (no `--allow-removal` needed). Verify on core-01: `docker exec
+   klai-core-portal-api-1 printenv GARAGE_DOCUMENTS_BUCKET` returns the
+   value (after step 4).
+2. **Garage bucket** — manual on core-01:
+   ```
+   ssh core-01 "docker exec klai-core-garage-1 /garage bucket create klai-documents"
+   ssh core-01 "docker exec klai-core-garage-1 /garage bucket allow \
+       --read --write --owner --key portal-api klai-documents"
+   ```
+   Verify: `garage bucket info klai-documents` shows portal-api access; `mc
+   anonymous get-status` returns `none`.
+3. **Caddy patch** — push to `deploy/caddy/Caddyfile`. The
+   `deploy-compose.yml` workflow auto-syncs the file via
+   `sync_and_recreate caddy` (Class-A bind-mount). Verify on core-01:
+   `cat /opt/klai/caddy/Caddyfile | grep request_body`.
+4. **portal-api code** — merge PR. CI builds `ghcr.io/getklai/portal-api`,
+   `portal-api.yml` workflow recreates the container.
+   `entrypoint.sh` runs `alembic upgrade head` (per
+   `SPEC-DEPLOY-AUTO-MIGRATE-001`); the new `kb_uploads` migration is
+   applied. Verify: `docker exec klai-core-portal-api-1 alembic current`
+   shows the new head; `docker exec ... printenv GARAGE_DOCUMENTS_BUCKET`
+   matches SOPS.
+5. **knowledge-ingest code** — same flow.
+6. **Frontend** — merge PR. `klai-portal.yml` deploys; verify bundle
+   timestamp on `/srv/portal/assets/*.js` matches deploy time.
+7. **e2e smoke** — upload `sample.md` as a test user via
+   `https://my.getklai.com`. Verify chunks via
+   `victorialogs query 'service:knowledge-ingest event:kb_file_extracted
+   status:done'`. Verify Grafana panel `KB Uploads — Hourly` shows 1
+   accepted upload.
+
+### Phases 2-4
+
+Same pattern, smaller surfaces. Phase 4 adds the libreoffice-headless
+container which goes through `deploy-compose.yml` workflow (Class-A
+bind-mount sync if any config file bind-mount, image-only otherwise).
+
+---
+
+## 12. Open questions (resolve in run phase)
+
+- Q-A: Existing `artifacts.extra` jsonb shape — confirm whether
+  `source_kind` / `s3_key` already used elsewhere; if so, namespace under
+  `file_upload.{...}` to avoid key collision.
+- Q-B: Is there an existing artifact-status webhook from knowledge-ingest
+  to portal-api, or do we add a new `POST /internal/kb-uploads/status`?
+  (Prefer reuse; check during Phase 1 implementation.)
+- Q-C: `kb_uploads_quota` granularity — per kb_id (matches REQ-5 wording)
+  vs. per (org_id, scope). Phase 1 default: per kb_id.
+- Q-D: Should presigned-GET URLs require an authenticated portal-api
+  session (BFF cookie) or are they self-contained TTL URLs? Phase 1
+  default: self-contained TTL ≤ 1 h, generated only inside an
+  authenticated handler.
+
+---
+
+## 13. Acceptance: definition of done for THIS spec
+
+This SPEC is `approved` (status: approved) when:
+
+- All 9 EARS requirements have testable acceptance criteria with
+  measurable outcomes.
+- Architecture decisions D-1..D-6 are recorded with rationale.
+- Risk register R-1..R-15 each maps to a concrete mitigation.
+- Code-impact table covers every file with the change shape.
+- Test plan maps tests to acceptance criteria.
+- Rollout sequence respects validator-env-parity, alembic-stamped-past,
+  bind-mount-sync, and gh-cleanup-cross-worktree pitfalls.
+
+This SPEC is `done` (status: done) when:
+
+- Phase 1, 2, 3 are merged to main, deployed to core-01, and a smoke test
+  upload of the canonical chemie-PDF fixture (105 MB) returns chunks
+  retrievable via `retrieval-api /retrieve` for the test KB.
+- Phase 4 is in scope for closure; if deferred to a follow-up SPEC, it is
+  explicitly recorded here as such.
+
+<moai>DONE</moai>

--- a/deploy/caddy/Caddyfile
+++ b/deploy/caddy/Caddyfile
@@ -341,6 +341,27 @@
         }
     }
 
+    # SPEC-KB-FILE-UPLOAD-001 REQ-2: scoped multipart-body cap on the new
+    # KB file-upload endpoint. Phase 1A only handles text formats so the
+    # cap is 10 MB (matches portal-api's MAX_TEXT_FILE_BYTES); Phase 1B
+    # raises this to 200 MB when streaming + Garage land. Place BEFORE
+    # the general /api/* handler so `handle` first-match wins on the
+    # narrow path. Anything outside this matcher hits the default
+    # request-body limit on /api/* below.
+    @kb-file-upload path_regexp kb_file_upload ^/api/app/knowledge-bases/[^/]+/sources/file$
+    handle @kb-file-upload {
+        request_body {
+            max_size 10MB
+        }
+        reverse_proxy portal-api:8010 {
+            header_up -X-Internal-Secret
+            header_up -X-Caller-Service
+            header_up -X-Org-ID
+            header_up -X-Org-Slug
+            header_up -X-User-ID
+        }
+    }
+
     handle /api/* {
         reverse_proxy portal-api:8010 {
             header_up -X-Internal-Secret

--- a/klai-portal/backend/app/api/app_knowledge_sources.py
+++ b/klai-portal/backend/app/api/app_knowledge_sources.py
@@ -28,7 +28,7 @@ from urllib.parse import urlparse
 
 import httpx
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile, status
 from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -38,7 +38,7 @@ from app.core.database import get_db
 from app.core.permissions import UserPermissions, get_caller
 from app.core.profiles import ProfileRole
 from app.models.knowledge_bases import PortalKnowledgeBase
-from app.services import knowledge_ingest_client
+from app.services import file_upload, knowledge_ingest_client
 from app.services.access import get_user_role_for_kb
 from app.services.kb_quota import assert_can_add_item_to_kb
 from app.services.source_extractors.exceptions import (
@@ -73,6 +73,26 @@ class SourceIngestedResponse(BaseModel):
     artifact_id: str
     source_ref: str
     source_type: str
+
+
+class FileUploadSkippedEntry(BaseModel):
+    """One file that was rejected during a multi-file upload."""
+
+    filename: str
+    reason: str
+    extension: str | None = None
+
+
+class FileSourcesIngestedResponse(BaseModel):
+    """Response for ``POST /sources/file``.
+
+    Multi-file uploads return one entry per accepted file plus a
+    ``skipped`` array per rejected file so the UI can show partial
+    success without forcing the user to re-upload the rest.
+    """
+
+    uploads: list[SourceIngestedResponse]
+    skipped: list[FileUploadSkippedEntry]
 
 
 # --- Helpers ---------------------------------------------------------------
@@ -312,3 +332,170 @@ async def add_text_source(
         duration_ms=int((time.monotonic() - start) * 1000),
     )
     return SourceIngestedResponse(artifact_id=artifact_id, source_ref=source_ref, source_type="text")
+
+
+# --- File route ------------------------------------------------------------
+
+# SPEC-KB-FILE-UPLOAD-001 Phase 1A: text-path only via multipart upload.
+# .md / .txt / .csv route through the existing /ingest/v1/document text
+# pipeline. .pdf / .docx / .pptx / .xlsx / .json / .xml / .zip / .tar / .doc
+# are recognised but return ``phase_pending`` per file in the ``skipped``
+# array; the frontend maps that to a localised "binnenkort beschikbaar"
+# message instead of the previous 500-on-Gitea-wiki-upload bug.
+
+# Hard cap on multipart parts per request. Keeps Starlette form parsing
+# bounded and matches REQ-2 (max 10 files per submit).
+_MAX_FILES_PER_REQUEST = 10
+
+
+@router.post(
+    "/knowledge-bases/{kb_slug}/sources/file",
+    response_model=FileSourcesIngestedResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def add_file_source(
+    kb_slug: str,
+    files: list[UploadFile] = File(...),
+    perms: UserPermissions = Depends(get_caller),
+    db: AsyncSession = Depends(get_db),
+) -> FileSourcesIngestedResponse:
+    """Accept a multipart file upload and ingest it into the KB.
+
+    SPEC-KB-FILE-UPLOAD-001 Phase 1A. The endpoint validates each file's
+    extension, decodes text-path bytes to UTF-8, and forwards the
+    normalised ``(title, content)`` to the same
+    ``/ingest/v1/document`` endpoint that ``/sources/text`` uses. Binary
+    formats are recorded as ``skipped`` with reason ``phase_pending``
+    so the UI can surface the limitation without faking success.
+
+    Multi-file requests partially succeed: accepted files are ingested,
+    rejected files appear in ``skipped``. The endpoint returns 400 only
+    when no file is acceptable.
+    """
+    if not files:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"error_code": "no_files"},
+        )
+    if len(files) > _MAX_FILES_PER_REQUEST:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "error_code": "too_many_files",
+                "max": _MAX_FILES_PER_REQUEST,
+                "received": len(files),
+            },
+        )
+
+    start = time.monotonic()
+    kb = await _get_writable_kb_or_raise(kb_slug, perms, db)
+    org = await _load_org_or_500(db, perms.org_id)
+
+    accepted: list[SourceIngestedResponse] = []
+    skipped: list[FileUploadSkippedEntry] = []
+
+    for upload in files:
+        filename = (upload.filename or "").strip() or "untitled"
+
+        try:
+            ext, phase = file_upload.classify_extension(filename)
+        except HTTPException as exc:
+            detail: Any = exc.detail
+            reason = detail.get("error_code") if isinstance(detail, dict) else "unsupported_extension"
+            skipped.append(FileUploadSkippedEntry(filename=filename, reason=reason or "unsupported_extension"))
+            logger.info(
+                "kb_upload_received",
+                org_id=org.zitadel_org_id,
+                kb_slug=kb_slug,
+                filename=filename,
+                decision="rejected",
+                failure_reason=reason,
+            )
+            continue
+
+        if phase == "phase_pending":
+            skipped.append(FileUploadSkippedEntry(filename=filename, reason="phase_pending", extension=ext))
+            logger.info(
+                "kb_upload_received",
+                org_id=org.zitadel_org_id,
+                kb_slug=kb_slug,
+                filename=filename,
+                extension=ext,
+                decision="rejected",
+                failure_reason="phase_pending",
+            )
+            continue
+
+        # Read up to MAX+1 so the size guard catches the boundary correctly.
+        body = await upload.read(file_upload.MAX_TEXT_FILE_BYTES + 1)
+        try:
+            validated = file_upload.validate_text_upload(filename, body)
+        except HTTPException as exc:
+            detail = exc.detail
+            reason = detail.get("error_code") if isinstance(detail, dict) else "invalid"
+            skipped.append(FileUploadSkippedEntry(filename=filename, reason=reason or "invalid", extension=ext))
+            logger.info(
+                "kb_upload_received",
+                org_id=org.zitadel_org_id,
+                kb_slug=kb_slug,
+                filename=filename,
+                extension=ext,
+                decision="rejected",
+                failure_reason=reason,
+            )
+            continue
+
+        artifact_id = await _forward_ingest(
+            zitadel_org_id=org.zitadel_org_id,
+            kb=kb,
+            title=validated.title,
+            content=validated.content,
+            source_type="file",
+            content_type="plain_text",
+            source_ref=validated.source_ref,
+            extra={
+                "original_filename": filename,
+                "extension": ext,
+                "phase": "1a",
+                "bytes": validated.bytes_count,
+            },
+        )
+        accepted.append(
+            SourceIngestedResponse(
+                artifact_id=artifact_id,
+                source_ref=validated.source_ref,
+                source_type="file",
+            )
+        )
+        logger.info(
+            "kb_upload_received",
+            org_id=org.zitadel_org_id,
+            kb_slug=kb_slug,
+            filename=filename,
+            extension=ext,
+            bytes=validated.bytes_count,
+            decision="accepted",
+        )
+
+    if not accepted:
+        # Every file was rejected. Surface a 400 with the first reason so
+        # the UI shows a coherent error instead of a confusing 202-with-
+        # zero-uploads response.
+        first_reason = skipped[0].reason if skipped else "no_accepted_files"
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "error_code": first_reason,
+                "skipped": [s.model_dump() for s in skipped],
+            },
+        )
+
+    logger.info(
+        "file_sources_ingested",
+        org_id=org.zitadel_org_id,
+        kb_slug=kb_slug,
+        accepted_count=len(accepted),
+        skipped_count=len(skipped),
+        duration_ms=int((time.monotonic() - start) * 1000),
+    )
+    return FileSourcesIngestedResponse(uploads=accepted, skipped=skipped)

--- a/klai-portal/backend/app/services/file_upload.py
+++ b/klai-portal/backend/app/services/file_upload.py
@@ -1,0 +1,223 @@
+"""File-upload validation service.
+
+SPEC-KB-FILE-UPLOAD-001 Phase 1A: text-path only (`.md`, `.txt`, `.csv`).
+
+The full SPEC enumerates 12 accepted extensions (REQ-1). Phase 1A handles
+the three pure-text formats by routing them through the **existing**
+``/ingest/v1/document`` text-ingest pipeline. Binary formats (`.pdf`,
+`.docx`, `.pptx`, `.xlsx`, `.json`, `.xml`) are recognised here but
+returned with ``error_code: "phase_pending"`` so the UI can show a
+clear "binnenkort" message instead of the previous 500. Archive formats
+(`.zip`, `.tar`) follow the same pattern. `.doc` is the Phase-4 LibreOffice
+target.
+
+Garage S3 + dedicated ``/ingest/v1/file`` endpoint land in Phase 1B.
+This module deliberately has **no** S3 client and **no** docling adapter
+yet — those are scoped out per SPEC §7 phasing.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+
+from fastapi import HTTPException, status
+
+# Phase 1A whitelist — extensions that route via the existing text-ingest
+# pipeline today. Adding any extension here must be paired with a
+# normalise / decode path; binary formats belong in Phase 1B+ instead.
+PHASE_1_TEXT_EXTENSIONS: frozenset[str] = frozenset({".md", ".txt", ".csv"})
+
+# Full whitelist per SPEC REQ-1. Anything in this set but not in
+# PHASE_1_TEXT_EXTENSIONS returns ``phase_pending`` so the UI can map
+# to a localised "wordt binnenkort ondersteund" message.
+FULL_WHITELIST: frozenset[str] = frozenset(
+    {
+        ".csv",
+        ".doc",
+        ".docx",
+        ".json",
+        ".md",
+        ".pdf",
+        ".pptx",
+        ".tar",
+        ".txt",
+        ".xlsx",
+        ".xml",
+        ".zip",
+    }
+)
+
+# Per-file size cap for the text path. Phase 1A reads the entire body into
+# memory before forwarding to the existing text-ingest path; the Phase 1B
+# streaming path raises this to the SPEC's 200 MB. 10 MB covers any
+# realistic markdown/csv/txt while keeping portal-api RSS bounded.
+MAX_TEXT_FILE_BYTES: int = 10 * 1024 * 1024
+
+# UTF-8 BOM that Excel and some Windows tools prepend to CSV.
+_UTF8_BOM = b"\xef\xbb\xbf"
+
+
+@dataclass(frozen=True)
+class ValidatedTextFile:
+    """Outcome of normalising a text-path upload.
+
+    ``content`` is decoded UTF-8 with BOM stripped. ``source_ref`` is a
+    content-addressed identifier so re-uploads of the same bytes dedupe
+    via knowledge-ingest's existing path-keyed insert.
+    """
+
+    filename: str
+    extension: str
+    content: str
+    bytes_count: int
+    source_ref: str
+    title: str
+
+
+def get_extension(filename: str) -> str:
+    """Return the lowercase extension including dot.
+
+    ``"Foo.PDF"`` → ``".pdf"``. Empty string when the filename has no
+    extension (rejected by :func:`classify_extension`).
+    """
+    return PurePosixPath(filename).suffix.lower()
+
+
+def classify_extension(filename: str) -> tuple[str, str]:
+    """Return ``(extension, phase)`` or raise HTTP 400.
+
+    ``phase`` is one of:
+
+    - ``"phase1"`` — extension is in the Phase 1A text whitelist; the
+      caller should read + decode the body and forward to
+      ``/ingest/v1/document``.
+    - ``"phase_pending"`` — extension is recognised per the SPEC's full
+      list but the binary/archive path is not yet implemented; the caller
+      should record the file as skipped with reason ``phase_pending``.
+
+    Raises ``HTTPException 400 unsupported_extension`` when the
+    extension is not in the SPEC whitelist at all.
+    """
+    ext = get_extension(filename)
+    if not ext:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "error_code": "unsupported_extension",
+                "filename": filename,
+            },
+        )
+    if ext in PHASE_1_TEXT_EXTENSIONS:
+        return ext, "phase1"
+    if ext in FULL_WHITELIST:
+        return ext, "phase_pending"
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail={
+            "error_code": "unsupported_extension",
+            "filename": filename,
+            "extension": ext,
+        },
+    )
+
+
+def assert_size_within_text_cap(size_bytes: int) -> None:
+    """Reject a Phase-1A text-path upload that exceeds the in-memory cap."""
+    if size_bytes > MAX_TEXT_FILE_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+            detail={
+                "error_code": "file_too_large",
+                "max_bytes": MAX_TEXT_FILE_BYTES,
+                "actual_bytes": size_bytes,
+            },
+        )
+
+
+def normalise_text_content(raw: bytes) -> str:
+    """Decode upload bytes to a UTF-8 ``str``, BOM stripped.
+
+    UTF-8 is attempted first. cp1252 is the fallback so the common
+    Excel-CSV-on-Windows case still imports successfully (R-12 in the
+    SPEC). Anything that decodes neither raises HTTP 400 with
+    ``error_code: "invalid_text_encoding"``.
+    """
+    if raw.startswith(_UTF8_BOM):
+        raw = raw[len(_UTF8_BOM) :]
+
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError:
+        pass
+
+    try:
+        return raw.decode("cp1252")
+    except UnicodeDecodeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "error_code": "invalid_text_encoding",
+                "tried_encodings": ["utf-8", "cp1252"],
+            },
+        ) from exc
+
+
+def build_source_ref(content: str) -> str:
+    """Build a content-addressed source_ref so re-uploads dedupe."""
+    digest = hashlib.sha256(content.encode("utf-8")).hexdigest()
+    return f"file:sha256:{digest}"
+
+
+def derive_title(filename: str, extension: str) -> str:
+    """Strip the extension from the filename to use as the artifact title.
+
+    A bare ``"chemie"`` (no extension) round-trips unchanged. An empty
+    filename falls back to ``"untitled"`` so the artifact always has
+    a non-empty display name.
+    """
+    base = filename.removesuffix(extension) if extension else filename
+    base = base.strip()
+    return base or "untitled"
+
+
+def validate_text_upload(filename: str, raw: bytes) -> ValidatedTextFile:
+    """End-to-end validation for a Phase-1A text-path upload.
+
+    Combines :func:`classify_extension`, :func:`assert_size_within_text_cap`,
+    :func:`normalise_text_content`, :func:`build_source_ref` and
+    :func:`derive_title`. Raises HTTP 400 / 413 on the first failing
+    check (caller decides whether to abort the whole request or skip the
+    individual file).
+    """
+    ext, phase = classify_extension(filename)
+    if phase != "phase1":
+        # Caller is responsible for routing phase_pending — surface it
+        # explicitly rather than silently falling through.
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "error_code": "phase_pending",
+                "filename": filename,
+                "extension": ext,
+            },
+        )
+    assert_size_within_text_cap(len(raw))
+    content = normalise_text_content(raw)
+    if not content.strip():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "error_code": "empty_content",
+                "filename": filename,
+            },
+        )
+    return ValidatedTextFile(
+        filename=filename,
+        extension=ext,
+        content=content,
+        bytes_count=len(raw),
+        source_ref=build_source_ref(content),
+        title=derive_title(filename, ext),
+    )

--- a/klai-portal/backend/tests/test_app_knowledge_sources_file.py
+++ b/klai-portal/backend/tests/test_app_knowledge_sources_file.py
@@ -1,0 +1,294 @@
+"""Integration tests for POST /sources/file (SPEC-KB-FILE-UPLOAD-001 Phase 1A).
+
+Mirrors the pattern in test_app_knowledge_sources.py: synthetic
+``UserPermissions`` via ``make_perms``, mocked DB + role + quota +
+ingest. Covers the Phase 1A acceptance criteria:
+
+- AC-1.1 / AC-1.2: whitelist routing + unsupported_extension rejection.
+- AC-1.5: text-path UTF-8 / cp1252 fallback.
+- AC-6.1: response shape with uploads + skipped arrays.
+- Phase 1A divergence: .pdf returns ``phase_pending`` (not 500, not the
+  Gitea wiki path), verifying the original bug is closed.
+"""
+
+from __future__ import annotations
+
+import io
+from contextlib import ExitStack
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException, UploadFile
+from starlette.datastructures import Headers
+
+from tests.conftest import make_perms
+
+# --- Fixtures (mirrors test_app_knowledge_sources.py) ----------------------
+
+
+def _make_db_mock(kb: MagicMock | None = None) -> AsyncMock:
+    db = AsyncMock()
+    db.add = MagicMock()  # SQLAlchemy add() is sync — see klai testing rule
+    kb_query_result = MagicMock()
+    kb_query_result.scalar_one_or_none.return_value = kb
+    db.execute.return_value = kb_query_result
+    return db
+
+
+def _make_org() -> MagicMock:
+    org = MagicMock()
+    org.id = 1
+    org.plan = "complete"
+    org.slug = "voys"
+    org.zitadel_org_id = "zitadel-org-1"
+    return org
+
+
+def _make_kb() -> MagicMock:
+    kb = MagicMock()
+    kb.id = 42
+    kb.slug = "personal"
+    kb.name = "Personal"
+    kb.org_id = 1
+    kb.owner_type = "user"
+    kb.owner_user_id = "user-abc"
+    kb.created_by = "user-abc"
+    kb.default_org_role = None
+    return kb
+
+
+def _make_perms() -> object:
+    return make_perms(role="admin", user_id="user-abc", org_id=1)
+
+
+def _upload(filename: str, content: bytes, content_type: str = "text/plain") -> UploadFile:
+    """Build a Starlette UploadFile carrying the given bytes."""
+    return UploadFile(
+        filename=filename,
+        file=io.BytesIO(content),
+        headers=Headers({"content-type": content_type}),
+    )
+
+
+class _FilePatches:
+    """Apply role / quota / org-load / ingest patches for the file route."""
+
+    def __init__(
+        self,
+        *,
+        role: str = "owner",
+        ingest_return: str = "art-file-1",
+    ) -> None:
+        self.role = role
+        self.ingest_return = ingest_return
+        self.stack = ExitStack()
+        self.mock_ingest: AsyncMock | None = None
+
+    def __enter__(self) -> _FilePatches:
+        org = _make_org()
+        self.stack.enter_context(
+            patch(
+                "app.api.app_knowledge_sources._load_org_or_500",
+                AsyncMock(return_value=org),
+            )
+        )
+        self.stack.enter_context(
+            patch(
+                "app.api.app_knowledge_sources.get_user_role_for_kb",
+                AsyncMock(return_value=self.role),
+            )
+        )
+        self.stack.enter_context(
+            patch(
+                "app.api.app_knowledge_sources.assert_can_add_item_to_kb",
+                AsyncMock(return_value=None),
+            )
+        )
+        self.mock_ingest = AsyncMock(return_value=self.ingest_return)
+        self.stack.enter_context(
+            patch(
+                "app.api.app_knowledge_sources.knowledge_ingest_client.ingest_document",
+                self.mock_ingest,
+            )
+        )
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.stack.close()
+
+
+# --- Happy path: text formats -----------------------------------------------
+
+
+class TestFileRouteHappyPath:
+    @pytest.mark.asyncio
+    async def test_md_upload_returns_202_with_artifact(self) -> None:
+        from app.api.app_knowledge_sources import add_file_source
+
+        kb = _make_kb()
+        db = _make_db_mock(kb)
+        files = [_upload("notes.md", b"# Hello\n\nworld", "text/markdown")]
+
+        with _FilePatches(ingest_return="art-md-1") as patches:
+            resp = await add_file_source(
+                kb_slug="personal",
+                files=files,
+                perms=_make_perms(),
+                db=db,
+            )
+
+        assert len(resp.uploads) == 1
+        assert resp.uploads[0].artifact_id == "art-md-1"
+        assert resp.uploads[0].source_type == "file"
+        assert resp.uploads[0].source_ref.startswith("file:sha256:")
+        assert resp.skipped == []
+
+        assert patches.mock_ingest is not None
+        payload = patches.mock_ingest.call_args.args[0]
+        assert payload["source_type"] == "file"
+        assert payload["content_type"] == "plain_text"
+        assert payload["title"] == "notes"
+        assert payload["content"] == "# Hello\n\nworld"
+        assert payload["extra"]["original_filename"] == "notes.md"
+        assert payload["extra"]["extension"] == ".md"
+        assert payload["extra"]["phase"] == "1a"
+
+    @pytest.mark.asyncio
+    async def test_csv_with_bom_strips_bom(self) -> None:
+        from app.api.app_knowledge_sources import add_file_source
+
+        kb = _make_kb()
+        db = _make_db_mock(kb)
+        files = [_upload("rows.csv", b"\xef\xbb\xbfa,b,c\n1,2,3\n", "text/csv")]
+
+        with _FilePatches() as patches:
+            await add_file_source(kb_slug="personal", files=files, perms=_make_perms(), db=db)
+
+        assert patches.mock_ingest is not None
+        payload = patches.mock_ingest.call_args.args[0]
+        assert payload["content"] == "a,b,c\n1,2,3\n"
+        assert payload["title"] == "rows"
+
+    @pytest.mark.asyncio
+    async def test_txt_upload_routes_to_ingest(self) -> None:
+        from app.api.app_knowledge_sources import add_file_source
+
+        kb = _make_kb()
+        db = _make_db_mock(kb)
+        files = [_upload("plain.txt", b"plain text content", "text/plain")]
+
+        with _FilePatches() as patches:
+            resp = await add_file_source(kb_slug="personal", files=files, perms=_make_perms(), db=db)
+
+        assert len(resp.uploads) == 1
+        assert patches.mock_ingest is not None
+        payload = patches.mock_ingest.call_args.args[0]
+        assert payload["content"] == "plain text content"
+
+
+# --- Phase 1A divergence: pdf / docx / etc. → phase_pending -----------------
+
+
+class TestPhasePendingPath:
+    @pytest.mark.asyncio
+    async def test_pdf_returns_400_phase_pending_no_ingest_call(self) -> None:
+        """Original 500-bug regression: .pdf must NOT 500, NOT hit klai-docs wiki."""
+        from app.api.app_knowledge_sources import add_file_source
+
+        kb = _make_kb()
+        db = _make_db_mock(kb)
+        files = [_upload("chemie.pdf", b"%PDF-1.4 fake", "application/pdf")]
+
+        with _FilePatches() as patches, pytest.raises(HTTPException) as excinfo:
+            await add_file_source(kb_slug="personal", files=files, perms=_make_perms(), db=db)
+
+        assert excinfo.value.status_code == 400
+        assert excinfo.value.detail["error_code"] == "phase_pending"
+        # Critical: no ingest call was made — content stays out of KB.
+        assert patches.mock_ingest is not None
+        patches.mock_ingest.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_mixed_request_partial_success(self) -> None:
+        """One .md accepted + one .pdf phase_pending = 202 with skipped array."""
+        from app.api.app_knowledge_sources import add_file_source
+
+        kb = _make_kb()
+        db = _make_db_mock(kb)
+        files = [
+            _upload("notes.md", b"# md content", "text/markdown"),
+            _upload("doc.pdf", b"%PDF", "application/pdf"),
+        ]
+
+        with _FilePatches() as patches:
+            resp = await add_file_source(kb_slug="personal", files=files, perms=_make_perms(), db=db)
+
+        assert len(resp.uploads) == 1
+        assert resp.uploads[0].source_type == "file"
+        assert len(resp.skipped) == 1
+        assert resp.skipped[0].filename == "doc.pdf"
+        assert resp.skipped[0].reason == "phase_pending"
+        assert resp.skipped[0].extension == ".pdf"
+        assert patches.mock_ingest is not None
+        # Only the .md was forwarded — exactly one call.
+        assert patches.mock_ingest.call_count == 1
+
+
+# --- Rejection paths --------------------------------------------------------
+
+
+class TestRejectionPaths:
+    @pytest.mark.asyncio
+    async def test_unsupported_extension_returns_400(self) -> None:
+        from app.api.app_knowledge_sources import add_file_source
+
+        kb = _make_kb()
+        db = _make_db_mock(kb)
+        files = [_upload("malware.exe", b"MZ\x90", "application/octet-stream")]
+
+        with _FilePatches(), pytest.raises(HTTPException) as excinfo:
+            await add_file_source(kb_slug="personal", files=files, perms=_make_perms(), db=db)
+
+        assert excinfo.value.status_code == 400
+        assert excinfo.value.detail["error_code"] == "unsupported_extension"
+
+    @pytest.mark.asyncio
+    async def test_empty_files_list_returns_400(self) -> None:
+        from app.api.app_knowledge_sources import add_file_source
+
+        kb = _make_kb()
+        db = _make_db_mock(kb)
+
+        with _FilePatches(), pytest.raises(HTTPException) as excinfo:
+            await add_file_source(kb_slug="personal", files=[], perms=_make_perms(), db=db)
+
+        assert excinfo.value.status_code == 400
+        assert excinfo.value.detail["error_code"] == "no_files"
+
+    @pytest.mark.asyncio
+    async def test_too_many_files_returns_400(self) -> None:
+        from app.api.app_knowledge_sources import add_file_source
+
+        kb = _make_kb()
+        db = _make_db_mock(kb)
+        files = [_upload(f"f{i}.md", b"x", "text/markdown") for i in range(11)]
+
+        with _FilePatches(), pytest.raises(HTTPException) as excinfo:
+            await add_file_source(kb_slug="personal", files=files, perms=_make_perms(), db=db)
+
+        assert excinfo.value.status_code == 400
+        assert excinfo.value.detail["error_code"] == "too_many_files"
+
+    @pytest.mark.asyncio
+    async def test_empty_content_skipped(self) -> None:
+        from app.api.app_knowledge_sources import add_file_source
+
+        kb = _make_kb()
+        db = _make_db_mock(kb)
+        files = [_upload("blank.md", b"   \n  ", "text/markdown")]
+
+        with _FilePatches(), pytest.raises(HTTPException) as excinfo:
+            await add_file_source(kb_slug="personal", files=files, perms=_make_perms(), db=db)
+
+        assert excinfo.value.status_code == 400
+        assert excinfo.value.detail["error_code"] == "empty_content"

--- a/klai-portal/backend/tests/test_file_upload.py
+++ b/klai-portal/backend/tests/test_file_upload.py
@@ -1,0 +1,189 @@
+"""Unit tests for file_upload service (SPEC-KB-FILE-UPLOAD-001 Phase 1A).
+
+Pure-function tests on the validation helpers. No DB, no httpx, no
+FastAPI test client — the wider integration is covered by
+``test_app_knowledge_sources_file.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from app.services.file_upload import (
+    FULL_WHITELIST,
+    MAX_TEXT_FILE_BYTES,
+    PHASE_1_TEXT_EXTENSIONS,
+    assert_size_within_text_cap,
+    build_source_ref,
+    classify_extension,
+    derive_title,
+    get_extension,
+    normalise_text_content,
+    validate_text_upload,
+)
+
+
+class TestGetExtension:
+    @pytest.mark.parametrize(
+        ("filename", "expected"),
+        [
+            ("foo.md", ".md"),
+            ("Foo.PDF", ".pdf"),
+            ("foo.tar.gz", ".gz"),
+            ("noext", ""),
+            ("UPPER.MD", ".md"),
+            ("path/with/slash.txt", ".txt"),
+        ],
+    )
+    def test_extracts_lowercase_suffix(self, filename: str, expected: str) -> None:
+        assert get_extension(filename) == expected
+
+
+class TestClassifyExtension:
+    @pytest.mark.parametrize("ext", sorted(PHASE_1_TEXT_EXTENSIONS))
+    def test_phase_1_text_extensions_route_to_phase1(self, ext: str) -> None:
+        result_ext, phase = classify_extension(f"foo{ext}")
+        assert result_ext == ext
+        assert phase == "phase1"
+
+    @pytest.mark.parametrize(
+        "ext",
+        sorted(FULL_WHITELIST - PHASE_1_TEXT_EXTENSIONS),
+    )
+    def test_full_whitelist_non_phase_1_returns_phase_pending(self, ext: str) -> None:
+        result_ext, phase = classify_extension(f"foo{ext}")
+        assert result_ext == ext
+        assert phase == "phase_pending"
+
+    @pytest.mark.parametrize(
+        "filename",
+        ["foo.exe", "script.sh", "binary.bin", "page.html"],
+    )
+    def test_unknown_extension_raises_400(self, filename: str) -> None:
+        with pytest.raises(HTTPException) as excinfo:
+            classify_extension(filename)
+        assert excinfo.value.status_code == 400
+        assert excinfo.value.detail["error_code"] == "unsupported_extension"
+
+    def test_no_extension_raises_400(self) -> None:
+        with pytest.raises(HTTPException) as excinfo:
+            classify_extension("readme")
+        assert excinfo.value.status_code == 400
+        assert excinfo.value.detail["error_code"] == "unsupported_extension"
+
+
+class TestAssertSizeWithinTextCap:
+    def test_ok_at_cap(self) -> None:
+        assert_size_within_text_cap(MAX_TEXT_FILE_BYTES)
+
+    def test_ok_below_cap(self) -> None:
+        assert_size_within_text_cap(1)
+
+    def test_zero_ok(self) -> None:
+        # Empty content is rejected later (empty_content); size guard alone
+        # accepts zero so the more specific reason can surface.
+        assert_size_within_text_cap(0)
+
+    def test_one_over_cap_raises_413(self) -> None:
+        with pytest.raises(HTTPException) as excinfo:
+            assert_size_within_text_cap(MAX_TEXT_FILE_BYTES + 1)
+        assert excinfo.value.status_code == 413
+        assert excinfo.value.detail["error_code"] == "file_too_large"
+
+
+class TestNormaliseTextContent:
+    def test_plain_utf8(self) -> None:
+        assert normalise_text_content(b"hello") == "hello"
+
+    def test_strips_utf8_bom(self) -> None:
+        assert normalise_text_content(b"\xef\xbb\xbfhello") == "hello"
+
+    def test_utf8_multibyte(self) -> None:
+        assert normalise_text_content("café".encode()) == "café"
+
+    def test_cp1252_fallback(self) -> None:
+        # 0x96 is en-dash in cp1252, invalid as UTF-8.
+        result = normalise_text_content(b"hello\x96world")
+        assert "hello" in result
+        assert "world" in result
+
+    def test_invalid_encoding_raises_400(self) -> None:
+        # Construct bytes that fail BOTH utf-8 and cp1252 decode.
+        # cp1252 actually decodes most byte sequences (it's a single-byte
+        # encoding with only 5 undefined slots: 0x81 0x8D 0x8F 0x90 0x9D).
+        bad = bytes([0x81, 0x8D, 0x8F, 0x90, 0x9D])
+        with pytest.raises(HTTPException) as excinfo:
+            normalise_text_content(bad)
+        assert excinfo.value.status_code == 400
+        assert excinfo.value.detail["error_code"] == "invalid_text_encoding"
+
+
+class TestBuildSourceRef:
+    def test_prefix(self) -> None:
+        assert build_source_ref("hello").startswith("file:sha256:")
+
+    def test_deterministic(self) -> None:
+        assert build_source_ref("hello") == build_source_ref("hello")
+
+    def test_different_content_different_ref(self) -> None:
+        assert build_source_ref("a") != build_source_ref("b")
+
+
+class TestDeriveTitle:
+    @pytest.mark.parametrize(
+        ("filename", "ext", "expected"),
+        [
+            ("notes.md", ".md", "notes"),
+            ("My Doc.txt", ".txt", "My Doc"),
+            ("data.csv", ".csv", "data"),
+            ("  spaced  .md", ".md", "spaced"),
+            ("noext", "", "noext"),
+            (".md", ".md", "untitled"),
+            ("", "", "untitled"),
+        ],
+    )
+    def test_strips_extension_and_whitespace(self, filename: str, ext: str, expected: str) -> None:
+        assert derive_title(filename, ext) == expected
+
+
+class TestValidateTextUpload:
+    def test_happy_path_md(self) -> None:
+        result = validate_text_upload("notes.md", b"# Hello\n\ncontent")
+        assert result.filename == "notes.md"
+        assert result.extension == ".md"
+        assert result.content == "# Hello\n\ncontent"
+        assert result.title == "notes"
+        assert result.bytes_count == len(b"# Hello\n\ncontent")
+        assert result.source_ref.startswith("file:sha256:")
+
+    def test_happy_path_csv_with_bom(self) -> None:
+        result = validate_text_upload("rows.csv", b"\xef\xbb\xbfa,b,c\n1,2,3\n")
+        assert result.content == "a,b,c\n1,2,3\n"
+        assert result.title == "rows"
+
+    def test_phase_pending_raises_400_phase_pending(self) -> None:
+        with pytest.raises(HTTPException) as excinfo:
+            validate_text_upload("doc.pdf", b"%PDF-1.4")
+        assert excinfo.value.status_code == 400
+        assert excinfo.value.detail["error_code"] == "phase_pending"
+        assert excinfo.value.detail["extension"] == ".pdf"
+
+    def test_unsupported_raises_400(self) -> None:
+        with pytest.raises(HTTPException) as excinfo:
+            validate_text_upload("script.sh", b"#!/bin/bash")
+        assert excinfo.value.status_code == 400
+        assert excinfo.value.detail["error_code"] == "unsupported_extension"
+
+    def test_empty_content_raises_400(self) -> None:
+        with pytest.raises(HTTPException) as excinfo:
+            validate_text_upload("empty.md", b"   \n  ")
+        assert excinfo.value.status_code == 400
+        assert excinfo.value.detail["error_code"] == "empty_content"
+
+    def test_oversize_raises_413(self) -> None:
+        oversize = b"a" * (MAX_TEXT_FILE_BYTES + 1)
+        with pytest.raises(HTTPException) as excinfo:
+            validate_text_upload("big.txt", oversize)
+        assert excinfo.value.status_code == 413
+        assert excinfo.value.detail["error_code"] == "file_too_large"

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source._components/FileUploadForm.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source._components/FileUploadForm.tsx
@@ -1,33 +1,115 @@
-import { useState, useCallback, useRef } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
-import { Upload, FileText, CheckCircle2 } from 'lucide-react'
+import { CheckCircle2, FileText, Upload } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import * as m from '@/paraglide/messages'
-import { apiFetch } from '@/lib/apiFetch'
-import { DOCS_BASE, getOrgSlug } from '@/lib/kb-editor/tree-utils'
+import { apiFetch, ApiError } from '@/lib/apiFetch'
+
+// SPEC-KB-FILE-UPLOAD-001 Phase 1A: text formats only via the new
+// /api/app/knowledge-bases/{kb}/sources/file route. Binary formats
+// (.pdf .docx .pptx .xlsx etc.) ship in Phase 1B+; the backend returns
+// `phase_pending` per file in the `skipped` array which we surface as
+// a localised "binnenkort" message. The previous wiring against
+// DOCS_BASE (klai-docs/Gitea) was wrong: that endpoint only accepted
+// .md and crashed on 100MB+ binaries.
+
+const PHASE_1_ACCEPT = '.md,.txt,.csv'
+const PHASE_1_MAX_BYTES = 10 * 1024 * 1024 // 10 MB — matches backend MAX_TEXT_FILE_BYTES
+const PHASE_1_FORMATS_LABEL = 'Markdown, TXT, CSV'
 
 export interface FileUploadFormProps {
   kbSlug: string
   onBack: () => void
 }
 
+interface SkippedEntry {
+  filename: string
+  reason: string
+  extension?: string | null
+}
+
+interface UploadResponse {
+  uploads: Array<{ artifact_id: string; source_ref: string; source_type: string }>
+  skipped: SkippedEntry[]
+}
+
+interface ClientRejection {
+  filename: string
+  reason: 'oversize' | 'unsupported_extension'
+  size?: number
+}
+
+const SUPPORTED_EXTS = new Set(['.md', '.txt', '.csv'])
+
+function getExtension(name: string): string {
+  const dot = name.lastIndexOf('.')
+  return dot >= 0 ? name.slice(dot).toLowerCase() : ''
+}
+
+function partitionClientSide(files: File[]): { ok: File[]; rejected: ClientRejection[] } {
+  const ok: File[] = []
+  const rejected: ClientRejection[] = []
+  for (const f of files) {
+    const ext = getExtension(f.name)
+    if (!SUPPORTED_EXTS.has(ext)) {
+      rejected.push({ filename: f.name, reason: 'unsupported_extension' })
+      continue
+    }
+    if (f.size > PHASE_1_MAX_BYTES) {
+      rejected.push({ filename: f.name, reason: 'oversize', size: f.size })
+      continue
+    }
+    ok.push(f)
+  }
+  return { ok, rejected }
+}
+
+function reasonToMessage(reason: string): string {
+  switch (reason) {
+    case 'unsupported_extension':
+    case 'phase_pending':
+      return `Bestandstype niet ondersteund. Phase 1 ondersteunt: ${PHASE_1_FORMATS_LABEL}.`
+    case 'file_too_large':
+    case 'oversize':
+      return 'Bestand te groot (max 10 MB voor tekst).'
+    case 'invalid_text_encoding':
+      return 'Bestand kon niet worden gedecodeerd (geen UTF-8 of Windows-1252).'
+    case 'empty_content':
+      return 'Bestand is leeg.'
+    case 'kb_quota_items_exceeded':
+      return 'Geen ruimte meer in deze kennisbank.'
+    case 'no_files':
+      return 'Geen bestand geselecteerd.'
+    case 'too_many_files':
+      return 'Te veel bestanden geselecteerd (max 10 per upload).'
+    default:
+      return 'Upload mislukt. Probeer opnieuw.'
+  }
+}
+
 export function FileUploadForm({ kbSlug, onBack }: FileUploadFormProps) {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
-  const orgSlug = getOrgSlug()
 
   const [selectedFiles, setSelectedFiles] = useState<File[]>([])
+  const [clientRejections, setClientRejections] = useState<ClientRejection[]>([])
+  const [serverSkipped, setServerSkipped] = useState<SkippedEntry[]>([])
   const [isDragOver, setIsDragOver] = useState(false)
   const [uploadSuccess, setUploadSuccess] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
 
+  const addFiles = useCallback((incoming: File[]) => {
+    const { ok, rejected } = partitionClientSide(incoming)
+    if (ok.length > 0) setSelectedFiles((prev) => [...prev, ...ok])
+    if (rejected.length > 0) setClientRejections((prev) => [...prev, ...rejected])
+  }, [])
+
   const onDrop = useCallback((e: React.DragEvent) => {
     e.preventDefault()
     setIsDragOver(false)
-    const files = Array.from(e.dataTransfer.files)
-    if (files.length > 0) setSelectedFiles((prev) => [...prev, ...files])
-  }, [])
+    addFiles(Array.from(e.dataTransfer.files))
+  }, [addFiles])
 
   const onDragOver = useCallback((e: React.DragEvent) => {
     e.preventDefault()
@@ -39,30 +121,49 @@ export function FileUploadForm({ kbSlug, onBack }: FileUploadFormProps) {
   }, [])
 
   const fileUploadMutation = useMutation({
-    mutationFn: async () => {
-      for (const file of selectedFiles) {
-        const formData = new FormData()
-        formData.append('file', file)
-        await apiFetch(`${DOCS_BASE}/orgs/${orgSlug}/kbs/${kbSlug}/upload`, {
-          method: 'POST',
-          body: formData,
-        })
-      }
+    mutationFn: async (): Promise<UploadResponse> => {
+      const formData = new FormData()
+      for (const file of selectedFiles) formData.append('files', file)
+      // SPEC-KB-FILE-UPLOAD-001: new portal-api endpoint, NOT the
+      // klai-docs wiki route. Multi-file in one request — backend
+      // partial-success semantics live in the response.
+      return apiFetch<UploadResponse>(
+        `/api/app/knowledge-bases/${kbSlug}/sources/file`,
+        { method: 'POST', body: formData }
+      )
     },
-    onSuccess: () => {
+    onSuccess: (data) => {
       void queryClient.invalidateQueries({ queryKey: ['kb-items', kbSlug] })
       void queryClient.invalidateQueries({ queryKey: ['personal-knowledge', kbSlug] })
       void queryClient.invalidateQueries({ queryKey: ['app-knowledge-bases-stats-summary'] })
-      setUploadSuccess(true)
+      setServerSkipped(data.skipped)
       setSelectedFiles([])
-      setTimeout(() => {
-        void navigate({
-          to: '/app/knowledge/$kbSlug/overview',
-          params: { kbSlug },
-        })
-      }, 1500)
+      // Only show full success when at least one file was accepted AND no skips.
+      if (data.uploads.length > 0 && data.skipped.length === 0) {
+        setUploadSuccess(true)
+        setTimeout(() => {
+          void navigate({
+            to: '/app/knowledge/$kbSlug/overview',
+            params: { kbSlug },
+          })
+        }, 1500)
+      }
     },
   })
+
+  const errorMessage = (() => {
+    if (!fileUploadMutation.error) return null
+    if (fileUploadMutation.error instanceof ApiError) {
+      try {
+        const parsed = JSON.parse(fileUploadMutation.error.detail) as { error_code?: string }
+        if (parsed.error_code) return reasonToMessage(parsed.error_code)
+      } catch {
+        // Fall through to generic message.
+      }
+      return reasonToMessage('default')
+    }
+    return reasonToMessage('default')
+  })()
 
   return (
     <div className="space-y-6">
@@ -98,19 +199,18 @@ export function FileUploadForm({ kbSlug, onBack }: FileUploadFormProps) {
         <p className="text-sm font-medium text-gray-900">
           {m.knowledge_add_source_file_drop_hint()}
         </p>
-        <p className="text-xs text-gray-400 mt-2">
-          PDF, Word, Excel, PowerPoint, TXT, Markdown, CSV
-        </p>
+        <p className="text-xs text-gray-400 mt-2">{PHASE_1_FORMATS_LABEL} (max 10 MB per bestand)</p>
+        <p className="text-xs text-gray-400 mt-1">PDF, Word, Excel, PowerPoint volgen binnenkort</p>
         <input
           ref={fileInputRef}
           type="file"
           multiple
-          accept=".pdf,.doc,.docx,.xls,.xlsx,.pptx,.txt,.md,.csv"
+          accept={PHASE_1_ACCEPT}
           className="sr-only"
           tabIndex={-1}
           onChange={(e) => {
             const files = Array.from(e.target.files ?? [])
-            if (files.length > 0) setSelectedFiles((prev) => [...prev, ...files])
+            addFiles(files)
             e.target.value = ''
           }}
         />
@@ -121,7 +221,7 @@ export function FileUploadForm({ kbSlug, onBack }: FileUploadFormProps) {
         <div className="space-y-1">
           {selectedFiles.map((file, i) => (
             <div
-              key={`${file.name}-${i}`}
+              key={`${file.name}-${String(i)}`}
               className="flex items-center gap-3 rounded-lg border border-gray-200 px-4 py-2.5"
             >
               <FileText className="h-4 w-4 text-gray-400 shrink-0" />
@@ -145,13 +245,48 @@ export function FileUploadForm({ kbSlug, onBack }: FileUploadFormProps) {
         </div>
       )}
 
+      {/* Client-side rejections */}
+      {clientRejections.length > 0 && (
+        <div className="rounded-lg border border-[var(--color-destructive)] bg-[var(--color-destructive-bg,_transparent)] p-3">
+          <p className="text-sm font-medium text-[var(--color-destructive)] mb-1">
+            Niet toegevoegd:
+          </p>
+          <ul className="text-xs text-[var(--color-destructive)] space-y-0.5">
+            {clientRejections.map((r, i) => (
+              <li key={`${r.filename}-${String(i)}`}>
+                {r.filename} — {reasonToMessage(r.reason)}
+              </li>
+            ))}
+          </ul>
+          <button
+            type="button"
+            onClick={() => setClientRejections([])}
+            className="mt-2 text-xs text-gray-400 hover:text-gray-900"
+          >
+            Sluiten
+          </button>
+        </div>
+      )}
+
+      {/* Server-side per-file skipped (after upload completes) */}
+      {serverSkipped.length > 0 && (
+        <div className="rounded-lg border border-[var(--color-warning)] bg-[var(--color-warning-bg)] p-3">
+          <p className="text-sm font-medium text-[var(--color-warning)] mb-1">
+            Niet verwerkt:
+          </p>
+          <ul className="text-xs text-[var(--color-warning)] space-y-0.5">
+            {serverSkipped.map((r, i) => (
+              <li key={`${r.filename}-${String(i)}`}>
+                {r.filename} — {reasonToMessage(r.reason)}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
       {/* Error banner */}
-      {fileUploadMutation.error && (
-        <p className="text-sm text-[var(--color-destructive)]">
-          {fileUploadMutation.error instanceof Error
-            ? fileUploadMutation.error.message
-            : m.knowledge_add_source_file_error_generic()}
-        </p>
+      {errorMessage && (
+        <p className="text-sm text-[var(--color-destructive)]">{errorMessage}</p>
       )}
 
       {/* Actions */}


### PR DESCRIPTION
## Summary

Closes the user-visible `500: 500` on `/app/knowledge/<kb>/add-source` for any non-`.md` upload (originally surfaced on a 105 MB chemie-PDF). Root cause: the `FileUploadForm` POSTed to the **klai-docs wiki** route (DOCS_BASE = `/api/docs/api`), which only accepts `.md` and OOMs on binaries. Phase 1A flips the form to a new portal-api route and routes text formats through the existing text-ingest pipeline.

- `POST /api/app/knowledge-bases/{kb}/sources/file` — multipart, max 10 files
- Whitelist: `.csv .doc .docx .json .md .pdf .pptx .tar .txt .xlsx .xml .zip` per SPEC REQ-1
- Phase 1A handles `.md / .txt / .csv` end-to-end via `/ingest/v1/document`
- Other whitelisted formats return `phase_pending` per file in `skipped[]` so the UI can show a clear "binnenkort" message instead of crashing
- Caddy `request_body { max_size 10MB }` scoped to the new path; Phase 1B raises to 200 MB when streaming + Garage land

Phase 1B (follow-up PR) lands `klai-libs/document-storage`, Garage `klai-documents` bucket, `kb_uploads`/`kb_uploads_quota` alembic tables (cat-D RLS), `assert_can_upload_bytes` with FOR UPDATE, dedicated `/ingest/v1/file` endpoint on knowledge-ingest, full Paraglide i18n table, and the runbook. Phase 2 adds docling routing for binary formats. See `.moai/specs/SPEC-KB-FILE-UPLOAD-001/spec.md` for the full plan and `progress.md` for the SPEC-divergence rationale.

## Test plan

- [x] `pytest tests/test_file_upload.py` — 48 unit tests on validation helpers (extension classifier, BOM strip, encoding fallback, size cap, source_ref dedupe)
- [x] `pytest tests/test_app_knowledge_sources_file.py` — 9 integration tests including the explicit `.pdf → phase_pending` regression test that locks the original bug closed
- [x] `pytest tests/test_app_knowledge_sources.py` — 14 existing url/text route tests still green (no regression)
- [x] `pytest tests/test_caddyfile_static_route_position.py` — Caddy lint invariant intact
- [x] `ruff check` + `ruff format --check` — clean
- [x] `tsc --noEmit --ignoreDeprecations 6.0` — clean
- [ ] Post-deploy smoke: upload `sample.md` at `https://my.getklai.com/app/knowledge/<kb>/add-source`, verify `service:portal-api AND event:kb_upload_received AND decision:accepted` in VictoriaLogs
- [ ] Post-deploy smoke: drop a `.pdf` on the same form, expect a NL "phase_pending" rail instead of a 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)