### PR TITLE
feat(portal): SPEC-PORTAL-PRICING-PER-USER-001 Phase 4 — capability resolution → seat-based

### DIFF
--- a/klai-portal/backend/app/core/permissions.py
+++ b/klai-portal/backend/app/core/permissions.py
@@ -35,9 +35,8 @@ from app.api.bearer import bearer
 from app.core.config import settings as _app_settings
 from app.core.database import get_db, set_tenant
 from app.core.features import derive_user_products
-from app.core.plan_limits import KBLimits, get_plan_limits
+from app.core.plan_limits import KBLimits
 from app.core.profiles import (
-    PROFILE_CAPABILITIES,
     PROFILE_LADDER,
     Capability,
     ProfileRole,
@@ -84,6 +83,15 @@ class UserPermissions:
     # Carried for the deprovisioning-block gate in get_caller. Not part of the
     # 12-field public contract; consumers should not branch on it directly.
     provisioning_status: str = "active"
+    # SPEC-PORTAL-PRICING-PER-USER-001 Phase 4 (2026-05-12): per-user
+    # billing tier. Read from ``portal_users.seat_type``. Drives the
+    # capability resolver — Phase 4 swap moves the intersection axis
+    # from plan to seat. ``plan`` stays on this struct for legacy
+    # callers (kb_quota.py, billing snapshots); Phase 6 deprecates it.
+    # Defaulted to ``"chat"`` (cheapest paid tier) so existing test
+    # constructors that pre-date Phase 4 still build without an explicit
+    # arg. The resolver always passes the real value.
+    seat_type: str = "chat"
 
 
 # ---------------------------------------------------------------------------
@@ -91,25 +99,47 @@ class UserPermissions:
 # ---------------------------------------------------------------------------
 
 
-def _derive_effective_capabilities(role: ProfileRole, plan: str) -> frozenset[Capability]:
-    """Profile capabilities ∩ plan capabilities, with admin bypass.
+def _derive_effective_capabilities(role: ProfileRole, seat_type: str) -> frozenset[Capability]:
+    """Profile capabilities ∩ seat-unlocked capabilities, with admin bypass.
 
-    Mirrors ``app/api/dependencies.py::get_effective_capabilities``:
-    admins on any plan tier receive the full ``knowledge``-tier capability
-    set so they can preview what a plan upgrade unlocks before paying for
-    it. Intentional per SPEC-PORTAL-PLAN-RENAME-001 (carrying forward the
-    SPEC-PORTAL-PROFILES-001 v0.2.0 / v0.3.0 admin-bypass policy).
+    SPEC-PORTAL-PRICING-PER-USER-001 Phase 4 (2026-05-12) — capability
+    intersection swapped from plan-axis to seat-axis. The plan-based
+    derivation (carried forward through SPEC-PORTAL-PLAN-RENAME-001) is
+    gone; billing tier is now ``portal_users.seat_type`` and that's the
+    table the resolver intersects against.
+
+    Pre-Phase-4 shape:
+        cap = PROFILE_CAPABILITIES[role] ∩ PLAN_LIMITS[org.plan].capabilities
+
+    Post-Phase-4 shape:
+        cap = PROFILE_CAPABILITIES[role] filtered through
+              CAPABILITY_TO_SEAT_FEATURE against SEAT_FEATURES[seat_type]
+
+    Both shapes preserve the admin-bypass: an ``admin`` role on any seat
+    receives the full KNOWLEDGE-tier capability set. The bypass exists
+    so a platform admin can preview the full feature surface regardless
+    of their billing tier (e.g. an admin who happens to be on a viewer
+    seat for cost reasons still sees the full admin UI). This mirrors
+    the pre-Phase-4 ``ADMIN -> knowledge plan`` bypass.
     """
     if role == ProfileRole.ADMIN:
-        # Use the knowledge-tier (full unlock) plan capabilities verbatim —
-        # these are the capability strings, but already typed via
-        # Capability(StrEnum) so the frozenset equality matches.
-        knowledge_caps = get_plan_limits("knowledge").capabilities
-        return frozenset(Capability(c) for c in knowledge_caps)
+        # Admin bypass: full KNOWLEDGE-seat capabilities regardless of
+        # the user's actual seat. Uses the seats-module canonical
+        # composition so the bypass cannot drift from the KNOWLEDGE
+        # tier's actual unlock set.
+        from app.core.seats import SeatType, effective_capabilities
 
-    role_caps = PROFILE_CAPABILITIES.get(role.value, frozenset())
-    plan_caps = get_plan_limits(plan).capabilities
-    return frozenset(Capability(c) for c in (set(role_caps) & set(plan_caps)))
+        return frozenset(Capability(c) for c in effective_capabilities(role.value, SeatType.KNOWLEDGE))
+
+    from app.core.seats import SeatType, effective_capabilities
+
+    try:
+        seat = SeatType(seat_type)
+    except ValueError:
+        # Unknown seat string (data drift) -> fall back to the cheapest
+        # paid tier. Matches the suggest_seat fail-closed pricing default.
+        seat = SeatType.CHAT
+    return frozenset(Capability(c) for c in effective_capabilities(role.value, seat))
 
 
 def _platform_unlocked_set(org: PortalOrg) -> frozenset[str]:
@@ -148,8 +178,13 @@ async def resolve_user_permissions(zitadel_user_id: str, db: AsyncSession) -> Us
 
     role = ProfileRole(user.role)
     plan = org.plan
+    # SPEC-PORTAL-PRICING-PER-USER-001 Phase 4: capability resolution
+    # axis swapped from plan to seat_type. ``plan`` stays on UserPermissions
+    # for the legacy kb-quota path (services/kb_quota.py reads org.plan to
+    # cap personal-KB count) — that swap is a follow-up.
+    seat_type = user.seat_type
     platform_features = _platform_unlocked_set(org)
-    effective_caps = _derive_effective_capabilities(role, plan)
+    effective_caps = _derive_effective_capabilities(role, seat_type)
     effective_prods = frozenset(derive_user_products(role.value, plan, list(platform_features)))
     kb_limits = effective_kb_limits(role.value, plan)
     is_platform_admin = org.slug == _app_settings.platform_org_slug
@@ -160,6 +195,7 @@ async def resolve_user_permissions(zitadel_user_id: str, db: AsyncSession) -> Us
         org_slug=org.slug,
         role=role,
         plan=plan,
+        seat_type=seat_type,
         platform_unlocked_features=platform_features,
         effective_role=role,  # alias-fase: identical to role until profile-stacking lands
         effective_capabilities=effective_caps,

--- a/klai-portal/backend/tests/conftest.py
+++ b/klai-portal/backend/tests/conftest.py
@@ -228,6 +228,7 @@ def make_perms(
     org_id: int = 101,
     org_slug: str = "voys",
     plan: str = "knowledge",
+    seat_type: str | None = None,
     enabled_addons: list[str] | None = None,
     platform_unlocked_features: list[str] | None = None,
     is_platform_admin: bool = False,
@@ -248,19 +249,29 @@ def make_perms(
     from app.core.features import derive_user_products
     from app.core.permissions import UserPermissions
     from app.core.plan_limits import get_plan_limits
-    from app.core.profiles import PROFILE_CAPABILITIES, Capability, ProfileRole
+    from app.core.profiles import Capability, ProfileRole
+    from app.core.seats import SeatType, suggest_seat
+    from app.core.seats import effective_capabilities as seat_effective_capabilities
 
     role_enum = role if isinstance(role, ProfileRole) else ProfileRole(str(role))
     # Back-compat: legacy enabled_addons param merges into platform_unlocked_features.
     plat_features = frozenset((platform_unlocked_features or []) + (enabled_addons or []))
 
+    # SPEC-PORTAL-PRICING-PER-USER-001 Phase 4: capability resolution uses
+    # seat_type. Default seat = suggest_seat(role) when caller doesn't pin
+    # one — mirrors the prod backfill semantics.
+    seat_str = seat_type if seat_type is not None else str(suggest_seat(role_enum.value))
+    try:
+        seat_enum = SeatType(seat_str)
+    except ValueError:
+        seat_enum = SeatType.CHAT
+
     if role_enum == ProfileRole.ADMIN:
-        knowledge_caps = get_plan_limits("knowledge").capabilities
-        eff_caps = frozenset(Capability(c) for c in knowledge_caps)
+        # Admin bypass: full KNOWLEDGE-seat capabilities regardless of
+        # the actual seat. Mirrors resolve_user_permissions semantics.
+        eff_caps = frozenset(Capability(c) for c in seat_effective_capabilities(role_enum.value, SeatType.KNOWLEDGE))
     else:
-        role_caps = PROFILE_CAPABILITIES.get(role_enum.value, frozenset())
-        plan_caps = get_plan_limits(plan).capabilities
-        eff_caps = frozenset(Capability(c) for c in (set(role_caps) & set(plan_caps)))
+        eff_caps = frozenset(Capability(c) for c in seat_effective_capabilities(role_enum.value, seat_enum))
 
     eff_products = frozenset(derive_user_products(role_enum.value, plan, list(plat_features)))
 
@@ -270,6 +281,7 @@ def make_perms(
         org_slug=org_slug,
         role=role_enum,
         plan=plan,
+        seat_type=seat_str,
         platform_unlocked_features=plat_features,
         effective_role=role_enum,
         effective_capabilities=eff_caps,

--- a/klai-portal/backend/tests/test_permissions.py
+++ b/klai-portal/backend/tests/test_permissions.py
@@ -44,6 +44,7 @@ def _row(
     *,
     role: str,
     plan: str,
+    seat_type: str | None = None,
     enabled_addons: list[str] | None = None,
     platform_unlocked_features: list[str] | None = None,
     org_id: int = 101,
@@ -56,7 +57,15 @@ def _row(
     SPEC-PORTAL-EXTENSIONS-UNIFY-001: `enabled_addons=` kept as back-compat alias —
     its value is merged into `platform_unlocked_features` for the mock org so older
     tests can still express their setup without rewriting.
+
+    SPEC-PORTAL-PRICING-PER-USER-001 Phase 4: ``seat_type`` is the new
+    capability-intersection axis (replaces plan). Default = the smart-
+    default for the chosen role (``suggest_seat`` semantics) so existing
+    tests that pre-date the seat axis produce intuitive results without
+    extra kwargs.
     """
+    from app.core.seats import suggest_seat
+
     org = MagicMock()
     org.id = org_id
     org.slug = slug
@@ -69,6 +78,11 @@ def _row(
     user.zitadel_user_id = "uid-test"
     user.org_id = org_id
     user.id = 42
+    user.seat_type = seat_type if seat_type is not None else str(suggest_seat(role))
+    return user_pair(org, user)
+
+
+def user_pair(org: MagicMock, user: MagicMock) -> tuple[MagicMock, MagicMock]:
     return org, user
 
 
@@ -188,12 +202,56 @@ async def test_resolve_personal_on_complete_gets_kb_connectors_only() -> None:
 
 
 @pytest.mark.asyncio
-async def test_resolve_personal_on_free_gets_no_capabilities() -> None:
-    """AC-8: personal on `free` → empty set (free has no plan-tier caps)."""
-    db = _db_with_row(_row(role="personal", plan="free"))
+async def test_resolve_personal_on_viewer_seat_gets_no_capabilities() -> None:
+    """SPEC-PORTAL-PRICING-PER-USER-001 Phase 4 (2026-05-12) — replaces
+    the pre-Phase-4 ``test_resolve_personal_on_free_gets_no_capabilities``.
+
+    Capability intersection moved from plan-axis to seat-axis. Free-plan
+    tenants are gone as a billing-tier signal; the equivalent "user has
+    no caps" combination is now ``personal`` role on a ``viewer`` seat —
+    viewer-seat unlocks ``chat_readonly`` / ``knowledge_readonly`` but no
+    capability in ``CAPABILITY_TO_SEAT_FEATURE`` maps to either, so the
+    intersection is empty.
+    """
+    db = _db_with_row(_row(role="personal", plan="free", seat_type="viewer"))
     perms = await resolve_user_permissions("uid-test", db)
     assert perms is not None
     assert perms.effective_capabilities == frozenset()
+
+
+@pytest.mark.asyncio
+async def test_resolve_kb_manager_on_chat_seat_keeps_only_basic_connector() -> None:
+    """SPEC-PORTAL-PRICING-PER-USER-001 Phase 4 — the canonical decoupled
+    case from the SPEC's example matrix.
+
+    kb_manager role + chat seat: role grants the full KB-management
+    capability set, but the chat-seat only unlocks ``kb.connectors``
+    (not ``kb.connectors.external``, not ``knowledge.full``). Result:
+    only ``kb.connectors`` survives the seat-side filter. This is the
+    behaviour the admin UI surfaces as a ⚠ warning (AC-5).
+    """
+    db = _db_with_row(_row(role="kb_manager", plan="knowledge", seat_type="chat"))
+    perms = await resolve_user_permissions("uid-test", db)
+    assert perms is not None
+    assert perms.effective_capabilities == frozenset({Capability.KB_CONNECTORS})
+
+
+@pytest.mark.asyncio
+async def test_resolve_kb_manager_on_knowledge_seat_keeps_full_caps() -> None:
+    """Mirror case: kb_manager on knowledge-seat gets the full KM cap-set."""
+    db = _db_with_row(_row(role="kb_manager", plan="knowledge", seat_type="knowledge"))
+    perms = await resolve_user_permissions("uid-test", db)
+    assert perms is not None
+    assert perms.effective_capabilities == frozenset(
+        {
+            Capability.KB_CONNECTORS,
+            Capability.KB_CONNECTORS_EXTERNAL,
+            Capability.KB_CREATE_ORG,
+            Capability.KB_MEMBERS,
+            Capability.KB_TAXONOMY,
+            Capability.KB_GAPS,
+        }
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Phase 4 — capability axis swap

Swaps the request-time capability intersection from plan to seat_type.

**Before**: `PROFILE_CAPABILITIES[role] ∩ PLAN_LIMITS[org.plan].capabilities`
**After**: `PROFILE_CAPABILITIES[role]` filtered through `CAPABILITY_TO_SEAT_FEATURE` against `SEAT_FEATURES[user.seat_type]`

A kb_manager on a chat-seat now gets only `kb.connectors` (Phase 1's `effective_capabilities` helper, now wired into the resolver). Admin-bypass preserved — admin on any seat sees full KNOWLEDGE-tier caps.

## SPEC AC addressed

| AC | Status |
|---|---|
| AC-6 (effective_capabilities filtered through seat) | ✓ on the capability axis |

The kb-quota max-counts (`max_personal_kbs_per_user`, `max_items_per_kb`, `can_create_org_kbs`) still flow through `effective_kb_limits(role, plan)` and three sites in `services/kb_quota.py`. The Phase 4 SPEC bullet "quotas move into SEAT_FEATURES derivation" is **deferred** to a Phase 5 sweep — same axis-swap pattern, different file.

## Changes

- `app/core/permissions.py::_derive_effective_capabilities` takes `(role, seat_type)`, delegates to `app.core.seats.effective_capabilities`.
- `UserPermissions` gains `seat_type: str` (defaulted to `"chat"` so test constructors that pre-date Phase 4 still build).
- `tests/conftest.py::make_perms` accepts `seat_type=` + defaults to `suggest_seat(role)`.
- `tests/test_permissions.py::_row` accepts `seat_type=` with the same default.
- Replaced `test_resolve_personal_on_free_gets_no_capabilities` (free-plan signal is gone since Phase 3) with three new tests:
  - personal + viewer seat → empty set
  - kb_manager + chat seat → `{kb.connectors}` only
  - kb_manager + knowledge seat → full KM cap-set

## Out of scope

- Phase 5: Moneybird per-seat line-items (per-tenant opt-in) + kb-quota seat-axis swap
- Phase 6: deprecate `portal_orgs.{plan,seats}` columns + drop `ALLOWED_PROFILES_PER_PLAN` + delete `assert_role_allowed_for_plan`

## Verification

```
Backend pytest: 2595 passed, 0 regressions
ruff check + fmt: clean
pyright: 0 errors
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)