### PR TITLE
fix(infra): harden core backup flow

### DIFF
--- a/.github/workflows/deploy-compose.yml
+++ b/.github/workflows/deploy-compose.yml
@@ -12,7 +12,7 @@ on:
       - 'deploy/vexa/profiles.yaml'               # SPEC-INFRA-CONFIG-SYNC-001 R3 — vexa runtime-api meeting-bot profiles
       - 'deploy/librechat/klai-entrypoint.sh'     # force light theme — synced before librechat-getklai recreate
       - 'deploy/grafana/provisioning/**'          # SPEC-SEC-024 M4.2 — alert rule + dashboard
-      - 'deploy/scripts/**'                       # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3 — compose-up wrapper + audit-orphan-snapshot
+      - 'deploy/scripts/**'                       # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3 — deploy scripts synced to /opt/klai/scripts
       - 'scripts/smoke-docker-socket-proxy.sh'    # SPEC-SEC-024 M4.3 — smoke-test
       - '.github/workflows/deploy-compose.yml'
   workflow_dispatch:
@@ -84,14 +84,18 @@ jobs:
             mkdir -p /opt/klai/litellm/klai_citations
             rsync -a --delete klai-libs/citations/klai_citations/ /opt/klai/litellm/klai_citations/
 
-            # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3 + REQ-5: sync
-            # deploy-wrapper + audit scripts to /opt/klai/scripts/ so
-            # service-deploy workflows and systemd timers can use them.
+            # Sync deploy scripts to /opt/klai/scripts/ so cron jobs,
+            # service-deploy workflows, and systemd timers all run the
+            # version from this repo.
             mkdir -p /opt/klai/scripts
-            install -m 0755 deploy/scripts/compose-up.sh /opt/klai/scripts/compose-up.sh
-            install -m 0755 deploy/scripts/audit-orphan-snapshot.sh /opt/klai/scripts/audit-orphan-snapshot.sh
-            install -m 0755 deploy/scripts/docker-orphan-audit.sh /opt/klai/scripts/docker-orphan-audit.sh
-            install -m 0755 deploy/scripts/kb-citation-smoke.sh /opt/klai/scripts/kb-citation-smoke.sh
+            for script in deploy/scripts/*.sh; do
+              bash -n "$script"
+            done
+            for script in deploy/scripts/*.sh; do
+              install -m 0755 "$script" "/opt/klai/scripts/$(basename "$script")"
+            done
+            test -x /opt/klai/scripts/backup.sh
+            test -x /opt/klai/scripts/push-health.sh
 
             # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-5 + REQ-6: sync systemd
             # units. Activation requires sudo and is one-time per host —

--- a/deploy/scripts/backup.sh
+++ b/deploy/scripts/backup.sh
@@ -1,421 +1,645 @@
 #!/usr/bin/env bash
-# backup.sh — Daily backup for all stateful services on core-01
+# backup.sh - Daily backup for all stateful services on core-01.
 #
 # Inventory authority: deploy/volume-mounts.yaml (SPEC-INFRA-005).
-# Every `category: data` entry with `backup: <non-skip>` is produced here.
+# Every `category: data` entry with `backup: <non-skip>` is represented here.
 #
-# What gets backed up:
-#   1. PostgreSQL       — pg_dumpall → postgres-all.sql
-#                         (includes klai, zitadel, litellm, gitea, glitchtip)
-#   2. Gitea repos      — git repos + config → gitea-repos.tar.gz
-#                         (KB source of truth; repos are content, DB is metadata)
-#   3. MongoDB          — mongodump archive
-#   4. Redis            — BGSAVE + dump.rdb copy
-#   5. Vexa Redis       — BGSAVE + dump.rdb copy
-#   6. Meilisearch      — snapshot trigger (written to volume)
-#   7. Qdrant           — snapshot per collection via API (zero downtime)
-#   8. FalkorDB         — BGSAVE + dump.rdb copy (knowledge graph)
-#   9. Garage meta      — `garage meta snapshot` (LMDB) + tar
-#  10. Garage data      — rsync blobs (immutable once written, live-safe)
-#  11. Firecrawl PG     — pg_dumpall → firecrawl-postgres-all.sql
-#  12. Scribe audio     — tar of /data/audio (retention handled by app; backup
-#                         of `failed` recordings only, successes auto-deleted)
-#  13. Research uploads — rsync of /opt/klai/research-uploads
-#  14. Encrypt + upload — age-encrypt then rsync to Hetzner Storage Box
+# Production cron, as the `klai` user:
+#   0 2 * * * /opt/klai/scripts/backup.sh >> /opt/klai/logs/backup.log 2>&1
 #
-# Usage:
-#   Production cron (runs as `klai` user — see `sudo crontab -u klai -l`):
-#     0 2 * * * /opt/klai/scripts/backup.sh >> /opt/klai/logs/backup.log 2>&1
+# Manual production run:
+#   sudo -u klai /opt/klai/scripts/backup.sh
 #
-#   Manual run: always invoke as the `klai` user, NOT as root. Only `klai`
-#   has the SSH key registered with the Hetzner Storage Box:
-#     sudo -u klai /opt/klai/scripts/backup.sh
-#
-#   Running as root produces all local artifacts correctly but the final
-#   rsync step fails with `Permission denied (publickey,password)`.
-#
-# Required env vars (loaded from /opt/klai/.env):
-#   MONGO_ROOT_PASSWORD   — MongoDB root password
-#   REDIS_PASSWORD        — Redis password
-#   MEILI_MASTER_KEY      — Meilisearch master key
-#   QDRANT_API_KEY        — Qdrant API key (header x-api-key)
-#
-# Optional env vars (for Storage Box upload):
-#   STORAGEBOX_HOST       — e.g. uXXXXXX.your-storagebox.de
-#   STORAGEBOX_USER       — e.g. uXXXXXX
-#
-set -euo pipefail
+# Do not run as root for the real job: only `klai` has the SSH key registered
+# with the Hetzner Storage Box.
 
-BACKUP_DATE=$(date +%Y-%m-%d)
-BACKUP_DIR="/opt/klai/backups/${BACKUP_DATE}"
-COMPOSE_DIR="/opt/klai"
-LOG_PREFIX="[backup $(date '+%H:%M:%S')]"
+set -Eeuo pipefail
 
-# Load secrets from their canonical locations
-SECRETS_DIR="$COMPOSE_DIR/secrets"
-MONGO_ROOT_PASSWORD=$(cat "$SECRETS_DIR/mongo_root_password.txt")
-MEILI_MASTER_KEY=$(cat "$SECRETS_DIR/meili_master_key.txt")
-# Redis password lives in the container environment (set at container creation from .env)
-REDIS_PASSWORD=$(docker inspect klai-core-redis-1 \
-  --format '{{range .Config.Env}}{{println .}}{{end}}' \
-  | grep '^REDIS_PASSWORD=' | head -1 | cut -d'=' -f2-)
-# Qdrant API key from the same source (read from the running container — matches
-# what retrieval-api/knowledge-ingest are actually using).
-QDRANT_API_KEY=$(docker inspect klai-core-qdrant-1 \
-  --format '{{range .Config.Env}}{{println .}}{{end}}' \
-  | grep '^QDRANT__SERVICE__API_KEY=' | head -1 | cut -d'=' -f2- || true)
-# Storage Box config from .env
-_env_get() { grep "^${1}=" "$COMPOSE_DIR/.env" 2>/dev/null | head -1 | cut -d'=' -f2- || true; }
-STORAGEBOX_HOST=${STORAGEBOX_HOST:-$(_env_get STORAGEBOX_HOST)}
-STORAGEBOX_USER=${STORAGEBOX_USER:-$(_env_get STORAGEBOX_USER)}
-KUMA_TOKEN_BACKUP=${KUMA_TOKEN_BACKUP:-$(_env_get KUMA_TOKEN_BACKUP)}
+readonly BACKUP_DATE="${BACKUP_DATE:-$(date +%Y-%m-%d)}"
+readonly BACKUP_ROOT="${BACKUP_ROOT:-/opt/klai/backups}"
+readonly BACKUP_DIR="${BACKUP_DIR:-${BACKUP_ROOT}/${BACKUP_DATE}}"
+readonly COMPOSE_DIR="${COMPOSE_DIR:-/opt/klai}"
+readonly SECRETS_DIR="${SECRETS_DIR:-${COMPOSE_DIR}/secrets}"
+readonly MONGODB_NETWORK="${MONGODB_NETWORK:-klai-net-mongodb}"
+readonly QDRANT_NETWORK="${QDRANT_NETWORK:-klai-net}"
+readonly TOTAL_STEPS=16
 
-# Container-name helper. Compose prefixes names with `klai-core-` + `-1`.
-_ctr() { echo "klai-core-${1}-1"; }
-
-# ─── Uptime Kuma heartbeat ────────────────────────────────────────────────────
-# Push on success (at end of script). Push failure on EXIT with non-zero code.
-_kuma_push() {
-  local status="$1" msg="$2"
-  [ -z "${KUMA_TOKEN_BACKUP:-}" ] && return 0
-  curl -fsS --max-time 10 \
-    "https://status.getklai.com/api/push/${KUMA_TOKEN_BACKUP}?status=${status}&msg=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1]))" "${msg}")&ping=" \
-    >/dev/null 2>&1 || true
-}
-# On any unhandled error: push failure before exiting
-trap '_kuma_push down "Backup failed at $(date +%H:%M:%S)"' ERR
-
-echo ""
-echo "${LOG_PREFIX} ============================================"
-echo "${LOG_PREFIX} Starting backup: ${BACKUP_DATE}"
-echo "${LOG_PREFIX} ============================================"
-
-mkdir -p "$BACKUP_DIR"
-cd "$COMPOSE_DIR"
-
-# ─── PostgreSQL ───────────────────────────────────────────────────────────────
-echo ""
-echo "${LOG_PREFIX} [1/13] PostgreSQL: dumping all databases..."
-docker compose exec -T postgres pg_dumpall -U klai > "$BACKUP_DIR/postgres-all.sql"
-echo "${LOG_PREFIX}       Size: $(du -sh "$BACKUP_DIR/postgres-all.sql" | cut -f1)"
-
-# ─── Gitea ────────────────────────────────────────────────────────────────────
-# PRIMARY DATA: git repos are the source of truth for all knowledge base content.
-# DB is already in PostgreSQL (pg_dumpall above). We only need the repo files + config.
-# Uses docker run with --volumes-from to read the volume as non-root alpine.
-echo ""
-echo "${LOG_PREFIX} [2/13] Gitea: backing up repositories and config..."
-docker run --rm \
-  --volumes-from klai-core-gitea-1:ro \
-  -v "$BACKUP_DIR:/backup" \
-  alpine tar -czf /backup/gitea-repos.tar.gz -C /data git/repositories gitea/conf
-echo "${LOG_PREFIX}       Size: $(du -sh "$BACKUP_DIR/gitea-repos.tar.gz" | cut -f1)"
-
-# ─── MongoDB ──────────────────────────────────────────────────────────────────
-echo ""
-echo "${LOG_PREFIX} [3/13] MongoDB: dumping all databases..."
-docker compose exec -T mongodb mongodump \
-  --username klai \
-  --password "${MONGO_ROOT_PASSWORD}" \
-  --authenticationDatabase admin \
-  --archive \
-  > "$BACKUP_DIR/mongodb-all.archive"
-echo "${LOG_PREFIX}       Size: $(du -sh "$BACKUP_DIR/mongodb-all.archive" | cut -f1)"
-
-# ─── Redis ────────────────────────────────────────────────────────────────────
-echo ""
-echo "${LOG_PREFIX} [4/13] Redis: triggering BGSAVE and copying dump..."
-docker compose exec -T redis redis-cli -a "${REDIS_PASSWORD}" --no-auth-warning BGSAVE
-sleep 3
-docker compose cp redis:/data/dump.rdb "$BACKUP_DIR/redis-dump.rdb"
-echo "${LOG_PREFIX}       Size: $(du -sh "$BACKUP_DIR/redis-dump.rdb" | cut -f1)"
-
-# ─── Vexa Redis ───────────────────────────────────────────────────────────────
-# Vexa's own Redis holds transcription pipeline state. Separate volume from
-# the shared Redis; lose it = a transcription batch is re-queued from scratch.
-echo ""
-echo "${LOG_PREFIX} [5/13] Vexa Redis: BGSAVE + dump copy..."
-if docker ps --format '{{.Names}}' | grep -q "^$(_ctr vexa-redis)$"; then
-  docker exec "$(_ctr vexa-redis)" redis-cli BGSAVE >/dev/null
-  sleep 3
-  docker cp "$(_ctr vexa-redis):/data/dump.rdb" "$BACKUP_DIR/vexa-redis-dump.rdb"
-  echo "${LOG_PREFIX}       Size: $(du -sh "$BACKUP_DIR/vexa-redis-dump.rdb" | cut -f1)"
-else
-  echo "${LOG_PREFIX}       Skipped (container not running)"
-fi
-
-# ─── Meilisearch ──────────────────────────────────────────────────────────────
-# Snapshots are written to /meili_data/snapshots/ inside the meilisearch-data volume.
-# Meilisearch indexes rebuild from MongoDB automatically — snapshot is a nice-to-have.
-echo ""
-echo "${LOG_PREFIX} [6/13] Meilisearch: creating snapshot..."
-SNAPSHOT_RESPONSE=$(docker compose exec -T meilisearch \
-  wget -qO- --post-data="" \
-  --header="Authorization: Bearer ${MEILI_MASTER_KEY}" \
-  http://127.0.0.1:7700/snapshots 2>/dev/null || echo '{"error":"snapshot failed"}')
-echo "${LOG_PREFIX}       Response: $SNAPSHOT_RESPONSE"
-
-# ─── Qdrant ───────────────────────────────────────────────────────────────────
-# Zero-downtime snapshot via API. One snapshot file per collection, written
-# inside the qdrant-data volume (/qdrant/storage/snapshots/<collection>/).
-#
-# The qdrant image itself is distroless — no wget/curl/python inside — so we
-# use an alpine sidecar on the klai-net network to speak the HTTP API.
-echo ""
-echo "${LOG_PREFIX} [7/13] Qdrant: snapshotting collections via API..."
-QDRANT_CONTAINER="$(_ctr qdrant)"
-_qdrant_api() {
-  # Usage: _qdrant_api <method> <path>
-  # Emits raw JSON on stdout, "" on failure.
-  local method="$1" path="$2"
-  local flags=()
-  case "${method}" in
-    GET)    : ;;
-    POST)   flags=(-X POST -d "") ;;
-    DELETE) flags=(-X DELETE) ;;
-    *)      echo "unknown method: ${method}" >&2; return 1 ;;
-  esac
-  docker run --rm --network klai-net curlimages/curl:8.11.1 \
-    -sSf --max-time 30 \
-    "${flags[@]}" \
-    -H "api-key: ${QDRANT_API_KEY}" \
-    "http://${QDRANT_CONTAINER}:6333${path}" 2>/dev/null || echo ""
-}
-if docker ps --format '{{.Names}}' | grep -q "^${QDRANT_CONTAINER}$"; then
-  COLLECTIONS_JSON=$(_qdrant_api GET /collections)
-  COLLECTIONS=$(echo "${COLLECTIONS_JSON}" | python3 -c "
-import json, sys
-try:
-    data = json.load(sys.stdin)
-    print('\n'.join(c['name'] for c in data.get('result', {}).get('collections', [])))
-except Exception:
-    pass
-" 2>/dev/null || echo "")
-  if [ -z "${COLLECTIONS}" ]; then
-    echo "${LOG_PREFIX}       No collections found (or API unreachable)" >&2
-  else
-    for col in ${COLLECTIONS}; do
-      # 1. Trigger snapshot creation. Qdrant writes it to an internal location
-      #    and returns the snapshot's name.
-      RESP=$(_qdrant_api POST "/collections/${col}/snapshots")
-      SNAP_NAME=$(echo "${RESP}" | python3 -c "
-import json, sys
-try:
-    print(json.load(sys.stdin).get('result', {}).get('name', ''))
-except Exception:
-    pass
-" 2>/dev/null || echo "")
-      if [ -z "${SNAP_NAME}" ]; then
-        echo "${LOG_PREFIX}       ${col} — snapshot API returned no name: ${RESP}" >&2
-        continue
-      fi
-      # 2. Download the snapshot via the same URL path (Qdrant v1 serves it on
-      #    GET). Writing to BACKUP_DIR via a mounted volume so the bytes land
-      #    on the host, not inside the sidecar container.
-      # --user 0:0: curl image's default 1001 can't write to the host-owned
-      # backup dir. We're already running as root in cron context.
-      if docker run --rm --network klai-net \
-           --user 0:0 \
-           -v "$BACKUP_DIR:/out" \
-           curlimages/curl:8.11.1 \
-           -sSfL --max-time 300 \
-           -H "api-key: ${QDRANT_API_KEY}" \
-           "http://${QDRANT_CONTAINER}:6333/collections/${col}/snapshots/${SNAP_NAME}" \
-           -o "/out/qdrant-${col}.snapshot" 2>/dev/null
-      then
-        echo "${LOG_PREFIX}       ${col} → $(du -sh "$BACKUP_DIR/qdrant-${col}.snapshot" | cut -f1)"
-      else
-        echo "${LOG_PREFIX}       ${col} — snapshot download failed" >&2
-        rm -f "$BACKUP_DIR/qdrant-${col}.snapshot"
-      fi
-      # 3. Clean up the snapshot on Qdrant's side (don't let them pile up).
-      _qdrant_api DELETE "/collections/${col}/snapshots/${SNAP_NAME}" >/dev/null || true
-    done
-  fi
-else
-  echo "${LOG_PREFIX}       Skipped (container not running)"
-fi
-
-# ─── FalkorDB ─────────────────────────────────────────────────────────────────
-# Redis-protocol BGSAVE writes dump.rdb to /var/lib/falkordb/data/dump.rdb
-# (post SPEC-INFRA-005 the host bind mount is correct). No auth on FalkorDB
-# — it's on klai-net only, no external exposure.
-echo ""
-echo "${LOG_PREFIX} [8/13] FalkorDB: BGSAVE + dump copy (knowledge graph)..."
-FALKORDB_CONTAINER="$(_ctr falkordb)"
-if docker ps --format '{{.Names}}' | grep -q "^${FALKORDB_CONTAINER}$"; then
-  docker exec "${FALKORDB_CONTAINER}" redis-cli BGSAVE >/dev/null
-  sleep 3
-  docker cp "${FALKORDB_CONTAINER}:/var/lib/falkordb/data/dump.rdb" \
-    "$BACKUP_DIR/falkordb-dump.rdb"
-  echo "${LOG_PREFIX}       Size: $(du -sh "$BACKUP_DIR/falkordb-dump.rdb" | cut -f1)"
-else
-  echo "${LOG_PREFIX}       Skipped (container not running)"
-fi
-
-# ─── Garage metadata ──────────────────────────────────────────────────────────
-# `garage meta snapshot` writes a consistent LMDB snapshot under
-# /var/lib/garage/meta/snapshots/ while the service keeps running (Garage
-# v0.9.4+). We tar the snapshot dir itself rather than the live LMDB file.
-echo ""
-echo "${LOG_PREFIX} [9/13] Garage: metadata snapshot..."
-GARAGE_CONTAINER="$(_ctr garage)"
-if docker ps --format '{{.Names}}' | grep -q "^${GARAGE_CONTAINER}$"; then
-  SNAP_OUT=$(docker exec "${GARAGE_CONTAINER}" /garage meta snapshot 2>&1 || echo 'snapshot-failed')
-  echo "${LOG_PREFIX}       ${SNAP_OUT}"
-  # Copy the most recent snapshot subdirectory out via volumes-from.
-  docker run --rm \
-    --volumes-from "${GARAGE_CONTAINER}:ro" \
-    -v "$BACKUP_DIR:/backup" \
-    alpine sh -c '
-      latest=$(ls -1td /var/lib/garage/meta/snapshots/*/ 2>/dev/null | head -1)
-      if [ -n "${latest}" ]; then
-        tar -czf /backup/garage-meta.tar.gz -C "${latest}" . && echo "tar OK"
-      else
-        echo "no snapshot dir found" >&2; exit 1
-      fi
-    '
-  echo "${LOG_PREFIX}       Size: $(du -sh "$BACKUP_DIR/garage-meta.tar.gz" 2>/dev/null | cut -f1 || echo '—')"
-else
-  echo "${LOG_PREFIX}       Skipped (container not running)"
-fi
-
-# ─── Garage data (blobs) ──────────────────────────────────────────────────────
-# Blobs are immutable content-addressed files — rsync while live is safe.
-# Bind mount at /opt/klai/garage-data, tar via sibling container so we don't
-# shell-out to host tar (which would fight file ownership — garage runs root).
-echo ""
-echo "${LOG_PREFIX} [10/13] Garage: data (blob) tar..."
-if [ -d /opt/klai/garage-data ]; then
-  docker run --rm \
-    -v /opt/klai/garage-data:/data:ro \
-    -v "$BACKUP_DIR:/backup" \
-    alpine tar -czf /backup/garage-data.tar.gz -C /data .
-  echo "${LOG_PREFIX}       Size: $(du -sh "$BACKUP_DIR/garage-data.tar.gz" | cut -f1)"
-else
-  echo "${LOG_PREFIX}       Skipped (no /opt/klai/garage-data)"
-fi
-
-# ─── Firecrawl PostgreSQL ─────────────────────────────────────────────────────
-# Firecrawl's Postgres uses POSTGRES_USER=firecrawl as the superuser.
-echo ""
-echo "${LOG_PREFIX} [11/13] Firecrawl Postgres: pg_dumpall..."
-if docker ps --format '{{.Names}}' | grep -q "^$(_ctr firecrawl-postgres)$"; then
-  if docker exec "$(_ctr firecrawl-postgres)" pg_dumpall -U firecrawl \
-       > "$BACKUP_DIR/firecrawl-postgres-all.sql" 2>/dev/null; then
-    echo "${LOG_PREFIX}       Size: $(du -sh "$BACKUP_DIR/firecrawl-postgres-all.sql" | cut -f1)"
-  else
-    rm -f "$BACKUP_DIR/firecrawl-postgres-all.sql"
-    echo "${LOG_PREFIX}       pg_dumpall failed — skipping"
-  fi
-else
-  echo "${LOG_PREFIX}       Skipped (container not running)"
-fi
-
-# ─── Scribe audio (Vexa transcription recordings) ─────────────────────────────
-# Retention is event-driven (deleted on successful transcription). At rest
-# this volume holds only `failed` recordings awaiting retry. Small tar.
-echo ""
-echo "${LOG_PREFIX} [12/13] Scribe audio: tar of failed-retry recordings..."
-if docker ps --format '{{.Names}}' | grep -q "^$(_ctr scribe-api)$"; then
-  docker run --rm \
-    --volumes-from "$(_ctr scribe-api):ro" \
-    -v "$BACKUP_DIR:/backup" \
-    alpine tar -czf /backup/scribe-audio.tar.gz -C /data/audio . 2>/dev/null \
-    || true
-  if [ -s "$BACKUP_DIR/scribe-audio.tar.gz" ]; then
-    echo "${LOG_PREFIX}       Size: $(du -sh "$BACKUP_DIR/scribe-audio.tar.gz" | cut -f1)"
-  else
-    rm -f "$BACKUP_DIR/scribe-audio.tar.gz"
-    echo "${LOG_PREFIX}       Empty (no retained recordings — good)"
-  fi
-else
-  echo "${LOG_PREFIX}       Skipped (container not running)"
-fi
-
-# ─── Research uploads (user-uploaded notebook sources) ────────────────────────
-# Bind-mount on host — rsync directly, no docker involved.
-echo ""
-echo "${LOG_PREFIX} [13/13] Research uploads: rsync of /opt/klai/research-uploads..."
-if [ -d /opt/klai/research-uploads ]; then
-  rsync -a --delete /opt/klai/research-uploads/ "$BACKUP_DIR/research-uploads/"
-  echo "${LOG_PREFIX}       Size: $(du -sh "$BACKUP_DIR/research-uploads" | cut -f1)"
-else
-  echo "${LOG_PREFIX}       Skipped (no /opt/klai/research-uploads)"
-fi
-
-# ─── Encrypt for remote storage (age) ───────────────────────────────────────
-# Plaintext stays local (7-day retention). Only encrypted files go to the Storage Box.
-# Both keys can decrypt: MacBook + core-01 (same keys as .sops.yaml)
-AGE_RECIPIENTS=(
+readonly AGE_RECIPIENTS=(
   "age1lyd243tsj8j7rn2wy4hdmnya99wsf2p87fpphys9k65kammerqsqnzpsur"
   "age15ztzw9vnngkdnw0pg5tn8upplglvhzkep23sm5zu86res5lcmv7syw5m4v"
 )
-ENCRYPT_DIR=$(mktemp -d)
-# Encrypt every archive artifact produced above. Loop over all matching files
-# so we don't silently skip a new backup kind when the script is extended.
-shopt -s nullglob
-for f in \
-  "$BACKUP_DIR"/postgres-all.sql \
-  "$BACKUP_DIR"/gitea-repos.tar.gz \
-  "$BACKUP_DIR"/mongodb-all.archive \
-  "$BACKUP_DIR"/redis-dump.rdb \
-  "$BACKUP_DIR"/vexa-redis-dump.rdb \
-  "$BACKUP_DIR"/qdrant-*.snapshot \
-  "$BACKUP_DIR"/falkordb-dump.rdb \
-  "$BACKUP_DIR"/garage-meta.tar.gz \
-  "$BACKUP_DIR"/garage-data.tar.gz \
-  "$BACKUP_DIR"/firecrawl-postgres-all.sql \
-  "$BACKUP_DIR"/scribe-audio.tar.gz; do
-  [ -f "$f" ] || continue
-  age -r "${AGE_RECIPIENTS[0]}" -r "${AGE_RECIPIENTS[1]}" "$f" > "$ENCRYPT_DIR/$(basename "$f").age"
-done
-# research-uploads is a directory — tar first, then encrypt.
-if [ -d "$BACKUP_DIR/research-uploads" ]; then
-  tar -czf - -C "$BACKUP_DIR" research-uploads \
-    | age -r "${AGE_RECIPIENTS[0]}" -r "${AGE_RECIPIENTS[1]}" \
-    > "$ENCRYPT_DIR/research-uploads.tar.gz.age"
-fi
-shopt -u nullglob
 
-# ─── Upload to Hetzner Storage Box ───────────────────────────────────────────
-echo ""
-if [ -n "${STORAGEBOX_HOST:-}" ] && [ -n "${STORAGEBOX_USER:-}" ]; then
-  echo "${LOG_PREFIX} [14/14] Uploading encrypted backups to Hetzner Storage Box..."
-  REMOTE_PATH="backups/core-01/${BACKUP_DATE}"
+declare -a ARTIFACTS=()
+CURRENT_STEP="startup"
+ENCRYPT_DIR=""
+STEP=0
 
+log() {
+  printf '[backup %s] %s\n' "$(date '+%H:%M:%S')" "$*"
+}
+
+fail() {
+  log "ERROR: $*"
+  return 1
+}
+
+cleanup() {
+  if [[ -n "${ENCRYPT_DIR}" && -d "${ENCRYPT_DIR}" ]]; then
+    rm -rf "${ENCRYPT_DIR}" || true
+  fi
+}
+
+env_get() {
+  local key="$1"
+  grep "^${key}=" "${COMPOSE_DIR}/.env" 2>/dev/null | head -1 | cut -d= -f2- || true
+}
+
+secret_file_value() {
+  local path="$1"
+
+  if [[ -r "${path}" ]]; then
+    <"${path}"
+  fi
+}
+
+urlencode() {
+  python3 -c 'import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1]))' "$1"
+}
+
+kuma_push() {
+  local status="$1"
+  local msg="$2"
+
+  [[ -z "${KUMA_TOKEN_BACKUP:-}" ]] && return 0
+
+  curl -fsS --max-time 10 \
+    "https://status.getklai.com/api/push/${KUMA_TOKEN_BACKUP}?status=${status}&msg=$(urlencode "${msg}")&ping=" \
+    >/dev/null 2>&1 || true
+}
+
+on_error() {
+  local code=$?
+  trap - ERR
+  cleanup
+  kuma_push down "Backup failed during ${CURRENT_STEP} (exit ${code})"
+  exit "${code}"
+}
+
+trap on_error ERR
+trap cleanup EXIT
+
+ctr() {
+  printf 'klai-core-%s-1' "$1"
+}
+
+container_running() {
+  local container="$1"
+  [[ "$(docker inspect -f '{{.State.Running}}' "${container}" 2>/dev/null || true)" == "true" ]]
+}
+
+container_restart_count() {
+  docker inspect -f '{{.RestartCount}}' "$1"
+}
+
+container_started_at() {
+  docker inspect -f '{{.State.StartedAt}}' "$1"
+}
+
+container_env_value() {
+  local container="$1"
+  local key="$2"
+
+  docker inspect \
+    --format '{{range .Config.Env}}{{println .}}{{end}}' \
+    "${container}" 2>/dev/null \
+    | awk -F= -v key="${key}" '$1 == key { sub("^[^=]+=", ""); print; exit }' \
+    || true
+}
+
+artifact_size() {
+  du -sh "$1" 2>/dev/null | cut -f1
+}
+
+record_file() {
+  local file="$1"
+
+  if [[ ! -s "${file}" ]]; then
+    fail "expected artifact is missing or empty: ${file}"
+  fi
+
+  ARTIFACTS+=("${file}")
+  log "      Size: $(artifact_size "${file}")"
+}
+
+record_optional_file() {
+  local file="$1"
+  local empty_msg="$2"
+
+  if [[ -s "${file}" ]]; then
+    ARTIFACTS+=("${file}")
+    log "      Size: $(artifact_size "${file}")"
+  else
+    rm -f "${file}"
+    log "      ${empty_msg}"
+  fi
+}
+
+load_config() {
+  MONGO_ROOT_PASSWORD="$(<"${SECRETS_DIR}/mongo_root_password.txt")"
+  REDIS_PASSWORD="$(container_env_value "$(ctr redis)" REDIS_PASSWORD)"
+  STORAGEBOX_HOST="${STORAGEBOX_HOST:-$(env_get STORAGEBOX_HOST)}"
+  STORAGEBOX_USER="${STORAGEBOX_USER:-$(env_get STORAGEBOX_USER)}"
+  KUMA_TOKEN_BACKUP="${KUMA_TOKEN_BACKUP:-$(env_get KUMA_TOKEN_BACKUP)}"
+
+  if [[ -z "${MONGO_ROOT_PASSWORD}" ]]; then
+    fail "MONGO_ROOT_PASSWORD is empty"
+  fi
+  if [[ -z "${REDIS_PASSWORD}" ]]; then
+    fail "REDIS_PASSWORD is empty"
+  fi
+}
+
+run_step() {
+  local title="$1"
+  shift
+
+  STEP=$((STEP + 1))
+  CURRENT_STEP="[${STEP}/${TOTAL_STEPS}] ${title}"
+  printf '\n'
+  log "${CURRENT_STEP}"
+  "$@"
+}
+
+backup_postgres() {
+  local output="${BACKUP_DIR}/postgres-all.sql"
+
+  docker compose exec -T postgres pg_dumpall -U klai > "${output}"
+  record_file "${output}"
+}
+
+backup_gitea() {
+  local output="${BACKUP_DIR}/gitea-repos.tar.gz"
+
+  docker run --rm \
+    --volumes-from "$(ctr gitea):ro" \
+    -v "${BACKUP_DIR}:/backup" \
+    alpine tar -czf /backup/gitea-repos.tar.gz -C /data git/repositories gitea/conf
+  record_file "${output}"
+}
+
+backup_mongodb() {
+  local container
+  local image
+  local tmp
+  local output
+  local before_restarts
+  local before_started_at
+  local after_restarts
+  local after_started_at
+
+  container="$(ctr mongodb)"
+  output="${BACKUP_DIR}/mongodb-all.archive"
+  tmp="${output}.partial"
+
+  if ! container_running "${container}"; then
+    fail "MongoDB container is not running"
+  fi
+
+  image="$(docker inspect -f '{{.Config.Image}}' "${container}")"
+  before_restarts="$(container_restart_count "${container}")"
+  before_started_at="$(container_started_at "${container}")"
+  rm -f "${tmp}" "${output}"
+
+  if ! docker run --rm \
+      --network "${MONGODB_NETWORK}" \
+      --user "$(id -u):$(id -g)" \
+      -v "${BACKUP_DIR}:/backup" \
+      "${image}" mongodump \
+      --host "${container}:27017" \
+      --numParallelCollections=1 \
+      --username klai \
+      --password "${MONGO_ROOT_PASSWORD}" \
+      --authenticationDatabase admin \
+      --archive="/backup/$(basename "${tmp}")"; then
+    rm -f "${tmp}" "${output}"
+    fail "mongodump failed"
+  fi
+
+  after_restarts="$(container_restart_count "${container}")"
+  after_started_at="$(container_started_at "${container}")"
+  if [[ "${before_restarts}" != "${after_restarts}" || "${before_started_at}" != "${after_started_at}" ]]; then
+    rm -f "${tmp}" "${output}"
+    fail "MongoDB restarted during mongodump (restarts ${before_restarts}->${after_restarts})"
+  fi
+
+  mv "${tmp}" "${output}"
+  record_file "${output}"
+}
+
+backup_redis() {
+  local output="${BACKUP_DIR}/redis-dump.rdb"
+
+  docker compose exec -T redis redis-cli -a "${REDIS_PASSWORD}" --no-auth-warning BGSAVE
+  sleep 3
+  docker compose cp redis:/data/dump.rdb "${output}"
+  record_file "${output}"
+}
+
+backup_vexa_redis() {
+  local container
+  local output
+
+  container="$(ctr vexa-redis)"
+  output="${BACKUP_DIR}/vexa-redis-dump.rdb"
+
+  if ! container_running "${container}"; then
+    log "      Skipped (container not running)"
+    return 0
+  fi
+
+  docker exec "${container}" redis-cli BGSAVE >/dev/null
+  sleep 3
+  docker cp "${container}:/data/dump.rdb" "${output}"
+  record_file "${output}"
+}
+
+backup_meilisearch() {
+  local key
+  local response
+  local container
+
+  container="$(ctr meilisearch)"
+  if ! container_running "${container}"; then
+    log "      Skipped (container not running)"
+    return 0
+  fi
+
+  key="${MEILI_MASTER_KEY:-$(secret_file_value "${SECRETS_DIR}/meili_master_key.txt")}"
+  if [[ -z "${key}" ]]; then
+    log "      Skipped (MEILI_MASTER_KEY is empty)"
+    return 0
+  fi
+
+  if response="$(docker compose exec -T meilisearch \
+      wget -qO- --post-data="" \
+      --header="Authorization: Bearer ${key}" \
+      http://127.0.0.1:7700/snapshots 2>/dev/null)"; then
+    log "      Response: ${response}"
+  else
+    log "      Snapshot failed (non-fatal; Meilisearch can rebuild from MongoDB)"
+  fi
+}
+
+qdrant_api() {
+  local method="$1"
+  local path="$2"
+  local flags=()
+
+  case "${method}" in
+    GET) ;;
+    POST) flags=(-X POST -d "") ;;
+    DELETE) flags=(-X DELETE) ;;
+    *) fail "unknown Qdrant API method: ${method}" ;;
+  esac
+
+  docker run --rm --network "${QDRANT_NETWORK}" curlimages/curl:8.11.1 \
+    -sSf --max-time 30 \
+    "${flags[@]}" \
+    -H "api-key: ${QDRANT_API_KEY}" \
+    "http://$(ctr qdrant):6333${path}"
+}
+
+json_qdrant_collections() {
+  python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+for collection in data.get("result", {}).get("collections", []):
+    name = collection.get("name")
+    if name:
+        print(name)
+'
+}
+
+json_qdrant_snapshot_name() {
+  python3 -c '
+import json
+import sys
+
+print(json.load(sys.stdin).get("result", {}).get("name", ""))
+'
+}
+
+backup_qdrant() {
+  local container
+  local collections_json
+  local collections
+  local collection
+  local response
+  local snapshot
+  local output
+
+  container="$(ctr qdrant)"
+  if ! container_running "${container}"; then
+    log "      Skipped (container not running)"
+    return 0
+  fi
+
+  QDRANT_API_KEY="${QDRANT_API_KEY:-$(container_env_value "${container}" QDRANT__SERVICE__API_KEY)}"
+  if [[ -z "${QDRANT_API_KEY}" ]]; then
+    fail "Qdrant is running but QDRANT__SERVICE__API_KEY is empty"
+  fi
+
+  collections_json="$(qdrant_api GET /collections)"
+  collections="$(printf '%s' "${collections_json}" | json_qdrant_collections)"
+  if [[ -z "${collections}" ]]; then
+    log "      No collections found"
+    return 0
+  fi
+
+  while IFS= read -r collection; do
+    [[ -n "${collection}" ]] || continue
+
+    response="$(qdrant_api POST "/collections/${collection}/snapshots")"
+    snapshot="$(printf '%s' "${response}" | json_qdrant_snapshot_name)"
+    if [[ -z "${snapshot}" ]]; then
+      fail "Qdrant did not return a snapshot name for ${collection}: ${response}"
+    fi
+
+    output="${BACKUP_DIR}/qdrant-${collection}.snapshot"
+    if ! docker run --rm --network "${QDRANT_NETWORK}" \
+        --user 0:0 \
+        -v "${BACKUP_DIR}:/out" \
+        curlimages/curl:8.11.1 \
+        -sSfL --max-time 300 \
+        -H "api-key: ${QDRANT_API_KEY}" \
+        "http://${container}:6333/collections/${collection}/snapshots/${snapshot}" \
+        -o "/out/$(basename "${output}")"; then
+      qdrant_api DELETE "/collections/${collection}/snapshots/${snapshot}" >/dev/null || true
+      rm -f "${output}"
+      fail "Qdrant snapshot download failed for ${collection}"
+    fi
+
+    if [[ -s "${output}" ]]; then
+      ARTIFACTS+=("${output}")
+      log "      Size: $(artifact_size "${output}")"
+    else
+      qdrant_api DELETE "/collections/${collection}/snapshots/${snapshot}" >/dev/null || true
+      rm -f "${output}"
+      fail "Qdrant snapshot download was empty for ${collection}"
+    fi
+    qdrant_api DELETE "/collections/${collection}/snapshots/${snapshot}" >/dev/null || true
+  done <<< "${collections}"
+}
+
+backup_falkordb() {
+  local container
+  local output
+
+  container="$(ctr falkordb)"
+  output="${BACKUP_DIR}/falkordb-dump.rdb"
+
+  if ! container_running "${container}"; then
+    log "      Skipped (container not running)"
+    return 0
+  fi
+
+  docker exec "${container}" redis-cli BGSAVE >/dev/null
+  sleep 3
+  docker cp "${container}:/var/lib/falkordb/data/dump.rdb" "${output}"
+  record_file "${output}"
+}
+
+backup_garage_meta() {
+  local container
+  local output
+  local snapshot_output
+
+  container="$(ctr garage)"
+  output="${BACKUP_DIR}/garage-meta.tar.gz"
+
+  if ! container_running "${container}"; then
+    log "      Skipped (container not running)"
+    return 0
+  fi
+
+  snapshot_output="$(docker exec "${container}" /garage meta snapshot 2>&1)"
+  log "      ${snapshot_output}"
+
+  docker run --rm \
+    --volumes-from "${container}:ro" \
+    -v "${BACKUP_DIR}:/backup" \
+    alpine sh -c '
+      latest=$(ls -1td /var/lib/garage/meta/snapshots/*/ 2>/dev/null | head -1)
+      test -n "${latest}"
+      tar -czf /backup/garage-meta.tar.gz -C "${latest}" .
+    '
+  record_file "${output}"
+}
+
+backup_garage_data() {
+  local output="${BACKUP_DIR}/garage-data.tar.gz"
+
+  if [[ ! -d /opt/klai/garage-data ]]; then
+    log "      Skipped (no /opt/klai/garage-data)"
+    return 0
+  fi
+
+  docker run --rm \
+    -v /opt/klai/garage-data:/data:ro \
+    -v "${BACKUP_DIR}:/backup" \
+    alpine tar -czf /backup/garage-data.tar.gz -C /data .
+  record_file "${output}"
+}
+
+backup_firecrawl_postgres() {
+  local container
+  local output
+
+  container="$(ctr firecrawl-postgres)"
+  output="${BACKUP_DIR}/firecrawl-postgres-all.sql"
+
+  if ! container_running "${container}"; then
+    log "      Skipped (container not running)"
+    return 0
+  fi
+
+  docker exec "${container}" pg_dumpall -U firecrawl > "${output}"
+  record_file "${output}"
+}
+
+backup_listmonk_postgres() {
+  local container
+  local output
+
+  container="$(ctr listmonk-db)"
+  output="${BACKUP_DIR}/listmonk-postgres-all.sql"
+
+  if ! container_running "${container}"; then
+    log "      Skipped (container not running)"
+    return 0
+  fi
+
+  docker exec "${container}" pg_dumpall -U listmonk > "${output}"
+  record_file "${output}"
+}
+
+backup_listmonk_uploads() {
+  local container
+  local output
+
+  container="$(ctr listmonk)"
+  output="${BACKUP_DIR}/listmonk-uploads.tar.gz"
+
+  if ! container_running "${container}"; then
+    log "      Skipped (container not running)"
+    return 0
+  fi
+
+  if docker run --rm \
+      --volumes-from "${container}:ro" \
+      -v "${BACKUP_DIR}:/backup" \
+      alpine tar -czf /backup/listmonk-uploads.tar.gz -C /listmonk/uploads . 2>/dev/null; then
+    record_optional_file "${output}" "Empty (no uploaded campaign media)"
+  else
+    rm -f "${output}"
+    log "      Tar failed; optional listmonk uploads artifact skipped"
+  fi
+}
+
+backup_scribe_audio() {
+  local container
+  local output
+
+  container="$(ctr scribe-api)"
+  output="${BACKUP_DIR}/scribe-audio.tar.gz"
+
+  if ! container_running "${container}"; then
+    log "      Skipped (container not running)"
+    return 0
+  fi
+
+  if docker run --rm \
+      --volumes-from "${container}:ro" \
+      -v "${BACKUP_DIR}:/backup" \
+      alpine tar -czf /backup/scribe-audio.tar.gz -C /data/audio . 2>/dev/null; then
+    record_optional_file "${output}" "Empty (no retained recordings)"
+  else
+    rm -f "${output}"
+    log "      Tar failed; optional scribe audio artifact skipped"
+  fi
+}
+
+backup_research_uploads() {
+  local output="${BACKUP_DIR}/research-uploads"
+
+  if [[ ! -d /opt/klai/research-uploads ]]; then
+    log "      Skipped (no /opt/klai/research-uploads)"
+    return 0
+  fi
+
+  rsync -a --delete /opt/klai/research-uploads/ "${output}/"
+  log "      Size: $(artifact_size "${output}")"
+}
+
+encrypt_artifacts() {
+  local artifact
+
+  ENCRYPT_DIR="$(mktemp -d)"
+
+  for artifact in "${ARTIFACTS[@]}"; do
+    age -r "${AGE_RECIPIENTS[0]}" -r "${AGE_RECIPIENTS[1]}" "${artifact}" \
+      > "${ENCRYPT_DIR}/$(basename "${artifact}").age"
+  done
+
+  if [[ -d "${BACKUP_DIR}/research-uploads" ]]; then
+    tar -czf - -C "${BACKUP_DIR}" research-uploads \
+      | age -r "${AGE_RECIPIENTS[0]}" -r "${AGE_RECIPIENTS[1]}" \
+      > "${ENCRYPT_DIR}/research-uploads.tar.gz.age"
+  fi
+}
+
+upload_encrypted_artifacts() {
+  local remote_path
+
+  if [[ -z "${STORAGEBOX_HOST:-}" || -z "${STORAGEBOX_USER:-}" ]]; then
+    log "      Storage Box is not configured; upload skipped."
+    log "      Set STORAGEBOX_HOST and STORAGEBOX_USER in ${COMPOSE_DIR}/.env."
+    return 0
+  fi
+
+  remote_path="backups/core-01/${BACKUP_DATE}"
   rsync \
     -e "ssh -p 23 -o StrictHostKeyChecking=accept-new -o ConnectTimeout=30" \
     -az --mkpath --stats \
-    "$ENCRYPT_DIR/" \
-    "${STORAGEBOX_USER}@${STORAGEBOX_HOST}:${REMOTE_PATH}/"
+    "${ENCRYPT_DIR}/" \
+    "${STORAGEBOX_USER}@${STORAGEBOX_HOST}:${remote_path}/"
 
-  rm -rf "$ENCRYPT_DIR"
-  echo "${LOG_PREFIX}       Uploaded to: ${STORAGEBOX_USER}@${STORAGEBOX_HOST}:${REMOTE_PATH}"
+  log "      Uploaded to: ${STORAGEBOX_USER}@${STORAGEBOX_HOST}:${remote_path}"
+}
 
-  # Remote retention: Storage Box uses a restricted shell (no find/rm via SSH).
-  # At ~45MB/day and 100GB, pruning is not needed until ~2026 days of backups accumulate.
-  # TODO: implement sftp-based pruning if/when storage grows beyond 80GB.
+encrypt_and_upload() {
+  encrypt_artifacts
+  upload_encrypted_artifacts
+}
 
-  echo "${LOG_PREFIX}       Storage Box upload complete."
-else
-  echo "${LOG_PREFIX} [14/14] Storage Box niet geconfigureerd (STORAGEBOX_HOST/STORAGEBOX_USER niet gezet) -- upload overgeslagen."
-  echo "${LOG_PREFIX}       Zie klai-infra/SERVERS.md voor setup-instructies."
-fi
+local_retention() {
+  local remaining
 
-# ─── Local retention: keep last 30 days ──────────────────────────────────────
-echo ""
-echo "${LOG_PREFIX} Lokale cleanup: backups ouder dan 30 dagen verwijderen..."
-find /opt/klai/backups/ -maxdepth 1 -type d -name '20*' | sort | head -n -30 | xargs -r rm -rf
-REMAINING=$(find /opt/klai/backups/ -maxdepth 1 -type d -name '20*' | wc -l)
-echo "${LOG_PREFIX} Lokale backups bewaard: ${REMAINING}"
+  printf '\n'
+  log "Local cleanup: removing backups older than the newest 30 days..."
+  find "${BACKUP_ROOT}/" -maxdepth 1 -type d -name '20*' | sort | head -n -30 | xargs -r rm -rf
+  remaining="$(find "${BACKUP_ROOT}/" -maxdepth 1 -type d -name '20*' | wc -l)"
+  log "Local backups retained: ${remaining}"
+}
 
-# ─── Uptime Kuma: report success ──────────────────────────────────────────────
-_kuma_push up "OK — $(du -sh "$BACKUP_DIR" | cut -f1)"
+print_summary() {
+  printf '\n'
+  log "============================================"
+  log "Backup completed: ${BACKUP_DIR}"
+  log "============================================"
+  ls -lh "${BACKUP_DIR}"
+}
 
-# ─── Summary ──────────────────────────────────────────────────────────────────
-echo ""
-echo "${LOG_PREFIX} ============================================"
-echo "${LOG_PREFIX} Backup voltooid: $BACKUP_DIR"
-echo "${LOG_PREFIX} ============================================"
-ls -lh "$BACKUP_DIR"
+main() {
+  printf '\n'
+  log "============================================"
+  log "Starting backup: ${BACKUP_DATE}"
+  log "============================================"
+
+  mkdir -p "${BACKUP_DIR}"
+  cd "${COMPOSE_DIR}"
+  load_config
+
+  run_step "PostgreSQL: dump all databases" backup_postgres
+  run_step "Gitea: repositories and config" backup_gitea
+  run_step "MongoDB: dump all databases" backup_mongodb
+  run_step "Redis: BGSAVE and copy dump" backup_redis
+  run_step "Vexa Redis: BGSAVE and copy dump" backup_vexa_redis
+  run_step "Meilisearch: create snapshot" backup_meilisearch
+  run_step "Qdrant: snapshot collections" backup_qdrant
+  run_step "FalkorDB: BGSAVE and copy dump" backup_falkordb
+  run_step "Garage: metadata snapshot" backup_garage_meta
+  run_step "Garage: blob data tar" backup_garage_data
+  run_step "Firecrawl Postgres: dump all databases" backup_firecrawl_postgres
+  run_step "listmonk Postgres: dump all databases" backup_listmonk_postgres
+  run_step "listmonk uploads: tar campaign media" backup_listmonk_uploads
+  run_step "Scribe audio: tar failed retry recordings" backup_scribe_audio
+  run_step "Research uploads: rsync user uploads" backup_research_uploads
+  run_step "Encrypt and upload to Storage Box" encrypt_and_upload
+
+  kuma_push up "OK - $(artifact_size "${BACKUP_DIR}")"
+
+  CURRENT_STEP="local retention"
+  if ! local_retention; then
+    log "Local retention failed (non-fatal; backup artifacts were already produced)"
+  fi
+
+  CURRENT_STEP="summary"
+  if ! print_summary; then
+    log "Summary output failed (non-fatal; backup artifacts were already produced)"
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Refactor `deploy/scripts/backup.sh` into explicit helpers and per-service backup steps.
- Add fail-loud MongoDB backup behavior: sidecar `mongodump`, `.partial` artifact writes, and restart-count/StartedAt guard.
- Include listmonk backup artifacts and track encrypted upload inputs centrally.
- Sync all deploy scripts to `/opt/klai/scripts` in the compose deploy workflow after `bash -n` validation.

## Root Cause
The production backup monitor was red because the backup run stalled around MongoDB and production script drift was possible: `backup.sh` and `push-health.sh` were not installed by the repo-managed compose sync workflow.

## Notes
MongoDB restart during dump is still an operational issue to investigate separately. This change intentionally avoids false-green monitoring by failing the backup if Mongo restarts during `mongodump`.

## Validation
- `bash -n deploy/scripts/backup.sh`
- `bash -n` for all `deploy/scripts/*.sh`
- `git diff --check`
- remote syntax check on `core-01`
- installed updated `/opt/klai/scripts/backup.sh` on `core-01`
- checked Mongo container status: `running`, `healthy`, `restart_count=44`
