### PR TITLE
fix(portal-frontend): make sidebar logo clickable, route by context

### DIFF
--- a/klai-portal/frontend/src/components/layout/Sidebar.tsx
+++ b/klai-portal/frontend/src/components/layout/Sidebar.tsx
@@ -55,7 +55,13 @@ export function Sidebar({ navItems }: SidebarProps) {
         collapsed ? 'justify-center' : 'justify-between px-6'
       )}>
         {!collapsed && (
-          <img src="/klai-logo.svg" alt="Klai" className="h-[18px] w-auto block" />
+          <Link
+            to={inAdmin ? '/admin' : '/app'}
+            aria-label={inAdmin ? 'Admin home' : 'App home'}
+            className="inline-flex items-center transition-opacity hover:opacity-70"
+          >
+            <img src="/klai-logo.svg" alt="Klai" className="h-[18px] w-auto block" />
+          </Link>
         )}
         <button
           onClick={toggle}


### PR DESCRIPTION
## Wat

De Klai-logo links bovenin de portal sidebar deed niks bij klik. Nu wel:

- In `/admin/...` → klik logo → `/admin`
- Elders (b.v. `/app/...`) → klik logo → `/app`

## Hoe

`<img>` in `Sidebar.tsx` is gewrapt in een TanStack Router `<Link>`. De
`inAdmin` flag (`location.pathname.startsWith('/admin')`) was al
berekend voor de admin/app switcher onderaan de sidebar — hergebruikt.

- `aria-label` "Admin home" / "App home" voor screen readers
- `hover:opacity-70` als subtiele clickability-hint
- Alleen actief als sidebar uitgeklapt is (collapsed state ongewijzigd)

## Verify

- [x] ESLint clean op `Sidebar.tsx`
- [ ] CI groen
- [ ] In prod: klik in `/admin/users` → land op `/admin`
- [ ] In prod: klik in `/app/chat` → land op `/app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)