### PR TITLE
fix(portal): swap Whatsapp example for klantenservice

### DIFF
--- a/klai-portal/frontend/messages/en.json
+++ b/klai-portal/frontend/messages/en.json
@@ -1591,7 +1591,7 @@
   "instructions_intro_heading": "What are instructions?",
   "instructions_intro_body": "An instruction is a piece of text you turn on before a chat. Klai picks it up as the starting point, so you don't have to type the same setup every time.",
   "instructions_intro_examples_heading": "For example:",
-  "instructions_intro_example_1": "a weekly Whatsapp update to customers with a fixed tone and structure,",
+  "instructions_intro_example_1": "customer-support replies with a fixed tone and clear escalation rules,",
   "instructions_intro_example_2": "or a sales follow-up after a demo that opens with the agreed next step.",
   "instructions_intro_invoke": "Turn one on from the Instructions button at the bottom of the chat. You can have several active at once.",
   "instructions_empty_title": "No instructions yet",

--- a/klai-portal/frontend/messages/nl.json
+++ b/klai-portal/frontend/messages/nl.json
@@ -1591,7 +1591,7 @@
   "instructions_intro_heading": "Wat zijn instructies?",
   "instructions_intro_body": "Een instructie is een stukje tekst dat je voor een chat aanzet. Klai pakt het op als startpunt, zodat je niet elke keer dezelfde uitleg hoeft te typen.",
   "instructions_intro_examples_heading": "Bijvoorbeeld:",
-  "instructions_intro_example_1": "een wekelijkse Whatsapp-update aan klanten met een vaste toon en opbouw,",
+  "instructions_intro_example_1": "klantenservice-antwoorden met een vaste toon en duidelijke escalatieregels,",
   "instructions_intro_example_2": "of een sales follow-up na een demo die opent met de afgesproken volgende stap.",
   "instructions_intro_invoke": "Aanzetten doe je via de Instructies-knop onderaan de chat. Je kunt er meerdere tegelijk aan hebben staan.",
   "instructions_empty_title": "Nog geen instructies",


### PR DESCRIPTION
User feedback: Whatsapp is too consumer-flavored, prefer a business example. Klantenservice + sales follow-up read better as 'wat ik hier kan doen' for a B2B audience.