### PR TITLE
[codex] Split KB creation wizard

### DIFF
--- a/.moai/specs/SPEC-PORTAL-KB-NEW-CLEANUP-001/spec.md
+++ b/.moai/specs/SPEC-PORTAL-KB-NEW-CLEANUP-001/spec.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-PORTAL-KB-NEW-CLEANUP-001
-version: 0.1.0
-status: draft
+version: 0.2.0
+status: implemented
 created: 2026-05-13
 author: Mark Vletter
 priority: medium
@@ -21,9 +21,8 @@ Reduce `klai-portal/frontend/src/routes/app/knowledge/new.tsx` from
 Multi-step KB-creation wizard, similar pattern to the connector
 wizards.
 
-This SPEC is **draft**. Note that `new.tsx` already has companion
-files (`new._types.ts` exists), so the colocation pattern is partially
-applied. Annotation cycle should determine the remaining split.
+Implemented on 2026-05-13. `new.tsx` is now 176 lines and keeps route
+orchestration only.
 
 ## Motivation metrics
 
@@ -62,6 +61,34 @@ connector wizards are now organized.
 - Backend KB-creation API changes
 - Adding new wizard steps
 - Permission / role-related changes
+
+## Implementation Summary
+
+- Extracted step JSX into route-local components under
+  `new._components/`:
+  - `-StepName.tsx`
+  - `-StepAccess.tsx`
+  - `-StepPermissions.tsx`
+  - `-StepConfirm.tsx`
+- Extracted member queries and the create-KB mutation into
+  `new._wizard-hooks.ts`.
+- Kept shared route-local state and API shapes in `new._types.ts`.
+- Added characterization coverage for create-KB payload mapping in
+  `__tests__/-new-wizard-hooks.test.ts`.
+
+## Validation
+
+- `npm run lint -- src/routes/app/knowledge/new.tsx src/routes/app/knowledge/new._wizard-hooks.ts src/routes/app/knowledge/new._types.ts src/routes/app/knowledge/new._components/-StepName.tsx src/routes/app/knowledge/new._components/-StepAccess.tsx src/routes/app/knowledge/new._components/-StepPermissions.tsx src/routes/app/knowledge/new._components/-StepConfirm.tsx src/routes/app/knowledge/__tests__/-new-wizard-hooks.test.ts`
+- `npm test -- src/routes/app/knowledge/__tests__/-new-wizard-hooks.test.ts`
+- `npx tsc -b --pretty false --force`
+- `npm run build`
+- Playwright MCP e2e on Voys tenant:
+  - created `e2e-kb-new-cleanup-20260513-092032` through
+    `/app/knowledge/new`
+  - verified redirect to
+    `/app/knowledge/e2e-kb-new-cleanup-20260513-092032/sources`
+  - deleted the test KB via `/api/app/knowledge-bases/{slug}` and
+    verified it no longer appears in the KB list API/page
 
 ## Approach
 

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -3,21 +3,26 @@ project_name: "klai"
 
 
 # list of languages for which language servers are started; choose from:
-#   al                  bash                clojure             cpp                 csharp
-#   csharp_omnisharp    dart                elixir              elm                 erlang
-#   fortran             fsharp              go                  groovy              haskell
-#   java                julia               kotlin              lua                 markdown
-#   matlab              nix                 pascal              perl                php
-#   php_phpactor        powershell          python              python_jedi         r
-#   rego                ruby                ruby_solargraph     rust                scala
-#   swift               terraform           toml                typescript          typescript_vts
-#   vue                 yaml                zig
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   swift               systemverilog       terraform           toml                typescript
+#   typescript_vts      vue                 yaml                zig
 #   (This list may be outdated. For the current list, see values of Language enum here:
 #   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
 #   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
 # Note:
 #   - For C, use cpp
 #   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
 #   - For Free Pascal/Lazarus, use pascal
 # Special requirements:
 #   Some languages require additional setup/installations.
@@ -51,8 +56,6 @@ ignore_all_files_in_gitignore: true
 # list of additional paths to ignore in this project.
 # Same syntax as gitignore, so you can use * and **.
 # Note: global ignored_paths from serena_config.yml are also applied additively.
-# These dirs contain specs, reports, and docs — not code. Excluding them prevents
-# search_for_pattern from matching hundreds of irrelevant markdown files.
 ignored_paths:
 - ".moai/specs/**"
 - ".moai/reports/**"
@@ -68,53 +71,17 @@ read_only: false
 
 # list of tool names to exclude.
 # This extends the existing exclusions (e.g. from the global configuration)
-#
-# Below is the complete list of tools for convenience.
-# To make sure you have the latest list of tools, and to view their descriptions, 
-# execute `uv run scripts/print_tool_overview.py`.
-#
-#  * `activate_project`: Activates a project by name.
-#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
-#  * `create_text_file`: Creates/overwrites a file in the project directory.
-#  * `delete_lines`: Deletes a range of lines within a file.
-#  * `delete_memory`: Deletes a memory from Serena's project-specific memory store.
-#  * `execute_shell_command`: Executes a shell command.
-#  * `find_referencing_code_snippets`: Finds code snippets in which the symbol at the given location is referenced.
-#  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
-#  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
-#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
-#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
-#  * `initial_instructions`: Gets the initial instructions for the current project.
-#     Should only be used in settings where the system prompt cannot be set,
-#     e.g. in clients you have no control over, like Claude Desktop.
-#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
-#  * `insert_at_line`: Inserts content at a given line in a file.
-#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
-#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
-#  * `list_memories`: Lists memories in Serena's project-specific memory store.
-#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
-#  * `prepare_for_new_conversation`: Provides instructions for preparing for a new conversation (in order to continue with the necessary context).
-#  * `read_file`: Reads a file within the project directory.
-#  * `read_memory`: Reads the memory with the given name from Serena's project-specific memory store.
-#  * `remove_project`: Removes a project from the Serena configuration.
-#  * `replace_lines`: Replaces a range of lines within a file with new content.
-#  * `replace_symbol_body`: Replaces the full definition of a symbol.
-#  * `restart_language_server`: Restarts the language server, may be necessary when edits not through Serena happen.
-#  * `search_for_pattern`: Performs a search for a pattern in the project.
-#  * `summarize_changes`: Provides instructions for summarizing the changes made to the codebase.
-#  * `switch_modes`: Activates modes by providing a list of their names
-#  * `think_about_collected_information`: Thinking tool for pondering the completeness of collected information.
-#  * `think_about_task_adherence`: Thinking tool for determining whether the agent is still on track with the current task.
-#  * `think_about_whether_you_are_done`: Thinking tool for determining whether the task is truly completed.
-#  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 excluded_tools: []
 
 # list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
 # This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 included_optional_tools: []
 
 # fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
 # This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 fixed_tools: []
 
 # list of mode names to that are always to be included in the set of active modes
@@ -125,11 +92,14 @@ fixed_tools: []
 # Set this to a list of mode names to always include the respective modes for this project.
 base_modes:
 
-# list of mode names that are to be activated by default.
-# The full set of modes to be activated is base_modes + default_modes.
-# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
 # Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
 # This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
 default_modes:
 
 # initial prompt for the project. It will always be given to the LLM upon activating the project
@@ -171,3 +141,19 @@ ignored_memory_patterns: []
 # Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
 # No documentation on options means no options are available.
 ls_specific_settings: {}
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []

--- a/klai-portal/frontend/src/routes/app/knowledge/__tests__/-new-wizard-hooks.test.ts
+++ b/klai-portal/frontend/src/routes/app/knowledge/__tests__/-new-wizard-hooks.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { buildCreateKnowledgeBasePayload } from '../new._wizard-hooks'
+import type { WizardData } from '../new._types'
+
+function baseWizardData(overrides: Partial<WizardData> = {}): WizardData {
+  return {
+    name: 'Support KB',
+    slug: 'support-kb',
+    slugManuallyEdited: false,
+    description: '',
+    ownerType: 'org',
+    visibilityMode: 'org',
+    allowContribute: true,
+    initialGroups: [],
+    initialUsers: [],
+    ...overrides,
+  }
+}
+
+describe('buildCreateKnowledgeBasePayload', () => {
+  it('maps org KB settings and initial members to the create API payload', () => {
+    const payload = buildCreateKnowledgeBasePayload(
+      baseWizardData({
+        description: 'Shared support answers',
+        visibilityMode: 'restricted',
+        allowContribute: false,
+        initialGroups: [{ id: 12, name: 'Support', role: 'contributor' }],
+        initialUsers: [
+          {
+            id: 'user-1',
+            name: 'Ada Lovelace',
+            email: 'ada@example.com',
+            role: 'viewer',
+          },
+        ],
+      }),
+    )
+
+    expect(payload).toEqual({
+      name: 'Support KB',
+      slug: 'support-kb',
+      description: 'Shared support answers',
+      visibility: 'private',
+      owner_type: 'org',
+      default_org_role: null,
+      initial_members: [
+        { type: 'group', id: '12', role: 'contributor' },
+        { type: 'user', id: 'user-1', role: 'viewer' },
+      ],
+    })
+  })
+
+  it('omits initial members for personal KBs', () => {
+    const payload = buildCreateKnowledgeBasePayload(
+      baseWizardData({
+        ownerType: 'user',
+        visibilityMode: 'org',
+        initialGroups: [{ id: 12, name: 'Support', role: 'contributor' }],
+      }),
+    )
+
+    expect(payload).toEqual({
+      name: 'Support KB',
+      slug: 'support-kb',
+      description: undefined,
+      visibility: 'internal',
+      owner_type: 'user',
+      default_org_role: 'contributor',
+      initial_members: undefined,
+    })
+  })
+})

--- a/klai-portal/frontend/src/routes/app/knowledge/new._components/-StepAccess.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/new._components/-StepAccess.tsx
@@ -1,0 +1,70 @@
+import { Globe, Lock, Users } from 'lucide-react'
+import * as m from '@/paraglide/messages'
+import type { WizardData, WizardDataSetter } from '../new._types'
+
+export function StepAccess({
+  data,
+  setData,
+}: {
+  data: WizardData
+  setData: WizardDataSetter
+}) {
+  const options = [
+    {
+      key: 'public' as const,
+      icon: Globe,
+      title: m.knowledge_sharing_visibility_public(),
+      desc: m.knowledge_sharing_visibility_public_description(),
+    },
+    {
+      key: 'org' as const,
+      icon: Users,
+      title: m.knowledge_sharing_visibility_org(),
+      desc: m.knowledge_sharing_visibility_org_description(),
+    },
+    {
+      key: 'restricted' as const,
+      icon: Lock,
+      title: m.knowledge_sharing_visibility_restricted(),
+      desc: m.knowledge_sharing_visibility_restricted_description(),
+    },
+  ] as const
+
+  return (
+    <div className="flex flex-col gap-5">
+      <p className="text-sm font-medium text-gray-900">
+        {m.knowledge_wizard_title_step2({ name: data.name })}
+      </p>
+
+      <div className="flex flex-col gap-2">
+        {options.map(({ key, icon: Icon, title, desc }) => (
+          <button
+            key={key}
+            type="button"
+            onClick={() =>
+              setData((prev) => ({
+                ...prev,
+                visibilityMode: key,
+                allowContribute: key === 'restricted' ? false : prev.allowContribute,
+              }))
+            }
+            className={[
+              'flex items-start gap-3 rounded-xl border p-4 text-left transition-all',
+              data.visibilityMode === key
+                ? 'border-gray-200 bg-black/[0.06] ring-1 ring-gray-900'
+                : 'border-gray-200 bg-[var(--color-card)] hover:border-gray-300',
+            ].join(' ')}
+          >
+            <Icon className="h-5 w-5 mt-0.5 text-gray-400" />
+            <div>
+              <span className="text-sm font-medium text-gray-900">
+                {title}
+              </span>
+              <span className="block text-xs text-gray-400">{desc}</span>
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/klai-portal/frontend/src/routes/app/knowledge/new._components/-StepConfirm.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/new._components/-StepConfirm.tsx
@@ -1,0 +1,135 @@
+import { Brain, Globe, Lock, Users } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import * as m from '@/paraglide/messages'
+import type { WizardData, WizardErrorKey } from '../new._types'
+
+export function StepConfirm({
+  data,
+  isPending,
+  errorKey,
+  canCreateKB,
+  onSubmit,
+  onEditSlug,
+}: {
+  data: WizardData
+  isPending: boolean
+  errorKey: WizardErrorKey
+  canCreateKB: boolean
+  onSubmit: () => void
+  onEditSlug: () => void
+}) {
+  const visibilityLabel =
+    data.visibilityMode === 'public'
+      ? m.knowledge_sharing_visibility_public()
+      : data.visibilityMode === 'org'
+        ? m.knowledge_sharing_visibility_org()
+        : m.knowledge_sharing_visibility_restricted()
+
+  const VisibilityIcon =
+    data.visibilityMode === 'public' ? Globe : data.visibilityMode === 'org' ? Users : Lock
+
+  return (
+    <div className="flex flex-col gap-5">
+      <p className="text-sm font-medium text-gray-900">
+        {m.knowledge_wizard_confirm_title()}
+      </p>
+
+      <Card>
+        <CardContent className="pt-4">
+          <div className="space-y-3 text-sm">
+            <div className="flex items-start gap-2">
+              <Brain className="h-4 w-4 mt-0.5 text-gray-400" />
+              <div>
+                <p className="font-medium text-gray-900">{data.name}</p>
+                <p className="text-xs text-gray-400">{data.slug}</p>
+              </div>
+            </div>
+
+            {data.description && (
+              <p className="text-gray-400 italic">
+                &ldquo;{data.description}&rdquo;
+              </p>
+            )}
+
+            {data.ownerType === 'org' && (
+              <div className="flex items-center gap-2">
+                <VisibilityIcon className="h-4 w-4 text-gray-400" />
+                <span className="text-gray-900">{visibilityLabel}</span>
+              </div>
+            )}
+
+            {data.ownerType === 'org' && data.visibilityMode !== 'restricted' && (
+              <p className="text-gray-400">
+                {m.knowledge_sharing_summary_org_default({
+                  role: data.allowContribute ? 'contributor' : 'viewer',
+                })}
+              </p>
+            )}
+
+            {data.ownerType === 'user' && (
+              <p className="text-gray-400">
+                {m.knowledge_wizard_personal_only()}
+              </p>
+            )}
+
+            {data.ownerType === 'org' &&
+              (data.initialGroups.length > 0 || data.initialUsers.length > 0) && (
+                <div className="border-t border-gray-200 pt-2">
+                  {data.visibilityMode === 'restricted' ? (
+                    <p className="text-xs font-medium text-gray-400 mb-1">
+                      {m.knowledge_sharing_summary_only_shared()}
+                    </p>
+                  ) : (
+                    <p className="text-xs font-medium text-gray-400 mb-1">
+                      {m.knowledge_wizard_extra_permissions_title()}:
+                    </p>
+                  )}
+                  {data.initialGroups.map((g) => (
+                    <p key={g.id} className="text-xs text-gray-400 pl-3">
+                      &bull; {g.name} ({g.role})
+                    </p>
+                  ))}
+                  {data.initialUsers.map((u) => (
+                    <p key={u.id} className="text-xs text-gray-400 pl-3">
+                      &bull; {u.name || u.email} ({u.role})
+                    </p>
+                  ))}
+                </div>
+              )}
+
+            <p className="text-gray-400">
+              {m.knowledge_sharing_summary_docs_auto()}
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      {errorKey === 'conflict' && (
+        <div className="flex items-center gap-2 text-sm">
+          <p className="text-[var(--color-destructive)]">
+            {m.knowledge_new_slug_conflict()}
+          </p>
+          <Button type="button" variant="link" size="sm" onClick={onEditSlug} className="px-0">
+            {m.knowledge_wizard_edit_slug()}
+          </Button>
+        </div>
+      )}
+      {errorKey === 'generic' && (
+        <p className="text-sm text-[var(--color-destructive)]">{m.knowledge_new_error()}</p>
+      )}
+
+      {data.ownerType === 'user' && !canCreateKB && (
+        <p className="text-sm text-gray-400 opacity-70">
+          {m.kb_limit_tooltip_kb_count()}
+        </p>
+      )}
+
+      <div className="flex justify-end pt-2">
+        <Button onClick={onSubmit} disabled={isPending || (data.ownerType === 'user' && !canCreateKB)}>
+          {m.knowledge_wizard_create_button()}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/klai-portal/frontend/src/routes/app/knowledge/new._components/-StepName.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/new._components/-StepName.tsx
@@ -1,0 +1,129 @@
+import { User, Users } from 'lucide-react'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import * as m from '@/paraglide/messages'
+import type { WizardData, WizardDataSetter, WizardErrorKey } from '../new._types'
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+export function StepName({
+  data,
+  setData,
+  errorKey,
+  isLimitedPlan,
+}: {
+  data: WizardData
+  setData: WizardDataSetter
+  errorKey: WizardErrorKey
+  isLimitedPlan: boolean
+}) {
+  function handleNameChange(value: string) {
+    setData((prev) => ({
+      ...prev,
+      name: value,
+      slug: prev.slugManuallyEdited ? prev.slug : slugify(value),
+    }))
+  }
+
+  function handleSlugChange(value: string) {
+    setData((prev) => ({
+      ...prev,
+      slug: slugify(value),
+      slugManuallyEdited: true,
+    }))
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      <p className="text-sm font-medium text-gray-900">
+        {m.knowledge_wizard_title_step1()}
+      </p>
+
+      {!isLimitedPlan && (
+        <div className="flex flex-col gap-1.5">
+          <Label>{m.knowledge_new_scope_label()}</Label>
+          <div className="grid grid-cols-2 gap-3">
+            {(['org', 'user'] as const).map((type) => (
+              <button
+                key={type}
+                type="button"
+                onClick={() =>
+                  setData((prev) => ({
+                    ...prev,
+                    ownerType: type,
+                    visibilityMode: type === 'user' ? 'org' : prev.visibilityMode,
+                  }))
+                }
+                className={[
+                  'flex flex-col items-start gap-1 rounded-xl border p-4 text-left transition-all',
+                  data.ownerType === type
+                    ? 'border-gray-200 bg-black/[0.06] ring-1 ring-gray-900'
+                    : 'border-gray-200 bg-[var(--color-card)] hover:border-gray-300',
+                ].join(' ')}
+              >
+                {type === 'org' ? (
+                  <Users className="h-4 w-4 text-gray-400" />
+                ) : (
+                  <User className="h-4 w-4 text-gray-400" />
+                )}
+                <span className="text-sm font-medium text-gray-900">
+                  {type === 'org' ? m.knowledge_new_scope_org() : m.knowledge_new_scope_personal()}
+                </span>
+                <span className="text-xs text-gray-400">
+                  {type === 'org'
+                    ? m.knowledge_new_scope_org_description()
+                    : m.knowledge_new_scope_personal_description()}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="kb-name">{m.knowledge_new_name_label()}</Label>
+        <Input
+          id="kb-name"
+          value={data.name}
+          onChange={(e) => handleNameChange(e.target.value)}
+          placeholder={m.knowledge_new_name_placeholder()}
+        />
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="kb-slug">{m.knowledge_new_slug_label()}</Label>
+        <Input
+          id="kb-slug"
+          value={data.slug}
+          onChange={(e) => handleSlugChange(e.target.value)}
+          pattern="[a-z0-9\-]+"
+        />
+        <p className="text-xs text-gray-400">
+          {m.knowledge_new_slug_hint()}
+        </p>
+        {errorKey === 'conflict' && (
+          <p className="text-xs text-[var(--color-destructive)]">
+            {m.knowledge_new_slug_conflict()}
+          </p>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="kb-description">{m.knowledge_wizard_description_label()}</Label>
+        <textarea
+          id="kb-description"
+          value={data.description}
+          onChange={(e) => setData((prev) => ({ ...prev, description: e.target.value }))}
+          placeholder={m.knowledge_wizard_description_placeholder()}
+          rows={3}
+          className="w-full rounded-md border border-gray-200 bg-transparent px-3 py-2 text-sm text-gray-900 outline-none transition-colors placeholder:text-gray-400 focus:ring-2 focus:ring-[var(--color-ring)] disabled:cursor-not-allowed disabled:opacity-50 resize-none"
+        />
+      </div>
+    </div>
+  )
+}

--- a/klai-portal/frontend/src/routes/app/knowledge/new._components/-StepPermissions.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/new._components/-StepPermissions.tsx
@@ -1,0 +1,104 @@
+import { Card, CardContent } from '@/components/ui/card'
+import * as m from '@/paraglide/messages'
+import type { OrgGroup, OrgUser, WizardData, WizardDataSetter } from '../new._types'
+import { MemberPicker } from './MemberPicker'
+
+export function StepPermissions({
+  data,
+  setData,
+  groups,
+  users,
+}: {
+  data: WizardData
+  setData: WizardDataSetter
+  groups: OrgGroup[]
+  users: OrgUser[]
+}) {
+  const isRestricted = data.visibilityMode === 'restricted'
+  const minRole = !isRestricted && data.allowContribute ? 'contributor' : 'viewer'
+
+  const isRestrictedEmpty =
+    isRestricted && data.initialGroups.length === 0 && data.initialUsers.length === 0
+
+  return (
+    <div className="flex flex-col gap-5">
+      <p className="text-sm font-medium text-gray-900">
+        {isRestricted
+          ? m.knowledge_wizard_title_step3_restricted({ name: data.name })
+          : m.knowledge_wizard_title_step3({ name: data.name })}
+      </p>
+
+      {!isRestricted && (
+        <Card>
+          <CardContent className="pt-4">
+            <div className="flex flex-col gap-3">
+              <p className="text-sm text-gray-900">
+                {m.knowledge_wizard_default_role_label()}
+              </p>
+              <label className="flex items-start gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={data.allowContribute}
+                  onChange={(e) =>
+                    setData((prev) => ({ ...prev, allowContribute: e.target.checked }))
+                  }
+                  className="mt-1 h-4 w-4 rounded border-gray-200 text-gray-400 focus:ring-[var(--color-ring)]"
+                />
+                <div>
+                  <span className="text-sm font-medium text-gray-900">
+                    {m.knowledge_wizard_contributor_checkbox()}
+                  </span>
+                  <span className="block text-xs text-gray-400">
+                    {m.knowledge_sharing_contributor_toggle_description()}
+                  </span>
+                </div>
+              </label>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {isRestricted && (
+        <p className="text-sm text-gray-400">
+          {m.knowledge_wizard_restricted_desc()}
+        </p>
+      )}
+
+      {!isRestricted && (
+        <div>
+          <p className="text-sm font-medium text-gray-900">
+            {m.knowledge_wizard_extra_permissions_title()}
+          </p>
+          <p className="text-xs text-gray-400">
+            {m.knowledge_wizard_extra_permissions_desc()}
+          </p>
+        </div>
+      )}
+
+      <MemberPicker
+        initialGroups={data.initialGroups}
+        setInitialGroups={(fn) =>
+          setData((prev) => ({
+            ...prev,
+            initialGroups: typeof fn === 'function' ? fn(prev.initialGroups) : fn,
+          }))
+        }
+        initialUsers={data.initialUsers}
+        setInitialUsers={(fn) =>
+          setData((prev) => ({
+            ...prev,
+            initialUsers: typeof fn === 'function' ? fn(prev.initialUsers) : fn,
+          }))
+        }
+        availableGroups={groups}
+        availableUsers={users}
+        minRole={minRole}
+        isRestrictedEmpty={isRestricted ? isRestrictedEmpty : false}
+      />
+
+      <p className="text-xs text-gray-400 italic">
+        {m.knowledge_wizard_owner_info()}
+      </p>
+    </div>
+  )
+}

--- a/klai-portal/frontend/src/routes/app/knowledge/new._types.ts
+++ b/klai-portal/frontend/src/routes/app/knowledge/new._types.ts
@@ -1,3 +1,5 @@
+import type { Dispatch, SetStateAction } from 'react'
+
 export interface OrgGroup {
   id: number
   name: string
@@ -35,3 +37,5 @@ export interface WizardData {
 }
 
 export type Step = 1 | 2 | 3 | 4
+export type WizardErrorKey = 'conflict' | 'generic' | null
+export type WizardDataSetter = Dispatch<SetStateAction<WizardData>>

--- a/klai-portal/frontend/src/routes/app/knowledge/new._wizard-hooks.ts
+++ b/klai-portal/frontend/src/routes/app/knowledge/new._wizard-hooks.ts
@@ -1,0 +1,99 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useNavigate } from '@tanstack/react-router'
+import { apiFetch, ApiError } from '@/lib/apiFetch'
+import type { OrgGroup, OrgUser, Step, WizardData, WizardErrorKey } from './new._types'
+
+export function buildCreateKnowledgeBasePayload(data: WizardData) {
+  const visibility =
+    data.visibilityMode === 'public'
+      ? 'public'
+      : data.visibilityMode === 'org'
+        ? 'internal'
+        : 'private'
+  const defaultOrgRole =
+    data.visibilityMode === 'restricted'
+      ? null
+      : data.allowContribute
+        ? 'contributor'
+        : 'viewer'
+
+  return {
+    name: data.name,
+    slug: data.slug,
+    description: data.description || undefined,
+    visibility,
+    owner_type: data.ownerType,
+    default_org_role: defaultOrgRole,
+    initial_members:
+      data.ownerType === 'org'
+        ? [
+            ...data.initialGroups.map((g) => ({
+              type: 'group',
+              id: String(g.id),
+              role: g.role,
+            })),
+            ...data.initialUsers.map((u) => ({
+              type: 'user',
+              id: u.id,
+              role: u.role,
+            })),
+          ]
+        : undefined,
+  }
+}
+
+export function useKnowledgeWizardMembers({
+  isAuthenticated,
+  ownerType,
+  step,
+}: {
+  isAuthenticated: boolean
+  ownerType: WizardData['ownerType']
+  step: Step
+}) {
+  const enabled = isAuthenticated && ownerType === 'org' && step >= 3
+
+  const { data: groupsData } = useQuery({
+    queryKey: ['app-groups'],
+    queryFn: () => apiFetch<{ groups: OrgGroup[] }>('/api/app/groups'),
+    enabled,
+  })
+
+  const { data: usersData } = useQuery({
+    queryKey: ['app-users'],
+    queryFn: () => apiFetch<{ users: OrgUser[] }>('/api/app/users'),
+    enabled,
+  })
+
+  return {
+    groups: groupsData?.groups ?? [],
+    users: usersData?.users ?? [],
+  }
+}
+
+export function useCreateKnowledgeBaseMutation({
+  data,
+  onErrorKey,
+}: {
+  data: WizardData
+  onErrorKey: (errorKey: WizardErrorKey) => void
+}) {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async () => {
+      return apiFetch<{ slug: string }>(`/api/app/knowledge-bases`, {
+        method: 'POST',
+        body: JSON.stringify(buildCreateKnowledgeBasePayload(data)),
+      })
+    },
+    onSuccess: (result) => {
+      void queryClient.invalidateQueries({ queryKey: ['app-knowledge-bases'] })
+      void navigate({ to: '/app/knowledge/$kbSlug', params: { kbSlug: result.slug } })
+    },
+    onError: (err: Error) => {
+      onErrorKey(err instanceof ApiError && err.status === 409 ? 'conflict' : 'generic')
+    },
+  })
+}

--- a/klai-portal/frontend/src/routes/app/knowledge/new.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/new.tsx
@@ -1,28 +1,22 @@
-import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { useAuth } from '@/lib/auth'
 import { useState } from 'react'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import {
-  Globe,
-  Users,
-  Lock,
-  ArrowLeft,
-  ArrowRight,
-  User,
-  Brain,
-} from 'lucide-react'
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import { Card, CardContent } from '@/components/ui/card'
-import { StepIndicator, type StepItem } from '@/components/ui/step-indicator'
-import * as m from '@/paraglide/messages'
-import { apiFetch, ApiError } from '@/lib/apiFetch'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { ArrowLeft, ArrowRight } from 'lucide-react'
 import { ProductGuard } from '@/components/layout/ProductGuard'
+import { Button } from '@/components/ui/button'
+import { StepIndicator, type StepItem } from '@/components/ui/step-indicator'
 import { useCurrentUser } from '@/hooks/useCurrentUser'
 import { useKBQuota } from '@/hooks/useKBQuota'
-import { MemberPicker } from './new._components/MemberPicker'
-import type { WizardData, Step, OrgGroup } from './new._types'
+import { useAuth } from '@/lib/auth'
+import * as m from '@/paraglide/messages'
+import { StepAccess } from './new._components/-StepAccess'
+import { StepConfirm } from './new._components/-StepConfirm'
+import { StepName } from './new._components/-StepName'
+import { StepPermissions } from './new._components/-StepPermissions'
+import {
+  useCreateKnowledgeBaseMutation,
+  useKnowledgeWizardMembers,
+} from './new._wizard-hooks'
+import type { Step, WizardData, WizardErrorKey } from './new._types'
 
 export const Route = createFileRoute('/app/knowledge/new')({
   component: () => (
@@ -32,40 +26,21 @@ export const Route = createFileRoute('/app/knowledge/new')({
   ),
 })
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function slugify(value: string): string {
-  return value
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-}
-
-// ---------------------------------------------------------------------------
-// Main page component
-// ---------------------------------------------------------------------------
-
 function NewKnowledgeBasePage() {
   const auth = useAuth()
   const navigate = useNavigate()
-  const queryClient = useQueryClient()
   const { user } = useCurrentUser()
   const { canCreateKB } = useKBQuota()
 
-  // Limited plan users (no kb.connectors) may only create personal KBs.
   const isLimitedPlan = user ? !user.hasCapability('kb.connectors') : false
-
   const [step, setStep] = useState<Step>(1)
-  const [errorKey, setErrorKey] = useState<'conflict' | 'generic' | null>(null)
+  const [errorKey, setErrorKey] = useState<WizardErrorKey>(null)
 
   const [data, setData] = useState<WizardData>({
     name: '',
     slug: '',
     slugManuallyEdited: false,
     description: '',
-    // Limited plan users can only create personal KBs.
     ownerType: isLimitedPlan ? 'user' : 'org',
     visibilityMode: 'org',
     allowContribute: true,
@@ -73,76 +48,23 @@ function NewKnowledgeBasePage() {
     initialUsers: [],
   })
 
-  // Queries for member picker (step 3)
-  const { data: groupsData } = useQuery({
-    queryKey: ['app-groups'],
-    queryFn: () =>
-      apiFetch<{ groups: OrgGroup[] }>('/api/app/groups'),
-    enabled: auth.isAuthenticated && data.ownerType === 'org' && step >= 3,
+  const { groups, users } = useKnowledgeWizardMembers({
+    isAuthenticated: auth.isAuthenticated,
+    ownerType: data.ownerType,
+    step,
   })
 
-  const { data: usersData } = useQuery({
-    queryKey: ['app-users'],
-    queryFn: () =>
-      apiFetch<{
-        users: { zitadel_user_id: string; display_name: string; email: string }[]
-      }>('/api/app/users'),
-    enabled: auth.isAuthenticated && data.ownerType === 'org' && step >= 3,
+  const { mutate, isPending } = useCreateKnowledgeBaseMutation({
+    data,
+    onErrorKey: setErrorKey,
   })
 
-  const { mutate, isPending } = useMutation({
-    mutationFn: async () => {
-      const visibility =
-        data.visibilityMode === 'public'
-          ? 'public'
-          : data.visibilityMode === 'org'
-            ? 'internal'
-            : 'private'
-      const defaultOrgRole =
-        data.visibilityMode === 'restricted'
-          ? null
-          : data.allowContribute
-            ? 'contributor'
-            : 'viewer'
-
-      return apiFetch<{ slug: string }>(`/api/app/knowledge-bases`, {
-        method: 'POST',
-        body: JSON.stringify({
-          name: data.name,
-          slug: data.slug,
-          description: data.description || undefined,
-          visibility,
-          owner_type: data.ownerType,
-          default_org_role: defaultOrgRole,
-          initial_members:
-            data.ownerType === 'org'
-              ? [
-                  ...data.initialGroups.map((g) => ({
-                    type: 'group',
-                    id: String(g.id),
-                    role: g.role,
-                  })),
-                  ...data.initialUsers.map((u) => ({
-                    type: 'user',
-                    id: u.id,
-                    role: u.role,
-                  })),
-                ]
-              : undefined,
-        }),
-      })
-    },
-    onSuccess: (result) => {
-      void queryClient.invalidateQueries({ queryKey: ['app-knowledge-bases'] })
-      void navigate({ to: '/app/knowledge/$kbSlug', params: { kbSlug: result.slug } })
-    },
-    onError: (err: Error) => {
-      setErrorKey(err instanceof ApiError && err.status === 409 ? 'conflict' : 'generic')
-    },
-  })
-
-  // Navigation
   const isPersonal = data.ownerType === 'user'
+  const step1Valid = data.name.trim() !== '' && data.slug.trim() !== ''
+  const step3Valid =
+    data.visibilityMode !== 'restricted' ||
+    data.initialGroups.length > 0 ||
+    data.initialUsers.length > 0
 
   function handleNext() {
     if (step === 1 && isPersonal) {
@@ -160,15 +82,6 @@ function NewKnowledgeBasePage() {
     }
   }
 
-  // Validation
-  const isRestrictedEmpty =
-    data.visibilityMode === 'restricted' &&
-    data.initialGroups.length === 0 &&
-    data.initialUsers.length === 0
-
-  const step1Valid = data.name.trim() !== '' && data.slug.trim() !== ''
-  const step3Valid = data.visibilityMode !== 'restricted' || !isRestrictedEmpty
-
   function canAdvance(): boolean {
     if (step === 1) return step1Valid
     if (step === 2) return true
@@ -178,7 +91,6 @@ function NewKnowledgeBasePage() {
 
   return (
     <div className="mx-auto max-w-lg px-6 py-10">
-      {/* Header with back/cancel */}
       <div className="flex items-start justify-between mb-6">
         <h1 className="page-title text-[26px] font-display-bold text-gray-900">
           {m.knowledge_new_heading()}
@@ -201,32 +113,24 @@ function NewKnowledgeBasePage() {
         )}
       </div>
 
-      {/* Step indicator — shared component */}
-      {(() => {
-        const allSteps: StepItem[] = [
-          { label: m.knowledge_wizard_step_name(),        onClick: () => setStep(1) },
-          { label: m.knowledge_wizard_step_access(),      onClick: () => setStep(2) },
-          { label: m.knowledge_wizard_step_permissions(), onClick: () => setStep(3) },
-          { label: m.knowledge_wizard_step_confirm() },
-        ]
-        // Personal scope skips access + permissions; only step 1 and step 4 are shown.
-        const steps = isPersonal ? [allSteps[0], allSteps[3]] : allSteps
-        const currentIndex = isPersonal
-          ? (step === 1 ? 0 : 1)
-          : step - 1
-        return <StepIndicator steps={steps} currentIndex={currentIndex} />
-      })()}
+      <StepIndicator steps={getStepItems(isPersonal, setStep)} currentIndex={getStepIndex(isPersonal, step)} />
 
-      {/* Step content */}
       <div className="mt-6">
-        {step === 1 && <StepName data={data} setData={setData} errorKey={errorKey} isLimitedPlan={isLimitedPlan} />}
+        {step === 1 && (
+          <StepName
+            data={data}
+            setData={setData}
+            errorKey={errorKey}
+            isLimitedPlan={isLimitedPlan}
+          />
+        )}
         {step === 2 && <StepAccess data={data} setData={setData} />}
         {step === 3 && (
           <StepPermissions
             data={data}
             setData={setData}
-            groups={groupsData?.groups ?? []}
-            users={usersData?.users ?? []}
+            groups={groups}
+            users={users}
           />
         )}
         {step === 4 && (
@@ -244,7 +148,6 @@ function NewKnowledgeBasePage() {
         )}
       </div>
 
-      {/* Navigation buttons (steps 1-3) */}
       {step < 4 && (
         <div className="flex pt-6">
           <Button onClick={handleNext} disabled={!canAdvance()}>
@@ -257,457 +160,17 @@ function NewKnowledgeBasePage() {
   )
 }
 
-// ---------------------------------------------------------------------------
-// Step 1: Name & Scope
-// ---------------------------------------------------------------------------
+function getStepItems(isPersonal: boolean, setStep: (step: Step) => void): StepItem[] {
+  const allSteps: StepItem[] = [
+    { label: m.knowledge_wizard_step_name(), onClick: () => setStep(1) },
+    { label: m.knowledge_wizard_step_access(), onClick: () => setStep(2) },
+    { label: m.knowledge_wizard_step_permissions(), onClick: () => setStep(3) },
+    { label: m.knowledge_wizard_step_confirm() },
+  ]
 
-function StepName({
-  data,
-  setData,
-  errorKey,
-  isLimitedPlan,
-}: {
-  data: WizardData
-  setData: React.Dispatch<React.SetStateAction<WizardData>>
-  errorKey: 'conflict' | 'generic' | null
-  isLimitedPlan: boolean
-}) {
-  function handleNameChange(value: string) {
-    setData((prev) => ({
-      ...prev,
-      name: value,
-      slug: prev.slugManuallyEdited ? prev.slug : slugify(value),
-    }))
-  }
-
-  function handleSlugChange(value: string) {
-    setData((prev) => ({
-      ...prev,
-      slug: slugify(value),
-      slugManuallyEdited: true,
-    }))
-  }
-
-  return (
-    <div className="flex flex-col gap-5">
-      <p className="text-sm font-medium text-gray-900">
-        {m.knowledge_wizard_title_step1()}
-      </p>
-
-      {/* Scope picker — limited plan users may only create personal KBs (D4) */}
-      {!isLimitedPlan && (
-        <div className="flex flex-col gap-1.5">
-          <Label>{m.knowledge_new_scope_label()}</Label>
-          <div className="grid grid-cols-2 gap-3">
-            {(['org', 'user'] as const).map((type) => (
-              <button
-                key={type}
-                type="button"
-                onClick={() =>
-                  setData((prev) => ({
-                    ...prev,
-                    ownerType: type,
-                    visibilityMode: type === 'user' ? 'org' : prev.visibilityMode,
-                  }))
-                }
-                className={[
-                  'flex flex-col items-start gap-1 rounded-xl border p-4 text-left transition-all',
-                  data.ownerType === type
-                    ? 'border-gray-200 bg-black/[0.06] ring-1 ring-gray-900'
-                    : 'border-gray-200 bg-[var(--color-card)] hover:border-gray-300',
-                ].join(' ')}
-              >
-                {type === 'org' ? (
-                  <Users className="h-4 w-4 text-gray-400" />
-                ) : (
-                  <User className="h-4 w-4 text-gray-400" />
-                )}
-                <span className="text-sm font-medium text-gray-900">
-                  {type === 'org' ? m.knowledge_new_scope_org() : m.knowledge_new_scope_personal()}
-                </span>
-                <span className="text-xs text-gray-400">
-                  {type === 'org'
-                    ? m.knowledge_new_scope_org_description()
-                    : m.knowledge_new_scope_personal_description()}
-                </span>
-              </button>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* Name */}
-      <div className="flex flex-col gap-1.5">
-        <Label htmlFor="kb-name">{m.knowledge_new_name_label()}</Label>
-        <Input
-          id="kb-name"
-          value={data.name}
-          onChange={(e) => handleNameChange(e.target.value)}
-          placeholder={m.knowledge_new_name_placeholder()}
-        />
-      </div>
-
-      {/* Slug */}
-      <div className="flex flex-col gap-1.5">
-        <Label htmlFor="kb-slug">{m.knowledge_new_slug_label()}</Label>
-        <Input
-          id="kb-slug"
-          value={data.slug}
-          onChange={(e) => handleSlugChange(e.target.value)}
-          pattern="[a-z0-9\-]+"
-        />
-        <p className="text-xs text-gray-400">
-          {m.knowledge_new_slug_hint()}
-        </p>
-        {errorKey === 'conflict' && (
-          <p className="text-xs text-[var(--color-destructive)]">
-            {m.knowledge_new_slug_conflict()}
-          </p>
-        )}
-      </div>
-
-      {/* Description */}
-      <div className="flex flex-col gap-1.5">
-        <Label htmlFor="kb-description">{m.knowledge_wizard_description_label()}</Label>
-        <textarea
-          id="kb-description"
-          value={data.description}
-          onChange={(e) => setData((prev) => ({ ...prev, description: e.target.value }))}
-          placeholder={m.knowledge_wizard_description_placeholder()}
-          rows={3}
-          className="w-full rounded-md border border-gray-200 bg-transparent px-3 py-2 text-sm text-gray-900 outline-none transition-colors placeholder:text-gray-400 focus:ring-2 focus:ring-[var(--color-ring)] disabled:cursor-not-allowed disabled:opacity-50 resize-none"
-        />
-      </div>
-    </div>
-  )
+  return isPersonal ? [allSteps[0], allSteps[3]] : allSteps
 }
 
-// ---------------------------------------------------------------------------
-// Step 2: Access / Visibility
-// ---------------------------------------------------------------------------
-
-function StepAccess({
-  data,
-  setData,
-}: {
-  data: WizardData
-  setData: React.Dispatch<React.SetStateAction<WizardData>>
-}) {
-  const options = [
-    {
-      key: 'public' as const,
-      icon: Globe,
-      title: m.knowledge_sharing_visibility_public(),
-      desc: m.knowledge_sharing_visibility_public_description(),
-    },
-    {
-      key: 'org' as const,
-      icon: Users,
-      title: m.knowledge_sharing_visibility_org(),
-      desc: m.knowledge_sharing_visibility_org_description(),
-    },
-    {
-      key: 'restricted' as const,
-      icon: Lock,
-      title: m.knowledge_sharing_visibility_restricted(),
-      desc: m.knowledge_sharing_visibility_restricted_description(),
-    },
-  ] as const
-
-  return (
-    <div className="flex flex-col gap-5">
-      <p className="text-sm font-medium text-gray-900">
-        {m.knowledge_wizard_title_step2({ name: data.name })}
-      </p>
-
-      <div className="flex flex-col gap-2">
-        {options.map(({ key, icon: Icon, title, desc }) => (
-          <button
-            key={key}
-            type="button"
-            onClick={() =>
-              setData((prev) => ({
-                ...prev,
-                visibilityMode: key,
-                allowContribute: key === 'restricted' ? false : prev.allowContribute,
-              }))
-            }
-            className={[
-              'flex items-start gap-3 rounded-xl border p-4 text-left transition-all',
-              data.visibilityMode === key
-                ? 'border-gray-200 bg-black/[0.06] ring-1 ring-gray-900'
-                : 'border-gray-200 bg-[var(--color-card)] hover:border-gray-300',
-            ].join(' ')}
-          >
-            <Icon className="h-5 w-5 mt-0.5 text-gray-400" />
-            <div>
-              <span className="text-sm font-medium text-gray-900">
-                {title}
-              </span>
-              <span className="block text-xs text-gray-400">{desc}</span>
-            </div>
-          </button>
-        ))}
-      </div>
-    </div>
-  )
-}
-
-// ---------------------------------------------------------------------------
-// Step 3: Permissions
-// ---------------------------------------------------------------------------
-
-function StepPermissions({
-  data,
-  setData,
-  groups,
-  users,
-}: {
-  data: WizardData
-  setData: React.Dispatch<React.SetStateAction<WizardData>>
-  groups: OrgGroup[]
-  users: { zitadel_user_id: string; display_name: string; email: string }[]
-}) {
-  const isRestricted = data.visibilityMode === 'restricted'
-  const minRole = !isRestricted && data.allowContribute ? 'contributor' : 'viewer'
-
-  const isRestrictedEmpty =
-    isRestricted && data.initialGroups.length === 0 && data.initialUsers.length === 0
-
-  return (
-    <div className="flex flex-col gap-5">
-      <p className="text-sm font-medium text-gray-900">
-        {isRestricted
-          ? m.knowledge_wizard_title_step3_restricted({ name: data.name })
-          : m.knowledge_wizard_title_step3({ name: data.name })}
-      </p>
-
-      {/* Variant A: org/public — default role section */}
-      {!isRestricted && (
-        <Card>
-          <CardContent className="pt-4">
-            <div className="flex flex-col gap-3">
-              <p className="text-sm text-gray-900">
-                {m.knowledge_wizard_default_role_label()}
-              </p>
-              <label className="flex items-start gap-2 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={data.allowContribute}
-                  onChange={(e) =>
-                    setData((prev) => ({ ...prev, allowContribute: e.target.checked }))
-                  }
-                  className="mt-1 h-4 w-4 rounded border-gray-200 text-gray-400 focus:ring-[var(--color-ring)]"
-                />
-                <div>
-                  <span className="text-sm font-medium text-gray-900">
-                    {m.knowledge_wizard_contributor_checkbox()}
-                  </span>
-                  <span className="block text-xs text-gray-400">
-                    {m.knowledge_sharing_contributor_toggle_description()}
-                  </span>
-                </div>
-              </label>
-            </div>
-          </CardContent>
-        </Card>
-      )}
-
-      {/* Variant B: restricted — explanation */}
-      {isRestricted && (
-        <p className="text-sm text-gray-400">
-          {m.knowledge_wizard_restricted_desc()}
-        </p>
-      )}
-
-      {/* Extra permissions heading for org/public */}
-      {!isRestricted && (
-        <div>
-          <p className="text-sm font-medium text-gray-900">
-            {m.knowledge_wizard_extra_permissions_title()}
-          </p>
-          <p className="text-xs text-gray-400">
-            {m.knowledge_wizard_extra_permissions_desc()}
-          </p>
-        </div>
-      )}
-
-      {/* Member picker */}
-      <MemberPicker
-        initialGroups={data.initialGroups}
-        setInitialGroups={(fn) =>
-          setData((prev) => ({
-            ...prev,
-            initialGroups: typeof fn === 'function' ? fn(prev.initialGroups) : fn,
-          }))
-        }
-        initialUsers={data.initialUsers}
-        setInitialUsers={(fn) =>
-          setData((prev) => ({
-            ...prev,
-            initialUsers: typeof fn === 'function' ? fn(prev.initialUsers) : fn,
-          }))
-        }
-        availableGroups={groups}
-        availableUsers={users}
-        minRole={minRole}
-        isRestrictedEmpty={isRestricted ? isRestrictedEmpty : false}
-      />
-
-      {/* Owner info */}
-      <p className="text-xs text-gray-400 italic">
-        {m.knowledge_wizard_owner_info()}
-      </p>
-    </div>
-  )
-}
-
-// ---------------------------------------------------------------------------
-// Step 4: Confirm
-// ---------------------------------------------------------------------------
-
-function StepConfirm({
-  data,
-  isPending,
-  errorKey,
-  canCreateKB,
-  onSubmit,
-  onEditSlug,
-}: {
-  data: WizardData
-  isPending: boolean
-  errorKey: 'conflict' | 'generic' | null
-  canCreateKB: boolean
-  onSubmit: () => void
-  onEditSlug: () => void
-}) {
-  const visibilityLabel =
-    data.visibilityMode === 'public'
-      ? m.knowledge_sharing_visibility_public()
-      : data.visibilityMode === 'org'
-        ? m.knowledge_sharing_visibility_org()
-        : m.knowledge_sharing_visibility_restricted()
-
-  const VisibilityIcon =
-    data.visibilityMode === 'public' ? Globe : data.visibilityMode === 'org' ? Users : Lock
-
-  return (
-    <div className="flex flex-col gap-5">
-      <p className="text-sm font-medium text-gray-900">
-        {m.knowledge_wizard_confirm_title()}
-      </p>
-
-      <Card>
-        <CardContent className="pt-4">
-          <div className="space-y-3 text-sm">
-            {/* Name + slug */}
-            <div className="flex items-start gap-2">
-              <Brain className="h-4 w-4 mt-0.5 text-gray-400" />
-              <div>
-                <p className="font-medium text-gray-900">{data.name}</p>
-                <p className="text-xs text-gray-400">{data.slug}</p>
-              </div>
-            </div>
-
-            {/* Description */}
-            {data.description && (
-              <p className="text-gray-400 italic">
-                &ldquo;{data.description}&rdquo;
-              </p>
-            )}
-
-            {/* Visibility (org scope only) */}
-            {data.ownerType === 'org' && (
-              <div className="flex items-center gap-2">
-                <VisibilityIcon className="h-4 w-4 text-gray-400" />
-                <span className="text-gray-900">{visibilityLabel}</span>
-              </div>
-            )}
-
-            {/* Default org role */}
-            {data.ownerType === 'org' && data.visibilityMode !== 'restricted' && (
-              <p className="text-gray-400">
-                {m.knowledge_sharing_summary_org_default({
-                  role: data.allowContribute ? 'contributor' : 'viewer',
-                })}
-              </p>
-            )}
-
-            {/* Personal scope info */}
-            {data.ownerType === 'user' && (
-              <p className="text-gray-400">
-                {m.knowledge_wizard_personal_only()}
-              </p>
-            )}
-
-            {/* Extra members */}
-            {data.ownerType === 'org' &&
-              (data.initialGroups.length > 0 || data.initialUsers.length > 0) && (
-                <div className="border-t border-gray-200 pt-2">
-                  {data.visibilityMode === 'restricted' ? (
-                    <p className="text-xs font-medium text-gray-400 mb-1">
-                      {m.knowledge_sharing_summary_only_shared()}
-                    </p>
-                  ) : (
-                    <p className="text-xs font-medium text-gray-400 mb-1">
-                      {m.knowledge_wizard_extra_permissions_title()}:
-                    </p>
-                  )}
-                  {data.initialGroups.map((g) => (
-                    <p
-                      key={g.id}
-                      className="text-xs text-gray-400 pl-3"
-                    >
-                      &bull; {g.name} ({g.role})
-                    </p>
-                  ))}
-                  {data.initialUsers.map((u) => (
-                    <p
-                      key={u.id}
-                      className="text-xs text-gray-400 pl-3"
-                    >
-                      &bull; {u.name || u.email} ({u.role})
-                    </p>
-                  ))}
-                </div>
-              )}
-
-            {/* Docs auto */}
-            <p className="text-gray-400">
-              {m.knowledge_sharing_summary_docs_auto()}
-            </p>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Slug conflict error with edit link */}
-      {errorKey === 'conflict' && (
-        <div className="flex items-center gap-2 text-sm">
-          <p className="text-[var(--color-destructive)]">
-            {m.knowledge_new_slug_conflict()}
-          </p>
-          <Button type="button" variant="link" size="sm" onClick={onEditSlug} className="px-0">
-            {m.knowledge_wizard_edit_slug()}
-          </Button>
-        </div>
-      )}
-      {errorKey === 'generic' && (
-        <p className="text-sm text-[var(--color-destructive)]">{m.knowledge_new_error()}</p>
-      )}
-
-      {/* Quota notice for personal KBs on limited plans */}
-      {data.ownerType === 'user' && !canCreateKB && (
-        <p className="text-sm text-gray-400 opacity-70">
-          {m.kb_limit_tooltip_kb_count()}
-        </p>
-      )}
-
-      {/* Submit button */}
-      <div className="flex justify-end pt-2">
-        <Button onClick={onSubmit} disabled={isPending || (data.ownerType === 'user' && !canCreateKB)}>
-          {m.knowledge_wizard_create_button()}
-        </Button>
-      </div>
-    </div>
-  )
+function getStepIndex(isPersonal: boolean, step: Step): number {
+  return isPersonal ? (step === 1 ? 0 : 1) : step - 1
 }


### PR DESCRIPTION
## Summary
- Split the KB creation wizard route into route-local step components.
- Extracted member fetching and create-KB mutation payload mapping into a wizard hooks module.
- Marked SPEC-PORTAL-KB-NEW-CLEANUP-001 implemented and documented validation.

## Validation
- npm run lint -- src/routes/app/knowledge/new.tsx src/routes/app/knowledge/new._wizard-hooks.ts src/routes/app/knowledge/new._types.ts src/routes/app/knowledge/new._components/-StepName.tsx src/routes/app/knowledge/new._components/-StepAccess.tsx src/routes/app/knowledge/new._components/-StepPermissions.tsx src/routes/app/knowledge/new._components/-StepConfirm.tsx src/routes/app/knowledge/__tests__/-new-wizard-hooks.test.ts
- npm test -- src/routes/app/knowledge/__tests__/-new-wizard-hooks.test.ts
- npx tsc -b --pretty false --force
- npm run build
- Playwright MCP e2e on Voys tenant: created e2e-kb-new-cleanup-20260513-092032 through /app/knowledge/new, verified redirect to sources page, deleted test KB with 204, verified it no longer appears in list API/page.

## Notes
- .serena/project.yml remains a local unstaged change and is not part of this PR.