### PR TITLE
fix(kb): show processing file uploads as sources

### DIFF
--- a/klai-portal/backend/app/api/app_knowledge_bases.py
+++ b/klai-portal/backend/app/api/app_knowledge_bases.py
@@ -21,6 +21,7 @@ from app.core.permissions import UserPermissions, get_caller
 from app.core.profiles import Capability
 from app.models.connectors import PortalConnector
 from app.models.groups import PortalGroup
+from app.models.kb_uploads import KBUpload
 from app.models.knowledge_bases import PortalGroupKBAccess, PortalKnowledgeBase, PortalUserKBAccess
 from app.models.portal import PortalUser
 from app.models.retrieval_gaps import PortalRetrievalGap
@@ -31,6 +32,7 @@ from app.services.zitadel import zitadel
 
 logger = structlog.get_logger()
 _QDRANT_COLLECTION = "klai_knowledge"
+_VISIBLE_UPLOAD_STATUSES: tuple[str, ...] = ("processing", "ingesting", "failed")
 
 
 async def _get_non_system_group_or_404(group_id: int, org_id: int, db: AsyncSession) -> PortalGroup:
@@ -400,6 +402,21 @@ async def knowledge_bases_stats_summary(
         if slug is not None:
             connectors_by_slug[slug] = count
 
+    uploads_result = await db.execute(
+        select(KBUpload.kb_id, func.count(KBUpload.id))
+        .where(
+            KBUpload.org_id == org.id,
+            KBUpload.kb_id.in_(kb_ids),
+            KBUpload.status.in_(_VISIBLE_UPLOAD_STATUSES),
+        )
+        .group_by(KBUpload.kb_id)
+    )
+    visible_uploads_by_slug: dict[str, int] = {}
+    for kb_id, count in uploads_result.all():
+        slug = slug_by_id.get(kb_id)
+        if slug is not None:
+            visible_uploads_by_slug[slug] = count
+
     # Open gaps per KB in the last 7 days (best-effort via nearest_kb_slug).
     gaps_result = await db.execute(
         select(PortalRetrievalGap.nearest_kb_slug, func.count(PortalRetrievalGap.id))
@@ -471,7 +488,7 @@ async def knowledge_bases_stats_summary(
         # bronnen = distinct connector_ids + direct upload artifacts (from
         # knowledge-ingest). Fall back to portal_connectors count when the
         # ingest call failed and we have no aggregate data.
-        bronnen_count = bronnen_by_slug.get(kb.slug, connectors_count)
+        bronnen_count = bronnen_by_slug.get(kb.slug, connectors_count) + visible_uploads_by_slug.get(kb.slug, 0)
         stats[kb.slug] = KBStatsSummary(
             items=items_count,
             connectors=connectors_count,
@@ -1087,6 +1104,30 @@ async def list_kb_bronnen(
                 chunks_count=int(upload.get("chunks_count") or 0),
                 status=None,
                 created_at=created_at_dt,
+            )
+        )
+
+    upload_rows_result = await db.execute(
+        select(KBUpload)
+        .where(
+            KBUpload.org_id == org.id,
+            KBUpload.kb_id == kb.id,
+            KBUpload.status.in_(_VISIBLE_UPLOAD_STATUSES),
+        )
+        .order_by(KBUpload.created_at.desc())
+    )
+    for upload in upload_rows_result.scalars().all():
+        bronnen.append(
+            BronOut(
+                kind="upload",
+                id=str(upload.id),
+                name=upload.filename,
+                type_label=_upload_type_label(upload.mime or upload.extension),
+                connector_type=None,
+                items_count=1,
+                chunks_count=0,
+                status=upload.status,
+                created_at=upload.created_at,
             )
         )
 

--- a/klai-portal/backend/app/api/app_knowledge_sources.py
+++ b/klai-portal/backend/app/api/app_knowledge_sources.py
@@ -29,10 +29,11 @@ from urllib.parse import urlparse
 
 import httpx
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.datastructures import UploadFile
 
 from app.api.dependencies import _load_org_or_500
 from app.core.database import get_db
@@ -617,6 +618,11 @@ async def add_file_source(
     (Caddy then logs "use of closed network connection" → 502). We
     raise the cap to ``MAX_BINARY_FILE_BYTES + 4 KiB`` so a 200 MB
     member uploads cleanly.
+
+    NOTE: the ``UploadFile`` type used in the ``isinstance`` filter MUST
+    come from ``starlette.datastructures`` — ``fastapi.UploadFile`` is a
+    subclass, so ``isinstance(starlette_obj, fastapi.UploadFile)`` returns
+    ``False`` and silently filters every parsed file out of the list.
     """
     # Override Starlette's 1 MB default per-part cap. Adding 4 KiB
     # accounts for the multipart envelope (boundary, headers, CRLFs).

--- a/klai-portal/backend/tests/test_app_knowledge_bases_stats_summary.py
+++ b/klai-portal/backend/tests/test_app_knowledge_bases_stats_summary.py
@@ -1,0 +1,63 @@
+"""Tests for the app KB stats-summary endpoint."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tests.conftest import make_perms
+
+
+def _make_perms() -> object:
+    return make_perms(role="admin", user_id="user-1", org_id=1)
+
+
+def _result_all(rows: list[object]) -> MagicMock:
+    result = MagicMock()
+    result.all.return_value = rows
+    return result
+
+
+def _result_scalars(rows: list[object]) -> MagicMock:
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = rows
+    return result
+
+
+@pytest.mark.asyncio
+async def test_stats_summary_counts_processing_uploads_before_ingest_artifact_exists() -> None:
+    """A 202-accepted upload must count as a bron while docling is processing."""
+
+    from app.api.app_knowledge_bases import knowledge_bases_stats_summary
+
+    org = MagicMock()
+    org.id = 1
+    org.zitadel_org_id = "zitadel-org-1"
+
+    kb = MagicMock()
+    kb.id = 42
+    kb.slug = "chemie"
+
+    db = AsyncMock()
+    db.execute.side_effect = [
+        _result_scalars([kb]),  # visible KBs
+        _result_all([]),  # portal connectors
+        _result_all([(42, 1)]),  # visible kb_uploads rows
+        _result_all([]),  # retrieval gaps
+        _result_all([]),  # usage rows
+    ]
+
+    with (
+        patch("app.api.app_knowledge_bases._load_org_or_500", new=AsyncMock(return_value=org)),
+        patch("app.api.app_knowledge_bases._qdrant_count_for_kb", new=AsyncMock(return_value=0)),
+        patch(
+            "app.api.app_knowledge_bases.knowledge_ingest_client.get_chunks_summary",
+            new=AsyncMock(return_value=({}, {"chemie": 0})),
+        ),
+    ):
+        result = await knowledge_bases_stats_summary(perms=_make_perms(), db=db)
+
+    stats = result.stats["chemie"]
+    assert stats.bronnen == 1
+    assert stats.chunks == 0

--- a/klai-portal/backend/tests/test_app_knowledge_bronnen.py
+++ b/klai-portal/backend/tests/test_app_knowledge_bronnen.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
 
 import pytest
 from fastapi import HTTPException
@@ -94,6 +95,29 @@ def _make_connector(cid: str, ctype: str = "notion", name: str | None = "My Noti
     return c
 
 
+def _make_upload(filename: str = "Chemie Overal 4VWO.pdf", status: str = "processing") -> MagicMock:
+    upload = MagicMock()
+    upload.id = uuid4()
+    upload.kb_id = 42
+    upload.org_id = 1
+    upload.filename = filename
+    upload.extension = ".pdf"
+    upload.mime = "application/pdf"
+    upload.status = status
+    upload.created_at = datetime(2026, 5, 10, tzinfo=UTC)
+    return upload
+
+
+def _make_sources_db(connectors: list[MagicMock], uploads: list[MagicMock] | None = None) -> AsyncMock:
+    db = AsyncMock()
+    conn_query_result = MagicMock()
+    conn_query_result.scalars.return_value.all.return_value = connectors
+    upload_query_result = MagicMock()
+    upload_query_result.scalars.return_value.all.return_value = uploads or []
+    db.execute.side_effect = [conn_query_result, upload_query_result]
+    return db
+
+
 @pytest.mark.asyncio
 async def test_list_kb_bronnen_merges_connectors_and_uploads() -> None:
     """Happy path: 1 connector with items, 1 connector with no items, 1 upload."""
@@ -104,11 +128,7 @@ async def test_list_kb_bronnen_merges_connectors_and_uploads() -> None:
     conn_with_items = _make_connector("conn-1", "notion", "Productdocs")
     conn_empty = _make_connector("conn-2", "github", "Mono-repo", status="pending")
 
-    db = AsyncMock()
-    # First db.execute returns the PortalConnector list
-    conn_query_result = MagicMock()
-    conn_query_result.scalars.return_value.all.return_value = [conn_with_items, conn_empty]
-    db.execute.return_value = conn_query_result
+    db = _make_sources_db([conn_with_items, conn_empty])
 
     aggregates = {
         "connectors": [
@@ -177,10 +197,7 @@ async def test_list_kb_bronnen_handles_orphan_connector_id() -> None:
     org = _make_org()
     kb = _make_kb()
 
-    db = AsyncMock()
-    conn_query_result = MagicMock()
-    conn_query_result.scalars.return_value.all.return_value = []  # no portal connectors
-    db.execute.return_value = conn_query_result
+    db = _make_sources_db([])
 
     aggregates = {
         "connectors": [
@@ -225,10 +242,7 @@ async def test_list_kb_bronnen_falls_back_to_empty_on_ingest_failure() -> None:
     kb = _make_kb()
     conn = _make_connector("conn-1", "notion", "Productdocs")
 
-    db = AsyncMock()
-    conn_query_result = MagicMock()
-    conn_query_result.scalars.return_value.all.return_value = [conn]
-    db.execute.return_value = conn_query_result
+    db = _make_sources_db([conn])
 
     with (
         patch(
@@ -255,6 +269,47 @@ async def test_list_kb_bronnen_falls_back_to_empty_on_ingest_failure() -> None:
     assert result.bronnen[0].id == "conn-1"
     assert result.bronnen[0].items_count == 0
     assert result.bronnen[0].chunks_count == 0
+
+
+@pytest.mark.asyncio
+async def test_list_kb_bronnen_includes_processing_uploads_before_ingest_artifact_exists() -> None:
+    """A 202-accepted file must be visible while docling is still processing."""
+
+    from app.api.app_knowledge_bases import list_kb_bronnen
+
+    org = _make_org()
+    kb = _make_kb()
+    upload = _make_upload()
+    db = _make_sources_db([], [upload])
+
+    with (
+        patch(
+            "app.api.app_knowledge_bases._load_org_or_500",
+            new=AsyncMock(return_value=org),
+        ),
+        patch(
+            "app.api.app_knowledge_bases._get_kb_or_404",
+            new=AsyncMock(return_value=kb),
+        ),
+        patch(
+            "app.api.app_knowledge_bases.knowledge_ingest_client.get_kb_sources",
+            new=AsyncMock(return_value={"connectors": [], "uploads": []}),
+        ),
+    ):
+        result = await list_kb_bronnen(
+            kb_slug="kb-a",
+            perms=_make_perms(),
+            db=db,
+        )
+
+    assert len(result.bronnen) == 1
+    bron = result.bronnen[0]
+    assert bron.kind == "upload"
+    assert bron.name == "Chemie Overal 4VWO.pdf"
+    assert bron.type_label == "PDF"
+    assert bron.items_count == 1
+    assert bron.chunks_count == 0
+    assert bron.status == "processing"
 
 
 # -- get_bron_content -------------------------------------------------------

--- a/klai-portal/backend/tests/test_app_knowledge_sources_file.py
+++ b/klai-portal/backend/tests/test_app_knowledge_sources_file.py
@@ -24,8 +24,9 @@ from contextlib import ExitStack
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from fastapi import HTTPException, UploadFile
-from starlette.datastructures import Headers
+from fastapi import HTTPException
+from starlette.datastructures import Headers, UploadFile
+from starlette.requests import Request
 
 from app.services.docling_client import DoclingError, DoclingSubmitResult
 from app.services.kb_uploads_repo import (
@@ -130,6 +131,41 @@ def _make_request(files: list[UploadFile]) -> MagicMock:
     request = MagicMock()
     request.form = AsyncMock(return_value=FormData(form_items))
     return request
+
+
+def _make_multipart_request(filename: str, content: bytes, content_type: str) -> Request:
+    """Build a real Starlette Request so request.form() creates UploadFile."""
+
+    boundary = "----klai-test-boundary"
+    body = (
+        f"--{boundary}\r\n"
+        f'Content-Disposition: form-data; name="files"; filename="{filename}"\r\n'
+        f"Content-Type: {content_type}\r\n"
+        "\r\n"
+    ).encode() + content + f"\r\n--{boundary}--\r\n".encode()
+    chunks = [body[i : i + 64 * 1024] for i in range(0, len(body), 64 * 1024)]
+
+    async def receive() -> dict[str, object]:
+        if chunks:
+            return {
+                "type": "http.request",
+                "body": chunks.pop(0),
+                "more_body": bool(chunks),
+            }
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/",
+            "headers": [
+                (b"content-type", f"multipart/form-data; boundary={boundary}".encode()),
+                (b"content-length", str(len(body)).encode("ascii")),
+            ],
+        },
+        receive,
+    )
 
 
 class _FilePatches:
@@ -321,6 +357,29 @@ class TestDoclingPipeline:
         kwargs = patches.mock_create_upload.call_args.kwargs
         assert kwargs["status"] == STATUS_PROCESSING
         assert kwargs["docling_task_id"] == "docling-task-xyz"
+
+    @pytest.mark.asyncio
+    async def test_real_starlette_multipart_pdf_is_accepted(self) -> None:
+        """Regression: request.form() returns Starlette UploadFile instances."""
+
+        from app.api.app_knowledge_sources import add_file_source
+
+        kb = _make_kb()
+        db = _make_db_mock(kb)
+        content = _TINY_PDF + (b"0" * (2 * 1024 * 1024))
+        request = _make_multipart_request("chemie.pdf", content, "application/pdf")
+
+        with _FilePatches(docling_task_id="docling-task-real-form") as patches:
+            resp = await add_file_source(kb_slug="personal", request=request, perms=_make_perms(), db=db)
+
+        assert len(resp.uploads) == 1
+        assert resp.uploads[0].status == "processing"
+        assert resp.uploads[0].filename == "chemie.pdf"
+        assert patches.mock_docling is not None
+        kwargs = patches.mock_docling.call_args.kwargs
+        assert kwargs["filename"] == "chemie.pdf"
+        assert kwargs["content"] == content
+        assert kwargs["content_type"] == "application/pdf"
 
     @pytest.mark.asyncio
     async def test_mime_mismatch_skipped_no_docling_call(self) -> None:

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/bronnen.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/bronnen.tsx
@@ -86,12 +86,13 @@ interface ContentResponse {
 type Status = 'synced' | 'pending' | 'not_synced'
 
 function mapStatus(bron: Bron): Status {
+  const s = (bron.status ?? '').toLowerCase()
   if (bron.kind === 'upload') {
-    // Uploads are one-shot: if it's in /sources, ingestion finished.
+    if (s === 'processing' || s === 'ingesting') return 'pending'
+    if (s === 'failed' || s.includes('error')) return 'not_synced'
     return 'synced'
   }
   // Connector — last_sync_status is the source of truth.
-  const s = (bron.status ?? '').toLowerCase()
   if (s === 'running' || s === 'pending' || s === 'syncing') return 'pending'
   if (s.includes('error') || s.includes('failed') || s === 'auth_error' || s === 'orphan') {
     return 'not_synced'


### PR DESCRIPTION
## What changed
- Count portal-side `kb_uploads` rows with `processing`, `ingesting`, or `failed` as visible bronnen in the KB list stats.
- Include those same upload rows in the KB Bronnen endpoint before knowledge-ingest has created an artifact.
- Show processing/ingesting upload rows as `Bezig` in the Bronnen tab instead of hiding them.
- Add regression coverage for the real Starlette multipart `UploadFile` path and for processing uploads appearing as bronnen.

## Why
A large PDF upload returned `202 Accepted` and persisted a `kb_uploads` row, but the Knowledge overview still showed `0 sources · 0 chunks` because stats and sources only looked at knowledge-ingest artifacts. While docling was still processing, the accepted file was invisible to the user.

## Validation
- `uv run pytest tests/test_app_knowledge_bronnen.py tests/test_app_knowledge_bases_stats_summary.py tests/test_app_knowledge_sources_file.py tests/test_file_upload.py -q`
- `uv run ruff check app/api/app_knowledge_bases.py tests/test_app_knowledge_bronnen.py tests/test_app_knowledge_bases_stats_summary.py tests/test_app_knowledge_sources_file.py`
- `npm run build`
