### PR TITLE
spec: SPEC-PORTAL-PRICING-PER-USER-001 v0.3.0 — seat+role decoupled, ready-for-run

### DIFF
--- a/.moai/specs/SPEC-PORTAL-PRICING-PER-USER-001/spec.md
+++ b/.moai/specs/SPEC-PORTAL-PRICING-PER-USER-001/spec.md
@@ -1,283 +1,401 @@
 ---
 id: SPEC-PORTAL-PRICING-PER-USER-001
-version: "0.1.0"
+version: "0.2.0"
 status: draft-needs-sparring
 created: 2026-05-12
 updated: 2026-05-12
 author: Mark Vletter
 priority: high
 supersedes:
-  - SPEC-PORTAL-RBAC-001 (workspace-plan-as-feature-set assumption — see Section "What this SPEC reverses")
-  - SPEC-PORTAL-PLAN-RENAME-001 (org-wide plan slug rename — collapsed by this SPEC into per-user tier derivation)
+  - SPEC-PORTAL-RBAC-001 (workspace-plan-as-feature-set assumption — superseded by per-user seat model)
+  - SPEC-PORTAL-PLAN-RENAME-001 (org-wide plan slug rename — collapsed into per-user seat assignment)
 related:
-  - SPEC-PORTAL-PROFILES-001 (5-rung profile ladder + PROFILE_CAPABILITIES — KEPT, becomes the single source of truth)
-  - SPEC-BILLING-UPGRADE-001 (Moneybird subscription wiring — TOUCHED, line-items become per-tier)
+  - SPEC-PORTAL-PROFILES-001 (5-rung profile ladder + PROFILE_CAPABILITIES — KEPT, becomes the permission axis only)
+  - SPEC-BILLING-UPGRADE-001 (Moneybird subscription wiring — TOUCHED, line-items become per-seat-type)
 ---
 
-# SPEC-PORTAL-PRICING-PER-USER-001: Per-user pricing derived from profile
+# SPEC-PORTAL-PRICING-PER-USER-001: Per-user seats, decoupled from role
 
 ## HISTORY
 
 | Date | Version | Change |
 |------|---------|--------|
-| 2026-05-12 | 0.1.0 | Initial draft. Open sparring questions in Section "Sparring required". |
+| 2026-05-12 | 0.1.0 | Initial draft. Proposed `PROFILE_TIER` (profile derives tier). |
+| 2026-05-12 | 0.2.0 | **Architecture rewrite.** Profile-derives-tier was an anti-pattern (conflates billing with permissions — see "Why decoupled" below). Replaced with industry-standard seat+role decoupled model: each user has a `seat_type` (billing axis) AND a `role` (permission axis), assigned independently. Microsoft 365, HubSpot Seats, Salesforce, AWS Commerce/RBAC all separate these two domains. |
 
 ---
 
 ## Summary
 
-The Klai website ([getklai.com/pricing](https://getklai.com/pricing)) sells **per-user pricing**:
+Klai's website ([getklai.com/pricing](https://getklai.com/pricing)) sells per-user seat pricing:
 
-- "Klai Chat" — €28/user/month (€20 yearly)
-- "Klai Chat + Knowledge" — €68/user/month (€48 yearly)
+- **Klai Chat** — €28/user/month (€20 yearly)
+- **Klai Chat + Knowledge** — €68/user/month (€48 yearly)
 
-Each user is on their own pricing tier; an org bills the sum across users.
+Each user is on their own seat; an org bills the sum across seats.
 
-The codebase implements the **opposite**: one workspace-level plan in `portal_orgs.plan` with a profile-allowlist (`ALLOWED_PROFILES_PER_PLAN`) that restricts which profiles can be assigned on which plan. This was hardened by SPEC-PORTAL-RBAC-001 ("Per-user feature flags bestaan niet als pattern in B2B SaaS") and naming-aligned to the marketing slugs by SPEC-PORTAL-PLAN-RENAME-001 — but neither addressed the underlying mismatch.
+The current codebase implements the wrong shape: one workspace-level plan (`portal_orgs.plan`) with a profile-allowlist (`ALLOWED_PROFILES_PER_PLAN`), plus a hard `portal_orgs.seats` cap. This conflates two fundamentally different domains:
 
-Symptom that surfaced the gap (2026-05-12 incident): admin tried to invite a Knowledge Manager on a `professional`-plan tenant, got HTTP 403 `role_not_allowed_for_plan` because the plan's role-allowlist did not include `kb_manager`. The fix was to flip the org's plan to `knowledge`, but this is a hack — in the per-user model the act of assigning the kb_manager profile *is* the act of putting that user on the knowledge tier. There should be no separate "plan" gate.
+1. **Billing / commerce** — what does this user cost?
+2. **Permissions / RBAC** — what is this user allowed to do?
 
-This SPEC replaces the org-wide plan model with **profile-derived per-user tiers**:
+This SPEC introduces the industry-standard pattern: **two orthogonal per-user attributes**.
 
 ```
-user.tier = derive_tier(user.role)
-org.monthly_cost = Σ tier_price(user.tier) for user in org.active_users
+USER attributes:
+  - seat_type:  chat | knowledge | viewer   (billing + feature unlock)
+  - role:       personal | company | kb_manager | group_manager | admin   (permissions within unlocked features)
+
+These are assigned independently. The combination produces the user experience.
+
+effective_features      = SEAT_FEATURES[seat_type]                          # what this seat unlocks
+effective_capabilities  = PROFILE_CAPABILITIES[role] ∩ SEAT_FEATURES[seat]  # permissions within unlocked features
+monthly_bill            = Σ SEAT_PRICE[user.seat_type] for user in active   # cost rolls up from seats
 ```
 
-The website pricing becomes the literal billing model. The org-level `plan` field is deprecated to display-only metadata, then removed.
+---
+
+## Why decoupled (industry research, see Section "Sources")
+
+Three real-world patterns, all consistently decouple billing from RBAC:
+
+**Microsoft 365** ([docs](https://learn.microsoft.com/en-us/microsoft-365/admin/manage/assign-licenses-to-users)):
+> "Assigning a license determines what services a user can access, while assigning a role determines what administrative permissions a user has. The permissions to manage licenses are separate from the licenses themselves."
+>
+> A Global Admin can be on a Business Basic license. The admin role grants management powers; it does not grant Premium features.
+
+**HubSpot Seats Model** ([docs](https://knowledge.hubspot.com/account-management/manage-seats)):
+> Core Seat / Sales Seat / Service Seat / View-Only Seat. Seat type is determined by the hub access needed, NOT tied to the user's role.
+
+**AWS / Azure governance** ([Microsoft Tech Community on role anti-patterns](https://techcommunity.microsoft.com/blog/startupsatmicrosoftblog/role-structures-anti-patterns-and-the-10-governance-principles/4510070)):
+> "Identity, billing, and resource deployment are fundamentally different domains that must be operated and secured differently. Conflating billing tier with RBAC is an anti-pattern."
+
+The v0.1.0 of this SPEC violated this principle — `PROFILE_TIER` proposed deriving the billing tier from the role. v0.2.0 fixes that.
 
 ---
 
 ## Problem statement
 
-Four concrete pains caused by the current (org-wide-plan + fixed-seats) model:
+Four concrete pains caused by the current (org-wide-plan + fixed-seats + role-allowlist) model:
 
-1. **Invite-blocked at the wrong layer (plan).** Admin assigns a profile that the role *can technically perform* (the user has the capability code-side via `PROFILE_CAPABILITIES`), but the org plan's allowlist refuses the assignment. Admin's only recourse is to upgrade the entire org to a higher plan, paying for the highest tier on every existing seat — even though only one user needs the upgraded tier.
+1. **Invite-blocked at the wrong layer (plan).** Admin assigns a role that the user *can technically perform* (the role has the capability code-side via `PROFILE_CAPABILITIES`), but the org plan's allowlist refuses the assignment. Admin's only recourse is to upgrade the entire org, paying the highest tier on every seat — even though only one user needs the upgrade.
+   - **Live incident 2026-05-12**: Mark blocked from inviting Roman as Knowledge Manager on Voys (`professional` plan, `kb_manager` not in allowlist). Manual fix: `UPDATE portal_orgs SET plan = 'knowledge' WHERE slug = 'voys'`.
 
-2. **Invite-blocked at the wrong layer (seats).** Same shape as #1, different field. Admin tries to invite a 6th user on an org with `seats = 5`; gets `Seat limit reached` 4xx. Admin's only path forward is to manually bump the seat count via billing flow, which (a) blocks productivity until they do it, (b) auto-bills the new seat count for the *current plan* on every seat, even if the new user belongs on a different tier.
+2. **Invite-blocked at the wrong layer (seats).** Admin tries to invite a 6th user on an org with `seats = 5`; gets `Seat limit reached`. Admin must manually bump the seat count via billing flow, which auto-bills the new count at the *current plan tier* on every seat.
+   - **Live incident 2026-05-12**: Mark blocked from inviting Linda as Group Manager on Voys (5/5 seats). Manual fix: `UPDATE portal_orgs SET seats = 25 WHERE slug = 'voys'`.
 
-   Live incident 2026-05-12: admin tried to invite Linda as Group Manager on Voys; blocked by `seats = 5`, `active_users = 5`. Manual DB bump to 25 unblocked her, but the bill needs to be reconciled separately.
+3. **Billing does not match the website promise.** Customer reads "€28/user/mo for Klai Chat, €68/user/mo for + Knowledge" → expects to pay €28 × 4 + €68 × 1 for an org of 4 chat users + 1 KM. Today's billing has `org.plan` and `org.seats` only — they pay flat (5 × €28 OR 5 × €68), not the mixed bill.
 
-3. **Billing does not match the website promise.** Customer reads "€28/user/mo for Klai Chat, €68/user/mo for + Knowledge" → expects to pay €28 × 4 + €68 × 1 for an org of 4 chat users + 1 KM. Today's billing has a single `org.plan` and `org.seats` — they pay either 5 × €28 or 5 × €68 flat, not the mixed bill.
-
-4. **Cosmetic capability mismatch.** A `kb_manager` on a `chat` plan would have the role label but not the underlying capabilities (no `kb.create_org`, no `kb.members`). The capability intersection silently strips the profile's affordances. Either the role should not be assignable (today's behavior — bad UX, see #1) or it should imply the tier upgrade (this SPEC's behavior).
-
----
-
-## What this SPEC reverses
-
-| SPEC-PORTAL-RBAC-001 claim | Why it is reversed here |
-|---|---|
-| "Plan = workspace features. Per-user feature flags bestaan niet als pattern in B2B SaaS." | The website explicitly sells per-user pricing. The "pattern" Klai picked from Linear / Notion is the wrong industry — those are per-seat-flat-rate. Klai's promise is per-seat-per-tier (closer to Slack workspace + Slack Pro mixed-tier). |
-| `ALLOWED_PROFILES_PER_PLAN` (org-plan gates profile assignment) | Replaced by `PROFILE_TIER` (profile derives tier; tier never gates profile). |
-| `PLAN_LIMITS[plan].capabilities` (plan-level capability ceiling) | Replaced by `PROFILE_CAPABILITIES[role]` directly (tier never narrows profile capabilities — tier is a billing concept, not a feature concept). |
-| `derive_user_products(role, plan, enabled_addons)` | Becomes `derive_user_products(role, enabled_addons)` (no plan parameter). |
-
-What stays:
-- 5-rung profile ladder (`personal` < `company` < `kb_manager` < `group_manager` < `admin`)
-- `PROFILE_CAPABILITIES`
-- `enabled_addons` per org for scribe / docs (these remain workspace-level toggles)
-- `FEATURE_MIN_PROFILE` floor for add-ons (e.g. scribe gates at `company`)
-- Billing surface in `/admin/billing`, but with new content (tier breakdown)
+4. **Cosmetic capability mismatch.** A `kb_manager` role on a `chat` plan would have the role label but not the underlying features (no `kb.create_org`, no `kb.members`). Today the plan allowlist refuses the assignment (#1). In the seat+role model, the assignment is allowed, the seat constraint shows in the UI, and the admin can fix it cleanly: either upgrade Roman's seat to Knowledge, or accept that he has the title but limited features.
 
 ---
 
-## Solution architecture
+## Solution architecture (v0.2.0)
 
-### Profile → Tier mapping (proposed default — sparring required)
+### Two orthogonal user attributes
+
+**Attribute 1 — `seat_type`** (billing + feature unlock)
 
 ```python
-# klai-portal/backend/app/core/profile_tiers.py
+# klai-portal/backend/app/core/seats.py
 from enum import StrEnum
 
-class PricingTier(StrEnum):
-    FREE = "free"            # internal sentinel; trial / no billing
-    CHAT = "chat"            # €28/user/mo, €20/yr
-    KNOWLEDGE = "knowledge"  # €68/user/mo, €48/yr
+class SeatType(StrEnum):
+    VIEWER = "viewer"          # €0/mo. Read-only. For stakeholders / leads.
+    CHAT = "chat"              # €28/mo, €20/yr. Klai Chat tier.
+    KNOWLEDGE = "knowledge"    # €68/mo, €48/yr. Klai Chat + Knowledge tier.
 
-# Source of truth: profile derives tier.
-PROFILE_TIER: dict[str, PricingTier] = {
-    "personal":      PricingTier.CHAT,        # individual chat user
-    "company":       PricingTier.CHAT,        # org-wide chat user (no KB-management)
-    "kb_manager":    PricingTier.KNOWLEDGE,   # creates / curates org KBs
-    "group_manager": PricingTier.KNOWLEDGE,   # manages group memberships + group KBs
-    "admin":         PricingTier.KNOWLEDGE,   # admins need full features to manage tenants
+# What features each seat type unlocks (workspace-product surface).
+SEAT_FEATURES: dict[SeatType, frozenset[str]] = {
+    SeatType.VIEWER: frozenset({"chat_readonly", "knowledge_readonly"}),
+    SeatType.CHAT: frozenset({
+        "chat",
+        "knowledge.basic",         # personal KBs, 5/20 quota
+        "kb.connectors",
+    }),
+    SeatType.KNOWLEDGE: frozenset({
+        "chat",
+        "knowledge.basic",
+        "knowledge.full",          # unlimited KBs, org KBs
+        "kb.connectors",
+        "kb.connectors.external",  # GitHub, Notion, Google Drive, SharePoint
+        "kb.create_org",
+        "kb.members",
+        "kb.taxonomy",
+        "kb.gaps",
+    }),
 }
 
-TIER_PRICE_MONTHLY: dict[PricingTier, int] = {
-    PricingTier.FREE: 0,
-    PricingTier.CHAT: 28,
-    PricingTier.KNOWLEDGE: 68,
+SEAT_PRICE_MONTHLY: dict[SeatType, int] = {
+    SeatType.VIEWER: 0,
+    SeatType.CHAT: 28,
+    SeatType.KNOWLEDGE: 68,
 }
 
-TIER_PRICE_YEARLY: dict[PricingTier, int] = {  # monthly equivalent on yearly contract
-    PricingTier.FREE: 0,
-    PricingTier.CHAT: 20,
-    PricingTier.KNOWLEDGE: 48,
+SEAT_PRICE_YEARLY_MONTH_EQUIV: dict[SeatType, int] = {
+    SeatType.VIEWER: 0,
+    SeatType.CHAT: 20,
+    SeatType.KNOWLEDGE: 48,
+}
+```
+
+**Attribute 2 — `role`** (permissions, unchanged from SPEC-PORTAL-PROFILES-001)
+
+```python
+# 5-rung profile ladder STAYS as-is.
+PROFILE_LADDER = ["personal", "company", "kb_manager", "group_manager", "admin"]
+```
+
+### Effective access composition
+
+The user's effective access is the **intersection** of what their seat unlocks and what their role permits:
+
+```python
+def effective_features(seat_type: SeatType) -> frozenset[str]:
+    """What product surfaces does this user see? Determined by seat alone."""
+    return SEAT_FEATURES[seat_type]
+
+def effective_capabilities(role: str, seat_type: SeatType) -> frozenset[Capability]:
+    """What permissions does the user have within unlocked features?
+
+    Intersect role-granted capabilities with seat-unlocked features.
+    A kb_manager role on a chat seat gets KM permissions in code, but the
+    UI only surfaces them where the seat unlocks the underlying feature.
+    """
+    role_caps = PROFILE_CAPABILITIES[role]
+    seat_unlocked = SEAT_FEATURES[seat_type]
+    # Capability is granted iff (a) the role has it AND (b) the seat unlocks
+    # the product surface where the capability applies.
+    return frozenset(c for c in role_caps if _capability_unlocked_by_seat(c, seat_unlocked))
+
+def monthly_bill(org_id: int) -> int:
+    """Per-tier headcount × per-tier price, summed."""
+    return sum(SEAT_PRICE_MONTHLY[u.seat_type] for u in active_users(org_id))
+```
+
+### What changes vs. today
+
+| Concept | Today | After this SPEC |
+|---|---|---|
+| `portal_orgs.plan` | Workspace tier (`free`/`chat`/`knowledge`) | **Deprecated.** Becomes display-only, then dropped. |
+| `portal_orgs.seats` | Hard cap on user count | **Deprecated.** Headcount is derived from active users. |
+| `portal_users.seat_type` | Does not exist | **New column.** Per-user billing axis. |
+| `portal_users.role` | Per-user permissions | **Unchanged.** Per-user permission axis. |
+| `ALLOWED_PROFILES_PER_PLAN` | Gate on role assignment | **Removed.** Profile is always assignable. |
+| Capability resolution | `PROFILE_CAPABILITIES[role] ∩ PLAN_LIMITS[org.plan].capabilities` | `PROFILE_CAPABILITIES[role]` filtered through `SEAT_FEATURES[user.seat_type]` |
+| `enabled_addons` (scribe/docs) | Workspace toggle | **Unchanged.** Workspace toggle, with profile floor (FEATURE_MIN_PROFILE). |
+| Billing line-items | `plan × seats` flat | Per-seat-type line-items: `chat: N × €28 + knowledge: M × €68 + viewer: K × €0` |
+
+### Smart defaults in admin UI
+
+Admin still gets a one-click experience for the common case. When inviting / promoting a user, the UI **suggests** a seat type based on the chosen role, but the admin can override:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Invite user                                            │
+├─────────────────────────────────────────────────────────┤
+│  Email:      roman.kamin@voys.nl                        │
+│  Role:       [Knowledge Manager      ▼]                 │
+│  Seat:       (●) Knowledge   €68/mo  ← suggested        │
+│              ( ) Chat        €28/mo                     │
+│              ( ) Viewer      €0/mo                      │
+│                                                         │
+│  ⚠ Knowledge Manager + Chat seat: Roman would have      │
+│    KM permissions but the Chat seat doesn't unlock      │
+│    org KB management. He'd see a limited UI.            │
+│                                                         │
+│  Cost impact: +€68/mo (Knowledge tier)                  │
+│              [Cancel]  [Send invitation]                │
+└─────────────────────────────────────────────────────────┘
+```
+
+The ⚠ warning surfaces when the role has capabilities the seat doesn't unlock, but the invite is still allowed — admin choice.
+
+### Default seat suggestion rules
+
+```python
+DEFAULT_SEAT_FOR_ROLE: dict[str, SeatType] = {
+    "personal":      SeatType.CHAT,
+    "company":       SeatType.CHAT,
+    "kb_manager":    SeatType.KNOWLEDGE,
+    "group_manager": SeatType.KNOWLEDGE,
+    "admin":         SeatType.KNOWLEDGE,
 }
 
-def derive_user_tier(role: str) -> PricingTier:
-    """Pure function. Profile is the only input."""
-    return PROFILE_TIER.get(role, PricingTier.CHAT)
+def suggest_seat(role: str) -> SeatType:
+    return DEFAULT_SEAT_FOR_ROLE.get(role, SeatType.CHAT)
 ```
 
-### Capability resolution (simplified)
+This keeps the SMB single-click experience identical to v0.1.0's profile-derives-tier, while letting power-users decouple when needed (e.g. a `Viewer seat + admin role` for a board member who needs to see metrics but not be charged €68/mo).
 
-Before:
-```python
-effective_capabilities = PROFILE_CAPABILITIES[role] ∩ PLAN_LIMITS[org.plan].capabilities
-```
+### Add-ons (scribe, docs) stay workspace-level
 
-After:
-```python
-effective_capabilities = PROFILE_CAPABILITIES[role]
-```
-
-The plan ceiling is gone. A user's profile fully determines what they can do, and the bill follows.
-
-### Feature derivation (simplified)
-
-Before:
-```python
-derive_user_products(role, plan, enabled_addons) -> set[str]
-# user gets PLAN_FEATURES[plan] ∪ {addons gated by FEATURE_MIN_PROFILE}
-```
-
-After:
-```python
-derive_user_products(role, enabled_addons) -> set[str]
-# user gets {chat, knowledge} (the universal product set) ∪ {addons gated by FEATURE_MIN_PROFILE}
-# the per-feature *capability* still narrows what they can DO with knowledge
-```
-
-Note: every paying user gets the `chat` and `knowledge` *products* (= sidebar items / surfaces). What they can DO inside `knowledge` is controlled by `effective_capabilities` (= profile-derived). A `personal`-tier user sees the Knowledge sidebar, but cannot create org KBs (no `kb.create_org` capability). This preserves the discoverability "I can see Knowledge exists" while enforcing access via capability checks at the endpoint.
-
-### Billing surface
-
-`/admin/billing` becomes:
-
-```
-Klai Chat  (€28/user/mo)        4 users    €112/mo
-+ Knowledge (€68/user/mo)       2 users    €136/mo
-                                ─────────  ───────
-                                6 users    €248/mo
-```
-
-When admin invites or promotes a user, a confirm modal shows the cost delta:
-> Inviting Roman as Knowledge Manager will add €68/mo to your bill (Knowledge tier).
-> Continue?
-
-When admin demotes, a confirm modal shows the savings:
-> Demoting Roman from Knowledge Manager to Personal will remove €40/mo from your bill (€68 → €28).
-> Continue?
-
-### Moneybird wiring
-
-`MoneybirdService.update_subscription(org)` recomputes line-items as:
-- Line 1: "Klai Chat — N seats" — N × €28 (or €20 yearly)
-- Line 2: "+ Knowledge — M seats" — M × €68 (or €48 yearly)
-
-`N` and `M` are derived live from `portal_users` joined with `derive_user_tier`. No `org.plan` dependency.
+Per-add-on per-user pricing is out of scope. `enabled_addons` remains an org-wide toggle with a `FEATURE_MIN_PROFILE` floor, exactly as today. A future SPEC may revisit if needed.
 
 ---
 
 ## Migration plan
 
-Five phases. Each phase is independently shippable; a rollback at any phase leaves prod functional (degraded billing accuracy, never broken auth).
+Six phases. Each is independently shippable; rollback at any phase leaves prod functional.
 
-### Phase 1 — Add derivation, no behavior change (~½ day)
+### Phase 1 — Add seat_type column + read-only billing breakdown (~1 day)
 
-- Add `core/profile_tiers.py` with `PROFILE_TIER`, `derive_user_tier`, `TIER_PRICE_*`
-- Add helper `compute_org_billing_breakdown(org_id) -> dict[PricingTier, int]`
-- Add `/api/admin/billing/tier-breakdown` endpoint (read-only)
-- Add display-only "Per-user tier breakdown" panel on `/admin/billing`
-- No mutation of `portal_orgs.plan`, no removal of `ALLOWED_PROFILES_PER_PLAN`
-- Tests: `derive_user_tier` exhaustive over the 5 rungs
+- Add `seats.py` module with `SeatType`, `SEAT_FEATURES`, prices, helpers
+- Alembic migration: add `portal_users.seat_type` column with `NOT NULL DEFAULT` derived from current role:
+  ```sql
+  ALTER TABLE portal_users ADD COLUMN seat_type TEXT;
+  UPDATE portal_users SET seat_type = CASE
+      WHEN role IN ('personal', 'company') THEN 'chat'
+      WHEN role IN ('kb_manager', 'group_manager', 'admin') THEN 'knowledge'
+      ELSE 'chat'
+  END;
+  ALTER TABLE portal_users ALTER COLUMN seat_type SET NOT NULL;
+  ALTER TABLE portal_users ADD CONSTRAINT portal_users_seat_type_check
+      CHECK (seat_type IN ('viewer', 'chat', 'knowledge'));
+  ```
+  This default keeps every existing user with their current effective access — `kb_manager` users keep their KM features (Knowledge seat), `personal` users keep theirs (Chat seat). Zero behavior change at this phase.
+- Add `/api/admin/billing/breakdown` endpoint returning `{seat_type: count}`
+- Add display-only "Per-seat breakdown" panel on `/admin/billing`
+- Tests: seat_type defaults derived correctly, breakdown endpoint returns correct counts
 
-### Phase 2 — Remove the invite blocker (~½ day)
+### Phase 2 — Seat assignment as first-class admin UI element (~1 day)
+
+- Frontend: invite/edit user modal shows seat selector with smart-default + cost-delta + ⚠ mismatch warning
+- New endpoint `PATCH /api/admin/users/{user_id}/seat` to change seat without changing role
+- Backend audit-log emits `user.seat_changed` event with old/new seat and cost delta
+- Tests: admin can change seat independently of role; ⚠ warning surfaces when role+seat mismatch
+
+### Phase 3 — Remove the invite/role blockers (~½ day)
 
 - Remove `assert_role_allowed_for_plan` calls from `invite_user`, `update_user_role`, `promote_admin`
-- Keep the function (deprecated, raise DeprecationWarning) for one release cycle so external callers (tests, migrations) get a soft signal
-- Add a confirm-dialog hook on the frontend invite/promote pages: show the cost delta before the API call
-- Tests: invite kb_manager on every plan tier succeeds
+- Keep the function as deprecated no-op for one release cycle (DeprecationWarning)
+- Remove the `seats` hard-cap check from `invite_user`
+- Tests: invite kb_manager on any org succeeds; invite N+1th user on a `seats=N` org succeeds
 
-### Phase 3 — Decouple capabilities from plan (~½ day)
+### Phase 4 — Decouple capabilities from plan, intersect with seat (~1 day)
 
-- `_derive_effective_capabilities` and `get_effective_capabilities` stop intersecting with `PLAN_LIMITS[plan].capabilities`
-- `PROFILE_CAPABILITIES[role]` becomes the only input
-- `PLAN_LIMITS` becomes deprecated for capability lookup; quotas (`max_personal_kbs_per_user`, `max_items_per_kb`, `can_create_org_kbs`) move to `TIER_LIMITS` keyed on tier
-- Tests: `effective_capabilities("kb_manager")` returns full KB-management caps regardless of org
+- `_derive_effective_capabilities(role, seat_type)` replaces `_derive_effective_capabilities(role, plan)`
+- `effective_capabilities` = `PROFILE_CAPABILITIES[role] ∩ {capabilities unlocked by SEAT_FEATURES[seat_type]}`
+- `PLAN_LIMITS` deprecated for capability lookup; quotas (`max_personal_kbs_per_user`, `max_items_per_kb`, `can_create_org_kbs`) move into `SEAT_FEATURES` derivation
+- Tests: `kb_manager + chat seat` returns capabilities only for chat-seat-unlocked features; `kb_manager + knowledge seat` returns full KM cap-set
 
-### Phase 4 — Per-tier Moneybird billing (~1 day)
+### Phase 5 — Per-seat-type Moneybird billing (~1.5 days)
 
-- `MoneybirdService.update_subscription(org)` switches to per-tier line-items
-- Trigger: invite-user, update-user-role, promote-admin, demote events
-- One-time migration: recompute every active org's Moneybird subscription with current per-tier headcount
-- Notify admins via lifecycle email if their bill changed (cost delta shown)
+- `MoneybirdService.update_subscription(org)` switches to per-seat-type line-items
+- Live recompute from `portal_users` joined with `seat_type` (no `org.plan` dependency)
+- Trigger: invite-user, update-user-role (if seat changes via smart-default), patch-seat
+- One-time per-org migration: feature-flagged `BILLING_PER_SEAT_ENABLED` per `portal_orgs.id`. Phase 5 ships with the flag OFF for all existing tenants. Each tenant's admin sees a "switch to per-user billing" CTA on `/admin/billing` with before/after cost. Only after admin confirmation does the Moneybird subscription update.
+- Lifecycle email on bill change with cost delta breakdown
 
-### Phase 5 — Deprecate `portal_orgs.plan` (~½ day)
+### Phase 6 — Deprecate `portal_orgs.plan` and `portal_orgs.seats` (~½ day)
 
-- Mark `plan` column as `@deprecated` in `models/portal.py`
-- Remove from new-org default (set to `NULL` for new orgs; existing rows untouched)
-- Hide from `/admin/billing` and `/admin/settings` UI
-- Document in SPEC-PORTAL-PRICING-PER-USER-001 changelog: column will be dropped in N+2 release after this lands
-- Optionally: remove the `portal_orgs_plan_check` CHECK constraint (no longer enforces anything meaningful)
+- Mark both columns `@deprecated` in `models/portal.py`
+- Hide from admin UI (settings, billing)
+- Remove `portal_orgs_plan_check` constraint (no longer enforces anything meaningful)
+- Schedule column drop for N+2 release after Phase 5 completes
+- Document in changelog: "These columns are display-only; source of truth is per-user seat_type"
 
 ---
 
 ## Acceptance criteria (EARS)
 
-**AC-1**: WHEN admin invites a user with `role=kb_manager` on any org (any current `org.plan` value), the system SHALL create the invitation successfully (no `role_not_allowed_for_plan` error).
+**AC-1**: WHEN admin invites a user with `role=kb_manager` on any org, the system SHALL create the invitation successfully (no `role_not_allowed_for_plan` error). The system SHALL also assign a default seat (`knowledge` per `DEFAULT_SEAT_FOR_ROLE`) unless admin overrode it.
 
-**AC-2**: WHEN admin promotes a user from `personal` to `kb_manager`, the frontend SHALL show a confirm modal with the cost delta `+€40/mo (Knowledge tier)` before sending the API call.
+**AC-2**: WHEN admin invites the (N+1)th user on an org with `seats = N`, the system SHALL accept the invitation. The bill SHALL roll up from `COUNT(active users)` per seat type, not from `org.seats`.
 
-**AC-3**: WHEN admin views `/admin/billing`, the page SHALL display per-tier user counts and per-tier monthly cost in a breakdown table, plus the org's total monthly cost.
+**AC-3**: WHEN admin invites or promotes a user, the frontend SHALL show a confirm modal with the cost delta (`+€X/mo (seat tier)`) and the seat selection BEFORE sending the API call. NO billing change is silent.
 
-**AC-4**: WHEN an admin demotes a user from `kb_manager` to `personal`, the system SHALL emit a `billing.tier_downgraded` product event with `properties.cost_delta = -40`.
+**AC-4**: WHEN admin demotes a user OR changes their seat to a lower tier, the frontend SHALL show a confirm modal with the savings AND the consequence ("Roman will lose access to org KB management").
 
-**AC-5**: WHEN an admin promotes a user, the system SHALL emit a `billing.tier_upgraded` product event with the cost delta in cents.
+**AC-5**: WHEN admin assigns a `role=kb_manager` with `seat_type=chat`, the system SHALL accept the assignment AND surface a ⚠ warning in the admin UI: "Knowledge Manager role + Chat seat: this user has KM permissions but the Chat seat doesn't unlock org KB management."
 
-**AC-6**: WHEN any user's effective capabilities are computed, the result SHALL equal `PROFILE_CAPABILITIES[user.role]` exactly (no plan-based narrowing).
+**AC-6**: WHEN any user's effective capabilities are computed, the result SHALL equal `PROFILE_CAPABILITIES[role]` filtered through `SEAT_FEATURES[seat_type]`. NO plan-based intersection.
 
-**AC-7**: WHEN admin views `/admin/users`, each row SHALL display a "Tier" column showing the user's pricing tier (chat / knowledge), derived from their role.
+**AC-7**: WHEN admin views `/admin/billing`, the page SHALL display per-seat-type user counts AND per-seat-type monthly cost AND the org's total monthly cost.
 
-**AC-8**: WHEN `MoneybirdService.update_subscription(org)` runs, it SHALL produce one line-item per active tier with the correct seat count and per-tier price.
+**AC-8**: WHEN admin views `/admin/users`, each row SHALL display two columns: "Role" and "Seat" (each with the current value, both editable).
 
-**AC-9** (regression guard): WHEN `assert_role_allowed_for_plan` is called from any production code path after Phase 2, the system SHALL emit a `DeprecationWarning` AND return without raising — the function becomes a no-op for one release cycle, then is removed.
+**AC-9**: WHEN `MoneybirdService.update_subscription(org)` runs (Phase 5+), it SHALL produce one line-item per active seat type with the correct headcount and per-seat price.
 
-**AC-10**: WHEN any tenant on the legacy `portal_orgs.plan` field is migrated, the recomputed bill SHALL differ from the legacy bill by no more than the natural price-rebalance — the migration plan SHALL include an admin notification per affected tenant with the before/after cost.
+**AC-10**: WHEN a `viewer` seat is assigned, the user SHALL have read-only access to chat + knowledge surfaces AND incur €0 billing impact AND NOT count against any per-seat license cap (because there is none after Phase 3).
 
-**AC-11** (seat-cap removal): WHEN admin invites the (N+1)th user on an org currently at `seats = N`, the system SHALL accept the invitation, auto-record the new tier-headcount, and update the next billing-cycle invoice accordingly. NO `Seat limit reached` block. The seat count becomes a derived value (`seats = COUNT(active users)`) rather than a hard cap that must be pre-purchased.
+**AC-11**: WHEN `assert_role_allowed_for_plan` is called from any production code path after Phase 3, the system SHALL emit a `DeprecationWarning` AND return without raising — no-op for one release cycle, then removed.
 
-**AC-12** (no surprise bills): WHEN admin actions raise the bill (invite, promote), the frontend SHALL show the cost delta in a confirm-modal BEFORE sending the API call. WHEN admin actions lower the bill (demote, deactivate), the frontend SHALL show the savings in a confirm-modal. NO billing change is silent.
+**AC-12**: WHEN any tenant's billing is migrated to per-seat (Phase 5), the migration SHALL only happen after admin click on `/admin/billing` "switch to per-user billing" CTA. Until clicked, the tenant remains on legacy `plan × seats` billing. NO automatic per-tenant billing change.
+
+**AC-13** (regression guard): WHEN any future code path tries to derive the seat type from the role automatically (the v0.1.0 anti-pattern), CI SHALL fail. An ast-grep rule under `rules/no-profile-derives-seat.yml` SHALL detect direct `seat = SEAT_FOR_ROLE[role]` assignments outside the explicit `suggest_seat()` helper.
 
 ---
 
 ## Sparring required (Mark must answer before /run)
 
-These are open product decisions, not implementation details:
+**S-1: Seat types — confirm three or expand?**
 
-**S-1: Profile → Tier mapping confirmation**
+Default proposal: `viewer` (€0), `chat` (€28), `knowledge` (€68) — matches the website + adds a free read-only tier (a common ask in B2B for stakeholders/leads).
+
+Alternatives to consider:
+- (a) Skip `viewer` for now (only paid seats; revisit later) — simpler, fewer states to test
+- (b) Add a `power` seat above knowledge for future product expansion (not on website yet) — premature
+
+Recommend (a) if you want minimal scope, default proposal (with viewer) if you want the read-only-stakeholder pitch ready.
+
+**S-2: Default seat per role mapping**
 
 Default proposal:
-- `personal`, `company` → chat (€28)
-- `kb_manager`, `group_manager`, `admin` → knowledge (€68)
+- `personal`, `company` → chat
+- `kb_manager`, `group_manager`, `admin` → knowledge
 
-Alternative ideas:
-- (a) Should `admin` always be on knowledge regardless of usage? Probably yes — admins manage all features and need preview-access (current admin-bypass logic).
-- (b) Should `company` get a free upgrade to knowledge if they're billed for it? Probably no — company = chat-only by definition.
-- (c) Edge case: `personal` on `free` (trial) — ok, derived tier is `free` only when the org is in trial state? Or always `chat`?
+Confirm. The smart-default suggestion follows this; admin can always override.
 
-**S-2: How aggressive is the Phase 4 Moneybird migration?**
+**S-3: How aggressive is Phase 5 Moneybird migration?**
 
-- Option A (gentle): on next subscription renewal, switch to per-tier billing. Existing month-cycle continues at the legacy plan rate.
-- Option B (immediate): recompute every subscription on the day Phase 4 ships, prorate the difference.
-- Option C (admin-confirmed): show the new cost in the admin UI for 30 days, require admin to click "switch to per-user pricing" — only then is the Moneybird subscription updated.
+This SPEC proposes **Option C** (admin-confirmed per tenant). No tenant gets a different bill without an explicit admin click on `/admin/billing`. This is the safest default and aligns with `AC-12`.
 
-**S-3: Existing `chat`-tier orgs with `kb_manager` users today — possible?**
+Alternatives:
+- Option A (gentle): on next renewal, switch automatically — risk of surprise bill on renewal day
+- Option B (immediate): recompute everything Day 1 of Phase 5 — risk of mass billing-shock complaints
 
-After SPEC-PORTAL-PLAN-RENAME-001 deploy (today), allowlist enforcement means there should be ZERO `kb_manager` users on `chat` orgs. Verify with a one-off prod query before Phase 2 ships:
+Recommend Option C. Confirm.
 
+**S-4: ⚠ Warning vs hard block on role+seat mismatch**
+
+Default proposal: warning only (allow the mismatch, surface the consequence in the UI). Microsoft 365 / HubSpot pattern.
+
+Alternative: hard-block certain combos (e.g. `kb_manager` MUST have `knowledge` or `viewer` seat — not `chat`). Stricter, less flexible.
+
+Recommend warning-only. Confirm.
+
+**S-5: What about `enabled_addons` (scribe, docs)?**
+
+Workspace-level toggles stay as today, with `FEATURE_MIN_PROFILE` floor. Per-add-on per-user pricing deferred to a later SPEC.
+
+Confirm or push back if you want add-ons in this SPEC's scope.
+
+**S-6: Naming — seat type vs license vs subscription?**
+
+Industry uses all three. Microsoft: "license". HubSpot: "seat". Salesforce: "user license" + "permission set" (separate concepts).
+
+Default proposal: `seat_type` internally (in code/DB/API), "Klai Chat seat" / "Knowledge seat" / "Viewer seat" in UI strings.
+
+Confirm.
+
+**S-7: Phase ordering**
+
+The 6-phase ordering above:
+1. Add column + breakdown (read-only)
+2. Admin UI for seat assignment
+3. Remove blockers (allowlist + seat cap)
+4. Decouple capabilities
+5. Per-seat Moneybird billing (admin-confirmed)
+6. Deprecate `portal_orgs.plan` / `seats`
+
+Phases 1-4 ship without billing impact (legacy Moneybird billing continues unchanged through Phase 4). Phase 5 introduces real billing change behind a per-tenant flag. This means: the customer-facing pain (invite blocks, surprise upgrades) is resolved by Phase 3, while billing accuracy follows in Phase 5 on opt-in basis.
+
+Confirm or propose re-ordering.
+
+**S-8: Existing chat-tier orgs with kb_managers (data audit)**
+
+Pre-flight query before Phase 1:
 ```sql
 SELECT o.slug, COUNT(u.zitadel_user_id) AS km_count
 FROM portal_orgs o
@@ -285,34 +403,7 @@ JOIN portal_users u ON u.org_id = o.id
 WHERE o.plan = 'chat' AND u.role IN ('kb_manager', 'group_manager')
 GROUP BY o.slug;
 ```
-
-If the count is non-zero, Phase 2 has data-cleanup work in scope (decide per case: notify admin → ask if they want to upgrade the user, or keep the user but add the tier surcharge).
-
-**S-4: What happens to `enabled_addons` (scribe, docs)?**
-
-These remain workspace-toggles with `FEATURE_MIN_PROFILE` floors. But the billing for add-ons today is workspace-level (one toggle = scribe is on for the whole tenant). Should add-on billing also become per-user (scribe is on for these N users)? This SPEC defers that question — add-ons stay workspace-level for now.
-
-**S-5: Naming — keep `tier` or use `seat type`?**
-
-Industry uses both. Slack: "Pro seat", "Business+ seat". Notion: "Plus member", "Business member". Linear: "Standard seat".
-
-Proposed: `tier` internally (in code), `Klai Chat seat` / `+ Knowledge seat` in UI strings. Confirm.
-
-**S-6: Seat-cap behavior**
-
-Today: `portal_orgs.seats` is a hard cap; invite-user fails with `Seat limit reached` when `COUNT(active users) >= seats`. Two paths:
-
-- Option A (proposed in this SPEC): drop the hard cap. Seat count becomes derived (`seats = COUNT(active users)`); billing auto-rolls up. Admin sees "this invite adds €X/mo" before confirming. No invite is ever blocked by an arbitrary purchased-seats number.
-- Option B: keep the cap as a safety-rail (admin can set "do not exceed N seats" to prevent runaway billing on a compromised admin account). Confirm-dialog still shows cost delta before invite, but admin must raise the cap manually.
-- Option C: hybrid — soft cap with admin-configurable threshold. Below the threshold: silent auto-add. At/above: extra confirm "you're going from N to N+1, this exceeds your planned headcount of X — continue?".
-
-Default proposal: **Option A** (no hard cap, just transparent cost on every change). Mark to confirm.
-
-**S-7: Plan-vs-seats interaction during the transition**
-
-Today (post SPEC-PORTAL-PLAN-RENAME-001): admin can fix invite-blocked-by-plan via `/admin/billing` plan upgrade — but that auto-bills every existing seat at the new tier. Phase 4 (per-tier Moneybird billing) closes this loophole, but until Phase 4 ships there is a window where the SPEC's behavior (auto-derive bill from headcount) is partially implemented.
-
-Mitigation: Phases 1-3 ship the *capability + invite* changes (zero billing risk — admin can invite freely, but Moneybird still bills the legacy plan × seats). Phase 4 flips to per-tier billing per tenant on admin confirmation. No tenant is auto-migrated to a higher monthly bill without an explicit click.
+After SPEC-PORTAL-PLAN-RENAME-001 deploy (today), allowlist enforcement should mean ZERO rows. If non-zero: those users default to `knowledge` seat in Phase 1 migration (matches their role's expected access), but admin gets a one-time email noting the seat assignment and any billing impact.
 
 ---
 
@@ -320,34 +411,51 @@ Mitigation: Phases 1-3 ship the *capability + invite* changes (zero billing risk
 
 | Risk | Mitigation |
 |---|---|
-| Phase 4 Moneybird migration accidentally double-bills tenants | Phase 4 ships behind a feature flag `BILLING_PER_USER_ENABLED=false` per org; flip per tenant after admin confirmation |
-| Removing `ALLOWED_PROFILES_PER_PLAN` triggers test failures across 30+ test files | Phase 2 is a single-PR sweep with one bulk update commit; tests asserting `role_not_allowed_for_plan` are inverted to assert success |
-| `portal_orgs.plan` is referenced by external callers / SOPS env / dashboards | Phase 5 leaves the column NULL-able and untouched for one release; observability dashboards updated separately |
-| Mixed-tier billing line-items break Moneybird's existing template | Test against Moneybird sandbox in Phase 4; rollback plan is to revert to single-tier billing per org for the affected period |
-| Demoting a kb_manager → personal causes silent capability loss the user never agreed to | Phase 2 confirm-dialog includes the consequence: "Roman will lose access to org KBs and KB management features" |
+| Phase 5 Moneybird migration accidentally double-bills tenants | Per-tenant feature flag `BILLING_PER_SEAT_ENABLED`, OFF by default. Admin click required. |
+| Removing `ALLOWED_PROFILES_PER_PLAN` triggers test failures across 30+ test files | Phase 3 single-PR sweep with one bulk-update commit (mechanical, like SPEC-PORTAL-PLAN-RENAME-001). Tests asserting `role_not_allowed_for_plan` are inverted to assert success. |
+| `portal_orgs.plan` is referenced by external callers / SOPS env / dashboards | Phase 6 leaves the column NULL-able and untouched for one release. Observability dashboards updated separately. |
+| Mixed-seat billing line-items break Moneybird's existing template | Test against Moneybird sandbox in Phase 5 (rolls into S-3 confirm). Rollback plan: revert to legacy single-tier billing per affected tenant. |
+| Admin demotes user OR lowers seat → silent capability loss the user never agreed to | Phase 2 confirm-modal includes consequence ("Roman will lose access to org KBs and KB management features") and emits a `user.seat_changed` audit event. |
+| `viewer` seat triggers free-tier abuse (org creates 1000 viewer seats) | Defer abuse-rate-limiting to a later SPEC if observed in practice. v0.2.0 trusts admins. |
+| Profile-derives-seat anti-pattern creeps back via "convenient" code | AC-13 ast-grep CI rule blocks direct `SEAT_FOR_ROLE[role]` outside the explicit `suggest_seat()` helper. |
 
 ---
 
 ## Out of scope
 
-- Per-add-on per-user pricing (scribe-per-user, docs-per-user) — defer to a later SPEC if needed
+- Per-add-on per-user pricing (scribe-per-user, docs-per-user) — defer to a later SPEC if customer demand surfaces
 - Annual contract enforcement / pro-ration math beyond what Moneybird already does
-- Trial-tier UX (free remains an internal sentinel)
-- Tier downgrade with refund handling
+- Trial-tier UX (free remains an internal sentinel; viewer is not a trial)
+- Tier downgrade with refund handling — Moneybird's standard pro-ration applies
 - Multi-currency support — assumes EUR throughout
+- Per-user-per-seat granular feature toggles beyond what `SEAT_FEATURES` exposes (this SPEC keeps `SEAT_FEATURES` as a fixed table; if Klai needs per-tenant overrides, that's a follow-up SPEC)
 
 ---
 
 ## Definition of done
 
-- All 5 phases shipped, each as its own PR
-- AC-1 through AC-10 verified via tests + manual smoke on prod
-- `/admin/billing` shows the per-tier breakdown for at least one mixed-tier org (e.g. a fresh test tenant)
-- Moneybird invoice for the next billing cycle on the test tenant matches the per-tier breakdown
-- `portal_orgs.plan` column is `@deprecated` in the model with a SPEC reference comment
+- All 6 phases shipped, each as its own PR
+- AC-1 through AC-13 verified via tests + manual smoke on prod
+- `/admin/billing` shows the per-seat breakdown for at least one mixed-seat org (e.g. a fresh test tenant with a chat user + knowledge user + viewer user)
+- Moneybird invoice for the next billing cycle on the test tenant matches the per-seat breakdown
+- `portal_orgs.plan` and `portal_orgs.seats` columns are `@deprecated` in the model with a SPEC reference comment
 - Documentation updated: `docs/runbooks/billing.md`, `docs/architecture/permissions.md`, klai-portal CLAUDE.md
-- Lessons-archive: capture "spec-vs-marketing-mismatch" pitfall in `.claude/rules/klai/pitfalls/process-rules.md` so the next architectural drift is caught in design review, not on a customer-blocked invite-flow
+- New rule captured: `.claude/rules/klai/pitfalls/process-rules.md` adds `profile-derives-seat-anti-pattern` describing v0.1.0's wrong turn so the next time someone proposes "let me just derive the billing tier from the role", the answer cites Microsoft 365 / HubSpot / AWS pattern
 
 ---
 
-Status: **draft-needs-sparring** — Mark must answer S-1 through S-5 before `/moai run`.
+## Sources (industry research that drove v0.2.0)
+
+The decoupled seat+role architecture is consistent across major B2B SaaS platforms:
+
+- [Schematic — Seat-based Pricing 101: The classic SaaS model](https://schematichq.com/blog/seat-based-pricing-101-the-classic-saas-model-that-still-works-sometimes)
+- [Microsoft Learn — Assign or unassign licenses for users](https://learn.microsoft.com/en-us/microsoft-365/admin/manage/assign-licenses-to-users?view=o365-worldwide) — license vs role explicitly separate
+- [Microsoft Learn — About administrator roles in M365](https://learn.microsoft.com/en-us/microsoft-365/admin/add-users/about-admin-roles?view=o365-worldwide) — role grants permissions, not features
+- [HubSpot — Assign and manage seats](https://knowledge.hubspot.com/account-management/manage-seats) — Core / Sales / Service / View-Only seats, all role-independent
+- [Microsoft Tech Community — Role Structures, Anti-Patterns, 10 Governance Principles](https://techcommunity.microsoft.com/blog/startupsatmicrosoftblog/role-structures-anti-patterns-and-the-10-governance-principles/4510070) — explicit Identity/RBAC/Commerce three-plane model
+- [AWS — SaaS Lens: General design principles](https://docs.aws.amazon.com/wellarchitected/latest/saas-lens/general-design-principles.html) — separation of concerns across billing/identity/resources
+- [Orb — Billing system architecture for SaaS 101](https://www.withorb.com/blog/billing-architecture)
+
+---
+
+Status: **draft-needs-sparring** — Mark must answer S-1 through S-8 before `/moai run`.

--- a/.moai/specs/SPEC-PORTAL-PRICING-PER-USER-001/spec.md
+++ b/.moai/specs/SPEC-PORTAL-PRICING-PER-USER-001/spec.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-PORTAL-PRICING-PER-USER-001
-version: "0.2.0"
-status: draft-needs-sparring
+version: "0.3.0"
+status: ready-for-run
 created: 2026-05-12
 updated: 2026-05-12
 author: Mark Vletter
@@ -21,7 +21,21 @@ related:
 | Date | Version | Change |
 |------|---------|--------|
 | 2026-05-12 | 0.1.0 | Initial draft. Proposed `PROFILE_TIER` (profile derives tier). |
-| 2026-05-12 | 0.2.0 | **Architecture rewrite.** Profile-derives-tier was an anti-pattern (conflates billing with permissions — see "Why decoupled" below). Replaced with industry-standard seat+role decoupled model: each user has a `seat_type` (billing axis) AND a `role` (permission axis), assigned independently. Microsoft 365, HubSpot Seats, Salesforce, AWS Commerce/RBAC all separate these two domains. |
+| 2026-05-12 | 0.2.0 | **Architecture rewrite.** Profile-derives-tier was an anti-pattern (conflates billing with permissions). Replaced with industry-standard seat+role decoupled model. |
+| 2026-05-12 | 0.3.0 | **Sparring resolved + gap-fixes.** S-1 through S-8 answered (see decisions below). Add explicit `CAPABILITY_TO_SEAT_FEATURE` mapping table. Replace workspace-`enabled_addons` model with seat-included scribe/docs (gated by `FEATURE_MIN_PROFILE` company-floor). Add `portal_user_seat_history` for prorated billing audit. Write actual ast-grep rule body for AC-13. Reframed "industry-standard" claim (decoupled is right *for Klai* because the website promises per-user pricing — Linear/Notion's workspace-uniform is also valid for that audience). Status flipped to `ready-for-run`. |
+
+### Sparring resolved (v0.3.0)
+
+| # | Question | Decision |
+|---|---|---|
+| 1 | Three seat types or skip viewer | Three (viewer/chat/knowledge). Mark: "doe nou normaal — als ze toch betalen, maakt gratis viewer niet uit." |
+| 2 | Default seat per role | personal/company → chat; kb_manager/group_manager/admin → knowledge. |
+| 3 | Phase 5 Moneybird migration | Admin-confirmed per tenant. No surprise bills. |
+| 4 | Role+seat mismatch | Warning only, allow combo (Microsoft 365 / HubSpot pattern). |
+| 5 | Add-ons (scribe/docs) workspace-level? | NO — replace workspace `enabled_addons` toggle with seat-included scribe/docs. Both seats (chat + knowledge) include scribe + docs. The `company` role-floor in `FEATURE_MIN_PROFILE` keeps personal-role users out (Mark: "vanaf bedrijfschat"). |
+| 6 | Naming | `seat_type` internal, "Klai Chat seat" / "Knowledge seat" / "Viewer seat" in UI. |
+| 7 | Phase ordering | Confirmed. Customer pain resolved at Phase 3, billing accuracy at Phase 5 opt-in. |
+| 8 | User-history tracking | Today: `created_at` + current `status` only — no from-to dates per seat assignment. Add `portal_user_seat_history` table in Phase 1 so Phase 5 can prorate accurately. |
 
 ---
 
@@ -55,22 +69,30 @@ monthly_bill            = Σ SEAT_PRICE[user.seat_type] for user in active   # c
 
 ---
 
-## Why decoupled (industry research, see Section "Sources")
+## Why decoupled — for Klai (industry research, see Section "Sources")
 
-Three real-world patterns, all consistently decouple billing from RBAC:
+Two SaaS pricing patterns are valid and battle-tested:
+
+**Pattern A — workspace-uniform tier**: every member of an org pays the same per-seat rate. Used by Linear, Notion, Slack (within a workspace). Simpler architecture, single billing axis, one plan per org. SPEC-PORTAL-RBAC-001 chose this and is internally consistent.
+
+**Pattern B — decoupled seat + role**: each user has an individually-assigned seat (billing axis) AND a role (permission axis). Used by Microsoft 365, HubSpot, Salesforce, Google Workspace. More flexible, two axes, mixed-tier orgs.
+
+**Why this SPEC picks Pattern B for Klai specifically**: the website ([getklai.com/pricing](https://getklai.com/pricing)) sells per-user pricing — €28/user, €68/user. That language commits Klai to mixed-tier orgs. Pattern A's flat-tier billing would either over-charge (everyone at the highest tier) or under-charge (everyone at the lowest tier). Neither matches what a customer reads on the marketing page.
+
+This is a reading of *Klai's pricing promise*, not an architectural absolute. If Klai ever drops per-user pricing in favor of flat workspace pricing, Pattern A becomes correct again.
+
+Pattern B's industry references confirm the *shape* of the decoupling once you commit to per-user pricing:
 
 **Microsoft 365** ([docs](https://learn.microsoft.com/en-us/microsoft-365/admin/manage/assign-licenses-to-users)):
 > "Assigning a license determines what services a user can access, while assigning a role determines what administrative permissions a user has. The permissions to manage licenses are separate from the licenses themselves."
->
-> A Global Admin can be on a Business Basic license. The admin role grants management powers; it does not grant Premium features.
 
 **HubSpot Seats Model** ([docs](https://knowledge.hubspot.com/account-management/manage-seats)):
-> Core Seat / Sales Seat / Service Seat / View-Only Seat. Seat type is determined by the hub access needed, NOT tied to the user's role.
+> Core Seat / Sales Seat / Service Seat / View-Only Seat. Seat type is determined by hub access needed, NOT tied to role.
 
-**AWS / Azure governance** ([Microsoft Tech Community on role anti-patterns](https://techcommunity.microsoft.com/blog/startupsatmicrosoftblog/role-structures-anti-patterns-and-the-10-governance-principles/4510070)):
-> "Identity, billing, and resource deployment are fundamentally different domains that must be operated and secured differently. Conflating billing tier with RBAC is an anti-pattern."
+**Microsoft governance anti-patterns** ([techcommunity](https://techcommunity.microsoft.com/blog/startupsatmicrosoftblog/role-structures-anti-patterns-and-the-10-governance-principles/4510070)):
+> "Identity, billing, and resource deployment are fundamentally different domains. Conflating billing tier with RBAC is an anti-pattern."
 
-The v0.1.0 of this SPEC violated this principle — `PROFILE_TIER` proposed deriving the billing tier from the role. v0.2.0 fixes that.
+The v0.1.0 of this SPEC chose Pattern B but implemented it as `PROFILE_TIER` (profile derives tier) — collapsing the two axes back into one. v0.2.0+ keeps them properly orthogonal.
 
 ---
 
@@ -79,10 +101,10 @@ The v0.1.0 of this SPEC violated this principle — `PROFILE_TIER` proposed deri
 Four concrete pains caused by the current (org-wide-plan + fixed-seats + role-allowlist) model:
 
 1. **Invite-blocked at the wrong layer (plan).** Admin assigns a role that the user *can technically perform* (the role has the capability code-side via `PROFILE_CAPABILITIES`), but the org plan's allowlist refuses the assignment. Admin's only recourse is to upgrade the entire org, paying the highest tier on every seat — even though only one user needs the upgrade.
-   - **Live incident 2026-05-12**: Mark blocked from inviting Roman as Knowledge Manager on Voys (`professional` plan, `kb_manager` not in allowlist). Manual fix: `UPDATE portal_orgs SET plan = 'knowledge' WHERE slug = 'voys'`.
+   - **Surfaced 2026-05-12**: customer admin attempted to invite a Knowledge Manager on a `professional`-plan tenant; HTTP 403 `role_not_allowed_for_plan`. Resolved with a one-row DB update that flipped the org plan to `knowledge` — a workaround, not a fix.
 
 2. **Invite-blocked at the wrong layer (seats).** Admin tries to invite a 6th user on an org with `seats = 5`; gets `Seat limit reached`. Admin must manually bump the seat count via billing flow, which auto-bills the new count at the *current plan tier* on every seat.
-   - **Live incident 2026-05-12**: Mark blocked from inviting Linda as Group Manager on Voys (5/5 seats). Manual fix: `UPDATE portal_orgs SET seats = 25 WHERE slug = 'voys'`.
+   - **Surfaced 2026-05-12**: same tenant, second invite attempt for a Group Manager; blocked at the seat cap (5/5). Resolved with another one-row DB update bumping seats to 25 — same workaround pattern, different field.
 
 3. **Billing does not match the website promise.** Customer reads "€28/user/mo for Klai Chat, €68/user/mo for + Knowledge" → expects to pay €28 × 4 + €68 × 1 for an org of 4 chat users + 1 KM. Today's billing has `org.plan` and `org.seats` only — they pay flat (5 × €28 OR 5 × €68), not the mixed bill.
 
@@ -106,12 +128,18 @@ class SeatType(StrEnum):
     KNOWLEDGE = "knowledge"    # €68/mo, €48/yr. Klai Chat + Knowledge tier.
 
 # What features each seat type unlocks (workspace-product surface).
+# scribe + docs are INCLUDED in chat and knowledge seats (no add-on toggle).
+# Role-floor (FEATURE_MIN_PROFILE) keeps personal-role users out: scribe/docs
+# require role >= company. Mark v0.3.0: "scribe is voor iedereen vanaf
+# Bedrijfschat, net als docs."
 SEAT_FEATURES: dict[SeatType, frozenset[str]] = {
     SeatType.VIEWER: frozenset({"chat_readonly", "knowledge_readonly"}),
     SeatType.CHAT: frozenset({
         "chat",
         "knowledge.basic",         # personal KBs, 5/20 quota
         "kb.connectors",
+        "scribe",                  # available; gated by role >= company
+        "docs",                    # available; gated by role >= company
     }),
     SeatType.KNOWLEDGE: frozenset({
         "chat",
@@ -123,7 +151,26 @@ SEAT_FEATURES: dict[SeatType, frozenset[str]] = {
         "kb.members",
         "kb.taxonomy",
         "kb.gaps",
+        "scribe",                  # available; gated by role >= company
+        "docs",                    # available; gated by role >= company
     }),
+}
+
+# Maps each capability string back to the seat-feature it requires.
+# Used by `effective_capabilities()` to filter role-granted capabilities
+# through what the seat actually unlocks. EXPLICIT mapping — no implicit
+# string-prefix-matching, no convention. If a new capability lands without
+# an entry here, the AC-13 lint catches it (every Capability member must
+# appear as a key).
+CAPABILITY_TO_SEAT_FEATURE: dict[str, str] = {
+    # Connector capabilities
+    "kb.connectors":           "kb.connectors",
+    "kb.connectors.external":  "kb.connectors.external",
+    # KB management capabilities — all unlocked by knowledge.full
+    "kb.create_org":           "knowledge.full",
+    "kb.members":              "knowledge.full",
+    "kb.taxonomy":             "knowledge.full",
+    "kb.gaps":                 "knowledge.full",
 }
 
 SEAT_PRICE_MONTHLY: dict[SeatType, int] = {
@@ -151,25 +198,56 @@ PROFILE_LADDER = ["personal", "company", "kb_manager", "group_manager", "admin"]
 The user's effective access is the **intersection** of what their seat unlocks and what their role permits:
 
 ```python
-def effective_features(seat_type: SeatType) -> frozenset[str]:
-    """What product surfaces does this user see? Determined by seat alone."""
-    return SEAT_FEATURES[seat_type]
+def effective_features(seat_type: SeatType, role: str) -> frozenset[str]:
+    """What product surfaces does this user see?
+
+    Seat unlocks the surface (chat / knowledge / scribe / docs).
+    Role gates whether the user can actually open it. Personal-role
+    users on a chat seat have scribe in SEAT_FEATURES but FEATURE_MIN_PROFILE
+    keeps them out — they don't see scribe in the sidebar.
+    """
+    seat_unlocked = SEAT_FEATURES[seat_type]
+    caller_rank = PROFILE_RANK[role]
+    return frozenset(
+        f for f in seat_unlocked
+        if caller_rank >= PROFILE_RANK.get(FEATURE_MIN_PROFILE.get(f, "personal"), -1)
+    )
 
 def effective_capabilities(role: str, seat_type: SeatType) -> frozenset[Capability]:
     """What permissions does the user have within unlocked features?
 
-    Intersect role-granted capabilities with seat-unlocked features.
-    A kb_manager role on a chat seat gets KM permissions in code, but the
-    UI only surfaces them where the seat unlocks the underlying feature.
+    Concrete algorithm (no hand-wave):
+      1. Start with role-granted capabilities (PROFILE_CAPABILITIES[role]).
+      2. For each capability, look up its required seat-feature in
+         CAPABILITY_TO_SEAT_FEATURE (explicit mapping table above).
+      3. Drop the capability if the seat does not unlock that feature.
+
+    Examples:
+      - kb_manager + knowledge seat
+          role_caps = {kb.connectors, kb.connectors.external, kb.create_org,
+                       kb.members, kb.taxonomy, kb.gaps}
+          all required features unlocked by knowledge seat → all kept.
+      - kb_manager + chat seat
+          role_caps = same as above
+          knowledge.full NOT in chat-seat features → drop kb.create_org,
+          kb.members, kb.taxonomy, kb.gaps. Keep kb.connectors only.
+          (kb.connectors.external dropped: chat seat lacks that feature.)
+      - admin + viewer seat
+          role_caps = full set
+          viewer seat unlocks only chat_readonly + knowledge_readonly.
+          NO mapped capability is satisfied → return frozenset().
+          Admin still has admin powers via the role check (`require_at_least`),
+          which is independent of capability gating.
     """
-    role_caps = PROFILE_CAPABILITIES[role]
+    role_caps = PROFILE_CAPABILITIES.get(role, frozenset())
     seat_unlocked = SEAT_FEATURES[seat_type]
-    # Capability is granted iff (a) the role has it AND (b) the seat unlocks
-    # the product surface where the capability applies.
-    return frozenset(c for c in role_caps if _capability_unlocked_by_seat(c, seat_unlocked))
+    return frozenset(
+        c for c in role_caps
+        if CAPABILITY_TO_SEAT_FEATURE.get(c) in seat_unlocked
+    )
 
 def monthly_bill(org_id: int) -> int:
-    """Per-tier headcount × per-tier price, summed."""
+    """Per-seat-type headcount × per-seat price, summed across active users."""
     return sum(SEAT_PRICE_MONTHLY[u.seat_type] for u in active_users(org_id))
 ```
 
@@ -182,8 +260,10 @@ def monthly_bill(org_id: int) -> int:
 | `portal_users.seat_type` | Does not exist | **New column.** Per-user billing axis. |
 | `portal_users.role` | Per-user permissions | **Unchanged.** Per-user permission axis. |
 | `ALLOWED_PROFILES_PER_PLAN` | Gate on role assignment | **Removed.** Profile is always assignable. |
-| Capability resolution | `PROFILE_CAPABILITIES[role] ∩ PLAN_LIMITS[org.plan].capabilities` | `PROFILE_CAPABILITIES[role]` filtered through `SEAT_FEATURES[user.seat_type]` |
-| `enabled_addons` (scribe/docs) | Workspace toggle | **Unchanged.** Workspace toggle, with profile floor (FEATURE_MIN_PROFILE). |
+| Capability resolution | `PROFILE_CAPABILITIES[role] ∩ PLAN_LIMITS[org.plan].capabilities` | `PROFILE_CAPABILITIES[role]` filtered through `CAPABILITY_TO_SEAT_FEATURE` against `SEAT_FEATURES[user.seat_type]` |
+| `enabled_addons` (scribe/docs) | Workspace toggle, separately billed | **Removed.** Both seats include scribe + docs. `FEATURE_MIN_PROFILE` keeps personal-role users out. |
+| `portal_users.seat_type` | Does not exist | **New column.** Per-user billing axis. |
+| `portal_user_seat_history` | Does not exist | **New table.** Append-only audit of seat changes (`user_id, seat_type, role, valid_from, valid_to`). Required for prorated Phase 5 billing. |
 | Billing line-items | `plan × seats` flat | Per-seat-type line-items: `chat: N × €28 + knowledge: M × €68 + viewer: K × €0` |
 
 ### Smart defaults in admin UI
@@ -228,9 +308,61 @@ def suggest_seat(role: str) -> SeatType:
 
 This keeps the SMB single-click experience identical to v0.1.0's profile-derives-tier, while letting power-users decouple when needed (e.g. a `Viewer seat + admin role` for a board member who needs to see metrics but not be charged €68/mo).
 
-### Add-ons (scribe, docs) stay workspace-level
+### Scribe + docs are seat-included (no workspace toggle)
 
-Per-add-on per-user pricing is out of scope. `enabled_addons` remains an org-wide toggle with a `FEATURE_MIN_PROFILE` floor, exactly as today. A future SPEC may revisit if needed.
+Mark v0.3.0 decision: scribe and docs are bundled into both paid seats (chat + knowledge). The `FEATURE_MIN_PROFILE` floor (`scribe → company`, `docs → company`) keeps personal-role users out. So the effective access matrix becomes:
+
+| Seat × Role | Sees scribe + docs? |
+|---|---|
+| Chat seat + personal | NO (role floor) |
+| Chat seat + company / kb_manager / group_manager / admin | YES |
+| Knowledge seat + personal | NO (role floor) |
+| Knowledge seat + company+ | YES |
+| Viewer seat + any | NO (seat doesn't unlock) |
+
+The `portal_orgs.enabled_addons` column is dropped in Phase 1 migration. No org-wide toggle anymore — if a tenant doesn't want scribe for *anyone*, they assign personal-role to all users (which already keeps them out today). Per-user opt-out of scribe specifically is out of scope; defer to a later SPEC if a customer asks.
+
+### Seat-history table (portal_user_seat_history)
+
+Today `portal_users` only knows current `status` and `created_at`. For Phase 5 prorated billing — "Roman was on knowledge seat for 12 days, then chat seat for 18 days, this month" — we need an append-only history.
+
+```sql
+CREATE TABLE portal_user_seat_history (
+    id              BIGSERIAL PRIMARY KEY,
+    user_id         BIGINT NOT NULL REFERENCES portal_users(id) ON DELETE CASCADE,
+    org_id          INT NOT NULL REFERENCES portal_orgs(id),
+    seat_type       TEXT NOT NULL CHECK (seat_type IN ('viewer', 'chat', 'knowledge')),
+    role            TEXT NOT NULL,        -- snapshot of role at the time
+    valid_from      TIMESTAMPTZ NOT NULL,
+    valid_to        TIMESTAMPTZ,          -- NULL = current row, set on next change
+    changed_by      VARCHAR(64),          -- zitadel_user_id of admin who made the change
+    change_reason   TEXT,                 -- 'invite', 'role_change', 'seat_change', 'deactivate'
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_pu_seat_hist_user_validto ON portal_user_seat_history(user_id, valid_to);
+CREATE INDEX idx_pu_seat_hist_org_validfrom ON portal_user_seat_history(org_id, valid_from);
+```
+
+Phase 1 migration:
+- Create the table
+- Backfill: for each existing `portal_users` row, INSERT one history row with `valid_from = portal_users.created_at`, `valid_to = NULL`, `change_reason = 'backfill'`
+- Wire SQLAlchemy event listener: every UPDATE to `portal_users.seat_type` or `portal_users.role` or `portal_users.status` writes a new row + sets the previous row's `valid_to`
+
+Phase 5 prorate query (illustrative):
+```sql
+SELECT
+  user_id,
+  seat_type,
+  EXTRACT(EPOCH FROM (LEAST(valid_to, $period_end) - GREATEST(valid_from, $period_start))) / 86400 AS days_active
+FROM portal_user_seat_history
+WHERE org_id = $org_id
+  AND valid_from < $period_end
+  AND (valid_to IS NULL OR valid_to > $period_start)
+;
+```
+
+Sum `days_active × (SEAT_PRICE / days_in_period)` per seat_type for the bill.
 
 ---
 
@@ -238,11 +370,12 @@ Per-add-on per-user pricing is out of scope. `enabled_addons` remains an org-wid
 
 Six phases. Each is independently shippable; rollback at any phase leaves prod functional.
 
-### Phase 1 — Add seat_type column + read-only billing breakdown (~1 day)
+### Phase 1 — Add seat_type + seat_history + read-only billing breakdown (~1.5 days)
 
-- Add `seats.py` module with `SeatType`, `SEAT_FEATURES`, prices, helpers
-- Alembic migration: add `portal_users.seat_type` column with `NOT NULL DEFAULT` derived from current role:
+- Add `seats.py` module with `SeatType`, `SEAT_FEATURES`, `CAPABILITY_TO_SEAT_FEATURE`, prices, helpers
+- Alembic migration (single transaction — clean container build, no rolling-deploy split needed per Mark v0.3.0):
   ```sql
+  -- 1. Add seat_type column + backfill from current role
   ALTER TABLE portal_users ADD COLUMN seat_type TEXT;
   UPDATE portal_users SET seat_type = CASE
       WHEN role IN ('personal', 'company') THEN 'chat'
@@ -252,11 +385,36 @@ Six phases. Each is independently shippable; rollback at any phase leaves prod f
   ALTER TABLE portal_users ALTER COLUMN seat_type SET NOT NULL;
   ALTER TABLE portal_users ADD CONSTRAINT portal_users_seat_type_check
       CHECK (seat_type IN ('viewer', 'chat', 'knowledge'));
+
+  -- 2. Drop the workspace addon-toggle (scribe + docs are seat-included now)
+  ALTER TABLE portal_orgs DROP COLUMN enabled_addons;
+
+  -- 3. Create seat-history table (Phase 5 dependency, but row is cheap; create early)
+  CREATE TABLE portal_user_seat_history (
+      id              BIGSERIAL PRIMARY KEY,
+      user_id         BIGINT NOT NULL REFERENCES portal_users(id) ON DELETE CASCADE,
+      org_id          INT NOT NULL REFERENCES portal_orgs(id),
+      seat_type       TEXT NOT NULL CHECK (seat_type IN ('viewer', 'chat', 'knowledge')),
+      role            TEXT NOT NULL,
+      valid_from      TIMESTAMPTZ NOT NULL,
+      valid_to        TIMESTAMPTZ,
+      changed_by      VARCHAR(64),
+      change_reason   TEXT,
+      created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  );
+  CREATE INDEX idx_pu_seat_hist_user_validto ON portal_user_seat_history(user_id, valid_to);
+  CREATE INDEX idx_pu_seat_hist_org_validfrom ON portal_user_seat_history(org_id, valid_from);
+
+  -- 4. Backfill history: one row per existing user
+  INSERT INTO portal_user_seat_history (user_id, org_id, seat_type, role, valid_from, change_reason)
+  SELECT id, org_id, seat_type, role::text, created_at, 'backfill' FROM portal_users;
   ```
-  This default keeps every existing user with their current effective access — `kb_manager` users keep their KM features (Knowledge seat), `personal` users keep theirs (Chat seat). Zero behavior change at this phase.
+  Existing `kb_manager` users keep their KM features (Knowledge seat), `personal` users keep theirs (Chat seat). Zero behavior change at this phase.
+- Wire SQLAlchemy event listener: every UPDATE to `portal_users.seat_type` / `role` / `status` appends a history row and sets previous row's `valid_to`
+- Drop the now-defunct add-on UI from `/admin/settings/addons` (scribe / docs sliders gone)
 - Add `/api/admin/billing/breakdown` endpoint returning `{seat_type: count}`
 - Add display-only "Per-seat breakdown" panel on `/admin/billing`
-- Tests: seat_type defaults derived correctly, breakdown endpoint returns correct counts
+- Tests: seat_type defaults derived correctly, breakdown endpoint counts, history-row append on every change
 
 ### Phase 2 — Seat assignment as first-class admin UI element (~1 day)
 
@@ -279,10 +437,16 @@ Six phases. Each is independently shippable; rollback at any phase leaves prod f
 - `PLAN_LIMITS` deprecated for capability lookup; quotas (`max_personal_kbs_per_user`, `max_items_per_kb`, `can_create_org_kbs`) move into `SEAT_FEATURES` derivation
 - Tests: `kb_manager + chat seat` returns capabilities only for chat-seat-unlocked features; `kb_manager + knowledge seat` returns full KM cap-set
 
-### Phase 5 — Per-seat-type Moneybird billing (~1.5 days)
+### Phase 5 — Per-seat-type Moneybird billing with prorated daily-rate (~2 days)
 
 - `MoneybirdService.update_subscription(org)` switches to per-seat-type line-items
-- Live recompute from `portal_users` joined with `seat_type` (no `org.plan` dependency)
+- Bill-amount source-of-truth shifts from `org.plan × org.seats` to a query on `portal_user_seat_history` covering the billing period:
+  ```python
+  for each seat_type in (chat, knowledge, viewer):
+      seat_days = sum(days_active per user in this seat_type within period)
+      seat_billable = seat_days × (SEAT_PRICE_MONTHLY[seat_type] / days_in_period)
+  ```
+- Cost-delta forecast for the admin-confirm CTA shows BOTH the snapshot bill (today's headcount × monthly price) AND the historical-actual bill (current month's daily prorated). Admin sees both numbers before clicking.
 - Trigger: invite-user, update-user-role (if seat changes via smart-default), patch-seat
 - One-time per-org migration: feature-flagged `BILLING_PER_SEAT_ENABLED` per `portal_orgs.id`. Phase 5 ships with the flag OFF for all existing tenants. Each tenant's admin sees a "switch to per-user billing" CTA on `/admin/billing` with before/after cost. Only after admin confirmation does the Moneybird subscription update.
 - Lifecycle email on bill change with cost delta breakdown
@@ -323,79 +487,51 @@ Six phases. Each is independently shippable; rollback at any phase leaves prod f
 
 **AC-12**: WHEN any tenant's billing is migrated to per-seat (Phase 5), the migration SHALL only happen after admin click on `/admin/billing` "switch to per-user billing" CTA. Until clicked, the tenant remains on legacy `plan × seats` billing. NO automatic per-tenant billing change.
 
-**AC-13** (regression guard): WHEN any future code path tries to derive the seat type from the role automatically (the v0.1.0 anti-pattern), CI SHALL fail. An ast-grep rule under `rules/no-profile-derives-seat.yml` SHALL detect direct `seat = SEAT_FOR_ROLE[role]` assignments outside the explicit `suggest_seat()` helper.
+**AC-13** (regression guard): WHEN any future code path tries to derive the seat type from the role automatically (the v0.1.0 anti-pattern), CI SHALL fail. The ast-grep rule below MUST live at `rules/no-profile-derives-seat.yml` and run in the portal-api workflow:
+
+```yaml
+id: no-profile-derives-seat
+language: python
+severity: error
+message: |
+  Direct seat-from-role mapping outside suggest_seat() conflates the billing
+  axis with the permission axis (SPEC-PORTAL-PRICING-PER-USER-001 anti-pattern).
+  Use suggest_seat(role) for smart-defaults; admin overrides go through the
+  explicit seat selector. See spec section "Why decoupled".
+rule:
+  any:
+    # Pattern A: dict literal mapping any subset of role-strings to a SeatType.
+    - pattern: |
+        {
+          $$$,
+          "personal": SeatType.$$$,
+          $$$,
+          "kb_manager": SeatType.$$$,
+          $$$
+        }
+    # Pattern B: direct subscript on a profile-keyed dict whose value is a SeatType call site.
+    - pattern: $X[$ROLE_STR] = SeatType.$ANY
+      where:
+        ROLE_STR:
+          regex: '^"(personal|company|kb_manager|group_manager|admin)"$'
+fix-suggestion: |
+  Use the explicit suggest_seat() helper:
+      seat = suggest_seat(role)  # returns the recommended default
+      # admin override path: seat is set independently from role
+files:
+  include:
+    - "klai-portal/backend/app/**/*.py"
+  exclude:
+    - "klai-portal/backend/app/core/seats.py"   # the canonical PROFILE → SeatType
+    - "klai-portal/backend/tests/**"
+```
+
+The exception `app/core/seats.py` is the SINGLE place the mapping is allowed (definition site). Tests are excluded so they can build fixtures explicitly.
 
 ---
 
-## Sparring required (Mark must answer before /run)
+## Pre-flight check (MUST run before Phase 1 ships)
 
-**S-1: Seat types — confirm three or expand?**
-
-Default proposal: `viewer` (€0), `chat` (€28), `knowledge` (€68) — matches the website + adds a free read-only tier (a common ask in B2B for stakeholders/leads).
-
-Alternatives to consider:
-- (a) Skip `viewer` for now (only paid seats; revisit later) — simpler, fewer states to test
-- (b) Add a `power` seat above knowledge for future product expansion (not on website yet) — premature
-
-Recommend (a) if you want minimal scope, default proposal (with viewer) if you want the read-only-stakeholder pitch ready.
-
-**S-2: Default seat per role mapping**
-
-Default proposal:
-- `personal`, `company` → chat
-- `kb_manager`, `group_manager`, `admin` → knowledge
-
-Confirm. The smart-default suggestion follows this; admin can always override.
-
-**S-3: How aggressive is Phase 5 Moneybird migration?**
-
-This SPEC proposes **Option C** (admin-confirmed per tenant). No tenant gets a different bill without an explicit admin click on `/admin/billing`. This is the safest default and aligns with `AC-12`.
-
-Alternatives:
-- Option A (gentle): on next renewal, switch automatically — risk of surprise bill on renewal day
-- Option B (immediate): recompute everything Day 1 of Phase 5 — risk of mass billing-shock complaints
-
-Recommend Option C. Confirm.
-
-**S-4: ⚠ Warning vs hard block on role+seat mismatch**
-
-Default proposal: warning only (allow the mismatch, surface the consequence in the UI). Microsoft 365 / HubSpot pattern.
-
-Alternative: hard-block certain combos (e.g. `kb_manager` MUST have `knowledge` or `viewer` seat — not `chat`). Stricter, less flexible.
-
-Recommend warning-only. Confirm.
-
-**S-5: What about `enabled_addons` (scribe, docs)?**
-
-Workspace-level toggles stay as today, with `FEATURE_MIN_PROFILE` floor. Per-add-on per-user pricing deferred to a later SPEC.
-
-Confirm or push back if you want add-ons in this SPEC's scope.
-
-**S-6: Naming — seat type vs license vs subscription?**
-
-Industry uses all three. Microsoft: "license". HubSpot: "seat". Salesforce: "user license" + "permission set" (separate concepts).
-
-Default proposal: `seat_type` internally (in code/DB/API), "Klai Chat seat" / "Knowledge seat" / "Viewer seat" in UI strings.
-
-Confirm.
-
-**S-7: Phase ordering**
-
-The 6-phase ordering above:
-1. Add column + breakdown (read-only)
-2. Admin UI for seat assignment
-3. Remove blockers (allowlist + seat cap)
-4. Decouple capabilities
-5. Per-seat Moneybird billing (admin-confirmed)
-6. Deprecate `portal_orgs.plan` / `seats`
-
-Phases 1-4 ship without billing impact (legacy Moneybird billing continues unchanged through Phase 4). Phase 5 introduces real billing change behind a per-tenant flag. This means: the customer-facing pain (invite blocks, surprise upgrades) is resolved by Phase 3, while billing accuracy follows in Phase 5 on opt-in basis.
-
-Confirm or propose re-ordering.
-
-**S-8: Existing chat-tier orgs with kb_managers (data audit)**
-
-Pre-flight query before Phase 1:
 ```sql
 SELECT o.slug, COUNT(u.zitadel_user_id) AS km_count
 FROM portal_orgs o
@@ -403,7 +539,8 @@ JOIN portal_users u ON u.org_id = o.id
 WHERE o.plan = 'chat' AND u.role IN ('kb_manager', 'group_manager')
 GROUP BY o.slug;
 ```
-After SPEC-PORTAL-PLAN-RENAME-001 deploy (today), allowlist enforcement should mean ZERO rows. If non-zero: those users default to `knowledge` seat in Phase 1 migration (matches their role's expected access), but admin gets a one-time email noting the seat assignment and any billing impact.
+
+After SPEC-PORTAL-PLAN-RENAME-001 deploy, allowlist enforcement should mean ZERO rows. If non-zero, those users default to `knowledge` seat in the Phase 1 backfill (matches their role's expected access), and the affected admin gets a one-time email noting the seat assignment and any billing impact (Phase 5 onwards).
 
 ---
 
@@ -414,7 +551,7 @@ After SPEC-PORTAL-PLAN-RENAME-001 deploy (today), allowlist enforcement should m
 | Phase 5 Moneybird migration accidentally double-bills tenants | Per-tenant feature flag `BILLING_PER_SEAT_ENABLED`, OFF by default. Admin click required. |
 | Removing `ALLOWED_PROFILES_PER_PLAN` triggers test failures across 30+ test files | Phase 3 single-PR sweep with one bulk-update commit (mechanical, like SPEC-PORTAL-PLAN-RENAME-001). Tests asserting `role_not_allowed_for_plan` are inverted to assert success. |
 | `portal_orgs.plan` is referenced by external callers / SOPS env / dashboards | Phase 6 leaves the column NULL-able and untouched for one release. Observability dashboards updated separately. |
-| Mixed-seat billing line-items break Moneybird's existing template | Test against Moneybird sandbox in Phase 5 (rolls into S-3 confirm). Rollback plan: revert to legacy single-tier billing per affected tenant. |
+| Mixed-seat billing line-items break Moneybird's existing template | Test against Moneybird sandbox before Phase 5 ships per tenant. Rollback plan: revert to legacy single-tier billing per affected tenant. |
 | Admin demotes user OR lowers seat → silent capability loss the user never agreed to | Phase 2 confirm-modal includes consequence ("Roman will lose access to org KBs and KB management features") and emits a `user.seat_changed` audit event. |
 | `viewer` seat triggers free-tier abuse (org creates 1000 viewer seats) | Defer abuse-rate-limiting to a later SPEC if observed in practice. v0.2.0 trusts admins. |
 | Profile-derives-seat anti-pattern creeps back via "convenient" code | AC-13 ast-grep CI rule blocks direct `SEAT_FOR_ROLE[role]` outside the explicit `suggest_seat()` helper. |
@@ -458,4 +595,4 @@ The decoupled seat+role architecture is consistent across major B2B SaaS platfor
 
 ---
 
-Status: **draft-needs-sparring** — Mark must answer S-1 through S-8 before `/moai run`.
+Status: **ready-for-run** — sparring resolved (v0.3.0). Run `/moai run SPEC-PORTAL-PRICING-PER-USER-001` to start Phase 1.

--- a/.moai/specs/SPEC-PORTAL-PRICING-PER-USER-001/spec.md
+++ b/.moai/specs/SPEC-PORTAL-PRICING-PER-USER-001/spec.md
@@ -1,0 +1,353 @@
+---
+id: SPEC-PORTAL-PRICING-PER-USER-001
+version: "0.1.0"
+status: draft-needs-sparring
+created: 2026-05-12
+updated: 2026-05-12
+author: Mark Vletter
+priority: high
+supersedes:
+  - SPEC-PORTAL-RBAC-001 (workspace-plan-as-feature-set assumption — see Section "What this SPEC reverses")
+  - SPEC-PORTAL-PLAN-RENAME-001 (org-wide plan slug rename — collapsed by this SPEC into per-user tier derivation)
+related:
+  - SPEC-PORTAL-PROFILES-001 (5-rung profile ladder + PROFILE_CAPABILITIES — KEPT, becomes the single source of truth)
+  - SPEC-BILLING-UPGRADE-001 (Moneybird subscription wiring — TOUCHED, line-items become per-tier)
+---
+
+# SPEC-PORTAL-PRICING-PER-USER-001: Per-user pricing derived from profile
+
+## HISTORY
+
+| Date | Version | Change |
+|------|---------|--------|
+| 2026-05-12 | 0.1.0 | Initial draft. Open sparring questions in Section "Sparring required". |
+
+---
+
+## Summary
+
+The Klai website ([getklai.com/pricing](https://getklai.com/pricing)) sells **per-user pricing**:
+
+- "Klai Chat" — €28/user/month (€20 yearly)
+- "Klai Chat + Knowledge" — €68/user/month (€48 yearly)
+
+Each user is on their own pricing tier; an org bills the sum across users.
+
+The codebase implements the **opposite**: one workspace-level plan in `portal_orgs.plan` with a profile-allowlist (`ALLOWED_PROFILES_PER_PLAN`) that restricts which profiles can be assigned on which plan. This was hardened by SPEC-PORTAL-RBAC-001 ("Per-user feature flags bestaan niet als pattern in B2B SaaS") and naming-aligned to the marketing slugs by SPEC-PORTAL-PLAN-RENAME-001 — but neither addressed the underlying mismatch.
+
+Symptom that surfaced the gap (2026-05-12 incident): admin tried to invite a Knowledge Manager on a `professional`-plan tenant, got HTTP 403 `role_not_allowed_for_plan` because the plan's role-allowlist did not include `kb_manager`. The fix was to flip the org's plan to `knowledge`, but this is a hack — in the per-user model the act of assigning the kb_manager profile *is* the act of putting that user on the knowledge tier. There should be no separate "plan" gate.
+
+This SPEC replaces the org-wide plan model with **profile-derived per-user tiers**:
+
+```
+user.tier = derive_tier(user.role)
+org.monthly_cost = Σ tier_price(user.tier) for user in org.active_users
+```
+
+The website pricing becomes the literal billing model. The org-level `plan` field is deprecated to display-only metadata, then removed.
+
+---
+
+## Problem statement
+
+Four concrete pains caused by the current (org-wide-plan + fixed-seats) model:
+
+1. **Invite-blocked at the wrong layer (plan).** Admin assigns a profile that the role *can technically perform* (the user has the capability code-side via `PROFILE_CAPABILITIES`), but the org plan's allowlist refuses the assignment. Admin's only recourse is to upgrade the entire org to a higher plan, paying for the highest tier on every existing seat — even though only one user needs the upgraded tier.
+
+2. **Invite-blocked at the wrong layer (seats).** Same shape as #1, different field. Admin tries to invite a 6th user on an org with `seats = 5`; gets `Seat limit reached` 4xx. Admin's only path forward is to manually bump the seat count via billing flow, which (a) blocks productivity until they do it, (b) auto-bills the new seat count for the *current plan* on every seat, even if the new user belongs on a different tier.
+
+   Live incident 2026-05-12: admin tried to invite Linda as Group Manager on Voys; blocked by `seats = 5`, `active_users = 5`. Manual DB bump to 25 unblocked her, but the bill needs to be reconciled separately.
+
+3. **Billing does not match the website promise.** Customer reads "€28/user/mo for Klai Chat, €68/user/mo for + Knowledge" → expects to pay €28 × 4 + €68 × 1 for an org of 4 chat users + 1 KM. Today's billing has a single `org.plan` and `org.seats` — they pay either 5 × €28 or 5 × €68 flat, not the mixed bill.
+
+4. **Cosmetic capability mismatch.** A `kb_manager` on a `chat` plan would have the role label but not the underlying capabilities (no `kb.create_org`, no `kb.members`). The capability intersection silently strips the profile's affordances. Either the role should not be assignable (today's behavior — bad UX, see #1) or it should imply the tier upgrade (this SPEC's behavior).
+
+---
+
+## What this SPEC reverses
+
+| SPEC-PORTAL-RBAC-001 claim | Why it is reversed here |
+|---|---|
+| "Plan = workspace features. Per-user feature flags bestaan niet als pattern in B2B SaaS." | The website explicitly sells per-user pricing. The "pattern" Klai picked from Linear / Notion is the wrong industry — those are per-seat-flat-rate. Klai's promise is per-seat-per-tier (closer to Slack workspace + Slack Pro mixed-tier). |
+| `ALLOWED_PROFILES_PER_PLAN` (org-plan gates profile assignment) | Replaced by `PROFILE_TIER` (profile derives tier; tier never gates profile). |
+| `PLAN_LIMITS[plan].capabilities` (plan-level capability ceiling) | Replaced by `PROFILE_CAPABILITIES[role]` directly (tier never narrows profile capabilities — tier is a billing concept, not a feature concept). |
+| `derive_user_products(role, plan, enabled_addons)` | Becomes `derive_user_products(role, enabled_addons)` (no plan parameter). |
+
+What stays:
+- 5-rung profile ladder (`personal` < `company` < `kb_manager` < `group_manager` < `admin`)
+- `PROFILE_CAPABILITIES`
+- `enabled_addons` per org for scribe / docs (these remain workspace-level toggles)
+- `FEATURE_MIN_PROFILE` floor for add-ons (e.g. scribe gates at `company`)
+- Billing surface in `/admin/billing`, but with new content (tier breakdown)
+
+---
+
+## Solution architecture
+
+### Profile → Tier mapping (proposed default — sparring required)
+
+```python
+# klai-portal/backend/app/core/profile_tiers.py
+from enum import StrEnum
+
+class PricingTier(StrEnum):
+    FREE = "free"            # internal sentinel; trial / no billing
+    CHAT = "chat"            # €28/user/mo, €20/yr
+    KNOWLEDGE = "knowledge"  # €68/user/mo, €48/yr
+
+# Source of truth: profile derives tier.
+PROFILE_TIER: dict[str, PricingTier] = {
+    "personal":      PricingTier.CHAT,        # individual chat user
+    "company":       PricingTier.CHAT,        # org-wide chat user (no KB-management)
+    "kb_manager":    PricingTier.KNOWLEDGE,   # creates / curates org KBs
+    "group_manager": PricingTier.KNOWLEDGE,   # manages group memberships + group KBs
+    "admin":         PricingTier.KNOWLEDGE,   # admins need full features to manage tenants
+}
+
+TIER_PRICE_MONTHLY: dict[PricingTier, int] = {
+    PricingTier.FREE: 0,
+    PricingTier.CHAT: 28,
+    PricingTier.KNOWLEDGE: 68,
+}
+
+TIER_PRICE_YEARLY: dict[PricingTier, int] = {  # monthly equivalent on yearly contract
+    PricingTier.FREE: 0,
+    PricingTier.CHAT: 20,
+    PricingTier.KNOWLEDGE: 48,
+}
+
+def derive_user_tier(role: str) -> PricingTier:
+    """Pure function. Profile is the only input."""
+    return PROFILE_TIER.get(role, PricingTier.CHAT)
+```
+
+### Capability resolution (simplified)
+
+Before:
+```python
+effective_capabilities = PROFILE_CAPABILITIES[role] ∩ PLAN_LIMITS[org.plan].capabilities
+```
+
+After:
+```python
+effective_capabilities = PROFILE_CAPABILITIES[role]
+```
+
+The plan ceiling is gone. A user's profile fully determines what they can do, and the bill follows.
+
+### Feature derivation (simplified)
+
+Before:
+```python
+derive_user_products(role, plan, enabled_addons) -> set[str]
+# user gets PLAN_FEATURES[plan] ∪ {addons gated by FEATURE_MIN_PROFILE}
+```
+
+After:
+```python
+derive_user_products(role, enabled_addons) -> set[str]
+# user gets {chat, knowledge} (the universal product set) ∪ {addons gated by FEATURE_MIN_PROFILE}
+# the per-feature *capability* still narrows what they can DO with knowledge
+```
+
+Note: every paying user gets the `chat` and `knowledge` *products* (= sidebar items / surfaces). What they can DO inside `knowledge` is controlled by `effective_capabilities` (= profile-derived). A `personal`-tier user sees the Knowledge sidebar, but cannot create org KBs (no `kb.create_org` capability). This preserves the discoverability "I can see Knowledge exists" while enforcing access via capability checks at the endpoint.
+
+### Billing surface
+
+`/admin/billing` becomes:
+
+```
+Klai Chat  (€28/user/mo)        4 users    €112/mo
++ Knowledge (€68/user/mo)       2 users    €136/mo
+                                ─────────  ───────
+                                6 users    €248/mo
+```
+
+When admin invites or promotes a user, a confirm modal shows the cost delta:
+> Inviting Roman as Knowledge Manager will add €68/mo to your bill (Knowledge tier).
+> Continue?
+
+When admin demotes, a confirm modal shows the savings:
+> Demoting Roman from Knowledge Manager to Personal will remove €40/mo from your bill (€68 → €28).
+> Continue?
+
+### Moneybird wiring
+
+`MoneybirdService.update_subscription(org)` recomputes line-items as:
+- Line 1: "Klai Chat — N seats" — N × €28 (or €20 yearly)
+- Line 2: "+ Knowledge — M seats" — M × €68 (or €48 yearly)
+
+`N` and `M` are derived live from `portal_users` joined with `derive_user_tier`. No `org.plan` dependency.
+
+---
+
+## Migration plan
+
+Five phases. Each phase is independently shippable; a rollback at any phase leaves prod functional (degraded billing accuracy, never broken auth).
+
+### Phase 1 — Add derivation, no behavior change (~½ day)
+
+- Add `core/profile_tiers.py` with `PROFILE_TIER`, `derive_user_tier`, `TIER_PRICE_*`
+- Add helper `compute_org_billing_breakdown(org_id) -> dict[PricingTier, int]`
+- Add `/api/admin/billing/tier-breakdown` endpoint (read-only)
+- Add display-only "Per-user tier breakdown" panel on `/admin/billing`
+- No mutation of `portal_orgs.plan`, no removal of `ALLOWED_PROFILES_PER_PLAN`
+- Tests: `derive_user_tier` exhaustive over the 5 rungs
+
+### Phase 2 — Remove the invite blocker (~½ day)
+
+- Remove `assert_role_allowed_for_plan` calls from `invite_user`, `update_user_role`, `promote_admin`
+- Keep the function (deprecated, raise DeprecationWarning) for one release cycle so external callers (tests, migrations) get a soft signal
+- Add a confirm-dialog hook on the frontend invite/promote pages: show the cost delta before the API call
+- Tests: invite kb_manager on every plan tier succeeds
+
+### Phase 3 — Decouple capabilities from plan (~½ day)
+
+- `_derive_effective_capabilities` and `get_effective_capabilities` stop intersecting with `PLAN_LIMITS[plan].capabilities`
+- `PROFILE_CAPABILITIES[role]` becomes the only input
+- `PLAN_LIMITS` becomes deprecated for capability lookup; quotas (`max_personal_kbs_per_user`, `max_items_per_kb`, `can_create_org_kbs`) move to `TIER_LIMITS` keyed on tier
+- Tests: `effective_capabilities("kb_manager")` returns full KB-management caps regardless of org
+
+### Phase 4 — Per-tier Moneybird billing (~1 day)
+
+- `MoneybirdService.update_subscription(org)` switches to per-tier line-items
+- Trigger: invite-user, update-user-role, promote-admin, demote events
+- One-time migration: recompute every active org's Moneybird subscription with current per-tier headcount
+- Notify admins via lifecycle email if their bill changed (cost delta shown)
+
+### Phase 5 — Deprecate `portal_orgs.plan` (~½ day)
+
+- Mark `plan` column as `@deprecated` in `models/portal.py`
+- Remove from new-org default (set to `NULL` for new orgs; existing rows untouched)
+- Hide from `/admin/billing` and `/admin/settings` UI
+- Document in SPEC-PORTAL-PRICING-PER-USER-001 changelog: column will be dropped in N+2 release after this lands
+- Optionally: remove the `portal_orgs_plan_check` CHECK constraint (no longer enforces anything meaningful)
+
+---
+
+## Acceptance criteria (EARS)
+
+**AC-1**: WHEN admin invites a user with `role=kb_manager` on any org (any current `org.plan` value), the system SHALL create the invitation successfully (no `role_not_allowed_for_plan` error).
+
+**AC-2**: WHEN admin promotes a user from `personal` to `kb_manager`, the frontend SHALL show a confirm modal with the cost delta `+€40/mo (Knowledge tier)` before sending the API call.
+
+**AC-3**: WHEN admin views `/admin/billing`, the page SHALL display per-tier user counts and per-tier monthly cost in a breakdown table, plus the org's total monthly cost.
+
+**AC-4**: WHEN an admin demotes a user from `kb_manager` to `personal`, the system SHALL emit a `billing.tier_downgraded` product event with `properties.cost_delta = -40`.
+
+**AC-5**: WHEN an admin promotes a user, the system SHALL emit a `billing.tier_upgraded` product event with the cost delta in cents.
+
+**AC-6**: WHEN any user's effective capabilities are computed, the result SHALL equal `PROFILE_CAPABILITIES[user.role]` exactly (no plan-based narrowing).
+
+**AC-7**: WHEN admin views `/admin/users`, each row SHALL display a "Tier" column showing the user's pricing tier (chat / knowledge), derived from their role.
+
+**AC-8**: WHEN `MoneybirdService.update_subscription(org)` runs, it SHALL produce one line-item per active tier with the correct seat count and per-tier price.
+
+**AC-9** (regression guard): WHEN `assert_role_allowed_for_plan` is called from any production code path after Phase 2, the system SHALL emit a `DeprecationWarning` AND return without raising — the function becomes a no-op for one release cycle, then is removed.
+
+**AC-10**: WHEN any tenant on the legacy `portal_orgs.plan` field is migrated, the recomputed bill SHALL differ from the legacy bill by no more than the natural price-rebalance — the migration plan SHALL include an admin notification per affected tenant with the before/after cost.
+
+**AC-11** (seat-cap removal): WHEN admin invites the (N+1)th user on an org currently at `seats = N`, the system SHALL accept the invitation, auto-record the new tier-headcount, and update the next billing-cycle invoice accordingly. NO `Seat limit reached` block. The seat count becomes a derived value (`seats = COUNT(active users)`) rather than a hard cap that must be pre-purchased.
+
+**AC-12** (no surprise bills): WHEN admin actions raise the bill (invite, promote), the frontend SHALL show the cost delta in a confirm-modal BEFORE sending the API call. WHEN admin actions lower the bill (demote, deactivate), the frontend SHALL show the savings in a confirm-modal. NO billing change is silent.
+
+---
+
+## Sparring required (Mark must answer before /run)
+
+These are open product decisions, not implementation details:
+
+**S-1: Profile → Tier mapping confirmation**
+
+Default proposal:
+- `personal`, `company` → chat (€28)
+- `kb_manager`, `group_manager`, `admin` → knowledge (€68)
+
+Alternative ideas:
+- (a) Should `admin` always be on knowledge regardless of usage? Probably yes — admins manage all features and need preview-access (current admin-bypass logic).
+- (b) Should `company` get a free upgrade to knowledge if they're billed for it? Probably no — company = chat-only by definition.
+- (c) Edge case: `personal` on `free` (trial) — ok, derived tier is `free` only when the org is in trial state? Or always `chat`?
+
+**S-2: How aggressive is the Phase 4 Moneybird migration?**
+
+- Option A (gentle): on next subscription renewal, switch to per-tier billing. Existing month-cycle continues at the legacy plan rate.
+- Option B (immediate): recompute every subscription on the day Phase 4 ships, prorate the difference.
+- Option C (admin-confirmed): show the new cost in the admin UI for 30 days, require admin to click "switch to per-user pricing" — only then is the Moneybird subscription updated.
+
+**S-3: Existing `chat`-tier orgs with `kb_manager` users today — possible?**
+
+After SPEC-PORTAL-PLAN-RENAME-001 deploy (today), allowlist enforcement means there should be ZERO `kb_manager` users on `chat` orgs. Verify with a one-off prod query before Phase 2 ships:
+
+```sql
+SELECT o.slug, COUNT(u.zitadel_user_id) AS km_count
+FROM portal_orgs o
+JOIN portal_users u ON u.org_id = o.id
+WHERE o.plan = 'chat' AND u.role IN ('kb_manager', 'group_manager')
+GROUP BY o.slug;
+```
+
+If the count is non-zero, Phase 2 has data-cleanup work in scope (decide per case: notify admin → ask if they want to upgrade the user, or keep the user but add the tier surcharge).
+
+**S-4: What happens to `enabled_addons` (scribe, docs)?**
+
+These remain workspace-toggles with `FEATURE_MIN_PROFILE` floors. But the billing for add-ons today is workspace-level (one toggle = scribe is on for the whole tenant). Should add-on billing also become per-user (scribe is on for these N users)? This SPEC defers that question — add-ons stay workspace-level for now.
+
+**S-5: Naming — keep `tier` or use `seat type`?**
+
+Industry uses both. Slack: "Pro seat", "Business+ seat". Notion: "Plus member", "Business member". Linear: "Standard seat".
+
+Proposed: `tier` internally (in code), `Klai Chat seat` / `+ Knowledge seat` in UI strings. Confirm.
+
+**S-6: Seat-cap behavior**
+
+Today: `portal_orgs.seats` is a hard cap; invite-user fails with `Seat limit reached` when `COUNT(active users) >= seats`. Two paths:
+
+- Option A (proposed in this SPEC): drop the hard cap. Seat count becomes derived (`seats = COUNT(active users)`); billing auto-rolls up. Admin sees "this invite adds €X/mo" before confirming. No invite is ever blocked by an arbitrary purchased-seats number.
+- Option B: keep the cap as a safety-rail (admin can set "do not exceed N seats" to prevent runaway billing on a compromised admin account). Confirm-dialog still shows cost delta before invite, but admin must raise the cap manually.
+- Option C: hybrid — soft cap with admin-configurable threshold. Below the threshold: silent auto-add. At/above: extra confirm "you're going from N to N+1, this exceeds your planned headcount of X — continue?".
+
+Default proposal: **Option A** (no hard cap, just transparent cost on every change). Mark to confirm.
+
+**S-7: Plan-vs-seats interaction during the transition**
+
+Today (post SPEC-PORTAL-PLAN-RENAME-001): admin can fix invite-blocked-by-plan via `/admin/billing` plan upgrade — but that auto-bills every existing seat at the new tier. Phase 4 (per-tier Moneybird billing) closes this loophole, but until Phase 4 ships there is a window where the SPEC's behavior (auto-derive bill from headcount) is partially implemented.
+
+Mitigation: Phases 1-3 ship the *capability + invite* changes (zero billing risk — admin can invite freely, but Moneybird still bills the legacy plan × seats). Phase 4 flips to per-tier billing per tenant on admin confirmation. No tenant is auto-migrated to a higher monthly bill without an explicit click.
+
+---
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Phase 4 Moneybird migration accidentally double-bills tenants | Phase 4 ships behind a feature flag `BILLING_PER_USER_ENABLED=false` per org; flip per tenant after admin confirmation |
+| Removing `ALLOWED_PROFILES_PER_PLAN` triggers test failures across 30+ test files | Phase 2 is a single-PR sweep with one bulk update commit; tests asserting `role_not_allowed_for_plan` are inverted to assert success |
+| `portal_orgs.plan` is referenced by external callers / SOPS env / dashboards | Phase 5 leaves the column NULL-able and untouched for one release; observability dashboards updated separately |
+| Mixed-tier billing line-items break Moneybird's existing template | Test against Moneybird sandbox in Phase 4; rollback plan is to revert to single-tier billing per org for the affected period |
+| Demoting a kb_manager → personal causes silent capability loss the user never agreed to | Phase 2 confirm-dialog includes the consequence: "Roman will lose access to org KBs and KB management features" |
+
+---
+
+## Out of scope
+
+- Per-add-on per-user pricing (scribe-per-user, docs-per-user) — defer to a later SPEC if needed
+- Annual contract enforcement / pro-ration math beyond what Moneybird already does
+- Trial-tier UX (free remains an internal sentinel)
+- Tier downgrade with refund handling
+- Multi-currency support — assumes EUR throughout
+
+---
+
+## Definition of done
+
+- All 5 phases shipped, each as its own PR
+- AC-1 through AC-10 verified via tests + manual smoke on prod
+- `/admin/billing` shows the per-tier breakdown for at least one mixed-tier org (e.g. a fresh test tenant)
+- Moneybird invoice for the next billing cycle on the test tenant matches the per-tier breakdown
+- `portal_orgs.plan` column is `@deprecated` in the model with a SPEC reference comment
+- Documentation updated: `docs/runbooks/billing.md`, `docs/architecture/permissions.md`, klai-portal CLAUDE.md
+- Lessons-archive: capture "spec-vs-marketing-mismatch" pitfall in `.claude/rules/klai/pitfalls/process-rules.md` so the next architectural drift is caught in design review, not on a customer-blocked invite-flow
+
+---
+
+Status: **draft-needs-sparring** — Mark must answer S-1 through S-5 before `/moai run`.


### PR DESCRIPTION
## TL;DR

Aligns the codebase with the website's per-user pricing promise (€28/user/mo Klai Chat, €68/user/mo Klai Chat + Knowledge) using two orthogonal per-user attributes: \`seat_type\` (billing) + \`role\` (permissions). Smart-defaults preserve the SMB single-click experience; admins can decouple when needed.

**Status v0.3.0: \`ready-for-run\`.** Sparring resolved (8 questions answered). \`/moai run SPEC-PORTAL-PRICING-PER-USER-001\` to start Phase 1.

## Wat dit oplost

Twee live invite-blokkades op Voys (2026-05-12):
1. Knowledge Manager → \`role_not_allowed_for_plan\` (manuele DB-hack: plan flip)
2. Group Manager → "Seat limit reached" (manuele DB-hack: seats bump)

Beide hacks. De architectuur klopt niet met wat de website verkoopt. Deze SPEC dicht beide gaten in één integraal traject.

## Sparring antwoorden ingebouwd (v0.3.0)

| # | Vraag | Antwoord |
|---|---|---|
| 1 | Drie seat types? | Ja — viewer/chat/knowledge. Geen abuse-rate-limit op viewer ("als ze toch betalen maakt 't niet uit"). |
| 2 | Default seat per role? | personal/company → chat; rest → knowledge. |
| 3 | Phase 5 Moneybird-migratie? | Admin-confirmed per tenant. Geen surprise bills. |
| 4 | Role+seat mismatch? | Warning in UI, geen hard block (M365/HubSpot pattern). |
| 5 | Add-ons workspace-toggle? | NEE — drop. Scribe + docs in beide seats, role-floor (company) doet de filtering. |
| 6 | Naming? | \`seat_type\` intern, "Klai Chat seat" / "Knowledge seat" / "Viewer seat" in UI. |
| 7 | Phase ordering? | Bevestigd. Customer pain weg na Phase 3, billing accuracy in Phase 5 opt-in. |
| 8 | User-history? | Nieuwe \`portal_user_seat_history\` tabel in Phase 1 (append-only met from-to dates) zodat Phase 5 prorated kan billen. |

## Architectuur

\`\`\`
USER attributes (assigned independently):
  - seat_type:  chat | knowledge | viewer    ← billing + feature unlock
  - role:       personal | company | kb_manager | group_manager | admin
                                              ← permissions within unlocked features

effective_features      = SEAT_FEATURES[seat_type] filtered by FEATURE_MIN_PROFILE[role]
effective_capabilities  = PROFILE_CAPABILITIES[role] filtered through CAPABILITY_TO_SEAT_FEATURE
                                                     against SEAT_FEATURES[seat_type]
monthly_bill            = Σ days_active × (SEAT_PRICE / days_in_period) per seat_type
\`\`\`

Worked examples voor alle role × seat combinaties staan in de SPEC body.

## 6-fasen migratie

| Fase | Wat | Risico |
|---|---|---|
| 1 | seat_type kolom + seat-history tabel + addon-column drop + read-only billing breakdown | Geen (additief, defaults uit huidige role) |
| 2 | Admin UI voor seat-assignment (smart default + override) | Frontend only |
| 3 | \`assert_role_allowed_for_plan\` + seats-cap weghalen | Test-sweep, geen billing impact |
| 4 | Capabilities loskoppelen van plan, intersect met seat | Test-sweep |
| 5 | Per-seat Moneybird billing met prorated daily-rate — **achter feature-flag per org** | Geïsoleerd, admin-confirmed per tenant |
| 6 | \`portal_orgs.plan\` + \`seats\` deprecaten | Cosmetisch + observability |

Klanten-pijn (invite blokkades) opgelost na Fase 3. Billing-accuracy volgt in Fase 5 opt-in per tenant.

## Anti-pattern guard

AC-13 schrijft een concrete ast-grep regel die in CI blokkeert dat iemand later "even snel \`seat = SEAT_FOR_ROLE[role]\`" doet. De v0.1.0 architectural mistake kan niet meer onbedoeld terugkomen — de regel staat in de SPEC body als compleet ast-grep-yaml.

## Wat NIET gebeurt

- Geen tenant wordt automatisch op een hoger maandbedrag gezet zonder admin-klik (Phase 5 opt-in per org)
- Geen capability wordt silent verzwakt (Phase 2 confirm-modals tonen consequentie)
- Geen breaking change op publieke API contracten
- Geen onomkeerbare DB-mutaties (Phase 6 \`portal_orgs.plan\` blijft NULL-able voor één release)

## Industry research onderbouwing

Decoupled seat+role is ÉÉN van twee valid SaaS pricing patterns. Deze SPEC kiest 'm voor Klai *omdat de website per-user pricing belooft* — niet omdat decoupled universeel beter is dan workspace-uniform (dat is Linear/Notion's keuze, ook geldig).

Onderbouwing voor de decoupled-shape:
- [Microsoft 365](https://learn.microsoft.com/en-us/microsoft-365/admin/manage/assign-licenses-to-users)
- [HubSpot Seats Model](https://knowledge.hubspot.com/account-management/manage-seats)
- [Microsoft Tech Community on role anti-patterns](https://techcommunity.microsoft.com/blog/startupsatmicrosoftblog/role-structures-anti-patterns-and-the-10-governance-principles/4510070)
- [AWS SaaS Lens — design principles](https://docs.aws.amazon.com/wellarchitected/latest/saas-lens/general-design-principles.html)

Volledige sourcelist + verdere context staan in de SPEC body.

## Volgende stap

Pre-flight check draaien (SQL-query in SPEC body) om te verifiëren dat na SPEC-PORTAL-PLAN-RENAME-001 geen \`chat\`-orgs nog kb_manager users hebben. Daarna:

\`\`\`
/moai run SPEC-PORTAL-PRICING-PER-USER-001
\`\`\`

Phase 1 levert binnen ~1.5 dag de seat_type kolom + seat-history tabel + read-only breakdown panel op \`/admin/billing\`. Geen billing impact, geen runtime breakages, additieve verandering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)