### PR TITLE
[codex] Fix Zitadel policy drift gate secret source

### DIFF
--- a/.github/workflows/portal-api.yml
+++ b/.github/workflows/portal-api.yml
@@ -279,7 +279,9 @@ jobs:
     # app.services.password_policy_guard. Without this, a Zitadel drift would
     # be discovered first by the new portal-api container and could crashloop
     # production. Keep this read-only: policy changes are still an explicit
-    # operator/runbook action.
+    # operator/runbook action. The admin PAT deliberately comes from the same
+    # core-01 env file used by production instead of a duplicate GitHub secret;
+    # a missing/out-of-sync repository secret must not decide deploy safety.
     needs: quality
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
@@ -294,9 +296,44 @@ jobs:
         with:
           python-version: "3.13"
 
+      - name: Load Zitadel admin PAT from core-01
+        env:
+          CORE01_HOST: ${{ secrets.CORE01_HOST }}
+          CORE01_DEPLOY_KEY: ${{ secrets.CORE01_DEPLOY_KEY }}
+        run: |
+          set -euo pipefail
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$CORE01_DEPLOY_KEY" > ~/.ssh/core01_deploy_key
+          chmod 600 ~/.ssh/core01_deploy_key
+          ssh-keyscan -H "$CORE01_HOST" >> ~/.ssh/known_hosts
+
+          PAT="$(
+            ssh -i ~/.ssh/core01_deploy_key \
+              -o BatchMode=yes \
+              -o IdentitiesOnly=yes \
+              -o StrictHostKeyChecking=yes \
+              "klai@${CORE01_HOST}" \
+              "sudo sed -n 's/^ZITADEL_ADMIN_PAT=//p' /opt/klai/.env | tail -n 1"
+          )"
+          PAT="${PAT%\"}"
+          PAT="${PAT#\"}"
+          PAT="${PAT%\'}"
+          PAT="${PAT#\'}"
+
+          if [ -z "$PAT" ]; then
+            echo "::error::ZITADEL_ADMIN_PAT is missing from /opt/klai/.env on core-01"
+            exit 1
+          fi
+
+          echo "::add-mask::$PAT"
+          {
+            echo "ZITADEL_ADMIN_PAT<<EOF"
+            printf '%s\n' "$PAT"
+            echo "EOF"
+          } >> "$GITHUB_ENV"
+
       - name: Verify production Zitadel password policy
         env:
-          ZITADEL_ADMIN_PAT: ${{ secrets.ZITADEL_ADMIN_PAT }}
           ZITADEL_BASE_URL: https://auth.getklai.com
         run: uv run --with httpx python scripts/update_zitadel_password_policy.py
 

--- a/docs/runbooks/zitadel-password-policy.md
+++ b/docs/runbooks/zitadel-password-policy.md
@@ -39,6 +39,12 @@ uv run python scripts/update_zitadel_password_policy.py --apply
 uv run python scripts/update_zitadel_password_policy.py
 ```
 
+The `portal-api` production workflow runs the same script before building a
+new image for `main`. That CI gate reads `ZITADEL_ADMIN_PAT` from
+`/opt/klai/.env` on `core-01` over the deployment SSH path, then masks it in
+Actions. Keep that server env in sync via infra/SOPS; do not create a second
+repository secret as the source of truth for this gate.
+
 After the portal deploy, verify the public contract:
 
 ```bash


### PR DESCRIPTION
## Summary
- change the portal-api Zitadel password-policy drift gate to load `ZITADEL_ADMIN_PAT` from `/opt/klai/.env` on `core-01` over the existing deploy SSH path
- keep the existing `scripts/update_zitadel_password_policy.py` as the single policy verification implementation
- document that the CI gate uses the production server env as source of truth, not a duplicate repository secret

## Root Cause
PR #770 added the right pre-build drift gate, but wired it to `secrets.ZITADEL_ADMIN_PAT`. That repository secret is currently empty or unavailable to the workflow, so the main deploy was blocked with `ERROR: ZITADEL_ADMIN_PAT is required` before the backend image could build. The PAT is present on `core-01`, which is already the deploy-time source for production env.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/portal-api.yml"); puts "YAML OK"'`
- `git diff --check`
- verified `core-01` has `ZITADEL_ADMIN_PAT` without logging the token
- ran the existing drift script locally with the PAT fetched from `core-01`: `OK: Zitadel password policy is Klai-compatible.`
