### PR TITLE
Fix stale portal chunks

### DIFF
--- a/deploy/caddy/Caddyfile
+++ b/deploy/caddy/Caddyfile
@@ -494,7 +494,13 @@
     # deleted chunks return 404 instead of /srv/portal/index.html.
     handle /assets/* {
         root * /srv/portal
-        header Cache-Control "public, max-age=31536000, immutable"
+
+        # Only existing chunks get the immutable cache. A missing chunk
+        # returns a bare 404 — caching that 404 immutably would make a
+        # deploy-race 404 unrecoverable until the browser cache is cleared.
+        @asset_exists file {path}
+        header @asset_exists Cache-Control "public, max-age=31536000, immutable"
+
         file_server
     }
 

--- a/deploy/caddy/Caddyfile
+++ b/deploy/caddy/Caddyfile
@@ -490,13 +490,17 @@
         }
     }
 
+    # Portal Vite assets. This block must stay before the SPA fallback so
+    # deleted chunks return 404 instead of /srv/portal/index.html.
+    handle /assets/* {
+        root * /srv/portal
+        header Cache-Control "public, max-age=31536000, immutable"
+        file_server
+    }
+
     # Portal SPA — static files (fallback for all *.${DOMAIN})
     handle {
         root * /srv/portal
-
-        # Vite hashed assets — immutable long-term cache
-        @spa-assets path /assets/*
-        header @spa-assets Cache-Control "public, max-age=31536000, immutable"
 
         # index.html and all SPA routes — always revalidate
         @spa-html not path /assets/*

--- a/klai-portal/backend/tests/test_caddyfile_static_route_position.py
+++ b/klai-portal/backend/tests/test_caddyfile_static_route_position.py
@@ -120,3 +120,37 @@ def test_public_docs_reader_route_precedes_catchall_and_api_block() -> None:
         "Caddyfile order regression: /docs/* reader route must come before "
         "the portal SPA catch-all, otherwise public docs URLs hit the login wall."
     )
+
+
+def test_portal_assets_route_precedes_spa_catchall() -> None:
+    """Missing Vite chunks must 404 instead of returning SPA HTML."""
+    if not _CADDYFILE.exists():
+        pytest.skip(f"Caddyfile not found at {_CADDYFILE}")
+
+    text = _CADDYFILE.read_text(encoding="utf-8")
+    lines = text.splitlines()
+
+    assets_line: int | None = None
+    catchall_line: int | None = None
+
+    assets_re = re.compile(r"^\s*handle\s+/assets/\*\s*\{")
+    catchall_re = re.compile(r"^\s*handle\s*\{")
+
+    for i, line in enumerate(lines, start=1):
+        if assets_line is None and assets_re.match(line):
+            assets_line = i
+        if catchall_line is None and catchall_re.match(line):
+            catchall_line = i
+        if assets_line and catchall_line:
+            break
+
+    assert assets_line is not None, (
+        "Caddyfile must route /assets/* before the SPA fallback. Otherwise "
+        "deleted Vite chunks are served as index.html and module imports fail with MIME errors."
+    )
+    assert catchall_line is not None, "Caddyfile must keep an explicit portal SPA catch-all."
+    assert assets_line < catchall_line, (
+        f"Caddyfile order regression: `handle /assets/*` (line {assets_line}) "
+        f"comes AFTER the catch-all `handle {{` (line {catchall_line}). "
+        "Missing Vite chunks would be served as HTML instead of returning 404."
+    )

--- a/klai-portal/backend/tests/test_caddyfile_static_route_position.py
+++ b/klai-portal/backend/tests/test_caddyfile_static_route_position.py
@@ -154,3 +154,54 @@ def test_portal_assets_route_precedes_spa_catchall() -> None:
         f"comes AFTER the catch-all `handle {{` (line {catchall_line}). "
         "Missing Vite chunks would be served as HTML instead of returning 404."
     )
+
+
+def test_portal_assets_immutable_header_scoped_to_existing_files() -> None:
+    """The immutable Cache-Control must not be applied to 404 responses.
+
+    `file_server` returns 404 for a missing chunk. If the immutable
+    Cache-Control header is applied unconditionally, the browser caches
+    that 404 for a year — a deploy-race 404 then becomes unrecoverable
+    until the browser cache is cleared. The header must be gated on a
+    `file {path}` matcher so only existing chunks get the immutable cache.
+    """
+    if not _CADDYFILE.exists():
+        pytest.skip(f"Caddyfile not found at {_CADDYFILE}")
+
+    text = _CADDYFILE.read_text(encoding="utf-8")
+    lines = text.splitlines()
+
+    in_assets_block = False
+    matcher_name: str | None = None
+    immutable_header_line: str | None = None
+
+    assets_re = re.compile(r"^\s*handle\s+/assets/\*\s*\{")
+    matcher_re = re.compile(r"^\s*(@\S+)\s+file\s+\{path\}\s*$")
+
+    for line in lines:
+        if assets_re.match(line):
+            in_assets_block = True
+            continue
+        if not in_assets_block:
+            continue
+        if re.match(r"^\s*\}\s*$", line):
+            break
+        m = matcher_re.match(line)
+        if m:
+            matcher_name = m.group(1)
+        if "Cache-Control" in line and "immutable" in line:
+            immutable_header_line = line.strip()
+
+    assert immutable_header_line is not None, (
+        "Caddyfile `handle /assets/*` block must set an immutable Cache-Control header."
+    )
+    assert matcher_name is not None, (
+        "Caddyfile `handle /assets/*` block must define a `@matcher file {path}` "
+        "matcher so the immutable header is not applied to 404s for missing chunks."
+    )
+    assert matcher_name in immutable_header_line, (
+        f"Caddyfile regression: the immutable Cache-Control header "
+        f"({immutable_header_line!r}) must be scoped to the `{matcher_name}` "
+        "file-existence matcher. Otherwise missing chunks return a 404 cached "
+        "immutably, making a deploy-race 404 unrecoverable."
+    )

--- a/klai-portal/frontend/src/lib/__tests__/stale-chunk-reload.test.ts
+++ b/klai-portal/frontend/src/lib/__tests__/stale-chunk-reload.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  isStaleChunkLoadError,
+  registerStaleChunkReloadHandler,
+  reloadForStaleChunk,
+} from '@/lib/stale-chunk-reload'
+
+function createStorage(): Pick<Storage, 'getItem' | 'setItem'> {
+  const values = new Map<string, string>()
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => { values.set(key, value) },
+  }
+}
+
+describe('stale chunk reload handling', () => {
+  it('recognizes Vite dynamic import and module MIME failures', () => {
+    expect(isStaleChunkLoadError(new TypeError('Failed to fetch dynamically imported module: /assets/page.js'))).toBe(true)
+    expect(isStaleChunkLoadError(new Error('Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of "text/html"'))).toBe(true)
+    expect(isStaleChunkLoadError(new Error('regular API request failed'))).toBe(false)
+  })
+
+  it('reloads once for the same URL inside the cooldown window', () => {
+    const storage = createStorage()
+    const reload = vi.fn()
+    const options = {
+      storage,
+      reload,
+      locationHref: () => 'https://getklai.test/app/docs/help/page',
+      now: () => 1000,
+    }
+
+    expect(reloadForStaleChunk(options)).toBe(true)
+    expect(reloadForStaleChunk(options)).toBe(false)
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('prevents Vite preload errors and reloads the page', () => {
+    const storage = createStorage()
+    const reload = vi.fn()
+    const unregister = registerStaleChunkReloadHandler({
+      storage,
+      reload,
+      locationHref: () => 'https://getklai.test/app/docs/help/page',
+      now: () => 1000,
+    })
+
+    const event = new CustomEvent('vite:preloadError', {
+      cancelable: true,
+      detail: new TypeError('Failed to fetch dynamically imported module: /assets/_pageId.lazy-old.js'),
+    })
+
+    window.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(reload).toHaveBeenCalledTimes(1)
+
+    unregister()
+  })
+})

--- a/klai-portal/frontend/src/lib/stale-chunk-reload.ts
+++ b/klai-portal/frontend/src/lib/stale-chunk-reload.ts
@@ -1,0 +1,123 @@
+const RELOAD_KEY = 'klai:stale-chunk-reload'
+const RELOAD_TTL_MS = 30_000
+
+const CHUNK_ERROR_PATTERNS = [
+  /Failed to fetch dynamically imported module/i,
+  /error loading dynamically imported module/i,
+  /Importing a module script failed/i,
+  /Loading chunk .* failed/i,
+  /ChunkLoadError/i,
+  /Expected a JavaScript-or-Wasm module script/i,
+  /Unable to preload CSS/i,
+]
+
+interface ReloadRecord {
+  href: string
+  at: number
+}
+
+interface StaleChunkReloadOptions {
+  now?: () => number
+  reload?: () => void
+  locationHref?: () => string
+  storage?: Pick<Storage, 'getItem' | 'setItem'>
+}
+
+type VitePreloadErrorEvent = Event & {
+  payload?: unknown
+  detail?: unknown
+}
+
+function getErrorText(error: unknown): string {
+  if (!error) return ''
+  if (typeof error === 'string') return error
+  if (error instanceof Error) return `${error.name} ${error.message} ${error.stack ?? ''}`
+  if (typeof error === 'object') {
+    const maybeError = error as { name?: unknown; message?: unknown; stack?: unknown; cause?: unknown }
+    return [
+      typeof maybeError.name === 'string' ? maybeError.name : '',
+      typeof maybeError.message === 'string' ? maybeError.message : '',
+      typeof maybeError.stack === 'string' ? maybeError.stack : '',
+      maybeError.cause ? getErrorText(maybeError.cause) : '',
+    ].join(' ')
+  }
+  if (typeof error === 'number' || typeof error === 'boolean' || typeof error === 'bigint') {
+    return error.toString()
+  }
+  if (typeof error === 'symbol') return error.description ?? ''
+  return ''
+}
+
+function getReloadRecord(storage: Pick<Storage, 'getItem'>): ReloadRecord | null {
+  let raw: string | null
+  try {
+    raw = storage.getItem(RELOAD_KEY)
+  } catch {
+    return null
+  }
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw) as Partial<ReloadRecord>
+    if (typeof parsed.href === 'string' && typeof parsed.at === 'number') {
+      return { href: parsed.href, at: parsed.at }
+    }
+  } catch {
+    return null
+  }
+  return null
+}
+
+export function isStaleChunkLoadError(error: unknown): boolean {
+  const text = getErrorText(error)
+  return CHUNK_ERROR_PATTERNS.some((pattern) => pattern.test(text))
+}
+
+export function reloadForStaleChunk(options: StaleChunkReloadOptions = {}): boolean {
+  const storage = options.storage ?? window.sessionStorage
+  const href = options.locationHref?.() ?? window.location.href
+  const now = options.now?.() ?? Date.now()
+  const previous = getReloadRecord(storage)
+
+  if (previous?.href === href && now - previous.at < RELOAD_TTL_MS) {
+    console.warn('Stale frontend chunk detected, but reload was already attempted for this URL.')
+    return false
+  }
+
+  try {
+    storage.setItem(RELOAD_KEY, JSON.stringify({ href, at: now }))
+  } catch {
+    console.warn('Stale frontend chunk detected, but reload state could not be stored.')
+  }
+  console.warn('Stale frontend chunk detected. Reloading to fetch the latest build.')
+  const reload = options.reload ?? (() => window.location.reload())
+  reload()
+  return true
+}
+
+export function registerStaleChunkReloadHandler(options: StaleChunkReloadOptions = {}): () => void {
+  const handlePreloadError = (event: Event) => {
+    const preloadEvent = event as VitePreloadErrorEvent
+    const error = preloadEvent.payload ?? preloadEvent.detail
+    if (!isStaleChunkLoadError(error)) return
+
+    if (reloadForStaleChunk(options)) {
+      event.preventDefault()
+    }
+  }
+
+  const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
+    if (!isStaleChunkLoadError(event.reason)) return
+
+    if (reloadForStaleChunk(options)) {
+      event.preventDefault()
+    }
+  }
+
+  window.addEventListener('vite:preloadError', handlePreloadError)
+  window.addEventListener('unhandledrejection', handleUnhandledRejection)
+
+  return () => {
+    window.removeEventListener('vite:preloadError', handlePreloadError)
+    window.removeEventListener('unhandledrejection', handleUnhandledRejection)
+  }
+}

--- a/klai-portal/frontend/src/main.tsx
+++ b/klai-portal/frontend/src/main.tsx
@@ -9,7 +9,10 @@ import { Toaster } from '@/components/ui/sonner'
 import { routeTree } from './routeTree.gen'
 import { initVitals } from '@/lib/vitals'
 import { registerNavigateSingleton } from '@/lib/navigate-singleton'
+import { registerStaleChunkReloadHandler } from '@/lib/stale-chunk-reload'
 import './index.css'
+
+registerStaleChunkReloadHandler()
 
 const queryClient = new QueryClient({
   defaultOptions: {


### PR DESCRIPTION
Fixes intermittent blank portal pages after deploy by handling stale Vite chunk load failures with a one-time reload in the frontend bootstrap.

The root cause was deleted `/assets/*` chunks being served as `index.html` by the SPA fallback, so Caddy now serves `/assets/*` before the fallback and missing chunks return 404 instead of HTML.

Adds frontend unit coverage for stale chunk detection and Caddy route-order coverage for the asset handler.

Validated with `npm run test -- src/lib/__tests__/stale-chunk-reload.test.ts`, `npm run lint`, `npm run build`, and `uv run pytest tests/test_caddyfile_static_route_position.py`.
