### PR TITLE
fix(portal): keep tenant redirects on app routes

### DIFF
--- a/klai-portal/backend/app/middleware/tenant_host.py
+++ b/klai-portal/backend/app/middleware/tenant_host.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import re
 import time
-from urllib.parse import urlunsplit
+from urllib.parse import urlsplit, urlunsplit
 
 import structlog
 from fastapi import Request, Response, status
@@ -209,12 +209,13 @@ class KlaiTenantHostMiddleware(BaseHTTPMiddleware):
         # by the caller) and ``settings.domain`` (hardcoded config) are
         # server-controlled. Construct the URL with ``urlunsplit`` so the
         # path/query/host segments stay structurally separated.
+        target_path, target_query = KlaiTenantHostMiddleware._redirect_path_query(request)
         target = urlunsplit(
             (
                 "https",
                 f"{session_slug}.{settings.domain}",
-                request.url.path,
-                request.url.query,
+                target_path,
+                target_query,
                 "",
             )
         )
@@ -245,6 +246,35 @@ class KlaiTenantHostMiddleware(BaseHTTPMiddleware):
                 }
             },
         )
+
+    @staticmethod
+    def _redirect_path_query(request: Request) -> tuple[str, str]:
+        """Return the browser route to use for tenant-mismatch redirects.
+
+        Page navigations should keep their current path. API calls are
+        different: redirecting to the same API path would land the browser on
+        raw JSON (for example `/api/me`). For XHR/fetch mismatches, use the
+        same-origin Referer page path when available, otherwise go to `/`.
+        """
+        if not request.url.path.startswith("/api/"):
+            return request.url.path, request.url.query
+
+        referer = request.headers.get("referer")
+        if not referer:
+            return "/", ""
+
+        try:
+            parsed = urlsplit(referer)
+        except ValueError:
+            return "/", ""
+
+        if parsed.scheme not in {"http", "https"}:
+            return "/", ""
+        if parsed.hostname != request.url.hostname:
+            return "/", ""
+        if parsed.path.startswith("/api/"):
+            return "/", ""
+        return parsed.path or "/", parsed.query
 
 
 __all__ = [

--- a/klai-portal/backend/tests/test_tenant_host_integration.py
+++ b/klai-portal/backend/tests/test_tenant_host_integration.py
@@ -115,7 +115,7 @@ def test_mismatch_html_navigation_returns_302() -> None:
         follow_redirects=False,
     )
     assert response.status_code == 302
-    assert response.headers["location"] == "https://getklai.getklai.com/api/me?page=2"
+    assert response.headers["location"] == "https://getklai.getklai.com/"
 
 
 # ---------------------------------------------------------------------------
@@ -128,13 +128,17 @@ def test_mismatch_xhr_returns_409_with_structured_body() -> None:
     client = TestClient(app)
     response = client.get(
         "/api/me",
-        headers={"host": "voys.getklai.com", "accept": "application/json"},
+        headers={
+            "host": "voys.getklai.com",
+            "accept": "application/json",
+            "referer": "https://voys.getklai.com/app/chat",
+        },
     )
     assert response.status_code == 409
     assert response.json() == {
         "detail": {
             "error_code": "tenant_host_mismatch",
-            "redirect_to": "https://getklai.getklai.com/api/me",
+            "redirect_to": "https://getklai.getklai.com/app/chat",
         }
     }
 

--- a/klai-portal/backend/tests/test_tenant_host_middleware.py
+++ b/klai-portal/backend/tests/test_tenant_host_middleware.py
@@ -31,6 +31,7 @@ def _make_request(
     method: str = "GET",
     query: str = "",
     accept: str = "application/json",
+    referer: str | None = None,
     session_org_id: int | None = 42,
 ) -> MagicMock:
     """Build a Starlette-compatible request mock."""
@@ -41,6 +42,8 @@ def _make_request(
     request.url.path = path
     request.url.query = query
     request.headers = {"accept": accept}
+    if referer is not None:
+        request.headers["referer"] = referer
 
     if session_org_id is not None:
         request.state.session = SessionContext(
@@ -275,11 +278,12 @@ class TestMismatchResponse:
 
     @pytest.mark.asyncio
     async def test_xhr_request_returns_409_json(self) -> None:
-        """XHR/fetch gets a 409 with structured error_code body."""
+        """XHR/fetch gets a 409 with a redirect back to the browser route."""
         middleware = KlaiTenantHostMiddleware(app=MagicMock())
         request = _make_request(
             host="voys.getklai.com",
             path="/api/me",
+            referer="https://voys.getklai.com/app/chat",
             session_org_id=42,
             accept="application/json",
         )
@@ -294,13 +298,33 @@ class TestMismatchResponse:
         assert body == {
             "detail": {
                 "error_code": "tenant_host_mismatch",
-                "redirect_to": "https://getklai.getklai.com/api/me",
+                "redirect_to": "https://getklai.getklai.com/app/chat",
             }
         }
 
     @pytest.mark.asyncio
-    async def test_xhr_request_with_query_string(self) -> None:
-        """409 JSON's redirect_to preserves the query string."""
+    async def test_xhr_request_uses_referer_query_string(self) -> None:
+        """409 JSON's redirect_to preserves the browser route query string."""
+        middleware = KlaiTenantHostMiddleware(app=MagicMock())
+        request = _make_request(
+            host="voys.getklai.com",
+            path="/api/me",
+            query="api_query_is_not_a_browser_route=1",
+            referer="https://voys.getklai.com/app/knowledge?tab=sources",
+            session_org_id=42,
+            accept="application/json",
+        )
+        call_next = AsyncMock()
+
+        with patch.object(mw_module, "_resolve_org_slug", _slug_resolver({42: "getklai"})):
+            response = await middleware.dispatch(request, call_next)
+
+        body = json.loads(response.body)
+        assert body["detail"]["redirect_to"] == "https://getklai.getklai.com/app/knowledge?tab=sources"
+
+    @pytest.mark.asyncio
+    async def test_api_mismatch_without_referer_falls_back_to_root(self) -> None:
+        """Never redirect a browser to raw API JSON when no Referer exists."""
         middleware = KlaiTenantHostMiddleware(app=MagicMock())
         request = _make_request(
             host="voys.getklai.com",
@@ -315,7 +339,7 @@ class TestMismatchResponse:
             response = await middleware.dispatch(request, call_next)
 
         body = json.loads(response.body)
-        assert body["detail"]["redirect_to"] == "https://getklai.getklai.com/api/me?x=1"
+        assert body["detail"]["redirect_to"] == "https://getklai.getklai.com/"
 
     @pytest.mark.asyncio
     async def test_accept_with_both_html_and_json_returns_json(self) -> None:

--- a/klai-portal/frontend/src/hooks/__tests__/useProtectedRoute.test.tsx
+++ b/klai-portal/frontend/src/hooks/__tests__/useProtectedRoute.test.tsx
@@ -76,6 +76,7 @@ describe('useProtectedRoute', () => {
     mockQuery = { user: undefined, isPending: true }
     // Reset any lingering location.replace mock.
     vi.restoreAllMocks()
+    vi.unstubAllGlobals()
   })
 
   it('does not resolve while auth is still loading', () => {
@@ -123,6 +124,46 @@ describe('useProtectedRoute', () => {
     expect(navigate).not.toHaveBeenCalled()
     expect(result.current.canRender).toBe(true)
     expect(result.current.user?.user_id).toBe('u1')
+  })
+
+  it('hands off protected routes from my.getklai.com to the workspace host', () => {
+    const replace = vi.fn()
+    vi.stubGlobal('location', {
+      hostname: 'my.getklai.com',
+      pathname: '/app/chat',
+      search: '?thread=1',
+      hash: '#reply',
+      replace,
+    } as unknown as Location)
+    mockQuery = {
+      user: userFixture({ workspace_url: 'https://voys.getklai.com' }),
+      isPending: false,
+    }
+    const { result } = renderHook(() => useProtectedRoute(), {
+      wrapper: wrapperFor(makeAuth({ isLoading: false, isAuthenticated: true })),
+    })
+    expect(replace).toHaveBeenCalledWith('https://voys.getklai.com/app/chat?thread=1#reply')
+    expect(result.current.canRender).toBe(false)
+  })
+
+  it('does not hand off when already on the workspace host', () => {
+    const replace = vi.fn()
+    vi.stubGlobal('location', {
+      hostname: 'voys.getklai.com',
+      pathname: '/app/chat',
+      search: '',
+      hash: '',
+      replace,
+    } as unknown as Location)
+    mockQuery = {
+      user: userFixture({ workspace_url: 'https://voys.getklai.com' }),
+      isPending: false,
+    }
+    const { result } = renderHook(() => useProtectedRoute(), {
+      wrapper: wrapperFor(makeAuth({ isLoading: false, isAuthenticated: true })),
+    })
+    expect(replace).not.toHaveBeenCalled()
+    expect(result.current.canRender).toBe(true)
   })
 
   it('redirects to /setup/2fa when requires_2fa_setup is true', () => {

--- a/klai-portal/frontend/src/hooks/useProtectedRoute.ts
+++ b/klai-portal/frontend/src/hooks/useProtectedRoute.ts
@@ -77,6 +77,20 @@ function hasRequiredRole(user: CurrentUser | undefined, options: UseProtectedRou
   return true
 }
 
+function workspaceHandoffUrl(workspaceUrl: string | null | undefined): string | null {
+  if (!workspaceUrl) return null
+  const current = window.location
+  if (current.hostname === 'localhost' || current.hostname === '127.0.0.1') return null
+  try {
+    const workspace = new URL(workspaceUrl)
+    if (current.hostname === workspace.hostname) return null
+    const target = new URL(`${current.pathname}${current.search}${current.hash}`, workspace.origin)
+    return target.toString()
+  } catch {
+    return null
+  }
+}
+
 export function useProtectedRoute(
   options: UseProtectedRouteOptions = {},
 ): UseProtectedRouteResult {
@@ -88,6 +102,7 @@ export function useProtectedRoute(
   const auth = useAuth()
   const navigate = useNavigate()
   const { user, isPending: userLoading } = useCurrentUser()
+  const workspaceRedirectUrl = user ? workspaceHandoffUrl(user.workspace_url) : null
 
   useEffect(() => {
     if (auth.isLoading) return
@@ -98,6 +113,10 @@ export function useProtectedRoute(
       return
     }
     if (userLoading) return
+    if (workspaceRedirectUrl) {
+      window.location.replace(workspaceRedirectUrl)
+      return
+    }
     // 2. MFA setup pending — send to the setup flow.
     if (user?.requires_2fa_setup) {
       window.location.replace('/setup/2fa')
@@ -112,6 +131,7 @@ export function useProtectedRoute(
     auth.isAuthenticated,
     user,
     userLoading,
+    workspaceRedirectUrl,
     needsRoleCheck,
     fallback,
     noRoleFallback,
@@ -120,7 +140,7 @@ export function useProtectedRoute(
   ])
 
   const roleOk = !needsRoleCheck || hasRequiredRole(user, options)
-  const isResolving = auth.isLoading || !auth.isAuthenticated || userLoading || !roleOk
+  const isResolving = auth.isLoading || !auth.isAuthenticated || userLoading || !!workspaceRedirectUrl || !roleOk
 
   return {
     user,


### PR DESCRIPTION
## What changed
- Redirect authenticated users off `my.getklai.com` and other wrong tenant hosts from the shared protected-route guard.
- Keep tenant mismatch redirects on browser routes instead of API endpoints, so `/api/me` can never land as raw JSON in the browser.
- Add frontend and backend regression coverage for both paths.

## Root cause
The previous handoff only ran during `/callback`. Direct visits to `my.getklai.com` or a wrong tenant host could bypass that path. Separately, the backend tenant-host guard built `redirect_to` from the API request path itself, so `/api/me` redirected to `/api/me` on the correct tenant and displayed raw JSON.

## Validation
- `npm test -- src/hooks/__tests__/useProtectedRoute.test.tsx`
- `npx eslint src/hooks/useProtectedRoute.ts src/hooks/__tests__/useProtectedRoute.test.tsx`
- `uv run pytest tests/test_tenant_host_middleware.py tests/test_tenant_host_integration.py`
- `uv run ruff check app/middleware/tenant_host.py tests/test_tenant_host_middleware.py tests/test_tenant_host_integration.py`
- `git diff --check`
