### PR TITLE
feat(portal): SPEC-PORTAL-AUTH-AUTOLOGIN-001 — auto-login after password-set

### DIFF
--- a/klai-portal/backend/app/api/auth.py
+++ b/klai-portal/backend/app/api/auth.py
@@ -40,6 +40,7 @@ import json
 import logging
 import secrets
 import time
+import urllib.parse
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import quote, urlparse
@@ -49,7 +50,7 @@ import redis.exceptions as redis_exc
 import structlog
 from cryptography.fernet import Fernet
 from fastapi import APIRouter, Cookie, Depends, HTTPException, Query, Request, Response, status
-from fastapi.responses import RedirectResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 from fastapi.security import HTTPAuthorizationCredentials
 from pydantic import BaseModel, EmailStr, field_validator
 from sqlalchemy import select
@@ -62,8 +63,10 @@ from app.core.database import AsyncSessionLocal, get_db
 from app.models.portal import PortalOrg, PortalUser
 from app.services import audit
 from app.services.auth_links import AuthLinkRoute, build_url_template
-from app.services.bff_session import SessionService
+from app.services.bff_oidc import OidcFlowError
+from app.services.bff_session import SessionService, session_service
 from app.services.events import emit_event
+from app.services.oidc_pending import oidc_pending
 from app.services.pending_session import PendingSessionService
 from app.services.redis_client import get_redis_pool
 from app.services.request_ip import resolve_caller_ip_subnet
@@ -935,6 +938,19 @@ class PasswordSetRequest(BaseModel):
     new_password: str
 
 
+class PasswordSetResponse(BaseModel):
+    """Where the frontend should navigate after a successful password set.
+
+    SPEC-PORTAL-AUTH-AUTOLOGIN-001 — the response also carries the BFF session
+    cookies (set on the Response object) so the user is logged in immediately.
+    On the auto-login fallback path, ``auto_login_failed`` is true and the
+    frontend should send the user through the normal ``/`` → /login flow.
+    """
+
+    redirect_to: str
+    auto_login_failed: bool = False
+
+
 class TOTPSetupResponse(BaseModel):
     uri: str
     secret: str
@@ -1052,13 +1068,30 @@ async def password_reset(body: PasswordResetRequest) -> None:
         return  # fail silently
 
 
-@router.post("/auth/password/set", status_code=status.HTTP_204_NO_CONTENT)
-async def password_set(body: PasswordSetRequest) -> None:
-    """Complete a password reset using the code from the reset email.
+@router.post("/auth/password/set", response_model=PasswordSetResponse)
+async def password_set(
+    body: PasswordSetRequest,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """Complete a password reset / activation using the code from the email.
 
     SPEC-SEC-AUTH-COVERAGE-001 REQ-3.4..3.6: emit `audit.log_event` on
     success and `password_set_failed` events on every failure leg.
+
+    SPEC-PORTAL-AUTH-AUTOLOGIN-001: after a successful password-set, run
+    Zitadel's "Custom Login UI" auto-login chain (authorize → create_session →
+    finalize → token exchange) and set the BFF session cookies on the response.
+    The frontend then redirects to ``/setup/mfa`` (if no MFA enrolled) or
+    ``/app`` (already enrolled) without asking the user to log in again.
+
+    Auto-login is fail-soft: any error in the chain returns
+    ``{redirect_to: '/', auto_login_failed: true}`` (200 OK) so the frontend
+    falls back to the normal login page with the user's freshly-set password.
+    The password-set itself is always successful at this point — the auth
+    bookkeeping is purely a UX optimisation.
     """
+    # --- Step 1: set the password in Zitadel ---------------------------------
     try:
         await zitadel.set_password_with_code(body.user_id, body.code, body.new_password)
     except httpx.HTTPStatusError as exc:
@@ -1097,6 +1130,145 @@ async def password_set(body: PasswordSetRequest) -> None:
         resource_id=body.user_id,
         details={"reason": "set"},
     )
+
+    # --- Step 2: auto-login (best-effort) ------------------------------------
+    response = JSONResponse({"redirect_to": "/setup/mfa"})
+    try:
+        await _autologin_after_password_set(
+            user_id=body.user_id,
+            password=body.new_password,
+            request=request,
+            response=response,
+            db=db,
+        )
+    except Exception as exc:
+        _slog.warning(
+            "password_set_autologin_failed",
+            actor_user_id=body.user_id,
+            error=str(exc),
+            exc_info=True,
+        )
+        # Return a 200 with auto_login_failed=true; frontend falls back to /login.
+        return JSONResponse(
+            {"redirect_to": "/", "auto_login_failed": True},
+            status_code=status.HTTP_200_OK,
+        )
+
+    return response
+
+
+async def _autologin_after_password_set(
+    *,
+    user_id: str,
+    password: str,
+    request: Request,
+    response: Response,
+    db: AsyncSession,
+) -> None:
+    """Run the Zitadel Custom-Login-UI chain to give the user a live BFF session.
+
+    On success, mutates ``response`` to set ``__Host-klai_session`` + CSRF
+    cookies and adjusts the JSON body to redirect to ``/setup/mfa`` or ``/app``
+    depending on whether the user already has MFA enrolled.
+
+    Raises on any failure — the caller wraps this in a try/except and falls
+    back to a manual-login redirect.
+    """
+    from app.api.auth_bff import (  # local import to avoid auth_bff → auth circular
+        initiate_server_side_authorize,
+        set_session_cookies,
+    )
+    from app.services.bff_oidc import exchange_code_for_tokens
+
+    user_agent_hash = session_service.hash_metadata(request.headers.get("user-agent"))
+
+    # Decide where to send the user BEFORE we burn the OIDC dance — a cheap
+    # has_any_mfa call now saves us a round-trip on success.
+    try:
+        has_mfa = await zitadel.has_any_mfa(user_id)
+    except Exception:
+        # If the MFA lookup itself fails, conservatively assume "no MFA" so the
+        # user lands on /setup/mfa. callback.tsx will redirect to /app if they
+        # actually have MFA.
+        has_mfa = False
+
+    target = "/app" if has_mfa else "/setup/mfa"
+
+    # Step 2a: server-side authorize → authRequestId + pending PKCE record
+    pending = await initiate_server_side_authorize(
+        return_to=target,
+        user_agent_hash=user_agent_hash,
+    )
+
+    # Step 2b: create a Zitadel session with the just-set password
+    session = await zitadel.create_session_with_password(user_id, password)
+    session_id = session["sessionId"]
+    session_token = session["sessionToken"]
+
+    # Step 2c: link the session to the auth-request → callback URL with code
+    callback_url = await zitadel.finalize_auth_request(pending.auth_request_id, session_id, session_token)
+
+    # Extract `code` and `state` from the callback URL Zitadel returns.
+    parsed = urllib.parse.urlparse(callback_url)
+    qs = urllib.parse.parse_qs(parsed.query)
+    code = (qs.get("code") or [""])[0]
+    cb_state = (qs.get("state") or [""])[0]
+    if not code or cb_state != pending.state:
+        raise OidcFlowError(
+            "finalize_callback_invalid",
+            f"missing code or state mismatch in callback_url={callback_url!r}",
+        )
+
+    # Step 2d: exchange the code for OAuth tokens (consumes the pending record)
+    pending_record = await oidc_pending.consume(cb_state)
+    if pending_record is None:
+        raise OidcFlowError("pending_record_missing", "Redis pending record vanished")
+
+    redirect_uri = f"{_origin_for_request(request)}/api/auth/oidc/callback"
+    tokens = await exchange_code_for_tokens(
+        code=code, code_verifier=pending_record.code_verifier, redirect_uri=redirect_uri
+    )
+
+    # Step 2e: resolve the portal org for the new BFF session
+    portal_row = (
+        await db.execute(select(PortalUser).where(PortalUser.zitadel_user_id == user_id))
+    ).scalar_one_or_none()
+    org_id = portal_row.org_id if portal_row is not None else None
+
+    # Step 2f: persist BFF session in Redis and set cookies on the response
+    record = await session_service.create(
+        zitadel_user_id=user_id,
+        org_id=org_id,
+        access_token=tokens.access_token,
+        refresh_token=tokens.refresh_token,
+        access_token_expires_at=int(time.time()) + (tokens.expires_in or 3600),
+        id_token=tokens.id_token,
+        user_agent=request.headers.get("user-agent"),
+        remote_ip=_client_ip_from_request(request),
+    )
+    set_session_cookies(
+        response,
+        sid=record.sid,
+        csrf_token=record.csrf_token,
+        max_age_seconds=settings.bff_session_ttl_seconds,
+    )
+    # Adjust the JSON body to reflect the (already-computed) target.
+    response.body = JSONResponse({"redirect_to": target}).body
+    response.headers["content-length"] = str(len(response.body))
+
+
+def _origin_for_request(request: Request) -> str:
+    """Mirror auth_bff._origin without the circular import."""
+    if settings.frontend_url:
+        return settings.frontend_url.rstrip("/")
+    return f"https://my.{settings.domain}"
+
+
+def _client_ip_from_request(request: Request) -> str | None:
+    xff = request.headers.get("x-forwarded-for")
+    if xff:
+        return xff.split(",", 1)[0].strip()
+    return request.client.host if request.client else None
 
 
 @router.post("/auth/login", response_model=LoginResponse)

--- a/klai-portal/backend/app/api/auth_bff.py
+++ b/klai-portal/backend/app/api/auth_bff.py
@@ -15,7 +15,9 @@ from __future__ import annotations
 
 import time
 import urllib.parse
+from dataclasses import dataclass
 
+import httpx
 import structlog
 from fastapi import APIRouter, Depends, Query, Request, Response
 from fastapi.responses import RedirectResponse
@@ -438,6 +440,91 @@ def _safe_return_to(value: str | None) -> str:
 def _access_token_expiry(expires_in: int) -> int:
     now = int(time.time())
     return now + (expires_in if expires_in > 0 else 3600)
+
+
+# ---------------------------------------------------------------------------
+# Auto-login helpers — SPEC-PORTAL-AUTH-AUTOLOGIN-001
+#
+# After a successful /api/auth/password/set, we want the user to land on
+# /setup/mfa (or /app if they already have MFA) without re-typing the password
+# they just chose. The mechanism is Zitadel's canonical "Custom Login UI"
+# flow: portal-api owns every step of the OIDC dance.
+#
+# Three steps that previously only happened browser-side are folded into one
+# server-side helper here:
+#   1. Initiate authorize  → get authRequestId          ( _server_side_authorize )
+#   2. Create Zitadel session with the new password     ( zitadel.create_session_with_password )
+#   3. Finalize auth-request with session               ( zitadel.finalize_auth_request )
+#   4. Exchange the resulting code for tokens           ( exchange_code_for_tokens )
+#   5. Persist a BFF session record + set cookies       ( session_service.create + set_session_cookies )
+#
+# All five are existing primitives; only step 1 needed a new entry point
+# because Klai's `/api/auth/oidc/start` redirects the BROWSER to Zitadel,
+# while here we need an HTTP client that follows the redirect and parses
+# `authRequest=V2_…` out of the resulting Location header.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class _PendingAuthorize:
+    """The state we need to keep around between authorize and token-exchange."""
+
+    auth_request_id: str
+    code_verifier: str
+    state: str
+
+
+async def initiate_server_side_authorize(
+    *,
+    return_to: str,
+    user_agent_hash: str,
+    ui_locales: str | None = None,
+) -> _PendingAuthorize:
+    """Server-side equivalent of `/api/auth/oidc/start` redirect.
+
+    Performs the same PKCE/state/pending-record bookkeeping as the browser
+    path, then issues `GET /oauth/v2/authorize` (without following redirects)
+    so we can pluck the `authRequest=V2_…` parameter out of the Location
+    header. The returned bundle is passed to ``finalize_auth_request``.
+
+    Raises ``OidcFlowError`` on any non-redirect response or a missing
+    ``authRequest`` query param — the caller decides whether to fall back.
+    """
+    code_verifier = generate_code_verifier()
+    code_challenge = s256_challenge(code_verifier)
+    state = generate_state()
+
+    await oidc_pending.put(
+        state=state,
+        code_verifier=code_verifier,
+        return_to=_safe_return_to(return_to),
+        user_agent_hash=user_agent_hash,
+    )
+
+    authorize_url = build_authorize_url(
+        state=state,
+        code_challenge=code_challenge,
+        redirect_uri=_callback_url(),
+        ui_locales=ui_locales,
+    )
+
+    async with httpx.AsyncClient(timeout=5.0, follow_redirects=False) as client:
+        resp = await client.get(authorize_url)
+    if resp.status_code != 302:
+        raise OidcFlowError(
+            "authorize_unexpected_status",
+            f"expected 302 from /oauth/v2/authorize, got {resp.status_code}",
+        )
+    location = resp.headers.get("location", "")
+    parsed = urllib.parse.urlparse(location)
+    qs = urllib.parse.parse_qs(parsed.query)
+    auth_request_id = (qs.get("authRequest") or [""])[0]
+    if not auth_request_id:
+        raise OidcFlowError(
+            "authorize_no_request_id",
+            f"no authRequest in redirect Location: {location!r}",
+        )
+    return _PendingAuthorize(auth_request_id=auth_request_id, code_verifier=code_verifier, state=state)
 
 
 def _client_ip(request: Request) -> str | None:

--- a/klai-portal/backend/tests/test_auth_password_endpoints.py
+++ b/klai-portal/backend/tests/test_auth_password_endpoints.py
@@ -13,11 +13,15 @@ Zitadel HTTP mocked via respx against the real ``ZitadelClient`` (REQ-5.7).
 
 from __future__ import annotations
 
+import json
+from unittest.mock import AsyncMock
+
 import httpx
 import pytest
 import respx
 from auth_test_helpers import _audit_log_patch, _capture_events, _expected_email_hash
 from fastapi import HTTPException
+from starlette.requests import Request
 from structlog.testing import capture_logs
 
 from app.api.auth import (
@@ -28,6 +32,21 @@ from app.api.auth import (
     password_set,
     verify_email,
 )
+
+
+def _mock_request() -> Request:
+    """Bare Starlette Request for handlers that need `request` but not its body."""
+    return Request(
+        scope={
+            "type": "http",
+            "method": "POST",
+            "path": "/api/auth/password/set",
+            "headers": [(b"user-agent", b"pytest")],
+            "client": ("127.0.0.1", 12345),
+            "query_string": b"",
+        }
+    )
+
 
 # ---------------------------------------------------------------------------
 # Scenario P1 — password_reset known email → 204 + audit (REQ-3.1)
@@ -144,13 +163,21 @@ async def test_password_reset_send_reset_5xx(respx_zitadel: respx.MockRouter) ->
 
 
 @pytest.mark.asyncio
-async def test_password_set_happy(respx_zitadel: respx.MockRouter) -> None:
+async def test_password_set_happy_audit_emitted(respx_zitadel: respx.MockRouter) -> None:
+    """REQ-3.4: audit fires on successful password-set.
+
+    SPEC-PORTAL-AUTH-AUTOLOGIN-001 makes the endpoint return JSON
+    ``{redirect_to, auto_login_failed}`` instead of 204. The auto-login chain
+    is fail-soft — with the catch-all respx mock the OIDC dance cannot complete,
+    so the response carries ``auto_login_failed=true``. The audit event MUST
+    still be emitted regardless of auto-login outcome.
+    """
     respx_zitadel.route().mock(return_value=httpx.Response(200, json={}))
 
     body = PasswordSetRequest(user_id="uid-1", code="123456", new_password="NewSecret123!")
 
     with capture_logs() as captured, _audit_log_patch() as audit_log:
-        await password_set(body=body)
+        response = await password_set(body=body, request=_mock_request(), db=AsyncMock())
 
     audit_log.assert_called_once()
     call_kwargs = audit_log.call_args.kwargs
@@ -158,6 +185,11 @@ async def test_password_set_happy(respx_zitadel: respx.MockRouter) -> None:
     assert call_kwargs["actor"] == "uid-1"
     assert call_kwargs["details"]["reason"] == "set"
     assert _capture_events(captured, "password_set_failed") == []
+
+    # The handler always returns a JSON body now — verify its shape.
+    payload = json.loads(response.body)
+    assert payload["redirect_to"] in ("/setup/mfa", "/app", "/")
+    assert "auto_login_failed" in payload
 
 
 # ---------------------------------------------------------------------------
@@ -173,7 +205,7 @@ async def test_password_set_expired_link(respx_zitadel: respx.MockRouter) -> Non
 
     with capture_logs() as captured, _audit_log_patch() as audit_log:
         with pytest.raises(HTTPException) as exc:
-            await password_set(body=body)
+            await password_set(body=body, request=_mock_request(), db=AsyncMock())
 
     assert exc.value.status_code == 400
     assert "expired or is invalid" in exc.value.detail
@@ -200,7 +232,7 @@ async def test_password_set_invalid_code(respx_zitadel: respx.MockRouter) -> Non
 
     with capture_logs() as captured, _audit_log_patch() as audit_log:
         with pytest.raises(HTTPException) as exc:
-            await password_set(body=body)
+            await password_set(body=body, request=_mock_request(), db=AsyncMock())
 
     assert exc.value.status_code == 400
     audit_log.assert_not_called()
@@ -224,7 +256,7 @@ async def test_password_set_zitadel_5xx(respx_zitadel: respx.MockRouter) -> None
 
     with capture_logs() as captured, _audit_log_patch() as audit_log:
         with pytest.raises(HTTPException) as exc:
-            await password_set(body=body)
+            await password_set(body=body, request=_mock_request(), db=AsyncMock())
 
     assert exc.value.status_code == 502
     assert "Failed to set password" in exc.value.detail

--- a/klai-portal/backend/tests/test_password_set_autologin.py
+++ b/klai-portal/backend/tests/test_password_set_autologin.py
@@ -1,0 +1,273 @@
+"""SPEC-PORTAL-AUTH-AUTOLOGIN-001 — happy-path + fallback for auto-login after password-set.
+
+The handler chains:
+  1. zitadel.set_password_with_code             (POST /v2/users/{id}/password)
+  2. zitadel.has_any_mfa                        (GET  /v2/users/{id}/authentication_methods)
+  3. _initiate_server_side_authorize            (GET  /oauth/v2/authorize, follow_redirects=False)
+  4. zitadel.create_session_with_password       (POST /v2/sessions)
+  5. zitadel.finalize_auth_request              (POST /v2/oidc/auth_requests/{id})
+  6. exchange_code_for_tokens                   (POST /oauth/v2/token)
+  7. session_service.create + set_session_cookies
+
+Any failure in 2-7 falls back to ``{redirect_to: '/', auto_login_failed: true}``
+with the password-set itself remaining successful.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+import respx
+from auth_test_helpers import _audit_log_patch
+from starlette.requests import Request
+
+
+def _mock_request() -> Request:
+    return Request(
+        scope={
+            "type": "http",
+            "method": "POST",
+            "path": "/api/auth/password/set",
+            "headers": [(b"user-agent", b"pytest-autologin")],
+            "client": ("127.0.0.1", 12345),
+            "query_string": b"",
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helper: build mocked respx routes for the full happy-path chain
+# ---------------------------------------------------------------------------
+
+
+def _wire_full_chain(
+    router: respx.MockRouter,
+    *,
+    user_id: str = "uid-1",
+    auth_request_id: str = "V2_xyz",
+    has_mfa: bool = False,
+) -> None:
+    # 1. set_password_with_code → 200
+    router.post(url__regex=rf"/v2/users/{user_id}/password").mock(return_value=httpx.Response(200, json={}))
+    # 2. has_any_mfa → list with one method (true) or empty (false)
+    methods = [{"type": "AUTHENTICATION_METHOD_TYPE_TOTP"}] if has_mfa else []
+    router.get(url__regex=rf"/v2/users/{user_id}/authentication_methods").mock(
+        return_value=httpx.Response(200, json={"authMethodTypes": methods}),
+    )
+    # 3. /oauth/v2/authorize → 302 with Location: …login?authRequest=V2_xyz
+    router.get(url__regex=r".*/oauth/v2/authorize.*").mock(
+        return_value=httpx.Response(
+            302,
+            headers={"location": f"https://my.test/login?authRequest={auth_request_id}"},
+        ),
+    )
+    # 4. create_session_with_password → sessionId + sessionToken
+    router.post(url__regex=r".*/v2/sessions$").mock(
+        return_value=httpx.Response(200, json={"sessionId": "sess-1", "sessionToken": "tok-1"}),
+    )
+    # 5. finalize_auth_request → callbackUrl
+    router.post(url__regex=rf".*/v2/oidc/auth_requests/{auth_request_id}").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "callbackUrl": "https://my.test/api/auth/oidc/callback"
+                "?code=AUTHCODE&state={state}"  # state placeholder filled below
+            },
+        ),
+    )
+    # 6. /oauth/v2/token → tokens
+    router.post(url__regex=r".*/oauth/v2/token$").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "access_token": "at-xyz",
+                "refresh_token": "rt-xyz",
+                "id_token": "id-xyz",
+                "expires_in": 3600,
+                "token_type": "Bearer",
+            },
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy-path: end-to-end auto-login success → cookies set, redirect to /setup/mfa
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_autologin_happy_path_sets_cookies_and_redirects_to_mfa_setup(
+    respx_zitadel: respx.MockRouter, monkeypatch
+) -> None:
+    """Full chain succeeds: response has redirect_to=/setup/mfa + session cookie."""
+    from app.api import auth as auth_module
+    from app.api.auth import PasswordSetRequest, password_set
+
+    user_id = "uid-1"
+    auth_request_id = "V2_xyz"
+
+    _wire_full_chain(respx_zitadel, user_id=user_id, auth_request_id=auth_request_id, has_mfa=False)
+
+    # Stub the server-side authorize helper so we control the state value end-to-end.
+    pending_obj = SimpleNamespace(auth_request_id=auth_request_id, code_verifier="cv-xyz", state="state-xyz")
+    monkeypatch.setattr(
+        "app.api.auth_bff.initiate_server_side_authorize",
+        AsyncMock(return_value=pending_obj),
+    )
+    # finalize returns a callback URL containing our state
+    monkeypatch.setattr(
+        "app.services.zitadel.zitadel.finalize_auth_request",
+        AsyncMock(return_value="https://my.test/api/auth/oidc/callback?code=AUTHCODE&state=state-xyz"),
+    )
+
+    # Stub oidc_pending.consume to return our seeded pending record.
+    pending_record = SimpleNamespace(
+        code_verifier="cv-xyz",
+        return_to="/setup/mfa",
+        user_agent_hash="ua-hash",
+        created_at=0,
+    )
+    monkeypatch.setattr("app.api.auth.oidc_pending.consume", AsyncMock(return_value=pending_record))
+
+    # Stub session_service.create — return a fake SessionRecord with sid + csrf_token.
+    monkeypatch.setattr(
+        "app.api.auth.session_service.create",
+        AsyncMock(return_value=SimpleNamespace(sid="bff-sid-xyz", csrf_token="bff-csrf-xyz")),
+    )
+
+    # Stub the DB lookup — portal_row None is fine, org_id will be None.
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=lambda: None))
+
+    body = PasswordSetRequest(user_id=user_id, code="123456", new_password="NewSecret123!")
+
+    with _audit_log_patch() as audit_log:
+        response = await password_set(body=body, request=_mock_request(), db=mock_db)
+
+    audit_log.assert_called_once()
+    payload = json.loads(response.body)
+    assert payload["redirect_to"] == "/setup/mfa"
+    assert payload.get("auto_login_failed", False) is False
+
+    # Session cookies must be on the response.
+    cookies = [h[1].decode() for h in response.raw_headers if h[0].lower() == b"set-cookie"]
+    assert any("klai_session" in c for c in cookies), f"expected session cookie; got {cookies}"
+    assert any("klai_csrf" in c for c in cookies), f"expected csrf cookie; got {cookies}"
+
+    # Sanity-check that we used the auth_module symbol (no dead-import drift).
+    assert hasattr(auth_module, "password_set")
+
+
+# ---------------------------------------------------------------------------
+# Happy-path with MFA already enrolled → redirect to /app instead of /setup/mfa
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_autologin_user_with_mfa_redirects_to_app(respx_zitadel: respx.MockRouter, monkeypatch) -> None:
+    from app.api.auth import PasswordSetRequest, password_set
+
+    user_id = "uid-mfa"
+    _wire_full_chain(respx_zitadel, user_id=user_id, has_mfa=True)
+
+    # has_any_mfa goes via the real zitadel client. The wired route returns
+    # AUTHENTICATION_METHOD_TYPE_TOTP so the handler should pick /app — but
+    # because we also monkeypatch initiate_server_side_authorize the actual
+    # HTTP call to /authentication_methods may not fire. Stub it directly so
+    # the result is unambiguous.
+    monkeypatch.setattr(
+        "app.services.zitadel.zitadel.has_any_mfa",
+        AsyncMock(return_value=True),
+    )
+    monkeypatch.setattr(
+        "app.api.auth_bff.initiate_server_side_authorize",
+        AsyncMock(return_value=SimpleNamespace(auth_request_id="V2_mfa", code_verifier="cv-mfa", state="state-mfa")),
+    )
+    monkeypatch.setattr(
+        "app.services.zitadel.zitadel.finalize_auth_request",
+        AsyncMock(return_value="https://my.test/api/auth/oidc/callback?code=AC&state=state-mfa"),
+    )
+    monkeypatch.setattr(
+        "app.api.auth.oidc_pending.consume",
+        AsyncMock(
+            return_value=SimpleNamespace(code_verifier="cv-mfa", return_to="/app", user_agent_hash="x", created_at=0)
+        ),
+    )
+    monkeypatch.setattr(
+        "app.api.auth.session_service.create",
+        AsyncMock(return_value=SimpleNamespace(sid="s", csrf_token="c")),
+    )
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=lambda: None))
+
+    body = PasswordSetRequest(user_id=user_id, code="123456", new_password="NewSecret123!")
+
+    with _audit_log_patch():
+        response = await password_set(body=body, request=_mock_request(), db=mock_db)
+
+    payload = json.loads(response.body)
+    assert payload["redirect_to"] == "/app"
+
+
+# ---------------------------------------------------------------------------
+# Fallback: any auto-login step fails → response carries auto_login_failed=true
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_autologin_fallback_when_authorize_fails(respx_zitadel: respx.MockRouter, monkeypatch) -> None:
+    """If server-side /authorize doesn't return a Location, fallback fires."""
+    from app.api.auth import PasswordSetRequest, password_set
+
+    # set_password_with_code succeeds; everything else falls through to failure
+    respx_zitadel.post(url__regex=r"/v2/users/uid-1/password").mock(
+        return_value=httpx.Response(200, json={}),
+    )
+    respx_zitadel.get(url__regex=r"/v2/users/uid-1/authentication_methods").mock(
+        return_value=httpx.Response(200, json={"authMethodTypes": []}),
+    )
+    # /authorize returns 200 (NOT a 302) → raises OidcFlowError("authorize_unexpected_status")
+    respx_zitadel.get(url__regex=r".*/oauth/v2/authorize.*").mock(
+        return_value=httpx.Response(200, text="not a redirect"),
+    )
+
+    body = PasswordSetRequest(user_id="uid-1", code="123456", new_password="NewSecret123!")
+
+    with _audit_log_patch():
+        response = await password_set(body=body, request=_mock_request(), db=AsyncMock())
+
+    assert response.status_code == 200
+    payload = json.loads(response.body)
+    assert payload["redirect_to"] == "/"
+    assert payload["auto_login_failed"] is True
+
+
+@pytest.mark.asyncio
+async def test_autologin_fallback_when_finalize_fails(respx_zitadel: respx.MockRouter, monkeypatch) -> None:
+    """If finalize_auth_request raises, fallback fires; audit still emitted."""
+    from app.api.auth import PasswordSetRequest, password_set
+
+    user_id = "uid-1"
+    _wire_full_chain(respx_zitadel, user_id=user_id, has_mfa=False)
+
+    monkeypatch.setattr(
+        "app.api.auth_bff.initiate_server_side_authorize",
+        AsyncMock(return_value=SimpleNamespace(auth_request_id="V2_x", code_verifier="cv", state="s")),
+    )
+    monkeypatch.setattr(
+        "app.services.zitadel.zitadel.finalize_auth_request",
+        AsyncMock(side_effect=httpx.HTTPError("finalize boom")),
+    )
+
+    body = PasswordSetRequest(user_id=user_id, code="123456", new_password="NewSecret123!")
+
+    with _audit_log_patch() as audit_log:
+        response = await password_set(body=body, request=_mock_request(), db=AsyncMock())
+
+    audit_log.assert_called_once()  # password-set audit MUST still fire
+    payload = json.loads(response.body)
+    assert payload["auto_login_failed"] is True

--- a/klai-portal/frontend/src/routes/password/set.tsx
+++ b/klai-portal/frontend/src/routes/password/set.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/react-router'
 import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { KeyRound } from 'lucide-react'
@@ -26,7 +26,6 @@ export const Route = createFileRoute('/password/set')({
 
 function PasswordSetPage() {
   const { userID, code } = Route.useSearch()
-  const navigate = useNavigate()
 
   const [password, setPassword] = useState('')
   const [confirm, setConfirm] = useState('')
@@ -49,20 +48,37 @@ function PasswordSetPage() {
 
     setLoading(true)
     try {
+      // SPEC-PORTAL-AUTH-AUTOLOGIN-001 — `credentials: 'include'` is required
+      // so the BFF session cookies set by the auto-login chain are accepted
+      // by the browser. Without it, the cookie set by the backend is silently
+      // dropped and the user lands on /setup/mfa without a session.
       const resp = await fetch(`${API_BASE}/api/auth/password/set`, {
         method: 'POST',
+        credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ user_id: userID, code, new_password: password }),
       })
 
       if (!resp.ok) {
-        const data = await resp.json().catch(() => ({}))
+        const data = (await resp.json().catch(() => ({}))) as { detail?: string }
         setError(data?.detail ?? m.set_error_server())
         return
       }
 
+      // Backend returns { redirect_to, auto_login_failed }. On the happy path
+      // the session cookies are already set on this response — we just
+      // navigate to the indicated route (`/setup/mfa` or `/app`). On the
+      // fail-soft fallback the user is sent to `/` and re-authenticates via
+      // the normal login page with the password they just chose.
+      const data = (await resp.json().catch(() => ({ redirect_to: '/' }))) as {
+        redirect_to?: string
+      }
+      const target = data?.redirect_to ?? '/'
+
       setDone(true)
-      setTimeout(() => void navigate({ to: '/' }), 2500)
+      // Hard navigation so any cross-tab session state is reloaded fresh and
+      // the new BFF session cookie is picked up by every subsequent fetch.
+      window.location.assign(target)
     } catch {
       setError(m.error_connection())
     } finally {


### PR DESCRIPTION
## What

After invite-mail activation or password-reset, the user lands on /password/set, chooses a password, and is **immediately logged in** — no re-typing of the password they just set. They go directly to `/setup/mfa` (if no MFA enrolled) or `/app` (already enrolled).

Before this PR: 5 user-steps between mail-click and reaching the app (password-set → '/' → OIDC redirect → login form → type-password-again → callback → /setup/mfa). After: 2 user-steps (password-set → /setup/mfa).

## How

Backend /api/auth/password/set runs Zitadel's canonical **Custom Login UI** chain in one handler:

1. `set_password_with_code` (existing)
2. `has_any_mfa` → choose `/setup/mfa` or `/app`
3. `initiate_server_side_authorize` — new helper in auth_bff; does the same PKCE + state + oidc_pending bookkeeping as `/oidc/start` and issues `GET /oauth/v2/authorize` (no follow_redirects) to pluck the `authRequest=V2_…` parameter
4. `create_session_with_password` (existing)
5. `finalize_auth_request` (existing)
6. `exchange_code_for_tokens` (existing)
7. `session_service.create` + `set_session_cookies` (existing)

Frontend `password/set.tsx` adds `credentials: 'include'` and navigates to `data.redirect_to` from the response (replaces the 2.5s setTimeout + navigate to `/`).

## Fail-soft

Any failure in steps 2-7 returns `{ redirect_to: '/', auto_login_failed: true }` (200 OK). The password-set itself is always successful at that point — auto-login is a UX optimisation, not a correctness invariant. The audit event (`auth.password.set`) fires regardless of auto-login outcome.

## Why this is the right pattern

Klai's portal-api is already Zitadel's [Custom Login UI](https://zitadel.com/docs/guides/integrate/login-ui/oidc-standard) for every other flow (login, signup, MFA, IDP intent). Password-set was the one path that still threw the user back to the OIDC dance. This PR closes the loop — same primitives Klai already uses for `/api/auth/login`, just without an externally-supplied `authRequest` (we initiate it server-side).

## Tests (2662 backend tests passing, 4 new)

- `test_password_set_happy_audit_emitted` — audit invariant
- `test_autologin_happy_path_sets_cookies_and_redirects_to_mfa_setup` — cookies + /setup/mfa
- `test_autologin_user_with_mfa_redirects_to_app` — MFA-already path
- `test_autologin_fallback_when_authorize_fails` — authorize step fails → fallback
- `test_autologin_fallback_when_finalize_fails` — finalize fails → fallback + audit still fires

ruff clean, frontend tsc clean.

## Verification post-deploy

1. Trigger admin-invite in voys tenant (Google SSO admin login)
2. Pull the activation link from VictoriaLogs
3. Open the link in a fresh browser → type password → submit
4. Expectation: user lands directly on `/setup/mfa` with `__Host-klai_session` cookie set, no Login V2 prompt, no re-typing the password

🤖 Generated with [Claude Code](https://claude.com/claude-code)