### PR TITLE
hotfix(widget-chat): reject non-UUID partner_key_id pre-DB + skip synthetic claim for widget (LAUNCH DAY)

### DIFF
--- a/klai-portal/backend/app/api/partner.py
+++ b/klai-portal/backend/app/api/partner.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Literal
 
@@ -186,6 +187,29 @@ async def chat_completions(
     # `knowledge.queried` product_event with the correct (org, partner-key)
     # tuple. Matches the existing convention used at line ~205 below for
     # write_retrieval_log.
+    #
+    # 2026-05-12 HOTFIX (chat-widget-launch-day): the F2 claim only resolves
+    # correctly when ``auth.key_id`` is a partner_api_keys UUID. Widget-driven
+    # calls authenticate via the widgets table (separate domain — see
+    # klai-portal/backend/app/models/widgets.py) and ``auth.key_id`` carries a
+    # ``wgt_<hex>`` identifier that is NOT a UUID. Forwarding it as
+    # ``partner:<wgt_id>`` made retrieval-api's identity-assert call portal-api's
+    # ``_resolve_partner_key_org_slug``, which SELECTed against
+    # ``partner_api_keys.id`` (uuid column) and asyncpg raised DataError →
+    # portal-api 5xx → SDK collapsed to ``portal_unreachable`` → 403 on
+    # /retrieve → widget chat showed "Er ging iets mis". Only forward the
+    # claim when it is parseable as a UUID; the widget path falls back to
+    # tenant-only verification at retrieval-api (already correct via the
+    # X-Internal-Secret + caller_service:portal-api contract). Product-event
+    # tagging on widget retrieval reverts to None until a dedicated
+    # ``evidence:"widget_key"`` path exists in identity-assert (follow-up
+    # SPEC). See pitfalls/process-rules.md → retrieve-caller-service-header-mismatch.
+    partner_user_id: str | None
+    try:
+        uuid.UUID(str(auth.key_id))
+        partner_user_id = f"partner:{auth.key_id}"
+    except (ValueError, AttributeError, TypeError):
+        partner_user_id = None
     try:
         chunks, system_prompt = await retrieve_context(
             org_id=auth.org_id,
@@ -193,7 +217,7 @@ async def chat_completions(
             kb_slugs=kb_slugs,
             messages=request.messages,
             settings=settings,
-            partner_user_id=f"partner:{auth.key_id}",
+            partner_user_id=partner_user_id,
         )
     except (httpx.TimeoutException, httpx.ReadTimeout) as exc:
         raise HTTPException(

--- a/klai-portal/backend/app/services/identity_verifier.py
+++ b/klai-portal/backend/app/services/identity_verifier.py
@@ -407,6 +407,8 @@ async def _resolve_partner_key_org_slug(
     F2 fix-forward (retrieval coupling audit 2026-05-06).
     """
 
+    import uuid as _uuid
+
     from sqlalchemy.exc import DataError
 
     from app.models.partner_api_keys import PartnerAPIKey
@@ -415,6 +417,23 @@ async def _resolve_partner_key_org_slug(
     # the DB. Fast reject saves a query on obviously-malformed inputs and
     # avoids forwarding garbage into asyncpg's UUID parser.
     if not partner_key_id or len(partner_key_id) > 64:
+        return None, "partner_key_not_found"
+
+    # 2026-05-12 HOTFIX (chat-widget-launch-day): assert partner_key_id parses
+    # as a UUID BEFORE hitting the DB. ``PartnerAPIKey.id`` is a uuid column
+    # so any non-UUID input (e.g. widget callers that authenticate via the
+    # ``widgets`` table and forward ``wgt_<hex>`` strings) is a guaranteed
+    # miss — but if we let asyncpg attempt the bind, it raises
+    # ``asyncpg.exceptions.DataError`` which SQLAlchemy wraps as
+    # ``DBAPIError`` (NOT ``DataError``). The narrow ``except DataError``
+    # below was therefore bypassed and the exception bubbled to a 5xx — the
+    # SDK collapsed it to ``portal_unreachable``, which masked every widget
+    # chat call as "Er ging iets mis". Fail-fast here keeps the contract
+    # surface ("partner_key_not_found") and avoids a server crash.
+    try:
+        _uuid.UUID(partner_key_id)
+    except (ValueError, AttributeError, TypeError):
+        logger.info("identity_verify_partner_non_uuid_key_id")
         return None, "partner_key_not_found"
 
     # partner_api_keys is RLS Category-B — SELECT works without tenant

--- a/klai-portal/backend/tests/test_identity_verifier.py
+++ b/klai-portal/backend/tests/test_identity_verifier.py
@@ -647,14 +647,14 @@ class TestPartnerKeyPath:
             db=mock_db,
             jwks_resolver=_FakeJwksResolver(),
             caller_service="portal-api",
-            claimed_user_id="partner:abc-123",
+            claimed_user_id="partner:11111111-1111-1111-1111-111111111111",
             claimed_org_id="zitadel-org-acme",
             bearer_jwt=None,
         )
 
         assert decision.verified is True
         assert decision.evidence == "partner_key"
-        assert decision.user_id == "partner:abc-123"
+        assert decision.user_id == "partner:11111111-1111-1111-1111-111111111111"
         assert decision.org_id == "zitadel-org-acme"
         assert decision.org_slug == "acme"
 
@@ -667,7 +667,7 @@ class TestPartnerKeyPath:
             db=mock_db,
             jwks_resolver=_FakeJwksResolver(),
             caller_service="portal-api",
-            claimed_user_id="partner:does-not-exist",
+            claimed_user_id="partner:22222222-2222-2222-2222-222222222222",
             claimed_org_id="zitadel-org-acme",
             bearer_jwt=None,
         )
@@ -688,7 +688,7 @@ class TestPartnerKeyPath:
             db=mock_db,
             jwks_resolver=_FakeJwksResolver(),
             caller_service="portal-api",
-            claimed_user_id="partner:abc-123",
+            claimed_user_id="partner:11111111-1111-1111-1111-111111111111",
             claimed_org_id="zitadel-org-victim",  # forged claim
             bearer_jwt=None,
         )
@@ -704,7 +704,7 @@ class TestPartnerKeyPath:
             db=mock_db,
             jwks_resolver=_FakeJwksResolver(),
             caller_service="knowledge-mcp",  # NOT portal-api
-            claimed_user_id="partner:abc-123",
+            claimed_user_id="partner:11111111-1111-1111-1111-111111111111",
             claimed_org_id="zitadel-org-acme",
             bearer_jwt=None,
         )
@@ -712,6 +712,30 @@ class TestPartnerKeyPath:
         assert decision.verified is False
         assert decision.reason == "partner_key_not_found"
         # No DB call should have happened on the gating reject.
+        mock_db.execute.assert_not_called()
+
+    async def test_deny_when_partner_key_id_not_uuid(self, mock_db: AsyncMock) -> None:
+        """2026-05-12 HOTFIX guard: a partner_key_id that is not a UUID (e.g.
+        the widget-id ``wgt_<hex>`` accidentally forwarded as a synthetic
+        partner claim) MUST be rejected pre-DB with ``partner_key_not_found``.
+        Otherwise asyncpg raises DataError, SQLAlchemy wraps it as
+        DBAPIError (not DataError), the narrow except is bypassed, the
+        endpoint 5xx's, and the SDK collapses to ``portal_unreachable`` —
+        masking every widget chat call as a generic "Er ging iets mis"
+        outage. Pre-check is fail-fast + fail-safe.
+        """
+        decision = await verify_identity_claim(
+            db=mock_db,
+            jwks_resolver=_FakeJwksResolver(),
+            caller_service="portal-api",
+            claimed_user_id="partner:wgt_47b8c9c46d10b17c527923e0a5454bef3285b71f",
+            claimed_org_id="zitadel-org-acme",
+            bearer_jwt=None,
+        )
+
+        assert decision.verified is False
+        assert decision.reason == "partner_key_not_found"
+        # No DB call must have happened on the gating reject.
         mock_db.execute.assert_not_called()
 
     async def test_deny_when_malformed_key_length(self, mock_db: AsyncMock) -> None:
@@ -736,7 +760,7 @@ class TestPartnerKeyPath:
             db=mock_db,
             jwks_resolver=_FakeJwksResolver(),
             caller_service="portal-api",
-            claimed_user_id="partner:abc-123",
+            claimed_user_id="partner:11111111-1111-1111-1111-111111111111",
             claimed_org_id="zitadel-org-acme",
             bearer_jwt="some.jwt.value",
         )
@@ -765,7 +789,7 @@ class TestPartnerKeyPath:
             db=mock_db,
             jwks_resolver=_FakeJwksResolver(),
             caller_service="portal-api",
-            claimed_user_id="partner:not-a-uuid",
+            claimed_user_id="partner:33333333-3333-3333-3333-333333333333",
             claimed_org_id="zitadel-org-acme",
             bearer_jwt=None,
         )
@@ -793,7 +817,7 @@ class TestPartnerKeyPath:
                 db=mock_db,
                 jwks_resolver=_FakeJwksResolver(),
                 caller_service="portal-api",
-                claimed_user_id="partner:abc-123",
+                claimed_user_id="partner:11111111-1111-1111-1111-111111111111",
                 claimed_org_id="zitadel-org-acme",
                 bearer_jwt=None,
             )
@@ -809,7 +833,7 @@ class TestPartnerKeyPath:
             db=mock_db,
             jwks_resolver=_FakeJwksResolver(),
             caller_service="portal-api",
-            claimed_user_id="partner:abc-123",
+            claimed_user_id="partner:11111111-1111-1111-1111-111111111111",
             claimed_org_id="zitadel-org-acme",
             bearer_jwt=None,
             claimed_org_slug="impostor-slug",
@@ -829,7 +853,7 @@ class TestPartnerKeyPath:
             db=mock_db,
             jwks_resolver=_FakeJwksResolver(),
             caller_service="portal-api",
-            claimed_user_id="partner:abc-123",
+            claimed_user_id="partner:11111111-1111-1111-1111-111111111111",
             claimed_org_id="zitadel-org-acme",
             bearer_jwt=None,
             claimed_org_slug=None,


### PR DESCRIPTION
Hotfix for widget chat on getklai.com — see commit message for full details. Sibling to #587 (lib-side allowlist) which was necessary but not sufficient. Validated in prod logs: portal-api was crashing on widget-id (wgt_<hex>) being matched against partner_api_keys.id (uuid). Tests 38/38 local. Merging admin.