### PR TITLE
fix(ingest): make crawl frontier deterministic

### DIFF
--- a/klai-connector/app/reason_codes.py
+++ b/klai-connector/app/reason_codes.py
@@ -40,6 +40,11 @@ class FetchReasonCode(StrEnum):
     PARSE_ERROR = "parse_error"
     RATE_LIMITED = "rate_limited"
     NON_CONTENT_LISTING_PAGE = "non_content_listing_page"
+    NOT_FETCHED_BUDGET_EXHAUSTED = "not_fetched_budget_exhausted"
+    NOT_FETCHED_DEPTH_LIMIT = "not_fetched_depth_limit"
+    NOT_FETCHED_DISCOVERY_LIMIT = "not_fetched_discovery_limit"
+    NOT_FETCHED_EXCLUDED = "not_fetched_excluded"
+    NOT_FETCHED_DUPLICATE = "not_fetched_duplicate"
     UNKNOWN_EXCEPTION = "unknown_exception"
 
 

--- a/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
+++ b/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import hashlib
 import json
 import time
+from collections import Counter
 
 import asyncpg
 import httpx
@@ -42,6 +43,10 @@ _VALID_LOGIN_WALL_MODES = ("reject", "degrade", "audit_only")
 # when the dirty-content guard trips. REQ-5 surfaces this exact string in the
 # UI badge query, so it MUST stay stable.
 DIRTY_CONTENT_REASON = "boilerplate_or_authwall_dominant"
+CRAWL_BUDGET_EXHAUSTED_REASON = "crawl_budget_exhausted"
+CRAWL_FRONTIER_INCOMPLETE_REASON = "crawl_frontier_incomplete"
+
+_NOT_FETCHED_REASON_PREFIX = "not_fetched_"
 
 _DIRTY_CONTENT_SUGGESTION = (
     "Re-run preview from the connector edit page. The site likely now requires "
@@ -103,6 +108,61 @@ def decide_terminal_status(
         "suggestion": _DIRTY_CONTENT_SUGGESTION,
     }
     return ("failed_partial", summary)
+
+
+def _build_crawl_outcome_warning(
+    fetch_outcomes: list[dict],
+    *,
+    max_pages: int,
+) -> dict | None:
+    """Summarise discovered-but-unfetched URLs for crawl_jobs.error_summary.
+
+    ``crawl_site`` owns URL discovery now, so a page-budget hit is no longer a
+    quiet implementation detail inside Crawl4AI. The adapter turns those
+    not_fetched outcomes into a compact, operator-readable warning.
+    """
+    omitted = [
+        outcome
+        for outcome in fetch_outcomes
+        if str(outcome.get("reason_code") or "").startswith(_NOT_FETCHED_REASON_PREFIX)
+    ]
+    if not omitted:
+        return None
+
+    counts = Counter(str(outcome.get("reason_code") or "") for outcome in omitted)
+    reason = (
+        CRAWL_BUDGET_EXHAUSTED_REASON
+        if counts.get("not_fetched_budget_exhausted", 0) > 0
+        else CRAWL_FRONTIER_INCOMPLETE_REASON
+    )
+    return {
+        "reason": reason,
+        "max_pages": max_pages,
+        "omitted_count": len(omitted),
+        "omitted_reason_counts": dict(counts),
+        "sample_omitted_urls": [
+            str(outcome.get("url") or "") for outcome in omitted[:10] if outcome.get("url")
+        ],
+    }
+
+
+def _crawl_warning_terminal_status(crawl_warning: dict | None) -> str:
+    """Return the terminal status implied by a crawl warning, if any."""
+    if crawl_warning is None:
+        return ""
+    if crawl_warning.get("reason") in {
+        CRAWL_BUDGET_EXHAUSTED_REASON,
+        CRAWL_FRONTIER_INCOMPLETE_REASON,
+    }:
+        return "failed_partial"
+    return ""
+
+
+def _attach_crawl_warning(summary: dict, crawl_warning: dict | None) -> dict:
+    """Attach warning details without replacing a stronger top-level reason."""
+    if crawl_warning is not None:
+        summary["crawl_warning"] = crawl_warning
+    return summary
 
 
 # @MX:ANCHOR: AuthWallDetected -- propagates login-indicator triggers from _ingest_crawl_result
@@ -250,8 +310,8 @@ async def run_crawl_job(
     Crawl a website and ingest each page into the knowledge pipeline.
     Updates knowledge.crawl_jobs progress as pages are processed.
 
-    Seeds the crawl with start_url + sitemap.xml, then recurses to max_depth
-    using Crawl4AI's BFSDeepCrawlStrategy (same strategy as klai-connector).
+    Seeds the crawl with start_url + sitemap.xml, then lets crawl_site's
+    Klai-owned frontier schedule same-domain links to max_depth.
 
     ``exclude_patterns`` is applied after crawl4ai discovery and before
     progress counting / dirty-content decisions. ``rate_limit`` is accepted
@@ -292,6 +352,10 @@ async def run_crawl_job(
             exclude_patterns=exclude_patterns,
             login_indicator_selector=login_indicator_selector,
             cookies=cookies,
+        )
+        crawl_outcome_warning = _build_crawl_outcome_warning(
+            fetch_outcomes,
+            max_pages=max_pages,
         )
         # canary_url / canary_fingerprint are accepted for forwards-compat with
         # the /ingest/v1/crawl/sync request body; they are plumbed here but the
@@ -392,6 +456,22 @@ async def run_crawl_job(
             # REQ-4 reason for forensic logs.
             summary_payload.setdefault("login_walls_skipped", len(auth_wall_pages))
             summary_payload.setdefault("sample_urls", auth_wall_pages[:10])
+            _attach_crawl_warning(summary_payload, crawl_outcome_warning)
+            summary_json = json.dumps(summary_payload)
+            await conn.execute(
+                "UPDATE knowledge.crawl_jobs SET status=$1, error_summary=$2::jsonb, "
+                "updated_at=$3 WHERE id=$4",
+                terminal_status,
+                summary_json,
+                int(time.time()),
+                job_id,
+            )
+        elif _crawl_warning_terminal_status(crawl_outcome_warning):
+            terminal_status = _crawl_warning_terminal_status(crawl_outcome_warning)
+            summary_payload = dict(crawl_outcome_warning or {})
+            if auth_wall_pages:
+                summary_payload["login_walls_skipped"] = len(auth_wall_pages)
+                summary_payload["sample_urls"] = auth_wall_pages[:10]
             summary_json = json.dumps(summary_payload)
             await conn.execute(
                 "UPDATE knowledge.crawl_jobs SET status=$1, error_summary=$2::jsonb, "
@@ -404,10 +484,10 @@ async def run_crawl_job(
         elif auth_wall_pages and pages_done == 0:
             terminal_status = "failed_partial"
             summary_json = json.dumps(
-                {
+                _attach_crawl_warning({
                     "login_walls_skipped": len(auth_wall_pages),
                     "sample_urls": auth_wall_pages[:10],
-                }
+                }, crawl_outcome_warning)
             )
             await conn.execute(
                 "UPDATE knowledge.crawl_jobs SET status=$1, error_summary=$2::jsonb, "
@@ -420,16 +500,26 @@ async def run_crawl_job(
         elif auth_wall_pages:
             terminal_status = "completed"
             summary_json = json.dumps(
-                {
+                _attach_crawl_warning({
                     "login_walls_skipped": len(auth_wall_pages),
                     "sample_urls": auth_wall_pages[:10],
-                }
+                }, crawl_outcome_warning)
             )
             await conn.execute(
                 "UPDATE knowledge.crawl_jobs SET status=$1, error_summary=$2::jsonb, "
                 "updated_at=$3 WHERE id=$4",
                 terminal_status,
                 summary_json,
+                int(time.time()),
+                job_id,
+            )
+        elif crawl_outcome_warning:
+            terminal_status = "completed"
+            await conn.execute(
+                "UPDATE knowledge.crawl_jobs SET status=$1, error_summary=$2::jsonb, "
+                "updated_at=$3 WHERE id=$4",
+                terminal_status,
+                json.dumps(crawl_outcome_warning),
                 int(time.time()),
                 job_id,
             )

--- a/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
@@ -13,7 +13,7 @@ import json
 import re
 from dataclasses import dataclass, field
 from html import unescape
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import urldefrag, urlparse, urlunparse
 
 import httpx
@@ -78,6 +78,39 @@ class CrawlResult:
     error_message: str | None = None
     metadata: dict[str, Any] | None = None
     response_headers: dict[str, str] | None = None
+
+
+DiscoverySourceKind = Literal["start", "sitemap", "page_link"]
+DiscoveryStatus = Literal["queued", "fetched", "omitted"]
+
+
+@dataclass
+class DiscoveredUrl:
+    """One URL in Klai's crawl frontier ledger.
+
+    Crawl4AI renders pages and extracts links; Klai owns the crawl plan.
+    The ledger lets us explain every in-scope discovered URL as fetched or
+    deliberately omitted instead of silently losing URLs inside a third-party
+    BFS frontier.
+    """
+
+    url: str
+    canonical_url: str
+    depth: int
+    discovered_from: str | None
+    source_kind: DiscoverySourceKind
+    priority: int
+    order: int
+    status: DiscoveryStatus = "queued"
+    reason_code: str | None = None
+
+
+_PRIORITY_START = 0
+_PRIORITY_SITEMAP = 10
+_PRIORITY_SECTION_ROOT = 20
+_PRIORITY_LISTING_CHILD = 25
+_PRIORITY_PAGE_LINK = 50
+_LISTING_LINK_THRESHOLD = 50
 
 
 # ---------------------------------------------------------------------------
@@ -681,6 +714,194 @@ async def crawl_page(
     return result
 
 
+class CrawlLedger:
+    """Deterministic crawl frontier + audit ledger."""
+
+    def __init__(
+        self,
+        *,
+        start_url: str,
+        base_domain: str,
+        include_patterns: list[str] | None,
+        exclude_patterns: list[str] | None,
+        max_depth: int,
+    ) -> None:
+        self.start_url = start_url
+        self.base_domain = base_domain
+        self.include_patterns = include_patterns
+        self.exclude_patterns = exclude_patterns
+        self.max_depth = max_depth
+        self._by_canonical: dict[str, DiscoveredUrl] = {}
+        self._order = 0
+
+    @property
+    def discovered_count(self) -> int:
+        return len(self._by_canonical)
+
+    def add_start(self) -> None:
+        self.add(
+            self.start_url,
+            depth=0,
+            discovered_from=None,
+            source_kind="start",
+            priority=_PRIORITY_START,
+            force=True,
+        )
+
+    def add_sitemap_urls(self, urls: list[str]) -> None:
+        for url in urls:
+            self.add(
+                url,
+                depth=1,
+                discovered_from=None,
+                source_kind="sitemap",
+                priority=_PRIORITY_SITEMAP,
+            )
+
+    def add_links_from_result(self, result: CrawlResult, *, source_depth: int) -> None:
+        internal = (result.links or {}).get("internal") or []
+        source_listing = _is_listing_source(result)
+        for entry in internal:
+            href = entry.get("href") if isinstance(entry, dict) else None
+            if not href:
+                continue
+            priority = (
+                _PRIORITY_LISTING_CHILD
+                if source_listing
+                else _priority_for_discovered_url(href)
+            )
+            self.add(
+                href,
+                depth=source_depth + 1,
+                discovered_from=result.url,
+                source_kind="page_link",
+                priority=priority,
+            )
+
+    def add(
+        self,
+        url: str,
+        *,
+        depth: int,
+        discovered_from: str | None,
+        source_kind: DiscoverySourceKind,
+        priority: int,
+        force: bool = False,
+    ) -> bool:
+        if not url:
+            return False
+        if not _same_site_domain(urlparse(url).netloc.lower(), self.base_domain):
+            return False
+        url = _coerce_same_site_url_to_base_host(url, self.base_domain)
+        if not force:
+            if not _url_matches_include_patterns(url, self.include_patterns):
+                return False
+            if _url_matches_patterns(url, self.exclude_patterns):
+                return False
+        canonical = _canonicalise_url(url)
+        existing = self._by_canonical.get(canonical)
+        if existing is not None:
+            if depth < existing.depth:
+                existing.depth = depth
+                existing.discovered_from = discovered_from
+                existing.source_kind = source_kind
+            existing.priority = min(existing.priority, priority)
+            return False
+        self._order += 1
+        self._by_canonical[canonical] = DiscoveredUrl(
+            url=url,
+            canonical_url=canonical,
+            depth=depth,
+            discovered_from=discovered_from,
+            source_kind=source_kind,
+            priority=priority,
+            order=self._order,
+        )
+        return True
+
+    def next_batch(self, *, remaining_budget: int) -> list[str]:
+        if remaining_budget <= 0:
+            return []
+        queued = [
+            item
+            for item in self._by_canonical.values()
+            if item.status == "queued" and item.depth <= self.max_depth
+        ]
+        queued.sort(key=lambda i: (i.priority, i.depth, i.order))
+        return [item.url for item in queued[:remaining_budget]]
+
+    def mark_outcome(self, outcome: FetchOutcome) -> None:
+        item = self._by_canonical.get(_canonicalise_url(str(outcome.get("url") or "")))
+        if item is None:
+            return
+        item.status = "fetched"
+        item.reason_code = str(outcome.get("reason_code") or "")
+
+    def depth_for_url(self, url: str) -> int | None:
+        item = self._by_canonical.get(_canonicalise_url(url))
+        return item.depth if item else None
+
+    def mark_unfetched(self, *, fetched_count: int, max_pages: int) -> None:
+        budget_exhausted = fetched_count >= max_pages
+        for item in self._by_canonical.values():
+            if item.status != "queued":
+                continue
+            item.status = "omitted"
+            if item.depth > self.max_depth:
+                item.reason_code = FetchReasonCode.NOT_FETCHED_DEPTH_LIMIT.value
+            elif budget_exhausted:
+                item.reason_code = FetchReasonCode.NOT_FETCHED_BUDGET_EXHAUSTED.value
+            else:
+                item.reason_code = FetchReasonCode.NOT_FETCHED_DISCOVERY_LIMIT.value
+
+    def omitted_outcomes(self) -> list[FetchOutcome]:
+        omitted = [
+            item
+            for item in self._by_canonical.values()
+            if item.status == "omitted" and item.reason_code
+        ]
+        omitted.sort(key=lambda i: (i.priority, i.depth, i.order))
+        return [
+            {
+                "url": item.url,
+                "reason_code": item.reason_code,
+                "status_code": None,
+                "content_length": 0,
+            }
+            for item in omitted
+        ]
+
+
+def _priority_for_discovered_url(url: str) -> int:
+    segments = _path_segments(url)
+    if 1 < len(segments) <= 2:
+        return _PRIORITY_SECTION_ROOT
+    return _PRIORITY_PAGE_LINK
+
+
+def _is_listing_source(result: CrawlResult) -> bool:
+    internal = (result.links or {}).get("internal") or []
+    if len(internal) >= _LISTING_LINK_THRESHOLD:
+        return True
+    return _is_non_content_listing_page(result)
+
+
+def _crawl_results_from_raw_results(
+    raw_results: list[dict[str, Any]],
+    *,
+    base_domain: str,
+) -> list[CrawlResult]:
+    """Parse successful same-domain responses for follow-up link discovery."""
+    results: list[CrawlResult] = []
+    for page in raw_results:
+        if not page:
+            continue
+        result = _extract_result(page.get("url") or "", page)
+        if result.success and _same_site_domain(urlparse(result.url).netloc.lower(), base_domain):
+            results.append(result)
+    return results
+
+
 async def crawl_site(
     start_url: str,
     selector: str | None = None,
@@ -691,44 +912,11 @@ async def crawl_site(
     login_indicator_selector: str | None = None,
     cookies: list[dict[str, Any]] | None = None,
 ) -> tuple[list[CrawlResult], list[FetchOutcome]]:
-    """Crawl a site via server-side BFS deep crawl + sitemap orphan supplement.
+    """Crawl a site with a Klai-owned deterministic frontier.
 
-    Two-phase architecture:
-
-    1. **Phase 1 — Server-side recursive BFS** (``/crawl/job`` +
-       ``BFSDeepCrawlStrategy``): crawl4ai walks the site link-graph
-       breadth-first up to ``max_depth`` levels and ``max_pages`` total,
-       respecting ``include_patterns`` via ``URLPatternFilter`` (real
-       fnmatch glob, not the substring approximation). crawl4ai's own
-       MemoryAdaptiveDispatcher handles concurrency safely server-side
-       — no client-side ``asyncio.gather`` over a shared connection.
-
-    2. **Phase 2 — Sitemap supplement** (chunked ``/crawl``): URLs in
-       ``sitemap.xml`` that the BFS did not visit (orphans, pages not
-       reachable via internal links from the start_url) are submitted via
-       the chunked-bulk-fetch path (≤100 URLs/request — crawl4ai 0.8
-       enforces that cap on the ``urls`` array). Per-chunk transport
-       failure logged but does not abort remaining chunks.
-
-    Phase 1 alone covers wikis/docs (recursive link-following). Phase 2
-    catches orphans (sitemap-only entries the homepage doesn't link to).
-    Together they reach the BOTH "everything in sitemap" AND "everything
-    reachable by following links" — a property neither alone provides.
-
-    Why two phases (and why the OLD pre-RECONCILE pattern was right):
-
-    - help.voys.nl: 208 sitemap entries, BFS-reachable subset is smaller →
-      Phase 1 covers most, Phase 2 fills the orphans.
-    - wiki.redcactus.cloud: no sitemap, ~150-300 internally-linked pages →
-      Phase 1 covers everything, Phase 2 is a no-op.
-
-    SPEC-INGEST-RECONCILE-001 replaced this pattern with "discovery
-    upfront, no recursion" because the old Phase 2 used
-    ``asyncio.gather(*[crawl_page(u)…], return_exceptions=True)`` which
-    silently dropped pages on concurrent-conn errors. THAT was the bug.
-    Phase 1 (server-side BFS) was always correct. The fix is to keep
-    Phase 1 and replace Phase 2's gather with the chunked-bulk-fetch
-    contract (which serialises work through crawl4ai's own dispatcher).
+    Crawl4AI renders pages and extracts links; Klai owns URL scheduling.
+    Every in-scope discovered URL is either fetched or emitted as a
+    ``not_fetched_*`` outcome, so page-budget/depth limits fail loudly.
 
     Returns ``(crawl_results, outcomes)``:
     - ``crawl_results``: same-domain pages with non-empty markdown.
@@ -743,111 +931,67 @@ async def crawl_site(
         selector,
         login_indicator_selector=login_indicator_selector,
     )
-
-    # ------------------------------------------------------------------
-    # Phase 1 — Server-side BFS deep crawl via crawl4ai BFSDeepCrawlStrategy.
-    # ------------------------------------------------------------------
-    bfs_results, bfs_error = await _bfs_deep_crawl(
+    ledger = CrawlLedger(
         start_url=start_url,
-        crawler_config=crawler_config,
-        max_depth=max_depth,
-        max_pages=max_pages,
+        base_domain=base_domain,
         include_patterns=include_patterns,
         exclude_patterns=exclude_patterns,
-        cookies=cookies,
+        max_depth=max_depth,
     )
-    # Same-domain + explicit-exclude guard: keep this even though
-    # exclude_patterns are also pushed into crawl4ai's BFS filter_chain. It
-    # protects progress counting / dirty-content decisions if crawl4ai changes
-    # filter semantics or sitemap/bulk results include an excluded URL.
-    bfs_results = [
-        r
-        for r in bfs_results
-        if _same_site_domain(urlparse(r.url).netloc.lower(), base_domain)
-        and not _url_matches_patterns(r.url, exclude_patterns)
-    ]
+    ledger.add_start()
 
-    # ------------------------------------------------------------------
-    # Phase 2 — Sitemap supplement: pages in sitemap.xml that BFS missed
-    # (orphans not reachable via internal links from start_url).
-    # ------------------------------------------------------------------
     sitemap_urls = await _fetch_sitemap_urls(start_url)
-    seen_canonicals: set[str] = {_canonicalise_url(start_url)}
-    seen_canonicals.update(_canonicalise_url(r.url) for r in bfs_results)
+    ledger.add_sitemap_urls(sitemap_urls)
 
-    supplement_candidates: list[str] = []
-    remaining_budget = max_pages - len(bfs_results)
-    for u in sitemap_urls:
-        if remaining_budget <= 0:
-            break
-        u = _coerce_same_site_url_to_base_host(u, base_domain)
-        canonical = _canonicalise_url(u)
-        if canonical in seen_canonicals:
-            continue
-        if not _url_matches_include_patterns(u, include_patterns):
-            continue
-        if _url_matches_patterns(u, exclude_patterns):
-            continue
-        if not _same_site_domain(urlparse(u).netloc.lower(), base_domain):
-            continue
-        seen_canonicals.add(canonical)
-        supplement_candidates.append(u)
-        remaining_budget -= 1
+    crawl_results: list[CrawlResult] = []
+    outcomes: list[FetchOutcome] = []
+    fetched_count = 0
 
-    logger.info(
-        "crawl_site_discovery_complete",
+    start_result = await _fetch_seed_page(
         start_url=start_url,
-        bfs_pages=len(bfs_results),
-        bfs_error=str(bfs_error) if bfs_error else None,
-        sitemap_urls=len(sitemap_urls),
-        supplement_candidates=len(supplement_candidates),
-        max_pages=max_pages,
-    )
-
-    supplement_raw_results, supplement_transport_error = await _chunked_bulk_fetch(
-        urls=supplement_candidates,
         crawler_config=crawler_config,
         cookies=cookies,
     )
+    start_outcome = _build_outcome_from_result(start_url, start_result)
+    ledger.mark_outcome(start_outcome)
+    outcomes.append(start_outcome)
+    fetched_count += 1
+    if _result_is_ingestable(start_result, base_domain=base_domain) and not _is_non_content_listing_page(start_result):
+        crawl_results.append(start_result)
+    if start_result.success:
+        ledger.add_links_from_result(start_result, source_depth=0)
 
-    # ------------------------------------------------------------------
-    # Combine BFS results + supplement results into the
-    # (crawl_results, outcomes) contract.
-    # ------------------------------------------------------------------
-    crawl_results: list[CrawlResult] = []
-    outcomes: list[FetchOutcome] = []
+    while fetched_count < max_pages:
+        batch = ledger.next_batch(remaining_budget=max_pages - fetched_count)
+        if not batch:
+            break
 
-    # BFS results: each visited page becomes one outcome + one ingestable
-    # result (when same-domain + non-empty markdown).
-    for r in bfs_results:
-        outcomes.append(_build_outcome_from_result(r.url, r))
-        if _result_is_ingestable(r, base_domain=base_domain) and not _is_non_content_listing_page(r):
-            crawl_results.append(r)
-
-    # If the BFS itself failed (network/timeout/5xx) AND we got no results,
-    # surface a transport_error outcome for start_url so operators see the
-    # failure in fetch_outcomes instead of a silent empty BFS.
-    if bfs_error is not None and not bfs_results:
-        outcomes.append(
-            {
-                "url": start_url,
-                "reason_code": FetchReasonCode.UNKNOWN_EXCEPTION.value,
-                "status_code": None,
-                "content_length": 0,
-            }
+        raw_results, transport_error = await _chunked_bulk_fetch(
+            urls=batch,
+            crawler_config=crawler_config,
+            cookies=cookies,
         )
+        fetched_count += len(batch)
 
-    # Supplement results: canonical-URL matched against the chunked-bulk
-    # response, with positional fallback for redirect cases (matches the
-    # RECONCILE contract).
-    supplement_results, supplement_outcomes = _combine_bulk_responses(
-        candidates=supplement_candidates,
-        raw_results=supplement_raw_results,
-        transport_error=supplement_transport_error,
-        base_domain=base_domain,
-    )
-    crawl_results.extend(supplement_results)
-    outcomes.extend(supplement_outcomes)
+        batch_results, batch_outcomes = _combine_bulk_responses(
+            candidates=batch,
+            raw_results=raw_results,
+            transport_error=transport_error,
+            base_domain=base_domain,
+        )
+        for outcome in batch_outcomes:
+            ledger.mark_outcome(outcome)
+        outcomes.extend(batch_outcomes)
+        crawl_results.extend(batch_results)
+
+        for result in _crawl_results_from_raw_results(raw_results, base_domain=base_domain):
+            source_depth = ledger.depth_for_url(result.url)
+            if source_depth is not None and source_depth < max_depth:
+                ledger.add_links_from_result(result, source_depth=source_depth)
+
+    ledger.mark_unfetched(fetched_count=fetched_count, max_pages=max_pages)
+    omitted_outcomes = ledger.omitted_outcomes()
+    outcomes.extend(omitted_outcomes)
 
     success_count = sum(1 for o in outcomes if o["reason_code"] == FetchReasonCode.SUCCESS.value)
     logger.info(
@@ -857,8 +1001,9 @@ async def crawl_site(
         results=len(crawl_results),
         success_outcomes=success_count,
         non_success_outcomes=len(outcomes) - success_count,
-        bfs_pages=len(bfs_results),
-        supplement_pages=len(supplement_results),
+        discovered_urls=ledger.discovered_count,
+        omitted_urls=len(omitted_outcomes),
+        max_pages=max_pages,
     )
 
     return crawl_results, outcomes

--- a/klai-knowledge-ingest/knowledge_ingest/reason_codes.py
+++ b/klai-knowledge-ingest/knowledge_ingest/reason_codes.py
@@ -49,6 +49,11 @@ class FetchReasonCode(StrEnum):
     PARSE_ERROR = "parse_error"
     RATE_LIMITED = "rate_limited"
     NON_CONTENT_LISTING_PAGE = "non_content_listing_page"
+    NOT_FETCHED_BUDGET_EXHAUSTED = "not_fetched_budget_exhausted"
+    NOT_FETCHED_DEPTH_LIMIT = "not_fetched_depth_limit"
+    NOT_FETCHED_DISCOVERY_LIMIT = "not_fetched_discovery_limit"
+    NOT_FETCHED_EXCLUDED = "not_fetched_excluded"
+    NOT_FETCHED_DUPLICATE = "not_fetched_duplicate"
     UNKNOWN_EXCEPTION = "unknown_exception"
 
 

--- a/klai-knowledge-ingest/tests/test_crawl4ai_filter_chain.py
+++ b/klai-knowledge-ingest/tests/test_crawl4ai_filter_chain.py
@@ -1,21 +1,4 @@
-"""SPEC-INGEST-RECONCILE-001 Fix 1 — include_patterns filtering on candidates.
-
-The legacy test (pre-Reconcile-001) asserted that ``filter_chain`` was
-JSON-wrapped correctly inside crawl4ai's ``deep_crawl_strategy`` payload.
-That payload no longer exists: ``crawl_site`` now hands a flat URL list
-to ``POST /crawl`` and applies ``include_patterns`` as a candidate-side
-substring filter. These tests pin the new behaviour:
-
-- When ``include_patterns`` is set, only matching candidates reach the
-  bulk request body.
-- When ``include_patterns`` is None, every same-domain candidate from
-  sitemap + BFS-union reaches the request body — but ``start_url`` is
-  NOT in the bulk submission (it is fetched separately as the seed; see
-  followup PR §"redundant start_url fetch").
-- The crawler_config payload no longer carries a ``deep_crawl_strategy``
-  key (regression guard against the legacy BFS path being reintroduced
-  alongside the bulk path).
-"""
+"""crawl_site frontier filtering and Crawl4AI payload shape tests."""
 
 from __future__ import annotations
 
@@ -65,20 +48,21 @@ async def test_crawl_site_applies_include_patterns_to_candidates(
         "https://wiki.redcactus.cloud/en/getting-started",
         "https://wiki.redcactus.cloud/nl/advanced",
     ]
-    bfs_results = [
-        _seed_result("https://wiki.redcactus.cloud", []),
-        _seed_result("https://wiki.redcactus.cloud/nl/blog", []),
-    ]
+    _patch_seed(
+        monkeypatch,
+        _seed_result(
+            "https://wiki.redcactus.cloud",
+            [
+                "https://wiki.redcactus.cloud/nl/blog",
+                "https://wiki.redcactus.cloud/en/blog",
+            ],
+        ),
+    )
 
     async def _fake_sitemap(_base: str) -> list[str]:
         return sitemap_urls
 
     monkeypatch.setattr(crawl4ai_client, "_fetch_sitemap_urls", _fake_sitemap)
-
-    async def _fake_bfs(**_kwargs: Any) -> tuple[list[CrawlResult], None]:
-        return bfs_results, None
-
-    monkeypatch.setattr(crawl4ai_client, "_bfs_deep_crawl", _fake_bfs)
 
     captured: dict[str, Any] = {}
 
@@ -112,12 +96,11 @@ async def test_crawl_site_applies_include_patterns_to_candidates(
         assert "/nl/" in u, f"include_patterns leaked a non-/nl/ URL: {u}"
     assert "https://wiki.redcactus.cloud/nl/getting-started" in urls_submitted
     assert "https://wiki.redcactus.cloud/nl/advanced" in urls_submitted
-    assert "https://wiki.redcactus.cloud/nl/blog" not in urls_submitted
+    assert "https://wiki.redcactus.cloud/nl/blog" in urls_submitted
     assert "https://wiki.redcactus.cloud/en/getting-started" not in urls_submitted
     assert "https://wiki.redcactus.cloud/en/blog" not in urls_submitted
     assert "deep_crawl_strategy" not in payload["crawler_config"]["params"]
-    # AC-4: every candidate produces an outcome record. BFS + supplement.
-    assert len(outcomes) == len(bfs_results) + len(urls_submitted)
+    assert len(outcomes) == 1 + len(urls_submitted)
 
 
 @pytest.mark.asyncio
@@ -135,14 +118,7 @@ async def test_crawl_site_no_include_patterns_passes_all_same_domain(
         return sitemap_urls
 
     monkeypatch.setattr(crawl4ai_client, "_fetch_sitemap_urls", _fake_sitemap)
-
-    async def _fake_bfs(**_kwargs: Any) -> tuple[list[CrawlResult], None]:
-        return [
-            _seed_result("https://example.com", []),
-            _seed_result("https://example.com/page-c", []),
-        ], None
-
-    monkeypatch.setattr(crawl4ai_client, "_bfs_deep_crawl", _fake_bfs)
+    _patch_seed(monkeypatch, _seed_result("https://example.com", ["https://example.com/page-c"]))
 
     captured: dict[str, Any] = {}
 
@@ -166,7 +142,7 @@ async def test_crawl_site_no_include_patterns_passes_all_same_domain(
     )
     assert "https://example.com/page-a" in urls_submitted
     assert "https://example.com/page-b" in urls_submitted
-    assert "https://example.com/page-c" not in urls_submitted
+    assert "https://example.com/page-c" in urls_submitted
     # Cross-domain entry from sitemap MUST NOT leak through.
     assert "https://other.com/skipped" not in urls_submitted
     assert "deep_crawl_strategy" not in payload["crawler_config"]["params"]
@@ -181,42 +157,40 @@ async def test_crawl_site_excludes_archive_candidates_after_discovery(
         "https://www.getklai.com/blog/article-from-sitemap",
         "https://www.getklai.com/blog/tag/privacy",
     ]
-    bfs_results = [
-        CrawlResult(
-            url="https://www.getklai.com/blog/article-from-bfs",
-            fit_markdown="Article",
-            raw_markdown="Article",
-            html="<html></html>",
-            word_count=1,
-            success=True,
-            links={"internal": []},
-        ),
-        CrawlResult(
-            url="https://www.getklai.com/blog/tag/AI",
-            fit_markdown="Tag archive",
-            raw_markdown="Tag archive",
-            html="<html></html>",
-            word_count=2,
-            success=True,
-            links={"internal": []},
-        ),
-    ]
-
-    async def _fake_bfs(**_kwargs: Any) -> tuple[list[CrawlResult], None]:
-        return bfs_results, None
-
     async def _fake_sitemap(_base: str) -> list[str]:
         return sitemap_urls
 
-    monkeypatch.setattr(crawl4ai_client, "_bfs_deep_crawl", _fake_bfs)
     monkeypatch.setattr(crawl4ai_client, "_fetch_sitemap_urls", _fake_sitemap)
+    _patch_seed(
+        monkeypatch,
+        _seed_result(
+            "https://www.getklai.com/blog",
+            [
+                "https://www.getklai.com/blog/article-from-bfs",
+                "https://www.getklai.com/blog/tag/AI",
+            ],
+        ),
+    )
 
     captured: dict[str, Any] = {}
 
     async def _fake_post(self: httpx.AsyncClient, url: str, **kwargs: Any) -> httpx.Response:
         captured["payload"] = kwargs.get("json")
+        urls = captured["payload"]["urls"]
+        results = [
+            {
+                "url": u,
+                "success": True,
+                "status_code": 200,
+                "html": "<html>Article</html>",
+                "markdown": "Article",
+                "links": {"internal": []},
+                "media": {},
+            }
+            for u in urls
+        ]
         request = httpx.Request("POST", url)
-        return httpx.Response(200, json={"results": []}, request=request)
+        return httpx.Response(200, json={"results": results}, request=request)
 
     with patch("httpx.AsyncClient.post", new=_fake_post):
         results, outcomes = await crawl4ai_client.crawl_site(
@@ -225,12 +199,20 @@ async def test_crawl_site_excludes_archive_candidates_after_discovery(
             exclude_patterns=["/blog/tag/*"],
         )
 
-    assert {r.url for r in results} == {"https://www.getklai.com/blog/article-from-bfs"}
-    assert {o["url"] for o in outcomes} == {
+    assert {r.url for r in results} == {
+        "https://www.getklai.com/blog",
         "https://www.getklai.com/blog/article-from-bfs",
         "https://www.getklai.com/blog/article-from-sitemap",
     }
-    assert captured["payload"]["urls"] == ["https://www.getklai.com/blog/article-from-sitemap"]
+    assert {o["url"] for o in outcomes} == {
+        "https://www.getklai.com/blog",
+        "https://www.getklai.com/blog/article-from-bfs",
+        "https://www.getklai.com/blog/article-from-sitemap",
+    }
+    assert captured["payload"]["urls"] == [
+        "https://www.getklai.com/blog/article-from-sitemap",
+        "https://www.getklai.com/blog/article-from-bfs",
+    ]
 
 
 @pytest.mark.asyncio

--- a/klai-knowledge-ingest/tests/test_crawl_site_dirty_content_guard.py
+++ b/klai-knowledge-ingest/tests/test_crawl_site_dirty_content_guard.py
@@ -17,7 +17,10 @@ from __future__ import annotations
 import pytest
 
 from knowledge_ingest.adapters.crawler import (
+    CRAWL_BUDGET_EXHAUSTED_REASON,
     DIRTY_CONTENT_REASON,
+    _build_crawl_outcome_warning,
+    _crawl_warning_terminal_status,
     decide_terminal_status,
 )
 
@@ -132,6 +135,33 @@ def test_summary_contains_actionable_suggestion() -> None:
         "authentication" in suggestion.lower()
         or "content_selector" in suggestion.lower()
     )
+
+
+def test_budget_exhausted_outcomes_build_failed_partial_warning() -> None:
+    warning = _build_crawl_outcome_warning(
+        [
+            {
+                "url": "https://example.com/fetched",
+                "reason_code": "success",
+                "status_code": 200,
+                "content_length": 100,
+            },
+            {
+                "url": "https://example.com/not-fetched",
+                "reason_code": "not_fetched_budget_exhausted",
+                "status_code": None,
+                "content_length": 0,
+            },
+        ],
+        max_pages=200,
+    )
+
+    assert warning is not None
+    assert warning["reason"] == CRAWL_BUDGET_EXHAUSTED_REASON
+    assert warning["omitted_count"] == 1
+    assert warning["omitted_reason_counts"] == {"not_fetched_budget_exhausted": 1}
+    assert warning["sample_omitted_urls"] == ["https://example.com/not-fetched"]
+    assert _crawl_warning_terminal_status(warning) == "failed_partial"
 
 
 @pytest.mark.parametrize("trip_rate_input", [0.31, 0.5, 0.7, 1.0])

--- a/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
+++ b/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
@@ -343,11 +343,7 @@ async def test_crawl_site_bulk_transport_failure_records_one_outcome_per_candida
         ]
 
     monkeypatch.setattr(crawl4ai_client, "_fetch_sitemap_urls", _fake_sitemap)
-
-    async def _fake_bfs(**_kwargs: Any) -> tuple[list[CrawlResult], None]:
-        return [_seed("https://example.com")], None
-
-    monkeypatch.setattr(crawl4ai_client, "_bfs_deep_crawl", _fake_bfs)
+    _patch_seed(monkeypatch, _seed("https://example.com"))
 
     async def _fake_post(self: httpx.AsyncClient, url: str, **_kwargs: Any) -> httpx.Response:
         raise httpx.ReadTimeout("simulated bulk timeout")
@@ -390,11 +386,7 @@ async def test_crawl_site_returns_one_outcome_per_candidate_on_partial_success(
         ]
 
     monkeypatch.setattr(crawl4ai_client, "_fetch_sitemap_urls", _fake_sitemap)
-
-    async def _fake_bfs(**_kwargs: Any) -> tuple[list[CrawlResult], None]:
-        return [_seed("https://example.com")], None
-
-    monkeypatch.setattr(crawl4ai_client, "_bfs_deep_crawl", _fake_bfs)
+    _patch_seed(monkeypatch, _seed("https://example.com"))
 
     # Bulk response — start_url is NOT in the request body, so the response
     # body MUST NOT include it either.
@@ -455,6 +447,154 @@ async def test_crawl_site_returns_one_outcome_per_candidate_on_partial_success(
     assert {r.url for r in results} == {"https://example.com", "https://example.com/ok"}
 
 
+@pytest.mark.asyncio
+async def test_crawl_site_frontier_fetches_listing_children(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Links discovered on fetched listing pages must enter the Klai frontier."""
+
+    async def _fake_sitemap(_base: str) -> list[str]:
+        return []
+
+    monkeypatch.setattr(crawl4ai_client, "_fetch_sitemap_urls", _fake_sitemap)
+    _patch_seed(
+        monkeypatch,
+        _seed("https://wiki.redcactus.cloud/nl", internal=[
+            "https://wiki.redcactus.cloud/nl/crm-software"
+        ]),
+    )
+
+    async def _fake_bulk_fetch(
+        *,
+        urls: list[str],
+        **_kwargs: Any,
+    ) -> tuple[list[dict[str, Any]], BaseException | None]:
+        pages: list[dict[str, Any]] = []
+        for url in urls:
+            if url == "https://wiki.redcactus.cloud/nl/crm-software":
+                pages.append(
+                    {
+                        "url": url,
+                        "success": True,
+                        "status_code": 200,
+                        "html": "<html>CRM listing</html>",
+                        "markdown": "CRM listing",
+                        "links": {
+                            "internal": [
+                                {
+                                    "href": "https://wiki.redcactus.cloud/nl/crm-software/zoho-bigin",
+                                    "text": "Zoho Bigin",
+                                },
+                                {
+                                    "href": "https://wiki.redcactus.cloud/nl/crm-software/zoho-crm",
+                                    "text": "Zoho CRM",
+                                },
+                                {
+                                    "href": "https://wiki.redcactus.cloud/nl/crm-software/zoho-desk",
+                                    "text": "Zoho Desk",
+                                },
+                            ]
+                        },
+                        "media": {},
+                    }
+                )
+            else:
+                pages.append(
+                    {
+                        "url": url,
+                        "success": True,
+                        "status_code": 200,
+                        "html": f"<html>{url}</html>",
+                        "markdown": url.rsplit("/", 1)[-1],
+                        "links": {"internal": []},
+                        "media": {},
+                    }
+                )
+        return pages, None
+
+    monkeypatch.setattr(crawl4ai_client, "_chunked_bulk_fetch", _fake_bulk_fetch)
+
+    results, outcomes = await crawl4ai_client.crawl_site(
+        start_url="https://wiki.redcactus.cloud/nl",
+        max_depth=2,
+        max_pages=10,
+        include_patterns=["/nl/"],
+    )
+
+    outcome_urls = {outcome["url"] for outcome in outcomes}
+    assert "https://wiki.redcactus.cloud/nl/crm-software/zoho-bigin" in outcome_urls
+    assert "https://wiki.redcactus.cloud/nl/crm-software/zoho-crm" in outcome_urls
+    assert "https://wiki.redcactus.cloud/nl/crm-software/zoho-desk" in outcome_urls
+    assert {
+        "https://wiki.redcactus.cloud/nl/crm-software/zoho-bigin",
+        "https://wiki.redcactus.cloud/nl/crm-software/zoho-crm",
+        "https://wiki.redcactus.cloud/nl/crm-software/zoho-desk",
+    }.issubset({result.url for result in results})
+
+
+@pytest.mark.asyncio
+async def test_crawl_site_records_budget_exhausted_for_unfetched_frontier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When max_pages stops the frontier, discovered URLs get explicit outcomes."""
+
+    async def _fake_sitemap(_base: str) -> list[str]:
+        return []
+
+    monkeypatch.setattr(crawl4ai_client, "_fetch_sitemap_urls", _fake_sitemap)
+    _patch_seed(
+        monkeypatch,
+        _seed("https://example.com/nl", internal=["https://example.com/nl/crm-software"]),
+    )
+
+    async def _fake_bulk_fetch(
+        *,
+        urls: list[str],
+        **_kwargs: Any,
+    ) -> tuple[list[dict[str, Any]], BaseException | None]:
+        assert urls == ["https://example.com/nl/crm-software"]
+        return [
+            {
+                "url": "https://example.com/nl/crm-software",
+                "success": True,
+                "status_code": 200,
+                "html": "<html>CRM listing</html>",
+                "markdown": "CRM listing",
+                "links": {
+                    "internal": [
+                        {"href": "https://example.com/nl/crm-software/zoho-bigin", "text": ""},
+                        {"href": "https://example.com/nl/crm-software/zoho-crm", "text": ""},
+                        {"href": "https://example.com/nl/crm-software/zoho-desk", "text": ""},
+                    ]
+                },
+                "media": {},
+            }
+        ], None
+
+    monkeypatch.setattr(crawl4ai_client, "_chunked_bulk_fetch", _fake_bulk_fetch)
+
+    _results, outcomes = await crawl4ai_client.crawl_site(
+        start_url="https://example.com/nl",
+        max_depth=2,
+        max_pages=2,
+        include_patterns=["/nl/"],
+    )
+
+    by_url = {outcome["url"]: outcome for outcome in outcomes}
+    assert (
+        by_url["https://example.com/nl/crm-software/zoho-bigin"]["reason_code"]
+        == FetchReasonCode.NOT_FETCHED_BUDGET_EXHAUSTED.value
+    )
+    assert (
+        by_url["https://example.com/nl/crm-software/zoho-crm"]["reason_code"]
+        == FetchReasonCode.NOT_FETCHED_BUDGET_EXHAUSTED.value
+    )
+    assert (
+        by_url["https://example.com/nl/crm-software/zoho-desk"]["reason_code"]
+        == FetchReasonCode.NOT_FETCHED_BUDGET_EXHAUSTED.value
+    )
+
+
 # ---------------------------------------------------------------------------
 # Followup PR — start_url is fetched once (no bulk re-fetch)
 # ---------------------------------------------------------------------------
@@ -504,17 +644,17 @@ async def test_seed_config_carries_login_indicator(monkeypatch: pytest.MonkeyPat
     "succeeded" on the login page, the BFS link list became
     login-form anchors, and the bulk ran into AUTH_ERROR on every URL.
     """
-    captured_bfs_config: dict[str, Any] = {}
+    captured_seed_config: dict[str, Any] = {}
 
-    async def _fake_bfs(
+    async def _fake_seed(
         *,
         crawler_config: dict[str, Any],
         **_kwargs: Any,
-    ) -> tuple[list[CrawlResult], None]:
-        captured_bfs_config.update(crawler_config)
-        return [_seed("https://wiki.example")], None
+    ) -> CrawlResult:
+        captured_seed_config.update(crawler_config)
+        return _seed("https://wiki.example")
 
-    monkeypatch.setattr(crawl4ai_client, "_bfs_deep_crawl", _fake_bfs)
+    monkeypatch.setattr(crawl4ai_client, "_fetch_seed_page", _fake_seed)
     monkeypatch.setattr(
         crawl4ai_client, "_fetch_sitemap_urls", lambda _base: _async_return([])
     )
@@ -529,9 +669,9 @@ async def test_seed_config_carries_login_indicator(monkeypatch: pytest.MonkeyPat
             login_indicator_selector="#loginForm",
         )
 
-    # The BFS config MUST reflect the login_indicator: build_crawl_config
+    # The seed config MUST reflect the login_indicator: build_crawl_config
     # negates the wait_for expression with the indicator selector when set.
-    wait_for = captured_bfs_config.get("wait_for", "")
+    wait_for = captured_seed_config.get("wait_for", "")
     assert "#loginForm" in wait_for, (
         f"seed config did not propagate login_indicator_selector — wait_for was {wait_for!r}"
     )


### PR DESCRIPTION
## Summary
- Replace Crawl4AI-owned server-side BFS scheduling with a Klai-owned deterministic crawl frontier ledger.
- Keep Crawl4AI responsible for rendering pages and extracting links, while Klai records every in-scope discovered URL as fetched or `not_fetched_*`.
- Surface crawl budget/depth truncation through `crawl_jobs.error_summary`, with `crawl_budget_exhausted` ending as `failed_partial` instead of silently completing.

## Root Cause
Red Cactus wiki pages such as `/nl/crm-software/zoho-desk` were discoverable from `/nl/crm-software`, but Crawl4AI BFS did not visit them within the current frontier ordering/page budget. The previous outcomes only showed fetched/candidate URLs, so budget truncation looked like a successful ingest.

## Validation
- `uv run pytest tests/test_crawl_site_reconcile.py tests/test_crawl4ai_filter_chain.py tests/test_crawl_site_dirty_content_guard.py tests/test_reason_codes_parity.py` in `klai-knowledge-ingest`
- `uv run pytest tests/test_crawler_anonymous_auth_wall.py tests/test_crawler_login_indicator.py tests/test_crawler_link_fields.py tests/test_crawler_link_fields_complete.py` in `klai-knowledge-ingest`
- `uv run --python 3.13 pytest tests/test_reason_codes_parity.py` in `klai-connector`
- `ruff check` on changed ingest/connector files
- `git diff --check`
