### PR TITLE
Fix sync run reaper detached rows

### DIFF
--- a/klai-connector/app/services/sync_run_reaper.py
+++ b/klai-connector/app/services/sync_run_reaper.py
@@ -27,6 +27,8 @@ lifecycle is the source of truth on whether a job should still be alive.
 from __future__ import annotations
 
 import asyncio
+import uuid
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -58,6 +60,15 @@ logger = get_logger(__name__)
 _TICK_S: float = 60.0
 _FINALIZE_AFTER_S: float = 5 * 60.0
 _FORCE_FAIL_AFTER_S: float = 7 * 24 * 60 * 60.0
+
+
+@dataclass(frozen=True)
+class _ReaperCandidate:
+    id: uuid.UUID
+    connector_id: uuid.UUID
+    org_id: str | None
+    started_at: datetime
+    cursor_state: dict | None
 
 
 class SyncRunReaper:
@@ -137,7 +148,17 @@ class SyncRunReaper:
                     SyncRun.cursor_state["remote_job_id"].astext.isnot(None),  # type: ignore[index]
                 ),
             )
-            rows = (await session.execute(stmt)).scalars().all()
+            db_rows = (await session.execute(stmt)).scalars().all()
+            rows = [
+                _ReaperCandidate(
+                    id=row.id,
+                    connector_id=row.connector_id,
+                    org_id=row.org_id,
+                    started_at=row.started_at,
+                    cursor_state=row.cursor_state if isinstance(row.cursor_state, dict) else None,
+                )
+                for row in db_rows
+            ]
 
         for row in rows:
             if await self._reap_row(row, force_fail_cutoff=force_fail_cutoff):
@@ -150,7 +171,7 @@ class SyncRunReaper:
             )
         return finalised
 
-    async def _reap_row(self, row: SyncRun, *, force_fail_cutoff: datetime) -> bool:
+    async def _reap_row(self, row: _ReaperCandidate, *, force_fail_cutoff: datetime) -> bool:
         """Process a single candidate. Returns True if the row was finalised."""
         cursor = row.cursor_state if isinstance(row.cursor_state, dict) else {}
         remote_job_id = cursor.get("remote_job_id")


### PR DESCRIPTION
## Summary

Fixes the `klai-connector` sync-run reaper crash where candidate `SyncRun` ORM rows were read after the cross-org session had closed, causing `DetachedInstanceError` on `row.cursor_state` and leaving stale `running` sync runs visible in the portal.

The reaper now snapshots candidate fields into a plain dataclass while the session is open, then processes those snapshots outside the session.

## Production impact

This was observed live on `Klai Docs` in `klai-web-demo`: the reaper crashed every minute and left `portal_connectors.last_sync_status=running`. A hotpatch on `core-01` finalized the stale run and `Klai Docs` now shows `completed` in Postgres.

## Validation

- `uv run --python 3.13 ruff check app/services/sync_run_reaper.py tests/services/test_sync_run_reaper.py`
- `uv run --python 3.13 pytest tests/services/test_sync_run_reaper.py` -> 7 passed
