### PR TITLE
docs: align CodeIndex with Conductor worktrees

### DIFF
--- a/.claude/rules/klai/codeindex.md
+++ b/.claude/rules/klai/codeindex.md
@@ -57,15 +57,22 @@ RETURN n.name, n.filePath
 
 ## Keeping the Index Fresh
 
-The index is a snapshot. After code changes it becomes stale.
+CodeIndex keeps one shared index for `klai`. In Conductor, that shared index is
+pinned to the main base (`origin/main`), while feature worktrees are treated as
+local overlays. Do not refresh the global index from a feature worktree just
+because the worktree has branch-only files.
 
 | Situation | Command |
 |---|---|
-| After a feature branch | `codeindex update && node scripts/codeindex-enrich.mjs` |
-| Full re-index (force) | `./scripts/codeindex-analyze-and-enrich.sh --force` |
-| Check freshness | `codeindex status` |
+| Diagnose shared main-index health | `scripts/codeindex-health.sh` |
+| Repair stale shared main index | `scripts/codeindex-health.sh --repair` |
+| Disruptive recovery for stuck MCP transports | `scripts/codeindex-health.sh --repair --restart-mcp` |
+| Manual full re-index outside Conductor workflow | `./scripts/codeindex-analyze-and-enrich.sh --force` |
 
-The SessionStart hook warns when the index is behind HEAD.
+If MCP context reports stale but `scripts/codeindex-health.sh` says the shared
+base index is healthy, treat the warning as advisory and verify branch-local
+code via local diffs/source files. This can happen when the registered canonical
+checkout is not currently on main.
 
 ## Hooks (project-local)
 

--- a/.claude/skills/codeindex/codeindex-cli/SKILL.md
+++ b/.claude/skills/codeindex/codeindex-cli/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: codeindex-cli
-description: "Use when the user needs to run CodeIndex CLI commands like analyze/index a repo, check status, clean the index, generate a wiki, or list indexed repos. Examples: \"Index this repo\", \"Reanalyze the codebase\", \"Generate a wiki\""
+description: "Use only when the user explicitly asks to run CodeIndex CLI commands like analyze/index a repo, check status, clean the index, generate a wiki, or list indexed repos. Do not use this for normal code navigation, stale-index warnings, or missing MCP tools. Examples: \"Index this repo\", \"Reanalyze the codebase\", \"Generate a wiki\""
 ---
 
 # CodeIndex CLI Commands
 
-All commands work via `npx` — no global install required.
+Use these commands only for explicit index/setup/maintenance requests. For normal agent work, use the MCP tools (`query`, `context`, `impact`) and verify stale results against source files.
 
 ## Commands
 
 ### analyze — Build or refresh the index
 
 ```bash
-npx codeindex analyze
+codeindex analyze
 ```
 
 Run from the project root. This parses all source files, builds the knowledge graph, writes it to `~/.codeindex/<ProjectName>/` (global cache — NEVER inside the working copy), and generates CLAUDE.md / AGENTS.md context files in the project root.
@@ -22,12 +22,30 @@ Run from the project root. This parses all source files, builds the knowledge gr
 | `--force`      | Force full re-index even if up to date                           |
 | `--embeddings` | Enable embedding generation for semantic search (off by default) |
 
-**When to run:** First time in a project, after major code changes, or when `codeindex://repo/{name}/context` reports the index is stale.
+**When to run:** First time in a project or when the user explicitly asks to
+rebuild the index. Do not run this automatically just because
+`codeindex://repo/{name}/context` reports stale data.
+
+For Klai in Conductor, do **not** run ad hoc analyze/update commands from a
+feature worktree. That warning can be caused by a worktree overlay or by the
+registered checkout not being on main. Run `scripts/codeindex-health.sh` first;
+only if it reports the shared base index is stale, run
+`scripts/codeindex-health.sh --repair`.
+
+### update — Refresh an existing index
+
+```bash
+codeindex update
+```
+
+Use this only when the user explicitly asks to refresh a stale index. For Klai
+Conductor worktrees, prefer `scripts/codeindex-health.sh --repair` for the
+shared main index.
 
 ### status — Check index freshness
 
 ```bash
-npx codeindex status
+codeindex status
 ```
 
 Shows whether the current repo has a CodeIndex index, when it was last updated, and symbol/relationship counts. Use this to check if re-indexing is needed.
@@ -35,7 +53,7 @@ Shows whether the current repo has a CodeIndex index, when it was last updated, 
 ### clean — Delete the index
 
 ```bash
-npx codeindex clean
+codeindex clean
 ```
 
 Deletes the repo's entry under `~/.codeindex/<ProjectName>/` and unregisters it from the global registry. Use before re-indexing if the index is corrupt or after removing CodeIndex from a project. Never deletes anything inside the working copy.
@@ -50,7 +68,7 @@ Deletes the repo's entry under `~/.codeindex/<ProjectName>/` and unregisters it 
 ### wiki — Generate documentation from the graph
 
 ```bash
-npx codeindex wiki
+codeindex wiki
 ```
 
 Generates repository documentation from the knowledge graph using an LLM. Requires an API key (saved to `~/.codeindex/config.json` on first use).
@@ -67,7 +85,7 @@ Generates repository documentation from the knowledge graph using an LLM. Requir
 ### list — Show all indexed repos
 
 ```bash
-npx codeindex list
+codeindex list
 ```
 
 Lists all repositories registered in `~/.codeindex/registry.json`. The MCP `list_repos` tool provides the same information.
@@ -80,5 +98,5 @@ Lists all repositories registered in `~/.codeindex/registry.json`. The MCP `list
 ## Troubleshooting
 
 - **"Not inside a git repository"**: Run from a directory inside a git repo
-- **Index is stale after re-analyzing**: Restart Claude Code to reload the MCP server
+- **Index is stale during a code task**: In Conductor, run `scripts/codeindex-health.sh`; if the shared main index is healthy, treat CodeIndex results as advisory and verify branch-local code with source files
 - **Embeddings slow**: Omit `--embeddings` (it's off by default) or set `OPENAI_API_KEY` for faster API-based embedding

--- a/.claude/skills/codeindex/codeindex-debugging/SKILL.md
+++ b/.claude/skills/codeindex/codeindex-debugging/SKILL.md
@@ -22,7 +22,10 @@ description: "Use when the user is debugging a bug, tracing an error, or asking 
 4. codeindex_cypher({query: "MATCH path..."})                 → Custom traces if needed
 ```
 
-> If "Index is stale" → run `npx codeindex analyze` in terminal.
+> In Conductor worktrees, "Index is stale" can be an overlay/canonical-checkout
+> mismatch. Use `scripts/codeindex-health.sh`; only run
+> `scripts/codeindex-health.sh --repair` when it reports the shared base index
+> is stale. Verify branch-local code with source files/diffs.
 
 ## Checklist
 

--- a/.claude/skills/codeindex/codeindex-exploring/SKILL.md
+++ b/.claude/skills/codeindex/codeindex-exploring/SKILL.md
@@ -23,7 +23,10 @@ description: "Use when the user asks how code works, wants to understand archite
 5. READ codeindex://repo/{name}/process/{name}      → Trace full execution flow
 ```
 
-> If step 2 says "Index is stale" → run `npx codeindex analyze` in terminal.
+> In Conductor worktrees, "Index is stale" can be an overlay/canonical-checkout
+> mismatch. Use `scripts/codeindex-health.sh`; only run
+> `scripts/codeindex-health.sh --repair` when it reports the shared base index
+> is stale. Verify branch-local code with source files/diffs.
 
 ## Checklist
 

--- a/.claude/skills/codeindex/codeindex-guide/SKILL.md
+++ b/.claude/skills/codeindex/codeindex-guide/SKILL.md
@@ -15,7 +15,11 @@ For any task involving code understanding, debugging, impact analysis, or refact
 2. **Match your task to a skill below** and **read that skill file**
 3. **Follow the skill's workflow and checklist**
 
-> If step 1 warns the index is stale, run `npx codeindex analyze` in the terminal first.
+> In Conductor worktrees, a stale warning can be an overlay/canonical-checkout
+> mismatch rather than a broken shared index. Do **not** run `codeindex analyze`
+> or `codeindex update` from a feature worktree. Run
+> `scripts/codeindex-health.sh`; only if it reports the shared base index is
+> stale, run `scripts/codeindex-health.sh --repair`.
 
 ## Skills
 

--- a/.claude/skills/codeindex/codeindex-impact-analysis/SKILL.md
+++ b/.claude/skills/codeindex/codeindex-impact-analysis/SKILL.md
@@ -23,7 +23,10 @@ description: "Use when the user wants to know what will break if they change som
 4. Assess risk and report to user
 ```
 
-> If "Index is stale" → run `npx codeindex analyze` in terminal.
+> In Conductor worktrees, "Index is stale" can be an overlay/canonical-checkout
+> mismatch. Use `scripts/codeindex-health.sh`; only run
+> `scripts/codeindex-health.sh --repair` when it reports the shared base index
+> is stale. Verify branch-local code with source files/diffs.
 
 ## Checklist
 

--- a/.claude/skills/codeindex/codeindex-refactoring/SKILL.md
+++ b/.claude/skills/codeindex/codeindex-refactoring/SKILL.md
@@ -22,7 +22,10 @@ description: "Use when the user wants to rename, extract, split, move, or restru
 4. Plan update order: interfaces → implementations → callers → tests
 ```
 
-> If "Index is stale" → run `npx codeindex analyze` in terminal.
+> In Conductor worktrees, "Index is stale" can be an overlay/canonical-checkout
+> mismatch. Use `scripts/codeindex-health.sh`; only run
+> `scripts/codeindex-health.sh --repair` when it reports the shared base index
+> is stale. Verify branch-local code with source files/diffs.
 
 ## Checklists
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ Confidence: [0-100] — <one-line evidence summary>   (evidence only; "looks rig
 <!-- codeindex:start -->
 # CodeIndex MCP
 
-This project is indexed by CodeIndex as **klai** (15301 symbols, 19385 relationships, 0 execution flows).
+This project is indexed by CodeIndex as **klai** (16280 symbols, 20581 relationships, 0 execution flows).
 
 ## Rules (MUST follow)
 
@@ -104,7 +104,12 @@ This project is indexed by CodeIndex as **klai** (15301 symbols, 19385 relations
 2. **Match your task to a skill below** and **read that skill file**
 3. **Follow the skill's workflow and checklist**
 
-> If step 1 warns the index is stale, run `codeindex update` in the terminal first.
+> In Conductor worktrees, a stale warning can mean the current worktree or the
+> registered checkout differs from the shared main index. Do **not** run
+> `codeindex update` from a feature worktree. Run `scripts/codeindex-health.sh`;
+> only if it reports the shared base index is stale, run
+> `scripts/codeindex-health.sh --repair`. Treat branch changes as an overlay on
+> the shared graph and verify local diffs/source files directly.
 
 ## Skills
 
@@ -116,5 +121,18 @@ This project is indexed by CodeIndex as **klai** (15301 symbols, 19385 relations
 | Rename / extract / split / refactor | `.claude/skills/codeindex/codeindex-refactoring/SKILL.md` |
 | Tools, resources, schema reference | `.claude/skills/codeindex/codeindex-guide/SKILL.md` |
 | Index, status, clean, wiki CLI commands | `.claude/skills/codeindex/codeindex-cli/SKILL.md` |
+
+## If CodeIndex tools appear missing
+
+If you don't see CodeIndex tools in your active toolset, they are almost certainly **deferred/lazy-loaded** by the agent harness — **NOT disconnected**. The MCP server is fine.
+
+Use your harness's tool-discovery mechanism once, then continue with the loaded CodeIndex MCP tools:
+
+- **Claude Code**: call `ToolSearch` with `select:mcp__codeindex__query,mcp__codeindex__context,mcp__codeindex__impact,mcp__codeindex__detect_changes,mcp__codeindex__rename,mcp__codeindex__cypher,mcp__codeindex__remember,mcp__codeindex__recall,mcp__codeindex__forget`
+- **Codex / Conductor**: call `tool_search` with the same `select:mcp__codeindex__...` query above
+
+After that the tools are directly callable, usually as `mcp__codeindex__query` / `mcp__codeindex__.query` or plain `query`, depending on the harness. If a `list_repos` tool is not exposed, read the `codeindex://repos` resource instead.
+
+Do **NOT** run `npx codeindex`, `codeindex analyze`, or `codeindex update` as a workaround for "missing MCP" or a stale index. The CLI is for explicit setup/maintenance requests. In Conductor, use `scripts/codeindex-health.sh` to diagnose shared main-index health; if it is healthy, use CodeIndex results as advisory and verify branch-local code against source files.
 
 <!-- codeindex:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -582,7 +582,7 @@ For detailed patterns on plugins, sandboxing, headless mode, and version managem
 <!-- codeindex:start -->
 # CodeIndex MCP
 
-This project is indexed by CodeIndex as **klai** (15301 symbols, 19385 relationships, 0 execution flows).
+This project is indexed by CodeIndex as **klai** (16280 symbols, 20581 relationships, 0 execution flows).
 
 ## Rules (MUST follow)
 
@@ -597,7 +597,12 @@ This project is indexed by CodeIndex as **klai** (15301 symbols, 19385 relations
 2. **Match your task to a skill below** and **read that skill file**
 3. **Follow the skill's workflow and checklist**
 
-> If step 1 warns the index is stale, run `codeindex update` in the terminal first.
+> In Conductor worktrees, a stale warning can mean the current worktree or the
+> registered checkout differs from the shared main index. Do **not** run
+> `codeindex update` from a feature worktree. Run `scripts/codeindex-health.sh`;
+> only if it reports the shared base index is stale, run
+> `scripts/codeindex-health.sh --repair`. Treat branch changes as an overlay on
+> the shared graph and verify local diffs/source files directly.
 
 ## Skills
 
@@ -609,5 +614,18 @@ This project is indexed by CodeIndex as **klai** (15301 symbols, 19385 relations
 | Rename / extract / split / refactor | `.claude/skills/codeindex/codeindex-refactoring/SKILL.md` |
 | Tools, resources, schema reference | `.claude/skills/codeindex/codeindex-guide/SKILL.md` |
 | Index, status, clean, wiki CLI commands | `.claude/skills/codeindex/codeindex-cli/SKILL.md` |
+
+## If CodeIndex tools appear missing
+
+If you don't see CodeIndex tools in your active toolset, they are almost certainly **deferred/lazy-loaded** by the agent harness — **NOT disconnected**. The MCP server is fine.
+
+Use your harness's tool-discovery mechanism once, then continue with the loaded CodeIndex MCP tools:
+
+- **Claude Code**: call `ToolSearch` with `select:mcp__codeindex__query,mcp__codeindex__context,mcp__codeindex__impact,mcp__codeindex__detect_changes,mcp__codeindex__rename,mcp__codeindex__cypher,mcp__codeindex__remember,mcp__codeindex__recall,mcp__codeindex__forget`
+- **Codex / Conductor**: call `tool_search` with the same `select:mcp__codeindex__...` query above
+
+After that the tools are directly callable, usually as `mcp__codeindex__query` / `mcp__codeindex__.query` or plain `query`, depending on the harness. If a `list_repos` tool is not exposed, read the `codeindex://repos` resource instead.
+
+Do **NOT** run `npx codeindex`, `codeindex analyze`, or `codeindex update` as a workaround for "missing MCP" or a stale index. The CLI is for explicit setup/maintenance requests. In Conductor, use `scripts/codeindex-health.sh` to diagnose shared main-index health; if it is healthy, use CodeIndex results as advisory and verify branch-local code against source files.
 
 <!-- codeindex:end -->

--- a/docs/setup/mcp-servers.md
+++ b/docs/setup/mcp-servers.md
@@ -345,7 +345,23 @@ codeindex analyze
 node scripts/codeindex-enrich.mjs
 ```
 
-After code changes, refresh the index:
+For Klai's Conductor workflow, keep the shared index pinned to `origin/main`.
+Feature-worktree changes are an overlay and should be verified with local
+diffs/source files, not by refreshing the global index from that worktree.
+
+Diagnose the shared main-index health:
+
+```bash
+scripts/codeindex-health.sh
+```
+
+If the shared main index is stale, repair it non-disruptively:
+
+```bash
+scripts/codeindex-health.sh --repair
+```
+
+For manual non-Conductor maintenance, refresh the index:
 
 ```bash
 codeindex update && node scripts/codeindex-enrich.mjs
@@ -503,7 +519,7 @@ uvx mcp-grafana --help
 7. **Playwright window opens but immediately closes** — corrupt profile directory or corrupt storage-state file. Fix: nuke the workspace's profile (`rm -rf ~/Library/Caches/ms-playwright/mcp-chrome-*` on macOS — see Section 3 "Starting from scratch") and, if used, the storage-state file. Restart Claude Code.
 8. **Login state visible in one site but missing in another** — only applies to the storage-state seed: it captured cookies from the sites you visited before calling `browser_run_code_unsafe`. With the persistent default this is rarely the right diagnosis; just log into the missing site once and the workspace profile keeps it. If you DO maintain a storage-state seed, re-seed after visiting + logging into every site you need.
 9. **CodeIndex not found** — `codeindex` command not available. Fix: `npm install -g klai-private/tools/codeindex-1.3.56.tgz`
-10. **CodeIndex stale index** — Index behind HEAD. Symptoms: impact analysis misses recent code. Fix: `codeindex update && node scripts/codeindex-enrich.mjs`
+10. **CodeIndex stale index** — In Conductor, first run `scripts/codeindex-health.sh`. If the shared base index is stale, fix with `scripts/codeindex-health.sh --repair`. If health is clean but MCP context still reports stale, the registered checkout or current worktree differs from the shared main index; treat CodeIndex as advisory and verify branch-local files directly.
 11. **VictoriaLogs tunnel not running** — MCP queries fail silently or timeout. Fix: `./scripts/victorialogs-tunnel.sh` then restart Claude Code.
 12. **VictoriaLogs auth missing** — `VICTORIALOGS_BASIC_AUTH_B64` not set in `~/.zshrc`. Symptoms: MCP connects but queries return 401. Fix: get the base64 value from SOPS and export it.
 13. **VictoriaLogs container IP changed** — Tunnel connects but queries fail. Cause: VictoriaLogs container restarted, got a new IP. Fix: `./scripts/victorialogs-tunnel.sh --stop && ./scripts/victorialogs-tunnel.sh` (re-resolves IP).

--- a/scripts/codeindex-health.sh
+++ b/scripts/codeindex-health.sh
@@ -150,6 +150,17 @@ ensure_base_worktree() {
   git -C "$BASE_WORKTREE" checkout --detach "$BASE_REF" --quiet
 }
 
+cleanup_base_worktree() {
+  if [ ! -d "$BASE_WORKTREE/.git" ] && [ ! -f "$BASE_WORKTREE/.git" ]; then
+    return 0
+  fi
+
+  # codeindex analyze regenerates agent instruction files in the analyzed tree.
+  # The dedicated base worktree is throwaway, so keep it pinned cleanly to main.
+  git -C "$BASE_WORKTREE" reset --hard --quiet
+  git -C "$BASE_WORKTREE" clean -fd --quiet
+}
+
 run_analyze_from_base() {
   local source_dir="$1"
   ensure_base_worktree "$source_dir" || return 1
@@ -159,7 +170,10 @@ run_analyze_from_base() {
   fi
 
   log "Running codeindex analyze from shared base worktree: $BASE_WORKTREE"
-  (cd "$BASE_WORKTREE" && codeindex analyze "$PROJECT_NAME" "$BASE_WORKTREE" --force --no-embeddings)
+  local analyze_rc=0
+  (cd "$BASE_WORKTREE" && codeindex analyze "$PROJECT_NAME" "$BASE_WORKTREE" --force --no-embeddings) || analyze_rc=$?
+  cleanup_base_worktree || return 1
+  return "$analyze_rc"
 }
 
 main() {
@@ -197,6 +211,9 @@ main() {
     case "$base_commit" in
       "$indexed_commit"*|"$indexed_commit")
         log "CodeIndex indexed commit matches $BASE_REF ($(short_sha "$indexed_commit")); treating as healthy."
+        if [ "$REPAIR" -eq 1 ]; then
+          cleanup_base_worktree || exit 1
+        fi
         if [ "$RESTART_MCP" -eq 1 ]; then
           restart_mcp_processes
         fi


### PR DESCRIPTION
## Summary

Aligns the CodeIndex instructions with the intended Conductor workflow:

- documents that `klai` has one shared CodeIndex graph pinned to `origin/main`
- treats feature worktree changes as a local overlay verified through source files and diffs
- replaces stale `codeindex update` / `npx codeindex analyze` reflexes in AGENTS, CLAUDE, CodeIndex skills, and MCP setup docs
- updates `scripts/codeindex-health.sh` so the dedicated base worktree is cleaned after `codeindex analyze` regenerates agent instruction files

## Root Cause

The MCP context can report stale when the registered canonical checkout or a feature worktree differs from the shared main index. Existing docs told agents to refresh from the current worktree, which conflicts with the Conductor model and can cause repeated stale-index session noise.

## Validation

- `git diff --check origin/main...HEAD`
- `bash -n scripts/codeindex-health.sh`
- `scripts/codeindex-health.sh`

The final health check reports the shared index matches `origin/main` and this branch is a one-commit overlay.
