### PR TITLE
fix(litellm): broad mode keeps model answer when no citable sources

### DIFF
--- a/deploy/litellm/klai_knowledge.py
+++ b/deploy/litellm/klai_knowledge.py
@@ -1531,14 +1531,47 @@ def _render_kb_citation_content(
     user_query: object,
     trusted_sources: list[dict[str, Any]],
     evidence_chunks: list[dict],
+    kb_narrow: bool,
 ) -> tuple[str, list[dict[str, str]], bool, dict[str, Any]]:
+    """Render the model's answer with deterministic citations.
+
+    When retrieval returned no trusted sources (or the source-selector
+    rejected every candidate), behaviour depends on the user's mode:
+
+    - **Narrow / strict** (``kb_narrow=True``): replace the model's
+      answer with the canned "I cannot answer reliably from the
+      available knowledge sources" string. The user opted into strict-
+      KB-only behaviour, so refusing without citable evidence is the
+      contract.
+
+    - **Broad / open** (``kb_narrow=False``): pass the model's original
+      answer through unchanged. The user opted into general-knowledge
+      fallback, so the model's response is valid even without citable
+      KB sources — clobbering it with a refusal trains users to ignore
+      the open/strict toggle.
+
+    Incident reference: Mijndomein tester 2026-05-27 saw the canned
+    refusal in every mode regardless of toggles because his retrieved
+    chunks produced no trusted sources (`no_trusted_sources`); under
+    broad mode the model's general-knowledge answer is the correct
+    fallback and the canned message hid it.
+    """
     if not trusted_sources:
-        return _no_citable_sources_message(user_query), [], True, {
+        if kb_narrow:
+            return _no_citable_sources_message(user_query), [], True, {
+                "mode": "document_level_supported_sources",
+                "candidate_count": 0,
+                "selected": [],
+                "rejected": [],
+                "no_citable_reason": "no_trusted_sources",
+            }
+        # Broad mode: keep model's answer, no citations appended.
+        return text, [], False, {
             "mode": "document_level_supported_sources",
             "candidate_count": 0,
             "selected": [],
             "rejected": [],
-            "no_citable_reason": "no_trusted_sources",
+            "no_citable_reason": "no_trusted_sources_broad_passthrough",
         }
     composed = compose_answer_with_trusted_sources(
         text,
@@ -1549,8 +1582,13 @@ def _render_kb_citation_content(
     )
     if not composed.content or not composed.sources:
         decision = dict(composed.decision)
-        decision["no_citable_reason"] = "selector_rejected_all_sources"
-        return _no_citable_sources_message(user_query), [], True, decision
+        if kb_narrow:
+            decision["no_citable_reason"] = "selector_rejected_all_sources"
+            return _no_citable_sources_message(user_query), [], True, decision
+        # Broad mode: pass model's answer through even when the source
+        # selector found nothing — general knowledge is still valid.
+        decision["no_citable_reason"] = "selector_rejected_all_sources_broad_passthrough"
+        return text, [], False, decision
     return composed.content, composed.sources, False, composed.decision
 
 
@@ -1613,6 +1651,7 @@ def _flush_citation_stream_buffer(
         user_query=kb_meta.get("user_query"),
         trusted_sources=trusted_sources,
         evidence_chunks=citation_chunks,
+        kb_narrow=bool(kb_meta.get("kb_narrow", False)),
     )
 
     for choice in _get_response_choices(response):
@@ -1654,6 +1693,7 @@ def _compose_non_streaming_kb_response(
                 user_query=kb_meta.get("user_query"),
                 trusted_sources=trusted_sources,
                 evidence_chunks=citation_chunks,
+                kb_narrow=bool(kb_meta.get("kb_narrow", False)),
             )
             if rendered_content != content or sources:
                 _set_message_content(message, _append_visible_sources_section(rendered_content, sources))
@@ -2177,6 +2217,7 @@ class KlaiKnowledgeHook(CustomLogger):
                 "org_id": org_id,
                 "user_id": user_id,
                 "user_query": query,
+                "kb_narrow": kb_narrow,
                 "chunks_injected": 0,
                 "chunk_ids": [],
                 "allowed_source_urls": [],
@@ -2237,6 +2278,7 @@ class KlaiKnowledgeHook(CustomLogger):
                     "org_id": org_id,
                     "user_id": user_id,
                     "user_query": query,
+                    "kb_narrow": kb_narrow,
                     "chunks_injected": 0,
                     "chunk_ids": [],
                     "allowed_source_urls": [],
@@ -2394,6 +2436,7 @@ class KlaiKnowledgeHook(CustomLogger):
             "org_id": org_id,
             "user_id": user_id,
             "user_query": query,
+            "kb_narrow": kb_narrow,
             "chunks_injected": len(context_chunks),
             "chunk_ids": [c.get("chunk_id") for c in context_chunks if c.get("chunk_id")],
             "allowed_source_urls": sorted(allowed_source_urls),

--- a/deploy/litellm/tests/test_klai_knowledge_hook.py
+++ b/deploy/litellm/tests/test_klai_knowledge_hook.py
@@ -2913,7 +2913,14 @@ class TestKlaiKnowledgeHookUrlImageGrounding:
         ]
 
     @pytest.mark.asyncio
-    async def test_post_call_guard_refuses_answer_without_citable_sources(self, monkeypatch, caplog):
+    async def test_post_call_guard_refuses_answer_in_narrow_mode_without_citable_sources(
+        self, monkeypatch, caplog
+    ):
+        """Narrow mode: no trusted sources → canned refuse.
+
+        Strict-KB-only mode contract: the user opted into "answer ONLY
+        from the KB", so refusing without citable evidence is correct.
+        """
         mod = _load_hook(monkeypatch)
         hook = mod.KlaiKnowledgeHook()
         caplog.set_level("WARNING", logger="klai_knowledge")
@@ -2930,6 +2937,7 @@ class TestKlaiKnowledgeHookUrlImageGrounding:
                     "org_id": "org123",
                     "user_id": "user123",
                     "user_query": "Hoe open is Klai?",
+                    "kb_narrow": True,
                     "chunks_injected": 1,
                     "retrieval_ms": 12,
                     "gate_bypassed": False,
@@ -2953,7 +2961,59 @@ class TestKlaiKnowledgeHookUrlImageGrounding:
         assert "kb_citations_no_citable_sources" in caplog.text
 
     @pytest.mark.asyncio
-    async def test_post_call_guard_refuses_empty_evidence_pack(self, monkeypatch):
+    async def test_post_call_keeps_model_answer_in_broad_mode_without_citable_sources(
+        self, monkeypatch, caplog
+    ):
+        """Broad mode: no trusted sources → keep the model's answer.
+
+        Mijndomein regression 2026-05-27: tester saw the canned refusal in
+        every mode regardless of toggles because his chunks produced no
+        trusted sources. In broad mode the user explicitly opted into
+        general-knowledge fallback — the model's response is the correct
+        output and the canned refusal hid it.
+        """
+        mod = _load_hook(monkeypatch)
+        hook = mod.KlaiKnowledgeHook()
+        caplog.set_level("WARNING", logger="klai_knowledge")
+        original_answer = "Klai is open source."
+        response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content=original_answer)
+                )
+            ]
+        )
+        data = {
+            "metadata": {
+                "_klai_kb_meta": {
+                    "org_id": "org123",
+                    "user_id": "user123",
+                    "user_query": "Hoe open is Klai?",
+                    "kb_narrow": False,
+                    "chunks_injected": 1,
+                    "retrieval_ms": 12,
+                    "gate_bypassed": False,
+                    "allowed_image_urls": [],
+                    "citation_chunks": [
+                        {
+                            "title": "Open",
+                            "text": "Klai is open source.",
+                        }
+                    ],
+                }
+            }
+        }
+
+        returned = await hook.async_post_call_success_hook(data, None, response)
+
+        assert returned is response
+        # Model's original answer survives — the canned refusal is NOT
+        # substituted in broad mode.
+        assert response.choices[0].message.content == original_answer
+
+    @pytest.mark.asyncio
+    async def test_post_call_guard_refuses_empty_evidence_pack_in_narrow_mode(self, monkeypatch):
+        """Narrow mode: empty evidence pack still triggers the canned refuse."""
         mod = _load_hook(monkeypatch)
         hook = mod.KlaiKnowledgeHook()
         response = SimpleNamespace(
@@ -2969,6 +3029,7 @@ class TestKlaiKnowledgeHookUrlImageGrounding:
                     "org_id": "org123",
                     "user_id": "user123",
                     "user_query": "Hoe voeg ik een nieuwe user toe?",
+                    "kb_narrow": True,
                     "chunks_injected": 0,
                     "retrieval_ms": 12,
                     "gate_bypassed": False,
@@ -2989,8 +3050,10 @@ class TestKlaiKnowledgeHookUrlImageGrounding:
         )
 
     @pytest.mark.asyncio
-    async def test_post_call_guard_refuses_irrelevant_citable_sources(self, monkeypatch, caplog):
-        """Do not cite the first retrieved URLs when none support the generated answer."""
+    async def test_post_call_guard_refuses_irrelevant_citable_sources_in_narrow_mode(
+        self, monkeypatch, caplog
+    ):
+        """Narrow mode: do not cite first retrieved URLs when none support the answer."""
         mod = _load_hook(monkeypatch)
         hook = mod.KlaiKnowledgeHook()
         caplog.set_level("WARNING", logger="klai_knowledge")
@@ -3012,6 +3075,7 @@ class TestKlaiKnowledgeHookUrlImageGrounding:
                     "org_id": "org123",
                     "user_id": "user123",
                     "user_query": "Hoe voeg ik een nieuwe user toe?",
+                    "kb_narrow": True,
                     "chunks_injected": 3,
                     "retrieval_ms": 12,
                     "gate_bypassed": False,


### PR DESCRIPTION
**Bug:** post-call citation render clobbers the model's response with a canned 'I cannot answer reliably...' string whenever retrieval produces no trusted sources — REGARDLESS of broad/strict mode.

**Impact:** users in broad/open mode (which is the default) get a refusal even though they explicitly opted into general-knowledge fallback. Mijndomein tester this morning reported this in EVERY mode regardless of toggles.

**Fix:** thread `kb_narrow` through to the render function. Narrow → keep canned refuse (correct strict-KB-only contract). Broad → pass model's answer through unchanged.

**Tests:** existing narrow-mode tests renamed and made explicit, new test added for broad-mode passthrough.