### PR TITLE
fix(kb-images): SPEC-TI-009 follow-up — Caddy port/handle + zitadel S3 prefix

### DIFF
--- a/.claude/rules/klai/pitfalls/process-rules.md
+++ b/.claude/rules/klai/pitfalls/process-rules.md
@@ -1,5 +1,71 @@
 # Process Rules
 
+## caddy-proxy-route-without-browser-leg (HIGH)
+A Caddy `reverse_proxy` directive that is only consumed by **RAG content**
+(LLM sees the URL as a token string, never fetches it) is **untested in
+production by definition**. The route can have a wrong upstream port, the
+wrong `handle` vs `handle_path` choice, or a wrong auth model — and the
+only signal would be a 5xx alert that never fires because nothing fetches it.
+
+Reference: SPEC-TI-009 `/kb-images/*` block landed 2026-04-22 with **three**
+stacked bugs (port 8000 instead of 8010, `handle_path` strips the matched
+prefix, read-route auth-check compared portal_orgs.id against zitadel_org_id
+strings). All three were invisible until 2026-05-12 when
+SPEC-PORTAL-DOCS-IMAGE-PASTE-001 (PR #592) shipped the first browser-leg
+consumer (docs-editor image paste). Caddy access logs of that 3-week window
+contained zero `/kb-images/*` requests beyond the operator's own diagnostic
+curls. 1553 production images sat in S3 but were only consumed as RAG
+context — the LLM read the URL as a string, no browser ever fetched.
+
+**Symptom class:** a feature ships with an obviously-broken transport layer
+that produces no metrics, no alerts, no support tickets, because the
+intended browser-leg consumer doesn't exist yet (or was deferred to a
+later SPEC). The bug becomes visible only when somebody finally adds a
+real `<img src>` or `<a href>` that hits the URL.
+
+**Prevention (mechanical, in this order):**
+
+1. **For every new Caddy `reverse_proxy` block, the PR description MUST
+   answer: "which browser-side consumer (`<img>`, `<a href>`, `<script>`,
+   `fetch(...)`) will exercise this route, and how is that consumer
+   verified in this PR?"** If the answer is "none — only LLM context"
+   then either:
+   - Ship the browser-leg consumer in the same PR, OR
+   - Add a Grafana synthetic-check that curls the route every 5 minutes
+     and alerts on non-2xx. This is the only mechanical equivalent of a
+     browser-leg test when no real consumer exists.
+
+2. **`caddy validate` is necessary but not sufficient.** The bug above
+   passed `caddy validate --config` (configuration is syntactically
+   valid) — it was only wrong against the upstream port and the FastAPI
+   route shape, neither of which Caddy can know. A post-deploy curl
+   smoketest (200 OR auth-expected 401/403) is the only way to catch
+   transport mismatches.
+
+3. **Prefer `handle` over `handle_path` for routes whose upstream FastAPI
+   handler declares the path prefix in its decorator.** `handle_path`
+   strips the matched prefix from the request URI before forwarding —
+   if the upstream expects the full path (which `@router.get("/kb-images/...")`
+   does), the route never matches and you get a 404 that looks identical
+   to "route doesn't exist". Only use `handle_path` when the upstream
+   explicitly expects the prefix-stripped form. In klai's Caddyfile there
+   was exactly **one** `handle_path` block (the broken one) versus 16
+   `handle` blocks — that asymmetry alone was a smell that nobody flagged.
+
+4. **For every new `reverse_proxy <service>:<port>` line, verify the
+   port matches the service's actual listener.** `docker inspect
+   <container> .Config.ExposedPorts` is the canonical source. Klai's
+   portal-api `Dockerfile` exposes only `8010/tcp` — and yet the Caddy
+   directive said `:8000`. Nothing in CI compares these two.
+
+5. **When inheriting a route convention from a sister service (here:
+   knowledge-ingest's `zitadel_org_id` text-typed RLS), the new consumer
+   in another service MUST match the same convention or have an explicit
+   resolution helper.** The read-route assumed `org_id` was an int
+   (portal_orgs.id) because portal-api's session model is int-based; the
+   producer was zitadel-string-based. Cross-service ID-type mismatches
+   need an ADR or a Pydantic discriminator, not a silent type annotation.
+
 ## postgres-no-return-type-overload (HIGH)
 PostgreSQL does NOT support function overloading by return type alone.
 Two zero-argument functions with the same name and different return

--- a/deploy/caddy/Caddyfile
+++ b/deploy/caddy/Caddyfile
@@ -279,8 +279,16 @@
     # portal-api verifies session.org_id == path[org_id] before streaming from S3.
     # Operator step: disable Garage website-mode ->
     #   ssh core-01 "docker exec klai-core-garage-1 garage bucket website --deny klai-images"
-    handle_path /kb-images/* {
-        reverse_proxy portal-api:8000 {
+    #
+    # SPEC-TI-009 follow-up (kb-images was silently 502 since 2026-04-22 because
+    # this block had two stacked bugs that no browser-leg traffic ever surfaced):
+    #   1. handle_path strips the /kb-images/ prefix before forwarding upstream,
+    #      so FastAPI never matched its declared route @router.get("/kb-images/...").
+    #      Use `handle` instead — keeps the path intact.
+    #   2. portal-api listens only on :8010 in production (uvicorn entrypoint
+    #      runs `--port 8010`). Routing to :8000 produced "Connection refused".
+    handle /kb-images/* {
+        reverse_proxy portal-api:8010 {
             header_up -X-Internal-Secret
             header_up -X-Caller-Service
             header_up -X-Org-ID

--- a/klai-portal/backend/app/api/kb_images.py
+++ b/klai-portal/backend/app/api/kb_images.py
@@ -33,6 +33,7 @@ from klai_image_storage import ImageStore
 from klai_image_storage.storage import MAX_IMAGE_SIZE
 from minio import Minio
 from minio.error import S3Error
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.app_knowledge_bases import _get_kb_or_404
@@ -43,6 +44,7 @@ from app.core.database import get_db
 from app.core.permissions import UserPermissions, get_caller_at_least
 from app.core.profiles import ProfileRole
 from app.core.session import SessionContext
+from app.models.portal import PortalOrg
 
 logger = structlog.get_logger()
 
@@ -164,44 +166,78 @@ async def _resolve_caller_org_id(
             logger.debug("kb_image_db_aclose_error", exc_info=True)
 
 
+async def _resolve_zitadel_org_id(org_id: int, db: AsyncSession) -> str:
+    """Look up the zitadel_org_id for a given portal_orgs.id.
+
+    The kb-images S3 key prefix uses zitadel_org_id (string) because that's
+    the canonical tenant id in the knowledge domain (knowledge.artifacts.org_id
+    is text, _rls_current_org_id() returns text). Auth-flow gives us
+    portal_orgs.id (numeric) from the session — we resolve via portal_orgs
+    once per request.
+
+    Raises HTTPException(404) if the org is gone (e.g. mid-deprovision).
+    """
+    result = await db.execute(select(PortalOrg.zitadel_org_id).where(PortalOrg.id == org_id))
+    zitadel = result.scalar_one_or_none()
+    if zitadel is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Organisation not found",
+        )
+    return zitadel
+
+
 # @MX:ANCHOR: KB-image auth-proxy endpoint -- AC-1 through AC-5 of SPEC-TI-009
 # @MX:REASON: Single enforcement point for cross-tenant image access control.
-#   Every image fetch from the browser goes through this handler after the
-#   Caddy backend is switched from garage:3902 to portal-api:8000.
+#   Every image fetch from the browser goes through this handler.
 #   Changing the org_id check or the S3 key format breaks tenant isolation.
+#   The path org_id is a zitadel_org_id (string) to match the convention used
+#   by klai-connector + klai-knowledge-ingest (which both use zitadel_org_id
+#   as the canonical tenant id in the knowledge domain — see knowledge.artifacts.org_id
+#   text column and the _rls_current_org_id() text helper).
 # @MX:SPEC: SPEC-TI-009, finding B-4
 @router.get("/kb-images/{org_id}/{kb_slug}/{filename}")
 async def get_kb_image(
-    org_id: int,
+    org_id: str,
     kb_slug: str,
     filename: str,
     request: Request,
     session: SessionContext | None = Depends(get_optional_session),
+    db: AsyncSession = Depends(get_db),
 ) -> StreamingResponse:
     """Auth-proxied KB-image read (SPEC-TI-009 AC-1).
 
-    Authorization: session.org_id or partner key org_id must equal path org_id.
-    Streams from Garage S3 API (private, authenticated).
-    Cache-Control: private, max-age=86400.
+    Authorization: caller's zitadel_org_id (looked up from session.org_id or
+    partner key) MUST equal the path's org_id. Streams from Garage S3 API
+    (private, authenticated). Cache-Control: private, max-age=86400.
+
+    The path uses zitadel_org_id (an 18-digit string) because that's the
+    canonical tenant id in the knowledge domain — the connector + crawler
+    pipelines both write S3 keys under {zitadel_org_id}/... and Caddy
+    serves browser fetches with the same prefix.
     """
-    # Step 1: Resolve caller identity
+    # Step 1: Resolve caller identity → portal_orgs.id (int)
     caller_org_id = await _resolve_caller_org_id(request, session)
 
-    # Step 2: Authorize -- caller org MUST match path org_id (AC-5)
-    if caller_org_id != org_id:
+    # Step 2: Look up the caller's zitadel_org_id (S3 keys use the zitadel id)
+    caller_zitadel_org_id = await _resolve_zitadel_org_id(caller_org_id, db)
+
+    # Step 3: Authorize — caller's zitadel org MUST match path org_id (AC-5)
+    if caller_zitadel_org_id != org_id:
         logger.warning(
             "kb_image_cross_tenant_blocked",
             caller_org_id=caller_org_id,
+            caller_zitadel_org_id=caller_zitadel_org_id,
             path_org_id=org_id,
             kb_slug=kb_slug,
             filename=filename,
         )
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
 
-    # Step 3: Build Garage S3 object key (format from SPEC-KB-IMAGE-002)
+    # Step 4: Build Garage S3 object key (format from SPEC-KB-IMAGE-002)
     object_key = f"{org_id}/images/{kb_slug}/{filename}"
 
-    # Step 4: Guard against unconfigured Garage endpoint (dev / test env)
+    # Step 5: Guard against unconfigured Garage endpoint (dev / test env)
     if not settings.garage_s3_endpoint:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -214,7 +250,7 @@ async def get_kb_image(
 
     structlog.contextvars.bind_contextvars(org_id=org_id, kb_slug=kb_slug)
 
-    # Step 5: Return StreamingResponse with cache headers (AC-1)
+    # Step 6: Return StreamingResponse with cache headers (AC-1)
     return StreamingResponse(
         _stream_object(client, settings.garage_kb_bucket, object_key),
         media_type=content_type,
@@ -339,18 +375,26 @@ async def upload_kb_image(
             detail="Unsupported image type",
         )
 
-    # Step 5: Upload via the shared lib (content-addressed dedup).
+    # Step 5: Resolve caller's zitadel_org_id — the S3 key prefix convention
+    # used by klai-connector + klai-knowledge-ingest, matched by the read-route
+    # above. Using portal_orgs.id here would create a dual prefix conventie
+    # (zitadel for connector-images, portal-int for user uploads) and break
+    # the read-route's auth check uniformity.
+    zitadel_org_id = await _resolve_zitadel_org_id(perms.org_id, db)
+
+    # Step 6: Upload via the shared lib (content-addressed dedup).
     store = ImageStore(
         endpoint=settings.garage_s3_endpoint,
         access_key=settings.garage_s3_access_key,
         secret_key=settings.garage_s3_secret_key,
         bucket=settings.garage_kb_bucket,
     )
-    result = await store.upload_image(str(perms.org_id), kb_slug, data, ext)
+    result = await store.upload_image(zitadel_org_id, kb_slug, data, ext)
 
     logger.info(
         "kb_image_uploaded",
         org_id=perms.org_id,
+        zitadel_org_id=zitadel_org_id,
         kb_slug=kb_slug,
         kb_id=kb.id,
         size=len(data),

--- a/klai-portal/backend/tests/test_kb_image_upload.py
+++ b/klai-portal/backend/tests/test_kb_image_upload.py
@@ -69,6 +69,14 @@ def _make_image_store_mock(deduplicated: bool = False) -> MagicMock:
     return constructor
 
 
+# Zitadel org_id used as the S3 key prefix. See SPEC-TI-009 follow-up:
+# kb-images uses zitadel_org_id (string) as the prefix because that matches
+# what klai-connector and klai-knowledge-ingest write. The route resolves
+# session.org_id (portal int) -> zitadel via _resolve_zitadel_org_id, which
+# we mock to return this value.
+ZITADEL_ORG_ID = "368884765035593759"
+
+
 # Minimal valid PNG bytes (1x1 transparent pixel).
 _PNG_1X1 = bytes.fromhex(
     "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4"
@@ -130,6 +138,7 @@ async def test_upload_png_returns_url_and_not_deduplicated() -> None:
         patch("app.api.kb_images._get_kb_or_404", AsyncMock(return_value=_make_kb())),
         patch("app.api.kb_images.settings", _mock_settings_with_garage()),
         patch("app.api.kb_images.ImageStore", store_cls),
+        patch("app.api.kb_images._resolve_zitadel_org_id", AsyncMock(return_value=ZITADEL_ORG_ID)),
     ):
         result = await upload_kb_image(
             request=_make_request(),
@@ -140,7 +149,7 @@ async def test_upload_png_returns_url_and_not_deduplicated() -> None:
         )
 
     assert result["deduplicated"] is False
-    assert result["url"].startswith("/kb-images/42/images/klai-help/")
+    assert result["url"].startswith(f"/kb-images/{ZITADEL_ORG_ID}/images/klai-help/")
     assert result["url"].endswith(".png")
     # ImageStore was instantiated once with the configured Garage settings.
     store_cls.assert_called_once()
@@ -158,6 +167,7 @@ async def test_upload_same_bytes_twice_deduplicates() -> None:
         patch("app.api.kb_images._get_kb_or_404", AsyncMock(return_value=_make_kb())),
         patch("app.api.kb_images.settings", _mock_settings_with_garage()),
         patch("app.api.kb_images.ImageStore", store_cls),
+        patch("app.api.kb_images._resolve_zitadel_org_id", AsyncMock(return_value=ZITADEL_ORG_ID)),
     ):
         result = await upload_kb_image(
             request=_make_request(),

--- a/klai-portal/backend/tests/test_kb_images_auth_proxy.py
+++ b/klai-portal/backend/tests/test_kb_images_auth_proxy.py
@@ -17,8 +17,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
+# Portal session org_id (portal_orgs.id, numeric).
 ORG_ID = 42
 OTHER_ORG_ID = 99
+# Zitadel org_id (string) — the canonical S3 key prefix used by connector +
+# crawler + the read-route path param. Resolved from session.org_id via the
+# _resolve_zitadel_org_id helper (mocked in tests).
+ZITADEL_ORG_ID = "368884765035593759"
+OTHER_ZITADEL_ORG_ID = "368884765035000000"
 KB_SLUG = "my-kb"
 FILENAME = "abc123.png"
 
@@ -75,31 +81,40 @@ def _mock_minio(data=b"fake", content_type="image/png"):
 
 @pytest.mark.anyio
 async def test_authenticated_user_can_read_own_org_image(kb_app):
-    """AC-1: session user reads own org image -> 200."""
+    """AC-1: session user reads own org image -> 200.
+
+    The path uses zitadel_org_id (string). The route resolves session.org_id
+    (portal int) to zitadel via _resolve_zitadel_org_id (patched here) and
+    compares against the path.
+    """
     from app.api.session_deps import get_optional_session
 
     session = _make_session(org_id=ORG_ID)
     kb_app.dependency_overrides[get_optional_session] = lambda: session
+    kb_app.dependency_overrides[__import__("app.core.database", fromlist=["get_db"]).get_db] = _mock_get_db()
     mock_cls = _mock_minio()
     with (
         patch("app.api.kb_images.Minio", mock_cls),
         patch("app.api.kb_images.settings", _mock_settings()),
+        patch("app.api.kb_images._resolve_zitadel_org_id", AsyncMock(return_value=ZITADEL_ORG_ID)),
     ):
         async with httpx.AsyncClient(transport=httpx.ASGITransport(app=kb_app), base_url="http://test") as client:
-            resp = await client.get(f"/kb-images/{ORG_ID}/{KB_SLUG}/{FILENAME}")
+            resp = await client.get(f"/kb-images/{ZITADEL_ORG_ID}/{KB_SLUG}/{FILENAME}")
     assert resp.status_code == 200
     assert resp.headers["Cache-Control"] == "private, max-age=86400"
 
 
 @pytest.mark.anyio
 async def test_authenticated_user_cannot_read_foreign_org_image(kb_app):
-    """AC-5: session user org=42 requests org=99 image -> 403."""
+    """AC-5: session user (zitadel=A) requests org-B image -> 403."""
     from app.api.session_deps import get_optional_session
 
     session = _make_session(org_id=ORG_ID)
     kb_app.dependency_overrides[get_optional_session] = lambda: session
-    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=kb_app), base_url="http://test") as client:
-        resp = await client.get(f"/kb-images/{OTHER_ORG_ID}/{KB_SLUG}/{FILENAME}")
+    kb_app.dependency_overrides[__import__("app.core.database", fromlist=["get_db"]).get_db] = _mock_get_db()
+    with patch("app.api.kb_images._resolve_zitadel_org_id", AsyncMock(return_value=ZITADEL_ORG_ID)):
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=kb_app), base_url="http://test") as client:
+            resp = await client.get(f"/kb-images/{OTHER_ZITADEL_ORG_ID}/{KB_SLUG}/{FILENAME}")
     assert resp.status_code == 403
     assert resp.json()["detail"] == "Access denied"
 
@@ -110,8 +125,9 @@ async def test_unauthenticated_request_rejected(kb_app):
     from app.api.session_deps import get_optional_session
 
     kb_app.dependency_overrides[get_optional_session] = lambda: None
+    kb_app.dependency_overrides[__import__("app.core.database", fromlist=["get_db"]).get_db] = _mock_get_db()
     async with httpx.AsyncClient(transport=httpx.ASGITransport(app=kb_app), base_url="http://test") as client:
-        resp = await client.get(f"/kb-images/{ORG_ID}/{KB_SLUG}/{FILENAME}")
+        resp = await client.get(f"/kb-images/{ZITADEL_ORG_ID}/{KB_SLUG}/{FILENAME}")
     assert resp.status_code == 401
 
 
@@ -140,29 +156,31 @@ def _mock_get_db():
 
 @pytest.mark.anyio
 async def test_widget_public_image_works(kb_app):
-    """Widget/partner caller with matching org_id -> 200."""
+    """Widget/partner caller with matching zitadel_org_id -> 200."""
     from app.api.partner_dependencies import PartnerAuthContext
     from app.api.session_deps import get_optional_session
 
     ctx = PartnerAuthContext(
         key_id="wgt",
         org_id=ORG_ID,
-        zitadel_org_id="z",
+        zitadel_org_id=ZITADEL_ORG_ID,
         permissions={"chat": True},
         kb_access={},
         rate_limit_rpm=60,
     )
     kb_app.dependency_overrides[get_optional_session] = lambda: None
+    kb_app.dependency_overrides[__import__("app.core.database", fromlist=["get_db"]).get_db] = _mock_get_db()
     mock_cls = _mock_minio(content_type="image/webp")
     with (
         patch("app.api.kb_images.get_partner_key", new=AsyncMock(return_value=ctx)),
         patch("app.core.database.get_db", new=_mock_get_db()),
         patch("app.api.kb_images.Minio", mock_cls),
         patch("app.api.kb_images.settings", _mock_settings()),
+        patch("app.api.kb_images._resolve_zitadel_org_id", AsyncMock(return_value=ZITADEL_ORG_ID)),
     ):
         async with httpx.AsyncClient(transport=httpx.ASGITransport(app=kb_app), base_url="http://test") as client:
             resp = await client.get(
-                f"/kb-images/{ORG_ID}/{KB_SLUG}/{FILENAME}",
+                f"/kb-images/{ZITADEL_ORG_ID}/{KB_SLUG}/{FILENAME}",
                 headers={"Authorization": "Bearer some-widget-token"},
             )
     assert resp.status_code == 200
@@ -170,29 +188,31 @@ async def test_widget_public_image_works(kb_app):
 
 @pytest.mark.anyio
 async def test_partner_api_key_image_access(kb_app):
-    """Partner API key with matching org_id -> 200."""
+    """Partner API key with matching zitadel_org_id -> 200."""
     from app.api.partner_dependencies import PartnerAuthContext
     from app.api.session_deps import get_optional_session
 
     ctx = PartnerAuthContext(
         key_id="pk_live_x",
         org_id=ORG_ID,
-        zitadel_org_id="z",
+        zitadel_org_id=ZITADEL_ORG_ID,
         permissions={},
         kb_access={},
         rate_limit_rpm=120,
     )
     kb_app.dependency_overrides[get_optional_session] = lambda: None
+    kb_app.dependency_overrides[__import__("app.core.database", fromlist=["get_db"]).get_db] = _mock_get_db()
     mock_cls = _mock_minio(content_type="image/jpeg")
     with (
         patch("app.api.kb_images.get_partner_key", new=AsyncMock(return_value=ctx)),
         patch("app.core.database.get_db", new=_mock_get_db()),
         patch("app.api.kb_images.Minio", mock_cls),
         patch("app.api.kb_images.settings", _mock_settings()),
+        patch("app.api.kb_images._resolve_zitadel_org_id", AsyncMock(return_value=ZITADEL_ORG_ID)),
     ):
         async with httpx.AsyncClient(transport=httpx.ASGITransport(app=kb_app), base_url="http://test") as client:
             resp = await client.get(
-                f"/kb-images/{ORG_ID}/{KB_SLUG}/{FILENAME}",
+                f"/kb-images/{ZITADEL_ORG_ID}/{KB_SLUG}/{FILENAME}",
                 headers={"Authorization": "Bearer pk_live_testkey"},
             )
     assert resp.status_code == 200
@@ -207,6 +227,7 @@ async def test_404_for_nonexistent_object(kb_app):
 
     session = _make_session(org_id=ORG_ID)
     kb_app.dependency_overrides[get_optional_session] = lambda: session
+    kb_app.dependency_overrides[__import__("app.core.database", fromlist=["get_db"]).get_db] = _mock_get_db()
 
     mock_cls = MagicMock()
     mock_client = MagicMock()
@@ -233,9 +254,10 @@ async def test_404_for_nonexistent_object(kb_app):
     with (
         patch("app.api.kb_images.Minio", mock_cls),
         patch("app.api.kb_images.settings", _mock_settings()),
+        patch("app.api.kb_images._resolve_zitadel_org_id", AsyncMock(return_value=ZITADEL_ORG_ID)),
     ):
         async with httpx.AsyncClient(transport=httpx.ASGITransport(app=kb_app), base_url="http://test") as client:
-            resp = await client.get(f"/kb-images/{ORG_ID}/{KB_SLUG}/{FILENAME}")
+            resp = await client.get(f"/kb-images/{ZITADEL_ORG_ID}/{KB_SLUG}/{FILENAME}")
     assert resp.status_code == 404
 
 
@@ -246,12 +268,14 @@ async def test_cache_control_header_set_correctly(kb_app):
 
     session = _make_session(org_id=ORG_ID)
     kb_app.dependency_overrides[get_optional_session] = lambda: session
+    kb_app.dependency_overrides[__import__("app.core.database", fromlist=["get_db"]).get_db] = _mock_get_db()
     mock_cls = _mock_minio()
     with (
         patch("app.api.kb_images.Minio", mock_cls),
         patch("app.api.kb_images.settings", _mock_settings()),
+        patch("app.api.kb_images._resolve_zitadel_org_id", AsyncMock(return_value=ZITADEL_ORG_ID)),
     ):
         async with httpx.AsyncClient(transport=httpx.ASGITransport(app=kb_app), base_url="http://test") as client:
-            resp = await client.get(f"/kb-images/{ORG_ID}/{KB_SLUG}/{FILENAME}")
+            resp = await client.get(f"/kb-images/{ZITADEL_ORG_ID}/{KB_SLUG}/{FILENAME}")
     assert resp.status_code == 200
     assert resp.headers["Cache-Control"] == "private, max-age=86400"


### PR DESCRIPTION
## TL;DR

Three stacked bugs made `/kb-images/*` silently broken since SPEC-TI-009 landed
(commit `b7ce84b4`, 2026-04-22, ~3 weeks). Caught while smoke-testing PR #592's
new image-paste flow — it was the first browser-leg consumer of the route.

## The three bugs

| # | Layer | Symptom | Cause |
|---|---|---|---|
| 1 | Caddy | 502 Bad Gateway | `reverse_proxy portal-api:8000` (dead); portal-api listens only on `:8010` |
| 2 | Caddy | 404 even if Bug 1 fixed | `handle_path` strips `/kb-images/` before forwarding; FastAPI route declared with that prefix never matches |
| 3 | portal-api | 403 even if Bugs 1+2 fixed | Read-route compares `session.org_id` (portal_orgs.id, numeric int) to path's `org_id` (also int) — but the connector + crawler write S3 keys under `{zitadel_org_id}/...` (18-digit string), so they'd never match |

Verified empirically: Caddy access logs of `/kb-images/*` since deploy show **only** this session's own diagnostic curls. No browser ever fetched a kb-image URL in production. The route was alive only for RAG context (LLM sees the URL as a token string, never fetches).

## Fix (Optie B — minimal scope)

- **Caddy**: `handle_path` → `handle`, `portal-api:8000` → `portal-api:8010` (2 line block).
- **Read-route**: path `org_id` now `str` (zitadel). Auth resolves `session.org_id` → zitadel via new `_resolve_zitadel_org_id` helper (1 PortalOrg lookup; client-cached 24h via existing `Cache-Control: private, max-age=86400`).
- **POST (from PR #592)**: writes under `{zitadel_org_id}/...` prefix too, consistent with connector + crawler. One DB roundtrip per upload.

## Why not Optie A (make everything portal_orgs.id)

- `knowledge.artifacts.org_id` is `text` and tied to `knowledge._rls_current_org_id() RETURNS text`. Migration would touch portal-api + connector + knowledge-ingest + an alembic migration on `knowledge.artifacts` + re-prefix of every S3 object.
- Optie B is one service, no migration, no data move. **The existing 1553 production images (Voys) keep working as-is.**

## Verification

- `test_kb_image_upload.py` + `test_kb_images_auth_proxy.py`: **17/17** green.
- Full portal-api suite: **2491/0**.
- `ruff check` + `ruff format` + `pyright` on changed files: clean.
- `caddy validate` against the new Caddyfile: `Valid configuration`.

## Post-merge deploy steps

1. `deploy-compose.yml` workflow auto-triggers on `deploy/caddy/Caddyfile` change → syncs to `/opt/klai/caddy/Caddyfile` → recreates Caddy container (per SPEC-INFRA-CADDY-CONFIG-DEPLOY-001). ~1s TLS interruption.
2. `portal-api.yml` workflow auto-triggers on `klai-portal/backend/**` change → rebuilds + deploys portal-api image.
3. **Manual smoketest after both runs are green**: open https://my.getklai.com/app/docs/<voys-kb>/<page> with an existing Voys page that has connector-images, verify they render. Then paste a fresh screenshot via the docs editor (PR #592 feature), verify it also renders.

## Why nobody noticed for 3 weeks

Documented as a new pitfall in `process-rules.md` (separate commit follow-up): *Caddy `reverse_proxy` regels die alleen door RAG-content worden geraakt produceren nooit een 5xx alert want er is geen browser-leg consumer.*

## Refs

- SPEC-TI-009 (the regression's origin)
- SPEC-PORTAL-DOCS-IMAGE-PASTE-001 (PR #592 — the browser-leg consumer that exposed this)
- SPEC-INFRA-CADDY-CONFIG-DEPLOY-001 (the Caddyfile sync pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)