### PR TITLE
fix(mailer): drop legacy InitCode events at /notify

### DIFF
--- a/klai-mailer/README.md
+++ b/klai-mailer/README.md
@@ -47,15 +47,22 @@ openssl rand -hex 32
 
 ## Notification types
 
-Five event types are handled (configured in Zitadel console under Instance > Settings > Message Texts):
+Four event types are handled (configured in Zitadel console under Instance > Settings > Message Texts):
 
 | Type | Trigger |
 |------|---------|
-| `InitCode` | Account created — activation email |
 | `VerifyEmail` | Email address verification |
 | `PasswordReset` | Password reset request |
 | `PasswordChange` | Password changed notification |
 | `InviteUser` | Admin invites a user to the organisation |
+
+A fifth Zitadel event-type — `user.human.initialization.code.added` (legacy
+"InitCode") — is **dropped** by the `/notify` handler with a 204. It fired
+automatically for every newly-created user in `USER_STATE_INITIAL`, producing
+a duplicate of the InviteUser mail with a link to Zitadel's stock hosted UI.
+The v2 invite_code flow (SPEC-PORTAL-AUTH-EMAIL-LINKS-001) owns admin-invites
+since 2026-05-13; the InitCode event no longer represents a user-visible
+flow we want to mail. See `_DROPPED_EVENT_TYPES` in `app/main.py`.
 
 Message text templates (subject, greeting, body, button text, footer) live in `zitadel-message-texts/en.yaml` and `nl.yaml`. These are applied in the Zitadel console; klai-mailer receives the already-rendered content.
 

--- a/klai-mailer/app/main.py
+++ b/klai-mailer/app/main.py
@@ -16,7 +16,7 @@ from typing import Any
 
 import structlog
 from fastapi import FastAPI, HTTPException, Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
 from jinja2 import TemplateNotFound, UndefinedError
 from jinja2.exceptions import SecurityError
 from pydantic import ValidationError
@@ -121,12 +121,29 @@ async def health() -> dict:
     return {"status": "ok"}
 
 
+# SPEC-MAILER-DROP-INITCODE-001: Zitadel fires `user.human.initialization.code.added`
+# automatically when a human user is created without a password or IDP-link,
+# regardless of the `sendCodes` flag on the import call. Since Klai migrated
+# admin invites to the v2 invite_code flow (which fires `user.human.invite.code.added`
+# with our own Klai-branded URL template), the InitCode mail is a duplicate
+# pointing at Zitadel's stock hosted UI — a UX regression discovered in
+# E2E verification of SPEC-PORTAL-AUTH-EMAIL-LINKS-001.
+#
+# We accept the event with 204 so Zitadel marks it as delivered (no retry),
+# and emit a structured `event="dropped_legacy_event"` log so the drop is
+# observable in VictoriaLogs. The InitCode message texts in
+# `zitadel-message-texts/{nl,en}.yaml` are removed in the same PR.
+_DROPPED_EVENT_TYPES = frozenset({"user.human.initialization.code.added"})
+
+
 @app.post("/notify")
 async def notify(request: Request) -> JSONResponse:
     """
     Receive a Zitadel notification, render Klai-branded HTML, send via SMTP.
 
     Returns 200 on success (Zitadel marks notification as sent).
+    Returns 204 on legacy event types we intentionally drop (Zitadel marks
+    as sent, no retry — see ``_DROPPED_EVENT_TYPES``).
     Returns 500 on render/SMTP failure (Zitadel will retry).
     """
     raw_body = await request.body()
@@ -137,10 +154,22 @@ async def notify(request: Request) -> JSONResponse:
 
     payload = ZitadelPayload.model_validate_json(raw_body)
     to_address = payload.recipient_email()
-    logger.info("Received notification type=%s to=%s", payload.event_type(), to_address)
+    event_type = payload.event_type()
+    logger.info("Received notification type=%s to=%s", event_type, to_address)
+
+    if event_type in _DROPPED_EVENT_TYPES:
+        # Legacy event — Klai's v2 invite_code flow owns the admin-invite mail.
+        # Accept with 204 so Zitadel does not retry; do NOT render or send SMTP.
+        # Use bare Response (no JSON body) — 204 mandates an empty payload.
+        logger.info(
+            "dropped_legacy_event type=%s to=%s reason=initcode_replaced_by_invite_code",
+            event_type,
+            to_address,
+        )
+        return Response(status_code=204)
 
     if not to_address:
-        logger.error("No recipient email in payload for event_type=%s", payload.event_type())
+        logger.error("No recipient email in payload for event_type=%s", event_type)
         raise HTTPException(status_code=422, detail="No recipient email address in payload")
 
     lang = await get_user_language(to_address)
@@ -302,12 +331,14 @@ async def internal_send(request: Request) -> JSONResponse:
     except ValidationError as exc:
         errors = []
         for err in exc.errors():
-            errors.append({
-                "loc": err.get("loc"),
-                "msg": err.get("msg"),
-                "type": err.get("type"),
-                "input": _truncate_error_value(err.get("input")),
-            })
+            errors.append(
+                {
+                    "loc": err.get("loc"),
+                    "msg": err.get("msg"),
+                    "type": err.get("type"),
+                    "input": _truncate_error_value(err.get("input")),
+                }
+            )
         struct_logger.warning(
             "mailer_template_schema_invalid",
             template=template_name,
@@ -320,9 +351,7 @@ async def internal_send(request: Request) -> JSONResponse:
 
     # REQ-3: bind recipient. Any mismatch / lookup failure short-circuits
     # BEFORE the rate-limit increment (REQ-4.5).
-    expected_recipient = await _resolve_expected_recipient(
-        template_name, validated, to_address
-    )
+    expected_recipient = await _resolve_expected_recipient(template_name, validated, to_address)
 
     # REQ-4: per-recipient rate limit (AFTER validation, BEFORE dispatch).
     decision = await check_rate_limit(expected_recipient)

--- a/klai-mailer/tests/test_notify_drop_initcode.py
+++ b/klai-mailer/tests/test_notify_drop_initcode.py
@@ -1,0 +1,117 @@
+"""SPEC-MAILER-DROP-INITCODE-001 — drop legacy InitCode events at /notify.
+
+Zitadel auto-fires ``user.human.initialization.code.added`` when a user is
+created in ``USER_STATE_INITIAL``, regardless of ``sendCodes`` on the
+import call. Klai migrated admin invites to the v2 invite_code flow with
+its own urlTemplate (SPEC-PORTAL-AUTH-EMAIL-LINKS-001), so the InitCode
+mail became a duplicate pointing at Zitadel's hosted UI. This test fixes
+the contract: InitCode events return 204 with no SMTP send.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tests._signing import sign
+
+
+@pytest.fixture
+async def client(settings_env, fake_redis, stub_smtp, monkeypatch):
+    """Test client with in-process fakeredis + stubbed portal language lookup."""
+    for mod in ("app.main", "app.nonce", "app.signature", "app.portal_client"):
+        sys.modules.pop(mod, None)
+    import app.nonce as nonce_mod
+
+    nonce_mod.set_redis_client(fake_redis)
+
+    async def _fake_lang(_email: str) -> str | None:
+        return "nl"
+
+    main = importlib.import_module("app.main")
+    import app.nonce as nonce_after
+
+    nonce_after.set_redis_client(fake_redis)
+    # main.py uses `from app.portal_client import get_user_language` → the name
+    # `get_user_language` is bound at module-level on app.main. Patch THAT,
+    # not the source module — source patches don't affect already-bound names.
+    monkeypatch.setattr(main, "get_user_language", _fake_lang)
+    return TestClient(main.app)
+
+
+def _signed_post(client: TestClient, body: dict, secret: str):
+    raw = json.dumps(body).encode()
+    header, _ = sign(raw, secret)
+    return client.post(
+        "/notify",
+        content=raw,
+        headers={"ZITADEL-Signature": header, "Content-Type": "application/json"},
+    )
+
+
+def test_initcode_event_returns_204_and_does_not_send(client, settings_env, stub_smtp):
+    """REQ: InitCode event is accepted with 204 and produces zero SMTP calls."""
+    body = {
+        "contextInfo": {
+            "eventType": "user.human.initialization.code.added",
+            "recipientEmailAddress": "alice@example.com",
+        },
+        "templateData": {
+            "subject": "Activeer je Klai-account",
+            "text": "We hebben een Klai-account voor je aangemaakt.",
+            "url": "https://auth.getklai.com/ui/login/user/init?code=ABC&userID=42",
+            "buttonText": "Account activeren",
+        },
+    }
+    resp = _signed_post(client, body, settings_env["WEBHOOK_SECRET"])
+    assert resp.status_code == 204, f"expected 204, got {resp.status_code}: {resp.text}"
+    assert resp.content == b"", "204 must have empty body"
+    assert stub_smtp.sent == [], (
+        f"InitCode event MUST NOT trigger an SMTP send. Got: {stub_smtp.sent}"
+    )
+
+
+def test_invite_event_still_sends(client, settings_env, stub_smtp):
+    """Regression guard: drop is targeted — InviteUser still mails."""
+    body = {
+        "contextInfo": {
+            "eventType": "user.human.invite.code.added",
+            "recipientEmailAddress": "bob@example.com",
+        },
+        "templateData": {
+            "subject": "Je bent uitgenodigd voor Klai",
+            "greeting": "Hallo Bob,",
+            "text": "Eén van je collega's nodigt je uit.",
+            "url": "https://my.getklai.com/password/set?userID=42&code=ABC&orgID=8",
+            "buttonText": "Account instellen",
+        },
+    }
+    resp = _signed_post(client, body, settings_env["WEBHOOK_SECRET"])
+    assert resp.status_code == 200
+    assert len(stub_smtp.sent) == 1
+    sent = stub_smtp.sent[0]
+    assert sent["to_address"] == "bob@example.com"
+    assert "Je bent uitgenodigd voor Klai" in sent["subject"]
+
+
+def test_password_changed_event_still_sends(client, settings_env, stub_smtp):
+    """Regression guard: drop is targeted — PasswordChange still mails."""
+    body = {
+        "contextInfo": {
+            "eventType": "user.human.password.changed",
+            "recipientEmailAddress": "carol@example.com",
+        },
+        "templateData": {
+            "subject": "Je wachtwoord is gewijzigd",
+            "greeting": "Hallo Carol,",
+            "text": "Het wachtwoord van je Klai-account is zojuist gewijzigd.",
+        },
+    }
+    resp = _signed_post(client, body, settings_env["WEBHOOK_SECRET"])
+    assert resp.status_code == 200
+    assert len(stub_smtp.sent) == 1
+    assert stub_smtp.sent[0]["to_address"] == "carol@example.com"

--- a/klai-mailer/zitadel-message-texts/en.yaml
+++ b/klai-mailer/zitadel-message-texts/en.yaml
@@ -3,14 +3,10 @@
 # Configure via: Zitadel console > Instance > Message Texts > Language: en
 # Available variables per type: https://zitadel.com/docs/guides/manage/customize/texts
 
-InitCode:
-  subject: "Activate your Klai account"
-  preHeader: "Just one click and your Klai environment is live"
-  title: "Activate account"
-  greeting: "Hi {{.FirstName}},"
-  text: "We've created a Klai account for you. Activate it using the button below and choose your password. After that, log in at my.${DOMAIN}."
-  buttonText: "Activate account"
-  footerText: "If you weren't expecting this email, feel free to ignore it."
+# InitCode template removed by SPEC-MAILER-DROP-INITCODE-001 — Klai's v2
+# invite_code flow (user.human.invite.code.added with our own urlTemplate)
+# owns the admin-invite mail since SPEC-PORTAL-AUTH-EMAIL-LINKS-001. The
+# InitCode event is now dropped at the klai-mailer /notify handler with a 204.
 
 VerifyEmail:
   subject: "Confirm your email address at Klai"

--- a/klai-mailer/zitadel-message-texts/nl.yaml
+++ b/klai-mailer/zitadel-message-texts/nl.yaml
@@ -6,14 +6,10 @@
 # These texts are pre-rendered by Zitadel and sent to klai-mailer in templateData.
 # klai-mailer wraps them in the Klai HTML email template.
 
-InitCode:
-  subject: "Activeer je Klai-account"
-  preHeader: "Nog één klik en je Klai-omgeving is actief"
-  title: "Account activeren"
-  greeting: "Hallo {{.FirstName}},"
-  text: "We hebben een Klai-account voor je aangemaakt. Activeer deze via de knop hieronder en kies je wachtwoord. Daarna log je in op my.${DOMAIN}."
-  buttonText: "Account activeren"
-  footerText: "Had je deze e-mail niet verwacht? Dan mag je hem gewoon negeren."
+# InitCode template removed by SPEC-MAILER-DROP-INITCODE-001 — Klai's v2
+# invite_code flow (user.human.invite.code.added with our own urlTemplate)
+# owns the admin-invite mail since SPEC-PORTAL-AUTH-EMAIL-LINKS-001. The
+# InitCode event is now dropped at the klai-mailer /notify handler with a 204.
 
 VerifyEmail:
   subject: "Bevestig je e-mailadres bij Klai"


### PR DESCRIPTION
## What

Discovered during E2E verification of #631 (SPEC-PORTAL-AUTH-EMAIL-LINKS-001): admin invites produced **two** mails to the same recipient — one Klai-branded (`user.human.invite.code.added`, link to `my.getklai.com`) and one Zitadel-default (`user.human.initialization.code.added`, link to `auth.getklai.com/ui/login/user/init`).

## Why two

Zitadel auto-fires `user.human.initialization.code.added` whenever a human user lands in `USER_STATE_INITIAL` (no password, no IDP-link), **regardless of `sendCodes` on the import call**. `sendCodes: False` only governs the email-verification mail, not the InitCode mail.

Since SPEC-PORTAL-AUTH-EMAIL-LINKS-001 the v2 invite_code flow owns the admin-invite mail with our own `urlTemplate`. The InitCode mail is now duplicate dead-code from Klai's perspective.

## Fix

klai-mailer's `/notify` handler skips `user.human.initialization.code.added` events with HTTP 204 — Zitadel marks the notification as delivered, no retry. Plus: InitCode message-text removed from `zitadel-message-texts/{nl,en}.yaml` as dead code.

Industry standard for B2B SaaS admin-invite: **one mail, one code, one click, password set, done.** This fix gets us there.

## Tests

- `test_initcode_event_returns_204_and_does_not_send` (the new contract)
- `test_invite_event_still_sends` (regression guard: drop is targeted)
- `test_password_changed_event_still_sends` (regression guard: drop is targeted)

102/102 klai-mailer tests pass, ruff clean.

## Verification post-deploy

1. Trigger admin invite in voys tenant
2. VictoriaLogs: `service:klai-mailer AND _msg:"Received notification type=user.human.initialization.code.added"` should still appear (Zitadel still fires the event), AND `_msg:"dropped_legacy_event"` should appear on the same request_id
3. VictoriaLogs: `service:klai-mailer AND event:"Email sent successfully"` count for that user should be exactly 1 (the InviteUser mail), not 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)