### PR TITLE
chore(portal): SPEC-PORTAL-PRICING-PER-USER-001 follow-up cleanup

### DIFF
--- a/klai-portal/backend/alembic/versions/a140bdc4290a_billing_per_seat_enabled_flag.py
+++ b/klai-portal/backend/alembic/versions/a140bdc4290a_billing_per_seat_enabled_flag.py
@@ -8,10 +8,19 @@ The flag is FALSE for every existing tenant at upgrade time. Phase 5b
 flag — until then, a tenant admin clicking the FE "switch to per-user
 billing" CTA hits a 501 stub that explains the staged rollout.
 
-ADD COLUMN with NOT NULL DEFAULT is instant metadata in PG 11+ — same
-RLS-safe shape as Phase 1's seat_type addition. portal_orgs is also
-FORCE RLS Cat-A, so this matters: no row-write happens, no WITH CHECK
-fires.
+ADD COLUMN with NOT NULL DEFAULT is instant metadata in PG 11+ —
+no row-rewrite happens, the alembic transaction commits in
+milliseconds.
+
+RLS note: ``portal_orgs`` has **no** RLS enabled at all (verified on
+prod 2026-05-13: ``relrowsecurity=false``, ``relforcerowsecurity=
+false``, ``owner=portal_api``). The earlier draft of this docstring
+claimed it was Cat-A like ``portal_users`` — that was wrong. The
+migration would have been safe either way (DDL doesn't fire WITH
+CHECK), but the docstring is now accurate. Phase 5b's eventual
+UPDATE on ``portal_orgs.billing_per_seat_enabled`` won't hit the
+WITH-CHECK trap that bit Phase 1's portal_users backfill — there
+is no policy to fire.
 
 Revision ID: a140bdc4290a
 Revises: 924465b9e0a6

--- a/klai-portal/backend/app/api/admin/billing.py
+++ b/klai-portal/backend/app/api/admin/billing.py
@@ -200,8 +200,13 @@ async def switch_to_per_seat_billing(
     The endpoint exists in Phase 5 light so the FE CTA can hit a real
     URL and surface a deterministic error rather than a 404 — admins
     see "coming soon, no billing change" instead of a broken-link page.
+
+    ``perms`` and ``db`` are taken even though the body never reads
+    them: FastAPI evaluates the ``Depends(get_caller_at_least(ADMIN))``
+    chain on every request, which is exactly the auth gate we want
+    the 501 to sit behind. A non-admin caller gets 403 from the
+    dependency, not 501 from this stub.
     """
-    _ = (perms, db)  # binds the auth + db dependencies; body is a stub
     raise HTTPException(
         status_code=status.HTTP_501_NOT_IMPLEMENTED,
         detail={

--- a/klai-portal/backend/tests/test_permissions.py
+++ b/klai-portal/backend/tests/test_permissions.py
@@ -63,6 +63,14 @@ def _row(
     default for the chosen role (``suggest_seat`` semantics) so existing
     tests that pre-date the seat axis produce intuitive results without
     extra kwargs.
+
+    ``plan`` is still meaningful post-Phase-4: it still drives
+    ``derive_user_products(role, plan, platform_features)`` (which
+    products surface in the FE sidebar) and ``effective_kb_limits(role,
+    plan)`` (the per-user KB quota). Only the capability-intersection
+    axis moved to ``seat_type``. Phase 5b / a follow-up SPEC will
+    finish the plan -> seat sweep across products + kb-quota; until
+    then this kwarg is a real input, not a stale relic.
     """
     from app.core.seats import suggest_seat
 


### PR DESCRIPTION
Three post-merge nits from the self-review of #614. No behaviour change.

| # | Fix |
|---|---|
| 1 | `switch_to_per_seat_billing`: dropped the `_ = (perms, db)` noise line. FastAPI evaluates the `Depends(...)` chain on parameter binding so the auth gate works without the body touching them. Added docstring note. |
| 2 | `test_permissions.py::_row(plan=...)`: clarified in the docstring that `plan` is still meaningful post-Phase-4 — it drives `derive_user_products` + `effective_kb_limits`, only the capability-axis moved to `seat_type`. Kwarg stays. |
| 3 | Migration `a140bdc4290a` docstring: corrected the RLS claim about `portal_orgs`. Verified on prod 2026-05-13: `relrowsecurity=false`, `relforcerowsecurity=false`, `owner=portal_api`. `portal_orgs` has no RLS at all. The migration's correctness was unaffected (DDL doesn't fire WITH CHECK either way) but the docstring now matches reality. |

## Verification

```
pytest:   2585 passed (unchanged)
ruff:     clean
pyright:  0 errors
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)