### PR TITLE
fix(portal): set_password_with_code handles invite AND reset codes

### DIFF
--- a/klai-portal/backend/app/services/zitadel.py
+++ b/klai-portal/backend/app/services/zitadel.py
@@ -375,15 +375,68 @@ class ZitadelClient:
         return resp.json()["callbackUrl"]
 
     async def set_password_with_code(self, user_id: str, code: str, new_password: str) -> None:
-        """Set a new password using a verification code from a password-reset email."""
-        resp = await self._http.post(
+        """Set a new password using a one-time code from email.
+
+        Zitadel has TWO distinct code flows that both land on Klai's
+        ``/password/set`` page:
+
+        - **Password reset** (from ``/password/forgot``) — one API call:
+          ``POST /v2/users/{id}/password`` with ``{newPassword, verificationCode}``.
+          Zitadel consumes the password_reset code and sets the password
+          atomically.
+
+        - **Invite** (from admin-invite mail) — two API calls:
+          1. ``POST /v2/users/{id}/invite_code/verify`` with
+             ``{verificationCode: code}`` — verifies the invite code AND
+             marks the user's email as verified.
+          2. ``POST /v2/users/{id}/password`` with ``{newPassword}`` (no
+             code) — sets the password on the now-verified user.
+
+          The invite_code consumer does NOT accept reset-style codes, and
+          the password endpoint does NOT accept invite codes. Without this
+          split the invite-flow returns 400 ``invalid_code``.
+
+        We try the invite-flow first because invite-codes are the more
+        common case (every newly invited user goes through it). If the
+        verify step returns a 4xx we fall back to the reset-flow.
+
+        Behaviour parity with the previous implementation:
+        - Raises ``httpx.HTTPStatusError`` (caller maps to 400/502).
+        - Both flows leave the user in a state where they can immediately
+          authenticate with the new password — the auto-login chain in
+          ``password_set`` works for either path.
+        """
+        # ---- Path 1: invite flow ------------------------------------------------
+        verify_resp = await self._http.post(
+            f"/v2/users/{user_id}/invite_code/verify",
+            json={"verificationCode": code},
+        )
+        if verify_resp.is_success:
+            # Invite verified; set the password without a code on the now-verified user.
+            password_resp = await self._http.post(
+                f"/v2/users/{user_id}/password",
+                json={"newPassword": {"password": new_password, "changeRequired": False}},
+            )
+            password_resp.raise_for_status()
+            return
+
+        # invite_code/verify returned 4xx/5xx. Two reasons it might:
+        #   - 4xx: the code is not an invite code (likely a password-reset code).
+        #          Fall back to the reset-flow below.
+        #   - 5xx: Zitadel itself is unhealthy. Propagate as HTTPStatusError so
+        #          the caller emits zitadel_5xx and returns 502.
+        if verify_resp.status_code >= 500:
+            verify_resp.raise_for_status()
+
+        # ---- Path 2: reset flow (1 call) ---------------------------------------
+        reset_resp = await self._http.post(
             f"/v2/users/{user_id}/password",
             json={
                 "newPassword": {"password": new_password, "changeRequired": False},
                 "verificationCode": code,
             },
         )
-        resp.raise_for_status()
+        reset_resp.raise_for_status()
 
     async def find_user_id_by_email(self, email: str) -> str | None:
         """Return the Zitadel userId for the given email, or None if not found.

--- a/klai-portal/backend/tests/test_password_set_autologin.py
+++ b/klai-portal/backend/tests/test_password_set_autologin.py
@@ -51,8 +51,12 @@ def _wire_full_chain(
     auth_request_id: str = "V2_xyz",
     has_mfa: bool = False,
 ) -> None:
-    # 1. set_password_with_code → 200
-    router.post(url__regex=rf"/v2/users/{user_id}/password").mock(return_value=httpx.Response(200, json={}))
+    # 1a. set_password_with_code tries invite_code/verify first → 200
+    router.post(url__regex=rf"/v2/users/{user_id}/invite_code/verify").mock(
+        return_value=httpx.Response(200, json={"details": {"sequence": "11"}}),
+    )
+    # 1b. then password (without verificationCode) → 200
+    router.post(url__regex=rf"/v2/users/{user_id}/password$").mock(return_value=httpx.Response(200, json={}))
     # 2. has_any_mfa → list with one method (true) or empty (false)
     methods = [{"type": "AUTHENTICATION_METHOD_TYPE_TOTP"}] if has_mfa else []
     router.get(url__regex=rf"/v2/users/{user_id}/authentication_methods").mock(
@@ -223,8 +227,11 @@ async def test_autologin_fallback_when_authorize_fails(respx_zitadel: respx.Mock
     """If server-side /authorize doesn't return a Location, fallback fires."""
     from app.api.auth import PasswordSetRequest, password_set
 
-    # set_password_with_code succeeds; everything else falls through to failure
-    respx_zitadel.post(url__regex=r"/v2/users/uid-1/password").mock(
+    # set_password_with_code succeeds via invite-flow; everything else falls through.
+    respx_zitadel.post(url__regex=r"/v2/users/uid-1/invite_code/verify").mock(
+        return_value=httpx.Response(200, json={"details": {"sequence": "11"}}),
+    )
+    respx_zitadel.post(url__regex=r"/v2/users/uid-1/password$").mock(
         return_value=httpx.Response(200, json={}),
     )
     respx_zitadel.get(url__regex=r"/v2/users/uid-1/authentication_methods").mock(

--- a/klai-portal/backend/tests/test_set_password_with_code_dual_flow.py
+++ b/klai-portal/backend/tests/test_set_password_with_code_dual_flow.py
@@ -1,0 +1,130 @@
+"""Coverage for set_password_with_code's dual-path (invite + reset) behaviour.
+
+Zitadel has two flows that both arrive on Klai's /password/set page:
+  - Invite:  POST /v2/users/{id}/invite_code/verify  + POST /v2/users/{id}/password
+  - Reset:   POST /v2/users/{id}/password (with verificationCode in the body)
+
+set_password_with_code MUST try invite first, then fall back to reset on 4xx.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+
+def _client_with_mocked_http():
+    from app.services.zitadel import ZitadelClient
+
+    client = ZitadelClient.__new__(ZitadelClient)
+    client._http = MagicMock()
+    return client
+
+
+def _resp(status: int, json_body: dict | None = None) -> MagicMock:
+    r = MagicMock()
+    r.status_code = status
+    r.is_success = 200 <= status < 300
+    r.json = MagicMock(return_value=json_body or {})
+
+    def _raise() -> None:
+        if status >= 400:
+            req = httpx.Request("POST", f"https://zitadel.example/v2/x?status={status}")
+            raw = httpx.Response(status, request=req)
+            raise httpx.HTTPStatusError(f"HTTP {status}", request=req, response=raw)
+
+    r.raise_for_status = MagicMock(side_effect=_raise)
+    return r
+
+
+@pytest.mark.asyncio
+async def test_invite_flow_happy_path() -> None:
+    """invite_code/verify 200 → password (no code) 200 → return."""
+    client = _client_with_mocked_http()
+    client._http.post = AsyncMock(
+        side_effect=[
+            _resp(200, {"details": {"sequence": "11"}}),  # invite_code/verify
+            _resp(200, {"details": {"sequence": "12"}}),  # password (no code)
+        ]
+    )
+
+    await client.set_password_with_code("uid-1", "INVITE", "NewSecret123!")
+
+    assert client._http.post.await_count == 2
+    # First call: verify
+    first = client._http.post.await_args_list[0]
+    assert first.args[0] == "/v2/users/uid-1/invite_code/verify"
+    assert first.kwargs["json"] == {"verificationCode": "INVITE"}
+    # Second call: password without verificationCode
+    second = client._http.post.await_args_list[1]
+    assert second.args[0] == "/v2/users/uid-1/password"
+    assert "verificationCode" not in second.kwargs["json"]
+    assert second.kwargs["json"]["newPassword"]["password"] == "NewSecret123!"
+
+
+@pytest.mark.asyncio
+async def test_invite_verify_4xx_falls_back_to_reset_flow() -> None:
+    """invite_code/verify 400 → reset-flow attempt → success."""
+    client = _client_with_mocked_http()
+    client._http.post = AsyncMock(
+        side_effect=[
+            _resp(400, {"error": "code is not an invite"}),  # invite_code/verify
+            _resp(200, {"details": {"sequence": "8"}}),  # reset-flow password (with code)
+        ]
+    )
+
+    await client.set_password_with_code("uid-1", "RESETCODE", "NewSecret123!")
+
+    assert client._http.post.await_count == 2
+    second = client._http.post.await_args_list[1]
+    assert second.args[0] == "/v2/users/uid-1/password"
+    # Reset flow includes verificationCode
+    assert second.kwargs["json"]["verificationCode"] == "RESETCODE"
+
+
+@pytest.mark.asyncio
+async def test_invite_verify_5xx_propagates() -> None:
+    """invite_code/verify 502 → propagate HTTPStatusError, no fallback attempt."""
+    client = _client_with_mocked_http()
+    client._http.post = AsyncMock(side_effect=[_resp(502, {"error": "bad gw"})])
+
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        await client.set_password_with_code("uid-1", "X", "NewSecret123!")
+    assert exc.value.response.status_code == 502
+    # No fallback attempted on 5xx.
+    assert client._http.post.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_reset_flow_4xx_invalid_code() -> None:
+    """invite_code/verify 400 → reset-flow 400 → both 4xx, raise as reset 4xx."""
+    client = _client_with_mocked_http()
+    client._http.post = AsyncMock(
+        side_effect=[
+            _resp(400, {"error": "not an invite"}),  # invite_code/verify
+            _resp(400, {"error": "bad code"}),  # reset password
+        ]
+    )
+
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        await client.set_password_with_code("uid-1", "BOGUS", "NewSecret123!")
+    assert exc.value.response.status_code == 400
+    assert client._http.post.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_invite_flow_password_step_5xx() -> None:
+    """invite_code/verify 200 → password 502 → propagate 502."""
+    client = _client_with_mocked_http()
+    client._http.post = AsyncMock(
+        side_effect=[
+            _resp(200, {"details": {"sequence": "11"}}),
+            _resp(502, {"error": "bad gw"}),
+        ]
+    )
+
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        await client.set_password_with_code("uid-1", "INVITE", "NewSecret123!")
+    assert exc.value.response.status_code == 502

--- a/klai-portal/backend/tests/test_zitadel_email_link_lint.py
+++ b/klai-portal/backend/tests/test_zitadel_email_link_lint.py
@@ -29,8 +29,11 @@ APP_DIR = Path(__file__).resolve().parents[1] / "app"
 # SendPasswordResetLink, and SendEmailVerificationCode all carry a
 # ``url_template`` field.
 _ENDPOINT_PATTERNS = (
-    re.compile(r"/v2/users/[^/]+(?:/invite_code(?:/resend)?|/password_reset)"),
-    re.compile(r"/v2/users/[^/]+/email/(?:_send_code|_resend)"),
+    # Anchored end ($ or ?) so consumer endpoints like .../invite_code/verify
+    # (which post to a matching prefix but are NOT mail-triggers and don't
+    # take a urlTemplate) don't trip the lint.
+    re.compile(r"/v2/users/[^/]+(?:/invite_code(?:/resend)?|/password_reset)(?:$|\?)"),
+    re.compile(r"/v2/users/[^/]+/email/(?:_send_code|_resend)(?:$|\?)"),
 )
 
 


### PR DESCRIPTION
Follow-up to #631 (SPEC-PORTAL-AUTH-EMAIL-LINKS-001) and #635 (SPEC-PORTAL-AUTH-AUTOLOGIN-001). Discovered in E2E verification.

## Bug

Zitadel uses **two different** one-time-code consumer endpoints for the two flows that both land on /password/set:

| Flow | Endpoint | Body |
|---|---|---|
| **Reset** (from /password/forgot) | `POST /v2/users/{id}/password` | `{newPassword, verificationCode}` |
| **Invite** (from admin invite-mail) | `POST /v2/users/{id}/invite_code/verify` then `POST /v2/users/{id}/password` | `{verificationCode}` then `{newPassword}` (no code) |

The original `set_password_with_code` only did the reset flow. Since #631 pointed the invite-mail link at Klai's /password/set instead of Zitadel's hosted UI, every new admin-invite returned 400 `invalid_code` at the server. **The reset flow was unaffected.**

## Fix

`set_password_with_code` now tries invite-flow first (verify → password no code) and falls back to reset-flow on 4xx. 5xx on verify propagates immediately (no silent fallback on server outage).

## Coverage

- 5 new tests for the dual-path behaviour: `test_set_password_with_code_dual_flow.py`
- Existing autologin + email-link-lint tests updated to mock the new `invite_code/verify` endpoint
- 2667/2667 backend tests passing, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)