### PR TITLE
Add feedback subdomain to OIDC callback allowlist

### DIFF
--- a/klai-portal/backend/app/api/auth.py
+++ b/klai-portal/backend/app/api/auth.py
@@ -435,6 +435,8 @@ _STATIC_SYSTEM_SUBDOMAINS: frozenset[str] = frozenset(
         # Observability
         "grafana",
         "errors",
+        # Public-facing system services with their own OIDC apps
+        "feedback",  # Fider feedback portal (Klai OIDC app "Fider Feedback")
     }
 )
 

--- a/klai-portal/backend/tests/test_validate_callback_url.py
+++ b/klai-portal/backend/tests/test_validate_callback_url.py
@@ -436,6 +436,7 @@ async def test_idn_punycode_subdomain_rejected() -> None:
         "grafana.getklai.com",
         "errors.getklai.com",
         "auth.getklai.com",
+        "feedback.getklai.com",
     ],
 )
 @pytest.mark.asyncio
@@ -529,7 +530,7 @@ def test_static_system_subdomains_set_includes_known_oidc_apps() -> None:
     ``_STATIC_SYSTEM_SUBDOMAINS`` for the curl command operators run
     quarterly to re-audit.
     """
-    expected = {"chat", "chat-dev", "dev", "grafana", "errors", "auth"}
+    expected = {"chat", "chat-dev", "dev", "grafana", "errors", "auth", "feedback"}
     assert auth_module._STATIC_SYSTEM_SUBDOMAINS == frozenset(expected), (
         "If you added a new Zitadel OIDC app with a redirect URI under "
         "*.getklai.com, extend `_STATIC_SYSTEM_SUBDOMAINS` AND update this "

--- a/scripts/check_zitadel_oidc_drift.py
+++ b/scripts/check_zitadel_oidc_drift.py
@@ -66,6 +66,7 @@ DEFAULT_EXPECTED_STATIC: frozenset[str] = frozenset({
     "grafana",
     "errors",
     "auth",
+    "feedback",
 })
 
 


### PR DESCRIPTION
## Summary

- Adds `feedback` to `_STATIC_SYSTEM_SUBDOMAINS` so OIDC callbacks to `feedback.getklai.com` (Fider feedback portal) pass `_validate_callback_url` instead of 502ing.
- Keeps the contract test and the nightly drift-script mirror in sync.

## Why

Login-with-Klai on feedback.getklai.com currently deadlocks. Zitadel finalizes the auth request fine, but Klai Portal's `sso-complete` and `idp-callback` both 502 in `_validate_callback_url` because `feedback` is neither a tenant slug nor a known system subdomain. The browser never reaches Fider's `/oauth/_<id>/callback`, the user retries, hits the same already-handled auth-request → 400 from Zitadel, loops.

Same class as the chat-iframe-SSO incident on 2026-04-30 — captured in `pitfalls/process-rules.md` as `allowlist-must-enumerate-all-host-classes (HIGH)`. The rule says: every new OIDC app on `*.getklai.com` MUST update the allowlist + the contract test + the drift-script mirror in one PR. This PR does exactly that.

## Test plan

- [x] `uv run pytest tests/test_validate_callback_url.py -q` — 45 passed, including the updated parametrize (7 hosts) and the updated contract test.
- [ ] After merge: portal-api deploy CI green.
- [ ] After deploy: sign in at feedback.getklai.com via "Sign in with Klai" — Zitadel → my.getklai.com/login → silent SSO → redirect back to Fider's callback → Fider session created. No 502.

## Out of scope

- Granting Klai Platform project access to other Zitadel orgs (Voys, etc.). Currently only users in the "Klai" org can sign into Fider via SSO. Customers in other orgs can still use GitHub OAuth or email magic link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)