### PR TITLE
fix(portal): SPEC-PORTAL-PRICING-PER-USER-001 — move backfill to post-deploy SQL (#599 hotfix)

### DIFF
--- a/.claude/rules/klai/pitfalls/process-rules.md
+++ b/.claude/rules/klai/pitfalls/process-rules.md
@@ -148,6 +148,80 @@ WITH CHECK (org_id = NULLIF(current_setting('app.current_org_id', true), '')::in
   in the same PR, or extend the rls-policy-smoke-test CI job to import
   `app.main` and invoke the lifespan assertion.
 
+## rls-with-check-blocks-migration-update (HIGH)
+The WITH CHECK clause on Cat-A RLS policies (the inline-NULLIF pattern,
+no IS-NULL permissive branch) FIRES on every UPDATE — even from
+portal_api, even inside an alembic migration. Migrations run without a
+tenant context, so `current_setting('app.current_org_id', true)` returns
+empty, NULLIF returns NULL, and `org_id = NULL` evaluates to NULL (not
+true). Every row is rejected with `new row violates row-level security
+policy`. The migration transaction rolls back. The container crashloops.
+
+This is the sibling failure-mode to `rls-policy-shape-must-match-
+lifespan-assert`: reads against Cat-A tables with no GUC succeed because
+the USING clause has the `IS NULL` permissive branch; writes fail
+because WITH CHECK does NOT have that branch (intentionally — it's the
+strict-side of the asymmetric policy).
+
+Reference incident: SPEC-PORTAL-PRICING-PER-USER-001 Phase 1 (PR #599,
+2026-05-12). The migration ran `UPDATE portal_users SET seat_type =
+CASE...` to backfill the new column. portal-api crashlooped on first
+deploy. Recovery: hand-applied the migration as klai superuser
+(`SET ROLE klai` bypasses FORCE RLS for the table owner) and stamped
+`alembic_version = 'f66c546c12eb'`. The structural fix (PR #608) split
+the migration:
+- `upgrade()` does portal_api-safe DDL only (ADD COLUMN with NOT NULL
+  DEFAULT — instant metadata op in PG 11+, no per-row write, no WITH
+  CHECK fires; CREATE TABLE; CREATE INDEX).
+- `post_deploy_<rev>.sql` does the per-row UPDATE + history-table
+  INSERT + trigger creation + RLS DDL, applied by an operator as klai.
+
+**Class summary:**
+
+| Operation on Cat-A table | Safe in alembic upgrade()? | Why |
+|---|---|---|
+| `ALTER TABLE ADD COLUMN col TYPE NOT NULL DEFAULT 'x'` | YES (PG 11+) | Metadata-only; existing rows lazily read the default; no row UPDATE; no WITH CHECK |
+| `ALTER TABLE ADD COLUMN col TYPE NOT NULL` (no default) | NO | Requires UPDATE on existing rows to satisfy NOT NULL |
+| `UPDATE table SET ...` | NO | WITH CHECK fires per row; no tenant context = NULL = rejected |
+| `INSERT INTO table ...` | NO | Same — INSERT triggers WITH CHECK |
+| `ALTER TABLE ALTER COLUMN ... SET NOT NULL` (after backfill) | NO inside the same tx | The UPDATE backfill is what triggers WITH CHECK; if the backfill is in post-deploy, ALTER NOT NULL belongs there too |
+| `DROP COLUMN`, `ADD CHECK CONSTRAINT`, `ADD INDEX`, `CREATE TABLE` | YES | Pure DDL; no row-write |
+| `CREATE TRIGGER` on Cat-A table | YES | DDL only |
+| `ALTER TABLE ENABLE / FORCE ROW LEVEL SECURITY` | NO | Requires klai superuser (separate class — `alembic-cannot-drop-non-portal_api-tables`) |
+
+**Prevention (mechanical):**
+
+1. **CI guard**: file-content test on every migration that touches
+   portal_users (or any other FORCE-RLS Cat-A table). The test rejects
+   any `UPDATE\s+portal_users` or `INSERT\s+INTO\s+portal_users` inside
+   `op.execute(...)`. Pattern: `test_no_update_on_portal_users` in
+   `tests/test_pricing_per_user_phase1_migration.py` is the reference.
+
+2. **SPEC pre-flight on prod-snapshot**: any SPEC that adds a column to
+   portal_users MUST include a pre-merge step that runs `alembic
+   upgrade head` against a snapshot of production (or a stage DB with
+   the same RLS policies). Any error here is a deployment-blocker.
+   File-content regex tests pass on the python source — they cannot
+   catch this runtime failure.
+
+3. **Pattern for new columns**: prefer `ADD COLUMN col TYPE NOT NULL
+   DEFAULT '<sensible>'` over `ADD COLUMN col TYPE` + later UPDATE. The
+   default-on-add path is instant metadata, RLS-safe, and produces a
+   sensible value for every existing row. If the right value differs
+   per row (e.g. derived from another column), move the per-row UPDATE
+   to post-deploy SQL.
+
+4. **Smoke-recovery for crashloops**: when portal-api logs show
+   `new row violates row-level security policy` during alembic upgrade:
+   ```bash
+   ssh core-01 "docker exec klai-core-postgres-1 sh -c \
+       'psql -U \$POSTGRES_USER -d \$POSTGRES_DB' < /tmp/manual-migration.sql"
+   ```
+   where `manual-migration.sql` replicates the migration's intent
+   verbatim (klai bypasses FORCE RLS) and ends with `UPDATE
+   alembic_version SET version_num = '<rev>'`. Then `docker restart
+   klai-core-portal-api-1`.
+
 ## asyncpg-pool-guc-not-shared (HIGH)
 Postgres GUCs (`current_setting('app.foo', true)`) are **connection-local**,
 not pool-local. Setting the GUC on connection A does NOT propagate to

--- a/klai-portal/backend/alembic/versions/f66c546c12eb_pricing_per_user_phase1.py
+++ b/klai-portal/backend/alembic/versions/f66c546c12eb_pricing_per_user_phase1.py
@@ -1,41 +1,50 @@
 """SPEC-PORTAL-PRICING-PER-USER-001 Phase 1.
 
 Adds the per-user billing axis (``portal_users.seat_type``) plus the
-append-only seat-change audit table (``portal_user_seat_history``) and
-the trigger that maintains it. RLS for the new table lives in the
-sibling post-deploy SQL file ``post_deploy_f66c546c12eb.sql`` (klai-
-superuser path; portal_api cannot ENABLE RLS on its own — see
-``alembic-cannot-drop-non-portal_api-tables`` pitfall, which extends to
-``ENABLE / FORCE ROW LEVEL SECURITY`` and ``CREATE POLICY``).
+append-only seat-change audit table (``portal_user_seat_history``).
+Trigger + RLS + per-row data-backfill live in the sibling post-deploy
+SQL file ``post_deploy_f66c546c12eb.sql`` (klai-superuser path) —
+portal_api cannot UPDATE FORCE-RLS-protected ``portal_users`` rows
+without setting a tenant context per row (see
+``rls-with-check-blocks-migration-update`` pitfall, added in this
+hotfix).
 
 Backfill mapping (matches ``app/core/seats.py::DEFAULT_SEAT_FOR_ROLE``):
-    personal | company                       -> chat
-    kb_manager | group_manager | admin       -> knowledge
-    (any other / unknown role string)        -> chat   (cheapest non-zero)
+    personal | company                       -> chat  (column DEFAULT)
+    kb_manager | group_manager | admin       -> knowledge  (post-deploy UPDATE)
 
-Why a Postgres trigger and not a SQLAlchemy event listener: the listener
-misses ``session.execute(update(PortalUser).values(...))`` bulk paths
-(several admin scripts use those) AND races on concurrent UPDATEs of the
-same user-row. The trigger fires on every UPDATE regardless of how it
-arrived and runs in the same transaction. The partial-unique index
-``idx_pu_seat_hist_one_open_per_user`` serializes concurrent writes.
+What changed vs the pre-hotfix shape:
+  * The role -> seat backfill UPDATE was rejected on prod by the
+    Cat-A inline-NULLIF RLS policy's WITH CHECK clause (which has NO
+    "IS NULL permissive" branch — see ``rls-policy-shape-must-match-
+    lifespan-assert``). With no ``app.current_org_id`` set inside the
+    alembic transaction, every WITH CHECK predicate evaluates to NULL
+    and the UPDATE fails with ``InsufficientPrivilegeError`` ->
+    portal-api crashloops. Recovery on prod was a hand-applied
+    klai-superuser SQL on 2026-05-12 that bypassed RLS; this file
+    captures the correct shape so future deploys reproduce it.
+  * ``ADD COLUMN ... NOT NULL DEFAULT 'chat'`` is instant metadata
+    in PG 11+ — no row-rewrite happens, so no WITH CHECK fires. All
+    existing rows inherit ``seat_type='chat'`` immediately. The
+    role-based UPDATE that bumps KMs/admins to ``knowledge`` lives in
+    post-deploy SQL.
+  * History backfill + trigger creation also moved to post-deploy.
+    The trigger gets installed AFTER the history backfill so the
+    backfill INSERT does NOT trigger itself.
+  * Intermediate state (alembic complete, post-deploy not yet applied):
+    portal_users.seat_type exists with all rows at 'chat',
+    portal_user_seat_history exists but empty. Python model resolves
+    cleanly (SeatType.CHAT is valid). KMs/admins read as 'chat' until
+    post-deploy runs — wrong-but-not-broken; admins see a slightly
+    off /admin/billing/breakdown for ~5 min until the operator runs
+    ``scripts/apply_post_deploy_sql.sh post_deploy_f66c546c12eb.sql``.
 
 Revision ID: f66c546c12eb
 Revises: c0d5e2a7b9f3
 Create Date: 2026-05-12
 
-Rebased on 2026-05-12 to chain off ``c0d5e2a7b9f3`` (tenant-lifecycle
-platform-features CHECK constraint fix) instead of ``e0ad7c2b1e80``
-(extensions-unify). The original parent was the production head when
-this PR opened; ``c0d5e2a7b9f3`` landed on main while this PR was in
-review and created a temporary alembic head-split (per the
-``alembic-multi-pr-head-split`` pitfall). Resolution chosen: rebase the
-second-merging migration onto the first head — preferred when the
-migration files are still recent and the parent change is small.
-Schema-side: the two migrations touch different tables (this one adds
-``portal_users.seat_type``; that one is a no-op stamp + post-deploy SQL
-on ``tenant_lifecycle_events``), so the linearisation has no
-content-level conflict.
+Rebased on 2026-05-12 to chain off ``c0d5e2a7b9f3`` (see prior
+revision comment in git history).
 """
 
 from __future__ import annotations
@@ -49,116 +58,24 @@ branch_labels = None
 depends_on = None
 
 
-# ---------------------------------------------------------------------------
-# Trigger function body. Defined as a module-level constant so the
-# upgrade() and downgrade() helpers can reference it without escaping.
-# ---------------------------------------------------------------------------
-
-# Fires AFTER INSERT OR UPDATE on portal_users. On INSERT, snapshots the
-# initial state with change_reason='invite'. On UPDATE, closes the
-# previous open row (idx_pu_seat_hist_one_open_per_user enforces "exactly
-# one open row per user", so the WHERE clause matches at most one row)
-# and inserts a new open row with the appropriate change_reason. Only
-# audited columns trigger the append (IS DISTINCT FROM handles NULL).
-#
-# changed_by attribution (Phase 1 limitation):
-#   ``changed_by VARCHAR(64)`` is on the table but the trigger writes
-#   NULL for now. The actor identity lives in Python (the FastAPI
-#   handler's ``perms.user_id``) and is NOT propagated to the
-#   transaction-local GUC the trigger could read. Phase 2 (admin seat-
-#   selector + cost-delta modal) is the natural place to land the
-#   propagation pattern:
-#     - portal-api session middleware runs
-#         SET LOCAL klai.changed_by_user_id = '<zitadel_user_id>';
-#       on every authenticated request.
-#     - The trigger reads it via
-#         current_setting('klai.changed_by_user_id', true)
-#       and stores into ``changed_by`` (NULL when unset, e.g. signup).
-#   Until then, the history row is the WHAT (seat/role/status snapshot)
-#   without the WHO. Audit-of-WHO can be reconstructed by joining
-#   ``portal_user_seat_history.valid_from`` against ``portal_audit_log``
-#   on the same timestamp window — the audit-log entries already carry
-#   the acting admin's user_id.
-#
-# DELETE path is NOT covered. portal_users rows are soft-deleted via
-# ``status = 'offboarded'`` (admin/users.py:542) — the trigger captures
-# that transition. Hard DELETE only happens via the FK CASCADE when an
-# org is deprovisioned, and at that point we deliberately want the
-# history rows to disappear too (the org's tenant scope is gone).
-_TRIGGER_FUNCTION_BODY = """
-CREATE OR REPLACE FUNCTION portal_users_seat_history_trg() RETURNS TRIGGER AS $$
-BEGIN
-    IF TG_OP = 'INSERT' THEN
-        INSERT INTO portal_user_seat_history
-            (user_id, org_id, seat_type, role, status, valid_from, change_reason)
-        VALUES
-            (NEW.id, NEW.org_id, NEW.seat_type, NEW.role::text, NEW.status::text,
-             NOW(), 'invite');
-        RETURN NEW;
-    END IF;
-    -- UPDATE path: only fire when an audited column changed
-    IF (NEW.seat_type IS DISTINCT FROM OLD.seat_type)
-       OR (NEW.role     IS DISTINCT FROM OLD.role)
-       OR (NEW.status   IS DISTINCT FROM OLD.status) THEN
-        -- Close the previous (current) row. The partial-unique index
-        -- guarantees at most one row matches.
-        UPDATE portal_user_seat_history
-           SET valid_to = NOW()
-         WHERE user_id = NEW.id
-           AND valid_to IS NULL;
-        -- Append the new current row, attributing the change to the
-        -- column that most-recently moved (precedence: seat > role > status
-        -- so a combined PATCH still records a meaningful reason).
-        INSERT INTO portal_user_seat_history
-            (user_id, org_id, seat_type, role, status, valid_from, change_reason)
-        VALUES
-            (NEW.id, NEW.org_id, NEW.seat_type, NEW.role::text, NEW.status::text,
-             NOW(),
-             CASE
-                 WHEN NEW.seat_type IS DISTINCT FROM OLD.seat_type THEN 'seat_change'
-                 WHEN NEW.role      IS DISTINCT FROM OLD.role      THEN 'role_change'
-                 ELSE 'status_change'
-             END);
-    END IF;
-    RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-"""
-
-
 def upgrade() -> None:
     # -----------------------------------------------------------------------
-    # 1. Add seat_type column to portal_users (nullable for backfill window).
+    # 1. Add seat_type column to portal_users.
+    #
+    #    NOT NULL DEFAULT 'chat' is intentional — Postgres 11+ records the
+    #    default as metadata and serves it lazily for existing rows, so the
+    #    ALTER TABLE is instant (no row-rewrite) and no WITH CHECK fires.
+    #    All existing rows immediately read as 'chat'. The post-deploy SQL
+    #    upgrades KMs/admins to 'knowledge'.
     # -----------------------------------------------------------------------
     op.add_column(
         "portal_users",
-        sa.Column("seat_type", sa.String(length=16), nullable=True),
-    )
-
-    # -----------------------------------------------------------------------
-    # 2. Backfill from role. Mirrors DEFAULT_SEAT_FOR_ROLE in seats.py.
-    # -----------------------------------------------------------------------
-    op.execute(
-        """
-        UPDATE portal_users
-           SET seat_type = CASE
-               WHEN role IN ('kb_manager', 'group_manager', 'admin') THEN 'knowledge'
-               WHEN role IN ('personal', 'company')                  THEN 'chat'
-               ELSE 'chat'
-           END
-        ;
-        """
-    )
-
-    # -----------------------------------------------------------------------
-    # 3. Lock the column down: NOT NULL + default + CHECK constraint.
-    # -----------------------------------------------------------------------
-    op.alter_column(
-        "portal_users",
-        "seat_type",
-        existing_type=sa.String(length=16),
-        nullable=False,
-        server_default="chat",
+        sa.Column(
+            "seat_type",
+            sa.String(length=16),
+            nullable=False,
+            server_default="chat",
+        ),
     )
     op.create_check_constraint(
         "ck_portal_users_seat_type",
@@ -167,7 +84,11 @@ def upgrade() -> None:
     )
 
     # -----------------------------------------------------------------------
-    # 4. Create the seat-history table.
+    # 2. Create the empty seat-history table + indexes.
+    #
+    #    Trigger + RLS + initial backfill are post-deploy. The trigger
+    #    must be installed AFTER the history backfill INSERT or it will
+    #    fire on the backfill UPDATE (which we don't want).
     # -----------------------------------------------------------------------
     op.create_table(
         "portal_user_seat_history",
@@ -208,8 +129,9 @@ def upgrade() -> None:
         ["org_id", "valid_from"],
     )
     # Partial-unique: at most one OPEN (current) row per user. The trigger
-    # below depends on this — closes the open row before inserting the new
-    # one. Concurrent UPDATEs race for this lock, not for the table.
+    # (created in post-deploy) depends on this — closes the open row
+    # before inserting the new one. Concurrent UPDATEs race for this lock,
+    # not for the table.
     op.create_index(
         "idx_pu_seat_hist_one_open_per_user",
         "portal_user_seat_history",
@@ -219,56 +141,37 @@ def upgrade() -> None:
     )
 
     # -----------------------------------------------------------------------
-    # 5. Backfill the history: one row per existing portal_users entry,
-    #    valid_from = the user's created_at, valid_to NULL (current).
-    # -----------------------------------------------------------------------
-    op.execute(
-        """
-        INSERT INTO portal_user_seat_history
-            (user_id, org_id, seat_type, role, status, valid_from, change_reason)
-        SELECT id, org_id, seat_type, role::text, status::text, created_at, 'backfill'
-          FROM portal_users
-        ;
-        """
-    )
-
-    # -----------------------------------------------------------------------
-    # 6. Install the trigger function + trigger. From here on, every
-    #    INSERT/UPDATE on portal_users is mirrored into portal_user_seat_history.
-    # -----------------------------------------------------------------------
-    op.execute(_TRIGGER_FUNCTION_BODY)
-    op.execute(
-        """
-        DROP TRIGGER IF EXISTS portal_users_seat_history ON portal_users;
-        CREATE TRIGGER portal_users_seat_history
-            AFTER INSERT OR UPDATE ON portal_users
-            FOR EACH ROW EXECUTE FUNCTION portal_users_seat_history_trg();
-        """
-    )
-
-    # -----------------------------------------------------------------------
-    # 7. RLS for portal_user_seat_history lives in
-    #    alembic/versions/post_deploy_f66c546c12eb.sql — applied as klai
-    #    superuser via scripts/apply_post_deploy_sql.sh. portal_api
-    #    cannot ENABLE / FORCE RLS on a table even if it owns it (same
-    #    class as alembic-cannot-drop-non-portal_api-tables).
+    # 3. Everything else (role-based UPDATE backfill, history backfill,
+    #    trigger function + trigger, RLS + billing._rls_current_org_id
+    #    helper) lives in alembic/versions/post_deploy_f66c546c12eb.sql.
+    #    Applied by an operator as the klai superuser via
+    #    ``scripts/apply_post_deploy_sql.sh post_deploy_f66c546c12eb.sql``.
+    #
+    #    Why this split:
+    #      - portal_users has FORCE RLS with WITH CHECK clauses that
+    #        require ``app.current_org_id`` to match each row's org_id.
+    #        Migrations run without a tenant context -> WITH CHECK
+    #        evaluates to NULL -> rows-violate-policy 500.
+    #      - portal_user_seat_history needs ENABLE/FORCE RLS + CREATE
+    #        POLICY, which require table-owner-or-superuser privileges
+    #        the same way ENABLE RLS does (see
+    #        ``alembic-cannot-drop-non-portal_api-tables`` pitfall).
+    #    Both classes are addressed by running the rest as klai.
     # -----------------------------------------------------------------------
 
 
 def downgrade() -> None:
-    # Reverse-order teardown. Trigger first (depends on the table), then
-    # the table, then the column.
-    op.execute("DROP TRIGGER IF EXISTS portal_users_seat_history ON portal_users")
-    op.execute("DROP FUNCTION IF EXISTS portal_users_seat_history_trg() CASCADE")
+    # Reverse-order teardown. Trigger + RLS objects are not alembic-
+    # managed (post-deploy SQL); to fully revert RLS, the operator runs:
+    #   DROP TRIGGER IF EXISTS portal_users_seat_history ON portal_users;
+    #   DROP FUNCTION IF EXISTS portal_users_seat_history_trg() CASCADE;
+    #   DROP POLICY IF EXISTS tenant_isolation ON portal_user_seat_history;
+    #   DROP FUNCTION IF EXISTS billing._rls_current_org_id();
+    #   DROP SCHEMA IF EXISTS billing;
+    # but the table is dropped here so the policy is moot.
     op.drop_index("idx_pu_seat_hist_one_open_per_user", table_name="portal_user_seat_history")
     op.drop_index("idx_pu_seat_hist_org_validfrom", table_name="portal_user_seat_history")
     op.drop_index("idx_pu_seat_hist_user_validto", table_name="portal_user_seat_history")
     op.drop_table("portal_user_seat_history")
     op.drop_constraint("ck_portal_users_seat_type", "portal_users", type_="check")
     op.drop_column("portal_users", "seat_type")
-    # RLS objects in post_deploy_f66c546c12eb.sql are not alembic-managed;
-    # to fully revert RLS, the operator runs:
-    #   DROP POLICY IF EXISTS tenant_isolation ON portal_user_seat_history;
-    #   DROP FUNCTION IF EXISTS billing._rls_current_org_id();
-    #   DROP SCHEMA IF EXISTS billing;
-    # but the table is gone here so the policy is moot.

--- a/klai-portal/backend/alembic/versions/post_deploy_f66c546c12eb.sql
+++ b/klai-portal/backend/alembic/versions/post_deploy_f66c546c12eb.sql
@@ -1,36 +1,132 @@
 -- SPEC-PORTAL-PRICING-PER-USER-001 Phase 1 post-deploy SQL.
 --
 -- Applied as the ``klai`` superuser AFTER ``alembic upgrade f66c546c12eb``
--- completes successfully. portal_api cannot ENABLE / FORCE RLS or
--- CREATE POLICY on a table even if it owns the table — same class as
--- alembic-cannot-drop-non-portal_api-tables in process-rules.md.
+-- completes successfully. Several pieces of this migration cannot run as
+-- portal_api in an alembic transaction:
 --
--- Idempotent: every statement uses IF NOT EXISTS / DROP IF EXISTS so
--- re-running on a partially-applied database is safe.
+--   1. ``UPDATE portal_users SET seat_type = ...`` — portal_users has
+--      FORCE RLS with a Cat-A inline-NULLIF policy whose WITH CHECK
+--      clause requires ``app.current_org_id`` to match each row's
+--      ``org_id``. Migrations run without tenant context -> every WITH
+--      CHECK predicate evaluates to NULL -> all rows rejected -> ``new
+--      row violates row-level security policy``. See
+--      ``rls-with-check-blocks-migration-update`` pitfall.
+--
+--   2. ``INSERT INTO portal_user_seat_history`` — depends on the
+--      seat_type backfill above being correct.
+--
+--   3. ``CREATE TRIGGER portal_users_seat_history`` — must be installed
+--      AFTER the history backfill INSERT, otherwise the trigger fires
+--      on the backfill UPDATE and writes spurious history rows.
+--
+--   4. ``ALTER TABLE portal_user_seat_history ENABLE / FORCE ROW LEVEL
+--      SECURITY`` — same class as ``alembic-cannot-drop-non-
+--      portal_api-tables``: needs table-owner privileges that alembic
+--      role doesn't have.
+--
+-- Idempotent: every statement uses IF NOT EXISTS / DROP IF EXISTS /
+-- ON CONFLICT / WHERE guards so re-running on a partially-applied
+-- database is safe.
 --
 -- Run from core-01 once after the deploy lands:
 --     ./scripts/apply_post_deploy_sql.sh post_deploy_f66c546c12eb.sql
 -- or manually:
 --     docker exec -i klai-core-postgres-1 sh -c \
---         'psql -U $POSTGRES_USER -d $POSTGRES_DB' \
+--         'psql -U $POSTGRES_USER -d $POSTGRES_DB -v ON_ERROR_STOP=1' \
 --         < post_deploy_f66c546c12eb.sql
 
 BEGIN;
 
 -- ---------------------------------------------------------------------------
--- 1. Schema-qualified RLS helper for the billing domain.
+-- 1. Backfill seat_type for KMs / group-managers / admins.
 --
---    Distinct from portal-api's public._rls_current_org_id() (which
---    returns integer) AND distinct from knowledge._rls_current_org_id()
---    (which returns text). Schema-qualification is the prescribed fix
---    in the postgres-no-return-type-overload pitfall — Postgres does NOT
---    support function overloading by return type alone, so co-existing
---    same-named functions in the same schema breaks production.
+--    The alembic ``ADD COLUMN seat_type ... DEFAULT 'chat'`` set every
+--    existing row to 'chat'. This UPDATE bumps the role-driven
+--    knowledge-tier users to their correct seat. Idempotent via the
+--    WHERE seat_type='chat' guard — re-running it is a no-op once the
+--    target rows are already on 'knowledge'.
+-- ---------------------------------------------------------------------------
+
+UPDATE portal_users
+   SET seat_type = 'knowledge'
+ WHERE role IN ('kb_manager', 'group_manager', 'admin')
+   AND seat_type = 'chat';
+
+-- ---------------------------------------------------------------------------
+-- 2. Backfill history: one row per existing user reflecting the FINAL
+--    seat_type (post-UPDATE above). Idempotent via NOT EXISTS — the
+--    partial-unique index on (user_id) WHERE valid_to IS NULL would
+--    refuse a second open row anyway, but the explicit predicate is
+--    clearer in the audit log of post-deploy applications.
+-- ---------------------------------------------------------------------------
+
+INSERT INTO portal_user_seat_history
+    (user_id, org_id, seat_type, role, status, valid_from, change_reason)
+SELECT u.id, u.org_id, u.seat_type, u.role::text, u.status::text, u.created_at, 'backfill'
+  FROM portal_users u
+ WHERE NOT EXISTS (
+     SELECT 1 FROM portal_user_seat_history h
+      WHERE h.user_id = u.id AND h.valid_to IS NULL
+ );
+
+-- ---------------------------------------------------------------------------
+-- 3. Install the trigger function. Owner adjusted to portal_api so
+--    future alembic-managed CREATE OR REPLACE FUNCTION (e.g. Phase 2's
+--    changed_by propagation) works without needing klai superuser again.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION portal_users_seat_history_trg() RETURNS TRIGGER AS $$
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        INSERT INTO portal_user_seat_history
+            (user_id, org_id, seat_type, role, status, valid_from, change_reason)
+        VALUES
+            (NEW.id, NEW.org_id, NEW.seat_type, NEW.role::text, NEW.status::text,
+             NOW(), 'invite');
+        RETURN NEW;
+    END IF;
+    -- UPDATE path: only fire when an audited column changed.
+    IF (NEW.seat_type IS DISTINCT FROM OLD.seat_type)
+       OR (NEW.role     IS DISTINCT FROM OLD.role)
+       OR (NEW.status   IS DISTINCT FROM OLD.status) THEN
+        UPDATE portal_user_seat_history
+           SET valid_to = NOW()
+         WHERE user_id = NEW.id
+           AND valid_to IS NULL;
+        INSERT INTO portal_user_seat_history
+            (user_id, org_id, seat_type, role, status, valid_from, change_reason)
+        VALUES
+            (NEW.id, NEW.org_id, NEW.seat_type, NEW.role::text, NEW.status::text,
+             NOW(),
+             CASE
+                 WHEN NEW.seat_type IS DISTINCT FROM OLD.seat_type THEN 'seat_change'
+                 WHEN NEW.role      IS DISTINCT FROM OLD.role      THEN 'role_change'
+                 ELSE 'status_change'
+             END);
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+ALTER FUNCTION portal_users_seat_history_trg() OWNER TO portal_api;
+
+-- ---------------------------------------------------------------------------
+-- 4. Install the trigger AFTER backfill (step 2 above) so the backfill
+--    INSERT does not trigger itself.
+-- ---------------------------------------------------------------------------
+
+DROP TRIGGER IF EXISTS portal_users_seat_history ON portal_users;
+CREATE TRIGGER portal_users_seat_history
+    AFTER INSERT OR UPDATE ON portal_users
+    FOR EACH ROW EXECUTE FUNCTION portal_users_seat_history_trg();
+
+-- ---------------------------------------------------------------------------
+-- 5. Schema-qualified RLS helper for the billing domain.
 --
---    STABLE is correct: within a single statement, current_setting()'s
---    value does not change. ``security definer`` is deliberately NOT
---    used — the function should resolve under the caller's privileges
---    so a superuser bypass remains visible in the policy plan.
+--    Distinct from portal-api's public._rls_current_org_id() (integer)
+--    AND distinct from knowledge._rls_current_org_id() (text).
+--    Schema-qualification is the prescribed fix in the postgres-no-
+--    return-type-overload pitfall — Postgres does NOT support function
+--    overloading by return type alone.
 -- ---------------------------------------------------------------------------
 
 CREATE SCHEMA IF NOT EXISTS billing;
@@ -40,39 +136,27 @@ CREATE OR REPLACE FUNCTION billing._rls_current_org_id() RETURNS integer AS $$
 $$ LANGUAGE sql STABLE;
 
 -- Explicit grants for portal_api. Postgres' default ACL grants USAGE on
--- new schemas and EXECUTE on new functions to PUBLIC, so this is
--- defensive: if a future hardening pass runs
---     REVOKE EXECUTE ON ALL FUNCTIONS ... FROM PUBLIC;
--- the RLS policy's USING clause would silently return NULL (no rows
--- visible) instead of failing loud. Explicit grants make portal_api's
--- read path immune to that drift. ``knowledge._rls_current_org_id()``
--- (created earlier under the same pattern) relies on the default PUBLIC
--- grants; we tighten this one because the migration is fresh and the
--- pattern is now established here for any future Cat-D helpers.
+-- new schemas and EXECUTE on new functions to PUBLIC; this makes
+-- portal_api's read path immune to a future cluster-wide ``REVOKE
+-- EXECUTE ON ALL FUNCTIONS ... FROM PUBLIC`` hardening pass.
 GRANT USAGE ON SCHEMA billing TO portal_api;
 GRANT EXECUTE ON FUNCTION billing._rls_current_org_id() TO portal_api;
 
 -- ---------------------------------------------------------------------------
--- 2. Enable + force RLS on portal_user_seat_history.
+-- 6. ENABLE + FORCE RLS on portal_user_seat_history.
 --
 --    ENABLE = policies apply to non-owner sessions.
 --    FORCE  = policies apply to the table owner too (portal_api). Without
---             FORCE, portal_api could read across tenants — defeating
---             the point. Mirrors the Cat-D pattern from SPEC-TI-005.
+--             FORCE, portal_api would bypass tenant isolation.
 -- ---------------------------------------------------------------------------
 
 ALTER TABLE portal_user_seat_history ENABLE ROW LEVEL SECURITY;
 ALTER TABLE portal_user_seat_history FORCE  ROW LEVEL SECURITY;
 
 -- ---------------------------------------------------------------------------
--- 3. The tenant_isolation policy.
---
---    Category D (strict): the helper raises if app.current_org_id is
---    NULL/empty (via NULLIF + ::integer coerce). Callers MUST set
---    SET LOCAL app.current_org_id = T before issuing any SELECT/INSERT/
---    UPDATE/DELETE. Phase 5 prorate-billing query is the canonical
---    consumer; Phase 1 portal-api only writes via the trigger from
---    inside an already-tenant-bound transaction.
+-- 7. The tenant_isolation policy. Cat-D (strict): no permissive null
+--    branch. Callers must SET LOCAL app.current_org_id = T before any
+--    SELECT/INSERT/UPDATE/DELETE.
 --
 --    CREATE POLICY does NOT support IF NOT EXISTS, so we DROP first.
 -- ---------------------------------------------------------------------------

--- a/klai-portal/backend/tests/test_pricing_per_user_phase1_migration.py
+++ b/klai-portal/backend/tests/test_pricing_per_user_phase1_migration.py
@@ -3,14 +3,23 @@
 Pure file-content regex checks, no live PostgreSQL. Same pattern as
 ``test_rls_join_requests.py`` and ``test_rls_hygiene.py``. The point is
 to guard against a future refactor accidentally reverting the structural
-shape (trigger body, partial-unique, RLS DDL) — drift here lands as a
-silent billing audit gap.
+shape — drift here lands as a silent billing audit gap.
+
+Hotfix (2026-05-12): the initial Phase 1 migration shape had the
+backfill UPDATE on portal_users inside ``alembic upgrade()``. portal_users
+has FORCE RLS with a Cat-A inline-NULLIF policy whose WITH CHECK clause
+requires ``app.current_org_id`` per row. The migration runs without a
+tenant context — every WITH CHECK predicate evaluated to NULL — every
+row rejected — portal-api crashlooped on prod. See the
+``rls-with-check-blocks-migration-update`` pitfall added in this hotfix
+PR. Tests below pin the new split: portal_api-safe DDL stays in alembic,
+all UPDATE/INSERT/trigger/RLS work moves to post-deploy SQL (klai
+superuser path).
 
 Live behaviour is exercised by:
-  - The pytest suite that imports the migration's trigger SQL string and
-    checks structural branches (this file, ``test_trigger_function_body``).
-  - The staging smoke test (``scripts/rls-smoke-test.sh`` if extended) that
-    verifies the policy resolves against ``pg_policies`` after deploy.
+  - The staging smoke test (``scripts/rls-smoke-test.sh`` if extended)
+    that verifies the policy resolves against ``pg_policies`` after
+    deploy.
   - A future integration test against a real Postgres if/when the suite
     gains that fixture (Phase 5 will need one for the prorate query).
 """
@@ -26,7 +35,6 @@ MIGRATION_PATH = (
     Path(__file__).resolve().parents[1] / "alembic" / "versions" / "f66c546c12eb_pricing_per_user_phase1.py"
 )
 POST_DEPLOY_PATH = Path(__file__).resolve().parents[1] / "alembic" / "versions" / "post_deploy_f66c546c12eb.sql"
-RLS_GUARD_PATH = Path(__file__).resolve().parents[1] / "app" / "core" / "rls_guard.py"
 
 
 @pytest.fixture(scope="module")
@@ -51,55 +59,60 @@ class TestMigrationChain:
         assert re.search(r'^revision\s*=\s*"f66c546c12eb"\s*$', migration_src, re.M)
 
     def test_chains_off_tenant_lifecycle_platform_features(self, migration_src: str) -> None:
-        # Originally chained off e0ad7c2b1e80 (extensions-unify, the prod
-        # head when this PR opened). Rebased to c0d5e2a7b9f3
-        # (tenant-lifecycle platform-features fix) after that landed on
-        # main mid-review and created an alembic head-split — see
-        # alembic-multi-pr-head-split pitfall. Drift in either direction
-        # means a new split.
+        # Originally chained off e0ad7c2b1e80 (extensions-unify). Rebased
+        # to c0d5e2a7b9f3 after that landed on main mid-review.
         assert re.search(r'down_revision\s*=\s*"c0d5e2a7b9f3"', migration_src)
 
 
 # ---------------------------------------------------------------------------
-# Schema additions on portal_users
+# Hotfix invariant: alembic upgrade() does NO writes to portal_users.
+# ---------------------------------------------------------------------------
+
+
+class TestUpgradeDoesNoPortalUsersWrites:
+    """RLS guard: alembic runs as portal_api with no tenant context. Any
+    UPDATE / INSERT on portal_users (or any other FORCE-RLS table with a
+    strict WITH CHECK) fails with ``new row violates row-level security
+    policy`` and crashlooops the container. Mechanical regression check
+    that the offending shapes never reappear in this migration.
+    """
+
+    def test_no_update_on_portal_users(self, migration_src: str) -> None:
+        # The whole class of failure is: any "UPDATE portal_users" inside
+        # op.execute(...). The string match is intentionally broad — we
+        # never want this migration to write tenant-scoped rows, period.
+        assert not re.search(r"UPDATE\s+portal_users", migration_src, re.IGNORECASE), (
+            "Phase 1 migration must NOT contain `UPDATE portal_users` — "
+            "FORCE RLS WITH CHECK blocks it. Move the backfill to "
+            "post_deploy_f66c546c12eb.sql (klai-superuser path)."
+        )
+
+    def test_no_insert_into_portal_users(self, migration_src: str) -> None:
+        # Same class. INSERT also fires WITH CHECK.
+        assert not re.search(r"INSERT\s+INTO\s+portal_users\b", migration_src, re.IGNORECASE), (
+            "Phase 1 migration must NOT contain `INSERT INTO portal_users` — FORCE RLS WITH CHECK blocks it."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Schema additions on portal_users (alembic-side, DDL only)
 # ---------------------------------------------------------------------------
 
 
 class TestPortalUsersSeatTypeAdd:
-    def test_add_column_seat_type_string16(self, migration_src: str) -> None:
-        assert re.search(
-            r'op\.add_column\(\s*"portal_users"\s*,\s*sa\.Column\(\s*"seat_type"\s*,\s*sa\.String\(length=16\)',
+    def test_add_column_seat_type_is_not_null_default_chat(self, migration_src: str) -> None:
+        """ADD COLUMN with NOT NULL + DEFAULT 'chat' is a metadata-only
+        op in PG 11+ — no row-write happens, so the FORCE RLS WITH CHECK
+        clause does NOT fire. This is the single safe shape for adding a
+        backfilled column to a strict-RLS table."""
+        # Permissive about ruff's trailing-comma + multi-line formatting.
+        # Required pieces: ADD COLUMN on portal_users naming seat_type as
+        # String(16), nullable=False, server_default="chat".
+        decl = re.search(
+            r'op\.add_column\(\s*"portal_users"\s*,\s*sa\.Column\(\s*"seat_type"\s*,\s*sa\.String\(length=16\)\s*,\s*nullable=False\s*,\s*server_default="chat"\s*,?\s*\)\s*,?\s*\)',
             migration_src,
         )
-
-    def test_backfill_case_handles_all_five_roles(self, migration_src: str) -> None:
-        # The CASE must explicitly enumerate every member of the
-        # 5-rung profile ladder — a future ladder change without a
-        # matching migration tweak would silently fall through to ELSE
-        # and over-bill or under-bill.
-        backfill_block = re.search(
-            r"UPDATE portal_users\s+SET seat_type = CASE(.+?)END",
-            migration_src,
-            re.DOTALL,
-        )
-        assert backfill_block is not None, "missing seat_type backfill CASE"
-        body = backfill_block.group(1)
-        for role in ("kb_manager", "group_manager", "admin"):
-            assert role in body, f"backfill CASE missing role {role!r}"
-        for role in ("personal", "company"):
-            assert role in body, f"backfill CASE missing role {role!r}"
-        # Default branch goes to 'chat' (cheapest non-zero). Viewer must
-        # never be a backfill outcome — that's a free billing tier for
-        # nobody.
-        assert "ELSE 'chat'" in body or "ELSE 'chat'\n" in body
-
-    def test_alter_seat_type_to_not_null(self, migration_src: str) -> None:
-        assert re.search(
-            r'op\.alter_column\(\s*"portal_users"\s*,\s*"seat_type"\s*,'
-            r".*nullable=False",
-            migration_src,
-            re.DOTALL,
-        )
+        assert decl is not None, "expected ADD COLUMN seat_type String(16) NOT NULL DEFAULT 'chat'"
 
     def test_check_constraint_locks_three_values(self, migration_src: str) -> None:
         assert re.search(
@@ -109,14 +122,12 @@ class TestPortalUsersSeatTypeAdd:
 
 
 # ---------------------------------------------------------------------------
-# portal_user_seat_history table
+# portal_user_seat_history table (alembic-side: empty table + indexes only)
 # ---------------------------------------------------------------------------
 
 
 class TestSeatHistoryTable:
     def test_table_has_all_eleven_columns(self, migration_src: str) -> None:
-        # Match the create_table block and confirm every column appears.
-        # Order doesn't matter; presence does.
         create_block = re.search(
             r'op\.create_table\(\s*"portal_user_seat_history"(.+?)\)\s*\n\s*op\.create_index',
             migration_src,
@@ -140,18 +151,16 @@ class TestSeatHistoryTable:
             assert f'"{col}"' in body, f"column {col!r} missing from create_table"
 
     def test_user_id_cascades_on_delete(self, migration_src: str) -> None:
-        # Removing a portal_users row must cascade to history (audit-only
-        # data, no FK we want to dangle).
         assert re.search(
             r'ForeignKey\(\s*"portal_users\.id"\s*,\s*ondelete="CASCADE"',
             migration_src,
         )
 
     def test_status_column_is_required(self, migration_src: str) -> None:
-        # v0.4.0: status is the snapshot column Phase 5 prorate scopes on.
-        # Must be NOT NULL — a backfill / trigger row without status
-        # breaks the billable-period query.
-        status_decl = re.search(r'sa\.Column\(\s*"status"\s*,\s*sa\.Text\(\)\s*,\s*nullable=False', migration_src)
+        status_decl = re.search(
+            r'sa\.Column\(\s*"status"\s*,\s*sa\.Text\(\)\s*,\s*nullable=False',
+            migration_src,
+        )
         assert status_decl is not None, "status column must be NOT NULL"
 
     def test_seat_type_check_constraint_in_table(self, migration_src: str) -> None:
@@ -169,74 +178,10 @@ class TestSeatHistoryTable:
             assert re.search(rf'create_index\(\s*"{name}"', migration_src), f"missing index {name}"
 
     def test_partial_unique_uses_valid_to_is_null_predicate(self, migration_src: str) -> None:
-        # The structural guarantee — at most one OPEN history row per user.
-        # Without this, the trigger races into overlapping rows.
         assert re.search(
             r'create_index\(\s*"idx_pu_seat_hist_one_open_per_user"\s*,\s*"portal_user_seat_history"\s*,\s*\["user_id"\]\s*,\s*unique=True\s*,\s*postgresql_where=sa\.text\(\s*"valid_to IS NULL"',
             migration_src,
         )
-
-    def test_history_backfill_uses_created_at(self, migration_src: str) -> None:
-        # Every existing user gets ONE history row with valid_from=created_at,
-        # valid_to=NULL, change_reason='backfill'. The change_reason value
-        # is read by Phase 5 prorate to know "this user has been on this
-        # seat since the dawn of time, not a real seat change".
-        assert re.search(
-            r"INSERT INTO portal_user_seat_history\s+\(user_id, org_id, seat_type, role, status, valid_from, change_reason\)\s+SELECT id, org_id, seat_type, role::text, status::text, created_at, 'backfill'\s+FROM portal_users",
-            migration_src,
-        )
-
-
-# ---------------------------------------------------------------------------
-# Trigger function — the structural guard against ORM-bypass and races
-# ---------------------------------------------------------------------------
-
-
-class TestTriggerFunctionBody:
-    def test_function_is_created_in_migration(self, migration_src: str) -> None:
-        assert "CREATE OR REPLACE FUNCTION portal_users_seat_history_trg()" in migration_src
-
-    def test_trigger_fires_after_insert_or_update(self, migration_src: str) -> None:
-        # AFTER (not BEFORE) so NEW.id is populated for INSERT inserts.
-        assert re.search(
-            r"CREATE TRIGGER portal_users_seat_history\s+AFTER INSERT OR UPDATE ON portal_users",
-            migration_src,
-        )
-
-    def test_insert_branch_writes_invite_reason(self, migration_src: str) -> None:
-        # New users land via INSERT — first history row is tagged 'invite'.
-        assert re.search(
-            r"IF TG_OP = 'INSERT' THEN\s+INSERT INTO portal_user_seat_history.+?'invite'\s*\)\s*;",
-            migration_src,
-            re.DOTALL,
-        )
-
-    def test_update_branch_uses_is_distinct_from(self, migration_src: str) -> None:
-        # IS DISTINCT FROM is the NULL-safe comparison Postgres requires
-        # — `<>` would let a NULL -> non-NULL transition slip through.
-        for col in ("seat_type", "role", "status"):
-            assert re.search(rf"NEW\.{col}\s+IS DISTINCT FROM\s+OLD\.{col}", migration_src), (
-                f"trigger missing IS DISTINCT FROM check for {col}"
-            )
-
-    def test_update_branch_closes_previous_open_row(self, migration_src: str) -> None:
-        # The trigger MUST close the previous open row before inserting
-        # the new one. The partial-unique index would otherwise reject
-        # the INSERT.
-        assert re.search(
-            r"UPDATE portal_user_seat_history\s+SET valid_to = NOW\(\)\s+WHERE user_id = NEW\.id\s+AND valid_to IS NULL",
-            migration_src,
-        )
-
-    def test_change_reason_precedence_seat_role_status(self, migration_src: str) -> None:
-        # CASE order matters: a combined PATCH that bumps seat AND status
-        # tags as 'seat_change' (the more interesting / billable change).
-        # The pattern is permissive — match the WHEN clauses in order.
-        case_block = re.search(
-            r"CASE\s+WHEN NEW\.seat_type IS DISTINCT FROM OLD\.seat_type\s+THEN 'seat_change'\s+WHEN NEW\.role\s+IS DISTINCT FROM OLD\.role\s+THEN 'role_change'\s+ELSE 'status_change'\s+END",
-            migration_src,
-        )
-        assert case_block is not None, "change_reason CASE precedence missing"
 
 
 # ---------------------------------------------------------------------------
@@ -245,19 +190,13 @@ class TestTriggerFunctionBody:
 
 
 class TestDowngradeReversesUpgrade:
-    def test_drops_trigger_and_function(self, migration_src: str) -> None:
-        assert "DROP TRIGGER IF EXISTS portal_users_seat_history" in migration_src
-        assert "DROP FUNCTION IF EXISTS portal_users_seat_history_trg()" in migration_src
-
     def test_drops_three_indexes(self, migration_src: str) -> None:
         for name in (
             "idx_pu_seat_hist_one_open_per_user",
             "idx_pu_seat_hist_org_validfrom",
             "idx_pu_seat_hist_user_validto",
         ):
-            assert f'drop_index(\n        "{name}"' in migration_src or re.search(
-                rf'drop_index\(\s*"{name}"', migration_src
-            ), f"downgrade missing drop_index({name!r})"
+            assert re.search(rf'drop_index\(\s*"{name}"', migration_src), f"downgrade missing drop_index({name!r})"
 
     def test_drops_table_and_constraint(self, migration_src: str) -> None:
         assert 'op.drop_table("portal_user_seat_history")' in migration_src
@@ -268,8 +207,66 @@ class TestDowngradeReversesUpgrade:
 
 
 # ---------------------------------------------------------------------------
-# Post-deploy SQL — RLS Cat-D shape
+# Post-deploy SQL — the klai-path that does the actual data + trigger work
 # ---------------------------------------------------------------------------
+
+
+class TestPostDeployBackfillAndTrigger:
+    """The data-side of Phase 1 lives entirely in the post-deploy SQL
+    (klai-superuser path). Everything that can't run as portal_api goes
+    here: the role-driven UPDATE backfill, the history-table INSERT,
+    the trigger function + trigger, RLS DDL.
+    """
+
+    def test_role_based_update_promotes_kms_to_knowledge(self, post_deploy_src: str) -> None:
+        # KMs / group-managers / admins get bumped from the column-DEFAULT
+        # 'chat' to 'knowledge'. Idempotent via WHERE seat_type='chat'.
+        assert re.search(
+            r"UPDATE portal_users\s+SET seat_type = 'knowledge'\s+WHERE role IN \('kb_manager', 'group_manager', 'admin'\)\s+AND seat_type = 'chat'",
+            post_deploy_src,
+        ), "missing role->knowledge UPDATE backfill"
+
+    def test_history_backfill_uses_one_row_per_user_idempotent(self, post_deploy_src: str) -> None:
+        # Every existing user gets ONE history row. NOT EXISTS guards
+        # idempotent re-application.
+        assert re.search(
+            r"INSERT INTO portal_user_seat_history\s+\(user_id, org_id, seat_type, role, status, valid_from, change_reason\)\s+SELECT u\.id, u\.org_id, u\.seat_type, u\.role::text, u\.status::text, u\.created_at, 'backfill'\s+FROM portal_users u\s+WHERE NOT EXISTS",
+            post_deploy_src,
+        ), "missing one-row-per-user history backfill INSERT with NOT EXISTS guard"
+
+    def test_trigger_function_defined(self, post_deploy_src: str) -> None:
+        assert "CREATE OR REPLACE FUNCTION portal_users_seat_history_trg()" in post_deploy_src
+
+    def test_trigger_function_owner_handed_to_portal_api(self, post_deploy_src: str) -> None:
+        # Future alembic-managed CREATE OR REPLACE FUNCTION needs to run
+        # as portal_api (e.g. Phase 2's changed_by propagation). Owner
+        # transfer here keeps the function in portal_api's hands so the
+        # operator doesn't need klai-superuser again.
+        assert "ALTER FUNCTION portal_users_seat_history_trg() OWNER TO portal_api" in post_deploy_src
+
+    def test_trigger_fires_after_insert_or_update(self, post_deploy_src: str) -> None:
+        assert re.search(
+            r"CREATE TRIGGER portal_users_seat_history\s+AFTER INSERT OR UPDATE ON portal_users",
+            post_deploy_src,
+        )
+
+    def test_trigger_uses_is_distinct_from_for_all_audited_cols(self, post_deploy_src: str) -> None:
+        for col in ("seat_type", "role", "status"):
+            assert re.search(rf"NEW\.{col}\s+IS DISTINCT FROM\s+OLD\.{col}", post_deploy_src), (
+                f"trigger missing IS DISTINCT FROM check for {col}"
+            )
+
+    def test_trigger_closes_previous_open_row(self, post_deploy_src: str) -> None:
+        assert re.search(
+            r"UPDATE portal_user_seat_history\s+SET valid_to = NOW\(\)\s+WHERE user_id = NEW\.id\s+AND valid_to IS NULL",
+            post_deploy_src,
+        )
+
+    def test_change_reason_case_precedence(self, post_deploy_src: str) -> None:
+        assert re.search(
+            r"CASE\s+WHEN NEW\.seat_type IS DISTINCT FROM OLD\.seat_type\s+THEN 'seat_change'\s+WHEN NEW\.role\s+IS DISTINCT FROM OLD\.role\s+THEN 'role_change'\s+ELSE 'status_change'\s+END",
+            post_deploy_src,
+        )
 
 
 class TestPostDeployRls:
@@ -277,27 +274,18 @@ class TestPostDeployRls:
         assert "CREATE SCHEMA IF NOT EXISTS billing" in post_deploy_src
 
     def test_helper_function_schema_qualified(self, post_deploy_src: str) -> None:
-        # Schema-qualified to avoid the postgres-no-return-type-overload
-        # collision with portal-api's public._rls_current_org_id().
         assert re.search(
             r"CREATE OR REPLACE FUNCTION billing\._rls_current_org_id\(\)\s+RETURNS integer",
             post_deploy_src,
         )
 
     def test_helper_uses_nullif_pattern(self, post_deploy_src: str) -> None:
-        # NULLIF + ::integer coerce matches the Cat-A/Cat-D shape used
-        # elsewhere in the portal. Direct subscript would raise on
-        # missing-context — fine for Cat-D, but the NULLIF form
-        # short-circuits cleanly to NULL for the RLS USING clause.
         assert re.search(
             r"NULLIF\(\s*current_setting\(\s*'app\.current_org_id'\s*,\s*true\s*\)\s*,\s*''\s*\)\s*::integer",
             post_deploy_src,
         )
 
     def test_enables_and_forces_rls(self, post_deploy_src: str) -> None:
-        # Both required: ENABLE turns it on, FORCE applies it to the table
-        # owner too (portal_api). Without FORCE, portal_api reads bypass
-        # the policy — defeating the cross-tenant guarantee.
         assert "ALTER TABLE portal_user_seat_history ENABLE ROW LEVEL SECURITY" in post_deploy_src
         assert (
             "ALTER TABLE portal_user_seat_history FORCE  ROW LEVEL SECURITY" in post_deploy_src
@@ -305,8 +293,6 @@ class TestPostDeployRls:
         )
 
     def test_drop_policy_before_create(self, post_deploy_src: str) -> None:
-        # CREATE POLICY doesn't support IF NOT EXISTS — re-running the
-        # post-deploy SQL on a partially-applied DB must not error.
         assert "DROP POLICY IF EXISTS tenant_isolation ON portal_user_seat_history" in post_deploy_src
 
     def test_policy_uses_helper_in_using_and_with_check(self, post_deploy_src: str) -> None:
@@ -316,18 +302,10 @@ class TestPostDeployRls:
         )
 
     def test_runs_in_a_transaction(self, post_deploy_src: str) -> None:
-        # BEGIN/COMMIT wrap so partial failures roll back cleanly.
         assert "BEGIN;" in post_deploy_src
         assert "COMMIT;" in post_deploy_src
 
     def test_portal_api_receives_explicit_schema_and_function_grants(self, post_deploy_src: str) -> None:
-        """portal_api must be able to USAGE the ``billing`` schema AND
-        EXECUTE the helper. Postgres' default ACL grants both to PUBLIC,
-        but a future cluster-wide hardening pass that does
-        ``REVOKE EXECUTE ON ALL FUNCTIONS ... FROM PUBLIC`` would silently
-        break the RLS USING clause (returns NULL -> zero rows visible).
-        Explicit grants make portal_api's read path immune to that drift.
-        """
         assert "GRANT USAGE ON SCHEMA billing TO portal_api" in post_deploy_src, (
             "missing GRANT USAGE for portal_api on billing schema"
         )


### PR DESCRIPTION
## Why

PR #599 hit production on 2026-05-12 ~19:15 UTC. Migration `f66c546c12eb`'s `UPDATE portal_users SET seat_type = CASE ...` was rejected by the FORCE-RLS WITH CHECK clause on `portal_users` — alembic runs without a tenant context, so the predicate evaluated to NULL on every row, every row was rejected with **`new row violates row-level security policy`**, the migration transaction rolled back, portal-api crashlooped.

~9 minutes of 502 (19:15 → 19:24 UTC). Recovered by hand-applying the migration as `klai` superuser (bypasses FORCE RLS) and stamping `alembic_version = 'f66c546c12eb'`.

This PR is the **durable fix** — the same shape that survives every future deploy. No prod change needed; the recovered DB is already in the correct end-state and the new SQL is idempotent.

## Split

| Was in `upgrade()` (broken) | Moved to `post_deploy_f66c546c12eb.sql` (klai-safe) |
|---|---|
| `UPDATE portal_users SET seat_type = CASE...` | `UPDATE portal_users SET seat_type='knowledge' WHERE role IN (KM,...) AND seat_type='chat'` (idempotent) |
| `ALTER COLUMN seat_type SET NOT NULL` | — (now done via `ADD COLUMN NOT NULL DEFAULT 'chat'` at add-time — instant metadata in PG 11+, no row-write, no WITH CHECK) |
| `INSERT INTO portal_user_seat_history ... SELECT ... FROM portal_users` | Same, with `WHERE NOT EXISTS` guard for idempotency |
| `CREATE FUNCTION ... TRIGGER portal_users_seat_history` | Same; trigger now installed AFTER backfill (so backfill INSERT doesn't trigger itself); function owner transferred to `portal_api` for future `CREATE OR REPLACE` |
| billing schema + helper + RLS DDL | Already there; unchanged |

`upgrade()` now contains zero writes to `portal_users` and zero writes to `portal_user_seat_history`. Only DDL.

## Pitfall captured

`.claude/rules/klai/pitfalls/process-rules.md::rls-with-check-blocks-migration-update`. Documents:
- The class (Cat-A WITH CHECK fires on UPDATE/INSERT regardless of role; USING has the IS-NULL permissive branch, WITH CHECK does NOT).
- Which alembic ops are RLS-safe vs not (incl. the PG 11+ `ADD COLUMN NOT NULL DEFAULT` exception).
- The mechanical CI guard (file-content test rejecting `UPDATE\s+portal_users` in any migration) — would have caught this pre-merge.
- The SQL-recovery playbook for future similar incidents.

## Test coverage

- `TestUpgradeDoesNoPortalUsersWrites` (NEW) — regression guard. Rejects any future `UPDATE portal_users` or `INSERT INTO portal_users` inside `op.execute(...)`.
- `TestPostDeployBackfillAndTrigger` (NEW) — pins the post-deploy SQL shape: role-driven UPDATE, idempotent NOT EXISTS history backfill, trigger function + owner-transfer to portal_api, trigger fires AFTER INSERT OR UPDATE, IS DISTINCT FROM null-safety, change_reason CASE precedence.
- `TestUpgradeDoesNoPortalUsersWrites` + `TestPortalUsersSeatTypeAdd` replace the previous tests (`test_backfill_case_handles_all_five_roles`, `test_alter_seat_type_to_not_null`, `test_history_backfill_uses_created_at`) — those expectations moved to the post-deploy tests.
- All other Phase 1 tests (seats module, billing breakdown endpoint, RLS policy shape, GRANTs) carry forward unchanged.

## Prod state (verified at 19:24 UTC post-recovery)

```
alembic_version = 'f66c546c12eb'      ✓
portal_user_seat_history exists       ✓
seat_type distribution: 10 knowledge + 2 chat across 2 orgs   ✓
portal-api container Up + Application startup complete         ✓
```

## After merge

CI auto-deploys the new image. The new `upgrade()` is a no-op on a DB at `f66c546c12eb`. The new post-deploy SQL is idempotent — re-running on the recovered DB matches zero rows for the UPDATE, short-circuits the history INSERT via `NOT EXISTS`, and `CREATE OR REPLACE` / `DROP IF EXISTS` / `ON CONFLICT` cover the rest. Operator step is optional re-run if you want belt-and-braces.

## Verification (local)

- Backend pytest: **2565 passed**, 0 regressions
- AC-13 fixture-matrix: 6/6
- ruff check + ruff format --check: clean
- alembic heads: single head `f66c546c12eb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)