### PR TITLE
fix(portal): show name and email on the Account page

### DIFF
--- a/klai-portal/frontend/src/routes/app/account.tsx
+++ b/klai-portal/frontend/src/routes/app/account.tsx
@@ -29,6 +29,8 @@ export const Route = createFileRoute('/app/account')({
 
 interface MeAccount {
   preferred_language?: 'nl' | 'en'
+  name?: string
+  email?: string
 }
 
 function AccountPage() {
@@ -93,8 +95,11 @@ function AccountPage() {
     },
   })
 
-  const name = auth.user?.profile?.name ?? auth.user?.profile?.preferred_username ?? ''
-  const email = auth.user?.profile?.email ?? ''
+  // Name and email come from /api/me (sourced server-side from the Zitadel
+  // userinfo claims). The BFF session only carries `sub`, so reading from
+  // auth.user.profile here would always be empty.
+  const name = meData?.name ?? ''
+  const email = meData?.email ?? ''
   const hasProfileInfo = Boolean(name || email)
 
   const tabs: { id: TabId; label: string; icon: React.ElementType }[] = [


### PR DESCRIPTION
## What

The Account page (`/app/account`) Settings tab has a profile block for name + email, but it never rendered in production.

## Why

`account.tsx` read `name`/`email` from `auth.user?.profile`. In the cookie-based BFF (`SPEC-AUTH-008`), the session response only carries `zitadel_user_id` (`sub`) — no name, no email. So `hasProfileInfo` was always false and the block was hidden.

`/api/me` already returns `name` and `email` as required fields (`MeResponse`, sourced server-side from the Zitadel userinfo claims). The page already calls `/api/me` for `preferred_language` — it just discarded the rest.

## Change

- Extend the local `MeAccount` interface with `name` and `email`
- Read the profile block from `meData` instead of `auth.user.profile`

Frontend-only. No backend change. `tsc --noEmit` green.

## Related

Help page `language-and-account.md` updated in Gitea (`org-getklai/klai-help`) to match the tabbed Account page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)