### PR TITLE
docs(playwright-mcp): persistent workspace-hash profile as default

### DIFF
--- a/.claude/rules/klai/lang/agent-browser.md
+++ b/.claude/rules/klai/lang/agent-browser.md
@@ -16,8 +16,8 @@ paths:
 | Smoke test na deploy (intent: "klop service aan, niets stuk?") | **Agent Browser** | AI-navigatie tolereert UI-drift, geen selector-onderhoud |
 | Onboarding/signup regression (intent-stable, UI-volatile) | **Agent Browser** | Idem |
 | Audit-style runs (a11y, copy-consistency, design checks) | **Agent Browser** | Past bij exploratory scoring door evaluator-active |
-| One-off CSS/visual check zonder login | Playwright MCP via incognito-tab | Eén MCP-server, ingelogd via storage-state — open een nieuwe tab als je een schone context wilt |
-| Authenticated portal regression met vaste selectors | Playwright MCP | Storage-state via `~/.claude/mcp-storageState.json` |
+| One-off CSS/visual check zonder login | Playwright MCP via incognito-tab óf `PLAYWRIGHT_ISOLATED=1` | Eén MCP-server, ingelogd via workspace-hashed persistent profile — open een nieuwe tab voor een schone context, of zet de env var voor een volledig logged-out browser |
+| Authenticated portal regression met vaste selectors | Playwright MCP | Persistent workspace profile (login state survives Claude Code restarts). Storage-state seed (`~/.claude/mcp-storageState.json`) is optional first-boot preload |
 
 Default: voor alles met "verify dat X werkt" → Playwright. Voor alles met "explore of er iets stuk is" → Agent Browser.
 
@@ -79,7 +79,7 @@ agent-browser --session "$SESSION" \
               open https://app.getklai.com/dashboard
 ```
 
-Refresh storage-state om de paar weken (zelfde cadans als Playwright). Als sessies "logged-out" starten: state file is verlopen → opnieuw `state save`.
+Refresh `~/.claude/agent-browser-state.json` om de paar weken wanneer Google's session cookies verlopen. (Dit geldt voor Agent Browser; Playwright MCP heeft die cadens niet meer — die gebruikt sinds 2026-05-13 een workspace-hashed persistent profile dat zichzelf onderhoudt.) Als Agent Browser sessies "logged-out" starten: state file is verlopen → opnieuw `state save`.
 
 ## Cleanup [HARD]
 

--- a/.claude/rules/klai/lang/testing.md
+++ b/.claude/rules/klai/lang/testing.md
@@ -9,20 +9,41 @@ paths:
 # Testing Rules
 
 ## [HARD] Close browser when done
-After ANY Playwright testing, close all tabs then `browser_close()`. Brave locks `userDataDir` with `SingletonLock` — leaving it open blocks the next session.
+After ANY Playwright testing, close all tabs then `browser_close()`. The persistent
+profile dir is workspace-hashed (see below), but the running Chrome instance still
+holds resources — leave a clean state for the next session.
+
+## [HARD] Never click "Log out" in a persistent Playwright session
+The default Playwright MCP browser uses a workspace-hashed PERSISTENT profile.
+Clicking Log out wipes the login state for the entire workspace, forcing a fresh
+hand-login next session. If you specifically need to test a logout/login flow,
+spawn a session with `PLAYWRIGHT_ISOLATED=1` (ephemeral, logged-out profile) — the
+workspace profile is untouched.
 
 ## Playwright MCP workflow
-1. Kill Brave before starting: `pkill -x "Brave Browser"`
-2. Navigate: `browser_navigate({ url: '...' })`
-3. Inspect: `browser_snapshot()` (prefer over screenshots for assertions)
-4. Interact via `ref` from snapshot, never CSS selectors: `browser_click({ ref: 'e66' })`
-5. Close browser when done (see rule above)
+1. Navigate: `browser_navigate({ url: '...' })` — workspace profile is already logged in
+2. Inspect: `browser_snapshot()` (prefer over screenshots for assertions)
+3. Interact via `ref` from snapshot, never CSS selectors: `browser_click({ target: 'e66', element: '...' })`
+4. Close browser when done (see rule above)
 
 ## Playwright session management
-- Persistent profile at `~/.claude/mcp-brave-profile` — login sessions survive across runs.
-- Brave locks `userDataDir` with `SingletonLock` — only one session at a time.
-- If "Profile already in use": `pkill -x "Brave Browser"`
+- Default profile: `~/Library/Caches/ms-playwright/mcp-chrome-{workspace-hash}` (macOS;
+  analogous paths on Linux/Windows). Each Conductor workspace gets its own hash,
+  so parallel sessions across workspaces don't collide.
+- Login state persists across Claude Code restarts within a workspace — no periodic
+  storage-state refresh needed (that was the pre-2026-05-13 `--isolated` pattern).
+- `Browser is already in use` happens only when two MCP clients touch the SAME
+  workspace's profile simultaneously. Fix: set `PLAYWRIGHT_ISOLATED=1` on the second
+  one. Cross-workspace concurrency is fine.
+- Storage-state seed (`~/.claude/mcp-storageState.json`) is optional first-boot
+  preload, mostly useful for isolated sessions. The persistent profile auto-saves
+  cookies on its own.
+- To wipe a workspace's login: `rm -rf ~/Library/Caches/ms-playwright/mcp-chrome-*`
+  (macOS) and restart Claude Code, then log in once more by hand.
 - Grant permissions programmatically: `context.grantPermissions(['microphone'], { origin: '...' })`
+
+For the full reasoning + anti-patterns, see `playwright-mcp-config-cycle` in
+`.claude/rules/klai/pitfalls/process-rules.md`.
 
 ## Browser console + GlitchTip
 - Check browser errors: `browser_console_messages({ level: 'error' })`

--- a/.claude/rules/klai/pitfalls/process-rules.md
+++ b/.claude/rules/klai/pitfalls/process-rules.md
@@ -1630,161 +1630,157 @@ deploy (PR #296, 12:11 CEST) used UIDs `spec-infra-container-hygiene-001-tenant-
 4. The `rsync without --delete` quirk is a SEPARATE class: `deploy-compose.yml` syncs `deploy/grafana/provisioning/` to `/opt/klai/grafana/provisioning/` with `rsync -ac` (no `--delete`). Revert-removed files persist on disk. For any future revert that removes provisioning files, the operator MUST `ssh core-01 "rm /opt/klai/grafana/provisioning/<deleted-path>"` after the revert merges. Long-term fix is to add `--delete` to the rsync (separate SPEC — `--delete` has its own blast-radius considerations because server-only files would also disappear).
 
 ## playwright-mcp-config-cycle (HIGH)
-The `@playwright/mcp` configuration in `.mcp.json` has been "fixed" at least
-five times since April 2026 (commits `940d079e`, `0ceab6b6`, `b26d5e01`,
-`0a423697`, `ce6a8ab5`) — each fix re-introduced the failure mode that the
-previous fix was trying to eliminate. The user has explicitly named this an
+The `@playwright/mcp` configuration has been "fixed" at least six times
+since April 2026, each fix re-introducing the failure mode the previous
+fix was trying to eliminate. The user has explicitly named this an
 "every-time-you-fix-it-it-breaks-the-other-thing" cycle. Before changing
-ANYTHING about this config, you MUST internalise this entry, because the
-failure modes look like ordinary bugs each time you encounter them.
+ANYTHING about this config, you MUST internalise this entry — the failure
+modes look like ordinary bugs each time you encounter them.
 
 **Use case (settled, do not re-derive):**
 AI-driven coding sessions where the assistant validates its own changes
-end-to-end via Playwright MCP. The user logs in ONCE; the AI takes over
-from there. Multiple coding sessions can run in parallel, each needing a
-visible browser with the same login already loaded. The AI does not log
-out, does not change passwords, does not mutate auth state. Read-only
-login state is therefore sufficient.
+end-to-end via Playwright MCP. You log in ONCE per workspace; the AI
+takes over from there. Multiple Conductor workspaces run Playwright in
+parallel, each needing a visible browser with that workspace's login
+already loaded. The AI must not click Log out; the workspace profile is
+the source of truth for login state.
 
-**The constraint on the platform.** `@playwright/mcp` and Chromium together
-allow two profile modes:
+**Canonical setup (post-2026-05-13):**
+`@playwright/mcp@latest --browser chrome`, with NO `--isolated` and NO
+`--user-data-dir` in the default args. Playwright MCP then uses its
+**workspace-hashed persistent profile** at:
 
-- Persistent `--user-data-dir`: login persists, BUT "A persistent profile
-  can only be used by one browser instance at a time, so concurrent MCP
-  clients sharing the same workspace will conflict." Symptom: second
-  Claude Code session fails with `Browser is already in use`.
-- `--isolated`: parallel sessions work, ephemeral profile per process. By
-  itself the profile starts empty; combine with `--storage-state <file>`
-  to preload cookies/localStorage at startup.
+- macOS: `~/Library/Caches/ms-playwright/mcp-{channel}-{workspace-hash}`
+- Linux: `~/.cache/ms-playwright/mcp-{channel}-{workspace-hash}`
+- Windows: `%LOCALAPPDATA%\ms-playwright\mcp-{channel}-{workspace-hash}`
 
-`--storage-state` is read-only at startup and never written back. Microsoft
-explicitly declined named-session-with-auto-save in
-[#1530](https://github.com/microsoft/playwright-mcp/issues/1530)
-(closed Not Planned, May 2026). For this repo's use case (AI doesn't mutate
-auth) read-only is fine — refresh the file once when Google's session
-cookies expire (~3 weeks).
+The `{workspace-hash}` is derived from the MCP client's workspace root,
+so each Conductor workspace gets its own profile directory automatically.
+No lock conflict across workspaces. Login state persists between Claude
+Code restarts within a workspace.
 
-**The canonical answer for this use case:**
-`--isolated --storage-state ~/.claude/mcp-storageState.json`. Seed the
-storage-state file via `browser_run_code_unsafe` with one Playwright
-snippet that calls `page.context().storageState({ path })` — verified
-working on 2026-05-07. Do NOT use `npx playwright codegen
---save-storage=...`: that path is flaky on macOS (the file only writes
-on a specific Inspector-side close event; closing the browser the
-wrong way means no file appears). PR #354 shipped codegen as the seed
-and lost a week of debugging before the 2026-05-07 retry confirmed
-the failure mode. Note: there is **no** separate `browser_storage_state`
-MCP tool in `@playwright/mcp@latest` — earlier drafts of this entry
-referenced one that does not exist. The functionality lives in the
-generic `browser_run_code_unsafe` tool, which executes Playwright code
-server-side; calling `page.context().storageState({ path: '...' })`
-writes the cookies + localStorage directly. No external tooling, no
-Inspector window, no Ctrl+C dance.
+The opt-in fallback is `PLAYWRIGHT_ISOLATED=1` (read by
+`.claude/scripts/playwright-launcher.mjs`), which adds `--isolated` and
+gives that session an ephemeral, logged-out profile. Use it when you
+specifically don't want login state — testing login flows, public-route
+verification, or a second Claude Code inside the same workspace.
+
+Verified 2026-05-13 against
+[playwright.dev/mcp/configuration/user-profile](https://playwright.dev/mcp/configuration/user-profile)
+("Each project gets a separate profile automatically based on the workspace")
+and [microsoft/playwright-mcp#1294](https://github.com/microsoft/playwright-mcp/issues/1294).
+
+**Storage-state seed (`~/.claude/mcp-storageState.json`) is now optional.**
+With the persistent default the workspace profile auto-saves login, so
+the ~3-week refresh cadence is dead. The seed file is still useful as a
+first-boot preload for brand-new workspaces, and for isolated sessions
+that need to start authenticated. Seed via `browser_run_code_unsafe`
+calling `page.context().storageState({ path })` — there is **no**
+separate `browser_storage_state` MCP tool (earlier drafts of this rule
+referenced one that does not exist; the functionality lives in the
+generic `browser_run_code_unsafe` tool).
 
 **Anti-patterns — do NOT propose any of these without re-reading this entry:**
 
-1. `--config <some.json>` with `userDataDir` set inside the JSON. **Silently
-   broken on `@playwright/mcp@0.0.70`** ([issue #1446](https://github.com/microsoft/playwright-mcp/issues/1446)):
+1. `--config <some.json>` with `userDataDir` set inside the JSON. Silently
+   broken on `@playwright/mcp@0.0.70`
+   ([issue #1446](https://github.com/microsoft/playwright-mcp/issues/1446)):
    the JSON `userDataDir` is ignored and the browser launches with an
    in-memory profile. CLI flags work; JSON does not. If you must use a JSON
    config for some reason, verify on the running version that `userDataDir`
    is honoured before relying on it.
-2. Persistent `--user-data-dir` for the primary playwright server.
-   Single-instance only — second concurrent session fails with the lock
-   error. Was tried in commits `b26d5e01` (apr 2) and `ce6a8ab5` (may 5).
-3. `--isolated` ALONE (no `--storage-state`) for the primary server. Each
-   session starts logged-out — defeats the whole point.
+2. Explicit `--user-data-dir <fixed-path>` shared across workspaces (i.e.
+   overriding the workspace-hash with a single path everyone shares).
+   Single-instance lock returns — a second workspace touching it fails
+   with `Browser is already in use`. This is the failure mode the
+   workspace-hash mechanism is designed to AVOID; do not re-introduce it
+   by hardcoding the path. The `{workspace-hash}` default is what makes
+   persistent + parallel coexist.
+3. `--isolated` as the DEFAULT (i.e. hardcoded in the launcher). Each
+   session starts logged-out, which forced a brittle storage-state seed
+   workflow with a ~3-week refresh cadence. This was the pre-2026-05-13
+   pattern; replaced because the persistent default is simpler and
+   doesn't break the read-only invariant of the storage-state seed when
+   the AI accidentally logs out.
 4. `--headless` on a server the AI uses to validate its own changes. The
    AI cannot SEE a headless browser; nothing to verify. Headed only.
-5. `--executable-path <Brave/Chrome>` for the primary browser. On Windows,
-   Brave/Chrome cannot run a second instance with a different profile —
-   the second instance becomes a background process with no visible window.
-   Use Playwright's bundled Chromium (omit `--executable-path` entirely).
+5. `--executable-path <Brave/Chrome>` to a different Chrome binary. On
+   Windows, Brave/Chrome cannot run a second instance with a different
+   profile — the second instance becomes a background process with no
+   visible window. Stick with Playwright's `--browser chrome` (system
+   Google Chrome install, workspace-hashed profile dir).
 6. Homegrown "slot pool" launchers that copy login files between profile
    directories at start/exit. Tempting because it sounds clever, but:
    - Not an industry standard pattern; no widely-validated implementation.
    - Race conditions on simultaneous shutdowns (last-write-wins on cookies).
    - SQLite cookie file copies during/after browser shutdown can corrupt.
-   - Only justified if the AI mutates auth state across sessions, which
-     this use case does not require.
-   Was attempted on 2026-05-05; reverted in favour of `--storage-state`.
-7. "Just remove all profile config and let Playwright pick its default" —
-   default IS persistent `--user-data-dir`, so this re-triggers
-   anti-pattern (2) from the other direction.
-8. `npx playwright codegen --save-storage=...` as the seed step on macOS.
+   - Made obsolete by workspace-hashed profiles — each Conductor workspace
+     already gets its own login store, no copying needed.
+   Was attempted on 2026-05-05; reverted.
+7. `npx playwright codegen --save-storage=...` as the seed step on macOS.
    The codegen process only writes the file on a specific Inspector-side
    close event; close the browser the wrong way and the file never
    appears. PR #354 (apr 2026) shipped this as the documented seed step
    and lost a full week of "but it should work" debugging before the
    2026-05-07 retry confirmed the failure mode. Use `browser_run_code_unsafe`
-   with `page.context().storageState({ path })` instead (see canonical
-   answer above).
+   with `page.context().storageState({ path })` instead.
+8. Clicking `Log out` in the persistent-profile browser. The launcher
+   provides login state in the workspace profile; logging out wipes that
+   state and forces a fresh hand-login on the next session. If you need
+   to verify a logout flow specifically, use `PLAYWRIGHT_ISOLATED=1`
+   (ephemeral profile) so the persistent workspace state is untouched.
+9. A second `playwright-isolated` MCP server entry in `.mcp.json`. Was
+   dropped on 2026-05-07 because the `mcp__playwright-isolated__*` tool
+   prefix was being mistakenly chosen by Claude over `mcp__playwright__*`,
+   giving logged-out browsers when login was expected. For one-off
+   unauthenticated checks: open a fresh tab in the existing Playwright
+   MCP browser with `browser_tabs(action: "new")`. For a fully-fresh
+   session, use `PLAYWRIGHT_ISOLATED=1` as the spawn-time env var, not a
+   second MCP entry.
 
-**The current working setup (do not change without strong cause):**
+**The current working setup:**
 
 - Primary `playwright` server in `.mcp.json` invokes
-  `.claude/scripts/playwright-launcher.mjs`, which spawns
-  `npx @playwright/mcp@latest --browser chrome --isolated
-  --storage-state ~/.claude/mcp-storageState.json`. Headed (no `--headless`).
-  Multi-session safe (each launch gets its own ephemeral profile).
-  All sessions preload the same login state. **Note**: on
-  `@playwright/mcp >= 0.0.74` the valid `--browser` values are
-  `chrome|firefox|webkit|msedge`. `chromium` was dropped — passing it
-  silently breaks the launcher. Use `chrome` (system Google Chrome
-  install; combined with `--isolated`, gets its own ephemeral profile
-  per session and does not collide with the user's regular Chrome).
-- No secondary MCP server. The earlier `playwright-isolated` (no
-  storage-state, for unauthenticated CSS work) was dropped on
-  2026-05-07 because the `mcp__playwright-isolated__*` tool prefix
-  was being mistakenly chosen by Claude over `mcp__playwright__*`,
-  giving logged-out browsers when login was expected. For one-off
-  unauthenticated checks: open a fresh tab in the existing Playwright
-  MCP browser with `browser_tabs(action: "new")` — the new tab does
-  share the storage-state, but for CSS-only work that doesn't matter.
-- Login seed/refresh (run when `~/.claude/mcp-storageState.json` is
-  missing, or when Google cookies have expired and sessions start
-  logged-out):
-  1. With the launcher in place but no storage-state file (or after
-     deleting it), restart Claude Code so the MCP server picks up the
-     new config. Open a new Playwright MCP session — the browser starts
-     logged-out.
-  2. Have the AI `browser_navigate` to a login URL (e.g.
-     `https://voys.getklai.com`).
-  3. Log in by hand (Google SSO + 2FA), wait until you're on the
-     post-login workspace.
-  4. Have the AI call `browser_run_code_unsafe` with this snippet (it
-     writes the current cookies + localStorage to disk):
-     ```js
-     async (page) => {
-       await page.context().storageState({
-         path: '/Users/<you>/.claude/mcp-storageState.json'
-       });
-       return { url: page.url(), cookieCount: (await page.context().cookies()).length };
-     }
-     ```
-     The tool returns immediately with the new cookie count. Verify the
-     file mtime/size with `ls -la ~/.claude/mcp-storageState.json`.
-  5. Restart Claude Code so the launcher picks the new file up via
-     `--storage-state` at startup.
-  6. From now on all MCP sessions, including parallel Claude Code
-     instances, start authenticated.
+  `.claude/scripts/playwright-launcher.mjs`, which spawns:
+  `npx @playwright/mcp@latest --browser chrome` (headed) and adds
+  `--storage-state ~/.claude/mcp-storageState.json` when the seed file
+  exists. With `PLAYWRIGHT_ISOLATED=1` set in the environment, the
+  launcher additionally passes `--isolated` for that one session.
+- No secondary MCP server. For unauthenticated work: `browser_tabs(new)`
+  in the existing browser, or `PLAYWRIGHT_ISOLATED=1` for a fresh session.
+- Login per workspace: open a Playwright session, navigate to a login
+  URL, log in by hand once. Subsequent sessions in that workspace start
+  authenticated automatically (Chrome persists the cookies in the
+  workspace's profile dir). No periodic refresh required.
+- `@playwright/mcp >= 0.0.74` valid `--browser` values are
+  `chrome|firefox|webkit|msedge` (`chromium` was dropped — passing it
+  silently breaks the launcher).
 
 **Prevention — symptom → correct response:**
 
 | Symptom | Correct response | Wrong response |
 |---|---|---|
-| Sessions start logged-out | Verify `~/.claude/mcp-storageState.json` exists and is recent. If missing/stale, re-seed by running `browser_run_code_unsafe` with `page.context().storageState({ path })` after a fresh login (see "Login seed/refresh" above). | Add `--user-data-dir` back (anti-pattern 2); fall back to `playwright codegen --save-storage` (anti-pattern 8); search for a non-existent `browser_storage_state` tool. |
-| `Browser is already in use` on a second session | Confirm `.mcp.json` uses `--isolated` not `--user-data-dir`. Each session must get its own ephemeral profile. | Add a slot-pool launcher (anti-pattern 6) |
-| AI cannot see what the browser is doing | Confirm no `--headless` flag in the primary server. | Tell the user to "just check the browser themselves" — defeats the point |
-| User says "iedere keer hetzelfde probleem" | Stop. Re-read this entry. Do not propose a config change before identifying which anti-pattern you are about to commit. | Propose another config edit |
-| `browser_run_code_unsafe` tool not visible in current session | Tool-schema-cache is from an older `@playwright/mcp` pin (pre `0.0.74` exposed `browser_run_code` instead). Restart Claude Code so it reloads the schema list from `@latest`. | Try `browser_evaluate` to read cookies (HttpOnly cookies are invisible) or write a homegrown seed script (anti-pattern 6 territory). |
-| `--browser chromium` rejected on launch | `@playwright/mcp >= 0.0.74` dropped `chromium` as a valid value. Use `--browser chrome`. | Pin back to `@0.0.70` (loses `browser_run_code_unsafe` — anti-pattern 8 territory). |
-| Storage state file is hand-edited / non-standard | Delete it, re-seed via `browser_run_code_unsafe` after a fresh login. | Hand-edit JSON in storageState |
+| Sessions in a new workspace start logged-out | Log in by hand once in the persistent browser; the workspace profile keeps it. Optionally seed `~/.claude/mcp-storageState.json` so future new workspaces start authenticated. | Hardcode `--isolated` back as default (anti-pattern 3); fall back to `playwright codegen --save-storage` (anti-pattern 7). |
+| Sessions in an EXISTING workspace start logged-out | The workspace profile got wiped (AI clicked Log out, or someone `rm -rf`'d the cache dir). Log in again by hand. If this keeps happening, find what's clicking Log out (anti-pattern 8). | Add `--user-data-dir` to a shared path (anti-pattern 2). |
+| `Browser is already in use` on a second session | Two MCP clients inside the SAME workspace. Set `PLAYWRIGHT_ISOLATED=1` on the second. Across-workspace concurrency is fine — they hash to different profile dirs. | Hardcode `--user-data-dir` to a shared path (anti-pattern 2); add a slot-pool launcher (anti-pattern 6). |
+| AI cannot see what the browser is doing | Confirm no `--headless` flag in the launcher (anti-pattern 4). | Tell the user to "just check the browser themselves" — defeats the point. |
+| User says "iedere keer hetzelfde probleem" | Stop. Re-read this entry. Do not propose a config change before identifying which anti-pattern you are about to commit. | Propose another config edit. |
+| `browser_run_code_unsafe` tool not visible | Tool-schema-cache is from an older `@playwright/mcp` pin (pre `0.0.74` exposed `browser_run_code` instead). Restart Claude Code so it reloads the schema list from `@latest`. | Try `browser_evaluate` to read cookies (HttpOnly cookies are invisible) or write a homegrown seed script (anti-pattern 6 territory). |
+| `--browser chromium` rejected on launch | `@playwright/mcp >= 0.0.74` dropped `chromium` as a valid value. Use `--browser chrome`. | Pin back to `@0.0.70` (loses `browser_run_code_unsafe`). |
+| Need to test the login flow itself | Set `PLAYWRIGHT_ISOLATED=1` for that session — ephemeral profile, starts logged-out. Workspace profile is untouched. | Click Log out in the persistent browser (anti-pattern 8). |
+| Storage state file is hand-edited / non-standard | Delete it; with persistent profile you don't need it. Optionally re-seed via `browser_run_code_unsafe` after a fresh login. | Hand-edit JSON in storageState. |
 
-If a future @playwright/mcp version introduces auto-write-back of storage
-state on session close, the manual refresh step can be removed. Until
-then, refreshing the storage-state file every few weeks is the cost of
-this design — accept it.
+**History:** between April and May 2026 we cycled through `--user-data-dir`,
+`--isolated`, `--isolated + storage-state`, codegen-seeded storage state,
+and a slot-pool launcher. Each had a failure mode the next "fix"
+reintroduced. The 2026-05-13 confirmation of Microsoft's
+workspace-hashed persistent profiles ended the cycle: persistent works
+across parallel workspaces natively, login state lives where Chrome
+expects it, and the storage-state seed is demoted from "mandatory
+ritual" to "optional first-boot convenience". If a future
+`@playwright/mcp` release changes the workspace-hash behaviour or the
+default profile path, re-verify the parallel-safety claim before
+trusting this entry.
 
 ## stale-decommission-attracts-defensive-fixes (HIGH)
 Wanneer een service is gedecommissioned maar de source-directory in de

--- a/.claude/scripts/playwright-launcher.mjs
+++ b/.claude/scripts/playwright-launcher.mjs
@@ -2,66 +2,74 @@
 /**
  * Cross-platform Playwright MCP launcher.
  *
- * Pattern: `--isolated --storage-state ~/.claude/mcp-storageState.json`.
- * Each Claude Code session gets its own ephemeral Chrome profile that is
- * preloaded with login cookies + localStorage from the storage-state JSON.
- * Multiple parallel Claude Code sessions are safe (no profile lock) and
- * all start authenticated.
+ * Default pattern: persistent profile, parallel-safe via workspace-hash.
+ * Fallback: `--isolated` (ephemeral profile, logged-out) when the env
+ * var `PLAYWRIGHT_ISOLATED=1` is set.
  *
- * Why this pattern (May 2026, post-research):
- *   - Microsoft has no officially-supported "parallel + shared login"
- *     CLI option besides this. Issue #1530 (named session management)
- *     was closed as "not planned".
- *   - The browser extension is the alternative Microsoft pushes; we
- *     reject it because it grants the AI full access to every other
- *     site the user is logged in to in their daily Chrome.
- *   - PR #346's `--user-data-dir` is single-instance, so it cannot
- *     serve parallel sessions.
- *   - The April 2026 attempt at this pattern (PR #354) failed because
- *     the seed step relied on `npx playwright codegen --save-storage`,
- *     which is flaky on macOS.
+ * Why default is persistent (verified 2026-05-13 against Microsoft docs):
+ *   @playwright/mcp@latest stores its persistent profile at
+ *   `~/Library/Caches/ms-playwright/mcp-{channel}-{workspace-hash}` on
+ *   macOS (analogous paths on Linux/Windows). The `{workspace-hash}` is
+ *   derived from the MCP client's workspace root, so every distinct
+ *   workspace gets its own profile directory automatically.
  *
- * The seed step (verified 2026-05-07):
- *   `@playwright/mcp >= 0.0.74` exposes `browser_run_code_unsafe`,
- *   which executes a Playwright snippet server-side with a `page`
- *   handle. Calling `page.context().storageState({ path })` from
- *   inside such a snippet writes the current cookies + localStorage
- *   to the storage-state file directly. No external codegen, no
- *   Inspector window, no Ctrl+C dance.
+ *   In our setup (Conductor + a canonical clone) each parallel session
+ *   runs from a different workspace root, so each picks a different
+ *   hash, so each opens a different profile. No lock conflict. Login
+ *   state persists between Claude Code restarts within that workspace.
  *
- *   1. With this launcher in place but no storage-state file yet,
- *      open a Playwright MCP session — the browser starts logged out.
- *   2. `browser_navigate` to a login URL, log in by hand.
- *   3. Have the AI call `browser_run_code_unsafe` with this snippet:
- *        async (page) => {
- *          await page.context().storageState({
- *            path: '/Users/<you>/.claude/mcp-storageState.json',
- *          });
- *          return { url: page.url(),
- *                   cookies: (await page.context().cookies()).length };
- *        }
- *      The tool returns immediately with the new cookie count.
- *   4. Restart Claude Code (so the launcher picks the file up at
- *      startup via the `--storage-state` flag).
- *   5. Refresh the same way every ~3 weeks when Google's session
- *      cookies expire.
+ *   The one situation where the default would still conflict is two
+ *   Claude Code instances inside the SAME workspace touching the
+ *   Playwright MCP simultaneously. We don't do that. If you ever
+ *   need it, set PLAYWRIGHT_ISOLATED=1 on the second instance.
  *
- *   NOTE: there is no separate `browser_storage_state` MCP tool. An
- *   earlier draft of this launcher and its docs claimed there was;
- *   that was a hallucination. The functionality lives in the generic
- *   `browser_run_code_unsafe` tool, as shown above.
+ * When to use the isolated fallback (PLAYWRIGHT_ISOLATED=1):
+ *   - You explicitly want a fresh, logged-out browser (testing the
+ *     login flow itself, verifying unauthenticated routes, etc).
+ *   - Two Claude Code instances inside the same workspace.
+ *   - Disposable verification where you don't want to pollute the
+ *     workspace's persistent profile.
+ *
+ * Storage-state file (`~/.claude/mcp-storageState.json`):
+ *   When present, the launcher passes `--storage-state` so a fresh
+ *   profile (or an isolated session) is preloaded with cookies +
+ *   localStorage from the seed file. With the persistent default this
+ *   is now mostly redundant — the profile auto-saves login on first
+ *   use — but it's harmless and useful as a first-boot preload for
+ *   brand-new workspaces.
+ *
+ *   To (re)seed: open a Playwright MCP session, browser_navigate to a
+ *   login URL, log in by hand, then call `browser_run_code_unsafe`:
+ *     async (page) => {
+ *       await page.context().storageState({
+ *         path: '/Users/<you>/.claude/mcp-storageState.json',
+ *       });
+ *       return { url: page.url(),
+ *                cookies: (await page.context().cookies()).length };
+ *     }
+ *
+ *   NOTE: there is no separate `browser_storage_state` MCP tool. The
+ *   functionality lives in the generic `browser_run_code_unsafe` tool.
  *
  * Why CLI flags instead of a JSON config file:
  *   microsoft/playwright-mcp#1446 — `userDataDir` set in a JSON
- *   --config file is silently ignored on @playwright/mcp@0.0.70.
- *   CLI flag works correctly.
+ *   `--config` file is silently ignored on `@playwright/mcp@0.0.70`.
+ *   CLI flags work correctly.
  *
  * Why `--browser chrome`:
- *   On @>=0.0.74 the valid `--browser` values are
- *   chrome|firefox|webkit|msedge. `chromium` was dropped. `chrome`
- *   uses the system Google Chrome installation but, combined with
- *   `--isolated`, gets its own ephemeral profile per session — no
- *   collision with the user's regular Chrome browser.
+ *   On `@playwright/mcp >= 0.0.74` the valid `--browser` values are
+ *   chrome|firefox|webkit|msedge (chromium was dropped). `chrome` uses
+ *   the system Google Chrome install; the workspace-hashed profile
+ *   path means it does NOT collide with the user's regular Chrome
+ *   browsing profile.
+ *
+ * History note: earlier versions of this launcher hardcoded `--isolated`
+ * because Microsoft's docs didn't surface workspace-hashing clearly.
+ * Once the workspace-hash mechanism was confirmed (2026-05-13, see
+ * playwright.dev/mcp/configuration/user-profile + issue #1294), the
+ * default flipped to persistent. The `--user-data-dir` single-instance
+ * lock pitfall is mitigated by the hash; it only re-emerges if you
+ * override with an explicit `--user-data-dir` argument.
  */
 import { spawn } from 'child_process';
 import { homedir, platform } from 'os';
@@ -71,22 +79,31 @@ import { existsSync } from 'fs';
 const isWin = platform() === 'win32';
 const STATE_FILE = join(homedir(), '.claude', 'mcp-storageState.json');
 
+// Default: persistent profile (login state survives between sessions).
+// Opt-in `--isolated` via PLAYWRIGHT_ISOLATED=1 for the explicit
+// "I want a fresh, logged-out browser" case (testing the login flow,
+// incognito-style verification, etc).
+const isolated = process.env.PLAYWRIGHT_ISOLATED === '1';
+
 const args = [
   '--yes',
   '@playwright/mcp@latest',
   '--browser', 'chrome',
-  '--isolated',
 ];
+
+if (isolated) {
+  args.push('--isolated');
+}
 
 if (existsSync(STATE_FILE)) {
   args.push('--storage-state', STATE_FILE);
-} else {
+} else if (isolated) {
   process.stderr.write(
-    `playwright-launcher: ${STATE_FILE} not found.\n` +
-    `Browser starts logged-out. To seed the file from inside a running\n` +
-    `MCP session: open a login URL via browser_navigate, log in by hand,\n` +
-    `then have the AI call browser_run_code_unsafe with a snippet that\n` +
-    `runs page.context().storageState({path: STATE_FILE}). Restart\n` +
+    `playwright-launcher: ${STATE_FILE} not found and PLAYWRIGHT_ISOLATED=1.\n` +
+    `Isolated browser starts logged-out. To seed the file from inside a\n` +
+    `running MCP session: open a login URL via browser_navigate, log in by\n` +
+    `hand, then have the AI call browser_run_code_unsafe with a snippet\n` +
+    `that runs page.context().storageState({path: STATE_FILE}). Restart\n` +
     `Claude Code afterwards so the launcher picks up the file.\n`
   );
 }

--- a/docs/setup/mcp-servers.md
+++ b/docs/setup/mcp-servers.md
@@ -90,51 +90,103 @@ It is **cross-platform** — all platform-specific settings live in local config
 |--------|---------|
 | **serena** | Semantic code navigation (symbol search, references, go-to-definition) and persistent project memories. Uses LSP for Python and TypeScript. |
 | **context7** | Up-to-date library documentation (React, FastAPI, Next.js, etc.). Prefer over web search for API docs. |
-| **playwright** | Browser automation for E2E spot-checks and visual verification. Headed Chrome with shared login state via `--storage-state` — every Claude Code session preloads the same auth, runs in its own ephemeral profile, parallel-safe. Single MCP server (no separate `-isolated` variant — see Section 3 for why). |
+| **playwright** | Browser automation for E2E spot-checks and visual verification. Headed Chrome with a per-workspace **persistent profile** (login state survives Claude Code restarts). Parallel-safe across workspaces via `{workspace-hash}` profile naming. Set `PLAYWRIGHT_ISOLATED=1` to opt into an ephemeral, logged-out profile. See Section 3. |
 | **codeindex** | Graph-powered code intelligence — call graphs, impact analysis, semantic search, communities, and enrichment queries (git hotspots, SPEC links, test coverage, PageRank). |
 | **grafana** | Read-only access to Grafana dashboards, Prometheus/VictoriaMetrics queries, and alerts. Cannot query VictoriaLogs — use the `victorialogs` MCP for log queries instead. |
 | **victorialogs** | Production log queries via LogsQL against VictoriaLogs. Requires SSH tunnel (`./scripts/victorialogs-tunnel.sh`) and `VICTORIALOGS_BASIC_AUTH_B64` env var. Preferred over `docker logs` for investigating issues. |
 
 ## 3. Set up Playwright
 
-No per-machine setup beyond a one-time login. The `playwright` server in `.mcp.json`
-invokes `.claude/scripts/playwright-launcher.mjs` (committed, cross-platform). The launcher
-spawns `@playwright/mcp@latest` with `--browser chrome --isolated --storage-state
-~/.claude/mcp-storageState.json`. Parallel-safe (every session gets its own ephemeral
-profile) and all sessions start authenticated by preloading the same storage-state file.
+No per-machine setup beyond a one-time login per workspace. The `playwright`
+server in `.mcp.json` invokes `.claude/scripts/playwright-launcher.mjs`
+(committed, cross-platform). The launcher spawns `@playwright/mcp@latest`
+with `--browser chrome`. By default it uses Playwright MCP's persistent
+profile, which is `{workspace-hash}`-keyed and therefore parallel-safe
+across distinct workspaces.
 
 ### Use case this is built for
 
-AI-driven coding sessions where the assistant validates its own changes end-to-end via
-Playwright MCP. You log in once; the AI takes over from there. Multiple coding sessions
-can run in parallel — each gets a visible browser window with the same login already
-loaded.
+AI-driven coding sessions where the assistant validates its own changes
+end-to-end via Playwright MCP. You log in once per workspace; the AI takes
+over from there. Multiple Conductor workspaces can run Playwright in
+parallel — each gets its own persistent Chrome profile (different
+workspace root → different profile dir → no lock).
 
-### Why `--isolated` + `--storage-state` (and not `--user-data-dir`)
+### How parallel + persistent coexist
 
-A persistent `--user-data-dir` is single-instance-locked: a second concurrent
-Claude Code session that needs the same profile fails with `Browser is already
-in use`. The `--isolated --storage-state` pattern dodges that lock — every
-session gets its own ephemeral profile, all preloaded with the same login
-state at startup. This is Microsoft's recommended path for parallel + login
-without the browser extension (Issue #1530, the alternative "named session
-management" feature, was closed by Microsoft as `not planned`).
+`@playwright/mcp@latest` stores its persistent profile at:
 
-Storage state is read-only at startup. The AI does not log out, change
-passwords, or otherwise mutate auth, so read-only is fine. Refresh the file
-when Google's session cookies expire (~3 weeks, see seed flow below).
+- **macOS:** `~/Library/Caches/ms-playwright/mcp-{channel}-{workspace-hash}`
+- **Linux:** `~/.cache/ms-playwright/mcp-{channel}-{workspace-hash}`
+- **Windows:** `%LOCALAPPDATA%\ms-playwright\mcp-{channel}-{workspace-hash}`
 
-The reason this pattern looked broken for weeks in April 2026: PR #354 used
-`npx playwright codegen --save-storage` as the seed step. On macOS that save
-only fires on a specific Inspector-side close event; if you closed the
-browser the wrong way, the file never appeared. Solved 2026-05-07 by
-switching the seed to a server-side Playwright snippet via the
-`browser_run_code_unsafe` MCP tool: `await page.context().storageState({
-path })` writes cookies + localStorage directly from the running MCP
-server's BrowserContext — no external codegen, no Inspector window, no
-Ctrl+C dance. Note: an earlier draft of these docs referenced a
-non-existent `browser_storage_state` tool. The functionality always lived
-in `browser_run_code_unsafe`; only the wording was off.
+The `{workspace-hash}` is derived from the MCP client's workspace root.
+Different Conductor workspaces (`/Users/<you>/conductor/workspaces/Klai/lyon`,
+`.../moscow`, `.../nairobi`, …) all hash to different directories, so each
+runs its own Chrome instance against its own profile. No conflict.
+
+**The only collision case:** two Claude Code instances inside the **same**
+workspace touching Playwright simultaneously. That's what
+`PLAYWRIGHT_ISOLATED=1` is for — set it on the second instance and it gets
+an ephemeral profile instead.
+
+(Verified 2026-05-13 against Microsoft's
+[Profile & State docs](https://playwright.dev/mcp/configuration/user-profile)
+and [issue #1294](https://github.com/microsoft/playwright-mcp/issues/1294).)
+
+### When to use `PLAYWRIGHT_ISOLATED=1`
+
+Opt-in fallback for when persistent + logged-in is **wrong**:
+
+- Testing the login flow itself (Google SSO, password reset, MFA setup).
+- Verifying unauthenticated routes / public marketing pages.
+- Disposable runs where you don't want to mutate the workspace profile.
+- A second Claude Code instance inside the same workspace.
+
+Set the env var in your shell or `.mcp.json` env block for the session
+that needs it. The launcher reads `process.env.PLAYWRIGHT_ISOLATED` at
+spawn time.
+
+### Storage-state seed (optional first-boot preload)
+
+The launcher also passes `--storage-state ~/.claude/mcp-storageState.json`
+when that file exists. With the persistent default this is mostly
+**redundant** — the profile auto-saves login on first hand-login and keeps
+it forever. The seed file is still useful for:
+
+- Bootstrapping a brand-new workspace with cookies you already have.
+- Isolated sessions (`PLAYWRIGHT_ISOLATED=1`) that need to start
+  authenticated.
+
+To (re)seed once, ask Claude something like *"navigate naar
+voys.getklai.com en seed de storage-state na mijn login"*. Claude opens
+the login page, you log in by hand, then Claude calls `browser_run_code_unsafe`:
+
+```js
+async (page) => {
+  await page.context().storageState({
+    path: '/Users/<you>/.claude/mcp-storageState.json'
+  });
+  const cookies = await page.context().cookies();
+  return {
+    url: page.url(),
+    cookieCount: cookies.length,
+    klaiCookies: cookies.filter(c => c.domain.includes('getklai')).length,
+  };
+}
+```
+
+Sanity-check the return: `klaiCookies` should be ≥ 6 (PARAGLIDE_LOCALE × 2,
+zitadel.useragent, klai_sso, __Secure-klai_session, __Secure-klai_csrf).
+
+**Note:** there is no separate `browser_storage_state` MCP tool — that was
+a hallucination in an earlier doc draft. The functionality lives in the
+generic `browser_run_code_unsafe` tool.
+
+You do **not** need to refresh the seed file every ~3 weeks anymore. That
+refresh cadence was a workaround for the old `--isolated` pattern where
+the ephemeral profile dropped cookies every session. The persistent
+profile keeps Google's session alive on its own.
 
 ### Why a launcher script and not a JSON `--config` file
 
@@ -143,64 +195,61 @@ on `@playwright/mcp@0.0.70`, profile-related options set inside a JSON `--config
 can be silently ignored. CLI flags work correctly. The launcher is the cross-platform
 vehicle for those flags.
 
-### One-time login (and refresh)
+### One-time login (per workspace)
 
-1. With the launcher in place but no storage-state file yet (or after deleting
-   it for a refresh), restart Claude Code so the MCP server picks up the new
-   config. Open a new Playwright MCP session — the browser starts logged-out.
-2. Ask Claude: **"navigate naar voys.getklai.com en seed de storage-state na
-   mijn login"**. Claude calls `browser_navigate` to open the login URL.
-3. Log in by hand in the browser-window (Google SSO + 2FA). Wait until you're
-   on `https://voys.getklai.com/app` (or `my.getklai.com` workspace).
-4. Tell Claude **"klaar"** (or "done"). Claude calls `browser_run_code_unsafe`
-   with this snippet:
-   ```js
-   async (page) => {
-     await page.context().storageState({
-       path: '/Users/<you>/.claude/mcp-storageState.json'
-     });
-     const cookies = await page.context().cookies();
-     return {
-       url: page.url(),
-       cookieCount: cookies.length,
-       klaiCookies: cookies.filter(c => c.domain.includes('getklai')).length,
-     };
-   }
-   ```
-   The tool returns immediately with the new cookie count. Sanity-check:
-   `klaiCookies` should be ≥ 6 (PARAGLIDE_LOCALE × 2, zitadel.useragent,
-   klai_sso, __Secure-klai_session, __Secure-klai_csrf).
-5. Restart Claude Code so the launcher picks the file up via `--storage-state`
-   on the next MCP-server spawn.
-6. From now on all MCP sessions, including parallel Claude Code instances,
-   start authenticated.
+1. Start Claude Code in the workspace. The Playwright MCP server boots
+   with a fresh persistent profile (no login yet).
+2. Ask Claude to `browser_navigate` to a login URL (e.g.
+   `https://voys.getklai.com`).
+3. Log in by hand in the headed Chrome window (Google SSO + 2FA).
+4. Done — the workspace profile now holds your login. Close the browser
+   when you're finished; the cookies persist for the next session.
 
-Refresh the same way every ~3 weeks when Google's session cookies expire (you
-notice because new sessions start logged-out again).
-
-For the full failure-mode history and anti-patterns to avoid, see
-`playwright-mcp-config-cycle (HIGH)` in
-`.claude/rules/klai/pitfalls/process-rules.md` (8 anti-patterns accumulated
-across many "fixes" since April 2026 — this section is the verified
-2026-05-07 canonical, anchored on Microsoft Issue #1530's outcome).
+Optionally (and only once on this machine, if you want isolated sessions
+to also start authenticated), have Claude write the storage-state file
+via `browser_run_code_unsafe` as shown above.
 
 ### Starting from scratch (logged-out state)
 
-Delete the storage-state file, restart Claude Code, then re-run the seed
-flow above (steps 2–5):
+To force a workspace back to logged-out, delete its profile directory:
+
+```bash
+# macOS — workspace-hash is opaque; clear the lot if you're not sure which:
+rm -rf ~/Library/Caches/ms-playwright/mcp-chrome-*
+```
 
 ```powershell
 # Windows (PowerShell)
-Remove-Item -Force "$env:USERPROFILE\.claude\mcp-storageState.json"
+Remove-Item -Recurse -Force "$env:LOCALAPPDATA\ms-playwright\mcp-chrome-*"
 ```
+
+```bash
+# Linux
+rm -rf ~/.cache/ms-playwright/mcp-chrome-*
+```
+
+If you also want to drop the storage-state seed:
 
 ```bash
 # macOS / Linux
 rm -f ~/.claude/mcp-storageState.json
 ```
 
-For session management rules (when to open/close the browser), see
+```powershell
+# Windows (PowerShell)
+Remove-Item -Force "$env:USERPROFILE\.claude\mcp-storageState.json"
+```
+
+Restart Claude Code afterwards so the launcher spawns a fresh MCP server.
+
+For session management rules (when to open/close the browser, don't click
+Log out in a persistent profile, etc.), see
 `.claude/rules/klai/lang/testing.md`.
+
+For the full failure-mode history, see `playwright-mcp-config-cycle` in
+`.claude/rules/klai/pitfalls/process-rules.md` — anchored on the
+2026-05-13 confirmation that `{workspace-hash}` makes persistent profiles
+parallel-safe.
 
 ## 4. Disable Serena web dashboard
 
@@ -400,10 +449,10 @@ uvx mcp-grafana --help
 3. **MCP timeout** — Serena takes too long to index. Check `.serena/project.yml` for overly broad
    file patterns.
 4. **Playwright launcher fails to start** — `node` not on PATH or the launcher script missing. Fix: verify `node --version` works in your shell and `.claude/scripts/playwright-launcher.mjs` exists. Restart Claude Code.
-5. **Playwright sessions start logged-out** — `~/.claude/mcp-storageState.json` is missing or its cookies have expired. Fix: re-run the seed flow in Section 3 (one-time login + `browser_run_code_unsafe` snippet), then restart Claude Code.
-6. **Playwright fails with `Browser is already in use`** — should not happen with `--isolated`. If it does, confirm `.mcp.json` still uses `--isolated --storage-state` and not a `--user-data-dir` flag. A leftover Chromium process can be killed with `taskkill /F /IM chrome.exe` (Windows) or `pkill -f playwright` (Mac/Linux).
-7. **Playwright window opens but immediately closes** — storage-state file is corrupt or in a non-Playwright format. Fix: `rm ~/.claude/mcp-storageState.json` and re-run the seed flow in Section 3.
-8. **Login state visible in one site but missing in another** — the seed only captured cookies from the sites you actually visited before triggering `browser_run_code_unsafe`. Fix: re-seed and visit + log in to every site you need (Google, voys, my.getklai.com, etc.) BEFORE asking Claude to write the storage-state file.
+5. **Playwright sessions start logged-out in a workspace** — the workspace's persistent profile was never logged in (new workspace, or you deleted the profile dir). Fix: `browser_navigate` to a login URL and log in by hand once; the profile remembers it. Optional: seed the shared `~/.claude/mcp-storageState.json` via the snippet in Section 3 so future new workspaces start authenticated.
+6. **Playwright fails with `Browser is already in use`** — two MCP clients inside the same workspace are trying to open the same persistent profile. Fix: set `PLAYWRIGHT_ISOLATED=1` on the second instance (ephemeral profile, no lock). A leftover Chromium process from a previous crash can be killed with `taskkill /F /IM chrome.exe` (Windows) or `pkill -f playwright` (Mac/Linux).
+7. **Playwright window opens but immediately closes** — corrupt profile directory or corrupt storage-state file. Fix: nuke the workspace's profile (`rm -rf ~/Library/Caches/ms-playwright/mcp-chrome-*` on macOS — see Section 3 "Starting from scratch") and, if used, the storage-state file. Restart Claude Code.
+8. **Login state visible in one site but missing in another** — only applies to the storage-state seed: it captured cookies from the sites you visited before calling `browser_run_code_unsafe`. With the persistent default this is rarely the right diagnosis; just log into the missing site once and the workspace profile keeps it. If you DO maintain a storage-state seed, re-seed after visiting + logging into every site you need.
 9. **CodeIndex not found** — `codeindex` command not available. Fix: `npm install -g klai-private/tools/codeindex-1.3.56.tgz`
 10. **CodeIndex stale index** — Index behind HEAD. Symptoms: impact analysis misses recent code. Fix: `codeindex update && node scripts/codeindex-enrich.mjs`
 11. **VictoriaLogs tunnel not running** — MCP queries fail silently or timeout. Fix: `./scripts/victorialogs-tunnel.sh` then restart Claude Code.


### PR DESCRIPTION
## Summary

Document the actual mechanism that makes parallel Playwright MCP sessions + persistent login coexist: Microsoft's `@playwright/mcp@latest` workspace-hashes its persistent profile directory, so each Conductor workspace automatically gets its own Chrome profile.

The launcher's default flips from `--isolated --storage-state` (ephemeral profile, cookies dropped every session) to **no flags** (persistent workspace-hashed profile, login state survives Claude Code restarts). `PLAYWRIGHT_ISOLATED=1` becomes the opt-in fallback for the explicit "I want a fresh, logged-out browser" case.

Verified 2026-05-13 against [Profile & State docs](https://playwright.dev/mcp/configuration/user-profile) ("Each project gets a separate profile automatically based on the workspace") and [microsoft/playwright-mcp#1294](https://github.com/microsoft/playwright-mcp/issues/1294).

## Files changed
- `.claude/scripts/playwright-launcher.mjs` — drop hardcoded `--isolated`, add `PLAYWRIGHT_ISOLATED=1` opt-in, rewrite docblock
- `docs/setup/mcp-servers.md` Section 3 — rewrite around persistent default + escape hatch
- `.claude/rules/klai/pitfalls/process-rules.md` — `playwright-mcp-config-cycle` updated anti-patterns and canonical setup; the ~3-week storage-state refresh cadence is retired
- `.claude/rules/klai/lang/testing.md` — replace Brave/`mcp-brave-profile` prose, add HARD rule against clicking Log out in persistent profile
- `.claude/rules/klai/lang/agent-browser.md` — correct stale "zelfde cadans als Playwright" comparison

## Test plan
- [x] `node --check` on the launcher confirms syntax valid
- [ ] After merge + Claude Code restart: new MCP session opens with a persistent workspace profile (verify `~/Library/Caches/ms-playwright/mcp-chrome-*` shows a workspace-hashed dir)
- [ ] Spawning a second Claude Code session in a DIFFERENT Conductor workspace works in parallel without the `Browser is already in use` lock
- [ ] `PLAYWRIGHT_ISOLATED=1 claude` opens a logged-out ephemeral browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)