### PR TITLE
[codex] Fix social signup workspace entitlements

### DIFF
--- a/klai-portal/backend/app/api/admin/platform_manage.py
+++ b/klai-portal/backend/app/api/admin/platform_manage.py
@@ -808,6 +808,7 @@ async def platform_create_tenant(
         zitadel_org_id=zitadel_org_id,
         name=body.company_name,
         slug=_to_slug(body.company_name, zitadel_org_id),
+        plan="knowledge",
         primary_domain=primary_domain_for_email_domain(owner_email_domain),
         auto_accept_same_domain=False,
     )

--- a/klai-portal/backend/app/api/signup.py
+++ b/klai-portal/backend/app/api/signup.py
@@ -33,6 +33,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.api.auth import invalidate_tenant_slug_cache
 from app.core.config import settings
 from app.core.database import get_db, set_tenant
+from app.core.seats import suggest_seat
 from app.models.portal import PortalOrg, PortalUser
 from app.services.auth_links import AuthLinkRoute, build_url_template
 from app.services.bff_session import SessionService
@@ -284,6 +285,7 @@ async def signup(
             zitadel_org_id=zitadel_org_id,
             name=body.company_name,
             slug=_to_slug(body.company_name, zitadel_org_id),
+            plan="knowledge",
             primary_domain=primary_domain_for_email_domain(_email_domain),
             auto_accept_same_domain=False,
         )
@@ -297,6 +299,7 @@ async def signup(
             zitadel_user_id=zitadel_user_id,
             org_id=org_row.id,
             role="admin",  # org creator is always admin
+            seat_type=str(suggest_seat("admin")),
             preferred_language=body.preferred_language,
         )
         db.add(user_row)
@@ -451,24 +454,16 @@ async def signup_social(
             detail="Social signup session expired. Please try again.",
         )
 
-    # SPEC-AUTH-009 R1 C1.3: reject free-email domains in social signup path too,
-    # unless the IDP callback already verified that this exact email has an invite.
+    # Social signup gets a verified email from the IDP. Free-email providers are
+    # allowed to create a workspace, but primary_domain_for_email_domain() below
+    # returns "" so gmail.com/hotmail/etc. can never be claimed for domain-match
+    # or auto-join.
     _social_email = pending.get("email", "")
     _social_domain = _social_email.split("@")[-1].strip().lower() if "@" in _social_email else ""
-    _has_valid_invite = bool(pending.get("has_valid_invite"))
     if not _social_domain:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Social signup session expired. Please try again.",
-        )
-    if not _has_valid_invite and _social_domain and is_free_email_provider(_social_domain):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=(
-                "Klai-werkruimtes kun je alleen aanmaken met een zakelijk mailadres. "
-                "Vraag je beheerder om een uitnodiging als je via een privé-mailadres "
-                "wilt deelnemen."
-            ),
         )
 
     # 2. Create Zitadel org
@@ -539,6 +534,7 @@ async def signup_social(
             zitadel_org_id=zitadel_org_id,
             name=body.company_name,
             slug=_to_slug(body.company_name, zitadel_org_id),
+            plan="knowledge",
             primary_domain=primary_domain_for_email_domain(_social_domain),
             auto_accept_same_domain=False,
         )
@@ -552,6 +548,7 @@ async def signup_social(
             zitadel_user_id=zitadel_user_id,
             org_id=org_row.id,
             role="admin",
+            seat_type=str(suggest_seat("admin")),
         )
         db.add(user_row)
         await db.commit()

--- a/klai-portal/backend/tests/test_platform_admin_manage.py
+++ b/klai-portal/backend/tests/test_platform_admin_manage.py
@@ -303,6 +303,7 @@ async def test_platform_create_tenant_user_insert_uses_tenant_scoped_session() -
     added_org = db.add.call_args_list[0].args[0]
     assert added_org.__class__.__name__ == "PortalOrg"
     assert added_org.primary_domain == "acme.example"
+    assert added_org.plan == "knowledge"
     tdb_session.add.assert_called_once()
     added_user = tdb_session.add.call_args.args[0]
     assert added_user.__class__.__name__ == "PortalUser"
@@ -371,6 +372,7 @@ async def test_platform_create_tenant_free_email_owner_does_not_claim_primary_do
     added_org = db.add.call_args_list[0].args[0]
     assert added_org.__class__.__name__ == "PortalOrg"
     assert added_org.primary_domain == ""
+    assert added_org.plan == "knowledge"
 
 
 @pytest.mark.asyncio

--- a/klai-portal/backend/tests/test_primary_domain.py
+++ b/klai-portal/backend/tests/test_primary_domain.py
@@ -61,13 +61,17 @@ class TestPrimaryDomainSetAtSignup:
             patch("app.api.signup.invalidate_tenant_slug_cache"),
             patch("app.api.signup.set_tenant", AsyncMock()),
             patch("app.api.signup.PortalOrg") as morg,
-            patch("app.api.signup.PortalUser"),
+            patch("app.api.signup.PortalUser") as muser,
         ):
             _mock_deps(mz, morg)
             await signup(body=body, background_tasks=MagicMock(), db=mock_db)
             kw = morg.call_args.kwargs
             assert "primary_domain" in kw
             assert kw["primary_domain"] == "bedrijf.nl"
+            assert kw["plan"] == "knowledge"
+            user_kw = muser.call_args.kwargs
+            assert user_kw["role"] == "admin"
+            assert user_kw["seat_type"] == "knowledge"
 
     @pytest.mark.asyncio
     async def test_signup_sets_auto_accept_false(self) -> None:

--- a/klai-portal/backend/tests/test_social_signup.py
+++ b/klai-portal/backend/tests/test_social_signup.py
@@ -724,7 +724,7 @@ class TestSignupSocial:
             patch("app.api.signup.settings") as mock_settings,
             patch("app.api.signup.zitadel") as mock_zitadel,
             patch("app.api.signup.PortalOrg") as mock_portal_org,
-            patch("app.api.signup.PortalUser"),
+            patch("app.api.signup.PortalUser") as mock_portal_user,
             patch("app.api.signup.provision_tenant"),
             patch("app.api.signup.emit_event"),
             patch("app.api.signup._get_fernet", return_value=Fernet(_FERNET_KEY.encode())),
@@ -752,7 +752,10 @@ class TestSignupSocial:
         assert result.redirect_url == "/"
         assert result.org_id == "zit-org-new"
         assert result.user_id == _FAKE_USER_ID
+        assert mock_portal_org.call_args.kwargs["plan"] == "knowledge"
         assert mock_portal_org.call_args.kwargs["primary_domain"] == "bedrijf.nl"
+        assert mock_portal_user.call_args.kwargs["role"] == "admin"
+        assert mock_portal_user.call_args.kwargs["seat_type"] == "knowledge"
         response_mock.set_cookie.assert_called_once()
         response_mock.delete_cookie.assert_called_once_with(
             key="klai_idp_pending",
@@ -816,40 +819,76 @@ class TestSignupSocial:
             user_id=_FAKE_USER_ID,
             role="org:owner",
         )
+        assert mock_portal_org.call_args.kwargs["plan"] == "knowledge"
         assert mock_portal_org.call_args.kwargs["primary_domain"] == "bedrijf.nl"
         assert mock_portal_org.call_args.kwargs["auto_accept_same_domain"] is False
         assert mock_portal_user.call_args.kwargs["zitadel_user_id"] == _FAKE_USER_ID
+        assert mock_portal_user.call_args.kwargs["role"] == "admin"
+        assert mock_portal_user.call_args.kwargs["seat_type"] == "knowledge"
         background_tasks.add_task.assert_called_once_with(mock_provision_tenant, org_row.id)
         mock_emit_event.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_free_email_social_signup_rejected_before_org_creation(self) -> None:
+    @pytest.mark.parametrize(
+        "email",
+        [
+            "founder@gmail.com",
+            "founder@hotmail.nl",
+            "founder@outlook.com",
+            "founder@protonmail.com",
+            "founder@icloud.com",
+        ],
+    )
+    async def test_free_email_social_signup_creates_workspace_without_claiming_domain(self, email: str) -> None:
         from app.api.signup import signup_social
+
+        db = AsyncMock()
+        db.add = MagicMock()
+        db.flush = AsyncMock()
+        db.commit = AsyncMock()
+
+        org_row = MagicMock()
+        org_row.id = 99
+        org_row.slug = "private-contact-zit-org"
+        org_row.plan = "knowledge"
 
         pending_cookie = _encrypt_pending(
             _FAKE_SESSION_ID,
             _FAKE_SESSION_TOKEN,
             _FAKE_USER_ID,
-            email="founder@gmail.com",
+            email=email,
         )
 
         with (
+            patch("app.api.signup.settings") as mock_settings,
             patch("app.api.signup.zitadel") as mock_zitadel,
+            patch("app.api.signup.PortalOrg") as mock_portal_org,
+            patch("app.api.signup.PortalUser"),
+            patch("app.api.signup.provision_tenant"),
+            patch("app.api.signup.emit_event"),
             patch("app.api.signup._get_fernet", return_value=Fernet(_FERNET_KEY.encode())),
         ):
-            mock_zitadel.create_org = AsyncMock()
-            with pytest.raises(HTTPException) as exc_info:
-                await signup_social(
-                    body=self._make_body(),
-                    response=self._make_response_mock(),
-                    background_tasks=MagicMock(),
-                    db=AsyncMock(),
-                    request=make_request(),
-                    klai_idp_pending=pending_cookie,
-                )
+            mock_settings.zitadel_portal_org_id = "portal-org-id"
+            mock_settings.domain = _DOMAIN
+            mock_settings.sso_cookie_max_age = 3600
+            mock_settings.sso_cookie_key = _FERNET_KEY
+            mock_zitadel.create_org = AsyncMock(return_value={"id": "zit-org-new"})
+            mock_zitadel.grant_user_role = AsyncMock()
+            mock_portal_org.return_value = org_row
 
-        assert exc_info.value.status_code == 400
-        mock_zitadel.create_org.assert_not_awaited()
+            result = await signup_social(
+                body=self._make_body("Private Contact"),
+                response=self._make_response_mock(),
+                background_tasks=MagicMock(),
+                db=db,
+                request=make_request(),
+                klai_idp_pending=pending_cookie,
+            )
+
+        assert result.redirect_url == "/"
+        mock_zitadel.create_org.assert_awaited_once()
+        assert mock_portal_org.call_args.kwargs["plan"] == "knowledge"
+        assert mock_portal_org.call_args.kwargs["primary_domain"] == ""
 
     @pytest.mark.asyncio
     async def test_invited_free_email_social_signup_does_not_claim_primary_domain(self) -> None:
@@ -901,6 +940,7 @@ class TestSignupSocial:
 
         assert result.redirect_url == "/"
         mock_zitadel.create_org.assert_awaited_once()
+        assert mock_portal_org.call_args.kwargs["plan"] == "knowledge"
         assert mock_portal_org.call_args.kwargs["primary_domain"] == ""
 
     @pytest.mark.asyncio

--- a/klai-portal/frontend/src/hooks/__tests__/useCurrentUser.test.ts
+++ b/klai-portal/frontend/src/hooks/__tests__/useCurrentUser.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { deriveIsAdmin } from '../useCurrentUser'
+
+describe('deriveIsAdmin', () => {
+  it('treats portal admins as admins even when Zitadel roles are absent', () => {
+    expect(deriveIsAdmin({ portal_role: 'admin', roles: [] })).toBe(true)
+  })
+
+  it('keeps existing Zitadel admin-role detection', () => {
+    expect(deriveIsAdmin({ portal_role: 'personal', roles: ['org:owner'] })).toBe(true)
+  })
+
+  it('does not mark normal users as admins', () => {
+    expect(deriveIsAdmin({ portal_role: 'personal', roles: [] })).toBe(false)
+  })
+})

--- a/klai-portal/frontend/src/hooks/useCurrentUser.ts
+++ b/klai-portal/frontend/src/hooks/useCurrentUser.ts
@@ -33,13 +33,17 @@ export interface CurrentUser extends MeResponse {
   hasCapability: (cap: string) => boolean
 }
 
+export function deriveIsAdmin(me: Pick<MeResponse, 'roles' | 'portal_role'>): boolean {
+  return me.portal_role === 'admin' || (me.roles?.some((r) => ADMIN_ROLES.includes(r)) ?? false)
+}
+
 export function useCurrentUser() {
   const auth = useAuth()
   const query = useQuery({
     queryKey: ['current-user'],
     queryFn: async () => {
       const me = await apiFetch<MeResponse>('/api/me')
-      const isAdmin = me.roles?.some((r) => ADMIN_ROLES.includes(r)) ?? false
+      const isAdmin = deriveIsAdmin(me)
       return {
         ...me,
         // Ensure capabilities is always an array even if older backend omits it

--- a/klai-portal/frontend/src/routes/callback.tsx
+++ b/klai-portal/frontend/src/routes/callback.tsx
@@ -109,7 +109,7 @@ async function resolveDestination(
 
   if (!me.mfa_enrolled) return { kind: 'navigate', url: '/setup/mfa' }
 
-  const isAdmin = me.roles?.some((r) => ADMIN_ROLES.includes(r)) ?? false
+  const isAdmin = me.portal_role === 'admin' || (me.roles?.some((r) => ADMIN_ROLES.includes(r)) ?? false)
   if (isAdmin) {
     const billingStatus = await fetchBillingStatus(signal)
     if (billingStatus === 'pending') return { kind: 'navigate', url: '/admin/billing' }

--- a/klai-portal/frontend/src/routes/join-request.tsx
+++ b/klai-portal/frontend/src/routes/join-request.tsx
@@ -39,7 +39,10 @@ function JoinRequestPage() {
 
   const submitMutation = useMutation({
     mutationFn: async () => {
-      if (!auth.isAuthenticated) throw new Error('Not authenticated')
+      if (!auth.isAuthenticated) {
+        await auth.signinRedirect({ returnTo: '/join-request' })
+        return new Promise<unknown>(() => {})
+      }
       return apiFetch<unknown>('/api/auth/join-request', { method: 'POST' })
     },
     onSuccess: () => {
@@ -122,7 +125,7 @@ function JoinRequestPage() {
 
       <Button
         onClick={() => submitMutation.mutate()}
-        disabled={submitMutation.isPending}
+        disabled={auth.isLoading || submitMutation.isPending}
         size="lg"
         className="w-full"
       >


### PR DESCRIPTION
## What changed

- Allows social signup with generic email domains while storing `primary_domain=''`, so Gmail/Hotmail/Outlook/etc. can create a workspace but can never claim a shared provider domain for auto-join/domain matching.
- Sets new ordinary workspaces to `plan='knowledge'` across public signup, social signup, and platform-admin tenant creation.
- Sets founder/admin `PortalUser.seat_type='knowledge'` explicitly in public signup and social signup.
- Treats `portal_role='admin'` from `/api/me` as authoritative in frontend admin detection and callback routing, instead of depending only on potentially stale Zitadel role claims.
- Redirects unauthenticated join-request submits into login instead of throwing a local `Not authenticated` error.

## Root cause

The registration paths had drifted apart. Platform-admin tenant creation explicitly derived the founder seat from `role=admin`, but public/social signup created an admin user while relying on the DB default for `seat_type`, which is `chat`. Social signup also still blocked generic domains even though the domain-matching logic already treats generic providers as unclaimable via `primary_domain=''`.

For Frits specifically, the live Zitadel identity existed but there was no Portal user/workspace row. I repaired production data by creating and provisioning a workspace for the existing Zitadel user with `role=admin`, `seat_type=knowledge`, `plan=knowledge`, and `primary_domain=''`.

## Validation

- `cd klai-portal/backend && uv run pytest tests/test_social_signup.py tests/test_primary_domain.py tests/test_platform_admin_manage.py tests/test_r3_idp_callback.py` -> 74 passed
- `cd klai-portal/frontend && npm test -- --run src/hooks/__tests__/useCurrentUser.test.ts` -> 3 passed
- `cd klai-portal/frontend && npx tsc -p tsconfig.app.json --noEmit`
- `git diff --check`

## Production repair already done

Frits de Roos (`fritsderoos@gmail.com`) now has a ready workspace in production:

- `org_id=56`
- slug `frits-de-roos-37508461`
- `role=admin`
- `seat_type=knowledge`
- `plan=knowledge`
- `primary_domain=''`
- `provisioning_status=ready`
