### PR TITLE
Fix LibreChat knowledge identity header

### DIFF
--- a/deploy/librechat/librechat.yaml
+++ b/deploy/librechat/librechat.yaml
@@ -92,7 +92,7 @@ mcpServers:
     type: streamable-http
     url: http://klai-knowledge-mcp:8080/mcp
     headers:
-      X-User-ID: "{{LIBRECHAT_USER_ID}}"
+      X-User-ID: "{{LIBRECHAT_USER_OPENIDID}}"
       X-Org-ID: "${KLAI_ZITADEL_ORG_ID}"
       X-Org-Slug: "${KLAI_ORG_SLUG}"
       X-Internal-Secret: "${KNOWLEDGE_INGEST_SECRET}"

--- a/klai-portal/backend/tests/services/provisioning/test_generators.py
+++ b/klai-portal/backend/tests/services/provisioning/test_generators.py
@@ -125,6 +125,8 @@ class TestCharacterizeGenerateLibrechatYaml:
               klai-knowledge:
                 type: streamable-http
                 url: http://klai-knowledge-mcp:8080/mcp
+                headers:
+                  X-User-ID: "{{LIBRECHAT_USER_OPENIDID}}"
             modelSpecs:
               prioritize: true
               list:
@@ -145,6 +147,7 @@ class TestCharacterizeGenerateLibrechatYaml:
         parsed = yaml.safe_load(result)
         assert "klai-knowledge" in parsed["mcpServers"]
         assert len(parsed["mcpServers"]) == 1
+        assert parsed["mcpServers"]["klai-knowledge"]["headers"]["X-User-ID"] == "{{LIBRECHAT_USER_OPENIDID}}"
 
     def test_returns_string(self, base_yaml_file):
         from app.services.provisioning import _generate_librechat_yaml

--- a/klai-portal/backend/tests/test_provisioning.py
+++ b/klai-portal/backend/tests/test_provisioning.py
@@ -293,6 +293,8 @@ def base_yaml_file(tmp_path):
           klai-knowledge:
             type: streamable-http
             url: http://klai-knowledge-mcp:8080/mcp
+            headers:
+              X-User-ID: "{{LIBRECHAT_USER_OPENIDID}}"
         modelSpecs:
           prioritize: true
           list:
@@ -338,6 +340,7 @@ class TestGenerateLibrechatYaml:
         assert "klai-knowledge" in parsed["mcpServers"]
         assert len(parsed["mcpServers"]) == 1
         assert parsed["modelSpecs"]["list"][0]["mcpServers"] == ["klai-knowledge"]
+        assert parsed["mcpServers"]["klai-knowledge"]["headers"]["X-User-ID"] == "{{LIBRECHAT_USER_OPENIDID}}"
 
     def test_extra_servers_merged_into_mcp_section(self, base_yaml_file):
         """Extra MCP servers are added to the mcpServers section."""


### PR DESCRIPTION
## Summary
- send the LibreChat OpenID/Klai user id to knowledge MCP instead of the internal chat database id
- add provisioning regression assertions for the klai-knowledge X-User-ID header

## Validation
- cd klai-portal/backend && uv run pytest tests/test_provisioning.py tests/services/provisioning/test_generators.py -q
- cd klai-portal/backend && uv run ruff check tests/test_provisioning.py tests/services/provisioning/test_generators.py
- production DeepBlue runtime config updated and container restarted
- production identity verify: old chat id returns 403 no_membership; Max Klai id returns 200 verified:true
- production MCP smoke from DeepBlue chat container: initialize 200; search_knowledge tools/call 200 without MCP error