### PR TITLE
fix(portal): CSRF-exempt /api/auth/password/{reset,set}

### DIFF
--- a/klai-portal/backend/app/middleware/session.py
+++ b/klai-portal/backend/app/middleware/session.py
@@ -66,6 +66,17 @@ _CSRF_EXEMPT_PREFIXES: tuple[str, ...] = (
     # would otherwise cause the CSRF check to reject the password finish.
     # REQ-4.3 / AC-2
     "/api/auth/login",
+    # pre-session: password-reset request comes from /password/forgot before
+    # any login. Authenticated only by the user's typed email (anti-enumeration
+    # 204 contract). A stale BFF cookie would otherwise demand a CSRF token
+    # that the un-authenticated page does not have.
+    # REQ-4.3 / AC-2
+    "/api/auth/password/reset",
+    # pre-session: activation / reset-completion endpoint. Caller arrives from
+    # a one-time mail-link with userID + code; that IS the authentication.
+    # The auto-login chain mints a fresh BFF session as part of the response.
+    # REQ-4.3 / AC-2
+    "/api/auth/password/set",
     # Zitadel Login V2 TOTP finisher — same pre-session rationale as
     # /api/auth/login.
     # REQ-4.3 / AC-2


### PR DESCRIPTION
Hotfix to SPEC-PORTAL-AUTH-AUTOLOGIN-001 (#635).

E2E verification revealed that a stale BFF session cookie (admin tab still open) causes /api/auth/password/set to 403 with `bff_csrf_check_failed`. Both /password/reset and /password/set are pre-session endpoints (user arrives from a one-time mail-link with userID+code as the only auth), so they belong in `_CSRF_EXEMPT_PREFIXES` next to /api/auth/login.

The auto-login chain mints a fresh BFF session as the response, so any pre-existing cookie was always irrelevant — this just teaches the middleware that.

Tests: 2662/2662 passing, CSRF-rationale lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)