### PR TITLE
[codex] Clarify website source labels

### DIFF
--- a/klai-portal/backend/app/api/app_knowledge_bases.py
+++ b/klai-portal/backend/app/api/app_knowledge_bases.py
@@ -978,7 +978,7 @@ def _connector_type_label(connector_type: str) -> str:
         "notion": "Notion",
         "google_drive": "Google Drive",
         "ms_docs": "Microsoft Docs",
-        "web_crawler": "Website",
+        "web_crawler": "Website (pagina's)",
         "airtable": "Airtable",
         "confluence": "Confluence",
         "mcp_connector": "MCP",
@@ -994,7 +994,7 @@ def _upload_type_label(content_type: str) -> str:
     if ct in {"pdf", "application/pdf"}:
         return "PDF"
     if ct == "web_page":
-        return "Website"
+        return "Websitepagina"
     if ct in {"url", "html", "text/html"}:
         return "Link"
     if ct in {"text", "markdown", "txt", "text/plain", "text/markdown"}:

--- a/klai-portal/backend/app/api/signup.py
+++ b/klai-portal/backend/app/api/signup.py
@@ -181,10 +181,7 @@ async def signup(
         else:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=(
-                    "Uitnodigingslink is verlopen of klopt niet bij dit e-mailadres. "
-                    "Vraag een nieuwe link aan."
-                ),
+                detail=("Uitnodigingslink is verlopen of klopt niet bij dit e-mailadres. Vraag een nieuwe link aan."),
             )
 
     if not _has_valid_invite and is_free_email_provider(_email_domain):

--- a/klai-portal/backend/app/services/notifications.py
+++ b/klai-portal/backend/app/services/notifications.py
@@ -265,12 +265,7 @@ async def issue_waitlist_invite(
         return False
 
     base = settings.frontend_url.rstrip("/")
-    signup_url = (
-        f"{base}/signup"
-        f"?token={quote(token)}"
-        f"&email={quote(email)}"
-        f"&company={quote(company)}"
-    )
+    signup_url = f"{base}/signup?token={quote(token)}&email={quote(email)}&company={quote(company)}"
 
     expires_in_hours = max(1, ttl_seconds // 3600)
     await send_waitlist_invite(

--- a/klai-portal/backend/app/services/source_extractors/url.py
+++ b/klai-portal/backend/app/services/source_extractors/url.py
@@ -31,13 +31,29 @@ _TITLE_MAX_CHARS = 120
 # First ATX-style H1 in the markdown — greedy match on the heading line only.
 _H1_PATTERN = re.compile(r"^\s*#\s+(.+?)\s*$", re.MULTILINE)
 
+# Keep these in sync with knowledge_ingest.crawl4ai_client's no-selector
+# web-crawl pipeline. Single-page URL sources and website crawls should strip
+# the same page chrome before markdown extraction.
+JS_REMOVE_CHROME = """
+[
+  'nav', 'header', 'footer', 'aside',
+  '[role="navigation"]', '[role="banner"]', '[role="contentinfo"]', '[role="complementary"]',
+  '[role="search"]',
+].forEach(sel => document.querySelectorAll(sel).forEach(el => el.remove()));
+"""
+
+JS_EXPAND_TOGGLES = """
+document.querySelectorAll('details:not([open])').forEach(d => d.setAttribute('open', ''));
+document.querySelectorAll('.notion-toggle__summary, [data-block-type="toggle"] > *:first-child').forEach(s => s.click());
+await new Promise(r => setTimeout(r, 300));
+"""
+
 
 def _crawl_config() -> dict[str, Any]:
     """Default crawler config for untrusted user-supplied URLs.
 
-    Matches the "full pipeline" from knowledge-ingest's build_crawl_config
-    (no selector) but without login-indicator selectors which are a
-    connector-only feature.
+    Matches the no-selector "full pipeline" from knowledge-ingest's
+    build_crawl_config. Login-indicator selectors remain connector-only.
     """
     return {
         "type": "CrawlerRunConfig",
@@ -45,9 +61,11 @@ def _crawl_config() -> dict[str, Any]:
             "cache_mode": "bypass",
             "word_count_threshold": 10,
             "wait_for": ("js:() => document.body.innerText.trim().split(/\\s+/).length > 50"),
+            "js_code_before_wait": JS_REMOVE_CHROME,
+            "js_code": JS_EXPAND_TOGGLES,
             "remove_consent_popups": True,
             "remove_overlay_elements": True,
-            "page_timeout": 25_000,  # crawl4ai internal page timeout, well under our 30s
+            "page_timeout": 30_000,
             "excluded_tags": ["nav", "footer", "header", "aside", "script", "style"],
             "markdown_generator": {
                 "type": "DefaultMarkdownGenerator",

--- a/klai-portal/backend/app/services/twenty.py
+++ b/klai-portal/backend/app/services/twenty.py
@@ -46,6 +46,7 @@ STAGE_INVITED = "INVITED"
 STAGE_INVITED_SENT = "INVITED_SENT"
 STAGE_WON = "WON"
 STAGE_UNSUBSCRIBED = "UNSUBSCRIBED"
+WAITLIST_DEAL_NAME_SEPARATOR = "\N{EN DASH}"
 
 
 class TwentyUnavailable(RuntimeError):
@@ -75,9 +76,7 @@ def _client() -> httpx.AsyncClient:
         TwentyUnavailable: when the URL or API key is missing.
     """
     if not is_configured():
-        raise TwentyUnavailable(
-            "Twenty CRM not configured — set TWENTY_URL and TWENTY_API_KEY in SOPS."
-        )
+        raise TwentyUnavailable("Twenty CRM not configured — set TWENTY_URL and TWENTY_API_KEY in SOPS.")
     return httpx.AsyncClient(
         base_url=settings.twenty_url,
         headers={
@@ -107,10 +106,11 @@ async def list_waitlist_opportunities_in_stage(stage: str) -> list[dict[str, Any
     """Return raw opportunity rows in the given stage.
 
     Filters by ``name[like]:Waitlist%`` so the poller only acts on rows
-    created by the website's waitlist endpoint — never on other deal
+    created by the website's waitlist endpoint - never on other deal
     pipelines an operator may run in the same Twenty workspace. The
-    waitlist endpoint always names deals ``"Waitlist – <Company>"`` or
-    ``"Waitlist – <Name>"`` (see klai-website/src/pages/api/waitlist.ts).
+    waitlist endpoint always names deals ``"Waitlist <en dash> <Company>"``
+    or ``"Waitlist <en dash> <Name>"`` (see
+    klai-website/src/pages/api/waitlist.ts).
     """
     async with _client() as client:
         # Twenty REST filter syntax: ?filter=field[op]:value, combinable
@@ -193,10 +193,10 @@ async def resolve_deal(opportunity: dict[str, Any]) -> WaitlistDeal | None:
             if isinstance(company, dict):
                 company_name = (company.get("name") or "").strip()
         if not company_name:
-            # Fall back to the deal name: "Waitlist – <Company>" or "Waitlist – <Name>"
+            # Fall back to the deal name: "Waitlist <en dash> <Company>".
             deal_name = opportunity.get("name") or ""
-            if "–" in deal_name:
-                company_name = deal_name.split("–", 1)[1].strip()
+            if WAITLIST_DEAL_NAME_SEPARATOR in deal_name:
+                company_name = deal_name.split(WAITLIST_DEAL_NAME_SEPARATOR, 1)[1].strip()
             else:
                 company_name = first_name or "your company"
 

--- a/klai-portal/backend/app/services/waitlist_dispatcher.py
+++ b/klai-portal/backend/app/services/waitlist_dispatcher.py
@@ -64,9 +64,7 @@ async def _dispatch_confirmations() -> dict[str, int]:
             email=deal.email,
             company=deal.company,
         )
-        ok = await twenty.update_opportunity_stage(
-            deal.opportunity_id, twenty.STAGE_CONFIRMATION_SENT
-        )
+        ok = await twenty.update_opportunity_stage(deal.opportunity_id, twenty.STAGE_CONFIRMATION_SENT)
         if ok:
             counters["sent"] += 1
             logger.info(
@@ -120,9 +118,7 @@ async def _dispatch_invites() -> dict[str, int]:
             )
             continue
 
-        ok = await twenty.update_opportunity_stage(
-            deal.opportunity_id, twenty.STAGE_INVITED_SENT
-        )
+        ok = await twenty.update_opportunity_stage(deal.opportunity_id, twenty.STAGE_INVITED_SENT)
         if ok:
             counters["sent"] += 1
             logger.info(

--- a/klai-portal/backend/app/services/waitlist_token.py
+++ b/klai-portal/backend/app/services/waitlist_token.py
@@ -96,9 +96,7 @@ def sign_invite_token(
     """
     key = _key_bytes()
     if key is None:
-        raise WaitlistTokenUnavailable(
-            "WAITLIST_TOKEN_KEY is not configured — set it in SOPS before issuing invites."
-        )
+        raise WaitlistTokenUnavailable("WAITLIST_TOKEN_KEY is not configured — set it in SOPS before issuing invites.")
 
     payload = {
         "email": email.strip().lower(),

--- a/klai-portal/backend/tests/test_app_knowledge_bronnen.py
+++ b/klai-portal/backend/tests/test_app_knowledge_bronnen.py
@@ -38,7 +38,7 @@ def test_connector_type_label_known_types() -> None:
     assert _connector_type_label("notion") == "Notion"
     assert _connector_type_label("google_drive") == "Google Drive"
     assert _connector_type_label("ms_docs") == "Microsoft Docs"
-    assert _connector_type_label("web_crawler") == "Website"
+    assert _connector_type_label("web_crawler") == "Website (pagina's)"
     assert _connector_type_label("airtable") == "Airtable"
     assert _connector_type_label("confluence") == "Confluence"
     assert _connector_type_label("mcp_connector") == "MCP"
@@ -58,7 +58,7 @@ def test_upload_type_label_known_content_types() -> None:
     assert _upload_type_label("application/pdf") == "PDF"
     assert _upload_type_label("html") == "Link"
     assert _upload_type_label("text/html") == "Link"
-    assert _upload_type_label("web_page") == "Website"
+    assert _upload_type_label("web_page") == "Websitepagina"
     assert _upload_type_label("text") == "Tekst"
     assert _upload_type_label("text/markdown") == "Tekst"
     assert _upload_type_label("image/png") == "Afbeelding"
@@ -236,7 +236,7 @@ async def test_list_kb_bronnen_labels_url_upload_as_website_with_source_url() ->
 
     bron = result.bronnen[0]
     assert bron.name == "https://example.com/"
-    assert bron.type_label == "Website"
+    assert bron.type_label == "Websitepagina"
     assert bron.source_url == "https://example.com/"
 
 

--- a/klai-portal/backend/tests/test_source_extractors_url.py
+++ b/klai-portal/backend/tests/test_source_extractors_url.py
@@ -106,6 +106,28 @@ class TestHappyPath:
         body = _json.loads(str(sent["json"]))
         assert body["urls"] == ["https://example.com/page"]
 
+    async def test_single_page_uses_same_no_selector_sanitization_as_crawler(
+        self,
+        mock_httpx_factory,
+    ) -> None:
+        from app.services.source_extractors.url import extract_url
+
+        sent = mock_httpx_factory(_crawl_response("# Hello"))
+        await extract_url("https://example.com/page")
+
+        import json as _json
+
+        body = _json.loads(str(sent["json"]))
+        params = body["crawler_config"]["params"]
+
+        assert params["excluded_tags"] == ["nav", "footer", "header", "aside", "script", "style"]
+        assert "document.querySelectorAll(sel).forEach(el => el.remove())" in params["js_code_before_wait"]
+        assert "details:not([open])" in params["js_code"]
+        assert params["markdown_generator"]["params"]["content_filter"] == {
+            "type": "PruningContentFilter",
+            "params": {"threshold": 0.45, "threshold_type": "dynamic"},
+        }
+
 
 class TestTitleDerivation:
     async def test_h1_wins(self, mock_httpx_factory) -> None:

--- a/klai-portal/backend/tests/test_waitlist_token.py
+++ b/klai-portal/backend/tests/test_waitlist_token.py
@@ -3,16 +3,12 @@
 from __future__ import annotations
 
 import time
-from unittest.mock import patch
 
 import pytest
 
 from app.services.waitlist_token import (
     DEFAULT_TTL_SECONDS,
     InviteTokenPayload,
-    WaitlistTokenUnavailable,
-    sign_invite_token,
-    verify_invite_token,
 )
 
 
@@ -55,7 +51,7 @@ def test_sign_normalises_email_to_lowercase(_key: str) -> None:
 
 
 def test_verify_rejects_tampered_payload(_key: str) -> None:
-    from app.services.waitlist_token import sign_invite_token, verify_invite_token
+    from app.services.waitlist_token import sign_invite_token
 
     token = sign_invite_token("eline@vermeer.nl", "Vermeer Advocaten")
     payload_b64, sig_b64 = token.split(".")
@@ -97,7 +93,7 @@ def test_sign_raises_when_key_unconfigured(monkeypatch: pytest.MonkeyPatch) -> N
     importlib.import_module("app.core.config")
     wt = importlib.import_module("app.services.waitlist_token")
 
-    with pytest.raises(WaitlistTokenUnavailable):
+    with pytest.raises(wt.WaitlistTokenUnavailable):
         wt.sign_invite_token("a@b.com", "Co")
 
 

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-bronnen-helpers.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-bronnen-helpers.tsx
@@ -61,7 +61,14 @@ export function BronIcon({ bron }: { bron: Bron }) {
   const ct = (bron.type_label ?? '').toLowerCase()
   const path = bron.name.toLowerCase()
   if (path.endsWith('.pdf') || ct === 'pdf') return <FileText className="h-4 w-4" />
-  if (path.startsWith('http') || bron.source_url || ct === 'website' || ct === 'link') {
+  if (
+    path.startsWith('http')
+    || bron.source_url
+    || ct === 'website'
+    || ct === 'websitepagina'
+    || ct === "website (pagina's)"
+    || ct === 'link'
+  ) {
     return <Globe className="h-4 w-4" />
   }
   if (ct.startsWith('afbeelding') || /\.(png|jpe?g|gif|webp|svg)$/i.test(path)) return <Image className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- Distinguish single URL uploads as Websitepagina and crawler sources as Website (pagina's)
- Apply the same no-selector crawl4ai chrome stripping and toggle expansion to single-page URL extraction as website crawls
- Keep Bronnen icons recognizing both website labels
- Clean up unrelated full-repo ruff/format blockers so the PR quality job can run green

## Validation
- uv run --python 3.13 ruff check .
- uv run --python 3.13 ruff format --check .
- uv run --python 3.13 pytest tests/test_app_knowledge_bronnen.py tests/test_source_extractors_url.py tests/test_waitlist_token.py
- npm run lint -- --quiet