### PR TITLE
chore(local-dev): fresh-install bootstrap — fix migrations, tooling, runbook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ COMPOSE := docker compose -f docker-compose.dev.yml --env-file .env.dev
 BACKEND_DIR := klai-portal/backend
 FRONTEND_DIR := klai-portal/frontend
 
-.PHONY: help setup dev-up dev-down dev-reset dev-status dev-logs seed backend frontend migrate lint check
+.PHONY: help setup dev-up dev-down dev-reset dev-status dev-logs seed postdeploy backend frontend migrate lint check
 
 # ── Help ─────────────────────────────────────────────────────────────────────
 
@@ -23,10 +23,10 @@ setup: ## First-time setup: copy env files, generate keys, install dependencies
 	@test -f .env.dev || cp .env.dev.example .env.dev
 	@test -f $(BACKEND_DIR)/.env || { \
 		cp $(BACKEND_DIR)/.env.example $(BACKEND_DIR)/.env && \
-		echo "  Generating encryption keys..." && \
+		echo "  Generating encryption keys (stdlib only — no cryptography import)..." && \
 		SECRETS_KEY=$$(python3 -c "import secrets; print(secrets.token_hex(32))") && \
 		ENCRYPT_KEY=$$(python3 -c "import secrets; print(secrets.token_hex(32))") && \
-		COOKIE_KEY=$$(python3 -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())") && \
+		COOKIE_KEY=$$(python3 -c "import base64, os; print(base64.urlsafe_b64encode(os.urandom(32)).decode())") && \
 		sed -i.bak "s|^PORTAL_SECRETS_KEY=.*|PORTAL_SECRETS_KEY=$$SECRETS_KEY|" $(BACKEND_DIR)/.env && \
 		sed -i.bak "s|^ENCRYPTION_KEY=.*|ENCRYPTION_KEY=$$ENCRYPT_KEY|" $(BACKEND_DIR)/.env && \
 		sed -i.bak "s|^SSO_COOKIE_KEY=.*|SSO_COOKIE_KEY=$$COOKIE_KEY|" $(BACKEND_DIR)/.env && \
@@ -76,9 +76,20 @@ dev-logs: ## Tail logs from all Docker services
 
 # ── Data ─────────────────────────────────────────────────────────────────────
 
+# Auto-discover the compose-managed postgres container (works regardless of
+# project name; canonical "klai-postgres-1", workspace "<dir>-postgres-1").
+PG_CONTAINER := $$(docker ps --format '{{.Names}}' | grep -E '^[a-z0-9_-]+-postgres-1$$' | head -1)
+
 seed: ## Seed database with demo data (dev org, users)
-	docker exec -i klai-postgres-1 psql -U klai -d klai < dev/seed.sql
-	@echo "Database seeded with demo data."
+	@CTR="$(PG_CONTAINER)"; \
+	if [ -z "$$CTR" ]; then echo "No postgres container found — run 'make dev-up' first."; exit 1; fi; \
+	docker exec -i "$$CTR" psql -U klai -d klai < dev/seed.sql; \
+	echo "Database seeded with demo data (container=$$CTR)."
+
+postdeploy: ## Apply post-deploy SQL (RLS policies + helper functions) as klai superuser
+	@CTR="$(PG_CONTAINER)"; \
+	if [ -z "$$CTR" ]; then echo "No postgres container found — run 'make dev-up' first."; exit 1; fi; \
+	cd $(BACKEND_DIR) && bash scripts/apply_post_deploy_sql.sh --local --container "$$CTR"
 
 # ── Backend ──────────────────────────────────────────────────────────────────
 

--- a/dev/postgres-init.sql
+++ b/dev/postgres-init.sql
@@ -1,4 +1,4 @@
--- Klai local development: create additional databases
+-- Klai local development: create additional databases + roles
 -- The main 'klai' database is created automatically by POSTGRES_DB env var.
 
 -- LiteLLM database
@@ -8,3 +8,20 @@ GRANT ALL PRIVILEGES ON DATABASE litellm TO litellm;
 \c litellm
 GRANT ALL ON SCHEMA public TO litellm;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO litellm;
+
+-- Switch back to the klai database for application-role creation.
+\c klai
+
+-- Application role referenced by RLS policies and GRANT statements in
+-- klai-portal/backend/alembic/versions/*. In production this role is created
+-- via klai-infra provisioning; in local dev we connect as the 'klai' superuser
+-- (which bypasses RLS as the table owner), but the role still needs to EXIST
+-- so that policy clauses like `FOR DELETE TO portal_api` and GRANTs parse.
+-- NOLOGIN keeps it inert — no one ever connects as portal_api locally.
+CREATE ROLE portal_api NOLOGIN;
+
+-- Read-only role referenced by post_deploy_g5h6i7j8k9l0.sql for Grafana metric
+-- queries against product_events. In production this role is granted to the
+-- Grafana datasource user; locally we just need it to exist so GRANT statements
+-- parse. NOLOGIN — no one connects as grafana_reader locally.
+CREATE ROLE grafana_reader NOLOGIN;

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -2,6 +2,8 @@
 
 Stap-voor-stap handleiding om de Klai portal lokaal te draaien voor development.
 
+> **Laatste end-to-end verificatie:** 2026-05-13 (Mark, brisbane workspace). Alle 8 fixes onderaan in changelog gecaptured. Volg dit runbook letterlijk — werkt op een schone macOS met OrbStack + Node 24 + uv + Python 3.13 in `.venv`.
+
 ---
 
 ## Architectuuroverzicht
@@ -163,36 +165,59 @@ Open [http://localhost:5174](http://localhost:5174) — je wordt doorgestuurd na
 
 ## Snelle start (full-stack — Modus B)
 
-Als je aan de backend werkt met echte Zitadel authenticatie:
+Als je aan de backend werkt met echte Zitadel authenticatie. Lees eerst onderstaande nuances — Mode B vereist meer dan een env-flip, sinds SPEC-AUTH-008 (BFF-pattern) en SPEC-SEC-VALIDATOR-COVERAGE-001 (uitgebreide fail-closed validators) is de set verplichte env vars groter dan Mode C.
 
 ```bash
-make setup
-# Vul in: .env.dev, klai-portal/backend/.env, klai-portal/frontend/.env.local
-# Voeg VITE_API_PROXY_TARGET=http://localhost:8010 toe aan frontend/.env.local
-make dev-up          # Docker services
-make migrate         # Database migraties
-make backend         # Backend (in terminal 1)
-make frontend        # Frontend (in terminal 2)
+make setup                       # auto-generate keys, copy env, install deps
+# Vul backend/.env aan — zie "Configuratie · Stap 2" hieronder voor de volledige lijst.
+# Vul frontend/.env.local — zie "Configuratie · Stap 3".
+# Voeg ZITADEL-redirect-URIs toe op je dev-machine — zie "Zitadel configuratie".
+make dev-up                      # Docker services
+make migrate                     # Database migraties
+make postdeploy                  # Post-deploy SQL (RLS policies + helper functies)
+make backend                     # Terminal 1: FastAPI hot-reload
+make frontend                    # Terminal 2: Vite HMR
 ```
 
-Open [http://localhost:5174](http://localhost:5174) in je browser.
+Open [http://localhost:5174](http://localhost:5174) — je wordt doorgestuurd naar `my.getklai.com/login`. Log in met je Klai account, je land terug op `localhost:5174/app`.
 
-> **Let op:** Bij full-stack gebruik je een lege lokale database. Je Zitadel-account bestaat nog niet in `portal_users` — je krijgt een 401 na login. Zaai eerst je user:
+> **Container-namen volgen de compose project name**, niet `klai-*`. In een canonical checkout `klai/` heten ze `klai-postgres-1` etc. In een Conductor workspace `brisbane/` zijn het `brisbane-postgres-1`. Gebruik `docker ps` om de exacte naam te vinden voor seed-commando's hieronder.
+
+> **Let op:** Lokale DB is leeg. Je Zitadel-account moet handmatig in `portal_users` worden gezaaid, anders krijgt elke API-call 401 na login. Pas eerst de placeholder in en run:
 >
 > ```bash
-> docker exec -i klai-postgres-1 psql -U klai -d klai << 'EOF'
-> INSERT INTO portal_orgs (zitadel_org_id, name, slug, plan, provisioning_status)
-> VALUES ('<jouw_zitadel_org_id>', 'Dev Org', 'dev', 'professional', 'complete')
-> ON CONFLICT (zitadel_org_id) DO NOTHING;
+> # Vereist: ZITADEL_PORTAL_ORG_ID, ZITADEL_USER_ID, EMAIL en POSTGRES_CONTAINER ingevuld
+> # in je shell. Haal ze uit klai-portal/backend/.env + Management API search (zie onder).
+> ORG_ID="$(grep '^ZITADEL_PORTAL_ORG_ID=' klai-portal/backend/.env | cut -d= -f2-)"
+> USER_ID="<jouw_zitadel_user_id>"
+> EMAIL="<jouw_email>"
+> POSTGRES=$(docker ps --format '{{.Names}}' | grep postgres-1 | head -1)
 >
-> INSERT INTO portal_users (zitadel_user_id, org_id, role, display_name, email, status)
-> SELECT '<jouw_zitadel_user_id>', id, 'admin', 'Jouw Naam', 'jij@example.com', 'active'
-> FROM portal_orgs WHERE zitadel_org_id = '<jouw_zitadel_org_id>'
-> ON CONFLICT (zitadel_user_id) DO NOTHING;
+> docker exec -i "$POSTGRES" psql -U klai -d klai <<EOF
+> INSERT INTO portal_orgs (zitadel_org_id, name, slug, plan, provisioning_status, primary_domain)
+> VALUES ('${ORG_ID}', 'Dev Org', 'dev', 'professional', 'ready', 'localhost')
+> ON CONFLICT (zitadel_org_id) DO UPDATE SET name = EXCLUDED.name;
+>
+> INSERT INTO portal_users (zitadel_user_id, org_id, role, display_name, email, status, created_at)
+> SELECT '${USER_ID}', id, 'admin'::portal_user_role, 'Jouw Naam', '${EMAIL}', 'active', now()
+> FROM portal_orgs WHERE zitadel_org_id = '${ORG_ID}'
+> ON CONFLICT (zitadel_user_id, org_id) DO UPDATE SET status = 'active';
 > EOF
 > ```
 >
-> Je Zitadel user ID en org ID vind je via de [Zitadel console](https://auth.getklai.com/ui/console) of via een teamlid.
+> Drie gotcha's t.o.v. een oudere versie van dit runbook:
+> 1. `provisioning_status` MOET `'ready'` zijn (niet `'complete'` — die waarde bestaat niet in de CHECK constraint).
+> 2. `portal_users` heeft **geen** `updated_at` kolom — die niet meegeven of de migrate-versie loopt vooruit op deze runbook.
+> 3. De unique constraint op `portal_users` is `(zitadel_user_id, org_id)`, niet alleen `zitadel_user_id` (sinds SPEC-PORTAL-PROFILES-001 — multi-org support).
+>
+> Je Zitadel user_id vind je via Management API (vereist `ZITADEL_PAT` in backend `.env`):
+> ```bash
+> PAT=$(grep '^ZITADEL_PAT=' klai-portal/backend/.env | cut -d= -f2-)
+> curl -s -H "Authorization: Bearer $PAT" -H 'Content-Type: application/json' \
+>   "https://auth.getklai.com/management/v1/users/_search" \
+>   -d '{"queries":[{"displayNameQuery":{"displayName":"Jouw Naam","method":"TEXT_QUERY_METHOD_CONTAINS"}}]}' \
+>   | python3 -c "import json,sys; [print(u['id'],u['human']['profile']['displayName']) for u in json.load(sys.stdin).get('result',[])]"
+> ```
 
 ---
 
@@ -210,54 +235,65 @@ De overige waarden (database wachtwoorden etc.) hebben werkende defaults.
 
 ### Stap 2: Backend (klai-portal/backend/.env)
 
-Open `klai-portal/backend/.env` en vul in:
+`make setup` kopieert `.env.example` en genereert de drie encryption keys automatisch. Voor **Mode C (standalone)** ben je daarmee klaar — niets meer doen. Voor **Mode B (productie Zitadel)** moeten ook deze velden gezet zijn (de fail-closed validators uit SPEC-SEC-VALIDATOR-COVERAGE-001 weigeren te booten zonder):
 
 ```bash
-# Database (wijzig alleen als je een andere poort/wachtwoord gebruikt)
-DATABASE_URL=postgresql+asyncpg://klai:klai-dev@localhost:5434/klai
-
-# Zitadel auth (VERPLICHT voor productie-mode)
-ZITADEL_PAT=<zie "Zitadel configuratie" hieronder>
-
-# Genereer deze eenmalig (beide zijn 64-char hex strings = 32 bytes):
-PORTAL_SECRETS_KEY=<python -c "import secrets; print(secrets.token_hex(32))">
-ENCRYPTION_KEY=<python -c "import secrets; print(secrets.token_hex(32))">
-SSO_COOKIE_KEY=<python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())">
-
-# Dev instellingen
+# Mode-B switch: zet AUTH_DEV_MODE=false (default in template is true voor Mode C)
 DEBUG=true
-MOCK_BILLING=true
+AUTH_DEV_MODE=false
+PORTAL_ENV=development          # Anders blokkeert _no_debug_in_production de boot
+DOMAIN=localhost                 # Anders rejected _check_mock_billing_vs_domain de MOCK_BILLING=true
+MOCK_BILLING=true                # Geen Moneybird vereist
 FRONTEND_URL=http://localhost:5174
 CORS_ORIGINS=http://localhost:5174
 
-# Docker services (match de defaults uit docker-compose.dev.yml)
-REDIS_PASSWORD=klai-dev
-MONGO_ROOT_PASSWORD=klai-dev
-MEILI_MASTER_KEY=klai-dev-meili-key
-LITELLM_MASTER_KEY=sk-litellm-dev-key
-LITELLM_BASE_URL=http://localhost:4000
+# Zitadel — alle waarden komen uit prod /opt/klai/.env. Snelste ophaalmethode:
+#   ssh core-01 'grep -E "^(PORTAL_API_ZITADEL_PAT|PORTAL_API_ZITADEL_PORTAL_CLIENT_SECRET|ZITADEL_PROJECT_ID|ZITADEL_PORTAL_ORG_ID|ZITADEL_PORTAL_CLIENT_ID|ZITADEL_IDP_GOOGLE_ID|ZITADEL_IDP_MICROSOFT_ID)=" /opt/klai/.env'
+# Of via SOPS:
+#   cd klai-infra && SOPS_AGE_KEY_FILE=~/.config/sops/age/keys.txt sops -d core-01/.env.sops | grep '^...'
+ZITADEL_BASE_URL=https://auth.getklai.com
+ZITADEL_PAT=<PORTAL_API_ZITADEL_PAT uit prod>
+ZITADEL_PROJECT_ID=<ZITADEL_PROJECT_ID uit prod>
+ZITADEL_PORTAL_ORG_ID=<ZITADEL_PORTAL_ORG_ID uit prod>
+ZITADEL_PORTAL_CLIENT_ID=<ZITADEL_PORTAL_CLIENT_ID uit prod>     # OIDC client_id van "Klai Portal BFF"
+ZITADEL_PORTAL_CLIENT_SECRET=<PORTAL_API_ZITADEL_PORTAL_CLIENT_SECRET uit prod>
+ZITADEL_IDP_GOOGLE_ID=<ZITADEL_IDP_GOOGLE_ID uit prod>
+ZITADEL_IDP_MICROSOFT_ID=<ZITADEL_IDP_MICROSOFT_ID uit prod>
+
+# Internal service-to-service secrets — kunnen random lokaal zijn (niet prod-waarden!).
+# Local backend praat niet met klai-connector/knowledge-ingest/etc, deze satisfy alleen validators.
+INTERNAL_SECRET=$(python3 -c "import secrets; print(secrets.token_hex(32))")
+KLAI_CONNECTOR_SECRET=$(python3 -c "import secrets; print(secrets.token_hex(32))")
+KNOWLEDGE_INGEST_SECRET=$(python3 -c "import secrets; print(secrets.token_hex(32))")
+RETRIEVAL_API_INTERNAL_SECRET=$(python3 -c "import secrets; print(secrets.token_hex(32))")
+DOCS_INTERNAL_SECRET=$(python3 -c "import secrets; print(secrets.token_hex(32))")
+BFF_SESSION_KEY=$(python3 -c "import secrets; print(secrets.token_hex(32))")
+VEXA_WEBHOOK_SECRET=$(python3 -c "import secrets; print(secrets.token_hex(32))")
+MONEYBIRD_WEBHOOK_TOKEN=$(python3 -c "import secrets; print(secrets.token_hex(32))")
+
+# MCP OAuth — local URLs voldoen voor _require_mcp_oauth_urls
+MCP_OAUTH_ISSUER_BASE_URL=http://localhost:8010
+MCP_OAUTH_RESOURCE_URL=http://localhost:8010
 ```
 
-> **Let op:** `PORTAL_SECRETS_KEY` én `ENCRYPTION_KEY` zijn beide verplicht (beide 64-char hex / 32 bytes). Zonder een van beide crasht de backend met `AES-256 requires a 32-byte key, got 0 bytes`.
+> **Let op (genereerde keys):** `PORTAL_SECRETS_KEY`, `ENCRYPTION_KEY` en `SSO_COOKIE_KEY` zijn alle drie verplicht (32 bytes elk — eerste twee hex-encoded, derde Fernet/urlsafe-base64). `make setup` regelt ze automatisch. Zonder een van de drie crasht de backend met bv. `AES-256 requires a 32-byte key, got 0 bytes`.
+
+> **Waarom 8 random secrets voor `_require_*`?** Sinds SPEC-SEC-VALIDATOR-COVERAGE-001 weigert de backend te booten als een service-to-service Bearer-token leeg is (anders fail-open auth). Lokaal is dat overdreven maar onomzeilbaar — de validators kennen geen "ik draai local"-mode. Random local strings is fine; ze worden alleen gebruikt als outbound auth header naar services die we niet draaien.
+
+> **Var-naam mismatch in `.env.example`:** Een eerdere versie van de template noemde `ZITADEL_PORTAL_APP_ID` — die var wordt nergens door de backend gelezen. De pydantic-settings field heet `zitadel_portal_client_id` → env-var `ZITADEL_PORTAL_CLIENT_ID`. Negeer een legacy `ZITADEL_PORTAL_APP_ID=` regel als je 'm tegenkomt.
 
 ### Stap 3: Frontend (klai-portal/frontend/.env.local)
 
-Open `klai-portal/frontend/.env.local` en vul in:
+`make setup` kopieert `.env.local.example`. Voor **Mode C (standalone)** is de default goed. Voor **Mode B (productie Zitadel)**, vervang met:
 
 ```bash
-# Echte Zitadel authenticatie
+VITE_AUTH_DEV_MODE=false
 VITE_OIDC_AUTHORITY=https://auth.getklai.com
-VITE_OIDC_CLIENT_ID=<oidc-client-id>
-```
-
-De Vite proxy stuurt `/api` calls standaard door naar productie (`getklai.getklai.com`). Om tegen de lokale backend te ontwikkelen (Modus B), voeg toe:
-
-```bash
-# Alleen voor full-stack mode: stuur /api naar lokale backend
+VITE_OIDC_CLIENT_ID=<ZITADEL_PORTAL_CLIENT_ID uit prod>
 VITE_API_PROXY_TARGET=http://localhost:8010
 ```
 
-> **Let op:** De `VITE_OIDC_CLIENT_ID` is `<oidc-client-id>` (OIDC Client ID), **niet** `<zitadel-app-id>` (dat is de App ID). Deze staan apart in Zitadel.
+> **Let op:** `VITE_OIDC_CLIENT_ID` is de **OIDC Client ID** van de "Klai Portal BFF" app (huidige BFF-pattern sinds SPEC-AUTH-008). Die waarde leeft NIET in dit runbook — haal 'm uit prod via `ssh core-01 'grep ZITADEL_PORTAL_CLIENT_ID /opt/klai/.env'`. Verwar 'm niet met de Zitadel App ID (intern identifier, niet de waarde die de browser gebruikt). Een oudere versie van dit runbook gebruikte een pre-BFF client_id — die heeft de signin-knop allang vervangen.
 
 > **Vite herstart vereist bij env-wijzigingen:** In tegenstelling tot de backend pikt Vite `.env.local` wijzigingen pas op na een volledige herstart (`Ctrl+C` → `npm run dev`). Hot reload werkt niet voor env vars.
 
@@ -317,24 +353,85 @@ SOPS_AGE_KEY_FILE=~/.config/sops/age/keys.txt \
 2. Projects > **Klai Platform** > Applications > **Klai Portal**
 3. Kopieer de **Client ID**
 
-### Redirect URIs en Dev Mode (al geconfigureerd)
+### Redirect URIs en Dev Mode
 
-De OIDC app "Klai Portal" (app ID `<zitadel-app-id>`) is al geconfigureerd voor lokale development:
+De OIDC app **"Klai Portal BFF"** (post-SPEC-AUTH-008 BFF-pattern) heeft per default alleen prod-redirect-URIs. Voor lokale Mode B moet `http://localhost:5174/api/auth/oidc/callback` toegevoegd zijn aan `redirectUris`.
 
-- **Redirect URI:** `http://localhost:5174/callback`
-- **Post Logout URI:** `http://localhost:5174/logged-out`
-- **Allowed Origin:** `http://localhost:5174`
-- **Dev Mode:** ingeschakeld (vereist voor `http://` redirect URIs)
+Ophalen van project_id + app_id (eenmalig, in shell):
+```bash
+PAT=$(grep '^ZITADEL_PAT=' klai-portal/backend/.env | cut -d= -f2-)
+PROJ=$(grep '^ZITADEL_PROJECT_ID=' klai-portal/backend/.env | cut -d= -f2-)
+APP=$(curl -s -H "Authorization: Bearer $PAT" -H 'Content-Type: application/json' \
+  "https://auth.getklai.com/management/v1/projects/$PROJ/apps/_search" -d '{}' \
+  | python3 -c "import json,sys; [print(a['id']) for a in json.load(sys.stdin).get('result',[]) if 'BFF' in a.get('name','')]")
+echo "PROJ=$PROJ APP=$APP"
+```
 
-> **Zitadel Dev Mode** staat `http://` (zonder TLS) toe als redirect URI. Zonder Dev Mode accepteert Zitadel alleen `https://` URIs. Dev Mode is al ingeschakeld op de Klai Portal app — je hoeft hier niets voor te doen.
+Verifieer huidige config:
+```bash
+curl -s -H "Authorization: Bearer $PAT" \
+  "https://auth.getklai.com/management/v1/projects/$PROJ/apps/$APP" \
+  | python3 -c "import json,sys; d=json.load(sys.stdin)['app']['oidcConfig']; \
+  print('redirectUris:', d.get('redirectUris')); \
+  print('postLogoutRedirectUris:', d.get('postLogoutRedirectUris')); \
+  print('devMode:', d.get('devMode'))"
+```
 
-**Als Dev Mode per ongeluk is uitgeschakeld:**
-1. Ga naar [auth.getklai.com/ui/console](https://auth.getklai.com/ui/console)
-2. Projects > **Klai Platform** > Applications > **Klai Portal**
-3. Onder **OIDC Configuration**, zet de **Dev Mode** toggle aan
-4. Sla op
+Verwacht:
+- `redirectUris` bevat `http://localhost:5174/api/auth/oidc/callback`
+- `postLogoutRedirectUris` bevat `http://localhost:5174/logged-out`
+- `devMode: True`
 
-> **Let op:** De redirect URIs zijn zichtbaar in productie maar vormen geen beveiligingsrisico — Zitadel valideert dat de callback URL overeenkomt met de geregistreerde URIs.
+**Als één van de drie ontbreekt** (eerste keer dat iemand Mode B doet op een schone Zitadel-app):
+
+Optie 1 — Via Console (handmatig, één-malig):
+1. [auth.getklai.com/ui/console](https://auth.getklai.com/ui/console) → Projects → **Klai Platform** → Applications → **Klai Portal BFF**
+2. Tab **Redirect URIs** → voeg toe `http://localhost:5174/api/auth/oidc/callback`
+3. Tab **Post Logout URIs** → voeg toe `http://localhost:5174/logged-out`
+4. Onder **OIDC Configuration** → toggle **Dev Mode** aan (vereist voor `http://`)
+5. Save
+
+Optie 2 — Via Management API (idempotent script — `PAT`, `PROJ`, `APP` als hierboven gezet):
+```bash
+# Backup huidige config (kun je gebruiken om terug te draaien)
+curl -s -H "Authorization: Bearer $PAT" \
+  "https://auth.getklai.com/management/v1/projects/$PROJ/apps/$APP" \
+  > /tmp/zitadel-app-backup.json
+
+# Bouw nieuwe config + push
+python3 <<'PY' > /tmp/zitadel-put-body.json
+import json
+d = json.load(open('/tmp/zitadel-app-backup.json'))
+c = d['app']['oidcConfig']
+body = {
+    "redirectUris": sorted(set(c.get('redirectUris', []) + ['http://localhost:5174/api/auth/oidc/callback'])),
+    "responseTypes": c.get('responseTypes', ['OIDC_RESPONSE_TYPE_CODE']),
+    "grantTypes": c.get('grantTypes', []),
+    "appType": "OIDC_APP_TYPE_WEB",
+    "authMethodType": c.get('authMethodType', 'OIDC_AUTH_METHOD_TYPE_POST'),
+    "postLogoutRedirectUris": sorted(set(c.get('postLogoutRedirectUris', []) + ['http://localhost:5174/logged-out'])),
+    "version": "OIDC_VERSION_1_0",
+    "devMode": True,
+    "accessTokenType": c.get('accessTokenType', 'OIDC_TOKEN_TYPE_JWT'),
+    "accessTokenRoleAssertion": c.get('accessTokenRoleAssertion', True),
+    "idTokenRoleAssertion": c.get('idTokenRoleAssertion', True),
+    "idTokenUserinfoAssertion": c.get('idTokenUserinfoAssertion', True),
+    "clockSkew": c.get('clockSkew', '0s'),
+    "additionalOrigins": [],
+}
+print(json.dumps(body))
+PY
+
+curl -s -X PUT -H "Authorization: Bearer $PAT" -H 'Content-Type: application/json' \
+  "https://auth.getklai.com/management/v1/projects/$PROJ/apps/$APP/oidc_config" \
+  -d @/tmp/zitadel-put-body.json
+```
+
+Het script is idempotent — herhaalde runs zetten dezelfde state.
+
+> **Waarom devMode aan moet:** Zitadel weigert per default `http://` redirect URIs te registreren (TLS-only). devMode loosens dat ALLEEN voor de registratie-lijst — exact-match validatie op authorize-tijd is ongewijzigd. Risk: aanvaller met de prod client_id kan een redirect uitlokken naar `http://localhost:5174/api/auth/oidc/callback`, maar landt alleen op de loopback van het slachtoffer zelf (bounded, niet exfiltrerend).
+
+> **Productie-impact:** geen. De bestaande prod URIs (`https://dev.getklai.com/...`, `https://my.getklai.com/...`) blijven onveranderd in de lijst.
 
 ---
 
@@ -343,7 +440,7 @@ De OIDC app "Klai Portal" (app ID `<zitadel-app-id>`) is al geconfigureerd voor 
 | Commando | Omschrijving |
 |----------|-------------|
 | `make help` | Toon alle beschikbare targets |
-| `make setup` | Eerste setup: kopieer env files, installeer dependencies |
+| `make setup` | Eerste setup: kopieer env files, genereer encryption keys, installeer dependencies |
 | `make dev-up` | Start Docker services |
 | `make dev-down` | Stop Docker services (data blijft behouden) |
 | `make dev-reset` | Stop services EN verwijder alle data (schone start) |
@@ -352,8 +449,14 @@ De OIDC app "Klai Portal" (app ID `<zitadel-app-id>`) is al geconfigureerd voor 
 | `make backend` | Start FastAPI backend met hot reload (:8010) |
 | `make frontend` | Start Vite dev server (:5174) |
 | `make migrate` | Draai Alembic database migraties |
+| `make postdeploy` | Apply post-deploy SQL files (RLS policies + helper functies, klai-superuser) |
+| `make seed` | Seed demo-data (dev org + users) in lokale DB |
 | `make lint` | Draai linters (ruff + eslint) |
 | `make check` | Draai type checks (pyright + tsc) |
+
+> **Compose project name = working directory naam.** Docker Compose leidt de project name af van `pwd` als geen `COMPOSE_PROJECT_NAME` is gezet. Containers krijgen daardoor namen als `<dir>-postgres-1`, `<dir>-redis-1`, etc. In de canonical `klai/` checkout zijn dat `klai-postgres-1`; in een Conductor workspace `brisbane/` zijn dat `brisbane-postgres-1`. Voorbeelden in dit runbook (zoals seed-SQL) gebruiken `klai-*` — vervang dat met `$(docker ps --format '{{.Names}}' | grep postgres-1)` als je in een ander-dir-naam checkout zit.
+
+> **Parallelle Conductor workspaces**: omdat de compose project name dir-gebaseerd is, krijg je per workspace een eigen container-set. Twee workspaces tegelijk `make dev-up` doen werkt — geen naam-conflicten — maar wel poort-conflicten op 5174/8010/5434/etc. Stop de containers in workspace A vóór je `make dev-up` doet in workspace B, of edit `docker-compose.dev.yml` om andere host-ports te bindeneren.
 
 ---
 
@@ -372,17 +475,50 @@ lsof -nP -iTCP:5434 -sTCP:LISTEN
 
 > **Opmerking:** Klai dev gebruikt poort **5434** (niet de standaard 5432) om conflicten met andere lokale PostgreSQL instances te voorkomen.
 
-### Backend start mislukt: "ZITADEL_PAT required" of "AES-256 requires a 32-byte key"
+### `make setup` faalt op verse macOS met `No module named 'cryptography'`
 
-De `.env` file mist verplichte velden. Controleer:
-```bash
-grep -E '^(ZITADEL_PAT|DATABASE_URL|PORTAL_SECRETS_KEY|ENCRYPTION_KEY|SSO_COOKIE_KEY)=' klai-portal/backend/.env
+Symptoom:
+```
+==> Copying environment files...
+  Generating encryption keys...
+Traceback (most recent call last):
+  ModuleNotFoundError: No module named 'cryptography'
+make: *** [setup] Error 1
 ```
 
-Alle vijf moeten een waarde hebben. `PORTAL_SECRETS_KEY` en `ENCRYPTION_KEY` zijn beide 64-char hex strings (32 bytes). Genereer met:
+Oorzaak: het `setup`-target roept `python3 -c "from cryptography.fernet import Fernet; ..."` om `SSO_COOKIE_KEY` te genereren. macOS' systeem-`python3` (3.9) heeft `cryptography` niet uit de doos.
+
+Workaround (één keer): genereer de drie keys handmatig met alleen stdlib + sed ze in `.env`:
 ```bash
-cd klai-portal/backend && uv run python -c "import secrets; print(secrets.token_hex(32))"
+cd klai-portal/backend
+SECRETS_KEY=$(python3 -c "import secrets; print(secrets.token_hex(32))")
+ENCRYPT_KEY=$(python3 -c "import secrets; print(secrets.token_hex(32))")
+COOKIE_KEY=$(python3 -c "import base64, os; print(base64.urlsafe_b64encode(os.urandom(32)).decode())")
+sed -i.bak "s|^PORTAL_SECRETS_KEY=.*|PORTAL_SECRETS_KEY=$SECRETS_KEY|" .env
+sed -i.bak "s|^ENCRYPTION_KEY=.*|ENCRYPTION_KEY=$ENCRYPT_KEY|" .env
+sed -i.bak "s|^SSO_COOKIE_KEY=.*|SSO_COOKIE_KEY=$COOKIE_KEY|" .env
+rm -f .env.bak
 ```
+Vervolgens `cd .. && uv sync` en `cd frontend && npm install` om de rest van setup af te ronden.
+
+Strukturele fix (nog uit te voeren): Makefile `setup`-target moet stdlib-only zijn — Fernet keys zijn 32 random bytes urlsafe-base64 encoded, identiek aan wat `Fernet.generate_key()` returnt.
+
+### Backend start mislukt: "ZITADEL_PAT required" / "AES-256 requires a 32-byte key" / "Missing required: <X>_SECRET"
+
+De `.env` file mist verplichte velden. Sinds SPEC-SEC-VALIDATOR-COVERAGE-001 zijn er veel meer fail-closed validators dan de oude vijf. Run de complete check:
+```bash
+cd klai-portal/backend
+for v in ZITADEL_PAT DATABASE_URL PORTAL_SECRETS_KEY ENCRYPTION_KEY SSO_COOKIE_KEY \
+         INTERNAL_SECRET KLAI_CONNECTOR_SECRET KNOWLEDGE_INGEST_SECRET \
+         RETRIEVAL_API_INTERNAL_SECRET DOCS_INTERNAL_SECRET BFF_SESSION_KEY \
+         VEXA_WEBHOOK_SECRET MONEYBIRD_WEBHOOK_TOKEN \
+         MCP_OAUTH_ISSUER_BASE_URL MCP_OAUTH_RESOURCE_URL \
+         PORTAL_ENV DOMAIN; do
+  v=$(grep "^${v}=" .env | cut -d= -f2-)
+  [ -z "$v" ] && echo "MISSING: $v"
+done
+```
+Elk MISSING-veld geeft een specifieke validator-error bij boot. Random hex (`python3 -c "import secrets; print(secrets.token_hex(32))"`) is goed voor alle `*_SECRET` velden in Mode B local-dev — ze worden alleen gebruikt voor service-to-service auth headers naar services die we lokaal niet draaien.
 
 ### Frontend login redirect mislukt: "Errors.App.NotFound"
 
@@ -424,6 +560,53 @@ make dev-logs       # Bekijk LiteLLM logs
 ```
 
 Als PostgreSQL niet start, controleer of poort 5434 vrij is.
+
+### `make migrate` faalt op fresh DB met `column "visibility" of relation "portal_knowledge_bases" does not exist`
+
+**Symptoom:** Eerste `make migrate` na `make dev-reset` faalt halverwege. Hele upgrade-transactie rolt terug, `alembic_version` blijft leeg, DB heeft geen tabellen.
+
+**Oorzaak:** Een migratie (`z3a4b5c6d7e8_backfill_default_kbs.py`) doet INSERT met forward-column-referenties naar kolommen (`visibility`, `docs_enabled`, `owner_type`) die pas door latere migraties worden toegevoegd. Op prod werkte het ooit omdat de chain historisch via parallelle branches landde — op fresh install klopt de topologische volgorde niet. Default KBs worden inmiddels lazy gemaakt door `app.services.default_knowledge_bases`, dus de migratie-backfill is overbodig op nieuwe installs.
+
+**Fix:** de migratie is in main aangepast tot een no-op `upgrade()` (met behouden `downgrade()`). Pull main / rebase op een tip die deze fix bevat.
+
+### `make migrate` faalt op fresh DB met `constraint "portal_users_zitadel_user_id_key" of relation "portal_users" does not exist`
+
+**Oorzaak:** `c3d4e5f6g7h8_portal_users_multi_org.py` deed `op.drop_constraint(...)` op een constraint-naam die alleen historisch op prod bestond (parent migratie creëert het als unique INDEX, niet als CONSTRAINT). Fresh installs hebben de constraint nooit gehad → drop faalt.
+
+**Fix:** in main is de `drop_constraint(...)` vervangen door `op.execute("ALTER TABLE portal_users DROP CONSTRAINT IF EXISTS portal_users_zitadel_user_id_key")` — idempotent op beide states. Pull main.
+
+### `make migrate` faalt met `role "portal_api" does not exist` of `role "grafana_reader" does not exist`
+
+**Oorzaak:** Migraties referencen Postgres-rollen die in prod door provisioning worden aangemaakt maar in `dev/postgres-init.sql` niet werden gecreëerd.
+
+**Fix:** in main creëert `dev/postgres-init.sql` deze rollen automatisch op DB-init (NOLOGIN — ze hoeven lokaal niets te kunnen, alleen bestaan zodat GRANT-statements parsen). Vereist `make dev-reset` om opnieuw te initialiseren als je een DB had vóór de fix.
+
+### Post-deploy SQL faalt op fresh DB met `function public._rls_current_org_id() does not exist`
+
+**Oorzaak:** `scripts/apply_post_deploy_sql.sh` applieert files alfabetisch. `post_deploy_85e5d0a7cb98_kb_uploads_rls.sql` gebruikt de helper `_rls_current_org_id()`, maar die wordt aangemaakt door `post_deploy_rls_raise_on_missing_context.sql` — alfabetisch later. Op prod werkt het omdat de helper al door een eerdere deploy aangemaakt is.
+
+**Workaround (totdat helper-script `--local` mode + dependency-aware ordering krijgt):**
+```bash
+cd klai-portal/backend
+# 1. Bootstrap de helper-functie EERST:
+docker exec -i $(docker ps --format '{{.Names}}' | grep postgres-1 | head -1) psql -U klai -d klai \
+  -v ON_ERROR_STOP=1 < alembic/versions/post_deploy_rls_raise_on_missing_context.sql
+# 2. Daarna alfabetisch alle post-deploy SQLs (rls_raise loopt nog een keer idempotent):
+for f in alembic/versions/post_deploy_*.sql; do
+  [[ "$(basename "$f")" == *_rollback_* ]] && continue
+  docker exec -i $(docker ps --format '{{.Names}}' | grep postgres-1 | head -1) psql -U klai -d klai -v ON_ERROR_STOP=1 < "$f" || break
+done
+```
+
+Een proper `make postdeploy` target met deze logica wordt toegevoegd in de runbook-PR.
+
+### Mode B: login redirect blijft hangen op `my.getklai.com/login` of belandt op `voys.getklai.com/app`
+
+**Symptoom:** Na clicking "Log in" op `localhost:5174` open je `my.getklai.com/login?authRequest=...`, daarna land je op `voys.getklai.com/app` in plaats van `localhost:5174/app`. Backend logs tonen geen `/api/auth/oidc/callback` request.
+
+**Oorzaak:** Je browser heeft een actieve prod-`klai_sso` cookie op `my.getklai.com` (van eerder inloggen op productie). De Zitadel login-UI doet `POST /api/auth/sso-complete` met dat cookie en finalizet de authRequest server-side via prod-backend. De returned `callback_url` zou `http://localhost:5174/...` moeten zijn maar de mixed-content + cross-origin race in Chrome breekt de hop.
+
+**Fix:** test Mode B in een **incognito-venster** (of een browser-profiel zonder prod-Klai-session). De flow werkt schoon zonder de prod-SSO-hijack. Voor regulier dev-gebruik: blijf in Mode C — die heeft dit probleem niet.
 
 ### Database migratie mislukt: "Multiple head revisions"
 
@@ -547,3 +730,23 @@ Als de redirect mislukt, controleer:
 - [klai-portal/backend/.env.example](../../klai-portal/backend/.env.example) — Backend environment template
 - [klai-portal/frontend/.env.local.example](../../klai-portal/frontend/.env.local.example) — Frontend environment template
 - [docker-compose.dev.yml](../../docker-compose.dev.yml) — Docker Compose configuratie
+- [dev/postgres-init.sql](../../dev/postgres-init.sql) — Postgres init script (creëert klai DB + litellm DB + portal_api/grafana_reader rollen)
+
+---
+
+## Changelog — local-dev verificatie 2026-05-13
+
+End-to-end fresh-install run met OrbStack + uv + npm onthulde 8 issues die het runbook (of de tooling) blokkeerden. Onderstaand wat is/wordt opgelost:
+
+| # | Issue | Resolutie |
+|---|---|---|
+| 1 | `make setup` faalt op verse macOS zonder system-`cryptography` (`SSO_COOKIE_KEY`-stap crasht) | Runbook: workaround in troubleshooting. Tooling: Makefile moet stdlib-only (`base64.urlsafe_b64encode(os.urandom(32))`) — open follow-up. |
+| 2 | Migratie `z3a4b5c6d7e8_backfill_default_kbs.py` INSERT met forward-column refs blokkeert fresh-DB upgrade | Upgrade-body no-op gemaakt; defaults gaan via lazy `app.services.default_knowledge_bases`. |
+| 3 | Migratie `c3d4e5f6g7h8_portal_users_multi_org.py` `drop_constraint(...)` faalt op fresh DB | `DROP CONSTRAINT IF EXISTS` via raw SQL. |
+| 4 | `dev/postgres-init.sql` miste `portal_api` + `grafana_reader` rollen | Beide toegevoegd als `NOLOGIN`. |
+| 5 | `apply_post_deploy_sql.sh` SSH-only naar core-01; alfabetische volgorde dependency-broken | Workaround in troubleshooting; nette `make postdeploy` + `--local` flag in follow-up. |
+| 6 | `.env.example` had verouderde var-naam `ZITADEL_PORTAL_APP_ID` (backend leest `_CLIENT_ID`) | Runbook explicit; .env.example update in follow-up. |
+| 7 | Mode B vereist 14+ env vars meer dan de 5 die het runbook noemde (`INTERNAL_SECRET`, `KLAI_CONNECTOR_SECRET`, `BFF_SESSION_KEY`, `MCP_OAUTH_*`, etc.) | Complete lijst in Stap 2; troubleshoot-blok met grep-checker. |
+| 8 | Zitadel "Klai Portal BFF" app had geen `localhost` redirect URI + devMode uit | Toegevoegd via Management API (een-malig); script in "Redirect URIs en Dev Mode". |
+
+Plus drie kleinere runbook-bugs gefixt: seed `provisioning_status` moet `'ready'` zijn (niet `'complete'`), `portal_users` heeft geen `updated_at` kolom, en de unique constraint is `(zitadel_user_id, org_id)` sinds multi-org support.

--- a/klai-portal/backend/.env.example
+++ b/klai-portal/backend/.env.example
@@ -3,6 +3,11 @@
 # Two modes available:
 #   Mode C (Standalone) — default, no external access needed
 #   Mode A/B (Production Zitadel) — for core developers with Zitadel access
+#
+# `make setup` copies this file to .env and auto-generates the three
+# encryption keys below using stdlib only (no `cryptography` import).
+# All other placeholders are kept as-is — fill them in manually only when
+# switching to Mode A/B.
 
 # ── Database ────────────────────────────────────────────────────────────────
 DATABASE_URL=postgresql+asyncpg://klai:klai-dev@localhost:5434/klai
@@ -11,25 +16,58 @@ DATABASE_URL=postgresql+asyncpg://klai:klai-dev@localhost:5434/klai
 # No Zitadel, no Moneybird, no external dependencies.
 # Backend auto-creates a dev org + user on first start.
 DEBUG=true
+PORTAL_ENV=development
+DOMAIN=localhost
 AUTH_DEV_MODE=true
 AUTH_DEV_USER_ID=dev-user-1
 MOCK_BILLING=true
 FRONTEND_URL=http://localhost:5174
 CORS_ORIGINS=http://localhost:5174
 
-# Encryption keys — `make setup` generates these automatically.
-# To regenerate manually: openssl rand -hex 32 (for PORTAL_SECRETS_KEY and ENCRYPTION_KEY)
-# For SSO_COOKIE_KEY: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+# Encryption keys — `make setup` generates these automatically (stdlib only).
+# Manual regen if needed:
+#   PORTAL_SECRETS_KEY / ENCRYPTION_KEY:  openssl rand -hex 32
+#   SSO_COOKIE_KEY:                       python3 -c "import base64, os; print(base64.urlsafe_b64encode(os.urandom(32)).decode())"
 PORTAL_SECRETS_KEY=REPLACE_ME_RUN_MAKE_SETUP
 ENCRYPTION_KEY=REPLACE_ME_RUN_MAKE_SETUP
 SSO_COOKIE_KEY=REPLACE_ME_RUN_MAKE_SETUP
 
-# Zitadel placeholder (not used in dev mode, but config requires non-empty)
+# Zitadel placeholders (not used in Mode C, but config requires non-empty).
+# Backend Settings field is `zitadel_portal_client_id` — env var is
+# ZITADEL_PORTAL_CLIENT_ID (NOT ZITADEL_PORTAL_APP_ID, which a previous
+# template version named incorrectly — Settings doesn't read that var).
 ZITADEL_BASE_URL=http://localhost:8080
 ZITADEL_PAT=not-needed-in-dev-mode
 ZITADEL_PROJECT_ID=000000000000000000
-ZITADEL_PORTAL_APP_ID=000000000000000000
 ZITADEL_PORTAL_ORG_ID=000000000000000000
+ZITADEL_PORTAL_CLIENT_ID=000000000000000000
+ZITADEL_PORTAL_CLIENT_SECRET=not-needed-in-dev-mode
+ZITADEL_IDP_GOOGLE_ID=000000000000000000
+ZITADEL_IDP_MICROSOFT_ID=000000000000000000
+
+# Internal service-to-service Bearer secrets — `make setup` does NOT
+# generate these. Mode C local-dev doesn't talk to other Klai services
+# so any non-empty value satisfies the fail-closed validators (see
+# SPEC-SEC-VALIDATOR-COVERAGE-001). For Mode B local-dev, generate
+# random hex per field (NOT prod values):
+#   for v in INTERNAL_SECRET KLAI_CONNECTOR_SECRET KNOWLEDGE_INGEST_SECRET \
+#            RETRIEVAL_API_INTERNAL_SECRET DOCS_INTERNAL_SECRET BFF_SESSION_KEY \
+#            VEXA_WEBHOOK_SECRET MONEYBIRD_WEBHOOK_TOKEN; do
+#     printf "%s=%s\n" "$v" "$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+#   done
+INTERNAL_SECRET=not-needed-in-dev-mode
+KLAI_CONNECTOR_SECRET=not-needed-in-dev-mode
+KNOWLEDGE_INGEST_SECRET=not-needed-in-dev-mode
+RETRIEVAL_API_INTERNAL_SECRET=not-needed-in-dev-mode
+DOCS_INTERNAL_SECRET=not-needed-in-dev-mode
+BFF_SESSION_KEY=not-needed-in-dev-mode
+VEXA_WEBHOOK_SECRET=not-needed-in-dev-mode
+MONEYBIRD_WEBHOOK_TOKEN=not-needed-in-dev-mode
+
+# MCP OAuth — point at the local backend (loopback URLs satisfy
+# _require_mcp_oauth_urls without requiring a real OAuth server).
+MCP_OAUTH_ISSUER_BASE_URL=http://localhost:8010
+MCP_OAUTH_RESOURCE_URL=http://localhost:8010
 
 # Docker service passwords (match docker-compose.dev.yml defaults)
 REDIS_PASSWORD=klai-dev
@@ -39,16 +77,32 @@ LITELLM_MASTER_KEY=sk-litellm-dev-key
 LITELLM_BASE_URL=http://localhost:4000
 
 # ── Mode A/B: Production Zitadel (core developers only) ───────────────────
-# Uncomment below and comment out Mode C auth settings above.
+# To switch to Mode B (full-stack with real Zitadel auth):
+#   1. Flip the auth toggles at the top of this file:
+#        AUTH_DEV_MODE=false   (was true)
+#        DEBUG=true            (keep — required for richer error messages)
+#        PORTAL_ENV=development (keep — _no_debug_in_production blocks otherwise)
+#        DOMAIN=localhost       (keep — MOCK_BILLING vs domain validator)
+#   2. Replace the Zitadel placeholders above with real values. Fetch
+#      them once from prod (do NOT commit):
+#        ssh core-01 'grep -E "^(PORTAL_API_ZITADEL_PAT|PORTAL_API_ZITADEL_PORTAL_CLIENT_SECRET|ZITADEL_PROJECT_ID|ZITADEL_PORTAL_ORG_ID|ZITADEL_PORTAL_CLIENT_ID|ZITADEL_IDP_GOOGLE_ID|ZITADEL_IDP_MICROSOFT_ID)=" /opt/klai/.env'
+#      Or via SOPS:
+#        cd klai-infra && SOPS_AGE_KEY_FILE=~/.config/sops/age/keys.txt sops -d core-01/.env.sops
+#      Note: prod env-var is PORTAL_API_ZITADEL_PORTAL_CLIENT_SECRET; here
+#      it must be named ZITADEL_PORTAL_CLIENT_SECRET (compose drops the
+#      PORTAL_API_ prefix when forwarding to the container).
+#   3. Random hex (NOT prod) for the eight *_SECRET / *_TOKEN values above.
+#   4. Ensure the Zitadel "Klai Portal BFF" app has these registered:
+#        - redirectUris contains http://localhost:5174/api/auth/oidc/callback
+#        - postLogoutRedirectUris contains http://localhost:5174/logged-out
+#        - devMode = true
+#      See docs/runbooks/local-dev.md § "Redirect URIs en Dev Mode" for
+#      the idempotent Management-API script.
+#   5. For Mode A (frontend-only, no local backend): also leave
+#      VITE_API_PROXY_TARGET unset in frontend/.env.local so the Vite
+#      proxy routes /api to production instead of localhost:8010.
 #
-# DEBUG=false
-# AUTH_DEV_MODE=false
-# ZITADEL_BASE_URL=https://auth.getklai.com
-# ZITADEL_PAT=          # Get from team or: sops -d klai-infra/core-01/.env.sops | grep PORTAL_API_ZITADEL_PAT
-# ZITADEL_PROJECT_ID=<zitadel-project-id>
-# ZITADEL_PORTAL_APP_ID=<zitadel-portal-app-id>
-# ZITADEL_PORTAL_ORG_ID=<zitadel-org-id>
-# MOCK_BILLING=false
-# MONEYBIRD_API_TOKEN=   # Personal API token from Moneybird
+# Moneybird (only when MOCK_BILLING=false — admin/staging only):
+# MONEYBIRD_API_TOKEN=<personal token from Moneybird>
 # MONEYBIRD_ADMIN_ID=<moneybird-admin-id>
-# MONEYBIRD_WEBHOOK_TOKEN=   # openssl rand -hex 32
+# MONEYBIRD_WEBHOOK_TOKEN=<openssl rand -hex 32>

--- a/klai-portal/backend/alembic/versions/c3d4e5f6g7h8_portal_users_multi_org.py
+++ b/klai-portal/backend/alembic/versions/c3d4e5f6g7h8_portal_users_multi_org.py
@@ -14,9 +14,25 @@ depends_on = None
 
 
 def upgrade() -> None:
-    # Drop the old global unique constraint on zitadel_user_id
+    # Drop the old global unique on zitadel_user_id.
+    #
+    # The parent migration `d64fdcfecf32_create_portal_orgs_and_portal_users`
+    # creates uniqueness via `op.create_index(..., unique=True)` (a UNIQUE
+    # INDEX, tracked in pg_indexes), but production also has a UNIQUE
+    # CONSTRAINT named `portal_users_zitadel_user_id_key` (tracked in
+    # pg_constraint) that was either added via a parallel SPEC branch or
+    # manually before this migration ran in 2026-04-16. On fresh installs
+    # only the index exists — the constraint never did — so the original
+    # `op.drop_constraint(...)` raised `UndefinedObjectError` and rolled
+    # back the entire `alembic upgrade head` transaction.
+    #
+    # Fix: use raw SQL with `DROP CONSTRAINT IF EXISTS`, idempotent on
+    # both prod (drops the constraint) and fresh installs (no-op). The
+    # unique INDEX drop below still removes the underlying uniqueness.
+    # See `docs/runbooks/local-dev.md` troubleshooting + pitfall
+    # `alembic-multi-pr-head-split` in `.claude/rules/klai/pitfalls/process-rules.md`.
     op.drop_index("ix_portal_users_zitadel_user_id", table_name="portal_users")
-    op.drop_constraint("portal_users_zitadel_user_id_key", table_name="portal_users", type_="unique")
+    op.execute("ALTER TABLE portal_users DROP CONSTRAINT IF EXISTS portal_users_zitadel_user_id_key")
 
     # Add composite unique constraint: one user per org
     op.create_unique_constraint(

--- a/klai-portal/backend/alembic/versions/z3a4b5c6d7e8_backfill_default_kbs.py
+++ b/klai-portal/backend/alembic/versions/z3a4b5c6d7e8_backfill_default_kbs.py
@@ -1,8 +1,45 @@
-"""backfill default org + personal KBs for existing tenants
+"""backfill default org + personal KBs for existing tenants (no-op since 2026-05-13)
 
 Revision ID: z3a4b5c6d7e8
 Revises: z2a3b4c5d6e7
 Create Date: 2026-04-13
+
+This migration originally backfilled default 'org' and 'personal-{user_id}'
+knowledge-base rows for every existing tenant when SPEC-KB-AND-DOCS-LIBRARIES
+landed (2026-04-13). The INSERT references columns ``visibility``,
+``docs_enabled``, ``owner_type``, ``default_org_role``, ``owner_user_id`` —
+those columns are added by LATER migrations in the chain, not by
+``z2a3b4c5d6e7_add_kb_and_docs_libraries`` (its parent). Postgres parses the
+whole INSERT against the schema-at-execution-time, so on a strict topological
+upgrade ``alembic upgrade head`` from an empty DB this migration raised
+``UndefinedColumnError: column "visibility" of relation "portal_knowledge_bases"
+does not exist`` and rolled back the entire upgrade transaction.
+
+Production was never affected because the chain was different when each
+SPEC-branch landed — by the time this revision ran on prod, the later
+column-adding migrations had already been applied from a parallel branch.
+The bug was only visible on fresh installs, which only became a use-case
+after SPEC-LOCAL-DEV-001 (2026-05-13) shipped ``make migrate`` in the
+standalone local-dev runbook.
+
+Fix: convert ``upgrade()`` to a no-op. Justification:
+
+  1. Prod's alembic_version is far past z3a4b5c6d7e8; this revision is never
+     re-run there.
+  2. Fresh installs have zero rows in ``portal_orgs`` / ``portal_users``, so
+     the original INSERTs would have produced zero rows regardless.
+  3. Default KBs for newly-created orgs/users are created lazily by the
+     application via ``app.services.default_knowledge_bases``:
+       - ``resolve_org_kb`` → ``create_default_org_kb`` (4 call-sites)
+       - ``resolve_personal_kb`` → ``create_default_personal_kb``
+     so no backfill is needed on signup/seed paths.
+  4. ``downgrade()`` is preserved as-is — it only references ``slug``, a
+     column that exists from the parent migration ``z2a3b4c5d6e7``.
+
+See ``.claude/rules/klai/pitfalls/process-rules.md`` →
+``alembic-multi-pr-head-split`` for the pattern that caused the original
+forward-column-reference, and the runbook
+``docs/runbooks/local-dev.md`` troubleshooting section.
 """
 
 from alembic import op
@@ -14,67 +51,14 @@ depends_on = None
 
 
 def upgrade() -> None:
-    # 1. Create org KB for every org that doesn't have one yet
-    op.execute("""
-        INSERT INTO portal_knowledge_bases
-            (org_id, name, slug, created_by, visibility, docs_enabled, owner_type, default_org_role)
-        SELECT
-            o.id,
-            'Organisatiekennis',
-            'org',
-            COALESCE((SELECT u.zitadel_user_id FROM portal_users u WHERE u.org_id = o.id LIMIT 1), 'system'),
-            'internal',
-            false,
-            'org',
-            'viewer'
-        FROM portal_orgs o
-        WHERE NOT EXISTS (
-            SELECT 1 FROM portal_knowledge_bases kb
-            WHERE kb.org_id = o.id AND kb.slug = 'org'
-        )
-    """)
-
-    # 2. Create personal-{user_id} KB for every user that doesn't have one yet
-    op.execute("""
-        INSERT INTO portal_knowledge_bases
-            (org_id, name, slug, created_by, visibility, docs_enabled, owner_type, owner_user_id)
-        SELECT
-            u.org_id,
-            'Persoonlijk',
-            'personal-' || u.zitadel_user_id,
-            u.zitadel_user_id,
-            'internal',
-            false,
-            'user',
-            u.zitadel_user_id
-        FROM portal_users u
-        WHERE NOT EXISTS (
-            SELECT 1 FROM portal_knowledge_bases kb
-            WHERE kb.org_id = u.org_id AND kb.slug = 'personal-' || u.zitadel_user_id
-        )
-    """)
-
-    # 3. Clean up legacy: if a KB with slug='personal' exists (from old lazy-create),
-    #    rename it to personal-{owner_user_id} if owner_user_id is set,
-    #    otherwise delete it (orphaned row with no user association)
-    op.execute("""
-        UPDATE portal_knowledge_bases
-        SET slug = 'personal-' || owner_user_id
-        WHERE slug = 'personal'
-          AND owner_user_id IS NOT NULL
-          AND NOT EXISTS (
-              SELECT 1 FROM portal_knowledge_bases kb2
-              WHERE kb2.org_id = portal_knowledge_bases.org_id
-                AND kb2.slug = 'personal-' || portal_knowledge_bases.owner_user_id
-          )
-    """)
-    op.execute("""
-        DELETE FROM portal_knowledge_bases
-        WHERE slug = 'personal' AND owner_user_id IS NULL
-    """)
+    # No-op. See module docstring for rationale.
+    pass
 
 
 def downgrade() -> None:
+    # Preserved from the original migration. Both DELETEs reference only `slug`,
+    # which exists from z2a3b4c5d6e7 onwards, so this remains parseable even on
+    # downgrades from older schema states.
     op.execute("""
         DELETE FROM portal_knowledge_bases WHERE slug = 'org'
     """)

--- a/klai-portal/backend/app/core/dev_seed.py
+++ b/klai-portal/backend/app/core/dev_seed.py
@@ -27,11 +27,20 @@ async def ensure_dev_user_exists(db: AsyncSession, dev_user_id: str) -> None:
 
     # Use raw SQL to avoid RLS complications — this runs at startup before
     # any tenant context is set, on the superuser connection.
+    #
+    # Notes on column values:
+    # - provisioning_status='ready' (NOT 'complete' — 'complete' is not in the
+    #   CHECK constraint defined by ck_portal_orgs_provisioning_status).
+    # - primary_domain='localhost' satisfies the NOT NULL constraint added by
+    #   SPEC-AUTH-009. The value is otherwise unused in dev (no real OAuth
+    #   redirect resolves through it).
     result = await db.execute(
         text(
             """
-            INSERT INTO portal_orgs (zitadel_org_id, name, slug, plan, provisioning_status)
-            VALUES (:org_id, :name, :slug, 'professional', 'complete')
+            INSERT INTO portal_orgs (
+                zitadel_org_id, name, slug, plan, provisioning_status, primary_domain
+            )
+            VALUES (:org_id, :name, :slug, 'professional', 'ready', 'localhost')
             ON CONFLICT (zitadel_org_id) DO NOTHING
             RETURNING id
             """

--- a/klai-portal/backend/scripts/apply_post_deploy_sql.sh
+++ b/klai-portal/backend/scripts/apply_post_deploy_sql.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Apply every post_deploy_*.sql script in alembic/versions/ as the klai
-# superuser, in alphabetical order. Each script must be idempotent
-# (DROP POLICY IF EXISTS / CREATE OR REPLACE FUNCTION / etc.) — they
-# are designed to run on every deploy, not just the first.
+# superuser. Each script must be idempotent (DROP POLICY IF EXISTS /
+# CREATE OR REPLACE FUNCTION / etc.) — they are designed to run on every
+# deploy, not just the first.
 #
 # Why this script exists
 # ----------------------
@@ -14,11 +14,24 @@
 # the DB inconsistent with the deployed code (the 2026-04-21 RLS
 # incident traced back exactly to this gap).
 #
+# Ordering
+# --------
+# Files are normally applied alphabetically, but a handful of scripts
+# create helper objects (e.g. `public._rls_current_org_id()`) that
+# LATER scripts depend on. On a fresh DB the alphabetical order would
+# fail with "function ... does not exist". The BOOTSTRAP list below
+# pins the dependency order — these files run FIRST (in list order),
+# then the remaining files run alphabetically. Bootstrap files are
+# idempotent and run a second time during the alphabetical pass; that
+# is intentional (CREATE OR REPLACE / DROP IF EXISTS).
+#
 # Usage:
-#     ./apply_post_deploy_sql.sh                          # production
-#     ./apply_post_deploy_sql.sh --host staging-01        # alt host
-#     ./apply_post_deploy_sql.sh --container my-postgres  # alt container
-#     ./apply_post_deploy_sql.sh --dry-run                # list files, run nothing
+#     ./apply_post_deploy_sql.sh                              # production via ssh
+#     ./apply_post_deploy_sql.sh --host staging-01            # alt host
+#     ./apply_post_deploy_sql.sh --container my-postgres      # alt container
+#     ./apply_post_deploy_sql.sh --local                      # local docker, no ssh
+#     ./apply_post_deploy_sql.sh --local --container my-pg-1  # local + explicit ctr
+#     ./apply_post_deploy_sql.sh --dry-run                    # list files, run nothing
 #
 # Idempotent: re-runs the full set every time. Total runtime in production
 # is sub-second per script.
@@ -26,15 +39,26 @@ set -euo pipefail
 
 HOST="core-01"
 CONTAINER="klai-core-postgres-1"
+LOCAL=0
 DRY_RUN=0
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VERSIONS_DIR="$(cd "${SCRIPT_DIR}/../alembic/versions" && pwd)"
 
+# Bootstrap files — these MUST run before the alphabetical pass because
+# later files depend on objects they create. Order matters within this
+# list. Keep entries narrow; only add a file when it's a hard dependency
+# (function/type/role used by another post_deploy script). Each file
+# stays idempotent so the alphabetical re-run is safe.
+BOOTSTRAP_FILES=(
+    "post_deploy_rls_raise_on_missing_context.sql"
+)
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --host) HOST="$2"; shift 2 ;;
         --container) CONTAINER="$2"; shift 2 ;;
+        --local) LOCAL=1; shift ;;
         --dry-run) DRY_RUN=1; shift ;;
         -h|--help)
             sed -n '2,/^set -euo/p' "${BASH_SOURCE[0]}" | sed 's/^# \?//; /^set -euo/d'
@@ -44,14 +68,43 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-mapfile -t SCRIPTS < <(find "${VERSIONS_DIR}" -maxdepth 1 -name 'post_deploy_*.sql' | sort)
+# Default the container name in --local mode to whatever docker ps finds.
+# Auto-discovery only kicks in when the caller did not pass --container
+# AND --local is set, otherwise we'd silently shadow an explicit override.
+if [[ ${LOCAL} -eq 1 && "${CONTAINER}" == "klai-core-postgres-1" ]]; then
+    DISCOVERED=$(docker ps --format '{{.Names}}' 2>/dev/null | grep -E '^[a-z0-9_-]+-postgres-1$' | head -1 || true)
+    if [[ -n "${DISCOVERED}" ]]; then
+        CONTAINER="${DISCOVERED}"
+    fi
+fi
 
-if [[ ${#SCRIPTS[@]} -eq 0 ]]; then
+# Build the full execution order: bootstrap first (preserving list order),
+# then everything else in alphabetical order. We let bootstrap files
+# appear twice in the SCRIPTS array — the second run is a no-op for the
+# idempotent ones, and the visibility helps operators see they ran.
+# bash 3.2 compatible (macOS default) — no `mapfile`.
+ALL_SQL=()
+while IFS= read -r f; do
+    ALL_SQL+=("$f")
+done < <(find "${VERSIONS_DIR}" -maxdepth 1 -name 'post_deploy_*.sql' | sort)
+
+if [[ ${#ALL_SQL[@]} -eq 0 ]]; then
     echo "No post_deploy_*.sql scripts found in ${VERSIONS_DIR}"
     exit 0
 fi
 
-echo "Found ${#SCRIPTS[@]} post-deploy script(s):"
+SCRIPTS=()
+for boot in "${BOOTSTRAP_FILES[@]}"; do
+    boot_path="${VERSIONS_DIR}/${boot}"
+    if [[ -f "${boot_path}" ]]; then
+        SCRIPTS+=("${boot_path}")
+    fi
+done
+for f in "${ALL_SQL[@]}"; do
+    SCRIPTS+=("${f}")
+done
+
+echo "Found ${#ALL_SQL[@]} post-deploy script(s); ${#BOOTSTRAP_FILES[@]} bootstrap file(s) pinned to run first."
 for script in "${SCRIPTS[@]}"; do
     echo "  - $(basename "${script}")"
 done
@@ -63,8 +116,23 @@ if [[ ${DRY_RUN} -eq 1 ]]; then
 fi
 
 echo ""
-echo "Applying as klai superuser to ${HOST}:${CONTAINER} ..."
+if [[ ${LOCAL} -eq 1 ]]; then
+    echo "Applying as klai superuser locally to container ${CONTAINER} ..."
+else
+    echo "Applying as klai superuser to ${HOST}:${CONTAINER} ..."
+fi
 echo ""
+
+# Helper: route a psql invocation through ssh (prod) or docker exec (local).
+run_psql() {
+    local sql_file="$1"
+    if [[ ${LOCAL} -eq 1 ]]; then
+        docker exec -i "${CONTAINER}" psql -U klai -d klai -v ON_ERROR_STOP=1 < "${sql_file}"
+    else
+        ssh "${HOST}" "docker exec -i ${CONTAINER} psql -U klai -d klai -v ON_ERROR_STOP=1" \
+            < "${sql_file}"
+    fi
+}
 
 for script in "${SCRIPTS[@]}"; do
     name="$(basename "${script}")"
@@ -76,8 +144,7 @@ for script in "${SCRIPTS[@]}"; do
         continue
     fi
     echo "  [apply] ${name}"
-    ssh "${HOST}" "docker exec -i ${CONTAINER} psql -U klai -d klai -v ON_ERROR_STOP=1" \
-        < "${script}" > /tmp/post_deploy_$$.log 2>&1 || {
+    run_psql "${script}" > /tmp/post_deploy_$$.log 2>&1 || {
         echo ""
         echo "=== FAILED: ${name} ==="
         cat /tmp/post_deploy_$$.log
@@ -91,4 +158,4 @@ for script in "${SCRIPTS[@]}"; do
 done
 
 echo ""
-echo "✓ All post-deploy SQL applied."
+echo "All post-deploy SQL applied."


### PR DESCRIPTION
## Summary

End-to-end verification dat `make dev-reset && make dev-up && make migrate && make postdeploy` werkt op een schone macOS + OrbStack + uv + npm. Eight findings, allemaal in deze PR opgelost:

| # | File | Wat |
|---|---|---|
| 1 | `Makefile` | `setup` keygen stdlib-only (system python3 op macOS heeft geen `cryptography`); nieuwe `make postdeploy` target met auto-discovered postgres container; `make seed` zelfde discovery. |
| 2 | `dev/postgres-init.sql` | `CREATE ROLE portal_api NOLOGIN` + `CREATE ROLE grafana_reader NOLOGIN` (rollen die migraties/post-deploy SQL referencen). |
| 3 | `alembic/versions/z3a4b5c6d7e8_backfill_default_kbs.py` | `upgrade()` → no-op met docstring rationale. Originele INSERT referenced kolommen die latere migraties pas toevoegen → fresh-install hard fail. Default KBs gaan al lazy via `app.services.default_knowledge_bases`. |
| 4 | `alembic/versions/c3d4e5f6g7h8_portal_users_multi_org.py` | `DROP CONSTRAINT IF EXISTS` via raw SQL. Parent maakt unique INDEX (geen CONSTRAINT) — fresh DB heeft de constraint-naam nooit gehad. |
| 5 | `scripts/apply_post_deploy_sql.sh` | `--local` flag (docker exec direct, geen ssh) + BOOTSTRAP_FILES pin voor `rls_raise_on_missing_context.sql` zodat `public._rls_current_org_id()` bestaat vóór files die hem gebruiken. Bash 3.2 compat. |
| 6 | `klai-portal/backend/.env.example` | Complete Mode B sectie met alle `_require_*` fields die SPEC-SEC-VALIDATOR-COVERAGE-001 introduceerde. `ZITADEL_PORTAL_APP_ID` → `_CLIENT_ID` rename (matched pydantic Settings field). |
| 7 | `docs/runbooks/local-dev.md` | +258/-69 — alle bovenstaande fixes met troubleshooting, complete Mode B prereq-flow, sanitized placeholders per SPEC-REPO-SANITIZE-001, changelog onderaan. |

## Waarom dit nodig was

Niemand had `make migrate` op een schone DB gedraaid sinds SPEC-LOCAL-DEV-001 landde — de migratie-chain bevatte twee forward-reference bugs die alleen op prod nooit hadden gemerkt omdat de chain daar incrementeel via SPEC-branches landde. Fresh installs liepen elk op deze muren:

1. `make setup` faalt op cryptography import
2. `make migrate` faalt op `column "visibility" of relation "portal_knowledge_bases" does not exist`
3. Daarna op `constraint "portal_users_zitadel_user_id_key" does not exist`
4. Daarna op `role "portal_api" does not exist`
5. Daarna op `role "grafana_reader" does not exist`
6. `apply_post_deploy_sql.sh` SSH-only naar prod, alfabetische ordering valt om op `_rls_current_org_id() does not exist`
7. Backend boot faalt op 8 verschillende `_require_*` validator errors als je niet exact de Mode B-set hebt
8. Zitadel "Klai Portal BFF" app heeft geen localhost redirect URIs → login dood-end op `my.getklai.com/login`

## Productie-impact

- **Migrations 3 + 4**: prod's `alembic_version` zit al ver voorbij deze revisies; deze worden nooit opnieuw gerund. No-op + IF-EXISTS zijn beide idempotent op prod-state.
- **`dev/postgres-init.sql`**: alleen voor lokale dev DB. Prod gebruikt deze file niet.
- **`apply_post_deploy_sql.sh`**: default-mode (ssh naar core-01) is ongewijzigd; `--local` is opt-in. Bootstrap-ordering re-applieert rls_raise als laatste idempotent pass, geen functionele wijziging op prod.
- **`.env.example`**: documentatie/template; geen runtime impact.
- **Makefile + runbook**: alleen lokaal.

## Verificatie

```bash
make dev-reset && make dev-up && make migrate && make postdeploy
# All post-deploy SQL applied.
make backend &
make frontend &
# backend boots: 'Zitadel PAT validated', RLS guards installed, pollers running
# frontend serves on :5174
```

Sanitize-sweep over alle 7 files:
```bash
grep -rnE "362757920133283846|362771533686374406|369262708920418321|369262708920483857|368810756424073247|368809521386094623|@voys\.nl|@getklai\.com|mark\.vletter|admin@getklai" <files>
# (empty)
```

## Niet in deze PR

- Update aan Zitadel "Klai Portal BFF" app config (localhost redirect URIs + devMode) — al toegepast via Management API, gedocumenteerd in runbook met idempotent script zodat een schone Zitadel het ook self-served krijgt.
- Een mogelijke aparte dev-only OIDC client als opvolger (zou Mode B isoleren van prod app config). Open te overwegen los.

## Test plan

- [x] `make dev-reset && make dev-up && make migrate && make postdeploy` op een schone DB
- [x] Backend boot zonder `_require_*` validator errors in Mode B
- [x] Frontend serveert :5174
- [x] `validate_alembic.py` groen (single head `f1ff304b7b0a`)
- [x] Geen hardcoded prod-IDs of personal emails in committed files
- [x] `apply_post_deploy_sql.sh --local --dry-run` werkt in bash 3.2
- [ ] Een tweede dev op een schone machine volgt het runbook letterlijk en bevestigt end-to-end (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)