### PR TITLE
fix(portal): default_templates seeding fails on Cat-D RLS — self-set tenant

### DIFF
--- a/klai-portal/backend/app/services/default_templates.py
+++ b/klai-portal/backend/app/services/default_templates.py
@@ -30,6 +30,7 @@ import structlog
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.database import set_tenant
 from app.models.templates import PortalTemplate
 
 logger = structlog.get_logger()
@@ -94,10 +95,30 @@ async def ensure_default_templates(
     Non-fatal: any exception is logged and swallowed — callers MUST NOT
     depend on this for correctness.
 
-    Call sites MUST have called ``set_tenant(org_id)`` on the session
-    beforehand so RLS admits the COUNT and the inserts.
+    Sets the tenant GUC itself as defense-in-depth. ``portal_templates``
+    is a Cat-D RLS table (strict ``USING (org_id = NULLIF(current_setting(
+    'app.current_org_id', true), '')::int)``); since no explicit WITH
+    CHECK clause is defined, the USING expression is used as WITH CHECK
+    for INSERTs. When the GUC is empty, the policy evaluates
+    ``org_id = NULL`` → NULL → fails WITH CHECK with
+    ``InsufficientPrivilegeError``. Production incident 2026-05-13 on
+    ``org_id=10`` (e2e tenant): the orchestrator's prior ``set_tenant``
+    via ``ensure_default_knowledge_bases`` did not survive an
+    intermediate commit / pool checkout, leaving the GUC empty for this
+    seeder. The tenant ended up with zero default templates and the
+    warning ``default_templates_seeding_failed`` fired.
+
+    Setting ``app.current_org_id`` here guarantees the INSERT WITH
+    CHECK passes regardless of how the caller manages the session.
+    Both call sites (provisioning orchestrator step 6b, and the lazy
+    seeder on ``GET /api/app/templates``) operate on pinned sessions,
+    so the ``set_config(..., false)`` is session-scoped and idempotent
+    even when the caller already set the same GUC.
     """
     try:
+        # Defense in depth — see docstring. Must run BEFORE COUNT/INSERT.
+        await set_tenant(db, org_id)
+
         count_result = await db.execute(
             select(func.count()).select_from(PortalTemplate).where(PortalTemplate.org_id == org_id)
         )

--- a/klai-portal/backend/tests/test_default_templates.py
+++ b/klai-portal/backend/tests/test_default_templates.py
@@ -128,3 +128,72 @@ async def test_exception_is_swallowed_and_rolled_back():
     inserted = await default_templates.ensure_default_templates(org_id=42, created_by="sys", db=db)
     assert inserted == 0
     db.rollback.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_ensure_sets_tenant_context_before_count_and_insert():
+    """Regression guard for 2026-05-13 incident on org_id=10 (e2e tenant).
+
+    portal_templates uses a Cat-D strict RLS policy:
+    USING (org_id = NULLIF(current_setting('app.current_org_id', true), '')::int).
+    Postgres uses USING as WITH CHECK when no explicit WITH CHECK clause
+    is defined, so every INSERT requires the app.current_org_id GUC to
+    match the row's org_id. If the GUC is empty (NULLIF -> NULL -> int
+    coercion -> NULL; org_id = NULL -> NULL -> fails WITH CHECK) the
+    INSERT raises 'new row violates row-level security policy'.
+
+    The orchestrator calls ensure_default_knowledge_bases (which sets
+    the tenant GUC) just before this seed. In production on 2026-05-13
+    that GUC was not visible to the seed's INSERTs — the e2e tenant
+    ended up with zero default templates and the warning
+    'default_templates_seeding_failed' fired with InsufficientPrivilegeError.
+
+    Defense in depth: ensure_default_templates MUST set the tenant
+    context itself, independent of caller order or upstream commit
+    timing. This test pins that contract via call-order inspection of
+    db.execute — the FIRST statement on the session must be set_config
+    for app.current_org_id, BEFORE any SELECT count or INSERT.
+    """
+    from app.services import default_templates
+
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=_count_result(0))
+    db.add = MagicMock()
+    db.flush = AsyncMock()
+    db.rollback = AsyncMock()
+
+    await default_templates.ensure_default_templates(org_id=99, created_by="sys", db=db)
+
+    assert db.execute.await_count >= 2, (
+        f"expected at least 2 execute() calls (set_config + COUNT); got {db.execute.await_count}"
+    )
+    first_call_sql = str(db.execute.call_args_list[0].args[0])
+    assert "set_config" in first_call_sql and "app.current_org_id" in first_call_sql, (
+        "ensure_default_templates must set app.current_org_id BEFORE any "
+        f"SELECT/INSERT for defense-in-depth against caller-context leaks. "
+        f"First execute() statement was: {first_call_sql!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ensure_set_tenant_passes_correct_org_id():
+    """The defensive set_tenant call must use the helper's org_id parameter,
+    not some other value (no off-by-one regressions where the GUC is set
+    to the caller's org instead of the new tenant's org).
+    """
+    from app.services import default_templates
+
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=_count_result(0))
+    db.add = MagicMock()
+    db.flush = AsyncMock()
+    db.rollback = AsyncMock()
+
+    await default_templates.ensure_default_templates(org_id=777, created_by="sys", db=db)
+
+    first_call = db.execute.call_args_list[0]
+    # set_tenant binds the org_id via :org_id parameter.
+    params = first_call.args[1] if len(first_call.args) > 1 else first_call.kwargs.get("parameters", {})
+    assert params == {"org_id": "777"}, (
+        f"set_tenant should be invoked with the helper's org_id (777), got params={params!r}"
+    )


### PR DESCRIPTION
## Summary
- New tenants since 2026-05-13 06:35 UTC get **0** default prompt templates instead of 4 — INSERT fails with `new row violates row-level security policy for table "portal_templates"`. Org 10 (e2e tenant) is the only victim so far; the warning was fail-soft so no alert fired.
- Root cause: `portal_templates` is Cat-D RLS (`USING` used as `WITH CHECK`) and `ensure_default_templates` relied on a sibling helper's `set_tenant` side-effect — a fragile contract that broke this week.
- Fix: helper now sets the tenant GUC itself, defense-in-depth. Both call sites (orchestrator step 6b, lazy seeder on `GET /api/app/templates`) operate on pinned sessions so the `set_config(..., false)` is idempotent and session-scoped.

## Test plan
- [x] New regression test `test_ensure_sets_tenant_context_before_count_and_insert` — RED before fix, GREEN after
- [x] New regression test `test_ensure_set_tenant_passes_correct_org_id` — guards off-by-one on GUC value
- [x] 9/9 tests in `test_default_templates.py` green
- [x] 51/51 wider regression suite green (orchestrator step 6b, app_templates lazy seeder, RLS audits)
- [x] ruff check + format clean
- [x] pyright clean
- [ ] **After deploy**: backfill org 10 (e2e tenant) — see commit body for one-liner, or wait for first `/api/app/templates` GET to trigger the lazy seeder.

## Backfill for org 10
After this PR deploys, the e2e tenant gets templates the first time anyone opens `/api/app/templates` (lazy-seeder fires the now-fixed helper). Alternative one-shot from core-01:

\`\`\`bash
ssh core-01 'docker exec klai-core-portal-api-1 python -c "
import asyncio
from app.core.database import AsyncSessionLocal, pin_session
from app.services.default_templates import ensure_default_templates

async def main():
    async with AsyncSessionLocal() as db:
        await pin_session(db)
        n = await ensure_default_templates(10, \"system\", db)
        await db.commit()
        print(f\"seeded {n} templates for org 10\")

asyncio.run(main())
"'
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)