### PR TITLE
fix(kb): pyright fail in docling_client.submit_file_async

### DIFF
--- a/docs/runbooks/kb-file-upload.md
+++ b/docs/runbooks/kb-file-upload.md
@@ -55,13 +55,11 @@ Browser ──multipart 200 MB──▶ Caddy ──▶ portal-api
    role does not own `kb_uploads` and cannot ENABLE RLS on it. Run:
 
    ```bash
-   ssh core-01 "docker cp klai-core-postgres-1:/dev/null /tmp/post_deploy.sql"  # placeholder
-   # Either copy the file in:
    scp klai-portal/backend/alembic/versions/post_deploy_85e5d0a7cb98_kb_uploads_rls.sql \
-       core-01:/tmp/post_deploy.sql
-   ssh core-01 "docker cp /tmp/post_deploy.sql klai-core-postgres-1:/tmp/"
+       core-01:/tmp/post_deploy_kb_uploads.sql
+   ssh core-01 "docker cp /tmp/post_deploy_kb_uploads.sql klai-core-postgres-1:/tmp/"
    ssh core-01 "docker exec klai-core-postgres-1 sh -c \
-       'psql -U \$POSTGRES_USER -d \$POSTGRES_DB -f /tmp/post_deploy.sql'"
+       'psql -U \$POSTGRES_USER -d \$POSTGRES_DB -f /tmp/post_deploy_kb_uploads.sql'"
    ```
 
    Verify:

--- a/klai-portal/backend/app/services/docling_client.py
+++ b/klai-portal/backend/app/services/docling_client.py
@@ -112,7 +112,7 @@ async def submit_file_async(
     filename: str,
     content: bytes,
     content_type: str,
-    to_formats: tuple[str, ...] = ("md",),
+    to_format: str = "md",
 ) -> DoclingSubmitResult:
     """Submit a file to docling-serve's async queue.
 
@@ -125,7 +125,9 @@ async def submit_file_async(
     :class:`DoclingTimeoutError` on transport timeouts.
     """
     files = [("files", (filename, content, content_type))]
-    data: list[tuple[str, str]] = [("to_formats", fmt) for fmt in to_formats]
+    # docling-serve accepts a comma-separated ``to_formats`` form field;
+    # a single value is the common case so we keep the signature simple.
+    data = {"to_formats": to_format}
 
     try:
         async with _client(_SUBMIT_TIMEOUT_S) as client:


### PR DESCRIPTION
Hotfix follow-up to #555.

The squash-merge of #555 landed at commit `f8244455` which contained the original `list[tuple[str, str]]` data-shape that pyright rejects on the `httpx.AsyncClient.post` data parameter. The fix was made on the branch (`5b3e4f9c`) but pushed AFTER the admin-merge had already executed server-side, so it never reached main.

Cherry-picks the two follow-up commits onto main:
- pyright fix in `docling_client.submit_file_async` (single `to_format: str` + `data={'to_formats': to_format}` dict — semantics unchanged, just satisfies the type stub)
- runbook copy cleanup (placeholder line removed)

Without this, portal-api builds on main fail at the pyright step, blocking the docling-pipeline deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)