### PR TITLE
fix(retrieval): honor Qdrant temporal validity fields

### DIFF
--- a/klai-retrieval-api/retrieval_api/services/search.py
+++ b/klai-retrieval-api/retrieval_api/services/search.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import warnings
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import structlog
 from qdrant_client import AsyncQdrantClient
@@ -34,6 +34,8 @@ warnings.filterwarnings("ignore", message="Api key is used with an insecure conn
 logger = structlog.get_logger()
 
 _client: AsyncQdrantClient | None = None
+_EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
+_ACTIVE_UNTIL_SENTINEL = 253402300800
 
 
 def _get_client() -> AsyncQdrantClient:
@@ -47,20 +49,63 @@ def _get_client() -> AsyncQdrantClient:
     return _client
 
 
-def _invalid_at_filter() -> Filter:
-    """Build a filter that excludes chunks where invalid_at is set and in the past.
+def _epoch_seconds_to_iso(value: object, *, open_ended_sentinel: bool = False) -> str | None:
+    """Convert Qdrant epoch-second payload values to API ISO strings."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        if open_ended_sentinel and value >= _ACTIVE_UNTIL_SENTINEL:
+            return None
+        try:
+            return (_EPOCH + timedelta(seconds=float(value))).isoformat()
+        except (OverflowError, ValueError):
+            return None
+    return None
 
-    Uses must_not with a range filter: a chunk is excluded only when invalid_at
-    is present AND <= now. Absent invalid_at fields pass through because Qdrant
-    range filters on absent fields return no match (so must_not = pass).
-    The old is_null=True approach did not match absent fields in Qdrant 1.17+.
+
+def _payload_valid_at(payload: dict) -> str | None:
+    return payload.get("valid_at") or _epoch_seconds_to_iso(payload.get("valid_from"))
+
+
+def _payload_invalid_at(payload: dict) -> str | None:
+    return payload.get("invalid_at") or _epoch_seconds_to_iso(
+        payload.get("valid_until"),
+        open_ended_sentinel=True,
+    )
+
+
+def _temporal_validity_filter() -> Filter:
+    """Exclude chunks outside either supported temporal payload contract.
+
+    Retrieval historically looked at ``valid_at``/``invalid_at`` while
+    knowledge-ingest writes ``valid_from``/``valid_until`` from
+    ``belief_time_start``/``belief_time_end``. Support both so stale points are
+    filtered even when a Qdrant delete/re-ingest left old payloads behind.
     """
-    now_iso = datetime.now(UTC).isoformat()
+    now = datetime.now(UTC)
+    now_iso = now.isoformat()
+    now_epoch = int(now.timestamp())
     return Filter(
         must_not=[
             FieldCondition(
                 key="invalid_at",
                 range={"lte": now_iso},
+            ),
+            FieldCondition(
+                key="valid_until",
+                range={"lte": now_epoch},
+            ),
+            FieldCondition(
+                key="valid_at",
+                range={"gt": now_iso},
+            ),
+            FieldCondition(
+                key="valid_from",
+                range={"gt": now_epoch},
             ),
         ]
     )
@@ -129,7 +174,7 @@ async def _search_knowledge(
     client = _get_client()
 
     scope_conditions = _scope_filter(request)
-    must_conditions = [*scope_conditions, _invalid_at_filter()]
+    must_conditions = [*scope_conditions, _temporal_validity_filter()]
 
     # SPEC-KB-022 R3: taxonomy filter with backward-compatible fallback.
     # OR: match on new taxonomy_node_ids (array) OR old taxonomy_node_id (int).
@@ -209,8 +254,8 @@ async def _search_knowledge(
             "context_prefix": r.payload.get("context_prefix"),
             "parent_chunk_id": r.payload.get("parent_chunk_id"),
             "scope": r.payload.get("scope"),
-            "valid_at": r.payload.get("valid_at"),
-            "invalid_at": r.payload.get("invalid_at"),
+            "valid_at": _payload_valid_at(r.payload),
+            "invalid_at": _payload_invalid_at(r.payload),
             "ingested_at": r.payload.get("ingested_at"),
             "assertion_mode": r.payload.get("assertion_mode"),
             "entity_pagerank_max": r.payload.get("entity_pagerank_max"),
@@ -250,7 +295,7 @@ async def fetch_chunks_by_urls(
         must=[
             *scope_conditions,
             FieldCondition(key="source_url", match=MatchAny(any=urls)),
-            _invalid_at_filter(),
+            _temporal_validity_filter(),
         ]
     )
 
@@ -282,8 +327,8 @@ async def fetch_chunks_by_urls(
             "context_prefix": r.payload.get("context_prefix"),
             "parent_chunk_id": r.payload.get("parent_chunk_id"),
             "scope": r.payload.get("scope"),
-            "valid_at": r.payload.get("valid_at"),
-            "invalid_at": r.payload.get("invalid_at"),
+            "valid_at": _payload_valid_at(r.payload),
+            "invalid_at": _payload_invalid_at(r.payload),
             "ingested_at": r.payload.get("ingested_at"),
             "assertion_mode": r.payload.get("assertion_mode"),
             "entity_pagerank_max": r.payload.get("entity_pagerank_max"),

--- a/klai-retrieval-api/tests/test_search.py
+++ b/klai-retrieval-api/tests/test_search.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -47,7 +48,7 @@ class TestSearch:
 
     @pytest.mark.asyncio
     async def test_kb_slugs_filter_excludes_other_kb(self):
-        """kb_slugs restricts search to the specified KBs; chunks from other KBs are not returned."""
+        """kb_slugs restricts search to the specified KBs."""
         from qdrant_client.models import MatchAny
 
         # Mock returns only the chunk that Qdrant would keep after applying the filter.
@@ -117,3 +118,116 @@ class TestSearch:
 
         assert results[0]["ingested_at"] is None
         assert results[0]["assertion_mode"] is None
+
+    @pytest.mark.asyncio
+    async def test_qdrant_temporal_filter_respects_valid_until_invalid_at_and_valid_from(self):
+        """The live Qdrant filter excludes stale ingest-contract temporal payloads."""
+        from qdrant_client import AsyncQdrantClient
+        from qdrant_client.models import Distance, PointStruct, VectorParams
+
+        client = AsyncQdrantClient(location=":memory:")
+        await client.create_collection(
+            "klai_knowledge",
+            vectors_config={
+                "vector_chunk": VectorParams(size=2, distance=Distance.COSINE),
+                "vector_questions": VectorParams(size=2, distance=Distance.COSINE),
+            },
+        )
+
+        now = int(time.time())
+        vector = {"vector_chunk": [1.0, 0.0], "vector_questions": [1.0, 0.0]}
+        await client.upsert(
+            "klai_knowledge",
+            points=[
+                PointStruct(
+                    id=1,
+                    vector=vector,
+                    payload={
+                        "org_id": "org-1",
+                        "kb_slug": "kb-1",
+                        "text": "expired by valid_until",
+                        "valid_from": now - 7200,
+                        "valid_until": now - 3600,
+                    },
+                ),
+                PointStruct(
+                    id=2,
+                    vector=vector,
+                    payload={
+                        "org_id": "org-1",
+                        "kb_slug": "kb-1",
+                        "text": "expired by invalid_at",
+                        "invalid_at": "2000-01-01T00:00:00+00:00",
+                    },
+                ),
+                PointStruct(
+                    id=3,
+                    vector=vector,
+                    payload={
+                        "org_id": "org-1",
+                        "kb_slug": "kb-1",
+                        "text": "not yet valid",
+                        "valid_from": now + 3600,
+                        "valid_until": now + 7200,
+                    },
+                ),
+                PointStruct(
+                    id=4,
+                    vector=vector,
+                    payload={
+                        "org_id": "org-1",
+                        "kb_slug": "kb-1",
+                        "text": "active by valid_until",
+                        "valid_from": now - 3600,
+                        "valid_until": now + 3600,
+                    },
+                ),
+                PointStruct(
+                    id=5,
+                    vector=vector,
+                    payload={
+                        "org_id": "org-1",
+                        "kb_slug": "kb-1",
+                        "text": "timeless legacy",
+                    },
+                ),
+            ],
+        )
+
+        try:
+            with patch.object(search, "_get_client", return_value=client):
+                req = RetrieveRequest(
+                    query="test",
+                    org_id="org-1",
+                    scope="org",
+                    kb_slugs=["kb-1"],
+                )
+                results = await search.hybrid_search([1.0, 0.0], req, 10)
+        finally:
+            await client.close()
+
+        assert {r["text"] for r in results} == {
+            "active by valid_until",
+            "timeless legacy",
+        }
+
+    @pytest.mark.asyncio
+    async def test_knowledge_search_aliases_valid_from_until_to_api_fields(self):
+        """Retrieval API response fields expose ingest-contract temporal payloads."""
+        point = _make_point(
+            "c1",
+            "chunk text",
+            0.8,
+            org_id="org-1",
+            valid_from=1_700_000_000,
+            valid_until=253_402_300_800,
+        )
+        mock_client = AsyncMock()
+        mock_client.query_points.return_value = _make_query_response([point])
+
+        with patch.object(search, "_get_client", return_value=mock_client):
+            req = RetrieveRequest(query="test", org_id="org-1", scope="org")
+            results = await search.hybrid_search([0.1, 0.2], req, 10)
+
+        assert results[0]["valid_at"] == "2023-11-14T22:13:20+00:00"
+        assert results[0]["invalid_at"] is None


### PR DESCRIPTION
## Summary
- Make retrieval-api temporal filtering honor both legacy `valid_at`/`invalid_at` and knowledge-ingest `valid_from`/`valid_until` payload contracts.
- Exclude chunks whose `valid_until` is in the past and chunks whose `valid_from` is in the future, while preserving the existing `invalid_at` behavior.
- Alias `valid_from`/`valid_until` back into the existing API response fields `valid_at`/`invalid_at` so downstream layers keep using the current contract.

## Bug Repro
Before this fix, live Qdrant v1.17.1 returned a chunk with `valid_until` in the past because retrieval only filtered on `invalid_at`. The same chunk disappeared only after adding `invalid_at`, proving the field-name contract drift.

## Verification
- `INTERNAL_SECRET=local-test PORTAL_INTERNAL_SECRET=local-test REDIS_URL=redis://localhost:6379 QDRANT_URL=http://unused uv run --extra dev ruff check retrieval_api/services/search.py tests/test_search.py`
- `INTERNAL_SECRET=local-test PORTAL_INTERNAL_SECRET=local-test REDIS_URL=redis://localhost:6379 QDRANT_URL=http://unused uv run --extra dev pytest tests/test_search.py`
- `INTERNAL_SECRET=local-test PORTAL_INTERNAL_SECRET=local-test REDIS_URL=redis://localhost:6379 QDRANT_URL=http://unused uv run --extra dev pytest tests/test_link_expand_search.py tests/test_link_expand_retrieve.py`
- `INTERNAL_SECRET=local-test PORTAL_INTERNAL_SECRET=local-test REDIS_URL=redis://localhost:6379 QDRANT_URL=http://unused GRAPHITI_ENABLED=false uv run --extra dev pytest tests/test_api.py`
- Live Docker smoke against `qdrant/qdrant:v1.17.1`: expired `valid_until` and expired `invalid_at` chunks were excluded; active `valid_until` chunk remained.

## Notes
- Direct push to `GetKlai/klai` is not available for the current GitHub account (`viewerPermission=READ`), so this PR is opened from the `Sjotie/klai` fork.
- `tests/test_api.py` without `GRAPHITI_ENABLED=false` still attempts to resolve local `falkordb:6379` in the health test; that is unrelated to this retrieval fix.
