### PR TITLE
fix(mailer): restore 'Activeer je Klai-account' brand voice on InviteUser template

### DIFF
--- a/klai-mailer/zitadel-message-texts/en.yaml
+++ b/klai-mailer/zitadel-message-texts/en.yaml
@@ -36,10 +36,12 @@ PasswordChange:
   footerText: "If you didn't make this change yourself, email us right away at mail@${DOMAIN}."
 
 InviteUser:
-  subject: "You've been invited to Klai"
-  preHeader: "Your access is ready"
-  title: "Invitation"
+  # See nl.yaml comment — Klai uses the InitCode brand voice ("Activate your
+  # Klai account") on the v2 invite_code flow that owns admin-invites.
+  subject: "Activate your Klai account"
+  preHeader: "Just one click and your Klai environment is live"
+  title: "Activate account"
   greeting: "Hi {{.FirstName}},"
-  text: "One of your colleagues is inviting you to use Klai. Klai is the privacy-friendly AI solution for businesses. Sensitive information stays protected, and your data remains yours."
-  buttonText: "Set up my account"
+  text: "We've created a Klai account for you. Activate it using the button below and choose your password. After that, log in at my.${DOMAIN}."
+  buttonText: "Activate account"
   footerText: "If you weren't expecting this email, feel free to ignore it."

--- a/klai-mailer/zitadel-message-texts/nl.yaml
+++ b/klai-mailer/zitadel-message-texts/nl.yaml
@@ -39,10 +39,15 @@ PasswordChange:
   footerText: "Wachtwoord niet zelf gewijzigd? Mail ons direct via mail@${DOMAIN}."
 
 InviteUser:
-  subject: "Je bent uitgenodigd voor Klai"
-  preHeader: "Jouw toegang staat klaar"
-  title: "Uitnodiging"
+  # The v2 invite_code flow is the canonical Klai admin-invite path since
+  # SPEC-PORTAL-AUTH-EMAIL-LINKS-001. This template uses the original
+  # InitCode brand voice — "Activeer je Klai-account" — because that is
+  # what Klai communicates to its users at account creation, regardless
+  # of which Zitadel event-type technically fires the mail.
+  subject: "Activeer je Klai-account"
+  preHeader: "Nog één klik en je Klai-omgeving is actief"
+  title: "Account activeren"
   greeting: "Hallo {{.FirstName}},"
-  text: "Eén van je collega's nodigt je uit om gebruik te maken van Klai. Klai is dé privacyvriendelijke AI oplossing voor bedrijven. Gevoelige informatie en persoonlijke gegevens blijven zo veilig. Je data blijft van jou."
-  buttonText: "Account instellen"
+  text: "We hebben een Klai-account voor je aangemaakt. Activeer deze via de knop hieronder en kies je wachtwoord. Daarna log je in op my.${DOMAIN}."
+  buttonText: "Account activeren"
   footerText: "Had je deze e-mail niet verwacht? Dan mag je hem gewoon negeren."


### PR DESCRIPTION
Restores the original InitCode brand voice on the v2 InviteUser template — 'Activeer je Klai-account' / 'We hebben een Klai-account voor je aangemaakt' — which is what Klai communicates to its users at account creation.

## Why

#631 migrated admin-invites from v1 InitCode to v2 invite_code (for urlTemplate control). #633 dropped the InitCode mail (was a dubbele mail). Net unintended consequence: the user-visible mail switched from 'Activeer je Klai-account' to 'Je bent uitgenodigd voor Klai' / 'Eén van je collega's nodigt je uit...' — a brand-voice shift that was not the intent.

## What

- `klai-mailer/zitadel-message-texts/nl.yaml` + `en.yaml` InviteUser block: 'Activeer je Klai-account' subject, 'We hebben een Klai-account voor je aangemaakt' body, 'Account activeren' button.
- Live Zitadel instance message-text synced via `PUT /admin/v1/text/message/invite_user/{nl,en}` (2026-05-13 13:07 UTC).
- Verified with fresh invite to e2e@getklai.com — mailer log: `Sending email to=e2e@getklai.com subject='Activeer je Klai-account'`.

No code change. Template-content only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)