### PR TITLE
docs(moai): sync admin settings cleanup spec

### DIFF
--- a/.moai/reports/sync-report-20260513T125015Z-SPEC-PORTAL-ADMIN-SETTINGS-CLEANUP-001.md
+++ b/.moai/reports/sync-report-20260513T125015Z-SPEC-PORTAL-ADMIN-SETTINGS-CLEANUP-001.md
@@ -1,0 +1,119 @@
+# Sync Report — SPEC-PORTAL-ADMIN-SETTINGS-CLEANUP-001
+
+**Timestamp:** 2026-05-13T12:50:15Z  
+**Workflow:** `/moai sync SPEC-PORTAL-ADMIN-SETTINGS-CLEANUP-001`  
+**Implementation PR:** #641  
+**Merge commit:** `9afe43a3`  
+**Target:** `origin/main`
+
+## Summary
+
+The admin settings cleanup was implemented, merged to `main`, deployed,
+and post-deploy smoke tested in the Voys tenant through Playwright MCP.
+This sync records the deployment and live verification that happened
+after the implementation was merged.
+
+## Implementation
+
+Changed frontend files delivered by PR #641:
+
+- `klai-portal/frontend/src/routes/admin/settings.tsx`
+  - Reduced to a route shell that owns the page heading and shared
+    settings query.
+  - Composes section components for language, security, organization,
+    telemetry, and extensions.
+- `klai-portal/frontend/src/routes/admin/-settings-hooks.ts`
+  - Extracted settings, extensions, and `/api/me` queries.
+  - Extracted language, MFA, auto-accept, telemetry, and extension
+    mutation hooks.
+- `klai-portal/frontend/src/routes/admin/_components/-LanguageSettingsSection.tsx`
+- `klai-portal/frontend/src/routes/admin/_components/-SecuritySettingsSection.tsx`
+- `klai-portal/frontend/src/routes/admin/_components/-OrganizationSettingsSection.tsx`
+- `klai-portal/frontend/src/routes/admin/_components/-TelemetrySettingsSection.tsx`
+- `klai-portal/frontend/src/routes/admin/_components/-ExtensionsSettingsSection.tsx`
+
+Architecture decision:
+
+- Followed route-local `-`-prefixed helper/component files so TanStack
+  Router ignores them.
+- Did not introduce app-wide helpers under `@/lib/`.
+- Preserved backend endpoint URLs, request bodies, query keys, cache
+  updates, logger calls, staged extension saving, and saved-state flash
+  timing.
+
+## Verification
+
+Local verification before merge:
+
+- CodeIndex `impact(AdminSettingsPage, upstream)` — LOW, no upstream
+  dependents.
+- `npm run lint` — passed.
+- `npm run build` — passed.
+- `npm test` — passed, 37 files / 260 tests.
+
+GitHub checks:
+
+- PR #641 `build-deploy` — passed.
+- PR #641 `semgrep` — passed.
+
+## Deployment
+
+Merged to `main` via PR #641.
+
+Main verification:
+
+- PR #641 merge commit `9afe43a3` is an ancestor of current
+  `origin/main` (`08cacba9` at sync time).
+- `Build and deploy portal-frontend` run `25799096488` for `9afe43a3`
+  succeeded and deployed to `core-01`.
+- A later frontend deploy for `main` also succeeded. Later frontend
+  changes touched `password/set.tsx` and locale message files, not
+  `admin/settings`.
+
+## Voys Smoke Test
+
+Validated with Playwright MCP against
+`https://voys.getklai.com/admin/settings` after the main deploy, using
+the existing Google social-login session in the Playwright profile.
+
+Checks:
+
+- Authenticated admin settings URL loaded.
+- `Settings` heading rendered.
+- Language, Security, Organisation, Telemetry, and Extensions sections
+  rendered.
+- `#settings-language`, `#settings-mfa`, and
+  `#settings-telemetry-level` were visible.
+- Extensions rendered 16 rows.
+- `/api/me`, `/api/admin/settings`, and `/api/admin/extensions`
+  returned HTTP 200.
+- No console errors.
+- No page errors.
+
+Screenshot:
+
+- `.context/voys-admin-settings-2026-05-13.png`
+
+No production settings or extension mutations were submitted during the
+smoke test.
+
+## Documentation Sync
+
+Project-wide documents did not require updates:
+
+- No new dependencies.
+- No environment variable changes.
+- No backend/API contract changes.
+- No top-level directory changes.
+- No product-capability changes.
+
+Updated MoAI artifacts:
+
+- `.moai/specs/SPEC-PORTAL-ADMIN-SETTINGS-CLEANUP-001/progress.md`
+- `.moai/reports/sync-report-20260513T125015Z-SPEC-PORTAL-ADMIN-SETTINGS-CLEANUP-001.md`
+
+## Status
+
+Ready. The cleanup is implemented, merged to `main`, deployed, and
+smoke tested on the Voys tenant through Google social login with
+Playwright MCP.

--- a/.moai/specs/SPEC-PORTAL-ADMIN-SETTINGS-CLEANUP-001/progress.md
+++ b/.moai/specs/SPEC-PORTAL-ADMIN-SETTINGS-CLEANUP-001/progress.md
@@ -31,3 +31,24 @@
 - `npm run build`: passed. Existing route-tree warnings remain for
   pre-existing helper/test files outside this change; the new settings
   helper files are ignored.
+
+## Deployment and Voys Smoke
+
+- PR: #641 (`refactor admin settings sections`)
+- Merge commit: `9afe43a3`
+- Current `origin/main` at sync time: `08cacba9`
+- Verified `9afe43a3` is an ancestor of current `origin/main`.
+- `Build and deploy portal-frontend` for the merge commit passed and
+  deployed to `core-01`.
+- A later `main` frontend deploy also passed; later frontend changes did
+  not touch `admin/settings`.
+- Playwright MCP smoke against `https://voys.getklai.com/admin/settings`
+  with the existing Google SSO session passed:
+  - Authenticated admin settings URL loaded.
+  - Language, Security, Organisation, Telemetry, and Extensions rendered.
+  - `#settings-language`, `#settings-mfa`, and
+    `#settings-telemetry-level` were visible.
+  - Extensions rendered 16 rows.
+  - `/api/me`, `/api/admin/settings`, and `/api/admin/extensions`
+    returned HTTP 200.
+  - No console errors or page errors.


### PR DESCRIPTION
## What changed

- Added the Moai sync report for `SPEC-PORTAL-ADMIN-SETTINGS-CLEANUP-001`.
- Updated the SPEC progress log with the main merge, deploy, and Voys Playwright smoke results.

## Validation

Documentation-only sync. Prior implementation validation and live Voys smoke are recorded in the report.
