### PR TITLE
Harden archive uploads

### DIFF
--- a/.moai/specs/SPEC-KB-FILE-UPLOAD-001/spec.md
+++ b/.moai/specs/SPEC-KB-FILE-UPLOAD-001/spec.md
@@ -218,6 +218,8 @@ Data flow invariants:
 | D-9 | Pre-chunked ingest contract | Forward Docling chunk text to `/ingest/v1/document` with `skip_chunking=true`, `chunks=[...]`, bounded `content`, and original file `content_hash`. | Prevents 422s from `content` max length, preserves Docling structure, and dedupes against the uploaded source instead of the preview. |
 | D-10 | Docling result lifecycle | Configure `DOCLING_SERVE_SINGLE_USE_RESULTS=false` and `DOCLING_SERVE_RESULT_REMOVAL_DELAY=86400`; still treat Docling results as volatile and ingest immediately after terminal success. | Docling Serve defaults are optimized for one client fetch. The portal poller may need retry tolerance after a transient `/ingest` failure or portal restart. Durable result storage in Klai remains a future hardening step. |
 | D-11 | Large-document enrichment | Skip per-chunk LLM enrichment when the ingest content is a truncated preview or when the chunk count exceeds `enrichment_max_chunks` (default 200). Keep the raw Docling vectors as the searchable source of truth. | A 1557-chunk textbook would require thousands of LiteLLM calls and can be rate-limited for minutes. Re-chunking the bounded preview during enrichment would also overwrite the full Docling index with partial content. |
+| D-12 | Archive semantics | Treat `.zip` / `.tar` as batch transport containers, never as semantic documents. Each accepted member becomes its own `kb_uploads` row and artifact; the archive itself is not indexed. | Docling and vector-store style retrieval systems operate on actual document files, not archive containers. Per-entry artifacts preserve filenames, status, retry behavior, deletion, citations, and quota accounting. |
+| D-13 | Archive acceptance policy | Archive ingest is all-or-nothing. If any member is unsupported, unsafe, malformed, too large, nested, mime-mismatched, or otherwise not accepted by the normal file rules, reject the whole archive before creating downstream ingest jobs. | Partial success is useful for multi-file browser uploads, but archives are opaque to users before upload. In business usage, silently indexing only part of an archive creates incomplete KBs and hard-to-debug trust issues. |
 
 ---
 
@@ -286,52 +288,144 @@ container metrics).
 
 ---
 
-### REQ-3 — Archive safety
+### REQ-3 — Archive safety and batch semantics
 
-**Ubiquitous.** Archives (`.zip`, `.tar`) shall be unpacked with streaming
-guards that abort early on adversarial content.
+**Ubiquitous.** Archives (`.zip`, `.tar`) shall be treated as batch
+containers. The archive file itself SHALL NOT be indexed. Every accepted
+member SHALL become an independent upload row, downstream ingest job, artifact,
+source row, and citation target.
 
-**Event-driven.** WHEN an archive entry's compression ratio exceeds 10:1,
-THE SYSTEM SHALL abort extraction and return `error_code:
-"archive_compression_ratio"` within 10 MB of decompression progress.
+**Ubiquitous.** Archive ingest SHALL be all-or-nothing. The system SHALL NOT
+create any `kb_uploads` rows, Docling tasks, Qdrant points, or artifacts for an
+archive until every member has passed archive preflight, extraction guards, and
+the same per-file validation used by top-level uploads.
 
-**Event-driven.** WHEN cumulative uncompressed size exceeds 500 MB OR
-per-entry uncompressed size exceeds 50 MB, THE SYSTEM SHALL abort with
-`error_code: "archive_total_size"` or `error_code:
+**State-driven.** BEFORE extracting member payloads, the system SHALL perform
+archive preflight using metadata available without decompression:
+
+- member count;
+- member paths;
+- extensions;
+- nested archive detection;
+- declared uncompressed size where available;
+- duplicate normalized paths;
+- tar member type;
+- cumulative declared uncompressed size where available.
+
+**Event-driven.** WHEN preflight finds any unacceptable member, THE SYSTEM
+SHALL reject the entire archive with the member-specific `error_code` and SHALL
+NOT process any other member.
+
+**Ubiquitous.** Archive members SHALL use the same accepted document whitelist
+as direct uploads, excluding archive extensions and phase-pending formats:
+`.csv`, `.docx`, `.json`, `.md`, `.pdf`, `.pptx`, `.txt`, `.xlsx`, `.xml`.
+`.doc` inside an archive SHALL reject the whole archive with
+`error_code: "doc_format_not_yet_supported"`.
+
+**Event-driven.** WHEN an archive contains more than 200 file members, THE
+SYSTEM SHALL reject the archive with `error_code: "archive_too_many_entries"`.
+
+**Event-driven.** WHEN an archive contains more than 10 Docling-path members
+(`.pdf`, `.docx`, `.pptx`, `.xlsx`, `.json`, `.xml`), THE SYSTEM SHALL reject
+the archive with `error_code: "archive_too_many_docling_entries"`.
+
+**Ubiquitous.** Archive preflight SHALL compute an archive complexity score so
+the allowed member count scales with member type and declared size:
+
+| Member shape | Complexity units |
+|---|---:|
+| `.md`, `.txt`, `.csv` up to 1 MB | 1 |
+| `.md`, `.txt`, `.csv` above 1 MB | 2 |
+| `.json`, `.xml` | 3 |
+| `.docx`, `.xlsx`, `.pptx` | 5 |
+| `.pdf` up to 10 MB | 10 |
+| `.pdf` above 10 MB | 10 + 1 per additional started 10 MB |
+
+WHEN the archive complexity score exceeds 200 units, THE SYSTEM SHALL reject
+the archive with `error_code: "archive_complexity_budget_exceeded"`.
+
+**Event-driven.** WHEN cumulative uncompressed size exceeds 500 MB OR a
+member's uncompressed size exceeds 50 MB, THE SYSTEM SHALL reject the archive
+with `error_code: "archive_total_size"` or `error_code:
 "archive_entry_too_large"`.
 
-**Event-driven.** WHEN an archive contains more than 50 entries, THE SYSTEM
-SHALL abort with `error_code: "archive_too_many_entries"` after counting the
-51st entry header.
+**Event-driven.** WHEN an entry name contains a NUL byte, an absolute path,
+parent traversal (`..`), a Windows drive prefix, or a path that normalizes
+outside the archive root, THE SYSTEM SHALL reject the archive with
+`error_code: "archive_path_traversal"`.
 
-**Event-driven.** WHEN an entry name contains `..`, an absolute path, or a
-backslash separator, THE SYSTEM SHALL abort with `error_code:
-"archive_path_traversal"`.
+**Event-driven.** WHEN two member paths normalize to the same value, THE SYSTEM
+SHALL reject the archive with `error_code: "archive_duplicate_entry"`.
 
 **Event-driven.** WHEN an entry's extension is `.zip` or `.tar` (nested
-archive), THE SYSTEM SHALL abort with `error_code: "archive_nested"`.
+archive), THE SYSTEM SHALL reject the archive with `error_code:
+"archive_nested"`.
 
-**Event-driven.** WHEN a tar entry has type other than REGTYPE / AREGTYPE,
-THE SYSTEM SHALL abort with `error_code: "archive_unsafe_entry"`.
+**Event-driven.** WHEN a tar member has type other than REGTYPE / AREGTYPE, THE
+SYSTEM SHALL reject the archive with `error_code: "archive_unsafe_entry"`.
 
-**Event-driven.** WHEN an entry's extension is whitelisted but its
-magic-byte content fails REQ-1 validation, THE SYSTEM SHALL skip the entry
-(not the entire archive) and record `entry_skipped` reason in the artifact
-log.
+**State-driven.** WHILE extracting each member into a disk-backed staging area,
+the system SHALL stream bytes and enforce per-entry size, total size, and
+compression-ratio limits. The system SHALL NOT hold all decompressed member
+bytes in memory.
+
+**Event-driven.** WHEN a zip member's compression ratio exceeds 10:1 after the
+first 1 MB of decompressed output, THE SYSTEM SHALL abort extraction and return
+`error_code: "archive_compression_ratio"` within 10 MB of decompression
+progress.
+
+**Event-driven.** WHEN an extracted member's magic-byte content fails the same
+validation required by REQ-1, THE SYSTEM SHALL reject the entire archive with
+the underlying file `error_code` (`mime_mismatch`, `empty_content`, or
+`invalid_text_encoding`) and SHALL delete all staged member files.
+
+**Event-driven.** WHEN all members pass validation, THE SYSTEM SHALL create one
+archive batch id, create one upload row per member with initial status
+`pending`, and enqueue one independent ingest job per member. Docling-path
+members SHALL enter the normal Docling queue; text-path members SHALL enter the
+normal direct ingest path. The request handler SHALL NOT run Docling conversion
+inline for archive members. The request SHALL return HTTP 202 with one upload
+entry per member, not one upload entry for the archive.
+
+**Ubiquitous.** Each member upload row and artifact SHALL include archive
+provenance metadata:
+
+- `archive_batch_id`;
+- `archive_filename`;
+- `archive_source_ref`;
+- `archive_member_path`;
+- `archive_member_index`;
+- `archive_member_count`.
+
+**Unwanted behaviour.** IF any member fails archive or file validation, THEN
+THE SYSTEM SHALL reject the whole archive. Partial indexing of a user-supplied
+archive is forbidden.
 
 **Acceptance criteria:**
 - AC-3.1: A canonical 42 KB → 4 GB zip-bomb fixture aborts within 10 MB
   decompression.
-- AC-3.2: A `.zip` with 51 valid `.md` entries returns 400
+- AC-3.2: A `.zip` with 201 valid `.md` entries returns 400
   `archive_too_many_entries`.
 - AC-3.3: A `.tar` containing `../../etc/passwd` returns 400
   `archive_path_traversal`.
-- AC-3.4: A `.zip` containing `nested.zip` rejects that entry with
-  `archive_nested`; the rest of the archive proceeds.
+- AC-3.4: A `.zip` containing `nested.zip` rejects the whole archive with
+  `archive_nested`; no upload rows are created.
 - AC-3.5: A `.tar` symlink entry returns 400 `archive_unsafe_entry`.
-- AC-3.6: A `.zip` with mixed `[1.md, 2.pdf, 3.exe]` produces 2 artifacts
-  (md, pdf) and 1 entry log line `entry_skipped: unsupported_extension` for
-  the `.exe`.
+- AC-3.6: A `.zip` with mixed `[1.md, 2.pdf, 3.exe]` returns 400
+  `unsupported_extension`; no artifacts, upload rows, Docling tasks, or Qdrant
+  points are created.
+- AC-3.7: A `.zip` with 5 valid members (`.md`, `.txt`, `.pdf`, `.docx`,
+  `.xlsx`) returns 202 with 5 upload entries and a shared `archive_batch_id`.
+- AC-3.8: A `.zip` with 11 valid PDF members returns 400
+  `archive_too_many_docling_entries`.
+- AC-3.9: A `.zip` with two paths that normalize to the same member path
+  returns 400 `archive_duplicate_entry`.
+- AC-3.10: A `.zip` with 150 valid small `.md` files returns 202 with 150
+  upload entries and a shared `archive_batch_id`.
+- AC-3.11: A `.zip` whose members stay under hard count limits but exceed 200
+  complexity units returns 400 `archive_complexity_budget_exceeded`.
+- AC-3.12: During a 500 MB archive staging run, portal-api RSS stays below
+  100 MB delta over baseline.
 
 ---
 
@@ -464,7 +558,10 @@ archive_compression_ratio
 archive_total_size
 archive_entry_too_large
 archive_too_many_entries
+archive_too_many_docling_entries
+archive_complexity_budget_exceeded
 archive_path_traversal
+archive_duplicate_entry
 archive_nested
 archive_unsafe_entry
 kb_quota_bytes_exceeded
@@ -667,12 +764,18 @@ Deliverables:
 ### Phase 3 — archives
 
 Deliverables:
-- New `knowledge-ingest/adapters/archive.py` (sunzip-style streaming
-  extractor with all REQ-3 guards).
+- New/updated `portal-api/app/services/archive.py` with two-stage archive
+  handling: metadata preflight, disk-backed staging, per-member validation,
+  then all-or-nothing job creation.
 - portal-api whitelist extends to `.zip .tar`.
 - Per-entry quota counts uncompressed bytes.
+- Archive entries become independent `kb_uploads` rows and artifacts with a
+  shared `archive_batch_id`; the archive itself is never indexed.
+- One archive may contain at most 200 accepted members, at most 10
+  Docling-path members, and at most 200 archive complexity units.
 - Tests: zip-bomb fixture, path-traversal fixture, nested-archive,
-  symlink-in-tar, mixed-content (md + pdf + exe → 2 + 1 skipped),
+  symlink-in-tar, duplicate normalized path, too-many-Docling-members,
+  mixed-content rejection (md + pdf + exe → whole archive rejected),
   Playwright real `.zip` upload.
 
 ### Phase 4 — `.doc` legacy support
@@ -708,6 +811,8 @@ Deliverables:
 | R-13 | docling-serve resource exhaustion on multiple large PDFs concurrently | MED | Procrastinate worker concurrency cap at 2 docling-jobs/worker. Monitor docling-serve memory in Grafana. |
 | R-14 | Frontend uploads many small files at once → 100/24h rate limit hit fast | LOW | Client batches ≤ 10 files per submit; per-org rate is per-artifact, archives count entries individually. Phase 5 may relax to per-byte quota. |
 | R-15 | `kb-documents` bucket reachable from internet via DNS-leak | MED | Garage `klai-documents` bucket has no website-mode binding; only S3 API on internal port 3900 (not exposed via Caddy). Verified by AC-9.5. |
+| R-16 | Archive partial ingest creates a misleading KB | HIGH | All-or-nothing archive staging: validate every member before creating any upload rows, Docling tasks, artifacts, or Qdrant points. One bad member rejects the whole archive. |
+| R-17 | Archive staging OOMs portal-api | HIGH | Stream members to disk-backed temp files/object storage; never accumulate all decompressed bytes in memory. AC-3.12 covers RSS. |
 
 ---
 
@@ -728,7 +833,7 @@ Deliverables:
 | `klai-portal/backend/app/api/internal.py` (or new) | 1 | Webhook receiver for knowledge-ingest status updates: `POST /internal/kb-uploads/status`. |
 | `klai-knowledge-ingest/knowledge_ingest/routes/ingest.py` | 1, 2, 3, 4 | +`POST /ingest/v1/file` (~80 LOC initial; grows per phase). |
 | `klai-knowledge-ingest/knowledge_ingest/adapters/docling.py` | 2 | NEW (~150 LOC): httpx client to docling-serve, schema detection, chunk normalization. |
-| `klai-knowledge-ingest/knowledge_ingest/adapters/archive.py` | 3 | NEW (~200 LOC): streaming sunzip with all REQ-3 guards. |
+| `klai-portal/backend/app/services/archive.py` | 3 | NEW/UPDATED (~250 LOC): archive preflight, disk-backed staging, all-or-nothing validation, and member metadata. |
 | `klai-knowledge-ingest/knowledge_ingest/adapters/libreoffice.py` | 4 | NEW (~80 LOC): HTTP client → docx → docling. |
 | `klai-knowledge-ingest/knowledge_ingest/config.py` | 1, 4 | +`docling_url: str`, `libreoffice_url: str` (Phase 4). |
 | `klai-knowledge-ingest/alembic/versions/<rev>_artifact_file_source.py` | 1 | If existing artifacts table needs new jsonb fields (`source_kind`, `s3_key`, `original_filename`), add via `extra` jsonb (no schema change). May be a no-op if jsonb is already free-form. |

--- a/docs/runbooks/kb-file-upload.md
+++ b/docs/runbooks/kb-file-upload.md
@@ -2,8 +2,9 @@
 
 > SPEC-KB-FILE-UPLOAD-001 — file ingestion for `.md / .txt / .csv /
 > .pdf / .docx / .pptx / .xlsx / .json / .xml`. Archive (`.zip / .tar`)
-> and `.doc` are documented as `phase_pending` in the UI; they ship in
-> a follow-up.
+> support is specified as an all-or-nothing batch container path: preflight,
+> stage, validate every member, then enqueue each member as its own upload.
+> Legacy `.doc` remains phase-pending until the LibreOffice sidecar ships.
 
 ## Architecture
 
@@ -35,6 +36,17 @@ Browser ──multipart 200 MB──▶ Caddy ──▶ portal-api
                                          frontend polls
                                          /api/app/knowledge-bases/{kb}/sources/file/{id}/status
                                          every 2 s until terminal
+
+archive path (.zip/.tar):
+Browser ──multipart archive──▶ portal-api archive preflight
+                              ├─ any bad member: reject whole archive, no rows/jobs
+                              └─ all members valid:
+                                   stage members on disk/object storage
+                                   create archive_batch_id
+                                   create one kb_uploads row per member
+                                   enqueue one member ingest job per row
+                                   text members → direct ingest
+                                   docling members → Docling async queue + poller
 ```
 
 ## What's live in each service
@@ -234,24 +246,58 @@ VictoriaLogs queries:
 
 ## Archive pipeline (`.zip` / `.tar`)
 
-`app/services/archive.py` implements stdlib-only safe extraction with
-sunzip-style guards. Each archive is unpacked **in memory** under:
+Archive files are transport containers, not documents. Klai should never send
+the archive itself to Docling or index it as one artifact. The intended flow is:
+
+1. Preflight archive metadata before decompression where possible.
+2. Reject the whole archive if any member is not acceptable.
+3. Stream surviving member payloads into disk-backed staging.
+4. Run the same per-file validation as direct uploads.
+5. Only after every member is valid, create one upload row and queued downstream
+   job per member with a shared `archive_batch_id`.
+
+This means unsupported files inside an archive are not skipped. A zip containing
+`notes.md`, `handbook.pdf`, and `script.exe` is rejected entirely. This is
+intentional: partial archive ingest makes a KB look complete when it is not.
+
+Preflight can catch member count, paths, extensions, nested archives, duplicate
+normalized paths, tar member types, and declared sizes. It cannot fully prove
+compression ratio or magic-byte correctness. Those checks still happen while
+streaming the member content.
+
+`app/services/archive.py` should implement stdlib-only safe extraction with
+sunzip-style guards. Member payloads must be staged on disk or object storage,
+not accumulated in process memory.
 
 | Guard | Value |
 |---|---|
-| Member count | 50 |
+| Member count | 200 file members |
+| Docling-path members | 10 |
+| Archive complexity budget | 200 units |
 | Per-entry uncompressed | 50 MB |
 | Total uncompressed | 500 MB |
 | Compression ratio | 10:1 (after 1 MB output — catches 42 KB → 4 GB bombs) |
-| Path traversal | reject `..`, `/`, `\`, NUL, drive letters |
-| Nested archives | reject `.zip` / `.tar` entries (no recursion) |
-| Symlinks / devices (tar) | only `REGTYPE` extracted |
-| Whitelist per entry | only TEXT or DOCLING extensions |
+| Path traversal | reject NUL, absolute paths, `..`, drive letters, paths outside archive root |
+| Duplicate normalized paths | reject whole archive |
+| Nested archives | reject whole archive on `.zip` / `.tar` entries |
+| Symlinks / devices (tar) | reject whole archive; only `REGTYPE` / `AREGTYPE` allowed |
+| Whitelist per entry | `.csv`, `.docx`, `.json`, `.md`, `.pdf`, `.pptx`, `.txt`, `.xlsx`, `.xml` |
 
-Each surviving member recurses through the same `_dispatch_blob`
-helper as a top-level file (with `allow_archive=False`). Successful
-entries become independent `kb_uploads` rows — the user sees one row
-per file in the archive in the UI.
+Complexity units:
+
+| Member shape | Units |
+|---|---:|
+| `.md`, `.txt`, `.csv` up to 1 MB | 1 |
+| `.md`, `.txt`, `.csv` above 1 MB | 2 |
+| `.json`, `.xml` | 3 |
+| `.docx`, `.xlsx`, `.pptx` | 5 |
+| `.pdf` up to 10 MB | 10 |
+| `.pdf` above 10 MB | 10 + 1 per additional started 10 MB |
+
+Accepted entries recurse through the same direct upload dispatcher with
+`allow_archive=False`. Text entries complete through direct ingest; Docling
+entries enter the Docling queue. The UI should show one source row per member,
+not one source row for the archive.
 
 ## Out of scope (next iterations)
 

--- a/klai-portal/backend/app/api/app_knowledge_sources.py
+++ b/klai-portal/backend/app/api/app_knowledge_sources.py
@@ -502,6 +502,30 @@ async def _ingest_docling_bytes(
     )
 
 
+def _validate_archive_member_bytes(
+    *,
+    body: bytes,
+    filename: str,
+) -> FileUploadSkippedEntry | None:
+    """Run normal per-file validation without creating rows or side effects."""
+    try:
+        ext, pipeline = file_upload.classify_extension(filename)
+        if pipeline == "text":
+            file_upload.validate_text_upload(filename, body)
+        elif pipeline == "docling":
+            file_upload.validate_binary_upload(filename, body)
+        elif pipeline == "archive":
+            return FileUploadSkippedEntry(filename=filename, reason="archive_nested", extension=ext)
+        elif pipeline == "phase_pending":
+            return FileUploadSkippedEntry(filename=filename, reason="phase_pending", extension=ext)
+    except HTTPException as exc:
+        return FileUploadSkippedEntry(
+            filename=filename,
+            reason=_failure_reason_from(exc),
+        )
+    return None
+
+
 async def _dispatch_blob(
     *,
     body: bytes,
@@ -534,8 +558,6 @@ async def _dispatch_blob(
         if not allow_archive:
             skipped.append(FileUploadSkippedEntry(filename=filename, reason="archive_nested", extension=ext))
             return accepted, skipped
-        # Extract once, recurse per entry. Whole-archive failures bubble
-        # up as HTTPException to the caller so the route raises 400.
         try:
             extraction = archive.extract_archive(filename, body)
         except archive.ArchiveAbort as exc:
@@ -543,8 +565,16 @@ async def _dispatch_blob(
             skipped.append(FileUploadSkippedEntry(filename=filename, reason=reason, extension=ext))
             return accepted, skipped
 
-        for entry_skip in extraction.skipped:
-            skipped.append(FileUploadSkippedEntry(filename=entry_skip.filename, reason=entry_skip.reason))
+        if not extraction.extracted:
+            skipped.append(FileUploadSkippedEntry(filename=filename, reason="archive_empty", extension=ext))
+            return accepted, skipped
+
+        # Archive ingest is all-or-nothing. Validate every extracted member
+        # before starting any downstream ingest/docling side effect.
+        for member in extraction.extracted:
+            member_skip = _validate_archive_member_bytes(body=member.content, filename=member.filename)
+            if member_skip is not None:
+                return [], [member_skip]
 
         for member in extraction.extracted:
             inner_accepted, inner_skipped = await _dispatch_blob(
@@ -558,9 +588,6 @@ async def _dispatch_blob(
             )
             accepted.extend(inner_accepted)
             skipped.extend(inner_skipped)
-
-        if not extraction.extracted and not extraction.skipped:
-            skipped.append(FileUploadSkippedEntry(filename=filename, reason="archive_empty", extension=ext))
         return accepted, skipped
 
     if pipeline == "text":

--- a/klai-portal/backend/app/services/archive.py
+++ b/klai-portal/backend/app/services/archive.py
@@ -1,9 +1,9 @@
 """Safe archive extraction for ``.zip`` and ``.tar`` uploads.
 
-SPEC-KB-FILE-UPLOAD-001 — adds the archive pipeline. Extracts each
-member into memory under a strict guard set and yields
-``(filename, bytes)`` pairs that the caller dispatches through the
-normal text / docling pipelines.
+SPEC-KB-FILE-UPLOAD-001 — treats archives as all-or-nothing batch
+containers. Every member must pass preflight and streaming guards before
+the caller dispatches the member bytes through the normal text / docling
+pipelines.
 
 Defenses (sunzip-style; see also CVE-2024-0450, GHSA-ffj4-jq7m-9g6v,
 PEP 706):
@@ -11,9 +11,9 @@ PEP 706):
 - **Path traversal** — entry name MUST be a single basename. Reject
   ``..``, absolute paths, backslash separators, NUL, leading slashes.
 - **Nested archives** — entries with a recognised archive extension
-  (``.zip`` / ``.tar``) are rejected; we never recurse.
+  (``.zip`` / ``.tar``) reject the whole archive; we never recurse.
 - **Symlinks / devices (tar)** — only ``REGTYPE`` / ``AREGTYPE``
-  members are considered. Anything else is dropped silently.
+  members are accepted. Anything else rejects the whole archive.
 - **Per-entry uncompressed cap** — refuses any member whose declared
   uncompressed size exceeds :data:`MAX_PER_ENTRY_BYTES` (zip header)
   or that exceeds it during streaming read (tar — no header guarantee).
@@ -23,21 +23,22 @@ PEP 706):
   output. Catches 42-KB → 4-GB zip bombs early.
 - **Total uncompressed cap** — abort the entire archive when cumulative
   output exceeds :data:`MAX_TOTAL_UNCOMPRESSED_BYTES`.
-- **Member count cap** — abort when the archive header reports more
-  than :data:`MAX_ENTRIES` entries.
+- **Member count / complexity caps** — abort when member count,
+  docling-heavy member count, or weighted complexity exceeds the caps.
 - **Whitelist per entry** — only members whose extension is in
-  :func:`is_extractable_extension` are extracted; others are recorded
-  as skipped with reason ``archive_unsafe_entry``.
+  :func:`is_extractable_extension` are extracted; unsupported members
+  reject the whole archive.
 
-The extractor is a pure generator: it never writes to the filesystem
-and never invokes ``zipfile.extract*``. The caller persists the bytes
-via the same pipelines a direct upload would use.
+The extractor never invokes ``zipfile.extract*`` / ``tarfile.extract*``.
+It currently returns member bytes for the existing dispatcher contract;
+the streaming guards still apply while reading each member.
 """
 
 from __future__ import annotations
 
 import io
 import tarfile
+import tempfile
 import zipfile
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -46,14 +47,23 @@ from typing import IO
 
 from fastapi import HTTPException, status
 
-from app.services.file_upload import DOCLING_EXTENSIONS, TEXT_EXTENSIONS
+from app.services.file_upload import (
+    ARCHIVE_EXTENSIONS,
+    DOCLING_EXTENSIONS,
+    PENDING_EXTENSIONS,
+    TEXT_EXTENSIONS,
+)
 
 # --- Caps (sunzip-style guards) -------------------------------------------
 
-MAX_ENTRIES: int = 50
+MAX_ENTRIES: int = 200
+MAX_DOCLING_ENTRIES: int = 10
+MAX_COMPLEXITY_UNITS: int = 200
 MAX_PER_ENTRY_BYTES: int = 50 * 1024 * 1024  # 50 MB per file in archive
 MAX_TOTAL_UNCOMPRESSED_BYTES: int = 500 * 1024 * 1024  # 500 MB cumulative
 MAX_COMPRESSION_RATIO: float = 10.0
+_ONE_MB: int = 1024 * 1024
+_TEN_MB: int = 10 * 1024 * 1024
 # Below this many output bytes we don't trust the running ratio (tiny
 # archives have small denominators that produce wild ratios).
 _RATIO_GUARD_FLOOR_BYTES: int = 1 * 1024 * 1024
@@ -71,16 +81,14 @@ class ExtractedEntry:
     """One file extracted from an archive."""
 
     filename: str
-    content: bytes
+    _content: IO[bytes]
     bytes_count: int
 
-
-@dataclass(frozen=True)
-class SkippedEntry:
-    """One member that was rejected during extraction."""
-
-    filename: str
-    reason: str
+    @property
+    def content(self) -> bytes:
+        """Read staged member bytes for the existing upload dispatcher."""
+        self._content.seek(0)
+        return self._content.read()
 
 
 @dataclass(frozen=True)
@@ -88,15 +96,14 @@ class ExtractionResult:
     """Outcome of one safe-extract pass."""
 
     extracted: list[ExtractedEntry]
-    skipped: list[SkippedEntry]
+    skipped: list[object]
 
 
 class ArchiveAbort(HTTPException):
     """Raised when an archive-level guard fires (whole-request rejection).
 
-    Per-entry rejections are recorded in ``skipped[]`` instead — only
-    archive-wide failures (zip bomb, oversize total, too many entries,
-    malformed archive) raise.
+    All archive validation is all-or-nothing: one bad member rejects the
+    whole archive before downstream ingest/docling side effects start.
     """
 
     def __init__(self, error_code: str, **detail: object) -> None:
@@ -135,6 +142,17 @@ def _is_safe_member_name(name: str) -> bool:
     return True
 
 
+def _extension_rejection_reason(filename: str) -> str | None:
+    ext = PurePosixPath(filename).suffix.lower()
+    if ext in ARCHIVE_EXTENSIONS:
+        return "archive_nested"
+    if ext in PENDING_EXTENSIONS:
+        return "doc_format_not_yet_supported"
+    if ext in TEXT_EXTENSIONS or ext in DOCLING_EXTENSIONS:
+        return None
+    return "unsupported_extension"
+
+
 def is_extractable_extension(filename: str) -> bool:
     """Return True iff the archive entry's extension is in the
     text or docling whitelist (so the caller can dispatch it through
@@ -146,6 +164,78 @@ def is_extractable_extension(filename: str) -> bool:
     """
     ext = PurePosixPath(filename).suffix.lower()
     return ext in TEXT_EXTENSIONS or ext in DOCLING_EXTENSIONS
+
+
+def complexity_units(filename: str, declared_uncompressed_size: int) -> int:
+    """Return weighted archive complexity units for one member."""
+    ext = PurePosixPath(filename).suffix.lower()
+    if ext in {".md", ".txt", ".csv"}:
+        return 1 if declared_uncompressed_size <= _ONE_MB else 2
+    if ext in {".json", ".xml"}:
+        return 3
+    if ext in {".docx", ".xlsx", ".pptx"}:
+        return 5
+    if ext == ".pdf":
+        if declared_uncompressed_size <= _TEN_MB:
+            return 10
+        extra_bytes = declared_uncompressed_size - _TEN_MB
+        return 10 + ((extra_bytes + _TEN_MB - 1) // _TEN_MB)
+    return 0
+
+
+def _preflight_member(
+    *,
+    name: str,
+    declared_uncompressed_size: int,
+    seen_names: set[str],
+    totals: dict[str, int],
+) -> None:
+    if not _is_safe_member_name(name):
+        raise ArchiveAbort("archive_path_traversal", filename=name or "<unnamed>")
+
+    normalised = PurePosixPath(name).name.lower()
+    if normalised in seen_names:
+        raise ArchiveAbort("archive_duplicate_entry", filename=name)
+    seen_names.add(normalised)
+
+    rejection = _extension_rejection_reason(name)
+    if rejection is not None:
+        raise ArchiveAbort(rejection, filename=name)
+
+    if declared_uncompressed_size > MAX_PER_ENTRY_BYTES:
+        raise ArchiveAbort(
+            "archive_entry_too_large",
+            filename=name,
+            max_bytes=MAX_PER_ENTRY_BYTES,
+            declared_bytes=declared_uncompressed_size,
+        )
+
+    totals["entries"] += 1
+    if totals["entries"] > MAX_ENTRIES:
+        raise ArchiveAbort("archive_too_many_entries", max_entries=MAX_ENTRIES)
+
+    ext = PurePosixPath(name).suffix.lower()
+    if ext in DOCLING_EXTENSIONS:
+        totals["docling_entries"] += 1
+        if totals["docling_entries"] > MAX_DOCLING_ENTRIES:
+            raise ArchiveAbort(
+                "archive_too_many_docling_entries",
+                max_entries=MAX_DOCLING_ENTRIES,
+            )
+
+    totals["uncompressed"] += declared_uncompressed_size
+    if totals["uncompressed"] > MAX_TOTAL_UNCOMPRESSED_BYTES:
+        raise ArchiveAbort(
+            "archive_total_size",
+            max_bytes=MAX_TOTAL_UNCOMPRESSED_BYTES,
+        )
+
+    totals["complexity"] += complexity_units(name, declared_uncompressed_size)
+    if totals["complexity"] > MAX_COMPLEXITY_UNITS:
+        raise ArchiveAbort(
+            "archive_complexity_budget_exceeded",
+            max_units=MAX_COMPLEXITY_UNITS,
+        )
 
 
 # --- Archive type detection ------------------------------------------------
@@ -173,24 +263,26 @@ def _read_with_caps(
     *,
     declared_compressed_size: int | None,
     cumulative_uncompressed: int,
-) -> bytes:
+) -> tuple[IO[bytes], int]:
     """Stream-read ``source`` enforcing per-entry + cumulative + ratio caps.
 
-    Raises ``ArchiveAbort`` on any violation. Returns the full content
-    bytes if every cap held.
+    Raises ``ArchiveAbort`` on any violation. Returns a disk-backed staged
+    file plus byte count if every cap held.
     """
-    output = bytearray()
+    output = tempfile.SpooledTemporaryFile(max_size=_ONE_MB)
+    output_bytes = 0
     while True:
         chunk = source.read(_STREAM_CHUNK)
         if not chunk:
             break
-        output.extend(chunk)
-        if len(output) > MAX_PER_ENTRY_BYTES:
+        output.write(chunk)
+        output_bytes += len(chunk)
+        if output_bytes > MAX_PER_ENTRY_BYTES:
             raise ArchiveAbort(
                 "archive_entry_too_large",
                 max_bytes=MAX_PER_ENTRY_BYTES,
             )
-        running_total = cumulative_uncompressed + len(output)
+        running_total = cumulative_uncompressed + output_bytes
         if running_total > MAX_TOTAL_UNCOMPRESSED_BYTES:
             raise ArchiveAbort(
                 "archive_total_size",
@@ -202,112 +294,91 @@ def _read_with_caps(
         if (
             declared_compressed_size is not None
             and declared_compressed_size > 0
-            and len(output) >= _RATIO_GUARD_FLOOR_BYTES
+            and output_bytes >= _RATIO_GUARD_FLOOR_BYTES
         ):
-            ratio = len(output) / declared_compressed_size
+            ratio = output_bytes / declared_compressed_size
             if ratio > MAX_COMPRESSION_RATIO:
                 raise ArchiveAbort(
                     "archive_compression_ratio",
                     ratio=round(ratio, 2),
                     max_ratio=MAX_COMPRESSION_RATIO,
                 )
-    return bytes(output)
+    output.seek(0)
+    return output, output_bytes
 
 
-def _iter_zip(content: bytes) -> Iterator[ExtractedEntry | SkippedEntry]:
-    """Yield ``ExtractedEntry`` / ``SkippedEntry`` for each zip member.
-
-    Caller is responsible for the cumulative ``uncompressed`` byte
-    counter and bailing out on whole-archive failures.
-    """
+def _iter_zip(content: bytes) -> Iterator[ExtractedEntry]:
+    """Yield ``ExtractedEntry`` for each zip member."""
     try:
         archive = zipfile.ZipFile(io.BytesIO(content), mode="r")
     except zipfile.BadZipFile as exc:
         raise ArchiveAbort("archive_malformed", archive_type="zip") from exc
 
-    members = archive.infolist()
-    if len(members) > MAX_ENTRIES:
-        raise ArchiveAbort("archive_too_many_entries", max_entries=MAX_ENTRIES, received=len(members))
+    members = [info for info in archive.infolist() if not info.is_dir()]
+    totals = {"entries": 0, "docling_entries": 0, "uncompressed": 0, "complexity": 0}
+    seen_names: set[str] = set()
+    for info in members:
+        _preflight_member(
+            name=info.filename,
+            declared_uncompressed_size=info.file_size,
+            seen_names=seen_names,
+            totals=totals,
+        )
 
     cumulative = 0
     for info in members:
-        if info.is_dir():
-            continue
         name = info.filename
-        if not _is_safe_member_name(name):
-            yield SkippedEntry(filename=name or "<unnamed>", reason="archive_path_traversal")
-            continue
-        if not is_extractable_extension(name):
-            yield SkippedEntry(filename=name, reason="archive_unsafe_entry")
-            continue
-        # The zip header tells us the declared uncompressed size. Refuse
-        # over-sized entries upfront — saves the streaming read.
-        if info.file_size > MAX_PER_ENTRY_BYTES:
-            raise ArchiveAbort(
-                "archive_entry_too_large",
-                filename=name,
-                max_bytes=MAX_PER_ENTRY_BYTES,
-                declared_bytes=info.file_size,
-            )
         with archive.open(info, mode="r") as fp:
-            data = _read_with_caps(
+            staged, bytes_count = _read_with_caps(
                 fp,
                 declared_compressed_size=info.compress_size,
                 cumulative_uncompressed=cumulative,
             )
-        cumulative += len(data)
-        yield ExtractedEntry(filename=name, content=data, bytes_count=len(data))
+        cumulative += bytes_count
+        yield ExtractedEntry(filename=name, _content=staged, bytes_count=bytes_count)
 
 
-def _iter_tar(content: bytes) -> Iterator[ExtractedEntry | SkippedEntry]:
+def _iter_tar(content: bytes) -> Iterator[ExtractedEntry]:
     """Yield entries for each tar member.
 
     Only ``REGTYPE`` / ``AREGTYPE`` members survive — symlinks, devices,
-    fifos, hard links, and directories are dropped silently. The caller
-    treats nothing-extracted as a hard rejection at the route level.
+    fifos, hard links, and directories reject the archive.
     """
     try:
         archive = tarfile.open(fileobj=io.BytesIO(content), mode="r:")
     except tarfile.TarError as exc:
         raise ArchiveAbort("archive_malformed", archive_type="tar") from exc
 
-    cumulative = 0
-    member_count = 0
-    for member in archive:
-        if member.isdir():
-            continue
-        member_count += 1
-        if member_count > MAX_ENTRIES:
-            raise ArchiveAbort("archive_too_many_entries", max_entries=MAX_ENTRIES)
-        # Only regular files. Drop symlinks, hard links, devices, fifos.
+    members = [member for member in archive if not member.isdir()]
+    totals = {"entries": 0, "docling_entries": 0, "uncompressed": 0, "complexity": 0}
+    seen_names: set[str] = set()
+    for member in members:
         if not member.isreg():
-            yield SkippedEntry(filename=member.name, reason="archive_unsafe_entry")
-            continue
+            raise ArchiveAbort("archive_unsafe_entry", filename=member.name)
+        _preflight_member(
+            name=member.name,
+            declared_uncompressed_size=member.size,
+            seen_names=seen_names,
+            totals=totals,
+        )
+
+    cumulative = 0
+    for member in members:
         name = member.name
-        if not _is_safe_member_name(name):
-            yield SkippedEntry(filename=name or "<unnamed>", reason="archive_path_traversal")
-            continue
-        if not is_extractable_extension(name):
-            yield SkippedEntry(filename=name, reason="archive_unsafe_entry")
-            continue
-        if member.size > MAX_PER_ENTRY_BYTES:
-            raise ArchiveAbort(
-                "archive_entry_too_large",
-                filename=name,
-                max_bytes=MAX_PER_ENTRY_BYTES,
-                declared_bytes=member.size,
-            )
         fp = archive.extractfile(member)
         if fp is None:
-            yield SkippedEntry(filename=name, reason="archive_unsafe_entry")
-            continue
+            raise ArchiveAbort("archive_unsafe_entry", filename=name)
         # tar lacks per-member compression metadata. We use the
         # declared uncompressed size as a sanity proxy — a tar can't
         # be zip-bombed in the classic sense, but an oversize member
         # still lands here.
-        data = _read_with_caps(fp, declared_compressed_size=None, cumulative_uncompressed=cumulative)
-        cumulative += len(data)
-        yield ExtractedEntry(filename=name, content=data, bytes_count=len(data))
+        staged, bytes_count = _read_with_caps(
+            fp,
+            declared_compressed_size=None,
+            cumulative_uncompressed=cumulative,
+        )
+        cumulative += bytes_count
+        yield ExtractedEntry(filename=name, _content=staged, bytes_count=bytes_count)
 
 
 # --- Public API ------------------------------------------------------------
@@ -316,22 +387,19 @@ def _iter_tar(content: bytes) -> Iterator[ExtractedEntry | SkippedEntry]:
 def extract_archive(filename: str, content: bytes) -> ExtractionResult:
     """Safely extract one ``.zip`` / ``.tar`` archive.
 
-    Returns the list of accepted entries plus the per-member rejection
-    list. Whole-archive failures (zip bomb, malformed, too-many-entries,
-    oversize entry, oversize cumulative) raise :class:`ArchiveAbort`.
+    Returns the list of accepted entries. Whole-archive failures (unsafe
+    member, zip bomb, malformed, too-many-entries, oversize entry,
+    oversize cumulative) raise :class:`ArchiveAbort`.
 
     Raises:
         ArchiveAbort: on whole-archive guard violation.
     """
     archive_type = detect_archive_type(filename)
     extracted: list[ExtractedEntry] = []
-    skipped: list[SkippedEntry] = []
+    skipped: list[object] = []
 
     iterator = _iter_zip(content) if archive_type == "zip" else _iter_tar(content)
     for entry in iterator:
-        if isinstance(entry, ExtractedEntry):
-            extracted.append(entry)
-        else:
-            skipped.append(entry)
+        extracted.append(entry)
 
     return ExtractionResult(extracted=extracted, skipped=skipped)

--- a/klai-portal/backend/tests/test_app_knowledge_sources_file.py
+++ b/klai-portal/backend/tests/test_app_knowledge_sources_file.py
@@ -7,8 +7,9 @@ Covers the three pipelines exposed by the route:
 - **docling** (``.pdf / .docx / .xlsx / .pptx / .json / .xml``): magic-
   byte validate + submit to docling-serve async queue. Row created in
   ``processing`` state with the ``task_id``.
-- **phase_pending** (``.zip / .tar / .doc``): recorded as ``skipped``
-  with that reason.
+- **archive** (``.zip / .tar``): safely extracted as an all-or-nothing
+  batch; each member recurses through the text/docling paths.
+- **phase_pending** (``.doc``): recorded as ``skipped`` with that reason.
 
 The tests mock ``knowledge_ingest_client.ingest_document``,
 ``docling_client.submit_file_async`` and ``kb_uploads_repo`` helpers
@@ -20,6 +21,7 @@ from __future__ import annotations
 
 import io
 import uuid
+import zipfile
 from contextlib import ExitStack
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -170,6 +172,14 @@ def _make_multipart_request(filename: str, content: bytes, content_type: str) ->
         },
         receive,
     )
+
+
+def _build_zip(members: list[tuple[str, bytes]]) -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for name, data in members:
+            zf.writestr(name, data)
+    return buffer.getvalue()
 
 
 class _FilePatches:
@@ -457,6 +467,76 @@ class TestPhasePending:
 
         assert excinfo.value.status_code == 400
         assert excinfo.value.detail["error_code"] == "archive_malformed"
+
+
+# --- Archive pipeline ------------------------------------------------------
+
+
+class TestArchivePipeline:
+    @pytest.mark.asyncio
+    async def test_zip_with_valid_markdown_members_ingests_each_member(self) -> None:
+        from app.api.app_knowledge_sources import add_file_source
+
+        kb = _make_kb()
+        db = _make_db_mock(kb)
+        zip_bytes = _build_zip([("one.md", b"# One"), ("two.md", b"# Two")])
+        files = [_upload("bundle.zip", zip_bytes, "application/zip")]
+
+        with _FilePatches() as patches:
+            resp = await add_file_source(kb_slug="personal", request=_make_request(files), perms=_make_perms(), db=db)
+
+        assert len(resp.uploads) == 2
+        assert {u.filename for u in resp.uploads} == {"one.md", "two.md"}
+        assert {u.status for u in resp.uploads} == {"done"}
+        assert resp.skipped == []
+        assert patches.mock_ingest is not None
+        assert patches.mock_ingest.call_count == 2
+        assert patches.mock_docling is not None
+        patches.mock_docling.assert_not_called()
+        assert patches.mock_create_upload is not None
+        assert patches.mock_create_upload.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_zip_with_unsupported_member_rejects_whole_archive(self) -> None:
+        from app.api.app_knowledge_sources import add_file_source
+
+        kb = _make_kb()
+        db = _make_db_mock(kb)
+        zip_bytes = _build_zip([("one.md", b"# One"), ("script.exe", b"MZ\x90")])
+        files = [_upload("bundle.zip", zip_bytes, "application/zip")]
+
+        with _FilePatches() as patches, pytest.raises(HTTPException) as excinfo:
+            await add_file_source(kb_slug="personal", request=_make_request(files), perms=_make_perms(), db=db)
+
+        assert excinfo.value.status_code == 400
+        assert excinfo.value.detail["error_code"] == "unsupported_extension"
+        assert patches.mock_ingest is not None
+        patches.mock_ingest.assert_not_called()
+        assert patches.mock_docling is not None
+        patches.mock_docling.assert_not_called()
+        assert patches.mock_create_upload is not None
+        patches.mock_create_upload.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_zip_with_mime_mismatch_rejects_before_any_member_ingest(self) -> None:
+        from app.api.app_knowledge_sources import add_file_source
+
+        kb = _make_kb()
+        db = _make_db_mock(kb)
+        zip_bytes = _build_zip([("one.md", b"# One"), ("fake.pdf", b"GIF89a\x00\x00")])
+        files = [_upload("bundle.zip", zip_bytes, "application/zip")]
+
+        with _FilePatches() as patches, pytest.raises(HTTPException) as excinfo:
+            await add_file_source(kb_slug="personal", request=_make_request(files), perms=_make_perms(), db=db)
+
+        assert excinfo.value.status_code == 400
+        assert excinfo.value.detail["error_code"] == "mime_mismatch"
+        assert patches.mock_ingest is not None
+        patches.mock_ingest.assert_not_called()
+        assert patches.mock_docling is not None
+        patches.mock_docling.assert_not_called()
+        assert patches.mock_create_upload is not None
+        patches.mock_create_upload.assert_not_called()
 
 
 # --- Mixed multi-file ------------------------------------------------------

--- a/klai-portal/backend/tests/test_archive.py
+++ b/klai-portal/backend/tests/test_archive.py
@@ -111,30 +111,33 @@ class TestZipExtraction:
         assert names == {"notes.md", "data.csv"}
         assert result.skipped == []
 
-    def test_path_traversal_skipped(self) -> None:
+    def test_path_traversal_aborts(self) -> None:
         zip_bytes = _build_zip([("notes.md", b"# ok"), ("../../etc/passwd.md", b"# attack")])
-        result = archive.extract_archive("bundle.zip", zip_bytes)
 
-        assert len(result.extracted) == 1
-        assert result.extracted[0].filename == "notes.md"
-        assert len(result.skipped) == 1
-        assert result.skipped[0].reason == "archive_path_traversal"
+        with pytest.raises(archive.ArchiveAbort) as excinfo:
+            archive.extract_archive("bundle.zip", zip_bytes)
+        assert excinfo.value.detail["error_code"] == "archive_path_traversal"
 
-    def test_nested_archive_skipped(self) -> None:
+    def test_nested_archive_aborts(self) -> None:
         zip_bytes = _build_zip([("notes.md", b"# ok"), ("inner.zip", b"PK\x03\x04")])
-        result = archive.extract_archive("bundle.zip", zip_bytes)
 
-        assert len(result.extracted) == 1
-        assert result.extracted[0].filename == "notes.md"
-        assert any(s.reason == "archive_unsafe_entry" for s in result.skipped)
+        with pytest.raises(archive.ArchiveAbort) as excinfo:
+            archive.extract_archive("bundle.zip", zip_bytes)
+        assert excinfo.value.detail["error_code"] == "archive_nested"
 
-    def test_unknown_extension_skipped(self) -> None:
+    def test_unknown_extension_aborts(self) -> None:
         zip_bytes = _build_zip([("notes.md", b"# ok"), ("script.sh", b"#!/bin/sh")])
-        result = archive.extract_archive("bundle.zip", zip_bytes)
 
-        assert len(result.extracted) == 1
-        assert result.extracted[0].filename == "notes.md"
-        assert any(s.reason == "archive_unsafe_entry" for s in result.skipped)
+        with pytest.raises(archive.ArchiveAbort) as excinfo:
+            archive.extract_archive("bundle.zip", zip_bytes)
+        assert excinfo.value.detail["error_code"] == "unsupported_extension"
+
+    def test_doc_inside_archive_aborts_as_not_supported(self) -> None:
+        zip_bytes = _build_zip([("legacy.doc", b"\xd0\xcf\x11\xe0")])
+
+        with pytest.raises(archive.ArchiveAbort) as excinfo:
+            archive.extract_archive("bundle.zip", zip_bytes)
+        assert excinfo.value.detail["error_code"] == "doc_format_not_yet_supported"
 
     def test_too_many_entries_aborts(self) -> None:
         members = [(f"f{i}.md", b"x") for i in range(archive.MAX_ENTRIES + 1)]
@@ -143,6 +146,38 @@ class TestZipExtraction:
         with pytest.raises(archive.ArchiveAbort) as excinfo:
             archive.extract_archive("big.zip", zip_bytes)
         assert excinfo.value.detail["error_code"] == "archive_too_many_entries"
+
+    def test_many_small_markdown_entries_allowed(self) -> None:
+        members = [(f"f{i}.md", b"# ok") for i in range(150)]
+        zip_bytes = _build_zip(members)
+
+        result = archive.extract_archive("many.zip", zip_bytes)
+
+        assert len(result.extracted) == 150
+
+    def test_too_many_docling_entries_aborts(self) -> None:
+        members = [(f"f{i}.pdf", b"%PDF-1.4\n%%EOF\n") for i in range(archive.MAX_DOCLING_ENTRIES + 1)]
+        zip_bytes = _build_zip(members)
+
+        with pytest.raises(archive.ArchiveAbort) as excinfo:
+            archive.extract_archive("pdfs.zip", zip_bytes)
+        assert excinfo.value.detail["error_code"] == "archive_too_many_docling_entries"
+
+    def test_duplicate_normalised_name_aborts(self) -> None:
+        zip_bytes = _build_zip([("Notes.md", b"# one"), ("notes.md", b"# two")])
+
+        with pytest.raises(archive.ArchiveAbort) as excinfo:
+            archive.extract_archive("dupes.zip", zip_bytes)
+        assert excinfo.value.detail["error_code"] == "archive_duplicate_entry"
+
+    def test_complexity_budget_aborts(self) -> None:
+        large_text = b"x" * (1024 * 1024 + 1)
+        members = [(f"f{i}.md", large_text) for i in range((archive.MAX_COMPLEXITY_UNITS // 2) + 1)]
+        zip_bytes = _build_zip(members)
+
+        with pytest.raises(archive.ArchiveAbort) as excinfo:
+            archive.extract_archive("complex.zip", zip_bytes)
+        assert excinfo.value.detail["error_code"] == "archive_complexity_budget_exceeded"
 
     def test_oversize_entry_header_aborts(self) -> None:
         # Build a member whose declared file_size > cap. Easiest: make
@@ -172,7 +207,7 @@ class TestTarExtraction:
         assert len(result.extracted) == 2
         assert result.skipped == []
 
-    def test_symlink_skipped(self) -> None:
+    def test_symlink_aborts(self) -> None:
         # Hand-build a tar with a SYMTYPE entry next to a regular file.
         buffer = io.BytesIO()
         with tarfile.open(fileobj=buffer, mode="w") as tf:
@@ -188,15 +223,13 @@ class TestTarExtraction:
             link.linkname = "/etc/passwd"
             tf.addfile(link)
 
-        result = archive.extract_archive("evil.tar", buffer.getvalue())
+        with pytest.raises(archive.ArchiveAbort) as excinfo:
+            archive.extract_archive("evil.tar", buffer.getvalue())
+        assert excinfo.value.detail["error_code"] == "archive_unsafe_entry"
 
-        assert len(result.extracted) == 1
-        assert result.extracted[0].filename == "notes.md"
-        assert any(s.reason == "archive_unsafe_entry" for s in result.skipped)
-
-    def test_path_traversal_skipped(self) -> None:
+    def test_path_traversal_aborts(self) -> None:
         tar_bytes = _build_tar([("notes.md", b"# ok"), ("../../etc/passwd.md", b"# attack")])
-        result = archive.extract_archive("evil.tar", tar_bytes)
 
-        assert len(result.extracted) == 1
-        assert any(s.reason == "archive_path_traversal" for s in result.skipped)
+        with pytest.raises(archive.ArchiveAbort) as excinfo:
+            archive.extract_archive("evil.tar", tar_bytes)
+        assert excinfo.value.detail["error_code"] == "archive_path_traversal"


### PR DESCRIPTION
## Summary
- make archive uploads all-or-nothing before downstream ingest/docling side effects
- raise light archive member cap to 200 with a weighted complexity budget and docling-member cap
- stage extracted members through spooled temp files and update spec/runbook/tests

## Validation
- cd klai-portal/backend && uv run pytest tests/test_archive.py tests/test_file_upload.py tests/test_app_knowledge_sources_file.py tests/test_kb_upload_poller.py -q
- cd klai-portal/backend && uv run ruff check app/services/archive.py app/api/app_knowledge_sources.py tests/test_archive.py tests/test_app_knowledge_sources_file.py
- cd klai-portal/backend && uv run pyright app/services/archive.py app/api/app_knowledge_sources.py
- git diff --check