### PR TITLE
hotfix(alembic): rebase personal-kb migration onto current head

### DIFF
--- a/klai-portal/backend/alembic/versions/a4b5c6d7e8f9_personal_kbs_private_visibility.py
+++ b/klai-portal/backend/alembic/versions/a4b5c6d7e8f9_personal_kbs_private_visibility.py
@@ -40,7 +40,12 @@ and the kb_config UPSERT is conditional on owner_type='user'.
 from alembic import op
 
 revision = "a4b5c6d7e8f9"
-down_revision = "z3a4b5c6d7e8"
+# Rebased 2026-05-27 from ``z3a4b5c6d7e8`` to ``e8f9a0b1c2d4``: the
+# original parent was no longer a head (it had been absorbed into a
+# merge migration on a parallel branch), so PR #709 landed a second
+# head and CI's "single head" guard fired on the post-merge deploy.
+# See pitfall ``alembic-multi-pr-head-split`` for the recovery pattern.
+down_revision = "e8f9a0b1c2d4"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
PR #709 introduced an alembic head split. Recovery via the
``alembic-multi-pr-head-split`` rebase path: re-point my migration's
``down_revision`` from ``z3a4b5c6d7e8`` (no longer a head) to
``e8f9a0b1c2d4`` (the current head, which #709 didn't see).

Only the ``down_revision`` line changes — the migration body
(``UPDATE portal_knowledge_bases SET visibility='private' WHERE owner_type='user'``) is unchanged.

Production impact: nil — the previous Build and push portal-api failed
at the alembic-integrity quality gate before the image was published,
so the running container is still on the pre-#709 schema. Once this PR
merges, the next ``Build and push portal-api`` will rebuild and the
entrypoint's ``alembic upgrade head`` will apply the visibility UPDATE
on first restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)