### PR TITLE
feat(portal): SPEC-PORTAL-EXTENSIONS-UNIFY-001 Phase 1 — partner_api gate on /api/admin/api-keys

### DIFF
--- a/klai-portal/backend/app/api/admin_api_keys.py
+++ b/klai-portal/backend/app/api/admin_api_keys.py
@@ -1,10 +1,16 @@
-"""Admin API Key management endpoints — SPEC-WIDGET-002.
+"""Admin API Key management endpoints — SPEC-WIDGET-002 + SPEC-PORTAL-EXTENSIONS-UNIFY-001.
 
 CRUD for developer-facing partner API keys (`pk_live_...`) scoped to the
-caller's org. Auth: Zitadel OIDC session with admin/owner role check.
+caller's org. Auth: Zitadel OIDC session with admin role check AND the
+`partner_api` platform-unlock (SPEC-PORTAL-EXTENSIONS-UNIFY-001 Phase 1,
+2026-05-12). Tenants without `partner_api` in `platform_unlocked_features`
+get 403 on every endpoint — the feature is opt-in per tenant via Klai
+platform admin (`/api/admin/extensions` or
+`/api/admin/orgs/{slug}/platform-unlocks`).
 
 Split from the previous admin_integrations.py which combined API keys
-and widgets. Widgets now live in admin_widgets.py.
+and widgets. Widgets now live in admin_widgets.py and use the same
+double-gate pattern (admin role + platform-unlock).
 
 No `active` / revoke action — DELETE is the only way to end a key.
 """
@@ -21,7 +27,12 @@ from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import get_db
-from app.core.permissions import ProfileRole, UserPermissions, get_caller_at_least
+from app.core.permissions import (
+    ProfileRole,
+    UserPermissions,
+    get_caller_at_least,
+    require_platform_unlocked,
+)
 from app.models.knowledge_bases import PortalKnowledgeBase
 from app.models.partner_api_keys import PartnerAPIKey, PartnerApiKeyKbAccess
 from app.services.events import emit_event
@@ -150,6 +161,7 @@ async def _count_kb_access(key_id: str, db: AsyncSession) -> int:
 async def create_api_key(
     body: CreateApiKeyRequest,
     perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
+    _platform: UserPermissions = Depends(require_platform_unlocked("partner_api")),
     db: AsyncSession = Depends(get_db),
 ) -> CreateApiKeyResponse:
     """Create a new partner API key."""
@@ -224,6 +236,7 @@ async def create_api_key(
 @router.get("")
 async def list_api_keys(
     perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
+    _platform: UserPermissions = Depends(require_platform_unlocked("partner_api")),
     db: AsyncSession = Depends(get_db),
 ) -> list[ApiKeyResponse]:
     """List all API keys for the caller's org."""
@@ -255,6 +268,7 @@ async def list_api_keys(
 async def get_api_key_detail(
     key_id: str,
     perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
+    _platform: UserPermissions = Depends(require_platform_unlocked("partner_api")),
     db: AsyncSession = Depends(get_db),
 ) -> ApiKeyDetailResponse:
     """Get full detail for a single API key."""
@@ -300,6 +314,7 @@ async def update_api_key(
     key_id: str,
     body: UpdateApiKeyRequest,
     perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
+    _platform: UserPermissions = Depends(require_platform_unlocked("partner_api")),
     db: AsyncSession = Depends(get_db),
 ) -> ApiKeyResponse:
     """Partial update of an API key."""
@@ -351,6 +366,7 @@ async def update_api_key(
 async def delete_api_key(
     key_id: str,
     perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
+    _platform: UserPermissions = Depends(require_platform_unlocked("partner_api")),
     db: AsyncSession = Depends(get_db),
 ) -> None:
     """Permanently delete an API key and its KB access entries."""

--- a/klai-portal/backend/tests/test_admin_api_keys_platform_gate.py
+++ b/klai-portal/backend/tests/test_admin_api_keys_platform_gate.py
@@ -1,0 +1,104 @@
+"""SPEC-PORTAL-EXTENSIONS-UNIFY-001 Phase 1 — partner_api platform-unlock gate.
+
+Pins the platform-unlock gate on all 5 /api/admin/api-keys endpoints:
+tenants without ``partner_api`` in ``platform_unlocked_features`` get 403,
+tenants with it pass through to the role gate.
+
+The actual gate is enforced by ``Depends(require_platform_unlocked("partner_api"))``.
+We test the inner ``_dep`` directly with a synthetic ``UserPermissions`` —
+the same pattern test_admin_api_keys_role_matrix.py uses for the role gate.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException, status
+
+from app.core.permissions import require_platform_unlocked
+from tests.conftest import make_perms
+
+
+class TestPartnerApiGate:
+    """Gate semantics: feature in unlocks → pass; missing → 403."""
+
+    @pytest.mark.asyncio
+    async def test_unlocked_tenant_passes_gate(self) -> None:
+        """An admin in a tenant with partner_api unlocked is allowed through."""
+        _dep = require_platform_unlocked("partner_api")
+        perms = make_perms(role="admin", platform_unlocked_features=["partner_api"])
+        # Should NOT raise.
+        result = await _dep(perms=perms)
+        assert result is perms
+
+    @pytest.mark.asyncio
+    async def test_locked_tenant_blocked_with_403(self) -> None:
+        """An admin in a tenant WITHOUT partner_api gets 403, even if other
+        unlocks are present."""
+        _dep = require_platform_unlocked("partner_api")
+        perms = make_perms(
+            role="admin",
+            platform_unlocked_features=["widgets", "custom_mcps", "scribe", "docs"],
+        )
+        with pytest.raises(HTTPException) as exc:
+            await _dep(perms=perms)
+        assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.asyncio
+    async def test_empty_unlocks_blocked_with_403(self) -> None:
+        """A tenant with no unlocks at all is blocked."""
+        _dep = require_platform_unlocked("partner_api")
+        perms = make_perms(role="admin", platform_unlocked_features=[])
+        with pytest.raises(HTTPException) as exc:
+            await _dep(perms=perms)
+        assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+
+
+class TestEndpointsHavePlatformGate:
+    """Static guard: every /api/admin/api-keys endpoint must declare the gate.
+
+    Refactor-resistance: if a future change accidentally drops the gate on
+    a single endpoint, this test catches it without needing a live HTTP
+    round-trip per endpoint.
+    """
+
+    def test_all_five_endpoints_depend_on_partner_api_unlock(self) -> None:
+        """Every router operation in admin_api_keys must include
+        require_platform_unlocked('partner_api') in its FastAPI dependencies."""
+        from app.api.admin_api_keys import router
+
+        # router.routes contains the five APIRoute objects.
+        operation_count = 0
+        for route in router.routes:
+            # Skip non-APIRoute (e.g. catch-all WebSocket routes — none here).
+            if not hasattr(route, "dependant"):
+                continue
+            operation_count += 1
+            # Each dependency tree must contain a call to require_platform_unlocked
+            # for the "partner_api" feature. We assert by walking the closure of
+            # any nested _dep functions and checking their bound feature.
+            depends_on_partner_api = _depends_on_partner_api_unlock(route.dependant)
+            assert depends_on_partner_api, (
+                f"Endpoint {route.path} ({route.methods}) is missing require_platform_unlocked('partner_api') gate"
+            )
+
+        assert operation_count == 5, f"Expected 5 /api/admin/api-keys operations, found {operation_count}"
+
+
+def _depends_on_partner_api_unlock(dependant) -> bool:
+    """Walk a FastAPI Dependant tree looking for require_platform_unlocked('partner_api')."""
+    for sub in dependant.dependencies:
+        call = sub.call
+        # The factory creates a nested function `_dep` whose closure binds
+        # the `feature` string. Inspect cell contents.
+        if getattr(call, "__name__", None) == "_dep" and getattr(call, "__closure__", None):
+            for cell in call.__closure__:
+                try:
+                    val = cell.cell_contents
+                except ValueError:
+                    continue
+                if val == "partner_api":
+                    return True
+        # Recurse to handle nested dependency trees.
+        if _depends_on_partner_api_unlock(sub):
+            return True
+    return False


### PR DESCRIPTION
## SPEC-PORTAL-EXTENSIONS-UNIFY-001 Phase 1

Closes the security gap identified during the Phase 2 scope discussion: all five `/api/admin/api-keys` endpoints (POST create, GET list, GET detail, PATCH, DELETE) now require `partner_api` in the caller org's `platform_unlocked_features` AND admin role. Previously they enforced only the admin role — any tenant-admin could mint live `pk_live_*` keys without Klai-side review.

## Implementation

- `app/api/admin_api_keys.py` — added `Depends(require_platform_unlocked("partner_api"))` next to the existing `Depends(get_caller_at_least(ProfileRole.ADMIN))` on every operation.

## Tests

- `tests/test_admin_api_keys_platform_gate.py`:
  - 3 functional tests against `require_platform_unlocked("partner_api")`: unlocked passes, locked → 403, empty unlocks → 403.
  - 1 static guard walking the FastAPI router dependant tree, asserting every one of the five operations declares the gate — catches accidental drop on a single endpoint in future PRs.

## Quality gate

- ruff check: All checks passed
- ruff format: 491 files already formatted
- pytest: **2471 passed, 3 deselected, 0 failed**

## Prod regression check

- Voys was backfilled with `partner_api` by Phase 2 migration (verified 2026-05-12 via prod psql). Voys' existing `pk_live_*` key remains accessible after this deploy.
- Getklai does not have `partner_api` unlocked, and no API keys exist for getklai — no regression there.

## Next phases

- Phase 3 — `/api/admin/extensions` GET/PATCH + `/api/me` wiring.
- Phase 4 — frontend `/admin/settings` Uitbreidingen-sectie + tenant-picker.
- Phase 5 — consistency audit + Playwright E2E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)