### PR TITLE
feat(portal-ui): SPEC-PORTAL-EXTENSIONS-UNIFY-001 Phase 4 — Uitbreidingen UI + tile filter

### DIFF
--- a/klai-portal/frontend/messages/en.json
+++ b/klai-portal/frontend/messages/en.json
@@ -1682,5 +1682,17 @@
   "admin_settings_telemetry_full_name": "Full",
   "admin_settings_telemetry_full_hint": "Klai stores the literal user queries in operational logs for 7 days. Only enable when you or Klai are actively investigating a specific issue. Don't forget to switch back to Shadow — after 14 days there will be a reminder.",
   "admin_settings_telemetry_disabled_for_non_admin": "Only organisation admins can change this setting.",
-  "admin_settings_telemetry_privacy_link": "Read more about the privacy modes in our privacy policy"
+  "admin_settings_telemetry_privacy_link": "Read more about the privacy modes in our privacy policy",
+  "admin_section_mcps_title": "MCP servers",
+  "admin_section_mcps_description": "Connect Model Context Protocol servers to your workspace.",
+  "admin_settings_extensions_title": "Extensions",
+  "admin_settings_extensions_description_tenant": "Features Klai has enabled for your organisation.",
+  "admin_settings_extensions_description_platform": "Manage which extensions are enabled per tenant. Klai staff only.",
+  "admin_settings_extensions_tenant_picker_label": "Tenant slug",
+  "admin_settings_extensions_tenant_picker_apply": "Apply",
+  "admin_settings_extensions_tenant_picker_reset": "Back to own org",
+  "admin_settings_extensions_active_slug": "Active: {slug}",
+  "admin_settings_extensions_status_on": "On",
+  "admin_settings_extensions_status_off": "Off",
+  "admin_settings_extensions_managed_by_klai": "These extensions are managed by Klai. Contact us to request changes."
 }

--- a/klai-portal/frontend/messages/nl.json
+++ b/klai-portal/frontend/messages/nl.json
@@ -1682,5 +1682,17 @@
   "admin_settings_telemetry_full_name": "Volledig",
   "admin_settings_telemetry_full_hint": "Klai slaat letterlijke vragen op in operationele logs voor 7 dagen. Alleen aanzetten als u of Klai actief een specifiek probleem onderzoekt. Vergeet niet terug te zetten naar Schaduw — er komt na 14 dagen een herinnering.",
   "admin_settings_telemetry_disabled_for_non_admin": "Alleen organisatie-beheerders kunnen deze instelling wijzigen.",
-  "admin_settings_telemetry_privacy_link": "Lees meer over de privacy-modi in ons privacybeleid"
+  "admin_settings_telemetry_privacy_link": "Lees meer over de privacy-modi in ons privacybeleid",
+  "admin_section_mcps_title": "MCP servers",
+  "admin_section_mcps_description": "Koppel Model Context Protocol servers aan jouw werkruimte.",
+  "admin_settings_extensions_title": "Uitbreidingen",
+  "admin_settings_extensions_description_tenant": "Functies die Klai voor jouw organisatie heeft vrijgegeven.",
+  "admin_settings_extensions_description_platform": "Beheer de uitbreidingen die per tenant zijn vrijgegeven. Alleen Klai-staff kan deze schakelen.",
+  "admin_settings_extensions_tenant_picker_label": "Tenant slug",
+  "admin_settings_extensions_tenant_picker_apply": "Toepassen",
+  "admin_settings_extensions_tenant_picker_reset": "Terug naar eigen org",
+  "admin_settings_extensions_active_slug": "Actief: {slug}",
+  "admin_settings_extensions_status_on": "Aan",
+  "admin_settings_extensions_status_off": "Uit",
+  "admin_settings_extensions_managed_by_klai": "Deze uitbreidingen worden door Klai beheerd. Neem contact op om wijzigingen aan te vragen."
 }

--- a/klai-portal/frontend/src/lib/api-me.ts
+++ b/klai-portal/frontend/src/lib/api-me.ts
@@ -21,6 +21,10 @@ export interface MeResponse {
   portal_role?: string
   products?: string[]
   org_found?: boolean
+  // SPEC-PORTAL-EXTENSIONS-UNIFY-001 Phase 3: powers Phase 4 tile-filter on
+  // /admin/index.tsx and the Uitbreidingen-sectie on /admin/settings.
+  is_platform_admin?: boolean
+  platform_unlocked_features?: string[]
 }
 
 /**

--- a/klai-portal/frontend/src/routes/admin/index.tsx
+++ b/klai-portal/frontend/src/routes/admin/index.tsx
@@ -1,12 +1,26 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { Users, FolderKanban, CreditCard, Settings, Key, MessageSquare, ChevronRight } from 'lucide-react'
+import { useQuery } from '@tanstack/react-query'
+import { Users, FolderKanban, CreditCard, Settings, Key, MessageSquare, Puzzle, ChevronRight } from 'lucide-react'
 import * as m from '@/paraglide/messages'
+import { useAuth } from '@/lib/auth'
+import { fetchMe, type MeResponse } from '@/lib/api-me'
 
 export const Route = createFileRoute('/admin/')({
   component: AdminHome,
 })
 
 function AdminHome() {
+  const auth = useAuth()
+  // SPEC-PORTAL-EXTENSIONS-UNIFY-001 Phase 4: tile-filter per tenant.
+  // Tiles for features behind platform-unlock (api-keys, widgets, mcps) are
+  // hidden when the caller's org does not have the feature unlocked, unless
+  // the caller is a platform-admin (Klai staff sees everything).
+  const { data: me } = useQuery({
+    queryKey: ['me'],
+    queryFn: ({ signal }) => fetchMe(signal),
+    enabled: auth.isAuthenticated,
+  })
+
   // SPEC-PORTAL-UI-CONSISTENCY-001 REQ-4 / REQ-5: rows, not cards.
   const adminSections = [
     {
@@ -26,12 +40,21 @@ function AdminHome() {
       description: m.admin_section_api_keys_description(),
       icon: Key,
       href: '/admin/api-keys',
+      requiresFeature: 'partner_api',
     },
     {
       title: m.admin_section_widgets_title(),
       description: m.admin_section_widgets_description(),
       icon: MessageSquare,
       href: '/admin/widgets',
+      requiresFeature: 'widgets',
+    },
+    {
+      title: m.admin_section_mcps_title(),
+      description: m.admin_section_mcps_description(),
+      icon: Puzzle,
+      href: '/admin/mcps',
+      requiresFeature: 'custom_mcps',
     },
     {
       title: m.admin_section_billing_title(),
@@ -45,7 +68,7 @@ function AdminHome() {
       icon: Settings,
       href: '/admin/settings',
     },
-  ]
+  ].filter((section) => sectionIsVisible(section, me))
 
   return (
     <div className="mx-auto max-w-3xl px-6 py-10 space-y-8">
@@ -82,4 +105,17 @@ function AdminHome() {
       </div>
     </div>
   )
+}
+
+function sectionIsVisible(
+  section: { requiresFeature?: string },
+  me: MeResponse | undefined,
+): boolean {
+  if (!section.requiresFeature) return true
+  // Show all tiles while /api/me is still loading — avoids a flash of
+  // "no tiles" before the first response lands. Platform-admin always sees
+  // everything; tenant-admin sees only their unlocked features.
+  if (!me) return true
+  if (me.is_platform_admin) return true
+  return (me.platform_unlocked_features ?? []).includes(section.requiresFeature)
 }

--- a/klai-portal/frontend/src/routes/admin/route.tsx
+++ b/klai-portal/frontend/src/routes/admin/route.tsx
@@ -1,10 +1,13 @@
 import { createFileRoute, Outlet } from '@tanstack/react-router'
+import { useQuery } from '@tanstack/react-query'
 import { LayoutDashboard, Users, FolderKanban, Settings, CreditCard, Puzzle, Key, MessageSquare, Sliders, Skull, ShieldCheck, type LucideIcon } from 'lucide-react'
 import { Sidebar } from '@/components/layout/Sidebar'
 import { HelpButton } from '@/components/help/HelpButton'
 import * as m from '@/paraglide/messages'
 import { useProtectedRoute } from '@/hooks/useProtectedRoute'
 import { meetsMinRole, type ProfileRole } from '@/lib/profiles'
+import { useAuth } from '@/lib/auth'
+import { fetchMe } from '@/lib/api-me'
 
 export const Route = createFileRoute('/admin')({
   component: AdminLayout,
@@ -13,17 +16,29 @@ export const Route = createFileRoute('/admin')({
 // SPEC-PORTAL-PROFILES-001 P3.2: per-tab minimum role on the admin sidebar.
 // kb_manager and group_manager can enter /admin for groups + templates.
 // Everything else remains admin-only.
-const ADMIN_NAV_ITEMS: Array<{ to: string; label: string; icon: LucideIcon; minRole: ProfileRole; end?: boolean }> = [
+//
+// SPEC-PORTAL-EXTENSIONS-UNIFY-001 Phase 4: api-keys, widgets, and mcps are
+// additionally platform-unlock-gated via `requiresFeature`. The nav-item is
+// hidden when the caller's org does not have the feature unlocked, unless
+// the caller is a platform-admin (Klai staff always sees everything).
+const ADMIN_NAV_ITEMS: Array<{
+  to: string
+  label: string
+  icon: LucideIcon
+  minRole: ProfileRole
+  end?: boolean
+  requiresFeature?: string
+}> = [
   { to: '/admin', label: m.admin_nav_overview(), icon: LayoutDashboard, minRole: 'kb_manager', end: true },
   { to: '/admin/users', label: m.admin_nav_users(), icon: Users, minRole: 'admin' },
   // SPEC-PORTAL-ADMIN-UI-001 REQ-11: Profiles between Users and Groups.
   { to: '/admin/profiles', label: m.admin_nav_profiles(), icon: ShieldCheck, minRole: 'admin' },
   { to: '/admin/groups', label: m.admin_nav_groups(), icon: FolderKanban, minRole: 'group_manager' },
   { to: '/admin/billing', label: m.admin_nav_billing(), icon: CreditCard, minRole: 'admin' },
-  { to: '/admin/api-keys', label: m.admin_nav_api_keys(), icon: Key, minRole: 'admin' },
-  { to: '/admin/widgets', label: m.admin_nav_widgets(), icon: MessageSquare, minRole: 'admin' },
+  { to: '/admin/api-keys', label: m.admin_nav_api_keys(), icon: Key, minRole: 'admin', requiresFeature: 'partner_api' },
+  { to: '/admin/widgets', label: m.admin_nav_widgets(), icon: MessageSquare, minRole: 'admin', requiresFeature: 'widgets' },
   { to: '/admin/templates', label: m.admin_nav_templates(), icon: Sliders, minRole: 'kb_manager' },
-  { to: '/admin/mcps', label: m.admin_nav_mcps(), icon: Puzzle, minRole: 'admin' },
+  { to: '/admin/mcps', label: m.admin_nav_mcps(), icon: Puzzle, minRole: 'admin', requiresFeature: 'custom_mcps' },
   { to: '/admin/settings', label: m.admin_nav_settings(), icon: Settings, minRole: 'admin' },
   { to: '/admin/danger-zone', label: m.admin_nav_danger_zone(), icon: Skull, minRole: 'admin' },
 ]
@@ -35,11 +50,29 @@ function AdminLayout() {
     noRoleFallback: '/app',
   })
 
-  // Filter nav items to only show what this user's role allows.
+  const auth = useAuth()
+  const { data: me } = useQuery({
+    queryKey: ['me'],
+    queryFn: ({ signal }) => fetchMe(signal),
+    enabled: auth.isAuthenticated,
+  })
+
+  // Filter nav items: role-check first, then platform-unlock-check.
   const effectiveRole = user?.effective_role
-  const adminNav = ADMIN_NAV_ITEMS
-    .filter((item) => meetsMinRole(effectiveRole, item.minRole))
-    .map(({ to, label, icon, end }) => ({ to, label, icon, end }))
+  const unlocked = me?.platform_unlocked_features ?? []
+  const isPlatformAdmin = me?.is_platform_admin ?? false
+
+  const adminNav = ADMIN_NAV_ITEMS.filter((item) => {
+    if (!meetsMinRole(effectiveRole, item.minRole)) return false
+    if (item.requiresFeature) {
+      // While /api/me is loading, keep the item visible to avoid a flash of
+      // missing nav. Platform-admin always sees everything.
+      if (!me) return true
+      if (isPlatformAdmin) return true
+      return unlocked.includes(item.requiresFeature)
+    }
+    return true
+  }).map(({ to, label, icon, end }) => ({ to, label, icon, end }))
 
   if (!canRender) {
     return (

--- a/klai-portal/frontend/src/routes/admin/settings.tsx
+++ b/klai-portal/frontend/src/routes/admin/settings.tsx
@@ -6,8 +6,10 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
 import { Select } from '@/components/ui/select'
-import { apiFetch } from '@/lib/apiFetch'
+import { Input } from '@/components/ui/input'
 import { Checkbox } from '@/components/ui/checkbox'
+import { apiFetch } from '@/lib/apiFetch'
+import { fetchMe } from '@/lib/api-me'
 import * as m from '@/paraglide/messages'
 import { adminLogger } from '@/lib/logger'
 
@@ -24,6 +26,21 @@ type OrgSettings = {
   auto_accept_same_domain: boolean
   primary_domain: string | null
   telemetry_level: TelemetryLevel
+}
+
+// SPEC-PORTAL-EXTENSIONS-UNIFY-001 Phase 3/4 — extensions API shape.
+type ExtensionItem = {
+  key: string
+  label: string
+  description: string
+  enabled: boolean
+  requires_profile: string | null
+  manageable_by_caller: boolean
+}
+
+type ExtensionsResponse = {
+  org_slug: string
+  extensions: ExtensionItem[]
 }
 
 function AdminSettingsPage() {
@@ -105,57 +122,65 @@ function AdminSettingsPage() {
     },
   })
 
-  // SPEC-PORTAL-PROFILES-001 P3.6: Add-on toggles.
-  // UX pattern: ticking a checkbox stages the change; user clicks Save to commit.
-  // Consistent with Language and MFA sections above.
-  const [addons, setAddons] = useState<string[]>([])
-  const [savedAddons, setSavedAddons] = useState(false)
+  // ---------------------------------------------------------------------
+  // SPEC-PORTAL-EXTENSIONS-UNIFY-001 Phase 4: Uitbreidingen sectie.
+  // - Tenant-admin: read-only status view of own-org extensions.
+  // - Platform-admin (Klai staff): tenant-picker + interactive checkboxes.
+  // ---------------------------------------------------------------------
+  const { data: me } = useQuery({
+    queryKey: ['me'],
+    queryFn: ({ signal }) => fetchMe(signal),
+    enabled: auth.isAuthenticated,
+  })
+  const isPlatformAdmin = me?.is_platform_admin ?? false
 
-  const { data: addonsData, isLoading: addonsLoading, error: addonsQueryError } = useQuery({
-    queryKey: ['admin-enabled-addons'],
-    queryFn: async () => apiFetch<{ enabled_addons: string[] }>('/api/admin/settings/addons'),
+  // Tenant-picker state — only used by platform-admins. Empty string = own org.
+  const [pickerSlug, setPickerSlug] = useState<string>('')
+  const [pickerInput, setPickerInput] = useState<string>('')
+  const activeSlug = isPlatformAdmin && pickerSlug !== '' ? pickerSlug : ''
+
+  const extQueryKey = ['admin-extensions', activeSlug] as const
+  const { data: extensions, isLoading: extensionsLoading, error: extensionsError } = useQuery({
+    queryKey: extQueryKey,
+    queryFn: async () =>
+      apiFetch<ExtensionsResponse>(
+        activeSlug ? `/api/admin/extensions?org_slug=${encodeURIComponent(activeSlug)}` : '/api/admin/extensions',
+      ),
     enabled: auth.isAuthenticated,
   })
 
-  useEffect(() => {
-    if (addonsData) {
-      setAddons(addonsData.enabled_addons ?? [])
-    }
-  }, [addonsData])
-
-  const addonsMutation = useMutation({
-    mutationFn: (next: string[]) =>
-      apiFetch('/api/admin/settings/addons', {
+  const extensionsMutation = useMutation({
+    mutationFn: (next: { org_slug: string; enabled_features: string[] }) =>
+      apiFetch<ExtensionsResponse>('/api/admin/extensions', {
         method: 'PATCH',
-        body: JSON.stringify({ enabled_addons: next }),
+        body: JSON.stringify(next),
       }),
-    onSuccess: (_data, next) => {
-      adminLogger.info('Add-ons updated', { enabled_addons: next })
-      // SPEC-PORTAL-RBAC-001 REQ-12: keep the addons-list cache in sync with
-      // the saved state so addonsDirty flips back to false and the Save
-      // button disables straight away.
-      queryClient.setQueryData(['admin-enabled-addons'], { enabled_addons: next })
-      // The sidebar in /app reads `user.products` from useCurrentUser()
-      // (queryKey ['current-user']). user.products is derived server-side
-      // from (role, plan, enabled_addons), so flipping an add-on toggle
-      // invalidates that view too. Without this, /app keeps the stale
-      // products list until the next hard refresh and the toggled-off
-      // add-on lingers in the sidebar.
-      void queryClient.invalidateQueries({ queryKey: ['current-user'] })
-      setSavedAddons(true)
-      setTimeout(() => setSavedAddons(false), 2500)
+    onSuccess: (data) => {
+      adminLogger.info('Extensions updated', {
+        org_slug: data.org_slug,
+        enabled: data.extensions.filter((e) => e.enabled).map((e) => e.key),
+      })
+      queryClient.setQueryData(extQueryKey, data)
+      // Invalidate /api/me so the tile-filter on /admin/index.tsx reflects
+      // the new state without a hard refresh.
+      void queryClient.invalidateQueries({ queryKey: ['me'] })
     },
   })
 
-  function toggleStaged(addon: string, enabled: boolean) {
-    setAddons((prev) =>
-      enabled ? [...new Set([...prev, addon])] : prev.filter((a) => a !== addon),
-    )
+  function toggleExtension(key: string, enabled: boolean) {
+    if (!extensions) return
+    const current = new Set(extensions.extensions.filter((e) => e.enabled).map((e) => e.key))
+    if (enabled) current.add(key)
+    else current.delete(key)
+    extensionsMutation.mutate({
+      org_slug: extensions.org_slug,
+      enabled_features: [...current].sort(),
+    })
   }
 
-  const addonsDirty =
-    addonsData != null &&
-    JSON.stringify([...addons].sort()) !== JSON.stringify([...(addonsData.enabled_addons ?? [])].sort())
+  function applyPicker() {
+    setPickerSlug(pickerInput.trim())
+  }
 
   return (
     <div className="mx-auto max-w-3xl px-6 py-10 space-y-6" data-help-id="admin-settings-general">
@@ -395,47 +420,101 @@ function AdminSettingsPage() {
         </CardContent>
       </Card>
 
+      {/* SPEC-PORTAL-EXTENSIONS-UNIFY-001 Phase 4 — Uitbreidingen */}
       <Card>
         <CardHeader>
-          <CardTitle>{m.admin_settings_addons_title()}</CardTitle>
+          <CardTitle>{m.admin_settings_extensions_title()}</CardTitle>
           <CardDescription>
-            {m.admin_settings_addons_description()}
+            {isPlatformAdmin
+              ? m.admin_settings_extensions_description_platform()
+              : m.admin_settings_extensions_description_tenant()}
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          {addonsLoading ? (
-            <p className="text-sm text-gray-400">{m.admin_users_loading()}</p>
-          ) : addonsQueryError ? (
-            <p className="text-sm text-[var(--color-destructive)]">{m.admin_settings_error_fetch()}</p>
-          ) : (
-            <>
-              <div className="space-y-3">
-                <Checkbox
-                  checked={addons.includes('scribe')}
-                  onChange={(e) => toggleStaged('scribe', e.target.checked)}
-                  disabled={addonsMutation.isPending}
-                  label={m.admin_settings_addon_scribe()}
-                />
-                <Checkbox
-                  checked={addons.includes('docs')}
-                  onChange={(e) => toggleStaged('docs', e.target.checked)}
-                  disabled={addonsMutation.isPending}
-                  label={m.admin_settings_addon_docs()}
+          {isPlatformAdmin && (
+            <div className="flex items-end gap-2 border-b pb-4 mb-2">
+              <div className="flex-1 space-y-1.5">
+                <Label htmlFor="extensions-tenant-slug">
+                  {m.admin_settings_extensions_tenant_picker_label()}
+                </Label>
+                <Input
+                  id="extensions-tenant-slug"
+                  type="text"
+                  value={pickerInput}
+                  placeholder={extensions?.org_slug ?? ''}
+                  onChange={(e) => setPickerInput(e.target.value)}
                 />
               </div>
-              {addonsMutation.error && (
+              <Button variant="outline" onClick={applyPicker} disabled={pickerInput.trim() === ''}>
+                {m.admin_settings_extensions_tenant_picker_apply()}
+              </Button>
+              {pickerSlug !== '' && (
+                <Button
+                  variant="ghost"
+                  onClick={() => {
+                    setPickerSlug('')
+                    setPickerInput('')
+                  }}
+                >
+                  {m.admin_settings_extensions_tenant_picker_reset()}
+                </Button>
+              )}
+            </div>
+          )}
+
+          {extensionsLoading ? (
+            <p className="text-sm text-gray-400">{m.admin_users_loading()}</p>
+          ) : extensionsError ? (
+            <p className="text-sm text-[var(--color-destructive)]">{m.admin_settings_error_fetch()}</p>
+          ) : !extensions ? null : (
+            <>
+              {isPlatformAdmin && (
+                <p className="text-xs text-gray-400">
+                  {m.admin_settings_extensions_active_slug({ slug: extensions.org_slug })}
+                </p>
+              )}
+              <ul className="divide-y divide-gray-200 border-t border-b border-gray-200">
+                {extensions.extensions.map((item) => (
+                  <li
+                    key={item.key}
+                    className="flex items-center justify-between gap-4 px-2 py-3"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <p className="text-[15px] font-display text-gray-900">{item.label}</p>
+                      <p className="text-xs text-gray-400 mt-0.5">{item.description}</p>
+                    </div>
+                    {item.manageable_by_caller ? (
+                      <Checkbox
+                        checked={item.enabled}
+                        onChange={(e) => toggleExtension(item.key, e.target.checked)}
+                        disabled={extensionsMutation.isPending}
+                        label=""
+                      />
+                    ) : (
+                      <span
+                        className={[
+                          'shrink-0 rounded-full px-3 py-0.5 text-xs font-medium',
+                          item.enabled
+                            ? 'bg-[var(--color-rl-cream)] text-[var(--color-rl-accent-dark)]'
+                            : 'bg-gray-100 text-gray-400',
+                        ].join(' ')}
+                      >
+                        {item.enabled
+                          ? m.admin_settings_extensions_status_on()
+                          : m.admin_settings_extensions_status_off()}
+                      </span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+              {!isPlatformAdmin && (
+                <p className="text-xs text-gray-400">
+                  {m.admin_settings_extensions_managed_by_klai()}
+                </p>
+              )}
+              {extensionsMutation.error && (
                 <p className="text-sm text-[var(--color-destructive)]">{m.admin_settings_error_save()}</p>
               )}
-              <Button
-                onClick={() => addonsMutation.mutate(addons)}
-                disabled={addonsMutation.isPending || savedAddons || !addonsDirty}
-              >
-                {savedAddons
-                  ? m.admin_settings_saved()
-                  : addonsMutation.isPending
-                    ? m.admin_settings_saving()
-                    : m.admin_settings_save()}
-              </Button>
             </>
           )}
         </CardContent>


### PR DESCRIPTION
## SPEC-PORTAL-EXTENSIONS-UNIFY-001 Phase 4

Replaces the legacy self-service add-on checkboxes on `/admin/settings` with the new Uitbreidingen sectie powered by `/api/admin/extensions` (shipped in Phase 3), and filters tile + nav visibility on `/admin/index.tsx` + `/admin/route.tsx` by the caller's `platform_unlocked_features`.

## /admin/settings — Uitbreidingen section

- **Tenant-admin view**: read-only status list (label, description, on/off pill, "Beheerd door Klai" annotation). No interactive toggles — the SPEC retired tenant self-service.
- **Platform-admin view (Klai staff)**: tenant-slug picker (text input + Apply / Reset) and interactive checkboxes per feature. Toggling triggers `PATCH /api/admin/extensions` which mutates the target tenant's `platform_unlocked_features` via the audit-trailed write path.
- **Removed**: the old `/api/admin/settings/addons` GET-staged + PATCH-commit block. Frontend stops reading the legacy endpoint that Phase 2 deprecated to a facade.

## /admin/index.tsx + /admin/route.tsx — visibility filter

- `api-keys`, `widgets`, `mcps` tiles + nav-items carry a `requiresFeature` marker. Hidden when caller's org lacks the matching `platform_unlocked_features` entry, unless caller is platform-admin (then always visible).
- `/api/me` data still loading → items shown (avoid flash of empty list).
- New **MCP servers** tile added to `/admin/index.tsx` — previously missing despite the route existing on the sidebar.

## /api/me type extension

`MeResponse` gains optional `is_platform_admin: boolean` and `platform_unlocked_features: string[]`. Already shipped on the backend in Phase 3 — this PR makes the frontend type-aware.

## i18n

New Paraglide strings (NL + EN): extensions section title, both description variants (tenant vs platform), tenant-picker labels + apply/reset buttons, on/off status pills, managed-by-Klai annotation, and the missing `admin_section_mcps_{title,description}` pair.

## Quality gate

- `npm run i18n:compile` — green
- `tsc -b --force` — green
- `eslint src/routes/admin/{index,route,settings}.tsx src/lib/api-me.ts` — clean

## Next

Phase 5 — consistency audit + Playwright E2E (final PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)