### PR TITLE
spec: carve 9 god-component candidates from SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 into own SPECs

### DIFF
--- a/.moai/specs/SPEC-PORTAL-ADMIN-SETTINGS-CLEANUP-001/spec.md
+++ b/.moai/specs/SPEC-PORTAL-ADMIN-SETTINGS-CLEANUP-001/spec.md
@@ -1,0 +1,79 @@
+---
+id: SPEC-PORTAL-ADMIN-SETTINGS-CLEANUP-001
+version: 0.1.0
+status: draft
+created: 2026-05-13
+author: Mark Vletter
+priority: medium
+parent: SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 (god-component § Follow-ups, carved out)
+related: []
+rule:
+  - .claude/rules/klai/projects/portal-frontend.md § "File organization for shared types and helpers"
+---
+
+# SPEC-PORTAL-ADMIN-SETTINGS-CLEANUP-001 — Split admin/settings.tsx (524 lines, 9 inline mutations)
+
+## Goal
+
+Reduce `klai-portal/frontend/src/routes/admin/settings.tsx` from 524
+lines to a route shell + per-section components + extracted mutation
+hooks. **Densest mutations of any candidate** (9 inline) — primary
+extraction target is the mutation set.
+
+This SPEC is **draft**. Annotation cycle confirms exact sub-section
+boundaries.
+
+## Motivation metrics
+
+| Metric | Value |
+|---|---|
+| File line count | 524 |
+| useState | 9 |
+| useEffect | 3 |
+| Inline mutations | **9 (densest in survey)** |
+| Inline queries | (TBD) |
+| Git churn last 90 days | 26 commits |
+| Last touched | 11 hours ago at SPEC creation |
+| Production-critical | Yes (admin settings) |
+
+9 mutations in one file is a strong signal that the page is doing too
+much. Settings pages typically have logical sections (general,
+billing, integrations, etc.). Extract per-section.
+
+## Scope (proposed)
+
+### In
+
+- Per-section sub-components in `admin/_components/`:
+  - `<GeneralSettingsSection>`, `<IntegrationsSection>`, etc.
+  - Each owns its own state + consumes its own mutation hooks
+- New `admin/-settings-hooks.ts`: 9 mutation hooks
+- Modify `settings.tsx`: route shell + section composition only
+
+### Out
+
+- Backend admin API changes
+- Adding new settings categories
+
+## Approach
+
+DDD methodology. The 9 mutations almost certainly cluster by
+logical concern (e.g. 3 mutations for general, 3 for integrations, 3
+for billing). ANALYZE phase identifies the clusters → each cluster
+becomes its own sub-component with its own mutation hooks.
+
+## Learnings to apply
+
+- File-organization rule + ESLint rule already in place
+- DDD characterization tests cover each settings-section's mutation
+  paths
+- Triplicate check vs `admin/_components/` (existing patterns for
+  shared admin UI) and `@/lib/` (admin-wide hooks)
+- Live verification per section after deploy
+- scale-the-answer: own SPEC
+
+## See Also
+
+- `.moai/specs/SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001/spec.md`
+- `.claude/rules/klai/projects/portal-frontend.md` § "File
+  organization for shared types and helpers"

--- a/.moai/specs/SPEC-PORTAL-ADMIN-USERS-CLEANUP-001/spec.md
+++ b/.moai/specs/SPEC-PORTAL-ADMIN-USERS-CLEANUP-001/spec.md
@@ -1,0 +1,94 @@
+---
+id: SPEC-PORTAL-ADMIN-USERS-CLEANUP-001
+version: 0.1.0
+status: draft
+created: 2026-05-13
+author: Mark Vletter
+priority: medium-high
+parent: SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 (god-component § Follow-ups, carved out)
+related:
+  - SPEC-PORTAL-TAXONOMY-EXTRACT-001 (sibling cleanup pattern reference)
+rule:
+  - .claude/rules/klai/projects/portal-frontend.md § "File organization for shared types and helpers"
+---
+
+# SPEC-PORTAL-ADMIN-USERS-CLEANUP-001 — Split admin/users/index.tsx (517 lines, 6 inline mutations)
+
+## Goal
+
+Reduce `klai-portal/frontend/src/routes/admin/users/index.tsx` from 517
+lines to a route-shell + sub-components + extracted mutation hooks.
+Pattern: same as TaxonomyTab (SPEC-PORTAL-TAXONOMY-EXTRACT-001 +
+SPEC-PORTAL-TAXONOMY-SPLIT-001).
+
+This SPEC is **draft**. Annotation cycle required to identify exact
+sub-component boundaries.
+
+## Motivation metrics
+
+| Metric | Value |
+|---|---|
+| File line count | 517 |
+| useState | 5 |
+| useEffect | 0 |
+| Inline mutations | 6 |
+| Inline queries | (TBD — verify in ANALYZE phase) |
+| Git churn last 90 days | 33 commits (#2 across all candidates) |
+| Last touched | 3 hours ago at SPEC creation |
+| Production-critical | Yes (admin user management) |
+
+The high churn signals active developer pain. The 6 inline mutations
+suggest natural extraction targets (`useInviteUser`, `useUpdateRole`,
+`useDeleteUser`, etc.).
+
+## Scope (proposed — needs annotation)
+
+### In
+
+- New `admin/users/_components/UserRow.tsx`: per-row affordances
+  (edit, delete, role-change) currently inlined in the table render
+- New `admin/users/_components/InviteUserForm.tsx`: invite form (if
+  inlined; verify)
+- New `admin/users/-users-hooks.ts`: 6 mutation hooks + relevant
+  query hooks
+- Modify `index.tsx`: route shell + table orchestration only
+
+### Out
+
+- Backend changes (admin user API stays as-is)
+- Adding new functionality
+- shadcn/ui table component refactor (separate concern)
+
+## Approach
+
+DDD methodology. Reference implementation:
+SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 followups. Phase order:
+1. Worktree + characterization tests for existing user-management flows
+2. Extract mutation hooks → `-users-hooks.ts`
+3. Extract `<UserRow>` (likely the densest sub-component)
+4. Extract `<InviteUserForm>` (if applicable)
+5. Reduce `index.tsx` to route + table assembly
+6. Verify gates + Playwright on `/admin/users`
+
+## Learnings to apply (from SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001)
+
+- **File-organization rule** + **klai/no-cross-route-import** ESLint
+  rule are already in place — re-use, don't reinvent.
+- **`_components/` for sub-components, `-`-prefixed for hooks/types/constants**.
+- **Triplicate elimination check**: grep for any `User*` types or
+  user-mutation hooks already exported elsewhere (`@/lib/`, other
+  admin routes) before creating new ones.
+- **DDD methodology**: characterization tests first, refactor in
+  small commits.
+- **Live verification** on production after deploy (any Klai admin
+  tenant works).
+- **scale-the-answer**: do NOT bundle with other god-component
+  cleanups. This SPEC is scoped to one file.
+
+## See Also
+
+- `.moai/specs/SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001/spec.md`
+- `.moai/specs/SPEC-PORTAL-TAXONOMY-EXTRACT-001/spec.md` — sibling
+  cleanup pattern.
+- `.claude/rules/klai/projects/portal-frontend.md` § "File
+  organization for shared types and helpers"

--- a/.moai/specs/SPEC-PORTAL-BILLING-CLEANUP-001/spec.md
+++ b/.moai/specs/SPEC-PORTAL-BILLING-CLEANUP-001/spec.md
@@ -1,0 +1,104 @@
+---
+id: SPEC-PORTAL-BILLING-CLEANUP-001
+version: 0.1.0
+status: draft
+created: 2026-05-13
+author: Mark Vletter
+priority: medium
+parent: SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 (god-component § Follow-ups, carved out)
+related:
+  - SPEC-PORTAL-PRICING-PER-USER-001 (recently active — billing.lazy.tsx is in active development)
+rule:
+  - .claude/rules/klai/projects/portal-frontend.md § "File organization for shared types and helpers"
+---
+
+# SPEC-PORTAL-BILLING-CLEANUP-001 — Split admin/billing.lazy.tsx (673 lines, 11 useState, no mutations)
+
+## Goal
+
+Reduce `klai-portal/frontend/src/routes/admin/billing.lazy.tsx` from
+673 lines to a route shell + per-section components + a state machine
+or `useReducer` for the 11-useState complexity. Notable: zero
+mutations (all data is via fetches, billing actions go through Moneybird
+external flows).
+
+This SPEC is **draft**. Annotation cycle should coordinate with the
+active SPEC-PORTAL-PRICING-PER-USER-001 work to avoid concurrent
+edits.
+
+## Motivation metrics
+
+| Metric | Value |
+|---|---|
+| File line count | 673 |
+| useState | 11 |
+| useEffect | 2 |
+| Inline mutations | 0 |
+| Inline queries | (TBD — likely fetched via apiFetch in useEffect) |
+| Git churn last 90 days | 22 commits |
+| Last touched | 3 hours ago at SPEC creation |
+| Production-critical | Yes (admin billing — revenue-impact) |
+| Active concurrent work | YES (SPEC-PORTAL-PRICING-PER-USER-001 phases ongoing) |
+
+11 useState with no mutations means it's a complex local state machine.
+The `useEffect`s likely orchestrate sequential fetches + state
+transitions. Strong candidate for `useReducer` consolidation.
+
+The CONCURRENT WORK signal is critical: do NOT start this SPEC while
+PRICING-PER-USER-001 is mid-execution. Coordinate via SPEC dependency.
+
+## Scope (proposed)
+
+### In
+
+- New `admin/_components/BillingBreakdownSection.tsx`,
+  `BillingMandateSection.tsx`, etc. — per-section components
+- Likely `useReducer` for the state machine (11 cross-coupled useStates
+  → consolidated reducer)
+- Modify `billing.lazy.tsx`: route shell + section composition
+
+### Out
+
+- Backend billing/Moneybird API changes
+- Pricing model changes (those are PRICING-PER-USER-001 SPEC scope)
+- New billing functionality
+
+## Approach
+
+DDD methodology. **Coordinate with PRICING-PER-USER-001 phase
+schedule** — start this SPEC only after that SPEC's last phase merges,
+to avoid ongoing merge conflicts (22 commits / 90 days, mostly from
+that SPEC).
+
+ANALYZE phase: map the 11 useStates and identify which cluster
+forms the actual state machine. The `useReducer` is likely the right
+end state.
+
+## Special note: prior fix (PR #617 + followup)
+
+This file received a 1-line `void Promise.allSettled(...)` hotfix in
+PR #617 + proper `adminLogger.error/warn` calls in PR #620 (via
+SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 followups). Those fixes are
+present and tested. Don't regress them during the cleanup.
+
+## Learnings to apply
+
+- File-organization rule + ESLint rule
+- DDD characterization tests, especially for the Promise.allSettled
+  + error-state interactions
+- `useReducer` is acceptable per project conventions (verify in
+  ANALYZE)
+- Live verification on production billing page (read-only is safe;
+  no mandate-state mutation needed)
+- **previous-deploy-failure-blocks-yours** retro pattern: this file
+  was the source of that incident — extra caution on lint state
+- scale-the-answer: own SPEC
+- **CONCURRENT WORK COORDINATION** — verify PRICING-PER-USER-001 is
+  fully merged before starting
+
+## See Also
+
+- `.moai/specs/SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001/spec.md`
+- `.moai/specs/SPEC-PORTAL-PRICING-PER-USER-001/spec.md` (active —
+  do not conflict)
+- `.claude/rules/klai/pitfalls/process-rules.md` § "previous-deploy-failure-blocks-yours"

--- a/.moai/specs/SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001/progress.md
+++ b/.moai/specs/SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001/progress.md
@@ -42,14 +42,58 @@ After v0.2.0 shipped, a self-review identified loose ends. The
 
 ## Outstanding follow-ups (per § Follow-ups)
 
-These remain explicitly out of this SPEC's scope:
+**UPDATE 2026-05-13 (post-sync):** All 9 god-component candidates from
+the F-table have been promoted to their own SPEC documents. The
+`§ Follow-ups` section in `spec.md` has been updated to reference each
+new SPEC-ID with current status. Below is the canonical pointer list:
 
-- **F-1**: `useConnectorWizardState` hook extraction (real win, real risk)
-- **F-2**: Page god-component split (depends on F-1)
-- **F-table row 1**: `TaxonomyTab` god-component split (1 cross-route
-  import marked with `eslint-disable-next-line` references this work)
-- **F-table other rows**: 7 more god-component candidates documented
-  in spec.md § Follow-ups
+### Direct followups to this SPEC (still TODO, no new SPECs created)
+
+- **F-1**: `useConnectorWizardState` hook extraction (real win, real risk).
+  Stays as a follow-up, not promoted to its own SPEC yet — needs a
+  concrete trigger (a feature touching the wizard state) to be worth
+  scheduling.
+- **F-2**: Page god-component split for AddConnectorPage / EditConnectorPage.
+  Depends on F-1. Same logic.
+
+### Repo-wide god-component cleanup SPECs (new, this commit)
+
+| Source area | New SPEC | Initial status |
+|---|---|---|
+| `taxonomy.tsx` (move) | `SPEC-PORTAL-TAXONOMY-EXTRACT-001` | ready (small, pickable now) |
+| `taxonomy.tsx` (interior split) | `SPEC-PORTAL-TAXONOMY-SPLIT-001` | draft (DDD, post-EXTRACT) |
+| `admin/users/index.tsx` | `SPEC-PORTAL-ADMIN-USERS-CLEANUP-001` | draft |
+| `$kbSlug/connectors.tsx` | `SPEC-PORTAL-CONNECTORS-TAB-CLEANUP-001` | draft (borderline) |
+| `knowledge/new.tsx` | `SPEC-PORTAL-KB-NEW-CLEANUP-001` | draft |
+| `admin/settings.tsx` | `SPEC-PORTAL-ADMIN-SETTINGS-CLEANUP-001` | draft |
+| `admin/billing.lazy.tsx` | `SPEC-PORTAL-BILLING-CLEANUP-001` | draft (coordinate with PRICING-PER-USER-001) |
+| `app/transcribe/add.tsx` | `SPEC-PORTAL-TRANSCRIBE-ADD-CLEANUP-001` | draft |
+| `setup/mfa.lazy.tsx` | `SPEC-PORTAL-MFA-SETUP-CLEANUP-001` | draft |
+| `$kbSlug/members.tsx` | `SPEC-PORTAL-KB-MEMBERS-CLEANUP-001` | draft |
+
+Each carved-out SPEC includes:
+- Source SPEC's metrics (lines, useState, churn) verbatim
+- Reference to the file-organization rule + ESLint guard already in place
+- Reference to the proven KBOverviewSections / TaxonomyTab extraction
+  pattern as precedent
+- Explicit "scale-the-answer" caveat: don't bundle multiple cleanups
+  in one SPEC, even if they look similar
+- Required learnings section pointing to this SPEC for context
+
+### Architectural smells (closed in followups commit)
+
+- **F-S1**: `insights.tsx` cross-route imports — PARTIALLY CLOSED
+  (`KBOverviewSections` extracted; `TaxonomyTab` left with explicit
+  marker, will close in `SPEC-PORTAL-TAXONOMY-EXTRACT-001`).
+- **F-S3**: ESLint rule for cross-route imports — DONE (PR #620 +
+  cross-reference doc PR #622).
+
+### Convention adoption
+
+- **F-C2**: Hoist legacy cross-directory imports — DONE in PR #620
+  for the wizard-only subset. Genuinely-shared symbols (CookieRow,
+  ConnectorSummary) correctly stayed in `-kb-types.ts`.
+- **F-C1**: Audit all 5 `-`-prefixed files — still open.
 
 ## Final state
 

--- a/.moai/specs/SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001/spec.md
+++ b/.moai/specs/SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001/spec.md
@@ -487,56 +487,56 @@ new rule's "smallest-shared scope" spirit at the SPEC level too.
 
 ### Repo-wide god-component candidates (each its own SPEC)
 
-| File | Regels | useState | useEffect | mutations/queries | Profiel | SPEC priority |
-|---|---|---|---|---|---|---|
-| `$kbSlug/taxonomy.tsx` | 1088 | 16 | 2 | ~12 | `TaxonomyTab` 720 regels, 8 inline mutations, 166-regel inline `proposals.map()` callback. Cross-imported by `insights.tsx`. | High — actual code-review pain |
-| `knowledge/new.tsx` | 713 | 4 | 0 | 4 | Multi-step KB-creation wizard; types already in `new._types.ts`. Modest useState count suggests it's reasonable for its size. | Medium — likely manageable refactor |
-| `admin/billing.lazy.tsx` | 673 | 11 | 2 | 0 | 11 useState in one component without mutations/queries is unusual — local form state machine. | Medium |
-| `setup/mfa.lazy.tsx` | 668 | **19** | 3 | 0 | 19 useState — highest in the codebase. Multi-step MFA setup. Strong refactor candidate. | High — fragility risk |
-| `app/transcribe/add.tsx` | 530 | 12 | 4 | 3 | Transcribe upload form. | Medium |
-| `admin/settings.tsx` | 524 | 9 | 3 | 9 | 9 mutations inline → mutation-hooks extraction. | Medium |
-| `admin/users/index.tsx` | 517 | 5 | 0 | 6 | 6 mutations inline; row-level affordances likely candidate for `_components/UserRow.tsx`. | Medium |
-| `$kbSlug/members.tsx` | 497 | 7 | 0 | 10 | 10 mutations is the densest mutation-per-line in the survey; row-level affordances. | Medium-high — touchy area, well-tested |
-| `$kbSlug/connectors.tsx` | 425 | 8 | 2 | 5 | Borderline — review value of refactor before SPEC. | Low |
+**UPDATE 2026-05-13:** All 9 candidates below have been promoted to
+their own SPEC documents in this same followups commit. The original
+F-table is preserved as a record; the live tracking lives in those
+SPECs. Order below matches the 90-day churn ranking (most-touched first):
 
-### Architectural smells (no-SPEC-needed; can be one-PR cleanups)
+| File | SPEC | Status |
+|---|---|---|
+| `$kbSlug/taxonomy.tsx` (1088 lines, 44 commits/90d, eslint-disable in insights.tsx) | `SPEC-PORTAL-TAXONOMY-EXTRACT-001` (move) + `SPEC-PORTAL-TAXONOMY-SPLIT-001` (interior split) | EXTRACT: ready · SPLIT: draft |
+| `admin/users/index.tsx` (517 lines, 33 commits/90d) | `SPEC-PORTAL-ADMIN-USERS-CLEANUP-001` | draft |
+| `$kbSlug/connectors.tsx` (425 lines, 29 commits/90d) | `SPEC-PORTAL-CONNECTORS-TAB-CLEANUP-001` | draft (borderline — annotation cycle may close as won't-fix) |
+| `knowledge/new.tsx` (713 lines, 28 commits/90d) | `SPEC-PORTAL-KB-NEW-CLEANUP-001` | draft |
+| `admin/settings.tsx` (524 lines, 26 commits/90d, 9 mutations) | `SPEC-PORTAL-ADMIN-SETTINGS-CLEANUP-001` | draft |
+| `admin/billing.lazy.tsx` (673 lines, 22 commits/90d, 11 useState) | `SPEC-PORTAL-BILLING-CLEANUP-001` | draft (coordinate with active PRICING-PER-USER-001) |
+| `app/transcribe/add.tsx` (530 lines, 22 commits/90d) | `SPEC-PORTAL-TRANSCRIBE-ADD-CLEANUP-001` | draft |
+| `setup/mfa.lazy.tsx` (668 lines, 16 commits/90d, **19 useState**) | `SPEC-PORTAL-MFA-SETUP-CLEANUP-001` | draft (worst structure in repo, low churn = stable pain) |
+| `$kbSlug/members.tsx` (497 lines, 15 commits/90d, 10 mutations) | `SPEC-PORTAL-KB-MEMBERS-CLEANUP-001` | draft (densest mutations per line) |
 
-- **F-S1: `insights.tsx` cross-route imports.** `insights.tsx`
-  (33 lines) imports `TaxonomyTab` from `./taxonomy` (1088 lines)
-  and `KBOverviewSections` from `./overview`. Both are route files.
-  Per the new rule this is a smell. Fix: extract `TaxonomyTab` to
-  `$kbSlug/-taxonomy-component.tsx` (or co-located inside taxonomy's
-  own `_components/`) and `KBOverviewSections` to a similar place.
-  Resolves the smell and makes F-table row 1 (`taxonomy.tsx`) easier.
+### Architectural smells
+
+- **F-S1: `insights.tsx` cross-route imports.**
+  **PARTIALLY RESOLVED 2026-05-13.** `KBOverviewSections` extracted to
+  `$kbSlug/_components/KBOverviewSections.tsx` (followups PR #620).
+  `TaxonomyTab` cross-route import remains marked with
+  `eslint-disable-next-line` + TODO; SPEC-PORTAL-TAXONOMY-EXTRACT-001
+  will close it.
 
 - **F-S2: Duplicate `interface User`-like types.** Out of scope for
-  this audit; flagged for next codebase-wide types audit.
+  this audit; flagged for next codebase-wide types audit. Still open.
 
-- **F-S3: ESLint `no-restricted-imports` rule** preventing
-  `import from '../<route-name>.tsx'` patterns. Once the existing
-  cross-route imports are eliminated (F-S1 + this SPEC), add the
-  rule to prevent regression.
+- **F-S3: ESLint rule preventing `import from '../<route-name>.tsx'`.**
+  **DONE 2026-05-13.** Implemented as `klai/no-cross-route-import` in
+  followups PR #620 (`klai-portal/frontend/eslint-rules/no-cross-route-import.js`)
+  with 13 unit tests + cross-reference in portal-frontend.md (PR #622).
 
 ### Convention adoption follow-ups
 
 - **F-C1: Audit existing `-`-prefixed files** against the new rule.
-  Five feature-local instances exist today
-  (`-kb-*`, `-bronnen-*`, `admin/api-keys/-*`, `admin/widgets/-*`,
-  `app/templates/-template-form.tsx`). Verify each matches the rule's
-  decision-tree clauses (smallest-shared scope, naming convention).
-  Cleanup-only — no new SPECs spawned unless an instance is
-  badly-placed.
+  Still open. Five feature-local instances exist today (`-kb-*`,
+  `-bronnen-*`, `admin/api-keys/-*`, `admin/widgets/-*`,
+  `app/templates/-template-form.tsx`). Cleanup-only — no new SPECs
+  spawned unless an instance is badly-placed.
 
-- **F-C2: Hoist legacy cross-directory imports.** add/edit-connector
-  consume from `$kbSlug/-kb-*` because that's where the symbols
-  happened to live. Per the new rule's clause 3, the smallest-shared
-  scope across `$kbSlug/` (KB-tabs) AND
-  `$kbSlug_.{add,edit}-connector.tsx` (wizards) is the parent
-  `routes/app/knowledge/`. A future SPEC could relocate the
-  wizard-relevant subset (`ASSERTION_MODE_OPTIONS`, `GitHubConfig`,
-  `WebCrawlerConfig`, etc.) to parent-level `-knowledge-*` files.
-  Not urgent — the legacy imports are tactical and tests catch
-  regressions.
+- **F-C2: Hoist legacy cross-directory imports.**
+  **DONE 2026-05-13** (PR #620 followups). Wizard-only symbols
+  (`GitHubConfig`, `WebCrawlerConfig`, `ASSERTION_MODE_OPTIONS`,
+  `joinSeedUrl`) hoisted from `$kbSlug/-kb-*` to parent-level
+  `-connector-*` files. Both wizard pages now consume zero symbols
+  from `$kbSlug/-kb-helpers.tsx` cross-directory. Remaining legitimate
+  cross-directory imports (`CookieRow`, `ConnectorSummary`) stay in
+  `-kb-types.ts` because they ARE genuinely shared with KB-tab routes.
 
 ## See Also
 

--- a/.moai/specs/SPEC-PORTAL-CONNECTORS-TAB-CLEANUP-001/spec.md
+++ b/.moai/specs/SPEC-PORTAL-CONNECTORS-TAB-CLEANUP-001/spec.md
@@ -1,0 +1,101 @@
+---
+id: SPEC-PORTAL-CONNECTORS-TAB-CLEANUP-001
+version: 0.1.0
+status: draft
+created: 2026-05-13
+author: Mark Vletter
+priority: medium
+parent: SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 (god-component § Follow-ups, carved out)
+related:
+  - SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 (this is the SAME area — connectors tab is the list view, the wizard pages are add/edit)
+rule:
+  - .claude/rules/klai/projects/portal-frontend.md § "File organization for shared types and helpers"
+---
+
+# SPEC-PORTAL-CONNECTORS-TAB-CLEANUP-001 — Borderline cleanup of $kbSlug/connectors.tsx (425 lines)
+
+## Goal
+
+Reduce `klai-portal/frontend/src/routes/app/knowledge/$kbSlug/connectors.tsx`
+from 425 lines to a route shell + extracted row-component(s) + hooks.
+This SPEC's status is **borderline** — 425 lines is close to the
+threshold where extraction becomes overkill. High git churn (29
+commits / 90 days) is the main argument FOR doing it.
+
+This SPEC is **draft**. Annotation cycle should reconsider whether to
+proceed at all (acceptable to mark as "won't fix" if the file's
+internal structure turns out to be reasonable for its size).
+
+## Motivation metrics
+
+| Metric | Value |
+|---|---|
+| File line count | 425 |
+| useState | 8 |
+| useEffect | 2 |
+| Inline mutations | 5 |
+| Inline queries | (TBD) |
+| Git churn last 90 days | 29 commits (#3 across all candidates) |
+| Last touched | 11 hours ago at SPEC creation |
+| Production-critical | Yes (per-KB connector management) |
+
+The high churn is the strongest signal. Many edits = many cognitive
+hits on the file's structure. But 425 lines is on the lower end of the
+god-component spectrum — if internal structure is already reasonable
+(separate concerns within the file), this SPEC may not pay off.
+
+## Scope (proposed — annotation cycle decides whether to proceed)
+
+### In (proposed)
+
+- New `_components/ConnectorRow.tsx`: per-row affordances if currently
+  inlined in the table render
+- New `-connectors-tab-hooks.ts`: 5 mutation hooks (sync, delete,
+  reauth, etc.)
+- Modify `connectors.tsx`: route shell + table assembly
+
+### Out
+
+- Backend connector changes
+- Wizard pages (those are SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001
+  territory — already done)
+- New functionality
+
+## Approach
+
+DDD methodology. Annotation cycle MUST first ANALYZE whether the file
+is actually god-shaped or just "long but OK". Recommended ANALYZE
+output:
+- Is each useState used in one place or scattered?
+- Are mutations grouped by concern or interleaved?
+- Is the JSX render path cohesive or branching wildly?
+
+If ANALYZE shows the file is internally cohesive → mark this SPEC as
+**won't fix** and update the parent SPEC's § Follow-ups.
+If ANALYZE shows real god-component patterns → proceed with extraction
+phases mirroring SPEC-PORTAL-TAXONOMY-EXTRACT-001 / -SPLIT-001.
+
+## Learnings to apply
+
+Same as SPEC-PORTAL-ADMIN-USERS-CLEANUP-001:
+- File-organization rule + ESLint rule already in place
+- DDD methodology with characterization tests
+- Triplicate check vs `-kb-helpers.tsx` and `-kb-types.ts` (this file
+  IS in the same dir — high overlap probability with SyncStatusBadge,
+  ConnectorSummary, etc.)
+- Live verification on Voys
+- scale-the-answer: own SPEC, no bundling
+
+## Special note: cross-reference with existing -kb-helpers
+
+`connectors.tsx` already imports `SyncStatusBadge` from `-kb-helpers.tsx`
+and `ConnectorSummary` from `-kb-types.ts` (verified during
+SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 audit). Any new extraction
+must check whether the new symbols also belong in these existing
+shared files OR a new connector-tab-specific `-`-prefixed file.
+
+## See Also
+
+- `.moai/specs/SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001/spec.md`
+- `.claude/rules/klai/projects/portal-frontend.md` § "File
+  organization for shared types and helpers"

--- a/.moai/specs/SPEC-PORTAL-KB-MEMBERS-CLEANUP-001/spec.md
+++ b/.moai/specs/SPEC-PORTAL-KB-MEMBERS-CLEANUP-001/spec.md
@@ -1,0 +1,90 @@
+---
+id: SPEC-PORTAL-KB-MEMBERS-CLEANUP-001
+version: 0.1.0
+status: draft
+created: 2026-05-13
+author: Mark Vletter
+priority: medium
+parent: SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 (god-component § Follow-ups, carved out)
+related: []
+rule:
+  - .claude/rules/klai/projects/portal-frontend.md § "File organization for shared types and helpers"
+---
+
+# SPEC-PORTAL-KB-MEMBERS-CLEANUP-001 — Split $kbSlug/members.tsx (497 lines, 10 inline mutations — densest per line)
+
+## Goal
+
+Reduce `klai-portal/frontend/src/routes/app/knowledge/$kbSlug/members.tsx`
+from 497 lines to a route shell + per-row component + extracted
+mutation hooks. **Densest mutation-per-line ratio of any candidate**
+(10 mutations in 497 lines = 1 mutation per ~50 lines).
+
+This SPEC is **draft**. Low churn (15 commits / 90 days) means it's
+not actively painful — but the structural density makes any future
+edit risky.
+
+## Motivation metrics
+
+| Metric | Value |
+|---|---|
+| File line count | 497 |
+| useState | 7 |
+| useEffect | 0 |
+| Inline mutations | **10 (densest mutations-per-line)** |
+| Inline queries | (TBD) |
+| Git churn last 90 days | 15 commits (low) |
+| Last touched | 11 hours ago at SPEC creation |
+| Production-critical | Yes (KB membership management — RBAC) |
+
+10 mutations almost certainly cover: invite-user, invite-group,
+revoke-user, revoke-group, change-role-user, change-role-group,
+accept-invite, decline-invite, leave-kb, transfer-ownership (or
+similar 10-action set). Each becomes its own hook.
+
+## Scope (proposed)
+
+### In
+
+- New `_components/MemberRow.tsx`: per-row affordances (role select,
+  remove, transfer)
+- New `_components/InviteSection.tsx`: invite form/banner
+- New `-members-hooks.ts`: 10 mutation hooks (one per action)
+- Modify `members.tsx`: route shell + table + invite-section
+  composition
+
+### Out
+
+- Backend RBAC / membership API changes
+- Adding new member actions (e.g. bulk-invite, group-merge)
+- Permission model changes
+
+## Approach
+
+DDD methodology. The 10 mutations form a clear extraction target.
+ANALYZE: confirm each mutation's distinct concern (no duplicates
+disguised as different names).
+
+PRESERVE: characterization tests for each role transition + invite
+flow. RBAC is sensitive — wrong role = wrong permissions in
+production.
+
+## Learnings to apply
+
+- File-organization rule + ESLint rule
+- DDD characterization tests cover each role-transition path
+  (RBAC = test coverage matters)
+- `_components/` and `-`-prefixed siblings already established in
+  `$kbSlug/` directory (existing precedent)
+- Triplicate check vs `-kb-helpers.tsx` (`SyncStatusBadge` etc. live
+  there — any new shared symbols may belong there too)
+- Live verification on Voys with a real KB
+- scale-the-answer: own SPEC
+
+## See Also
+
+- `.moai/specs/SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001/spec.md`
+- `.moai/specs/SPEC-PORTAL-KB-OWNERSHIP-001` (recently merged —
+  related membership work, verify no overlap)
+- `.claude/rules/klai/projects/portal-frontend.md` § "File
+  organization for shared types and helpers"

--- a/.moai/specs/SPEC-PORTAL-KB-NEW-CLEANUP-001/spec.md
+++ b/.moai/specs/SPEC-PORTAL-KB-NEW-CLEANUP-001/spec.md
@@ -1,0 +1,108 @@
+---
+id: SPEC-PORTAL-KB-NEW-CLEANUP-001
+version: 0.1.0
+status: draft
+created: 2026-05-13
+author: Mark Vletter
+priority: medium
+parent: SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 (god-component § Follow-ups, carved out)
+related:
+  - SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 (the connector wizards in $kbSlug_.add-connector.tsx are sibling multi-step wizards — share patterns)
+rule:
+  - .claude/rules/klai/projects/portal-frontend.md § "File organization for shared types and helpers"
+---
+
+# SPEC-PORTAL-KB-NEW-CLEANUP-001 — Split knowledge/new.tsx (713 lines, multi-step KB-creation wizard)
+
+## Goal
+
+Reduce `klai-portal/frontend/src/routes/app/knowledge/new.tsx` from
+713 lines to a route shell + per-step sub-components + shared types.
+Multi-step KB-creation wizard, similar pattern to the connector
+wizards.
+
+This SPEC is **draft**. Note that `new.tsx` already has companion
+files (`new._types.ts` exists), so the colocation pattern is partially
+applied. Annotation cycle should determine the remaining split.
+
+## Motivation metrics
+
+| Metric | Value |
+|---|---|
+| File line count | 713 |
+| useState | 4 |
+| useEffect | 0 |
+| Inline mutations | 4 |
+| Inline queries | (TBD) |
+| Git churn last 90 days | 28 commits |
+| Last touched | 2 days ago at SPEC creation |
+| Production-critical | Yes (KB creation flow — every new KB) |
+| Existing colocation | `new._types.ts` already exists |
+
+The relatively low useState count (4) suggests state is already
+contained per step. The 713 lines = mostly JSX of multi-step wizard
+pages. Likely the right extraction is per-step components (`<DetailsStep>`,
+`<ConnectorChoiceStep>`, `<ConfirmStep>`, etc.) similar to how the
+connector wizards are now organized.
+
+## Scope (proposed — annotation cycle confirms)
+
+### In
+
+- New `new._components/Step1Details.tsx`, `Step2Members.tsx`, etc.
+  — per-step components (exact step naming TBD)
+- Existing `new._types.ts` likely needs additions for newly-extracted
+  step state shapes
+- New `new._wizard-hooks.ts`: 4 mutation hooks (create-KB,
+  invite-members, etc.)
+- Modify `new.tsx`: route shell + step orchestration only
+
+### Out
+
+- Backend KB-creation API changes
+- Adding new wizard steps
+- Permission / role-related changes
+
+## Approach
+
+DDD methodology. The wizard pattern is similar to add-connector
+(extracted in SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001). Re-use those
+patterns:
+1. Worktree + characterization tests for full create-KB happy path
+2. Extract per-step components into `new._components/`
+3. Extract mutation hooks into `new._wizard-hooks.ts`
+4. Reduce `new.tsx` to ≤ 200 lines (route + step machine + assembly)
+5. Verify gates + Playwright on `/app/knowledge/new`
+
+## Special pattern: `_types.ts` already exists
+
+`new._types.ts` is the precedent for `<route>._<feature>` colocation
+in this directory. New colocation files should follow the same pattern:
+- `new._components/` (directory of step components)
+- `new._wizard-hooks.ts` (alongside `new._types.ts`)
+
+This is the `<route>._<feature>` pattern from the file-organization
+rule's decision tree (TanStack ignores `._` infix segments).
+
+## Learnings to apply
+
+- File-organization rule's clause for `<route>._<feature>` colocation
+  applies here directly.
+- ESLint rule `klai/no-cross-route-import` already prevents
+  regressions.
+- Connector wizards (SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001) used
+  Notion union pattern (Option A — names retained, no mode tag) for
+  subtly-divergent shapes. If KB-creation has similar divergent
+  shapes (e.g. "personal KB" vs "org KB"), use the same pattern.
+- DDD methodology with characterization tests covering full
+  happy-path flow.
+- scale-the-answer: own SPEC, no bundling.
+
+## See Also
+
+- `.moai/specs/SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001/spec.md` —
+  reference for multi-step wizard extraction pattern.
+- `klai-portal/frontend/src/routes/app/knowledge/new._types.ts` —
+  existing colocation precedent.
+- `.claude/rules/klai/projects/portal-frontend.md` § "File
+  organization for shared types and helpers"

--- a/.moai/specs/SPEC-PORTAL-MFA-SETUP-CLEANUP-001/spec.md
+++ b/.moai/specs/SPEC-PORTAL-MFA-SETUP-CLEANUP-001/spec.md
@@ -1,0 +1,112 @@
+---
+id: SPEC-PORTAL-MFA-SETUP-CLEANUP-001
+version: 0.1.0
+status: draft
+created: 2026-05-13
+author: Mark Vletter
+priority: medium
+parent: SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 (god-component § Follow-ups, carved out)
+related: []
+rule:
+  - .claude/rules/klai/projects/portal-frontend.md § "File organization for shared types and helpers"
+---
+
+# SPEC-PORTAL-MFA-SETUP-CLEANUP-001 — Refactor setup/mfa.lazy.tsx (668 lines, 19 useState — worst structure in repo)
+
+## Goal
+
+Reduce `klai-portal/frontend/src/routes/setup/mfa.lazy.tsx` from
+668 lines + 19 useState to a state-machine-driven multi-step setup
+flow. **Highest useState count in the entire frontend** — strong
+signal that the file needs `useReducer` consolidation, not just
+component extraction.
+
+This SPEC is **draft**. Annotation cycle MUST first map the 19
+useState slots into a state machine before any refactor begins.
+
+## Motivation metrics
+
+| Metric | Value |
+|---|---|
+| File line count | 668 |
+| useState | **19 (highest in entire frontend)** |
+| useEffect | 3 |
+| Inline mutations | 0 |
+| Git churn last 90 days | 16 commits (low — file is stable) |
+| Last touched | 2 days ago at SPEC creation |
+| Production-critical | Yes (MFA setup — security-critical) |
+
+The LOW churn signals that the file is stable but **structurally
+worst**. This is "stable pain" — works in production, but every time
+someone touches it they hit cognitive load. Worth fixing because the
+fix lasts (low rate of re-emerging god-state).
+
+19 useState in one component is almost certainly NOT 19 independent
+flags. It's a state machine pretending to be flags. ANALYZE phase
+should produce a state-transition diagram; the refactor turns it
+into a `useReducer` or XState machine.
+
+## Scope (proposed — annotation cycle MUST decide state-machine pattern first)
+
+### In
+
+- ANALYZE deliverable: state-transition diagram for the 19 useStates
+  (which combinations are valid, which are mutually exclusive)
+- Refactor to `useReducer` (most likely) or XState (if state-transition
+  count justifies the dependency)
+- Per-step sub-components in `setup/_components/`:
+  - `<MfaIntroStep>`, `<TotpEnrollStep>`, `<RecoveryCodesStep>`,
+    `<ConfirmStep>` (exact steps TBD)
+- Modify `mfa.lazy.tsx`: route shell + state machine + step
+  composition
+
+### Out
+
+- Backend MFA / TOTP API changes
+- Adding new MFA factors (WebAuthn, SMS — separate feature SPECs)
+- Changing security model
+
+## Approach
+
+DDD methodology. **ANALYZE phase is the most important phase here**:
+the 19 useState reflect undocumented business logic. Get the state
+machine right BEFORE writing any refactor commit.
+
+PRESERVE phase: characterization tests for every MFA setup path
+(happy path, recovery code regeneration, abort mid-flow, etc.). MFA is
+security-critical — behavior preservation is non-negotiable.
+
+IMPROVE phase: incremental.
+
+## Special note: security-critical area
+
+MFA setup is in the auth perimeter. Any refactor needs:
+- Security review (delegate to expert-security or klai-security-audit
+  agent post-refactor)
+- Live verification on a NON-PRODUCTION tenant first if possible
+- Explicit user acknowledgment in PR description that the refactor is
+  behavior-preserving
+
+## Learnings to apply
+
+- File-organization rule + ESLint rule
+- DDD methodology with comprehensive characterization tests
+  (security-critical = test coverage matters)
+- `useReducer` consolidation pattern (annotation cycle decides if
+  XState is justified — likely overkill for one form)
+- Live verification on production after deploy (test setup flow with
+  a real user account)
+- **Security review** post-refactor (klai-security-audit agent)
+- scale-the-answer: own SPEC
+- previous-deploy-failure-blocks-yours: setup/ files are deploy-
+  triggers, double-check main CI before pushing
+
+## See Also
+
+- `.moai/specs/SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001/spec.md`
+- `.moai/specs/SPEC-AUTH-TOTP-POPORDER-001` (related TOTP work — verify
+  no regression of fixes shipped there)
+- `.claude/rules/klai/projects/portal-frontend.md` § "File
+  organization for shared types and helpers"
+- `.claude/rules/klai/projects/portal-security.md` (if exists, for
+  auth-perimeter conventions)

--- a/.moai/specs/SPEC-PORTAL-TAXONOMY-EXTRACT-001/spec.md
+++ b/.moai/specs/SPEC-PORTAL-TAXONOMY-EXTRACT-001/spec.md
@@ -1,0 +1,299 @@
+---
+id: SPEC-PORTAL-TAXONOMY-EXTRACT-001
+version: 0.1.0
+status: ready
+created: 2026-05-13
+author: Mark Vletter
+priority: high
+parent: SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 (deferred-fix marker in insights.tsx points here)
+related:
+  - SPEC-PORTAL-TAXONOMY-SPLIT-001 (sibling — interior split of TaxonomyTab; this SPEC is the prerequisite move)
+  - SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 (origin of the file-organization rule + ESLint guard this SPEC applies)
+rule:
+  - .claude/rules/klai/projects/portal-frontend.md § "File organization for shared types and helpers"
+---
+
+# SPEC-PORTAL-TAXONOMY-EXTRACT-001 — Move TaxonomyTab from taxonomy.tsx (route) to _components/
+
+## Goal
+
+Move the `TaxonomyTab` function (~720 lines, currently inside the
+`taxonomy.tsx` route file) verbatim into
+`klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/TaxonomyTab.tsx`.
+Update both consumers (`taxonomy.tsx` and `insights.tsx`) to import
+from the new location. Remove the `eslint-disable-next-line` +
+TODO comment in `insights.tsx` that was the deferred-fix marker for
+exactly this work (left behind by the SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001
+followups).
+
+This SPEC is **pure file relocation, zero behavior change**. The
+720-line function body moves intact; no internal refactor, no
+sub-component extraction, no hook extraction. Those are
+SPEC-PORTAL-TAXONOMY-SPLIT-001 territory.
+
+## Motivation
+
+### The deferred marker
+
+`insights.tsx` currently contains:
+
+```ts
+// TODO: F-table row 1 of SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 § Follow-ups
+// will extract TaxonomyTab (currently a 720-line god-component inside
+// ./taxonomy.tsx) to _components/TaxonomyTab.tsx. Splitting that monolith
+// deserves its own SPEC. Until then, this single cross-route import is
+// the deferred-fix marker.
+// eslint-disable-next-line klai/no-cross-route-import
+import { TaxonomyTab } from './taxonomy'
+```
+
+That comment is the explicit "this is a known smell, the SPEC for
+fixing it is documented" pointer. Eslint-disable-next-line markers age
+poorly — every week they sit there, the chance someone copies the
+pattern increases ("oh, you can just disable the rule"). Closing this
+marker quickly preserves the rule's authority.
+
+### Mechanical signals
+
+`taxonomy.tsx` is the highest-pain god-component in the repo:
+
+| Metric | Value |
+|---|---|
+| File line count | 1088 |
+| TaxonomyTab function body | ~720 lines (66% of file) |
+| Inline mutations | 8 |
+| Inline queries | 4 |
+| useState calls | 16 |
+| useCallback / useMemo | 0 |
+| Inline JSX in proposals.map() callback | 166 lines |
+| Git churn last 90 days | 44 commits (highest in survey) |
+| Cross-imported by | insights.tsx (the eslint-disable) |
+| Last touched | 11 hours ago at SPEC time |
+
+The file is being actively edited and the cross-route import is
+literally an open wound the rule is forced to ignore.
+
+### Why move now, split later
+
+Moving the function body to `_components/TaxonomyTab.tsx` is a
+mechanically simple, behavior-preserving relocation. The pattern is
+proven: SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 followups (PR #620)
+did the exact same thing for `KBOverviewSections` (extracted from
+`overview.tsx` to `_components/KBOverviewSections.tsx`). Same
+directory, same convention.
+
+Splitting the 720-line body into `<ProposalCard>`, `<TaxonomyTree>`,
+extracted mutation hooks, etc. is a different beast — real refactor
+risk on a god-component with 16 useState and 8 inline mutations.
+That work is SPEC-PORTAL-TAXONOMY-SPLIT-001, scheduled when concrete
+feature pressure picks it up (per scale-the-answer: don't preemptively
+split monoliths that aren't in your path).
+
+## Scope
+
+### In
+
+**Frontend** (`klai-portal/frontend/src/routes/app/knowledge/$kbSlug/`):
+
+- New file `_components/TaxonomyTab.tsx`:
+  - Contains the verbatim body of the current `TaxonomyTab` function
+    (currently inside `taxonomy.tsx`)
+  - All currently-inline imports the function needs (lucide icons,
+    React Query hooks, `apiFetch`, paraglide messages, type imports
+    from `-kb-types`, etc.) move with it
+  - JSDoc header explains: "Extracted from taxonomy.tsx route file
+    so insights.tsx can consume it without violating
+    klai/no-cross-route-import. Internal split into sub-components
+    is tracked under SPEC-PORTAL-TAXONOMY-SPLIT-001."
+
+- Modify `taxonomy.tsx`:
+  - Reduces to a route-shell (~30 lines): imports `TaxonomyTab` from
+    `./_components/TaxonomyTab`, exports `Route` with
+    `component: TaxonomyTab` (or wraps it in the existing
+    `<RoleGuard>` if the route already does that)
+  - All other imports the route used only for TaxonomyTab go away
+    (since they moved with the function body)
+
+- Modify `insights.tsx`:
+  - Remove the entire `TODO: F-table row 1 ...` comment block
+  - Remove the `eslint-disable-next-line klai/no-cross-route-import`
+    line
+  - Change `from './taxonomy'` to `from './_components/TaxonomyTab'`
+
+### Out (explicit)
+
+- **TaxonomyTab interior split** — sub-component extraction
+  (`<ProposalCard>`, `<TaxonomyTree>`, `<TaxonomyToolbar>`),
+  mutation hook extraction (`-taxonomy-hooks.ts`), useCallback /
+  useMemo introduction. All tracked under
+  SPEC-PORTAL-TAXONOMY-SPLIT-001 with characterization-test
+  discipline (DDD).
+- **Touching the `proposals.map()` 166-line inline JSX**. That's the
+  obvious first target for the SPLIT SPEC; this MOVE SPEC leaves it
+  exactly as-is.
+- **Coverage gaps inside TaxonomyTab**. Whatever tests exist today
+  continue to pass; no new tests added in this SPEC.
+- **Performance work**. Adding useCallback/useMemo for stable closure
+  identity is part of the SPLIT SPEC, not this one.
+
+### Backend changes summary
+
+None. Frontend file move only. No alembic migration, no API change,
+no env var, no SPEC-DB linkage.
+
+## Requirements (EARS)
+
+### Functional
+
+- **REQ-1**: When a contributor opens
+  `klai-portal/frontend/src/routes/app/knowledge/$kbSlug/taxonomy.tsx`
+  after this SPEC, the file shall NOT contain the `TaxonomyTab`
+  function body. It shall contain only the `Route` definition (and
+  any TanStack Router boilerplate) plus an import of `TaxonomyTab`
+  from `./_components/TaxonomyTab`.
+
+- **REQ-2**: When a contributor opens
+  `klai-portal/frontend/src/routes/app/knowledge/$kbSlug/insights.tsx`
+  after this SPEC, the file shall NOT contain the
+  `eslint-disable-next-line klai/no-cross-route-import` directive
+  NOR the `TODO: F-table row 1 ...` comment block. The
+  `TaxonomyTab` import shall come from
+  `'./_components/TaxonomyTab'`.
+
+- **REQ-3**: When the user navigates to the Taxonomie tab on a KB
+  detail page, the rendered DOM shall be byte-identical to the
+  pre-SPEC behavior (no visual or interactive change).
+
+- **REQ-4**: When the user navigates to the Inzichten tab on a KB
+  detail page, the rendered DOM shall be byte-identical to the
+  pre-SPEC behavior (TaxonomyTab section renders unchanged inside
+  the InsightsTab composition).
+
+### Non-functional
+
+- **REQ-5**: After this SPEC, `tsc --noEmit` on
+  `klai-portal/frontend` shall pass with zero errors. `eslint .`
+  shall pass with zero errors and zero new warnings.
+
+- **REQ-6**: After this SPEC, `vitest run` shall report the same
+  pass count as the pre-SPEC baseline. No assertion changes.
+
+- **REQ-7**: After this SPEC, line counts shall satisfy:
+  - `taxonomy.tsx`: ≤ 60 lines (down from 1088)
+  - `_components/TaxonomyTab.tsx`: 980-1080 lines (the function body
+    + its imports + JSDoc — upper bound generous because we're
+    moving the whole thing as-is, not refactoring)
+  - `insights.tsx`: ~28-32 lines (down from 36, since the eslint-
+    disable comment block goes away)
+
+- **REQ-8**: `git grep -n "eslint-disable-next-line klai/no-cross-route-import" klai-portal/frontend/src` shall return zero hits after this SPEC. The deferred-fix marker is gone.
+
+## Acceptance Criteria
+
+1. New file `klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/TaxonomyTab.tsx` exists and contains the moved `TaxonomyTab` function plus required imports.
+2. `taxonomy.tsx` reduced to route shell (`wc -l` ≤ 60).
+3. `insights.tsx` has no eslint-disable; `git grep "eslint-disable-next-line klai/no-cross-route-import"` returns zero hits.
+4. `tsc --noEmit` zero errors. `eslint .` zero errors. `bun run build` green.
+5. `vitest run` same pass count as baseline.
+6. Playwright smoke (Voys tenant): open Taxonomie tab on Support KB → verify proposals render; open Inzichten tab on same KB → verify TaxonomyTab section renders identically. Screenshots saved.
+7. `git diff --stat` shows: 1 file added (`_components/TaxonomyTab.tsx`), 2 files modified (`taxonomy.tsx`, `insights.tsx`). `routeTree.gen.ts` byte-identical (TanStack ignores `_components/`).
+
+## Implementation Plan
+
+Pure-extraction PR with these commits, each independently green:
+
+### Phase 0 — Worktree + baseline
+
+- `git worktree add ../klai-taxonomy-extract -b feat/SPEC-PORTAL-TAXONOMY-EXTRACT-001 origin/main`
+- Capture baseline: `wc -l taxonomy.tsx insights.tsx` and pre-SPEC vitest pass count.
+
+### Phase 1 — Move TaxonomyTab to _components/ (single commit)
+
+- Cut the entire `TaxonomyTab` function body (currently lines ~370-1087 of taxonomy.tsx, exact range to be confirmed at execution time) along with its required imports.
+- Paste into new file `_components/TaxonomyTab.tsx` with a JSDoc header.
+- In `taxonomy.tsx`: remove the function and now-unused imports; add `import { TaxonomyTab } from './_components/TaxonomyTab'`; ensure `Route.component` references the imported function.
+- In `insights.tsx`: change import path; remove the eslint-disable comment block.
+- Verify: `tsc --noEmit` clean, `eslint .` clean, `vitest run __tests__/` pass count unchanged.
+
+### Phase 2 — QA + ship
+
+- `bun run lint` zero errors.
+- `bun run build` green.
+- Full vitest suite passes.
+- Playwright smoke on Voys tenant: Support KB → Taxonomie tab → screenshot. Same KB → Inzichten tab → screenshot. Compare against pre-SPEC: pixel-identical.
+- PR with checklist below.
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| TaxonomyTab uses an import that exists only in `taxonomy.tsx` and isn't moved with it | Medium — 720 lines = many imports | Medium | `tsc --noEmit` catches every missing import. Resolve by tracing each undefined identifier and either moving its import or adding it. |
+| Closure dependency: function body references something in `taxonomy.tsx`'s module scope (a const or another local function) | Low — code review of the function body should confirm self-contained | Medium | Phase 1 commit message lists every external reference resolved. If a non-import dependency appears, move it too. |
+| Route component re-render behavior subtly differs after the move (e.g. memoization boundaries) | Very low — JS function identity preserved by single-import pattern | Low | Playwright verification specifically watches for re-render symptoms (form state loss, scroll position). |
+| `routeTree.gen.ts` regenerates with noise (TanStack picks up _components/) | Very low — `_components/` is the standard ignored convention; precedent in same dir | Low | Verify `routeTree.gen.ts` byte-identical via `git diff --stat`. |
+| Concurrent edit on taxonomy.tsx during the SPEC merges into a conflict | Medium — 44 commits in 90 days = active file | Medium | Rebase before merge. If conflict in TaxonomyTab body itself: take origin/main version (incoming changes are real product work) and replay our move on top. |
+
+## PR Description Checklist
+
+- [ ] No backend changes. No alembic migration. No API change. No env var.
+- [ ] New file `_components/TaxonomyTab.tsx` contains the verbatim `TaxonomyTab` function.
+- [ ] `wc -l klai-portal/frontend/src/routes/app/knowledge/\$kbSlug/taxonomy.tsx` ≤ 60.
+- [ ] `git grep "eslint-disable-next-line klai/no-cross-route-import" klai-portal/frontend/src` zero hits.
+- [ ] `git grep "F-table row 1 of SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001"` zero hits (the TODO marker is gone).
+- [ ] `tsc --noEmit` clean. `eslint .` clean. `bun run build` green.
+- [ ] `vitest run` same pass count as pre-SPEC baseline.
+- [ ] Playwright smoke verified on Voys: Taxonomie tab + Inzichten tab render identically. Screenshots attached.
+- [ ] `routeTree.gen.ts` byte-identical (verify via `git diff --stat`).
+
+## Open Questions
+
+1. **Should the JSDoc header on the moved file mention the SPLIT SPEC?**
+   Yes — recommend including: "Internal split into sub-components is
+   tracked under SPEC-PORTAL-TAXONOMY-SPLIT-001". This makes the
+   727-line monolith's deferred work discoverable from the file
+   itself.
+
+2. **Other files in `taxonomy.tsx` besides TaxonomyTab?** Need to
+   confirm at execution time. If `taxonomy.tsx` exports more than
+   just the route + TaxonomyTab, those other exports stay in
+   `taxonomy.tsx` (or move per the file-organization rule).
+
+## Learnings to apply (from SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001)
+
+This SPEC follows the patterns proven by the connector-wizard
+extract. Re-use, don't re-discover:
+
+- **File-organization rule** (`portal-frontend.md` § "File organization
+  for shared types and helpers") already documents the `_components/`
+  convention this SPEC applies. No new rule needed.
+- **klai/no-cross-route-import ESLint rule** (already shipped in #620)
+  catches regressions automatically — the test that the SPEC succeeds
+  is partly that the rule passes after the move.
+- **`_components/` precedent**: `KBOverviewSections.tsx` was moved
+  from `overview.tsx` to `_components/KBOverviewSections.tsx` in #620.
+  Identical pattern, identical directory, identical mechanism.
+- **Verify gates after EACH commit** (tsc + lint + tests). Bisectable
+  history is more valuable than commit-count economy.
+- **Symlink node_modules + paraglide** from main checkout into the
+  worktree before running gates — saves a full `npm install`.
+- **Live verification on Voys** is the AC10 step. Don't rely solely
+  on tsc/tests for a UI-visible move.
+- **Rebase before merge** if upstream has moved (44 commits in 90
+  days = high concurrent edit probability).
+- **previous-deploy-failure-blocks-yours** (process-rules.md) — check
+  `gh run list --branch main --limit 5` before pushing to make sure a
+  prior PR's deploy failure isn't going to block this PR's deploy.
+- **Don't bundle this with the SPLIT SPEC** — scale-the-answer: one
+  job, one PR.
+
+## See Also
+
+- `.moai/specs/SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001/spec.md` —
+  origin of the file-organization rule + the deferred-fix marker
+  this SPEC closes.
+- `klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/KBOverviewSections.tsx` —
+  the precedent this SPEC mirrors.
+- `klai-portal/frontend/eslint-rules/no-cross-route-import.js` —
+  the rule whose `eslint-disable-next-line` this SPEC eliminates.
+- `.claude/rules/klai/projects/portal-frontend.md` § "File
+  organization for shared types and helpers" — the rule.

--- a/.moai/specs/SPEC-PORTAL-TAXONOMY-SPLIT-001/spec.md
+++ b/.moai/specs/SPEC-PORTAL-TAXONOMY-SPLIT-001/spec.md
@@ -1,0 +1,282 @@
+---
+id: SPEC-PORTAL-TAXONOMY-SPLIT-001
+version: 0.1.0
+status: draft
+created: 2026-05-13
+author: Mark Vletter
+priority: medium
+parent: SPEC-PORTAL-TAXONOMY-EXTRACT-001 (prerequisite — TaxonomyTab must already live in _components/)
+related:
+  - SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 (origin of file-organization rule + ESLint guard)
+rule:
+  - .claude/rules/klai/projects/portal-frontend.md § "File organization for shared types and helpers"
+---
+
+# SPEC-PORTAL-TAXONOMY-SPLIT-001 — Internal split of TaxonomyTab god-component
+
+## Goal
+
+Split the 720-line `TaxonomyTab` god-component (extracted to
+`_components/TaxonomyTab.tsx` by the prerequisite SPEC-PORTAL-TAXONOMY-EXTRACT-001)
+into focused sub-components and extracted hooks, **with behavior
+preservation** (DDD methodology). Target end state:
+
+- `TaxonomyTab.tsx`: ≤ 250 lines (state composition + sub-component
+  orchestration only)
+- `_components/ProposalCard.tsx`: ~150-200 lines (currently the
+  166-line inline `proposals.map()` callback)
+- `_components/TaxonomyTree.tsx`: ~100-150 lines (the tree rendering
+  + node selection)
+- `_components/TaxonomyToolbar.tsx`: ~50-80 lines (action bar)
+- `-taxonomy-hooks.ts`: ~150-250 lines (8 mutation hooks)
+- 0 cross-route imports (already enforced by ESLint rule)
+- All existing tests pass (235/235); coverage equal-or-better
+
+This SPEC is **draft** — needs annotation cycle before pickup. The
+720-line function has 16 useState + 8 inline mutations + 4 inline
+queries; splitting it requires careful behavior-preservation
+(characterization tests, mutation prop drilling vs context, etc.).
+
+## Motivation
+
+After SPEC-PORTAL-TAXONOMY-EXTRACT-001 lands, TaxonomyTab will live in
+`_components/TaxonomyTab.tsx` but still be 720 lines internally.
+That's the move SPEC's deliberate scope (mechanical relocation only).
+
+The internal split is where the actual code-quality win happens:
+
+| Today (post-EXTRACT) | Post-SPLIT target |
+|---|---|
+| 1 file, 720 lines | 5 files, 150-250 lines each |
+| 1 god-function holding 16 useState | TaxonomyTab orchestrator + sub-components with focused state |
+| 8 mutations declared inline in function body | 8 hooks in `-taxonomy-hooks.ts`, consumed by sub-components |
+| 4 inline queries | Same hooks pattern |
+| 166-line inline `proposals.map()` JSX | `<ProposalCard>` component with own props |
+| 0 useCallback/useMemo (every render rebuilds every closure) | useCallback on stable callbacks, useMemo on derived data |
+
+This is a real refactor — not a relocation. Behavior preservation is
+non-trivial because the 16 useState forms an implicit state machine
+that needs to be either:
+- Distributed correctly across sub-components (each owning its own
+  state)
+- OR consolidated into a `useReducer` (probably the right answer
+  given the cross-coupling)
+- OR kept centrally with prop-drilling (works but verbose)
+
+## Motivation metrics
+
+| Metric | Value |
+|---|---|
+| TaxonomyTab function lines | ~720 |
+| useState | 16 |
+| Inline mutations | 8 (`createNodeMutation`, `deleteNodeMutation`, `renameNodeMutation`, `approveMutation`, `rejectMutation`, `bootstrapMutation`, `backfillMutation`, `applyAllMutation`) |
+| Inline queries | 4 (`coverageQuery`, `nodesQuery`, `proposalsQuery`, `topTagsQuery`) |
+| Inline JSX (proposals.map callback) | 166 lines |
+| useCallback / useMemo | 0 |
+| Git churn last 90 days | 44 commits |
+| Production-critical | Yes (Inzichten + Taxonomie tab) |
+
+## Scope (initial draft — needs annotation cycle)
+
+### In (proposed)
+
+**Frontend** (`klai-portal/frontend/src/routes/app/knowledge/$kbSlug/`):
+
+- New `_components/ProposalCard.tsx`:
+  - Extract the 166-line `proposals.map()` callback into a focused
+    component
+  - Props: `proposal` + per-proposal mutation callbacks
+  - Owns: editing state for that specific proposal
+    (`editingProposalTitle`, `editingProposalDescription`,
+    `rejectingProposalId`, `rejectReason`)
+
+- New `_components/TaxonomyTree.tsx`:
+  - Extract tree rendering + node-selection logic
+  - Props: `nodes`, `activeNodeId`, `onNodeClick`, `onNodeAdd`, etc.
+  - Owns: `addParentId`, `newNodeName`, `showAddRoot`,
+    `isAddingChild`
+
+- New `_components/TaxonomyToolbar.tsx`:
+  - Extract action-bar (suggest, bootstrap, backfill, apply-all)
+  - Props: state of in-flight mutations + handlers
+
+- New `-taxonomy-hooks.ts`:
+  - 8 mutation hooks: `useCreateNode`, `useDeleteNode`, `useRenameNode`,
+    `useApproveProposal`, `useRejectProposal`, `useBootstrapTaxonomy`,
+    `useBackfillTaxonomy`, `useApplyAllProposals`
+  - 4 query hooks: `useTaxonomyNodes`, `useTaxonomyProposals`,
+    `useTaxonomyCoverage`, `useTopTags`
+  - Each hook contains the same `mutationFn` / `queryFn` body that
+    currently lives inline in TaxonomyTab. Pure relocation per hook.
+
+- Modify `_components/TaxonomyTab.tsx` (the orchestrator):
+  - State: 16 → maybe 4-6 (most state moves into sub-components)
+  - Body: ≤ 250 lines (orchestration + composition only)
+  - Optionally introduce `useReducer` if the remaining cross-coupled
+    state benefits from it (annotation cycle decides)
+
+### Out (explicit)
+
+- **Adding new functionality**. This SPEC preserves behavior; it does
+  not improve UX, add features, or change APIs.
+- **Refactoring backend taxonomy endpoints**. They stay as-is.
+- **Changing query patterns** (e.g. moving from React Query to
+  another lib). Out of scope.
+- **Adding new tests beyond characterization tests for the existing
+  behavior**. Coverage delta should be neutral-or-positive but is
+  not the goal.
+
+### Backend changes summary
+
+None.
+
+## Approach (DDD methodology — required)
+
+This is a behavior-preservation refactor on production-critical code.
+Use the DDD ANALYZE-PRESERVE-IMPROVE cycle:
+
+1. **ANALYZE**: Read every line of TaxonomyTab. Document the implicit
+   state machine (which useState combinations are valid, which are
+   invariants). Map data flow: which mutations invalidate which
+   queries, which proposals.map() branches render under which
+   conditions.
+
+2. **PRESERVE**: Add characterization tests BEFORE any refactor:
+   - Each mutation's success / failure path
+   - Each rendering branch (proposal types: rename, create-child,
+     update-prompt, approve, reject)
+   - Edit-mode state transitions
+   - Tree expand/collapse + active node tracking
+
+3. **IMPROVE**: Refactor in small commits, each green:
+   - Commit 1: Extract `-taxonomy-hooks.ts` (queries + mutations).
+     TaxonomyTab consumes the hooks but JSX unchanged.
+   - Commit 2: Extract `<ProposalCard>` from the 166-line
+     `proposals.map()` callback.
+   - Commit 3: Extract `<TaxonomyTree>`.
+   - Commit 4: Extract `<TaxonomyToolbar>`.
+   - Commit 5 (optional): Introduce `useReducer` if remaining state
+     is cross-coupled enough to warrant it.
+   - Commit 6: Add useCallback to handlers passed to memo-able
+     children. Add useMemo to derived data (filtered proposals,
+     active node lookup).
+
+Each commit: tsc + eslint + vitest + characterization tests green.
+
+## Requirements (EARS) — placeholder, expand in annotation cycle
+
+- **REQ-1**: When TaxonomyTab is opened on a KB with N proposals, the
+  user shall see exactly the same set of proposals in the same order
+  with the same per-proposal affordances (edit / approve / reject)
+  as pre-SPEC.
+- **REQ-2**: When a contributor approves a proposal, the system shall
+  invalidate the same query keys and trigger the same UI transitions
+  as pre-SPEC.
+- **REQ-3**: When a contributor edits a proposal's title and saves, the
+  edit-mode state shall behave identically (cancel restores original;
+  enter saves; loading disables).
+- **REQ-4**: TaxonomyTab.tsx shall be ≤ 250 lines after this SPEC.
+- **REQ-5**: All sub-components shall be in the `_components/`
+  directory adjacent to TaxonomyTab.tsx.
+- **REQ-6**: All mutation/query hooks shall be in
+  `-taxonomy-hooks.ts` adjacent to taxonomy.tsx (the route file).
+
+(More requirements added during annotation cycle.)
+
+## Acceptance Criteria — placeholder
+
+1. Characterization test suite added in Phase ANALYZE/PRESERVE
+   (pre-refactor) all green at refactor end.
+2. `wc -l TaxonomyTab.tsx` ≤ 250.
+3. 4 new files in `_components/` (`ProposalCard.tsx`,
+   `TaxonomyTree.tsx`, `TaxonomyToolbar.tsx`, plus the existing
+   `KBOverviewSections.tsx` from prior work).
+4. New file `-taxonomy-hooks.ts` containing 8 mutation hooks + 4 query
+   hooks, each consumed by either TaxonomyTab or a sub-component.
+5. tsc + eslint + vitest all green; full vitest pass count maintained
+   or grown.
+6. Playwright on Voys: Taxonomie tab end-to-end flow (view proposals,
+   edit one, approve another, reject a third with reason) renders
+   pixel-identical and exhibits identical behavior pre-vs-post.
+7. Performance check: console-perf marker added shows no render
+   regression on a KB with 50+ proposals.
+
+## Risks (high level — annotation cycle expands)
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| useState distribution introduces a hidden bug (e.g. state lives in two places, gets out-of-sync) | High — 16 state slots interact in non-obvious ways | High | DDD characterization tests. If a test fails post-refactor, revert and rethink that piece of state. |
+| Mutation prop-drilling becomes verbose / ugly | Medium | Low | Extract `useTaxonomyMutations` hook that returns a stable object containing all 8, pass as one prop. |
+| Performance regression from sub-component re-renders | Low — React 19 + memo + useCallback should handle | Medium | Memo'd sub-components + useCallback on handlers. Phase 6 explicitly. |
+| Coverage decrease (sub-components are harder to test in isolation) | Medium | Medium | Per-sub-component tests added in PRESERVE phase. Coverage report compared pre/post. |
+| Concurrent edits on TaxonomyTab during the SPEC (44 commits / 90 days) | High — actively-edited file | High | Land EXTRACT SPEC first (small target, easy rebase). For SPLIT SPEC: short-lived branch (≤1 week from start to merge), rebase frequently, conflict-resolve in our favor (the refactor is structural). |
+| Notion / Notion-like proposal types behave subtly differently after split | Low — proposals are taxonomy-internal | Low | Characterization tests cover all proposal types. |
+
+## Open Questions
+
+1. **`useReducer` or distributed `useState`?** Annotation cycle
+   decides. Lean toward `useReducer` for the cross-coupled subset
+   (active node, active tags, editing-state) and `useState` for
+   independent flags.
+
+2. **Hook bundle vs individual hook calls?** Pass `useTaxonomyMutations()`
+   returning `{ approve, reject, create, ... }` (one call site, stable
+   object) vs eight individual calls. Lean toward bundle.
+
+3. **Should `-taxonomy-hooks.ts` co-locate with the route file
+   (`$kbSlug/-taxonomy-hooks.ts`) or with the components
+   (`$kbSlug/_components/-taxonomy-hooks.ts`)?** Per file-organization
+   rule, smallest-shared scope = `$kbSlug/` (used by TaxonomyTab and
+   any future sub-component). Place at route-directory level.
+
+4. **Do any of the 8 mutations have non-obvious cross-invalidation
+   patterns?** ANALYZE phase must document. E.g., does
+   `approveMutation` invalidate `taxonomyNodes` AND `coverage` AND
+   `proposals`? The hook extraction must preserve every invalidation.
+
+5. **Is `applyAllMutation` a special case?** It iterates over
+   proposals and approves each. Might warrant its own helper rather
+   than being a single mutation.
+
+## Learnings to apply (from SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001)
+
+This SPEC operates in the same area as the connector-wizard extract.
+Patterns proven there apply directly:
+
+- **File-organization rule** (`portal-frontend.md` § "File organization
+  for shared types and helpers") covers the `-`-prefixed sibling vs
+  `_components/` split this SPEC uses.
+- **klai/no-cross-route-import ESLint rule** prevents regression
+  automatically.
+- **`_components/` precedent**: KBOverviewSections (from #620) +
+  TaxonomyTab (from SPEC-PORTAL-TAXONOMY-EXTRACT-001) are existing
+  inhabitants.
+- **DDD methodology required**: prior SPECs used DDD (ANALYZE-PRESERVE-IMPROVE)
+  for similar behavior-preservation refactors. Required here.
+- **Phase ordering**: hook extraction first (mechanical, low-risk),
+  then sub-components (medium-risk), then state-machine consolidation
+  (highest risk). Each phase its own commit, each commit green.
+- **Live verification on Voys** is mandatory — this is production-
+  critical UX.
+- **scale-the-answer**: don't bundle this with other god-component
+  splits. Each is its own SPEC.
+- **previous-deploy-failure-blocks-yours**: check main CI before
+  pushing.
+- **Worktree-for-long-running-changes**: this SPEC is multi-day work,
+  worktree mandatory.
+- **Triplicate elimination**: before extracting hooks, grep for
+  existing canonical `useTaxonomyXxx` hooks in `-kb-helpers.tsx` or
+  similar — re-use, don't duplicate.
+
+## See Also
+
+- `.moai/specs/SPEC-PORTAL-TAXONOMY-EXTRACT-001/spec.md` —
+  prerequisite (TaxonomyTab must already be in `_components/`).
+- `.moai/specs/SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001/spec.md` —
+  origin of patterns + ESLint rule.
+- `klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/KBOverviewSections.tsx` —
+  precedent for `_components/` extraction.
+- `.claude/rules/klai/projects/portal-frontend.md` § "File
+  organization for shared types and helpers" — the rule.
+- `.claude/rules/klai/workflow/process-full.md` — DDD methodology
+  reference (if exists; otherwise see `workflow-modes.md`).

--- a/.moai/specs/SPEC-PORTAL-TRANSCRIBE-ADD-CLEANUP-001/spec.md
+++ b/.moai/specs/SPEC-PORTAL-TRANSCRIBE-ADD-CLEANUP-001/spec.md
@@ -1,0 +1,80 @@
+---
+id: SPEC-PORTAL-TRANSCRIBE-ADD-CLEANUP-001
+version: 0.1.0
+status: draft
+created: 2026-05-13
+author: Mark Vletter
+priority: medium
+parent: SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 (god-component § Follow-ups, carved out)
+related: []
+rule:
+  - .claude/rules/klai/projects/portal-frontend.md § "File organization for shared types and helpers"
+---
+
+# SPEC-PORTAL-TRANSCRIBE-ADD-CLEANUP-001 — Split transcribe/add.tsx (530 lines, 12 useState, 4 useEffect)
+
+## Goal
+
+Reduce `klai-portal/frontend/src/routes/app/transcribe/add.tsx` from
+530 lines to a route shell + extracted upload-form components + hooks.
+Mid-tier god-component — high useState count + multiple useEffects
+suggest a multi-mode form (record / upload / paste).
+
+This SPEC is **draft**. Annotation cycle confirms exact sub-form
+boundaries.
+
+## Motivation metrics
+
+| Metric | Value |
+|---|---|
+| File line count | 530 |
+| useState | 12 |
+| useEffect | 4 |
+| Inline mutations | 3 |
+| Git churn last 90 days | 22 commits |
+| Last touched | 2 days ago at SPEC creation |
+| Production-critical | Yes (Scribe upload entry point) |
+| Existing colocation | `transcribe/_components/` already exists (e.g. TranscriptionTable.tsx) |
+
+The `_components/` directory in this area is already used (precedent
+in TranscriptionTable.tsx). Extension is the obvious next step.
+
+## Scope (proposed)
+
+### In
+
+- New components in existing `transcribe/_components/`:
+  - `<RecordingForm>`, `<FileUploadForm>`, `<PasteUrlForm>` (or
+    whatever the actual upload modes are — verify in ANALYZE)
+- New `transcribe/-add-hooks.ts`: 3 mutation hooks
+- Modify `add.tsx`: route shell + mode-switcher + form composition
+
+### Out
+
+- Backend transcribe API changes
+- Adding new upload modes
+
+## Approach
+
+DDD methodology. ANALYZE first: which 4 `useEffect`s do what?
+Often `useEffect` count > 2 suggests state coordination that should
+either be a reducer or moved into sub-components.
+
+## Learnings to apply
+
+- File-organization rule + ESLint rule
+- `transcribe/_components/` already established — extend, don't
+  proliferate
+- DDD characterization tests cover each upload mode's happy path +
+  error states
+- Triplicate check vs `transcribe/_components/` exports
+- Live verification on Voys (Scribe is per-user)
+- scale-the-answer: own SPEC
+
+## See Also
+
+- `.moai/specs/SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001/spec.md`
+- `klai-portal/frontend/src/routes/app/transcribe/_components/TranscriptionTable.tsx` —
+  existing colocation precedent.
+- `.claude/rules/klai/projects/portal-frontend.md` § "File
+  organization for shared types and helpers"


### PR DESCRIPTION
Per the user's request after closing the connector-wizard refactor:
\"alle volgende godcomplex uit die spec meenemen naar de nieuwe specs\".

Each F-table row from SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 § Follow-ups now has its own SPEC document so they can be planned and prioritized independently per scale-the-answer.

## What's in this PR

**10 new SPECs** (2 detailed, 8 stubs) — pure docs, no code changes.

| Priority | SPEC | Status | Notes |
|---|---|---|---|
| HIGH | SPEC-PORTAL-TAXONOMY-EXTRACT-001 | ready | Closes the eslint-disable in insights.tsx; small mechanical move using the proven KBOverviewSections pattern |
| HIGH | SPEC-PORTAL-TAXONOMY-SPLIT-001 | draft | TaxonomyTab interior split (DDD with characterization tests) |
| MED-H | SPEC-PORTAL-ADMIN-USERS-CLEANUP-001 | draft | 33 churn / 90d, 6 inline mutations |
| MED | SPEC-PORTAL-CONNECTORS-TAB-CLEANUP-001 | draft | Borderline (425 lines) — annotation cycle may close as won't-fix |
| MED | SPEC-PORTAL-KB-NEW-CLEANUP-001 | draft | Multi-step KB creation wizard, has `new._types.ts` precedent |
| MED | SPEC-PORTAL-ADMIN-SETTINGS-CLEANUP-001 | draft | 9 mutations — densest |
| MED | SPEC-PORTAL-BILLING-CLEANUP-001 | draft | Coordinate with active PRICING-PER-USER-001 |
| MED | SPEC-PORTAL-TRANSCRIBE-ADD-CLEANUP-001 | draft | Multi-mode upload form |
| MED | SPEC-PORTAL-MFA-SETUP-CLEANUP-001 | draft | 19 useState (worst), low churn (stable pain) |
| MED | SPEC-PORTAL-KB-MEMBERS-CLEANUP-001 | draft | 10 mutations / 497 lines (densest per line) |

Plus updates to **SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001**:
- spec.md § Follow-ups F-table now references the new SPEC-IDs with status
- F-S1 marked as PARTIALLY RESOLVED, F-S3 + F-C2 marked DONE
- progress.md updated with the carved-out SPEC list

## Learnings carried into each new SPEC

Every new SPEC has a "Learnings to apply" section pointing at:
- File-organization rule (`portal-frontend.md`) + ESLint guard already in place
- KBOverviewSections + TaxonomyTab `_components/` pattern as precedent
- DDD methodology with characterization tests
- scale-the-answer (own SPEC, no bundling)
- previous-deploy-failure-blocks-yours (process-rules.md retro)
- Triplicate-elimination check vs existing `-helpers` / `-types` files

## What's NOT in this PR

- F-1 (`useConnectorWizardState` hook) and F-2 (page god-component split for AddConnectorPage / EditConnectorPage) stay as direct-followup TODOs in the parent SPEC. Reason: they're sequels to the wizard work, not independent god-component cleanups.
- F-C1 (audit existing 5 `-`-prefixed file locations) — small enough for a one-PR cleanup, not worth a SPEC.
- F-S2 (duplicate User-like types) — codebase-wide types audit territory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)