### PR TITLE
fix(kb-images): route declaration mist 'images' literal segment — finale laag

### DIFF
--- a/klai-portal/backend/app/api/kb_images.py
+++ b/klai-portal/backend/app/api/kb_images.py
@@ -191,12 +191,20 @@ async def _resolve_zitadel_org_id(org_id: int, db: AsyncSession) -> str:
 # @MX:REASON: Single enforcement point for cross-tenant image access control.
 #   Every image fetch from the browser goes through this handler.
 #   Changing the org_id check or the S3 key format breaks tenant isolation.
-#   The path org_id is a zitadel_org_id (string) to match the convention used
-#   by klai-connector + klai-knowledge-ingest (which both use zitadel_org_id
-#   as the canonical tenant id in the knowledge domain — see knowledge.artifacts.org_id
-#   text column and the _rls_current_org_id() text helper).
+#
+#   The path has a literal 'images' segment between org_id and kb_slug.
+#   This matches the S3 key + public URL shape that ImageStore generates:
+#       object_key:  {org_id}/images/{kb_slug}/{sha256}.{ext}
+#       public_url:  /kb-images/{org_id}/images/{kb_slug}/{sha256}.{ext}
+#   Removing 'images' here would make the route declaration diverge from
+#   what ImageStore.build_public_url() returns — a 5-segment URL no longer
+#   matches a 4-segment route → 404 on every browser fetch (the latent bug
+#   that survived from SPEC-TI-009 until the 2026-05-12 e2e smoketest).
+#
+#   The path org_id is a zitadel_org_id (string) to match the convention
+#   used by klai-connector + klai-knowledge-ingest.
 # @MX:SPEC: SPEC-TI-009, finding B-4
-@router.get("/kb-images/{org_id}/{kb_slug}/{filename}")
+@router.get("/kb-images/{org_id}/images/{kb_slug}/{filename}")
 async def get_kb_image(
     org_id: str,
     kb_slug: str,

--- a/klai-portal/backend/tests/test_kb_images_auth_proxy.py
+++ b/klai-portal/backend/tests/test_kb_images_auth_proxy.py
@@ -99,7 +99,7 @@ async def test_authenticated_user_can_read_own_org_image(kb_app):
         patch("app.api.kb_images._resolve_zitadel_org_id", AsyncMock(return_value=ZITADEL_ORG_ID)),
     ):
         async with httpx.AsyncClient(transport=httpx.ASGITransport(app=kb_app), base_url="http://test") as client:
-            resp = await client.get(f"/kb-images/{ZITADEL_ORG_ID}/{KB_SLUG}/{FILENAME}")
+            resp = await client.get(f"/kb-images/{ZITADEL_ORG_ID}/images/{KB_SLUG}/{FILENAME}")
     assert resp.status_code == 200
     assert resp.headers["Cache-Control"] == "private, max-age=86400"
 
@@ -114,7 +114,7 @@ async def test_authenticated_user_cannot_read_foreign_org_image(kb_app):
     kb_app.dependency_overrides[__import__("app.core.database", fromlist=["get_db"]).get_db] = _mock_get_db()
     with patch("app.api.kb_images._resolve_zitadel_org_id", AsyncMock(return_value=ZITADEL_ORG_ID)):
         async with httpx.AsyncClient(transport=httpx.ASGITransport(app=kb_app), base_url="http://test") as client:
-            resp = await client.get(f"/kb-images/{OTHER_ZITADEL_ORG_ID}/{KB_SLUG}/{FILENAME}")
+            resp = await client.get(f"/kb-images/{OTHER_ZITADEL_ORG_ID}/images/{KB_SLUG}/{FILENAME}")
     assert resp.status_code == 403
     assert resp.json()["detail"] == "Access denied"
 
@@ -127,7 +127,7 @@ async def test_unauthenticated_request_rejected(kb_app):
     kb_app.dependency_overrides[get_optional_session] = lambda: None
     kb_app.dependency_overrides[__import__("app.core.database", fromlist=["get_db"]).get_db] = _mock_get_db()
     async with httpx.AsyncClient(transport=httpx.ASGITransport(app=kb_app), base_url="http://test") as client:
-        resp = await client.get(f"/kb-images/{ZITADEL_ORG_ID}/{KB_SLUG}/{FILENAME}")
+        resp = await client.get(f"/kb-images/{ZITADEL_ORG_ID}/images/{KB_SLUG}/{FILENAME}")
     assert resp.status_code == 401
 
 
@@ -180,7 +180,7 @@ async def test_widget_public_image_works(kb_app):
     ):
         async with httpx.AsyncClient(transport=httpx.ASGITransport(app=kb_app), base_url="http://test") as client:
             resp = await client.get(
-                f"/kb-images/{ZITADEL_ORG_ID}/{KB_SLUG}/{FILENAME}",
+                f"/kb-images/{ZITADEL_ORG_ID}/images/{KB_SLUG}/{FILENAME}",
                 headers={"Authorization": "Bearer some-widget-token"},
             )
     assert resp.status_code == 200
@@ -212,7 +212,7 @@ async def test_partner_api_key_image_access(kb_app):
     ):
         async with httpx.AsyncClient(transport=httpx.ASGITransport(app=kb_app), base_url="http://test") as client:
             resp = await client.get(
-                f"/kb-images/{ZITADEL_ORG_ID}/{KB_SLUG}/{FILENAME}",
+                f"/kb-images/{ZITADEL_ORG_ID}/images/{KB_SLUG}/{FILENAME}",
                 headers={"Authorization": "Bearer pk_live_testkey"},
             )
     assert resp.status_code == 200
@@ -257,7 +257,7 @@ async def test_404_for_nonexistent_object(kb_app):
         patch("app.api.kb_images._resolve_zitadel_org_id", AsyncMock(return_value=ZITADEL_ORG_ID)),
     ):
         async with httpx.AsyncClient(transport=httpx.ASGITransport(app=kb_app), base_url="http://test") as client:
-            resp = await client.get(f"/kb-images/{ZITADEL_ORG_ID}/{KB_SLUG}/{FILENAME}")
+            resp = await client.get(f"/kb-images/{ZITADEL_ORG_ID}/images/{KB_SLUG}/{FILENAME}")
     assert resp.status_code == 404
 
 
@@ -276,6 +276,6 @@ async def test_cache_control_header_set_correctly(kb_app):
         patch("app.api.kb_images._resolve_zitadel_org_id", AsyncMock(return_value=ZITADEL_ORG_ID)),
     ):
         async with httpx.AsyncClient(transport=httpx.ASGITransport(app=kb_app), base_url="http://test") as client:
-            resp = await client.get(f"/kb-images/{ZITADEL_ORG_ID}/{KB_SLUG}/{FILENAME}")
+            resp = await client.get(f"/kb-images/{ZITADEL_ORG_ID}/images/{KB_SLUG}/{FILENAME}")
     assert resp.status_code == 200
     assert resp.headers["Cache-Control"] == "private, max-age=86400"


### PR DESCRIPTION
## TL;DR

Vijfde en laatste laag van de SPEC-TI-009 regression chain. Mark wist al dat hij geen image in een chat reactie of in z'n docs editor zag. De vorige 4 fixes (Caddy port, handle_path, env vars, frontend URL) onthulden steeds een volgende laag — dit is de **inhoudelijke** bug.

## Root cause

`ImageStore.build_public_url()` retourneert URLs met **5 segments**:
```
/kb-images/{org_id}/images/{kb_slug}/{sha}.{ext}
```

Maar de route was gedeclareerd met **4 placeholders**:
```python
@router.get('/kb-images/{org_id}/{kb_slug}/{filename}')
```

FastAPI heeft **geen enkele** echte URL gematched sinds SPEC-TI-009 (2026-04-22). Elke browser-fetch op een productie-image URL gaf 404. Verified:

- Direct `wget` vanuit caddy-container naar `portal-api:8010` op echte 5-segment URL → **404**
- `stat_object` vanuit dezelfde container op de exact key → **OK** (object bestaat in Garage)
- Bewijs dat de route handler dus nooit werd bereikt

## Fix

Eén regel — voeg `images` literal segment toe:
```diff
-@router.get('/kb-images/{org_id}/{kb_slug}/{filename}')
+@router.get('/kb-images/{org_id}/images/{kb_slug}/{filename}')
```

Tests bijgewerkt om de productie 5-segment URL shape te gebruiken. 17/17 groen.

## Followup

Dit is **fix #5** in een rij — patch op patch. De onderliggende architectural debt (`ImageStore.build_public_url()` in lib X + route declaration in lib Y kunnen silently driften) blijft bestaan. Aparte PR met **`SPEC-KB-IMAGES-V2`** komt direct hierna: clean redesign zonder de implicit coupling, met E2E browser test als acceptance criterion in CI.

## Geen merge zonder browser-test

Anders dan vorige PRs: ik commit pas op merge nadat een **echte browser-fetch via Playwright** op een productie image URL een 200 returnt na deploy. Geen "Confidence 90"-claim op basis van unit tests dit keer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)