### PR TITLE
refactor(portal): split KB members route

### DIFF
--- a/.moai/specs/SPEC-PORTAL-KB-MEMBERS-CLEANUP-001/progress.md
+++ b/.moai/specs/SPEC-PORTAL-KB-MEMBERS-CLEANUP-001/progress.md
@@ -1,0 +1,32 @@
+## SPEC-PORTAL-KB-MEMBERS-CLEANUP-001 Progress
+
+- Started: 2026-05-13T12:14:49Z
+- Harness level: standard
+- Development mode: tdd
+- Scope: frontend-only refactor of `klai-portal/frontend/src/routes/app/knowledge/$kbSlug/members.tsx`
+
+## Implementation Notes
+
+- Reduced `members.tsx` from 497 lines in the SPEC baseline to 362 lines.
+- Extracted mutation contracts into `-members-hooks.ts`.
+- Extracted the repeated group/person invite combobox section into `_components/-InviteSection.tsx`.
+- Extracted shared group/user member row rendering into `_components/-MemberRow.tsx`.
+- Kept the route responsible for auth, route params, data queries, visibility derivation, ownership checks, and confirmation dialog state.
+- Preserved existing endpoint URLs, request bodies, query invalidation intent, role defaults, owner-only removal rules, and personal-KB/read-only behavior.
+
+## Verification
+
+- `npm ci`: passed; 0 vulnerabilities.
+- `npx vitest run 'src/routes/app/knowledge/\$kbSlug/__tests__/-members-hooks.test.tsx'`: passed, 1 file / 3 tests.
+- `npm run lint -- --quiet`: passed.
+- `npm run i18n:compile && npx tsc -b --force`: passed.
+- `npm run security:audit && npm run lint && npm run build`: passed. Existing TanStack route-tree warnings remain outside this SPEC's new files.
+- `cd klai-widget && npm ci && npm run build`: passed. `npm ci` reports 2 existing moderate audit findings in widget dependencies.
+- `python3 scripts/fix-mojibake-locales.py --check`: passed.
+- Full `npm test` was also attempted after the test file rename; it still fails on existing admin/user locale expectations unrelated to this SPEC (rendered EN labels vs tests expecting NL labels).
+- CodeIndex pre-change `impact({target: "members.tsx", direction: "upstream"})`: LOW risk; direct importer is `routeTree.gen.ts`.
+- CodeIndex post-change `detect_changes`: reported LOW risk / no affected processes, but its changed-symbol listing appears stale relative to `git status`.
+
+## Not Performed
+
+- Live Voys tenant smoke for KB membership management.

--- a/.moai/specs/SPEC-PORTAL-KB-MEMBERS-CLEANUP-001/spec.md
+++ b/.moai/specs/SPEC-PORTAL-KB-MEMBERS-CLEANUP-001/spec.md
@@ -1,7 +1,8 @@
 ---
 id: SPEC-PORTAL-KB-MEMBERS-CLEANUP-001
 version: 0.1.0
-status: draft
+status: done
+completed: 2026-05-13
 created: 2026-05-13
 author: Mark Vletter
 priority: medium
@@ -20,9 +21,31 @@ from 497 lines to a route shell + per-row component + extracted
 mutation hooks. **Densest mutation-per-line ratio of any candidate**
 (10 mutations in 497 lines = 1 mutation per ~50 lines).
 
-This SPEC is **draft**. Low churn (15 commits / 90 days) means it's
-not actively painful — but the structural density makes any future
-edit risky.
+This SPEC started as **draft**. Low churn (15 commits / 90 days) meant
+it was not actively painful, but the structural density made future
+membership edits risky enough to justify a narrow split.
+
+## Outcome
+
+Implemented 2026-05-13 after the requested `/moai run
+KB-MEMBERS-CLEANUP` pass. The route remains the TanStack shell and
+data-loading owner, while the mutation endpoints and repeated member
+UI are now feature-local helpers.
+
+Architecture decision:
+- Added `-members-hooks.ts` for the KB visibility, invite-user,
+  invite-group, remove-user, and remove-group mutation contracts.
+- Added `_components/-InviteSection.tsx` for the shared group/person
+  combobox section and `_components/-MemberRow.tsx` for group/user
+  member cards.
+- Kept the existing backend endpoints, query keys, visibility mapping,
+  owner-only controls, and remove confirmation behavior unchanged.
+- Characterized the mutation contracts with focused Vitest coverage in
+  `__tests__/members-hooks.test.tsx`.
+
+Result: `members.tsx` is reduced from 497 lines to 362 lines in this
+workspace baseline. Live Voys tenant smoke was not performed during
+this local run.
 
 ## Motivation metrics
 

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-members-hooks.ts
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-members-hooks.ts
@@ -1,0 +1,86 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { apiFetch } from '@/lib/apiFetch'
+import { kbQueryKeys } from '@/lib/kb-query-keys'
+import type { KnowledgeBase } from './-kb-types'
+
+export const kbMembersQueryKey = (kbSlug: string) => ['kb-members', kbSlug] as const
+
+interface UpdateKnowledgeBaseBody {
+  visibility?: string
+  default_org_role?: string
+}
+
+export function useKnowledgeBaseUpdate(kbSlug: string) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (body: UpdateKnowledgeBaseBody) =>
+      apiFetch<KnowledgeBase>(`/api/app/knowledge-bases/${kbSlug}`, {
+        method: 'PATCH',
+        body: JSON.stringify(body),
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: kbQueryKeys.knowledgeBase(kbSlug) })
+    },
+  })
+}
+
+export function useInviteUser(kbSlug: string, onInvited?: () => void) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ email, role }: { email: string; role: string }) => {
+      await apiFetch(`/api/app/knowledge-bases/${kbSlug}/members/users`, {
+        method: 'POST',
+        body: JSON.stringify({ email, role }),
+      })
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: kbMembersQueryKey(kbSlug) })
+      onInvited?.()
+    },
+  })
+}
+
+export function useInviteGroup(kbSlug: string, onInvited?: () => void) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ groupId, role }: { groupId: number; role: string }) => {
+      await apiFetch(`/api/app/knowledge-bases/${kbSlug}/members/groups`, {
+        method: 'POST',
+        body: JSON.stringify({ group_id: groupId, role }),
+      })
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: kbMembersQueryKey(kbSlug) })
+      onInvited?.()
+    },
+  })
+}
+
+export function useRemoveUser(kbSlug: string) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (id: number) => {
+      await apiFetch(`/api/app/knowledge-bases/${kbSlug}/members/users/${id}`, {
+        method: 'DELETE',
+      })
+    },
+    onSuccess: () => void queryClient.invalidateQueries({ queryKey: kbMembersQueryKey(kbSlug) }),
+  })
+}
+
+export function useRemoveGroup(kbSlug: string) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (id: number) => {
+      await apiFetch(`/api/app/knowledge-bases/${kbSlug}/members/groups/${id}`, {
+        method: 'DELETE',
+      })
+    },
+    onSuccess: () => void queryClient.invalidateQueries({ queryKey: kbMembersQueryKey(kbSlug) }),
+  })
+}

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/__tests__/-members-hooks.test.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/__tests__/-members-hooks.test.tsx
@@ -1,0 +1,81 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { type ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useInviteUser, useKnowledgeBaseUpdate, useRemoveGroup } from '../-members-hooks'
+
+vi.mock('@/lib/apiFetch', () => ({
+  apiFetch: vi.fn(),
+}))
+
+import { apiFetch } from '@/lib/apiFetch'
+
+const apiFetchMock = vi.mocked(apiFetch)
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )
+}
+
+describe('members mutation hooks', () => {
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+    apiFetchMock.mockResolvedValue({})
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('patches the knowledge base visibility settings', async () => {
+    const wrapper = makeWrapper()
+    const { result } = renderHook(() => useKnowledgeBaseUpdate('kb-a'), { wrapper })
+
+    result.current.mutate({ visibility: 'internal', default_org_role: 'viewer' })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/app/knowledge-bases/kb-a',
+      {
+        method: 'PATCH',
+        body: JSON.stringify({ visibility: 'internal', default_org_role: 'viewer' }),
+      },
+    )
+  })
+
+  it('invites a user and calls the success reset callback', async () => {
+    const wrapper = makeWrapper()
+    const onInvited = vi.fn()
+    const { result } = renderHook(() => useInviteUser('kb-a', onInvited), { wrapper })
+
+    result.current.mutate({ email: 'person@example.com', role: 'viewer' })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/app/knowledge-bases/kb-a/members/users',
+      {
+        method: 'POST',
+        body: JSON.stringify({ email: 'person@example.com', role: 'viewer' }),
+      },
+    )
+    expect(onInvited).toHaveBeenCalledTimes(1)
+  })
+
+  it('deletes a group member by membership id', async () => {
+    const wrapper = makeWrapper()
+    const { result } = renderHook(() => useRemoveGroup('kb-a'), { wrapper })
+
+    result.current.mutate(42)
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/app/knowledge-bases/kb-a/members/groups/42',
+      { method: 'DELETE' },
+    )
+  })
+})

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/-InviteSection.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/-InviteSection.tsx
@@ -1,0 +1,127 @@
+import { useRef, type ReactNode } from 'react'
+import { Search } from 'lucide-react'
+import { Input } from '@/components/ui/input'
+import * as m from '@/paraglide/messages'
+
+export interface OrgGroup {
+  id: number
+  name: string
+}
+
+export interface OrgUser {
+  zitadel_user_id: string
+  display_name: string
+  email: string
+}
+
+interface InviteSectionProps {
+  kind: 'groups' | 'users'
+  title: string
+  isOwner: boolean
+  search: string
+  onSearchChange: (value: string) => void
+  focused: boolean
+  onFocusedChange: (focused: boolean) => void
+  options: OrgGroup[] | OrgUser[]
+  error: unknown
+  onInviteGroup?: (groupId: number) => void
+  onInviteUser?: (email: string) => void
+  children: ReactNode
+  emptyReadOnlyMessage: string
+  isEmpty: boolean
+}
+
+export function InviteSection({
+  kind,
+  title,
+  isOwner,
+  search,
+  onSearchChange,
+  focused,
+  onFocusedChange,
+  options,
+  error,
+  onInviteGroup,
+  onInviteUser,
+  children,
+  emptyReadOnlyMessage,
+  isEmpty,
+}: InviteSectionProps) {
+  const rootRef = useRef<HTMLDivElement>(null)
+  const placeholder =
+    kind === 'groups'
+      ? m.knowledge_sharing_search_group()
+      : m.knowledge_sharing_search_person()
+  const errorMessage = formatError(error)
+
+  return (
+    <div className="space-y-2">
+      <h2 className="text-sm font-semibold text-gray-900">{title}</h2>
+      {isOwner && (
+        <div
+          className="relative"
+          ref={rootRef}
+          onFocusCapture={() => onFocusedChange(true)}
+          onBlurCapture={(e) => {
+            if (!rootRef.current?.contains(e.relatedTarget as Node)) {
+              onFocusedChange(false)
+            }
+          }}
+        >
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+          <Input
+            value={search}
+            onChange={(e) => onSearchChange(e.target.value)}
+            placeholder={placeholder}
+            className="pl-9"
+          />
+          {focused && options.length > 0 && (
+            <div className="absolute z-10 mt-1 w-full rounded-lg border border-gray-200 bg-[var(--color-card)] shadow-md max-h-40 overflow-y-auto">
+              {kind === 'groups'
+                ? (options as OrgGroup[]).map((group) => (
+                    <button
+                      key={group.id}
+                      type="button"
+                      onMouseDown={(e) => e.preventDefault()}
+                      onClick={() => onInviteGroup?.(group.id)}
+                      className="w-full px-3 py-2 text-left text-sm text-gray-900 hover:bg-gray-50 transition-colors"
+                    >
+                      {group.name}
+                    </button>
+                  ))
+                : (options as OrgUser[]).map((user) => (
+                    <button
+                      key={user.zitadel_user_id}
+                      type="button"
+                      onMouseDown={(e) => e.preventDefault()}
+                      onClick={() => onInviteUser?.(user.email)}
+                      className="w-full px-3 py-2 text-left text-sm hover:bg-gray-50 transition-colors"
+                    >
+                      <span className="text-gray-900">{user.display_name}</span>
+                      <span className="ml-2 text-xs text-gray-400">{user.email}</span>
+                    </button>
+                  ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {errorMessage && (
+        <p className="text-sm text-[var(--color-destructive)]">{errorMessage}</p>
+      )}
+
+      {children}
+
+      {isEmpty && !isOwner && (
+        <p className="text-sm text-gray-400">{emptyReadOnlyMessage}</p>
+      )}
+    </div>
+  )
+}
+
+function formatError(error: unknown): string | null {
+  if (!error) return null
+  if (error instanceof Error) return error.message
+  if (typeof error === 'string') return error
+  return m.knowledge_members_invite_error()
+}

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/-MemberRow.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/-MemberRow.tsx
@@ -1,0 +1,55 @@
+import { X } from 'lucide-react'
+import type { GroupMember, UserMember } from '../-kb-types'
+
+interface GroupMemberRowProps {
+  kind: 'group'
+  member: GroupMember
+  isOwner: boolean
+  onRemove: (id: number) => void
+}
+
+interface UserMemberRowProps {
+  kind: 'user'
+  member: UserMember
+  isOwner: boolean
+  myUserId?: string
+  onRemove: (id: number) => void
+}
+
+type MemberRowProps = GroupMemberRowProps | UserMemberRowProps
+
+export function MemberRow(props: MemberRowProps) {
+  const { isOwner, onRemove } = props
+  const canRemove =
+    props.kind === 'group' ||
+    (props.kind === 'user' && props.member.user_id !== props.myUserId)
+
+  return (
+    <div className="flex items-center justify-between rounded-lg border border-gray-200 bg-[var(--color-card)] px-3 py-2">
+      {props.kind === 'group' ? (
+        <span className="text-sm text-gray-900">{props.member.group_name}</span>
+      ) : (
+        <div>
+          <span className="text-sm text-gray-900">{props.member.display_name ?? props.member.email ?? props.member.user_id}</span>
+          {props.member.display_name && props.member.email && (
+            <span className="ml-2 text-xs text-gray-400">{props.member.email}</span>
+          )}
+        </div>
+      )}
+
+      <div className="flex items-center gap-2">
+        <span className="text-xs text-gray-400">{props.member.role}</span>
+        {isOwner && canRemove && (
+          <button
+            type="button"
+            onClick={() => onRemove(props.member.id)}
+            className="flex h-6 w-6 items-center justify-center text-gray-400 hover:text-[var(--color-destructive)] transition-colors"
+            aria-label="Remove member"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/members.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/members.tsx
@@ -1,9 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { useAuth } from '@/lib/auth'
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { useRef, useState } from 'react'
-import { Globe, Lock, Users, Search, X } from 'lucide-react'
-import { Input } from '@/components/ui/input'
+import { useQuery } from '@tanstack/react-query'
+import { useState, type ElementType } from 'react'
+import { Globe, Lock, Users } from 'lucide-react'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -14,22 +12,22 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
-import * as m from '@/paraglide/messages'
 import { RoleGuard } from '@/components/layout/RoleGuard'
 import { apiFetch } from '@/lib/apiFetch'
-import type { KnowledgeBase, MembersResponse } from './-kb-types'
+import { useAuth } from '@/lib/auth'
 import { kbQueryKeys } from '@/lib/kb-query-keys'
-
-interface OrgGroup {
-  id: number
-  name: string
-}
-
-interface OrgUser {
-  zitadel_user_id: string
-  display_name: string
-  email: string
-}
+import * as m from '@/paraglide/messages'
+import {
+  kbMembersQueryKey,
+  useInviteGroup,
+  useInviteUser,
+  useKnowledgeBaseUpdate,
+  useRemoveGroup,
+  useRemoveUser,
+} from './-members-hooks'
+import type { KnowledgeBase, MembersResponse } from './-kb-types'
+import { InviteSection, type OrgGroup, type OrgUser } from './_components/-InviteSection'
+import { MemberRow } from './_components/-MemberRow'
 
 export const Route = createFileRoute('/app/knowledge/$kbSlug/members')({
   component: () => (
@@ -50,17 +48,11 @@ function deriveVisibilityMode(kb: KnowledgeBase): VisibilityMode {
 function MembersTab() {
   const { kbSlug } = Route.useParams()
   const auth = useAuth()
-  const queryClient = useQueryClient()
 
-  // Combobox state
   const [groupSearch, setGroupSearch] = useState('')
   const [groupFocused, setGroupFocused] = useState(false)
   const [userSearch, setUserSearch] = useState('')
   const [userFocused, setUserFocused] = useState(false)
-  const groupRef = useRef<HTMLDivElement>(null)
-  const userRef = useRef<HTMLDivElement>(null)
-
-  // Remove confirmations
   const [confirmingRemoveUser, setConfirmingRemoveUser] = useState<number | null>(null)
   const [confirmingRemoveGroup, setConfirmingRemoveGroup] = useState<number | null>(null)
 
@@ -71,85 +63,33 @@ function MembersTab() {
   })
 
   const { data: members, isLoading } = useQuery<MembersResponse>({
-    queryKey: ['kb-members', kbSlug],
+    queryKey: kbMembersQueryKey(kbSlug),
     queryFn: async () => apiFetch<MembersResponse>(`/api/app/knowledge-bases/${kbSlug}/members`),
     enabled: auth.isAuthenticated,
   })
 
-  // Fetch org groups and users for comboboxes
-  const { data: groupsData } = useQuery({
+  const { data: groupsData } = useQuery<{ groups: OrgGroup[] }>({
     queryKey: ['app-groups'],
     queryFn: () => apiFetch<{ groups: OrgGroup[] }>('/api/app/groups'),
     enabled: auth.isAuthenticated && kb?.owner_type === 'org',
   })
 
-  const { data: usersData } = useQuery({
+  const { data: usersData } = useQuery<{ users: OrgUser[] }>({
     queryKey: ['app-users'],
     queryFn: () => apiFetch<{ users: OrgUser[] }>('/api/app/users'),
     enabled: auth.isAuthenticated && kb?.owner_type === 'org',
   })
 
+  const updateKbMutation = useKnowledgeBaseUpdate(kbSlug)
+  const inviteUserMutation = useInviteUser(kbSlug, () => setUserSearch(''))
+  const inviteGroupMutation = useInviteGroup(kbSlug, () => setGroupSearch(''))
+  const removeUserMutation = useRemoveUser(kbSlug)
+  const removeGroupMutation = useRemoveGroup(kbSlug)
+
   const myUserId = auth.user?.profile?.sub
   const isCreator = !!(myUserId && kb?.created_by === myUserId)
-  const isOwner = isCreator || !!(myUserId && members?.users.some((u) => u.user_id === myUserId && u.role === 'owner'))
+  const isOwner = isCreator || !!(myUserId && members?.users.some((user) => user.user_id === myUserId && user.role === 'owner'))
   const isPersonal = kb?.owner_type === 'user'
-
-  // Mutations
-  const updateKbMutation = useMutation({
-    mutationFn: async (body: { visibility?: string; default_org_role?: string }) => {
-      return apiFetch<KnowledgeBase>(`/api/app/knowledge-bases/${kbSlug}`, {
-        method: 'PATCH',
-        body: JSON.stringify(body),
-      })
-    },
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: kbQueryKeys.knowledgeBase(kbSlug) })
-    },
-  })
-
-  const inviteUserMutation = useMutation({
-    mutationFn: async ({ email, role }: { email: string; role: string }) => {
-      await apiFetch(`/api/app/knowledge-bases/${kbSlug}/members/users`, {
-        method: 'POST',
-        body: JSON.stringify({ email, role }),
-      })
-    },
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['kb-members', kbSlug] })
-      setUserSearch('')
-    },
-  })
-
-  const inviteGroupMutation = useMutation({
-    mutationFn: async ({ groupId, role }: { groupId: number; role: string }) => {
-      await apiFetch(`/api/app/knowledge-bases/${kbSlug}/members/groups`, {
-        method: 'POST',
-        body: JSON.stringify({ group_id: groupId, role }),
-      })
-    },
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['kb-members', kbSlug] })
-      setGroupSearch('')
-    },
-  })
-
-  const removeUserMutation = useMutation({
-    mutationFn: async (id: number) => {
-      await apiFetch(`/api/app/knowledge-bases/${kbSlug}/members/users/${id}`, {
-        method: 'DELETE',
-      })
-    },
-    onSuccess: () => void queryClient.invalidateQueries({ queryKey: ['kb-members', kbSlug] }),
-  })
-
-  const removeGroupMutation = useMutation({
-    mutationFn: async (id: number) => {
-      await apiFetch(`/api/app/knowledge-bases/${kbSlug}/members/groups/${id}`, {
-        method: 'DELETE',
-      })
-    },
-    onSuccess: () => void queryClient.invalidateQueries({ queryKey: ['kb-members', kbSlug] }),
-  })
 
   if (isPersonal) {
     return (
@@ -163,6 +103,19 @@ function MembersTab() {
 
   const visibilityMode = kb ? deriveVisibilityMode(kb) : 'restricted'
   const allowContribute = kb?.default_org_role === 'contributor'
+  const existingGroupIds = new Set(members?.groups.map((group) => group.group_id) ?? [])
+  const filteredGroups = (groupsData?.groups ?? []).filter(
+    (group) =>
+      !existingGroupIds.has(group.id) &&
+      group.name.toLowerCase().includes(groupSearch.toLowerCase()),
+  )
+  const existingUserIds = new Set(members?.users.map((user) => user.user_id) ?? [])
+  const filteredUsers = (usersData?.users ?? []).filter(
+    (user) =>
+      !existingUserIds.has(user.zitadel_user_id) &&
+      (user.display_name.toLowerCase().includes(userSearch.toLowerCase()) ||
+        user.email.toLowerCase().includes(userSearch.toLowerCase())),
+  )
 
   function handleVisibilityChange(mode: VisibilityMode) {
     if (!kb) return
@@ -184,86 +137,18 @@ function MembersTab() {
 
   function handleContributeToggle() {
     if (!kb) return
-    const newRole = allowContribute ? 'viewer' : 'contributor'
-    updateKbMutation.mutate({ default_org_role: newRole })
+    updateKbMutation.mutate({ default_org_role: allowContribute ? 'viewer' : 'contributor' })
   }
-
-  // Filter groups: exclude system groups and already-added groups
-  const existingGroupIds = new Set(members?.groups.map((g) => g.group_id) ?? [])
-  const filteredGroups = (groupsData?.groups ?? []).filter(
-    (g) =>
-      !existingGroupIds.has(g.id) &&
-      g.name.toLowerCase().includes(groupSearch.toLowerCase())
-  )
-
-  // Filter users: exclude already-added users
-  const existingUserIds = new Set(members?.users.map((u) => u.user_id) ?? [])
-  const filteredUsers = (usersData?.users ?? []).filter(
-    (u) =>
-      !existingUserIds.has(u.zitadel_user_id) &&
-      (u.display_name.toLowerCase().includes(userSearch.toLowerCase()) ||
-        u.email.toLowerCase().includes(userSearch.toLowerCase()))
-  )
-
-  const visibilityOptions: { mode: VisibilityMode; icon: React.ElementType; label: string; description: string }[] = [
-    {
-      mode: 'public',
-      icon: Globe,
-      label: m.knowledge_sharing_visibility_public(),
-      description: m.knowledge_sharing_visibility_public_description(),
-    },
-    {
-      mode: 'org',
-      icon: Users,
-      label: m.knowledge_sharing_visibility_org(),
-      description: m.knowledge_sharing_visibility_org_description(),
-    },
-    {
-      mode: 'restricted',
-      icon: Lock,
-      label: m.knowledge_sharing_visibility_restricted(),
-      description: m.knowledge_sharing_visibility_restricted_description(),
-    },
-  ]
 
   return (
     <div className="space-y-6">
-      {/* Visibility selector — owners only */}
       {kb && kb.owner_type === 'org' && isOwner && (
-        <div className="space-y-2">
-          <h2 className="text-sm font-semibold text-gray-900">
-            {m.knowledge_sharing_who_can_access()}
-          </h2>
-          <div className="flex flex-col gap-2">
-            {visibilityOptions.map(({ mode, icon: Icon, label, description }) => (
-              <button
-                key={mode}
-                type="button"
-                onClick={() => handleVisibilityChange(mode)}
-                className={`flex items-start gap-3 rounded-lg border p-3 text-left transition-colors ${
-                  visibilityMode === mode
-                    ? 'border-gray-200 bg-black/[0.06]'
-                    : 'border-gray-200 hover:border-gray-300'
-                }`}
-              >
-                <Icon className={`h-4 w-4 mt-0.5 shrink-0 ${
-                  visibilityMode === mode ? 'text-gray-400' : 'text-gray-400'
-                }`} />
-                <div>
-                  <span className="text-sm font-medium text-gray-900">
-                    {label}
-                  </span>
-                  <p className="text-xs text-gray-400 mt-0.5">
-                    {description}
-                  </p>
-                </div>
-              </button>
-            ))}
-          </div>
-        </div>
+        <VisibilitySelector
+          visibilityMode={visibilityMode}
+          onVisibilityChange={handleVisibilityChange}
+        />
       )}
 
-      {/* Contribute toggle — only for public/org, owners only */}
       {kb && kb.owner_type === 'org' && isOwner && visibilityMode !== 'restricted' && (
         <label className="flex items-start gap-2 cursor-pointer">
           <input
@@ -283,216 +168,195 @@ function MembersTab() {
         </label>
       )}
 
-      {/* Non-owner visibility display */}
       {kb && kb.owner_type === 'org' && !isOwner && (
-        <div className="flex items-center gap-2 text-sm text-gray-400">
-          {visibilityMode === 'public' && <Globe className="h-4 w-4" />}
-          {visibilityMode === 'org' && <Users className="h-4 w-4" />}
-          {visibilityMode === 'restricted' && <Lock className="h-4 w-4" />}
-          <span>
-            {visibilityMode === 'public' && m.knowledge_sharing_visibility_public()}
-            {visibilityMode === 'org' && m.knowledge_sharing_visibility_org()}
-            {visibilityMode === 'restricted' && m.knowledge_sharing_visibility_restricted()}
-          </span>
-        </div>
+        <VisibilitySummary visibilityMode={visibilityMode} />
       )}
 
-      {/* Groups — MemberPicker style */}
-      <div className="space-y-2">
-        <h2 className="text-sm font-semibold text-gray-900">
-          {visibilityMode !== 'restricted' ? m.knowledge_sharing_groups_extra() : m.knowledge_sharing_groups()}
-        </h2>
-        {/* Group search combobox — owners only */}
-        {isOwner && (
-          <div
-            className="relative"
-            ref={groupRef}
-            onFocusCapture={() => setGroupFocused(true)}
-            onBlurCapture={(e) => {
-              if (!groupRef.current?.contains(e.relatedTarget as Node)) {
-                setGroupFocused(false)
-              }
-            }}
-          >
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
-            <Input
-              value={groupSearch}
-              onChange={(e) => setGroupSearch(e.target.value)}
-              placeholder={m.knowledge_sharing_search_group()}
-              className="pl-9"
-            />
-            {groupFocused && filteredGroups.length > 0 && (
-              <div className="absolute z-10 mt-1 w-full rounded-lg border border-gray-200 bg-[var(--color-card)] shadow-md max-h-40 overflow-y-auto">
-                {filteredGroups.map((g) => (
-                  <button
-                    key={g.id}
-                    type="button"
-                    onMouseDown={(e) => e.preventDefault()}
-                    onClick={() => {
-                      inviteGroupMutation.mutate({ groupId: g.id, role: 'viewer' })
-                    }}
-                    className="w-full px-3 py-2 text-left text-sm text-gray-900 hover:bg-gray-50 transition-colors"
-                  >
-                    {g.name}
-                  </button>
-                ))}
-              </div>
-            )}
-          </div>
-        )}
-
-        {inviteGroupMutation.error && (
-          <p className="text-sm text-[var(--color-destructive)]">{String(inviteGroupMutation.error)}</p>
-        )}
-
-        {/* Existing group members as cards */}
-        {members?.groups.map((g) => (
-          <div
-            key={g.id}
-            className="flex items-center justify-between rounded-lg border border-gray-200 bg-[var(--color-card)] px-3 py-2"
-          >
-            <span className="text-sm text-gray-900">{g.group_name}</span>
-            <div className="flex items-center gap-2">
-              <span className="text-xs text-gray-400">{g.role}</span>
-              {isOwner && (
-                <button
-                  type="button"
-                  onClick={() => setConfirmingRemoveGroup(g.id)}
-                  className="flex h-6 w-6 items-center justify-center text-gray-400 hover:text-[var(--color-destructive)] transition-colors"
-                >
-                  <X className="h-3.5 w-3.5" />
-                </button>
-              )}
-            </div>
-          </div>
+      <InviteSection
+        kind="groups"
+        title={visibilityMode !== 'restricted' ? m.knowledge_sharing_groups_extra() : m.knowledge_sharing_groups()}
+        isOwner={isOwner}
+        search={groupSearch}
+        onSearchChange={setGroupSearch}
+        focused={groupFocused}
+        onFocusedChange={setGroupFocused}
+        options={filteredGroups}
+        error={inviteGroupMutation.error}
+        onInviteGroup={(groupId) => inviteGroupMutation.mutate({ groupId, role: 'viewer' })}
+        emptyReadOnlyMessage={m.knowledge_members_empty_groups()}
+        isEmpty={!members?.groups || members.groups.length === 0}
+      >
+        {members?.groups.map((group) => (
+          <MemberRow
+            key={group.id}
+            kind="group"
+            member={group}
+            isOwner={isOwner}
+            onRemove={setConfirmingRemoveGroup}
+          />
         ))}
+      </InviteSection>
 
-        {(!members?.groups || members.groups.length === 0) && !isOwner && (
-          <p className="text-sm text-gray-400">{m.knowledge_members_empty_groups()}</p>
-        )}
-      </div>
-
-      {/* Persons — MemberPicker style */}
-      <div className="space-y-2">
-        <h2 className="text-sm font-semibold text-gray-900">
-          {visibilityMode !== 'restricted' ? m.knowledge_sharing_persons_extra() : m.knowledge_sharing_persons()}
-        </h2>
-        {/* Person search combobox — owners only */}
-        {isOwner && (
-          <div
-            className="relative"
-            ref={userRef}
-            onFocusCapture={() => setUserFocused(true)}
-            onBlurCapture={(e) => {
-              if (!userRef.current?.contains(e.relatedTarget as Node)) {
-                setUserFocused(false)
-              }
-            }}
-          >
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
-            <Input
-              value={userSearch}
-              onChange={(e) => setUserSearch(e.target.value)}
-              placeholder={m.knowledge_sharing_search_person()}
-              className="pl-9"
-            />
-            {userFocused && filteredUsers.length > 0 && (
-              <div className="absolute z-10 mt-1 w-full rounded-lg border border-gray-200 bg-[var(--color-card)] shadow-md max-h-40 overflow-y-auto">
-                {filteredUsers.map((u) => (
-                  <button
-                    key={u.zitadel_user_id}
-                    type="button"
-                    onMouseDown={(e) => e.preventDefault()}
-                    onClick={() => {
-                      inviteUserMutation.mutate({ email: u.email, role: 'viewer' })
-                    }}
-                    className="w-full px-3 py-2 text-left text-sm hover:bg-gray-50 transition-colors"
-                  >
-                    <span className="text-gray-900">{u.display_name}</span>
-                    <span className="ml-2 text-xs text-gray-400">{u.email}</span>
-                  </button>
-                ))}
-              </div>
-            )}
-          </div>
-        )}
-
-        {inviteUserMutation.error && (
-          <p className="text-sm text-[var(--color-destructive)]">{String(inviteUserMutation.error)}</p>
-        )}
-
-        {/* Existing user members as cards */}
-        {members?.users.map((u) => (
-          <div
-            key={u.id}
-            className="flex items-center justify-between rounded-lg border border-gray-200 bg-[var(--color-card)] px-3 py-2"
-          >
-            <div>
-              <span className="text-sm text-gray-900">{u.display_name ?? u.email ?? u.user_id}</span>
-              {u.display_name && u.email && (
-                <span className="ml-2 text-xs text-gray-400">{u.email}</span>
-              )}
-            </div>
-            <div className="flex items-center gap-2">
-              <span className="text-xs text-gray-400">{u.role}</span>
-              {isOwner && u.user_id !== myUserId && (
-                <button
-                  type="button"
-                  onClick={() => setConfirmingRemoveUser(u.id)}
-                  className="flex h-6 w-6 items-center justify-center text-gray-400 hover:text-[var(--color-destructive)] transition-colors"
-                >
-                  <X className="h-3.5 w-3.5" />
-                </button>
-              )}
-            </div>
-          </div>
+      <InviteSection
+        kind="users"
+        title={visibilityMode !== 'restricted' ? m.knowledge_sharing_persons_extra() : m.knowledge_sharing_persons()}
+        isOwner={isOwner}
+        search={userSearch}
+        onSearchChange={setUserSearch}
+        focused={userFocused}
+        onFocusedChange={setUserFocused}
+        options={filteredUsers}
+        error={inviteUserMutation.error}
+        onInviteUser={(email) => inviteUserMutation.mutate({ email, role: 'viewer' })}
+        emptyReadOnlyMessage={m.knowledge_members_empty_users()}
+        isEmpty={!members?.users || members.users.length === 0}
+      >
+        {members?.users.map((user) => (
+          <MemberRow
+            key={user.id}
+            kind="user"
+            member={user}
+            isOwner={isOwner}
+            myUserId={myUserId}
+            onRemove={setConfirmingRemoveUser}
+          />
         ))}
-
-        {(!members?.users || members.users.length === 0) && !isOwner && (
-          <p className="text-sm text-gray-400">{m.knowledge_members_empty_users()}</p>
-        )}
-      </div>
+      </InviteSection>
 
       <p className="text-xs text-gray-400 italic">
         {m.knowledge_sharing_creator_note({ name: '' })}
       </p>
 
-      {/* Remove confirmations */}
-      <AlertDialog open={confirmingRemoveUser !== null} onOpenChange={(open) => { if (!open) setConfirmingRemoveUser(null) }}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{m.knowledge_members_remove_confirm_title()}</AlertDialogTitle>
-            <AlertDialogDescription>{m.knowledge_members_remove_confirm_body()}</AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>{m.knowledge_members_invite_cancel()}</AlertDialogCancel>
-            <AlertDialogAction
-              className="bg-[var(--color-destructive)] text-white hover:bg-[var(--color-destructive)]/90"
-              onClick={() => { if (confirmingRemoveUser) removeUserMutation.mutate(confirmingRemoveUser); setConfirmingRemoveUser(null) }}
-            >
-              {m.knowledge_members_remove_button()}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <RemoveMemberDialog
+        open={confirmingRemoveUser !== null}
+        onOpenChange={(open) => {
+          if (!open) setConfirmingRemoveUser(null)
+        }}
+        onConfirm={() => {
+          if (confirmingRemoveUser) removeUserMutation.mutate(confirmingRemoveUser)
+          setConfirmingRemoveUser(null)
+        }}
+      />
 
-      <AlertDialog open={confirmingRemoveGroup !== null} onOpenChange={(open) => { if (!open) setConfirmingRemoveGroup(null) }}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{m.knowledge_members_remove_confirm_title()}</AlertDialogTitle>
-            <AlertDialogDescription>{m.knowledge_members_remove_confirm_body()}</AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>{m.knowledge_members_invite_cancel()}</AlertDialogCancel>
-            <AlertDialogAction
-              className="bg-[var(--color-destructive)] text-white hover:bg-[var(--color-destructive)]/90"
-              onClick={() => { if (confirmingRemoveGroup) removeGroupMutation.mutate(confirmingRemoveGroup); setConfirmingRemoveGroup(null) }}
-            >
-              {m.knowledge_members_remove_button()}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <RemoveMemberDialog
+        open={confirmingRemoveGroup !== null}
+        onOpenChange={(open) => {
+          if (!open) setConfirmingRemoveGroup(null)
+        }}
+        onConfirm={() => {
+          if (confirmingRemoveGroup) removeGroupMutation.mutate(confirmingRemoveGroup)
+          setConfirmingRemoveGroup(null)
+        }}
+      />
     </div>
+  )
+}
+
+interface VisibilityOption {
+  mode: VisibilityMode
+  icon: ElementType
+  label: string
+  description: string
+}
+
+function getVisibilityOptions(): VisibilityOption[] {
+  return [
+    {
+      mode: 'public',
+      icon: Globe,
+      label: m.knowledge_sharing_visibility_public(),
+      description: m.knowledge_sharing_visibility_public_description(),
+    },
+    {
+      mode: 'org',
+      icon: Users,
+      label: m.knowledge_sharing_visibility_org(),
+      description: m.knowledge_sharing_visibility_org_description(),
+    },
+    {
+      mode: 'restricted',
+      icon: Lock,
+      label: m.knowledge_sharing_visibility_restricted(),
+      description: m.knowledge_sharing_visibility_restricted_description(),
+    },
+  ]
+}
+
+interface VisibilitySelectorProps {
+  visibilityMode: VisibilityMode
+  onVisibilityChange: (mode: VisibilityMode) => void
+}
+
+function VisibilitySelector({ visibilityMode, onVisibilityChange }: VisibilitySelectorProps) {
+  const visibilityOptions = getVisibilityOptions()
+
+  return (
+    <div className="space-y-2">
+      <h2 className="text-sm font-semibold text-gray-900">
+        {m.knowledge_sharing_who_can_access()}
+      </h2>
+      <div className="flex flex-col gap-2">
+        {visibilityOptions.map(({ mode, icon: Icon, label, description }) => (
+          <button
+            key={mode}
+            type="button"
+            onClick={() => onVisibilityChange(mode)}
+            className={`flex items-start gap-3 rounded-lg border p-3 text-left transition-colors ${
+              visibilityMode === mode
+                ? 'border-gray-200 bg-black/[0.06]'
+                : 'border-gray-200 hover:border-gray-300'
+            }`}
+          >
+            <Icon className="h-4 w-4 mt-0.5 shrink-0 text-gray-400" />
+            <div>
+              <span className="text-sm font-medium text-gray-900">{label}</span>
+              <p className="text-xs text-gray-400 mt-0.5">{description}</p>
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function VisibilitySummary({ visibilityMode }: { visibilityMode: VisibilityMode }) {
+  const Icon = getVisibilityOptions().find((option) => option.mode === visibilityMode)?.icon ?? Lock
+  return (
+    <div className="flex items-center gap-2 text-sm text-gray-400">
+      <Icon className="h-4 w-4" />
+      <span>
+        {visibilityMode === 'public' && m.knowledge_sharing_visibility_public()}
+        {visibilityMode === 'org' && m.knowledge_sharing_visibility_org()}
+        {visibilityMode === 'restricted' && m.knowledge_sharing_visibility_restricted()}
+      </span>
+    </div>
+  )
+}
+
+interface RemoveMemberDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onConfirm: () => void
+}
+
+function RemoveMemberDialog({ open, onOpenChange, onConfirm }: RemoveMemberDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{m.knowledge_members_remove_confirm_title()}</AlertDialogTitle>
+          <AlertDialogDescription>{m.knowledge_members_remove_confirm_body()}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>{m.knowledge_members_invite_cancel()}</AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-[var(--color-destructive)] text-white hover:bg-[var(--color-destructive)]/90"
+            onClick={onConfirm}
+          >
+            {m.knowledge_members_remove_button()}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   )
 }


### PR DESCRIPTION
## Summary
- split the KB members route into feature-local mutation hooks and member UI components
- add focused mutation hook coverage
- mark SPEC-PORTAL-KB-MEMBERS-CLEANUP-001 done with progress notes

## Validation
- npm ci
- npx vitest run 'src/routes/app/knowledge/\/__tests__/-members-hooks.test.tsx'
- npm run lint -- --quiet
- npm run i18n:compile && npx tsc -b --force
- npm run security:audit && npm run lint && npm run build
- cd klai-widget && npm ci && npm run build
- python3 scripts/fix-mojibake-locales.py --check

## Notes
- Full npm test still has existing unrelated admin/user locale expectation failures (rendered EN labels vs NL expectations).