### PR TITLE
Strip citation footers from assistant history

### DIFF
--- a/deploy/litellm/klai_knowledge.py
+++ b/deploy/litellm/klai_knowledge.py
@@ -757,6 +757,73 @@ def _llm_safety_short_circuit(
     return data
 
 
+_KLAI_SOURCES_METADATA_MARKER_RE = re.compile(
+    r"\n?<!--\s*klai_sources=[A-Za-z0-9_-]+={0,2}\s*-->\n?",
+    re.IGNORECASE,
+)
+_KLAI_BACKEND_FOOTER_HEADING_RE = re.compile(
+    r"(?im)^[ \t]*(?:\*\*)?(Bronnen|Agent activiteit)(?:\*\*)?[ \t]*$"
+)
+
+
+def _strip_klai_backend_footer_from_text(text: str) -> str:
+    """Remove Klai-managed citation/provenance footer from assistant history."""
+    without_marker = _KLAI_SOURCES_METADATA_MARKER_RE.sub("\n", text)
+    matches = list(_KLAI_BACKEND_FOOTER_HEADING_RE.finditer(without_marker))
+    first_activity_index = next(
+        (
+            index
+            for index, match in enumerate(matches)
+            if match.group(1).lower() == "agent activiteit"
+        ),
+        None,
+    )
+    if first_activity_index is None:
+        return without_marker.rstrip() if without_marker != text else text
+
+    cut_match = matches[first_activity_index]
+    for match in reversed(matches[:first_activity_index]):
+        if match.group(1).lower() == "bronnen":
+            cut_match = match
+            break
+    return without_marker[: cut_match.start()].rstrip()
+
+
+def _strip_klai_backend_footer_from_content(content: object) -> object:
+    if isinstance(content, str):
+        return _strip_klai_backend_footer_from_text(content)
+    if isinstance(content, list):
+        changed = False
+        stripped_parts: list[object] = []
+        for part in content:
+            if isinstance(part, dict) and isinstance(part.get("text"), str):
+                stripped_text = _strip_klai_backend_footer_from_text(part["text"])
+                if stripped_text != part["text"]:
+                    changed = True
+                    part = {**part, "text": stripped_text}
+            stripped_parts.append(part)
+        return stripped_parts if changed else content
+    return content
+
+
+def _sanitize_assistant_history_messages(messages: object) -> object:
+    """Strip backend-only footers from assistant messages before model input."""
+    if not isinstance(messages, list):
+        return messages
+    sanitized: list[object] = []
+    for message in messages:
+        if not isinstance(message, dict) or message.get("role") != "assistant":
+            sanitized.append(message)
+            continue
+        content = message.get("content")
+        stripped_content = _strip_klai_backend_footer_from_content(content)
+        if stripped_content == content:
+            sanitized.append(message)
+        else:
+            sanitized.append({**message, "content": stripped_content})
+    return sanitized
+
+
 def _build_conversation_history(messages: list[dict]) -> list[dict]:
     """Return up to the last 6 turns (3 exchanges) of user/assistant history.
 
@@ -764,7 +831,12 @@ def _build_conversation_history(messages: list[dict]) -> list[dict]:
     Used by retrieval-api for coreference resolution ("hij" → "Jan Pietersen").
     """
     history = [
-        {"role": m["role"], "content": m["content"]}
+        {
+            "role": m["role"],
+            "content": _strip_klai_backend_footer_from_text(m["content"])
+            if m.get("role") == "assistant"
+            else m["content"],
+        }
         for m in messages[:-1]
         if m.get("role") in ("user", "assistant") and isinstance(m.get("content"), str)
     ]
@@ -2624,7 +2696,8 @@ class KlaiKnowledgeHook(CustomLogger):
         if call_type not in ("completion", "acompletion"):
             return data
 
-        messages = data.get("messages", [])
+        messages = _sanitize_assistant_history_messages(data.get("messages", []))
+        data["messages"] = messages
         query = _last_user_message(messages)
         if not query or _is_trivial(query):
             return data

--- a/deploy/litellm/tests/test_klai_knowledge_hook.py
+++ b/deploy/litellm/tests/test_klai_knowledge_hook.py
@@ -303,6 +303,50 @@ def _patch_http(monkeypatch, portal_resp=None, retrieval_resp=None):
 # ─── Legacy tests (preserved, updated for new hook) ─────────────────────────
 
 class TestKlaiKnowledgeHookLegacy:
+    def test_strips_backend_footer_from_assistant_history_text(self, monkeypatch):
+        """Prior deterministic footers must not be fed back to the model."""
+        mod = _load_hook(monkeypatch)
+
+        content = (
+            "Het antwoord zelf blijft beschikbaar.\n\n"
+            "**Bronnen**\n"
+            "- [Handleiding](https://docs.example/manual)\n\n"
+            "**Agent activiteit**\n"
+            "- Modus: Strict, alleen kennisbank.\n"
+            "- Kennisbank geraadpleegd: 9 fragmenten opgehaald in 1004 ms.\n\n"
+            "<!-- klai_sources=eyJ0ZXN0IjpbXX0 -->"
+        )
+
+        assert mod._strip_klai_backend_footer_from_text(content) == (
+            "Het antwoord zelf blijft beschikbaar."
+        )
+
+    def test_sanitizes_assistant_history_content_parts(self, monkeypatch):
+        """LibreChat can send text content as parts; strip those too."""
+        mod = _load_hook(monkeypatch)
+
+        messages = [
+            {"role": "user", "content": "Wat is het budget?"},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": (
+                            "Het budget is 100k.\n\n"
+                            "**Agent activiteit**\n"
+                            "- Modus: Open, kennisbank met fallback."
+                        ),
+                    }
+                ],
+            },
+        ]
+
+        sanitized = mod._sanitize_assistant_history_messages(messages)
+
+        assert sanitized[0] is messages[0]
+        assert sanitized[1]["content"][0]["text"] == "Het budget is 100k."
+
     @pytest.mark.asyncio
     async def test_retrieve_request_includes_auth_header(self, monkeypatch):
         """V001: retrieve request must include X-Internal-Secret header.
@@ -362,6 +406,32 @@ class TestKlaiKnowledgeHookLegacy:
             if post_call:
                 headers = post_call.kwargs.get("headers") or {}
                 assert "X-Internal-Secret" not in headers
+
+    @pytest.mark.asyncio
+    async def test_no_kb_branch_strips_assistant_footer_from_provider_input(self, monkeypatch):
+        """Even non-retrieval branches must not feed old footers to the model."""
+        mod = _load_hook(monkeypatch)
+        hook = mod.KlaiKnowledgeHook()
+        cache = _make_cache(feature_enabled=False)
+
+        data = {"user": "aabbcc112233445566778899", "messages": [
+            {"role": "user", "content": "Wat is het budget?"},
+            {
+                "role": "assistant",
+                "content": (
+                    "Het budget is 100k.\n\n"
+                    "**Agent activiteit**\n"
+                    "- Modus: Strict, alleen kennisbank."
+                ),
+            },
+            {"role": "user", "content": "En wie beheert het?"},
+        ]}
+
+        result = await hook.async_pre_call_hook(_make_user_api_key(), cache, data, "completion")
+
+        assistant = next(message for message in result["messages"] if message["role"] == "assistant")
+        assert assistant["content"] == "Het budget is 100k."
+        assert "**Agent activiteit**" not in assistant["content"]
 
 
 # ─── SPEC-SEC-SERVICE-AUTH-001 Phase C-1 — dual-auth tests ──────────────────
@@ -1415,7 +1485,17 @@ class TestKlaiKnowledgeHookKB010:
 
         data = {"user": "aabbcc112233445566778899", "messages": [
             {"role": "user", "content": "Wat is het budget?"},
-            {"role": "assistant", "content": "Het budget is 100k."},
+            {
+                "role": "assistant",
+                "content": (
+                    "Het budget is 100k.\n\n"
+                    "**Bronnen**\n"
+                    "- [Budgetplan](https://docs.example/budget)\n\n"
+                    "**Agent activiteit**\n"
+                    "- Modus: Strict, alleen kennisbank.\n"
+                    "- Kennisbank geraadpleegd: 12 fragmenten opgehaald in 804 ms."
+                ),
+            },
             {"role": "user", "content": "Wie heeft dat besloten?"},
         ]}
 
@@ -1433,6 +1513,11 @@ class TestKlaiKnowledgeHookKB010:
             assert len(history) == 2
             assert history[0]["role"] == "user"
             assert history[1]["role"] == "assistant"
+            assert history[1]["content"] == "Het budget is 100k."
+            assert "**Bronnen**" not in history[1]["content"]
+            assert "**Agent activiteit**" not in history[1]["content"]
+            assistant = next(message for message in data["messages"] if message["role"] == "assistant")
+            assert assistant["content"] == "Het budget is 100k."
 
     @pytest.mark.asyncio
     async def test_gate_bypass_no_injection(self, monkeypatch):


### PR DESCRIPTION
## Summary
- Strip Klai-managed citation/provenance footers from prior assistant messages before they are sent back to the model.
- Apply the same stripping to retrieval/coreference conversation_history so old `**Bronnen**` / `**Agent activiteit**` blocks do not influence rewrite/retrieval.
- Preserve stored LibreChat messages and current response rendering; this only changes model input/history copies.

## Root cause
Production Mongo + VictoriaLogs showed duplicate `Agent activiteit` was not caused by `message.sources`. Previous assistant messages already contained deterministic Klai footers. Those footers were sent back in later model history, the model sometimes repeated them, and the backend then appended the current deterministic footer. That produced duplicated activity/source sections in one saved assistant message.

## Validation
- `uv run --python 3.12 --with pytest --with pytest-asyncio --with httpx --with ./klai-libs/citations --with ./klai-libs/llm-safety --with ./klai-libs/chat-prompts --with ./klai-libs/retrieval-telemetry pytest deploy/litellm/tests/test_klai_knowledge_hook.py -q`
- `uv run --python 3.12 --with pytest --with pytest-asyncio --with httpx --with ./klai-libs/citations --with ./klai-libs/llm-safety --with ./klai-libs/chat-prompts --with ./klai-libs/retrieval-telemetry pytest deploy/litellm/tests/test_query_rewrite.py -q`
- `uv run pytest tests/test_citations.py -q` in `klai-libs/citations`
- `node deploy/librechat/tests/stream_sources.test.cjs`