### PR TITLE
[codex] Harden invite recovery deployment safety

### DIFF
--- a/.github/workflows/portal-api.yml
+++ b/.github/workflows/portal-api.yml
@@ -274,8 +274,34 @@ jobs:
         working-directory: klai-portal/backend
         run: psql -h localhost -U klai -d klai -v ON_ERROR_STOP=1 < alembic/versions/post_deploy_rls_rollback_to_nullif_pattern.sql
 
+  zitadel-password-policy-drift:
+    # Deployment gate for the fail-loud startup guard in
+    # app.services.password_policy_guard. Without this, a Zitadel drift would
+    # be discovered first by the new portal-api container and could crashloop
+    # production. Keep this read-only: policy changes are still an explicit
+    # operator/runbook action.
+    needs: quality
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: klai-portal/backend
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.13"
+
+      - name: Verify production Zitadel password policy
+        env:
+          ZITADEL_ADMIN_PAT: ${{ secrets.ZITADEL_ADMIN_PAT }}
+          ZITADEL_BASE_URL: https://auth.getklai.com
+        run: uv run --with httpx python scripts/update_zitadel_password_policy.py
+
   build-push:
-    needs: [quality, rls-policy-smoke-test]
+    needs: [quality, rls-policy-smoke-test, zitadel-password-policy-drift]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 

--- a/docs/runbooks/zitadel-password-policy.md
+++ b/docs/runbooks/zitadel-password-policy.md
@@ -53,14 +53,41 @@ Expected response:
 
 ## Rollback
 
-If the portal deploy must be rolled back, roll back the portal image first. If
-Zitadel also needs to be restored to the previous production policy, set:
+Rolling the portal image back across this change is not a plain app rollback.
+Older portal builds validated shorter passwords locally. If those builds run
+while Zitadel still requires `minLength: 15`, a user can submit a password that
+old Klai accepts, have the one-time invite code consumed, and then be rejected
+by Zitadel. That recreates the original stuck-invite failure mode.
 
-- `minLength`: `8`
+If you must roll back to a pre-modern-policy portal image, first set Zitadel to
+a policy that is no stricter than the rollback image validates locally. For the
+pre-2026-06-05 production portal that means:
+
+- `minLength`: `12` or lower
 - `hasUppercase`: `true`
 - `hasLowercase`: `true`
 - `hasNumber`: `true`
 - `hasSymbol`: `true`
 
-Do not leave a new portal image running against the old Zitadel policy: the
-startup guard will reject that configuration.
+Then verify the old portal's public contract after rollback:
+
+```bash
+curl -fsS https://my.getklai.com/api/auth/password-policy
+```
+
+Never run:
+
+- a new portal image against old stricter composition policy; the startup guard
+  rejects this and the portal API can crashloop by design.
+- an old portal image against the new `minLength: 15` Zitadel policy; that can
+  consume invite links before Zitadel rejects the password.
+
+Before any rollback, verify the current policy compatibility so the operator
+knows which side of the deploy/rollback boundary they are on:
+
+```bash
+cd klai-portal/backend
+export ZITADEL_ADMIN_PAT=...
+export ZITADEL_BASE_URL=https://auth.getklai.com
+uv run python scripts/update_zitadel_password_policy.py
+```

--- a/klai-portal/backend/app/api/admin/platform_manage.py
+++ b/klai-portal/backend/app/api/admin/platform_manage.py
@@ -53,6 +53,7 @@ from app.services.user_memberships import get_user_global_membership_state, get_
 from app.services.zitadel import _sync_zitadel_role_grant, zitadel
 from app.services.zitadel_identity_recovery import (
     ZitadelIdentityRecoveryError,
+    email_hash_for_log,
     recover_existing_zitadel_identity_for_invite,
 )
 
@@ -125,10 +126,10 @@ async def _find_existing_zitadel_user_for_platform_invite(
     existing_user_id = await zitadel.find_user_id_by_email(email)
     if existing_user_id:
         logger.info(
-            "platform_invite_existing_zitadel_user_reused",
-            email=email,
-            target_org_id=org_id,
-            zitadel_user_id=existing_user_id,
+            "platform_invite_existing_zitadel_user_reused email_hash=%s target_org_id=%d zitadel_user_id=%s",
+            email_hash_for_log(email),
+            org_id,
+            existing_user_id,
         )
         return existing_user_id
 
@@ -167,7 +168,7 @@ async def _create_or_reuse_platform_invite_zitadel_user(
                 conflict_exc=exc,
             )
             return existing_user_id, False
-        logger.exception("platform_invite_zitadel_failed", email=body.email)
+        logger.exception("platform_invite_zitadel_failed email_hash=%s", email_hash_for_log(body.email))
         await _emit_audit_safe(
             action="platform_admin.invite_zitadel_invite_failed",
             details={
@@ -179,7 +180,7 @@ async def _create_or_reuse_platform_invite_zitadel_user(
         )
         raise HTTPException(status_code=502, detail=f"Zitadel invite mislukt: {exc}") from exc
     except Exception as exc:
-        logger.exception("platform_invite_zitadel_failed", email=body.email)
+        logger.exception("platform_invite_zitadel_failed email_hash=%s", email_hash_for_log(body.email))
         await _emit_audit_safe(
             action="platform_admin.invite_zitadel_invite_failed",
             details={

--- a/klai-portal/backend/app/api/admin/users.py
+++ b/klai-portal/backend/app/api/admin/users.py
@@ -45,6 +45,7 @@ from app.services.user_memberships import get_user_membership_summary
 from app.services.zitadel import _sync_zitadel_role_grant, zitadel
 from app.services.zitadel_identity_recovery import (
     ZitadelIdentityRecoveryError,
+    email_hash_for_log,
     recover_existing_zitadel_identity_for_invite,
 )
 
@@ -187,7 +188,11 @@ async def _reuse_existing_zitadel_user_for_invite(
     try:
         existing_user_id = await zitadel.find_user_id_by_email(str(body.email))
     except Exception as lookup_exc:
-        logger.exception("Existing user lookup failed for %s: %s", body.email, lookup_exc)
+        logger.exception(
+            "Existing user lookup failed email_hash=%s error=%s",
+            email_hash_for_log(str(body.email)),
+            lookup_exc,
+        )
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail="Uitnodiging kon niet worden verwerkt. Probeer het opnieuw.",
@@ -196,7 +201,7 @@ async def _reuse_existing_zitadel_user_for_invite(
     if not existing_user_id:
         _slog.warning(
             "invite_existing_zitadel_user_not_found",
-            email=body.email,
+            email_hash=email_hash_for_log(str(body.email)),
             org_id=org.id,
         )
         raise HTTPException(
@@ -220,7 +225,7 @@ async def _reuse_existing_zitadel_user_for_invite(
     if membership is not None:
         _slog.info(
             "invite_offboarded_zitadel_user_reused",
-            email=body.email,
+            email_hash=email_hash_for_log(str(body.email)),
             org_id=org.id,
             zitadel_user_id=existing_user_id,
         )
@@ -239,7 +244,7 @@ async def _reuse_existing_zitadel_user_for_invite(
     except ZitadelIdentityRecoveryError as recovery_exc:
         _slog.exception(
             "invite_existing_zitadel_identity_recovery_failed",
-            email=body.email,
+            email_hash=email_hash_for_log(str(body.email)),
             org_id=org.id,
             zitadel_user_id=existing_user_id,
         )
@@ -250,7 +255,7 @@ async def _reuse_existing_zitadel_user_for_invite(
 
     _slog.info(
         "invite_existing_zitadel_user_reused",
-        email=body.email,
+        email_hash=email_hash_for_log(str(body.email)),
         org_id=org.id,
         zitadel_user_id=recovery.user_id,
         original_zitadel_user_id=existing_user_id,
@@ -288,7 +293,7 @@ async def _restore_reactivated_zitadel_user_if_needed(
         _slog.exception(
             "invite_reactivated_zitadel_restore_failed",
             zitadel_user_id=zitadel_user_id,
-            email=email,
+            email_hash=email_hash_for_log(email),
             org_id=org_id,
             failure_step=failure_step,
         )
@@ -335,7 +340,7 @@ async def _persist_invited_user_and_send_code(
         _slog.exception(
             "invite_failed_zitadel_user_cleaned_up",
             zitadel_user_id=zitadel_user_id,
-            email=body.email,
+            email_hash=email_hash_for_log(str(body.email)),
             org_id=org.id,
             failure_step=failure_step,
         )
@@ -495,7 +500,7 @@ async def invite_user(
         zitadel_user_created = True
     except httpx.HTTPStatusError as exc:
         if exc.response.status_code != status.HTTP_409_CONFLICT:
-            logger.exception("User invite failed for %s: %s", body.email, exc)
+            logger.exception("User invite failed email_hash=%s error=%s", email_hash_for_log(str(body.email)), exc)
             raise HTTPException(
                 status_code=status.HTTP_502_BAD_GATEWAY,
                 detail=f"Failed to invite user: {exc}",
@@ -512,7 +517,7 @@ async def invite_user(
         zitadel_user_created = existing_identity.created_new_zitadel_user
         reactivated_existing_zitadel_user = existing_identity.reactivated_zitadel_user
     except Exception as exc:
-        logger.exception("User invite failed for %s: %s", body.email, exc)
+        logger.exception("User invite failed email_hash=%s error=%s", email_hash_for_log(str(body.email)), exc)
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail=f"Failed to invite user: {exc}",
@@ -523,7 +528,7 @@ async def invite_user(
             _slog.info(
                 "invite_zitadel_cleanup_skipped_existing_user",
                 zitadel_user_id=zitadel_user_id,
-                email=body.email,
+                email_hash=email_hash_for_log(str(body.email)),
                 reason=reason,
             )
             return
@@ -536,7 +541,7 @@ async def invite_user(
             _slog.exception(
                 "invite_zitadel_cleanup_failed",
                 zitadel_user_id=zitadel_user_id,
-                email=body.email,
+                email_hash=email_hash_for_log(str(body.email)),
                 reason=reason,
             )
 

--- a/klai-portal/backend/app/api/auth.py
+++ b/klai-portal/backend/app/api/auth.py
@@ -1242,7 +1242,12 @@ async def password_set(body: PasswordSetRequest) -> None:
         ) from exc
 
     try:
-        flow = await zitadel.set_password_with_code(body.user_id, body.code, body.new_password)
+        flow = await zitadel.set_password_with_code(
+            body.user_id,
+            body.code,
+            body.new_password,
+            invite_retry_url_template=build_url_template(AuthLinkRoute.PASSWORD_SET),
+        )
     except httpx.HTTPStatusError as exc:
         _slog.exception("set_password_with_code_failed", zitadel_status=exc.response.status_code)
         if is_zitadel_password_policy_error(exc):

--- a/klai-portal/backend/app/services/zitadel.py
+++ b/klai-portal/backend/app/services/zitadel.py
@@ -534,7 +534,14 @@ class ZitadelClient:
         resp.raise_for_status()
         return resp.json()["callbackUrl"]
 
-    async def set_password_with_code(self, user_id: str, code: str, new_password: str) -> Literal["invite", "reset"]:
+    async def set_password_with_code(
+        self,
+        user_id: str,
+        code: str,
+        new_password: str,
+        *,
+        invite_retry_url_template: str | None = None,
+    ) -> Literal["invite", "reset"]:
         """Set a new password using a one-time code from email.
 
         Returns ``"invite"`` if the code was consumed via the invite flow
@@ -567,8 +574,15 @@ class ZitadelClient:
         common case (every newly invited user goes through it). If the
         verify step returns a 4xx we fall back to the reset-flow.
 
-        Raises ``httpx.HTTPStatusError`` (caller maps to 400/502) when
-        both flows fail or Zitadel returns a 5xx during verify.
+        If the invite verify step succeeds but the later password PATCH fails,
+        the invite code has already been consumed by Zitadel. When
+        ``invite_retry_url_template`` is provided, we immediately issue a fresh
+        invite code before re-raising the original PATCH error so the user is
+        not left with only an exhausted link.
+
+        Raises ``httpx.HTTPStatusError`` (caller maps to 400/502) when both
+        flows fail, Zitadel returns a 5xx during verify, or the invite password
+        PATCH fails.
         """
         # ---- Path 1: invite flow ------------------------------------------------
         verify_resp = await self._http.post(
@@ -591,7 +605,23 @@ class ZitadelClient:
                     }
                 },
             )
-            password_resp.raise_for_status()
+            try:
+                password_resp.raise_for_status()
+            except httpx.HTTPStatusError:
+                if invite_retry_url_template is not None:
+                    try:
+                        await self.send_invite_code(user_id, url_template=invite_retry_url_template)
+                    except Exception:
+                        logger.exception(
+                            "invite_code_reissue_after_password_failure_failed zitadel_status=%d",
+                            password_resp.status_code,
+                        )
+                    else:
+                        logger.warning(
+                            "invite_code_reissued_after_password_failure zitadel_status=%d",
+                            password_resp.status_code,
+                        )
+                raise
             return "invite"
 
         # invite_code/verify returned 4xx/5xx. Two reasons it might:

--- a/klai-portal/backend/app/services/zitadel_identity_recovery.py
+++ b/klai-portal/backend/app/services/zitadel_identity_recovery.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass
 
 import structlog
@@ -25,6 +26,10 @@ class InviteIdentityRecoveryResult:
     user_id: str
     created_new_user: bool = False
     reactivated_existing_user: bool = False
+
+
+def email_hash_for_log(email: str) -> str:
+    return hashlib.sha256(email.lower().encode("utf-8")).hexdigest()
 
 
 def _extract_zitadel_user_state(user_response: dict) -> str:
@@ -93,7 +98,7 @@ async def recover_existing_zitadel_identity_for_invite(
             "invite_dangling_zitadel_user_recreated",
             old_zitadel_user_id=zitadel_user_id,
             new_zitadel_user_id=new_user_id,
-            email=email,
+            email_hash=email_hash_for_log(email),
             org_id=org_id,
             previous_state=state,
         )
@@ -103,7 +108,7 @@ async def recover_existing_zitadel_identity_for_invite(
         _slog.error(
             "invite_existing_zitadel_user_initial_state_blocked",
             zitadel_user_id=zitadel_user_id,
-            email=email,
+            email_hash=email_hash_for_log(email),
             org_id=org_id,
             memberships=membership_summary.total_count,
         )
@@ -122,7 +127,7 @@ async def recover_existing_zitadel_identity_for_invite(
     _slog.info(
         "invite_existing_zitadel_user_unlocked",
         zitadel_user_id=zitadel_user_id,
-        email=email,
+        email_hash=email_hash_for_log(email),
         org_id=org_id,
         previous_state=state,
     )

--- a/klai-portal/backend/scripts/update_zitadel_password_policy.py
+++ b/klai-portal/backend/scripts/update_zitadel_password_policy.py
@@ -37,7 +37,7 @@ def _policy_errors(payload: dict[str, Any]) -> list[str]:
         else:
             if actual is None and expected is False:
                 actual = False
-            matches = actual is expected
+            matches = actual == expected
         if not matches:
             errors.append(f"{key}: expected {expected!r}, got {actual!r}")
     return errors

--- a/klai-portal/backend/tests/test_auth_password_endpoints.py
+++ b/klai-portal/backend/tests/test_auth_password_endpoints.py
@@ -378,6 +378,9 @@ async def test_password_set_maps_zitadel_password_policy_400(respx_zitadel: resp
     respx_zitadel.patch("/v2/users/uid-1").mock(
         return_value=httpx.Response(400, json={"message": "password violates password complexity policy"})
     )
+    invite_reissue_route = respx_zitadel.post("/v2/users/uid-1/invite_code").mock(
+        return_value=httpx.Response(200, json={})
+    )
 
     body = PasswordSetRequest(user_id="uid-1", code="123456", new_password=_STRONG_PASSWORD)
 
@@ -387,6 +390,7 @@ async def test_password_set_maps_zitadel_password_policy_400(respx_zitadel: resp
 
     assert exc.value.status_code == 400
     assert "Wachtwoord voldoet niet" in exc.value.detail
+    assert invite_reissue_route.called
     audit_log.assert_not_called()
     events = _capture_events(captured, "password_set_failed")
     assert len(events) == 1

--- a/klai-portal/backend/tests/test_set_password_with_code_dual_flow.py
+++ b/klai-portal/backend/tests/test_set_password_with_code_dual_flow.py
@@ -139,16 +139,55 @@ async def test_reset_flow_4xx_invalid_code() -> None:
 
 @pytest.mark.asyncio
 async def test_invite_flow_password_step_5xx() -> None:
-    """invite_code/verify 200 -> update-user password 502 -> propagate 502."""
+    """invite_code/verify 200 -> password 502 reissues invite before propagating."""
     client = _client_with_mocked_http()
     client._http.post = AsyncMock(
         side_effect=[
             _resp(200, {"details": {"sequence": "11"}}),
+            _resp(200, {"details": {"sequence": "12"}}),
         ]
     )
     client._http.patch = AsyncMock(return_value=_resp(502, {"error": "bad gw"}))
 
     with pytest.raises(httpx.HTTPStatusError) as exc:
-        await client.set_password_with_code("uid-1", "INVITE", "NewSecret123!")
+        await client.set_password_with_code(
+            "uid-1",
+            "INVITE",
+            "NewSecret123!",
+            invite_retry_url_template="https://my.getklai.com/password/set?userID={{.UserID}}&code={{.Code}}",
+        )
     assert exc.value.response.status_code == 502
     client._http.patch.assert_awaited_once()
+    assert client._http.post.await_count == 2
+    reissue = client._http.post.await_args_list[1]
+    assert reissue.args[0] == "/v2/users/uid-1/invite_code"
+    assert reissue.kwargs["json"] == {
+        "sendCode": {
+            "urlTemplate": "https://my.getklai.com/password/set?userID={{.UserID}}&code={{.Code}}",
+            "applicationName": "Klai",
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_invite_flow_password_step_5xx_preserves_original_error_when_reissue_fails() -> None:
+    """Invite reissue is best-effort; the caller still sees the original PATCH failure."""
+    client = _client_with_mocked_http()
+    client._http.post = AsyncMock(
+        side_effect=[
+            _resp(200, {"details": {"sequence": "11"}}),
+            _resp(503, {"error": "invite unavailable"}),
+        ]
+    )
+    client._http.patch = AsyncMock(return_value=_resp(502, {"error": "bad gw"}))
+
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        await client.set_password_with_code(
+            "uid-1",
+            "INVITE",
+            "NewSecret123!",
+            invite_retry_url_template="https://my.getklai.com/password/set?userID={{.UserID}}&code={{.Code}}",
+        )
+
+    assert exc.value.response.status_code == 502
+    assert client._http.post.await_count == 2


### PR DESCRIPTION
## What changed

Follow-up hardening from the adversarial release review of #767/#769.

- Mitigates the invite `verify -> password PATCH` consume gap:
  - if invite-code verification succeeds but the following password PATCH fails, Klai now best-effort issues a fresh invite code using the Klai `/password/set` template before re-raising the original error.
  - this does not make Zitadel's invite flow atomic, but it prevents the user from being left only with an exhausted link after a post-verify password failure.
- Adds regression coverage for successful and failed invite-code reissue after password PATCH failure.
- Adds an endpoint-level assertion that a Zitadel password-policy rejection after invite verification reissues an invite code.
- Adds a read-only production Zitadel password-policy drift gate to the `portal-api` main deploy pipeline before image build/deploy.
- Fixes the password-policy rollback runbook so old portal images are not rolled back against the new stricter Zitadel policy.
- Scrubs plaintext email from the invite recovery/admin operational logs touched by this incident, replacing it with `email_hash`.
- Uses equality, not identity, for normalized boolean comparison in the Zitadel password-policy script.

## Why

The review correctly identified that #767 closed the observed customer state but left release-safety gaps:

- A future Zitadel-side rejection after `invite_code/verify` could still burn the one-time invite link.
- Rollback to an old portal image while Zitadel remains on `minLength: 15` can recreate the original stuck-invite bug.
- The Zitadel policy migration was protected by a runbook and startup crash guard, but not by a deploy gate.
- Recovery logs still emitted plaintext email addresses in several paths.

## Validation

- `uv run pytest tests/test_admin_users.py tests/test_platform_admin_manage.py tests/test_password_policy_guard.py tests/test_auth_password_endpoints.py tests/test_set_password_with_code_dual_flow.py -q`
  - `80 passed`
- `uv run pytest tests/test_password_policy_guard.py tests/test_auth_password_endpoints.py tests/test_set_password_with_code_dual_flow.py -q`
  - `40 passed`
- `uv run ruff check app/services/zitadel.py app/api/auth.py app/services/zitadel_identity_recovery.py app/api/admin/users.py app/api/admin/platform_manage.py scripts/update_zitadel_password_policy.py tests/test_set_password_with_code_dual_flow.py tests/test_auth_password_endpoints.py`
- `uv run ruff format --check app/services/zitadel.py app/api/auth.py app/services/zitadel_identity_recovery.py app/api/admin/users.py app/api/admin/platform_manage.py scripts/update_zitadel_password_policy.py tests/test_set_password_with_code_dual_flow.py tests/test_auth_password_endpoints.py`
- `uv run --with pyright pyright app/services/zitadel.py app/api/auth.py app/services/zitadel_identity_recovery.py app/api/admin/users.py app/api/admin/platform_manage.py scripts/update_zitadel_password_policy.py`
  - `0 errors`
- Live read-only production Zitadel check with `ZITADEL_ADMIN_PAT` from `core-01`:
  - `OK: Zitadel password policy is Klai-compatible.`
- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/portal-api.yml'); puts 'YAML OK'"`

## Residual risk

The invite flow is still not truly atomic because Zitadel exposes invite verification and password setup as separate operations. This PR mitigates the failure mode by issuing a fresh invite code after post-verify password failure. A deeper future improvement would be moving invite completion to a Zitadel-supported single-call flow if/when one exists, or redesigning onboarding around password-reset codes for first password setup.
