### PR TITLE
fix(infra): raise MongoDB nofile for backups

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -106,6 +106,10 @@ services:
   mongodb:
     image: mongo:8.2.7
     restart: unless-stopped
+    ulimits:
+      nofile:
+        soft: 64000
+        hard: 64000
     volumes:
       - mongodb-data:/data/db
     environment:

--- a/deploy/scripts/backup.sh
+++ b/deploy/scripts/backup.sh
@@ -21,6 +21,7 @@ readonly BACKUP_DIR="${BACKUP_DIR:-${BACKUP_ROOT}/${BACKUP_DATE}}"
 readonly COMPOSE_DIR="${COMPOSE_DIR:-/opt/klai}"
 readonly SECRETS_DIR="${SECRETS_DIR:-${COMPOSE_DIR}/secrets}"
 readonly MONGODB_NETWORK="${MONGODB_NETWORK:-klai-net-mongodb}"
+readonly MONGODB_MIN_NOFILE="${MONGODB_MIN_NOFILE:-64000}"
 readonly QDRANT_NETWORK="${QDRANT_NETWORK:-klai-net}"
 readonly TOTAL_STEPS=16
 
@@ -103,6 +104,10 @@ container_restart_count() {
 
 container_started_at() {
   docker inspect -f '{{.State.StartedAt}}' "$1"
+}
+
+container_nofile_limit() {
+  docker exec "$1" sh -lc 'ulimit -n'
 }
 
 container_env_value() {
@@ -196,6 +201,7 @@ backup_mongodb() {
   local before_started_at
   local after_restarts
   local after_started_at
+  local nofile_limit
 
   container="$(ctr mongodb)"
   output="${BACKUP_DIR}/mongodb-all.archive"
@@ -203,6 +209,11 @@ backup_mongodb() {
 
   if ! container_running "${container}"; then
     fail "MongoDB container is not running"
+  fi
+
+  nofile_limit="$(container_nofile_limit "${container}")"
+  if [[ "${nofile_limit}" =~ ^[0-9]+$ && "${nofile_limit}" -lt "${MONGODB_MIN_NOFILE}" ]]; then
+    fail "MongoDB nofile limit is ${nofile_limit}; set compose ulimits.nofile to at least ${MONGODB_MIN_NOFILE}"
   fi
 
   image="$(docker inspect -f '{{.Config.Image}}' "${container}")"


### PR DESCRIPTION
## Summary
- Raise the MongoDB container `nofile` ulimit to 64000.
- Add a backup preflight that fails clearly if MongoDB is running below the required file descriptor limit.

## Root Cause
The core backup was red because `mongodump` caused MongoDB/WiredTiger to open enough collection/index files to hit the container's default `nofile=1024` limit. MongoDB then fatal-asserted with `Too many open files`, Docker restarted the container, and `backup.sh` correctly failed because MongoDB restarted during the dump.

Production evidence from `core-01`:
- before rollout: `docker exec klai-core-mongodb-1 sh -lc 'ulimit -n'` returned `1024`
- Mongo logs showed `Too many open files` and startup warning `recommendedMinimum=64000`
- backup log showed `ERROR: MongoDB restarted during mongodump`

## Production Rollout Already Applied
This fix was manually applied to `core-01` before opening the PR:
- synced `/opt/klai/docker-compose.yml`
- synced `/opt/klai/scripts/backup.sh`
- force-recreated only `mongodb`
- verified MongoDB is `healthy` with `nofile=64000`

## Validation
- `bash -n deploy/scripts/backup.sh`
- `git diff --check -- deploy/docker-compose.yml deploy/scripts/backup.sh`
- `docker compose -f deploy/docker-compose.yml config --services`
- production manual backup: exit `0`, all 16 steps completed, Storage Box upload succeeded
- production MongoDB after backup: `nofile=64000`, `restarts=0`, `health=healthy`
