### PR TITLE
fix(kb-sources): delete-during-processing — handle KBUpload.id vs artifact_id

### DIFF
--- a/klai-portal/backend/app/api/app_knowledge_bases.py
+++ b/klai-portal/backend/app/api/app_knowledge_bases.py
@@ -1453,21 +1453,43 @@ async def rename_kb_upload(
 
 
 @router.delete(
-    "/knowledge-bases/{kb_slug}/uploads/{artifact_id}", status_code=204, dependencies=[Depends(get_kb_with_access)]
+    "/knowledge-bases/{kb_slug}/uploads/{upload_or_artifact_id}",
+    status_code=204,
+    dependencies=[Depends(get_kb_with_access)],
 )
 async def delete_kb_upload(
     kb_slug: str,
-    artifact_id: str,
+    upload_or_artifact_id: str,
     perms: UserPermissions = Depends(get_caller),
     db: AsyncSession = Depends(get_db),
 ) -> None:
-    """Delete a direct-upload artifact from the KB.
+    """Delete a direct-upload from the KB, handling both lifecycle stages.
 
     Owners may delete any upload.
     Contributors may only delete their own uploads (ownership enforced by
-    knowledge-ingest via X-User-ID check).
+    knowledge-ingest via X-User-ID check for done artifacts; by created_by
+    check on the KBUpload row for in-flight uploads).
     Viewers get 403.
-    SPEC-PORTAL-KENNIS-002 B2.
+
+    The path id parameter is overloaded by design because the Sources tab
+    surfaces two different id types under the same row.id field:
+
+    - status in {processing, ingesting, failed}  →  KBUpload.id (uuid)
+      The artifact does not exist yet (or never will, if failed). Only the
+      kb_uploads row exists.
+    - status == done                              →  artifact_id (uuid)
+      The kb_uploads row is hidden once status flips to done; the artifact
+      is the canonical handle.
+
+    This handler tries the KBUpload lookup first. If hit, we delete the
+    kb_uploads row (and cascade to the artifact if it was already created).
+    Otherwise we fall back to the legacy artifact-delete forward.
+
+    Regression: before this handler accepted both id types, clicking delete
+    on a still-processing upload sent the kb_uploads.id to knowledge-ingest
+    as if it were artifact_id, which 404'd, which left the kb_uploads row
+    in place. On the next refresh the row reappeared, reading as "delete
+    didn't do anything" (incident 2026-05-28 — Jantine).
     """
     org = await _load_org_or_500(db, perms.org_id)
     kb = await _get_kb_or_404(kb_slug, perms.org_id, db)
@@ -1487,13 +1509,80 @@ async def delete_kb_upload(
             detail="Contributor or owner access required",
         )
 
+    # Try to find a KBUpload row by id — this handles the
+    # processing/ingesting/failed case where no artifact exists yet
+    # (or where the artifact failed to materialise).
+    upload_row = await db.execute(
+        select(KBUpload).where(
+            KBUpload.id == upload_or_artifact_id,
+            KBUpload.org_id == perms.org_id,
+            KBUpload.kb_id == kb.id,
+        )
+    )
+    upload = upload_row.scalar_one_or_none()
+
     # Contributors: pass user_id so knowledge-ingest enforces ownership.
     # Owners: omit user_id to allow cross-user deletes.
     caller_user_id = perms.user_id if role == "contributor" else None
+
+    if upload is not None:
+        # Contributor ownership check for in-flight uploads — mirrors
+        # knowledge-ingest's X-User-ID gate on the artifact-side delete.
+        if role == "contributor" and upload.created_by != perms.user_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="you can only delete your own uploads",
+            )
+
+        # If the upload already produced an artifact, cascade the delete to
+        # knowledge-ingest so Qdrant + artifact row also go. We do this
+        # BEFORE the local row delete so a failing upstream call does not
+        # leave an artifact stranded with no kb_uploads breadcrumb.
+        if upload.artifact_id:
+            try:
+                await knowledge_ingest_client.delete_kb_upload(
+                    org.zitadel_org_id,
+                    kb.slug,
+                    upload.artifact_id,
+                    user_id=caller_user_id,
+                )
+            except httpx.HTTPStatusError as exc:
+                # 404 = artifact already gone (race with poller). Treat as
+                # success and continue to delete the local row. Anything
+                # else propagates as 502 — local row will linger but the
+                # user can retry.
+                if exc.response.status_code != 404:
+                    logger.exception(
+                        "delete_kb_upload_cascade_failed",
+                        kb_slug=kb_slug,
+                        upload_id=str(upload.id),
+                        artifact_id=upload.artifact_id,
+                        status=exc.response.status_code,
+                    )
+                    raise HTTPException(
+                        status_code=status.HTTP_502_BAD_GATEWAY,
+                        detail="Could not clean up artifact",
+                    ) from exc
+
+        await db.delete(upload)
+        await db.commit()
+        logger.info(
+            "kb_upload_deleted",
+            org_id=org.zitadel_org_id,
+            kb_slug=kb_slug,
+            upload_id=str(upload.id),
+            had_artifact=bool(upload.artifact_id),
+            status_at_delete=upload.status,
+        )
+        return
+
+    # No KBUpload row — treat as a legacy artifact_id and forward.
+    # The artifact-side delete enforces its own ownership check on
+    # contributor calls (user_id query param).
     await knowledge_ingest_client.delete_kb_upload(
         org.zitadel_org_id,
         kb.slug,
-        artifact_id,
+        upload_or_artifact_id,
         user_id=caller_user_id,
     )
 

--- a/klai-portal/backend/tests/test_kb_upload_permissions.py
+++ b/klai-portal/backend/tests/test_kb_upload_permissions.py
@@ -44,9 +44,19 @@ def _make_kb() -> MagicMock:
     return kb
 
 
-def _make_db() -> AsyncMock:
+def _make_db(kb_upload: object | None = None) -> AsyncMock:
+    """Build a mock AsyncSession.
+
+    Pass ``kb_upload=row`` to simulate the KBUpload-by-id lookup hitting; the
+    default ``None`` makes that lookup return no row so callers exercise the
+    legacy artifact-id fallback path in ``delete_kb_upload``.
+    """
     db = AsyncMock()
     db.add = MagicMock()
+    db.delete = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none = MagicMock(return_value=kb_upload)
+    db.execute = AsyncMock(return_value=result)
     return db
 
 
@@ -244,7 +254,7 @@ async def test_delete_upload_contributor_passes_user_id() -> None:
     ):
         result = await delete_kb_upload(
             kb_slug=_KB_SLUG,
-            artifact_id=_ARTIFACT_ID,
+            upload_or_artifact_id=_ARTIFACT_ID,
             perms=perms,
             db=_make_db(),
         )
@@ -290,7 +300,7 @@ async def test_delete_upload_owner_passes_none_user_id() -> None:
     ):
         result = await delete_kb_upload(
             kb_slug=_KB_SLUG,
-            artifact_id=_ARTIFACT_ID,
+            upload_or_artifact_id=_ARTIFACT_ID,
             perms=perms,
             db=_make_db(),
         )
@@ -334,7 +344,7 @@ async def test_delete_upload_viewer_raises_403() -> None:
         with pytest.raises(HTTPException) as exc_info:
             await delete_kb_upload(
                 kb_slug=_KB_SLUG,
-                artifact_id=_ARTIFACT_ID,
+                upload_or_artifact_id=_ARTIFACT_ID,
                 perms=perms,
                 db=_make_db(),
             )
@@ -373,10 +383,167 @@ async def test_delete_upload_no_role_raises_403() -> None:
         with pytest.raises(HTTPException) as exc_info:
             await delete_kb_upload(
                 kb_slug=_KB_SLUG,
-                artifact_id=_ARTIFACT_ID,
+                upload_or_artifact_id=_ARTIFACT_ID,
                 perms=perms,
                 db=_make_db(),
             )
 
     assert exc_info.value.status_code == 403
     mock_delete.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# delete_kb_upload — KBUpload-by-id path (2026-05-28 incident, processing rows)
+# ---------------------------------------------------------------------------
+
+
+def _make_kb_upload(
+    *,
+    upload_id: str = "11111111-2222-3333-4444-555555555555",
+    artifact_id: str | None = None,
+    status_value: str = "processing",
+    created_by: str = _USER_ID,
+) -> MagicMock:
+    upload = MagicMock()
+    upload.id = upload_id
+    upload.artifact_id = artifact_id
+    upload.status = status_value
+    upload.created_by = created_by
+    return upload
+
+
+@pytest.mark.asyncio
+async def test_delete_processing_upload_deletes_kb_upload_row_no_artifact_call() -> None:
+    """An in-flight upload (status=processing, no artifact) → delete the
+    kb_uploads row and SKIP the knowledge-ingest call.
+
+    Regression test for the 2026-05-28 silent-no-op incident: previously
+    the kb_uploads.id was sent to knowledge-ingest as artifact_id → 404 →
+    kb_uploads row never removed → row reappears on next refresh.
+    """
+    from app.api.app_knowledge_bases import delete_kb_upload
+
+    org = _make_org()
+    kb = _make_kb()
+    perms = make_perms(role="admin", user_id=_OWNER_USER_ID, org_id=_ORG_ID)
+    upload = _make_kb_upload(artifact_id=None, status_value="processing")
+    db = _make_db(kb_upload=upload)
+
+    with (
+        patch(
+            "app.api.app_knowledge_bases._load_org_or_500",
+            new=AsyncMock(return_value=org),
+        ),
+        patch(
+            "app.api.app_knowledge_bases._get_kb_or_404",
+            new=AsyncMock(return_value=kb),
+        ),
+        patch(
+            "app.api.app_knowledge_bases.get_user_role_for_kb",
+            new=AsyncMock(return_value="owner"),
+        ),
+        patch(
+            "app.api.app_knowledge_bases.knowledge_ingest_client.delete_kb_upload",
+            new=AsyncMock(return_value=None),
+        ) as mock_delete,
+    ):
+        result = await delete_kb_upload(
+            kb_slug=_KB_SLUG,
+            upload_or_artifact_id=str(upload.id),
+            perms=perms,
+            db=db,
+        )
+
+    assert result is None
+    db.delete.assert_awaited_once_with(upload)
+    db.commit.assert_awaited()
+    # Critical: no artifact-side delete call because no artifact exists yet.
+    mock_delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delete_done_upload_cascades_to_artifact_then_deletes_row() -> None:
+    """A finished upload (status=done, has artifact_id) → cascade-delete
+    the artifact via knowledge-ingest AND delete the local kb_uploads row.
+    """
+    from app.api.app_knowledge_bases import delete_kb_upload
+
+    org = _make_org()
+    kb = _make_kb()
+    perms = make_perms(role="admin", user_id=_OWNER_USER_ID, org_id=_ORG_ID)
+    upload = _make_kb_upload(artifact_id="art-xyz", status_value="done")
+    db = _make_db(kb_upload=upload)
+
+    with (
+        patch(
+            "app.api.app_knowledge_bases._load_org_or_500",
+            new=AsyncMock(return_value=org),
+        ),
+        patch(
+            "app.api.app_knowledge_bases._get_kb_or_404",
+            new=AsyncMock(return_value=kb),
+        ),
+        patch(
+            "app.api.app_knowledge_bases.get_user_role_for_kb",
+            new=AsyncMock(return_value="owner"),
+        ),
+        patch(
+            "app.api.app_knowledge_bases.knowledge_ingest_client.delete_kb_upload",
+            new=AsyncMock(return_value=None),
+        ) as mock_delete,
+    ):
+        await delete_kb_upload(
+            kb_slug=_KB_SLUG,
+            upload_or_artifact_id=str(upload.id),
+            perms=perms,
+            db=db,
+        )
+
+    mock_delete.assert_awaited_once_with(
+        org.zitadel_org_id,
+        kb.slug,
+        "art-xyz",
+        user_id=None,  # owner
+    )
+    db.delete.assert_awaited_once_with(upload)
+
+
+@pytest.mark.asyncio
+async def test_delete_processing_upload_contributor_other_user_403() -> None:
+    """Contributor cannot delete another contributor's in-flight upload.
+
+    Mirrors the artifact-side X-User-ID check for kb_uploads rows that
+    have not produced an artifact yet.
+    """
+    from app.api.app_knowledge_bases import delete_kb_upload
+
+    org = _make_org()
+    kb = _make_kb()
+    perms = make_perms(role="personal", user_id="someone-else", org_id=_ORG_ID)
+    upload = _make_kb_upload(created_by=_USER_ID)  # owned by user-contributor
+    db = _make_db(kb_upload=upload)
+
+    with (
+        patch(
+            "app.api.app_knowledge_bases._load_org_or_500",
+            new=AsyncMock(return_value=org),
+        ),
+        patch(
+            "app.api.app_knowledge_bases._get_kb_or_404",
+            new=AsyncMock(return_value=kb),
+        ),
+        patch(
+            "app.api.app_knowledge_bases.get_user_role_for_kb",
+            new=AsyncMock(return_value="contributor"),
+        ),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await delete_kb_upload(
+                kb_slug=_KB_SLUG,
+                upload_or_artifact_id=str(upload.id),
+                perms=perms,
+                db=db,
+            )
+
+    assert exc_info.value.status_code == 403
+    db.delete.assert_not_awaited()


### PR DESCRIPTION
## Summary

Sequel to #721 — same UX class (the Sources tab lies to the user about what just happened) but a different code path: delete instead of list.

The Sources tab surfaces two different id types under the same \`row.id\` field depending on upload lifecycle:
- \`status ∈ {processing, ingesting, failed}\` → \`KBUpload.id\` (kb_uploads tabel)
- \`status == done\` → \`artifact_id\` (knowledge.artifacts tabel)

The DELETE endpoint treated everything as artifact_id and forwarded blindly to knowledge-ingest. For a still-processing row, knowledge-ingest 404'd, the kb_uploads row was never cleaned up, and the row reappeared on next refresh.

## Fix

\`delete_kb_upload\` looks up KBUpload first:
1. Found + \`artifact_id\` set → cascade delete via knowledge-ingest (404 = idempotent, anything else = 502) + delete kb_uploads row
2. Found, no \`artifact_id\` (in-flight or failed) → just delete kb_uploads row, no upstream call
3. Not found → legacy artifact_id path (unchanged)

Contributor ownership check mirrored on kb_uploads side (\`created_by == perms.user_id\`).

## Test plan

- [x] 11/11 in \`test_kb_upload_permissions.py\` green (8 existing adapted + 3 new)
- [x] New regression test reproducing exactly the 2026-05-28 scenario: \`test_delete_processing_upload_deletes_kb_upload_row_no_artifact_call\`
- [x] \`ruff check\` + \`ruff format --check\` clean
- [ ] Post-deploy verify: click delete on a processing upload → row gone after refresh

## Stacked on

#721 (merged just before this — same files, no conflicts expected since this PR was branched from origin/main after #721 landed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)