### PR TITLE
docs(agents): unify Codex + Claude instruction layer

### DIFF
--- a/.agents/codex/README.md
+++ b/.agents/codex/README.md
@@ -1,0 +1,34 @@
+# Codex-specific notes
+
+Reference for agents running under Codex (GPT-5.5) in this repo. The binding
+rules are in the `AGENTS.md` hierarchy; this file only explains what differs
+from Claude so no agent makes a false assumption.
+
+## What Codex does NOT have (that Claude does)
+
+- **No Stop / PreToolUse hooks.** Claude mechanically enforces the confidence
+  format, fail-loud, worktree, and container-hygiene rules via hooks in
+  `.claude/settings.json`. Codex runs none of these. Under Codex, the rules in
+  `AGENTS.md` are self-enforced — there is no safety net that blocks a bad
+  action or rejects a "done" claim without evidence. Hold yourself to them.
+- **No `paths:`-scoped auto-loading.** Claude auto-loads `.claude/rules/klai/**`
+  when matching files are opened. Codex only auto-loads files named `AGENTS.md`
+  in the directory chain (root → cwd, 32 KiB combined cap). The compact gates
+  in each `AGENTS.md` are therefore self-sufficient; the `.claude/rules/**`
+  files are optional deeper reference you must choose to open.
+- **No MoAI `/moai …` orchestration or Claude `Agent()` subagent catalog.**
+  Those are Claude-only. Use Codex's own task/plan model; do not treat MoAI
+  command syntax or the Agent catalog as required workflow.
+
+## What Codex shares with Claude
+
+- The same MCP servers (`serena`, `context7`, `playwright`, `codeindex`,
+  `grafana`, `victorialogs`) — configured in `~/.codex/config.toml`.
+- The same model-neutral rules in the root and nested `AGENTS.md` files.
+
+## How instructions load under Codex
+
+Codex concatenates `AGENTS.md` from the repo root down to your working
+directory; closer files win on conflict. A linked file that is NOT named
+`AGENTS.md` is read only if you decide to open it — never rely on a link to
+carry a hard rule. That is why every gate here is inline.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,82 @@
+# Klai — Agent Operating Rules
+
+Model-neutral rules for every agent in this monorepo (Codex, Claude, or other).
+Codex reads this file natively. Claude reads it via `@AGENTS.md` in `CLAUDE.md`.
+A nested `AGENTS.md` closer to the file you edit overrides anything here.
+
+> Enforcement note: Claude runs Stop/PreToolUse hooks that mechanically enforce
+> some of these rules. **Codex runs no such hooks** — under Codex these rules
+> are self-enforced only. Treat them as MUST, not as suggestions.
+> Codex-specific notes: `.agents/codex/README.md`.
+
+## Prime directive — autonomy on execution, strictness on claims
+
+- Keep going. Do not ask permission to proceed, to push approved work, or to
+  move to the next step. Stop only for (a) a real decision the user must make,
+  or (b) a failing guard: CI red, test failure, or unverifiable external state.
+- You may NOT claim "fixed / done / deployed" without evidence per claim.
+  "Looks correct" / "should work" / "reviewed the code" is not evidence — it
+  scores zero. Prove it, don't assert it.
+
+## Always-on engineering discipline
+
+- **data-before-code** — Trace real logs / DB / runtime before fixing. No
+  guessing, no stacked patches. For production: query VictoriaLogs by
+  `request_id:<uuid>`. One root cause confirmed by data = one fix.
+- **fail loudly** — No silent fallback on external-provider drift. Unknown
+  external state = raise an error or report explicit residual risk. No
+  "best-effort success" when the core mutation failed. (Database-layer RLS
+  defense-in-depth is deliberate and stays — this rule is about app-layer
+  shims, not the DB security model.)
+- **minimal changes** — Only what was asked. No drive-by refactors, reformatting,
+  or "improvements" to untouched files.
+- **verify-changes-landed** — Before reporting done: `git diff --stat` (right
+  files?), service health/logs (running new code?), and a Playwright
+  click-through for any UI change (real user flow works?).
+- **search broadly when changing a default/name** — grep every consumer, all
+  case variants (kebab, snake, camel, Pascal, SCREAMING_SNAKE). Defaults have
+  unbounded blast radius.
+- **no plausible assumptions** — Do not infer `message.sources`, Zitadel
+  password policy, streaming chunks, BFF cookies, OIDC flows, or performance
+  paths from intuition. Require evidence from code, tests, logs, docs, or an
+  explicit user confirmation.
+
+## Production bugfix gate (stateful / customer-reported bugs)
+
+Treat a customer report as a SYMPTOM, not a diagnosis. Before closing:
+
+1. **Contract first** — write down: visible problem · which system contract is
+   hit · who is source of truth (frontend / backend / Zitadel / LibreChat /
+   LiteLLM / retrieval-api / …) · which tests prove it, which are missing.
+2. **Reproduce or trace** the real runtime/code path — confirmed by data.
+3. **State/lifecycle matrix** — list every state the entity can hold and every
+   route/API/UI action that mutates it; check the fix against all of them.
+4. **Regression test first** — write a test that FAILS on the broken
+   user-visible behavior BEFORE the patch. Test name names the contract, not
+   the implementation. Then patch. Cover: reported path + one adjacent edge +
+   the legacy/partial-failure external-system state.
+5. **Shared-helper stopgate** — if the change touches a multi-path helper
+   (citation rendering, password policy, auth, Zitadel, streaming, caching,
+   retrieval): before patching, report direct callers, indirect paths, which
+   paths you test, and which you cannot.
+
+Auth / invite / delete / offboard / suspend / IdP bugs have an extra gate in
+`klai-portal/backend/AGENTS.md`. Use CodeIndex `impact` before editing any
+shared helper; if the index is stale, verify against source + git history.
+
+## End-of-bugfix answer format
+
+Separate evidence from assumptions. Always end with:
+
+```
+Proven:           <claim · source path · test name · command run>
+Assumed:          <what you took on faith>
+Not verified:     <what you could not check>
+Tests run:        <commands + result>
+Remaining risk:   <honest residual>
+Confidence: [0-100] — <one-line evidence summary>   (evidence only; "looks right" = 0)
+```
+
 <!-- codeindex:start -->
 # CodeIndex MCP
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,12 @@
 # MoAI Execution Directive
 
+@AGENTS.md
+
+<!-- The import above pulls in the model-neutral Klai agent rules (prime
+directive, engineering discipline, production-bugfix gate, answer format) that
+Codex reads natively from AGENTS.md. Keeping them in one neutral source avoids
+drift between Codex and Claude. Claude-specific orchestration follows below. -->
+
 ## 1. Core Identity
 
 MoAI is the Strategic Orchestrator for Claude Code. All tasks must be delegated to specialized agents.

--- a/klai-portal/AGENTS.md
+++ b/klai-portal/AGENTS.md
@@ -1,0 +1,30 @@
+# klai-portal
+
+Inherits the root `AGENTS.md`. Rules below apply to everything under
+`klai-portal/`. Backend- and frontend-specific gates live in
+`backend/AGENTS.md` and `frontend/AGENTS.md`.
+
+## Deploy DoD (CRIT)
+
+After every commit to klai-portal:
+
+1. `git push`
+2. `gh run watch --exit-status` — wait for the GitHub Action to complete.
+3. Verify server rollout — check bundle timestamp or container age on core-01.
+
+**Never claim something is deployed before BOTH CI is green AND the new code is
+confirmed on the server.** Do not run `portal-deploy.sh` manually — the GitHub
+Action handles it. ("CI green" alone is not "deployed".)
+
+## Tenant & user lifecycle runbooks
+
+Stateful flows with their own state machines — read the runbook before changing
+them, and follow the identity gate in `backend/AGENTS.md`:
+
+- Tenant provisioning: `docs/runbooks/provisioning-retry.md` (state machine,
+  retry endpoint, stuck-detector — SPEC-PROV-001).
+- Tenant deprovisioning: `docs/runbooks/tenant-delete.md` (16-step orchestrator,
+  owner self-service delete, platform-admin endpoints — SPEC-INFRA-TENANT-DELETE-001).
+- User offboarding: `docs/runbooks/user-offboarding.md` (disposition wizard,
+  KB transfer/delete, auto-revoke of API keys + MCP tokens, suspend-vs-offboard
+  — SPEC-PORTAL-KB-OWNERSHIP-001).

--- a/klai-portal/CLAUDE.md
+++ b/klai-portal/CLAUDE.md
@@ -1,22 +1,5 @@
-# klai-portal
+@AGENTS.md
 
-## Deploy workflow
-
-After every commit to klai-portal:
-
-1. `git push`
-2. `gh run watch --exit-status` — wait for the GitHub Action to complete
-3. Verify server rollout — check bundle timestamp or container age on core-01
-
-Never claim something is deployed before both CI is green AND the new code is confirmed on the server. Do not run `portal-deploy.sh` manually — the GitHub Action handles it.
-
-## Key rules
-
-- All UI components must come from `components/ui/` — never use raw `<button>`, `<input>`, `<select>` with inline Tailwind
-- Form pages: `max-w-lg`, header `flex items-center justify-between mb-6` (title left, ghost cancel button right)
-- Error text: `text-[var(--color-destructive)]` not `text-red-600`
-- i18n: all UI strings via Paraglide (`import * as m from '@/paraglide/messages'`)
-- Reference implementation: `frontend/src/routes/admin/users/invite.tsx`
-- Tenant provisioning: see [docs/runbooks/provisioning-retry.md](../docs/runbooks/provisioning-retry.md) for the state machine, retry endpoint, and stuck-detector behaviour (SPEC-PROV-001).
-- Tenant deprovisioning: see [docs/runbooks/tenant-delete.md](../docs/runbooks/tenant-delete.md) for the 16-step orchestrator, owner self-service delete, platform-admin endpoints, and manual cleanup (SPEC-INFRA-TENANT-DELETE-001).
-- User offboarding: see [docs/runbooks/user-offboarding.md](../docs/runbooks/user-offboarding.md) for the disposition wizard, KB transfer/delete choice, auto-revoke of API keys + MCP tokens, and suspend-vs-offboard guidance (SPEC-PORTAL-KB-OWNERSHIP-001).
+<!-- Canonical klai-portal rules live in AGENTS.md (deploy DoD, tenant/user
+lifecycle runbooks) so Codex and Claude read the same source. Frontend UI rules:
+frontend/AGENTS.md. Backend RLS + identity gates: backend/AGENTS.md. -->

--- a/klai-portal/backend/AGENTS.md
+++ b/klai-portal/backend/AGENTS.md
@@ -1,0 +1,79 @@
+# klai-portal backend
+
+Inherits root `AGENTS.md` and `klai-portal/AGENTS.md`. This file holds the hard
+gates that have caused production incidents. They are compact on purpose; the
+full reference lives in `.claude/rules/klai/projects/portal-{backend,security}.md`
+and `platform/zitadel.md` (Claude auto-loads these by path; under Codex, open
+them when a gate below points you there).
+
+## Before changing DB access, migrations, or auth code
+
+RLS is live on portal tables (4-category framework). Read
+`.claude/rules/klai/projects/portal-security.md` and `…/portal-backend.md`
+before touching DB access or writing a migration.
+
+## MUST — these have bitten production
+
+1. **Alembic on Cat-A FORCE-RLS tables (`portal_users`, `portal_connectors`):
+   no `UPDATE`/`INSERT` inside `upgrade()`.** WITH CHECK fires with no tenant
+   context during migration → every row rejected → container crashloops. Pure
+   DDL only in `upgrade()`; put per-row backfill in `post_deploy_<rev>.sql`
+   (applied as the `klai` superuser). `ADD COLUMN … NOT NULL DEFAULT '…'` is
+   safe (metadata-only); a later `UPDATE` backfill is not.
+2. **New env var read by a pydantic validator → add it to
+   `klai-infra/<server>/.env.sops` FIRST.** A validator that rejects empty
+   values ships before the var exists = startup ValidationError = 502 crashloop.
+   Env var first, validator second. Never the same deploy gap without the var.
+3. **Encryption-key / secret fields need a `@field_validator(mode="after")`
+   that rejects empty/invalid at startup.** Empty AES/Fernet key crashes
+   mid-lifespan with a cryptic error; empty auth secret fails OPEN. Fail-closed,
+   fail-loud, at module load.
+4. **Compare secrets/tokens/signatures with `hmac.compare_digest`, never
+   `==`/`!=`.** `==` short-circuits and leaks length/content via timing.
+5. **Cat-A RLS tables are queried before tenant context is set** → use the
+   inline NULLIF pattern, not the `_rls_current_org_id()` helper (helper raises
+   42501 and 500s every authenticated request). Cat-D strict tenant tables use
+   the helper. Never swap them.
+
+Use CodeIndex `impact` before editing any shared helper. If the index is stale,
+verify against source + git history — do not trust a stale call graph.
+
+## Identity lifecycle gate (auth / invite / delete / offboard / suspend / IdP)
+
+Klai identity spans TWO systems. A bug is only closed when BOTH are accounted
+for, per state. Never reason about one in isolation. This is the gate that the
+invite/password-reset incident bypassed by closing too early.
+
+**Source of truth:** `sub` (OIDC subject) → `portal_users` → `portal_orgs`
+join. `portal_users` is a mapping only (no email/name; identity is fetched live
+from Zitadel). Never use `urn:zitadel:iam:user:resourceowner:id` — it is absent
+from every Klai token (CI rule blocks reintroduction).
+
+**Fill in the matrix before closing:**
+
+| Dimension | States to check |
+|---|---|
+| portal_users row | exists / missing |
+| portal_users.status | active · suspended · offboarded · invite_pending |
+| Zitadel identity | exists / missing |
+| Zitadel user state | active · initial · inactive(deactivated) · locked |
+| Tenant membership | single vs multiple memberships |
+
+**Delete semantics:** hard-delete the local row; remove the Zitadel identity
+ONLY if this was the user's LAST membership; preserve it if the user still
+belongs to another tenant.
+
+**Re-invite semantics (where the bug lived):**
+- `status=active` → resend invite; do not recreate the identity.
+- `status=offboarded` → reactivation path, not a fresh create.
+- **Legacy dangling Zitadel identity** (local row gone, Zitadel user still
+  present) → must be detected and reconciled. A fresh invite against a dangling
+  identity is what produced "Link has expired or is invalid". Always check this
+  branch for delete-then-re-add scenarios.
+
+**Evidence rule:** any claim about external cleanup MUST cite the exact Zitadel
+API call (method + path) that performed or verified it. "Zitadel cleaned it up"
+without the `DELETE /management/v1/users/<id>` cited is not done. Confirm a hard
+delete actually removed the user; do not assume.
+
+Background: `.claude/rules/klai/platform/zitadel.md`.

--- a/klai-portal/backend/CLAUDE.md
+++ b/klai-portal/backend/CLAUDE.md
@@ -1,0 +1,6 @@
+@AGENTS.md
+
+<!-- Canonical backend hard gates (RLS, alembic, secrets, identity lifecycle)
+live in AGENTS.md so Codex and Claude read the same source. Deeper detail stays
+in .claude/rules/klai/projects/portal-{backend,security}.md and
+platform/zitadel.md, which Claude auto-loads by path. -->

--- a/klai-portal/frontend/CLAUDE.md
+++ b/klai-portal/frontend/CLAUDE.md
@@ -1,0 +1,4 @@
+@AGENTS.md
+
+<!-- Canonical frontend UI rules live in this directory's AGENTS.md (and
+frontend/docs/ui-standards.md) so Codex and Claude read the same source. -->


### PR DESCRIPTION
Make Klai's hard-won engineering rules reach **both** Codex (GPT-5.5) and Claude (Opus 4.8) reliably.

## Why
Research-backed (Anthropic memory docs + OpenAI Codex AGENTS.md guide):
- Codex auto-loads **only** files literally named `AGENTS.md` (root→cwd, 32 KiB cap).
- Claude reads `CLAUDE.md`, **not** `AGENTS.md`; only `@import` is reliably auto-loaded.
- Plain "read this file" links are best-effort for **both** models.

So every gate is **inlined in the narrowest auto-loaded surface**, never carried by a fragile cross-file link. `AGENTS.md` is the model-neutral source; `CLAUDE.md` bridges to it via `@AGENTS.md`.

## What
- `AGENTS.md` (root): prime directive (autonomy on execution, strictness on claims), always-on engineering discipline, production-bugfix gate, evidence/assumption answer format. Prepended above the CodeIndex block (markers intact).
- `CLAUDE.md` (root): `@AGENTS.md` bridge so Claude loads the same source.
- `klai-portal/AGENTS.md`: deploy DoD + tenant/user lifecycle runbooks.
- `klai-portal/backend/AGENTS.md`: RLS/alembic/secret MUST rules + identity-lifecycle gate (the gate the invite/password-reset incident bypassed by closing too early).
- Nested `CLAUDE.md` mirrors (`@AGENTS.md`) for portal / backend / frontend.
- `.agents/codex/README.md`: what Codex lacks (no hooks, no `paths:` loading).

## Notes
- Instruction layer only — **no code changes**.
- Content moved out of `klai-portal/CLAUDE.md` (UI rules) was verified to survive in `frontend/docs/ui-standards.md` + `frontend/AGENTS.md`; deploy/runbook content moved to `klai-portal/AGENTS.md`. Net de-duplication.
- Chain size root→backend = 11.3 KB, well under Codex's 32 KiB cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)