### PR TITLE
Refactor transcribe add route

### DIFF
--- a/.moai/specs/SPEC-PORTAL-TRANSCRIBE-ADD-CLEANUP-001/progress.md
+++ b/.moai/specs/SPEC-PORTAL-TRANSCRIBE-ADD-CLEANUP-001/progress.md
@@ -1,0 +1,9 @@
+## SPEC-PORTAL-TRANSCRIBE-ADD-CLEANUP-001 Progress
+
+- Started: 2026-05-13T09:05:01+02:00
+- Phase 0.5 complete: memory_guard=disabled, strategy=full
+- Phase 0.9 complete: detected_language_skills=typescript
+- Phase 0.95 complete: scale-based mode=focused (frontend route refactor)
+- Phase 1 complete: analyzed `transcribe/add.tsx`; actual modes are record and upload, with no paste URL mode.
+- Phase 2 complete: extracted route helpers, mutation hooks, recording form, upload form, and result cards.
+- Phase 2.75 complete: targeted unit test, ESLint, TypeScript build, and production build passed.

--- a/klai-portal/frontend/src/routes/app/transcribe/-add-helpers.ts
+++ b/klai-portal/frontend/src/routes/app/transcribe/-add-helpers.ts
@@ -1,0 +1,17 @@
+export const SCRIBE_BASE = '/api/scribe/v1'
+export const ACCEPTED_TYPES = '.wav,.mp3,.m4a,.ogg,.webm'
+export const MAX_UPLOAD_MB = 100
+
+export type AddTranscribeTab = 'record' | 'upload'
+
+export const ADD_TRANSCRIBE_TABS: AddTranscribeTab[] = ['record', 'upload']
+
+export function isAddTranscribeTab(value: unknown): value is AddTranscribeTab {
+  return typeof value === 'string' && ADD_TRANSCRIBE_TABS.includes(value as AddTranscribeTab)
+}
+
+export function formatDuration(seconds: number): string {
+  const mins = Math.floor(seconds / 60)
+  const secs = Math.floor(seconds % 60)
+  return `${mins}:${secs.toString().padStart(2, '0')}`
+}

--- a/klai-portal/frontend/src/routes/app/transcribe/-add-hooks.ts
+++ b/klai-portal/frontend/src/routes/app/transcribe/-add-hooks.ts
@@ -1,0 +1,77 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useNavigate } from '@tanstack/react-router'
+import { apiFetch } from '@/lib/apiFetch'
+import { SCRIBE_BASE } from './-add-helpers'
+
+export interface TranscriptionResponse {
+  id: string
+  name: string | null
+  status: string
+  text: string | null
+  language: string | null
+  duration_seconds: number | null
+  inference_time_seconds: number | null
+  summary_json: Record<string, unknown> | null
+  created_at: string
+}
+
+interface MutationOptions {
+  language: string
+  onQueued: (data: TranscriptionResponse) => void
+  onError: (message: string) => void
+  onSuccess?: () => void
+}
+
+function useTranscriptionSuccessHandler(onQueued: (data: TranscriptionResponse) => void) {
+  const queryClient = useQueryClient()
+  const navigate = useNavigate({ from: '/app/transcribe/add' })
+
+  return (data: TranscriptionResponse) => {
+    void queryClient.invalidateQueries({ queryKey: ['transcriptions'] })
+    if (data.status === 'transcribed') {
+      void navigate({ to: '/app/transcribe/$transcriptionId', params: { transcriptionId: data.id } })
+      return
+    }
+    onQueued(data)
+  }
+}
+
+export function useTranscribeFileMutation({ language, onQueued, onError, onSuccess }: MutationOptions) {
+  const handleSuccess = useTranscriptionSuccessHandler(onQueued)
+
+  return useMutation({
+    mutationFn: async (file: File) => {
+      const form = new FormData()
+      form.append('file', file)
+      if (language) form.append('language', language)
+      return apiFetch<TranscriptionResponse>(`${SCRIBE_BASE}/transcribe`, {
+        method: 'POST',
+        body: form,
+      })
+    },
+    onSuccess: (data) => {
+      handleSuccess(data)
+      onSuccess?.()
+    },
+    onError: (err: Error) => {
+      onError(err.message)
+    },
+  })
+}
+
+export function useRetryTranscriptionMutation({ language, onQueued, onError }: MutationOptions) {
+  const handleSuccess = useTranscriptionSuccessHandler(onQueued)
+
+  return useMutation({
+    mutationFn: async (txnId: string) => {
+      const params = language ? `?language=${encodeURIComponent(language)}` : ''
+      return apiFetch<TranscriptionResponse>(`${SCRIBE_BASE}/transcriptions/${txnId}/retry${params}`, {
+        method: 'POST',
+      })
+    },
+    onSuccess: handleSuccess,
+    onError: (err: Error) => {
+      onError(err.message)
+    },
+  })
+}

--- a/klai-portal/frontend/src/routes/app/transcribe/__tests__/-add-helpers.test.ts
+++ b/klai-portal/frontend/src/routes/app/transcribe/__tests__/-add-helpers.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { formatDuration, isAddTranscribeTab } from '../-add-helpers'
+
+describe('isAddTranscribeTab', () => {
+  it('accepts supported transcribe add tabs', () => {
+    expect(isAddTranscribeTab('record')).toBe(true)
+    expect(isAddTranscribeTab('upload')).toBe(true)
+  })
+
+  it('rejects unknown or non-string values', () => {
+    expect(isAddTranscribeTab('paste')).toBe(false)
+    expect(isAddTranscribeTab(undefined)).toBe(false)
+    expect(isAddTranscribeTab(1)).toBe(false)
+  })
+})
+
+describe('formatDuration', () => {
+  it('formats seconds as m:ss', () => {
+    expect(formatDuration(0)).toBe('0:00')
+    expect(formatDuration(65)).toBe('1:05')
+    expect(formatDuration(3599)).toBe('59:59')
+  })
+})

--- a/klai-portal/frontend/src/routes/app/transcribe/_components/-FileUploadForm.tsx
+++ b/klai-portal/frontend/src/routes/app/transcribe/_components/-FileUploadForm.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useRef, useState } from 'react'
+import { Loader2, Upload } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import * as m from '@/paraglide/messages'
+import { ACCEPTED_TYPES, MAX_UPLOAD_MB } from '../-add-helpers'
+
+interface FileUploadFormProps {
+  active: boolean
+  isTranscribing: boolean
+  resetToken: number
+  onFileReady: () => void
+  onSubmit: (file: File) => void
+  onError: (message: string) => void
+}
+
+export function FileUploadForm({
+  active,
+  isTranscribing,
+  resetToken,
+  onFileReady,
+  onSubmit,
+  onError,
+}: FileUploadFormProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [dragging, setDragging] = useState(false)
+  const [selectedFile, setSelectedFile] = useState<File | null>(null)
+
+  useEffect(() => {
+    setSelectedFile(null)
+  }, [resetToken])
+
+  function handleFile(file: File) {
+    onFileReady()
+    if (file.size > MAX_UPLOAD_MB * 1024 * 1024) {
+      onError(m.app_transcribe_error_too_large({ max: String(MAX_UPLOAD_MB) }))
+      return
+    }
+    setSelectedFile(file)
+  }
+
+  function submitSelectedFile() {
+    if (!selectedFile) return
+    onSubmit(selectedFile)
+  }
+
+  if (!active) return null
+
+  return (
+    <div className="space-y-4">
+      <div
+        className={`border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-colors ${
+          dragging
+            ? 'border-[var(--color-rl-accent)] bg-[var(--color-rl-accent)]/5'
+            : 'border-gray-200 hover:border-[var(--color-rl-accent)]/50'
+        }`}
+        onClick={() => fileInputRef.current?.click()}
+        onDragOver={(event) => {
+          event.preventDefault()
+          setDragging(true)
+        }}
+        onDragLeave={() => setDragging(false)}
+        onDrop={(event) => {
+          event.preventDefault()
+          setDragging(false)
+          const file = event.dataTransfer.files[0]
+          if (file) handleFile(file)
+        }}
+      >
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept={ACCEPTED_TYPES}
+          className="hidden"
+          onChange={(event) => {
+            const file = event.target.files?.[0]
+            if (file) handleFile(file)
+          }}
+        />
+        <Upload className="mx-auto mb-3 h-8 w-8 text-gray-400" />
+        {selectedFile ? (
+          <div>
+            <p className="font-medium text-sm">{selectedFile.name}</p>
+            <p className="text-xs text-gray-400 mt-1">
+              {(selectedFile.size / 1024 / 1024).toFixed(1)} MB
+            </p>
+          </div>
+        ) : (
+          <div>
+            <p className="text-sm font-medium">{m.app_transcribe_dropzone_label()}</p>
+            <p className="text-xs text-gray-400 mt-1">
+              {m.app_transcribe_dropzone_hint({
+                formats: 'WAV, MP3, M4A, OGG, WebM',
+                max: String(MAX_UPLOAD_MB),
+              })}
+            </p>
+          </div>
+        )}
+      </div>
+
+      <div className="flex pt-2">
+        <Button
+          onClick={submitSelectedFile}
+          disabled={!selectedFile || isTranscribing}
+        >
+          {isTranscribing ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              {m.app_transcribe_processing()}
+            </>
+          ) : (
+            <>
+              <Upload className="mr-2 h-4 w-4" />
+              {m.app_transcribe_submit()}
+            </>
+          )}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/klai-portal/frontend/src/routes/app/transcribe/_components/-RecordingForm.tsx
+++ b/klai-portal/frontend/src/routes/app/transcribe/_components/-RecordingForm.tsx
@@ -1,0 +1,221 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Mic, Square } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import * as m from '@/paraglide/messages'
+import { formatDuration } from '../-add-helpers'
+
+interface RecordingFormProps {
+  active: boolean
+  isTranscribing: boolean
+  onBeforeRecord: () => void
+  onRecordedFile: (file: File) => void
+  onError: (message: string) => void
+}
+
+export function RecordingForm({
+  active,
+  isTranscribing,
+  onBeforeRecord,
+  onRecordedFile,
+  onError,
+}: RecordingFormProps) {
+  const [micPermission, setMicPermission] = useState<'idle' | 'requesting' | 'granted' | 'denied'>('idle')
+  const [micBlocked, setMicBlocked] = useState(false)
+  const [recording, setRecording] = useState(false)
+  const [recordDuration, setRecordDuration] = useState(0)
+  const [audioLevel, setAudioLevel] = useState(0)
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null)
+  const streamRef = useRef<MediaStream | null>(null)
+  const audioContextRef = useRef<AudioContext | null>(null)
+  const analyserRef = useRef<AnalyserNode | null>(null)
+  const animFrameRef = useRef<number | null>(null)
+  const durationIntervalRef = useRef<number | null>(null)
+
+  const updateAudioLevel = useCallback(() => {
+    if (!analyserRef.current) return
+    const data = new Uint8Array(analyserRef.current.frequencyBinCount)
+    analyserRef.current.getByteFrequencyData(data)
+    const avg = data.reduce((a, b) => a + b, 0) / data.length
+    setAudioLevel(Math.min(100, (avg / 128) * 100))
+    // eslint-disable-next-line react-hooks/immutability
+    animFrameRef.current = requestAnimationFrame(updateAudioLevel)
+  }, [])
+
+  const requestMicAccess = useCallback(async () => {
+    setMicBlocked(false)
+    setMicPermission('requesting')
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+      streamRef.current = stream
+      setMicPermission('granted')
+      try {
+        const AudioCtx =
+          window.AudioContext ??
+          (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext
+        const audioCtx = new AudioCtx()
+        audioContextRef.current = audioCtx
+        const analyser = audioCtx.createAnalyser()
+        analyser.fftSize = 256
+        analyserRef.current = analyser
+        audioCtx.createMediaStreamSource(stream).connect(analyser)
+      } catch {
+        // Audio visualisation unavailable - non-fatal.
+      }
+    } catch {
+      setMicPermission('denied')
+      try {
+        const status = await navigator.permissions.query({ name: 'microphone' as PermissionName })
+        setMicBlocked(status.state === 'denied')
+      } catch {
+        // Permissions API unavailable, so the UI falls back to retry.
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!active) return
+    if (streamRef.current) return
+    void requestMicAccess()
+  }, [active, requestMicAccess])
+
+  const stopRecording = useCallback(() => {
+    if (mediaRecorderRef.current?.state === 'recording') {
+      mediaRecorderRef.current.stop()
+    }
+    setRecording(false)
+    if (durationIntervalRef.current) {
+      clearInterval(durationIntervalRef.current)
+      durationIntervalRef.current = null
+    }
+    if (animFrameRef.current) {
+      cancelAnimationFrame(animFrameRef.current)
+      animFrameRef.current = null
+    }
+    setAudioLevel(0)
+  }, [])
+
+  const startRecording = useCallback(() => {
+    onBeforeRecord()
+
+    if (!streamRef.current || micPermission !== 'granted') {
+      onError(m.app_transcribe_record_error_mic())
+      return
+    }
+
+    const chunks: Blob[] = []
+    const recorder = new MediaRecorder(streamRef.current)
+    mediaRecorderRef.current = recorder
+
+    recorder.ondataavailable = (e) => chunks.push(e.data)
+    recorder.onstop = () => {
+      const blob = new Blob(chunks, { type: 'audio/webm' })
+      onRecordedFile(new File([blob], 'recording.webm', { type: 'audio/webm' }))
+    }
+
+    recorder.start()
+    setRecording(true)
+    setRecordDuration(0)
+    durationIntervalRef.current = window.setInterval(() => setRecordDuration((d) => d + 1), 1000)
+    void audioContextRef.current?.resume().then(updateAudioLevel).catch(updateAudioLevel)
+  }, [micPermission, onBeforeRecord, onError, onRecordedFile, updateAudioLevel])
+
+  useEffect(
+    () => () => {
+      stopRecording()
+      streamRef.current?.getTracks().forEach((track) => track.stop())
+      void audioContextRef.current?.close()
+    },
+    [stopRecording],
+  )
+
+  useEffect(() => {
+    if (!active) return
+    const onKey = (event: KeyboardEvent) => {
+      if (event.code !== 'Space') return
+      if (['INPUT', 'TEXTAREA', 'SELECT'].includes((event.target as HTMLElement).tagName)) return
+      event.preventDefault()
+      if (recording) stopRecording()
+      else startRecording()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [active, recording, startRecording, stopRecording])
+
+  if (!active) return null
+
+  if (micPermission === 'requesting') {
+    return (
+      <p className="text-sm text-gray-400">
+        {m.app_transcribe_record_permission_request()}
+      </p>
+    )
+  }
+
+  if (micPermission === 'denied') {
+    return (
+      <div className="space-y-2">
+        <p className="text-sm text-[var(--color-destructive)]">
+          {m.app_transcribe_record_permission_denied()}
+        </p>
+        {!micBlocked && (
+          <Button variant="outline" size="sm" onClick={requestMicAccess}>
+            {m.app_transcribe_record_grant_permission()}
+          </Button>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-4">
+        <Button
+          variant={recording ? 'destructive' : 'default'}
+          onClick={() => (recording ? stopRecording() : startRecording())}
+          disabled={isTranscribing || micPermission === 'idle'}
+        >
+          {recording ? (
+            <>
+              <Square className="mr-2 h-4 w-4" />
+              {m.app_transcribe_record_stop()}
+            </>
+          ) : (
+            <>
+              <Mic className="mr-2 h-4 w-4" />
+              {m.app_transcribe_record_start()}
+            </>
+          )}
+        </Button>
+
+        {recording && (
+          <span className="font-mono text-sm text-gray-400">
+            {formatDuration(recordDuration)}
+          </span>
+        )}
+      </div>
+
+      {recording && (
+        <div className="space-y-1.5">
+          <div className="flex items-center gap-2">
+            <div className="h-2 w-2 rounded-full bg-[var(--color-destructive)] animate-pulse" />
+            <span className="text-xs font-medium text-[var(--color-destructive)]">
+              {m.app_transcribe_record_recording()}
+            </span>
+          </div>
+          <div className="h-2 w-full rounded-full bg-[var(--color-muted)] overflow-hidden">
+            <div
+              className="h-full bg-[var(--color-success)] transition-all duration-75"
+              style={{ width: `${audioLevel}%` }}
+            />
+          </div>
+        </div>
+      )}
+
+      {!recording && !isTranscribing && (
+        <p className="text-xs text-gray-400">
+          {m.app_transcribe_record_shortcut_hint()}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/klai-portal/frontend/src/routes/app/transcribe/_components/-TranscriptionResultCards.tsx
+++ b/klai-portal/frontend/src/routes/app/transcribe/_components/-TranscriptionResultCards.tsx
@@ -1,0 +1,99 @@
+import { useState } from 'react'
+import { CheckCheck, Copy, Loader2, RotateCcw } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import * as m from '@/paraglide/messages'
+import { formatDuration } from '../-add-helpers'
+import type { TranscriptionResponse } from '../-add-hooks'
+
+interface TranscriptionResultCardsProps {
+  result: TranscriptionResponse | null
+  isRetrying: boolean
+  onRetry: (id: string) => void
+  onBack: () => void
+}
+
+export function TranscriptionResultCards({
+  result,
+  isRetrying,
+  onRetry,
+  onBack,
+}: TranscriptionResultCardsProps) {
+  const [copied, setCopied] = useState(false)
+
+  function handleCopy() {
+    if (!result?.text) return
+    void navigator.clipboard.writeText(result.text).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    })
+  }
+
+  if (result?.status === 'failed') {
+    return (
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle>{m.app_transcribe_status_failed()}</CardTitle>
+          <CardDescription>{m.app_transcribe_failed_hint()}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="flex gap-3 pt-2">
+            <Button
+              disabled={isRetrying}
+              onClick={() => onRetry(result.id)}
+            >
+              {isRetrying ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  {m.app_transcribe_processing()}
+                </>
+              ) : (
+                <>
+                  <RotateCcw className="mr-2 h-4 w-4" />
+                  {m.app_transcribe_retry_button()}
+                </>
+              )}
+            </Button>
+            <Button
+              variant="outline"
+              disabled={isRetrying}
+              onClick={onBack}
+            >
+              {m.app_transcribe_back()}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (result?.status === 'transcribed' && result.text) {
+    return (
+      <Card>
+        <CardHeader className="pb-2">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <CardTitle>{m.app_transcribe_result_title()}</CardTitle>
+              {result.language && result.duration_seconds != null && (
+                <CardDescription>
+                  {m.app_transcribe_result_meta({
+                    language: result.language.toUpperCase(),
+                    duration: formatDuration(result.duration_seconds),
+                  })}
+                </CardDescription>
+              )}
+            </div>
+            <Button variant="outline" size="sm" onClick={handleCopy}>
+              {copied ? <CheckCheck className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm whitespace-pre-wrap leading-relaxed">{result.text}</p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return null
+}

--- a/klai-portal/frontend/src/routes/app/transcribe/add.tsx
+++ b/klai-portal/frontend/src/routes/app/transcribe/add.tsx
@@ -1,28 +1,30 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { useRef, useState, useEffect, useCallback } from 'react'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { useState } from 'react'
+import { ArrowLeft, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
 import { Select } from '@/components/ui/select'
-import { ArrowLeft, Upload, Copy, CheckCheck, Loader2, Mic, Square, RotateCcw } from 'lucide-react'
-import * as m from '@/paraglide/messages'
-import { apiFetch } from '@/lib/apiFetch'
 import { ProductGuard } from '@/components/layout/ProductGuard'
+import * as m from '@/paraglide/messages'
+import { FileUploadForm } from './_components/-FileUploadForm'
+import { RecordingForm } from './_components/-RecordingForm'
+import { TranscriptionResultCards } from './_components/-TranscriptionResultCards'
+import {
+  useRetryTranscriptionMutation,
+  useTranscribeFileMutation,
+  type TranscriptionResponse,
+} from './-add-hooks'
+import {
+  ADD_TRANSCRIBE_TABS,
+  isAddTranscribeTab,
+  type AddTranscribeTab,
+} from './-add-helpers'
 
-const SCRIBE_BASE = '/api/scribe/v1'
-const ACCEPTED_TYPES = '.wav,.mp3,.m4a,.ogg,.webm'
-const MAX_MB = 100
-
-type Tab = 'record' | 'upload'
-
-const VALID_ADD_TABS = new Set<Tab>(['record', 'upload'])
-
-type AddTranscribeSearch = { tab?: Tab }
+type AddTranscribeSearch = { tab?: AddTranscribeTab }
 
 export const Route = createFileRoute('/app/transcribe/add')({
   validateSearch: (search: Record<string, unknown>): AddTranscribeSearch => ({
-    tab: (VALID_ADD_TABS as Set<string>).has(search.tab as string) ? (search.tab as Tab) : undefined,
+    tab: isAddTranscribeTab(search.tab) ? search.tab : undefined,
   }),
   component: () => (
     <ProductGuard product="scribe">
@@ -31,234 +33,48 @@ export const Route = createFileRoute('/app/transcribe/add')({
   ),
 })
 
-interface TranscriptionResponse {
-  id: string
-  name: string | null
-  status: string
-  text: string | null
-  language: string | null
-  duration_seconds: number | null
-  inference_time_seconds: number | null
-  summary_json: Record<string, unknown> | null
-  created_at: string
-}
-
-function formatDuration(seconds: number): string {
-  const mins = Math.floor(seconds / 60)
-  const secs = Math.floor(seconds % 60)
-  return `${mins}:${secs.toString().padStart(2, '0')}`
-}
-
 function AddTranscribePage() {
-  const queryClient = useQueryClient()
   const navigate = useNavigate({ from: '/app/transcribe/add' })
-
   const { tab: tabParam } = Route.useSearch()
-  const activeTab: Tab = tabParam ?? 'record'
-  const [language, setLanguage] = useState<string>('')
+  const activeTab: AddTranscribeTab = tabParam ?? 'record'
+
+  const [language, setLanguage] = useState('')
   const [result, setResult] = useState<TranscriptionResponse | null>(null)
-  const [copied, setCopied] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [uploadResetToken, setUploadResetToken] = useState(0)
 
-  // Upload tab
-  const fileInputRef = useRef<HTMLInputElement>(null)
-  const [dragging, setDragging] = useState(false)
-  const [selectedFile, setSelectedFile] = useState<File | null>(null)
-
-  // Record tab
-  const [micPermission, setMicPermission] = useState<'idle' | 'requesting' | 'granted' | 'denied'>('idle')
-  const [micBlocked, setMicBlocked] = useState(false)
-  const [recording, setRecording] = useState(false)
-  const [recordDuration, setRecordDuration] = useState(0)
-  const [audioLevel, setAudioLevel] = useState(0)
-  const mediaRecorderRef = useRef<MediaRecorder | null>(null)
-  const streamRef = useRef<MediaStream | null>(null)
-  const audioContextRef = useRef<AudioContext | null>(null)
-  const analyserRef = useRef<AnalyserNode | null>(null)
-  const animFrameRef = useRef<number | null>(null)
-  const durationIntervalRef = useRef<number | null>(null)
-
-  const transcribeMutation = useMutation({
-    mutationFn: async (file: File) => {
-      setError(null)
-      const form = new FormData()
-      form.append('file', file)
-      if (language) form.append('language', language)
-      return apiFetch<TranscriptionResponse>(`${SCRIBE_BASE}/transcribe`, {
-        method: 'POST',
-        body: form,
-      })
-    },
-    onSuccess: (data) => {
-      void queryClient.invalidateQueries({ queryKey: ['transcriptions'] })
-      if (data.status === 'transcribed') {
-        void navigate({ to: '/app/transcribe/$transcriptionId', params: { transcriptionId: data.id } })
-      } else {
-        setResult(data)
-      }
-      setSelectedFile(null)
-    },
-    onError: (err: Error) => {
-      setError(err.message)
-    },
-  })
-
-  const retryMutation = useMutation({
-    mutationFn: async (txnId: string) => {
-      setError(null)
-      const params = language ? `?language=${encodeURIComponent(language)}` : ''
-      return apiFetch<TranscriptionResponse>(`${SCRIBE_BASE}/transcriptions/${txnId}/retry${params}`, {
-        method: 'POST',
-      })
-    },
-    onSuccess: (data) => {
-      void queryClient.invalidateQueries({ queryKey: ['transcriptions'] })
-      if (data.status === 'transcribed') {
-        void navigate({ to: '/app/transcribe/$transcriptionId', params: { transcriptionId: data.id } })
-      } else {
-        setResult(data)
-      }
-    },
-    onError: (err: Error) => {
-      setError(err.message)
-    },
-  })
-
-  const handleFile = (file: File) => {
+  function clearFeedback() {
     setError(null)
     setResult(null)
-    if (file.size > MAX_MB * 1024 * 1024) {
-      setError(m.app_transcribe_error_too_large({ max: String(MAX_MB) }))
-      return
-    }
-    setSelectedFile(file)
   }
 
-  const handleCopy = () => {
-    if (!result?.text) return
-    void navigator.clipboard.writeText(result.text).then(() => {
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
-    })
-  }
-
-  const updateAudioLevel = useCallback(() => {
-    if (!analyserRef.current) return
-    const data = new Uint8Array(analyserRef.current.frequencyBinCount)
-    analyserRef.current.getByteFrequencyData(data)
-    const avg = data.reduce((a, b) => a + b, 0) / data.length
-    setAudioLevel(Math.min(100, (avg / 128) * 100))
-    // eslint-disable-next-line react-hooks/immutability
-    animFrameRef.current = requestAnimationFrame(updateAudioLevel)
-  }, [])
-
-  const requestMicAccess = useCallback(async () => {
-    setMicBlocked(false)
-    setMicPermission('requesting')
-    try {
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
-      streamRef.current = stream
-      setMicPermission('granted')
-      try {
-        const AudioCtx =
-          window.AudioContext ??
-          (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext
-        const audioCtx = new AudioCtx()
-        audioContextRef.current = audioCtx
-        const analyser = audioCtx.createAnalyser()
-        analyser.fftSize = 256
-        analyserRef.current = analyser
-        audioCtx.createMediaStreamSource(stream).connect(analyser)
-      } catch {
-        // Audio visualisation unavailable — non-fatal
-      }
-    } catch {
-      setMicPermission('denied')
-      // Check if browser has permanently blocked mic (no prompt will ever appear)
-      try {
-        const status = await navigator.permissions.query({ name: 'microphone' as PermissionName })
-        setMicBlocked(status.state === 'denied')
-      } catch {
-        // Permissions API unavailable — can't determine if permanently blocked
-      }
-    }
-  }, [])
-
-  // Request mic permission when record tab becomes active
-  useEffect(() => {
-    if (activeTab !== 'record') return
-    if (streamRef.current) return // already have stream
-    void requestMicAccess()
-  }, [activeTab, requestMicAccess])
-
-  const stopRecording = useCallback(() => {
-    if (mediaRecorderRef.current?.state === 'recording') {
-      mediaRecorderRef.current.stop()
-    }
-    setRecording(false)
-    if (durationIntervalRef.current) {
-      clearInterval(durationIntervalRef.current)
-      durationIntervalRef.current = null
-    }
-    if (animFrameRef.current) {
-      cancelAnimationFrame(animFrameRef.current)
-      animFrameRef.current = null
-    }
-    setAudioLevel(0)
-  }, [])
-
-  const startRecording = useCallback(() => {
-    setError(null)
-    setResult(null)
-
-    if (!streamRef.current || micPermission !== 'granted') {
-      setError(m.app_transcribe_record_error_mic())
-      return
-    }
-
-    const chunks: Blob[] = []
-    const recorder = new MediaRecorder(streamRef.current)
-    mediaRecorderRef.current = recorder
-
-    recorder.ondataavailable = (e) => chunks.push(e.data)
-    recorder.onstop = () => {
-      const blob = new Blob(chunks, { type: 'audio/webm' })
-      transcribeMutation.mutate(new File([blob], 'recording.webm', { type: 'audio/webm' }))
-    }
-
-    recorder.start()
-    setRecording(true)
-    setRecordDuration(0)
-    durationIntervalRef.current = window.setInterval(() => setRecordDuration((d) => d + 1), 1000)
-    // Resume AudioContext in case it was suspended (can happen when created outside a direct user gesture)
-    void audioContextRef.current?.resume().then(updateAudioLevel).catch(updateAudioLevel)
-  }, [micPermission, updateAudioLevel, transcribeMutation])
-
-  // Cleanup stream on unmount
-  useEffect(
-    () => () => {
-      stopRecording()
-      streamRef.current?.getTracks().forEach((t) => t.stop())
-      void audioContextRef.current?.close()
-    },
-    [stopRecording],
-  )
-
-  // Space key shortcut
-  useEffect(() => {
-    if (activeTab !== 'record') return
-    const onKey = (e: KeyboardEvent) => {
-      if (e.code !== 'Space') return
-      if (['INPUT', 'TEXTAREA', 'SELECT'].includes((e.target as HTMLElement).tagName)) return
-      e.preventDefault()
-      if (recording) stopRecording()
-      else startRecording()
-    }
-    window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
-  }, [activeTab, recording, startRecording, stopRecording])
-
+  const transcribeMutation = useTranscribeFileMutation({
+    language,
+    onQueued: setResult,
+    onError: setError,
+    onSuccess: () => setUploadResetToken((token) => token + 1),
+  })
+  const retryMutation = useRetryTranscriptionMutation({
+    language,
+    onQueued: setResult,
+    onError: setError,
+  })
   const isTranscribing = transcribeMutation.isPending || retryMutation.isPending
+
+  function selectTab(tab: AddTranscribeTab) {
+    void navigate({ search: { tab: tab === 'record' ? undefined : tab } })
+    setError(null)
+  }
+
+  function submitFile(file: File) {
+    setError(null)
+    transcribeMutation.mutate(file)
+  }
+
+  function retryTranscription(id: string) {
+    setError(null)
+    retryMutation.mutate(id)
+  }
 
   return (
     <div className="mx-auto max-w-lg px-6 py-10">
@@ -274,13 +90,12 @@ function AddTranscribePage() {
 
       <div className="space-y-6">
         <div className="space-y-4">
-          {/* Language selector — global setting, shown above tabs */}
           <div className="space-y-1.5">
             <Label htmlFor="language">{m.app_transcribe_language_label()}</Label>
             <Select
               id="language"
               value={language}
-              onChange={(e) => setLanguage(e.target.value)}
+              onChange={(event) => setLanguage(event.target.value)}
               className="max-w-xs"
             >
               <option value="">{m.app_transcribe_language_auto()}</option>
@@ -291,15 +106,11 @@ function AddTranscribePage() {
             </Select>
           </div>
 
-          {/* Tabs */}
           <div className="flex gap-1 p-1 bg-[var(--color-muted)]/40 rounded-lg w-fit">
-            {(['record', 'upload'] as Tab[]).map((tab) => (
+            {ADD_TRANSCRIBE_TABS.map((tab) => (
               <button
                 key={tab}
-                onClick={() => {
-                  void navigate({ search: { tab: tab === 'record' ? undefined : tab } })
-                  setError(null)
-                }}
+                onClick={() => selectTab(tab)}
                 className={`px-4 py-1.5 text-sm font-medium rounded-md transition-colors ${
                   activeTab === tab
                     ? 'bg-[var(--color-background)] shadow-sm text-gray-900'
@@ -311,219 +122,39 @@ function AddTranscribePage() {
             ))}
           </div>
 
-          {/* Record tab */}
-          {activeTab === 'record' && (
-            <div className="space-y-3">
-              {micPermission === 'requesting' && (
-                <p className="text-sm text-gray-400">
-                  {m.app_transcribe_record_permission_request()}
-                </p>
-              )}
+          <RecordingForm
+            active={activeTab === 'record'}
+            isTranscribing={isTranscribing}
+            onBeforeRecord={clearFeedback}
+            onRecordedFile={submitFile}
+            onError={setError}
+          />
 
-              {micPermission === 'denied' && (
-                <div className="space-y-2">
-                  <p className="text-sm text-[var(--color-destructive)]">
-                    {m.app_transcribe_record_permission_denied()}
-                  </p>
-                  {!micBlocked && (
-                    <Button variant="outline" size="sm" onClick={requestMicAccess}>
-                      {m.app_transcribe_record_grant_permission()}
-                    </Button>
-                  )}
-                </div>
-              )}
-
-              {(micPermission === 'granted' || micPermission === 'idle') && (
-                <>
-                  <div className="flex items-center gap-4">
-                    <Button
-                      variant={recording ? 'destructive' : 'default'}
-                      onClick={() => (recording ? stopRecording() : startRecording())}
-                      disabled={isTranscribing || micPermission === 'idle'}
-                    >
-                      {recording ? (
-                        <>
-                          <Square className="mr-2 h-4 w-4" />
-                          {m.app_transcribe_record_stop()}
-                        </>
-                      ) : (
-                        <>
-                          <Mic className="mr-2 h-4 w-4" />
-                          {m.app_transcribe_record_start()}
-                        </>
-                      )}
-                    </Button>
-
-                    {recording && (
-                      <span className="font-mono text-sm text-gray-400">
-                        {formatDuration(recordDuration)}
-                      </span>
-                    )}
-                  </div>
-
-                  {recording && (
-                    <div className="space-y-1.5">
-                      <div className="flex items-center gap-2">
-                        <div className="h-2 w-2 rounded-full bg-[var(--color-destructive)] animate-pulse" />
-                        <span className="text-xs font-medium text-[var(--color-destructive)]">
-                          {m.app_transcribe_record_recording()}
-                        </span>
-                      </div>
-                      <div className="h-2 w-full rounded-full bg-[var(--color-muted)] overflow-hidden">
-                        <div
-                          className="h-full bg-[var(--color-success)] transition-all duration-75"
-                          style={{ width: `${audioLevel}%` }}
-                        />
-                      </div>
-                    </div>
-                  )}
-
-                  {!recording && !isTranscribing && (
-                    <p className="text-xs text-gray-400">
-                      {m.app_transcribe_record_shortcut_hint()}
-                    </p>
-                  )}
-                </>
-              )}
-            </div>
-          )}
-
-          {/* Upload tab */}
-          {activeTab === 'upload' && (
-            <div
-              className={`border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-colors ${
-                dragging
-                  ? 'border-[var(--color-rl-accent)] bg-[var(--color-rl-accent)]/5'
-                  : 'border-gray-200 hover:border-[var(--color-rl-accent)]/50'
-              }`}
-              onClick={() => fileInputRef.current?.click()}
-              onDragOver={(e) => {
-                e.preventDefault()
-                setDragging(true)
-              }}
-              onDragLeave={() => setDragging(false)}
-              onDrop={(e) => {
-                e.preventDefault()
-                setDragging(false)
-                const f = e.dataTransfer.files[0]
-                if (f) handleFile(f)
-              }}
-            >
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept={ACCEPTED_TYPES}
-                className="hidden"
-                onChange={(e) => {
-                  const f = e.target.files?.[0]
-                  if (f) handleFile(f)
-                }}
-              />
-              <Upload className="mx-auto mb-3 h-8 w-8 text-gray-400" />
-              {selectedFile ? (
-                <div>
-                  <p className="font-medium text-sm">{selectedFile.name}</p>
-                  <p className="text-xs text-gray-400 mt-1">
-                    {(selectedFile.size / 1024 / 1024).toFixed(1)} MB
-                  </p>
-                </div>
-              ) : (
-                <div>
-                  <p className="text-sm font-medium">{m.app_transcribe_dropzone_label()}</p>
-                  <p className="text-xs text-gray-400 mt-1">
-                    {m.app_transcribe_dropzone_hint({ formats: 'WAV, MP3, M4A, OGG, WebM', max: String(MAX_MB) })}
-                  </p>
-                </div>
-              )}
-            </div>
-          )}
+          <FileUploadForm
+            active={activeTab === 'upload'}
+            isTranscribing={isTranscribing}
+            resetToken={uploadResetToken}
+            onFileReady={clearFeedback}
+            onSubmit={submitFile}
+            onError={setError}
+          />
 
           {error && <p className="text-sm text-[var(--color-destructive)]">{error}</p>}
 
-          {/* Submit button (upload only) */}
-          {activeTab === 'upload' && (
-            <div className="flex pt-2">
-              <Button
-                onClick={() => selectedFile && transcribeMutation.mutate(selectedFile)}
-                disabled={!selectedFile || isTranscribing}
-              >
-                {isTranscribing ? (
-                  <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    {m.app_transcribe_processing()}
-                  </>
-                ) : (
-                  <>
-                    <Upload className="mr-2 h-4 w-4" />
-                    {m.app_transcribe_submit()}
-                  </>
-                )}
-              </Button>
-            </div>
-          )}
-
           {isTranscribing && (
             <p className="text-xs text-gray-400 text-center">
+              <Loader2 className="mr-2 inline h-3 w-3 animate-spin" />
               {m.app_transcribe_processing_hint()}
             </p>
           )}
         </div>
 
-        {result && result.status === 'failed' && (
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle>{m.app_transcribe_status_failed()}</CardTitle>
-              <CardDescription>{m.app_transcribe_failed_hint()}</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-3">
-              <div className="flex gap-3 pt-2">
-                <Button
-                  disabled={retryMutation.isPending}
-                  onClick={() => retryMutation.mutate(result.id)}
-                >
-                  {retryMutation.isPending ? (
-                    <><Loader2 className="mr-2 h-4 w-4 animate-spin" />{m.app_transcribe_processing()}</>
-                  ) : (
-                    <><RotateCcw className="mr-2 h-4 w-4" />{m.app_transcribe_retry_button()}</>
-                  )}
-                </Button>
-                <Button
-                  variant="outline"
-                  disabled={retryMutation.isPending}
-                  onClick={() => { setResult(null); setError(null) }}
-                >
-                  {m.app_transcribe_back()}
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
-        )}
-
-        {result && result.status === 'transcribed' && result.text && (
-          <Card>
-            <CardHeader className="pb-2">
-              <div className="flex items-start justify-between gap-3">
-                <div>
-                  <CardTitle>{m.app_transcribe_result_title()}</CardTitle>
-                  {result.language && result.duration_seconds != null && (
-                    <CardDescription>
-                      {m.app_transcribe_result_meta({
-                        language: result.language.toUpperCase(),
-                        duration: formatDuration(result.duration_seconds),
-                      })}
-                    </CardDescription>
-                  )}
-                </div>
-                <Button variant="outline" size="sm" onClick={handleCopy}>
-                  {copied ? <CheckCheck className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
-                </Button>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <p className="text-sm whitespace-pre-wrap leading-relaxed">{result.text}</p>
-            </CardContent>
-          </Card>
-        )}
+        <TranscriptionResultCards
+          result={result}
+          isRetrying={retryMutation.isPending}
+          onRetry={retryTranscription}
+          onBack={clearFeedback}
+        />
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- Split the transcribe add route into a small route shell plus focused upload, recording, result, helper, and mutation modules.
- Preserved the existing record/upload behavior and kept tab-local state mounted while switching tabs.
- Added focused helper coverage for tab validation and duration formatting.

## Validation
- `npm test -- --run src/routes/app/transcribe/__tests__/-add-helpers.test.ts`
- `npx eslint --quiet src/routes/app/transcribe/add.tsx src/routes/app/transcribe/-add-hooks.ts src/routes/app/transcribe/-add-helpers.ts src/routes/app/transcribe/_components/-RecordingForm.tsx src/routes/app/transcribe/_components/-FileUploadForm.tsx src/routes/app/transcribe/_components/-TranscriptionResultCards.tsx src/routes/app/transcribe/__tests__/-add-helpers.test.ts`
- `npx tsc -b --force --pretty false`
- `npm run build`

## Notes
- Voys live E2E validation still needs to run against the deployed PR environment.
