### PR TITLE
fix(portal): use plain anchor for password-set 'Inloggen' button

### DIFF
--- a/klai-portal/frontend/src/routes/password/set.tsx
+++ b/klai-portal/frontend/src/routes/password/set.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/react-router'
 import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { KeyRound } from 'lucide-react'
@@ -26,7 +26,6 @@ export const Route = createFileRoute('/password/set')({
 
 function PasswordSetPage() {
   const { userID, code } = Route.useSearch()
-  const navigate = useNavigate()
 
   const [password, setPassword] = useState('')
   const [confirm, setConfirm] = useState('')
@@ -111,14 +110,11 @@ function PasswordSetPage() {
           <p className="text-sm text-gray-400">
             {m.set_done_body()}
           </p>
-          <Button
-            type="button"
-            size="lg"
-            className="w-full"
-            onClick={() => void navigate({ to: '/' })}
-            autoFocus
-          >
-            {m.set_done_continue()}
+          {/* Anchor wrapped in Button styling — native browser navigation
+              is immune to React event-handler crashes elsewhere on the page
+              (e.g. the tabPrompt chunk that throws on /password/set). */}
+          <Button asChild size="lg" className="w-full">
+            <a href="/">{m.set_done_continue()}</a>
           </Button>
         </div>
       ) : (


### PR DESCRIPTION
User reported: "Ik kan daarna niet op inloggen klikken" with browser console errors from a separate `tabPrompt.js` chunk:

```
TypeError: Cannot read properties of undefined (reading 'item')
    at eA (844.tabPrompt.js:1:5875)
```

That TypeError crashes the React event-handler tree, breaking the Button's `onClick` even though the Button renders. Native browser navigation via `<a href>` is immune to this.

Fix: `<Button asChild><a href="/">…</a></Button>` — same styling, native navigation.

Note: the underlying tabPrompt crash on /password/set is a separate bug (chat-input chunk shouldn't load on the auth page) — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)