### PR TITLE
chore(portal): ruff format zitadel.py

### DIFF
--- a/klai-portal/backend/app/services/zitadel.py
+++ b/klai-portal/backend/app/services/zitadel.py
@@ -375,9 +375,7 @@ class ZitadelClient:
         resp.raise_for_status()
         return resp.json()["callbackUrl"]
 
-    async def set_password_with_code(
-        self, user_id: str, code: str, new_password: str
-    ) -> Literal["invite", "reset"]:
+    async def set_password_with_code(self, user_id: str, code: str, new_password: str) -> Literal["invite", "reset"]:
         """Set a new password using a one-time code from email.
 
         Returns ``"invite"`` if the code was consumed via the invite flow


### PR DESCRIPTION
Pure formatting follow-up to #643 — backend deploy failed because I ran `ruff check` locally but not `ruff format --check`. ruff format normalised the `set_password_with_code` signature.

No behavioural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)