### PR TITLE
fix(signup): add missing signup_password_too_short paraglide message

### DIFF
--- a/klai-portal/frontend/messages/en.json
+++ b/klai-portal/frontend/messages/en.json
@@ -67,6 +67,7 @@
   "signup_privacy_link": "privacy policy",
   "signup_error_server": "Error {status} — please try again",
   "signup_error_connection": "Cannot connect to the server",
+  "signup_password_too_short": "Password must be at least 12 characters",
   "signup_or_continue_with": "or continue with",
   "signup_with_google": "Continue with Google",
   "signup_with_microsoft": "Continue with Microsoft",

--- a/klai-portal/frontend/messages/nl.json
+++ b/klai-portal/frontend/messages/nl.json
@@ -67,6 +67,7 @@
   "signup_privacy_link": "privacyverklaring",
   "signup_error_server": "Fout {status} — probeer opnieuw",
   "signup_error_connection": "Kan geen verbinding maken met de server",
+  "signup_password_too_short": "Wachtwoord moet minimaal 12 tekens zijn",
   "signup_or_continue_with": "of ga verder met",
   "signup_with_google": "Ga verder met Google",
   "signup_with_microsoft": "Ga verder met Microsoft",


### PR DESCRIPTION
## Wat

Voegt de ontbrekende paraglide message-key `signup_password_too_short` toe in
`en.json` en `nl.json`.

## Waarom

Pre-existing tsc-error op `origin/main` sinds SPEC-AUTH-001 (commit
[\`4bd4219a\`](https://github.com/GetKlai/klai/commit/4bd4219a)). Die PR
introduceerde een aanroep naar `m.signup_password_too_short()` op
[signup/index.tsx:84](https://github.com/GetKlai/klai/blob/main/klai-portal/frontend/src/routes/%24locale/signup/index.tsx#L84)
maar zette de message-key zelf niet in de twee messages-bestanden. Effect:

```
src/routes/$locale/signup/index.tsx(84,18): error TS2339:
Property 'signup_password_too_short' does not exist on type
'typeof import(".../paraglide/messages")'.
```

## Copy

Spiegelt de feitelijke constraint op
[signup/index.tsx:83](https://github.com/GetKlai/klai/blob/main/klai-portal/frontend/src/routes/%24locale/signup/index.tsx#L83)
(`form.password.length < 12` per SPEC-LAUNCH-SOFTLAUNCH-001 B-1):

- **en**: `Password must be at least 12 characters`
- **nl**: `Wachtwoord moet minimaal 12 tekens zijn`

Stijl-consistent met de naburige `signup_error_*` messages in beide
bestanden.

## Quality gates (lokaal)

- `npm run i18n:compile` — clean
- `npx tsc -b --force` — **exit 0** (was 1 op origin/main)
- `vitest run` — 27 files, 204 tests passed

## Scope

Alleen deze ene message-key. Geen andere ontbrekende keys, geen wijzigingen
aan de signup-flow zelf, geen refactor.

## Out of scope (aparte PRs nodig)

- `npm audit` failures die `Build and deploy portal-frontend` workflow
  blokkeren sinds 2026-05-11 (8 vulnerabilities incl. critical malware in
  `@tanstack/history`). Deze PR's CI zal pas écht groen worden in
  `Build and deploy portal-frontend` zodra dat npm-audit-issue apart is
  opgelost — de typecheck-stap zelf zou wel moeten slagen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)