### PR TITLE
fix(portal): pyright type for docling-serve form data

### DIFF
--- a/klai-portal/backend/app/services/docling_client.py
+++ b/klai-portal/backend/app/services/docling_client.py
@@ -125,7 +125,11 @@ async def submit_file_async(
     :class:`DoclingTimeoutError` on transport timeouts.
     """
     files = [("files", (filename, content, content_type))]
-    data: list[tuple[str, str]] = [("to_formats", fmt) for fmt in to_formats]
+    # docling-serve accepts repeated ``to_formats=`` form fields. httpx
+    # encodes a sequence value as repeated fields under the same key, so
+    # ``{"to_formats": ["md", "html"]}`` becomes ``to_formats=md&to_formats=html``
+    # on the wire — matching the multi-value semantics docling expects.
+    data: dict[str, list[str]] = {"to_formats": list(to_formats)}
 
     try:
         async with _client(_SUBMIT_TIMEOUT_S) as client:


### PR DESCRIPTION
## Summary

Hotfix: post-merge `quality` job on main has been failing pyright since PR #555 landed (SPEC-KB-FILE-UPLOAD-001). Type stub for httpx's `data=` parameter rejects `list[tuple[str, str]]`. This blocks the deploy job for every PR that merges to main.

## Change

```diff
- data: list[tuple[str, str]] = [("to_formats", fmt) for fmt in to_formats]
+ data: dict[str, list[str]] = {"to_formats": list(to_formats)}
```

httpx encodes a sequence value as repeated form fields, so the wire-format is identical (`to_formats=md&to_formats=html`). docling-serve sees the same request bytes.

## Test plan
- [x] `uv run --with pyright pyright app/services/docling_client.py` → 0 errors
- [x] `uv run ruff check + format --check` → clean
- [x] `uv run pytest -k docling` → 16 passed
- [ ] CI green
- [ ] Post-merge: deploy job for PR #552 (REQ-14/18/19) unblocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)