### PR TITLE
Status page tweaks: composite Scribe, rename groups

### DIFF
--- a/deploy/scripts/push-health.sh
+++ b/deploy/scripts/push-health.sh
@@ -100,10 +100,36 @@ push_exec "$PORTAL_API" \
     "python3 -c \"import urllib.request; urllib.request.urlopen('http://librechat-getklai:3080/health')\"" \
     "${KUMA_TOKEN_CHAT:-}" "Chat"
 
-# Scribe: scribe-api receives audio, calls whisper-server internally
-push_exec "$PORTAL_API" \
-    "python3 -c \"import urllib.request; urllib.request.urlopen('http://scribe-api:8020/health')\"" \
-    "${KUMA_TOKEN_SCRIBE:-}" "Scribe"
+# Scribe: receives audio (upload via scribe-api OR live Vexa-bot via api-gateway),
+# transcribes via gpu-01 Vexa workers, summarizes via LiteLLM. Composite check —
+# product is only healthy when BOTH the upload-path entry (scribe-api) AND the
+# meeting-bot entry (api-gateway) are responding. Granular per-component
+# detail lives in the "Meeting recordings & transcripts" group.
+scribe_composite_status() {
+    # Probe 1: scribe-api /health (upload path)
+    if ! docker exec "$PORTAL_API" \
+        python3 -c "import urllib.request; urllib.request.urlopen('http://scribe-api:8020/health', timeout=5)" 2>/dev/null; then
+        echo "down&msg=scribe-api-unreachable"
+        return
+    fi
+    # Probe 2: Vexa api-gateway healthcheck (live-bot path)
+    if [ -z "$MEETING" ]; then
+        echo "down&msg=api-gateway-missing"
+        return
+    fi
+    local health
+    health=$(docker inspect --format='{{.State.Health.Status}}' "$MEETING" 2>/dev/null | tr -d '\n\r' || echo missing)
+    if [ "$health" != "healthy" ]; then
+        echo "down&msg=meeting-bot-${health}"
+        return
+    fi
+    echo "up&msg=OK"
+}
+if [ -n "${KUMA_TOKEN_SCRIBE:-}" ]; then
+    SCRIBE_STATUS=$(scribe_composite_status)
+    curl -sf "${KUMA}/${KUMA_TOKEN_SCRIBE}?status=${SCRIBE_STATUS}" -o /dev/null
+    [[ "$SCRIBE_STATUS" == down* ]] && echo "$(date -Iseconds) WARN Scribe: ${SCRIBE_STATUS#down&msg=}" >> "$LOG"
+fi
 
 # Docs: Next.js app — check TCP reachability (no /health route)
 push_exec "$PORTAL_API" \


### PR DESCRIPTION
## Summary

User-feedback driven cleanup van status.getklai.com na de groeperings-refactor.

**1. Scribe wordt composite check.** Scribe is one product met twee invoer-routes (upload via `scribe-api`, live bot via Vexa `api-gateway`). Vóór deze PR probet de Scribe-monitor alleen scribe-api — een meeting-bot uitval zou Scribe ten onrechte groen laten. Nu UP alleen als beide healthy.

**2. "Meeting service" verhuist van Products → Meeting recordings & transcripts.** Het is technisch de Vexa V3 entry-point (api-gateway), niet een aparte product-feature. Klant ziet 1 ding: Scribe. Granular diagnostiek (api-gateway + meeting-api + runtime-api + admin-api + transcription workers) blijft zichtbaar in zijn eigen groep voor wie wil debuggen.

**3. "Account & Auth" → "Account & Authentication".** Geen afkortingen op een klant-page.

## Status page hierarchy na deze PR

- **Products** (4): Chat, Scribe, Knowledge, Docs
- **Account & Authentication** (3): Portal API, Login system, Email service
- **AI Engine** (7): LLM Gateway, Primary/Backup LLM, Embeddings, Reranker, Sparse Embeddings, Document processing
- **Meeting recordings & transcripts** (7): Meeting service, Transcription engine + 2 workers, Meeting API/Runtime/Admin
- **Knowledge & Search** (7): Ingest, Sync, Crawler, Retrieval, MCP, Web Content Fetcher, Web search
- **Data & Storage** (8): 7 DBs + Object Storage
- **Infrastructure** (9): Website, GPU, Monitoring, Web analytics, Error tracking, Feedback, GitHub, Backup, Internal Booking System

## Test plan

- [x] `bash /opt/klai/scripts/push-health.sh` succeeded, geen WARN
- [x] Scribe heartbeat status=1 (composite OK)
- [x] curl status.getklai.com → 7 groepen in juiste volgorde
- [x] Products toont nu 4 items (geen verwarrende Meeting service-naast-Scribe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)