### PR TITLE
chore(sources-tab): clean up adversarial-review findings (post-SPEC-PORTAL-SOURCES-RENAME-001)

### DIFF
--- a/klai-portal/backend/app/api/app_knowledge_bases.py
+++ b/klai-portal/backend/app/api/app_knowledge_bases.py
@@ -1001,7 +1001,13 @@ def _upload_type_label(content_type: str) -> str:
         return "Tekst"
     if ct.startswith("image"):
         return "Afbeelding"
-    return content_type.split("/")[-1].upper() if "/" in content_type else content_type.title()
+    # Fallback for unrecognised types: split MIME by "/" and uppercase the
+    # subtype ("text/plain" → "PLAIN"), or for non-MIME slugs replace
+    # underscores with spaces before title-casing ("plain_text" → "Plain Text").
+    # Previously str.title() left underscores intact and rendered "Plain_Text".
+    if "/" in content_type:
+        return content_type.split("/")[-1].upper()
+    return content_type.replace("_", " ").title()
 
 
 @router.get(

--- a/klai-portal/backend/tests/test_app_knowledge_sources_list.py
+++ b/klai-portal/backend/tests/test_app_knowledge_sources_list.py
@@ -66,6 +66,20 @@ def test_upload_type_label_known_content_types() -> None:
     assert _upload_type_label("unknown") == "Bestand"
 
 
+def test_upload_type_label_fallback_replaces_underscores() -> None:
+    """Regression: bare-underscore content_type slugs previously rendered as
+    "Plain_Text" because str.title() does not split on underscores. The
+    fallback now replaces underscores with spaces before title-casing so
+    the user-visible meta line reads "Plain Text" / "Rich Text Format" /
+    etc."""
+    from app.api.app_knowledge_bases import _upload_type_label
+
+    assert _upload_type_label("plain_text") == "Plain Text"
+    assert _upload_type_label("rich_text_format") == "Rich Text Format"
+    # MIME-shaped fallback still uppercases the subtype.
+    assert _upload_type_label("application/octet-stream") == "OCTET-STREAM"
+
+
 # -- list_kb_sources --------------------------------------------------------
 
 

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-sources-row-actions.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-sources-row-actions.tsx
@@ -10,6 +10,11 @@
  * occupy the same width without layout shift. The actual Save/Cancel
  * controls live in `-sources-row.tsx` because they share state with
  * the `<InlineEdit>` overlay.
+ *
+ * The six icon-only affordances all share the same h-8/w-8 rounded
+ * button shell with hover + disabled states; extracted into the
+ * `RowActionIconButton` component below so each individual action site
+ * only owns its label, icon, and click handler.
  */
 import { Link } from '@tanstack/react-router'
 import {
@@ -22,6 +27,7 @@ import {
   Settings,
   Trash2,
 } from 'lucide-react'
+import type { ComponentType, ReactNode } from 'react'
 import { InlineDeleteConfirm } from '@/components/ui/inline-delete-confirm'
 import { Tooltip } from '@/components/ui/tooltip'
 import * as m from '@/paraglide/messages'
@@ -32,6 +38,74 @@ import {
   useSourceSync,
 } from './-sources-hooks'
 import type { Source } from './-sources-types'
+
+interface RowActionIconButtonProps {
+  label: string
+  icon: ComponentType<{ className?: string }>
+  onClick?: () => void
+  disabled?: boolean
+  /** Optional element to replace the icon while loading (e.g. spinner). */
+  spinner?: ReactNode
+  /** Style variant — `destructive` paints hover red. */
+  variant?: 'default' | 'destructive'
+}
+
+/** Shared icon-only h-8/w-8 button + tooltip + aria-label, the canonical
+ *  affordance for any per-row action in the Sources tab. */
+function RowActionIconButton({
+  label,
+  icon: Icon,
+  onClick,
+  disabled,
+  spinner,
+  variant = 'default',
+}: RowActionIconButtonProps) {
+  const hoverClass = variant === 'destructive'
+    ? 'hover:text-[var(--color-destructive)]'
+    : 'hover:text-gray-900'
+  return (
+    <Tooltip label={label}>
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={disabled}
+        aria-label={label}
+        className={`inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-400 ${hoverClass} hover:bg-gray-100 transition-colors disabled:opacity-50 disabled:cursor-not-allowed`}
+      >
+        {spinner ?? <Icon className="h-4 w-4" />}
+      </button>
+    </Tooltip>
+  )
+}
+
+/** Link-shaped sibling of `RowActionIconButton` — same shell, but the
+ *  target is a TanStack Router `<Link>` rather than a click handler. */
+function RowActionIconLink({
+  label,
+  icon: Icon,
+  to,
+  params,
+}: {
+  label: string
+  icon: ComponentType<{ className?: string }>
+  to: string
+  // TanStack params are route-strict; we accept the runtime shape and let
+  // the caller pin its own typing.
+  params: Record<string, string>
+}) {
+  return (
+    <Tooltip label={label}>
+      <Link
+        to={to}
+        params={params}
+        aria-label={label}
+        className="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-400 hover:text-gray-900 hover:bg-gray-100 transition-colors"
+      >
+        <Icon className="h-4 w-4" />
+      </Link>
+    </Tooltip>
+  )
+}
 
 interface SourceRowActionsProps {
   source: Source
@@ -73,6 +147,8 @@ export function SourceRowActions({
 
   return (
     <div className={`flex items-center ${isRenaming ? 'opacity-0 pointer-events-none' : ''}`}>
+      {/* Reauth is the only non-icon-only action — it carries a label so
+          the affordance is unambiguous when an auth_error appears. */}
       {isAuthError && (
         <Tooltip label={m.kb_sources_row_reauth_tooltip()}>
           <button
@@ -90,17 +166,13 @@ export function SourceRowActions({
         </Tooltip>
       )}
 
-      <Tooltip label={syncTooltip}>
-        <button
-          type="button"
-          onClick={() => { if (!syncDisabled) syncMutation.mutate() }}
-          disabled={syncDisabled}
-          aria-label={syncTooltip}
-          className="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-400 hover:text-gray-900 hover:bg-gray-100 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          {isSyncing ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
-        </button>
-      </Tooltip>
+      <RowActionIconButton
+        label={syncTooltip}
+        icon={RefreshCw}
+        onClick={() => { if (!syncDisabled) syncMutation.mutate() }}
+        disabled={syncDisabled}
+        spinner={isSyncing ? <Loader2 className="h-4 w-4 animate-spin" /> : undefined}
+      />
 
       <InlineDeleteConfirm
         isConfirming={confirmingDelete}
@@ -110,56 +182,39 @@ export function SourceRowActions({
         onConfirm={() => { deleteMutation.mutate(); onSetConfirmingDelete(false) }}
         onCancel={() => onSetConfirmingDelete(false)}
       >
-        <Tooltip label={m.kb_sources_row_delete_tooltip()}>
-          <button
-            type="button"
-            onClick={() => onSetConfirmingDelete(true)}
-            disabled={isDeleting}
-            aria-label={m.kb_sources_row_delete_tooltip()}
-            className="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-400 hover:text-[var(--color-destructive)] hover:bg-gray-100 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            <Trash2 className="h-4 w-4" />
-          </button>
-        </Tooltip>
+        <RowActionIconButton
+          label={m.kb_sources_row_delete_tooltip()}
+          icon={Trash2}
+          onClick={() => onSetConfirmingDelete(true)}
+          disabled={isDeleting}
+          variant="destructive"
+        />
       </InlineDeleteConfirm>
 
       {source.kind === 'connector' && (
-        <Tooltip label={m.kb_sources_row_edit_connector_tooltip()}>
-          <Link
-            to="/app/knowledge/$kbSlug/edit-connector/$connectorId"
-            params={{ kbSlug, connectorId: source.id }}
-            aria-label={m.kb_sources_row_edit_connector_tooltip()}
-            className="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-400 hover:text-gray-900 hover:bg-gray-100 transition-colors"
-          >
-            <Settings className="h-4 w-4" />
-          </Link>
-        </Tooltip>
+        <RowActionIconLink
+          label={m.kb_sources_row_edit_connector_tooltip()}
+          icon={Settings}
+          to="/app/knowledge/$kbSlug/edit-connector/$connectorId"
+          params={{ kbSlug, connectorId: source.id }}
+        />
       )}
 
       {source.kind === 'upload' && (
-        <Tooltip label={m.kb_sources_row_rename_tooltip()}>
-          <button
-            type="button"
-            onClick={onStartRename}
-            aria-label={m.kb_sources_row_rename_tooltip()}
-            className="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-400 hover:text-gray-900 hover:bg-gray-100 transition-colors"
-          >
-            <Pencil className="h-4 w-4" />
-          </button>
-        </Tooltip>
+        <RowActionIconButton
+          label={m.kb_sources_row_rename_tooltip()}
+          icon={Pencil}
+          onClick={onStartRename}
+        />
       )}
 
       {editablePageId !== null && (
-        <Tooltip label={m.kb_sources_row_open_in_editor()}>
-          <Link
-            to="/app/docs/$kbSlug/$pageId"
-            params={{ kbSlug, pageId: editablePageId }}
-            aria-label={m.kb_sources_row_open_in_editor()}
-            className="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-400 hover:text-gray-900 hover:bg-gray-100 transition-colors"
-          >
-            <NotebookPen className="h-4 w-4" />
-          </Link>
-        </Tooltip>
+        <RowActionIconLink
+          label={m.kb_sources_row_open_in_editor()}
+          icon={NotebookPen}
+          to="/app/docs/$kbSlug/$pageId"
+          params={{ kbSlug, pageId: editablePageId }}
+        />
       )}
 
       <button


### PR DESCRIPTION
Two cosmetic items from the post-deploy review of #596.

## Backend `_upload_type_label` fallback underscore bug

End users saw `Plain_Text` (with underscore) on the Sources tab for
`content_type='plain_text'` because `str.title()` doesn't split on
underscores. Fix: `.replace("_", " ").title()` before fallback.

Regression test pins `plain_text` → `Plain Text` and keeps
`application/octet-stream` → `OCTET-STREAM` (existing MIME path).

## Frontend `SourceRowActions` icon-button extraction

The action cluster repeated the same `h-8/w-8` shell + Tooltip +
aria-label + hover classes in 7 places (~10 lines each). Extracted
into `RowActionIconButton` + `RowActionIconLink`. Each call site is
now 4-7 lines.

File grew 175 → 230 lines because of the two helper components +
JSDoc, but call-site density is much lower.

## Out of scope (separate issues)

- Dual-key wire cleanup (drop `bronnen_by_kb` field + portal-api
  fallback) — wait one deploy cycle, own PR.
- Legacy `/bronnen` redirect stub removal — wait 30 days of zero
  hits in VictoriaLogs.

## QA

- `pytest tests/test_app_knowledge_sources_list.py`: 14/14 pass
- `tsc --noEmit`: exit 0
- `eslint src eslint-rules --max-warnings 0`: exit 0
- `vitest run`: 216/216 pass
- `npm run build`: green

🤖 Generated with [Claude Code](https://claude.com/claude-code)