### PR TITLE
Fix knowledge Bronnen URL source display

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/pg_store.py
+++ b/klai-knowledge-ingest/knowledge_ingest/pg_store.py
@@ -1156,6 +1156,8 @@ async def list_kb_sources(
         SELECT
             a.id::text AS id,
             a.path AS path,
+            COALESCE(NULLIF(a.extra::jsonb->>'display_name', ''), a.path) AS display_name,
+            NULLIF(a.extra::jsonb->>'source_url', '') AS source_url,
             a.content_type AS content_type,
             a.created_at AS created_at,
             COUNT(pc.id) AS chunks_count,
@@ -1166,7 +1168,7 @@ async def list_kb_sources(
           AND a.kb_slug = $2
           AND a.belief_time_end = $3
           AND (a.extra IS NULL OR a.extra::jsonb->>'source_connector_id' IS NULL)
-        GROUP BY a.id, a.path, a.content_type, a.created_at, a.index_status
+        GROUP BY a.id, a.path, a.extra, a.content_type, a.created_at, a.index_status
         ORDER BY a.created_at DESC
         """,
         org_id,
@@ -1177,6 +1179,8 @@ async def list_kb_sources(
         {
             "id": row["id"],
             "path": row["path"],
+            "display_name": row["display_name"],
+            "source_url": row["source_url"],
             "content_type": row["content_type"],
             "created_at": int(row["created_at"]),
             "chunks_count": int(row["chunks_count"] or 0),
@@ -1326,6 +1330,45 @@ async def set_artifact_index_status(
     if row is None:
         return None
     return {"artifact_id": row["artifact_id"], "path": row["path"]}
+
+
+async def update_artifact_display_name(
+    conn: asyncpg.Connection,
+    artifact_id: str,
+    org_id: str,
+    kb_slug: str,
+    display_name: str,
+) -> dict | None:
+    """Set a direct-upload display name without changing the storage path.
+
+    ``path`` is the Qdrant/delete/reindex identity for direct uploads. Renaming
+    it in place would leave vector payloads and artifact rows disagreeing, so
+    the editable user-facing name lives in ``extra.display_name``.
+    """
+    row = await conn.fetchrow(
+        """
+        UPDATE knowledge.artifacts
+        SET extra = COALESCE(extra, '{}'::jsonb) || jsonb_build_object('display_name', $1::text)
+        WHERE id = $2::uuid
+          AND org_id = $3
+          AND kb_slug = $4
+          AND belief_time_end = $5
+          AND (extra IS NULL OR extra::jsonb->>'source_connector_id' IS NULL)
+        RETURNING id::text AS artifact_id, path, extra::jsonb->>'display_name' AS display_name
+        """,
+        display_name,
+        artifact_id,
+        org_id,
+        kb_slug,
+        _SENTINEL,
+    )
+    if row is None:
+        return None
+    return {
+        "artifact_id": row["artifact_id"],
+        "path": row["path"],
+        "display_name": row["display_name"],
+    }
 
 
 async def get_kb_upload_artifact(

--- a/klai-knowledge-ingest/knowledge_ingest/routes/kb_sources.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/kb_sources.py
@@ -59,6 +59,8 @@ class ConnectorAggregate(BaseModel):
 class UploadSummary(BaseModel):
     id: str
     path: str
+    display_name: str | None = None
+    source_url: str | None = None
     content_type: str
     created_at: int
     chunks_count: int = 0
@@ -207,6 +209,16 @@ class ReindexResponse(BaseModel):
     index_status: str
 
 
+class RenameUploadRequest(BaseModel):
+    name: str = Field(min_length=1, max_length=200)
+
+
+class RenameUploadResponse(BaseModel):
+    artifact_id: str
+    path: str
+    display_name: str
+
+
 @router.post(
     "/knowledge/v1/artifacts/{artifact_id}/reindex",
     response_model=ReindexResponse,
@@ -241,6 +253,36 @@ async def reindex_upload(
         org_id=verified_org_id,
     )
     return ReindexResponse(artifact_id=artifact_id, index_status="pending")
+
+
+@router.patch(
+    "/knowledge/v1/kb/{kb_slug}/uploads/{artifact_id}",
+    response_model=RenameUploadResponse,
+)
+async def rename_upload(
+    request: Request,
+    kb_slug: str,
+    artifact_id: str,
+    body: RenameUploadRequest,
+    org_id: str = Query(..., description="Zitadel org ID"),
+) -> RenameUploadResponse:
+    """Rename the user-facing label for a direct-upload artifact.
+
+    This intentionally does not mutate ``artifacts.path`` because that field
+    is also the document identity used in Qdrant cleanup and reindex flows.
+    """
+    verified_org_id = await assert_caller_identity_tenant_only(request, claimed_org_id=org_id)
+    async with tenant_scoped_connection(verified_org_id) as conn:
+        updated = await pg_store.update_artifact_display_name(
+            conn,
+            artifact_id,
+            verified_org_id,
+            kb_slug,
+            body.name.strip(),
+        )
+    if updated is None:
+        raise HTTPException(status_code=404, detail="artifact not found")
+    return RenameUploadResponse(**updated)
 
 
 @router.delete(

--- a/klai-knowledge-ingest/knowledge_ingest/source_label.py
+++ b/klai-knowledge-ingest/knowledge_ingest/source_label.py
@@ -2,23 +2,30 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from urllib.parse import urlparse
 
 if TYPE_CHECKING:
     from knowledge_ingest.models import IngestRequest
 
 
-def compute_source_label(req: "IngestRequest") -> str:
+def compute_source_label(req: IngestRequest) -> str:
     """Compute a human-readable source label for a chunk payload.
 
     Priority order:
     1. crawl + source_domain  → domain (e.g. "help.mitel.nl")
-    2. connector + connector_type → connector_type slug
-    3. connector + source_connector_id (no connector_type) → connector id
-    4. content_type contains "transcript" or "1on1" → "meetings"
-    5. fallback → kb_slug
+    2. direct URL source + source_ref/source_url → domain
+    3. connector + connector_type → connector_type slug
+    4. connector + source_connector_id (no connector_type) → connector id
+    5. content_type contains "transcript" or "1on1" → "meetings"
+    6. fallback → kb_slug
     """
     if req.source_type == "crawl" and req.source_domain:
         return req.source_domain
+    if req.source_type == "url":
+        source_url = req.source_ref or str((req.extra or {}).get("source_url") or "")
+        host = urlparse(source_url).hostname if source_url else None
+        if host:
+            return host
     if req.source_type == "connector":
         if req.connector_type:
             return req.connector_type

--- a/klai-knowledge-ingest/tests/test_kb_sources.py
+++ b/klai-knowledge-ingest/tests/test_kb_sources.py
@@ -119,6 +119,8 @@ async def test_list_kb_sources_groups_connectors_and_uploads() -> None:
                 {
                     "id": "art-1",
                     "path": "report.pdf",
+                    "display_name": "Annual report",
+                    "source_url": None,
                     "content_type": "pdf",
                     "created_at": 1700000000,
                     "chunks_count": 7,
@@ -137,6 +139,8 @@ async def test_list_kb_sources_groups_connectors_and_uploads() -> None:
         {
             "id": "art-1",
             "path": "report.pdf",
+            "display_name": "Annual report",
+            "source_url": None,
             "content_type": "pdf",
             "created_at": 1700000000,
             "chunks_count": 7,
@@ -150,7 +154,39 @@ async def test_list_kb_sources_groups_connectors_and_uploads() -> None:
     assert "source_connector_id" in connector_sql
     assert "IS NOT NULL" in connector_sql
     assert "extra IS NULL" in upload_sql or "IS NULL" in upload_sql
+    assert "display_name" in upload_sql
+    assert "source_url" in upload_sql
     assert "ORDER BY a.created_at DESC" in upload_sql
+
+
+@pytest.mark.asyncio
+async def test_update_artifact_display_name_stores_metadata_not_path() -> None:
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(
+        return_value={
+            "artifact_id": "art-1",
+            "path": "https://example.com/",
+            "display_name": "Example docs",
+        }
+    )
+
+    result = await pg_store.update_artifact_display_name(
+        conn,
+        "art-1",
+        "org-1",
+        "kb-a",
+        "Example docs",
+    )
+
+    assert result == {
+        "artifact_id": "art-1",
+        "path": "https://example.com/",
+        "display_name": "Example docs",
+    }
+    sql = conn.fetchrow.await_args.args[0]
+    assert "jsonb_build_object('display_name'" in sql
+    assert "SET extra" in sql
+    assert "SET path" not in sql
 
 
 @pytest.mark.asyncio

--- a/klai-knowledge-ingest/tests/test_source_label.py
+++ b/klai-knowledge-ingest/tests/test_source_label.py
@@ -1,5 +1,4 @@
 """Tests for source_label computation (SPEC-KB-021 Change 1)."""
-import pytest
 
 from knowledge_ingest.models import IngestRequest
 from knowledge_ingest.source_label import compute_source_label as _compute_source_label
@@ -20,6 +19,18 @@ def test_compute_source_label_webcrawl():
     """source_type=crawl + source_domain → domain as label."""
     req = _make_request(source_type="crawl", source_domain="help.mitel.nl")
     assert _compute_source_label(req) == "help.mitel.nl"
+
+
+def test_compute_source_label_direct_url_uses_hostname():
+    """source_type=url + source_ref URL → domain as label."""
+    req = _make_request(source_type="url", source_ref="https://docs.getklai.com/path")
+    assert _compute_source_label(req) == "docs.getklai.com"
+
+
+def test_compute_source_label_direct_url_uses_extra_source_url_fallback():
+    """source_type=url without source_ref can still label by extra.source_url."""
+    req = _make_request(source_type="url", extra={"source_url": "https://help.example.com/a"})
+    assert _compute_source_label(req) == "help.example.com"
 
 
 def test_compute_source_label_crawl_no_domain_falls_back_to_kb_slug():

--- a/klai-portal/backend/app/api/app_knowledge_bases.py
+++ b/klai-portal/backend/app/api/app_knowledge_bases.py
@@ -9,7 +9,7 @@ from typing import Literal
 import httpx
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy import func, select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -921,6 +921,7 @@ class BronOut(BaseModel):
     name: str  # display name (connector.name OR artifact.path)
     type_label: str  # "Notion", "GitHub", "PDF", "URL", etc. — frontend may translate
     connector_type: str | None = None  # raw connector_type for connectors; None for uploads
+    source_url: str | None = None  # direct URL uploads only; stable source URL for drill-down display
     items_count: int = 0  # number of artifacts under a connector; 1 for direct uploads
     chunks_count: int = 0  # parent_chunks across the bron's artifact(s)
     status: str | None = None  # raw last_sync_status for connectors; None for uploads
@@ -931,6 +932,15 @@ class BronOut(BaseModel):
 
 class BronnenResponse(BaseModel):
     bronnen: list[BronOut] = []
+
+
+class RenameUploadRequest(BaseModel):
+    name: str = Field(min_length=1, max_length=200)
+
+
+class RenameUploadResponse(BaseModel):
+    artifact_id: str
+    display_name: str
 
 
 class BronContentItem(BaseModel):
@@ -983,6 +993,8 @@ def _upload_type_label(content_type: str) -> str:
     ct = content_type.lower()
     if ct in {"pdf", "application/pdf"}:
         return "PDF"
+    if ct == "web_page":
+        return "Website"
     if ct in {"url", "html", "text/html"}:
         return "Link"
     if ct in {"text", "markdown", "txt", "text/plain", "text/markdown"}:
@@ -1098,9 +1110,10 @@ async def list_kb_bronnen(
             BronOut(
                 kind="upload",
                 id=str(upload.get("id") or ""),
-                name=str(upload.get("path") or "(zonder naam)"),
+                name=str(upload.get("display_name") or upload.get("path") or "(zonder naam)"),
                 type_label=_upload_type_label(str(upload.get("content_type") or "")),
                 connector_type=None,
+                source_url=upload.get("source_url"),
                 items_count=1,
                 chunks_count=int(upload.get("chunks_count") or 0),
                 status=None,
@@ -1268,6 +1281,52 @@ async def reindex_upload(
 
     await knowledge_ingest_client.reindex_artifact(org.zitadel_org_id, artifact_id)
     return {"artifact_id": artifact_id, "status": "pending"}
+
+
+@router.patch(
+    "/knowledge-bases/{kb_slug}/uploads/{artifact_id}",
+    response_model=RenameUploadResponse,
+)
+async def rename_kb_upload(
+    kb_slug: str,
+    artifact_id: str,
+    body: RenameUploadRequest,
+    perms: UserPermissions = Depends(get_caller),
+    db: AsyncSession = Depends(get_db),
+) -> RenameUploadResponse:
+    """Rename the display label for a direct-upload artifact.
+
+    The ingest-side artifact path is left untouched because it is the stable
+    Qdrant document key. This endpoint changes only the user-facing name.
+    """
+    org = await _load_org_or_500(db, perms.org_id)
+    kb = await _get_kb_or_404(kb_slug, perms.org_id, db)
+
+    role = await get_user_role_for_kb(
+        kb.id,
+        perms.user_id,
+        db,
+        default_org_role=kb.default_org_role,
+        kb_org_id=kb.org_id,
+        kb_created_by=kb.created_by,
+    )
+    if role not in ("contributor", "owner"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Contributor or owner access required",
+        )
+
+    display_name = body.name.strip()
+    result = await knowledge_ingest_client.rename_kb_upload(
+        org.zitadel_org_id,
+        kb.slug,
+        artifact_id,
+        display_name,
+    )
+    return RenameUploadResponse(
+        artifact_id=str(result.get("artifact_id") or artifact_id),
+        display_name=str(result.get("display_name") or display_name),
+    )
 
 
 @router.delete("/knowledge-bases/{kb_slug}/uploads/{artifact_id}", status_code=204)

--- a/klai-portal/backend/app/services/knowledge_ingest_client.py
+++ b/klai-portal/backend/app/services/knowledge_ingest_client.py
@@ -587,6 +587,36 @@ async def delete_kb_upload(
         resp.raise_for_status()
 
 
+async def rename_kb_upload(
+    org_id: str,
+    kb_slug: str,
+    artifact_id: str,
+    name: str,
+) -> dict:
+    """Update the display name for a direct-upload artifact.
+
+    The ingest service stores this as artifact metadata, not as ``path``.
+    ``path`` remains the stable document key for Qdrant cleanup/reindex.
+    """
+    async with httpx.AsyncClient(
+        base_url=settings.knowledge_ingest_url,
+        headers={
+            "X-Internal-Secret": settings.knowledge_ingest_secret,
+            "X-Caller-Service": "portal-api",
+            **get_trace_headers(),
+        },
+        timeout=10.0,
+    ) as client:
+        resp = await client.patch(
+            f"/knowledge/v1/kb/{kb_slug}/uploads/{artifact_id}",
+            params={"org_id": org_id},
+            json={"name": name},
+        )
+        resp.raise_for_status()
+        data: dict = resp.json()
+        return data
+
+
 async def get_chunks_summary(org_id: str, kb_slugs: list[str]) -> tuple[dict[str, int], dict[str, int]]:
     """Bulk chunk + bronnen counts per KB.
 

--- a/klai-portal/backend/tests/test_app_knowledge_bronnen.py
+++ b/klai-portal/backend/tests/test_app_knowledge_bronnen.py
@@ -58,6 +58,7 @@ def test_upload_type_label_known_content_types() -> None:
     assert _upload_type_label("application/pdf") == "PDF"
     assert _upload_type_label("html") == "Link"
     assert _upload_type_label("text/html") == "Link"
+    assert _upload_type_label("web_page") == "Website"
     assert _upload_type_label("text") == "Tekst"
     assert _upload_type_label("text/markdown") == "Tekst"
     assert _upload_type_label("image/png") == "Afbeelding"
@@ -138,6 +139,8 @@ async def test_list_kb_bronnen_merges_connectors_and_uploads() -> None:
             {
                 "id": "art-1",
                 "path": "report.pdf",
+                "display_name": "Annual report",
+                "source_url": None,
                 "content_type": "pdf",
                 "created_at": 1700000000,
                 "chunks_count": 7,
@@ -180,10 +183,61 @@ async def test_list_kb_bronnen_merges_connectors_and_uploads() -> None:
     assert by_id["conn-2"].status == "pending"
 
     assert by_id["art-1"].kind == "upload"
-    assert by_id["art-1"].name == "report.pdf"
+    assert by_id["art-1"].name == "Annual report"
     assert by_id["art-1"].type_label == "PDF"
+    assert by_id["art-1"].source_url is None
     assert by_id["art-1"].chunks_count == 7
     assert by_id["art-1"].created_at is not None
+
+
+@pytest.mark.asyncio
+async def test_list_kb_bronnen_labels_url_upload_as_website_with_source_url() -> None:
+    from app.api.app_knowledge_bases import list_kb_bronnen
+
+    org = _make_org()
+    kb = _make_kb()
+    db = _make_sources_db([])
+
+    aggregates = {
+        "connectors": [],
+        "uploads": [
+            {
+                "id": "art-url",
+                "path": "https://example.com/",
+                "display_name": None,
+                "source_url": "https://example.com/",
+                "content_type": "web_page",
+                "created_at": 1700000000,
+                "chunks_count": 0,
+                "index_status": "synced",
+            },
+        ],
+    }
+
+    with (
+        patch(
+            "app.api.app_knowledge_bases._load_org_or_500",
+            new=AsyncMock(return_value=org),
+        ),
+        patch(
+            "app.api.app_knowledge_bases._get_kb_or_404",
+            new=AsyncMock(return_value=kb),
+        ),
+        patch(
+            "app.api.app_knowledge_bases.knowledge_ingest_client.get_kb_sources",
+            new=AsyncMock(return_value=aggregates),
+        ),
+    ):
+        result = await list_kb_bronnen(
+            kb_slug="kb-a",
+            perms=_make_perms(),
+            db=db,
+        )
+
+    bron = result.bronnen[0]
+    assert bron.name == "https://example.com/"
+    assert bron.type_label == "Website"
+    assert bron.source_url == "https://example.com/"
 
 
 @pytest.mark.asyncio

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-bronnen-helpers.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-bronnen-helpers.tsx
@@ -1,0 +1,79 @@
+import {
+  File,
+  FileText,
+  Globe,
+  Image,
+  Type,
+  Zap,
+} from 'lucide-react'
+import { SiAirtable, SiConfluence, SiGithub, SiGoogledrive, SiNotion } from '@icons-pack/react-simple-icons'
+import { Badge } from '@/components/ui/badge'
+import * as m from '@/paraglide/messages'
+import type { Bron } from './-bronnen-types'
+
+export type BronStatus = 'synced' | 'pending' | 'not_synced'
+
+export function mapBronStatus(bron: Bron): BronStatus {
+  const s = (bron.status ?? '').toLowerCase()
+  if (bron.kind === 'upload') {
+    const idx = (bron.index_status ?? '').toLowerCase()
+    if (idx === 'pending' || s === 'processing' || s === 'ingesting') return 'pending'
+    if (idx === 'failed' || s === 'failed' || s.includes('error')) return 'not_synced'
+    if (idx === 'synced') return 'synced'
+    if (bron.chunks_count === 0 && !idx) return 'not_synced'
+    return 'synced'
+  }
+  if (s === 'running' || s === 'pending' || s === 'syncing') return 'pending'
+  if (s.includes('error') || s.includes('failed') || s === 'auth_error' || s === 'orphan') {
+    return 'not_synced'
+  }
+  if (s === 'success' || s === 'completed' || s === 'ok') return 'synced'
+  if (bron.items_count > 0 || bron.chunks_count > 0) return 'synced'
+  return 'not_synced'
+}
+
+export function StatusBadge({ status }: { status: BronStatus }) {
+  const labelMap = {
+    synced: m.kb_status_klaar(),
+    pending: m.kb_status_bezig(),
+    not_synced: m.kb_status_leeg(),
+  } as const
+  const variantMap = {
+    synced: 'success' as const,
+    pending: 'secondary' as const,
+    not_synced: 'secondary' as const,
+  }
+  return <Badge variant={variantMap[status]}>{labelMap[status]}</Badge>
+}
+
+export function BronIcon({ bron }: { bron: Bron }) {
+  if (bron.kind === 'connector') {
+    const t = bron.connector_type ?? ''
+    if (t === 'github') return <SiGithub className="h-4 w-4" />
+    if (t === 'notion') return <SiNotion className="h-4 w-4" />
+    if (t === 'google_drive') return <SiGoogledrive className="h-4 w-4" />
+    if (t === 'airtable') return <SiAirtable className="h-4 w-4" />
+    if (t === 'confluence') return <SiConfluence className="h-4 w-4" />
+    if (t === 'web_crawler') return <Globe className="h-4 w-4" />
+    if (t === 'ms_docs') return <FileText className="h-4 w-4" />
+    return <Zap className="h-4 w-4" />
+  }
+  const ct = (bron.type_label ?? '').toLowerCase()
+  const path = bron.name.toLowerCase()
+  if (path.endsWith('.pdf') || ct === 'pdf') return <FileText className="h-4 w-4" />
+  if (path.startsWith('http') || bron.source_url || ct === 'website' || ct === 'link') {
+    return <Globe className="h-4 w-4" />
+  }
+  if (ct.startsWith('afbeelding') || /\.(png|jpe?g|gif|webp|svg)$/i.test(path)) return <Image className="h-4 w-4" />
+  if (ct === 'tekst') return <Type className="h-4 w-4" />
+  return <File className="h-4 w-4" />
+}
+
+export function editablePageIdForBron(
+  bron: Bron,
+  slugToPageId: Map<string, string>,
+): string | null {
+  if (bron.kind !== 'upload') return null
+  const stripped = bron.name.replace(/\.md$/i, '')
+  return slugToPageId.get(stripped) ?? slugToPageId.get(bron.name) ?? null
+}

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-bronnen-types.ts
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-bronnen-types.ts
@@ -1,0 +1,48 @@
+export interface Bron {
+  kind: 'connector' | 'upload'
+  id: string
+  name: string
+  type_label: string
+  connector_type: string | null
+  source_url?: string | null
+  items_count: number
+  chunks_count: number
+  status: string | null
+  last_sync_at: string | null
+  created_at: string | null
+  /** Upload-only: pending / synced / failed from Track 3 backend. */
+  index_status?: string | null
+}
+
+export interface BronnenResponse {
+  bronnen: Bron[]
+}
+
+export interface ConnectorItem {
+  id: string
+  path: string
+  content_type: string
+  chunks_count: number
+  created_at: string
+}
+
+export interface UploadChunk {
+  id: number
+  position: number
+  text: string
+  token_count: number
+}
+
+export interface ContentResponse {
+  kind: 'connector' | 'upload'
+  items: ConnectorItem[]
+  chunks: UploadChunk[]
+  total: number
+  limit: number
+  offset: number
+}
+
+export interface PageIndexEntry {
+  id: string | null
+  slug: string
+}

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-kb-query-keys.ts
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-kb-query-keys.ts
@@ -1,0 +1,26 @@
+import type { QueryClient } from '@tanstack/react-query'
+
+export const kbQueryKeys = {
+  knowledgeBase: (kbSlug: string) => ['app-knowledge-base', kbSlug] as const,
+  bronnen: (kbSlug: string) => ['kb-bronnen', kbSlug] as const,
+  bronContent: (kbSlug: string, kind: string, id: string) =>
+    ['bron-content', kbSlug, kind, id] as const,
+  kbItems: (kbSlug: string) => ['kb-items', kbSlug] as const,
+  personalKnowledge: (kbSlug: string) => ['personal-knowledge', kbSlug] as const,
+  statsSummary: () => ['app-knowledge-bases-stats-summary'] as const,
+  docsTree: (orgSlug: string | undefined, kbSlug: string) =>
+    ['docs-tree', orgSlug, kbSlug] as const,
+  docsPageIndex: (orgSlug: string | undefined, kbSlug: string) =>
+    ['docs-page-index', orgSlug, kbSlug] as const,
+  connectorsPortal: (kbSlug: string) => ['kb-connectors-portal', kbSlug] as const,
+}
+
+export function invalidateKnowledgeSourceLists(
+  queryClient: Pick<QueryClient, 'invalidateQueries'>,
+  kbSlug: string,
+) {
+  void queryClient.invalidateQueries({ queryKey: kbQueryKeys.bronnen(kbSlug) })
+  void queryClient.invalidateQueries({ queryKey: kbQueryKeys.kbItems(kbSlug) })
+  void queryClient.invalidateQueries({ queryKey: kbQueryKeys.personalKnowledge(kbSlug) })
+  void queryClient.invalidateQueries({ queryKey: kbQueryKeys.statsSummary() })
+}

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/bronnen.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/bronnen.tsx
@@ -13,22 +13,18 @@ import { createFileRoute, Link } from '@tanstack/react-router'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useMemo, useState } from 'react'
 import {
+  Check,
   ChevronRight,
   File,
-  FileText,
-  Globe,
-  Image,
   Link as LinkIcon,
   Loader2,
   Pencil,
   Plus,
   RefreshCw,
   Trash2,
-  Type,
+  X,
   Zap,
 } from 'lucide-react'
-import { SiAirtable, SiConfluence, SiGithub, SiGoogledrive, SiNotion } from '@icons-pack/react-simple-icons'
-import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { InlineDeleteConfirm } from '@/components/ui/inline-delete-confirm'
 import { Tooltip } from '@/components/ui/tooltip'
@@ -37,136 +33,19 @@ import { apiFetch } from '@/lib/apiFetch'
 import { useCurrentUser } from '@/hooks/useCurrentUser'
 import { DOCS_BASE, getOrgSlug } from '@/lib/kb-editor/tree-utils'
 import { queryLogger } from '@/lib/logger'
+import type { Bron, BronnenResponse, ContentResponse, PageIndexEntry } from './-bronnen-types'
+import { BronIcon, editablePageIdForBron, mapBronStatus, StatusBadge } from './-bronnen-helpers'
+import { kbQueryKeys } from './-kb-query-keys'
 
 export const Route = createFileRoute('/app/knowledge/$kbSlug/bronnen')({
   component: BronnenTab,
 })
 
-// -- Types ------------------------------------------------------------------
-
-interface Bron {
-  kind: 'connector' | 'upload'
-  id: string
-  name: string
-  type_label: string
-  connector_type: string | null
-  items_count: number
-  chunks_count: number
-  status: string | null
-  last_sync_at: string | null
-  created_at: string | null
-  /** Upload-only: pending / synced / failed from Track 3 backend. */
-  index_status?: string | null
-}
-
-interface BronnenResponse {
-  bronnen: Bron[]
-}
-
-interface ConnectorItem {
-  id: string
-  path: string
-  content_type: string
-  chunks_count: number
-  created_at: string
-}
-
-interface UploadChunk {
-  id: number
-  position: number
-  text: string
-  token_count: number
-}
-
-interface ContentResponse {
-  kind: 'connector' | 'upload'
-  items: ConnectorItem[]
-  chunks: UploadChunk[]
-  total: number
-  limit: number
-  offset: number
-}
-
-// -- Status mapping ---------------------------------------------------------
-//
-// User mental model: a bron is gesynchroniseerd, pending (mid-sync), or
-// niet gesynchroniseerd (failed / never started). Three states only.
-
-type Status = 'synced' | 'pending' | 'not_synced'
-
-function mapStatus(bron: Bron): Status {
-  const s = (bron.status ?? '').toLowerCase()
-  if (bron.kind === 'upload') {
-    // index_status is the authoritative field (Track 3).
-    // parent_chunks count is NOT a reliable proxy for "synced": artifacts
-    // that came through the docs-editor / graphiti path index into Qdrant
-    // but leave parent_chunks empty — the overview page already counts the
-    // vector_chunk_count separately. An artifact with index_status='synced'
-    // IS retrievable by the LLM, regardless of parent_chunks.
-    const idx = (bron.index_status ?? '').toLowerCase()
-    if (idx === 'pending' || s === 'processing' || s === 'ingesting') return 'pending'
-    if (idx === 'failed' || s === 'failed' || s.includes('error')) return 'not_synced'
-    if (idx === 'synced') return 'synced'
-    // Unknown status with no chunks → assume not yet indexed.
-    if (bron.chunks_count === 0 && !idx) return 'not_synced'
-    return 'synced'
-  }
-  // Connector — last_sync_status is the source of truth.
-  if (s === 'running' || s === 'pending' || s === 'syncing') return 'pending'
-  if (s.includes('error') || s.includes('failed') || s === 'auth_error' || s === 'orphan') {
-    return 'not_synced'
-  }
-  if (s === 'success' || s === 'completed' || s === 'ok') return 'synced'
-  // Has data but unknown explicit status — assume synced.
-  if (bron.items_count > 0 || bron.chunks_count > 0) return 'synced'
-  return 'not_synced'
-}
-
-function StatusBadge({ status }: { status: Status }) {
-  const labelMap = {
-    synced: m.kb_status_klaar(),
-    pending: m.kb_status_bezig(),
-    not_synced: m.kb_status_leeg(),
-  } as const
-  // Synced = success (subtle green). Pending = secondary (neutral).
-  // Not_synced = subtle secondary: it's "not yet" not "failed".
-  const variantMap = {
-    synced: 'success' as const,
-    pending: 'secondary' as const,
-    not_synced: 'secondary' as const,
-  }
-  return <Badge variant={variantMap[status]}>{labelMap[status]}</Badge>
-}
-
-// -- Bron icon --------------------------------------------------------------
-
-function BronIcon({ bron }: { bron: Bron }) {
-  if (bron.kind === 'connector') {
-    const t = bron.connector_type ?? ''
-    if (t === 'github') return <SiGithub className="h-4 w-4" />
-    if (t === 'notion') return <SiNotion className="h-4 w-4" />
-    if (t === 'google_drive') return <SiGoogledrive className="h-4 w-4" />
-    if (t === 'airtable') return <SiAirtable className="h-4 w-4" />
-    if (t === 'confluence') return <SiConfluence className="h-4 w-4" />
-    if (t === 'web_crawler') return <Globe className="h-4 w-4" />
-    if (t === 'ms_docs') return <FileText className="h-4 w-4" />
-    return <Zap className="h-4 w-4" />
-  }
-  // upload
-  const ct = (bron.connector_type ?? '').toLowerCase()
-  const path = bron.name.toLowerCase()
-  if (path.endsWith('.pdf') || ct === 'pdf') return <FileText className="h-4 w-4" />
-  if (path.startsWith('http') || ct === 'url' || ct === 'html') return <Globe className="h-4 w-4" />
-  if (ct.startsWith('image') || /\.(png|jpe?g|gif|webp|svg)$/i.test(path)) return <Image className="h-4 w-4" />
-  if (ct === 'text' || ct === 'markdown') return <Type className="h-4 w-4" />
-  return <File className="h-4 w-4" />
-}
-
 // -- Bron content (drill-down) ----------------------------------------------
 
 function BronContent({ kbSlug, bron }: { kbSlug: string; bron: Bron }) {
   const { data, isLoading, isError } = useQuery<ContentResponse>({
-    queryKey: ['bron-content', kbSlug, bron.kind, bron.id],
+    queryKey: kbQueryKeys.bronContent(kbSlug, bron.kind, bron.id),
     queryFn: () =>
       apiFetch<ContentResponse>(
         `/api/app/knowledge-bases/${kbSlug}/sources/${bron.id}/content?kind=${bron.kind}&limit=20`,
@@ -221,6 +100,15 @@ function BronContent({ kbSlug, bron }: { kbSlug: string; bron: Bron }) {
   // upload
   const chunks = data?.chunks ?? []
   if (chunks.length === 0) {
+    if (bron.source_url) {
+      return (
+        <div className="pl-[44px] pr-2 pb-3 flex items-center gap-2 text-xs">
+          <File className="h-3.5 w-3.5 text-gray-400 shrink-0" />
+          <span className="text-gray-700 truncate">{bron.source_url}</span>
+          <span className="text-gray-400 shrink-0">URL</span>
+        </div>
+      )
+    }
     // Two cases produce empty chunks here:
     //  1) Truly unindexed — index_status='pending'/'failed' on the row above.
     //  2) Indexed via docs/graphiti path — vectors live in Qdrant, no
@@ -271,10 +159,12 @@ function BronRow({
   editablePageId: string | null
 }) {
   const queryClient = useQueryClient()
-  const status = mapStatus(bron)
+  const status = mapBronStatus(bron)
   const [confirmingDelete, setConfirmingDelete] = useState(false)
   const [reauthError, setReauthError] = useState(false)
   const [reauthPending, setReauthPending] = useState(false)
+  const [isRenaming, setIsRenaming] = useState(false)
+  const [draftName, setDraftName] = useState(bron.name)
 
   // REQ-13: per-row sync/reindex button.
   // For connectors → POST /connectors/{id}/sync (full source-side resync).
@@ -286,8 +176,8 @@ function BronRow({
   const syncMutation = useMutation({
     mutationFn: async () => apiFetch(syncEndpoint, { method: 'POST' }),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['kb-bronnen', kbSlug] })
-      void queryClient.invalidateQueries({ queryKey: ['app-knowledge-bases-stats-summary'] })
+      void queryClient.invalidateQueries({ queryKey: kbQueryKeys.bronnen(kbSlug) })
+      void queryClient.invalidateQueries({ queryKey: kbQueryKeys.statsSummary() })
     },
     onError: (err) => queryLogger.error('Bron sync failed', { kbSlug, bronId: bron.id, kind: bron.kind, err }),
   })
@@ -295,10 +185,10 @@ function BronRow({
   // REQ-15: delete upload artifact.
   const deleteUploadMutation = useMutation({
     mutationFn: async () =>
-      apiFetch(`/api/knowledge/personal/items/${bron.id}`, { method: 'DELETE' }),
+      apiFetch(`/api/app/knowledge-bases/${kbSlug}/uploads/${bron.id}`, { method: 'DELETE' }),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['kb-bronnen', kbSlug] })
-      void queryClient.invalidateQueries({ queryKey: ['app-knowledge-bases-stats-summary'] })
+      void queryClient.invalidateQueries({ queryKey: kbQueryKeys.bronnen(kbSlug) })
+      void queryClient.invalidateQueries({ queryKey: kbQueryKeys.statsSummary() })
     },
     onError: (err) => queryLogger.error('Bron delete (upload) failed', { kbSlug, bronId: bron.id, err }),
   })
@@ -308,14 +198,27 @@ function BronRow({
     mutationFn: async () =>
       apiFetch(`/api/app/knowledge-bases/${kbSlug}/connectors/${bron.id}`, { method: 'DELETE' }),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['kb-bronnen', kbSlug] })
-      void queryClient.invalidateQueries({ queryKey: ['app-knowledge-bases-stats-summary'] })
+      void queryClient.invalidateQueries({ queryKey: kbQueryKeys.bronnen(kbSlug) })
+      void queryClient.invalidateQueries({ queryKey: kbQueryKeys.statsSummary() })
     },
     onError: (err) => queryLogger.error('Bron delete (connector) failed', { kbSlug, bronId: bron.id, err }),
   })
 
   const deleteMutation = bron.kind === 'upload' ? deleteUploadMutation : deleteConnectorMutation
   const isDeleting = deleteMutation.isPending
+
+  const renameMutation = useMutation({
+    mutationFn: async (name: string) =>
+      apiFetch(`/api/app/knowledge-bases/${kbSlug}/uploads/${bron.id}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ name }),
+      }),
+    onSuccess: () => {
+      setIsRenaming(false)
+      void queryClient.invalidateQueries({ queryKey: kbQueryKeys.bronnen(kbSlug) })
+    },
+    onError: (err) => queryLogger.error('Bron rename failed', { kbSlug, bronId: bron.id, err }),
+  })
 
   // Q4: "Verbind opnieuw" — connector has auth_error status.
   const isAuthError = bron.kind === 'connector' && (bron.status ?? '').toLowerCase().includes('auth')
@@ -342,7 +245,7 @@ function BronRow({
       setReauthPending(false)
       setReauthError(true)
       queryLogger.error('Connector reauth failed', { kbSlug, bronId: bron.id, err })
-      void queryClient.invalidateQueries({ queryKey: ['kb-bronnen', kbSlug] })
+      void queryClient.invalidateQueries({ queryKey: kbQueryKeys.bronnen(kbSlug) })
     }
   }
 
@@ -361,22 +264,70 @@ function BronRow({
   return (
     <div>
       <div className="group flex items-center gap-2 pr-2 hover:bg-black/[0.03] transition-colors">
-        <button
-          type="button"
-          onClick={onToggle}
-          className="flex flex-1 min-w-0 items-center gap-3 px-2 py-3.5 text-left"
-          aria-expanded={expanded}
-        >
+        <div className="flex flex-1 min-w-0 items-center gap-3 px-2 py-3.5">
           <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-gray-50 text-gray-400">
             <BronIcon bron={bron} />
           </div>
           <div className="min-w-0 flex-1">
-            <div className="flex items-baseline gap-2 flex-wrap">
-              <span className="text-[15px] font-display text-gray-900 truncate">{bron.name}</span>
-              <span className="text-xs text-gray-400">{meta}</span>
-            </div>
+            {isRenaming ? (
+              <div className="flex items-center gap-1 min-w-[220px] max-w-full">
+                <input
+                  value={draftName}
+                  autoFocus
+                  onChange={(e) => setDraftName(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Escape') {
+                      setDraftName(bron.name)
+                      setIsRenaming(false)
+                    }
+                    if (e.key === 'Enter' && draftName.trim()) {
+                      renameMutation.mutate(draftName.trim())
+                    }
+                  }}
+                  className="h-8 min-w-0 flex-1 rounded-md border border-gray-200 bg-white px-2 text-sm text-gray-900 outline-none focus:border-gray-400"
+                />
+                <button
+                  type="button"
+                  aria-label="Naam opslaan"
+                  disabled={!draftName.trim() || renameMutation.isPending}
+                  onClick={() => {
+                    if (draftName.trim()) renameMutation.mutate(draftName.trim())
+                  }}
+                  className="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-400 hover:text-gray-900 hover:bg-gray-100 disabled:opacity-50"
+                >
+                  {renameMutation.isPending ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Check className="h-4 w-4" />
+                  )}
+                </button>
+                <button
+                  type="button"
+                  aria-label="Naam bewerken annuleren"
+                  onClick={() => {
+                    setDraftName(bron.name)
+                    setIsRenaming(false)
+                  }}
+                  className="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-400 hover:text-gray-900 hover:bg-gray-100"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={onToggle}
+                className="min-w-0 text-left"
+                aria-expanded={expanded}
+              >
+                <span className="flex items-baseline gap-2 flex-wrap">
+                  <span className="text-[15px] font-display text-gray-900 truncate">{bron.name}</span>
+                  <span className="text-xs text-gray-400">{meta}</span>
+                </span>
+              </button>
+            )}
           </div>
-        </button>
+        </div>
         <StatusBadge status={status} />
 
         {/* Q4: "Verbind opnieuw" — only for connectors in auth_error state. */}
@@ -463,6 +414,35 @@ function BronRow({
           </Tooltip>
         </InlineDeleteConfirm>
 
+        {bron.kind === 'connector' && (
+          <Tooltip label="Bewerk bron">
+            <Link
+              to="/app/knowledge/$kbSlug/edit-connector/$connectorId"
+              params={{ kbSlug, connectorId: bron.id }}
+              aria-label="Bewerk bron"
+              className="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-400 hover:text-gray-900 hover:bg-gray-100 transition-colors"
+            >
+              <Pencil className="h-4 w-4" />
+            </Link>
+          </Tooltip>
+        )}
+
+        {bron.kind === 'upload' && (
+          <Tooltip label="Naam aanpassen">
+            <button
+              type="button"
+              onClick={() => {
+                setDraftName(bron.name)
+                setIsRenaming(true)
+              }}
+              aria-label="Naam aanpassen"
+              className="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-400 hover:text-gray-900 hover:bg-gray-100 transition-colors"
+            >
+              <Pencil className="h-4 w-4" />
+            </button>
+          </Tooltip>
+        )}
+
         {/* Per-row "Bewerken in editor" — only rendered when the bron name
             actually maps to a Gitea page slug in the KB's page-index. The
             mapping is computed once at KB level (see BronnenTab) so each
@@ -504,13 +484,13 @@ function BronnenTab() {
   const [expandedId, setExpandedId] = useState<string | null>(null)
 
   const { data, isLoading, isError } = useQuery<BronnenResponse>({
-    queryKey: ['kb-bronnen', kbSlug],
+    queryKey: kbQueryKeys.bronnen(kbSlug),
     queryFn: () => apiFetch<BronnenResponse>(`/api/app/knowledge-bases/${kbSlug}/sources`),
     retry: false,
     // Poll while any connector is syncing so the badge updates without refresh.
     refetchInterval: (query) => {
       const list = query.state.data?.bronnen ?? []
-      const anyPending = list.some((b) => mapStatus(b) === 'pending')
+      const anyPending = list.some((b) => mapBronStatus(b) === 'pending')
       return anyPending ? 4000 : false
     },
   })
@@ -520,7 +500,7 @@ function BronnenTab() {
 
   // KB data is already cached by the route shell; reuse same query key.
   const { data: kb } = useQuery<{ docs_enabled: boolean }>({
-    queryKey: ['app-knowledge-base', kbSlug],
+    queryKey: kbQueryKeys.knowledgeBase(kbSlug),
     queryFn: () => apiFetch<{ docs_enabled: boolean }>(`/api/app/knowledge-bases/${kbSlug}`),
   })
 
@@ -533,7 +513,7 @@ function BronnenTab() {
   const { user } = useCurrentUser()
   const orgSlug = getOrgSlug(user?.workspace_url)
   const { data: docsTree } = useQuery<{ id: string }[]>({
-    queryKey: ['docs-tree', orgSlug, kbSlug],
+    queryKey: kbQueryKeys.docsTree(orgSlug, kbSlug),
     queryFn: () => apiFetch<{ id: string }[]>(`${DOCS_BASE}/orgs/${orgSlug}/kbs/${kbSlug}/tree`),
     enabled: !!kb?.docs_enabled && !!orgSlug,
     // 404 / forbidden / empty repo: fall back to "no pages" silently.
@@ -546,10 +526,10 @@ function BronnenTab() {
   // pencil — only show when the bron's name strips to a slug that exists
   // in the page-index. Prevents 'Pagina niet gevonden' on click. Stable
   // key with route.tsx so a hit here warms the editor's cache.
-  const { data: pageIndex } = useQuery<{ id: string | null; slug: string }[]>({
-    queryKey: ['docs-page-index', orgSlug, kbSlug],
+  const { data: pageIndex } = useQuery<PageIndexEntry[]>({
+    queryKey: kbQueryKeys.docsPageIndex(orgSlug, kbSlug),
     queryFn: () =>
-      apiFetch<{ id: string | null; slug: string }[]>(
+      apiFetch<PageIndexEntry[]>(
         `${DOCS_BASE}/orgs/${orgSlug}/kbs/${kbSlug}/page-index`,
       ),
     enabled: !!kb?.docs_enabled && !!orgSlug && hasEditorPages,
@@ -580,8 +560,8 @@ function BronnenTab() {
       return results
     },
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['kb-bronnen', kbSlug] })
-      void queryClient.invalidateQueries({ queryKey: ['app-knowledge-bases-stats-summary'] })
+      void queryClient.invalidateQueries({ queryKey: kbQueryKeys.bronnen(kbSlug) })
+      void queryClient.invalidateQueries({ queryKey: kbQueryKeys.statsSummary() })
     },
     onError: (err) => queryLogger.error('Sync-all failed', { kbSlug, err }),
   })
@@ -656,14 +636,7 @@ function BronnenTab() {
       ) : (
         <div className="border-t border-b border-gray-200 divide-y divide-gray-200">
           {bronnen.map((bron) => {
-            // Match bron.name (e.g. 'why-now.md') against the page-index slugs.
-            // Try both the raw name and the .md-stripped variant — page slugs
-            // in Gitea typically come without the extension.
-            let editablePageId: string | null = null
-            if (bron.kind === 'upload') {
-              const stripped = bron.name.replace(/\.md$/i, '')
-              editablePageId = slugToPageId.get(stripped) ?? slugToPageId.get(bron.name) ?? null
-            }
+            const editablePageId = editablePageIdForBron(bron, slugToPageId)
             return (
               <BronRow
                 key={`${bron.kind}-${bron.id}`}

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source._components/FileUploadForm.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source._components/FileUploadForm.tsx
@@ -5,6 +5,7 @@ import { CheckCircle2, FileText, Upload } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import * as m from '@/paraglide/messages'
 import { ApiError, apiFetch } from '@/lib/apiFetch'
+import { invalidateKnowledgeSourceLists } from '../$kbSlug/-kb-query-keys'
 
 // SPEC-KB-FILE-UPLOAD-001 — full whitelist routed through portal-api.
 // .md / .txt / .csv go to /ingest/v1/document directly. PDF / DOCX /
@@ -177,11 +178,7 @@ export function FileUploadForm({ kbSlug, onBack }: FileUploadFormProps) {
       )
     },
     onSuccess: (data) => {
-      void queryClient.invalidateQueries({ queryKey: ['kb-items', kbSlug] })
-      void queryClient.invalidateQueries({ queryKey: ['personal-knowledge', kbSlug] })
-      void queryClient.invalidateQueries({
-        queryKey: ['app-knowledge-bases-stats-summary'],
-      })
+      invalidateKnowledgeSourceLists(queryClient, kbSlug)
       setServerSkipped(data.skipped)
       setSelectedFiles([])
       setTrackedEntries(

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source._components/useSourceSubmit.ts
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source._components/useSourceSubmit.ts
@@ -11,6 +11,7 @@ import { useNavigate } from '@tanstack/react-router'
 import { useState } from 'react'
 import { ApiError, apiFetch } from '@/lib/apiFetch'
 import * as m from '@/paraglide/messages'
+import { invalidateKnowledgeSourceLists } from '../$kbSlug/-kb-query-keys'
 
 export type SourceKind = 'url' | 'text'
 
@@ -97,11 +98,7 @@ export function useSourceSubmit<TBody>({
         }
       ),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['kb-items', kbSlug] })
-      void queryClient.invalidateQueries({ queryKey: ['personal-knowledge', kbSlug] })
-      void queryClient.invalidateQueries({
-        queryKey: ['app-knowledge-bases-stats-summary'],
-      })
+      invalidateKnowledgeSourceLists(queryClient, kbSlug)
       setSuccessful(true)
       setTimeout(() => {
         void navigate({

--- a/klai-portal/frontend/src/routes/app/knowledge/__tests__/-kb-query-keys.test.ts
+++ b/klai-portal/frontend/src/routes/app/knowledge/__tests__/-kb-query-keys.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from 'vitest'
+import { invalidateKnowledgeSourceLists, kbQueryKeys } from '../$kbSlug/-kb-query-keys'
+
+describe('kbQueryKeys', () => {
+  it('invalidates the Bronnen query after source mutations', () => {
+    const queryClient = { invalidateQueries: vi.fn() }
+
+    invalidateKnowledgeSourceLists(queryClient, 'klai-web-demo')
+
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: kbQueryKeys.bronnen('klai-web-demo'),
+    })
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: kbQueryKeys.kbItems('klai-web-demo'),
+    })
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: kbQueryKeys.personalKnowledge('klai-web-demo'),
+    })
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: kbQueryKeys.statsSummary(),
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Fixes the Knowledge Bronnen production issues around direct URL sources and source management:

- invalidate the Bronnen query after adding URL/text/file sources so the new source appears without a hard refresh
- label `web_page` uploads as `Website`
- preserve and expose `source_url` for direct URL uploads
- compute URL `source_label` from hostname instead of falling back to `kb_slug`
- add safe display-name rename for direct uploads via `artifact.extra.display_name`, without mutating the stable artifact path used by Qdrant/delete/reindex
- add connector edit links and clean up the Bronnen route into types/helpers/query-key helpers

## Validation

- `klai-knowledge-ingest`: `ruff check knowledge_ingest/source_label.py knowledge_ingest/pg_store.py knowledge_ingest/routes/kb_sources.py tests/test_source_label.py tests/test_kb_sources.py`
- `klai-knowledge-ingest`: `pytest tests/test_source_label.py tests/test_kb_sources.py` -> 22 passed
- `klai-portal/backend`: `ruff check app/api/app_knowledge_bases.py app/services/knowledge_ingest_client.py tests/test_app_knowledge_bronnen.py`
- `klai-portal/backend`: `pytest tests/test_app_knowledge_sources.py::TestUrlRoute tests/test_app_knowledge_bronnen.py` -> 18 passed
- `klai-portal/frontend`: targeted Vitest -> 15 passed
- `klai-portal/frontend`: `npm run lint -- ...`
- `klai-portal/frontend`: `npm run build`

## Live verification before deploy

Production ingest was tested on `core-01` against `klai-web-demo`: URL extraction, portal-to-ingest forwarding, Postgres artifact, Qdrant points, enrichment, parent chunks, and Graphiti all worked. That confirmed ingest itself works, and that the remaining production issues are presentation/cache/metadata mapping issues fixed here.
