### PR TITLE
chore(portal-frontend): fix floating promise in billing.lazy.tsx (unblock deploy)

### DIFF
--- a/klai-portal/frontend/src/routes/admin/billing.lazy.tsx
+++ b/klai-portal/frontend/src/routes/admin/billing.lazy.tsx
@@ -180,7 +180,7 @@ function SeatBreakdownPanel() {
     // per-seat-billing opt-in status. Failing the status fetch falls
     // back to "Phase 5 light not available" semantics — the breakdown
     // stays visible and the CTA banner shows the coming-soon copy.
-    Promise.allSettled([
+    void Promise.allSettled([
       apiFetch<SeatBreakdownResponse>(`/api/admin/billing/breakdown`),
       apiFetch<PerSeatStatusResponse>(`/api/admin/billing/per-seat-status`),
     ])


### PR DESCRIPTION
PR #614 introduced an unawaited Promise.allSettled chain in billing.lazy.tsx#183, tripping `@typescript-eslint/no-floating-promises` and breaking CI deploy on main. This 1-line fix prefixes the chain with `void` to mark the fire-and-forget intent explicit (the `.finally(() => setLoading(false))` is the cleanup the page actually relies on).

No behavior change.

Surfaced while landing #613 — that deploy is also blocked until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)