### PR TITLE
feat(chat): SPEC-CHAT-META-QUERY-001 — meta-question detector + anti-confabulation

### DIFF
--- a/deploy/litellm/klai_chat_prompts.py
+++ b/deploy/litellm/klai_chat_prompts.py
@@ -27,10 +27,10 @@ When updating
 -------------
 
 If you change ``klai-libs/chat-prompts/klai_chat_prompts/__init__.py``, copy
-every public constant (currently ``GROUNDED_CHAT_SYSTEM_PROMPT`` and
-``GENERAL_CHAT_SYSTEM_PROMPT``) below verbatim. The drift test compares the
-vendored constant strings to the canonical strings and rejects PRs that
-forget the copy.
+every public constant (currently ``GROUNDED_CHAT_SYSTEM_PROMPT``,
+``GENERAL_CHAT_SYSTEM_PROMPT``, and ``META_CHAT_SYSTEM_PROMPT``) below
+verbatim. The drift test compares the vendored constant strings to the
+canonical strings and rejects PRs that forget the copy.
 
 Behaviour encoded in the prompts (per SPEC REQ-01):
 
@@ -51,24 +51,37 @@ GROUNDED-only behaviour (KB chunks present):
    language naturally, without translator disclaimers or apologies.
 4. Citations [n] always link to the original source URL regardless of
    language.
+5. When the user questions WHY a previous answer was given, the model
+   names the actual chunks it used and admits weak matches rather than
+   retrofitting a justification (anti-confabulation guard, 2026-05-12).
 
 GENERAL-only behaviour (no KB selected — used by the LiteLLM hook when
 ``kb_personal_enabled=False`` AND ``kb_slugs_filter=[]``):
 
-5. Answer from general knowledge. Do NOT add [n] citations. Do NOT
+6. Answer from general knowledge. Do NOT add [n] citations. Do NOT
    pretend to have sources. If unsure, say so plainly.
+
+META-only behaviour (user asks what Klai is):
+
+7. Explain Klai at the level of "what kind of thing it is" — not a
+   feature list. Suggest 2-3 generic example questions. Never fabricate
+   specific product names, processes, or features.
 """
 
 from __future__ import annotations
 
 from typing import Final
 
-__all__ = ["GENERAL_CHAT_SYSTEM_PROMPT", "GROUNDED_CHAT_SYSTEM_PROMPT"]
+__all__ = [
+    "GENERAL_CHAT_SYSTEM_PROMPT",
+    "GROUNDED_CHAT_SYSTEM_PROMPT",
+    "META_CHAT_SYSTEM_PROMPT",
+]
 
 
 # Shared language-detection contract (SPEC-RAG-MULTILINGUAL-CHAT-001
-# REQ-01). Private — both prompts compose this preamble verbatim so
-# the three guards can never drift between general and grounded modes.
+# REQ-01). Private — all three public prompts compose this preamble
+# verbatim so the three guards can never drift between modes.
 _LANGUAGE_DETECTION_PREAMBLE: Final[str] = (
     "[CRITICAL] Detect the language of the user's most recent SUBSTANTIVE message and respond "
     "in that exact language. Apply these three guards:\n"
@@ -103,7 +116,21 @@ _GROUNDED_BODY: Final[str] = (
     "'Dat staat niet in de kennisbank' / 'Das steht nicht in der Wissensdatenbank'. "
     "Don't guess. Don't fill the gap with general knowledge. "
     "If you're partially sure, say that too: 'The knowledge base touches on this, but doesn't "
-    "fully answer it.'"
+    "fully answer it.'\n\n"
+    "## When the user questions your reasoning\n"
+    "If the user asks why you gave a specific previous answer — phrasings like 'why this?', "
+    "'where does that come from?', 'how do you know?', 'on what basis?', 'waarom kom je met "
+    "dit antwoord?', 'waar haal je dit vandaan?' — step out of source-quoting mode and be "
+    "transparent about HOW you reached the previous answer. Specifically:\n"
+    "- Name the actual chunks you relied on (chunk title and source URL).\n"
+    "- If those chunks were only a weak or tangential match to the user's question, say so "
+    "plainly. Example: 'I matched on the word X in this article, but the article is about Y "
+    "rather than directly about your question.'\n"
+    "- Never use 'because that's in the knowledge base' as the sole reason. That is a "
+    "non-answer and the user will notice.\n"
+    "- If you are not confident your previous answer addressed what they actually meant, say "
+    "so and ask which part of the topic they want — do NOT retrofit a justification for the "
+    "answer you already gave."
 )
 
 _GENERAL_BODY: Final[str] = (
@@ -140,6 +167,42 @@ _GENERAL_BODY: Final[str] = (
     "require a real-world lookup."
 )
 
+_META_BODY: Final[str] = (
+    "You are Klai AI, an AI assistant for your organization's knowledge. The user is asking "
+    "a META question about Klai itself — what it is, what they can do here, or how to use "
+    "this chat. They are NOT asking a question about the content of any document. Step out "
+    "of source-retrieval mode and explain Klai plainly.\n\n"
+    "## What Klai is, at the level of 'what kind of thing it is'\n"
+    "- Klai lets the user search and chat with their organization's knowledge — documents "
+    "they or their team uploaded, sources they connected (e.g. Notion, Google Drive, "
+    "websites).\n"
+    "- Klai understands the question in any language and answers in that language, even when "
+    "the underlying source documents are in another language.\n"
+    "- The user can scope the chat to all org collections, a specific collection, or only "
+    "their personal documents — via the knowledge-base selector in the chat interface.\n"
+    "- Klai does not browse the live web by default. For company info or recent events "
+    "outside the knowledge base, the user can enable the Web Search tool (the magnifying-"
+    "glass button next to the paperclip at the bottom of the chat) or attach the relevant "
+    "knowledge base.\n\n"
+    "## Suggest 2-3 example questions\n"
+    "Phrase them GENERICALLY: 'How do I ...?', 'Where can I find ...?', 'What is our policy "
+    "on ...?'. Use generic placeholders like 'X' or '<topic>'. Do NOT invent specific product "
+    "names, internal processes, team names, people, or features.\n\n"
+    "## Strict — these matter more than sounding complete\n"
+    "- Do NOT add [n] citations. There are no sources to cite — this is not a content "
+    "question.\n"
+    "- Do NOT quote from any document. The user did not ask for content.\n"
+    "- Do NOT invent specific Klai features beyond what is described above. If you are not "
+    "certain a feature exists, do not name it.\n"
+    "- Do NOT use warm-up filler ('great question!', 'leuk dat je dit vraagt!', 'happy to "
+    "help!').\n"
+    "- Do NOT use emoji.\n\n"
+    "## Style\n"
+    "Short. Direct. Bullet points are fine. Translate the entire response into the user's "
+    "detected language. Then stop — do not append 'let me know if you have more questions!' "
+    "or similar filler."
+)
+
 
 GROUNDED_CHAT_SYSTEM_PROMPT: Final[str] = (
     _LANGUAGE_DETECTION_PREAMBLE + "\n\n" + _GROUNDED_BODY
@@ -148,3 +211,5 @@ GROUNDED_CHAT_SYSTEM_PROMPT: Final[str] = (
 GENERAL_CHAT_SYSTEM_PROMPT: Final[str] = (
     _LANGUAGE_DETECTION_PREAMBLE + "\n\n" + _GENERAL_BODY
 )
+
+META_CHAT_SYSTEM_PROMPT: Final[str] = _LANGUAGE_DETECTION_PREAMBLE + "\n\n" + _META_BODY

--- a/deploy/litellm/klai_knowledge.py
+++ b/deploy/litellm/klai_knowledge.py
@@ -42,7 +42,11 @@ import httpx
 # ``/opt/klai/scripts/compose-up.sh litellm`` (= ``docker compose up -d
 # --remove-orphans litellm``) so new mounts are picked up automatically —
 # matching every other klai service deploy.
-from klai_chat_prompts import GENERAL_CHAT_SYSTEM_PROMPT, GROUNDED_CHAT_SYSTEM_PROMPT
+from klai_chat_prompts import (
+    GENERAL_CHAT_SYSTEM_PROMPT,
+    GROUNDED_CHAT_SYSTEM_PROMPT,
+    META_CHAT_SYSTEM_PROMPT,
+)
 
 # SPEC-MCP-RETRIEVAL-001 Phase 1: telemetry helpers moved out of this file
 # into ``klai-libs/retrieval-telemetry/`` so klai-knowledge-mcp's new
@@ -266,12 +270,8 @@ PORTAL_RETRIEVAL_LOG_URL = os.getenv(
 )
 EMBEDDING_MODEL_VERSION = os.getenv("EMBEDDING_MODEL_VERSION", "bge-m3-v1")
 KB_IMAGES_BASE_URL = os.getenv("KB_IMAGES_BASE_URL", "https://getklai.getklai.com")
-_MARKDOWN_IMAGE_RE = re.compile(
-    r"!\[([^\]]*)\]\((\S+?)(?:\s+['\"][^'\"]*['\"])?\)"
-)
-_MARKDOWN_LINK_RE = re.compile(
-    r"(?<!!)\[([^\]]+)\]\((\S+?)(?:\s+['\"][^'\"]*['\"])?\)"
-)
+_MARKDOWN_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\((\S+?)(?:\s+['\"][^'\"]*['\"])?\)")
+_MARKDOWN_LINK_RE = re.compile(r"(?<!!)\[([^\]]+)\]\((\S+?)(?:\s+['\"][^'\"]*['\"])?\)")
 _RAW_URL_RE = re.compile(r"https?://[^\s<>()\]]+")
 
 # SPEC-RAG-LOW-CONFIDENCE-ABSTAIN-001 REQ-2 — anti-hallucination injection
@@ -314,6 +314,75 @@ def _is_trivial(text: str) -> bool:
     if len(text) < 8:
         return True
     return bool(_TRIVIAL_PATTERNS.match(text))
+
+
+# Meta-question patterns — detect questions ABOUT Klai itself (capability
+# discovery) rather than questions about content in the knowledge base.
+# Anchored at start AND end of string so we only match short stand-alone
+# meta-questions, not content questions that happen to contain a meta-y
+# substring (e.g. "hoe werkt onze prijsstrategie" must NOT match
+# "hoe werkt"; "ik wil weten wat ik hier kan doen" must NOT match either).
+#
+# Background: 2026-05-12 Voys "Meldingen" incident. The user typed
+# "wat kan ik hier?" — 16 chars, fell through `_is_trivial`, hit
+# retrieval, returned a tangential KB chunk about voice-mail
+# announcements ("Meldingen") that lexically matched on common Dutch
+# words. The chunk became the answer. Solution: detect meta-questions
+# before retrieval and route to META_CHAT_SYSTEM_PROMPT instead.
+#
+# Tight regex by design — preferring false negatives (a meta-question
+# slipping through to retrieval, where it might still get a reasonable
+# answer or a low-confidence abstention) over false positives (a
+# legitimate content question losing access to its KB chunks).
+_META_QUERY_PATTERNS = re.compile(
+    r"^\s*(?:"
+    # NL — "wat kan/kun ik/je/jij" + 0-3 modifier words ("hier", "doen",
+    # "allemaal", "met klai/jou/je"). The {0,3} is what makes
+    # "wat kan ik hier doen?" match alongside "wat kan ik?".
+    r"wat\s+(?:kan|kun)\s+(?:ik|je|jij)"
+    r"(?:\s+(?:hier|met\s+(?:klai|jou|je)|allemaal|doen)){0,3}"
+    # NL — "wat is/doet/doe klai/jij/je"
+    r"|wat\s+(?:is|doet|doe)\s+(?:klai|jij|je)"
+    # NL — "wat kan/kun klai/je/jij (doen)?"
+    r"|wat\s+(?:kan|kun)\s+(?:klai|je|jij)(?:\s+doen)?"
+    # NL — "hoe werkt deze chat/dit/klai/jij/je". Longest alternatives
+    # first so "deze chat" wins over "dit" in left-to-right alternation.
+    r"|hoe\s+werkt\s+(?:deze\s+chat|dit|klai|jij|je)"
+    # NL — "hoe gebruik/werk ik (met)? deze chat/klai/dit"
+    r"|hoe\s+(?:gebruik|werk)\s+ik\s+(?:met\s+)?(?:deze\s+chat|klai|dit)"
+    # NL — "wie ben je"
+    r"|wie\s+ben\s+je"
+    # NL — "waarvoor is dit/klai"
+    r"|waarvoor\s+is\s+(?:dit|klai)"
+    # NL — "waar is dit/klai voor"
+    r"|waar\s+is\s+(?:dit|klai)\s+voor"
+    # NL/EN — "help" standalone (single rule, case-insensitive flag)
+    r"|help"
+    # EN — "what can I/you do" + 0-2 modifier suffixes
+    r"|what\s+can\s+(?:i|you)\s+do"
+    r"(?:\s+(?:here|with\s+(?:klai|you))){0,2}"
+    # EN — "what is/are/does klai (do)?"
+    r"|what\s+(?:is|are|does)\s+klai(?:\s+do)?"
+    # EN — "how does this chat/this/klai work". Longest alternative first.
+    r"|how\s+does\s+(?:this\s+chat|this|klai)\s+work"
+    # EN — "how do I use this chat/klai/this". Longest alternative first.
+    r"|how\s+do\s+i\s+use\s+(?:this\s+chat|klai|this)"
+    # EN — "who are you"
+    r"|who\s+are\s+you"
+    r")[\s!.?]*$",
+    re.IGNORECASE,
+)
+
+
+def _is_meta_query(text: str) -> bool:
+    """Return True if the user is asking ABOUT Klai itself (capability
+    discovery) rather than asking a content question.
+
+    Anchored full-string match — long content questions that contain
+    a meta-y substring do not match. See ``_META_QUERY_PATTERNS`` for
+    the rationale.
+    """
+    return bool(_META_QUERY_PATTERNS.match(text.strip()))
 
 
 def _last_user_message(messages: list[dict]) -> str | None:
@@ -1109,7 +1178,11 @@ def _absolute_image_url(url: object) -> str:
     normalised = _normalise_guard_url(url)
     if not normalised:
         return ""
-    return f"{KB_IMAGES_BASE_URL}{normalised}" if normalised.startswith("/") else normalised
+    return (
+        f"{KB_IMAGES_BASE_URL}{normalised}"
+        if normalised.startswith("/")
+        else normalised
+    )
 
 
 def _sanitize_kb_markdown_output(
@@ -1258,6 +1331,35 @@ def _compose_general_chat_prefix(*blocks: str) -> str:
     return "\n\n".join(b for b in (GENERAL_CHAT_SYSTEM_PROMPT, *blocks) if b)
 
 
+def _compose_meta_chat_prefix(*blocks: str) -> str:
+    """Compose the system-prompt prefix for path A when the user is asking
+    a META question about Klai itself ("what is Klai", "what can I do
+    here", "how does this chat work") rather than a content question.
+
+    Triggered by :func:`_is_meta_query` matching the latest user message.
+    Same language-detection contract as the other two prefixes, but the
+    KB-grounding rules are swapped for capability-explanation rules so
+    the model:
+
+    * does NOT emit [n] citations (no chunks in scope),
+    * does NOT pull or quote any KB content (the user didn't ask for any),
+    * describes Klai at the level of "what kind of thing it is", not a
+      fabricated feature list.
+
+    Templates still apply on this branch — admins may want to override
+    or extend the canned capability description per org. Reachable only
+    from the meta-query branch in
+    :class:`KlaiKnowledgeHook.async_pre_call_hook` (path A only). Paths
+    B and C are server-to-server and never see meta-questions.
+
+    Background: 2026-05-12 Voys "Meldingen" incident. Without this
+    early-return path, a vague meta-question ("wat kan ik hier?") fell
+    through to retrieval, matched a tangential KB chunk on common
+    words, and the model defended that match as the answer.
+    """
+    return "\n\n".join(b for b in (META_CHAT_SYSTEM_PROMPT, *blocks) if b)
+
+
 class KlaiKnowledgeHook(CustomLogger):
     async def async_pre_call_hook(self, user_api_key_dict, cache, data, call_type):
         if call_type not in ("completion", "acompletion"):
@@ -1291,6 +1393,32 @@ class KlaiKnowledgeHook(CustomLogger):
         # Fail-open: empty list on any portal-api error.
         template_instructions = await _get_templates(org_id, librechat_user_id, cache)
         templates_block = _build_template_instructions_block(template_instructions)
+
+        # Meta-question early-return (Voys "Meldingen" incident, 2026-05-12).
+        # When the user asks ABOUT Klai itself ("wat kan ik hier?", "what is
+        # Klai?", "how does this chat work?") rather than asking a content
+        # question, skip retrieval entirely and inject META_CHAT_SYSTEM_PROMPT
+        # so the model gives a plain capability-description answer without
+        # fabricating features or grasping at tangential KB chunks.
+        #
+        # Sits AFTER _is_trivial / org_id / librechat_user_id checks so it
+        # only fires inside a valid path-A request. Sits BEFORE the KB
+        # feature flag because a user without KB entitlement asking "what
+        # is Klai?" still deserves a real answer — not the generic libre
+        # prefix that promises KB grounding.
+        #
+        # Templates still apply so admins can extend the canned capability
+        # description per org.
+        if _is_meta_query(query):
+            _prepend_system_prefix(messages, _compose_meta_chat_prefix(templates_block))
+            data["messages"] = messages
+            logger.info(
+                "meta_query_detected org_id=%s user_id=%s query=%r",
+                org_id,
+                librechat_user_id,
+                query[:80],
+            )
+            return data
 
         # Feature gate + KB scope preference (version-based cache, 30s propagation)
         feature = await _get_kb_feature(librechat_user_id, org_id, cache)
@@ -1743,7 +1871,10 @@ class KlaiKnowledgeHook(CustomLogger):
             if source_url:
                 lines.append(f"source_url: {source_url}")
             absolute_urls = [
-                url for url in (_absolute_image_url(u) for u in chunk.get("image_urls") or [])
+                url
+                for url in (
+                    _absolute_image_url(u) for u in chunk.get("image_urls") or []
+                )
                 if url
             ]
             allowed_image_urls.update(absolute_urls)

--- a/deploy/litellm/tests/test_klai_chat_prompts_drift.py
+++ b/deploy/litellm/tests/test_klai_chat_prompts_drift.py
@@ -55,7 +55,9 @@ def test_vendored_grounded_prompt_matches_canonical() -> None:
     vendored = _load("_drift_vendored_prompts", _VENDORED_PATH)
     canonical = _load("_drift_canonical_prompts", _CANONICAL_PATH)
 
-    assert vendored.GROUNDED_CHAT_SYSTEM_PROMPT == canonical.GROUNDED_CHAT_SYSTEM_PROMPT, (
+    assert (
+        vendored.GROUNDED_CHAT_SYSTEM_PROMPT == canonical.GROUNDED_CHAT_SYSTEM_PROMPT
+    ), (
         "GROUNDED_CHAT_SYSTEM_PROMPT drift between vendored and canonical.\n"
         "  Update deploy/litellm/klai_chat_prompts.py to match "
         "klai-libs/chat-prompts/klai_chat_prompts/__init__.py.\n"
@@ -75,8 +77,30 @@ def test_vendored_general_prompt_matches_canonical() -> None:
     vendored = _load("_drift_vendored_general", _VENDORED_PATH)
     canonical = _load("_drift_canonical_general", _CANONICAL_PATH)
 
-    assert vendored.GENERAL_CHAT_SYSTEM_PROMPT == canonical.GENERAL_CHAT_SYSTEM_PROMPT, (
+    assert (
+        vendored.GENERAL_CHAT_SYSTEM_PROMPT == canonical.GENERAL_CHAT_SYSTEM_PROMPT
+    ), (
         "GENERAL_CHAT_SYSTEM_PROMPT drift between vendored and canonical.\n"
+        "  Update deploy/litellm/klai_chat_prompts.py to match "
+        "klai-libs/chat-prompts/klai_chat_prompts/__init__.py."
+    )
+
+
+def test_vendored_meta_prompt_matches_canonical() -> None:
+    """The ``META_CHAT_SYSTEM_PROMPT`` constant string MUST be byte-identical
+    between vendored and canonical copies. The LiteLLM hook (path A) prepends
+    this prompt on the meta-question early-return path (``_is_meta_query``);
+    drift here would mean Klai answers "what is Klai?" with stale wording in
+    production while passing local tests against the canonical lib.
+
+    Paths B (partner_chat) and C (synthesis) do NOT use META — they are
+    server-to-server with KB scope always in play.
+    """
+    vendored = _load("_drift_vendored_meta", _VENDORED_PATH)
+    canonical = _load("_drift_canonical_meta", _CANONICAL_PATH)
+
+    assert vendored.META_CHAT_SYSTEM_PROMPT == canonical.META_CHAT_SYSTEM_PROMPT, (
+        "META_CHAT_SYSTEM_PROMPT drift between vendored and canonical.\n"
         "  Update deploy/litellm/klai_chat_prompts.py to match "
         "klai-libs/chat-prompts/klai_chat_prompts/__init__.py."
     )

--- a/deploy/litellm/tests/test_klai_knowledge_meta_query.py
+++ b/deploy/litellm/tests/test_klai_knowledge_meta_query.py
@@ -1,0 +1,348 @@
+"""Tests for the meta-query early-return path added 2026-05-12.
+
+Background: SPEC-CHAT-META-QUERY-001 (Voys "Meldingen" incident retro).
+
+A vague meta-question — "wat kan ik hier?" — fell through `_is_trivial`
+(16 chars > 8-byte threshold, no pattern match), reached retrieval, and
+matched a tangential Voys KB chunk about voice-mail announcements on
+common Dutch lexical overlap. The Klai chat presented that chunk as
+the answer, then defended it when the user asked why ("dat staat in
+de kennisbank"). No mechanism existed to detect "this is a question
+ABOUT Klai, not a content question" before retrieval ran.
+
+The fix adds three things to deploy/litellm/klai_knowledge.py:
+
+1. ``_META_QUERY_PATTERNS`` — a tight anchored regex.
+2. ``_is_meta_query`` — predicate function.
+3. An early-return path in ``async_pre_call_hook`` that injects
+   ``META_CHAT_SYSTEM_PROMPT`` and skips retrieval entirely.
+
+These tests guard those three points:
+- Regex matches every documented meta phrasing (NL + EN positives).
+- Regex does NOT match content questions that contain meta-y substrings
+  (the critical failure mode — false positives would silently strip KB
+  retrieval from legitimate user questions).
+- The hook's early-return path actually fires: META prompt is prepended,
+  retrieval HTTP call is never made, KB feature lookup is never made.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ─── Mock litellm so klai_knowledge can be imported in the test env ────
+
+
+@pytest.fixture(autouse=True)
+def _mock_litellm():
+    """Same shim as test_klai_knowledge_hook.py — litellm is not installed
+    locally (lives only inside the Docker image). Build a minimal stub that
+    satisfies the ``from litellm.integrations.custom_logger import
+    CustomLogger`` import path in klai_knowledge.
+    """
+    litellm_mod = types.ModuleType("litellm")
+    integrations_mod = types.ModuleType("litellm.integrations")
+    custom_logger_mod = types.ModuleType("litellm.integrations.custom_logger")
+
+    class CustomLogger:
+        async def async_pre_call_hook(self, *args, **kwargs):
+            pass
+
+        async def async_post_call_success_hook(self, *args, **kwargs):
+            pass
+
+        async def async_post_call_failure_hook(self, *args, **kwargs):
+            pass
+
+    custom_logger_mod.CustomLogger = CustomLogger
+    litellm_mod.integrations = integrations_mod
+    integrations_mod.custom_logger = custom_logger_mod
+
+    sys.modules["litellm"] = litellm_mod
+    sys.modules["litellm.integrations"] = integrations_mod
+    sys.modules["litellm.integrations.custom_logger"] = custom_logger_mod
+
+    yield
+
+    for mod_name in (
+        "litellm",
+        "litellm.integrations",
+        "litellm.integrations.custom_logger",
+    ):
+        sys.modules.pop(mod_name, None)
+    sys.modules.pop("klai_knowledge", None)
+
+
+def _load_hook(monkeypatch):
+    env = {
+        "PORTAL_INTERNAL_SECRET": "test-portal-secret",
+        "RETRIEVAL_INTERNAL_SECRET": "test-retrieval-secret",
+        "KNOWLEDGE_RETRIEVE_URL": "http://retrieval-api:8040/retrieve",
+        "PORTAL_API_URL": "http://portal-api:8000",
+    }
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    sys.modules.pop("klai_knowledge", None)
+    import klai_knowledge
+
+    importlib.reload(klai_knowledge)
+    # Silence fire-and-forget producers per .claude/rules/klai/lang/testing.md
+    # (coroutine-never-awaited at GC). Not strictly needed for the meta-path
+    # since retrieval is skipped, but mirrors the canonical pattern from
+    # test_klai_knowledge_hook.py.
+    monkeypatch.setattr(klai_knowledge, "_fire_gap_event", MagicMock())
+    monkeypatch.setattr(klai_knowledge, "_fire_retrieval_log", MagicMock())
+    return klai_knowledge
+
+
+# ─── Regex positives — phrasings that MUST match ───────────────────────
+
+
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        # ─── Dutch ────────────────────────────────────────────────
+        "wat kan ik hier?",
+        "wat kan ik hier",
+        "Wat kan ik hier doen?",
+        "wat kan ik met klai",
+        "wat kan ik met jou",
+        "wat kan ik met je doen?",
+        "wat kan ik allemaal?",
+        "wat is klai?",
+        "wat doet klai",
+        "wat doe je",
+        "wat kan je",
+        "Wat kan je doen?",
+        "wat kun je?",
+        "wat kan klai doen?",
+        "hoe werkt dit?",
+        "hoe werkt klai",
+        "hoe werkt deze chat",
+        "hoe gebruik ik klai?",
+        "hoe gebruik ik deze chat",
+        "wie ben je?",
+        "waarvoor is dit?",
+        "waar is dit voor?",
+        "help",
+        "Help?",
+        # ─── English ──────────────────────────────────────────────
+        "what can I do?",
+        "what can I do here?",
+        "What can I do with Klai?",
+        "what can I do with you",
+        "what can you do?",
+        "what can you do here",
+        "what is klai?",
+        "what is Klai",
+        "what does klai do",
+        "what are klai",
+        "how does this work?",
+        "how does klai work",
+        "how does this chat work?",
+        "how do I use klai?",
+        "how do I use this chat?",
+        "who are you?",
+        "Help",
+    ],
+)
+def test_meta_query_matches_known_phrasings(phrase, monkeypatch):
+    mod = _load_hook(monkeypatch)
+    assert mod._is_meta_query(phrase), f"expected meta-match: {phrase!r}"
+
+
+# ─── Regex negatives — content questions that MUST NOT match ───────────
+#
+# These are the high-cost false-positive cases. A user asking a real
+# content question that lexically contains "wat kan ik" or "how does"
+# must NOT be misclassified as a meta-question — that would silently
+# strip retrieval and produce a non-answer.
+
+
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        # NL — content questions that lexically contain meta substrings
+        "wat kan ik doen om mijn factuur te betalen?",
+        "wat kan ik aanpassen aan onze prijsstrategie",
+        "wat is onze hoofdkantoor in Amsterdam",
+        "wat doet onze HR-afdeling met vakantiedagen",
+        "hoe werkt onze prijsstrategie?",
+        "hoe werkt de salesfunnel bij ons",
+        "hoe gebruik ik het CRM",
+        "ik wil weten wat ik hier kan",
+        "ik wil weten hoe dit werkt voor klanten",
+        "kun je me helpen met het onboarding-proces?",
+        "help me met deze klant",
+        # EN — content questions with meta substrings
+        "what can I do to escalate a customer issue?",
+        "what does our refund policy say",
+        "what is our pricing for enterprise?",
+        "how does our pricing tier work?",
+        "how does this customer escalation work",
+        "how do I use the CRM",
+        "i need to know what can I do about a refund",
+        "help me with the onboarding flow",
+        # Edge: long messages where meta phrase is a substring
+        "Klant vraagt wat kan ik hier doen, hoe leg ik dat uit?",
+        "How does this product compare to competitor X for enterprise?",
+    ],
+)
+def test_meta_query_does_not_match_content_questions(phrase, monkeypatch):
+    mod = _load_hook(monkeypatch)
+    assert not mod._is_meta_query(phrase), (
+        f"false-positive meta-match for content question: {phrase!r}"
+    )
+
+
+# ─── Integration: hook early-return injects META and skips retrieval ───
+
+
+def _make_cache():
+    """Minimal cache that returns empty templates and forces a kb_feature
+    cache miss. The meta-path returns BEFORE kb_feature is consulted, so
+    the cache miss should never trigger an HTTP call — that's the
+    invariant the integration test guards.
+    """
+    cache = MagicMock()
+    cache.async_set_cache = AsyncMock()
+
+    async def _get(key: str) -> object:
+        if key.startswith("templates:"):
+            return []
+        return None
+
+    cache.async_get_cache = AsyncMock(side_effect=_get)
+    return cache
+
+
+def _make_user_api_key(org_id: str = "org123"):
+    uak = MagicMock()
+    uak.metadata = {"org_id": org_id}
+    return uak
+
+
+@pytest.mark.asyncio
+async def test_meta_query_injects_meta_prompt_and_skips_retrieval(monkeypatch):
+    """End-to-end: 'wat kan ik hier?' triggers the early-return path.
+
+    Asserts:
+      1. ``META_CHAT_SYSTEM_PROMPT`` is prepended to the system message.
+      2. ``GROUNDED_CHAT_SYSTEM_PROMPT`` is NOT present (would mean the
+         hook fell through to the libre-chat path).
+      3. No httpx call is made (no retrieval, no kb_feature lookup) —
+         this is the cost-saving + correctness invariant: retrieval
+         must not run for meta-questions.
+    """
+    mod = _load_hook(monkeypatch)
+    hook = mod.KlaiKnowledgeHook()
+    cache = _make_cache()
+
+    data = {
+        "user": "aabbcc112233445566778899",
+        "messages": [{"role": "user", "content": "wat kan ik hier?"}],
+    }
+
+    with patch("klai_knowledge.httpx.AsyncClient") as cls:
+        mc = AsyncMock()
+        mc.get = AsyncMock()
+        mc.post = AsyncMock()
+        mc.__aenter__ = AsyncMock(return_value=mc)
+        mc.__aexit__ = AsyncMock(return_value=None)
+        cls.return_value = mc
+
+        result = await hook.async_pre_call_hook(
+            _make_user_api_key(), cache, data, "completion"
+        )
+
+        # Invariant 3: no HTTP calls at all on the meta path.
+        assert mc.post.await_count == 0, (
+            "meta-query path must not call retrieval-api /retrieve"
+        )
+        assert mc.get.await_count == 0, (
+            "meta-query path must not call portal-api /internal/kb-feature"
+        )
+
+    messages = result["messages"]
+    # Invariant 1: there's now a system message and it starts with META.
+    assert messages[0]["role"] == "system"
+    sys_content = messages[0]["content"]
+    # Anchor on a unique META section marker — the language preamble is
+    # shared with GROUNDED/GENERAL so we cannot match on the [CRITICAL]
+    # prefix alone.
+    assert "META question about Klai itself" in sys_content, (
+        "system message does not contain META_CHAT_SYSTEM_PROMPT body"
+    )
+    # Invariant 2: the GROUNDED-only KB header is absent.
+    assert "knowledge base chunks provided" not in sys_content, (
+        "GROUNDED prompt leaked into the meta-question path"
+    )
+
+
+@pytest.mark.asyncio
+async def test_meta_query_is_not_triggered_by_content_question(monkeypatch):
+    """A content question that lexically contains 'hoe werkt' must take the
+    normal retrieval path (HTTP call to /retrieve), not the META early
+    return. Guards the regex's false-positive rate at the hook level.
+    """
+    mod = _load_hook(monkeypatch)
+    hook = mod.KlaiKnowledgeHook()
+
+    # Use the real kb_feature cache shape so the hook reaches retrieval.
+    cache = MagicMock()
+    cache.async_set_cache = AsyncMock()
+    feat = {
+        "enabled": True,
+        "kb_retrieval_enabled": True,
+        "kb_personal_enabled": True,
+        "kb_slugs_filter": None,
+        "version": 0,
+        "zitadel_user_id": "362901948573220875",
+    }
+
+    async def _get(key: str) -> object:
+        if key.startswith("kb_ver:"):
+            return "0"
+        if key.startswith("kb_feature:"):
+            return feat
+        if key.startswith("templates:"):
+            return []
+        if key.startswith("tax_trees:") or key.startswith("tax_coverage:"):
+            return {}
+        return None
+
+    cache.async_get_cache = AsyncMock(side_effect=_get)
+
+    data = {
+        "user": "aabbcc112233445566778899",
+        "messages": [{"role": "user", "content": "hoe werkt onze prijsstrategie?"}],
+    }
+
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"chunks": [], "retrieval_bypassed": False}
+    resp.raise_for_status = MagicMock()
+
+    with patch("klai_knowledge.httpx.AsyncClient") as cls:
+        mc = AsyncMock()
+        mc.get = AsyncMock(return_value=resp)
+        mc.post = AsyncMock(return_value=resp)
+        mc.__aenter__ = AsyncMock(return_value=mc)
+        mc.__aexit__ = AsyncMock(return_value=None)
+        cls.return_value = mc
+
+        await hook.async_pre_call_hook(_make_user_api_key(), cache, data, "completion")
+
+        # Content questions MUST reach retrieval. Without this assertion
+        # an over-eager regex tweak would silently strip KB access from
+        # every "how does our X work" style question.
+        assert mc.post.await_count >= 1, (
+            "content question with 'hoe werkt' substring must still call "
+            "retrieval — the meta regex must NOT match it"
+        )

--- a/klai-libs/chat-prompts/klai_chat_prompts/__init__.py
+++ b/klai-libs/chat-prompts/klai_chat_prompts/__init__.py
@@ -14,6 +14,15 @@ no [n] citation pressure — the model behaves as a general-purpose
 assistant. Paths B and C never reach this prompt because they are
 server-to-server and always carry KB scope.
 
+:data:`META_CHAT_SYSTEM_PROMPT` is used by the LiteLLM hook (path A)
+when the user asks a META question about Klai itself — "what is Klai?",
+"what can I do here?", "how does this work?". Same language-detection
+contract as GROUNDED and GENERAL, but no retrieval and no KB-grounding
+rules — the model gives a plain "what Klai is and how to use it"
+answer without fabricating specific features. Paths B and C never
+reach this prompt: partners build their own UI affordances around the
+chat surface, and retrieval-api /chat is server-to-server.
+
 Behaviour encoded in both prompts (per SPEC REQ-01):
 
 1. Auto-detect the language of the user's most recent SUBSTANTIVE
@@ -33,11 +42,23 @@ GROUNDED-only behaviour (KB chunks present):
    language naturally, without translator disclaimers or apologies.
 4. Citations [n] always link to the original source URL regardless of
    language.
+5. When the user questions WHY a previous answer was given, the model
+   names the actual chunks it used and admits weak matches rather than
+   retrofitting a justification. This is the anti-confabulation guard
+   (added 2026-05-12 after the Voys "Meldingen" incident where the
+   model defended a tangential KB match by claiming "dat staat in de
+   kennisbank" as the sole justification).
 
 GENERAL-only behaviour (no KB selected):
 
-5. Answer from general knowledge. Do NOT add [n] citations. Do NOT
+6. Answer from general knowledge. Do NOT add [n] citations. Do NOT
    pretend to have sources. If unsure, say so plainly.
+
+META-only behaviour (user asks what Klai is):
+
+7. Explain Klai at the level of "what kind of thing it is" — not a
+   feature list. Suggest 2-3 generic example questions. Never fabricate
+   specific product names, processes, or features.
 
 Industry validation for the three guards: Invent's 2025 multilingual-AI
 agents best-practices guide and Quickchat's 2026 multilingual-chatbots
@@ -53,12 +74,16 @@ from __future__ import annotations
 
 from typing import Final
 
-__all__ = ["GENERAL_CHAT_SYSTEM_PROMPT", "GROUNDED_CHAT_SYSTEM_PROMPT"]
+__all__ = [
+    "GENERAL_CHAT_SYSTEM_PROMPT",
+    "GROUNDED_CHAT_SYSTEM_PROMPT",
+    "META_CHAT_SYSTEM_PROMPT",
+]
 
 
 # Shared language-detection contract (SPEC-RAG-MULTILINGUAL-CHAT-001
-# REQ-01). Private — both prompts compose this preamble verbatim so
-# the three guards can never drift between general and grounded modes.
+# REQ-01). Private — all three public prompts compose this preamble
+# verbatim so the three guards can never drift between modes.
 _LANGUAGE_DETECTION_PREAMBLE: Final[str] = (
     "[CRITICAL] Detect the language of the user's most recent SUBSTANTIVE message and respond "
     "in that exact language. Apply these three guards:\n"
@@ -93,7 +118,21 @@ _GROUNDED_BODY: Final[str] = (
     "'Dat staat niet in de kennisbank' / 'Das steht nicht in der Wissensdatenbank'. "
     "Don't guess. Don't fill the gap with general knowledge. "
     "If you're partially sure, say that too: 'The knowledge base touches on this, but doesn't "
-    "fully answer it.'"
+    "fully answer it.'\n\n"
+    "## When the user questions your reasoning\n"
+    "If the user asks why you gave a specific previous answer — phrasings like 'why this?', "
+    "'where does that come from?', 'how do you know?', 'on what basis?', 'waarom kom je met "
+    "dit antwoord?', 'waar haal je dit vandaan?' — step out of source-quoting mode and be "
+    "transparent about HOW you reached the previous answer. Specifically:\n"
+    "- Name the actual chunks you relied on (chunk title and source URL).\n"
+    "- If those chunks were only a weak or tangential match to the user's question, say so "
+    "plainly. Example: 'I matched on the word X in this article, but the article is about Y "
+    "rather than directly about your question.'\n"
+    "- Never use 'because that's in the knowledge base' as the sole reason. That is a "
+    "non-answer and the user will notice.\n"
+    "- If you are not confident your previous answer addressed what they actually meant, say "
+    "so and ask which part of the topic they want — do NOT retrofit a justification for the "
+    "answer you already gave."
 )
 
 _GENERAL_BODY: Final[str] = (
@@ -130,11 +169,45 @@ _GENERAL_BODY: Final[str] = (
     "require a real-world lookup."
 )
 
-
-GROUNDED_CHAT_SYSTEM_PROMPT: Final[str] = (
-    _LANGUAGE_DETECTION_PREAMBLE + "\n\n" + _GROUNDED_BODY
+_META_BODY: Final[str] = (
+    "You are Klai AI, an AI assistant for your organization's knowledge. The user is asking "
+    "a META question about Klai itself — what it is, what they can do here, or how to use "
+    "this chat. They are NOT asking a question about the content of any document. Step out "
+    "of source-retrieval mode and explain Klai plainly.\n\n"
+    "## What Klai is, at the level of 'what kind of thing it is'\n"
+    "- Klai lets the user search and chat with their organization's knowledge — documents "
+    "they or their team uploaded, sources they connected (e.g. Notion, Google Drive, "
+    "websites).\n"
+    "- Klai understands the question in any language and answers in that language, even when "
+    "the underlying source documents are in another language.\n"
+    "- The user can scope the chat to all org collections, a specific collection, or only "
+    "their personal documents — via the knowledge-base selector in the chat interface.\n"
+    "- Klai does not browse the live web by default. For company info or recent events "
+    "outside the knowledge base, the user can enable the Web Search tool (the magnifying-"
+    "glass button next to the paperclip at the bottom of the chat) or attach the relevant "
+    "knowledge base.\n\n"
+    "## Suggest 2-3 example questions\n"
+    "Phrase them GENERICALLY: 'How do I ...?', 'Where can I find ...?', 'What is our policy "
+    "on ...?'. Use generic placeholders like 'X' or '<topic>'. Do NOT invent specific product "
+    "names, internal processes, team names, people, or features.\n\n"
+    "## Strict — these matter more than sounding complete\n"
+    "- Do NOT add [n] citations. There are no sources to cite — this is not a content "
+    "question.\n"
+    "- Do NOT quote from any document. The user did not ask for content.\n"
+    "- Do NOT invent specific Klai features beyond what is described above. If you are not "
+    "certain a feature exists, do not name it.\n"
+    "- Do NOT use warm-up filler ('great question!', 'leuk dat je dit vraagt!', 'happy to "
+    "help!').\n"
+    "- Do NOT use emoji.\n\n"
+    "## Style\n"
+    "Short. Direct. Bullet points are fine. Translate the entire response into the user's "
+    "detected language. Then stop — do not append 'let me know if you have more questions!' "
+    "or similar filler."
 )
 
-GENERAL_CHAT_SYSTEM_PROMPT: Final[str] = (
-    _LANGUAGE_DETECTION_PREAMBLE + "\n\n" + _GENERAL_BODY
-)
+
+GROUNDED_CHAT_SYSTEM_PROMPT: Final[str] = _LANGUAGE_DETECTION_PREAMBLE + "\n\n" + _GROUNDED_BODY
+
+GENERAL_CHAT_SYSTEM_PROMPT: Final[str] = _LANGUAGE_DETECTION_PREAMBLE + "\n\n" + _GENERAL_BODY
+
+META_CHAT_SYSTEM_PROMPT: Final[str] = _LANGUAGE_DETECTION_PREAMBLE + "\n\n" + _META_BODY

--- a/klai-libs/chat-prompts/tests/test_grounded_prompt.py
+++ b/klai-libs/chat-prompts/tests/test_grounded_prompt.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from klai_chat_prompts import (
     GENERAL_CHAT_SYSTEM_PROMPT,
     GROUNDED_CHAT_SYSTEM_PROMPT,
+    META_CHAT_SYSTEM_PROMPT,
 )
 
 
@@ -130,12 +131,9 @@ def test_general_prompt_forbids_kb_grounding_phrases():
         "fallback — it instructs the model to refuse general-knowledge "
         "questions when no KB is in scope."
     )
-    assert "knowledge base chunks provided" not in text, (
-        "GENERAL prompt MUST NOT promise KB chunks — there are none."
-    )
+    assert "knowledge base chunks provided" not in text, "GENERAL prompt MUST NOT promise KB chunks — there are none."
     assert "Every factual claim gets a [n] citation" not in text, (
-        "GENERAL prompt MUST NOT mandate [n] citations — without sources "
-        "the model will fabricate citation markers."
+        "GENERAL prompt MUST NOT mandate [n] citations — without sources the model will fabricate citation markers."
     )
 
 
@@ -176,9 +174,7 @@ def test_general_prompt_carries_anti_hallucination_block():
     # tagline ("volledig groene telefonie"). The follow-up adds an
     # explicit anti-fabrication block.
     text = GENERAL_CHAT_SYSTEM_PROMPT
-    assert "Do NOT invent" in text, (
-        "GENERAL prompt missing the explicit anti-fabrication directive."
-    )
+    assert "Do NOT invent" in text, "GENERAL prompt missing the explicit anti-fabrication directive."
     # Must reference the Web Search escape hatch by name so the model
     # tells the user where to enable it.
     assert "Web Search" in text, (
@@ -191,3 +187,148 @@ def test_general_prompt_carries_anti_hallucination_block():
     # Must explicitly forbid fabricating URLs/domains — that was the
     # exact regression: 'voys.nl' invented out of thin air.
     assert "URL" in text
+
+
+# ─── GROUNDED anti-confabulation guard ──────────────────────────────
+
+
+def test_grounded_prompt_carries_anti_confabulation_block():
+    """Regression for the 2026-05-12 Voys "Meldingen" incident: when the user
+    questions WHY a previous answer was given, the model must not retrofit a
+    justification by saying "dat staat in de kennisbank". The GROUNDED prompt
+    now carries an explicit "When the user questions your reasoning" section
+    that instructs the model to name actual chunks used, admit weak matches,
+    and offer a re-try instead of defending the original answer.
+    """
+    text = GROUNDED_CHAT_SYSTEM_PROMPT
+    # Section header — anchors the rule so a future edit that removes it
+    # surfaces immediately.
+    assert "When the user questions your reasoning" in text, (
+        "GROUNDED prompt missing the anti-confabulation section. The Voys "
+        "incident retrospect required a dedicated section, not just a "
+        "passing mention."
+    )
+    # Bilingual trigger phrasings — Klai's primary user-facing language is
+    # NL; English coverage is required for partner-API surfaces.
+    text_lower = text.lower()
+    assert "waarom kom je met dit antwoord" in text_lower
+    assert "why this?" in text_lower or "where does that come from" in text_lower
+    # Positive instruction: name the actual chunks used.
+    assert "name the actual chunks" in text_lower
+    # Explicit forbid: never use the "it's in the KB" non-answer.
+    assert "non-answer" in text_lower, (
+        "GROUNDED prompt must explicitly mark 'it's in the KB' as a "
+        "non-answer — otherwise the model keeps reaching for it."
+    )
+
+
+# ─── META_CHAT_SYSTEM_PROMPT regression tests ────────────────────────
+
+
+def test_meta_prompt_is_non_empty():
+    assert isinstance(META_CHAT_SYSTEM_PROMPT, str)
+    assert len(META_CHAT_SYSTEM_PROMPT) > 500
+
+
+def test_meta_prompt_carries_critical_marker():
+    # The shared language-detection preamble starts with [CRITICAL].
+    assert "[CRITICAL]" in META_CHAT_SYSTEM_PROMPT
+
+
+def test_meta_prompt_inherits_three_guards_from_preamble():
+    # The 3-guard contract is shared across GROUNDED / GENERAL / META via
+    # the private _LANGUAGE_DETECTION_PREAMBLE. If a refactor drops the
+    # preamble from META, this test fails loud instead of silently
+    # drifting.
+    text = META_CHAT_SYSTEM_PROMPT.lower()
+    assert "substantive" in text
+    assert "5 words" in META_CHAT_SYSTEM_PROMPT
+    assert "single foreign-language words" in text or "single foreign" in text
+    assert "stays switched" in text
+
+
+def test_meta_prompt_includes_klai_ai_identity():
+    assert "Klai AI" in META_CHAT_SYSTEM_PROMPT
+
+
+def test_meta_prompt_marks_question_as_meta():
+    # The whole point of this prompt: instruct the model that the user is
+    # asking ABOUT Klai, not asking a content question. If a future edit
+    # softens this framing, the model falls back to source-quoting mode and
+    # the Voys-style failure reopens.
+    text = META_CHAT_SYSTEM_PROMPT
+    assert "META question" in text or "meta question" in text.lower()
+    assert "NOT asking a question about the content" in text
+
+
+def test_meta_prompt_forbids_citation_and_quoting():
+    # META MUST NOT cite [n] — there are no chunks in scope.
+    text = META_CHAT_SYSTEM_PROMPT
+    assert "Do NOT add [n] citations" in text, (
+        "META prompt MUST explicitly forbid [n] citations — without sources the model would fabricate citation markers."
+    )
+    assert "Do NOT quote from any document" in text
+
+
+def test_meta_prompt_forbids_feature_fabrication():
+    # The specific anti-pattern: Klai inventing feature names that don't
+    # exist. The phrasing must be unambiguous, not just hint.
+    text = META_CHAT_SYSTEM_PROMPT
+    assert "Do NOT invent specific Klai features" in text
+
+
+def test_meta_prompt_requires_generic_example_phrasing():
+    # The model is asked to give 2-3 example questions, but PHRASED
+    # generically with placeholders. The exact regression we want to
+    # prevent: model invents "voorbeeld: wat is onze pricing voor X?" with
+    # invented product names.
+    text = META_CHAT_SYSTEM_PROMPT
+    assert "GENERICALLY" in text
+    assert "Do NOT invent specific product names" in text
+
+
+def test_meta_prompt_describes_klai_at_capability_level():
+    # The "what kind of thing it is" description must mention:
+    # - org knowledge (KB grounding)
+    # - multilingual
+    # - KB selector (the chat surface UI affordance)
+    # - Web Search escape hatch
+    text = META_CHAT_SYSTEM_PROMPT
+    assert "organization's knowledge" in text or "organization knowledge" in text.lower()
+    assert "any language" in text.lower()
+    assert "knowledge-base selector" in text.lower() or "kb selector" in text.lower()
+    assert "Web Search" in text
+
+
+def test_meta_prompt_forbids_sycophancy_and_emoji():
+    # Specific anti-pattern from the Voys incident: the response ended
+    # with "Bedankt! 😊" — sycophancy + emoji. META must explicitly
+    # forbid both so the model doesn't default back to filler.
+    text = META_CHAT_SYSTEM_PROMPT
+    assert "Do NOT use warm-up filler" in text
+    assert "Do NOT use emoji" in text
+
+
+def test_meta_prompt_shares_preamble_byte_for_byte_with_grounded():
+    # META and GROUNDED MUST share the identical language-detection
+    # preamble. Same invariant as the GROUNDED ↔ GENERAL pair, extended
+    # to the third prompt now in play.
+    preamble_end = GROUNDED_CHAT_SYSTEM_PROMPT.find("\n\nYou are Klai AI")
+    assert preamble_end > 0, "GROUNDED prompt structure changed unexpectedly"
+    grounded_preamble = GROUNDED_CHAT_SYSTEM_PROMPT[:preamble_end]
+    assert META_CHAT_SYSTEM_PROMPT.startswith(grounded_preamble + "\n\n"), (
+        "META and GROUNDED must share an identical language-detection "
+        "preamble. Refactor _LANGUAGE_DETECTION_PREAMBLE if you need to "
+        "change it — never edit one of the public constants in isolation."
+    )
+
+
+def test_all_three_prompts_share_identical_preamble():
+    # Defence-in-depth: the previous two pairwise tests cover GROUNDED ↔
+    # GENERAL and GROUNDED ↔ META. This third test asserts the full
+    # three-way equality so a future refactor can't accidentally derive
+    # the preamble from two of the three.
+    preamble_end = GROUNDED_CHAT_SYSTEM_PROMPT.find("\n\nYou are Klai AI")
+    preamble = GROUNDED_CHAT_SYSTEM_PROMPT[:preamble_end]
+    assert GENERAL_CHAT_SYSTEM_PROMPT.startswith(preamble + "\n\n")
+    assert META_CHAT_SYSTEM_PROMPT.startswith(preamble + "\n\n")


### PR DESCRIPTION
Adds two complementary safeguards to klai's customer-facing chat (path A,
LibreChat → LiteLLM hook → Mistral). Triggered by the 2026-05-12 Voys
"Meldingen" incident where a vague meta-question ("wat kan ik hier?")
fell through `_is_trivial`, hit retrieval, and the model defended a
tangential Voys-Meldingen chunk by claiming "dat staat in de kennisbank"
as the sole justification when the user asked why.

## Change 1 — Meta-question detector (path A only)

- New `META_CHAT_SYSTEM_PROMPT` constant in `klai-libs/chat-prompts` +
  byte-identical vendored mirror. Describes Klai at "what kind of thing
  it is" level — no fabricated feature lists, no [n] citations, no KB
  quoting, no emoji, no sycophancy. Asks for 2-3 GENERIC example
  questions ("How do I ...?") with placeholders, not invented specifics.
- New `_META_QUERY_PATTERNS` regex + `_is_meta_query()` in
  `deploy/litellm/klai_knowledge.py`. Anchored start/end so only short
  stand-alone meta-questions match. NL + EN coverage. Content questions
  with meta-y substrings ("hoe werkt onze prijsstrategie?", "what can I
  do to escalate") explicitly do NOT match.
- New `_compose_meta_chat_prefix()` helper. Templates pass through.
- New early-return branch in `KlaiKnowledgeHook.async_pre_call_hook`
  AFTER `_is_trivial` / identity checks, BEFORE KB feature flag. Skips
  retrieval entirely. Logs `meta_query_detected`.

## Change 2 — Anti-confabulation rule (paths A + B + C)

- New `## When the user questions your reasoning` section in
  `_GROUNDED_BODY`. Triggers on phrasings like "waarom kom je met dit
  antwoord?", "where does that come from?". Instructs the model to name
  actual chunks used, admit weak matches, never claim "it's in the KB"
  as sole reason, offer re-try instead of retrofitting a justification.
- Applies automatically to paths B (partner_chat) and C (synthesis)
  because they import GROUNDED from the canonical lib.

## Not in scope (explicit)

- Retrieval-side confidence threshold tuning (retrieval-api concern)
- UI-level suggested-prompt cards on empty chat (frontend, parallel)
- LLM-based intent classifier (regex covers known class without latency)
- Meta detection on paths B + C (server-to-server, don't ask meta)

## Tests

- `klai-libs/chat-prompts/tests/test_grounded_prompt.py` — +13 tests
  covering META structure + GROUNDED anti-confabulation block.
- `deploy/litellm/tests/test_klai_chat_prompts_drift.py` — +1 META
  byte-identity drift test.
- `deploy/litellm/tests/test_klai_knowledge_meta_query.py` (NEW) — 64
  parametrized regex cases (positives + critical false-positive
  negatives) + 2 hook-level integration tests.

## Verification

- 33/33 `klai-libs/chat-prompts` tests pass
- 208/208 `deploy/litellm` tests pass (incl. 64 new + 4 drift)
- 15/15 `test_partner_chat.py` pass (path B backward-compat)
- 17/17 `test_synthesis.py` pass (path C backward-compat)
- `scripts/lint-no-duplicate-chat-prompt.sh` clean
- `ruff check` + `ruff format --check` clean on all 6 changed files

## Deploy

Triggers `litellm-hook-deploy.yml` on merge, which uses
`compose-up.sh --force-recreate litellm` per
`bind-mount-content-vs-python-module-cache` pitfall — new
`klai_chat_prompts.py` content gets picked up on first request after
recreate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)