### PR TITLE
Implement GDPR SAR export completeness

### DIFF
--- a/.moai/specs/SPEC-GDPR-003/spec.md
+++ b/.moai/specs/SPEC-GDPR-003/spec.md
@@ -1,7 +1,8 @@
 ---
 id: SPEC-GDPR-003
 version: 0.1.0
-status: draft
+status: done
+completed: 2026-05-13
 created: 2026-05-13
 updated: 2026-05-13
 author: klai-team
@@ -14,6 +15,7 @@ supersedes_scope_of: SPEC-GDPR-001 (LibreChat + Twenty + rate-limit out-of-scope
 | Datum      | Versie | Wijziging                                                          |
 |------------|--------|--------------------------------------------------------------------|
 | 2026-05-13 | 0.1.0  | Initieel SPEC — AVG art. 15 volledigheid + abuse-controls          |
+| 2026-05-13 | 0.1.0  | Geimplementeerd via Moai:run in Richmond workspace                 |
 
 ---
 
@@ -30,6 +32,17 @@ SPEC-GDPR-001 leverde een werkende self-service SAR-export, maar drie onderdelen
 Bij juridische review (2026-05-13) is vastgesteld dat **LibreChat-chats** en **Twenty CRM-persoonsgegevens** persoonsgegevens zijn in de zin van AVG Art. 4(1) en daarmee onder het inzagerecht van Art. 15 vallen. De huidige "stuur een e-mail"-route is juridisch geldig (Art. 12(3) — antwoord binnen 1 maand), maar de marketing-belofte van een self-service-knop dekt niet de werkelijkheid. Deze SPEC sluit dat gat én pakt twee bekende security-gaten mee (rate-limit + audit-log van de download zelf).
 
 **Moneybird blijft buiten scope:** betaalgegevens zijn organisatie-data van de tenant, geen persoonsgegevens van de individuele eindgebruiker. De org-contactpersoon kan een aparte uitvraag doen via `privacy@getklai.com`.
+
+## Outcome
+
+Geimplementeerd op 2026-05-13:
+
+- SAR-export bevat nu `klai_portal.librechat_conversations` met strikt op `portal_users.librechat_user_id` gescopete LibreChat-conversaties en berichten.
+- Twenty CRM wordt op `portal_users.email` bevraagd en vult `external_systems.twenty_crm.records` met de SAR-veilige velden.
+- LibreChat en Twenty falen graceful met `null` in de betreffende sectie en warning logs.
+- `/api/me/sar-export` heeft een user-keyed Redis sliding-window rate limit van 5 exports per uur met HTTP 429 + `Retry-After`, en fail-closed HTTP 503 bij Redis-onbeschikbaarheid.
+- Succesvolle exports en rate-limit rejects schrijven onafhankelijke `PortalAuditLog` entries met `sar.exported` en `sar.rate_limited`.
+- De accountpagina toont een specifieke 429-melding.
 
 ## AVG-context
 

--- a/klai-portal/backend/app/api/me.py
+++ b/klai-portal/backend/app/api/me.py
@@ -9,15 +9,18 @@ import logging
 from datetime import UTC, datetime
 from typing import Any, Literal
 
+from bson import ObjectId
+from bson.errors import InvalidId
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials
+from motor.motor_asyncio import AsyncIOMotorClient
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.bearer import bearer
 from app.core.config import settings
-from app.core.database import get_db, set_tenant
+from app.core.database import AsyncSessionLocal, get_db, set_tenant
 from app.core.permissions import resolve_user_permissions
 from app.models.audit import PortalAuditLog
 from app.models.events import ProductEvent
@@ -25,11 +28,18 @@ from app.models.groups import PortalGroup, PortalGroupMembership
 from app.models.knowledge_bases import PortalKnowledgeBase, PortalUserKBAccess
 from app.models.meetings import VexaMeeting
 from app.models.portal import PortalOrg, PortalUser
+from app.services import twenty as twenty_service
+from app.services.partner_rate_limit import check_rate_limit
+from app.services.redis_client import get_redis_pool
 from app.services.zitadel import zitadel
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api", tags=["auth"])
+
+_SAR_EXPORT_LIMIT_PER_HOUR = 5
+_SAR_EXPORT_WINDOW_SECONDS = 3600
+_SAR_EXPORT_RL_KEY_PREFIX = "sar_export:"
 
 
 class LanguageUpdate(BaseModel):
@@ -249,6 +259,19 @@ class SarMeeting(BaseModel):
     summary_json: dict[str, Any] | None
 
 
+class SarLibreChatMessage(BaseModel):
+    role: str
+    text: str | None
+    created_at: datetime | None
+
+
+class SarLibreChatConversation(BaseModel):
+    title: str | None
+    created_at: datetime | None
+    updated_at: datetime | None
+    messages: list[SarLibreChatMessage]
+
+
 class SarKlaiPortal(BaseModel):
     identity: SarIdentity
     account: SarAccount
@@ -257,6 +280,7 @@ class SarKlaiPortal(BaseModel):
     audit_events: list[SarAuditEvent]
     usage_events: list[SarUsageEvent]
     meetings: list[SarMeeting]
+    librechat_conversations: list[SarLibreChatConversation] | None
 
 
 class SarMoneybird(BaseModel):
@@ -269,8 +293,16 @@ class SarLibreChat(BaseModel):
     librechat_user_id: str | None
 
 
+class SarTwentyCRMRecord(BaseModel):
+    first_name: str | None
+    last_name: str | None
+    email: str | None
+    company_name: str | None
+
+
 class SarTwentyCRM(BaseModel):
     note: str
+    records: list[SarTwentyCRMRecord] | None
 
 
 class SarExternalSystems(BaseModel):
@@ -284,6 +316,161 @@ class SarExportResponse(BaseModel):
     request_user_id: str
     klai_portal: SarKlaiPortal
     external_systems: SarExternalSystems
+
+
+def _coerce_mongo_datetime(value: Any) -> datetime | None:
+    return value if isinstance(value, datetime) else None
+
+
+def _message_role(message: dict[str, Any]) -> str:
+    raw_role = message.get("role")
+    if isinstance(raw_role, str) and raw_role:
+        return raw_role
+    if message.get("isCreatedByUser") is True:
+        return "user"
+    sender = message.get("sender")
+    return sender if isinstance(sender, str) and sender else "assistant"
+
+
+def _message_text(message: dict[str, Any]) -> str | None:
+    text = message.get("text")
+    if isinstance(text, str):
+        return text
+    content = message.get("content")
+    if isinstance(content, str):
+        return content
+    return None
+
+
+async def _load_librechat_conversations(
+    org: PortalOrg,
+    portal_user: PortalUser,
+) -> list[SarLibreChatConversation] | None:
+    librechat_user_id = portal_user.librechat_user_id
+    if not librechat_user_id:
+        return []
+    if not settings.librechat_mongo_root_uri or not org.librechat_container:
+        logger.warning(
+            "SAR: LibreChat export unavailable for user %s; missing Mongo URI or container",
+            portal_user.zitadel_user_id,
+        )
+        return None
+
+    try:
+        user_oid = ObjectId(librechat_user_id)
+    except InvalidId:
+        logger.warning("SAR: invalid LibreChat user id %s for user %s", librechat_user_id, portal_user.zitadel_user_id)
+        return None
+
+    mongo_client: AsyncIOMotorClient | None = None
+    try:
+        mongo_client = AsyncIOMotorClient(settings.librechat_mongo_root_uri)
+        database = mongo_client[org.librechat_container]
+        conversation_rows = await (
+            database["conversations"].find({"user": user_oid}).sort("updatedAt", -1).to_list(length=None)
+        )
+
+        conversations: list[SarLibreChatConversation] = []
+        for conversation in conversation_rows:
+            conversation_id = conversation.get("conversationId")
+            message_filter: dict[str, Any] = {"user": user_oid}
+            if conversation_id is not None:
+                message_filter["conversationId"] = conversation_id
+            message_rows = await database["messages"].find(message_filter).sort("createdAt", 1).to_list(length=None)
+
+            conversations.append(
+                SarLibreChatConversation(
+                    title=conversation.get("title") if isinstance(conversation.get("title"), str) else None,
+                    created_at=_coerce_mongo_datetime(conversation.get("createdAt")),
+                    updated_at=_coerce_mongo_datetime(conversation.get("updatedAt")),
+                    messages=[
+                        SarLibreChatMessage(
+                            role=_message_role(message),
+                            text=_message_text(message),
+                            created_at=_coerce_mongo_datetime(message.get("createdAt")),
+                        )
+                        for message in message_rows
+                        if isinstance(message, dict)
+                    ],
+                )
+            )
+        return conversations
+    except Exception as exc:
+        logger.warning(
+            "SAR: LibreChat conversation export failed for user %s: %s",
+            portal_user.zitadel_user_id,
+            exc,
+            exc_info=True,
+        )
+        return None
+    finally:
+        if mongo_client is not None:
+            mongo_client.close()
+
+
+async def _load_twenty_records(email: str | None) -> list[SarTwentyCRMRecord] | None:
+    if not email:
+        return []
+    try:
+        records = await twenty_service.list_people_by_email(email)
+    except Exception as exc:
+        logger.warning("SAR: Twenty CRM lookup failed for %s: %s", email, exc, exc_info=True)
+        return None
+    return [
+        SarTwentyCRMRecord(
+            first_name=record.first_name,
+            last_name=record.last_name,
+            email=record.email,
+            company_name=record.company_name,
+        )
+        for record in records
+    ]
+
+
+async def _write_sar_audit(org_id: int, user_id: str, action: Literal["sar.exported", "sar.rate_limited"]) -> None:
+    try:
+        async with AsyncSessionLocal() as session:
+            session.add(
+                PortalAuditLog(
+                    org_id=org_id,
+                    actor_user_id=user_id,
+                    action=action,
+                    resource_type="self",
+                    resource_id=user_id,
+                )
+            )
+            await session.commit()
+    except Exception:
+        logger.exception("SAR: audit write failed for action %s user %s", action, user_id)
+
+
+async def _enforce_sar_rate_limit(user_id: str, org_id: int) -> None:
+    try:
+        redis_pool = await get_redis_pool()
+        if redis_pool is None:
+            raise RuntimeError("redis_pool_none")
+        allowed, retry_after = await check_rate_limit(
+            redis_pool,
+            f"{_SAR_EXPORT_RL_KEY_PREFIX}{user_id}",
+            _SAR_EXPORT_LIMIT_PER_HOUR,
+            window_seconds=_SAR_EXPORT_WINDOW_SECONDS,
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.warning("SAR: rate limit backend unavailable for user %s: %s", user_id, exc, exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="SAR export rate limit backend unavailable",
+        ) from exc
+
+    if not allowed:
+        await _write_sar_audit(org_id, user_id, "sar.rate_limited")
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="SAR export rate limit exceeded",
+            headers={"Retry-After": str(retry_after)},
+        )
 
 
 @router.patch("/me/language", response_model=MessageResponse)
@@ -358,6 +545,8 @@ async def sar_export(
     # product_events, vexa_meetings). Set tenant context once here so the
     # PostgreSQL fail-loud policy lets them through.
     await set_tenant(db, org.id)
+
+    await _enforce_sar_rate_limit(user_id, org.id)
 
     # 2. Zitadel identity (live fetch - source of truth for name/email)
     zitadel_user_data: dict[str, Any] = {}
@@ -491,7 +680,19 @@ async def sar_export(
         for mtg in meeting_rows
     ]
 
-    # 9. External systems - data not held in the portal DB
+    # 9. External systems - graceful degradation mirrors the Zitadel fallback above.
+    librechat_conversations = await _load_librechat_conversations(org, portal_user)
+    twenty_records = await _load_twenty_records(portal_user.email)
+
+    librechat_note = (
+        "AI-gesprekken staan nu in de klai_portal.librechat_conversations sectie. "
+        "Het LibreChat user-ID blijft opgenomen voor traceability."
+    )
+    twenty_note = (
+        "Matchende CRM-records op basis van uw bevestigde portal e-mailadres staan in records."
+        if twenty_records is not None
+        else "Twenty CRM kon niet worden bevraagd; neem contact op met privacy@getklai.com voor de handmatige route."
+    )
     external_systems = SarExternalSystems(
         moneybird=SarMoneybird(
             note=(
@@ -502,21 +703,16 @@ async def sar_export(
             contact_id=org.moneybird_contact_id,
         ),
         librechat=SarLibreChat(
-            note=(
-                "AI-gespreksgeschiedenis wordt bewaard in de LibreChat omgeving van uw organisatie. "
-                "Neem contact op met uw organisatiebeheerder of stuur een verzoek naar privacy@getklai.com."
-            ),
+            note=librechat_note,
             librechat_user_id=portal_user.librechat_user_id,
         ),
         twenty_crm=SarTwentyCRM(
-            note=(
-                "Klai verwerkt mogelijk de volgende persoonsgegevens in haar interne CRM: "
-                "voornaam, achternaam, e-mailadres en bedrijfsnaam. "
-                "Deze gegevens vallen buiten de self-service export. "
-                "Neem contact op met privacy@getklai.com voor een volledig overzicht."
-            ),
+            note=twenty_note,
+            records=twenty_records,
         ),
     )
+
+    await _write_sar_audit(org.id, user_id, "sar.exported")
 
     return SarExportResponse(
         generated_at=datetime.now(tz=UTC),
@@ -529,6 +725,7 @@ async def sar_export(
             audit_events=audit_events,
             usage_events=usage_events,
             meetings=meetings,
+            librechat_conversations=librechat_conversations,
         ),
         external_systems=external_systems,
     )

--- a/klai-portal/backend/app/services/partner_rate_limit.py
+++ b/klai-portal/backend/app/services/partner_rate_limit.py
@@ -22,20 +22,23 @@ async def check_rate_limit(
     redis_pool: aioredis.Redis,
     key_id: str,
     limit_per_minute: int,
+    window_seconds: int = 60,
 ) -> tuple[bool, int]:
     """Check and increment sliding-window rate limit.
 
     Args:
         redis_pool: Async Redis connection.
         key_id: Partner API key UUID string.
-        limit_per_minute: Maximum requests per 60-second window.
+        limit_per_minute: Maximum requests per sliding window.
+        window_seconds: Sliding window size. Defaults to 60 seconds for the
+            existing partner/internal API callers.
 
     Returns:
         (allowed, retry_after_seconds): allowed=True if under limit,
         retry_after_seconds=0 if allowed, else seconds until window opens.
     """
     now = time.time()
-    window_start = now - 60
+    window_start = now - window_seconds
     redis_key = f"partner_rl:{key_id}"
 
     # Remove entries older than the window
@@ -46,9 +49,11 @@ async def check_rate_limit(
 
     if current_count >= limit_per_minute:
         # Calculate retry_after: time until the oldest entry expires
-        # The oldest entry in the window will expire at oldest_score + 60
+        # The oldest entry in the window will expire at oldest_score + window_seconds
         # We return ceil of the difference
-        retry_after = max(1, math.ceil(60 - (now - window_start)))
+        oldest = await redis_pool.zrange(redis_key, 0, 0, withscores=True)
+        oldest_score = oldest[0][1] if oldest else window_start
+        retry_after = max(1, math.ceil(window_seconds - (now - float(oldest_score))))
         return False, retry_after
 
     # Add new entry
@@ -56,6 +61,6 @@ async def check_rate_limit(
     await redis_pool.zadd(redis_key, {member: now})
 
     # Set TTL on the key to auto-cleanup
-    await redis_pool.expire(redis_key, 120)
+    await redis_pool.expire(redis_key, window_seconds * 2)
 
     return True, 0

--- a/klai-portal/backend/app/services/twenty.py
+++ b/klai-portal/backend/app/services/twenty.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any
+from urllib.parse import quote
 
 import httpx
 import structlog
@@ -62,6 +63,16 @@ class WaitlistDeal:
     name: str  # the recipient's first name (best-effort)
     email: str
     company: str
+
+
+@dataclass(frozen=True)
+class TwentyPersonRecord:
+    """Privacy-safe subset of a Twenty person record for SAR exports."""
+
+    first_name: str | None
+    last_name: str | None
+    email: str | None
+    company_name: str | None
 
 
 def is_configured() -> bool:
@@ -152,6 +163,79 @@ async def get_company(client: httpx.AsyncClient, company_id: str) -> dict[str, A
     if isinstance(body, dict):
         return body.get("company") if isinstance(body.get("company"), dict) else body
     return None
+
+
+def _extract_person_email(person: dict[str, Any]) -> str | None:
+    emails = person.get("emails")
+    if isinstance(emails, dict):
+        email = emails.get("primaryEmail") or emails.get("primary")
+        if isinstance(email, str) and email.strip():
+            return email.strip()
+    email = person.get("email")
+    if isinstance(email, str) and email.strip():
+        return email.strip()
+    return None
+
+
+async def list_people_by_email(email: str) -> list[TwentyPersonRecord]:
+    """Return SAR-safe Twenty person records matching the confirmed portal email."""
+    email = email.strip()
+    if not email:
+        return []
+
+    async with _client() as client:
+        path = f"/rest/people?filter=emails.primaryEmail[eq]:{quote(email)}&limit=100"
+        data = await _get_json(client, path)
+        if not isinstance(data, dict):
+            return []
+
+        body = data.get("data")
+        if isinstance(body, dict):
+            items = body.get("people", [])
+        elif isinstance(body, list):
+            items = body
+        else:
+            items = []
+
+        records: list[TwentyPersonRecord] = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+
+            matched_email = _extract_person_email(item)
+            if matched_email is None or matched_email.casefold() != email.casefold():
+                continue
+
+            raw_name = item.get("name")
+            name_obj: dict[str, Any] = raw_name if isinstance(raw_name, dict) else {}
+            first_name = name_obj.get("firstName") or item.get("firstName")
+            last_name = name_obj.get("lastName") or item.get("lastName")
+
+            company_name: str | None = None
+            company = item.get("company")
+            if isinstance(company, dict):
+                raw_company_name = company.get("name")
+                if isinstance(raw_company_name, str) and raw_company_name.strip():
+                    company_name = raw_company_name.strip()
+            if company_name is None:
+                company_id = item.get("companyId")
+                if isinstance(company_id, str) and company_id:
+                    company_row = await get_company(client, company_id)
+                    if isinstance(company_row, dict):
+                        raw_company_name = company_row.get("name")
+                        if isinstance(raw_company_name, str) and raw_company_name.strip():
+                            company_name = raw_company_name.strip()
+
+            records.append(
+                TwentyPersonRecord(
+                    first_name=first_name.strip() if isinstance(first_name, str) and first_name.strip() else None,
+                    last_name=last_name.strip() if isinstance(last_name, str) and last_name.strip() else None,
+                    email=matched_email,
+                    company_name=company_name,
+                )
+            )
+
+        return records
 
 
 async def resolve_deal(opportunity: dict[str, Any]) -> WaitlistDeal | None:

--- a/klai-portal/backend/tests/test_partner_rate_limit.py
+++ b/klai-portal/backend/tests/test_partner_rate_limit.py
@@ -34,12 +34,23 @@ def mock_redis():
             store[key].append((score, member))
         return 1
 
+    async def zrange(key, start, end, withscores=False):
+        items = sorted(store.get(key, []), key=lambda item: item[0])
+        if end == -1:
+            selected = items[start:]
+        else:
+            selected = items[start : end + 1]
+        if withscores:
+            return [(member, score) for score, member in selected]
+        return [member for _, member in selected]
+
     async def expire(key, seconds):
         return True
 
     redis.zremrangebyscore = AsyncMock(side_effect=zremrangebyscore)
     redis.zcard = AsyncMock(side_effect=zcard)
     redis.zadd = AsyncMock(side_effect=zadd)
+    redis.zrange = AsyncMock(side_effect=zrange)
     redis.expire = AsyncMock(side_effect=expire)
     redis._store = store  # expose for test manipulation
 

--- a/klai-portal/backend/tests/test_sar_export.py
+++ b/klai-portal/backend/tests/test_sar_export.py
@@ -13,7 +13,9 @@ from fastapi import HTTPException
 
 def _mock_org() -> MagicMock:
     org = MagicMock()
+    org.id = 1
     org.moneybird_contact_id = "mb-123"
+    org.librechat_container = "librechat-test"
     return org
 
 
@@ -59,6 +61,19 @@ class TestSarExport:
         stub = AsyncMock()
         monkeypatch.setattr("app.api.me.set_tenant", stub)
         return stub
+
+    @pytest.fixture(autouse=True)
+    def _stub_rate_limit(self, monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+        redis_pool = MagicMock()
+        monkeypatch.setattr("app.api.me.get_redis_pool", AsyncMock(return_value=redis_pool))
+        stub = AsyncMock(return_value=(True, 0))
+        monkeypatch.setattr("app.api.me.check_rate_limit", stub)
+        return stub
+
+    @pytest.fixture(autouse=True)
+    def _stub_external_sources(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("app.api.me._load_twenty_records", AsyncMock(return_value=[]))
+        monkeypatch.setattr("app.api.me._write_sar_audit", AsyncMock())
 
     @pytest.mark.asyncio
     async def test_sets_tenant_before_rls_queries(self, _stub_set_tenant: AsyncMock) -> None:
@@ -153,11 +168,13 @@ class TestSarExport:
         assert "audit_events" in portal
         assert "usage_events" in portal
         assert "meetings" in portal
+        assert "librechat_conversations" in portal
 
         ext = result_dict["external_systems"]
         assert "moneybird" in ext
         assert "librechat" in ext
         assert "twenty_crm" in ext
+        assert ext["twenty_crm"]["records"] == []
 
     @pytest.mark.asyncio
     async def test_identity_includes_mfa_status(self) -> None:
@@ -296,3 +313,115 @@ class TestSarExport:
         assert result.klai_portal.account.preferred_language == "nl"
         assert result.klai_portal.group_memberships == []
         assert result.klai_portal.meetings == []
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_exceeded_returns_429_and_audits(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.api import me as me_module
+
+        org = _mock_org()
+        portal_user = _mock_portal_user()
+
+        mock_result_org_user = MagicMock()
+        mock_result_org_user.one_or_none.return_value = (org, portal_user)
+
+        db = AsyncMock()
+        db.execute.side_effect = [mock_result_org_user]
+
+        audit_stub = AsyncMock()
+        monkeypatch.setattr(me_module, "_write_sar_audit", audit_stub)
+        monkeypatch.setattr(me_module, "check_rate_limit", AsyncMock(return_value=(False, 123)))
+
+        with patch("app.api.me.zitadel") as mock_zitadel:
+            mock_zitadel.get_userinfo = AsyncMock(return_value={"sub": "user-limited"})
+
+            with pytest.raises(HTTPException) as exc_info:
+                await me_module.sar_export(credentials=MagicMock(), db=db)
+
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.headers == {"Retry-After": "123"}
+        audit_stub.assert_awaited_once_with(org.id, "user-limited", "sar.rate_limited")
+
+    @pytest.mark.asyncio
+    async def test_successful_export_writes_audit_entry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.api import me as me_module
+
+        org = _mock_org()
+        portal_user = _mock_portal_user()
+
+        mock_result_org_user = MagicMock()
+        mock_result_org_user.one_or_none.return_value = (org, portal_user)
+        mock_result_empty = MagicMock()
+        mock_result_empty.all.return_value = []
+        mock_result_meetings = MagicMock()
+        mock_result_meetings.scalars.return_value.all.return_value = []
+
+        db = AsyncMock()
+        db.execute.side_effect = [
+            mock_result_org_user,
+            mock_result_empty,
+            mock_result_empty,
+            mock_result_empty,
+            mock_result_empty,
+            mock_result_meetings,
+        ]
+
+        audit_stub = AsyncMock()
+        monkeypatch.setattr(me_module, "_write_sar_audit", audit_stub)
+
+        with patch("app.api.me.zitadel") as mock_zitadel:
+            mock_zitadel.get_userinfo = AsyncMock(return_value={"sub": "user-audit"})
+            mock_zitadel.get_user_by_id = AsyncMock(return_value=_zitadel_user_response())
+            mock_zitadel.has_any_mfa = AsyncMock(return_value=False)
+
+            await me_module.sar_export(credentials=MagicMock(), db=db)
+
+        audit_stub.assert_awaited_once_with(org.id, "user-audit", "sar.exported")
+
+    @pytest.mark.asyncio
+    async def test_twenty_records_are_included_when_lookup_matches(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.api import me as me_module
+
+        org = _mock_org()
+        portal_user = _mock_portal_user()
+
+        mock_result_org_user = MagicMock()
+        mock_result_org_user.one_or_none.return_value = (org, portal_user)
+        mock_result_empty = MagicMock()
+        mock_result_empty.all.return_value = []
+        mock_result_meetings = MagicMock()
+        mock_result_meetings.scalars.return_value.all.return_value = []
+
+        db = AsyncMock()
+        db.execute.side_effect = [
+            mock_result_org_user,
+            mock_result_empty,
+            mock_result_empty,
+            mock_result_empty,
+            mock_result_empty,
+            mock_result_meetings,
+        ]
+
+        monkeypatch.setattr(
+            me_module,
+            "_load_twenty_records",
+            AsyncMock(
+                return_value=[
+                    me_module.SarTwentyCRMRecord(
+                        first_name="Test",
+                        last_name="User",
+                        email="test@example.com",
+                        company_name="Acme",
+                    )
+                ]
+            ),
+        )
+
+        with patch("app.api.me.zitadel") as mock_zitadel:
+            mock_zitadel.get_userinfo = AsyncMock(return_value={"sub": "user-twenty"})
+            mock_zitadel.get_user_by_id = AsyncMock(return_value=_zitadel_user_response())
+            mock_zitadel.has_any_mfa = AsyncMock(return_value=False)
+
+            result = await me_module.sar_export(credentials=MagicMock(), db=db)
+
+        assert result.external_systems.twenty_crm.records is not None
+        assert result.external_systems.twenty_crm.records[0].company_name == "Acme"

--- a/klai-portal/frontend/messages/en.json
+++ b/klai-portal/frontend/messages/en.json
@@ -350,6 +350,7 @@
   "account_sar_description": "Download an overview of all personal data Klai processes about you (GDPR art. 15).",
   "account_sar_button": "Download my data",
   "account_sar_downloading": "Exporting...",
+  "account_sar_rate_limited": "You can download your data up to 5 times per hour. Please try again later.",
   "account_sar_error": "Export failed, please try again",
   "sidebar_account": "My account",
   "provisioning_polling_title": "Setting up your workspace",

--- a/klai-portal/frontend/messages/nl.json
+++ b/klai-portal/frontend/messages/nl.json
@@ -350,6 +350,7 @@
   "account_sar_description": "Download een overzicht van alle persoonlijke gegevens die Klai over jou verwerkt (AVG art. 15).",
   "account_sar_button": "Download mijn gegevens",
   "account_sar_downloading": "Exporteren...",
+  "account_sar_rate_limited": "Je kunt je gegevens maximaal 5 keer per uur downloaden. Probeer het later opnieuw.",
   "account_sar_error": "Export mislukt, probeer opnieuw",
   "sidebar_account": "Mijn account",
   "provisioning_polling_title": "Werkruimte wordt aangemaakt",

--- a/klai-portal/frontend/src/routes/app/account.tsx
+++ b/klai-portal/frontend/src/routes/app/account.tsx
@@ -8,7 +8,7 @@ import { Label } from '@/components/ui/label'
 import { Select } from '@/components/ui/select'
 import { useLocale } from '@/lib/locale'
 import * as m from '@/paraglide/messages'
-import { apiFetch } from '@/lib/apiFetch'
+import { ApiError, apiFetch } from '@/lib/apiFetch'
 
 export const Route = createFileRoute('/app/account')({
   component: AccountPage,
@@ -156,7 +156,11 @@ function AccountPage() {
         </CardHeader>
         <CardContent className="space-y-4">
           {sarMutation.error && (
-            <p className="text-sm text-[var(--color-destructive)]">{m.account_sar_error()}</p>
+            <p className="text-sm text-[var(--color-destructive)]">
+              {sarMutation.error instanceof ApiError && sarMutation.error.status === 429
+                ? m.account_sar_rate_limited()
+                : m.account_sar_error()}
+            </p>
           )}
           <Button
             onClick={() => sarMutation.mutate()}


### PR DESCRIPTION
## Summary

Implements SPEC-GDPR-003 for SAR export completeness and abuse controls:

- Adds LibreChat conversations to `klai_portal.librechat_conversations`, scoped to the requesting user's `librechat_user_id`.
- Adds Twenty CRM records to `external_systems.twenty_crm.records`, scoped to the requesting user's confirmed portal email.
- Keeps LibreChat and Twenty lookups gracefully degradable with `null` output and warning logs.
- Adds user-keyed SAR export rate limiting: 5 successful exports per hour, HTTP 429 with `Retry-After`, and fail-closed HTTP 503 when Redis is unavailable.
- Writes independent `PortalAuditLog` entries for `sar.exported` and `sar.rate_limited`.
- Adds frontend 429 handling copy on the account page.

## Validation

- `uv run pytest tests/test_sar_export.py tests/test_partner_rate_limit.py`
- `uv run ruff check app/api/me.py app/services/twenty.py app/services/partner_rate_limit.py tests/test_sar_export.py tests/test_partner_rate_limit.py`
- `npm run lint -- src/routes/app/account.tsx`
- Earlier in this workspace: `npm run build` passed with existing route/chunk warnings.

## Notes

Existing local CodeIndex/AGENTS/CLAUDE dirty files are intentionally not included in this PR.
