### PR TITLE
feat(portal): SPEC-PORTAL-AUTH-EMAIL-LINKS-001 — Klai-branded URLs in Zitadel email-link flows

### DIFF
--- a/.moai/specs/SPEC-PORTAL-AUTH-EMAIL-LINKS-001/acceptance.md
+++ b/.moai/specs/SPEC-PORTAL-AUTH-EMAIL-LINKS-001/acceptance.md
@@ -1,0 +1,157 @@
+# SPEC-PORTAL-AUTH-EMAIL-LINKS-001 — Acceptance Criteria
+
+Each criterion is binary: pass or fail. No partial credit.
+
+## AC-1: Password reset link points at Klai UI
+
+**Setup**
+1. On staging, request a password reset for a test user: `POST /api/auth/password/reset` with `{"email": "e2e@getklai.com"}`.
+2. Wait for the email to arrive in the test inbox (SMTP relay).
+
+**Verify**
+- The "Nieuw wachtwoord instellen" button URL in the rendered HTML mail starts with `https://my.getklai.com/password/set?` (NOT `https://auth.getklai.com/ui/login/`).
+- The URL contains `userID=`, `code=`, `orgID=` query parameters with non-empty values.
+- Clicking the URL lands on Klai's `/password/set` page (not Zitadel's hosted UI).
+
+**Pass condition** All three checks true.
+
+---
+
+## AC-2: New-user invite link points at Klai UI
+
+**Setup**
+1. As an admin in staging, invite a new user: `POST /api/admin/users/invite` with a fresh email address.
+2. Wait for the email.
+
+**Verify**
+- The "Account activeren" button URL starts with `https://my.getklai.com/password/set?` (NOT `https://auth.getklai.com/ui/login/`).
+- Clicking it lands on Klai's `/password/set` page.
+- The user can set a password and is then redirected to `/` (per existing `password/set.tsx` behaviour, file:69).
+- A subsequent login attempt succeeds.
+
+**Pass condition** All four checks true.
+
+---
+
+## AC-3: Resend invite link points at Klai UI
+
+**Setup**
+1. Invite a user (AC-2 setup).
+2. Before the user clicks, the admin clicks "Resend invite" in the portal.
+3. Wait for the second email.
+
+**Verify**
+- Both emails contain `my.getklai.com/password/set?` URLs.
+- The codes in the two URLs differ (Zitadel rotates the code on resend).
+- The latest code works in `/password/set`; the previous code yields a 400 "expired/invalid code" toast.
+
+**Pass condition** All three checks true.
+
+---
+
+## AC-4: Mid-deploy backward compatibility
+
+**Setup**
+1. Pre-deploy: generate a password-reset link using the current Zitadel-default URL.
+2. Save the link.
+3. Deploy this SPEC.
+4. Within 72 hours, click the saved link (which points at `auth.getklai.com/ui/login/...`).
+
+**Verify**
+- The pre-deploy link still works — Zitadel's hosted UI accepts the password and sets it.
+- The user can log in to Klai afterwards.
+
+**Pass condition** Both checks true. (This proves no rollback is needed and codes are URL-template-agnostic.)
+
+---
+
+## AC-5: Partial-failure handling
+
+**Setup** (chaos test, dev only)
+1. Patch `ZitadelClient.send_invite_code` to raise `httpx.HTTPStatusError(500)`.
+2. Invite a user via the admin UI.
+
+**Verify**
+- The HTTP response is 502 with body `{"detail": "invite_partial_failure", "user_id": "..."}`.
+- A `event:invite_partial_user_created` log line appears in VictoriaLogs at ERROR level with the userId.
+- The Zitadel user exists (queryable via `find_user_id_by_email`) but has no active invite_code.
+- Calling `POST /api/admin/users/{id}/resend-invite` on that user successfully issues an invite mail with a `my.getklai.com` URL.
+
+**Pass condition** All four checks true.
+
+---
+
+## AC-6: CI lint rule catches regressions
+
+**Setup**
+1. On a test branch, add a new file `klai-portal/backend/app/api/test_offender.py` containing:
+
+```python
+await client.post(f"/v2/users/{uid}/password_reset")
+```
+
+2. Push and open a PR.
+
+**Verify**
+- The `Alerting provisioning checks` job in `.github/workflows/portal-api.yml` fails with an ast-grep error pointing at the offending line.
+- The PR cannot be merged with the lint failure.
+
+**Pass condition** Both checks true.
+
+---
+
+## AC-7: Boot assertion catches misconfiguration
+
+**Setup** (dev only)
+1. Set `FRONTEND_URL=http://example.com` (an obviously-wrong value).
+2. Restart portal-api locally.
+
+**Verify**
+- The container's startup fails (does not pass lifespan).
+- The error log contains `assert_auth_link_template_ready` or similar, with the misconfigured URL printed.
+
+**Pass condition** Both checks true. (Mirrors `assert_portal_users_rls_ready` behaviour.)
+
+---
+
+## AC-8: Observability fields present
+
+**Setup**
+1. Invite a test user (AC-2).
+2. Query VictoriaLogs.
+
+**Verify**
+- `service:portal-api AND event:invite_user` returns a log with field `url_template_host` equal to `my.getklai.com`.
+- `service:klai-mailer AND eventType:InviteUser` returns a log whose `templateData.url` contains `my.getklai.com`.
+- A `request_id:<uuid>` query joining both services shows the same trace ID end-to-end.
+
+**Pass condition** All three checks true.
+
+---
+
+## AC-9: No regression in other Zitadel calls
+
+**Setup** Run the existing portal-api test suite.
+
+**Verify**
+- `pytest klai-portal/backend/tests/` exits 0.
+- Specifically the following pre-existing test files still pass with no modification beyond signature-update parity:
+  - `tests/test_user_lifecycle.py`
+  - `tests/test_zitadel_session_create.py`
+  - `tests/test_auth_mfa_fail_closed.py`
+
+**Pass condition** Suite passes.
+
+---
+
+## AC-10: Application name appears in invite mail
+
+**Setup**
+1. Trigger an invite (AC-2 setup).
+2. Inspect the rendered email subject AND the `args.ApplicationName` field in klai-mailer's webhook payload (use `klai-mailer/app/main.py` `/debug` endpoint on staging).
+
+**Verify**
+- The webhook payload's `args.ApplicationName` (`klai-mailer/app/models.py:39`) equals `"Klai"`, NOT `"ZITADEL"`.
+- This guarantees any future use of `{{.ApplicationName}}` in the Zitadel message-text template renders "Klai" instead of "ZITADEL".
+
+**Pass condition** Field equals `"Klai"`.

--- a/.moai/specs/SPEC-PORTAL-AUTH-EMAIL-LINKS-001/research.md
+++ b/.moai/specs/SPEC-PORTAL-AUTH-EMAIL-LINKS-001/research.md
@@ -1,0 +1,181 @@
+# SPEC-PORTAL-AUTH-EMAIL-LINKS-001 — Research Notes
+
+## Problem framing
+
+Discovered 2026-05-13: a user activating their Klai account via invite lands on Zitadel's stock hosted UI (`https://auth.getklai.com/ui/login/user/init?...`) instead of Klai's branded `/password/set` page. Klai-mailer wraps the email body in the Klai HTML template, but the call-to-action link points at Zitadel's UI rather than Klai's.
+
+Same issue applies to the password-reset email flow (`POST /api/auth/password/reset` → Zitadel mails a link to the user → link points at `auth.getklai.com`).
+
+## Existing Klai pattern (mapped 2026-05-13)
+
+Klai already has a fully-branded UI for every authenticated user interaction, with portal-api as the exclusive Zitadel-v2-API client. The "Klai UI on the front, Zitadel v2 API on the back" pattern is the canonical Klai answer to "how do we avoid Zitadel UI".
+
+Routing mechanisms for keeping Zitadel pointed at Klai UI (all Zitadel-native):
+
+1. **OIDC pre-auth login** — Zitadel Login V2 with `base_uri = https://my.getklai.com`. SPEC-AUTH-008 documents this. Login V2 sits BEFORE the OIDC app so every `oauth/v2/authorize` request is forwarded to Klai's `/login`.
+2. **IDP intent flows** — `urls.successUrl` parameter on `POST /v2/idp_intents`. Klai uses this in `klai-portal/backend/app/services/zitadel.py:574` for Google SSO. The successUrl points at `{settings.portal_url}/api/auth/idp-callback` — Zitadel calls back into portal-api directly.
+3. **Email-link flows** — `url_template` parameter on `SendInviteCode`, `SendPasswordResetLink`, `SendEmailVerificationCode`. **Not currently used by Klai. This is the gap.**
+
+## Zitadel v2 API verification (proto-level)
+
+Source: `https://raw.githubusercontent.com/zitadel/zitadel/main/proto/zitadel/user/v2/{user_service,user,email,password}.proto` (downloaded 2026-05-13).
+
+### SendPasswordResetLink (password.proto:38-53)
+
+```proto
+message SendPasswordResetLink {
+  NotificationType notification_type = 1;
+  // Optionally set a url_template, which will be used in the password reset mail
+  // sent by Zitadel to guide the user to your password change page.
+  // If no template is set, the default Zitadel url will be used.
+  //
+  // The following placeholders can be used: UserID, OrgID, Code
+  optional string url_template = 2 [
+    (validate.rules).string = {min_len: 1, max_len: 200},
+    example: "https://example.com/password/changey?userID={{.UserID}}&code={{.Code}}&orgID={{.OrgID}}"
+  ];
+}
+
+enum NotificationType {
+  NOTIFICATION_TYPE_Unspecified = 0;
+  NOTIFICATION_TYPE_Email = 1;
+  NOTIFICATION_TYPE_SMS = 2;
+}
+```
+
+JSON shape: `{"sendLink": {"notificationType": "NOTIFICATION_TYPE_Email", "urlTemplate": "..."}}`.
+
+### SendInviteCode (user.proto:339-363)
+
+```proto
+message SendInviteCode {
+  // Optionally set a url_template, which will be used in the invite mail
+  // sent by Zitadel to guide the user to your invitation page.
+  // If no template is set and no previous code was created, the default Zitadel url will be used.
+  //
+  // The following placeholders can be used: UserID, OrgID, Code
+  optional string url_template = 1 [
+    (validate.rules).string = {min_len: 1, max_len: 200},
+    example: "https://example.com/user/invite?userID={{.UserID}}&code={{.Code}}&orgID={{.OrgID}}"
+  ];
+  // Optionally set an application name, which will be used in the invite mail.
+  // If no application name is set and no previous code was created, Zitadel will be used as default.
+  optional string application_name = 2 [
+    (validate.rules).string = {min_len: 1, max_len: 200},
+    example: "CustomerPortal"
+  ];
+}
+
+message ReturnInviteCode {}
+```
+
+JSON shape: `{"sendCode": {"urlTemplate": "...", "applicationName": "Klai"}}`.
+
+**Critical:** the proto comment "If no template is set **and no previous code was created**, the default Zitadel url will be used" → Zitadel caches the `url_template` per user. If a previous invite-code was generated without `urlTemplate`, that cached default wins until a new call passes an explicit template. REQ-10 in spec.md forces explicit `urlTemplate` on every call to defeat this cache.
+
+### SendEmailVerificationCode (email.proto:41-55)
+
+```proto
+message SendEmailVerificationCode {
+  // Optionally set a url_template, which will be used in the verification mail
+  // sent by Zitadel to guide the user to your verification page.
+  // If no template is set, the default Zitadel url will be used.
+  //
+  // The following placeholders can be used: UserID, OrgID, Code
+  optional string url_template = 1 [
+    (validate.rules).string = {min_len: 1, max_len: 200},
+    example: "https://example.com/email/verify?userID={{.UserID}}&code={{.Code}}&orgID={{.OrgID}}"
+  ];
+}
+```
+
+JSON shape: `{"sendCode": {"urlTemplate": "..."}}`. No `application_name` field (email-verification mail does not use the app-name).
+
+### AddHumanUserRequest (user_service.proto:1992+ + user.proto:22-70)
+
+`POST /v2/users/human` accepts:
+- `username` (optional)
+- `profile.given_name` (required, ≤200)
+- `profile.family_name` (required, ≤200)
+- `profile.nick_name` (optional)
+- `profile.display_name` (optional)
+- `profile.preferred_language` (optional, ≤10)
+- `profile.gender` (optional, `Gender` enum)
+- `email.email` (required, RFC-822) + email-verification oneof: `is_verified: true` | `send_code: SendEmailVerificationCode` | `return_code: ReturnEmailVerificationCode`
+- `phone` (optional, similar shape)
+- `metadata` (optional)
+- `idpLinks` (optional)
+- `totpSecret` (optional)
+
+**Cannot trigger invite-mail directly.** The `email.send_code` oneof triggers an **email-verification** mail (not an invite mail). To send an invite, a separate `POST /v2/users/{user_id}/invite_code` is required. This is why REQ-2 mandates two sequential calls.
+
+## Decision matrix (3 alternatives considered)
+
+| Option | Description                                                                                     | Pros                                                          | Cons                                                                                                                                                                                                  | Decision |
+|--------|-------------------------------------------------------------------------------------------------|----------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
+| A      | `url_template` on each Zitadel v2 call                                                          | Single-layer change. Zitadel-native. Mirrors `successUrl` pattern already used for IDP intents. Smallest blast radius. | Three call-sites need parameter. Requires lint rule to enforce.                                                                                                                                       | **PICKED** |
+| B      | klai-mailer parses incoming `templateData.url`, swaps host to `my.getklai.com`, preserves query params | No portal-api change. Works even if someone hits Zitadel directly. | Brittle (Zitadel URL format may change between versions). Places routing decisions outside the layer that owns them. Adds complexity to klai-mailer beyond its "wrap content in HTML" responsibility. | Rejected |
+| C      | `returnCode: true`, portal-api receives the code in response, renders mail itself via klai-mailer's `/internal/send` | Maximum control. Independent of Zitadel notification provider. | Duplicates klai-mailer's existing Zitadel-notification-provider pipeline. Requires implementing retry, rate-limit, template-variables again. Two pipelines to maintain.                              | Rejected |
+
+Option A picked because it **completes the existing Klai pattern**. `urls.successUrl` (used today for IDP intents) and `url_template` (this SPEC) are the same architectural lever: portal-api injects its own URL into a Zitadel API call. Options B and C would *invent* a new layer where Klai already has the Zitadel-native answer.
+
+## Risks investigated
+
+### Risk 1: Login V2 base_uri interaction
+
+Login V2 instance feature has `base_uri = https://my.getklai.com`. The URL the user clicks lands them on `my.getklai.com/password/set?userID=…&code=…&orgID=…`. The Klai `/password/set` page does NOT initiate a Zitadel session; it only calls `POST /api/auth/password/set` which uses `ZitadelClient.set_password_with_code` (`zitadel.py:324`) — a `POST /v2/users/{userId}/password` with `verificationCode`. No OIDC flow is initiated from `/password/set`. Therefore Login V2 base_uri is irrelevant to this flow. ✅ No conflict.
+
+### Risk 2: Mail-template `{{.URL}}` consumer behaviour
+
+The button URL in the email body is `templateData.url` (per `klai-mailer/app/models.py:31` and `:54-55`). klai-mailer's renderer does:
+
+```python
+button_url=_append_lang_to_url(payload.button_url(), lang)  # renderer.py:120
+```
+
+`_append_lang_to_url` (renderer.py:28-44) appends `&lang=<lang>` if the URL already has `?`, else `?lang=<lang>`. Since the Zitadel-substituted URL is `https://my.getklai.com/password/set?userID=…&code=…&orgID=…` (contains `?`), klai-mailer appends `&lang=nl` → final URL `https://my.getklai.com/password/set?userID=…&code=…&orgID=…&lang=nl`. The frontend `password/set.tsx` validator (file:13-23) accepts unknown search params, so the extra `lang` is harmless. ✅ No conflict.
+
+### Risk 3: Email-change flow conflict
+
+Verified 2026-05-13 via grep across `klai-portal/backend/app/api/`: no end-user-facing email-change endpoint exists. The only `users/{id}/email/_verify` callsite (`zitadel.py:196`) is for admin/migration scripts. REQ-4 documents the forward-compat pattern in case a change-email flow is added; no current scope.
+
+### Risk 4: Tenant-subdomain users
+
+Per SPEC-AUTH-008 (Login V2 base_uri) and `klai-infra/SERVERS.md`, login always happens on `my.getklai.com`. Tenant subdomains like `voys.getklai.com` are the per-tenant chat UI, not the login UI. URL template hardcoded to `my.getklai.com` (via `settings.frontend_url`) is correct for all tenants. ✅ No per-tenant variation needed.
+
+### Risk 5: Existing in-flight Zitadel-default mails
+
+Per REQ-9 and AC-4: codes are URL-template-agnostic. The Klai `/password/set` route accepts the same `userID + code + orgID` payload as Zitadel's hosted UI; either UI completes the flow with the same Zitadel API call (`set_password_with_code`). No deploy-window blackout, no migration step.
+
+## Klai-mailer template inventory (current)
+
+From `klai-mailer/zitadel-message-texts/nl.yaml`:
+
+| Event-type     | Mail template title             | Triggered by                                                  | Current URL host          | Post-SPEC URL host   |
+|----------------|----------------------------------|---------------------------------------------------------------|----------------------------|------------------------|
+| `InitCode`     | "Account activeren"              | v1 `users/human/_import` with `sendCodes: True` (legacy)      | `auth.getklai.com`         | retired (REQ-2 split) |
+| `InviteUser`   | "Je bent uitgenodigd voor Klai"  | v2 `/v2/users/{id}/invite_code` with `sendCode`               | `auth.getklai.com`         | `my.getklai.com` ✅   |
+| `PasswordReset`| "Nieuw wachtwoord instellen"     | v2 `/v2/users/{id}/password_reset` with `sendLink`            | `auth.getklai.com`         | `my.getklai.com` ✅   |
+| `VerifyEmail`  | "Bevestig je e-mailadres bij Klai" | Future: `/v2/users/{id}/email/_send_code` with `sendCode`     | (not currently triggered)  | `my.getklai.com` (REQ-4 forward-compat) |
+| `PasswordChange` | "Je wachtwoord is gewijzigd"   | Automatic on password-set                                      | No button (informational)  | unchanged             |
+
+Post-SPEC: every email Klai issues that contains a click-link points at `my.getklai.com`. `PasswordChange` has no button (it's a security notification, not an action), so unaffected.
+
+## Open verification tasks (deferred to research phase of the SPEC run)
+
+1. **Live curl test against dev Zitadel.** Build an invite_code call with `sendCode.urlTemplate`, watch the resulting mail in dev SMTP, confirm `templateData.url` contains the Klai host. Falsifies the assumption that our Zitadel version (v4.x per SERVERS.md) honours `url_template`.
+2. **`_append_lang_to_url` spot-check.** Read `renderer.py:28-44` and verify the `&lang=` appending composes correctly with the multi-param Klai URL. Likely a no-op test (regex appends `&`), but worth a unit test to lock in.
+3. **Frontend search-param tolerance.** Confirm `password/set.tsx`'s `validateSearch` (file:13-23) ignores `lang`, `loginname`, `passwordset`, `authRequestID`, `organization` (the extras Zitadel might inject) without error. Spot-check from a manual reset.
+
+## References
+
+- Zitadel v2 user-service proto: https://github.com/zitadel/zitadel/blob/main/proto/zitadel/user/v2/user_service.proto
+- Zitadel v2 user proto (SendInviteCode): https://github.com/zitadel/zitadel/blob/main/proto/zitadel/user/v2/user.proto#L339
+- Zitadel v2 password proto (SendPasswordResetLink): https://github.com/zitadel/zitadel/blob/main/proto/zitadel/user/v2/password.proto#L38
+- Zitadel v2 email proto (SendEmailVerificationCode): https://github.com/zitadel/zitadel/blob/main/proto/zitadel/user/v2/email.proto#L41
+- Zitadel docs — Password Reset API: https://zitadel.com/docs/apis/resources/user_service_v2/user-service-password-reset
+- Zitadel docs — Custom Login UI password reset: https://zitadel.com/docs/guides/integrate/login-ui/password-reset
+- Klai SPEC-AUTH-008 (Login V2 + BFF): `.moai/specs/SPEC-AUTH-008/spec.md`
+- Klai rule — Zitadel platform: `.claude/rules/klai/platform/zitadel.md`
+- Klai rule — Mailer patterns: `.claude/rules/klai/projects/mailer.md`
+- Klai rule — Portal backend FRONTEND_URL pitfall: `.claude/rules/klai/projects/portal-backend.md`

--- a/.moai/specs/SPEC-PORTAL-AUTH-EMAIL-LINKS-001/spec.md
+++ b/.moai/specs/SPEC-PORTAL-AUTH-EMAIL-LINKS-001/spec.md
@@ -1,0 +1,234 @@
+---
+id: SPEC-PORTAL-AUTH-EMAIL-LINKS-001
+version: "0.1.0"
+status: draft
+created: "2026-05-13"
+updated: "2026-05-13"
+author: MoAI
+priority: P1
+supersedes: null
+related: [SPEC-AUTH-008, SPEC-SEC-MAILER-INJECTION-001]
+---
+
+## HISTORY
+
+| Date       | Version | Change                                                                         |
+|------------|---------|--------------------------------------------------------------------------------|
+| 2026-05-13 | 0.1.0   | Initial draft — Klai-branded UI for invite, password reset, email verification |
+
+# SPEC-PORTAL-AUTH-EMAIL-LINKS-001: Klai-branded URLs in Zitadel notification emails
+
+## Context
+
+Klai's auth architecture is **"Klai UI on the front, Zitadel v2 API on the back"**: for every user-facing interaction the portal has its own frontend route in `klai-portal/frontend/src/routes/` and its own portal-api endpoint in `klai-portal/backend/app/api/auth.py` that delegates to the Zitadel v2 API via the `ZitadelClient`. The user never sees Zitadel's hosted UI. The complete inventory of flows that already follow this pattern:
+
+| Klai UI                  | portal-api endpoint                                  | Zitadel v2 call                                                        |
+|--------------------------|------------------------------------------------------|------------------------------------------------------------------------|
+| `/login`                 | `/api/auth/login`                                    | `POST /v2/sessions`                                                    |
+| `/login` (TOTP)          | `/api/auth/totp-login`                               | `POST /v2/sessions/{id}` with TOTP                                     |
+| `/login` (Google SSO)    | `/api/auth/idp-intent` + `/idp-callback`             | `POST /v2/idp_intents` with `urls.successUrl` pointing at portal-api  |
+| `/login` (SSO complete)  | `/api/auth/sso-complete`                             | sessions API                                                           |
+| `/signup`                | `/api/auth/signup` + `/api/auth/idp-intent-signup`   | `POST /v2/users/human`, `POST /v2/idp_intents`                         |
+| `/verify`                | `/api/auth/verify-email`                             | `POST /v2/users/{id}/otp_email/_verify`                                |
+| `/setup/mfa`, `/setup/2fa` | `/api/auth/{totp,passkey,email-otp}/{setup,confirm}` | `POST /v2/users/{id}/{totp,passkeys,otp_email}`                        |
+| `/password/forgot`       | `/api/auth/password/reset`                           | `POST /v2/users/{id}/password_reset`                                   |
+| `/password/set`          | `/api/auth/password/set`                             | `POST /v2/users/{id}/password`                                         |
+
+Two routing mechanisms keep Zitadel pointed at Klai's UI:
+
+1. **Pre-auth login flows** — Zitadel Login V2 with instance `base_uri = https://my.getklai.com` (`.claude/rules/klai/platform/zitadel.md` § Login V2 base_uri). Every `oauth/v2/authorize` flow routes to `my.getklai.com/login?authRequest=…`.
+2. **IDP intent flows (Google SSO)** — the `create_idp_intent` call passes `urls.successUrl = "{settings.portal_url}/api/auth/idp-callback?…"` (`zitadel.py:574`, callsite `auth.py:1797`). Zitadel calls back into portal-api directly.
+
+There is one remaining surface where Zitadel still owns the URL: **email-link flows**. When a user is invited, requests a password reset, or (future) confirms a primary-email change, Zitadel pre-renders the message text, fills `templateData.url` with a link to **its own hosted UI** (`https://auth.getklai.com/ui/login/user/init?…`), and webhooks the payload to klai-mailer. klai-mailer wraps the content in the Klai HTML template and sends via SMTP. The mail is Klai-branded; the *destination* of the call-to-action button is not.
+
+Discovered 2026-05-13 by user activation through invite: the "Activeer User" landing page is the stock Zitadel UI, not `my.getklai.com/password/set` — even though `klai-portal/frontend/src/routes/password/set.tsx` and `POST /api/auth/password/set` (`auth.py:1051`) plus `ZitadelClient.set_password_with_code` (`zitadel.py:324`) already implement the full Klai-side flow.
+
+The Zitadel v2 API has native support for redirecting these links to a custom URL via the `url_template` field on `SendInviteCode`, `SendPasswordResetLink`, and `SendEmailVerificationCode`. Klai already uses the parallel `urls.successUrl` parameter on `create_idp_intent`. This SPEC completes the pattern for the three remaining email-link flows.
+
+This is a **consistency fix**, not an architecture change. It does not introduce a new abstraction layer, does not change klai-mailer, and does not migrate any other auth flow.
+
+---
+
+## Scope
+
+| Layer                | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+|----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Backend (portal-api) | `ZitadelClient.send_password_reset(user_id)` → add required `url_template: str` parameter. `ZitadelClient.resend_init_mail(org_id, user_id)` → add required `url_template: str` and optional `application_name: str = "Klai"`. New helper `ZitadelClient.send_invite_code(user_id, url_template, application_name="Klai")` invoking `POST /v2/users/{user_id}/invite_code` with `sendCode.urlTemplate`. `ZitadelClient.invite_user` callers split into two calls: `human/_import` with `sendCodes=False`, then `send_invite_code`. |
+| Callers              | `auth.py::password_reset` (`auth.py:1037`) passes the URL template. `admin/users.py::invite_user` (`admin/users.py:228`) and `admin/users.py::resend_invite` (`admin/users.py:506`) pass the template. Any other callsite is updated in the same PR. URL template values are derived from `settings.frontend_url`.                                                                                                                                                                                                                     |
+| CI / Lint            | New ast-grep rule `rules/no-zitadel-mail-without-url-template.yml` rejecting any `POST /v2/users/.../{password_reset,invite_code,invite_code/resend,email/_verify}` call whose JSON body does not contain `urlTemplate`. Wired into `.github/workflows/portal-api.yml`.                                                                                                                                                                                                                                                                  |
+| Tests                | Unit tests asserting payload shape for each of the three call sites. Existing `tests/test_user_lifecycle.py` updated. Integration smoke test in `klai-portal/backend/tests/test_zitadel_email_link_urls.py` that exercises the wire-level payload against a recorded fixture. E2E covered by `klai-portal/frontend/e2e/` invite + reset flow when the seeded storage-state fixture is active.                                                                                                                                            |
+| Configuration        | No new env-var. `settings.frontend_url` is the existing source of truth per `.claude/rules/klai/projects/portal-backend.md` § "FRONTEND_URL controls OAuth redirect URIs (CRIT)". Tenant-subdomain users still land on `my.getklai.com` per SPEC-AUTH-008 (Login V2 base_uri is the login domain, not the tenant-portal domain).                                                                                                                                                                                                            |
+| Klai-mailer          | No change. Continues to receive Zitadel webhooks with pre-rendered `templateData.url` and forwards them to the existing Klai HTML wrapper. The only difference: the URL inside the payload now points at `my.getklai.com` instead of `auth.getklai.com`.                                                                                                                                                                                                                                                                                |
+| Zitadel              | No instance-config change. Login V2 `base_uri` stays `my.getklai.com`. Message-text templates in Zitadel console stay unchanged. Notification provider URL stays `http://klai-mailer:8000/notify`.                                                                                                                                                                                                                                                                                                                                       |
+
+## Out of Scope
+
+- **Email-change flow** — no end-user-facing primary-email change endpoint exists in portal-api today (verified 2026-05-13 via grep across `klai-portal/backend/app/api/`). If such a flow is added in the future, REQ-4 contains the pattern to follow.
+- **Email-OTP signup flow** (`/api/auth/email-otp/resend`) — uses a 6-digit code the user types into `/verify`, not a click-link. No URL to override.
+- **InitCode legacy flow** — Zitadel's `InitCode` mail (event-type `InitCode` in klai-mailer/zitadel-message-texts/) is triggered by the v1 Management API's `users/human/_import` with `sendCodes: True`. This SPEC migrates to the v2 invite flow (REQ-2) where InitCode is replaced by `InviteUser`, retiring the InitCode mail. The InitCode message-text in `nl.yaml` / `en.yaml` is kept for backward-compat; once the migration is verified in production, removal is a follow-up.
+- **klai-mailer rewrite** — the alternative of having klai-mailer parse and rewrite `templateData.url` was considered and rejected as it places routing decisions outside the layer that owns them (portal-api).
+- **`returnCode` + Klai-rendered mail** — the alternative of receiving the code in the response and mailing it ourselves via klai-mailer's `/internal/send` was considered and rejected as it duplicates the Zitadel-notification-provider pipeline that already works for all other notification types.
+- **Removal of `auth.getklai.com/ui/login/user/init` access** — Zitadel's hosted UI remains technically reachable but no Klai-issued email points to it anymore. Disabling the route on Zitadel's side is a follow-up SPEC.
+
+---
+
+## Requirements
+
+### REQ-1: Password reset link template
+
+**WHEN** `auth.py::password_reset` (`POST /api/auth/password/reset`) successfully resolves a Zitadel user-id from the supplied email,
+**THEN** the portal SHALL invoke `ZitadelClient.send_password_reset(user_id, url_template)` with `url_template = f"{settings.frontend_url}/password/set?userID={{.UserID}}&code={{.Code}}&orgID={{.OrgID}}"`.
+
+**AND** the wire-level JSON body to `POST /v2/users/{user_id}/password_reset` SHALL contain exactly:
+
+```json
+{
+  "sendLink": {
+    "notificationType": "NOTIFICATION_TYPE_Email",
+    "urlTemplate": "https://my.getklai.com/password/set?userID={{.UserID}}&code={{.Code}}&orgID={{.OrgID}}"
+  }
+}
+```
+
+**AND** `ZitadelClient.send_password_reset` SHALL have signature `(self, user_id: str, *, url_template: str) -> None` — `url_template` is keyword-only and required. The previous parameter-less form is removed in the same commit; no callers may rely on Zitadel's default URL.
+
+### REQ-2: Invite link template (new-user invite)
+
+**WHEN** an admin invites a new user via `admin/users.py::invite_user`,
+**THEN** the portal SHALL perform two sequential calls:
+
+1. `POST /management/v1/users/human/_import` with `sendCodes: False` (no mail).
+2. `POST /v2/users/{user_id}/invite_code` with body:
+
+```json
+{
+  "sendCode": {
+    "urlTemplate": "https://my.getklai.com/password/set?userID={{.UserID}}&code={{.Code}}&orgID={{.OrgID}}",
+    "applicationName": "Klai"
+  }
+}
+```
+
+**AND** `ZitadelClient.invite_user` SHALL no longer pass `sendCodes: True`. A new helper `ZitadelClient.send_invite_code(user_id: str, *, url_template: str, application_name: str = "Klai") -> None` SHALL encapsulate call (2).
+
+**AND** the two calls SHALL be wrapped so that if call (2) fails after call (1) succeeds, the partial user is logged as `event="invite_partial_user_created"` with the userId at ERROR level and the HTTP response to the admin returns 502 with body `{"detail": "invite_partial_failure", "user_id": "..."}`. The orphan user can be remediated via `admin/users.py::resend_invite` (REQ-3) which re-issues only the invite_code call.
+
+### REQ-3: Invite link template (resend)
+
+**WHEN** an admin triggers `admin/users.py::resend_invite` (`POST /api/admin/users/{zitadel_user_id}/resend-invite`),
+**THEN** the portal SHALL invoke `ZitadelClient.send_invite_code(user_id, url_template=..., application_name="Klai")` with the same `url_template` as REQ-2.
+
+**AND** the old `ZitadelClient.resend_init_mail` method SHALL be deleted in the same commit. Its single caller is updated to call `send_invite_code` directly.
+
+### REQ-4: Email-verification link template (forward-compat)
+
+**WHEN** any future code path triggers Zitadel's `SendEmailVerificationCode` flow (`POST /v2/users/{user_id}/email`, `POST /v2/users/{user_id}/email/_resend`, or `POST /v2/users/{user_id}/email/_send_code`),
+**THEN** that call SHALL pass `sendCode.urlTemplate = f"{settings.frontend_url}/verify?userID={{.UserID}}&code={{.Code}}&orgID={{.OrgID}}"`.
+
+**AND** the CI lint in REQ-6 SHALL enforce presence of `urlTemplate` on these endpoints from day one, even though no code path triggers them today, to prevent future drift.
+
+### REQ-5: URL-template construction helper
+
+**WHEN** any caller composes a URL template for one of the three flows,
+**THEN** it SHALL use the helper `app.services.auth_links.build_url_template(route: AuthLinkRoute) -> str` defined in a new module `klai-portal/backend/app/services/auth_links.py`.
+
+```python
+class AuthLinkRoute(str, Enum):
+    PASSWORD_SET = "/password/set"
+    VERIFY_EMAIL = "/verify"
+
+def build_url_template(route: AuthLinkRoute) -> str:
+    """Compose the Zitadel url_template for an email-link flow.
+
+    Returns a URL with Zitadel placeholders {{.UserID}}, {{.Code}}, {{.OrgID}}
+    that Zitadel will substitute server-side before emitting the notification.
+    """
+    base = settings.frontend_url.rstrip("/")
+    return (
+        f"{base}{route.value}"
+        f"?userID={{{{.UserID}}}}&code={{{{.Code}}}}&orgID={{{{.OrgID}}}}"
+    )
+```
+
+**AND** the helper SHALL be the only place in `klai-portal/backend/app/` that composes Zitadel placeholder URLs. The CI lint in REQ-6 enforces this.
+
+### REQ-6: CI lint rule
+
+**WHEN** a PR modifies any Python file under `klai-portal/backend/app/`,
+**THEN** an ast-grep rule `rules/no-zitadel-mail-without-url-template.yml` SHALL fail the build if any of the following patterns appear without a sibling `urlTemplate` key:
+
+- `httpx` POST to a path matching `/v2/users/[^/]+/password_reset`
+- `httpx` POST to a path matching `/v2/users/[^/]+/invite_code(/resend)?`
+- `httpx` POST to a path matching `/v2/users/[^/]+/email(/_resend|/_send_code)?`
+- A hand-rolled URL placeholder string `"{{.UserID}}"` outside `app/services/auth_links.py`
+
+**AND** the rule SHALL be added to `.github/workflows/portal-api.yml` `Alerting provisioning checks` job. Existing pattern for ast-grep rules: `rules/no-zitadel-resourceowner-claim.yml` (see `.claude/rules/klai/platform/zitadel.md` § User lookup).
+
+### REQ-7: Boot-time assertion
+
+**WHEN** portal-api starts up,
+**THEN** a lifespan-phase assertion SHALL verify that `build_url_template(AuthLinkRoute.PASSWORD_SET)` produces a string that:
+
+1. Starts with `https://my.getklai.com` in production (`settings.frontend_url` matches), or `https://localhost` / `http://localhost` in dev.
+2. Contains all three placeholders `{{.UserID}}`, `{{.Code}}`, `{{.OrgID}}` literally (Zitadel does not URL-decode them).
+3. Is at most 200 characters (Zitadel `url_template` validation cap per proto).
+
+The assertion fails fast at startup. Pattern: same as `assert_portal_users_rls_ready()` in `klai-portal/backend/app/main.py`.
+
+### REQ-8: Observability
+
+**WHEN** any of the three Zitadel email-link calls succeed or fail,
+**THEN** the existing `_emit_auth_event` (`auth.py`) and `_slog.exception` paths SHALL be preserved — no new events. Additionally, on success of `send_invite_code` the existing `event="invite_user"` / `event="resend_invite"` logs in `admin/users.py` SHALL include the field `url_template_host` equal to `settings.frontend_url`'s host, so a VictoriaLogs query can prove the link host across all invites.
+
+### REQ-9: Backward compatibility of `/password/set`
+
+**WHEN** a user clicks a link in an in-flight Zitadel-default mail (sent before this SPEC's deploy) and lands on `auth.getklai.com/ui/login/user/init?…`,
+**THEN** the user SHALL still be able to set their password on Zitadel's hosted UI for the duration of the code's 72-hour TTL. The Klai-side `/password/set` route accepts the same `userID + code + orgID` payload and SHALL continue to accept codes that were generated by Zitadel-default URLs (the code itself is generated by Zitadel and is identical regardless of the URL template).
+
+**AND** no rollback mechanism is required — the change is forward-compatible. A re-deploy without the SPEC reverts new mails to Zitadel's default URL; existing codes keep working in either UI.
+
+### REQ-10: Caching gotcha mitigation
+
+**WHEN** `send_invite_code` is called for a user that already had an invite_code generated previously (e.g. an admin clicking "Resend invite"),
+**THEN** the portal SHALL ALWAYS pass an explicit `urlTemplate`, never relying on Zitadel's per-user cache.
+
+Per Zitadel proto comment (`user.proto:341`): *"If no template is set and no previous code was created, the default Zitadel url will be used."* This means: if a previous code WAS created (e.g. by a pre-SPEC deploy of `resend_init_mail` that did not pass `urlTemplate`), the cached previous template wins. The portal SHALL pass `urlTemplate` explicitly on every call to defeat the cache and converge stale templates within one resend cycle.
+
+---
+
+## Acceptance Criteria
+
+See `acceptance.md`.
+
+---
+
+## Deployment
+
+1. Land the code change. Image is built by `.github/workflows/portal-api.yml`.
+2. Smoke-test on staging: invite a test user, click the link in the mail, assert browser URL matches `https://my.getklai.com/password/set?userID=…&code=…&orgID=…`. Set password. Log in.
+3. Promote to production. No DB migration. No SOPS env-var change. No Zitadel instance-config change.
+4. Verify in VictoriaLogs:
+   - `service:klai-mailer AND eventType:InviteUser` → `templateData.url` field contains `my.getklai.com` (not `auth.getklai.com`).
+   - `service:portal-api AND event:invite_user AND url_template_host:my.getklai.com` count matches the number of admin invites.
+5. Watch for `event:invite_partial_user_created` (REQ-2). Zero is the expected count; any occurrence is an ops alert.
+
+---
+
+## Risks
+
+| Risk                                                                                                                                | Likelihood | Mitigation                                                                                                                                                                                                                |
+|-------------------------------------------------------------------------------------------------------------------------------------|------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `urlTemplate` field name in JSON body differs between Zitadel versions (proto vs HTTP gateway)                                       | Low        | Verified via raw proto inspection (`zitadel/user/v2/{user,password,email}.proto`). HTTP gateway uses camelCase: `urlTemplate`, `applicationName`, `notificationType`. Integration test in REQ-1 unit-tests the exact JSON. |
+| Invite partial-success leaves orphan Zitadel users without invite mail (REQ-2 call 1 succeeds, call 2 fails)                         | Low        | REQ-2 documents the failure response and recovery path (`resend_invite` re-issues call 2). Operator playbook in `docs/runbooks/`. Monitoring: VictoriaLogs alert on `event:invite_partial_user_created`.                   |
+| Login V2 base_uri vs frontend_url drift across environments (dev/staging/prod)                                                       | Low        | REQ-7 boot assertion catches drift at startup. Existing `FRONTEND_URL` pitfall is documented (`.claude/rules/klai/projects/portal-backend.md`).                                                                            |
+| Zitadel caches the previous `url_template` per user (REQ-10)                                                                         | Medium     | REQ-10 forces explicit `urlTemplate` on every call; first new call converges the cache. Smoke-test in deployment step 4 verifies link host.                                                                                |
+| Mid-deploy: some users have in-flight Zitadel-default mails, others get Klai-mails                                                   | Low        | REQ-9 documents forward-compat — both UIs accept the same code. Zitadel-default UI keeps working for the 72h TTL of any in-flight code.                                                                                    |
+| ast-grep rule (REQ-6) misses a future Zitadel SDK migration that changes call shape                                                  | Low        | Rule is keyed on HTTP path strings, which are stable across SDK versions. Boot assertion (REQ-7) is a second line of defence.                                                                                              |
+
+---
+
+## Open Verification Tasks (research phase)
+
+- [ ] Run an integration test against the actual Klai dev Zitadel instance: invite a synthetic user, assert the email body contains the `my.getklai.com` URL. Required to falsify the assumption that `urlTemplate` is honoured by our specific Zitadel version (currently v4.x — `klai-infra/SERVERS.md`).
+- [ ] Verify that `klai-mailer` passes through the substituted URL byte-identically (no rewrites in `renderer.py::_append_lang_to_url`). The `lang` query-param appending in `klai-mailer/app/renderer.py:28` adds `?lang=...` to the URL; verify this composes correctly when our URL already has `?userID=...` (should use `&lang=...`). Spot-check by reading `_append_lang_to_url`.
+- [ ] Confirm `klai-portal/frontend/src/routes/password/set.tsx` happily accepts the URL produced when both `?` and `&` separators are in play (Zitadel substitutes the placeholders, then klai-mailer may append `&lang=nl`). The frontend validator on `search` params already accepts unknown keys per file:13-23.

--- a/.moai/specs/SPEC-PORTAL-AUTH-EMAIL-LINKS-001/spec.md
+++ b/.moai/specs/SPEC-PORTAL-AUTH-EMAIL-LINKS-001/spec.md
@@ -155,14 +155,28 @@ def build_url_template(route: AuthLinkRoute) -> str:
 ### REQ-6: CI lint rule
 
 **WHEN** a PR modifies any Python file under `klai-portal/backend/app/`,
-**THEN** an ast-grep rule `rules/no-zitadel-mail-without-url-template.yml` SHALL fail the build if any of the following patterns appear without a sibling `urlTemplate` key:
+**THEN** `tests/test_zitadel_email_link_lint.py` SHALL fail the build if any
+`<client>.post(<path>, …)` call has a path matching one of the following AND
+the call body does not contain the literal string `urlTemplate`:
 
-- `httpx` POST to a path matching `/v2/users/[^/]+/password_reset`
-- `httpx` POST to a path matching `/v2/users/[^/]+/invite_code(/resend)?`
-- `httpx` POST to a path matching `/v2/users/[^/]+/email(/_resend|/_send_code)?`
-- A hand-rolled URL placeholder string `"{{.UserID}}"` outside `app/services/auth_links.py`
+- `/v2/users/[^/]+/password_reset`
+- `/v2/users/[^/]+/invite_code(/resend)?`
+- `/v2/users/[^/]+/email/(_send_code|_resend)`
 
-**AND** the rule SHALL be added to `.github/workflows/portal-api.yml` `Alerting provisioning checks` job. Existing pattern for ast-grep rules: `rules/no-zitadel-resourceowner-claim.yml` (see `.claude/rules/klai/platform/zitadel.md` § User lookup).
+**AND** the lint SHALL be implemented in pure Python `ast` module against
+`klai-portal/backend/app/**/*.py`. Pivoted from an ast-grep YAML rule
+during implementation (2026-05-13): ast-grep's `not: has: regex:` semantics
+do not reliably express "call without a literal substring in the body" at
+sub-expression granularity, while a 50-line `ast.walk` does so trivially.
+The pytest implementation:
+
+- Runs in the existing `pytest` step of `.github/workflows/portal-api.yml`
+  with zero additional CI wiring (the existing portal-api workflow already
+  runs `pytest tests/`).
+- Includes self-tests with 5 bad fixtures and 5 good fixtures so the
+  lint cannot silently become a no-op if the scanner drifts.
+- Walks the AST so it handles both `f"/v2/users/{uid}/..."` and constant
+  string variants.
 
 ### REQ-7: Boot-time assertion
 

--- a/klai-portal/backend/app/api/admin/users.py
+++ b/klai-portal/backend/app/api/admin/users.py
@@ -4,6 +4,7 @@ import logging
 from collections.abc import Mapping
 from datetime import datetime
 from typing import Final, Literal
+from urllib.parse import urlparse
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -28,6 +29,7 @@ from app.core.permissions import (
 from app.models.groups import PortalGroup, PortalGroupMembership
 from app.models.portal import PortalOrg, PortalUser
 from app.services.audit import log_event
+from app.services.auth_links import AuthLinkRoute, build_url_template
 from app.services.github import remove_github_org_member
 from app.services.kb_offboarding import (
     KbDisposition,
@@ -241,6 +243,31 @@ async def invite_user(
 
     zitadel_user_id: str = user_data["userId"]
 
+    # SPEC-PORTAL-AUTH-EMAIL-LINKS-001 REQ-2: the user now exists in Zitadel
+    # but no invite mail was sent (invite_user used sendCodes=False). Issue
+    # the invite code with an explicit Klai urlTemplate so the activation
+    # link in the mail lands on my.getklai.com/password/set, not on
+    # auth.getklai.com/ui/login/. If this second call fails after the first
+    # succeeded, we return 502 with the orphan userId so an admin can recover
+    # via the resend-invite endpoint (which re-issues only call 2).
+    invite_url_template = build_url_template(AuthLinkRoute.PASSWORD_SET)
+    try:
+        await zitadel.send_invite_code(zitadel_user_id, url_template=invite_url_template)
+    except Exception as exc:
+        _slog.exception(
+            "invite_partial_user_created",
+            zitadel_user_id=zitadel_user_id,
+            email=body.email,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail={
+                "code": "invite_partial_failure",
+                "user_id": zitadel_user_id,
+                "message": "User created but invite mail failed — retry via resend-invite",
+            },
+        ) from exc
+
     # SPEC-SEC-TENANT-001 REQ-2 (v0.5.0 / β): only portal_role="admin" gets a
     # Zitadel grant; group-admin and member rely on portal_users.role for
     # authorization. v0.1 hardcoded role="org:owner" for every invite — the
@@ -324,7 +351,16 @@ async def invite_user(
 
     await create_default_personal_kb(zitadel_user_id, org.id, db)
     await db.commit()
-    logger.info("User invited: email=%s, role=%s, org_id=%d", body.email, body.role, org.id)
+    # SPEC-PORTAL-AUTH-EMAIL-LINKS-001 REQ-8: emit url_template_host so a
+    # VictoriaLogs query can prove the link host across all invites.
+    _slog.info(
+        "invite_user",
+        email=body.email,
+        role=body.role,
+        org_id=org.id,
+        zitadel_user_id=zitadel_user_id,
+        url_template_host=urlparse(invite_url_template).netloc,
+    )
 
     return InviteResponse(
         user_id=zitadel_user_id,
@@ -519,16 +555,26 @@ async def resend_invite(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
     try:
-        await zitadel.resend_init_mail(
-            org_id=settings.zitadel_portal_org_id,
-            user_id=zitadel_user_id,
-        )
+        # SPEC-PORTAL-AUTH-EMAIL-LINKS-001 REQ-3: replaces the legacy
+        # resend_init_mail. Same v2 endpoint, but with an explicit Klai
+        # urlTemplate. REQ-10 — always pass urlTemplate to defeat Zitadel's
+        # per-user url_template cache (a previous Zitadel-default URL would
+        # otherwise persist).
+        invite_url_template = build_url_template(AuthLinkRoute.PASSWORD_SET)
+        await zitadel.send_invite_code(zitadel_user_id, url_template=invite_url_template)
     except Exception as exc:
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail=f"Failed to resend invitation: {exc}",
         ) from exc
 
+    # SPEC-PORTAL-AUTH-EMAIL-LINKS-001 REQ-8: same observability field on resend.
+    _slog.info(
+        "resend_invite",
+        zitadel_user_id=zitadel_user_id,
+        org_id=perms.org_id,
+        url_template_host=urlparse(invite_url_template).netloc,
+    )
     return MessageResponse(message="Invitation resent.")
 
 

--- a/klai-portal/backend/app/api/auth.py
+++ b/klai-portal/backend/app/api/auth.py
@@ -61,6 +61,7 @@ from app.core.config import settings
 from app.core.database import AsyncSessionLocal, get_db
 from app.models.portal import PortalOrg, PortalUser
 from app.services import audit
+from app.services.auth_links import AuthLinkRoute, build_url_template
 from app.services.bff_session import SessionService
 from app.services.events import emit_event
 from app.services.pending_session import PendingSessionService
@@ -1034,7 +1035,10 @@ async def password_reset(body: PasswordResetRequest) -> None:
         return  # unknown email — return 204 silently (REQ-3.2)
 
     try:
-        await zitadel.send_password_reset(user_id)
+        # SPEC-PORTAL-AUTH-EMAIL-LINKS-001 REQ-1: point the reset link at Klai's
+        # /password/set page, not Zitadel's hosted /ui/login/.
+        url_template = build_url_template(AuthLinkRoute.PASSWORD_SET)
+        await zitadel.send_password_reset(user_id, url_template=url_template)
     except httpx.HTTPStatusError as exc:
         _slog.exception("send_password_reset_failed", zitadel_status=exc.response.status_code)
         _emit_auth_event(

--- a/klai-portal/backend/app/main.py
+++ b/klai-portal/backend/app/main.py
@@ -228,6 +228,15 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     await assert_portal_users_rls_ready()
     logger.info("portal_users RLS policy checked: IS NULL branch present")
 
+    # SPEC-PORTAL-AUTH-EMAIL-LINKS-001 REQ-7: refuse to start if FRONTEND_URL /
+    # DOMAIN are misconfigured. Without a valid portal_url, the Zitadel email-
+    # link flows would silently fall back to Zitadel's hosted UI instead of
+    # Klai's /password/set route.
+    from app.services.auth_links import assert_auth_link_templates_ready
+
+    assert_auth_link_templates_ready()
+    logger.info("auth_links url_template checked: portal_url is valid")
+
     await _run_stuck_detector()
 
     poller_task = asyncio.create_task(poll_loop())

--- a/klai-portal/backend/app/services/auth_links.py
+++ b/klai-portal/backend/app/services/auth_links.py
@@ -1,0 +1,110 @@
+"""URL-template builder for Zitadel email-link flows.
+
+SPEC-PORTAL-AUTH-EMAIL-LINKS-001 REQ-5.
+
+Zitadel v2 emits invite, password-reset, and email-verification mails with a
+button link whose target URL is built from a ``url_template`` field that Zitadel
+substitutes server-side using ``{{.UserID}}``, ``{{.Code}}`` and ``{{.OrgID}}``
+placeholders. Klai pins those links to ``my.getklai.com`` so the user lands on
+the Klai-branded ``/password/set`` (or future ``/verify``) route instead of
+Zitadel's stock hosted UI.
+
+This module is the SINGLE place in ``klai-portal/backend/app`` that composes
+those template URLs. The ``tests/test_zitadel_email_link_lint.py`` AST-walker
+test (SPEC REQ-6) enforces that every Zitadel email-link API call passes a
+literal ``urlTemplate`` in its JSON body.
+
+Why a helper instead of inline strings: every caller builds the same URL, and
+forgetting one placeholder produces a silent regression (Zitadel ships a
+mail with an unusable link). Centralising in one module + boot-time assertion
+(SPEC REQ-7) closes the loop.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from urllib.parse import urlparse
+
+from app.core.config import settings
+
+# Zitadel substitutes these tokens server-side. They must appear literally in
+# the URL we send — no URL-encoding, no formatting. See proto:
+#   zitadel/user/v2/{user,password,email}.proto — url_template field comments.
+_QUERY_TEMPLATE = "?userID={{.UserID}}&code={{.Code}}&orgID={{.OrgID}}"
+
+# Per-proto max length for url_template across all three Send* messages.
+# (validate.rules).string = {min_len: 1, max_len: 200}
+URL_TEMPLATE_MAX_LEN = 200
+
+
+class AuthLinkRoute(StrEnum):
+    """Klai frontend routes that consume Zitadel-substituted auth links.
+
+    The enum value is the frontend path. Adding a new value here is the
+    one-line change required to wire up a new Zitadel email-link flow
+    (e.g. a future email-change verification flow — SPEC REQ-4).
+    """
+
+    PASSWORD_SET = "/password/set"
+    VERIFY_EMAIL = "/verify"
+
+
+def build_url_template(route: AuthLinkRoute) -> str:
+    """Compose the Zitadel ``url_template`` for an email-link flow.
+
+    Returns a URL of the form
+    ``<portal_url>/<route>?userID={{.UserID}}&code={{.Code}}&orgID={{.OrgID}}``
+    where the three placeholders are passed literally for Zitadel to substitute.
+
+    Uses ``settings.portal_url`` (which falls back to ``f"https://portal.{domain}"``
+    if ``FRONTEND_URL`` is empty) — same source of truth as ``auth.py``'s
+    ``create_idp_intent.success_url`` (SPEC-AUTH-008 callsite pattern).
+
+    Raises ``RuntimeError`` if the resulting URL exceeds the 200-character
+    proto-level cap — this would cause Zitadel to reject the call with a
+    validation error at runtime, which is harder to diagnose than a fail-fast.
+    """
+    base = settings.portal_url.rstrip("/")
+    template = base + route.value + _QUERY_TEMPLATE
+    if len(template) > URL_TEMPLATE_MAX_LEN:
+        raise RuntimeError(
+            f"auth_links url_template exceeds Zitadel max_len=200: "
+            f"len={len(template)} route={route.value} base={base!r}"
+        )
+    return template
+
+
+def assert_auth_link_templates_ready() -> None:
+    """Boot-time assertion (SPEC REQ-7).
+
+    Called from ``app.main.lifespan``. Refuses to start the container if:
+      * ``portal_url`` is empty or malformed
+      * the composed template misses any of the three placeholders
+      * the composed template exceeds the 200-char proto cap
+
+    The pattern mirrors ``assert_portal_users_rls_ready()`` — fail loud at
+    startup, not at first request.
+    """
+    portal_url = settings.portal_url
+    if not portal_url:
+        raise RuntimeError(
+            "auth_links: settings.portal_url is empty. "
+            "Cannot build Zitadel url_template — refusing to start. "
+            "Set FRONTEND_URL (e.g. https://my.getklai.com) in the env, "
+            "or ensure DOMAIN is configured so portal_url falls back to "
+            "https://portal.<domain>."
+        )
+    parsed = urlparse(portal_url)
+    if not parsed.scheme or not parsed.netloc:
+        raise RuntimeError(
+            f"auth_links: settings.portal_url is not a URL: {portal_url!r}. Expected scheme://host form."
+        )
+
+    required_placeholders = ("{{.UserID}}", "{{.Code}}", "{{.OrgID}}")
+    for route in AuthLinkRoute:
+        template = build_url_template(route)
+        for placeholder in required_placeholders:
+            if placeholder not in template:
+                raise RuntimeError(
+                    f"auth_links url_template for {route.name} is missing placeholder {placeholder!r}: {template!r}"
+                )

--- a/klai-portal/backend/app/services/zitadel.py
+++ b/klai-portal/backend/app/services/zitadel.py
@@ -162,7 +162,17 @@ class ZitadelClient:
         last_name: str,
         preferred_language: str = "nl",
     ) -> dict:
-        """Create a human user and send initialization email (password-less invite).
+        """Create a human user WITHOUT sending the activation email.
+
+        SPEC-PORTAL-AUTH-EMAIL-LINKS-001 REQ-2 — formerly this method passed
+        ``sendCodes: True`` so Zitadel auto-mailed an init-code link to its
+        own hosted UI. The split is now:
+
+          1. This method imports the user with ``sendCodes: False`` — no mail.
+          2. The caller follows up with :meth:`send_invite_code` which uses
+             the v2 ``/v2/users/{id}/invite_code`` endpoint with a Klai
+             ``urlTemplate``, sending the activation mail with a link to
+             ``my.getklai.com/password/set``.
 
         ``userName`` is lowercased before submission — see
         ``create_human_user`` for rationale. The display ``email`` field
@@ -184,11 +194,54 @@ class ZitadelClient:
                     "email": email,
                     "isEmailVerified": False,
                 },
-                "sendCodes": True,
+                # REQ-2: never let Zitadel mail an init-code with a default
+                # hosted-UI URL. The caller issues a follow-up send_invite_code
+                # call with an explicit Klai urlTemplate.
+                "sendCodes": False,
             },
         )
         resp.raise_for_status()
         return resp.json()
+
+    async def send_invite_code(
+        self,
+        user_id: str,
+        *,
+        url_template: str,
+        application_name: str = "Klai",
+    ) -> None:
+        """Issue (or re-issue) a Zitadel invite code and mail it to the user.
+
+        SPEC-PORTAL-AUTH-EMAIL-LINKS-001 REQ-2 / REQ-3. Used both by the
+        new-user invite flow (right after ``invite_user``) and the
+        resend-invite flow (replaces the legacy ``resend_init_mail``).
+
+        Body shape (per zitadel/user/v2/user.proto::SendInviteCode):
+
+        .. code-block:: json
+
+            {
+              "sendCode": {
+                "urlTemplate": "https://my.getklai.com/password/set?userID=...",
+                "applicationName": "Klai"
+              }
+            }
+
+        REQ-10 — ``url_template`` MUST be set explicitly on every call.
+        Zitadel caches the previous url_template per user; relying on the
+        cache means a stale Zitadel-default URL silently wins on the next
+        resend if the previous call did not pass urlTemplate.
+        """
+        resp = await self._http.post(
+            f"/v2/users/{user_id}/invite_code",
+            json={
+                "sendCode": {
+                    "urlTemplate": url_template,
+                    "applicationName": application_name,
+                },
+            },
+        )
+        resp.raise_for_status()
 
     async def verify_user_email(self, org_id: str, user_id: str, code: str) -> None:
         """Verify a user's email address using the code from the verification email."""
@@ -405,21 +458,40 @@ class ZitadelClient:
         )
         put_resp.raise_for_status()
 
-    async def resend_init_mail(self, org_id: str, user_id: str) -> None:
-        """Resend the invite email to a user who hasn't completed setup.
+    # resend_init_mail was deleted in SPEC-PORTAL-AUTH-EMAIL-LINKS-001 REQ-3.
+    # Use ``send_invite_code(user_id, url_template=...)`` instead — same API
+    # call, but with an explicit Klai urlTemplate instead of {} (which made
+    # Zitadel default to its own hosted UI).
 
-        Uses the Zitadel v2 invite_code API. The Management v1 resend_init_mail
-        endpoint returns NOT_FOUND once the original init code expires (72h TTL).
+    async def send_password_reset(self, user_id: str, *, url_template: str) -> None:
+        """Trigger Zitadel to send a password reset email to the user.
+
+        SPEC-PORTAL-AUTH-EMAIL-LINKS-001 REQ-1: ``url_template`` is keyword-only
+        and required. Zitadel substitutes ``{{.UserID}}``, ``{{.Code}}`` and
+        ``{{.OrgID}}`` server-side before mailing the link. Callers MUST build
+        the template via :func:`app.services.auth_links.build_url_template` so
+        every Klai mail-link points at the same frontend route.
+
+        Body shape (per zitadel/user/v2/password.proto::SendPasswordResetLink):
+
+        .. code-block:: json
+
+            {
+              "sendLink": {
+                "notificationType": "NOTIFICATION_TYPE_Email",
+                "urlTemplate": "https://my.getklai.com/password/set?userID=..."
+              }
+            }
         """
         resp = await self._http.post(
-            f"/v2/users/{user_id}/invite_code",
-            json={"sendCode": {}},
+            f"/v2/users/{user_id}/password_reset",
+            json={
+                "sendLink": {
+                    "notificationType": "NOTIFICATION_TYPE_Email",
+                    "urlTemplate": url_template,
+                },
+            },
         )
-        resp.raise_for_status()
-
-    async def send_password_reset(self, user_id: str) -> None:
-        """Trigger Zitadel to send a password reset email to the user."""
-        resp = await self._http.post(f"/v2/users/{user_id}/password_reset")
         resp.raise_for_status()
 
     # ── MFA / TOTP ────────────────────────────────────────────────────────────

--- a/klai-portal/backend/tests/test_admin_users.py
+++ b/klai-portal/backend/tests/test_admin_users.py
@@ -168,6 +168,7 @@ async def test_invite_user_grants_portal_role_to_zitadel(
         ),
     ):
         mock_zitadel.invite_user = AsyncMock(return_value={"userId": f"new-user-{portal_role}"})
+        mock_zitadel.send_invite_code = AsyncMock()  # SPEC-PORTAL-AUTH-EMAIL-LINKS-001 REQ-2
         mock_zitadel.grant_user_role = AsyncMock()
         await invite_user(body=body, perms=perms, db=mock_db)
 
@@ -255,6 +256,7 @@ async def test_invite_user_creates_personal_kb_before_commit() -> None:
         ),
     ):
         mock_zitadel.invite_user = AsyncMock(return_value={"userId": "new-user-id"})
+        mock_zitadel.send_invite_code = AsyncMock()  # SPEC-PORTAL-AUTH-EMAIL-LINKS-001 REQ-2
         mock_zitadel.grant_user_role = AsyncMock()
         await invite_user(body=body, perms=perms, db=mock_db)
 

--- a/klai-portal/backend/tests/test_admin_users_seat_phase2.py
+++ b/klai-portal/backend/tests/test_admin_users_seat_phase2.py
@@ -83,6 +83,7 @@ async def test_invite_user_default_seat_from_role(role: str, expected_default_se
         ),
     ):
         mock_zitadel.invite_user = AsyncMock(return_value={"userId": f"new-user-{role}"})
+        mock_zitadel.send_invite_code = AsyncMock()  # SPEC-PORTAL-AUTH-EMAIL-LINKS-001 REQ-2
         mock_zitadel.grant_user_role = AsyncMock()
         await invite_user(body=body, perms=perms, db=mock_db)
 
@@ -139,6 +140,7 @@ async def test_invite_user_ignores_client_supplied_seat_override() -> None:
         ),
     ):
         mock_zitadel.invite_user = AsyncMock(return_value={"userId": "u-km"})
+        mock_zitadel.send_invite_code = AsyncMock()  # SPEC-PORTAL-AUTH-EMAIL-LINKS-001 REQ-2
         mock_zitadel.grant_user_role = AsyncMock()
         await invite_user(body=body, perms=perms, db=mock_db)
 

--- a/klai-portal/backend/tests/test_auth_links.py
+++ b/klai-portal/backend/tests/test_auth_links.py
@@ -1,0 +1,81 @@
+"""Unit tests for app.services.auth_links — SPEC-PORTAL-AUTH-EMAIL-LINKS-001 REQ-5/REQ-7."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.config import settings
+from app.services.auth_links import (
+    URL_TEMPLATE_MAX_LEN,
+    AuthLinkRoute,
+    assert_auth_link_templates_ready,
+    build_url_template,
+)
+
+
+class TestBuildUrlTemplate:
+    def test_password_set_template_shape(self):
+        """REQ-5: produces <portal_url>/password/set?userID=...&code=...&orgID=..."""
+        url = build_url_template(AuthLinkRoute.PASSWORD_SET)
+        base = settings.portal_url.rstrip("/")
+        assert url == base + "/password/set?userID={{.UserID}}&code={{.Code}}&orgID={{.OrgID}}"
+
+    def test_verify_email_template_shape(self):
+        """REQ-4 forward-compat: verify-email route uses the same placeholders."""
+        url = build_url_template(AuthLinkRoute.VERIFY_EMAIL)
+        base = settings.portal_url.rstrip("/")
+        assert url == base + "/verify?userID={{.UserID}}&code={{.Code}}&orgID={{.OrgID}}"
+
+    def test_all_three_placeholders_present_literally(self):
+        """Zitadel substitutes server-side; placeholders MUST appear as literal text."""
+        for route in AuthLinkRoute:
+            url = build_url_template(route)
+            assert "{{.UserID}}" in url, f"{route.name} missing UserID placeholder"
+            assert "{{.Code}}" in url, f"{route.name} missing Code placeholder"
+            assert "{{.OrgID}}" in url, f"{route.name} missing OrgID placeholder"
+
+    def test_template_under_proto_max_len(self):
+        """Zitadel proto caps url_template at 200 chars across all three Send* messages."""
+        for route in AuthLinkRoute:
+            url = build_url_template(route)
+            assert len(url) <= URL_TEMPLATE_MAX_LEN, (
+                f"{route.name} template too long: {len(url)}>{URL_TEMPLATE_MAX_LEN}"
+            )
+
+    def test_trailing_slash_in_frontend_url_does_not_double(self, monkeypatch):
+        """Defensive: FRONTEND_URL with trailing slash should not produce //path."""
+        monkeypatch.setattr(settings, "frontend_url", "https://my.getklai.com/")
+        url = build_url_template(AuthLinkRoute.PASSWORD_SET)
+        assert url == "https://my.getklai.com/password/set?userID={{.UserID}}&code={{.Code}}&orgID={{.OrgID}}"
+        assert "//password" not in url
+
+    def test_oversized_frontend_url_raises(self, monkeypatch):
+        """If a future env-var pushes the URL past 200 chars, fail fast."""
+        long_host = "https://" + "x" * 200 + ".example.com"
+        monkeypatch.setattr(settings, "frontend_url", long_host)
+        with pytest.raises(RuntimeError, match="exceeds Zitadel max_len=200"):
+            build_url_template(AuthLinkRoute.PASSWORD_SET)
+
+
+class TestAssertAuthLinkTemplatesReady:
+    """REQ-7: boot-time assertion catches misconfigured FRONTEND_URL / DOMAIN."""
+
+    def test_passes_with_default_settings(self):
+        """Default settings (FRONTEND_URL or DOMAIN-fallback) pass silently."""
+        assert_auth_link_templates_ready()  # raises on failure
+
+    def test_scheme_only_portal_url_raises(self, monkeypatch):
+        """A URL with no host (e.g. ``https://``) fails the boot check."""
+        monkeypatch.setattr(settings, "frontend_url", "https://")
+        with pytest.raises(RuntimeError, match="not a URL"):
+            assert_auth_link_templates_ready()
+
+    def test_non_url_frontend_url_raises(self, monkeypatch):
+        monkeypatch.setattr(settings, "frontend_url", "my.getklai.com")  # missing scheme
+        with pytest.raises(RuntimeError, match="not a URL"):
+            assert_auth_link_templates_ready()
+
+    def test_localhost_dev_url_passes(self, monkeypatch):
+        """Per SPEC REQ-7: localhost is valid in dev."""
+        monkeypatch.setattr(settings, "frontend_url", "http://localhost:5173")
+        assert_auth_link_templates_ready()

--- a/klai-portal/backend/tests/test_rbac_phase3_enforcement.py
+++ b/klai-portal/backend/tests/test_rbac_phase3_enforcement.py
@@ -237,6 +237,7 @@ class TestPlanCeilingGoneOnRoleAssignment:
             ),
         ):
             mock_zitadel.invite_user = AsyncMock(return_value={"userId": "new-km"})
+            mock_zitadel.send_invite_code = AsyncMock()  # SPEC-PORTAL-AUTH-EMAIL-LINKS-001 REQ-2
             mock_zitadel.grant_user_role = AsyncMock()
             # Must not raise — plan ceiling is gone.
             await invite_user(body=body, perms=perms, db=mock_db)
@@ -283,6 +284,7 @@ class TestPlanCeilingGoneOnRoleAssignment:
             ),
         ):
             mock_zitadel.invite_user = AsyncMock(return_value={"userId": "new-over"})
+            mock_zitadel.send_invite_code = AsyncMock()  # SPEC-PORTAL-AUTH-EMAIL-LINKS-001 REQ-2
             mock_zitadel.grant_user_role = AsyncMock()
             # Must not raise. Pre-Phase-3 raised
             # HTTPException(409, "Seat limit reached").

--- a/klai-portal/backend/tests/test_zitadel_email_link_lint.py
+++ b/klai-portal/backend/tests/test_zitadel_email_link_lint.py
@@ -1,0 +1,175 @@
+"""SPEC-PORTAL-AUTH-EMAIL-LINKS-001 REQ-6 — AST-level lint.
+
+Scans every Python file under ``klai-portal/backend/app/`` for ``await
+<client>.post(<path>, ...)`` calls where ``<path>`` matches one of the
+four Zitadel v2 email-link endpoints, and asserts the JSON body contains
+``urlTemplate``. The lint is a regression net against silent drift —
+Zitadel caches the previous url_template per user, so a single call
+without urlTemplate silently restores the previous (possibly Zitadel-default)
+URL in every subsequent mail.
+
+This is implemented as a pytest test rather than an ast-grep YAML rule
+because Python's stdlib ``ast`` module gives us exact control over the
+"call without literal ``urlTemplate`` key" predicate that ast-grep's
+relational matchers express awkwardly.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+APP_DIR = Path(__file__).resolve().parents[1] / "app"
+
+# Endpoints whose POST body MUST contain "urlTemplate". Sourced from
+# zitadel/user/v2/{user,password,email}.proto where SendInviteCode,
+# SendPasswordResetLink, and SendEmailVerificationCode all carry a
+# ``url_template`` field.
+_ENDPOINT_PATTERNS = (
+    re.compile(r"/v2/users/[^/]+(?:/invite_code(?:/resend)?|/password_reset)"),
+    re.compile(r"/v2/users/[^/]+/email/(?:_send_code|_resend)"),
+)
+
+
+def _extract_path_str(node: ast.expr) -> str | None:
+    """Return the static path string of the first argument to a .post() call,
+    or None if the path is built dynamically and we cannot statically inspect it.
+    """
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.JoinedStr):
+        # f-string: concatenate the literal parts; placeholder parts are
+        # represented as FormattedValue and replaced with a generic token so
+        # the regex still recognises the endpoint shape.
+        out: list[str] = []
+        for part in node.values:
+            if isinstance(part, ast.Constant) and isinstance(part.value, str):
+                out.append(part.value)
+            else:
+                out.append("X")  # placeholder for any FormattedValue
+        return "".join(out)
+    return None
+
+
+def _body_contains_url_template(call: ast.Call) -> bool:
+    """Check if any kwarg/dict in the call's arguments contains the literal
+    string ``urlTemplate`` (either as a dict key or anywhere in a string)."""
+    # Cheapest check: ast.unparse the full call and grep for the literal.
+    # urlTemplate is sufficiently rare in API payloads that string-search has
+    # no false positives in this codebase.
+    return "urlTemplate" in ast.unparse(call)
+
+
+def _scan_file(path: Path) -> list[tuple[int, str]]:
+    """Return a list of (line, endpoint_path) offences in this file."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return []  # leave parser errors to ruff/pyright
+
+    offences: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        # Match <something>.post(<path>, ...)
+        if not isinstance(node.func, ast.Attribute) or node.func.attr != "post":
+            continue
+        if not node.args:
+            continue
+        url = _extract_path_str(node.args[0])
+        if url is None:
+            continue
+        if not any(p.search(url) for p in _ENDPOINT_PATTERNS):
+            continue
+        if _body_contains_url_template(node):
+            continue
+        offences.append((node.lineno, url))
+    return offences
+
+
+def test_all_zitadel_mail_calls_pass_url_template():
+    """REQ-6: every production-code call to a Zitadel email-link endpoint
+    MUST include ``urlTemplate`` in the JSON body. Catches silent drift —
+    Zitadel's per-user url_template cache means one bad call poisons the
+    next mail too."""
+    offences: list[str] = []
+    for py_file in APP_DIR.rglob("*.py"):
+        # Skip __pycache__ and other generated dirs.
+        if "__pycache__" in py_file.parts:
+            continue
+        for lineno, url in _scan_file(py_file):
+            rel = py_file.relative_to(APP_DIR.parent.parent.parent)
+            offences.append(f"  {rel}:{lineno} — POST {url}")
+    assert not offences, (
+        "SPEC-PORTAL-AUTH-EMAIL-LINKS-001 REQ-6: Zitadel email-link API call "
+        "without urlTemplate detected. The mail will point at Zitadel's hosted "
+        "UI instead of my.getklai.com. Build the template via "
+        "build_url_template(AuthLinkRoute.PASSWORD_SET) and include it in "
+        "the JSON body.\n\nOffences:\n" + "\n".join(offences)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Self-tests for the scanner — guard against the lint silently becoming a no-op.
+# ---------------------------------------------------------------------------
+
+
+_BAD_FIXTURES = [
+    'await client.post(f"/v2/users/{uid}/password_reset")',
+    'await client.post(f"/v2/users/{uid}/password_reset", json={})',
+    'await self._http.post(f"/v2/users/{user_id}/invite_code", json={"sendCode": {}})',
+    'await c.post(f"/v2/users/{uid}/invite_code/resend", json={})',
+    'await c.post(f"/v2/users/{uid}/email/_send_code", json={})',
+]
+
+_GOOD_FIXTURES = [
+    (
+        'await client.post(f"/v2/users/{uid}/password_reset", '
+        'json={"sendLink": {"notificationType": "NOTIFICATION_TYPE_Email", "urlTemplate": tpl}})'
+    ),
+    (
+        'await c.post(f"/v2/users/{uid}/invite_code", '
+        'json={"sendCode": {"urlTemplate": tpl, "applicationName": "Klai"}})'
+    ),
+    ('await c.post(f"/v2/users/{uid}/email/_send_code", json={"sendCode": {"urlTemplate": tpl}})'),
+    'await c.post(f"/api/admin/users", json={})',  # not a target endpoint
+    'await c.post(f"/v2/users", json={})',  # AddHumanUser — not in scope
+]
+
+
+def _parse_first_call(src: str) -> ast.Call:
+    """Wrap source in an async function so ``await`` parses, then pluck the Call."""
+    wrapped = "async def _():\n    " + src
+    tree = ast.parse(wrapped)
+    fn = tree.body[0]
+    assert isinstance(fn, ast.AsyncFunctionDef)
+    expr = fn.body[0]
+    assert isinstance(expr, ast.Expr)
+    aw = expr.value
+    assert isinstance(aw, ast.Await)
+    call = aw.value
+    assert isinstance(call, ast.Call)
+    return call
+
+
+@pytest.mark.parametrize("src", _BAD_FIXTURES)
+def test_scanner_flags_bad_fixture(src: str):
+    call = _parse_first_call(src)
+    url = _extract_path_str(call.args[0])
+    assert url is not None
+    assert any(p.search(url) for p in _ENDPOINT_PATTERNS), f"endpoint regex missed: {url}"
+    assert not _body_contains_url_template(call), f"urlTemplate should not be in: {src}"
+
+
+@pytest.mark.parametrize("src", _GOOD_FIXTURES)
+def test_scanner_passes_good_fixture(src: str):
+    call = _parse_first_call(src)
+    url = _extract_path_str(call.args[0])
+    if url is None:
+        return  # non-static URL is out of scope
+    if not any(p.search(url) for p in _ENDPOINT_PATTERNS):
+        return  # not a Zitadel email-link endpoint
+    assert _body_contains_url_template(call), f"urlTemplate missing in good fixture: {src}"

--- a/klai-portal/backend/tests/test_zitadel_email_link_urls.py
+++ b/klai-portal/backend/tests/test_zitadel_email_link_urls.py
@@ -1,0 +1,142 @@
+"""Wire-level payload tests for SPEC-PORTAL-AUTH-EMAIL-LINKS-001.
+
+For each of the three Zitadel v2 email-link calls, assert that the JSON body
+posted to Zitadel contains the expected ``urlTemplate`` placeholders and
+mandatory metadata (notificationType for password reset, applicationName for
+invite). These tests are the regression net against silent fall-back to
+Zitadel's default hosted-UI URL.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _client_with_mocked_http():
+    """Build a ZitadelClient with `self._http` stubbed to return 200 on POST."""
+    from app.services.zitadel import ZitadelClient
+
+    client = ZitadelClient.__new__(ZitadelClient)
+    response = MagicMock()
+    response.raise_for_status = MagicMock(return_value=None)
+    response.json = MagicMock(return_value={"userId": "uid-1"})
+    response.is_error = False
+    response.aread = AsyncMock()
+    mock_http = MagicMock()
+    mock_http.post = AsyncMock(return_value=response)
+    client._http = mock_http
+    return client, mock_http
+
+
+_KLAI_URL_TEMPLATE = "https://my.getklai.com/password/set?userID={{.UserID}}&code={{.Code}}&orgID={{.OrgID}}"
+
+
+# ---------------------------------------------------------------------------
+# REQ-1 — send_password_reset
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_password_reset_uses_sendlink_with_url_template():
+    client, mock_http = _client_with_mocked_http()
+
+    await client.send_password_reset("uid-1", url_template=_KLAI_URL_TEMPLATE)
+
+    args, kwargs = mock_http.post.call_args
+    assert args[0] == "/v2/users/uid-1/password_reset"
+    assert kwargs["json"] == {
+        "sendLink": {
+            "notificationType": "NOTIFICATION_TYPE_Email",
+            "urlTemplate": _KLAI_URL_TEMPLATE,
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_send_password_reset_requires_url_template_kwarg():
+    """REQ-1: url_template is keyword-only and required — no positional, no default."""
+    client, _ = _client_with_mocked_http()
+    with pytest.raises(TypeError):
+        # Missing url_template should raise — defends against caller drift.
+        await client.send_password_reset("uid-1")  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# REQ-2 — invite_user split: sendCodes=False + send_invite_code with template
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invite_user_does_not_send_default_zitadel_mail():
+    """REQ-2: invite_user creates the user WITHOUT triggering Zitadel's mail."""
+    client, mock_http = _client_with_mocked_http()
+
+    await client.invite_user(
+        org_id="org-1",
+        email="alice@example.com",
+        first_name="Alice",
+        last_name="Doe",
+    )
+
+    _args, kwargs = mock_http.post.call_args
+    assert kwargs["json"]["sendCodes"] is False, (
+        "invite_user MUST pass sendCodes=False so the activation mail is "
+        "issued separately via send_invite_code with a Klai urlTemplate"
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_invite_code_payload_shape():
+    """REQ-2: send_invite_code passes urlTemplate + applicationName='Klai'."""
+    client, mock_http = _client_with_mocked_http()
+
+    await client.send_invite_code("uid-1", url_template=_KLAI_URL_TEMPLATE)
+
+    args, kwargs = mock_http.post.call_args
+    assert args[0] == "/v2/users/uid-1/invite_code"
+    assert kwargs["json"] == {
+        "sendCode": {
+            "urlTemplate": _KLAI_URL_TEMPLATE,
+            "applicationName": "Klai",
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_send_invite_code_application_name_overridable():
+    """For multi-tenant futures where the app-name should not be 'Klai'."""
+    client, mock_http = _client_with_mocked_http()
+
+    await client.send_invite_code(
+        "uid-1",
+        url_template=_KLAI_URL_TEMPLATE,
+        application_name="CustomerPortal",
+    )
+
+    _args, kwargs = mock_http.post.call_args
+    assert kwargs["json"]["sendCode"]["applicationName"] == "CustomerPortal"
+
+
+@pytest.mark.asyncio
+async def test_send_invite_code_requires_url_template_kwarg():
+    """REQ-10: url_template is keyword-only and required; no Zitadel-cache fallback."""
+    client, _ = _client_with_mocked_http()
+    with pytest.raises(TypeError):
+        await client.send_invite_code("uid-1")  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# REQ-3 — resend_init_mail is gone; replaced by send_invite_code
+# ---------------------------------------------------------------------------
+
+
+def test_resend_init_mail_method_removed():
+    """REQ-3: the legacy resend_init_mail method is deleted in the same commit."""
+    from app.services.zitadel import ZitadelClient
+
+    assert not hasattr(ZitadelClient, "resend_init_mail"), (
+        "resend_init_mail must be removed in SPEC-PORTAL-AUTH-EMAIL-LINKS-001 REQ-3. "
+        "Callers MUST use send_invite_code(url_template=...) instead."
+    )

--- a/klai-portal/backend/tests/test_zitadel_username_normalization.py
+++ b/klai-portal/backend/tests/test_zitadel_username_normalization.py
@@ -128,9 +128,11 @@ class TestInviteUserUsernameLowercased:
         assert kwargs["json"]["email"]["email"] == "NewHire@Acme.IO"
 
     @pytest.mark.asyncio
-    async def test_send_codes_flag_unchanged(self) -> None:
-        """Regression: the lowercase rename must not break the invite-mail
-        send-codes flag."""
+    async def test_send_codes_disabled_per_split_invite_flow(self) -> None:
+        """SPEC-PORTAL-AUTH-EMAIL-LINKS-001 REQ-2: invite_user MUST NOT trigger
+        a Zitadel-default invite mail. The flow is split — invite_user creates
+        the user with sendCodes=False, then send_invite_code mails the link
+        with an explicit Klai urlTemplate."""
         client, mock_http = _zitadel_client_with_mocked_http()
 
         await client.invite_user(
@@ -141,7 +143,7 @@ class TestInviteUserUsernameLowercased:
         )
 
         _args, kwargs = mock_http.post.call_args
-        assert kwargs["json"]["sendCodes"] is True
+        assert kwargs["json"]["sendCodes"] is False
 
 
 class TestCreateZitadelUserFromIdpUsernameLowercased:


### PR DESCRIPTION
## What

Pins the invite + password-reset + (forward-compat) email-verify mail links at `my.getklai.com` instead of `auth.getklai.com/ui/login/`. Completes the existing Klai pattern of *Klai UI on the front, Zitadel v2 API on the back* for email-link flows — the last layer that still hit Zitadel's hosted UI.

## Mechanism

Every Zitadel v2 `Send*` call now passes a `sendLink.urlTemplate` (or `sendCode.urlTemplate`) with placeholders `{{.UserID}}`, `{{.Code}}`, `{{.OrgID}}` that Zitadel substitutes server-side. `klai-mailer` is unchanged — the URL inside `templateData.url` now resolves to Klai's `/password/set` route instead of Zitadel's `/ui/login/user/init`.

## SPEC

[SPEC-PORTAL-AUTH-EMAIL-LINKS-001](.moai/specs/SPEC-PORTAL-AUTH-EMAIL-LINKS-001/spec.md) — 10 EARS requirements, 10 acceptance criteria, full research with proto-level verification.

## Pivot during implementation

REQ-6 originally specified an ast-grep YAML rule. Pivoted to a pytest AST-walker (`tests/test_zitadel_email_link_lint.py`) because ast-grep's `not: has: regex:` does not reliably express *call without literal substring in body* at sub-expression granularity, while `ast.walk` does so trivially. Same enforcement, integrated into existing pytest CI, with 5 bad + 5 good self-test fixtures.

## Risk

- Mid-deploy: in-flight Zitadel-default mails keep working (codes are URL-template-agnostic — both UIs accept the same code, same Zitadel API call on submit).
- Zitadel caches `url_template` per user — REQ-10 forces explicit `urlTemplate` on every call so the first new call after deploy converges the cache.
- `AddHumanUserRequest` cannot trigger invite-mail directly; new invite flow is split into two sequential calls. Partial-failure handling: 502 with the orphan `user_id` so an admin can recover via resend-invite.

## Test status

- **2658 / 2658 tests passing** in `klai-portal/backend/` suite
- `ruff check .` + `ruff format --check .` clean
- New tests: `test_auth_links.py` (10), `test_zitadel_email_link_urls.py` (7), `test_zitadel_email_link_lint.py` (11)
- 5 pre-existing tests updated to mock the new `send_invite_code` call

## Verification plan (post-merge)

1. Watch `Build and push portal-api` workflow to green.
2. Verify container recreated on core-01 with new bundle timestamp.
3. Trigger an invite via the admin UI in the voys tenant (Google SSO).
4. Query VictoriaLogs: `service:portal-api AND event:invite_user` → field `url_template_host` MUST equal `my.getklai.com`.
5. Cross-check: `service:klai-mailer AND eventType:InviteUser` → `templateData.url` starts with `https://my.getklai.com/password/set?`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)