### PR TITLE
feat(portal): SPEC-PORTAL-EXTENSIONS-UNIFY-001 Phase 3 — extensions API + /api/me wiring

### DIFF
--- a/klai-portal/backend/app/api/admin/__init__.py
+++ b/klai-portal/backend/app/api/admin/__init__.py
@@ -44,6 +44,7 @@ def _require_platform_admin(caller_org: "PortalOrg") -> None:
 # --- Sub-router inclusion (no prefix on sub-routers!) ---
 from .audit import router as audit_router  # noqa: E402
 from .deprovision_org import router as deprovision_org_router  # noqa: E402
+from .extensions import router as extensions_router  # noqa: E402
 from .join_requests import router as join_requests_router  # noqa: E402
 from .platform_unlocks import router as platform_unlocks_router  # noqa: E402
 from .products import router as products_router  # noqa: E402
@@ -59,6 +60,7 @@ router.include_router(join_requests_router)
 router.include_router(retry_provisioning_router)
 router.include_router(deprovision_org_router)
 router.include_router(platform_unlocks_router)
+router.include_router(extensions_router)
 
 __all__ = [
     "_require_platform_admin",

--- a/klai-portal/backend/app/api/admin/extensions.py
+++ b/klai-portal/backend/app/api/admin/extensions.py
@@ -1,0 +1,222 @@
+"""SPEC-PORTAL-EXTENSIONS-UNIFY-001 Phase 3 — tenant extensions API.
+
+Two endpoints power the new ``/admin/settings`` Uitbreidingen-sectie:
+
+- ``GET /api/admin/extensions`` — returns the full known-features list with
+  per-feature on/off status for the caller's own org (admin role required).
+  When called by a platform-admin (Klai staff), an optional ``?org_slug=…``
+  parameter switches the view to another tenant.
+- ``PATCH /api/admin/extensions`` — replaces a tenant's
+  ``platform_unlocked_features`` set. Platform-admin-only.
+
+The PATCH delegates to the same persistence + audit path as
+``platform_unlocks.py::patch_platform_unlocks`` so there is one shared
+write path with a uniform ``tenant_lifecycle_events`` trail.
+"""
+
+from __future__ import annotations
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.admin.platform_unlocks import _KNOWN_FEATURES
+from app.core.database import get_db
+from app.core.features import FEATURE_MIN_PROFILE
+from app.core.permissions import ProfileRole, UserPermissions, get_caller_at_least
+from app.models.portal import PortalOrg
+from app.services.audit.tenant_lifecycle import emit_lifecycle_event
+
+logger = structlog.get_logger()
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Display registry — labels + descriptions per known feature.
+# ---------------------------------------------------------------------------
+
+_EXTENSION_LABELS: dict[str, str] = {
+    "partner_api": "API keys",
+    "widgets": "Chat-widgets",
+    "custom_mcps": "Custom MCP servers",
+    "scribe": "Scribe — meeting-transcripties",
+    "docs": "Docs — gedeelde KBs",
+}
+
+_EXTENSION_DESCRIPTIONS: dict[str, str] = {
+    "partner_api": "Programmatische toegang via pk_live_* API-keys.",
+    "widgets": "Embed chat-widget op klant-website.",
+    "custom_mcps": "Eigen Model Context Protocol servers koppelen.",
+    "scribe": "Automatische meeting-transcriptie.",
+    "docs": "Documentatie-KBs delen binnen de organisatie.",
+}
+
+
+# ---------------------------------------------------------------------------
+# Pydantic schemas
+# ---------------------------------------------------------------------------
+
+
+class ExtensionItem(BaseModel):
+    key: str
+    label: str
+    description: str
+    enabled: bool
+    requires_profile: str | None
+    manageable_by_caller: bool
+
+
+class ExtensionsResponse(BaseModel):
+    org_slug: str
+    extensions: list[ExtensionItem]
+
+
+class UpdateExtensionsRequest(BaseModel):
+    org_slug: str
+    enabled_features: list[str]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _resolve_target_org(
+    perms: UserPermissions,
+    org_slug: str | None,
+    db: AsyncSession,
+) -> PortalOrg:
+    """Resolve target org. Without slug, returns caller's own org. With slug,
+    requires platform-admin and looks up by slug."""
+    if org_slug is None:
+        result = await db.execute(select(PortalOrg).where(PortalOrg.id == perms.org_id, PortalOrg.deleted_at.is_(None)))
+        org = result.scalar_one_or_none()
+        if org is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Organisation not found")
+        return org
+
+    if not perms.is_platform_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Cross-org queries require platform admin",
+        )
+
+    result = await db.execute(select(PortalOrg).where(PortalOrg.slug == org_slug, PortalOrg.deleted_at.is_(None)))
+    org = result.scalar_one_or_none()
+    if org is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Organisation not found")
+    return org
+
+
+def _build_extensions_payload(org: PortalOrg, perms: UserPermissions) -> ExtensionsResponse:
+    """Build the response payload for a given target org + caller perms."""
+    unlocked = set(org.platform_unlocked_features or [])
+    items: list[ExtensionItem] = []
+    for key in sorted(_KNOWN_FEATURES):
+        items.append(
+            ExtensionItem(
+                key=key,
+                label=_EXTENSION_LABELS.get(key, key),
+                description=_EXTENSION_DESCRIPTIONS.get(key, ""),
+                enabled=key in unlocked,
+                requires_profile=FEATURE_MIN_PROFILE.get(key),
+                manageable_by_caller=perms.is_platform_admin,
+            )
+        )
+    return ExtensionsResponse(org_slug=org.slug, extensions=items)
+
+
+# ---------------------------------------------------------------------------
+# GET /api/admin/extensions
+# ---------------------------------------------------------------------------
+
+
+@router.get("/extensions", response_model=ExtensionsResponse)
+async def list_extensions(
+    org_slug: str | None = None,
+    perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
+    db: AsyncSession = Depends(get_db),
+) -> ExtensionsResponse:
+    """Return all known extensions with on/off status for the target org.
+
+    Without ``org_slug``: returns the caller's own org. With ``org_slug``:
+    requires ``is_platform_admin`` and returns the named tenant. Tenant
+    admins who attempt a cross-org query get 403.
+    """
+    target = await _resolve_target_org(perms, org_slug, db)
+    return _build_extensions_payload(target, perms)
+
+
+# ---------------------------------------------------------------------------
+# PATCH /api/admin/extensions
+# ---------------------------------------------------------------------------
+
+
+@router.patch("/extensions", response_model=ExtensionsResponse)
+async def update_extensions(
+    body: UpdateExtensionsRequest,
+    perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
+    db: AsyncSession = Depends(get_db),
+) -> ExtensionsResponse:
+    """Replace the platform_unlocked_features set for the target org.
+
+    Platform-admin only — tenant admins always get 403 here, even on their
+    own org. This is intentional per the SPEC: extension toggling is a
+    Klai-staff decision, not a tenant-admin self-service action.
+
+    Body payload mirrors the existing
+    ``/api/admin/orgs/{slug}/platform-unlocks`` PATCH — same write path,
+    same ``tenant_lifecycle_events`` audit trail, different URL shape that
+    fits the frontend's tenant-picker UX.
+    """
+    if not perms.is_platform_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Extension management requires platform admin",
+        )
+
+    # Validate every requested feature against the known-features registry.
+    unknown = [k for k in body.enabled_features if k not in _KNOWN_FEATURES]
+    if unknown:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unknown feature(s): {sorted(unknown)}. Valid: {sorted(_KNOWN_FEATURES)}",
+        )
+
+    target = await _resolve_target_org(perms, body.org_slug, db)
+    previous = list(target.platform_unlocked_features or [])
+    new_features = sorted(set(body.enabled_features))
+
+    target.platform_unlocked_features = new_features  # type: ignore[assignment]
+
+    # Audit-trail in the same transaction so the write + audit either both
+    # succeed or both roll back. tenant_lifecycle_events has no FK to
+    # portal_orgs so the audit row survives a hard-delete by design.
+    await emit_lifecycle_event(
+        db,
+        event_type="platform_features_updated",
+        org_id_snapshot=target.id,
+        org_slug_snapshot=target.slug,
+        org_name_snapshot=target.name,
+        actor_user_id=perms.user_id,
+        actor_type="platform_admin",
+        properties={
+            "previous_features": previous,
+            "new_features": new_features,
+            "via": "extensions_api",
+        },
+    )
+
+    await db.commit()
+
+    logger.info(
+        "extensions_updated",
+        target_slug=target.slug,
+        previous=previous,
+        new=new_features,
+        actor_user_id=perms.user_id,
+    )
+    return _build_extensions_payload(target, perms)

--- a/klai-portal/backend/app/api/admin/platform_unlocks.py
+++ b/klai-portal/backend/app/api/admin/platform_unlocks.py
@@ -29,7 +29,11 @@ router = APIRouter()
 
 # Recognised platform-locked feature identifiers.
 # Any string is technically valid, but these are the documented values.
-_KNOWN_FEATURES = frozenset({"partner_api", "widgets", "custom_mcps"})
+# SPEC-PORTAL-EXTENSIONS-UNIFY-001 (2026-05-12): scribe and docs joined this
+# set when the dual-track gating was unified — they are still user-facing
+# products (FEATURE_MIN_PROFILE entry "company"), but their on/off toggle
+# is now Klai-staff-only like the rest.
+_KNOWN_FEATURES = frozenset({"partner_api", "widgets", "custom_mcps", "scribe", "docs"})
 
 
 # ---------------------------------------------------------------------------

--- a/klai-portal/backend/app/api/me.py
+++ b/klai-portal/backend/app/api/me.py
@@ -57,6 +57,12 @@ class MeResponse(BaseModel):
     effective_role: str = "personal"
     effective_capabilities: list[str] = []
     org_found: bool = False
+    # SPEC-PORTAL-EXTENSIONS-UNIFY-001 Phase 3: expose the gating state to
+    # the frontend so /admin/index.tsx can filter tiles per tenant and
+    # /admin/settings can render the read-only status list. Platform-admin
+    # callers (Klai staff) additionally see the tenant-picker.
+    is_platform_admin: bool = False
+    platform_unlocked_features: list[str] = []
 
 
 def _extract_roles(info: dict) -> list[str]:
@@ -175,6 +181,8 @@ async def me(
         effective_role=_eff_role,
         effective_capabilities=_capabilities,
         org_found=org_found,
+        is_platform_admin=perms.is_platform_admin if perms is not None else False,
+        platform_unlocked_features=sorted(perms.platform_unlocked_features) if perms is not None else [],
     )
 
 

--- a/klai-portal/backend/tests/test_admin_extensions.py
+++ b/klai-portal/backend/tests/test_admin_extensions.py
@@ -1,0 +1,139 @@
+"""SPEC-PORTAL-EXTENSIONS-UNIFY-001 Phase 3 — /api/admin/extensions endpoint.
+
+Tests the new unified extensions API used by /admin/settings UI:
+- GET (own-org) — admin returns full feature list with status.
+- GET (cross-org) — platform-admin only; tenant-admin → 403.
+- PATCH (cross-org) — platform-admin only; tenant-admin → 403.
+- PATCH validates unknown features (400) and persists to platform_unlocked_features.
+- Audit event ``platform_features_updated`` emitted via tenant_lifecycle_events.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException, status
+
+from app.api.admin.extensions import (
+    UpdateExtensionsRequest,
+    list_extensions,
+    update_extensions,
+)
+from tests.conftest import make_org, make_perms
+
+
+def _db_with_org(org: MagicMock) -> AsyncMock:
+    """Mock AsyncSession that returns the given org on `.execute().scalar_one_or_none()`."""
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none = MagicMock(return_value=org)
+    db.execute = AsyncMock(return_value=result)
+    db.commit = AsyncMock()
+    return db
+
+
+class TestListExtensionsOwnOrg:
+    """Tenant-admin sees own-org extensions, read-only."""
+
+    @pytest.mark.asyncio
+    async def test_returns_full_known_features_list(self) -> None:
+        perms = make_perms(role="admin", org_id=42, platform_unlocked_features=["scribe", "docs"])
+        org = make_org(org_id=42, slug="acme", platform_unlocked_features=["scribe", "docs"])
+        db = _db_with_org(org)
+
+        result = await list_extensions(org_slug=None, perms=perms, db=db)
+        keys = {item.key for item in result.extensions}
+        assert keys == {"partner_api", "widgets", "custom_mcps", "scribe", "docs"}
+        enabled = {item.key for item in result.extensions if item.enabled}
+        assert enabled == {"scribe", "docs"}
+
+    @pytest.mark.asyncio
+    async def test_tenant_admin_cannot_query_other_org(self) -> None:
+        perms = make_perms(role="admin", org_id=42, is_platform_admin=False)
+        db = AsyncMock()
+        with pytest.raises(HTTPException) as exc:
+            await list_extensions(org_slug="some-other-tenant", perms=perms, db=db)
+        assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.asyncio
+    async def test_manageable_by_caller_false_for_tenant_admin(self) -> None:
+        perms = make_perms(role="admin", org_id=42, is_platform_admin=False)
+        org = make_org(org_id=42, slug="acme")
+        db = _db_with_org(org)
+        result = await list_extensions(org_slug=None, perms=perms, db=db)
+        for item in result.extensions:
+            assert item.manageable_by_caller is False
+
+
+class TestListExtensionsPlatformAdmin:
+    """Platform-admin can query any org by slug."""
+
+    @pytest.mark.asyncio
+    async def test_platform_admin_can_query_other_org(self) -> None:
+        perms = make_perms(role="admin", org_id=1, is_platform_admin=True)
+        target_org = make_org(org_id=42, slug="voys", platform_unlocked_features=["partner_api"])
+        db = _db_with_org(target_org)
+        result = await list_extensions(org_slug="voys", perms=perms, db=db)
+        assert result.org_slug == "voys"
+        partner = next(i for i in result.extensions if i.key == "partner_api")
+        assert partner.enabled is True
+
+    @pytest.mark.asyncio
+    async def test_manageable_by_caller_true_for_platform_admin(self) -> None:
+        perms = make_perms(role="admin", org_id=1, is_platform_admin=True)
+        org = make_org(org_id=1, slug="getklai")
+        db = _db_with_org(org)
+        result = await list_extensions(org_slug=None, perms=perms, db=db)
+        for item in result.extensions:
+            assert item.manageable_by_caller is True
+
+
+class TestUpdateExtensions:
+    """PATCH is platform-admin only and persists the unlock set."""
+
+    @pytest.mark.asyncio
+    async def test_tenant_admin_blocked_with_403(self) -> None:
+        perms = make_perms(role="admin", org_id=42, is_platform_admin=False)
+        body = UpdateExtensionsRequest(org_slug="acme", enabled_features=["scribe"])
+        with pytest.raises(HTTPException) as exc:
+            await update_extensions(body=body, perms=perms, db=AsyncMock())
+        assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.asyncio
+    async def test_unknown_feature_returns_400(self) -> None:
+        perms = make_perms(role="admin", org_id=1, is_platform_admin=True)
+        body = UpdateExtensionsRequest(org_slug="voys", enabled_features=["x_legacy_feature"])
+        with pytest.raises(HTTPException) as exc:
+            await update_extensions(body=body, perms=perms, db=AsyncMock())
+        assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+
+    @pytest.mark.asyncio
+    async def test_platform_admin_replaces_feature_set(self) -> None:
+        perms = make_perms(role="admin", org_id=1, is_platform_admin=True)
+        target_org = make_org(org_id=42, slug="voys", platform_unlocked_features=["scribe"])
+        db = _db_with_org(target_org)
+        body = UpdateExtensionsRequest(org_slug="voys", enabled_features=["partner_api", "widgets"])
+
+        with patch("app.api.admin.extensions.emit_lifecycle_event", new=AsyncMock()) as mock_audit:
+            result = await update_extensions(body=body, perms=perms, db=db)
+
+        assert sorted(target_org.platform_unlocked_features) == ["partner_api", "widgets"]
+        db.commit.assert_called_once()
+        mock_audit.assert_called_once()
+        # Sanity: response reflects the new state.
+        enabled = {item.key for item in result.extensions if item.enabled}
+        assert enabled == {"partner_api", "widgets"}
+
+    @pytest.mark.asyncio
+    async def test_dedupe_and_sort_in_persisted_set(self) -> None:
+        """Caller may send duplicates / unsorted; storage is normalised."""
+        perms = make_perms(role="admin", org_id=1, is_platform_admin=True)
+        target_org = make_org(org_id=42, slug="voys", platform_unlocked_features=[])
+        db = _db_with_org(target_org)
+        body = UpdateExtensionsRequest(org_slug="voys", enabled_features=["widgets", "scribe", "widgets", "scribe"])
+
+        with patch("app.api.admin.extensions.emit_lifecycle_event", new=AsyncMock()):
+            await update_extensions(body=body, perms=perms, db=db)
+
+        assert target_org.platform_unlocked_features == ["scribe", "widgets"]

--- a/klai-portal/backend/uv.lock
+++ b/klai-portal/backend/uv.lock
@@ -751,7 +751,7 @@ dev = [
 
 [[package]]
 name = "klai-identity-assert"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "../../klai-libs/identity-assert" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## SPEC-PORTAL-EXTENSIONS-UNIFY-001 Phase 3

Adds the tenant-facing extensions API used by the new `/admin/settings` Uitbreidingen-sectie, and exposes `platform_unlocked_features` + `is_platform_admin` on `/api/me` so the frontend can render the tile-filter + read-only or interactive status list.

## New endpoints

- `GET /api/admin/extensions [?org_slug=…]` — returns `{ org_slug, extensions: [{key, label, description, enabled, requires_profile, manageable_by_caller}] }` for every key in `_KNOWN_FEATURES` (partner_api, widgets, custom_mcps, scribe, docs). Without slug → caller's own org (admin role). With slug → requires `is_platform_admin` else 403.
- `PATCH /api/admin/extensions` — body `{ org_slug, enabled_features }`. **Platform-admin only** — tenant admins get 403 even on their own org. Validates against `_KNOWN_FEATURES` (400 on unknown). Persists to `platform_unlocked_features` (de-duped, sorted) and emits `platform_features_updated` lifecycle event in the same transaction.

## /api/me extension

`MeResponse` gains two fields: `is_platform_admin: bool` and `platform_unlocked_features: list[str]`. Powers Phase 4's frontend tile-filter and read-only status list.

## Registry

`_KNOWN_FEATURES` in `admin/platform_unlocks.py` extended to include `scribe` + `docs`. Single source of truth — the extensions endpoint enumerates this set.

## Tests

`tests/test_admin_extensions.py` — 9 tests covering own-org list, cross-org platform-admin list, tenant-admin 403 on cross-org, PATCH tenant-admin 403, unknown-feature 400, replacement semantics, dedupe + sort, and `manageable_by_caller` flag.

## Quality gate

- ruff check: All checks passed
- ruff format: 491 files already formatted
- pytest: **2481 passed, 3 deselected, 0 failed**

## Next

- Phase 4 — frontend `/admin/settings` Uitbreidingen-sectie + tenant-picker.
- Phase 5 — consistency audit + Playwright E2E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)