### PR TITLE
fix(litellm): narrow Persoonlijk scope to canonical KB only

### DIFF
--- a/deploy/litellm/klai_knowledge.py
+++ b/deploy/litellm/klai_knowledge.py
@@ -1966,9 +1966,28 @@ class KlaiKnowledgeHook(CustomLogger):
         # Translate (kb_personal, kb_slugs) → retrieval-api `scope` + optional
         # `kb_slugs` filter.
         if kb_personal and kb_slugs == []:
-            # Personal-only: no org KBs at all.
+            # User picked the "Persoonlijk" entry in the chat dropdown.
+            #
+            # Bug fixed 2026-05-27: this branch used to send
+            # ``kb_slugs_for_request = None`` together with scope=personal.
+            # Retrieval-api then returned every chunk where
+            # ``visibility=private`` AND ``owner_user_id`` matched the
+            # requester — which includes user-created KBs (e.g. "test2")
+            # that the user explicitly deselected as separate items in
+            # the SAME dropdown. The UI semantic is "Persoonlijk = the
+            # canonical 'Persoonlijk' KB only", so narrow the request to
+            # the auto-provisioned slug for this user.
+            #
+            # The canonical slug pattern lives in portal_knowledge_bases
+            # for owner_type='user' rows whose slug starts with
+            # ``personal-<zitadel_user_id>``. The hook already has
+            # ``user_id`` resolved by the identity-verify step above.
+            #
+            # Retrieval-api filters on kb_slug through the same code path
+            # it uses for org-scope kb_slugs — see ``_scope_filter`` in
+            # klai-retrieval-api/retrieval_api/services/search.py.
             scope = "personal"
-            kb_slugs_for_request: list[str] | None = None
+            kb_slugs_for_request: list[str] | None = [f"personal-{user_id}"]
         else:
             scope = "both" if kb_personal else "org"
             kb_slugs_for_request = kb_slugs if kb_slugs else None

--- a/deploy/litellm/tests/test_klai_knowledge_hook.py
+++ b/deploy/litellm/tests/test_klai_knowledge_hook.py
@@ -842,8 +842,29 @@ class TestKlaiKnowledgeHookSlugsTriState:
         )
 
     @pytest.mark.asyncio
-    async def test_empty_slugs_and_personal_on_uses_personal_scope(self, monkeypatch):
-        """[] + personal=True → scope=personal, no kb_slugs filter."""
+    async def test_empty_slugs_and_personal_on_narrows_to_canonical_personal_kb(
+        self, monkeypatch
+    ):
+        """[] + personal=True → scope=personal AND kb_slugs=["personal-<user_id>"].
+
+        Bug discovered 2026-05-27 when Jantine flagged that company.csv
+        chunks from a user-created KB called "test2" showed up while
+        she had "Persoonlijk" selected and "test2" explicitly unchecked
+        in the dropdown.
+
+        Root cause: the "Persoonlijk" dropdown entry lists user-created
+        KBs (e.g. "test2") as SEPARATE items. The previous wire contract
+        sent ``kb_slugs=[]`` + scope=personal, which retrieval-api
+        interpreted as "all chunks where owner_user_id matches" —
+        including chunks from user-owned KBs that the user explicitly
+        DESELECTED in the dropdown.
+
+        Fix: when the user picks "Persoonlijk" the hook narrows the
+        retrieve request to the canonical personal KB only by sending
+        kb_slugs=[f"personal-{user_id}"]. The slug follows the
+        auto-provisioned pattern in portal_knowledge_bases for
+        owner_type='user' rows whose slug starts with 'personal-'.
+        """
         mod = _load_hook(monkeypatch)
         hook = mod.KlaiKnowledgeHook()
         cache = _make_cache(
@@ -874,10 +895,16 @@ class TestKlaiKnowledgeHookSlugsTriState:
             assert mc.post.call_count == 1
             body = mc.post.call_args.kwargs["json"]
             assert body["scope"] == "personal", (
-                f"Expected scope=personal when only personal is enabled, got {body['scope']!r}"
+                f"Expected scope=personal when only personal is enabled, "
+                f"got {body['scope']!r}"
             )
-            assert "kb_slugs" not in body, (
-                "kb_slugs filter MUST NOT be sent in personal-only scope."
+            # NEW behaviour: kb_slugs MUST be the canonical personal KB
+            # slug. Without this filter, retrieval-api returns chunks
+            # from EVERY user-owned KB (the previous bug).
+            assert body.get("kb_slugs") == ["personal-300000000000000002"], (
+                "Personal scope must narrow to the canonical "
+                "'personal-<user_id>' KB. Sending no filter caused "
+                "user-created KBs like 'test2' to leak in."
             )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

When a user picks "Persoonlijk" in the chat dropdown, the LiteLLM hook was sending scope=personal **without** kb_slugs. Retrieval-api then returned chunks from EVERY user-owned KB (any `visibility=private` chunk where `owner_user_id` matched the requester), including user-created KBs the user had explicitly **deselected** as separate items in the same dropdown.

## Concrete incident

Jantine (GetKlai org) opened a chat with "Persoonlijk" selected and "test2" unchecked, asked "wie is jantine?". Chunks came back from her own OneDrive's `company.csv` via the `ms_docs` connector on `kb_id=33` "test2". The Persoonlijk page in the portal lists only `kb_id=24` (jantinedoornbos.nl) — so the result looked like it came from nowhere. Verified end-to-end via:

- ChatConfigBar wire contract (`kb_slugs_filter=[]`, `kb_personal_enabled=true`) 
- Hook scope translation (`scope=personal`, `kb_slugs_for_request=None`)
- Production retrieval-api log: 20 chunks from `company.csv` (URL: `jantinedoornbos-my.sharepoint.com/personal/jantinedoornbos_...`)

## Fix

In the `(kb_personal=True, kb_slugs=[])` branch, send `kb_slugs_for_request=[f"personal-{user_id}"]`. The auto-provisioned canonical personal KB always uses slug pattern `personal-<zitadel_user_id>` (verified in `portal_knowledge_bases` for `owner_type='user'` rows). Retrieval-api filters identically on `kb_slug` across `scope=org` and `scope=personal` — see `klai-retrieval-api/retrieval_api/services/search.py::_scope_filter`.

## Test plan

- [x] `TestKlaiKnowledgeHookSlugsTriState::test_empty_slugs_and_personal_on_narrows_to_canonical_personal_kb` updated. Was the negative-guard pinning the OLD (buggy) behaviour; now requires `body.kb_slugs == ["personal-<user_id>"]`.
- [x] 229/230 tests green locally. One pre-existing unrelated failure (`test_streaming_post_call_without_trusted_sources_fails_closed`) was already red on `origin/main` before this change — verified by `git stash` baseline.
- [ ] Live verification after deploy: Jantine to repeat "Persoonlijk" + "wie is jantine?" — expect zero chunks now (her canonical Persoonlijk KB only has jantinedoornbos.nl, no `jantine`-named entries) and the new mode-aware "zero results" header from PR #697 should kick in.

## CI scope

Only `deploy/litellm/klai_knowledge.py` + its tests. Triggers `litellm-hook-deploy.yml` (rsync + `compose-up.sh --force-recreate litellm`). The four unrelated red workflows on main today (caddy-hetzner, whisper-server, knowledge-mcp pip-audit, alerting-checks) are independent and don't gate this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)