### PR TITLE
fix(klai-docs): preserve emphasis on text-runs with leading/trailing whitespace

### DIFF
--- a/klai-docs/lib/blocknote-markdown.ts
+++ b/klai-docs/lib/blocknote-markdown.ts
@@ -198,13 +198,28 @@ function renderInline(
 }
 
 function applyStyles(text: string, styles: Record<string, boolean | string>): string {
-  let value = text;
+  if (!text) return text;
+
+  const hasStyle =
+    styles.code || styles.bold || styles.italic || styles.strike || styles.underline;
+  if (!hasStyle) return text;
+
+  // Markdown emphasis markers cannot have whitespace between the marker and the
+  // wrapped content: "** foo **" renders as literal asterisks, "**foo**" renders
+  // bold. Pull leading/trailing whitespace out of the styled span so the run
+  // still renders with emphasis even when authors include surrounding spaces in
+  // the BlockNote text-run (a common shape produced by the editor itself).
+  const match = text.match(/^(\s*)([\s\S]*?)(\s*)$/);
+  if (!match || !match[2]) return text;
+  const [, leading, core, trailing] = match;
+
+  let value = core;
   if (styles.code) value = `\`${value.replace(/`/g, "\\`")}\``;
   if (styles.bold) value = `**${value}**`;
   if (styles.italic) value = `_${value}_`;
   if (styles.strike) value = `~~${value}~~`;
   if (styles.underline) value = `<u>${value}</u>`;
-  return value;
+  return `${leading}${value}${trailing}`;
 }
 
 function extractPlainText(content: InlineContent[] | string | undefined): string {

--- a/klai-docs/tests/blocknote-markdown.test.ts
+++ b/klai-docs/tests/blocknote-markdown.test.ts
@@ -77,4 +77,52 @@ describe("blockNoteJsonToMarkdown", () => {
     expect(blockNoteJsonToMarkdown("## Legacy markdown")).toBeNull();
     expect(blockNoteJsonToMarkdown("[not json")).toBeNull();
   });
+
+  it("moves whitespace out of bold/italic/strike/underline/code runs so emphasis still renders", () => {
+    const content = JSON.stringify([
+      {
+        type: "paragraph",
+        content: [
+          { type: "text", text: "If you are a Chat user, you have access to", styles: {} },
+          { type: "text", text: " File upload", styles: { bold: true } },
+          { type: "text", text: " and ", styles: {} },
+          { type: "text", text: "URL crawler only", styles: { bold: true } },
+          { type: "text", text: ". Trailing space ", styles: { italic: true } },
+          { type: "text", text: "inline.", styles: {} },
+        ],
+        children: [],
+      },
+    ]);
+
+    const markdown = blockNoteJsonToMarkdown(content);
+
+    // Bold renders even with a leading space in the run (space moved outside the markers)
+    expect(markdown).toContain("to **File upload** and **URL crawler only**");
+    // Trailing space stays OUTSIDE the italic markers so emphasis still renders;
+    // escapeMarkdown turns "." into "\.". Resulting fragment: _\. Trailing space_ inline\.
+    expect(markdown).toContain("**URL crawler only**_\\. Trailing space_ inline\\.");
+    // The original bug shape — opening marker glued to whitespace — must not reappear.
+    // (Closing "**" followed by a space is fine: "**bold** word".)
+    expect(markdown).not.toContain("** File upload");
+    expect(markdown).not.toContain("** Trailing space");
+  });
+
+  it("leaves all-whitespace styled runs as plain text (no empty emphasis markers)", () => {
+    const content = JSON.stringify([
+      {
+        type: "paragraph",
+        content: [
+          { type: "text", text: "before", styles: {} },
+          { type: "text", text: "   ", styles: { bold: true } },
+          { type: "text", text: "after", styles: {} },
+        ],
+        children: [],
+      },
+    ]);
+
+    const markdown = blockNoteJsonToMarkdown(content);
+
+    expect(markdown).toBe("before   after");
+    expect(markdown).not.toContain("**");
+  });
 });


### PR DESCRIPTION
## Problem

BlockNote stores text-runs with whitespace baked into `.text` — e.g. `" File upload"` with `styles.bold = true`. The SSR markdown serializer wrapped this verbatim into `** File upload**`, which markdown renders as **literal asterisks** because emphasis markers may not be adjacent to whitespace.

Discovered live on `org-getklai/klai-help/build-a-knowledge-base.md`:

```
Before (rendered HTML):
... access to** File upload** and <strong>URL crawler only</strong> ...

After:
... access to <strong>File upload</strong> and <strong>URL crawler only</strong> ...
```

Scan across all 14 pages of `klai-help` showed exactly 1 instance — the content
itself has already been fixed in Gitea (commit `36a77ce` in
`org-getklai/klai-help`). This PR fixes the pipeline so authors can keep
inserting whitespace-prefixed bold runs (which is the natural BlockNote
authoring shape) without breaking rendering on the public reader.

## Fix

`applyStyles` now:
1. Detects whether any style is applied (early-return preserves prior behaviour for plain runs).
2. Splits the text-run into `leading / core / trailing` whitespace partitions.
3. Wraps `core` with emphasis markers.
4. Re-attaches `leading` and `trailing` whitespace **outside** the markers.

All-whitespace runs short-circuit (no `** **` emission).

## Scope

- **klai-docs SSR reader (public `/docs/...`)** — affected, now fixed.
- **klai-portal SPA editor** — unaffected. The editor renders directly from the BlockNote JSON tree and never goes through this markdown converter.

## Tests

Added two cases to `klai-docs/tests/blocknote-markdown.test.ts`:
- Leading/trailing whitespace in bold + italic runs renders with markers intact.
- All-whitespace styled run produces no emphasis markers.

```
✓ tests/blocknote-markdown.test.ts (5 tests) 1ms
  Tests  5 passed (5)
```

## Verification plan

- CI: `gh run watch` on this PR
- Post-merge: `curl -s https://getklai.getklai.com/docs/klai-help/build-a-knowledge-base | grep -oE "If you are a Chat user.{0,180}"` — expect both bold spans wrapped in `<strong>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)