### PR TITLE
[codex] Fix password strength meter policy feedback

### DIFF
--- a/klai-portal/frontend/messages/en.json
+++ b/klai-portal/frontend/messages/en.json
@@ -73,6 +73,7 @@
   "signup_password_strength_fair": "Could be stronger",
   "signup_password_strength_good": "Good",
   "signup_password_strength_strong": "Strong",
+  "signup_password_strength_too_short": "{strength}, but too short",
   "signup_password_strength_label": "Strength",
   "signup_password_policy_label": "Policy",
   "signup_password_policy_checking": "Checking",

--- a/klai-portal/frontend/messages/nl.json
+++ b/klai-portal/frontend/messages/nl.json
@@ -73,6 +73,7 @@
   "signup_password_strength_fair": "Kan sterker",
   "signup_password_strength_good": "Goed",
   "signup_password_strength_strong": "Sterk",
+  "signup_password_strength_too_short": "{strength}, maar te kort",
   "signup_password_strength_label": "Sterkte",
   "signup_password_policy_label": "Beleid",
   "signup_password_policy_checking": "Wordt gecontroleerd",

--- a/klai-portal/frontend/src/components/auth/PasswordStrengthMeter.tsx
+++ b/klai-portal/frontend/src/components/auth/PasswordStrengthMeter.tsx
@@ -21,13 +21,23 @@ export function PasswordStrengthMeter({
   if (!show) return null
 
   const level = Math.max(0, Math.min(4, score))
-  const displayLevel = !estimated && issues.includes('too_short') ? 0 : level
+  const isTooShort = !estimated && issues.includes('too_short')
+  const strengthLabel = isTooShort
+    ? m.signup_password_strength_too_short({ strength: passwordStrengthLabel(level) })
+    : passwordStrengthLabel(level)
   const activeClass =
-    displayLevel >= 3
+    isAcceptable && level >= 3
       ? 'bg-emerald-500'
-      : displayLevel === 2
+      : level >= 2
         ? 'bg-amber-500'
         : 'bg-[var(--color-destructive-text)]'
+  const strengthTextClass = isTooShort
+    ? 'text-amber-700'
+    : level >= 3
+      ? 'text-emerald-700'
+      : level === 2
+        ? 'text-amber-700'
+        : 'text-gray-500'
 
   return (
     <div className="space-y-2" aria-live="polite">
@@ -35,15 +45,15 @@ export function PasswordStrengthMeter({
         {[0, 1, 2, 3].map((index) => (
           <div
             key={index}
-            className={`h-1.5 rounded-full ${index <= displayLevel - 1 ? activeClass : 'bg-gray-200'}`}
+            className={`h-1.5 rounded-full ${index <= level - 1 ? activeClass : 'bg-gray-200'}`}
           />
         ))}
       </div>
       <div className="grid gap-1 text-xs sm:grid-cols-2 sm:gap-3">
         <div className="flex min-w-0 items-start justify-between gap-2">
           <span className="shrink-0 text-gray-500">{m.signup_password_strength_label()}</span>
-          <span className={displayLevel >= 3 ? 'text-emerald-700' : displayLevel === 2 ? 'text-amber-700' : 'text-gray-500'}>
-            {passwordStrengthLabel(displayLevel)}
+          <span className={`text-right ${strengthTextClass}`}>
+            {strengthLabel}
           </span>
         </div>
         <div className="flex min-w-0 items-start justify-between gap-2">

--- a/klai-portal/frontend/src/components/auth/__tests__/PasswordStrengthMeter.test.tsx
+++ b/klai-portal/frontend/src/components/auth/__tests__/PasswordStrengthMeter.test.tsx
@@ -11,6 +11,8 @@ vi.mock("@/paraglide/messages", () => ({
   signup_password_strength_good: () => "Good",
   signup_password_strength_label: () => "Strength",
   signup_password_strength_strong: () => "Strong",
+  signup_password_strength_too_short: ({ strength }: { strength: string }) =>
+    `${strength}, but too short`,
   signup_password_strength_very_weak: () => "Very weak",
   signup_password_strength_weak: () => "Weak",
   signup_password_too_short: ({ minLength }: { minLength: string }) =>
@@ -19,8 +21,8 @@ vi.mock("@/paraglide/messages", () => ({
 }));
 
 describe("PasswordStrengthMeter", () => {
-  it("does not show a strong password while the minimum length policy fails", () => {
-    render(
+  it("shows strength feedback while making clear that a strong password is still too short", () => {
+    const { container } = render(
       <PasswordStrengthMeter
         score={4}
         issues={["too_short"]}
@@ -34,9 +36,11 @@ describe("PasswordStrengthMeter", () => {
       />,
     );
 
-    expect(screen.getByText("Very weak")).toBeTruthy();
-    expect(screen.queryByText("Strong")).toBeNull();
+    expect(screen.getByText("Strong, but too short")).toBeTruthy();
+    expect(screen.queryByText("Very weak")).toBeNull();
     expect(screen.getByText("Use at least 15 characters.")).toBeTruthy();
+    expect(container.querySelectorAll(".bg-amber-500")).toHaveLength(4);
+    expect(container.querySelectorAll(".bg-emerald-500")).toHaveLength(0);
   });
 
   it("does not show policy compliance while strength is still estimated", () => {


### PR DESCRIPTION
## Summary
- keep the password meter useful before the minimum length is reached by showing raw zxcvbn strength progress
- prevent misleading success: a strong-but-too-short password now shows `Strong, but too short` / `Sterk, maar te kort`
- keep the meter amber until both conditions are true: strength is sufficient and the 15-character policy is met

## Root Cause
The previous fix clamped every `too_short` password to display level 0. That avoided the misleading `Strong` label for invalid passwords, but it also made the strength meter useless until 15 characters by rendering strong passphrase attempts as `Very weak`.

## Expected UX
- weak short password: low/red strength feedback
- strong short password: filled amber meter + `Strong, but too short`
- strong valid password: green meter + policy met

## Validation
- `npm run i18n:compile`
- `npm test -- PasswordStrengthMeter.test.tsx`
- `npm run lint -- src/components/auth/PasswordStrengthMeter.tsx src/components/auth/__tests__/PasswordStrengthMeter.test.tsx`
- `npm run build`
