### PR TITLE
fix(kb): SPEC-KB-FILE-UPLOAD-001 — bypass Starlette 1.0 max_part_size for large file uploads

### DIFF
--- a/klai-portal/backend/app/api/app_knowledge_sources.py
+++ b/klai-portal/backend/app/api/app_knowledge_sources.py
@@ -29,7 +29,7 @@ from urllib.parse import urlparse
 
 import httpx
 import structlog
-from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile, status
+from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile, status
 from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -582,7 +582,7 @@ async def _dispatch_blob(
 )
 async def add_file_source(
     kb_slug: str,
-    files: list[UploadFile] = File(...),
+    request: Request,
     perms: UserPermissions = Depends(get_caller),
     db: AsyncSession = Depends(get_db),
 ) -> FileSourcesIngestedResponse:
@@ -608,7 +608,38 @@ async def add_file_source(
     ``uploads`` (with their per-file status), rejected files in
     ``skipped``. The endpoint returns 400 only when no file is
     acceptable, so the frontend can surface a coherent error.
+
+    The route does its own ``request.form()`` call rather than relying
+    on FastAPI's ``files: list[UploadFile] = File(...)`` injection
+    because the default ``max_part_size`` is 1 MB — Starlette 1.0's
+    multipart parser enforces that on every part including file parts,
+    so a 128 MB PDF mid-stream causes the parser to drop the connection
+    (Caddy then logs "use of closed network connection" → 502). We
+    raise the cap to ``MAX_BINARY_FILE_BYTES + 4 KiB`` so a 200 MB
+    member uploads cleanly.
     """
+    # Override Starlette's 1 MB default per-part cap. Adding 4 KiB
+    # accounts for the multipart envelope (boundary, headers, CRLFs).
+    try:
+        form = await request.form(
+            max_files=_MAX_FILES_PER_REQUEST,
+            max_part_size=file_upload.MAX_BINARY_FILE_BYTES + 4 * 1024,
+        )
+    except Exception as exc:
+        # Starlette MultiPartException + httpx parse errors land here.
+        # The most common is the user uploading > 200 MB; surface as
+        # 413 with the structured error code rather than 500.
+        logger.warning("kb_upload_form_parse_failed", error=str(exc), exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+            detail={
+                "error_code": "file_too_large",
+                "max_bytes": file_upload.MAX_BINARY_FILE_BYTES,
+            },
+        ) from exc
+
+    files: list[UploadFile] = [v for v in form.getlist("files") if isinstance(v, UploadFile)]
+
     if not files:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/klai-portal/backend/tests/test_app_knowledge_sources_file.py
+++ b/klai-portal/backend/tests/test_app_knowledge_sources_file.py
@@ -122,6 +122,16 @@ def _upload(filename: str, content: bytes, content_type: str = "text/plain") -> 
     )
 
 
+def _make_request(files: list[UploadFile]) -> MagicMock:
+    """Build a mock Request whose form() returns the given UploadFiles."""
+    from starlette.datastructures import FormData
+
+    form_items: list[tuple[str, UploadFile]] = [("files", f) for f in files]
+    request = MagicMock()
+    request.form = AsyncMock(return_value=FormData(form_items))
+    return request
+
+
 class _FilePatches:
     """Bundle the ingest + docling + repo patches for the file route."""
 
@@ -233,7 +243,7 @@ class TestTextPipeline:
         files = [_upload("notes.md", b"# Hello\n\nworld", "text/markdown")]
 
         with _FilePatches(ingest_artifact_id="art-md-99") as patches:
-            resp = await add_file_source(kb_slug="personal", files=files, perms=_make_perms(), db=db)
+            resp = await add_file_source(kb_slug="personal", request=_make_request(files), perms=_make_perms(), db=db)
 
         assert len(resp.uploads) == 1
         assert resp.uploads[0].status == "done"
@@ -267,7 +277,7 @@ class TestTextPipeline:
         files = [_upload("rows.csv", b"\xef\xbb\xbfa,b\n1,2\n", "text/csv")]
 
         with _FilePatches() as patches:
-            await add_file_source(kb_slug="personal", files=files, perms=_make_perms(), db=db)
+            await add_file_source(kb_slug="personal", request=_make_request(files), perms=_make_perms(), db=db)
 
         assert patches.mock_ingest is not None
         payload = patches.mock_ingest.call_args.args[0]
@@ -287,7 +297,7 @@ class TestDoclingPipeline:
         files = [_upload("chemie.pdf", _TINY_PDF, "application/pdf")]
 
         with _FilePatches(docling_task_id="docling-task-xyz") as patches:
-            resp = await add_file_source(kb_slug="personal", files=files, perms=_make_perms(), db=db)
+            resp = await add_file_source(kb_slug="personal", request=_make_request(files), perms=_make_perms(), db=db)
 
         assert len(resp.uploads) == 1
         assert resp.uploads[0].status == "processing"
@@ -322,7 +332,7 @@ class TestDoclingPipeline:
         files = [_upload("fake.pdf", b"GIF89a\x00\x00\x00\x00", "application/pdf")]
 
         with _FilePatches() as patches, pytest.raises(HTTPException) as excinfo:
-            await add_file_source(kb_slug="personal", files=files, perms=_make_perms(), db=db)
+            await add_file_source(kb_slug="personal", request=_make_request(files), perms=_make_perms(), db=db)
 
         assert excinfo.value.status_code == 400
         assert excinfo.value.detail["error_code"] == "mime_mismatch"
@@ -344,7 +354,7 @@ class TestDoclingPipeline:
             ),
             pytest.raises(HTTPException) as excinfo,
         ):
-            await add_file_source(kb_slug="personal", files=files, perms=_make_perms(), db=db)
+            await add_file_source(kb_slug="personal", request=_make_request(files), perms=_make_perms(), db=db)
 
         assert excinfo.value.status_code == 400
         assert excinfo.value.detail["error_code"] == "extraction_failed"
@@ -363,7 +373,7 @@ class TestPhasePending:
         files = [_upload("legacy.doc", b"\xd0\xcf\x11\xe0", "application/msword")]
 
         with _FilePatches() as patches, pytest.raises(HTTPException) as excinfo:
-            await add_file_source(kb_slug="personal", files=files, perms=_make_perms(), db=db)
+            await add_file_source(kb_slug="personal", request=_make_request(files), perms=_make_perms(), db=db)
 
         assert excinfo.value.status_code == 400
         assert excinfo.value.detail["error_code"] == "phase_pending"
@@ -380,7 +390,7 @@ class TestPhasePending:
         files = [_upload("nope.zip", b"PK\x03\x04", "application/zip")]
 
         with _FilePatches(), pytest.raises(HTTPException) as excinfo:
-            await add_file_source(kb_slug="personal", files=files, perms=_make_perms(), db=db)
+            await add_file_source(kb_slug="personal", request=_make_request(files), perms=_make_perms(), db=db)
 
         assert excinfo.value.status_code == 400
         assert excinfo.value.detail["error_code"] == "archive_malformed"
@@ -402,7 +412,7 @@ class TestMixedRequest:
         ]
 
         with _FilePatches() as patches:
-            resp = await add_file_source(kb_slug="personal", files=files, perms=_make_perms(), db=db)
+            resp = await add_file_source(kb_slug="personal", request=_make_request(files), perms=_make_perms(), db=db)
 
         # Both accepted; one done (md), one processing (pdf).
         assert len(resp.uploads) == 2
@@ -428,7 +438,7 @@ class TestMixedRequest:
         ]
 
         with _FilePatches():
-            resp = await add_file_source(kb_slug="personal", files=files, perms=_make_perms(), db=db)
+            resp = await add_file_source(kb_slug="personal", request=_make_request(files), perms=_make_perms(), db=db)
 
         assert len(resp.uploads) == 1
         assert resp.uploads[0].status == "done"
@@ -449,7 +459,7 @@ class TestProtocolErrors:
         files = [_upload("malware.exe", b"MZ\x90", "application/octet-stream")]
 
         with _FilePatches(), pytest.raises(HTTPException) as excinfo:
-            await add_file_source(kb_slug="personal", files=files, perms=_make_perms(), db=db)
+            await add_file_source(kb_slug="personal", request=_make_request(files), perms=_make_perms(), db=db)
 
         assert excinfo.value.status_code == 400
         assert excinfo.value.detail["error_code"] == "unsupported_extension"
@@ -462,7 +472,7 @@ class TestProtocolErrors:
         db = _make_db_mock(kb)
 
         with _FilePatches(), pytest.raises(HTTPException) as excinfo:
-            await add_file_source(kb_slug="personal", files=[], perms=_make_perms(), db=db)
+            await add_file_source(kb_slug="personal", request=_make_request([]), perms=_make_perms(), db=db)
 
         assert excinfo.value.status_code == 400
         assert excinfo.value.detail["error_code"] == "no_files"
@@ -476,7 +486,7 @@ class TestProtocolErrors:
         files = [_upload(f"f{i}.md", b"x", "text/markdown") for i in range(11)]
 
         with _FilePatches(), pytest.raises(HTTPException) as excinfo:
-            await add_file_source(kb_slug="personal", files=files, perms=_make_perms(), db=db)
+            await add_file_source(kb_slug="personal", request=_make_request(files), perms=_make_perms(), db=db)
 
         assert excinfo.value.status_code == 400
         assert excinfo.value.detail["error_code"] == "too_many_files"


### PR DESCRIPTION
## Summary

Production trace from a 128 MB chemie-PDF upload showed Caddy receiving 121 MB of body, then portal-api closing the TCP mid-stream → 502:

\`\`\`
Caddy: bytes_read=121549824 status=502 duration=91s
err: \"use of closed network connection\" (172.18.0.6:8010)
\`\`\`

### Root cause

Starlette 1.0's \`MultiPartParser\` enforces \`max_part_size\` (default 1 MiB) on **every** multipart part, including file parts. FastAPI's \`files: list[UploadFile] = File(...)\` injection calls \`request.form()\` with defaults — so any file part >1 MiB throws mid-stream, uvicorn closes TCP, Caddy logs 502.

### Fix

Drop the \`File()\` injection. Take \`request: Request\` and call \`request.form(max_files=10, max_part_size=MAX_BINARY_FILE_BYTES + 4 KiB)\` ourselves. Form-parse failures surface as structured 413 \`file_too_large\` rather than 502.

### Test plan

- [x] \`pytest\` 117 SPEC tests passing
- [x] \`ruff check\` + \`pyright\` clean
- [ ] Post-deploy: chemie-PDF 128 MB upload completes end-to-end via UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)