### PR TITLE
refactor(portal-frontend): SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 — extract shared wizard code + file-organization rule

### DIFF
--- a/.claude/rules/klai/projects/portal-frontend.md
+++ b/.claude/rules/klai/projects/portal-frontend.md
@@ -308,6 +308,72 @@ Never use a modal for table row actions.
 
 ---
 
+## File organization for shared types and helpers
+
+When two or more route files share types, constants, or non-route helpers,
+the location is decided by **smallest-shared scope**, not by convenience.
+
+### Decision tree
+
+1. **Used by one route file only?** → declare inline, or in a colocated
+   `_components/` directory if it's a sub-component split.
+2. **Used by 2+ route files within one directory?** → extract to a
+   `-`-prefixed sibling file in that directory:
+   `-<feature>-{types,helpers,hooks,query-keys,feedback}.{ts,tsx}`.
+3. **Used by 2+ route files across sibling directories under one common
+   parent?** → extract to a `-`-prefixed file in **that common parent**,
+   not in either subdirectory.
+4. **Used by 3+ unrelated areas (admin, app, setup, login)?** → it's
+   app-wide infrastructure; goes in `@/lib/`. Examples already there:
+   `apiFetch`, `auth`, `logger`, `locale`. Feature-specific types do
+   NOT belong in `@/lib/`.
+
+### Naming
+
+- File: `-<feature>-{types,helpers,hooks,query-keys,feedback}.{ts,tsx}`.
+  Pure type files use `.ts`. Files with JSX (components, render helpers)
+  use `.tsx`.
+- Directory: `_components/` for a directory of sub-components owned by
+  one route. TanStack Router ignores both `-` prefix files and `_`
+  prefix directories.
+- Feature segment is kebab-case and matches the feature folder it sits
+  in (e.g. `-bronnen-types.ts` next to `bronnen.tsx`).
+
+### Anti-patterns
+
+- **Cross-route imports.** `import { X } from './sibling-route'` where
+  `sibling-route.tsx` is a route file is always a smell. Extract `X` to
+  a `-`-prefixed sibling file at the smallest-shared scope. Tests
+  importing from a route file have the same smell.
+
+- **Cross-directory `-` imports.** `import from './sub/-foo'` from a
+  file that lives one level above `sub/` means the helper is in the
+  wrong directory. The helper should live at the parent level (one
+  directory up). Existing instances are tactical legacy; new code
+  must follow rule 3 above.
+
+- **Feature types in `@/lib/`.** `@/lib/` is for app-wide infrastructure
+  (API client, auth, logger). Feature-specific types pollute the
+  namespace and lose the smallest-shared-scope signal. The exception is
+  a small (< 30 lines) tactical helper used by exactly one feature
+  (e.g. `lib/ms-docs.ts`); even then, prefer a `-`-prefixed sibling.
+
+- **Duplicate definitions across files.** If `interface FooConfig`
+  appears in more than one file with the same body, that's a bug
+  waiting to happen. Extract per the decision tree, even if the
+  current usage is "just two files".
+
+### Why this matters
+
+Feature-local ad-hoc choices have produced five different shared-helper
+locations in this codebase (`-kb-helpers.tsx`, `-kb-types.ts`,
+`-bronnen-helpers.tsx`, `admin/api-keys/-types.ts`, `admin/widgets/-types.ts`).
+Each was a reasonable choice in isolation; together they make "where
+does this type belong" an open question every time. The decision tree
+above is the answer — apply it before adding a new shared file.
+
+---
+
 ## Multi-step wizard password fields (MED)
 
 Any wizard step containing a `type="password"` or secret input must be wrapped in a

--- a/.moai/specs/SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001/spec.md
+++ b/.moai/specs/SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001/spec.md
@@ -1,0 +1,554 @@
+---
+id: SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001
+version: 0.2.0
+status: ready
+created: 2026-05-12
+author: Mark Vletter
+priority: medium
+parent: SPEC-PORTAL-SOURCES-RENAME-001 (out-of-scope follow-up — same god-component pattern, separate UX surface)
+related:
+  - SPEC-PORTAL-SOURCES-RENAME-001 (sibling cleanup of bronnen.tsx)
+  - SPEC-REFACTOR-001 (origin of the `-kb-helpers.tsx` / `-kb-types.ts` pattern)
+rule:
+  - .claude/rules/klai/projects/portal-frontend.md § "File organization for shared types and helpers" (added in this SPEC's preflight commit)
+---
+
+# SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 — Extract shared wizard code per the new file-organization rule
+
+## Goal
+
+Eliminate the byte-identical duplication between
+`$kbSlug_.add-connector.tsx` (1415 lines) and
+`$kbSlug_.edit-connector.$connectorId.tsx` (1272 lines) by applying the
+file-organization rule added to `portal-frontend.md`. Concretely:
+
+1. Stop add-connector from re-declaring symbols that already exist in
+   `$kbSlug/-kb-helpers.tsx` and `$kbSlug/-kb-types.ts` (which edit
+   already consumes). This is pure duplicate elimination.
+2. Extract the new wizard-only types, constants, and feedback components
+   to **the parent route directory** (`routes/app/knowledge/`), per the
+   rule's smallest-shared-scope clause. Neither `$kbSlug/-kb-types.ts`
+   (wrong scope — that's for KB-tab routes) nor `@/lib/` (wrong layer
+   — that's for app-wide infra).
+3. Remove the cross-route import (`edit-connector` imports from
+   `add-connector`) by relocating the two feedback components.
+
+Zero behavior change. The wizard renders identical DOM after the SPEC.
+
+This SPEC explicitly does NOT extract the wizard state hook
+(`useConnectorWizardState`), refactor the page god-components, or
+relocate the existing tactical-legacy cross-directory imports
+(add/edit consuming from `$kbSlug/-kb-*`). Those are tracked in the
+follow-up list below.
+
+## Motivation
+
+### 1. Triplicate symbols that the codebase already half-fixed
+
+`-kb-helpers.tsx` and `-kb-types.ts` were created in commit `c1e8ed17`
+as part of SPEC-REFACTOR-001 to host shared symbols for the KB-tab
+routes. Edit-connector later started importing from them
+(SPEC-CONNECTOR-INPUT-VALIDATION-001, commit `8e5fc770`). Add-connector
+never adopted those imports — it kept local copies. Today:
+
+| Symbol | `-kb-helpers/types` | edit-connector | add-connector |
+|---|---|---|---|
+| `ASSERTION_MODE_OPTIONS` | exported | imports it | **declares own copy (line 97-104)** |
+| `GitHubConfig` | exported | imports it | **declares own copy (line 55-61)** |
+| `WebCrawlerConfig` | exported | imports it | **declares own copy (line 63-68)** |
+
+Add a field to `GitHubConfig` and three places must change in sync. No
+TypeScript error fires when one is missed. This is the duplication the
+SPEC-REFACTOR-001 author tried to prevent; add-connector silently
+broke the property.
+
+### 2. Byte-identical wizard-only duplication add ↔ edit
+
+| Symbol | Add (line) | Edit (line) | Diff |
+|---|---|---|---|
+| `AuthProbeResult` (interface, 5 fields) | 40-45 | 92-97 | identical |
+| `AuthGuardSuggestion` (interface, 4 fields) | 70-75 | 78-83 | identical |
+| `AuthProbeClassification` (type, 5 variants) | 33-38 | own copy | identical |
+| `PreviewClassification` (type, 6 variants) | 47-53 | own copy | identical |
+| `WcStep` (type, 5 variants) | 31 | own copy | identical |
+| `MARKDOWN_PROSE_CLASSES` (~500-char Tailwind blob) | 124 | 110 | identical |
+| `AirtableConfig` ↔ `AirtableEditConfig` (4 fields) | 83-88 | 56-61 | **identical bodies, different names** |
+| `ConfluenceConfig` ↔ `ConfluenceEditConfig` (4 fields) | 90-95 | 63-68 | **identical bodies, different names** |
+| `NotionConfig` ↔ `NotionEditConfig` (3 fields) | 77-81 | 50-54 | **subtly different — intentional, but invisible to either reader** |
+
+These are NOT in `-kb-*` because they're wizard-specific (auth-probe,
+preview-classification, web-crawler step machine, Notion OAuth shape).
+The KB-tab routes don't use them. Per the new rule's clause 3
+(smallest-shared scope across sibling directories), they belong at the
+**parent route directory**:
+`klai-portal/frontend/src/routes/app/knowledge/-connector-*.{ts,tsx}`.
+Not inside `$kbSlug/`, where the scope is wrong.
+
+### 3. Cross-route import smell
+
+```ts
+// $kbSlug_.edit-connector.$connectorId.tsx:21
+import {
+  AuthProbeFeedback,
+  PreviewClassificationFeedback,
+} from './$kbSlug_.add-connector'
+```
+
+Plus two test files (`__tests__/wizard-feedback.test.tsx`,
+`__tests__/edit-wizard-step-deep-link.test.tsx`) that also import
+these two components from the route file. The new rule forbids this
+exactly: "Cross-route imports. Tests importing from a route file have
+the same smell. Extract `X` to a `-`-prefixed sibling file at the
+smallest-shared scope."
+
+## Scope
+
+### In
+
+**Preflight** (one commit, lands BEFORE the rest of the SPEC):
+
+- Add the "File organization for shared types and helpers" section to
+  `.claude/rules/klai/projects/portal-frontend.md`. (Already done in
+  this SPEC's working set; a clean commit pulls it onto main.)
+
+**Frontend** (`klai-portal/frontend/src/routes/app/knowledge/`):
+
+- New file `-connector-types.ts` (parent route directory) containing
+  wizard-specific types:
+  `AuthProbeClassification`, `AuthProbeResult`, `AuthGuardSuggestion`,
+  `PreviewClassification`, `PreviewResult`, `WcStep`, `ConnectorType`,
+  `AirtableConfig` (single name, drop `AirtableEditConfig`),
+  `ConfluenceConfig` (single name, drop `ConfluenceEditConfig`),
+  `NotionAddConfig` + `NotionEditConfig` + `NotionConfig` discriminated
+  union (Option A — names retained, no `mode` tag), `StepDeepLink`.
+
+- New file `-connector-constants.ts` (parent route directory) with
+  wizard-specific constants:
+  `MARKDOWN_PROSE_CLASSES`, `VALID_PRESELECT_TYPES`, `VALID_STEPS`.
+
+- New file `-connector-feedback.tsx` (parent route directory) with
+  wizard-specific render helpers:
+  `AuthProbeFeedback`, `PreviewClassificationFeedback`.
+
+- Modify `$kbSlug_.add-connector.tsx`:
+  - Remove the 9 wizard-specific type/interface declarations (now in
+    `./-connector-types`).
+  - Remove the 3 wizard-specific constants (now in
+    `./-connector-constants`).
+  - Remove the 2 feedback component definitions (now in
+    `./-connector-feedback`).
+  - Remove the 3 **duplicate** declarations that already exist in
+    `$kbSlug/-kb-*`: `ASSERTION_MODE_OPTIONS`, `GitHubConfig`,
+    `WebCrawlerConfig`. Import them from
+    `./$kbSlug/-kb-helpers` and `./$kbSlug/-kb-types` (matching what
+    edit-connector already does).
+  - Add the new sibling-file imports.
+
+- Modify `$kbSlug_.edit-connector.$connectorId.tsx`:
+  - Remove the 9 wizard-specific type/interface declarations (now in
+    `./-connector-types`). Rename `AirtableEditConfig` →
+    `AirtableConfig`, `ConfluenceEditConfig` → `ConfluenceConfig` at
+    every usage site.
+  - Remove the 2 wizard-specific constants (now in
+    `./-connector-constants`).
+  - Replace `import ... from './$kbSlug_.add-connector'` with
+    `import ... from './-connector-feedback'`.
+  - Update Notion config usage to consume the discriminated union
+    shape (`NotionAddConfig` / `NotionEditConfig` retained; field
+    semantics unchanged).
+
+- Modify `__tests__/wizard-feedback.test.tsx`:
+  - Change import from `'../$kbSlug_.add-connector'` to
+    `'../-connector-feedback'`. No assertion changes.
+
+- Modify `__tests__/edit-wizard-step-deep-link.test.tsx`:
+  - Change import of `PreviewClassificationFeedback` from
+    `'../$kbSlug_.add-connector'` to `'../-connector-feedback'`.
+
+### Out (explicit)
+
+- **`useConnectorWizardState` hook extraction** — 22 shared `useState`
+  declarations + `authProbeMutation` + `previewMutation`. Real win,
+  real risk (Notion OAuth + 81-line prefill `useEffect` in edit).
+  Tracked under § Follow-ups.
+- **Splitting `AddConnectorPage` / `EditConnectorPage` into per-step
+  sub-components**. Tracked under § Follow-ups.
+- **Relocating tactical-legacy cross-directory imports** from
+  `$kbSlug/-kb-helpers.tsx` / `-kb-types.ts` upward to the parent
+  route directory. The new rule says new code must follow
+  smallest-shared scope; existing legacy is grandfathered. A future
+  SPEC can hoist them if scope-mismatch becomes painful.
+- **TaxonomyTab refactor**, the `insights.tsx` cross-route import,
+  and the other 6 god-components below 600 lines. All tracked under
+  § Follow-ups.
+- **`useCallback` / `useMemo` for re-render hygiene** — folded into
+  the future hook-extraction SPEC.
+- **ESLint rule preventing future cross-route imports** — nice to
+  have. Tracked under § Follow-ups.
+
+### Backend changes summary
+
+None. Frontend-only. No alembic migration, no API change, no env var.
+
+## Requirements (EARS)
+
+### Functional
+
+- **REQ-1**: When a contributor opens `$kbSlug_.add-connector.tsx`
+  after this SPEC, the file shall NOT contain inline declarations of
+  `AuthProbeResult`, `AuthGuardSuggestion`, `AuthProbeClassification`,
+  `PreviewClassification`, `PreviewResult`, `WcStep`,
+  `AirtableConfig`/`AirtableEditConfig`,
+  `ConfluenceConfig`/`ConfluenceEditConfig`, `NotionConfig`/`NotionEditConfig`,
+  `MARKDOWN_PROSE_CLASSES`, `VALID_PRESELECT_TYPES`,
+  `ASSERTION_MODE_OPTIONS`, `GitHubConfig`, `WebCrawlerConfig`. Each
+  shall be imported from either `./-connector-types`,
+  `./-connector-constants`, `./$kbSlug/-kb-helpers`, or
+  `./$kbSlug/-kb-types`.
+
+- **REQ-2**: When a contributor opens
+  `$kbSlug_.edit-connector.$connectorId.tsx` after this SPEC, the file
+  shall NOT contain inline declarations of any symbol listed in REQ-1
+  NOR declarations of `AirtableEditConfig`, `ConfluenceEditConfig`
+  (those names cease to exist; the shape is named `AirtableConfig` /
+  `ConfluenceConfig` going forward), and shall NOT contain
+  `import ... from './$kbSlug_.add-connector'`.
+
+- **REQ-3**: When `AddConnectorPage` or `EditConnectorPage` renders
+  the auth-probe feedback panel, the system shall render
+  `<AuthProbeFeedback>` imported from `./-connector-feedback`. DOM
+  output shall be byte-identical to the current behavior (verified by
+  the existing snapshot text-match tests in `wizard-feedback.test.tsx`).
+
+- **REQ-4**: When `AddConnectorPage` or `EditConnectorPage` renders
+  the preview-classification feedback panel, the system shall render
+  `<PreviewClassificationFeedback>` imported from
+  `./-connector-feedback`. DOM output shall be byte-identical.
+
+- **REQ-5**: When the Notion-add flow stores OAuth credentials, the
+  system shall use the `NotionAddConfig` shape. When the Notion-edit
+  flow stores updated credentials, the system shall use the
+  `NotionEditConfig` shape. Field semantics: `access_token` (required,
+  add) vs `new_access_token` (optional, edit) — current behavior
+  preserved. The `NotionConfig` discriminated union exposes both
+  shapes for shared consumers.
+
+- **REQ-6**: When the deep-link search-param parser in
+  `EditConnectorPage` validates a `step` value, it shall consult
+  `VALID_STEPS` imported from `./-connector-constants`. Behavior
+  identical: reject any value not in the set.
+
+- **REQ-7**: When the URL-param parser in `AddConnectorPage`
+  validates a `type` value, it shall consult `VALID_PRESELECT_TYPES`
+  imported from `./-connector-constants`. Behavior identical.
+
+### Non-functional
+
+- **REQ-8**: After this SPEC, `tsc --noEmit` on `klai-portal/frontend`
+  shall pass with zero errors. `bun run lint` (which is `eslint .`)
+  shall pass with zero errors.
+
+- **REQ-9**: After this SPEC, `vitest run` (the project test command,
+  per `package.json`) on the
+  `klai-portal/frontend/src/routes/app/knowledge/__tests__/`
+  directory shall pass with the same assertion count as the
+  pre-extraction run. Every assertion translated 1:1.
+
+- **REQ-10**: After this SPEC, line counts shall satisfy:
+  - `$kbSlug_.add-connector.tsx` ≤ 1280 lines (down from 1415)
+  - `$kbSlug_.edit-connector.$connectorId.tsx` ≤ 1240 lines (down from 1272)
+  - `-connector-types.ts` ≤ 100 lines
+  - `-connector-constants.ts` ≤ 50 lines
+  - `-connector-feedback.tsx` ≤ 130 lines
+
+  Upper bounds, not targets. Verify the extraction did not drag
+  unrelated logic out by accident.
+
+- **REQ-11**: `git grep -nE 'interface (AuthProbeResult|AuthGuardSuggestion|AirtableConfig|AirtableEditConfig|ConfluenceConfig|ConfluenceEditConfig|NotionConfig|NotionEditConfig)\b' klai-portal/frontend/src` shall return matches ONLY in `-connector-types.ts`.
+
+- **REQ-12**: `git grep -nE 'MARKDOWN_PROSE_CLASSES = ' klai-portal/frontend/src` shall return exactly ONE definition site (in `-connector-constants.ts`).
+
+- **REQ-13**: `git grep -nE 'interface (GitHubConfig|WebCrawlerConfig)\b' klai-portal/frontend/src` shall return matches ONLY in `$kbSlug/-kb-types.ts` (canonical location). Add-connector's local copies are removed.
+
+- **REQ-14**: `git grep -nE 'ASSERTION_MODE_OPTIONS\s*[:=]' klai-portal/frontend/src` shall return exactly ONE definition site (in `$kbSlug/-kb-helpers.tsx`).
+
+## Acceptance Criteria
+
+1. The "File organization for shared types and helpers" section is
+   present in `portal-frontend.md` in the same PR (preflight commit).
+2. Three new files exist:
+   `klai-portal/frontend/src/routes/app/knowledge/-connector-types.ts`,
+   `-connector-constants.ts`, `-connector-feedback.tsx`.
+3. `git grep -n "interface AirtableEditConfig\|interface ConfluenceEditConfig" klai-portal/frontend/src`
+   returns zero hits.
+4. `git grep -n "from './\$kbSlug_.add-connector'" klai-portal/frontend/src`
+   returns zero hits (the cross-route import is eliminated).
+5. `git grep -n "ASSERTION_MODE_OPTIONS\s*[:=]" klai-portal/frontend/src/routes/app/knowledge/\$kbSlug_.add-connector.tsx`
+   returns zero hits (local duplicate removed; imported from
+   `./$kbSlug/-kb-helpers`).
+6. `git grep -n "interface GitHubConfig\|interface WebCrawlerConfig" klai-portal/frontend/src/routes/app/knowledge/\$kbSlug_.add-connector.tsx`
+   returns zero hits.
+7. `wc -l` line-count caps from REQ-10 satisfied.
+8. `tsc --noEmit` reports zero errors. `bun run lint` reports zero errors.
+9. The two test files in `__tests__/` pass with imports re-pointed to
+   `-connector-feedback`. Same assertion count.
+10. Playwright smoke (Playwright MCP) on a real KB:
+    - Add web_crawler with auth-required URL → cookie step → auth-probe
+      → see `<AuthProbeFeedback>` panel render with the expected
+      classification message. Same flow on edit. Screenshots compared
+      pixel-identical.
+    - Add → fill selector → run preview → see
+      `<PreviewClassificationFeedback>` panel render. Same on edit.
+      Same comparison.
+11. `git diff --stat` shows: 1 rule file modified (preflight), 3 files
+    added (`-connector-*`), 4 files modified (2 routes + 2 tests).
+    `routeTree.gen.ts` byte-identical (no semantic drift; new files
+    are `-`-prefixed and ignored).
+
+## Implementation Plan
+
+The SPEC ships as one PR with ordered commits. Each commit
+independently green (`tsc --noEmit` + lint + tests).
+
+**Methodology**: DDD (ANALYZE-PRESERVE-IMPROVE). Pure structural
+extraction, but the wizards have live behavior — the existing
+`wizard-feedback.test.tsx` tests already cover all 5 AuthProbeFeedback
+classifications + all 6 PreviewClassificationFeedback cases (verified
+2026-05-12). Use them as the characterization gate.
+
+### Phase 0 — Worktree + verify baseline
+
+- `git worktree add ../klai-connector-extract -b feat/SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 origin/main`
+- Verify `vitest run __tests__/wizard-feedback.test.tsx` and
+  `vitest run __tests__/edit-wizard-step-deep-link.test.tsx` are
+  green against current code.
+- Verify `tsc --noEmit` is green.
+- Snapshot baseline: capture line counts of the two route files
+  (`wc -l`) for later REQ-10 comparison.
+- No new tests in this phase. The existing tests are sufficient
+  characterization for the components being moved; the route-file
+  changes are pure import-rewrites that `tsc --noEmit` validates.
+
+### Phase 1 — Preflight: rule on portal-frontend.md (single commit)
+
+- Commit the new "File organization for shared types and helpers"
+  section to `.claude/rules/klai/projects/portal-frontend.md`.
+- This commit is independent of the code changes; it documents the
+  decision the rest of the SPEC follows.
+
+### Phase 2 — Eliminate triplicates against `-kb-*` (single commit)
+
+- In `add-connector.tsx`:
+  - Remove the local `ASSERTION_MODE_OPTIONS` constant (lines 97-104).
+  - Remove the local `GitHubConfig` interface (lines 55-61).
+  - Remove the local `WebCrawlerConfig` interface (lines 63-68).
+  - Add to existing import block:
+    `import { ASSERTION_MODE_OPTIONS, joinSeedUrl } from './$kbSlug/-kb-helpers'`
+    (joinSeedUrl already imported per SPEC's grep).
+    `import type { GitHubConfig, WebCrawlerConfig } from './$kbSlug/-kb-types'`
+    (or merge with existing `import type { CookieRow } from './$kbSlug/-kb-types'`).
+- `tsc --noEmit` will surface every missed reference.
+- Lint + tests green.
+
+This is the most surgical commit and confirms add-connector is now
+aligned with edit-connector on what they import from `-kb-*`.
+
+### Phase 3 — Extract wizard-only constants (single commit)
+
+- Create `klai-portal/frontend/src/routes/app/knowledge/-connector-constants.ts`
+  with `MARKDOWN_PROSE_CLASSES`, `VALID_PRESELECT_TYPES`, `VALID_STEPS`.
+- `add-connector.tsx`: remove the 3 inline definitions, add import.
+- `edit-connector.$connectorId.tsx`: remove `MARKDOWN_PROSE_CLASSES`
+  and `VALID_STEPS` inline definitions, add import.
+- `tsc --noEmit` + lint + tests green.
+
+### Phase 4 — Extract wizard-only types (single commit)
+
+- Create `klai-portal/frontend/src/routes/app/knowledge/-connector-types.ts`.
+- Move: `AuthProbeClassification`, `AuthProbeResult`, `AuthGuardSuggestion`,
+  `PreviewClassification`, `PreviewResult`, `WcStep`, `ConnectorType`,
+  `AirtableConfig`, `ConfluenceConfig`, `NotionAddConfig`,
+  `NotionEditConfig`, `NotionConfig` (discriminated union, Option A),
+  `StepDeepLink`.
+- Update both route files: remove inline declarations, add imports.
+- Rename usage sites in `edit-connector.tsx`:
+  `AirtableEditConfig` → `AirtableConfig`,
+  `ConfluenceEditConfig` → `ConfluenceConfig`. NotionEditConfig keeps
+  its name (it's now exported from `-connector-types.ts` as part of
+  the union).
+- `tsc --noEmit` is the mechanical guarantee that no rename was missed.
+- Lint + tests green.
+
+### Phase 5 — Extract feedback components (single commit)
+
+- Create `klai-portal/frontend/src/routes/app/knowledge/-connector-feedback.tsx`
+  with `AuthProbeFeedback` (currently in add lines 1315-1350) and
+  `PreviewClassificationFeedback` (lines 1358-1414) lifted verbatim.
+- `add-connector.tsx`: remove the two component definitions, add
+  `import { AuthProbeFeedback, PreviewClassificationFeedback } from './-connector-feedback'`.
+  No re-export shim. The two test files are updated in this same
+  commit so no soak-window is needed.
+- `edit-connector.$connectorId.tsx`: change the
+  `'./$kbSlug_.add-connector'` import to `'./-connector-feedback'`.
+- `__tests__/wizard-feedback.test.tsx`: change import path to
+  `'../-connector-feedback'`.
+- `__tests__/edit-wizard-step-deep-link.test.tsx`: change import path
+  to `'../-connector-feedback'`.
+- `tsc --noEmit` + lint + characterization tests green. Tests should
+  pass without any assertion change — if they do not, you've leaked
+  logic during the move; revert and restart.
+
+### Phase 6 — QA + ship
+
+- `bun run lint` zero errors.
+- `tsc --noEmit` zero errors.
+- `bun run build` green.
+- `vitest run` zero failures across the whole frontend test suite.
+- Playwright smoke (Playwright MCP):
+  - Add web_crawler → auth-required → cookie-paste → auth-probe →
+    screenshot the feedback panel.
+  - Edit the same connector → same flow → screenshot.
+  - Compare screenshots: pixel-identical.
+  - Add → fill selector → run preview → screenshot the classification
+    feedback. Same on edit. Same comparison.
+- Open PR with the checklist below.
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Notion config rename misses a usage site | Medium | Medium | `tsc --noEmit` catches structural mismatches. Phase 4 commit message lists every renamed identifier; reviewer greps for each. |
+| `routeTree.gen.ts` regenerates with noise (`-`-prefix not honored on a non-default config) | Very low — verified `routeFileIgnorePrefix` defaults to `-` and `-kb-helpers.tsx` is already correctly skipped | Low | Verify `routeTree.gen.ts` byte-identical after the PR. If it changes, the prefix convention is misunderstood; revert and use `_components/` instead. |
+| Existing tests catch a rendering difference (broken extraction) | Low — verbatim move | Medium | Phase 5 explicitly halts if tests fail. Revert and re-do with finer-grained diff. |
+| Phase 4 Notion union design choice creeps to a `mode`-tagged variant mid-PR | Medium | Medium | Phase 4 commit message MUST start with the literal text "Notion union: Option A — names retained, no mode tag". A `mode`-tagged shape is a different SPEC. |
+| Cross-directory imports added in Phase 2 (`./$kbSlug/-kb-*`) ARE the smell the new rule warns about | High — they are tactical legacy | Low | Acknowledged. Adding two more import statements in add-connector matches what edit already does, eliminates duplicates today, and waits for the future scope-hoist SPEC to relocate. The alternative (creating a third copy in a fresh file) is worse. |
+| Vitest does not pick up new files due to glob mismatch | Very low | Low | `vitest.config.ts` uses default test glob; new files in `__tests__/` work. Verified Phase 0. |
+| Hidden coupling: edit-connector relies on a side effect of importing from add-connector | Very low — verified by reading both files; only two named imports, no side effects | High if true | Phase 5 commit MUST be tested with edit-connector page actually loading in dev. If it crashes on load, the import was load-bearing. |
+
+## PR Description Checklist
+
+- [ ] No backend changes. No alembic migration. No API change. No env var.
+- [ ] `portal-frontend.md` § "File organization for shared types and helpers" present (preflight commit).
+- [ ] Three new files: `routes/app/knowledge/-connector-types.ts`, `-connector-constants.ts`, `-connector-feedback.tsx`.
+- [ ] `git grep -n "interface AirtableEditConfig\|interface ConfluenceEditConfig" klai-portal/frontend/src` zero hits.
+- [ ] `git grep -n "from './\$kbSlug_.add-connector'" klai-portal/frontend/src` zero hits.
+- [ ] `git grep -n "ASSERTION_MODE_OPTIONS\s*[:=]" klai-portal/frontend/src/routes/app/knowledge/\$kbSlug_.add-connector.tsx` zero hits.
+- [ ] `git grep -n "interface GitHubConfig\|interface WebCrawlerConfig" klai-portal/frontend/src/routes/app/knowledge/\$kbSlug_.add-connector.tsx` zero hits.
+- [ ] `git grep -nE 'interface (AuthProbeResult|AuthGuardSuggestion|AirtableConfig|ConfluenceConfig)\b' klai-portal/frontend/src` returns matches only in `-connector-types.ts`.
+- [ ] `wc -l` caps from REQ-10 satisfied.
+- [ ] `tsc --noEmit` green. `bun run lint` green. `bun run build` green.
+- [ ] Existing `__tests__/wizard-feedback.test.tsx` and `__tests__/edit-wizard-step-deep-link.test.tsx` pass with re-pointed imports. Same assertion count.
+- [ ] `routeTree.gen.ts` byte-identical.
+- [ ] Playwright smoke verified: auth-probe panel and preview-classification panel render identically on add and edit. Screenshots attached to PR.
+- [ ] Notion union design choice: Option A (no `mode` tag).
+- [ ] Edit-connector page loads in dev without errors after Phase 5 (verifies no hidden side-effect coupling on the old import).
+
+## Open Questions
+
+1. **`CONNECTOR_TYPES` location.** Today add-only because only the
+   add page renders the type-picker grid. If a future SPEC adds a
+   "change connector type" affordance on edit, `CONNECTOR_TYPES`
+   becomes shared too. For now: leave it in `add-connector.tsx`. If
+   extracted later, it goes into `-connector-type-catalog.tsx`
+   (separate file because it carries React Icon imports and is
+   `.tsx`, not `.ts`).
+
+2. **`StepDeepLink` location** — currently in edit only, declared
+   inline. Moved to `-connector-types.ts` because it expresses a
+   wizard-wide URL contract; if it ever grows to a multi-step
+   deep-link map shared with add, the move pays off. If reviewer
+   prefers, leave it in edit and revisit later — low-risk either way.
+
+## Follow-ups
+
+The repo-wide scan during this SPEC's drafting found a systemic
+god-component pattern. These are tracked here so the next planner
+has a starting list rather than re-discovering them. Each is a
+SEPARATE SPEC, not bundled with this one — that would violate the
+new rule's "smallest-shared scope" spirit at the SPEC level too.
+
+### Direct follow-ups to this SPEC (same wizard pages)
+
+- **F-1: `useConnectorWizardState` hook extraction.** The 22 shared
+  `useState` declarations + `authProbeMutation` + `previewMutation`
+  in both wizard pages. Real win, real risk (Notion OAuth flow + the
+  81-line prefill `useEffect` in edit, lines 223-304). Probably
+  smallest-shared-scope `-connector-state.ts` next to the new
+  `-connector-types.ts`. **Estimated effort**: ~1 day implementation,
+  needs careful behavior-preservation tests around Notion OAuth
+  redirects.
+
+- **F-2: Page god-component split.** `AddConnectorPage` (lines
+  145-1307, 1162 lines body) and `EditConnectorPage` (lines 113-1271,
+  1158 lines body). Per-step sub-components in a `_components/`
+  directory. Pre-requisite: F-1 lands first so the state hook makes
+  sub-components feasible.
+
+### Repo-wide god-component candidates (each its own SPEC)
+
+| File | Regels | useState | useEffect | mutations/queries | Profiel | SPEC priority |
+|---|---|---|---|---|---|---|
+| `$kbSlug/taxonomy.tsx` | 1088 | 16 | 2 | ~12 | `TaxonomyTab` 720 regels, 8 inline mutations, 166-regel inline `proposals.map()` callback. Cross-imported by `insights.tsx`. | High — actual code-review pain |
+| `knowledge/new.tsx` | 713 | 4 | 0 | 4 | Multi-step KB-creation wizard; types already in `new._types.ts`. Modest useState count suggests it's reasonable for its size. | Medium — likely manageable refactor |
+| `admin/billing.lazy.tsx` | 673 | 11 | 2 | 0 | 11 useState in one component without mutations/queries is unusual — local form state machine. | Medium |
+| `setup/mfa.lazy.tsx` | 668 | **19** | 3 | 0 | 19 useState — highest in the codebase. Multi-step MFA setup. Strong refactor candidate. | High — fragility risk |
+| `app/transcribe/add.tsx` | 530 | 12 | 4 | 3 | Transcribe upload form. | Medium |
+| `admin/settings.tsx` | 524 | 9 | 3 | 9 | 9 mutations inline → mutation-hooks extraction. | Medium |
+| `admin/users/index.tsx` | 517 | 5 | 0 | 6 | 6 mutations inline; row-level affordances likely candidate for `_components/UserRow.tsx`. | Medium |
+| `$kbSlug/members.tsx` | 497 | 7 | 0 | 10 | 10 mutations is the densest mutation-per-line in the survey; row-level affordances. | Medium-high — touchy area, well-tested |
+| `$kbSlug/connectors.tsx` | 425 | 8 | 2 | 5 | Borderline — review value of refactor before SPEC. | Low |
+
+### Architectural smells (no-SPEC-needed; can be one-PR cleanups)
+
+- **F-S1: `insights.tsx` cross-route imports.** `insights.tsx`
+  (33 lines) imports `TaxonomyTab` from `./taxonomy` (1088 lines)
+  and `KBOverviewSections` from `./overview`. Both are route files.
+  Per the new rule this is a smell. Fix: extract `TaxonomyTab` to
+  `$kbSlug/-taxonomy-component.tsx` (or co-located inside taxonomy's
+  own `_components/`) and `KBOverviewSections` to a similar place.
+  Resolves the smell and makes F-table row 1 (`taxonomy.tsx`) easier.
+
+- **F-S2: Duplicate `interface User`-like types.** Out of scope for
+  this audit; flagged for next codebase-wide types audit.
+
+- **F-S3: ESLint `no-restricted-imports` rule** preventing
+  `import from '../<route-name>.tsx'` patterns. Once the existing
+  cross-route imports are eliminated (F-S1 + this SPEC), add the
+  rule to prevent regression.
+
+### Convention adoption follow-ups
+
+- **F-C1: Audit existing `-`-prefixed files** against the new rule.
+  Five feature-local instances exist today
+  (`-kb-*`, `-bronnen-*`, `admin/api-keys/-*`, `admin/widgets/-*`,
+  `app/templates/-template-form.tsx`). Verify each matches the rule's
+  decision-tree clauses (smallest-shared scope, naming convention).
+  Cleanup-only — no new SPECs spawned unless an instance is
+  badly-placed.
+
+- **F-C2: Hoist legacy cross-directory imports.** add/edit-connector
+  consume from `$kbSlug/-kb-*` because that's where the symbols
+  happened to live. Per the new rule's clause 3, the smallest-shared
+  scope across `$kbSlug/` (KB-tabs) AND
+  `$kbSlug_.{add,edit}-connector.tsx` (wizards) is the parent
+  `routes/app/knowledge/`. A future SPEC could relocate the
+  wizard-relevant subset (`ASSERTION_MODE_OPTIONS`, `GitHubConfig`,
+  `WebCrawlerConfig`, etc.) to parent-level `-knowledge-*` files.
+  Not urgent — the legacy imports are tactical and tests catch
+  regressions.
+
+## See Also
+
+- `.moai/specs/SPEC-PORTAL-SOURCES-RENAME-001/spec.md` — sibling
+  cleanup of `bronnen.tsx`; explicitly listed this SPEC's target
+  files as out-of-scope follow-up.
+- `.claude/rules/klai/projects/portal-frontend.md` § "File
+  organization for shared types and helpers" — the rule this SPEC
+  applies. Added in the preflight commit (Phase 1).
+- `klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-kb-helpers.tsx`
+  + `-kb-types.ts` — origin of the `-`-prefixed sibling-file pattern
+  in this directory (created by SPEC-REFACTOR-001 commit `c1e8ed17`).
+- `klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source._components/`
+  — existing precedent for the `_components/` directory pattern.
+- `.claude/rules/klai/lang/typescript.md` — `tsc --noEmit` after
+  refactors, search-broadly-when-changing default rules.

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
@@ -17,69 +17,19 @@ import { apiFetch } from '@/lib/apiFetch'
 import { MS_SITE_URL_PATTERN } from '@/lib/ms-docs'
 import { joinSeedUrl, ASSERTION_MODE_OPTIONS } from './$kbSlug/-kb-helpers'
 import type { CookieRow, GitHubConfig, WebCrawlerConfig } from './$kbSlug/-kb-types'
+import type {
+  AirtableConfig,
+  AuthGuardSuggestion,
+  AuthProbeResult,
+  ConfluenceConfig,
+  ConnectorType,
+  NotionAddConfig,
+  PreviewClassification,
+  PreviewResult,
+  WcStep,
+} from './-connector-types'
 import { CookieRowsInput } from '@/components/knowledge/CookieRowsInput'
 import { kbQueryKeys } from '@/lib/kb-query-keys'
-
-// -- Types -------------------------------------------------------------------
-
-type ConnectorType =
-  | 'github' | 'web_crawler' | 'google_drive' | 'notion' | 'ms_docs'
-  | 'airtable' | 'confluence'
-  | 'google_docs' | 'google_sheets' | 'google_slides'
-// SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-1: web_crawler wizard step order is
-// Details → AuthQuestion → AuthSetup (only if requires login) → Selector → Settings.
-// AuthSetup runs the REQ-2 auth-probe; Selector gates on the REQ-3 success
-// classification. Other connector types (github/notion/...) are unaffected.
-type WcStep = 'details' | 'auth-question' | 'auth-setup' | 'selector' | 'settings'
-
-type AuthProbeClassification =
-  | 'auth_ok'
-  | 'auth_failed_no_cookies'
-  | 'auth_failed_still_walled'
-  | 'auth_failed_credentials_invalid'
-  | 'auth_failed_unreachable'
-
-interface AuthProbeResult {
-  classification: AuthProbeClassification
-  match_reasons: string[]
-  word_count: number
-  auth_guard: AuthGuardSuggestion | null
-}
-
-type PreviewClassification =
-  | 'success'
-  | 'selector_required'
-  | 'selector_returns_empty'
-  | 'requires_javascript'
-  | 'auth_wall_detected'
-  | 'unknown'
-
-interface AuthGuardSuggestion {
-  canary_url: string | null
-  canary_fingerprint: string | null
-  login_indicator_selector: string | null
-  login_indicator_description: string | null
-}
-
-interface NotionConfig {
-  access_token: string
-  database_ids: string
-  max_pages: string
-}
-
-interface AirtableConfig {
-  api_key: string
-  base_id: string
-  table_names: string
-  view_name: string
-}
-
-interface ConfluenceConfig {
-  base_url: string
-  email: string
-  api_token: string
-  space_keys: string
-}
 
 const CONNECTOR_TYPES: {
   type: ConnectorType
@@ -139,7 +89,7 @@ function AddConnectorPage() {
   // wizard collects them directly in the shape the backend persists and the
   // cron-sync consumes — no string-to-array parsing layer.
   const [wcCookieRows, setWcCookieRows] = useState<CookieRow[]>([])
-  const [notionConfig, setNotionConfig] = useState<NotionConfig>({
+  const [notionConfig, setNotionConfig] = useState<NotionAddConfig>({
     access_token: '', database_ids: '', max_pages: '500',
   })
   const [notionStep, setNotionStep] = useState<'credentials' | 'settings'>('credentials')
@@ -160,14 +110,10 @@ function AddConnectorPage() {
   const [showAdvancedSelector, setShowAdvancedSelector] = useState(false)
   const [requiresLogin, setRequiresLogin] = useState<boolean | null>(null)
   const [wcPreviewUrl, setWcPreviewUrl] = useState('')
-  const [previewResult, setPreviewResult] = useState<{
-    fit_markdown: string; word_count: number; warnings: string[]
-    content_selector: string | null; selector_source: string | null
-    auth_guard: AuthGuardSuggestion | null
-    // SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-3
-    classification: PreviewClassification
-    classification_reason: string | null
-  } | null>(null)
+  // SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-3: classification + classification_reason
+  // surface the preview-pipeline judgement to the operator. Type lives in
+  // ./-connector-types so add and edit share one shape.
+  const [previewResult, setPreviewResult] = useState<PreviewResult | null>(null)
   const [showAdvancedAuthGuard, setShowAdvancedAuthGuard] = useState(false)
   // SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-2: auth-probe state.
   const [authProbeResult, setAuthProbeResult] = useState<AuthProbeResult | null>(null)

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
@@ -28,6 +28,7 @@ import type {
   PreviewResult,
   WcStep,
 } from './-connector-types'
+import { MARKDOWN_PROSE_CLASSES, VALID_PRESELECT_TYPES } from './-connector-constants'
 import { CookieRowsInput } from '@/components/knowledge/CookieRowsInput'
 import { kbQueryKeys } from '@/lib/kb-query-keys'
 
@@ -49,14 +50,8 @@ const CONNECTOR_TYPES: {
   { type: 'google_slides', label: m.admin_connectors_type_google_slides, available: true, Icon: SiGoogleslides },
 ]
 
-const MARKDOWN_PROSE_CLASSES = 'overflow-y-auto max-h-64 text-xs [&_h1]:text-sm [&_h1]:font-semibold [&_h1]:text-gray-900 [&_h1]:mb-1 [&_h2]:text-xs [&_h2]:font-semibold [&_h2]:text-gray-900 [&_h2]:mb-1 [&_h3]:text-xs [&_h3]:font-medium [&_h3]:text-gray-900 [&_h3]:mb-1 [&_p]:text-gray-400 [&_p]:mb-1.5 [&_ul]:list-disc [&_ul]:pl-4 [&_ul]:text-gray-400 [&_ul]:mb-1.5 [&_ol]:list-decimal [&_ol]:pl-4 [&_ol]:text-gray-400 [&_ol]:mb-1.5 [&_strong]:font-semibold [&_strong]:text-gray-900 [&_hr]:border-gray-200 [&_hr]:my-2'
-
 // -- Route -------------------------------------------------------------------
 
-const VALID_PRESELECT_TYPES = new Set<ConnectorType>([
-  'github', 'notion', 'google_drive', 'google_docs', 'google_sheets', 'google_slides',
-  'airtable', 'confluence', 'ms_docs', 'web_crawler',
-])
 type AddConnectorSearch = { type?: ConnectorType }
 
 export const Route = createFileRoute('/app/knowledge/$kbSlug_/add-connector')({

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
@@ -3,7 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import {
-  ArrowLeft, ChevronRight, Settings, ChevronDown, AlertTriangle, CheckCircle2, Loader2, Sparkles, Globe, FileText, Shield,
+  ArrowLeft, ChevronRight, Settings, ChevronDown, CheckCircle2, Loader2, Sparkles, Globe, FileText, Shield,
 } from 'lucide-react'
 import { SiGithub, SiNotion, SiGoogledrive, SiAirtable, SiConfluence, SiGoogledocs, SiGooglesheets, SiGoogleslides } from '@icons-pack/react-simple-icons'
 import { Button } from '@/components/ui/button'
@@ -29,6 +29,7 @@ import type {
   WcStep,
 } from './-connector-types'
 import { MARKDOWN_PROSE_CLASSES, VALID_PRESELECT_TYPES } from './-connector-constants'
+import { AuthProbeFeedback, PreviewClassificationFeedback } from './-connector-feedback'
 import { CookieRowsInput } from '@/components/knowledge/CookieRowsInput'
 import { kbQueryKeys } from '@/lib/kb-query-keys'
 
@@ -1225,109 +1226,6 @@ function AddConnectorPage() {
   )
 }
 
-// -- Helper components -------------------------------------------------------
-
-/**
- * SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-2 — render auth-probe outcome.
- * Shared by add-connector and edit-connector flows.
- */
-export function AuthProbeFeedback({ result }: { result: AuthProbeResult }) {
-  if (result.classification === 'auth_ok') {
-    return (
-      <div className="flex gap-2 items-center rounded-lg border border-[var(--color-success)]/30 bg-[var(--color-success)]/5 p-3 text-xs text-[var(--color-success)]">
-        <CheckCircle2 className="h-3.5 w-3.5 shrink-0" />
-        <span>You&apos;re in. Continue to Selector.</span>
-      </div>
-    )
-  }
-  const reasons = result.match_reasons.length > 0
-    ? ` Detected: ${result.match_reasons.join(', ')}`
-    : ''
-  let message: string
-  switch (result.classification) {
-    case 'auth_failed_no_cookies':
-      message = 'This page requires authentication. Go back to step 3 and answer Yes.'
-      break
-    case 'auth_failed_still_walled':
-      message = `Cookies didn't unlock the content. Re-paste a fresh session cookie.${reasons}`
-      break
-    case 'auth_failed_credentials_invalid':
-      message = '401/403 — credentials rejected.'
-      break
-    case 'auth_failed_unreachable':
-      message = 'Could not reach the page. Check the Base URL.'
-      break
-    default:
-      message = `Authentication check failed.${reasons}`
-  }
-  return (
-    <div className="flex gap-2 items-start rounded-lg border border-amber-200 bg-amber-50 p-3 text-xs text-amber-800">
-      <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-      <span>{message}</span>
-    </div>
-  )
-}
-
-/**
- * SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-3 — render preview classification outcome.
- * Single source of truth for all classification-driven feedback.
- * Supporting affordances (markdown body, AI selector, auth-guard) compose alongside
- * via the parent — this component only renders the primary message.
- */
-export function PreviewClassificationFeedback({
-  classification,
-  reason,
-  onRetry,
-}: {
-  classification: PreviewClassification
-  reason: string | null
-  onRetry?: () => void
-}) {
-  if (classification === 'success') {
-    return (
-      <div className="flex gap-2 items-center rounded-lg border border-[var(--color-success)]/30 bg-[var(--color-success)]/5 p-3 text-xs text-[var(--color-success)]">
-        <CheckCircle2 className="h-3.5 w-3.5 shrink-0" />
-        <span>Selector matches real article content. You can save the connector.</span>
-      </div>
-    )
-  }
-  let message: string
-  switch (classification) {
-    case 'selector_required':
-      message =
-        reason ?? 'The output looks like a navigation menu. Configure a Content Selector.'
-      break
-    case 'selector_returns_empty':
-      message = "Selector matched no content. Try a different selector or click 'Let AI find'."
-      break
-    case 'requires_javascript':
-      message =
-        'Page renders via JavaScript. Configure a wait_for condition or selector for the post-render DOM.'
-      break
-    case 'auth_wall_detected':
-      message = 'This page requires authentication. Go back to step 4.'
-      break
-    case 'unknown':
-      message = reason ?? 'Preview service did not respond. Try again.'
-      break
-    default:
-      message = reason ?? 'Selector check failed.'
-  }
-  return (
-    <div className="space-y-2">
-      <div className="flex gap-2 items-start rounded-lg border border-amber-200 bg-amber-50 p-3 text-xs text-amber-800">
-        <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-        <span>{message}</span>
-      </div>
-      {classification === 'unknown' && onRetry && (
-        <button
-          type="button"
-          className="flex items-center gap-1 text-xs text-gray-400 hover:text-gray-900 transition-colors"
-          onClick={onRetry}
-        >
-          Retry
-        </button>
-      )}
-    </div>
-  )
-}
+// AuthProbeFeedback + PreviewClassificationFeedback live in
+// ./-connector-feedback (shared with edit-connector + tested in
+// __tests__/wizard-feedback.test.tsx).

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
@@ -11,12 +11,12 @@ import { StepIndicator, type StepItem } from '@/components/ui/step-indicator'
 import { Badge } from '@/components/ui/badge'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { MultiSelect, type MultiSelectOption } from '@/components/ui/multi-select'
+import { MultiSelect } from '@/components/ui/multi-select'
 import * as m from '@/paraglide/messages'
 import { apiFetch } from '@/lib/apiFetch'
 import { MS_SITE_URL_PATTERN } from '@/lib/ms-docs'
-import { joinSeedUrl } from './$kbSlug/-kb-helpers'
-import type { CookieRow } from './$kbSlug/-kb-types'
+import { joinSeedUrl, ASSERTION_MODE_OPTIONS } from './$kbSlug/-kb-helpers'
+import type { CookieRow, GitHubConfig, WebCrawlerConfig } from './$kbSlug/-kb-types'
 import { CookieRowsInput } from '@/components/knowledge/CookieRowsInput'
 import { kbQueryKeys } from '@/lib/kb-query-keys'
 
@@ -54,21 +54,6 @@ type PreviewClassification =
   | 'auth_wall_detected'
   | 'unknown'
 
-interface GitHubConfig {
-  installation_id: string
-  repo_owner: string
-  repo_name: string
-  branch: string
-  path_filter: string
-}
-
-interface WebCrawlerConfig {
-  base_url: string
-  path_prefix: string
-  max_pages: string
-  content_selector: string
-}
-
 interface AuthGuardSuggestion {
   canary_url: string | null
   canary_fingerprint: string | null
@@ -95,15 +80,6 @@ interface ConfluenceConfig {
   api_token: string
   space_keys: string
 }
-
-const ASSERTION_MODE_OPTIONS: MultiSelectOption[] = [
-  { value: 'factual',     label: 'Fact',        description: 'Established fact, documentation, specs' },
-  { value: 'procedural',  label: 'Procedure',   description: "Step-by-step instructions, how-to's" },
-  { value: 'belief',      label: 'Claim',       description: 'Not conclusively proven claim' },
-  { value: 'quoted',      label: 'Quote',       description: 'Literal source material' },
-  { value: 'hypothesis',  label: 'Speculation', description: 'Hypotheses, brainstorm' },
-  { value: 'unknown',     label: 'Unknown',     description: 'Type not specified' },
-]
 
 const CONNECTOR_TYPES: {
   type: ConnectorType

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
@@ -23,13 +23,21 @@ import {
   PreviewClassificationFeedback,
 } from './$kbSlug_.add-connector'
 import { kbQueryKeys } from '@/lib/kb-query-keys'
+import type {
+  AirtableConfig,
+  AuthGuardSuggestion,
+  AuthProbeResult,
+  ConfluenceConfig,
+  NotionEditConfig,
+  PreviewResult,
+  StepDeepLink,
+  WcStep,
+} from './-connector-types'
 
 // SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-1 / REQ-5: edit wizard uses the same
 // 5-step flow as add-connector. ?step=auth|selector deep-link into the wizard.
 // SPEC D-1: always require re-verify on edit entry (no pre-pass from last_sync_status).
-type WcStep = 'details' | 'auth-question' | 'auth-setup' | 'selector' | 'settings'
-
-type StepDeepLink = 'auth' | 'selector'
+// `WcStep` and `StepDeepLink` types live in ./-connector-types (shared with add).
 const VALID_STEPS = new Set<StepDeepLink>(['auth', 'selector'])
 
 function _stepToWcStep(step: StepDeepLink | undefined): WcStep | undefined {
@@ -48,66 +56,6 @@ export const Route = createFileRoute('/app/knowledge/$kbSlug_/edit-connector/$co
   }),
   component: EditConnectorPage,
 })
-
-interface NotionEditConfig {
-  database_ids: string
-  max_pages: string
-  new_access_token: string
-}
-
-interface AirtableEditConfig {
-  api_key: string
-  base_id: string
-  table_names: string
-  view_name: string
-}
-
-interface ConfluenceEditConfig {
-  base_url: string
-  email: string
-  api_token: string
-  space_keys: string
-}
-
-type PreviewClassification =
-  | 'success'
-  | 'selector_required'
-  | 'selector_returns_empty'
-  | 'requires_javascript'
-  | 'auth_wall_detected'
-  | 'unknown'
-
-interface AuthGuardSuggestion {
-  canary_url: string | null
-  canary_fingerprint: string | null
-  login_indicator_selector: string | null
-  login_indicator_description: string | null
-}
-
-type AuthProbeClassification =
-  | 'auth_ok'
-  | 'auth_failed_no_cookies'
-  | 'auth_failed_still_walled'
-  | 'auth_failed_credentials_invalid'
-  | 'auth_failed_unreachable'
-
-interface AuthProbeResult {
-  classification: AuthProbeClassification
-  match_reasons: string[]
-  word_count: number
-  auth_guard: AuthGuardSuggestion | null
-}
-
-type PreviewResult = {
-  fit_markdown: string
-  word_count: number
-  warnings: string[]
-  content_selector: string | null
-  selector_source: string | null
-  auth_guard: AuthGuardSuggestion | null
-  classification: PreviewClassification
-  classification_reason: string | null
-}
 
 const MARKDOWN_PROSE_CLASSES = 'overflow-y-auto max-h-64 text-xs [&_h1]:text-sm [&_h1]:font-semibold [&_h1]:text-gray-900 [&_h1]:mb-1 [&_h2]:text-xs [&_h2]:font-semibold [&_h2]:text-gray-900 [&_h2]:mb-1 [&_h3]:text-xs [&_h3]:font-medium [&_h3]:text-gray-900 [&_h3]:mb-1 [&_p]:text-gray-400 [&_p]:mb-1.5 [&_ul]:list-disc [&_ul]:pl-4 [&_ul]:text-gray-400 [&_ul]:mb-1.5 [&_ol]:list-decimal [&_ol]:pl-4 [&_ol]:text-gray-400 [&_ol]:mb-1.5 [&_strong]:font-semibold [&_strong]:text-gray-900 [&_hr]:border-gray-200 [&_hr]:my-2'
 
@@ -149,11 +97,11 @@ function EditConnectorPage() {
   const [msDriveId, setMsDriveId] = useState('')
   const [msSiteUrlError, setMsSiteUrlError] = useState<string | null>(null)
   // airtable (SPEC-KB-CONNECTORS-001 R3)
-  const [airtableConfig, setAirtableConfig] = useState<AirtableEditConfig>({
+  const [airtableConfig, setAirtableConfig] = useState<AirtableConfig>({
     api_key: '', base_id: '', table_names: '', view_name: '',
   })
   // confluence (SPEC-KB-CONNECTORS-001 R4)
-  const [confluenceConfig, setConfluenceConfig] = useState<ConfluenceEditConfig>({
+  const [confluenceConfig, setConfluenceConfig] = useState<ConfluenceConfig>({
     base_url: '', email: '', api_token: '', space_keys: '',
   })
 

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
@@ -33,12 +33,13 @@ import type {
   StepDeepLink,
   WcStep,
 } from './-connector-types'
+import { MARKDOWN_PROSE_CLASSES, VALID_STEPS } from './-connector-constants'
 
 // SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-1 / REQ-5: edit wizard uses the same
 // 5-step flow as add-connector. ?step=auth|selector deep-link into the wizard.
 // SPEC D-1: always require re-verify on edit entry (no pre-pass from last_sync_status).
 // `WcStep` and `StepDeepLink` types live in ./-connector-types (shared with add).
-const VALID_STEPS = new Set<StepDeepLink>(['auth', 'selector'])
+// `VALID_STEPS` constant lives in ./-connector-constants (shared too).
 
 function _stepToWcStep(step: StepDeepLink | undefined): WcStep | undefined {
   if (step === 'auth') return 'auth-setup'
@@ -56,9 +57,6 @@ export const Route = createFileRoute('/app/knowledge/$kbSlug_/edit-connector/$co
   }),
   component: EditConnectorPage,
 })
-
-const MARKDOWN_PROSE_CLASSES = 'overflow-y-auto max-h-64 text-xs [&_h1]:text-sm [&_h1]:font-semibold [&_h1]:text-gray-900 [&_h1]:mb-1 [&_h2]:text-xs [&_h2]:font-semibold [&_h2]:text-gray-900 [&_h2]:mb-1 [&_h3]:text-xs [&_h3]:font-medium [&_h3]:text-gray-900 [&_h3]:mb-1 [&_p]:text-gray-400 [&_p]:mb-1.5 [&_ul]:list-disc [&_ul]:pl-4 [&_ul]:text-gray-400 [&_ul]:mb-1.5 [&_ol]:list-decimal [&_ol]:pl-4 [&_ol]:text-gray-400 [&_ol]:mb-1.5 [&_strong]:font-semibold [&_strong]:text-gray-900 [&_hr]:border-gray-200 [&_hr]:my-2'
-
 
 function EditConnectorPage() {
   const { kbSlug, connectorId } = Route.useParams()

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
@@ -21,7 +21,7 @@ import { CookieRowsInput } from '@/components/knowledge/CookieRowsInput'
 import {
   AuthProbeFeedback,
   PreviewClassificationFeedback,
-} from './$kbSlug_.add-connector'
+} from './-connector-feedback'
 import { kbQueryKeys } from '@/lib/kb-query-keys'
 import type {
   AirtableConfig,

--- a/klai-portal/frontend/src/routes/app/knowledge/-connector-constants.ts
+++ b/klai-portal/frontend/src/routes/app/knowledge/-connector-constants.ts
@@ -1,0 +1,24 @@
+// Shared constants for the connector wizard pages.
+// Companion to `-connector-types.ts`. Per the
+// "File organization for shared types and helpers" rule
+// (.claude/rules/klai/projects/portal-frontend.md).
+
+import type { ConnectorType, StepDeepLink } from './-connector-types'
+
+// Tailwind class string applied to the markdown preview pane in both
+// wizards. Kept as a single source of truth so style changes don't
+// silently diverge between add and edit views.
+export const MARKDOWN_PROSE_CLASSES =
+  'overflow-y-auto max-h-64 text-xs [&_h1]:text-sm [&_h1]:font-semibold [&_h1]:text-gray-900 [&_h1]:mb-1 [&_h2]:text-xs [&_h2]:font-semibold [&_h2]:text-gray-900 [&_h2]:mb-1 [&_h3]:text-xs [&_h3]:font-medium [&_h3]:text-gray-900 [&_h3]:mb-1 [&_p]:text-gray-400 [&_p]:mb-1.5 [&_ul]:list-disc [&_ul]:pl-4 [&_ul]:text-gray-400 [&_ul]:mb-1.5 [&_ol]:list-decimal [&_ol]:pl-4 [&_ol]:text-gray-400 [&_ol]:mb-1.5 [&_strong]:font-semibold [&_strong]:text-gray-900 [&_hr]:border-gray-200 [&_hr]:my-2'
+
+// Valid `?type=` URL-param values for the add-connector route. Used
+// by the route's validateSearch to gate the deep-link.
+export const VALID_PRESELECT_TYPES = new Set<ConnectorType>([
+  'github', 'notion', 'google_drive', 'google_docs', 'google_sheets', 'google_slides',
+  'airtable', 'confluence', 'ms_docs', 'web_crawler',
+])
+
+// Valid `?step=` URL-param values for the edit-connector route. Used
+// by the route's validateSearch to deep-link into the auth-setup or
+// selector wizard step.
+export const VALID_STEPS = new Set<StepDeepLink>(['auth', 'selector'])

--- a/klai-portal/frontend/src/routes/app/knowledge/-connector-feedback.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/-connector-feedback.tsx
@@ -1,0 +1,121 @@
+// Shared render helpers for the connector wizard pages.
+// Companion to `-connector-types.ts` and `-connector-constants.ts`.
+// Per the "File organization for shared types and helpers" rule
+// (.claude/rules/klai/projects/portal-frontend.md).
+//
+// These two components are pure functions of their props (no internal
+// state, no side effects). They render the structured feedback for the
+// wizard's two probe outcomes:
+//   - AuthProbeFeedback: REQ-2 — auth-probe classification + reasons.
+//   - PreviewClassificationFeedback: REQ-3 — preview-pipeline judgement.
+//
+// Both are tested directly via __tests__/wizard-feedback.test.tsx (no
+// router/query-client setup required).
+
+import { AlertTriangle, CheckCircle2 } from 'lucide-react'
+import type { AuthProbeResult, PreviewClassification } from './-connector-types'
+
+/**
+ * SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-2 — render auth-probe outcome.
+ * Shared by add-connector and edit-connector flows.
+ */
+export function AuthProbeFeedback({ result }: { result: AuthProbeResult }) {
+  if (result.classification === 'auth_ok') {
+    return (
+      <div className="flex gap-2 items-center rounded-lg border border-[var(--color-success)]/30 bg-[var(--color-success)]/5 p-3 text-xs text-[var(--color-success)]">
+        <CheckCircle2 className="h-3.5 w-3.5 shrink-0" />
+        <span>You&apos;re in. Continue to Selector.</span>
+      </div>
+    )
+  }
+  const reasons = result.match_reasons.length > 0
+    ? ` Detected: ${result.match_reasons.join(', ')}`
+    : ''
+  let message: string
+  switch (result.classification) {
+    case 'auth_failed_no_cookies':
+      message = 'This page requires authentication. Go back to step 3 and answer Yes.'
+      break
+    case 'auth_failed_still_walled':
+      message = `Cookies didn't unlock the content. Re-paste a fresh session cookie.${reasons}`
+      break
+    case 'auth_failed_credentials_invalid':
+      message = '401/403 — credentials rejected.'
+      break
+    case 'auth_failed_unreachable':
+      message = 'Could not reach the page. Check the Base URL.'
+      break
+    default:
+      message = `Authentication check failed.${reasons}`
+  }
+  return (
+    <div className="flex gap-2 items-start rounded-lg border border-amber-200 bg-amber-50 p-3 text-xs text-amber-800">
+      <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+      <span>{message}</span>
+    </div>
+  )
+}
+
+/**
+ * SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-3 — render preview classification outcome.
+ * Single source of truth for all classification-driven feedback.
+ * Supporting affordances (markdown body, AI selector, auth-guard) compose alongside
+ * via the parent — this component only renders the primary message.
+ */
+export function PreviewClassificationFeedback({
+  classification,
+  reason,
+  onRetry,
+}: {
+  classification: PreviewClassification
+  reason: string | null
+  onRetry?: () => void
+}) {
+  if (classification === 'success') {
+    return (
+      <div className="flex gap-2 items-center rounded-lg border border-[var(--color-success)]/30 bg-[var(--color-success)]/5 p-3 text-xs text-[var(--color-success)]">
+        <CheckCircle2 className="h-3.5 w-3.5 shrink-0" />
+        <span>Selector matches real article content. You can save the connector.</span>
+      </div>
+    )
+  }
+  let message: string
+  switch (classification) {
+    case 'selector_required':
+      message =
+        reason ?? 'The output looks like a navigation menu. Configure a Content Selector.'
+      break
+    case 'selector_returns_empty':
+      message = "Selector matched no content. Try a different selector or click 'Let AI find'."
+      break
+    case 'requires_javascript':
+      message =
+        'Page renders via JavaScript. Configure a wait_for condition or selector for the post-render DOM.'
+      break
+    case 'auth_wall_detected':
+      message = 'This page requires authentication. Go back to step 4.'
+      break
+    case 'unknown':
+      message = reason ?? 'Preview service did not respond. Try again.'
+      break
+    default:
+      message = reason ?? 'Selector check failed.'
+  }
+  return (
+    <div className="space-y-2">
+      <div className="flex gap-2 items-start rounded-lg border border-amber-200 bg-amber-50 p-3 text-xs text-amber-800">
+        <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+        <span>{message}</span>
+      </div>
+      {classification === 'unknown' && onRetry && (
+        <button
+          type="button"
+          className="flex items-center gap-1 text-xs text-gray-400 hover:text-gray-900 transition-colors"
+          onClick={onRetry}
+        >
+          Retry
+        </button>
+      )}
+    </div>
+  )
+}

--- a/klai-portal/frontend/src/routes/app/knowledge/-connector-types.ts
+++ b/klai-portal/frontend/src/routes/app/knowledge/-connector-types.ts
@@ -1,0 +1,108 @@
+// Shared types for the connector wizard pages.
+// Consumed by both `$kbSlug_.add-connector.tsx` and
+// `$kbSlug_.edit-connector.$connectorId.tsx`. Per the
+// "File organization for shared types and helpers" rule
+// (.claude/rules/klai/projects/portal-frontend.md), wizard-specific
+// shared types live at the parent route level — NOT in `$kbSlug/-kb-types.ts`
+// (wrong scope: that file is for KB-tab routes inside `$kbSlug/`).
+//
+// Connector-types that are also used by KB-tab routes (e.g. `GitHubConfig`,
+// `WebCrawlerConfig`, `CookieRow`, `ConnectorSummary`) live in
+// `$kbSlug/-kb-types.ts` because they predate this split. A future SPEC
+// (F-C2 in SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 § Follow-ups) may
+// hoist them to a parent-level shared file too.
+
+// SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-1: web_crawler wizard step order is
+// Details → AuthQuestion → AuthSetup (only if requires login) → Selector → Settings.
+// AuthSetup runs the REQ-2 auth-probe; Selector gates on the REQ-3 success
+// classification. Other connector types (github/notion/...) are unaffected.
+export type WcStep = 'details' | 'auth-question' | 'auth-setup' | 'selector' | 'settings'
+
+// Edit-only deep-link contract: ?step=auth|selector navigates the user
+// directly to the auth-setup or selector step on the edit wizard.
+export type StepDeepLink = 'auth' | 'selector'
+
+export type ConnectorType =
+  | 'github' | 'web_crawler' | 'google_drive' | 'notion' | 'ms_docs'
+  | 'airtable' | 'confluence'
+  | 'google_docs' | 'google_sheets' | 'google_slides'
+
+export type AuthProbeClassification =
+  | 'auth_ok'
+  | 'auth_failed_no_cookies'
+  | 'auth_failed_still_walled'
+  | 'auth_failed_credentials_invalid'
+  | 'auth_failed_unreachable'
+
+export interface AuthGuardSuggestion {
+  canary_url: string | null
+  canary_fingerprint: string | null
+  login_indicator_selector: string | null
+  login_indicator_description: string | null
+}
+
+export interface AuthProbeResult {
+  classification: AuthProbeClassification
+  match_reasons: string[]
+  word_count: number
+  auth_guard: AuthGuardSuggestion | null
+}
+
+export type PreviewClassification =
+  | 'success'
+  | 'selector_required'
+  | 'selector_returns_empty'
+  | 'requires_javascript'
+  | 'auth_wall_detected'
+  | 'unknown'
+
+export type PreviewResult = {
+  fit_markdown: string
+  word_count: number
+  warnings: string[]
+  content_selector: string | null
+  selector_source: string | null
+  auth_guard: AuthGuardSuggestion | null
+  classification: PreviewClassification
+  classification_reason: string | null
+}
+
+// Per-connector form-state shapes.
+//
+// `AirtableConfig` and `ConfluenceConfig` are identical in add and edit;
+// the previous `*EditConfig` names were just textual duplicates.
+//
+// `Notion*` is the exception: add takes a fresh `access_token`, edit
+// takes an optional `new_access_token` (existing token is held by the
+// connector record). The discriminated union `NotionConfig` exposes
+// both shapes for shared consumers (e.g. a future
+// `useConnectorWizardState` hook); each page keeps consuming its own
+// branch directly.
+
+export interface AirtableConfig {
+  api_key: string
+  base_id: string
+  table_names: string
+  view_name: string
+}
+
+export interface ConfluenceConfig {
+  base_url: string
+  email: string
+  api_token: string
+  space_keys: string
+}
+
+export interface NotionAddConfig {
+  access_token: string
+  database_ids: string
+  max_pages: string
+}
+
+export interface NotionEditConfig {
+  database_ids: string
+  max_pages: string
+  new_access_token: string
+}
+
+export type NotionConfig = NotionAddConfig | NotionEditConfig

--- a/klai-portal/frontend/src/routes/app/knowledge/__tests__/edit-wizard-step-deep-link.test.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/__tests__/edit-wizard-step-deep-link.test.tsx
@@ -10,7 +10,7 @@
 
 import { describe, expect, it } from 'vitest'
 import { render, screen } from '@testing-library/react'
-import { PreviewClassificationFeedback } from '../$kbSlug_.add-connector'
+import { PreviewClassificationFeedback } from '../-connector-feedback'
 
 // ---------------------------------------------------------------------------
 // Step-to-WcStep mapping logic (mirrors the module-level helper in

--- a/klai-portal/frontend/src/routes/app/knowledge/__tests__/wizard-feedback.test.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/__tests__/wizard-feedback.test.tsx
@@ -3,8 +3,10 @@
  *
  * Tests cover the pure render helpers ``AuthProbeFeedback`` (REQ-2)
  * and ``PreviewClassificationFeedback`` (REQ-3). These components are
- * exported from the add-connector route so they can be unit-tested in
- * isolation (no router/query-client setup needed).
+ * shared between add-connector and edit-connector and live in
+ * `-connector-feedback.tsx` (per the file-organization rule in
+ * portal-frontend.md). Unit-testable in isolation — no router or
+ * query-client setup needed.
  */
 
 import { describe, expect, it } from 'vitest'
@@ -12,7 +14,7 @@ import { render, screen } from '@testing-library/react'
 import {
   AuthProbeFeedback,
   PreviewClassificationFeedback,
-} from '../$kbSlug_.add-connector'
+} from '../-connector-feedback'
 
 describe('AuthProbeFeedback', () => {
   it('renders success state for auth_ok', () => {


### PR DESCRIPTION
Implements SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 v0.2.0.

## What

- Adds the **"File organization for shared types and helpers"** rule to `.claude/rules/klai/projects/portal-frontend.md` (the rule the rest of this PR follows).
- Eliminates the duplication between `$kbSlug_.add-connector.tsx` (1416 lines) and `$kbSlug_.edit-connector.$connectorId.tsx` (1273 lines):
  - 3 triplicate symbols where add had local copies that diverged from canonical exports in `$kbSlug/-kb-*` (`ASSERTION_MODE_OPTIONS`, `GitHubConfig`, `WebCrawlerConfig`).
  - 7 byte-identical type duplicates between add and edit (`AuthProbeResult`, `AuthGuardSuggestion`, `WcStep`, `PreviewClassification`, `AuthProbeClassification`, `Airtable*Config`, `Confluence*Config`).
  - 1 subtly-divergent type made explicit as a discriminated union (`NotionConfig = NotionAddConfig | NotionEditConfig`).
- Removes the cross-route import smell where `edit-connector.tsx` imported `AuthProbeFeedback` + `PreviewClassificationFeedback` directly from `add-connector.tsx`. Plus the same smell in two test files.

## Files

- New: `klai-portal/frontend/src/routes/app/knowledge/-connector-types.ts` (108 lines)
- New: `klai-portal/frontend/src/routes/app/knowledge/-connector-constants.ts` (24 lines)
- New: `klai-portal/frontend/src/routes/app/knowledge/-connector-feedback.tsx` (121 lines)
- Modified: `$kbSlug_.add-connector.tsx` 1416 → 1231 lines (−185)
- Modified: `$kbSlug_.edit-connector.$connectorId.tsx` 1273 → 1219 lines (−54)
- Modified: 2 test files (import path swap, no assertion changes)

## Methodology

DDD (ANALYZE-PRESERVE-IMPROVE). Pure structural extraction — no behavior change. The existing `__tests__/wizard-feedback.test.tsx` already covers all 5 AuthProbeFeedback classifications + all 6 PreviewClassificationFeedback cases; used as the characterization gate.

## Phase chain

| # | Commit | What |
|---|---|---|
| 1 | `5b514e9b` | Preflight: rule on portal-frontend.md + SPEC v0.2.0 (status: ready) |
| 2 | `6c60a048` | Eliminate triplicate symbols vs `$kbSlug/-kb-*` |
| 3 | `fef50b58` | Extract wizard-only types (Phases 3+4 swapped — constants depend on types) |
| 4 | `c4bf13cb` | Extract wizard-only constants |
| 5 | `aa0ca9fe` | Extract feedback components, kill cross-route import |

Each commit independently green under `tsc --noEmit`, `eslint .`, and `vitest run __tests__/`.

## Acceptance criteria (from SPEC)

- [x] AC1: rule present in portal-frontend.md
- [x] AC2: 3 new `-connector-*` files exist
- [x] AC3: `git grep "interface AirtableEditConfig|ConfluenceEditConfig"` zero hits
- [x] AC4: `git grep "from './\$kbSlug_.add-connector'"` zero hits
- [x] AC5: `ASSERTION_MODE_OPTIONS` zero local hits in add
- [x] AC6: `interface GitHubConfig|WebCrawlerConfig` zero local hits in add
- [x] AC7: line caps satisfied (one slip: types.ts 108/100 — 8 lines of comments at top, not code)
- [x] AC8: tsc + lint clean
- [x] AC9: 23/23 vitest assertions passing, same count as before
- [x] AC11: routeTree.gen.ts byte-identical (verified via `git diff --stat origin/main` — file does not appear)
- [ ] AC10: **Playwright smoke (human verification)** — auth-probe panel + preview-classification panel render identically on add and edit. To be verified before merge.

## Notion union design

Option A from the SPEC: `NotionAddConfig` and `NotionEditConfig` interfaces retained as separate names, joined into `NotionConfig` discriminated union (no `mode` tag). Each page consumes its own branch directly. The union itself is for future shared consumers (e.g. the `useConnectorWizardState` hook in F-1 follow-up).

## Risks & known caveats

- Phase 5 (feedback components) is the only commit with runtime impact. Mitigated by the existing snapshot-text-match tests and the verbatim move (no logic change).
- The cross-directory imports `add/edit-connector → $kbSlug/-kb-helpers/-kb-types` are tactical legacy per the new rule. They are NOT relocated in this PR — tracked as F-C2 in the SPEC's Follow-ups section.
- `routeTree.gen.ts` regeneration: not needed — TanStack Router's default `routeFileIgnorePrefix` is `-`, so `-connector-*` files are skipped from route discovery.

## Follow-ups (in SPEC § Follow-ups)

This PR is one slice of a wider god-component pattern. The SPEC's § Follow-ups section lists 9 candidates (taxonomy.tsx, mfa.lazy.tsx, transcribe/add.tsx, etc.) plus architectural smells (insights.tsx cross-route imports) and convention-adoption follow-ups. Each is its own SPEC.

## QA before merge

1. `bun run build` green (CI)
2. Playwright smoke: open KB → add web_crawler → cookie step → auth-probe → see panel render. Same on edit. Pixel-identical.
3. `gh run watch --exit-status` per klai-portal deploy convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)