### PR TITLE
fix: require widget jwt kid

### DIFF
--- a/klai-portal/backend/app/api/partner_dependencies.py
+++ b/klai-portal/backend/app/api/partner_dependencies.py
@@ -114,34 +114,15 @@ async def _auth_via_session_token(token: str, db: AsyncSession) -> PartnerAuthCo
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=_AUTH_ERROR)
 
     # SPEC-SEC-HYGIENE-001 REQ-24.2: signing key is HKDF-derived per tenant.
-    # New widget JWTs carry a `kid` header that selects the portal org used to
-    # derive the verification key. The header is only a key-selection hint; the
-    # verified payload's org_id is checked against the selected org below.
+    # Widget JWTs must carry a `kid` header that selects the portal org used
+    # to derive the verification key. The header is only a key-selection hint;
+    # the verified payload's org_id is checked against the selected org below.
     try:
         kid = get_unverified_session_token_key_id(token)
     except jwt.InvalidTokenError as exc:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=_AUTH_ERROR) from exc
 
-    if kid is None:
-        # Deploy-window compatibility for old in-flight JWTs minted before the
-        # `kid` header existed. Remove after one widget JWT TTL has elapsed in
-        # production. This unverified value is used only for key selection and
-        # is followed by decode_session_token() in this same function.
-        try:
-            # nosemgrep: python.jwt.security.unverified-jwt-decode.unverified-jwt-decode
-            legacy_payload = jwt.decode(token, options={"verify_signature": False})
-        except jwt.InvalidTokenError as exc:
-            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=_AUTH_ERROR) from exc
-
-        legacy_org_id = legacy_payload.get("org_id")
-        org_id_for_key = (
-            legacy_org_id
-            if isinstance(legacy_org_id, int) and not isinstance(legacy_org_id, bool) and legacy_org_id > 0
-            else None
-        )
-    else:
-        org_id_for_key = org_id_from_session_token_key_id(kid)
-
+    org_id_for_key = org_id_from_session_token_key_id(kid) if kid is not None else None
     if org_id_for_key is None:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=_AUTH_ERROR)
 

--- a/klai-portal/backend/tests/test_partner_dependencies.py
+++ b/klai-portal/backend/tests/test_partner_dependencies.py
@@ -349,13 +349,13 @@ def _make_jwt(
     )
 
 
-def _make_legacy_jwt(
+def _make_no_kid_jwt(
     wgt_id: str = "wgt_abcdef0123456789",
     org_id: int = 42,
     kb_ids: list[int] | None = None,
     tenant_slug: str = "acme",
 ) -> str:
-    """Encode a pre-kid widget session JWT for deploy-window fallback tests."""
+    """Encode a widget session JWT without a kid header."""
     from app.services.widget_auth import _derive_tenant_key
 
     payload = {
@@ -363,7 +363,7 @@ def _make_legacy_jwt(
         "org_id": org_id,
         "kb_ids": kb_ids if kb_ids is not None else [1, 2],
         "exp": int((datetime.now(UTC) + timedelta(hours=1)).timestamp()),
-        "jti": "legacy-test-jti",
+        "jti": "no-kid-test-jti",
     }
     return jwt.encode(payload, _derive_tenant_key(_TEST_WIDGET_SECRET, tenant_slug), algorithm="HS256")
 
@@ -406,8 +406,8 @@ async def test_session_token_all_kbs_valid_returns_full_scope():
 
 
 @pytest.mark.asyncio
-async def test_session_token_uses_kid_header_without_legacy_payload_decode():
-    """New JWTs must select the tenant key via kid, not unverified payload."""
+async def test_session_token_uses_kid_header_without_payload_decode():
+    """JWTs must select the tenant key via kid, not unverified payload."""
     from app.api.partner_dependencies import get_partner_key
 
     token = _make_jwt(kb_ids=[1, 2, 3])
@@ -426,7 +426,7 @@ async def test_session_token_uses_kid_header_without_legacy_payload_decode():
     def _reject_unverified_decode(*args, **kwargs):
         options = kwargs.get("options")
         if isinstance(options, dict) and options.get("verify_signature") is False:
-            raise AssertionError("legacy payload fallback should not run for kid JWTs")
+            raise AssertionError("kid JWTs must not trigger unverified payload decode")
         return original_decode(*args, **kwargs)
 
     patches = _session_patches()
@@ -446,27 +446,25 @@ async def test_session_token_uses_kid_header_without_legacy_payload_decode():
 
 
 @pytest.mark.asyncio
-async def test_session_token_without_kid_uses_legacy_fallback_during_deploy_window():
-    """Old in-flight JWTs without kid remain valid for one deploy window."""
+async def test_session_token_without_kid_is_rejected_without_payload_decode():
+    """No-kid JWTs are rejected before DB or tenant lookup."""
     from app.api.partner_dependencies import get_partner_key
 
-    token = _make_legacy_jwt(kb_ids=[1, 2])
+    token = _make_no_kid_jwt(kb_ids=[1, 2])
     db = AsyncMock()
-    setup_db(
-        db,
-        [
-            FakeResult([FakeOrg()]),
-            FakeResult([FakeWidget()]),
-            FakeResult(rows=[1, 2]),
-        ],
-    )
 
-    patches = _session_patches()
-    with patches[0], patches[1], patches[2]:
-        result = await get_partner_key(request=_make_request(token=token), db=db)
+    with (
+        patch("app.api.partner_dependencies.settings.widget_jwt_secret", _TEST_WIDGET_SECRET),
+        patch(
+            "app.api.partner_dependencies.jwt.decode",
+            side_effect=AssertionError("no-kid JWT must not trigger unverified payload decode"),
+        ),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await get_partner_key(request=_make_request(token=token), db=db)
 
-    assert result.org_id == 42
-    assert result.kb_access == {1: "read", 2: "read"}
+    assert exc.value.status_code == 401
+    db.execute.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -504,7 +502,7 @@ async def test_session_token_rejects_verified_org_mismatch_after_kid_lookup():
 
 
 @pytest.mark.asyncio
-async def test_session_token_rejects_malformed_kid_without_legacy_fallback():
+async def test_session_token_rejects_malformed_kid_without_payload_decode():
     """Malformed kid is a hard auth failure, not a reason to read payload claims."""
     from app.api.partner_dependencies import get_partner_key
     from app.services.widget_auth import _derive_tenant_key
@@ -528,7 +526,7 @@ async def test_session_token_rejects_malformed_kid_without_legacy_fallback():
         patch("app.api.partner_dependencies.settings.widget_jwt_secret", secret),
         patch(
             "app.api.partner_dependencies.jwt.decode",
-            side_effect=AssertionError("legacy fallback should not run when kid is present"),
+            side_effect=AssertionError("malformed kid must not trigger payload decode"),
         ),
     ):
         with pytest.raises(HTTPException) as exc:

--- a/klai-portal/backend/tests/test_widget_platform_unlock.py
+++ b/klai-portal/backend/tests/test_widget_platform_unlock.py
@@ -14,10 +14,12 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import jwt
 import pytest
 from fastapi import HTTPException
 
 from app.api.partner import public_bot_config, widget_config
+from app.services.widget_auth import session_token_key_id
 
 # ---------------------------------------------------------------------------
 # Shared fakes
@@ -238,16 +240,15 @@ async def test_chat_completion_returns_403_when_widgets_not_unlocked():
 
         # The function should raise 403 due to platform-unlock check
         with pytest.raises(HTTPException) as exc_info:
-            # Use a real-enough JWT that survives the unverified peek
-            import jwt as pyjwt
-
-            token = pyjwt.encode(
+            token = jwt.encode(
                 {"org_id": 42, "wgt_id": "wgt_test", "kb_ids": [1]},
-                "legacy-test-secret-at-least-32-bytes",
+                "test-widget-secret-at-least-32-bytes",
+                headers={"kid": session_token_key_id(42), "typ": "JWT"},
             )
             await _auth_via_session_token(token, db)
 
     assert exc_info.value.status_code == 403
     detail = exc_info.value.detail
+    assert isinstance(detail, dict)
     assert detail.get("error_code") == "feature_not_unlocked"
     assert detail.get("feature") == "widgets"


### PR DESCRIPTION
## Summary
- remove the temporary no-kid widget JWT fallback
- reject widget session tokens before DB/tenant lookup when the kid header is missing or malformed
- update widget auth tests for the stricter key-selection path

## Verification
- uv run pytest -q tests/test_partner_dependencies.py tests/test_widget_jwt_per_tenant.py tests/test_widget_platform_unlock.py tests/test_widget_preview_flagging.py
- uv run pytest -q tests/test_partner*.py tests/test_widget*.py
- uv run pytest -q
- uv run ruff check .
- uv run pyright
- uvx semgrep scan --config .semgrep/rules/jwt-peek-without-verify.yml klai-portal/backend/app/api/partner_dependencies.py --error