### PR TITLE
[codex] Stop citing unsupported retrieved sources

### DIFF
--- a/deploy/litellm/klai_knowledge.py
+++ b/deploy/litellm/klai_knowledge.py
@@ -1987,11 +1987,6 @@ def _render_kb_citation_content(
         ):
             decision["no_citable_reason"] = "strict_refusal_no_supported_sources"
             return strict_refusal, [], True, decision
-        fallback_sources = _trusted_sources_visible_fallback(trusted_sources)
-        if fallback_sources:
-            decision["fallback"] = "document_level_trusted_sources"
-            decision["no_citable_reason"] = "selector_rejected_all_sources_fallback"
-            return composed.content or text, fallback_sources, False, decision
         if kb_narrow:
             decision["no_citable_reason"] = "selector_rejected_all_sources"
             return strict_refusal, [], True, decision
@@ -2135,32 +2130,6 @@ def _prepend_primary_upload_source(
         updated["label"] = str(index)
         relabelled.append(updated)
     return relabelled
-
-
-def _trusted_sources_visible_fallback(
-    trusted_sources: list[dict[str, Any]],
-    *,
-    max_sources: int = 3,
-) -> list[dict[str, Any]]:
-    """Render document-level sources when answer/source text matching is too strict."""
-    sources: list[dict[str, Any]] = []
-    seen_keys: set[str] = set()
-    for source in trusted_sources:
-        url = _normalise_guard_url(source.get("url"))
-        key = url or str(
-            source.get("artifact_id")
-            or source.get("source_id")
-            or source.get("title")
-            or source.get("source_label")
-            or ""
-        ).strip()
-        if not key or key in seen_keys:
-            continue
-        seen_keys.add(key)
-        sources.append(_source_with_metadata(source, label=str(len(sources) + 1)))
-        if len(sources) >= max_sources:
-            break
-    return sources
 
 
 def _plural_nl(count: int, singular: str, plural: str) -> str:

--- a/deploy/litellm/tests/test_klai_knowledge_hook.py
+++ b/deploy/litellm/tests/test_klai_knowledge_hook.py
@@ -3308,21 +3308,18 @@ class TestKlaiKnowledgeHookUrlImageGrounding:
         ]
 
     @pytest.mark.asyncio
-    async def test_post_call_guard_falls_back_to_document_sources_when_selector_rejects(
+    async def test_post_call_guard_does_not_cite_document_sources_when_selector_rejects(
         self, monkeypatch, caplog
     ):
-        """LibreChat must still show provenance when trusted KB sources exist."""
+        """Retrieved docs are not answer citations when source support fails."""
         mod = _load_hook(monkeypatch)
         hook = mod.KlaiKnowledgeHook()
         caplog.set_level("WARNING", logger="klai_knowledge")
+        original_answer = "Frank Wolters trekt Data Readiness en Governance & Ethiek."
         response = SimpleNamespace(
             choices=[
                 SimpleNamespace(
-                    message=SimpleNamespace(
-                        content=(
-                            "Frank Wolters trekt Data Readiness en Governance & Ethiek."
-                        )
-                    )
+                    message=SimpleNamespace(content=original_answer)
                 )
             ]
         )
@@ -3346,7 +3343,8 @@ class TestKlaiKnowledgeHookUrlImageGrounding:
                         }
                     ],
                     # Deliberately no evidence_ids/source text match for the
-                    # selector. The fallback must still show the trusted doc.
+                    # selector. The retrieved doc must not be shown as an
+                    # answer citation when support cannot be established.
                     "trusted_sources": [
                         {
                             "label": "1",
@@ -3363,20 +3361,11 @@ class TestKlaiKnowledgeHookUrlImageGrounding:
 
         assert returned is response
         content = response.choices[0].message.content
-        assert "Frank Wolters trekt Data Readiness" in content
-        assert "**Bronnen**" in content
-        assert "- [Organogram](https://kb.getklai.test/organogram.pdf)" in content
-        assert "**Agent activiteit**" in content
-        assert "- Gebruikte bronnen: Organogram." in content
-        assert response.choices[0].message.sources == [
-            {
-                "label": "1",
-                "title": "Organogram",
-                "url": "https://kb.getklai.test/organogram.pdf",
-                "evidence_ids": ["different-evidence-id"],
-            }
-        ]
-        assert "selector_rejected_all_sources_fallback" in caplog.text
+        assert content == original_answer
+        assert "**Bronnen**" not in content
+        assert "Organogram" not in content
+        assert not hasattr(response.choices[0].message, "sources")
+        assert "selector_rejected_all_sources_fallback" not in caplog.text
 
     @pytest.mark.asyncio
     async def test_post_call_guard_renders_uploaded_document_source_without_url(


### PR DESCRIPTION
## What changed

Removes the LiteLLM citation fallback that showed retrieved document sources even when the answer/source selector rejected every source as unsupported.

## Why

Retrieved documents are provenance, not answer citations. If the final answer cannot be matched to a retrieved source, the UI must not present that source as a citation.

## Root cause

`_render_kb_citation_content()` called `_trusted_sources_visible_fallback()` after `compose_answer_with_trusted_sources()` returned zero supported sources. That turned "retrieved but unsupported" documents into visible `**Bronnen**` and structured `message.sources`, which can produce unrelated source pills for an answer.

## User impact

When retrieval returns tangential documents, Klai will no longer present those documents as citations for an answer they do not support. In strict mode the existing refusal behavior remains. In open mode the model answer can still pass through, but without unsupported citations.

## Validation

- `uv run pytest tests/test_citations.py -q` from `klai-libs/citations` → 25 passed
- `uv run --python 3.12 --with pytest --with pytest-asyncio --with httpx --with ./klai-libs/citations --with ./klai-libs/llm-safety --with ./klai-libs/chat-prompts --with ./klai-libs/retrieval-telemetry pytest deploy/litellm/tests/test_klai_knowledge_hook.py -q` → 103 passed
