### PR TITLE
fix(portal): staged-save UX, drop tenant picker, capture constraint hotfix

### DIFF
--- a/klai-portal/backend/alembic/versions/c0d5e2a7b9f3_tenant_lifecycle_platform_features.py
+++ b/klai-portal/backend/alembic/versions/c0d5e2a7b9f3_tenant_lifecycle_platform_features.py
@@ -1,0 +1,55 @@
+"""SPEC-PORTAL-EXTENSIONS-UNIFY-001 — allow 'platform_features_updated' in tenant_lifecycle_events.
+
+The CHECK constraint ``ck_tenant_lifecycle_events_event_type`` on
+``tenant_lifecycle_events`` originally listed only the three tenant-lifecycle
+events (``provisioned``, ``deprovisioned``, ``failed_deprovisioning``).
+
+SPEC-PORTAL-RBAC-REFACTOR-001 Phase 5D added a fourth event type
+``platform_features_updated`` for platform-unlock audit, but never updated
+the constraint — and the ``/api/admin/orgs/{slug}/platform-unlocks`` PATCH
+endpoint that emits the event never had a UI, so the constraint mismatch
+went undetected for weeks.
+
+SPEC-PORTAL-EXTENSIONS-UNIFY-001 Phase 4 shipped the new
+``/api/admin/extensions`` PATCH which IS used by the frontend, and prod
+hit the constraint immediately (asyncpg.CheckViolationError → 500 → user
+sees "Opslaan mislukt"). Fixed live on 2026-05-12 via psql as klai
+superuser; this migration captures that fix in code so future deploys
+reproduce it.
+
+Ownership note: ``tenant_lifecycle_events`` is owned by ``klai`` superuser,
+not ``portal_api`` — so the alembic upgrade run by portal-api's entrypoint
+CANNOT execute ALTER TABLE on this constraint. The actual DDL lives in
+the paired post-deploy SQL file
+``post_deploy_c0d5e2a7b9f3_tenant_lifecycle_platform_features.sql``,
+applied by an operator via ``scripts/apply_post_deploy_sql.sh`` (or
+``psql`` directly as the ``klai`` role). The Python migration is a stamp-only
+no-op so the alembic head advances and the post-deploy file is the canonical
+record. Pattern mirrors the RLS post-deploy SQL files in this directory.
+
+Revision: c0d5e2a7b9f3
+Down-revision: e0ad7c2b1e80
+Created: 2026-05-12
+"""
+
+from __future__ import annotations
+
+revision = "c0d5e2a7b9f3"
+down_revision = "e0ad7c2b1e80"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # No-op: actual ALTER TABLE lives in the paired post-deploy SQL file
+    # (klai superuser required for a klai-owned table). Live prod was fixed
+    # on 2026-05-12 via psql; this stamp keeps the alembic graph in sync.
+    pass
+
+
+def downgrade() -> None:
+    # No-op for symmetry. Rolling back the event-type allow-list would only
+    # be relevant if the application code stopped emitting
+    # ``platform_features_updated`` entirely, in which case the constraint
+    # tightening can be applied manually via psql.
+    pass

--- a/klai-portal/backend/alembic/versions/post_deploy_c0d5e2a7b9f3_tenant_lifecycle_platform_features.sql
+++ b/klai-portal/backend/alembic/versions/post_deploy_c0d5e2a7b9f3_tenant_lifecycle_platform_features.sql
@@ -1,0 +1,33 @@
+-- post_deploy_c0d5e2a7b9f3_tenant_lifecycle_platform_features.sql
+-- SPEC-PORTAL-EXTENSIONS-UNIFY-001 Phase 4 hotfix.
+--
+-- Extends ck_tenant_lifecycle_events_event_type to allow the
+-- 'platform_features_updated' event type emitted by the platform-unlock
+-- update path (admin/platform_unlocks.py + admin/extensions.py).
+--
+-- Run as klai superuser (NOT portal_api) because tenant_lifecycle_events
+-- is owned by klai. The pattern matches the RLS post-deploy SQL files in
+-- this directory.
+--
+-- Idempotent: DROP IF EXISTS + named ADD CONSTRAINT means repeated runs
+-- (e.g. retried deploys) leave the constraint in its target state.
+--
+-- Live prod applied 2026-05-12 17:00 CEST via psql; this file captures
+-- the same change for reproducibility in any rebuilt environment.
+
+BEGIN;
+
+ALTER TABLE tenant_lifecycle_events
+    DROP CONSTRAINT IF EXISTS ck_tenant_lifecycle_events_event_type;
+
+ALTER TABLE tenant_lifecycle_events
+    ADD CONSTRAINT ck_tenant_lifecycle_events_event_type CHECK (
+        event_type = ANY (ARRAY[
+            'provisioned'::text,
+            'deprovisioned'::text,
+            'failed_deprovisioning'::text,
+            'platform_features_updated'::text
+        ])
+    );
+
+COMMIT;

--- a/klai-portal/frontend/src/routes/admin/settings.tsx
+++ b/klai-portal/frontend/src/routes/admin/settings.tsx
@@ -6,7 +6,6 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
 import { Select } from '@/components/ui/select'
-import { Input } from '@/components/ui/input'
 import { Checkbox } from '@/components/ui/checkbox'
 import { apiFetch } from '@/lib/apiFetch'
 import { fetchMe } from '@/lib/api-me'
@@ -124,30 +123,35 @@ function AdminSettingsPage() {
 
   // ---------------------------------------------------------------------
   // SPEC-PORTAL-EXTENSIONS-UNIFY-001 Phase 4: Uitbreidingen sectie.
-  // - Tenant-admin: read-only status view of own-org extensions.
-  // - Platform-admin (Klai staff): tenant-picker + interactive checkboxes.
+  // Staged-toggle pattern, consistent with the Language / MFA / Telemetry
+  // sections above: checkbox change updates local state only; Save commits.
+  // Tenant-admin: checkboxes always disabled (read-only).
+  // Platform-admin (Klai staff): checkboxes interactive on own org.
   // ---------------------------------------------------------------------
   const { data: me } = useQuery({
     queryKey: ['me'],
     queryFn: ({ signal }) => fetchMe(signal),
     enabled: auth.isAuthenticated,
   })
-  const isPlatformAdmin = me?.is_platform_admin ?? false
 
-  // Tenant-picker state — only used by platform-admins. Empty string = own org.
-  const [pickerSlug, setPickerSlug] = useState<string>('')
-  const [pickerInput, setPickerInput] = useState<string>('')
-  const activeSlug = isPlatformAdmin && pickerSlug !== '' ? pickerSlug : ''
-
-  const extQueryKey = ['admin-extensions', activeSlug] as const
   const { data: extensions, isLoading: extensionsLoading, error: extensionsError } = useQuery({
-    queryKey: extQueryKey,
-    queryFn: async () =>
-      apiFetch<ExtensionsResponse>(
-        activeSlug ? `/api/admin/extensions?org_slug=${encodeURIComponent(activeSlug)}` : '/api/admin/extensions',
-      ),
+    queryKey: ['admin-extensions'],
+    queryFn: async () => apiFetch<ExtensionsResponse>('/api/admin/extensions'),
     enabled: auth.isAuthenticated,
   })
+
+  // Staged feature set + saved-flash state. Mirrors Language / MFA / Telemetry
+  // sections — a Save button commits, not the checkbox change itself.
+  const [stagedExtensions, setStagedExtensions] = useState<Set<string>>(new Set())
+  const [savedExtensions, setSavedExtensions] = useState(false)
+
+  useEffect(() => {
+    if (extensions) {
+      setStagedExtensions(
+        new Set(extensions.extensions.filter((e) => e.enabled).map((e) => e.key)),
+      )
+    }
+  }, [extensions])
 
   const extensionsMutation = useMutation({
     mutationFn: (next: { org_slug: string; enabled_features: string[] }) =>
@@ -160,27 +164,31 @@ function AdminSettingsPage() {
         org_slug: data.org_slug,
         enabled: data.extensions.filter((e) => e.enabled).map((e) => e.key),
       })
-      queryClient.setQueryData(extQueryKey, data)
+      queryClient.setQueryData(['admin-extensions'], data)
       // Invalidate /api/me so the tile-filter on /admin/index.tsx reflects
       // the new state without a hard refresh.
       void queryClient.invalidateQueries({ queryKey: ['me'] })
+      setSavedExtensions(true)
+      setTimeout(() => setSavedExtensions(false), 2500)
     },
   })
 
-  function toggleExtension(key: string, enabled: boolean) {
-    if (!extensions) return
-    const current = new Set(extensions.extensions.filter((e) => e.enabled).map((e) => e.key))
-    if (enabled) current.add(key)
-    else current.delete(key)
-    extensionsMutation.mutate({
-      org_slug: extensions.org_slug,
-      enabled_features: [...current].sort(),
+  function stageExtension(key: string, enabled: boolean) {
+    setStagedExtensions((prev) => {
+      const next = new Set(prev)
+      if (enabled) next.add(key)
+      else next.delete(key)
+      return next
     })
   }
 
-  function applyPicker() {
-    setPickerSlug(pickerInput.trim())
-  }
+  const savedEnabled = new Set(
+    extensions?.extensions.filter((e) => e.enabled).map((e) => e.key) ?? [],
+  )
+  const extensionsDirty =
+    extensions != null &&
+    (stagedExtensions.size !== savedEnabled.size ||
+      [...stagedExtensions].some((k) => !savedEnabled.has(k)))
 
   return (
     <div className="mx-auto max-w-3xl px-6 py-10 space-y-6" data-help-id="admin-settings-general">
@@ -425,95 +433,76 @@ function AdminSettingsPage() {
         <CardHeader>
           <CardTitle>{m.admin_settings_extensions_title()}</CardTitle>
           <CardDescription>
-            {isPlatformAdmin
+            {(me?.is_platform_admin ?? false)
               ? m.admin_settings_extensions_description_platform()
               : m.admin_settings_extensions_description_tenant()}
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          {isPlatformAdmin && (
-            <div className="flex items-end gap-2 border-b pb-4 mb-2">
-              <div className="flex-1 space-y-1.5">
-                <Label htmlFor="extensions-tenant-slug">
-                  {m.admin_settings_extensions_tenant_picker_label()}
-                </Label>
-                <Input
-                  id="extensions-tenant-slug"
-                  type="text"
-                  value={pickerInput}
-                  placeholder={extensions?.org_slug ?? ''}
-                  onChange={(e) => setPickerInput(e.target.value)}
-                />
-              </div>
-              <Button variant="outline" onClick={applyPicker} disabled={pickerInput.trim() === ''}>
-                {m.admin_settings_extensions_tenant_picker_apply()}
-              </Button>
-              {pickerSlug !== '' && (
-                <Button
-                  variant="ghost"
-                  onClick={() => {
-                    setPickerSlug('')
-                    setPickerInput('')
-                  }}
-                >
-                  {m.admin_settings_extensions_tenant_picker_reset()}
-                </Button>
-              )}
-            </div>
-          )}
-
           {extensionsLoading ? (
             <p className="text-sm text-gray-400">{m.admin_users_loading()}</p>
           ) : extensionsError ? (
             <p className="text-sm text-[var(--color-destructive)]">{m.admin_settings_error_fetch()}</p>
           ) : !extensions ? null : (
             <>
-              {isPlatformAdmin && (
-                <p className="text-xs text-gray-400">
-                  {m.admin_settings_extensions_active_slug({ slug: extensions.org_slug })}
-                </p>
-              )}
               <ul className="divide-y divide-gray-200 border-t border-b border-gray-200">
-                {extensions.extensions.map((item) => (
-                  <li
-                    key={item.key}
-                    className="flex items-center justify-between gap-4 px-2 py-3"
-                  >
-                    <div className="min-w-0 flex-1">
-                      <p className="text-[15px] font-display text-gray-900">{item.label}</p>
-                      <p className="text-xs text-gray-400 mt-0.5">{item.description}</p>
-                    </div>
-                    {item.manageable_by_caller ? (
-                      <Checkbox
-                        checked={item.enabled}
-                        onChange={(e) => toggleExtension(item.key, e.target.checked)}
-                        disabled={extensionsMutation.isPending}
-                        label=""
-                      />
-                    ) : (
-                      <span
-                        className={[
-                          'shrink-0 rounded-full px-3 py-0.5 text-xs font-medium',
-                          item.enabled
-                            ? 'bg-[var(--color-rl-cream)] text-[var(--color-rl-accent-dark)]'
-                            : 'bg-gray-100 text-gray-400',
-                        ].join(' ')}
-                      >
-                        {item.enabled
-                          ? m.admin_settings_extensions_status_on()
-                          : m.admin_settings_extensions_status_off()}
-                      </span>
-                    )}
-                  </li>
-                ))}
+                {extensions.extensions.map((item) => {
+                  const staged = stagedExtensions.has(item.key)
+                  return (
+                    <li key={item.key} className="flex items-center justify-between gap-4 px-2 py-3">
+                      <div className="min-w-0 flex-1">
+                        <p className="text-[15px] font-display text-gray-900">{item.label}</p>
+                        <p className="text-xs text-gray-400 mt-0.5">{item.description}</p>
+                      </div>
+                      {item.manageable_by_caller ? (
+                        <Checkbox
+                          checked={staged}
+                          onChange={(e) => stageExtension(item.key, e.target.checked)}
+                          disabled={extensionsMutation.isPending}
+                          label=""
+                        />
+                      ) : (
+                        <span
+                          className={[
+                            'shrink-0 rounded-full px-3 py-0.5 text-xs font-medium',
+                            item.enabled
+                              ? 'bg-[var(--color-rl-cream)] text-[var(--color-rl-accent-dark)]'
+                              : 'bg-gray-100 text-gray-400',
+                          ].join(' ')}
+                        >
+                          {item.enabled
+                            ? m.admin_settings_extensions_status_on()
+                            : m.admin_settings_extensions_status_off()}
+                        </span>
+                      )}
+                    </li>
+                  )
+                })}
               </ul>
-              {!isPlatformAdmin && (
+              {!(me?.is_platform_admin ?? false) && (
                 <p className="text-xs text-gray-400">
                   {m.admin_settings_extensions_managed_by_klai()}
                 </p>
               )}
               {extensionsMutation.error && (
                 <p className="text-sm text-[var(--color-destructive)]">{m.admin_settings_error_save()}</p>
+              )}
+              {(me?.is_platform_admin ?? false) && (
+                <Button
+                  onClick={() =>
+                    extensionsMutation.mutate({
+                      org_slug: extensions.org_slug,
+                      enabled_features: [...stagedExtensions].sort(),
+                    })
+                  }
+                  disabled={extensionsMutation.isPending || savedExtensions || !extensionsDirty}
+                >
+                  {savedExtensions
+                    ? m.admin_settings_saved()
+                    : extensionsMutation.isPending
+                      ? m.admin_settings_saving()
+                      : m.admin_settings_save()}
+                </Button>
               )}
             </>
           )}


### PR DESCRIPTION
Three corrections to the SPEC-PORTAL-EXTENSIONS-UNIFY-001 Phase 3/4 follow-up.

## 1) UX — match the existing Klai save-pattern

The Uitbreidingen sectie previously committed each checkbox click straight to `/api/admin/extensions`. Inconsistent with the Language, MFA, and Telemetry sections that all use stage-then-Save. Reverted to the staged pattern.

## 2) Drop the tenant slug picker

Scope-creep — the user asked for visibility, not for cross-tenant management embedded in their own `/admin/settings`. Platform-admin sees and edits own-org status. Cross-tenant management still works via the existing `PATCH /api/admin/orgs/{slug}/platform-unlocks` (curl / API).

## 3) Capture live-prod constraint hotfix in code

The `/api/admin/extensions` PATCH raised a `CheckViolationError` on the first real call: `ck_tenant_lifecycle_events_event_type` only allowed `provisioned`/`deprovisioned`/`failed_deprovisioning`. The `platform_features_updated` event type (introduced by SPEC-PORTAL-RBAC-REFACTOR-001 Phase 5D's audit emit) was never added to the allow-list, and went undetected because the legacy `/api/admin/orgs/{slug}/platform-unlocks` PATCH had no UI consumer.

Live prod fixed via psql as klai superuser (2026-05-12 17:00 CEST). This PR captures the same DDL in a post-deploy SQL file. The Python alembic revision is a stamp-only no-op because `tenant_lifecycle_events` is owned by the klai superuser — same pattern as the RLS post-deploy SQL files in this directory.

## Quality gate

- `npm run i18n:compile` — green
- `tsc -b --force` — green
- `ruff check` on the new migration — All checks passed
- `alembic heads` — single head `c0d5e2a7b9f3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)