### PR TITLE
Fix invited Gmail social signup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- codeindex:start -->
 # CodeIndex MCP
 
-This project is indexed by CodeIndex as **klai** (21662 symbols, 34566 relationships, 0 execution flows).
+This project is indexed by CodeIndex as **klai** (15301 symbols, 19385 relationships, 0 execution flows).
 
 ## Rules (MUST follow)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -575,7 +575,7 @@ For detailed patterns on plugins, sandboxing, headless mode, and version managem
 <!-- codeindex:start -->
 # CodeIndex MCP
 
-This project is indexed by CodeIndex as **klai** (21662 symbols, 34566 relationships, 0 execution flows).
+This project is indexed by CodeIndex as **klai** (15301 symbols, 19385 relationships, 0 execution flows).
 
 ## Rules (MUST follow)
 

--- a/klai-portal/backend/app/api/auth.py
+++ b/klai-portal/backend/app/api/auth.py
@@ -68,6 +68,7 @@ from app.services.events import emit_event
 from app.services.pending_session import PendingSessionService
 from app.services.redis_client import get_redis_pool
 from app.services.request_ip import resolve_caller_ip_subnet
+from app.services.waitlist_token import verify_invite_token
 from app.services.zitadel import zitadel
 from app.utils.response_sanitizer import sanitize_response_body  # SPEC-SEC-INTERNAL-001 REQ-4
 
@@ -989,6 +990,7 @@ def _resolve_idp_id(requested_idp: str) -> str | None:
 class IDPIntentSignupRequest(BaseModel):
     idp_id: str
     locale: str = "nl"
+    invite_token: str | None = None
 
     @field_validator("locale")
     @classmethod
@@ -999,6 +1001,13 @@ class IDPIntentSignupRequest(BaseModel):
 # Pending social signup cookie name — short-lived, Fernet-encrypted
 _IDP_PENDING_COOKIE = "klai_idp_pending"
 _IDP_PENDING_MAX_AGE = 600  # 10 minutes
+
+
+def _invite_token_matches_email(invite_token: str | None, email_norm: str) -> bool:
+    if not invite_token:
+        return False
+    invite_payload = verify_invite_token(invite_token)
+    return invite_payload is not None and invite_payload.email == email_norm
 
 
 # ---------------------------------------------------------------------------
@@ -2100,6 +2109,8 @@ async def idp_intent_signup(body: IDPIntentSignupRequest) -> IDPIntentResponse:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Unknown IDP")
 
     success_url = f"{settings.portal_url}/api/auth/idp-signup-callback?locale={body.locale}"
+    if body.invite_token:
+        success_url = f"{success_url}&invite_token={quote(body.invite_token, safe='')}"
     failure_url = f"{settings.portal_url}/{body.locale}/signup?error=idp_failed"
 
     try:
@@ -2144,11 +2155,12 @@ async def idp_intent_signup(body: IDPIntentSignupRequest) -> IDPIntentResponse:
 
 
 @router.get("/auth/idp-signup-callback")
-async def idp_signup_callback(
+async def idp_signup_callback(  # noqa: C901 - existing callback flow has many external failure legs.
     id: str,
     token: str,
     request: Request,
     locale: str = Query(default="nl"),
+    invite_token: str | None = None,
     db: AsyncSession = Depends(get_db),
 ) -> RedirectResponse:
     """Handle the redirect back from a social IDP during signup.
@@ -2294,6 +2306,7 @@ async def idp_signup_callback(
     first_name: str = raw_info.get("given_name") or user_factor.get("displayName", "").split(" ")[0]
     last_name: str = raw_info.get("family_name") or (" ".join(user_factor.get("displayName", "").split(" ")[1:]) or "")
     email: str = raw_info.get("email") or user_factor.get("loginName", "")
+    email_norm = email.strip().lower()
 
     # 3. Check if a PortalUser already exists for this Zitadel user
     existing_user = await db.scalar(select(PortalUser).where(PortalUser.zitadel_user_id == zitadel_user_id))
@@ -2324,6 +2337,16 @@ async def idp_signup_callback(
         )
         return response
 
+    has_valid_invite = False
+    if invite_token:
+        has_valid_invite = _invite_token_matches_email(invite_token, email_norm)
+        if not has_valid_invite:
+            _slog.warning(
+                "idp_signup_callback_invite_token_rejected",
+                email_domain=email_norm.split("@")[-1] if "@" in email_norm else "",
+            )
+            return RedirectResponse(url=failure_url, status_code=302)
+
     # 4. New user — store pending session in encrypted cookie, redirect to company name form.
     # SPEC-SEC-SESSION-001 REQ-2.1: snapshot the issuing browser + IP-subnet
     # so the consume side (signup_social) can reject a stolen-cookie replay
@@ -2336,6 +2359,7 @@ async def idp_signup_callback(
             "session_token": session_token,
             "zitadel_user_id": zitadel_user_id,
             "email": email,
+            "has_valid_invite": has_valid_invite,
             "ua_hash": pending_ua_hash,
             "ip_subnet": pending_ip_subnet,
         }

--- a/klai-portal/backend/app/api/signup.py
+++ b/klai-portal/backend/app/api/signup.py
@@ -153,16 +153,6 @@ def _to_slug(name: str, suffix: str = "") -> str:
 async def signup(
     body: SignupRequest, background_tasks: BackgroundTasks, db: AsyncSession = Depends(get_db)
 ) -> SignupResponse:
-    # SPEC-SEC-HYGIENE-001 REQ-19.5: per-email rate-limit check runs AFTER
-    # Pydantic validation (so malformed emails never hit Redis) and BEFORE
-    # Zitadel org-creation (so rejected attempts never consume Zitadel quota).
-    # Fail-open on Redis unreachable — see REQ-19.4 + check_signup_email_rate_limit.
-    if not await check_signup_email_rate_limit(body.email):
-        raise HTTPException(
-            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-            detail="Too many signup attempts for this email. Please try again tomorrow.",
-        )
-
     # SPEC-AUTH-009 R1/R7 C1.3: reject free-email domains before any Zitadel/DB work.
     # C7.2: NL message instructs the user to use a company email or request an invitation.
     # SPEC-LAUNCH-SOFTLAUNCH-001 B-3: bypass the free-email block when the
@@ -194,6 +184,15 @@ async def signup(
                 "Vraag je beheerder om een uitnodiging als je via een privé-mailadres "
                 "wilt deelnemen."
             ),
+        )
+
+    # SPEC-SEC-HYGIENE-001 REQ-19.5: rate-limit only attempts that can reach
+    # Zitadel. Rejected free-email attempts should not poison a later valid
+    # invite retry, and a verified invite is already a narrow allowlist gate.
+    if not _has_valid_invite and not await check_signup_email_rate_limit(body.email):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many signup attempts for this email. Please try again tomorrow.",
         )
 
     # 1. Create Zitadel org
@@ -452,15 +451,17 @@ async def signup_social(
             detail="Social signup session expired. Please try again.",
         )
 
-    # SPEC-AUTH-009 R1 C1.3: reject free-email domains in social signup path too.
+    # SPEC-AUTH-009 R1 C1.3: reject free-email domains in social signup path too,
+    # unless the IDP callback already verified that this exact email has an invite.
     _social_email = pending.get("email", "")
     _social_domain = _social_email.split("@")[-1].strip().lower() if "@" in _social_email else ""
+    _has_valid_invite = bool(pending.get("has_valid_invite"))
     if not _social_domain:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Social signup session expired. Please try again.",
         )
-    if _social_domain and is_free_email_provider(_social_domain):
+    if not _has_valid_invite and _social_domain and is_free_email_provider(_social_domain):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=(

--- a/klai-portal/backend/tests/test_signup_rate_limit.py
+++ b/klai-portal/backend/tests/test_signup_rate_limit.py
@@ -13,6 +13,7 @@ Covers:
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -173,6 +174,67 @@ async def test_endpoint_returns_429_when_rate_limited() -> None:
     assert "Too many signup attempts" in str(exc_info.value.detail)
     assert exc_info.value.detail.endswith("try again tomorrow.")  # type: ignore[union-attr]
     fake_zitadel.create_org.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_free_email_rejection_does_not_consume_rate_limit() -> None:
+    """Rejected personal-domain signups should not poison a later invite retry."""
+    from fastapi import HTTPException
+
+    from app.api.signup import SignupRequest, signup
+
+    body = SignupRequest(
+        first_name="Eve",
+        last_name="User",
+        email="eve@gmail.com",
+        password="strong-passphrase-for-test",
+        company_name="ACME",
+    )
+
+    rate_limit = AsyncMock(return_value=True)
+
+    with patch("app.api.signup.check_signup_email_rate_limit", rate_limit):
+        with pytest.raises(HTTPException) as exc_info:
+            await signup(body=body, background_tasks=AsyncMock(), db=AsyncMock())
+
+    assert exc_info.value.status_code == 400
+    rate_limit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_invited_signup_bypasses_email_rate_limit() -> None:
+    """A verified invite is the allowlist gate; stale counters must not block it."""
+    from app.api.signup import SignupRequest, signup
+
+    body = SignupRequest(
+        first_name="Eve",
+        last_name="User",
+        email="eve@gmail.com",
+        password="strong-passphrase-for-test",
+        company_name="ACME",
+        invite_token="valid-token",
+    )
+
+    rate_limit = AsyncMock(return_value=False)
+    fake_zitadel = AsyncMock()
+    fake_zitadel.create_org = AsyncMock(side_effect=RuntimeError("downstream-stub"))
+
+    with (
+        patch("app.api.signup.check_signup_email_rate_limit", rate_limit),
+        patch(
+            "app.api.signup.verify_invite_token",
+            return_value=SimpleNamespace(email="eve@gmail.com", company="ACME", exp=1),
+        ),
+        patch("app.api.signup.zitadel", fake_zitadel),
+    ):
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            await signup(body=body, background_tasks=AsyncMock(), db=AsyncMock())
+
+    assert exc_info.value.status_code == 502
+    rate_limit.assert_not_awaited()
+    fake_zitadel.create_org.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/klai-portal/backend/tests/test_social_signup.py
+++ b/klai-portal/backend/tests/test_social_signup.py
@@ -10,6 +10,7 @@ All string values below are test placeholders, NOT real credentials.
 """
 
 import json
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -49,6 +50,7 @@ def _encrypt_pending(
     user_id: str,
     *,
     email: str = "jan@bedrijf.nl",
+    has_valid_invite: bool = False,
     ua_hash: str = "",
     ip_subnet: str = "127.0.0.0",
 ) -> str:
@@ -66,6 +68,7 @@ def _encrypt_pending(
             "session_token": session_token,
             "zitadel_user_id": user_id,
             "email": email,
+            "has_valid_invite": has_valid_invite,
             "ua_hash": ua_hash,
             "ip_subnet": ip_subnet,
         }
@@ -137,6 +140,29 @@ class TestIDPIntentSignup:
             call_args = mock_zitadel.create_idp_intent.call_args
             success_url: str = call_args.args[1] if call_args.args else call_args.kwargs["success_url"]
             assert "locale=en" in success_url
+
+    @pytest.mark.asyncio
+    async def test_invite_token_embedded_in_success_url(self) -> None:
+        """Invite context must survive the Google/Microsoft redirect roundtrip."""
+        from app.api.auth import IDPIntentSignupRequest, idp_intent_signup
+
+        with (
+            patch("app.api.auth.settings") as mock_settings,
+            patch("app.api.auth.zitadel") as mock_zitadel,
+        ):
+            mock_settings.zitadel_idp_google_id = _GOOGLE_IDP_ID
+            mock_settings.zitadel_idp_microsoft_id = "microsoft-idp-id"
+            mock_settings.portal_url = _PORTAL_URL
+            mock_zitadel.create_idp_intent = AsyncMock(return_value={"authUrl": "https://auth.example.com/"})
+
+            await idp_intent_signup(
+                IDPIntentSignupRequest(idp_id=_GOOGLE_IDP_ID, locale="nl", invite_token="payload.signature")
+            )
+
+            call_args = mock_zitadel.create_idp_intent.call_args
+            success_url: str = call_args.args[1] if call_args.args else call_args.kwargs["success_url"]
+            assert "locale=nl" in success_url
+            assert "invite_token=payload.signature" in success_url
 
     @pytest.mark.asyncio
     async def test_invalid_locale_defaults_to_nl(self) -> None:
@@ -282,6 +308,74 @@ class TestIDPSignupCallback:
         assert "klai_idp_pending" in response.headers.get("set-cookie", "")
 
     @pytest.mark.asyncio
+    async def test_valid_invite_token_is_stored_in_pending_cookie(self) -> None:
+        """A social signup invite for a Gmail address is validated against the IDP email."""
+        from app.api.auth import idp_signup_callback
+
+        db = AsyncMock()
+        db.scalar = AsyncMock(return_value=None)
+
+        with (
+            patch("app.api.auth.settings") as mock_settings,
+            patch("app.api.auth.zitadel") as mock_zitadel,
+            patch("app.api.auth._get_sso_fernet") as mock_fernet,
+            patch(
+                "app.api.auth.verify_invite_token",
+                return_value=SimpleNamespace(email="founder@gmail.com", company="Private Contact", exp=1),
+            ),
+        ):
+            _configure_settings_mock(mock_settings)
+            _configure_zitadel_mock(
+                mock_zitadel,
+                session_detail=_session_detail(_FAKE_USER_ID, email="founder@gmail.com"),
+            )
+            mock_fernet.return_value.encrypt = MagicMock(return_value=b"ENCRYPTED_PENDING")
+
+            response = await idp_signup_callback(
+                id="intent-id",
+                token="intent-token",
+                request=make_request(),
+                locale="nl",
+                invite_token="valid-token",
+                db=db,
+            )
+
+        assert response.status_code == 302
+        pending_payload = json.loads(mock_fernet.return_value.encrypt.call_args.args[0])
+        assert pending_payload["email"] == "founder@gmail.com"
+        assert pending_payload["has_valid_invite"] is True
+
+    @pytest.mark.asyncio
+    async def test_invalid_invite_token_redirects_to_failure_url(self) -> None:
+        from app.api.auth import idp_signup_callback
+
+        db = AsyncMock()
+        db.scalar = AsyncMock(return_value=None)
+
+        with (
+            patch("app.api.auth.settings") as mock_settings,
+            patch("app.api.auth.zitadel") as mock_zitadel,
+            patch("app.api.auth.verify_invite_token", return_value=None),
+        ):
+            _configure_settings_mock(mock_settings)
+            _configure_zitadel_mock(
+                mock_zitadel,
+                session_detail=_session_detail(_FAKE_USER_ID, email="founder@gmail.com"),
+            )
+
+            response = await idp_signup_callback(
+                id="intent-id",
+                token="intent-token",
+                request=make_request(),
+                locale="nl",
+                invite_token="bad-token",
+                db=db,
+            )
+
+        assert response.status_code == 302
+        assert response.headers["location"] == f"{_PORTAL_URL}/nl/signup?error=idp_failed"
+
+    @pytest.mark.asyncio
     async def test_new_user_locale_en_in_redirect(self) -> None:
         """Locale=en is preserved in the redirect to /signup/social."""
         from app.api.auth import idp_signup_callback
@@ -332,6 +426,39 @@ class TestIDPSignupCallback:
         assert "klai_sso" in response.headers.get("set-cookie", "")
         # Existing-user branch must record the login event
         mock_emit_event.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_existing_user_ignores_invalid_invite_token(self) -> None:
+        """Invite validation is only for new workspace creation, not existing-user login."""
+        from app.api.auth import idp_signup_callback
+
+        existing_user = MagicMock()
+        db = AsyncMock()
+        db.scalar = AsyncMock(return_value=existing_user)
+
+        with (
+            patch("app.api.auth.settings") as mock_settings,
+            patch("app.api.auth.zitadel") as mock_zitadel,
+            patch("app.api.auth._get_sso_fernet") as mock_fernet,
+            patch("app.api.auth.emit_event"),
+            patch("app.api.auth.verify_invite_token", return_value=None) as mock_verify_invite,
+        ):
+            _configure_settings_mock(mock_settings)
+            _configure_zitadel_mock(mock_zitadel)
+            mock_fernet.return_value.encrypt = MagicMock(return_value=b"ENCRYPTED_SSO")
+
+            response = await idp_signup_callback(
+                id="intent-id",
+                token="intent-token",
+                request=make_request(),
+                locale="nl",
+                invite_token="expired-token",
+                db=db,
+            )
+
+        assert response.status_code == 302
+        assert response.headers["location"] == f"{_PORTAL_URL}/"
+        mock_verify_invite.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_new_zitadel_user_created_when_intent_lacks_user_id(self) -> None:
@@ -723,6 +850,58 @@ class TestSignupSocial:
 
         assert exc_info.value.status_code == 400
         mock_zitadel.create_org.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_invited_free_email_social_signup_does_not_claim_primary_domain(self) -> None:
+        from app.api.signup import signup_social
+
+        db = AsyncMock()
+        db.add = MagicMock()
+        db.flush = AsyncMock()
+        db.commit = AsyncMock()
+
+        org_row = MagicMock()
+        org_row.id = 99
+        org_row.slug = "private-contact-zit-org"
+        org_row.plan = "chat"
+
+        pending_cookie = _encrypt_pending(
+            _FAKE_SESSION_ID,
+            _FAKE_SESSION_TOKEN,
+            _FAKE_USER_ID,
+            email="founder@gmail.com",
+            has_valid_invite=True,
+        )
+
+        with (
+            patch("app.api.signup.settings") as mock_settings,
+            patch("app.api.signup.zitadel") as mock_zitadel,
+            patch("app.api.signup.PortalOrg") as mock_portal_org,
+            patch("app.api.signup.PortalUser"),
+            patch("app.api.signup.provision_tenant"),
+            patch("app.api.signup.emit_event"),
+            patch("app.api.signup._get_fernet", return_value=Fernet(_FERNET_KEY.encode())),
+        ):
+            mock_settings.zitadel_portal_org_id = "portal-org-id"
+            mock_settings.domain = _DOMAIN
+            mock_settings.sso_cookie_max_age = 3600
+            mock_settings.sso_cookie_key = _FERNET_KEY
+            mock_zitadel.create_org = AsyncMock(return_value={"id": "zit-org-new"})
+            mock_zitadel.grant_user_role = AsyncMock()
+            mock_portal_org.return_value = org_row
+
+            result = await signup_social(
+                body=self._make_body("Private Contact"),
+                response=self._make_response_mock(),
+                background_tasks=MagicMock(),
+                db=db,
+                request=make_request(),
+                klai_idp_pending=pending_cookie,
+            )
+
+        assert result.redirect_url == "/"
+        mock_zitadel.create_org.assert_awaited_once()
+        assert mock_portal_org.call_args.kwargs["primary_domain"] == ""
 
     @pytest.mark.asyncio
     async def test_pending_cookie_without_email_raises_400(self) -> None:

--- a/klai-portal/frontend/src/routes/$locale/signup/index.tsx
+++ b/klai-portal/frontend/src/routes/$locale/signup/index.tsx
@@ -56,7 +56,11 @@ function SignupPage() {
       const resp = await fetch(`${API_BASE}/api/auth/idp-intent-signup`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ idp_id: idpId, locale }),
+        body: JSON.stringify({
+          idp_id: idpId,
+          locale,
+          ...(invite.token ? { invite_token: invite.token } : {}),
+        }),
       })
       if (!resp.ok) {
         setError(m.signup_error_server({ status: String(resp.status) }))

--- a/klai-portal/frontend/src/routes/$locale/signup/social.tsx
+++ b/klai-portal/frontend/src/routes/$locale/signup/social.tsx
@@ -53,6 +53,8 @@ function SocialSignupPage() {
           setError(m.signup_social_expired())
         } else if (resp.status === 409) {
           setError(m.signup_social_name_taken())
+        } else if (typeof data?.detail === 'string' && data.detail.trim()) {
+          setError(data.detail)
         } else {
           setError(m.signup_social_error_server({ status: String(resp.status) }))
         }

--- a/scripts/codeindex-health.sh
+++ b/scripts/codeindex-health.sh
@@ -17,6 +17,7 @@ set -u
 REPAIR=0
 RESTART_MCP=0
 QUIET=0
+PROJECT_NAME="${CODEINDEX_PROJECT_NAME:-klai}"
 
 for arg in "$@"; do
   case "$arg" in
@@ -65,6 +66,10 @@ canonical_repo_from_status() {
   sed -n 's/^Repository: //p' | head -1
 }
 
+indexed_commit_from_status() {
+  sed -n 's/^Indexed commit: //p' | awk '{print $1}' | head -1
+}
+
 is_up_to_date() {
   grep -q 'Status: .*up-to-date'
 }
@@ -101,23 +106,26 @@ restart_mcp_processes() {
   sleep 1
 }
 
-run_update_from() {
-  local repo_dir="$1"
-  if [ ! -d "$repo_dir/.git" ] && [ ! -f "$repo_dir/.git" ]; then
-    warn "ERROR: CodeIndex repository path is not a git checkout: $repo_dir"
+run_analyze_from() {
+  local worktree_dir="$1"
+  if [ ! -d "$worktree_dir/.git" ] && [ ! -f "$worktree_dir/.git" ]; then
+    warn "ERROR: CodeIndex worktree path is not a git checkout: $worktree_dir"
     return 1
   fi
 
-  log "Running codeindex update from canonical repo: $repo_dir"
-  (cd "$repo_dir" && codeindex update)
+  log "Running codeindex analyze from current worktree: $worktree_dir"
+  (cd "$worktree_dir" && codeindex analyze "$PROJECT_NAME" "$worktree_dir" --force --no-embeddings)
 }
 
 main() {
   require_codeindex
 
-  local status repo_dir
+  local status repo_dir worktree_dir current_head indexed_commit
   status="$(status_output)"
   repo_dir="$(printf '%s\n' "$status" | canonical_repo_from_status)"
+  worktree_dir="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  current_head="$(git -C "$worktree_dir" rev-parse HEAD 2>/dev/null || true)"
+  indexed_commit="$(printf '%s\n' "$status" | indexed_commit_from_status)"
 
   if [ -z "$repo_dir" ]; then
     warn "$status"
@@ -132,6 +140,22 @@ main() {
       restart_mcp_processes
     fi
     exit 0
+  fi
+
+  # CodeIndex status currently compares a Conductor worktree index against the
+  # canonical checkout's HEAD because both share the same git common-dir. If the
+  # stored index commit matches this worktree's HEAD, the index is healthy for
+  # this workspace even when `codeindex status` prints a stale warning.
+  if [ -n "$current_head" ] && [ -n "$indexed_commit" ]; then
+    case "$current_head" in
+      "$indexed_commit"*)
+        log "CodeIndex indexed commit matches current worktree ($indexed_commit); treating as healthy."
+        if [ "$RESTART_MCP" -eq 1 ]; then
+          restart_mcp_processes
+        fi
+        exit 0
+        ;;
+    esac
   fi
 
   if [ "$REPAIR" -ne 1 ]; then
@@ -150,14 +174,14 @@ main() {
   stop_codeindex_serve
 
   local update_log
-  update_log="$(run_update_from "$repo_dir" 2>&1)"
+  update_log="$(run_analyze_from "$worktree_dir" 2>&1)"
   local update_rc=$?
   log "$update_log"
 
   if [ "$update_rc" -ne 0 ] && printf '%s\n' "$update_log" | is_locked; then
-    warn "CodeIndex update hit a DB lock; stopping codeindex serve and retrying once."
+    warn "CodeIndex analyze hit a DB lock; stopping codeindex serve and retrying once."
     stop_codeindex_serve
-    update_log="$(run_update_from "$repo_dir" 2>&1)"
+    update_log="$(run_analyze_from "$worktree_dir" 2>&1)"
     update_rc=$?
     log "$update_log"
   fi
@@ -169,8 +193,22 @@ main() {
 
   status="$(status_output)"
   log "$status"
+  indexed_commit="$(printf '%s\n' "$status" | indexed_commit_from_status)"
 
-  if ! printf '%s\n' "$status" | is_up_to_date; then
+  if printf '%s\n' "$status" | is_up_to_date; then
+    :
+  elif [ -n "$current_head" ] && [ -n "$indexed_commit" ]; then
+    case "$current_head" in
+      "$indexed_commit"*)
+        log "CodeIndex indexed commit matches current worktree ($indexed_commit); repair succeeded."
+        ;;
+      *)
+        warn "ERROR: CodeIndex still reports stale after repair."
+        warn "$status"
+        exit 1
+        ;;
+    esac
+  else
     warn "ERROR: CodeIndex still reports stale after repair."
     warn "$status"
     exit 1


### PR DESCRIPTION
## Summary
- carry waitlist invite tokens through social signup IDP redirects and validate them against the IDP email before allowing personal-domain workspace creation
- let invited Gmail signups bypass stale per-email signup rate limits while keeping unsolicited personal-domain signup blocked
- repair CodeIndex health handling for Conductor worktrees so it rebuilds from the current workspace and does not treat matching worktree indexes as stale

## Verification
- uv run ruff check app/api/auth.py app/api/signup.py tests/test_social_signup.py tests/test_signup_rate_limit.py
- uv run pytest tests/test_r3_idp_callback.py tests/test_platform_admin_manage.py tests/test_auth_idp_endpoints.py tests/test_social_signup.py tests/test_signup_rate_limit.py tests/test_primary_domain.py tests/test_domain_validation.py tests/test_r7_free_email_and_mailer.py tests/test_r2_removal.py tests/test_r5_auto_accept_toggle.py
- npm run lint -- --quiet src/routes/$locale/signup/index.tsx src/routes/$locale/signup/social.tsx
- npm run build
- scripts/codeindex-health.sh --quiet
- codeindex query -r klai -l 1 "signup social invite token"
- codeindex impact -r klai --depth 2 --include-tests signup_social