### PR TITLE
fix(portal-api): wire GARAGE_S3_* env into compose — kb-images was 503

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -474,6 +474,18 @@ services:
       # a future admin-api caller picks up the real token, matching the
       # pre-migration env-shape.
       VEXA_ADMIN_TOKEN: ${VEXA_ADMIN_TOKEN}
+      # ─── Garage S3 — KB-image auth-proxy (SPEC-TI-009 + SPEC-PORTAL-DOCS-IMAGE-PASTE-001) ─
+      # portal-api is the auth-proxy for /kb-images/{org_id}/{kb_slug}/{filename}
+      # (read: SPEC-TI-009 GET; write: SPEC-PORTAL-DOCS-IMAGE-PASTE-001 POST).
+      # Without these vars the route 503s with "Image storage not configured".
+      # Missing from compose pre-fix because SPEC-SEC-ENVFILE-SCOPE-001 didn't
+      # include them when portal-api's environment block was made explicit —
+      # the read-route was never browser-fetched until 2026-05-12, so nobody
+      # noticed. Same env shape as klai-connector + klai-knowledge-ingest.
+      GARAGE_S3_ENDPOINT: garage:3900
+      GARAGE_S3_ACCESS_KEY: ${GARAGE_ACCESS_KEY}
+      GARAGE_S3_SECRET_KEY: ${GARAGE_SECRET_KEY}
+      GARAGE_KB_BUCKET: ${GARAGE_BUCKET:-klai-images}
       # ─── Billing — Moneybird ────────────────────────────────────
       # Validator in config.py requires MONEYBIRD_WEBHOOK_TOKEN at boot.
       MONEYBIRD_WEBHOOK_TOKEN: ${MONEYBIRD_WEBHOOK_TOKEN}


### PR DESCRIPTION
## TL;DR

E2E-smoketest van PR #598 (kb-images Caddy fix) onthulde een vierde latente bug: portal-api's `docker-compose.yml` environment block heeft géén `GARAGE_S3_*` env vars. Daardoor returnt zowel de read-route als mijn nieuwe POST `503 Image storage not configured` — ook ná de Caddy fix.

## Bewijs

```bash
$ docker exec klai-core-portal-api-1 printenv | grep -i garage
(empty)
$ curl -b cookies https://my.getklai.com/kb-images/.../foo.png
HTTP/1.1 503 Service Unavailable
{"detail":"Image storage not configured"}
```

## Root cause

SPEC-SEC-ENVFILE-SCOPE-001 maakte portal-api's environment-block expliciet (was `env_file: .env`) maar nam de `GARAGE_S3_*` family niet mee. De read-route (SPEC-TI-009) werd nooit browser-fetched in productie (zie PR #598 retro), dus de 503 was onzichtbaar. De Caddy port+handle_path bugs in #598 maskeerden het verder — Caddy gaf 502 voordat portal-api z'n 503 kon laten zien.

## Fix

Zelfde env-shape als klai-connector + klai-knowledge-ingest, toegevoegd aan portal-api's `environment:` block:

```yaml
GARAGE_S3_ENDPOINT: garage:3900
GARAGE_S3_ACCESS_KEY: ${GARAGE_ACCESS_KEY}
GARAGE_S3_SECRET_KEY: ${GARAGE_SECRET_KEY}
GARAGE_KB_BUCKET: ${GARAGE_BUCKET:-klai-images}
```

`GARAGE_ACCESS_KEY` / `GARAGE_SECRET_KEY` / `GARAGE_BUCKET` zijn de bestaande names in `/opt/klai/.env` (connector + crawler gebruiken ze al). De pydantic-veld-namen in portal-api zijn `garage_s3_*` dus environment-mapping naar `GARAGE_S3_*` is de juiste vorm.

## Deploy

`deploy-compose.yml` workflow triggert op `deploy/docker-compose.yml` change → `compose-up.sh portal-api` recreate.

## Post-merge verificatie

Curl tegen een echte productie s3_key met een geldige sessie:
- Expected: `200 OK` (object exists) of `404` (object gone) — NIET `503`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)