### PR TITLE
refactor(portal-frontend): SPEC-PORTAL-TAXONOMY-SPLIT-001 polish round 2 — small cleanups

### DIFF
--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-taxonomy-hooks.ts
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-taxonomy-hooks.ts
@@ -228,6 +228,11 @@ export function useApproveProposal(kbSlug: string) {
       void queryClient.invalidateQueries({ queryKey: ['taxonomy-coverage', kbSlug] })
     },
     onError: (err) => {
+      // TODO(klai): string-matching on err.message is brittle — if
+      // apiFetch ever rewords its error string the user sees the wrong
+      // toast. Better: have apiFetch throw a typed error class with
+      // `.status: number` and check that. Out of scope for this hook,
+      // tracked as a future cross-cutting cleanup.
       const is409 = err instanceof Error && err.message.includes('409')
       taxonomyLogger.warn('Proposal approve failed', { error: String(err), is409 })
       if (is409) {

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/CoverageWidget.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/CoverageWidget.tsx
@@ -56,7 +56,7 @@ export function CoverageWidget({
   onSuggest,
   isSuggesting,
   isBackfilling,
-  canEdit,
+  canEdit = false,
   onRename,
   onDelete,
 }: CoverageWidgetProps) {
@@ -125,7 +125,7 @@ export function CoverageWidget({
           isActive={activeNodeId === node.taxonomy_node_id}
           isEditing={editingNodeId === node.taxonomy_node_id}
           isConfirmingDelete={confirmDeleteId === node.taxonomy_node_id}
-          canEdit={!!canEdit}
+          canEdit={canEdit}
           onNodeClick={() => onNodeClick(node.taxonomy_node_id)}
           onStartEdit={() => {
             setEditingNodeId(node.taxonomy_node_id)
@@ -172,7 +172,7 @@ export function CoverageWidget({
                 showSuggestInUntagged && (
                   <button
                     type="button"
-                    onClick={(e) => { e.stopPropagation(); onSuggest?.() }}
+                    onClick={() => onSuggest?.()}
                     disabled={isSuggesting}
                     className="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded-full font-medium bg-gray-900 text-white hover:opacity-90 transition-opacity disabled:opacity-50"
                   >

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/ProposalCard.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/ProposalCard.tsx
@@ -119,6 +119,8 @@ export function ProposalCard({
       ? { label: m.knowledge_taxonomy_proposals_status_rejected(), variant: 'destructive' }
       : { label: m.knowledge_taxonomy_proposals_status_pending(), variant: 'accent' }
 
+  const description = payloadDescription(proposal.payload)
+
   return (
     <Card
       className={isRejected ? 'opacity-60' : isApproved ? 'bg-[var(--color-success)]/5' : undefined}
@@ -180,9 +182,9 @@ export function ProposalCard({
             ) : (
               <>
                 <p className="text-sm font-medium text-gray-900">{proposal.title}</p>
-                {payloadDescription(proposal.payload) && (
+                {description && (
                   <p className="text-xs text-gray-400 mt-0.5">
-                    {payloadDescription(proposal.payload)}
+                    {description}
                   </p>
                 )}
                 <p className="text-xs text-gray-400 mt-0.5">

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/TaxonomyTab.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/TaxonomyTab.tsx
@@ -1,14 +1,26 @@
 /**
- * TaxonomyTab — extracted from `../taxonomy.tsx` route file by
- * SPEC-PORTAL-TAXONOMY-EXTRACT-001 so that `../insights.tsx` can
- * consume it without violating the `klai/no-cross-route-import`
- * ESLint rule (routes must not import from each other).
+ * TaxonomyTab — orchestrator for the Taxonomy/Insights tab. Composes
+ * `<CoverageWidget>` (with `<CoverageNodeRow>`), `<ProposalCard>`,
+ * `<TagCloud>`, plus the inline filter bar, add-form, and
+ * suggest-flow banners.
  *
- * This file currently contains the entire 720-line TaxonomyTab body
- * + two private helper components (CoverageWidget, TagCloud) + one
- * private constant (MAX_HEALTHY_NODE_COUNT) — all moved verbatim. The
- * internal split into focused sub-components and extracted hooks is
- * tracked under SPEC-PORTAL-TAXONOMY-SPLIT-001.
+ * Lives under `_components/` (TanStack Router ignores the directory)
+ * so both the `/taxonomy` and `/insights` routes can consume it
+ * without violating the `klai/no-cross-route-import` ESLint rule.
+ *
+ * Owns the orchestrator state:
+ *   - filter (activeNodeId, activeTags)
+ *   - suggest-flow state machine (suggestState)
+ *   - inline add-form (showAddRoot, addParentId, newNodeName)
+ *   - singleton ids for proposal edit / reject (per-card input
+ *     buffers live inside ProposalCard)
+ *   - applyAllMutation + handleApplyAll (loops raw apiFetch + fires
+ *     backfill — see SPEC Beslissingen § B5 for why orchestration
+ *     stays here and not in a hook)
+ *
+ * Queries + mutations are extracted to `../-taxonomy-hooks.ts`.
+ * History: SPEC-PORTAL-TAXONOMY-EXTRACT-001 moved this out of the
+ * route file; SPEC-PORTAL-TAXONOMY-SPLIT-001 split the body further.
  */
 
 import { useParams } from '@tanstack/react-router'
@@ -138,14 +150,19 @@ export function TaxonomyTab({ kbSlug: kbSlugProp }: { kbSlug?: string } = {}) {
   // -- Suggest categories flow --
   const [suggestState, setSuggestState] = useState<SuggestState>('idle')
 
-  // Sync suggestState with server data so the banner survives a page refresh.
+  // Sync suggestState with server data so the banner survives a page
+  // refresh. Depend on the derived pending-count (a primitive) rather
+  // than on proposalsQuery.data — the latter is a new object reference
+  // on every refetch, which would re-fire the effect unnecessarily.
+  const pendingProposalCount = (proposalsQuery.data?.proposals ?? []).filter(
+    (p) => p.status === 'pending',
+  ).length
   useEffect(() => {
     if (!proposalsQuery.isSuccess) return
-    const pending = (proposalsQuery.data?.proposals ?? []).filter((p) => p.status === 'pending').length
-    if (pending > 0) {
+    if (pendingProposalCount > 0) {
       setSuggestState((prev) => (prev === 'idle' ? 'proposals_ready' : prev))
     }
-  }, [proposalsQuery.isSuccess, proposalsQuery.data])
+  }, [proposalsQuery.isSuccess, pendingProposalCount])
 
   const bootstrapMutation = useBootstrapTaxonomy(kbSlug, setSuggestState)
 
@@ -153,6 +170,17 @@ export function TaxonomyTab({ kbSlug: kbSlugProp }: { kbSlug?: string } = {}) {
     proposalsForFallback: () => proposalsQuery.data?.proposals ?? [],
   })
 
+  const canEdit = isContributor || isAdmin
+  const nodes = nodesQuery.data?.nodes ?? []
+  const proposals = proposalsQuery.data?.proposals ?? []
+
+  /**
+   * Apply-all orchestrator: approve every pending proposal with
+   * `auto_categorise=false` (skip per-approve classification), then
+   * trigger a single backfill to re-classify everything against the
+   * now-complete taxonomy. Calls `apiFetch` directly rather than via
+   * `useApproveProposal` — see SPEC Beslissingen § B5.
+   */
   async function handleApplyAll() {
     const pendingProposals = proposals.filter((p) => p.status === 'pending')
     // SPEC-TAXONOMY-REVIEW-FLOW-001 Issue 4: pass auto_categorise=false on each
@@ -180,10 +208,6 @@ export function TaxonomyTab({ kbSlug: kbSlugProp }: { kbSlug?: string } = {}) {
   const applyAllMutation = useMutation({
     mutationFn: handleApplyAll,
   })
-
-  const canEdit = isContributor || isAdmin
-  const nodes = nodesQuery.data?.nodes ?? []
-  const proposals = proposalsQuery.data?.proposals ?? []
 
   const isAddingChild = addParentId !== null
 


### PR DESCRIPTION
Seven small follow-ups to PR #646/#651 caught in a third post-merge
critical pass. All behaviour-preserving — no API contract, network, or
rendering change. Polish only.

| # | File | Fix |
|---|------|-----|
| 1 | TaxonomyTab.tsx | Replace stale file-header (still described the pre-split state) with an accurate description of what the orchestrator now owns |
| 2 | TaxonomyTab.tsx | useEffect dep array: depend on derived pending-count (number) rather than \`proposalsQuery.data\` (object ref); same anti-pattern as the earlier ProposalCard fix |
| 3 | -taxonomy-hooks.ts | Add TODO comment on brittle 409 string-match in \`useApproveProposal.onError\`. Real fix is a typed apiFetch error class — cross-cutting, out of scope here |
| 4 | ProposalCard.tsx | Extract local \`description\` const so \`payloadDescription(proposal.payload)\` is called once per render not twice |
| 5 | TaxonomyTab.tsx | Move \`canEdit / nodes / proposals\` declarations above \`handleApplyAll\` so the orchestrator's closure deps are declared in source order |
| 6 | CoverageWidget.tsx | \`canEdit = false\` default in destructuring + drop \`!!canEdit\` coercion at the CoverageNodeRow call site |
| 7 | CoverageWidget.tsx | Drop a dead \`e.stopPropagation()\` on the Suggest button — carry-over from when the parent was a clickable card |

## Gates
- \`tsc -b --force\`: clean
- \`npx eslint\`: clean
- \`vitest run\`: 321/321 (no test changes — refactor is internal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)