### PR TITLE
Drop disallowed images from public shares

### DIFF
--- a/deploy/librechat/patches/share.js
+++ b/deploy/librechat/patches/share.js
@@ -64,7 +64,7 @@ function sanitizeMarkdown(text) {
       if (isAllowedImageUrl(url)) {
         return _match;
       }
-      return alt ? String(alt) : '';
+      return '';
     })
     .replace(/\[([^\]]+)\]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)/g, (_match, label, url) => {
       if (isPlaceholderUrl(url)) {


### PR DESCRIPTION
## Summary
- remove disallowed markdown images entirely from public LibreChat share responses instead of preserving alt text

## Verification
- node --check deploy/librechat/patches/share.js
- git diff --check -- deploy/librechat/patches/share.js