### PR TITLE
fix(retrieval): evidence_pack accepts uploaded documents (PDFs etc.)

### DIFF
--- a/klai-retrieval-api/retrieval_api/services/evidence_pack.py
+++ b/klai-retrieval-api/retrieval_api/services/evidence_pack.py
@@ -138,13 +138,33 @@ def build_evidence_pack(
     if not chunks:
         return EvidencePack(no_citable_reason="no_evidence")
 
-    candidates: list[tuple[EvidenceItem, str, str, float]] = []
+    candidates: list[tuple[EvidenceItem, str, str | None, float]] = []
     below_threshold_count = 0
     for chunk in chunks:
         source_url = _source_url(chunk)
-        source_key = source_url_key(source_url) if source_url else ""
+        # Derive a stable source_key. PUBLIC sources (web crawl, MS-Docs,
+        # Notion) carry a real URL — use the URL's normalised key. PRIVATE
+        # uploads (PDFs, plain-text snippets a user pastes into their
+        # personal KB) have NO public URL; their chunks land in qdrant
+        # with ``source_url=None``. Before 2026-05-27 those chunks were
+        # filtered out entirely below ("if not source_url: continue"),
+        # which meant a user's CV / contract / handbook could be
+        # retrieved by the reranker but disappeared from the evidence
+        # pack — and therefore from the citation list — leaving the
+        # model answering "Dat staat niet in de kennisbank" from chunks
+        # that explicitly mention the requested content. Fall back to
+        # the chunk's ``artifact_id`` (always present for uploads): all
+        # chunks from the same PDF share one artifact and therefore
+        # collapse into one source in the citations panel.
+        artifact_id = _string_value(_chunk_value(chunk, "artifact_id"))
+        if source_url:
+            source_key = source_url_key(source_url)
+        elif artifact_id:
+            source_key = f"artifact:{artifact_id}"
+        else:
+            source_key = ""
         title = _title(chunk, source_url)
-        if not source_url or not source_key:
+        if not source_key:
             continue
         relevance_score = _relevance_score(chunk)
         if (
@@ -216,21 +236,34 @@ def build_evidence_pack(
 
 
 def evidence_pack_sources_payload(pack: EvidencePack) -> list[dict[str, object]]:
-    """Return the structured source shape used by chat/portal clients."""
-    return [
-        {
-            "label": str(index),
-            "title": source.title,
-            "url": source.source_url,
-            "source_id": source.source_id,
-            "evidence_ids": source.evidence_ids,
-            "artifact_id": source.artifact_id,
-            "source_label": source.source_label,
-            "relevance_score": source.relevance_score,
-        }
-        for index, source in enumerate(pack.sources, 1)
-        if source.source_url
-    ]
+    """Return the structured source shape used by chat/portal clients.
+
+    Includes sources without a ``source_url`` (uploaded documents — PDFs,
+    pasted text — that have no public address). The chat client decides
+    how to render a URL-less source: typically as a non-clickable label
+    showing the filename / artifact title, with the option to open it via
+    the portal's KB browse view. Filtering URL-less sources out here would
+    re-introduce the 2026-05-27 bug where a user's uploaded CV was
+    retrieved but never appeared in the citations panel.
+    """
+    payload: list[dict[str, object]] = []
+    for index, source in enumerate(pack.sources, 1):
+        if not source.source_url and not source.artifact_id:
+            # No URL and no artifact: nothing addressable to cite.
+            continue
+        payload.append(
+            {
+                "label": str(index),
+                "title": source.title,
+                "url": source.source_url,
+                "source_id": source.source_id,
+                "evidence_ids": source.evidence_ids,
+                "artifact_id": source.artifact_id,
+                "source_label": source.source_label,
+                "relevance_score": source.relevance_score,
+            }
+        )
+    return payload
 
 
 def evidence_pack_items_as_chunks(pack: EvidencePack) -> list[dict[str, Any]]:

--- a/klai-retrieval-api/tests/test_evidence_pack.py
+++ b/klai-retrieval-api/tests/test_evidence_pack.py
@@ -205,3 +205,160 @@ def test_evidence_pack_preserves_heading_metadata_for_prompt_context():
 
     assert chunks[0]["heading_path"] == "Admin > People"
     assert chunks[0]["text"].startswith("3. Enter")
+
+
+# ─── 2026-05-27: uploaded-document chunks must reach the citations panel ───
+#
+# Live bug: Jantine (GetKlai org, Persoonlijk KB) uploaded
+# ``CV_Jantine_Doornbos.pdf``. Knowledge-ingest stored 9 chunks in
+# Qdrant via the docling pipeline. Every chunk had:
+#   - artifact_id      = "853797a1-3a22-4d90-872e-6a917d996c9a"
+#   - source_url       = None      (uploads have no public URL)
+#   - source_label     = "personal-364818484816773122"  (kb_slug fallback)
+#   - text             = "WERKERVARING: Mede-oprichter bij Klai...", etc.
+#
+# When she asked "Wat staat er in het CV van Jantine?", retrieval-api
+# returned 11 candidates (2 web_crawler + 9 CV) and reranker scored the
+# CV chunks 0.04 / 0.0002 / 0.0001 etc. — but those numbers don't
+# matter: ``build_evidence_pack`` filtered EVERY chunk without a
+# ``source_url`` BEFORE looking at the score (old code at line 147:
+# ``if not source_url or not source_key: continue``). The CV
+# disappeared from the citations panel entirely, and the model
+# answered "Dat staat niet in de kennisbank" from the homepage chunks
+# alone — even though the CV chunks containing the actual answer were
+# in the retrieval output.
+#
+# Fix: accept chunks with ``artifact_id`` as fallback ownership signal
+# when ``source_url`` is absent. All chunks from the same upload
+# collapse into one synthetic source ``artifact:<uuid>``.
+
+def test_evidence_pack_includes_uploaded_documents_without_source_url():
+    """Uploads (PDFs, pasted text) have no public URL — their chunks
+    must still reach the evidence pack via the ``artifact_id``
+    fallback key, otherwise the user cannot cite their own documents.
+    """
+    pack = build_evidence_pack(
+        [
+            # The CV upload — 2 chunks, same artifact, no source_url.
+            {
+                "chunk_id": "cv-chunk-1",
+                "artifact_id": "853797a1-3a22-4d90-872e-6a917d996c9a",
+                "title": "CV_Jantine_Doornbos.pdf",
+                "text": "WERKERVARING\nMede-oprichter bij Klai jan 2026 - heden.",
+                "source_url": None,
+                "source_label": "personal-364818484816773122",
+                "score": 0.4,
+                "reranker_score": 0.04,
+            },
+            {
+                "chunk_id": "cv-chunk-2",
+                "artifact_id": "853797a1-3a22-4d90-872e-6a917d996c9a",
+                "title": "CV_Jantine_Doornbos.pdf",
+                "text": "VAARDIGHEDEN\nAI-ontwikkeling, consultancy, Azure.",
+                "source_url": None,
+                "source_label": "personal-364818484816773122",
+                "score": 0.3,
+                "reranker_score": 0.03,
+            },
+            # A normal web-crawled chunk that DOES have source_url —
+            # both sources must coexist in the same pack.
+            {
+                "chunk_id": "homepage-1",
+                "artifact_id": "d9382163-ef99-4ad8-b297-c300aa08cfe8",
+                "title": "Hi I'm Jantine",
+                "text": "Freelance digital product designer.",
+                "source_url": "https://jantinedoornbos.nl/",
+                "source_label": "web_crawler",
+                "score": 0.9,
+                "reranker_score": 0.89,
+            },
+        ],
+    )
+
+    # Both sources land in the pack — neither the upload nor the URL
+    # source gets dropped.
+    assert len(pack.sources) == 2, (
+        "Both the URL source and the artifact-only upload source must "
+        "appear in the evidence pack. Pre-fix bug dropped uploads."
+    )
+    titles = {source.title for source in pack.sources}
+    assert "CV_Jantine_Doornbos.pdf" in titles
+    assert "Hi I'm Jantine" in titles
+
+    # Three items total — all 3 chunks contributed.
+    assert len(pack.items) == 3
+    chunk_ids = {item.chunk_id for item in pack.items}
+    assert chunk_ids == {"cv-chunk-1", "cv-chunk-2", "homepage-1"}
+
+    # The CV source (no URL) still surfaces via evidence_pack_sources_payload:
+    payload = evidence_pack_sources_payload(pack)
+    cv_entry = next(p for p in payload if p["title"] == "CV_Jantine_Doornbos.pdf")
+    assert cv_entry["url"] is None
+    assert cv_entry["artifact_id"] == "853797a1-3a22-4d90-872e-6a917d996c9a"
+    # Both source rows are surfaced — the URL-less one is no longer
+    # dropped by the payload helper.
+    assert len(payload) == 2
+
+
+def test_evidence_pack_groups_upload_chunks_by_artifact_id():
+    """All chunks from one upload share an ``artifact_id`` and must
+    collapse into a single source — not two parallel sources confusing
+    the citations panel.
+    """
+    pack = build_evidence_pack(
+        [
+            {
+                "chunk_id": "a",
+                "artifact_id": "doc-123",
+                "title": "handbook.pdf",
+                "text": "First section.",
+                "source_url": None,
+                "score": 0.5,
+            },
+            {
+                "chunk_id": "b",
+                "artifact_id": "doc-123",
+                "title": "handbook.pdf",
+                "text": "Second section.",
+                "source_url": None,
+                "score": 0.4,
+            },
+            {
+                "chunk_id": "c",
+                "artifact_id": "doc-123",
+                "title": "handbook.pdf",
+                "text": "Third section.",
+                "source_url": None,
+                "score": 0.3,
+            },
+        ],
+    )
+
+    assert len(pack.sources) == 1, (
+        "Three chunks from the same artifact_id must collapse into "
+        "one source row, not three parallel rows."
+    )
+    assert pack.sources[0].title == "handbook.pdf"
+    assert len(pack.sources[0].evidence_ids) == 3
+    assert pack.no_citable_reason is None
+
+
+def test_evidence_pack_still_drops_chunks_with_no_url_and_no_artifact():
+    """The fallback is artifact-id-only: a chunk with neither
+    source_url nor artifact_id has nothing addressable to cite and is
+    still dropped (we'd otherwise emit a phantom source).
+    """
+    pack = build_evidence_pack(
+        [
+            {
+                "chunk_id": "orphan",
+                "title": "Orphan",
+                "text": "Some text without provenance.",
+                "source_url": None,
+                "artifact_id": None,
+                "score": 0.5,
+            },
+        ],
+    )
+    assert pack.sources == []
+    assert pack.no_citable_reason == "no_citable_sources"


### PR DESCRIPTION
Bug: PDF chunks have source_url=None, so build_evidence_pack silently dropped them — the user's CV could be retrieved but never appeared in citations or model answer. Fix: artifact-id fallback as source_key.

11/11 evidence_pack tests green. 3 new tests pin the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)