### PR TITLE
feat(spec): SPEC-SEC-CROSS-TENANT-FOLLOWUP-001 Window 2 (REQ-4/5/6/7/8)

### DIFF
--- a/.moai/specs/SPEC-SEC-CROSS-TENANT-FOLLOWUP-001/spec.md
+++ b/.moai/specs/SPEC-SEC-CROSS-TENANT-FOLLOWUP-001/spec.md
@@ -18,6 +18,8 @@ issue_number: 0
 | 0.1.0 | 2026-05-24 | platform/backend | Initial draft from cross-tenant audit + PR #672 follow-up. Verification against `origin/main` at commit `f8ee7826` confirms: B-1 (no `assert_platform_unlocked` on partner endpoints) still open; B-2 (`if not allowed_origins: return True` at `widget_auth.py:171`) still open; B-3 partially addressed by `public_share_enabled` check (`partner.py:911`), but rate-limit + Origin gate still missing; B-13/C-1 confirmed open. PR #672 introduced `_platform: UserPermissions = Depends(require_platform_unlocked("widgets"))` on admin CRUD routes at lines 196/262/294/333/374/420 of `admin_widgets.py` but NOT on activity-tab routes at lines 498/558/618 — REQ-13 still applies. |
 | 0.2.0 | 2026-05-24 | orchestrator | Resolved all 5 open questions after production-data check + Klai-pattern review. (1) REQ-2 customer-communication window dropped — production cohort query returned 2 widgets, both inside the `getklai` tenant itself (0 external customers impacted); replaced by automated CI cohort gate (deploy pipeline runs the cohort SQL via SSH and aborts if impacted_widgets > 5 OR any external tenant slug appears). (2) REQ-4 hot-cut chosen over feature-flag — `deprovisioning_orchestrator` pattern is proven, user-delete frequency is low (<5/week at Klai scale), git revert is the rollback plan; feature-flag adds parallel-path complexity without real benefit. (3) REQ-17/REQ-19 cross-repo dependency decoupled — SPEC closes when all klai-portal code REQs land; klai-infra PRs tracked as `cross_repo_dependency` with explicit PR-link cross-reference. (4) REQ-12 inline `user.status` check chosen — `_resolve_caller_with_options` already SELECTs the row; Redis cache adds invalidation edge-cases for a handful of suspended users. (5) REQ-8 retention 90d default with `WIDGET_MESSAGES_RETENTION_DAYS` env-var — no unified Klai retention policy in code; 90d defensible per GDPR legitimate interest. |
 | 0.2.1 | 2026-05-24 | orchestrator | Removed all "operator manual inspect" language per project principle (Klai works fully autonomously; no manual gates between deploy steps). REQ-2 cohort verification is enforced by an automated GitHub Actions step in `.github/workflows/portal-api.yml` that SSHes to core-01, runs `scripts/verify_widget_cohort.sh`, and aborts the deploy if `impacted_widgets > 5 OR impacted_tenants includes any slug outside the platform_org list`. If the deploy aborts, REQ-2 is split into a follow-up SPEC with the standard 7-day comm protocol. No human pre-merge inspection required — the migration's automated branches handle the safe defaults per row. |
+| 0.3.0 | 2026-05-24 | orchestrator | **Window 1 (REQ-1, REQ-2, REQ-3, REQ-9) DELIVERED TO PRODUCTION via PR #674.** Required 4 hotfix PRs to land cleanly; lessons learned saved to CodeIndex memory `5c0ab6a1` for future SPECs. Hotfix chain: (a) PR #675 `fix(ci): inline REQ-2 cohort-gate SQL` — `/opt/klai/` on core-01 has sparse-checkout that does NOT include `klai-portal/backend/scripts/`; inlined the cohort SQL directly in the workflow step. (b) PR #676 `fix(alembic): move widgets ALTER TABLE to klai-superuser post-deploy SQL` — `widgets` and `widget_conversations` are klai-owned (not portal_api), so ALTER TABLE on them goes in post-deploy SQL; alembic migration `a1c2d3e4f5b6` is now a no-op marker. (c) PR #677 `fix(alembic): correct portal_audit_log schema` — column names are `action`/`actor_user_id`/`details`, NOT `event_type`/`actor_type`/`properties` (per `app/models/audit.py`); also removed redundant "REQ-2 + REQ-3 post-deploy SQL" workflow step because `/opt/klai/scripts/deploy-portal-api.sh` already auto-iterates every `alembic/versions/post_deploy_*.sql`. Production verified via 5 curl-tests on `/partner/v1/widget-config` (origin-gate behaves as specified: getklai-subdomain=200, phishing=403, no-Origin=403, unknown-widget=404, public-bot-without-share=404); pg_policy query confirms `WITH CHECK (org_id = _rls_current_org_id())` on portal_templates; container running fresh image `10ccb8fe736f...` since 2026-05-24T19:50Z; VictoriaLogs shows 0 Caddy 5xx since deploy. |
+| 0.4.0 | 2026-05-25 | orchestrator | **Window 2 (REQ-4, REQ-5, REQ-6, REQ-7, REQ-8) IMPLEMENTED on feature branch `feature/SPEC-SEC-CROSS-TENANT-FOLLOWUP-001-window-2`, NOT yet deployed.** 5 commits on branch (`adb2f6e5` REQ-7, `031c6f5c` REQ-6, `ece61ecc` REQ-5, `76e12781` REQ-8, `5c74a6be` REQ-4). Backend test suite at 2804 passing (was 2772 after Window 1 = +32 new tests). Alembic single head `5c6ad9cf7983`. All Window 1 lessons applied: REQ-8 schema change (`widget_messages.content CHECK constraint`) correctly placed in post-deploy SQL (klai-owned table); REQ-4 schema (`portal_users.deletion_status` columns) correctly in alembic upgrade (portal_api-owned); adjacent FakeWidget/FakeOrg mocks updated across all test files (no Window-1-style adjacent regression); portal_audit_log INSERTs use correct column names. REQ-4 state-machine mirrors `deprovisioning_orchestrator` pattern exactly; new endpoint `POST /api/admin/platform/users/{zitadel_user_id}/retry-delete`; self-delete + last-platform-admin guards. REQ-4 implementation also closes REQ-11 (Finding A-5 partial-failure audit event) — flagging for Window 3 scope adjustment. |
 
 ## 1. Problem
 
@@ -517,18 +519,52 @@ Final tag-set will be confirmed during the Run phase per the SPEC-MX-001 protoco
 
 ## 13. Definition of Done
 
-- All 19 REQs have a passing test (`acceptance.md` AC1..AC19).
-- `klai-portal/backend` `uv run pytest -q --tb=short` exits 0.
+### Per-Window status (live as of 2026-05-25)
+
+**Window 1 (REQ-1, REQ-2, REQ-3, REQ-9) — ✅ DELIVERED TO PRODUCTION** via PR #674 + hotfixes #675/#676/#677. Merge commit `fde33d68` on main. Container `klai-core-portal-api-1` running image `10ccb8fe736f...` since `2026-05-24T19:50:47Z`.
+
+- [x] REQ-1 `assert_platform_unlocked` on partner endpoints — code deployed; indirect-verified via cohort-gate working + 5 curl-tests reaching `widget_config` code-path
+- [x] REQ-2 default-deny origins + cohort-gate + data-migration — directly verified via 5 curl-tests on `/partner/v1/widget-config`: getklai-subdomain=200, phishing=403, no-Origin=403, unknown-widget=404, public-bot-without-share=404; the 403 cases were 200 pre-Window-1 (CRIT B-2 closed)
+- [x] REQ-3 `portal_templates` WITH CHECK — directly verified: `SELECT pg_get_expr(polwithcheck, polrelid) FROM pg_policy WHERE polname='tenant_isolation' AND polrelid='portal_templates'::regclass` returns `(org_id = _rls_current_org_id())`
+- [x] REQ-9 ActivityTab scheme-allowlist — bundle `assets/index-BsgXprzL.js` 200 served via Caddy; 18 vitest scenarios green at commit `732d57e9`; admin-UI click-test deferred to Mark's browser session
+- [x] CI cohort gate green on every deploy run since 2026-05-24
+- [x] VictoriaLogs: 0 `service:caddy AND status:>=500` since deploy; 1 pre-existing `service:portal-api AND level:error` (RLS-cleanup warning on `portal_retrieval_gaps`, not REQ-related)
+
+**Window 2 (REQ-4, REQ-5, REQ-6, REQ-7, REQ-8) — 🟡 IMPLEMENTED ON BRANCH** `feature/SPEC-SEC-CROSS-TENANT-FOLLOWUP-001-window-2`. Not yet deployed.
+
+- [x] All 5 REQs have a passing test; backend pytest 2804/2804 (was 2772 = +32 new)
+- [x] Alembic single head `5c6ad9cf7983`; ruff/format/pyright clean
+- [x] REQ-8 schema (CHECK constraint on `widget_messages.content`) correctly placed in post-deploy SQL (klai-owned table — applied Window-1 lesson)
+- [x] REQ-4 schema (`portal_users.deletion_status` + `failure_reason` + `last_attempted_step`) correctly in alembic upgrade (portal_api-owned)
+- [x] Adjacent FakeWidget/FakeOrg mocks updated across all test files (no Window-1-style adjacent regression)
+- [x] REQ-4 closes REQ-11 (Finding A-5 partial-failure audit-event) as a side effect — flag for Window 3 scope adjustment
+- [ ] PR open + admin-merged to main
+- [ ] Deploy to production via portal-api.yml
+- [ ] Live verification (curl tests for REQ-7 rate-limit, SQL check for REQ-4 state-machine columns, etc.)
+
+**Window 3 (REQ-10..19) — ⬜ NOT STARTED** (out of scope until Window 2 lands on production).
+
+### Always-on gates (apply to every Window deploy)
+
+- `klai-portal/backend` `uv run pytest -q --tb=short` exits 0 (FULL suite, not cherry-picked — Window-1 lesson).
 - `klai-portal/backend` `uv run ruff check .` exits 0.
 - `klai-portal/backend` `uv run ruff format --check .` exits 0.
 - `klai-portal/backend` `uv run --with pyright pyright` exits 0.
-- `klai-portal/frontend` `npm run lint` + `npm run test` exit 0 (covers REQ-9, REQ-2 UI bits).
+- `klai-portal/frontend` `npx tsc -b --force` exits 0 (stricter than vitest — Window-1 lesson; caught `id: 1` vs `string` type mismatch).
+- `klai-portal/frontend` `npm run lint` + `npm test -- --run` exit 0.
 - Coverage on new code >= 85% (per `.moai/config/sections/quality.yaml` threshold).
-- security-review skill PASS for REQ-1, REQ-2, REQ-3.
-- Alembic head still single (verify with `alembic heads | wc -l == 1`) — see `alembic-multi-pr-head-split` pitfall.
-- Production smoke-test: after Window 1 deploy, a curl against `/partner/v1/widget-config?id=<widget-of-tenant-with-widgets-disabled>` returns 404; a curl against `/partner/v1/widget-config?id=<widget-of-tenant-with-widgets-enabled>` returns 200.
-- Automated CI cohort gate (GitHub Actions step in `portal-api.yml`) passes on the deploy run for Window 1; the step's output (cohort SQL result) is captured in the workflow log for audit.
-- Cross-repo: klai-infra PRs for REQ-17 + REQ-19 tracked as `cross_repo_dependency` in this SPEC's PR description; deliverable status of this SPEC does NOT block on klai-infra merge — REQ-17 + REQ-19 are marked "delegated to klai-infra" once the cross-repo PR is opened with this SPEC ID in the description.
+- Alembic head single (`alembic heads | wc -l == 1`) — see `alembic-multi-pr-head-split` pitfall.
+- security-review skill PASS for REQ-1, REQ-2, REQ-3 (Window 1 ✓).
+- Cross-repo: klai-infra PRs for REQ-17 + REQ-19 tracked as `cross_repo_dependency`; deliverable status does NOT block on klai-infra merge.
+
+### Lessons learned during Window 1 deploy (captured in CodeIndex memory `5c0ab6a1`)
+
+1. **Schema-FIRST**: read `app/models/*.py` BEFORE writing any SQL — `portal_audit_log` columns are `action`/`actor_user_id`/`resource_type`/`resource_id`/`details`, NOT `event_type`/`actor_type`/`properties`.
+2. **Table ownership**: `widgets`, `widget_conversations`, `widget_messages` are klai-owned (created via post-deploy SQL in earlier work) — ALTER TABLE on them goes in post-deploy SQL, NOT alembic upgrade (`alembic-cannot-drop-non-portal_api-tables` pitfall class). `portal_users` is portal_api-owned (auth table) — normal alembic upgrade is fine.
+3. **deploy-portal-api.sh auto-iterates `alembic/versions/post_deploy_*.sql`** as klai superuser after `alembic upgrade head`. No separate workflow step needed.
+4. **/opt/klai sparse-checkout** does NOT include `klai-portal/backend/scripts/` — bash scripts referenced from workflow YAML must either live in repo root `scripts/` (and be added to deploy-compose.yml sync paths) or be inlined directly in the YAML step.
+5. **Full pytest, not cherry-picked** — adjacent FakeWidget/FakeOrg mocks may need updates when new attribute access lands in production code-path. Window 1 had 13 hidden regressions because I only ran 5 new test files.
+6. **`tsc -b --force` is stricter than vitest** — `id: 1` (number) passes vitest with loose types but fails the build's strict tsc. Always run `npx tsc -b --force` after writing TypeScript tests.
 
 ## 14. Exclusions (What NOT to Build)
 

--- a/klai-portal/backend/alembic/versions/57b2c33efe55_marker_req8_widget_messages_retention.py
+++ b/klai-portal/backend/alembic/versions/57b2c33efe55_marker_req8_widget_messages_retention.py
@@ -1,0 +1,32 @@
+"""REQ-8 (SPEC-SEC-CROSS-TENANT-FOLLOWUP-001): widget_messages retention marker.
+
+The DDL change (length CHECK constraint on widget_messages.content) lives in
+post_deploy_57b2c33efe55.sql.  widget_messages is owned by the 'klai' superuser
+role — ALTER TABLE is not executable by the 'portal_api' role that runs
+alembic upgrade head.  The post-deploy SQL is applied manually by an operator
+(or via apply_post_deploy_sql.sh) after this migration has been stamped.
+
+Revision ID: 57b2c33efe55
+Revises: b2d3e4f5a6c7
+Create Date: 2026-05-24
+"""
+
+from __future__ import annotations
+
+from alembic import op  # noqa: F401 — imported for future use
+
+# revision identifiers, used by Alembic.
+revision = "57b2c33efe55"
+down_revision = "b2d3e4f5a6c7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # No-op: widget_messages is klai-owned; DDL is in post_deploy_57b2c33efe55.sql
+    pass
+
+
+def downgrade() -> None:
+    # No-op: post-deploy SQL is not automatically reversed.
+    pass

--- a/klai-portal/backend/alembic/versions/5c6ad9cf7983_add_user_deletion_state_columns.py
+++ b/klai-portal/backend/alembic/versions/5c6ad9cf7983_add_user_deletion_state_columns.py
@@ -1,0 +1,49 @@
+"""Add portal_users.deletion_status, failure_reason, last_attempted_step.
+
+REQ-4 (SPEC-SEC-CROSS-TENANT-FOLLOWUP-001): State tracking for the
+platform user-delete state machine. Allows partial failures to be recorded
+and retried via POST /api/admin/platform/users/{uid}/retry-delete.
+
+Revision ID: 5c6ad9cf7983
+Revises: 57b2c33efe55
+Create Date: 2026-05-24
+
+# @MX:NOTE: upgrade() adds three nullable columns with no defaults.
+#   Existing rows will have NULL in all three (no deletion attempt yet).
+#   The columns are populated by user_deletion_orchestrator._mark_user_delete_failed
+#   when a step fails.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+# revision identifiers, used by Alembic.
+revision: str = "5c6ad9cf7983"
+down_revision: str | None = "57b2c33efe55"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    # Three nullable columns — existing rows keep NULL (no ongoing deletion).
+    op.add_column(
+        "portal_users",
+        sa.Column("deletion_status", sa.String(32), nullable=True),
+    )
+    op.add_column(
+        "portal_users",
+        sa.Column("failure_reason", JSONB, nullable=True),
+    )
+    op.add_column(
+        "portal_users",
+        sa.Column("last_attempted_step", sa.String(64), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("portal_users", "last_attempted_step")
+    op.drop_column("portal_users", "failure_reason")
+    op.drop_column("portal_users", "deletion_status")

--- a/klai-portal/backend/alembic/versions/post_deploy_57b2c33efe55_widget_messages_content_length.sql
+++ b/klai-portal/backend/alembic/versions/post_deploy_57b2c33efe55_widget_messages_content_length.sql
@@ -1,0 +1,13 @@
+-- REQ-8 (SPEC-SEC-CROSS-TENANT-FOLLOWUP-001 Finding B-5, HIGH):
+-- Add CHECK constraint capping widget_messages.content at 10000 characters.
+--
+-- Run as the 'klai' superuser (portal_api cannot ALTER klai-owned tables).
+-- Apply after: alembic upgrade head stamps revision 57b2c33efe55.
+--
+-- This is a belt-and-suspenders constraint — the application already clamps
+-- content to 10000 chars before INSERT (AC8.1). The DB constraint prevents
+-- any future code path from silently bypassing the cap.
+
+ALTER TABLE widget_messages
+    ADD CONSTRAINT widget_messages_content_length
+    CHECK (LENGTH(content) <= 10000);

--- a/klai-portal/backend/app/api/admin/platform_manage.py
+++ b/klai-portal/backend/app/api/admin/platform_manage.py
@@ -45,7 +45,7 @@ from app.services.default_knowledge_bases import create_default_personal_kb
 from app.services.mcp_role_notifier import fire_role_change_notification
 from app.services.provisioning import provision_tenant
 from app.services.user_memberships import get_user_membership_summary
-from app.services.zitadel import zitadel
+from app.services.zitadel import _sync_zitadel_role_grant, zitadel
 
 
 def _slugify(name: str) -> str:
@@ -108,6 +108,12 @@ class MessageResponse(BaseModel):
     message: str
 
 
+class RoleUpdateResponse(MessageResponse):
+    """Response for role-change endpoints; carries zitadel_sync_failed flag (REQ-5)."""
+
+    zitadel_sync_failed: bool = False
+
+
 class RoleUpdateRequest(BaseModel):
     role: PortalRole
 
@@ -150,14 +156,14 @@ async def _rollback_zitadel_user(zitadel_user_id: str) -> None:
 
 @router.patch(
     "/organizations/{org_id}/users/{zitadel_user_id}/role",
-    response_model=MessageResponse,
+    response_model=RoleUpdateResponse,
 )
 async def platform_update_role(
     org_id: int,
     zitadel_user_id: str,
     body: RoleUpdateRequest,
     perms: UserPermissions = Depends(require_platform_admin()),
-) -> MessageResponse:
+) -> RoleUpdateResponse:
     """Change a user's role inside a target tenant. Refuses to demote the
     last admin (mirrors the per-tenant invariant)."""
     async with tenant_scoped_session(org_id) as db:
@@ -193,6 +199,7 @@ async def platform_update_role(
                     detail="Kan rol niet wijzigen: dit is de laatste admin.",
                 )
 
+        old_role = user.role
         user.role = body.role
         await db.commit()
 
@@ -205,7 +212,29 @@ async def platform_update_role(
         resource_id=zitadel_user_id,
         details={"target_org_id": org_id, "new_role": body.role},
     )
-    return MessageResponse(message="Rol bijgewerkt.")
+
+    # REQ-5 (Finding A-4): sync Zitadel org:owner grant after DB commit.
+    # @MX:NOTE: [AUTO] Failure is non-fatal: DB is already committed; we emit
+    # a desync audit event and surface zitadel_sync_failed in the response.
+    # @MX:SPEC: SPEC-SEC-CROSS-TENANT-FOLLOWUP-001 REQ-5
+    zitadel_sync_failed = False
+    try:
+        await _sync_zitadel_role_grant(zitadel_user_id, old_role=old_role, new_role=body.role)
+    except Exception:
+        zitadel_sync_failed = True
+        logger.exception("platform_role_change_zitadel_sync_failed", zitadel_user_id=zitadel_user_id)
+        await _emit_audit_safe(
+            action="platform_admin.role_change_zitadel_desync",
+            details={
+                "db_role": body.role,
+                "target_zitadel_role": "org:owner",
+                "zitadel_sync_failed": True,
+                "target_org_id": org_id,
+            },
+            perms=perms,
+        )
+
+    return RoleUpdateResponse(message="Rol bijgewerkt.", zitadel_sync_failed=zitadel_sync_failed)
 
 
 # ---------------------------------------------------------------------------

--- a/klai-portal/backend/app/api/admin/platform_manage.py
+++ b/klai-portal/backend/app/api/admin/platform_manage.py
@@ -66,6 +66,31 @@ logger = structlog.get_logger()
 
 router = APIRouter(prefix="/platform", tags=["platform-admin"])
 
+
+async def _emit_audit_safe(action: str, details: dict, perms: UserPermissions) -> None:
+    """Emit an audit event; fall back to structlog on DB failure (REQ-6 AC6.3).
+
+    # @MX:NOTE: [AUTO] Used for partial-failure audit paths where the primary session
+    # may be aborted. Mirrors the fallback pattern in kb_offboarding._do_delete.
+    # @MX:SPEC: SPEC-SEC-CROSS-TENANT-FOLLOWUP-001 REQ-6
+    """
+    try:
+        await log_event(
+            org_id=perms.org_id,
+            actor=perms.user_id,
+            action=action,
+            resource_type="user",
+            resource_id="",
+            details=details,
+        )
+    except Exception:
+        logger.exception(
+            "platform_admin_audit_emit_failed",
+            original_action=action,
+            original_details=details,
+        )
+
+
 PortalRole = Literal["personal", "company", "kb_manager", "group_manager", "admin"]
 
 # Mirror of users.py::_ZITADEL_ROLE_BY_PORTAL_ROLE — only admin gets a
@@ -416,6 +441,17 @@ async def platform_invite(
         )
     except Exception as exc:
         logger.exception("platform_invite_zitadel_failed", email=body.email)
+        # REQ-6 (Finding A-7): emit audit event for permanent trail even though
+        # VictoriaLogs captures the exception above (30-day retention only).
+        await _emit_audit_safe(
+            action="platform_admin.invite_zitadel_invite_failed",
+            details={
+                "target_email": body.email,
+                "target_org_id": org_id,
+                "error": str(exc)[:200],
+            },
+            perms=perms,
+        )
         raise HTTPException(status_code=502, detail=f"Zitadel invite mislukt: {exc}") from exc
     zitadel_user_id: str = user_data["userId"]
 
@@ -430,6 +466,15 @@ async def platform_invite(
             )
         except Exception as exc:
             logger.exception("platform_invite_grant_failed", zitadel_user_id=zitadel_user_id)
+            await _emit_audit_safe(
+                action="platform_admin.invite_grant_role_failed",
+                details={
+                    "target_email": body.email,
+                    "target_org_id": org_id,
+                    "error": str(exc)[:200],
+                },
+                perms=perms,
+            )
             await _rollback_zitadel_user(zitadel_user_id)
             raise HTTPException(status_code=502, detail=f"Rol-grant mislukt: {exc}") from exc
 
@@ -560,6 +605,17 @@ async def platform_create_tenant(
         )
     except Exception as exc:
         logger.exception("platform_create_tenant_owner_setup_failed", email=body.owner_email)
+        # REQ-6 (Finding A-7): permanent audit trail for grant failure.
+        await _emit_audit_safe(
+            action="platform_admin.create_tenant_grant_role_failed",
+            details={
+                "target_email": body.owner_email,
+                "target_org_id": None,
+                "target_zitadel_org_id": zitadel_org_id,
+                "error": str(exc)[:200],
+            },
+            perms=perms,
+        )
         await _rollback_zitadel_user(owner_user_id)
         await _rollback_zitadel_org()
         raise HTTPException(status_code=502, detail=f"Owner-setup mislukt: {exc}") from exc

--- a/klai-portal/backend/app/api/admin/platform_manage.py
+++ b/klai-portal/backend/app/api/admin/platform_manage.py
@@ -44,6 +44,7 @@ from app.services.auth_links import AuthLinkRoute, build_url_template
 from app.services.default_knowledge_bases import create_default_personal_kb
 from app.services.mcp_role_notifier import fire_role_change_notification
 from app.services.provisioning import provision_tenant
+from app.services.user_deletion_orchestrator import delete_user_with_state_machine
 from app.services.user_memberships import get_user_membership_summary
 from app.services.zitadel import _sync_zitadel_role_grant, zitadel
 
@@ -344,10 +345,53 @@ async def platform_delete_user(
 
     Deleting the sole owner of a tenant leaves an empty org — use the
     tenant-deprovision endpoint to remove the whole tenant instead.
+
+    Uses the user_deletion_orchestrator state machine (REQ-4) so that partial
+    failures are recorded on portal_users.deletion_status and can be retried.
+    """
+    return await _execute_user_delete(
+        org_id=org_id,
+        zitadel_user_id=zitadel_user_id,
+        perms=perms,
+    )
+
+
+@router.post(
+    "/organizations/{org_id}/users/{zitadel_user_id}/retry-delete",
+    response_model=MessageResponse,
+)
+async def platform_retry_user_delete(
+    org_id: int,
+    zitadel_user_id: str,
+    perms: UserPermissions = Depends(require_platform_admin()),
+) -> MessageResponse:
+    """Restart the user-delete state machine from scratch.
+
+    Each step is idempotent — already-deleted resources are skipped
+    harmlessly. Use this after a portal_users.deletion_status='failed_partial'
+    to complete the deletion.
+    """
+    return await _execute_user_delete(
+        org_id=org_id,
+        zitadel_user_id=zitadel_user_id,
+        perms=perms,
+    )
+
+
+async def _execute_user_delete(
+    *,
+    org_id: int,
+    zitadel_user_id: str,
+    perms: UserPermissions,
+) -> MessageResponse:
+    """Shared implementation for platform_delete_user and platform_retry_user_delete.
+
+    Resolves all pre-conditions, then delegates to delete_user_with_state_machine.
+    The orchestrator records partial failures on portal_users so the retry
+    endpoint can restart from scratch.
     """
     from app.services.kb_offboarding import (
         KbDisposition,
-        apply_dispositions,
         compute_offboard_preview,
         revoke_user_credentials,
     )
@@ -381,49 +425,44 @@ async def platform_delete_user(
             )
         delete_global_identity = membership_summary.remaining_count == 0
 
-        # 1. Purge KBs: personal + solely-owned org KBs (complete delete).
+        # Pre-compute KB dispositions + revoke credentials before entering the
+        # state machine. Credential revocation is safe to do here because it is
+        # idempotent (already-revoked keys are skipped).
         preview = await compute_offboard_preview(zitadel_user_id, org_id, db)
-        dispositions = [
+        kb_dispositions = [
             KbDisposition(kb_id=kb.kb_id, action="delete")
             for kb in (*preview.personal_kbs, *preview.org_kbs_solely_owned)
         ]
-        if dispositions:
-            await apply_dispositions(zitadel_user_id, dispositions, perms.user_id, org, db)
-
-        # 2. Revoke partner API keys + MCP tokens.
         api_keys, mcp_tokens = await revoke_user_credentials(zitadel_user_id, org_id, db)
 
-        # 3. Delete the global Zitadel identity only when this was the last
-        # tenant membership. Multi-tenant users keep their login elsewhere.
-        if delete_global_identity:
-            try:
-                await zitadel.remove_user(
-                    org_id=settings_zitadel_portal_org_id(),
-                    zitadel_user_id=zitadel_user_id,
-                )
-            except Exception as exc:
-                raise HTTPException(status_code=502, detail=f"Zitadel-verwijdering mislukt: {exc}") from exc
+        # Delegate to the state machine. It records partial failures and emits
+        # the audit event. We pass the open tenant-scoped session so step 3
+        # (portal_db_delete) runs in the same RLS context.
+        success = await delete_user_with_state_machine(
+            org_id=org_id,
+            zitadel_user_id=zitadel_user_id,
+            actor_user_id=perms.user_id,
+            delete_global_identity=delete_global_identity,
+            kb_dispositions=kb_dispositions,
+            api_keys_count=api_keys,
+            mcp_tokens_count=mcp_tokens,
+            org=org,
+            portal_user=user,
+            db=db,
+        )
 
-        # 4. Delete the portal_users row (cascades memberships/capabilities).
-        await db.delete(user)
-        await db.commit()
+        if success:
+            await db.commit()
 
     fire_role_change_notification(zitadel_user_id)
-    await log_event(
-        org_id=perms.org_id,
-        actor=perms.user_id,
-        action="platform_admin.user_deleted",
-        resource_type="user",
-        resource_id=zitadel_user_id,
-        details={
-            "target_org_id": org_id,
-            "kbs_deleted": len(dispositions),
-            "api_keys_revoked": api_keys,
-            "mcp_tokens_revoked": mcp_tokens,
-            "global_identity_deleted": delete_global_identity,
-            "remaining_membership_count": membership_summary.remaining_count,
-        },
-    )
+
+    if not success:
+        # Partial failure — orchestrator already wrote deletion_status and audit.
+        raise HTTPException(
+            status_code=502,
+            detail=("Verwijdering gedeeltelijk mislukt. Gebruik POST .../retry-delete om opnieuw te proberen."),
+        )
+
     message = "Gebruiker volledig verwijderd." if delete_global_identity else "Gebruiker uit tenant verwijderd."
     return MessageResponse(message=message)
 

--- a/klai-portal/backend/app/api/admin/users.py
+++ b/klai-portal/backend/app/api/admin/users.py
@@ -40,7 +40,7 @@ from app.services.kb_offboarding import (
 )
 from app.services.mcp_role_notifier import fire_role_change_notification
 from app.services.user_memberships import get_user_membership_summary
-from app.services.zitadel import zitadel
+from app.services.zitadel import _sync_zitadel_role_grant, zitadel
 
 logger = logging.getLogger(__name__)
 # Structured-event logger for VictoriaLogs queryability — follows the
@@ -148,6 +148,12 @@ class SeatUpdateRequest(BaseModel):
 
 class MessageResponse(BaseModel):
     message: str
+
+
+class RoleUpdateResponse(MessageResponse):
+    """Response for role-change endpoints; carries zitadel_sync_failed flag (REQ-5)."""
+
+    zitadel_sync_failed: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -406,13 +412,13 @@ async def update_user(
     return MessageResponse(message="User updated.")
 
 
-@router.patch("/users/{zitadel_user_id}/role", response_model=MessageResponse)
+@router.patch("/users/{zitadel_user_id}/role", response_model=RoleUpdateResponse)
 async def update_user_role(
     zitadel_user_id: str,
     body: RoleUpdateRequest,
     perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
     db: AsyncSession = Depends(get_db),
-) -> MessageResponse:
+) -> RoleUpdateResponse:
     """SPEC-PORTAL-ADMIN-UI-001 REQ-2: unified change-profile endpoint.
 
     Serialises role changes per-org and refuses to demote the last admin so
@@ -461,6 +467,7 @@ async def update_user_role(
                 detail="Cannot change profile: this is the last admin. Promote another user first.",
             )
 
+    old_role = user.role
     user.role = body.role
     await db.commit()
     logger.info("Role changed: user_id=%s, new_role=%s, org_id=%d", zitadel_user_id, body.role, perms.org_id)
@@ -472,7 +479,33 @@ async def update_user_role(
     # role-change response never waits on the cross-service hop.
     fire_role_change_notification(zitadel_user_id)
 
-    return MessageResponse(message="Rol bijgewerkt.")
+    # REQ-5 (Finding A-4): sync Zitadel org:owner grant after DB commit.
+    # @MX:NOTE: [AUTO] Failure is non-fatal — DB already committed.
+    # @MX:SPEC: SPEC-SEC-CROSS-TENANT-FOLLOWUP-001 REQ-5
+    zitadel_sync_failed = False
+    try:
+        await _sync_zitadel_role_grant(zitadel_user_id, old_role=old_role, new_role=body.role)
+    except Exception:
+        zitadel_sync_failed = True
+        _slog.exception(
+            "users_role_change_zitadel_sync_failed",
+            zitadel_user_id=zitadel_user_id,
+            org_id=perms.org_id,
+        )
+        await log_event(
+            org_id=perms.org_id,
+            actor=perms.user_id,
+            action="platform_admin.role_change_zitadel_desync",
+            resource_type="user",
+            resource_id=zitadel_user_id,
+            details={
+                "db_role": body.role,
+                "target_zitadel_role": "org:owner",
+                "zitadel_sync_failed": True,
+            },
+        )
+
+    return RoleUpdateResponse(message="Rol bijgewerkt.", zitadel_sync_failed=zitadel_sync_failed)
 
 
 @router.patch("/users/{zitadel_user_id}/seat", response_model=MessageResponse)

--- a/klai-portal/backend/app/api/partner.py
+++ b/klai-portal/backend/app/api/partner.py
@@ -819,15 +819,18 @@ async def widget_config(
     # @MX:NOTE: [AUTO] Rate-limit key is widget_mint:{id} (public widget_id from URL param).
     # Limit is 10/min per widget to prevent unbounded LLM-token drain via the public mint path.
     # @MX:SPEC: SPEC-SEC-CROSS-TENANT-FOLLOWUP-001 REQ-7
-    redis = get_redis_pool()
-    allowed, retry_after = await check_rate_limit(redis, f"widget_mint:{id}", limit_per_minute=10, window_seconds=60)
-    if not allowed:
-        return Response(
-            content='{"detail":"Rate limit exceeded"}',
-            status_code=429,
-            media_type="application/json",
-            headers={"Retry-After": str(retry_after)},
+    redis = await get_redis_pool()
+    if redis is not None:
+        allowed, retry_after = await check_rate_limit(
+            redis, f"widget_mint:{id}", limit_per_minute=10, window_seconds=60
         )
+        if not allowed:
+            return Response(
+                content='{"detail":"Rate limit exceeded"}',
+                status_code=429,
+                media_type="application/json",
+                headers={"Retry-After": str(retry_after)},
+            )
 
     # Look up widget by public widget_id (SPEC-WIDGET-002: own table)
     result = await db.execute(select(Widget).where(Widget.widget_id == id))
@@ -938,15 +941,18 @@ async def public_bot_config(
     # @MX:NOTE: [AUTO] Same rate-limit as widget_config — isolates public share-link
     # mint path from the embed mint path with separate per-widget keys.
     # @MX:SPEC: SPEC-SEC-CROSS-TENANT-FOLLOWUP-001 REQ-7
-    redis = get_redis_pool()
-    allowed, retry_after = await check_rate_limit(redis, f"widget_mint:{id}", limit_per_minute=10, window_seconds=60)
-    if not allowed:
-        return Response(
-            content='{"detail":"Rate limit exceeded"}',
-            status_code=429,
-            media_type="application/json",
-            headers={"Retry-After": str(retry_after)},
+    redis = await get_redis_pool()
+    if redis is not None:
+        allowed, retry_after = await check_rate_limit(
+            redis, f"widget_mint:{id}", limit_per_minute=10, window_seconds=60
         )
+        if not allowed:
+            return Response(
+                content='{"detail":"Rate limit exceeded"}',
+                status_code=429,
+                media_type="application/json",
+                headers={"Retry-After": str(retry_after)},
+            )
 
     result = await db.execute(select(Widget).where(Widget.widget_id == id))
     widget_row = result.scalar_one_or_none()

--- a/klai-portal/backend/app/api/partner.py
+++ b/klai-portal/backend/app/api/partner.py
@@ -43,6 +43,7 @@ from app.services.partner_chat import (
     chat_completion_streaming,
     retrieve_context,
 )
+from app.services.partner_rate_limit import check_rate_limit
 from app.services.quality_scorer import schedule_quality_update
 from app.services.redis_client import get_redis_pool
 from app.services.retrieval_log import find_correlated_log, write_retrieval_log
@@ -814,6 +815,20 @@ async def widget_config(
             media_type="application/json",
         )
 
+    # REQ-7 (Finding B-4): per-widget mint rate-limit BEFORE DB lookup.
+    # @MX:NOTE: [AUTO] Rate-limit key is widget_mint:{id} (public widget_id from URL param).
+    # Limit is 10/min per widget to prevent unbounded LLM-token drain via the public mint path.
+    # @MX:SPEC: SPEC-SEC-CROSS-TENANT-FOLLOWUP-001 REQ-7
+    redis = get_redis_pool()
+    allowed, retry_after = await check_rate_limit(redis, f"widget_mint:{id}", limit_per_minute=10, window_seconds=60)
+    if not allowed:
+        return Response(
+            content='{"detail":"Rate limit exceeded"}',
+            status_code=429,
+            media_type="application/json",
+            headers={"Retry-After": str(retry_after)},
+        )
+
     # Look up widget by public widget_id (SPEC-WIDGET-002: own table)
     result = await db.execute(select(Widget).where(Widget.widget_id == id))
     widget_row = result.scalar_one_or_none()
@@ -917,6 +932,20 @@ async def public_bot_config(
             content='{"detail":"Widget authentication not configured"}',
             status_code=503,
             media_type="application/json",
+        )
+
+    # REQ-7 (Finding B-4): per-widget mint rate-limit BEFORE DB lookup.
+    # @MX:NOTE: [AUTO] Same rate-limit as widget_config — isolates public share-link
+    # mint path from the embed mint path with separate per-widget keys.
+    # @MX:SPEC: SPEC-SEC-CROSS-TENANT-FOLLOWUP-001 REQ-7
+    redis = get_redis_pool()
+    allowed, retry_after = await check_rate_limit(redis, f"widget_mint:{id}", limit_per_minute=10, window_seconds=60)
+    if not allowed:
+        return Response(
+            content='{"detail":"Rate limit exceeded"}',
+            status_code=429,
+            media_type="application/json",
+            headers={"Retry-After": str(retry_after)},
         )
 
     result = await db.execute(select(Widget).where(Widget.widget_id == id))

--- a/klai-portal/backend/app/core/config.py
+++ b/klai-portal/backend/app/core/config.py
@@ -311,6 +311,10 @@ class Settings(BaseSettings):
     # When empty, widget endpoints return 503.
     widget_jwt_secret: str = ""  # PORTAL_API_WIDGET_JWT_SECRET
 
+    # REQ-8 (SPEC-SEC-CROSS-TENANT-FOLLOWUP-001): widget_messages retention.
+    # Rows older than this many days are deleted daily by the background loop.
+    widget_messages_retention_days: int = 90  # PORTAL_API_WIDGET_MESSAGES_RETENTION_DAYS
+
     # CORS — explicit allowlist of trusted origins for credentialed requests.
     # SPEC-SEC-CORS-001 REQ-1.6: cors_allow_origin_regex removed. The runtime
     # CORS check is the fixed first-party regex in KlaiCORSMiddleware (REQ-1.2)

--- a/klai-portal/backend/app/main.py
+++ b/klai-portal/backend/app/main.py
@@ -51,6 +51,7 @@ from app.services.kb_upload_poller import run_poll_loop as run_kb_upload_poll_lo
 from app.services.recording_cleanup import recording_cleanup_loop
 from app.services.telemetry_purge import telemetry_purge_loop
 from app.services.vexa import vexa
+from app.services.widget_messages_retention import widget_messages_retention_loop
 from app.services.zitadel import zitadel
 
 setup_logging("portal-api")
@@ -261,6 +262,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     telemetry_purge_task = asyncio.create_task(telemetry_purge_loop())
     logger.info("Telemetry purge loop started")
 
+    # REQ-8 (SPEC-SEC-CROSS-TENANT-FOLLOWUP-001): daily widget_messages retention.
+    widget_messages_retention_task = asyncio.create_task(widget_messages_retention_loop())
+    logger.info("Widget messages retention loop started")
+
     imap_task: asyncio.Task[None] | None = None
     if settings.imap_host and settings.imap_username:
         from app.services.imap_listener import start_imap_listener
@@ -276,6 +281,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     kb_upload_poller_task.cancel()
     cleanup_task.cancel()
     telemetry_purge_task.cancel()
+    widget_messages_retention_task.cancel()
     if imap_task is not None:
         imap_task.cancel()
     if _event_tasks:

--- a/klai-portal/backend/app/models/portal.py
+++ b/klai-portal/backend/app/models/portal.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Literal
+from typing import Any, Literal
 
 import sqlalchemy as sa
 from sqlalchemy import (
@@ -15,6 +15,7 @@ from sqlalchemy import (
     UniqueConstraint,
     func,
 )
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base
@@ -204,6 +205,13 @@ class PortalUser(Base):
     # SPEC-CHAT-TEMPLATES-001: active prompt-template IDs the user has toggled on.
     # NULL means no active templates. Validated at PATCH time to belong to caller's org.
     active_template_ids: Mapped[list[int] | None] = mapped_column(ARRAY(Integer), nullable=True)
+
+    # SPEC-SEC-CROSS-TENANT-FOLLOWUP-001 REQ-4: user-delete state machine columns.
+    # NULL = no deletion attempt. 'failed_partial' = one step failed; use
+    # POST .../retry-delete to restart the sequence.
+    deletion_status: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    failure_reason: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    last_attempted_step: Mapped[str | None] = mapped_column(String(64), nullable=True)
 
     org: Mapped["PortalOrg"] = relationship(back_populates="users")
 

--- a/klai-portal/backend/app/services/user_deletion_orchestrator.py
+++ b/klai-portal/backend/app/services/user_deletion_orchestrator.py
@@ -1,0 +1,227 @@
+"""State-machine orchestrator for platform user hard-delete.
+
+Mirrors the structure of deprovisioning_orchestrator.py.
+
+SPEC-SEC-CROSS-TENANT-FOLLOWUP-001 REQ-4 (Finding A-2, HIGH)
+
+The delete sequence is:
+  1. step_zitadel_remove       — remove Zitadel identity
+  2. step_external_kb_delete   — purge KBs + revoke credentials
+  3. step_portal_db_delete     — DELETE portal_users + audit (same tx)
+
+On any step failure:
+  - Write portal_users.deletion_status = 'failed_partial'
+  - Write portal_users.failure_reason JSONB
+  - Write portal_users.last_attempted_step TEXT
+  - Emit audit event platform_admin.user_delete_partial_failure
+
+# @MX:ANCHOR fan_in=2
+# @MX:NOTE: Steps execute sequentially; there is no retry per step (unlike
+#   deprovisioning_orchestrator). The retry endpoint (platform_retry_user_delete)
+#   restarts the full sequence from scratch, which is idempotent per step.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import suppress
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+import structlog
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import app.services.user_deletion_steps as _steps
+from app.services.audit import log_event
+
+logger = structlog.get_logger()
+
+_STEP_SEQUENCE = [
+    "step_zitadel_remove",
+    "step_external_kb_delete",
+    "step_portal_db_delete",
+]
+
+_STEP_DISPLAY_NAMES = {
+    "step_zitadel_remove": "zitadel_remove",
+    "step_external_kb_delete": "external_kb_delete",
+    "step_portal_db_delete": "portal_db_delete",
+}
+
+
+def _get_steps():
+    """Return (step_fn, step_display_name) pairs, resolved at call-time."""
+    return [(getattr(_steps, attr), _STEP_DISPLAY_NAMES[attr]) for attr in _STEP_SEQUENCE]
+
+
+@dataclass
+class _UserDeletionState:
+    """Mutable state passed through each step function."""
+
+    org_id: int
+    zitadel_user_id: str
+    actor_user_id: str
+    delete_global_identity: bool
+
+    # Pre-computed by the request handler before calling delete_user_with_state_machine.
+    kb_dispositions: list[Any] = field(default_factory=list)
+    api_keys_count: int = 0
+    mcp_tokens_count: int = 0
+
+    # Resolved by load_user_deletion_state from DB
+    org: Any = None
+    portal_user: Any = None
+
+    # Session for DB operations inside steps (tenant-scoped, open during run).
+    db_for_steps: AsyncSession | None = None
+
+    # Progress flags updated as steps complete.
+    zitadel_identity_deleted: bool = False
+    kbs_deleted_externally: int = 0
+    db_user_deleted: bool = False
+
+
+async def _mark_user_delete_failed(
+    state: _UserDeletionState,
+    db: AsyncSession,
+    step_name: str,
+    error_str: str,
+) -> None:
+    """Write deletion_status='failed_partial', failure_reason, last_attempted_step.
+
+    Best-effort: exceptions here are logged but not re-raised.
+    Uses raw text() to avoid RLS complications on the portal_users UPDATE.
+    """
+    try:
+        failed_at = datetime.now(UTC).isoformat()
+        failure_payload = json.dumps(
+            {
+                "step": step_name,
+                "error": error_str[:500],
+                "failed_at": failed_at,
+            }
+        )
+        await db.execute(
+            text(
+                "UPDATE portal_users"
+                " SET deletion_status = 'failed_partial',"
+                "     failure_reason = CAST(:failure AS jsonb),"
+                "     last_attempted_step = :step"
+                " WHERE zitadel_user_id = :uid AND org_id = :org_id"
+            ),
+            {
+                "failure": failure_payload,
+                "step": step_name,
+                "uid": state.zitadel_user_id,
+                "org_id": state.org_id,
+            },
+        )
+        await db.commit()
+        logger.info(
+            "user_deletion.failed_partial_state_set",
+            zitadel_user_id=state.zitadel_user_id,
+            step=step_name,
+        )
+    except Exception:
+        logger.exception(
+            "user_deletion.mark_failed_error",
+            zitadel_user_id=state.zitadel_user_id,
+            step=step_name,
+        )
+        with suppress(Exception):
+            await db.rollback()
+
+
+async def _run_user_deletion(
+    state: _UserDeletionState,
+    db: AsyncSession,
+) -> None:
+    """Execute the three-step deletion sequence.
+
+    On success: emits platform_admin.user_deleted audit event.
+    On failure: calls _mark_user_delete_failed + emits
+    platform_admin.user_delete_partial_failure.
+
+    Does NOT raise — the caller (endpoint handler) inspects state flags.
+    """
+    state.db_for_steps = db
+
+    for step_fn, step_name in _get_steps():
+        try:
+            await step_fn(state)
+        except Exception as exc:
+            # Record failure state in DB.
+            await _mark_user_delete_failed(state, db, step_name, str(exc))
+
+            # Emit permanent audit event.
+            with suppress(Exception):
+                await log_event(
+                    org_id=state.org_id,
+                    actor=state.actor_user_id,
+                    action="platform_admin.user_delete_partial_failure",
+                    resource_type="user",
+                    resource_id=state.zitadel_user_id,
+                    details={
+                        "step": step_name,
+                        "error": str(exc)[:200],
+                        "kbs_deleted_externally": state.kbs_deleted_externally,
+                        "api_keys_revoked": state.api_keys_count,
+                        "mcp_tokens_revoked": state.mcp_tokens_count,
+                        "zitadel_identity_deleted": state.zitadel_identity_deleted,
+                        "db_user_deleted": state.db_user_deleted,
+                    },
+                )
+            return
+
+    # All three steps succeeded — emit success audit event.
+    await log_event(
+        org_id=state.org_id,
+        actor=state.actor_user_id,
+        action="platform_admin.user_deleted",
+        resource_type="user",
+        resource_id=state.zitadel_user_id,
+        details={
+            "target_org_id": state.org_id,
+            "kbs_deleted": state.kbs_deleted_externally,
+            "api_keys_revoked": state.api_keys_count,
+            "mcp_tokens_revoked": state.mcp_tokens_count,
+            "global_identity_deleted": state.zitadel_identity_deleted,
+            "zitadel_identity_deleted": state.zitadel_identity_deleted,
+            "db_user_deleted": state.db_user_deleted,
+        },
+    )
+
+
+async def delete_user_with_state_machine(
+    *,
+    org_id: int,
+    zitadel_user_id: str,
+    actor_user_id: str,
+    delete_global_identity: bool,
+    kb_dispositions: list[Any],
+    api_keys_count: int,
+    mcp_tokens_count: int,
+    org: Any,
+    portal_user: Any,
+    db: AsyncSession,
+) -> bool:
+    """Entry point called by the endpoint handler.
+
+    Returns True if all steps succeeded, False on partial failure.
+    The caller should check this to decide the response message.
+    """
+    state = _UserDeletionState(
+        org_id=org_id,
+        zitadel_user_id=zitadel_user_id,
+        actor_user_id=actor_user_id,
+        delete_global_identity=delete_global_identity,
+        kb_dispositions=kb_dispositions,
+        api_keys_count=api_keys_count,
+        mcp_tokens_count=mcp_tokens_count,
+        org=org,
+        portal_user=portal_user,
+    )
+    await _run_user_deletion(state, db)
+    return state.db_user_deleted

--- a/klai-portal/backend/app/services/user_deletion_steps.py
+++ b/klai-portal/backend/app/services/user_deletion_steps.py
@@ -1,0 +1,135 @@
+"""Step functions for the platform user-delete state machine.
+
+Each step is idempotent: if the resource has already been deleted,
+the function succeeds silently (skips gracefully).
+
+SPEC-SEC-CROSS-TENANT-FOLLOWUP-001 REQ-4 (Finding A-2, HIGH)
+
+Step execution order (enforced by _run_user_deletion):
+  1. step_zitadel_remove       — remove Zitadel identity (cheap to undo)
+  2. step_external_kb_delete   — purge KBs + revoke credentials
+  3. step_portal_db_delete     — DELETE portal_users row + audit write (same tx)
+
+# @MX:ANCHOR fan_in=3
+# @MX:NOTE: Steps are intentionally free-standing async functions (not methods)
+#   so they can be patched independently in unit tests — same pattern as
+#   deprovisioning_steps.py.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import structlog
+
+if TYPE_CHECKING:
+    from app.services.user_deletion_orchestrator import _UserDeletionState
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.services.zitadel import zitadel
+
+logger = structlog.get_logger()
+
+
+# ---------------------------------------------------------------------------
+# Step 1: Remove Zitadel identity
+# ---------------------------------------------------------------------------
+
+
+async def step_zitadel_remove(state: _UserDeletionState) -> None:
+    """Remove Zitadel identity when this is the user's last org membership.
+
+    Idempotent: if already removed (404 from Zitadel), logs a warning and
+    continues — the goal state (identity gone) is already achieved.
+    """
+    if not state.delete_global_identity:
+        logger.info(
+            "user_deletion.zitadel_skip_multi_tenant",
+            zitadel_user_id=state.zitadel_user_id,
+            org_id=state.org_id,
+        )
+        return
+
+    try:
+        await zitadel.remove_user(
+            org_id=settings.zitadel_portal_org_id,
+            zitadel_user_id=state.zitadel_user_id,
+        )
+        state.zitadel_identity_deleted = True
+        logger.info(
+            "user_deletion.zitadel_removed",
+            zitadel_user_id=state.zitadel_user_id,
+        )
+    except Exception:
+        # Re-raise so the orchestrator can record the failure.
+        # zitadel.remove_user raises on non-2xx; idempotency (404 already-deleted)
+        # should be handled by the zitadel client itself.
+        logger.exception(
+            "user_deletion.zitadel_remove_failed",
+            zitadel_user_id=state.zitadel_user_id,
+        )
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Step 2: External KB deletes + revoke credentials
+# ---------------------------------------------------------------------------
+
+
+async def step_external_kb_delete(state: _UserDeletionState) -> None:
+    """Delete KBs externally (Qdrant/Garage/knowledge-ingest/docs-app) and
+    revoke partner API keys + MCP tokens.
+
+    Both sub-operations are applied; errors from either propagate up.
+    """
+    from app.services.kb_offboarding import apply_dispositions
+
+    if state.kb_dispositions:
+        await apply_dispositions(
+            state.zitadel_user_id,
+            state.kb_dispositions,
+            state.actor_user_id,
+            state.org,
+            state.db_for_steps,
+        )
+        state.kbs_deleted_externally = len(state.kb_dispositions)
+        logger.info(
+            "user_deletion.kbs_deleted",
+            count=state.kbs_deleted_externally,
+            zitadel_user_id=state.zitadel_user_id,
+        )
+
+    # Credentials were already revoked in the request handler before calling the
+    # orchestrator; the counts are stored in state.
+    logger.info(
+        "user_deletion.credentials_revoked",
+        api_keys=state.api_keys_count,
+        mcp_tokens=state.mcp_tokens_count,
+        zitadel_user_id=state.zitadel_user_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Step 3: Delete portal_users row + write audit entry in the same transaction
+# ---------------------------------------------------------------------------
+
+
+async def step_portal_db_delete(state: _UserDeletionState) -> None:
+    """Hard-delete the portal_users row.
+
+    This step uses state.db_for_steps (the caller's session) so the
+    DELETE and the success audit row land in the same transaction.
+    """
+    db: AsyncSession = state.db_for_steps
+
+    await db.delete(state.portal_user)
+    # Flush so the DELETE is in the session before commit.
+    await db.flush()
+    state.db_user_deleted = True
+    logger.info(
+        "user_deletion.portal_user_deleted",
+        zitadel_user_id=state.zitadel_user_id,
+        org_id=state.org_id,
+    )

--- a/klai-portal/backend/app/services/user_deletion_steps.py
+++ b/klai-portal/backend/app/services/user_deletion_steps.py
@@ -87,6 +87,7 @@ async def step_external_kb_delete(state: _UserDeletionState) -> None:
     from app.services.kb_offboarding import apply_dispositions
 
     if state.kb_dispositions:
+        assert state.db_for_steps is not None, "db_for_steps must be set before step_external_kb_delete"
         await apply_dispositions(
             state.zitadel_user_id,
             state.kb_dispositions,
@@ -122,6 +123,7 @@ async def step_portal_db_delete(state: _UserDeletionState) -> None:
     This step uses state.db_for_steps (the caller's session) so the
     DELETE and the success audit row land in the same transaction.
     """
+    assert state.db_for_steps is not None, "db_for_steps must be set before step_portal_db_delete"
     db: AsyncSession = state.db_for_steps
 
     await db.delete(state.portal_user)

--- a/klai-portal/backend/app/services/widget_audit.py
+++ b/klai-portal/backend/app/services/widget_audit.py
@@ -146,7 +146,7 @@ async def record_widget_turn(
                     "conversation_id": conv_id,
                     "org_id": org_id,
                     "role": role,
-                    "content": content,
+                    "content": content[:10000],  # REQ-8: clamp to 10000 chars (AC8.1)
                     "sources": None if sources is None else json.dumps(sources),
                     "sequence": sequence,
                 },

--- a/klai-portal/backend/app/services/widget_messages_retention.py
+++ b/klai-portal/backend/app/services/widget_messages_retention.py
@@ -1,0 +1,97 @@
+"""REQ-8 (SPEC-SEC-CROSS-TENANT-FOLLOWUP-001 Finding B-5, HIGH):
+Widget message retention worker.
+
+Background loop that runs every 24 hours and deletes widget_messages rows
+older than ``settings.widget_messages_retention_days`` days in chunks of
+10 000 rows.
+
+Design mirrors ``telemetry_purge.py``:
+- cross-org: retention is platform-wide, not per-tenant.
+- chunked: bounded-time deletes avoid long-running transactions.
+- audit: emits ``widget_messages.retention_deleted`` via structlog.
+- resilient: exceptions are caught and logged; the loop continues.
+- cancellable: ``asyncio.CancelledError`` exits cleanly (lifespan shutdown).
+
+# @MX:NOTE: [AUTO] See also: telemetry_purge.py for the canonical loop pattern.
+# @MX:SPEC: SPEC-SEC-CROSS-TENANT-FOLLOWUP-001 REQ-8
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+import structlog
+from sqlalchemy import text
+
+from app.core.config import settings
+from app.core.database import cross_org_session
+
+logger = structlog.get_logger()
+
+# 24-hour cadence: at most a ~25-hour-old row survives one cycle.
+RETENTION_INTERVAL_SECONDS = 24 * 60 * 60
+# Chunk size for each DELETE pass — avoids long-running table locks.
+_CHUNK_SIZE = 10_000
+
+
+async def _retention_run_once() -> dict[str, int]:
+    """Delete expired widget_messages rows in chunks.
+
+    Returns a dict with ``deleted_count`` (total rows removed) and
+    ``chunk_count`` (number of DELETE passes executed).
+    """
+    cutoff = datetime.now(UTC) - timedelta(days=settings.widget_messages_retention_days)
+    deleted_total = 0
+    chunk_count = 0
+
+    while True:
+        async with cross_org_session() as db:
+            result = await db.execute(
+                text(
+                    """
+                    DELETE FROM widget_messages
+                    WHERE id IN (
+                        SELECT id FROM widget_messages
+                        WHERE created_at < :cutoff
+                        LIMIT :chunk_size
+                    )
+                    """
+                ),
+                {"cutoff": cutoff, "chunk_size": _CHUNK_SIZE},
+            )
+            rows_deleted: int = result.rowcount or 0  # type: ignore[attr-defined]
+            await db.commit()
+
+        chunk_count += 1
+        deleted_total += rows_deleted
+
+        if rows_deleted == 0:
+            break
+
+    logger.info(
+        "widget_messages.retention_deleted",
+        deleted_count=deleted_total,
+        chunk_count=chunk_count,
+        cutoff=cutoff.isoformat(),
+        retention_days=settings.widget_messages_retention_days,
+    )
+    return {"deleted_count": deleted_total, "chunk_count": chunk_count}
+
+
+async def widget_messages_retention_loop() -> None:
+    """FastAPI-lifespan-attached daily widget_messages retention loop.
+
+    Sleeps 60 s on startup so the app can finish wiring before the first
+    DB hit. Then runs ``_retention_run_once`` every RETENTION_INTERVAL_SECONDS
+    until cancelled.
+    """
+    await asyncio.sleep(60)
+    while True:
+        try:
+            await _retention_run_once()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("widget_messages_retention_unexpected_error")
+        await asyncio.sleep(RETENTION_INTERVAL_SECONDS)

--- a/klai-portal/backend/app/services/zitadel.py
+++ b/klai-portal/backend/app/services/zitadel.py
@@ -202,6 +202,37 @@ class ZitadelClient:
         )
         resp.raise_for_status()
 
+    async def list_user_grants(self, org_id: str, user_id: str) -> list[dict]:
+        """List all project grants for a user in a specific org."""
+        resp = await self._http.post(
+            f"/management/v1/users/{user_id}/grants/_search",
+            headers={"x-zitadel-orgid": org_id},
+            json={},
+        )
+        resp.raise_for_status()
+        return resp.json().get("result", [])
+
+    async def remove_user_role(self, org_id: str, user_id: str, role: str) -> None:
+        """Remove a project role grant from a user.
+
+        Looks up the grant ID for the project and role, then deletes it.
+        No-op if no matching grant is found (idempotent).
+
+        # @MX:NOTE: [AUTO] Called on admin→non-admin demotion to revoke org:owner JWT claim.
+        # @MX:SPEC: SPEC-SEC-CROSS-TENANT-FOLLOWUP-001 REQ-5
+        """
+        grants = await self.list_user_grants(org_id=org_id, user_id=user_id)
+        for grant in grants:
+            if grant.get("projectId") == settings.zitadel_project_id and role in (grant.get("roles") or []):
+                grant_id = grant["id"]
+                resp = await self._http.delete(
+                    f"/management/v1/users/{user_id}/grants/{grant_id}",
+                    headers={"x-zitadel-orgid": org_id},
+                )
+                resp.raise_for_status()
+                return
+        # No matching grant found — already removed or never granted. Treat as success.
+
     async def list_org_users(self, org_id: str) -> list[dict]:
         """List all human users in a Zitadel org."""
         resp = await self._http.post(
@@ -933,3 +964,53 @@ class ZitadelClient:
 
 # Singleton — reused across requests
 zitadel = ZitadelClient()
+
+# ---------------------------------------------------------------------------
+# Shared role-sync helper (REQ-5)
+# ---------------------------------------------------------------------------
+
+# Mirror of _ZITADEL_ROLE_BY_PORTAL_ROLE in platform_manage.py and users.py.
+# Only admin maps to a Zitadel grant; all other portal roles have no grant.
+_ZITADEL_ROLE_FOR_PORTAL_ADMIN = "org:owner"
+_PORTAL_ADMIN_ROLE = "admin"
+
+
+async def _sync_zitadel_role_grant(
+    zitadel_user_id: str,
+    old_role: str,
+    new_role: str,
+) -> None:
+    """Sync the Zitadel org:owner grant when a portal role transitions to or from admin.
+
+    Called AFTER the DB commit — does NOT rollback on failure.
+
+    - promotion to admin  → grant_user_role(org:owner)
+    - demotion from admin → remove_user_role(org:owner)
+    - no admin transition  → no-op
+
+    Callers must catch exceptions and emit a desync audit event without
+    propagating (DB commit must not be undone).
+
+    # @MX:NOTE: [AUTO] Shared between platform_manage.platform_update_role and
+    # users.update_user_role. Single source of truth for the admin↔Zitadel
+    # grant relationship.
+    # @MX:SPEC: SPEC-SEC-CROSS-TENANT-FOLLOWUP-001 REQ-5
+    """
+    from app.core.config import settings as _settings  # local import to avoid circular
+
+    portal_org_id = _settings.zitadel_portal_org_id
+
+    if old_role != _PORTAL_ADMIN_ROLE and new_role == _PORTAL_ADMIN_ROLE:
+        # Promotion to admin → grant org:owner
+        await zitadel.grant_user_role(
+            org_id=portal_org_id,
+            user_id=zitadel_user_id,
+            role=_ZITADEL_ROLE_FOR_PORTAL_ADMIN,
+        )
+    elif old_role == _PORTAL_ADMIN_ROLE and new_role != _PORTAL_ADMIN_ROLE:
+        # Demotion from admin → remove org:owner
+        await zitadel.remove_user_role(
+            org_id=portal_org_id,
+            user_id=zitadel_user_id,
+            role=_ZITADEL_ROLE_FOR_PORTAL_ADMIN,
+        )

--- a/klai-portal/backend/tests/test_partner_cors.py
+++ b/klai-portal/backend/tests/test_partner_cors.py
@@ -115,6 +115,8 @@ async def test_partner_cors_widget_origin_no_credentials() -> None:
 
     with (
         patch("app.api.partner.settings") as mock_settings,
+        patch("app.api.partner.get_redis_pool"),
+        patch("app.api.partner.check_rate_limit", new_callable=AsyncMock, return_value=(True, 0)),
         patch("app.api.partner.set_tenant", new=AsyncMock()),
         patch("app.api.partner.generate_session_token", return_value="fake.jwt.token"),
     ):
@@ -183,6 +185,8 @@ async def test_partner_cors_blocks_unlisted_origin() -> None:
 
     with (
         patch("app.api.partner.settings") as mock_settings,
+        patch("app.api.partner.get_redis_pool"),
+        patch("app.api.partner.check_rate_limit", new_callable=AsyncMock, return_value=(True, 0)),
     ):
         mock_settings.widget_jwt_secret = "shared-secret"
 

--- a/klai-portal/backend/tests/test_platform_admin_manage.py
+++ b/klai-portal/backend/tests/test_platform_admin_manage.py
@@ -223,3 +223,128 @@ async def test_platform_create_tenant_owner_setup_failure_rolls_back_org_and_use
     assert exc_info.value.status_code == 502
     zitadel.remove_user.assert_awaited_once()
     zitadel.delete_org.assert_awaited_once_with("zitadel-org-new")
+
+
+# ---------------------------------------------------------------------------
+# REQ-6 (Finding A-7): partial-failure paths emit audit events
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_platform_invite_zitadel_invite_failure_emits_audit_event() -> None:
+    """AC6.1 — invite Zitadel-failure emits platform_admin.invite_zitadel_invite_failed."""
+    from app.api.admin.platform_manage import PlatformInviteRequest, platform_invite
+
+    org = _org()
+    log_calls: list[dict] = []
+
+    async def _capture_log_event(**kwargs: object) -> None:
+        log_calls.append(kwargs)
+
+    with (
+        patch("app.api.admin.platform_manage._load_org_or_404", new=AsyncMock(return_value=org)),
+        patch("app.api.admin.platform_manage.log_event", side_effect=_capture_log_event),
+        patch("app.api.admin.platform_manage.zitadel") as mock_zitadel,
+    ):
+        mock_zitadel.invite_user = AsyncMock(side_effect=RuntimeError("zitadel 502"))
+        mock_zitadel.remove_user = AsyncMock()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await platform_invite(
+                org_id=42,
+                body=PlatformInviteRequest(
+                    email="probe@attacker.example",
+                    first_name="Probe",
+                    last_name="Attacker",
+                    role="personal",
+                ),
+                perms=_platform_perms(),
+            )
+
+    assert exc_info.value.status_code == 502
+    assert len(log_calls) == 1, "Exactly one audit event should be emitted on Zitadel-invite failure"
+    evt = log_calls[0]
+    assert evt["action"] == "platform_admin.invite_zitadel_invite_failed"
+    assert evt["details"]["target_email"] == "probe@attacker.example"
+    assert evt["details"]["target_org_id"] == 42
+    assert "zitadel 502" in evt["details"]["error"]
+    assert len(evt["details"]["error"]) <= 200
+
+
+@pytest.mark.asyncio
+async def test_platform_create_tenant_grant_role_failure_emits_audit_event() -> None:
+    """AC6.2 — create-tenant grant_role failure emits platform_admin.create_tenant_grant_role_failed."""
+    from app.api.admin.platform_manage import CreateTenantRequest, platform_create_tenant
+
+    db = AsyncMock()
+    background_tasks = MagicMock()
+    log_calls: list[dict] = []
+
+    async def _capture_log_event(**kwargs: object) -> None:
+        log_calls.append(kwargs)
+
+    with (
+        patch("app.api.admin.platform_manage.log_event", side_effect=_capture_log_event),
+        patch("app.api.admin.platform_manage.zitadel") as mock_zitadel,
+    ):
+        mock_zitadel.create_org = AsyncMock(return_value={"id": "zitadel-org-new"})
+        mock_zitadel.invite_user = AsyncMock(return_value={"userId": "owner-user"})
+        mock_zitadel.grant_user_role = AsyncMock(side_effect=RuntimeError("grant 502"))
+        mock_zitadel.remove_user = AsyncMock()
+        mock_zitadel.delete_org = AsyncMock()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await platform_create_tenant(
+                body=CreateTenantRequest(
+                    company_name="Acme BV",
+                    owner_email="owner@acme.example",
+                    owner_first_name="Owner",
+                    owner_last_name="User",
+                ),
+                background_tasks=background_tasks,
+                perms=_platform_perms(),
+                db=db,
+            )
+
+    assert exc_info.value.status_code == 502
+    assert len(log_calls) == 1
+    evt = log_calls[0]
+    assert evt["action"] == "platform_admin.create_tenant_grant_role_failed"
+    assert evt["details"]["target_email"] == "owner@acme.example"
+    assert "grant 502" in evt["details"]["error"]
+    assert len(evt["details"]["error"]) <= 200
+
+
+@pytest.mark.asyncio
+async def test_audit_emit_failure_falls_back_to_structlog() -> None:
+    """AC6.3 — when log_event itself raises, structlog platform_admin_audit_emit_failed is logged."""
+    import structlog.testing
+
+    from app.api.admin.platform_manage import PlatformInviteRequest, platform_invite
+
+    org = _org()
+
+    with (
+        patch("app.api.admin.platform_manage._load_org_or_404", new=AsyncMock(return_value=org)),
+        patch("app.api.admin.platform_manage.log_event", side_effect=Exception("DB aborted")),
+        patch("app.api.admin.platform_manage.zitadel") as mock_zitadel,
+    ):
+        mock_zitadel.invite_user = AsyncMock(side_effect=RuntimeError("zitadel 502"))
+        mock_zitadel.remove_user = AsyncMock()
+
+        with structlog.testing.capture_logs() as log_output:
+            with pytest.raises(HTTPException):
+                await platform_invite(
+                    org_id=42,
+                    body=PlatformInviteRequest(
+                        email="probe@attacker.example",
+                        first_name="Probe",
+                        last_name="Attacker",
+                        role="personal",
+                    ),
+                    perms=_platform_perms(),
+                )
+
+    # Must have logged platform_admin_audit_emit_failed with structlog
+    audit_fail_logs = [e for e in log_output if e.get("event") == "platform_admin_audit_emit_failed"]
+    assert len(audit_fail_logs) == 1, f"Expected exactly 1 audit-emit-failed log, got: {log_output}"

--- a/klai-portal/backend/tests/test_platform_admin_manage.py
+++ b/klai-portal/backend/tests/test_platform_admin_manage.py
@@ -74,13 +74,17 @@ async def test_platform_role_change_notifies_active_sessions() -> None:
 
 @pytest.mark.asyncio
 async def test_platform_delete_keeps_global_identity_when_other_memberships_exist() -> None:
+    """Endpoint delegates to delete_user_with_state_machine with delete_global_identity=False
+    when remaining_count > 0. The orchestrator handles the actual deletion."""
     from app.api.admin.platform_manage import platform_delete_user
     from app.services.user_memberships import UserMembershipSummary
 
     db = AsyncMock()
-    db.delete = AsyncMock()
+    db.add = MagicMock()
     setup_db(db, [FakeResult([_org()]), FakeResult([_user()])])
     preview = MagicMock(personal_kbs=[], org_kbs_solely_owned=[])
+
+    orchestrator_mock = AsyncMock(return_value=True)  # True = success
 
     with (
         patch("app.api.admin.platform_manage.tenant_scoped_session", return_value=AsyncContext(db)),
@@ -92,19 +96,19 @@ async def test_platform_delete_keeps_global_identity_when_other_memberships_exis
         ),
         patch("app.services.kb_offboarding.compute_offboard_preview", new=AsyncMock(return_value=preview)),
         patch("app.services.kb_offboarding.revoke_user_credentials", new=AsyncMock(return_value=(0, 0))),
-        patch("app.api.admin.platform_manage.zitadel") as zitadel,
+        patch(
+            "app.api.admin.platform_manage.delete_user_with_state_machine",
+            new=orchestrator_mock,
+        ),
         patch("app.api.admin.platform_manage.fire_role_change_notification"),
-        patch("app.api.admin.platform_manage.log_event", new=AsyncMock()) as log_event,
     ):
-        zitadel.remove_user = AsyncMock()
         response = await platform_delete_user(org_id=42, zitadel_user_id="target-user", perms=_platform_perms())
 
-    zitadel.remove_user.assert_not_awaited()
-    db.delete.assert_awaited_once()
+    orchestrator_mock.assert_awaited_once()
+    call_kwargs = orchestrator_mock.await_args.kwargs
+    # Multi-tenant user: delete_global_identity must be False
+    assert call_kwargs["delete_global_identity"] is False
     assert response.message == "Gebruiker uit tenant verwijderd."
-    details = log_event.await_args.kwargs["details"]
-    assert details["global_identity_deleted"] is False
-    assert details["remaining_membership_count"] == 1
 
 
 @pytest.mark.asyncio

--- a/klai-portal/backend/tests/test_platform_role_change_zitadel_sync.py
+++ b/klai-portal/backend/tests/test_platform_role_change_zitadel_sync.py
@@ -1,0 +1,333 @@
+"""REQ-5 (Finding A-4, HIGH): Role changes SHALL sync Zitadel org:owner grant.
+
+Tests cover:
+  AC5.1 — promotion to admin calls grant_user_role with org:owner
+  AC5.2 — demotion from admin calls remove_user_role
+  AC5.3 — Zitadel failure → DB committed, audit emitted, zitadel_sync_failed=true in response
+
+Both platform_update_role (platform_manage.py) and update_user_role (users.py) are
+covered so the shared helper is exercised from both call sites.
+
+# @MX:NOTE: [AUTO] Tests mirror AC5.x from SPEC-SEC-CROSS-TENANT-FOLLOWUP-001.
+# @MX:SPEC: SPEC-SEC-CROSS-TENANT-FOLLOWUP-001 REQ-5
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tests.conftest import make_perms
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class AsyncContext:
+    def __init__(self, value):
+        self.value = value
+
+    async def __aenter__(self):
+        return self.value
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def _org(org_id: int = 42):
+    org = MagicMock()
+    org.id = org_id
+    org.slug = f"org-{org_id}"
+    org.deleted_at = None
+    return org
+
+
+def _user(*, org_id: int = 42, zitadel_user_id: str = "zit-abc123", role: str = "company"):
+    user = MagicMock()
+    user.org_id = org_id
+    user.zitadel_user_id = zitadel_user_id
+    user.role = role
+    user.status = "active"
+    return user
+
+
+def _platform_perms():
+    return make_perms(role="admin", user_id="platform-admin", org_id=1, org_slug="getklai", is_platform_admin=True)
+
+
+def _org_admin_perms(org_id: int = 42):
+    return make_perms(role="admin", user_id="org-admin-user", org_id=org_id, org_slug="acme", is_platform_admin=False)
+
+
+def _setup_db(db, execute_results: list):
+    """Feed execute_results sequentially to db.execute."""
+    db.execute = AsyncMock(
+        side_effect=[MagicMock(scalar_one_or_none=MagicMock(return_value=r)) for r in execute_results]
+    )
+    db.commit = AsyncMock()
+    db.add = MagicMock()
+
+
+# ---------------------------------------------------------------------------
+# AC5.1 — promotion to admin triggers _sync_zitadel_role_grant with old→new
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_platform_update_role_admin_promotion_calls_sync_helper():
+    """platform_update_role: company→admin calls _sync_zitadel_role_grant(old='company', new='admin')."""
+    from app.api.admin.platform_manage import RoleUpdateRequest, platform_update_role
+
+    user = _user(role="company")
+    db = AsyncMock()
+    _setup_db(db, [_org(), user])
+
+    mock_sync = AsyncMock()
+
+    with (
+        patch("app.api.admin.platform_manage.tenant_scoped_session", return_value=AsyncContext(db)),
+        patch("app.api.admin.platform_manage.fire_role_change_notification"),
+        patch("app.api.admin.platform_manage.log_event", new=AsyncMock()),
+        patch("app.api.admin.platform_manage._sync_zitadel_role_grant", mock_sync),
+    ):
+        result = await platform_update_role(
+            org_id=42,
+            zitadel_user_id="zit-abc123",
+            body=RoleUpdateRequest(role="admin"),
+            perms=_platform_perms(),
+        )
+
+    mock_sync.assert_awaited_once_with("zit-abc123", old_role="company", new_role="admin")
+    assert result.zitadel_sync_failed is False
+
+
+@pytest.mark.asyncio
+async def test_update_user_role_admin_promotion_calls_sync_helper():
+    """users.py update_user_role: company→admin calls _sync_zitadel_role_grant."""
+    from app.api.admin.users import RoleUpdateRequest, update_user_role
+
+    perms = _org_admin_perms(org_id=42)
+    user = _user(org_id=42, role="company")
+
+    db = AsyncMock()
+    db.execute = AsyncMock(
+        side_effect=[
+            MagicMock(scalar_one=MagicMock(return_value=_org())),
+            MagicMock(scalar_one_or_none=MagicMock(return_value=user)),
+        ]
+    )
+    db.commit = AsyncMock()
+
+    mock_sync = AsyncMock()
+
+    with (
+        patch("app.api.admin.users.fire_role_change_notification"),
+        patch("app.api.admin.users.log_event", new=AsyncMock()),
+        patch("app.api.admin.users._sync_zitadel_role_grant", mock_sync),
+    ):
+        result = await update_user_role(
+            zitadel_user_id="zit-abc123",
+            body=RoleUpdateRequest(role="admin"),
+            perms=perms,
+            db=db,
+        )
+
+    mock_sync.assert_awaited_once_with("zit-abc123", old_role="company", new_role="admin")
+    assert result.zitadel_sync_failed is False
+
+
+# ---------------------------------------------------------------------------
+# AC5.2 — demotion from admin triggers _sync_zitadel_role_grant
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_platform_update_role_admin_demotion_calls_sync_helper():
+    """platform_update_role: admin→company calls _sync_zitadel_role_grant(old='admin', new='company')."""
+    from app.api.admin.platform_manage import RoleUpdateRequest, platform_update_role
+
+    user = _user(role="admin")
+    db = AsyncMock()
+    _setup_db(db, [_org(), user])
+    # admin_count > 1 to allow demotion
+    db.scalar = AsyncMock(return_value=2)
+
+    mock_sync = AsyncMock()
+
+    with (
+        patch("app.api.admin.platform_manage.tenant_scoped_session", return_value=AsyncContext(db)),
+        patch("app.api.admin.platform_manage.fire_role_change_notification"),
+        patch("app.api.admin.platform_manage.log_event", new=AsyncMock()),
+        patch("app.api.admin.platform_manage._sync_zitadel_role_grant", mock_sync),
+    ):
+        result = await platform_update_role(
+            org_id=42,
+            zitadel_user_id="zit-abc123",
+            body=RoleUpdateRequest(role="company"),
+            perms=_platform_perms(),
+        )
+
+    mock_sync.assert_awaited_once_with("zit-abc123", old_role="admin", new_role="company")
+    assert result.zitadel_sync_failed is False
+
+
+@pytest.mark.asyncio
+async def test_update_user_role_demotion_calls_sync_helper():
+    """users.py update_user_role: admin→company calls _sync_zitadel_role_grant."""
+    from app.api.admin.users import RoleUpdateRequest, update_user_role
+
+    perms = _org_admin_perms(org_id=42)
+    user = _user(org_id=42, role="admin")
+
+    db = AsyncMock()
+    db.execute = AsyncMock(
+        side_effect=[
+            MagicMock(scalar_one=MagicMock(return_value=_org())),
+            MagicMock(scalar_one_or_none=MagicMock(return_value=user)),
+        ]
+    )
+    db.scalar = AsyncMock(return_value=2)  # admin_count > 1
+    db.commit = AsyncMock()
+
+    mock_sync = AsyncMock()
+
+    with (
+        patch("app.api.admin.users.fire_role_change_notification"),
+        patch("app.api.admin.users.log_event", new=AsyncMock()),
+        patch("app.api.admin.users._sync_zitadel_role_grant", mock_sync),
+    ):
+        result = await update_user_role(
+            zitadel_user_id="zit-abc123",
+            body=RoleUpdateRequest(role="company"),
+            perms=perms,
+            db=db,
+        )
+
+    mock_sync.assert_awaited_once_with("zit-abc123", old_role="admin", new_role="company")
+    assert result.zitadel_sync_failed is False
+
+
+# ---------------------------------------------------------------------------
+# AC5.3 — Zitadel failure: DB committed, audit emitted, zitadel_sync_failed in response
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_platform_update_role_zitadel_failure_no_db_rollback():
+    """Zitadel sync failure → DB stays committed (no exception propagated), audit emitted."""
+    from app.api.admin.platform_manage import RoleUpdateRequest, platform_update_role
+
+    user = _user(role="company")
+    db = AsyncMock()
+    _setup_db(db, [_org(), user])
+
+    captured_audit: list[dict] = []
+
+    async def _raise_zitadel(*args, **kwargs):
+        raise RuntimeError("Zitadel 502 Bad Gateway")
+
+    async def _capture_audit(**kwargs):
+        captured_audit.append(kwargs)
+
+    with (
+        patch("app.api.admin.platform_manage.tenant_scoped_session", return_value=AsyncContext(db)),
+        patch("app.api.admin.platform_manage.fire_role_change_notification"),
+        patch("app.api.admin.platform_manage.log_event", side_effect=_capture_audit),
+        patch("app.api.admin.platform_manage._sync_zitadel_role_grant", side_effect=_raise_zitadel),
+        patch("app.api.admin.platform_manage._emit_audit_safe", new=AsyncMock()) as mock_emit_safe,
+    ):
+        result = await platform_update_role(
+            org_id=42,
+            zitadel_user_id="zit-abc123",
+            body=RoleUpdateRequest(role="admin"),
+            perms=_platform_perms(),
+        )
+
+    # DB MUST be committed — no rollback
+    db.commit.assert_awaited_once()
+
+    # Response carries the flag
+    assert result.zitadel_sync_failed is True
+
+    # _emit_audit_safe called with desync action
+    assert mock_emit_safe.await_count == 1
+    call_kwargs = mock_emit_safe.await_args.kwargs
+    assert call_kwargs["action"] == "platform_admin.role_change_zitadel_desync"
+    assert call_kwargs["details"]["zitadel_sync_failed"] is True
+
+
+@pytest.mark.asyncio
+async def test_update_user_role_zitadel_failure_no_db_rollback():
+    """users.py: Zitadel sync failure → DB committed, audit event emitted."""
+    from app.api.admin.users import RoleUpdateRequest, update_user_role
+
+    perms = _org_admin_perms(org_id=42)
+    user = _user(org_id=42, role="company")
+
+    db = AsyncMock()
+    db.execute = AsyncMock(
+        side_effect=[
+            MagicMock(scalar_one=MagicMock(return_value=_org())),
+            MagicMock(scalar_one_or_none=MagicMock(return_value=user)),
+        ]
+    )
+    db.commit = AsyncMock()
+
+    captured_audit: list[dict] = []
+
+    async def _raise_zitadel(*args, **kwargs):
+        raise RuntimeError("Zitadel 502 Bad Gateway")
+
+    async def _capture_audit(**kwargs):
+        captured_audit.append(kwargs)
+
+    with (
+        patch("app.api.admin.users.fire_role_change_notification"),
+        patch("app.api.admin.users.log_event", side_effect=_capture_audit),
+        patch("app.api.admin.users._sync_zitadel_role_grant", side_effect=_raise_zitadel),
+    ):
+        result = await update_user_role(
+            zitadel_user_id="zit-abc123",
+            body=RoleUpdateRequest(role="admin"),
+            perms=perms,
+            db=db,
+        )
+
+    db.commit.assert_awaited_once()
+    assert result.zitadel_sync_failed is True
+
+    desync_events = [e for e in captured_audit if e.get("action") == "platform_admin.role_change_zitadel_desync"]
+    assert len(desync_events) == 1
+    assert desync_events[0]["details"]["zitadel_sync_failed"] is True
+
+
+@pytest.mark.asyncio
+async def test_no_sync_call_when_role_unchanged():
+    """When old_role == new_role, _sync_zitadel_role_grant is still called but is a no-op inside."""
+    from app.api.admin.platform_manage import RoleUpdateRequest, platform_update_role
+
+    # company → company (no admin transition)
+    user = _user(role="company")
+    db = AsyncMock()
+    _setup_db(db, [_org(), user])
+
+    mock_sync = AsyncMock()
+
+    with (
+        patch("app.api.admin.platform_manage.tenant_scoped_session", return_value=AsyncContext(db)),
+        patch("app.api.admin.platform_manage.fire_role_change_notification"),
+        patch("app.api.admin.platform_manage.log_event", new=AsyncMock()),
+        patch("app.api.admin.platform_manage._sync_zitadel_role_grant", mock_sync),
+    ):
+        result = await platform_update_role(
+            org_id=42,
+            zitadel_user_id="zit-abc123",
+            body=RoleUpdateRequest(role="company"),
+            perms=_platform_perms(),
+        )
+
+    # sync still called — no-op is inside the helper, not here
+    mock_sync.assert_awaited_once_with("zit-abc123", old_role="company", new_role="company")
+    assert result.zitadel_sync_failed is False

--- a/klai-portal/backend/tests/test_platform_user_delete_state_machine.py
+++ b/klai-portal/backend/tests/test_platform_user_delete_state_machine.py
@@ -1,0 +1,469 @@
+"""RED tests for REQ-4: platform user-delete state machine.
+
+SPEC-SEC-CROSS-TENANT-FOLLOWUP-001 REQ-4 (Finding A-2, HIGH):
+
+- Delete sequence must execute in order: Zitadel → External KB → portal_users DELETE
+- On any step failure: write deletion_status='failed_partial', failure_reason JSONB,
+  last_attempted_step TEXT to portal_users, emit audit event
+  platform_admin.user_delete_partial_failure
+- Retry endpoint restarts state machine from scratch (idempotent)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tests.conftest import make_perms
+
+
+def _platform_perms():
+    return make_perms(
+        role="admin",
+        user_id="platform-admin",
+        org_id=1,
+        org_slug="getklai",
+        is_platform_admin=True,
+    )
+
+
+def _deletion_state(
+    *,
+    org_id: int = 42,
+    zitadel_user_id: str = "target-user",
+    delete_global_identity: bool = True,
+    kbs: int = 2,
+    api_keys: int = 1,
+    mcp_tokens: int = 1,
+):
+    """Build a _UserDeletionState-like object for testing."""
+    from app.services.user_deletion_orchestrator import _UserDeletionState
+
+    state = _UserDeletionState(
+        org_id=org_id,
+        zitadel_user_id=zitadel_user_id,
+        actor_user_id="platform-admin",
+        delete_global_identity=delete_global_identity,
+        kb_dispositions=[MagicMock() for _ in range(kbs)],
+        api_keys_count=api_keys,
+        mcp_tokens_count=mcp_tokens,
+    )
+    return state
+
+
+# ---------------------------------------------------------------------------
+# AC4.1 — Step ordering: Zitadel → External KB → portal_users DELETE
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_user_steps_execute_in_order() -> None:
+    """Steps must execute in the required order: zitadel_remove, external_kb_delete, portal_db_delete."""
+    from app.services.user_deletion_orchestrator import _run_user_deletion
+
+    call_order: list[str] = []
+
+    async def fake_zitadel_remove(state):
+        call_order.append("zitadel_remove")
+
+    async def fake_kb_delete(state):
+        call_order.append("external_kb_delete")
+
+    async def fake_db_delete(state):
+        call_order.append("portal_db_delete")
+
+    with (
+        patch(
+            "app.services.user_deletion_steps.step_zitadel_remove",
+            side_effect=fake_zitadel_remove,
+        ),
+        patch(
+            "app.services.user_deletion_steps.step_external_kb_delete",
+            side_effect=fake_kb_delete,
+        ),
+        patch(
+            "app.services.user_deletion_steps.step_portal_db_delete",
+            side_effect=fake_db_delete,
+        ),
+    ):
+        db = AsyncMock()
+        state = _deletion_state()
+        await _run_user_deletion(state, db)
+
+    assert call_order == ["zitadel_remove", "external_kb_delete", "portal_db_delete"]
+
+
+# ---------------------------------------------------------------------------
+# AC4.2 — Zitadel step failure → failed_partial + audit event
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_zitadel_remove_failure_marks_failed_partial_and_emits_audit() -> None:
+    """When zitadel_remove step fails, portal_users gets deletion_status=failed_partial
+    and audit event platform_admin.user_delete_partial_failure is emitted."""
+    from app.services.user_deletion_orchestrator import _run_user_deletion
+
+    async def failing_zitadel(state):
+        raise RuntimeError("Zitadel 502")
+
+    async def ok_kb(state):
+        pass
+
+    async def ok_db(state):
+        pass
+
+    db = AsyncMock()
+    log_event_mock = AsyncMock()
+    state = _deletion_state()
+
+    with (
+        patch(
+            "app.services.user_deletion_steps.step_zitadel_remove",
+            side_effect=failing_zitadel,
+        ),
+        patch(
+            "app.services.user_deletion_steps.step_external_kb_delete",
+            side_effect=ok_kb,
+        ),
+        patch(
+            "app.services.user_deletion_steps.step_portal_db_delete",
+            side_effect=ok_db,
+        ),
+        patch(
+            "app.services.user_deletion_orchestrator.log_event",
+            new=log_event_mock,
+        ),
+        patch(
+            "app.services.user_deletion_orchestrator._mark_user_delete_failed",
+            new=AsyncMock(),
+        ) as mark_failed,
+    ):
+        await _run_user_deletion(state, db)
+
+    # _mark_user_delete_failed called with correct step name
+    mark_failed.assert_awaited_once()
+    call_kwargs = mark_failed.await_args
+    assert call_kwargs.args[2] == "zitadel_remove" or call_kwargs.kwargs.get("step_name") == "zitadel_remove"
+
+    # audit event emitted
+    log_event_mock.assert_awaited_once()
+    audit_action = log_event_mock.await_args.kwargs.get("action") or log_event_mock.await_args.args[0]
+    assert audit_action == "platform_admin.user_delete_partial_failure"
+    details = log_event_mock.await_args.kwargs["details"]
+    assert details["step"] == "zitadel_remove"
+    assert details["zitadel_identity_deleted"] is False
+    assert details["db_user_deleted"] is False
+
+
+# ---------------------------------------------------------------------------
+# AC4.3 — External KB delete step failure → failed_partial + audit event
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kb_delete_failure_marks_failed_partial_and_emits_audit() -> None:
+    """When external_kb_delete step fails, portal_users gets deletion_status=failed_partial
+    and audit event platform_admin.user_delete_partial_failure is emitted."""
+    from app.services.user_deletion_orchestrator import _run_user_deletion
+
+    async def ok_zitadel(state):
+        state.zitadel_identity_deleted = True
+
+    async def failing_kb(state):
+        raise RuntimeError("knowledge-ingest 503")
+
+    async def ok_db(state):
+        pass
+
+    db = AsyncMock()
+    log_event_mock = AsyncMock()
+    state = _deletion_state()
+
+    with (
+        patch(
+            "app.services.user_deletion_steps.step_zitadel_remove",
+            side_effect=ok_zitadel,
+        ),
+        patch(
+            "app.services.user_deletion_steps.step_external_kb_delete",
+            side_effect=failing_kb,
+        ),
+        patch(
+            "app.services.user_deletion_steps.step_portal_db_delete",
+            side_effect=ok_db,
+        ),
+        patch(
+            "app.services.user_deletion_orchestrator.log_event",
+            new=log_event_mock,
+        ),
+        patch(
+            "app.services.user_deletion_orchestrator._mark_user_delete_failed",
+            new=AsyncMock(),
+        ) as mark_failed,
+    ):
+        await _run_user_deletion(state, db)
+
+    mark_failed.assert_awaited_once()
+    call_kwargs = mark_failed.await_args
+    assert call_kwargs.args[2] == "external_kb_delete" or call_kwargs.kwargs.get("step_name") == "external_kb_delete"
+
+    log_event_mock.assert_awaited_once()
+    details = log_event_mock.await_args.kwargs["details"]
+    assert details["step"] == "external_kb_delete"
+    assert details["zitadel_identity_deleted"] is True  # already done
+    assert details["db_user_deleted"] is False
+
+
+# ---------------------------------------------------------------------------
+# AC4.4 — portal_db_delete step failure → failed_partial + audit event
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_portal_db_delete_failure_marks_failed_partial_and_emits_audit() -> None:
+    """When portal_db_delete step fails, portal_users gets deletion_status=failed_partial."""
+    from app.services.user_deletion_orchestrator import _run_user_deletion
+
+    async def ok_zitadel(state):
+        state.zitadel_identity_deleted = True
+
+    async def ok_kb(state):
+        state.kbs_deleted_externally = len(state.kb_dispositions)
+
+    async def failing_db(state):
+        raise RuntimeError("DB 500")
+
+    db = AsyncMock()
+    log_event_mock = AsyncMock()
+    state = _deletion_state()
+
+    with (
+        patch(
+            "app.services.user_deletion_steps.step_zitadel_remove",
+            side_effect=ok_zitadel,
+        ),
+        patch(
+            "app.services.user_deletion_steps.step_external_kb_delete",
+            side_effect=ok_kb,
+        ),
+        patch(
+            "app.services.user_deletion_steps.step_portal_db_delete",
+            side_effect=failing_db,
+        ),
+        patch(
+            "app.services.user_deletion_orchestrator.log_event",
+            new=log_event_mock,
+        ),
+        patch(
+            "app.services.user_deletion_orchestrator._mark_user_delete_failed",
+            new=AsyncMock(),
+        ) as mark_failed,
+    ):
+        await _run_user_deletion(state, db)
+
+    mark_failed.assert_awaited_once()
+    details = log_event_mock.await_args.kwargs["details"]
+    assert details["step"] == "portal_db_delete"
+    assert details["zitadel_identity_deleted"] is True
+    assert details["db_user_deleted"] is False
+
+
+# ---------------------------------------------------------------------------
+# AC4.5 — Successful run emits platform_admin.user_deleted (not partial_failure)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_successful_delete_emits_user_deleted_audit_event() -> None:
+    """On successful completion, platform_admin.user_deleted is emitted (not partial_failure)."""
+    from app.services.user_deletion_orchestrator import _run_user_deletion
+
+    async def ok_zitadel(state):
+        state.zitadel_identity_deleted = True
+
+    async def ok_kb(state):
+        state.kbs_deleted_externally = len(state.kb_dispositions)
+
+    async def ok_db(state):
+        state.db_user_deleted = True
+
+    db = AsyncMock()
+    log_event_mock = AsyncMock()
+    state = _deletion_state()
+
+    with (
+        patch(
+            "app.services.user_deletion_steps.step_zitadel_remove",
+            side_effect=ok_zitadel,
+        ),
+        patch(
+            "app.services.user_deletion_steps.step_external_kb_delete",
+            side_effect=ok_kb,
+        ),
+        patch(
+            "app.services.user_deletion_steps.step_portal_db_delete",
+            side_effect=ok_db,
+        ),
+        patch(
+            "app.services.user_deletion_orchestrator.log_event",
+            new=log_event_mock,
+        ),
+    ):
+        await _run_user_deletion(state, db)
+
+    log_event_mock.assert_awaited_once()
+    action = log_event_mock.await_args.kwargs["action"]
+    assert action == "platform_admin.user_deleted"
+    details = log_event_mock.await_args.kwargs["details"]
+    assert details["zitadel_identity_deleted"] is True
+    assert details["db_user_deleted"] is True
+
+
+# ---------------------------------------------------------------------------
+# AC4.6 — platform_delete_user endpoint calls orchestrator
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_platform_delete_user_calls_orchestrator() -> None:
+    """platform_delete_user endpoint must delegate to delete_user_with_state_machine."""
+    from app.api.admin.platform_manage import platform_delete_user
+    from app.services.user_memberships import UserMembershipSummary
+
+    class AsyncContext:
+        def __init__(self, value):
+            self.value = value
+
+        async def __aenter__(self):
+            return self.value
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    db = AsyncMock()
+    db.add = MagicMock()
+
+    org = MagicMock()
+    org.id = 42
+
+    user = MagicMock()
+    user.org_id = 42
+    user.zitadel_user_id = "target-user"
+    user.status = "active"
+
+    from helpers import FakeResult, setup_db
+
+    setup_db(db, [FakeResult([org]), FakeResult([user])])
+
+    orchestrator_mock = AsyncMock()
+    preview = MagicMock(personal_kbs=[], org_kbs_solely_owned=[])
+
+    with (
+        patch("app.api.admin.platform_manage.tenant_scoped_session", return_value=AsyncContext(db)),
+        patch(
+            "app.api.admin.platform_manage.get_user_membership_summary",
+            new=AsyncMock(
+                return_value=UserMembershipSummary(total_count=1, remaining_count=0, is_platform_admin=False)
+            ),
+        ),
+        patch("app.services.kb_offboarding.compute_offboard_preview", new=AsyncMock(return_value=preview)),
+        patch("app.services.kb_offboarding.revoke_user_credentials", new=AsyncMock(return_value=(2, 1))),
+        patch(
+            "app.api.admin.platform_manage.delete_user_with_state_machine",
+            new=orchestrator_mock,
+        ),
+        patch("app.api.admin.platform_manage.fire_role_change_notification"),
+    ):
+        await platform_delete_user(org_id=42, zitadel_user_id="target-user", perms=_platform_perms())
+
+    orchestrator_mock.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# AC4.7 — retry-delete endpoint calls orchestrator from scratch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retry_delete_endpoint_calls_orchestrator() -> None:
+    """POST /api/admin/platform/users/{zitadel_user_id}/retry-delete must call
+    delete_user_with_state_machine (restart from scratch — idempotent)."""
+    from app.api.admin.platform_manage import platform_retry_user_delete
+    from app.services.user_memberships import UserMembershipSummary
+
+    class AsyncContext:
+        def __init__(self, value):
+            self.value = value
+
+        async def __aenter__(self):
+            return self.value
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    db = AsyncMock()
+    db.add = MagicMock()
+
+    org = MagicMock()
+    org.id = 42
+
+    user = MagicMock()
+    user.org_id = 42
+    user.zitadel_user_id = "target-user"
+    user.status = "active"
+    user.deletion_status = "failed_partial"
+
+    from helpers import FakeResult, setup_db
+
+    setup_db(db, [FakeResult([org]), FakeResult([user])])
+
+    orchestrator_mock = AsyncMock()
+    preview = MagicMock(personal_kbs=[], org_kbs_solely_owned=[])
+
+    with (
+        patch("app.api.admin.platform_manage.tenant_scoped_session", return_value=AsyncContext(db)),
+        patch(
+            "app.api.admin.platform_manage.get_user_membership_summary",
+            new=AsyncMock(
+                return_value=UserMembershipSummary(total_count=1, remaining_count=0, is_platform_admin=False)
+            ),
+        ),
+        patch("app.services.kb_offboarding.compute_offboard_preview", new=AsyncMock(return_value=preview)),
+        patch("app.services.kb_offboarding.revoke_user_credentials", new=AsyncMock(return_value=(0, 0))),
+        patch(
+            "app.api.admin.platform_manage.delete_user_with_state_machine",
+            new=orchestrator_mock,
+        ),
+        patch("app.api.admin.platform_manage.fire_role_change_notification"),
+    ):
+        await platform_retry_user_delete(org_id=42, zitadel_user_id="target-user", perms=_platform_perms())
+
+    orchestrator_mock.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# AC4.8 — _mark_user_delete_failed writes three columns
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mark_user_delete_failed_writes_correct_columns() -> None:
+    """_mark_user_delete_failed must update deletion_status, failure_reason, last_attempted_step."""
+    from app.services.user_deletion_orchestrator import _mark_user_delete_failed
+
+    db = AsyncMock()
+    state = _deletion_state()
+
+    await _mark_user_delete_failed(state, db, "zitadel_remove", "some error message")
+
+    # Must call db.execute with an UPDATE that touches the three columns
+    db.execute.assert_awaited_once()
+    call_args = db.execute.await_args
+    # The SQL text should reference the three columns
+    sql_text = str(call_args.args[0])
+    assert "deletion_status" in sql_text
+    assert "failure_reason" in sql_text
+    assert "last_attempted_step" in sql_text
+    db.commit.assert_awaited_once()

--- a/klai-portal/backend/tests/test_widget_config.py
+++ b/klai-portal/backend/tests/test_widget_config.py
@@ -97,6 +97,8 @@ async def test_widget_config_happy_path():
 
     with (
         patch("app.api.partner.settings") as mock_settings,
+        patch("app.api.partner.get_redis_pool"),
+        patch("app.api.partner.check_rate_limit", new_callable=AsyncMock, return_value=(True, 0)),
         patch("app.api.partner.set_tenant", new=AsyncMock()),
         patch("app.api.partner.generate_session_token", return_value="fake.jwt.token"),
     ):
@@ -130,7 +132,11 @@ async def test_widget_config_unknown_widget_id():
     db = _make_db_chain(None, None, [])
     request = _make_request()
 
-    with patch("app.api.partner.settings") as mock_settings:
+    with (
+        patch("app.api.partner.settings") as mock_settings,
+        patch("app.api.partner.get_redis_pool"),
+        patch("app.api.partner.check_rate_limit", new_callable=AsyncMock, return_value=(True, 0)),
+    ):
         mock_settings.widget_jwt_secret = "shared-secret"
         with pytest.raises(Exception) as exc_info:
             await widget_config(id="wgt_does_not_exist", request=request, db=db)
@@ -145,7 +151,11 @@ async def test_widget_config_disallowed_origin():
     db = _make_db_chain(widget, None, [])
     request = _make_request("https://evil.example.com")
 
-    with patch("app.api.partner.settings") as mock_settings:
+    with (
+        patch("app.api.partner.settings") as mock_settings,
+        patch("app.api.partner.get_redis_pool"),
+        patch("app.api.partner.check_rate_limit", new_callable=AsyncMock, return_value=(True, 0)),
+    ):
         mock_settings.widget_jwt_secret = "shared-secret"
         response = await widget_config(id=widget.widget_id, request=request, db=db)
 
@@ -178,6 +188,8 @@ async def test_widget_config_empty_allowed_origins_denied_by_default():
 
     with (
         patch("app.api.partner.settings") as mock_settings,
+        patch("app.api.partner.get_redis_pool"),
+        patch("app.api.partner.check_rate_limit", new_callable=AsyncMock, return_value=(True, 0)),
         patch("app.api.partner.set_tenant", new=AsyncMock()),
         patch("app.api.partner.generate_session_token", return_value="fake.jwt.token"),
     ):
@@ -211,6 +223,8 @@ async def test_widget_config_empty_allowed_origins_allowed_when_allow_any_origin
 
     with (
         patch("app.api.partner.settings") as mock_settings,
+        patch("app.api.partner.get_redis_pool"),
+        patch("app.api.partner.check_rate_limit", new_callable=AsyncMock, return_value=(True, 0)),
         patch("app.api.partner.set_tenant", new=AsyncMock()),
         patch("app.api.partner.generate_session_token", return_value="fake.jwt.token"),
     ):
@@ -298,7 +312,11 @@ async def test_public_bot_config_rejects_when_share_disabled():
     widget = FakeWidget()
     db = _make_db_chain(widget, None, [])
 
-    with patch("app.api.partner.settings") as mock_settings:
+    with (
+        patch("app.api.partner.settings") as mock_settings,
+        patch("app.api.partner.get_redis_pool"),
+        patch("app.api.partner.check_rate_limit", new_callable=AsyncMock, return_value=(True, 0)),
+    ):
         mock_settings.widget_jwt_secret = "shared-secret"
         with pytest.raises(Exception) as exc_info:
             await public_bot_config(id=widget.widget_id, db=db)
@@ -326,6 +344,8 @@ async def test_public_bot_config_returns_token_when_share_enabled():
 
     with (
         patch("app.api.partner.settings") as mock_settings,
+        patch("app.api.partner.get_redis_pool"),
+        patch("app.api.partner.check_rate_limit", new_callable=AsyncMock, return_value=(True, 0)),
         patch("app.api.partner.set_tenant", new=AsyncMock()),
         patch("app.api.partner.generate_session_token", return_value="public.jwt.token"),
     ):

--- a/klai-portal/backend/tests/test_widget_messages_retention.py
+++ b/klai-portal/backend/tests/test_widget_messages_retention.py
@@ -1,0 +1,314 @@
+"""REQ-8 (Finding B-5, HIGH): Widget message content SHALL be length-capped and retention-bounded.
+
+Tests cover:
+  AC8.1 — record_widget_turn clamps content to 10000 chars before INSERT
+  AC8.2 — retention worker deletes rows older than retention_days in chunks
+  AC8.3 — retention worker emits audit event with deleted_count and chunk_count
+  AC8.4 — retention worker is idempotent (no rows to delete → no error)
+  AC8.5 — retention loop catches exceptions and continues (does not abort)
+
+# @MX:NOTE: [AUTO] Tests mirror AC8.x from SPEC-SEC-CROSS-TENANT-FOLLOWUP-001.
+# @MX:SPEC: SPEC-SEC-CROSS-TENANT-FOLLOWUP-001 REQ-8
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# AC8.1 — content clamping at INSERT
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_record_widget_turn_clamps_content_at_10000_chars():
+    """Content longer than 10000 chars is silently truncated to 10000 before INSERT."""
+    from app.services.widget_audit import record_widget_turn
+
+    long_content = "x" * 15000
+    captured_params: list[dict] = []
+
+    async def _fake_execute(stmt, params=None, **kwargs):
+        if params is not None:
+            captured_params.append(dict(params))
+        result = MagicMock()
+        result.first = MagicMock(return_value=(1, 0))  # conv_id=1, prior_count=0
+        return result
+
+    fake_db = AsyncMock()
+    fake_db.execute = _fake_execute
+    fake_db.commit = AsyncMock()
+    fake_db.__aenter__ = AsyncMock(return_value=fake_db)
+    fake_db.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("app.services.widget_audit.tenant_scoped_session", return_value=fake_db):
+        await record_widget_turn(
+            widget_id="wid-1",
+            org_id=42,
+            session_key="ses-1",
+            role="user",
+            content=long_content,
+        )
+
+    # Find the INSERT INTO widget_messages params
+    message_inserts = [p for p in captured_params if "content" in p and "conversation_id" in p]
+    assert message_inserts, "No widget_messages INSERT params captured"
+    assert len(message_inserts[0]["content"]) == 10000
+
+
+@pytest.mark.asyncio
+async def test_record_widget_turn_does_not_truncate_short_content():
+    """Content at or below 10000 chars is not modified."""
+    from app.services.widget_audit import record_widget_turn
+
+    short_content = "hello world"
+    captured_params: list[dict] = []
+
+    async def _fake_execute(stmt, params=None, **kwargs):
+        if params is not None:
+            captured_params.append(dict(params))
+        result = MagicMock()
+        result.first = MagicMock(return_value=(1, 0))
+        return result
+
+    fake_db = AsyncMock()
+    fake_db.execute = _fake_execute
+    fake_db.commit = AsyncMock()
+    fake_db.__aenter__ = AsyncMock(return_value=fake_db)
+    fake_db.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("app.services.widget_audit.tenant_scoped_session", return_value=fake_db):
+        await record_widget_turn(
+            widget_id="wid-1",
+            org_id=42,
+            session_key="ses-1",
+            role="assistant",
+            content=short_content,
+        )
+
+    message_inserts = [p for p in captured_params if "content" in p and "conversation_id" in p]
+    assert message_inserts
+    assert message_inserts[0]["content"] == short_content
+
+
+@pytest.mark.asyncio
+async def test_record_widget_turn_clamps_exactly_at_boundary():
+    """Content of exactly 10000 chars passes through unchanged."""
+    from app.services.widget_audit import record_widget_turn
+
+    boundary_content = "y" * 10000
+    captured_params: list[dict] = []
+
+    async def _fake_execute(stmt, params=None, **kwargs):
+        if params is not None:
+            captured_params.append(dict(params))
+        result = MagicMock()
+        result.first = MagicMock(return_value=(1, 0))
+        return result
+
+    fake_db = AsyncMock()
+    fake_db.execute = _fake_execute
+    fake_db.commit = AsyncMock()
+    fake_db.__aenter__ = AsyncMock(return_value=fake_db)
+    fake_db.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("app.services.widget_audit.tenant_scoped_session", return_value=fake_db):
+        await record_widget_turn(
+            widget_id="wid-1",
+            org_id=42,
+            session_key="ses-1",
+            role="user",
+            content=boundary_content,
+        )
+
+    message_inserts = [p for p in captured_params if "content" in p and "conversation_id" in p]
+    assert message_inserts
+    assert len(message_inserts[0]["content"]) == 10000
+
+
+# ---------------------------------------------------------------------------
+# AC8.2 — retention worker deletes old rows in chunks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retention_run_once_deletes_old_rows():
+    """_retention_run_once executes DELETE with correct retention cutoff."""
+    from app.services.widget_messages_retention import _retention_run_once
+
+    deleted_counts: list[int] = []
+
+    db = AsyncMock()
+
+    async def _execute(stmt, params=None, **kwargs):
+        result = MagicMock()
+        # Simulate 3 rows deleted in first chunk, 0 in second (done)
+        if not deleted_counts:
+            result.rowcount = 3
+        else:
+            result.rowcount = 0
+        deleted_counts.append(result.rowcount)
+        return result
+
+    db.execute = _execute
+    db.commit = AsyncMock()
+
+    @asynccontextmanager
+    async def _fake_session():
+        yield db
+
+    with (
+        patch("app.services.widget_messages_retention.cross_org_session", _fake_session),
+        patch("app.services.widget_messages_retention.settings") as mock_settings,
+    ):
+        mock_settings.widget_messages_retention_days = 90
+        result = await _retention_run_once()
+
+    assert result["deleted_count"] >= 0
+    assert "chunk_count" in result
+
+
+@pytest.mark.asyncio
+async def test_retention_run_once_returns_zero_when_no_old_rows():
+    """When no rows are old enough to delete, returns deleted_count=0, chunk_count=0."""
+    from app.services.widget_messages_retention import _retention_run_once
+
+    db = AsyncMock()
+
+    async def _execute(stmt, params=None, **kwargs):
+        result = MagicMock()
+        result.rowcount = 0
+        return result
+
+    db.execute = _execute
+    db.commit = AsyncMock()
+
+    @asynccontextmanager
+    async def _fake_session():
+        yield db
+
+    with (
+        patch("app.services.widget_messages_retention.cross_org_session", _fake_session),
+        patch("app.services.widget_messages_retention.settings") as mock_settings,
+    ):
+        mock_settings.widget_messages_retention_days = 90
+        result = await _retention_run_once()
+
+    assert result["deleted_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# AC8.3 — retention worker emits audit event
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retention_run_once_emits_audit_event():
+    """_retention_run_once emits widget_messages.retention_deleted audit event."""
+    from app.services.widget_messages_retention import _retention_run_once
+
+    call_count = 0
+    db = AsyncMock()
+
+    async def _execute(stmt, params=None, **kwargs):
+        result = MagicMock()
+        # Return 5 rows on first call, 0 on subsequent (end of chunks)
+        result.rowcount = 5 if call_count <= 1 else 0
+        return result
+
+    db.execute = _execute
+    db.commit = AsyncMock()
+
+    @asynccontextmanager
+    async def _fake_session():
+        nonlocal call_count
+        call_count += 1
+        yield db
+
+    import structlog.testing
+
+    with (
+        patch("app.services.widget_messages_retention.cross_org_session", _fake_session),
+        patch("app.services.widget_messages_retention.settings") as mock_settings,
+        structlog.testing.capture_logs() as captured,
+    ):
+        mock_settings.widget_messages_retention_days = 90
+        await _retention_run_once()
+
+    audit_events = [e for e in captured if e.get("event") == "widget_messages.retention_deleted"]
+    assert len(audit_events) == 1
+    assert "deleted_count" in audit_events[0]
+    assert "chunk_count" in audit_events[0]
+
+
+# ---------------------------------------------------------------------------
+# AC8.4 — retention worker uses configurable retention_days from settings
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retention_run_once_uses_settings_retention_days():
+    """_retention_run_once passes settings.widget_messages_retention_days as cutoff."""
+    from app.services.widget_messages_retention import _retention_run_once
+
+    captured_params: list[dict] = []
+    db = AsyncMock()
+
+    async def _execute(stmt, params=None, **kwargs):
+        if params:
+            captured_params.append(dict(params))
+        result = MagicMock()
+        result.rowcount = 0  # no rows, one chunk, done immediately
+        return result
+
+    db.execute = _execute
+    db.commit = AsyncMock()
+
+    @asynccontextmanager
+    async def _fake_session():
+        yield db
+
+    with (
+        patch("app.services.widget_messages_retention.cross_org_session", _fake_session),
+        patch("app.services.widget_messages_retention.settings") as mock_settings,
+    ):
+        mock_settings.widget_messages_retention_days = 30  # custom value
+        await _retention_run_once()
+
+    # The SQL must have been called with a cutoff param
+    assert captured_params, "No SQL params captured — DELETE not issued"
+
+
+# ---------------------------------------------------------------------------
+# AC8.5 — retention loop handles exceptions without aborting
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retention_loop_continues_after_exception():
+    """widget_messages_retention_loop does not abort when _retention_run_once raises."""
+    from app.services.widget_messages_retention import widget_messages_retention_loop
+
+    call_count = 0
+
+    async def _raise_first_then_cancel():
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError("transient DB error")
+        raise asyncio.CancelledError
+
+    with (
+        patch("app.services.widget_messages_retention._retention_run_once", side_effect=_raise_first_then_cancel),
+        patch("app.services.widget_messages_retention.RETENTION_INTERVAL_SECONDS", 0),
+        patch("asyncio.sleep", new=AsyncMock()),
+    ):
+        # Loop should exit cleanly on CancelledError (not propagate RuntimeError)
+        with pytest.raises(asyncio.CancelledError):
+            await widget_messages_retention_loop()
+
+    assert call_count >= 2, "Loop did not retry after the exception"

--- a/klai-portal/backend/tests/test_widget_mint_rate_limit.py
+++ b/klai-portal/backend/tests/test_widget_mint_rate_limit.py
@@ -1,0 +1,265 @@
+"""RED: Per-widget mint rate-limit on /partner/v1/widget-config and /public-bot-config.
+
+REQ-7 (Finding B-4, SPEC-SEC-CROSS-TENANT-FOLLOWUP-001):
+- widget-config must call check_rate_limit before DB lookup
+- public-bot-config must call check_rate_limit before DB lookup
+- 429 is returned with Retry-After header when limit exceeded
+
+AC7.1, AC7.2, AC7.3 from acceptance.md.
+
+# @MX:NOTE: [AUTO] Tests patch app.services.partner_rate_limit.check_rate_limit
+# because partner.py imports the function directly from that module.
+# @MX:SPEC: SPEC-SEC-CROSS-TENANT-FOLLOWUP-001 REQ-7
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Shared fakes (mirrors test_widget_platform_unlock.py)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeWidget:
+    id: str = "widget-uuid-1"
+    org_id: int = 42
+    name: str = "Test widget"
+    description: str | None = None
+    widget_id: str = "wgt_abcdef1234567890abcdef1234567890abcdef12"
+    widget_config: dict = field(
+        default_factory=lambda: {
+            "allowed_origins": ["https://example.com"],
+            "title": "Chat",
+            "welcome_message": "Hello!",
+            "css_variables": {},
+        }
+    )
+    public_share_enabled: bool = True
+    allow_any_origin: bool = True  # allow any origin so origin check doesn't interfere
+    rate_limit_rpm: int = 60
+    last_used_at: datetime | None = None
+    created_at: datetime = field(default_factory=lambda: datetime(2026, 1, 1, tzinfo=UTC))
+    created_by: str = "test-user"
+
+
+@dataclass
+class FakeOrg:
+    id: int = 42
+    zitadel_org_id: str = "zitadel-org-123"
+    slug: str = "test"
+    platform_unlocked_features: list = field(default_factory=lambda: ["widgets"])
+    enabled_addons: list = field(default_factory=list)
+
+
+def _make_db_mock(widget_row=None, org_row=None):
+    """Build a mock AsyncSession that returns the given rows in sequence."""
+    db = AsyncMock()
+    db.add = MagicMock()
+
+    widget_result = MagicMock()
+    widget_result.scalar_one_or_none.return_value = widget_row or FakeWidget()
+
+    org_result = MagicMock()
+    org_result.scalar_one_or_none.return_value = org_row or FakeOrg()
+
+    kb_result = MagicMock()
+    kb_result.scalars.return_value.all.return_value = []
+
+    db.execute = AsyncMock(side_effect=[widget_result, org_result, kb_result])
+    return db
+
+
+def _make_request(origin: str = "https://example.com"):
+    req = MagicMock()
+    req.headers = {"origin": origin}
+    return req
+
+
+# ---------------------------------------------------------------------------
+# AC7.2: 429 returned on widget-config when rate limit exceeded
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_widget_config_429_after_10_calls_per_minute():
+    """widget-config returns 429 with Retry-After when rate limit exceeded (AC7.2)."""
+    from app.api.partner import widget_config
+
+    db = _make_db_mock()
+    request = _make_request()
+
+    with (
+        patch("app.api.partner.settings") as mock_settings,
+        patch("app.api.partner.get_redis_pool") as mock_get_redis,
+        patch("app.api.partner.check_rate_limit", new_callable=AsyncMock) as mock_rl,
+        patch("app.api.partner.set_tenant", new_callable=AsyncMock),
+        patch("app.api.partner.generate_session_token", return_value="tok"),
+    ):
+        mock_settings.widget_jwt_secret = "test-secret"
+        mock_redis = AsyncMock()
+        mock_get_redis.return_value = mock_redis
+        # Simulate rate limit exceeded: allowed=False, retry_after=45
+        mock_rl.return_value = (False, 45)
+
+        response = await widget_config(id="wgt_abcdef1234567890abcdef1234567890abcdef12", request=request, db=db)
+
+    assert response.status_code == 429
+    assert "Retry-After" in response.headers
+    assert response.headers["Retry-After"] == "45"
+
+
+@pytest.mark.asyncio
+async def test_public_bot_config_429_after_10_calls_per_minute():
+    """public-bot-config returns 429 with Retry-After when rate limit exceeded (AC7.2)."""
+    from app.api.partner import public_bot_config
+
+    db = _make_db_mock()
+
+    with (
+        patch("app.api.partner.settings") as mock_settings,
+        patch("app.api.partner.get_redis_pool") as mock_get_redis,
+        patch("app.api.partner.check_rate_limit", new_callable=AsyncMock) as mock_rl,
+        patch("app.api.partner.set_tenant", new_callable=AsyncMock),
+        patch("app.api.partner.generate_session_token", return_value="tok"),
+    ):
+        mock_settings.widget_jwt_secret = "test-secret"
+        mock_redis = AsyncMock()
+        mock_get_redis.return_value = mock_redis
+        # Simulate rate limit exceeded
+        mock_rl.return_value = (False, 30)
+
+        response = await public_bot_config(id="wgt_abcdef1234567890abcdef1234567890abcdef12", db=db)
+
+    assert response.status_code == 429
+    assert "Retry-After" in response.headers
+    assert response.headers["Retry-After"] == "30"
+
+
+@pytest.mark.asyncio
+async def test_429_includes_retry_after_header():
+    """429 response always includes Retry-After header with positive seconds (AC7.2)."""
+    from app.api.partner import widget_config
+
+    db = _make_db_mock()
+    request = _make_request()
+
+    with (
+        patch("app.api.partner.settings") as mock_settings,
+        patch("app.api.partner.get_redis_pool") as mock_get_redis,
+        patch("app.api.partner.check_rate_limit", new_callable=AsyncMock) as mock_rl,
+        patch("app.api.partner.set_tenant", new_callable=AsyncMock),
+    ):
+        mock_settings.widget_jwt_secret = "test-secret"
+        mock_redis = AsyncMock()
+        mock_get_redis.return_value = mock_redis
+        mock_rl.return_value = (False, 60)
+
+        response = await widget_config(id="wgt_abcdef1234567890abcdef1234567890abcdef12", request=request, db=db)
+
+    assert response.status_code == 429
+    retry_after = int(response.headers["Retry-After"])
+    assert retry_after > 0
+
+
+# ---------------------------------------------------------------------------
+# AC7.1: 200 returned when within limit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_widget_config_200_within_limit():
+    """widget-config returns 200 when rate limit is not exceeded (AC7.1)."""
+    from app.api.partner import widget_config
+
+    db = _make_db_mock()
+    request = _make_request()
+
+    with (
+        patch("app.api.partner.settings") as mock_settings,
+        patch("app.api.partner.get_redis_pool") as mock_get_redis,
+        patch("app.api.partner.check_rate_limit", new_callable=AsyncMock) as mock_rl,
+        patch("app.api.partner.set_tenant", new_callable=AsyncMock),
+        patch("app.api.partner.generate_session_token", return_value="tok"),
+        patch("app.api.partner.assert_platform_unlocked"),
+    ):
+        mock_settings.widget_jwt_secret = "test-secret"
+        mock_redis = AsyncMock()
+        mock_get_redis.return_value = mock_redis
+        mock_rl.return_value = (True, 0)
+
+        response = await widget_config(id="wgt_abcdef1234567890abcdef1234567890abcdef12", request=request, db=db)
+
+    assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# AC7.3: Separate widgets have independent rate limit keys
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_key_uses_widget_id():
+    """check_rate_limit is called with a key scoped to the widget_id (AC7.3).
+
+    The key must be f'widget_mint:{widget_id}' so each widget is isolated.
+    """
+    from app.api.partner import widget_config
+
+    widget_id = "wgt_abcdef1234567890abcdef1234567890abcdef12"
+    db = _make_db_mock()
+    request = _make_request()
+
+    with (
+        patch("app.api.partner.settings") as mock_settings,
+        patch("app.api.partner.get_redis_pool") as mock_get_redis,
+        patch("app.api.partner.check_rate_limit", new_callable=AsyncMock) as mock_rl,
+        patch("app.api.partner.set_tenant", new_callable=AsyncMock),
+        patch("app.api.partner.generate_session_token", return_value="tok"),
+        patch("app.api.partner.assert_platform_unlocked"),
+    ):
+        mock_settings.widget_jwt_secret = "test-secret"
+        mock_redis = AsyncMock()
+        mock_get_redis.return_value = mock_redis
+        mock_rl.return_value = (True, 0)
+
+        await widget_config(id=widget_id, request=request, db=db)
+
+    mock_rl.assert_called_once()
+    call_args = mock_rl.call_args[0]  # positional args
+    key_arg = call_args[1]  # second positional: key_id
+    assert key_arg == f"widget_mint:{widget_id}"
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_uses_limit_10_per_minute():
+    """check_rate_limit is called with limit_per_minute=10 (REQ-7 spec)."""
+    from app.api.partner import widget_config
+
+    widget_id = "wgt_abcdef1234567890abcdef1234567890abcdef12"
+    db = _make_db_mock()
+    request = _make_request()
+
+    with (
+        patch("app.api.partner.settings") as mock_settings,
+        patch("app.api.partner.get_redis_pool") as mock_get_redis,
+        patch("app.api.partner.check_rate_limit", new_callable=AsyncMock) as mock_rl,
+        patch("app.api.partner.set_tenant", new_callable=AsyncMock),
+        patch("app.api.partner.generate_session_token", return_value="tok"),
+        patch("app.api.partner.assert_platform_unlocked"),
+    ):
+        mock_settings.widget_jwt_secret = "test-secret"
+        mock_redis = AsyncMock()
+        mock_get_redis.return_value = mock_redis
+        mock_rl.return_value = (True, 0)
+
+        await widget_config(id=widget_id, request=request, db=db)
+
+    mock_rl.assert_called_once()
+    call_kwargs = mock_rl.call_args[1]  # keyword args
+    assert call_kwargs.get("limit_per_minute") == 10

--- a/klai-portal/backend/tests/test_widget_platform_unlock.py
+++ b/klai-portal/backend/tests/test_widget_platform_unlock.py
@@ -113,6 +113,8 @@ async def test_widget_config_returns_404_when_widgets_not_unlocked():
 
     with (
         patch("app.api.partner.settings") as mock_settings,
+        patch("app.api.partner.get_redis_pool"),
+        patch("app.api.partner.check_rate_limit", new_callable=AsyncMock, return_value=(True, 0)),
         patch("app.api.partner.set_tenant", new=AsyncMock()),
         patch("app.api.partner.generate_session_token", return_value="fake.jwt.token"),
     ):
@@ -134,6 +136,8 @@ async def test_widget_config_returns_200_when_widgets_unlocked():
 
     with (
         patch("app.api.partner.settings") as mock_settings,
+        patch("app.api.partner.get_redis_pool"),
+        patch("app.api.partner.check_rate_limit", new_callable=AsyncMock, return_value=(True, 0)),
         patch("app.api.partner.set_tenant", new=AsyncMock()),
         patch("app.api.partner.generate_session_token", return_value="fake.jwt.token"),
     ):
@@ -158,6 +162,8 @@ async def test_public_bot_config_returns_404_when_widgets_not_unlocked():
 
     with (
         patch("app.api.partner.settings") as mock_settings,
+        patch("app.api.partner.get_redis_pool"),
+        patch("app.api.partner.check_rate_limit", new_callable=AsyncMock, return_value=(True, 0)),
         patch("app.api.partner.set_tenant", new=AsyncMock()),
         patch("app.api.partner.generate_session_token", return_value="fake.jwt.token"),
     ):
@@ -178,6 +184,8 @@ async def test_public_bot_config_returns_200_when_widgets_unlocked():
 
     with (
         patch("app.api.partner.settings") as mock_settings,
+        patch("app.api.partner.get_redis_pool"),
+        patch("app.api.partner.check_rate_limit", new_callable=AsyncMock, return_value=(True, 0)),
         patch("app.api.partner.set_tenant", new=AsyncMock()),
         patch("app.api.partner.generate_session_token", return_value="fake.jwt.token"),
     ):


### PR DESCRIPTION
## Summary

Window 2 of SPEC-SEC-CROSS-TENANT-FOLLOWUP-001 — closes 5 audit findings from the May 2026 cross-tenant scan. Window 1 (PR #674 + hotfixes) is already LIVE.

## Closes (5 REQs, 5 commits + 1 SPEC docs commit)

| REQ | Finding | Severity | What |
|---|---|---|---|
| REQ-4 | A-2 | HIGH | Hard-delete state-machine refactor mirroring `deprovisioning_orchestrator`. Idempotent 3-step orchestrator (Zitadel-remove FIRST, external KB-deletes, portal DB delete with audit). Self-delete + last-platform-admin guards. New `POST /api/admin/platform/users/{zid}/retry-delete` endpoint. New columns on `portal_users`: `deletion_status`, `failure_reason JSONB`, `last_attempted_step`. Also closes REQ-11 (A-5 partial-failure audit) as a side effect. |
| REQ-5 | A-4 | HIGH | `zitadel.revoke_user_role` added. `_sync_zitadel_role_grant` helper called from `platform_update_role` + `users.py update_user_role`. Promotion `personal→admin` triggers `grant_user_role(org:owner)`; demotion triggers revoke. On Zitadel failure: `platform_admin.role_change_zitadel_desync` audit event, DB commit NOT rolled back. |
| REQ-6 | A-7 | MED | try/finally around every external Zitadel call in `platform_invite` + `platform_create_tenant`. Emits `platform_admin.{step}_failed` audit events with truncated error context. |
| REQ-7 | B-4 | HIGH | Per-widget mint rate-limit (10/min) on `/partner/v1/widget-config` + `/partner/v1/public-bot-config` via existing `check_rate_limit` helper. Returns 429 + `Retry-After`. |
| REQ-8 | B-5 | HIGH | Content clamp `[:10000]` in `record_widget_turn`; CHECK constraint via post-deploy SQL (klai-owned table); new `widget_messages_retention.py` background worker (chunked DELETE older than 90d, lifespan-registered); `WIDGET_MESSAGES_RETENTION_DAYS` env-var default 90. |

## Commits

```
43faa70d docs(spec): update SPEC-SEC-CROSS-TENANT-FOLLOWUP-001 with live deploy status
5c74a6be feat(security): REQ-4 platform user-delete state machine with partial-failure tracking
76e12781 feat(security): REQ-8 widget message content clamping + retention worker
ece61ecc feat(security): REQ-5 sync Zitadel org:owner grant on role change
031c6f5c feat(platform-admin): emit audit events on partial Zitadel failures (Finding A-7)
adb2f6e5 feat(widgets): per-widget mint rate-limit on public endpoints (Finding B-4)
```

## Test plan

- [x] Backend: `uv run pytest -q --tb=short` (full suite) → **2804 passed** (was 2772 = +32 new tests)
- [x] Lint: `ruff check`, `ruff format --check`, `pyright` → all clean
- [x] Alembic: single head `5c6ad9cf7983`
- [x] Window-1 lessons applied: schema-first (REQ-8 post-deploy SQL for klai-owned `widget_messages`); adjacent FakeWidget mocks updated (REQ-7 commit shows +4/+26/+8 in `test_partner_cors`/`test_widget_config`/`test_widget_platform_unlock`); portal_audit_log uses correct column names
- [ ] CI green on PR
- [ ] REQ-4 alembic upgrade on production adds 3 columns to `portal_users` without error (portal_api-owned)
- [ ] REQ-8 post-deploy SQL adds CHECK constraint on `widget_messages.content` (klai superuser via deploy-portal-api.sh)
- [ ] Live: REQ-7 rate-limit — 11th call to `/partner/v1/widget-config?id=<wgt>` from same client within 60s returns 429
- [ ] Live: REQ-5 — promoting a test user to admin via platform-admin console triggers `grant_user_role(org:owner)` in Zitadel
- [ ] Live: REQ-8 — `widget_messages_retention` worker registered in lifespan; `WIDGET_MESSAGES_RETENTION_DAYS=90` in env

## Window 3 (out of scope)

REQ-10..19 will land in a separate follow-up PR. Note: REQ-11 (Finding A-5) is closed as a side effect of REQ-4's state-machine — scope adjustment for Window 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)