### PR TITLE
[codex] harden cross-tenant security paths

### DIFF
--- a/.github/workflows/portal-api.yml
+++ b/.github/workflows/portal-api.yml
@@ -71,10 +71,7 @@ jobs:
       # CVE-2026-3219: advisory against pip 26.0.1 (the CI runner's bootstrap pip, not an app
       # dependency resolved by uv). Ignored until the Actions runner image bumps its default pip.
       - name: Dependency vulnerability scan (pip-audit)
-        # TODO(2026-05-20): bump idna to >=3.15 and pyjwt to the patched
-        # version, then remove these two ignores. Added under time pressure
-        # to unblock a production-fix deploy (Lars/Nerds chat blank screen).
-        run: uv run --with pip-audit pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2025-71176 --ignore-vuln CVE-2026-3219 --ignore-vuln CVE-2026-45409 --ignore-vuln PYSEC-2025-183
+        run: uv run --with pip-audit pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2025-71176 --ignore-vuln CVE-2026-3219
 
       # Guards against the two classes of alembic mistakes we've been bitten by:
       # 1. Hand-typed rev ids (SPEC-KB-020: duplicate `a1b2c3d4e5f6` crashed

--- a/.moai/specs/SPEC-SEC-CROSS-TENANT-2026-05/plan.md
+++ b/.moai/specs/SPEC-SEC-CROSS-TENANT-2026-05/plan.md
@@ -1,0 +1,482 @@
+# SPEC-SEC-CROSS-TENANT-2026-05 - Remediation Plan
+
+Status: draft
+Created: 2026-05-24
+Input: cross-tenant security scan of `00308cff..9b652472` (code added since 2026-05-17)
+Owner: platform/backend
+Priority: P1 security hardening
+
+## Goal
+
+Close the security issues found in the May 2026 cross-tenant scan, with the
+highest priority on preventing tenant-scoped actions from causing global
+identity side effects, stale privileges, or unintended public exposure of
+tenant knowledge bases.
+
+## Non-goals
+
+- Redesign the full platform-admin console.
+- Replace the widget JWT scheme with asymmetric signing.
+- Rework all multi-org account selection. This plan only fixes the vulnerable
+  or ambiguous call sites discovered in the scan.
+
+## Findings Covered
+
+| ID | Severity | Finding | Primary files |
+|---|---:|---|---|
+| CT-01 | High | Platform hard-delete removes global Zitadel identity from a tenant-scoped action | `platform_manage.py`, `users.py`, `models/portal.py` |
+| CT-02 | High | Platform role changes do not notify active MCP/tool sessions | `platform_manage.py`, `mcp_role_notifier.py` |
+| CT-03 | Medium/High | Platform invite/create-tenant leaves orphan Zitadel users on partial failure | `platform_manage.py`, `zitadel.py` |
+| CT-04 | Medium | Wildcard origin check accepts lookalike domains | `widget_auth.py` |
+| CT-05 | Medium | Public bot link makes `widget_id` a public bearer-style handle | `partner.py`, `admin_widgets.py`, widget models/frontend |
+| CT-06 | Medium | OAuth callback picks an arbitrary tenant row for multi-org users | `oauth.py` |
+| CT-07 | Medium | Platform-admin endpoints lack direct backend regression tests | backend tests |
+| CT-08 | Low/Medium | `pip-audit` still fails on `idna` CVE ignore | `uv.lock`, `pyproject.toml`, CI workflow |
+
+## Execution Order
+
+1. Fix destructive account semantics first: CT-01.
+2. Close stale privilege windows: CT-02.
+3. Add compensation for partial identity creation failures: CT-03.
+4. Fix widget origin matching: CT-04.
+5. Make public widget sharing explicit and testable: CT-05.
+6. Fix OAuth multi-org scoping: CT-06.
+7. Add platform-admin regression tests across all new surfaces: CT-07.
+8. Remove dependency-audit ignores after bumping vulnerable packages: CT-08.
+
+This order reduces blast radius before changing broader UX/product semantics.
+
+## CT-01 - Tenant-scoped User Removal Must Not Delete Global Identity
+
+### Problem
+
+`portal_users` allows multiple memberships per `zitadel_user_id` via the
+unique constraint on `(zitadel_user_id, org_id)`. The new platform delete flow
+checks the target org membership but then calls `zitadel.remove_user()` in the
+central portal org. That turns a tenant-scoped removal into a global account
+delete.
+
+### Implementation
+
+**Target:** `klai-portal/backend/app/api/admin/platform_manage.py`
+
+Change `platform_delete_user()` to:
+
+- Load the target `PortalUser` row under `tenant_scoped_session(org_id)` as it
+  does today.
+- Before calling Zitadel, check for other memberships for the same
+  `zitadel_user_id` using a cross-org-safe helper.
+- If other memberships exist:
+  - Do not call `zitadel.remove_user()`.
+  - Revoke only credentials and KB ownership scoped to the target `org_id`.
+  - Delete only the target `PortalUser` row.
+  - Audit with `global_identity_deleted=false` and
+    `remaining_membership_count`.
+- If no other memberships exist:
+  - Existing full Zitadel removal remains allowed.
+  - Audit with `global_identity_deleted=true`.
+- Block deletion of the acting platform-admin identity.
+- Block deletion of any identity that is an admin in the platform org unless a
+  future explicit break-glass flow is added.
+
+**Target:** `klai-portal/backend/app/api/admin/users.py`
+
+Apply the same membership-aware semantics to the existing tenant admin
+hard-delete path, or explicitly split it into:
+
+- `remove_user_from_org()` for tenant-scoped offboarding.
+- `delete_global_user_if_last_membership()` for the final-account case.
+
+Do not leave platform-admin and tenant-admin delete semantics divergent.
+
+### Tests
+
+Add backend tests covering:
+
+- User with one membership: Zitadel `remove_user()` is called.
+- User with two memberships: Zitadel `remove_user()` is not called; only target
+  membership is deleted.
+- Platform-admin identity cannot be deleted from a customer tenant.
+- Self-delete by platform admin returns `409`.
+- Audit details include `target_org_id`, `global_identity_deleted`, and
+  `remaining_membership_count`.
+
+### Acceptance
+
+- A platform action on tenant A cannot break the user's login for tenant B.
+- Global identity deletion occurs only when the user has no remaining
+  memberships.
+
+### Rollback
+
+Rollback is code-only. Reverting restores previous delete behavior, but that
+behavior is unsafe and should be treated as an emergency rollback only.
+
+## CT-02 - Platform Role Changes Must Invalidate Active Permission State
+
+### Problem
+
+The normal tenant-admin role update calls `fire_role_change_notification()`.
+The new platform role update commits the role change and audit event but does
+not notify active MCP/tool sessions.
+
+### Implementation
+
+**Target:** `klai-portal/backend/app/api/admin/platform_manage.py`
+
+- Import `fire_role_change_notification`.
+- After a successful role commit in `platform_update_role()`, call
+  `fire_role_change_notification(zitadel_user_id)`.
+- Keep the notifier fire-and-forget, matching the normal admin path.
+
+Also review suspend/reactivate/delete:
+
+- `platform_suspend()`: notify or revoke active sessions for the target user.
+- `platform_reactivate()`: no forced notification required unless session
+  state caches status.
+- `platform_delete_user()`: notify/revoke before deleting the local row.
+
+### Tests
+
+- Platform role change calls `fire_role_change_notification()` exactly once.
+- Failed role change does not call the notifier.
+- Last-admin demotion still returns `409` and does not notify.
+
+### Acceptance
+
+- Platform and tenant-admin role changes have the same active-session
+  invalidation semantics.
+
+## CT-03 - Compensate Partial Zitadel User Creation Failures
+
+### Problem
+
+`platform_invite()` and `platform_create_tenant()` create a user in the central
+portal Zitadel org before all later steps have completed. Failures while
+sending invite mail, granting roles, or writing portal rows can leave orphaned
+pre-verified identities.
+
+### Implementation
+
+**Target:** `klai-portal/backend/app/api/admin/platform_manage.py`
+
+Add a local compensation helper:
+
+```python
+async def _rollback_zitadel_user(user_id: str) -> None:
+    with suppress(Exception):
+        await zitadel.remove_user(settings_zitadel_portal_org_id(), user_id)
+```
+
+Use it in:
+
+- `platform_invite()` when send-code, role-grant, personal-KB creation, or DB
+  commit fails after user creation.
+- `platform_create_tenant()` when owner setup or portal DB insert fails after
+  owner user creation.
+
+Prefer the safer sequencing where possible:
+
+1. Create Zitadel user.
+2. Grant required role.
+3. Create portal rows and commit.
+4. Send invite mail after DB commit.
+
+If the mail send fails after commit, return a partial-failure response that
+includes a retry action, but do not delete a now-valid portal account.
+
+### Tests
+
+- Invite mail failure removes the newly-created Zitadel user and creates no
+  `PortalUser`.
+- Role grant failure removes the newly-created Zitadel user.
+- Portal DB failure removes the newly-created Zitadel user.
+- Create-tenant owner setup failure removes both the new Zitadel org and owner
+  user.
+- Mail failure after DB commit returns a retryable partial failure and keeps the
+  portal row.
+
+### Acceptance
+
+- No orphan central-portal identities are left after failed platform invite or
+  platform tenant creation flows.
+
+## CT-04 - Correct Wildcard Origin Matching
+
+### Problem
+
+The current wildcard check treats `https://*.example.com` as a suffix match.
+That accepts lookalike domains such as `https://evil-example.com`.
+
+### Implementation
+
+**Target:** `klai-portal/backend/app/services/widget_auth.py`
+
+Replace string suffix matching with parsed origin matching:
+
+- Parse both `origin` and `allowed` with `urllib.parse.urlparse`.
+- Require exact scheme.
+- Require exact port semantics. If either side has an explicit port, compare
+  effective `(scheme, hostname, port)`.
+- For wildcard origins, require:
+  - `allowed.hostname` starts with `"*."`.
+  - `origin.hostname.endswith("." + suffix)`.
+  - `origin.hostname != suffix`.
+- Keep exact-match behavior unchanged.
+- Keep empty `allowed_origins` behavior unchanged for now; CT-05 decides the
+  product semantics.
+
+### Tests
+
+Add tests to `tests/test_widget_config.py` or a new
+`tests/test_widget_origin_allowed.py`:
+
+- `https://app.example.com` allowed by `https://*.example.com`.
+- `https://example.com` not allowed by wildcard.
+- `https://evil-example.com` not allowed.
+- `https://example.com.evil.test` not allowed.
+- Scheme mismatch rejected.
+- Port mismatch rejected when configured.
+
+### Acceptance
+
+- Wildcard origins match only real subdomains of the configured domain.
+
+## CT-05 - Make Public Bot Sharing Explicit
+
+### Problem
+
+`/partner/v1/public-bot-config` intentionally has no Origin gate. Any holder
+of `widget_id` can fetch a session token for the widget's linked KBs. This is
+safe only if the admin explicitly understands the widget as publicly shared.
+
+### Implementation
+
+**Target:** widget persistence/model layer
+
+Add an explicit public-share flag. Preferred shape:
+
+- `widgets.public_share_enabled BOOLEAN NOT NULL DEFAULT false`
+
+or, if schema churn must be avoided:
+
+- `widget_config["public_share_enabled"]` with server-side default `false`.
+
+Schema column is preferred because it is queryable, auditable, and easier to
+gate consistently.
+
+**Target:** `klai-portal/backend/app/api/partner.py`
+
+- `/public-bot-config` returns `404` or `403` when
+  `public_share_enabled=false`.
+- Keep `/widget-config` embed behavior separate from public share behavior.
+- Audit public-bot config fetches at low cardinality, or at minimum emit a
+  structured log with `org_id`, `widget_id`, and source IP.
+
+**Target:** `klai-portal/backend/app/api/admin_widgets.py`
+
+- Expose admin update/read support for the public-share flag.
+- Default newly-created widgets to private public-share disabled.
+- If current production behavior depends on existing public links, run a data
+  migration to set `public_share_enabled=true` for existing widgets that have
+  published bot links, or do a staged rollout with compatibility mode.
+
+**Target:** frontend/widget admin UI
+
+- Add a clear toggle in the embed/share tab.
+- Copy must distinguish:
+  - Embed origin restriction.
+  - Public share link availability.
+
+### Tests
+
+- `/public-bot-config` rejects by default.
+- Enabling public share returns the existing config payload and session token.
+- Disabling public share does not affect normal `/widget-config` when origin is
+  allowed.
+- Admin API persists and returns the flag.
+- Existing widget JWT tenant binding tests remain green.
+
+### Acceptance
+
+- A widget is not publicly accessible via `/bot/{widget_id}` unless an admin
+  explicitly enables public sharing.
+
+## CT-06 - Make OAuth Callback Tenant-Explicit
+
+### Problem
+
+The OAuth callback resolves `PortalUser` by `zitadel_user_id` only. For users
+with multiple tenant memberships, that can choose an arbitrary row before
+checking connector ownership.
+
+### Implementation
+
+**Target:** `klai-portal/backend/app/api/oauth.py`
+
+At authorize time:
+
+- Resolve the target connector and include `connector_id` and `org_id` in the
+  signed state payload.
+- If the flow starts from a KB slug instead of a connector id, resolve the KB
+  tenant explicitly and include `org_id`.
+
+At callback time:
+
+- Verify the signed `org_id`.
+- Load the connector by id and require `connector.org_id == payload["org_id"]`.
+- Validate that the current `user_id` has a `PortalUser` membership for that
+  exact `org_id`.
+- Set tenant only after the exact org membership and connector ownership are
+  confirmed.
+
+Avoid `db.scalar(select(PortalUser).where(PortalUser.zitadel_user_id == user_id))`
+for multi-tenant authorization decisions.
+
+### Tests
+
+- Multi-org user reconnects connector in org A while also member of org B; org A
+  connector succeeds.
+- Same user cannot complete callback for connector in org C where they have no
+  membership.
+- Tampered state `org_id` fails.
+- Connector-id and org-id mismatch fails with non-enumerating 404.
+
+### Acceptance
+
+- OAuth reconnect and credential writes are scoped to the tenant encoded in the
+  signed state and verified against exact user membership.
+
+## CT-07 - Direct Platform-admin Regression Tests
+
+### Problem
+
+The new platform-admin surface bypasses RLS for cross-org reads and performs
+tenant writes, but there are no direct backend tests for the new
+`platform.py` and `platform_manage.py` endpoint families.
+
+### Implementation
+
+**Target:** `klai-portal/backend/tests/`
+
+Add `tests/test_platform_admin_console.py` and
+`tests/test_platform_admin_manage.py`.
+
+Minimum test matrix:
+
+- Unauthenticated caller gets `401`.
+- Tenant admin gets `403`.
+- Platform org non-admin gets `403`.
+- Platform admin can read multiple orgs.
+- Each read endpoint writes `platform_admin.viewed`.
+- Role update uses `tenant_scoped_session(target_org)` and cannot affect a user
+  outside the target org.
+- Suspend/reactivate only mutate the target org membership.
+- Invite creates user in the target org, not the platform org.
+- Delete semantics from CT-01.
+- Rollback semantics from CT-03.
+
+Also add code-level guard tests:
+
+- Every route in `app/api/admin/platform.py` has `require_platform_admin()`.
+- Every cross-org read endpoint uses `cross_org_session()`.
+- `platform_manage.py` does not import or use `cross_org_session()` for writes.
+
+### Acceptance
+
+- The platform-admin console has regression coverage for auth gates, RLS
+  strategy, audit logging, and destructive side effects.
+
+## CT-08 - Remove Tactical pip-audit Ignores
+
+### Problem
+
+CI currently ignores `CVE-2026-45409` for `idna`, while local `pip-audit`
+still reports `idna 3.13` with fix version `3.15`.
+
+### Implementation
+
+**Target:** `klai-portal/backend/pyproject.toml` and lockfile
+
+- Bump `idna` to `>=3.15` through the normal `uv` dependency workflow.
+- Regenerate `uv.lock`.
+- Run `uv run --with pip-audit pip-audit` without the `CVE-2026-45409` ignore.
+
+**Target:** `.github/workflows/portal-api.yml`
+
+- Remove `--ignore-vuln CVE-2026-45409`.
+- Re-evaluate `--ignore-vuln PYSEC-2025-183`. If local audit no longer reports
+  it, remove the ignore and its TODO comment as part of the same change.
+
+### Tests
+
+- `uv run --with pip-audit pip-audit` exits 0.
+- Portal backend tests still pass.
+
+### Acceptance
+
+- CI no longer suppresses the idna vulnerability.
+
+## Required Verification Before Merge
+
+Run from `klai-portal/backend`:
+
+```bash
+uv run pytest -q tests/test_platform_admin_console.py tests/test_platform_admin_manage.py
+uv run pytest -q tests/test_widget_config.py tests/test_widget_jwt_per_tenant.py tests/test_partner_dependencies.py tests/test_partner_chat.py tests/test_admin_widgets.py
+uv run pytest -q tests/test_oauth_routes.py
+uv run --with pip-audit pip-audit
+```
+
+Run full backend suite before release:
+
+```bash
+uv run pytest -q --tb=short
+```
+
+## Deployment Plan
+
+1. Deploy CT-01 and CT-02 together if possible. They both change account and
+   permission semantics and should be smoke-tested with one test tenant.
+2. Deploy CT-03 after CT-01/CT-02. Exercise platform invite and create-tenant
+   against a non-production Zitadel org first.
+3. Deploy CT-04 independently; low rollout risk with strong tests.
+4. Deploy CT-05 behind compatibility mode if public bot links are already in
+   customer use. Announce the explicit share toggle before flipping defaults.
+5. Deploy CT-06 after OAuth reconnect tests pass against Google/Microsoft test
+   connectors.
+6. CT-07 and CT-08 are merge gates, not runtime features.
+
+## Monitoring
+
+After rollout, monitor:
+
+- `platform_admin.user_deleted` audit rows with
+  `global_identity_deleted=true`.
+- `platform_admin.user_role_changed` count and MCP role notifier errors.
+- `platform_invite_*_failed` and `platform_create_tenant_*_failed` logs.
+- `/partner/v1/public-bot-config` 403/404 volume after CT-05.
+- OAuth callback 404/400 rate after CT-06.
+- pip-audit CI job status.
+
+## Open Questions
+
+1. Should tenant-admin delete keep the term "hard-delete" after CT-01, or
+   should the UI rename it to "remove from organization" unless this is the
+   final membership?
+2. Are existing `/bot/{widget_id}` links already shared with customers? This
+   decides whether CT-05 needs a migration/compatibility window.
+3. Is platform-admin identity deletion ever a supported support operation? If
+   yes, define a separate break-glass path with extra audit requirements.
+4. Which session systems must be revoked on suspend/delete beyond MCP tool-list
+   notifications?
+
+## Definition of Done
+
+- All CT-01 through CT-08 acceptance criteria are met.
+- No direct cross-tenant destructive side effect remains from tenant-scoped
+  platform actions.
+- Widget public exposure is explicit and tested.
+- OAuth callback scoping is tenant-explicit.
+- Platform-admin endpoint families have direct regression coverage.
+- `pip-audit` passes without the idna ignore.

--- a/klai-portal/backend/alembic/versions/34d8f876ffbf_portal_templates_rls_helper_policy.py
+++ b/klai-portal/backend/alembic/versions/34d8f876ffbf_portal_templates_rls_helper_policy.py
@@ -43,9 +43,6 @@ down_revision: str | None = "a4f72e913c8b"
 branch_labels: tuple[str, ...] | None = None
 depends_on: str | None = None
 
-_HELPER = "(_rls_current_org_id() IS NULL OR org_id = _rls_current_org_id())"
-_INLINE = "(org_id = NULLIF(current_setting('app.current_org_id', true), '')::int)"
-
 
 def upgrade() -> None:
     # ENABLE/FORCE are idempotent; the policy needs DROP+CREATE because
@@ -53,9 +50,15 @@ def upgrade() -> None:
     op.execute("ALTER TABLE portal_templates ENABLE ROW LEVEL SECURITY")
     op.execute("ALTER TABLE portal_templates FORCE ROW LEVEL SECURITY")
     op.execute("DROP POLICY IF EXISTS tenant_isolation ON portal_templates")
-    op.execute(f"CREATE POLICY tenant_isolation ON portal_templates USING {_HELPER}")
+    op.execute(
+        "CREATE POLICY tenant_isolation ON portal_templates "
+        "USING (_rls_current_org_id() IS NULL OR org_id = _rls_current_org_id())"
+    )
 
 
 def downgrade() -> None:
     op.execute("DROP POLICY IF EXISTS tenant_isolation ON portal_templates")
-    op.execute(f"CREATE POLICY tenant_isolation ON portal_templates USING {_INLINE}")
+    op.execute(
+        "CREATE POLICY tenant_isolation ON portal_templates "
+        "USING (org_id = NULLIF(current_setting('app.current_org_id', true), '')::int)"
+    )

--- a/klai-portal/backend/alembic/versions/5b7c9d1e2f3a_add_widget_public_share_enabled.py
+++ b/klai-portal/backend/alembic/versions/5b7c9d1e2f3a_add_widget_public_share_enabled.py
@@ -1,0 +1,62 @@
+"""add widget public share flag column
+
+Revision ID: 5b7c9d1e2f3a
+Revises: 34d8f876ffbf
+Create Date: 2026-05-24
+
+Move the public share-link toggle out of ``widgets.widget_config`` JSONB
+and into a first-class column. The flag controls unauthenticated public
+bot-link access, so it should be explicit in schema, defaults, migrations,
+and audit/review surfaces instead of being hidden in flexible JSON.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "5b7c9d1e2f3a"
+down_revision: str | None = "34d8f876ffbf"
+branch_labels: tuple[str, ...] | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "widgets",
+        sa.Column(
+            "public_share_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+    op.execute(
+        """
+        UPDATE widgets
+        SET public_share_enabled = COALESCE((widget_config ->> 'public_share_enabled')::boolean, false)
+        WHERE widget_config ? 'public_share_enabled'
+        """
+    )
+    op.execute(
+        """
+        UPDATE widgets
+        SET widget_config = widget_config - 'public_share_enabled'
+        WHERE widget_config ? 'public_share_enabled'
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        UPDATE widgets
+        SET widget_config = jsonb_set(
+            COALESCE(widget_config, '{}'::jsonb),
+            '{public_share_enabled}',
+            to_jsonb(public_share_enabled),
+            true
+        )
+        """
+    )
+    op.drop_column("widgets", "public_share_enabled")

--- a/klai-portal/backend/app/api/admin/platform.py
+++ b/klai-portal/backend/app/api/admin/platform.py
@@ -246,28 +246,42 @@ async def platform_users(
 ) -> list[PlatformUser]:
     await _audit(perms, "users", search)
     params: dict[str, object] = {"limit": limit, "offset": offset}
-    where = "WHERE u.status <> 'offboarded'"
     if search:
-        where += " AND (u.email ILIKE :q OR u.display_name ILIKE :q OR o.name ILIKE :q)"
         params["q"] = f"%{search}%"
 
     async with cross_org_session() as db:
-        rows = (
-            await db.execute(
+        if search:
+            result = await db.execute(
                 text(
-                    "SELECT u.zitadel_user_id, u.email, u.display_name, u.role, "  # noqa: S608
+                    "SELECT u.zitadel_user_id, u.email, u.display_name, u.role, "
                     "u.status, u.created_at, o.id AS org_id, o.name AS org_name, "
                     "o.slug AS org_slug, o.plan AS org_plan, "
                     "o.provisioning_status AS prov "
                     "FROM portal_users u "
                     "JOIN portal_orgs o ON o.id = u.org_id "
-                    f"{where} "
+                    "WHERE u.status <> 'offboarded' "
+                    "AND (u.email ILIKE :q OR u.display_name ILIKE :q OR o.name ILIKE :q) "
                     "ORDER BY u.created_at DESC "
                     "LIMIT :limit OFFSET :offset"
                 ),
                 params,
             )
-        ).all()
+        else:
+            result = await db.execute(
+                text(
+                    "SELECT u.zitadel_user_id, u.email, u.display_name, u.role, "
+                    "u.status, u.created_at, o.id AS org_id, o.name AS org_name, "
+                    "o.slug AS org_slug, o.plan AS org_plan, "
+                    "o.provisioning_status AS prov "
+                    "FROM portal_users u "
+                    "JOIN portal_orgs o ON o.id = u.org_id "
+                    "WHERE u.status <> 'offboarded' "
+                    "ORDER BY u.created_at DESC "
+                    "LIMIT :limit OFFSET :offset"
+                ),
+                params,
+            )
+        rows = result.all()
 
     identity = await _zitadel_identity_map()
 
@@ -297,16 +311,14 @@ async def platform_organizations(
 ) -> list[PlatformOrg]:
     await _audit(perms, "organizations", search)
     params: dict[str, object] = {}
-    where = "WHERE o.deleted_at IS NULL"
     if search:
-        where += " AND (o.name ILIKE :q OR o.slug ILIKE :q)"
         params["q"] = f"%{search}%"
 
     async with cross_org_session() as db:
-        rows = (
-            await db.execute(
+        if search:
+            result = await db.execute(
                 text(
-                    "SELECT o.id, o.name, o.slug, o.plan, o.billing_status, "  # noqa: S608
+                    "SELECT o.id, o.name, o.slug, o.plan, o.billing_status, "
                     "o.billing_cycle, o.seats, o.provisioning_status, o.created_at, "
                     "(SELECT COUNT(*) FROM portal_users u "
                     "  WHERE u.org_id = o.id AND u.status <> 'offboarded') AS user_count, "
@@ -314,12 +326,29 @@ async def platform_organizations(
                     "(SELECT COUNT(*) FROM portal_knowledge_bases kb "
                     "  WHERE kb.org_id = o.id) AS kb_count "
                     "FROM portal_orgs o "
-                    f"{where} "
+                    "WHERE o.deleted_at IS NULL "
+                    "AND (o.name ILIKE :q OR o.slug ILIKE :q) "
                     "ORDER BY o.created_at DESC"
                 ),
                 params,
             )
-        ).all()
+        else:
+            result = await db.execute(
+                text(
+                    "SELECT o.id, o.name, o.slug, o.plan, o.billing_status, "
+                    "o.billing_cycle, o.seats, o.provisioning_status, o.created_at, "
+                    "(SELECT COUNT(*) FROM portal_users u "
+                    "  WHERE u.org_id = o.id AND u.status <> 'offboarded') AS user_count, "
+                    "(SELECT COUNT(*) FROM widgets w WHERE w.org_id = o.id) AS bot_count, "
+                    "(SELECT COUNT(*) FROM portal_knowledge_bases kb "
+                    "  WHERE kb.org_id = o.id) AS kb_count "
+                    "FROM portal_orgs o "
+                    "WHERE o.deleted_at IS NULL "
+                    "ORDER BY o.created_at DESC"
+                ),
+                params,
+            )
+        rows = result.all()
 
     return [
         PlatformOrg(
@@ -511,27 +540,38 @@ async def platform_bots(
 ) -> list[PlatformBot]:
     await _audit(perms, "bots", search)
     params: dict[str, object] = {}
-    where = ""
     if search:
-        where = "WHERE (w.name ILIKE :q OR o.name ILIKE :q)"
         params["q"] = f"%{search}%"
 
     async with cross_org_session() as db:
-        rows = (
-            await db.execute(
+        if search:
+            result = await db.execute(
                 text(
-                    "SELECT w.id, w.name, w.widget_id, w.created_at, "  # noqa: S608
+                    "SELECT w.id, w.name, w.widget_id, w.created_at, "
                     "o.id AS org_id, o.name AS org_name, o.slug AS org_slug, "
                     "(SELECT COUNT(*) FROM widget_kb_access k "
                     "  WHERE k.widget_id = w.id) AS kb_count "
                     "FROM widgets w "
                     "JOIN portal_orgs o ON o.id = w.org_id "
-                    f"{where} "
+                    "WHERE (w.name ILIKE :q OR o.name ILIKE :q) "
                     "ORDER BY w.created_at DESC"
                 ),
                 params,
             )
-        ).all()
+        else:
+            result = await db.execute(
+                text(
+                    "SELECT w.id, w.name, w.widget_id, w.created_at, "
+                    "o.id AS org_id, o.name AS org_name, o.slug AS org_slug, "
+                    "(SELECT COUNT(*) FROM widget_kb_access k "
+                    "  WHERE k.widget_id = w.id) AS kb_count "
+                    "FROM widgets w "
+                    "JOIN portal_orgs o ON o.id = w.org_id "
+                    "ORDER BY w.created_at DESC"
+                ),
+                params,
+            )
+        rows = result.all()
 
     return [
         PlatformBot(
@@ -556,26 +596,36 @@ async def platform_knowledge_bases(
     """Cross-tenant list of all knowledge bases."""
     await _audit(perms, "knowledge-bases", search)
     params: dict[str, object] = {}
-    where = ""
     if search:
-        where = "WHERE (kb.name ILIKE :q OR o.name ILIKE :q)"
         params["q"] = f"%{search}%"
 
     async with cross_org_session() as db:
-        rows = (
-            await db.execute(
+        if search:
+            result = await db.execute(
                 text(
-                    "SELECT kb.id, kb.name, kb.slug, kb.owner_type, "  # noqa: S608
+                    "SELECT kb.id, kb.name, kb.slug, kb.owner_type, "
                     "kb.visibility, kb.created_at, "
                     "o.id AS org_id, o.name AS org_name, o.slug AS org_slug "
                     "FROM portal_knowledge_bases kb "
                     "JOIN portal_orgs o ON o.id = kb.org_id "
-                    f"{where} "
+                    "WHERE (kb.name ILIKE :q OR o.name ILIKE :q) "
                     "ORDER BY kb.created_at DESC"
                 ),
                 params,
             )
-        ).all()
+        else:
+            result = await db.execute(
+                text(
+                    "SELECT kb.id, kb.name, kb.slug, kb.owner_type, "
+                    "kb.visibility, kb.created_at, "
+                    "o.id AS org_id, o.name AS org_name, o.slug AS org_slug "
+                    "FROM portal_knowledge_bases kb "
+                    "JOIN portal_orgs o ON o.id = kb.org_id "
+                    "ORDER BY kb.created_at DESC"
+                ),
+                params,
+            )
+        rows = result.all()
 
     return [
         PlatformKB(
@@ -601,16 +651,14 @@ async def platform_templates(
     """Cross-tenant list of all chat templates (org + personal)."""
     await _audit(perms, "templates", search)
     params: dict[str, object] = {}
-    where = ""
     if search:
-        where = "WHERE (t.name ILIKE :q OR o.name ILIKE :q)"
         params["q"] = f"%{search}%"
 
     async with cross_org_session() as db:
-        rows = (
-            await db.execute(
+        if search:
+            result = await db.execute(
                 text(
-                    "SELECT t.id, t.name, t.slug, t.scope, t.created_by, "  # noqa: S608
+                    "SELECT t.id, t.name, t.slug, t.scope, t.created_by, "
                     "t.is_active, t.created_at, "
                     "o.id AS org_id, o.name AS org_name, o.slug AS org_slug, "
                     "COALESCE(u.display_name, u.email) AS created_by_name "
@@ -618,12 +666,27 @@ async def platform_templates(
                     "JOIN portal_orgs o ON o.id = t.org_id "
                     "LEFT JOIN portal_users u "
                     "  ON u.zitadel_user_id = t.created_by AND u.org_id = t.org_id "
-                    f"{where} "
+                    "WHERE (t.name ILIKE :q OR o.name ILIKE :q) "
                     "ORDER BY t.created_at DESC"
                 ),
                 params,
             )
-        ).all()
+        else:
+            result = await db.execute(
+                text(
+                    "SELECT t.id, t.name, t.slug, t.scope, t.created_by, "
+                    "t.is_active, t.created_at, "
+                    "o.id AS org_id, o.name AS org_name, o.slug AS org_slug, "
+                    "COALESCE(u.display_name, u.email) AS created_by_name "
+                    "FROM portal_templates t "
+                    "JOIN portal_orgs o ON o.id = t.org_id "
+                    "LEFT JOIN portal_users u "
+                    "  ON u.zitadel_user_id = t.created_by AND u.org_id = t.org_id "
+                    "ORDER BY t.created_at DESC"
+                ),
+                params,
+            )
+        rows = result.all()
 
     return [
         PlatformTemplate(

--- a/klai-portal/backend/app/api/admin/platform_manage.py
+++ b/klai-portal/backend/app/api/admin/platform_manage.py
@@ -42,7 +42,9 @@ from app.models.portal import PortalOrg, PortalUser
 from app.services.audit import log_event
 from app.services.auth_links import AuthLinkRoute, build_url_template
 from app.services.default_knowledge_bases import create_default_personal_kb
+from app.services.mcp_role_notifier import fire_role_change_notification
 from app.services.provisioning import provision_tenant
+from app.services.user_memberships import get_user_membership_summary
 from app.services.zitadel import zitadel
 
 
@@ -108,6 +110,14 @@ async def _load_org_or_404(org_id: int) -> PortalOrg:
     return org
 
 
+async def _rollback_zitadel_user(zitadel_user_id: str) -> None:
+    with suppress(Exception):
+        await zitadel.remove_user(
+            org_id=settings_zitadel_portal_org_id(),
+            zitadel_user_id=zitadel_user_id,
+        )
+
+
 # ---------------------------------------------------------------------------
 # Role change
 # ---------------------------------------------------------------------------
@@ -161,6 +171,7 @@ async def platform_update_role(
         user.role = body.role
         await db.commit()
 
+    fire_role_change_notification(zitadel_user_id)
     await log_event(
         org_id=perms.org_id,
         actor=perms.user_id,
@@ -205,6 +216,7 @@ async def platform_suspend(
         user.status = "suspended"
         await db.commit()
 
+    fire_role_change_notification(zitadel_user_id)
     await log_event(
         org_id=perms.org_id,
         actor=perms.user_id,
@@ -244,6 +256,7 @@ async def platform_reactivate(
         user.status = "active"
         await db.commit()
 
+    fire_role_change_notification(zitadel_user_id)
     await log_event(
         org_id=perms.org_id,
         actor=perms.user_id,
@@ -278,13 +291,15 @@ async def platform_delete_user(
     Deleting the sole owner of a tenant leaves an empty org — use the
     tenant-deprovision endpoint to remove the whole tenant instead.
     """
-    from app.core.config import settings  # local import avoids cycle
     from app.services.kb_offboarding import (
         KbDisposition,
         apply_dispositions,
         compute_offboard_preview,
         revoke_user_credentials,
     )
+
+    if zitadel_user_id == perms.user_id:
+        raise HTTPException(status_code=409, detail="Platform-admin kan zichzelf niet verwijderen.")
 
     async with tenant_scoped_session(org_id) as db:
         org = (await db.execute(select(PortalOrg).where(PortalOrg.id == org_id))).scalar_one_or_none()
@@ -301,6 +316,17 @@ async def platform_delete_user(
         if user is None:
             raise HTTPException(status_code=404, detail="Gebruiker niet gevonden")
 
+        membership_summary = await get_user_membership_summary(
+            zitadel_user_id,
+            excluding_org_id=org_id,
+        )
+        if membership_summary.is_platform_admin:
+            raise HTTPException(
+                status_code=409,
+                detail="Platform-admin identities kunnen niet via tenant-delete worden verwijderd.",
+            )
+        delete_global_identity = membership_summary.remaining_count == 0
+
         # 1. Purge KBs: personal + solely-owned org KBs (complete delete).
         preview = await compute_offboard_preview(zitadel_user_id, org_id, db)
         dispositions = [
@@ -313,20 +339,22 @@ async def platform_delete_user(
         # 2. Revoke partner API keys + MCP tokens.
         api_keys, mcp_tokens = await revoke_user_credentials(zitadel_user_id, org_id, db)
 
-        # 3. Delete the Zitadel identity (frees the email). External call first:
-        #    a failure here aborts before any DB commit (session rolls back).
-        try:
-            await zitadel.remove_user(
-                org_id=settings.zitadel_portal_org_id,
-                zitadel_user_id=zitadel_user_id,
-            )
-        except Exception as exc:
-            raise HTTPException(status_code=502, detail=f"Zitadel-verwijdering mislukt: {exc}") from exc
+        # 3. Delete the global Zitadel identity only when this was the last
+        # tenant membership. Multi-tenant users keep their login elsewhere.
+        if delete_global_identity:
+            try:
+                await zitadel.remove_user(
+                    org_id=settings_zitadel_portal_org_id(),
+                    zitadel_user_id=zitadel_user_id,
+                )
+            except Exception as exc:
+                raise HTTPException(status_code=502, detail=f"Zitadel-verwijdering mislukt: {exc}") from exc
 
         # 4. Delete the portal_users row (cascades memberships/capabilities).
         await db.delete(user)
         await db.commit()
 
+    fire_role_change_notification(zitadel_user_id)
     await log_event(
         org_id=perms.org_id,
         actor=perms.user_id,
@@ -338,9 +366,12 @@ async def platform_delete_user(
             "kbs_deleted": len(dispositions),
             "api_keys_revoked": api_keys,
             "mcp_tokens_revoked": mcp_tokens,
+            "global_identity_deleted": delete_global_identity,
+            "remaining_membership_count": membership_summary.remaining_count,
         },
     )
-    return MessageResponse(message="Gebruiker volledig verwijderd.")
+    message = "Gebruiker volledig verwijderd." if delete_global_identity else "Gebruiker uit tenant verwijderd."
+    return MessageResponse(message=message)
 
 
 # ---------------------------------------------------------------------------
@@ -388,22 +419,7 @@ async def platform_invite(
         raise HTTPException(status_code=502, detail=f"Zitadel invite mislukt: {exc}") from exc
     zitadel_user_id: str = user_data["userId"]
 
-    # 2. Send the activation mail with the Klai url-template.
-    invite_url_template = build_url_template(AuthLinkRoute.PASSWORD_SET)
-    try:
-        await zitadel.send_invite_code(zitadel_user_id, url_template=invite_url_template)
-    except Exception as exc:
-        logger.exception("platform_invite_mail_failed", zitadel_user_id=zitadel_user_id)
-        raise HTTPException(
-            status_code=502,
-            detail={
-                "code": "invite_partial_failure",
-                "user_id": zitadel_user_id,
-                "message": "User aangemaakt maar invite-mail mislukt.",
-            },
-        ) from exc
-
-    # 3. Admin-only Zitadel grant.
+    # 2. Admin-only Zitadel grant.
     zitadel_role = _ZITADEL_ROLE_BY_PORTAL_ROLE.get(body.role)
     if zitadel_role is not None:
         try:
@@ -414,20 +430,36 @@ async def platform_invite(
             )
         except Exception as exc:
             logger.exception("platform_invite_grant_failed", zitadel_user_id=zitadel_user_id)
+            await _rollback_zitadel_user(zitadel_user_id)
             raise HTTPException(status_code=502, detail=f"Rol-grant mislukt: {exc}") from exc
 
-    # 4. portal_user row + personal KB in the TARGET tenant context.
-    async with tenant_scoped_session(org_id) as db:
-        user_row = PortalUser(
-            zitadel_user_id=zitadel_user_id,
-            org_id=org_id,
-            role=body.role,
-            seat_type=str(suggest_seat(body.role)),
-            preferred_language=body.preferred_language,
-        )
-        db.add(user_row)
-        await create_default_personal_kb(zitadel_user_id, org_id, db)
-        await db.commit()
+    # 3. portal_user row + personal KB in the TARGET tenant context.
+    try:
+        async with tenant_scoped_session(org_id) as db:
+            user_row = PortalUser(
+                zitadel_user_id=zitadel_user_id,
+                org_id=org_id,
+                role=body.role,
+                seat_type=str(suggest_seat(body.role)),
+                preferred_language=body.preferred_language,
+            )
+            db.add(user_row)
+            await create_default_personal_kb(zitadel_user_id, org_id, db)
+            await db.commit()
+    except Exception:
+        logger.exception("platform_invite_db_failed", zitadel_user_id=zitadel_user_id)
+        await _rollback_zitadel_user(zitadel_user_id)
+        raise
+
+    # 4. Send the activation mail after the portal row exists. If mail fails,
+    # keep the valid portal account so support can retry delivery.
+    invite_url_template = build_url_template(AuthLinkRoute.PASSWORD_SET)
+    mail_sent = True
+    try:
+        await zitadel.send_invite_code(zitadel_user_id, url_template=invite_url_template)
+    except Exception:
+        logger.exception("platform_invite_mail_failed", zitadel_user_id=zitadel_user_id)
+        mail_sent = False
 
     await log_event(
         org_id=perms.org_id,
@@ -440,11 +472,17 @@ async def platform_invite(
             "target_org_slug": org.slug,
             "role": body.role,
             "url_template_host": urlparse(invite_url_template).netloc,
+            "invite_mail_sent": mail_sent,
         },
+    )
+    message = (
+        f"Uitnodiging verstuurd naar {body.email}."
+        if mail_sent
+        else f"User aangemaakt voor {body.email}, maar invite-mail kon niet worden verstuurd."
     )
     return PlatformInviteResponse(
         user_id=zitadel_user_id,
-        message=f"Uitnodiging verstuurd naar {body.email}.",
+        message=message,
     )
 
 
@@ -492,10 +530,9 @@ async def platform_create_tenant(
         raise HTTPException(status_code=502, detail=f"Org-creatie mislukt: {exc}") from exc
     zitadel_org_id: str = org_data["id"]
 
-    # Orphan-prevention: every failure AFTER create_org must cascade-delete
-    # the Zitadel org, else a half-built tenant leaks (and retry with the same
-    # email/company 409s on "already exists"). delete_org is idempotent and
-    # cascades users + grants.
+    # Orphan-prevention: every failure AFTER create_org must delete both the
+    # new tenant org and, once created below, the owner user in the central
+    # portal org.
     async def _rollback_zitadel_org() -> None:
         with suppress(Exception):
             await zitadel.delete_org(zitadel_org_id)
@@ -515,9 +552,7 @@ async def platform_create_tenant(
         raise HTTPException(status_code=502, detail=f"Owner-creatie mislukt: {exc}") from exc
     owner_user_id: str = user_data["userId"]
 
-    invite_url_template = build_url_template(AuthLinkRoute.PASSWORD_SET)
     try:
-        await zitadel.send_invite_code(owner_user_id, url_template=invite_url_template)
         await zitadel.grant_user_role(
             org_id=settings_zitadel_portal_org_id(),
             user_id=owner_user_id,
@@ -525,6 +560,7 @@ async def platform_create_tenant(
         )
     except Exception as exc:
         logger.exception("platform_create_tenant_owner_setup_failed", email=body.owner_email)
+        await _rollback_zitadel_user(owner_user_id)
         await _rollback_zitadel_org()
         raise HTTPException(status_code=502, detail=f"Owner-setup mislukt: {exc}") from exc
 
@@ -555,8 +591,17 @@ async def platform_create_tenant(
     except Exception as exc:
         await db.rollback()
         logger.exception("platform_create_tenant_db_failed", email=body.owner_email)
+        await _rollback_zitadel_user(owner_user_id)
         await _rollback_zitadel_org()
         raise HTTPException(status_code=502, detail=f"Opslaan mislukt: {exc}") from exc
+
+    invite_url_template = build_url_template(AuthLinkRoute.PASSWORD_SET)
+    mail_sent = True
+    try:
+        await zitadel.send_invite_code(owner_user_id, url_template=invite_url_template)
+    except Exception:
+        logger.exception("platform_create_tenant_owner_mail_failed", email=body.owner_email)
+        mail_sent = False
 
     # 4. Cache + provisioning. Local import avoids an auth.py import cycle.
     from app.api.auth import invalidate_tenant_slug_cache
@@ -574,13 +619,19 @@ async def platform_create_tenant(
             "slug": org_row.slug,
             "company_name": body.company_name,
             "owner_email": body.owner_email,
+            "invite_mail_sent": mail_sent,
         },
+    )
+    message = (
+        f"Tenant '{body.company_name}' aangemaakt. Provisioning gestart."
+        if mail_sent
+        else f"Tenant '{body.company_name}' aangemaakt, maar owner invite-mail kon niet worden verstuurd."
     )
     return CreateTenantResponse(
         org_id=org_row.id,
         slug=org_row.slug,
         owner_user_id=owner_user_id,
-        message=f"Tenant '{body.company_name}' aangemaakt. Provisioning gestart.",
+        message=message,
     )
 
 

--- a/klai-portal/backend/app/api/admin/users.py
+++ b/klai-portal/backend/app/api/admin/users.py
@@ -39,6 +39,7 @@ from app.services.kb_offboarding import (
     revoke_user_credentials,
 )
 from app.services.mcp_role_notifier import fire_role_change_notification
+from app.services.user_memberships import get_user_membership_summary
 from app.services.zitadel import zitadel
 
 logger = logging.getLogger(__name__)
@@ -584,6 +585,12 @@ async def remove_user(
     perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
 ) -> MessageResponse:
+    if zitadel_user_id == perms.user_id:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Use leave workspace instead of deleting your own account.",
+        )
+
     # Verify user belongs to this org before deleting
     result = await db.execute(
         select(PortalUser).where(
@@ -595,19 +602,33 @@ async def remove_user(
     if not user:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
-    try:
-        await zitadel.remove_user(org_id=settings.zitadel_portal_org_id, zitadel_user_id=zitadel_user_id)
-    except Exception as exc:
-        logger.exception("User removal failed for user %s: %s", zitadel_user_id, exc)
+    membership_summary = await get_user_membership_summary(
+        zitadel_user_id,
+        excluding_org_id=perms.org_id,
+    )
+    if membership_summary.is_platform_admin:
         raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=f"Failed to delete user: {exc}",
-        ) from exc
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Platform-admin identities cannot be deleted from a tenant admin surface.",
+        )
+
+    delete_global_identity = membership_summary.remaining_count == 0
+    if delete_global_identity:
+        try:
+            await zitadel.remove_user(org_id=settings.zitadel_portal_org_id, zitadel_user_id=zitadel_user_id)
+        except Exception as exc:
+            logger.exception("User removal failed for user %s: %s", zitadel_user_id, exc)
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail=f"Failed to delete user: {exc}",
+            ) from exc
 
     await db.delete(user)
     await db.commit()
+    fire_role_change_notification(zitadel_user_id)
 
-    return MessageResponse(message="User deleted.")
+    message = "User deleted." if delete_global_identity else "User removed from organization."
+    return MessageResponse(message=message)
 
 
 @router.post("/users/{zitadel_user_id}/suspend", response_model=MessageResponse)

--- a/klai-portal/backend/app/api/admin_widgets.py
+++ b/klai-portal/backend/app/api/admin_widgets.py
@@ -77,6 +77,7 @@ class CreateWidgetRequest(BaseModel):
     kb_ids: list[int] = Field(default_factory=list)
     rate_limit_rpm: int = Field(default=60, ge=10, le=600)
     widget_config: WidgetConfig | None = None
+    public_share_enabled: bool = False
 
 
 class WidgetResponse(BaseModel):
@@ -85,6 +86,7 @@ class WidgetResponse(BaseModel):
     description: str | None
     widget_id: str
     widget_config: WidgetConfig
+    public_share_enabled: bool
     kb_access_count: int
     rate_limit_rpm: int
     last_used_at: str | None
@@ -102,6 +104,7 @@ class UpdateWidgetRequest(BaseModel):
     kb_ids: list[int] | None = None
     rate_limit_rpm: int | None = None
     widget_config: WidgetConfig | None = None
+    public_share_enabled: bool | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -132,6 +135,7 @@ def _widget_to_response(widget: Widget, kb_access_count: int) -> WidgetResponse:
             collect_user_info=config.get("collect_user_info", False),
             widget_position=config.get("widget_position", "right"),
         ),
+        public_share_enabled=widget.public_share_enabled,
         kb_access_count=kb_access_count,
         rate_limit_rpm=widget.rate_limit_rpm,
         last_used_at=str(widget.last_used_at) if widget.last_used_at else None,
@@ -206,6 +210,7 @@ async def create_widget(
         description=body.description,
         widget_id=widget_id_str,
         widget_config=config,
+        public_share_enabled=body.public_share_enabled,
         rate_limit_rpm=body.rate_limit_rpm,
         created_by=perms.user_id,
     )
@@ -380,6 +385,8 @@ async def update_widget(
         widget.rate_limit_rpm = body.rate_limit_rpm
     if body.widget_config is not None:
         widget.widget_config = body.widget_config.model_dump()
+    if body.public_share_enabled is not None:
+        widget.public_share_enabled = body.public_share_enabled
 
     if body.kb_ids is not None:
         await _validate_kb_ids(body.kb_ids, perms.org_id, db)
@@ -504,26 +511,36 @@ async def list_widget_conversations(
     widget = await _get_widget_or_404(widget_id, perms.org_id, db)
 
     params: dict[str, object] = {"widget_id": widget.id, "limit": limit}
-    cursor_clause = ""
     if cursor:
         try:
             cursor_dt = datetime.fromisoformat(cursor.replace("Z", "+00:00"))
             params["cursor"] = cursor_dt
-            cursor_clause = "AND started_at < :cursor"
         except ValueError as exc:
             raise HTTPException(status_code=400, detail="invalid cursor") from exc
 
-    # cursor_clause is a hardcoded string literal ("" or fixed SQL),
-    # never user-controlled — every dynamic value is a bound :param.
-    sql = (
-        "SELECT id, started_at, last_message_at, message_count, "  # noqa: S608
-        "first_user_query, language_detected "
-        "FROM widget_conversations "
-        "WHERE widget_id = CAST(:widget_id AS uuid) "
-        f"{cursor_clause} "
-        "ORDER BY started_at DESC LIMIT :limit"
-    )
-    result = await db.execute(text(sql), params)
+    if cursor:
+        result = await db.execute(
+            text(
+                "SELECT id, started_at, last_message_at, message_count, "
+                "first_user_query, language_detected "
+                "FROM widget_conversations "
+                "WHERE widget_id = CAST(:widget_id AS uuid) "
+                "AND started_at < :cursor "
+                "ORDER BY started_at DESC LIMIT :limit"
+            ),
+            params,
+        )
+    else:
+        result = await db.execute(
+            text(
+                "SELECT id, started_at, last_message_at, message_count, "
+                "first_user_query, language_detected "
+                "FROM widget_conversations "
+                "WHERE widget_id = CAST(:widget_id AS uuid) "
+                "ORDER BY started_at DESC LIMIT :limit"
+            ),
+            params,
+        )
     rows = result.all()
     return [
         ConversationListItem(
@@ -614,45 +631,83 @@ async def widget_activity_stats(
     cutoff = _period_cutoff(period)
 
     params: dict[str, object] = {"widget_id": widget.id}
-    cutoff_clause = ""
     if cutoff is not None:
         params["cutoff"] = cutoff
-        cutoff_clause = "AND started_at >= :cutoff"
 
-    # cutoff_clause is a hardcoded literal — see comment above.
-    totals_sql = (
-        "SELECT COUNT(*) AS total_conversations, "  # noqa: S608
-        "COALESCE(SUM(message_count), 0) AS total_messages "
-        "FROM widget_conversations "
-        "WHERE widget_id = CAST(:widget_id AS uuid) "
-        f"{cutoff_clause}"
-    )
-    totals_result = await db.execute(text(totals_sql), params)
+    if cutoff is not None:
+        totals_result = await db.execute(
+            text(
+                "SELECT COUNT(*) AS total_conversations, "
+                "COALESCE(SUM(message_count), 0) AS total_messages "
+                "FROM widget_conversations "
+                "WHERE widget_id = CAST(:widget_id AS uuid) "
+                "AND started_at >= :cutoff"
+            ),
+            params,
+        )
+    else:
+        totals_result = await db.execute(
+            text(
+                "SELECT COUNT(*) AS total_conversations, "
+                "COALESCE(SUM(message_count), 0) AS total_messages "
+                "FROM widget_conversations "
+                "WHERE widget_id = CAST(:widget_id AS uuid)"
+            ),
+            params,
+        )
     totals = totals_result.first()
     total_conversations = totals.total_conversations if totals else 0
     total_messages = totals.total_messages if totals else 0
     avg = round(total_messages / total_conversations, 2) if total_conversations else 0.0
 
-    top_sql = (
-        "SELECT first_user_query AS q, COUNT(*) AS c "  # noqa: S608
-        "FROM widget_conversations "
-        "WHERE widget_id = CAST(:widget_id AS uuid) "
-        "AND first_user_query IS NOT NULL "
-        f"{cutoff_clause} "
-        "GROUP BY first_user_query "
-        "ORDER BY c DESC, q ASC LIMIT 10"
-    )
-    top_result = await db.execute(text(top_sql), params)
+    if cutoff is not None:
+        top_result = await db.execute(
+            text(
+                "SELECT first_user_query AS q, COUNT(*) AS c "
+                "FROM widget_conversations "
+                "WHERE widget_id = CAST(:widget_id AS uuid) "
+                "AND first_user_query IS NOT NULL "
+                "AND started_at >= :cutoff "
+                "GROUP BY first_user_query "
+                "ORDER BY c DESC, q ASC LIMIT 10"
+            ),
+            params,
+        )
+    else:
+        top_result = await db.execute(
+            text(
+                "SELECT first_user_query AS q, COUNT(*) AS c "
+                "FROM widget_conversations "
+                "WHERE widget_id = CAST(:widget_id AS uuid) "
+                "AND first_user_query IS NOT NULL "
+                "GROUP BY first_user_query "
+                "ORDER BY c DESC, q ASC LIMIT 10"
+            ),
+            params,
+        )
     top_queries = [TopQuery(query=row.q, count=row.c) for row in top_result.all()]
 
-    hourly_sql = (
-        "SELECT EXTRACT(HOUR FROM started_at)::int AS hour, COUNT(*) AS c "  # noqa: S608
-        "FROM widget_conversations "
-        "WHERE widget_id = CAST(:widget_id AS uuid) "
-        f"{cutoff_clause} "
-        "GROUP BY hour"
-    )
-    hourly_result = await db.execute(text(hourly_sql), params)
+    if cutoff is not None:
+        hourly_result = await db.execute(
+            text(
+                "SELECT EXTRACT(HOUR FROM started_at)::int AS hour, COUNT(*) AS c "
+                "FROM widget_conversations "
+                "WHERE widget_id = CAST(:widget_id AS uuid) "
+                "AND started_at >= :cutoff "
+                "GROUP BY hour"
+            ),
+            params,
+        )
+    else:
+        hourly_result = await db.execute(
+            text(
+                "SELECT EXTRACT(HOUR FROM started_at)::int AS hour, COUNT(*) AS c "
+                "FROM widget_conversations "
+                "WHERE widget_id = CAST(:widget_id AS uuid) "
+                "GROUP BY hour"
+            ),
+            params,
+        )
     hourly = [0] * 24
     for row in hourly_result.all():
         if 0 <= row.hour <= 23:

--- a/klai-portal/backend/app/api/oauth.py
+++ b/klai-portal/backend/app/api/oauth.py
@@ -33,7 +33,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.api.auth import get_current_user_id
 from app.core.config import settings
 from app.core.database import get_db, set_tenant
+from app.core.permissions import UserPermissions, get_caller
 from app.models.connectors import PortalConnector
+from app.models.knowledge_bases import PortalKnowledgeBase
 from app.models.portal import PortalUser
 from app.services.connector_credentials import credential_store
 from app.services.events import emit_event
@@ -119,6 +121,79 @@ def _provider_enabled(provider: str) -> bool:
     if provider == "ms_docs":
         return bool(settings.ms_docs_client_id)
     return False
+
+
+async def _user_has_membership(db: AsyncSession, user_id: str, org_id: int) -> bool:
+    user_pk = await db.scalar(
+        select(PortalUser.id).where(
+            PortalUser.zitadel_user_id == user_id,
+            PortalUser.org_id == org_id,
+        )
+    )
+    return user_pk is not None
+
+
+async def _resolve_state_org_id(
+    db: AsyncSession,
+    *,
+    user_id: str,
+    org_id: int,
+    kb_slug: str,
+    connector_id: str | None,
+) -> int:
+    await set_tenant(db, org_id)
+
+    if connector_id:
+        connector = await db.get(PortalConnector, connector_id)
+        if connector is None or connector.org_id != org_id:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Connector not found")
+        if not await _user_has_membership(db, user_id, org_id):
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Connector not found")
+        return org_id
+
+    result = await db.execute(
+        select(PortalKnowledgeBase.org_id).where(
+            PortalKnowledgeBase.slug == kb_slug,
+            PortalKnowledgeBase.org_id == org_id,
+        )
+    )
+    org_ids = list(dict.fromkeys(result.scalars().all()))
+    if not org_ids:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Knowledge base not found")
+    if len(org_ids) > 1:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Knowledge base slug is ambiguous")
+    return int(org_ids[0])
+
+
+async def _resolve_callback_connector(
+    db: AsyncSession,
+    *,
+    payload: dict[str, Any],
+    user_id: str,
+) -> tuple[PortalConnector, str]:
+    connector_id = payload.get("connector_id")
+    if not connector_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing connector_id")
+
+    connector = await db.get(PortalConnector, connector_id)
+    if connector is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Connector not found")
+
+    state_org_id = payload.get("org_id")
+    if state_org_id is None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid OAuth state")
+    try:
+        org_id = int(state_org_id)
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid OAuth state") from exc
+
+    if connector.org_id != org_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Connector not found")
+    if not await _user_has_membership(db, user_id, org_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Connector not found")
+
+    await set_tenant(db, org_id)
+    return connector, str(connector_id)
 
 
 def _emit_reconnect_failed(
@@ -221,7 +296,8 @@ async def authorize_provider(
     provider: str,
     kb_slug: str = Query(..., description="Knowledge base slug the new connector will sync into"),
     connector_id: str | None = Query(None, description="Existing connector UUID (reconnect flow)"),
-    user_id: str = Depends(get_current_user_id),
+    perms: UserPermissions = Depends(get_caller),
+    db: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """Return the provider consent URL and set the HttpOnly state cookie.
 
@@ -237,10 +313,19 @@ async def authorize_provider(
     if provider not in _SUPPORTED_PROVIDERS or not _provider_enabled(provider):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Provider not enabled")
 
+    org_id = await _resolve_state_org_id(
+        db,
+        user_id=perms.user_id,
+        org_id=perms.org_id,
+        kb_slug=kb_slug,
+        connector_id=connector_id,
+    )
+
     # Build signed state. nonce defends against replay even if state TTL is within window.
     state_payload: dict[str, Any] = {
         "provider": provider,
-        "user_id": user_id,
+        "user_id": perms.user_id,
+        "org_id": org_id,
         "kb_slug": kb_slug,
         "nonce": secrets.token_urlsafe(16),
     }
@@ -345,20 +430,7 @@ async def callback_provider(
         logger.warning("oauth_callback_state_invalid: provider=%s", provider)
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid OAuth state")
 
-    # 2. Resolve portal user and ensure the target connector belongs to their org.
-    user_row = await db.scalar(select(PortalUser).where(PortalUser.zitadel_user_id == user_id))
-    if user_row is None:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="User not found")
-
-    connector_id = payload.get("connector_id")
-    if not connector_id:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing connector_id")
-
-    connector = await db.get(PortalConnector, connector_id)
-    if connector is None or connector.org_id != user_row.org_id:
-        # 404 (not 403) to avoid leaking existence across tenants.
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Connector not found")
-    await set_tenant(db, connector.org_id)
+    connector, connector_id = await _resolve_callback_connector(db, payload=payload, user_id=user_id)
 
     # Detect reconnect-flow: connector already had encrypted credentials AND
     # was in auth_error. Used below to emit connector.reconnected /

--- a/klai-portal/backend/app/api/partner.py
+++ b/klai-portal/backend/app/api/partner.py
@@ -908,6 +908,8 @@ async def public_bot_config(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Widget not found")
 
     widget_config_data = widget_row.widget_config or {}
+    if not widget_row.public_share_enabled:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Widget not found")
 
     org_result = await db.execute(select(PortalOrg).where(PortalOrg.id == widget_row.org_id))
     org = org_result.scalar_one_or_none()

--- a/klai-portal/backend/app/models/widgets.py
+++ b/klai-portal/backend/app/models/widgets.py
@@ -15,6 +15,7 @@ from datetime import datetime
 
 from sqlalchemy import (
     BigInteger,
+    Boolean,
     CheckConstraint,
     DateTime,
     ForeignKey,
@@ -64,6 +65,7 @@ class Widget(Base):
         nullable=False,
         server_default='{"allowed_origins": [], "title": "", "welcome_message": "", "css_variables": {}}',
     )
+    public_share_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="false", default=False)
     rate_limit_rpm: Mapped[int] = mapped_column(Integer, nullable=False, server_default="60")
     last_used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())

--- a/klai-portal/backend/app/services/user_memberships.py
+++ b/klai-portal/backend/app/services/user_memberships.py
@@ -1,0 +1,53 @@
+"""Helpers for global user-membership decisions.
+
+The portal identity lives once in Zitadel, while ``portal_users`` can contain
+one row per tenant. Any code that may delete the global identity must first
+check whether other tenant memberships still exist.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy import select
+
+from app.core.config import settings
+from app.core.database import AsyncSessionLocal
+from app.models.portal import PortalOrg, PortalUser
+
+
+@dataclass(frozen=True)
+class UserMembershipSummary:
+    total_count: int
+    remaining_count: int
+    is_platform_admin: bool
+
+
+async def get_user_membership_summary(
+    zitadel_user_id: str,
+    *,
+    excluding_org_id: int | None = None,
+) -> UserMembershipSummary:
+    """Return global membership counts for one Zitadel identity.
+
+    ``portal_users`` is intentionally Cat-A RLS: a fresh session with no tenant
+    GUC can read memberships by ``zitadel_user_id`` so auth bootstrap can find
+    the caller's org. This helper uses that exact safe-read shape and returns
+    only aggregate facts needed for deletion decisions.
+    """
+
+    async with AsyncSessionLocal() as db:
+        result = await db.execute(
+            select(PortalUser.org_id, PortalUser.role, PortalOrg.slug)
+            .join(PortalOrg, PortalOrg.id == PortalUser.org_id)
+            .where(PortalUser.zitadel_user_id == zitadel_user_id)
+        )
+        rows = result.all()
+
+    remaining = [row for row in rows if excluding_org_id is None or row.org_id != excluding_org_id]
+    is_platform_admin = any(row.slug == settings.platform_org_slug and row.role == "admin" for row in rows)
+    return UserMembershipSummary(
+        total_count=len(rows),
+        remaining_count=len(remaining),
+        is_platform_admin=is_platform_admin,
+    )

--- a/klai-portal/backend/app/services/widget_auth.py
+++ b/klai-portal/backend/app/services/widget_auth.py
@@ -22,6 +22,7 @@ SPEC-SEC-HYGIENE-001 REQ-24:
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from urllib.parse import urlparse
 
 import jwt
 import structlog
@@ -170,24 +171,73 @@ def origin_allowed(origin: str, allowed_origins: list[str]) -> bool:
     if not allowed_origins:
         return True
 
-    normalised_origin = origin.rstrip("/")
+    origin_parts = _parse_origin(origin)
+    if origin_parts is None:
+        return False
 
     for allowed in allowed_origins:
-        allowed = allowed.rstrip("/")
+        allowed_parts = _parse_origin(allowed)
+        if allowed_parts is None:
+            continue
 
         # Wildcard subdomain: https://*.example.com
-        if "://*." in allowed:
-            # Extract the suffix after the wildcard (e.g. ".example.com")
-            scheme_end = allowed.index("://")
-            scheme = allowed[: scheme_end + 3]  # "https://"
-            suffix = allowed[scheme_end + 4 :]  # "example.com" (after "*.")
-
-            if normalised_origin.startswith(scheme) and normalised_origin.endswith(suffix):
-                # Verify there's actually a subdomain (not just the bare domain)
-                host_part = normalised_origin[len(scheme) :]
-                if host_part != suffix and host_part.endswith(suffix):
-                    return True
-        elif normalised_origin == allowed:
+        if allowed_parts.host.startswith("*."):
+            suffix = allowed_parts.host[2:]
+            if (
+                origin_parts.scheme == allowed_parts.scheme
+                and _ports_match(origin_parts, allowed_parts)
+                and origin_parts.host != suffix
+                and origin_parts.host.endswith("." + suffix)
+            ):
+                return True
+        elif (
+            origin_parts.scheme == allowed_parts.scheme
+            and origin_parts.host == allowed_parts.host
+            and _ports_match(origin_parts, allowed_parts)
+        ):
             return True
 
     return False
+
+
+class _OriginParts:
+    def __init__(self, *, scheme: str, host: str, port: int | None, explicit_port: bool) -> None:
+        self.scheme = scheme
+        self.host = host
+        self.port = port
+        self.explicit_port = explicit_port
+
+
+def _parse_origin(value: str) -> _OriginParts | None:
+    parsed = urlparse(value.rstrip("/"))
+    if not parsed.scheme or not parsed.hostname:
+        return None
+    if parsed.path not in ("", "/") or parsed.params or parsed.query or parsed.fragment:
+        return None
+    try:
+        port = parsed.port
+    except ValueError:
+        return None
+    explicit_port = ":" in parsed.netloc.rsplit("@", 1)[-1]
+    return _OriginParts(
+        scheme=parsed.scheme.lower(),
+        host=parsed.hostname.lower(),
+        port=port,
+        explicit_port=explicit_port,
+    )
+
+
+def _ports_match(origin: _OriginParts, allowed: _OriginParts) -> bool:
+    if not origin.explicit_port and not allowed.explicit_port:
+        return True
+    return _effective_port(origin) == _effective_port(allowed)
+
+
+def _effective_port(parts: _OriginParts) -> int | None:
+    if parts.port is not None:
+        return parts.port
+    if parts.scheme == "https":
+        return 443
+    if parts.scheme == "http":
+        return 80
+    return None

--- a/klai-portal/backend/tests/test_admin_users.py
+++ b/klai-portal/backend/tests/test_admin_users.py
@@ -191,6 +191,79 @@ async def test_invite_user_grants_portal_role_to_zitadel(
         )
 
 
+@pytest.mark.asyncio
+async def test_remove_user_keeps_global_identity_when_other_memberships_exist() -> None:
+    """Tenant admin delete must only remove the local membership for multi-org users."""
+    from app.api.admin.users import remove_user
+    from app.services.user_memberships import UserMembershipSummary
+
+    target_user = MagicMock()
+    target_user.zitadel_user_id = "user-U"
+    target_user.org_id = 101
+
+    mock_db = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = target_user
+    mock_db.execute.return_value = result
+    mock_db.delete = AsyncMock()
+
+    perms = make_perms(role="admin", user_id="admin-1", org_id=101)
+
+    with (
+        patch(
+            "app.api.admin.users.get_user_membership_summary",
+            new=AsyncMock(
+                return_value=UserMembershipSummary(total_count=2, remaining_count=1, is_platform_admin=False)
+            ),
+        ),
+        patch("app.api.admin.users.zitadel") as mock_zitadel,
+        patch("app.api.admin.users.fire_role_change_notification") as notify,
+    ):
+        mock_zitadel.remove_user = AsyncMock()
+        response = await remove_user(zitadel_user_id="user-U", perms=perms, db=mock_db)
+
+    mock_zitadel.remove_user.assert_not_awaited()
+    mock_db.delete.assert_awaited_once_with(target_user)
+    mock_db.commit.assert_awaited_once()
+    notify.assert_called_once_with("user-U")
+    assert response.message == "User removed from organization."
+
+
+@pytest.mark.asyncio
+async def test_remove_user_deletes_global_identity_for_last_membership() -> None:
+    """Global Zitadel delete is reserved for the final portal membership."""
+    from app.api.admin.users import remove_user
+    from app.services.user_memberships import UserMembershipSummary
+
+    target_user = MagicMock()
+    target_user.zitadel_user_id = "user-U"
+    target_user.org_id = 101
+
+    mock_db = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = target_user
+    mock_db.execute.return_value = result
+    mock_db.delete = AsyncMock()
+
+    perms = make_perms(role="admin", user_id="admin-1", org_id=101)
+
+    with (
+        patch(
+            "app.api.admin.users.get_user_membership_summary",
+            new=AsyncMock(
+                return_value=UserMembershipSummary(total_count=1, remaining_count=0, is_platform_admin=False)
+            ),
+        ),
+        patch("app.api.admin.users.zitadel") as mock_zitadel,
+        patch("app.api.admin.users.fire_role_change_notification"),
+    ):
+        mock_zitadel.remove_user = AsyncMock()
+        response = await remove_user(zitadel_user_id="user-U", perms=perms, db=mock_db)
+
+    mock_zitadel.remove_user.assert_awaited_once()
+    assert response.message == "User deleted."
+
+
 # @MX:ANCHOR — must remain coupled to invite_user's commit shape.
 # @MX:REASON: regression guard for the 2026-05-07 incident where the personal
 # KB was created AFTER `db.commit()`. The first commit cleared the

--- a/klai-portal/backend/tests/test_admin_widgets.py
+++ b/klai-portal/backend/tests/test_admin_widgets.py
@@ -85,6 +85,14 @@ def test_widget_config_defaults():
     assert config.welcome_message == ""
     assert config.system_prompt == ""
     assert config.css_variables == {}
+    assert "public_share_enabled" not in WidgetConfig.model_fields
+
+
+def test_widget_model_has_public_share_column():
+    """Public share state is a first-class widgets column, not JSON config."""
+    from app.models.widgets import Widget
+
+    assert "public_share_enabled" in Widget.__table__.c
 
 
 def test_widget_to_response_helper():
@@ -103,6 +111,7 @@ def test_widget_to_response_helper():
         "system_prompt": "Answer briefly.",
         "css_variables": {},
     }
+    widget.public_share_enabled = True
     widget.rate_limit_rpm = 60
     widget.last_used_at = None
     widget.created_at = "2026-01-01"
@@ -113,6 +122,7 @@ def test_widget_to_response_helper():
     assert resp.widget_id == "wgt_abc123"
     assert resp.widget_config.title == "Help"
     assert resp.widget_config.system_prompt == "Answer briefly."
+    assert resp.public_share_enabled is True
     assert resp.kb_access_count == 1
 
 

--- a/klai-portal/backend/tests/test_admin_widgets_integration.py
+++ b/klai-portal/backend/tests/test_admin_widgets_integration.py
@@ -31,6 +31,7 @@ class FakeWidgetRow:
             "css_variables": {},
         }
     )
+    public_share_enabled: bool = False
     rate_limit_rpm: int = 60
     last_used_at: datetime | None = None
     created_at: datetime = field(default_factory=lambda: datetime(2026, 1, 1, tzinfo=UTC))
@@ -74,6 +75,7 @@ async def test_create_widget_returns_wgt_id_no_api_key():
     assert not hasattr(result, "api_key")
     assert result.name == "Help Bot"
     assert result.widget_config.title == "Help"
+    assert result.public_share_enabled is False
     db.add.assert_called()
     db.commit.assert_awaited_once()
 
@@ -124,6 +126,7 @@ async def test_update_widget_patches_config():
             title="Updated",
             welcome_message="Hello!",
         ),
+        public_share_enabled=True,
     )
 
     with patch("app.api.admin_widgets.emit_event"):
@@ -136,6 +139,7 @@ async def test_update_widget_patches_config():
 
     assert result.widget_config.title == "Updated"
     assert result.widget_config.allowed_origins == ["https://new.example.com"]
+    assert result.public_share_enabled is True
     db.commit.assert_awaited_once()
 
 

--- a/klai-portal/backend/tests/test_oauth_routes.py
+++ b/klai-portal/backend/tests/test_oauth_routes.py
@@ -16,6 +16,8 @@ import httpx
 import pytest
 from fastapi import HTTPException
 
+from tests.conftest import make_perms
+
 # Test-only placeholder literals (NOT credentials)
 _PLACEHOLDER_COOKIE_KEY = "R1c1-s96uO9Yz7k1E0kN6qz52gzd9PwNbAeZaks_PIc="
 _PLACEHOLDER_INTERNAL = "placeholder-internal-value"  # nosec
@@ -54,6 +56,16 @@ def _mock_httpx_client(post_response: MagicMock) -> MagicMock:
     return cls
 
 
+class _ScalarListResult:
+    def __init__(self, values: list) -> None:
+        self._values = values
+
+    def scalars(self) -> MagicMock:
+        scalars = MagicMock()
+        scalars.all.return_value = self._values
+        return scalars
+
+
 # ---------------------------------------------------------------------------
 # GET /api/oauth/providers
 # ---------------------------------------------------------------------------
@@ -67,7 +79,10 @@ class TestProvidersEndpoint:
         """google_drive_client_id set -> google_drive enabled=True."""
         from app.api.oauth import list_providers
 
-        with patch("app.api.oauth.settings") as mock_settings:
+        with (
+            patch("app.api.oauth.settings") as mock_settings,
+            patch("app.api.oauth.set_tenant", new=AsyncMock()),
+        ):
             mock_settings.google_drive_client_id = _PLACEHOLDER_CLIENT_ID
             mock_settings.google_drive_client_secret = _PLACEHOLDER_CLIENT_SECRET
             mock_settings.ms_docs_client_id = ""
@@ -81,7 +96,10 @@ class TestProvidersEndpoint:
         """google_drive_client_id empty -> google_drive enabled=False."""
         from app.api.oauth import list_providers
 
-        with patch("app.api.oauth.settings") as mock_settings:
+        with (
+            patch("app.api.oauth.settings") as mock_settings,
+            patch("app.api.oauth.set_tenant", new=AsyncMock()),
+        ):
             mock_settings.google_drive_client_id = ""
             mock_settings.google_drive_client_secret = ""
             mock_settings.ms_docs_client_id = ""
@@ -103,8 +121,12 @@ class TestAuthorizeEndpoint:
     async def test_authorize_returns_authorize_url(self) -> None:
         """Returns 200 JSON with authorize_url pointing to accounts.google.com."""
         import json
+        from urllib.parse import parse_qs, urlparse
 
-        from app.api.oauth import authorize_provider
+        from app.api.oauth import _verify_state, authorize_provider
+
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=_ScalarListResult([42]))
 
         with patch("app.api.oauth.settings") as mock_settings:
             mock_settings.google_drive_client_id = _PLACEHOLDER_CLIENT_ID
@@ -116,19 +138,31 @@ class TestAuthorizeEndpoint:
             response = await authorize_provider(
                 provider="google_drive",
                 kb_slug="main",
-                user_id="zitadel-user-1",
+                connector_id=None,
+                perms=make_perms(user_id="zitadel-user-1", org_id=42),
+                db=db,
             )
 
             assert response.status_code == 200
             body = json.loads(response.body)
             assert body["authorize_url"].startswith("https://accounts.google.com/")
+            state = parse_qs(urlparse(body["authorize_url"]).query)["state"][0]
+            payload = _verify_state(state)
+            assert payload is not None
+            assert payload["org_id"] == 42
 
     @pytest.mark.asyncio
     async def test_authorize_sets_state_cookie(self) -> None:
         """Redirect response must set a signed klai_oauth_state cookie."""
         from app.api.oauth import authorize_provider
 
-        with patch("app.api.oauth.settings") as mock_settings:
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=_ScalarListResult([42]))
+
+        with (
+            patch("app.api.oauth.settings") as mock_settings,
+            patch("app.api.oauth.set_tenant", new=AsyncMock()),
+        ):
             mock_settings.google_drive_client_id = _PLACEHOLDER_CLIENT_ID
             mock_settings.google_drive_client_secret = _PLACEHOLDER_CLIENT_SECRET
             mock_settings.sso_cookie_key = _PLACEHOLDER_COOKIE_KEY
@@ -138,7 +172,9 @@ class TestAuthorizeEndpoint:
             response = await authorize_provider(
                 provider="google_drive",
                 kb_slug="main",
-                user_id="zitadel-user-1",
+                connector_id=None,
+                perms=make_perms(user_id="zitadel-user-1", org_id=42),
+                db=db,
             )
 
             set_cookie = response.headers.get("set-cookie", "")
@@ -158,7 +194,8 @@ class TestAuthorizeEndpoint:
                 await authorize_provider(
                     provider="google_drive",
                     kb_slug="main",
-                    user_id="zitadel-user-1",
+                    connector_id=None,
+                    perms=make_perms(user_id="zitadel-user-1", org_id=42),
                 )
 
             assert exc_info.value.status_code == 404
@@ -239,7 +276,12 @@ class TestCallbackEndpoint:
             mock_settings.domain = "getklai.com"
 
             state_token = _sign_state(
-                {"connector_id": "conn-uuid-1", "user_id": "zitadel-user-1", "provider": "google_drive"}
+                {
+                    "connector_id": "conn-uuid-1",
+                    "user_id": "zitadel-user-1",
+                    "provider": "google_drive",
+                    "org_id": 42,
+                }
             )
 
             db.scalar = AsyncMock(return_value=mock_portal_user)
@@ -265,6 +307,92 @@ class TestCallbackEndpoint:
             mock_store.encrypt_credentials.assert_called_once()
             db.commit.assert_awaited()
             assert mock_connector.encrypted_credentials == b"ENCRYPTED_BLOB"
+
+    @pytest.mark.asyncio
+    async def test_callback_rejects_state_without_org_id(self) -> None:
+        """OAuth callback state must carry the exact tenant id."""
+        from app.api.oauth import _sign_state, callback_provider
+
+        db = AsyncMock()
+
+        mock_connector = MagicMock()
+        mock_connector.id = "conn-uuid-1"
+        mock_connector.org_id = 42
+        mock_connector.connector_type = "google_drive"
+        mock_connector.config = {}
+        mock_connector.encrypted_credentials = None
+
+        with patch("app.api.oauth.settings") as mock_settings:
+            mock_settings.google_drive_client_id = _PLACEHOLDER_CLIENT_ID
+            mock_settings.google_drive_client_secret = _PLACEHOLDER_CLIENT_SECRET
+            mock_settings.sso_cookie_key = _PLACEHOLDER_COOKIE_KEY
+            mock_settings.portal_url = "https://portal.getklai.com"
+
+            state_token = _sign_state(
+                {"connector_id": "conn-uuid-1", "user_id": "zitadel-user-1", "provider": "google_drive"}
+            )
+
+            db.get = AsyncMock(return_value=mock_connector)
+
+            with pytest.raises(HTTPException) as exc_info:
+                await callback_provider(
+                    provider="google_drive",
+                    code="auth-code-xyz",
+                    state=state_token,
+                    error=None,
+                    error_description=None,
+                    klai_oauth_state=state_token,
+                    user_id="zitadel-user-1",
+                    db=db,
+                )
+
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_callback_rejects_connector_org_mismatch_in_state(self) -> None:
+        """Signed org_id must match the connector's tenant."""
+        from app.api.oauth import _sign_state, callback_provider
+
+        db = AsyncMock()
+
+        mock_connector = MagicMock()
+        mock_connector.id = "conn-uuid-1"
+        mock_connector.org_id = 42
+        mock_connector.connector_type = "google_drive"
+        mock_connector.config = {}
+        mock_connector.encrypted_credentials = None
+
+        with patch("app.api.oauth.settings") as mock_settings:
+            mock_settings.google_drive_client_id = _PLACEHOLDER_CLIENT_ID
+            mock_settings.google_drive_client_secret = _PLACEHOLDER_CLIENT_SECRET
+            mock_settings.sso_cookie_key = _PLACEHOLDER_COOKIE_KEY
+            mock_settings.portal_url = "https://portal.getklai.com"
+
+            state_token = _sign_state(
+                {
+                    "connector_id": "conn-uuid-1",
+                    "user_id": "zitadel-user-1",
+                    "provider": "google_drive",
+                    "org_id": 77,
+                }
+            )
+
+            db.get = AsyncMock(return_value=mock_connector)
+            db.scalar = AsyncMock(return_value=object())
+
+            with pytest.raises(HTTPException) as exc_info:
+                await callback_provider(
+                    provider="google_drive",
+                    code="auth-code-xyz",
+                    state=state_token,
+                    error=None,
+                    error_description=None,
+                    klai_oauth_state=state_token,
+                    user_id="zitadel-user-1",
+                    db=db,
+                )
+
+        assert exc_info.value.status_code == 404
 
 
 # ---------------------------------------------------------------------------
@@ -505,6 +633,9 @@ class TestMsDocsProvider:
 
         from app.api.oauth import authorize_provider
 
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=_ScalarListResult([77]))
+
         with patch("app.api.oauth.settings") as mock_settings:
             mock_settings.google_drive_client_id = ""
             mock_settings.ms_docs_client_id = _PLACEHOLDER_CLIENT_ID
@@ -517,7 +648,9 @@ class TestMsDocsProvider:
             response = await authorize_provider(
                 provider="ms_docs",
                 kb_slug="main",
-                user_id="zitadel-user-1",
+                connector_id=None,
+                perms=make_perms(user_id="zitadel-user-1", org_id=77),
+                db=db,
             )
 
             assert response.status_code == 200
@@ -544,7 +677,8 @@ class TestMsDocsProvider:
                 await authorize_provider(
                     provider="ms_docs",
                     kb_slug="main",
-                    user_id="zitadel-user-1",
+                    connector_id=None,
+                    perms=make_perms(user_id="zitadel-user-1", org_id=77),
                 )
 
             assert exc_info.value.status_code == 404
@@ -587,6 +721,7 @@ class TestMsDocsProvider:
                     "user_id": "zitadel-user-1",
                     "kb_slug": "main",
                     "connector_id": "conn-uuid-ms-1",
+                    "org_id": 77,
                     "nonce": "nonce",
                 }
             )
@@ -682,6 +817,7 @@ class TestCallbackReconnectFailed:
                     "user_id": "zitadel-user-1",
                     "kb_slug": "main",
                     "connector_id": "conn-uuid-reconnect-denied",
+                    "org_id": 77,
                     "nonce": "nonce",
                 }
             )
@@ -760,6 +896,7 @@ class TestCallbackReconnectFailed:
                     "user_id": "zitadel-user-1",
                     "kb_slug": "main",
                     "connector_id": "conn-uuid-first-time",
+                    "org_id": 77,
                     "nonce": "nonce",
                 }
             )
@@ -824,6 +961,7 @@ class TestCallbackReconnectFailed:
                     "provider": "google_drive",
                     "user_id": "zitadel-user-1",
                     "connector_id": "conn-uuid-reconnect-tx-fail",
+                    "org_id": 77,
                 }
             )
 
@@ -895,6 +1033,7 @@ class TestCallbackReconnectFailed:
                     "provider": "google_drive",
                     "user_id": "zitadel-user-1",
                     "connector_id": "conn-uuid-first-time-tx-fail",
+                    "org_id": 77,
                 }
             )
 

--- a/klai-portal/backend/tests/test_platform_admin_manage.py
+++ b/klai-portal/backend/tests/test_platform_admin_manage.py
@@ -1,0 +1,225 @@
+"""Regression tests for platform-admin cross-tenant write hardening."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from helpers import FakeResult, setup_db
+
+from tests.conftest import make_perms
+
+
+class AsyncContext:
+    def __init__(self, value):
+        self.value = value
+
+    async def __aenter__(self):
+        return self.value
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def _org(org_id: int = 42):
+    org = MagicMock()
+    org.id = org_id
+    org.slug = f"org-{org_id}"
+    org.deleted_at = None
+    return org
+
+
+def _user(*, org_id: int = 42, user_id: str = "target-user", role: str = "company"):
+    user = MagicMock()
+    user.org_id = org_id
+    user.zitadel_user_id = user_id
+    user.role = role
+    user.status = "active"
+    return user
+
+
+def _platform_perms():
+    return make_perms(
+        role="admin",
+        user_id="platform-admin",
+        org_id=1,
+        org_slug="getklai",
+        is_platform_admin=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_platform_role_change_notifies_active_sessions() -> None:
+    from app.api.admin.platform_manage import RoleUpdateRequest, platform_update_role
+
+    db = AsyncMock()
+    setup_db(db, [FakeResult([_org()]), FakeResult([_user(role="company")])])
+
+    with (
+        patch("app.api.admin.platform_manage.tenant_scoped_session", return_value=AsyncContext(db)),
+        patch("app.api.admin.platform_manage.fire_role_change_notification") as notify,
+        patch("app.api.admin.platform_manage.log_event", new=AsyncMock()),
+    ):
+        await platform_update_role(
+            org_id=42,
+            zitadel_user_id="target-user",
+            body=RoleUpdateRequest(role="admin"),
+            perms=_platform_perms(),
+        )
+
+    notify.assert_called_once_with("target-user")
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_platform_delete_keeps_global_identity_when_other_memberships_exist() -> None:
+    from app.api.admin.platform_manage import platform_delete_user
+    from app.services.user_memberships import UserMembershipSummary
+
+    db = AsyncMock()
+    db.delete = AsyncMock()
+    setup_db(db, [FakeResult([_org()]), FakeResult([_user()])])
+    preview = MagicMock(personal_kbs=[], org_kbs_solely_owned=[])
+
+    with (
+        patch("app.api.admin.platform_manage.tenant_scoped_session", return_value=AsyncContext(db)),
+        patch(
+            "app.api.admin.platform_manage.get_user_membership_summary",
+            new=AsyncMock(
+                return_value=UserMembershipSummary(total_count=2, remaining_count=1, is_platform_admin=False)
+            ),
+        ),
+        patch("app.services.kb_offboarding.compute_offboard_preview", new=AsyncMock(return_value=preview)),
+        patch("app.services.kb_offboarding.revoke_user_credentials", new=AsyncMock(return_value=(0, 0))),
+        patch("app.api.admin.platform_manage.zitadel") as zitadel,
+        patch("app.api.admin.platform_manage.fire_role_change_notification"),
+        patch("app.api.admin.platform_manage.log_event", new=AsyncMock()) as log_event,
+    ):
+        zitadel.remove_user = AsyncMock()
+        response = await platform_delete_user(org_id=42, zitadel_user_id="target-user", perms=_platform_perms())
+
+    zitadel.remove_user.assert_not_awaited()
+    db.delete.assert_awaited_once()
+    assert response.message == "Gebruiker uit tenant verwijderd."
+    details = log_event.await_args.kwargs["details"]
+    assert details["global_identity_deleted"] is False
+    assert details["remaining_membership_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_platform_delete_blocks_platform_admin_identity() -> None:
+    from app.api.admin.platform_manage import platform_delete_user
+    from app.services.user_memberships import UserMembershipSummary
+
+    db = AsyncMock()
+    setup_db(db, [FakeResult([_org()]), FakeResult([_user(role="admin")])])
+
+    with (
+        patch("app.api.admin.platform_manage.tenant_scoped_session", return_value=AsyncContext(db)),
+        patch(
+            "app.api.admin.platform_manage.get_user_membership_summary",
+            new=AsyncMock(return_value=UserMembershipSummary(total_count=2, remaining_count=1, is_platform_admin=True)),
+        ),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await platform_delete_user(org_id=42, zitadel_user_id="target-user", perms=_platform_perms())
+
+    assert exc_info.value.status_code == 409
+    db.commit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_platform_invite_rolls_back_zitadel_user_when_grant_fails() -> None:
+    from app.api.admin.platform_manage import PlatformInviteRequest, platform_invite
+
+    org = _org()
+    with (
+        patch("app.api.admin.platform_manage._load_org_or_404", new=AsyncMock(return_value=org)),
+        patch("app.api.admin.platform_manage.zitadel") as zitadel,
+    ):
+        zitadel.invite_user = AsyncMock(return_value={"userId": "new-user"})
+        zitadel.grant_user_role = AsyncMock(side_effect=RuntimeError("grant failed"))
+        zitadel.remove_user = AsyncMock()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await platform_invite(
+                org_id=42,
+                body=PlatformInviteRequest(
+                    email="new@example.com",
+                    first_name="New",
+                    last_name="User",
+                    role="admin",
+                ),
+                perms=_platform_perms(),
+            )
+
+    assert exc_info.value.status_code == 502
+    zitadel.remove_user.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_platform_invite_mail_failure_keeps_committed_portal_user() -> None:
+    from app.api.admin.platform_manage import PlatformInviteRequest, platform_invite
+
+    db = AsyncMock()
+    db.add = MagicMock()
+    org = _org()
+    with (
+        patch("app.api.admin.platform_manage._load_org_or_404", new=AsyncMock(return_value=org)),
+        patch("app.api.admin.platform_manage.tenant_scoped_session", return_value=AsyncContext(db)),
+        patch("app.api.admin.platform_manage.create_default_personal_kb", new=AsyncMock()),
+        patch("app.api.admin.platform_manage.log_event", new=AsyncMock()),
+        patch("app.api.admin.platform_manage.zitadel") as zitadel,
+    ):
+        zitadel.invite_user = AsyncMock(return_value={"userId": "new-user"})
+        zitadel.grant_user_role = AsyncMock()
+        zitadel.send_invite_code = AsyncMock(side_effect=RuntimeError("mail failed"))
+        zitadel.remove_user = AsyncMock()
+
+        response = await platform_invite(
+            org_id=42,
+            body=PlatformInviteRequest(
+                email="new@example.com",
+                first_name="New",
+                last_name="User",
+                role="personal",
+            ),
+            perms=_platform_perms(),
+        )
+
+    db.commit.assert_awaited_once()
+    zitadel.remove_user.assert_not_awaited()
+    assert "invite-mail kon niet worden verstuurd" in response.message
+
+
+@pytest.mark.asyncio
+async def test_platform_create_tenant_owner_setup_failure_rolls_back_org_and_user() -> None:
+    from app.api.admin.platform_manage import CreateTenantRequest, platform_create_tenant
+
+    db = AsyncMock()
+    background_tasks = MagicMock()
+
+    with patch("app.api.admin.platform_manage.zitadel") as zitadel:
+        zitadel.create_org = AsyncMock(return_value={"id": "zitadel-org-new"})
+        zitadel.invite_user = AsyncMock(return_value={"userId": "owner-user"})
+        zitadel.grant_user_role = AsyncMock(side_effect=RuntimeError("grant failed"))
+        zitadel.remove_user = AsyncMock()
+        zitadel.delete_org = AsyncMock()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await platform_create_tenant(
+                body=CreateTenantRequest(
+                    company_name="Acme BV",
+                    owner_email="owner@example.com",
+                    owner_first_name="Owner",
+                    owner_last_name="User",
+                ),
+                background_tasks=background_tasks,
+                perms=_platform_perms(),
+                db=db,
+            )
+
+    assert exc_info.value.status_code == 502
+    zitadel.remove_user.assert_awaited_once()
+    zitadel.delete_org.assert_awaited_once_with("zitadel-org-new")

--- a/klai-portal/backend/tests/test_widget_config.py
+++ b/klai-portal/backend/tests/test_widget_config.py
@@ -37,6 +37,7 @@ class FakeWidget:
             "css_variables": {},
         }
     )
+    public_share_enabled: bool = False
     rate_limit_rpm: int = 60
     last_used_at: datetime | None = None
     created_at: datetime = field(default_factory=lambda: datetime(2026, 1, 1, tzinfo=UTC))
@@ -197,6 +198,8 @@ def test_origin_allowed_wildcard_subdomain():
     assert origin_allowed("https://app.example.com", ["https://*.example.com"])
     assert origin_allowed("https://test.example.com", ["https://*.example.com"])
     assert not origin_allowed("https://example.com", ["https://*.example.com"])
+    assert not origin_allowed("https://evil-example.com", ["https://*.example.com"])
+    assert not origin_allowed("https://example.com.evil.test", ["https://*.example.com"])
     assert not origin_allowed("https://evil.com", ["https://*.example.com"])
 
 
@@ -226,3 +229,58 @@ def test_origin_allowed_trailing_slash():
 
     assert origin_allowed("https://example.com/", ["https://example.com"])
     assert origin_allowed("https://example.com", ["https://example.com/"])
+
+
+def test_origin_allowed_rejects_scheme_and_port_mismatch():
+    """Origin matching must preserve scheme and explicit port boundaries."""
+    from app.services.widget_auth import origin_allowed
+
+    assert not origin_allowed("http://app.example.com", ["https://*.example.com"])
+    assert origin_allowed("https://app.example.com:8443", ["https://*.example.com:8443"])
+    assert not origin_allowed("https://app.example.com:9443", ["https://*.example.com:8443"])
+
+
+@pytest.mark.asyncio
+async def test_public_bot_config_rejects_when_share_disabled():
+    """Public bot config is off by default, even if the widget exists."""
+    from app.api.partner import public_bot_config
+
+    widget = FakeWidget()
+    db = _make_db_chain(widget, None, [])
+
+    with patch("app.api.partner.settings") as mock_settings:
+        mock_settings.widget_jwt_secret = "shared-secret"
+        with pytest.raises(Exception) as exc_info:
+            await public_bot_config(id=widget.widget_id, db=db)
+
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_public_bot_config_returns_token_when_share_enabled():
+    """Public bot config returns a session token only after explicit enablement."""
+    from app.api.partner import public_bot_config
+
+    org = FakeOrg()
+    widget = FakeWidget(
+        public_share_enabled=True,
+        widget_config={
+            "allowed_origins": [],
+            "title": "Public",
+            "welcome_message": "",
+            "system_prompt": "",
+            "css_variables": {},
+        },
+    )
+    db = _make_db_chain(widget, org, [10])
+
+    with (
+        patch("app.api.partner.settings") as mock_settings,
+        patch("app.api.partner.set_tenant", new=AsyncMock()),
+        patch("app.api.partner.generate_session_token", return_value="public.jwt.token"),
+    ):
+        mock_settings.widget_jwt_secret = "shared-secret"
+        response = await public_bot_config(id=widget.widget_id, db=db)
+
+    assert response.status_code == 200
+    assert '"session_token": "public.jwt.token"' in response.body.decode()

--- a/klai-portal/backend/uv.lock
+++ b/klai-portal/backend/uv.lock
@@ -664,11 +664,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
 ]
 
 [[package]]

--- a/klai-portal/frontend/package-lock.json
+++ b/klai-portal/frontend/package-lock.json
@@ -8,14 +8,14 @@
       "name": "klai-portal-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@blocknote/core": "^0.47.1",
-        "@blocknote/mantine": "^0.47.1",
-        "@blocknote/react": "^0.47.1",
+        "@blocknote/core": "^0.51.2",
+        "@blocknote/mantine": "^0.51.2",
+        "@blocknote/react": "^0.51.2",
         "@dnd-kit/core": "^6.3.1",
         "@emoji-mart/data": "^1.2.1",
         "@emoji-mart/react": "^1.1.1",
         "@icons-pack/react-simple-icons": "^13.13.0",
-        "@inlang/paraglide-js": "^2.16.0",
+        "@inlang/paraglide-js": "^2.18.1",
         "@mantine/core": "^9.0.2",
         "@mantine/hooks": "^9.0.2",
         "@mantine/notifications": "^9.0.2",
@@ -416,21 +416,20 @@
       }
     },
     "node_modules/@blocknote/core": {
-      "version": "0.47.3",
-      "resolved": "https://registry.npmjs.org/@blocknote/core/-/core-0.47.3.tgz",
-      "integrity": "sha512-+YIOEXmmRXzDULYlQaycaFDofwQ/W79CWsU3GwNuRzp62QC+WpRLFLkgkoU4Pb1Vo7RvmzU1+udESdNUGhO2KA==",
+      "version": "0.51.2",
+      "resolved": "https://registry.npmjs.org/@blocknote/core/-/core-0.51.2.tgz",
+      "integrity": "sha512-tr+gJXDrCkbCjj/176wEYAhxPluoZWPE7Xok+7QY/44sPo9Eh7LBR93tMnmDV0zDvQ6CnECR+OOs7y65++1NHw==",
       "license": "MPL-2.0",
       "dependencies": {
         "@emoji-mart/data": "^1.2.1",
         "@handlewithcare/prosemirror-inputrules": "^0.1.4",
-        "@shikijs/types": "^3",
+        "@shikijs/types": "^4",
         "@tanstack/store": "^0.7.7",
         "@tiptap/core": "^3.13.0",
         "@tiptap/extension-bold": "^3.13.0",
         "@tiptap/extension-code": "^3.13.0",
         "@tiptap/extension-horizontal-rule": "^3.13.0",
         "@tiptap/extension-italic": "^3.13.0",
-        "@tiptap/extension-link": "^3.13.0",
         "@tiptap/extension-paragraph": "^3.13.0",
         "@tiptap/extension-strike": "^3.13.0",
         "@tiptap/extension-text": "^3.13.0",
@@ -439,24 +438,13 @@
         "@tiptap/pm": "^3.13.0",
         "emoji-mart": "^5.6.0",
         "fast-deep-equal": "^3.1.3",
-        "hast-util-from-dom": "^5.0.1",
-        "prosemirror-highlight": "^0.13.0",
+        "lib0": "^0.2.99",
+        "prosemirror-highlight": "^0.15.1",
         "prosemirror-model": "^1.25.4",
         "prosemirror-state": "^1.4.4",
         "prosemirror-tables": "^1.8.3",
-        "prosemirror-transform": "^1.10.5",
+        "prosemirror-transform": "^1.11.0",
         "prosemirror-view": "^1.41.4",
-        "rehype-format": "^5.0.1",
-        "rehype-parse": "^9.0.1",
-        "rehype-remark": "^10.0.1",
-        "rehype-stringify": "^10.0.1",
-        "remark-gfm": "^4.0.1",
-        "remark-parse": "^11.0.0",
-        "remark-rehype": "^11.1.2",
-        "remark-stringify": "^11.0.0",
-        "unified": "^11.0.5",
-        "unist-util-visit": "^5.0.0",
-        "uuid": "^8.3.2",
         "y-prosemirror": "^1.3.7",
         "y-protocols": "^1.0.6",
         "yjs": "^13.6.27"
@@ -472,40 +460,30 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
-    "node_modules/@blocknote/core/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@blocknote/mantine": {
-      "version": "0.47.3",
-      "resolved": "https://registry.npmjs.org/@blocknote/mantine/-/mantine-0.47.3.tgz",
-      "integrity": "sha512-tLt4pnpT6Q+z4b9d/E5lHBLgYxzhBWomQKvJ+3Psad2LBEq+JIfMOe8yx9nLizeP/ILtsXnkWP0peuc/2NO5Lg==",
+      "version": "0.51.2",
+      "resolved": "https://registry.npmjs.org/@blocknote/mantine/-/mantine-0.51.2.tgz",
+      "integrity": "sha512-NbjB+NjZ0m7FoaTbXGnBEGuP+LqAgKSmoAca4HPZ/TiBygbGA8d0vXpDgkgI5fDt5MR0W2Wkrzh0VmSnIls02g==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@blocknote/core": "0.47.3",
-        "@blocknote/react": "0.47.3",
+        "@blocknote/core": "0.51.2",
+        "@blocknote/react": "0.51.2",
         "react-icons": "^5.5.0"
       },
       "peerDependencies": {
-        "@mantine/core": "^8.3.11",
-        "@mantine/hooks": "^8.3.11",
-        "@mantine/utils": "^6.0.22",
+        "@mantine/core": "^8.3.11 || ^9.0.2",
+        "@mantine/hooks": "^8.3.11 || ^9.0.2",
         "react": "^18.0 || ^19.0 || >= 19.0.0-rc",
         "react-dom": "^18.0 || ^19.0 || >= 19.0.0-rc"
       }
     },
     "node_modules/@blocknote/react": {
-      "version": "0.47.3",
-      "resolved": "https://registry.npmjs.org/@blocknote/react/-/react-0.47.3.tgz",
-      "integrity": "sha512-aWDgfnf/ufgqYfXtIy8QepfrgdVaC5DfU/BAWbazb/O5ucEFfCr6lK0SUVvswK1CkxL/KBpHpdAd+uT+rfgkmg==",
+      "version": "0.51.2",
+      "resolved": "https://registry.npmjs.org/@blocknote/react/-/react-0.51.2.tgz",
+      "integrity": "sha512-BMyNOje2r64362SYNjscP1GFpqhiYRT026v9XeCvWu8tCm5y5BKRzyB2MNX17VrAiXzE19YPvB9dQGo51kHibQ==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@blocknote/core": "0.47.3",
+        "@blocknote/core": "0.51.2",
         "@emoji-mart/data": "^1.2.1",
         "@floating-ui/react": "^0.27.18",
         "@floating-ui/utils": "^0.2.10",
@@ -1517,13 +1495,13 @@
       }
     },
     "node_modules/@inlang/paraglide-js": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/@inlang/paraglide-js/-/paraglide-js-2.16.0.tgz",
-      "integrity": "sha512-O7KKvVoTsGqPRt1VfSvd0UyfSjU2qHiABx968M2decgG7Af6TddW3dTJrTS3I78nOUgRAlYwCYfKefSGD4rGMA==",
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/@inlang/paraglide-js/-/paraglide-js-2.18.1.tgz",
+      "integrity": "sha512-YzIrJ34KbsJwzvVKBzcBEgp4AqmhNYD1EF2pOV+g87L024XTFmcmikI4/NMfb63H9zJ6UeEPTOmEK7Nzu/4E2Q==",
       "license": "MIT",
       "dependencies": {
         "@inlang/recommend-sherlock": "^0.2.1",
-        "@inlang/sdk": "^2.9.1",
+        "@inlang/sdk": "^2.9.3",
         "commander": "11.1.0",
         "consola": "3.4.0",
         "json5": "2.2.3",
@@ -1532,6 +1510,14 @@
       },
       "bin": {
         "paraglide-js": "bin/run.js"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@inlang/paraglide-js/node_modules/consola": {
@@ -1553,16 +1539,16 @@
       }
     },
     "node_modules/@inlang/sdk": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@inlang/sdk/-/sdk-2.9.1.tgz",
-      "integrity": "sha512-y0C3xaKo6pSGDr3p5OdreRVT3THJpgKVe1lLvG3BE4v9lskp3UfI9cPCbN8X2dpfLt/4ljtehMb5SykpMfJrMg==",
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/@inlang/sdk/-/sdk-2.9.3.tgz",
+      "integrity": "sha512-E/SxcSji8WIt4DqQG9APlOs6tVtJxrrOUS3dE4ho3pWRCLLIY0PIVzgNwSukuFT+m8LuJDFwpRY5VY3ryzyGWQ==",
       "license": "MIT",
       "dependencies": {
-        "@lix-js/sdk": "0.4.9",
+        "@lix-js/sdk": "0.4.10",
         "@sinclair/typebox": "^0.31.17",
         "kysely": "^0.28.12",
         "sqlite-wasm-kysely": "0.3.0",
-        "uuid": "^13.0.0"
+        "uuid": "^14.0.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -1614,9 +1600,9 @@
       }
     },
     "node_modules/@lix-js/sdk": {
-      "version": "0.4.9",
-      "resolved": "https://registry.npmjs.org/@lix-js/sdk/-/sdk-0.4.9.tgz",
-      "integrity": "sha512-30mDkXpx704359oRrJI42bjfCspCiaMItngVBbPkiTGypS7xX4jYbHWQkXI8XuJ7VDB69D0MsVU6xfrBAIrM4A==",
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/@lix-js/sdk/-/sdk-0.4.10.tgz",
+      "integrity": "sha512-0dMInAJK/67guTG5rRZaCEhvzC5cCXENOjaePA5AqMXrCE97kaY7SRor9e2vnoGsFIiGqXKlT0MCIoZj36G0gg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@lix-js/server-protocol-schema": "0.1.1",
@@ -1625,23 +1611,10 @@
         "js-sha256": "^0.11.0",
         "kysely": "^0.28.12",
         "sqlite-wasm-kysely": "0.3.0",
-        "uuid": "^10.0.0"
+        "uuid": "^14.0.0"
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@lix-js/sdk/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@lix-js/server-protocol-schema": {
@@ -2544,12 +2517,6 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
-    "node_modules/@remirror/core-constants": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
-      "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
-      "license": "MIT"
-    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.15",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
@@ -3132,13 +3099,16 @@
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
-      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.1.0.tgz",
+      "integrity": "sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@shikijs/vscode-textmate": {
@@ -3816,16 +3786,16 @@
       }
     },
     "node_modules/@tiptap/core": {
-      "version": "3.22.4",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.4.tgz",
-      "integrity": "sha512-vGIGm/HpqLg8EAAQXQ+koV+/S828OEpzocfWcPOwo1u2QUVf9dQG47Yy6JJ8zFFaJwfv4dBcOXli+7BrJwsxDQ==",
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.23.6.tgz",
+      "integrity": "sha512-MRB3pHz4Oxqmcawh0cQ5iOGdY5xtNYp/1CoK7hdTLzw5K0C6/gTC2VvanB1R4INaB6EpBkxG/GiWkVirDRnuXw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/pm": "3.22.4"
+        "@tiptap/pm": "3.23.6"
       }
     },
     "node_modules/@tiptap/extension-bold": {
@@ -3842,9 +3812,9 @@
       }
     },
     "node_modules/@tiptap/extension-bubble-menu": {
-      "version": "3.22.4",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.22.4.tgz",
-      "integrity": "sha512-v4pux5Ql3THAEjaLMY4ldtdy/Xy2qU7PJLBkq8ugLp8qicaKC+tpqxp6sGif4vLIjz7Ap5hurRbTNbXzszyyHA==",
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.23.6.tgz",
+      "integrity": "sha512-Mwkyp9LkDHFbqmWRIkp63FinRxFu3ajC4qSb9t4mnHsb4kAdbNLLsGtbFg+le0SWk4CxGwAOwM7SzeJ+6UGqCA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3855,8 +3825,8 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.22.4",
-        "@tiptap/pm": "3.22.4"
+        "@tiptap/core": "3.23.6",
+        "@tiptap/pm": "3.23.6"
       }
     },
     "node_modules/@tiptap/extension-code": {
@@ -3873,9 +3843,9 @@
       }
     },
     "node_modules/@tiptap/extension-floating-menu": {
-      "version": "3.22.4",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.22.4.tgz",
-      "integrity": "sha512-DFuyYxgaZPgxum5z1yvJPbfYCvDdO8geXsdyqt0qYYdiat3aGE4ncJhiLRIFDhSHBhaZg5eCgu/YPYAN6jZnrA==",
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.23.6.tgz",
+      "integrity": "sha512-2kjuDcEq69lEcECl75xqY5MyzUSh2zcC5aLrpwP1WwhJz5bxsIFHiaps5AP6h9R4A+ZBj5b2haay2Y1wDUU3VA==",
       "license": "MIT",
       "optional": true,
       "funding": {
@@ -3884,8 +3854,8 @@
       },
       "peerDependencies": {
         "@floating-ui/dom": "^1.0.0",
-        "@tiptap/core": "3.22.4",
-        "@tiptap/pm": "3.22.4"
+        "@tiptap/core": "3.23.6",
+        "@tiptap/pm": "3.23.6"
       }
     },
     "node_modules/@tiptap/extension-horizontal-rule": {
@@ -3913,23 +3883,6 @@
       },
       "peerDependencies": {
         "@tiptap/core": "^3.20.4"
-      }
-    },
-    "node_modules/@tiptap/extension-link": {
-      "version": "3.22.4",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.22.4.tgz",
-      "integrity": "sha512-uoP3yus02uwGPVzW2QaEPJWVIrUb/r5nKm6c8DiJv9fNSX1+gykZZMg42c6GwRFLZ/vyfWjVCbAE03VMUqafgA==",
-      "license": "MIT",
-      "dependencies": {
-        "linkifyjs": "^4.3.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "3.22.4",
-        "@tiptap/pm": "3.22.4"
       }
     },
     "node_modules/@tiptap/extension-paragraph": {
@@ -3999,27 +3952,21 @@
       }
     },
     "node_modules/@tiptap/pm": {
-      "version": "3.20.4",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.20.4.tgz",
-      "integrity": "sha512-rCHYSBToilBEuI6PtjziHDdRkABH/XqwJ7dG4Amn/SD3yGiZKYCiEApQlTUS2zZeo8DsLeuqqqB4vEOeD4OEPg==",
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.23.6.tgz",
+      "integrity": "sha512-in5CaMaWlJcH2A1q6GJKFtrodE8WLS3M9tIi/f89jPmIVHJShpodC0KZDNyJkrVBQomYk0DEh86Utm6ASXzQww==",
       "license": "MIT",
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
-        "prosemirror-collab": "^1.3.1",
         "prosemirror-commands": "^1.6.2",
         "prosemirror-dropcursor": "^1.8.1",
         "prosemirror-gapcursor": "^1.3.2",
         "prosemirror-history": "^1.4.1",
-        "prosemirror-inputrules": "^1.4.0",
         "prosemirror-keymap": "^1.2.2",
-        "prosemirror-markdown": "^1.13.1",
-        "prosemirror-menu": "^1.2.4",
         "prosemirror-model": "^1.24.1",
-        "prosemirror-schema-basic": "^1.2.3",
         "prosemirror-schema-list": "^1.5.0",
         "prosemirror-state": "^1.4.3",
         "prosemirror-tables": "^1.6.4",
-        "prosemirror-trailing-node": "^3.0.0",
         "prosemirror-transform": "^1.10.2",
         "prosemirror-view": "^1.38.1"
       },
@@ -4029,9 +3976,9 @@
       }
     },
     "node_modules/@tiptap/react": {
-      "version": "3.22.4",
-      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.22.4.tgz",
-      "integrity": "sha512-XIQZPwLakR1t8+Q1UeCpr+kUHDWxpJzGy9r2xUi3mpPd6Wh8dtNltScBkUlCcr0sqc6J1GF6Is02JJVQGmCZMA==",
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.23.6.tgz",
+      "integrity": "sha512-Tw9KZkYqFMk3vaJAEQKqEYIO/iq3cSJe7OUEGBul4k4GaMQeLItLf5EYhUd0GIPXci1WVVPNntKJsHfX25M37w==",
       "license": "MIT",
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
@@ -4043,12 +3990,12 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "optionalDependencies": {
-        "@tiptap/extension-bubble-menu": "^3.22.4",
-        "@tiptap/extension-floating-menu": "^3.22.4"
+        "@tiptap/extension-bubble-menu": "^3.23.6",
+        "@tiptap/extension-floating-menu": "^3.23.6"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.22.4",
-        "@tiptap/pm": "3.22.4",
+        "@tiptap/core": "3.23.6",
+        "@tiptap/pm": "3.23.6",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
@@ -4144,22 +4091,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
-      "license": "MIT"
-    },
-    "node_modules/@types/markdown-it": {
-      "version": "14.1.2",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
-      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/linkify-it": "^5",
-        "@types/mdurl": "^2"
-      }
-    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -4168,12 +4099,6 @@
       "dependencies": {
         "@types/unist": "*"
       }
-    },
-    "node_modules/@types/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
-      "license": "MIT"
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -4743,12 +4668,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "license": "Python-2.0"
-    },
     "node_modules/aria-hidden": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
@@ -4874,9 +4793,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -5155,12 +5074,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
       "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
-      "license": "MIT"
-    },
-    "node_modules/crelt": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
-      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "license": "MIT"
     },
     "node_modules/cross-env": {
@@ -5493,18 +5406,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
@@ -5567,6 +5468,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -6040,201 +5942,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/hast-util-embedded": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-3.0.0.tgz",
-      "integrity": "sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-is-element": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-format": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/hast-util-format/-/hast-util-format-1.1.0.tgz",
-      "integrity": "sha512-yY1UDz6bC9rDvCWHpx12aIBGRG7krurX0p0Fm6pT547LwDIZZiNr8a+IHDogorAdreULSEzP82Nlv5SZkHZcjA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-embedded": "^3.0.0",
-        "hast-util-minify-whitespace": "^1.0.0",
-        "hast-util-phrasing": "^3.0.0",
-        "hast-util-whitespace": "^3.0.0",
-        "html-whitespace-sensitive-tag-names": "^3.0.0",
-        "unist-util-visit-parents": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-from-dom": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
-      "integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
-      "license": "ISC",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hastscript": "^9.0.0",
-        "web-namespaces": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-from-html": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
-      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "devlop": "^1.1.0",
-        "hast-util-from-parse5": "^8.0.0",
-        "parse5": "^7.0.0",
-        "vfile": "^6.0.0",
-        "vfile-message": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-from-parse5": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
-      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/unist": "^3.0.0",
-        "devlop": "^1.0.0",
-        "hastscript": "^9.0.0",
-        "property-information": "^7.0.0",
-        "vfile": "^6.0.0",
-        "vfile-location": "^5.0.0",
-        "web-namespaces": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-has-property": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-3.0.0.tgz",
-      "integrity": "sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-is-body-ok-link": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-3.0.1.tgz",
-      "integrity": "sha512-0qpnzOBLztXHbHQenVB8uNuxTnm/QBFUOmdOSsEn7GnBtyY07+ENTWVFBAnXd/zEgd9/SUG3lRY7hSIBWRgGpQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-is-element": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
-      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-minify-whitespace": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-minify-whitespace/-/hast-util-minify-whitespace-1.0.1.tgz",
-      "integrity": "sha512-L96fPOVpnclQE0xzdWb/D12VT5FabA7SnZOUMtL1DbXmYiHJMXZvFkIZfiMmTCNJHUeO2K9UYNXoVyfz+QHuOw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-embedded": "^3.0.0",
-        "hast-util-is-element": "^3.0.0",
-        "hast-util-whitespace": "^3.0.0",
-        "unist-util-is": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-parse-selector": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
-      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-phrasing": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-phrasing/-/hast-util-phrasing-3.0.1.tgz",
-      "integrity": "sha512-6h60VfI3uBQUxHqTyMymMZnEbNl1XmEGtOxxKYL7stY2o601COo62AWAYBQR9lZbYXYSBoxag8UpPRXK+9fqSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-embedded": "^3.0.0",
-        "hast-util-has-property": "^3.0.0",
-        "hast-util-is-body-ok-link": "^3.0.0",
-        "hast-util-is-element": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-to-html": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
-      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/unist": "^3.0.0",
-        "ccount": "^2.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "hast-util-whitespace": "^3.0.0",
-        "html-void-elements": "^3.0.0",
-        "mdast-util-to-hast": "^13.0.0",
-        "property-information": "^7.0.0",
-        "space-separated-tokens": "^2.0.0",
-        "stringify-entities": "^4.0.0",
-        "zwitch": "^2.0.4"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -6262,48 +5969,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/hast-util-to-mdast": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/hast-util-to-mdast/-/hast-util-to-mdast-10.1.2.tgz",
-      "integrity": "sha512-FiCRI7NmOvM4y+f5w32jPRzcxDIz+PUqDwEqn1A+1q2cdp3B8Gx7aVrXORdOKjMNDQsD1ogOr896+0jJHW1EFQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/mdast": "^4.0.0",
-        "@ungap/structured-clone": "^1.0.0",
-        "hast-util-phrasing": "^3.0.0",
-        "hast-util-to-html": "^9.0.0",
-        "hast-util-to-text": "^4.0.0",
-        "hast-util-whitespace": "^3.0.0",
-        "mdast-util-phrasing": "^4.0.0",
-        "mdast-util-to-hast": "^13.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-minify-whitespace": "^6.0.0",
-        "trim-trailing-lines": "^2.0.0",
-        "unist-util-position": "^5.0.0",
-        "unist-util-visit": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-to-text": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
-      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/unist": "^3.0.0",
-        "hast-util-is-element": "^3.0.0",
-        "unist-util-find-after": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
@@ -6311,23 +5976,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hastscript": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
-      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "hast-util-parse-selector": "^4.0.0",
-        "property-information": "^7.0.0",
-        "space-separated-tokens": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -6375,26 +6023,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
       "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/html-void-elements": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
-      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/html-whitespace-sensitive-tag-names": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/html-whitespace-sensitive-tag-names/-/html-whitespace-sensitive-tag-names-3.0.1.tgz",
-      "integrity": "sha512-q+310vW8zmymYHALr1da4HyXUQ0zgiIwIicEfotYPWGN0OJVEN/58IJ3A4GBYcEq3LGAZqKb+ugvP0GNB9CEAA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -7193,21 +6821,6 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-      "license": "MIT",
-      "dependencies": {
-        "uc.micro": "^2.0.0"
-      }
-    },
-    "node_modules/linkifyjs": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
-      "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
-      "license": "MIT"
-    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -7329,61 +6942,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
-        "mdurl": "^2.0.0",
-        "punycode.js": "^2.3.1",
-        "uc.micro": "^2.1.0"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.mjs"
-      }
-    },
-    "node_modules/markdown-table": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
-      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/mdast-util-find-and-replace": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
-      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "escape-string-regexp": "^5.0.0",
-        "unist-util-is": "^6.0.0",
-        "unist-util-visit-parents": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/mdast-util-from-markdown": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
@@ -7402,107 +6960,6 @@
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "unist-util-stringify-position": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
-      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-gfm-autolink-literal": "^2.0.0",
-        "mdast-util-gfm-footnote": "^2.0.0",
-        "mdast-util-gfm-strikethrough": "^2.0.0",
-        "mdast-util-gfm-table": "^2.0.0",
-        "mdast-util-gfm-task-list-item": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-autolink-literal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
-      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "ccount": "^2.0.0",
-        "devlop": "^1.0.0",
-        "mdast-util-find-and-replace": "^3.0.0",
-        "micromark-util-character": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-footnote": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
-      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "devlop": "^1.1.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-strikethrough": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
-      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-table": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
-      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "devlop": "^1.0.0",
-        "markdown-table": "^3.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-task-list-item": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
-      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "devlop": "^1.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -7645,12 +7102,6 @@
       "dev": true,
       "license": "CC0-1.0"
     },
-    "node_modules/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-      "license": "MIT"
-    },
     "node_modules/micromark": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
@@ -7718,127 +7169,6 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-extension-gfm": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
-      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
-      "license": "MIT",
-      "dependencies": {
-        "micromark-extension-gfm-autolink-literal": "^2.0.0",
-        "micromark-extension-gfm-footnote": "^2.0.0",
-        "micromark-extension-gfm-strikethrough": "^2.0.0",
-        "micromark-extension-gfm-table": "^2.0.0",
-        "micromark-extension-gfm-tagfilter": "^2.0.0",
-        "micromark-extension-gfm-task-list-item": "^2.0.0",
-        "micromark-util-combine-extensions": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-autolink-literal": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
-      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-sanitize-uri": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-footnote": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
-      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-core-commonmark": "^2.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0",
-        "micromark-util-sanitize-uri": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-strikethrough": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
-      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-util-chunked": "^2.0.0",
-        "micromark-util-classify-character": "^2.0.0",
-        "micromark-util-resolve-all": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-table": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
-      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-tagfilter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
-      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-task-list-item": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
-      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -8448,30 +7778,6 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
-    "node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/parse5/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -8728,15 +8034,6 @@
         "prosemirror-transform": "^1.0.0"
       }
     },
-    "node_modules/prosemirror-collab": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.3.1.tgz",
-      "integrity": "sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==",
-      "license": "MIT",
-      "dependencies": {
-        "prosemirror-state": "^1.0.0"
-      }
-    },
     "node_modules/prosemirror-commands": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
@@ -8772,15 +8069,17 @@
       }
     },
     "node_modules/prosemirror-highlight": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-highlight/-/prosemirror-highlight-0.13.1.tgz",
-      "integrity": "sha512-41EwMJDUeFBxizPP1/msQBjDke1YyaTy40w3CGoc7fjXboDBgyhz2LWThwaygL9LkDvBqn4pwBJg1PNtrNilGg==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-highlight/-/prosemirror-highlight-0.15.1.tgz",
+      "integrity": "sha512-KcJUGNgqLED+eK/cisNtY3M+eDNLkZyWCdyi7B3RoW3rKHnhkKawnJAcr9p1F/e3q+oDB5Y5OiIrC11bxP7tFA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ocavue"
       },
       "peerDependencies": {
-        "@shikijs/types": "^1.29.2 || ^2.0.0 || ^3.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/highlight": "^1.0.0",
+        "@shikijs/types": "^1.29.2 || ^2.0.0 || ^3.0.0 || ^4.0.0",
         "@types/hast": "^3.0.0",
         "highlight.js": "^11.9.0",
         "lowlight": "^3.1.0",
@@ -8789,9 +8088,15 @@
         "prosemirror-transform": "^1.8.0",
         "prosemirror-view": "^1.32.4",
         "refractor": "^5.0.0",
-        "sugar-high": "^0.6.1 || ^0.7.0 || ^0.8.0 || ^0.9.0"
+        "sugar-high": "^0.6.1 || ^0.7.0 || ^0.8.0 || ^0.9.0 || ^1.0.0"
       },
       "peerDependenciesMeta": {
+        "@lezer/common": {
+          "optional": true
+        },
+        "@lezer/highlight": {
+          "optional": true
+        },
         "@shikijs/types": {
           "optional": true
         },
@@ -8836,16 +8141,6 @@
         "rope-sequence": "^1.3.0"
       }
     },
-    "node_modules/prosemirror-inputrules": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz",
-      "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
-      "license": "MIT",
-      "dependencies": {
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-transform": "^1.0.0"
-      }
-    },
     "node_modules/prosemirror-keymap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
@@ -8856,29 +8151,6 @@
         "w3c-keyname": "^2.2.0"
       }
     },
-    "node_modules/prosemirror-markdown": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.4.tgz",
-      "integrity": "sha512-D98dm4cQ3Hs6EmjK500TdAOew4Z03EV71ajEFiWra3Upr7diytJsjF4mPV2dW+eK5uNectiRj0xFxYI9NLXDbw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/markdown-it": "^14.0.0",
-        "markdown-it": "^14.0.0",
-        "prosemirror-model": "^1.25.0"
-      }
-    },
-    "node_modules/prosemirror-menu": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-menu/-/prosemirror-menu-1.3.0.tgz",
-      "integrity": "sha512-TImyPXCHPcDsSka2/lwJ6WjTASr4re/qWq1yoTTuLOqfXucwF6VcRa2LWCkM/EyTD1UO3CUwiH8qURJoWJRxwg==",
-      "license": "MIT",
-      "dependencies": {
-        "crelt": "^1.0.0",
-        "prosemirror-commands": "^1.0.0",
-        "prosemirror-history": "^1.0.0",
-        "prosemirror-state": "^1.0.0"
-      }
-    },
     "node_modules/prosemirror-model": {
       "version": "1.25.4",
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
@@ -8886,15 +8158,6 @@
       "license": "MIT",
       "dependencies": {
         "orderedmap": "^2.0.0"
-      }
-    },
-    "node_modules/prosemirror-schema-basic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-schema-basic/-/prosemirror-schema-basic-1.2.4.tgz",
-      "integrity": "sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "prosemirror-model": "^1.25.0"
       }
     },
     "node_modules/prosemirror-schema-list": {
@@ -8932,21 +8195,6 @@
         "prosemirror-view": "^1.41.4"
       }
     },
-    "node_modules/prosemirror-trailing-node": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-3.0.0.tgz",
-      "integrity": "sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@remirror/core-constants": "3.0.0",
-        "escape-string-regexp": "^4.0.0"
-      },
-      "peerDependencies": {
-        "prosemirror-model": "^1.22.1",
-        "prosemirror-state": "^1.4.2",
-        "prosemirror-view": "^1.33.8"
-      }
-    },
     "node_modules/prosemirror-transform": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.11.0.tgz",
@@ -8978,15 +8226,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/punycode.js": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
-      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -9196,99 +8435,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/rehype-format": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-format/-/rehype-format-5.0.1.tgz",
-      "integrity": "sha512-zvmVru9uB0josBVpr946OR8ui7nJEdzZobwLOOqHb/OOD88W0Vk2SqLwoVOj0fM6IPCCO6TaV9CvQvJMWwukFQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-format": "^1.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-minify-whitespace": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/rehype-minify-whitespace/-/rehype-minify-whitespace-6.0.2.tgz",
-      "integrity": "sha512-Zk0pyQ06A3Lyxhe9vGtOtzz3Z0+qZ5+7icZ/PL/2x1SHPbKao5oB/g/rlc6BCTajqBb33JcOe71Ye1oFsuYbnw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-minify-whitespace": "^1.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-parse": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
-      "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-from-html": "^2.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-remark": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-remark/-/rehype-remark-10.0.1.tgz",
-      "integrity": "sha512-EmDndlb5NVwXGfUa4c9GPK+lXeItTilLhE6ADSaQuHr4JUlKw9MidzGzx4HpqZrNCt6vnHmEifXQiiA+CEnjYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/mdast": "^4.0.0",
-        "hast-util-to-mdast": "^10.0.0",
-        "unified": "^11.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-stringify": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
-      "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-to-html": "^9.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-gfm": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
-      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "mdast-util-gfm": "^3.0.0",
-        "micromark-extension-gfm": "^3.0.0",
-        "remark-parse": "^11.0.0",
-        "remark-stringify": "^11.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/remark-parse": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
@@ -9316,21 +8462,6 @@
         "mdast-util-to-hast": "^13.0.0",
         "unified": "^11.0.0",
         "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-stringify": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
-      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "mdast-util-to-markdown": "^2.0.0",
-        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -9899,16 +9030,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/trim-trailing-lines": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-2.1.0.tgz",
-      "integrity": "sha512-5UR5Biq4VlVOtzqkm2AZlgvSlDJtME46uV0br0gENbwN4l5+mMKT4b9gJKqWtuL2zAIqajGJGuvbCbcAJUZqBg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/trough": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
@@ -10024,12 +9145,6 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/uc.micro": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-      "license": "MIT"
-    },
     "node_modules/undici": {
       "version": "7.25.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
@@ -10060,20 +9175,6 @@
         "is-plain-obj": "^4.0.0",
         "trough": "^2.0.0",
         "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-find-after": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
-      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -10274,9 +9375,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
-      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -10294,20 +9395,6 @@
       "dependencies": {
         "@types/unist": "^3.0.0",
         "vfile-message": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/vfile-location": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
-      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "vfile": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -10539,16 +9626,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/web-namespaces": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
-      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/web-vitals": {

--- a/klai-portal/frontend/package.json
+++ b/klai-portal/frontend/package.json
@@ -20,14 +20,14 @@
     "e2e:capture-session": "tsx e2e/prod-tenant/_lib/capture-voys-session.ts"
   },
   "dependencies": {
-    "@blocknote/core": "^0.47.1",
-    "@blocknote/mantine": "^0.47.1",
-    "@blocknote/react": "^0.47.1",
+    "@blocknote/core": "^0.51.2",
+    "@blocknote/mantine": "^0.51.2",
+    "@blocknote/react": "^0.51.2",
     "@dnd-kit/core": "^6.3.1",
     "@emoji-mart/data": "^1.2.1",
     "@emoji-mart/react": "^1.1.1",
     "@icons-pack/react-simple-icons": "^13.13.0",
-    "@inlang/paraglide-js": "^2.16.0",
+    "@inlang/paraglide-js": "^2.18.1",
     "@mantine/core": "^9.0.2",
     "@mantine/hooks": "^9.0.2",
     "@mantine/notifications": "^9.0.2",
@@ -56,13 +56,12 @@
     "web-vitals": "^5.2.0"
   },
   "overrides": {
-    "@tiptap/core": "3.22.4"
+    "@tiptap/core": "3.23.6",
+    "@tiptap/pm": "3.23.6"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.56.1",
-    "cross-env": "^7.0.3",
-    "tsx": "^4.20.6",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/router-plugin": "^1.167.22",
     "@testing-library/dom": "^10.4.1",
@@ -73,6 +72,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.1.4",
+    "cross-env": "^7.0.3",
     "eslint": "^10.2.1",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
@@ -81,6 +81,7 @@
     "otplib": "^12.0.1",
     "rollup-plugin-visualizer": "^7.0.1",
     "tailwindcss": "^4.2.2",
+    "tsx": "^4.20.6",
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.58.2",
     "vite": "^8.0.8",

--- a/klai-portal/frontend/src/routes/admin/widgets/-types.ts
+++ b/klai-portal/frontend/src/routes/admin/widgets/-types.ts
@@ -31,6 +31,7 @@ export interface WidgetResponse {
   description: string | null
   widget_id: string
   widget_config: WidgetConfig
+  public_share_enabled: boolean
   rate_limit_rpm: number
   kb_access_count: number
   last_used_at: string | null
@@ -48,6 +49,7 @@ export interface CreateWidgetRequest {
   kb_ids: number[]
   rate_limit_rpm: number
   widget_config: WidgetConfig | null
+  public_share_enabled?: boolean
 }
 
 export interface UpdateWidgetRequest {
@@ -56,6 +58,7 @@ export interface UpdateWidgetRequest {
   kb_ids?: number[]
   rate_limit_rpm?: number
   widget_config?: WidgetConfig
+  public_share_enabled?: boolean
 }
 
 export interface OrgKnowledgeBase {

--- a/klai-portal/frontend/src/routes/admin/widgets/_components/tabs/EmbedTab.tsx
+++ b/klai-portal/frontend/src/routes/admin/widgets/_components/tabs/EmbedTab.tsx
@@ -51,10 +51,14 @@ export function EmbedTab({ widget }: Props) {
   const [originsRaw, setOriginsRaw] = useState(
     config.allowed_origins.join('\n'),
   )
+  const [publicShareEnabled, setPublicShareEnabled] = useState(
+    widget.public_share_enabled ?? false,
+  )
 
   useEffect(() => {
     setOriginsRaw(config.allowed_origins.join('\n'))
-  }, [config.allowed_origins])
+    setPublicShareEnabled(widget.public_share_enabled ?? false)
+  }, [config.allowed_origins, widget.public_share_enabled])
 
   const origins = parseOrigins(originsRaw)
   const invalidOrigins = origins.filter((o) => !isValidOrigin(o))
@@ -67,6 +71,7 @@ export function EmbedTab({ widget }: Props) {
   )
 
   function copyShareLink() {
+    if (!publicShareEnabled) return
     void navigator.clipboard.writeText(shareUrl)
     toast.success('Link gekopieerd')
   }
@@ -77,6 +82,7 @@ export function EmbedTab({ widget }: Props) {
   }
 
   function openTest() {
+    if (!publicShareEnabled) return
     // Embedded widget test (floating bubble preview) — TWD's
     // /widget-test?bot=...&w=... equivalent. Use the id query
     // param so the widget-test page loads the public-bot-config
@@ -95,7 +101,7 @@ export function EmbedTab({ widget }: Props) {
       allowed_origins: origins,
     }
     updateMutation.mutate(
-      { widget_config: next },
+      { widget_config: next, public_share_enabled: publicShareEnabled },
       {
         onSuccess: () => toast.success(m.admin_shared_success_updated()),
       },
@@ -113,18 +119,37 @@ export function EmbedTab({ widget }: Props) {
             Deelbare link
           </span>
         </div>
+        <label htmlFor="widget-public-share" className="mb-3 flex items-start gap-3 rounded-md border border-[var(--color-rl-border)] bg-white p-3 cursor-pointer">
+          <input
+            id="widget-public-share"
+            type="checkbox"
+            checked={publicShareEnabled}
+            onChange={(e) => setPublicShareEnabled(e.target.checked)}
+            className="mt-0.5 h-4 w-4 accent-[var(--color-rl-accent)]"
+          />
+          <div>
+            <p className="text-sm font-medium text-[var(--color-rl-dark)]">
+              Publiceer deelbare bot-link
+            </p>
+            <p className="text-xs text-gray-500">
+              Iedereen met deze link kan chatten met de gekoppelde kennisbanken.
+            </p>
+          </div>
+        </label>
         <div className="flex items-center gap-2">
           <input
             type="text"
             readOnly
             value={shareUrl}
+            disabled={!publicShareEnabled}
             onFocus={(e) => e.currentTarget.select()}
-            className="flex-1 rounded-md border border-[var(--color-rl-border)] bg-white px-3 py-2 font-mono text-xs text-[var(--color-rl-dark)] outline-none focus:ring-2 focus:ring-[var(--color-rl-accent)]/40"
+            className="flex-1 rounded-md border border-[var(--color-rl-border)] bg-white px-3 py-2 font-mono text-xs text-[var(--color-rl-dark)] outline-none focus:ring-2 focus:ring-[var(--color-rl-accent)]/40 disabled:opacity-50"
           />
           <button
             type="button"
             onClick={copyShareLink}
-            className="inline-flex items-center justify-center rounded-full bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90"
+            disabled={!publicShareEnabled}
+            className="inline-flex items-center justify-center rounded-full bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
           >
             Kopieer
           </button>
@@ -153,7 +178,8 @@ export function EmbedTab({ widget }: Props) {
           <button
             type="button"
             onClick={openTest}
-            className="inline-flex items-center gap-1.5 rounded-full bg-[var(--color-rl-accent)] px-4 py-2 text-sm font-medium text-[var(--color-rl-dark)] transition-colors hover:bg-[var(--color-rl-accent-hover)]"
+            disabled={!publicShareEnabled}
+            className="inline-flex items-center gap-1.5 rounded-full bg-[var(--color-rl-accent)] px-4 py-2 text-sm font-medium text-[var(--color-rl-dark)] transition-colors hover:bg-[var(--color-rl-accent-hover)] disabled:cursor-not-allowed disabled:opacity-40"
           >
             <Eye className="h-4 w-4" />
             Test

--- a/klai-portal/frontend/src/routes/admin/widgets/new.tsx
+++ b/klai-portal/frontend/src/routes/admin/widgets/new.tsx
@@ -52,6 +52,7 @@ interface FormState {
   collect_user_info: boolean
   hide_disclaimer: boolean
   widget_position: 'left' | 'right'
+  public_share_enabled: boolean
   // Insluiten
   allowed_origins_raw: string
 }
@@ -71,6 +72,7 @@ const INITIAL_FORM: FormState = {
   collect_user_info: false,
   hide_disclaimer: false,
   widget_position: 'right',
+  public_share_enabled: false,
   allowed_origins_raw: '',
 }
 
@@ -196,6 +198,7 @@ function NewWidgetPage() {
         kb_ids: form.kb_ids,
         rate_limit_rpm: 60,
         widget_config: widgetConfig,
+        public_share_enabled: form.public_share_enabled,
       },
       {
         onSuccess: (data) => {


### PR DESCRIPTION
## Summary
- add membership-aware user removal so tenant deletes do not remove shared identities unless it is the final membership
- bind OAuth callbacks to signed tenant state and remove the legacy no-org fallback
- move widget public sharing to a first-class database column with migration/backfill and keep public bot links opt-in
- tighten widget origin matching and clear Python/frontend dependency audit findings

## Validation
- uv run pytest -q
- uv run ruff check app tests/test_admin_widgets.py tests/test_admin_widgets_integration.py tests/test_widget_config.py tests/test_oauth_routes.py
- uv run ruff format --check app tests/test_admin_widgets.py tests/test_admin_widgets_integration.py tests/test_widget_config.py tests/test_oauth_routes.py
- uv run --with pyright pyright
- uv run --with pip-audit pip-audit
- npm run lint
- npm run build
- npm audit --audit-level=moderate