### PR TITLE
Fix waitlist portal CI

### DIFF
--- a/docs/privacy/dpa-telemetry-addendum.md
+++ b/docs/privacy/dpa-telemetry-addendum.md
@@ -12,7 +12,7 @@ sessions.
 
 ## Article — Telemetry modes for query content (Klai)
 
-The Tenant ("Controller") and Klai BV ("Processor") acknowledge that
+The Tenant ("Controller") and Klai B.V. i.o. ("Processor") acknowledge that
 Klai's chat platform processes queries submitted by the Tenant's
 end-users in order to produce knowledge-base-grounded answers. Klai
 records aggregate telemetry about these queries to maintain service

--- a/klai-portal/backend/app/services/twenty.py
+++ b/klai-portal/backend/app/services/twenty.py
@@ -76,7 +76,7 @@ def _client() -> httpx.AsyncClient:
         TwentyUnavailable: when the URL or API key is missing.
     """
     if not is_configured():
-        raise TwentyUnavailable("Twenty CRM not configured — set TWENTY_URL and TWENTY_API_KEY in SOPS.")
+        raise TwentyUnavailable("Twenty CRM not configured - set TWENTY_URL and TWENTY_API_KEY in SOPS.")
     return httpx.AsyncClient(
         base_url=settings.twenty_url,
         headers={


### PR DESCRIPTION
## Summary
- remove the remaining ambiguous en dash from the Twenty client error string so portal-api ruff passes
- cherry-pick the local DPA wording update from Klai BV to Klai B.V. i.o.

## Verification
- uv run ruff check .
- uv run ruff format --check .
- uv run pyright app/services/twenty.py app/services/waitlist_token.py tests/test_waitlist_token.py
- uv run pytest tests/test_waitlist_token.py tests/test_signup_rate_limit.py tests/test_social_signup.py -q
- uv run pytest -q