### PR TITLE
fix(klai-docs): drop em-dash from page title separator (house rule)

### DIFF
--- a/klai-docs/app/(reader)/[...path]/page.tsx
+++ b/klai-docs/app/(reader)/[...path]/page.tsx
@@ -210,7 +210,7 @@ export async function generateMetadata({
     if (raw) {
       const { frontmatter } = parsePage(raw);
       return {
-        title: `${frontmatter.title ?? kbSlug} — ${kb.name}`,
+        title: `${frontmatter.title ?? kbSlug} · ${kb.name}`,
         description: frontmatter.description,
       };
     }


### PR DESCRIPTION
Klai brand-voice forbids em-dashes in user-facing copy. The reader's `<title>` separator used `—` (e.g. "Add sources — Klai Help"). Replaced with middle-dot `·`.

One-line code change. Visible in browser tab on every klai-help page after docs.yml redeploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)