### PR TITLE
feat(portal): SPEC-PORTAL-EXTENSIONS-UNIFY-001 Phase 2 — unify extension gating, drop enabled_addons

### DIFF
--- a/.moai/specs/SPEC-PORTAL-EXTENSIONS-UNIFY-001/spec.md
+++ b/.moai/specs/SPEC-PORTAL-EXTENSIONS-UNIFY-001/spec.md
@@ -1,0 +1,440 @@
+---
+id: SPEC-PORTAL-EXTENSIONS-UNIFY-001
+version: "0.1.0"
+status: ready-for-review
+created: 2026-05-12
+updated: 2026-05-12
+author: Mark Vletter
+priority: high
+related:
+  - SPEC-PORTAL-RBAC-001 (single-source derivation — wordt aangepast)
+  - SPEC-PORTAL-RBAC-REFACTOR-001 (platform_unlocked_features — wordt single gating-laag)
+  - SPEC-PORTAL-PROFILES-001 (5-rung profiel-ladder — basis blijft)
+  - SPEC-WIDGET-002 (widgets + partner-API — gating consolidatie)
+  - SPEC-SEC-IDENTITY-ASSERT-001 (klai_identity_assert response-schema — `enabled_addons` veld vervalt)
+---
+
+# SPEC-PORTAL-EXTENSIONS-UNIFY-001: Eén gating-laag voor uitbreidingen, sluit `partner_api` gap
+
+## HISTORY
+
+| Date | Version | Change |
+|------|---------|--------|
+| 2026-05-12 | 0.1.0 | Initial draft. Scope = unify `enabled_addons` + `platform_unlocked_features` in één laag (`platform_unlocked_features`), fix security gap op `/api/admin/api-keys`, tenant-visible status + superadmin tenant-picker op `/admin/settings`, DROP `enabled_addons` kolom. Prod-data uitgelezen 2026-05-12. |
+
+---
+
+## Summary
+
+`portal_orgs` heeft vandaag **twee parallelle gating-kolommen** voor uitbreidingen:
+
+- `enabled_addons` — bedoeld als tenant-admin self-service (vandaag: `scribe`, `docs`)
+- `platform_unlocked_features` — Klai-staff gated (vandaag: `partner_api`, `widgets`, `custom_mcps`)
+
+Per product-besluit (2026-05-12): **alle uitbreidingen zijn superadmin-only. Geen self-service.** Het `enabled_addons` concept was testing-scaffolding, niet productie-design. Daarmee zijn de twee lagen dubbelop en moet alles op `platform_unlocked_features` consolideren.
+
+Daarbovenop één concrete security-gap: `/api/admin/api-keys` heeft géén `platform_unlocked_features`-check, ook al staat `partner_api` in `_KNOWN_FEATURES`. Voys (id=8) heeft daardoor een actieve `pk_live_*`-key zonder dat `partner_api` ooit is ontgrendeld. Bevestigd via prod-query 2026-05-12.
+
+Deze SPEC consolideert beide concepten in `platform_unlocked_features`, dropt de `enabled_addons` kolom, sluit de api-keys gap, en geeft tenant-admins een read-only status van wat aanstaat — plus een tenant-picker voor superadmins op dezelfde pagina.
+
+---
+
+## Conceptueel kader (na deze SPEC)
+
+| Laag | Wie zet aan/uit | Waar | Voorbeelden |
+|---|---|---|---|
+| **Plan** (`portal_orgs.plan`) | Billing/Stripe | `PLAN_FEATURES` in `core/features.py` | `chat`, `knowledge` |
+| **Platform-unlocks** (`portal_orgs.platform_unlocked_features`) | Klai-superadmin (org-slug = `platform_org_slug`) | `_KNOWN_FEATURES` in `admin/platform_unlocks.py` | `partner_api`, `widgets`, `custom_mcps`, `scribe`, `docs` |
+| **Profile-filter per feature** (`portal_users.role`) | Tenant-admin (binnen plan-ceiling) | `FEATURE_MIN_PROFILE` in `core/features.py` | `scribe`/`docs` → `company+`, `partner_api`/`widgets`/`custom_mcps` → `admin` |
+
+Drie lagen, duidelijke verantwoordelijkheden. Niets self-service voor uitbreidingen.
+
+---
+
+## Prod-data (verified 2026-05-12)
+
+```
+ id |  slug   | enabled_addons | platform_unlocked_features
+----+---------+----------------+-----------------------------
+  1 | getklai | {docs, scribe} | {widgets, custom_mcps}
+  8 | voys    | {}             | {}
+```
+
+Side-tabellen:
+- `partner_api_keys`: voys=1 key (orphan — `partner_api` niet unlocked).
+- `widgets`: getklai=2 widgets (consistent met `widgets` unlock).
+
+Product-besluit voor migratie:
+- **getklai** → `platform_unlocked_features = {widgets, custom_mcps, docs, scribe}` (union van bestaande state).
+- **voys** → `platform_unlocked_features = {partner_api, widgets, custom_mcps, scribe, docs}` (per product owner: Voys mag alle features aan hebben).
+
+---
+
+## Motivation
+
+1. **Twee parallelle gating-kolommen zonder gedrags-verschil.** Beide lijsten kunnen vandaag features bevatten die `derive_user_products` als equivalent zou behandelen — alleen de write-paden verschillen. Drift-risico permanent.
+2. **`partner_api` gap op `/api/admin/api-keys`.** Beleid en code lopen 4+ weken uit elkaar. Voys heeft een actieve key zonder unlock. Elke tenant-admin kan vandaag live `pk_live_*`-keys aanmaken zonder review.
+3. **`enabled_addons` werd nergens als business-besluit gebruikt.** De toggle bestaat alleen omdat hij ooit als testing-scaffolding was bedoeld. Het feit dat hij zo lang ongebruikt is gebleven zonder dat iemand het zag, is precies waarom dubbelop-kolommen geen blijvers mogen zijn.
+4. **Geen tenant-zichtbaar overzicht.** Tenant-admins kunnen niet zien welke uitbreidingen aanstaan voor hun org. Superadmin kan dat ook niet zonder direct in de DB te kijken — er is geen UI voor `platform_unlocked_features` beheer.
+5. **Tile-pollutie op `/admin/index.tsx`.** Tegels voor api-keys / widgets / mcps verschijnen altijd voor elke admin, ongeacht of de feature ge-unlocked is. Doorklikken geeft 403 (widgets/mcps) of 200 (api-keys, want bug). Slechte UX, en onbedoeld "preview" van features die de tenant niet heeft.
+
+---
+
+## Scope — vijf phases
+
+### Phase 1: Security gap dichten (REQ-1)
+
+**1A: Backend gate op `/api/admin/api-keys`.**
+
+Alle 5 endpoints in `klai-portal/backend/app/api/admin_api_keys.py` (GET list, POST create, GET detail, PATCH, DELETE) krijgen `Depends(require_platform_unlocked("partner_api"))` toegevoegd náást de bestaande `Depends(get_caller_at_least(ProfileRole.ADMIN))`.
+
+```python
+@router.get("")
+async def list_api_keys(
+    perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
+    _platform: UserPermissions = Depends(require_platform_unlocked("partner_api")),
+    db: AsyncSession = Depends(get_db),
+) -> list[ApiKeyResponse]:
+    ...
+```
+
+**1B: Test coverage.**
+
+Nieuwe testset `test_admin_api_keys_platform_gate.py`:
+- Tenant zonder `partner_api` → 403 op elk endpoint.
+- Tenant mét `partner_api` → endpoint werkt normaal.
+- Voys' bestaande key blijft na migratie zichtbaar (zie Phase 2).
+
+**Deploy-volgorde [HARD]:** Phase 2 migratie MOET eerst draaien (zodat Voys' `partner_api` ge-unlocked is) vóór Phase 1-code deployt. Anders breekt Voys' bestaande key-admin met 403. Verwoord als deploy-check in PR-beschrijving.
+
+### Phase 2: Datamodel unification + migratie (REQ-2, REQ-3)
+
+**2A: `_KNOWN_FEATURES` uitbreiden.**
+
+In `klai-portal/backend/app/api/admin/platform_unlocks.py`:
+
+```python
+_KNOWN_FEATURES = frozenset({
+    "partner_api", "widgets", "custom_mcps",
+    "scribe", "docs",   # nieuw — verhuisd uit ADDON_FEATURES
+})
+```
+
+**2B: `derive_user_products` refactor.**
+
+Functie-signatuur verandert:
+
+```python
+# BEFORE
+def derive_user_products(role: str, plan: str, enabled_addons: list[str]) -> set[str]: ...
+
+# AFTER
+def derive_user_products(role: str, plan: str, platform_unlocked_features: list[str]) -> set[str]: ...
+```
+
+Body-logica identiek, alleen de naam van de set die door `FEATURE_MIN_PROFILE` wordt gefilterd. `ADDON_FEATURES` constant wordt verwijderd uit `core/features.py`.
+
+**2C: `UserPermissions` veld weghalen.**
+
+`UserPermissions.enabled_addons: frozenset[str]` verdwijnt. Alle reads (`permissions.py:151,164`, `internal.py:425,473`, `admin/settings.py:148`, `admin/products.py:93,96,111`) switchen naar `perms.platform_unlocked_features`.
+
+**2D: `GET/PATCH /api/admin/settings/addons` endpoints verwijderen.**
+
+Endpoints in `admin/settings.py:143-200` vervallen. Frontend hook `useEnabledAddons.ts` en de UI-code in `admin/settings.tsx:114-160` (de addons-checkbox-sectie) worden in Phase 4 vervangen.
+
+**2E: `/internal/identity/permissions` response-schema.**
+
+`enabled_addons: list[str]` veld vervalt uit `IdentityPermissionsResponse`. Geen consumer leest dit veld (geverifieerd 2026-05-12 via grep over `klai-libs/`, `klai-connector/`, `klai-retrieval-api/`, `klai-knowledge-ingest/`, `klai-mailer/`, `klai-knowledge-mcp/`, `scribe-api/`). Veilig om te verwijderen in dezelfde release.
+
+**2F: Eenmalige data-migratie (Alembic post-deploy SQL).**
+
+Bestand: `klai-portal/backend/alembic/versions/post_deploy_extensions_unify.sql`
+
+```sql
+BEGIN;
+
+-- Statement A: kopieer enabled_addons → platform_unlocked_features (set-union, idempotent).
+UPDATE portal_orgs
+SET platform_unlocked_features = (
+    SELECT array_agg(DISTINCT x ORDER BY x)
+    FROM unnest(COALESCE(platform_unlocked_features, '{}') || COALESCE(enabled_addons, '{}')) AS x
+)
+WHERE enabled_addons IS NOT NULL
+  AND cardinality(enabled_addons) > 0;
+
+-- Statement B: per product owner 2026-05-12 — Voys volledig ontgrendeld.
+UPDATE portal_orgs
+SET platform_unlocked_features = ARRAY['partner_api','widgets','custom_mcps','scribe','docs']
+WHERE slug = 'voys';
+
+-- Verify (one row, expected new state):
+-- getklai → {custom_mcps,docs,scribe,widgets}
+-- voys    → {custom_mcps,docs,partner_api,scribe,widgets}
+
+COMMIT;
+```
+
+**2G: DROP COLUMN — Alembic upgrade migration.**
+
+Volgende migration (zelfde release):
+
+```python
+def upgrade():
+    op.drop_column('portal_orgs', 'enabled_addons')
+
+def downgrade():
+    op.add_column(
+        'portal_orgs',
+        sa.Column('enabled_addons', postgresql.ARRAY(sa.Text()), nullable=False, server_default='{}'),
+    )
+```
+
+`portal_orgs` is owner = `portal_api` (geen RLS-blocker — verifieer via `\dt+ portal_orgs` voor PR). Geen RLS-policies te updaten.
+
+**2H: Code-residu opruimen.**
+
+- `core/system_groups.py:5` comment update: `portal_orgs.platform_unlocked_features` in plaats van `portal_orgs.enabled_addons`.
+- `models/portal.py:81-86` mapping en comments.
+- `api/admin/users.py:248`, `api/admin/products.py:2-3,62`, `api/groups.py:5` comments.
+
+### Phase 3: Backend extensions API (REQ-4, REQ-5, REQ-8)
+
+**3A: Nieuw endpoint `GET /api/admin/extensions`.**
+
+In nieuw bestand `klai-portal/backend/app/api/admin/extensions.py`:
+
+```python
+@router.get("/extensions", response_model=ExtensionsResponse)
+async def list_extensions(
+    org_slug: str | None = None,
+    perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
+    db: AsyncSession = Depends(get_db),
+) -> ExtensionsResponse:
+    """Return all known extensions with enabled-status for the target org.
+
+    - Without org_slug: returns status for caller's own org.
+    - With org_slug: requires perms.is_platform_admin, returns status for target tenant.
+    """
+    if org_slug is not None and not perms.is_platform_admin:
+        raise HTTPException(403, "cross-org query requires platform admin")
+
+    target_org = await _resolve_target_org(perms, org_slug, db)
+    unlocked = set(target_org.platform_unlocked_features or [])
+
+    items = [
+        ExtensionItem(
+            key=key,
+            label=_EXTENSION_LABELS[key],
+            description=_EXTENSION_DESCRIPTIONS[key],
+            enabled=key in unlocked,
+            requires_profile=FEATURE_MIN_PROFILE[key],
+            manageable_by_caller=perms.is_platform_admin,
+        )
+        for key in sorted(_KNOWN_FEATURES)
+    ]
+    return ExtensionsResponse(org_slug=target_org.slug, extensions=items)
+```
+
+**3B: `PATCH /api/admin/extensions` (superadmin-only).**
+
+Delegeert naar bestaande `/api/admin/orgs/{slug}/platform-unlocks` PATCH-handler:
+
+```python
+@router.patch("/extensions", response_model=ExtensionsResponse)
+async def update_extensions(
+    body: UpdateExtensionsRequest,    # { org_slug: str, enabled_features: list[str] }
+    perms: UserPermissions = Depends(require_platform_admin()),
+    db: AsyncSession = Depends(get_db),
+) -> ExtensionsResponse:
+    # Reuse existing implementation from admin/platform_unlocks.py
+    ...
+```
+
+Audit log via bestaande `tenant_lifecycle_events` (`platform_unlocks_updated` event).
+
+**3C: Labels & descriptions registry.**
+
+In `core/features.py` (of nieuw `core/extensions_meta.py`):
+
+```python
+_EXTENSION_LABELS: dict[str, str] = {
+    "partner_api": "API-keys",
+    "widgets": "Chat-widgets",
+    "custom_mcps": "Custom MCP servers",
+    "scribe": "Scribe — meeting-transcripties",
+    "docs": "Docs — gedeelde KBs",
+}
+
+_EXTENSION_DESCRIPTIONS: dict[str, str] = {
+    "partner_api": "Programmatische toegang via pk_live_* API-keys.",
+    "widgets": "Embed chat-widget op klant-website.",
+    "custom_mcps": "Eigen Model Context Protocol servers koppelen.",
+    "scribe": "Automatische meeting-transcriptie.",
+    "docs": "Documentatie-KBs delen binnen de organisatie.",
+}
+```
+
+**3D: `/api/me` response uitbreiden (REQ-8).**
+
+Tenant-frontend leest `is_platform_admin` en `platform_unlocked_features` vandaag NIET. Audit welk endpoint de frontend gebruikt (waarschijnlijk `/api/me` — `klai-portal/backend/app/api/me.py`). Voeg beide velden toe aan de `MeResponse`. Frontend `useAuth()` context absorbeert ze.
+
+### Phase 4: Frontend UI (REQ-6, REQ-7)
+
+**4A: `/admin/settings` — vervangende Uitbreidingen sectie.**
+
+`klai-portal/frontend/src/routes/admin/settings.tsx`:
+- Verwijder de huidige addons-checkbox-sectie (regels ~114-160).
+- Verwijder de `useEnabledAddons.ts` hook.
+- Voeg een nieuwe sectie "Uitbreidingen" toe die `GET /api/admin/extensions` aanroept.
+- Voor non-platform-admin: render een read-only status-lijst (Card + Switch met `disabled` of een statisch indicator-icoontje). Status-tekst: "Beheerd door Klai".
+- Voor `is_platform_admin`: bovenaan de sectie een tenant-picker (autocomplete via `GET /api/admin/orgs?query=...` of bestaande slug-API). Default-selectie = eigen org. Switch-changes triggeren `PATCH /api/admin/extensions` met `org_slug` + nieuwe set.
+
+UI-spec volgt `klai-portal-ui` skill: components uit `components/ui/`, `text-[var(--color-destructive)]` voor error-toasts, i18n via `import * as m from '@/paraglide/messages'`.
+
+**4B: `/admin/index.tsx` tegel-filtering.**
+
+```tsx
+const { effective_products, is_platform_admin, platform_unlocked_features } = useAuth()
+
+const adminSections = [
+    // ... users, groups always visible
+    {
+        title: m.admin_section_api_keys_title(),
+        href: '/admin/api-keys',
+        requiresFeature: 'partner_api',
+    },
+    {
+        title: m.admin_section_widgets_title(),
+        href: '/admin/widgets',
+        requiresFeature: 'widgets',
+    },
+    {
+        title: m.admin_section_mcps_title(),
+        href: '/admin/mcps',
+        requiresFeature: 'custom_mcps',
+    },
+    // ... billing, settings always visible
+].filter(section =>
+    !section.requiresFeature
+    || is_platform_admin
+    || platform_unlocked_features.includes(section.requiresFeature)
+)
+```
+
+`/admin/route.tsx` nav-items krijgen dezelfde filter.
+
+**4C: i18n strings.**
+
+Nieuwe Paraglide messages voor section-labels, status-pills, "Beheerd door Klai", tenant-picker placeholder. NL + EN.
+
+### Phase 5: Consistency audit & tests (REQ-9)
+
+**5A: Gate-consistency audit.**
+
+Verifieer alle drie gating-paden uniform:
+- `admin_api_keys.py`: alle 5 endpoints na Phase 1 → `require_platform_unlocked("partner_api")`. ✓
+- `admin_widgets.py`: alle 5 endpoints — `require_platform_unlocked("widgets")`. Bestaand. ✓
+- `mcp_servers.py`: GET (catalog list) is platform-unlock-agnostisch (laat alle gebruikers ManagedMCPs zien), PATCH (mutate org-MCPs) gebruikt `assert_platform_unlocked(org, "custom_mcps")`. ✓ Geen wijziging.
+
+**5B: Regression-test op `derive_user_products`.**
+
+Snapshot-test die voor elke prod-tenant het `effective_products` resultaat berekent vóór én na refactor en assert dat ze identiek zijn:
+
+```python
+@pytest.mark.parametrize("role,plan,unlocked,expected", [
+    ("admin", "complete", {"widgets","custom_mcps","docs","scribe"}, {"chat","knowledge","scribe","docs"}),
+    ("personal", "complete", {"widgets","custom_mcps","docs","scribe"}, {"chat","knowledge"}),
+    ("admin", "professional", {"partner_api","widgets","custom_mcps","scribe","docs"}, {"chat","knowledge","scribe","docs"}),
+    # ... edge cases
+])
+def test_derive_user_products_snapshot(role, plan, unlocked, expected):
+    assert derive_user_products(role, plan, sorted(unlocked)) == expected
+```
+
+**5C: ast-grep regression-guard.**
+
+Nieuwe rule `rules/no-enabled-addons-read.yml`:
+
+```yaml
+id: no-enabled-addons-read
+language: python
+rule:
+  pattern: $OBJ.enabled_addons
+message: enabled_addons column is dropped; use platform_unlocked_features.
+```
+
+Gewired in `klai-portal/backend/.github/workflows/portal-api.yml` via `ast-grep/action`. Fail-on-match.
+
+**5D: E2E flow.**
+
+Playwright MCP test (binnen REQ-9):
+- Login als platform-admin (Klai-account) → `/admin/settings` → toggle een feature voor Voys → reload → status reflecteert. Toggle terug → reload → terug.
+- Login als tenant-admin op een test-tenant → `/admin/settings` → "Uitbreidingen" sectie is read-only.
+
+---
+
+## Acceptance Criteria
+
+- [ ] Post-migratie prod-state:
+    - `getklai.platform_unlocked_features = {custom_mcps, docs, scribe, widgets}`
+    - `voys.platform_unlocked_features = {custom_mcps, docs, partner_api, scribe, widgets}`
+- [ ] `portal_orgs.enabled_addons` kolom bestaat niet meer (`\d portal_orgs` → kolom afwezig).
+- [ ] `GET /api/admin/api-keys` zonder `partner_api` in unlocks → 403; mét → 200.
+- [ ] Voys' bestaande `partner_api_keys`-record blijft toegankelijk via admin-UI na deploy.
+- [ ] `/admin/settings` als tenant-admin (test-tenant zonder platform-admin rechten) → "Uitbreidingen"-sectie is read-only, toont status van álle 5 features, met "Beheerd door Klai" indicatie.
+- [ ] `/admin/settings` als platform-admin (Klai-account) → tenant-picker zichtbaar; switch-changes roepen `PATCH /api/admin/extensions` aan; reload bevestigt persisted state.
+- [ ] `/admin/index.tsx` als tenant-admin → alleen tegels voor unlocked features zichtbaar. Als platform-admin → alle tegels zichtbaar.
+- [ ] `derive_user_products` regression-test groen voor beide prod-tenants — pre/post refactor identiek.
+- [ ] `ast-grep --rule rules/no-enabled-addons-read.yml klai-portal/backend/app/` → zero matches.
+- [ ] Geen consumer van `/internal/identity/permissions` faalt op missend `enabled_addons` veld (grep clean voor klai-libs en alle services).
+- [ ] CI groen: `ruff check`, `ruff format --check`, `pyright`, `pytest`.
+
+---
+
+## Out of Scope
+
+- Tenant-impersonation flow. Tenant-picker op `/admin/settings` volstaat voor 2 tenants. Bij groei naar 10+ tenants → herwaarderen.
+- Overzichtspagina "alle tenants × alle features" matrix. Bewust uitgesteld per product-besluit (2026-05-12: "3 niet nu").
+- Stripe / billing-koppeling voor platform-unlocked features.
+- Wijzigingen aan `FEATURE_MIN_PROFILE` policy (scribe/docs blijven `company+`, api-keys/widgets/mcps blijven `admin`).
+- Per-user / per-group product-entitlement tables (al opgeheven in SPEC-PORTAL-RBAC-001).
+- Grafana dashboard voor platform-unlocks tijdreeks. Audit-events lopen al via `tenant_lifecycle_events`.
+
+---
+
+## Rollout Volgorde
+
+Vijf PRs, in volgorde:
+
+1. **PR 1 — Phase 2 migratie + datamodel cleanup.** Migratie loopt eerst, code-refactor activeert in dezelfde release. Voys krijgt `partner_api` (en alles) ontgrendeld vóór Phase 1 de gate sluit. `enabled_addons` kolom drop'pt in dezelfde Alembic-chain.
+2. **PR 2 — Phase 1 security gate op `/api/admin/api-keys`.** Klein, geïsoleerd. Mag pas na PR 1 om regressie te vermijden.
+3. **PR 3 — Phase 3 extensions endpoint + `/api/me` velden.** Backend-only.
+4. **PR 4 — Phase 4 frontend UI.** Tenant-picker, status-pills, tegel-filter. Vereist PR 3 voor data.
+5. **PR 5 — Phase 5 tests + ast-grep guard.** Sluit het loket: regression-snapshot, no-enabled-addons-read rule, E2E flow.
+
+Elke PR vóór merge: `gh run watch --exit-status` op groen, daarna verificatie op core-01 (bundle timestamp + container age) per `klai-portal/CLAUDE.md` deploy-rule. Voor PR 1 specifiek: post-deploy `SELECT slug, platform_unlocked_features FROM portal_orgs;` om te verifiëren dat beide rows matchen acceptance-criteria.
+
+---
+
+## Risico's en mitigaties
+
+| Risico | Mitigatie |
+|---|---|
+| PR 2 deployt vóór PR 1 migratie → Voys breekt (geen `partner_api` unlocked, key-CRUD geeft 403). | PR-volgorde hard in beschrijving; CI-job die controleert dat de migratie heeft gedraaid voor PR 2-deploy; Voys' migratie-statement in PR 1 unlocked Voys voor álle features, dus PR 2 raakt Voys niet. |
+| `/internal/identity/permissions` consumer breekt op missend veld. | Veld-grep over alle klai-services + klai-libs gedaan 2026-05-12, niemand leest het. Bij twijfel: backward-compat-window via lege list in Phase 2, drop in opvolg-PR. (Niet nodig op basis van audit, dus single-release.) |
+| DROP COLUMN op een grotere tabel zou lock-contention veroorzaken. | `portal_orgs` heeft 2 rows. Niet relevant. |
+| Frontend `useAuth` cache toont stale `platform_unlocked_features` na superadmin-toggle. | `PATCH /api/admin/extensions` response invalidate via TanStack Query — `queryClient.invalidateQueries({ queryKey: ['me'] })` direct ná success. |
+| Bestaande SPECs (`SPEC-PORTAL-RBAC-REFACTOR-001`, `SPEC-PORTAL-PROFILES-001`) refereren naar `enabled_addons`. | Documentatie-update buiten code-scope. Comments in code worden in Phase 2-2H bijgewerkt; SPEC-docs blijven historisch correct. |
+
+---
+
+## Verifiability
+
+Elke acceptance-criterium is binnen ~5 minuten verifieerbaar door:
+- Prod-query op `portal_orgs.platform_unlocked_features`.
+- `curl` op `/api/admin/api-keys` met en zonder unlock.
+- Playwright MCP flow voor `/admin/settings` (twee accounts).
+- `pytest klai-portal/backend/tests/test_features_derive.py -k snapshot`.
+- `ast-grep --rule rules/no-enabled-addons-read.yml klai-portal/backend/app/`.
+
+Geen acceptance-criterium vereist een handmatige UI-walkthrough zonder script-handvat — alles is automatiseerbaar.

--- a/klai-portal/backend/alembic/versions/e0ad7c2b1e80_extensions_unify.py
+++ b/klai-portal/backend/alembic/versions/e0ad7c2b1e80_extensions_unify.py
@@ -1,0 +1,92 @@
+"""SPEC-PORTAL-EXTENSIONS-UNIFY-001: drop enabled_addons, unify on platform_unlocked_features.
+
+Two parallel gating columns (enabled_addons tenant-self-service +
+platform_unlocked_features Klai-staff) collapse into one. Done in three
+atomic UPDATE+DDL steps:
+
+1. Set-union copy: for every org with non-empty enabled_addons, add those
+   entries to platform_unlocked_features (idempotent via DISTINCT).
+2. Voys explicit unlock (per product owner 2026-05-12): all five features
+   enabled. Hard-coded in the migration so the data-decision is auditable
+   in commit history rather than via a post-deploy curl.
+3. DROP COLUMN portal_orgs.enabled_addons. portal_api owns the table on
+   prod (verified 2026-05-12 via pg_tables.tableowner), so the standard
+   alembic upgrade path can execute the ALTER TABLE without escalation.
+
+Single transaction — if any step fails, the whole migration rolls back
+and the column survives. Container entrypoint.sh re-attempts on next start
+unless the failure is wedged (then manual psql + alembic stamp recovery
+per .claude/rules/klai/pitfalls/process-rules.md::alembic-cannot-drop-non-portal_api-tables).
+
+Revision: e0ad7c2b1e80
+Down-revision: e3765cd03dd2
+Created: 2026-05-12
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "e0ad7c2b1e80"
+down_revision = "e3765cd03dd2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Step 1: set-union copy. Any tenant with a non-empty enabled_addons
+    # gets those values merged (de-duplicated, sorted) into
+    # platform_unlocked_features.
+    op.execute(
+        """
+        UPDATE portal_orgs
+        SET platform_unlocked_features = (
+            SELECT COALESCE(array_agg(DISTINCT x ORDER BY x), '{}'::text[])
+            FROM unnest(
+                COALESCE(platform_unlocked_features, '{}'::text[])
+                || COALESCE(enabled_addons, '{}'::text[])
+            ) AS x
+        )
+        WHERE enabled_addons IS NOT NULL
+          AND cardinality(enabled_addons) > 0
+        """
+    )
+
+    # Step 2: per product owner decision (sparring 2026-05-12) — Voys
+    # gets every extension unlocked. Hard-coded here so the data-decision
+    # lives in commit history, not in an out-of-band curl.
+    op.execute(
+        """
+        UPDATE portal_orgs
+        SET platform_unlocked_features = ARRAY[
+            'custom_mcps', 'docs', 'partner_api', 'scribe', 'widgets'
+        ]::text[]
+        WHERE slug = 'voys'
+        """
+    )
+
+    # Step 3: drop the now-redundant column. portal_api owns portal_orgs on
+    # prod (verified 2026-05-12 via pg_tables.tableowner).
+    op.drop_column("portal_orgs", "enabled_addons")
+
+
+def downgrade() -> None:
+    # Best-effort rollback: re-create the column with empty array default.
+    # Original per-tenant enabled_addons values are NOT restorable — they
+    # were merged into platform_unlocked_features by upgrade Step 1, and
+    # there is no way to split them back out after the union. Acceptable
+    # because this SPEC retires enabled_addons as a concept; rollback
+    # would only be invoked if downstream code references the column
+    # again, in which case re-deriving the value from the application
+    # layer is the operator's problem.
+    op.add_column(
+        "portal_orgs",
+        sa.Column(
+            "enabled_addons",
+            postgresql.ARRAY(sa.Text()),
+            nullable=False,
+            server_default="{}",
+        ),
+    )

--- a/klai-portal/backend/app/api/admin/products.py
+++ b/klai-portal/backend/app/api/admin/products.py
@@ -1,10 +1,14 @@
 """Admin product endpoints.
 
 SPEC-PORTAL-RBAC-001 v0.2.0: per-user/per-group product assignment is removed.
-Products are derived from (profile, plan, enabled_addons) -- see
+Products are derived from (profile, plan, platform_unlocked_features) -- see
 `app.core.features.derive_user_products`. The legacy assignment endpoints
 return 410 Gone. Two read-only endpoints remain because the frontend uses
 them for the assignable-products list and the per-user effective view.
+
+SPEC-PORTAL-EXTENSIONS-UNIFY-001 (2026-05-12): the third derivation input
+was renamed from `enabled_addons` to `platform_unlocked_features` after
+the two gating columns were unified.
 """
 
 from typing import Literal
@@ -40,6 +44,10 @@ class ProductsResponse(BaseModel):
 
 class EffectiveProductOut(BaseModel):
     product: str
+    # Source classification — "plan" for chat/knowledge, "addon" for
+    # scribe/docs (granted via platform_unlocked_features). The wire-name
+    # remains "addon" for frontend backward-compatibility; conceptually
+    # it now means "platform-unlocked product" per SPEC-PORTAL-EXTENSIONS-UNIFY-001.
     source: Literal["plan", "addon"]
 
 
@@ -57,12 +65,12 @@ async def list_available_products(
     perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
 ) -> ProductsResponse:
-    """Return products available to the caller given (profile, org plan, enabled add-ons).
+    """Return products available to the caller given (profile, plan, platform_unlocked_features).
 
     UserPermissions already carries `effective_products` derived from the
-    same (role, plan, enabled_addons) input — return that instead of
-    re-deriving. Equivalent to calling `derive_user_products` from this
-    handler in earlier code, just sourced one layer up.
+    same triple — return that instead of re-deriving. Equivalent to calling
+    `derive_user_products` from this handler in earlier code, just sourced
+    one layer up.
     """
     return ProductsResponse(products=sorted(perms.effective_products))
 
@@ -73,7 +81,7 @@ async def get_user_effective_products(
     perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
 ) -> EffectiveProductsResponse:
-    """Return effective products for a user with source attribution (plan or addon)."""
+    """Return effective products for a user with source attribution (plan vs platform-unlock)."""
     target = await db.scalar(
         select(PortalUser).where(
             PortalUser.zitadel_user_id == zitadel_user_id,
@@ -86,15 +94,15 @@ async def get_user_effective_products(
     # Derive products specifically for the TARGET user with the caller's
     # tenant config — same shape `get_effective_products` would return,
     # but routed through `derive_user_products` so we can also classify
-    # each product as plan- vs addon-sourced for the response.
+    # each product as plan- vs platform-unlock-sourced for the response.
     effective = sorted(
         derive_user_products(
             role=target.role,
             plan=perms.plan,
-            enabled_addons=list(perms.enabled_addons),
+            platform_unlocked_features=list(perms.platform_unlocked_features),
         )
     )
-    enabled_addons = set(perms.enabled_addons)
+    unlocked = set(perms.platform_unlocked_features)
     # Keep the canonical resolver as a sanity sentinel so any future drift
     # between derive_user_products and get_effective_products surfaces here
     # rather than at the user-visible response.
@@ -109,7 +117,10 @@ async def get_user_effective_products(
         products=[
             EffectiveProductOut(
                 product=p,
-                source="addon" if p in enabled_addons else "plan",
+                # Wire-name "addon" preserved for frontend back-compat;
+                # semantically: this product came from platform_unlocked_features
+                # rather than from the plan baseline.
+                source="addon" if p in unlocked else "plan",
             )
             for p in effective
         ]

--- a/klai-portal/backend/app/api/admin/settings.py
+++ b/klai-portal/backend/app/api/admin/settings.py
@@ -1,4 +1,13 @@
-"""Admin org settings and plan management endpoints."""
+"""Admin org settings and plan management endpoints.
+
+SPEC-PORTAL-EXTENSIONS-UNIFY-001 (2026-05-12): the legacy self-service
+addons endpoints (GET/PATCH /api/admin/settings/addons) are deprecated.
+GET remains as a read-only facade returning the subset of
+platform_unlocked_features that are user-facing products (scribe/docs).
+PATCH returns 410 Gone — tenants can no longer toggle add-ons themselves.
+The full extension-management lives behind /api/admin/extensions and is
+gated by require_platform_admin for cross-org writes.
+"""
 
 import logging
 from typing import Literal
@@ -9,10 +18,16 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.dependencies import _load_org_or_500
 from app.core.database import get_db
-from app.core.features import ADDON_FEATURES, PLAN_FEATURES
+from app.core.features import FEATURE_MIN_PROFILE, PLAN_FEATURES
 from app.core.permissions import ProfileRole, UserPermissions, get_caller_at_least
-from app.services.audit import log_event
-from app.services.events import emit_event
+
+# Set of user-facing product keys (= keys that appear in derive_user_products
+# output). Used by the deprecated /settings/addons GET facade to return only
+# the "addon-like" subset of platform_unlocked_features, preserving its
+# original response shape for any lingering frontend reader.
+_ADDON_PRODUCT_KEYS: frozenset[str] = frozenset(
+    k for k, _floor in FEATURE_MIN_PROFILE.items() if k not in {"chat", "knowledge"}
+)
 
 logger = logging.getLogger(__name__)
 
@@ -112,8 +127,8 @@ async def change_plan(
     """Upgrade or downgrade org plan.
 
     SPEC-PORTAL-RBAC-001 v0.2.0: products are derived from (profile, plan,
-    enabled_addons), so changing the plan automatically (re-)gates the
-    feature set on the next request. No per-user/group product cleanup
+    platform_unlocked_features), so changing the plan automatically (re-)gates
+    the feature set on the next request. No per-user/group product cleanup
     needed -- those tables are no longer the source of truth.
     """
     new_plan = body.plan
@@ -128,7 +143,14 @@ async def change_plan(
 
 
 # ---------------------------------------------------------------------------
-# Add-on toggle endpoints (SPEC-PORTAL-PROFILES-001 Phase 2 P2.4)
+# Deprecated add-on toggle endpoints (SPEC-PORTAL-EXTENSIONS-UNIFY-001)
+#
+# The original self-service toggle behaviour is gone: tenant-admins can no
+# longer enable or disable extensions. GET remains as a read-only facade so
+# any lingering frontend reader sees a stable response shape during the
+# transition window. PATCH returns 410 Gone — the new path is
+# `/api/admin/extensions` (Phase 3, gated by require_platform_admin for
+# writes).
 # ---------------------------------------------------------------------------
 
 
@@ -136,65 +158,32 @@ class AddonsOut(BaseModel):
     enabled_addons: list[str]
 
 
-class AddonsUpdate(BaseModel):
-    enabled_addons: list[str]
-
-
-@router.get("/settings/addons", response_model=AddonsOut)
+@router.get("/settings/addons", response_model=AddonsOut, deprecated=True)
 async def get_addons(
     perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
 ) -> AddonsOut:
-    """Return the tenant's currently enabled add-ons."""
-    return AddonsOut(enabled_addons=list(perms.enabled_addons))
+    """Read-only facade — returns the subset of platform_unlocked_features
+    that are user-facing products (scribe/docs).
 
-
-@router.patch("/settings/addons", response_model=AddonsOut)
-async def update_addons(
-    body: AddonsUpdate,
-    perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
-    db: AsyncSession = Depends(get_db),
-) -> AddonsOut:
-    """Enable or disable tenant-level add-ons.
-
-    # @MX:NOTE: SPEC-PORTAL-PROFILES-001 Phase 2 P2.4 — only values in
-    # ADDON_FEATURES are accepted. Unknown values raise 400. Per
-    # SPEC-PORTAL-RBAC-001 v0.2.0, products are derived purely from
-    # (role, plan, enabled_addons); there are no per-user / per-group
-    # entitlement tables to keep in sync. Disabling an add-on simply
-    # stops surfacing it to the derivation function on the next request.
+    Wire-name `enabled_addons` preserved for backward compatibility with the
+    legacy frontend. Will be removed once /admin/settings frontend is migrated
+    to /api/admin/extensions in Phase 3.
     """
-    unknown = [p for p in body.enabled_addons if p not in ADDON_FEATURES]
-    if unknown:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Unknown add-on product(s): {unknown}. Valid: {sorted(ADDON_FEATURES)}",
-        )
+    unlocked = set(perms.platform_unlocked_features)
+    addons = sorted(unlocked & _ADDON_PRODUCT_KEYS)
+    return AddonsOut(enabled_addons=addons)
 
-    org = await _load_org_or_500(db, perms.org_id)
-    before = list(org.enabled_addons or [])
-    after = list(body.enabled_addons)
 
-    org.enabled_addons = after
-
-    added = sorted(set(after) - set(before))
-    removed = sorted(set(before) - set(after))
-
-    await log_event(
-        org_id=perms.org_id,
-        actor=perms.user_id,
-        action="addons.updated",
-        resource_type="org",
-        resource_id=str(perms.org_id),
-        details={"before": before, "after": after, "added": added, "removed": removed},
+@router.patch("/settings/addons", status_code=status.HTTP_410_GONE, deprecated=True)
+async def update_addons_gone() -> dict:
+    """Deprecated by SPEC-PORTAL-EXTENSIONS-UNIFY-001. All extension toggles
+    are platform-admin controlled — see PATCH /api/admin/extensions."""
+    raise HTTPException(
+        status_code=status.HTTP_410_GONE,
+        detail=(
+            "Tenant-level add-on toggles are no longer self-service. "
+            "Extensions are managed by Klai platform admins via "
+            "/api/admin/extensions."
+        ),
     )
-    await db.commit()
-
-    emit_event(
-        "tenant.addons_updated",
-        org_id=perms.org_id,
-        user_id=perms.user_id,
-        properties={"enabled_addons": after, "added": added, "removed": removed},
-    )
-
-    return AddonsOut(enabled_addons=after)

--- a/klai-portal/backend/app/api/admin/users.py
+++ b/klai-portal/backend/app/api/admin/users.py
@@ -246,8 +246,9 @@ async def invite_user(
     )
     db.add(user_row)
 
-    # SPEC-PORTAL-RBAC-001: products are derived from (role, plan, enabled_addons)
-    # at read time; no per-user entitlement rows are written here.
+    # SPEC-PORTAL-RBAC-001: products are derived from (role, plan,
+    # platform_unlocked_features) at read time; no per-user entitlement
+    # rows are written here.
     #
     # Personal KB is created in the SAME transaction as the portal_users INSERT
     # so that the tenant-scoped GUC (`app.current_org_id`) is still active when

--- a/klai-portal/backend/app/api/groups.py
+++ b/klai-portal/backend/app/api/groups.py
@@ -3,8 +3,9 @@ Group management endpoints.
 All endpoints require authentication and are scoped to the caller's org.
 
 SPEC-PORTAL-RBAC-001 v0.2.0: groups are content-scoping (KB access) only.
-Products are derived from (profile, plan, enabled_addons) and not assigned
-per group. The legacy product-assignment endpoints below return 410 Gone.
+Products are derived from (profile, plan, platform_unlocked_features) and
+not assigned per group. The legacy product-assignment endpoints below
+return 410 Gone.
 """
 
 import logging

--- a/klai-portal/backend/app/api/internal.py
+++ b/klai-portal/backend/app/api/internal.py
@@ -422,7 +422,10 @@ class UserPermissionsResponse(BaseModel):
     org_slug: str
     role: str
     plan: str
-    enabled_addons: list[str]
+    # SPEC-PORTAL-EXTENSIONS-UNIFY-001: enabled_addons column dropped 2026-05-12.
+    # platform_unlocked_features is now the single source of truth for
+    # tenant-level extension state. No consumer of /internal/identity/permissions
+    # was reading enabled_addons (audited 2026-05-12 across all klai services).
     platform_unlocked_features: list[str]
     effective_role: str
     effective_capabilities: list[str]
@@ -470,7 +473,6 @@ async def get_user_permissions(
         org_slug=perms.org_slug,
         role=perms.role.value,
         plan=perms.plan,
-        enabled_addons=sorted(perms.enabled_addons),
         platform_unlocked_features=sorted(perms.platform_unlocked_features),
         effective_role=perms.effective_role.value,
         effective_capabilities=sorted(c.value for c in perms.effective_capabilities),

--- a/klai-portal/backend/app/core/features.py
+++ b/klai-portal/backend/app/core/features.py
@@ -1,17 +1,25 @@
-"""Feature derivation for SPEC-PORTAL-RBAC-001.
+"""Feature derivation for SPEC-PORTAL-RBAC-001 + SPEC-PORTAL-EXTENSIONS-UNIFY-001.
 
-Single source of truth for "which products does a given (role, plan, enabled_addons)
-combination grant". Replaces the per-user / per-group entitlement tables that
-SPEC-PORTAL-PROFILES-001 Phase 2 set up but never produced an industry-standard
-result.
+Single source of truth for "which products does a given (role, plan,
+platform_unlocked_features) combination grant".
+
+SPEC-PORTAL-EXTENSIONS-UNIFY-001 (2026-05-12): the previous dual-track
+gating (enabled_addons tenant-self-service + platform_unlocked_features
+Klai-staff) has been unified onto `platform_unlocked_features`. The old
+`ADDON_FEATURES` constant and `enabled_addons` parameter are gone. The
+set of features that surface as user-facing **products** in
+`derive_user_products` is exactly the subset declared in
+`FEATURE_MIN_PROFILE` (so adding a feature there makes it a product;
+adding a feature only to `_KNOWN_FEATURES` in admin/platform_unlocks.py
+keeps it as a pure platform-gate without product semantics).
 
 Three-concept model (Linear / Notion / Slack / GitHub / Auth0):
-    workspace features = plan features OR enabled add-ons
+    workspace features = plan features OR platform-unlocked features
     user permissions   = profile rank
     feature x profile  = filter via FEATURE_MIN_PROFILE
 
-There are no per-user feature flags. If a feature is enabled at workspace level
-and the user's profile is high enough, they get it. Period.
+There are no per-user feature flags. If a feature is enabled at workspace
+level and the user's profile is high enough, they get it. Period.
 """
 
 from app.core.profiles import PROFILE_RANK
@@ -30,11 +38,14 @@ PLAN_FEATURES: dict[str, frozenset[str]] = {
     "knowledge": frozenset({"chat", "knowledge"}),
 }
 
-# @MX:ANCHOR fan_in=2+ -- canonical add-on registry.
-ADDON_FEATURES: frozenset[str] = frozenset({"scribe", "docs"})
-
-# Minimum profile rung required for each feature. A user's profile rank must
-# be >= the rank of FEATURE_MIN_PROFILE[feature] for the feature to be granted.
+# Minimum profile rung required for each USER-FACING PRODUCT. A user's profile
+# rank must be >= FEATURE_MIN_PROFILE[product] for the product to be granted.
+#
+# Features that exist in `_KNOWN_FEATURES` (admin/platform_unlocks.py) but NOT
+# here are pure platform-gates: they unlock admin-only endpoints
+# (`/admin/api-keys`, `/admin/widgets`, `/admin/mcps`) via
+# `require_platform_unlocked(...)`, but they do NOT surface in
+# `effective_products`. They are not "products" in the tenant-app sense.
 #
 # Sparring decision (SPEC-PORTAL-RBAC-001 v0.2.0): scribe/docs gate at
 # `company`. Personal chat is the "only-my-own-work" rung — secretarial-style
@@ -49,12 +60,19 @@ FEATURE_MIN_PROFILE: dict[str, str] = {
 
 # @MX:ANCHOR fan_in=2+ -- pure derivation, called from get_effective_products
 # and from tests. No DB access; signature is stable contract.
-def derive_user_products(role: str, plan: str, enabled_addons: list[str]) -> set[str]:
-    """Return the set of products a user with this (role, plan, enabled_addons) has.
+def derive_user_products(role: str, plan: str, platform_unlocked_features: list[str]) -> set[str]:
+    """Return the set of products a user with this combination has.
 
-    plan_features      always granted to anyone in the org (modulo profile floor).
-    addon_features     granted iff (a) tenant has the add-on enabled AND
-                       (b) user's profile rank >= FEATURE_MIN_PROFILE[addon].
+    plan_features        always granted to anyone in the org (modulo profile floor).
+    unlocked_products    granted iff (a) the feature is in
+                         ``platform_unlocked_features`` AND (b) the feature has a
+                         ``FEATURE_MIN_PROFILE`` entry (i.e. is a user-facing
+                         product, not a pure platform-gate) AND (c) the user's
+                         profile rank >= ``FEATURE_MIN_PROFILE[feature]``.
+
+    Features that exist in ``_KNOWN_FEATURES`` but lack a ``FEATURE_MIN_PROFILE``
+    entry are pure platform-gates (widgets, custom_mcps, partner_api) — they
+    unlock admin endpoints but do not surface as user-facing products here.
 
     Unknown plan -> empty plan_features. Unknown role -> rank -1, fails every
     FEATURE_MIN_PROFILE check, so user effectively has nothing. Both are safe
@@ -63,15 +81,15 @@ def derive_user_products(role: str, plan: str, enabled_addons: list[str]) -> set
     plan_features = set(PLAN_FEATURES.get(plan, frozenset()))
     caller_rank = PROFILE_RANK.get(role, -1)
 
-    addon_features: set[str] = set()
-    for addon in enabled_addons:
-        if addon not in ADDON_FEATURES:
-            continue
-        floor = FEATURE_MIN_PROFILE.get(addon)
+    unlocked_products: set[str] = set()
+    for feature in platform_unlocked_features:
+        floor = FEATURE_MIN_PROFILE.get(feature)
         if floor is None:
+            # Platform-gate only (widgets, custom_mcps, partner_api).
+            # Not a user-facing product — skip.
             continue
         if caller_rank >= PROFILE_RANK.get(floor, -1):
-            addon_features.add(addon)
+            unlocked_products.add(feature)
 
     # Plan features still need to clear FEATURE_MIN_PROFILE — chat and
     # knowledge default to "personal" so this is a no-op for the current
@@ -81,4 +99,4 @@ def derive_user_products(role: str, plan: str, enabled_addons: list[str]) -> set
         f for f in plan_features if caller_rank >= PROFILE_RANK.get(FEATURE_MIN_PROFILE.get(f, "personal"), -1)
     }
 
-    return plan_features | addon_features
+    return plan_features | unlocked_products

--- a/klai-portal/backend/app/core/permissions.py
+++ b/klai-portal/backend/app/core/permissions.py
@@ -75,7 +75,6 @@ class UserPermissions:
     org_slug: str
     role: ProfileRole
     plan: str
-    enabled_addons: frozenset[str]
     platform_unlocked_features: frozenset[str]
     effective_role: ProfileRole
     effective_capabilities: frozenset[Capability]
@@ -149,10 +148,9 @@ async def resolve_user_permissions(zitadel_user_id: str, db: AsyncSession) -> Us
 
     role = ProfileRole(user.role)
     plan = org.plan
-    enabled_addons = frozenset(org.enabled_addons or [])
     platform_features = _platform_unlocked_set(org)
     effective_caps = _derive_effective_capabilities(role, plan)
-    effective_prods = frozenset(derive_user_products(role.value, plan, list(enabled_addons)))
+    effective_prods = frozenset(derive_user_products(role.value, plan, list(platform_features)))
     kb_limits = effective_kb_limits(role.value, plan)
     is_platform_admin = org.slug == _app_settings.platform_org_slug
 
@@ -162,7 +160,6 @@ async def resolve_user_permissions(zitadel_user_id: str, db: AsyncSession) -> Us
         org_slug=org.slug,
         role=role,
         plan=plan,
-        enabled_addons=enabled_addons,
         platform_unlocked_features=platform_features,
         effective_role=role,  # alias-fase: identical to role until profile-stacking lands
         effective_capabilities=effective_caps,

--- a/klai-portal/backend/app/core/system_groups.py
+++ b/klai-portal/backend/app/core/system_groups.py
@@ -1,8 +1,9 @@
 """System group registry.
 
-SPEC-PORTAL-RBAC-001 v0.2.0: empty registry. Role-bind and add-on groups are
-removed -- profile is the single writer of `portal_users.role`, and add-ons
-are derived from `portal_orgs.enabled_addons` + profile rank. The
+SPEC-PORTAL-RBAC-001 v0.2.0 + SPEC-PORTAL-EXTENSIONS-UNIFY-001: empty
+registry. Role-bind and add-on groups are removed -- profile is the single
+writer of `portal_users.role`, and products are derived from
+`portal_orgs.platform_unlocked_features` + profile rank. The
 `create_system_groups` helper remains as a no-op so the provisioning state
 machine keeps its API surface stable.
 """

--- a/klai-portal/backend/app/models/portal.py
+++ b/klai-portal/backend/app/models/portal.py
@@ -77,20 +77,16 @@ class PortalOrg(Base):
     # @MX:NOTE SPEC-AUTH-009 R5 -- when True, domain_match picker entries skip join-request
     # approval and directly INSERT a portal_users row (R4-C4.3). Default False.
     auto_accept_same_domain: Mapped[bool] = mapped_column(nullable=False, default=False, server_default="false")
-    # @MX:NOTE: SPEC-PORTAL-PROFILES-001 Phase 2 P2.1 — per-tenant add-on toggles.
-    # Stores which add-on products (scribe, docs) the admin has enabled for this org.
-    # A user/group still needs an entitlement in portal_user_products / portal_group_products;
-    # access = enabled_addons AND user/group entitlement (both required).
-    enabled_addons: Mapped[list[str]] = mapped_column(
-        ARRAY(Text()),
-        nullable=False,
-        default=list,
-        server_default="{}",
-    )
-    # @MX:NOTE: SPEC-PORTAL-RBAC-REFACTOR-001 Phase 5A — platform-admin-managed feature gates.
-    # Stores which platform-locked features (partner_api, widgets, custom_mcps) Klai staff
-    # has explicitly unlocked for this org. NOT editable by tenant admins.
-    # Empty by default for all tenants; set via /api/admin/orgs/{slug}/platform-unlocks.
+    # @MX:NOTE: SPEC-PORTAL-EXTENSIONS-UNIFY-001 (2026-05-12) — single gating
+    # column for all tenant extensions. Stores every Klai-staff-managed feature
+    # unlock for this org: scribe, docs (= user-facing products with profile-
+    # floor), partner_api, widgets, custom_mcps (= platform-only gates).
+    # NOT editable by tenant admins; mutated via /api/admin/extensions and
+    # /api/admin/orgs/{slug}/platform-unlocks (both gated by
+    # require_platform_admin). The legacy `enabled_addons` column was dropped
+    # in the same migration that introduced this comment — data was copied
+    # forward by the post-deploy SQL (set-union with the existing
+    # platform_unlocked_features values).
     platform_unlocked_features: Mapped[list[str]] = mapped_column(
         ARRAY(Text()),
         nullable=False,

--- a/klai-portal/backend/app/services/entitlements.py
+++ b/klai-portal/backend/app/services/entitlements.py
@@ -1,9 +1,10 @@
 """Effective product entitlement resolution.
 
-SPEC-PORTAL-RBAC-001 v0.2.0: products are derived purely from
-(role, plan, enabled_addons). No reads on portal_user_products /
-portal_group_products. Single SELECT against the permissive
-portal_users + portal_orgs tables — no tenant-context dance needed.
+SPEC-PORTAL-RBAC-001 v0.2.0 + SPEC-PORTAL-EXTENSIONS-UNIFY-001 (2026-05-12):
+products are derived purely from (role, plan, platform_unlocked_features).
+No reads on portal_user_products / portal_group_products. Single SELECT
+against the permissive portal_users + portal_orgs tables — no
+tenant-context dance needed.
 """
 
 from sqlalchemy import select
@@ -15,25 +16,26 @@ from app.models.portal import PortalOrg, PortalUser
 
 # @MX:ANCHOR fan_in=4 -- called from /api/me, /internal/users/{id}/products,
 #   dependencies.require_product, and SPEC-SEC-022 gating. Signature stable.
-# @MX:NOTE SPEC-PORTAL-RBAC-001: derivation is plan OR enabled_addons gated by
-#   FEATURE_MIN_PROFILE. No per-user / per-group tables. No tenant-context
-#   self-healing -- both portal_users and portal_orgs are permissive on the
-#   zitadel-user-id lookup so this is RLS-safe without set_tenant.
+# @MX:NOTE SPEC-PORTAL-EXTENSIONS-UNIFY-001: derivation is plan OR
+#   platform_unlocked_features gated by FEATURE_MIN_PROFILE. No per-user /
+#   per-group tables. No tenant-context self-healing — both portal_users and
+#   portal_orgs are permissive on the zitadel-user-id lookup so this is
+#   RLS-safe without set_tenant.
 # @MX:SPEC SPEC-PORTAL-RBAC-001
 async def get_effective_products(zitadel_user_id: str, db: AsyncSession) -> list[str]:
     """Return all products a user has access to.
 
-    Single SELECT pulls (role, plan, enabled_addons); pure-Python
+    Single SELECT pulls (role, plan, platform_unlocked_features); pure-Python
     derivation produces the answer. Returns empty list if user has no
     portal row yet (pre-provisioning or deleted user).
     """
     result = await db.execute(
-        select(PortalUser.role, PortalOrg.plan, PortalOrg.enabled_addons)
+        select(PortalUser.role, PortalOrg.plan, PortalOrg.platform_unlocked_features)
         .join(PortalOrg, PortalOrg.id == PortalUser.org_id)
         .where(PortalUser.zitadel_user_id == zitadel_user_id)
     )
     row = result.one_or_none()
     if row is None:
         return []
-    role, plan, enabled_addons = row
-    return sorted(derive_user_products(role, plan, enabled_addons or []))
+    role, plan, unlocked = row
+    return sorted(derive_user_products(role, plan, unlocked or []))

--- a/klai-portal/backend/app/services/tenant_matcher.py
+++ b/klai-portal/backend/app/services/tenant_matcher.py
@@ -4,19 +4,20 @@ Tenant matcher -- resolve an email address to (zitadel_user_id, org_id).
 Uses Zitadel to find the user, then looks up the PortalOrg to get the
 integer org_id (FK to portal_orgs.id).
 
-Includes scribe-add-on check (SPEC-PORTAL-PLAN-RENAME-001): only orgs that
-have explicitly enabled the ``scribe`` add-on (via
-``portal_orgs.enabled_addons``) are eligible for invite-bot meeting traffic.
-This replaces the legacy SCRIBE_PLANS = {"professional", "complete"}
-plan-bound check, which is incompatible with the new 2-tier plan model
-(chat / knowledge) where scribe is no longer plan-bundled.
+Includes scribe gate (SPEC-PORTAL-PLAN-RENAME-001 +
+SPEC-PORTAL-EXTENSIONS-UNIFY-001): only orgs that have ``scribe`` in
+``portal_orgs.platform_unlocked_features`` are eligible for invite-bot
+meeting traffic. This replaces the legacy SCRIBE_PLANS = {"professional",
+"complete"} plan-bound check, which was incompatible with the 2-tier plan
+model. On 2026-05-12 the legacy ``enabled_addons`` column was retired and
+the read here moved to ``platform_unlocked_features``.
 
 Results are cached in-memory with a 60-second TTL (SPEC-SEC-HYGIENE-001
 REQ-27 Option A). The previous 5-minute TTL meant a tenant disabling the
-scribe add-on could still send invite-bot meeting traffic for up to
+scribe feature could still send invite-bot meeting traffic for up to
 5 minutes after the toggle — business-logic hygiene fix. Option A (short
 TTL) was chosen over Option B (explicit invalidate_cache hook on the
-add-on-toggle path) for simplicity; profiling during /run did not show
+toggle path) for simplicity; profiling during /run did not show
 measurable Zitadel-load increase from the shorter window.
 """
 
@@ -34,9 +35,9 @@ logger = logging.getLogger(__name__)
 # SPEC-SEC-HYGIENE-001 REQ-27.1 Option A: 60-second TTL (was 5 minutes).
 CACHE_TTL = timedelta(seconds=60)
 
-# SPEC-PORTAL-PLAN-RENAME-001: scribe is no longer plan-bundled.
-# An org is eligible iff "scribe" is in portal_orgs.enabled_addons.
-SCRIBE_ADDON: str = "scribe"
+# SPEC-PORTAL-EXTENSIONS-UNIFY-001: scribe is no longer plan-bundled.
+# An org is eligible iff "scribe" is in portal_orgs.platform_unlocked_features.
+SCRIBE_FEATURE: str = "scribe"
 
 # In-memory cache: email -> (result, expiry)
 _cache: dict[str, tuple[tuple[str, int | None] | None, datetime]] = {}
@@ -74,12 +75,15 @@ async def _lookup(email: str) -> tuple[str, int | None] | None:
 
     zitadel_user_id, zitadel_org_id = user_info
 
-    # Resolve zitadel_org_id (string) to portal_orgs.id (int) and check add-on
+    # Resolve zitadel_org_id (string) to portal_orgs.id (int) and check the
+    # platform-unlock gate (SPEC-PORTAL-EXTENSIONS-UNIFY-001).
     org_id: int | None = None
     try:
         async with AsyncSessionLocal() as db:
             row = await db.execute(
-                select(PortalOrg.id, PortalOrg.enabled_addons).where(PortalOrg.zitadel_org_id == zitadel_org_id)
+                select(PortalOrg.id, PortalOrg.platform_unlocked_features).where(
+                    PortalOrg.zitadel_org_id == zitadel_org_id
+                )
             )
             org_row = row.one_or_none()
             if org_row is None:
@@ -90,12 +94,12 @@ async def _lookup(email: str) -> tuple[str, int | None] | None:
                 )
                 return None
 
-            org_id, enabled_addons = org_row.id, list(org_row.enabled_addons or [])
+            org_id, unlocked = org_row.id, list(org_row.platform_unlocked_features or [])
 
-            # SPEC-PORTAL-PLAN-RENAME-001: scribe is now an opt-in add-on.
-            if SCRIBE_ADDON not in enabled_addons:
+            # SPEC-PORTAL-EXTENSIONS-UNIFY-001: scribe is platform-unlock gated.
+            if SCRIBE_FEATURE not in unlocked:
                 logger.info(
-                    "Scribe add-on not enabled for org_id=%s, email=%s",
+                    "Scribe feature not unlocked for org_id=%s, email=%s",
                     org_id,
                     email,
                 )

--- a/klai-portal/backend/tests/conftest.py
+++ b/klai-portal/backend/tests/conftest.py
@@ -229,6 +229,12 @@ def make_perms(
     Replaces the legacy ``patch("..._get_caller_org", return_value=(uid, org,
     user))`` test pattern. Produces a frozen ``UserPermissions`` with derived
     capabilities + products consistent with the other inputs.
+
+    SPEC-PORTAL-EXTENSIONS-UNIFY-001 (2026-05-12): ``UserPermissions.enabled_addons``
+    is gone. The ``enabled_addons=`` parameter is kept here as a back-compat
+    alias for existing call-sites — its value is merged into
+    ``platform_unlocked_features`` so callers do not need to rewrite all at once.
+    Prefer ``platform_unlocked_features=`` in new tests.
     """
     from app.core.features import derive_user_products
     from app.core.permissions import UserPermissions
@@ -236,8 +242,8 @@ def make_perms(
     from app.core.profiles import PROFILE_CAPABILITIES, Capability, ProfileRole
 
     role_enum = role if isinstance(role, ProfileRole) else ProfileRole(str(role))
-    addons = frozenset(enabled_addons or [])
-    plat_features = frozenset(platform_unlocked_features or [])
+    # Back-compat: legacy enabled_addons param merges into platform_unlocked_features.
+    plat_features = frozenset((platform_unlocked_features or []) + (enabled_addons or []))
 
     if role_enum == ProfileRole.ADMIN:
         knowledge_caps = get_plan_limits("knowledge").capabilities
@@ -247,7 +253,7 @@ def make_perms(
         plan_caps = get_plan_limits(plan).capabilities
         eff_caps = frozenset(Capability(c) for c in (set(role_caps) & set(plan_caps)))
 
-    eff_products = frozenset(derive_user_products(role_enum.value, plan, list(addons)))
+    eff_products = frozenset(derive_user_products(role_enum.value, plan, list(plat_features)))
 
     return UserPermissions(
         user_id=user_id,
@@ -255,7 +261,6 @@ def make_perms(
         org_slug=org_slug,
         role=role_enum,
         plan=plan,
-        enabled_addons=addons,
         platform_unlocked_features=plat_features,
         effective_role=role_enum,
         effective_capabilities=eff_caps,

--- a/klai-portal/backend/tests/test_admin_addons.py
+++ b/klai-portal/backend/tests/test_admin_addons.py
@@ -1,118 +1,78 @@
-"""SPEC-PORTAL-RBAC-001: tenant-level add-on toggle endpoints.
+"""SPEC-PORTAL-EXTENSIONS-UNIFY-001: deprecated addons endpoints.
 
-After RBAC-001, the add-on toggles are the *only* state needed -- no
-group-membership / per-user-product side-effects on update_addons. These
-tests cover the get + patch endpoints.
+GET /api/admin/settings/addons is a read-only facade returning the
+subset of platform_unlocked_features that are user-facing products
+(scribe/docs), preserving the legacy response shape for transition.
 
-SPEC-PORTAL-RBAC-REFACTOR-001 Phase 2a: endpoints now take
-``perms: UserPermissions`` directly (no more ``_get_caller_org`` patch).
-The rol-gate (admin-only) is enforced declaratively by
-``Depends(get_caller_at_least(ProfileRole.ADMIN))`` — that branch is
-covered in `test_permissions.py::test_get_caller_at_least_role_matrix`.
+PATCH /api/admin/settings/addons returns 410 Gone — tenants can no
+longer self-toggle. Extension toggling is platform-admin-only via
+the new /api/admin/extensions endpoint (Phase 3).
 """
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
-from fastapi import HTTPException
+from fastapi import HTTPException, status
 
 from tests.conftest import make_perms
 
 
-def _mock_org(enabled_addons: list[str] | None = None, plan: str = "chat") -> MagicMock:
-    org = MagicMock()
-    org.id = 42
-    org.plan = plan
-    org.enabled_addons = enabled_addons or []
-    return org
+class TestGetAddonsFacade:
+    """GET surfaces the addon-product subset of platform_unlocked_features."""
 
-
-class TestGetAddons:
     @pytest.mark.asyncio
-    async def test_returns_current_state(self) -> None:
+    async def test_returns_scribe_when_unlocked(self) -> None:
         from app.api.admin.settings import get_addons
 
-        perms = make_perms(role="admin", org_id=42, enabled_addons=["scribe"])
+        perms = make_perms(
+            role="admin",
+            org_id=42,
+            platform_unlocked_features=["scribe"],
+        )
         result = await get_addons(perms=perms, db=AsyncMock())
         assert result.enabled_addons == ["scribe"]
 
     @pytest.mark.asyncio
-    async def test_returns_empty_list_by_default(self) -> None:
+    async def test_returns_empty_when_no_unlocks(self) -> None:
         from app.api.admin.settings import get_addons
 
-        perms = make_perms(role="admin", org_id=42, enabled_addons=[])
+        perms = make_perms(role="admin", org_id=42, platform_unlocked_features=[])
         result = await get_addons(perms=perms, db=AsyncMock())
         assert result.enabled_addons == []
 
-
-class TestUpdateAddons:
     @pytest.mark.asyncio
-    async def test_patch_valid_addon_updates_org(self) -> None:
-        from app.api.admin.settings import AddonsUpdate, update_addons
+    async def test_filters_out_pure_platform_gates(self) -> None:
+        """widgets / custom_mcps / partner_api are not user-facing products,
+        so they must NOT appear in the facade response — even though they
+        ARE in platform_unlocked_features."""
+        from app.api.admin.settings import get_addons
 
-        org = _mock_org(enabled_addons=[])
-        perms = make_perms(role="admin", org_id=42, enabled_addons=[])
-        mock_db = AsyncMock()
-        mock_db.get = AsyncMock(return_value=org)
-        body = AddonsUpdate(enabled_addons=["scribe"])
-        with (
-            patch("app.api.admin.settings.log_event", new=AsyncMock()),
-            patch("app.api.admin.settings.emit_event") as mock_emit,
-        ):
-            result = await update_addons(body=body, perms=perms, db=mock_db)
-        assert result.enabled_addons == ["scribe"]
-        assert org.enabled_addons == ["scribe"]
-        mock_db.commit.assert_called_once()
-        assert mock_emit.call_args.args[0] == "tenant.addons_updated"
-
-    @pytest.mark.asyncio
-    async def test_patch_unknown_addon_returns_400(self) -> None:
-        from app.api.admin.settings import AddonsUpdate, update_addons
-
-        perms = make_perms(role="admin", org_id=42)
-        body = AddonsUpdate(enabled_addons=["hacker_product"])
-        with pytest.raises(HTTPException) as exc_info:
-            await update_addons(body=body, perms=perms, db=AsyncMock())
-        assert exc_info.value.status_code == 400
-        assert "hacker_product" in str(exc_info.value.detail)
-
-    @pytest.mark.asyncio
-    async def test_patch_both_addons(self) -> None:
-        from app.api.admin.settings import AddonsUpdate, update_addons
-
-        org = _mock_org()
-        perms = make_perms(role="admin", org_id=42)
-        mock_db = AsyncMock()
-        mock_db.get = AsyncMock(return_value=org)
-        body = AddonsUpdate(enabled_addons=["scribe", "docs"])
-        with (
-            patch("app.api.admin.settings.log_event", new=AsyncMock()),
-            patch("app.api.admin.settings.emit_event"),
-        ):
-            result = await update_addons(body=body, perms=perms, db=mock_db)
+        perms = make_perms(
+            role="admin",
+            org_id=42,
+            platform_unlocked_features=[
+                "widgets",
+                "custom_mcps",
+                "partner_api",
+                "scribe",
+                "docs",
+            ],
+        )
+        result = await get_addons(perms=perms, db=AsyncMock())
         assert set(result.enabled_addons) == {"scribe", "docs"}
+        for non_product in ("widgets", "custom_mcps", "partner_api"):
+            assert non_product not in result.enabled_addons
+
+
+class TestUpdateAddonsGone:
+    """PATCH always returns 410 Gone; the deprecation is hard, not soft."""
 
     @pytest.mark.asyncio
-    async def test_patch_empty_disables_all(self) -> None:
-        from app.api.admin.settings import AddonsUpdate, update_addons
+    async def test_patch_returns_410_gone(self) -> None:
+        from app.api.admin.settings import update_addons_gone
 
-        org = _mock_org(enabled_addons=["scribe"])
-        perms = make_perms(role="admin", org_id=42, enabled_addons=["scribe"])
-        mock_db = AsyncMock()
-        mock_db.get = AsyncMock(return_value=org)
-        body = AddonsUpdate(enabled_addons=[])
-        with (
-            patch("app.api.admin.settings.log_event", new=AsyncMock()),
-            patch("app.api.admin.settings.emit_event"),
-        ):
-            result = await update_addons(body=body, perms=perms, db=mock_db)
-        assert result.enabled_addons == []
-
-    # NOTE: `test_non_admin_rejected` was removed in SPEC-PORTAL-RBAC-REFACTOR-001
-    # Phase 2a. The role gate is now enforced via
-    # `Depends(get_caller_at_least(ProfileRole.ADMIN))` and pinned in
-    # `tests/test_permissions.py::test_get_caller_at_least_role_matrix`
-    # for every (caller_role, required_role) pair. Keeping a copy here
-    # would test the FastAPI dependency-injection wiring, not endpoint
-    # behaviour — that lives in the FastAPI/Starlette test layer
-    # (`tests/test_app_chat.py` style), not unit tests.
+        with pytest.raises(HTTPException) as exc_info:
+            await update_addons_gone()
+        assert exc_info.value.status_code == status.HTTP_410_GONE
+        assert "platform admins" in str(exc_info.value.detail).lower()
+        assert "/api/admin/extensions" in str(exc_info.value.detail)

--- a/klai-portal/backend/tests/test_auth_deprovisioning_block.py
+++ b/klai-portal/backend/tests/test_auth_deprovisioning_block.py
@@ -49,7 +49,6 @@ def _make_perms(provisioning_status: str = "active") -> UserPermissions:
         org_slug="voys",
         role=ProfileRole.ADMIN,
         plan="knowledge",
-        enabled_addons=frozenset(),
         platform_unlocked_features=frozenset(),
         effective_role=ProfileRole.ADMIN,
         effective_capabilities=frozenset(),

--- a/klai-portal/backend/tests/test_features_derive.py
+++ b/klai-portal/backend/tests/test_features_derive.py
@@ -1,20 +1,24 @@
-"""SPEC-PORTAL-RBAC-001: derive_user_products parametrized matrix.
+"""SPEC-PORTAL-RBAC-001 + SPEC-PORTAL-EXTENSIONS-UNIFY-001:
+derive_user_products parametrized matrix.
 
-Pure-function tests on the canonical (role, plan, enabled_addons) -> products
-derivation. No DB, no mocks; just the function contract.
+Pure-function tests on the canonical (role, plan, platform_unlocked_features)
+-> products derivation. No DB, no mocks; just the function contract.
+
+NB: positional args throughout so the tests stay readable regardless of the
+third-parameter rename history (enabled_addons -> platform_unlocked_features
+on 2026-05-12).
 """
 
 import pytest
 
 from app.core.features import (
-    ADDON_FEATURES,
     FEATURE_MIN_PROFILE,
     PLAN_FEATURES,
     derive_user_products,
 )
 
 # ---------------------------------------------------------------------------
-# Plan + role matrix (no add-ons)
+# Plan + role matrix (no platform-unlocks)
 # ---------------------------------------------------------------------------
 
 
@@ -40,42 +44,53 @@ def test_plan_features_only(role: str, plan: str, expected: set[str]) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Add-on threshold gating: scribe/docs floor at "company"
+# Platform-unlocked product threshold gating: scribe/docs floor at "company"
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
-    "role,enabled_addons,expected_added",
+    "role,unlocked,expected_added",
     [
-        # personal: addons enabled at tenant but not granted
+        # personal: products unlocked at tenant but not granted to personal-rank
         ("personal", ["scribe"], set()),
         ("personal", ["docs"], set()),
         ("personal", ["scribe", "docs"], set()),
-        # company: addons granted
+        # company: products granted
         ("company", ["scribe"], {"scribe"}),
         ("company", ["docs"], {"docs"}),
         ("company", ["scribe", "docs"], {"scribe", "docs"}),
-        # kb_manager and above: same as company (addon FLOOR is "company")
+        # kb_manager and above: same as company (product FLOOR is "company")
         ("kb_manager", ["scribe", "docs"], {"scribe", "docs"}),
         ("group_manager", ["scribe", "docs"], {"scribe", "docs"}),
         ("admin", ["scribe", "docs"], {"scribe", "docs"}),
     ],
 )
-def test_addon_threshold(role: str, enabled_addons: list[str], expected_added: set[str]) -> None:
+def test_product_threshold(role: str, unlocked: list[str], expected_added: set[str]) -> None:
     base = {"chat", "knowledge"}
-    result = derive_user_products(role, "chat", enabled_addons)
+    result = derive_user_products(role, "chat", unlocked)
     assert result == base | expected_added
 
 
-def test_disabled_addon_not_granted_even_to_admin() -> None:
+def test_no_unlocks_admin_gets_plan_only() -> None:
     assert derive_user_products("admin", "chat", []) == {"chat", "knowledge"}
     assert "scribe" not in derive_user_products("admin", "chat", [])
 
 
-def test_unknown_addon_in_enabled_list_ignored() -> None:
+def test_unknown_feature_in_unlocked_list_ignored() -> None:
     # If a stale db row has e.g. "x_legacy_feature" the derivation drops it.
     result = derive_user_products("admin", "chat", ["scribe", "x_legacy_feature"])
     assert result == {"chat", "knowledge", "scribe"}
+
+
+def test_pure_platform_gate_does_not_appear_as_product() -> None:
+    # SPEC-PORTAL-EXTENSIONS-UNIFY-001: features without FEATURE_MIN_PROFILE
+    # entry are platform-gates (widgets/custom_mcps/partner_api), not products.
+    # They never surface in derive_user_products output regardless of role.
+    result = derive_user_products("admin", "knowledge", ["widgets", "custom_mcps", "partner_api"])
+    assert result == {"chat", "knowledge"}
+    assert "widgets" not in result
+    assert "custom_mcps" not in result
+    assert "partner_api" not in result
 
 
 # ---------------------------------------------------------------------------
@@ -87,12 +102,12 @@ def test_unknown_plan_returns_empty() -> None:
     assert derive_user_products("admin", "enterprise_xl", []) == set()
 
 
-def test_unknown_role_grants_nothing_with_addons() -> None:
+def test_unknown_role_grants_nothing_with_unlocks() -> None:
     # Unknown role -> rank -1, fails every FEATURE_MIN_PROFILE check.
     assert derive_user_products("nobody", "chat", ["scribe"]) == set()
 
 
-def test_empty_enabled_addons_treated_as_no_addons() -> None:
+def test_empty_unlocks_treated_as_plan_only() -> None:
     assert derive_user_products("admin", "chat", []) == {"chat", "knowledge"}
 
 
@@ -101,25 +116,20 @@ def test_empty_enabled_addons_treated_as_no_addons() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_addon_features_set() -> None:
-    assert ADDON_FEATURES == frozenset({"scribe", "docs"})
-
-
 def test_plan_features_keys() -> None:
     assert set(PLAN_FEATURES.keys()) == {"free", "chat", "knowledge"}
 
 
-def test_feature_min_profile_keys() -> None:
-    # Every PLAN_FEATURES product and every ADDON_FEATURE must declare a floor.
+def test_feature_min_profile_covers_plan_products() -> None:
+    """Every product that comes from a plan MUST declare a profile-floor."""
     declared = set(FEATURE_MIN_PROFILE.keys())
     plan_products: set[str] = set()
     for s in PLAN_FEATURES.values():
         plan_products |= s
-    expected = plan_products | set(ADDON_FEATURES)
-    assert declared >= expected, f"missing floors for: {expected - declared}"
+    assert declared >= plan_products, f"missing floors for plan-products: {plan_products - declared}"
 
 
-def test_addon_floor_company() -> None:
-    # SPEC sparring decision #1: scribe/docs gate at "company".
+def test_addon_products_floor_company() -> None:
+    # SPEC sparring decision: scribe/docs gate at "company".
     assert FEATURE_MIN_PROFILE["scribe"] == "company"
     assert FEATURE_MIN_PROFILE["docs"] == "company"

--- a/klai-portal/backend/tests/test_features_derive_regression.py
+++ b/klai-portal/backend/tests/test_features_derive_regression.py
@@ -1,0 +1,112 @@
+"""SPEC-PORTAL-EXTENSIONS-UNIFY-001 — derive_user_products behavior-parity snapshot.
+
+Locks the (role, plan, unlocked_features) -> products mapping for every
+production-relevant tenant state and every profile-rank we have today.
+This test must remain green across the refactor that renames the third
+positional parameter from ``enabled_addons`` to ``platform_unlocked_features``.
+
+Positional args throughout — that way the test does not need to change when
+the parameter name is renamed in the next commit. Behavior is what we lock,
+not the call-site spelling.
+
+Reference data (verified on prod 2026-05-12):
+- getklai: plan=complete, current effective unlocks={widgets, custom_mcps,
+  scribe, docs} post-migration.
+- voys:    plan=knowledge, current effective unlocks={partner_api, widgets,
+  custom_mcps, scribe, docs} post-migration.
+"""
+
+import pytest
+
+from app.core.features import derive_user_products
+
+# ---------------------------------------------------------------------------
+# Behavior snapshot per (role, plan, unlocked) input
+# ---------------------------------------------------------------------------
+
+# Locked set the refactor MUST preserve. If a row here changes, that's a
+# semantic regression — investigate before updating the snapshot.
+SNAPSHOT_CASES: list[tuple[str, str, list[str], set[str]]] = [
+    # getklai (plan=complete) — admin sees scribe/docs (company-floor), no
+    # partner_api (not unlocked), widgets/custom_mcps don't appear in
+    # derive_user_products output (they're platform gates, not products).
+    (
+        "admin",
+        "knowledge",
+        ["custom_mcps", "docs", "scribe", "widgets"],
+        {"chat", "knowledge", "scribe", "docs"},
+    ),
+    # getklai with a personal user — chat/knowledge only (scribe/docs floor
+    # at company, personal is below).
+    (
+        "personal",
+        "knowledge",
+        ["custom_mcps", "docs", "scribe", "widgets"],
+        {"chat", "knowledge"},
+    ),
+    # getklai with a company user — scribe/docs granted.
+    (
+        "company",
+        "knowledge",
+        ["custom_mcps", "docs", "scribe", "widgets"],
+        {"chat", "knowledge", "scribe", "docs"},
+    ),
+    # voys (plan=knowledge) — admin sees scribe/docs; partner_api/widgets/
+    # custom_mcps are platform gates, not products in derive_user_products.
+    (
+        "admin",
+        "knowledge",
+        ["custom_mcps", "docs", "partner_api", "scribe", "widgets"],
+        {"chat", "knowledge", "scribe", "docs"},
+    ),
+    # voys with a personal user — chat/knowledge only.
+    (
+        "personal",
+        "knowledge",
+        ["custom_mcps", "docs", "partner_api", "scribe", "widgets"],
+        {"chat", "knowledge"},
+    ),
+    # ---- Edge cases that must remain stable across the refactor ----
+    # Empty unlocks → plan-only.
+    ("admin", "chat", [], {"chat", "knowledge"}),
+    ("personal", "chat", [], {"chat", "knowledge"}),
+    # Unknown plan → no plan_features, but unlocked products still flow
+    # through (subject to FEATURE_MIN_PROFILE). Admin clears the company
+    # floor for scribe, so scribe surfaces.
+    ("admin", "enterprise_xl", ["scribe"], {"scribe"}),
+    # Unknown role → rank -1, fails every floor, nothing granted.
+    ("nobody", "chat", ["scribe", "docs"], set()),
+    # Stale legacy feature → ignored (no FEATURE_MIN_PROFILE entry).
+    ("admin", "chat", ["scribe", "x_legacy_feature"], {"chat", "knowledge", "scribe"}),
+    # Free plan → no plan_features. Unlocked products still grant when
+    # profile clears the floor (admin >= company → scribe + docs). The
+    # widgets entry is a pure platform-gate (no profile-floor entry) so
+    # it does NOT appear as a product.
+    ("admin", "free", ["scribe", "docs", "widgets"], {"scribe", "docs"}),
+    # kb_manager and group_manager treated same as admin/company for scribe/docs.
+    ("kb_manager", "chat", ["scribe", "docs"], {"chat", "knowledge", "scribe", "docs"}),
+    ("group_manager", "chat", ["scribe", "docs"], {"chat", "knowledge", "scribe", "docs"}),
+]
+
+
+@pytest.mark.parametrize("role,plan,unlocked,expected", SNAPSHOT_CASES)
+def test_derive_user_products_behavior_snapshot(role: str, plan: str, unlocked: list[str], expected: set[str]) -> None:
+    """Behavior-parity contract. Positional args survive the param rename."""
+    assert derive_user_products(role, plan, unlocked) == expected
+
+
+def test_widgets_and_partner_api_are_not_products_in_derivation() -> None:
+    """Platform-feature keys must NOT leak into derive_user_products output.
+
+    `widgets`, `custom_mcps`, `partner_api` are gating-only — they unlock
+    admin endpoints (handled by require_platform_unlocked), but they are
+    NOT user-facing products. derive_user_products produces only the
+    `effective_products` set used for product-gates on tenant-app endpoints.
+    """
+    result = derive_user_products("admin", "knowledge", ["widgets", "custom_mcps", "partner_api", "scribe", "docs"])
+    assert "widgets" not in result
+    assert "custom_mcps" not in result
+    assert "partner_api" not in result
+    # Scribe and docs ARE products (user-facing modules), so they appear.
+    assert "scribe" in result
+    assert "docs" in result

--- a/klai-portal/backend/tests/test_internal_user_permissions_endpoint.py
+++ b/klai-portal/backend/tests/test_internal_user_permissions_endpoint.py
@@ -31,14 +31,16 @@ def _fake_perms(
     is_platform_admin: bool = False,
     provisioning_status: str = "active",
 ) -> UserPermissions:
+    # SPEC-PORTAL-EXTENSIONS-UNIFY-001: enabled_addons folded into
+    # platform_unlocked_features. The `addons=` kwarg is kept for test
+    # readability but merges into the unified set.
     return UserPermissions(
         user_id="zit-user-1",
         org_id=42,
         org_slug="voys",
         role=role,
         plan=plan,
-        enabled_addons=frozenset(addons),
-        platform_unlocked_features=frozenset(platform_unlocks),
+        platform_unlocked_features=frozenset(platform_unlocks) | frozenset(addons),
         effective_role=role,
         effective_capabilities=frozenset({Capability.KB_CONNECTORS}),
         effective_products=frozenset({"chat"}),
@@ -119,9 +121,10 @@ class TestGetUserPermissionsEndpoint:
         assert result.role == "kb_manager"
         assert result.effective_role == "kb_manager"
         assert result.plan == "knowledge"
-        # Frozenset → sorted list invariant.
-        assert result.enabled_addons == ["docs", "scribe"]
-        assert result.platform_unlocked_features == ["custom_mcps", "widgets"]
+        # Frozenset → sorted list invariant. Unified set contains both the
+        # legacy "addons" and the explicit platform-unlocks (SPEC-PORTAL-
+        # EXTENSIONS-UNIFY-001 merged them on 2026-05-12).
+        assert result.platform_unlocked_features == ["custom_mcps", "docs", "scribe", "widgets"]
         # Capability enum → string.
         assert result.effective_capabilities == ["kb.connectors"]
         assert result.effective_products == ["chat"]

--- a/klai-portal/backend/tests/test_me_org_found.py
+++ b/klai-portal/backend/tests/test_me_org_found.py
@@ -47,7 +47,6 @@ def _mock_perms(*, org_id: int = 42, role: ProfileRole = ProfileRole.COMPANY) ->
         org_slug="acme",
         role=role,
         plan="knowledge",
-        enabled_addons=frozenset(),
         platform_unlocked_features=frozenset(),
         effective_role=role,
         effective_capabilities=frozenset({Capability.KB_CONNECTORS}),

--- a/klai-portal/backend/tests/test_permissions.py
+++ b/klai-portal/backend/tests/test_permissions.py
@@ -51,13 +51,17 @@ def _row(
     provisioning_status: str = "active",
 ) -> tuple[MagicMock, MagicMock]:
     """Build a (PortalOrg, PortalUser) tuple as `db.execute(...).one_or_none()` would
-    return for the resolver query."""
+    return for the resolver query.
+
+    SPEC-PORTAL-EXTENSIONS-UNIFY-001: `enabled_addons=` kept as back-compat alias —
+    its value is merged into `platform_unlocked_features` for the mock org so older
+    tests can still express their setup without rewriting.
+    """
     org = MagicMock()
     org.id = org_id
     org.slug = slug
     org.plan = plan
-    org.enabled_addons = enabled_addons or []
-    org.platform_unlocked_features = platform_unlocked_features or []
+    org.platform_unlocked_features = list({*(platform_unlocked_features or []), *(enabled_addons or [])})
     org.provisioning_status = provisioning_status
 
     user = MagicMock()
@@ -140,7 +144,9 @@ async def test_resolve_returns_user_permissions_dataclass() -> None:
     assert perms.org_slug == "voys"
     assert perms.role == ProfileRole.ADMIN
     assert perms.plan == "knowledge"
-    assert isinstance(perms.enabled_addons, frozenset)
+    # SPEC-PORTAL-EXTENSIONS-UNIFY-001: enabled_addons folded into
+    # platform_unlocked_features; UserPermissions no longer carries
+    # enabled_addons as a separate field.
     assert isinstance(perms.platform_unlocked_features, frozenset)
     assert perms.effective_role == ProfileRole.ADMIN
     assert isinstance(perms.effective_capabilities, frozenset)
@@ -331,7 +337,6 @@ async def test_get_caller_at_least_admin_passes_for_admin() -> None:
         org_slug="voys",
         role=ProfileRole.ADMIN,
         plan="knowledge",
-        enabled_addons=frozenset(),
         platform_unlocked_features=frozenset(),
         effective_role=ProfileRole.ADMIN,
         effective_capabilities=frozenset(),
@@ -353,7 +358,6 @@ async def test_get_caller_at_least_admin_blocks_company() -> None:
         org_slug="voys",
         role=ProfileRole.COMPANY,
         plan="knowledge",
-        enabled_addons=frozenset(),
         platform_unlocked_features=frozenset(),
         effective_role=ProfileRole.COMPANY,
         effective_capabilities=frozenset(),
@@ -386,7 +390,6 @@ async def test_get_caller_at_least_role_matrix(caller: ProfileRole, required: Pr
         org_slug="voys",
         role=caller,
         plan="knowledge",
-        enabled_addons=frozenset(),
         platform_unlocked_features=frozenset(),
         effective_role=caller,
         effective_capabilities=frozenset(),
@@ -422,7 +425,6 @@ def _perms_with(
         org_slug="voys",
         role=role,
         plan="knowledge",
-        enabled_addons=frozenset(),
         platform_unlocked_features=platform_features,
         effective_role=role,
         effective_capabilities=caps,

--- a/klai-portal/backend/tests/test_tenant_matcher.py
+++ b/klai-portal/backend/tests/test_tenant_matcher.py
@@ -2,7 +2,7 @@
 
 SPEC-PORTAL-PLAN-RENAME-001: scribe gating moved from a plan-bound
 allowlist (SCRIBE_PLANS = {"professional", "complete"}) to a per-org
-add-on toggle (``portal_orgs.enabled_addons`` contains ``"scribe"``).
+add-on toggle (``portal_orgs.platform_unlocked_features`` contains ``"scribe"``).
 """
 
 from types import SimpleNamespace
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from app.services.tenant_matcher import SCRIBE_ADDON, clear_cache, find_tenant
+from app.services.tenant_matcher import SCRIBE_FEATURE, clear_cache, find_tenant
 
 
 @pytest.fixture(autouse=True)
@@ -19,9 +19,9 @@ def _clear_cache() -> None:
     clear_cache()
 
 
-def _make_org_row(org_id: int = 42, enabled_addons: list[str] | None = None) -> SimpleNamespace:
-    """Create a fake DB row with id and enabled_addons attributes."""
-    return SimpleNamespace(id=org_id, enabled_addons=enabled_addons or [])
+def _make_org_row(org_id: int = 42, platform_unlocked_features: list[str] | None = None) -> SimpleNamespace:
+    """Create a fake DB row with id and platform_unlocked_features attributes."""
+    return SimpleNamespace(id=org_id, platform_unlocked_features=platform_unlocked_features or [])
 
 
 def _mock_session_with_org(org_row: SimpleNamespace | None = None) -> AsyncMock:
@@ -46,7 +46,7 @@ async def test_known_email_with_scribe_addon_returns_user_and_org() -> None:
     mock_zitadel = AsyncMock()
     mock_zitadel.find_user_by_email.return_value = ("user-123", "zorg-456")
 
-    mock_session = _mock_session_with_org(_make_org_row(42, enabled_addons=["scribe"]))
+    mock_session = _mock_session_with_org(_make_org_row(42, platform_unlocked_features=["scribe"]))
 
     with (
         patch("app.services.tenant_matcher.zitadel", mock_zitadel),
@@ -76,7 +76,7 @@ async def test_cache_prevents_second_zitadel_call() -> None:
     mock_zitadel = AsyncMock()
     mock_zitadel.find_user_by_email.return_value = ("user-123", "zorg-456")
 
-    mock_session = _mock_session_with_org(_make_org_row(42, enabled_addons=["scribe"]))
+    mock_session = _mock_session_with_org(_make_org_row(42, platform_unlocked_features=["scribe"]))
 
     with (
         patch("app.services.tenant_matcher.zitadel", mock_zitadel),
@@ -95,11 +95,11 @@ async def test_cache_prevents_second_zitadel_call() -> None:
 
 @pytest.mark.asyncio
 async def test_org_with_scribe_addon_allowed() -> None:
-    """An org with ``scribe`` in enabled_addons is allowed."""
+    """An org with ``scribe`` in platform_unlocked_features is allowed."""
     mock_zitadel = AsyncMock()
     mock_zitadel.find_user_by_email.return_value = ("user-1", "zorg-1")
 
-    mock_session = _mock_session_with_org(_make_org_row(10, enabled_addons=["scribe"]))
+    mock_session = _mock_session_with_org(_make_org_row(10, platform_unlocked_features=["scribe"]))
 
     with (
         patch("app.services.tenant_matcher.zitadel", mock_zitadel),
@@ -116,7 +116,7 @@ async def test_org_with_scribe_and_other_addons_allowed() -> None:
     mock_zitadel = AsyncMock()
     mock_zitadel.find_user_by_email.return_value = ("user-2", "zorg-2")
 
-    mock_session = _mock_session_with_org(_make_org_row(20, enabled_addons=["scribe", "docs"]))
+    mock_session = _mock_session_with_org(_make_org_row(20, platform_unlocked_features=["scribe", "docs"]))
 
     with (
         patch("app.services.tenant_matcher.zitadel", mock_zitadel),
@@ -129,11 +129,11 @@ async def test_org_with_scribe_and_other_addons_allowed() -> None:
 
 @pytest.mark.asyncio
 async def test_org_without_scribe_addon_rejected() -> None:
-    """An org whose enabled_addons does not contain ``scribe`` is rejected."""
+    """An org whose platform_unlocked_features does not contain ``scribe`` is rejected."""
     mock_zitadel = AsyncMock()
     mock_zitadel.find_user_by_email.return_value = ("user-3", "zorg-3")
 
-    mock_session = _mock_session_with_org(_make_org_row(30, enabled_addons=["docs"]))
+    mock_session = _mock_session_with_org(_make_org_row(30, platform_unlocked_features=["docs"]))
 
     with (
         patch("app.services.tenant_matcher.zitadel", mock_zitadel),
@@ -146,11 +146,11 @@ async def test_org_without_scribe_addon_rejected() -> None:
 
 @pytest.mark.asyncio
 async def test_org_with_no_addons_rejected() -> None:
-    """An org with an empty enabled_addons list is rejected."""
+    """An org with an empty platform_unlocked_features list is rejected."""
     mock_zitadel = AsyncMock()
     mock_zitadel.find_user_by_email.return_value = ("user-4", "zorg-4")
 
-    mock_session = _mock_session_with_org(_make_org_row(40, enabled_addons=[]))
+    mock_session = _mock_session_with_org(_make_org_row(40, platform_unlocked_features=[]))
 
     with (
         patch("app.services.tenant_matcher.zitadel", mock_zitadel),
@@ -179,5 +179,5 @@ async def test_no_portal_org_returns_none() -> None:
 
 
 def test_scribe_addon_constant() -> None:
-    """The exported SCRIBE_ADDON constant matches the canonical add-on name."""
-    assert SCRIBE_ADDON == "scribe"
+    """The exported SCRIBE_FEATURE constant matches the canonical add-on name."""
+    assert SCRIBE_FEATURE == "scribe"

--- a/klai-portal/backend/tests/test_tenant_matcher_cache.py
+++ b/klai-portal/backend/tests/test_tenant_matcher_cache.py
@@ -9,7 +9,7 @@ the SPEC — preferred for simplicity over an explicit invalidate_cache
 hook on the add-on toggle path).
 
 SPEC-PORTAL-PLAN-RENAME-001 update: scribe gating moved from a plan-bound
-SCRIBE_PLANS allowlist to a per-org ``enabled_addons`` list. The cache
+SCRIBE_PLANS allowlist to a per-org ``platform_unlocked_features`` list. The cache
 test now exercises an add-on REMOVAL across the TTL boundary; same
 semantic concern, different signal.
 
@@ -45,8 +45,8 @@ def test_cache_ttl_is_sixty_seconds() -> None:
     )
 
 
-def _mock_session_with_org(enabled_addons: list[str]) -> AsyncMock:
-    org_row = SimpleNamespace(id=42, enabled_addons=enabled_addons)
+def _mock_session_with_org(platform_unlocked_features: list[str]) -> AsyncMock:
+    org_row = SimpleNamespace(id=42, platform_unlocked_features=platform_unlocked_features)
     mock_result = MagicMock()
     mock_result.one_or_none.return_value = org_row
     mock_session = AsyncMock()

--- a/rules/no-enabled-addons-read.yml
+++ b/rules/no-enabled-addons-read.yml
@@ -1,0 +1,26 @@
+# SPEC-PORTAL-EXTENSIONS-UNIFY-001 — block reintroduction of enabled_addons reads.
+#
+# Why: portal_orgs.enabled_addons was dropped on 2026-05-12. All extension
+# state lives in portal_orgs.platform_unlocked_features. Any new code that
+# touches `.enabled_addons` is either reading a dead attribute (silent
+# wrong-empty-list bug) or trying to re-introduce the dual-track gating
+# concept this SPEC removed. Block both at PR-time.
+#
+# The legacy test helper `make_perms` (tests/conftest.py) keeps an
+# `enabled_addons=` parameter as a back-compat alias — that name lives on
+# the keyword-only param, not as an attribute read, so it does NOT match
+# this rule.
+
+id: no-enabled-addons-read
+language: python
+severity: error
+message: |
+  enabled_addons was retired by SPEC-PORTAL-EXTENSIONS-UNIFY-001 (2026-05-12).
+  Read perms.platform_unlocked_features instead. See
+  .moai/specs/SPEC-PORTAL-EXTENSIONS-UNIFY-001/spec.md.
+
+rule:
+  pattern: $OBJ.enabled_addons
+
+files:
+  - klai-portal/backend/app/**/*.py


### PR DESCRIPTION
## SPEC-PORTAL-EXTENSIONS-UNIFY-001 Phase 2

Collapses the dual-track tenant-extension model (`enabled_addons` self-service + `platform_unlocked_features` Klai-staff) onto a single column. Per product owner decision (2026-05-12): **all extension toggling is superadmin-only**. The `enabled_addons` column was testing scaffolding, never production design.

See [`.moai/specs/SPEC-PORTAL-EXTENSIONS-UNIFY-001/spec.md`](.moai/specs/SPEC-PORTAL-EXTENSIONS-UNIFY-001/spec.md) for the full 5-phase plan. This PR is **Phase 2 of 5**.

## What changes

### Backend code
- `core/features.py` — `derive_user_products` third param renamed `enabled_addons → platform_unlocked_features`. `ADDON_FEATURES` constant removed. User-facing products are now exactly the subset of `platform_unlocked_features` that have an entry in `FEATURE_MIN_PROFILE`. Features without a profile-floor (`widgets`, `custom_mcps`, `partner_api`) are pure platform-gates and never surface as products.
- `core/permissions.py` — `UserPermissions.enabled_addons` field dropped. Resolver derives effective products from `platform_unlocked_features` only.
- `models/portal.py` — `enabled_addons` column mapping removed (column DROPped in this PR's alembic migration).
- `services/entitlements.py` — SELECT switches to `platform_unlocked_features`.
- `api/internal.py` — `/internal/identity/permissions` response loses the `enabled_addons` field. **Cross-service grep audit completed 2026-05-12**: no consumer outside klai-portal reads this field (verified across `klai-libs/`, `klai-connector/`, `klai-retrieval-api/`, `klai-knowledge-ingest/`, `klai-mailer/`, `klai-knowledge-mcp/`, `scribe-api/`).
- `api/admin/products.py` — switches to `perms.platform_unlocked_features`. Wire-name `"addon"` preserved in `EffectiveProductOut.source` for frontend back-compat.
- `api/admin/settings.py` — `GET /api/admin/settings/addons` becomes a read-only facade returning the addon-product subset (`scribe`, `docs`) of `platform_unlocked_features`. `PATCH` returns **410 Gone** — tenants can no longer self-toggle.

### Data migration (alembic `e0ad7c2b1e80`)
Single transaction, three steps:
1. Set-union copy `enabled_addons → platform_unlocked_features` (idempotent).
2. Hard-coded **Voys gets all five extensions enabled** per product owner decision 2026-05-12 (`{partner_api, widgets, custom_mcps, scribe, docs}`).
3. `DROP COLUMN portal_orgs.enabled_addons`. `portal_api` owns the table on prod (verified 2026-05-12 via `pg_tables.tableowner`), so the standard alembic upgrade path runs the ALTER TABLE without superuser escalation.

### Tests
- **New** `tests/test_features_derive_regression.py` — behavior-parity snapshot for `derive_user_products`. Positional args throughout — refactor-resistant.
- **Rewritten** `tests/test_admin_addons.py` — covers GET facade + PATCH 410 behavior.
- **Updated** `test_features_derive`, `test_permissions`, `test_internal_user_permissions_endpoint`, `test_auth_deprovisioning_block`, `test_me_org_found`, `conftest`.

### Regression guard
- **New** `rules/no-enabled-addons-read.yml` (ast-grep). Blocks any new `$OBJ.enabled_addons` read in `klai-portal/backend/app/**/*.py`. Already wired into `portal-api.yml` CI via `sgconfig.yml::ruleDirs`.

## Quality gate

- `ruff check`: **All checks passed**
- `ruff format`: **480 files already formatted**
- `pyright`: 1 pre-existing error in `services/docling_client.py` (unrelated to this PR; same error confirmed on main)
- `pytest`: **2403 passed, 3 deselected, 0 failed**
- ast-grep `no-enabled-addons-read`: zero matches in `klai-portal/backend/app/`
- `alembic heads`: single head `e0ad7c2b1e80`

## Post-deploy verification

After CI green + container recreate, expected prod state:

| Tenant | Before (`enabled_addons` / `platform_unlocked_features`) | After (`platform_unlocked_features`) |
|---|---|---|
| getklai | `{docs, scribe}` / `{widgets, custom_mcps}` | `{custom_mcps, docs, scribe, widgets}` |
| voys | `{}` / `{}` | `{custom_mcps, docs, partner_api, scribe, widgets}` |

```bash
ssh core-01 "docker exec klai-core-postgres-1 sh -c 'psql -U \$POSTGRES_USER -d \$POSTGRES_DB -c \"SELECT slug, platform_unlocked_features FROM portal_orgs WHERE deleted_at IS NULL ORDER BY id;\"'"
```

And `\d portal_orgs` should show no `enabled_addons` column.

## Rollout notes

- **Single container per service** — no rolling-deploy schema-mismatch concern.
- Voys has 1 active `partner_api_key` that was never `partner_api`-unlocked (the gap Phase 1 of this SPEC closes). Step 2 of the migration unlocks all five features for Voys, so when Phase 1 lands the existing key remains accessible.
- Frontend `/admin/settings` will show empty/no-op behavior on its Uitbreidingen-section until Phase 4 lands (UI replacement). The PATCH 410 means clicking a toggle yields an error toast; the GET facade keeps the read path functional.

## Next phases
- **Phase 1** — security-gate on `/api/admin/api-keys` (`require_platform_unlocked("partner_api")`).
- **Phase 3** — `/api/admin/extensions` GET/PATCH endpoints + `/api/me` wiring.
- **Phase 4** — frontend `/admin/settings` Uitbreidingen-sectie + tenant-picker for superadmin.
- **Phase 5** — consistency audit + Playwright E2E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)