### PR TITLE
Feedback: filter selects side by side instead of stacked full-width

### DIFF
--- a/klai-portal/frontend/src/routes/admin/platform/-components/feedback/FeedbackTab.tsx
+++ b/klai-portal/frontend/src/routes/admin/platform/-components/feedback/FeedbackTab.tsx
@@ -96,7 +96,7 @@ function InboxPanel({
         <Select
           value={statusFilter}
           onChange={(event) => setStatusFilter(event.target.value)}
-          className="h-9 min-w-[150px]"
+          className="h-9 w-48"
           aria-label={m.platform_feedback_filter_status()}
         >
           <option value="">{m.platform_feedback_filter_all_statuses()}</option>
@@ -109,7 +109,7 @@ function InboxPanel({
         <Select
           value={kindFilter}
           onChange={(event) => setKindFilter(event.target.value)}
-          className="h-9 min-w-[130px]"
+          className="h-9 w-48"
           aria-label={m.platform_feedback_filter_type()}
         >
           <option value="">{m.platform_feedback_filter_all_types()}</option>
@@ -238,7 +238,7 @@ function OpenItemsPanel({
           <Select
             value={statusFilter}
             onChange={(event) => setStatusFilter(event.target.value)}
-            className="h-9 min-w-[150px]"
+            className="h-9 w-48"
             aria-label={m.platform_feedback_filter_status()}
           >
             <option value="active">{m.platform_feedback_filter_active()}</option>
@@ -250,7 +250,7 @@ function OpenItemsPanel({
           <Select
             value={kindFilter}
             onChange={(event) => setKindFilter(event.target.value)}
-            className="h-9 min-w-[130px]"
+            className="h-9 w-48"
             aria-label={m.platform_feedback_filter_type()}
           >
             <option value="all">{m.platform_feedback_filter_all_types()}</option>


### PR DESCRIPTION
## Probleem

Op de Inbox (en Open items) stonden de twee filter-selects "Alle statussen" en "Alle types" volle breedte **onder elkaar** gestapeld i.p.v. compact naast elkaar.

## Oorzaak

De `Select`-basis is `w-full`. De filters gebruikten `min-w-[150px]` / `min-w-[130px]`, en `min-width` overschrijft `width` niet — dus elke select werd 100% breed en wrapte naar een eigen regel. (De oude paginafilters gebruikten expliciete `w-44`/`w-40`, die `w-full` wél overschreven; vandaar dat die destijds naast elkaar stonden.)

## Fix

Alle vier selects (`InboxPanel` + `OpenItemsPanel`) een expliciete, gelijke breedte (`w-48`) → één nette filterrij met de twee selects naast elkaar. In beide views gefixt zodat ze visueel consistent blijven.

Pure className-wijziging. tsc + eslint clean, 380/380 vitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)