### PR TITLE
fix(portal): hide legacy help overlay

### DIFF
--- a/klai-portal/frontend/src/routes/admin/route.tsx
+++ b/klai-portal/frontend/src/routes/admin/route.tsx
@@ -2,7 +2,6 @@ import { createFileRoute, Outlet } from '@tanstack/react-router'
 import { useQuery } from '@tanstack/react-query'
 import { LayoutDashboard, Users, FolderKanban, Settings, CreditCard, Puzzle, Key, MessageSquare, Skull, ShieldCheck, Globe2, type LucideIcon } from 'lucide-react'
 import { Sidebar } from '@/components/layout/Sidebar'
-import { HelpButton } from '@/components/help/HelpButton'
 import * as m from '@/paraglide/messages'
 import { useProtectedRoute } from '@/hooks/useProtectedRoute'
 import { meetsMinRole, type ProfileRole } from '@/lib/profiles'
@@ -101,7 +100,6 @@ function AdminLayout() {
       <main className="flex-1 overflow-y-auto">
         <Outlet />
       </main>
-      <HelpButton />
     </div>
   )
 }

--- a/klai-portal/frontend/src/routes/app/route.tsx
+++ b/klai-portal/frontend/src/routes/app/route.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute, Outlet } from '@tanstack/react-router'
 import { MessageSquare, Mic, BookMarked, Brain, Sliders } from 'lucide-react'
 import { Sidebar } from '@/components/layout/Sidebar'
-import { HelpButton } from '@/components/help/HelpButton'
 import * as m from '@/paraglide/messages'
 import { useProtectedRoute } from '@/hooks/useProtectedRoute'
 
@@ -54,7 +53,6 @@ function AppLayout() {
       <main className="flex-1 overflow-y-auto">
         <Outlet />
       </main>
-      <HelpButton />
     </div>
   )
 }


### PR DESCRIPTION
## What changed
- Removed the legacy in-app HelpButton from the app layout.
- Removed the legacy in-app HelpButton from the admin layout.

## Why
The old help overlay/button was still rendering over the product and making it look like the Klai chat widget was missing. The Klai widget script remains configured in `klai-portal/frontend/index.html`, so hiding the legacy overlay lets the current widget be visible.

## Validation
- `npm run lint -- --max-warnings=0 src/routes/app/route.tsx src/routes/admin/route.tsx`
- `npm run build`
- `npm run security:audit`
