### PR TITLE
refactor(ingest): isolate docs document normalization

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/blocknote_markdown.py
+++ b/klai-knowledge-ingest/knowledge_ingest/blocknote_markdown.py
@@ -1,0 +1,267 @@
+"""BlockNote JSON to Markdown rendering for knowledge indexing.
+
+Docs pages are stored in Gitea as BlockNote JSON so the editor can round-trip
+its native schema. Retrieval needs readable, mostly-Markdown text instead.
+This module intentionally supports the block and inline shapes we index today
+and degrades unknown blocks to their rendered children.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+JsonObject = dict[str, Any]
+
+_LIST_BLOCK_TYPES = {"bulletListItem", "numberedListItem", "checkListItem"}
+_KNOWN_BLOCK_TYPES = {
+    "paragraph",
+    "heading",
+    *_LIST_BLOCK_TYPES,
+    "codeBlock",
+    "quote",
+    "table",
+    "image",
+    "file",
+}
+
+
+def blocknote_json_to_markdown(body: str) -> str | None:
+    """Return Markdown text if ``body`` is a BlockNote JSON array."""
+    trimmed = body.strip()
+    if not trimmed.startswith("["):
+        return None
+    try:
+        blocks = json.loads(trimmed)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(blocks, list):
+        return None
+    if not blocks:
+        return ""
+    if not all(isinstance(block, dict) and _looks_like_blocknote_block(block) for block in blocks):
+        return None
+    return _render_blocks(blocks).strip()
+
+
+def _looks_like_blocknote_block(block: JsonObject) -> bool:
+    block_type = block.get("type")
+    content = block.get("content")
+    children = block.get("children")
+    props = block.get("props")
+
+    if block_type is not None and not isinstance(block_type, str):
+        return False
+    if children is not None and not isinstance(children, list):
+        return False
+    if props is not None and not isinstance(props, dict):
+        return False
+    if block_type in _KNOWN_BLOCK_TYPES:
+        return True
+    return isinstance(content, (str, list, dict)) or isinstance(children, list)
+
+
+def _render_blocks(blocks: list[JsonObject], depth: int = 0) -> str:
+    rendered: list[str] = []
+    index = 0
+    while index < len(blocks):
+        block = blocks[index]
+        block_type = block.get("type")
+        if block_type in _LIST_BLOCK_TYPES:
+            items: list[str] = []
+            number = 1
+            while index < len(blocks) and blocks[index].get("type") == block_type:
+                items.append(_render_list_item(blocks[index], depth, number))
+                number += 1
+                index += 1
+            rendered.append("\n".join(item for item in items if item))
+            continue
+
+        block_text = _render_block(block, depth)
+        if block_text:
+            rendered.append(block_text)
+        index += 1
+    return "\n\n".join(rendered)
+
+
+def _render_block(block: JsonObject, depth: int) -> str:
+    block_type = block.get("type")
+    content = block.get("content")
+    text = "" if _is_table_content(content) else _render_inline_content(content)
+    rendered_children = _render_children(block, depth)
+
+    if block_type == "heading":
+        level = _heading_level(block.get("props"))
+        primary = f"{'#' * level} {text}".strip()
+    elif block_type == "codeBlock":
+        language = _code_language(block.get("props"))
+        primary = f"```{language}\n{_extract_inline_plain_text(content)}\n```"
+    elif block_type == "quote":
+        primary = "\n".join(f"> {line}" for line in text.splitlines())
+    elif block_type == "table" and _is_table_content(content):
+        primary = _render_table(content)
+    else:
+        primary = text
+
+    if primary and rendered_children:
+        return f"{primary}\n\n{rendered_children}"
+    return primary or rendered_children
+
+
+def _render_children(block: JsonObject, depth: int) -> str:
+    children = block.get("children")
+    if isinstance(children, list) and all(isinstance(child, dict) for child in children):
+        return _render_blocks(children, depth + 1)
+    return ""
+
+
+def _heading_level(props: object) -> int:
+    if not isinstance(props, dict):
+        return 2
+    level = props.get("level")
+    return max(1, min(level, 6)) if isinstance(level, int) else 2
+
+
+def _code_language(props: object) -> str:
+    if not isinstance(props, dict):
+        return ""
+    language = props.get("language")
+    return language if isinstance(language, str) else ""
+
+
+def _render_list_item(block: JsonObject, depth: int, number: int) -> str:
+    block_type = block.get("type")
+    indent = "  " * depth
+    text = _render_inline_content(block.get("content"))
+    if block_type == "numberedListItem":
+        marker = f"{number}."
+    elif block_type == "checkListItem":
+        props = block.get("props") if isinstance(block.get("props"), dict) else {}
+        marker = "- [x]" if props.get("checked") else "- [ ]"
+    else:
+        marker = "-"
+    line = f"{indent}{marker} {text}".rstrip()
+    rendered_children = _render_children(block, depth)
+    if rendered_children:
+        return f"{line}\n{rendered_children}"
+    return line
+
+
+def _render_inline_content(content: object) -> str:
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    return "".join(_render_inline_item(item) for item in content)
+
+
+def _render_inline_item(item: object) -> str:
+    if isinstance(item, str):
+        return item
+    if not isinstance(item, dict):
+        return ""
+
+    item_type = item.get("type")
+    if item_type == "text":
+        return _apply_inline_styles(str(item.get("text") or ""), item.get("styles"))
+    if item_type == "link":
+        label = _render_inline_content(item.get("content"))
+        href = _link_href(item)
+        return f"[{label}]({href})" if href and label else label
+    if item_type == "wikilink":
+        props = item.get("props") if isinstance(item.get("props"), dict) else {}
+        return str(props.get("title") or props.get("pageId") or "")
+    return ""
+
+
+def _link_href(item: JsonObject) -> str | None:
+    href = item.get("href")
+    if isinstance(href, str) and href.strip():
+        return href.strip()
+    props = item.get("props")
+    if isinstance(props, dict):
+        url = props.get("url")
+        if isinstance(url, str) and url.strip():
+            return url.strip()
+    return None
+
+
+def _apply_inline_styles(text: str, styles: object) -> str:
+    if not text or not isinstance(styles, dict):
+        return text
+    leading = re.match(r"^\s*", text).group(0)
+    trailing = re.search(r"\s*$", text).group(0)
+    core = text[len(leading) : len(text) - len(trailing) if trailing else len(text)]
+    if not core:
+        return text
+    if styles.get("code"):
+        escaped_core = core.replace("`", "\\`")
+        core = f"`{escaped_core}`"
+    if styles.get("bold"):
+        core = f"**{core}**"
+    if styles.get("italic"):
+        core = f"_{core}_"
+    if styles.get("strike"):
+        core = f"~~{core}~~"
+    return f"{leading}{core}{trailing}"
+
+
+def _extract_inline_plain_text(content: object) -> str:
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for item in content:
+        if isinstance(item, str):
+            parts.append(item)
+        elif isinstance(item, dict):
+            if item.get("type") == "text":
+                parts.append(str(item.get("text") or ""))
+            elif item.get("type") == "link":
+                parts.append(_extract_inline_plain_text(item.get("content")))
+            elif item.get("type") == "wikilink":
+                props = item.get("props") if isinstance(item.get("props"), dict) else {}
+                parts.append(str(props.get("title") or ""))
+    return "".join(parts)
+
+
+def _is_table_content(content: object) -> bool:
+    return (
+        isinstance(content, dict)
+        and content.get("type") == "tableContent"
+        and isinstance(content.get("rows"), list)
+    )
+
+
+def _table_cell_content(cell: object) -> object:
+    if isinstance(cell, list):
+        return cell
+    if isinstance(cell, dict):
+        return cell.get("content")
+    return None
+
+
+def _render_table(content: JsonObject) -> str:
+    rows = content.get("rows")
+    if not isinstance(rows, list) or not rows:
+        return ""
+    parsed_rows: list[list[str]] = []
+    width = 0
+    for row in rows:
+        if not isinstance(row, dict) or not isinstance(row.get("cells"), list):
+            continue
+        cells = [
+            _render_inline_content(_table_cell_content(cell)).replace("\n", " ").strip()
+            for cell in row["cells"]
+        ]
+        parsed_rows.append(cells)
+        width = max(width, len(cells))
+    if not parsed_rows or width == 0:
+        return ""
+    normalized = [row + [""] * (width - len(row)) for row in parsed_rows]
+    lines = [f"| {' | '.join(cell or ' ' for cell in normalized[0])} |"]
+    lines.append(f"|{' --- |' * width}")
+    lines.extend(f"| {' | '.join(cell or ' ' for cell in row)} |" for row in normalized[1:])
+    return "\n".join(lines)

--- a/klai-knowledge-ingest/knowledge_ingest/chunker.py
+++ b/klai-knowledge-ingest/knowledge_ingest/chunker.py
@@ -11,9 +11,10 @@ narrative context. The legacy chunk_markdown() entry point is preserved
 for callers that don't yet need parents.
 """
 
-import json
 import re
 from dataclasses import dataclass, field
+
+from knowledge_ingest.document_normalizer import split_frontmatter
 
 
 @dataclass
@@ -40,257 +41,6 @@ class ParentChunk:
     char_start: int
     position: int  # 0-based ordering within the document
     child_indices: list[int] = field(default_factory=list)
-
-
-def _strip_frontmatter(text: str) -> tuple[str, str]:
-    """Return (frontmatter_block, body). frontmatter_block may be empty."""
-    if text.startswith("---"):
-        end = text.find("\n---", 3)
-        if end != -1:
-            return text[: end + 4], text[end + 4 :].lstrip("\n")
-    return "", text
-
-
-def normalize_document_for_chunking(content: str) -> str:
-    """Return Markdown-like text suitable for chunking and embedding.
-
-    Docs pages are stored losslessly as BlockNote JSON in Gitea so the editor
-    can round-trip custom blocks. The knowledge pipeline, however, needs
-    readable text. Convert a BlockNote JSON body to Markdown while preserving
-    YAML frontmatter; legacy Markdown content passes through unchanged.
-    """
-    frontmatter, body = _strip_frontmatter(content)
-    converted = _blocknote_json_to_markdown(body)
-    if converted is None:
-        return content
-    if frontmatter:
-        return f"{frontmatter}\n\n{converted}".rstrip()
-    return converted
-
-
-def _blocknote_json_to_markdown(body: str) -> str | None:
-    trimmed = body.strip()
-    if not trimmed.startswith("["):
-        return None
-    try:
-        blocks = json.loads(trimmed)
-    except json.JSONDecodeError:
-        return None
-    if (
-        not isinstance(blocks, list)
-        or not blocks
-        or not all(isinstance(b, dict) and _looks_like_blocknote_block(b) for b in blocks)
-    ):
-        return None
-    return _render_blocknote_blocks(blocks).strip()
-
-
-def _looks_like_blocknote_block(block: dict) -> bool:
-    block_type = block.get("type")
-    content = block.get("content")
-    children = block.get("children")
-    if block_type is not None and not isinstance(block_type, str):
-        return False
-    if children is not None and not isinstance(children, list):
-        return False
-    if block_type in {
-        "paragraph",
-        "heading",
-        "bulletListItem",
-        "numberedListItem",
-        "checkListItem",
-        "codeBlock",
-        "quote",
-        "table",
-        "image",
-        "file",
-    }:
-        return True
-    return isinstance(content, (str, list, dict)) or isinstance(children, list)
-
-
-def _render_blocknote_blocks(blocks: list[dict], depth: int = 0) -> str:
-    rendered: list[str] = []
-    i = 0
-    while i < len(blocks):
-        block = blocks[i]
-        block_type = block.get("type")
-        if block_type in {"bulletListItem", "numberedListItem", "checkListItem"}:
-            items: list[str] = []
-            number = 1
-            while i < len(blocks) and blocks[i].get("type") == block_type:
-                items.append(_render_blocknote_list_item(blocks[i], depth, number))
-                number += 1
-                i += 1
-            rendered.append("\n".join(item for item in items if item))
-            continue
-
-        block_text = _render_blocknote_block(block, depth)
-        if block_text:
-            rendered.append(block_text)
-        i += 1
-    return "\n\n".join(rendered)
-
-
-def _render_blocknote_block(block: dict, depth: int) -> str:
-    block_type = block.get("type")
-    content = block.get("content")
-    text = "" if _is_table_content(content) else _render_inline_content(content)
-    children = block.get("children")
-    rendered_children = (
-        _render_blocknote_blocks(children, depth + 1)
-        if isinstance(children, list) and all(isinstance(c, dict) for c in children)
-        else ""
-    )
-
-    if block_type == "heading":
-        props = block.get("props") if isinstance(block.get("props"), dict) else {}
-        level = props.get("level")
-        if not isinstance(level, int):
-            level = 2
-        primary = f"{'#' * max(1, min(level, 6))} {text}".strip()
-    elif block_type == "codeBlock":
-        props = block.get("props") if isinstance(block.get("props"), dict) else {}
-        language = props.get("language")
-        language = language if isinstance(language, str) else ""
-        primary = f"```{language}\n{_extract_inline_plain_text(content)}\n```"
-    elif block_type == "quote":
-        primary = "\n".join(f"> {line}" for line in text.splitlines())
-    elif block_type == "table" and _is_table_content(content):
-        primary = _render_blocknote_table(content)
-    else:
-        primary = text
-
-    if primary and rendered_children:
-        return f"{primary}\n\n{rendered_children}"
-    return primary or rendered_children
-
-
-def _render_blocknote_list_item(block: dict, depth: int, number: int) -> str:
-    block_type = block.get("type")
-    indent = "  " * depth
-    text = _render_inline_content(block.get("content"))
-    if block_type == "numberedListItem":
-        marker = f"{number}."
-    elif block_type == "checkListItem":
-        props = block.get("props") if isinstance(block.get("props"), dict) else {}
-        marker = "- [x]" if props.get("checked") else "- [ ]"
-    else:
-        marker = "-"
-    line = f"{indent}{marker} {text}".rstrip()
-    children = block.get("children")
-    if isinstance(children, list) and all(isinstance(c, dict) for c in children):
-        rendered_children = _render_blocknote_blocks(children, depth + 1)
-        if rendered_children:
-            return f"{line}\n{rendered_children}"
-    return line
-
-
-def _render_inline_content(content: object) -> str:
-    if isinstance(content, str):
-        return content
-    if not isinstance(content, list):
-        return ""
-    return "".join(_render_inline_item(item) for item in content)
-
-
-def _render_inline_item(item: object) -> str:
-    if isinstance(item, str):
-        return item
-    if not isinstance(item, dict):
-        return ""
-
-    item_type = item.get("type")
-    if item_type == "text":
-        return _apply_inline_styles(str(item.get("text") or ""), item.get("styles"))
-    if item_type == "link":
-        label = _render_inline_content(item.get("content"))
-        href = item.get("href")
-        return f"[{label}]({href})" if isinstance(href, str) and href.strip() else label
-    if item_type == "wikilink":
-        props = item.get("props") if isinstance(item.get("props"), dict) else {}
-        return str(props.get("title") or props.get("pageId") or "")
-    return ""
-
-
-def _apply_inline_styles(text: str, styles: object) -> str:
-    if not text or not isinstance(styles, dict):
-        return text
-    leading = re.match(r"^\s*", text).group(0)
-    trailing = re.search(r"\s*$", text).group(0)
-    core = text[len(leading) : len(text) - len(trailing) if trailing else len(text)]
-    if not core:
-        return text
-    if styles.get("code"):
-        escaped_core = core.replace("`", "\\`")
-        core = f"`{escaped_core}`"
-    if styles.get("bold"):
-        core = f"**{core}**"
-    if styles.get("italic"):
-        core = f"_{core}_"
-    if styles.get("strike"):
-        core = f"~~{core}~~"
-    return f"{leading}{core}{trailing}"
-
-
-def _extract_inline_plain_text(content: object) -> str:
-    if isinstance(content, str):
-        return content
-    if not isinstance(content, list):
-        return ""
-    parts: list[str] = []
-    for item in content:
-        if isinstance(item, str):
-            parts.append(item)
-        elif isinstance(item, dict):
-            if item.get("type") == "text":
-                parts.append(str(item.get("text") or ""))
-            elif item.get("type") == "link":
-                parts.append(_extract_inline_plain_text(item.get("content")))
-            elif item.get("type") == "wikilink":
-                props = item.get("props") if isinstance(item.get("props"), dict) else {}
-                parts.append(str(props.get("title") or ""))
-    return "".join(parts)
-
-
-def _is_table_content(content: object) -> bool:
-    return (
-        isinstance(content, dict)
-        and content.get("type") == "tableContent"
-        and isinstance(content.get("rows"), list)
-    )
-
-
-def _table_cell_content(cell: object) -> object:
-    if isinstance(cell, list):
-        return cell
-    if isinstance(cell, dict):
-        return cell.get("content")
-    return None
-
-
-def _render_blocknote_table(content: dict) -> str:
-    rows = content.get("rows")
-    if not isinstance(rows, list) or not rows:
-        return ""
-    parsed_rows: list[list[str]] = []
-    width = 0
-    for row in rows:
-        if not isinstance(row, dict) or not isinstance(row.get("cells"), list):
-            continue
-        cells = [
-            _render_inline_content(_table_cell_content(cell)).replace("\n", " ").strip()
-            for cell in row["cells"]
-        ]
-        parsed_rows.append(cells)
-        width = max(width, len(cells))
-    if not parsed_rows or width == 0:
-        return ""
-    normalized = [row + [""] * (width - len(row)) for row in parsed_rows]
-    lines = [f"| {' | '.join(cell or ' ' for cell in normalized[0])} |"]
-    lines.append(f"|{' --- |' * width}")
-    lines.extend(f"| {' | '.join(cell or ' ' for cell in row)} |" for row in normalized[1:])
-    return "\n".join(lines)
 
 
 def _find_code_block_ranges(text: str) -> list[tuple[int, int]]:
@@ -409,7 +159,7 @@ def _split_by_size(text: str, size: int, overlap: int) -> list[str]:
 
 def chunk_markdown(content: str, chunk_size: int = 1500, overlap: int = 200) -> list[Chunk]:
     """Chunk markdown content into retrieval-ready pieces."""
-    _, body = _strip_frontmatter(content)
+    _, body = split_frontmatter(content)
     sections = _split_by_headings(body) if body.strip() else []
 
     if not sections:
@@ -471,7 +221,7 @@ def chunk_markdown_with_parents(
     Section boundaries are preserved: a parent never spans two markdown
     headings (children inside a section all share that section's parent).
     """
-    _, body = _strip_frontmatter(content)
+    _, body = split_frontmatter(content)
     sections = _split_by_headings(body) if body.strip() else []
 
     if not sections:

--- a/klai-knowledge-ingest/knowledge_ingest/docs_provenance.py
+++ b/klai-knowledge-ingest/knowledge_ingest/docs_provenance.py
@@ -1,0 +1,48 @@
+"""Public provenance helpers for Docs pages stored in tenant Gitea repos."""
+
+from __future__ import annotations
+
+from urllib.parse import quote
+
+_GITEA_ORG_PREFIX = "org-"
+_DOCS_PUBLIC_DOMAIN = "getklai.com"
+
+
+def build_docs_source_extra(gitea_repo: str, kb_slug: str, path: str) -> dict[str, str]:
+    """Build source metadata for a Docs page.
+
+    Gitea repos are named ``org-{tenant_slug}/{kb_slug}``; the public reader
+    lives at ``https://{tenant_slug}.getklai.com/docs/{kb_slug}/{page}``.
+    """
+    source_url = build_docs_source_url(gitea_repo, kb_slug, path)
+    if source_url is None:
+        return {}
+    return {"source_url": source_url, "source_ref": source_url}
+
+
+def build_docs_source_url(gitea_repo: str, kb_slug: str, path: str) -> str | None:
+    org_slug = _tenant_slug_from_repo(gitea_repo)
+    page_slug = _page_slug_from_path(path)
+    if org_slug is None or page_slug is None:
+        return None
+    return (
+        f"https://{org_slug}.{_DOCS_PUBLIC_DOMAIN}/docs/"
+        f"{quote(kb_slug, safe='')}/{_quote_path(page_slug)}"
+    )
+
+
+def _tenant_slug_from_repo(gitea_repo: str) -> str | None:
+    owner = gitea_repo.split("/", 1)[0] if "/" in gitea_repo else ""
+    if not owner.startswith(_GITEA_ORG_PREFIX):
+        return None
+    org_slug = owner.removeprefix(_GITEA_ORG_PREFIX).strip()
+    return org_slug or None
+
+
+def _page_slug_from_path(path: str) -> str | None:
+    page_slug = path.removesuffix(".md").strip("/")
+    return page_slug or None
+
+
+def _quote_path(path: str) -> str:
+    return "/".join(quote(part, safe="") for part in path.split("/") if part)

--- a/klai-knowledge-ingest/knowledge_ingest/document_normalizer.py
+++ b/klai-knowledge-ingest/knowledge_ingest/document_normalizer.py
@@ -1,0 +1,29 @@
+"""Normalize source document bodies before chunking and embedding."""
+
+from __future__ import annotations
+
+from knowledge_ingest.blocknote_markdown import blocknote_json_to_markdown
+
+
+def split_frontmatter(text: str) -> tuple[str, str]:
+    """Return ``(frontmatter_block, body)``; frontmatter may be empty."""
+    if text.startswith("---"):
+        end = text.find("\n---", 3)
+        if end != -1:
+            return text[: end + 4], text[end + 4 :].lstrip("\n")
+    return "", text
+
+
+def normalize_document_for_chunking(content: str) -> str:
+    """Return Markdown-like text suitable for chunking and embedding.
+
+    Legacy Markdown passes through unchanged. Docs pages stored as BlockNote
+    JSON are rendered to Markdown-like text while preserving YAML frontmatter.
+    """
+    frontmatter, body = split_frontmatter(content)
+    converted = blocknote_json_to_markdown(body)
+    if converted is None:
+        return content
+    if frontmatter:
+        return f"{frontmatter}\n\n{converted}".rstrip()
+    return converted

--- a/klai-knowledge-ingest/knowledge_ingest/enrichment_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/enrichment_tasks.py
@@ -42,6 +42,7 @@ from knowledge_ingest import (
 )
 from knowledge_ingest.content_profiles import get_profile
 from knowledge_ingest.db import cross_org_admin_connection, tenant_scoped_connection
+from knowledge_ingest.document_normalizer import normalize_document_for_chunking
 from knowledge_ingest.enrichment_policy import enrichment_skip_reason
 
 logger = structlog.get_logger()
@@ -171,7 +172,7 @@ async def _load_and_enrich(artifact_id: str) -> None:
         return
 
     title: str = extra.get("title") or ""
-    document_text = chunker.normalize_document_for_chunking(document_text)
+    document_text = normalize_document_for_chunking(document_text)
 
     # Re-derive chunks deterministically from the current PG body so
     # Phase-2 always operates on the same content the artifact row claims

--- a/klai-knowledge-ingest/knowledge_ingest/ingest_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/ingest_tasks.py
@@ -42,10 +42,10 @@ def register_ingest_tasks(procrastinate_app: object) -> None:
         """
         # Lazy imports to avoid circular dependencies and psycopg at module level
         from knowledge_ingest.db import tenant_scoped_connection
+        from knowledge_ingest.docs_provenance import build_docs_source_extra
         from knowledge_ingest.models import IngestRequest
         from knowledge_ingest.routes.ingest import (
             _fetch_gitea_file,
-            docs_source_extra,
             ingest_document,
         )
 
@@ -64,7 +64,7 @@ def register_ingest_tasks(procrastinate_app: object) -> None:
             source_type="docs",
             content_type="kb_article",
             user_id=user_id,
-            extra=docs_source_extra(gitea_repo, kb_slug, path),
+            extra=build_docs_source_extra(gitea_repo, kb_slug, path),
         )
         async with tenant_scoped_connection(org_id) as conn:
             result = await ingest_document(conn, req)

--- a/klai-knowledge-ingest/knowledge_ingest/rebuild_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/rebuild_tasks.py
@@ -281,8 +281,9 @@ async def _rebuild_artifact(
 
             # Step 1: Re-chunk with parent-child chunking (SPEC-RAG-PARENT-CHILD-001).
             from knowledge_ingest import chunker
+            from knowledge_ingest.document_normalizer import normalize_document_for_chunking
 
-            document_text = chunker.normalize_document_for_chunking(document_text)
+            document_text = normalize_document_for_chunking(document_text)
             child_chunks, parent_chunks_obj = chunker.chunk_markdown_with_parents(document_text)
             child_texts = [c.text for c in child_chunks]
             # Each child knows its parent's index in parent_chunks_obj —

--- a/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
@@ -17,7 +17,6 @@ import hmac
 import json
 import time
 from datetime import UTC, datetime
-from urllib.parse import quote
 
 import asyncpg
 import httpx
@@ -41,6 +40,8 @@ from knowledge_ingest.config import settings
 from knowledge_ingest.content_labeler import generate_content_label
 from knowledge_ingest.content_profiles import get_profile
 from knowledge_ingest.db import tenant_scoped_connection
+from knowledge_ingest.docs_provenance import build_docs_source_extra
+from knowledge_ingest.document_normalizer import normalize_document_for_chunking
 from knowledge_ingest.enrichment_policy import enrichment_skip_reason
 from knowledge_ingest.identity import assert_caller_identity, assert_caller_identity_tenant_only
 from knowledge_ingest.models import (
@@ -58,20 +59,6 @@ _background_tasks: set = set()  # Prevents fire-and-forget tasks from being GC'd
 
 logger = structlog.get_logger()
 router = APIRouter()
-
-
-def docs_source_extra(gitea_repo: str, kb_slug: str, path: str) -> dict[str, str]:
-    """Build public Docs provenance for pages stored in a tenant Gitea repo."""
-    org_part = gitea_repo.split("/", 1)[0] if "/" in gitea_repo else ""
-    if not org_part.startswith("org-"):
-        return {}
-    org_slug = org_part[4:]
-    page_slug = path.removesuffix(".md")
-    encoded_slug = "/".join(quote(part) for part in page_slug.split("/") if part)
-    if not org_slug or not encoded_slug:
-        return {}
-    source_url = f"https://{org_slug}.getklai.com/docs/{quote(kb_slug)}/{encoded_slug}"
-    return {"source_url": source_url, "source_ref": source_url}
 
 
 def _verify_internal_secret(request: Request) -> None:
@@ -304,7 +291,7 @@ async def ingest_document(conn: asyncpg.Connection, req: IngestRequest) -> dict:
     indexable_content = (
         req.content
         if req.skip_chunking
-        else chunker.normalize_document_for_chunking(req.content)
+        else normalize_document_for_chunking(req.content)
     )
     content_hash = req.content_hash or hashlib.sha256(indexable_content.encode()).hexdigest()
     stored_hash = await pg_store.get_active_content_hash(conn, req.org_id, req.kb_slug, req.path)
@@ -847,7 +834,7 @@ async def gitea_webhook(request: Request) -> dict:
                 source_type="docs",
                 content_type="kb_article",
                 user_id=webhook_user_id,
-                extra=docs_source_extra(full_name, kb_slug, path),
+                extra=build_docs_source_extra(full_name, kb_slug, path),
             )
             try:
                 async with tenant_scoped_connection(org_id) as conn:
@@ -1162,7 +1149,7 @@ async def bulk_sync_kb_route(request: Request, req: BulkSyncRequest) -> dict:
                 content=content,
                 source_type="docs",
                 content_type="kb_article",
-                extra=docs_source_extra(req.gitea_repo, req.kb_slug, path),
+                extra=build_docs_source_extra(req.gitea_repo, req.kb_slug, path),
             )
             try:
                 await ingest_document(conn, ingest_req)

--- a/klai-knowledge-ingest/tests/test_chunker_parent_child.py
+++ b/klai-knowledge-ingest/tests/test_chunker_parent_child.py
@@ -10,8 +10,8 @@ from knowledge_ingest.chunker import (
     Chunk,
     ParentChunk,
     chunk_markdown_with_parents,
-    normalize_document_for_chunking,
 )
+from knowledge_ingest.document_normalizer import normalize_document_for_chunking
 
 # A short document that fits in one parent — exercises the trivial case.
 _SHORT_DOC = """\

--- a/klai-knowledge-ingest/tests/test_document_normalizer.py
+++ b/klai-knowledge-ingest/tests/test_document_normalizer.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+
+from knowledge_ingest.blocknote_markdown import blocknote_json_to_markdown
+from knowledge_ingest.docs_provenance import (
+    build_docs_source_extra,
+    build_docs_source_url,
+)
+from knowledge_ingest.document_normalizer import normalize_document_for_chunking
+
+
+def test_markdown_content_passes_through_unchanged() -> None:
+    content = "---\ntitle: Plain\n---\n\n# Plain\n\nAlready markdown."
+
+    assert normalize_document_for_chunking(content) == content
+
+
+def test_blocknote_document_preserves_frontmatter_and_renders_text() -> None:
+    blocks = [
+        {
+            "type": "heading",
+            "props": {"level": 1},
+            "content": [{"type": "text", "text": "Invite people", "styles": {}}],
+            "children": [],
+        },
+        {
+            "type": "paragraph",
+            "content": [
+                {"type": "text", "text": "Open ", "styles": {}},
+                {"type": "link", "href": "https://getklai.com", "content": ["Klai"]},
+                {"type": "text", "text": ".", "styles": {}},
+            ],
+            "children": [],
+        },
+    ]
+
+    normalized = normalize_document_for_chunking(
+        "---\ntitle: Invite people\n---\n\n" + json.dumps(blocks)
+    )
+
+    assert normalized.startswith("---\ntitle: Invite people\n---")
+    assert "# Invite people" in normalized
+    assert "Open [Klai](https://getklai.com)." in normalized
+
+
+def test_blocknote_empty_document_is_not_indexed_as_json() -> None:
+    assert blocknote_json_to_markdown("[]") == ""
+
+
+def test_non_blocknote_json_is_left_to_callers() -> None:
+    assert blocknote_json_to_markdown(json.dumps([{"not": "blocknote"}])) is None
+
+
+def test_docs_provenance_builds_public_reader_url() -> None:
+    source_url = build_docs_source_url(
+        "org-getklai/klai-help",
+        "klai-help",
+        "users/invite people.md",
+    )
+
+    assert source_url == "https://getklai.getklai.com/docs/klai-help/users/invite%20people"
+    assert build_docs_source_extra("org-getklai/klai-help", "klai-help", "users/page.md") == {
+        "source_url": "https://getklai.getklai.com/docs/klai-help/users/page",
+        "source_ref": "https://getklai.getklai.com/docs/klai-help/users/page",
+    }
+
+
+def test_docs_provenance_ignores_non_tenant_repos() -> None:
+    assert build_docs_source_url("personal/klai-help", "klai-help", "users/page.md") is None
+    assert build_docs_source_extra("personal/klai-help", "klai-help", "users/page.md") == {}

--- a/klai-knowledge-ingest/tests/test_ingest_debounce.py
+++ b/klai-knowledge-ingest/tests/test_ingest_debounce.py
@@ -120,9 +120,15 @@ def webhook_client(mock_pool):
 
 
 def test_docs_source_extra_builds_public_reader_url():
-    from knowledge_ingest.routes.ingest import docs_source_extra
+    from knowledge_ingest.docs_provenance import build_docs_source_extra
 
-    assert docs_source_extra("org-getklai/klai-help", "klai-help", "users/invite people.md") == {
+    extra = build_docs_source_extra(
+        "org-getklai/klai-help",
+        "klai-help",
+        "users/invite people.md",
+    )
+
+    assert extra == {
         "source_url": "https://getklai.getklai.com/docs/klai-help/users/invite%20people",
         "source_ref": "https://getklai.getklai.com/docs/klai-help/users/invite%20people",
     }


### PR DESCRIPTION
## Summary
- move BlockNote JSON rendering out of the Markdown chunker into `blocknote_markdown.py`
- add `document_normalizer.py` as the single pre-chunking normalization entry point
- move Docs reader URL/source metadata construction into `docs_provenance.py`
- add direct regression tests for BlockNote normalization and Docs source URL generation

## Notes
This keeps the behavior from #685, but separates responsibilities so the chunker is not also a Docs/BlockNote adapter.

## Validation
- `uv run ruff check knowledge_ingest/blocknote_markdown.py knowledge_ingest/document_normalizer.py knowledge_ingest/docs_provenance.py knowledge_ingest/chunker.py knowledge_ingest/routes/ingest.py knowledge_ingest/ingest_tasks.py knowledge_ingest/enrichment_tasks.py knowledge_ingest/rebuild_tasks.py tests/test_chunker_parent_child.py tests/test_ingest_debounce.py tests/test_document_normalizer.py`
- `uv run pytest tests/test_document_normalizer.py tests/test_chunker_parent_child.py tests/test_ingest_content_hash_dedup.py tests/test_ingest_debounce.py`
- `git diff --check`
