### PR TITLE
Harden LibreChat patch deployment

### DIFF
--- a/.github/workflows/deploy-compose.yml
+++ b/.github/workflows/deploy-compose.yml
@@ -42,6 +42,7 @@ jobs:
           chmod +x deploy/check-image-tags.sh deploy/check-image-pullable.sh
           sh deploy/check-image-tags.sh
           sh deploy/check-image-pullable.sh
+          sh deploy/librechat/check-patch-drift.sh
 
       - name: Sync docker-compose.yml + config + run smoke-test
         uses: appleboy/ssh-action@v1

--- a/.github/workflows/deploy-librechat-config.yml
+++ b/.github/workflows/deploy-librechat-config.yml
@@ -20,6 +20,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Validate LibreChat patches
+        run: sh deploy/librechat/check-patch-drift.sh
+
       - name: Sync base config and patches to core-01
         uses: appleboy/ssh-action@v1
         with:

--- a/deploy/VERSIONS.md
+++ b/deploy/VERSIONS.md
@@ -44,7 +44,7 @@ Automated dependency updates are handled by Dependabot / Renovate. Upgrades foll
 |---|---|---|
 | `litellm` | `ghcr.io/berriai/litellm:v1.83.7-stable` | Pinned explicitly (moved from rolling `:main-stable` on 2026-04-19). v1.83.x fixes CVE-2026-35030 (OIDC userinfo cache key collision — auth bypass). Re-assess monthly; LiteLLM ships stable tags ~weekly. |
 | `ollama` | `ollama/ollama:0.21.0` | CPU fallback for LLM inference. |
-| `librechat-getklai` | `ghcr.io/danny-avila/librechat:v0.8.5-rc1` | Multi-tenant chat UI. **Currently on RC1** — rolled in from `:latest` during 2026-04-19 audit. 3 mounted CJS patches (`format.cjs`, `stream.cjs`, `search.cjs`) target internal paths in `@librechat/agents` — any LibreChat upgrade must re-verify those patches against the new bundle. Goal: move to stable v0.8.5 when released. |
+| `librechat-getklai` | `ghcr.io/danny-avila/librechat:v0.8.5-rc1` | Multi-tenant chat UI. **Currently on RC1** — rolled in from `:latest` during 2026-04-19 audit. 4 mounted patches (`format.cjs`, `share.js`, `stream.cjs`, `search.cjs`) target LibreChat internal files — any LibreChat upgrade must re-verify those patches against `deploy/librechat/patch-manifest.txt`. Goal: move to stable v0.8.5 when released. |
 
 ### Document + search
 

--- a/deploy/librechat/check-patch-drift.sh
+++ b/deploy/librechat/check-patch-drift.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+# Validate LibreChat patch assumptions before syncing patched files to prod.
+#
+# This fails when the pinned LibreChat image, docker-compose image, portal-api
+# provisioning default, or upstream files drift out of lockstep. That is
+# intentional: mounted route/bundle patches are acceptable only when upgrades
+# are explicit and reviewed.
+
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+MANIFEST="$ROOT_DIR/deploy/librechat/patch-manifest.txt"
+LIBRECHAT_IMAGE="${LIBRECHAT_IMAGE:-ghcr.io/danny-avila/librechat:v0.8.5-rc1}"
+FAIL=0
+
+COMPOSE_IMAGE=$(awk '
+  $1 == "librechat-getklai:" { in_service = 1; next }
+  in_service && $1 == "image:" { print $2; exit }
+  in_service && $1 ~ /^[a-zA-Z0-9_-]+:/ { exit }
+' "$ROOT_DIR/deploy/docker-compose.yml")
+
+if [ "$COMPOSE_IMAGE" != "$LIBRECHAT_IMAGE" ]; then
+  echo "ERROR: deploy/docker-compose.yml uses $COMPOSE_IMAGE but patch drift check expects $LIBRECHAT_IMAGE" >&2
+  FAIL=1
+fi
+
+if ! grep -q "librechat_image: str = \"$LIBRECHAT_IMAGE\"" \
+  "$ROOT_DIR/klai-portal/backend/app/core/config.py"; then
+  echo "ERROR: portal-api default librechat_image is not pinned to $LIBRECHAT_IMAGE" >&2
+  FAIL=1
+fi
+
+if printf '%s\n' "$LIBRECHAT_IMAGE" | grep -Eq ':(latest|dev|staging)$'; then
+  echo "ERROR: LibreChat image must be explicitly pinned, got $LIBRECHAT_IMAGE" >&2
+  FAIL=1
+fi
+
+while IFS='|' read -r local_patch upstream_path expected_sha _reason; do
+  case "$local_patch" in
+    ""|\#*) continue ;;
+  esac
+
+  if [ ! -f "$ROOT_DIR/deploy/librechat/$local_patch" ]; then
+    echo "ERROR: manifest references missing patch deploy/librechat/$local_patch" >&2
+    FAIL=1
+    continue
+  fi
+
+  case "$local_patch" in
+    *.js|*.cjs)
+      node --check "$ROOT_DIR/deploy/librechat/$local_patch" >/dev/null
+      ;;
+  esac
+
+  actual_sha=$(
+    docker run --rm --entrypoint sh "$LIBRECHAT_IMAGE" \
+      -c "sha256sum '$upstream_path'" 2>/dev/null | awk '{ print $1 }'
+  )
+  if [ -z "$actual_sha" ]; then
+    echo "ERROR: could not read $upstream_path from $LIBRECHAT_IMAGE" >&2
+    FAIL=1
+    continue
+  fi
+
+  if [ "$actual_sha" != "$expected_sha" ]; then
+    echo "ERROR: upstream drift for $local_patch" >&2
+    echo "       image:    $LIBRECHAT_IMAGE" >&2
+    echo "       upstream: $upstream_path" >&2
+    echo "       expected: $expected_sha" >&2
+    echo "       actual:   $actual_sha" >&2
+    FAIL=1
+  fi
+done < "$MANIFEST"
+
+if [ "$FAIL" -ne 0 ]; then
+  echo "" >&2
+  echo "Fix: review the LibreChat upgrade, update the mounted patch, then update deploy/librechat/patch-manifest.txt." >&2
+  exit 1
+fi
+
+echo "OK: LibreChat image pin and mounted patch upstream hashes match $LIBRECHAT_IMAGE."

--- a/deploy/librechat/patch-manifest.txt
+++ b/deploy/librechat/patch-manifest.txt
@@ -1,0 +1,12 @@
+# LibreChat patch manifest.
+#
+# Format:
+#   local_patch|upstream_path|expected_upstream_sha256|reason
+#
+# The drift check compares each patched upstream file in LIBRECHAT_IMAGE
+# against expected_upstream_sha256. If the upstream file changes, the patch
+# must be reviewed against the new LibreChat image before deployment.
+patches/format.cjs|/app/node_modules/@librechat/agents/dist/cjs/messages/format.cjs|cf56ae86938a1ffd2db8da5b8322a1536acfcb007ddecdc13059d200427ee590|Preserve Klai message formatting behavior in LibreChat agent output.
+patches/share.js|/app/api/server/routes/share.js|0efa16cc2b6812b1543c4875fb6db76d2f9fccd0e0049582b29989a71bc0b0a4|Allow public shares and sanitize placeholder links/images before serving shared messages.
+patches/stream.cjs|/app/node_modules/@librechat/agents/dist/cjs/stream.cjs|38baa938c9e97c71b7162cc7bf5c3757744802aac3b14d103e071dd8b5df8876|Preserve Klai streaming behavior in LibreChat agent responses.
+patches/search.cjs|/app/node_modules/@librechat/agents/dist/cjs/tools/search/search.cjs|bd29bafe754d714c4804bf5262d7b45c186dcb4ca2eebc7ee80c8de5c7d4cbae|Preserve Klai web-search behavior in LibreChat agent tooling.

--- a/deploy/librechat/patches/feedback.patch
+++ b/deploy/librechat/patches/feedback.patch
@@ -1,4 +1,4 @@
---- messages.js	(upstream LibreChat ghcr.io/danny-avila/librechat:latest)
+--- messages.js	(upstream LibreChat ghcr.io/danny-avila/librechat:v0.8.5-rc1)
 +++ messages.js	(SPEC-KB-015 patch)
 @@ -391,6 +391,37 @@
        { context: 'updateFeedback' },

--- a/deploy/librechat/tests/share_sanitizer.test.cjs
+++ b/deploy/librechat/tests/share_sanitizer.test.cjs
@@ -1,0 +1,58 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const repoRoot = path.resolve(__dirname, '../../..');
+const shareRoute = fs.readFileSync(
+  path.join(repoRoot, 'deploy/librechat/patches/share.js'),
+  'utf8',
+);
+const sanitizerStart = shareRoute.indexOf('const PLACEHOLDER_HOSTS');
+const sanitizerEnd = shareRoute.indexOf('/**\n * Shared messages');
+
+assert.notEqual(sanitizerStart, -1, 'share sanitizer block start not found');
+assert.notEqual(sanitizerEnd, -1, 'share sanitizer block end not found');
+
+const sandbox = {
+  URL,
+  process: {
+    env: {
+      DOMAIN_CLIENT: 'https://chat-voys.getklai.com',
+    },
+  },
+};
+
+vm.runInNewContext(
+  `${shareRoute.slice(sanitizerStart, sanitizerEnd)}\nthis.sanitizeMarkdown = sanitizeMarkdown;`,
+  sandbox,
+);
+
+const { sanitizeMarkdown } = sandbox;
+
+assert.equal(
+  sanitizeMarkdown('Bekijk [Rekenvoorbeeld2](https://example.com/rekenvoorbeeld2)'),
+  'Bekijk Rekenvoorbeeld2',
+);
+
+assert.equal(
+  sanitizeMarkdown('![image](https://example.com/molair-volume-gas.png)\n\n📎 Rekenvoorbeeld2'),
+  '\n\n📎 Rekenvoorbeeld2',
+);
+
+assert.equal(
+  sanitizeMarkdown('Bron https://example.com/fake en https://example.org/fake'),
+  'Bron  en ',
+);
+
+assert.equal(
+  sanitizeMarkdown('![diagram](https://chat-voys.getklai.com/kb-images/diagram.png)'),
+  '![diagram](https://chat-voys.getklai.com/kb-images/diagram.png)',
+);
+
+assert.equal(
+  sanitizeMarkdown('[Docs](https://getklai.com/docs)'),
+  '[Docs](https://getklai.com/docs)',
+);
+
+console.log('OK: LibreChat share sanitizer policy holds.');

--- a/klai-portal/backend/.env.example
+++ b/klai-portal/backend/.env.example
@@ -50,7 +50,7 @@ MEILI_MASTER_KEY=
 LITELLM_MASTER_KEY=
 
 # Docker infrastructure — paths and container names on the server
-# LIBRECHAT_IMAGE=ghcr.io/danny-avila/librechat:v0.8.3-rc2   # update when upgrading LibreChat
+# LIBRECHAT_IMAGE=ghcr.io/danny-avila/librechat:v0.8.5-rc1   # update with deploy/librechat/patch-manifest.txt when upgrading LibreChat
 # LIBRECHAT_HOST_DATA_PATH=/opt/klai/librechat                # host path for LibreChat volumes
 # LIBRECHAT_CONTAINER_DATA_PATH=/librechat                    # container-internal base path
 # CADDY_CONTAINER_NAME=klai-core-caddy-1                      # Docker container name for Caddy reload

--- a/klai-portal/backend/app/core/config.py
+++ b/klai-portal/backend/app/core/config.py
@@ -107,7 +107,7 @@ class Settings(BaseSettings):
     caddy_tenants_path: str = "/caddy/tenants"  # per-tenant .caddyfile dir (caddy-tenants volume)
     librechat_container_data_path: str = "/librechat"  # base dir for per-tenant librechat files
     librechat_host_data_path: str = "/opt/klai/librechat"  # HOST path for Docker volume mounts
-    librechat_image: str = "ghcr.io/danny-avila/librechat:latest"
+    librechat_image: str = "ghcr.io/danny-avila/librechat:v0.8.5-rc1"
     caddy_container_name: str = "klai-core-caddy-1"  # Docker container name for Caddy reload
     redis_container_name: str = "klai-core-redis-1"  # Docker container name; legacy operational reference
 

--- a/klai-portal/backend/tests/services/provisioning/test_infrastructure.py
+++ b/klai-portal/backend/tests/services/provisioning/test_infrastructure.py
@@ -29,7 +29,7 @@ def _mock_settings():
         mock.redis_host = "redis"
         mock.redis_port = 6379
         mock.redis_password = "test-redis-pw"
-        mock.librechat_image = "ghcr.io/danny-avila/librechat:latest"
+        mock.librechat_image = "ghcr.io/danny-avila/librechat:v0.8.5-rc1"
         mock.librechat_host_data_path = "/opt/klai/librechat-data"
         mock.librechat_container_data_path = "/tmp/test-librechat-data"  # noqa: S108
         mock.mongodb_container_name = "mongodb"
@@ -413,7 +413,7 @@ class TestCharacterizeStartLibrechatContainer:
         ):
             mock_settings.librechat_host_data_path = "/opt/klai/librechat-data"
             mock_settings.librechat_container_data_path = str(tmp_path)
-            mock_settings.librechat_image = "ghcr.io/danny-avila/librechat:latest"
+            mock_settings.librechat_image = "ghcr.io/danny-avila/librechat:v0.8.5-rc1"
             mock_docker.from_env.return_value = mock_client
             mock_docker.errors.NotFound = type("NotFound", (Exception,), {})
             mock_client.containers.get.side_effect = mock_docker.errors.NotFound("not found")
@@ -438,7 +438,7 @@ class TestCharacterizeStartLibrechatContainer:
         ):
             mock_settings.librechat_host_data_path = "/opt/klai/librechat-data"
             mock_settings.librechat_container_data_path = str(tmp_path)
-            mock_settings.librechat_image = "ghcr.io/danny-avila/librechat:latest"
+            mock_settings.librechat_image = "ghcr.io/danny-avila/librechat:v0.8.5-rc1"
             mock_docker.from_env.return_value = mock_client
             mock_docker.errors.NotFound = type("NotFound", (Exception,), {})
             mock_client.containers.get.side_effect = mock_docker.errors.NotFound("not found")
@@ -466,7 +466,7 @@ class TestCharacterizeStartLibrechatContainer:
         ):
             mock_settings.librechat_host_data_path = "/opt/klai/librechat-data"
             mock_settings.librechat_container_data_path = str(tmp_path)
-            mock_settings.librechat_image = "ghcr.io/danny-avila/librechat:latest"
+            mock_settings.librechat_image = "ghcr.io/danny-avila/librechat:v0.8.5-rc1"
             mock_docker.from_env.return_value = mock_client
             mock_docker.errors.NotFound = type("NotFound", (Exception,), {})
             mock_client.containers.get.side_effect = mock_docker.errors.NotFound("not found")
@@ -514,7 +514,7 @@ class TestCharacterizeStartLibrechatContainer:
         ):
             mock_settings.librechat_host_data_path = "/opt/klai/librechat-data"
             mock_settings.librechat_container_data_path = str(tmp_path)
-            mock_settings.librechat_image = "ghcr.io/danny-avila/librechat:latest"
+            mock_settings.librechat_image = "ghcr.io/danny-avila/librechat:v0.8.5-rc1"
             mock_docker.from_env.return_value = mock_client
             mock_docker.errors.NotFound = type("NotFound", (Exception,), {})
             mock_client.containers.get.side_effect = mock_docker.errors.NotFound("not found")
@@ -546,7 +546,7 @@ class TestCharacterizeStartLibrechatContainer:
         ):
             mock_settings.librechat_host_data_path = "/opt/klai/librechat-data"
             mock_settings.librechat_container_data_path = str(tmp_path)
-            mock_settings.librechat_image = "ghcr.io/danny-avila/librechat:latest"
+            mock_settings.librechat_image = "ghcr.io/danny-avila/librechat:v0.8.5-rc1"
             mock_docker.from_env.return_value = mock_client
             mock_docker.errors.NotFound = type("NotFound", (Exception,), {})
             mock_client.containers.get.side_effect = mock_docker.errors.NotFound("not found")


### PR DESCRIPTION
## Summary
- pin portal tenant LibreChat provisioning to the same v0.8.5-rc1 image as compose
- add a LibreChat patch manifest plus drift check for mounted upstream files
- run the drift check in compose and LibreChat config deploy workflows
- add share sanitizer policy tests

## Verification
- node --check deploy/librechat/patches/share.js
- node deploy/librechat/tests/share_sanitizer.test.cjs
- sh -n deploy/librechat/check-patch-drift.sh
- uv run pytest tests/services/provisioning/test_infrastructure.py -q
- uv run ruff check app/core/config.py tests/services/provisioning/test_infrastructure.py
- uv run ruff format --check app/core/config.py tests/services/provisioning/test_infrastructure.py
- uv run pyright app/core/config.py
- ran check-patch-drift.sh against Docker on core-01 with the changed files