### PR TITLE
[codex] Restore visible citation sources

### DIFF
--- a/deploy/litellm/klai_knowledge.py
+++ b/deploy/litellm/klai_knowledge.py
@@ -2183,20 +2183,18 @@ def _format_visible_sources_markdown(sources: list[dict[str, Any]]) -> str:
 def _split_sources_for_librechat_render(
     sources: list[dict[str, Any]],
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
-    """Split sources into disjoint native metadata and Markdown fallback sets.
+    """Return structured metadata plus a visible Markdown fallback.
 
-    LibreChat's native source UI owns URL-backed sources. URL-less uploads are
-    rendered only in the Markdown fallback so they remain visible without being
-    duplicated if the client also decides to show metadata-only sources.
+    LibreChat does not reliably surface ``message.sources`` for every KB chat
+    path, so the answer text must still carry the deterministic source footer.
+    Keep URL-backed sources in structured metadata for clients that do support
+    it, but render all selected sources visibly so citations cannot disappear.
     """
     structured_sources: list[dict[str, Any]] = []
-    visible_fallback_sources: list[dict[str, Any]] = []
     for source in sources:
         if _normalise_guard_url(source.get("url")):
             structured_sources.append(source)
-        else:
-            visible_fallback_sources.append(source)
-    return structured_sources, visible_fallback_sources
+    return structured_sources, sources
 
 
 def _append_visible_sources_section(

--- a/deploy/litellm/tests/test_klai_knowledge_hook.py
+++ b/deploy/litellm/tests/test_klai_knowledge_hook.py
@@ -2707,8 +2707,8 @@ class TestKlaiKnowledgeHookUrlImageGrounding:
             "\n\n**Bronnen**\n- Verantwoordelijkheden per bouwblok.pdf"
         )
 
-    def test_librechat_source_split_keeps_native_and_fallback_disjoint(self, monkeypatch):
-        """URL-backed sources go to metadata; URL-less uploads go to Markdown only."""
+    def test_librechat_source_split_keeps_native_and_visible_fallback(self, monkeypatch):
+        """URL-backed sources get metadata and remain visible in Markdown."""
         mod = _load_hook(monkeypatch)
         sources = [
             {
@@ -2733,10 +2733,10 @@ class TestKlaiKnowledgeHookUrlImageGrounding:
         )
 
         assert structured_sources == [sources[0]]
-        assert visible_sources == [sources[1]]
+        assert visible_sources == sources
         visible_block = content.split("**Bronnen**\n", 1)[1].split("\n\n", 1)[0]
+        assert "- [Public doc](https://docs.getklai.com/public)" in visible_block
         assert "- Upload.pdf" in visible_block
-        assert "Public doc" not in visible_block
         assert _decode_sources_marker(content) == [sources[0]]
 
     def _system_msg(self, result: dict) -> str:
@@ -3220,8 +3220,8 @@ class TestKlaiKnowledgeHookUrlImageGrounding:
         content = response.choices[0].message.content
         assert "Zie het diagram bron en fake." in content
         assert "https://example.com" not in content
-        assert "**Bronnen**" not in content
-        assert "- [Diagram](https://docs.getklai.com/diagram)" not in content
+        assert "**Bronnen**" in content
+        assert "- [Diagram](https://docs.getklai.com/diagram)" in content
         assert "**Agent activiteit**" in content
         assert "- Kennisbank geraadpleegd: 1 fragment opgehaald in 12 ms." in content
         assert "- Bronselectie: 1 bron gekoppeld" in content
@@ -3287,10 +3287,10 @@ class TestKlaiKnowledgeHookUrlImageGrounding:
         assert returned is response
         content = response.choices[0].message.content
         assert "Je kunt iemand uitnodigen via het beheerscherm." in content
-        assert "**Bronnen**" not in content
+        assert "**Bronnen**" in content
         assert (
             "- [Invite and remove people](https://docs.getklai.com/admin/invite-remove-people)"
-            not in content
+            in content
         )
         assert "**Agent activiteit**" in content
         assert "- Modus: Open, kennisbank met fallback." in content
@@ -3364,8 +3364,8 @@ class TestKlaiKnowledgeHookUrlImageGrounding:
         assert returned is response
         content = response.choices[0].message.content
         assert "Frank Wolters trekt Data Readiness" in content
-        assert "**Bronnen**" not in content
-        assert "- [Organogram](https://kb.getklai.test/organogram.pdf)" not in content
+        assert "**Bronnen**" in content
+        assert "- [Organogram](https://kb.getklai.test/organogram.pdf)" in content
         assert "**Agent activiteit**" in content
         assert "- Gebruikte bronnen: Organogram." in content
         assert response.choices[0].message.sources == [
@@ -3769,8 +3769,8 @@ class TestKlaiKnowledgeHookUrlImageGrounding:
         assert footer.choices[0].finish_reason is None
         assert "https://bad.example" not in footer.choices[0].delta.content
         assert "fake." in footer.choices[0].delta.content
-        assert "**Bronnen**" not in footer.choices[0].delta.content
-        assert "- [Diagram](https://docs.getklai.com/diagram)" not in footer.choices[0].delta.content
+        assert "**Bronnen**" in footer.choices[0].delta.content
+        assert "- [Diagram](https://docs.getklai.com/diagram)" in footer.choices[0].delta.content
         assert "**Agent activiteit**" in footer.choices[0].delta.content
         assert footer.choices[0].delta.sources == [
             {
@@ -3875,8 +3875,8 @@ class TestKlaiKnowledgeHookUrlImageGrounding:
         assert streamed == [only]
         content = streamed[0]["choices"][0]["delta"]["content"]
         assert "Zie diagram." in content
-        assert "**Bronnen**" not in content
-        assert "- [Diagram](https://docs.getklai.com/diagram)" not in content
+        assert "**Bronnen**" in content
+        assert "- [Diagram](https://docs.getklai.com/diagram)" in content
         assert "**Agent activiteit**" in content
         assert streamed[0]["choices"][0]["delta"]["sources"] == [
             {


### PR DESCRIPTION
## What changed

Restores visible citation footers for KB chat responses while keeping structured `message.sources` metadata for clients that support it.

## Why

URL-backed sources were being sent only through structured metadata. LibreChat does not reliably render that metadata on every KB chat path, so users could see answers with no visible citations even when the backend had selected valid sources.

## Root cause

The LiteLLM citation renderer split selected sources into disjoint sets:

- URL-backed sources went only to native `sources` metadata.
- URL-less uploads went to the Markdown `**Bronnen**` fallback.

That made URL-backed citations disappear in clients that ignore or drop `message.sources`.

## Validation

- `uv run pytest tests/test_citations.py -q` from `klai-libs/citations` → 25 passed
- `uv run --python 3.12 --with pytest --with pytest-asyncio --with httpx --with ./klai-libs/citations --with ./klai-libs/llm-safety --with ./klai-libs/chat-prompts --with ./klai-libs/retrieval-telemetry pytest deploy/litellm/tests/test_klai_knowledge_hook.py -q` → 103 passed
