### PR TITLE
Guard widget client session id parsing

### DIFF
--- a/klai-portal/backend/app/api/partner.py
+++ b/klai-portal/backend/app/api/partner.py
@@ -1373,7 +1373,7 @@ def _widget_client_session_id(request: Request | None) -> str | None:
     if request is None:
         return None
     value = request.query_params.get("session_id")
-    if not value:
+    if not isinstance(value, str) or not value:
         return None
     return value if _WIDGET_CLIENT_SESSION_RE.fullmatch(value) else None
 


### PR DESCRIPTION
## What changed
- Guard widget client `session_id` parsing against non-string test/mocked query values.

## Why
The latest main portal-api run failed in widget-config tests because mocked `request.query_params.get("session_id")` returned a `MagicMock`, which was passed to the regex matcher.

## Validation
- `python3 -m py_compile klai-portal/backend/app/api/partner.py`
- `uv run pytest tests/test_partner_cors.py::test_partner_cors_widget_origin_no_credentials tests/test_widget_mint_rate_limit.py::test_widget_config_200_within_limit tests/test_widget_platform_unlock.py::test_widget_config_returns_200_when_widgets_unlocked`
