### PR TITLE
chore(portal-frontend): SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 followups — F-C2 hoist, ESLint rule, billing logger, retro

### DIFF
--- a/.claude/rules/klai/pitfalls/process-rules.md
+++ b/.claude/rules/klai/pitfalls/process-rules.md
@@ -2121,3 +2121,70 @@ check entirely.
    identity paths.
 
 Reference: SPEC-SEC-IDENTITY-ASSERT-002 + ops timeline 2026-05-08.
+
+## previous-deploy-failure-blocks-yours (HIGH)
+A failed `Build and deploy portal-frontend` (or any other deploy
+workflow) on `main` does not surface as a global blocker. The
+GitHub Actions UI shows "1 failed" on a single run, but the next
+contributor's push still triggers the same workflow against the
+same broken main. Their deploy fails for the SAME pre-existing
+reason — and they get blamed for "their" deploy failure when in
+fact it was inherited from the previous merge.
+
+Reference: 2026-05-13 — PR #614 (SPEC-PORTAL-PRICING-PER-USER-001
+Phase 5+6, merged 22:42 CEST) shipped a `Promise.allSettled(...)`
+chain in `klai-portal/frontend/src/routes/admin/billing.lazy.tsx`
+without a `void` prefix or `.catch()`, tripping
+`@typescript-eslint/no-floating-promises`. The deploy CI for #614
+failed silently. ~5 hours later, PR #613
+(SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001) was admin-merged with a
+green PR-CI; its deploy CI inherited the broken main and failed on
+the SAME billing.lazy.tsx error. Felt like #613 had introduced the
+break — actually #614 had, and the failure had been invisible
+because nobody runs `gh run list --branch main` between merges.
+
+**Why this slips through:**
+
+1. PR-level CI ran against the rebased PR branch + main, both green.
+   Deploy CI runs ONLY after merge, against post-merge main.
+2. A failed deploy CI shows up as one red run in the actions list,
+   but does NOT mark main as "do not push." There's no equivalent
+   of branch protection for "main is currently broken in CI."
+3. Slack alerts (if any) for deploy-failures often go to a separate
+   channel that the next dev doesn't watch.
+
+**Prevention (ordered by mechanical strength):**
+
+1. **Pre-push gate**: a Husky / `pre-push` hook in klai-portal that
+   runs `gh run list --branch main --workflow "Build and deploy
+   portal-frontend" --limit 1 --json conclusion -q '.[0].conclusion'`
+   and refuses to push if the result is `failure`. The dev sees
+   immediately: "main's last deploy is red — fix that first."
+
+2. **Status alert in Slack/email** when a deploy CI on main
+   transitions to red. Subscribes the team broadly, not the
+   merger only. Equivalent to the alerter-on-alerter pattern from
+   SPEC-OBS-001.
+
+3. **Mechanical fix in the workflow itself**: the
+   `Build and deploy portal-frontend` workflow could fail loudly
+   in a separate `pre-build-precheck` job that runs `gh run list
+   --workflow "..." --status failure --branch main --limit 1` and
+   refuses to start the build until the previous failure is
+   resolved (auto-cancel). Heavier; only worth it if option 1
+   isn't enforced.
+
+4. **Manual playbook**: when admin-merging a PR, ALWAYS check
+   `gh run list --branch main --limit 5` first. If the previous
+   deploy is red → fix that first, then merge yours.
+
+5. **The hotfix pattern**: the right response when you discover
+   you've inherited a broken main is to land the SMALLEST
+   possible fix as a separate hotfix PR (NOT mix it into your
+   PR's commit history). #617 (the one-line `void` prefix) is
+   the canonical example.
+
+**Audit (2026-05-13):** No mechanical pre-push gate exists today.
+Manual playbook is the current state. Option 1 (Husky pre-push
+hook) is the cheapest mechanical guard and would have caught
+this incident before either dev pushed.

--- a/.moai/specs/SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001/progress.md
+++ b/.moai/specs/SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001/progress.md
@@ -1,0 +1,65 @@
+# SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 — Progress
+
+## Status: done (2026-05-13)
+
+## Phases shipped
+
+| Phase | Commit | Description |
+|---|---|---|
+| 1 | `5b514e9b` (in PR #613) | Preflight: rule on portal-frontend.md + SPEC v0.2.0 |
+| 2 | `6c60a048` | Eliminate triplicate symbols vs `$kbSlug/-kb-*` |
+| 3 | `fef50b58` | Extract wizard-only types to `-connector-types.ts` |
+| 4 | `c4bf13cb` | Extract wizard-only constants to `-connector-constants.ts` |
+| 5 | `aa0ca9fe` | Extract feedback components, kill cross-route import |
+
+PR #613 admin-merged 2026-05-13 02:36 CEST → commit `9c1b4d77` on main.
+Deploy CI #25774863654 green at 02:39 CEST (after PR #617 hotfix unblocked
+the inherited billing.lazy.tsx lint failure from PR #614).
+
+Live verification on `voys.getklai.com`:
+- AuthProbeFeedback panel rendered correctly on add-connector wizard
+  (classification `auth_failed_still_walled`)
+- AuthProbeFeedback panel rendered correctly on edit-connector wizard
+  (classification `auth_failed_unreachable`)
+- Edit-connector page loaded clean — pre-fill `useEffect` populated form
+  values, zero console errors across full flow
+- Cross-route import dead — verified by `git grep`
+- Screenshots saved: `add-connector-auth-probe-panel.png`,
+  `edit-connector-auth-probe-panel.png`
+
+## Follow-up cleanups landed in this branch
+
+After v0.2.0 shipped, a self-review identified loose ends. The
+2026-05-13 followups branch addressed them:
+
+| # | Commit | Item |
+|---|---|---|
+| 1 | `c623ffd3` | F-C2 partial: hoist `GitHubConfig` + `WebCrawlerConfig` from `$kbSlug/-kb-types.ts` to `-connector-types.ts` |
+| 2 | `edc81f81` | F-C2 cont.: hoist `ASSERTION_MODE_OPTIONS` + `joinSeedUrl` from `$kbSlug/-kb-helpers.tsx` to `-connector-constants.ts`. Removed dead `roleBadge` (no consumer found). Renamed test file. |
+| 3 | `d6818af0` | F-S3: new ESLint rule `klai/no-cross-route-import` + 13 unit tests. Extract `KBOverviewSections` to `_components/` to satisfy the rule. `TaxonomyTab` import in `insights.tsx` marked with explicit deferred-fix marker (eslint-disable-next-line + TODO referencing F-table row 1). |
+| 4 | `41ee1a3f` | Item 5 from self-review: add `adminLogger.error` / `adminLogger.warn` calls to billing breakdown fetch. Restores Sentry diagnostic trail that the void-prefix hotfix had not added. |
+| 5 | `<this commit>` | Item 7 from self-review: retro entry `previous-deploy-failure-blocks-yours` added to `process-rules.md`. SPEC sync: status flipped to `done`, this progress.md added. |
+
+## Outstanding follow-ups (per § Follow-ups)
+
+These remain explicitly out of this SPEC's scope:
+
+- **F-1**: `useConnectorWizardState` hook extraction (real win, real risk)
+- **F-2**: Page god-component split (depends on F-1)
+- **F-table row 1**: `TaxonomyTab` god-component split (1 cross-route
+  import marked with `eslint-disable-next-line` references this work)
+- **F-table other rows**: 7 more god-component candidates documented
+  in spec.md § Follow-ups
+
+## Final state
+
+- 12 source/test files modified
+- 4 new files created (`-connector-types.ts`, `-connector-constants.ts`,
+  `-connector-feedback.tsx`, `_components/KBOverviewSections.tsx`)
+- 2 new docs files (`portal-frontend.md` rule section,
+  `process-rules.md` retro entry)
+- 1 new ESLint rule + 1 unit test file (13 cases)
+- 1 file renamed (`kb-helpers.test.ts` → `connector-helpers.test.ts`)
+- 0 SPEC requirements unmet
+- 0 outstanding lint errors
+- 0 console errors in live Voys verification

--- a/.moai/specs/SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001/spec.md
+++ b/.moai/specs/SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001/spec.md
@@ -1,7 +1,8 @@
 ---
 id: SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001
-version: 0.2.0
-status: ready
+version: 0.2.1
+status: done
+completed: 2026-05-13
 created: 2026-05-12
 author: Mark Vletter
 priority: medium

--- a/klai-portal/frontend/eslint-rules/__tests__/no-cross-route-import.test.js
+++ b/klai-portal/frontend/eslint-rules/__tests__/no-cross-route-import.test.js
@@ -1,0 +1,110 @@
+/**
+ * Tests for `klai/no-cross-route-import`.
+ *
+ * RuleTester from `eslint` registers its own describe/it blocks against
+ * vitest's globals and MUST be called at module top-level.
+ */
+import { RuleTester } from 'eslint'
+import rule from '../no-cross-route-import.js'
+
+const ruleTester = new RuleTester({
+  languageOptions: { ecmaVersion: 2022, sourceType: 'module' },
+})
+
+ruleTester.run('klai/no-cross-route-import', rule, {
+  valid: [
+    // Dash-prefixed sibling — the canonical helper pattern.
+    {
+      filename: '/repo/src/routes/app/knowledge/$kbSlug_.add-connector.tsx',
+      code: `import { AuthProbeFeedback } from './-connector-feedback'`,
+    },
+    // Dash-prefixed file in a sibling directory — cross-directory but to a helper.
+    {
+      filename: '/repo/src/routes/app/knowledge/$kbSlug_.add-connector.tsx',
+      code: `import { CookieRow } from './$kbSlug/-kb-types'`,
+    },
+    // Colocation: <route>._<types> sibling file (TanStack ignores).
+    {
+      filename: '/repo/src/routes/app/knowledge/new.tsx',
+      code: `import { WizardData } from './new._types'`,
+    },
+    // Colocation: <route>._components/ directory.
+    {
+      filename: '/repo/src/routes/app/knowledge/$kbSlug_.add-source.tsx',
+      code: `import { SourceTypeGrid } from './$kbSlug_.add-source._components/SourceTypeGrid'`,
+    },
+    // Absolute alias — never a relative cross-route concern.
+    {
+      filename: '/repo/src/routes/app/knowledge/$kbSlug/sources.tsx',
+      code: `import { apiFetch } from '@/lib/apiFetch'`,
+    },
+    // Helper file ITSELF (importer is dash-prefixed): rule does not run.
+    {
+      filename: '/repo/src/routes/app/knowledge/$kbSlug/-kb-helpers.tsx',
+      code: `import { Foo } from './sources'`,
+    },
+    // _components colocated file importing from sibling: rule does not run on importer.
+    {
+      filename: '/repo/src/routes/app/knowledge/$kbSlug_.add-source._components/Foo.tsx',
+      code: `import { Bar } from './Bar'`,
+    },
+    // File outside src/routes/: rule does not run.
+    {
+      filename: '/repo/src/components/ui/Foo.tsx',
+      code: `import { Bar } from './Bar'`,
+    },
+    // routeTree.gen is the codegen consumer — explicitly allowed.
+    {
+      filename: '/repo/src/routes/app/knowledge/$kbSlug/sources.tsx',
+      code: `import { Route } from './routeTree.gen'`,
+    },
+  ],
+  invalid: [
+    // The exact smell SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 eliminated.
+    {
+      filename: '/repo/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx',
+      code: `import { AuthProbeFeedback } from './$kbSlug_.add-connector'`,
+      errors: [
+        {
+          messageId: 'crossRoute',
+          data: {
+            from: '$kbSlug_.edit-connector.$connectorId.tsx',
+            to: './$kbSlug_.add-connector',
+          },
+        },
+      ],
+    },
+    // F-S1 in the SPEC's follow-ups — insights.tsx imports two sibling routes.
+    {
+      filename: '/repo/src/routes/app/knowledge/$kbSlug/insights.tsx',
+      code: `import { TaxonomyTab } from './taxonomy'`,
+      errors: [
+        {
+          messageId: 'crossRoute',
+          data: { from: 'insights.tsx', to: './taxonomy' },
+        },
+      ],
+    },
+    {
+      filename: '/repo/src/routes/app/knowledge/$kbSlug/insights.tsx',
+      code: `import { KBOverviewSections } from './overview'`,
+      errors: [
+        {
+          messageId: 'crossRoute',
+          data: { from: 'insights.tsx', to: './overview' },
+        },
+      ],
+    },
+    // Up-and-over cross-route: parent dir's sibling.
+    {
+      filename: '/repo/src/routes/app/knowledge/$kbSlug/sources.tsx',
+      code: `import { Foo } from '../new'`,
+      errors: [
+        {
+          messageId: 'crossRoute',
+          data: { from: 'sources.tsx', to: '../new' },
+        },
+      ],
+    },
+  ],
+})

--- a/klai-portal/frontend/eslint-rules/no-cross-route-import.js
+++ b/klai-portal/frontend/eslint-rules/no-cross-route-import.js
@@ -1,0 +1,109 @@
+/**
+ * @fileoverview Forbid one route file from importing directly from another
+ * route file. Routes must communicate through `-`-prefixed sibling files
+ * or `_components/`-style co-located directories at the smallest-shared
+ * scope. Documented in portal-frontend.md § "File organization for shared
+ * types and helpers".
+ *
+ * Background: SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 eliminated a
+ * cross-route import (`edit-connector` → `add-connector`) plus two test
+ * files importing from a route file. Without enforcement, the next
+ * contributor can re-introduce the smell silently. This rule prevents that.
+ *
+ * Heuristic for "is this a route import?":
+ *   - The IMPORTING file lives under `src/routes/` AND its basename does
+ *     NOT start with `-` or `_` AND does NOT contain `._` (i.e., the
+ *     importer is itself a route, not a colocated helper).
+ *   - The IMPORT SOURCE is a relative path (`.` or `..`) AND none of its
+ *     path segments start with `-` or `_` and none contain `._` (i.e.,
+ *     the target is also a route, not a `-`helper or `_components/`
+ *     directory or `<route>._<something>` colocation).
+ *
+ * Allowed:
+ *   - `from './-connector-feedback'`     (dash-prefixed sibling)
+ *   - `from './$kbSlug/-kb-types'`       (dash-prefixed file in subdir)
+ *   - `from './new._types'`              (.<route>._<something> colocation)
+ *   - `from './add-source._components/Foo'` (._components/ colocation)
+ *   - `from '@/lib/foo'`                 (absolute alias, never matches)
+ *
+ * Forbidden:
+ *   - `from './taxonomy'` from insights.tsx
+ *   - `from './$kbSlug_.add-connector'` from edit-connector
+ *   - `from '../sibling-route'`
+ */
+
+function isColocationOrHelperSegment(segment) {
+  if (!segment) return false
+  if (segment.startsWith('-')) return true
+  if (segment.startsWith('_')) return true
+  // <route>._<feature> or <route>._components style — TanStack co-location
+  if (segment.includes('._')) return true
+  return false
+}
+
+function isAllowedTarget(importSource) {
+  // We only fire on relative imports.
+  if (!importSource.startsWith('.')) return true
+  const segments = importSource.split('/')
+  for (const seg of segments) {
+    if (isColocationOrHelperSegment(seg)) return true
+  }
+  if (importSource.includes('/__tests__/')) return true
+  if (segments[segments.length - 1] === 'routeTree.gen') return true
+  return false
+}
+
+function isRouteFile(filename) {
+  if (!filename) return false
+  const normalized = filename.replace(/\\/g, '/')
+  const routesIdx = normalized.indexOf('/src/routes/')
+  if (routesIdx < 0) return false
+  // Walk all path segments inside src/routes/. If ANY of them is a
+  // colocation/helper marker, the file is not a route — it lives in
+  // a `-`-helper file, a `_components/` directory, or a `<route>._<x>`
+  // co-located file/directory.
+  const after = normalized.slice(routesIdx + '/src/routes/'.length)
+  const segments = after.split('/')
+  if (segments.length === 0) return false
+  const fileBasename = segments[segments.length - 1].replace(/\.(tsx?|jsx?)$/, '')
+  if (isColocationOrHelperSegment(fileBasename)) return false
+  for (let i = 0; i < segments.length - 1; i++) {
+    if (isColocationOrHelperSegment(segments[i])) return false
+  }
+  return true
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow cross-route imports inside src/routes/. Routes must communicate via -prefixed sibling files or _components/ directories at the smallest-shared scope.',
+    },
+    schema: [],
+    messages: {
+      crossRoute:
+        "Cross-route import: route '{{from}}' must not import directly from another route ('{{to}}'). Extract the shared symbol to a -prefixed sibling file or _components/ directory at the smallest-shared scope. See portal-frontend.md § 'File organization for shared types and helpers'.",
+    },
+  },
+  create(context) {
+    const filename = context.filename ?? context.getFilename?.() ?? ''
+    if (!isRouteFile(filename)) return {}
+
+    const fromShort = filename.slice(filename.lastIndexOf('/') + 1)
+
+    return {
+      ImportDeclaration(node) {
+        const source = node.source && node.source.value
+        if (typeof source !== 'string') return
+        if (isAllowedTarget(source)) return
+        context.report({
+          node,
+          messageId: 'crossRoute',
+          data: { from: fromShort, to: source },
+        })
+      },
+    }
+  },
+}

--- a/klai-portal/frontend/eslint.config.js
+++ b/klai-portal/frontend/eslint.config.js
@@ -5,6 +5,7 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 import noDirectKbQuerykey from './eslint-rules/no-direct-kb-querykey.js'
+import noCrossRouteImport from './eslint-rules/no-cross-route-import.js'
 
 export default defineConfig([
   globalIgnores([
@@ -21,6 +22,7 @@ export default defineConfig([
       klai: {
         rules: {
           'no-direct-kb-querykey': noDirectKbQuerykey,
+          'no-cross-route-import': noCrossRouteImport,
         },
       },
     },
@@ -41,6 +43,7 @@ export default defineConfig([
     rules: {
       'no-console': ['error', { allow: ['warn', 'error'] }],
       'klai/no-direct-kb-querykey': 'error',
+      'klai/no-cross-route-import': 'error',
       // TanStack Router uses async functions in route config (beforeLoad, loader)
       '@typescript-eslint/no-misused-promises': [
         'error',

--- a/klai-portal/frontend/src/routes/admin/billing.lazy.tsx
+++ b/klai-portal/frontend/src/routes/admin/billing.lazy.tsx
@@ -11,6 +11,7 @@ import * as m from '@/paraglide/messages'
 import { getLocale } from '@/paraglide/runtime'
 import { number } from '@/paraglide/registry'
 import { apiFetch } from '@/lib/apiFetch'
+import { adminLogger } from '@/lib/logger'
 
 export const Route = createLazyFileRoute('/admin/billing')({
   component: BillingPage,
@@ -188,11 +189,20 @@ function SeatBreakdownPanel() {
         if (breakdown.status === 'fulfilled') {
           setData(breakdown.value)
         } else {
+          // Per portal-logging-ts.md: log API errors to Sentry (level=error)
+          // alongside the user-facing setError. Without the logger call the
+          // server-side reason is invisible in production.
+          adminLogger.error('Billing breakdown fetch failed', { reason: breakdown.reason })
           setError(m.admin_billing_breakdown_error())
         }
         if (perSeat.status === 'fulfilled') {
           setStatus(perSeat.value)
         } else {
+          // Soft fallback — UI degrades to "Phase 5 light not available".
+          // Use warn (not error) since we have a defined fallback path.
+          adminLogger.warn('Per-seat status fetch failed; falling back to disabled', {
+            reason: perSeat.reason,
+          })
           setStatus({ enabled: false, available: false })
         }
       })

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-kb-helpers.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-kb-helpers.tsx
@@ -1,8 +1,9 @@
-// Shared helpers for knowledge base detail routes
+// Shared helpers for knowledge base detail routes (KB tabs).
+// Connector-wizard-only helpers live in
+// `klai-portal/frontend/src/routes/app/knowledge/-connector-constants.ts`.
 
 import { Badge } from '@/components/ui/badge'
 import { Tooltip } from '@/components/ui/tooltip'
-import { type MultiSelectOption } from '@/components/ui/multi-select'
 import * as m from '@/paraglide/messages'
 
 function formatRelativeTime(dateStr: string): string {
@@ -14,15 +15,6 @@ function formatRelativeTime(dateStr: string): string {
   if (Math.abs(diffMin) < 60) return rtf.format(diffMin, 'minute')
   if (Math.abs(diffHour) < 24) return rtf.format(diffHour, 'hour')
   return rtf.format(diffDay, 'day')
-}
-
-export function roleBadge(role: string) {
-  const labels: Record<string, () => string> = {
-    viewer: m.knowledge_members_role_viewer,
-    contributor: m.knowledge_members_role_contributor,
-    owner: m.knowledge_members_role_owner,
-  }
-  return <Badge variant="secondary">{(labels[role] ?? (() => role))()}</Badge>
 }
 
 export function SyncStatusBadge({
@@ -110,33 +102,13 @@ export function DashboardSection({
   )
 }
 
-export const ASSERTION_MODE_OPTIONS: MultiSelectOption[] = [
-  { value: 'factual',    label: 'Fact',        description: 'Established fact, documentation, specs' },
-  { value: 'procedural', label: 'Procedure',   description: "Step-by-step instructions, how-to's" },
-  { value: 'belief',     label: 'Claim',       description: 'Not conclusively proven claim' },
-  { value: 'quoted',     label: 'Quote',       description: 'Literal source material' },
-  { value: 'hypothesis', label: 'Speculation', description: 'Hypotheses, brainstorm' },
-  { value: 'unknown',    label: 'Unknown',     description: 'Type not specified' },
-]
-
-/**
- * SPEC-CONNECTOR-INPUT-VALIDATION-001 hotfix — slash-safe URL build.
- *
- * Combines ``base_url`` and ``path_prefix`` without producing the ``//``
- * artifact that crawl4ai handles inconsistently (`https://x.com/` + `/nl/`
- * = `https://x.com//nl/`). Trims trailing slash off base, leading slash
- * off path, then joins with single `/` if path is non-empty.
- *
- * Used by both add-connector and edit-connector wizard auth-probe call sites.
- */
-export function joinSeedUrl(baseUrl: string, pathPrefix: string): string {
-  const base = baseUrl.replace(/\/+$/, '')
-  const path = (pathPrefix || '').replace(/^\/+/, '').replace(/\/+$/, '')
-  if (!path) return base + '/'
-  return `${base}/${path}/`
-}
-
-// parseCookieString was removed: the wizard now collects cookies as
-// structured {name, value} rows via CookieRowsInput, matching the shape
+// `ASSERTION_MODE_OPTIONS` and `joinSeedUrl` were moved to
+// `klai-portal/frontend/src/routes/app/knowledge/-connector-constants.ts`
+// — wizard-only, smallest-shared scope is the parent route dir.
+//
+// `roleBadge` was removed (dead code — no consumers).
+//
+// `parseCookieString` was removed earlier: the wizard now collects cookies
+// as structured {name, value} rows via CookieRowsInput, matching the shape
 // the backend persists and the cron-sync consumes. No parser layer means
 // no chance of cookie-name guessing. See components/knowledge/CookieRowsInput.tsx.

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-kb-types.ts
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-kb-types.ts
@@ -137,20 +137,10 @@ export interface TopTagsResponse {
   total_chunks_sampled: number
 }
 
-export interface GitHubConfig {
-  installation_id: string
-  repo_owner: string
-  repo_name: string
-  branch: string
-  path_filter: string
-}
-
-export interface WebCrawlerConfig {
-  base_url: string
-  path_prefix: string
-  max_pages: string
-  content_selector: string
-}
+// `GitHubConfig` and `WebCrawlerConfig` were moved to
+// `klai-portal/frontend/src/routes/app/knowledge/-connector-types.ts`
+// — wizard-only types, smallest-shared scope is the parent route dir.
+// See portal-frontend.md § "File organization for shared types and helpers".
 
 /**
  * Single authentication cookie input row.

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/KBOverviewSections.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/KBOverviewSections.tsx
@@ -1,0 +1,172 @@
+import { Link } from '@tanstack/react-router'
+import { useAuth } from '@/lib/auth'
+import { useQuery } from '@tanstack/react-query'
+import {
+  BookOpen, FileText, BarChart2, AlertTriangle, Database, Search, GitBranch,
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import * as m from '@/paraglide/messages'
+import { apiFetch } from '@/lib/apiFetch'
+import { useCurrentUser } from '@/hooks/useCurrentUser'
+import { DashboardSection } from '../-kb-helpers'
+import type { KnowledgeBase, KBStats } from '../-kb-types'
+import { kbQueryKeys } from '@/lib/kb-query-keys'
+
+/**
+ * Reusable Docs + Statistieken sections — embedded into the Inzichten tab.
+ *
+ * Was the body of the standalone /overview route before consolidation. Now
+ * lives in `_components/` (TanStack ignores the directory, no route impact)
+ * so `insights.tsx` can consume it without violating the
+ * `klai/no-cross-route-import` ESLint rule.
+ */
+export function KBOverviewSections({ kbSlug }: { kbSlug: string }) {
+  const auth = useAuth()
+  const { user } = useCurrentUser()
+
+  // These queries reuse the same queryKeys as the parent layout -- TanStack Query
+  // serves cached data without re-fetching.
+  const { data: kb } = useQuery<KnowledgeBase>({
+    queryKey: kbQueryKeys.knowledgeBase(kbSlug),
+    queryFn: async () => apiFetch<KnowledgeBase>(`/api/app/knowledge-bases/${kbSlug}`),
+    enabled: auth.isAuthenticated,
+  })
+
+  const { data: stats } = useQuery<KBStats>({
+    queryKey: ['kb-stats', kbSlug],
+    queryFn: async () => apiFetch<KBStats>(`/api/app/knowledge-bases/${kbSlug}/stats`),
+    enabled: auth.isAuthenticated && !!kb,
+  })
+
+  if (!kb) return null
+
+  const docsLabel =
+    stats?.docs_count == null
+      ? m.knowledge_detail_docs_none()
+      : stats.docs_count === 1
+        ? m.knowledge_detail_docs_count_one()
+        : m.knowledge_detail_docs_count({ count: String(stats.docs_count) })
+
+  return (
+    <div className="space-y-8">
+      <DashboardSection icon={BookOpen} title={m.knowledge_detail_section_docs()}>
+        {!kb.docs_enabled ? (
+          <p className="text-sm text-gray-400">{m.knowledge_detail_docs_not_enabled()}</p>
+        ) : (
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <FileText className="h-4 w-4 text-gray-400" />
+              <span className="text-sm text-gray-900">{docsLabel}</span>
+            </div>
+            {kb.gitea_repo_slug && (
+              <Link to="/app/docs/$kbSlug" params={{ kbSlug: kb.slug }} >
+                <Button variant="outline" size="sm">{m.knowledge_detail_view_in_docs()}</Button>
+              </Link>
+            )}
+          </div>
+        )}
+      </DashboardSection>
+
+      <DashboardSection icon={BarChart2} title={m.knowledge_detail_section_stats()}>
+        <div className="flex gap-8 mb-5">
+          <div>
+            <p className="text-xs text-gray-400 tracking-wide mb-1">{m.knowledge_detail_stats_search_index()}</p>
+            <p className="text-sm font-medium text-gray-900">
+              {stats?.volume != null
+                ? m.knowledge_detail_volume({ count: String(stats.volume) })
+                : m.knowledge_detail_volume_unknown()}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-gray-400 tracking-wide mb-1">{m.knowledge_detail_stats_queries()}</p>
+            <p className="text-sm font-medium text-gray-900">
+              {stats?.usage_last_30d != null
+                ? String(stats.usage_last_30d)
+                : m.knowledge_detail_usage_unknown()}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-gray-400 tracking-wide mb-1">{m.knowledge_detail_stats_users()}</p>
+            <p className="text-sm font-medium text-gray-900">
+              {stats?.unique_users_30d != null
+                ? String(stats.unique_users_30d)
+                : m.knowledge_detail_usage_unknown()}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-gray-400 tracking-wide mb-1">{m.knowledge_detail_stats_active_days()}</p>
+            <p className="text-sm font-medium text-gray-900">
+              {stats?.active_days_30d != null
+                ? m.knowledge_detail_active_days_value({ count: String(stats.active_days_30d) })
+                : m.knowledge_detail_usage_unknown()}
+            </p>
+          </div>
+          {user?.isAdmin === true && stats?.org_gap_count_7d != null && (
+            <Link to="/app/gaps" className="group">
+              <div>
+                <p className="text-xs text-gray-400 tracking-wide mb-1 flex items-center gap-1">
+                  <AlertTriangle className="h-3 w-3" />
+                  {m.gaps_overview_tile()}
+                </p>
+                <p className="text-sm font-medium text-gray-900 group-hover:text-gray-900 transition-colors">
+                  {stats.org_gap_count_7d}
+                </p>
+              </div>
+            </Link>
+          )}
+        </div>
+
+        {/* Breakdown per database */}
+        <div>
+          <p className="text-xs text-gray-400 tracking-wide mb-2">
+            {m.knowledge_detail_volume_breakdown_title()}
+          </p>
+          <div className="grid grid-cols-3 gap-3">
+            <div className="flex items-start gap-2 rounded-lg border border-gray-200 p-3">
+              <Database className="h-4 w-4 text-gray-400 mt-0.5 shrink-0" />
+              <div>
+                <p className="text-xs font-medium text-gray-900">
+                  {m.knowledge_detail_volume_sources()}
+                </p>
+                <p className="text-sm text-gray-900">
+                  {stats?.source_page_count != null
+                    ? m.knowledge_detail_volume_sources_count({ count: String(stats.source_page_count) })
+                    : m.knowledge_detail_volume_unavailable()}
+                </p>
+              </div>
+            </div>
+            <div className="flex items-start gap-2 rounded-lg border border-gray-200 p-3">
+              <Search className="h-4 w-4 text-gray-400 mt-0.5 shrink-0" />
+              <div>
+                <p className="text-xs font-medium text-gray-900">
+                  {m.knowledge_detail_volume_search_chunks()}
+                </p>
+                <p className="text-sm text-gray-900">
+                  {stats?.vector_chunk_count != null
+                    ? m.knowledge_detail_volume_search_chunks_count({ count: String(stats.vector_chunk_count) })
+                    : m.knowledge_detail_volume_unavailable()}
+                </p>
+              </div>
+            </div>
+            <div className="flex items-start gap-2 rounded-lg border border-gray-200 p-3">
+              <GitBranch className="h-4 w-4 text-gray-400 mt-0.5 shrink-0" />
+              <div>
+                <p className="text-xs font-medium text-gray-900">
+                  {m.knowledge_detail_volume_graph()}
+                </p>
+                <p className="text-sm text-gray-900">
+                  {stats?.graph_entity_count != null && stats?.graph_edge_count != null
+                    ? m.knowledge_detail_volume_graph_count({
+                        entities: String(stats.graph_entity_count),
+                        edges: String(stats.graph_edge_count),
+                      })
+                    : m.knowledge_detail_volume_unavailable()}
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </DashboardSection>
+    </div>
+  )
+}

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/insights.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/insights.tsx
@@ -1,7 +1,13 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { RoleGuard } from '@/components/layout/RoleGuard'
+// TODO: F-table row 1 of SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 § Follow-ups
+// will extract TaxonomyTab (currently a 720-line god-component inside
+// ./taxonomy.tsx) to _components/TaxonomyTab.tsx. Splitting that monolith
+// deserves its own SPEC. Until then, this single cross-route import is
+// the deferred-fix marker.
+// eslint-disable-next-line klai/no-cross-route-import
 import { TaxonomyTab } from './taxonomy'
-import { KBOverviewSections } from './overview'
+import { KBOverviewSections } from './_components/KBOverviewSections'
 
 export const Route = createFileRoute('/app/knowledge/$kbSlug/insights')({
   component: () => (

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/overview.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/overview.tsx
@@ -1,21 +1,9 @@
-import { createFileRoute, redirect, Link } from '@tanstack/react-router'
-import { useAuth } from '@/lib/auth'
-import { useQuery } from '@tanstack/react-query'
-import {
-  BookOpen, FileText, BarChart2, AlertTriangle, Database, Search, GitBranch,
-} from 'lucide-react'
-import { Button } from '@/components/ui/button'
-import * as m from '@/paraglide/messages'
-import { apiFetch } from '@/lib/apiFetch'
-import { useCurrentUser } from '@/hooks/useCurrentUser'
-import { DashboardSection } from './-kb-helpers'
-import type { KnowledgeBase, KBStats } from './-kb-types'
-import { kbQueryKeys } from '@/lib/kb-query-keys'
+import { createFileRoute, redirect } from '@tanstack/react-router'
 
 /**
  * Legacy /overview route — redirects to /insights, which now hosts the
- * Docs / Statistieken sections (see KBOverviewSections below) AND the
- * taxonomy / coverage / sync-history blocks.
+ * Docs / Statistieken sections (extracted to `_components/KBOverviewSections.tsx`)
+ * AND the taxonomy / coverage / sync-history blocks.
  */
 export const Route = createFileRoute('/app/knowledge/$kbSlug/overview')({
   beforeLoad: ({ params }) => {
@@ -26,157 +14,8 @@ export const Route = createFileRoute('/app/knowledge/$kbSlug/overview')({
   },
 })
 
-/**
- * Reusable Docs + Statistieken sections — embedded into the Inzichten tab.
- * Was the body of the standalone /overview route before the consolidation.
- */
-export function KBOverviewSections({ kbSlug }: { kbSlug: string }) {
-  const auth = useAuth()
-  const { user } = useCurrentUser()
-
-  // These queries reuse the same queryKeys as the parent layout -- TanStack Query
-  // serves cached data without re-fetching.
-  const { data: kb } = useQuery<KnowledgeBase>({
-    queryKey: kbQueryKeys.knowledgeBase(kbSlug),
-    queryFn: async () => apiFetch<KnowledgeBase>(`/api/app/knowledge-bases/${kbSlug}`),
-    enabled: auth.isAuthenticated,
-  })
-
-  const { data: stats } = useQuery<KBStats>({
-    queryKey: ['kb-stats', kbSlug],
-    queryFn: async () => apiFetch<KBStats>(`/api/app/knowledge-bases/${kbSlug}/stats`),
-    enabled: auth.isAuthenticated && !!kb,
-  })
-
-  if (!kb) return null
-
-  const docsLabel =
-    stats?.docs_count == null
-      ? m.knowledge_detail_docs_none()
-      : stats.docs_count === 1
-        ? m.knowledge_detail_docs_count_one()
-        : m.knowledge_detail_docs_count({ count: String(stats.docs_count) })
-
-  return (
-    <div className="space-y-8">
-      <DashboardSection icon={BookOpen} title={m.knowledge_detail_section_docs()}>
-        {!kb.docs_enabled ? (
-          <p className="text-sm text-gray-400">{m.knowledge_detail_docs_not_enabled()}</p>
-        ) : (
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <FileText className="h-4 w-4 text-gray-400" />
-              <span className="text-sm text-gray-900">{docsLabel}</span>
-            </div>
-            {kb.gitea_repo_slug && (
-              <Link to="/app/docs/$kbSlug" params={{ kbSlug: kb.slug }} >
-                <Button variant="outline" size="sm">{m.knowledge_detail_view_in_docs()}</Button>
-              </Link>
-            )}
-          </div>
-        )}
-      </DashboardSection>
-
-      <DashboardSection icon={BarChart2} title={m.knowledge_detail_section_stats()}>
-        <div className="flex gap-8 mb-5">
-          <div>
-            <p className="text-xs text-gray-400 tracking-wide mb-1">{m.knowledge_detail_stats_search_index()}</p>
-            <p className="text-sm font-medium text-gray-900">
-              {stats?.volume != null
-                ? m.knowledge_detail_volume({ count: String(stats.volume) })
-                : m.knowledge_detail_volume_unknown()}
-            </p>
-          </div>
-          <div>
-            <p className="text-xs text-gray-400 tracking-wide mb-1">{m.knowledge_detail_stats_queries()}</p>
-            <p className="text-sm font-medium text-gray-900">
-              {stats?.usage_last_30d != null
-                ? String(stats.usage_last_30d)
-                : m.knowledge_detail_usage_unknown()}
-            </p>
-          </div>
-          <div>
-            <p className="text-xs text-gray-400 tracking-wide mb-1">{m.knowledge_detail_stats_users()}</p>
-            <p className="text-sm font-medium text-gray-900">
-              {stats?.unique_users_30d != null
-                ? String(stats.unique_users_30d)
-                : m.knowledge_detail_usage_unknown()}
-            </p>
-          </div>
-          <div>
-            <p className="text-xs text-gray-400 tracking-wide mb-1">{m.knowledge_detail_stats_active_days()}</p>
-            <p className="text-sm font-medium text-gray-900">
-              {stats?.active_days_30d != null
-                ? m.knowledge_detail_active_days_value({ count: String(stats.active_days_30d) })
-                : m.knowledge_detail_usage_unknown()}
-            </p>
-          </div>
-          {user?.isAdmin === true && stats?.org_gap_count_7d != null && (
-            <Link to="/app/gaps" className="group">
-              <div>
-                <p className="text-xs text-gray-400 tracking-wide mb-1 flex items-center gap-1">
-                  <AlertTriangle className="h-3 w-3" />
-                  {m.gaps_overview_tile()}
-                </p>
-                <p className="text-sm font-medium text-gray-900 group-hover:text-gray-900 transition-colors">
-                  {stats.org_gap_count_7d}
-                </p>
-              </div>
-            </Link>
-          )}
-        </div>
-
-        {/* Breakdown per database */}
-        <div>
-          <p className="text-xs text-gray-400 tracking-wide mb-2">
-            {m.knowledge_detail_volume_breakdown_title()}
-          </p>
-          <div className="grid grid-cols-3 gap-3">
-            <div className="flex items-start gap-2 rounded-lg border border-gray-200 p-3">
-              <Database className="h-4 w-4 text-gray-400 mt-0.5 shrink-0" />
-              <div>
-                <p className="text-xs font-medium text-gray-900">
-                  {m.knowledge_detail_volume_sources()}
-                </p>
-                <p className="text-sm text-gray-900">
-                  {stats?.source_page_count != null
-                    ? m.knowledge_detail_volume_sources_count({ count: String(stats.source_page_count) })
-                    : m.knowledge_detail_volume_unavailable()}
-                </p>
-              </div>
-            </div>
-            <div className="flex items-start gap-2 rounded-lg border border-gray-200 p-3">
-              <Search className="h-4 w-4 text-gray-400 mt-0.5 shrink-0" />
-              <div>
-                <p className="text-xs font-medium text-gray-900">
-                  {m.knowledge_detail_volume_search_chunks()}
-                </p>
-                <p className="text-sm text-gray-900">
-                  {stats?.vector_chunk_count != null
-                    ? m.knowledge_detail_volume_search_chunks_count({ count: String(stats.vector_chunk_count) })
-                    : m.knowledge_detail_volume_unavailable()}
-                </p>
-              </div>
-            </div>
-            <div className="flex items-start gap-2 rounded-lg border border-gray-200 p-3">
-              <GitBranch className="h-4 w-4 text-gray-400 mt-0.5 shrink-0" />
-              <div>
-                <p className="text-xs font-medium text-gray-900">
-                  {m.knowledge_detail_volume_graph()}
-                </p>
-                <p className="text-sm text-gray-900">
-                  {stats?.graph_entity_count != null && stats?.graph_edge_count != null
-                    ? m.knowledge_detail_volume_graph_count({
-                        entities: String(stats.graph_entity_count),
-                        edges: String(stats.graph_edge_count),
-                      })
-                    : m.knowledge_detail_volume_unavailable()}
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </DashboardSection>
-    </div>
-  )
-}
+// `KBOverviewSections` was extracted to
+// `./_components/KBOverviewSections.tsx` so the Inzichten tab
+// (`insights.tsx`) can consume it without violating
+// klai/no-cross-route-import (insights.tsx and overview.tsx are
+// both routes; routes do not import from each other).

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
@@ -16,17 +16,19 @@ import * as m from '@/paraglide/messages'
 import { apiFetch } from '@/lib/apiFetch'
 import { MS_SITE_URL_PATTERN } from '@/lib/ms-docs'
 import { joinSeedUrl, ASSERTION_MODE_OPTIONS } from './$kbSlug/-kb-helpers'
-import type { CookieRow, GitHubConfig, WebCrawlerConfig } from './$kbSlug/-kb-types'
+import type { CookieRow } from './$kbSlug/-kb-types'
 import type {
   AirtableConfig,
   AuthGuardSuggestion,
   AuthProbeResult,
   ConfluenceConfig,
   ConnectorType,
+  GitHubConfig,
   NotionAddConfig,
   PreviewClassification,
   PreviewResult,
   WcStep,
+  WebCrawlerConfig,
 } from './-connector-types'
 import { MARKDOWN_PROSE_CLASSES, VALID_PRESELECT_TYPES } from './-connector-constants'
 import { AuthProbeFeedback, PreviewClassificationFeedback } from './-connector-feedback'

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
@@ -15,7 +15,6 @@ import { MultiSelect } from '@/components/ui/multi-select'
 import * as m from '@/paraglide/messages'
 import { apiFetch } from '@/lib/apiFetch'
 import { MS_SITE_URL_PATTERN } from '@/lib/ms-docs'
-import { joinSeedUrl, ASSERTION_MODE_OPTIONS } from './$kbSlug/-kb-helpers'
 import type { CookieRow } from './$kbSlug/-kb-types'
 import type {
   AirtableConfig,
@@ -30,7 +29,12 @@ import type {
   WcStep,
   WebCrawlerConfig,
 } from './-connector-types'
-import { MARKDOWN_PROSE_CLASSES, VALID_PRESELECT_TYPES } from './-connector-constants'
+import {
+  ASSERTION_MODE_OPTIONS,
+  joinSeedUrl,
+  MARKDOWN_PROSE_CLASSES,
+  VALID_PRESELECT_TYPES,
+} from './-connector-constants'
 import { AuthProbeFeedback, PreviewClassificationFeedback } from './-connector-feedback'
 import { CookieRowsInput } from '@/components/knowledge/CookieRowsInput'
 import { kbQueryKeys } from '@/lib/kb-query-keys'

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
@@ -16,7 +16,7 @@ import * as m from '@/paraglide/messages'
 import { apiFetch } from '@/lib/apiFetch'
 import { MS_SITE_URL_PATTERN } from '@/lib/ms-docs'
 import { ASSERTION_MODE_OPTIONS, joinSeedUrl } from './$kbSlug/-kb-helpers'
-import type { ConnectorSummary, CookieRow, GitHubConfig, WebCrawlerConfig } from './$kbSlug/-kb-types'
+import type { ConnectorSummary, CookieRow } from './$kbSlug/-kb-types'
 import { CookieRowsInput } from '@/components/knowledge/CookieRowsInput'
 import {
   AuthProbeFeedback,
@@ -28,10 +28,12 @@ import type {
   AuthGuardSuggestion,
   AuthProbeResult,
   ConfluenceConfig,
+  GitHubConfig,
   NotionEditConfig,
   PreviewResult,
   StepDeepLink,
   WcStep,
+  WebCrawlerConfig,
 } from './-connector-types'
 import { MARKDOWN_PROSE_CLASSES, VALID_STEPS } from './-connector-constants'
 

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
@@ -15,7 +15,6 @@ import { StepIndicator, type StepItem } from '@/components/ui/step-indicator'
 import * as m from '@/paraglide/messages'
 import { apiFetch } from '@/lib/apiFetch'
 import { MS_SITE_URL_PATTERN } from '@/lib/ms-docs'
-import { ASSERTION_MODE_OPTIONS, joinSeedUrl } from './$kbSlug/-kb-helpers'
 import type { ConnectorSummary, CookieRow } from './$kbSlug/-kb-types'
 import { CookieRowsInput } from '@/components/knowledge/CookieRowsInput'
 import {
@@ -35,7 +34,12 @@ import type {
   WcStep,
   WebCrawlerConfig,
 } from './-connector-types'
-import { MARKDOWN_PROSE_CLASSES, VALID_STEPS } from './-connector-constants'
+import {
+  ASSERTION_MODE_OPTIONS,
+  joinSeedUrl,
+  MARKDOWN_PROSE_CLASSES,
+  VALID_STEPS,
+} from './-connector-constants'
 
 // SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-1 / REQ-5: edit wizard uses the same
 // 5-step flow as add-connector. ?step=auth|selector deep-link into the wizard.

--- a/klai-portal/frontend/src/routes/app/knowledge/-connector-constants.ts
+++ b/klai-portal/frontend/src/routes/app/knowledge/-connector-constants.ts
@@ -1,8 +1,14 @@
-// Shared constants for the connector wizard pages.
+// Shared constants and tiny helpers for the connector wizard pages.
 // Companion to `-connector-types.ts`. Per the
 // "File organization for shared types and helpers" rule
 // (.claude/rules/klai/projects/portal-frontend.md).
+//
+// `joinSeedUrl` is a one-function helper kept here rather than in its own
+// `-connector-helpers.ts` because a single function does not warrant a
+// separate file (would be the proliferation anti-pattern the rule warns
+// against). When a second wizard-only helper appears, split this file.
 
+import { type MultiSelectOption } from '@/components/ui/multi-select'
 import type { ConnectorType, StepDeepLink } from './-connector-types'
 
 // Tailwind class string applied to the markdown preview pane in both
@@ -22,3 +28,31 @@ export const VALID_PRESELECT_TYPES = new Set<ConnectorType>([
 // by the route's validateSearch to deep-link into the auth-setup or
 // selector wizard step.
 export const VALID_STEPS = new Set<StepDeepLink>(['auth', 'selector'])
+
+// SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-9: assertion-mode options
+// shown in the wizard's allowedAssertionModes MultiSelect.
+export const ASSERTION_MODE_OPTIONS: MultiSelectOption[] = [
+  { value: 'factual',    label: 'Fact',        description: 'Established fact, documentation, specs' },
+  { value: 'procedural', label: 'Procedure',   description: "Step-by-step instructions, how-to's" },
+  { value: 'belief',     label: 'Claim',       description: 'Not conclusively proven claim' },
+  { value: 'quoted',     label: 'Quote',       description: 'Literal source material' },
+  { value: 'hypothesis', label: 'Speculation', description: 'Hypotheses, brainstorm' },
+  { value: 'unknown',    label: 'Unknown',     description: 'Type not specified' },
+]
+
+/**
+ * SPEC-CONNECTOR-INPUT-VALIDATION-001 hotfix — slash-safe URL build.
+ *
+ * Combines ``base_url`` and ``path_prefix`` without producing the ``//``
+ * artifact that crawl4ai handles inconsistently (`https://x.com/` + `/nl/`
+ * = `https://x.com//nl/`). Trims trailing slash off base, leading slash
+ * off path, then joins with single `/` if path is non-empty.
+ *
+ * Used by both add-connector and edit-connector wizard auth-probe call sites.
+ */
+export function joinSeedUrl(baseUrl: string, pathPrefix: string): string {
+  const base = baseUrl.replace(/\/+$/, '')
+  const path = (pathPrefix || '').replace(/^\/+/, '').replace(/\/+$/, '')
+  if (!path) return base + '/'
+  return `${base}/${path}/`
+}

--- a/klai-portal/frontend/src/routes/app/knowledge/-connector-types.ts
+++ b/klai-portal/frontend/src/routes/app/knowledge/-connector-types.ts
@@ -6,11 +6,9 @@
 // shared types live at the parent route level — NOT in `$kbSlug/-kb-types.ts`
 // (wrong scope: that file is for KB-tab routes inside `$kbSlug/`).
 //
-// Connector-types that are also used by KB-tab routes (e.g. `GitHubConfig`,
-// `WebCrawlerConfig`, `CookieRow`, `ConnectorSummary`) live in
-// `$kbSlug/-kb-types.ts` because they predate this split. A future SPEC
-// (F-C2 in SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 § Follow-ups) may
-// hoist them to a parent-level shared file too.
+// Types that are genuinely shared between KB-tab routes AND wizard routes
+// (`CookieRow`, `ConnectorSummary`) stay in `$kbSlug/-kb-types.ts` —
+// they have a broader scope than this file.
 
 // SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-1: web_crawler wizard step order is
 // Details → AuthQuestion → AuthSetup (only if requires login) → Selector → Settings.
@@ -106,3 +104,22 @@ export interface NotionEditConfig {
 }
 
 export type NotionConfig = NotionAddConfig | NotionEditConfig
+
+// Per-connector form-state shapes for connectors with their own
+// flat-config schemas (no fancy add/edit divergence). github + web_crawler
+// reuse the same shape across both wizards.
+
+export interface GitHubConfig {
+  installation_id: string
+  repo_owner: string
+  repo_name: string
+  branch: string
+  path_filter: string
+}
+
+export interface WebCrawlerConfig {
+  base_url: string
+  path_prefix: string
+  max_pages: string
+  content_selector: string
+}

--- a/klai-portal/frontend/src/routes/app/knowledge/__tests__/connector-helpers.test.ts
+++ b/klai-portal/frontend/src/routes/app/knowledge/__tests__/connector-helpers.test.ts
@@ -1,14 +1,16 @@
 /**
- * SPEC-CONNECTOR-INPUT-VALIDATION-001 — kb-helpers shared utilities.
+ * SPEC-CONNECTOR-INPUT-VALIDATION-001 — connector wizard shared utilities.
  *
- * Covers ``joinSeedUrl`` (slash normalisation). Cookie parsing was
- * intentionally removed: the wizard now collects cookies as structured
- * {name, value} rows via CookieRowsInput, eliminating the parser-layer
- * bug class entirely.
+ * Covers ``joinSeedUrl`` (slash normalisation), now hosted in
+ * ../-connector-constants.ts (was ../$kbSlug/-kb-helpers.tsx until the
+ * SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 followups). Cookie parsing was
+ * intentionally removed earlier: the wizard now collects cookies as
+ * structured {name, value} rows via CookieRowsInput, eliminating the
+ * parser-layer bug class entirely.
  */
 
 import { describe, expect, it } from 'vitest'
-import { joinSeedUrl } from '../$kbSlug/-kb-helpers'
+import { joinSeedUrl } from '../-connector-constants'
 
 describe('joinSeedUrl', () => {
   it('combines clean base + path with single slash', () => {


### PR DESCRIPTION
Self-review followups to PR #613 (SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001). 5 small commits, each green and revertable.

## What

| # | Commit | Item from self-review |
|---|---|---|
| 1 | `c623ffd3` | F-C2 partial: hoist `GitHubConfig` + `WebCrawlerConfig` from `\$kbSlug/-kb-types` to `-connector-types` |
| 2 | `edc81f81` | F-C2 cont.: hoist `ASSERTION_MODE_OPTIONS` + `joinSeedUrl`; drop dead `roleBadge` |
| 3 | `d6818af0` | F-S3: new `klai/no-cross-route-import` ESLint rule (13 unit tests) + extract `KBOverviewSections` to `_components/` |
| 4 | `41ee1a3f` | Billing logger fix: add `adminLogger.error/warn` to PR #617's void-prefix hotfix territory |
| 5 | `48eb9758` | Retro entry `previous-deploy-failure-blocks-yours` + SPEC sync (status: ready → done) |

## Why each

After landing PR #613 + the rollout to production, a self-review identified that I had:
1. **Made the cross-directory import smell WORSE** in Phase 2 (added two new such imports in add-connector to match what edit already had). The new rule itself flags this. Commits 1-2 eliminate them by hoisting the wizard-only symbols up to the parent route directory where they belong.
2. **Left the rule unenforced.** Commit 3 adds `klai/no-cross-route-import` ESLint rule that catches future regressions. Plus extracts `KBOverviewSections` from `overview.tsx` to `_components/` (smallest-shared scope) so the rule can be enabled. The remaining `TaxonomyTab` cross-route import in `insights.tsx` is marked `eslint-disable-next-line` with explicit TODO referencing F-table row 1 — splitting that 720-line god-component is a separate SPEC's worth of work.
3. **Shipped a symptom-fix in PR #617** (one-line `void` prefix to unblock deploy) that didn't add the logger calls `portal-logging-ts.md` requires. Commit 4 restores Sentry diagnostic trail.
4. **Lost the lesson** from the inherited-deploy-failure incident. Commit 5 documents `previous-deploy-failure-blocks-yours` in process-rules.md with 5 prevention options.
5. **Skipped SPEC sync.** Commit 5 also flips status to `done` and adds progress.md.

## Verification

- vitest run (full suite): 235/235 passing
- eslint . (with the new rule active): exit 0
- tsc --noEmit: clean (only pre-existing tsconfig warning)
- The new rule's own unit tests: 13/13 passing

## What this PR does NOT do

- TaxonomyTab god-component split (F-table row 1) — own SPEC
- The other 8 god-component candidates from § Follow-ups — own SPECs
- `useConnectorWizardState` hook extraction (F-1) — own SPEC

These remain in the SPEC's § Follow-ups for prioritisation later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)