### PR TITLE
Use Docling chunks for KB file ingest

### DIFF
--- a/.moai/specs/SPEC-KB-FILE-UPLOAD-001/spec.md
+++ b/.moai/specs/SPEC-KB-FILE-UPLOAD-001/spec.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-KB-FILE-UPLOAD-001
 title: KB File Upload via docling-serve
-version: 0.1.0
+version: 0.2.0
 status: draft
 created_at: 2026-05-10
 owner: mark.vletter
@@ -22,6 +22,7 @@ related_specs:
 
 | Date       | Version | Author        | Note                                         |
 |------------|---------|---------------|----------------------------------------------|
+| 2026-05-11 | 0.2.0   | codex         | Align live design with Docling Serve async chunk endpoints, pre-chunked ingest, and result lifecycle requirements. |
 | 2026-05-10 | 0.1.0   | mark.vletter  | Initial draft. Phase 1-4 plan, EARS REQ-1..9 |
 
 ---
@@ -36,8 +37,10 @@ chunks in Qdrant + Postgres via the existing chunk → embed → graph pipeline.
 
 ### Outcome (success measured by)
 
-- Uploading a 100 MB PDF via the KB UI produces ≥ 100 retrievable chunks within
-  60 seconds end-to-end on production hardware.
+- Uploading a large structured document via the KB UI produces retrievable
+  chunks without exceeding the `knowledge-ingest` `IngestRequest.content`
+  bound. The 129 MB Chemie Overal 4VWO PDF is the production regression
+  fixture for this path.
 - The current `500: 500` failure on `/app/knowledge/<kb>/add-source` for
   non-`.md` files is gone; failure responses are structured with a
   machine-readable `error_code`.
@@ -73,13 +76,23 @@ file-upload endpoint** today. `app_knowledge_sources.py` has only `url`,
 `text`, and a deprecated `youtube` stub.
 
 `docling-serve v1.16.1` is already deployed (`deploy/docker-compose.yml:783`)
-on the internal `klai-net` and accepts every required binary format via
-`POST /v1/convert/file` and `POST /v1/chunk/hybrid/file`. The
+on the internal `klai-net` and accepts every required document format via
+`POST /v1/convert/file`, `POST /v1/chunk/hybrid/file`, and their async
+variants. The
 architecture document (`docs/architecture/klai-knowledge-architecture.md`)
 already describes the intended shape (`klai-connector file upload endpoint`)
 but the endpoint was never built — the design predates `SPEC-DECOMM-FOCUS-001`
 and the docling integration in `klai-focus/research-api/services/docling.py`
 was decommissioned with the rest of klai-focus.
+
+Production testing on 2026-05-11 showed why Docling must be treated as a
+generic conversion and chunking product, not as a PDF-to-Markdown helper:
+a 129 MB PDF converted through `/v1/convert/file/async` yielded about 491 MB
+of Markdown because images were embedded as base64. Switching only
+`image_export_mode=placeholder` avoided the image explosion but still kept the
+pipeline dependent on one oversized `content` field and on Docling's default
+single-use result storage. The live path therefore uses Docling Serve's async
+chunk endpoint and forwards Docling chunks directly to `knowledge-ingest`.
 
 ---
 
@@ -141,43 +154,52 @@ portal-api  POST /api/app/knowledge-bases/{kb_slug}/sources/file
   │     d. content-addressed S3 write to garage://klai-documents/<sha256>
   │     e. INSERT INTO kb_uploads (artifact_id, s3_key, bytes, mime, status='pending')
   │     f. emit knowledge.uploaded event per artifact
-  │     g. POST http://knowledge-ingest:8000/ingest/v1/file
-  │        body: { artifact_id, org_id, kb_slug, s3_key, mime, bytes, filename }
-  │        headers: X-Internal-Secret + X-Caller-Service: portal-api + trace
+  │     g. text-path: POST http://knowledge-ingest:8000/ingest/v1/document
+  │        body: { org_id, kb_slug, path, content, source_type="file", ... }
+  │     h. docling-path:
+  │        POST http://docling-serve:5001/v1/chunk/hybrid/file/async
+  │        body: file + include_converted_doc=false
+  │              + convert_image_export_mode=placeholder
+  │              + convert_from_formats=<explicit Docling enum when known>
+  │        persist { status='processing', docling_task_id }
   │  4. return 202 { uploads: [...] }
   ▼
-knowledge-ingest  POST /ingest/v1/file        (Procrastinate enqueue → 202)
-  │
-  └── background job: process_file_upload(artifact_id)
-        │
-        ├── fetch from Garage (streaming GET via s3_key)
-        ├── route by mime:
-        │   ├── text-path  (.md .txt simple .csv non-schema .json non-schema .xml):
-        │   │     normalize-encoding → markdown_chunker
-        │   ├── docling-path (.pdf .docx .pptx .xlsx schema-.json schema-.xml):
-        │   │     POST docling-serve /v1/chunk/hybrid/file
-        │   │     → chunks with page_numbers, headings, num_tokens
-        │   └── doc-path (.doc, Phase 4 only):
-        │         POST libreoffice-headless /convert (doc → docx)
-        │         → docling-path
-        ├── embed BGE-M3 dense (TEI) + sparse (bge-m3-sparse)
-        ├── INSERT artifacts + parent_chunks + chunks (existing pg_store)
-        ├── upsert Qdrant vectors (existing index_chunks)
-        ├── Graphiti graph extraction (existing, GRAPHITI_ENABLED)
-        ├── emit kb_file_extracted event with chunks_count + duration_ms
-        └── update kb_uploads.status = 'done' | 'failed' + failure_reason
+portal-api kb_upload_poller
+  │ poll /v1/status/poll/{task_id}
+  │ on success: fetch /v1/result/{task_id}
+  │ normalize ChunkDocumentResponse.chunks[].text
+  │ build bounded content preview (≤ 450k chars)
+  │ POST /ingest/v1/document
+  │ body includes:
+  │   skip_chunking=true
+  │   chunks=[Docling chunk text...]
+  │   content=<bounded preview>
+  │   content_hash=<original file sha256>
+  ▼
+knowledge-ingest /ingest/v1/document
+  │ respects pre-computed chunks when skip_chunking=true
+  │ stores source hash from content_hash to dedupe the original file,
+  │ not the truncated preview
   ▼
 portal-api artifact-status polling                      (existing pattern)
 ```
 
 Data flow invariants:
 
-- `kb_uploads.s3_key` is the only durable pointer to the binary. The binary is
-  never copied to local disk.
-- The artifact_id chosen by portal-api is reused as the knowledge-ingest
-  artifact id — same UUID across services, matches existing trace pattern.
-- Magic-byte validation happens **once**, in portal-api, before the Garage
-  write. Downstream services trust the validated mime.
+- Docling is the structural parser and chunker for the docling path. Klai must
+  not reconstruct document chunks by walking a giant Markdown string when
+  Docling already returned typed chunks.
+- `IngestRequest.content` is bounded metadata/classification input for
+  pre-chunked Docling documents. The complete document text is represented by
+  `chunks[]`.
+- `content_hash` is the full original source hash for pre-chunked/truncated
+  ingests. Deduplication must not use the bounded preview body.
+- Docling results are volatile service state. The poller should fetch the
+  terminal result once and ingest it immediately; production also configures
+  Docling with non-single-use results and a longer result TTL for restart and
+  retry tolerance.
+- Magic-byte validation happens **once**, in portal-api. Downstream services
+  trust the validated mime and explicit Docling input format.
 
 ---
 
@@ -191,6 +213,10 @@ Data flow invariants:
 | D-4 | Async UX | Poll-based artifact status (existing connector pattern). | WebSocket adds infra surface for marginal UX win; poll already works for connector syncs which have similar runtime. |
 | D-5 | Garage bucket policy | `klai-documents` is **private**, presigned-GET only, TTL 1 h. **Different from `kb-images`** which uses website-mode + Caddy reverse-proxy. | Documents may contain sensitive content (legal, HR). URL-guessing on a website-mode bucket leaks content. Presigned-GET requires authenticated portal-api session. |
 | D-6 | New table vs. extend | Extend knowledge-ingest artifacts via existing `extra` jsonb (add `source_kind: "file"`, `s3_key`, `original_filename`). New `kb_uploads` table on portal-api side for s3_key tracking + per-KB byte quota counter. | Existing artifacts table (with `source_connector_id` pattern) is the authoritative chunk system; mirroring that on portal-api would create dual-write. portal-api owns only what it needs to route status / quota. |
+| D-7 | Docling endpoint | Use `POST /v1/chunk/hybrid/file/async` for the docling path, not `/v1/convert/file/async`. | Docling Serve already exposes hybrid chunks with headings, page numbers, token counts and text. Using convert first creates oversized Markdown and loses the product's chunking semantics. |
+| D-8 | Converted document payload | Submit with `include_converted_doc=false` and `convert_image_export_mode=placeholder`. | RAG ingestion needs text chunks, not an embedded DoclingDocument or base64 image payloads. This keeps result and ingest payloads bounded. |
+| D-9 | Pre-chunked ingest contract | Forward Docling chunk text to `/ingest/v1/document` with `skip_chunking=true`, `chunks=[...]`, bounded `content`, and original file `content_hash`. | Prevents 422s from `content` max length, preserves Docling structure, and dedupes against the uploaded source instead of the preview. |
+| D-10 | Docling result lifecycle | Configure `DOCLING_SERVE_SINGLE_USE_RESULTS=false` and `DOCLING_SERVE_RESULT_REMOVAL_DELAY=86400`; still treat Docling results as volatile and ingest immediately after terminal success. | Docling Serve defaults are optimized for one client fetch. The portal poller may need retry tolerance after a transient `/ingest` failure or portal restart. Durable result storage in Klai remains a future hardening step. |
 
 ---
 
@@ -335,9 +361,19 @@ docling-path, or doc-path.
 | `application/msword` (.doc) — Phase 4 | doc → docling | `docx` after libreoffice |
 
 **Event-driven.** WHEN a file routes to docling-path, THE SYSTEM SHALL POST
-the binary to `http://docling-serve:5001/v1/chunk/hybrid/file` with the
-correct format parameter and `target_type=md` AND parse the chunked response
-into `(text, headings, page_numbers, num_tokens)` per chunk.
+the binary to `http://docling-serve:5001/v1/chunk/hybrid/file/async` with
+`include_converted_doc=false`, `convert_image_export_mode=placeholder`, and
+the correct explicit `convert_from_formats` value when the detected format
+maps to a Docling enum.
+
+**Event-driven.** WHEN Docling reports terminal success, THE SYSTEM SHALL fetch
+`/v1/result/{task_id}` once, parse `ChunkDocumentResponse.chunks[].text`, and
+forward those values to `knowledge-ingest` as `skip_chunking=true` and
+`chunks=[...]`.
+
+**Ubiquitous.** For docling-path uploads, the `content` field sent to
+`knowledge-ingest` SHALL be a bounded preview no larger than 450,000
+characters and `content_hash` SHALL be the original uploaded source hash.
 
 **Event-driven.** WHEN docling-serve returns non-2xx OR times out (≥ 600 s),
 THE SYSTEM SHALL mark the artifact `failed` with `failure_reason:
@@ -346,8 +382,8 @@ THE SYSTEM SHALL mark the artifact `failed` with `failure_reason:
 **Acceptance criteria:**
 - AC-4.1: `.md` upload produces chunks via the existing Markdown chunker
   (verified by absence of HTTP call to docling-serve in test).
-- AC-4.2: `.pdf` upload produces chunks via docling `/v1/chunk/hybrid/file`
-  with `format=pdf`.
+- AC-4.2: `.pdf` upload submits to docling
+  `/v1/chunk/hybrid/file/async` with `convert_from_formats=pdf`.
 - AC-4.3: A 5-page sample PDF produces ≥ 5 chunks each with non-null
   `page_numbers` payload field.
 - AC-4.4: An `.xml` file whose root local-name is `article` (JATS) routes
@@ -355,6 +391,12 @@ THE SYSTEM SHALL mark the artifact `failed` with `failure_reason:
 - AC-4.5 (Phase ≤ 3): `.doc` returns 400 `doc_format_not_yet_supported`.
 - AC-4.6 (Phase 4): `.doc` is converted via libreoffice-headless and
   produces docling chunks.
+- AC-4.7: The Chemie Overal 4VWO 129 MB PDF produces a `/ingest/v1/document`
+  request whose `content` is ≤ 450,000 chars, whose `chunks` array is non-empty,
+  and whose `skip_chunking` is true.
+- AC-4.8: The same Chemie upload does not produce HTTP 422 from
+  `knowledge-ingest` and never transitions from Docling success to
+  `docling_result_not_found`.
 
 ---
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -783,6 +783,12 @@ services:
   docling-serve:
     image: ghcr.io/docling-project/docling-serve:v1.16.1
     restart: unless-stopped
+    environment:
+      # Portal-api may need to retry /v1/result after a transient
+      # knowledge-ingest failure or restart. Docling Serve's defaults are
+      # single-use results, which are too fragile for our async poller.
+      DOCLING_SERVE_SINGLE_USE_RESULTS: "false"
+      DOCLING_SERVE_RESULT_REMOVAL_DELAY: "86400"
     networks:
       - klai-net
     # NOT exposed via Caddy — internal Docker network only

--- a/docs/runbooks/kb-file-upload.md
+++ b/docs/runbooks/kb-file-upload.md
@@ -15,14 +15,20 @@ Browser ──multipart 200 MB──▶ Caddy ──▶ portal-api
                                          │
                                          └─ docling path (.pdf/.docx/.pptx/.xlsx/.json/.xml)
                                              magic-byte validate
-                                             POST docling-serve /v1/convert/file/async
+                                             POST docling-serve /v1/chunk/hybrid/file/async
+                                             include_converted_doc=false
+                                             convert_image_export_mode=placeholder
                                              → kb_uploads.status=processing + docling_task_id
                                                    │
                                                    ▼
                                          portal-api kb_upload_poller (every 5 s)
                                              docling /v1/status/poll/{task_id}
-                                             → success: GET /v1/result → markdown
+                                             → success: GET /v1/result → chunks[].text
                                                         → /ingest/v1/document
+                                                          skip_chunking=true
+                                                          chunks=[...]
+                                                          content=<bounded preview>
+                                                          content_hash=<source sha256>
                                                         → kb_uploads.status=done
                                              → failure: kb_uploads.status=failed
                                          frontend polls
@@ -36,8 +42,8 @@ Browser ──multipart 200 MB──▶ Caddy ──▶ portal-api
 |---|---|
 | Caddy | `request_body { max_size 200MB }` on `^/api/app/knowledge-bases/[^/]+/sources/file$` |
 | portal-api | new `POST /api/app/knowledge-bases/{kb}/sources/file`, new `GET .../sources/file/{id}/status`, new `kb_uploads` table + cat-D RLS, `kb_upload_poller` background task |
-| docling-serve | unchanged — uses the existing v1.16.1 deployment on klai-net |
-| knowledge-ingest | unchanged — receives docling-derived markdown via the existing `/ingest/v1/document` endpoint |
+| docling-serve | v1.16.1 on klai-net; async hybrid chunk endpoint; non-single-use result retention configured for retry tolerance |
+| knowledge-ingest | receives either normal text content or Docling pre-computed chunks via the existing `/ingest/v1/document` endpoint |
 
 ## Deploy steps
 
@@ -74,7 +80,9 @@ Browser ──multipart 200 MB──▶ Caddy ──▶ portal-api
    ```
 
 4. **Smoke test.** Upload `sample.md` via the UI on a test KB. Then
-   upload a small PDF (5 pages). Watch:
+   upload a small PDF (5 pages). For the regression path, upload
+   `/Users/mvletter/Downloads/Chemie Overal 4VWO.pdf` to a fresh test KB
+   and watch it reach `done` with non-zero chunks.
 
    ```bash
    # Should show one done + one processing within seconds
@@ -128,6 +136,47 @@ SET status = 'failed', failure_reason = 'operator_recovery', updated_at = NOW()
 WHERE id = '<uuid>';
 ```
 
+### Docling success followed by `docling_result_not_found`
+
+This means portal-api observed terminal success but could not fetch the
+result later. Docling Serve defaults are single-use results with a short
+removal delay, so Klai production must run docling-serve with:
+
+```yaml
+DOCLING_SERVE_SINGLE_USE_RESULTS: "false"
+DOCLING_SERVE_RESULT_REMOVAL_DELAY: "86400"
+```
+
+Diagnose the live container environment:
+
+```bash
+ssh core-01 "docker exec klai-core-docling-serve-1 sh -c \
+    'env | grep DOCLING_SERVE_ | sort'"
+```
+
+If the variables are missing after a merge, redeploy the compose stack or
+recreate the docling-serve container. Existing failed upload rows cannot be
+recovered from Docling if the result was already removed; re-upload the source
+after fixing the environment.
+
+### knowledge-ingest returns HTTP 422 for a large document
+
+The docling path must not forward one giant converted document in
+`content`. The expected request shape to `/ingest/v1/document` is:
+
+```json
+{
+  "content": "<= 450000 chars preview",
+  "content_hash": "<original file sha256>",
+  "skip_chunking": true,
+  "chunks": ["Docling chunk text", "..."]
+}
+```
+
+If logs show `skip_chunking=false` or no `chunks`, the portal-api image is
+not running the Docling chunk pipeline. If `content` is larger than 500,000
+characters, the preview bound has regressed.
+
 ### portal-api container OOM during upload
 
 200 MB binary uploads land in Starlette's `SpooledTemporaryFile` which
@@ -153,6 +202,8 @@ VictoriaLogs queries:
 - `service:portal-api AND event:kb_upload_docling_failed` — failed docling tasks
 - `service:portal-api AND event:kb_upload_poll_docling_error` — poller couldn't reach docling
 - `service:portal-api AND event:kb_upload_poll_transient` — docling slow (>5 s status poll)
+- `service:portal-api AND event:docling_submit_accepted` — submitted task IDs and source byte size
+- `service:portal-api AND event:docling_markdown_embedded_images_stripped` — defensive evidence that embedded image payloads were removed
 
 ## Archive pipeline (`.zip` / `.tar`)
 

--- a/klai-knowledge-ingest/knowledge_ingest/models.py
+++ b/klai-knowledge-ingest/knowledge_ingest/models.py
@@ -34,10 +34,12 @@ class IngestRequest(BaseModel):
     skip_chunking: bool = False  # True when adapter provides pre-chunked text
     extra: dict = {}  # Adapter-specific metadata (participants, source_url, etc.)
     chunks: list[str] | None = None  # Pre-computed chunks (used with skip_chunking=True)
+    content_hash: str | None = None  # Optional full-source hash for pre-chunked/truncated content
     source_connector_id: str | None = None  # ID of the connector that produced this document
     source_ref: str | None = None  # Source reference (e.g. URL, Notion page ID, repo path)
     synthesis_depth: int | None = None  # Optional override (adapters set this explicitly)
-    allowed_assertion_modes: list[str] | None = None  # Connector-level hint: expected modes for this source
+    # Connector-level hint: expected modes for this source
+    allowed_assertion_modes: list[str] | None = None
     # SPEC-KB-021: source-aware enrichment
     kb_name: str | None = None  # Human-readable KB name (e.g. "Voys Helpdesk")
     connector_type: str | None = None  # Connector type slug (e.g. "redcactus-wiki", "webscrape")

--- a/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
@@ -292,7 +292,7 @@ async def ingest_document(conn: asyncpg.Connection, req: IngestRequest) -> dict:
             }
 
     # Early exit if content is unchanged since last ingest
-    content_hash = hashlib.sha256(req.content.encode()).hexdigest()
+    content_hash = req.content_hash or hashlib.sha256(req.content.encode()).hexdigest()
     stored_hash = await pg_store.get_active_content_hash(conn, req.org_id, req.kb_slug, req.path)
     if stored_hash is not None and stored_hash == content_hash:
         logger.info(

--- a/klai-knowledge-ingest/tests/test_ingest_content_hash_dedup.py
+++ b/klai-knowledge-ingest/tests/test_ingest_content_hash_dedup.py
@@ -250,3 +250,65 @@ async def test_content_hash_stored_on_create():
 
     call_kwargs = mock_create.call_args.kwargs
     assert call_kwargs["content_hash"] == expected_hash
+
+
+@pytest.mark.asyncio
+async def test_content_hash_override_used_for_prechunked_ingest():
+    """Pre-chunked large documents can dedupe on full-source hash."""
+    req = _make_request("Preview only")
+    req.content_hash = "source-sha256"
+    req.skip_chunking = True
+    req.chunks = ["chunk one", "chunk two"]
+    conn = _make_mock_conn()
+
+    mock_create = AsyncMock(return_value="artifact-uuid-4")
+
+    with (
+        patch(
+            "knowledge_ingest.pg_store.get_active_content_hash",
+            new_callable=AsyncMock,
+            return_value=None,
+        ) as mock_get_hash,
+        patch("knowledge_ingest.pg_store.soft_delete_artifact", new_callable=AsyncMock),
+        patch("knowledge_ingest.pg_store.create_artifact", mock_create),
+        patch("knowledge_ingest.pg_store.update_artifact_extra", new_callable=AsyncMock),
+        patch(
+            "knowledge_ingest.embedder.embed",
+            new_callable=AsyncMock,
+            return_value=[[0.1] * 10, [0.2] * 10],
+        ),
+        patch("knowledge_ingest.qdrant_store.upsert_chunks", new_callable=AsyncMock) as mock_upsert,
+        patch(
+            "knowledge_ingest.org_config.is_enrichment_enabled",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "knowledge_ingest.routes.ingest.kb_config.get_kb_visibility",
+            new_callable=AsyncMock,
+            return_value="internal",
+        ),
+        patch(
+            "knowledge_ingest.portal_client.fetch_taxonomy_nodes",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "knowledge_ingest.content_labeler.generate_content_label",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch("knowledge_ingest.routes.ingest.settings") as mock_settings,
+    ):
+        mock_settings.graphiti_enabled = False
+        mock_settings.chunk_size = 1500
+        mock_settings.chunk_overlap = 200
+        mock_settings.enrichment_enabled = False
+
+        from knowledge_ingest.routes.ingest import ingest_document
+
+        await ingest_document(conn, req)
+
+    mock_get_hash.assert_called_once_with(conn, req.org_id, req.kb_slug, req.path)
+    assert mock_create.call_args.kwargs["content_hash"] == "source-sha256"
+    assert mock_upsert.call_args.kwargs["chunks"] == ["chunk one", "chunk two"]

--- a/klai-portal/backend/app/api/app_knowledge_sources.py
+++ b/klai-portal/backend/app/api/app_knowledge_sources.py
@@ -469,6 +469,7 @@ async def _ingest_docling_bytes(
             filename=validated.filename,
             content=validated.content,
             content_type=validated.mime,
+            input_format=validated.docling_format,
         )
     except docling_client.DoclingTimeoutError:
         logger.exception("docling_submit_timeout", filename=filename, extension=ext, bytes=validated.bytes_count)

--- a/klai-portal/backend/app/services/docling_client.py
+++ b/klai-portal/backend/app/services/docling_client.py
@@ -3,8 +3,8 @@
 SPEC-KB-FILE-UPLOAD-001 — wraps the three async endpoints exposed by
 ``docling-serve v1.16.1``:
 
-- ``POST /v1/convert/file/async`` — submit a file, returns ``task_id``
-  immediately. Conversion runs in docling-serve's own worker queue.
+- ``POST /v1/chunk/hybrid/file/async`` — submit a file, returns ``task_id``
+  immediately. Conversion + chunking run in docling-serve's own worker queue.
 - ``GET /v1/status/poll/{task_id}`` — current task status (``pending``,
   ``in_progress``, ``success``, ``failure``, etc.). Cheap to call.
 - ``GET /v1/result/{task_id}`` — fetch the converted markdown once
@@ -77,6 +77,15 @@ class DoclingPollResult:
     queue_position: int | None
 
 
+@dataclass(frozen=True)
+class DoclingIngestResult:
+    """Docling output normalized for knowledge-ingest."""
+
+    content: str
+    chunks: tuple[str, ...] | None
+    chunk_count: int
+
+
 class DoclingError(Exception):
     """Raised on any non-recoverable docling-serve failure."""
 
@@ -98,9 +107,15 @@ _SUBMIT_TIMEOUT_S: float = 60.0
 # Status polls are cheap; 5 s is generous.
 _STATUS_TIMEOUT_S: float = 5.0
 
-# Result fetches return the full markdown — for a chunked 100 MB PDF
-# this can be several MB of JSON. 30 s covers slow links.
+# Result fetches return chunks and may include converted document
+# metadata. 30 s covers slow links without hiding a stuck service.
 _RESULT_TIMEOUT_S: float = 30.0
+
+# knowledge-ingest IngestRequest.content is intentionally bounded. For
+# pre-chunked Docling results, content is a representative preview while
+# the complete text is sent in chunks[].
+_CONTENT_PREVIEW_MAX_CHARS = 450_000
+_FALLBACK_CHUNK_CHARS = 20_000
 
 # Docling Serve defaults ``image_export_mode`` to ``embedded`` for Markdown,
 # which can put base64 PNGs directly in md_content. A 129 MB textbook produced
@@ -109,6 +124,27 @@ _RESULT_TIMEOUT_S: float = 30.0
 _IMAGE_EXPORT_MODE = "placeholder"
 _IMAGE_PLACEHOLDER = "<!-- image -->"
 _EMBEDDED_DATA_IMAGE_RE = re.compile(r"!\[[^\]]*\]\(data:image/[^)]*;base64,[^)]+\)")
+_EXPLICIT_INPUT_FORMATS = frozenset(
+    {
+        "pdf",
+        "docx",
+        "pptx",
+        "xlsx",
+        "html",
+        "image",
+        "csv",
+        "md",
+        "asciidoc",
+        "json_docling",
+        "xml_uspto",
+        "xml_jats",
+        "xml_xbrl",
+        "mets_gbs",
+        "audio",
+        "vtt",
+        "latex",
+    }
+)
 
 
 def _client(timeout_s: float) -> httpx.AsyncClient:
@@ -125,6 +161,7 @@ async def submit_file_async(
     filename: str,
     content: bytes,
     content_type: str,
+    input_format: str | None = None,
     to_formats: tuple[str, ...] = ("md",),
 ) -> DoclingSubmitResult:
     """Submit a file to docling-serve's async queue.
@@ -138,18 +175,19 @@ async def submit_file_async(
     :class:`DoclingTimeoutError` on transport timeouts.
     """
     files = [("files", (filename, content, content_type))]
-    # docling-serve accepts repeated ``to_formats=`` form fields. httpx
-    # encodes a sequence value as repeated fields under the same key, so
-    # ``{"to_formats": ["md", "html"]}`` becomes ``to_formats=md&to_formats=html``
-    # on the wire — matching the multi-value semantics docling expects.
+    # Use Docling Serve's own chunk endpoint for all binary office/document
+    # formats. It preserves Docling's structural context while avoiding our
+    # old "one giant markdown string" handoff to knowledge-ingest.
     data: dict[str, object] = {
-        "to_formats": list(to_formats),
-        "image_export_mode": _IMAGE_EXPORT_MODE,
+        "include_converted_doc": False,
+        "convert_image_export_mode": _IMAGE_EXPORT_MODE,
     }
+    if input_format in _EXPLICIT_INPUT_FORMATS:
+        data["convert_from_formats"] = [input_format]
 
     try:
         async with _client(_SUBMIT_TIMEOUT_S) as client:
-            response = await client.post("/v1/convert/file/async", files=files, data=data)
+            response = await client.post("/v1/chunk/hybrid/file/async", files=files, data=data)
             response.raise_for_status()
             payload = response.json()
     except httpx.TimeoutException as exc:
@@ -211,11 +249,19 @@ async def poll_status(task_id: str) -> DoclingPollResult:
 
 
 async def get_result_markdown(task_id: str) -> str:
+    """Backward-compatible helper returning a markdown/text body."""
+    result = await get_result_document(task_id)
+    if result.chunks:
+        return "\n\n".join(result.chunks)
+    return result.content
+
+
+async def get_result_document(task_id: str) -> DoclingIngestResult:
     """Fetch the converted markdown body for a successful task.
 
-    Returns the concatenated ``md_content`` of every document in the
-    response (docling can convert multiple files per task; in our flow
-    we always submit exactly one file, so the result has one document).
+    The primary path expects Docling Serve's ``ChunkDocumentResponse``
+    from ``/v1/chunk/hybrid/file/async`` and returns pre-computed chunks.
+    A legacy ``ConvertDocumentResponse`` is still accepted defensively.
 
     Raises :class:`DoclingError` if the document body is missing or the
     conversion was marked as ``failed`` or ``skipped`` even though the
@@ -241,7 +287,7 @@ async def get_result_markdown(task_id: str) -> str:
         logger.exception("docling_result_request_error", task_id=task_id)
         raise DoclingError("docling result transport error") from exc
 
-    return _extract_markdown(payload, task_id)
+    return _extract_ingest_result(payload, task_id)
 
 
 def _strip_embedded_images(markdown: str, task_id: str) -> str:
@@ -256,6 +302,60 @@ def _strip_embedded_images(markdown: str, task_id: str) -> str:
             stripped_chars=len(stripped),
         )
     return stripped
+
+
+def _content_preview(texts: tuple[str, ...]) -> str:
+    """Return a bounded representative body for metadata/classification."""
+    parts: list[str] = []
+    remaining = _CONTENT_PREVIEW_MAX_CHARS
+    for text in texts:
+        if remaining <= 0:
+            break
+        if not text:
+            continue
+        part = text[:remaining]
+        parts.append(part)
+        remaining -= len(part) + 2
+    return "\n\n".join(parts).strip()
+
+
+def _fallback_chunks(markdown: str) -> tuple[str, ...]:
+    """Chunk legacy converted markdown if Docling did not return chunks."""
+    chunks = tuple(
+        markdown[i : i + _FALLBACK_CHUNK_CHARS].strip()
+        for i in range(0, len(markdown), _FALLBACK_CHUNK_CHARS)
+        if markdown[i : i + _FALLBACK_CHUNK_CHARS].strip()
+    )
+    return chunks or (markdown,)
+
+
+def _extract_ingest_result(payload: Any, task_id: str) -> DoclingIngestResult:
+    """Normalize Docling chunk or conversion responses for ingestion."""
+    if isinstance(payload, dict) and isinstance(payload.get("chunks"), list):
+        raw_chunks = payload["chunks"]
+        texts: list[str] = []
+        for item in raw_chunks:
+            if not isinstance(item, dict):
+                continue
+            text = item.get("text")
+            if isinstance(text, str) and text.strip():
+                texts.append(_strip_embedded_images(text, task_id).strip())
+        chunks = tuple(texts)
+        if not chunks:
+            raise DoclingError(f"docling produced no chunks for {task_id}")
+        return DoclingIngestResult(
+            content=_content_preview(chunks),
+            chunks=chunks,
+            chunk_count=len(chunks),
+        )
+
+    markdown = _extract_markdown(payload, task_id)
+    chunks = _fallback_chunks(markdown) if len(markdown) > _CONTENT_PREVIEW_MAX_CHARS else None
+    return DoclingIngestResult(
+        content=_content_preview(chunks) if chunks else markdown,
+        chunks=chunks,
+        chunk_count=len(chunks) if chunks else 0,
+    )
 
 
 def _extract_markdown(payload: Any, task_id: str) -> str:

--- a/klai-portal/backend/app/services/kb_upload_poller.py
+++ b/klai-portal/backend/app/services/kb_upload_poller.py
@@ -111,9 +111,9 @@ async def _process_processing_row(view: KBUploadView) -> None:
         )
         return
 
-    # docling reports success — fetch the markdown and advance to ingesting.
+    # docling reports success — fetch the chunks/result and advance to ingesting.
     try:
-        markdown = await docling_client.get_result_markdown(view.docling_task_id)
+        result = await docling_client.get_result_document(view.docling_task_id)
     except docling_client.DoclingError:
         logger.exception(
             "kb_upload_result_fetch_failed",
@@ -129,7 +129,7 @@ async def _process_processing_row(view: KBUploadView) -> None:
         await kb_uploads_repo.mark_ingesting(db, upload_id=view.id)
         await db.commit()
 
-    await _ingest_and_finish(view, markdown=markdown)
+    await _ingest_and_finish(view, result=result)
 
 
 async def _process_ingesting_row(view: KBUploadView) -> None:
@@ -147,7 +147,7 @@ async def _process_ingesting_row(view: KBUploadView) -> None:
         return
 
     try:
-        markdown = await docling_client.get_result_markdown(view.docling_task_id)
+        result = await docling_client.get_result_document(view.docling_task_id)
     except docling_client.DoclingResultNotFoundError:
         logger.exception(
             "kb_upload_ingesting_result_not_found",
@@ -167,11 +167,11 @@ async def _process_ingesting_row(view: KBUploadView) -> None:
         # operator alert (Grafana log query) catches the long-stuck row.
         return
 
-    await _ingest_and_finish(view, markdown=markdown)
+    await _ingest_and_finish(view, result=result)
 
 
-async def _ingest_and_finish(view: KBUploadView, *, markdown: str) -> None:
-    """Forward a docling-derived markdown body to knowledge-ingest.
+async def _ingest_and_finish(view: KBUploadView, *, result: docling_client.DoclingIngestResult) -> None:
+    """Forward a docling-derived document result to knowledge-ingest.
 
     Resolves the KB + Org for the row, builds the IngestRequest payload
     in the same shape ``app_knowledge_sources._forward_ingest`` uses,
@@ -209,11 +209,13 @@ async def _ingest_and_finish(view: KBUploadView, *, markdown: str) -> None:
         return
 
     title = file_upload.derive_title(view.filename, view.extension)
+    source_content_hash = view.source_ref.removeprefix("file:sha256:")
     payload: dict[str, object] = {
         "org_id": org_zitadel_id,
         "kb_slug": kb_slug,
         "path": view.source_ref,
-        "content": markdown,
+        "content": result.content,
+        "content_hash": source_content_hash,
         "title": title,
         "source_type": "file",
         "content_type": "document",
@@ -226,8 +228,13 @@ async def _ingest_and_finish(view: KBUploadView, *, markdown: str) -> None:
             "bytes": view.bytes,
             "pipeline": "docling",
             "docling_task_id": view.docling_task_id,
+            "docling_chunk_count": result.chunk_count,
+            "document_text_truncated": result.chunks is not None,
         },
     }
+    if result.chunks is not None:
+        payload["skip_chunking"] = True
+        payload["chunks"] = list(result.chunks)
 
     try:
         artifact_id = await knowledge_ingest_client.ingest_document(payload)

--- a/klai-portal/backend/tests/test_docling_client.py
+++ b/klai-portal/backend/tests/test_docling_client.py
@@ -19,6 +19,7 @@ class _Response:
 
 class _AsyncClient:
     def __init__(self) -> None:
+        self.path: str | None = None
         self.data: dict[str, object] | None = None
 
     async def __aenter__(self) -> _AsyncClient:
@@ -28,23 +29,42 @@ class _AsyncClient:
         return None
 
     async def post(self, path: str, *, files: Any, data: dict[str, object]) -> _Response:
+        self.path = path
         self.data = data
         return _Response()
 
 
-def test_extract_markdown_strips_embedded_data_images() -> None:
+def test_extract_ingest_result_strips_embedded_data_images() -> None:
     payload = {
         "document": {"md_content": ("Intro\n\n![Image](data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==)\n\nOutro")}
     }
 
-    markdown = docling_client._extract_markdown(payload, "task-123")
+    result = docling_client._extract_ingest_result(payload, "task-123")
 
-    assert "data:image" not in markdown
-    assert markdown == "Intro\n\n<!-- image -->\n\nOutro"
+    assert "data:image" not in result.content
+    assert result.content == "Intro\n\n<!-- image -->\n\nOutro"
+    assert result.chunks is None
+
+
+def test_extract_ingest_result_uses_docling_chunks() -> None:
+    payload = {
+        "chunks": [
+            {"filename": "a.pdf", "chunk_index": 0, "text": "First", "doc_items": []},
+            {"filename": "a.pdf", "chunk_index": 1, "text": "Second", "doc_items": []},
+        ],
+        "documents": [],
+        "processing_time": 1.0,
+    }
+
+    result = docling_client._extract_ingest_result(payload, "task-123")
+
+    assert result.content == "First\n\nSecond"
+    assert result.chunks == ("First", "Second")
+    assert result.chunk_count == 2
 
 
 @pytest.mark.asyncio
-async def test_submit_file_async_requests_placeholder_images(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_submit_file_async_requests_hybrid_chunks(monkeypatch: pytest.MonkeyPatch) -> None:
     fake_client = _AsyncClient()
     monkeypatch.setattr(docling_client, "_client", lambda _timeout_s: fake_client)
 
@@ -52,8 +72,11 @@ async def test_submit_file_async_requests_placeholder_images(monkeypatch: pytest
         filename="chemie.pdf",
         content=b"%PDF",
         content_type="application/pdf",
+        input_format="pdf",
     )
 
+    assert fake_client.path == "/v1/chunk/hybrid/file/async"
     assert fake_client.data is not None
-    assert fake_client.data["to_formats"] == ["md"]
-    assert fake_client.data["image_export_mode"] == "placeholder"
+    assert fake_client.data["include_converted_doc"] is False
+    assert fake_client.data["convert_from_formats"] == ["pdf"]
+    assert fake_client.data["convert_image_export_mode"] == "placeholder"

--- a/klai-portal/backend/tests/test_kb_upload_poller.py
+++ b/klai-portal/backend/tests/test_kb_upload_poller.py
@@ -18,6 +18,7 @@ import pytest
 from app.services import kb_upload_poller
 from app.services.docling_client import (
     DoclingError,
+    DoclingIngestResult,
     DoclingPollResult,
     DoclingResultNotFoundError,
     DoclingTaskStatus,
@@ -73,6 +74,7 @@ class _PollerPatches:
         poll_result: DoclingPollResult | None = None,
         poll_side_effect: Exception | None = None,
         markdown: str | None = "# converted markdown",
+        chunks: tuple[str, ...] | None = None,
         result_side_effect: Exception | None = None,
         ingest_artifact: str = "art-pdf-1",
         ingest_side_effect: Exception | None = None,
@@ -82,6 +84,7 @@ class _PollerPatches:
         self.poll_result = poll_result
         self.poll_side_effect = poll_side_effect
         self.markdown = markdown
+        self.chunks = chunks
         self.result_side_effect = result_side_effect
         self.ingest_artifact = ingest_artifact
         self.ingest_side_effect = ingest_side_effect
@@ -99,10 +102,15 @@ class _PollerPatches:
         self.mock_poll = AsyncMock(return_value=self.poll_result, side_effect=self.poll_side_effect)
         self.stack.enter_context(patch("app.services.kb_upload_poller.docling_client.poll_status", self.mock_poll))
 
-        self.mock_result = AsyncMock(return_value=self.markdown, side_effect=self.result_side_effect)
+        docling_result = DoclingIngestResult(
+            content=self.markdown or "",
+            chunks=self.chunks,
+            chunk_count=len(self.chunks or ()),
+        )
+        self.mock_result = AsyncMock(return_value=docling_result, side_effect=self.result_side_effect)
         self.stack.enter_context(
             patch(
-                "app.services.kb_upload_poller.docling_client.get_result_markdown",
+                "app.services.kb_upload_poller.docling_client.get_result_document",
                 self.mock_result,
             )
         )
@@ -286,6 +294,7 @@ class TestProcessingState:
         patches.mock_ingest.assert_called_once()  # type: ignore[union-attr]
         ingest_payload = patches.mock_ingest.call_args.args[0]  # type: ignore[union-attr]
         assert ingest_payload["content"] == "# converted"
+        assert ingest_payload["content_hash"] == "abc"
         assert ingest_payload["source_type"] == "file"
         assert ingest_payload["content_type"] == "document"
         assert ingest_payload["extra"]["pipeline"] == "docling"
@@ -294,6 +303,31 @@ class TestProcessingState:
         kwargs = patches.mock_mark_done.call_args.kwargs  # type: ignore[union-attr]
         assert kwargs["upload_id"] == view.id
         assert kwargs["artifact_id"] == "art-99"
+
+    @pytest.mark.asyncio
+    async def test_success_forwards_docling_chunks_as_prechunked_ingest(self) -> None:
+        view = _view(status=STATUS_PROCESSING)
+        with _PollerPatches(
+            poll_result=DoclingPollResult(
+                task_id="task-1",
+                status=DoclingTaskStatus.SUCCESS,
+                terminal=True,
+                error_message=None,
+                queue_position=None,
+            ),
+            markdown="Preview",
+            chunks=("Chunk one", "Chunk two"),
+        ) as patches:
+            await kb_upload_poller._process_processing_row(view)
+
+        patches.mock_ingest.assert_called_once()  # type: ignore[union-attr]
+        ingest_payload = patches.mock_ingest.call_args.args[0]  # type: ignore[union-attr]
+        assert ingest_payload["content"] == "Preview"
+        assert ingest_payload["skip_chunking"] is True
+        assert ingest_payload["chunks"] == ["Chunk one", "Chunk two"]
+        assert ingest_payload["content_hash"] == "abc"
+        assert ingest_payload["extra"]["docling_chunk_count"] == 2
+        assert ingest_payload["extra"]["document_text_truncated"] is True
 
     @pytest.mark.asyncio
     async def test_transient_timeout_leaves_row_pending(self) -> None:


### PR DESCRIPTION
## Summary
- switch KB Docling uploads from convert markdown to async hybrid chunk results
- forward Docling chunks to knowledge-ingest as pre-chunked content with a bounded preview and original source content_hash
- configure docling-serve result retention and update the file upload spec/runbook with the new pipeline

## Verification
- cd klai-portal/backend && uv run pytest tests/test_docling_client.py tests/test_kb_upload_poller.py tests/test_app_knowledge_sources_file.py -q
- cd klai-portal/backend && uv run ruff check app/services/docling_client.py app/services/kb_upload_poller.py app/api/app_knowledge_sources.py tests/test_docling_client.py tests/test_kb_upload_poller.py
- cd klai-portal/backend && uv run pyright app/services/docling_client.py app/services/kb_upload_poller.py tests/test_docling_client.py tests/test_kb_upload_poller.py
- cd klai-knowledge-ingest && uv run pytest tests/test_ingest_content_hash_dedup.py -q
- cd klai-knowledge-ingest && uv run ruff check knowledge_ingest/models.py knowledge_ingest/routes/ingest.py tests/test_ingest_content_hash_dedup.py

Note: knowledge-ingest has no pyright binary in its current dev dependency group.