### PR TITLE
docs(sync): SPEC-PORTAL-TAXONOMY-SPLIT-001 — expand progress.md + sync report

### DIFF
--- a/.moai/reports/sync-report-20260513T1730Z-SPEC-PORTAL-TAXONOMY-SPLIT-001.md
+++ b/.moai/reports/sync-report-20260513T1730Z-SPEC-PORTAL-TAXONOMY-SPLIT-001.md
@@ -1,0 +1,106 @@
+# Sync Report — SPEC-PORTAL-TAXONOMY-SPLIT-001
+
+- **Date**: 2026-05-13
+- **SPEC**: SPEC-PORTAL-TAXONOMY-SPLIT-001 (status: done, version 0.2.0)
+- **Mode**: auto (post-merge SPEC-lifecycle sync)
+- **Scope**: SPEC progress tracking + sync report. No code changes —
+  the implementation work was delivered in PRs #646 / #651 / #654 / #658
+  and was already on main + deployed at sync time.
+
+## Why a separate sync PR
+
+The four implementation PRs (#646 / #651 / #654 / #658) landed and
+deployed before any single SPEC-lifecycle sync ran. A first batch sync
+(#655, godcomp-batch) normalised the SPEC status to `done` and added a
+stub `progress.md`, but only knew about #646 and #651 — polish rounds
+2 and 3 happened after. This sync closes that gap.
+
+## Phase summary
+
+### Phase 0 — Pre-Sync Quality Gate
+N/A. Implementation PRs each ran their own gates (tsc, eslint, vitest
+all green per PR description); CI on each PR passed; final main is in
+known-good state.
+
+### Phase 0.5 — Quality Verification
+N/A. Each implementation PR ran the standard checks. Cumulative state
+on main:
+- `tsc -b --force`: clean
+- `npx eslint`: 0 errors, 0 warnings
+- `vitest run`: 321/321 green (was 260 pre-SPEC)
+
+### Phase 0.55 — Security Scan
+N/A. Behaviour-preserving refactor of an internal frontend component;
+no auth/db/API surface touched.
+
+### Phase 0.6 — MX Tag Validation
+N/A. Frontend TypeScript; existing files did not carry MX tags
+pre-SPEC and the refactor preserved that. No new exported functions
+crossed the fan_in >= 3 / complexity >= 15 thresholds.
+
+### Phase 0.7 — Coverage
+The 4 PRs added 61 new unit + characterization tests:
+- 18 hook tests covering each row of SPEC Appendix A invalidation map
+- 12 CoverageWidget integration tests (state machine + Suggest CTA gates)
+- 14 CoverageNodeRow tests (singleton edit/delete + buffer preservation regression)
+- 13 ProposalCard tests (status branches + edit/reject mode)
+- 4 minor additions across polish rounds
+
+### Phase 1.5 — SPEC-Implementation Divergence Analysis
+
+| Planned | Implemented | Notes |
+|---|---|---|
+| 3 new `_components/` files | 4 files | CoverageNodeRow extracted in polish #651, not in original scope. Documented in updated progress.md. |
+| `-taxonomy-hooks.ts` with 11 hooks | 11 hooks | Per Appendix A exactly. |
+| `TaxonomyTab.tsx ≤ 250 lines` (AC2) | 451 lines | AC2 revised to ≤500 in PR #646 commit `7e0f31e9` with rationale appended to SPEC. |
+| Behaviour preservation | Verified | Playwright on Voys after each merge confirmed identical network calls + DOM structure. |
+| No `useReducer` / `useCallback` / `memo()` / TaxonomyToolbar | Held | All explicitly scoped out in SPEC. |
+
+No undocumented scope drift. The CoverageNodeRow extension was
+in-scope per the refactor's intent (the SPEC's `proposals.map → ProposalCard`
+move set the precedent; CoverageWidget's `nodes.map` was the same
+pattern in dual standard) and was applied during polish.
+
+### Phase 2 — Document Sync
+- `spec.md` already updated to v0.2.0 + status `done` (via godcomp-batch
+  #655); no further changes needed.
+- `progress.md` expanded with PRs #654 + #658 and accurate
+  production-verification notes (this PR).
+- This sync-report file created (this PR).
+- `.moai/project/` — no updates required. The refactor introduced no
+  new directories, dependencies, or architectural patterns; the
+  `_components/` + `-sibling-hooks.ts` pattern was already documented
+  in `.claude/rules/klai/projects/portal-frontend.md` § File
+  organization, which the SPEC follows.
+- README.md — no updates required.
+
+### Phase 2.4 — SPEC Status
+- Status: `done` (already set by #655)
+- Version: `0.2.0` (unchanged — SPEC content is final)
+- Completed: `2026-05-13`
+
+### Phase 3 — Git Operations
+- Strategy: `github_flow`
+- Branch: `chore/SPEC-PORTAL-TAXONOMY-SPLIT-001-sync`
+- PR target: main
+- This sync delivers `progress.md` + this sync-report. No code, no
+  build, no deploy.
+
+## Files updated
+
+- `.moai/specs/SPEC-PORTAL-TAXONOMY-SPLIT-001/progress.md` — expanded
+  from stub to full implementation log with PR table, final file
+  shapes, AC2 deviation rationale, test coverage summary, and
+  production verification notes.
+- `.moai/reports/sync-report-20260513T1730Z-SPEC-PORTAL-TAXONOMY-SPLIT-001.md` —
+  this file (new).
+
+## Outstanding follow-ups
+
+None on this SPEC. Possible future work:
+- A separate SPEC could further extract `<FilterBar>`, `<AddForm>`, and
+  `<SuggestBanners>` from TaxonomyTab.tsx to hit the original ≤250 line
+  target. Out of scope for this SPEC.
+- Cross-cutting: a typed apiFetch error class with `.status: number`
+  would let `useApproveProposal` drop the brittle `err.message.includes('409')`
+  match. TODO comment added in PR #654.

--- a/.moai/specs/SPEC-PORTAL-TAXONOMY-SPLIT-001/progress.md
+++ b/.moai/specs/SPEC-PORTAL-TAXONOMY-SPLIT-001/progress.md
@@ -4,29 +4,74 @@
 
 ## Implementation
 
-| PR | Description |
-|---|---|
-| #646 | refactor(portal-frontend): SPEC-PORTAL-TAXONOMY-SPLIT-001 — split TaxonomyTab god-component |
-| #651 | refactor(portal-frontend): SPEC-PORTAL-TAXONOMY-SPLIT-001 polish — code cleanup pass |
+The 1093-line `TaxonomyTab.tsx` god-component was split into focused
+sub-components and extracted hooks per the SPEC plan. Pre-requisite
+was met: TaxonomyTab lived in `_components/` before SPLIT started
+(SPEC-PORTAL-TAXONOMY-EXTRACT-001 + PR #625).
 
-The 720-line TaxonomyTab function (extracted to
-`_components/TaxonomyTab.tsx` by SPEC-PORTAL-TAXONOMY-EXTRACT-001 +
-PR #625) was split into focused sub-components and extracted hooks
-per the SPEC's plan. Pre-requisite was met: TaxonomyTab lived in
-`_components/` before SPLIT started.
+### PR sequence
 
-## Outstanding
+| PR | Title | Highlights |
+|---|---|---|
+| #646 | refactor(portal-frontend): SPEC-PORTAL-TAXONOMY-SPLIT-001 — split TaxonomyTab god-component | Foundational split: `-taxonomy-hooks.ts` (11 hooks) + `_components/{TagCloud,CoverageWidget,ProposalCard}.tsx`. TaxonomyTab.tsx 1093 → 451 lines (-59%). +43 characterization tests (18 hook + 12 CoverageWidget + 13 ProposalCard). Includes the v0.2.1 useEffect bug-fix in ProposalCard (`useRef` transition guard against query-refetch buffer wipe). |
+| #651 | refactor(portal-frontend): SPEC-PORTAL-TAXONOMY-SPLIT-001 polish — code cleanup pass | Extract `<CoverageNodeRow>` (CoverageWidget 315 → 196 lines) + 14 unit tests; `useBackfillTaxonomy` cleanup (`pollBackfillJob` helper + named constants + default `proposalsForFallback`); `payloadDescription` dedupe in ProposalCard. |
+| #654 | refactor(portal-frontend): SPEC-PORTAL-TAXONOMY-SPLIT-001 polish round 2 — small cleanups | TaxonomyTab.tsx file-header refresh; useEffect dep array fix (primitive `pendingProposalCount` instead of object `proposalsQuery.data`); 409 string-match TODO; `payloadDescription` extract; `handleApplyAll` declaration order; `canEdit = false` default; dead `e.stopPropagation()` drop. |
+| #658 | refactor(portal-frontend): SPEC-PORTAL-TAXONOMY-SPLIT-001 polish round 3 — micro-cleanups | `useMemo` for `pendingProposals` + `activeNode` + stable `nodes`/`proposals`; `AGGREGATE_QUERY_STALE_MS` constant; uniform paraglide test strategy (drop bespoke mock, use `m.*()` in assertions); `-taxonomy-hooks.ts` header cleanup. |
 
-This progress.md is a **post-hoc summary** added during the
-2026-05-13 batch cleanup. The implementation PRs above did not
-include their own progress.md (different sync discipline used by
-the parallel session that did this work). Browser interactive
-verification was not done by me — if F-table row 1 follow-up work
-needs that, it should be added before any further refactor.
+### Final shape
+
+| File | Lines | Role |
+|---|---|---|
+| `_components/TaxonomyTab.tsx` | 451 | Orchestrator — filter state, suggest-flow state machine, add-form, banners, `applyAllMutation` |
+| `-taxonomy-hooks.ts` | 379 | 11 hooks: 4 queries + 7 mutations (all per SPEC Appendix A) |
+| `_components/CoverageWidget.tsx` | 202 | Coverage list + Suggest CTA gating |
+| `_components/CoverageNodeRow.tsx` | 210 | Per-row state machine (singleton edit/delete) |
+| `_components/ProposalCard.tsx` | 255 | One proposal card with edit/reject/approve flow |
+| `_components/TagCloud.tsx` | 51 | Pure renderer |
+
+### AC2 deviation
+
+Original target was `_components/TaxonomyTab.tsx ≤ 250 lines`. Revised
+to `≤ 500` (see commit `7e0f31e9` on PR #646) once the four-extraction
+scope was tallied. Hitting 250 would require further extracting the
+filter bar, add-form, and suggest banners — deferred to a future SPEC
+if a stricter target is wanted. Final figure: **451 lines**.
+
+### Test coverage
+
+- 321/321 vitest green (was 260 pre-SPEC; +61 from this SPEC's
+  characterization + polish-round tests).
+- `tsc -b --force` clean.
+- `npx eslint` clean (0 errors, 0 warnings).
+
+### Production verification
+
+Playwright via MCP on https://voys.getklai.com/app/knowledge/support/taxonomy
+after each merge. Confirmed:
+- All 4 taxonomy API-calls fire identically to pre-SPEC (nodes,
+  proposals, coverage, top-tags).
+- 8 `<CoverageNodeRow>` components render with correct percentages
+  (6/28/15/4/58/46/2/12%) and untagged section (1%).
+- Per-row rename + delete affordances visible per `canEdit`.
+- Node-click triggers `top-tags?taxonomy_node_id=<id>` refetch with
+  correct `activeNodeId` cache key and filter bar appears in
+  TaxonomyTab orchestrator.
+- "Clear all filters" resets activeNodeId + activeTags as expected.
+
+The `applyAllMutation` orchestrator path and the `ProposalCard`
+edit/reject/approve flow were not exercised live (no pending proposals
+on the verified KB; bootstrap would mutate prod data). Coverage for
+those paths comes from the 18 hook + 13 ProposalCard unit tests; the
+behaviour is identical to pre-SPEC inline code per the
+behaviour-preservation contract in SPEC Appendix A.
 
 ## See Also
 
 - `.moai/specs/SPEC-PORTAL-TAXONOMY-EXTRACT-001/spec.md` —
   prerequisite (TaxonomyTab move).
 - `.moai/specs/SPEC-PORTAL-CONNECTOR-WIZARD-EXTRACT-001/spec.md` —
-  origin SPEC, F-table row 1.
+  origin SPEC (F-table row 1).
+- `.moai/specs/SPEC-PORTAL-KENNIS-002/spec.md` — `-sources-hooks.ts`
+  precedent the hook extraction mirrors.
+- `.moai/reports/sync-report-20260513T1730Z-SPEC-PORTAL-TAXONOMY-SPLIT-001.md` —
+  this sync's report.


### PR DESCRIPTION
Post-merge SPEC-lifecycle sync for SPEC-PORTAL-TAXONOMY-SPLIT-001.

The four implementation PRs (#646 / #651 / #654 / #658) landed and
deployed before any single SPEC-level sync ran. The godcomp-batch sync
(#655) normalised the SPEC status to \`done\` and dropped a stub
progress.md, but only knew about #646 + #651 — polish rounds 2 and 3
shipped after. This PR closes that gap.

## Files

- \`.moai/specs/SPEC-PORTAL-TAXONOMY-SPLIT-001/progress.md\` — expanded
  from stub to full implementation log with per-PR highlights, final
  file shapes, AC2 deviation rationale (≤250 → ≤500 with motivation),
  test coverage summary (321/321), and production verification notes
  via Playwright on Voys.

- \`.moai/reports/sync-report-20260513T1730Z-SPEC-PORTAL-TAXONOMY-SPLIT-001.md\` —
  new sync-report covering divergence analysis (planned vs implemented)
  and outstanding follow-ups (FilterBar/AddForm extraction as future
  SPEC; typed apiFetch error class for the 409 string-match TODO).

## What changed in production

Nothing. No code, no build, no deploy. spec.md unchanged
(already at v0.2.0 / status done via #655).

🤖 Generated with [Claude Code](https://claude.com/claude-code)