### PR TITLE
fix(alembic): correct portal_audit_log schema + remove redundant CI step

### DIFF
--- a/.github/workflows/portal-api.yml
+++ b/.github/workflows/portal-api.yml
@@ -472,41 +472,8 @@ jobs:
             chmod +x /opt/klai/scripts/deploy-portal-api.sh
             /opt/klai/scripts/deploy-portal-api.sh
 
-      # SPEC-SEC-CROSS-TENANT-FOLLOWUP-001 REQ-2 + REQ-3: post-deploy SQL.
-      #
-      # These two SQL files require the klai superuser — portal_api cannot
-      # DROP/CREATE POLICY on portal_templates (Cat-D RLS) and cannot UPDATE
-      # rows in widgets without bound tenant context (REQ-2 data-migration
-      # runs across all orgs). The alembic upgrade (run by portal-api's
-      # entrypoint as portal_api) handles only additive DDL (ADD COLUMN);
-      # the row-write + policy work is delegated here.
-      #
-      # Idempotency: REQ-2 UPDATE branches use selective WHERE clauses
-      # (empty origins AND public_share_enabled = X) so a re-run is a no-op
-      # once allow_any_origin has been set. REQ-3 uses DROP POLICY IF EXISTS
-      # + CREATE POLICY so re-runs reset to the same state. Safe to run on
-      # every deploy.
-      - name: REQ-2 + REQ-3 post-deploy SQL (klai superuser)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.CORE01_HOST }}
-          username: klai
-          key: ${{ secrets.CORE01_DEPLOY_KEY }}
-          script: |
-            set -e
-            PG_USER=$(docker exec klai-core-postgres-1 printenv POSTGRES_USER)
-            PG_DB=$(docker exec klai-core-postgres-1 printenv POSTGRES_DB)
-            for sql_file in \
-              post_deploy_a1c2d3e4f5b6.sql \
-              post_deploy_b2d3e4f5a6c7_portal_templates_rls_with_check.sql; do
-              echo "::group::Applying $sql_file"
-              docker cp "klai-core-portal-api-1:/app/alembic/versions/$sql_file" "/tmp/$sql_file"
-              docker cp "/tmp/$sql_file" "klai-core-postgres-1:/tmp/$sql_file"
-              docker exec klai-core-postgres-1 psql \
-                -U "$PG_USER" \
-                -d "$PG_DB" \
-                -v ON_ERROR_STOP=1 \
-                -f "/tmp/$sql_file"
-              echo "::endgroup::"
-            done
+      # NOTE: post_deploy_a1c2d3e4f5b6.sql (REQ-2) and
+      # post_deploy_b2d3e4f5a6c7_portal_templates_rls_with_check.sql (REQ-3)
+      # are auto-applied by /opt/klai/scripts/deploy-portal-api.sh during the
+      # "Deploy to core-01" step above (it iterates every alembic/versions/
+      # post_deploy_*.sql). No separate runner step needed.

--- a/klai-portal/backend/alembic/versions/post_deploy_a1c2d3e4f5b6.sql
+++ b/klai-portal/backend/alembic/versions/post_deploy_a1c2d3e4f5b6.sql
@@ -50,13 +50,16 @@ WHERE jsonb_array_length(COALESCE(widget_config->'allowed_origins', '[]'::jsonb)
   AND public_share_enabled = true;
 
 -- Emit audit events for Branch 2 migrations.
-INSERT INTO portal_audit_log (org_id, event_type, actor_type, properties, created_at)
+-- portal_audit_log schema (app/models/audit.py): org_id, actor_user_id, action,
+-- resource_type, resource_id, details, created_at.
+INSERT INTO portal_audit_log (org_id, actor_user_id, action, resource_type, resource_id, details, created_at)
 SELECT
     org_id,
-    'widget.allow_any_origin_migrated',
     'system',
+    'widget.allow_any_origin_migrated',
+    'widget',
+    id::text,
     jsonb_build_object(
-        'widget_id', id,
         'reason', 'public_share_enabled',
         'migration_revision', 'a1c2d3e4f5b6'
     ),
@@ -80,15 +83,15 @@ WHERE w.org_id = o.id
   AND w.allow_any_origin = false;
 
 -- Emit audit events for Branch 3 migrations.
--- Note: portal_audit_log.org_id is INT; w.org_id is the right field
--- (w.id is the widget UUID).
-INSERT INTO portal_audit_log (org_id, event_type, actor_type, properties, created_at)
+-- Same column order as Branch 2 (see portal_audit_log schema in app/models/audit.py).
+INSERT INTO portal_audit_log (org_id, actor_user_id, action, resource_type, resource_id, details, created_at)
 SELECT
     w.org_id,
-    'widget.allow_any_origin_migrated',
     'system',
+    'widget.allow_any_origin_migrated',
+    'widget',
+    w.id::text,
     jsonb_build_object(
-        'widget_id', w.id,
         'reason', 'tenant_subdomain_default',
         'tenant_slug', o.slug,
         'migration_revision', 'a1c2d3e4f5b6'


### PR DESCRIPTION
Hotfix #2 for SPEC-SEC-CROSS-TENANT-FOLLOWUP-001 deploy. Wrong column names in audit INSERT crashed post_deploy_a1c2d3e4f5b6.sql apply step. Plus deploy-portal-api.sh auto-applies post-deploy SQL — my separate runner step was redundant. Full pytest 2772 still passes.