### PR TITLE
feat(portal): global top bar with right-aligned account menu on every page

### DIFF
--- a/klai-portal/frontend/src/components/layout/AccountMenu.tsx
+++ b/klai-portal/frontend/src/components/layout/AccountMenu.tsx
@@ -1,0 +1,119 @@
+import { Link, useLocation } from '@tanstack/react-router'
+import { useQuery } from '@tanstack/react-query'
+import { LayoutGrid, LogOut, Shield, User, UserCircle } from 'lucide-react'
+import { useAuth } from '@/lib/auth'
+import { useCurrentUser } from '@/hooks/useCurrentUser'
+import { apiFetch } from '@/lib/apiFetch'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import * as m from '@/paraglide/messages'
+
+interface AccountFeedbackUpdatesResponse {
+  unread_count: number
+}
+
+// Initials avatar is the dominant SaaS fallback when there is no profile photo
+// (Google, Atlassian, Notion). Falls back to a neutral user icon when no name
+// is known. Swap the `{initials || <User .../>}` line for just `<User .../>`
+// to use a plain icon everywhere.
+function getInitials(name: string | null): string {
+  if (!name) return ''
+  const parts = name.trim().split(/\s+/).filter(Boolean)
+  if (parts.length === 0) return ''
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
+}
+
+export function AccountMenu() {
+  const auth = useAuth()
+  const location = useLocation()
+  const { user } = useCurrentUser()
+  const { data: feedbackUpdates } = useQuery({
+    queryKey: ['account-feedback-updates'],
+    queryFn: () => apiFetch<AccountFeedbackUpdatesResponse>('/api/app/account/feedback-updates'),
+    enabled: auth.isAuthenticated,
+  })
+
+  const inAdmin = location.pathname.startsWith('/admin')
+  const isAdmin = inAdmin || user?.isAdmin === true
+  const feedbackUnreadCount = feedbackUpdates?.unread_count ?? 0
+
+  const name = auth.user?.profile.name ?? auth.user?.profile.preferred_username ?? null
+  const email = auth.user?.profile.email ?? null
+  const initials = getInitials(name)
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          data-testid="user-menu"
+          aria-label={m.sidebar_account()}
+          className="relative inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[var(--color-rl-dark)] text-[11px] font-medium text-white outline-none transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-[var(--color-rl-accent)]"
+        >
+          {initials || <User className="h-4 w-4" strokeWidth={1.75} />}
+          {feedbackUnreadCount > 0 && (
+            <span
+              className="absolute -right-0.5 -top-0.5 h-2.5 w-2.5 rounded-full bg-[var(--color-success)] ring-2 ring-[var(--color-sidebar)]"
+              aria-label={m.account_feedback_unread()}
+            />
+          )}
+        </button>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent align="end" sideOffset={8} className="w-60">
+        {(name || email) && (
+          <>
+            <DropdownMenuLabel className="font-normal">
+              {name && <p className="truncate text-sm font-medium text-gray-900">{name}</p>}
+              {email && <p className="truncate text-xs text-gray-400">{email}</p>}
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+          </>
+        )}
+
+        {isAdmin && (
+          <DropdownMenuItem asChild>
+            <Link to={inAdmin ? '/app' : '/admin'} className="cursor-pointer">
+              {inAdmin ? <LayoutGrid className="h-4 w-4" /> : <Shield className="h-4 w-4" />}
+              {inAdmin ? m.sidebar_go_to_app() : m.sidebar_go_to_admin()}
+            </Link>
+          </DropdownMenuItem>
+        )}
+
+        <DropdownMenuItem asChild>
+          <Link to="/app/account" className="cursor-pointer">
+            <UserCircle className="h-4 w-4" />
+            {m.sidebar_account()}
+            {feedbackUnreadCount > 0 && (
+              <span className="ml-auto inline-flex min-w-5 items-center justify-center rounded-full bg-[var(--color-success)] px-1.5 text-[11px] font-medium leading-5 text-white">
+                {feedbackUnreadCount}
+              </span>
+            )}
+          </Link>
+        </DropdownMenuItem>
+
+        <DropdownMenuSeparator />
+
+        <DropdownMenuItem
+          onSelect={() => {
+            // BFF logout via signoutRedirect → removeUser does the full flow:
+            // revoke server-side session, clear cookies, navigate to Zitadel
+            // end_session. Matches the previous sidebar logout behavior.
+            void auth.signoutRedirect()
+          }}
+          className="cursor-pointer text-[var(--color-destructive)] focus:text-[var(--color-destructive)]"
+        >
+          <LogOut className="h-4 w-4" />
+          {m.sidebar_logout()}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/klai-portal/frontend/src/components/layout/Sidebar.tsx
+++ b/klai-portal/frontend/src/components/layout/Sidebar.tsx
@@ -1,12 +1,8 @@
 import { Link, useLocation } from '@tanstack/react-router'
 import { useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
-import { useAuth } from '@/lib/auth'
-import { LayoutGrid, LogOut, PanelLeftClose, PanelLeftOpen, Shield, UserCircle, type LucideIcon } from 'lucide-react'
+import { PanelLeftClose, PanelLeftOpen, type LucideIcon } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import { useCurrentUser } from '@/hooks/useCurrentUser'
 import { STORAGE_KEYS } from '@/lib/storage'
-import { apiFetch } from '@/lib/apiFetch'
 import * as m from '@/paraglide/messages'
 
 export interface NavItem {
@@ -23,23 +19,10 @@ interface SidebarProps {
   navItems: NavItem[]
 }
 
-interface AccountFeedbackUpdatesResponse {
-  unread_count: number
-}
-
 export function Sidebar({ navItems }: SidebarProps) {
-  const auth = useAuth()
   const location = useLocation()
-  const { user } = useCurrentUser()
-  const { data: feedbackUpdates } = useQuery({
-    queryKey: ['account-feedback-updates'],
-    queryFn: () => apiFetch<AccountFeedbackUpdatesResponse>('/api/app/account/feedback-updates'),
-    enabled: auth.isAuthenticated,
-  })
 
   const inAdmin = location.pathname.startsWith('/admin')
-  const isAdmin = inAdmin || user?.isAdmin === true
-  const feedbackUnreadCount = feedbackUpdates?.unread_count ?? 0
 
   const [collapsed, setCollapsed] = useState(() => {
     return localStorage.getItem(STORAGE_KEYS.sidebarCollapsed) === 'true'
@@ -51,21 +34,12 @@ export function Sidebar({ navItems }: SidebarProps) {
     localStorage.setItem(STORAGE_KEYS.sidebarCollapsed, String(next))
   }
 
-  function renderBadge(
-    count: number | undefined,
-    label: string,
-    tone: 'destructive' | 'success' = 'destructive',
-  ) {
+  function renderBadge(count: number | undefined, label: string) {
     if (!count || count <= 0) return null
-    const toneClass =
-      tone === 'success'
-        ? 'bg-[var(--color-success)]'
-        : 'bg-[var(--color-destructive)]'
     return (
       <span
         className={cn(
-          'ml-auto inline-flex min-w-5 items-center justify-center rounded-full px-1.5 text-[11px] font-medium leading-5 text-white',
-          toneClass,
+          'ml-auto inline-flex min-w-5 items-center justify-center rounded-full bg-[var(--color-destructive)] px-1.5 text-[11px] font-medium leading-5 text-white',
           collapsed && 'absolute translate-x-3 -translate-y-2 px-1 min-w-4 leading-4 text-[10px]'
         )}
         aria-label={label}
@@ -84,9 +58,10 @@ export function Sidebar({ navItems }: SidebarProps) {
         collapsed ? 'w-14' : 'w-60'
       )}
     >
-      {/* Logo + toggle - h-[66px] centers content at 33px → logo top-edge at 24px */}
+      {/* Logo + toggle - h-16 + bottom border lines the logo up exactly with
+          the global TopBar so the two rails read as one continuous header. */}
       <div className={cn(
-        'flex h-[66px] items-center',
+        'flex h-16 shrink-0 items-center border-b border-[var(--color-sidebar-border)]',
         collapsed ? 'justify-center' : 'justify-between px-6'
       )}>
         {!collapsed && (
@@ -179,75 +154,6 @@ export function Sidebar({ navItems }: SidebarProps) {
           ))}
         </ul>
       </nav>
-
-      {/* Admin/App switcher */}
-      {isAdmin && (
-        <div className="border-t border-[var(--color-sidebar-border)] py-3">
-          <Link
-            to={inAdmin ? '/app' : '/admin'}
-            title={collapsed ? (inAdmin ? m.sidebar_go_to_app() : m.sidebar_go_to_admin()) : undefined}
-            className={cn(
-              'flex items-center rounded-md py-2 mx-3 text-sm transition-colors',
-              'text-[var(--color-sidebar-foreground)]/70 klai-hover hover:text-[var(--color-sidebar-foreground)]',
-              collapsed ? 'justify-center' : 'gap-3 px-3'
-            )}
-          >
-            {inAdmin
-              ? <LayoutGrid size={18} strokeWidth={1.5} />
-              : <Shield size={18} strokeWidth={1.5} />
-            }
-            {!collapsed && (inAdmin ? m.sidebar_go_to_app() : m.sidebar_go_to_admin())}
-          </Link>
-        </div>
-      )}
-
-      {/* User + logout */}
-      <div className="border-t border-[var(--color-sidebar-border)] pt-2 pb-4">
-        {auth.user && !collapsed && (
-          <div className="mb-2 px-6 py-2">
-            <p className="truncate text-xs font-medium text-[var(--color-sidebar-foreground)]">
-              {auth.user.profile.name ?? auth.user.profile.preferred_username}
-            </p>
-            <p className="truncate text-xs text-[var(--color-sidebar-muted-foreground)]">
-              {auth.user.profile.email}
-            </p>
-          </div>
-        )}
-        <Link
-          to="/app/account"
-          title={collapsed ? m.sidebar_account() : undefined}
-          className={cn(
-            'relative flex items-center rounded-md py-2 mx-3 text-sm transition-colors',
-            'text-[var(--color-sidebar-foreground)]/70 klai-hover hover:text-[var(--color-sidebar-foreground)]',
-            collapsed ? 'justify-center' : 'gap-3 px-3'
-          )}
-          activeProps={{
-            className: 'bg-[var(--color-hover)] text-[var(--color-sidebar-accent-foreground)]',
-          }}
-        >
-          <UserCircle size={18} strokeWidth={1.5} />
-          {!collapsed && m.sidebar_account()}
-          {renderBadge(feedbackUnreadCount, m.account_feedback_unread(), 'success')}
-        </Link>
-        <button
-          onClick={() => {
-            // BFF logout via signoutRedirect → removeUser does the full flow:
-            // revoke server-side session, clear cookies, navigate to Zitadel
-            // end_session. No sendBeacon needed - legacy /api/auth/logout
-            // only clears a cookie the BFF doesn't use and fails CSRF.
-            void auth.signoutRedirect()
-          }}
-          title={collapsed ? m.sidebar_logout() : undefined}
-          className={cn(
-            'flex w-full items-center rounded-md py-2 mx-3 text-sm transition-colors',
-            'text-[var(--color-sidebar-foreground)]/70 klai-hover hover:text-[var(--color-sidebar-foreground)]',
-            collapsed ? 'justify-center' : 'gap-3 px-3'
-          )}
-        >
-          <LogOut size={18} strokeWidth={1.5} />
-          {!collapsed && m.sidebar_logout()}
-        </button>
-      </div>
     </aside>
   )
 }

--- a/klai-portal/frontend/src/components/layout/TopBar.tsx
+++ b/klai-portal/frontend/src/components/layout/TopBar.tsx
@@ -1,0 +1,51 @@
+import { createContext, useContext, useState, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+import { AccountMenu } from './AccountMenu'
+
+// Global application top bar. Rendered once by each authenticated layout
+// (app + admin) above the routed <Outlet>. It is a full-width band that lines
+// up with the sidebar logo header (same h-16 height + bottom border) so the
+// two rails read as one continuous header.
+//
+// Layout: [page-injected left slot]  ...........  [account avatar menu (right)]
+//
+// Pages inject their own contextual controls into the left slot via <TopBarLeft>
+// (chat puts its config controls there). Pages with no controls leave it empty,
+// which pushes the avatar to the far right.
+
+interface TopBarSlot {
+  node: HTMLElement | null
+  setNode: (node: HTMLElement | null) => void
+}
+
+const TopBarSlotContext = createContext<TopBarSlot>({
+  node: null,
+  setNode: () => {},
+})
+
+export function TopBarSlotProvider({ children }: { children: ReactNode }) {
+  const [node, setNode] = useState<HTMLElement | null>(null)
+  return (
+    <TopBarSlotContext.Provider value={{ node, setNode }}>
+      {children}
+    </TopBarSlotContext.Provider>
+  )
+}
+
+export function TopBar() {
+  const { setNode } = useContext(TopBarSlotContext)
+  return (
+    <header className="flex h-16 shrink-0 items-center gap-4 border-b border-[var(--color-sidebar-border)] bg-[var(--color-sidebar)] px-4">
+      <div ref={setNode} className="flex min-w-0 flex-1 items-center" />
+      <AccountMenu />
+    </header>
+  )
+}
+
+// Portals its children into the TopBar's left slot. Renders nothing until the
+// TopBar has mounted and registered the slot node (one-frame delay on first
+// paint, imperceptible).
+export function TopBarLeft({ children }: { children: ReactNode }) {
+  const { node } = useContext(TopBarSlotContext)
+  return node ? createPortal(children, node) : null
+}

--- a/klai-portal/frontend/src/routes/admin/route.tsx
+++ b/klai-portal/frontend/src/routes/admin/route.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, Outlet } from '@tanstack/react-router'
 import { useQuery } from '@tanstack/react-query'
 import { LayoutDashboard, Users, FolderKanban, Settings, CreditCard, Puzzle, Key, MessageSquare, Skull, ShieldCheck, Globe2, type LucideIcon } from 'lucide-react'
 import { Sidebar } from '@/components/layout/Sidebar'
+import { TopBar, TopBarSlotProvider } from '@/components/layout/TopBar'
 import { KlaiAssistantLauncher } from '@/features/klai-assistant/KlaiAssistantLauncher'
 import * as m from '@/paraglide/messages'
 import { useProtectedRoute } from '@/hooks/useProtectedRoute'
@@ -120,9 +121,14 @@ function AdminLayout() {
   return (
     <div className="flex h-screen overflow-hidden bg-[var(--color-background)]">
       <Sidebar navItems={adminNav} />
-      <main className="flex-1 overflow-y-auto">
-        <Outlet />
-      </main>
+      <TopBarSlotProvider>
+        <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+          <TopBar />
+          <main className="flex-1 overflow-y-auto">
+            <Outlet />
+          </main>
+        </div>
+      </TopBarSlotProvider>
       <KlaiAssistantLauncher />
     </div>
   )

--- a/klai-portal/frontend/src/routes/app/_components/ChatConfigBar.tsx
+++ b/klai-portal/frontend/src/routes/app/_components/ChatConfigBar.tsx
@@ -152,7 +152,9 @@ export function ChatConfigBar() {
   }
 
   return (
-    <div className="flex shrink-0 items-center gap-6 bg-[var(--color-sidebar)] border-b border-[var(--color-sidebar-border)] pl-4 pr-4 pt-3 pb-3">
+    <div className="flex min-w-0 items-center gap-6">
+      {/* Rendered inside the global TopBar's left slot (see chat.tsx). The
+          TopBar provides the bar height, background, and bottom border. */}
       {collOpen && <div className="fixed inset-0 z-40" onClick={() => setCollOpen(false)} />}
       {instrOpen && <div className="fixed inset-0 z-40" onClick={() => setInstrOpen(false)} />}
 

--- a/klai-portal/frontend/src/routes/app/chat.tsx
+++ b/klai-portal/frontend/src/routes/app/chat.tsx
@@ -8,6 +8,7 @@ import { useCurrentUser } from '@/hooks/useCurrentUser'
 import { chatKbLogger } from '@/lib/logger'
 import * as m from '@/paraglide/messages'
 
+import { TopBarLeft } from '@/components/layout/TopBar'
 import { ChatConfigBar } from './_components/ChatConfigBar'
 
 // Threshold: 25 days (conservative - LibreChat refresh tokens are 30d)
@@ -194,9 +195,14 @@ function ChatPage() {
   const showError = phase === 'error' || phase === 'stuck'
 
   return (
-    <div className="flex h-full w-full flex-col" data-help-id="chat-page">
-      <ChatConfigBar />
-      <div className="relative flex-1">
+    <div className="h-full w-full" data-help-id="chat-page">
+      {/* Chat config controls live in the global TopBar's left slot, so the
+          bar is one continuous header (logo · config · account) instead of a
+          separate sub-bar above the iframe. */}
+      <TopBarLeft>
+        <ChatConfigBar />
+      </TopBarLeft>
+      <div className="relative h-full w-full">
         {/* Loading overlay */}
         {showOverlay && (
           <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 bg-[var(--color-secondary)]">

--- a/klai-portal/frontend/src/routes/app/route.tsx
+++ b/klai-portal/frontend/src/routes/app/route.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Outlet } from '@tanstack/react-router'
 import { Sidebar } from '@/components/layout/Sidebar'
+import { TopBar, TopBarSlotProvider } from '@/components/layout/TopBar'
 import { KlaiAssistantLauncher } from '@/features/klai-assistant/KlaiAssistantLauncher'
 import { useProtectedRoute } from '@/hooks/useProtectedRoute'
 import { getAccessibleAppTools } from './-app-tools'
@@ -29,9 +30,14 @@ function AppLayout() {
   return (
     <div className="flex h-screen overflow-hidden bg-[var(--color-background)]">
       <Sidebar navItems={appNav} />
-      <main className="flex-1 overflow-y-auto">
-        <Outlet />
-      </main>
+      <TopBarSlotProvider>
+        <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+          <TopBar />
+          <main className="flex-1 overflow-y-auto">
+            <Outlet />
+          </main>
+        </div>
+      </TopBarSlotProvider>
       <KlaiAssistantLauncher />
     </div>
   )


### PR DESCRIPTION
## What

Brings the chat-page top bar to **every** authenticated portal page (`/app` + `/admin`) as one consistent full-width header, with the account actions moved to a right-aligned avatar menu.

- **New `TopBar`** (`h-16`) on both layouts: a page-injectable left slot (React context + `createPortal`) and a right-aligned **`AccountMenu`** (avatar dropdown: admin switch, Mijn account, Uitloggen).
- **Sidebar**: admin-switch / account / logout removed from the bottom and moved into the AccountMenu (no parallel old+new). Logo header aligned to the same `h-16` + bottom border so the logo lines up (vertically centered) with the bar content.
- **Chat**: config controls (`ChatConfigBar`) now render into the TopBar left slot → one continuous bar (logo · config · avatar) instead of a separate sub-bar above the iframe.

Avatar = initials with a user-icon fallback (dominant SaaS convention when there is no profile photo). `data-testid="user-menu"` lets the existing logout e2e use the real menu path.

## UX goal

Logo centered/aligned to the bar; menu items default right-aligned; same bar on every page.

## Verification

- `tsc -b` → 0 errors
- `eslint` (changed files) → 0
- `ChatConfigBar.test.tsx` → pass
- `npm run build` (production bundler) → success
- Live visual click-through pending post-deploy (local authenticated render not possible: dev server proxies to prod, cross-origin cookies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)