### PR TITLE
fix(alembic): move widgets ALTER TABLE to klai post-deploy SQL

### DIFF
--- a/klai-portal/backend/alembic/versions/a1c2d3e4f5b6_widget_allow_any_origin_and_loaded_origin.py
+++ b/klai-portal/backend/alembic/versions/a1c2d3e4f5b6_widget_allow_any_origin_and_loaded_origin.py
@@ -1,28 +1,24 @@
 """widget allow_any_origin and loaded_origin columns — SPEC-SEC-CROSS-TENANT-FOLLOWUP-001 REQ-2
 
-Adds:
-  - widgets.allow_any_origin BOOLEAN NOT NULL DEFAULT false
-    Explicit opt-in flag for open-world origin policy. When True, the
-    origin_allowed() gate is bypassed entirely. Replaces the old
-    "empty allowed_origins = open to the world" behaviour.
-  - widget_conversations.loaded_origin VARCHAR(200) NULL
-    Records the Origin header from each conversation start for audit
-    visibility. NULL when Origin header was absent (e.g. direct API call).
+Per `alembic-cannot-drop-non-portal_api-tables` pitfall: `widgets` is owned
+by the `klai` superuser (created via post-deploy SQL in earlier work), not
+by `portal_api`. ALTER TABLE on the widgets table fails with
+`InsufficientPrivilegeError: must be owner of table widgets` when run from
+the entrypoint's `alembic upgrade head` (which runs as `portal_api`).
 
-Both columns are additive DDL — no per-row writes in upgrade() so this
-migration is safe on Cat-B (widgets) and Cat-D (widget_conversations)
-RLS tables per the rls-with-check-blocks-migration-update pitfall.
+`widget_conversations` is in the same boat (Cat-D RLS, klai-owned per
+post_deploy_a4f72e913c8b_widget_conversations_rls.sql).
 
-Data migration (3-branch per-row UPDATE for existing widgets) lives in
-post_deploy_a1c2d3e4f5b6.sql and must be applied as the klai superuser.
+So this alembic revision is intentionally a no-op marker — its only job is
+to occupy the migration chain so a single head is preserved. The actual
+ADD COLUMN statements live in the sibling post_deploy_a1c2d3e4f5b6.sql,
+which the portal-api.yml deploy job applies as the klai superuser after
+the alembic upgrade succeeds.
 
 Revision ID: a1c2d3e4f5b6
 Revises: 5b7c9d1e2f3a
 Create Date: 2026-05-24
 """
-
-import sqlalchemy as sa
-from alembic import op
 
 revision = "a1c2d3e4f5b6"
 down_revision = "5b7c9d1e2f3a"
@@ -31,29 +27,10 @@ depends_on = None
 
 
 def upgrade() -> None:
-    # Add widgets.allow_any_origin — DDL only, no per-row write.
-    op.add_column(
-        "widgets",
-        sa.Column(
-            "allow_any_origin",
-            sa.Boolean(),
-            nullable=False,
-            server_default="false",
-        ),
-    )
-
-    # Add widget_conversations.loaded_origin — DDL only, nullable so
-    # existing rows stay valid without a backfill.
-    op.add_column(
-        "widget_conversations",
-        sa.Column(
-            "loaded_origin",
-            sa.String(200),
-            nullable=True,
-        ),
-    )
+    # No-op: schema work delegated to post_deploy_a1c2d3e4f5b6.sql (klai role).
+    pass
 
 
 def downgrade() -> None:
-    op.drop_column("widget_conversations", "loaded_origin")
-    op.drop_column("widgets", "allow_any_origin")
+    # No-op: schema work delegated to post_deploy_a1c2d3e4f5b6.sql (klai role).
+    pass

--- a/klai-portal/backend/alembic/versions/post_deploy_a1c2d3e4f5b6.sql
+++ b/klai-portal/backend/alembic/versions/post_deploy_a1c2d3e4f5b6.sql
@@ -2,7 +2,16 @@
 -- Revision: a1c2d3e4f5b6
 --
 -- Run as klai superuser AFTER `alembic upgrade head` completes.
--- Applies the 3-branch data migration for existing widget rows:
+--
+-- Schema work (ALTER TABLE) is delegated here because `widgets` and
+-- `widget_conversations` are klai-owned (created via earlier post-deploy
+-- SQL); portal_api cannot ALTER them. Per the
+-- `alembic-cannot-drop-non-portal_api-tables` pitfall. The sibling
+-- alembic revision a1c2d3e4f5b6_widget_allow_any_origin_and_loaded_origin.py
+-- is intentionally a no-op marker.
+--
+-- After the ALTER TABLE statements, applies the 3-branch data migration for
+-- existing widget rows:
 --
 --   Branch 1: widgets with a non-empty allowed_origins list → keep as-is.
 --             allow_any_origin stays false (default); no changes needed.
@@ -20,8 +29,19 @@
 --
 -- The audit events in the INSERT below use the portal_audit_log table (Cat-C
 -- RLS: INSERT permissive, so no GUC needed).
+--
+-- Idempotency: ADD COLUMN IF NOT EXISTS, UPDATE branches use selective WHERE
+-- (no-op on re-run after first apply), audit INSERTs may duplicate on re-run
+-- but that's accepted as cheap append-only noise.
 
 BEGIN;
+
+-- Schema additions (klai-only — see header).
+ALTER TABLE widgets
+    ADD COLUMN IF NOT EXISTS allow_any_origin BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE widget_conversations
+    ADD COLUMN IF NOT EXISTS loaded_origin VARCHAR(200);
 
 -- Branch 2: empty origins + public_share_enabled → set allow_any_origin.
 UPDATE widgets
@@ -60,9 +80,11 @@ WHERE w.org_id = o.id
   AND w.allow_any_origin = false;
 
 -- Emit audit events for Branch 3 migrations.
+-- Note: portal_audit_log.org_id is INT; w.org_id is the right field
+-- (w.id is the widget UUID).
 INSERT INTO portal_audit_log (org_id, event_type, actor_type, properties, created_at)
 SELECT
-    w.id,
+    w.org_id,
     'widget.allow_any_origin_migrated',
     'system',
     jsonb_build_object(
@@ -75,7 +97,7 @@ SELECT
 FROM widgets w
 JOIN portal_orgs o ON o.id = w.org_id
 WHERE jsonb_array_length(COALESCE(w.widget_config->'allowed_origins', '[]'::jsonb)) = 1
-  AND w.widget_config->'allowed_origins'->0 LIKE 'https://%.getklai.com'
+  AND w.widget_config->'allowed_origins'->>0 LIKE 'https://%.getklai.com'
   AND w.allow_any_origin = false
   AND w.public_share_enabled = false;
 


### PR DESCRIPTION
Hotfix for crashed deploy after #674: widgets is klai-owned, portal_api cannot ALTER. ADD COLUMN statements moved to post_deploy_a1c2d3e4f5b6.sql (klai superuser). alembic migration is now a no-op marker (preserves chain head). Plus 2 pre-existing bugs fixed in branch-3 audit INSERT. Full pytest 2772 passes.