### PR TITLE
fix(kb): finish docling uploads after polling

### DIFF
--- a/klai-portal/backend/app/services/docling_client.py
+++ b/klai-portal/backend/app/services/docling_client.py
@@ -84,6 +84,10 @@ class DoclingTimeoutError(DoclingError):
     """Raised when docling-serve does not respond within the HTTP timeout."""
 
 
+class DoclingResultNotFoundError(DoclingError):
+    """Raised when docling-serve no longer has a completed task result."""
+
+
 # Submission timeout: docling-serve buffers the upload to disk before
 # returning the task_id. For a 200 MB file this can take 20-30 s on
 # the existing pipe; 60 s gives plenty of headroom without holding the
@@ -218,6 +222,8 @@ async def get_result_markdown(task_id: str) -> str:
             task_id=task_id,
             status=exc.response.status_code,
         )
+        if exc.response.status_code == 404:
+            raise DoclingResultNotFoundError(f"docling result not found for {task_id}") from exc
         raise DoclingError(f"docling result returned {exc.response.status_code}") from exc
     except httpx.RequestError as exc:
         logger.exception("docling_result_request_error", task_id=task_id)

--- a/klai-portal/backend/app/services/kb_upload_poller.py
+++ b/klai-portal/backend/app/services/kb_upload_poller.py
@@ -148,6 +148,15 @@ async def _process_ingesting_row(view: KBUploadView) -> None:
 
     try:
         markdown = await docling_client.get_result_markdown(view.docling_task_id)
+    except docling_client.DoclingResultNotFoundError:
+        logger.exception(
+            "kb_upload_ingesting_result_not_found",
+            upload_id=str(view.id),
+        )
+        async with tenant_scoped_session(view.org_id) as db:
+            await kb_uploads_repo.mark_failed(db, upload_id=view.id, failure_reason="docling_result_not_found")
+            await db.commit()
+        return
     except docling_client.DoclingError:
         logger.exception(
             "kb_upload_ingesting_result_fetch_failed",
@@ -175,7 +184,19 @@ async def _ingest_and_finish(view: KBUploadView, *, markdown: str) -> None:
         org_result = await db.execute(select(PortalOrg).where(PortalOrg.id == view.org_id))
         org = org_result.scalar_one_or_none()
 
-    if kb is None or org is None:
+        if kb is None or org is None:
+            kb_slug = None
+            kb_name = None
+            org_zitadel_id = None
+        else:
+            # Copy ORM-backed values while the session is still open. The
+            # session context commits on exit, which expires attributes; using
+            # ORM instances afterwards can raise DetachedInstanceError.
+            kb_slug = kb.slug
+            kb_name = kb.name
+            org_zitadel_id = org.zitadel_org_id
+
+    if kb_slug is None or kb_name is None or org_zitadel_id is None:
         logger.error(
             "kb_upload_ingest_kb_or_org_missing",
             upload_id=str(view.id),
@@ -189,15 +210,15 @@ async def _ingest_and_finish(view: KBUploadView, *, markdown: str) -> None:
 
     title = file_upload.derive_title(view.filename, view.extension)
     payload: dict[str, object] = {
-        "org_id": org.zitadel_org_id,
-        "kb_slug": kb.slug,
+        "org_id": org_zitadel_id,
+        "kb_slug": kb_slug,
         "path": view.source_ref,
         "content": markdown,
         "title": title,
         "source_type": "file",
         "content_type": "document",
         "source_ref": view.source_ref,
-        "kb_name": kb.name,
+        "kb_name": kb_name,
         "extra": {
             "original_filename": view.filename,
             "extension": view.extension,
@@ -214,7 +235,7 @@ async def _ingest_and_finish(view: KBUploadView, *, markdown: str) -> None:
         logger.exception(
             "kb_upload_ingest_forward_failed",
             upload_id=str(view.id),
-            kb_slug=kb.slug,
+            kb_slug=kb_slug,
         )
         # Stay at ingesting — knowledge-ingest may be transiently down.
         # Operator alert catches rows stuck > N minutes.
@@ -227,7 +248,7 @@ async def _ingest_and_finish(view: KBUploadView, *, markdown: str) -> None:
         "kb_upload_done",
         upload_id=str(view.id),
         artifact_id=artifact_id,
-        kb_slug=kb.slug,
+        kb_slug=kb_slug,
         bytes=view.bytes,
     )
 

--- a/klai-portal/backend/tests/test_kb_upload_poller.py
+++ b/klai-portal/backend/tests/test_kb_upload_poller.py
@@ -19,6 +19,7 @@ from app.services import kb_upload_poller
 from app.services.docling_client import (
     DoclingError,
     DoclingPollResult,
+    DoclingResultNotFoundError,
     DoclingTaskStatus,
     DoclingTimeoutError,
 )
@@ -180,6 +181,46 @@ class _PollerPatches:
         return org
 
 
+class _SessionBoundValue:
+    """Object that raises when accessed after the fake DB session closes."""
+
+    def __init__(self, value: str, closed: dict[str, bool]) -> None:
+        self.value = value
+        self.closed = closed
+
+    def get(self) -> str:
+        if self.closed["value"]:
+            raise RuntimeError("attribute accessed after session closed")
+        return self.value
+
+
+class _SessionBoundKB:
+    id = 42
+
+    def __init__(self, closed: dict[str, bool]) -> None:
+        self._slug = _SessionBoundValue("chemie", closed)
+        self._name = _SessionBoundValue("Chemie", closed)
+
+    @property
+    def slug(self) -> str:
+        return self._slug.get()
+
+    @property
+    def name(self) -> str:
+        return self._name.get()
+
+
+class _SessionBoundOrg:
+    id = 1
+
+    def __init__(self, closed: dict[str, bool]) -> None:
+        self._zitadel_org_id = _SessionBoundValue("zitadel-org-1", closed)
+
+    @property
+    def zitadel_org_id(self) -> str:
+        return self._zitadel_org_id.get()
+
+
 # ---- Processing-state transitions -----------------------------------------
 
 
@@ -316,6 +357,58 @@ class TestIngestingState:
         # No terminal transition — row stays ingesting for next tick.
         patches.mock_mark_failed.assert_not_called()  # type: ignore[union-attr]
         patches.mock_mark_done.assert_not_called()  # type: ignore[union-attr]
+
+    @pytest.mark.asyncio
+    async def test_missing_docling_result_marks_failed(self) -> None:
+        view = _view(status=STATUS_INGESTING)
+        with _PollerPatches(
+            result_side_effect=DoclingResultNotFoundError("gone"),
+        ) as patches:
+            await kb_upload_poller._process_ingesting_row(view)
+
+        patches.mock_mark_failed.assert_called_once()  # type: ignore[union-attr]
+        kwargs = patches.mock_mark_failed.call_args.kwargs  # type: ignore[union-attr]
+        assert kwargs["failure_reason"] == "docling_result_not_found"
+        patches.mock_mark_done.assert_not_called()  # type: ignore[union-attr]
+
+    @pytest.mark.asyncio
+    async def test_ingest_copies_kb_and_org_values_before_session_closes(self) -> None:
+        """Regression for production DetachedInstanceError on org.zitadel_org_id."""
+
+        view = _view(status=STATUS_INGESTING)
+        closed = {"value": False}
+        kb = _SessionBoundKB(closed)
+        org = _SessionBoundOrg(closed)
+
+        async def _execute_stub(stmt, *args, **kwargs):
+            text_repr = str(stmt).lower()
+            result = MagicMock()
+            if "portal_knowledge_bases" in text_repr:
+                result.scalar_one_or_none = MagicMock(return_value=kb)
+            elif "portal_orgs" in text_repr:
+                result.scalar_one_or_none = MagicMock(return_value=org)
+            else:
+                result.scalar_one_or_none = MagicMock(return_value=None)
+            return result
+
+        @asynccontextmanager
+        async def _scoped(_org_id: int):
+            db = AsyncMock()
+            db.execute.side_effect = _execute_stub
+            yield db
+            closed["value"] = True
+
+        with _PollerPatches(markdown="# retry", ingest_artifact="art-retry") as patches:
+            patches.stack.enter_context(patch("app.services.kb_upload_poller.tenant_scoped_session", _scoped))
+
+            await kb_upload_poller._process_ingesting_row(view)
+
+        patches.mock_ingest.assert_called_once()  # type: ignore[union-attr]
+        payload = patches.mock_ingest.call_args.args[0]  # type: ignore[union-attr]
+        assert payload["org_id"] == "zitadel-org-1"
+        assert payload["kb_slug"] == "chemie"
+        assert payload["kb_name"] == "Chemie"
+        patches.mock_mark_done.assert_called_once()  # type: ignore[union-attr]
 
 
 # ---- Loop wrapper ---------------------------------------------------------


### PR DESCRIPTION
## Summary
- copy knowledge base/org values while the DB session is still open before starting ingestion
- treat missing Docling task results as terminal upload failures instead of retrying forever
- add regression tests for detached session access and missing Docling results

## Production finding
The Voys Chemie PDF upload reached Docling successfully, then failed in the portal poller with SQLAlchemy DetachedInstanceError because _ingest_and_finish accessed org/kb ORM attributes after tenant_scoped_session had closed. Later retries could no longer fetch the Docling result, which is why the upload stayed stuck with 0 files / 0 chunks.

## Validation
- cd klai-portal/backend && uv run pytest tests/test_kb_upload_poller.py -q
- cd klai-portal/backend && uv run pytest tests/test_kb_upload_poller.py tests/test_app_knowledge_bronnen.py tests/test_app_knowledge_bases_stats_summary.py tests/test_app_knowledge_sources_file.py tests/test_file_upload.py -q
- cd klai-portal/backend && uv run pyright app/services/kb_upload_poller.py app/services/docling_client.py tests/test_kb_upload_poller.py
- cd klai-portal/backend && uv run ruff check .
- cd klai-portal/backend && uv run ruff format --check .

After merge/deploy I will re-upload /Users/mvletter/Downloads/Chemie Overal 4VWO.pdf on voys.getklai.com and verify the source opens with indexed chunks.