### PR TITLE
Clean up unclaimable primary domains

### DIFF
--- a/klai-portal/backend/alembic/versions/a6b7c8d9e0f1_cleanup_unclaimable_primary_domains.py
+++ b/klai-portal/backend/alembic/versions/a6b7c8d9e0f1_cleanup_unclaimable_primary_domains.py
@@ -1,0 +1,109 @@
+"""cleanup unclaimable primary domains
+
+Revision ID: a6b7c8d9e0f1
+Revises: fc5d6e7f8a9b
+Create Date: 2026-05-28
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "a6b7c8d9e0f1"
+down_revision: Union[str, Sequence[str], None] = "fc5d6e7f8a9b"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+UNCLAIMABLE_DOMAINS: tuple[str, ...] = (
+    "126.com",
+    "163.com",
+    "aol.com",
+    "bk.ru",
+    "casema.nl",
+    "chello.nl",
+    "duck.com",
+    "email.com",
+    "fastmail.com",
+    "free.fr",
+    "gmail.com",
+    "gmx.com",
+    "gmx.de",
+    "googlemail.com",
+    "hetnet.nl",
+    "home.nl",
+    "hotmail.co.uk",
+    "hotmail.com",
+    "hotmail.nl",
+    "hushmail.com",
+    "icloud.com",
+    "inbox.com",
+    "kpnmail.nl",
+    "laposte.net",
+    "libero.it",
+    "list.ru",
+    "live.com",
+    "live.nl",
+    "mac.com",
+    "mail.com",
+    "mail.ru",
+    "mailbox.org",
+    "mailfence.com",
+    "me.com",
+    "msn.com",
+    "orange.fr",
+    "outlook.com",
+    "outlook.nl",
+    "planet.nl",
+    "pm.me",
+    "posteo.de",
+    "proton.me",
+    "protonmail.ch",
+    "protonmail.com",
+    "qq.com",
+    "quicknet.nl",
+    "rambler.ru",
+    "rediffmail.com",
+    "seznam.cz",
+    "sina.com",
+    "t-online.de",
+    "telfort.nl",
+    "tuta.com",
+    "tutanota.com",
+    "upcmail.nl",
+    "virgilio.it",
+    "wanadoo.fr",
+    "wanadoo.nl",
+    "web.de",
+    "xs4all.nl",
+    "yandex.com",
+    "yandex.ru",
+    "yahoo.com",
+    "yahoo.co.uk",
+    "yahoo.nl",
+    "zeelandnet.nl",
+    "ziggo.nl",
+    "zoho.com",
+    "zohomail.com",
+)
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            """
+            UPDATE portal_orgs
+            SET primary_domain = '',
+                auto_accept_same_domain = false
+            WHERE lower(primary_domain) IN :domains
+            """
+        ).bindparams(sa.bindparam("domains", value=UNCLAIMABLE_DOMAINS, expanding=True))
+    )
+
+
+def downgrade() -> None:
+    # Destructive cleanup is intentionally not reversible: restoring prior
+    # unclaimable primary_domain values would reintroduce unsafe metadata.
+    pass

--- a/klai-portal/backend/app/api/admin/settings.py
+++ b/klai-portal/backend/app/api/admin/settings.py
@@ -20,6 +20,7 @@ from app.api.dependencies import _load_org_or_500
 from app.core.database import get_db
 from app.core.features import FEATURE_MIN_PROFILE, PLAN_FEATURES
 from app.core.permissions import ProfileRole, UserPermissions, get_caller_at_least
+from app.services.domain_validation import primary_domain_for_email_domain
 
 # Set of user-facing product keys (= keys that appear in derive_user_products
 # output). Used by the deprecated /settings/addons GET facade to return only
@@ -71,6 +72,18 @@ class PlanChangeRequest(BaseModel):
     plan: str
 
 
+def _settings_out(org) -> OrgSettingsOut:
+    primary_domain = primary_domain_for_email_domain(org.primary_domain or "")
+    return OrgSettingsOut(
+        name=org.name,
+        default_language=org.default_language,
+        mfa_policy=org.mfa_policy,
+        auto_accept_same_domain=bool(org.auto_accept_same_domain) if primary_domain else False,
+        primary_domain=primary_domain or None,
+        telemetry_level=org.telemetry_level,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
@@ -82,14 +95,7 @@ async def get_org_settings(
     db: AsyncSession = Depends(get_db),
 ) -> OrgSettingsOut:
     org = await _load_org_or_500(db, perms.org_id)
-    return OrgSettingsOut(
-        name=org.name,
-        default_language=org.default_language,
-        mfa_policy=org.mfa_policy,
-        auto_accept_same_domain=bool(org.auto_accept_same_domain),
-        primary_domain=org.primary_domain or None,
-        telemetry_level=org.telemetry_level,
-    )
+    return _settings_out(org)
 
 
 @router.patch("/settings", response_model=OrgSettingsOut)
@@ -105,17 +111,12 @@ async def update_org_settings(
         org.mfa_policy = body.mfa_policy
     # C5.1: only update when explicitly provided
     if body.auto_accept_same_domain is not None:
-        org.auto_accept_same_domain = body.auto_accept_same_domain
+        org.auto_accept_same_domain = bool(body.auto_accept_same_domain) and bool(
+            primary_domain_for_email_domain(org.primary_domain or "")
+        )
     await db.commit()
     logger.info("Org settings updated: org_id=%d", perms.org_id)
-    return OrgSettingsOut(
-        name=org.name,
-        default_language=org.default_language,
-        mfa_policy=org.mfa_policy,
-        auto_accept_same_domain=bool(org.auto_accept_same_domain),
-        primary_domain=org.primary_domain or None,
-        telemetry_level=org.telemetry_level,
-    )
+    return _settings_out(org)
 
 
 @router.patch("/plan", response_model=MessageResponse)

--- a/klai-portal/backend/tests/test_r5_auto_accept_toggle.py
+++ b/klai-portal/backend/tests/test_r5_auto_accept_toggle.py
@@ -16,14 +16,14 @@ import pytest
 from tests.conftest import make_perms
 
 
-def _make_org(auto_accept: bool = False) -> MagicMock:
+def _make_org(auto_accept: bool = False, primary_domain: str | None = "acme.nl") -> MagicMock:
     org = MagicMock()
     org.id = 1
     org.name = "Acme"
     org.default_language = "nl"
     org.mfa_policy = "optional"
     org.auto_accept_same_domain = auto_accept
-    org.primary_domain = None
+    org.primary_domain = primary_domain
     # SPEC-PRIVACY-QUERY-SHADOW-001 REQ-15: OrgSettingsOut now also
     # carries telemetry_level. Pin to the privacy-friendly default for
     # tests that don't explicitly exercise this field.
@@ -130,3 +130,37 @@ class TestPatchSettingsAutoAccept:
         result = await get_org_settings(perms=perms, db=db)
 
         assert result.auto_accept_same_domain is True
+        assert result.primary_domain == "acme.nl"
+
+    @pytest.mark.asyncio
+    async def test_get_settings_hides_unclaimable_primary_domain(self) -> None:
+        from app.api.admin.settings import get_org_settings
+
+        org = _make_org(auto_accept=True, primary_domain="gmail.com")
+        perms = make_perms(role="admin", org_id=1)
+        db = AsyncMock()
+        db.get = AsyncMock(return_value=org)
+
+        result = await get_org_settings(perms=perms, db=db)
+
+        assert result.primary_domain is None
+        assert result.auto_accept_same_domain is False
+
+    @pytest.mark.asyncio
+    async def test_patch_does_not_enable_auto_accept_for_unclaimable_primary_domain(self) -> None:
+        from app.api.admin.settings import OrgSettingsUpdate, update_org_settings
+
+        org = _make_org(auto_accept=False, primary_domain="gmail.com")
+        perms = make_perms(role="admin", org_id=1)
+        db = AsyncMock()
+        db.get = AsyncMock(return_value=org)
+
+        result = await update_org_settings(
+            body=OrgSettingsUpdate(auto_accept_same_domain=True),
+            perms=perms,
+            db=db,
+        )
+
+        assert org.auto_accept_same_domain is False
+        assert result.auto_accept_same_domain is False
+        assert result.primary_domain is None


### PR DESCRIPTION
## Summary
- hide unclaimable primary domains from admin settings responses
- prevent enabling `auto_accept_same_domain` when the org primary domain is not claimable
- clean existing unclaimable `portal_orgs.primary_domain` values and disable auto-accept for those rows

## Context
Follow-up to PR #727 and issue #728. The emergency fix prevents free/personal domains from matching during login and from being newly written as claimable domains. This closes the remaining admin UX/data polish: existing generic domains should not appear as auto-accept labels, and stored generic primary domains should be cleaned up.

## Validation
- `uv run pytest tests/test_primary_domain.py tests/test_r3_idp_callback.py tests/test_platform_admin_manage.py tests/test_auth_idp_endpoints.py tests/test_social_signup.py tests/test_r7_free_email_and_mailer.py tests/test_r2_removal.py tests/test_r5_auto_accept_toggle.py tests/test_domain_validation.py`
- `uv run ruff check app/api/admin/settings.py tests/test_r5_auto_accept_toggle.py alembic/versions/a6b7c8d9e0f1_cleanup_unclaimable_primary_domains.py`
- `uv run python scripts/validate_alembic.py`
- `git diff --check`
