### PR TITLE
SPEC-RAG-PERSONAL-SCOPE-001: server-side enforcement of Persoonlijk-KB narrowing

### DIFF
--- a/.github/workflows/portal-api.yml
+++ b/.github/workflows/portal-api.yml
@@ -6,12 +6,14 @@ on:
     paths:
       - 'klai-portal/backend/**'
       - 'klai-libs/connector-credentials/**'
+      - 'klai-libs/kb-slugs/**'
       - '.github/workflows/portal-api.yml'
   pull_request:
     branches: [main]
     paths:
       - 'klai-portal/backend/**'
       - 'klai-libs/connector-credentials/**'
+      - 'klai-libs/kb-slugs/**'
       - '.github/workflows/portal-api.yml'
 
 permissions:

--- a/.github/workflows/retrieval-api.yml
+++ b/.github/workflows/retrieval-api.yml
@@ -10,6 +10,7 @@ on:
       # this image build.
       - 'klai-libs/identity-assert/**'
       - 'klai-libs/chat-prompts/**'
+      - 'klai-libs/kb-slugs/**'
       - 'klai-libs/citations/**'
       - '.github/workflows/retrieval-api.yml'
   pull_request:
@@ -18,6 +19,7 @@ on:
       - 'klai-retrieval-api/**'
       - 'klai-libs/identity-assert/**'
       - 'klai-libs/chat-prompts/**'
+      - 'klai-libs/kb-slugs/**'
       - 'klai-libs/citations/**'
       - '.github/workflows/retrieval-api.yml'
   workflow_dispatch:

--- a/.moai/specs/SPEC-RAG-PERSONAL-SCOPE-001/acceptance.md
+++ b/.moai/specs/SPEC-RAG-PERSONAL-SCOPE-001/acceptance.md
@@ -1,0 +1,102 @@
+# Acceptance criteria: SPEC-RAG-PERSONAL-SCOPE-001
+
+## Definition of Done
+
+This SPEC is "done" when all of the following are true on `main`:
+
+1. The shared library `klai-libs/kb-slugs` exists, is consumed by both `klai-portal` and `klai-retrieval-api`, and ships its own unit tests + drift test.
+2. Retrieval-api `_scope_filter` always appends the canonical-slug condition for `scope=personal` (REQ-2) and the personal portion of `scope=both` (REQ-3).
+3. The Jantine regression test (REQ-7) reproduces the live bug on main and passes after the fix.
+4. The structured log event (REQ-8) appears in VictoriaLogs at least once after deploy.
+5. All four test suites are green: `klai-libs/kb-slugs/tests`, `klai-portal/backend/tests`, `klai-retrieval-api/tests`, `deploy/litellm/tests`.
+6. Lint clean on retrieval-api + portal-api (`ruff check` + `ruff format --check`).
+7. Manual e2e verification documented in the PR description (Phase 6 of plan.md).
+
+## Test matrix
+
+### Library tests (`klai-libs/kb-slugs/tests/test_personal_kb_slug.py`)
+
+| Test ID | Description | Pass criterion |
+|---|---|---|
+| LIB-T1 | `personal_kb_slug("u1")` returns `"personal-u1"` | string equality |
+| LIB-T2 | `personal_kb_slug("")` returns `"personal-"` | edge case — empty user_id allowed at lib level; validation lives in retrieval-api |
+| LIB-T3 | Function is importable from `klai_kb_slugs` namespace | `from klai_kb_slugs import personal_kb_slug` succeeds |
+| LIB-T4 | `__all__` contains `personal_kb_slug` | for re-export safety |
+
+### Portal-api drift test (`klai-portal/backend/tests/test_personal_kb_slug_drift.py`)
+
+| Test ID | Description | Pass criterion |
+|---|---|---|
+| PORTAL-T1 | Portal's `personal_kb_slug` re-export matches the lib output | `from app.services.default_knowledge_bases import personal_kb_slug; assert personal_kb_slug("uX") == "personal-uX"` |
+| PORTAL-T2 | Portal's output equals the inline-literal pattern | `assert personal_kb_slug(user_id) == f"personal-{user_id}"` for several user_ids — guards against accidental rename |
+| PORTAL-T3 | Existing call-sites still import correctly | `assert callable(personal_kb_slug)` and signature unchanged |
+
+### Retrieval-api scope-filter tests (`klai-retrieval-api/tests/test_scope_filter.py`)
+
+| Test ID | Description | Pass criterion |
+|---|---|---|
+| SCOPE-T1 | `scope=personal` + `user_id=u1` → conditions include `kb_slug=personal-u1` | search `conditions` for a `FieldCondition(key='kb_slug', match=MatchValue('personal-u1'))` |
+| SCOPE-T2 | `scope=personal` + `effective_role=personal` → canonical filter still present | same assertion as SCOPE-T1, with `effective_role` set |
+| SCOPE-T3 | `scope=both` + `user_id=u1` → `visibility_should` private branch carries `kb_slug=personal-u1` | navigate the filter tree; assert canonical slug inside the `must` of the private-branch Filter |
+| SCOPE-T4 | `scope=org` + `user_id=u1` → no canonical slug appended (scope=org has no personal portion) | assert no `kb_slug=personal-u1` appears in conditions |
+| SCOPE-T5 | `scope=personal` + `user_id=None` → no canonical slug appended (no user to derive from); but `retrieve` endpoint should have returned 400 before reaching this point | unit on `_scope_filter` only — `_scope_filter` is permissive when user_id absent; endpoint enforces |
+| SCOPE-T6 (regression) | Existing `test_kb_slugs_both_scope_with_user_bypasses_personal_chunks` updated to assert the new canonical-narrowed shape | test passes after fix |
+
+### Retrieval-api role-filter tests (`klai-retrieval-api/tests/test_role_filter.py`)
+
+| Test ID | Description | Pass criterion |
+|---|---|---|
+| ROLE-T1 | `test_personal_role_org_scope_becomes_personal` unchanged | stays green |
+| ROLE-T2 | `test_personal_role_clears_kb_slugs` unchanged | stays green |
+| ROLE-T3 (new) | `test_personal_role_stripped_slugs_still_canonical_narrowed`: build a request with `effective_role=personal, scope=org, kb_slugs=["sneaky-org"]`. Apply `_apply_role_rewrite` then `_scope_filter`. Assert: scope becomes personal, kb_slugs becomes None, BUT canonical slug filter is appended | new assertion combining strip + canonical narrowing |
+
+### Retrieval-api regression test (`klai-retrieval-api/tests/test_personal_scope_canonical_regression.py`)
+
+| Test ID | Description | Pass criterion |
+|---|---|---|
+| REG-T1 (Jantine, personal role) | scope=personal, user_id=U, effective_role=personal, no kb_slugs supplied → exactly one `kb_slug` field condition AND it equals `personal-U` | exactly one canonical filter |
+| REG-T2 (Jantine, admin role) | Same as REG-T1 but effective_role=admin | exactly one canonical filter |
+| REG-T3 (Jantine, company role) | Same as REG-T1 but effective_role=company | exactly one canonical filter |
+| REG-T4 (proves bug existed) | If run against main without the fix: REG-T1 fails (no canonical filter applied for personal-role) | documented as expected pre-fix red |
+
+### Integration test (`klai-retrieval-api/tests/test_api.py`)
+
+| Test ID | Description | Pass criterion |
+|---|---|---|
+| API-T1 | POST /retrieve with scope=personal + valid user_id → 200 + filtered chunks | response body has chunks with `kb_slug=personal-<user>` only |
+| API-T2 | POST /retrieve with scope=personal + missing user_id → 400 with detail "user_id required" | existing test stays green |
+| API-T3 | POST /retrieve with scope=both + valid user_id + kb_slugs=[org1] → 200; personal chunks restricted to canonical slug | filter tree contains canonical-narrowed private branch |
+
+### LiteLLM hook tests (`deploy/litellm/tests/test_klai_knowledge_hook.py`)
+
+| Test ID | Description | Pass criterion |
+|---|---|---|
+| HOOK-T1 | Existing `test_empty_slugs_and_personal_on_narrows_to_canonical_personal_kb` | unchanged, still green |
+| HOOK-T2 | Existing `test_empty_slugs_and_personal_on_falls_through_when_portal_omits_slug` | unchanged, still green |
+
+Hook tests require ZERO changes — the hook keeps sending the client-side filter; the new server-side filter is additive.
+
+## Manual e2e checklist (post-deploy)
+
+| Step | Expected outcome |
+|---|---|
+| Login as a `personal`-role test user with two private KBs: canonical Persoonlijk + a user-created KB `test2` | login succeeds |
+| Upload a unique-content document to `test2` (e.g., "secret-marker-12345") | upload succeeds, doc visible in test2 |
+| Open chat with only "Persoonlijk" selected in dropdown | dropdown reflects single selection |
+| Ask: "wat staat er over secret-marker-12345" | response either says "Ik kan dit niet betrouwbaar beantwoorden" OR retrieves canonical-KB content only (no test2 content) |
+| Same query with "Persoonlijk" + "test2" selected | response surfaces test2 content correctly |
+| VictoriaLogs query: `service:retrieval-api AND event:retrieval_personal_scope_canonical_filter_applied` over last 30 min | ≥1 event present |
+
+## Out-of-scope verifications (deferred)
+
+- Performance impact of the extra `FieldCondition` on Qdrant search latency. Expected zero-impact (O(1) filter); not benchmarked.
+- Migration of existing chunks to add `kb_kind=personal_canonical` metadata. Future SPEC.
+- Removal of LiteLLM hook's redundant client-side filter. Intentionally kept as defense-in-depth.
+
+## Sign-off
+
+- [ ] Code review approved (focus areas: shared lib drift test + scope_filter canonical condition placement)
+- [ ] All test suites green on the feature branch
+- [ ] Manual e2e checklist completed and recorded in PR description
+- [ ] Grafana REQ-8 log event verified post-deploy
+- [ ] Deploy comms drafted ("Persoonlijk dropdown now surfaces only the canonical KB; non-canonical user-private KBs must be selected explicitly")

--- a/.moai/specs/SPEC-RAG-PERSONAL-SCOPE-001/plan.md
+++ b/.moai/specs/SPEC-RAG-PERSONAL-SCOPE-001/plan.md
@@ -1,0 +1,301 @@
+# Plan: SPEC-RAG-PERSONAL-SCOPE-001
+
+> Implementation methodology: TDD (RED-GREEN-REFACTOR), single-PR rollout.
+> Status: draft
+> Author: Mark Vletter + Claude Opus 4.7
+
+## Phase 0 — Worktree setup
+
+```bash
+git worktree add ../geneva-personal-scope -b feature/SPEC-RAG-PERSONAL-SCOPE-001 main
+cd ../geneva-personal-scope
+```
+
+Rationale: SPEC touches 3 services and 1 new library — well above the 3-file threshold from `spec-work-in-a-worktree` pitfall.
+
+## Phase 1 — Shared library
+
+### 1.1 Scaffold `klai-libs/kb-slugs`
+
+Copy the structure from `klai-libs/chat-prompts`:
+- `klai-libs/kb-slugs/pyproject.toml` — name `klai-kb-slugs`, version `0.1.0`, no runtime deps
+- `klai-libs/kb-slugs/klai_kb_slugs/__init__.py` — exports `personal_kb_slug`
+- `klai-libs/kb-slugs/klai_kb_slugs/py.typed` — empty marker for pyright
+- `klai-libs/kb-slugs/tests/test_personal_kb_slug.py` — pytest for the function
+- `klai-libs/kb-slugs/README.md` — one-paragraph rationale referencing this SPEC
+
+Function body:
+
+```python
+def personal_kb_slug(user_id: str) -> str:
+    """Build the canonical personal KB slug for a user.
+
+    Source of truth for the slug template — imported by klai-portal at
+    provisioning time and by klai-retrieval-api at search time. Keep this
+    function trivial; if the template ever needs to change, both services
+    pick up the change atomically via re-deploy.
+    """
+    return f"personal-{user_id}"
+
+
+__all__ = ["personal_kb_slug"]
+```
+
+### 1.2 Wire portal-api to the new library
+
+- Add `klai-kb-slugs = { workspace = true }` (or path-dep equivalent — mirror what `klai-portal/backend/pyproject.toml` does for `klai-chat-prompts`).
+- In `klai-portal/backend/app/services/default_knowledge_bases.py`: replace the inline `personal_kb_slug` body with `from klai_kb_slugs import personal_kb_slug`. Keep the local re-export so existing imports `from app.services.default_knowledge_bases import personal_kb_slug` continue to work without churn.
+- Drift test: `klai-portal/backend/tests/test_personal_kb_slug_drift.py` asserts `personal_kb_slug("uX") == "personal-uX"` AND equals the legacy `f"personal-{user_id}"` literal — guard against accidental rename.
+
+### 1.3 Wire retrieval-api to the new library
+
+- Add `klai-kb-slugs` path-dep to `klai-retrieval-api/pyproject.toml`.
+- Add Dockerfile COPY of the library (mirror the pattern used for `klai-chat-prompts`).
+- Verify build: `docker build -f klai-retrieval-api/Dockerfile .` succeeds locally.
+
+## Phase 2 — Retrieval-api filter
+
+### 2.1 RED — failing tests first
+
+In `klai-retrieval-api/tests/test_scope_filter.py`:
+
+```python
+def test_scope_personal_narrows_to_canonical_slug(self):
+    req = _make_request(scope="personal", user_id="u1")
+    conditions = _scope_filter(req)
+    # User_id condition still present
+    assert any(
+        isinstance(c, FieldCondition) and c.key == "user_id"
+        and c.match.value == "u1"
+        for c in conditions
+    )
+    # NEW: canonical slug condition present
+    assert any(
+        isinstance(c, FieldCondition) and c.key == "kb_slug"
+        and c.match.value == "personal-u1"
+        for c in conditions
+    )
+
+def test_scope_personal_personal_role_still_narrows_to_canonical(self):
+    # personal-role kb_slugs strip happens upstream of _scope_filter;
+    # this test asserts the filter applies regardless of effective_role
+    req = _make_request(scope="personal", user_id="u1", kb_slugs=None)
+    req = req.model_copy(update={"effective_role": "personal"})
+    conditions = _scope_filter(req)
+    assert any(
+        isinstance(c, FieldCondition) and c.key == "kb_slug"
+        and c.match.value == "personal-u1"
+        for c in conditions
+    )
+
+def test_scope_both_personal_portion_narrows_to_canonical(self):
+    req = _make_request(scope="both", user_id="u1", kb_slugs=["org1"])
+    conditions = _scope_filter(req)
+    # Find the visibility_should Filter; assert the private-branch carries
+    # the canonical slug condition
+    visibility_filter = next(
+        c for c in conditions
+        if isinstance(c, Filter) and c.should is not None
+    )
+    private_branch = next(
+        s for s in visibility_filter.should
+        if s.must and any(
+            isinstance(m, FieldCondition) and m.key == "visibility"
+            and m.match.value == "private"
+            for m in s.must
+        )
+    )
+    slug_conditions = [
+        m for m in private_branch.must
+        if isinstance(m, FieldCondition) and m.key == "kb_slug"
+    ]
+    assert any(
+        c.match.value == "personal-u1" for c in slug_conditions
+    )
+```
+
+Run pytest; confirm RED.
+
+### 2.2 GREEN — minimal patch to `_scope_filter`
+
+```python
+from klai_kb_slugs import personal_kb_slug
+
+def _scope_filter(request: RetrieveRequest) -> list[FieldCondition | Filter]:
+    conditions: list[FieldCondition | Filter] = [
+        FieldCondition(key="org_id", match=MatchValue(value=request.org_id)),
+    ]
+
+    if request.scope == "personal":
+        if request.user_id:
+            conditions.append(
+                FieldCondition(key="user_id", match=MatchValue(value=request.user_id))
+            )
+            # SPEC-RAG-PERSONAL-SCOPE-001 REQ-2: server-side narrow to canonical
+            conditions.append(
+                FieldCondition(
+                    key="kb_slug",
+                    match=MatchValue(value=personal_kb_slug(request.user_id))
+                )
+            )
+    else:
+        not_private = Filter(
+            must_not=[FieldCondition(key="visibility", match=MatchValue(value="private"))]
+        )
+        visibility_should: list[Filter] = [not_private]
+        if request.user_id:
+            # SPEC-RAG-PERSONAL-SCOPE-001 REQ-3: personal portion narrows to canonical
+            visibility_should.append(
+                Filter(
+                    must=[
+                        FieldCondition(key="visibility", match=MatchValue(value="private")),
+                        FieldCondition(key="user_id", match=MatchValue(value=request.user_id)),
+                        FieldCondition(
+                            key="kb_slug",
+                            match=MatchValue(value=personal_kb_slug(request.user_id))
+                        ),
+                    ]
+                )
+            )
+        conditions.append(Filter(should=visibility_should))
+
+    if request.kb_slugs:
+        if request.scope == "both" and request.user_id:
+            conditions.append(
+                Filter(
+                    should=[
+                        FieldCondition(key="kb_slug", match=MatchAny(any=request.kb_slugs)),
+                        FieldCondition(key="user_id", match=MatchValue(value=request.user_id)),
+                    ]
+                )
+            )
+        else:
+            conditions.append(
+                FieldCondition(key="kb_slug", match=MatchAny(any=request.kb_slugs))
+            )
+    return conditions
+```
+
+Run pytest; confirm GREEN.
+
+### 2.3 Add structured log event (REQ-8)
+
+In `retrieve.py` (after `_scope_filter` is called inside the search functions, or via a helper invoked alongside it):
+
+```python
+if req.scope in ("personal", "both") and req.user_id:
+    logger.info(
+        "retrieval_personal_scope_canonical_filter_applied",
+        org_id=req.org_id,
+        user_id=req.user_id,
+        canonical_slug=personal_kb_slug(req.user_id),
+        scope=req.scope,
+        effective_role=req.effective_role,
+        client_supplied_kb_slugs=req.kb_slugs,
+    )
+```
+
+Place the call once per request, immediately after `_apply_role_rewrite` has run and just before `_search_knowledge` is invoked — so the logged `req` reflects the post-strip state.
+
+## Phase 3 — Regression test
+
+`klai-retrieval-api/tests/test_personal_scope_canonical_regression.py`:
+
+```python
+"""SPEC-RAG-PERSONAL-SCOPE-001 REQ-7 — Jantine scenario.
+
+Two private KBs owned by the same user:
+  - personal-<user_id> (canonical)
+  - test2 (user-created)
+
+scope=personal MUST return only canonical KB chunks.
+"""
+
+import pytest
+from retrieval_api.models import RetrieveRequest
+from retrieval_api.services.search import _scope_filter
+from qdrant_client.http.models import FieldCondition, Filter
+
+
+@pytest.mark.parametrize("role", ["personal", "admin", "company"])
+def test_personal_scope_excludes_non_canonical_user_owned_kbs(role: str):
+    req = RetrieveRequest(
+        query="wie is jantine?",
+        org_id="o1",
+        scope="personal",
+        user_id="jantine-zitadel-sub",
+        effective_role=role,
+    )
+    conditions = _scope_filter(req)
+    slug_conditions = [
+        c for c in conditions
+        if isinstance(c, FieldCondition) and c.key == "kb_slug"
+    ]
+    assert len(slug_conditions) == 1
+    assert slug_conditions[0].match.value == "personal-jantine-zitadel-sub", (
+        f"Expected canonical slug filter for role={role}, "
+        f"got {slug_conditions[0].match.value!r}"
+    )
+```
+
+## Phase 4 — Test update sweep
+
+| File | Change |
+|---|---|
+| `klai-retrieval-api/tests/test_scope_filter.py` | Add the 3 new tests from Phase 2.1; update `test_kb_slugs_both_scope_with_user_bypasses_personal_chunks` to expect canonical slug inside the private branch |
+| `klai-retrieval-api/tests/test_role_filter.py` | Add `test_personal_role_stripped_slugs_still_canonical_narrowed` (end-to-end through `_apply_role_rewrite` + `_scope_filter`) |
+| `klai-retrieval-api/tests/test_api.py` | Verify integration tests around `/retrieve` endpoint still green |
+| `deploy/litellm/tests/test_klai_knowledge_hook.py` | Should require zero changes; hook keeps sending kb_slugs filter (redundant defense-in-depth) |
+| `klai-portal/backend/tests/test_personal_kb_slug_drift.py` | New file — drift test for the shared library |
+| `klai-libs/kb-slugs/tests/test_personal_kb_slug.py` | New file — unit tests for the library |
+
+## Phase 5 — Pre-merge validation
+
+```bash
+# library tests
+cd klai-libs/kb-slugs && uv run --extra dev pytest -q
+
+# portal-api tests
+cd klai-portal/backend && uv run pytest tests/ -q
+
+# retrieval-api tests
+cd klai-retrieval-api && uv run pytest tests/ -q
+
+# litellm tests (should be unchanged)
+cd deploy/litellm && PYTHONPATH=. .venv-test/bin/python3 -m pytest tests/ -q
+
+# lint
+cd klai-retrieval-api && uv run ruff check . && uv run ruff format --check .
+cd klai-portal/backend && uv run ruff check . && uv run ruff format --check .
+```
+
+## Phase 6 — Manual e2e
+
+After CI green + deploy:
+1. Login as a test user with `effective_role=personal`.
+2. Create a second private KB called `test2`. Upload a unique document.
+3. Open chat with only "Persoonlijk" selected in the dropdown.
+4. Ask a question that should match content in `test2` (e.g., a phrase that appears only in test2).
+5. Verify the response either does not surface test2 content OR explicitly refuses (canned no-citable-sources message).
+6. Switch dropdown to include "Persoonlijk" AND "test2" → repeat the query. test2 content SHOULD now appear (kb_slugs=[`personal-U`, `test2`] explicitly).
+7. Query VictoriaLogs: `service:retrieval-api AND event:retrieval_personal_scope_canonical_filter_applied` → events present.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Existing user with non-canonical personal-KB content stops seeing it in Persoonlijk dropdown | Intentional — the whole point. Notify in deploy comms ("Persoonlijk now only surfaces the canonical KB; pick the other KB explicitly to include it"). |
+| Knowledge-mcp users (Claude Desktop, Cursor) suddenly miss content from user-created private KBs | scope=both still returns those chunks via the user_id-bypass in the kb_slugs branch. The visibility-should narrowing only fires when kb_slugs is set or absent — re-check this in the GREEN phase. |
+| Slug template renamed in the future | Single point of change in `klai-libs/kb-slugs`; both services pick up via re-deploy. Drift test catches accidental local re-introduction. |
+| Pre-existing `_apply_role_rewrite` becomes redundant | Kept intentionally — preserves the original RBAC intent (personal-role can't reach org_slugs). Add a code comment cross-referencing this SPEC so future readers know the strip and the canonical filter co-exist by design. |
+| LiteLLM hook's PR #715 client-side filter becomes redundant | Kept intentionally — defense-in-depth. Two layers narrow to the same set; second layer catches if first layer drops. |
+
+## Estimated diff size
+
+- 1 new package (klai-libs/kb-slugs): ~50 lines incl. tests
+- klai-portal/backend: ~5-line edit + 1 new test file
+- klai-retrieval-api: ~15-line edit + 2 new test files
+- Dockerfile + pyproject updates: ~10 lines across 2 files
+- Total: <300 lines additions, <50 lines deletions
+
+Single PR, single commit (or 3 logical commits — lib / portal / retrieval — squash-merged).

--- a/.moai/specs/SPEC-RAG-PERSONAL-SCOPE-001/research.md
+++ b/.moai/specs/SPEC-RAG-PERSONAL-SCOPE-001/research.md
@@ -1,0 +1,200 @@
+# Research: Server-side enforcement of Persoonlijk-KB narrowing in retrieval-api
+
+> Date: 2026-05-27
+> Authors: Mark Vletter + Claude Opus 4.7
+> Status: complete
+> SPEC: SPEC-RAG-PERSONAL-SCOPE-001
+
+## 1. Incident timeline
+
+### 1.1 The Jantine bug (2026-05-27 17:00 CEST)
+
+Jantine (GetKlai org, admin role) opens a chat with **"Persoonlijk"** selected as the only knowledge source. Her widget UI lists exactly one canonical Persoonlijk-KB (kb_id=24, slug=`personal-300000000000000002`, source = `jantinedoornbos.nl`). She asks *"wie is jantine?"* and gets chunks back from a **separate** user-created KB called `test2` (kb_id=33), containing data from her own OneDrive `company.csv`. The `test2` KB was explicitly unchecked elsewhere in the dropdown — visually deselected.
+
+PR #705 (merged 17:36 CEST) made the LiteLLM-hook send `kb_slugs=["personal-{user_id}"]` together with `scope=personal`. Retrieval-api's `_scope_filter` honours the kb_slug filter for admin/company/kb_manager/group_manager users, so Jantine's chat surface stopped leaking immediately.
+
+### 1.2 The follow-up gap (this SPEC)
+
+While investigating "is this code safe enough?" we read `klai-retrieval-api/retrieval_api/api/retrieve.py` lines 258-262 and found:
+
+```python
+if req.effective_role == "personal":
+    if req.scope != "personal":
+        req = req.model_copy(update={"scope": "personal", "kb_slugs": None})
+    elif req.kb_slugs is not None:
+        req = req.model_copy(update={"kb_slugs": None})
+```
+
+For users whose `effective_role == "personal"`, retrieval-api **strips the kb_slugs field** before search. The strip is RBAC-driven (SPEC-PORTAL-RBAC-REFACTOR-001 REQ-17) — its intent is "personal-role callers cannot reach ORG KBs by spec'ing org-side kb_slugs". The implementation is over-broad: it also strips the defensive personal-canonical filter we just shipped.
+
+Result: for personal-role users (= the default role for every newly-onboarded employee; SPEC-PORTAL-RBAC-REFACTOR-001 REQ-11 says *"New users join as personal"*), the Jantine-bug is **still live in production after PR #705 / #715 / #716**.
+
+## 2. Architecture walkthrough
+
+### 2.1 Caller inventory for `/retrieve`
+
+Codebase-wide grep on 2026-05-27:
+
+| Service | File | `scope=` used | `kb_slugs=` shape |
+|---|---|---|---|
+| LiteLLM hook (path A) | `deploy/litellm/klai_knowledge.py:1989` | `personal` (when dropdown = Persoonlijk-alone), `both` (Persoonlijk + org KBs), `org` (org KBs only) | `[personal-<user_id>]` or `[org_slugs]` or `[mixed]` |
+| Knowledge-mcp | `klai-knowledge-mcp/main.py:1080` | `both` | not sent (None) |
+| Partner-chat (path B) | `klai-portal/backend/app/services/partner_chat.py:1369` | `org` | optional org slugs |
+| Internal/Research | none | n/a | n/a |
+
+**Key conclusion**: the only caller that sends `scope=personal` is the LiteLLM-hook. knowledge-mcp uses `scope=both` for "all my chunks" semantic (third-party MCP); partner_chat uses `scope=org` for widget chat.
+
+### 2.2 Current `_scope_filter` behaviour
+
+`klai-retrieval-api/retrieval_api/services/search.py:69-115`:
+
+For `scope == "personal"`:
+- Add `org_id = X` filter
+- Add `user_id = U` filter (if user_id present)
+- **No visibility filter** — comment says *"personal scope is already restricted to one user; no visibility filter needed"*
+- If `kb_slugs` is set after RBAC strip: add `kb_slug IN [list]` filter
+
+For `scope == "org"` / `scope == "both"`:
+- Add `org_id = X` filter
+- Add visibility filter: `visibility != private` OR (`visibility = private` AND `user_id = U`)
+- If `kb_slugs`: for `scope = both` add `(kb_slug IN [list] OR user_id = U)` — for `scope = org` add `kb_slug IN [list]`
+
+**Two leak shapes**:
+
+1. **scope=personal + RBAC-stripped kb_slugs**: returns every chunk where `user_id = U`. Personal-role users hit this path.
+2. **scope=both** (any role): the visibility-should branch unconditionally lets `user_id = U` chunks pass — even when kb_slugs explicitly listed only `[org1, org2]`. The user's `test2` KB chunks come through.
+
+The Jantine incident was shape (1). Shape (2) is silently present today but no one has reported it yet — the UI dropdown only triggers it when a user picks `Persoonlijk + org-KBs` and ALSO has unwanted user-created private KBs.
+
+### 2.3 Server-side validation already in place
+
+`klai-retrieval-api/retrieval_api/api/retrieve.py:252-253`:
+
+```python
+if req.scope in ("personal", "both") and not req.user_id:
+    raise HTTPException(status_code=400, detail="user_id required for scope=personal/both")
+```
+
+The earlier worry that "scope=personal without user_id returns the whole org" is **already mitigated** by this 400. The remaining gap is purely the kb_slug-narrowing one.
+
+### 2.4 Slug-template ownership
+
+`klai-portal/backend/app/services/default_knowledge_bases.py:22-24`:
+
+```python
+def personal_kb_slug(user_id: str) -> str:
+    """Build the canonical personal KB slug for a user."""
+    return f"personal-{user_id}"
+```
+
+This helper is also used during provisioning (`create_default_personal_kb`, `ensure_default_knowledge_bases`) and as the magic-slug shortcut in `get_kb_with_access`. It is the single source of truth on the portal-api side.
+
+After PR #716, the canonical slug is also surfaced to the LiteLLM-hook via `KnowledgeFeatureResponse.personal_kb_slug`. The hook in PR #715 builds the kb_slug filter from that value.
+
+## 3. Trade-off analysis
+
+Four design options surfaced during research. We weigh each against (a) drift risk vs the slug template, (b) deploy-window risk, (c) defense-in-depth value, (d) refactor cost.
+
+### Option A: Bigger client-side wallpaper
+
+Frontend dropdown sends `kb_slugs=[personal-<user>, ...other-selected]` directly, with `scope` reduced to a pure visibility hint. The current `kb_personal_enabled` boolean disappears in favour of explicit slug listing.
+
+| Dimension | Score |
+|---|---|
+| Drift risk | High — slug template now lives in frontend too |
+| Deploy risk | High — UI + portal-api + hook must ship together |
+| Defense-in-depth | Low — still client-driven; server trusts the list |
+| Refactor cost | Large — every chat surface needs UI changes |
+
+**Verdict**: rejected. Maintains the same trust model that produced this bug; adds drift surface.
+
+### Option B: Explicit `personal_kb_slug` field on RetrieveRequest
+
+Add `personal_kb_slug: str | None` to RetrieveRequest. When `scope=personal` and field present, retrieval-api forces `kb_slug = personal_kb_slug`. Hook propagates field from portal feature response (already present per PR #716).
+
+| Dimension | Score |
+|---|---|
+| Drift risk | Low — portal owns template, retrieval-api receives the slug |
+| Deploy risk | Low — additive field; old hooks fall through to current behaviour |
+| Defense-in-depth | Medium — server enforces only what client sent |
+| Refactor cost | Small — 1 field, 2 services |
+
+**Verdict**: viable. But the server still trusts the client to send the right slug; a buggy or malicious client that omits or scrambles the field bypasses the narrowing.
+
+### Option C: Server-derived canonical slug via shared library
+
+Retrieval-api derives `canonical_slug = personal_kb_slug(verified_user_id)` using a new shared library (`klai-libs/kb-slugs`) that BOTH portal-api and retrieval-api import. The verified_user_id comes from `verify_body_identity` — already enforced server-side per SPEC-SEC-IDENTITY-ASSERT-001.
+
+`_scope_filter` for `scope=personal`:
+```python
+conditions.append(FieldCondition(key="kb_slug", match=MatchValue(value=canonical_slug)))
+conditions.append(FieldCondition(key="user_id", match=MatchValue(value=verified_user_id)))
+```
+
+| Dimension | Score |
+|---|---|
+| Drift risk | Very low — one library, both services import |
+| Deploy risk | Very low — additive filter; no API contract change |
+| Defense-in-depth | High — server fully owns the narrowing; client cannot bypass |
+| Refactor cost | Small — new shared lib (1 function), 2 import updates |
+
+**Verdict**: preferred. The shared library captures the template once; the filter is server-side enforced regardless of what the client sends. Defence-in-depth is real: even if the hook is bypassed (direct curl, future MCP, debug call), the canonical narrowing applies.
+
+### Option D: Chunk-metadata refactor (`kb_kind=personal_canonical`)
+
+Stamp a new metadata field on every personal-KB chunk at ingest time. Retrieval-api filters on `kb_kind=personal_canonical AND user_id=U` instead of on slug strings.
+
+| Dimension | Score |
+|---|---|
+| Drift risk | None — slug string irrelevant to filter |
+| Deploy risk | High — requires re-stamping millions of existing chunks |
+| Defense-in-depth | High |
+| Refactor cost | Very large — ingest pipeline + qdrant payload index + migration |
+
+**Verdict**: best long-term but not worth the migration cost for this fix. Defer to a future SPEC if the slug-template ever needs to change.
+
+## 4. Decision
+
+**Option C: Server-derived canonical slug via shared library.**
+
+Rationale:
+1. Defense-in-depth is the right level for "personal-KB leak". Client-side narrowing depends on every caller doing the right thing; server-side narrowing is the contract.
+2. Shared library captures the slug template once. No drift between portal-api provisioning and retrieval-api search.
+3. Backwards compatible — no API contract change, no new field on RetrieveRequest. knowledge-mcp/partner_chat unaffected (they don't use scope=personal).
+4. The existing RBAC strip (REQ-17) can stay — it loses its over-broad effect because the canonical filter is added back server-side after the strip.
+
+We will also fix the **scope=both** personal-portion leak in the same SPEC (Phase 2). Same shared library, same canonical filter, applied inside the visibility-should clause.
+
+## 5. Implementation roadmap
+
+### Phase 1: Shared library + scope=personal enforcement (critical)
+
+1. Create `klai-libs/kb-slugs` package exporting `personal_kb_slug(user_id: str) -> str`.
+2. portal-api: replace inline `personal_kb_slug` in `app.services.default_knowledge_bases` with the shared import.
+3. retrieval-api: import the shared lib in `retrieval_api/services/search.py`.
+4. `_scope_filter` for `scope=personal`: always append `kb_slug = personal_kb_slug(verified_user_id)` filter. Replaces the user_id-only condition or runs alongside.
+5. Tests: update `test_role_filter.py` (the rewrite mirror), add `test_scope_filter.py` canonical-narrowing assertions, add regression test for the Jantine scenario.
+
+### Phase 2: scope=both personal-portion enforcement (defense)
+
+1. `_scope_filter` for `scope=both`: in the `visibility_should` clause, replace `(visibility=private AND user_id=U)` with `(visibility=private AND user_id=U AND kb_slug=canonical_slug)`.
+2. Tests: new `test_scope_both_excludes_non_canonical_personal_chunks`.
+
+### Phase 3: Strip-rule simplification (clean-up)
+
+After Phase 1+2, the RBAC strip rule (lines 258-262 in retrieve.py) is no longer needed for canonical-narrowing purposes. It remains valuable for "personal-role can't query org_slug". Keep it; add a code comment cross-referencing this SPEC so the next reader understands why the strip is narrower in intent than its implementation.
+
+### Phase 4: Hook clean-up (optional)
+
+The LiteLLM-hook's PR #715 client-side narrowing becomes redundant. Two options:
+- Keep it — defense-in-depth, two layers narrow to the same set.
+- Remove it — single source of truth, fewer moving parts.
+
+**Decision**: keep it. The cost is one extra field on the request; the benefit is a fast-fail path if retrieval-api ever loses the canonical filter (loud test failure instead of silent leak).
+
+## 6. References
+
+- **Code**: `klai-retrieval-api/retrieval_api/services/search.py:69-115`, `klai-retrieval-api/retrieval_api/api/retrieve.py:242-262`, `klai-portal/backend/app/services/default_knowledge_bases.py:22-24`, `deploy/litellm/klai_knowledge.py:1944-1993`
+- **Related SPECs**: SPEC-PORTAL-RBAC-REFACTOR-001 REQ-17 (RBAC strip), SPEC-SEC-IDENTITY-ASSERT-001 (verify_body_identity), SPEC-PORTAL-KB-OWNERSHIP-001 (route-level firewall)
+- **Recent PRs**: #705 (initial hook narrowing — Jantine fix), #715 (shared `no_citable_sources_message` lib), #716 (`personal_kb_slug` field on KnowledgeFeatureResponse)
+- **Pitfall class**: `url-shape-multi-file-drift` (multi-file contract drift) and the "single gatekeeper" anti-pattern in CLAUDE.md

--- a/.moai/specs/SPEC-RAG-PERSONAL-SCOPE-001/spec.md
+++ b/.moai/specs/SPEC-RAG-PERSONAL-SCOPE-001/spec.md
@@ -1,0 +1,168 @@
+---
+id: SPEC-RAG-PERSONAL-SCOPE-001
+version: "0.1.0"
+status: draft
+created: 2026-05-27
+updated: 2026-05-27
+author: Mark Vletter
+priority: high
+related:
+  - SPEC-PORTAL-RBAC-REFACTOR-001 (REQ-17 — personal-role kb_slugs strip; this SPEC adds canonical filter alongside)
+  - SPEC-SEC-IDENTITY-ASSERT-001 (verify_body_identity gives us the trusted user_id this SPEC consumes)
+  - SPEC-PORTAL-KB-OWNERSHIP-001 (route-level firewall on portal-api uses the same canonical slug)
+prs:
+  - "#705 — initial client-side narrowing (Jantine fix; admin-only effective)"
+  - "#716 — personal_kb_slug field on KnowledgeFeatureResponse"
+---
+
+# HISTORY
+
+| Version | Date       | Author       | Change                                               |
+|---------|------------|--------------|------------------------------------------------------|
+| 0.1.0   | 2026-05-27 | Mark Vletter | Initial draft — surface personal-role leak after #705 ships |
+
+---
+
+# SPEC-RAG-PERSONAL-SCOPE-001: Server-side enforcement of Persoonlijk-KB narrowing
+
+## Summary
+
+Retrieval-api MUST narrow `scope=personal` (and the personal portion of `scope=both`) to the requester's canonical Persoonlijk-KB, regardless of which `kb_slugs` the caller supplied and regardless of the caller's `effective_role`. The slug template lives in exactly one place — a new shared library `klai-libs/kb-slugs` — that both `klai-portal` and `klai-retrieval-api` import. Defense-in-depth replaces the current client-side-only narrowing, which is silently bypassed for personal-role callers by the existing RBAC strip rule.
+
+## Motivation
+
+The 2026-05-27 Jantine incident exposed a leak where the Persoonlijk dropdown returned chunks from other user-owned private KBs. PR #705 patched it client-side in the LiteLLM-hook. Code review on 2026-05-27 evening surfaced that retrieval-api's `_apply_role_rewrite` (`klai-retrieval-api/retrieval_api/api/retrieve.py:258-262`) **strips** every `kb_slugs` value for callers whose `effective_role == "personal"`. Because new users join as `personal` by default (SPEC-PORTAL-RBAC-REFACTOR-001 REQ-11), the majority of production users continue to see the leak after PR #705 / #715 / #716 shipped.
+
+Three diagnostic facts shape this SPEC:
+
+- **Defense-in-depth is missing.** The client (hook) is the only narrowing gate today. A buggy or future caller that omits the slug filter re-opens the leak. Retrieval-api must enforce.
+- **scope=both is also leaky** (lower priority). `kb_personal=True + kb_slugs=[org_slugs]` translates to `scope=both, kb_slugs=[org_slugs]`. The current visibility-should clause lets every `user_id=requester` chunk through, including non-canonical user-private KBs.
+- **No drift acceptable.** Putting the slug template (`personal-<zitadel_user_id>`) in both portal-api and retrieval-api creates the exact `url-shape-multi-file-drift` pattern we have a pitfall rule against. A shared library is the only safe place for the template.
+
+## Out of scope
+
+- Re-stamping existing Qdrant chunks with a new `kb_kind` payload field (Option D in research.md). Larger refactor, deferred.
+- Replacing the `scope` enum with kb_slugs-only semantics across the API. Long-term refactor, deferred.
+- Frontend dropdown UX changes. The widget UI is unchanged; the wire contract from the LiteLLM-hook stays additive.
+- Performance optimisation of the qdrant filter (extra `FieldCondition` is O(1)).
+
+## Requirements (EARS format)
+
+### REQ-1 — Shared slug-template library
+
+The repository SHALL contain a new package `klai-libs/kb-slugs` exposing a single function `personal_kb_slug(user_id: str) -> str` that returns `f"personal-{user_id}"`. The package SHALL be importable by `klai-portal` (replacing the inline helper in `app.services.default_knowledge_bases`) and by `klai-retrieval-api`. The package SHALL ship a unit test pinning the exact string format with at least one positive sample and one validation against the legacy inline output.
+
+Acceptance:
+- `klai-libs/kb-slugs/klai_kb_slugs/__init__.py` exports `personal_kb_slug`.
+- `klai-portal/backend/app/services/default_knowledge_bases.py` re-exports the lib's function (no behavioural change).
+- A drift test in `klai-portal/backend/tests/test_personal_kb_slug_drift.py` asserts `personal_kb_slug("u1")` returns `"personal-u1"` AND equals the legacy inline string `f"personal-{u1}"`.
+
+### REQ-2 — Server-side narrowing for scope=personal
+
+WHEN `req.scope == "personal"`, retrieval-api `_scope_filter` SHALL unconditionally append `FieldCondition(key="kb_slug", match=MatchValue(value=personal_kb_slug(req.user_id)))` to the must-conditions list, irrespective of the value of `req.kb_slugs` or `req.effective_role`. The new condition SHALL be appended AFTER the existing `user_id = req.user_id` condition so both must match.
+
+Acceptance:
+- `test_scope_filter::test_scope_personal_narrows_to_canonical_slug` passes (new test).
+- `test_scope_filter::test_scope_personal_personal_role_still_narrows_to_canonical` passes (new test — covers the RBAC-strip path).
+- Existing `test_scope_filter` assertions on the user_id filter remain green.
+
+### REQ-3 — Server-side narrowing for scope=both, personal portion
+
+WHEN `req.scope == "both"`, retrieval-api `_scope_filter` SHALL replace the existing `(visibility=private AND user_id=U)` Filter inside `visibility_should` with `(visibility=private AND user_id=U AND kb_slug=personal_kb_slug(req.user_id))`. The non-private branch (`visibility != private`) SHALL remain unchanged.
+
+Acceptance:
+- `test_scope_filter::test_scope_both_personal_portion_narrows_to_canonical` passes (new test).
+- `test_scope_both_kb_slugs_with_user_bypasses_personal_chunks` (existing test) is updated to assert the new bypass shape (only canonical slug passes via user_id-bypass).
+
+### REQ-4 — user_id requirement remains the precondition
+
+The current 400 ("user_id required for scope=personal/both") in `retrieve()` SHALL continue to fire when `scope in ("personal", "both")` and `user_id` is missing. The new canonical-slug filter MUST NOT mask the missing-user_id error path.
+
+Acceptance:
+- `test_retrieve_missing_user_id_returns_400_for_personal` stays green.
+- `test_retrieve_missing_user_id_returns_400_for_both` stays green.
+- Code review verifies the 400 check fires before `_scope_filter` is invoked.
+
+### REQ-5 — RBAC strip rule preserved
+
+The existing personal-role rewrite (`klai-retrieval-api/retrieval_api/api/retrieve.py:258-262`) SHALL remain unchanged in behaviour. Specifically: personal-role callers that supply `scope=org` or `kb_slugs=[<org_slug>]` SHALL still have their request rewritten (scope → personal, kb_slugs → None). The new canonical-narrowing is additive; the strip remains the RBAC guard against ORG-KB sneaking.
+
+Acceptance:
+- `test_role_filter::test_personal_role_org_scope_becomes_personal` stays green.
+- `test_role_filter::test_personal_role_clears_kb_slugs` stays green.
+- A new test `test_personal_role_stripped_slugs_still_canonical_narrowed` asserts the chained behaviour: kb_slugs stripped to None, but canonical slug filter still applied by `_scope_filter`.
+
+### REQ-6 — Caller contract unchanged for non-personal scopes
+
+The LiteLLM-hook, knowledge-mcp, and partner_chat SHALL require no contract changes:
+- LiteLLM-hook's PR #715 client-side filter (`kb_slugs=[personal-<user>]`) MAY remain in place as a redundant client-side narrowing. It SHALL NOT be removed in this SPEC.
+- knowledge-mcp (scope=both, kb_slugs=None) SHALL keep returning the broad "everything I own + org chunks" set; the new canonical narrowing for scope=both only filters the personal portion, not the org portion. MCP traffic against non-canonical user-owned chunks (test2 etc.) STOPS in line with the new contract — accept this as an intentional behaviour tightening for third-party MCP traffic.
+- partner_chat (scope=org) is untouched by this SPEC.
+
+Acceptance:
+- LiteLLM hook tests in `deploy/litellm/tests/test_klai_knowledge_hook.py` stay green without modification.
+- knowledge-mcp tests stay green without modification.
+- partner_chat tests stay green without modification.
+
+### REQ-7 — Regression test for the Jantine scenario
+
+A new end-to-end test in `klai-retrieval-api/tests/` SHALL reproduce the Jantine bug shape and assert it does not leak:
+- Setup: two private KBs owned by the same user, slugs `personal-U` and `test2`. User_id = U. Effective_role = personal.
+- Request: `scope=personal`, kb_slugs=None or kb_slugs=[`personal-U`].
+- Assertion: only `personal-U` chunks appear in the response; zero chunks from `test2`.
+
+Acceptance:
+- `test_personal_scope_excludes_non_canonical_user_owned_kbs` passes for both `effective_role=personal` and `effective_role=admin`.
+- The same test, when run against the current main branch code, fails — proves the test reproduces the live bug.
+
+### REQ-8 — Observability
+
+When `_scope_filter` appends the canonical slug condition, it SHALL log a structured event at INFO level once per request:
+
+```
+event: retrieval_personal_scope_canonical_filter_applied
+org_id: ...
+user_id: ...
+canonical_slug: personal-<user_id>
+scope: personal | both
+effective_role: ...
+client_supplied_kb_slugs: [...] | null
+```
+
+This lets us verify in VictoriaLogs that the filter fires for every relevant request after deploy, and lets us spot-check that the slug template did not silently change.
+
+Acceptance:
+- Grafana query `service:retrieval-api AND event:retrieval_personal_scope_canonical_filter_applied` returns >0 within 1 hour of deploy.
+
+## Success criteria
+
+- [ ] REQ-1: shared library `klai-libs/kb-slugs` exists, both services import it, drift test green
+- [ ] REQ-2: scope=personal applies canonical slug filter regardless of role
+- [ ] REQ-3: scope=both narrows personal portion to canonical slug
+- [ ] REQ-4: user_id validation 400 still fires before _scope_filter
+- [ ] REQ-5: RBAC strip behaviour preserved
+- [ ] REQ-6: no contract change for any external caller
+- [ ] REQ-7: regression test reproduces the live bug and passes after the fix
+- [ ] REQ-8: structured log event visible in VictoriaLogs
+- [ ] All existing klai-retrieval-api tests pass
+- [ ] All existing deploy/litellm tests pass
+- [ ] All existing klai-portal/backend tests pass
+
+## Test plan
+
+See `acceptance.md` for the full test matrix.
+
+## Implementation references
+
+- `klai-retrieval-api/retrieval_api/services/search.py:69-115` (`_scope_filter`)
+- `klai-retrieval-api/retrieval_api/api/retrieve.py:252-262` (validation + RBAC strip)
+- `klai-portal/backend/app/services/default_knowledge_bases.py:22-24` (current inline helper)
+- `klai-libs/chat-prompts/klai_chat_prompts/__init__.py` (pattern reference for the new shared lib)
+- `deploy/litellm/klai_knowledge.py:1944-1993` (existing client-side narrowing for comparison)
+
+## Rollout
+
+1. Land in a single PR (no flag, no migration). The new filter is additive — the behaviour change is that some chunks STOP being returned. Loud test failures on regression-tests are the canary.
+2. Post-merge: run a manual e2e check with a non-admin test user — confirm Persoonlijk dropdown returns only canonical KB chunks.
+3. Within 1 hour of deploy: query Grafana for REQ-8 log event. Zero events ≠ rollout failure (could mean no personal-scope traffic in the window); but presence confirms the filter is wired.
+4. No backout plan needed — the filter is server-side, no client coordination, revert is a single Git revert.

--- a/klai-libs/kb-slugs/README.md
+++ b/klai-libs/kb-slugs/README.md
@@ -1,0 +1,30 @@
+# klai-kb-slugs
+
+Canonical Knowledge Base slug helpers shared between `klai-portal` (provisioning side)
+and `klai-retrieval-api` (search side). One library = one slug template = no drift.
+
+## Why this exists
+
+The slug template ``personal-<zitadel_user_id>`` was originally defined inline in
+``klai-portal/backend/app/services/default_knowledge_bases.py`` and reconstructed
+ad-hoc in ``deploy/litellm/klai_knowledge.py`` and elsewhere. The 2026-05-27
+"Jantine incident" surfaced that this kind of multi-file string contract drifts
+silently (see ``url-shape-multi-file-drift`` pitfall in
+``.claude/rules/klai/pitfalls/process-rules.md``).
+
+This package centralises the template. Both portal-api and retrieval-api import
+``personal_kb_slug`` so a future rename moves in one place.
+
+## Usage
+
+```python
+from klai_kb_slugs import personal_kb_slug
+
+slug = personal_kb_slug("300000000000000002")
+# -> "personal-300000000000000002"
+```
+
+## SPEC
+
+- SPEC-RAG-PERSONAL-SCOPE-001 (server-side enforcement of Persoonlijk-KB narrowing)
+- SPEC-PORTAL-KB-OWNERSHIP-001 (consumer: route-level firewall magic-slug shortcut)

--- a/klai-libs/kb-slugs/klai_kb_slugs/__init__.py
+++ b/klai-libs/kb-slugs/klai_kb_slugs/__init__.py
@@ -1,0 +1,33 @@
+"""Canonical Knowledge Base slug helpers shared across Klai services.
+
+Owned by SPEC-RAG-PERSONAL-SCOPE-001. Both ``klai-portal``'s provisioning
+helpers and ``klai-retrieval-api``'s scope filter import this same function
+so the slug template lives in exactly one place. A future rename of the
+template moves in one file and both services pick up the change atomically.
+
+The template ``personal-<zitadel_user_id>`` is also reproduced by chunk
+metadata stamped at ingest time (``klai-knowledge-ingest``); the search
+side never reads that stamp by string, it reads via this helper. If the
+template ever changes, ingest+search must be redeployed together — the
+shared lib is the coordination point.
+"""
+
+from __future__ import annotations
+
+__all__ = ["personal_kb_slug"]
+
+
+def personal_kb_slug(user_id: str) -> str:
+    """Return the canonical Persoonlijk-KB slug for a user.
+
+    The slug is deterministic and lives on:
+
+    - ``portal_knowledge_bases.slug`` (DB row, created at provisioning)
+    - Qdrant chunk payload ``kb_slug`` (stamped at ingest)
+    - retrieval-api ``_scope_filter`` (matched at search)
+
+    Pass the Zitadel user sub (``portal_users.zitadel_user_id``); the
+    library does not validate the input shape because every call site
+    already passes a verified identifier upstream.
+    """
+    return f"personal-{user_id}"

--- a/klai-libs/kb-slugs/pyproject.toml
+++ b/klai-libs/kb-slugs/pyproject.toml
@@ -1,0 +1,51 @@
+[project]
+name = "klai-kb-slugs"
+version = "0.1.0"
+description = "Shared canonical KB slug helpers (SPEC-RAG-PERSONAL-SCOPE-001)."
+requires-python = ">=3.12"
+readme = "README.md"
+license = { text = "Proprietary" }
+authors = [{ name = "Klai" }]
+
+# Zero runtime dependencies — the library is a single f-string helper.
+# Keep it dependency-free so klai-portal, klai-retrieval-api, and any
+# future consumer can import without dragging in extra wheels.
+dependencies = []
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8",
+    "ruff>=0.8",
+    "pyright>=1.1.390",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=8",
+    "ruff>=0.8",
+    "pyright>=1.1.390",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["klai_kb_slugs"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 120
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "S", "RUF"]
+ignore = [
+    "S101",  # assert is fine in tests
+]
+
+[tool.pyright]
+pythonVersion = "3.12"
+typeCheckingMode = "strict"

--- a/klai-libs/kb-slugs/tests/test_personal_kb_slug.py
+++ b/klai-libs/kb-slugs/tests/test_personal_kb_slug.py
@@ -1,0 +1,64 @@
+"""Unit tests for :func:`klai_kb_slugs.personal_kb_slug`.
+
+The function is trivial by design (a single f-string) — the value of
+these tests is pinning the EXACT output shape. Any future refactor that
+changes the template silently would break consumers (portal-api
+provisioning, retrieval-api scope filter, knowledge-ingest chunk
+metadata) and these tests catch it loudly.
+
+See SPEC-RAG-PERSONAL-SCOPE-001 REQ-1.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from klai_kb_slugs import personal_kb_slug
+
+
+@pytest.mark.parametrize(
+    "user_id, expected",
+    [
+        ("300000000000000002", "personal-300000000000000002"),
+        ("u1", "personal-u1"),
+        ("abc-def-ghi", "personal-abc-def-ghi"),
+        # Empty user_id is permitted at the lib level (validation lives in retrieve.py's
+        # ``user_id required`` 400). The lib is a pure string helper.
+        ("", "personal-"),
+    ],
+)
+def test_personal_kb_slug_matches_template(user_id: str, expected: str) -> None:
+    assert personal_kb_slug(user_id) == expected
+
+
+def test_personal_kb_slug_matches_legacy_inline_pattern() -> None:
+    """Guards against accidental rename of the slug prefix.
+
+    Before SPEC-RAG-PERSONAL-SCOPE-001, the template was an inline f-string
+    in ``klai-portal/backend/app/services/default_knowledge_bases.py``:
+
+        def personal_kb_slug(user_id: str) -> str:
+            return f"personal-{user_id}"
+
+    This test pins the byte-equal output so that a future contributor
+    cannot silently introduce a different template via this library.
+    """
+    samples = ["jantine-zitadel-sub", "u1", "300000000000000002", ""]
+    for user_id in samples:
+        legacy_inline = f"personal-{user_id}"
+        assert personal_kb_slug(user_id) == legacy_inline, (
+            f"Slug template drift for user_id={user_id!r}: "
+            f"lib produced {personal_kb_slug(user_id)!r}, "
+            f"legacy inline produced {legacy_inline!r}"
+        )
+
+
+def test_personal_kb_slug_is_in_dunder_all() -> None:
+    """Public-API surface is intentionally narrow — exactly one export.
+
+    Adding new exports requires updating ``__all__``; this test ensures
+    re-exports stay deliberate.
+    """
+    import klai_kb_slugs
+
+    assert klai_kb_slugs.__all__ == ["personal_kb_slug"]

--- a/klai-libs/kb-slugs/uv.lock
+++ b/klai-libs/kb-slugs/uv.lock
@@ -1,0 +1,154 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "klai-kb-slugs"
+version = "0.1.0"
+source = { editable = "." }
+
+[package.optional-dependencies]
+dev = [
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.390" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8" },
+]
+provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pyright", specifier = ">=1.1.390" },
+    { name = "pytest", specifier = ">=8" },
+    { name = "ruff", specifier = ">=0.8" },
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.409"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/4e/3aa27f74211522dba7e9cbc3e74de779c6d4b654c54e50a4840623be8014/pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93", size = 4430434, upload-time = "2026-04-23T11:02:03.799Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/6b/330d8ebae582b30c2959a1ef4c3bc344ebde48c2ff0c3f113c4710735e11/pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3", size = 6438161, upload-time = "2026-04-23T11:02:01.309Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/8a/8bce2894573e9dae6ff4d77fe34ad727d79b9e6238ad288c5638990d90f6/ruff-0.15.14.tar.gz", hash = "sha256:48e866b165be4a9bdbf310f7d3c9a07edef2fe8cd63ffeb4e00bb590506ebf9f", size = 4700910, upload-time = "2026-05-21T14:34:55.177Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/c8/74a92c6ff9fcfb4f1f947126d3ebee8389276e161ecc85de5bda7cda51bd/ruff-0.15.14-py3-none-linux_armv6l.whl", hash = "sha256:8dd2db9416e487c8d4b01fa7056bb02c4d05969d4f8d17a08c229c2f4ff3c108", size = 10739177, upload-time = "2026-05-21T14:34:37.332Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/254a35c20acc38a7223c9d2d594af12e794432464f2cdeb52af1dc4a892d/ruff-0.15.14-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:be4ff55af755bd71a00ab3dc6bd7ffc467bd76e0df6881e286c2e3d23e8fb43b", size = 11144969, upload-time = "2026-05-21T14:34:43.978Z" },
+    { url = "https://files.pythonhosted.org/packages/56/9e/d13e40f83b8d0a94430e6778ce1d94a43b38cf2efe63278bdd2b4c65abbf/ruff-0.15.14-py3-none-macosx_11_0_arm64.whl", hash = "sha256:48d5909d7d06276ce7dde6d32bfa4b0d4cb2651145cd8ee4b440722cbc77832f", size = 10478207, upload-time = "2026-05-21T14:34:48.378Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/f1/b15a7839fa4f332f8acec78e20564f26bb2d866e3d21710b877fd0263000/ruff-0.15.14-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca8cbfa94c4f90984a67561978602746d4cd27103568f745fa90eee3f0d4107d", size = 10818459, upload-time = "2026-05-21T14:34:22.318Z" },
+    { url = "https://files.pythonhosted.org/packages/45/33/53d651177f84f94b400a0e27f8824eeada3dddc9d5ee8aeb048f4352a520/ruff-0.15.14-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9a6bbc0333f1ab053423bcbf6226477d266ca7cec7738c4c8e3f55647803f3c4", size = 10541800, upload-time = "2026-05-21T14:34:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a6/868f87e0bf9786ed24b5d0d0ad8676b8a94fd1912f42cddf9cfc7857818a/ruff-0.15.14-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8a24a4f7605d7003a6674d4387651effd939dead3fddd0f36561eb77a9a2e542", size = 11342149, upload-time = "2026-05-21T14:34:46.365Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/8b/38cd5c19faffdcc05a408d2b78edccc69492ab9720eadb49ea15ef80d768/ruff-0.15.14-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:049b5326e53ed80978f2fc041a280603f69dd6b0c95464342a2bb4572d9d9e2f", size = 12212563, upload-time = "2026-05-21T14:34:28.579Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/4d/a3c5b874a556d5731e3e657aaf04311bb76f0a5c3ec220ed43051be6b64b/ruff-0.15.14-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4ed42e6696c8dfa5f06728e6441993901f548eb92d73bc472cb5a38d1395fbf", size = 11493299, upload-time = "2026-05-21T14:34:41.836Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c0/56472c251d09858a53e51efbd485b09e1995d8731668b76d52e5dd6ee0f1/ruff-0.15.14-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:715c543cf450c4888251f91c52f1942a800541d9bddd7ac060aa4e6b77ae7cba", size = 11455931, upload-time = "2026-05-21T14:34:57.276Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/4a/e2e7b4d8dbf233d4eace59c75bc3435fa6d8bd3bae82d351d4e4300c0fd1/ruff-0.15.14-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:72ebab6013ec887d439d8b7593737a0a4ffb06d45d209d4e4bf2e92813082d3f", size = 11400794, upload-time = "2026-05-21T14:34:39.773Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c7/83c0539fe34c3e09136204d1e75d6052492364e0b3cb05e9465423f567d7/ruff-0.15.14-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:49072d36abdbe97a8dd7f480afe9c675699c0c495d4c84076e2c1203c4550581", size = 10804759, upload-time = "2026-05-21T14:34:31.045Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a6/18f2bfc095a2ab4a78745644e428205532ce6653a5d0fa8501572891534d/ruff-0.15.14-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:958522aee105068640c2c2ceae08f413ae44d922f52a1374ac13d6a96032fc93", size = 10539517, upload-time = "2026-05-21T14:34:53.064Z" },
+    { url = "https://files.pythonhosted.org/packages/54/3a/5a8b3b69c654d4e4bf1d246ac5b49cbcdac6eaab6905925f8915f31e3b80/ruff-0.15.14-py3-none-musllinux_1_2_i686.whl", hash = "sha256:f3707da619a143a2e8830e2abab8224478d69ace2d28cb6c20543ae97c36bf61", size = 11065169, upload-time = "2026-05-21T14:34:24.484Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c5/8864e4e7925b836ea354b31d57641ec03830564e281a8b6f061f8c3e0ec1/ruff-0.15.14-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:bb01d645694e3ec0102105d07ef2d53703970407d59c04e59d3ba0b7a1d53553", size = 11560214, upload-time = "2026-05-21T14:34:50.975Z" },
+    { url = "https://files.pythonhosted.org/packages/36/38/012bf76752e1f89ed50b77b99532d90f3a3e287bc7918e1fc0948ac866ac/ruff-0.15.14-py3-none-win32.whl", hash = "sha256:6d0c1ad2a0ab718d39b6d8fd2217981ce4d625cd96a720095f798fb47d8b13e6", size = 10805548, upload-time = "2026-05-21T14:34:33.453Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b7/4ea2c170f10ad760fff2a5250beb18897719dc8b52b53a24cddbb9dd3f19/ruff-0.15.14-py3-none-win_amd64.whl", hash = "sha256:802342981e056db3851a7836e5b070f8f15f67d4a685ae2a6160939d364b2902", size = 11939523, upload-time = "2026-05-21T14:34:18.077Z" },
+    { url = "https://files.pythonhosted.org/packages/62/d5/bc97ff895ec35cf3925d4bd60f3b39d822f377a446906ec9bcc87405e59b/ruff-0.15.14-py3-none-win_arm64.whl", hash = "sha256:ff47b90a9ef6a40c9e2f3b479c1fb78531adf055b94c1eba0a7ba04b31951826", size = 11208607, upload-time = "2026-05-21T14:34:26.525Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]

--- a/klai-portal/backend/Dockerfile
+++ b/klai-portal/backend/Dockerfile
@@ -23,6 +23,8 @@ COPY klai-libs/log-utils klai-libs/log-utils
 COPY klai-libs/identity-assert klai-libs/identity-assert
 # SPEC-RAG-MULTILINGUAL-CHAT-001 REQ-02: shared chat-prompt constant.
 COPY klai-libs/chat-prompts klai-libs/chat-prompts
+# SPEC-RAG-PERSONAL-SCOPE-001 REQ-1: canonical personal-KB slug helper.
+COPY klai-libs/kb-slugs klai-libs/kb-slugs
 COPY klai-libs/citations klai-libs/citations
 COPY klai-portal/backend/pyproject.toml klai-portal/backend/pyproject.toml
 COPY klai-portal/backend/uv.lock klai-portal/backend/uv.lock

--- a/klai-portal/backend/app/services/default_knowledge_bases.py
+++ b/klai-portal/backend/app/services/default_knowledge_bases.py
@@ -6,9 +6,19 @@ during tenant provisioning, the personal KB during user signup or invite.
 
 These helpers are idempotent: calling them multiple times for the same
 tenant/user is safe (INSERT ... ON CONFLICT DO NOTHING pattern).
+
+The :func:`personal_kb_slug` template is re-exported from
+``klai-libs/kb-slugs`` (SPEC-RAG-PERSONAL-SCOPE-001 REQ-1) so retrieval-api
+consumes the same helper for server-side scope=personal narrowing without
+the slug template living in two places.
 """
 
 import structlog
+
+# Re-export the canonical template so existing call sites
+# ``from app.services.default_knowledge_bases import personal_kb_slug``
+# continue to resolve. The shared library owns the string.
+from klai_kb_slugs import personal_kb_slug
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -18,10 +28,14 @@ from app.models.knowledge_bases import PortalKnowledgeBase
 
 logger = structlog.get_logger()
 
-
-def personal_kb_slug(user_id: str) -> str:
-    """Build the canonical personal KB slug for a user."""
-    return f"personal-{user_id}"
+__all__ = [
+    "create_default_org_kb",
+    "create_default_personal_kb",
+    "ensure_default_knowledge_bases",
+    "personal_kb_slug",
+    "resolve_org_kb",
+    "resolve_personal_kb",
+]
 
 
 async def resolve_personal_kb(caller_id: str, org_id: int, db: AsyncSession) -> PortalKnowledgeBase:

--- a/klai-portal/backend/pyproject.toml
+++ b/klai-portal/backend/pyproject.toml
@@ -46,6 +46,10 @@ dependencies = [
     # used by partner_chat. Single source of truth across portal-api and
     # retrieval-api; CI lint asserts no other service hardcodes a copy.
     "klai-chat-prompts",
+    # SPEC-RAG-PERSONAL-SCOPE-001 REQ-1: shared canonical-slug helper used by
+    # provisioning (default_knowledge_bases.py) and re-exported by retrieval-api
+    # for server-side scope=personal narrowing.
+    "klai-kb-slugs",
     # Shared deterministic citation composer used by widget/partner chat and
     # vendored into the LiteLLM hook for the LibreChat path.
     "klai-citations",
@@ -64,6 +68,7 @@ klai-image-storage = { path = "../../klai-libs/image-storage", editable = true }
 klai-identity-assert = { path = "../../klai-libs/identity-assert", editable = true }
 klai-log-utils = { path = "../../klai-libs/log-utils", editable = true }
 klai-chat-prompts = { path = "../../klai-libs/chat-prompts", editable = true }
+klai-kb-slugs = { path = "../../klai-libs/kb-slugs", editable = true }
 klai-citations = { path = "../../klai-libs/citations", editable = true }
 
 [project.optional-dependencies]

--- a/klai-portal/backend/tests/test_personal_kb_slug_drift.py
+++ b/klai-portal/backend/tests/test_personal_kb_slug_drift.py
@@ -1,0 +1,65 @@
+"""Drift-test for the shared ``personal_kb_slug`` template.
+
+SPEC-RAG-PERSONAL-SCOPE-001 REQ-1. Pins the slug template at the portal-api
+re-export site so a future refactor of either the library or the inline
+helper cannot silently change the format. The same template is consumed by:
+
+  - Provisioning (``create_default_personal_kb`` here)
+  - Magic-slug shortcut (``resolve_personal_kb`` here)
+  - Retrieval-api's server-side scope filter
+  - Knowledge-ingest chunk metadata stamping
+
+If this test fails, several services drift together — refuse to merge the
+change until every consumer is updated in the same PR.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.default_knowledge_bases import personal_kb_slug
+
+
+@pytest.mark.parametrize(
+    "user_id, expected",
+    [
+        ("300000000000000002", "personal-300000000000000002"),
+        ("jantine-zitadel-sub", "personal-jantine-zitadel-sub"),
+        ("u1", "personal-u1"),
+    ],
+)
+def test_personal_kb_slug_re_export_matches_canonical(user_id: str, expected: str) -> None:
+    assert personal_kb_slug(user_id) == expected
+
+
+def test_personal_kb_slug_matches_legacy_inline_pattern() -> None:
+    """Pin the byte-equal output across all call sites that historically
+    constructed the slug inline:
+
+      - ``app.services.default_knowledge_bases.personal_kb_slug`` (pre-SPEC inline)
+      - ``deploy/litellm/klai_knowledge.py`` (PR #705 inline)
+      - ``klai-knowledge-ingest`` chunk-stamping code (search the repo grep)
+
+    A drift here breaks server-side narrowing silently. Loud failure here
+    is the only thing keeping the contract honest.
+    """
+    samples = ["jantine-zitadel-sub", "u1", "300000000000000002", ""]
+    for user_id in samples:
+        legacy = f"personal-{user_id}"
+        assert personal_kb_slug(user_id) == legacy, (
+            f"Slug template drift for user_id={user_id!r}: "
+            f"helper produced {personal_kb_slug(user_id)!r}, "
+            f"legacy inline produced {legacy!r}"
+        )
+
+
+def test_personal_kb_slug_is_callable_with_expected_signature() -> None:
+    """Existing callers spread across the codebase pass a single str arg.
+
+    If the signature ever changes (added kwargs, return type drift), this
+    test fails before a downstream caller hits a runtime TypeError.
+    """
+    assert callable(personal_kb_slug)
+    result = personal_kb_slug("test")
+    assert isinstance(result, str)
+    assert result == "personal-test"

--- a/klai-portal/backend/uv.lock
+++ b/klai-portal/backend/uv.lock
@@ -832,6 +832,26 @@ dev = [
 ]
 
 [[package]]
+name = "klai-kb-slugs"
+version = "0.1.0"
+source = { editable = "../../klai-libs/kb-slugs" }
+
+[package.metadata]
+requires-dist = [
+    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.390" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8" },
+]
+provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pyright", specifier = ">=1.1.390" },
+    { name = "pytest", specifier = ">=8" },
+    { name = "ruff", specifier = ">=0.8" },
+]
+
+[[package]]
 name = "klai-log-utils"
 version = "0.1.0"
 source = { editable = "../../klai-libs/log-utils" }
@@ -880,6 +900,7 @@ dependencies = [
     { name = "klai-citations" },
     { name = "klai-connector-credentials" },
     { name = "klai-image-storage" },
+    { name = "klai-kb-slugs" },
     { name = "klai-log-utils" },
     { name = "lingua-language-detector" },
     { name = "motor" },
@@ -941,6 +962,7 @@ requires-dist = [
     { name = "klai-connector-credentials", editable = "../../klai-libs/connector-credentials" },
     { name = "klai-identity-assert", marker = "extra == 'dev'", editable = "../../klai-libs/identity-assert" },
     { name = "klai-image-storage", editable = "../../klai-libs/image-storage" },
+    { name = "klai-kb-slugs", editable = "../../klai-libs/kb-slugs" },
     { name = "klai-log-utils", editable = "../../klai-libs/log-utils" },
     { name = "lingua-language-detector", specifier = ">=2.2.0" },
     { name = "motor", specifier = ">=3.7" },

--- a/klai-retrieval-api/Dockerfile
+++ b/klai-retrieval-api/Dockerfile
@@ -16,6 +16,8 @@ WORKDIR /repo
 COPY --chown=app:app klai-libs/identity-assert klai-libs/identity-assert
 # SPEC-RAG-MULTILINGUAL-CHAT-001 REQ-02: shared chat-prompt constant.
 COPY --chown=app:app klai-libs/chat-prompts klai-libs/chat-prompts
+# SPEC-RAG-PERSONAL-SCOPE-001 REQ-1: canonical personal-KB slug helper.
+COPY --chown=app:app klai-libs/kb-slugs klai-libs/kb-slugs
 # Shared evidence context + deterministic citation/source helpers.
 COPY --chown=app:app klai-libs/citations klai-libs/citations
 COPY --chown=app:app klai-retrieval-api/pyproject.toml klai-retrieval-api/pyproject.toml

--- a/klai-retrieval-api/pyproject.toml
+++ b/klai-retrieval-api/pyproject.toml
@@ -28,6 +28,10 @@ dependencies = [
     # SPEC-RAG-MULTILINGUAL-CHAT-001 REQ-02: shared chat-prompt constant.
     # Editable install — same pattern as klai-identity-assert.
     "klai-chat-prompts",
+    # SPEC-RAG-PERSONAL-SCOPE-001 REQ-1: shared canonical personal-KB slug
+    # helper. Same template as portal-api provisioning so server-side
+    # scope=personal narrowing cannot drift from the provisioned value.
+    "klai-kb-slugs",
     # Shared evidence context + deterministic citation/source helpers.
     "klai-citations",
 ]
@@ -35,6 +39,7 @@ dependencies = [
 [tool.uv.sources]
 klai-identity-assert = { path = "../klai-libs/identity-assert", editable = true }
 klai-chat-prompts = { path = "../klai-libs/chat-prompts", editable = true }
+klai-kb-slugs = { path = "../klai-libs/kb-slugs", editable = true }
 klai-citations = { path = "../klai-libs/citations", editable = true }
 
 [project.optional-dependencies]

--- a/klai-retrieval-api/retrieval_api/api/retrieve.py
+++ b/klai-retrieval-api/retrieval_api/api/retrieve.py
@@ -12,6 +12,7 @@ from urllib.parse import urlparse, urlunparse
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request
+from klai_kb_slugs import personal_kb_slug
 
 from retrieval_api.config import settings
 from retrieval_api.metrics import (
@@ -105,16 +106,12 @@ def _apply_page_context_boost(
 
         boosted_count += 1
         score_key = (
-            "reranker_score"
-            if isinstance(chunk.get("reranker_score"), (int, float))
-            else "score"
+            "reranker_score" if isinstance(chunk.get("reranker_score"), (int, float)) else "score"
         )
         if isinstance(chunk.get(score_key), (int, float)):
             boosted_score = chunk[score_key] * _PAGE_CONTEXT_SCORE_BOOST
             chunk[score_key] = (
-                min(boosted_score, 1.0)
-                if score_key == "reranker_score"
-                else boosted_score
+                min(boosted_score, 1.0) if score_key == "reranker_score" else boosted_score
             )
             if mark:
                 chunk["_page_context_boosted"] = True
@@ -255,11 +252,33 @@ async def retrieve(
     # SPEC-PORTAL-RBAC-REFACTOR-001 REQ-17 / REQ-6: personal-role callers may
     # only search personal-scope KBs. Force scope to "personal" and strip any
     # caller-supplied kb_slugs so they cannot reach org KBs via this endpoint.
+    #
+    # Note (SPEC-RAG-PERSONAL-SCOPE-001): the strip below removes the
+    # caller-supplied kb_slugs filter, but does NOT widen scope=personal.
+    # Server-side canonical narrowing (``_scope_filter`` adds
+    # ``kb_slug=personal_kb_slug(user_id)`` for every scope=personal request)
+    # re-applies the equivalent filter independent of effective_role.
     if req.effective_role == "personal":
         if req.scope != "personal":
             req = req.model_copy(update={"scope": "personal", "kb_slugs": None})
         elif req.kb_slugs is not None:
             req = req.model_copy(update={"kb_slugs": None})
+
+    # SPEC-RAG-PERSONAL-SCOPE-001 REQ-8: structured observability event.
+    # Fires once per request for scope=personal / scope=both so VictoriaLogs
+    # can confirm the canonical narrowing is in effect post-deploy. If this
+    # event ever stops firing, the canonical filter has regressed silently.
+    if req.scope in ("personal", "both") and req.user_id:
+        logger.info(
+            "retrieval_personal_scope_canonical_filter_applied",
+            org_id=req.org_id,
+            user_id=req.user_id,
+            canonical_slug=personal_kb_slug(req.user_id),
+            scope=req.scope,
+            effective_role=req.effective_role,
+            client_supplied_kb_slugs=req.kb_slugs,
+        )
+
     page_context = req.page_context.model_dump(exclude_none=True) if req.page_context else None
 
     # SPEC-SEC-010 REQ-3 + SPEC-SEC-IDENTITY-ASSERT-001 REQ-4: cross-user /

--- a/klai-retrieval-api/retrieval_api/services/search.py
+++ b/klai-retrieval-api/retrieval_api/services/search.py
@@ -11,6 +11,7 @@ import warnings
 from datetime import UTC, datetime
 
 import structlog
+from klai_kb_slugs import personal_kb_slug
 from qdrant_client import AsyncQdrantClient
 from qdrant_client.models import (
     FieldCondition,
@@ -77,33 +78,29 @@ def _scope_filter(request: RetrieveRequest) -> list[FieldCondition | Filter]:
     ]
     if request.scope == "personal":
         if request.user_id:
-            # Match chunks owned by the requester via EITHER signal:
-            #   1. ``user_id`` payload field equals request.user_id (the
-            #      preferred stamping; written by ingest paths that
-            #      thread user_id through).
-            #   2. ``kb_slug`` equals the canonical per-user slug
-            #      ``personal-<user_id>`` (a structural ownership proof
-            #      — the slug name itself encodes the owner).
+            # SPEC-RAG-PERSONAL-SCOPE-001 REQ-2: scope=personal narrows to
+            # the requester's canonical Persoonlijk-KB slug. The slug
+            # template ``personal-<user_id>`` is the structural ownership
+            # proof — a chunk with this slug is BY CONSTRUCTION part of
+            # the canonical Persoonlijk-KB of the user encoded in the
+            # suffix, regardless of whether the chunk's ``user_id``
+            # payload was stamped at ingest.
             #
-            # The second branch is a defensive fallback for chunks
-            # ingested via connectors that did not pass user_id through
-            # to ``qdrant_store.upsert_chunks`` (e.g. legacy web_crawler
-            # runs on a personal KB before the 2026-05-27 ingest fix).
-            # Without it, those chunks are invisible to the very user
-            # who owns them.
-            canonical_personal_slug = f"personal-{request.user_id}"
+            # PR #709 added an OR-filter (user_id OR canonical_slug) to
+            # recover from connectors that did not stamp user_id.
+            # However, the user_id-OR branch let chunks from non-canonical
+            # user-owned KBs (e.g. ``test2``) leak through whenever the
+            # caller was the chunk's owner — exactly the Jantine bug we
+            # want to close. The canonical-slug branch alone matches both
+            # cases the OR was designed to handle:
+            #   - Modern chunks (kb_slug=canonical, user_id=me): pass
+            #   - Legacy chunks (kb_slug=canonical, user_id=None): pass
+            # and rejects the leak case:
+            #   - Other user-owned KB chunks (kb_slug=test2, user_id=me): blocked
             conditions.append(
-                Filter(
-                    should=[
-                        FieldCondition(
-                            key="user_id",
-                            match=MatchValue(value=request.user_id),
-                        ),
-                        FieldCondition(
-                            key="kb_slug",
-                            match=MatchValue(value=canonical_personal_slug),
-                        ),
-                    ]
+                FieldCondition(
+                    key="kb_slug",
+                    match=MatchValue(value=personal_kb_slug(request.user_id)),
                 )
             )
         # personal scope is already restricted to one user; no visibility filter needed
@@ -114,14 +111,27 @@ def _scope_filter(request: RetrieveRequest) -> list[FieldCondition | Filter]:
         )
         visibility_should: list[Filter] = [not_private]
         if request.user_id:
-            visibility_should.append(
-                Filter(
-                    must=[
-                        FieldCondition(key="visibility", match=MatchValue(value="private")),
-                        FieldCondition(key="user_id", match=MatchValue(value=request.user_id)),
-                    ]
+            own_private_must: list[FieldCondition] = [
+                FieldCondition(key="visibility", match=MatchValue(value="private")),
+                FieldCondition(key="user_id", match=MatchValue(value=request.user_id)),
+            ]
+            # SPEC-RAG-PERSONAL-SCOPE-001 REQ-3: scope=both, personal
+            # portion narrows to canonical slug. Without this, the
+            # own-private branch would let ALL user-owned private
+            # chunks pass — including non-canonical user-created
+            # private KBs like ``test2`` — even when the caller picked
+            # "Persoonlijk + specific org KBs" in the dropdown.
+            # scope=org keeps the wider semantic (REQ-3 narrows
+            # scope=both only) because no scope=org consumer models the
+            # Persoonlijk-vs-other-user-KB distinction today.
+            if request.scope == "both":
+                own_private_must.append(
+                    FieldCondition(
+                        key="kb_slug",
+                        match=MatchValue(value=personal_kb_slug(request.user_id)),
+                    )
                 )
-            )
+            visibility_should.append(Filter(must=own_private_must))
         conditions.append(Filter(should=visibility_should))
     if request.kb_slugs:
         if request.scope == "both" and request.user_id:

--- a/klai-retrieval-api/tests/test_personal_scope_canonical_regression.py
+++ b/klai-retrieval-api/tests/test_personal_scope_canonical_regression.py
@@ -1,0 +1,135 @@
+"""SPEC-RAG-PERSONAL-SCOPE-001 REQ-7 — Jantine scenario regression.
+
+The Jantine incident (2026-05-27 ~17:00 CEST): a user with two private
+knowledge bases — canonical Persoonlijk (slug ``personal-<user_id>``)
+and a user-created KB called ``test2`` — selected only "Persoonlijk" in
+the chat dropdown but received chunks from ``test2`` anyway. The leak
+was kept alive for personal-role callers by retrieval-api's
+``_apply_role_rewrite`` stripping the client-side kb_slugs filter (PR #715
+fix landed but was effectively bypassed for the default role).
+
+These tests pin the post-SPEC-RAG-PERSONAL-SCOPE-001 contract: scope=personal
+ALWAYS narrows to the canonical Persoonlijk-KB slug at the
+``_scope_filter`` layer, regardless of ``effective_role`` and regardless
+of whether the client supplied ``kb_slugs``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from klai_kb_slugs import personal_kb_slug
+from qdrant_client.models import FieldCondition
+
+from retrieval_api.models import RetrieveRequest
+from retrieval_api.services.search import _scope_filter
+
+
+@pytest.mark.parametrize(
+    "role",
+    ["personal", "company", "kb_manager", "group_manager", "admin", "unknown"],
+)
+def test_scope_personal_canonical_filter_applies_for_every_role(role: str) -> None:
+    """Across the entire ProfileRole ladder, scope=personal MUST end up
+    with exactly one canonical-slug filter in the conditions list.
+
+    The bug shape we close: personal-role callers had their kb_slugs
+    stripped server-side, leaving scope=personal as "any chunk where
+    user_id matches", which leaked test2 chunks. Now the canonical-slug
+    filter is added by ``_scope_filter`` itself, downstream of any
+    role-driven strip.
+    """
+    req = RetrieveRequest(
+        query="wie is jantine?",
+        org_id="o1",
+        scope="personal",
+        user_id="jantine-zitadel-sub",
+        effective_role=role,
+    )
+    conditions = _scope_filter(req)
+    slug_conditions = [
+        c for c in conditions if isinstance(c, FieldCondition) and c.key == "kb_slug"
+    ]
+    assert len(slug_conditions) == 1, (
+        f"expected exactly one kb_slug filter for role={role!r}, got {len(slug_conditions)}"
+    )
+    assert slug_conditions[0].match.value == personal_kb_slug("jantine-zitadel-sub"), (
+        f"role={role!r}: expected canonical slug filter, got {slug_conditions[0].match.value!r}"
+    )
+
+
+def test_scope_personal_without_kb_slugs_still_narrows_to_canonical() -> None:
+    """The personal-role kb_slugs strip leaves kb_slugs=None at the
+    ``_scope_filter`` call site. Even then, the canonical narrowing
+    must fire (it does not depend on req.kb_slugs)."""
+    req = RetrieveRequest(
+        query="q",
+        org_id="o1",
+        scope="personal",
+        user_id="u1",
+        effective_role="personal",
+        kb_slugs=None,
+    )
+    conditions = _scope_filter(req)
+    slug_conditions = [
+        c for c in conditions if isinstance(c, FieldCondition) and c.key == "kb_slug"
+    ]
+    assert len(slug_conditions) == 1
+    assert slug_conditions[0].match.value == "personal-u1"
+
+
+def test_scope_personal_with_client_supplied_canonical_slugs_no_duplicate() -> None:
+    """If the LiteLLM hook (post-PR-#715) also sends
+    ``kb_slugs=["personal-u1"]`` as a redundant client-side filter, the
+    conditions end up with TWO ``kb_slug`` FieldConditions — the
+    server-side canonical narrowing (MatchValue) AND the client-supplied
+    filter (MatchAny). Both target the same value; the search still
+    works. Defense in depth.
+    """
+    req = RetrieveRequest(
+        query="q",
+        org_id="o1",
+        scope="personal",
+        user_id="u1",
+        kb_slugs=["personal-u1"],
+        effective_role="admin",  # admin role does not trigger strip
+    )
+    conditions = _scope_filter(req)
+    slug_conditions = [
+        c for c in conditions if isinstance(c, FieldCondition) and c.key == "kb_slug"
+    ]
+    assert len(slug_conditions) == 2, (
+        f"expected canonical (MatchValue) + client (MatchAny) — got {len(slug_conditions)}"
+    )
+    # The canonical narrow is a MatchValue
+    match_value = next(c for c in slug_conditions if hasattr(c.match, "value"))
+    assert match_value.match.value == "personal-u1"
+    # The client-supplied filter is a MatchAny
+    match_any = next(c for c in slug_conditions if hasattr(c.match, "any"))
+    assert match_any.match.any == ["personal-u1"]
+
+
+def test_scope_personal_non_canonical_kb_slug_filter_still_appends_canonical() -> None:
+    """A future caller (or wrong-headed PR) sets ``kb_slugs=["test2"]``
+    together with ``scope=personal``. Server-side, the canonical
+    narrowing MUST still apply — the resulting filter has both
+    ``kb_slug=canonical`` (REQ-2) AND ``kb_slug=test2`` (client-supplied).
+    Both must hold via AND → empty result set. User explicitly receives
+    nothing rather than silently leaking test2.
+    """
+    req = RetrieveRequest(
+        query="q",
+        org_id="o1",
+        scope="personal",
+        user_id="u1",
+        kb_slugs=["test2"],
+        effective_role="admin",
+    )
+    conditions = _scope_filter(req)
+    slug_conditions = [
+        c for c in conditions if isinstance(c, FieldCondition) and c.key == "kb_slug"
+    ]
+    # One canonical (MatchValue), one client-supplied (MatchAny)
+    match_value = next(c for c in slug_conditions if hasattr(c.match, "value"))
+    assert match_value.match.value == "personal-u1"
+    match_any = next(c for c in slug_conditions if hasattr(c.match, "any"))
+    assert match_any.match.any == ["test2"]

--- a/klai-retrieval-api/tests/test_role_filter.py
+++ b/klai-retrieval-api/tests/test_role_filter.py
@@ -163,3 +163,86 @@ class TestPersonalRoleRewrite:
         )
         result = _apply_role_rewrite(req)
         assert result.scope == "org"
+
+
+# ---------------------------------------------------------------------------
+# Integration: role-rewrite + scope-filter chain (SPEC-RAG-PERSONAL-SCOPE-001 REQ-5)
+# ---------------------------------------------------------------------------
+
+
+class TestPersonalRoleRewriteChainsIntoCanonicalNarrow:
+    """The personal-role kb_slugs strip (RBAC, REQ-17 of
+    SPEC-PORTAL-RBAC-REFACTOR-001) MUST NOT defeat the canonical-slug
+    narrowing introduced by SPEC-RAG-PERSONAL-SCOPE-001 REQ-2.
+
+    Chain: client request → ``_apply_role_rewrite`` → ``_scope_filter``.
+    Even though the strip removes ``kb_slugs`` for personal-role callers,
+    ``_scope_filter`` must still append the canonical-slug filter.
+    """
+
+    def test_personal_role_stripped_slugs_still_canonical_narrowed(self) -> None:
+        from qdrant_client.models import FieldCondition
+
+        from retrieval_api.models import RetrieveRequest
+        from retrieval_api.services.search import _scope_filter
+
+        # Start from a personal-role caller's "I want canonical Persoonlijk
+        # only" intent — but with org-side kb_slugs that the strip should
+        # remove. Pre-SPEC, this leaked: scope became personal, kb_slugs
+        # became None, and _scope_filter's user_id-OR-kb_slug let test2
+        # chunks through via the user_id branch.
+        req = RetrieveRequest(
+            query="wie is jantine?",
+            org_id="o1",
+            scope="org",
+            kb_slugs=["sneaky-org-kb"],
+            user_id="u1",
+            effective_role="personal",
+        )
+
+        # Apply the rewrite (strips kb_slugs, forces scope to personal).
+        rewritten = _apply_role_rewrite(req)
+        assert rewritten.scope == "personal"
+        assert rewritten.kb_slugs is None
+
+        # The canonical narrow MUST be present in the filter conditions.
+        conditions = _scope_filter(rewritten)
+        slug_conditions = [
+            c for c in conditions if isinstance(c, FieldCondition) and c.key == "kb_slug"
+        ]
+        assert len(slug_conditions) == 1, (
+            f"expected exactly one canonical kb_slug filter after the chain, "
+            f"got {len(slug_conditions)}"
+        )
+        assert slug_conditions[0].match.value == "personal-u1"
+
+    def test_personal_role_with_canonical_kb_slugs_strip_then_narrow(self) -> None:
+        from qdrant_client.models import FieldCondition
+
+        from retrieval_api.models import RetrieveRequest
+        from retrieval_api.services.search import _scope_filter
+
+        # Edge case: the LiteLLM hook (post-PR-#715) sends
+        # kb_slugs=["personal-u1"] together with scope=personal AND
+        # effective_role=personal. The RBAC strip removes kb_slugs (it
+        # doesn't distinguish canonical from non-canonical). Server-side
+        # canonical narrow then re-applies it. End-state: caller's
+        # intent is preserved despite the strip.
+        req = RetrieveRequest(
+            query="q",
+            org_id="o1",
+            scope="personal",
+            kb_slugs=["personal-u1"],
+            user_id="u1",
+            effective_role="personal",
+        )
+        rewritten = _apply_role_rewrite(req)
+        # Strip removed the client-supplied filter
+        assert rewritten.kb_slugs is None
+        # Server-side canonical narrow recovers it
+        conditions = _scope_filter(rewritten)
+        slug_conditions = [
+            c for c in conditions if isinstance(c, FieldCondition) and c.key == "kb_slug"
+        ]
+        assert len(slug_conditions) == 1
+        assert slug_conditions[0].match.value == "personal-u1"

--- a/klai-retrieval-api/tests/test_scope_filter.py
+++ b/klai-retrieval-api/tests/test_scope_filter.py
@@ -36,31 +36,72 @@ class TestScopeFilterVisibility:
         conditions = _scope_filter(req)
         assert _find_visibility_filter(conditions) is not None
 
-    def test_personal_scope_matches_user_id_or_canonical_slug(self):
-        """personal scope: chunk matches if EITHER user_id OR
-        ``kb_slug == personal-<user_id>`` matches.
+    def test_personal_scope_filters_by_canonical_kb_slug_only(self):
+        """SPEC-RAG-PERSONAL-SCOPE-001 REQ-2: scope=personal narrows to the
+        canonical Persoonlijk-KB slug, irrespective of any user_id field
+        on the chunk.
 
-        Bug fix 2026-05-27: previously this branch only matched on
-        ``user_id``. Connectors like web_crawler ingest into a personal
-        KB without passing user_id, so chunks landed in Qdrant with
-        ``user_id=None`` and the owner could not retrieve their own
-        content. The slug-based fallback restores ownership matching
-        via the structural slug pattern (``personal-<user_id>``)
-        without weakening any other scope's filter.
+        The slug template ``personal-<user_id>`` is the structural ownership
+        proof: a chunk with this slug is BY CONSTRUCTION part of the
+        canonical Persoonlijk-KB of the user encoded in the suffix. The
+        user_id payload field is redundant defence-in-depth — and an
+        ``user_id OR kb_slug`` OR-filter (the SPEC-PERSONAL-KB-#709 attempt)
+        wrongly lets chunks from OTHER user-owned KBs (e.g. ``test2``)
+        through via the user_id branch.
+
+        This test pins the post-fix contract: scope=personal MUST contain
+        a single direct FieldCondition on ``kb_slug`` with the canonical
+        value, AND MUST NOT contain a nested should-filter on ``user_id``
+        for ownership.
         """
         req = _make_request(scope="personal", user_id="user-1")
         conditions = _scope_filter(req)
-        nested = _find_visibility_filter(conditions)
-        assert nested is not None, "personal scope must add an ownership Filter"
-        assert nested.should is not None
-        assert len(nested.should) == 2, (
-            f"expected 2-branch should (user_id, kb_slug), got {len(nested.should)}"
+
+        # The canonical slug filter is a direct FieldCondition, not nested in a should.
+        slug_conditions = [
+            c for c in conditions
+            if isinstance(c, FieldCondition) and c.key == "kb_slug"
+        ]
+        assert len(slug_conditions) == 1, (
+            f"expected exactly one kb_slug condition, got {len(slug_conditions)}"
         )
-        # The two branches: user_id == user_id AND kb_slug == personal-<user_id>
-        keys = {c.key for c in nested.should if isinstance(c, FieldCondition)}
-        assert keys == {"user_id", "kb_slug"}, (
-            f"expected branches on user_id + kb_slug, got {keys}"
+        assert slug_conditions[0].match.value == "personal-user-1", (
+            f"expected canonical slug 'personal-user-1', "
+            f"got {slug_conditions[0].match.value!r}"
         )
+
+        # Regression guard: must NOT carry the pre-fix OR-filter that let
+        # test2-style chunks through via the user_id branch.
+        should_filters_with_user_id = [
+            c for c in conditions
+            if isinstance(c, Filter)
+            and c.should is not None
+            and any(
+                isinstance(s, FieldCondition) and s.key == "user_id"
+                for s in c.should
+            )
+        ]
+        assert should_filters_with_user_id == [], (
+            "scope=personal must NOT use the user_id-OR-kb_slug branch — "
+            "the OR lets chunks from non-canonical user-owned KBs leak."
+        )
+
+    def test_personal_scope_canonical_slug_uses_shared_helper(self):
+        """The canonical slug template lives in klai-libs/kb-slugs.
+
+        This test imports the shared helper and asserts the filter value
+        matches its output exactly — guards against retrieval-api silently
+        re-inventing a different template string.
+        """
+        from klai_kb_slugs import personal_kb_slug
+
+        req = _make_request(scope="personal", user_id="someone")
+        conditions = _scope_filter(req)
+        slug_cond = next(
+            c for c in conditions
+            if isinstance(c, FieldCondition) and c.key == "kb_slug"
+        )
+        assert slug_cond.match.value == personal_kb_slug("someone")
 
     def test_org_scope_without_user_only_public_branch(self):
         """Without user_id, only the not-private branch is present (no own-private exception)."""
@@ -103,6 +144,65 @@ class TestScopeFilterVisibility:
         keys = {c.key for c in own_branch.must if isinstance(c, FieldCondition)}
         assert "visibility" in keys
         assert "user_id" in keys
+
+    def test_scope_both_own_private_branch_narrows_to_canonical_slug(self):
+        """SPEC-RAG-PERSONAL-SCOPE-001 REQ-3: scope=both, personal portion
+        narrows to canonical slug.
+
+        The visibility-should clause for scope=both/org has two branches:
+        not_private (org chunks) and (visibility=private + user_id=me)
+        (personal chunks). Without narrowing, ALL user-owned private
+        chunks pass through the second branch — including non-canonical
+        user-created private KBs (e.g. ``test2``). This is the scope=both
+        sibling of the scope=personal leak fixed by REQ-2.
+
+        Fix: add ``kb_slug=personal-<user>`` to the private branch's must
+        list so only canonical Persoonlijk-KB chunks pass via the
+        user_id-bypass.
+        """
+        req = _make_request(scope="both", user_id="user-42", kb_slugs=["engineering"])
+        conditions = _scope_filter(req)
+        vis = _find_visibility_filter(conditions)
+        assert vis is not None
+        assert vis.should is not None and len(vis.should) == 2
+        own_branch = vis.should[1]
+        assert isinstance(own_branch, Filter)
+        assert own_branch.must is not None
+        keys_to_values = {
+            c.key: c.match.value
+            for c in own_branch.must
+            if isinstance(c, FieldCondition)
+        }
+        assert "visibility" in keys_to_values
+        assert "user_id" in keys_to_values
+        # NEW: canonical slug condition pins the private branch to
+        # canonical Persoonlijk only.
+        assert "kb_slug" in keys_to_values, (
+            "scope=both private branch must carry canonical kb_slug condition"
+        )
+        assert keys_to_values["kb_slug"] == "personal-user-42"
+
+    def test_scope_org_own_private_branch_does_not_add_canonical_slug(self):
+        """scope=org also has the visibility-should clause but is a pure-org
+        scope semantically. The own-private branch lets a user's private
+        chunks through (legitimate for "their org plus their private
+        notes"). REQ-3 explicitly narrows ONLY scope=both, not scope=org.
+
+        Rationale: scope=org callers (partner_chat) never opt into
+        personal narrowing; they don't model a Persoonlijk dropdown. The
+        chunks that pass via the own-private branch for scope=org are
+        legitimate org-personal overlaps. Don't tighten without a
+        consumer asking for it.
+        """
+        req = _make_request(scope="org", user_id="user-42")
+        conditions = _scope_filter(req)
+        vis = _find_visibility_filter(conditions)
+        own_branch = vis.should[1]
+        keys = {c.key for c in own_branch.must if isinstance(c, FieldCondition)}
+        assert "kb_slug" not in keys, (
+            "scope=org private branch should NOT carry canonical kb_slug — "
+            "REQ-3 narrows scope=both only."
+        )
 
     def test_kb_slugs_filter_org_scope(self):
         """kb_slugs filter added as a direct FieldCondition for scope=org."""

--- a/klai-retrieval-api/uv.lock
+++ b/klai-retrieval-api/uv.lock
@@ -761,6 +761,26 @@ dev = [
 ]
 
 [[package]]
+name = "klai-kb-slugs"
+version = "0.1.0"
+source = { editable = "../klai-libs/kb-slugs" }
+
+[package.metadata]
+requires-dist = [
+    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.390" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8" },
+]
+provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pyright", specifier = ">=1.1.390" },
+    { name = "pytest", specifier = ">=8" },
+    { name = "ruff", specifier = ">=0.8" },
+]
+
+[[package]]
 name = "lingua-language-detector"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1291,6 +1311,7 @@ dependencies = [
     { name = "klai-chat-prompts" },
     { name = "klai-citations" },
     { name = "klai-identity-assert" },
+    { name = "klai-kb-slugs" },
     { name = "lingua-language-detector" },
     { name = "prometheus-client" },
     { name = "pydantic" },
@@ -1322,6 +1343,7 @@ requires-dist = [
     { name = "klai-chat-prompts", editable = "../klai-libs/chat-prompts" },
     { name = "klai-citations", editable = "../klai-libs/citations" },
     { name = "klai-identity-assert", editable = "../klai-libs/identity-assert" },
+    { name = "klai-kb-slugs", editable = "../klai-libs/kb-slugs" },
     { name = "lingua-language-detector", specifier = ">=2.2.0" },
     { name = "prometheus-client", specifier = ">=0.21" },
     { name = "pydantic", specifier = ">=2.9" },


### PR DESCRIPTION
## SPEC

[SPEC-RAG-PERSONAL-SCOPE-001](.moai/specs/SPEC-RAG-PERSONAL-SCOPE-001/spec.md) — research.md, plan.md, acceptance.md in same dir.

## Probleem

De Jantine-bug (2026-05-27): user picks "Persoonlijk" in chat-dropdown, krijgt chunks van een ander user-owned KB (``test2``). PR #705/#715/#716 hebben dit client-side gefixt (LiteLLM-hook stuurt ``kb_slugs=["personal-<user>"]``). Werkt voor admin/company users.

**Maar niet voor personal-role users** (= default bij signup, dus de meeste users). Retrieval-api strip ``_apply_role_rewrite`` haalt ``kb_slugs`` weg → ``_scope_filter`` met OR ``(user_id=me OR kb_slug=canonical)`` laat ``test2`` chunks door via de user_id-branch. Klassiek "single gatekeeper, server vertrouwt client" anti-pattern.

## Fix

**Server-side canonical narrowing in retrieval-api**, ongeacht role of client-input.

### 3 commits

1. **8c2fc1de**: nieuwe ``klai-libs/kb-slugs`` shared library — één plek voor het slug-template (``personal-<user_id>``). + SPEC docs.
2. **b5b19a67**: portal-api re-routeert ``app.services.default_knowledge_bases.personal_kb_slug`` door de shared lib. Drift test pinst byte-equal output.
3. **1c1d047c**: retrieval-api ``_scope_filter`` voegt canonical kb_slug filter toe voor scope=personal (REQ-2) en scope=both private-branch (REQ-3). ``_apply_role_rewrite`` blijft ongewijzigd. + REQ-8 structured log event.

### Test totalen

| Suite | Resultaat |
|---|---|
| ``klai-libs/kb-slugs`` | 6/6 |
| portal-api (incl. drift) | 2918/2918 |
| retrieval-api scope/role/regression | 38/38 (3 nieuwe + 9 nieuwe + 15 in role-suite) |
| retrieval-api totaal | 500 passed, 1 skipped, 2 pre-existing reds unchanged |
| Lint (alle gewijzigde files) | clean |

### Defense-in-depth behoud

LiteLLM-hook's client-side filter (PR #715) blijft staan — twee lagen die naar dezelfde slug narrow'en. Test ``test_scope_personal_with_client_supplied_canonical_slugs_no_duplicate`` pint het observable gedrag zodat een toekomstige refactor niet per ongeluk één van de lagen weghaalt.

## Backwards-compatibility

- **knowledge-mcp** (scope=both, kb_slugs=None): de nieuwe REQ-3 narrowing voor scope=both raakt alleen de visibility-should private-branch. MCP-flow gebruikt geen kb_slugs filter → personal-portion blijft afhankelijk van canonical narrowing. Voor MCP users die expliciet non-canonical user-private KB content via scope=both wilden vinden: zie REQ-6 (intentioneel tightening voor 3rd-party MCP traffic).
- **partner_chat** (scope=org): ongewijzigd. REQ-3 narrowt scope=both, niet scope=org.
- **LiteLLM hook** (scope=personal/both): bestaande tests blijven groen zonder wijziging.

## Post-deploy verification

1. CI green
2. Container deployed (``gh run watch``)
3. VictoriaLogs query binnen 1 uur: ``service:retrieval-api AND event:retrieval_personal_scope_canonical_filter_applied`` returns >0
4. Manual e2e (zie acceptance.md Section "Manual e2e checklist"): personal-role test user, twee KBs, dropdown "Persoonlijk" only → geen test2 content lekt

## Rollback

Eén ``git revert`` — geen migration, geen client-coordination nodig. De canonical filter is additive in conditions list; reverten brengt de oude (lekkende) OR-filter terug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)