### PR TITLE
Fix LibreChat tenant env recreate

### DIFF
--- a/klai-portal/backend/app/services/provisioning/generators.py
+++ b/klai-portal/backend/app/services/provisioning/generators.py
@@ -161,6 +161,8 @@ DOMAIN_CLIENT=https://chat-{slug}.{domain}
 DOMAIN_SERVER=https://chat-{slug}.{domain}
 APP_TITLE=Klai Chat
 ALLOW_IFRAME=true
+ALLOW_SHARED_LINKS=true
+ALLOW_SHARED_LINKS_PUBLIC=true
 
 # Session secrets
 JWT_SECRET={jwt_secret}

--- a/klai-portal/backend/app/services/provisioning/infrastructure.py
+++ b/klai-portal/backend/app/services/provisioning/infrastructure.py
@@ -31,6 +31,17 @@ logger = structlog.get_logger()
 # user does not exist). Non-fatal for idempotent drop.
 _MONGO_USER_NOT_FOUND = 11
 
+_LIBRECHAT_REQUIRED_ENV_FLAGS = {
+    "ALLOW_SHARED_LINKS": "true",
+    "ALLOW_SHARED_LINKS_PUBLIC": "true",
+}
+
+_LIBRECHAT_PATCH_MOUNTS = {
+    "patches/format.cjs": "/app/node_modules/@librechat/agents/dist/cjs/messages/format.cjs",
+    "patches/stream.cjs": "/app/node_modules/@librechat/agents/dist/cjs/stream.cjs",
+    "patches/search.cjs": "/app/node_modules/@librechat/agents/dist/cjs/tools/search/search.cjs",
+}
+
 # Process-wide lock that serialises Caddy file writes + container restarts.
 # Both `provision_tenant` (orchestrator.py) and `deprovision_tenant`
 # (deprovisioning_orchestrator.py + deprovisioning_steps.py) acquire this
@@ -130,6 +141,53 @@ def _create_mongodb_tenant_user(slug: str, tenant_password: str) -> None:
         logger.info("mongodb_tenant_user_created", slug=slug, db=db_name)
     except OperationFailure as exc:
         raise RuntimeError(f"MongoDB tenant user creation failed for {slug} (code {exc.code}): {exc.details}") from exc
+
+
+def _read_dotenv_file(path: Path) -> dict[str, str]:
+    """Parse the generated tenant .env into Docker process env values."""
+    values: dict[str, str] = {}
+    for lineno, raw_line in enumerate(path.read_text().splitlines(), start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, sep, value = line.partition("=")
+        if not sep or not key:
+            raise RuntimeError(f"Invalid LibreChat env line in {path} at line {lineno}")
+        values[key] = value
+    return values
+
+
+def _ensure_librechat_env_flags(path: Path) -> dict[str, str]:
+    """Persist required non-secret flags and return process env for Docker."""
+    env = _read_dotenv_file(path)
+    changed = False
+    for key, value in _LIBRECHAT_REQUIRED_ENV_FLAGS.items():
+        if env.get(key) != value:
+            env[key] = value
+            changed = True
+
+    if changed:
+        lines = path.read_text().splitlines()
+        seen: set[str] = set()
+        updated: list[str] = []
+        for line in lines:
+            key, sep, _value = line.partition("=")
+            if sep and key in _LIBRECHAT_REQUIRED_ENV_FLAGS:
+                updated.append(f"{key}={_LIBRECHAT_REQUIRED_ENV_FLAGS[key]}")
+                seen.add(key)
+            else:
+                updated.append(line)
+
+        missing = [key for key in _LIBRECHAT_REQUIRED_ENV_FLAGS if key not in seen]
+        insert_at = next(
+            (idx + 1 for idx, line in enumerate(updated) if line.startswith("ALLOW_IFRAME=")),
+            len(updated),
+        )
+        for offset, key in enumerate(missing):
+            updated.insert(insert_at + offset, f"{key}={_LIBRECHAT_REQUIRED_ENV_FLAGS[key]}")
+        path.write_text("\n".join(updated).rstrip() + "\n")
+
+    return env
 
 
 def _flush_redis_and_restart_librechat(slug: str) -> None:
@@ -276,7 +334,23 @@ def _start_librechat_container(
     tenant_yaml_content = _generate_librechat_yaml(base_yaml_path, mcp_servers)
     tenant_yaml_dir = Path(settings.librechat_container_data_path) / slug
     tenant_yaml_dir.mkdir(parents=True, exist_ok=True)
+    (tenant_yaml_dir / "images").mkdir(exist_ok=True)
     (tenant_yaml_dir / "librechat.yaml").write_text(tenant_yaml_content)
+    tenant_env_path = tenant_yaml_dir / ".env"
+    if not tenant_env_path.exists():
+        raise RuntimeError(f"LibreChat tenant env file missing for {slug}: {tenant_env_path}")
+    container_environment = _ensure_librechat_env_flags(tenant_env_path)
+
+    volumes = {
+        env_file_host_path: {"bind": "/app/.env", "mode": "ro"},
+        f"{librechat_host_base}/{slug}/librechat.yaml": {"bind": "/app/librechat.yaml", "mode": "ro"},
+        f"{librechat_host_base}/{slug}/images": {"bind": "/app/client/public/images", "mode": "rw"},
+    }
+    for source_rel_path, destination in _LIBRECHAT_PATCH_MOUNTS.items():
+        patch_container_path = Path(settings.librechat_container_data_path) / source_rel_path
+        if not patch_container_path.exists():
+            raise RuntimeError(f"LibreChat patch file missing: {patch_container_path}")
+        volumes[f"{librechat_host_base}/{source_rel_path}"] = {"bind": destination, "mode": "ro"}
 
     # @MX:ANCHOR provisioning-labels — SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-2.
     # These three labels mark the container as klasse-B (provisioning-managed)
@@ -297,11 +371,8 @@ def _start_librechat_container(
         detach=True,
         restart_policy={"Name": "unless-stopped"},  # type: ignore[arg-type]
         labels=container_labels,
-        volumes={
-            env_file_host_path: {"bind": "/app/.env", "mode": "ro"},
-            f"{librechat_host_base}/{slug}/librechat.yaml": {"bind": "/app/librechat.yaml", "mode": "ro"},
-            f"{librechat_host_base}/{slug}/images": {"bind": "/app/client/public/images", "mode": "rw"},
-        },
+        environment=container_environment,
+        volumes=volumes,
         network="klai-net",
     )
 

--- a/klai-portal/backend/tests/services/provisioning/test_generators.py
+++ b/klai-portal/backend/tests/services/provisioning/test_generators.py
@@ -105,6 +105,8 @@ class TestCharacterizeGenerateLibrechatEnvSnapshot:
         assert "MONGO_URI=mongodb://librechat-snapshot-org:pw-snap@mongodb:27017" in result
         assert "OPENID_CLIENT_ID=cid-snap" in result
         assert "DOMAIN_CLIENT=https://chat-snapshot-org.getklai.com" in result
+        assert "ALLOW_SHARED_LINKS=true" in result
+        assert "ALLOW_SHARED_LINKS_PUBLIC=true" in result
         assert "KLAI_ZITADEL_ORG_ID=org-snap-123" in result
         assert "KLAI_ORG_SLUG=snapshot-org" in result
         # Deterministic secrets

--- a/klai-portal/backend/tests/services/provisioning/test_infrastructure.py
+++ b/klai-portal/backend/tests/services/provisioning/test_infrastructure.py
@@ -389,12 +389,20 @@ class TestCharacterizeFlushRedisAndRestartLibrechat:
 class TestCharacterizeStartLibrechatContainer:
     """Characterization tests for _start_librechat_container."""
 
+    def _write_lc_files(self, tmp_path: Path, slug: str = "acme") -> None:
+        (tmp_path / "librechat.yaml").write_text("version: 1.0\n")
+        tenant_dir = tmp_path / slug
+        tenant_dir.mkdir(parents=True, exist_ok=True)
+        (tenant_dir / ".env").write_text("MONGO_URI=mongodb://example\nALLOW_IFRAME=true\nJWT_SECRET=keep-me\n")
+        patch_dir = tmp_path / "patches"
+        patch_dir.mkdir(exist_ok=True)
+        for name in ("format.cjs", "stream.cjs", "search.cjs"):
+            (patch_dir / name).write_text("// patch\n")
+
     def test_starts_container_with_correct_config(self, tmp_path):
         from app.services.provisioning import _start_librechat_container
 
-        # Create base yaml file
-        base_yaml = Path(tmp_path) / "librechat.yaml"
-        base_yaml.write_text("version: 1.0\n")
+        self._write_lc_files(tmp_path)
 
         mock_client = MagicMock()
         mock_client.containers.get.side_effect = type("NotFound", (Exception,), {})("not found")
@@ -418,6 +426,67 @@ class TestCharacterizeStartLibrechatContainer:
             assert call_kwargs[1]["detach"] is True
             assert call_kwargs[1]["network"] == "klai-net"
 
+    def test_passes_tenant_env_as_process_environment(self, tmp_path):
+        from app.services.provisioning import _start_librechat_container
+
+        self._write_lc_files(tmp_path)
+
+        mock_client = MagicMock()
+        with (
+            patch("app.services.provisioning.infrastructure.docker") as mock_docker,
+            patch("app.services.provisioning.infrastructure.settings") as mock_settings,
+        ):
+            mock_settings.librechat_host_data_path = "/opt/klai/librechat-data"
+            mock_settings.librechat_container_data_path = str(tmp_path)
+            mock_settings.librechat_image = "ghcr.io/danny-avila/librechat:latest"
+            mock_docker.from_env.return_value = mock_client
+            mock_docker.errors.NotFound = type("NotFound", (Exception,), {})
+            mock_client.containers.get.side_effect = mock_docker.errors.NotFound("not found")
+
+            _start_librechat_container("acme", "/opt/klai/librechat-data/acme/.env")
+
+        environment = mock_client.containers.run.call_args[1]["environment"]
+        assert environment["MONGO_URI"] == "mongodb://example"
+        assert environment["JWT_SECRET"] == "keep-me"
+        assert environment["ALLOW_SHARED_LINKS"] == "true"
+        assert environment["ALLOW_SHARED_LINKS_PUBLIC"] == "true"
+        env_file_content = (tmp_path / "acme" / ".env").read_text()
+        assert "ALLOW_SHARED_LINKS=true" in env_file_content
+        assert "ALLOW_SHARED_LINKS_PUBLIC=true" in env_file_content
+
+    def test_mounts_live_librechat_patches(self, tmp_path):
+        from app.services.provisioning import _start_librechat_container
+
+        self._write_lc_files(tmp_path)
+
+        mock_client = MagicMock()
+        with (
+            patch("app.services.provisioning.infrastructure.docker") as mock_docker,
+            patch("app.services.provisioning.infrastructure.settings") as mock_settings,
+        ):
+            mock_settings.librechat_host_data_path = "/opt/klai/librechat-data"
+            mock_settings.librechat_container_data_path = str(tmp_path)
+            mock_settings.librechat_image = "ghcr.io/danny-avila/librechat:latest"
+            mock_docker.from_env.return_value = mock_client
+            mock_docker.errors.NotFound = type("NotFound", (Exception,), {})
+            mock_client.containers.get.side_effect = mock_docker.errors.NotFound("not found")
+
+            _start_librechat_container("acme", "/opt/klai/librechat-data/acme/.env")
+
+        volumes = mock_client.containers.run.call_args[1]["volumes"]
+        assert volumes["/opt/klai/librechat-data/patches/format.cjs"] == {
+            "bind": "/app/node_modules/@librechat/agents/dist/cjs/messages/format.cjs",
+            "mode": "ro",
+        }
+        assert volumes["/opt/klai/librechat-data/patches/stream.cjs"] == {
+            "bind": "/app/node_modules/@librechat/agents/dist/cjs/stream.cjs",
+            "mode": "ro",
+        }
+        assert volumes["/opt/klai/librechat-data/patches/search.cjs"] == {
+            "bind": "/app/node_modules/@librechat/agents/dist/cjs/tools/search/search.cjs",
+            "mode": "ro",
+        }
+
     def test_provisioning_labels_are_set(self, tmp_path):
         """SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-2a: tenant-LibreChats MUST
         carry klai.managed_by, klai.tenant_slug, and klai.kind labels so
@@ -430,8 +499,7 @@ class TestCharacterizeStartLibrechatContainer:
         """
         from app.services.provisioning import _start_librechat_container
 
-        base_yaml = Path(tmp_path) / "librechat.yaml"
-        base_yaml.write_text("version: 1.0\n")
+        self._write_lc_files(tmp_path, slug="voys")
 
         mock_client = MagicMock()
         mock_client.containers.get.side_effect = type("NotFound", (Exception,), {})("not found")
@@ -461,8 +529,9 @@ class TestCharacterizeStartLibrechatContainer:
         """
         from app.services.provisioning import _start_librechat_container
 
-        base_yaml = Path(tmp_path) / "librechat.yaml"
-        base_yaml.write_text("version: 1.0\n")
+        self._write_lc_files(tmp_path, slug="voys")
+        self._write_lc_files(tmp_path, slug="acme-corp")
+        self._write_lc_files(tmp_path, slug="klai-internal")
 
         mock_client = MagicMock()
         mock_client.containers.get.side_effect = type("NotFound", (Exception,), {})("not found")

--- a/klai-portal/backend/tests/test_provisioning.py
+++ b/klai-portal/backend/tests/test_provisioning.py
@@ -69,6 +69,8 @@ class TestCharacterizeGenerateLibrechatEnv:
         assert "DOMAIN_CLIENT=https://chat-acme.getklai.com" in result
         assert "DOMAIN_SERVER=https://chat-acme.getklai.com" in result
         assert "APP_TITLE=Klai Chat" in result
+        assert "ALLOW_SHARED_LINKS=true" in result
+        assert "ALLOW_SHARED_LINKS_PUBLIC=true" in result
 
         # Session secrets (non-deterministic, just check they exist)
         assert "JWT_SECRET=" in result


### PR DESCRIPTION
## Summary

- add LibreChat public share env flags to generated tenant env files
- make portal-managed tenant recreates pass tenant `.env` as Docker process env
- preserve the live LibreChat patch mounts when tenant containers are recreated

## Why

`librechat-voys` currently has `ALLOW_SHARED_LINKS_PUBLIC` missing from Docker process env. Updating the tenant `.env` file and restarting is not enough because Docker does not reload process env on restart. The recreate path also needed to preserve the mounted LibreChat patches already present on live containers.

## Validation

- `uv run pytest tests/services/provisioning/test_infrastructure.py tests/test_provisioning.py tests/services/provisioning/test_generators.py -q`
- `uv run pytest tests/services/provisioning tests/test_provisioning.py tests/test_librechat_regenerate.py -q`
- `uv run ruff check app/services/provisioning/infrastructure.py app/services/provisioning/generators.py tests/services/provisioning/test_infrastructure.py tests/test_provisioning.py tests/services/provisioning/test_generators.py`
- `uv run pyright app/services/provisioning/infrastructure.py app/services/provisioning/generators.py`
