### PR TITLE
fix(widget): gate visitor identity persistence behind opt-in + 30-day TTL

### DIFF
--- a/klai-widget/src/components/ChatWindow.tsx
+++ b/klai-widget/src/components/ChatWindow.tsx
@@ -16,6 +16,8 @@ import {
   setHandoffActive,
   setHandoffConnecting,
   setVisitorIdentity,
+  setRememberIdentity,
+  clearStoredIdentity,
   startNewConversation,
   switchConversation,
 } from "../store/chat";
@@ -543,6 +545,27 @@ export function ChatWindow(props: ChatWindowProps) {
                 }}
               />
             </div>
+            <label class="klai-remember-me">
+              <input
+                type="checkbox"
+                checked={chatState.rememberIdentity}
+                onChange={(e) => setRememberIdentity(e.currentTarget.checked)}
+              />
+              <span>{t().rememberMe}</span>
+            </label>
+            <Show when={chatState.rememberIdentity && (visitorName() || visitorEmail())}>
+              <button
+                type="button"
+                class="klai-clear-identity"
+                onClick={() => {
+                  setVisitorName("");
+                  setVisitorEmail("");
+                  clearStoredIdentity();
+                }}
+              >
+                {t().clearStoredIdentity}
+              </button>
+            </Show>
           </div>
         </Show>
         <textarea

--- a/klai-widget/src/i18n/labels.ts
+++ b/klai-widget/src/i18n/labels.ts
@@ -22,6 +22,8 @@ export interface WidgetLabels {
   userInfoHelp: string
   handoffConnectedWith: string
   handoffNamePlaceholder: string
+  rememberMe: string
+  clearStoredIdentity: string
   conversationHistory: string
   newConversation: string
   closeConversation: string
@@ -50,6 +52,8 @@ const nl: WidgetLabels = {
   userInfoHelp: "Laat je gegevens achter voor opvolging.",
   handoffConnectedWith: "Je praat met {name}.",
   handoffNamePlaceholder: "Je naam",
+  rememberMe: "Onthoud mijn gegevens (30 dagen)",
+  clearStoredIdentity: "Wis opgeslagen gegevens",
   conversationHistory: "Gesprekken",
   newConversation: "Nieuw gesprek",
   closeConversation: "Sluit gesprek",
@@ -78,6 +82,8 @@ const en: WidgetLabels = {
   userInfoHelp: "Leave your details for follow-up.",
   handoffConnectedWith: "You are talking to {name}.",
   handoffNamePlaceholder: "Your name",
+  rememberMe: "Remember my details (30 days)",
+  clearStoredIdentity: "Clear stored details",
   conversationHistory: "Conversations",
   newConversation: "New conversation",
   closeConversation: "Close conversation",

--- a/klai-widget/src/store/chat.ts
+++ b/klai-widget/src/store/chat.ts
@@ -31,9 +31,19 @@ export interface ChatState {
   agentName: string | null;
   visitorName: string;
   visitorEmail: string;
+  // Opt-in flag controlling whether visitorName/visitorEmail are
+  // persisted to localStorage across sessions. False by default — the
+  // current session keeps both in memory and ships them to the handoff
+  // API, but a fresh browser tab on a shared computer starts blank.
+  rememberIdentity: boolean;
   conversationStatus: ConversationStatus;
   conversations: ConversationListItem[];
 }
+
+// Stored identity is wiped after this many milliseconds. The visitor's
+// next visit starts blank and re-prompts. Chosen at 30 days to match
+// the industry convention used by Intercom/Drift for the same opt-in.
+const IDENTITY_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 
 interface PersistedConversation {
   id: string;
@@ -67,6 +77,21 @@ interface PersistedWidgetStateV2 {
   conversations: PersistedConversation[];
 }
 
+interface PersistedWidgetStateV3 {
+  version: 3;
+  activeConversationId: string;
+  // Visitor identity is only persisted when the visitor explicitly
+  // opted in via the "Remember me" checkbox. The TTL is enforced on
+  // read so an expired entry surfaces as blank without an extra wipe
+  // pass.
+  identity: {
+    name: string;
+    email: string;
+    savedAt: number;
+  } | null;
+  conversations: PersistedConversation[];
+}
+
 const initialState: ChatState = {
   messages: [],
   sessionToken: "",
@@ -83,6 +108,7 @@ const initialState: ChatState = {
   agentName: null,
   visitorName: "",
   visitorEmail: "",
+  rememberIdentity: false,
   conversationStatus: "active",
   conversations: [],
 };
@@ -123,7 +149,12 @@ export function getInitialConversationSessionId(widgetId: string): string {
   try {
     const raw = window.localStorage.getItem(storageKey(widgetId));
     if (raw) {
-      const parsed = JSON.parse(raw) as Partial<PersistedWidgetStateV1 | PersistedWidgetStateV2>;
+      const parsed = JSON.parse(raw) as Partial<
+        PersistedWidgetStateV1 | PersistedWidgetStateV2 | PersistedWidgetStateV3
+      >;
+      if (parsed.version === 3 && isValidSessionId(parsed.activeConversationId)) {
+        return parsed.activeConversationId;
+      }
       if (parsed.version === 2 && isValidSessionId(parsed.activeConversationId)) {
         return parsed.activeConversationId;
       }
@@ -178,12 +209,36 @@ function normalizeConversation(value: Partial<PersistedConversation>): Persisted
   };
 }
 
-function loadPersistedState(widgetId: string, fallbackConversationId: string): PersistedWidgetStateV2 | null {
+function normalizeIdentity(
+  raw: unknown,
+  now: number,
+): PersistedWidgetStateV3["identity"] {
+  if (!raw || typeof raw !== "object") return null;
+  const candidate = raw as {
+    name?: unknown;
+    email?: unknown;
+    savedAt?: unknown;
+  };
+  const savedAt = Number(candidate.savedAt ?? 0);
+  if (!savedAt || !Number.isFinite(savedAt)) return null;
+  if (savedAt > now) return null; // future timestamp = corrupted entry
+  if (now - savedAt > IDENTITY_TTL_MS) return null; // expired → wipe on next persist
+  const name = typeof candidate.name === "string" ? candidate.name.slice(0, 120) : "";
+  const email = typeof candidate.email === "string" ? candidate.email.slice(0, 254) : "";
+  if (!name && !email) return null;
+  return { name, email, savedAt };
+}
+
+function loadPersistedState(widgetId: string, fallbackConversationId: string): PersistedWidgetStateV3 | null {
   try {
     const raw = window.localStorage.getItem(storageKey(widgetId));
     if (!raw) return null;
-    const parsed = JSON.parse(raw) as Partial<PersistedWidgetStateV1 | PersistedWidgetStateV2>;
-    if (parsed.version === 2) {
+    const parsed = JSON.parse(raw) as Partial<
+      PersistedWidgetStateV1 | PersistedWidgetStateV2 | PersistedWidgetStateV3
+    >;
+    const now = Date.now();
+
+    if (parsed.version === 3) {
       const conversations = Array.isArray(parsed.conversations)
         ? parsed.conversations
             .map((conversation) => normalizeConversation(conversation))
@@ -191,12 +246,31 @@ function loadPersistedState(widgetId: string, fallbackConversationId: string): P
             .slice(0, 20)
         : [];
       return {
-        version: 2,
+        version: 3,
         activeConversationId: isValidSessionId(parsed.activeConversationId)
           ? parsed.activeConversationId
           : fallbackConversationId,
-        visitorName: typeof parsed.visitorName === "string" ? parsed.visitorName.slice(0, 120) : "",
-        visitorEmail: typeof parsed.visitorEmail === "string" ? parsed.visitorEmail.slice(0, 254) : "",
+        identity: normalizeIdentity(parsed.identity, now),
+        conversations,
+      };
+    }
+
+    if (parsed.version === 2) {
+      // v2 persisted identity unconditionally. Treat the upgrade path as
+      // a privacy reset: drop the identity, keep the conversation list,
+      // and let the visitor re-opt-in via the new checkbox.
+      const conversations = Array.isArray(parsed.conversations)
+        ? parsed.conversations
+            .map((conversation) => normalizeConversation(conversation))
+            .filter((conversation): conversation is PersistedConversation => conversation !== null)
+            .slice(0, 20)
+        : [];
+      return {
+        version: 3,
+        activeConversationId: isValidSessionId(parsed.activeConversationId)
+          ? parsed.activeConversationId
+          : fallbackConversationId,
+        identity: null,
         conversations,
       };
     }
@@ -213,10 +287,9 @@ function loadPersistedState(widgetId: string, fallbackConversationId: string): P
         status: parsed.handoffActive ? "handoff_active" : "active",
       });
       return {
-        version: 2,
+        version: 3,
         activeConversationId: id,
-        visitorName: typeof parsed.visitorName === "string" ? parsed.visitorName.slice(0, 120) : "",
-        visitorEmail: typeof parsed.visitorEmail === "string" ? parsed.visitorEmail.slice(0, 254) : "",
+        identity: null,
         conversations: migrated ? [migrated] : [],
       };
     }
@@ -271,11 +344,22 @@ function persistState(status = chatState.conversationStatus): void {
       .sort((a, b) => b.updatedAt - a.updatedAt)
       .slice(0, 20);
     persistedConversations = Object.fromEntries(conversations.map((conversation) => [conversation.id, conversation]));
-    const payload: PersistedWidgetStateV2 = {
-      version: 2,
+    // Visitor identity is only persisted when the visitor opted in.
+    // Without the opt-in we ship the current name/email for the live
+    // session (in-memory state) but localStorage stays clean — a
+    // shared computer never leaks a previous visitor's email.
+    const identity: PersistedWidgetStateV3["identity"] =
+      chatState.rememberIdentity && (chatState.visitorName || chatState.visitorEmail)
+        ? {
+            name: chatState.visitorName,
+            email: chatState.visitorEmail,
+            savedAt: Date.now(),
+          }
+        : null;
+    const payload: PersistedWidgetStateV3 = {
+      version: 3,
       activeConversationId: chatState.clientSessionId,
-      visitorName: chatState.visitorName,
-      visitorEmail: chatState.visitorEmail,
+      identity,
       conversations,
     };
     window.localStorage.setItem(storageKey(chatState.widgetId), JSON.stringify(payload));
@@ -324,8 +408,12 @@ export function initStore(widgetId: string, config: WidgetConfig, clientSessionI
     lastHandoffEventId: conversation.lastHandoffEventId,
     unreadCount: conversation.unreadCount,
     agentName: conversation.agentName,
-    visitorName: persisted?.visitorName ?? "",
-    visitorEmail: persisted?.visitorEmail ?? "",
+    visitorName: persisted?.identity?.name ?? "",
+    visitorEmail: persisted?.identity?.email ?? "",
+    // If a persisted identity survived the load (= visitor previously
+    // opted in AND the entry is still within TTL), the checkbox stays
+    // checked on next visit. Otherwise default off.
+    rememberIdentity: persisted?.identity != null,
     conversationStatus: conversation.status,
     conversations: conversationList(),
   });
@@ -417,6 +505,21 @@ export function setVisitorIdentity(identity: { name?: string; email?: string }):
   if (identity.email !== undefined) {
     setChatState("visitorEmail", identity.email.slice(0, 254));
   }
+  schedulePersist();
+}
+
+export function setRememberIdentity(value: boolean): void {
+  setChatState("rememberIdentity", value);
+  schedulePersist();
+}
+
+export function clearStoredIdentity(): void {
+  // Reset both the live session and the persisted entry. The opt-in
+  // flag goes back to off so a fresh "Remember me" tick is needed to
+  // re-persist.
+  setChatState("visitorName", "");
+  setChatState("visitorEmail", "");
+  setChatState("rememberIdentity", false);
   schedulePersist();
 }
 

--- a/klai-widget/src/styles/widget.css
+++ b/klai-widget/src/styles/widget.css
@@ -717,6 +717,42 @@
   color: var(--klai-text-muted);
 }
 
+.klai-remember-me {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--klai-text-muted);
+  cursor: pointer;
+  user-select: none;
+}
+
+.klai-remember-me input[type="checkbox"] {
+  margin: 0;
+  width: 14px;
+  height: 14px;
+  accent-color: var(--klai-primary-color);
+  cursor: pointer;
+}
+
+.klai-clear-identity {
+  align-self: flex-start;
+  margin-top: 6px;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  font-family: var(--klai-font-family);
+  font-size: 11px;
+  color: var(--klai-text-muted);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.klai-clear-identity:hover {
+  color: var(--klai-text-color);
+}
+
 .klai-textarea {
   flex: 1;
   resize: none;


### PR DESCRIPTION
## Probleem

PR 9b42435c persisteerde ``visitorName`` en ``visitorEmail`` onvoorwaardelijk naar ``localStorage`` op iedere toetsaanslag. Op een gedeelde computer (kantoorbalie, bibliotheek) opent de volgende bezoeker de widget en ziet het email-adres van de vorige bezoeker pre-filled — AVG-wise een verwerking zonder consent of retentie.

Volledig schrappen van de storage zou alleen de UX schaden zonder het consent-gat dicht te leggen. Industry standard voor chat widgets (Intercom / Drift / Crisp) is opt-in + TTL + clear-button.

## Fix

1. **``rememberIdentity: boolean``** flag in chat store, default false. Live sessie houdt naam + email in-memory en stuurt ze naar de handoff API zoals voorheen — de immediate UX blijft identiek.
2. **Schema v2 → v3**: identity zit nu in een ``identity: { name, email, savedAt } | null`` block, alleen geschreven als de bezoeker de checkbox tikte.
3. **30-day TTL** afgedwongen on read via ``normalizeIdentity`` — verlopen entries komen als null door en worden bij de volgende persist gewist.
4. **v2 → v3 migratie** is een eenmalige privacy-reset: conversation-list migreert mee, het identity-block niet. Visitors moeten opnieuw opt-inen via de checkbox.
5. **UI**: "Onthoud mijn gegevens (30 dagen)" checkbox onder de naam/email velden + "Wis opgeslagen gegevens" link die zowel live state als persisted entry reset. NL + EN labels.

## Net effect

Returning visitors die opt-inen krijgen dezelfde UX. Op gedeelde computers blijft de storage schoon als de visitor de checkbox niet tikt.

## Tests
- Widget heeft geen JS test framework; ``tsc -b`` + ``vite build`` valideren TS en bundle.
- Bundle delta: +0.4 KB gzipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)