### PR TITLE
refactor(portal-frontend): SPEC-PORTAL-TAXONOMY-SPLIT-001 polish round 3 — micro-cleanups

### DIFF
--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-taxonomy-hooks.ts
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-taxonomy-hooks.ts
@@ -1,20 +1,18 @@
 /**
- * Taxonomy queries + mutations extracted out of TaxonomyTab.tsx by
- * SPEC-PORTAL-TAXONOMY-SPLIT-001 commit 1.
+ * Taxonomy queries + mutations for the Taxonomy/Insights tab.
+ * Extracted from TaxonomyTab.tsx by SPEC-PORTAL-TAXONOMY-SPLIT-001.
  *
- * Each hook here owns one taxonomy concern. Query keys are unchanged
- * from the pre-SPEC inline versions. Mutation invalidation sets follow
- * the contract in Appendix A of the SPEC.
+ * Each hook owns one taxonomy concern. Query keys are unchanged from
+ * the pre-extraction inline versions. Mutation invalidation sets are
+ * the behaviour-preservation contract — see SPEC Appendix A.
  *
  * `applyAllMutation` is intentionally NOT here — it orchestrates a
- * loop of `apiFetch(/approve?auto_categorise=false)` calls, three
- * queryClient invalidations, and a `backfillMutation.mutate()`
- * trigger. That orchestration belongs in the orchestrator
+ * loop of raw `apiFetch(/approve?auto_categorise=false)` calls plus a
+ * backfill trigger. That orchestration belongs in the orchestrator
  * (TaxonomyTab.tsx). See SPEC Beslissingen § B5.
  *
  * Auth gating is the caller's responsibility — pass `enabled` to the
- * query hooks. This matches the pattern from
- * `klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-sources-hooks.ts`.
+ * query hooks. Matches the `-sources-hooks.ts` pattern.
  */
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { apiFetch } from '@/lib/apiFetch'
@@ -38,6 +36,14 @@ export type SuggestState =
 type SuggestStateSetter = (
   next: SuggestState | ((prev: SuggestState) => SuggestState),
 ) => void
+
+/**
+ * Stale window for the heavier server-side aggregations (coverage +
+ * top-tags). They're expensive to recompute on every navigation and
+ * the data is fresh enough at 5 minutes. The lighter queries (nodes,
+ * proposals) use TanStack Query's default.
+ */
+const AGGREGATE_QUERY_STALE_MS = 5 * 60 * 1000
 
 // -- Queries -----------------------------------------------------------------
 
@@ -89,7 +95,7 @@ export function useTaxonomyCoverage(kbSlug: string, enabled = true) {
       }
     },
     enabled,
-    staleTime: 5 * 60 * 1000,
+    staleTime: AGGREGATE_QUERY_STALE_MS,
   })
 }
 
@@ -108,7 +114,7 @@ export function useTopTags(
       )
     },
     enabled,
-    staleTime: 5 * 60 * 1000,
+    staleTime: AGGREGATE_QUERY_STALE_MS,
   })
 }
 

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/__tests__/taxonomy-hooks.test.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/__tests__/taxonomy-hooks.test.tsx
@@ -28,14 +28,14 @@ vi.mock('@/lib/logger', () => ({
   taxonomyLogger: { warn: vi.fn(), error: vi.fn() },
 }))
 vi.mock('sonner', () => ({ toast: { error: vi.fn() } }))
-vi.mock('@/paraglide/messages', () => ({
-  knowledge_taxonomy_proposals_conflict: () => 'conflict-msg',
-  knowledge_taxonomy_proposals_approve_error: () => 'generic-msg',
-}))
+// Paraglide is NOT mocked — same approach as the component test files.
+// Assertions below check that *some* string was passed to toast.error,
+// not the specific translation, so this stays robust to copy changes.
 
 import { apiFetch } from '@/lib/apiFetch'
 import { taxonomyLogger } from '@/lib/logger'
 import { toast } from 'sonner'
+import * as m from '@/paraglide/messages'
 
 const apiFetchMock = vi.mocked(apiFetch)
 const toastErrorMock = vi.mocked(toast.error)
@@ -271,7 +271,7 @@ describe('useApproveProposal', () => {
     result.current.mutate({ proposalId: 42 })
     await waitFor(() => expect(result.current.isError).toBe(true))
 
-    expect(toastErrorMock).toHaveBeenCalledWith('conflict-msg')
+    expect(toastErrorMock).toHaveBeenCalledWith(m.knowledge_taxonomy_proposals_conflict())
     expect(loggerWarnMock).toHaveBeenCalledWith(
       'Proposal approve failed',
       expect.objectContaining({ is409: true }),
@@ -292,7 +292,7 @@ describe('useApproveProposal', () => {
     result.current.mutate({ proposalId: 42 })
     await waitFor(() => expect(result.current.isError).toBe(true))
 
-    expect(toastErrorMock).toHaveBeenCalledWith('generic-msg')
+    expect(toastErrorMock).toHaveBeenCalledWith(m.knowledge_taxonomy_proposals_approve_error())
     expect(loggerWarnMock).toHaveBeenCalledWith(
       'Proposal approve failed',
       expect.objectContaining({ is409: false }),

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/TaxonomyTab.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/TaxonomyTab.tsx
@@ -26,7 +26,7 @@
 import { useParams } from '@tanstack/react-router'
 import { useAuth } from '@/lib/auth'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { useState, useEffect } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import {
   Plus, Loader2, BarChart2,
   X, Tag, Filter, Sparkles,
@@ -150,19 +150,39 @@ export function TaxonomyTab({ kbSlug: kbSlugProp }: { kbSlug?: string } = {}) {
   // -- Suggest categories flow --
   const [suggestState, setSuggestState] = useState<SuggestState>('idle')
 
+  const canEdit = isContributor || isAdmin
+  // Stable empty-array fallbacks — TanStack Query returns undefined
+  // until the first response, and a fresh `[]` per render would defeat
+  // the useMemo'd derivations below.
+  const nodes = useMemo(() => nodesQuery.data?.nodes ?? [], [nodesQuery.data?.nodes])
+  const proposals = useMemo(
+    () => proposalsQuery.data?.proposals ?? [],
+    [proposalsQuery.data?.proposals],
+  )
+
+  // One memoised "pending" view used by:
+  //   - the suggestState useEffect below (count > 0 → banner)
+  //   - handleApplyAll (loop body)
+  //   - the Apply All button visibility
+  // Recomputes only when the proposals array changes — query refetches
+  // that return identical content hand back a new ref but the equality
+  // check inside useMemo still sees a new ref, so this is mostly a
+  // readability + DRY win, not a perf one.
+  const pendingProposals = useMemo(
+    () => proposals.filter((p) => p.status === 'pending'),
+    [proposals],
+  )
+
   // Sync suggestState with server data so the banner survives a page
-  // refresh. Depend on the derived pending-count (a primitive) rather
-  // than on proposalsQuery.data — the latter is a new object reference
-  // on every refetch, which would re-fire the effect unnecessarily.
-  const pendingProposalCount = (proposalsQuery.data?.proposals ?? []).filter(
-    (p) => p.status === 'pending',
-  ).length
+  // refresh. Depend on the derived count (a primitive) rather than on
+  // proposalsQuery.data — that object's ref changes on every refetch,
+  // which would re-fire the effect unnecessarily.
   useEffect(() => {
     if (!proposalsQuery.isSuccess) return
-    if (pendingProposalCount > 0) {
+    if (pendingProposals.length > 0) {
       setSuggestState((prev) => (prev === 'idle' ? 'proposals_ready' : prev))
     }
-  }, [proposalsQuery.isSuccess, pendingProposalCount])
+  }, [proposalsQuery.isSuccess, pendingProposals.length])
 
   const bootstrapMutation = useBootstrapTaxonomy(kbSlug, setSuggestState)
 
@@ -170,23 +190,18 @@ export function TaxonomyTab({ kbSlug: kbSlugProp }: { kbSlug?: string } = {}) {
     proposalsForFallback: () => proposalsQuery.data?.proposals ?? [],
   })
 
-  const canEdit = isContributor || isAdmin
-  const nodes = nodesQuery.data?.nodes ?? []
-  const proposals = proposalsQuery.data?.proposals ?? []
-
   /**
    * Apply-all orchestrator: approve every pending proposal with
    * `auto_categorise=false` (skip per-approve classification), then
    * trigger a single backfill to re-classify everything against the
    * now-complete taxonomy. Calls `apiFetch` directly rather than via
    * `useApproveProposal` — see SPEC Beslissingen § B5.
+   *
+   * SPEC-TAXONOMY-REVIEW-FLOW-001 Issue 4: per-approve auto_categorise
+   * is suppressed so the single backfill at the end does all the
+   * classification work in one pass. Saves N-1 wasted runs.
    */
   async function handleApplyAll() {
-    const pendingProposals = proposals.filter((p) => p.status === 'pending')
-    // SPEC-TAXONOMY-REVIEW-FLOW-001 Issue 4: pass auto_categorise=false on each
-    // approve so the backend skips per-approve classification jobs. The single
-    // backfillMutation.mutate() at the bottom does the full re-classification
-    // once. Saves N-1 wasted classification runs (was: N+1, now: 1).
     for (const proposal of pendingProposals) {
       try {
         await apiFetch(
@@ -200,8 +215,6 @@ export function TaxonomyTab({ kbSlug: kbSlugProp }: { kbSlug?: string } = {}) {
     void queryClient.invalidateQueries({ queryKey: ['taxonomy-proposals', kbSlug] })
     void queryClient.invalidateQueries({ queryKey: ['taxonomy-nodes', kbSlug] })
     void queryClient.invalidateQueries({ queryKey: ['taxonomy-coverage', kbSlug] })
-    // Then trigger backfill — this is the single classification pass that
-    // tags all chunks against the now-complete taxonomy.
     backfillMutation.mutate()
   }
 
@@ -211,8 +224,11 @@ export function TaxonomyTab({ kbSlug: kbSlugProp }: { kbSlug?: string } = {}) {
 
   const isAddingChild = addParentId !== null
 
-  // Resolve active node name for filter chips
-  const activeNode = activeNodeId !== null ? nodes.find((n) => n.id === activeNodeId) : null
+  // Resolve active node name for filter chips.
+  const activeNode = useMemo(
+    () => (activeNodeId !== null ? nodes.find((n) => n.id === activeNodeId) ?? null : null),
+    [activeNodeId, nodes],
+  )
 
   return (
     <div className="space-y-8">
@@ -361,7 +377,7 @@ export function TaxonomyTab({ kbSlug: kbSlugProp }: { kbSlug?: string } = {}) {
           <div className="flex items-center gap-2 mb-3">
             <BarChart2 className="h-4 w-4 text-gray-900" />
             <h2 className="text-sm font-semibold text-gray-900">{m.knowledge_taxonomy_proposals_heading()}</h2>
-            <Badge variant="accent">{String(proposals.filter((p) => p.status === 'pending').length)}</Badge>
+            <Badge variant="accent">{String(pendingProposals.length)}</Badge>
           </div>
           <div className="space-y-3">
             {proposals.map((proposal) => (
@@ -390,7 +406,7 @@ export function TaxonomyTab({ kbSlug: kbSlugProp }: { kbSlug?: string } = {}) {
               />
             ))}
             {/* Apply All only shows when there are pending proposals to apply */}
-            {canEdit && suggestState === 'proposals_ready' && proposals.some((p) => p.status === 'pending') && (
+            {canEdit && suggestState === 'proposals_ready' && pendingProposals.length > 0 && (
               <div className="pt-3">
                 <Button
                   size="sm"


### PR DESCRIPTION
Five micro-cleanups on top of PR #646/#651/#654. All behaviour-preserving,
readability + idiomatic React only.

| # | File | Fix |
|---|------|-----|
| 1 | TaxonomyTab.tsx | Single memoised \`pendingProposals\` replaces 3 inline filter/some calls (useEffect, handleApplyAll, Apply All visibility, count badge); plus stable useMemo wrappers around \`nodes\` / \`proposals\` so the derivation deps don't change every render |
| 2 | TaxonomyTab.tsx | \`useMemo\` for \`activeNode\` (was \`nodes.find\` per render) |
| 3 | -taxonomy-hooks.ts | \`AGGREGATE_QUERY_STALE_MS\` constant with comment; replaces two literal \`5 * 60 * 1000\` occurrences |
| 4 | taxonomy-hooks.test.tsx | Drop stub paraglide mock with bespoke 'conflict-msg' / 'generic-msg'; use real paraglide via \`m.*()\` in assertions. Now consistent with the three component test files |
| 5 | -taxonomy-hooks.ts | Drop 'commit 1' procedural reference in the file-header; SPEC reference is enough |

## Gates
- \`tsc -b --force\`: clean
- \`npx eslint\`: 0 errors, 0 warnings
- \`vitest run\`: 321/321

🤖 Generated with [Claude Code](https://claude.com/claude-code)