### PR TITLE
fix(ingest): normalize docs pages for widget retrieval

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/chunker.py
+++ b/klai-knowledge-ingest/knowledge_ingest/chunker.py
@@ -11,6 +11,7 @@ narrative context. The legacy chunk_markdown() entry point is preserved
 for callers that don't yet need parents.
 """
 
+import json
 import re
 from dataclasses import dataclass, field
 
@@ -48,6 +49,248 @@ def _strip_frontmatter(text: str) -> tuple[str, str]:
         if end != -1:
             return text[: end + 4], text[end + 4 :].lstrip("\n")
     return "", text
+
+
+def normalize_document_for_chunking(content: str) -> str:
+    """Return Markdown-like text suitable for chunking and embedding.
+
+    Docs pages are stored losslessly as BlockNote JSON in Gitea so the editor
+    can round-trip custom blocks. The knowledge pipeline, however, needs
+    readable text. Convert a BlockNote JSON body to Markdown while preserving
+    YAML frontmatter; legacy Markdown content passes through unchanged.
+    """
+    frontmatter, body = _strip_frontmatter(content)
+    converted = _blocknote_json_to_markdown(body)
+    if converted is None:
+        return content
+    if frontmatter:
+        return f"{frontmatter}\n\n{converted}".rstrip()
+    return converted
+
+
+def _blocknote_json_to_markdown(body: str) -> str | None:
+    trimmed = body.strip()
+    if not trimmed.startswith("["):
+        return None
+    try:
+        blocks = json.loads(trimmed)
+    except json.JSONDecodeError:
+        return None
+    if (
+        not isinstance(blocks, list)
+        or not blocks
+        or not all(isinstance(b, dict) and _looks_like_blocknote_block(b) for b in blocks)
+    ):
+        return None
+    return _render_blocknote_blocks(blocks).strip()
+
+
+def _looks_like_blocknote_block(block: dict) -> bool:
+    block_type = block.get("type")
+    content = block.get("content")
+    children = block.get("children")
+    if block_type is not None and not isinstance(block_type, str):
+        return False
+    if children is not None and not isinstance(children, list):
+        return False
+    if block_type in {
+        "paragraph",
+        "heading",
+        "bulletListItem",
+        "numberedListItem",
+        "checkListItem",
+        "codeBlock",
+        "quote",
+        "table",
+        "image",
+        "file",
+    }:
+        return True
+    return isinstance(content, (str, list, dict)) or isinstance(children, list)
+
+
+def _render_blocknote_blocks(blocks: list[dict], depth: int = 0) -> str:
+    rendered: list[str] = []
+    i = 0
+    while i < len(blocks):
+        block = blocks[i]
+        block_type = block.get("type")
+        if block_type in {"bulletListItem", "numberedListItem", "checkListItem"}:
+            items: list[str] = []
+            number = 1
+            while i < len(blocks) and blocks[i].get("type") == block_type:
+                items.append(_render_blocknote_list_item(blocks[i], depth, number))
+                number += 1
+                i += 1
+            rendered.append("\n".join(item for item in items if item))
+            continue
+
+        block_text = _render_blocknote_block(block, depth)
+        if block_text:
+            rendered.append(block_text)
+        i += 1
+    return "\n\n".join(rendered)
+
+
+def _render_blocknote_block(block: dict, depth: int) -> str:
+    block_type = block.get("type")
+    content = block.get("content")
+    text = "" if _is_table_content(content) else _render_inline_content(content)
+    children = block.get("children")
+    rendered_children = (
+        _render_blocknote_blocks(children, depth + 1)
+        if isinstance(children, list) and all(isinstance(c, dict) for c in children)
+        else ""
+    )
+
+    if block_type == "heading":
+        props = block.get("props") if isinstance(block.get("props"), dict) else {}
+        level = props.get("level")
+        if not isinstance(level, int):
+            level = 2
+        primary = f"{'#' * max(1, min(level, 6))} {text}".strip()
+    elif block_type == "codeBlock":
+        props = block.get("props") if isinstance(block.get("props"), dict) else {}
+        language = props.get("language")
+        language = language if isinstance(language, str) else ""
+        primary = f"```{language}\n{_extract_inline_plain_text(content)}\n```"
+    elif block_type == "quote":
+        primary = "\n".join(f"> {line}" for line in text.splitlines())
+    elif block_type == "table" and _is_table_content(content):
+        primary = _render_blocknote_table(content)
+    else:
+        primary = text
+
+    if primary and rendered_children:
+        return f"{primary}\n\n{rendered_children}"
+    return primary or rendered_children
+
+
+def _render_blocknote_list_item(block: dict, depth: int, number: int) -> str:
+    block_type = block.get("type")
+    indent = "  " * depth
+    text = _render_inline_content(block.get("content"))
+    if block_type == "numberedListItem":
+        marker = f"{number}."
+    elif block_type == "checkListItem":
+        props = block.get("props") if isinstance(block.get("props"), dict) else {}
+        marker = "- [x]" if props.get("checked") else "- [ ]"
+    else:
+        marker = "-"
+    line = f"{indent}{marker} {text}".rstrip()
+    children = block.get("children")
+    if isinstance(children, list) and all(isinstance(c, dict) for c in children):
+        rendered_children = _render_blocknote_blocks(children, depth + 1)
+        if rendered_children:
+            return f"{line}\n{rendered_children}"
+    return line
+
+
+def _render_inline_content(content: object) -> str:
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    return "".join(_render_inline_item(item) for item in content)
+
+
+def _render_inline_item(item: object) -> str:
+    if isinstance(item, str):
+        return item
+    if not isinstance(item, dict):
+        return ""
+
+    item_type = item.get("type")
+    if item_type == "text":
+        return _apply_inline_styles(str(item.get("text") or ""), item.get("styles"))
+    if item_type == "link":
+        label = _render_inline_content(item.get("content"))
+        href = item.get("href")
+        return f"[{label}]({href})" if isinstance(href, str) and href.strip() else label
+    if item_type == "wikilink":
+        props = item.get("props") if isinstance(item.get("props"), dict) else {}
+        return str(props.get("title") or props.get("pageId") or "")
+    return ""
+
+
+def _apply_inline_styles(text: str, styles: object) -> str:
+    if not text or not isinstance(styles, dict):
+        return text
+    leading = re.match(r"^\s*", text).group(0)
+    trailing = re.search(r"\s*$", text).group(0)
+    core = text[len(leading) : len(text) - len(trailing) if trailing else len(text)]
+    if not core:
+        return text
+    if styles.get("code"):
+        escaped_core = core.replace("`", "\\`")
+        core = f"`{escaped_core}`"
+    if styles.get("bold"):
+        core = f"**{core}**"
+    if styles.get("italic"):
+        core = f"_{core}_"
+    if styles.get("strike"):
+        core = f"~~{core}~~"
+    return f"{leading}{core}{trailing}"
+
+
+def _extract_inline_plain_text(content: object) -> str:
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for item in content:
+        if isinstance(item, str):
+            parts.append(item)
+        elif isinstance(item, dict):
+            if item.get("type") == "text":
+                parts.append(str(item.get("text") or ""))
+            elif item.get("type") == "link":
+                parts.append(_extract_inline_plain_text(item.get("content")))
+            elif item.get("type") == "wikilink":
+                props = item.get("props") if isinstance(item.get("props"), dict) else {}
+                parts.append(str(props.get("title") or ""))
+    return "".join(parts)
+
+
+def _is_table_content(content: object) -> bool:
+    return (
+        isinstance(content, dict)
+        and content.get("type") == "tableContent"
+        and isinstance(content.get("rows"), list)
+    )
+
+
+def _table_cell_content(cell: object) -> object:
+    if isinstance(cell, list):
+        return cell
+    if isinstance(cell, dict):
+        return cell.get("content")
+    return None
+
+
+def _render_blocknote_table(content: dict) -> str:
+    rows = content.get("rows")
+    if not isinstance(rows, list) or not rows:
+        return ""
+    parsed_rows: list[list[str]] = []
+    width = 0
+    for row in rows:
+        if not isinstance(row, dict) or not isinstance(row.get("cells"), list):
+            continue
+        cells = [
+            _render_inline_content(_table_cell_content(cell)).replace("\n", " ").strip()
+            for cell in row["cells"]
+        ]
+        parsed_rows.append(cells)
+        width = max(width, len(cells))
+    if not parsed_rows or width == 0:
+        return ""
+    normalized = [row + [""] * (width - len(row)) for row in parsed_rows]
+    lines = [f"| {' | '.join(cell or ' ' for cell in normalized[0])} |"]
+    lines.append(f"|{' --- |' * width}")
+    lines.extend(f"| {' | '.join(cell or ' ' for cell in row)} |" for row in normalized[1:])
+    return "\n".join(lines)
 
 
 def _find_code_block_ranges(text: str) -> list[tuple[int, int]]:

--- a/klai-knowledge-ingest/knowledge_ingest/enrichment_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/enrichment_tasks.py
@@ -171,6 +171,8 @@ async def _load_and_enrich(artifact_id: str) -> None:
         return
 
     title: str = extra.get("title") or ""
+    document_text = chunker.normalize_document_for_chunking(document_text)
+
     # Re-derive chunks deterministically from the current PG body so
     # Phase-2 always operates on the same content the artifact row claims
     # is current, regardless of what was in flight at enqueue time.

--- a/klai-knowledge-ingest/knowledge_ingest/ingest_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/ingest_tasks.py
@@ -41,11 +41,13 @@ def register_ingest_tasks(procrastinate_app: object) -> None:
         how many saves were made after the task was queued.
         """
         # Lazy imports to avoid circular dependencies and psycopg at module level
-        from knowledge_ingest.routes.ingest import (  # noqa: PLC0415
+        from knowledge_ingest.db import tenant_scoped_connection
+        from knowledge_ingest.models import IngestRequest
+        from knowledge_ingest.routes.ingest import (
             _fetch_gitea_file,
+            docs_source_extra,
             ingest_document,
         )
-        from knowledge_ingest.models import IngestRequest  # noqa: PLC0415
 
         logger.info("gitea_ingest_started", kb_slug=kb_slug, path=path, org_id=org_id)
 
@@ -62,8 +64,10 @@ def register_ingest_tasks(procrastinate_app: object) -> None:
             source_type="docs",
             content_type="kb_article",
             user_id=user_id,
+            extra=docs_source_extra(gitea_repo, kb_slug, path),
         )
-        result = await ingest_document(req)
+        async with tenant_scoped_connection(org_id) as conn:
+            result = await ingest_document(conn, req)
         logger.info(
             "gitea_ingest_complete",
             kb_slug=kb_slug,

--- a/klai-knowledge-ingest/knowledge_ingest/rebuild_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/rebuild_tasks.py
@@ -282,6 +282,7 @@ async def _rebuild_artifact(
             # Step 1: Re-chunk with parent-child chunking (SPEC-RAG-PARENT-CHILD-001).
             from knowledge_ingest import chunker
 
+            document_text = chunker.normalize_document_for_chunking(document_text)
             child_chunks, parent_chunks_obj = chunker.chunk_markdown_with_parents(document_text)
             child_texts = [c.text for c in child_chunks]
             # Each child knows its parent's index in parent_chunks_obj —

--- a/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
@@ -17,6 +17,7 @@ import hmac
 import json
 import time
 from datetime import UTC, datetime
+from urllib.parse import quote
 
 import asyncpg
 import httpx
@@ -57,6 +58,20 @@ _background_tasks: set = set()  # Prevents fire-and-forget tasks from being GC'd
 
 logger = structlog.get_logger()
 router = APIRouter()
+
+
+def docs_source_extra(gitea_repo: str, kb_slug: str, path: str) -> dict[str, str]:
+    """Build public Docs provenance for pages stored in a tenant Gitea repo."""
+    org_part = gitea_repo.split("/", 1)[0] if "/" in gitea_repo else ""
+    if not org_part.startswith("org-"):
+        return {}
+    org_slug = org_part[4:]
+    page_slug = path.removesuffix(".md")
+    encoded_slug = "/".join(quote(part) for part in page_slug.split("/") if part)
+    if not org_slug or not encoded_slug:
+        return {}
+    source_url = f"https://{org_slug}.getklai.com/docs/{quote(kb_slug)}/{encoded_slug}"
+    return {"source_url": source_url, "source_ref": source_url}
 
 
 def _verify_internal_secret(request: Request) -> None:
@@ -283,8 +298,15 @@ async def ingest_document(conn: asyncpg.Connection, req: IngestRequest) -> dict:
                 "chunks": 0,
             }
 
-    # Early exit if content is unchanged since last ingest
-    content_hash = req.content_hash or hashlib.sha256(req.content.encode()).hexdigest()
+    # Early exit if indexable content is unchanged since last ingest. Docs pages
+    # are stored as BlockNote JSON for editor fidelity; hash the normalized
+    # chunking input so deploying converter fixes forces one clean re-index.
+    indexable_content = (
+        req.content
+        if req.skip_chunking
+        else chunker.normalize_document_for_chunking(req.content)
+    )
+    content_hash = req.content_hash or hashlib.sha256(indexable_content.encode()).hexdigest()
     stored_hash = await pg_store.get_active_content_hash(conn, req.org_id, req.kb_slug, req.path)
     if stored_hash is not None and stored_hash == content_hash:
         logger.info(
@@ -320,7 +342,7 @@ async def ingest_document(conn: asyncpg.Connection, req: IngestRequest) -> dict:
         # retrieval-api falls through to child text when parent_chunk_id
         # is absent (REQ-3).
         chunks, parents = chunker.chunk_markdown_with_parents(
-            req.content,
+            indexable_content,
             child_size=chunk_size,
             child_overlap=settings.chunk_overlap,
         )
@@ -342,8 +364,8 @@ async def ingest_document(conn: asyncpg.Connection, req: IngestRequest) -> dict:
 
     vectors = await embedder.embed(texts)
 
-    title = _extract_title(req.content, req.path)
-    kf = _parse_knowledge_fields(req.content, req.source_type, req.allowed_assertion_modes)
+    title = _extract_title(indexable_content, req.path)
+    kf = _parse_knowledge_fields(indexable_content, req.source_type, req.allowed_assertion_modes)
 
     # Apply synthesis_depth override from adapter if provided
     if req.synthesis_depth is not None:
@@ -353,7 +375,7 @@ async def ingest_document(conn: asyncpg.Connection, req: IngestRequest) -> dict:
     # Uses klai-fast, 15s timeout, returns [] on failure (non-fatal).
     content_label = await generate_content_label(
         title=title,
-        content_preview=req.content,
+        content_preview=indexable_content,
     )
 
     # Taxonomy classification (SPEC-KB-022 R1) — multi-label, one call per document.
@@ -370,7 +392,7 @@ async def ingest_document(conn: asyncpg.Connection, req: IngestRequest) -> dict:
             if centroids:
                 from knowledge_ingest import embedder as _embedder
 
-                doc_vectors = await _embedder.embed([req.content[:512]])
+                doc_vectors = await _embedder.embed([indexable_content[:512]])
                 doc_vec = doc_vectors[0] if doc_vectors else None
                 if doc_vec is not None:
                     centroid_result = classify_by_centroid(
@@ -400,13 +422,13 @@ async def ingest_document(conn: asyncpg.Connection, req: IngestRequest) -> dict:
         if not centroid_matched:
             matched_nodes, llm_tags = await classify_document(
                 title=title,
-                content_preview=req.content,
+                content_preview=indexable_content,
                 taxonomy_nodes=taxonomy_nodes,
             )
             taxonomy_node_ids = [node_id for node_id, _conf in matched_nodes]
 
     # Merge frontmatter tags + LLM-suggested tags (frontmatter has priority, dedup)
-    frontmatter_meta = _extract_frontmatter_metadata(req.content)
+    frontmatter_meta = _extract_frontmatter_metadata(indexable_content)
     frontmatter_tags: list[str] = frontmatter_meta.get("tags", [])
     if isinstance(frontmatter_tags, list):
         seen: set[str] = set()
@@ -439,8 +461,8 @@ async def ingest_document(conn: asyncpg.Connection, req: IngestRequest) -> dict:
     # the artifact row so rebuild_kb can replay against the original
     # source instead of reconstructing from Qdrant chunks. Bounded by
     # the same ingest-content limits the rest of the pipeline observes.
-    if req.content:
-        pg_extra["document_text"] = req.content
+    if indexable_content:
+        pg_extra["document_text"] = indexable_content
 
     artifact_id = await pg_store.create_artifact(
         conn,
@@ -492,8 +514,8 @@ async def ingest_document(conn: asyncpg.Connection, req: IngestRequest) -> dict:
     # chunk-overlap leaves duplication on boundaries). Stored on extra
     # JSONB to avoid a schema migration; size is bounded by the same
     # ingest limits the rest of the pipeline observes.
-    if req.content:
-        extra_payload["document_text"] = req.content
+    if indexable_content:
+        extra_payload["document_text"] = indexable_content
     if req.source_type:
         extra_payload["source_type"] = req.source_type
     if req.source_connector_id:
@@ -615,7 +637,7 @@ async def ingest_document(conn: asyncpg.Connection, req: IngestRequest) -> dict:
             queueing_lock=f"graphiti:{artifact_id}",
         ).defer_async(
             artifact_id=artifact_id,
-            document_text=req.content,
+            document_text=indexable_content,
             org_id=req.org_id,
             content_type=req.content_type,
             belief_time_start=kf["belief_time_start"],
@@ -825,6 +847,7 @@ async def gitea_webhook(request: Request) -> dict:
                 source_type="docs",
                 content_type="kb_article",
                 user_id=webhook_user_id,
+                extra=docs_source_extra(full_name, kb_slug, path),
             )
             try:
                 async with tenant_scoped_connection(org_id) as conn:
@@ -1139,6 +1162,7 @@ async def bulk_sync_kb_route(request: Request, req: BulkSyncRequest) -> dict:
                 content=content,
                 source_type="docs",
                 content_type="kb_article",
+                extra=docs_source_extra(req.gitea_repo, req.kb_slug, path),
             )
             try:
                 await ingest_document(conn, ingest_req)

--- a/klai-knowledge-ingest/tests/test_chunker_parent_child.py
+++ b/klai-knowledge-ingest/tests/test_chunker_parent_child.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import json
+
 from knowledge_ingest.chunker import (
     CHILD_CHUNK_SIZE_DEFAULT,
     PARENT_CHUNK_SIZE_DEFAULT,
     Chunk,
     ParentChunk,
     chunk_markdown_with_parents,
+    normalize_document_for_chunking,
 )
 
 # A short document that fits in one parent — exercises the trivial case.
@@ -121,6 +124,47 @@ def test_frontmatter_is_stripped_from_chunks() -> None:
         assert "tags: [crm, voys]" not in c.text
     for p in parents:
         assert "title: Test" not in p.text
+
+
+def test_blocknote_json_is_normalized_before_chunking() -> None:
+    blocks = [
+        {
+            "type": "paragraph",
+            "content": [
+                {"type": "text", "text": "User management lives under ", "styles": {}},
+                {"type": "text", "text": "Admin > Users", "styles": {"bold": True}},
+                {"type": "text", "text": ".", "styles": {}},
+            ],
+            "children": [],
+        },
+        {
+            "type": "heading",
+            "props": {"level": 2},
+            "content": [{"type": "text", "text": "Invite a colleague", "styles": {}}],
+            "children": [],
+        },
+        {
+            "type": "numberedListItem",
+            "content": [{"type": "text", "text": "Click Invite.", "styles": {}}],
+            "children": [],
+        },
+    ]
+    content = (
+        "---\n"
+        "title: Invite people\n"
+        "---\n\n"
+        f"{json.dumps(blocks)}"
+    )
+
+    normalized = normalize_document_for_chunking(content)
+    children, parents = chunk_markdown_with_parents(normalized)
+    combined = "\n\n".join([*(c.text for c in children), *(p.text for p in parents)])
+
+    assert "## Invite a colleague" in normalized
+    assert "User management lives under **Admin > Users**." in combined
+    assert "Invite a colleague" in combined
+    assert "1. Click Invite." in combined
+    assert '"type":"paragraph"' not in combined
 
 
 def test_position_field_is_zero_indexed_and_monotonic() -> None:

--- a/klai-knowledge-ingest/tests/test_ingest_debounce.py
+++ b/klai-knowledge-ingest/tests/test_ingest_debounce.py
@@ -17,6 +17,7 @@ import json
 import logging
 import sys
 import types
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -116,6 +117,15 @@ def webhook_client(mock_pool):
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
+
+def test_docs_source_extra_builds_public_reader_url():
+    from knowledge_ingest.routes.ingest import docs_source_extra
+
+    assert docs_source_extra("org-getklai/klai-help", "klai-help", "users/invite people.md") == {
+        "source_url": "https://getklai.getklai.com/docs/klai-help/users/invite%20people",
+        "source_ref": "https://getklai.getklai.com/docs/klai-help/users/invite%20people",
+    }
 
 
 def test_webhook_defers_debounced_task(webhook_client):
@@ -263,6 +273,12 @@ async def test_ingest_from_gitea_task_fetches_latest_content():
     """ingest_from_gitea must call _fetch_gitea_file at execution time, not use queued content."""
     mock_fetch = AsyncMock(return_value="# Latest content\nFresh text")
     mock_ingest = AsyncMock(return_value={"status": "ok", "chunks": 1})
+    mock_conn = MagicMock()
+
+    @asynccontextmanager
+    async def fake_tenant_conn(org_id: str):
+        assert org_id == "org1"
+        yield mock_conn
 
     with (
         patch(
@@ -272,6 +288,10 @@ async def test_ingest_from_gitea_task_fetches_latest_content():
         patch(
             "knowledge_ingest.routes.ingest.ingest_document",
             mock_ingest,
+        ),
+        patch(
+            "knowledge_ingest.db.tenant_scoped_connection",
+            fake_tenant_conn,
         ),
     ):
         from knowledge_ingest.ingest_tasks import register_ingest_tasks
@@ -300,6 +320,11 @@ async def test_ingest_from_gitea_task_fetches_latest_content():
 
     mock_fetch.assert_called_once_with("org-myslug/kb", "docs/page.md")
     mock_ingest.assert_called_once()
-    req_arg = mock_ingest.call_args.args[0]
+    conn_arg, req_arg = mock_ingest.call_args.args
+    assert conn_arg is mock_conn
     assert req_arg.content == "# Latest content\nFresh text"
     assert req_arg.org_id == "org1"
+    assert req_arg.extra == {
+        "source_url": "https://myslug.getklai.com/docs/kb/docs/page",
+        "source_ref": "https://myslug.getklai.com/docs/kb/docs/page",
+    }


### PR DESCRIPTION
## Summary
- normalize BlockNote JSON docs pages to Markdown-like text before chunking, embedding, enrichment, and rebuilds
- attach public Docs reader URLs to Gitea-backed docs sources so widget answers have citable sources
- fix the debounced Gitea ingest path to call `ingest_document` with a tenant-scoped DB connection

## Root Cause
Docs pages are stored in Gitea as BlockNote JSON for editor round-tripping, but knowledge-ingest was indexing that JSON directly. Retrieval could find the right article, yet the model/citation layer received noisy JSON chunks and no `source_url`, so the widget returned the fallback "not enough knowledge sources" answer.

## Validation
- `uv run ruff check knowledge_ingest/chunker.py knowledge_ingest/routes/ingest.py knowledge_ingest/ingest_tasks.py knowledge_ingest/enrichment_tasks.py knowledge_ingest/rebuild_tasks.py tests/test_chunker_parent_child.py tests/test_ingest_debounce.py`
- `uv run pytest tests/test_chunker_parent_child.py tests/test_ingest_content_hash_dedup.py tests/test_ingest_debounce.py`
- `git diff --check`
