### PR TITLE
Skip LLM enrichment for large Docling ingests

### DIFF
--- a/.moai/specs/SPEC-KB-FILE-UPLOAD-001/spec.md
+++ b/.moai/specs/SPEC-KB-FILE-UPLOAD-001/spec.md
@@ -217,6 +217,7 @@ Data flow invariants:
 | D-8 | Converted document payload | Submit with `include_converted_doc=false` and `convert_image_export_mode=placeholder`. | RAG ingestion needs text chunks, not an embedded DoclingDocument or base64 image payloads. This keeps result and ingest payloads bounded. |
 | D-9 | Pre-chunked ingest contract | Forward Docling chunk text to `/ingest/v1/document` with `skip_chunking=true`, `chunks=[...]`, bounded `content`, and original file `content_hash`. | Prevents 422s from `content` max length, preserves Docling structure, and dedupes against the uploaded source instead of the preview. |
 | D-10 | Docling result lifecycle | Configure `DOCLING_SERVE_SINGLE_USE_RESULTS=false` and `DOCLING_SERVE_RESULT_REMOVAL_DELAY=86400`; still treat Docling results as volatile and ingest immediately after terminal success. | Docling Serve defaults are optimized for one client fetch. The portal poller may need retry tolerance after a transient `/ingest` failure or portal restart. Durable result storage in Klai remains a future hardening step. |
+| D-11 | Large-document enrichment | Skip per-chunk LLM enrichment when the ingest content is a truncated preview or when the chunk count exceeds `enrichment_max_chunks` (default 200). Keep the raw Docling vectors as the searchable source of truth. | A 1557-chunk textbook would require thousands of LiteLLM calls and can be rate-limited for minutes. Re-chunking the bounded preview during enrichment would also overwrite the full Docling index with partial content. |
 
 ---
 
@@ -375,6 +376,11 @@ forward those values to `knowledge-ingest` as `skip_chunking=true` and
 `knowledge-ingest` SHALL be a bounded preview no larger than 450,000
 characters and `content_hash` SHALL be the original uploaded source hash.
 
+**Ubiquitous.** WHEN a docling-path upload has `document_text_truncated=true`
+OR produces more chunks than `enrichment_max_chunks`, THE SYSTEM SHALL NOT
+enqueue per-chunk LLM enrichment. The raw Docling chunks SHALL remain indexed
+and searchable.
+
 **Event-driven.** WHEN docling-serve returns non-2xx OR times out (≥ 600 s),
 THE SYSTEM SHALL mark the artifact `failed` with `failure_reason:
 "docling_timeout"` or `"extraction_failed"` and NOT retry automatically.
@@ -397,6 +403,10 @@ THE SYSTEM SHALL mark the artifact `failed` with `failure_reason:
 - AC-4.8: The same Chemie upload does not produce HTTP 422 from
   `knowledge-ingest` and never transitions from Docling success to
   `docling_result_not_found`.
+- AC-4.9: The same Chemie upload stores 1557 raw chunks in Qdrant and skips
+  LLM enrichment with `llm_enrichment_skip_reason=document_text_truncated`.
+  No enrichment job may overwrite the index with chunks derived from the
+  bounded preview.
 
 ---
 

--- a/docs/runbooks/kb-file-upload.md
+++ b/docs/runbooks/kb-file-upload.md
@@ -29,6 +29,7 @@ Browser ──multipart 200 MB──▶ Caddy ──▶ portal-api
                                                           chunks=[...]
                                                           content=<bounded preview>
                                                           content_hash=<source sha256>
+                                                          skip LLM enrichment when preview is truncated
                                                         → kb_uploads.status=done
                                              → failure: kb_uploads.status=failed
                                          frontend polls
@@ -176,6 +177,32 @@ The docling path must not forward one giant converted document in
 If logs show `skip_chunking=false` or no `chunks`, the portal-api image is
 not running the Docling chunk pipeline. If `content` is larger than 500,000
 characters, the preview bound has regressed.
+
+### Large document indexed but enrichment fails or retries
+
+Large Docling documents must stay searchable on raw Docling chunk vectors.
+They should not fan out into hundreds or thousands of LiteLLM enrichment
+requests during ingest. The expected behavior for a truncated Docling preview
+or a document above `enrichment_max_chunks` is:
+
+```text
+event=enrichment_enqueue_skipped reason=document_text_truncated
+```
+
+The artifact extra should include:
+
+```json
+{
+  "llm_enrichment_skipped": true,
+  "llm_enrichment_skip_reason": "document_text_truncated",
+  "docling_chunk_count": 1557
+}
+```
+
+This is not a failed ingest. It means search/RAG uses the raw Docling chunks
+already stored in Qdrant. If enrichment jobs are still retrying for such an
+artifact, the knowledge-ingest image is stale or an old queued job predates
+the policy guard.
 
 ### portal-api container OOM during upload
 

--- a/klai-knowledge-ingest/knowledge_ingest/config.py
+++ b/klai-knowledge-ingest/knowledge_ingest/config.py
@@ -57,6 +57,8 @@ class Settings(BaseSettings):
     enrichment_model: str = "klai-fast"
     enrichment_timeout: float = 15.0
     enrichment_max_concurrent: int = 2  # Mistral account limit: 60 RPM shared across all aliases
+    # Larger docs keep raw chunk vectors; per-chunk LLM fan-out is not viable.
+    enrichment_max_chunks: int = 200
     enrichment_max_document_tokens: int = 2000
     # Sparse embedding sidecar (BGE-M3 FlagEmbedding)
     sparse_sidecar_url: str = "http://172.18.0.1:8001"
@@ -128,7 +130,7 @@ class Settings(BaseSettings):
     # actually contains.
     #
     # ``'leaf'`` returns the leaves of the cluster hierarchy — finer-grained,
-    # typically 2-4× more clusters than EOM on the same input. Targets the
+    # typically 2-4x more clusters than EOM on the same input. Targets the
     # 5-9 IA sweet spot at typical KB sizes; needs revisiting if the corpus
     # grows >300 docs (then the leaf count may climb past the comfortable
     # browsing range and hierarchical taxonomy becomes warranted).

--- a/klai-knowledge-ingest/knowledge_ingest/enrichment_policy.py
+++ b/klai-knowledge-ingest/knowledge_ingest/enrichment_policy.py
@@ -1,0 +1,32 @@
+"""Shared policy for deciding when LLM enrichment should run."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from knowledge_ingest.config import settings
+
+_DEFAULT_MAX_CHUNKS = 200
+
+
+def _configured_max_chunks() -> int:
+    value = getattr(settings, "enrichment_max_chunks", _DEFAULT_MAX_CHUNKS)
+    return value if isinstance(value, int) else _DEFAULT_MAX_CHUNKS
+
+
+def enrichment_skip_reason(
+    *,
+    chunk_count: int,
+    extra_payload: Mapping[str, Any] | None,
+) -> str | None:
+    """Return a machine-readable reason when LLM enrichment should be skipped."""
+    extra = extra_payload or {}
+    if extra.get("document_text_truncated"):
+        return "document_text_truncated"
+
+    max_chunks = _configured_max_chunks()
+    if max_chunks > 0 and chunk_count > max_chunks:
+        return "too_many_chunks"
+
+    return None

--- a/klai-knowledge-ingest/knowledge_ingest/enrichment_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/enrichment_tasks.py
@@ -42,6 +42,7 @@ from knowledge_ingest import (
 )
 from knowledge_ingest.content_profiles import get_profile
 from knowledge_ingest.db import cross_org_admin_connection, tenant_scoped_connection
+from knowledge_ingest.enrichment_policy import enrichment_skip_reason
 
 logger = structlog.get_logger()
 
@@ -143,6 +144,20 @@ async def _load_and_enrich(artifact_id: str) -> None:
 
     extra: dict = artifact["extra"] or {}
     document_text: str = extra.get("document_text", "") or ""
+    prechunked_skip = enrichment_skip_reason(
+        chunk_count=int(extra.get("docling_chunk_count") or 0),
+        extra_payload=extra,
+    )
+    if prechunked_skip is not None:
+        logger.info(
+            "enrichment_aborted_by_policy",
+            artifact_id=artifact_id,
+            kb_slug=artifact["kb_slug"],
+            path=artifact["path"],
+            reason=prechunked_skip,
+            docling_chunk_count=extra.get("docling_chunk_count"),
+        )
+        return
     if not document_text:
         # Pre-SPEC-INGEST-CONTENT-PG-001 artifact rows may have no
         # document_text on extra. Without a body we cannot enrich; the
@@ -161,6 +176,17 @@ async def _load_and_enrich(artifact_id: str) -> None:
     # is current, regardless of what was in flight at enqueue time.
     children, parents = chunker.chunk_markdown_with_parents(document_text)
     chunks_text = [c.text for c in children]
+    derived_skip = enrichment_skip_reason(chunk_count=len(chunks_text), extra_payload=extra)
+    if derived_skip is not None:
+        logger.info(
+            "enrichment_aborted_by_policy",
+            artifact_id=artifact_id,
+            kb_slug=artifact["kb_slug"],
+            path=artifact["path"],
+            reason=derived_skip,
+            chunks=len(chunks_text),
+        )
+        return
     parents_serialised: list[dict] = [
         {
             "text": p.text,

--- a/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
@@ -40,6 +40,7 @@ from knowledge_ingest.config import settings
 from knowledge_ingest.content_labeler import generate_content_label
 from knowledge_ingest.content_profiles import get_profile
 from knowledge_ingest.db import tenant_scoped_connection
+from knowledge_ingest.enrichment_policy import enrichment_skip_reason
 from knowledge_ingest.identity import assert_caller_identity, assert_caller_identity_tenant_only
 from knowledge_ingest.models import (
     BulkSyncRequest,
@@ -537,6 +538,10 @@ async def ingest_document(conn: asyncpg.Connection, req: IngestRequest) -> dict:
         extra_payload["connector_type"] = req.connector_type
     if req.source_domain:
         extra_payload["source_domain"] = req.source_domain
+    enrichment_skip = enrichment_skip_reason(chunk_count=len(texts), extra_payload=extra_payload)
+    if enrichment_skip is not None:
+        extra_payload["llm_enrichment_skipped"] = True
+        extra_payload["llm_enrichment_skip_reason"] = enrichment_skip
     # Visibility is authoritative from kb_config — set last so req.extra cannot override it
     extra_payload["visibility"] = visibility
 
@@ -574,7 +579,17 @@ async def ingest_document(conn: asyncpg.Connection, req: IngestRequest) -> dict:
     # fields are loaded from PostgreSQL at execution time. Closes the
     # race-window where two POSTs in quick succession could leave the
     # worker processing a stale (frozen-in-args) content snapshot.
-    if await org_config.is_enrichment_enabled(conn, req.org_id):
+    if enrichment_skip is not None:
+        logger.info(
+            "enrichment_enqueue_skipped",
+            reason=enrichment_skip,
+            chunks=len(texts),
+            kb_slug=req.kb_slug,
+            path=req.path,
+            org_id=req.org_id,
+            content_type=req.content_type,
+        )
+    elif await org_config.is_enrichment_enabled(conn, req.org_id):
         from knowledge_ingest import enrichment_tasks
 
         proc_app = enrichment_tasks.get_app()

--- a/klai-knowledge-ingest/tests/test_enrichment_dedup.py
+++ b/klai-knowledge-ingest/tests/test_enrichment_dedup.py
@@ -123,6 +123,7 @@ def _base_patches(mock_app):
             mock_settings.chunk_size = 1500
             mock_settings.chunk_overlap = 200
             mock_settings.enrichment_enabled = True
+            mock_settings.enrichment_max_chunks = 200
             mock_settings.taxonomy_centroid_match_threshold = 0.85
             yield
 
@@ -211,3 +212,33 @@ async def test_two_ingests_same_path_only_one_enrichment():
     # configure called twice (once per ingest), but only the first defer_async succeeds
     assert task_fn.configure.call_count == 2
     assert configured.defer_async.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_truncated_docling_document_skips_enrichment_enqueue():
+    """A bounded preview for a pre-chunked Docling file must not start LLM fan-out."""
+    from knowledge_ingest.models import IngestRequest
+    from knowledge_ingest.routes.ingest import ingest_document
+
+    mock_app, task_fn, _ = _make_mock_app()
+    conn = _make_mock_conn()
+    req = IngestRequest(
+        org_id="org-3",
+        kb_slug="chemie",
+        path="file:sha256:source",
+        content="Preview only",
+        source_type="file",
+        content_type="document",
+        skip_chunking=True,
+        chunks=["docling chunk one", "docling chunk two"],
+        extra={
+            "document_text_truncated": True,
+            "docling_chunk_count": 2,
+        },
+    )
+
+    async with _base_patches(mock_app):
+        result = await ingest_document(conn, req)
+
+    assert result["status"] == "ok"
+    task_fn.configure.assert_not_called()

--- a/klai-knowledge-ingest/tests/test_enrichment_loads_from_pg.py
+++ b/klai-knowledge-ingest/tests/test_enrichment_loads_from_pg.py
@@ -214,6 +214,45 @@ async def test_load_and_enrich_skips_when_document_text_missing():
 
 
 @pytest.mark.asyncio
+async def test_load_and_enrich_skips_truncated_docling_artifact():
+    """Existing queued jobs for pre-chunked large Docling files soft-skip."""
+    fake_artifact = {
+        "artifact_id": "11111111-2222-3333-4444-555555555555",
+        "org_id": "org1",
+        "kb_slug": "chemie",
+        "path": "file:sha256:source",
+        "user_id": None,
+        "content_type": "document",
+        "synthesis_depth": 0,
+        "assertion_mode": "factual",
+        "provenance_type": "extracted",
+        "confidence": None,
+        "belief_time_start": 0,
+        "belief_time_end": 253402300800,
+        "extra": {
+            "document_text": "Preview only",
+            "document_text_truncated": True,
+            "docling_chunk_count": 1557,
+        },
+    }
+    with (
+        patch(
+            "knowledge_ingest.enrichment_tasks.pg_store.read_artifact_for_enrichment",
+            new_callable=AsyncMock,
+            return_value=fake_artifact,
+        ),
+        patch(
+            "knowledge_ingest.enrichment_tasks._enrich_document", new_callable=AsyncMock
+        ) as mock_enrich,
+    ):
+        from knowledge_ingest.enrichment_tasks import _load_and_enrich
+
+        await _load_and_enrich("11111111-2222-3333-4444-555555555555")
+
+    mock_enrich.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_load_and_enrich_passes_pg_state_to_enrich_document():
     """The kwargs handed to _enrich_document come entirely from PG —
     not from any caller-frozen state. This is the contract that closes


### PR DESCRIPTION
## Summary
- add a shared enrichment policy that skips per-chunk LLM enrichment for truncated Docling previews and documents above enrichment_max_chunks
- prevent queued enrichment workers from re-chunking bounded previews and overwriting full Docling indexes
- document the large-document ingest behavior in the spec and runbook

## Verification
- cd klai-knowledge-ingest && uv run pytest tests/test_enrichment_dedup.py tests/test_enrichment_loads_from_pg.py tests/test_ingest_content_hash_dedup.py -q
- cd klai-knowledge-ingest && uv run ruff check knowledge_ingest/enrichment_policy.py knowledge_ingest/config.py knowledge_ingest/routes/ingest.py knowledge_ingest/enrichment_tasks.py tests/test_enrichment_dedup.py tests/test_enrichment_loads_from_pg.py