### PR TITLE
[codex] Improve Google Drive connector picker

### DIFF
--- a/klai-connector/app/adapters/google_drive.py
+++ b/klai-connector/app/adapters/google_drive.py
@@ -79,6 +79,7 @@ _GOOGLE_EXPORT_MIMES: dict[str, str] = {
 
 # Which mime types are Google-native (require export) vs binary downloads.
 _GOOGLE_NATIVE_MIMES = set(_GOOGLE_EXPORT_MIMES.keys())
+_GOOGLE_FOLDER_MIME = "application/vnd.google-apps.folder"
 
 # Fallback max_files when config omits it — keeps single-run latency bounded.
 _DEFAULT_MAX_FILES = 500
@@ -183,6 +184,11 @@ class GoogleDriveAdapter(OAuthAdapterBase, BaseAdapter):
 
         return {
             "folder_id": config.get("folder_id") or None,
+            "item_ids": [
+                str(item_id).strip()
+                for item_id in (config.get("item_ids") or [])
+                if str(item_id).strip()
+            ],
             "max_files": int(config.get("max_files") or _DEFAULT_MAX_FILES),
             "content_types": content_types,
         }
@@ -258,6 +264,8 @@ class GoogleDriveAdapter(OAuthAdapterBase, BaseAdapter):
         connector_id = str(connector.id)
         max_files: int = cfg["max_files"]
         content_types: list[str] | None = cfg.get("content_types")
+        item_ids: list[str] = cfg["item_ids"]
+        selected_item_ids = set(item_ids)
         page_token = (cursor_context or {}).get("page_token") if cursor_context else None
 
         # Build the set of allowed mimeTypes (None = all types).
@@ -275,6 +283,8 @@ class GoogleDriveAdapter(OAuthAdapterBase, BaseAdapter):
             # Client-side mimeType filter for incremental path (changes API has no q= support).
             if allowed_mimes is not None:
                 raw_files = [f for f in raw_files if f and f.get("mimeType") in allowed_mimes]
+            if selected_item_ids:
+                raw_files = [f for f in raw_files if f and f.get("id") in selected_item_ids]
             new_cursor = response.get("newStartPageToken")
             if new_cursor:
                 self._latest_page_token[connector_id] = new_cursor
@@ -284,11 +294,18 @@ class GoogleDriveAdapter(OAuthAdapterBase, BaseAdapter):
                 connector_id,
                 cfg["folder_id"],
             )
-            response = await self._list_files(
-                connector,
-                folder_id=cfg["folder_id"],
-                allowed_mimes=allowed_mimes,
-            )
+            if item_ids:
+                response = await self._get_files_by_ids(
+                    connector,
+                    file_ids=item_ids,
+                    allowed_mimes=allowed_mimes,
+                )
+            else:
+                response = await self._list_files(
+                    connector,
+                    folder_id=cfg["folder_id"],
+                    allowed_mimes=allowed_mimes,
+                )
             raw_files = list(response.get("files", []))
             # Client-side guard: the q= filter is applied in _list_files, but
             # when _list_files is mocked in tests it may return any files.
@@ -301,6 +318,8 @@ class GoogleDriveAdapter(OAuthAdapterBase, BaseAdapter):
             if not file:
                 continue
             mime = file.get("mimeType", "")
+            if mime == _GOOGLE_FOLDER_MIME:
+                continue
             size_str = file.get("size")
             try:
                 size = int(size_str) if size_str else 0
@@ -345,6 +364,44 @@ class GoogleDriveAdapter(OAuthAdapterBase, BaseAdapter):
             page_token is not None,
         )
         return refs
+
+    async def list_folders(
+        self,
+        connector: Any,
+        parent_id: str | None = None,
+    ) -> list[dict[str, object]]:
+        """List visible Drive children for the portal picker.
+
+        Returns folders plus files that match the connector's implicit content
+        type filter. ``parent_id=None`` means the user's Drive root.
+        """
+        cfg = self._extract_config(connector)
+        allowed_mimes: set[str] | None = None
+        if cfg.get("content_types"):
+            allowed_mimes = {_CONTENT_TYPE_TO_MIME[ct] for ct in cfg["content_types"]}
+
+        response = await self._list_folder_children(
+            connector,
+            parent_id=parent_id or "root",
+            allowed_mimes=allowed_mimes,
+        )
+        items: list[dict[str, object]] = []
+        for file in response.get("files", []):
+            if not file:
+                continue
+            mime = str(file.get("mimeType", ""))
+            is_folder = mime == _GOOGLE_FOLDER_MIME
+            items.append(
+                {
+                    "id": str(file.get("id") or ""),
+                    "name": str(file.get("name") or file.get("id") or ""),
+                    "kind": "folder" if is_folder else "file",
+                    # Drive does not expose child counts in files.list; the
+                    # picker lazy-loads folders when expanded.
+                    "child_count": 0,
+                }
+            )
+        return items
 
     async def fetch_document(self, ref: DocumentRef, connector: Any) -> bytes:
         """Download a single Drive file as bytes.
@@ -477,6 +534,71 @@ class GoogleDriveAdapter(OAuthAdapterBase, BaseAdapter):
         if new_start_page_token is not None:
             result["newStartPageToken"] = new_start_page_token
         return result
+
+    async def _list_folder_children(
+        self,
+        connector: Any,
+        parent_id: str,
+        allowed_mimes: set[str] | None = None,
+    ) -> dict[str, Any]:
+        """List one folder level for the portal Drive picker."""
+        token = await self.ensure_token(connector)
+        params: dict[str, Any] = {
+            "pageSize": 100,
+            "fields": _LIST_FIELDS,
+            "spaces": "drive",
+            "includeItemsFromAllDrives": "true",
+            "supportsAllDrives": "true",
+            "orderBy": "folder,name_natural",
+        }
+        base_q = f"'{parent_id}' in parents and trashed = false"
+        if allowed_mimes:
+            mime_clauses = " or ".join(f"mimeType='{m}'" for m in sorted(allowed_mimes))
+            params["q"] = f"{base_q} and (mimeType='{_GOOGLE_FOLDER_MIME}' or {mime_clauses})"
+        else:
+            params["q"] = base_q
+
+        all_files: list[dict[str, Any]] = []
+        next_token: str | None = None
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            while True:
+                if next_token:
+                    params["pageToken"] = next_token
+                response = await client.get(
+                    _DRIVE_FILES_URL,
+                    headers={"Authorization": f"Bearer {token}"},
+                    params=params,
+                )
+                response.raise_for_status()
+                data = response.json()
+                all_files.extend(data.get("files", []))
+                next_token = data.get("nextPageToken")
+                if not next_token:
+                    break
+        return {"files": all_files}
+
+    async def _get_files_by_ids(
+        self,
+        connector: Any,
+        file_ids: list[str],
+        allowed_mimes: set[str] | None = None,
+    ) -> dict[str, Any]:
+        """Fetch a specific set of Drive files selected in the picker."""
+        token = await self.ensure_token(connector)
+        files: list[dict[str, Any]] = []
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            for file_id in file_ids:
+                response = await client.get(
+                    f"{_DRIVE_FILES_URL}/{file_id}",
+                    headers={"Authorization": f"Bearer {token}"},
+                    params={"fields": _FILE_FIELDS, "supportsAllDrives": "true"},
+                )
+                response.raise_for_status()
+                file = response.json()
+                if allowed_mimes is not None and file.get("mimeType") not in allowed_mimes:
+                    continue
+                files.append(file)
+        return {"files": files}
 
     async def _fetch_start_page_token(self, connector: Any) -> str:
         """Bootstrap a starting cursor via ``changes/startPageToken``."""

--- a/klai-connector/app/routes/connectors.py
+++ b/klai-connector/app/routes/connectors.py
@@ -215,3 +215,56 @@ async def list_ms_docs_folders(
         logger.exception("ms_docs list_folders failed for %s", connector_id)
         raise HTTPException(status_code=502, detail=f"Microsoft Graph error: {exc.response.status_code}") from exc
     return {"folders": folders}
+
+
+@router.get("/{connector_id}/google-drive/folders")
+async def list_google_drive_folders(
+    connector_id: uuid.UUID,
+    request: Request,
+    parent: str | None = None,
+) -> dict[str, list[dict[str, object]]]:
+    """List child Drive items for a Google Drive / Workspace connector.
+
+    Powers the post-OAuth picker in the portal. The endpoint accepts the
+    ``google_docs`` / ``google_sheets`` / ``google_slides`` aliases; the
+    adapter applies their content-type presets when listing files.
+    """
+    _require_portal_call(request)
+
+    portal_client = getattr(request.app.state, "portal_client", None)
+    if portal_client is None:
+        raise HTTPException(status_code=503, detail="Portal client unavailable")
+    try:
+        portal_config = await portal_client.get_connector_config(connector_id)
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 404:
+            raise HTTPException(status_code=404, detail="Connector not found") from exc
+        logger.exception("Portal config fetch failed for %s", connector_id)
+        raise HTTPException(status_code=502, detail="Portal config fetch failed") from exc
+
+    if portal_config.connector_type not in {
+        "google_drive",
+        "google_docs",
+        "google_sheets",
+        "google_slides",
+    }:
+        raise HTTPException(status_code=400, detail="Not a Google Drive connector")
+
+    registry = getattr(request.app.state, "registry", None)
+    if registry is None:
+        raise HTTPException(status_code=503, detail="Adapter registry unavailable")
+    try:
+        adapter = registry.get(portal_config.connector_type)
+    except ValueError:
+        raise HTTPException(
+            status_code=503,
+            detail="google_drive adapter not registered on this deployment",
+        ) from None
+
+    parent_id = parent.strip() if parent else None
+    try:
+        folders = await adapter.list_folders(portal_config, parent_id=parent_id)  # type: ignore[attr-defined]
+    except httpx.HTTPStatusError as exc:
+        logger.exception("google_drive list_folders failed for %s", connector_id)
+        raise HTTPException(status_code=502, detail=f"Google Drive error: {exc.response.status_code}") from exc
+    return {"folders": folders}

--- a/klai-connector/tests/adapters/test_google_drive.py
+++ b/klai-connector/tests/adapters/test_google_drive.py
@@ -194,6 +194,117 @@ async def test_list_documents_respects_max_files(
     assert len(refs) == 2
 
 
+async def test_list_documents_uses_selected_item_ids(
+    gdrive_adapter: Any,
+) -> None:
+    """When item_ids are configured, first sync fetches only those files."""
+    connector = _make_connector(
+        {
+            "access_token": "placeholder-access-value",
+            "refresh_token": "placeholder-refresh-value",
+            "item_ids": ["file-a", "file-b"],
+            "max_files": 20,
+        }
+    )
+    files = [
+        {
+            "id": "file-a",
+            "name": "A.pdf",
+            "mimeType": "application/pdf",
+            "modifiedTime": "2026-04-10T10:00:00.000Z",
+            "webViewLink": "https://drive.google.com/file/d/file-a/view",
+            "size": "100",
+        },
+        {
+            "id": "file-b",
+            "name": "B.pdf",
+            "mimeType": "application/pdf",
+            "modifiedTime": "2026-04-10T10:00:00.000Z",
+            "webViewLink": "https://drive.google.com/file/d/file-b/view",
+            "size": "100",
+        },
+    ]
+    get_files = AsyncMock(return_value=_list_response(files))
+
+    with (
+        patch.object(gdrive_adapter, "_get_files_by_ids", get_files),
+        patch.object(gdrive_adapter, "_list_files", AsyncMock()) as list_files,
+    ):
+        refs = await gdrive_adapter.list_documents(connector, cursor_context=None)
+
+    get_files.assert_awaited_once()
+    list_files.assert_not_called()
+    assert {r.ref for r in refs} == {"file-a", "file-b"}
+
+
+async def test_list_documents_incremental_filters_selected_item_ids(
+    gdrive_adapter: Any,
+) -> None:
+    """Incremental changes are ignored unless they belong to selected item_ids."""
+    connector = _make_connector(
+        {
+            "access_token": "placeholder-access-value",
+            "refresh_token": "placeholder-refresh-value",
+            "item_ids": ["file-keep"],
+        }
+    )
+    changes_response = {
+        "changes": [
+            {
+                "fileId": "file-keep",
+                "file": {
+                    "id": "file-keep",
+                    "name": "Keep.pdf",
+                    "mimeType": "application/pdf",
+                    "modifiedTime": "2026-04-12T11:00:00.000Z",
+                    "webViewLink": "https://drive.google.com/file/d/file-keep/view",
+                    "size": "100",
+                },
+            },
+            {
+                "fileId": "file-skip",
+                "file": {
+                    "id": "file-skip",
+                    "name": "Skip.pdf",
+                    "mimeType": "application/pdf",
+                    "modifiedTime": "2026-04-12T11:00:00.000Z",
+                    "webViewLink": "https://drive.google.com/file/d/file-skip/view",
+                    "size": "100",
+                },
+            },
+        ],
+        "newStartPageToken": "new-cursor-token",
+    }
+
+    with patch.object(gdrive_adapter, "_list_changes", AsyncMock(return_value=changes_response)):
+        refs = await gdrive_adapter.list_documents(connector, cursor_context={"page_token": "old"})
+
+    assert [r.ref for r in refs] == ["file-keep"]
+
+
+async def test_list_folders_returns_picker_items(gdrive_adapter: Any) -> None:
+    """Portal picker gets folders and files in the common {id,name,kind} shape."""
+    connector = _make_connector(
+        {
+            "access_token": "placeholder-access-value",
+            "refresh_token": "placeholder-refresh-value",
+        }
+    )
+    folder_mime = "application/vnd.google-apps.folder"
+    files = [
+        {"id": "folder-1", "name": "Team", "mimeType": folder_mime},
+        {"id": "file-1", "name": "Plan", "mimeType": "application/vnd.google-apps.document"},
+    ]
+
+    with patch.object(gdrive_adapter, "_list_folder_children", AsyncMock(return_value=_list_response(files))):
+        items = await gdrive_adapter.list_folders(connector)
+
+    assert items == [
+        {"id": "folder-1", "name": "Team", "kind": "folder", "child_count": 0},
+        {"id": "file-1", "name": "Plan", "kind": "file", "child_count": 0},
+    ]
+
+
 # ---------------------------------------------------------------------------
 # 4. fetch_document -- Google Doc is exported as DOCX
 # ---------------------------------------------------------------------------

--- a/klai-portal/backend/app/api/connectors.py
+++ b/klai-portal/backend/app/api/connectors.py
@@ -816,6 +816,68 @@ async def list_ms_docs_folders(
     return {"folders": folders}
 
 
+@router.get("/{connector_id}/google-drive/folders")
+async def list_google_drive_folders(
+    kb_slug: str,
+    connector_id: str,
+    parent: str | None = None,
+    perms: UserPermissions = Depends(get_caller),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, list[dict]]:
+    """List child items for a Google Drive / Workspace connector picker."""
+    org = await _load_org_or_500(db, perms.org_id)
+    kb = await _get_kb_with_owner_check(
+        kb_slug,
+        perms.user_id,
+        perms.org_id,
+        db,
+        is_platform_admin=perms.is_platform_admin,
+    )
+    result = await db.execute(
+        select(PortalConnector).where(
+            PortalConnector.id == connector_id,
+            PortalConnector.kb_id == kb.id,
+            PortalConnector.state == "active",
+        )
+    )
+    connector = result.scalar_one_or_none()
+    if connector is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Connector not found")
+    if connector.connector_type not in {
+        "google_drive",
+        "google_docs",
+        "google_sheets",
+        "google_slides",
+    }:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Not a Google Drive connector",
+        )
+
+    try:
+        folders = await klai_connector_client.list_google_drive_folders(
+            connector_id,
+            org_id=org.zitadel_org_id,
+            parent_id=parent,
+        )
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == status.HTTP_404_NOT_FOUND:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Folder not found") from exc
+        logger.exception("klai-connector google-drive folders error for %s", connector_id)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Folder picker service error",
+        ) from exc
+    except httpx.HTTPError as exc:
+        logger.exception("Failed to reach klai-connector for connector %s", connector_id)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Folder picker service unavailable",
+        ) from exc
+
+    return {"folders": folders}
+
+
 @router.get("/{connector_id}/syncs", response_model=list[SyncRunData])
 async def list_sync_runs(
     kb_slug: str,

--- a/klai-portal/backend/app/api/oauth.py
+++ b/klai-portal/backend/app/api/oauth.py
@@ -545,12 +545,12 @@ async def callback_provider(
     )
 
     # 6. Redirect back to the frontend.
-    # For first-time ms_docs connects: land on the edit page with the
+    # For first-time Drive-style connects: land on the edit page with the
     # picker auto-opened so the user can pick folders/files as a natural
     # next step of the wizard. Reconnects keep the legacy ?oauth=connected
     # redirect — there's nothing for the user to pick after a re-consent.
     kb_slug = payload.get("kb_slug", "")
-    if provider == "ms_docs" and not was_reconnect:
+    if provider in {"google_drive", "ms_docs"} and not was_reconnect:
         target = _frontend_redirect_url(f"/app/knowledge/{kb_slug}/edit-connector/{connector.id}?show=picker")
     else:
         target = _frontend_redirect_url(f"/app/knowledge/{kb_slug}/connectors?oauth=connected")

--- a/klai-portal/backend/app/api/oauth.py
+++ b/klai-portal/backend/app/api/oauth.py
@@ -71,7 +71,7 @@ def _canonical_provider(provider: str) -> str:
 # Google Drive OAuth endpoints (constants -- never secrets).
 _GOOGLE_AUTHORIZE_URL = "https://accounts.google.com/o/oauth2/v2/auth"
 _GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
-_GOOGLE_SCOPES = "https://www.googleapis.com/auth/drive.readonly"
+_GOOGLE_SCOPES = "https://www.googleapis.com/auth/drive.file"
 
 # Microsoft Graph OAuth endpoints (constants -- never secrets). SPEC-KB-MS-DOCS-001.
 # tenant_id is injected at request time from settings.ms_docs_tenant_id ("common" by default).

--- a/klai-portal/backend/app/services/klai_connector_client.py
+++ b/klai-portal/backend/app/services/klai_connector_client.py
@@ -193,5 +193,27 @@ class KlaiConnectorClient:
             folders = data.get("folders", []) if isinstance(data, dict) else []
             return folders if isinstance(folders, list) else []
 
+    async def list_google_drive_folders(
+        self,
+        connector_id: str,
+        *,
+        org_id: str,
+        parent_id: str | None = None,
+    ) -> list[dict]:
+        """List child Drive items for a Google Drive / Workspace connector."""
+        params: dict[str, str] = {}
+        if parent_id:
+            params["parent"] = parent_id
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            response = await client.get(
+                f"{settings.klai_connector_url}/api/v1/connectors/{connector_id}/google-drive/folders",
+                params=params,
+                headers=self._headers(org_id=org_id),
+            )
+            response.raise_for_status()
+            data = response.json()
+            folders = data.get("folders", []) if isinstance(data, dict) else []
+            return folders if isinstance(folders, list) else []
+
 
 klai_connector_client = KlaiConnectorClient()

--- a/klai-portal/backend/tests/test_oauth_routes.py
+++ b/klai-portal/backend/tests/test_oauth_routes.py
@@ -259,7 +259,7 @@ class TestCallbackEndpoint:
                 "refresh_token": "placeholder-refresh-value",
                 "expires_in": 3599,
                 "token_type": "Bearer",
-                "scope": "https://www.googleapis.com/auth/drive.readonly",
+                "scope": "https://www.googleapis.com/auth/drive.file",
             },
         )
 

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/GoogleDrivePicker.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/GoogleDrivePicker.tsx
@@ -1,0 +1,305 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { ChevronDown, ChevronRight, File, Folder, FolderOpen, Loader2 } from 'lucide-react'
+import { apiFetch } from '@/lib/apiFetch'
+import { Button } from '@/components/ui/button'
+
+interface DriveItem {
+  id: string
+  name: string
+  kind: 'folder' | 'file'
+  child_count: number
+}
+
+interface FoldersResponse {
+  folders: DriveItem[]
+}
+
+export interface GoogleDrivePickerResult {
+  folderId: string
+  folderName: string
+  fileIds: string[]
+}
+
+interface NodeProps {
+  kbSlug: string
+  connectorId: string
+  item: DriveItem
+  depth: number
+  selectedFolderId: string
+  selectedFileIds: Set<string>
+  onSelectFolder: (id: string) => void
+  onToggleFile: (id: string) => void
+  onSeeName: (id: string, name: string) => void
+}
+
+function ItemNode({
+  kbSlug,
+  connectorId,
+  item,
+  depth,
+  selectedFolderId,
+  selectedFileIds,
+  onSelectFolder,
+  onToggleFile,
+  onSeeName,
+}: NodeProps) {
+  const isFolder = item.kind === 'folder'
+  const [expanded, setExpanded] = useState(false)
+  const isFolderSelected = isFolder && selectedFolderId === item.id
+  const isFileSelected = !isFolder && selectedFileIds.has(item.id)
+
+  const { data, isLoading } = useQuery<FoldersResponse>({
+    queryKey: ['google-drive-folders', kbSlug, connectorId, item.id],
+    queryFn: async () =>
+      apiFetch<FoldersResponse>(
+        `/api/app/knowledge-bases/${encodeURIComponent(kbSlug)}/connectors/${connectorId}/google-drive/folders?parent=${encodeURIComponent(item.id)}`,
+      ),
+    enabled: expanded && isFolder,
+    staleTime: 60_000,
+  })
+
+  useEffect(() => {
+    if (!isFolder) return
+    onSeeName(item.id, item.name)
+    if (data?.folders) {
+      for (const child of data.folders) {
+        if (child.kind === 'folder') onSeeName(child.id, child.name)
+      }
+    }
+  }, [data, item.id, item.name, isFolder, onSeeName])
+
+  return (
+    <div>
+      <div
+        className={[
+          'group flex items-center gap-1 rounded-md px-1 py-1 transition-colors cursor-pointer',
+          isFolderSelected || isFileSelected ? 'bg-gray-100' : 'klai-hover',
+        ].join(' ')}
+        style={{ paddingLeft: `${depth * 16 + 4}px` }}
+        onClick={() => (isFolder ? onSelectFolder(item.id) : onToggleFile(item.id))}
+      >
+        {isFolder ? (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation()
+              setExpanded((p) => !p)
+            }}
+            className="inline-flex h-5 w-5 items-center justify-center text-gray-400 hover:text-gray-900"
+            aria-label={expanded ? 'Inklappen' : 'Uitklappen'}
+          >
+            {expanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+          </button>
+        ) : (
+          <input
+            type="checkbox"
+            checked={isFileSelected}
+            readOnly
+            tabIndex={-1}
+            aria-label={`Selecteer ${item.name}`}
+            className="h-3.5 w-3.5 accent-gray-900 ml-1 mr-1 cursor-pointer"
+          />
+        )}
+        {isFolder ? (
+          expanded ? (
+            <FolderOpen className="h-3.5 w-3.5 text-gray-400 shrink-0" />
+          ) : (
+            <Folder className="h-3.5 w-3.5 text-gray-400 shrink-0" />
+          )
+        ) : (
+          <File className="h-3.5 w-3.5 text-gray-400 shrink-0" />
+        )}
+        <span
+          className={[
+            'text-sm truncate flex-1',
+            isFolder ? 'text-gray-900' : isFileSelected ? 'text-gray-900' : 'text-gray-700',
+          ].join(' ')}
+        >
+          {item.name}
+        </span>
+      </div>
+      {expanded && isFolder && (
+        <div>
+          {isLoading && (
+            <div
+              className="flex items-center gap-2 text-xs text-gray-400 py-1"
+              style={{ paddingLeft: `${(depth + 1) * 16 + 4}px` }}
+            >
+              <Loader2 className="h-3 w-3 animate-spin" />
+              Laden...
+            </div>
+          )}
+          {data && data.folders.length === 0 && !isLoading && (
+            <div
+              className="text-xs text-gray-400 italic py-1"
+              style={{ paddingLeft: `${(depth + 1) * 16 + 4}px` }}
+            >
+              Leeg
+            </div>
+          )}
+          {data?.folders.map((child) => (
+            <ItemNode
+              key={child.id}
+              kbSlug={kbSlug}
+              connectorId={connectorId}
+              item={child}
+              depth={depth + 1}
+              selectedFolderId={selectedFolderId}
+              selectedFileIds={selectedFileIds}
+              onSelectFolder={onSelectFolder}
+              onToggleFile={onToggleFile}
+              onSeeName={onSeeName}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface PickerProps {
+  kbSlug: string
+  connectorId: string
+  initialFolderId: string
+  initialFileIds: string[]
+  onConfirm: (result: GoogleDrivePickerResult) => void
+  onCancel: () => void
+}
+
+export function GoogleDrivePicker({
+  kbSlug,
+  connectorId,
+  initialFolderId,
+  initialFileIds,
+  onConfirm,
+  onCancel,
+}: PickerProps) {
+  const [selectedFolderId, setSelectedFolderId] = useState<string>(initialFolderId)
+  const [selectedFileIds, setSelectedFileIds] = useState<Set<string>>(
+    () => new Set(initialFileIds),
+  )
+  const [nameById, setNameById] = useState<Record<string, string>>({})
+
+  useEffect(() => {
+    setSelectedFolderId(initialFolderId)
+    setSelectedFileIds(new Set(initialFileIds))
+  }, [initialFolderId, initialFileIds])
+
+  function rememberName(id: string, name: string) {
+    setNameById((prev) => (prev[id] === name ? prev : { ...prev, [id]: name }))
+  }
+
+  function selectFolder(id: string) {
+    setSelectedFolderId(id)
+    setSelectedFileIds(new Set())
+  }
+
+  function toggleFile(id: string) {
+    setSelectedFolderId('')
+    setSelectedFileIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  function selectWholeDrive() {
+    setSelectedFolderId('')
+    setSelectedFileIds(new Set())
+  }
+
+  const { data, isLoading, error } = useQuery<FoldersResponse>({
+    queryKey: ['google-drive-folders', kbSlug, connectorId, 'root'],
+    queryFn: async () =>
+      apiFetch<FoldersResponse>(
+        `/api/app/knowledge-bases/${encodeURIComponent(kbSlug)}/connectors/${connectorId}/google-drive/folders`,
+      ),
+  })
+
+  const fileCount = selectedFileIds.size
+  const summary = useMemo(() => {
+    if (selectedFolderId) return `Map: ${nameById[selectedFolderId] ?? 'geselecteerd'}`
+    if (fileCount > 0) return `${fileCount} bestand${fileCount === 1 ? '' : 'en'} geselecteerd`
+    return 'Hele Google Drive'
+  }, [selectedFolderId, fileCount, nameById])
+
+  const isWholeDriveSelected = selectedFolderId === '' && fileCount === 0
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white">
+      <div className="border-b border-gray-200 px-3 py-2">
+        <p className="text-sm font-medium text-gray-900">Kies wat je wilt syncen</p>
+        <p className="text-xs text-gray-400 mt-0.5">
+          Klap een map uit om te browsen. Klik op een map voor de hele map,
+          of vink losse bestanden aan voor alleen die bestanden.
+        </p>
+      </div>
+
+      <div className="max-h-72 overflow-y-auto px-2 py-2 space-y-0.5">
+        <div
+          className={[
+            'flex items-center gap-2 rounded-md px-2 py-1.5 cursor-pointer',
+            isWholeDriveSelected ? 'bg-gray-100' : 'klai-hover',
+          ].join(' ')}
+          onClick={selectWholeDrive}
+        >
+          <Folder className="h-3.5 w-3.5 text-gray-400" />
+          <span className="text-sm text-gray-900">Hele Google Drive</span>
+        </div>
+
+        {isLoading && (
+          <div className="flex items-center gap-2 px-2 py-2 text-xs text-gray-400">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            Bestanden laden...
+          </div>
+        )}
+        {error && (
+          <div className="px-2 py-2 text-xs text-[var(--color-destructive)]">
+            {error instanceof Error ? error.message : 'Kon Google Drive niet ophalen'}
+          </div>
+        )}
+        {data?.folders.length === 0 && !isLoading && (
+          <div className="px-2 py-2 text-xs text-gray-400">Deze map is leeg.</div>
+        )}
+        {data?.folders.map((item) => (
+          <ItemNode
+            key={item.id}
+            kbSlug={kbSlug}
+            connectorId={connectorId}
+            item={item}
+            depth={0}
+            selectedFolderId={selectedFolderId}
+            selectedFileIds={selectedFileIds}
+            onSelectFolder={selectFolder}
+            onToggleFile={toggleFile}
+            onSeeName={rememberName}
+          />
+        ))}
+      </div>
+
+      <div className="flex items-center justify-between gap-2 border-t border-gray-200 px-3 py-2">
+        <p className="text-xs text-gray-400 truncate">{summary}</p>
+        <div className="flex items-center gap-2 shrink-0">
+          <Button type="button" size="sm" variant="ghost" onClick={onCancel}>
+            Annuleren
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            onClick={() =>
+              onConfirm({
+                folderId: selectedFolderId,
+                folderName: selectedFolderId ? (nameById[selectedFolderId] ?? '') : '',
+                fileIds: Array.from(selectedFileIds),
+              })
+            }
+          >
+            Gebruik deze keuze
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
@@ -98,7 +98,6 @@ function AddConnectorPage() {
   const [confluenceConfig, setConfluenceConfig] = useState<ConfluenceConfig>({
     base_url: '', email: '', api_token: '', space_keys: '',
   })
-  const [folderId, setFolderId] = useState('')
   // ms_docs (SPEC-KB-MS-DOCS-001): optional site_url + drive_id - both empty = personal OneDrive
   const [msSiteUrl, setMsSiteUrl] = useState('')
   const [msDriveId, setMsDriveId] = useState('')
@@ -229,7 +228,6 @@ function AddConnectorPage() {
       // connector.connector_type. We pass the selected type as-is.
       const connectorType = selectedType ?? 'google_drive'
       const config: Record<string, unknown> = {}
-      if (folderId.trim()) config.folder_id = folderId.trim()
       const result = await apiFetch<{ id: string }>(`/api/app/knowledge-bases/${kbSlug}/connectors/`, {
         method: 'POST',
         body: JSON.stringify({
@@ -422,7 +420,6 @@ function AddConnectorPage() {
                         setSelectedType(type)
                         setWcStep('details')
                         setNotionStep('credentials')
-                        setFolderId('')
                         setShowAdvancedSelector(false)
                         setPreviewResult(null)
                         setWcPreviewUrl('')
@@ -570,11 +567,14 @@ function AddConnectorPage() {
                   <Label htmlFor="gd-name">{m.admin_connectors_field_name()}</Label>
                   <Input id="gd-name" required placeholder={m.admin_connectors_field_name_placeholder()} value={name} onChange={(e) => setName(e.target.value)} />
                 </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="gd-folder-id">{m.admin_connectors_google_drive_folder_id()}</Label>
-                  <Input id="gd-folder-id" placeholder={m.admin_connectors_google_drive_folder_id_placeholder()} value={folderId} onChange={(e) => setFolderId(e.target.value)} />
-                  <p className="text-xs text-gray-400">{m.admin_connectors_google_drive_folder_id_help()}</p>
-                </div>                {createGoogleDriveMutation.error && (
+                <div className="rounded-lg border border-gray-200 px-4 py-3 space-y-2">
+                  <p className="text-sm font-medium text-gray-900">Kies je bestanden na het inloggen</p>
+                  <p className="text-xs text-gray-400">
+                    We openen na Google-authenticatie een Drive-kiezer. Daar kies je de volledige Drive,
+                    een specifieke map of losse bestanden zonder ID's uit URL's te kopieren.
+                  </p>
+                </div>
+                {createGoogleDriveMutation.error && (
                   <p className="text-sm text-[var(--color-destructive)]">
                     {createGoogleDriveMutation.error instanceof Error ? createGoogleDriveMutation.error.message : m.admin_connectors_error_create_generic()}
                   </p>

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
@@ -16,6 +16,7 @@ import { apiFetch } from '@/lib/apiFetch'
 import { MS_SITE_URL_PATTERN } from '@/lib/ms-docs'
 import type { ConnectorSummary, CookieRow } from './$kbSlug/-kb-types'
 import { CookieRowsInput } from '@/components/knowledge/CookieRowsInput'
+import { GoogleDrivePicker } from './$kbSlug/_components/GoogleDrivePicker'
 import { MsDocsFolderPicker } from './$kbSlug/_components/MsDocsFolderPicker'
 import {
   AuthProbeFeedback,
@@ -51,6 +52,13 @@ function _stepToWcStep(step: StepDeepLink | undefined): WcStep | undefined {
   if (step === 'selector') return 'selector'
   return undefined
 }
+
+const GOOGLE_DRIVE_CONNECTOR_TYPES = new Set([
+  'google_drive',
+  'google_docs',
+  'google_sheets',
+  'google_slides',
+])
 
 type EditSearch = { step?: StepDeepLink; show?: 'picker' }
 
@@ -97,6 +105,9 @@ function EditConnectorPage() {
     database_ids: '', max_pages: '500', new_access_token: '',
   })
   const [folderId, setFolderId] = useState('')
+  const [folderName, setFolderName] = useState('')
+  const [fileIds, setFileIds] = useState<string[]>([])
+  const [showGoogleDrivePicker, setShowGoogleDrivePicker] = useState(false)
   const [isReconnecting, setIsReconnecting] = useState(false)
   // ms_docs (SPEC-KB-MS-DOCS-001 R4.4): optional site_url + drive_id +
   // post-OAuth scope. Three mutually-exclusive scope modes:
@@ -238,9 +249,12 @@ function EditConnectorPage() {
         new_access_token: '',
       })
     }
-    if (connector.connector_type === 'google_drive') {
-      const cfg = connector.config as { folder_id?: string }
+    if (GOOGLE_DRIVE_CONNECTOR_TYPES.has(connector.connector_type)) {
+      const cfg = connector.config as { folder_id?: string; folder_name?: string; item_ids?: string[] }
       setFolderId(cfg.folder_id ?? '')
+      setFolderName(cfg.folder_name ?? '')
+      setFileIds(Array.isArray(cfg.item_ids) ? cfg.item_ids : [])
+      setShowGoogleDrivePicker(search.show === 'picker')
     }
     if (connector.connector_type === 'ms_docs') {
       const cfg = connector.config as {
@@ -318,8 +332,13 @@ function EditConnectorPage() {
         if (ids.length > 0) config.database_ids = ids
         if (notionConfig.max_pages) config.max_pages = Number(notionConfig.max_pages)
       }
-      if (connector.connector_type === 'google_drive') {
-        if (folderId.trim()) config.folder_id = folderId.trim()
+      if (GOOGLE_DRIVE_CONNECTOR_TYPES.has(connector.connector_type)) {
+        if (fileIds.length > 0) {
+          config.item_ids = fileIds
+        } else if (folderId.trim()) {
+          config.folder_id = folderId.trim()
+          if (folderName.trim()) config.folder_name = folderName.trim()
+        }
       }
       if (connector.connector_type === 'ms_docs') {
         const siteUrl = msSiteUrl.trim()
@@ -432,6 +451,60 @@ function EditConnectorPage() {
       <p className="text-sm text-[var(--color-destructive)]">
         {updateMutation.error instanceof Error ? updateMutation.error.message : m.admin_connectors_error_create_generic()}
       </p>
+    )
+  }
+
+  function renderGoogleDriveScopePicker() {
+    if (!connector) return null
+    return (
+      <div className="space-y-1.5">
+        <Label>Wat wil je syncen?</Label>
+        <div className="flex items-center justify-between rounded-md border border-gray-200 px-3 py-2">
+          <div className="min-w-0 flex-1">
+            {fileIds.length > 0 ? (
+              <p className="text-sm text-gray-900 truncate">
+                {fileIds.length} bestand{fileIds.length === 1 ? '' : 'en'} geselecteerd
+              </p>
+            ) : folderId ? (
+              <p className="text-sm text-gray-900 truncate">
+                Map: {folderName || 'geselecteerd'}
+              </p>
+            ) : (
+              <p className="text-sm text-gray-400">Hele Google Drive</p>
+            )}
+          </div>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => setShowGoogleDrivePicker((p) => !p)}
+          >
+            {showGoogleDrivePicker
+              ? 'Sluiten'
+              : folderId || fileIds.length > 0
+                ? 'Wijzigen'
+                : 'Kies mappen / bestanden'}
+          </Button>
+        </div>
+        <p className="text-xs text-gray-400">
+          Voor Google Docs, Sheets en Slides tonen we alleen bestanden van het gekozen type.
+        </p>
+        {showGoogleDrivePicker && (
+          <GoogleDrivePicker
+            kbSlug={kbSlug}
+            connectorId={connector.id}
+            initialFolderId={folderId}
+            initialFileIds={fileIds}
+            onCancel={() => setShowGoogleDrivePicker(false)}
+            onConfirm={(result) => {
+              setFolderId(result.folderId)
+              setFolderName(result.folderId ? result.folderName : '')
+              setFileIds(result.fileIds)
+              setShowGoogleDrivePicker(false)
+            }}
+          />
+        )}
+      </div>
     )
   }
 
@@ -1040,11 +1113,8 @@ function EditConnectorPage() {
                 <Label htmlFor="edit-conn-name">{m.admin_connectors_field_name()}</Label>
                 <Input id="edit-conn-name" required value={name} onChange={(e) => setName(e.target.value)} />
               </div>
-              <div className="space-y-1.5">
-                <Label htmlFor="edit-conn-folder-id">{m.admin_connectors_google_drive_folder_id()}</Label>
-                <Input id="edit-conn-folder-id" placeholder={m.admin_connectors_google_drive_folder_id_placeholder()} value={folderId} onChange={(e) => setFolderId(e.target.value)} />
-                <p className="text-xs text-gray-400">{m.admin_connectors_google_drive_folder_id_help()}</p>
-              </div>              {renderError()}
+              {renderGoogleDriveScopePicker()}
+              {renderError()}
               <div className="flex gap-2 pt-2">
                 <Button type="submit" size="sm" disabled={updateMutation.isPending}>{m.admin_connectors_save()}</Button>
                 <Button
@@ -1165,7 +1235,9 @@ function EditConnectorPage() {
               )}
               {connector.connector_type === 'google_slides' && (
                 <p className="text-sm text-gray-400">{m.admin_connectors_google_slides_subtitle()}</p>
-              )}              {renderError()}
+              )}
+              {renderGoogleDriveScopePicker()}
+              {renderError()}
               <div className="flex gap-2 pt-2">
                 <Button type="submit" size="sm" disabled={updateMutation.isPending}>{m.admin_connectors_save()}</Button>
                 <Button


### PR DESCRIPTION
## Summary
- Adds Google Drive picker support for folders and individual files after OAuth.
- Adds portal and connector API endpoints to browse Google Drive items.
- Stores selected folder or item IDs in connector config and respects them during sync.

## Why
Users should be able to choose Drive scope from the UI instead of manually copying folder IDs from URLs.

## Impact
Google Drive, Docs, Sheets, and Slides connectors can now browse selectable Drive items, with content-type filtering preserved for Workspace-specific connector types.

## Validation
- `git diff --check`
- `uv run pytest tests/adapters/test_google_drive.py` from `klai-connector` (`33 passed`)
