### PR TITLE
fix(docs): preserve Gitea org metadata for ingest

### DIFF
--- a/klai-docs/app/api/orgs/[org]/kbs/[kb]/pages/[...path]/route.ts
+++ b/klai-docs/app/api/orgs/[org]/kbs/[kb]/pages/[...path]/route.ts
@@ -98,6 +98,7 @@ export async function PUT(
   if (!kb) return NextResponse.json({ error: "Not found" }, { status: 404 });
   const denied = checkKBAccess(kb, payload.sub);
   if (denied) return denied;
+  await gitea.ensureOrgDescription(`org-${orgSlug}`, org.zitadel_org_id);
 
   const pagePath = path.join("/");
 

--- a/klai-docs/app/api/orgs/[org]/kbs/route.ts
+++ b/klai-docs/app/api/orgs/[org]/kbs/route.ts
@@ -49,12 +49,13 @@ export async function POST(
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
     org = await db.createOrg(orgSlug, orgSlug, zitadelOrgId);
-    await gitea.createOrg(`org-${orgSlug}`, orgSlug);
+    await gitea.createOrg(`org-${orgSlug}`, orgSlug, zitadelOrgId);
   } else {
     // Existing org: verify caller belongs to it
     if (payload.org_id && payload.org_id !== org.zitadel_org_id) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
+    await gitea.ensureOrgDescription(`org-${orgSlug}`, org.zitadel_org_id);
   }
 
   const giteaOrg = `org-${orgSlug}`;

--- a/klai-docs/lib/gitea.ts
+++ b/klai-docs/lib/gitea.ts
@@ -18,6 +18,7 @@ type GiteaFile = {
 type GiteaCreateOrg = {
   username: string;
   full_name?: string;
+  description?: string;
   visibility?: "public" | "private";
 };
 
@@ -54,13 +55,24 @@ async function giteaFetch(path: string, init?: RequestInit) {
 
 // ─── Organisation & repo management ──────────────────────────────────────────
 
-export async function createOrg(orgName: string, displayName: string) {
+export async function createOrg(orgName: string, displayName: string, description?: string) {
   const body: GiteaCreateOrg = {
     username: orgName,
     full_name: displayName,
     visibility: "private",
   };
+  if (description) body.description = description;
   return giteaFetch("/orgs", { method: "POST", body: JSON.stringify(body) });
+}
+
+export async function ensureOrgDescription(orgName: string, description: string): Promise<void> {
+  const org = await giteaFetch(`/orgs/${orgName}`);
+  if (org?.description === description) return;
+
+  await giteaFetch(`/orgs/${orgName}`, {
+    method: "PATCH",
+    body: JSON.stringify({ description }),
+  });
 }
 
 export async function createRepo(orgName: string, repoSlug: string, description = "") {

--- a/klai-docs/tests/gitea.test.ts
+++ b/klai-docs/tests/gitea.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+async function loadGitea() {
+  vi.resetModules();
+  return import("../lib/gitea");
+}
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("gitea org metadata", () => {
+  it("stores the Zitadel org id in the Gitea org description on create", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({}),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const gitea = await loadGitea();
+    await gitea.createOrg("org-klai", "klai", "zitadel-org-123");
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(fetchMock.mock.calls[0][0]).toBe("http://gitea:3000/api/v1/orgs");
+    expect(body).toMatchObject({
+      username: "org-klai",
+      full_name: "klai",
+      description: "zitadel-org-123",
+      visibility: "private",
+    });
+  });
+
+  it("repairs missing Gitea org description for existing orgs", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ description: "" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const gitea = await loadGitea();
+    await gitea.ensureOrgDescription("org-klai", "zitadel-org-123");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1][0]).toBe("http://gitea:3000/api/v1/orgs/org-klai");
+    expect(fetchMock.mock.calls[1][1].method).toBe("PATCH");
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body as string)).toEqual({
+      description: "zitadel-org-123",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Store the Zitadel org id in the Gitea org description when Docs creates a Gitea org.
- Repair existing Gitea org descriptions during KB provisioning and before page writes.
- Add coverage for create/repair behavior in the Gitea client.

## Root Cause
`knowledge-ingest` resolves the tenant for Gitea webhooks by reading the Gitea org `description`. `klai-docs` created Gitea orgs without that description, so Docs pages could exist in Gitea while webhooks were ignored with `org_id_not_found`, leaving no chunks/sources for widget retrieval.

## Validation
- `npm test` in `klai-docs`
- `npm run lint -- --max-warnings=0 lib/gitea.ts 'app/api/orgs/[org]/kbs/route.ts' 'app/api/orgs/[org]/kbs/[kb]/pages/[...path]/route.ts' tests/gitea.test.ts`

## Deploy Notes
A workflow_dispatch docs deploy was triggered from this branch for the live hotfix.
Existing Docs pages still require a bulk sync/backfill; this patch prevents the webhook path from silently dropping future saves.
