### PR TITLE
fix(portal): expose personal KB slug to LiteLLM hook (drop slug reconstruction)

### DIFF
--- a/klai-portal/backend/app/api/internal.py
+++ b/klai-portal/backend/app/api/internal.py
@@ -46,6 +46,7 @@ from app.models.knowledge_bases import PortalKnowledgeBase
 from app.models.portal import PortalOrg, PortalUser
 from app.models.templates import PortalTemplate
 from app.services.connector_credentials import credential_store
+from app.services.default_knowledge_bases import personal_kb_slug
 from app.services.entitlements import get_effective_products
 from app.services.events import emit_event
 from app.services.gap_rescorer import schedule_rescore
@@ -697,6 +698,13 @@ class KnowledgeFeatureResponse(BaseModel):
     # qdrant chunks (klai-portal/backend/app/api/knowledge.py:172-204), so
     # the personal-scope filter also works.
     zitadel_user_id: str | None = None
+    # Canonical slug of this user's auto-provisioned personal KB. Returned
+    # so the LiteLLM hook can scope a "Persoonlijk"-only retrieval call to
+    # exactly that one KB without reconstructing the slug from string parts
+    # (the `personal-<zitadel_user_id>` template lives in
+    # `app.services.default_knowledge_bases.personal_kb_slug` — single
+    # source of truth on the portal-api side).
+    personal_kb_slug: str | None = None
     # SPEC-PRIVACY-QUERY-SHADOW-001 REQ-2: per-tenant telemetry mode threaded
     # through to the LiteLLM hook + knowledge-mcp. Default 'shadow' for
     # backwards compatibility — when the field is absent in cached responses
@@ -820,6 +828,7 @@ async def get_knowledge_feature(
         kb_narrow=user.kb_narrow,
         kb_pref_version=user.kb_pref_version,
         zitadel_user_id=user.zitadel_user_id,
+        personal_kb_slug=personal_kb_slug(user.zitadel_user_id) if user.zitadel_user_id else None,
         telemetry_level=org_telemetry_level,
     )
 

--- a/klai-portal/backend/tests/test_knowledge_feature_personal_kb_slug.py
+++ b/klai-portal/backend/tests/test_knowledge_feature_personal_kb_slug.py
@@ -1,0 +1,44 @@
+"""Pin the ``KnowledgeFeatureResponse.personal_kb_slug`` contract.
+
+The LiteLLM hook relies on this field to scope a "Persoonlijk"-only
+retrieve call to exactly the canonical personal KB. We MUST NOT let
+the slug-template diverge between this service (which provisions
+personal KBs) and the LiteLLM hook (which used to reconstruct the slug
+from string parts before SPEC-RAG-PERSONAL-SLUG-CONTRACT landed).
+
+Pure schema test: builds the Pydantic model and checks that the field
+exists, defaults to None, and round-trips a real slug.
+"""
+
+from __future__ import annotations
+
+from app.api.internal import KnowledgeFeatureResponse
+from app.services.default_knowledge_bases import personal_kb_slug
+
+
+def test_personal_kb_slug_defaults_to_none() -> None:
+    response = KnowledgeFeatureResponse(enabled=True)
+    assert response.personal_kb_slug is None
+
+
+def test_personal_kb_slug_round_trips_a_value() -> None:
+    response = KnowledgeFeatureResponse(
+        enabled=True,
+        personal_kb_slug="personal-300000000000000002",
+    )
+    dumped = response.model_dump()
+    assert dumped["personal_kb_slug"] == "personal-300000000000000002"
+
+
+def test_personal_kb_slug_matches_helper_output() -> None:
+    """The hook builds its filter from this exact field. The slug it
+    receives MUST equal what ``personal_kb_slug(user_id)`` produces on
+    the portal-api side — otherwise the filter targets a non-existent
+    KB and the user gets zero results."""
+    user_id = "300000000000000002"
+    expected = personal_kb_slug(user_id)
+    response = KnowledgeFeatureResponse(
+        enabled=True,
+        personal_kb_slug=expected,
+    )
+    assert response.personal_kb_slug == expected


### PR DESCRIPTION
## Probleem

PR #705 had de "Persoonlijk lekt naar andere user-owned KB's" bug gefixt door in de LiteLLM-hook de slug zelf te reconstrueren als ``f\"personal-{user_id}\"``. Dat was de tweede definitie naast ``app.services.default_knowledge_bases.personal_kb_slug`` in portal-api — klassieke ``url-shape-multi-file-drift`` pitfall. Een rename van de prefix in portal zou de hook stil naar 0 chunks laten teruggeven, zonder error of log.

## Fix

1. ``KnowledgeFeatureResponse`` (internal API endpoint dat de LiteLLM hook bevraagt) krijgt veld ``personal_kb_slug``, gevuld via ``personal_kb_slug(user.zitadel_user_id)`` — exact dezelfde helper die provisioning gebruikt. Single source of truth.

## Compat

De hook-kant (PR #715, al gemerged) leest het veld al en valt graceful terug naar ``scope=personal`` zonder kb_slug filter als het ontbreekt — dus tijdens de mid-deploy state tussen PR #715 en deze PR draait alles correct. Na deze PR krijgt de hook de slug netjes door en filtert exact één KB.

## Tests
- ``test_knowledge_feature_personal_kb_slug.py``: 3 pure schema tests (default None, round-trip, equals helper output).
- ``ruff check`` + ``ruff format --check``: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)