### PR TITLE
fix(identity-assert): accept partner_key evidence in SDK whitelist (widget chat HOTFIX)

### DIFF
--- a/klai-libs/identity-assert/klai_identity_assert/client.py
+++ b/klai-libs/identity-assert/klai_identity_assert/client.py
@@ -106,6 +106,17 @@ def _interpret_response(payload: Any) -> VerifyResult:
             "no_membership",
             "org_slug_mismatch",
             "cache_unavailable",
+            # F2 fix-forward (retrieval coupling audit 2026-05-06): partner-key
+            # paths. Portal-api denies a synthetic ``partner:<key_id>`` claim
+            # when the key row is absent (``partner_key_not_found``) or when
+            # the key exists but belongs to a different org than the claimed
+            # one (``partner_key_org_mismatch``). Both are authoritative
+            # portal-side denials — surface them with their stable code so
+            # operators can distinguish "configuration drift" from a real
+            # outage. Without this entry the SDK collapsed them to
+            # ``portal_unreachable``, which obscured the actual reject.
+            "partner_key_not_found",
+            "partner_key_org_mismatch",
         )
         if isinstance(reason, str) and reason in known:
             return VerifyResult.deny(reason)  # type: ignore[arg-type]
@@ -117,7 +128,15 @@ def _interpret_response(payload: Any) -> VerifyResult:
     evidence = body.get("evidence")
     if not isinstance(user_id, str) or not isinstance(org_id, str) or not isinstance(org_slug, str):
         return VerifyResult.deny("portal_unreachable")
-    if evidence not in ("jwt", "membership"):
+    # ``partner_key`` (F2 fix-forward 2026-05-06): synthetic ``partner:<key_id>``
+    # identities verified server-side against ``partner_api_keys``. Portal-api's
+    # IdentityVerifySuccess schema (klai-portal/backend/app/api/internal.py)
+    # declares ``evidence: Literal["jwt", "membership", "partner_key"]`` — we
+    # mirror that allowlist here so the contract stays symmetric. New evidence
+    # types from the server MUST be added here in the SAME release, otherwise
+    # the SDK fail-closes to ``portal_unreachable`` (silent partner-chat outage
+    # — see retrieve-caller-service-header-mismatch pitfall + commit comment).
+    if evidence not in ("jwt", "membership", "partner_key"):
         return VerifyResult.deny("portal_unreachable")
     return VerifyResult.allow(user_id=user_id, org_id=org_id, org_slug=org_slug, evidence=evidence)
 

--- a/klai-libs/identity-assert/pyproject.toml
+++ b/klai-libs/identity-assert/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "klai-identity-assert"
-version = "0.1.0"
+version = "0.2.0"
 description = "Shared identity-assertion helper for Klai services (SPEC-SEC-IDENTITY-ASSERT-001)."
 requires-python = ">=3.12"
 readme = "README.md"

--- a/klai-libs/identity-assert/tests/test_client.py
+++ b/klai-libs/identity-assert/tests/test_client.py
@@ -108,6 +108,129 @@ async def test_verify_returns_allow_on_membership_evidence(fake_user_id: str, fa
     await asserter.aclose()
 
 
+async def test_verify_returns_allow_on_partner_key_evidence(fake_user_id: str, fake_org_id: str) -> None:
+    """Widget / partner-API path: portal-api verifies a synthetic
+    ``partner:<key_id>`` claim against the ``partner_api_keys`` table and
+    returns ``evidence="partner_key"`` (F2 fix-forward, retrieval coupling
+    audit 2026-05-06). The SDK MUST accept this evidence value just like
+    ``"jwt"`` / ``"membership"``; without it the synthetic partner claim
+    collapses to ``portal_unreachable`` and every widget chat returns 403.
+    See pitfalls/process-rules.md → retrieve-caller-service-header-mismatch.
+    """
+
+    transport = _mock_portal(
+        body={
+            "verified": True,
+            "user_id": "partner:wgt_47b8c9c46d10b17c527923e0a5454bef3285b71f",
+            "org_id": fake_org_id,
+            "org_slug": "acme",
+            "cache_ttl_seconds": 60,
+            "evidence": "partner_key",
+        },
+    )
+    asserter = await _build_asserter(transport)
+
+    result = await asserter.verify(
+        caller_service="portal-api",
+        claimed_user_id="partner:wgt_47b8c9c46d10b17c527923e0a5454bef3285b71f",
+        claimed_org_id=fake_org_id,
+        bearer_jwt=None,
+    )
+
+    assert result.verified is True
+    assert result.user_id == "partner:wgt_47b8c9c46d10b17c527923e0a5454bef3285b71f"
+    assert result.org_id == fake_org_id
+    assert result.org_slug == "acme"
+    assert result.evidence == "partner_key"
+    assert result.cached is False
+    await asserter.aclose()
+
+
+async def test_verify_returns_deny_on_partner_key_not_found(fake_user_id: str, fake_org_id: str) -> None:
+    """Portal-side authoritative deny: the ``partner_api_keys`` row for the
+    claimed key_id does not exist (revoked, never provisioned, typo). The
+    SDK MUST surface ``partner_key_not_found`` with its stable code so
+    operators can distinguish configuration drift from a real outage —
+    not collapse to ``portal_unreachable``.
+    """
+
+    transport = _mock_portal(
+        status_code=403,
+        body={"verified": False, "reason": "partner_key_not_found"},
+    )
+    asserter = await _build_asserter(transport)
+
+    result = await asserter.verify(
+        caller_service="portal-api",
+        claimed_user_id="partner:wgt_does_not_exist",
+        claimed_org_id=fake_org_id,
+        bearer_jwt=None,
+    )
+
+    assert result.verified is False
+    assert result.reason == "partner_key_not_found"
+    await asserter.aclose()
+
+
+async def test_verify_returns_deny_on_partner_key_org_mismatch(fake_user_id: str, other_org_id: str) -> None:
+    """Portal-side authoritative deny: the partner key exists but belongs to
+    a different org than the one the caller claimed. Cross-tenant defence
+    — distinct stable code so it shows up as a security signal in logs,
+    not as ``portal_unreachable`` noise.
+    """
+
+    transport = _mock_portal(
+        status_code=403,
+        body={"verified": False, "reason": "partner_key_org_mismatch"},
+    )
+    asserter = await _build_asserter(transport)
+
+    result = await asserter.verify(
+        caller_service="portal-api",
+        claimed_user_id="partner:wgt_belongs_to_other_org",
+        claimed_org_id=other_org_id,
+        bearer_jwt=None,
+    )
+
+    assert result.verified is False
+    assert result.reason == "partner_key_org_mismatch"
+    await asserter.aclose()
+
+
+async def test_unrecognised_evidence_still_collapses_to_portal_unreachable(
+    fake_user_id: str, fake_org_id: str
+) -> None:
+    """Fail-closed regression: an evidence value not in the SDK allowlist
+    MUST still collapse to ``portal_unreachable``. This prevents a future
+    server-side evidence type from silently allowing through without an
+    explicit SDK update — the contract is symmetric and intentionally
+    strict (see commit comment in _interpret_response).
+    """
+
+    transport = _mock_portal(
+        body={
+            "verified": True,
+            "user_id": fake_user_id,
+            "org_id": fake_org_id,
+            "org_slug": "acme",
+            "cache_ttl_seconds": 60,
+            "evidence": "some_future_evidence_we_do_not_know",
+        },
+    )
+    asserter = await _build_asserter(transport)
+
+    result = await asserter.verify(
+        caller_service="scribe",
+        claimed_user_id=fake_user_id,
+        claimed_org_id=fake_org_id,
+        bearer_jwt=None,
+    )
+
+    assert result.verified is False
+    assert result.reason == "portal_unreachable"
+    await asserter.aclose()
+
+
 async def test_verify_returns_deny_on_no_membership(fake_user_id: str, other_org_id: str) -> None:
     transport = _mock_portal(
         status_code=403,


### PR DESCRIPTION
## Production widget chat is broken — this PR fixes it

`getklai.com` widget returns *"Er ging iets mis. Probeer het opnieuw."* on every send. Root cause is an SDK/server contract gap exposed by #550 (SPEC-SEC-IDENTITY-ASSERT-003).

### Symptom (VictoriaLogs evidence)

For request_id `08dfc6a7-23bf-406c-ab13-7e9a58ff5cb8` (representative of every failing widget call today):

| Hop | Result |
|---|---|
| widget → portal-api `/partner/v1/chat/completions` | OK |
| portal-api → retrieval-api `/retrieve` (`X-Caller-Service: portal-api`, `user_id: partner:<key_id>`) | `auth_accepted, auth_method=internal` |
| retrieval-api → portal-api `/internal/identity/verify` | **`verified=false, reason=portal_unreachable`** |
| retrieval-api → portal-api | 403 → portal-api raises `HTTPStatusError` |

LibreChat path (`caller_service: litellm`, real Zitadel user_ids) keeps working — `evidence: membership, verified: true`.

### Root cause

- Portal-api's `IdentityVerifySuccess` schema declares `evidence: Literal["jwt", "membership", "partner_key"]` since the F2 fix-forward (retrieval coupling audit 2026-05-06).
- SDK-side `_interpret_response` in `klai_identity_assert/client.py:120` only allowlisted `("jwt", "membership")`.
- Result: every authoritative `evidence="partner_key"` response from portal-api collapsed to `VerifyResult.deny("portal_unreachable")`.
- #550 made retrieval-api membership-authoritative on `/retrieve`, exposing the gap for the first time on the widget/partner pad.

### Fix

1. Allow `evidence in ("jwt", "membership", "partner_key")` in `_interpret_response`.
2. Recognise the two authoritative deny codes (`partner_key_not_found`, `partner_key_org_mismatch`) so operators see the real reason instead of generic `portal_unreachable` noise.
3. Version bump `0.1.0 → 0.2.0` (new accepted evidence value).
4. Tests:
   - `test_verify_returns_allow_on_partner_key_evidence` — positive case
   - `test_verify_returns_deny_on_partner_key_not_found`
   - `test_verify_returns_deny_on_partner_key_org_mismatch`
   - `test_unrecognised_evidence_still_collapses_to_portal_unreachable` — fail-closed regression guard

Local: `33 passed in 0.19s`.

### Why this does NOT weaken the hardening

- Portal-api remains **authoritative** for the `partner_key` principal: it validates the `partner_api_keys` row exists, is not revoked, and belongs to the claimed `org_id` (per F2 fix-forward in `klai-portal/backend/app/api/internal.py`). The SDK-side allowlist is a defensive contract mirror — it only accepts what portal-api already verified.
- Truly-unknown evidence values still collapse to `portal_unreachable` (regression test guards this).
- `caller_service` allowlist unchanged.
- `Authorization: Bearer <internal_secret>` requirement unchanged.
- Rate limiting, cache TTLs, fail-closed semantics unchanged.

### Deploy impact

- `klai-libs/identity-assert/**` is in the trigger path for `.github/workflows/retrieval-api.yml` → image rebuild + deploy happens automatically on merge.
- Portal-api does NOT import `klai_identity_assert` at runtime (only documentary comments), so no portal-api deploy needed.
- klai-connector workflow does NOT auto-trigger on this path (gap, separate follow-up); not blocking for widget chat which goes through retrieval-api.

### Post-merge verification

VictoriaLogs query within minutes after deploy:

```
service:retrieval-api AND event:identity_assert_call
  AND caller_service:portal-api AND verified:true AND evidence:partner_key
```

Plus live test on `https://getklai.com` STEP 3 chat widget.

### Bijvangst (separate follow-up PR)

Same request trace shows `klai-retrieval-api/retrieval_api/services/rate_limit.py:47` raises `ValueError: Port could not be cast to integer value as 'hPKBf'` on Redis pool init (rate limiter degrades gracefully, not blocking). Known pitfall `redis-url-password-must-be-parsed-manually` — fix in a separate PR.

Refs:
- SPEC-SEC-IDENTITY-ASSERT-001 (F2 fix-forward 2026-05-06)
- SPEC-SEC-IDENTITY-ASSERT-003 (#550 db8922b9)
- Pitfall: `retrieve-caller-service-header-mismatch` (process-rules.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)