### PR TITLE
[codex] Fix password strength display for short passwords

### DIFF
--- a/klai-portal/frontend/src/components/auth/PasswordStrengthMeter.tsx
+++ b/klai-portal/frontend/src/components/auth/PasswordStrengthMeter.tsx
@@ -21,10 +21,11 @@ export function PasswordStrengthMeter({
   if (!show) return null
 
   const level = Math.max(0, Math.min(4, score))
+  const displayLevel = !estimated && issues.includes('too_short') ? 0 : level
   const activeClass =
-    level >= 3
+    displayLevel >= 3
       ? 'bg-emerald-500'
-      : level === 2
+      : displayLevel === 2
         ? 'bg-amber-500'
         : 'bg-[var(--color-destructive-text)]'
 
@@ -34,15 +35,15 @@ export function PasswordStrengthMeter({
         {[0, 1, 2, 3].map((index) => (
           <div
             key={index}
-            className={`h-1.5 rounded-full ${index <= level - 1 ? activeClass : 'bg-gray-200'}`}
+            className={`h-1.5 rounded-full ${index <= displayLevel - 1 ? activeClass : 'bg-gray-200'}`}
           />
         ))}
       </div>
       <div className="grid gap-1 text-xs sm:grid-cols-2 sm:gap-3">
         <div className="flex min-w-0 items-start justify-between gap-2">
           <span className="shrink-0 text-gray-500">{m.signup_password_strength_label()}</span>
-          <span className={level >= 3 ? 'text-emerald-700' : level === 2 ? 'text-amber-700' : 'text-gray-500'}>
-            {passwordStrengthLabel(level)}
+          <span className={displayLevel >= 3 ? 'text-emerald-700' : displayLevel === 2 ? 'text-amber-700' : 'text-gray-500'}>
+            {passwordStrengthLabel(displayLevel)}
           </span>
         </div>
         <div className="flex min-w-0 items-start justify-between gap-2">

--- a/klai-portal/frontend/src/components/auth/__tests__/PasswordStrengthMeter.test.tsx
+++ b/klai-portal/frontend/src/components/auth/__tests__/PasswordStrengthMeter.test.tsx
@@ -19,6 +19,26 @@ vi.mock("@/paraglide/messages", () => ({
 }));
 
 describe("PasswordStrengthMeter", () => {
+  it("does not show a strong password while the minimum length policy fails", () => {
+    render(
+      <PasswordStrengthMeter
+        score={4}
+        issues={["too_short"]}
+        show
+        isAcceptable={false}
+        estimated={false}
+        policy={{
+          min_length: 15,
+          min_score: 3,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Very weak")).toBeTruthy();
+    expect(screen.queryByText("Strong")).toBeNull();
+    expect(screen.getByText("Use at least 15 characters.")).toBeTruthy();
+  });
+
   it("does not show policy compliance while strength is still estimated", () => {
     render(
       <PasswordStrengthMeter


### PR DESCRIPTION
## What changed

Fixes the password strength meter so it no longer shows a strong/green password while the hard minimum-length policy is failing.

- Keeps the raw zxcvbn score available internally.
- Clamps the displayed strength level to `Very weak` when `too_short` is present.
- Adds a regression test for `score=4` + `too_short`, matching the production screenshot failure mode.

## Root cause

The UI showed two separate signals without reconciling them:

- `Strength: Strong` came from raw zxcvbn score.
- `Policy: Use at least 15 characters` came from Klai policy validation.

That meant an 11-character password could visually look safe while still being rejected by policy/server validation. The backend policy was not the issue here; the presentation layer was misleading.

## Validation

- `npm run test -- PasswordStrengthMeter`
- `git diff --check`

## Residual risk

This PR fixes the visible meter inconsistency. It does not change backend password acceptance rules or Zitadel policy.
