### PR TITLE
spec: flip SPEC-PORTAL-TAXONOMY-EXTRACT-001 status to done (corrects PR #627)

### DIFF
--- a/.moai/specs/SPEC-PORTAL-TAXONOMY-EXTRACT-001/spec.md
+++ b/.moai/specs/SPEC-PORTAL-TAXONOMY-EXTRACT-001/spec.md
@@ -1,8 +1,9 @@
 ---
 id: SPEC-PORTAL-TAXONOMY-EXTRACT-001
-version: 0.1.0
-status: ready
+version: 0.1.1
+status: done
 created: 2026-05-13
+completed: 2026-05-13
 author: Mark Vletter
 priority: high
 parent: SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 (deferred-fix marker in insights.tsx points here)


### PR DESCRIPTION
Tiny correction: PR #627 added progress.md saying "Status: done" but the spec.md frontmatter still said `status: ready` because an Edit tool call had failed silently. This commit flips the frontmatter to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)