### PR TITLE
fix(kb): show Persoonlijk first, then Organisatiekennis, then rest

### DIFF
--- a/klai-portal/frontend/src/routes/app/knowledge/index.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/index.tsx
@@ -153,6 +153,21 @@ function KbRow({
   )
 }
 
+// -- Sort -------------------------------------------------------------------
+
+/**
+ * Rank for the KB list ordering. Lower rank = closer to the top.
+ *
+ * 0 — Personal KBs (owned by the current user — only one per user in practice)
+ * 1 — Default org KB (slug "org", rendered as "Organisatiekennis")
+ * 2 — Every other org-owned KB (team / topic collections)
+ */
+function kbSortRank(kb: KnowledgeBase): 0 | 1 | 2 {
+  if (kb.owner_type === 'user') return 0
+  if (kb.slug === 'org') return 1
+  return 2
+}
+
 // -- Page -------------------------------------------------------------------
 
 function KnowledgePage() {
@@ -182,12 +197,18 @@ function KnowledgePage() {
   const statsBySlug = statsData?.stats ?? {}
   const allKbs = kbsData?.knowledge_bases ?? []
 
+  // Display order: personal KBs first, then the default org KB
+  // ("Organisatiekennis", slug='org' per default_knowledge_bases.py),
+  // then every other org-owned collection. Array.sort is stable since
+  // ES2019, so within each rank the API order is preserved.
+  const sortedKbs = [...allKbs].sort((a, b) => kbSortRank(a) - kbSortRank(b))
+
   const filteredKbs = search.trim()
-    ? allKbs.filter((kb) => {
+    ? sortedKbs.filter((kb) => {
         const q = search.toLowerCase()
         return kb.name.toLowerCase().includes(q) || (kb.description ?? '').toLowerCase().includes(q)
       })
-    : allKbs
+    : sortedKbs
 
   return (
     <div className="mx-auto max-w-3xl px-6 pb-10">


### PR DESCRIPTION
## What

Reorder collections on `/app/knowledge`:

1. **Persoonlijk** (`owner_type='user'`)
2. **Organisatiekennis** (`slug='org'` — the default org KB from `default_knowledge_bases.py:48`)
3. Everything else (Handbook, Klai Help, etc. — API order preserved)

## Why

Raw API order surfaced team / topic KBs above the user's own collection, which is the wrong information hierarchy for the page.

## How

Single `kbSortRank()` helper + a stable sort on `allKbs` before the search filter. `Array.sort` has been stable since ES2019, so rank-2 KBs keep their existing API order.

## Out of scope

- Admin UI ordering
- KB picker in chat
- Alphabetical sort within "rest"

🤖 Generated with [Claude Code](https://claude.com/claude-code)