### PR TITLE
[codex] fix chat KB strict scope toggles

### DIFF
--- a/klai-portal/frontend/src/routes/app/_components/ChatConfigBar.tsx
+++ b/klai-portal/frontend/src/routes/app/_components/ChatConfigBar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Link } from '@tanstack/react-router'
 import { ChevronDown, Info } from 'lucide-react'
@@ -42,28 +42,35 @@ export function ChatConfigBar() {
   const { data: pref } = useQuery<KBPref>({
     queryKey: ['kb-preference'],
     queryFn: async () => apiFetch<KBPref>('/api/app/account/kb-preference'),
+    staleTime: 30_000,
   })
 
   const { data: kbsData } = useQuery<{ knowledge_bases: OrgKB[] }>({
     queryKey: ['all-kbs-for-bar'],
     queryFn: async () => apiFetch<{ knowledge_bases: OrgKB[] }>('/api/app/knowledge-bases'),
+    staleTime: 5 * 60_000,
   })
 
   const { data: instructionsData } = useQuery<Instruction[]>({
     queryKey: ['app-instructions-for-bar'],
     queryFn: async () => apiFetch<Instruction[]>('/api/app/templates'),
     retry: false,
+    staleTime: 5 * 60_000,
   })
 
   // Exclude every personal-* slug: the caller's own toggles via "Persoonlijk"
   // and other users' personal KBs should never show up in the chat dropdown.
-  const allKbs = (kbsData?.knowledge_bases ?? []).filter((kb) => !kb.slug.startsWith('personal-'))
-  const allSlugs = allKbs.map((kb) => kb.slug)
-  const currentSlugs: string[] = pref
-    ? pref.kb_slugs_filter === null
-      ? allSlugs
-      : pref.kb_slugs_filter.filter((s) => allSlugs.includes(s))
-    : allSlugs
+  const allKbs = useMemo(
+    () => (kbsData?.knowledge_bases ?? []).filter((kb) => !kb.slug.startsWith('personal-')),
+    [kbsData?.knowledge_bases],
+  )
+  const allSlugs = useMemo(() => allKbs.map((kb) => kb.slug), [allKbs])
+  const allSlugSet = useMemo(() => new Set(allSlugs), [allSlugs])
+  const currentSlugs: string[] = useMemo(() => {
+    if (!pref) return allSlugs
+    if (pref.kb_slugs_filter === null) return allSlugs
+    return pref.kb_slugs_filter.filter((s) => allSlugSet.has(s))
+  }, [allSlugSet, allSlugs, pref])
 
   const mutation = useMutation({
     mutationFn: async (patch: Partial<Omit<KBPref, 'kb_pref_version'>>) =>
@@ -111,17 +118,27 @@ export function ChatConfigBar() {
     }
   }
 
-  if (!pref || allKbs.length === 0) return null
+  const activeNames = useMemo(() => {
+    const names: string[] = []
+    if (!pref) return names
+    if (pref.kb_personal_enabled) names.push('Persoonlijk')
+    for (const kb of allKbs) {
+      if (currentSlugs.includes(kb.slug)) names.push(kb.name)
+    }
+    return names
+  }, [allKbs, currentSlugs, pref])
 
-  const activeNames: string[] = []
-  if (pref.kb_personal_enabled) activeNames.push('Persoonlijk')
-  for (const kb of allKbs) {
-    if (currentSlugs.includes(kb.slug)) activeNames.push(kb.name)
-  }
+  const allInstructions = useMemo(() => instructionsData ?? [], [instructionsData])
+  const activeInstructionIds: number[] = useMemo(
+    () => pref?.active_template_ids ?? [],
+    [pref?.active_template_ids],
+  )
+  const activeInstructions = useMemo(
+    () => allInstructions.filter((t) => activeInstructionIds.includes(t.id)),
+    [activeInstructionIds, allInstructions],
+  )
 
-  const allInstructions = instructionsData ?? []
-  const activeInstructionIds: number[] = pref.active_template_ids ?? []
-  const activeInstructions = allInstructions.filter((t) => activeInstructionIds.includes(t.id))
+  if (!pref) return null
 
   function toggleInstruction(id: number) {
     const next = activeInstructionIds.includes(id)

--- a/klai-portal/frontend/src/routes/app/_components/__tests__/ChatConfigBar.test.tsx
+++ b/klai-portal/frontend/src/routes/app/_components/__tests__/ChatConfigBar.test.tsx
@@ -1,0 +1,89 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const apiFetchMock = vi.fn()
+vi.mock('@/lib/apiFetch', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/apiFetch')>('@/lib/apiFetch')
+  return { ...actual, apiFetch: (...args: unknown[]) => apiFetchMock(...args) }
+})
+
+vi.mock('@tanstack/react-router', async () => {
+  const actual = await vi.importActual<typeof import('@tanstack/react-router')>('@tanstack/react-router')
+  return {
+    ...actual,
+    Link: ({ children }: { children: ReactNode }) => <a href="/app/knowledge">{children}</a>,
+  }
+})
+
+vi.mock('@/paraglide/messages', () => ({
+  chatbar_collections_general_ai: () => 'General AI',
+  chatbar_collections_label: () => 'Collections',
+  chatbar_collections_all_off: () => 'All off',
+  chatbar_collections_all_on: () => 'All on',
+  chatbar_collections_manage: () => 'Manage',
+  chatbar_mode_label: () => 'Mode',
+  chatbar_mode_narrow_on: () => 'Strict',
+  chatbar_mode_narrow_off: () => 'Open',
+  chatbar_mode_broad_description: () => 'Use KB plus general knowledge.',
+  chatbar_mode_narrow_description: () => 'Use only the KB.',
+  chatbar_instructions_label: () => 'Instructions',
+  chatbar_instructions_empty: () => 'None',
+  chatbar_instructions_clear: () => 'Clear',
+}))
+
+import { ChatConfigBar } from '../ChatConfigBar'
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}
+
+function mockApi({
+  kbs,
+  kbNarrow = false,
+}: {
+  kbs: Array<{ slug: string; name: string }>
+  kbNarrow?: boolean
+}) {
+  apiFetchMock.mockImplementation((path: string) => {
+    if (path === '/api/app/account/kb-preference') {
+      return Promise.resolve({
+        kb_retrieval_enabled: true,
+        kb_personal_enabled: true,
+        kb_slugs_filter: null,
+        kb_narrow: kbNarrow,
+        kb_pref_version: 1,
+        active_template_ids: null,
+      })
+    }
+    if (path === '/api/app/knowledge-bases') {
+      return Promise.resolve({ knowledge_bases: kbs })
+    }
+    if (path === '/api/app/templates') return Promise.resolve([])
+    return Promise.reject(new Error(`Unexpected apiFetch: ${path}`))
+  })
+}
+
+beforeEach(() => {
+  apiFetchMock.mockReset()
+})
+
+describe('ChatConfigBar', () => {
+  it('keeps the Open/Strict toggle visible for personal-only workspaces', async () => {
+    mockApi({ kbs: [{ slug: 'personal-user-1', name: 'Persoonlijk' }] })
+
+    render(
+      <Wrapper>
+        <ChatConfigBar />
+      </Wrapper>,
+    )
+
+    await waitFor(() => expect(screen.getByRole('radiogroup', { name: 'Mode' })).toBeTruthy())
+    expect(screen.getByRole('radio', { name: 'Open' })).toBeTruthy()
+    expect(screen.getByRole('radio', { name: 'Strict' })).toBeTruthy()
+  })
+})

--- a/klai-retrieval-api/retrieval_api/services/search.py
+++ b/klai-retrieval-api/retrieval_api/services/search.py
@@ -115,20 +115,29 @@ def _scope_filter(request: RetrieveRequest) -> list[FieldCondition | Filter]:
                 FieldCondition(key="visibility", match=MatchValue(value="private")),
                 FieldCondition(key="user_id", match=MatchValue(value=request.user_id)),
             ]
-            # SPEC-RAG-PERSONAL-SCOPE-001 REQ-3: scope=both, personal
-            # portion narrows to canonical slug. Without this, the
-            # own-private branch would let ALL user-owned private
-            # chunks pass — including non-canonical user-created
-            # private KBs like ``test2`` — even when the caller picked
-            # "Persoonlijk + specific org KBs" in the dropdown.
-            # scope=org keeps the wider semantic (REQ-3 narrows
-            # scope=both only) because no scope=org consumer models the
-            # Persoonlijk-vs-other-user-KB distinction today.
+            # SPEC-RAG-PERSONAL-SCOPE-001 REQ-3: scope=both must not use
+            # `user_id` as an unconstrained private-KB bypass. It may include
+            # the canonical Persoonlijk KB and any caller-selected KB slugs,
+            # but it must not let every private chunk owned by the user pass.
+            #
+            # This preserves the Jantine fix (selecting only Persoonlijk does
+            # not leak `test2`) while keeping the legitimate case working:
+            # selecting "Persoonlijk + test2" includes both slugs.
+            # scope=org keeps the wider semantic because partner_chat does not
+            # model a Persoonlijk-vs-other-user-KB dropdown today.
             if request.scope == "both":
+                allowed_private_slugs = list(
+                    dict.fromkeys(
+                        [
+                            personal_kb_slug(request.user_id),
+                            *(request.kb_slugs or []),
+                        ]
+                    )
+                )
                 own_private_must.append(
                     FieldCondition(
                         key="kb_slug",
-                        match=MatchValue(value=personal_kb_slug(request.user_id)),
+                        match=MatchAny(any=allowed_private_slugs),
                     )
                 )
             visibility_should.append(Filter(must=own_private_must))

--- a/klai-retrieval-api/tests/test_scope_filter.py
+++ b/klai-retrieval-api/tests/test_scope_filter.py
@@ -145,9 +145,9 @@ class TestScopeFilterVisibility:
         assert "visibility" in keys
         assert "user_id" in keys
 
-    def test_scope_both_own_private_branch_narrows_to_canonical_slug(self):
+    def test_scope_both_own_private_branch_narrows_to_canonical_and_selected_slugs(self):
         """SPEC-RAG-PERSONAL-SCOPE-001 REQ-3: scope=both, personal portion
-        narrows to canonical slug.
+        narrows to canonical + explicitly selected private slugs.
 
         The visibility-should clause for scope=both/org has two branches:
         not_private (org chunks) and (visibility=private + user_id=me)
@@ -156,11 +156,11 @@ class TestScopeFilterVisibility:
         user-created private KBs (e.g. ``test2``). This is the scope=both
         sibling of the scope=personal leak fixed by REQ-2.
 
-        Fix: add ``kb_slug=personal-<user>`` to the private branch's must
-        list so only canonical Persoonlijk-KB chunks pass via the
-        user_id-bypass.
+        Fix: add an allowed-slug condition to the private branch's must
+        list so only canonical Persoonlijk-KB chunks and explicitly selected
+        private KB slugs pass via the user_id-bypass.
         """
-        req = _make_request(scope="both", user_id="user-42", kb_slugs=["engineering"])
+        req = _make_request(scope="both", user_id="user-42", kb_slugs=["engineering", "test2"])
         conditions = _scope_filter(req)
         vis = _find_visibility_filter(conditions)
         assert vis is not None
@@ -168,19 +168,29 @@ class TestScopeFilterVisibility:
         own_branch = vis.should[1]
         assert isinstance(own_branch, Filter)
         assert own_branch.must is not None
-        keys_to_values = {
-            c.key: c.match.value
+        fields_by_key = {
+            c.key: c
             for c in own_branch.must
             if isinstance(c, FieldCondition)
         }
-        assert "visibility" in keys_to_values
-        assert "user_id" in keys_to_values
-        # NEW: canonical slug condition pins the private branch to
-        # canonical Persoonlijk only.
-        assert "kb_slug" in keys_to_values, (
-            "scope=both private branch must carry canonical kb_slug condition"
+        assert "visibility" in fields_by_key
+        assert "user_id" in fields_by_key
+        assert "kb_slug" in fields_by_key, (
+            "scope=both private branch must carry an allowed kb_slug condition"
         )
-        assert keys_to_values["kb_slug"] == "personal-user-42"
+        assert fields_by_key["kb_slug"].match.any == ["personal-user-42", "engineering", "test2"]
+
+    def test_scope_both_without_selected_slugs_blocks_non_canonical_private_kbs(self):
+        """Selecting only Persoonlijk must not leak other user-owned private KBs."""
+        req = _make_request(scope="both", user_id="user-42", kb_slugs=None)
+        conditions = _scope_filter(req)
+        vis = _find_visibility_filter(conditions)
+        own_branch = vis.should[1]
+        slug_cond = next(
+            c for c in own_branch.must
+            if isinstance(c, FieldCondition) and c.key == "kb_slug"
+        )
+        assert slug_cond.match.any == ["personal-user-42"]
 
     def test_scope_org_own_private_branch_does_not_add_canonical_slug(self):
         """scope=org also has the visibility-should clause but is a pure-org


### PR DESCRIPTION
## Summary

Fixes two chat knowledge-base edge cases:

- keeps the Open/Strict mode toggle visible in personal-only workspaces
- allows `scope=both` retrieval to include the canonical personal KB plus explicitly selected private KB slugs, without restoring the old unconstrained `user_id` private-KB bypass

## Why

The prior personal-scope hardening correctly stopped `Persoonlijk` from leaking non-canonical private KBs, but it also meant an explicitly selected private KB could be filtered out when selected together with `Persoonlijk`. Separately, the chat config bar returned `null` when only personal KBs were available, hiding the Open/Strict toggle.

## Validation

- `uv run --with pytest pytest tests/test_scope_filter.py tests/test_personal_scope_canonical_regression.py`
- `PYTHONPATH=../../klai-libs/citations uv run --with pytest --with pytest-asyncio --with httpx --with structlog --with litellm pytest tests/test_klai_knowledge_hook.py -k "ZeroChunksMode or post_call_keeps_model_answer_in_broad_mode_without_citable_sources or post_call_guard_refuses_empty_evidence_pack_in_narrow_mode"`
- `npm run lint -- src/routes/app/_components/ChatConfigBar.tsx src/routes/app/_components/__tests__/ChatConfigBar.test.tsx`
- `npm run build`
- `npm test -- ChatConfigBar.test.tsx`
- `git diff --check`
