### PR TITLE
fix(deploy): make widget content constraint idempotent

### DIFF
--- a/klai-portal/backend/alembic/versions/post_deploy_57b2c33efe55_widget_messages_content_length.sql
+++ b/klai-portal/backend/alembic/versions/post_deploy_57b2c33efe55_widget_messages_content_length.sql
@@ -8,6 +8,16 @@
 -- content to 10000 chars before INSERT (AC8.1). The DB constraint prevents
 -- any future code path from silently bypassing the cap.
 
-ALTER TABLE widget_messages
-    ADD CONSTRAINT widget_messages_content_length
-    CHECK (LENGTH(content) <= 10000);
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'widget_messages_content_length'
+          AND conrelid = 'widget_messages'::regclass
+    ) THEN
+        ALTER TABLE widget_messages
+            ADD CONSTRAINT widget_messages_content_length
+            CHECK (LENGTH(content) <= 10000);
+    END IF;
+END $$;


### PR DESCRIPTION
## What changed
- Make `post_deploy_57b2c33efe55_widget_messages_content_length.sql` idempotent.
- The deploy script reruns all `post_deploy_*.sql` files; this constraint already exists in prod, so the script must skip creation when present.

## Why
The portal-api deploy for PR #679 built and pushed successfully, but failed during post-deploy SQL with:

`constraint "widget_messages_content_length" for relation "widget_messages" already exists`

## Validation
- `uv run python scripts/check_migration_post_deploy.py alembic/versions/57b2c33efe55_add_widget_message_content_length.py`
- `git diff --check`
