### PR TITLE
Feedback: one contextual filter row per view (kill the duplicate page-level filters)

### DIFF
--- a/klai-portal/frontend/src/routes/admin/platform/-components/feedback/FeedbackTab.tsx
+++ b/klai-portal/frontend/src/routes/admin/platform/-components/feedback/FeedbackTab.tsx
@@ -20,19 +20,13 @@ import {
 
 export function FeedbackTab({
   search,
-  status,
-  kind,
   fmtDate,
 }: {
   search: string
-  status: string
-  kind: string
   fmtDate: (s: string | null) => string
 }) {
-  const { data, isLoading } = usePlatformFeedbackSubmissions(search, status, kind)
   const navigate = useNavigate()
   const [feedbackView, setFeedbackView] = useState<'inbox' | 'items'>('inbox')
-  const rows = data ?? []
 
   return (
     <>
@@ -67,38 +61,89 @@ export function FeedbackTab({
           }
         />
       ) : (
-        <PlatformTableShell
-          loading={isLoading}
-          empty={rows.length === 0}
-          emptyText={m.platform_empty_feedback()}
-        >
-          <thead>
-            <tr className="border-b border-gray-200">
-              <th className={TH}>{m.platform_col_type()}</th>
-              <th className={TH}>{m.platform_col_status()}</th>
-              <th className={TH}>{m.platform_col_organization()}</th>
-              <th className={TH}>{m.platform_col_detail()}</th>
-              <th className={TH}>{m.platform_col_time()}</th>
-              <th className={TH}></th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((item) => (
-              <FeedbackSubmissionRow
-                key={item.id}
-                item={item}
-                fmtDate={fmtDate}
-                onOpen={() =>
-                  void navigate({
-                    to: '/admin/platform/feedback/submissions/$submissionId',
-                    params: { submissionId: String(item.id) },
-                  })
-                }
-              />
-            ))}
-          </tbody>
-        </PlatformTableShell>
+        <InboxPanel
+          search={search}
+          fmtDate={fmtDate}
+          onOpen={(submissionId) =>
+            void navigate({
+              to: '/admin/platform/feedback/submissions/$submissionId',
+              params: { submissionId: String(submissionId) },
+            })
+          }
+        />
       )}
+    </>
+  )
+}
+
+function InboxPanel({
+  search,
+  fmtDate,
+  onOpen,
+}: {
+  search: string
+  fmtDate: (s: string | null) => string
+  onOpen: (submissionId: number) => void
+}) {
+  const [statusFilter, setStatusFilter] = useState('')
+  const [kindFilter, setKindFilter] = useState('')
+  const { data, isLoading } = usePlatformFeedbackSubmissions(search, statusFilter, kindFilter)
+  const rows = data ?? []
+
+  return (
+    <>
+      <div className="mb-4 flex flex-wrap items-center gap-2">
+        <Select
+          value={statusFilter}
+          onChange={(event) => setStatusFilter(event.target.value)}
+          className="h-9 min-w-[150px]"
+          aria-label={m.platform_feedback_filter_status()}
+        >
+          <option value="">{m.platform_feedback_filter_all_statuses()}</option>
+          <option value="new">{m.platform_feedback_status_new()}</option>
+          <option value="open">{m.platform_feedback_status_open()}</option>
+          <option value="resolved">{m.platform_feedback_status_resolved()}</option>
+          <option value="support">{m.platform_feedback_status_support()}</option>
+          <option value="dismissed">{m.platform_feedback_status_dismissed()}</option>
+        </Select>
+        <Select
+          value={kindFilter}
+          onChange={(event) => setKindFilter(event.target.value)}
+          className="h-9 min-w-[130px]"
+          aria-label={m.platform_feedback_filter_type()}
+        >
+          <option value="">{m.platform_feedback_filter_all_types()}</option>
+          <option value="feedback">{m.platform_feedback_kind_feedback()}</option>
+          <option value="problem">{m.platform_feedback_kind_problem()}</option>
+          <option value="question">{m.platform_feedback_kind_question()}</option>
+        </Select>
+      </div>
+      <PlatformTableShell
+        loading={isLoading}
+        empty={rows.length === 0}
+        emptyText={m.platform_empty_feedback()}
+      >
+        <thead>
+          <tr className="border-b border-gray-200">
+            <th className={TH}>{m.platform_col_type()}</th>
+            <th className={TH}>{m.platform_col_status()}</th>
+            <th className={TH}>{m.platform_col_organization()}</th>
+            <th className={TH}>{m.platform_col_detail()}</th>
+            <th className={TH}>{m.platform_col_time()}</th>
+            <th className={TH}></th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((item) => (
+            <FeedbackSubmissionRow
+              key={item.id}
+              item={item}
+              fmtDate={fmtDate}
+              onOpen={() => onOpen(item.id)}
+            />
+          ))}
+        </tbody>
+      </PlatformTableShell>
     </>
   )
 }

--- a/klai-portal/frontend/src/routes/admin/platform/index.tsx
+++ b/klai-portal/frontend/src/routes/admin/platform/index.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from 'react'
 import { BookOpen, Check, Copy, Download, Key, Plus, RotateCw, Search, Shield } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { Select } from '@/components/ui/select'
 import { API_BASE } from '@/lib/api'
 import { apiFetch } from '@/lib/apiFetch'
 import { fetchMe } from '@/lib/api-me'
@@ -91,8 +90,6 @@ function PlatformConsole() {
   const navigate = useNavigate()
   const routeSearch = Route.useSearch()
   const [search, setSearch] = useState('')
-  const [feedbackStatus, setFeedbackStatus] = useState('')
-  const [feedbackKind, setFeedbackKind] = useState('')
   const [shieldToken, setShieldToken] = useState<string | null>(null)
   const [shieldCopied, setShieldCopied] = useState(false)
   const auth = useAuth()
@@ -383,32 +380,6 @@ function PlatformConsole() {
             className="pl-9"
           />
         </div>
-        {tab === 'feedback' && (
-          <>
-            <Select
-              value={feedbackStatus}
-              onChange={(event) => setFeedbackStatus(event.target.value)}
-              className="w-44"
-            >
-              <option value="">{m.platform_feedback_filter_all_statuses()}</option>
-              <option value="new">{m.platform_feedback_status_new()}</option>
-              <option value="open">{m.platform_feedback_status_open()}</option>
-              <option value="resolved">{m.platform_feedback_status_resolved()}</option>
-              <option value="support">{m.platform_feedback_status_support()}</option>
-              <option value="dismissed">{m.platform_feedback_status_dismissed()}</option>
-            </Select>
-            <Select
-              value={feedbackKind}
-              onChange={(event) => setFeedbackKind(event.target.value)}
-              className="w-40"
-            >
-              <option value="">{m.platform_feedback_filter_all_types()}</option>
-              <option value="feedback">{m.platform_feedback_kind_feedback()}</option>
-              <option value="problem">{m.platform_feedback_kind_problem()}</option>
-              <option value="question">{m.platform_feedback_kind_question()}</option>
-            </Select>
-          </>
-        )}
         <Button type="button" onClick={refresh} variant="secondary">
           <RotateCw className="h-4 w-4" />
           {m.platform_refresh()}
@@ -426,12 +397,7 @@ function PlatformConsole() {
       )}
       {tab === 'bots' && <BotsTab search={search} fmtDate={fmtDate} />}
       {tab === 'feedback' && (
-        <FeedbackTab
-          search={search}
-          status={feedbackStatus}
-          kind={feedbackKind}
-          fmtDate={fmtDate}
-        />
+        <FeedbackTab search={search} fmtDate={fmtDate} />
       )}
       {tab === 'chat-errors' && <ChatErrorsTab fmtDate={fmtDate} />}
       {tab === 'status' && <StatusTab />}


### PR DESCRIPTION
## Probleem

Op de **Open items**-view stonden twee filterrijen boven elkaar:
- paginaniveau (uit `index.tsx`): status + type — **submission**-taxonomie
- in `OpenItemsPanel`: status + type — **item**-taxonomie

"Alle types" stond dubbel en de bovenste rij deed niets op de items-view, omdat Inbox (submissions) en Open items (items) twee verschillende entiteiten met verschillende status-taxonomieën zijn.

## Oorzaak (architectuur)

Filter-eigenaarschap zat op paginaniveau (`index.tsx`), dat niet weet welke view actief is — de Inbox/Open-items-toggle woont ín `FeedbackTab`. Daardoor groeide de items-view z'n eigen filters erbij en bestonden beide rijen naast elkaar.

## Fix

Elke view bezit z'n eigen filters; precies één contextuele filterrij.

1. **`index.tsx`**: `feedbackStatus`/`feedbackKind`-state + het feedback-select-blok eruit. De paginabalk is weer uniform voor álle tabs (zoeken + refresh). `search` blijft gedeeld (elke tab gebruikt 'm).
2. **`FeedbackTab`**: Inbox getrokken in een eigen `InboxPanel` (symmetrisch met het bestaande `OpenItemsPanel`). Elk panel bezit z'n eigen status/type-filters en rendert één filterrij onder de toggle, met de taxonomie die bij die view past.

`search` blijft behouden bij het togglen (paginaniveau); per-view-filters resetten bij toggle, net als `OpenItemsPanel` al deed.

## Verificatie

- `tsc -p tsconfig.app.json --noEmit` clean
- `eslint` clean op beide bestanden
- `vitest run` → 380/380 pass
- Geen nieuwe i18n-keys (alle hergebruikt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)