### PR TITLE
fix(auth): allow required MFA setup bootstrap

### DIFF
--- a/klai-portal/backend/app/api/auth.py
+++ b/klai-portal/backend/app/api/auth.py
@@ -774,8 +774,6 @@ async def _resolve_and_enforce_mfa(
         HTTPException(503): Org fetch failed (cannot determine policy for a
             known portal user) OR Zitadel/connection failure during
             ``has_any_mfa`` under ``mfa_policy="required"``.
-        HTTPException(403): ``mfa_policy="required"`` and the user has no MFA
-            enrolled (existing behaviour, unchanged).
 
     Fail-open paths (login proceeds):
         - portal_user lookup raised — cannot map email to org; preserve
@@ -893,9 +891,18 @@ async def _resolve_and_enforce_mfa(
         raise _mfa_unavailable() from exc
 
     if not user_has_mfa:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="MFA required by your organization. Please set up two-factor authentication.",
+        # Bootstrap path for org-required MFA: the password has been verified,
+        # so allow the OIDC/BFF session to be created solely so the frontend can
+        # route the user to /setup/mfa and the setup endpoints can register the
+        # first factor. Post-login navigation is still gated by /api/me's
+        # requires_2fa_setup signal and the protected-route guard.
+        _emit_auth_event(
+            "mfa_setup_required",
+            reason="no_mfa_enrolled",
+            mfa_policy="required",
+            outcome="allow-setup",
+            email=email,
+            level="warning",
         )
 
     return portal_user

--- a/klai-portal/backend/app/api/me.py
+++ b/klai-portal/backend/app/api/me.py
@@ -59,6 +59,7 @@ class MeResponse(BaseModel):
     provisioning_status: str = "pending"
     mfa_enrolled: bool = False
     mfa_policy: str = "optional"
+    requires_2fa_setup: bool = False
     preferred_language: Literal["nl", "en"] = "nl"
     portal_role: str = "personal"
     products: list[str] = []
@@ -194,6 +195,7 @@ async def me(
         provisioning_status=provisioning_status,
         mfa_enrolled=mfa_enrolled,
         mfa_policy=mfa_policy,
+        requires_2fa_setup=mfa_policy == "required" and not mfa_enrolled,
         preferred_language=preferred_language,
         portal_role=portal_role,
         products=_products,

--- a/klai-portal/backend/tests/test_auth_mfa_fail_closed.py
+++ b/klai-portal/backend/tests/test_auth_mfa_fail_closed.py
@@ -20,6 +20,7 @@ import pytest
 import respx
 from auth_test_helpers import (
     _audit_emit_patches,
+    _capture_events,
     _expected_email_hash,
     _make_db_mock,
     _make_login_body,
@@ -208,6 +209,45 @@ async def test_happy_path_optional_no_mfa_sets_cookie(respx_zitadel: respx.MockR
     assert result.status == "ok"
     response.set_cookie.assert_called_once()  # session cookie minted by _finalize_and_set_cookie
     assert _mfa_events(captured) == []
+
+
+# ---------------------------------------------------------------------------
+# Scenario 5a — required policy + no MFA → setup bootstrap, not lockout
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_required_no_mfa_allows_setup_bootstrap(respx_zitadel: respx.MockRouter) -> None:
+    respx_zitadel.post("/v2/users").mock(
+        return_value=httpx.Response(
+            200, json={"result": [{"userId": "uid-req", "details": {"resourceOwner": "zorg-req"}}]}
+        )
+    )
+    auth_methods = respx_zitadel.get("/v2/users/uid-req/authentication_methods").mock(
+        return_value=httpx.Response(200, json={"authMethodTypes": []})
+    )
+    respx_zitadel.post("/v2/sessions").mock(return_value=httpx.Response(200, json=_session_ok()))
+    respx_zitadel.post(url__regex=r"/v2/oidc/auth_requests/.+").mock(
+        return_value=httpx.Response(200, json={"callbackUrl": "https://chat.getklai.com/cb"})
+    )
+
+    db = _make_db_mock(org_mfa_policy="required")
+    response = MagicMock()
+    audit_patch, emit_patch = _audit_emit_patches()
+
+    with capture_logs() as captured, audit_patch, emit_patch:
+        result = await login(body=_make_login_body(), response=response, request=make_request(), db=db)
+
+    assert result.status == "ok"
+    response.set_cookie.assert_called_once()
+    assert auth_methods.call_count == 2  # has_totp UI probe + required-policy has_any_mfa check
+    assert _mfa_events(captured) == []
+
+    setup_events = _capture_events(captured, "mfa_setup_required")
+    assert len(setup_events) == 1
+    assert setup_events[0]["reason"] == "no_mfa_enrolled"
+    assert setup_events[0]["mfa_policy"] == "required"
+    assert setup_events[0]["outcome"] == "allow-setup"
 
 
 # ---------------------------------------------------------------------------

--- a/klai-portal/backend/tests/test_auth_security.py
+++ b/klai-portal/backend/tests/test_auth_security.py
@@ -294,8 +294,8 @@ class TestMFAPolicyEnforcement:
     """Verify that org-level MFA policy is enforced during login."""
 
     @pytest.mark.asyncio
-    async def test_mfa_required_no_mfa_enrolled_returns_403(self) -> None:
-        """When org.mfa_policy='required' and user has no MFA, login returns 403."""
+    async def test_mfa_required_no_mfa_enrolled_allows_setup_session(self) -> None:
+        """When org.mfa_policy='required' and user has no MFA, login creates the setup session."""
         from app.api.auth import LoginRequest, login
 
         body = LoginRequest(email="user@test.com", password="pass123", auth_request_id="ar-mfa-1")
@@ -312,6 +312,7 @@ class TestMFAPolicyEnforcement:
             mock_zitadel.has_totp = AsyncMock(return_value=False)
             mock_zitadel.create_session_with_password = AsyncMock(return_value=_make_session_response())
             mock_zitadel.has_any_mfa = AsyncMock(return_value=False)
+            mock_zitadel.finalize_auth_request = AsyncMock(return_value="https://chat.getklai.com/callback")
 
             # Portal user belongs to an org with mfa_policy=required
             mock_portal_user = MagicMock()
@@ -323,11 +324,10 @@ class TestMFAPolicyEnforcement:
 
             mock_audit.log_event = AsyncMock()
 
-            with pytest.raises(Exception) as exc_info:
-                await login(body=body, response=response, request=make_request(), db=db)
+            result = await login(body=body, response=response, request=make_request(), db=db)
 
-            assert exc_info.value.status_code == 403  # type: ignore[union-attr]
-            assert "MFA required" in str(exc_info.value.detail)  # type: ignore[union-attr]
+            assert result.status == "ok"
+            response.set_cookie.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_mfa_required_with_mfa_enrolled_proceeds(self, fake_redis) -> None:

--- a/klai-portal/backend/tests/test_me_org_found.py
+++ b/klai-portal/backend/tests/test_me_org_found.py
@@ -99,6 +99,50 @@ class TestMeOrgFound:
             response = await me(credentials=mock_credentials, db=mock_db)
 
         assert response.org_found is True
+        assert response.requires_2fa_setup is False
+
+    @pytest.mark.asyncio
+    async def test_required_mfa_without_enrolment_sets_setup_flag(self) -> None:
+        """Required org MFA should tell the SPA to keep the user in the setup flow."""
+        from app.api.me import me
+
+        org = _mock_org()
+        org.mfa_policy = "required"
+        portal_user = _mock_portal_user()
+        perms = _mock_perms(org_id=org.id)
+
+        mock_row = MagicMock()
+        mock_row.__iter__ = lambda self: iter((org, portal_user))
+
+        mock_result = MagicMock()
+        mock_result.one_or_none.return_value = mock_row
+
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock(return_value=mock_result)
+        mock_db.commit = AsyncMock()
+
+        mock_credentials = MagicMock()
+        mock_credentials.credentials = "test-token"
+
+        userinfo = {
+            "sub": "user-123",
+            "email": "test@acme.nl",
+            "name": "Test User",
+        }
+
+        with (
+            patch("app.api.me.zitadel") as mock_zitadel,
+            patch("app.api.me.resolve_user_permissions", new=AsyncMock(return_value=perms)),
+            patch("app.api.me.set_tenant", new_callable=AsyncMock),
+        ):
+            mock_zitadel.get_userinfo = AsyncMock(return_value=userinfo)
+            mock_zitadel.has_any_mfa = AsyncMock(return_value=False)
+
+            response = await me(credentials=mock_credentials, db=mock_db)
+
+        assert response.mfa_policy == "required"
+        assert response.mfa_enrolled is False
+        assert response.requires_2fa_setup is True
 
     @pytest.mark.asyncio
     async def test_org_found_false_when_no_portal_user(self) -> None:

--- a/klai-portal/frontend/src/hooks/__tests__/useProtectedRoute.test.tsx
+++ b/klai-portal/frontend/src/hooks/__tests__/useProtectedRoute.test.tsx
@@ -166,14 +166,26 @@ describe('useProtectedRoute', () => {
     expect(result.current.canRender).toBe(true)
   })
 
-  it('redirects to /setup/2fa when requires_2fa_setup is true', () => {
+  it('redirects to /setup/mfa when requires_2fa_setup is true', () => {
     const replace = vi.fn()
-    vi.stubGlobal('location', { replace } as unknown as Location)
+    vi.stubGlobal('location', { pathname: '/app', replace } as unknown as Location)
     mockQuery = { user: userFixture({ requires_2fa_setup: true }), isPending: false }
-    renderHook(() => useProtectedRoute(), {
+    const { result } = renderHook(() => useProtectedRoute(), {
       wrapper: wrapperFor(makeAuth({ isLoading: false, isAuthenticated: true })),
     })
-    expect(replace).toHaveBeenCalledWith('/setup/2fa')
+    expect(replace).toHaveBeenCalledWith('/setup/mfa')
+    expect(result.current.canRender).toBe(false)
+  })
+
+  it('allows the setup route to render when requires_2fa_setup is true', () => {
+    const replace = vi.fn()
+    vi.stubGlobal('location', { pathname: '/setup/mfa', replace } as unknown as Location)
+    mockQuery = { user: userFixture({ requires_2fa_setup: true }), isPending: false }
+    const { result } = renderHook(() => useProtectedRoute(), {
+      wrapper: wrapperFor(makeAuth({ isLoading: false, isAuthenticated: true })),
+    })
+    expect(replace).not.toHaveBeenCalled()
+    expect(result.current.canRender).toBe(true)
   })
 
   it('redirects to noRoleFallback when requireAdmin is true and user lacks the role', () => {

--- a/klai-portal/frontend/src/hooks/useProtectedRoute.ts
+++ b/klai-portal/frontend/src/hooks/useProtectedRoute.ts
@@ -91,6 +91,10 @@ function workspaceHandoffUrl(workspaceUrl: string | null | undefined): string | 
   }
 }
 
+function isMfaSetupPath(pathname: string): boolean {
+  return pathname === '/setup/mfa' || pathname === '/setup/2fa'
+}
+
 export function useProtectedRoute(
   options: UseProtectedRouteOptions = {},
 ): UseProtectedRouteResult {
@@ -103,6 +107,8 @@ export function useProtectedRoute(
   const navigate = useNavigate()
   const { user, isPending: userLoading } = useCurrentUser()
   const workspaceRedirectUrl = user ? workspaceHandoffUrl(user.workspace_url) : null
+  const currentPath = window.location.pathname
+  const blockedByMfaSetup = !!user?.requires_2fa_setup && !isMfaSetupPath(currentPath)
 
   useEffect(() => {
     if (auth.isLoading) return
@@ -117,9 +123,9 @@ export function useProtectedRoute(
       window.location.replace(workspaceRedirectUrl)
       return
     }
-    // 2. MFA setup pending - send to the setup flow.
-    if (user?.requires_2fa_setup) {
-      window.location.replace('/setup/2fa')
+    // 2. MFA setup pending - send to the setup flow, but let that flow render.
+    if (blockedByMfaSetup) {
+      window.location.replace('/setup/mfa')
       return
     }
     // 3. Role-gated route with an insufficient-role caller.
@@ -132,6 +138,7 @@ export function useProtectedRoute(
     user,
     userLoading,
     workspaceRedirectUrl,
+    blockedByMfaSetup,
     needsRoleCheck,
     fallback,
     noRoleFallback,
@@ -140,7 +147,8 @@ export function useProtectedRoute(
   ])
 
   const roleOk = !needsRoleCheck || hasRequiredRole(user, options)
-  const isResolving = auth.isLoading || !auth.isAuthenticated || userLoading || !!workspaceRedirectUrl || !roleOk
+  const isResolving =
+    auth.isLoading || !auth.isAuthenticated || userLoading || !!workspaceRedirectUrl || blockedByMfaSetup || !roleOk
 
   return {
     user,

--- a/klai-portal/frontend/src/lib/api-me.ts
+++ b/klai-portal/frontend/src/lib/api-me.ts
@@ -17,6 +17,7 @@ export interface MeResponse {
   provisioning_status?: string
   mfa_enrolled?: boolean
   mfa_policy?: string
+  requires_2fa_setup?: boolean
   preferred_language?: 'nl' | 'en'
   portal_role?: string
   products?: string[]


### PR DESCRIPTION
## Summary
- Allow users in orgs with required MFA but no enrolled factor to complete password login into the MFA setup bootstrap flow instead of receiving the blocking MFA-required error.
- Expose `requires_2fa_setup` from `/api/me` and keep protected routes redirected to `/setup/mfa` until enrollment completes.
- Add backend and frontend regression coverage for the lockout path.

Fixes #750

## Tests
- `PORTAL_ENV=development DEBUG=false MOCK_BILLING=false uv run pytest tests/test_auth_mfa_fail_closed.py tests/test_auth_security.py tests/test_me_org_found.py`
- `npm test -- useProtectedRoute`