### PR TITLE
feat(librechat): force light theme via Klai entrypoint wrapper

### DIFF
--- a/.github/workflows/deploy-compose.yml
+++ b/.github/workflows/deploy-compose.yml
@@ -10,6 +10,7 @@ on:
       - 'deploy/alloy/config.alloy'               # SPEC-INFRA-CONFIG-SYNC-001 R3 — alloy log-pipeline config
       - 'deploy/searxng/settings.yml'             # SPEC-INFRA-CONFIG-SYNC-001 R3 — searxng search config
       - 'deploy/vexa/profiles.yaml'               # SPEC-INFRA-CONFIG-SYNC-001 R3 — vexa runtime-api meeting-bot profiles
+      - 'deploy/librechat/klai-entrypoint.sh'     # force light theme — synced before librechat-getklai recreate
       - 'deploy/grafana/provisioning/**'          # SPEC-SEC-024 M4.2 — alert rule + dashboard
       - 'deploy/scripts/**'                       # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3 — compose-up wrapper + audit-orphan-snapshot
       - 'scripts/smoke-docker-socket-proxy.sh'    # SPEC-SEC-024 M4.3 — smoke-test
@@ -67,6 +68,7 @@ jobs:
               deploy/alloy/config.alloy \
               deploy/searxng/settings.yml \
               deploy/vexa/profiles.yaml \
+              deploy/librechat/klai-entrypoint.sh \
               deploy/grafana/provisioning \
               deploy/scripts \
               deploy/systemd \
@@ -204,6 +206,12 @@ jobs:
             sync_and_recreate alloy       deploy/alloy/config.alloy     /opt/klai/alloy/config.alloy
             sync_and_recreate searxng     deploy/searxng/settings.yml   /opt/klai/searxng/settings.yml
             sync_and_recreate runtime-api deploy/vexa/profiles.yaml     /opt/klai/vexa/profiles.yaml
+            # Force-light-theme wrapper for the compose-managed getklai tenant.
+            # Copies the script to the host THEN force-recreates the container,
+            # so the bind-mount source exists before (re)create — no empty-dir
+            # race. Per-tenant (provisioning-managed) containers pick it up on
+            # their next recreate via _start_librechat_container.
+            sync_and_recreate librechat-getklai deploy/librechat/klai-entrypoint.sh /opt/klai/librechat/klai-entrypoint.sh
 
             # SPEC-SEC-024 M4.3 — sync smoke-test script. `chmod +x` because
             # git clone on a Linux runner usually preserves the execute bit,

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -287,6 +287,15 @@ services:
     image: ghcr.io/danny-avila/librechat:v0.8.5-rc1
     container_name: librechat-getklai
     restart: unless-stopped
+    # Force light theme via the Klai entrypoint wrapper (LibreChat has no
+    # server-side theme config — see deploy/librechat/klai-entrypoint.sh).
+    # In Compose, `entrypoint:` CLEARS the image CMD, so `command:` MUST be set
+    # explicitly; the wrapper passes it through ("$@") to docker-entrypoint.sh.
+    # The script is synced to /opt/klai/librechat/klai-entrypoint.sh by
+    # deploy-compose.yml's sync_and_recreate BEFORE this container is
+    # (re)created, so the bind-mount source always exists (no empty-dir race).
+    entrypoint: ["/bin/sh", "/klai-entrypoint.sh"]
+    command: ["npm", "run", "backend"]
     env_file:
       - ./librechat/getklai/.env
     environment:
@@ -295,6 +304,7 @@ services:
     volumes:
       - ./librechat/getklai/librechat.yaml:/app/librechat.yaml:ro
       - ./librechat/getklai/images:/app/client/public/images
+      - ./librechat/klai-entrypoint.sh:/klai-entrypoint.sh:ro
       # Persistent patches - survive image updates until fixed upstream
       - ./librechat/patches/format.cjs:/app/node_modules/@librechat/agents/dist/cjs/messages/format.cjs:ro
       - ./librechat/patches/share.js:/app/api/server/routes/share.js:ro

--- a/deploy/librechat/klai-entrypoint.sh
+++ b/deploy/librechat/klai-entrypoint.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+# Klai LibreChat entrypoint wrapper — force light theme for every tenant.
+#
+# LibreChat has NO server-side config to force a default/locked theme
+# (enhancement danny-avila/LibreChat#5389 is still open as of v0.8.5). The
+# theme lives client-side in localStorage['color-theme'] and the SPA's
+# getInitialTheme() falls back to the OS `prefers-color-scheme` when no value
+# is stored — so OS-dark users (and anyone who once toggled dark) land in
+# dark mode.
+#
+# This wrapper injects a tiny script as the FIRST child of <head> in the
+# built SPA index.html. It runs before LibreChat's own theme-boot <script>
+# and before the React bundle, writing color-theme=light on every page load,
+# so every Klai tenant is always in light mode regardless of OS preference or
+# a previously-stored choice. (Per the explicit "altijd light" request the
+# dark toggle still renders but is effectively reset to light on each load —
+# there is no config to hide it without patching the hashed bundle.)
+#
+# Design constraints (why this exact shape):
+#   * Additive insert — it never rewrites the hashed /assets/index-<hash>.js
+#     reference, so it survives LibreChat image upgrades automatically. A
+#     whole-file bind-mount of index.html would freeze that hash and white-
+#     screen on the next upgrade (see platform/librechat.md).
+#   * Idempotent via the `klai-force-light` marker. `docker restart` keeps the
+#     writable layer (so the marker is already present); `up -d --force-recreate`
+#     resets it to the image and this re-runs once.
+#   * Fail-safe: nothing here may stop LibreChat from booting. If the index.html
+#     path moves in a future version, or node/sed misbehaves, we log and boot
+#     normally (theme just not forced — visible by the absent marker in logs).
+#
+# Wired identically by two deployment paths (keep them in lockstep):
+#   * deploy/docker-compose.yml          — librechat-getklai (compose-managed)
+#   * provisioning/infrastructure.py     — _start_librechat_container (per tenant)
+# Synced to the host (/opt/klai/librechat/klai-entrypoint.sh) by
+# .github/workflows/deploy-compose.yml's sync_and_recreate so the bind-mount
+# source exists BEFORE the container is (re)created (no empty-dir race).
+
+set -e
+
+INDEX=/app/client/dist/index.html
+MARKER=klai-force-light
+
+if [ -f "$INDEX" ]; then
+  if grep -q "$MARKER" "$INDEX" 2>/dev/null; then
+    echo "[klai-entrypoint] light-theme already injected, skipping"
+  else
+    node - "$INDEX" <<'NODE' || echo "[klai-entrypoint] light-theme inject failed (non-fatal), booting anyway"
+const { readFileSync, writeFileSync } = require('fs');
+const target = process.argv[2];
+const html = readFileSync(target, 'utf8');
+const idx = html.indexOf('<head>');
+if (idx === -1) {
+  process.stderr.write('[klai-entrypoint] <head> not found; skipping light-theme force\n');
+  process.exit(0);
+}
+const inject =
+  "<script>/*klai-force-light*/try{localStorage.setItem('color-theme','light');}catch(e){}</script>";
+const out = html.slice(0, idx + '<head>'.length) + inject + html.slice(idx + '<head>'.length);
+writeFileSync(target, out);
+process.stdout.write('[klai-entrypoint] light-theme injected\n');
+NODE
+  fi
+else
+  echo "[klai-entrypoint] $INDEX not found; skipping light-theme force"
+fi
+
+# Hand off to the stock LibreChat boot. The image has no ENTRYPOINT and a
+# CMD of ["npm","run","backend"]; both deployment paths pass that command
+# through explicitly, so "$@" == `npm run backend`. The node base image
+# normally provides docker-entrypoint.sh on PATH — fall back to exec'ing the
+# command directly if it is ever absent, so boot can never be blocked here.
+if command -v docker-entrypoint.sh >/dev/null 2>&1; then
+  exec docker-entrypoint.sh "$@"
+else
+  exec "$@"
+fi

--- a/klai-portal/backend/app/services/provisioning/infrastructure.py
+++ b/klai-portal/backend/app/services/provisioning/infrastructure.py
@@ -441,6 +441,20 @@ def _start_librechat_container(
             raise RuntimeError(f"LibreChat patch file missing: {patch_container_path}")
         volumes[f"{librechat_host_base}/{source_rel_path}"] = {"bind": destination, "mode": "ro"}
 
+    # Klai entrypoint wrapper that forces light theme on every tenant (LibreChat
+    # has no server-side theme config — see deploy/librechat/klai-entrypoint.sh).
+    # Mounted read-only; the container `entrypoint` below runs it before boot.
+    # Fail-loud if missing: a missing bind source would make Docker create an
+    # empty directory at /klai-entrypoint.sh and the container would crash on
+    # start. The file is synced to the host by deploy-compose.yml.
+    entrypoint_container_path = Path(settings.librechat_container_data_path) / "klai-entrypoint.sh"
+    if not entrypoint_container_path.exists():
+        raise RuntimeError(f"LibreChat entrypoint wrapper missing: {entrypoint_container_path}")
+    volumes[f"{librechat_host_base}/klai-entrypoint.sh"] = {
+        "bind": "/klai-entrypoint.sh",
+        "mode": "ro",
+    }
+
     # @MX:ANCHOR provisioning-labels — SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-2.
     # These three labels mark the container as klasse-B (provisioning-managed)
     # so that hooks (.claude/hooks/klai/container-hygiene-preflight.sh) and
@@ -476,6 +490,11 @@ def _start_librechat_container(
         environment=container_environment,
         volumes=volumes,
         network="klai-net",
+        # Force light theme via the Klai entrypoint wrapper. Setting entrypoint
+        # requires passing the original command through explicitly so LibreChat
+        # still boots with `npm run backend`; the wrapper forwards it via "$@".
+        entrypoint=["/bin/sh", "/klai-entrypoint.sh"],
+        command=["npm", "run", "backend"],
     )
 
     # Connect the extra networks while the container is still STOPPED, so the

--- a/klai-portal/backend/tests/services/provisioning/test_infrastructure.py
+++ b/klai-portal/backend/tests/services/provisioning/test_infrastructure.py
@@ -403,6 +403,8 @@ class TestCharacterizeStartLibrechatContainer:
         patch_dir.mkdir(exist_ok=True)
         for name in ("format.cjs", "share.js", "stream.cjs", "search.cjs"):
             (patch_dir / name).write_text("// patch\n")
+        # Klai light-theme entrypoint wrapper — fail-loud mounted, must exist.
+        (tmp_path / "klai-entrypoint.sh").write_text('#!/bin/sh\nexec docker-entrypoint.sh "$@"\n')
 
     def test_starts_container_with_correct_config(self, tmp_path):
         from app.services.provisioning import _start_librechat_container
@@ -498,6 +500,39 @@ class TestCharacterizeStartLibrechatContainer:
         }
         assert volumes["/opt/klai/librechat-data/patches/search.cjs"] == {
             "bind": "/app/node_modules/@librechat/agents/dist/cjs/tools/search/search.cjs",
+            "mode": "ro",
+        }
+
+    def test_forces_light_theme_via_entrypoint_wrapper(self, tmp_path):
+        """Every provisioned tenant must boot through the Klai entrypoint
+        wrapper that forces light theme. `entrypoint` clears the image CMD, so
+        `command` MUST be passed through explicitly, and the wrapper script MUST
+        be mounted read-only at /klai-entrypoint.sh.
+        """
+        from app.services.provisioning import _start_librechat_container
+
+        self._write_lc_files(tmp_path)
+
+        mock_client = MagicMock()
+        with (
+            patch("app.services.provisioning.infrastructure.docker") as mock_docker,
+            patch("app.services.provisioning.infrastructure.settings") as mock_settings,
+        ):
+            mock_settings.librechat_host_data_path = "/opt/klai/librechat-data"
+            mock_settings.librechat_container_data_path = str(tmp_path)
+            mock_settings.librechat_image = "ghcr.io/danny-avila/librechat:v0.8.5-rc1"
+            mock_docker.from_env.return_value = mock_client
+            mock_docker.errors.NotFound = type("NotFound", (Exception,), {})
+            mock_client.containers.get.side_effect = mock_docker.errors.NotFound("not found")
+
+            _start_librechat_container("acme", "/opt/klai/librechat-data/acme/.env")
+
+        call_kwargs = mock_client.containers.create.call_args[1]
+        assert call_kwargs["entrypoint"] == ["/bin/sh", "/klai-entrypoint.sh"]
+        assert call_kwargs["command"] == ["npm", "run", "backend"]
+        volumes = call_kwargs["volumes"]
+        assert volumes["/opt/klai/librechat-data/klai-entrypoint.sh"] == {
+            "bind": "/klai-entrypoint.sh",
             "mode": "ro",
         }
 


### PR DESCRIPTION
## Summary

LibreChat has no server-side theme lock (upstream #5389 still open in v0.8.5). OS-dark users (and anyone who toggled dark once) land in dark mode against the Klai brand.

Fix: bind-mount a tiny entrypoint wrapper that injects a one-line \`<script>\` into the SPA's \`index.html\` to force \`color-theme=light\` on every page load. The wrapper then exec's stock \`docker-entrypoint.sh\` with the original CMD, so LibreChat boots normally.

Wired identically in both deploy paths:
- \`deploy/docker-compose.yml\` (librechat-getklai, compose-managed)
- \`provisioning/infrastructure.py::_start_librechat_container\` (per-tenant, fail-loud if mount source missing)

\`deploy-compose.yml\` syncs the script to \`/opt/klai/librechat/klai-entrypoint.sh\` BEFORE container recreate — no empty-dir race.

## Test plan

- [x] 26/26 in \`test_infrastructure.py\` green (existing + new \`test_forces_light_theme_via_entrypoint_wrapper\`)
- [x] \`ruff check\` + \`ruff format --check\` clean
- [ ] Post-deploy verify: open \`my.getklai.com\` from a Chrome window with OS in dark mode → LibreChat shows light theme. Then check a per-tenant librechat after next provisioning recreate.

## Notes

- The script is additive — never rewrites the hashed bundle reference, so it survives LibreChat image upgrades automatically.
- Idempotent via the \`klai-force-light\` marker; \`docker restart\` keeps the writable layer (marker stays), \`--force-recreate\` resets the layer and the inject runs once.
- The dark/light toggle still renders in the UI but is effectively reset to light on each page load — there is no upstream config to hide it without patching the hashed React bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)