### PR TITLE
Revert citation channel split

### DIFF
--- a/deploy/litellm/klai_knowledge.py
+++ b/deploy/litellm/klai_knowledge.py
@@ -2180,43 +2180,16 @@ def _format_visible_sources_markdown(sources: list[dict[str, Any]]) -> str:
     return "\n".join(lines)
 
 
-def _split_sources_for_librechat_render(
-    sources: list[dict[str, Any]],
-) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
-    """Return structured metadata plus a visible Markdown fallback.
-
-    LibreChat does not reliably surface ``message.sources`` for every KB chat
-    path, so the answer text must still carry the deterministic source footer.
-    Keep URL-backed sources in structured metadata for clients that do support
-    it, but render all selected sources visibly so citations cannot disappear.
-    """
-    structured_sources: list[dict[str, Any]] = []
-    for source in sources:
-        if _normalise_guard_url(source.get("url")):
-            structured_sources.append(source)
-    return structured_sources, sources
-
-
 def _append_visible_sources_section(
     content: str,
     sources: list[dict[str, Any]],
     *,
     kb_meta: dict[str, Any] | None = None,
-    visible_sources: list[dict[str, Any]] | None = None,
-    metadata_sources: list[dict[str, Any]] | None = None,
-    include_metadata_marker: bool = True,
 ) -> str:
-    """Append backend-selected fallback sections.
-
-    ``visible_sources=None`` preserves the legacy/dumb-client behaviour: render
-    all sources as Markdown. Structured clients can pass a filtered list so
-    only sources that need a text fallback are rendered. ``metadata_sources``
-    controls the hidden LibreChat recovery marker and defaults to ``sources``.
-    """
+    """Append backend-selected sources for clients that ignore structured metadata."""
     sections: list[str] = []
-    fallback_sources = sources if visible_sources is None else visible_sources
-    if fallback_sources:
-        sources_markdown = _format_visible_sources_markdown(fallback_sources).strip()
+    if sources:
+        sources_markdown = _format_visible_sources_markdown(sources).strip()
         if sources_markdown:
             sections.append(f"**Bronnen**\n{sources_markdown}")
     has_no_citable_reason = (
@@ -2228,9 +2201,8 @@ def _append_visible_sources_section(
         activity = _format_visible_agent_activity(kb_meta, sources)
         if activity:
             sections.append(f"**Agent activiteit**\n{activity}")
-    marker_sources = sources if metadata_sources is None else metadata_sources
-    if include_metadata_marker and marker_sources:
-        marker = _format_sources_metadata_marker(marker_sources)
+    if sources:
+        marker = _format_sources_metadata_marker(sources)
         if marker:
             sections.append(marker)
     if not sections:
@@ -2385,19 +2357,8 @@ def _flush_citation_stream_buffer(
             decision,
             no_citable_sources=no_citable_sources,
         )
-        structured_sources, visible_sources = _split_sources_for_librechat_render(sources)
-        _set_message_content(
-            delta,
-            _append_visible_sources_section(
-                rendered_content,
-                sources,
-                kb_meta=kb_meta,
-                visible_sources=visible_sources,
-                metadata_sources=structured_sources,
-            ),
-        )
-        if structured_sources:
-            _set_message_field(delta, "sources", structured_sources)
+        _set_message_content(delta, _append_visible_sources_section(rendered_content, sources, kb_meta=kb_meta))
+        _set_message_field(delta, "sources", sources)
         stream_parts.clear()
         stats.mutated_messages += 1
         stats.rendered_messages += 1
@@ -2467,19 +2428,11 @@ def _compose_non_streaming_kb_response(
                     decision,
                     no_citable_sources=no_citable_sources,
                 )
-                structured_sources, visible_sources = _split_sources_for_librechat_render(sources)
                 _set_message_content(
                     message,
-                    _append_visible_sources_section(
-                        rendered_content,
-                        sources,
-                        kb_meta=kb_meta,
-                        visible_sources=visible_sources,
-                        metadata_sources=structured_sources,
-                    ),
+                    _append_visible_sources_section(rendered_content, sources, kb_meta=kb_meta),
                 )
-                if structured_sources:
-                    _set_message_field(message, "sources", structured_sources)
+                _set_message_field(message, "sources", sources)
                 stats.mutated_messages += 1
                 stats.rendered_messages += 1
                 stats.rendered_sources = max(stats.rendered_sources, len(sources))
@@ -2544,16 +2497,9 @@ def _compose_streaming_kb_response(
                 decision,
                 no_citable_sources=no_citable_sources,
             )
-            structured_sources, visible_sources = _split_sources_for_librechat_render(sources)
             _set_message_content(
                 delta,
-                _append_visible_sources_section(
-                    rendered_content,
-                    sources,
-                    kb_meta=kb_meta,
-                    visible_sources=visible_sources,
-                    metadata_sources=structured_sources,
-                ),
+                _append_visible_sources_section(rendered_content, sources, kb_meta=kb_meta),
             )
             kb_meta["_citation_stream_sources_appended"] = True
             kb_meta["_citation_stream_guard_buffer"] = ""
@@ -2598,17 +2544,10 @@ def _compose_streaming_kb_response(
             decision,
             no_citable_sources=no_citable_sources,
         )
-        structured_sources, visible_sources = _split_sources_for_librechat_render(sources)
-        final_text = _append_visible_sources_section(
-            rendered_content,
-            sources,
-            kb_meta=kb_meta,
-            visible_sources=visible_sources,
-            metadata_sources=structured_sources,
-        )
+        final_text = _append_visible_sources_section(rendered_content, sources, kb_meta=kb_meta)
         final_text = _remove_already_streamed_prefix(final_text, emitted_text)
-        if structured_sources:
-            _set_message_field(delta, "sources", structured_sources)
+        if sources:
+            _set_message_field(delta, "sources", sources)
         _set_message_content(delta, final_text)
         kb_meta["_citation_stream_sources_appended"] = True
         kb_meta["_citation_stream_guard_buffer"] = ""

--- a/deploy/litellm/tests/test_klai_knowledge_hook.py
+++ b/deploy/litellm/tests/test_klai_knowledge_hook.py
@@ -2,9 +2,7 @@
 
 litellm is not installed locally (runs in Docker), so we mock the import.
 """
-import base64
 import importlib
-import json
 import sys
 import types
 from contextlib import contextmanager
@@ -88,12 +86,6 @@ def _load_hook(monkeypatch, extra_env=None, *, mock_fire_and_forget=True):
         monkeypatch.setattr(klai_knowledge, "_fire_gap_event", MagicMock())
         monkeypatch.setattr(klai_knowledge, "_fire_retrieval_log", MagicMock())
     return klai_knowledge
-
-
-def _decode_sources_marker(content):
-    encoded = content.split("<!-- klai_sources=", 1)[1].split(" -->", 1)[0]
-    padding = "=" * (-len(encoded) % 4)
-    return json.loads(base64.urlsafe_b64decode(f"{encoded}{padding}").decode())
 
 
 def _make_cache(feature_enabled: bool | None = None, feature: dict | None = None):
@@ -2707,38 +2699,6 @@ class TestKlaiKnowledgeHookUrlImageGrounding:
             "\n\n**Bronnen**\n- Verantwoordelijkheden per bouwblok.pdf"
         )
 
-    def test_librechat_source_split_keeps_native_and_visible_fallback(self, monkeypatch):
-        """URL-backed sources get metadata and remain visible in Markdown."""
-        mod = _load_hook(monkeypatch)
-        sources = [
-            {
-                "label": "1",
-                "title": "Public doc",
-                "url": "https://docs.getklai.com/public",
-            },
-            {
-                "label": "2",
-                "title": "Upload.pdf",
-                "url": "",
-                "artifact_id": "artifact-upload",
-            },
-        ]
-
-        structured_sources, visible_sources = mod._split_sources_for_librechat_render(sources)
-        content = mod._append_visible_sources_section(
-            "Answer.",
-            sources,
-            visible_sources=visible_sources,
-            metadata_sources=structured_sources,
-        )
-
-        assert structured_sources == [sources[0]]
-        assert visible_sources == sources
-        visible_block = content.split("**Bronnen**\n", 1)[1].split("\n\n", 1)[0]
-        assert "- [Public doc](https://docs.getklai.com/public)" in visible_block
-        assert "- Upload.pdf" in visible_block
-        assert _decode_sources_marker(content) == [sources[0]]
-
     def _system_msg(self, result: dict) -> str:
         msgs = [m for m in result["messages"] if m["role"] == "system"]
         assert len(msgs) == 1, f"expected exactly one system message, got {len(msgs)}"
@@ -3438,7 +3398,15 @@ class TestKlaiKnowledgeHookUrlImageGrounding:
         assert "- [CV_Jantine_Doornbos.pdf]" not in content
         assert "**Agent activiteit**" in content
         assert "- Gebruikte bronnen: CV_Jantine_Doornbos.pdf." in content
-        assert not hasattr(response.choices[0].message, "sources")
+        assert response.choices[0].message.sources == [
+            {
+                "label": "1",
+                "title": "CV_Jantine_Doornbos.pdf",
+                "url": "",
+                "evidence_ids": ["E1"],
+                "artifact_id": "853797a1-3a22-4d90-872e-6a917d996c9a",
+            }
+        ]
         assert "kb_citations_rendered_structured" in caplog.text
 
     @pytest.mark.asyncio
@@ -3965,7 +3933,18 @@ class TestKlaiKnowledgeHookUrlImageGrounding:
         assert "**Agent activiteit**" in footer_delta["content"]
         assert "- Modus: Strict, alleen kennisbank." in footer_delta["content"]
         assert "- Retrieval score: low; bronfragmenten gekoppeld." in footer_delta["content"]
-        assert "sources" not in footer_delta
+        assert footer_delta["sources"] == [
+            {
+                "label": "1",
+                "title": "CV_Jantine_Doornbos.pdf",
+                "url": "",
+                "source_id": "S1",
+                "evidence_ids": ["E1"],
+                "artifact_id": "ca867993-6498-4ce2-bee5-647ffc8cfa21",
+                "source_label": "personal-374185638016057361",
+                "relevance_score": 0.07,
+            }
+        ]
         assert final["choices"][0]["finish_reason"] == "stop"
         assert final_delta == {"content": ""}
 
@@ -4052,7 +4031,8 @@ class TestKlaiKnowledgeHookUrlImageGrounding:
         footer_delta = streamed[1]["choices"][0]["delta"]
         assert streamed[1]["choices"][0]["finish_reason"] is None
         assert "- Verantwoordelijkheden per bouwblok.pdf" in footer_delta["content"]
-        assert "sources" not in footer_delta
+        assert footer_delta["sources"][0]["title"] == "Verantwoordelijkheden per bouwblok.pdf"
+        assert footer_delta["sources"][0]["artifact_id"] == "artifact-responsibilities"
         assert final["choices"][0]["finish_reason"] == "stop"
         assert final["choices"][0]["delta"] == {"content": ""}
 


### PR DESCRIPTION
## Summary
- Revert the citation rendering changes from #754 and #756 back to the last known-good state before the LibreChat source-channel split.
- Restore visible `**Bronnen**` output for all selected KB sources and restore full `message.sources` metadata, including upload-backed sources without URLs.
- Remove the split helper/tests that filtered metadata to URL-backed sources only.

## Why
The channel split was intended to address duplicate LibreChat citation/activity rendering, but it broke the core citation contract: citations could disappear or lose source metadata for upload-backed sources. For production safety, this PR restores the known-good citation engine first. The duplicate Agent activiteit issue should be investigated separately with real persisted/streaming fixtures instead of changing source channels.

## Validation
- `uv run pytest tests/test_citations.py -q`
- `node deploy/librechat/tests/stream_sources.test.cjs`
- `uv run --python 3.12 --with pytest --with pytest-asyncio --with httpx --with ./klai-libs/citations --with ./klai-libs/llm-safety --with ./klai-libs/chat-prompts --with ./klai-libs/retrieval-telemetry pytest deploy/litellm/tests/test_klai_knowledge_hook.py -q`