### PR TITLE
Pass user id for personal KB ingests

### DIFF
--- a/klai-portal/backend/app/api/app_knowledge_sources.py
+++ b/klai-portal/backend/app/api/app_knowledge_sources.py
@@ -184,6 +184,7 @@ async def _forward_ingest(
     content_type: str,
     source_ref: str,
     extra: dict,
+    user_id: str | None = None,
 ) -> str:
     """Build the IngestRequest payload and post it to knowledge-ingest."""
     payload: dict = {
@@ -198,6 +199,8 @@ async def _forward_ingest(
         "kb_name": kb.name,
         "extra": extra,
     }
+    if user_id:
+        payload["user_id"] = user_id
     try:
         return await knowledge_ingest_client.ingest_document(payload)
     except httpx.HTTPStatusError as exc:
@@ -270,6 +273,7 @@ async def add_url_source(
         content_type="web_page",
         source_ref=source_ref,
         extra={"source_url": source_ref},
+        user_id=perms.user_id if kb.owner_type == "user" else None,
     )
     logger.info(
         "source_ingested",
@@ -349,6 +353,7 @@ async def add_text_source(
         content_type="plain_text",
         source_ref=source_ref,
         extra={"original_title": (body.title or "").strip() or None},
+        user_id=perms.user_id if kb.owner_type == "user" else None,
     )
     logger.info(
         "source_ingested",
@@ -416,6 +421,7 @@ async def _ingest_text_bytes(
             "bytes": validated.bytes_count,
             "pipeline": "text",
         },
+        user_id=perms.user_id if kb.owner_type == "user" else None,
     )
 
     upload_view = await kb_uploads_repo.create_upload(

--- a/klai-portal/backend/tests/test_app_knowledge_sources_file.py
+++ b/klai-portal/backend/tests/test_app_knowledge_sources_file.py
@@ -310,6 +310,7 @@ class TestTextPipeline:
         assert payload["content_type"] == "plain_text"
         assert payload["title"] == "notes"
         assert payload["content"] == "# Hello\n\nworld"
+        assert payload["user_id"] == "user-abc"
         assert payload["extra"]["pipeline"] == "text"
 
         # kb_uploads row created in 'done' state


### PR DESCRIPTION
## Summary
- include user_id when portal forwards URL/text/file ingests for user-owned KBs
- adds a regression assertion for file uploads into user KBs

## Validation
- cd klai-portal/backend && uv run pytest tests/test_app_knowledge_sources_file.py tests/test_app_knowledge_sources.py -q
- cd klai-portal/backend && uv run ruff check app/api/app_knowledge_sources.py tests/test_app_knowledge_sources_file.py tests/test_app_knowledge_sources.py
- cd klai-portal/backend && uv run pyright app/api/app_knowledge_sources.py
- git diff --check