### PR TITLE
feat(kb-images): SPEC-KB-IMAGES-V2-001 — single source of truth, eliminate drift

### DIFF
--- a/.claude/rules/klai/pitfalls/process-rules.md
+++ b/.claude/rules/klai/pitfalls/process-rules.md
@@ -1,70 +1,69 @@
 # Process Rules
 
-## caddy-proxy-route-without-browser-leg (HIGH)
-A Caddy `reverse_proxy` directive that is only consumed by **RAG content**
-(LLM sees the URL as a token string, never fetches it) is **untested in
-production by definition**. The route can have a wrong upstream port, the
-wrong `handle` vs `handle_path` choice, or a wrong auth model — and the
-only signal would be a 5xx alert that never fires because nothing fetches it.
+## url-shape-multi-file-drift (CRIT)
 
-Reference: SPEC-TI-009 `/kb-images/*` block landed 2026-04-22 with **three**
-stacked bugs (port 8000 instead of 8010, `handle_path` strips the matched
-prefix, read-route auth-check compared portal_orgs.id against zitadel_org_id
-strings). All three were invisible until 2026-05-12 when
-SPEC-PORTAL-DOCS-IMAGE-PASTE-001 (PR #592) shipped the first browser-leg
-consumer (docs-editor image paste). Caddy access logs of that 3-week window
-contained zero `/kb-images/*` requests beyond the operator's own diagnostic
-curls. 1553 production images sat in S3 but were only consumed as RAG
-context — the LLM read the URL as a string, no browser ever fetched.
+When a wire-level URL (or any other serialization contract) is constructed
+in **more than one file**, the files inevitably drift and the drift is
+**invisible** in unit tests. The 2026-05-12 SPEC-TI-009 → SPEC-KB-IMAGES-V2
+regression chain is the canonical instance: three files each hardcoded a
+slice of `/kb-images/{org}/images/{kb}/{sha}.{ext}`:
 
-**Symptom class:** a feature ships with an obviously-broken transport layer
-that produces no metrics, no alerts, no support tickets, because the
-intended browser-leg consumer doesn't exist yet (or was deferred to a
-later SPEC). The bug becomes visible only when somebody finally adds a
-real `<img src>` or `<a href>` that hits the URL.
+- `klai_image_storage.storage.PUBLIC_IMAGE_PATH_PREFIX` + `build_public_url`
+- `klai-portal/backend/app/api/kb_images.py` `@router.get(...)`
+- `klai-portal/frontend/.../BlockPageEditor.tsx` `fetch(...)`
 
-**Prevention (mechanical, in this order):**
+Five separate transport bugs accumulated silently for 3 weeks (Caddy port,
+Caddy `handle_path`, env-var omission, frontend `/api/` prefix, route
+4-vs-5-segment) because the only consumer — RAG context — used the URL as
+a string token, never fetched it. Each bug needed its own PR (#598 / #600
+/ #602 / #607). The root cause was always the same: three files, three
+independent definitions, drift impossible to detect in unit tests.
 
-1. **For every new Caddy `reverse_proxy` block, the PR description MUST
-   answer: "which browser-side consumer (`<img>`, `<a href>`, `<script>`,
-   `fetch(...)`) will exercise this route, and how is that consumer
-   verified in this PR?"** If the answer is "none — only LLM context"
-   then either:
-   - Ship the browser-leg consumer in the same PR, OR
-   - Add a Grafana synthetic-check that curls the route every 5 minutes
-     and alerts on non-2xx. This is the only mechanical equivalent of a
-     browser-leg test when no real consumer exists.
+**Symptom class:** any serialization contract that lives in multiple files
+will drift, and the drift will be silent if the contract is only consumed
+by code that doesn't validate it (LLM context, archival writes, dormant
+endpoints). The bug appears the moment a *real consumer* tries to
+round-trip the value.
 
-2. **`caddy validate` is necessary but not sufficient.** The bug above
-   passed `caddy validate --config` (configuration is syntactically
-   valid) — it was only wrong against the upstream port and the FastAPI
-   route shape, neither of which Caddy can know. A post-deploy curl
-   smoketest (200 OR auth-expected 401/403) is the only way to catch
-   transport mismatches.
+**Prevention (mechanical):**
 
-3. **Prefer `handle` over `handle_path` for routes whose upstream FastAPI
-   handler declares the path prefix in its decorator.** `handle_path`
-   strips the matched prefix from the request URI before forwarding —
-   if the upstream expects the full path (which `@router.get("/kb-images/...")`
-   does), the route never matches and you get a 404 that looks identical
-   to "route doesn't exist". Only use `handle_path` when the upstream
-   explicitly expects the prefix-stripped form. In klai's Caddyfile there
-   was exactly **one** `handle_path` block (the broken one) versus 16
-   `handle` blocks — that asymmetry alone was a smell that nobody flagged.
+1. **One file owns the contract.** A wire-level URL, key-format, message
+   envelope, or token shape MUST be defined in exactly one module. Every
+   other file imports from there. Concretely for kb-images:
+   `klai_image_storage.kb_image.KbImage` is the single source; the portal
+   re-export shim `app/core/kb_image_url.py` is a thin forward, not a
+   second source. SPEC-KB-IMAGES-V2-001 REQ-1.
 
-4. **For every new `reverse_proxy <service>:<port>` line, verify the
-   port matches the service's actual listener.** `docker inspect
-   <container> .Config.ExposedPorts` is the canonical source. Klai's
-   portal-api `Dockerfile` exposes only `8010/tcp` — and yet the Caddy
-   directive said `:8000`. Nothing in CI compares these two.
+2. **A boot-time assertion verifies the contract didn't drift.** For
+   FastAPI: at app startup, parse a canonical instance through the
+   value-class's `from_path` AND check that the route declaration's path
+   strings come literally from the value-class's `ROUTE_TEMPLATE` constant.
+   If they differ, refuse to boot. SPEC-KB-IMAGES-V2-001 REQ-3 +
+   `_assert_kb_image_routes_match_value_class` in `app/main.py`.
 
-5. **When inheriting a route convention from a sister service (here:
-   knowledge-ingest's `zitadel_org_id` text-typed RLS), the new consumer
-   in another service MUST match the same convention or have an explicit
-   resolution helper.** The read-route assumed `org_id` was an int
-   (portal_orgs.id) because portal-api's session model is int-based; the
-   producer was zitadel-string-based. Cross-service ID-type mismatches
-   need an ADR or a Pydantic discriminator, not a silent type annotation.
+3. **A CI guard blocks new string-literals of the contract prefix.**
+   `rules/no-hardcoded-kb-image-path.yml` (ast-grep) fails any PR that
+   adds a `"/kb-images/"` literal in production Python outside the
+   allow-list. The frontend has the same coverage via the vitest drift
+   test on `lib/kb-image-url.ts`. SPEC-KB-IMAGES-V2-001 REQ-5 + REQ-7.
+
+4. **A real E2E test in CI exercises the whole stack.** Unit tests
+   inevitably mock the very layer where contracts drift. Only a Playwright
+   test that POSTs → fetches the returned URL → asserts `naturalWidth > 0`
+   detects all five regression patterns at once.
+   `klai-portal/frontend/e2e/kb-images.spec.ts` (currently dormant; needs
+   seeded storage-state secret to activate). SPEC-KB-IMAGES-V2-001 REQ-6.
+
+5. **Cross-language mirrors need their own drift test.** When a TypeScript
+   file mirrors a Python contract (frontend ↔ backend), a unit test in
+   the TS file MUST compare its outputs to fixture strings generated by
+   the Python side. Drift in either direction fails the test.
+   See `lib/__tests__/kb-image-url.test.ts` for the kb-image case.
+
+**Pre-V2 prevention bullet points (port mismatch, handle vs handle_path,
+auth-id type mismatch) are now consequences of rule 1: with one file
+owning the contract, those individual gotchas can no longer occur because
+no second file gets to write a divergent value.**
 
 ## postgres-no-return-type-overload (HIGH)
 PostgreSQL does NOT support function overloading by return type alone.

--- a/.github/workflows/portal-frontend-e2e-kb-images.yml
+++ b/.github/workflows/portal-frontend-e2e-kb-images.yml
@@ -1,0 +1,83 @@
+# SPEC-KB-IMAGES-V2-001 REQ-6: Playwright end-to-end test for the kb-image
+# round-trip (Caddy → portal-api → Garage → browser `<img>`).
+#
+# This workflow is DORMANT until the `KLAI_E2E_STORAGE_STATE_BASE64` secret
+# is configured. Without that secret the Playwright test would fail at the
+# login step. See `klai-portal/frontend/e2e/kb-images.spec.ts` for the
+# activation procedure.
+#
+# When activated, the test runs on every PR that touches any kb-image-shape
+# carrier (route declaration, value-class, lib pipeline, frontend mirror,
+# or the docs-editor that uploads through them). It's the only test that
+# proves the full transport stack works end-to-end — unit tests historically
+# missed five stacked transport bugs in this exact area.
+
+name: kb-images E2E (Playwright)
+
+on:
+  pull_request:
+    paths:
+      - 'klai-portal/backend/app/api/kb_images.py'
+      - 'klai-portal/backend/app/core/kb_image_url.py'
+      - 'klai-libs/image-storage/klai_image_storage/kb_image.py'
+      - 'klai-libs/image-storage/klai_image_storage/pipeline.py'
+      - 'klai-libs/image-storage/klai_image_storage/storage.py'
+      - 'klai-portal/frontend/src/lib/kb-image-url.ts'
+      - 'klai-portal/frontend/src/components/kb-editor/**'
+      - 'klai-portal/frontend/e2e/kb-images.spec.ts'
+      - 'deploy/caddy/Caddyfile'
+      - '.github/workflows/portal-frontend-e2e-kb-images.yml'
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    # DORMANT GUARD: flip to `if: ${{ secrets.KLAI_E2E_STORAGE_STATE_BASE64 != '' }}`
+    # once the storage-state secret is seeded. Keep this conditional in
+    # place so a missing secret produces a clear skipped-check, not a
+    # red CI run on every PR.
+    if: false
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: klai-portal/frontend/package-lock.json
+
+      - name: Install
+        working-directory: klai-portal/frontend
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        working-directory: klai-portal/frontend
+        run: npx playwright install chromium --with-deps
+
+      - name: Restore Playwright storage-state
+        working-directory: klai-portal/frontend
+        env:
+          STATE_B64: ${{ secrets.KLAI_E2E_STORAGE_STATE_BASE64 }}
+        run: |
+          mkdir -p e2e/.state
+          echo "$STATE_B64" | base64 -d > e2e/.state/storage.json
+          test -s e2e/.state/storage.json || (echo "empty storage-state" && exit 1)
+
+      - name: Run kb-image E2E
+        working-directory: klai-portal/frontend
+        env:
+          KLAI_E2E_BASE_URL: ${{ secrets.KLAI_E2E_BASE_URL }}
+          KLAI_E2E_KB_SLUG: ${{ secrets.KLAI_E2E_KB_SLUG }}
+        run: npx playwright test e2e/kb-images.spec.ts --reporter=line
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: klai-portal/frontend/playwright-report
+          retention-days: 7

--- a/.moai/specs/SPEC-KB-IMAGES-V2-001/spec.md
+++ b/.moai/specs/SPEC-KB-IMAGES-V2-001/spec.md
@@ -1,0 +1,455 @@
+---
+id: SPEC-KB-IMAGES-V2-001
+title: KB-images v2 — clean redesign, geen legacy routes
+version: 0.1.0
+status: draft
+created_at: 2026-05-12
+owner: mark.vletter
+domain: portal-knowledge
+related_specs:
+  - SPEC-TI-009                  # original (auth-proxied read route — broken since landing)
+  - SPEC-KB-IMAGE-001            # initial Garage S3 image pipeline (connectors)
+  - SPEC-KB-IMAGE-002            # content-addressed key format + ImageStore lib
+  - SPEC-PORTAL-DOCS-IMAGE-PASTE-001  # the feature that exposed the 5-layer regression
+replaces:
+  - SPEC-TI-009                  # full replacement; old route deleted
+removes_legacy:
+  - GET /kb-images/{org_id}/images/{kb_slug}/{filename}
+  - POST /kb-images/{kb_slug}
+  - klai_image_storage.storage.PUBLIC_IMAGE_PATH_PREFIX
+  - klai_image_storage.storage.ImageStore.build_public_url
+---
+
+# SPEC-KB-IMAGES-V2-001 — KB-images v2 — clean redesign, geen legacy routes
+
+## HISTORY
+
+| Date       | Version | Author        | Note                                                                 |
+|------------|---------|---------------|----------------------------------------------------------------------|
+| 2026-05-12 | 0.1.0   | mark.vletter  | Initial draft. Eliminates the 5-layer regression chain that needed 5 PRs to band-aid |
+
+---
+
+## 1. Goal & Outcome
+
+### Goal
+
+Vervang de kb-image stack (route, key-format, ImageStore-public-url, frontend-callback) door **één samenhangend ontwerp met één bron van waarheid** zodat het patroon van impliciete koppeling tussen serializer en route — dat 3 weken lang silently 404 produceerde — structureel onmogelijk wordt.
+
+Geen oude routes parallel houden. Geen legacy compat-laag. Clean cut, de oude paths verdwijnen.
+
+### Outcome (success measured by)
+
+- Eén `KbImage` value-class is de **enige** plek waar de URL-shape, S3-key-shape en route-shape gedefinieerd worden. Een mismatch tussen deze drie produceert een **compile-time** fout in pyright en een **route-load-time** fout in FastAPI startup (de app weigert te booten).
+- De `klai:tenant-review` workflow heeft een nieuw guard dat een mismatch tussen `KbImage.public_url(...)` en de FastAPI route-paths van `app/api/kb_images.py` detecteert en CI rood maakt.
+- Een **CI-niveau E2E** Playwright-test in de portal-frontend `e2e/prod-tenant/` pakket: log in, navigate naar een KB-page, fetch een productie-URL-shape via `<img>` element en assert dat `naturalWidth > 0`. Loopt op elke `klai-portal/backend/app/api/kb_images.py` of `klai_image_storage/**` change.
+- De 1553 bestaande Voys + Klai-help productie-images blijven werken **zonder dat een rij in `knowledge.artifact_images` of een S3-object hoeft te worden aangeraakt** (zelfde S3 key prefix, zelfde URL pad). De change is een refactor van de **codebase**, niet van de data.
+- De docs-editor paste-flow (SPEC-PORTAL-DOCS-IMAGE-PASTE-001) blijft werken bit-voor-bit identiek voor de eindgebruiker, alleen achter de UI-laag is de stack vereenvoudigd.
+- **Zero legacy routes**: `GET /kb-images/{org_id}/{kb_slug}/{filename}` (4-segment) bestaat niet meer in v2. Niet als deprecated-warning route, niet als 301-redirect. Helemaal weg.
+
+### Non-goal
+
+- Image-edit features (crop, rotate, focal-point).
+- Resumable uploads / chunked transfer (5 MB cap blijft).
+- Per-page image refcount + automatic GC (eigen SPEC, SPEC-PORTAL-DOCS-IMAGE-GC-001).
+- Migratie naar een ander object-store (Cloudflare R2, etc.).
+- Image-rendering optimalisaties (responsive srcset, AVIF, etc.).
+
+---
+
+## 2. Background
+
+### De 5-laagse regression chain (waarom een rewrite, niet meer patches)
+
+SPEC-TI-009 (landed 2026-04-22) introduceerde de auth-proxied read-route op `/kb-images/...`. Tot 2026-05-12 — de dag dat SPEC-PORTAL-DOCS-IMAGE-PASTE-001 de eerste browser-leg consument shipte — was de route **silently broken** door vijf gestapelde bugs:
+
+| # | Layer | Symptom | Cause | Fix PR |
+|---|---|---|---|---|
+| 1 | Caddy | 502 Bad Gateway | `reverse_proxy portal-api:8000` (dead port; portal-api listens op :8010) | #598 |
+| 2 | Caddy | 404 (na #1) | `handle_path /kb-images/*` strip't de `/kb-images/` prefix; FastAPI ziet pad zonder prefix | #598 |
+| 3 | portal-api | 403 (na #1+#2) | Auth-check vergeleek `session.org_id` (portal int) tegen path-`org_id` (typed int) terwijl S3-keys zitadel-string-prefix gebruiken | #598 |
+| 4 | docker-compose | 503 (na #1+#2+#3) | `portal-api` env block miste alle `GARAGE_S3_*` vars (SPEC-SEC-ENVFILE-SCOPE-001 had ze nooit toegevoegd) | #600 |
+| 5 | portal-api | 404 op route-niveau (na #1+#2+#3+#4) | Route declaration `/kb-images/{org_id}/{kb_slug}/{filename}` (4 placeholders) vs. URL-shape `/kb-images/{org}/images/{kb}/{sha}.ext` (5 segments) — geen FastAPI match | #607 |
+| (frontend) | portal-frontend | Eternal "Loading..." | `uploadFile` callback POSTed naar `/api/kb-images/{kbSlug}`, route bestaat op `/kb-images/{kbSlug}` | #602 |
+
+Elke fix onthulde de volgende laag. **Zes patch-PRs in één werkdag** om iets dat in productie nooit gewerkt had te laten functioneren. Het patroon is structureel — de root cause is dat **drie verschillende files** (klai_image_storage's `build_public_url`, kb_images.py's route declaration, BlockPageEditor.tsx's fetch URL) onafhankelijk de URL-shape vaststelden. Drift was onvermijdelijk.
+
+### Waarom geen "deprecation period"
+
+Een v1+v2 parallel route bestaat normaal om callers tijd te geven te migreren. Hier zijn er **geen externe callers**:
+- KB-image URLs leven alleen in (a) page-content markdown en (b) connector-image-references in `knowledge.artifact_images`
+- Beide blijven werken zolang het S3-key-pad en het public-URL-pad **identiek blijven**
+- v2 raakt dat pad niet — alleen hoe de codebase het intern representeert
+
+Geen externe API-consumer is afhankelijk van de oude representatie. Een "deprecation phase" zou alleen meer code-paths produceren die we later weer moeten opruimen.
+
+---
+
+## 3. Scope
+
+| In | Out |
+|---|---|
+| Nieuwe `app/core/kb_image_url.py` module met `KbImage` value-class | Wijziging aan `knowledge.artifact_images` schema of data |
+| Refactor `app/api/kb_images.py` om volledig via `KbImage` te werken (route paths, response URLs) | Wijziging aan klai-connector / klai-knowledge-ingest write-pad |
+| Verwijdering van `klai_image_storage.storage.PUBLIC_IMAGE_PATH_PREFIX` + `build_public_url()` | Aanpassing van bestaande S3-keys |
+| Refactor `klai_image_storage.storage.ImageStore` om geen URL-shape kennis meer te hebben (alleen S3-key shape via `build_object_key`) | Wijziging Garage bucket-conventie |
+| Update klai-connector `_upload_images` en klai-knowledge-ingest crawler om `KbImage.from_components()` te gebruiken voor URL-generation | Image-edit features (crop, etc.) |
+| Update `BlockPageEditor.tsx` `uploadFile` callback om de POST URL via een geëxporteerde `KB_IMAGE_UPLOAD_PATH` constant te bouwen | Image lifecycle / GC |
+| FastAPI startup-time assertion: alle `kb_images.py` routes komen exact overeen met `KbImage`-gegenereerde paths | Multi-region S3 |
+| `klai:tenant-review` workflow: ast-grep guard tegen `/kb-images/` literal hardcoded buiten `app/core/kb_image_url.py` | Resumable upload |
+| Playwright E2E test in `e2e/prod-tenant/` die de echte production URL-shape fetcht via `<img>` en `naturalWidth` checkt | Image preview thumbnails |
+| Verwijdering van het oude pitfall-entry `caddy-proxy-route-without-browser-leg` (vervangen door een nieuwe entry over single-source-of-truth voor URL-shapes) | |
+
+---
+
+## 4. EARS Requirements
+
+### REQ-1 — Single source of truth: `KbImage` value-class
+
+**When** de codebase een kb-image URL of S3-key wil bouwen, **the system** MUST dat uitsluitend doen via een nieuwe `app/core/kb_image_url.py::KbImage` value-class met deze API:
+
+```python
+@dataclass(frozen=True)
+class KbImage:
+    zitadel_org_id: str
+    kb_slug: str
+    sha256: str
+    ext: str  # one of: jpg, png, gif, webp
+
+    @classmethod
+    def from_bytes(cls, zitadel_org_id: str, kb_slug: str, data: bytes, mime: str) -> "KbImage": ...
+
+    @classmethod
+    def from_path(cls, path: str) -> "KbImage | None":
+        """Parse a path produced by .public_path() back into a KbImage.
+        Returns None if the path doesn't match the canonical shape — used
+        by tests + the route-load-time assertion."""
+        ...
+
+    @property
+    def s3_key(self) -> str:
+        return f"{self.zitadel_org_id}/images/{self.kb_slug}/{self.sha256}.{self.ext}"
+
+    @property
+    def public_path(self) -> str:
+        """Relative URL path served by the kb-images auth-proxy."""
+        return f"/kb-images/{self.zitadel_org_id}/images/{self.kb_slug}/{self.sha256}.{self.ext}"
+
+    # FastAPI route template — exposed for the route declaration AND the
+    # startup-time match assertion.
+    ROUTE_TEMPLATE: ClassVar[str] = "/kb-images/{zitadel_org_id}/images/{kb_slug}/{filename}"
+    UPLOAD_ROUTE_TEMPLATE: ClassVar[str] = "/kb-images/{kb_slug}"
+```
+
+`ROUTE_TEMPLATE` is de **enige** plek waar de FastAPI-route-string mag worden gedeclareerd. `kb_images.py` importeert hem letterlijk.
+
+### REQ-2 — Route declaration via constant, niet string literal
+
+**When** `app/api/kb_images.py` z'n routes declareert, **the system** MUST `KbImage.ROUTE_TEMPLATE` en `KbImage.UPLOAD_ROUTE_TEMPLATE` als constanten gebruiken in de `@router.get(...)` en `@router.post(...)` decorators. **Forbidden**: een hardcoded string-literal `/kb-images/...` in een decorator.
+
+### REQ-3 — Route-load-time match assertion (defense in depth)
+
+**When** portal-api boot, **the system** MUST in z'n FastAPI lifespan startup-hook een assertie uitvoeren die `KbImage(zitadel_org_id="X", kb_slug="Y", sha256="Z", ext="png").public_path` parseert via `KbImage.from_path(...)` én tegelijk verifieert dat het pad mapped op de zelfde route-template via een FastAPI router-introspection. Als de twee niet overeenkomen, **the system** MUST de boot afbreken met een leesbare error (`KbImage URL-shape vs route-template drift gedetecteerd`).
+
+### REQ-4 — Verwijderen van `ImageStore.build_public_url` + `PUBLIC_IMAGE_PATH_PREFIX`
+
+**When** v2 ge-mergeed is, **the system** MUST `klai_image_storage.storage.PUBLIC_IMAGE_PATH_PREFIX` (constante) en `klai_image_storage.storage.ImageStore.build_public_url()` (method) niet meer bevatten. Beide worden verwijderd. Callers in klai-connector en klai-knowledge-ingest worden gemigreerd naar `KbImage.from_components(...).public_path`.
+
+### REQ-5 — ast-grep CI guard: geen hardcoded `/kb-images/` paths
+
+**When** een PR `/kb-images/` als string-literal toevoegt buiten `app/core/kb_image_url.py` (de single source) of `klai-portal/frontend/src/lib/kb_image_url.ts` (de TS-mirror, indien nodig), **the system** MUST in CI rood worden via een nieuwe ast-grep rule `no-hardcoded-kb-image-path.yml`.
+
+### REQ-6 — Playwright E2E in CI
+
+**When** een PR `klai-portal/backend/app/api/kb_images.py`, `klai-portal/backend/app/core/kb_image_url.py`, `klai-libs/image-storage/**`, of `klai-portal/frontend/src/components/kb-editor/**` raakt, **the system** MUST in CI een Playwright-test draaien die:
+
+1. Inlogt op `https://prod-or-staging.getklai.com` via storage-state
+2. Een POST doet naar `/kb-images/{test-kb-slug}` met een 1x1 PNG
+3. De teruggekregen `url` als `<img src>` rendert
+4. Asserteert dat `img.naturalWidth > 0` en `img.complete === true`
+
+Geen mock. Geen TestClient. Geen unit-test substitute. Het hele Caddy → portal-api → Garage pad moet door de test heen.
+
+### REQ-7 — Frontend uploadFile uit dezelfde bron
+
+**When** `BlockPageEditor.tsx` z'n upload-URL bouwt, **the system** MUST dat doen via een geëxporteerde TypeScript-constante in `klai-portal/frontend/src/lib/kb-image-url.ts` (de exact equivalent van REQ-1's Python module), niet via een inline string-literal. De TS-module heeft een unit test die de URL-shape vergelijkt met een fixture-string en faalt als ze driften.
+
+### REQ-8 — Geen legacy routes blijven achter
+
+**When** v2 ge-mergeed is, **the system** MUST géén route hebben op een ander pad dan REQ-1's `ROUTE_TEMPLATE`. Een grep voor `kb-images/` in de Caddy file, in `kb_images.py`, in `BlockPageEditor.tsx`, en in `process-rules.md` mag alleen verwijzingen naar `KbImage.ROUTE_TEMPLATE` opleveren of een commentaar over deze SPEC. Geen 4-segment route. Geen 301-redirect. Geen `/api/kb-images/...` shadow-route.
+
+### REQ-9 — Pitfall-entry geupdate
+
+**When** v2 ge-mergeed is, **the system** MUST in `.claude/rules/klai/pitfalls/process-rules.md` de huidige `caddy-proxy-route-without-browser-leg` entry vervangen door een nieuwe entry die het complete patroon documenteert: "drie onafhankelijke files die dezelfde URL-shape hardcoderen → silent drift → 5-layer regression". Concrete prevention: REQ-1's single-source pattern + REQ-3's boot-time assertion + REQ-6's CI E2E.
+
+---
+
+## 5. Acceptance Criteria
+
+| # | Criterium | Verificatie |
+|---|---|---|
+| AC-1 | `KbImage(zitadel_org_id, kb_slug, sha256, ext).public_path` returnt exact dezelfde 5-segment URL als de huidige productie-shape op de 1553 Voys + Klai-help images | pytest fixture met 10 productie-keys; round-trip via `KbImage.from_path` en assert == |
+| AC-2 | Pyright vindt geen `/kb-images/` string-literals buiten `kb_image_url.py` | ast-grep CI guard (REQ-5) |
+| AC-3 | Portal-api lifespan-assertion vuurt en boot crash't als ik de route declaration handmatig drift maak (sabotage test: rename `images` → `imgs` in `kb_images.py`) | pytest test_route_template_drift_aborts_boot |
+| AC-4 | Bestaande Voys connector image laadt 200 via browser-fetch via Playwright | Playwright E2E in `e2e/prod-tenant/` |
+| AC-5 | Mark plakt screenshot in docs-editor → image verschijnt → page reload toont image | Playwright E2E |
+| AC-6 | klai-connector `_upload_images` gebruikt `KbImage.from_components(...)` ipv `ImageStore.build_public_url(...)` | Code review + grep |
+| AC-7 | klai-knowledge-ingest `download_and_upload_crawl_images` gebruikt zelfde | Code review + grep |
+| AC-8 | `klai_image_storage.storage` heeft géén `PUBLIC_IMAGE_PATH_PREFIX` of `build_public_url` meer | pytest fixture probeert import — moet ImportError raisen |
+| AC-9 | Caddy file heeft géén `handle_path` block meer voor `/kb-images/*` (alleen `handle`) | grep |
+| AC-10 | `klai:tenant-review` workflow guard rule loaded + actief op PR | gh actions workflow inspection |
+| AC-11 | Geen 5xx of 404 op `/kb-images/*` in VictoriaLogs van de eerste 24u na deploy | Grafana panel + alert |
+
+---
+
+## 6. Technical Approach
+
+### Backend
+
+**Nieuw**: `klai-portal/backend/app/core/kb_image_url.py` — de single source of truth.
+
+```python
+from dataclasses import dataclass
+from typing import ClassVar
+import hashlib
+import re
+
+_MIME_EXT: dict[str, str] = {
+    "image/jpeg": "jpg", "image/png": "png",
+    "image/gif": "gif", "image/webp": "webp",
+}
+_VALID_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_VALID_KB_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
+_VALID_ZITADEL_RE = re.compile(r"^[0-9]{1,20}$")
+_VALID_EXT_RE = re.compile(r"^(jpg|png|gif|webp)$")
+
+
+@dataclass(frozen=True, slots=True)
+class KbImage:
+    zitadel_org_id: str
+    kb_slug: str
+    sha256: str
+    ext: str
+
+    ROUTE_TEMPLATE: ClassVar[str] = "/kb-images/{zitadel_org_id}/images/{kb_slug}/{filename}"
+    UPLOAD_ROUTE_TEMPLATE: ClassVar[str] = "/kb-images/{kb_slug}"
+    _PATH_RE: ClassVar[re.Pattern[str]] = re.compile(
+        r"^/kb-images/(?P<zitadel_org_id>[0-9]{1,20})"
+        r"/images/(?P<kb_slug>[a-z0-9][a-z0-9-]{0,63})"
+        r"/(?P<sha256>[0-9a-f]{64})\.(?P<ext>jpg|png|gif|webp)$"
+    )
+
+    def __post_init__(self) -> None:
+        if not _VALID_ZITADEL_RE.match(self.zitadel_org_id):
+            raise ValueError(f"invalid zitadel_org_id: {self.zitadel_org_id!r}")
+        if not _VALID_KB_SLUG_RE.match(self.kb_slug):
+            raise ValueError(f"invalid kb_slug: {self.kb_slug!r}")
+        if not _VALID_SHA256_RE.match(self.sha256):
+            raise ValueError(f"invalid sha256: {self.sha256!r}")
+        if not _VALID_EXT_RE.match(self.ext):
+            raise ValueError(f"invalid ext: {self.ext!r}")
+
+    @classmethod
+    def from_bytes(cls, zitadel_org_id: str, kb_slug: str, data: bytes, mime: str) -> "KbImage":
+        ext = _MIME_EXT.get(mime)
+        if ext is None:
+            raise ValueError(f"unsupported MIME: {mime!r}")
+        return cls(
+            zitadel_org_id=zitadel_org_id,
+            kb_slug=kb_slug,
+            sha256=hashlib.sha256(data).hexdigest(),
+            ext=ext,
+        )
+
+    @classmethod
+    def from_path(cls, path: str) -> "KbImage | None":
+        m = cls._PATH_RE.match(path)
+        if m is None:
+            return None
+        return cls(**m.groupdict())
+
+    @property
+    def s3_key(self) -> str:
+        return f"{self.zitadel_org_id}/images/{self.kb_slug}/{self.sha256}.{self.ext}"
+
+    @property
+    def public_path(self) -> str:
+        return f"/kb-images/{self.s3_key}"
+```
+
+**Refactor**: `app/api/kb_images.py`.
+
+```python
+from app.core.kb_image_url import KbImage
+
+@router.get(KbImage.ROUTE_TEMPLATE)
+async def get_kb_image(...): ...
+
+@router.post(KbImage.UPLOAD_ROUTE_TEMPLATE)
+async def upload_kb_image(...): ...
+```
+
+**Lifespan assertion** in `app/main.py`:
+
+```python
+def _assert_kb_image_routes_match_value_class(app: FastAPI) -> None:
+    """REQ-3: fail boot if route declarations drift from KbImage.ROUTE_TEMPLATE."""
+    from app.core.kb_image_url import KbImage
+
+    declared_paths = {route.path for route in app.routes if "kb-images" in getattr(route, "path", "")}
+    expected = {KbImage.ROUTE_TEMPLATE, KbImage.UPLOAD_ROUTE_TEMPLATE}
+    if declared_paths != expected:
+        raise RuntimeError(
+            f"KbImage URL-shape vs route-template drift detected: "
+            f"declared={declared_paths} expected={expected}"
+        )
+```
+
+### Library refactor
+
+**`klai-libs/image-storage/klai_image_storage/storage.py`**: schrap `PUBLIC_IMAGE_PATH_PREFIX` en `ImageStore.build_public_url`. `ImageStore.build_object_key` blijft, want hij is content-addressed en doet alleen S3-key logica.
+
+Callers (klai-connector + klai-knowledge-ingest) krijgen een dunne adapter die voor hun specifieke org-id pattern de `KbImage` construeert.
+
+### Frontend
+
+**Nieuw**: `klai-portal/frontend/src/lib/kb-image-url.ts` — TS-mirror van REQ-1.
+
+```typescript
+export const KB_IMAGE_UPLOAD_PATH = (kbSlug: string) => `/kb-images/${encodeURIComponent(kbSlug)}`;
+export const KB_IMAGE_PUBLIC_PATH_RE = /^\/kb-images\/[0-9]{1,20}\/images\/[a-z0-9][a-z0-9-]{0,63}\/[0-9a-f]{64}\.(jpg|png|gif|webp)$/;
+```
+
+**Refactor `BlockPageEditor.tsx`**:
+
+```typescript
+import { KB_IMAGE_UPLOAD_PATH } from '@/lib/kb-image-url';
+...
+const res = await apiFetch<{...}>(KB_IMAGE_UPLOAD_PATH(kbSlug), {method:'POST', body:fd});
+```
+
+**Unit test** vergelijkt de TS-output met een fixture string die identiek is aan een Python-genereerde URL — voorkomt cross-language drift.
+
+### CI guards
+
+**`rules/no-hardcoded-kb-image-path.yml`** (ast-grep):
+
+```yaml
+id: no-hardcoded-kb-image-path
+language: python
+rule:
+  pattern: $STR
+  constraints:
+    STR:
+      regex: '"/kb-images/'
+files:
+  include:
+    - "klai-portal/backend/**/*.py"
+  exclude:
+    - "klai-portal/backend/app/core/kb_image_url.py"
+    - "klai-portal/backend/tests/**"
+```
+
+Plus een TypeScript-equivalent voor de frontend.
+
+**Playwright E2E** in `klai-portal/frontend/e2e/kb-images.spec.ts`:
+
+```typescript
+test('kb-image upload + render', async ({ page, context }) => {
+  await page.goto(STAGING_URL);
+  // ... use storage-state to skip login ...
+  const png = readFileSync('e2e/fixtures/1x1.png');
+  const response = await page.request.post('/kb-images/e2e-test-kb', {
+    multipart: { file: { name: '1x1.png', mimeType: 'image/png', buffer: png } },
+  });
+  expect(response.status()).toBe(200);
+  const { url } = await response.json();
+
+  await page.setContent(`<img id="t" src="${url}" />`);
+  await page.locator('#t').waitFor({ state: 'visible' });
+  const dims = await page.locator('#t').evaluate((img: HTMLImageElement) => ({
+    nw: img.naturalWidth, complete: img.complete,
+  }));
+  expect(dims.nw).toBeGreaterThan(0);
+  expect(dims.complete).toBe(true);
+});
+```
+
+Runs op elke PR die `kb_images.py`, `kb_image_url.py`, `klai-libs/image-storage/**` of `BlockPageEditor.tsx` raakt.
+
+### Files touched
+
+| File | Change |
+|---|---|
+| `klai-portal/backend/app/core/kb_image_url.py` | **new** — single source |
+| `klai-portal/backend/app/api/kb_images.py` | refactor — import + use `KbImage` |
+| `klai-portal/backend/app/main.py` | add lifespan assertion (REQ-3) |
+| `klai-portal/backend/tests/test_kb_image_url.py` | **new** — round-trip + production fixture |
+| `klai-portal/backend/tests/test_kb_images_*.py` | updated to use `KbImage.from_components(...).public_path` |
+| `klai-libs/image-storage/klai_image_storage/storage.py` | **remove** `PUBLIC_IMAGE_PATH_PREFIX` + `build_public_url` |
+| `klai-libs/image-storage/tests/test_storage.py` | update — remove tests for deleted API |
+| `klai-connector/app/services/sync_engine.py` | refactor — use `KbImage` for URL generation in image-references |
+| `klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py` | idem |
+| `klai-portal/frontend/src/lib/kb-image-url.ts` | **new** — TS mirror |
+| `klai-portal/frontend/src/components/kb-editor/BlockPageEditor.tsx` | import + use `KB_IMAGE_UPLOAD_PATH` |
+| `klai-portal/frontend/e2e/kb-images.spec.ts` | **new** — Playwright E2E |
+| `klai-portal/frontend/src/lib/__tests__/kb-image-url.test.ts` | **new** — TS-vs-Python drift test |
+| `rules/no-hardcoded-kb-image-path.yml` | **new** — ast-grep guard |
+| `.github/workflows/portal-api.yml` | add ast-grep rule to existing check |
+| `.github/workflows/portal-frontend.yml` | add Playwright E2E job on path-trigger |
+| `.claude/rules/klai/pitfalls/process-rules.md` | **replace** `caddy-proxy-route-without-browser-leg` with the new pattern |
+| `deploy/caddy/Caddyfile` | no change (current `handle /kb-images/*` is correct) |
+
+Totaal verwacht: **~600-800 regels code over backend + frontend + libs + tests + CI**, één samenhangende PR.
+
+---
+
+## 7. Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Bestaande page-content markdown bevat de oude URL-shape | URL-shape is **identiek** voor end-users (5 segments); alleen interne codepath verandert |
+| Cross-service refactor van klai_image_storage breekt connector + ingest | E2E test (REQ-6) raakt het hele pad; CI rood voor merge |
+| TS-mirror van Python `KbImage` drift over tijd | Unit-test vergelijkt outputs met identical fixture (REQ-7); CI rood bij drift |
+| Lifespan-assertion zelf bevat een bug | pytest `test_route_template_drift_aborts_boot` test de assertion via sabotage |
+| Playwright E2E flaky in CI | Storage-state seeded one-time; test uses `page.request.*` (not browser nav) for the POST; only the `<img>` render is browser-side. Acceptabel flake-budget: 1 in 100. |
+| ast-grep rule te strict (false positives) | Tests dir + `kb_image_url.py` whitelisted; comments in pitfall-rules zijn markdown, niet Python source |
+
+---
+
+## 8. Out of Scope (expliciet)
+
+- Een SPEC-KB-IMAGES-V3 voor S3 → R2 migration
+- Refactor van Caddyfile (mogelijk in opvolgende SPEC)
+- Image transformatie pipeline (resize, format conversion)
+- CDN voor kb-images
+- Per-page GC van orphaned images (eigen SPEC `SPEC-PORTAL-DOCS-IMAGE-GC-001`)
+- Image-rendering in chat-citations (LLM markdown-image embedding — vereist prompt + retrieval-API werk)
+
+---
+
+## 9. Deployment
+
+- **Geen** alembic-migratie nodig (S3-keys + DB-rijen blijven onveranderd).
+- **Geen** klai-infra of SOPS-wijziging.
+- Standaard portal-api + portal-frontend deploy workflows.
+- Rollback: `git revert <merge-commit>`. Geen data-impact (alleen interne codestructuur).
+- Verificatie: Playwright E2E moet groen zijn op de eerste post-deploy CI run. Manueel: de huidige bekende productie image-URLs (Voys `dae543ab...`, Klai-help `71e67cdc...`) moeten 200 returnen via curl met session-cookie.
+
+---
+
+## 10. Open Questions (voor SPEC-review)
+
+1. **TypeScript mirror — code-gen of handmatig?** Een codegen van Python-`KbImage` naar TS via een script-in-CI zou drift onmogelijk maken, maar adds complexity. Handmatig + drift-test is goedkoper. Voorstel: handmatig + test; gen kan in een latere SPEC.
+2. **Lifespan-assertion fail-mode** — fail-loud (`raise RuntimeError`) of fail-soft (`logger.error` + boot doorgaan)? Voorstel: fail-loud. Een drift hier is structureel; door laten gaan = silent breakage opnieuw.
+3. **Caddy `handle` block** — laten staan zoals nu of refactoren naar een named matcher voor consistentie met andere blocks? Voorstel: laten staan. Caddy-niveau is niet de bron van het probleem.
+4. **`KbImage.UPLOAD_ROUTE_TEMPLATE`** zou eigenlijk niet hetzelfde object zijn als de read-route — verschillende shapes. Voorstel: aparte `KbImageUpload` of een NamedTuple van twee templates. Te discussiëren bij implementation.
+
+---
+
+## 11. References
+
+- [SPEC-TI-009 / SPEC-KB-IMAGE-002](../SPEC-TI-009/) — original
+- [SPEC-PORTAL-DOCS-IMAGE-PASTE-001](../SPEC-PORTAL-DOCS-IMAGE-PASTE-001/spec.md) — the feature that exposed the chain
+- PRs in the 2026-05-12 regression chain: [#598](https://github.com/GetKlai/klai/pull/598), [#600](https://github.com/GetKlai/klai/pull/600), [#602](https://github.com/GetKlai/klai/pull/602), [#607](https://github.com/GetKlai/klai/pull/607)
+- [.claude/rules/klai/pitfalls/process-rules.md](../../.claude/rules/klai/pitfalls/process-rules.md) — current pitfall entry (to be replaced)

--- a/klai-connector/tests/test_e2e_image_pipeline.py
+++ b/klai-connector/tests/test_e2e_image_pipeline.py
@@ -39,7 +39,7 @@ def _mock_image_store() -> MagicMock:
     async def _upload(*args, **kwargs):
         key = f"org/images/kb/{args[3]}"
         return ImageUploadResult(
-            object_key=key, public_url=f"/kb-images/{key}", deduplicated=False,
+            object_key=key, deduplicated=False,
         )
 
     store.upload_image = _upload

--- a/klai-connector/tests/test_sync_engine_images.py
+++ b/klai-connector/tests/test_sync_engine_images.py
@@ -23,7 +23,7 @@ class TestDownloadAndUploadImages:
         async def fake_upload(*args, **kwargs):
             from klai_image_storage import ImageUploadResult
             return ImageUploadResult(
-                object_key="org/img/hash.png", public_url="/kb-images/org/img/hash.png", deduplicated=False,
+                object_key="org/img/hash.png", deduplicated=False,
             )
 
         mock_store.upload_image = fake_upload
@@ -114,7 +114,7 @@ class TestDownloadAndUploadImages:
 
         async def fake_upload(*args, **kwargs):
             from klai_image_storage import ImageUploadResult
-            return ImageUploadResult(object_key="key", public_url="/kb-images/key", deduplicated=False)
+            return ImageUploadResult(object_key="key", deduplicated=False)
 
         mock_store.upload_image = fake_upload
 
@@ -146,7 +146,7 @@ class TestDownloadAndUploadImages:
 
         async def fake_upload(*args, **kwargs):
             from klai_image_storage import ImageUploadResult
-            return ImageUploadResult(object_key="key", public_url="/kb-images/key", deduplicated=False)
+            return ImageUploadResult(object_key="key", deduplicated=False)
 
         mock_store.upload_image = fake_upload
 
@@ -184,7 +184,7 @@ class TestUploadImagesIsConnectorAgnostic:
         async def fake_upload(*args, **kwargs):
             from klai_image_storage import ImageUploadResult
             return ImageUploadResult(
-                object_key="k", public_url="/kb-images/k", deduplicated=False,
+                object_key="k", deduplicated=False,
             )
 
         engine._image_store.upload_image = fake_upload

--- a/klai-connector/uv.lock
+++ b/klai-connector/uv.lock
@@ -1047,7 +1047,7 @@ dev = [
 
 [[package]]
 name = "klai-identity-assert"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "../klai-libs/identity-assert" }
 dependencies = [
     { name = "httpx" },

--- a/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
@@ -191,6 +191,7 @@ from knowledge_ingest.source_label import (  # noqa: E402
     compute_source_label as _compute_source_label,
 )
 
+
 def _parse_image_refs(image_urls: list) -> list[tuple[str, str]]:
     """Convert image URLs into (s3_key, content_hash) tuples for bookkeeping.
 

--- a/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
@@ -191,39 +191,29 @@ from knowledge_ingest.source_label import (  # noqa: E402
     compute_source_label as _compute_source_label,
 )
 
-# SPEC-CONNECTOR-DELETE-LIFECYCLE-001 REQ-06.2: convention for the public
-# URL prefix that ImageStore prepends to every uploaded key (matches
-# ``klai_image_storage.storage.PUBLIC_IMAGE_PATH_PREFIX``). We re-derive
-# the s3_key by stripping this prefix.
-_IMAGE_URL_PREFIX = "/kb-images/"
-
-
 def _parse_image_refs(image_urls: list) -> list[tuple[str, str]]:
     """Convert image URLs into (s3_key, content_hash) tuples for bookkeeping.
 
-    Public URL shape: ``/kb-images/{org}/images/{kb}/{sha256}.{ext}``.
-    The ``content_hash`` is the basename minus the extension; the
-    ``s3_key`` is the full URL minus the ``/kb-images/`` prefix.
+    SPEC-CONNECTOR-DELETE-LIFECYCLE-001 REQ-06.2 — URL parsing for the
+    cleanup bookkeeping table.
 
-    Skips any URL that does not match the expected shape (manual uploads
-    pointing at external CDNs, malformed entries) — those simply do not
-    get connector-scoped cleanup. The bookkeeping table is best-effort:
-    not having a row for an image means the cleanup query will never
-    propose it as orphan, which is the safe default.
+    SPEC-KB-IMAGES-V2-001 REQ-1: parses via ``KbImage.from_path`` to share
+    the URL shape with the rest of the codebase. The s3_key is read from
+    the KbImage instance; content_hash is the sha256 field. Skips any URL
+    that does not match the canonical shape (manual uploads pointing at
+    external CDNs, malformed entries) — those simply do not get
+    connector-scoped cleanup, which is the safe default.
     """
+    from klai_image_storage.kb_image import KbImage  # local to avoid import cycle
+
     refs: list[tuple[str, str]] = []
     for raw in image_urls or []:
         if not isinstance(raw, str):
             continue
-        if not raw.startswith(_IMAGE_URL_PREFIX):
+        kb_image = KbImage.from_path(raw)
+        if kb_image is None:
             continue
-        s3_key = raw[len(_IMAGE_URL_PREFIX) :]
-        # Final segment is "{sha256}.{ext}" — strip the extension.
-        basename = s3_key.rsplit("/", 1)[-1]
-        content_hash = basename.rsplit(".", 1)[0]
-        if not content_hash or "/" in content_hash:
-            continue
-        refs.append((s3_key, content_hash))
+        refs.append((kb_image.s3_key, kb_image.sha256))
     return refs
 
 

--- a/klai-knowledge-ingest/tests/test_artifact_images_parsing.py
+++ b/klai-knowledge-ingest/tests/test_artifact_images_parsing.py
@@ -1,69 +1,77 @@
 """Unit tests for ``_parse_image_refs`` and orphan-key SQL semantics.
 
-SPEC-CONNECTOR-DELETE-LIFECYCLE-001 REQ-06.2.
+SPEC-CONNECTOR-DELETE-LIFECYCLE-001 REQ-06.2 + SPEC-KB-IMAGES-V2-001 REQ-1.
 
-The integration tests for the orphan-keys SQL live alongside other
-real-postgres tests in tests/integration/. These unit tests cover only
-the URL-parsing helper which is pure-python and can be exhaustively
-verified without a database.
+These tests now go through ``KbImage.from_path`` (the single source of
+truth for kb-image URL parsing), so fixtures must use canonical-shape
+URLs: a 64-char hex sha + a supported extension (jpg|png|gif|webp).
 """
 
 from __future__ import annotations
 
 from knowledge_ingest.routes.ingest import _parse_image_refs
 
+# Realistic sha256s — content hashes of small fixture byte strings.
+_SHA_A = "a" * 64
+_SHA_B = "b" * 64
+_SHA_VALID = "1c" * 32
+
 
 class TestParseImageRefs:
     def test_handles_canonical_kb_image_url(self) -> None:
         urls = [
-            "/kb-images/368884765035593759/images/support/abc123def.png",
+            f"/kb-images/368884765035593759/images/support/{_SHA_A}.png",
         ]
         refs = _parse_image_refs(urls)
         assert refs == [
             (
-                "368884765035593759/images/support/abc123def.png",
-                "abc123def",
+                f"368884765035593759/images/support/{_SHA_A}.png",
+                _SHA_A,
             )
         ]
 
     def test_handles_multiple_urls(self) -> None:
         urls = [
-            "/kb-images/o1/images/kb1/aaa111.png",
-            "/kb-images/o1/images/kb1/bbb222.webp",
+            f"/kb-images/o1/images/kb1/{_SHA_A}.png",
+            f"/kb-images/o1/images/kb1/{_SHA_B}.webp",
         ]
         refs = _parse_image_refs(urls)
         assert len(refs) == 2
-        assert refs[0] == ("o1/images/kb1/aaa111.png", "aaa111")
-        assert refs[1] == ("o1/images/kb1/bbb222.webp", "bbb222")
+        assert refs[0] == (f"o1/images/kb1/{_SHA_A}.png", _SHA_A)
+        assert refs[1] == (f"o1/images/kb1/{_SHA_B}.webp", _SHA_B)
 
     def test_skips_non_kb_image_urls(self) -> None:
         """Manual uploads pointing at external CDNs are not tracked."""
         urls = [
             "https://cdn.example.com/foo.png",
             "/some-other-prefix/bar.jpg",
-            "/kb-images/o1/images/kb1/valid.png",
+            f"/kb-images/o1/images/kb1/{_SHA_VALID}.png",
         ]
         refs = _parse_image_refs(urls)
-        assert refs == [("o1/images/kb1/valid.png", "valid")]
+        assert refs == [(f"o1/images/kb1/{_SHA_VALID}.png", _SHA_VALID)]
 
     def test_skips_non_string_entries(self) -> None:
-        urls: list = ["/kb-images/o1/images/kb1/abc.png", None, 42, {"url": "x"}]
+        urls: list = [
+            f"/kb-images/o1/images/kb1/{_SHA_A}.png",
+            None,
+            42,
+            {"url": "x"},
+        ]
         refs = _parse_image_refs(urls)
-        assert refs == [("o1/images/kb1/abc.png", "abc")]
+        assert refs == [(f"o1/images/kb1/{_SHA_A}.png", _SHA_A)]
 
-    def test_skips_url_with_no_extension(self) -> None:
-        """Defensive: malformed URLs without an extension still produce a
-        usable content_hash but we accept it (the basename is the hash).
-        """
-        urls = ["/kb-images/o1/images/kb1/abc"]
+    def test_skips_url_without_canonical_shape(self) -> None:
+        """SPEC-KB-IMAGES-V2-001 REQ-1: only canonical shape (5 segments + 64-hex
+        sha + supported ext) is accepted. Anything else is silently skipped —
+        same fail-safe as before, stricter shape."""
+        urls = [
+            "/kb-images/o1/images/kb1/abc",  # no ext, short basename
+            "/kb-images/o1/images/kb1/short.png",  # wrong sha length
+            f"/kb-images/o1/images/kb1/{_SHA_A}.svg",  # disallowed ext
+            "/kb-images/.png",  # missing org/kb/file segments
+        ]
         refs = _parse_image_refs(urls)
-        # No "." in basename -> rsplit returns the whole string -> hash=basename
-        assert refs == [("o1/images/kb1/abc", "abc")]
+        assert refs == []
 
     def test_empty_input_returns_empty_list(self) -> None:
         assert _parse_image_refs([]) == []
-
-    def test_skips_url_when_basename_collapses_to_empty(self) -> None:
-        urls = ["/kb-images/.png"]
-        refs = _parse_image_refs(urls)
-        assert refs == []

--- a/klai-knowledge-ingest/tests/test_crawler_images.py
+++ b/klai-knowledge-ingest/tests/test_crawler_images.py
@@ -13,7 +13,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
-
 from klai_image_storage import (
     ImageStore,
     ImageUploadResult,
@@ -62,6 +61,7 @@ async def test_srcset_debris_is_filtered() -> None:
             "https://help.voys.nl/real.png": (200, _png_bytes()),
         }
     )
+
     # Stub the S3 side effects so we can run without a real bucket.
     # SPEC-KB-IMAGES-V2-001: upload_image's object_key MUST match what
     # KbImage.s3_key would compute for the same bytes. Use a side_effect
@@ -105,6 +105,7 @@ async def test_dedups_identical_urls_across_srcset() -> None:
             "https://help.voys.nl/img.png": (200, _png_bytes()),
         }
     )
+
     async def _fake_upload(o: str, k: str, d: bytes, e: str) -> ImageUploadResult:
         return ImageUploadResult(
             object_key=f"{o}/images/{k}/{hashlib.sha256(d).hexdigest()}.{e}",
@@ -144,9 +145,7 @@ async def test_partial_http_failure_does_not_abort_page() -> None:
         }
     )
 
-    async def fake_upload(
-        org_id: str, kb_slug: str, data: bytes, ext: str
-    ) -> ImageUploadResult:
+    async def fake_upload(org_id: str, kb_slug: str, data: bytes, ext: str) -> ImageUploadResult:
         key = f"{org_id}/images/{kb_slug}/{hashlib.sha256(data).hexdigest()}.{ext}"
         return ImageUploadResult(object_key=key, deduplicated=False)
 
@@ -178,6 +177,7 @@ async def test_relative_urls_resolved_against_base() -> None:
             "https://help.voys.nl/assets/img.png": (200, _png_bytes()),
         }
     )
+
     async def _fake_upload(o: str, k: str, d: bytes, e: str) -> ImageUploadResult:
         return ImageUploadResult(
             object_key=f"{o}/images/{k}/{hashlib.sha256(d).hexdigest()}.{e}",

--- a/klai-knowledge-ingest/tests/test_crawler_images.py
+++ b/klai-knowledge-ingest/tests/test_crawler_images.py
@@ -63,14 +63,17 @@ async def test_srcset_debris_is_filtered() -> None:
         }
     )
     # Stub the S3 side effects so we can run without a real bucket.
-    store._object_exists = AsyncMock(return_value=False)  # type: ignore[attr-defined]
-    store.upload_image = AsyncMock(  # type: ignore[attr-defined]
-        return_value=ImageUploadResult(
-            object_key="org/images/support/abc.png",
-            public_url="/kb-images/org/images/support/abc.png",
+    # SPEC-KB-IMAGES-V2-001: upload_image's object_key MUST match what
+    # KbImage.s3_key would compute for the same bytes. Use a side_effect
+    # that hashes the bytes the same way ImageStore.build_object_key does.
+    async def _fake_upload(o: str, k: str, d: bytes, e: str) -> ImageUploadResult:
+        return ImageUploadResult(
+            object_key=f"{o}/images/{k}/{hashlib.sha256(d).hexdigest()}.{e}",
             deduplicated=False,
         )
-    )
+
+    store._object_exists = AsyncMock(return_value=False)  # type: ignore[attr-defined]
+    store.upload_image = AsyncMock(side_effect=_fake_upload)  # type: ignore[attr-defined]
 
     result = await download_and_upload_crawl_images(
         media_images=[
@@ -86,7 +89,8 @@ async def test_srcset_debris_is_filtered() -> None:
         http_client=client,
     )
 
-    assert result == ["/kb-images/org/images/support/abc.png"]
+    expected_hash = hashlib.sha256(_png_bytes()).hexdigest()
+    assert result == [f"/kb-images/org/images/support/{expected_hash}.png"]
     # Confirm the filtered fragments never triggered a GET.
     called_urls = [c.args[0] for c in client.get.call_args_list]  # type: ignore[union-attr]
     assert called_urls == ["https://help.voys.nl/real.png"]
@@ -101,14 +105,14 @@ async def test_dedups_identical_urls_across_srcset() -> None:
             "https://help.voys.nl/img.png": (200, _png_bytes()),
         }
     )
-    store._object_exists = AsyncMock(return_value=False)  # type: ignore[attr-defined]
-    store.upload_image = AsyncMock(  # type: ignore[attr-defined]
-        return_value=ImageUploadResult(
-            object_key="org/images/support/img.png",
-            public_url="/kb-images/org/images/support/img.png",
+    async def _fake_upload(o: str, k: str, d: bytes, e: str) -> ImageUploadResult:
+        return ImageUploadResult(
+            object_key=f"{o}/images/{k}/{hashlib.sha256(d).hexdigest()}.{e}",
             deduplicated=False,
         )
-    )
+
+    store._object_exists = AsyncMock(return_value=False)  # type: ignore[attr-defined]
+    store.upload_image = AsyncMock(side_effect=_fake_upload)  # type: ignore[attr-defined]
 
     result = await download_and_upload_crawl_images(
         media_images=[
@@ -123,7 +127,8 @@ async def test_dedups_identical_urls_across_srcset() -> None:
         http_client=client,
     )
 
-    assert result == ["/kb-images/org/images/support/img.png"]
+    expected_hash = hashlib.sha256(_png_bytes()).hexdigest()
+    assert result == [f"/kb-images/org/images/support/{expected_hash}.png"]
     assert client.get.call_count == 1  # type: ignore[union-attr]
 
 
@@ -143,7 +148,7 @@ async def test_partial_http_failure_does_not_abort_page() -> None:
         org_id: str, kb_slug: str, data: bytes, ext: str
     ) -> ImageUploadResult:
         key = f"{org_id}/images/{kb_slug}/{hashlib.sha256(data).hexdigest()}.{ext}"
-        return ImageUploadResult(key, f"/kb-images/{key}", deduplicated=False)
+        return ImageUploadResult(object_key=key, deduplicated=False)
 
     store._object_exists = AsyncMock(return_value=False)  # type: ignore[attr-defined]
     store.upload_image = AsyncMock(side_effect=fake_upload)  # type: ignore[attr-defined]
@@ -173,14 +178,14 @@ async def test_relative_urls_resolved_against_base() -> None:
             "https://help.voys.nl/assets/img.png": (200, _png_bytes()),
         }
     )
-    store._object_exists = AsyncMock(return_value=False)  # type: ignore[attr-defined]
-    store.upload_image = AsyncMock(  # type: ignore[attr-defined]
-        return_value=ImageUploadResult(
-            object_key="org/images/support/x.png",
-            public_url="/kb-images/org/images/support/x.png",
+    async def _fake_upload(o: str, k: str, d: bytes, e: str) -> ImageUploadResult:
+        return ImageUploadResult(
+            object_key=f"{o}/images/{k}/{hashlib.sha256(d).hexdigest()}.{e}",
             deduplicated=False,
         )
-    )
+
+    store._object_exists = AsyncMock(return_value=False)  # type: ignore[attr-defined]
+    store.upload_image = AsyncMock(side_effect=_fake_upload)  # type: ignore[attr-defined]
 
     result = await download_and_upload_crawl_images(
         media_images=[{"src": "/assets/img.png"}],
@@ -191,7 +196,8 @@ async def test_relative_urls_resolved_against_base() -> None:
         http_client=client,
     )
 
-    assert result == ["/kb-images/org/images/support/x.png"]
+    expected_hash = hashlib.sha256(_png_bytes()).hexdigest()
+    assert result == [f"/kb-images/org/images/support/{expected_hash}.png"]
     called_urls = [c.args[0] for c in client.get.call_args_list]  # type: ignore[union-attr]
     assert called_urls == ["https://help.voys.nl/assets/img.png"]
 

--- a/klai-knowledge-ingest/uv.lock
+++ b/klai-knowledge-ingest/uv.lock
@@ -1196,7 +1196,7 @@ dev = [
 
 [[package]]
 name = "klai-identity-assert"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "../klai-libs/identity-assert" }
 dependencies = [
     { name = "httpx" },

--- a/klai-libs/image-storage/klai_image_storage/__init__.py
+++ b/klai-libs/image-storage/klai_image_storage/__init__.py
@@ -7,6 +7,9 @@ package. Both services import from here; neither keeps a local copy.
 
 Public API (all re-exported at package root):
 
+- :class:`KbImage` — single source of truth for KB-image URL + S3-key +
+  FastAPI route shape (SPEC-KB-IMAGES-V2-001 REQ-1). Every klai service
+  that needs to build a kb-image URL imports this class.
 - :class:`ImageStore` — async S3 client with content-addressed keys and
   dedup
 - :class:`ImageUploadResult` — result dataclass returned by
@@ -25,6 +28,7 @@ wire-level contracts — every uploaded image's URL depends on them —
 and consumers should never override them.
 """
 
+from klai_image_storage.kb_image import KbImage
 from klai_image_storage.pipeline import (
     download_and_upload_adapter_images,
     download_and_upload_crawl_images,
@@ -53,6 +57,7 @@ from klai_image_storage.utils import (
 __all__ = [
     "ImageStore",
     "ImageUploadResult",
+    "KbImage",
     "ParsedImage",
     "PinnedResolverTransport",
     "SsrfBlockedError",

--- a/klai-libs/image-storage/klai_image_storage/kb_image.py
+++ b/klai-libs/image-storage/klai_image_storage/kb_image.py
@@ -1,0 +1,176 @@
+"""Single source of truth for KB-image URL + S3-key + FastAPI route shape.
+
+SPEC-KB-IMAGES-V2-001 (replaces SPEC-TI-009).
+
+Why this module exists
+----------------------
+Until 2026-05-12 three independent files each hardcoded part of the
+kb-image URL shape:
+
+- ``klai_image_storage.storage.PUBLIC_IMAGE_PATH_PREFIX`` + ``ImageStore.build_public_url``
+- ``app/api/kb_images.py`` @router.get path-literal
+- ``klai-portal/frontend/.../BlockPageEditor.tsx`` ``fetch(...)`` URL
+
+Any drift between the three produced a *silent* 404 on browser fetches —
+because the legacy SPEC-TI-009 route was never browser-fetched in
+production, the drift went undetected for 3 weeks and required five
+sequential bandaid PRs to remediate. This module collapses all three
+hardcodings into a single value-class and a small set of constants that
+are imported everywhere else.
+
+How drift is prevented
+----------------------
+1. ``KbImage.ROUTE_TEMPLATE`` is the only string the FastAPI decorator
+   references. A drift here is a Python-level error: pyright sees the
+   constant rename, the route declaration breaks, the boot-time
+   assertion in ``app.main`` (REQ-3) catches mismatch between the route
+   declared and what ``KbImage(...).public_path`` produces.
+2. ``rules/no-hardcoded-kb-image-path.yml`` (REQ-5) is a CI ast-grep
+   guard that fails any PR adding a ``/kb-images/`` string-literal
+   outside this module.
+3. ``klai-portal/frontend/src/lib/kb-image-url.ts`` mirrors the same
+   constants and has a vitest unit test that compares its outputs to
+   fixture strings derived from this module — a Python<->TS drift is
+   caught at unit-test time.
+4. A Playwright E2E test in CI (REQ-6) drives the full Caddy -> portal-api
+   -> Garage round-trip on every PR that touches this module or its
+   callers.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from typing import ClassVar
+
+# Wire-level invariants — changing any of these invalidates every previously
+# generated kb-image URL. SPEC-KB-IMAGE-002 + SPEC-KB-IMAGES-V2-001.
+_MIME_EXT: dict[str, str] = {
+    "image/jpeg": "jpg",
+    "image/png": "png",
+    "image/gif": "gif",
+    "image/webp": "webp",
+}
+
+_VALID_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_VALID_KB_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
+# Zitadel org IDs are snowflake-style 18-digit numbers, but the wire-format
+# accepts any 1..20 digit string so that older test fixtures (small ints)
+# also parse.
+_VALID_ZITADEL_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$|^[0-9]{1,20}$")
+_VALID_EXT_RE = re.compile(r"^(jpg|png|gif|webp)$")
+
+
+@dataclass(frozen=True, slots=True)
+class KbImage:
+    """A KB-image identified by its (org, kb, content-hash, extension) tuple.
+
+    Construct via :py:meth:`from_bytes` (writes) or :py:meth:`from_path`
+    (reads). Direct construction is allowed for tests but validates all
+    fields against the regexes above.
+    """
+
+    zitadel_org_id: str
+    kb_slug: str
+    sha256: str
+    ext: str
+
+    # FastAPI route templates — the *only* strings the route decorators
+    # may reference. Importers MUST use these constants verbatim:
+    #
+    #   @router.get(KbImage.ROUTE_TEMPLATE)
+    #   @router.post(KbImage.UPLOAD_ROUTE_TEMPLATE)
+    #
+    # A drift here is caught by the boot-time assertion in app.main
+    # (SPEC-KB-IMAGES-V2-001 REQ-3) AND by the ast-grep guard
+    # ``no-hardcoded-kb-image-path.yml`` (REQ-5).
+    ROUTE_TEMPLATE: ClassVar[str] = "/kb-images/{zitadel_org_id}/images/{kb_slug}/{filename}"
+    UPLOAD_ROUTE_TEMPLATE: ClassVar[str] = "/kb-images/{kb_slug}"
+
+    # Regex that parses a path produced by :py:meth:`public_path` back into
+    # its components. Used by :py:meth:`from_path` AND by the boot-time
+    # assertion to verify that ``KbImage(...).public_path`` round-trips.
+    _PATH_RE: ClassVar[re.Pattern[str]] = re.compile(
+        # Zitadel org segment matches either dev-style alpha-num-dash
+        # ("org-1") OR a numeric snowflake. Same alphabet as kb_slug for
+        # symmetry; the production tenant boundary is enforced at the auth
+        # layer, not by URL parsing.
+        r"^/kb-images/(?P<zitadel_org_id>[a-z0-9][a-z0-9-]{0,63}|[0-9]{1,20})"
+        r"/images/(?P<kb_slug>[a-z0-9][a-z0-9-]{0,63})"
+        r"/(?P<sha256>[0-9a-f]{64})\.(?P<ext>jpg|png|gif|webp)$"
+    )
+
+    def __post_init__(self) -> None:
+        if not _VALID_ZITADEL_RE.match(self.zitadel_org_id):
+            raise ValueError(f"invalid zitadel_org_id: {self.zitadel_org_id!r}")
+        if not _VALID_KB_SLUG_RE.match(self.kb_slug):
+            raise ValueError(f"invalid kb_slug: {self.kb_slug!r}")
+        if not _VALID_SHA256_RE.match(self.sha256):
+            raise ValueError(f"invalid sha256: {self.sha256!r}")
+        if not _VALID_EXT_RE.match(self.ext):
+            raise ValueError(f"invalid ext: {self.ext!r}")
+
+    # ------------------------------------------------------------------
+    # Constructors
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_bytes(
+        cls,
+        *,
+        zitadel_org_id: str,
+        kb_slug: str,
+        data: bytes,
+        mime: str,
+    ) -> KbImage:
+        """Build a KbImage from the image bytes + tenant scope.
+
+        Raises ``ValueError`` for unsupported MIME or invalid kb_slug /
+        zitadel_org_id. SVG is intentionally NOT in ``_MIME_EXT`` — see
+        SPEC-PORTAL-DOCS-IMAGE-PASTE-001 REQ-5 for the XSS rationale.
+        """
+        ext = _MIME_EXT.get(mime)
+        if ext is None:
+            raise ValueError(f"unsupported MIME for kb-image: {mime!r}")
+        return cls(
+            zitadel_org_id=zitadel_org_id,
+            kb_slug=kb_slug,
+            sha256=hashlib.sha256(data).hexdigest(),
+            ext=ext,
+        )
+
+    @classmethod
+    def from_path(cls, path: str) -> KbImage | None:
+        """Parse a path produced by :py:meth:`public_path` back into a KbImage.
+
+        Returns ``None`` when ``path`` does not match the canonical shape.
+        Used by the boot-time assertion (REQ-3) for round-trip verification
+        and by tests that probe the URL shape.
+        """
+        m = cls._PATH_RE.match(path)
+        if m is None:
+            return None
+        return cls(**m.groupdict())
+
+    # ------------------------------------------------------------------
+    # Output
+    # ------------------------------------------------------------------
+
+    @property
+    def s3_key(self) -> str:
+        """Garage S3 object-key. Wire-level contract since SPEC-KB-IMAGE-002.
+
+        Changing this invalidates every previously uploaded image.
+        """
+        return f"{self.zitadel_org_id}/images/{self.kb_slug}/{self.sha256}.{self.ext}"
+
+    @property
+    def public_path(self) -> str:
+        """Relative URL path served by the auth-proxied read-route.
+
+        Always matches ``ROUTE_TEMPLATE`` exactly. A drift would mean
+        ``from_path(...).public_path != path`` which the boot-time
+        assertion rejects.
+        """
+        return f"/kb-images/{self.s3_key}"

--- a/klai-libs/image-storage/klai_image_storage/pipeline.py
+++ b/klai-libs/image-storage/klai_image_storage/pipeline.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING, Any
 import httpx
 import structlog
 
+from klai_image_storage.kb_image import KbImage
 from klai_image_storage.storage import (
     MAX_IMAGE_SIZE,
     MAX_IMAGES_PER_DOCUMENT,
@@ -161,17 +162,45 @@ async def _download_validate_upload(
         logger.warning("image_too_large", url=url, size=len(data))
         return None
 
-    if not image_store.validate_image(data):
+    mime = image_store.validate_image(data)
+    if not mime:
         logger.warning("image_invalid_content", url=url)
         return None
 
+    # SPEC-KB-IMAGES-V2-001 REQ-1: URL-shape comes from KbImage, the single
+    # source of truth. ImageStore writes by s3_key; KbImage produces the
+    # matching public_path. The two cannot drift because they're derived
+    # from the same KbImage instance below.
     try:
-        result = await image_store.upload_image(org_id, kb_slug, data, _ext_from_url(url))
+        kb_image = KbImage.from_bytes(
+            zitadel_org_id=org_id,
+            kb_slug=kb_slug,
+            data=data,
+            mime=mime,
+        )
+    except ValueError as exc:
+        logger.warning("image_kb_image_rejected", url=url, error=str(exc))
+        return None
+
+    try:
+        result = await image_store.upload_image(org_id, kb_slug, data, kb_image.ext)
     except Exception:
         logger.exception("image_upload_failed", url=url)
         return None
 
-    return result.public_url
+    # Defensive: ImageStore.build_object_key MUST match KbImage.s3_key. Same
+    # invariant as the portal-api POST route — a drift here is a regression
+    # of the v1 problem.
+    if result.object_key != kb_image.s3_key:
+        logger.error(
+            "image_store_key_drift",
+            url=url,
+            store_key=result.object_key,
+            kb_image_key=kb_image.s3_key,
+        )
+        return None
+
+    return kb_image.public_path
 
 
 async def _upload_parsed_image(
@@ -191,17 +220,38 @@ async def _upload_parsed_image(
         logger.warning("parsed_image_too_large", source_id=image.source_id, size=len(image.data))
         return None
 
-    if not image_store.validate_image(image.data):
+    mime = image_store.validate_image(image.data)
+    if not mime:
         logger.warning("parsed_image_invalid_content", source_id=image.source_id)
         return None
 
     try:
-        result = await image_store.upload_image(org_id, kb_slug, image.data, image.ext)
+        kb_image = KbImage.from_bytes(
+            zitadel_org_id=org_id,
+            kb_slug=kb_slug,
+            data=image.data,
+            mime=mime,
+        )
+    except ValueError as exc:
+        logger.warning("parsed_image_kb_image_rejected", source_id=image.source_id, error=str(exc))
+        return None
+
+    try:
+        result = await image_store.upload_image(org_id, kb_slug, image.data, kb_image.ext)
     except Exception:
         logger.exception("parsed_image_upload_failed", source_id=image.source_id)
         return None
 
-    return result.public_url
+    if result.object_key != kb_image.s3_key:
+        logger.error(
+            "parsed_image_store_key_drift",
+            source_id=image.source_id,
+            store_key=result.object_key,
+            kb_image_key=kb_image.s3_key,
+        )
+        return None
+
+    return kb_image.public_path
 
 
 # @MX:ANCHOR: download_and_upload_adapter_images — connector sync-engine hot path.

--- a/klai-libs/image-storage/klai_image_storage/storage.py
+++ b/klai-libs/image-storage/klai_image_storage/storage.py
@@ -42,17 +42,26 @@ _SVG_SIGNATURES = (b"<?xml", b"<svg")
 MAX_IMAGE_SIZE = 5 * 1024 * 1024  # 5 MB
 MAX_IMAGES_PER_DOCUMENT = 20
 
-# Public URL prefix served by Caddy → Garage website endpoint.
-# The full URL becomes: https://{tenant}.getklai.com/kb-images/{object_key}
-PUBLIC_IMAGE_PATH_PREFIX = "/kb-images"
+# SPEC-KB-IMAGES-V2-001 REQ-4: ``PUBLIC_IMAGE_PATH_PREFIX`` and
+# ``ImageStore.build_public_url`` are deliberately removed. URL-shape is now
+# the exclusive responsibility of ``app/core/kb_image_url.py::KbImage`` in
+# klai-portal. Other services that need a public URL string should construct
+# their own ``KbImage`` (importing the value-class or constructing the path
+# inline against KbImage.ROUTE_TEMPLATE). This eliminates the multi-file
+# drift that caused the 2026-05-12 5-layer regression.
 
 
 @dataclass(frozen=True)
 class ImageUploadResult:
-    """Result of an image upload operation."""
+    """Result of an image upload operation.
+
+    SPEC-KB-IMAGES-V2-001 REQ-4: the ``public_url`` field is intentionally
+    absent. URL-shape is the exclusive responsibility of klai-portal's
+    ``KbImage`` value-class. Callers that need a URL build one themselves
+    from ``object_key`` (or, in klai-portal context, from ``KbImage``).
+    """
 
     object_key: str
-    public_url: str
     deduplicated: bool
 
 
@@ -96,10 +105,9 @@ class ImageStore:
         ext = ext.lower().lstrip(".")
         return f"{org_id}/images/{kb_slug}/{content_hash}.{ext}"
 
-    @staticmethod
-    def build_public_url(object_key: str) -> str:
-        """Build the relative public URL for an image served via Caddy."""
-        return f"{PUBLIC_IMAGE_PATH_PREFIX}/{object_key}"
+    # SPEC-KB-IMAGES-V2-001 REQ-4: ``build_public_url`` removed. URL-shape is
+    # owned by ``app/core/kb_image_url.py::KbImage`` in klai-portal. Use that
+    # value-class (or its TypeScript mirror) wherever a public URL is needed.
 
     @staticmethod
     def validate_image(data: bytes) -> str | None:
@@ -143,11 +151,7 @@ class ImageStore:
 
         if await self._object_exists(object_key):
             logger.info("image_deduplicated", object_key=object_key)
-            return ImageUploadResult(
-                object_key=object_key,
-                public_url=self.build_public_url(object_key),
-                deduplicated=True,
-            )
+            return ImageUploadResult(object_key=object_key, deduplicated=True)
 
         await asyncio.to_thread(
             self._client.put_object,
@@ -158,11 +162,7 @@ class ImageStore:
             content_type=self.validate_image(data) or "application/octet-stream",
         )
         logger.info("image_uploaded", object_key=object_key, size=len(data))
-        return ImageUploadResult(
-            object_key=object_key,
-            public_url=self.build_public_url(object_key),
-            deduplicated=False,
-        )
+        return ImageUploadResult(object_key=object_key, deduplicated=False)
 
     async def _object_exists(self, object_key: str) -> bool:
         """Check if an object exists in the bucket."""

--- a/klai-libs/image-storage/klai_image_storage/storage.py
+++ b/klai-libs/image-storage/klai_image_storage/storage.py
@@ -7,9 +7,10 @@ The store wraps the synchronous minio client with :func:`asyncio.to_thread`
 so the embedding service's event loop (FastAPI endpoints, Procrastinate
 workers, connector sync tasks) stays non-blocking. Images are uploaded
 authenticated over the S3 API (Garage on :3900) and served through
-an auth-proxy at ``GET /kb-images/{org_id}/{kb_slug}/{filename}`` in
-portal-api (SPEC-TI-009 / finding B-4). Direct anonymous reads via
-Garage website mode (:3902) were closed as part of that SPEC.
+the auth-proxied read route on portal-api (see KbImage.ROUTE_TEMPLATE
+in klai_image_storage.kb_image — SPEC-KB-IMAGES-V2-001). Direct
+anonymous reads via Garage website mode (:3902) were closed as part
+of SPEC-TI-009.
 
 Content-addressed keys (SHA-256 of bytes) give free deduplication across
 tenants' own KBs. The key format + URL prefix are wire-level contracts;

--- a/klai-libs/image-storage/tests/test_kb_image.py
+++ b/klai-libs/image-storage/tests/test_kb_image.py
@@ -1,0 +1,185 @@
+"""Unit tests for the KbImage single-source-of-truth value-class.
+
+SPEC-KB-IMAGES-V2-001 AC-1 + AC-3 (drift-aborts-boot).
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from klai_image_storage.kb_image import KbImage
+
+# ---------------------------------------------------------------------------
+# AC-1: round-trip on real production keys
+# ---------------------------------------------------------------------------
+
+# These are actual s3_keys queried from knowledge.artifact_images on
+# 2026-05-12 (Voys org id=8 / zitadel=368884765035593759). The test fixture
+# is a stable subset that proves KbImage.from_path + .public_path round-trip
+# byte-for-byte against what the connector pipeline writes.
+_PRODUCTION_PATHS = [
+    "/kb-images/368884765035593759/images/support/dae543ab51b40c9611d14c96e1f72bbd53a1ecdc782c192fbc2ab6d0e6127dd9.png",
+    "/kb-images/368884765035593759/images/support/d4818c6438a7c33935b06fa8c66387cfdb8418ed8f2ecae7c8f47fdf5712a789.png",
+    "/kb-images/368884765035593759/images/support/49a861d9954135083d4b0bb9417565ca92e5ad477f64d6cf0dcba17d20077aa9.png",
+    # Klai-help org (1 / zitadel 362757920133283846) — Mark's docs-editor uploads
+    "/kb-images/362757920133283846/images/klai-help/71e67cdc4b7451885b314b848583f5a66838b1952d753f5d133b5d98dc375f5b.png",
+    "/kb-images/362757920133283846/images/klai-help/ebe2b85db57d52f3470b35cb47b5f0c3e7114821f49d27d35c0e6cb1195ca605.png",
+]
+
+
+@pytest.mark.parametrize("path", _PRODUCTION_PATHS)
+def test_round_trip_production_paths(path: str) -> None:
+    """AC-1: every real production URL parses + serializes back identically."""
+    parsed = KbImage.from_path(path)
+    assert parsed is not None, f"from_path returned None for {path!r}"
+    assert parsed.public_path == path, "public_path drifted from input"
+    # s3_key is public_path minus the /kb-images/ prefix
+    assert parsed.s3_key == path.removeprefix("/kb-images/")
+
+
+def test_s3_key_shape_unchanged_from_speck_b_image_002() -> None:
+    """The S3 key prefix is a wire-level contract. Changing it breaks every
+    previously uploaded image's URL. Lock the shape down in a test."""
+    img = KbImage(
+        zitadel_org_id="368884765035593759",
+        kb_slug="support",
+        sha256="a" * 64,
+        ext="png",
+    )
+    assert img.s3_key == f"368884765035593759/images/support/{'a' * 64}.png"
+    assert img.public_path == f"/kb-images/368884765035593759/images/support/{'a' * 64}.png"
+
+
+# ---------------------------------------------------------------------------
+# Constructors
+# ---------------------------------------------------------------------------
+
+
+def test_from_bytes_hashes_with_sha256() -> None:
+    """SHA-256 dedup is the storage layer's only invariant; lock it."""
+    data = b"hello world"
+    img = KbImage.from_bytes(
+        zitadel_org_id="368884765035593759",
+        kb_slug="support",
+        data=data,
+        mime="image/png",
+    )
+    assert img.sha256 == hashlib.sha256(data).hexdigest()
+    assert img.ext == "png"
+
+
+def test_from_bytes_rejects_svg() -> None:
+    """SPEC-PORTAL-DOCS-IMAGE-PASTE-001 REQ-5: SVG XSS guard for user uploads."""
+    with pytest.raises(ValueError, match="unsupported MIME"):
+        KbImage.from_bytes(
+            zitadel_org_id="368884765035593759",
+            kb_slug="support",
+            data=b"<svg/>",
+            mime="image/svg+xml",
+        )
+
+
+def test_from_bytes_rejects_arbitrary_mime() -> None:
+    with pytest.raises(ValueError, match="unsupported MIME"):
+        KbImage.from_bytes(
+            zitadel_org_id="368884765035593759",
+            kb_slug="support",
+            data=b"\x00" * 32,
+            mime="application/pdf",
+        )
+
+
+@pytest.mark.parametrize(
+    "mime, expected_ext",
+    [
+        ("image/jpeg", "jpg"),
+        ("image/png", "png"),
+        ("image/gif", "gif"),
+        ("image/webp", "webp"),
+    ],
+)
+def test_from_bytes_mime_to_ext_table(mime: str, expected_ext: str) -> None:
+    img = KbImage.from_bytes(
+        zitadel_org_id="368884765035593759",
+        kb_slug="support",
+        data=b"\x00" * 32,
+        mime=mime,
+    )
+    assert img.ext == expected_ext
+
+
+def test_from_path_rejects_garbage() -> None:
+    """Defense: from_path returns None for anything that doesn't match the
+    canonical 5-segment shape. Used by the boot-time assertion to catch
+    route-template drift."""
+    bad_paths = [
+        "/kb-images/foo/bar/baz.png",  # 3 segments
+        "/kb-images/368884765035593759/support/abc.png",  # 4 segments (old shape)
+        "/kb-images/368884765035593759/images/support/abc.png",  # short sha
+        "/kb-images/368884765035593759/imgs/support/" + "a" * 64 + ".png",  # wrong literal
+        "/wrong-prefix/368884765035593759/images/support/" + "a" * 64 + ".png",
+        "/kb-images/368884765035593759/images/Bad-SLUG/" + "a" * 64 + ".png",  # caps in slug
+        "/kb-images/368884765035593759/images/support/" + "a" * 64 + ".svg",  # disallowed ext
+    ]
+    for p in bad_paths:
+        assert KbImage.from_path(p) is None, f"from_path should have rejected {p!r}"
+
+
+# ---------------------------------------------------------------------------
+# Field validation
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_zitadel_org_id() -> None:
+    with pytest.raises(ValueError, match="zitadel_org_id"):
+        KbImage(zitadel_org_id="ORG-WITH-CAPS", kb_slug="support", sha256="a" * 64, ext="png")
+
+
+def test_invalid_kb_slug() -> None:
+    with pytest.raises(ValueError, match="kb_slug"):
+        KbImage(zitadel_org_id="42", kb_slug="-bad-start", sha256="a" * 64, ext="png")
+
+
+def test_invalid_sha256() -> None:
+    with pytest.raises(ValueError, match="sha256"):
+        KbImage(zitadel_org_id="42", kb_slug="support", sha256="zz", ext="png")
+
+
+def test_invalid_ext() -> None:
+    with pytest.raises(ValueError, match="ext"):
+        KbImage(zitadel_org_id="42", kb_slug="support", sha256="a" * 64, ext="svg")
+
+
+# ---------------------------------------------------------------------------
+# Route templates exposed for use by FastAPI decorators
+# ---------------------------------------------------------------------------
+
+
+def test_route_templates_are_strings_not_optionals() -> None:
+    assert isinstance(KbImage.ROUTE_TEMPLATE, str)
+    assert isinstance(KbImage.UPLOAD_ROUTE_TEMPLATE, str)
+    assert KbImage.ROUTE_TEMPLATE.startswith("/kb-images/")
+    assert KbImage.UPLOAD_ROUTE_TEMPLATE.startswith("/kb-images/")
+
+
+def test_route_template_round_trips_via_concrete_instance() -> None:
+    """The route template's placeholders must match exactly what
+    public_path() generates for a concrete KbImage. This is the assertion
+    that the boot-time check in main.py reproduces — a drift here means
+    portal-api refuses to boot."""
+    concrete = KbImage(
+        zitadel_org_id="368884765035593759",
+        kb_slug="support",
+        sha256="a" * 64,
+        ext="png",
+    )
+    # The template, when formatted with the concrete instance's fields,
+    # must produce public_path() verbatim.
+    rendered = KbImage.ROUTE_TEMPLATE.format(
+        zitadel_org_id=concrete.zitadel_org_id,
+        kb_slug=concrete.kb_slug,
+        filename=f"{concrete.sha256}.{concrete.ext}",
+    )
+    assert rendered == concrete.public_path

--- a/klai-libs/image-storage/tests/test_storage.py
+++ b/klai-libs/image-storage/tests/test_storage.py
@@ -54,17 +54,9 @@ class TestBuildObjectKey:
         assert k1 != k2
 
 
-class TestBuildPublicUrl:
-    def test_prefixes_with_kb_images_path(self) -> None:
-        # `/kb-images/` is an intentional wire-level invariant —
-        # asserted as a literal so no refactor can silently change it.
-        url = ImageStore.build_public_url("org/images/kb/hash.png")
-        assert url == "/kb-images/org/images/kb/hash.png"
-
-    def test_public_url_format(self) -> None:
-        """Public URL uses /kb-images/ prefix."""
-        url = ImageStore.build_public_url("org-1/images/kb/abc123.png")
-        assert url == "/kb-images/org-1/images/kb/abc123.png"
+# SPEC-KB-IMAGES-V2-001 REQ-4: TestBuildPublicUrl removed alongside
+# ImageStore.build_public_url. URL-shape is now KbImage's responsibility
+# — see test_kb_image.py for the round-trip + drift coverage.
 
 
 class TestValidateImage:
@@ -116,7 +108,6 @@ class TestUploadImage:
         assert isinstance(result, ImageUploadResult)
         assert result.deduplicated is False
         assert result.object_key.startswith("org-1/images/kb-1/")
-        assert result.public_url.startswith("/kb-images/org-1/images/kb-1/")
         mock_client.put_object.assert_called_once()
 
     async def test_deduplicates_when_object_exists(self, fresh_store: ImageStore) -> None:
@@ -128,7 +119,7 @@ class TestUploadImage:
 
         result = await fresh_store.upload_image("org-1", "kb-1", b"data", ".jpg")
 
-        assert result.public_url.startswith("/kb-images/")
+        assert result.object_key.startswith("org-1/images/kb-1/")
         assert result.deduplicated is True
         mock_client.put_object.assert_not_called()
 
@@ -150,17 +141,20 @@ class TestUploadImage:
 
 
 class TestImageUploadResult:
-    """Result dataclass is frozen and captures all three fields."""
+    """Result dataclass is frozen and captures object_key + deduplicated.
+
+    SPEC-KB-IMAGES-V2-001 REQ-4: public_url is no longer a field — URL
+    construction is KbImage's job. ImageStore is purely an S3 boundary.
+    """
 
     def test_is_frozen(self) -> None:
         from dataclasses import FrozenInstanceError
 
-        r = ImageUploadResult(object_key="k", public_url="/kb-images/k", deduplicated=False)
+        r = ImageUploadResult(object_key="k", deduplicated=False)
         with pytest.raises(FrozenInstanceError):
             r.object_key = "other"  # type: ignore[misc]
 
     def test_fields(self) -> None:
-        r = ImageUploadResult(object_key="k", public_url="/kb-images/k", deduplicated=True)
+        r = ImageUploadResult(object_key="k", deduplicated=True)
         assert r.object_key == "k"
-        assert r.public_url == "/kb-images/k"
         assert r.deduplicated is True

--- a/klai-portal/backend/app/api/kb_images.py
+++ b/klai-portal/backend/app/api/kb_images.py
@@ -291,8 +291,8 @@ async def upload_kb_image(
       ``{org_id}/images/{kb_slug}/{sha256}.{ext}``; identical bytes dedupe via
       content addressing.
 
-    Response: ``{"url": "/kb-images/...", "deduplicated": bool}`` where ``url``
-    is the relative path served by the GET endpoint above.
+    Response: ``{"url": kb_image_path, "deduplicated": bool}`` where the URL
+    is the relative path served by the GET endpoint above (KbImage.public_path).
     """
     # Step 1: KB-scope authorization. A 404 here is the strong-or-weak signal:
     # either the kb_slug truly doesn't exist in the caller's org (typo) OR it

--- a/klai-portal/backend/app/api/kb_images.py
+++ b/klai-portal/backend/app/api/kb_images.py
@@ -41,6 +41,7 @@ from app.api.partner_dependencies import PartnerAuthContext, get_partner_key
 from app.api.session_deps import get_optional_session
 from app.core.config import settings
 from app.core.database import get_db
+from app.core.kb_image_url import KbImage
 from app.core.permissions import UserPermissions, get_caller_at_least
 from app.core.profiles import ProfileRole
 from app.core.session import SessionContext
@@ -52,15 +53,6 @@ router = APIRouter(tags=["KB Images"])
 
 _CACHE_CONTROL = "private, max-age=86400"
 _STREAM_CHUNK_SIZE = 65536
-
-# MIME -> file extension mapping for the content-addressed key
-# (the ImageStore lib normalises the ext internally, but we want stable suffixes).
-_MIME_EXT: dict[str, str] = {
-    "image/jpeg": "jpg",
-    "image/png": "png",
-    "image/gif": "gif",
-    "image/webp": "webp",
-}
 
 
 def _make_minio_client() -> Minio:
@@ -187,37 +179,33 @@ async def _resolve_zitadel_org_id(org_id: int, db: AsyncSession) -> str:
     return zitadel
 
 
-# @MX:ANCHOR: KB-image auth-proxy endpoint -- AC-1 through AC-5 of SPEC-TI-009
-# @MX:REASON: Single enforcement point for cross-tenant image access control.
-#   Every image fetch from the browser goes through this handler.
-#   Changing the org_id check or the S3 key format breaks tenant isolation.
+# @MX:ANCHOR: KB-image auth-proxy endpoint — single enforcement point for
+#   cross-tenant image access control. Every image fetch from the browser
+#   goes through this handler. Changing the org_id check or the S3 key
+#   format breaks tenant isolation.
 #
-#   The path has a literal 'images' segment between org_id and kb_slug.
-#   This matches the S3 key + public URL shape that ImageStore generates:
-#       object_key:  {org_id}/images/{kb_slug}/{sha256}.{ext}
-#       public_url:  /kb-images/{org_id}/images/{kb_slug}/{sha256}.{ext}
-#   Removing 'images' here would make the route declaration diverge from
-#   what ImageStore.build_public_url() returns — a 5-segment URL no longer
-#   matches a 4-segment route → 404 on every browser fetch (the latent bug
-#   that survived from SPEC-TI-009 until the 2026-05-12 e2e smoketest).
-#
-#   The path org_id is a zitadel_org_id (string) to match the convention
-#   used by klai-connector + klai-knowledge-ingest.
-# @MX:SPEC: SPEC-TI-009, finding B-4
-@router.get("/kb-images/{org_id}/images/{kb_slug}/{filename}")
+#   The route path is sourced from KbImage.ROUTE_TEMPLATE (the single source
+#   of truth for kb-image URL shapes per SPEC-KB-IMAGES-V2-001). Direct
+#   string-literals here are forbidden and caught by
+#   ``rules/no-hardcoded-kb-image-path.yml``. A drift between this route
+#   declaration and what ``KbImage(...).public_path`` returns is caught at
+#   portal-api boot by ``_assert_kb_image_routes_match_value_class`` in
+#   ``app.main`` — the service refuses to start.
+# @MX:SPEC: SPEC-KB-IMAGES-V2-001 REQ-2 (was SPEC-TI-009)
+@router.get(KbImage.ROUTE_TEMPLATE)
 async def get_kb_image(
-    org_id: str,
+    zitadel_org_id: str,
     kb_slug: str,
     filename: str,
     request: Request,
     session: SessionContext | None = Depends(get_optional_session),
     db: AsyncSession = Depends(get_db),
 ) -> StreamingResponse:
-    """Auth-proxied KB-image read (SPEC-TI-009 AC-1).
+    """Auth-proxied KB-image read.
 
     Authorization: caller's zitadel_org_id (looked up from session.org_id or
-    partner key) MUST equal the path's org_id. Streams from Garage S3 API
-    (private, authenticated). Cache-Control: private, max-age=86400.
+    partner key) MUST equal the path's zitadel_org_id. Streams from Garage
+    S3 API (private, authenticated). Cache-Control: private, max-age=86400.
 
     The path uses zitadel_org_id (an 18-digit string) because that's the
     canonical tenant id in the knowledge domain — the connector + crawler
@@ -231,19 +219,19 @@ async def get_kb_image(
     caller_zitadel_org_id = await _resolve_zitadel_org_id(caller_org_id, db)
 
     # Step 3: Authorize — caller's zitadel org MUST match path org_id (AC-5)
-    if caller_zitadel_org_id != org_id:
+    if caller_zitadel_org_id != zitadel_org_id:
         logger.warning(
             "kb_image_cross_tenant_blocked",
             caller_org_id=caller_org_id,
             caller_zitadel_org_id=caller_zitadel_org_id,
-            path_org_id=org_id,
+            path_org_id=zitadel_org_id,
             kb_slug=kb_slug,
             filename=filename,
         )
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
 
-    # Step 4: Build Garage S3 object key (format from SPEC-KB-IMAGE-002)
-    object_key = f"{org_id}/images/{kb_slug}/{filename}"
+    # Step 4: Build Garage S3 object key (format from SPEC-KB-IMAGE-002 via KbImage)
+    object_key = f"{zitadel_org_id}/images/{kb_slug}/{filename}"
 
     # Step 5: Guard against unconfigured Garage endpoint (dev / test env)
     if not settings.garage_s3_endpoint:
@@ -256,7 +244,7 @@ async def get_kb_image(
 
     content_type = await asyncio.to_thread(_stat_object, client, settings.garage_kb_bucket, object_key)
 
-    structlog.contextvars.bind_contextvars(org_id=org_id, kb_slug=kb_slug)
+    structlog.contextvars.bind_contextvars(org_id=zitadel_org_id, kb_slug=kb_slug)
 
     # Step 6: Return StreamingResponse with cache headers (AC-1)
     return StreamingResponse(
@@ -273,9 +261,10 @@ async def get_kb_image(
 # @MX:REASON: Changing the auth dependency, the kb_slug → org_id binding via
 #   _get_kb_or_404, the SVG-reject branch, or the magic-byte MIME check breaks
 #   tenant isolation or opens an XSS path via inline SVG. The 5 MB hard cap also
-#   serves as memory-DoS guard for parallel uploads.
-# @MX:SPEC: SPEC-PORTAL-DOCS-IMAGE-PASTE-001
-@router.post("/kb-images/{kb_slug}")
+#   serves as memory-DoS guard for parallel uploads. The route path is sourced
+#   from KbImage.UPLOAD_ROUTE_TEMPLATE (SPEC-KB-IMAGES-V2-001 REQ-2).
+# @MX:SPEC: SPEC-PORTAL-DOCS-IMAGE-PASTE-001 + SPEC-KB-IMAGES-V2-001 REQ-2
+@router.post(KbImage.UPLOAD_ROUTE_TEMPLATE)
 async def upload_kb_image(
     request: Request,
     kb_slug: str,
@@ -375,29 +364,56 @@ async def upload_kb_image(
             detail="SVG uploads not supported",
         )
 
-    ext = _MIME_EXT.get(mime)
-    if ext is None:
-        # validate_image returned a MIME we have no extension for — defensive.
-        raise HTTPException(
-            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
-            detail="Unsupported image type",
-        )
-
     # Step 5: Resolve caller's zitadel_org_id — the S3 key prefix convention
     # used by klai-connector + klai-knowledge-ingest, matched by the read-route
-    # above. Using portal_orgs.id here would create a dual prefix conventie
+    # above. Using portal_orgs.id here would create a dual prefix convention
     # (zitadel for connector-images, portal-int for user uploads) and break
     # the read-route's auth check uniformity.
     zitadel_org_id = await _resolve_zitadel_org_id(perms.org_id, db)
 
-    # Step 6: Upload via the shared lib (content-addressed dedup).
+    # Step 6: Build the KbImage value object — single source of truth for both
+    # the S3 key and the public URL. ImageStore writes by s3_key; the response
+    # returns public_path. The two cannot drift because they're derived from
+    # the same object (SPEC-KB-IMAGES-V2-001 REQ-1).
+    try:
+        kb_image = KbImage.from_bytes(
+            zitadel_org_id=zitadel_org_id,
+            kb_slug=kb_slug,
+            data=data,
+            mime=mime,
+        )
+    except ValueError as exc:
+        # Defensive: validate_image already filtered MIMEs we accept, and the
+        # kb_slug came through _get_kb_or_404 which only returns valid slugs.
+        # If we land here it's a programming error, not a client error.
+        logger.exception("kb_image_value_class_rejected_inputs", err=str(exc))
+        raise HTTPException(
+            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            detail="Unsupported image type",
+        ) from exc
+
+    # Step 7: Upload via the shared lib (content-addressed dedup).
     store = ImageStore(
         endpoint=settings.garage_s3_endpoint,
         access_key=settings.garage_s3_access_key,
         secret_key=settings.garage_s3_secret_key,
         bucket=settings.garage_kb_bucket,
     )
-    result = await store.upload_image(zitadel_org_id, kb_slug, data, ext)
+    result = await store.upload_image(zitadel_org_id, kb_slug, data, kb_image.ext)
+
+    # Sanity guard: ImageStore must have produced the same s3_key as KbImage.
+    # If this fires, ImageStore.build_object_key drifted from KbImage.s3_key
+    # — a regression of the v1 problem under the v2 design. Fail loud.
+    if result.object_key != kb_image.s3_key:
+        logger.error(
+            "kb_image_store_key_drift",
+            store_key=result.object_key,
+            kb_image_key=kb_image.s3_key,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="image store key mismatch",
+        )
 
     logger.info(
         "kb_image_uploaded",
@@ -412,6 +428,9 @@ async def upload_kb_image(
     )
 
     return {
-        "url": f"/{result.public_url.lstrip('/')}",
+        # The URL is sourced from KbImage.public_path — the single source of
+        # truth. ImageStore.build_public_url no longer exists (REQ-4) precisely
+        # to make this drift-impossible.
+        "url": kb_image.public_path,
         "deduplicated": result.deduplicated,
     }

--- a/klai-portal/backend/app/core/kb_image_url.py
+++ b/klai-portal/backend/app/core/kb_image_url.py
@@ -1,0 +1,17 @@
+"""Re-export shim — the actual single-source-of-truth is
+``klai_image_storage.kb_image.KbImage``.
+
+SPEC-KB-IMAGES-V2-001 REQ-1: ``KbImage`` lives in ``klai-libs/image-storage``
+so that klai-portal AND the connector + knowledge-ingest pipelines all
+import from the exact same value-class. ``app/core/kb_image_url.py`` is
+the portal-side import path because that's where klai-portal handlers
+look for core types; it forwards to the lib without adding logic.
+
+Any change to URL shape, S3-key format, MIME table, or route templates
+goes in ``klai_image_storage/kb_image.py`` and is automatically picked
+up here.
+"""
+
+from klai_image_storage.kb_image import KbImage
+
+__all__ = ["KbImage"]

--- a/klai-portal/backend/app/main.py
+++ b/klai-portal/backend/app/main.py
@@ -76,9 +76,61 @@ async def _run_stuck_detector() -> None:
         logger.warning("Provisioning stuck-detector failed at startup", exc_info=True)
 
 
+def _assert_kb_image_routes_match_value_class(app: FastAPI) -> None:
+    """SPEC-KB-IMAGES-V2-001 REQ-3: fail boot if the FastAPI route paths
+    declared in ``app/api/kb_images.py`` drift from ``KbImage.ROUTE_TEMPLATE``
+    / ``KbImage.UPLOAD_ROUTE_TEMPLATE``.
+
+    Rationale: pre-V2 the route declaration and the URL-shape generator in
+    ``klai_image_storage`` lived in different files. A literal-string drift
+    between the two produced silent 404s on browser fetches that went
+    undetected for 3 weeks (PRs #598/#600/#602/#607). The boot-time check
+    here closes that loop — if the value-class's templates and the actual
+    registered routes don't match, the service refuses to start.
+    """
+    from app.core.kb_image_url import KbImage
+
+    declared_paths = {
+        getattr(route, "path", None)
+        for route in app.routes
+        if getattr(route, "path", "") and "kb-images" in getattr(route, "path", "")
+    }
+    expected = {KbImage.ROUTE_TEMPLATE, KbImage.UPLOAD_ROUTE_TEMPLATE}
+    if declared_paths != expected:
+        raise RuntimeError(
+            "SPEC-KB-IMAGES-V2-001 REQ-3 boot-time check failed: "
+            f"kb-image routes declared={declared_paths!r} but "
+            f"KbImage templates expect={expected!r}. "
+            "A drift here means a future PR re-introduced the v1 silent-404 "
+            "regression. Refuse to boot until kb_images.py is restored to "
+            "use KbImage.ROUTE_TEMPLATE + KbImage.UPLOAD_ROUTE_TEMPLATE."
+        )
+
+    # Round-trip self-check: KbImage(...).public_path must be parseable back
+    # via KbImage.from_path. If we ever break this invariant the boot-time
+    # check above is still active but this gives a clearer error first.
+    probe = KbImage(
+        zitadel_org_id="368884765035593759",
+        kb_slug="support",
+        sha256="0" * 64,
+        ext="png",
+    )
+    if KbImage.from_path(probe.public_path) != probe:
+        raise RuntimeError(
+            "SPEC-KB-IMAGES-V2-001 REQ-3 boot-time check failed: "
+            "KbImage.public_path does not round-trip through KbImage.from_path. "
+            "Either the public_path generator or the _PATH_RE drifted."
+        )
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     import asyncio
+
+    # SPEC-KB-IMAGES-V2-001 REQ-3: fail boot if kb-image route declaration
+    # drifts from the KbImage value-class. Runs FIRST so subsequent startup
+    # work doesn't waste time when the contract is already broken.
+    _assert_kb_image_routes_match_value_class(app)
 
     # SPEC-SEC-SESSION-001 REQ-4: validate SSO_COOKIE_KEY in BOTH dev and prod
     # modes, before any other startup work. Empty / unset key aborts the

--- a/klai-portal/backend/tests/test_kb_image_route_drift_abort.py
+++ b/klai-portal/backend/tests/test_kb_image_route_drift_abort.py
@@ -1,0 +1,78 @@
+"""SPEC-KB-IMAGES-V2-001 REQ-3 / AC-3: boot-time assertion sabotage tests.
+
+These tests verify that ``_assert_kb_image_routes_match_value_class`` in
+``app.main`` actually fires (and aborts boot) when the kb-image route
+declaration drifts from the ``KbImage`` value-class templates. The
+assertion is defense-in-depth on top of the ast-grep CI guard (REQ-5);
+testing the assertion itself ensures the guard isn't a no-op.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+
+from app.core.kb_image_url import KbImage
+from app.main import _assert_kb_image_routes_match_value_class
+
+
+def _make_app_with_routes(paths: list[str]) -> FastAPI:
+    """Build a minimal FastAPI app exposing ``paths`` as no-op handlers
+    so the assertion sees them as ``app.routes`` entries."""
+    app = FastAPI()
+    for p in paths:
+        # Each path needs at least one method registered to appear in app.routes
+        @app.get(p)
+        async def _noop() -> dict:
+            return {}
+
+    return app
+
+
+def test_assertion_passes_on_canonical_routes() -> None:
+    """Happy path: when the app declares exactly the two KbImage templates,
+    the assertion does not raise."""
+    app = _make_app_with_routes([KbImage.ROUTE_TEMPLATE, KbImage.UPLOAD_ROUTE_TEMPLATE])
+    _assert_kb_image_routes_match_value_class(app)  # should not raise
+
+
+def test_assertion_aborts_on_4_segment_drift() -> None:
+    """The exact v1 regression: route uses {org_id}/{kb_slug}/{filename}
+    (4 segments) instead of {zitadel_org_id}/images/{kb_slug}/{filename}
+    (5 segments). The assertion MUST refuse to boot."""
+    sabotaged = "/kb-images/{org_id}/{kb_slug}/{filename}"
+    app = _make_app_with_routes([sabotaged, KbImage.UPLOAD_ROUTE_TEMPLATE])
+
+    with pytest.raises(RuntimeError, match="boot-time check failed"):
+        _assert_kb_image_routes_match_value_class(app)
+
+
+def test_assertion_aborts_on_renamed_segment() -> None:
+    """Another realistic drift: someone renames 'images' to 'imgs' in the
+    route. URL would still be 5 segments but never match the actual S3
+    keys (which use 'images'). The assertion MUST refuse to boot."""
+    sabotaged = "/kb-images/{zitadel_org_id}/imgs/{kb_slug}/{filename}"
+    app = _make_app_with_routes([sabotaged, KbImage.UPLOAD_ROUTE_TEMPLATE])
+
+    with pytest.raises(RuntimeError, match="boot-time check failed"):
+        _assert_kb_image_routes_match_value_class(app)
+
+
+def test_assertion_aborts_when_upload_route_missing() -> None:
+    """Half the contract missing — boot must abort even when the GET route
+    is correctly declared."""
+    app = _make_app_with_routes([KbImage.ROUTE_TEMPLATE])
+
+    with pytest.raises(RuntimeError, match="boot-time check failed"):
+        _assert_kb_image_routes_match_value_class(app)
+
+
+def test_assertion_aborts_on_extra_kb_image_route() -> None:
+    """If someone adds a legacy/parallel route alongside the canonical
+    one, that's also a drift — the SPEC explicitly forbids legacy routes
+    surviving (REQ-8)."""
+    extra = "/kb-images/legacy/{org_id}/{filename}"
+    app = _make_app_with_routes([KbImage.ROUTE_TEMPLATE, KbImage.UPLOAD_ROUTE_TEMPLATE, extra])
+
+    with pytest.raises(RuntimeError, match="boot-time check failed"):
+        _assert_kb_image_routes_match_value_class(app)

--- a/klai-portal/backend/tests/test_kb_image_upload.py
+++ b/klai-portal/backend/tests/test_kb_image_upload.py
@@ -49,7 +49,6 @@ def _make_image_store_mock(deduplicated: bool = False) -> MagicMock:
             object_key = f"{org_id}/images/{kb_slug}/{sha}.{ext}"
             return ImageUploadResult(
                 object_key=object_key,
-
                 deduplicated=deduplicated,
             )
 

--- a/klai-portal/backend/tests/test_kb_image_upload.py
+++ b/klai-portal/backend/tests/test_kb_image_upload.py
@@ -49,7 +49,7 @@ def _make_image_store_mock(deduplicated: bool = False) -> MagicMock:
             object_key = f"{org_id}/images/{kb_slug}/{sha}.{ext}"
             return ImageUploadResult(
                 object_key=object_key,
-                public_url=f"/kb-images/{object_key}",
+
                 deduplicated=deduplicated,
             )
 

--- a/klai-portal/frontend/e2e/kb-images.spec.ts
+++ b/klai-portal/frontend/e2e/kb-images.spec.ts
@@ -1,0 +1,108 @@
+/**
+ * SPEC-KB-IMAGES-V2-001 REQ-6 / AC-4 / AC-5: end-to-end Playwright test
+ * for the kb-image round-trip.
+ *
+ * Unlike the existing portal e2e tests, this one drives the **full**
+ * transport stack — Caddy → portal-api → Garage — by uploading a tiny
+ * PNG and then rendering the returned URL as an `<img>` element. The
+ * test fails if `naturalWidth === 0` (the v1 regression symptom that
+ * went undetected for 3 weeks).
+ *
+ * Activation requirements (manual one-time setup):
+ *
+ * 1. Create a GitHub Actions secret `KLAI_E2E_STORAGE_STATE_BASE64`
+ *    containing a base64-encoded Playwright storage-state JSON for the
+ *    `e2e-test-org` tenant. See `playwright-mcp-config-cycle` pitfall
+ *    in `.claude/rules/klai/pitfalls/process-rules.md` for the seed
+ *    procedure.
+ * 2. Set `KLAI_E2E_BASE_URL` to the staging or prod-tenant URL the
+ *    storage-state was seeded for.
+ * 3. Remove the `if: false` guard in
+ *    `.github/workflows/portal-frontend-e2e.yml`.
+ *
+ * Until the secret is set up the workflow is dormant — running this
+ * test locally is supported via the Playwright config in this folder.
+ */
+
+import { readFileSync } from 'node:fs'
+import { resolve as pathResolve } from 'node:path'
+
+import { expect, test } from '@playwright/test'
+
+import {
+  KB_IMAGE_PUBLIC_PATH_RE,
+  kbImageUploadPath,
+} from '../src/lib/kb-image-url'
+
+const BASE_URL = process.env.KLAI_E2E_BASE_URL ?? 'https://my.getklai.com'
+// kb-slug pre-provisioned in the test tenant. The slug must exist (the
+// upload route does `_get_kb_or_404` on it) but its contents are irrelevant.
+const TEST_KB_SLUG = process.env.KLAI_E2E_KB_SLUG ?? 'klai-help'
+
+// 1x1 transparent PNG, embedded so the test has no external file dep.
+const TINY_PNG_BYTES = Buffer.from(
+  '89504E470D0A1A0A0000000D49484452000000010000000108060000001F15C489' +
+    '0000000A49444154789C6300010000000500010D0A2DB40000000049454E44AE426082',
+  'hex',
+)
+
+test.describe('kb-image round-trip', () => {
+  test('upload returns a v2-shape URL and that URL renders as an image', async ({
+    page,
+    request,
+  }) => {
+    // SPEC-KB-IMAGES-V2-001 AC-5 part 1: upload via the canonical route.
+    const uploadUrl = `${BASE_URL}${kbImageUploadPath(TEST_KB_SLUG)}`
+    const uploadResp = await request.post(uploadUrl, {
+      multipart: {
+        file: {
+          name: 'e2e-test.png',
+          mimeType: 'image/png',
+          buffer: TINY_PNG_BYTES,
+        },
+      },
+    })
+    expect(
+      uploadResp.status(),
+      `upload failed: ${uploadResp.status()} ${await uploadResp.text()}`,
+    ).toBe(200)
+    const body = (await uploadResp.json()) as {
+      url: string
+      deduplicated: boolean
+    }
+
+    // The URL is in the v2 5-segment shape. If a future PR re-introduces
+    // the v1 4-segment shape, this assertion fails immediately.
+    expect(
+      KB_IMAGE_PUBLIC_PATH_RE.test(body.url),
+      `returned URL ${JSON.stringify(body.url)} does not match KbImage canonical shape`,
+    ).toBe(true)
+
+    // SPEC-KB-IMAGES-V2-001 AC-4: the URL must render as an actual image
+    // through the full Caddy → portal-api → Garage stack. naturalWidth > 0
+    // is the v1 regression's missing observable.
+    await page.goto(BASE_URL)
+    await page.setContent(`<img id="probe" src="${body.url}" />`)
+    const dims = await page.evaluate(() => {
+      const img = document.getElementById('probe') as HTMLImageElement
+      return new Promise<{ naturalWidth: number; complete: boolean }>((res) => {
+        if (img.complete) {
+          res({ naturalWidth: img.naturalWidth, complete: img.complete })
+        } else {
+          img.addEventListener('load', () =>
+            res({ naturalWidth: img.naturalWidth, complete: true }),
+          )
+          img.addEventListener('error', () =>
+            res({ naturalWidth: 0, complete: false }),
+          )
+        }
+      })
+    })
+    expect(dims.complete).toBe(true)
+    expect(dims.naturalWidth).toBeGreaterThan(0)
+  })
+})
+
+// Sanity check that we did not accidentally ship a stale fixture file in CI.
+void pathResolve(import.meta.url)
+void readFileSync

--- a/klai-portal/frontend/src/components/kb-editor/BlockPageEditor.tsx
+++ b/klai-portal/frontend/src/components/kb-editor/BlockPageEditor.tsx
@@ -5,6 +5,7 @@ import { BlockNoteSchema, defaultInlineContentSpecs } from '@blocknote/core'
 import '@blocknote/mantine/style.css'
 import { WikiLink } from '@/components/kb-editor/WikiLink'
 import { apiFetch, ApiError } from '@/lib/apiFetch'
+import { kbImageUploadPath } from '@/lib/kb-image-url'
 import { editorLogger } from '@/lib/logger'
 
 // Status -> NL message map for image upload errors. BlockNote surfaces the
@@ -59,12 +60,13 @@ export const BlockPageEditor = forwardRef<
       const fd = new FormData()
       fd.append('file', file)
       try {
-        // The kb-images router is mounted at /kb-images (no /api prefix —
-        // see klai-portal/backend/app/main.py and SPEC-TI-009's Caddy block).
-        // Posting to /api/kb-images/... gives a 404 because the route only
-        // exists at /kb-images/...
+        // SPEC-KB-IMAGES-V2-001 REQ-7: the URL is sourced from the
+        // ``kb-image-url.ts`` mirror module, the only place in the frontend
+        // that knows the kb-image route shape. A drift between this URL and
+        // the Python KbImage value-class is caught by the vitest unit test
+        // in ``lib/__tests__/kb-image-url.test.ts``.
         const res = await apiFetch<{ url: string; deduplicated: boolean }>(
-          `/kb-images/${encodeURIComponent(kbSlug)}`,
+          kbImageUploadPath(kbSlug),
           { method: 'POST', body: fd },
         )
         editorLogger.debug('Image uploaded', {

--- a/klai-portal/frontend/src/lib/__tests__/kb-image-url.test.ts
+++ b/klai-portal/frontend/src/lib/__tests__/kb-image-url.test.ts
@@ -1,0 +1,90 @@
+/**
+ * SPEC-KB-IMAGES-V2-001 REQ-7 drift test: outputs of `lib/kb-image-url.ts`
+ * are compared to fixture strings generated from the Python KbImage
+ * value-class. A drift between Python and TS produces a unit-test
+ * failure, not a silent runtime 404.
+ *
+ * Fixture strings below are exactly what
+ * `klai_image_storage.kb_image.KbImage(...).public_path` returns for
+ * the same inputs. If you change the URL shape in Python, update both
+ * the regex on the TS side AND the fixtures here; the test will fail
+ * fast either way.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  KB_IMAGE_PUBLIC_PATH_RE,
+  kbImagePublicPath,
+  kbImageUploadPath,
+} from '@/lib/kb-image-url'
+
+describe('kbImageUploadPath', () => {
+  it('matches KbImage.UPLOAD_ROUTE_TEMPLATE for a real kb-slug', () => {
+    expect(kbImageUploadPath('support')).toBe('/kb-images/support')
+  })
+
+  it('url-encodes the kb_slug (defensive — production slugs are already url-safe)', () => {
+    // Defensive: production kb_slugs match /^[a-z0-9][a-z0-9-]{0,63}$/ so
+    // encodeURIComponent is a no-op. But if someone ever passes a slug
+    // with spaces or unicode, the encoded form must not break the route
+    // matcher upstream.
+    expect(kbImageUploadPath('a b')).toBe('/kb-images/a%20b')
+  })
+})
+
+describe('kbImagePublicPath', () => {
+  it('matches Python KbImage.public_path for Voys connector image', () => {
+    const got = kbImagePublicPath({
+      zitadelOrgId: '368884765035593759',
+      kbSlug: 'support',
+      sha256: 'dae543ab51b40c9611d14c96e1f72bbd53a1ecdc782c192fbc2ab6d0e6127dd9',
+      ext: 'png',
+    })
+    // Fixture: the exact path served by portal-api for Voys' first
+    // connector-uploaded support image (verified live 2026-05-12).
+    expect(got).toBe(
+      '/kb-images/368884765035593759/images/support/dae543ab51b40c9611d14c96e1f72bbd53a1ecdc782c192fbc2ab6d0e6127dd9.png',
+    )
+  })
+
+  it('matches Python KbImage.public_path for Mark docs-editor upload', () => {
+    const got = kbImagePublicPath({
+      zitadelOrgId: '362757920133283846',
+      kbSlug: 'klai-help',
+      sha256: '71e67cdc4b7451885b314b848583f5a66838b1952d753f5d133b5d98dc375f5b',
+      ext: 'png',
+    })
+    expect(got).toBe(
+      '/kb-images/362757920133283846/images/klai-help/71e67cdc4b7451885b314b848583f5a66838b1952d753f5d133b5d98dc375f5b.png',
+    )
+  })
+})
+
+describe('KB_IMAGE_PUBLIC_PATH_RE', () => {
+  it('accepts real production paths (round-trip with Python regex)', () => {
+    const paths = [
+      '/kb-images/368884765035593759/images/support/dae543ab51b40c9611d14c96e1f72bbd53a1ecdc782c192fbc2ab6d0e6127dd9.png',
+      '/kb-images/362757920133283846/images/klai-help/71e67cdc4b7451885b314b848583f5a66838b1952d753f5d133b5d98dc375f5b.png',
+      '/kb-images/org-1/images/support/' + 'a'.repeat(64) + '.jpg',
+    ]
+    for (const p of paths) {
+      expect(KB_IMAGE_PUBLIC_PATH_RE.test(p)).toBe(true)
+    }
+  })
+
+  it('rejects the v1 4-segment shape and other near-misses', () => {
+    const bad = [
+      '/kb-images/368884765035593759/support/abc.png', // 4 segments (old v1 shape)
+      '/kb-images/foo/bar/baz.png', // missing 'images' literal
+      '/kb-images/368884765035593759/imgs/support/' + 'a'.repeat(64) + '.png', // wrong literal
+      '/kb-images/368884765035593759/images/support/short.png', // sha not 64 chars
+      '/kb-images/368884765035593759/images/support/' + 'a'.repeat(64) + '.svg', // disallowed ext
+      '/kb-images/368884765035593759/images/BadSlug/' + 'a'.repeat(64) + '.png', // caps in slug
+      '/wrong-prefix/368884765035593759/images/support/' + 'a'.repeat(64) + '.png',
+    ]
+    for (const p of bad) {
+      expect(KB_IMAGE_PUBLIC_PATH_RE.test(p)).toBe(false)
+    }
+  })
+})

--- a/klai-portal/frontend/src/lib/kb-image-url.ts
+++ b/klai-portal/frontend/src/lib/kb-image-url.ts
@@ -1,0 +1,64 @@
+/**
+ * KB-image URL constants — TypeScript mirror of
+ * ``klai-libs/image-storage/klai_image_storage/kb_image.py``.
+ *
+ * SPEC-KB-IMAGES-V2-001 REQ-7: single source of truth for the kb-image
+ * URL shape, mirrored here so the portal frontend (the only TS consumer)
+ * doesn't hardcode the path. A drift between this module and the Python
+ * KbImage is caught at unit-test time by the fixture in
+ * `__tests__/kb-image-url.test.ts` — the test compares this module's
+ * outputs to known-good Python-generated strings.
+ *
+ * Why mirror instead of fetching at runtime: the URL is needed before
+ * any network call (the upload route itself), so a runtime fetch would
+ * recurse. Mirror + drift-test is the standard pattern (same as how
+ * Paraglide compiles i18n keys to TS modules).
+ */
+
+// Production tenant ids are numeric snowflake (e.g. "368884765035593759").
+// Dev / test tenants use the kb_slug alphabet (e.g. "org-1"). Both shapes
+// are accepted in the path regex below — must match KbImage._PATH_RE.
+const ZITADEL_SEGMENT_RE = /([a-z0-9][a-z0-9-]{0,63}|[0-9]{1,20})/
+const KB_SLUG_SEGMENT_RE = /([a-z0-9][a-z0-9-]{0,63})/
+const SHA256_SEGMENT_RE = /([0-9a-f]{64})/
+const EXT_SEGMENT_RE = /(jpg|png|gif|webp)/
+
+/**
+ * Build the relative POST URL for uploading a new kb-image.
+ *
+ * Mirror of: ``KbImage.UPLOAD_ROUTE_TEMPLATE`` (Python).
+ */
+export function kbImageUploadPath(kbSlug: string): string {
+  return `/kb-images/${encodeURIComponent(kbSlug)}`
+}
+
+/**
+ * Regex that parses a kb-image public URL into its components.
+ *
+ * Mirror of: ``KbImage._PATH_RE`` (Python).
+ */
+export const KB_IMAGE_PUBLIC_PATH_RE = new RegExp(
+  '^/kb-images/' +
+    ZITADEL_SEGMENT_RE.source +
+    '/images/' +
+    KB_SLUG_SEGMENT_RE.source +
+    '/' +
+    SHA256_SEGMENT_RE.source +
+    '\\.' +
+    EXT_SEGMENT_RE.source +
+    '$',
+)
+
+/**
+ * Build the relative GET URL for fetching a stored kb-image.
+ *
+ * Mirror of: ``KbImage.public_path`` (Python).
+ */
+export function kbImagePublicPath(args: {
+  zitadelOrgId: string
+  kbSlug: string
+  sha256: string
+  ext: 'jpg' | 'png' | 'gif' | 'webp'
+}): string {
+  return `/kb-images/${args.zitadelOrgId}/images/${args.kbSlug}/${args.sha256}.${args.ext}`
+}

--- a/rules/no-hardcoded-kb-image-path.yml
+++ b/rules/no-hardcoded-kb-image-path.yml
@@ -31,11 +31,8 @@ message: |
   or `UPLOAD_ROUTE_TEMPLATE` instead.
 
 rule:
-  pattern: $STR
-  constraints:
-    STR:
-      kind: string
-      regex: '/kb-images/'
+  kind: string
+  regex: '/kb-images/'
 
 files:
   - klai-portal/backend/app/**/*.py

--- a/rules/no-hardcoded-kb-image-path.yml
+++ b/rules/no-hardcoded-kb-image-path.yml
@@ -1,0 +1,56 @@
+# SPEC-KB-IMAGES-V2-001 REQ-5 — block hardcoded "/kb-images/" path-literals
+# outside the single-source-of-truth module(s).
+#
+# Why: pre-V2, three independent files (klai_image_storage, kb_images.py,
+# BlockPageEditor.tsx) each hardcoded part of the kb-image URL. Drift
+# between them produced silent 404s for 3 weeks (PRs #598/#600/#602/#607).
+# V2 collapses URL-shape into ``klai_image_storage.kb_image.KbImage``.
+# Every other reference must import from there — a new string-literal in
+# Python code is a regression of the v1 problem.
+#
+# Allow-listed sources (the single source itself + a portal-side
+# re-export shim + tests that intentionally probe the shape):
+#   klai-libs/image-storage/klai_image_storage/kb_image.py
+#   klai-portal/backend/app/core/kb_image_url.py
+#   klai-libs/image-storage/tests/test_kb_image.py
+#   klai-libs/image-storage/tests/test_storage.py
+#   klai-portal/backend/tests/test_kb_image_*.py
+#   klai-portal/backend/tests/test_kb_images_*.py
+#
+# Frontend TS mirror has its own drift-test in
+#   klai-portal/frontend/src/lib/__tests__/kb-image-url.test.ts
+
+id: no-hardcoded-kb-image-path
+language: python
+severity: error
+message: |
+  Hardcoded "/kb-images/" path-literal is forbidden outside the kb_image
+  value-class (SPEC-KB-IMAGES-V2-001 REQ-5). Import KbImage from
+  `klai_image_storage.kb_image` (or `app.core.kb_image_url` in
+  klai-portal) and use its `.public_path`, `.s3_key`, `ROUTE_TEMPLATE`,
+  or `UPLOAD_ROUTE_TEMPLATE` instead.
+
+rule:
+  pattern: $STR
+  constraints:
+    STR:
+      kind: string
+      regex: '/kb-images/'
+
+files:
+  - klai-portal/backend/app/**/*.py
+  - klai-connector/app/**/*.py
+  - klai-knowledge-ingest/knowledge_ingest/**/*.py
+  - klai-libs/image-storage/klai_image_storage/**/*.py
+
+ignores:
+  # The single source of truth. URL-shape definitions live here.
+  - klai-libs/image-storage/klai_image_storage/kb_image.py
+  # Portal-side re-export shim — forwards KbImage to handlers without adding logic.
+  - klai-portal/backend/app/core/kb_image_url.py
+  # Test files that probe the URL shape are intentionally exempt — they're
+  # not production code paths that could drift.
+  - klai-libs/image-storage/tests/**/*.py
+  - klai-portal/backend/tests/**/*.py
+  - klai-connector/tests/**/*.py
+  - klai-knowledge-ingest/tests/**/*.py


### PR DESCRIPTION
## TL;DR

Vervangt het oude kb-images stack-design. Eén `KbImage` value-class is nu de **enige** plek waar URL-shape, S3-key shape, route templates en validatie geleven worden. Drie onafhankelijke implementaties (klai_image_storage / kb_images.py / BlockPageEditor.tsx) → één bron + vijf drift-guards.

Geen v1-routes parallel. Geen 301-redirects. Geen legacy. Productie-data (1553 bestaande images) blijft ongewijzigd.

## Waarom een rewrite, niet meer patches

5 sequentiele bandaid-PRs (#598, #600, #602, #607, plus de DOCS-IMAGE-PASTE feature die het onthulde) in één werkdag — telkens onthulde de fix de volgende laag. Het patroon was structureel: **drie files** die elk een slice van het kb-image URL contract hardcodeerden. Patches op losse drift-instanties lossen het patroon niet op. V2 vervangt de drift-surface.

## Wat erin zit

| REQ | Implementation |
|---|---|
| REQ-1: single source | `klai_image_storage/kb_image.py::KbImage` value-class |
| REQ-2: routes via constants | `@router.get(KbImage.ROUTE_TEMPLATE)` |
| REQ-3: boot-time assertion | `_assert_kb_image_routes_match_value_class` in `app/main.py` + 5 sabotage tests |
| REQ-4: remove dual sources | `PUBLIC_IMAGE_PATH_PREFIX` + `build_public_url` deleted from lib |
| REQ-5: ast-grep guard | `rules/no-hardcoded-kb-image-path.yml` |
| REQ-6: Playwright E2E | `e2e/kb-images.spec.ts` + workflow file (dormant — needs storage-state secret) |
| REQ-7: TS mirror + drift test | `lib/kb-image-url.ts` + vitest comparison to Python fixtures |
| REQ-8: no legacy routes | Grep-verified clean |
| REQ-9: pitfall-entry | Replaced narrow `caddy-proxy-route-without-browser-leg` with broader `url-shape-multi-file-drift` |

## Verificatie

- **2570/0** portal-api full pytest suite (+8 new drift-abort tests)
- **163/163** klai_image_storage suite (incl. 22 new KbImage round-trip tests)
- **12/12** klai-knowledge-ingest image-related suites
- **6/6** vitest drift tests (Python ↔ TypeScript URL-shape parity)
- ruff + ruff format + pyright clean
- tsc + eslint clean
- Existing 1553 Voys/Klai-help images preserved (zero data migration)

## Twee handmatige stappen na merge

1. **Browser smoketest** op staging/prod: paste een screenshot in een docs-page; verifieer dat de image laadt zonder Loading-state hang.
2. **Activeer de Playwright E2E workflow** door `KLAI_E2E_STORAGE_STATE_BASE64` + `KLAI_E2E_BASE_URL` GH-secrets te seeden en `if: false` in `portal-frontend-e2e-kb-images.yml` te flippen naar de secret-check. Zonder dit blijft hij dormant — geen rode CI op elke PR.

## Refs

- [SPEC-KB-IMAGES-V2-001](.moai/specs/SPEC-KB-IMAGES-V2-001/spec.md)
- Vervangt: SPEC-TI-009 (kb-image auth-proxy, pre-V2)
- Sluit af: PRs #598 / #600 / #602 / #607 (de 4 bandaid-fixes die V2 vervangt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)