### PR TITLE
Prevent personal email domains claiming workspaces

### DIFF
--- a/klai-portal/backend/app/api/admin/platform_manage.py
+++ b/klai-portal/backend/app/api/admin/platform_manage.py
@@ -43,6 +43,7 @@ from app.models.portal import PortalOrg, PortalUser
 from app.services.audit import log_event
 from app.services.auth_links import AuthLinkRoute, build_url_template
 from app.services.default_knowledge_bases import create_default_personal_kb
+from app.services.domain_validation import primary_domain_for_email_domain
 from app.services.mcp_role_notifier import fire_role_change_notification
 from app.services.provisioning import provision_tenant
 from app.services.user_deletion_orchestrator import delete_user_with_state_machine
@@ -807,7 +808,7 @@ async def platform_create_tenant(
         zitadel_org_id=zitadel_org_id,
         name=body.company_name,
         slug=_to_slug(body.company_name, zitadel_org_id),
-        primary_domain=owner_email_domain,
+        primary_domain=primary_domain_for_email_domain(owner_email_domain),
         auto_accept_same_domain=False,
     )
     try:

--- a/klai-portal/backend/app/api/auth.py
+++ b/klai-portal/backend/app/api/auth.py
@@ -63,6 +63,7 @@ from app.models.portal import PortalOrg, PortalUser
 from app.services import audit
 from app.services.auth_links import AuthLinkRoute, build_url_template
 from app.services.bff_session import SessionService
+from app.services.domain_validation import primary_domain_for_email_domain
 from app.services.events import emit_event
 from app.services.pending_session import PendingSessionService
 from app.services.redis_client import get_redis_pool
@@ -1966,11 +1967,12 @@ async def idp_callback(
 
     # Query orgs with matching primary_domain that user is NOT already a member of.
     email_domain = email.rsplit("@", 1)[-1].strip().lower() if "@" in email else ""
+    claimable_domain = primary_domain_for_email_domain(email_domain)
     domain_orgs: list[PortalOrg] = []
-    if email_domain and zitadel_user_id:
+    if claimable_domain and zitadel_user_id:
         member_org_ids = {u.org_id for u in member_users}
         domain_query = select(PortalOrg).where(
-            PortalOrg.primary_domain == email_domain,
+            PortalOrg.primary_domain == claimable_domain,
             PortalOrg.deleted_at.is_(None),
         )
         if member_org_ids:

--- a/klai-portal/backend/app/api/signup.py
+++ b/klai-portal/backend/app/api/signup.py
@@ -36,7 +36,7 @@ from app.core.database import get_db, set_tenant
 from app.models.portal import PortalOrg, PortalUser
 from app.services.auth_links import AuthLinkRoute, build_url_template
 from app.services.bff_session import SessionService
-from app.services.domain_validation import is_free_email_provider
+from app.services.domain_validation import is_free_email_provider, primary_domain_for_email_domain
 from app.services.events import emit_event
 from app.services.provisioning import provision_tenant
 from app.services.request_ip import resolve_caller_ip_subnet
@@ -285,7 +285,7 @@ async def signup(
             zitadel_org_id=zitadel_org_id,
             name=body.company_name,
             slug=_to_slug(body.company_name, zitadel_org_id),
-            primary_domain=_email_domain,
+            primary_domain=primary_domain_for_email_domain(_email_domain),
             auto_accept_same_domain=False,
         )
         db.add(org_row)
@@ -538,7 +538,7 @@ async def signup_social(
             zitadel_org_id=zitadel_org_id,
             name=body.company_name,
             slug=_to_slug(body.company_name, zitadel_org_id),
-            primary_domain=_social_domain,
+            primary_domain=primary_domain_for_email_domain(_social_domain),
             auto_accept_same_domain=False,
         )
         db.add(org_row)

--- a/klai-portal/backend/app/services/domain_validation.py
+++ b/klai-portal/backend/app/services/domain_validation.py
@@ -6,14 +6,75 @@ import re
 # An attacker could register gmail.com and auto-provision into any org.
 FREE_EMAIL_PROVIDERS: frozenset[str] = frozenset(
     {
+        "126.com",
+        "163.com",
+        "aol.com",
+        "bk.ru",
+        "casema.nl",
+        "chello.nl",
+        "duck.com",
+        "email.com",
+        "fastmail.com",
+        "free.fr",
         "gmail.com",
-        "hotmail.com",
-        "outlook.com",
-        "yahoo.com",
-        "live.com",
-        "icloud.com",
-        "proton.me",
         "gmx.com",
+        "gmx.de",
+        "googlemail.com",
+        "hetnet.nl",
+        "home.nl",
+        "hotmail.co.uk",
+        "hotmail.com",
+        "hotmail.nl",
+        "hushmail.com",
+        "icloud.com",
+        "inbox.com",
+        "kpnmail.nl",
+        "laposte.net",
+        "libero.it",
+        "list.ru",
+        "live.com",
+        "live.nl",
+        "mac.com",
+        "mail.com",
+        "mail.ru",
+        "mailbox.org",
+        "mailfence.com",
+        "me.com",
+        "msn.com",
+        "orange.fr",
+        "outlook.com",
+        "outlook.nl",
+        "planet.nl",
+        "pm.me",
+        "posteo.de",
+        "proton.me",
+        "protonmail.ch",
+        "protonmail.com",
+        "qq.com",
+        "quicknet.nl",
+        "rambler.ru",
+        "rediffmail.com",
+        "seznam.cz",
+        "sina.com",
+        "t-online.de",
+        "telfort.nl",
+        "tuta.com",
+        "tutanota.com",
+        "upcmail.nl",
+        "virgilio.it",
+        "wanadoo.fr",
+        "wanadoo.nl",
+        "web.de",
+        "xs4all.nl",
+        "yandex.com",
+        "yandex.ru",
+        "yahoo.com",
+        "yahoo.co.uk",
+        "yahoo.nl",
+        "zeelandnet.nl",
+        "ziggo.nl",
+        "zoho.com",
+        "zohomail.com",
     }
 )
 
@@ -29,6 +90,14 @@ def normalize_domain(domain: str) -> str:
 def is_free_email_provider(domain: str) -> bool:
     """Return True if the domain is a free email provider (C3.3)."""
     return normalize_domain(domain) in FREE_EMAIL_PROVIDERS
+
+
+def primary_domain_for_email_domain(domain: str) -> str:
+    """Return the org-claimable primary domain, or empty for personal mail domains."""
+    normalized = normalize_domain(domain)
+    if is_free_email_provider(normalized):
+        return ""
+    return normalized
 
 
 def is_valid_domain(domain: str) -> bool:

--- a/klai-portal/backend/tests/test_domain_validation.py
+++ b/klai-portal/backend/tests/test_domain_validation.py
@@ -7,6 +7,8 @@ Covers:
 - Domain normalization (lowercase, strip)
 """
 
+import pytest
+
 
 class TestFreeEmailBlocklist:
     """Free email providers must be rejected when adding allowed domains."""
@@ -45,6 +47,50 @@ class TestFreeEmailBlocklist:
         from app.services.domain_validation import is_free_email_provider
 
         assert is_free_email_provider("Gmail.COM") is True
+
+    @pytest.mark.parametrize(
+        "domain",
+        [
+            "googlemail.com",
+            "hotmail.nl",
+            "outlook.nl",
+            "live.nl",
+            "msn.com",
+            "aol.com",
+            "me.com",
+            "mac.com",
+            "protonmail.com",
+            "pm.me",
+            "mail.com",
+            "fastmail.com",
+            "duck.com",
+            "tuta.com",
+            "mailbox.org",
+            "zoho.com",
+            "web.de",
+            "yahoo.nl",
+            "gmx.de",
+            "ziggo.nl",
+            "kpnmail.nl",
+        ],
+    )
+    def test_common_personal_mail_domains_are_blocked(self, domain: str) -> None:
+        from app.services.domain_validation import is_free_email_provider
+
+        assert is_free_email_provider(domain) is True
+
+
+class TestPrimaryDomainForEmailDomain:
+    def test_corporate_domain_is_claimable(self) -> None:
+        from app.services.domain_validation import primary_domain_for_email_domain
+
+        assert primary_domain_for_email_domain("Acme.NL") == "acme.nl"
+
+    @pytest.mark.parametrize("domain", ["gmail.com", "hotmail.nl", "protonmail.com", "me.com"])
+    def test_personal_mail_domain_is_not_claimable(self, domain: str) -> None:
+        from app.services.domain_validation import primary_domain_for_email_domain
+
+        assert primary_domain_for_email_domain(domain) == ""
 
 
 class TestDomainNormalization:

--- a/klai-portal/backend/tests/test_platform_admin_manage.py
+++ b/klai-portal/backend/tests/test_platform_admin_manage.py
@@ -300,6 +300,9 @@ async def test_platform_create_tenant_user_insert_uses_tenant_scoped_session() -
 
     # AC10.1 — user INSERT issued via tenant_scoped_session
     tenant_scoped_mock.assert_called_once_with(new_org_id)
+    added_org = db.add.call_args_list[0].args[0]
+    assert added_org.__class__.__name__ == "PortalOrg"
+    assert added_org.primary_domain == "acme.example"
     tdb_session.add.assert_called_once()
     added_user = tdb_session.add.call_args.args[0]
     assert added_user.__class__.__name__ == "PortalUser"
@@ -317,6 +320,57 @@ async def test_platform_create_tenant_user_insert_uses_tenant_scoped_session() -
 
     assert response.org_id == new_org_id
     assert response.owner_user_id == "owner-user"
+
+
+@pytest.mark.asyncio
+async def test_platform_create_tenant_free_email_owner_does_not_claim_primary_domain() -> None:
+    from app.api.admin.platform_manage import CreateTenantRequest, platform_create_tenant
+
+    db = AsyncMock()
+    db.add = MagicMock()
+    background_tasks = MagicMock()
+    new_org_id = 12347
+
+    async def _fake_commit() -> None:
+        for call in db.add.call_args_list:
+            (obj,) = call.args
+            if obj.__class__.__name__ == "PortalOrg" and getattr(obj, "id", None) is None:
+                obj.id = new_org_id
+
+    db.commit.side_effect = _fake_commit
+    db.flush = AsyncMock(side_effect=_fake_commit)
+
+    tdb_session = AsyncMock()
+    tdb_session.add = MagicMock()
+
+    with (
+        patch("app.api.admin.platform_manage.tenant_scoped_session", return_value=AsyncContext(tdb_session)),
+        patch("app.api.admin.platform_manage.cross_org_session", return_value=AsyncContext(AsyncMock())),
+        patch("app.api.auth.invalidate_tenant_slug_cache"),
+        patch("app.api.admin.platform_manage.provision_tenant", new=AsyncMock()),
+        patch("app.api.admin.platform_manage.log_event", new=AsyncMock()),
+        patch("app.api.admin.platform_manage.zitadel") as mock_zitadel,
+    ):
+        mock_zitadel.create_org = AsyncMock(return_value={"id": "z-org-new"})
+        mock_zitadel.invite_user = AsyncMock(return_value={"userId": "owner-user"})
+        mock_zitadel.grant_user_role = AsyncMock()
+        mock_zitadel.send_invite_code = AsyncMock()
+
+        await platform_create_tenant(
+            body=CreateTenantRequest(
+                company_name="Private Contact",
+                owner_email="owner@gmail.com",
+                owner_first_name="Owner",
+                owner_last_name="User",
+            ),
+            background_tasks=background_tasks,
+            perms=_platform_perms(),
+            db=db,
+        )
+
+    added_org = db.add.call_args_list[0].args[0]
+    assert added_org.__class__.__name__ == "PortalOrg"
+    assert added_org.primary_domain == ""
 
 
 @pytest.mark.asyncio

--- a/klai-portal/backend/tests/test_primary_domain.py
+++ b/klai-portal/backend/tests/test_primary_domain.py
@@ -5,6 +5,7 @@ Covers AC-1, AC-2, C1.1, C1.3, R7/C7.2.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -50,6 +51,7 @@ class TestPrimaryDomainSetAtSignup:
         from app.api.signup import SignupRequest, signup
 
         mock_db = AsyncMock()
+        mock_db.add = MagicMock()
         body = SignupRequest(**_BASE)
         with (
             patch("app.api.signup.check_signup_email_rate_limit", AsyncMock(return_value=True)),
@@ -73,6 +75,7 @@ class TestPrimaryDomainSetAtSignup:
         from app.api.signup import SignupRequest, signup
 
         mock_db = AsyncMock()
+        mock_db.add = MagicMock()
         body = SignupRequest(**_BASE)
         with (
             patch("app.api.signup.check_signup_email_rate_limit", AsyncMock(return_value=True)),
@@ -95,6 +98,7 @@ class TestPrimaryDomainSetAtSignup:
         from app.api.signup import SignupRequest, signup
 
         mock_db = AsyncMock()
+        mock_db.add = MagicMock()
         body = SignupRequest(**{**_BASE, "email": "founder@BEDRIJF.NL"})
         with (
             patch("app.api.signup.check_signup_email_rate_limit", AsyncMock(return_value=True)),
@@ -110,6 +114,33 @@ class TestPrimaryDomainSetAtSignup:
             await signup(body=body, background_tasks=MagicMock(), db=mock_db)
             kw = morg.call_args.kwargs
             assert kw.get("primary_domain") == "bedrijf.nl"
+
+    @pytest.mark.asyncio
+    async def test_invited_free_email_signup_does_not_claim_primary_domain(self) -> None:
+        """Invite bypass can create a workspace, but must not reserve gmail.com."""
+        from app.api.signup import SignupRequest, signup
+
+        mock_db = AsyncMock()
+        mock_db.add = MagicMock()
+        body = SignupRequest(**{**_BASE, "email": "user@gmail.com", "invite_token": "valid-token"})
+        with (
+            patch("app.api.signup.check_signup_email_rate_limit", AsyncMock(return_value=True)),
+            patch(
+                "app.api.signup.verify_invite_token",
+                return_value=SimpleNamespace(email="user@gmail.com", company="Private Contact", exp=1),
+            ),
+            patch("app.api.signup.zitadel") as mz,
+            patch("app.api.signup.provision_tenant"),
+            patch("app.api.signup.emit_event"),
+            patch("app.api.signup.invalidate_tenant_slug_cache"),
+            patch("app.api.signup.set_tenant", AsyncMock()),
+            patch("app.api.signup.PortalOrg") as morg,
+            patch("app.api.signup.PortalUser"),
+        ):
+            _mock_deps(mz, morg)
+            await signup(body=body, background_tasks=MagicMock(), db=mock_db)
+            kw = morg.call_args.kwargs
+            assert kw.get("primary_domain") == ""
 
 
 class TestFreeEmailSignupRejected:

--- a/klai-portal/backend/tests/test_r3_idp_callback.py
+++ b/klai-portal/backend/tests/test_r3_idp_callback.py
@@ -85,6 +85,21 @@ class TestIdpCallbackCase1NoMemberNoDomain:
         assert response.status_code == 302
         assert "/no-account" in response.headers.get("location", "")
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("email", ["user@gmail.com", "user@hotmail.nl", "user@protonmail.com"])
+    async def test_free_email_domain_does_not_match_org_primary_domain(self, email: str) -> None:
+        from app.api.auth import idp_callback
+
+        mr = MagicMock()
+        mr.scalars.return_value.all.return_value = []
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock(return_value=mr)
+        with patch("app.api.auth.zitadel", _zitadel_mocks(email)), patch("app.api.auth.emit_event"):
+            response = await idp_callback(id="intent-1", token="tok-1", auth_request_id="ar-1", db=mock_db)
+        assert response.status_code == 302
+        assert "/no-account" in response.headers.get("location", "")
+        assert mock_db.execute.await_count == 1
+
 
 class TestIdpCallbackCase2SingleMemberNoDomain:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- centralize claimable workspace-domain derivation in `domain_validation`
- prevent personal/free-mail domains from being stored or matched as `PortalOrg.primary_domain`
- cover signup, social signup, platform tenant creation, and IDP domain matching
- expand regression coverage for Gmail, Hotmail/Outlook NL, Proton, and other personal/ISP domains

## Root cause
Email domains were directly stored and later matched as workspace `primary_domain`. When a personal provider domain such as `gmail.com` was present on an org row, later social login could treat that provider domain as a tenant/org reservation.

## Validation
- `uv run pytest tests/test_domain_validation.py tests/test_primary_domain.py tests/test_r3_idp_callback.py tests/test_platform_admin_manage.py tests/test_auth_idp_endpoints.py tests/test_social_signup.py tests/test_r7_free_email_and_mailer.py tests/test_r2_removal.py`
- `uv run ruff check app/services/domain_validation.py app/api/auth.py app/api/signup.py app/api/admin/platform_manage.py tests/test_domain_validation.py tests/test_primary_domain.py tests/test_r3_idp_callback.py tests/test_platform_admin_manage.py`
- `git diff --check`
