### PR TITLE
fix(kb-sources): 30s timeout + fail-loud — Sources tab silent-empty regression

### DIFF
--- a/klai-portal/backend/app/api/app_knowledge_bases.py
+++ b/klai-portal/backend/app/api/app_knowledge_bases.py
@@ -1148,10 +1148,18 @@ async def list_kb_sources(
     deleting_ids = {str(c.id) for c in all_portal_connectors if c.state == "deleting"}
     connector_by_id: dict[str, PortalConnector] = {str(c.id): c for c in portal_connectors}
 
-    # Knowledge-ingest aggregates (per connector_id and direct uploads)
+    # Knowledge-ingest aggregates (per connector_id and direct uploads).
+    # FAIL-LOUD: when the upstream call fails (timeout, 5xx, transport),
+    # raise 503 so the frontend's isError branch fires ("Kon bronnen niet
+    # laden — probeer opnieuw"). Returning an empty list misleads users
+    # into thinking their just-uploaded source disappeared
+    # (incident 2026-05-28 — Jantine personal-KB).
     aggregates = await knowledge_ingest_client.get_kb_sources(org.zitadel_org_id, kb.slug)
     if aggregates is None:
-        aggregates = {"connectors": [], "uploads": []}
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={"error_code": "knowledge_ingest_unreachable"},
+        )
 
     sources: list[SourceOut] = []
 

--- a/klai-portal/backend/app/services/knowledge_ingest_client.py
+++ b/klai-portal/backend/app/services/knowledge_ingest_client.py
@@ -19,6 +19,14 @@ logger = logging.getLogger(__name__)
 # never hold the primary UI hostage when knowledge-ingest is busy.
 _DERIVED_READ_TIMEOUT = httpx.Timeout(1.0, connect=0.3)
 
+# Canonical UI data — the Sources tab IS this response, not an enrichment
+# badge. A 1s budget guarantees a timeout on cold queries (the artifacts-
+# join-parent_chunks scan measured 14-28s on prod 2026-05-28), which lands
+# in the UI as a misleading empty state. A generous budget paired with the
+# fail-loud branch in list_kb_sources lets the user see real data on warm
+# calls and a real error on the rare cold-and-slow path.
+_CANONICAL_READ_TIMEOUT = httpx.Timeout(30.0, connect=2.0)
+
 
 async def get_graph_stats(org_id: str) -> dict[str, int | None]:
     """Fetch entity/edge counts from knowledge-ingest (FalkorDB graph).
@@ -435,8 +443,15 @@ async def get_kb_sources(org_id: str, kb_slug: str) -> dict | None:
 
     Returns ``{"connectors": [{connector_id, items_count, chunks_count}, ...],
     "uploads": [{id, path, content_type, created_at, chunks_count}, ...]}``
-    on success, ``None`` on transport / decode failure (caller can fall back
-    to an empty UI state).
+    on success, ``None`` on transport / decode failure (caller MUST raise
+    503 — see ``list_kb_sources``; an empty fallback misleads the user into
+    thinking their upload disappeared).
+
+    Uses ``_CANONICAL_READ_TIMEOUT`` (30s), not ``_DERIVED_READ_TIMEOUT`` (1s):
+    this endpoint backs the Sources tab and its query joins
+    ``knowledge.artifacts`` with ``knowledge.parent_chunks`` — measured at
+    14-28s cold, 13ms warm on prod 2026-05-28. A 1s budget guaranteed
+    timeouts on every cold call.
     """
     try:
         async with httpx.AsyncClient(
@@ -446,7 +461,7 @@ async def get_kb_sources(org_id: str, kb_slug: str) -> dict | None:
                 "X-Caller-Service": "portal-api",
                 **get_trace_headers(),
             },
-            timeout=_DERIVED_READ_TIMEOUT,
+            timeout=_CANONICAL_READ_TIMEOUT,
         ) as client:
             resp = await client.get(
                 f"/knowledge/v1/kb/{kb_slug}/sources",

--- a/klai-portal/backend/tests/test_app_knowledge_sources_list.py
+++ b/klai-portal/backend/tests/test_app_knowledge_sources_list.py
@@ -314,8 +314,19 @@ async def test_list_kb_sources_handles_orphan_connector_id() -> None:
 
 
 @pytest.mark.asyncio
-async def test_list_kb_sources_falls_back_to_empty_on_ingest_failure() -> None:
-    """Knowledge-ingest unreachable → still return portal-side connectors."""
+async def test_list_kb_sources_raises_503_on_ingest_failure() -> None:
+    """Knowledge-ingest unreachable → 503, NOT a misleading empty list.
+
+    Regression test for 2026-05-28 incident: a 1s portal-api timeout on the
+    canonical Sources query (knowledge-ingest's join over artifacts +
+    parent_chunks measured 14-28s cold) caused every upload to appear to
+    silently vanish. The old fall-back-to-empty behavior is the bug — the
+    user thinks their just-uploaded source disappeared. Fail-loud lets the
+    frontend's isError branch render "Kon bronnen niet laden — probeer
+    opnieuw" so the user knows it is a transient problem, not data loss.
+    """
+    from fastapi import HTTPException
+
     from app.api.app_knowledge_bases import list_kb_sources
 
     org = _make_org()
@@ -337,18 +348,16 @@ async def test_list_kb_sources_falls_back_to_empty_on_ingest_failure() -> None:
             "app.api.app_knowledge_bases.knowledge_ingest_client.get_kb_sources",
             new=AsyncMock(return_value=None),  # transport failure
         ),
+        pytest.raises(HTTPException) as excinfo,
     ):
-        result = await list_kb_sources(
+        await list_kb_sources(
             kb_slug="kb-a",
             perms=_make_perms(),
             db=db,
         )
 
-    # Connector still surfaced via portal-side list, with zero counts.
-    assert len(result.sources) == 1
-    assert result.sources[0].id == "conn-1"
-    assert result.sources[0].items_count == 0
-    assert result.sources[0].chunks_count == 0
+    assert excinfo.value.status_code == 503
+    assert excinfo.value.detail == {"error_code": "knowledge_ingest_unreachable"}
 
 
 @pytest.mark.asyncio
@@ -575,3 +584,42 @@ async def test_get_source_content_upload_returns_chunks() -> None:
     assert result.chunks[0].position == 0
     assert result.total == 2
     assert result.items == []
+
+
+# -- Timeout choice regression (2026-05-28 personal-KB silent-empty incident) --
+
+
+def test_get_kb_sources_uses_canonical_not_derived_timeout() -> None:
+    """``get_kb_sources`` MUST use the canonical (30s) timeout, not the
+    derived-metric (1s) one.
+
+    The Sources tab IS this response, not an enrichment badge. A 1s budget
+    guaranteed every cold call timed out (production query measured 14-28s
+    cold, 13ms warm on 2026-05-28). The portal silently swallowed the
+    timeout and returned an empty list, making every just-uploaded source
+    appear to vanish.
+
+    This pin protects against future refactors that switch the call back
+    to ``_DERIVED_READ_TIMEOUT`` thinking it is "just enrichment".
+    """
+    from pathlib import Path
+
+    client_file = Path(__file__).parent.parent / "app" / "services" / "knowledge_ingest_client.py"
+    source = client_file.read_text(encoding="utf-8")
+
+    # Find the get_kb_sources function body and assert it carries the
+    # canonical timeout name. We do not assert the literal number — the
+    # value can be re-tuned without changing the contract this test pins.
+    fn_start = source.index("async def get_kb_sources(")
+    fn_end = source.index("\nasync def ", fn_start + 1)
+    body = source[fn_start:fn_end]
+
+    assert "timeout=_CANONICAL_READ_TIMEOUT" in body, (
+        "get_kb_sources must use _CANONICAL_READ_TIMEOUT (30s) — "
+        "this endpoint backs the Sources tab and 1s guarantees cold-call "
+        "timeouts on the artifacts+parent_chunks join. See "
+        "klai-portal/backend/app/services/knowledge_ingest_client.py."
+    )
+    assert "timeout=_DERIVED_READ_TIMEOUT" not in body, (
+        "get_kb_sources must NOT use _DERIVED_READ_TIMEOUT (1s) — see 2026-05-28 personal-KB silent-empty regression."
+    )


### PR DESCRIPTION
## Summary

- `get_kb_sources` (portal-api → knowledge-ingest) used `_DERIVED_READ_TIMEOUT` (1s) on the **canonical** Sources tab response. Knowledge-ingest's query measured **14-28s cold / 13ms warm** on prod 2026-05-28 — guaranteed every cold call timed out, then silently returned `{connectors: [], uploads: []}` so newly-uploaded sources appeared to vanish.
- Bump that one call to a new `_CANONICAL_READ_TIMEOUT` (30s); other derived-metric calls (graph_stats, source_count) keep the 1s budget.
- `list_kb_sources` now raises **HTTP 503 `knowledge_ingest_unreachable`** instead of returning an empty list when knowledge-ingest fails. The frontend already renders `isError` as "Kon bronnen niet laden — probeer opnieuw" — honest beats misleading-empty.

## Root cause evidence (prod 2026-05-28)

`getklai` tenant — Jantine's personal KB:
- DB: `CV_Jantine_Doornbos.pdf` artifact, `belief_time_end=alive`, `source_connector_id=NULL` → SHOULD appear in Sources list.
- portal-api logs (request_id `627e27e3`): **23 × `httpx.ReadTimeout`** on the call to knowledge-ingest's `/knowledge/v1/kb/{slug}/sources`.
- Direct curl from inside knowledge-ingest container: HTTP 200 in **14.350s** (1st call), **27.795s** (2nd), **0.013s** (3rd, cached). Response body correctly contained the missing PDF.

## Test plan

- [x] `tests/test_app_knowledge_sources_list.py` — 15/15 green
- [x] New regression `test_list_kb_sources_raises_503_on_ingest_failure` pins the fail-loud contract
- [x] New source-grep `test_get_kb_sources_uses_canonical_not_derived_timeout` blocks future re-introduction of the 1s timeout
- [x] `ruff check` + `ruff format --check` clean
- [x] `pyright` clean on both modified app files
- [ ] Verify post-deploy: open Persoonlijk KB → Bronnen tab on `jantine-doornbos-37418563` tenant — should show the existing PDF instead of "Nog geen bronnen"

## Follow-up (separate PRs, not blocking)

1. **knowledge-ingest query speedup**: covering index on `knowledge.artifacts (org_id, kb_slug, belief_time_end)` and/or a fast-path that doesn't `LEFT JOIN parent_chunks` for the listing. 14-28s for 2 rows is not a timeout problem — it is a query problem.
2. **UX simplification of the add-source flow** (discussed separately) — separate add-source route + 462-line FileUploadForm + 4 pipelines + 2s polling loop is more complexity than the surface earns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)