### PR TITLE
chore(portal): polish password-set flow — explicit flow logging + manual continue

### DIFF
--- a/klai-portal/backend/app/api/auth.py
+++ b/klai-portal/backend/app/api/auth.py
@@ -1075,7 +1075,7 @@ async def password_set(body: PasswordSetRequest) -> None:
     ``/authorize``) — tracked as a follow-up.
     """
     try:
-        await zitadel.set_password_with_code(body.user_id, body.code, body.new_password)
+        flow = await zitadel.set_password_with_code(body.user_id, body.code, body.new_password)
     except httpx.HTTPStatusError as exc:
         _slog.exception("set_password_with_code_failed", zitadel_status=exc.response.status_code)
         if exc.response.status_code in (400, 404, 410):
@@ -1104,13 +1104,20 @@ async def password_set(body: PasswordSetRequest) -> None:
             detail="Failed to set password, please try again later",
         ) from exc
 
+    # Surface which Zitadel flow consumed the code so operators can split
+    # invite-completion vs reset-completion in VictoriaLogs / Grafana.
+    _slog.info(
+        "password_set",
+        actor_user_id=body.user_id,
+        flow=flow,
+    )
     await audit.log_event(
         org_id=0,
         actor=body.user_id,
         action="auth.password.set",
         resource_type="user",
         resource_id=body.user_id,
-        details={"reason": "set"},
+        details={"reason": "set", "flow": flow},
     )
 
 

--- a/klai-portal/backend/app/services/zitadel.py
+++ b/klai-portal/backend/app/services/zitadel.py
@@ -6,6 +6,7 @@ All calls use the portal-api service account PAT — never exposed to the browse
 import asyncio
 import logging
 import time
+from typing import Literal
 
 import httpx
 
@@ -374,8 +375,16 @@ class ZitadelClient:
         resp.raise_for_status()
         return resp.json()["callbackUrl"]
 
-    async def set_password_with_code(self, user_id: str, code: str, new_password: str) -> None:
+    async def set_password_with_code(
+        self, user_id: str, code: str, new_password: str
+    ) -> Literal["invite", "reset"]:
         """Set a new password using a one-time code from email.
+
+        Returns ``"invite"`` if the code was consumed via the invite flow
+        (``invite_code/verify`` + ``password`` without code) and ``"reset"``
+        if it was consumed via the legacy single-call reset flow
+        (``password`` with verificationCode). Callers should record this
+        in their structured logs so operators can split metrics by path.
 
         Zitadel has TWO distinct code flows that both land on Klai's
         ``/password/set`` page:
@@ -400,11 +409,8 @@ class ZitadelClient:
         common case (every newly invited user goes through it). If the
         verify step returns a 4xx we fall back to the reset-flow.
 
-        Behaviour parity with the previous implementation:
-        - Raises ``httpx.HTTPStatusError`` (caller maps to 400/502).
-        - Both flows leave the user in a state where they can immediately
-          authenticate with the new password — the auto-login chain in
-          ``password_set`` works for either path.
+        Raises ``httpx.HTTPStatusError`` (caller maps to 400/502) when
+        both flows fail or Zitadel returns a 5xx during verify.
         """
         # ---- Path 1: invite flow ------------------------------------------------
         verify_resp = await self._http.post(
@@ -418,7 +424,7 @@ class ZitadelClient:
                 json={"newPassword": {"password": new_password, "changeRequired": False}},
             )
             password_resp.raise_for_status()
-            return
+            return "invite"
 
         # invite_code/verify returned 4xx/5xx. Two reasons it might:
         #   - 4xx: the code is not an invite code (likely a password-reset code).
@@ -437,6 +443,7 @@ class ZitadelClient:
             },
         )
         reset_resp.raise_for_status()
+        return "reset"
 
     async def find_user_id_by_email(self, email: str) -> str | None:
         """Return the Zitadel userId for the given email, or None if not found.

--- a/klai-portal/backend/tests/test_set_password_with_code_dual_flow.py
+++ b/klai-portal/backend/tests/test_set_password_with_code_dual_flow.py
@@ -50,7 +50,8 @@ async def test_invite_flow_happy_path() -> None:
         ]
     )
 
-    await client.set_password_with_code("uid-1", "INVITE", "NewSecret123!")
+    flow = await client.set_password_with_code("uid-1", "INVITE", "NewSecret123!")
+    assert flow == "invite"
 
     assert client._http.post.await_count == 2
     # First call: verify
@@ -75,7 +76,8 @@ async def test_invite_verify_4xx_falls_back_to_reset_flow() -> None:
         ]
     )
 
-    await client.set_password_with_code("uid-1", "RESETCODE", "NewSecret123!")
+    flow = await client.set_password_with_code("uid-1", "RESETCODE", "NewSecret123!")
+    assert flow == "reset"
 
     assert client._http.post.await_count == 2
     second = client._http.post.await_args_list[1]

--- a/klai-portal/frontend/messages/en.json
+++ b/klai-portal/frontend/messages/en.json
@@ -39,6 +39,7 @@
   "set_back": "Back to login",
   "set_done_heading": "Password set",
   "set_done_body": "You can now log in.",
+  "set_done_continue": "Log in",
   "set_error_min_length": "Password must be at least 8 characters",
   "set_error_mismatch": "Passwords do not match",
   "set_error_invalid_link": "Link has expired or is invalid, request a new reset link",

--- a/klai-portal/frontend/messages/nl.json
+++ b/klai-portal/frontend/messages/nl.json
@@ -39,6 +39,7 @@
   "set_back": "Terug naar inloggen",
   "set_done_heading": "Wachtwoord ingesteld",
   "set_done_body": "Je kunt nu inloggen.",
+  "set_done_continue": "Inloggen",
   "set_error_min_length": "Wachtwoord moet minimaal 8 tekens bevatten",
   "set_error_mismatch": "Wachtwoorden komen niet overeen",
   "set_error_invalid_link": "Link is verlopen of ongeldig, vraag een nieuwe reset-link aan",

--- a/klai-portal/frontend/src/routes/password/set.tsx
+++ b/klai-portal/frontend/src/routes/password/set.tsx
@@ -62,11 +62,11 @@ function PasswordSetPage() {
       }
 
       // Password is set. Backend returns 204 — auto-login is intentionally
-      // not attempted here (see #638). Send the user through the normal
-      // OIDC login flow at `/`; they'll re-authenticate with the password
-      // they just chose and continue to /setup/mfa via callback.tsx.
+      // not attempted here (see #638). Show a success state with an explicit
+      // "Inloggen" button; the user clicks through to the standard OIDC
+      // login flow at `/` and re-authenticates with the password they just
+      // chose. callback.tsx then redirects to /setup/mfa for new users.
       setDone(true)
-      setTimeout(() => void navigate({ to: '/' }), 2500)
     } catch {
       setError(m.error_connection())
     } finally {
@@ -101,7 +101,7 @@ function PasswordSetPage() {
   return (
     <AuthPageLayout leftContent={leftContent} showLocale>
       {done ? (
-        <div className="space-y-3 text-center">
+        <div className="space-y-4 text-center">
           <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-[var(--color-foreground)]">
             <KeyRound size={22} className="text-[var(--color-rl-cream)]" />
           </div>
@@ -111,6 +111,15 @@ function PasswordSetPage() {
           <p className="text-sm text-gray-400">
             {m.set_done_body()}
           </p>
+          <Button
+            type="button"
+            size="lg"
+            className="w-full"
+            onClick={() => void navigate({ to: '/' })}
+            autoFocus
+          >
+            {m.set_done_continue()}
+          </Button>
         </div>
       ) : (
         <>


### PR DESCRIPTION
Two small UX/observability improvements identified during the SPEC-PORTAL-AUTH-AUTOLOGIN-001 retrospective.

## 1. `set_password_with_code` returns `Literal['invite', 'reset']`

The function tries the invite flow first and falls back to reset (#637). Callers got no signal about which path was actually consumed, so operators couldn't split invite-completion vs reset-completion in VictoriaLogs.

Now `password_set` logs `event='password_set'` with a `flow` field, and the audit detail includes `'flow': '<invite|reset>'`. Operators can now query e.g. `service:portal-api AND event:password_set AND flow:invite` to see admin-invite completions.

## 2. `password/set.tsx`: explicit "Inloggen" button instead of `setTimeout`

The old flow showed the success screen for 2.5 seconds and then navigated away. Arbitrary delay, no user control. The new flow shows the success screen with a primary "Inloggen" / "Log in" button (autofocused) that takes the user to the login page on click. User-paced, no magic timer.

## Tests

- `test_invite_flow_happy_path`: asserts `flow == 'invite'`
- `test_invite_verify_4xx_falls_back_to_reset_flow`: asserts `flow == 'reset'`
- 2663/2663 backend tests passing, ruff clean, frontend tsc clean

i18n: new key `set_done_continue` in `nl.json` + `en.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)