### PR TITLE
fix(ingest): docling parent_chunks gap — chat hallucinated on PDF KBs

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
@@ -74,10 +74,7 @@ def _strip_postgres_nul(value):
     if isinstance(value, list):
         return [_strip_postgres_nul(item) for item in value]
     if isinstance(value, dict):
-        return {
-            _strip_postgres_nul(key): _strip_postgres_nul(item)
-            for key, item in value.items()
-        }
+        return {_strip_postgres_nul(key): _strip_postgres_nul(item) for key, item in value.items()}
     return value
 
 
@@ -333,9 +330,7 @@ async def ingest_document(conn: asyncpg.Connection, req: IngestRequest) -> dict:
     # are stored as BlockNote JSON for editor fidelity; hash the normalized
     # chunking input so deploying converter fixes forces one clean re-index.
     indexable_content = (
-        req.content
-        if req.skip_chunking
-        else normalize_document_for_chunking(req.content)
+        req.content if req.skip_chunking else normalize_document_for_chunking(req.content)
     )
     content_hash = req.content_hash or hashlib.sha256(indexable_content.encode()).hexdigest()
     stored_hash = await pg_store.get_active_content_hash(conn, req.org_id, req.kb_slug, req.path)
@@ -359,6 +354,22 @@ async def ingest_document(conn: asyncpg.Connection, req: IngestRequest) -> dict:
             texts = req.chunks
         else:
             texts = [req.content]
+        # Docling/connector-prechunked uploads: each pre-provided chunk is its
+        # own semantic parent (no further split). Populate parents_serialised
+        # + parent_index_per_child so the insert_parent_chunks block below
+        # ALSO fires for this path. Without this, PDF uploads landed chunks
+        # in Qdrant but NEVER wrote parent_chunks rows, breaking retrieval-
+        # api's child→parent lookup (incident 2026-05-28: chat hallucinated
+        # because relevant docling-chunked PDFs were effectively unfindable).
+        parents_serialised = [
+            {
+                "text": t,
+                "token_count": chunker._approx_token_count(t),
+                "position": i,
+            }
+            for i, t in enumerate(texts)
+        ]
+        parent_index_per_child = list(range(len(texts)))
     else:
         # Use content profile chunk_tokens_max (converted to chars) when it
         # differs from the global default.  1 token ≈ 4 chars.
@@ -496,7 +507,7 @@ async def ingest_document(conn: asyncpg.Connection, req: IngestRequest) -> dict:
     # for the symmetric visibility override.
     chunk_user_id = req.user_id
     if not chunk_user_id and req.kb_slug.startswith("personal-"):
-        derived = req.kb_slug[len("personal-"):]
+        derived = req.kb_slug[len("personal-") :]
         if derived:
             chunk_user_id = derived
 

--- a/klai-knowledge-ingest/scripts/backfill_docling_parent_chunks.py
+++ b/klai-knowledge-ingest/scripts/backfill_docling_parent_chunks.py
@@ -1,0 +1,275 @@
+"""Backfill parent_chunks rows for docling-prechunked artifacts.
+
+Context (incident 2026-05-28):
+
+Before fix/docling-parent-chunks, the ingest.py ``skip_chunking`` branch
+only populated ``texts`` and never set ``parents_serialised`` /
+``parent_index_per_child``, so the ``insert_parent_chunks`` block at the
+bottom of ``ingest_document`` was silently skipped for every
+docling-prechunked PDF upload. Result: Qdrant got the chunks (visible
+via ``upsert_chunks``) but ``knowledge.parent_chunks`` stayed empty for
+the artifact. ``retrieval-api``'s child→parent lookup returned nothing,
+the LLM never saw the relevant context, and chat answers hallucinated.
+
+This script repairs the existing rows so chat starts working immediately
+for every tenant that uploaded docling PDFs since SPEC-KB-FILE-UPLOAD-001
+landed:
+
+1. Find every artifact where ``extra->>'pipeline' = 'docling'`` AND no
+   ``parent_chunks`` rows exist.
+2. Pull the Qdrant child points for the artifact (ordered by
+   ``chunk_index``), extract the ``text`` payload.
+3. INSERT each child as its own parent_chunk row (1:1, matching the
+   in-code fix's semantic: every docling chunk IS its own semantic
+   parent — Docling already chunks at paragraph/section granularity).
+4. UPDATE the Qdrant points so each child's payload carries
+   ``parent_chunk_id`` pointing to the new pg row. Without step 4 the
+   retrieval-api's parent-lookup still fails because the Qdrant payload
+   has no link to the new pg rows.
+
+Idempotent: re-running on an artifact that already has parent_chunks is
+a no-op (the LEFT JOIN skips it).
+
+Run from inside the knowledge-ingest container:
+
+    docker exec klai-core-knowledge-ingest-1 \\
+        python -m knowledge_ingest.scripts.backfill_docling_parent_chunks
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import urllib.request
+
+import asyncpg
+import structlog
+
+from knowledge_ingest.config import settings
+
+logger = structlog.get_logger()
+
+
+_QDRANT_COLLECTION = "klai_knowledge"
+
+
+def _qdrant_scroll(org_id: str, artifact_id: str) -> list[dict]:
+    """Return every Qdrant point for ``artifact_id``, ordered by chunk_index.
+
+    Uses urllib (no extra deps) and the QDRANT_API_KEY env var that the
+    knowledge-ingest container already has. Each point has ``id`` and
+    ``payload`` with at least ``text`` and ``chunk_index``.
+    """
+    api_key = os.environ.get("QDRANT_API_KEY") or ""
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["api-key"] = api_key
+
+    body = {
+        "limit": 500,
+        "filter": {
+            "must": [
+                {"key": "org_id", "match": {"value": org_id}},
+                {"key": "artifact_id", "match": {"value": artifact_id}},
+            ]
+        },
+        "with_payload": True,
+        "with_vector": False,
+    }
+    points: list[dict] = []
+    next_offset: str | None = None
+    while True:
+        if next_offset is not None:
+            body["offset"] = next_offset
+        req = urllib.request.Request(  # noqa: S310
+            f"{settings.qdrant_url}/collections/{_QDRANT_COLLECTION}/points/scroll",
+            data=json.dumps(body).encode(),
+            headers=headers,
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+            data = json.loads(resp.read())
+        result = data.get("result", {})
+        page = result.get("points") or []
+        points.extend(page)
+        next_offset = result.get("next_page_offset")
+        if not next_offset:
+            break
+    points.sort(key=lambda p: int((p.get("payload") or {}).get("chunk_index") or 0))
+    return points
+
+
+def _qdrant_set_parent_chunk_ids(
+    point_id_to_parent_id: dict[str, int],
+) -> None:
+    """Batch-update each Qdrant point's payload with parent_chunk_id.
+
+    Qdrant exposes a per-point ``set_payload`` endpoint; we send one
+    request per point (the bulk endpoint requires identical payloads
+    across points which we don't have here). N≈18 per artifact in the
+    Jantine case so the per-point overhead is fine.
+    """
+    api_key = os.environ.get("QDRANT_API_KEY") or ""
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["api-key"] = api_key
+
+    for point_id, parent_id in point_id_to_parent_id.items():
+        body = {"payload": {"parent_chunk_id": parent_id}, "points": [point_id]}
+        req = urllib.request.Request(  # noqa: S310
+            f"{settings.qdrant_url}/collections/{_QDRANT_COLLECTION}/points/payload",
+            data=json.dumps(body).encode(),
+            headers=headers,
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310
+            resp.read()
+
+
+async def _backfill_one_artifact(
+    conn: asyncpg.Connection,
+    org_id: str,
+    kb_slug: str,
+    artifact_id: str,
+) -> tuple[int, str]:
+    points = _qdrant_scroll(org_id, artifact_id)
+    if not points:
+        return 0, "no_qdrant_points"
+
+    # Build the parents list from Qdrant payload text. Each point is its own
+    # parent (1:1, matching the in-code fix semantic for docling uploads).
+    parents = []
+    point_ids_in_order: list[str] = []
+    for i, point in enumerate(points):
+        text = (point.get("payload") or {}).get("text") or ""
+        if not text:
+            continue
+        parents.append(
+            {
+                "text": text,
+                "token_count": max(
+                    1, len(text) // 4
+                ),  # rough — matches chunker._approx_token_count
+                "position": i,
+            }
+        )
+        point_ids_in_order.append(str(point["id"]))
+
+    if not parents:
+        return 0, "qdrant_points_had_no_text"
+
+    # Set tenant context so RLS lets the inserts through.
+    await conn.execute("SELECT set_config('app.current_org_id', $1, false)", org_id)
+
+    # Idempotency: double-check no parent_chunks already exist for this
+    # artifact (the SQL filter caught this, but a concurrent run might race).
+    existing = await conn.fetchval(
+        "SELECT COUNT(*) FROM knowledge.parent_chunks WHERE artifact_id = $1",
+        artifact_id,
+    )
+    if existing:
+        return 0, "already_has_parent_chunks"
+
+    # Insert and capture ids. asyncpg returns RECORD per row.
+    inserted_ids: list[int] = []
+    async with conn.transaction():
+        for p in parents:
+            row_id = await conn.fetchval(
+                """
+                INSERT INTO knowledge.parent_chunks
+                    (artifact_id, org_id, text, token_count, position)
+                VALUES ($1, $2, $3, $4, $5)
+                RETURNING id
+                """,
+                artifact_id,
+                org_id,
+                p["text"],
+                int(p["token_count"]),
+                int(p["position"]),
+            )
+            inserted_ids.append(int(row_id))
+
+    # Update each Qdrant point's payload with its parent_chunk_id.
+    point_id_to_parent_id = dict(zip(point_ids_in_order, inserted_ids, strict=True))
+    _qdrant_set_parent_chunk_ids(point_id_to_parent_id)
+
+    logger.info(
+        "backfilled_artifact",
+        org_id=org_id,
+        kb_slug=kb_slug,
+        artifact_id=artifact_id,
+        parent_chunks_inserted=len(inserted_ids),
+    )
+    return len(inserted_ids), "ok"
+
+
+async def _list_docling_artifacts_without_parents(
+    conn: asyncpg.Connection,
+) -> list[tuple[str, str, str]]:
+    """Return ``(org_id, kb_slug, artifact_id)`` for every artifact that:
+
+    - was ingested via docling (``extra->>'pipeline' = 'docling'``)
+    - is the current active row (``belief_time_end = sentinel``)
+    - has zero parent_chunks rows
+    """
+    rows = await conn.fetch(
+        """
+        SELECT a.org_id, a.kb_slug, a.id::text AS artifact_id
+        FROM knowledge.artifacts a
+        LEFT JOIN knowledge.parent_chunks pc ON pc.artifact_id = a.id
+        WHERE a.extra::jsonb->>'pipeline' = 'docling'
+          AND a.belief_time_end = '253402300800'
+        GROUP BY a.org_id, a.kb_slug, a.id
+        HAVING COUNT(pc.id) = 0
+        ORDER BY a.org_id, a.kb_slug, a.created_at DESC
+        """
+    )
+    return [(r["org_id"], r["kb_slug"], r["artifact_id"]) for r in rows]
+
+
+async def main() -> int:
+    # Connect as klai superuser to bypass RLS for the cross-org listing,
+    # then set tenant context per-artifact for the actual inserts.
+    dsn = os.environ.get("KLAI_SUPERUSER_DSN") or os.environ.get("DATABASE_URL")
+    if not dsn:
+        print(
+            "Set KLAI_SUPERUSER_DSN to the klai superuser DSN before running.",
+            file=sys.stderr,
+        )
+        return 1
+
+    conn = await asyncpg.connect(dsn)
+    try:
+        targets = await _list_docling_artifacts_without_parents(conn)
+        print(f"Found {len(targets)} docling artifacts missing parent_chunks.")
+
+        total_inserted = 0
+        outcomes: dict[str, int] = {}
+        for org_id, kb_slug, artifact_id in targets:
+            try:
+                inserted, status = await _backfill_one_artifact(conn, org_id, kb_slug, artifact_id)
+            except Exception as exc:
+                logger.exception(
+                    "backfill_artifact_failed",
+                    org_id=org_id,
+                    kb_slug=kb_slug,
+                    artifact_id=artifact_id,
+                )
+                outcomes["error"] = outcomes.get("error", 0) + 1
+                print(f"  FAIL {artifact_id}: {exc}", file=sys.stderr)
+                continue
+            outcomes[status] = outcomes.get(status, 0) + 1
+            total_inserted += inserted
+
+        print(f"Total parent_chunks rows inserted: {total_inserted}")
+        print("Per-status breakdown:")
+        for status, count in sorted(outcomes.items()):
+            print(f"  {status}: {count}")
+        return 0
+    finally:
+        await conn.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/klai-knowledge-ingest/tests/test_ingest_content_hash_dedup.py
+++ b/klai-knowledge-ingest/tests/test_ingest_content_hash_dedup.py
@@ -288,6 +288,11 @@ async def test_content_hash_override_used_for_prechunked_ingest():
         patch("knowledge_ingest.pg_store.create_artifact", mock_create),
         patch("knowledge_ingest.pg_store.update_artifact_extra", new_callable=AsyncMock),
         patch(
+            "knowledge_ingest.pg_store.insert_parent_chunks",
+            new_callable=AsyncMock,
+            return_value=[1, 2],
+        ),
+        patch(
             "knowledge_ingest.embedder.embed",
             new_callable=AsyncMock,
             return_value=[[0.1] * 10, [0.2] * 10],
@@ -327,3 +332,96 @@ async def test_content_hash_override_used_for_prechunked_ingest():
     mock_get_hash.assert_called_once_with(conn, req.org_id, req.kb_slug, req.path)
     assert mock_create.call_args.kwargs["content_hash"] == "source-sha256"
     assert mock_upsert.call_args.kwargs["chunks"] == ["chunk one", "chunk two"]
+
+
+@pytest.mark.asyncio
+async def test_docling_skip_chunking_writes_parent_chunks() -> None:
+    """Regression for 2026-05-28: docling-prechunked uploads (skip_chunking
+    + chunks) MUST insert parent_chunks rows and thread parent_chunk_ids
+    into the Qdrant upsert.
+
+    Before this fix, the skip_chunking branch only set ``texts`` and never
+    populated ``parents_serialised`` / ``parent_index_per_child``, so the
+    insert_parent_chunks block was skipped. PDF uploads landed chunks in
+    Qdrant but parent_chunks stayed empty for the artifact, breaking
+    retrieval-api's child→parent lookup and causing chat to hallucinate
+    from off-topic chunks (Jantine's "Wie is Frank?" incident).
+    """
+    req = _make_request("Preview only")
+    req.content_hash = "docling-sha256"
+    req.skip_chunking = True
+    req.chunks = ["frank-paragraph", "verantwoordelijkheden-paragraph", "third"]
+    conn = _make_mock_conn()
+
+    mock_create = AsyncMock(return_value="artifact-docling-1")
+    # Each parent_chunks INSERT returns its generated id — order-preserved.
+    mock_insert_parents = AsyncMock(return_value=[101, 102, 103])
+
+    with (
+        patch(
+            "knowledge_ingest.pg_store.get_active_content_hash",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch("knowledge_ingest.pg_store.soft_delete_artifact", new_callable=AsyncMock),
+        patch("knowledge_ingest.pg_store.create_artifact", mock_create),
+        patch("knowledge_ingest.pg_store.update_artifact_extra", new_callable=AsyncMock),
+        patch("knowledge_ingest.pg_store.insert_parent_chunks", mock_insert_parents),
+        patch(
+            "knowledge_ingest.embedder.embed",
+            new_callable=AsyncMock,
+            return_value=[[0.1] * 10, [0.2] * 10, [0.3] * 10],
+        ),
+        patch("knowledge_ingest.qdrant_store.upsert_chunks", new_callable=AsyncMock) as mock_upsert,
+        patch(
+            "knowledge_ingest.org_config.is_enrichment_enabled",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "knowledge_ingest.routes.ingest.kb_config.get_kb_visibility",
+            new_callable=AsyncMock,
+            return_value="private",
+        ),
+        patch(
+            "knowledge_ingest.portal_client.fetch_taxonomy_nodes",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "knowledge_ingest.content_labeler.generate_content_label",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch("knowledge_ingest.routes.ingest.settings") as mock_settings,
+    ):
+        mock_settings.graphiti_enabled = False
+        mock_settings.chunk_size = 1500
+        mock_settings.chunk_overlap = 200
+        mock_settings.enrichment_enabled = False
+
+        from knowledge_ingest.routes.ingest import ingest_document
+
+        await ingest_document(conn, req)
+
+    # Contract 1: insert_parent_chunks IS called for docling uploads.
+    # Before this fix, it was silently skipped — that's the bug.
+    mock_insert_parents.assert_awaited_once()
+    insert_kwargs = mock_insert_parents.call_args.kwargs
+    assert insert_kwargs["artifact_id"] == "artifact-docling-1"
+    assert insert_kwargs["org_id"] == "org1"
+    parents_passed = insert_kwargs["parents"]
+    assert len(parents_passed) == 3, "every docling chunk must become its own parent"
+    assert [p["text"] for p in parents_passed] == [
+        "frank-paragraph",
+        "verantwoordelijkheden-paragraph",
+        "third",
+    ]
+    # Each parent gets a sequential position (0-based) so retrieval-api can
+    # reconstruct document order if needed.
+    assert [p["position"] for p in parents_passed] == [0, 1, 2]
+
+    # Contract 2: parent_chunk_ids flows into the Qdrant upsert so chunks
+    # in Qdrant carry a parent_chunk_id field pointing to the new pg rows.
+    upsert_kwargs = mock_upsert.call_args.kwargs
+    assert upsert_kwargs["parent_chunk_ids"] == [101, 102, 103]


### PR DESCRIPTION
## Summary

**Root cause** (incident 2026-05-28): the \`skip_chunking\` branch in \`routes/ingest.py\` only set \`texts\` but never populated \`parents_serialised\` / \`parent_index_per_child\`. The existing \`insert_parent_chunks\` block was silently skipped for every docling-prechunked PDF upload — Qdrant got the chunks but \`knowledge.parent_chunks\` stayed empty.

**Downstream effect:** retrieval-api's child→parent lookup returned nothing → LLM never saw the relevant context → chat answers hallucinated from off-topic chunks.

**Concrete repro:** Jantine asked \"Wie is Frank?\". Frank is in her uploaded \"Verantwoordelijkheden bouwblok.pdf\" (18 Qdrant chunks, 0 parent_chunks). Retrieval missed the doc; the LLM invented a story about Frank by recycling her CV.

**Fix:** in the \`skip_chunking\` branch, treat each pre-provided chunk as its own semantic parent (1:1). Docling already chunks at paragraph/section granularity — no further split needed. With \`parents_serialised\` + \`parent_index_per_child\` populated, the existing insert + qdrant-thread block fires symmetrically with the chunker path. Chunker path is unchanged.

## DB evidence before fix (\`personal-374185638016057361\`):

| Bron | Qdrant chunks | parent_chunks |
|---|---|---|
| AI-Blueprint.pdf | 66 | **0** |
| Verantwoordelijkheden bouwblok (Frank!) | 18 | **0** |
| CV_Jantine_Doornbos.pdf | 9 | **0** |
| jantinedoornbos.nl (non-docling) | 2 | 2 ✓ |

## Test plan

- [x] Regression test \`test_docling_skip_chunking_writes_parent_chunks\` asserts:
  - \`insert_parent_chunks\` IS awaited
  - 1 parent row per docling chunk
  - \`parent_chunk_ids\` threads into the Qdrant upsert
- [x] \`test_content_hash_override_used_for_prechunked_ingest\` updated to mock the new insert (otherwise it failed because conn mock returned None from fetchval)
- [x] All 6 tests in \`test_ingest_content_hash_dedup.py\` green
- [x] \`ruff check\` + \`ruff format --check\` clean
- [ ] **Post-merge:** run \`scripts/backfill_docling_parent_chunks.py\` from inside the knowledge-ingest container to repair existing docling artifacts (Jantine + every other tenant that uploaded PDFs since SPEC-KB-FILE-UPLOAD-001).

## Backfill script

\`scripts/backfill_docling_parent_chunks.py\` — for each artifact with \`extra->>'pipeline' = 'docling'\` AND zero \`parent_chunks\` rows:
1. Scroll Qdrant for all points of the artifact
2. Insert each chunk text as a parent_chunks row (1:1 with code-fix semantic)
3. Update each Qdrant point's payload with \`parent_chunk_id\` pointing to the new pg row

Idempotent. Skips artifacts that already have parent_chunks.

## Follow-up (not in this PR)

The wider \"KB has too many bugs\" theme (Jantine raised today): collapse parent_chunks tier entirely à la superdock single-tier RAG. Tracked in TODO #5 — proposed gefaseerd, requires explicit go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)