### PR TITLE
fix(kb): prevent docling embedded image bloat

### DIFF
--- a/klai-portal/backend/app/services/docling_client.py
+++ b/klai-portal/backend/app/services/docling_client.py
@@ -24,6 +24,7 @@ portal-api dep.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any
@@ -101,6 +102,14 @@ _STATUS_TIMEOUT_S: float = 5.0
 # this can be several MB of JSON. 30 s covers slow links.
 _RESULT_TIMEOUT_S: float = 30.0
 
+# Docling Serve defaults ``image_export_mode`` to ``embedded`` for Markdown,
+# which can put base64 PNGs directly in md_content. A 129 MB textbook produced
+# ~491 MB of markdown that exceeded knowledge-ingest's request schema. For RAG
+# ingestion, image placeholders are enough; OCR text remains in the markdown.
+_IMAGE_EXPORT_MODE = "placeholder"
+_IMAGE_PLACEHOLDER = "<!-- image -->"
+_EMBEDDED_DATA_IMAGE_RE = re.compile(r"!\[[^\]]*\]\(data:image/[^)]*;base64,[^)]+\)")
+
 
 def _client(timeout_s: float) -> httpx.AsyncClient:
     """Build an httpx client pointed at the configured docling-serve URL."""
@@ -133,7 +142,10 @@ async def submit_file_async(
     # encodes a sequence value as repeated fields under the same key, so
     # ``{"to_formats": ["md", "html"]}`` becomes ``to_formats=md&to_formats=html``
     # on the wire — matching the multi-value semantics docling expects.
-    data: dict[str, list[str]] = {"to_formats": list(to_formats)}
+    data: dict[str, object] = {
+        "to_formats": list(to_formats),
+        "image_export_mode": _IMAGE_EXPORT_MODE,
+    }
 
     try:
         async with _client(_SUBMIT_TIMEOUT_S) as client:
@@ -232,6 +244,20 @@ async def get_result_markdown(task_id: str) -> str:
     return _extract_markdown(payload, task_id)
 
 
+def _strip_embedded_images(markdown: str, task_id: str) -> str:
+    """Replace embedded base64 image markdown with a stable placeholder."""
+    stripped, count = _EMBEDDED_DATA_IMAGE_RE.subn(_IMAGE_PLACEHOLDER, markdown)
+    if count:
+        logger.info(
+            "docling_markdown_embedded_images_stripped",
+            task_id=task_id,
+            images=count,
+            original_chars=len(markdown),
+            stripped_chars=len(stripped),
+        )
+    return stripped
+
+
 def _extract_markdown(payload: Any, task_id: str) -> str:
     """Pull the ``md_content`` field from a single-document response.
 
@@ -250,4 +276,4 @@ def _extract_markdown(payload: Any, task_id: str) -> str:
         raise DoclingError(
             f"docling produced no markdown for {task_id} (status={status}, errors={errors!r})",
         )
-    return md
+    return _strip_embedded_images(md, task_id)

--- a/klai-portal/backend/tests/test_docling_client.py
+++ b/klai-portal/backend/tests/test_docling_client.py
@@ -1,0 +1,59 @@
+"""Unit tests for the docling-serve client."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.services import docling_client
+
+
+class _Response:
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, str]:
+        return {"task_id": "task-123", "task_status": "pending"}
+
+
+class _AsyncClient:
+    def __init__(self) -> None:
+        self.data: dict[str, object] | None = None
+
+    async def __aenter__(self) -> _AsyncClient:
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        return None
+
+    async def post(self, path: str, *, files: Any, data: dict[str, object]) -> _Response:
+        self.data = data
+        return _Response()
+
+
+def test_extract_markdown_strips_embedded_data_images() -> None:
+    payload = {
+        "document": {"md_content": ("Intro\n\n![Image](data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==)\n\nOutro")}
+    }
+
+    markdown = docling_client._extract_markdown(payload, "task-123")
+
+    assert "data:image" not in markdown
+    assert markdown == "Intro\n\n<!-- image -->\n\nOutro"
+
+
+@pytest.mark.asyncio
+async def test_submit_file_async_requests_placeholder_images(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_client = _AsyncClient()
+    monkeypatch.setattr(docling_client, "_client", lambda _timeout_s: fake_client)
+
+    await docling_client.submit_file_async(
+        filename="chemie.pdf",
+        content=b"%PDF",
+        content_type="application/pdf",
+    )
+
+    assert fake_client.data is not None
+    assert fake_client.data["to_formats"] == ["md"]
+    assert fake_client.data["image_export_mode"] == "placeholder"


### PR DESCRIPTION
## Summary
- request Docling Markdown with image_export_mode=placeholder instead of the default embedded mode
- strip existing embedded data:image base64 markdown before forwarding a Docling result to knowledge-ingest
- add docling client regression tests

## Production finding
The fresh Voys Chemie upload completed Docling successfully, then portal-api forwarded markdown to knowledge-ingest and received 422. Production Docling result for task 2f9df563-0951-428f-9c36-0264dffcb84d was about 491 MB because Markdown contained 518 embedded base64 images. knowledge-ingest IngestRequest.content has max_length=500_000, so the request was schema-rejected before chunking.

Docling Serve OpenAPI for /v1/convert/file/async shows image_export_mode supports placeholder, embedded, referenced and defaults to embedded. For RAG ingestion we need OCR/text, not base64 PNG payloads.

## Validation
- cd klai-portal/backend && uv run pytest tests/test_docling_client.py tests/test_kb_upload_poller.py tests/test_app_knowledge_sources_file.py tests/test_app_knowledge_bronnen.py tests/test_app_knowledge_bases_stats_summary.py tests/test_file_upload.py -q
- cd klai-portal/backend && uv run pyright app/services/docling_client.py tests/test_docling_client.py
- cd klai-portal/backend && uv run ruff check .
- cd klai-portal/backend && uv run ruff format --check .

After deploy I will keep the current Voys upload 6d412fe1-d8ea-41a9-a8d6-e7d6c49067c5 running; it should recover by re-fetching the existing Docling result, stripping embedded images, and completing ingestion.