### PR TITLE
chore(portal): polish — i18n, drift-guard, helper reuse

### DIFF
--- a/klai-portal/backend/app/api/admin/extensions.py
+++ b/klai-portal/backend/app/api/admin/extensions.py
@@ -7,24 +7,24 @@ Powers the /admin/settings Uitbreidingen-sectie.
 Writes live on ``PATCH /api/admin/orgs/{slug}/platform-unlocks`` —
 platform-admin only, sole write-path so there is exactly one audit trail
 in ``tenant_lifecycle_events``. This module deliberately does NOT export
-a PATCH endpoint of its own anymore; the brief Phase 4 duplicate has
-been retired during cleanup so platform_unlocks.py is the single source
-of mutation.
+a PATCH endpoint of its own; the brief Phase 4 duplicate has been retired
+so platform_unlocks.py is the single source of mutation.
+
+The response payload is intentionally language-agnostic: only the feature
+``key`` is returned. The frontend maps each key to its Paraglide messages
+``admin_extension_{key}_label`` / ``..._description``, keeping NL/EN
+switching client-side without a server round-trip.
 """
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends
 from pydantic import BaseModel
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.api.dependencies import _load_org_or_500
 from app.core.database import get_db
-from app.core.extensions_registry import (
-    EXTENSION_DESCRIPTIONS,
-    EXTENSION_LABELS,
-    KNOWN_FEATURES,
-)
+from app.core.extensions_registry import KNOWN_FEATURES
 from app.core.features import FEATURE_MIN_PROFILE
 from app.core.permissions import ProfileRole, UserPermissions, get_caller_at_least
 from app.models.portal import PortalOrg
@@ -39,8 +39,6 @@ router = APIRouter()
 
 class ExtensionItem(BaseModel):
     key: str
-    label: str
-    description: str
     enabled: bool
     requires_profile: str | None
     manageable_by_caller: bool
@@ -59,18 +57,15 @@ class ExtensionsResponse(BaseModel):
 def _build_extensions_payload(org: PortalOrg, perms: UserPermissions) -> ExtensionsResponse:
     """Build the response payload for a given target org + caller perms."""
     unlocked = set(org.platform_unlocked_features or [])
-    items: list[ExtensionItem] = []
-    for key in sorted(KNOWN_FEATURES):
-        items.append(
-            ExtensionItem(
-                key=key,
-                label=EXTENSION_LABELS.get(key, key),
-                description=EXTENSION_DESCRIPTIONS.get(key, ""),
-                enabled=key in unlocked,
-                requires_profile=FEATURE_MIN_PROFILE.get(key),
-                manageable_by_caller=perms.is_platform_admin,
-            )
+    items = [
+        ExtensionItem(
+            key=key,
+            enabled=key in unlocked,
+            requires_profile=FEATURE_MIN_PROFILE.get(key),
+            manageable_by_caller=perms.is_platform_admin,
         )
+        for key in sorted(KNOWN_FEATURES)
+    ]
     return ExtensionsResponse(org_slug=org.slug, extensions=items)
 
 
@@ -86,13 +81,11 @@ async def list_extensions(
 ) -> ExtensionsResponse:
     """Return all known extensions with on/off status for the caller's own org.
 
-    Tenant-admin sees own-org status read-only. Platform-admin sees same
-    payload with ``manageable_by_caller=true`` flag so the frontend renders
-    interactive checkboxes — writes still go through PATCH
-    /api/admin/orgs/{slug}/platform-unlocks (single source of mutation).
+    Tenant-admin sees own-org status read-only. Platform-admin sees the same
+    payload with ``manageable_by_caller=true`` so the frontend renders
+    interactive checkboxes — writes still go through
+    ``PATCH /api/admin/orgs/{slug}/platform-unlocks`` (single source of
+    mutation).
     """
-    result = await db.execute(select(PortalOrg).where(PortalOrg.id == perms.org_id, PortalOrg.deleted_at.is_(None)))
-    org = result.scalar_one_or_none()
-    if org is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Organisation not found")
+    org = await _load_org_or_500(db, perms.org_id)
     return _build_extensions_payload(org, perms)

--- a/klai-portal/backend/app/core/extensions_registry.py
+++ b/klai-portal/backend/app/core/extensions_registry.py
@@ -1,18 +1,25 @@
 """Single registry for tenant extensions — SPEC-PORTAL-EXTENSIONS-UNIFY-001.
 
-One source of truth for:
+One source of truth for the set of platform-managed feature keys that may
+appear in ``portal_orgs.platform_unlocked_features``. Validated by every
+write path (``admin/platform_unlocks.py::patch_platform_unlocks``) and
+enumerated by every read path (``admin/extensions.py::list_extensions``).
 
-- ``KNOWN_FEATURES`` — the set of platform-managed feature keys that may
-  appear in ``portal_orgs.platform_unlocked_features``. Validated by every
-  write path (admin/platform_unlocks PATCH, admin/extensions GET context).
-- ``EXTENSION_LABELS`` / ``EXTENSION_DESCRIPTIONS`` — user-facing strings
-  surfaced by ``GET /api/admin/extensions`` so the frontend renders a
-  consistent list across tenants.
+User-facing labels and descriptions used to live here too. They moved to
+the frontend (Paraglide i18n) so the backend stays language-agnostic and
+EN/NL switching works without a server round-trip.
 
-Adding a new platform-managed feature: add the key here AND give it a
-``FEATURE_MIN_PROFILE`` entry in ``app/core/features.py`` if it is a
-user-facing product. Features without a ``FEATURE_MIN_PROFILE`` entry
-remain platform-gates only (no surface in ``derive_user_products``).
+Adding a new platform-managed feature:
+
+1. Add the key here.
+2. If it surfaces as a user-facing product (sidebar item / page), give it
+   a ``FEATURE_MIN_PROFILE`` entry in ``app/core/features.py``.
+3. Add ``admin_extension_{key}_label`` + ``admin_extension_{key}_description``
+   Paraglide messages in ``klai-portal/frontend/messages/{nl,en}.json``.
+
+The drift-guard
+``test_features_derive.py::test_known_features_consistent_with_feature_min_profile``
+fails CI if (1) and (2) get out of sync.
 """
 
 from __future__ import annotations
@@ -30,20 +37,7 @@ KNOWN_FEATURES: frozenset[str] = frozenset(
     }
 )
 
-
-EXTENSION_LABELS: dict[str, str] = {
-    "partner_api": "API keys",
-    "widgets": "Chat-widgets",
-    "custom_mcps": "Custom MCP servers",
-    "scribe": "Scribe — meeting-transcripties",
-    "docs": "Docs — gedeelde KBs",
-}
-
-
-EXTENSION_DESCRIPTIONS: dict[str, str] = {
-    "partner_api": "Programmatische toegang via pk_live_* API-keys.",
-    "widgets": "Embed chat-widget op klant-website.",
-    "custom_mcps": "Eigen Model Context Protocol servers koppelen.",
-    "scribe": "Automatische meeting-transcriptie.",
-    "docs": "Documentatie-KBs delen binnen de organisatie.",
-}
+# Subset of KNOWN_FEATURES whose entries are also user-facing products
+# (i.e. show up in derive_user_products output, gated by FEATURE_MIN_PROFILE).
+# The drift-guard test pins this to match the FEATURE_MIN_PROFILE keys.
+PRODUCT_FEATURES: frozenset[str] = frozenset({"scribe", "docs"})

--- a/klai-portal/backend/tests/test_admin_extensions.py
+++ b/klai-portal/backend/tests/test_admin_extensions.py
@@ -17,11 +17,14 @@ from tests.conftest import make_org, make_perms
 
 
 def _db_with_org(org: MagicMock) -> AsyncMock:
-    """Mock AsyncSession that returns the given org on `.execute().scalar_one_or_none()`."""
+    """Mock AsyncSession that returns the given org on ``db.get(PortalOrg, org_id)``.
+
+    The endpoint resolves the caller's org via ``_load_org_or_500`` which uses
+    ``db.get``; older versions of these tests stubbed ``db.execute`` directly,
+    which silently no-op'd after the cleanup PR.
+    """
     db = AsyncMock()
-    result = MagicMock()
-    result.scalar_one_or_none = MagicMock(return_value=org)
-    db.execute = AsyncMock(return_value=result)
+    db.get = AsyncMock(return_value=org)
     return db
 
 
@@ -57,8 +60,10 @@ class TestListExtensions:
             assert item.manageable_by_caller is True
 
     @pytest.mark.asyncio
-    async def test_response_payload_is_sorted_and_labelled(self) -> None:
-        """Each item carries its display label + description; order is stable."""
+    async def test_response_payload_is_sorted_and_language_agnostic(self) -> None:
+        """SPEC-PORTAL-EXTENSIONS-UNIFY-001 polish: backend returns keys only,
+        no language-specific label/description. Frontend maps to Paraglide
+        messages client-side so NL/EN switching is server-free."""
         perms = make_perms(role="admin", org_id=42)
         org = make_org(org_id=42, slug="acme", platform_unlocked_features=["partner_api"])
         db = _db_with_org(org)
@@ -66,7 +71,7 @@ class TestListExtensions:
         # Sorted by key alphabetically.
         keys_in_order = [item.key for item in result.extensions]
         assert keys_in_order == sorted(keys_in_order)
-        # Every item has a non-empty label.
+        # No label/description fields leak through — the schema is i18n-clean.
         for item in result.extensions:
-            assert item.label
-            assert item.description
+            assert not hasattr(item, "label") or "label" not in item.model_fields
+            assert not hasattr(item, "description") or "description" not in item.model_fields

--- a/klai-portal/backend/tests/test_features_derive.py
+++ b/klai-portal/backend/tests/test_features_derive.py
@@ -133,3 +133,34 @@ def test_addon_products_floor_company() -> None:
     # SPEC sparring decision: scribe/docs gate at "company".
     assert FEATURE_MIN_PROFILE["scribe"] == "company"
     assert FEATURE_MIN_PROFILE["docs"] == "company"
+
+
+def test_known_features_consistent_with_feature_min_profile() -> None:
+    """SPEC-PORTAL-EXTENSIONS-UNIFY-001 drift-guard.
+
+    A platform-feature that surfaces as a user-facing product MUST:
+    - Be in ``KNOWN_FEATURES`` (so PATCH validation accepts it).
+    - Have a ``FEATURE_MIN_PROFILE`` entry (so derive_user_products emits it).
+    - Be in ``PRODUCT_FEATURES`` (the explicit subset).
+
+    Adding a new product means editing both files; this test fails CI if
+    one of the edits is missed, mechanically preventing the "silent skip
+    in derive_user_products" failure mode.
+    """
+    from app.core.extensions_registry import KNOWN_FEATURES, PRODUCT_FEATURES
+
+    # Plan-only products (chat / knowledge) are NOT platform-features and
+    # therefore not in KNOWN_FEATURES.
+    plan_only_products = {"chat", "knowledge"}
+    product_floors = set(FEATURE_MIN_PROFILE.keys()) - plan_only_products
+
+    # The product-floors must exactly match PRODUCT_FEATURES.
+    assert product_floors == PRODUCT_FEATURES, (
+        f"FEATURE_MIN_PROFILE (minus plan-products) = {sorted(product_floors)} "
+        f"diverges from PRODUCT_FEATURES = {sorted(PRODUCT_FEATURES)}"
+    )
+
+    # And every product-feature must be a member of KNOWN_FEATURES.
+    assert PRODUCT_FEATURES <= KNOWN_FEATURES, (
+        f"PRODUCT_FEATURES not a subset of KNOWN_FEATURES: {sorted(PRODUCT_FEATURES - KNOWN_FEATURES)}"
+    )

--- a/klai-portal/frontend/messages/en.json
+++ b/klai-portal/frontend/messages/en.json
@@ -1730,5 +1730,15 @@
   "admin_settings_extensions_active_slug": "Active: {slug}",
   "admin_settings_extensions_status_on": "On",
   "admin_settings_extensions_status_off": "Off",
-  "admin_settings_extensions_managed_by_klai": "These extensions are managed by Klai. Contact us to request changes."
+  "admin_settings_extensions_managed_by_klai": "These extensions are managed by Klai. Contact us to request changes.",
+  "admin_extension_partner_api_label": "API keys",
+  "admin_extension_partner_api_description": "Programmatic access via pk_live_* API keys.",
+  "admin_extension_widgets_label": "Chat widgets",
+  "admin_extension_widgets_description": "Embed a chat widget on customer-facing sites.",
+  "admin_extension_custom_mcps_label": "Custom MCP servers",
+  "admin_extension_custom_mcps_description": "Connect your own Model Context Protocol servers.",
+  "admin_extension_scribe_label": "Scribe — meeting transcripts",
+  "admin_extension_scribe_description": "Automatic meeting transcription.",
+  "admin_extension_docs_label": "Docs — shared KBs",
+  "admin_extension_docs_description": "Share documentation KBs across the organisation."
 }

--- a/klai-portal/frontend/messages/nl.json
+++ b/klai-portal/frontend/messages/nl.json
@@ -1730,5 +1730,15 @@
   "admin_settings_extensions_active_slug": "Actief: {slug}",
   "admin_settings_extensions_status_on": "Aan",
   "admin_settings_extensions_status_off": "Uit",
-  "admin_settings_extensions_managed_by_klai": "Deze uitbreidingen worden door Klai beheerd. Neem contact op om wijzigingen aan te vragen."
+  "admin_settings_extensions_managed_by_klai": "Deze uitbreidingen worden door Klai beheerd. Neem contact op om wijzigingen aan te vragen.",
+  "admin_extension_partner_api_label": "API keys",
+  "admin_extension_partner_api_description": "Programmatische toegang via pk_live_* API-keys.",
+  "admin_extension_widgets_label": "Chat-widgets",
+  "admin_extension_widgets_description": "Embed chat-widget op klant-website.",
+  "admin_extension_custom_mcps_label": "Custom MCP servers",
+  "admin_extension_custom_mcps_description": "Eigen Model Context Protocol servers koppelen.",
+  "admin_extension_scribe_label": "Scribe — meeting-transcripties",
+  "admin_extension_scribe_description": "Automatische meeting-transcriptie.",
+  "admin_extension_docs_label": "Docs — gedeelde KBs",
+  "admin_extension_docs_description": "Documentatie-KBs delen binnen de organisatie."
 }

--- a/klai-portal/frontend/src/lib/extensions-i18n.ts
+++ b/klai-portal/frontend/src/lib/extensions-i18n.ts
@@ -1,0 +1,54 @@
+/**
+ * SPEC-PORTAL-EXTENSIONS-UNIFY-001 polish — frontend i18n for extension keys.
+ *
+ * The backend returns only feature keys (language-agnostic). This helper maps
+ * each key to its Paraglide label + description, keeping NL/EN switching
+ * client-side without a server round-trip.
+ *
+ * Adding a new key requires three matching edits:
+ *  1. `app/core/extensions_registry.py::KNOWN_FEATURES` (+ PRODUCT_FEATURES if relevant).
+ *  2. `admin_extension_<key>_label` + `admin_extension_<key>_description` Paraglide
+ *     messages in `klai-portal/frontend/messages/{nl,en}.json`.
+ *  3. The switch arm below.
+ *
+ * The backend drift-guard test
+ * `test_features_derive::test_known_features_consistent_with_feature_min_profile`
+ * fails CI if (1) gets out of sync. (2) and (3) surface as missing-message
+ * type errors at frontend build time.
+ */
+
+import * as m from '@/paraglide/messages'
+
+export function extensionLabel(key: string): string {
+  switch (key) {
+    case 'partner_api':
+      return m.admin_extension_partner_api_label()
+    case 'widgets':
+      return m.admin_extension_widgets_label()
+    case 'custom_mcps':
+      return m.admin_extension_custom_mcps_label()
+    case 'scribe':
+      return m.admin_extension_scribe_label()
+    case 'docs':
+      return m.admin_extension_docs_label()
+    default:
+      return key
+  }
+}
+
+export function extensionDescription(key: string): string {
+  switch (key) {
+    case 'partner_api':
+      return m.admin_extension_partner_api_description()
+    case 'widgets':
+      return m.admin_extension_widgets_description()
+    case 'custom_mcps':
+      return m.admin_extension_custom_mcps_description()
+    case 'scribe':
+      return m.admin_extension_scribe_description()
+    case 'docs':
+      return m.admin_extension_docs_description()
+    default:
+      return ''
+  }
+}

--- a/klai-portal/frontend/src/routes/admin/settings.tsx
+++ b/klai-portal/frontend/src/routes/admin/settings.tsx
@@ -9,6 +9,7 @@ import { Select } from '@/components/ui/select'
 import { Checkbox } from '@/components/ui/checkbox'
 import { apiFetch } from '@/lib/apiFetch'
 import { fetchMe } from '@/lib/api-me'
+import { extensionDescription, extensionLabel } from '@/lib/extensions-i18n'
 import * as m from '@/paraglide/messages'
 import { adminLogger } from '@/lib/logger'
 
@@ -27,11 +28,10 @@ type OrgSettings = {
   telemetry_level: TelemetryLevel
 }
 
-// SPEC-PORTAL-EXTENSIONS-UNIFY-001 Phase 3/4 — extensions API shape.
+// SPEC-PORTAL-EXTENSIONS-UNIFY-001 — extensions API shape (i18n-clean:
+// labels + descriptions live in Paraglide via lib/extensions-i18n.ts).
 type ExtensionItem = {
   key: string
-  label: string
-  description: string
   enabled: boolean
   requires_profile: string | null
   manageable_by_caller: boolean
@@ -459,8 +459,8 @@ function AdminSettingsPage() {
                   return (
                     <li key={item.key} className="flex items-center justify-between gap-4 px-2 py-3">
                       <div className="min-w-0 flex-1">
-                        <p className="text-[15px] font-display text-gray-900">{item.label}</p>
-                        <p className="text-xs text-gray-400 mt-0.5">{item.description}</p>
+                        <p className="text-[15px] font-display text-gray-900">{extensionLabel(item.key)}</p>
+                        <p className="text-xs text-gray-400 mt-0.5">{extensionDescription(item.key)}</p>
                       </div>
                       {item.manageable_by_caller ? (
                         <Checkbox


### PR DESCRIPTION
Three follow-up corrections after the consolidation PR.

## 1) i18n bug fix

Backend ``extensions_registry.py`` shipped hardcoded NL labels and descriptions. ``GET /api/admin/extensions`` returned them verbatim, so an EN-locale user saw NL strings in the Uitbreidingen sectie. Dropped ``label``/``description`` from the API contract entirely; new frontend Paraglide mapping helper (``lib/extensions-i18n.ts``) renders them client-side. Backend is now language-agnostic. Adds 10 messages (5 keys × {label, description}) per locale.

## 2) Drift-guard for dual-source feature definition

``KNOWN_FEATURES`` (extensions_registry.py) and ``FEATURE_MIN_PROFILE`` (core/features.py) had to stay in sync by hand. New ``PRODUCT_FEATURES`` subset captures the intersection explicitly, and ``test_known_features_consistent_with_feature_min_profile`` fails CI if one of the two definitions gets out of sync.

## 3) Helper reuse

``list_extensions`` hand-rolled a ``select(PortalOrg)`` query — duplicate of ``_load_org_or_500``. Switched to the helper.

## Quality gate

- ruff check + format — clean
- pyright on touched modules — 0 errors
- pytest — **2489 passed, 3 deselected, 0 failed**
- frontend tsc -b --force — clean
- npm run i18n:compile — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)