### PR TITLE
fix(portal-ui): drop platform-admin bypass on sidebar + tile filter

### DIFF
--- a/klai-portal/frontend/src/routes/admin/index.tsx
+++ b/klai-portal/frontend/src/routes/admin/index.tsx
@@ -113,9 +113,10 @@ function sectionIsVisible(
 ): boolean {
   if (!section.requiresFeature) return true
   // Show all tiles while /api/me is still loading — avoids a flash of
-  // "no tiles" before the first response lands. Platform-admin always sees
-  // everything; tenant-admin sees only their unlocked features.
+  // "no tiles" before the first response lands. Both tenant-admin and
+  // platform-admin see exactly what their own tenant has unlocked
+  // (emulation view). Cross-tenant management uses the tenant-picker on
+  // /admin/settings, not the platform-admin's own sidebar/tegels.
   if (!me) return true
-  if (me.is_platform_admin) return true
   return (me.platform_unlocked_features ?? []).includes(section.requiresFeature)
 }

--- a/klai-portal/frontend/src/routes/admin/route.tsx
+++ b/klai-portal/frontend/src/routes/admin/route.tsx
@@ -58,17 +58,20 @@ function AdminLayout() {
   })
 
   // Filter nav items: role-check first, then platform-unlock-check.
+  // The platform-unlock filter applies uniformly — including to platform-admin
+  // callers. Platform-admins managing other tenants do so via the Uitbreidingen
+  // tenant-picker on /admin/settings; their own sidebar/tegels mirror what a
+  // normal admin in their own tenant would see (emulation view). Without this
+  // alignment, the sidebar contradicts the Uitbreidingen status panel.
   const effectiveRole = user?.effective_role
   const unlocked = me?.platform_unlocked_features ?? []
-  const isPlatformAdmin = me?.is_platform_admin ?? false
 
   const adminNav = ADMIN_NAV_ITEMS.filter((item) => {
     if (!meetsMinRole(effectiveRole, item.minRole)) return false
     if (item.requiresFeature) {
       // While /api/me is loading, keep the item visible to avoid a flash of
-      // missing nav. Platform-admin always sees everything.
+      // missing nav.
       if (!me) return true
-      if (isPlatformAdmin) return true
       return unlocked.includes(item.requiresFeature)
     }
     return true


### PR DESCRIPTION
Phase 4 follow-up. Drops the platform-admin "see everything" bypass on the sidebar + admin-home tile filter so platform-admins see exactly what a normal admin in their own tenant would see (emulation view).

## Symptom

User reported: on `/admin/settings` the Uitbreidingen sectie correctly showed `API keys = uit` for getklai, but `/admin` still listed an API keys nav-item because the caller was platform-admin. Inconsistent.

## Fix

- `route.tsx` — sidebar filter applies `platform_unlocked_features` check uniformly.
- `index.tsx` — `sectionIsVisible` same fix.

Cross-tenant management still works via the Uitbreidingen tenant-picker on `/admin/settings`. That is the only surface where platform-admin status changes anything; the sidebar and admin home now mirror the caller's own tenant.

## Quality gate

- `npm run i18n:compile` — green
- `tsc -b --force` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)