### PR TITLE
spec(godcomp-batch): normalise status to done across all 10 SPECs + add 3 missing progress.md

### DIFF
--- a/.moai/specs/SPEC-PORTAL-ADMIN-SETTINGS-CLEANUP-001/spec.md
+++ b/.moai/specs/SPEC-PORTAL-ADMIN-SETTINGS-CLEANUP-001/spec.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-PORTAL-ADMIN-SETTINGS-CLEANUP-001
 version: 0.2.0
-status: implemented
+status: done
 completed: 2026-05-13
 created: 2026-05-13
 author: Mark Vletter

--- a/.moai/specs/SPEC-PORTAL-BILLING-CLEANUP-001/spec.md
+++ b/.moai/specs/SPEC-PORTAL-BILLING-CLEANUP-001/spec.md
@@ -1,9 +1,10 @@
 ---
 id: SPEC-PORTAL-BILLING-CLEANUP-001
 version: 0.1.1
-status: implemented
+status: done
 created: 2026-05-13
 updated: 2026-05-13
+completed: 2026-05-13
 author: Mark Vletter
 priority: medium
 parent: SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 (god-component § Follow-ups, carved out)

--- a/.moai/specs/SPEC-PORTAL-CONNECTORS-TAB-CLEANUP-001/progress.md
+++ b/.moai/specs/SPEC-PORTAL-CONNECTORS-TAB-CLEANUP-001/progress.md
@@ -1,0 +1,36 @@
+# SPEC-PORTAL-CONNECTORS-TAB-CLEANUP-001 — Progress
+
+## Status: done (2026-05-13)
+
+## Implementation
+
+| Commit | Description |
+|---|---|
+| `0d043ccb` | refactor portal connectors tab |
+
+The 425-line `$kbSlug/connectors.tsx` route file was split — the
+borderline case from the SPEC's annotation cycle ended up justifying
+the refactor rather than a won't-fix conclusion.
+
+| Changed file | Status |
+|---|---|
+| `$kbSlug/connectors.tsx` | reduced from 425 to ~210 lines |
+| `$kbSlug/-connectors-hooks.ts` (new) | mutation hooks extracted |
+| `$kbSlug/-connectors-row.tsx` (new) | per-row affordances component |
+
+Stat: 271 insertions, 186 deletions across 4 files (the
+`connectors.tsx` shrink + 2 new files + spec.md status update).
+
+## Outstanding
+
+This progress.md is a **post-hoc summary** added during the
+2026-05-13 batch cleanup. The implementation commit did not include
+its own progress.md. Live verification on Voys was not done by me —
+add browser interactive E2E if a future SPEC depends on the
+connectors-tab behaviour.
+
+## See Also
+
+- `.moai/specs/SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001/spec.md` —
+  parent SPEC; `connectors.tsx` is the list view, the wizards are the
+  add/edit pages already extracted there.

--- a/.moai/specs/SPEC-PORTAL-KB-NEW-CLEANUP-001/progress.md
+++ b/.moai/specs/SPEC-PORTAL-KB-NEW-CLEANUP-001/progress.md
@@ -1,0 +1,37 @@
+# SPEC-PORTAL-KB-NEW-CLEANUP-001 — Progress
+
+## Status: done (2026-05-13)
+
+## Implementation
+
+| PR | Description |
+|---|---|
+| #630 | [codex] Split KB creation wizard |
+
+The 713-line `knowledge/new.tsx` route file was split into per-step
+components:
+
+| New file | Role |
+|---|---|
+| `new._components/-StepName.tsx` | Step 1 — name + description |
+| `new._components/-StepAccess.tsx` | Step 2 — visibility / access control |
+| `new._components/-StepPermissions.tsx` | Step 3 — role assignment |
+| `new._components/-StepConfirm.tsx` | Step 4 — review + submit |
+| `new._wizard-hooks.ts` | Mutation hooks for KB creation |
+| `__tests__/-new-wizard-hooks.test.ts` | Unit tests for hooks |
+
+Plus type additions in existing `new._types.ts`. `new.tsx` itself
+shrank from 633 lines to ~40 (route shell).
+
+## Outstanding
+
+This progress.md is a **post-hoc summary** added during the
+2026-05-13 batch cleanup. The implementation PR did not include
+its own progress.md. Live verification on Voys was not done by me —
+add browser interactive E2E if a future SPEC depends on the wizard
+behaviour.
+
+## See Also
+
+- `.moai/specs/SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001/spec.md` —
+  parent SPEC.

--- a/.moai/specs/SPEC-PORTAL-KB-NEW-CLEANUP-001/spec.md
+++ b/.moai/specs/SPEC-PORTAL-KB-NEW-CLEANUP-001/spec.md
@@ -1,8 +1,9 @@
 ---
 id: SPEC-PORTAL-KB-NEW-CLEANUP-001
 version: 0.2.0
-status: implemented
+status: done
 created: 2026-05-13
+completed: 2026-05-13
 author: Mark Vletter
 priority: medium
 parent: SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 (god-component § Follow-ups, carved out)

--- a/.moai/specs/SPEC-PORTAL-MFA-SETUP-CLEANUP-001/spec.md
+++ b/.moai/specs/SPEC-PORTAL-MFA-SETUP-CLEANUP-001/spec.md
@@ -1,8 +1,9 @@
 ---
 id: SPEC-PORTAL-MFA-SETUP-CLEANUP-001
-version: 0.1.0
-status: draft
+version: 0.1.1
+status: done
 created: 2026-05-13
+completed: 2026-05-13
 author: Mark Vletter
 priority: medium
 parent: SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 (god-component § Follow-ups, carved out)

--- a/.moai/specs/SPEC-PORTAL-TAXONOMY-SPLIT-001/progress.md
+++ b/.moai/specs/SPEC-PORTAL-TAXONOMY-SPLIT-001/progress.md
@@ -1,0 +1,32 @@
+# SPEC-PORTAL-TAXONOMY-SPLIT-001 — Progress
+
+## Status: done (2026-05-13)
+
+## Implementation
+
+| PR | Description |
+|---|---|
+| #646 | refactor(portal-frontend): SPEC-PORTAL-TAXONOMY-SPLIT-001 — split TaxonomyTab god-component |
+| #651 | refactor(portal-frontend): SPEC-PORTAL-TAXONOMY-SPLIT-001 polish — code cleanup pass |
+
+The 720-line TaxonomyTab function (extracted to
+`_components/TaxonomyTab.tsx` by SPEC-PORTAL-TAXONOMY-EXTRACT-001 +
+PR #625) was split into focused sub-components and extracted hooks
+per the SPEC's plan. Pre-requisite was met: TaxonomyTab lived in
+`_components/` before SPLIT started.
+
+## Outstanding
+
+This progress.md is a **post-hoc summary** added during the
+2026-05-13 batch cleanup. The implementation PRs above did not
+include their own progress.md (different sync discipline used by
+the parallel session that did this work). Browser interactive
+verification was not done by me — if F-table row 1 follow-up work
+needs that, it should be added before any further refactor.
+
+## See Also
+
+- `.moai/specs/SPEC-PORTAL-TAXONOMY-EXTRACT-001/spec.md` —
+  prerequisite (TaxonomyTab move).
+- `.moai/specs/SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001/spec.md` —
+  origin SPEC, F-table row 1.

--- a/.moai/specs/SPEC-PORTAL-TAXONOMY-SPLIT-001/spec.md
+++ b/.moai/specs/SPEC-PORTAL-TAXONOMY-SPLIT-001/spec.md
@@ -1,9 +1,10 @@
 ---
 id: SPEC-PORTAL-TAXONOMY-SPLIT-001
 version: 0.2.0
-status: ready
+status: done
 created: 2026-05-13
 updated: 2026-05-13
+completed: 2026-05-13
 author: Mark Vletter
 priority: medium
 parent: SPEC-PORTAL-TAXONOMY-EXTRACT-001 (prerequisite — done; TaxonomyTab lives in `_components/TaxonomyTab.tsx`)

--- a/.moai/specs/SPEC-PORTAL-TRANSCRIBE-ADD-CLEANUP-001/spec.md
+++ b/.moai/specs/SPEC-PORTAL-TRANSCRIBE-ADD-CLEANUP-001/spec.md
@@ -1,8 +1,9 @@
 ---
 id: SPEC-PORTAL-TRANSCRIBE-ADD-CLEANUP-001
-version: 0.1.0
-status: draft
+version: 0.1.1
+status: done
 created: 2026-05-13
+completed: 2026-05-13
 author: Mark Vletter
 priority: medium
 parent: SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001 (god-component § Follow-ups, carved out)


### PR DESCRIPTION
Pure docs cleanup after the 2026-05-13 god-component batch. 10 parallel sessions used 4 different status conventions (`done`, `implemented`, `ready`, `draft`) and 3 SPECs landed without progress.md. This PR normalises everything.

## Status flips (all → `done`)

| SPEC | Before | After |
|---|---|---|
| TAXONOMY-SPLIT-001 | ready | done |
| KB-NEW-CLEANUP-001 | implemented | done |
| ADMIN-SETTINGS-CLEANUP-001 | implemented | done |
| BILLING-CLEANUP-001 | implemented | done |
| MFA-SETUP-CLEANUP-001 | draft (silent-fail) | done |
| TRANSCRIBE-ADD-CLEANUP-001 | draft (silent-fail) | done |

## New progress.md files (post-hoc summaries)

- TAXONOMY-SPLIT-001 — refs PR #646 + #651
- KB-NEW-CLEANUP-001 — refs PR #630
- CONNECTORS-TAB-CLEANUP-001 — refs commit `0d043ccb`

Each progress.md explicitly flags that live Voys verification was NOT done by me; future SPECs depending on those areas should add their own E2E checks first.

No code changes. Pure docs/frontmatter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)