### PR TITLE
fix(kb): SPEC-KB-FILE-UPLOAD-001 — UploadFile isinstance + Starlette max_part_size

### DIFF
--- a/klai-portal/backend/app/api/app_knowledge_sources.py
+++ b/klai-portal/backend/app/api/app_knowledge_sources.py
@@ -29,10 +29,11 @@ from urllib.parse import urlparse
 
 import httpx
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.datastructures import UploadFile
 
 from app.api.dependencies import _load_org_or_500
 from app.core.database import get_db
@@ -617,6 +618,11 @@ async def add_file_source(
     (Caddy then logs "use of closed network connection" → 502). We
     raise the cap to ``MAX_BINARY_FILE_BYTES + 4 KiB`` so a 200 MB
     member uploads cleanly.
+
+    NOTE: the ``UploadFile`` type used in the ``isinstance`` filter MUST
+    come from ``starlette.datastructures`` — ``fastapi.UploadFile`` is a
+    subclass, so ``isinstance(starlette_obj, fastapi.UploadFile)`` returns
+    ``False`` and silently filters every parsed file out of the list.
     """
     # Override Starlette's 1 MB default per-part cap. Adding 4 KiB
     # accounts for the multipart envelope (boundary, headers, CRLFs).


### PR DESCRIPTION
## Summary

Two-part fix for the 128 MB PDF upload regression that landed after Phase 1 of SPEC-KB-FILE-UPLOAD-001:

1. **Starlette `max_part_size` bypass** (commit 34a58ca0, already merged in 11807e55):
   - Default `max_part_size=1 MiB` aborts a 128 MB part mid-stream → Caddy 502.
   - Route now does its own `request.form(max_part_size=200 MB + 4 KiB)`.

2. **`UploadFile` isinstance bug** (this PR):
   - `request.form()` returns `starlette.datastructures.UploadFile`.
   - The route imported `UploadFile` from `fastapi` for the `isinstance` filter.
   - `fastapi.UploadFile` is a **subclass** of Starlette's, so the filter rejected every parsed file.
   - Symptom: 134 MB body uploaded successfully, route returned `400 no_files`, no `kb_upload_received` log line.
   - Fix: import `UploadFile` from `starlette.datastructures`.

## Test plan

- [x] `ruff check` + `ruff format --check` clean
- [x] `pyright` 0 errors
- [ ] After deploy: re-upload 128 MB PDF to a Voys "Chemie" KB and verify status transitions `processing → ingesting → done`

🤖 Generated with [Claude Code](https://claude.com/claude-code)