### PR TITLE
docs(agents): clean-code + proportionality + Codex reasoning-effort rules

### DIFF
--- a/.agents/codex/README.md
+++ b/.agents/codex/README.md
@@ -20,6 +20,19 @@ from Claude so no agent makes a false assumption.
   Those are Claude-only. Use Codex's own task/plan model; do not treat MoAI
   command syntax or the Agent catalog as required workflow.
 
+## Reasoning effort
+
+Default is `medium` (set in `~/.codex/config.toml`). Re-evaluate the level
+before escalating — escalate for genuine uncertainty, not by default:
+
+- `none` / `low` — titles, branch names, small docs, known-file copy edits.
+- `medium` — normal Codex work: scoped bugfixes, PR comments, small
+  backend/frontend tasks.
+- `high` — architecture, security, migrations, multi-file refactors, unclear
+  production bugs, schema changes, live deploys.
+- `xhigh` — only when "we don't know where the truth is": large system design,
+  cross-service root-cause, security-critical review.
+
 ## What Codex shares with Claude
 
 - The same MCP servers (`serena`, `context7`, `playwright`, `codeindex`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,15 @@ A nested `AGENTS.md` closer to the file you edit overrides anything here.
   shims, not the DB security model.)
 - **minimal changes** — Only what was asked. No drive-by refactors, reformatting,
   or "improvements" to untouched files.
+- **clean over clever, no parallel old+new** — Remove the code your change
+  replaces in the SAME change: no dead fields, no commented-out blocks, no old
+  and new flow living side by side. Clean solutions over defensive clutter. (This
+  is about removing what you replaced — not editing untouched files; it composes
+  with "minimal changes", it does not contradict it.)
+- **scale the answer to the problem** — Lead with the simplest solution that
+  works (the 5-minute fix if one exists); escalate to a bigger design only when
+  the problem demands it. No SPEC for something that affects 1–5 people. State
+  explicitly what you deliberately did NOT do.
 - **verify-changes-landed** — Before reporting done: `git diff --stat` (right
   files?), service health/logs (running new code?), and a Playwright
   click-through for any UI change (real user flow works?).


### PR DESCRIPTION
Follow-up to #764. Closes the gaps found by auditing the GPT-5.5 and Opus 4.8 upgrade handbooks against the merged instruction layer.

- **AGENTS.md — clean-code philosophy** (Mark's most-repeated value, 380× "schone code"; the GPT-5.5 handbook explicitly recommends putting it in AGENTS.md): remove the code your change replaces in the same change, no dead fields, no parallel old+new flows. Reconciled with `minimal changes`.
- **AGENTS.md — proportionality**: simplest fix first, no SPEC for 1-5 people, state what you deliberately did NOT do. Was only in `.claude/rules` (Claude-only) → now neutral so Codex sees it too.
- **.agents/codex/README.md — reasoning-effort discipline**: `medium` default; escalate to `high`/`xhigh` only for security, migrations, multi-file refactors, cross-service root-cause.

Instruction layer only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)