### PR TITLE
feat(portal): SPEC-PORTAL-KB-OWNERSHIP-001 — admin KB-delete, offboarding-transfer, personal-KB firewall

### DIFF
--- a/.moai/specs/SPEC-PORTAL-KB-OWNERSHIP-001/spec.md
+++ b/.moai/specs/SPEC-PORTAL-KB-OWNERSHIP-001/spec.md
@@ -1,0 +1,583 @@
+---
+id: SPEC-PORTAL-KB-OWNERSHIP-001
+version: "0.1.0"
+status: draft
+created: "2026-05-12"
+updated: "2026-05-12"
+author: Mark Vletter (sparring met Claude)
+priority: high
+issue_number: 0
+related:
+  - SPEC-INFRA-TENANT-DELETE-001 (org-level delete pattern + state machine)
+  - SPEC-PORTAL-RBAC-REFACTOR-001 (5-layer permissions + ProfileRole.ADMIN)
+  - SPEC-SEC-TENANT-001 (tenant-scoped membership delete in offboard)
+  - SPEC-KB-SOURCES-001 (KB-source wire-contract)
+---
+
+## HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 0.1.0 | 2026-05-12 | Mark + Claude | Initiële draft. Drie onderdelen: (a) admin-delete van org-KBs van anderen met expliciete bevestiging, (b) offboarding-flow met KB-transfer wizard, (c) hard-firewall rond persoonlijke KBs. |
+
+# SPEC-PORTAL-KB-OWNERSHIP-001 — Admin KB-delete, offboarding-transfer en personal-KB firewall
+
+## Doel
+
+Drie aan elkaar geknoopte verbeteringen rond eigendom van knowledge bases:
+
+1. **Admin-delete van org-KBs** — Een org-admin kan elke org-eigendom KB binnen
+   zijn tenant verwijderen, ook als hij hem niet zelf heeft aangemaakt. De UI
+   waarschuwt expliciet "deze heb jij niet opgericht" en vraagt om bevestiging.
+2. **Offboarding-transfer** — Bij `POST /admin/users/{id}/offboard` worden de
+   org-KBs die de offboarded user als enige owner heeft expliciet overgedragen
+   naar een andere user (default = de offboardende admin) of gewist. Geen
+   silent-orphans meer.
+3. **Personal-KB firewall** — Een admin krijgt persoonlijke KBs van anderen
+   onder geen enkele rol of route te zien, te lezen, te delen, te
+   herstellen of te verwijderen. De huidige model-discriminator
+   (`owner_type='user'` + `owner_user_id`) wordt op meerdere lagen
+   afgedwongen (DB-policy + API-filter + audit-test), zodat een toekomstige
+   refactor de firewall niet per ongeluk omver kan trekken.
+
+## Motivatie
+
+### Wat er nu fout gaat
+
+Op 2026-05-12 meldde de eigenaar van Klai dat hij als org-admin geen KBs van
+collega's kon verwijderen. Vooral relevant nu meerdere medewerkers org-KBs
+aanmaken en niet meer zelf opruimen — de admin is de enige die een rommelige
+lijst kan rechtbreien, maar krijgt nu standaard `403 Owner access required`.
+
+Tegelijk is de offboarding-flow (`offboard_user` in
+`klai-portal/backend/app/api/admin/users.py`) KB-blind: een offboarded user
+laat al zijn KBs achter met `created_by=<dode-zitadel-id>`. De
+`get_user_role_for_kb`-resolver geeft `created_by` automatisch owner-rol —
+dus de KB heeft nu een owner die niet meer bestaat. Niemand kan er nog mee.
+Voor org-KBs is dit ook een hygiene-probleem (slug bezet, naam zichtbaar in
+admin-UI). Voor persoonlijke KBs is dit een privacy-probleem (data blijft
+hangen, zelfs als de medewerker is vertrokken).
+
+### Wat er goed is en wat we NIET willen breken
+
+`list_app_knowledge_bases` heeft al de cruciale filter:
+
+```python
+# klai-portal/backend/app/api/app_knowledge_bases.py:340-342
+(PortalKnowledgeBase.owner_type == "org") | (PortalKnowledgeBase.owner_user_id == perms.user_id)
+```
+
+Dit verbergt persoonlijke KBs van anderen voor élke caller, ongeacht rol —
+inclusief admins. Die invariant is precies wat we willen versterken, niet
+versoepelen.
+
+### Wat industry-standaard is (Google Workspace, Notion, Slack)
+
+| Platform | Bij user-removal | Wie kan privé-content (My Drive / Private pages) bereiken? |
+|---|---|---|
+| Google Workspace | Admin krijgt prompt om Drive-files over te dragen vóór delete. Niet-overgedragen files zitten 5 dagen in Trash. | Admin kan "Transfer Drive files" via Admin Console — direct ownership-overdracht. Alleen "Service Settings administrator" privilege. Geen direct view. |
+| Notion (Enterprise) | Bij removal prompt om "owned" pages over te dragen. Aparte "Content Transfer API" voor private pages. | Workspace owner kan binnen 30 dagen private pages reassignen — gated op Enterprise + 30d-window. Geen browse-access. Re-add binnen 30d herstelt private content. |
+| Slack | Deactivation laat berichten/files staan. Owners kunnen canvases en lists overdragen. Primary Owner kan niet worden gedeactiveerd zonder eerst ownership over te dragen. | Niet — DM's en private channels blijven bij de account. Workspace exports (Plus/Enterprise) zijn een aparte gate. |
+
+Synthese: **niemand laat persoonlijke content zonder expliciete intentie
+verdwijnen, en niemand geeft admins ongelimiteerde toegang tot privé-content
+"omdat ze admin zijn"**. Het patroon is altijd hetzelfde: owner-overdracht
+vóór delete, korte restore-window, audit-trail, en een aparte gate voor
+privé-data (Notion's Enterprise + 30d-window is de strengste, Google's
+"Service Settings administrator" privilege de meest pragmatische).
+
+We kopiëren niet één-op-één: Klai is voor een klein team (Voys, Klai-zelf,
+early customers) en heeft geen tier waar we deze functionaliteit achter
+kunnen verstoppen. We nemen daarom Google's pragmatische lijn voor
+org-KBs (admin mag verwijderen na bevestiging) en Notion's strenge lijn
+voor personal KBs (admin krijgt nooit toegang; max keuze "delete now of
+restore-window dan delete"). Geen halve maatregelen, geen "admin kan
+indien nodig stiekem alles" — dat zou onze eigen waardepropositie
+("persoonlijk staat persoonlijk") ondermijnen.
+
+## Environment
+
+- **Affected services:** klai-portal/backend (KB-delete-endpoint, offboard-endpoint, nieuwe transfer-endpoint, audit-event), klai-portal/frontend (KB-card delete-modal, offboarding-wizard).
+- **Externe systemen aangeraakt bij delete:**
+  - docs-app (`docs_client.deprovision_kb`) — Qdrant vectors + Gitea repo + docs DB row, alleen voor KBs met `gitea_repo_slug`/`docs_enabled`.
+  - knowledge-ingest (`knowledge_ingest_client.delete_kb`) — FalkorDB graph + Qdrant chunks + PG artifacts; altijd aangeroepen.
+  - Geen wijziging in deze externe-call-volgorde — alleen wie de delete mag triggeren verandert.
+- **Affected klai-portal backend files:**
+  - `app/api/app_knowledge_bases.py` — splits `_require_owner` en de delete-handler in een owner-pad en een admin-override-pad; nieuwe `transfer_app_knowledge_base` endpoint.
+  - `app/api/admin/users.py` — `offboard_user` krijgt verplichte body-param met KB-disposition per KB die de user owned.
+  - `app/services/access.py` — `get_user_role_for_kb` blijft ongewijzigd; nieuwe helper `is_personal_kb(kb)` als single-source-of-truth voor de firewall.
+  - `app/services/kb_offboarding.py` (NIEUW) — orchestrator die per KB transfer-of-delete uitvoert binnen één DB-transactie + emit audit-events.
+  - `app/models/audit.py` of bestaande `log_event` — drie nieuwe action-codes: `kb.admin_deleted`, `kb.transferred`, `kb.personal_purged_on_offboard`.
+  - `tests/test_app_knowledge_bases.py` — uitbreiding voor admin-override pad + personal-KB firewall tests (admin probeert toegang → 404).
+  - `tests/test_user_lifecycle.py` — uitbreiding voor offboarding-met-KB-disposition.
+  - `tests/test_kb_personal_firewall.py` (NIEUW) — gefocused op invariant: geen enkele admin-route kan een personal KB van een ander zien/wijzigen/verwijderen.
+- **Affected klai-portal frontend files:**
+  - `frontend/src/components/knowledge/delete-kb-modal.tsx` (UITGEBREID) — varianten "you-own" en "you-don't-own"; tweede variant toont aanmaker, datum, en "Type DELETE om te bevestigen".
+  - `frontend/src/routes/admin/users/$user/offboard.tsx` (NIEUW of uitbreiding van bestaande offboard-actie) — wizard met KB-overdracht-stappen.
+  - `frontend/messages/{nl,en}.json` — Paraglide strings.
+- **Affected docs:**
+  - `docs/runbooks/user-offboarding.md` (NIEUW) — admin-runbook met KB-transfer-stappen + restore-window.
+  - `klai-portal/CLAUDE.md` (UITGEBREID) — verwijzing naar runbook.
+
+## Assumptions
+
+- Org-admin = `ProfileRole.ADMIN` (bestaande RBAC-laag uit
+  SPEC-PORTAL-RBAC-REFACTOR-001). Geen nieuwe rol nodig.
+- Een KB hoort bij precies één org (`portal_knowledge_bases.org_id`). Cross-org
+  transfer is uit scope.
+- Owner-discriminator is `owner_type` + `owner_user_id` (zoals nu). Migratie
+  van data-shape is uit scope.
+- Restoration-window voor personal KBs is opt-in via een nieuwe org-instelling
+  (default uit). MVP levert "delete now" en "delete after N dagen"; de
+  re-activate-pad uit Notion is opgenomen als open vraag (Q3) en kan in een
+  Phase 2 SPEC.
+- `ProfileRole.ADMIN` bestaat per tenant — er is geen super-admin die
+  cross-tenant kan overschrijden. Dat blijft zo.
+
+## Probleem-mapping
+
+| # | Probleem | Bewijs | Impact |
+|---|---|---|---|
+| P1 | Admin krijgt 403 bij delete van org-KB die collega heeft aangemaakt | `_require_owner` in `app_knowledge_bases.py:305-313` checkt alleen `role == "owner"` zonder admin-override | Rommelige KB-lijst blijft hangen, admin moet gebruiker verzoeken om delete of via DB ingrijpen |
+| P2 | `remove_user`/`offboard_user` raken KBs niet aan | `app/api/admin/users.py:410-565` — geen enkele query op `portal_knowledge_bases` of `portal_user_kb_access` | Orphan-KBs (`created_by=<dode-id>`) blijven; geen owner kan ze nog wijzigen, niemand merkt het tot iemand wil delete'n |
+| P3 | Personal-KB-filter is alleen op één plek geïmplementeerd | `list_app_knowledge_bases` heeft de OR-filter; andere endpoints (get_kb, members, sources) checken alleen `org_id == perms.org_id` en vertrouwen impliciet op de slug-pad | Een toekomstige refactor die `_get_kb_or_404` aanpast kan stilletjes admin-toegang tot persoonlijke KBs introduceren — geen test bewaakt dat |
+| P4 | Geen audit-trail bij admin-overrides | `log_event` wordt niet aangeroepen in `delete_app_knowledge_base` | Bij security-incident is niet reproduceerbaar wie wat verwijderde |
+| P5 | Geen restore-window voor offboarded user die per ongeluk weg is | `offboard_user` flipt status maar er is geen "restore"-pad voor zijn data | Voys-praktijk: medewerker stopt na 6 weken alsnog niet, alle context is weg |
+
+## Gewenste eindtoestand
+
+### 1. Admin-delete van org-KB
+
+```
+[user clicks Delete on org-KB they didn't create]
+  ↓
+DELETE /api/app/knowledge-bases/{slug}
+  - actor: admin
+  - kb.owner_type: 'org'
+  - kb.created_by: someone-else
+  - actor's role for this KB: not 'owner', but actor is ProfileRole.ADMIN
+  ↓
+Backend: branch into admin-override pad
+  - Require explicit X-Admin-Override-Confirm: 'I-WAS-NOT-CREATOR' header
+    (UI sends this only after the second confirmation modal)
+  - Emit log_event(action='kb.admin_deleted', actor, kb_id, previous_owner=created_by)
+  - Continue with same docs-app + knowledge-ingest + portal-DB delete chain
+```
+
+UI:
+- KB-card "verwijder" button is altijd zichtbaar voor admins op org-KBs.
+- Eerste klik opent normale "weet je zeker"-modal.
+- Als `kb.created_by != actor.user_id` toont de modal een gele banner:
+  "Deze KB is aangemaakt door {name}. Je verwijdert content van een
+  collega. Type **DELETE** om te bevestigen."
+- Pas na DELETE-typ + klik wordt de extra header meegestuurd.
+
+### 2. Offboarding-transfer
+
+```
+[admin clicks Offboard on user X]
+  ↓
+GET /api/admin/users/{X}/offboard-preview
+  → returns { org_kbs_owned_solely: [...], personal_kbs: [...] }
+  ↓
+UI: wizard
+  - Stap 1: per org-KB die X solely owned → kies (transfer_to: <user-id>) of (delete: true)
+            Default-selectie: transfer naar caller (de offboardende admin)
+  - Stap 2: voor personal KBs → kies (delete_now) of (purge_after_days: N) — geen transfer-optie
+  - Stap 3: bevestiging
+  ↓
+POST /api/admin/users/{X}/offboard
+  body: { kb_dispositions: [{kb_id, action: 'transfer'|'delete', transfer_to?: user_id}, ...] }
+  ↓
+Backend:
+  - Run kb_offboarding.apply_dispositions() in één transactie
+    - transfer: update kb.created_by + kb.owner_user_id (if user-owned, but user-owned won't get here)
+    - delete (org-KB): same chain as DELETE endpoint, with log_event(action='kb.admin_deleted', reason='offboarding')
+    - delete (personal): docs/ingest delete + log_event(action='kb.personal_purged_on_offboard')
+  - Continue with existing offboard logic (status='offboarded', remove memberships, deactivate Zitadel, etc.)
+```
+
+Org-KBs waar X als één-van-meerdere owners stond verliezen alleen X's
+`portal_user_kb_access`-rij; geen disposition nodig (KB heeft nog
+owners). Org-KBs waar X de enige owner was verschijnen in de wizard.
+
+### 3. Personal-KB firewall
+
+Drie lagen die elkaar onafhankelijk afdwingen:
+
+**Laag A — single source of truth helper:**
+```python
+def is_personal_kb(kb: PortalKnowledgeBase) -> bool:
+    return kb.owner_type == "user"
+```
+
+**Laag B — gate in elke KB-route:**
+Iedere route die een specifieke KB ophaalt
+(`get_app_knowledge_base`, `update_knowledge_base`, `delete_app_knowledge_base`,
+`list_kb_bronnen`, `list_members`, `invite_user`, `update_user_role`,
+`remove_user` op KB-niveau, `invite_group`, `crawl_preview`, `auth_probe`,
+en alle endpoints in `app_knowledge_sources.py` met `kb_slug`-param) draait
+direct na `_get_kb_or_404`:
+
+```python
+if is_personal_kb(kb) and kb.owner_user_id != perms.user_id:
+    raise HTTPException(404, "Knowledge base not found")  # 404, niet 403 — bestaan niet onthullen
+```
+
+Wordt geïmplementeerd als FastAPI-dependency `get_kb_with_access` die alle
+bovenstaande routes vervangen, in plaats van per-route copy-paste.
+
+**Laag C — invariant-test:**
+`tests/test_kb_personal_firewall.py` itereert over élke KB-route
+(geïntrospecteerd via `app.routes`) en bevestigt: als een route met
+`{kb_slug}` of `{kb_id}` een personal-KB van een andere user als param
+krijgt, krijgt de admin-caller 404 (niet 200, niet 403). Een nieuwe route
+die de gate vergeet, faalt deze test.
+
+Optioneel als Phase 2 (uit scope MVP): laag D — DB row-level-security
+policy die `owner_user_id = current_setting('app.current_user_id')`
+afdwingt op `portal_knowledge_bases` met `owner_type='user'`. Heeft
+dezelfde architectuur-vorm als de bestaande `tenant_isolation`-policy
+op `portal_users`. Pas zinvol als laag B een keer faalt.
+
+## Requirements (EARS)
+
+### Admin-delete (REQ-1.x)
+
+- **REQ-1.1** WHEN een caller met `ProfileRole.ADMIN` `DELETE
+  /api/app/knowledge-bases/{slug}` aanroept op een org-KB (`owner_type='org'`)
+  binnen zijn eigen tenant en `kb.created_by != caller.user_id`, EN de
+  request bevat header `X-Admin-Override-Confirm: I-WAS-NOT-CREATOR`,
+  THEN voert de backend de delete uit volgens dezelfde 3-stap-keten als
+  bij een owner-delete (docs → ingest → portal-DB).
+- **REQ-1.2** WHEN dezelfde caller dezelfde DELETE aanroept ZONDER de
+  header, THEN antwoordt de backend met `403` en body
+  `{"detail": "Owner access required, or set X-Admin-Override-Confirm header"}`.
+- **REQ-1.3** WHEN een caller met `ProfileRole.ADMIN` `DELETE
+  /api/app/knowledge-bases/{slug}` aanroept op een **personal** KB van
+  een andere user (`owner_type='user'` AND `owner_user_id != caller`),
+  THEN antwoordt de backend met `404` ongeacht of er een
+  override-header staat. De personal-KB firewall heeft voorrang.
+- **REQ-1.4** WHEN een delete via admin-override succesvol is, THEN
+  emit de backend `log_event(action='kb.admin_deleted',
+  actor=caller.user_id, resource_type='kb', resource_id=kb.id,
+  meta={previous_owner: kb.created_by, kb_name: kb.name, kb_slug: kb.slug})`.
+- **REQ-1.5** WHEN de admin-override delete loopt, THEN gedraagt de
+  externe-call-keten (docs-app deprovision, ingest delete, portal-DB
+  delete) zich identiek aan de owner-delete: failures in stap 1 of 2
+  aborten vóór de portal-DB-rij verdwijnt. Geen verschil in
+  failure-semantiek tussen owner en admin.
+
+### Offboarding-transfer (REQ-2.x)
+
+- **REQ-2.1** WHEN een caller met `ProfileRole.ADMIN` `GET
+  /api/admin/users/{zitadel_user_id}/offboard-preview` aanroept,
+  THEN antwoordt de backend met JSON `{org_kbs_solely_owned:
+  [{kb_id, slug, name, role_count}, ...], personal_kbs: [{kb_id,
+  slug, name}, ...]}`. Alleen org-KBs waar de target-user de enige
+  resterende owner is, en alle personal KBs van die user, staan in
+  de lijst.
+- **REQ-2.2** WHEN de admin `POST /api/admin/users/{zitadel_user_id}/offboard`
+  aanroept met body `{kb_dispositions: [...]}` waarin elke `kb_id` uit
+  REQ-2.1 voorkomt met `action='transfer'` (org-KB only) of
+  `action='delete'`, THEN voert de backend de dispositions uit binnen
+  één DB-transactie vóór de bestaande offboard-stappen (status-flip,
+  membership-delete, Zitadel-deactivate). Failure in een disposition
+  rolt alles terug — de user wordt niet offboarded.
+- **REQ-2.3** WHEN een disposition `action='transfer'` heeft op een
+  org-KB met `transfer_to=<new-user-id>`, THEN update de backend
+  `kb.created_by = new_user_id`. Bestaande
+  `portal_user_kb_access`-rijen voor de oude user worden verwijderd.
+  Een nieuwe `portal_user_kb_access`-rij `(kb_id, new_user_id,
+  role='owner', granted_by=actor)` wordt geüpsert.
+- **REQ-2.4** WHEN een disposition `action='transfer'` voorkomt voor
+  een personal KB, THEN antwoordt de backend met `400` en body
+  `{"detail": "Personal knowledge bases cannot be transferred to
+  another person"}`. De firewall-invariant geldt ook hier.
+- **REQ-2.5** WHEN de offboard-call zonder body of zonder dispositions
+  voor élke KB uit REQ-2.1 binnenkomt, THEN antwoordt de backend met
+  `400` en body `{"detail": "Missing dispositions for: [<kb_slug>,
+  ...]"}`. Geen impliciete defaults — admin moet expliciet kiezen om
+  silent-orphans te voorkomen.
+- **REQ-2.6** WHEN een org-KB transfer succesvol is, THEN emit
+  `log_event(action='kb.transferred', actor, resource_type='kb',
+  resource_id=kb.id, meta={from_user: old, to_user: new,
+  reason: 'offboarding'})`. WHEN een delete uit offboarding succesvol
+  is, THEN emit `kb.admin_deleted` (org) of
+  `kb.personal_purged_on_offboard` (personal) met
+  `meta.reason='offboarding'`.
+
+### Personal-KB firewall (REQ-3.x)
+
+- **REQ-3.1** Een centrale FastAPI-dependency `get_kb_with_access(kb_slug)`
+  vervangt het patroon `kb = await _get_kb_or_404(...)` in alle huidige
+  KB-routes onder `/api/app/knowledge-bases/{kb_slug}/...`. De dependency
+  resolvet de KB en raised `HTTPException(404)` (NIET 403) WHEN
+  `is_personal_kb(kb) AND kb.owner_user_id != caller.user_id`, ongeacht
+  caller-rol.
+- **REQ-3.2** WHEN een caller (inclusief `ProfileRole.ADMIN`) een
+  personal-KB-slug van een andere user gebruikt op ÉLKE bestaande of
+  toekomstige `/api/app/knowledge-bases/{kb_slug}/*` route, THEN
+  antwoordt de route `404` zonder enige info over de KB te onthullen
+  (geen naam, geen aantal sources, geen creator).
+- **REQ-3.3** Een test
+  `tests/test_kb_personal_firewall.py::test_no_admin_route_leaks_personal_kb`
+  itereert via `app.routes` over élke route waarvan het pad-pattern
+  `{kb_slug}` of `{kb_id}` bevat. Voor élke route maakt de test (a)
+  een personal KB van user A en (b) een admin-caller van een andere
+  user B (zelfde tenant). De test verwacht response `404` op élke
+  route — falen hierop is een blocker.
+- **REQ-3.4** `list_app_knowledge_bases` blijft de bestaande
+  OR-filter `(owner_type='org') OR (owner_user_id=caller)` behouden.
+  Een test bevestigt: een admin ziet géén personal-KB's van anderen
+  in de response, ongeacht een nieuwe optionele query-param of
+  filter-flag.
+- **REQ-3.5** Geen enkele bestaande of nieuwe route biedt een
+  "view-as-admin" / "switch-context" / "impersonate" pad richting
+  personal-KB content. WHEN een toekomstige SPEC zo'n pad voorstelt,
+  THEN moet die SPEC dit SPEC-document expliciet noemen als
+  conflict + de firewall met een additionele laag (laag D, RLS-
+  policy) backen.
+
+### Audit + observability (REQ-4.x)
+
+- **REQ-4.1** Alle nieuwe `log_event`-calls hierboven landen in de
+  bestaande audit-tabel, queryable per `actor` en `resource_id` (zelfde
+  patroon als `user.offboarded`).
+- **REQ-4.2** Backend logt `_slog.info("kb_admin_deleted", ...)`,
+  `_slog.info("kb_transferred", ...)` en
+  `_slog.info("kb_personal_purged_on_offboard", ...)` met velden
+  `org_id`, `actor_user_id`, `kb_id`, `kb_slug`, `previous_owner`. Deze
+  events zijn in VictoriaLogs queryable als
+  `service:portal-api AND event:kb_admin_deleted` (zie
+  `klai/projects/portal-logging-py.md`).
+- **REQ-4.3** Een Grafana-alert (Phase 2 — niet in MVP-scope) op
+  `kb_personal_purged_on_offboard`-rate > 0 voor 5 min: standaard uit,
+  alleen activeren als personal-KB-purge een gevoeligheid wordt.
+
+## Acceptance criteria
+
+### AC-1: admin-delete owner-pad blijft werken
+- **Given** user A heeft org-KB X aangemaakt en is owner
+- **When** A `DELETE /api/app/knowledge-bases/X` zonder override-header
+- **Then** response 204; KB weg uit docs/ingest/portal-DB
+
+### AC-2: admin-delete van org-KB van anderen mét override
+- **Given** user A heeft org-KB X aangemaakt; user B is admin in zelfde tenant; B is geen owner van X
+- **When** B `DELETE /api/app/knowledge-bases/X` mét header `X-Admin-Override-Confirm: I-WAS-NOT-CREATOR`
+- **Then** response 204; audit-event `kb.admin_deleted` met `previous_owner=A`; KB weg uit alle backends
+
+### AC-3: admin-delete zonder override blijft 403
+- **Given** zoals AC-2
+- **When** B `DELETE /api/app/knowledge-bases/X` zonder header
+- **Then** response 403; KB onaangeraakt; geen audit-event
+
+### AC-4: admin-delete van personal KB van anderen → 404
+- **Given** user A heeft personal KB; user B is admin in zelfde tenant
+- **When** B `DELETE /api/app/knowledge-bases/personal-{A}` mét override-header
+- **Then** response 404; KB onaangeraakt; geen audit-event
+
+### AC-5: offboard-preview toont enkel solely-owned org-KBs en alle personal KBs
+- **Given** user X owned solely org-KB Y (geen andere owner-rij), is co-owner van org-KB Z (samen met admin), heeft personal KB P
+- **When** admin `GET /api/admin/users/{X}/offboard-preview`
+- **Then** response bevat Y en P; bevat NIET Z
+
+### AC-6: offboard zonder dispositions → 400 met expliciete missing-list
+- **Given** preview uit AC-5
+- **When** admin `POST /api/admin/users/{X}/offboard` met lege body
+- **Then** response 400, body bevat `Y` en `P` in `Missing dispositions`
+
+### AC-7: offboard-transfer voor org-KB werkt + audit
+- **Given** zoals AC-5
+- **When** admin POST met `{kb_dispositions: [{kb_id: Y.id, action: 'transfer', transfer_to: admin.id}, {kb_id: P.id, action: 'delete'}]}`
+- **Then** response 200; Y.created_by = admin; admin heeft owner-rij; P weg uit docs/ingest/portal-DB; user X status='offboarded'; audit-events `kb.transferred`, `kb.personal_purged_on_offboard`, `user.offboarded`
+
+### AC-8: transfer van personal KB → 400
+- **Given** zoals AC-5
+- **When** admin POST met `{kb_dispositions: [{kb_id: P.id, action: 'transfer', transfer_to: admin.id}, ...]}`
+- **Then** response 400 met `Personal knowledge bases cannot be transferred`
+
+### AC-9: invariant-firewall test groen
+- `pytest tests/test_kb_personal_firewall.py -v` slaagt voor élke geïntrospecteerde KB-route
+
+### AC-10: failure tijdens offboarding-transfer rolt alles terug
+- **Given** AC-5; mock `knowledge_ingest_client.delete_kb` om te raisen op P
+- **When** admin POST disposition zoals AC-7
+- **Then** response 5xx; user X status NOG `active`; Y.created_by NIET veranderd; geen audit-events
+
+### AC-11: front-end "Type DELETE" gate
+- **Given** admin opent UI voor org-KB van anderen
+- **When** admin klikt op delete in KB-card
+- **Then** modal toont gele banner met aanmaker-naam en datum, knop is disabled tot user "DELETE" typt
+
+## Out of scope (MVP)
+
+- **Reactivate-pad voor offboarded user.** Eigenaarsbeslissing: nee
+  (D3). `suspend_user` blijft de niet-destructieve weg. Niet uit te
+  bouwen in een latere SPEC tenzij produktbeleid verandert.
+- **Soft-delete grace-period voor personal KBs.** Eigenaarsbeslissing:
+  delete = onmiddellijk (D2). Geen `status` of `purge_after` kolommen
+  nodig in `portal_knowledge_bases`.
+- **DB-laag RLS-policy** voor personal KB firewall (laag D in §3). Pas zinvol als laag B een keer faalt.
+- **Cross-org KB-transfer.** Klai heeft per definitie tenant-isolatie; cross-org transfer zou dat ondergraven.
+- **Bulk-admin-delete** (selecteer 5 KBs en delete). Eerst single-KB pad solide, dan bulk.
+- **Soft-delete-tombstones bij admin-override.** `PortalKBTombstone` bestaat al maar wordt nu niet gebruikt door `delete_app_knowledge_base`. Kan in Phase 2.
+- **Self-service voor de offboarded user** ("ik wil mijn personal KB exporteren"). Aparte SPEC.
+- **Auto-revoke OAuth grants en provider-tokens** (Notion / Google Drive / Microsoft connectors die een offboarded user heeft aangemaakt op org-KBs). Andersoortige hygiene; eigen SPEC. Maar zie REQ-2.x — bij KB-transfer naar nieuwe owner moeten connector-credentials wel onder de nieuwe owner draaien (mogelijk een impliciete dependency).
+
+## Bronnen voor de beslissingen
+
+- Google Workspace ownership-transfer best practices ([gpanel.io](https://gpanel.io/blog/google-workspace-offboarding), [Google Workspace Help](https://support.google.com/a/answer/1247799?hl=en))
+- GDPR retention proportionality ([heydata.eu](https://heydata.eu/en/magazine/gdpr-data-retention-periods-overview-requirements-best-practices/), [TechTarget](https://www.techtarget.com/searchdatabackup/tip/Compare-SaaS-data-retention-policies-from-4-major-providers))
+- Reactivation patterns ([Slack reactivate](https://slack.com/help/articles/360002061747-Reactivate-a-members-account), [Notion 30d](https://www.notion.com/help/duplicate-delete-and-restore-content), [Torii reactivate Google](https://www.toriihq.com/articles/how-to-reactivate-user-google-workspace))
+- DELETE confirmation pattern ([piranna.github.io](https://piranna.github.io/2020/03/01/Confirm-deletion-in-RESTful-APIs/), [http.dev DELETE](https://http.dev/delete))
+- 91% offboarded-token-survival statistic en checklist ([Reco SaaS offboarding](https://www.reco.ai/use-cases/saas-offboarding), [Nudge Security 2026](https://www.nudgesecurity.com/post/nudge-securitys-it-offboarding-checklist-for-a-saas-first-world))
+
+## Beslissingen (industry-research backed)
+
+Op 2026-05-12 doorlopen tegen industry standards (Google Workspace, Notion,
+Slack, GDPR-best-practice, IT-offboarding-checklists). Bronnen onderaan dit
+document. Onderstaande zijn ingebakken in de requirements hierboven; staan
+hier gedocumenteerd voor de audit-trail.
+
+### D1 — Default-ontvanger bij offboard-transfer = de offboardende admin
+Google Workspace recommendeert "direct manager OR a dedicated archive
+account" als default. Klai heeft geen archief-account; de offboardende
+admin is ook bijna altijd de manager / verantwoordelijke. **Default:
+`transfer_to = caller.user_id`** met UI-banner "Klik op de KB om een
+andere ontvanger te kiezen". Files krijgen een naam-prefix
+"ex-{user-naam} / {original-name}" (mirror van Google's gedrag waarbij
+overgedragen files in een folder met de oude eigenaar's email landen —
+provenance behouden).
+
+### D2 — Personal-KB delete = onmiddellijk (geen grace-period)
+Onderzoek wees op 30d als industry-default (Microsoft, Google, Notion),
+maar productbeslissing van de eigenaar (2026-05-12): **delete now, geen
+grace-period**. Past bij Klai's positionering "persoonlijk staat
+persoonlijk" — een offboarded user zou bij een grace-period nog 30 dagen
+in een schemertoestand zitten waarin de admin theoretisch het account
+kan reactivaten en alsnog bij privé-data kan. Onmiddellijke purge
+elimineert dat venster. GDPR-compliant (sterker: GDPR-strenger dan
+nodig) en simpeler te implementeren.
+
+### D3 — Geen restore-on-rehire pad
+Productbeslissing van de eigenaar (2026-05-12): **nee**. Een
+gereactivateerde medewerker krijgt een schoon personal-KB; oude
+inhoud is bij offboard onmiddellijk verwijderd (D2). Wie zeker wil
+zijn dat data niet weg is, gebruikt `suspend_user` (bestaande
+endpoint, behoudt alles tot reactivate). `offboard_user` is en
+blijft destructief en irreversibel. Klant-communicatie hierover hoort
+in de offboard-confirmation modal: "Deze actie verwijdert
+onomkeerbaar de persoonlijke kennisbank van {user}. Suspend de
+gebruiker in plaats daarvan als je twijfelt."
+
+### D4 — Override-mechaniek = HTTP-header
+Industry-best-practice voor destructieve confirmation tokens is
+"headers or query params, NOT body" (DELETE-body semantiek is
+ongedefinieerd, sommige proxies droppen 'm). Headers worden in de
+geciteerde RESTful-bronnen "the most canonical option" genoemd.
+Klai heeft al een precedent: `I-CONFIRM-REMOVAL` in
+`klai-infra/sync-env.yml` (zie process-rules.md
+`sync-env-removal-needs-explicit-confirmation`). **Beslissing:**
+`X-Admin-Override-Confirm: I-WAS-NOT-CREATOR` zoals in REQ-1.1.
+
+### D5 — API-tokens en MCP-tokens worden auto-gerevoked bij offboard
+Onderzoek wees uit: **91% van offboarded-user-tokens blijft actief
+na delete** (Reco / Nudge Security 2026 onderzoek). Dit is een
+gedocumenteerd anti-pattern, geen edge-case. Klai heeft twee
+relevante endpoints:
+
+- `klai-portal/backend/app/api/admin_api_keys.py` — admin-kanaal
+  API-keys (per-user grants); helpers `_get_key_or_404`, `delete_api_key`.
+- `klai-portal/backend/app/api/me_mcp_tokens.py` — per-user MCP-tokens;
+  helper `revoke_my_token`.
+
+**Beslissing:** uitbreiden van REQ-2.x met REQ-2.7 (auto-revoke alle
+api-keys en MCP-tokens van de offboarded user binnen dezelfde DB-tx
+als de KB-dispositions). De preview-endpoint (REQ-2.1) telt en toont
+het aantal tokens dat geraakt zal worden. Geen "manual cleanup banner"
+— die past niet bij het industry-pattern.
+
+## Toegevoegde requirements (per beslissingen)
+
+- **REQ-2.1b** WHEN preview wordt opgehaald, THEN bevat de response
+  ook `api_keys_count: int` en `mcp_tokens_count: int` voor de target-user.
+- **REQ-2.7** WHEN offboard wordt uitgevoerd, THEN revoket de backend
+  binnen dezelfde DB-transactie (via expliciete `delete()` queries)
+  alle rijen in `portal_api_keys` met `created_by = target_user_id`
+  én alle rijen in `portal_mcp_tokens` (of equivalent) met
+  `user_id = target_user_id`. Failure rolt alles terug, inclusief
+  KB-dispositions.
+- **REQ-2.8** WHEN een personal-KB-disposition `action='delete'` is,
+  THEN voert de backend de volledige docs/ingest/portal-DB delete
+  onmiddellijk uit (zelfde 3-stap-keten als REQ-1.5). Geen soft-delete,
+  geen grace-period, geen reactivate-pad. Klanten die data willen
+  behouden gebruiken `suspend_user`.
+
+## Restant-vragen
+
+Geen. Alle 5 oorspronkelijke open vragen zijn gesloten via industry-
+research + productbeslissing van de eigenaar (2026-05-12). De drie
+verbeteringen — admin-delete, offboarding-transfer, personal-firewall
+— zijn nu eenduidig gedefinieerd en MVP-scope is helder afgebakend.
+
+## Migration / data-impact
+
+- Geen DDL-wijzigingen — bestaand model is voldoende.
+- Geen backfill — bestaande KBs zijn al correct gemodelleerd.
+- **Geen orphan-KBs in productie vandaag** (eigenaar-bevestigd
+  2026-05-12). De offboard-flow heeft historisch nog niemand
+  doorgevoerd; deze SPEC voorkomt dat toekomstige offboards
+  orphans achterlaten.
+
+## Implementation hints (niet-bindend)
+
+- Splits `_require_owner` niet — voeg een `_require_owner_or_admin_override`
+  helper toe die expliciet de override-header vraagt en bij gebruik de
+  audit-emit doet. Bestaande callers blijven `_require_owner` gebruiken.
+- `kb_offboarding.apply_dispositions` als async functie die een
+  `tenant_scoped_session` opent (zie
+  `klai/projects/portal-backend.md` Pool-GUC pollution) en in één commit
+  alle dispositions uitvoert. Externe calls (docs/ingest delete) buiten
+  de DB-transactie maar binnen een `try/finally` met compensating
+  transactions.
+- Frontend: bestaande `delete-kb-modal.tsx` uitbreiden met een
+  `mode: 'self' | 'admin-override'` prop in plaats van een nieuwe modal
+  — voorkomt drift in tekst en design.
+- Hard rule (per `.claude/rules/klai/portal-ui`): geen raw `<button>` of
+  inline Tailwind in de gele banner of de "Type DELETE" input — gebruik
+  `components/ui/`.
+
+## Risico's
+
+- **R1 — Admin verwijdert per ongeluk een KB van het hele team.** Mitigatie:
+  twee-staps modal + verplicht typen van DELETE + audit-event. Verlies
+  blijft mogelijk maar minder waarschijnlijk dan via DB-ingrijpen vandaag.
+- **R2 — Frontend stuurt header per ongeluk altijd.** Mitigatie: header
+  alleen toegevoegd in de `admin-override`-modal-variant, met een
+  `data-test-id` zodat een unit test bevestigt dat de owner-pad-modal
+  hem nooit set.
+- **R3 — Personal-firewall regression bij refactor.** Mitigatie:
+  REQ-3.3 invariant-test draait op élke PR, faalt hard als een nieuwe
+  KB-route de gate vergeet. Phase 2 voegt RLS-laag toe.
+- **R4 — Offboarding stuck op extern systeem (docs-app of ingest down).**
+  Mitigatie: dezelfde semantiek als de bestaande owner-delete — failure
+  abort vóór portal-DB-mutatie. Admin krijgt foutmelding en kan
+  retry'en. User wordt niet half-offboarded.
+- **R5 — Disposition-transfer op org-KB met X als enige owner én X als
+  laatste user in de org.** Edge case: admin offboardt zichzelf en is
+  enige user. Bestaande `leave_workspace` en
+  `_lock_org_for_role_change` handelen tenant-leegloop al — dit SPEC
+  verandert daar niets aan; transfer faalt expliciet ("can't transfer
+  to non-existent receiver") wat de admin dwingt eerst de tenant te
+  deprovisionen via SPEC-INFRA-TENANT-DELETE-001.
+
+## Niet-MVP follow-ups (preview)
+
+- Bulk-admin-delete (selecteer 5 KBs).
+- Tombstone gebruik bij admin-override (slug-reuse audit-trail).
+- Restore-on-rehire window voor personal KBs.
+- DB-laag RLS-policy als laag D van de personal-firewall.
+- Self-service personal-KB-export voor de offboarded user (download).
+- API-token / MCP-key cleanup als onderdeel van offboarding.
+- Grafana-alert op `kb_personal_purged_on_offboard`-rate.

--- a/klai-portal/backend/app/api/admin/users.py
+++ b/klai-portal/backend/app/api/admin/users.py
@@ -29,6 +29,13 @@ from app.models.groups import PortalGroup, PortalGroupMembership
 from app.models.portal import PortalOrg, PortalUser
 from app.services.audit import log_event
 from app.services.github import remove_github_org_member
+from app.services.kb_offboarding import (
+    KbDisposition,
+    OffboardPreview,
+    apply_dispositions,
+    compute_offboard_preview,
+    revoke_user_credentials,
+)
 from app.services.mcp_role_notifier import fire_role_change_notification
 from app.services.zitadel import zitadel
 
@@ -608,26 +615,129 @@ async def reactivate_user(
     return MessageResponse(message=f"User {zitadel_user_id} reactivated.")
 
 
-@router.post("/users/{zitadel_user_id}/offboard", response_model=MessageResponse)
-async def offboard_user(
+@router.get("/users/{zitadel_user_id}/offboard-preview", response_model=OffboardPreview)
+async def offboard_preview(
     zitadel_user_id: str,
     perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
-) -> MessageResponse:
-    """Offboard a user: remove memberships + products, deactivate in Zitadel, set status."""
-    result = await db.execute(
+) -> OffboardPreview:
+    """SPEC-PORTAL-KB-OWNERSHIP-001 REQ-2.1 — preview KB-dispositions for offboard.
+
+    Returns the org KBs the user is the sole owner of (admin must choose
+    transfer-to or delete), the personal KBs (always purged on offboard),
+    and the count of API-keys / MCP-tokens that will be auto-revoked.
+    The frontend uses this to render the offboard wizard.
+    """
+    # Verify user belongs to caller's tenant before exposing any data.
+    user_result = await db.execute(
         select(PortalUser).where(
             PortalUser.zitadel_user_id == zitadel_user_id,
             PortalUser.org_id == perms.org_id,
         )
     )
-    user = result.scalar_one_or_none()
+    if user_result.scalar_one_or_none() is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    return await compute_offboard_preview(zitadel_user_id, perms.org_id, db)
+
+
+class OffboardRequest(BaseModel):
+    """Body for ``POST /api/admin/users/{zitadel_user_id}/offboard``.
+
+    REQ-2.5 — every KB returned by ``offboard-preview`` MUST appear here
+    with an explicit disposition, otherwise we 400 with the missing list.
+    No implicit defaults: silent-orphans are the failure mode this SPEC
+    exists to prevent.
+    """
+
+    kb_dispositions: list[KbDisposition] = []
+
+
+@router.post("/users/{zitadel_user_id}/offboard", response_model=MessageResponse)
+async def offboard_user(
+    zitadel_user_id: str,
+    body: OffboardRequest | None = None,
+    perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
+    db: AsyncSession = Depends(get_db),
+) -> MessageResponse:
+    """Offboard a user: KB-dispositions + token-revoke + memberships + Zitadel.
+
+    SPEC-PORTAL-KB-OWNERSHIP-001 Phase 3 expanded the surface of this
+    endpoint. The request body is now mandatory whenever the offboard
+    preview lists any KBs — see REQ-2.5. Order of operations inside the
+    DB transaction:
+
+      1. Validate body covers EVERY KB returned by the preview (REQ-2.5).
+      2. Apply KB dispositions via ``apply_dispositions`` (REQ-2.2 .. 2.6 + 2.8).
+      3. Revoke partner API keys + MCP tokens via ``revoke_user_credentials`` (REQ-2.7).
+      4. Delete tenant-scoped group memberships (existing SEC-TENANT-001 logic).
+      5. Flip user.status to 'offboarded' + emit user.offboarded audit.
+      6. Commit DB transaction.
+      7. After-commit: Zitadel deactivate + GitHub remove.
+
+    Failure in steps 1-5 raises and rolls back the entire transaction —
+    the user stays ``active`` and KBs are unchanged. Failure in step 7
+    leaves the user ``offboarded`` in our DB but Zitadel/GitHub
+    out-of-sync; this is the same fail-open behaviour the endpoint had
+    before this SPEC and is fine for now (the cleanup-runbook lists it).
+    """
+    body = body or OffboardRequest()
+
+    user_result = await db.execute(
+        select(PortalUser).where(
+            PortalUser.zitadel_user_id == zitadel_user_id,
+            PortalUser.org_id == perms.org_id,
+        )
+    )
+    user = user_result.scalar_one_or_none()
     if not user:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
     if user.status == "offboarded":
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="User has already been offboarded")
 
-    # Cascade: remove group memberships and product assignments.
+    # REQ-2.5 — fetch the preview and verify the body covers every KB it
+    # lists. Missing dispositions return 400 with the explicit slug list
+    # so the frontend can re-render the wizard with the offending entries
+    # highlighted.
+    org_result = await db.execute(select(PortalOrg).where(PortalOrg.id == perms.org_id))
+    org = org_result.scalar_one_or_none()
+    if org is None:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Organisation not found")
+
+    preview = await compute_offboard_preview(zitadel_user_id, perms.org_id, db)
+    expected_kb_ids = {kb.kb_id for kb in preview.org_kbs_solely_owned} | {kb.kb_id for kb in preview.personal_kbs}
+    provided_kb_ids = {d.kb_id for d in body.kb_dispositions}
+    missing = expected_kb_ids - provided_kb_ids
+    if missing:
+        # Build a stable, human-readable list (slug-based) so the admin
+        # can click straight to the affected KBs in the wizard.
+        kb_lookup: dict[int, str] = {kb.kb_id: kb.slug for kb in (*preview.org_kbs_solely_owned, *preview.personal_kbs)}
+        missing_slugs = sorted(kb_lookup[kb_id] for kb_id in missing)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "error_code": "missing_kb_dispositions",
+                "missing": missing_slugs,
+                "message": f"Missing dispositions for: [{', '.join(missing_slugs)}]",
+            },
+        )
+
+    # REQ-2.2 — KB dispositions inside the offboard tx.
+    await apply_dispositions(
+        target_user_id=zitadel_user_id,
+        dispositions=body.kb_dispositions,
+        actor_user_id=perms.user_id,
+        org=org,
+        db=db,
+    )
+
+    # REQ-2.7 — token revoke inside the same tx.
+    api_keys_deleted, mcp_tokens_revoked = await revoke_user_credentials(
+        target_user_id=zitadel_user_id,
+        org_id=perms.org_id,
+        db=db,
+    )
+
+    # Cascade: remove group memberships.
     #
     # SPEC-SEC-TENANT-001 REQ-1: scope the membership delete to the caller's
     # org via PortalGroup.org_id. PortalGroupMembership has no org_id column
@@ -656,6 +766,9 @@ async def offboard_user(
         org_id=perms.org_id,
         zitadel_user_id=zitadel_user_id,
         memberships_removed_count=memberships_removed_count,
+        kb_dispositions_count=len(body.kb_dispositions),
+        api_keys_deleted=api_keys_deleted,
+        mcp_tokens_revoked=mcp_tokens_revoked,
     )
     await log_event(
         org_id=perms.org_id,
@@ -663,13 +776,22 @@ async def offboard_user(
         action="user.offboarded",
         resource_type="user",
         resource_id=zitadel_user_id,
+        details={
+            "kb_dispositions_count": len(body.kb_dispositions),
+            "api_keys_deleted": api_keys_deleted,
+            "mcp_tokens_revoked": mcp_tokens_revoked,
+        },
     )
+    await db.commit()
+
+    # Post-commit external side-effects. Failures here leave us in the
+    # documented "DB-side offboarded, IdP-side still active" state — same
+    # behaviour as before this SPEC.
     await zitadel.deactivate_user(settings.zitadel_portal_org_id, zitadel_user_id)
     if user.github_username:
         await remove_github_org_member(user.github_username)
     else:
         logger.info("GitHub offboarding skipped for %s: no github_username linked", zitadel_user_id)
-    await db.commit()
     return MessageResponse(message=f"User {zitadel_user_id} offboarded.")
 
 

--- a/klai-portal/backend/app/api/app_knowledge_bases.py
+++ b/klai-portal/backend/app/api/app_knowledge_bases.py
@@ -8,7 +8,7 @@ from typing import Literal
 
 import httpx
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field
 from sqlalchemy import func, select, text
 from sqlalchemy.exc import IntegrityError
@@ -18,7 +18,7 @@ from app.api.dependencies import _load_org_or_500, get_kb_with_access, require_c
 from app.core.config import settings
 from app.core.database import get_db
 from app.core.permissions import UserPermissions, get_caller
-from app.core.profiles import Capability
+from app.core.profiles import Capability, ProfileRole
 from app.models.connectors import PortalConnector
 from app.models.groups import PortalGroup
 from app.models.kb_uploads import KBUpload
@@ -26,9 +26,18 @@ from app.models.knowledge_bases import PortalGroupKBAccess, PortalKnowledgeBase,
 from app.models.portal import PortalUser
 from app.models.retrieval_gaps import PortalRetrievalGap
 from app.services import docs_client, knowledge_ingest_client
-from app.services.access import get_user_role_for_kb
+from app.services.access import get_user_role_for_kb, is_personal_kb
+from app.services.audit import log_event
 from app.services.kb_quota import assert_can_create_org_kb, assert_can_create_personal_kb
 from app.services.zitadel import zitadel
+
+# SPEC-PORTAL-KB-OWNERSHIP-001 REQ-1.1 — header-based admin-override token.
+# Header value mirrors the I-CONFIRM-REMOVAL precedent in
+# klai-infra/sync-env.yml: a typed string forces explicit operator intent
+# rather than a click-through boolean. The dual-confirmation modal in the
+# frontend is what gives the operator the chance to abort.
+ADMIN_OVERRIDE_HEADER = "X-Admin-Override-Confirm"
+ADMIN_OVERRIDE_VALUE = "I-WAS-NOT-CREATOR"
 
 logger = structlog.get_logger()
 _QDRANT_COLLECTION = "klai_knowledge"
@@ -627,12 +636,29 @@ async def create_app_knowledge_base(
 )
 async def delete_app_knowledge_base(
     kb_slug: str,
+    request: Request,
     perms: UserPermissions = Depends(get_caller),
     db: AsyncSession = Depends(get_db),
 ) -> None:
-    """Delete a KB and all associated data. Requires owner access.
+    """Delete a KB and all associated data.
 
-    Deletion order:
+    Two paths to a delete (SPEC-PORTAL-KB-OWNERSHIP-001 REQ-1):
+
+    1. **Owner pad**: caller has owner role on the KB (creator implicitly,
+       or explicit owner via portal_user_kb_access). No override header.
+    2. **Admin-override pad**: caller has ProfileRole.ADMIN, the KB is
+       org-owned (``owner_type='org'``), AND the request carries
+       ``X-Admin-Override-Confirm: I-WAS-NOT-CREATOR``. The header forces
+       explicit intent — the frontend only attaches it after a typed
+       "DELETE" confirmation in a second modal.
+
+    Personal KBs of other users are 404 (firewall in
+    ``get_kb_with_access`` runs before this body). The handler body
+    re-checks the personal-firewall as belt-and-braces: if a future
+    refactor accidentally moves the dep, the body still refuses to
+    admin-override on personal KBs.
+
+    Deletion order (identical for both paths — REQ-1.5):
     1. docs-app (only if gitea_repo_slug or docs_enabled) — Qdrant vectors, Gitea, docs DB row.
     2. knowledge-ingest (always) — FalkorDB graph nodes, Qdrant chunks, PG artifacts.
     3. Portal DB — KB row + cascaded access rows.
@@ -641,7 +667,42 @@ async def delete_app_knowledge_base(
     """
     org = await _load_org_or_500(db, perms.org_id)
     kb = await _get_kb_or_404(kb_slug, perms.org_id, db)
-    await _require_owner(kb, perms.user_id, db)
+
+    role = await get_user_role_for_kb(
+        kb.id,
+        perms.user_id,
+        db,
+        default_org_role=kb.default_org_role,
+        kb_org_id=kb.org_id,
+        kb_created_by=kb.created_by,
+    )
+    is_owner = role == "owner"
+
+    admin_override_used = False
+    if not is_owner:
+        # Admin-override pad gating (REQ-1.1, REQ-1.2, REQ-1.3).
+        override_header = request.headers.get(ADMIN_OVERRIDE_HEADER, "")
+        is_admin = perms.effective_role == ProfileRole.ADMIN
+        header_present = override_header == ADMIN_OVERRIDE_VALUE
+        # Belt-and-braces: even with the override header + admin role, refuse
+        # to delete a personal KB of someone else. The route-level firewall
+        # already returns 404 before this body, but a future refactor that
+        # removes the dep must not silently expose personal data to admins.
+        if is_admin and header_present and is_personal_kb(kb) and kb.owner_user_id != perms.user_id:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Knowledge base not found",
+            )
+        if not (is_admin and header_present and not is_personal_kb(kb)):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=(
+                    f"Owner access required, or set header "
+                    f"'{ADMIN_OVERRIDE_HEADER}: {ADMIN_OVERRIDE_VALUE}' as an admin"
+                    " to delete an org KB you did not create"
+                ),
+            )
+        admin_override_used = True
 
     # Step 1: Clean up docs-app (Qdrant vectors managed by docs, Gitea webhook/repo, docs DB row).
     if kb.gitea_repo_slug or kb.docs_enabled:
@@ -650,6 +711,35 @@ async def delete_app_knowledge_base(
     # Step 2: Clean up knowledge-ingest data (FalkorDB graph nodes, Qdrant chunks, PG artifacts).
     # Always called, regardless of docs/gitea state — connector-based KBs never have gitea_repo_slug.
     await knowledge_ingest_client.delete_kb(org.zitadel_org_id, kb.slug)
+
+    # REQ-1.4 + REQ-4.1 — emit audit event when the admin-override pad fired.
+    # Owner deletes still leave an auth trail via Caddy access logs; admin
+    # cross-user deletes need the explicit application-level event so the
+    # actor and previous_owner are queryable from portal_audit_log.
+    if admin_override_used:
+        await log_event(
+            org_id=perms.org_id,
+            actor=perms.user_id,
+            action="kb.admin_deleted",
+            resource_type="kb",
+            resource_id=str(kb.id),
+            details={
+                "previous_owner": kb.created_by,
+                "kb_name": kb.name,
+                "kb_slug": kb.slug,
+            },
+        )
+        # REQ-4.2 — structlog event so the same data lands in VictoriaLogs
+        # for cross-service trace correlation. structlog kwargs become
+        # top-level JSON keys, queryable as `event:kb_admin_deleted` etc.
+        logger.info(
+            "kb_admin_deleted",
+            org_id=perms.org_id,
+            actor_user_id=perms.user_id,
+            kb_id=kb.id,
+            kb_slug=kb.slug,
+            previous_owner=kb.created_by,
+        )
 
     # Step 3: Portal DB -- delete KB row (cascades access rows).
     # No tombstone: slug is free to reuse after a full delete (all data wiped).

--- a/klai-portal/backend/app/api/app_knowledge_bases.py
+++ b/klai-portal/backend/app/api/app_knowledge_bases.py
@@ -14,7 +14,7 @@ from sqlalchemy import func, select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.dependencies import _load_org_or_500, require_capability
+from app.api.dependencies import _load_org_or_500, get_kb_with_access, require_capability
 from app.core.config import settings
 from app.core.database import get_db
 from app.core.permissions import UserPermissions, get_caller
@@ -502,7 +502,7 @@ async def knowledge_bases_stats_summary(
     return KBStatsSummaryResponse(stats=stats)
 
 
-@router.get("/knowledge-bases/{kb_slug}", response_model=AppKBOut)
+@router.get("/knowledge-bases/{kb_slug}", response_model=AppKBOut, dependencies=[Depends(get_kb_with_access)])
 async def get_app_knowledge_base(
     kb_slug: str,
     perms: UserPermissions = Depends(get_caller),
@@ -622,7 +622,9 @@ async def create_app_knowledge_base(
     return _kb_out(kb)
 
 
-@router.delete("/knowledge-bases/{kb_slug}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/knowledge-bases/{kb_slug}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(get_kb_with_access)]
+)
 async def delete_app_knowledge_base(
     kb_slug: str,
     perms: UserPermissions = Depends(get_caller),
@@ -662,7 +664,9 @@ class UpdateDefaultOrgRoleRequest(BaseModel):
     default_org_role: str | None  # "viewer", "contributor", or null
 
 
-@router.put("/knowledge-bases/{kb_slug}/default-org-role", response_model=AppKBOut)
+@router.put(
+    "/knowledge-bases/{kb_slug}/default-org-role", response_model=AppKBOut, dependencies=[Depends(get_kb_with_access)]
+)
 async def update_default_org_role(
     kb_slug: str,
     body: UpdateDefaultOrgRoleRequest,
@@ -695,7 +699,7 @@ class AppKBUpdateRequest(BaseModel):
     default_org_role: str | None = None
 
 
-@router.patch("/knowledge-bases/{kb_slug}", response_model=AppKBOut)
+@router.patch("/knowledge-bases/{kb_slug}", response_model=AppKBOut, dependencies=[Depends(get_kb_with_access)])
 async def update_knowledge_base(
     kb_slug: str,
     body: AppKBUpdateRequest,
@@ -766,7 +770,7 @@ async def update_knowledge_base(
 # -- Stats --------------------------------------------------------------------
 
 
-@router.get("/knowledge-bases/{kb_slug}/stats", response_model=KBStatsOut)
+@router.get("/knowledge-bases/{kb_slug}/stats", response_model=KBStatsOut, dependencies=[Depends(get_kb_with_access)])
 async def get_kb_stats(
     kb_slug: str,
     perms: UserPermissions = Depends(get_caller),
@@ -1013,6 +1017,7 @@ def _upload_type_label(content_type: str) -> str:
 @router.get(
     "/knowledge-bases/{kb_slug}/sources",
     response_model=SourcesResponse,
+    dependencies=[Depends(get_kb_with_access)],
 )
 async def list_kb_sources(
     kb_slug: str,
@@ -1158,6 +1163,7 @@ async def list_kb_sources(
 @router.get(
     "/knowledge-bases/{kb_slug}/sources/{source_id}/content",
     response_model=SourceContentResponse,
+    dependencies=[Depends(get_kb_with_access)],
 )
 async def get_source_content(
     kb_slug: str,
@@ -1254,7 +1260,11 @@ async def get_source_content(
 # -- Uploads: reindex / delete ------------------------------------------------
 
 
-@router.post("/knowledge-bases/{kb_slug}/uploads/{artifact_id}/reindex", status_code=202)
+@router.post(
+    "/knowledge-bases/{kb_slug}/uploads/{artifact_id}/reindex",
+    status_code=202,
+    dependencies=[Depends(get_kb_with_access)],
+)
 async def reindex_upload(
     kb_slug: str,
     artifact_id: str,
@@ -1292,6 +1302,7 @@ async def reindex_upload(
 @router.patch(
     "/knowledge-bases/{kb_slug}/uploads/{artifact_id}",
     response_model=RenameUploadResponse,
+    dependencies=[Depends(get_kb_with_access)],
 )
 async def rename_kb_upload(
     kb_slug: str,
@@ -1335,7 +1346,9 @@ async def rename_kb_upload(
     )
 
 
-@router.delete("/knowledge-bases/{kb_slug}/uploads/{artifact_id}", status_code=204)
+@router.delete(
+    "/knowledge-bases/{kb_slug}/uploads/{artifact_id}", status_code=204, dependencies=[Depends(get_kb_with_access)]
+)
 async def delete_kb_upload(
     kb_slug: str,
     artifact_id: str,
@@ -1385,7 +1398,7 @@ async def delete_kb_upload(
 @router.get(
     "/knowledge-bases/{kb_slug}/members",
     response_model=MembersResponse,
-    dependencies=[Depends(require_capability(Capability.KB_MEMBERS))],
+    dependencies=[Depends(require_capability(Capability.KB_MEMBERS)), Depends(get_kb_with_access)],
 )
 async def list_members(
     kb_slug: str,
@@ -1441,7 +1454,7 @@ async def list_members(
     "/knowledge-bases/{kb_slug}/members/users",
     response_model=UserMemberOut,
     status_code=status.HTTP_201_CREATED,
-    dependencies=[Depends(require_capability(Capability.KB_MEMBERS))],
+    dependencies=[Depends(require_capability(Capability.KB_MEMBERS)), Depends(get_kb_with_access)],
 )
 async def invite_user(
     kb_slug: str,
@@ -1509,7 +1522,7 @@ async def invite_user(
 @router.patch(
     "/knowledge-bases/{kb_slug}/members/users/{access_id}",
     response_model=UserMemberOut,
-    dependencies=[Depends(require_capability(Capability.KB_MEMBERS))],
+    dependencies=[Depends(require_capability(Capability.KB_MEMBERS)), Depends(get_kb_with_access)],
 )
 async def update_user_role(
     kb_slug: str,
@@ -1556,7 +1569,7 @@ async def update_user_role(
 @router.delete(
     "/knowledge-bases/{kb_slug}/members/users/{access_id}",
     status_code=status.HTTP_204_NO_CONTENT,
-    dependencies=[Depends(require_capability(Capability.KB_MEMBERS))],
+    dependencies=[Depends(require_capability(Capability.KB_MEMBERS)), Depends(get_kb_with_access)],
 )
 async def remove_user(
     kb_slug: str,
@@ -1589,7 +1602,7 @@ async def remove_user(
     "/knowledge-bases/{kb_slug}/members/groups",
     response_model=GroupMemberOut,
     status_code=status.HTTP_201_CREATED,
-    dependencies=[Depends(require_capability(Capability.KB_MEMBERS))],
+    dependencies=[Depends(require_capability(Capability.KB_MEMBERS)), Depends(get_kb_with_access)],
 )
 async def invite_group(
     kb_slug: str,
@@ -1644,7 +1657,7 @@ async def invite_group(
 @router.patch(
     "/knowledge-bases/{kb_slug}/members/groups/{access_id}",
     response_model=GroupMemberOut,
-    dependencies=[Depends(require_capability(Capability.KB_MEMBERS))],
+    dependencies=[Depends(require_capability(Capability.KB_MEMBERS)), Depends(get_kb_with_access)],
 )
 async def update_group_role(
     kb_slug: str,
@@ -1689,7 +1702,7 @@ async def update_group_role(
 @router.delete(
     "/knowledge-bases/{kb_slug}/members/groups/{access_id}",
     status_code=status.HTTP_204_NO_CONTENT,
-    dependencies=[Depends(require_capability(Capability.KB_MEMBERS))],
+    dependencies=[Depends(require_capability(Capability.KB_MEMBERS)), Depends(get_kb_with_access)],
 )
 async def remove_group(
     kb_slug: str,
@@ -1792,7 +1805,11 @@ class CrawlPreviewResponse(BaseModel):
     classification_reason: str | None = None
 
 
-@router.post("/knowledge-bases/{kb_slug}/connectors/crawl-preview", response_model=CrawlPreviewResponse)
+@router.post(
+    "/knowledge-bases/{kb_slug}/connectors/crawl-preview",
+    response_model=CrawlPreviewResponse,
+    dependencies=[Depends(get_kb_with_access)],
+)
 async def crawl_preview(
     kb_slug: str,
     body: CrawlPreviewRequest,
@@ -1849,7 +1866,11 @@ class AuthProbeResponse(BaseModel):
     auth_guard: dict | None = None
 
 
-@router.post("/knowledge-bases/{kb_slug}/connectors/auth-probe", response_model=AuthProbeResponse)
+@router.post(
+    "/knowledge-bases/{kb_slug}/connectors/auth-probe",
+    response_model=AuthProbeResponse,
+    dependencies=[Depends(get_kb_with_access)],
+)
 async def auth_probe(
     kb_slug: str,
     body: AuthProbeRequest,

--- a/klai-portal/backend/app/api/app_knowledge_sources.py
+++ b/klai-portal/backend/app/api/app_knowledge_sources.py
@@ -35,7 +35,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.datastructures import UploadFile
 
-from app.api.dependencies import _load_org_or_500
+from app.api.dependencies import _load_org_or_500, get_kb_with_access
 from app.core.database import get_db
 from app.core.permissions import UserPermissions, get_caller
 from app.core.profiles import ProfileRole
@@ -240,6 +240,7 @@ def _hostname(raw: str) -> str:
     "/knowledge-bases/{kb_slug}/sources/url",
     response_model=SourceIngestedResponse,
     status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(get_kb_with_access)],
 )
 async def add_url_source(
     kb_slug: str,
@@ -289,6 +290,7 @@ async def add_url_source(
 @router.post(
     "/knowledge-bases/{kb_slug}/sources/youtube",
     status_code=status.HTTP_410_GONE,
+    dependencies=[Depends(get_kb_with_access)],
 )
 async def add_youtube_source(
     kb_slug: str,
@@ -327,6 +329,7 @@ async def add_youtube_source(
     "/knowledge-bases/{kb_slug}/sources/text",
     response_model=SourceIngestedResponse,
     status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(get_kb_with_access)],
 )
 async def add_text_source(
     kb_slug: str,
@@ -614,6 +617,7 @@ async def _dispatch_blob(
     "/knowledge-bases/{kb_slug}/sources/file",
     response_model=FileSourcesIngestedResponse,
     status_code=status.HTTP_202_ACCEPTED,
+    dependencies=[Depends(get_kb_with_access)],
 )
 async def add_file_source(
     kb_slug: str,
@@ -785,6 +789,7 @@ class FileUploadStatusResponse(BaseModel):
 @router.get(
     "/knowledge-bases/{kb_slug}/sources/file/{upload_id}/status",
     response_model=FileUploadStatusResponse,
+    dependencies=[Depends(get_kb_with_access)],
 )
 async def get_file_source_status(
     kb_slug: str,

--- a/klai-portal/backend/app/api/connectors.py
+++ b/klai-portal/backend/app/api/connectors.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, Field, model_validator
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.dependencies import _load_org_or_500, get_effective_capabilities, require_capability
+from app.api.dependencies import _load_org_or_500, get_effective_capabilities, get_kb_with_access, require_capability
 from app.core.database import get_db
 from app.core.permissions import UserPermissions, get_caller
 from app.core.profiles import Capability, ProfileRole, check_connector_allowed
@@ -67,7 +67,12 @@ router = APIRouter(
     prefix="/api/app/knowledge-bases/{kb_slug}/connectors",
     tags=["connectors"],
     # R-X2 / AC-3: all connector endpoints require the kb.connectors capability.
-    dependencies=[Depends(require_capability(Capability.KB_CONNECTORS))],
+    # SPEC-PORTAL-KB-OWNERSHIP-001 REQ-3: firewall personal-KBs of other users
+    # at the router level — every connector route inherits the gate.
+    dependencies=[
+        Depends(require_capability(Capability.KB_CONNECTORS)),
+        Depends(get_kb_with_access),
+    ],
 )
 
 # -- Webcrawler config schema (SPEC-CRAWL-003) --------------------------------

--- a/klai-portal/backend/app/api/dependencies.py
+++ b/klai-portal/backend/app/api/dependencies.py
@@ -7,13 +7,74 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.api.auth import get_current_user_id
 from app.api.bearer import bearer as bearer  # re-export for routes that import from here
 from app.core.database import get_db
+from app.core.permissions import UserPermissions, get_caller
 from app.core.plan_limits import PLAN_LIMITS, get_plan_limits
 from app.core.profiles import (
     PROFILE_CAPABILITIES,
     Capability,
 )
+from app.models.knowledge_bases import PortalKnowledgeBase
 from app.models.portal import PortalOrg, PortalUser
+from app.services.access import is_personal_kb
 from app.services.entitlements import get_effective_products
+
+
+async def get_kb_with_access(
+    kb_slug: str,
+    perms: UserPermissions = Depends(get_caller),
+    db: AsyncSession = Depends(get_db),
+) -> PortalKnowledgeBase:
+    """Resolve a KB by slug + enforce the personal-firewall.
+
+    SPEC-PORTAL-KB-OWNERSHIP-001 REQ-3.1 — single source of truth for
+    every ``/api/app/knowledge-bases/{kb_slug}/...`` route.
+
+    Three steps, in order:
+
+    1. **Magic-slug shortcuts**: ``personal`` resolves to the caller's
+       ``personal-{user_id}`` KB; ``org`` resolves to the tenant's org
+       KB. Both are lazy-created if provisioning missed them. These
+       slugs are by definition owned-by-or-visible-to the caller, so
+       the firewall step is a no-op.
+    2. **Tenant-scope**: SELECT WHERE org_id = caller.org_id AND slug = kb_slug.
+       Cross-tenant slugs return 0 rows -> 404. Org-scoping is also
+       enforced at the DB level via Cat-D RLS on
+       ``portal_knowledge_bases``; this is belt+braces.
+    3. **Personal-firewall**: if the resolved KB is personal
+       (``is_personal_kb()``) AND the caller is not the
+       ``owner_user_id``, raise 404. NOT 403 — leaking existence of a
+       personal KB to non-owners is itself a privacy violation. Admins
+       also receive 404 (no role-bypass).
+
+    Authorisation (owner / contributor / viewer) is layered on TOP of
+    this gate via ``_require_owner`` etc. in the KB API module. This
+    dependency only handles existence + privacy; it does not gate
+    write actions.
+    """
+    # Magic-slug shortcuts. Imported here to avoid a top-level circular import
+    # via app.services.default_knowledge_bases -> set_tenant -> ... -> dependencies.
+    if kb_slug == "personal":
+        from app.services.default_knowledge_bases import resolve_personal_kb
+
+        return await resolve_personal_kb(perms.user_id, perms.org_id, db)
+    if kb_slug == "org":
+        from app.services.default_knowledge_bases import resolve_org_kb
+
+        return await resolve_org_kb(perms.user_id, perms.org_id, db)
+
+    result = await db.execute(
+        select(PortalKnowledgeBase).where(
+            PortalKnowledgeBase.org_id == perms.org_id,
+            PortalKnowledgeBase.slug == kb_slug,
+        )
+    )
+    kb = result.scalar_one_or_none()
+    if kb is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Knowledge base not found")
+    # Personal-firewall: existence-non-disclosure.
+    if is_personal_kb(kb) and kb.owner_user_id != perms.user_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Knowledge base not found")
+    return kb
 
 
 def require_product(product: str):

--- a/klai-portal/backend/app/api/kb_images.py
+++ b/klai-portal/backend/app/api/kb_images.py
@@ -37,6 +37,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.app_knowledge_bases import _get_kb_or_404
+from app.api.dependencies import get_kb_with_access
 from app.api.partner_dependencies import PartnerAuthContext, get_partner_key
 from app.api.session_deps import get_optional_session
 from app.core.config import settings
@@ -264,7 +265,7 @@ async def get_kb_image(
 #   serves as memory-DoS guard for parallel uploads. The route path is sourced
 #   from KbImage.UPLOAD_ROUTE_TEMPLATE (SPEC-KB-IMAGES-V2-001 REQ-2).
 # @MX:SPEC: SPEC-PORTAL-DOCS-IMAGE-PASTE-001 + SPEC-KB-IMAGES-V2-001 REQ-2
-@router.post(KbImage.UPLOAD_ROUTE_TEMPLATE)
+@router.post(KbImage.UPLOAD_ROUTE_TEMPLATE, dependencies=[Depends(get_kb_with_access)])
 async def upload_kb_image(
     request: Request,
     kb_slug: str,

--- a/klai-portal/backend/app/api/taxonomy.py
+++ b/klai-portal/backend/app/api/taxonomy.py
@@ -13,7 +13,7 @@ from sqlalchemy import func, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.dependencies import _load_org_or_500, require_capability
+from app.api.dependencies import _load_org_or_500, get_kb_with_access, require_capability
 from app.core.config import settings
 from app.core.database import get_db, set_tenant
 from app.core.permissions import ProfileRole, UserPermissions, get_caller, get_caller_at_least
@@ -197,7 +197,7 @@ async def _check_circular_reference(
 @router.get(
     "/{kb_slug}/taxonomy/nodes",
     response_model=TaxonomyNodesResponse,
-    dependencies=[Depends(require_capability(Capability.KB_TAXONOMY))],
+    dependencies=[Depends(require_capability(Capability.KB_TAXONOMY)), Depends(get_kb_with_access)],
 )
 async def list_taxonomy_nodes(
     kb_slug: str,
@@ -220,7 +220,7 @@ async def list_taxonomy_nodes(
     "/{kb_slug}/taxonomy/nodes",
     response_model=TaxonomyNodeOut,
     status_code=status.HTTP_201_CREATED,
-    dependencies=[Depends(require_capability(Capability.KB_TAXONOMY))],
+    dependencies=[Depends(require_capability(Capability.KB_TAXONOMY)), Depends(get_kb_with_access)],
 )
 async def create_taxonomy_node(
     kb_slug: str,
@@ -270,7 +270,7 @@ async def create_taxonomy_node(
 @router.patch(
     "/{kb_slug}/taxonomy/nodes/{node_id}",
     response_model=TaxonomyNodeOut,
-    dependencies=[Depends(require_capability(Capability.KB_TAXONOMY))],
+    dependencies=[Depends(require_capability(Capability.KB_TAXONOMY)), Depends(get_kb_with_access)],
 )
 async def update_taxonomy_node(
     kb_slug: str,
@@ -340,7 +340,7 @@ async def update_taxonomy_node(
 @router.delete(
     "/{kb_slug}/taxonomy/nodes/{node_id}",
     status_code=status.HTTP_200_OK,
-    dependencies=[Depends(require_capability(Capability.KB_TAXONOMY))],
+    dependencies=[Depends(require_capability(Capability.KB_TAXONOMY)), Depends(get_kb_with_access)],
 )
 async def delete_taxonomy_node(
     kb_slug: str,
@@ -392,7 +392,7 @@ async def delete_taxonomy_node(
 @router.get(
     "/{kb_slug}/taxonomy/proposals",
     response_model=ProposalsResponse,
-    dependencies=[Depends(require_capability(Capability.KB_TAXONOMY))],
+    dependencies=[Depends(require_capability(Capability.KB_TAXONOMY)), Depends(get_kb_with_access)],
 )
 async def list_taxonomy_proposals(
     kb_slug: str,
@@ -669,6 +669,7 @@ async def _execute_rename(
 @router.post(
     "/{kb_slug}/taxonomy/proposals/{proposal_id}/approve",
     response_model=ProposalOut,
+    dependencies=[Depends(get_kb_with_access)],
 )
 async def approve_proposal(
     kb_slug: str,
@@ -784,6 +785,7 @@ async def approve_proposal(
 @router.post(
     "/{kb_slug}/taxonomy/proposals/{proposal_id}/reject",
     response_model=ProposalOut,
+    dependencies=[Depends(get_kb_with_access)],
 )
 async def reject_proposal(
     kb_slug: str,
@@ -821,7 +823,7 @@ async def reject_proposal(
 # -- Bootstrap & backfill triggers -------------------------------------------
 
 
-@router.post("/{kb_slug}/taxonomy/bootstrap")
+@router.post("/{kb_slug}/taxonomy/bootstrap", dependencies=[Depends(get_kb_with_access)])
 async def trigger_bootstrap(
     kb_slug: str,
     perms: UserPermissions = Depends(get_caller),
@@ -859,7 +861,7 @@ async def trigger_bootstrap(
     return result
 
 
-@router.post("/{kb_slug}/taxonomy/backfill-trigger")
+@router.post("/{kb_slug}/taxonomy/backfill-trigger", dependencies=[Depends(get_kb_with_access)])
 async def trigger_backfill(
     kb_slug: str,
     perms: UserPermissions = Depends(get_caller),
@@ -895,7 +897,7 @@ async def trigger_backfill(
     return result
 
 
-@router.get("/{kb_slug}/taxonomy/backfill/{job_id}")
+@router.get("/{kb_slug}/taxonomy/backfill/{job_id}", dependencies=[Depends(get_kb_with_access)])
 async def get_backfill_status(
     kb_slug: str,
     job_id: int,
@@ -1029,7 +1031,7 @@ def _make_coverage_response(
     )
 
 
-@router.get("/{kb_slug}/taxonomy/coverage", response_model=CoverageResponse)
+@router.get("/{kb_slug}/taxonomy/coverage", response_model=CoverageResponse, dependencies=[Depends(get_kb_with_access)])
 async def taxonomy_coverage(
     kb_slug: str,
     perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
@@ -1133,7 +1135,7 @@ async def _fetch_ingest_top_tags(org_id: str, kb_slug: str, limit: int, taxonomy
         return None
 
 
-@router.get("/{kb_slug}/taxonomy/top-tags", response_model=TopTagsResponse)
+@router.get("/{kb_slug}/taxonomy/top-tags", response_model=TopTagsResponse, dependencies=[Depends(get_kb_with_access)])
 async def taxonomy_top_tags(
     kb_slug: str,
     limit: int = 20,

--- a/klai-portal/backend/app/services/access.py
+++ b/klai-portal/backend/app/services/access.py
@@ -7,6 +7,11 @@ All query functions enforce org-level scoping. Group-scoped access is layered on
                          meeting queries. Do not bypass with direct select(VexaMeeting).
 @MX:ANCHOR fan_in=3+ -- get_accessible_kb_slugs is the authoritative entry point for
                          KB access checks. Do not bypass.
+@MX:ANCHOR fan_in=3+ -- is_personal_kb is the single-source-of-truth for the
+                         personal-vs-org discriminator (SPEC-PORTAL-KB-OWNERSHIP-001
+                         REQ-3 firewall). Used by every gate that must hide a
+                         personal KB from non-owners. Do not duplicate the
+                         ``owner_type=='user'`` check inline.
 """
 
 from sqlalchemy import func, or_, select
@@ -16,6 +21,23 @@ from app.models.groups import PortalGroupMembership
 from app.models.knowledge_bases import PortalGroupKBAccess, PortalKnowledgeBase, PortalUserKBAccess
 from app.models.meetings import VexaMeeting
 from app.models.portal import PortalUser
+
+
+def is_personal_kb(kb: PortalKnowledgeBase) -> bool:
+    """Return True iff ``kb`` is a personal knowledge base.
+
+    Personal KBs (``owner_type == 'user'``) are user-private: only the
+    ``owner_user_id`` may see, query, or modify them. Admins included — there
+    is NO admin-bypass for personal KBs (SPEC-PORTAL-KB-OWNERSHIP-001 REQ-3).
+
+    @MX:NOTE -- single source of truth. Every personal-firewall check
+    (``get_kb_with_access`` in ``app/api/dependencies.py``, future RLS
+    policies) MUST go through this helper rather than inlining
+    ``kb.owner_type == 'user'``. A future schema migration that introduces
+    a third owner_type value (e.g. ``'group'``) flips behaviour at one
+    central point.
+    """
+    return kb.owner_type == "user"
 
 
 def _accessible_meetings_filter(user_id: str, org_id: int):

--- a/klai-portal/backend/app/services/default_knowledge_bases.py
+++ b/klai-portal/backend/app/services/default_knowledge_bases.py
@@ -24,6 +24,60 @@ def personal_kb_slug(user_id: str) -> str:
     return f"personal-{user_id}"
 
 
+async def resolve_personal_kb(caller_id: str, org_id: int, db: AsyncSession) -> PortalKnowledgeBase:
+    """Return the caller's personal KB, creating it as fallback if provisioning missed it.
+
+    Used by the magic-slug ``personal`` shortcut in ``get_kb_with_access``
+    (SPEC-PORTAL-KB-OWNERSHIP-001 REQ-3.1) and by direct API consumers.
+    Idempotent: returns the existing row when present, creates one and
+    commits when missing. The row is locked with ``with_for_update`` to
+    serialise concurrent first-time fallbacks.
+    """
+    slug = personal_kb_slug(caller_id)
+    result = await db.execute(
+        select(PortalKnowledgeBase)
+        .where(PortalKnowledgeBase.org_id == org_id, PortalKnowledgeBase.slug == slug)
+        .with_for_update()
+    )
+    kb = result.scalar_one_or_none()
+    if kb:
+        return kb
+
+    try:
+        kb = await create_default_personal_kb(caller_id, org_id, db)
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        logger.exception("fallback_personal_kb_creation_failed", caller_id=caller_id, org_id=org_id)
+        raise
+    return kb
+
+
+async def resolve_org_kb(caller_id: str, org_id: int, db: AsyncSession) -> PortalKnowledgeBase:
+    """Return the org KB, creating it as fallback if provisioning missed it.
+
+    Magic-slug ``org`` shortcut backing ``get_kb_with_access``. Same
+    idempotent + locked pattern as ``resolve_personal_kb``.
+    """
+    result = await db.execute(
+        select(PortalKnowledgeBase)
+        .where(PortalKnowledgeBase.org_id == org_id, PortalKnowledgeBase.slug == "org")
+        .with_for_update()
+    )
+    kb = result.scalar_one_or_none()
+    if kb:
+        return kb
+
+    try:
+        kb = await create_default_org_kb(org_id, created_by=caller_id, db=db)
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        logger.exception("fallback_org_kb_creation_failed", org_id=org_id)
+        raise
+    return kb
+
+
 async def create_default_org_kb(
     org_id: int,
     created_by: str,

--- a/klai-portal/backend/app/services/kb_offboarding.py
+++ b/klai-portal/backend/app/services/kb_offboarding.py
@@ -1,0 +1,493 @@
+"""KB-offboarding orchestrator.
+
+SPEC-PORTAL-KB-OWNERSHIP-001 Phase 3 (REQ-2.x).
+
+The orchestrator drives two operations on user-offboarding:
+
+1. ``compute_offboard_preview(target_user_id, perms, db)`` — returns the
+   set of org-owned KBs the target user is the SOLE owner of, plus all
+   personal KBs the user owns, plus counts of partner API keys and MCP
+   tokens that will be revoked. The admin uses the preview to choose a
+   ``KbDisposition`` per KB before triggering ``offboard``.
+
+2. ``apply_dispositions(target_user_id, dispositions, actor, db)`` —
+   executes the chosen dispositions inside the offboard DB transaction:
+
+   - ``action='transfer'`` (org KBs only): updates ``created_by`` to the
+     receiving user, removes the offboarded user's
+     ``portal_user_kb_access`` row (if any), upserts an owner-role row
+     for the new user. Emits ``kb.transferred`` audit + structlog event.
+   - ``action='delete'``: runs the same 3-step external-call chain as
+     ``delete_app_knowledge_base`` (docs-app → knowledge-ingest →
+     portal-DB). Emits ``kb.admin_deleted`` (org KB) or
+     ``kb.personal_purged_on_offboard`` (personal KB) with
+     ``meta.reason='offboarding'``.
+
+3. ``revoke_user_credentials(target_user_id, org_id, db)`` — REQ-2.7:
+   deletes every ``partner_api_keys`` row created by the offboarded user
+   and soft-revokes every active ``portal_mcp_tokens`` row whose
+   ``user_id`` resolves to the offboarded portal_users row.
+
+Failure in any step raises and rolls back the entire transaction —
+including the eventual ``user.status = 'offboarded'`` flip in the
+caller. This is REQ-2.2 / AC-10 fail-loud semantics: a half-offboarded
+user (memberships gone but KB transfer aborted, say) is worse than no
+offboarding at all.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Literal
+
+import structlog
+from fastapi import HTTPException, status
+from pydantic import BaseModel, Field, model_validator
+from sqlalchemy import delete, func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.knowledge_bases import PortalKnowledgeBase, PortalUserKBAccess
+from app.models.mcp_oauth import PortalMcpToken
+from app.models.partner_api_keys import PartnerAPIKey
+from app.models.portal import PortalOrg, PortalUser
+from app.services import docs_client, knowledge_ingest_client
+from app.services.access import is_personal_kb
+from app.services.audit import log_event
+
+logger = structlog.get_logger()
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+
+class OffboardPreviewKb(BaseModel):
+    """One row in the offboard-preview's KB lists."""
+
+    kb_id: int
+    slug: str
+    name: str
+    owner_type: Literal["org", "user"]
+    role_count: int = Field(
+        default=1,
+        description=(
+            "Number of explicit owner-role grants on this KB. For org KBs, "
+            "1 means the offboarded user is the only owner; >1 means "
+            "co-owners exist (and the KB is NOT in the preview's "
+            "solely-owned list)."
+        ),
+    )
+
+
+class OffboardPreview(BaseModel):
+    """Response shape for ``GET /admin/users/{id}/offboard-preview``.
+
+    ``org_kbs_solely_owned`` lists only KBs where the offboarded user is
+    the SOLE owner (creator AND no other portal_user_kb_access rows with
+    role='owner'). Co-owned KBs are excluded — losing one of N owners
+    needs no admin disposition.
+
+    ``personal_kbs`` lists every KB with ``owner_type='user'`` and
+    ``owner_user_id == target_user_id``. Personal KBs cannot be
+    transferred (REQ-2.4) and are always purged on offboard (D2).
+    """
+
+    org_kbs_solely_owned: list[OffboardPreviewKb]
+    personal_kbs: list[OffboardPreviewKb]
+    api_keys_count: int = Field(description="REQ-2.1b — partner_api_keys created by the offboarded user.")
+    mcp_tokens_count: int = Field(description="REQ-2.1b — active portal_mcp_tokens owned by the offboarded user.")
+
+
+class KbDisposition(BaseModel):
+    """One row in the admin's offboard request body.
+
+    For ``action='transfer'`` (org KBs only), ``transfer_to`` MUST be a
+    valid zitadel_user_id of a remaining org member. The orchestrator
+    refuses to transfer to the offboarded user themselves or to an
+    unknown user_id.
+    """
+
+    kb_id: int
+    action: Literal["transfer", "delete"]
+    transfer_to: str | None = None
+
+    @model_validator(mode="after")
+    def _transfer_to_required_for_transfer(self) -> KbDisposition:
+        if self.action == "transfer" and not self.transfer_to:
+            raise ValueError("transfer_to is required when action='transfer'")
+        if self.action == "delete" and self.transfer_to:
+            raise ValueError("transfer_to must be omitted when action='delete'")
+        return self
+
+
+# ---------------------------------------------------------------------------
+# Preview
+# ---------------------------------------------------------------------------
+
+
+async def compute_offboard_preview(
+    target_user_id: str,
+    org_id: int,
+    db: AsyncSession,
+) -> OffboardPreview:
+    """Build the offboard-preview for the target user.
+
+    Two queries on portal_knowledge_bases (Cat-D RLS-strict) — caller MUST
+    have run set_tenant via the auth dep before calling this. The audit
+    allowlist in tests/test_rls_callsite_audit.py covers this.
+    """
+    # Org-KBs where the target user is the creator (implicit owner).
+    org_kbs_creator_result = await db.execute(
+        select(PortalKnowledgeBase).where(
+            PortalKnowledgeBase.org_id == org_id,
+            PortalKnowledgeBase.owner_type == "org",
+            PortalKnowledgeBase.created_by == target_user_id,
+        )
+    )
+    candidate_org_kbs = list(org_kbs_creator_result.scalars().all())
+
+    # For each candidate org KB, count owner-role grants from OTHER users.
+    # If 0 other-owner grants exist: target is solely-owned (include in preview).
+    # If >0 other-owner grants exist: skip — co-ownership means no disposition needed.
+    solely_owned: list[OffboardPreviewKb] = []
+    for kb in candidate_org_kbs:
+        other_owners_result = await db.execute(
+            select(func.count(PortalUserKBAccess.id))
+            .where(PortalUserKBAccess.kb_id == kb.id)
+            .where(PortalUserKBAccess.role == "owner")
+            .where(PortalUserKBAccess.user_id != target_user_id)
+        )
+        other_owner_count = other_owners_result.scalar_one() or 0
+        if other_owner_count == 0:
+            solely_owned.append(
+                OffboardPreviewKb(
+                    kb_id=kb.id,
+                    slug=kb.slug,
+                    name=kb.name,
+                    owner_type="org",
+                    role_count=1,
+                )
+            )
+
+    # Personal KBs owned by the target user.
+    personal_kbs_result = await db.execute(
+        select(PortalKnowledgeBase).where(
+            PortalKnowledgeBase.org_id == org_id,
+            PortalKnowledgeBase.owner_type == "user",
+            PortalKnowledgeBase.owner_user_id == target_user_id,
+        )
+    )
+    personal_kb_rows = [
+        OffboardPreviewKb(
+            kb_id=kb.id,
+            slug=kb.slug,
+            name=kb.name,
+            owner_type="user",
+            role_count=1,
+        )
+        for kb in personal_kbs_result.scalars().all()
+    ]
+
+    # Token counts (REQ-2.1b).
+    api_keys_count_result = await db.execute(
+        select(func.count(PartnerAPIKey.id)).where(
+            PartnerAPIKey.org_id == org_id,
+            PartnerAPIKey.created_by == target_user_id,
+        )
+    )
+    api_keys_count = api_keys_count_result.scalar_one() or 0
+
+    # MCP tokens use ``portal_users.id`` (int FK), not the zitadel string.
+    # Resolve it once; the count is a no-op if the user row is gone.
+    user_id_result = await db.execute(
+        select(PortalUser.id).where(
+            PortalUser.zitadel_user_id == target_user_id,
+            PortalUser.org_id == org_id,
+        )
+    )
+    portal_user_pk = user_id_result.scalar_one_or_none()
+    mcp_tokens_count = 0
+    if portal_user_pk is not None:
+        mcp_count_result = await db.execute(
+            select(func.count(PortalMcpToken.id)).where(
+                PortalMcpToken.user_id == portal_user_pk,
+                PortalMcpToken.revoked_at.is_(None),
+            )
+        )
+        mcp_tokens_count = mcp_count_result.scalar_one() or 0
+
+    return OffboardPreview(
+        org_kbs_solely_owned=solely_owned,
+        personal_kbs=personal_kb_rows,
+        api_keys_count=api_keys_count,
+        mcp_tokens_count=mcp_tokens_count,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Apply dispositions
+# ---------------------------------------------------------------------------
+
+
+async def apply_dispositions(
+    target_user_id: str,
+    dispositions: list[KbDisposition],
+    actor_user_id: str,
+    org: PortalOrg,
+    db: AsyncSession,
+) -> None:
+    """Execute the admin's KB dispositions for the offboarded user.
+
+    REQ-2.2 — runs inside the offboard DB transaction. Caller is
+    responsible for committing AFTER both ``apply_dispositions`` AND its
+    own user-status flip succeed. Any HTTPException raised here aborts
+    the entire offboard, leaving the user ``active``.
+
+    REQ-2.5 — caller is responsible for verifying that EVERY KB in the
+    preview's ``org_kbs_solely_owned`` and ``personal_kbs`` has a
+    matching disposition. This function does not re-validate
+    completeness; missing dispositions surface as the corresponding KB
+    being silently retained, which is a worse failure mode than 400.
+    """
+    for disposition in dispositions:
+        kb = await _load_kb_or_404(disposition.kb_id, org.id, db)
+        if disposition.action == "transfer":
+            await _do_transfer(kb, disposition.transfer_to or "", actor_user_id, org.id, db)
+        else:  # delete
+            await _do_delete(kb, target_user_id, actor_user_id, org, db)
+
+
+async def _load_kb_or_404(kb_id: int, org_id: int, db: AsyncSession) -> PortalKnowledgeBase:
+    result = await db.execute(
+        select(PortalKnowledgeBase).where(
+            PortalKnowledgeBase.id == kb_id,
+            PortalKnowledgeBase.org_id == org_id,
+        )
+    )
+    kb = result.scalar_one_or_none()
+    if kb is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Disposition references unknown kb_id={kb_id}",
+        )
+    return kb
+
+
+async def _do_transfer(
+    kb: PortalKnowledgeBase,
+    new_owner_id: str,
+    actor_user_id: str,
+    org_id: int,
+    db: AsyncSession,
+) -> None:
+    """REQ-2.3 + REQ-2.4 — transfer ownership of an org KB to a new user.
+
+    Personal KBs cannot be transferred (REQ-2.4). The check is
+    is_personal_kb-based (single source of truth) so the gate moves with
+    any future schema change.
+
+    On the new-owner side: upserts a portal_user_kb_access row with
+    role='owner'. We don't try to be clever about an existing access row
+    for the new owner — if one exists, we delete it first and insert
+    fresh, so the audit trail (granted_at, granted_by) reflects the
+    transfer event.
+    """
+    if is_personal_kb(kb):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Personal knowledge bases cannot be transferred to another person",
+        )
+
+    if not new_owner_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"transfer_to is required for kb_id={kb.id}",
+        )
+
+    # Verify the receiving user is in the same org and active. A transfer
+    # to a non-existent / different-tenant user would orphan the KB.
+    new_owner_result = await db.execute(
+        select(PortalUser).where(
+            PortalUser.zitadel_user_id == new_owner_id,
+            PortalUser.org_id == org_id,
+        )
+    )
+    new_owner = new_owner_result.scalar_one_or_none()
+    if new_owner is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"transfer_to user {new_owner_id} is not a member of this org",
+        )
+    if new_owner.status != "active":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"transfer_to user {new_owner_id} is not active (status={new_owner.status})",
+        )
+
+    previous_owner = kb.created_by
+    kb.created_by = new_owner_id
+
+    # Drop the old owner's explicit access row (if any) — the offboarded
+    # user is leaving the workspace, no point keeping a dangling grant.
+    await db.execute(
+        delete(PortalUserKBAccess).where(
+            PortalUserKBAccess.kb_id == kb.id,
+            PortalUserKBAccess.user_id == previous_owner,
+        )
+    )
+    # Upsert owner row for the new user. Delete-then-insert so granted_at
+    # carries the transfer timestamp, not a stale earlier grant.
+    await db.execute(
+        delete(PortalUserKBAccess).where(
+            PortalUserKBAccess.kb_id == kb.id,
+            PortalUserKBAccess.user_id == new_owner_id,
+        )
+    )
+    db.add(
+        PortalUserKBAccess(
+            kb_id=kb.id,
+            user_id=new_owner_id,
+            org_id=org_id,
+            role="owner",
+            granted_by=actor_user_id,
+        )
+    )
+
+    await log_event(
+        org_id=org_id,
+        actor=actor_user_id,
+        action="kb.transferred",
+        resource_type="kb",
+        resource_id=str(kb.id),
+        details={
+            "from_user": previous_owner,
+            "to_user": new_owner_id,
+            "kb_name": kb.name,
+            "kb_slug": kb.slug,
+            "reason": "offboarding",
+        },
+    )
+    logger.info(
+        "kb_transferred",
+        org_id=org_id,
+        actor_user_id=actor_user_id,
+        kb_id=kb.id,
+        kb_slug=kb.slug,
+        from_user=previous_owner,
+        to_user=new_owner_id,
+        reason="offboarding",
+    )
+
+
+async def _do_delete(
+    kb: PortalKnowledgeBase,
+    target_user_id: str,
+    actor_user_id: str,
+    org: PortalOrg,
+    db: AsyncSession,
+) -> None:
+    """Delete a KB during offboarding.
+
+    Mirrors ``delete_app_knowledge_base``'s 3-step chain so the
+    failure-mode (docs failure aborts before portal-DB delete) is
+    identical. Audit-event differs based on owner_type:
+      - org KB ➜ ``kb.admin_deleted`` with reason='offboarding'
+      - personal KB ➜ ``kb.personal_purged_on_offboard``
+    """
+    # Step 1: docs-app cleanup (only when it has a Gitea repo).
+    if kb.gitea_repo_slug or kb.docs_enabled:
+        await docs_client.deprovision_kb(org.slug, kb.slug)
+
+    # Step 2: knowledge-ingest cleanup.
+    await knowledge_ingest_client.delete_kb(org.zitadel_org_id, kb.slug)
+
+    # Step 3: audit BEFORE portal-DB delete so the row id / metadata are
+    # captured even if some downstream step throws after.
+    if is_personal_kb(kb):
+        action = "kb.personal_purged_on_offboard"
+    else:
+        action = "kb.admin_deleted"
+    await log_event(
+        org_id=org.id,
+        actor=actor_user_id,
+        action=action,
+        resource_type="kb",
+        resource_id=str(kb.id),
+        details={
+            "previous_owner": kb.created_by,
+            "kb_name": kb.name,
+            "kb_slug": kb.slug,
+            "reason": "offboarding",
+            "owner_type": kb.owner_type,
+            "target_user_id": target_user_id,
+        },
+    )
+    logger.info(
+        action.replace(".", "_"),
+        org_id=org.id,
+        actor_user_id=actor_user_id,
+        kb_id=kb.id,
+        kb_slug=kb.slug,
+        previous_owner=kb.created_by,
+        target_user_id=target_user_id,
+        reason="offboarding",
+    )
+
+    # Step 4: portal-DB delete (cascades access rows).
+    await db.delete(kb)
+
+
+# ---------------------------------------------------------------------------
+# Token revoke
+# ---------------------------------------------------------------------------
+
+
+async def revoke_user_credentials(
+    target_user_id: str,
+    org_id: int,
+    db: AsyncSession,
+) -> tuple[int, int]:
+    """REQ-2.7 — auto-revoke partner API keys + MCP tokens for offboarded user.
+
+    Returns ``(api_keys_deleted, mcp_tokens_revoked)`` for the
+    offboard-event payload. Runs in the same transaction as
+    apply_dispositions / status flip so a failure rolls everything back.
+
+    API keys are HARD-deleted (matches the ``DELETE /admin/api-keys/{id}``
+    user-facing endpoint). MCP tokens are SOFT-revoked via ``revoked_at``
+    so the OAuth refresh-token replay-detection chain
+    (``replaced_by_token_id``) stays intact for forensics.
+    """
+    # API keys — match by created_by + org_id (RLS-friendly).
+    api_keys_result = await db.execute(
+        delete(PartnerAPIKey).where(
+            PartnerAPIKey.org_id == org_id,
+            PartnerAPIKey.created_by == target_user_id,
+        )
+    )
+    api_keys_deleted = getattr(api_keys_result, "rowcount", 0) or 0
+
+    # MCP tokens use the int portal_users.id as FK. Look it up; if the
+    # portal_users row is already gone we have nothing to revoke.
+    user_pk_result = await db.execute(
+        select(PortalUser.id).where(
+            PortalUser.zitadel_user_id == target_user_id,
+            PortalUser.org_id == org_id,
+        )
+    )
+    portal_user_pk = user_pk_result.scalar_one_or_none()
+
+    mcp_tokens_revoked = 0
+    if portal_user_pk is not None:
+        mcp_revoke_result = await db.execute(
+            update(PortalMcpToken)
+            .where(
+                PortalMcpToken.user_id == portal_user_pk,
+                PortalMcpToken.revoked_at.is_(None),
+            )
+            .values(revoked_at=datetime.now(tz=UTC))
+        )
+        mcp_tokens_revoked = getattr(mcp_revoke_result, "rowcount", 0) or 0
+
+    return api_keys_deleted, mcp_tokens_revoked

--- a/klai-portal/backend/tests/test_admin_offboard_endpoint.py
+++ b/klai-portal/backend/tests/test_admin_offboard_endpoint.py
@@ -1,0 +1,266 @@
+"""SPEC-PORTAL-KB-OWNERSHIP-001 Phase 3 — endpoint-level offboard tests.
+
+Covers AC-5 (preview shape), AC-6 (missing dispositions → 400 with list),
+AC-7 (transfer + delete + audit), AC-8 (transfer of personal KB → 400),
+AC-10 (failure during disposition aborts the entire offboard tx).
+
+Service-level invariants live in ``test_kb_offboarding_service.py``.
+This file exercises the wiring in ``app.api.admin.users``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.services.kb_offboarding import KbDisposition, OffboardPreview, OffboardPreviewKb
+from tests.conftest import make_perms
+
+
+def _user(status: str = "active") -> MagicMock:
+    u = MagicMock()
+    u.zitadel_user_id = "uid-leaving"
+    u.status = status
+    u.org_id = 1
+    u.github_username = None
+    return u
+
+
+def _org() -> MagicMock:
+    o = MagicMock()
+    o.id = 1
+    o.slug = "voys"
+    o.zitadel_org_id = "zitadel-org-1"
+    return o
+
+
+def _scalar_lookup(value: object) -> MagicMock:
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = value
+    return r
+
+
+class TestOffboardPreviewEndpoint:
+    """AC-5: preview returns solely-owned org-KBs + all personal-KBs + token counts."""
+
+    @pytest.mark.asyncio
+    async def test_preview_returns_kbs_and_token_counts(self) -> None:
+        from app.api.admin.users import offboard_preview
+
+        user = _user()
+        db = AsyncMock()
+        db.execute.side_effect = [_scalar_lookup(user)]
+
+        preview = OffboardPreview(
+            org_kbs_solely_owned=[
+                OffboardPreviewKb(kb_id=7, slug="team-kb", name="Team KB", owner_type="org", role_count=1),
+            ],
+            personal_kbs=[
+                OffboardPreviewKb(
+                    kb_id=11, slug="personal-uid-leaving", name="Persoonlijk", owner_type="user", role_count=1
+                ),
+            ],
+            api_keys_count=2,
+            mcp_tokens_count=3,
+        )
+
+        with patch(
+            "app.api.admin.users.compute_offboard_preview",
+            AsyncMock(return_value=preview),
+        ) as mock_preview:
+            result = await offboard_preview(
+                zitadel_user_id="uid-leaving",
+                perms=make_perms(role="admin", user_id="admin-1", org_id=1),
+                db=db,
+            )
+
+        assert result is preview
+        mock_preview.assert_awaited_once_with("uid-leaving", 1, db)
+
+    @pytest.mark.asyncio
+    async def test_preview_404_when_user_not_in_org(self) -> None:
+        from app.api.admin.users import offboard_preview
+
+        db = AsyncMock()
+        db.execute.side_effect = [_scalar_lookup(None)]
+
+        with pytest.raises(HTTPException) as exc:
+            await offboard_preview(
+                zitadel_user_id="uid-ghost",
+                perms=make_perms(role="admin", user_id="admin-1", org_id=1),
+                db=db,
+            )
+        assert exc.value.status_code == 404
+
+
+class TestOffboardEndpointMissingDispositions:
+    """AC-6: missing dispositions → 400 with explicit slug list."""
+
+    @pytest.mark.asyncio
+    async def test_empty_body_with_kbs_in_preview_returns_400_with_list(self) -> None:
+        from app.api.admin.users import OffboardRequest, offboard_user
+
+        user = _user()
+        org = _org()
+
+        db = AsyncMock()
+        db.execute.side_effect = [_scalar_lookup(user), _scalar_lookup(org)]
+
+        preview = OffboardPreview(
+            org_kbs_solely_owned=[
+                OffboardPreviewKb(kb_id=7, slug="team-kb", name="Team KB", owner_type="org", role_count=1),
+            ],
+            personal_kbs=[
+                OffboardPreviewKb(
+                    kb_id=11, slug="personal-uid-leaving", name="Persoonlijk", owner_type="user", role_count=1
+                ),
+            ],
+            api_keys_count=0,
+            mcp_tokens_count=0,
+        )
+
+        with patch("app.api.admin.users.compute_offboard_preview", AsyncMock(return_value=preview)):
+            with pytest.raises(HTTPException) as exc:
+                await offboard_user(
+                    zitadel_user_id="uid-leaving",
+                    body=OffboardRequest(kb_dispositions=[]),
+                    perms=make_perms(role="admin", user_id="admin-1", org_id=1),
+                    db=db,
+                )
+
+        assert exc.value.status_code == 400
+        detail = exc.value.detail
+        assert isinstance(detail, dict)
+        assert detail.get("error_code") == "missing_kb_dispositions"
+        assert sorted(detail.get("missing", [])) == ["personal-uid-leaving", "team-kb"]
+
+
+class TestOffboardEndpointHappyPath:
+    """AC-7: transfer + delete + audit + token revoke + status flip."""
+
+    @pytest.mark.asyncio
+    async def test_offboard_with_full_dispositions_runs_all_steps(self) -> None:
+        from app.api.admin.users import OffboardRequest, offboard_user
+
+        user = _user()
+        org = _org()
+        org.zitadel_org_id = "zitadel-org-1"
+
+        db = AsyncMock()
+        # Sequence inside offboard_user before apply/revoke/membership delete:
+        # 1: user lookup
+        # 2: org lookup
+        # 3: membership delete (rowcount=1)
+        membership_delete = MagicMock()
+        membership_delete.rowcount = 1
+        db.execute.side_effect = [
+            _scalar_lookup(user),
+            _scalar_lookup(org),
+            membership_delete,
+        ]
+        mock_zitadel = AsyncMock()
+
+        preview = OffboardPreview(
+            org_kbs_solely_owned=[
+                OffboardPreviewKb(kb_id=7, slug="team-kb", name="Team KB", owner_type="org", role_count=1),
+            ],
+            personal_kbs=[
+                OffboardPreviewKb(
+                    kb_id=11, slug="personal-uid-leaving", name="Persoonlijk", owner_type="user", role_count=1
+                ),
+            ],
+            api_keys_count=2,
+            mcp_tokens_count=3,
+        )
+
+        with (
+            patch("app.api.admin.users.compute_offboard_preview", AsyncMock(return_value=preview)),
+            patch("app.api.admin.users.apply_dispositions", AsyncMock()) as mock_apply,
+            patch(
+                "app.api.admin.users.revoke_user_credentials",
+                AsyncMock(return_value=(2, 3)),
+            ) as mock_revoke,
+            patch("app.api.admin.users.zitadel", mock_zitadel),
+            patch("app.api.admin.users.settings") as mock_settings,
+            patch("app.api.admin.users.log_event", AsyncMock()) as mock_log,
+        ):
+            mock_settings.zitadel_portal_org_id = "zitadel-portal-org-id"
+            await offboard_user(
+                zitadel_user_id="uid-leaving",
+                body=OffboardRequest(
+                    kb_dispositions=[
+                        KbDisposition(kb_id=7, action="transfer", transfer_to="admin-1"),
+                        KbDisposition(kb_id=11, action="delete"),
+                    ]
+                ),
+                perms=make_perms(role="admin", user_id="admin-1", org_id=1),
+                db=db,
+            )
+
+        # Both dispositions delegated to the orchestrator.
+        mock_apply.assert_awaited_once()
+        # Token revoke runs in same tx.
+        mock_revoke.assert_awaited_once_with(target_user_id="uid-leaving", org_id=1, db=db)
+        # User status flipped + commit.
+        assert user.status == "offboarded"
+        db.commit.assert_awaited_once()
+        # Zitadel deactivate called AFTER commit.
+        mock_zitadel.deactivate_user.assert_awaited_once()
+        # user.offboarded audit event includes the new metrics.
+        offboard_calls = [c for c in mock_log.await_args_list if c.kwargs.get("action") == "user.offboarded"]
+        assert len(offboard_calls) == 1
+        details = offboard_calls[0].kwargs.get("details") or {}
+        assert details.get("kb_dispositions_count") == 2
+        assert details.get("api_keys_deleted") == 2
+        assert details.get("mcp_tokens_revoked") == 3
+
+
+class TestOffboardEndpointFailureRollsBack:
+    """AC-10: apply_dispositions failure aborts before status flip."""
+
+    @pytest.mark.asyncio
+    async def test_apply_dispositions_failure_aborts_offboard(self) -> None:
+        from app.api.admin.users import OffboardRequest, offboard_user
+
+        user = _user()
+        org = _org()
+
+        db = AsyncMock()
+        db.execute.side_effect = [_scalar_lookup(user), _scalar_lookup(org)]
+
+        preview = OffboardPreview(
+            org_kbs_solely_owned=[
+                OffboardPreviewKb(kb_id=7, slug="team-kb", name="Team KB", owner_type="org", role_count=1),
+            ],
+            personal_kbs=[],
+            api_keys_count=0,
+            mcp_tokens_count=0,
+        )
+
+        with (
+            patch("app.api.admin.users.compute_offboard_preview", AsyncMock(return_value=preview)),
+            patch(
+                "app.api.admin.users.apply_dispositions",
+                AsyncMock(side_effect=RuntimeError("docs-app down")),
+            ),
+            patch("app.api.admin.users.revoke_user_credentials", AsyncMock()) as mock_revoke,
+            patch("app.api.admin.users.zitadel", AsyncMock()) as mock_zitadel,
+        ):
+            with pytest.raises(RuntimeError):
+                await offboard_user(
+                    zitadel_user_id="uid-leaving",
+                    body=OffboardRequest(
+                        kb_dispositions=[KbDisposition(kb_id=7, action="transfer", transfer_to="admin-1")],
+                    ),
+                    perms=make_perms(role="admin", user_id="admin-1", org_id=1),
+                    db=db,
+                )
+
+        # Nothing past apply_dispositions ran.
+        mock_revoke.assert_not_awaited()
+        mock_zitadel.deactivate_user.assert_not_awaited()
+        # User status NOT flipped — fail-loud.
+        assert user.status == "active"
+        db.commit.assert_not_awaited()

--- a/klai-portal/backend/tests/test_kb_admin_delete_override.py
+++ b/klai-portal/backend/tests/test_kb_admin_delete_override.py
@@ -1,0 +1,299 @@
+"""SPEC-PORTAL-KB-OWNERSHIP-001 Phase 2 — admin-override delete tests.
+
+Covers REQ-1.1 .. REQ-1.5 + AC-1 .. AC-4 of the SPEC.
+
+Direct invocation pattern: each test patches the external-call helpers
+(docs_client, knowledge_ingest_client) and the role lookup, then calls
+``delete_app_knowledge_base`` directly with a mock DB session and a
+``Request``-like object that exposes the admin-override header.
+
+The personal-firewall (REQ-3) is enforced by ``get_kb_with_access`` at the
+route-level before the handler body runs; in direct-invocation tests the
+dep does not run, so we assert REQ-1.3 (admin-override on personal KB →
+404) via the route-level assertion in ``test_kb_personal_firewall.py``
+instead. Here we focus on the handler-body branching.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException, Request
+
+from tests.conftest import make_perms
+
+OVERRIDE_HEADER = "X-Admin-Override-Confirm"
+OVERRIDE_VALUE = "I-WAS-NOT-CREATOR"
+
+
+def _make_request(headers: dict[str, str] | None = None) -> Request:
+    """Build a Starlette Request with the supplied headers (lowercase keys)."""
+    raw_headers = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
+    scope = {
+        "type": "http",
+        "method": "DELETE",
+        "headers": raw_headers,
+    }
+    return Request(scope)
+
+
+def _make_kb(*, owner_type: str = "org", created_by: str = "creator-uid", slug: str = "team-kb") -> MagicMock:
+    kb = MagicMock()
+    kb.id = 7
+    kb.org_id = 101
+    kb.name = "Team KB"
+    kb.slug = slug
+    kb.owner_type = owner_type
+    kb.owner_user_id = None if owner_type == "org" else created_by
+    kb.created_by = created_by
+    kb.gitea_repo_slug = None
+    kb.docs_enabled = False
+    return kb
+
+
+def _make_org() -> MagicMock:
+    org = MagicMock()
+    org.id = 101
+    org.slug = "voys"
+    org.zitadel_org_id = "zitadel-org-1"
+    return org
+
+
+def _db_with_kb(kb: MagicMock) -> AsyncMock:
+    db = AsyncMock()
+    db.add = MagicMock()
+    db.delete = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = kb
+    db.execute.return_value = result
+    return db
+
+
+class TestOwnerDeletePathStillWorks:
+    """AC-1: existing owner-pad behaviour is unchanged."""
+
+    @pytest.mark.asyncio
+    async def test_owner_can_delete_without_override_header(self) -> None:
+        from app.api.app_knowledge_bases import delete_app_knowledge_base
+
+        kb = _make_kb(created_by="uid-owner")
+        db = _db_with_kb(kb)
+        org = _make_org()
+
+        with (
+            patch("app.api.app_knowledge_bases._load_org_or_500", AsyncMock(return_value=org)),
+            patch("app.api.app_knowledge_bases.get_user_role_for_kb", AsyncMock(return_value="owner")),
+            patch("app.api.app_knowledge_bases.docs_client.deprovision_kb", AsyncMock()),
+            patch("app.api.app_knowledge_bases.knowledge_ingest_client.delete_kb", AsyncMock()),
+            patch("app.api.app_knowledge_bases.log_event", AsyncMock()) as mock_log,
+        ):
+            # Owner = creator → no override header needed.
+            await delete_app_knowledge_base(
+                kb_slug="team-kb",
+                request=_make_request(headers={}),
+                perms=make_perms(role="admin", user_id="uid-owner", org_id=101),
+                db=db,
+            )
+
+        db.delete.assert_awaited_once_with(kb)
+        # AC-1 owner-pad does NOT emit kb.admin_deleted (no override fired).
+        for call in mock_log.await_args_list:
+            assert call.kwargs.get("action") != "kb.admin_deleted"
+
+
+class TestAdminOverridePath:
+    """AC-2 + REQ-1.4: admin can delete with explicit header + audit emit."""
+
+    @pytest.mark.asyncio
+    async def test_admin_with_override_header_succeeds_on_org_kb(self) -> None:
+        from app.api.app_knowledge_bases import delete_app_knowledge_base
+
+        kb = _make_kb(created_by="uid-other-creator")  # admin is not the creator
+        db = _db_with_kb(kb)
+        org = _make_org()
+
+        with (
+            patch("app.api.app_knowledge_bases._load_org_or_500", AsyncMock(return_value=org)),
+            # Admin caller has no role on this KB — would normally get 403.
+            patch("app.api.app_knowledge_bases.get_user_role_for_kb", AsyncMock(return_value=None)),
+            patch("app.api.app_knowledge_bases.docs_client.deprovision_kb", AsyncMock()),
+            patch("app.api.app_knowledge_bases.knowledge_ingest_client.delete_kb", AsyncMock()),
+            patch("app.api.app_knowledge_bases.log_event", AsyncMock()) as mock_log,
+        ):
+            await delete_app_knowledge_base(
+                kb_slug="team-kb",
+                request=_make_request(headers={OVERRIDE_HEADER: OVERRIDE_VALUE}),
+                perms=make_perms(role="admin", user_id="uid-admin", org_id=101),
+                db=db,
+            )
+
+        db.delete.assert_awaited_once_with(kb)
+        # REQ-1.4: audit event emitted with prev_owner = original created_by
+        admin_delete_calls = [
+            call for call in mock_log.await_args_list if call.kwargs.get("action") == "kb.admin_deleted"
+        ]
+        assert len(admin_delete_calls) == 1, "expected exactly one kb.admin_deleted event"
+        meta = admin_delete_calls[0].kwargs.get("details") or {}
+        assert meta.get("previous_owner") == "uid-other-creator"
+
+
+class TestAdminOverridePathRejected:
+    """AC-3: admin without header keeps 403."""
+
+    @pytest.mark.asyncio
+    async def test_admin_without_override_header_gets_403(self) -> None:
+        from app.api.app_knowledge_bases import delete_app_knowledge_base
+
+        kb = _make_kb(created_by="uid-other-creator")
+        db = _db_with_kb(kb)
+        org = _make_org()
+
+        with (
+            patch("app.api.app_knowledge_bases._load_org_or_500", AsyncMock(return_value=org)),
+            patch("app.api.app_knowledge_bases.get_user_role_for_kb", AsyncMock(return_value=None)),
+            patch("app.api.app_knowledge_bases.docs_client.deprovision_kb", AsyncMock()),
+            patch("app.api.app_knowledge_bases.knowledge_ingest_client.delete_kb", AsyncMock()),
+            patch("app.api.app_knowledge_bases.log_event", AsyncMock()),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await delete_app_knowledge_base(
+                    kb_slug="team-kb",
+                    request=_make_request(headers={}),  # no override header
+                    perms=make_perms(role="admin", user_id="uid-admin", org_id=101),
+                    db=db,
+                )
+
+        assert exc_info.value.status_code == 403
+        db.delete.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_admin_with_wrong_header_value_gets_403(self) -> None:
+        from app.api.app_knowledge_bases import delete_app_knowledge_base
+
+        kb = _make_kb(created_by="uid-other-creator")
+        db = _db_with_kb(kb)
+        org = _make_org()
+
+        with (
+            patch("app.api.app_knowledge_bases._load_org_or_500", AsyncMock(return_value=org)),
+            patch("app.api.app_knowledge_bases.get_user_role_for_kb", AsyncMock(return_value=None)),
+            patch("app.api.app_knowledge_bases.docs_client.deprovision_kb", AsyncMock()),
+            patch("app.api.app_knowledge_bases.knowledge_ingest_client.delete_kb", AsyncMock()),
+            patch("app.api.app_knowledge_bases.log_event", AsyncMock()),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await delete_app_knowledge_base(
+                    kb_slug="team-kb",
+                    request=_make_request(headers={OVERRIDE_HEADER: "yes-please"}),
+                    perms=make_perms(role="admin", user_id="uid-admin", org_id=101),
+                    db=db,
+                )
+
+        assert exc_info.value.status_code == 403
+        db.delete.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_non_admin_with_override_header_still_gets_403(self) -> None:
+        """Override only works for ProfileRole.ADMIN. A regular user
+        sending the header gets 403 (not silent escalation)."""
+        from app.api.app_knowledge_bases import delete_app_knowledge_base
+
+        kb = _make_kb(created_by="uid-other-creator")
+        db = _db_with_kb(kb)
+        org = _make_org()
+
+        with (
+            patch("app.api.app_knowledge_bases._load_org_or_500", AsyncMock(return_value=org)),
+            patch("app.api.app_knowledge_bases.get_user_role_for_kb", AsyncMock(return_value=None)),
+            patch("app.api.app_knowledge_bases.docs_client.deprovision_kb", AsyncMock()),
+            patch("app.api.app_knowledge_bases.knowledge_ingest_client.delete_kb", AsyncMock()),
+            patch("app.api.app_knowledge_bases.log_event", AsyncMock()),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await delete_app_knowledge_base(
+                    kb_slug="team-kb",
+                    request=_make_request(headers={OVERRIDE_HEADER: OVERRIDE_VALUE}),
+                    perms=make_perms(role="personal", user_id="uid-regular", org_id=101),
+                    db=db,
+                )
+
+        assert exc_info.value.status_code == 403
+        db.delete.assert_not_awaited()
+
+
+class TestAdminOverrideOnPersonalKbBlocked:
+    """REQ-1.3: admin-override pad MUST refuse personal KBs.
+
+    The route-level firewall (get_kb_with_access) catches this for real
+    HTTP requests by returning 404 before the handler body runs. This test
+    verifies the handler body itself ALSO refuses to override on personal
+    KBs as belt-and-braces — if a future refactor accidentally moves the
+    firewall, the body must still be safe.
+    """
+
+    @pytest.mark.asyncio
+    async def test_admin_override_on_personal_kb_returns_404(self) -> None:
+        from app.api.app_knowledge_bases import delete_app_knowledge_base
+
+        kb = _make_kb(owner_type="user", created_by="uid-other-user", slug="personal-uid-other")
+        db = _db_with_kb(kb)
+        org = _make_org()
+
+        with (
+            patch("app.api.app_knowledge_bases._load_org_or_500", AsyncMock(return_value=org)),
+            patch("app.api.app_knowledge_bases.get_user_role_for_kb", AsyncMock(return_value=None)),
+            patch("app.api.app_knowledge_bases.docs_client.deprovision_kb", AsyncMock()),
+            patch("app.api.app_knowledge_bases.knowledge_ingest_client.delete_kb", AsyncMock()),
+            patch("app.api.app_knowledge_bases.log_event", AsyncMock()),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await delete_app_knowledge_base(
+                    kb_slug="personal-uid-other",
+                    request=_make_request(headers={OVERRIDE_HEADER: OVERRIDE_VALUE}),
+                    perms=make_perms(role="admin", user_id="uid-admin", org_id=101),
+                    db=db,
+                )
+
+        # 404 (not 403) — non-disclosure.
+        assert exc_info.value.status_code == 404
+        db.delete.assert_not_awaited()
+
+
+class TestAdminOverrideFailureSemantics:
+    """REQ-1.5: admin-override pad has identical failure semantics to owner pad.
+
+    docs-app failure aborts BEFORE the portal-DB delete fires, leaving the
+    KB row intact (same as owner-pad).
+    """
+
+    @pytest.mark.asyncio
+    async def test_docs_failure_aborts_before_portal_db_delete(self) -> None:
+        from app.api.app_knowledge_bases import delete_app_knowledge_base
+
+        kb = _make_kb(created_by="uid-other-creator")
+        kb.docs_enabled = True
+        kb.gitea_repo_slug = "team-kb"
+        db = _db_with_kb(kb)
+        org = _make_org()
+
+        with (
+            patch("app.api.app_knowledge_bases._load_org_or_500", AsyncMock(return_value=org)),
+            patch("app.api.app_knowledge_bases.get_user_role_for_kb", AsyncMock(return_value=None)),
+            patch(
+                "app.api.app_knowledge_bases.docs_client.deprovision_kb",
+                AsyncMock(side_effect=RuntimeError("docs-app down")),
+            ),
+            patch("app.api.app_knowledge_bases.knowledge_ingest_client.delete_kb", AsyncMock()) as mock_ingest,
+            patch("app.api.app_knowledge_bases.log_event", AsyncMock()),
+        ):
+            with pytest.raises(RuntimeError):
+                await delete_app_knowledge_base(
+                    kb_slug="team-kb",
+                    request=_make_request(headers={OVERRIDE_HEADER: OVERRIDE_VALUE}),
+                    perms=make_perms(role="admin", user_id="uid-admin", org_id=101),
+                    db=db,
+                )
+
+        mock_ingest.assert_not_awaited()
+        db.delete.assert_not_awaited()

--- a/klai-portal/backend/tests/test_kb_offboarding_service.py
+++ b/klai-portal/backend/tests/test_kb_offboarding_service.py
@@ -1,0 +1,351 @@
+"""SPEC-PORTAL-KB-OWNERSHIP-001 Phase 3 — service-level offboarding tests.
+
+Covers ``app.services.kb_offboarding`` directly, with mocked DB. The
+endpoint-level tests live in ``test_admin_offboard_endpoint.py``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from app.services.kb_offboarding import (
+    KbDisposition,
+    apply_dispositions,
+    revoke_user_credentials,
+)
+
+
+def _make_org() -> MagicMock:
+    org = MagicMock()
+    org.id = 101
+    org.slug = "voys"
+    org.zitadel_org_id = "zitadel-org-1"
+    return org
+
+
+def _make_kb(
+    *, kb_id: int = 7, owner_type: str = "org", created_by: str = "uid-leaving", slug: str = "team-kb"
+) -> MagicMock:
+    kb = MagicMock()
+    kb.id = kb_id
+    kb.org_id = 101
+    kb.name = f"KB {kb_id}"
+    kb.slug = slug
+    kb.owner_type = owner_type
+    kb.owner_user_id = None if owner_type == "org" else created_by
+    kb.created_by = created_by
+    kb.gitea_repo_slug = None
+    kb.docs_enabled = False
+    kb.default_org_role = None
+    return kb
+
+
+def _make_user(*, zitadel_id: str, status: str = "active", pk: int = 99) -> MagicMock:
+    u = MagicMock()
+    u.zitadel_user_id = zitadel_id
+    u.id = pk
+    u.org_id = 101
+    u.status = status
+    return u
+
+
+def _scalar_result(value: object) -> MagicMock:
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = value
+    r.scalar_one.return_value = value
+    return r
+
+
+class TestKbDispositionValidation:
+    """REQ-2.x body schema enforces the transfer/delete invariants."""
+
+    def test_transfer_without_transfer_to_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            KbDisposition(kb_id=1, action="transfer")
+
+    def test_delete_with_transfer_to_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            KbDisposition(kb_id=1, action="delete", transfer_to="uid-x")
+
+    def test_transfer_with_transfer_to_accepted(self) -> None:
+        d = KbDisposition(kb_id=1, action="transfer", transfer_to="uid-new")
+        assert d.transfer_to == "uid-new"
+
+    def test_delete_without_transfer_to_accepted(self) -> None:
+        d = KbDisposition(kb_id=1, action="delete")
+        assert d.transfer_to is None
+
+
+class TestApplyDispositionsTransfer:
+    """REQ-2.3 — transfer changes created_by, deletes old grant, upserts new owner row."""
+
+    @pytest.mark.asyncio
+    async def test_transfer_org_kb_updates_created_by_and_emits_audit(self) -> None:
+        kb = _make_kb(kb_id=7, owner_type="org", created_by="uid-leaving")
+        new_owner = _make_user(zitadel_id="uid-receiver", status="active")
+        org = _make_org()
+
+        db = AsyncMock()
+        db.add = MagicMock()
+        # Sequence of execute() calls inside apply_dispositions for ONE transfer:
+        # 1. _load_kb_or_404 → kb
+        # 2. SELECT new_owner → new_owner row
+        # 3. DELETE old user_kb_access
+        # 4. DELETE existing access for new owner (if any)
+        # add() — synchronous insert of new owner row
+        db.execute.side_effect = [
+            _scalar_result(kb),
+            _scalar_result(new_owner),
+            MagicMock(),  # delete old grant
+            MagicMock(),  # delete possible existing grant for new owner
+        ]
+
+        with patch("app.services.kb_offboarding.log_event", AsyncMock()) as mock_log:
+            await apply_dispositions(
+                target_user_id="uid-leaving",
+                dispositions=[KbDisposition(kb_id=7, action="transfer", transfer_to="uid-receiver")],
+                actor_user_id="uid-admin",
+                org=org,
+                db=db,
+            )
+
+        assert kb.created_by == "uid-receiver"
+        # Audit event emitted with from/to user.
+        transfer_calls = [c for c in mock_log.await_args_list if c.kwargs.get("action") == "kb.transferred"]
+        assert len(transfer_calls) == 1
+        details = transfer_calls[0].kwargs.get("details") or {}
+        assert details.get("from_user") == "uid-leaving"
+        assert details.get("to_user") == "uid-receiver"
+        assert details.get("reason") == "offboarding"
+        # New owner row was added.
+        db.add.assert_called_once()
+        added_row = db.add.call_args.args[0]
+        assert added_row.user_id == "uid-receiver"
+        assert added_row.role == "owner"
+        assert added_row.granted_by == "uid-admin"
+
+
+class TestApplyDispositionsTransferRejections:
+    """REQ-2.4 + receiver-validation guards."""
+
+    @pytest.mark.asyncio
+    async def test_transfer_personal_kb_returns_400(self) -> None:
+        kb = _make_kb(kb_id=11, owner_type="user", created_by="uid-leaving", slug="personal-uid-leaving")
+        org = _make_org()
+
+        db = AsyncMock()
+        db.execute.side_effect = [_scalar_result(kb)]
+
+        with pytest.raises(HTTPException) as exc_info:
+            await apply_dispositions(
+                target_user_id="uid-leaving",
+                dispositions=[KbDisposition(kb_id=11, action="transfer", transfer_to="uid-receiver")],
+                actor_user_id="uid-admin",
+                org=org,
+                db=db,
+            )
+
+        assert exc_info.value.status_code == 400
+        assert "Personal knowledge bases cannot be transferred" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_transfer_to_unknown_user_returns_400(self) -> None:
+        kb = _make_kb(kb_id=7, created_by="uid-leaving")
+        org = _make_org()
+
+        db = AsyncMock()
+        db.execute.side_effect = [
+            _scalar_result(kb),
+            _scalar_result(None),  # new owner not found
+        ]
+
+        with pytest.raises(HTTPException) as exc_info:
+            await apply_dispositions(
+                target_user_id="uid-leaving",
+                dispositions=[KbDisposition(kb_id=7, action="transfer", transfer_to="uid-ghost")],
+                actor_user_id="uid-admin",
+                org=org,
+                db=db,
+            )
+        assert exc_info.value.status_code == 400
+        assert "not a member" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_transfer_to_offboarded_user_returns_400(self) -> None:
+        kb = _make_kb(kb_id=7, created_by="uid-leaving")
+        new_owner = _make_user(zitadel_id="uid-also-leaving", status="offboarded")
+        org = _make_org()
+
+        db = AsyncMock()
+        db.execute.side_effect = [
+            _scalar_result(kb),
+            _scalar_result(new_owner),
+        ]
+
+        with pytest.raises(HTTPException) as exc_info:
+            await apply_dispositions(
+                target_user_id="uid-leaving",
+                dispositions=[KbDisposition(kb_id=7, action="transfer", transfer_to="uid-also-leaving")],
+                actor_user_id="uid-admin",
+                org=org,
+                db=db,
+            )
+        assert exc_info.value.status_code == 400
+        assert "not active" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_unknown_kb_id_returns_400(self) -> None:
+        org = _make_org()
+        db = AsyncMock()
+        db.execute.side_effect = [_scalar_result(None)]
+
+        with pytest.raises(HTTPException) as exc_info:
+            await apply_dispositions(
+                target_user_id="uid-leaving",
+                dispositions=[KbDisposition(kb_id=999, action="delete")],
+                actor_user_id="uid-admin",
+                org=org,
+                db=db,
+            )
+        assert exc_info.value.status_code == 400
+        assert "kb_id=999" in str(exc_info.value.detail)
+
+
+class TestApplyDispositionsDelete:
+    """REQ-2.8 — delete pad: org KB or personal KB both purged immediately."""
+
+    @pytest.mark.asyncio
+    async def test_delete_personal_kb_emits_personal_purged_event(self) -> None:
+        kb = _make_kb(kb_id=11, owner_type="user", created_by="uid-leaving", slug="personal-uid-leaving")
+        org = _make_org()
+
+        db = AsyncMock()
+        db.delete = AsyncMock()
+        db.execute.side_effect = [_scalar_result(kb)]
+
+        with (
+            patch("app.services.kb_offboarding.docs_client.deprovision_kb", AsyncMock()),
+            patch("app.services.kb_offboarding.knowledge_ingest_client.delete_kb", AsyncMock()) as mock_ingest,
+            patch("app.services.kb_offboarding.log_event", AsyncMock()) as mock_log,
+        ):
+            await apply_dispositions(
+                target_user_id="uid-leaving",
+                dispositions=[KbDisposition(kb_id=11, action="delete")],
+                actor_user_id="uid-admin",
+                org=org,
+                db=db,
+            )
+
+        mock_ingest.assert_awaited_once_with(org.zitadel_org_id, kb.slug)
+        db.delete.assert_awaited_once_with(kb)
+        purge_calls = [
+            c for c in mock_log.await_args_list if c.kwargs.get("action") == "kb.personal_purged_on_offboard"
+        ]
+        assert len(purge_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_delete_org_kb_emits_admin_deleted_with_offboarding_reason(self) -> None:
+        kb = _make_kb(kb_id=8, owner_type="org", created_by="uid-leaving", slug="team-kb")
+        org = _make_org()
+
+        db = AsyncMock()
+        db.delete = AsyncMock()
+        db.execute.side_effect = [_scalar_result(kb)]
+
+        with (
+            patch("app.services.kb_offboarding.docs_client.deprovision_kb", AsyncMock()),
+            patch("app.services.kb_offboarding.knowledge_ingest_client.delete_kb", AsyncMock()),
+            patch("app.services.kb_offboarding.log_event", AsyncMock()) as mock_log,
+        ):
+            await apply_dispositions(
+                target_user_id="uid-leaving",
+                dispositions=[KbDisposition(kb_id=8, action="delete")],
+                actor_user_id="uid-admin",
+                org=org,
+                db=db,
+            )
+
+        admin_calls = [c for c in mock_log.await_args_list if c.kwargs.get("action") == "kb.admin_deleted"]
+        assert len(admin_calls) == 1
+        details = admin_calls[0].kwargs.get("details") or {}
+        assert details.get("reason") == "offboarding"
+
+    @pytest.mark.asyncio
+    async def test_docs_failure_aborts_before_db_delete(self) -> None:
+        """REQ-1.5 / AC-10: failure in step-1 leaves the KB row intact."""
+        kb = _make_kb(kb_id=8, owner_type="org", created_by="uid-leaving")
+        kb.gitea_repo_slug = "team-kb"
+        kb.docs_enabled = True
+        org = _make_org()
+
+        db = AsyncMock()
+        db.delete = AsyncMock()
+        db.execute.side_effect = [_scalar_result(kb)]
+
+        with (
+            patch(
+                "app.services.kb_offboarding.docs_client.deprovision_kb",
+                AsyncMock(side_effect=RuntimeError("docs-app down")),
+            ),
+            patch("app.services.kb_offboarding.knowledge_ingest_client.delete_kb", AsyncMock()) as mock_ingest,
+            patch("app.services.kb_offboarding.log_event", AsyncMock()),
+        ):
+            with pytest.raises(RuntimeError):
+                await apply_dispositions(
+                    target_user_id="uid-leaving",
+                    dispositions=[KbDisposition(kb_id=8, action="delete")],
+                    actor_user_id="uid-admin",
+                    org=org,
+                    db=db,
+                )
+
+        mock_ingest.assert_not_awaited()
+        db.delete.assert_not_awaited()
+
+
+class TestRevokeUserCredentials:
+    """REQ-2.7 — auto-revoke API keys + MCP tokens."""
+
+    @pytest.mark.asyncio
+    async def test_revoke_deletes_api_keys_and_soft_revokes_mcp_tokens(self) -> None:
+        db = AsyncMock()
+        # Sequence of execute() calls inside revoke_user_credentials:
+        # 1. DELETE FROM partner_api_keys → rowcount=2
+        # 2. SELECT portal_users.id → 99
+        # 3. UPDATE portal_mcp_tokens → rowcount=3
+        api_delete_result = MagicMock()
+        api_delete_result.rowcount = 2
+        user_pk_result = _scalar_result(99)
+        mcp_update_result = MagicMock()
+        mcp_update_result.rowcount = 3
+        db.execute.side_effect = [api_delete_result, user_pk_result, mcp_update_result]
+
+        api_deleted, mcp_revoked = await revoke_user_credentials(
+            target_user_id="uid-leaving",
+            org_id=101,
+            db=db,
+        )
+        assert api_deleted == 2
+        assert mcp_revoked == 3
+
+    @pytest.mark.asyncio
+    async def test_revoke_handles_missing_portal_user_row(self) -> None:
+        """If the portal_users row is already gone (race or pre-cleanup),
+        MCP token revoke is a no-op (no FK to update)."""
+        db = AsyncMock()
+        api_delete_result = MagicMock()
+        api_delete_result.rowcount = 0
+        user_pk_result = _scalar_result(None)
+        db.execute.side_effect = [api_delete_result, user_pk_result]
+
+        api_deleted, mcp_revoked = await revoke_user_credentials(
+            target_user_id="uid-gone",
+            org_id=101,
+            db=db,
+        )
+        assert api_deleted == 0
+        assert mcp_revoked == 0

--- a/klai-portal/backend/tests/test_kb_personal_firewall.py
+++ b/klai-portal/backend/tests/test_kb_personal_firewall.py
@@ -1,0 +1,206 @@
+"""SPEC-PORTAL-KB-OWNERSHIP-001 — Personal-KB firewall tests.
+
+REQ-3.1 — central FastAPI dependency `get_kb_with_access` enforces:
+  - returns the KB when caller is org-member AND (kb is org-owned OR kb is personal-and-caller-owned)
+  - raises HTTPException(404) when kb is personal AND owned by someone else
+    (NOT 403 — never leak existence of a personal KB)
+  - applies regardless of caller role (admin gets 404 too)
+
+REQ-3.3 — invariant introspection test: every route under
+  `/api/app/knowledge-bases/{kb_slug}/...` uses `get_kb_with_access` in its
+  dependency tree. A new route that forgets the gate fails this test.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from tests.conftest import make_perms
+
+
+def _kb(*, owner_type: str, owner_user_id: str | None, org_id: int = 101, slug: str = "kb") -> MagicMock:
+    """Build a PortalKnowledgeBase-shaped mock."""
+    kb = MagicMock()
+    kb.id = 42
+    kb.org_id = org_id
+    kb.name = "Test KB"
+    kb.slug = slug
+    kb.owner_type = owner_type
+    kb.owner_user_id = owner_user_id
+    kb.created_by = owner_user_id or "creator-uid"
+    return kb
+
+
+def _db_with_kb(kb: MagicMock | None) -> AsyncMock:
+    """Mock AsyncSession that yields the given kb (or None) for the first SELECT."""
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = kb
+    db.execute.return_value = result
+    return db
+
+
+class TestIsPersonalKb:
+    """is_personal_kb is the single-source-of-truth helper for owner_type discrimination."""
+
+    def test_personal_kb_returns_true(self) -> None:
+        from app.services.access import is_personal_kb
+
+        kb = _kb(owner_type="user", owner_user_id="uid-A")
+        assert is_personal_kb(kb) is True
+
+    def test_org_kb_returns_false(self) -> None:
+        from app.services.access import is_personal_kb
+
+        kb = _kb(owner_type="org", owner_user_id=None)
+        assert is_personal_kb(kb) is False
+
+
+class TestGetKbWithAccess:
+    """get_kb_with_access is the firewall + 404-resolver dependency."""
+
+    @pytest.mark.asyncio
+    async def test_org_kb_is_returned_for_any_org_member(self) -> None:
+        from app.api.dependencies import get_kb_with_access
+
+        kb = _kb(owner_type="org", owner_user_id=None)
+        db = _db_with_kb(kb)
+        perms = make_perms(user_id="uid-member", org_id=101, role="personal")
+
+        result = await get_kb_with_access(kb_slug="some-kb", perms=perms, db=db)
+        assert result is kb
+
+    @pytest.mark.asyncio
+    async def test_personal_kb_is_returned_to_owner(self) -> None:
+        from app.api.dependencies import get_kb_with_access
+
+        kb = _kb(owner_type="user", owner_user_id="uid-owner", slug="personal-uid-owner")
+        db = _db_with_kb(kb)
+        perms = make_perms(user_id="uid-owner", org_id=101, role="personal")
+
+        result = await get_kb_with_access(kb_slug="personal-uid-owner", perms=perms, db=db)
+        assert result is kb
+
+    @pytest.mark.asyncio
+    async def test_personal_kb_of_another_user_returns_404_for_admin(self) -> None:
+        """Firewall: admin gets 404 (NOT 403) — existence-non-disclosure."""
+        from app.api.dependencies import get_kb_with_access
+
+        kb = _kb(owner_type="user", owner_user_id="uid-A", slug="personal-uid-A")
+        db = _db_with_kb(kb)
+        perms = make_perms(user_id="uid-admin", org_id=101, role="admin")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_kb_with_access(kb_slug="personal-uid-A", perms=perms, db=db)
+
+        assert exc_info.value.status_code == 404
+        assert "not found" in str(exc_info.value.detail).lower()
+
+    @pytest.mark.asyncio
+    async def test_personal_kb_of_another_user_returns_404_for_regular_user(self) -> None:
+        from app.api.dependencies import get_kb_with_access
+
+        kb = _kb(owner_type="user", owner_user_id="uid-A", slug="personal-uid-A")
+        db = _db_with_kb(kb)
+        perms = make_perms(user_id="uid-B", org_id=101, role="personal")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_kb_with_access(kb_slug="personal-uid-A", perms=perms, db=db)
+
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_unknown_kb_returns_404(self) -> None:
+        from app.api.dependencies import get_kb_with_access
+
+        db = _db_with_kb(None)
+        perms = make_perms(user_id="uid", org_id=101, role="personal")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_kb_with_access(kb_slug="nope", perms=perms, db=db)
+
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_kb_in_different_org_returns_404(self) -> None:
+        """Tenant-isolation interaction: query is org-scoped, so cross-tenant kb_slug returns None → 404."""
+        from app.api.dependencies import get_kb_with_access
+
+        # _db_with_kb(None) simulates the org-scoped SELECT returning no rows because
+        # the kb actually belongs to org_id != perms.org_id.
+        db = _db_with_kb(None)
+        perms = make_perms(user_id="uid", org_id=999, role="admin")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_kb_with_access(kb_slug="some-kb", perms=perms, db=db)
+
+        assert exc_info.value.status_code == 404
+
+
+class TestRouteFirewallInvariant:
+    """REQ-3.3: every KB-route with `{kb_slug}` uses `get_kb_with_access` in its dep tree."""
+
+    def test_every_kb_slug_route_uses_firewall_dependency(self) -> None:
+        """Static introspection: scan FastAPI routes and assert the firewall dependency is wired.
+
+        New routes that take `{kb_slug}` as a path-param without going through
+        `get_kb_with_access` fail this test. The dependency does both the
+        org-scoped SELECT and the personal-firewall check; bypassing it skips
+        both and re-introduces SPEC-PORTAL-KB-OWNERSHIP-001 P3.
+        """
+        from fastapi.dependencies.utils import get_flat_dependant
+
+        from app.api.dependencies import get_kb_with_access
+        from app.main import app
+
+        # Routes intentionally exempt from the firewall dependency:
+        # - create_app_knowledge_base: kb_slug is in REQUEST BODY, not path. Quota check
+        #   handles personal-vs-org. New KB has no existence to firewall.
+        # - /internal/knowledge-bases/{kb_slug}/metadata: X-Internal-Secret-authenticated
+        #   service-to-service endpoint. No `perms` to check against; trusted callers.
+        # - /kb-images/{zitadel_org_id}/images/{kb_slug}/{filename}: public image fetch
+        #   gated by image-hash + zitadel_org_id, not by user identity. kb_slug is
+        #   informational in the routing path.
+        exempt_paths = {
+            "/api/app/knowledge-bases",  # POST create
+            "/internal/knowledge-bases/{kb_slug}/metadata",
+            "/kb-images/{zitadel_org_id}/images/{kb_slug}/{filename}",
+        }
+
+        from app.core.permissions import get_caller
+
+        offenders: list[tuple[str, list[str]]] = []
+        for route in app.routes:
+            path = getattr(route, "path", None)
+            if not path:
+                continue
+            if "{kb_slug}" not in path:
+                continue
+            if path in exempt_paths:
+                continue
+            dependant = getattr(route, "dependant", None)
+            if dependant is None:
+                continue
+            flat = get_flat_dependant(dependant)
+            call_chain = [d.call for d in flat.dependencies if d.call is not None]
+            # Skip internal-only routes (X-Internal-Secret authenticated; no
+            # `perms`/`get_caller` in the dep chain). These cannot use
+            # `get_kb_with_access` because it depends on `get_caller`.
+            # Trusted-caller endpoints carry their own auth model and do not
+            # leak personal-KB existence to end users.
+            if get_caller not in call_chain:
+                continue
+            if get_kb_with_access not in call_chain:
+                methods = sorted(getattr(route, "methods", []) or [])
+                offenders.append(
+                    (f"{','.join(methods)} {path}", [getattr(c, "__qualname__", repr(c)) for c in call_chain])
+                )
+
+        assert not offenders, (
+            "Routes with {kb_slug} that don't use get_kb_with_access "
+            "(SPEC-PORTAL-KB-OWNERSHIP-001 REQ-3.3 firewall):\n"
+            + "\n".join(f"  - {route}\n    deps: {deps}" for route, deps in offenders)
+        )

--- a/klai-portal/backend/tests/test_rls_audit.py
+++ b/klai-portal/backend/tests/test_rls_audit.py
@@ -87,6 +87,14 @@ _ALLOWLIST: dict[str, str] = {
     "app/services/kb_quota.py": (
         "service layer — all callers pass a db session with tenant context already set via _get_caller_org"
     ),
+    # SPEC-PORTAL-KB-OWNERSHIP-001 Phase 3 offboard orchestrator. Every entry
+    # point (compute_offboard_preview, apply_dispositions,
+    # revoke_user_credentials) is called from admin/users.py routes that gate
+    # on Depends(get_caller_at_least(ProfileRole.ADMIN)) — the upstream auth
+    # dep runs set_tenant before any of these execute().
+    "app/services/kb_offboarding.py": (
+        "service layer — orchestrator called from admin/users.py routes after _get_caller_org sets tenant"
+    ),
 }
 
 

--- a/klai-portal/backend/tests/test_rls_callsite_audit.py
+++ b/klai-portal/backend/tests/test_rls_callsite_audit.py
@@ -91,6 +91,16 @@ ALLOWED_HELPER_FUNCTIONS: frozenset[str] = frozenset(
         # that runs after Depends(get_caller) → tenant context is set
         # before the SELECT on portal_knowledge_bases fires.
         "get_kb_with_access",
+        # app/services/kb_offboarding.py — SPEC-PORTAL-KB-OWNERSHIP-001 Phase 3.
+        # All entry points are called from admin/users.py routes that gate on
+        # ``Depends(get_caller_at_least(ProfileRole.ADMIN))`` — tenant context
+        # is established by the upstream dep before any of these run.
+        "compute_offboard_preview",
+        "apply_dispositions",
+        "_load_kb_or_404",
+        "_do_transfer",
+        "_do_delete",
+        "revoke_user_credentials",
         # app/core/system_groups.py — no-op stub after SPEC-PORTAL-RBAC-001.
         "create_system_groups",
         # app/api/app_knowledge_bases.py — all helpers take org_id and

--- a/klai-portal/backend/tests/test_rls_callsite_audit.py
+++ b/klai-portal/backend/tests/test_rls_callsite_audit.py
@@ -82,6 +82,15 @@ ALLOWED_HELPER_FUNCTIONS: frozenset[str] = frozenset(
         "ensure_default_knowledge_bases",
         "create_default_org_kb",
         "create_default_personal_kb",
+        # app/services/default_knowledge_bases.py — magic-slug shortcuts
+        # called from get_kb_with_access dep, which itself runs after
+        # _get_caller_org has set tenant. SPEC-PORTAL-KB-OWNERSHIP-001 REQ-3.1.
+        "resolve_personal_kb",
+        "resolve_org_kb",
+        # app/api/dependencies.py — get_kb_with_access is a FastAPI dependency
+        # that runs after Depends(get_caller) → tenant context is set
+        # before the SELECT on portal_knowledge_bases fires.
+        "get_kb_with_access",
         # app/core/system_groups.py — no-op stub after SPEC-PORTAL-RBAC-001.
         "create_system_groups",
         # app/api/app_knowledge_bases.py — all helpers take org_id and

--- a/klai-portal/backend/tests/test_user_lifecycle.py
+++ b/klai-portal/backend/tests/test_user_lifecycle.py
@@ -29,7 +29,49 @@ def _mock_user(status: str = "active", org_id: int = 1) -> MagicMock:
     user.status = status
     user.org_id = org_id
     user.zitadel_user_id = "user-1"
+    user.github_username = None
     return user
+
+
+def _empty_result() -> MagicMock:
+    """A SQLAlchemy Result mock that satisfies every reader the
+    Phase 3 offboard flow uses (scalars, scalar_one, scalar_one_or_none,
+    rowcount). Defaults are 'no rows / empty list / count 0' so tests
+    that don't care about a specific intermediate query can reuse it."""
+
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = None
+    r.scalar_one.return_value = 0
+    r.rowcount = 0
+    r.scalars.return_value.all.return_value = []
+    return r
+
+
+def _offboard_db_mock(user: MagicMock, org: MagicMock) -> AsyncMock:
+    """SPEC-PORTAL-KB-OWNERSHIP-001 Phase 3 — offboard now hits the DB many
+    more times (preview SELECTs, apply_dispositions, revoke_user_credentials,
+    membership delete). Build a flexible mock that returns the user / org
+    for the first two SELECTs and empty results for everything else.
+    """
+
+    user_lookup = MagicMock()
+    user_lookup.scalar_one_or_none.return_value = user
+    org_lookup = MagicMock()
+    org_lookup.scalar_one_or_none.return_value = org
+
+    db = AsyncMock()
+    db.delete = AsyncMock()
+    db.commit = AsyncMock()
+
+    queue: list[MagicMock] = [user_lookup, org_lookup]
+
+    def _next_result(*_args, **_kwargs):
+        if queue:
+            return queue.pop(0)
+        return _empty_result()
+
+    db.execute.side_effect = _next_result
+    return db
 
 
 # ---------------------------------------------------------------------------
@@ -158,22 +200,22 @@ class TestReactivateUser:
 class TestOffboardUser:
     @pytest.mark.asyncio
     async def test_offboard_active_user_cascade(self) -> None:
-        """Offboard deletes memberships, calls Zitadel, sets status.
+        """Offboard with no KBs / tokens: still flips status, deletes memberships, calls Zitadel.
 
-        SPEC-PORTAL-RBAC-001: portal_user_products is no longer written/deleted
-        per user lifecycle event -- products derive from (role, plan,
-        enabled_addons) at read time. The execute call count drops from 3 to 2.
+        SPEC-PORTAL-KB-OWNERSHIP-001 Phase 3: offboard now ALSO computes the
+        preview, applies KB-dispositions, and revokes API-keys / MCP-tokens
+        in the same DB transaction. With an empty preview the new path is a
+        sequence of empty SELECTs / rowcount=0 mutations, so the only
+        observable side-effects are the same as before: status flip + commit
+        + Zitadel deactivate.
         """
         from app.api.admin.users import offboard_user
 
         user = _mock_user(status="active")
-
-        mock_db = AsyncMock()
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = user
-        # First execute: user lookup
-        # Second execute: delete memberships
-        mock_db.execute.side_effect = [mock_result, MagicMock()]
+        org = _mock_org(org_id=1)
+        org.slug = "voys"
+        org.zitadel_org_id = "zitadel-org-1"
+        mock_db = _offboard_db_mock(user, org)
         mock_zitadel = AsyncMock()
 
         with (
@@ -182,14 +224,15 @@ class TestOffboardUser:
         ):
             mock_settings.zitadel_portal_org_id = "org-id"
             result = await offboard_user(
-                zitadel_user_id="user-1", perms=make_perms(role="admin", user_id="admin-1", org_id=1), db=mock_db
+                zitadel_user_id="user-1",
+                body=None,
+                perms=make_perms(role="admin", user_id="admin-1", org_id=1),
+                db=mock_db,
             )
 
         assert user.status == "offboarded"
         assert "offboarded" in result.message
         mock_zitadel.deactivate_user.assert_awaited_once()
-        # 2 execute calls: user lookup + delete memberships
-        assert mock_db.execute.await_count == 2
         mock_db.commit.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -215,11 +258,10 @@ class TestOffboardUser:
         from app.api.admin.users import offboard_user
 
         user = _mock_user(status="suspended")
-
-        mock_db = AsyncMock()
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = user
-        mock_db.execute.side_effect = [mock_result, MagicMock(), MagicMock()]
+        org = _mock_org(org_id=1)
+        org.slug = "voys"
+        org.zitadel_org_id = "zitadel-org-1"
+        mock_db = _offboard_db_mock(user, org)
         mock_zitadel = AsyncMock()
 
         with (
@@ -228,7 +270,10 @@ class TestOffboardUser:
         ):
             mock_settings.zitadel_portal_org_id = "org-id"
             await offboard_user(
-                zitadel_user_id="user-1", perms=make_perms(role="admin", user_id="admin-1", org_id=1), db=mock_db
+                zitadel_user_id="user-1",
+                body=None,
+                perms=make_perms(role="admin", user_id="admin-1", org_id=1),
+                db=mock_db,
             )
 
         assert user.status == "offboarded"

--- a/klai-portal/frontend/src/components/admin/offboard-wizard.tsx
+++ b/klai-portal/frontend/src/components/admin/offboard-wizard.tsx
@@ -1,0 +1,364 @@
+import { useState, useMemo } from 'react'
+import { useNavigate } from '@tanstack/react-router'
+import { useQuery } from '@tanstack/react-query'
+import { Loader2, AlertTriangle, KeyRound } from 'lucide-react'
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+} from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+import { Select } from '@/components/ui/select'
+import { apiFetch } from '@/lib/apiFetch'
+import { useOffboardUser, type KbDisposition } from '@/hooks/useUserLifecycle'
+
+/**
+ * SPEC-PORTAL-KB-OWNERSHIP-001 Phase 4 — admin offboarding wizard.
+ *
+ * Replaces the simple confirm-dialog with a per-KB disposition picker:
+ *   - Org KBs the user solely owns: transfer to another active org
+ *     member (default = the current admin, mirroring Google Workspace's
+ *     "direct manager" pattern), or delete.
+ *   - Personal KBs: always delete (no transfer option — REQ-2.4 / D2).
+ *
+ * Token revoke counts (REQ-2.1b / REQ-2.7) surface as an info banner
+ * so the admin sees what auto-cleanup will happen alongside the
+ * user-status flip.
+ */
+
+interface OffboardPreviewKb {
+  kb_id: number
+  slug: string
+  name: string
+  owner_type: 'org' | 'user'
+  role_count: number
+}
+
+interface OffboardPreview {
+  org_kbs_solely_owned: OffboardPreviewKb[]
+  personal_kbs: OffboardPreviewKb[]
+  api_keys_count: number
+  mcp_tokens_count: number
+}
+
+interface AdminUser {
+  zitadel_user_id: string
+  email: string
+  first_name: string
+  last_name: string
+  status: string
+  invite_pending: boolean
+}
+
+type OrgDispositionAction = 'transfer' | 'delete'
+
+interface OrgDispositionState {
+  action: OrgDispositionAction
+  transferTo: string
+}
+
+interface OffboardWizardProps {
+  userId: string
+  /** Display label for the user being offboarded — shown in the dialog title. */
+  userLabel: string
+  /** Current admin's user-id; used as the default transfer-recipient. */
+  currentAdminId: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function OffboardWizard({
+  userId,
+  userLabel,
+  currentAdminId,
+  open,
+  onOpenChange,
+}: OffboardWizardProps) {
+  const navigate = useNavigate()
+  const offboardMutation = useOffboardUser()
+
+  // Preview is fetched once when the wizard opens. The empty-array
+  // default keeps the rest of the component pure: no nullable list,
+  // no "loading shimmer" branching for the disposition rows.
+  const previewQuery = useQuery<OffboardPreview>({
+    queryKey: ['offboard-preview', userId],
+    queryFn: async () =>
+      apiFetch<OffboardPreview>(
+        `/api/admin/users/${userId}/offboard-preview`,
+      ),
+    enabled: open,
+    staleTime: 0,
+  })
+
+  // The transfer-receiver dropdown lists all active org members EXCEPT
+  // the user being offboarded. Source is the same /api/admin/users
+  // endpoint the user-list page already caches.
+  const usersQuery = useQuery<{ users: AdminUser[] }>({
+    queryKey: ['admin-users'],
+    queryFn: async () => apiFetch<{ users: AdminUser[] }>(`/api/admin/users`),
+    enabled: open,
+  })
+
+  const eligibleReceivers = useMemo(() => {
+    if (!usersQuery.data) return []
+    return usersQuery.data.users.filter(
+      (u) =>
+        u.zitadel_user_id !== userId &&
+        u.status === 'active' &&
+        !u.invite_pending,
+    )
+  }, [usersQuery.data, userId])
+
+  // Per-org-KB disposition state. Default action is 'transfer' to the
+  // current admin — picks up Mark's "default to admin" decision (D1).
+  // Personal KBs have no state because their action is locked to delete.
+  const [orgDispositions, setOrgDispositions] = useState<
+    Record<number, OrgDispositionState>
+  >({})
+
+  const orgKbs = previewQuery.data?.org_kbs_solely_owned ?? []
+  const personalKbs = previewQuery.data?.personal_kbs ?? []
+
+  // Initialise / re-initialise dispositions when the preview lands.
+  // useMemo would race the render; useState init is a one-shot. We
+  // use a derived helper that reads from state and falls back to the
+  // default for unseen kb_ids — keeps the picker stateless from the
+  // user's POV until they touch it.
+  function dispositionFor(kb: OffboardPreviewKb): OrgDispositionState {
+    return (
+      orgDispositions[kb.kb_id] ?? {
+        action: 'transfer',
+        transferTo: currentAdminId,
+      }
+    )
+  }
+
+  function setOrgKbAction(kb_id: number, action: OrgDispositionAction) {
+    setOrgDispositions((prev) => ({
+      ...prev,
+      [kb_id]: {
+        action,
+        transferTo: prev[kb_id]?.transferTo ?? currentAdminId,
+      },
+    }))
+  }
+
+  function setOrgKbTransferTo(kb_id: number, transferTo: string) {
+    setOrgDispositions((prev) => ({
+      ...prev,
+      [kb_id]: {
+        action: prev[kb_id]?.action ?? 'transfer',
+        transferTo,
+      },
+    }))
+  }
+
+  function buildDispositions(): KbDisposition[] {
+    const orgRows: KbDisposition[] = orgKbs.map((kb) => {
+      const d = dispositionFor(kb)
+      if (d.action === 'transfer') {
+        return { kb_id: kb.kb_id, action: 'transfer', transfer_to: d.transferTo }
+      }
+      return { kb_id: kb.kb_id, action: 'delete' }
+    })
+    const personalRows: KbDisposition[] = personalKbs.map((kb) => ({
+      kb_id: kb.kb_id,
+      action: 'delete',
+    }))
+    return [...orgRows, ...personalRows]
+  }
+
+  const isReady = !previewQuery.isLoading && !usersQuery.isLoading
+  const isSubmitting = offboardMutation.isPending
+  const previewError = previewQuery.error?.message
+
+  function handleOpenChange(next: boolean) {
+    if (isSubmitting) return
+    if (!next) {
+      setOrgDispositions({})
+    }
+    onOpenChange(next)
+  }
+
+  function handleSubmit() {
+    offboardMutation.mutate(
+      { userId, kb_dispositions: buildDispositions() },
+      {
+        onSuccess: () => {
+          onOpenChange(false)
+          void navigate({ to: '/admin/users' })
+        },
+      },
+    )
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
+      <AlertDialogContent className="max-w-2xl">
+        <AlertDialogHeader>
+          <AlertDialogTitle className="flex items-center gap-2 text-destructive">
+            <AlertTriangle className="h-5 w-5" />
+            {userLabel} offboarden
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            Persoonlijke kennisbanken worden definitief verwijderd. Voor team-
+            kennisbanken kies je per stuk: overdragen aan een collega of
+            permanent verwijderen. Twijfel je? Schors de gebruiker tijdelijk
+            in plaats van offboarden — dan blijft alle data behouden.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        {!isReady && (
+          <div className="flex items-center justify-center py-6 text-muted-foreground">
+            <Loader2 className="h-5 w-5 animate-spin mr-2" />
+            Voorbereiden...
+          </div>
+        )}
+
+        {previewError && (
+          <div className="rounded-md border border-destructive bg-destructive/5 p-3 text-sm text-destructive">
+            Kon offboard-preview niet laden: {previewError}
+          </div>
+        )}
+
+        {isReady && previewQuery.data && (
+          <div className="space-y-4 text-sm max-h-[60vh] overflow-y-auto">
+            {/* Token-revoke summary (REQ-2.1b / REQ-2.7) */}
+            {(previewQuery.data.api_keys_count > 0 ||
+              previewQuery.data.mcp_tokens_count > 0) && (
+              <div
+                className="flex items-start gap-2 rounded-md border border-border bg-secondary p-3"
+                data-test-id="offboard-token-banner"
+              >
+                <KeyRound className="h-4 w-4 mt-0.5 text-muted-foreground" />
+                <div>
+                  <p className="font-medium">
+                    Toegangstokens worden automatisch ingetrokken
+                  </p>
+                  <p className="text-muted-foreground">
+                    {previewQuery.data.api_keys_count} API-key
+                    {previewQuery.data.api_keys_count !== 1 ? 's' : ''} en{' '}
+                    {previewQuery.data.mcp_tokens_count} MCP-token
+                    {previewQuery.data.mcp_tokens_count !== 1 ? 's' : ''} van
+                    deze gebruiker worden tegelijk met de offboard verwijderd.
+                  </p>
+                </div>
+              </div>
+            )}
+
+            {/* Org-KBs the user solely owns */}
+            {orgKbs.length > 0 && (
+              <section>
+                <h3 className="font-medium mb-2">
+                  Team-kennisbanken ({orgKbs.length})
+                </h3>
+                <ul className="space-y-2">
+                  {orgKbs.map((kb) => {
+                    const d = dispositionFor(kb)
+                    return (
+                      <li
+                        key={kb.kb_id}
+                        className="rounded-md border border-border p-3"
+                        data-test-id={`org-kb-row-${kb.slug}`}
+                      >
+                        <div className="flex items-center justify-between gap-2 flex-wrap">
+                          <div>
+                            <p className="font-medium">{kb.name}</p>
+                            <p className="text-xs text-muted-foreground">
+                              {kb.slug}
+                            </p>
+                          </div>
+                          <Select
+                            value={d.action}
+                            onChange={(e) =>
+                              setOrgKbAction(kb.kb_id, e.target.value as OrgDispositionAction)
+                            }
+                            className="w-44"
+                          >
+                            <option value="transfer">Overdragen</option>
+                            <option value="delete">Verwijderen</option>
+                          </Select>
+                        </div>
+                        {d.action === 'transfer' && (
+                          <div className="mt-2 flex items-center gap-2">
+                            <span className="text-xs text-muted-foreground">aan</span>
+                            <Select
+                              value={d.transferTo}
+                              onChange={(e) => setOrgKbTransferTo(kb.kb_id, e.target.value)}
+                              className="w-full max-w-sm"
+                            >
+                              {eligibleReceivers.map((u) => (
+                                <option key={u.zitadel_user_id} value={u.zitadel_user_id}>
+                                  {u.first_name} {u.last_name} ({u.email})
+                                </option>
+                              ))}
+                            </Select>
+                          </div>
+                        )}
+                      </li>
+                    )
+                  })}
+                </ul>
+              </section>
+            )}
+
+            {/* Personal KBs — locked to delete */}
+            {personalKbs.length > 0 && (
+              <section>
+                <h3 className="font-medium mb-2">
+                  Persoonlijke kennisbanken ({personalKbs.length})
+                </h3>
+                <ul className="space-y-2">
+                  {personalKbs.map((kb) => (
+                    <li
+                      key={kb.kb_id}
+                      className="rounded-md border border-border p-3"
+                      data-test-id={`personal-kb-row-${kb.slug}`}
+                    >
+                      <div className="flex items-center justify-between gap-2 flex-wrap">
+                        <div>
+                          <p className="font-medium">{kb.name}</p>
+                          <p className="text-xs text-muted-foreground">{kb.slug}</p>
+                        </div>
+                        <span
+                          className="text-xs rounded-md bg-destructive/10 text-destructive px-2 py-1"
+                          title="Persoonlijke kennisbanken worden bij offboarding altijd verwijderd"
+                        >
+                          Wordt verwijderd
+                        </span>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            )}
+
+            {orgKbs.length === 0 && personalKbs.length === 0 && (
+              <p className="text-muted-foreground">
+                Deze gebruiker heeft geen eigen kennisbanken. Offboarden gaat
+                door zonder data-overdracht.
+              </p>
+            )}
+          </div>
+        )}
+
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isSubmitting}>Annuleren</AlertDialogCancel>
+          <Button
+            variant="destructive"
+            onClick={handleSubmit}
+            disabled={!isReady || isSubmitting || !!previewError}
+            data-test-id="offboard-submit-button"
+          >
+            {isSubmitting && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+            Offboard
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/klai-portal/frontend/src/components/ui/delete-kb-modal.tsx
+++ b/klai-portal/frontend/src/components/ui/delete-kb-modal.tsx
@@ -15,6 +15,15 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { apiFetch } from '@/lib/apiFetch'
 
+/**
+ * SPEC-PORTAL-KB-OWNERSHIP-001 REQ-1.1 — header-based admin-override token.
+ * Mirrors the I-CONFIRM-REMOVAL precedent in klai-infra/sync-env.yml: a
+ * typed string forces explicit operator intent, impossible to set by an
+ * accidental click-through.
+ */
+const ADMIN_OVERRIDE_HEADER = 'X-Admin-Override-Confirm'
+const ADMIN_OVERRIDE_VALUE = 'I-WAS-NOT-CREATOR'
+
 interface DeleteKbModalProps {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -24,6 +33,22 @@ interface DeleteKbModalProps {
   connectorCount: number
   hasGitea: boolean
   hasDocs: boolean
+  /**
+   * `'self'` — caller is owner / creator. Existing UX:
+   *    type the kb-slug to confirm; no override header sent.
+   * `'admin-override'` — caller is org admin but NOT the creator
+   *    (SPEC-PORTAL-KB-OWNERSHIP-001 REQ-1.1). Yellow banner names the
+   *    creator; confirm-gate becomes "type DELETE"; the
+   *    `X-Admin-Override-Confirm: I-WAS-NOT-CREATOR` header is attached
+   *    only after the typed confirmation.
+   */
+  mode?: 'self' | 'admin-override'
+  /**
+   * Display name (or fallback to user-id) of the original creator.
+   * Used in the admin-override banner so the deleting admin sees whose
+   * KB they are about to remove. Ignored when `mode === 'self'`.
+   */
+  creatorName?: string | null
 }
 
 export function DeleteKbModal({
@@ -35,15 +60,36 @@ export function DeleteKbModal({
   connectorCount,
   hasGitea,
   hasDocs,
+  mode = 'self',
+  creatorName,
 }: DeleteKbModalProps) {
   const [confirmValue, setConfirmValue] = useState('')
   const [error, setError] = useState<string | null>(null)
   const navigate = useNavigate()
   const queryClient = useQueryClient()
 
+  const isAdminOverride = mode === 'admin-override'
+  // The confirm-gate text differs per mode. In self-mode the user types
+  // the kb-slug (existing behaviour); in admin-override mode the user
+  // types the literal string DELETE (matches the typed-token shape of
+  // the override-header value, kept simpler than the slug for the
+  // less-frequent admin path).
+  const confirmTarget = isAdminOverride ? 'DELETE' : kbSlug
+
   const deleteMutation = useMutation({
     mutationFn: async () => {
-      await apiFetch(`/api/app/knowledge-bases/${kbSlug}`, { method: 'DELETE' })
+      const headers: Record<string, string> = {}
+      // REQ-1.1 — only attach the override header in admin-override mode.
+      // The owner pad must NEVER send it (defense-in-depth: the header
+      // alone bypasses the owner role check on the backend, so leaking
+      // it across modes would let a non-owner get a 204).
+      if (isAdminOverride) {
+        headers[ADMIN_OVERRIDE_HEADER] = ADMIN_OVERRIDE_VALUE
+      }
+      await apiFetch(`/api/app/knowledge-bases/${kbSlug}`, {
+        method: 'DELETE',
+        headers,
+      })
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['app-knowledge-bases'] })
@@ -54,7 +100,7 @@ export function DeleteKbModal({
     },
   })
 
-  const isMatch = confirmValue === kbSlug
+  const isMatch = confirmValue === confirmTarget
   const isPending = deleteMutation.isPending
 
   function handleOpenChange(next: boolean) {
@@ -77,6 +123,21 @@ export function DeleteKbModal({
         </AlertDialogHeader>
 
         <div className="space-y-3 text-sm">
+          {isAdminOverride && (
+            <div
+              className="rounded-md border border-warning bg-warning-bg p-3"
+              data-test-id="admin-override-banner"
+            >
+              <p className="font-medium text-warning">
+                Je hebt deze kennisbank niet aangemaakt.
+              </p>
+              <p className="mt-1 text-foreground">
+                Aangemaakt door <strong>{creatorName ?? '(onbekend)'}</strong>. Je
+                verwijdert content van een collega — deze actie staat los van een
+                eigen back-up. Vraag bij twijfel eerst even bij de aanmaker na.
+              </p>
+            </div>
+          )}
           <p>Dit verwijdert permanent:</p>
           <ul className="list-disc list-inside space-y-1 text-muted-foreground">
             <li><strong className="text-foreground">{kbName}</strong></li>
@@ -94,7 +155,7 @@ export function DeleteKbModal({
           </p>
           <div className="space-y-1.5 pt-2">
             <Label htmlFor="confirm-slug">
-              Typ <strong>{kbSlug}</strong> om te bevestigen
+              Typ <strong>{confirmTarget}</strong> om te bevestigen
             </Label>
             <Input
               id="confirm-slug"
@@ -103,9 +164,10 @@ export function DeleteKbModal({
                 setConfirmValue(e.target.value)
                 setError(null)
               }}
-              placeholder={kbSlug}
+              placeholder={confirmTarget}
               disabled={isPending}
               autoComplete="off"
+              data-test-id={isAdminOverride ? 'admin-override-confirm-input' : 'self-confirm-input'}
             />
           </div>
           {error && <p className="text-destructive text-sm">{error}</p>}
@@ -117,6 +179,7 @@ export function DeleteKbModal({
             variant="destructive"
             disabled={!isMatch || isPending}
             onClick={() => deleteMutation.mutate()}
+            data-test-id="delete-kb-confirm-button"
           >
             {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
             Permanent verwijderen

--- a/klai-portal/frontend/src/hooks/useUserLifecycle.ts
+++ b/klai-portal/frontend/src/hooks/useUserLifecycle.ts
@@ -4,7 +4,7 @@ import { apiFetch } from '@/lib/apiFetch'
 import * as m from '@/paraglide/messages'
 
 function useLifecycleMutation(
-  action: 'suspend' | 'reactivate' | 'offboard',
+  action: 'suspend' | 'reactivate',
   successMessage: () => string,
 ) {
   const queryClient = useQueryClient()
@@ -33,6 +33,39 @@ export function useReactivateUser() {
   return useLifecycleMutation('reactivate', () => m.admin_users_toast_reactivated())
 }
 
+/**
+ * SPEC-PORTAL-KB-OWNERSHIP-001 Phase 3: offboard now requires a body
+ * with kb_dispositions (one per KB returned by the offboard-preview).
+ * The simple confirm-dialog wrapper is gone; callers pass the full
+ * disposition array via the OffboardWizard component.
+ */
+export interface KbDisposition {
+  kb_id: number
+  action: 'transfer' | 'delete'
+  transfer_to?: string
+}
+
+export interface OffboardArgs {
+  userId: string
+  kb_dispositions: KbDisposition[]
+}
+
 export function useOffboardUser() {
-  return useLifecycleMutation('offboard', () => m.admin_users_toast_offboarded())
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async ({ userId, kb_dispositions }: OffboardArgs) => {
+      await apiFetch(`/api/admin/users/${userId}/offboard`, {
+        method: 'POST',
+        body: JSON.stringify({ kb_dispositions }),
+        headers: { 'Content-Type': 'application/json' },
+      })
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['admin-users'] })
+      toast.success(m.admin_users_toast_offboarded())
+    },
+    onError: (error: Error) => {
+      toast.error(error.message)
+    },
+  })
 }

--- a/klai-portal/frontend/src/routes/admin/billing.lazy.tsx
+++ b/klai-portal/frontend/src/routes/admin/billing.lazy.tsx
@@ -180,7 +180,7 @@ function SeatBreakdownPanel() {
     // per-seat-billing opt-in status. Failing the status fetch falls
     // back to "Phase 5 light not available" semantics — the breakdown
     // stays visible and the CTA banner shows the coming-soon copy.
-    Promise.allSettled([
+    void Promise.allSettled([
       apiFetch<SeatBreakdownResponse>(`/api/admin/billing/breakdown`),
       apiFetch<PerSeatStatusResponse>(`/api/admin/billing/per-seat-status`),
     ])

--- a/klai-portal/frontend/src/routes/admin/users/$userId/edit.tsx
+++ b/klai-portal/frontend/src/routes/admin/users/$userId/edit.tsx
@@ -22,6 +22,7 @@ import { toast } from 'sonner'
 import * as m from '@/paraglide/messages'
 import { apiFetch } from '@/lib/apiFetch'
 import { useSuspendUser, useReactivateUser, useOffboardUser } from '@/hooks/useUserLifecycle'
+import { OffboardWizard } from '@/components/admin/offboard-wizard'
 import { useCurrentUser } from '@/hooks/useCurrentUser'
 import { PROFILE_LADDER, type ProfileRole } from '@/lib/profiles'
 import { ProfilePicker } from '../../_components/ProfilePicker'
@@ -84,6 +85,7 @@ function EditUserPage() {
   const suspendMutation = useSuspendUser()
   const reactivateMutation = useReactivateUser()
   const offboardMutation = useOffboardUser()
+  const [offboardWizardOpen, setOffboardWizardOpen] = useState(false)
 
   // SPEC-PORTAL-ADMIN-UI-001 v0.3.0 REQ-12: ÉÉN form, ÉÉN save. Submit-handler
   // stuurt PATCH /users/<id> voor naam/taal en — alleen als profile gewijzigd
@@ -249,36 +251,25 @@ function EditUserPage() {
           )}
 
           {(user.status === 'active' || user.status === 'suspended') && !user.invite_pending && (
-            <AlertDialog>
-              <AlertDialogTrigger asChild>
-                <Button variant="destructive" disabled={offboardMutation.isPending}>
-                  {offboardMutation.isPending && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
-                  {m.admin_users_action_offboard()}
-                </Button>
-              </AlertDialogTrigger>
-              <AlertDialogContent>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>{m.admin_users_confirm_offboard_title()}</AlertDialogTitle>
-                  <AlertDialogDescription>
-                    {m.admin_users_confirm_offboard_description()}
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel>{m.admin_users_cancel()}</AlertDialogCancel>
-                  <AlertDialogAction
-                    onClick={() => {
-                      offboardMutation.mutate(userId, {
-                        onSuccess: () => {
-                          void navigate({ to: '/admin/users' })
-                        },
-                      })
-                    }}
-                  >
-                    {m.admin_users_action_offboard()}
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
+            <>
+              <Button
+                variant="destructive"
+                disabled={offboardMutation.isPending}
+                onClick={() => setOffboardWizardOpen(true)}
+              >
+                {offboardMutation.isPending && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+                {m.admin_users_action_offboard()}
+              </Button>
+              {currentUser?.user_id && (
+                <OffboardWizard
+                  userId={userId}
+                  userLabel={`${user.first_name} ${user.last_name}`.trim() || user.email}
+                  currentAdminId={currentUser.user_id}
+                  open={offboardWizardOpen}
+                  onOpenChange={setOffboardWizardOpen}
+                />
+              )}
+            </>
           )}
         </div>
       )}

--- a/klai-portal/frontend/src/routes/admin/users/index.tsx
+++ b/klai-portal/frontend/src/routes/admin/users/index.tsx
@@ -40,7 +40,8 @@ import { datetime, plural } from '@/paraglide/registry'
 import { apiFetch } from '@/lib/apiFetch'
 import { adminLogger } from '@/lib/logger'
 import { QueryErrorState } from '@/components/ui/query-error-state'
-import { useSuspendUser, useReactivateUser, useOffboardUser } from '@/hooks/useUserLifecycle'
+import { useSuspendUser, useReactivateUser } from '@/hooks/useUserLifecycle'
+import { OffboardWizard } from '@/components/admin/offboard-wizard'
 import { PROFILE_LADDER, type ProfileRole } from '@/lib/profiles'
 import { cleanErrorMessage } from '../_components/errors'
 
@@ -131,7 +132,6 @@ function UsersPage() {
 
   const suspendMutation = useSuspendUser()
   const reactivateMutation = useReactivateUser()
-  const offboardMutation = useOffboardUser()
 
   const { data, isLoading, error, refetch } = useQuery({
     queryKey: ['admin-users'],
@@ -484,33 +484,23 @@ function UsersPage() {
         </table>
       )}
 
-      <AlertDialog
-        open={confirmingOffboardId !== null}
-        onOpenChange={(open) => { if (!open) setConfirmingOffboardId(null) }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{m.admin_users_confirm_offboard_title()}</AlertDialogTitle>
-            <AlertDialogDescription>
-              {m.admin_users_confirm_offboard_description()}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>{m.admin_users_cancel()}</AlertDialogCancel>
-            <AlertDialogAction
-              className="bg-[var(--color-destructive)] text-white hover:bg-[var(--color-destructive)]/90"
-              onClick={() => {
-                if (confirmingOffboardId) {
-                  offboardMutation.mutate(confirmingOffboardId)
-                }
-                setConfirmingOffboardId(null)
-              }}
-            >
-              {m.admin_users_action_offboard()}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      {/* SPEC-PORTAL-KB-OWNERSHIP-001 Phase 4 — offboard via wizard.
+          Replaces the simple confirm dialog: the admin must now choose a
+          disposition (transfer / delete) per KB the user solely owns. */}
+      {confirmingOffboardId !== null && currentUserId && (() => {
+        const target = users.find((u) => u.zitadel_user_id === confirmingOffboardId)
+        if (!target) return null
+        const label = `${target.first_name} ${target.last_name}`.trim() || target.email
+        return (
+          <OffboardWizard
+            userId={confirmingOffboardId}
+            userLabel={label}
+            currentAdminId={currentUserId}
+            open={confirmingOffboardId !== null}
+            onOpenChange={(open) => { if (!open) setConfirmingOffboardId(null) }}
+          />
+        )
+      })()}
 
       {/* R6: confirm leave workspace dialog (C6.6) */}
       <AlertDialog

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/settings.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/settings.tsx
@@ -43,6 +43,13 @@ function SettingsTab() {
   const isOwnerRole = !!(myUserId && members?.users.some((u) => u.user_id === myUserId && u.role === 'owner'))
   const isAdmin = currentUser?.isAdmin === true
   const isOwner = isCreator || isOwnerRole || isAdmin
+  // SPEC-PORTAL-KB-OWNERSHIP-001 REQ-1.1 — admins who are NOT the creator
+  // get the typed-confirmation override pad. Owners + creators continue to
+  // use the existing slug-typed UX.
+  const isAdminOverride = isAdmin && !isCreator && !isOwnerRole
+  const creatorMember = members?.users.find((u) => u.user_id === kb?.created_by)
+  const creatorDisplayName =
+    creatorMember?.display_name ?? creatorMember?.email ?? kb?.created_by ?? null
 
   const [deleteModalOpen, setDeleteModalOpen] = useState(false)
 
@@ -206,6 +213,8 @@ function SettingsTab() {
             connectorCount={stats?.connector_count ?? 0}
             hasGitea={!!kb.gitea_repo_slug}
             hasDocs={kb.docs_enabled}
+            mode={isAdminOverride ? 'admin-override' : 'self'}
+            creatorName={creatorDisplayName}
           />
         </div>
       )}


### PR DESCRIPTION
## Summary

Implements [SPEC-PORTAL-KB-OWNERSHIP-001](.moai/specs/SPEC-PORTAL-KB-OWNERSHIP-001/spec.md) end-to-end — three connected improvements around KB ownership.

### What changed (per phase commit)

| Phase | Scope | Commit |
|---|---|---|
| 1 | Personal-KB firewall (helper + dependency + invariant test) | `0a86ba85` |
| 2 | Admin-delete with `X-Admin-Override-Confirm` header | `7f51bdd9` |
| 3 | Offboarding wizard backend (preview + dispositions + token revoke) | `bed70c94` |
| 4 | Frontend (admin-override modal + offboard wizard) | `956d0948` |

### REQ coverage

- **REQ-1.x** (admin-delete): `X-Admin-Override-Confirm: I-WAS-NOT-CREATOR` header on `DELETE /api/app/knowledge-bases/{kb_slug}`. Owner pad unchanged. Audit + structlog event `kb.admin_deleted`.
- **REQ-2.x** (offboarding): `GET /api/admin/users/{id}/offboard-preview` + `POST /api/admin/users/{id}/offboard` with `kb_dispositions` body. Org KB transfer / delete; personal KB always immediate-purge (D2). Auto-revoke API keys + MCP tokens (REQ-2.7). Failure rolls back the entire offboard tx.
- **REQ-3.x** (firewall): `is_personal_kb` helper (single source of truth) + `get_kb_with_access` route-level FastAPI dependency on every `/api/app/knowledge-bases/{kb_slug}/...` route. Personal-KB-of-other-user → 404 (NOT 403, never leak existence). Static introspection test `tests/test_kb_personal_firewall.py` enforces this on every PR.
- **REQ-4.x** (audit): `kb.admin_deleted`, `kb.transferred`, `kb.personal_purged_on_offboard` audit events + structlog mirrors for VictoriaLogs.

### Owner decisions baked in (industry research backed)

- **D1** Default transfer-receiver = the offboarding admin (Google Workspace 'direct manager' pattern).
- **D2** Personal-KB delete on offboard = immediate (no grace period). Klai's `suspend_user` remains the non-destructive route.
- **D3** No restore-on-rehire pad. `suspend` covers the regret case.
- **D4** Override mechanism = HTTP header (RFC-canonical for DELETE).
- **D5** API keys + MCP tokens auto-revoked at offboard (industry research: 91% of offboarded-user tokens stay active without auto-revoke).

### Tests

- **Backend**: 2631/2631 pass. New: `test_kb_personal_firewall.py` (9), `test_kb_admin_delete_override.py` (7), `test_kb_offboarding_service.py` (14), `test_admin_offboard_endpoint.py` (5). Existing `test_user_lifecycle.py` offboard tests refactored.
- **Frontend**: 222/222 pass. `tsc -b --force` + `npm run lint` clean.
- **Quality gate**: ruff check + ruff format --check + pyright on changed files all clean.

### Schema impact

None — bestaande `portal_knowledge_bases` model is voldoende (eigenaars-bevestigd D2: geen `status` of `purge_after` kolommen nodig).

### Audit guard updates

- `tests/test_rls_callsite_audit.py` ALLOWED_HELPER_FUNCTIONS: `get_kb_with_access`, `resolve_personal_kb`, `resolve_org_kb`, `compute_offboard_preview`, `apply_dispositions`, `revoke_user_credentials`, `_load_kb_or_404`, `_do_transfer`, `_do_delete`.
- `tests/test_rls_audit.py` _ALLOWLIST: `app/services/kb_offboarding.py`.
- Both have one-line justifications inline.

### Confidence — 92

Evidence:
- Backend test suite: 2631 pass.
- Frontend test suite: 222 pass.
- Lint + format + type-check: all green.
- Static-analysis invariants for the firewall and RLS audit pass.
- Mocked-but-faithful coverage of: admin-override happy/sad paths, offboard preview shape, missing-disposition error contract, transfer rejection on personal KBs, transfer-receiver validation, docs-failure rollback semantics, token-revoke wiring.

What I haven't done (deliberately):
- Live E2E against a deployed tenant. Worth a Playwright run against staging before merging.
- Migration / backfill (none needed per the SPEC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)