### PR TITLE
fix(deprovisioning): SPEC-INFRA-TENANT-DELETE-003 — Meili net + jsonb encode

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -537,6 +537,7 @@ services:
       - net-postgres
       - net-mongodb
       - net-redis
+      - net-meilisearch  # SPEC-INFRA-TENANT-DELETE-003 Bug A — deprovisioning step 6 (_delete_meilisearch_index) needs DNS for meilisearch:7700
       - socket-proxy
 
   # ─── GlitchTip (frontend error tracking) ────────────────────────────────

--- a/klai-portal/backend/app/services/provisioning/deprovisioning_orchestrator.py
+++ b/klai-portal/backend/app/services/provisioning/deprovisioning_orchestrator.py
@@ -20,6 +20,7 @@ skipped harmlessly.
 from __future__ import annotations
 
 import asyncio
+import json
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -334,18 +335,24 @@ async def _mark_failed(db: AsyncSession, org_id: int, step_name: str, error_str:
             step=step_name,
         )
         # Populate last_failure JSONB. Use raw text() to avoid ORM RLS issues.
+        # @MX:NOTE: SPEC-INFRA-TENANT-DELETE-003 Bug B — asyncpg cannot bind a
+        #   Python dict to a jsonb column via text() prepared statements; it
+        #   tries to call `.encode()` on the dict and raises DataError. Encode
+        #   to a JSON string and CAST on the SQL side so the bind value is a
+        #   str (which asyncpg encodes correctly). See portal-backend.md
+        #   "SQLAlchemy + RLS — ::jsonb casts conflict with :param".
         failed_at = datetime.now(UTC).isoformat()
-        await db.execute(
-            text("UPDATE portal_orgs SET last_failure = :failure WHERE id = :id"),
+        failure_payload = json.dumps(
             {
-                "failure": {
-                    "step": step_name,
-                    "error": error_str[:500],  # truncate to keep JSONB compact
-                    "attempt": attempt,
-                    "failed_at": failed_at,
-                },
-                "id": org_id,
-            },
+                "step": step_name,
+                "error": error_str[:500],  # truncate to keep JSONB compact
+                "attempt": attempt,
+                "failed_at": failed_at,
+            }
+        )
+        await db.execute(
+            text("UPDATE portal_orgs SET last_failure = CAST(:failure AS jsonb) WHERE id = :id"),
+            {"failure": failure_payload, "id": org_id},
         )
         await db.commit()
         logger.info("deprovisioning_failed_state_set", org_id=org_id, step=step_name)

--- a/klai-portal/backend/tests/test_deprovisioning_orchestrator.py
+++ b/klai-portal/backend/tests/test_deprovisioning_orchestrator.py
@@ -209,6 +209,70 @@ class TestMarkFailed:
             # Must not raise
             await _mark_failed(db, org_id=42, step_name="step_x", error_str="boom")
 
+    @pytest.mark.asyncio
+    async def test_mark_failed_writes_dict_as_jsonb(self) -> None:
+        """SPEC-INFRA-TENANT-DELETE-003 REQ-2 — _mark_failed must serialise the
+        failure dict in a way asyncpg can bind to a jsonb column.
+
+        Regression: prior implementation passed a Python ``dict`` directly as a
+        text() bind value, which asyncpg rejects with
+        ``DataError: 'dict' object has no attribute 'encode'``. The DataError
+        was swallowed by the outer try/except so ``last_failure`` stayed NULL
+        in production. The fix must encode the dict to a JSON string and CAST
+        on the SQL side, so the dict-bind path no longer fires.
+        """
+        captured: dict[str, object] = {}
+
+        async def fake_execute(stmt, params=None):
+            # transition_state is patched out below, so the only db.execute
+            # we see here is the UPDATE portal_orgs SET last_failure = ...
+            # bound to a dict in the buggy code path.
+            if params is None:
+                return MagicMock()
+            captured["params"] = params
+            captured["stmt"] = stmt
+            # Simulate asyncpg's actual behaviour: a raw dict bound to a
+            # jsonb column raises DataError because dicts have no .encode().
+            for key, val in params.items():
+                if isinstance(val, dict):
+                    raise asyncpg.exceptions.DataError(
+                        f"invalid input for query argument ${key}: {val!r} ('dict' object has no attribute 'encode')"
+                    )
+            return MagicMock()
+
+        db = AsyncMock()
+        db.execute.side_effect = fake_execute
+
+        with patch(
+            "app.services.provisioning.state_machine.transition_state",
+            new=AsyncMock(),
+        ):
+            await _mark_failed(
+                db,
+                org_id=10,
+                step_name="_delete_meilisearch_index",
+                error_str="connection refused",
+                attempt=3,
+            )
+
+        # No DataError leaked + commit reached = the bind value is no longer
+        # a dict. Belt+braces assertions: inspect the captured bind shape.
+        db.commit.assert_awaited_once()
+        assert "params" in captured, "db.execute(UPDATE last_failure) never called"
+        params = captured["params"]
+        assert isinstance(params, dict)
+        # No dict-typed bind values remain — anything containing the failure
+        # payload must have been serialised to a string before the call.
+        dict_binds = [k for k, v in params.items() if isinstance(v, dict)]
+        assert dict_binds == [], (
+            f"_mark_failed still passes a dict to asyncpg: {dict_binds}. "
+            "Use CAST(:val AS jsonb) with json.dumps(...) or the ORM path."
+        )
+        # Sanity: the SQL string must CAST the parameter to jsonb so the
+        # JSON-string bind reaches the column as jsonb (REQ-2 AC-2.1).
+        stmt_text = str(captured["stmt"])
+        assert "jsonb" in stmt_text.lower(), f"UPDATE statement must cast bind to jsonb, got: {stmt_text!r}"
+
 
 # ---------------------------------------------------------------------------
 # _resolve_litellm_team_id


### PR DESCRIPTION
## Summary

Fix two deprovisioning orchestrator bugs found while preparing the first real-world tenant delete (SPEC-E2E-PROD-TENANT — `e2e@getklai.com`, org_id=10).

- **Bug A (CRIT)** — portal-api was not on `klai-net-meilisearch`, so step 6 `_delete_meilisearch_index` failed with `httpx.ConnectError` (DNS) on every production tenant.
- **Bug B (HIGH)** — `_mark_failed` passed a Python dict as a bound param to a `text() ... :failure ...` UPDATE; asyncpg rejects this for jsonb columns (`'dict' object has no attribute 'encode'`). The DataError was swallowed, leaving `last_failure` NULL and stripping admin diagnostic context.

## Changes

- `deploy/docker-compose.yml`: portal-api joins `net-meilisearch` (network already existed for Meilisearch + LibreChat tenants)
- `app/services/provisioning/deprovisioning_orchestrator.py`: `_mark_failed` encodes failure dict via `json.dumps(...)` and uses `CAST(:failure AS jsonb)` per the `::jsonb`-vs-`:param` pattern in `portal-backend.md`
- `tests/test_deprovisioning_orchestrator.py`: new RED→GREEN `test_mark_failed_writes_dict_as_jsonb` that simulates the asyncpg DataError on dict-bind

## Test plan

- [x] `pytest tests/test_deprovisioning_orchestrator.py tests/test_deprovisioning_steps.py tests/test_state_machine_deprovision.py tests/test_deprovision_endpoints.py tests/services/provisioning/` → 150/150 green
- [x] RED test fails against pre-fix code with the exact prod traceback, green after fix
- [x] `ruff check` + `ruff format --check` clean on changed files
- [x] `pyright` clean on changed files (0 errors, 0 warnings)
- [x] `docker-compose.yml` YAML parses; portal-api networks = `[klai-net, net-postgres, net-mongodb, net-redis, net-meilisearch, socket-proxy]`

## Post-deploy verification (manual — REQ-1.2/1.3 + REQ-3.1–3.4)

After `deploy-compose.yml` auto-fires:

1. `ssh core-01 docker exec klai-core-portal-api-1 getent hosts meilisearch` → returns IP
2. `ssh core-01 docker exec klai-core-portal-api-1 curl -s -o /dev/null -w '%{http_code}' http://meilisearch:7700/health` → `200`
3. Retry deprovisioning of `e2e-37271947` (org_id=10) → `portal_orgs` row gone, `librechat-e2e*` container gone, Zitadel `e2e@getklai.com` user gone

## SPEC

`.moai/specs/SPEC-INFRA-TENANT-DELETE-003/spec.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)