### PR TITLE
Fix connector secret handling

### DIFF
--- a/klai-libs/connector-credentials/connector_credentials/store.py
+++ b/klai-libs/connector-credentials/connector_credentials/store.py
@@ -50,6 +50,8 @@ SENSITIVE_FIELDS: dict[str, list[str]] = {
     "google_drive": ["oauth_token", "refresh_token", "access_token"],
     "ms_docs": ["oauth_token", "refresh_token", "access_token"],
     "web_crawler": ["auth_headers", "cookies"],
+    "confluence": ["api_token"],
+    "airtable": ["api_key"],
 }
 
 

--- a/klai-libs/connector-credentials/tests/test_store.py
+++ b/klai-libs/connector-credentials/tests/test_store.py
@@ -92,6 +92,12 @@ class TestSensitiveFieldsMapping:
     def test_web_crawler_fields(self) -> None:
         assert set(SENSITIVE_FIELDS["web_crawler"]) == {"auth_headers", "cookies"}
 
+    def test_confluence_fields(self) -> None:
+        assert SENSITIVE_FIELDS["confluence"] == ["api_token"]
+
+    def test_airtable_fields(self) -> None:
+        assert SENSITIVE_FIELDS["airtable"] == ["api_key"]
+
     def test_all_connector_types_present(self) -> None:
         assert set(SENSITIVE_FIELDS.keys()) == {
             "github",
@@ -99,6 +105,8 @@ class TestSensitiveFieldsMapping:
             "google_drive",
             "ms_docs",
             "web_crawler",
+            "confluence",
+            "airtable",
         }
 
 
@@ -175,6 +183,60 @@ class TestRoundTrip:
             decrypted = await store.decrypt_credentials(org_id=42, encrypted_credentials=blob, db=db)
             assert decrypted["cookies"] == [{"name": "session", "value": "s-abc"}]
             assert decrypted["auth_headers"] == {"X-Sso": "token-xyz"}
+
+    @pytest.mark.asyncio()
+    async def test_confluence_roundtrip(self) -> None:
+        store = _make_store()
+        db = AsyncMock()
+        config = {
+            "base_url": "https://example.atlassian.net/wiki",
+            "email": "admin@example.com",
+            "api_token": FAKE_TOKEN_A,
+            "space_keys": ["ENG"],
+        }
+        with patch.object(store, "get_or_create_dek", return_value=os.urandom(32)):
+            blob, stripped = await store.encrypt_credentials(
+                org_id=7,
+                connector_type="confluence",
+                config=config,
+                db=db,
+            )
+            assert "api_token" not in stripped
+            assert stripped == {
+                "base_url": "https://example.atlassian.net/wiki",
+                "email": "admin@example.com",
+                "space_keys": ["ENG"],
+            }
+
+            assert blob is not None
+            decrypted = await store.decrypt_credentials(org_id=7, encrypted_credentials=blob, db=db)
+            assert decrypted == {"api_token": FAKE_TOKEN_A}
+
+    @pytest.mark.asyncio()
+    async def test_airtable_roundtrip(self) -> None:
+        store = _make_store()
+        db = AsyncMock()
+        config = {
+            "api_key": FAKE_TOKEN_A,
+            "base_id": "app123456789",
+            "table_names": ["Customers"],
+        }
+        with patch.object(store, "get_or_create_dek", return_value=os.urandom(32)):
+            blob, stripped = await store.encrypt_credentials(
+                org_id=8,
+                connector_type="airtable",
+                config=config,
+                db=db,
+            )
+            assert "api_key" not in stripped
+            assert stripped == {
+                "base_id": "app123456789",
+                "table_names": ["Customers"],
+            }
+
+            assert blob is not None
+            decrypted = await store.decrypt_credentials(org_id=8, encrypted_credentials=blob, db=db)
+            assert decrypted == {"api_key": FAKE_TOKEN_A}
 
     @pytest.mark.asyncio()
     async def test_unknown_connector_type_is_passthrough(self) -> None:

--- a/klai-portal/backend/alembic/versions/sh1e1d2a3b4c_platform_admin_shield.py
+++ b/klai-portal/backend/alembic/versions/sh1e1d2a3b4c_platform_admin_shield.py
@@ -81,12 +81,25 @@ def upgrade() -> None:
 
     op.execute("DROP POLICY IF EXISTS tenant_isolation ON portal_shield_tokens")
     op.execute(
-        f"CREATE POLICY tenant_isolation ON portal_shield_tokens USING (org_id = {_TENANT} OR {_TENANT_IS_NULL})"
+        sa.text(
+            """
+            CREATE POLICY tenant_isolation ON portal_shield_tokens
+            USING (
+                org_id = NULLIF(current_setting('app.current_org_id', true), '')::int
+                OR NULLIF(current_setting('app.current_org_id', true), '') IS NULL
+            )
+            """
+        )
     )
     op.execute("DROP POLICY IF EXISTS tenant_isolation ON portal_shield_logs")
     op.execute(
-        "CREATE POLICY tenant_isolation ON portal_shield_logs "
-        f"USING (org_id = {_TENANT}) WITH CHECK (org_id = {_TENANT})"
+        sa.text(
+            """
+            CREATE POLICY tenant_isolation ON portal_shield_logs
+            USING (org_id = NULLIF(current_setting('app.current_org_id', true), '')::int)
+            WITH CHECK (org_id = NULLIF(current_setting('app.current_org_id', true), '')::int)
+            """
+        )
     )
 
 

--- a/klai-portal/backend/app/api/connectors.py
+++ b/klai-portal/backend/app/api/connectors.py
@@ -207,12 +207,28 @@ class ConfluenceConfig(BaseModel):
         return self
 
 
+class AirtableConfig(BaseModel):
+    """Validated configuration schema for Airtable connectors."""
+
+    api_key: str
+    base_id: str
+    table_names: list[str] = Field(min_length=1)
+    view_name: str | None = None
+
+    @model_validator(mode="after")
+    def _validate_airtable_config(self) -> "AirtableConfig":
+        if not self.base_id.startswith("app"):
+            raise ValueError("base_id must start with 'app'")
+        return self
+
+
 # Connector-type -> pydantic config class. Adding a new entry wires
 # validation (including SSRF) into both create_connector and
 # update_connector without further per-endpoint code.
 _CONFIG_SCHEMA: dict[str, type[BaseModel]] = {
     "web_crawler": WebcrawlerConfig,
     "confluence": ConfluenceConfig,
+    "airtable": AirtableConfig,
 }
 
 
@@ -234,7 +250,7 @@ def _validate_connector_config(connector_type: str, config: dict) -> dict:
         # Surface the original validation message so the UI can
         # display which field was rejected.
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=str(exc),
         ) from exc
     # model_dump keeps the dict-on-disk contract; sensitive fields
@@ -393,18 +409,89 @@ def _compute_needs_reconfiguration(c: PortalConnector) -> bool:
     return c.connector_type == "web_crawler" and c.last_sync_status == "failed"
 
 
+def _sensitive_fields_for(connector_type: str) -> set[str]:
+    return set(SENSITIVE_FIELDS.get(connector_type, []))
+
+
+def _plaintext_sensitive_fields(connector_type: str, config: dict | None) -> list[str]:
+    if not config:
+        return []
+    sensitive_fields = _sensitive_fields_for(connector_type)
+    return sorted(field for field in sensitive_fields if field in config)
+
+
+def _assert_no_plaintext_sensitive_config(
+    *,
+    connector_type: str,
+    config: dict | None,
+    connector_id: str | None = None,
+) -> None:
+    fields = _plaintext_sensitive_fields(connector_type, config)
+    if not fields:
+        return
+    logger.error(
+        "connector_plaintext_sensitive_config_detected",
+        extra={
+            "connector_id": connector_id,
+            "connector_type": connector_type,
+            "fields": fields,
+        },
+    )
+    raise RuntimeError("connector config contains plaintext sensitive fields")
+
+
+def _require_credential_store_for_sensitive_config(connector_type: str, config: dict) -> None:
+    fields = _plaintext_sensitive_fields(connector_type, config)
+    if fields and credential_store is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={"error_code": "credential_store_required_for_sensitive_connector"},
+        )
+
+
+async def _merge_saved_sensitive_credentials(
+    *,
+    connector: PortalConnector,
+    config: dict,
+    org_id: int,
+    db: AsyncSession,
+) -> dict:
+    """Fill omitted secret fields from encrypted storage for edit requests."""
+    sensitive_fields = _sensitive_fields_for(connector.connector_type)
+    missing_fields = sensitive_fields - set(config)
+    if not missing_fields or connector.encrypted_credentials is None:
+        return config
+    if credential_store is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={"error_code": "credential_store_unavailable"},
+        )
+
+    saved_credentials = await credential_store.decrypt_credentials(
+        org_id=org_id,
+        encrypted_credentials=bytes(connector.encrypted_credentials),
+        db=db,
+    )
+    merged = dict(config)
+    for field in missing_fields:
+        if field in saved_credentials:
+            merged[field] = saved_credentials[field]
+    return merged
+
+
 def _connector_out(c: PortalConnector) -> ConnectorOut:
-    # Mask sensitive fields so they never appear in public API responses
-    masked_config = dict(c.config) if c.config else {}
-    for field in SENSITIVE_FIELDS.get(c.connector_type, []):
-        if field in masked_config:
-            masked_config[field] = "***"
+    _assert_no_plaintext_sensitive_config(
+        connector_type=c.connector_type,
+        config=c.config,
+        connector_id=str(c.id),
+    )
+    public_config = dict(c.config) if c.config else {}
     return ConnectorOut(
         id=str(c.id),
         kb_id=c.kb_id,
         name=c.name,
         connector_type=c.connector_type,
-        config=masked_config,
+        config=public_config,
         schedule=c.schedule,
         is_enabled=c.is_enabled,
         last_sync_at=c.last_sync_at,
@@ -508,7 +595,7 @@ async def create_connector(
         invalid = set(body.allowed_assertion_modes) - VALID_ASSERTION_MODES
         if invalid:
             raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                 detail=f"Invalid assertion modes: {sorted(invalid)}. Valid: {sorted(VALID_ASSERTION_MODES)}",
             )
     # SPEC-SEC-SSRF-001 REQ-2 / REQ-8 / AC-7 / AC-19: validate the
@@ -523,6 +610,7 @@ async def create_connector(
     # Encrypt sensitive fields if credential store is configured
     config_to_store = config_for_save
     encrypted_blob = None
+    _require_credential_store_for_sensitive_config(body.connector_type, config_for_save)
     if credential_store is not None:
         encrypted_blob, config_to_store = await credential_store.encrypt_credentials(
             org_id=perms.org_id,
@@ -530,6 +618,10 @@ async def create_connector(
             config=config_for_save,
             db=db,
         )
+    _assert_no_plaintext_sensitive_config(
+        connector_type=body.connector_type,
+        config=config_to_store,
+    )
     connector = PortalConnector(
         kb_id=kb.id,
         org_id=perms.org_id,
@@ -641,12 +733,21 @@ async def update_connector(
     if body.name is not None:
         connector.name = body.name
     if body.config is not None:
+        config_input = body.config
+        if not body.clear_credentials:
+            config_input = await _merge_saved_sensitive_credentials(
+                connector=connector,
+                config=config_input,
+                org_id=perms.org_id,
+                db=db,
+            )
         # SPEC-SEC-SSRF-001 REQ-2.1 / AC-8 / AC-20: SSRF + allowlist
         # validation runs before any downstream fingerprint fetch
         # (which would dispatch an HTTP request to the candidate URL).
-        validated_config = _validate_connector_config(connector.connector_type, body.config)
+        validated_config = _validate_connector_config(connector.connector_type, config_input)
         # SPEC-CRAWL-004: auto-compute canary fingerprint before encryption
         config_for_save = await _auto_fill_canary_fingerprint(validated_config)
+        _require_credential_store_for_sensitive_config(connector.connector_type, config_for_save)
         if credential_store is not None:
             encrypted_blob, stripped_config = await credential_store.encrypt_credentials(
                 org_id=perms.org_id,
@@ -659,6 +760,11 @@ async def update_connector(
                 connector.encrypted_credentials = encrypted_blob
         else:
             connector.config = config_for_save
+        _assert_no_plaintext_sensitive_config(
+            connector_type=connector.connector_type,
+            config=connector.config,
+            connector_id=str(connector.id),
+        )
     if body.clear_credentials:
         connector.encrypted_credentials = None
     if body.schedule is not None:
@@ -671,7 +777,7 @@ async def update_connector(
         invalid = set(body.allowed_assertion_modes) - VALID_ASSERTION_MODES
         if invalid:
             raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                 detail=f"Invalid assertion modes: {sorted(invalid)}. Valid: {sorted(VALID_ASSERTION_MODES)}",
             )
         connector.allowed_assertion_modes = body.allowed_assertion_modes

--- a/klai-portal/backend/app/api/internal.py
+++ b/klai-portal/backend/app/api/internal.py
@@ -46,7 +46,7 @@ from app.models.connectors import PortalConnector
 from app.models.knowledge_bases import PortalKnowledgeBase
 from app.models.portal import PortalOrg, PortalUser
 from app.models.templates import PortalTemplate
-from app.services.connector_credentials import credential_store
+from app.services.connector_credentials import SENSITIVE_FIELDS, credential_store
 from app.services.entitlements import get_effective_products
 from app.services.events import emit_event
 from app.services.gap_rescorer import schedule_rescore
@@ -60,6 +60,57 @@ logger = logging.getLogger(__name__)
 structlog_logger = structlog.get_logger()
 
 router = APIRouter(prefix="/internal", tags=["internal"])
+
+_REQUIRED_ENCRYPTED_CREDENTIAL_FIELDS: dict[str, set[str]] = {
+    "confluence": {"api_token"},
+    "airtable": {"api_key"},
+}
+
+
+def _sensitive_fields_for_connector(connector_type: str) -> set[str]:
+    return set(SENSITIVE_FIELDS.get(connector_type, []))
+
+
+def _plaintext_sensitive_fields(connector: PortalConnector) -> list[str]:
+    config = connector.config or {}
+    return sorted(field for field in _sensitive_fields_for_connector(connector.connector_type) if field in config)
+
+
+def _raise_plaintext_sensitive_config(connector: PortalConnector, fields: list[str]) -> None:
+    logger.error(
+        "connector_plaintext_sensitive_config_detected",
+        extra={
+            "connector_id": str(connector.id),
+            "connector_type": connector.connector_type,
+            "fields": fields,
+        },
+    )
+    raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail={"error_code": "connector_plaintext_secret_detected"},
+    )
+
+
+def _assert_connector_credentials_readable(connector: PortalConnector) -> None:
+    fields = _plaintext_sensitive_fields(connector)
+    if fields:
+        _raise_plaintext_sensitive_config(connector, fields)
+
+    required_fields = _REQUIRED_ENCRYPTED_CREDENTIAL_FIELDS.get(connector.connector_type, set())
+    if required_fields and connector.encrypted_credentials is None:
+        logger.error(
+            "connector_required_encrypted_credentials_missing",
+            extra={
+                "connector_id": str(connector.id),
+                "connector_type": connector.connector_type,
+                "fields": sorted(required_fields),
+            },
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={"error_code": "connector_required_credentials_missing"},
+        )
+
 
 # SPEC-SEC-005 REQ-2.3: hold references to fire-and-forget audit tasks so the
 # event loop cannot GC them mid-flight. Same pattern as partner_dependencies._pending.
@@ -528,12 +579,25 @@ async def get_connector_config(
         )
     connector, kb, org = row
 
-    # Merge decrypted credentials into config for internal consumers
-    # @MX:NOTE: [AUTO] Fallback: encrypted_credentials IS NULL => read plaintext config (legacy).
-    # Remove after cleanup migration.
+    _assert_connector_credentials_readable(connector)
+
+    # Merge decrypted credentials into config for internal consumers.
+    # Public app endpoints never receive this merged shape; it is only sent to
+    # klai-connector over the internal API after the service secret check.
     merged_config = dict(connector.config) if connector.config else {}
-    if connector.encrypted_credentials is not None and credential_store is not None:
-        decrypted = await credential_store.decrypt_credentials(
+    if connector.encrypted_credentials is not None and credential_store is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={"error_code": "credential_store_unavailable"},
+        )
+    if connector.encrypted_credentials is not None:
+        store = credential_store
+        if store is None:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail={"error_code": "credential_store_unavailable"},
+            )
+        decrypted = await store.decrypt_credentials(
             org_id=connector.org_id,
             encrypted_credentials=connector.encrypted_credentials,
             db=db,
@@ -636,8 +700,8 @@ async def update_connector_credentials(
     2. Load connector and set tenant context.
     3. Decrypt current credentials (preserves refresh_token, etc.).
     4. Merge in the new access_token + optional token_expiry.
-    5. Re-encrypt and persist. The plaintext config column is overwritten
-       with the redacted form (sensitive fields masked as "***").
+    5. Re-encrypt and persist. The config column is overwritten with the
+       stripped non-secret config returned by the credential store.
     """
     await _require_internal_token(request)
     connector = await db.get(PortalConnector, connector_id)
@@ -651,7 +715,11 @@ async def update_connector_credentials(
             detail="Credential store not configured",
         )
 
-    # Start from whatever is currently stored (encrypted or legacy plaintext).
+    _assert_connector_credentials_readable(connector)
+
+    # Start from encrypted credentials only. Plaintext config fallback is a
+    # security bug: it keeps leaked secrets alive and hides incomplete
+    # remediation.
     merged: dict = {}
     if connector.encrypted_credentials is not None:
         merged = await credential_store.decrypt_credentials(
@@ -659,8 +727,6 @@ async def update_connector_credentials(
             encrypted_credentials=connector.encrypted_credentials,
             db=db,
         )
-    else:
-        merged = dict(connector.config or {})
 
     # Apply the patch — NEVER log access_token / refresh_token values.
     merged["access_token"] = body.access_token
@@ -671,14 +737,15 @@ async def update_connector_credentials(
     if body.refresh_token is not None:
         merged["refresh_token"] = body.refresh_token
 
-    encrypted_blob, redacted_config = await credential_store.encrypt_credentials(
+    encrypted_blob, stripped_config = await credential_store.encrypt_credentials(
         org_id=connector.org_id,
         connector_type=connector.connector_type,
         config=merged,
         db=db,
     )
     connector.encrypted_credentials = encrypted_blob
-    connector.config = redacted_config
+    connector.config = stripped_config
+    _assert_connector_credentials_readable(connector)
     await db.commit()
     await _audit_internal_call(request, org_id=connector.org_id)
 

--- a/klai-portal/backend/app/api/oauth.py
+++ b/klai-portal/backend/app/api/oauth.py
@@ -612,14 +612,14 @@ async def callback_provider(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Credential store not configured",
         )
-    encrypted_blob, redacted_config = await credential_store.encrypt_credentials(
+    encrypted_blob, stripped_config = await credential_store.encrypt_credentials(
         org_id=connector.org_id,
         connector_type=connector.connector_type,
         config=new_config,
         db=db,
     )
     connector.encrypted_credentials = encrypted_blob
-    connector.config = redacted_config
+    connector.config = stripped_config
     # Clear auth_error so the badge + Reconnect CTA disappear on the next list
     # query. sync_engine will overwrite this again on the next run; clearing
     # here is a best-effort UX improvement so users aren't left staring at a

--- a/klai-portal/backend/app/static/shield-extension/src/sidepanel/sidepanel.js
+++ b/klai-portal/backend/app/static/shield-extension/src/sidepanel/sidepanel.js
@@ -147,30 +147,36 @@ function renderAccount() {
 function renderCollections() {
   const collections = currentSettings.knowledgeBases || currentSettings.config?.knowledge_bases || [];
   const active = currentSettings.activeKnowledgeBases || [];
+  clearChildren(els.collectionList);
   if (!collections.length) {
-    els.collectionList.innerHTML = '<div class="result-panel empty">Geen kennisbanken gevonden in Klai.</div>';
+    els.collectionList.appendChild(emptyPanel("Geen kennisbanken gevonden in Klai."));
     return;
   }
-  els.collectionList.innerHTML = collections
-    .map((kb) => {
-      const slug = kb.slug || kb.id;
-      const on = active.includes(slug);
-      return `
-        <div class="toggle-card ${on ? "on" : ""}">
-          <div class="t-row">
-            <div class="t-icon">
-              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 7v10a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-6l-2-2H5a2 2 0 0 0-2 2z"/></svg>
-            </div>
-            <div class="t-body">
-              <div class="t-label">${escapeHtml(kb.name || slug || "Klai kennisbank")}</div>
-              <div class="t-sub">${escapeHtml(slug || "knowledge")}</div>
-            </div>
-            <label class="sw"><input type="checkbox" data-kb="${escapeAttr(slug)}" ${on ? "checked" : ""}><span class="sl"></span></label>
-          </div>
-        </div>
-      `;
-    })
-    .join("");
+
+  collections.forEach((kb) => {
+    const slug = kb.slug || kb.id || "";
+    const on = active.includes(slug);
+    const card = toggleCard({ on });
+    const row = div("t-row");
+    row.appendChild(icon("folder"));
+
+    const body = div("t-body");
+    body.appendChild(textDiv("t-label", kb.name || slug || "Klai kennisbank"));
+    body.appendChild(textDiv("t-sub", slug || "knowledge"));
+    row.appendChild(body);
+
+    const label = div("sw", "label");
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.dataset.kb = slug;
+    checkbox.checked = on;
+    label.appendChild(checkbox);
+    label.appendChild(div("sl", "span"));
+    row.appendChild(label);
+
+    card.appendChild(row);
+    els.collectionList.appendChild(card);
+  });
 
   els.collectionList.querySelectorAll("input[data-kb]").forEach((checkbox) => {
     checkbox.addEventListener("change", async () => {
@@ -188,26 +194,33 @@ function renderCollections() {
 
 function renderTemplates() {
   const templates = currentSettings.templates || [];
+  clearChildren(els.templateList);
   if (!templates.length) {
-    els.templateList.innerHTML = '<div class="result-panel empty">Klai gebruikt nu automatisch het context-template.</div>';
+    els.templateList.appendChild(emptyPanel("Klai gebruikt nu automatisch het context-template."));
     return;
   }
-  els.templateList.innerHTML = templates
-    .map((template) => `
-      <div class="toggle-card on">
-        <div class="t-row">
-          <div class="t-icon">
-            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/></svg>
-          </div>
-          <div class="t-body">
-            <div class="t-label">${escapeHtml(template.name || "Klai template")}</div>
-            <div class="t-sub">${escapeHtml(template.description || "Actief voor context-injectie")}</div>
-          </div>
-          <label class="sw"><input type="checkbox" checked disabled><span class="sl"></span></label>
-        </div>
-      </div>
-    `)
-    .join("");
+  templates.forEach((template) => {
+    const card = toggleCard({ on: true });
+    const row = div("t-row");
+    row.appendChild(icon("document"));
+
+    const body = div("t-body");
+    body.appendChild(textDiv("t-label", template.name || "Klai template"));
+    body.appendChild(textDiv("t-sub", template.description || "Actief voor context-injectie"));
+    row.appendChild(body);
+
+    const label = div("sw", "label");
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.checked = true;
+    checkbox.disabled = true;
+    label.appendChild(checkbox);
+    label.appendChild(div("sl", "span"));
+    row.appendChild(label);
+
+    card.appendChild(row);
+    els.templateList.appendChild(card);
+  });
 }
 
 function renderCompliance() {
@@ -261,20 +274,22 @@ function renderComplianceResult(result) {
   const warnings = result.warnings || [];
   els.checkSummary.classList.remove("empty");
   els.checkSummary.dataset.status = status;
-  els.checkSummary.innerHTML = `
-    <div class="result-title">
-      <span>${escapeHtml(statusLabel(status))}</span>
-      <span>${Number(result.risk_score || 0)}/100</span>
-    </div>
-    ${
-      warnings.length
-        ? `<ul class="warning-list">${warnings
-            .slice(0, 4)
-            .map((warning) => `<li>${escapeHtml(warning.label || warning.id || "Waarschuwing")}</li>`)
-            .join("")}</ul>`
-        : `<p class="empty">Deze tekst kan door volgens de huidige regels.</p>`
-    }
-  `;
+  clearChildren(els.checkSummary);
+
+  const title = div("result-title");
+  title.appendChild(textDiv("", statusLabel(status), "span"));
+  title.appendChild(textDiv("", `${Number(result.risk_score || 0)}/100`, "span"));
+  els.checkSummary.appendChild(title);
+
+  if (warnings.length) {
+    const list = div("warning-list", "ul");
+    warnings.slice(0, 4).forEach((warning) => {
+      list.appendChild(textDiv("", warning.label || warning.id || "Waarschuwing", "li"));
+    });
+    els.checkSummary.appendChild(list);
+  } else {
+    els.checkSummary.appendChild(textDiv("empty", "Deze tekst kan door volgens de huidige regels.", "p"));
+  }
 }
 
 async function runQuery() {
@@ -296,14 +311,15 @@ function renderChunks(chunks) {
     return;
   }
   els.results.classList.remove("empty");
-  els.results.innerHTML = latestChunks
-    .slice(0, 6)
-    .map((chunk, index) => {
-      const title = chunk.title || chunk.source || chunk.metadata?.title || `Bron ${index + 1}`;
-      const text = (chunk.text || chunk.content || "").trim().slice(0, 260);
-      return `<article class="result"><strong>${escapeHtml(title)}</strong><p>${escapeHtml(text)}</p></article>`;
-    })
-    .join("");
+  clearChildren(els.results);
+  latestChunks.slice(0, 6).forEach((chunk, index) => {
+    const title = chunk.title || chunk.source || chunk.metadata?.title || `Bron ${index + 1}`;
+    const text = (chunk.text || chunk.content || "").trim().slice(0, 260);
+    const article = div("result", "article");
+    article.appendChild(textDiv("", title, "strong"));
+    article.appendChild(textDiv("", text, "p"));
+    els.results.appendChild(article);
+  });
 }
 
 async function insertContext() {
@@ -343,17 +359,48 @@ function bindButton(button, handler) {
   });
 }
 
-function escapeHtml(value) {
-  return String(value ?? "")
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#039;");
+function clearChildren(node) {
+  node.replaceChildren();
 }
 
-function escapeAttr(value) {
-  return escapeHtml(value).replaceAll("`", "&#096;");
+function emptyPanel(text) {
+  return textDiv("result-panel empty", text);
+}
+
+function toggleCard({ on }) {
+  const card = div("toggle-card");
+  card.classList.toggle("on", on);
+  return card;
+}
+
+function div(className, tagName = "div") {
+  const element = document.createElement(tagName);
+  if (className) element.className = className;
+  return element;
+}
+
+function textDiv(className, text, tagName = "div") {
+  const element = div(className, tagName);
+  element.textContent = String(text ?? "");
+  return element;
+}
+
+function icon(kind) {
+  const wrapper = div("t-icon");
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute("viewBox", "0 0 24 24");
+  svg.setAttribute("aria-hidden", "true");
+  const paths =
+    kind === "folder"
+      ? ["M3 7v10a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-6l-2-2H5a2 2 0 0 0-2 2z"]
+      : ["M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z", "M14 2v6h6"];
+  paths.forEach((pathDefinition) => {
+    const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    path.setAttribute("d", pathDefinition);
+    svg.appendChild(path);
+  });
+  wrapper.appendChild(svg);
+  return wrapper;
 }
 
 init();

--- a/klai-portal/backend/scripts/migrate_connector_credentials.py
+++ b/klai-portal/backend/scripts/migrate_connector_credentials.py
@@ -1,9 +1,9 @@
 """One-shot data migration: encrypt existing plaintext connector credentials.
 
 Idempotent:
-  - Skips orgs where connector_dek_enc IS NOT NULL
-  - Skips connectors where encrypted_credentials IS NOT NULL
-  - Does NOT remove sensitive fields from config (backward compat)
+  - Creates per-org connector DEKs on demand
+  - Merges plaintext config secrets into any existing encrypted credential blob
+  - Removes sensitive fields from portal_connectors.config after encryption
 
 Usage:
   ENCRYPTION_KEY=<64-char-hex> uv run python scripts/migrate_connector_credentials.py
@@ -12,7 +12,6 @@ Requires ENCRYPTION_KEY and DATABASE_URL env vars.
 """
 
 import asyncio
-import json
 import os
 import sys
 
@@ -30,47 +29,21 @@ async def main() -> None:
     from sqlalchemy.orm import sessionmaker
 
     from app.core.config import settings
-    from app.core.security import AESGCMCipher
     from app.models.connectors import PortalConnector
-    from app.models.portal import PortalOrg
-    from app.services.connector_credentials import SENSITIVE_FIELDS
+    from app.services.connector_credentials import SENSITIVE_FIELDS, ConnectorCredentialStore
 
     if not settings.encryption_key:
         logger.error("ENCRYPTION_KEY env var is required")
         sys.exit(1)
 
-    kek = AESGCMCipher(bytes.fromhex(settings.encryption_key))
+    store = ConnectorCredentialStore(settings.encryption_key)
     engine = create_async_engine(settings.database_url)
     async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
     async with async_session() as db:
-        # Step 1: Generate DEKs for orgs that don't have one yet
-        result = await db.execute(select(PortalOrg).where(PortalOrg.connector_dek_enc.is_(None)))
-        orgs_without_dek = result.scalars().all()
-        dek_count = 0
-        dek_cache: dict[int, bytes] = {}
-
-        for org in orgs_without_dek:
-            raw_dek = os.urandom(32)
-            org.connector_dek_enc = kek.encrypt(raw_dek.hex())
-            dek_cache[org.id] = raw_dek
-            dek_count += 1
-
-        if dek_count:
-            logger.info("Generated DEKs for orgs", count=dek_count)
-            await db.flush()
-
-        # Pre-load existing DEKs
-        result = await db.execute(select(PortalOrg).where(PortalOrg.connector_dek_enc.isnot(None)))
-        for org in result.scalars().all():
-            if org.id not in dek_cache:
-                dek_hex = kek.decrypt(org.connector_dek_enc)
-                dek_cache[org.id] = bytes.fromhex(dek_hex)
-
-        # Step 2: Encrypt connector credentials
-        result = await db.execute(select(PortalConnector).where(PortalConnector.encrypted_credentials.is_(None)))
+        result = await db.execute(select(PortalConnector))
         connectors = result.scalars().all()
-        encrypted_count = 0
+        remediated_count = 0
         skipped_count = 0
 
         for i, connector in enumerate(connectors):
@@ -85,23 +58,30 @@ async def main() -> None:
                 skipped_count += 1
                 continue
 
-            org_dek = dek_cache.get(connector.org_id)
-            if org_dek is None:
-                logger.warning(
-                    "No DEK for org, skipping connector",
+            merged_credentials: dict = {}
+            if connector.encrypted_credentials is not None:
+                merged_credentials = await store.decrypt_credentials(
                     org_id=connector.org_id,
-                    connector_id=str(connector.id),
+                    encrypted_credentials=bytes(connector.encrypted_credentials),
+                    db=db,
                 )
-                skipped_count += 1
-                continue
-
-            dek_cipher = AESGCMCipher(org_dek)
-            connector.encrypted_credentials = dek_cipher.encrypt(json.dumps(sensitive_data))
-            encrypted_count += 1
-
-            # NOTE: We intentionally do NOT remove sensitive fields from
-            # connector.config yet. This preserves backward compatibility
-            # until all consumers use the decrypt path.
+            merged_credentials.update(sensitive_data)
+            encrypted_blob, stripped_config = await store.encrypt_credentials(
+                org_id=connector.org_id,
+                connector_type=connector.connector_type,
+                config={**config, **merged_credentials},
+                db=db,
+            )
+            if encrypted_blob is None:
+                logger.error(
+                    "Credential remediation produced no encrypted blob",
+                    connector_id=str(connector.id),
+                    connector_type=connector.connector_type,
+                )
+                sys.exit(1)
+            connector.encrypted_credentials = encrypted_blob
+            connector.config = stripped_config
+            remediated_count += 1
 
             if (i + 1) % 100 == 0:
                 logger.info("Migration progress", processed=i + 1, total=len(connectors))
@@ -109,9 +89,8 @@ async def main() -> None:
         await db.commit()
         logger.info(
             "Migration complete",
-            encrypted=encrypted_count,
+            remediated=remediated_count,
             skipped=skipped_count,
-            deks_generated=dek_count,
         )
 
 

--- a/klai-portal/backend/tests/test_connector_credentials.py
+++ b/klai-portal/backend/tests/test_connector_credentials.py
@@ -92,6 +92,12 @@ class TestSensitiveFieldsMapping:
     def test_web_crawler_fields(self) -> None:
         assert set(SENSITIVE_FIELDS["web_crawler"]) == {"auth_headers", "cookies"}
 
+    def test_confluence_fields(self) -> None:
+        assert SENSITIVE_FIELDS["confluence"] == ["api_token"]
+
+    def test_airtable_fields(self) -> None:
+        assert SENSITIVE_FIELDS["airtable"] == ["api_key"]
+
     def test_all_connector_types_present(self) -> None:
         assert set(SENSITIVE_FIELDS.keys()) == {
             "github",
@@ -99,6 +105,8 @@ class TestSensitiveFieldsMapping:
             "google_drive",
             "ms_docs",
             "web_crawler",
+            "confluence",
+            "airtable",
         }
 
 

--- a/klai-portal/backend/tests/test_connector_encryption_api.py
+++ b/klai-portal/backend/tests/test_connector_encryption_api.py
@@ -1,22 +1,23 @@
 """Tests for connector credential encryption in API layer.
 
 Verifies that:
-- _connector_out masks sensitive fields with '***'
+- _connector_out rejects plaintext sensitive fields instead of masking them
 - The internal get_connector_config decrypts and merges credentials
-- Legacy connectors (encrypted_credentials=None) work as fallback
 """
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from app.api.connectors import _connector_out, _cookie_names_from_credentials
+import pytest
+
+from app.api.connectors import _connector_out, _cookie_names_from_credentials, _merge_saved_sensitive_credentials
 from app.services.connector_credentials import SENSITIVE_FIELDS
 
 # Test-only placeholder values (NOT real credentials)
 FAKE_TOKEN = "test-placeholder-value"
 
 
-class TestConnectorOutMasking:
-    """_connector_out masks all sensitive fields per SENSITIVE_FIELDS mapping."""
+class TestConnectorOutPlaintextSecretRejection:
+    """_connector_out must fail closed when storage still contains plaintext secrets."""
 
     def _make_connector(self, connector_type: str, config: dict) -> MagicMock:
         c = MagicMock()
@@ -36,32 +37,43 @@ class TestConnectorOutMasking:
         c.encrypted_credentials = None
         return c
 
-    def test_github_sensitive_fields_masked(self) -> None:
+    @pytest.mark.parametrize("connector_type,fields", sorted(SENSITIVE_FIELDS.items()))
+    def test_sensitive_fields_rejected(self, connector_type: str, fields: list[str]) -> None:
+        config = {field: FAKE_TOKEN for field in fields}
+        config["safe_field"] = "visible"
+        with pytest.raises(RuntimeError, match="plaintext sensitive fields"):
+            _connector_out(self._make_connector(connector_type, config))
+
+    def test_github_sensitive_fields_rejected(self) -> None:
         config = {
             "repo": "GetKlai/klai",
             "access_token": FAKE_TOKEN,
             "installation_token": FAKE_TOKEN,
             "app_private_key": FAKE_TOKEN,
         }
-        out = _connector_out(self._make_connector("github", config))
-        assert out.config["access_token"] == "***"
-        assert out.config["installation_token"] == "***"
-        assert out.config["app_private_key"] == "***"
-        assert out.config["repo"] == "GetKlai/klai"
+        with pytest.raises(RuntimeError, match="plaintext sensitive fields"):
+            _connector_out(self._make_connector("github", config))
 
-    def test_notion_sensitive_fields_masked(self) -> None:
+    def test_notion_sensitive_fields_rejected(self) -> None:
         config = {"workspace_id": "ws-123", "access_token": FAKE_TOKEN}
-        out = _connector_out(self._make_connector("notion", config))
-        assert out.config["access_token"] == "***"
-        assert out.config["workspace_id"] == "ws-123"
+        with pytest.raises(RuntimeError, match="plaintext sensitive fields"):
+            _connector_out(self._make_connector("notion", config))
 
-    def test_web_crawler_sensitive_fields_masked(self) -> None:
+    def test_web_crawler_sensitive_fields_rejected(self) -> None:
         config = {"url": "https://example.com", "auth_headers": FAKE_TOKEN}
-        out = _connector_out(self._make_connector("web_crawler", config))
-        assert out.config["auth_headers"] == "***"
-        assert out.config["url"] == "https://example.com"
+        with pytest.raises(RuntimeError, match="plaintext sensitive fields"):
+            _connector_out(self._make_connector("web_crawler", config))
 
-    def test_unknown_type_no_masking(self) -> None:
+    def test_confluence_api_token_rejected(self) -> None:
+        config = {
+            "base_url": "https://example.atlassian.net/wiki",
+            "email": "admin@example.com",
+            "api_token": FAKE_TOKEN,
+        }
+        with pytest.raises(RuntimeError, match="plaintext sensitive fields"):
+            _connector_out(self._make_connector("confluence", config))
+
+    def test_unknown_type_no_secret_contract(self) -> None:
         config = {"url": "https://example.com", "custom_field": "safe"}
         out = _connector_out(self._make_connector("unknown_type", config))
         assert out.config["url"] == "https://example.com"
@@ -95,12 +107,30 @@ def test_cookie_names_from_credentials_returns_names_without_values() -> None:
     assert names == ["prod-knowledgebase-session", "XSRF-TOKEN"]
     assert FAKE_TOKEN not in names
 
-    def test_all_connector_types_mask_correctly(self) -> None:
-        """Every connector type in SENSITIVE_FIELDS has its fields masked."""
-        for connector_type, fields in SENSITIVE_FIELDS.items():
-            config = {f: FAKE_TOKEN for f in fields}
-            config["safe_field"] = "visible"
-            out = _connector_out(self._make_connector(connector_type, config))
-            for f in fields:
-                assert out.config[f] == "***", f"Field {f} not masked for {connector_type}"
-            assert out.config["safe_field"] == "visible"
+
+@pytest.mark.asyncio
+async def test_merge_saved_sensitive_credentials_fills_omitted_confluence_token() -> None:
+    connector = MagicMock()
+    connector.connector_type = "confluence"
+    connector.encrypted_credentials = b"ENCRYPTED"
+
+    with patch("app.api.connectors.credential_store") as mock_store:
+        mock_store.decrypt_credentials = AsyncMock(return_value={"api_token": FAKE_TOKEN})
+
+        merged = await _merge_saved_sensitive_credentials(
+            connector=connector,
+            config={
+                "base_url": "https://example.atlassian.net/wiki",
+                "email": "admin@example.com",
+                "space_keys": ["ENG"],
+            },
+            org_id=77,
+            db=AsyncMock(),
+        )
+
+    assert merged == {
+        "base_url": "https://example.atlassian.net/wiki",
+        "email": "admin@example.com",
+        "space_keys": ["ENG"],
+        "api_token": FAKE_TOKEN,
+    }

--- a/klai-portal/backend/tests/test_connectors_profile_gating.py
+++ b/klai-portal/backend/tests/test_connectors_profile_gating.py
@@ -77,6 +77,7 @@ class TestCreateConnectorProfilePlanMatrix:
         out = _make_out("notion")
 
         db = AsyncMock()
+        db.add = MagicMock()
         body = ConnectorCreateRequest(
             connector_type="notion",
             config={},
@@ -90,7 +91,7 @@ class TestCreateConnectorProfilePlanMatrix:
                 new_callable=AsyncMock,
                 return_value={"kb.connectors", "kb.connectors.external"},
             ),
-            patch("app.api.connectors._validate_connector_config", new_callable=AsyncMock, return_value=None),
+            patch("app.api.connectors._validate_connector_config", return_value={}),
             patch("app.api.connectors._auto_fill_canary_fingerprint", return_value=None),
             patch("app.api.connectors.credential_store", None),
             patch("app.api.connectors._connector_out", return_value=out),
@@ -179,6 +180,7 @@ class TestCreateConnectorProfilePlanMatrix:
         out = _make_out("url")
 
         db = AsyncMock()
+        db.add = MagicMock()
         body = _make_body("url")
 
         caps_mock = AsyncMock(return_value={"kb.connectors", "kb.connectors.external"})
@@ -186,7 +188,7 @@ class TestCreateConnectorProfilePlanMatrix:
         with (
             patch("app.api.connectors._get_kb_with_owner_check", new_callable=AsyncMock, return_value=kb),
             patch("app.api.connectors.get_effective_capabilities", caps_mock),
-            patch("app.api.connectors._validate_connector_config", new_callable=AsyncMock, return_value=None),
+            patch("app.api.connectors._validate_connector_config", return_value={}),
             patch("app.api.connectors._auto_fill_canary_fingerprint", return_value=None),
             patch("app.api.connectors.credential_store", None),
             patch("app.api.connectors._connector_out", return_value=out),
@@ -212,6 +214,7 @@ class TestCreateConnectorProfilePlanMatrix:
         out = _make_out("url")
 
         db = AsyncMock()
+        db.add = MagicMock()
         body = _make_body("url")
 
         caps_mock = AsyncMock(return_value={"kb.connectors"})
@@ -219,7 +222,7 @@ class TestCreateConnectorProfilePlanMatrix:
         with (
             patch("app.api.connectors._get_kb_with_owner_check", new_callable=AsyncMock, return_value=kb),
             patch("app.api.connectors.get_effective_capabilities", caps_mock),
-            patch("app.api.connectors._validate_connector_config", new_callable=AsyncMock, return_value=None),
+            patch("app.api.connectors._validate_connector_config", return_value={}),
             patch("app.api.connectors._auto_fill_canary_fingerprint", return_value=None),
             patch("app.api.connectors.credential_store", None),
             patch("app.api.connectors._connector_out", return_value=out),

--- a/klai-portal/backend/tests/test_connectors_ssrf.py
+++ b/klai-portal/backend/tests/test_connectors_ssrf.py
@@ -174,8 +174,22 @@ class TestValidateConnectorConfig:
             )
         assert excinfo.value.status_code == 422
 
-    def test_unknown_connector_type_passes_through(self) -> None:
-        """github / notion / etc. have no SSRF config surface today.
+    def test_airtable_dispatch_invokes_validator(self) -> None:
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as excinfo:
+            _validate_connector_config(
+                "airtable",
+                {
+                    "api_key": "pat_placeholder",
+                    "base_id": "not-an-airtable-base",
+                    "table_names": ["Customers"],
+                },
+            )
+        assert excinfo.value.status_code == 422
+
+    def test_connector_type_without_config_schema_passes_through(self) -> None:
+        """github has no portal-side user credential config surface today.
 
         Pass through unchanged — any future SSRF-relevant connector
         adds itself to ``_CONFIG_SCHEMA`` to opt in.

--- a/klai-portal/backend/tests/test_internal_connector_config_security.py
+++ b/klai-portal/backend/tests/test_internal_connector_config_security.py
@@ -1,0 +1,178 @@
+"""Security regressions for internal connector config materialization."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+_PLACEHOLDER_INTERNAL = "placeholder-internal-value"  # nosec
+_PLACEHOLDER_TOKEN = "placeholder-token-value"  # nosec
+
+
+def _request() -> MagicMock:
+    request = MagicMock()
+    request.headers = {"Authorization": f"Bearer {_PLACEHOLDER_INTERNAL}"}
+    return request
+
+
+def _connector(*, connector_type: str = "confluence", config: dict, encrypted_credentials: bytes | None) -> MagicMock:
+    connector = MagicMock()
+    connector.id = "conn-confluence-1"
+    connector.kb_id = 123
+    connector.org_id = 77
+    connector.connector_type = connector_type
+    connector.config = config
+    connector.schedule = None
+    connector.is_enabled = True
+    connector.allowed_assertion_modes = None
+    connector.created_by = "zitadel-user-1"
+    connector.encrypted_credentials = encrypted_credentials
+    return connector
+
+
+def _row(connector: MagicMock) -> MagicMock:
+    kb = MagicMock()
+    kb.slug = "kb-main"
+    org = MagicMock()
+    org.zitadel_org_id = "200000000000000001"
+    result = MagicMock()
+    result.one_or_none.return_value = (connector, kb, org)
+    return result
+
+
+class TestInternalConnectorConfigSecurity:
+    @pytest.mark.parametrize(
+        "connector_type,config",
+        [
+            (
+                "confluence",
+                {
+                    "base_url": "https://example.atlassian.net/wiki",
+                    "email": "admin@example.com",
+                    "api_token": _PLACEHOLDER_TOKEN,
+                },
+            ),
+            (
+                "airtable",
+                {
+                    "base_id": "app123456789",
+                    "table_names": ["Customers"],
+                    "api_key": _PLACEHOLDER_TOKEN,
+                },
+            ),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_plaintext_connector_secret_is_rejected(self, connector_type: str, config: dict) -> None:
+        from app.api.internal import get_connector_config
+
+        connector = _connector(
+            connector_type=connector_type,
+            config=config,
+            encrypted_credentials=None,
+        )
+        db = AsyncMock()
+        db.get = AsyncMock(return_value=connector)
+        db.execute = AsyncMock(return_value=_row(connector))
+
+        with (
+            patch("app.api.internal.settings") as mock_settings,
+            patch("app.api.internal.set_tenant", new=AsyncMock()),
+            patch("app.api.internal._audit_internal_call", new=AsyncMock()),
+        ):
+            mock_settings.internal_secret = _PLACEHOLDER_INTERNAL
+
+            with pytest.raises(HTTPException) as exc_info:
+                await get_connector_config(
+                    connector_id="conn-confluence-1",
+                    request=_request(),
+                    db=db,
+                )
+
+            assert exc_info.value.status_code == 500
+            assert exc_info.value.detail == {"error_code": "connector_plaintext_secret_detected"}
+
+    @pytest.mark.asyncio
+    async def test_encrypted_confluence_api_token_is_merged_for_internal_consumer(self) -> None:
+        from app.api.internal import get_connector_config
+
+        connector = _connector(
+            config={
+                "base_url": "https://example.atlassian.net/wiki",
+                "email": "admin@example.com",
+            },
+            encrypted_credentials=b"ENCRYPTED",
+        )
+        db = AsyncMock()
+        db.get = AsyncMock(return_value=connector)
+        db.execute = AsyncMock(return_value=_row(connector))
+
+        with (
+            patch("app.api.internal.settings") as mock_settings,
+            patch("app.api.internal.set_tenant", new=AsyncMock()),
+            patch("app.api.internal._audit_internal_call", new=AsyncMock()),
+            patch("app.api.internal.credential_store") as mock_store,
+        ):
+            mock_settings.internal_secret = _PLACEHOLDER_INTERNAL
+            mock_store.decrypt_credentials = AsyncMock(return_value={"api_token": _PLACEHOLDER_TOKEN})
+
+            result = await get_connector_config(
+                connector_id="conn-confluence-1",
+                request=_request(),
+                db=db,
+            )
+
+            assert result.config["api_token"] == _PLACEHOLDER_TOKEN
+            assert connector.config == {
+                "base_url": "https://example.atlassian.net/wiki",
+                "email": "admin@example.com",
+            }
+
+    @pytest.mark.parametrize(
+        "connector_type,config",
+        [
+            (
+                "confluence",
+                {
+                    "base_url": "https://example.atlassian.net/wiki",
+                    "email": "admin@example.com",
+                },
+            ),
+            (
+                "airtable",
+                {
+                    "base_id": "app123456789",
+                    "table_names": ["Customers"],
+                },
+            ),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_required_encrypted_credentials_missing_is_rejected(self, connector_type: str, config: dict) -> None:
+        from app.api.internal import get_connector_config
+
+        connector = _connector(
+            connector_type=connector_type,
+            config=config,
+            encrypted_credentials=None,
+        )
+        db = AsyncMock()
+        db.get = AsyncMock(return_value=connector)
+        db.execute = AsyncMock(return_value=_row(connector))
+
+        with (
+            patch("app.api.internal.settings") as mock_settings,
+            patch("app.api.internal.set_tenant", new=AsyncMock()),
+            patch("app.api.internal._audit_internal_call", new=AsyncMock()),
+        ):
+            mock_settings.internal_secret = _PLACEHOLDER_INTERNAL
+
+            with pytest.raises(HTTPException) as exc_info:
+                await get_connector_config(
+                    connector_id="conn-confluence-1",
+                    request=_request(),
+                    db=db,
+                )
+
+            assert exc_info.value.status_code == 500
+            assert exc_info.value.detail == {"error_code": "connector_required_credentials_missing"}

--- a/klai-portal/backend/tests/test_oauth_routes.py
+++ b/klai-portal/backend/tests/test_oauth_routes.py
@@ -412,9 +412,7 @@ class TestCallbackEndpoint:
             db.get = AsyncMock(return_value=mock_connector)
             db.commit = AsyncMock()
 
-            mock_store.encrypt_credentials = AsyncMock(
-                return_value=(b"ENCRYPTED_BLOB", {"access_token": "***", "refresh_token": "***"})
-            )
+            mock_store.encrypt_credentials = AsyncMock(return_value=(b"ENCRYPTED_BLOB", {}))
 
             response = await callback_provider(
                 provider="google_drive",
@@ -564,9 +562,7 @@ class TestInternalCredentialsWriteback:
                     "refresh_token": "placeholder-refresh-value",
                 }
             )
-            mock_store.encrypt_credentials = AsyncMock(
-                return_value=(b"NEW_ENCRYPTED", {"access_token": "***", "refresh_token": "***"})
-            )
+            mock_store.encrypt_credentials = AsyncMock(return_value=(b"NEW_ENCRYPTED", {}))
 
             await update_connector_credentials(
                 connector_id="conn-uuid-2",
@@ -627,9 +623,7 @@ class TestInternalCredentialsWriteback:
                     "refresh_token": "placeholder-old-refresh-value",
                 }
             )
-            mock_store.encrypt_credentials = AsyncMock(
-                return_value=(b"NEW_ENCRYPTED", {"access_token": "***", "refresh_token": "***"})
-            )
+            mock_store.encrypt_credentials = AsyncMock(return_value=(b"NEW_ENCRYPTED", {}))
 
             await update_connector_credentials(
                 connector_id="conn-uuid-ms-r9",
@@ -683,9 +677,7 @@ class TestInternalCredentialsWriteback:
                     "refresh_token": "placeholder-stored-refresh-value",
                 }
             )
-            mock_store.encrypt_credentials = AsyncMock(
-                return_value=(b"NEW_ENCRYPTED", {"access_token": "***", "refresh_token": "***"})
-            )
+            mock_store.encrypt_credentials = AsyncMock(return_value=(b"NEW_ENCRYPTED", {}))
 
             await update_connector_credentials(
                 connector_id="conn-uuid-gdrive",
@@ -863,9 +855,7 @@ class TestMsDocsProvider:
             db.get = AsyncMock(return_value=mock_connector)
             db.commit = AsyncMock()
 
-            mock_store.encrypt_credentials = AsyncMock(
-                return_value=(b"ENCRYPTED_BLOB", {"access_token": "***", "refresh_token": "***"})
-            )
+            mock_store.encrypt_credentials = AsyncMock(return_value=(b"ENCRYPTED_BLOB", {}))
 
             response = await callback_provider(
                 provider="ms_docs",


### PR DESCRIPTION
## Summary
- encrypt and strip Confluence `api_token` and Airtable `api_key` instead of returning them in connector config
- fail closed when plaintext connector secrets are still present in API/internal responses
- migrate existing plaintext connector secrets into encrypted credential storage and remove them from config
- add regression coverage for public connector responses, internal connector config, OAuth callback writeback, and connector credential mapping

## Root cause
Confluence and Airtable credential fields were missing from the shared `SENSITIVE_FIELDS` mapping. That allowed secrets to remain in `PortalConnector.config`, so update/read responses could send them back to frontend callers.

## Validation
- `cd klai-portal/backend && uv run ruff check .`
- `cd klai-portal/backend && uv run ruff format --check .`
- `cd klai-portal/backend && uv run --with pyright pyright`
- `cd klai-portal/backend && uv run pytest -q --tb=short` (`3110 passed, 3 deselected`)
- `cd klai-libs/connector-credentials && uv run pytest tests/test_store.py -q` (`28 passed`)
- `git diff --check`

## Production follow-up
After deploy, run `cd klai-portal/backend && uv run python scripts/migrate_connector_credentials.py` in the production portal-api environment to move any existing plaintext secrets into encrypted storage.
