### PR TITLE
Fix account reinvite recovery

### DIFF
--- a/klai-portal/backend/app/api/admin/platform_manage.py
+++ b/klai-portal/backend/app/api/admin/platform_manage.py
@@ -111,6 +111,132 @@ _ZITADEL_ROLE_BY_PORTAL_ROLE: dict[str, str | None] = {
 }
 
 
+async def _find_existing_zitadel_user_for_platform_invite(
+    *,
+    email: str,
+    org_id: int,
+    perms: UserPermissions,
+    conflict_exc: httpx.HTTPStatusError,
+) -> str:
+    existing_user_id = await zitadel.find_user_id_by_email(email)
+    if existing_user_id:
+        logger.info(
+            "platform_invite_existing_zitadel_user_reused",
+            email=email,
+            target_org_id=org_id,
+            zitadel_user_id=existing_user_id,
+        )
+        return existing_user_id
+
+    await _emit_audit_safe(
+        action="platform_admin.invite_existing_zitadel_user_not_found",
+        details={"target_email": email, "target_org_id": org_id},
+        perms=perms,
+    )
+    raise HTTPException(
+        status_code=409,
+        detail="Dit e-mailadres bestaat al, maar kon niet aan deze tenant worden gekoppeld.",
+    ) from conflict_exc
+
+
+async def _create_or_reuse_platform_invite_zitadel_user(
+    *,
+    body: PlatformInviteRequest,
+    org_id: int,
+    perms: UserPermissions,
+) -> tuple[str, bool]:
+    try:
+        user_data = await zitadel.invite_user(
+            org_id=settings.zitadel_portal_org_id,
+            email=body.email,
+            first_name=body.first_name,
+            last_name=body.last_name,
+            preferred_language=body.preferred_language,
+        )
+        return user_data["userId"], True
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == status.HTTP_409_CONFLICT:
+            existing_user_id = await _find_existing_zitadel_user_for_platform_invite(
+                email=body.email,
+                org_id=org_id,
+                perms=perms,
+                conflict_exc=exc,
+            )
+            return existing_user_id, False
+        logger.exception("platform_invite_zitadel_failed", email=body.email)
+        await _emit_audit_safe(
+            action="platform_admin.invite_zitadel_invite_failed",
+            details={
+                "target_email": body.email,
+                "target_org_id": org_id,
+                "error": str(exc)[:200],
+            },
+            perms=perms,
+        )
+        raise HTTPException(status_code=502, detail=f"Zitadel invite mislukt: {exc}") from exc
+    except Exception as exc:
+        logger.exception("platform_invite_zitadel_failed", email=body.email)
+        await _emit_audit_safe(
+            action="platform_admin.invite_zitadel_invite_failed",
+            details={
+                "target_email": body.email,
+                "target_org_id": org_id,
+                "error": str(exc)[:200],
+            },
+            perms=perms,
+        )
+        raise HTTPException(status_code=502, detail=f"Zitadel invite mislukt: {exc}") from exc
+
+
+async def _grant_platform_invite_role_or_rollback(
+    *,
+    role: PortalRole,
+    email: str,
+    org_id: int,
+    zitadel_user_id: str,
+    zitadel_user_created: bool,
+    perms: UserPermissions,
+) -> None:
+    zitadel_role = _ZITADEL_ROLE_BY_PORTAL_ROLE.get(role)
+    if zitadel_role is None:
+        return
+
+    try:
+        await zitadel.grant_user_role(
+            org_id=settings.zitadel_portal_org_id,
+            user_id=zitadel_user_id,
+            role=zitadel_role,
+        )
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == status.HTTP_409_CONFLICT:
+            logger.info(
+                "platform_invite_grant_already_exists",
+                target_org_id=org_id,
+                zitadel_user_id=zitadel_user_id,
+                role=role,
+            )
+            return
+        logger.exception("platform_invite_grant_failed", zitadel_user_id=zitadel_user_id)
+        await _emit_audit_safe(
+            action="platform_admin.invite_grant_role_failed",
+            details={"target_email": email, "target_org_id": org_id, "error": str(exc)[:200]},
+            perms=perms,
+        )
+        if zitadel_user_created:
+            await _rollback_zitadel_user(zitadel_user_id)
+        raise HTTPException(status_code=502, detail=f"Rol-grant mislukt: {exc}") from exc
+    except Exception as exc:
+        logger.exception("platform_invite_grant_failed", zitadel_user_id=zitadel_user_id)
+        await _emit_audit_safe(
+            action="platform_admin.invite_grant_role_failed",
+            details={"target_email": email, "target_org_id": org_id, "error": str(exc)[:200]},
+            perms=perms,
+        )
+        if zitadel_user_created:
+            await _rollback_zitadel_user(zitadel_user_id)
+        raise HTTPException(status_code=502, detail=f"Rol-grant mislukt: {exc}") from exc
+
+
 class MessageResponse(BaseModel):
     message: str
 
@@ -567,71 +693,85 @@ async def platform_invite(
     org = await _load_org_or_404(org_id)
     from app.core.config import settings  # local import avoids cycle
 
-    # 1. Create the Zitadel user (single portal org), no auto-mail.
-    try:
-        user_data = await zitadel.invite_user(
-            org_id=settings.zitadel_portal_org_id,
-            email=body.email,
-            first_name=body.first_name,
-            last_name=body.last_name,
-            preferred_language=body.preferred_language,
-        )
-    except Exception as exc:
-        logger.exception("platform_invite_zitadel_failed", email=body.email)
-        # REQ-6 (Finding A-7): emit audit event for permanent trail even though
-        # VictoriaLogs captures the exception above (30-day retention only).
-        await _emit_audit_safe(
-            action="platform_admin.invite_zitadel_invite_failed",
-            details={
-                "target_email": body.email,
-                "target_org_id": org_id,
-                "error": str(exc)[:200],
-            },
-            perms=perms,
-        )
-        raise HTTPException(status_code=502, detail=f"Zitadel invite mislukt: {exc}") from exc
-    zitadel_user_id: str = user_data["userId"]
+    # 1. Create or reuse the Zitadel user (single portal org), no auto-mail.
+    zitadel_user_id, zitadel_user_created = await _create_or_reuse_platform_invite_zitadel_user(
+        body=body,
+        org_id=org_id,
+        perms=perms,
+    )
 
     # 2. Admin-only Zitadel grant.
-    zitadel_role = _ZITADEL_ROLE_BY_PORTAL_ROLE.get(body.role)
-    if zitadel_role is not None:
-        try:
-            await zitadel.grant_user_role(
-                org_id=settings.zitadel_portal_org_id,
-                user_id=zitadel_user_id,
-                role=zitadel_role,
-            )
-        except Exception as exc:
-            logger.exception("platform_invite_grant_failed", zitadel_user_id=zitadel_user_id)
-            await _emit_audit_safe(
-                action="platform_admin.invite_grant_role_failed",
-                details={
-                    "target_email": body.email,
-                    "target_org_id": org_id,
-                    "error": str(exc)[:200],
-                },
-                perms=perms,
-            )
-            await _rollback_zitadel_user(zitadel_user_id)
-            raise HTTPException(status_code=502, detail=f"Rol-grant mislukt: {exc}") from exc
+    await _grant_platform_invite_role_or_rollback(
+        role=body.role,
+        email=body.email,
+        org_id=org_id,
+        zitadel_user_id=zitadel_user_id,
+        zitadel_user_created=zitadel_user_created,
+        perms=perms,
+    )
 
     # 3. portal_user row + personal KB in the TARGET tenant context.
+    reactivated_offboarded = False
+    reactivated_old_role: str | None = None
     try:
         async with tenant_scoped_session(org_id) as db:
-            user_row = PortalUser(
-                zitadel_user_id=zitadel_user_id,
-                org_id=org_id,
-                role=body.role,
-                seat_type=str(suggest_seat(body.role)),
-                preferred_language=body.preferred_language,
-            )
-            db.add(user_row)
+            existing_membership = (
+                await db.execute(
+                    select(PortalUser).where(
+                        PortalUser.zitadel_user_id == zitadel_user_id,
+                        PortalUser.org_id == org_id,
+                    )
+                )
+            ).scalar_one_or_none()
+            if existing_membership is not None and existing_membership.status != "offboarded":
+                raise HTTPException(status_code=409, detail="Deze gebruiker is al lid van deze tenant.")
+            if existing_membership is None:
+                user_row = PortalUser(
+                    zitadel_user_id=zitadel_user_id,
+                    org_id=org_id,
+                    role=body.role,
+                    seat_type=str(suggest_seat(body.role)),
+                    preferred_language=body.preferred_language,
+                )
+                db.add(user_row)
+            else:
+                reactivated_old_role = existing_membership.role
+                existing_membership.status = "active"
+                existing_membership.role = body.role
+                existing_membership.seat_type = str(suggest_seat(body.role))
+                existing_membership.preferred_language = body.preferred_language
+                user_row = existing_membership
+                reactivated_offboarded = True
             await create_default_personal_kb(zitadel_user_id, org_id, db)
+            if reactivated_offboarded:
+                await zitadel.unlock_user(
+                    zitadel_user_id=zitadel_user_id,
+                    org_id=settings.zitadel_portal_org_id,
+                )
             await db.commit()
+    except HTTPException:
+        if zitadel_user_created:
+            await _rollback_zitadel_user(zitadel_user_id)
+        raise
     except Exception:
         logger.exception("platform_invite_db_failed", zitadel_user_id=zitadel_user_id)
-        await _rollback_zitadel_user(zitadel_user_id)
+        if zitadel_user_created:
+            await _rollback_zitadel_user(zitadel_user_id)
+        if reactivated_offboarded:
+            with suppress(Exception):
+                await zitadel.deactivate_user(
+                    user_id=zitadel_user_id,
+                    org_id=settings.zitadel_portal_org_id,
+                )
         raise
+
+    if not zitadel_user_created and reactivated_offboarded:
+        with suppress(Exception):
+            await _sync_zitadel_role_grant(
+                zitadel_user_id,
+                old_role=reactivated_old_role or "",
+                new_role=body.role,
+            )
 
     # 4. Send the activation mail after the portal row exists. If mail fails,
     # keep the valid portal account so support can retry delivery.
@@ -655,13 +795,15 @@ async def platform_invite(
             "role": body.role,
             "url_template_host": urlparse(invite_url_template).netloc,
             "invite_mail_sent": mail_sent,
+            "reactivated_offboarded": reactivated_offboarded,
         },
     )
-    message = (
-        f"Uitnodiging verstuurd naar {body.email}."
-        if mail_sent
-        else f"User aangemaakt voor {body.email}, maar invite-mail kon niet worden verstuurd."
-    )
+    if mail_sent:
+        message = f"Uitnodiging verstuurd naar {body.email}."
+    elif reactivated_offboarded:
+        message = f"User hersteld voor {body.email}, maar invite-mail kon niet worden verstuurd."
+    else:
+        message = f"User aangemaakt voor {body.email}, maar invite-mail kon niet worden verstuurd."
 
     from app.services.listmonk import sync_portal_user_best_effort
 

--- a/klai-portal/backend/app/api/admin/users.py
+++ b/klai-portal/backend/app/api/admin/users.py
@@ -1,7 +1,8 @@
 """Admin user lifecycle endpoints."""
 
 import logging
-from collections.abc import Mapping
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Final, Literal
 from urllib.parse import urlparse
@@ -75,6 +76,15 @@ _ZITADEL_ROLE_BY_PORTAL_ROLE: Final[Mapping[str, str | None]] = {
 }
 
 router = APIRouter()
+
+
+@dataclass(frozen=True)
+class ExistingInviteIdentity:
+    user_id: str
+    membership: PortalUser | None = None
+
+
+CleanupInviteUser = Callable[[str], Awaitable[None]]
 
 
 # ---------------------------------------------------------------------------
@@ -163,7 +173,7 @@ async def _reuse_existing_zitadel_user_for_invite(
     org: PortalOrg,
     db: AsyncSession,
     conflict_exc: httpx.HTTPStatusError,
-) -> str:
+) -> ExistingInviteIdentity:
     # A user may already exist globally because they signed up socially,
     # belonged to another tenant, or were left behind by an older partial
     # onboarding attempt. Reuse that identity for this workspace instead
@@ -194,11 +204,21 @@ async def _reuse_existing_zitadel_user_for_invite(
             PortalUser.org_id == org.id,
         )
     )
-    if membership_result.scalar_one_or_none() is not None:
+    membership = membership_result.scalar_one_or_none()
+    if membership is not None and membership.status != "offboarded":
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail="Deze gebruiker is al lid van deze workspace.",
         ) from conflict_exc
+
+    if membership is not None:
+        _slog.info(
+            "invite_offboarded_zitadel_user_reused",
+            email=body.email,
+            org_id=org.id,
+            zitadel_user_id=existing_user_id,
+        )
+        return ExistingInviteIdentity(user_id=existing_user_id, membership=membership)
 
     _slog.info(
         "invite_existing_zitadel_user_reused",
@@ -206,7 +226,145 @@ async def _reuse_existing_zitadel_user_for_invite(
         org_id=org.id,
         zitadel_user_id=existing_user_id,
     )
-    return existing_user_id
+    return ExistingInviteIdentity(user_id=existing_user_id)
+
+
+def _invite_failure_detail(failure_step: str) -> str:
+    if failure_step == "invite_mail":
+        return "Uitnodigingsmail kon niet worden verstuurd. Probeer het opnieuw."
+    if failure_step == "zitadel_reactivate":
+        return "Gebruiker kon niet opnieuw worden geactiveerd. Probeer het opnieuw."
+    return "Uitnodiging kon niet worden opgeslagen. Probeer het opnieuw."
+
+
+async def _restore_reactivated_zitadel_user_if_needed(
+    *,
+    reactivated_zitadel_user: bool,
+    zitadel_user_id: str,
+    email: str,
+    org_id: int,
+    failure_step: str,
+) -> None:
+    if not reactivated_zitadel_user:
+        return
+    try:
+        await zitadel.deactivate_user(zitadel_user_id, settings.zitadel_portal_org_id)
+    except Exception:
+        _slog.exception(
+            "invite_reactivated_zitadel_restore_failed",
+            zitadel_user_id=zitadel_user_id,
+            email=email,
+            org_id=org_id,
+            failure_step=failure_step,
+        )
+
+
+async def _persist_invited_user_and_send_code(
+    *,
+    db: AsyncSession,
+    org: PortalOrg,
+    body: InviteRequest,
+    zitadel_user_id: str,
+    user_row: PortalUser,
+    reactivated_membership: PortalUser | None,
+    invite_url_template: str,
+    cleanup_zitadel_user: CleanupInviteUser,
+) -> None:
+    from app.services.default_knowledge_bases import create_default_personal_kb
+
+    failure_step = "portal_db"
+    reactivated_zitadel_user = False
+    try:
+        if reactivated_membership is None:
+            db.add(user_row)
+        await create_default_personal_kb(zitadel_user_id, org.id, db)
+        if reactivated_membership is not None:
+            failure_step = "zitadel_reactivate"
+            await zitadel.unlock_user(zitadel_user_id, settings.zitadel_portal_org_id)
+            reactivated_zitadel_user = True
+        failure_step = "invite_mail"
+        await zitadel.send_invite_code(zitadel_user_id, url_template=invite_url_template)
+        failure_step = "portal_commit"
+        await db.commit()
+    except Exception as exc:
+        await db.rollback()
+        await _restore_reactivated_zitadel_user_if_needed(
+            reactivated_zitadel_user=reactivated_zitadel_user,
+            zitadel_user_id=zitadel_user_id,
+            email=str(body.email),
+            org_id=org.id,
+            failure_step=failure_step,
+        )
+        await cleanup_zitadel_user(f"{failure_step}_failed")
+        _slog.exception(
+            "invite_failed_zitadel_user_cleaned_up",
+            zitadel_user_id=zitadel_user_id,
+            email=body.email,
+            org_id=org.id,
+            failure_step=failure_step,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=_invite_failure_detail(failure_step),
+        ) from exc
+
+
+async def _grant_invited_user_role(
+    *,
+    body: InviteRequest,
+    org: PortalOrg,
+    zitadel_user_id: str,
+    cleanup_zitadel_user: CleanupInviteUser,
+) -> None:
+    try:
+        zitadel_role = _ZITADEL_ROLE_BY_PORTAL_ROLE[body.role]
+    except KeyError as exc:
+        logger.exception(
+            "invite_role_not_in_mapping",
+            extra={"portal_role": body.role, "email": body.email},
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Unsupported role",
+        ) from exc
+
+    if zitadel_role is None:
+        _slog.info(
+            "invite_no_zitadel_grant",
+            org_id=org.id,
+            portal_role=body.role,
+            zitadel_user_id=zitadel_user_id,
+        )
+        return
+
+    try:
+        await zitadel.grant_user_role(
+            org_id=settings.zitadel_portal_org_id,
+            user_id=zitadel_user_id,
+            role=zitadel_role,
+        )
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == status.HTTP_409_CONFLICT:
+            _slog.info(
+                "invite_zitadel_grant_already_exists",
+                org_id=org.id,
+                portal_role=body.role,
+                zitadel_user_id=zitadel_user_id,
+            )
+            return
+        logger.exception("Role grant failed for invited user %s: %s", body.email, exc)
+        await cleanup_zitadel_user("role_grant_failed")
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"Failed to assign project role: {exc}",
+        ) from exc
+    except Exception as exc:
+        logger.exception("Role grant failed for invited user %s: %s", body.email, exc)
+        await cleanup_zitadel_user("role_grant_failed")
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"Failed to assign project role: {exc}",
+        ) from exc
 
 
 # ---------------------------------------------------------------------------
@@ -287,6 +445,7 @@ async def invite_user(
     # grep) so a future refactor cannot silently reintroduce them.
 
     zitadel_user_created = False
+    reactivated_membership: PortalUser | None = None
     try:
         user_data = await zitadel.invite_user(
             org_id=settings.zitadel_portal_org_id,
@@ -305,12 +464,14 @@ async def invite_user(
                 detail=f"Failed to invite user: {exc}",
             ) from exc
 
-        zitadel_user_id = await _reuse_existing_zitadel_user_for_invite(
+        existing_identity = await _reuse_existing_zitadel_user_for_invite(
             body=body,
             org=org,
             db=db,
             conflict_exc=exc,
         )
+        zitadel_user_id = existing_identity.user_id
+        reactivated_membership = existing_identity.membership
     except Exception as exc:
         logger.exception("User invite failed for %s: %s", body.email, exc)
         raise HTTPException(
@@ -345,61 +506,12 @@ async def invite_user(
     # authorization. v0.1 hardcoded role="org:owner" for every invite — the
     # finding #10 time-bomb. v0.5.0 keeps the admin grant as before and
     # explicitly skips the Zitadel call for non-admins.
-    try:
-        zitadel_role = _ZITADEL_ROLE_BY_PORTAL_ROLE[body.role]
-    except KeyError as exc:
-        # REQ-2.3: pydantic Literal blocks this at parse time; the runtime
-        # check exists to keep the mapping and the InviteRequest schema in
-        # lock-step. Reaching this branch means the schema added a value the
-        # mapping has not — a developer error, not a user-supplied input.
-        logger.exception(
-            "invite_role_not_in_mapping",
-            extra={"portal_role": body.role, "email": body.email},
-        )
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Unsupported role",
-        ) from exc
-
-    if zitadel_role is None:
-        # REQ-2.1 observability: structured event so the absence-of-grant is
-        # queryable in VictoriaLogs (e.g. confirm zero org:* grants land for
-        # non-admin invites in production).
-        _slog.info(
-            "invite_no_zitadel_grant",
-            org_id=org.id,
-            portal_role=body.role,
-            zitadel_user_id=zitadel_user_id,
-        )
-    else:
-        try:
-            await zitadel.grant_user_role(
-                org_id=settings.zitadel_portal_org_id,
-                user_id=zitadel_user_id,
-                role=zitadel_role,
-            )
-        except httpx.HTTPStatusError as exc:
-            if exc.response.status_code == status.HTTP_409_CONFLICT:
-                _slog.info(
-                    "invite_zitadel_grant_already_exists",
-                    org_id=org.id,
-                    portal_role=body.role,
-                    zitadel_user_id=zitadel_user_id,
-                )
-            else:
-                logger.exception("Role grant failed for invited user %s: %s", body.email, exc)
-                await _cleanup_zitadel_user("role_grant_failed")
-                raise HTTPException(
-                    status_code=status.HTTP_502_BAD_GATEWAY,
-                    detail=f"Failed to assign project role: {exc}",
-                ) from exc
-        except Exception as exc:
-            logger.exception("Role grant failed for invited user %s: %s", body.email, exc)
-            await _cleanup_zitadel_user("role_grant_failed")
-            raise HTTPException(
-                status_code=status.HTTP_502_BAD_GATEWAY,
-                detail=f"Failed to assign project role: {exc}",
-            ) from exc
+    await _grant_invited_user_role(
+        body=body,
+        org=org,
+        zitadel_user_id=zitadel_user_id,
+        cleanup_zitadel_user=_cleanup_zitadel_user,
+    )
 
     # SPEC-PORTAL-PRICING-PER-USER-001 v0.5.0: account-type is DERIVED
     # from role server-side. The Phase 2 ``body.seat_type`` override
@@ -411,13 +523,22 @@ async def invite_user(
 
     seat_type_value = str(suggest_seat(body.role))
 
-    user_row = PortalUser(
-        zitadel_user_id=zitadel_user_id,
-        org_id=org.id,
-        role=body.role,
-        seat_type=seat_type_value,
-        preferred_language=body.preferred_language,
-    )
+    reactivated_old_role: str | None = None
+    if reactivated_membership is None:
+        user_row = PortalUser(
+            zitadel_user_id=zitadel_user_id,
+            org_id=org.id,
+            role=body.role,
+            seat_type=seat_type_value,
+            preferred_language=body.preferred_language,
+        )
+    else:
+        reactivated_old_role = reactivated_membership.role
+        reactivated_membership.status = "active"
+        reactivated_membership.role = body.role
+        reactivated_membership.seat_type = seat_type_value
+        reactivated_membership.preferred_language = body.preferred_language
+        user_row = reactivated_membership
 
     # SPEC-PORTAL-RBAC-001: products are derived from (role, seat_type,
     # platform_unlocked_features) at read time; no per-user entitlement
@@ -434,41 +555,22 @@ async def invite_user(
     # with the same email address. The invite mail is intentionally sent only
     # after both portal rows have flushed, so validation/RLS failures surface
     # before an activation link leaves the system.
-    from app.services.default_knowledge_bases import create_default_personal_kb
-
     # SPEC-PORTAL-AUTH-EMAIL-LINKS-001 REQ-2: the user now exists in Zitadel
     # and any admin grant has succeeded, but no invite mail was sent
     # (invite_user used sendCodes=False). Issue the invite code with an
     # explicit Klai urlTemplate so the activation link lands on
     # my.getklai.com/password/set, not auth.getklai.com/ui/login/.
     invite_url_template = build_url_template(AuthLinkRoute.PASSWORD_SET)
-    failure_step = "portal_db"
-    try:
-        db.add(user_row)
-        await create_default_personal_kb(zitadel_user_id, org.id, db)
-        failure_step = "invite_mail"
-        await zitadel.send_invite_code(zitadel_user_id, url_template=invite_url_template)
-        failure_step = "portal_commit"
-        await db.commit()
-    except Exception as exc:
-        await db.rollback()
-        await _cleanup_zitadel_user(f"{failure_step}_failed")
-        _slog.exception(
-            "invite_failed_zitadel_user_cleaned_up",
-            zitadel_user_id=zitadel_user_id,
-            email=body.email,
-            org_id=org.id,
-            failure_step=failure_step,
-        )
-        detail = (
-            "Uitnodigingsmail kon niet worden verstuurd. Probeer het opnieuw."
-            if failure_step == "invite_mail"
-            else "Uitnodiging kon niet worden opgeslagen. Probeer het opnieuw."
-        )
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=detail,
-        ) from exc
+    await _persist_invited_user_and_send_code(
+        db=db,
+        org=org,
+        body=body,
+        zitadel_user_id=zitadel_user_id,
+        user_row=user_row,
+        reactivated_membership=reactivated_membership,
+        invite_url_template=invite_url_template,
+        cleanup_zitadel_user=_cleanup_zitadel_user,
+    )
     # SPEC-PORTAL-AUTH-EMAIL-LINKS-001 REQ-8: emit url_template_host so a
     # VictoriaLogs query can prove the link host across all invites.
     _slog.info(
@@ -491,13 +593,32 @@ async def invite_user(
         source="portal_admin_invite",
     )
 
+    if reactivated_membership is not None and reactivated_old_role != body.role:
+        try:
+            await _sync_zitadel_role_grant(
+                zitadel_user_id,
+                old_role=reactivated_old_role or "",
+                new_role=body.role,
+            )
+        except Exception:
+            _slog.exception(
+                "invite_reactivated_user_zitadel_role_sync_failed",
+                zitadel_user_id=zitadel_user_id,
+                org_id=org.id,
+                old_role=reactivated_old_role,
+                new_role=body.role,
+            )
+
+    if zitadel_user_created:
+        message = f"Uitnodiging verstuurd naar {body.email}."
+    elif reactivated_membership is not None:
+        message = f"Gebruiker {body.email} opnieuw uitgenodigd."
+    else:
+        message = f"Gebruiker {body.email} toegevoegd aan deze workspace."
+
     return InviteResponse(
         user_id=zitadel_user_id,
-        message=(
-            f"Uitnodiging verstuurd naar {body.email}."
-            if zitadel_user_created
-            else f"Gebruiker {body.email} toegevoegd aan deze workspace."
-        ),
+        message=message,
     )
 
 
@@ -709,9 +830,13 @@ async def resend_invite(
             PortalUser.org_id == perms.org_id,
         )
     )
-    if not result.scalar_one_or_none():
+    user = result.scalar_one_or_none()
+    if not user:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
+    reactivating_offboarded = user.status == "offboarded"
+    failure_step = "invite_mail"
+    reactivated_zitadel_user = False
     try:
         # SPEC-PORTAL-AUTH-EMAIL-LINKS-001 REQ-3: replaces the legacy
         # resend_init_mail. Same v2 endpoint, but with an explicit Klai
@@ -719,11 +844,37 @@ async def resend_invite(
         # per-user url_template cache (a previous Zitadel-default URL would
         # otherwise persist).
         invite_url_template = build_url_template(AuthLinkRoute.PASSWORD_SET)
+        if reactivating_offboarded:
+            from app.services.default_knowledge_bases import create_default_personal_kb
+
+            failure_step = "portal_db"
+            user.status = "active"
+            await create_default_personal_kb(zitadel_user_id, perms.org_id, db)
+            failure_step = "zitadel_reactivate"
+            await zitadel.unlock_user(zitadel_user_id, settings.zitadel_portal_org_id)
+            reactivated_zitadel_user = True
+            failure_step = "invite_mail"
         await zitadel.send_invite_code(zitadel_user_id, url_template=invite_url_template)
+        if reactivating_offboarded:
+            failure_step = "portal_commit"
+            await db.commit()
     except Exception as exc:
+        if reactivating_offboarded:
+            await db.rollback()
+            await _restore_reactivated_zitadel_user_if_needed(
+                reactivated_zitadel_user=reactivated_zitadel_user,
+                zitadel_user_id=zitadel_user_id,
+                email=getattr(user, "email", "") or "",
+                org_id=perms.org_id,
+                failure_step=failure_step,
+            )
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=f"Failed to resend invitation: {exc}",
+            detail=(
+                _invite_failure_detail(failure_step)
+                if reactivating_offboarded
+                else f"Failed to resend invitation: {exc}"
+            ),
         ) from exc
 
     # SPEC-PORTAL-AUTH-EMAIL-LINKS-001 REQ-8: same observability field on resend.
@@ -732,6 +883,7 @@ async def resend_invite(
         zitadel_user_id=zitadel_user_id,
         org_id=perms.org_id,
         url_template_host=urlparse(invite_url_template).netloc,
+        reactivated_offboarded=reactivating_offboarded,
     )
     return MessageResponse(message="Invitation resent.")
 

--- a/klai-portal/backend/tests/test_admin_users.py
+++ b/klai-portal/backend/tests/test_admin_users.py
@@ -412,6 +412,131 @@ async def test_invite_user_existing_global_user_already_in_workspace_returns_409
 
 
 @pytest.mark.asyncio
+async def test_invite_user_reactivates_offboarded_workspace_member() -> None:
+    """Offboarded members can be invited again with a fresh invite code."""
+    from app.api.admin.users import InviteRequest, invite_user
+
+    org = MagicMock()
+    org.id = 101
+    org.plan = "knowledge"
+
+    locked_org_result = MagicMock()
+    locked_org_result.scalar_one.return_value = org
+    offboarded_member = MagicMock()
+    offboarded_member.status = "offboarded"
+    offboarded_member.role = "admin"
+    membership_result = MagicMock()
+    membership_result.scalar_one_or_none.return_value = offboarded_member
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(side_effect=[locked_org_result, membership_result])
+    mock_db.add = MagicMock()
+
+    body = InviteRequest(
+        email="returning@example.com",
+        first_name="Returning",
+        last_name="User",
+        role="company",
+        preferred_language="nl",
+    )
+    perms = make_perms(role="admin", user_id="admin-1", org_id=101, plan="knowledge")
+    call_order: list[str] = []
+
+    async def _record_unlock(*_args, **_kwargs):
+        call_order.append("unlock")
+
+    async def _record_send_invite(*_args, **_kwargs):
+        call_order.append("send_invite")
+
+    async def _record_commit(*_args, **_kwargs):
+        call_order.append("commit")
+
+    mock_db.commit = AsyncMock(side_effect=_record_commit)
+
+    with (
+        patch("app.api.admin.users.zitadel") as mock_zitadel,
+        patch(
+            "app.services.default_knowledge_bases.create_default_personal_kb",
+            new=AsyncMock(),
+        ) as create_personal_kb,
+        patch("app.api.admin.users._sync_zitadel_role_grant", new=AsyncMock()) as sync_role,
+    ):
+        mock_zitadel.invite_user = AsyncMock(side_effect=_http_error(409))
+        mock_zitadel.find_user_id_by_email = AsyncMock(return_value="returning-user")
+        mock_zitadel.grant_user_role = AsyncMock()
+        mock_zitadel.unlock_user = AsyncMock(side_effect=_record_unlock)
+        mock_zitadel.send_invite_code = AsyncMock(side_effect=_record_send_invite)
+        mock_zitadel.deactivate_user = AsyncMock()
+        mock_zitadel.remove_user = AsyncMock()
+
+        response = await invite_user(body=body, perms=perms, db=mock_db)
+
+    assert response.user_id == "returning-user"
+    assert response.message == "Gebruiker returning@example.com opnieuw uitgenodigd."
+    assert offboarded_member.status == "active"
+    assert offboarded_member.role == "company"
+    assert offboarded_member.seat_type == "chat"
+    assert offboarded_member.preferred_language == "nl"
+    assert call_order == ["unlock", "send_invite", "commit"]
+    mock_db.add.assert_not_called()
+    create_personal_kb.assert_awaited_once_with("returning-user", 101, mock_db)
+    mock_zitadel.unlock_user.assert_awaited_once()
+    mock_zitadel.send_invite_code.assert_awaited_once_with("returning-user", url_template=ANY)
+    mock_zitadel.deactivate_user.assert_not_awaited()
+    sync_role.assert_awaited_once_with("returning-user", old_role="admin", new_role="company")
+
+
+@pytest.mark.asyncio
+async def test_resend_invite_reactivates_offboarded_workspace_member() -> None:
+    """The users-table resend action must also recover offboarded members."""
+    from app.api.admin.users import resend_invite
+
+    offboarded_member = MagicMock()
+    offboarded_member.status = "offboarded"
+    offboarded_member.email = "returning@example.com"
+    user_result = MagicMock()
+    user_result.scalar_one_or_none.return_value = offboarded_member
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(return_value=user_result)
+    call_order: list[str] = []
+
+    async def _record_unlock(*_args, **_kwargs):
+        call_order.append("unlock")
+
+    async def _record_send_invite(*_args, **_kwargs):
+        call_order.append("send_invite")
+
+    async def _record_commit(*_args, **_kwargs):
+        call_order.append("commit")
+
+    mock_db.commit = AsyncMock(side_effect=_record_commit)
+
+    with (
+        patch("app.api.admin.users.zitadel") as mock_zitadel,
+        patch(
+            "app.services.default_knowledge_bases.create_default_personal_kb",
+            new=AsyncMock(),
+        ) as create_personal_kb,
+    ):
+        mock_zitadel.unlock_user = AsyncMock(side_effect=_record_unlock)
+        mock_zitadel.send_invite_code = AsyncMock(side_effect=_record_send_invite)
+        mock_zitadel.deactivate_user = AsyncMock()
+
+        response = await resend_invite(
+            zitadel_user_id="returning-user",
+            perms=make_perms(role="admin", user_id="admin-1", org_id=101),
+            db=mock_db,
+        )
+
+    assert response.message == "Invitation resent."
+    assert offboarded_member.status == "active"
+    assert call_order == ["unlock", "send_invite", "commit"]
+    create_personal_kb.assert_awaited_once_with("returning-user", 101, mock_db)
+    mock_zitadel.deactivate_user.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_invite_user_treats_existing_admin_grant_as_success() -> None:
     """Zitadel may report an existing org:owner grant for reused/admin identities; invite stays idempotent."""
     from app.api.admin.users import InviteRequest, invite_user

--- a/klai-portal/backend/tests/test_platform_admin_manage.py
+++ b/klai-portal/backend/tests/test_platform_admin_manage.py
@@ -249,6 +249,9 @@ async def test_platform_invite_mail_failure_keeps_committed_portal_user() -> Non
 
     db = AsyncMock()
     db.add = MagicMock()
+    membership_result = MagicMock()
+    membership_result.scalar_one_or_none.return_value = None
+    db.execute = AsyncMock(return_value=membership_result)
     org = _org()
     with (
         patch("app.api.admin.platform_manage._load_org_or_404", new=AsyncMock(return_value=org)),
@@ -276,6 +279,112 @@ async def test_platform_invite_mail_failure_keeps_committed_portal_user() -> Non
     db.commit.assert_awaited_once()
     zitadel.remove_user.assert_not_awaited()
     assert "invite-mail kon niet worden verstuurd" in response.message
+
+
+@pytest.mark.asyncio
+async def test_platform_invite_reuses_existing_global_identity() -> None:
+    from app.api.admin.platform_manage import PlatformInviteRequest, platform_invite
+
+    db = AsyncMock()
+    db.add = MagicMock()
+    membership_result = MagicMock()
+    membership_result.scalar_one_or_none.return_value = None
+    db.execute = AsyncMock(return_value=membership_result)
+    org = _org()
+
+    with (
+        patch("app.api.admin.platform_manage._load_org_or_404", new=AsyncMock(return_value=org)),
+        patch("app.api.admin.platform_manage.tenant_scoped_session", return_value=AsyncContext(db)),
+        patch("app.api.admin.platform_manage.create_default_personal_kb", new=AsyncMock()),
+        patch("app.api.admin.platform_manage.log_event", new=AsyncMock()),
+        patch("app.api.admin.platform_manage.zitadel") as zitadel,
+    ):
+        zitadel.invite_user = AsyncMock(side_effect=_http_error(409))
+        zitadel.find_user_id_by_email = AsyncMock(return_value="existing-user")
+        zitadel.grant_user_role = AsyncMock()
+        zitadel.send_invite_code = AsyncMock()
+        zitadel.remove_user = AsyncMock()
+
+        response = await platform_invite(
+            org_id=42,
+            body=PlatformInviteRequest(
+                email="existing@example.com",
+                first_name="Existing",
+                last_name="User",
+                role="company",
+            ),
+            perms=_platform_perms(),
+        )
+
+    zitadel.find_user_id_by_email.assert_awaited_once_with("existing@example.com")
+    zitadel.remove_user.assert_not_awaited()
+    db.add.assert_called_once()
+    db.commit.assert_awaited_once()
+    assert response.user_id == "existing-user"
+
+
+@pytest.mark.asyncio
+async def test_platform_invite_reactivates_offboarded_tenant_member() -> None:
+    from app.api.admin.platform_manage import PlatformInviteRequest, platform_invite
+
+    offboarded_member = _user(role="admin")
+    offboarded_member.status = "offboarded"
+    membership_result = MagicMock()
+    membership_result.scalar_one_or_none.return_value = offboarded_member
+    db = AsyncMock()
+    db.add = MagicMock()
+    db.execute = AsyncMock(return_value=membership_result)
+    org = _org()
+    call_order: list[str] = []
+
+    async def _record_unlock(*_args, **_kwargs):
+        call_order.append("unlock")
+
+    async def _record_send_invite(*_args, **_kwargs):
+        call_order.append("send_invite")
+
+    async def _record_commit(*_args, **_kwargs):
+        call_order.append("commit")
+
+    db.commit = AsyncMock(side_effect=_record_commit)
+
+    with (
+        patch("app.api.admin.platform_manage._load_org_or_404", new=AsyncMock(return_value=org)),
+        patch("app.api.admin.platform_manage.tenant_scoped_session", return_value=AsyncContext(db)),
+        patch("app.api.admin.platform_manage.create_default_personal_kb", new=AsyncMock()) as create_personal_kb,
+        patch("app.api.admin.platform_manage._sync_zitadel_role_grant", new=AsyncMock()) as sync_role,
+        patch("app.api.admin.platform_manage.log_event", new=AsyncMock()),
+        patch("app.api.admin.platform_manage.zitadel") as zitadel,
+    ):
+        zitadel.invite_user = AsyncMock(side_effect=_http_error(409))
+        zitadel.find_user_id_by_email = AsyncMock(return_value="target-user")
+        zitadel.grant_user_role = AsyncMock()
+        zitadel.unlock_user = AsyncMock(side_effect=_record_unlock)
+        zitadel.send_invite_code = AsyncMock(side_effect=_record_send_invite)
+        zitadel.remove_user = AsyncMock()
+        zitadel.deactivate_user = AsyncMock()
+
+        response = await platform_invite(
+            org_id=42,
+            body=PlatformInviteRequest(
+                email="returning@example.com",
+                first_name="Returning",
+                last_name="User",
+                role="company",
+            ),
+            perms=_platform_perms(),
+        )
+
+    assert response.user_id == "target-user"
+    assert offboarded_member.status == "active"
+    assert offboarded_member.role == "company"
+    assert offboarded_member.seat_type == "chat"
+    assert call_order == ["unlock", "commit", "send_invite"]
+    db.add.assert_not_called()
+    create_personal_kb.assert_awaited_once_with("target-user", 42, db)
+    sync_role.assert_awaited_once_with("target-user", old_role="admin", new_role="company")
+    zitadel.remove_user.assert_not_awaited()
+    zitadel.deactivate_user.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/klai-portal/frontend/src/routes/admin/users/__tests__/index.test.tsx
+++ b/klai-portal/frontend/src/routes/admin/users/__tests__/index.test.tsx
@@ -112,6 +112,18 @@ const usersResponse = {
       created_at: '2026-05-02T00:00:00Z',
       invite_pending: true,
     },
+    {
+      zitadel_user_id: 'u3',
+      email: 'cleo@example.com',
+      first_name: 'Cleo',
+      last_name: 'Offboarded',
+      role: 'company',
+      seat_type: 'chat',
+      status: 'offboarded',
+      preferred_language: 'en',
+      created_at: '2026-05-03T00:00:00Z',
+      invite_pending: false,
+    },
   ],
 }
 
@@ -143,7 +155,8 @@ describe('Admin users index', () => {
     })
 
     expect(screen.getByText('Bob Builder')).toBeTruthy()
-    expect(screen.getByText('2 users')).toBeTruthy()
+    expect(screen.getByText('Cleo Offboarded')).toBeTruthy()
+    expect(screen.getByText('3 users')).toBeTruthy()
 
     fireEvent.change(screen.getByLabelText('Search users'), {
       target: { value: 'bob@' },
@@ -151,6 +164,37 @@ describe('Admin users index', () => {
 
     expect(screen.queryByText('Ada Lovelace')).toBeNull()
     expect(screen.getByText('Bob Builder')).toBeTruthy()
+  })
+
+  it('allows resending invites for active and offboarded users', async () => {
+    renderUsersPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Ada Lovelace')).toBeTruthy()
+    })
+
+    const resendButtons = screen.getAllByLabelText('Resend invite')
+    expect(resendButtons).toHaveLength(3)
+
+    fireEvent.click(resendButtons[0])
+    fireEvent.click(resendButtons[2])
+
+    await waitFor(() => {
+      expect(
+        apiFetchMock.mock.calls.some(
+          ([url, options]) =>
+            url === '/api/admin/users/u1/resend-invite' &&
+            (options as { method?: string } | undefined)?.method === 'POST',
+        ),
+      ).toBe(true)
+      expect(
+        apiFetchMock.mock.calls.some(
+          ([url, options]) =>
+            url === '/api/admin/users/u3/resend-invite' &&
+            (options as { method?: string } | undefined)?.method === 'POST',
+        ),
+      ).toBe(true)
+    })
   })
 
   it('keeps delete available only for pending invites and calls the delete endpoint after confirmation', async () => {

--- a/klai-portal/frontend/src/routes/admin/users/_components/UserActions.tsx
+++ b/klai-portal/frontend/src/routes/admin/users/_components/UserActions.tsx
@@ -70,6 +70,9 @@ export function UserActions({
   const isDeleting =
     deleteMutation.isPending &&
     deleteMutation.variables?.zitadel_user_id === user.zitadel_user_id
+  const canResendInvite =
+    user.invite_pending || user.status === 'active' || user.status === 'offboarded'
+  const canOffboard = user.status === 'active' || user.status === 'suspended'
 
   return (
     <InlineDeleteConfirm
@@ -84,7 +87,7 @@ export function UserActions({
       onCancel={() => onConfirmDelete(null)}
     >
       <div className="flex items-start justify-end gap-2 mt-px">
-        {user.invite_pending && (
+        {canResendInvite && (
           <Tooltip label={m.admin_users_resend_invite()}>
             <button
               disabled={isResending}
@@ -187,14 +190,18 @@ export function UserActions({
                       {m.admin_users_action_reactivate()}
                     </DropdownMenuItem>
                   )}
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    onClick={() => onConfirmOffboard(user.zitadel_user_id)}
-                    className="text-[var(--color-destructive)]"
-                  >
-                    <UserX className="mr-2 h-4 w-4" />
-                    {m.admin_users_action_offboard()}
-                  </DropdownMenuItem>
+                  {canOffboard && (
+                    <>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        onClick={() => onConfirmOffboard(user.zitadel_user_id)}
+                        className="text-[var(--color-destructive)]"
+                      >
+                        <UserX className="mr-2 h-4 w-4" />
+                        {m.admin_users_action_offboard()}
+                      </DropdownMenuItem>
+                    </>
+                  )}
                 </>
               )}
             </DropdownMenuContent>


### PR DESCRIPTION
## Summary
- make tenant admin invite/resend recovery work for active and offboarded users
- make platform-admin invite recovery consistent with tenant-admin behavior
- add regression coverage for active/offboarded resend, existing identity reuse, and password-set recovery context

## Root cause
Invite recovery was split across several paths with different assumptions: the UI only showed resend for `invite_pending`, backend invite blocked offboarded memberships as already existing, resend did not reactivate offboarded users, and platform-admin invite did not reuse existing Zitadel identities.

## Validation
- `uv run ruff check app/api/admin/users.py app/api/admin/platform_manage.py tests/test_admin_users.py tests/test_platform_admin_manage.py`
- `uv run pytest tests/test_admin_users.py tests/test_platform_admin_manage.py tests/test_set_password_with_code_dual_flow.py tests/test_auth_password_endpoints.py -q`
- `npm test -- src/routes/admin/users/__tests__/index.test.tsx src/routes/password/__tests__/set.test.tsx`
- `git diff --check`