### PR TITLE
fix(litellm): zero-chunks branch must not set no_citable_sources=True

### DIFF
--- a/deploy/litellm/klai_knowledge.py
+++ b/deploy/litellm/klai_knowledge.py
@@ -2357,7 +2357,23 @@ class KlaiKnowledgeHook(CustomLogger):
                     "trusted_sources": [],
                     "evidence_pack": evidence_pack,
                     "citable_sources_count": 0,
-                    "no_citable_sources": True,
+                    # Bug fix 2026-05-27: PR #697 set ``no_citable_sources=True``
+                    # here. The structured-citation post-call render reads that
+                    # flag (as ``force_no_citable``) and runs
+                    # ``_render_kb_citation_content`` even when there are no
+                    # chunks. In Strict mode (kb_narrow=True) that path replaces
+                    # the model's answer with the English-only
+                    # ``_no_citable_sources_message`` — clobbering the
+                    # mode-aware multilingual instruction this branch already
+                    # injected into the system prompt above. Setting the flag
+                    # to False here lets the post-call render short-circuit
+                    # (``not trusted_sources and not force_no_citable and not
+                    # citation_chunks`` is now True), and the model's
+                    # mode-correct, language-correct answer passes through
+                    # unchanged. The ``no_citable_reason`` from
+                    # retrieval-api's evidence_pack is still recorded for
+                    # observability.
+                    "no_citable_sources": False,
                     "no_citable_reason": evidence_pack.get("no_citable_reason")
                     if isinstance(evidence_pack, dict)
                     else None,
@@ -2365,7 +2381,6 @@ class KlaiKnowledgeHook(CustomLogger):
                     "render_mode": render_strategy.mode,
                     "retrieval_ms": retrieval_ms,
                     "gate_bypassed": False,
-                    "kb_narrow": kb_narrow,
                 }
             return data
 

--- a/deploy/litellm/tests/test_klai_knowledge_hook.py
+++ b/deploy/litellm/tests/test_klai_knowledge_hook.py
@@ -3532,3 +3532,99 @@ class TestKlaiKnowledgeHookZeroChunksMode:
         assert meta is not None
         assert meta["chunks_injected"] == 0
         assert meta["kb_narrow"] is False
+
+    @pytest.mark.asyncio
+    async def test_zero_chunks_strict_metadata_lets_post_call_short_circuit(
+        self, monkeypatch
+    ):
+        """Strict + zero chunks MUST NOT set ``no_citable_sources=True``.
+
+        Live incident 2026-05-27 (Jantine, GetKlai): in Strict mode with
+        an empty retrieval, the model received our multilingual refusal
+        instruction and answered "Dat staat niet in de kennisbank" — but
+        the post-call structured-citation render then REPLACED that
+        answer with the English-only ``_no_citable_sources_message``
+        because the metadata flag ``no_citable_sources`` was True.
+
+        Contract: the zero-chunks branch must leave
+        ``no_citable_sources=False`` so the post-call guard
+        ``not trusted_sources and not force_no_citable and not
+        citation_chunks`` short-circuits and the model's mode-aware,
+        language-correct refusal passes through.
+        """
+        mod = _load_hook(monkeypatch)
+        hook = mod.KlaiKnowledgeHook()
+        cache = _make_cache(feature={"kb_narrow": True})
+
+        data = {
+            "user": "aabbcc112233445566778899",
+            "messages": [
+                {"role": "user", "content": "Wie is Jantine?"}
+            ],
+        }
+        retrieval_resp = _make_resp(
+            {"chunks": [], "retrieval_bypassed": False}
+        )
+
+        with patch("klai_knowledge.httpx.AsyncClient") as cls:
+            mc = AsyncMock()
+            mc.post = AsyncMock(return_value=retrieval_resp)
+            mc.__aenter__ = AsyncMock(return_value=mc)
+            mc.__aexit__ = AsyncMock(return_value=None)
+            cls.return_value = mc
+
+            result = await hook.async_pre_call_hook(
+                _make_user_api_key(), cache, data, "completion"
+            )
+
+        meta = result.get("metadata", {}).get("_klai_kb_meta")
+        assert meta is not None
+        assert meta["chunks_injected"] == 0
+        assert meta["trusted_sources"] == []
+        assert meta["citation_chunks"] == []
+        # The critical flag — must be False so the post-call renderer
+        # leaves the model's mode-aware answer alone.
+        assert meta["no_citable_sources"] is False, (
+            "Zero-chunks branch must NOT set no_citable_sources=True. "
+            "PR #697 did, and the post-call render then replaced the "
+            "model's Dutch 'Dat staat niet in de kennisbank' with the "
+            "English-only canned message."
+        )
+
+    @pytest.mark.asyncio
+    async def test_zero_chunks_open_metadata_lets_post_call_short_circuit(
+        self, monkeypatch
+    ):
+        """Symmetric to the strict case — Open mode also must not set
+        the flag, otherwise the post-call render would wipe the
+        general-knowledge fallback answer this branch instructed the
+        model to produce.
+        """
+        mod = _load_hook(monkeypatch)
+        hook = mod.KlaiKnowledgeHook()
+        cache = _make_cache(feature_enabled=True)
+
+        data = {
+            "user": "aabbcc112233445566778899",
+            "messages": [
+                {"role": "user", "content": "Iets algemeens"}
+            ],
+        }
+        retrieval_resp = _make_resp(
+            {"chunks": [], "retrieval_bypassed": False}
+        )
+
+        with patch("klai_knowledge.httpx.AsyncClient") as cls:
+            mc = AsyncMock()
+            mc.post = AsyncMock(return_value=retrieval_resp)
+            mc.__aenter__ = AsyncMock(return_value=mc)
+            mc.__aexit__ = AsyncMock(return_value=None)
+            cls.return_value = mc
+
+            result = await hook.async_pre_call_hook(
+                _make_user_api_key(), cache, data, "completion"
+            )
+
+        meta = result.get("metadata", {}).get("_klai_kb_meta")
+        assert meta is not None
+        assert meta["no_citable_sources"] is False


### PR DESCRIPTION
## Summary

Live follow-up to PR #697 (zero-chunks mode-aware header) and PR #705 (personal-scope narrow).

When Jantine retested today in Strict mode with "Persoonlijk" selected and an empty retrieval, the LiteLLM hook injected the multilingual "answer is not in knowledge base" instruction correctly — but the post-call **structured-citation render** then replaced the model's Dutch answer with the English-only ``"I cannot answer this reliably from the available knowledge sources."``

## Root cause

PR #697 set ``no_citable_sources=True`` in the zero-chunks ``_klai_kb_meta`` block. The structured-citation render (which landed on ``origin/main`` between when I started PR #697 and when I started this fix) reads that flag as ``force_no_citable``:

```python
# _compose_streaming_kb_response
if not trusted_sources and not force_no_citable and not citation_chunks:
    return stats  # short-circuit — model's content passes through
```

With ``force_no_citable=True`` the guard returns ``False``, ``_render_kb_citation_content`` runs with ``kb_narrow=True`` and empty ``trusted_sources``, and the path returns the canned English message — clobbering the model's actual mode-aware reply.

## Fix

In the zero-chunks branch, set ``no_citable_sources=False``. The descriptive ``no_citable_reason`` from retrieval-api's evidence_pack is still recorded for observability (e.g. ``"no_evidence"`` when retrieval returns zero items). Also removed an accidental duplicate ``"kb_narrow"`` key in the same dict.

## Test plan

- [x] Two new tests in ``TestKlaiKnowledgeHookZeroChunksMode``: ``test_zero_chunks_strict_metadata_lets_post_call_short_circuit`` and the Open companion. Both assert ``no_citable_sources is False``.
- [x] 230/231 tests green locally. Same pre-existing unrelated failure (``test_streaming_post_call_without_trusted_sources_fails_closed``) was already red on ``origin/main`` before this branch.
- [ ] Live verification after deploy: Jantine to retry "Wie is Jantine?" in Strict + Persoonlijk — expect a Dutch "Dat staat niet in de kennisbank" reply (per PR #697's pre-call instruction), NOT the English canned message.

## CI scope

Touches ``deploy/litellm/**`` only. Triggers ``litellm-hook-deploy.yml``. The same four unrelated red workflows on main today (caddy-hetzner, whisper-server, knowledge-mcp pip-audit, alerting-checks) remain unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)