### PR TITLE
fix(portal-frontend): kb-images POST URL needs no /api prefix

### DIFF
--- a/klai-portal/frontend/src/components/kb-editor/BlockPageEditor.tsx
+++ b/klai-portal/frontend/src/components/kb-editor/BlockPageEditor.tsx
@@ -59,8 +59,12 @@ export const BlockPageEditor = forwardRef<
       const fd = new FormData()
       fd.append('file', file)
       try {
+        // The kb-images router is mounted at /kb-images (no /api prefix —
+        // see klai-portal/backend/app/main.py and SPEC-TI-009's Caddy block).
+        // Posting to /api/kb-images/... gives a 404 because the route only
+        // exists at /kb-images/...
         const res = await apiFetch<{ url: string; deduplicated: boolean }>(
-          `/api/kb-images/${encodeURIComponent(kbSlug)}`,
+          `/kb-images/${encodeURIComponent(kbSlug)}`,
           { method: 'POST', body: fd },
         )
         editorLogger.debug('Image uploaded', {


### PR DESCRIPTION
## TL;DR

End-to-end testing van PR #592 onthulde dat mijn `uploadFile`-callback in
`BlockPageEditor.tsx` POSTede naar `/api/kb-images/{kbSlug}` — maar de
`kb_images.py` router is gemount op `/kb-images` (zonder `/api/` prefix,
zelfde shape als de SPEC-TI-009 GET en de Caddy `handle /kb-images/*` block).

Result: BlockNote's paste-flow blijft in **'Loading...'** hangen omdat de
404-response een ApiError gooit die m'n catch-block opvangt en omzet in
een NL-melding, maar BlockNote's progress UI reset niet altijd schoon op
elke error-shape.

## Bewijs (via Playwright E2E)

```
POST /api/kb-images/{kbSlug} + CSRF → 404 'Not Found'  (route bestaat niet)
POST /kb-images/{kbSlug}     + CSRF → 404 'Knowledge base not found' (route OK, helper-fail op slug)
```

De tweede vorm is wat we willen: route bestaat, auth werkt, KB-resolve geeft
404 omdat de test-slug niet bestaat in mijn org. Met een echte KB-slug zou
het 200 + dedup-URL returnen.

## Fix

```diff
- `/api/kb-images/${encodeURIComponent(kbSlug)}`
+ `/kb-images/${encodeURIComponent(kbSlug)}`
```

## Deploy

`portal-frontend.yml` workflow auto-triggers op `klai-portal/frontend/**`
change → rebuilt SPA bundle, Caddy serveert direct.

## Verificatie (post-deploy)

Browser smoketest:
1. `https://my.getklai.com/app/docs/<kb>/<page>` openen
2. Cmd-V een screenshot uit clipboard
3. Verwacht: image verschijnt in page; **niet** een eeuwige 'Loading...'

🤖 Generated with [Claude Code](https://claude.com/claude-code)