### PR TITLE
[codex] standardize UI list states

### DIFF
--- a/klai-portal/frontend/docs/ui-standards.md
+++ b/klai-portal/frontend/docs/ui-standards.md
@@ -7,6 +7,59 @@ other document must be updated in the same change.
 This file is portal-only. It does not define website, landing-page, marketing,
 or public web patterns. Keep those in the website-specific design guidance.
 
+## Live Catalog
+
+A running visual reference of these patterns lives at `/dev/ui`
+(`src/routes/dev/ui.tsx`). It renders the owned components with every tone,
+state, and layout this document describes. It is DEV-only (gated on
+`import.meta.env.DEV`) and never ships to production.
+
+Use it as the paired reference to this file: this document is the written
+rule, `/dev/ui` is the rendered proof. When you add or change a shared UI
+component, update both — a new tone, state, or variant must appear in the
+catalog and be described here in the same change.
+
+## Component Library Reference
+
+All shared UI lives in `src/components/ui/`. The base is **shadcn/ui**
+(see `components.json`: style `default`, base color `neutral`, lucide icons,
+CSS variables), themed with Klai tokens from `index.css`. On top of the
+standard shadcn primitives (`button`, `badge`, `card`, `dialog`,
+`alert-dialog`, `dropdown-menu`, `popover`, `command`, `sheet`, `tooltip`,
+form controls, `sonner`) sit Klai's own additions (`row-action`, `list`,
+`inline-delete-confirm`, `step-indicator`, `inline-edit`, `multi-select`,
+`query-error-state`, `delete-*`). The widget (`klai-widget`) and website
+(`klai-website`) are separate systems with their own components — this
+library is portal-only.
+
+Build pages from these; never hand-roll a raw `<button>`, `<input>`,
+`<select>`, list row, or delete confirmation with inline Tailwind.
+
+| Component | Purpose | Canonical? |
+|---|---|---|
+| `button` | All buttons (variants: default/secondary/ghost/outline/destructive; sizes: default/sm/icon) | Yes |
+| `badge` | Inline status labels (secondary/success/warning/destructive/outline) | Yes |
+| `input` `select` `textarea` `label` `checkbox` | Form controls | Yes |
+| `row-action` | List/table row actions: `RowActionIconButton`, `RowActionButton`, `RowActionGroup` + the action→tone system | Yes |
+| `list` | List primitives: `ListFrame`, `ListRow`, `ListRowContent`, `ListRowTitle`, `ListRowDescription`, `ListRowActions`, `ListRowIcon` | Yes |
+| `inline-delete-confirm` | Inline destructive confirmation inside a row (no layout shift) | Yes |
+| `step-indicator` | Wizard step progress (`StepIndicator`) | Yes |
+| `alert-dialog` | Centered confirm dialog for destructive actions outside rows | Yes |
+| `dialog` | Generic modal | Yes |
+| `dropdown-menu` `popover` `command` | Menus, popovers, command/combobox | Yes |
+| `multi-select` | Multi-value select | Yes |
+| `inline-edit` | Click-to-edit text in place | Yes |
+| `tooltip` | Hover/focus tooltips (used by `row-action`) | Yes |
+| `sonner` | Toasts (`toast()` feedback) | Yes |
+| `card` | Framed repeated items / stat blocks | Yes |
+| `query-error-state` | Standard error block for failed queries | Yes |
+| `sheet` | Slide-over. **Forbidden** for admin entity detail (see Detail And Edit) | Restricted |
+| `delete-confirm-button` | Older inline trash→confirm toggle. **Deprecated** — use `inline-delete-confirm`. Migrate on touch. | Deprecated |
+| `delete-kb-modal` `delete-org-modal` | Feature-specific destructive modals (not generic) | Feature |
+
+Tabs are a **pattern, not a component** (see Tabs). They are currently
+hand-rolled in 5 places and are a candidate for extraction.
+
 ## Required Workflow
 
 Before changing portal UI:
@@ -74,8 +127,163 @@ Use table/list views for admin collections. Rows use `klai-hover`; never use
 </table>
 ```
 
-List actions use familiar icon buttons with tooltips/labels where needed.
-Edit/delete must follow the existing admin action style.
+For new lists, prefer the `list` primitives over a hand-built table when the
+content is a stack of titled rows with a description and trailing actions
+(see List Primitives). Use a real `<table>` only when you need columns with
+headers and aligned cells.
+
+Row actions (edit, delete, sync, ...) use the `row-action` components, never
+raw `<button>` icons. See Row Actions And Action Tones.
+
+## Row Actions And Action Tones
+
+Row-level actions use the owned `row-action` components. They encode a fixed
+action→tone→color mapping so the same action looks identical everywhere.
+
+Components:
+
+- `RowActionIconButton` — icon-only action (the default in lists/tables).
+- `RowActionButton` — icon + text label action.
+- `RowActionGroup` — right-aligned flex container with `gap-1` for a row's
+  actions.
+
+Pass an `action` and the icon, tone, and tooltip default are derived for you:
+
+```tsx
+import { RowActionGroup, RowActionIconButton } from '@/components/ui/row-action'
+
+<RowActionGroup>
+  <RowActionIconButton label="Bewerken" action="edit" />
+  <RowActionIconButton label="Synchroniseren" action="sync" />
+  <RowActionIconButton label="Verwijderen" action="delete" />
+</RowActionGroup>
+```
+
+Every `action` maps to one tone; never restyle the icon color by hand. The
+tone is overridable via the `tone` prop only when a specific row genuinely
+needs a different semantic.
+
+| Tone | Color token | Meaning | Example actions |
+|---|---|---|---|
+| `neutral` | `text-gray-400/500` | Utility, navigation, low-risk | rename, configure, open, view, copy, more, cancel |
+| `primary` | `var(--color-primary)` | Primary create / submit / send | add, send |
+| `info` | `var(--color-info-text)` | Information, progress, system context | info |
+| `success` | `var(--color-success)` | Positive status change or recovery | sync, save, reactivate |
+| `warning` | `var(--color-warning)` | Caution / reversible risky action | edit, retry, suspend |
+| `danger` | `var(--color-destructive)` | Destructive or high-impact | delete, stop, leave, offboard |
+
+Note: `edit` is tone `warning` (amber) — editing is a reversible change that
+deserves a caution cue, distinct from neutral navigation.
+
+The full action→tone and action→icon maps are the single source of truth in
+`src/components/ui/row-action.tsx` (`rowActionToneByAction`, `rowActionIcons`).
+Add new actions there, not ad hoc per page.
+
+### Bordered action icons
+
+When actions need a visible affordance (outlined icon buttons), the border
+must match the icon color. Use `border border-current` so the border inherits
+the tone's `currentColor` — never a hardcoded border color and never an inline
+`style`. See Borders And Cascade Layers for why this works.
+
+## List Primitives
+
+`list` provides the standard "stack of rows" surface used across the portal.
+
+```tsx
+import {
+  ListFrame, ListRow, ListRowContent, ListRowTitle,
+  ListRowDescription, ListRowActions,
+} from '@/components/ui/list'
+
+<ListFrame>
+  <ListRow interactive>
+    <ListRowContent>
+      <ListRowTitle>Kennisbank bronnen</ListRowTitle>
+      <ListRowDescription>Rustige lijst met compacte acties.</ListRowDescription>
+    </ListRowContent>
+    <ListRowActions className="self-center">
+      <RowActionIconButton label="Bewerken" action="edit" />
+      <RowActionIconButton label="Verwijderen" action="delete" />
+    </ListRowActions>
+  </ListRow>
+</ListFrame>
+```
+
+- `ListFrame` draws the `divide-y` separators and top/bottom border.
+- `ListRow interactive` adds `klai-hover` + pointer; `confirming` tints the
+  row while a destructive confirm is open.
+- `ListRowTitle` truncates on one line; `ListRowDescription` is the muted
+  secondary line.
+- `ListRowActions` is the trailing action cell; put a `RowActionGroup` or
+  loose `RowActionIconButton`s inside.
+
+## Inline Delete Confirmation
+
+Destructive actions inside a row use `InlineDeleteConfirm` — the canonical
+inline confirm. It keeps the original actions in the DOM as an invisible
+ghost spacer and overlays the confirm/cancel controls absolutely, so the row
+never shifts width when confirming.
+
+```tsx
+import { InlineDeleteConfirm } from '@/components/ui/inline-delete-confirm'
+
+<InlineDeleteConfirm
+  isConfirming={confirmDeleteId === row.id}
+  isPending={deleteMutation.isPending}
+  label={m.source_delete_confirm({ name: row.name })}
+  cancelLabel={m.cancel()}
+  onConfirm={() => deleteMutation.mutate(row.id)}
+  onCancel={() => setConfirmDeleteId(null)}
+>
+  <RowActionGroup>
+    <RowActionIconButton label="Bewerken" action="edit" />
+    <RowActionIconButton
+      label="Verwijderen"
+      action="delete"
+      onClick={() => setConfirmDeleteId(row.id)}
+    />
+  </RowActionGroup>
+</InlineDeleteConfirm>
+```
+
+Rules:
+
+- Use this for row-level deletes. It is controlled — you own the
+  `confirmDeleteId` / pending state.
+- The confirm button is destructive-filled with the action label; cancel is a
+  ghost `X`. Both come from the component — do not restyle.
+- For destructive actions that are NOT in a row (e.g. a whole page or card),
+  use `alert-dialog` instead.
+- `delete-confirm-button` is the deprecated predecessor (raw buttons,
+  hardcoded English labels). Do not use it in new code; migrate to
+  `InlineDeleteConfirm` when you touch a screen that still uses it.
+- Never use `window.confirm`.
+
+## Wizards
+
+Multi-step flows (create knowledge base, add connector, new API key, new
+widget) use `StepIndicator` for progress.
+
+```tsx
+import { StepIndicator } from '@/components/ui/step-indicator'
+
+<StepIndicator
+  steps={[
+    { label: 'Details' },
+    { label: 'Bron', onClick: () => setStep(1) },
+    { label: 'Bevestigen' },
+  ]}
+  currentIndex={step}
+/>
+```
+
+- Active step: solid `gray-900` pill with its number.
+- Completed step: light pill with a check; clickable to jump back only when
+  `onClick` is provided.
+- Future step: muted pill, not clickable.
+- Wizard steps containing a `type="password"` / secret field must be wrapped
+  in a `<form>` with `onSubmit` advancing the step (browser autofill).
 
 ## Tabs
 
@@ -85,6 +293,29 @@ to return to the same section.
 
 Do not use pill tabs for admin/account/detail surfaces unless the surrounding
 module already does.
+
+Tabs are currently hand-rolled (no shared `tabs` component yet) in:
+`app/account.tsx`, `app/knowledge/$kbSlug/route.tsx`, `admin/platform/index.tsx`,
+`admin/api-keys/$id.tsx`, `admin/widgets/$id.tsx`. The standard markup is an
+underline row with an active `border-b-2`:
+
+```tsx
+<div className="flex gap-6 border-b border-gray-200">
+  <button
+    type="button"
+    onClick={() => setTab('details')}
+    className={tab === 'details'
+      ? 'border-b-2 border-gray-900 pb-2 text-sm font-medium text-gray-900'
+      : 'border-b-2 border-transparent pb-2 text-sm text-gray-400 hover:text-gray-900'}
+  >
+    Details
+  </button>
+</div>
+```
+
+Because this pattern repeats in 5 places, it is a candidate for extraction
+into a shared `Tabs` component (tracked for the cleanup phase). Until then,
+copy the markup above exactly so the 5 instances stay identical.
 
 ## Detail And Edit
 
@@ -173,6 +404,62 @@ Use:
 Do not use raw Tailwind semantic colors such as `text-green-*`, `text-red-*`,
 `bg-amber-*`, or `hover:bg-gray-50` in new portal UI.
 
+For row/action coloring, do not pick colors by hand — use the action tone
+system (see Row Actions And Action Tones).
+
+## Borders And Cascade Layers
+
+`index.css` sets a default border color for every element so a bare `border`
+utility renders in the neutral border color:
+
+```css
+@layer base {
+  * {
+    border-color: var(--color-border);
+    outline-color: var(--color-ring);
+  }
+}
+```
+
+This rule MUST stay inside `@layer base`. CSS cascade layers, not specificity,
+decide the winner here: unlayered declarations rank after every explicit
+layer, so an unlayered `* { border-color }` would beat every Tailwind utility
+(which live in `@layer utilities`) regardless of class specificity. When this
+rule was unlayered, every colored border utility in the portal
+(`border-[var(--color-destructive)]`, `border-current`, `border-amber-300`,
+...) was silently overridden to the neutral grey — invisible because grey is
+close to `gray-200`. Keeping it in `@layer base` lets utilities win, which is
+Tailwind v4's intended preflight behaviour.
+
+Consequences for component code:
+
+- A colored border is just a utility: `border border-[var(--color-destructive)]`
+  or, to match the current text color, `border border-current`.
+- Never fix a border color with an inline `style={{ borderColor }}` — that
+  only "works" because inline styles sit outside layers entirely. It is a
+  workaround, not the pattern.
+- Never add a second unlayered `* { border-color }` or an `@utility` override
+  to "win" — fix the layer, not the specificity.
+
+## Overlays, Menus And Feedback
+
+| Need | Component | Notes |
+|---|---|---|
+| Confirm a destructive action outside a row | `alert-dialog` | Centered, focus-trapped. Row-level deletes use `inline-delete-confirm` instead. |
+| Generic modal (form, detail that is genuinely modal) | `dialog` | Not for admin entity detail — those are separate routes. |
+| Action menu on a trigger | `dropdown-menu` | Use for "more actions" overflow. |
+| Floating content on a trigger | `popover` | Non-menu floating panels. |
+| Searchable list / combobox | `command` | Command palette and filterable pickers. |
+| Multi-value selection | `multi-select` | |
+| Edit a value in place | `inline-edit` | Click-to-edit text, commits on blur/enter. |
+| Hover/focus hint | `tooltip` | `RowActionIconButton` wires this automatically via `label`. |
+| Transient feedback after an action | `sonner` (`toast`) | Success/error confirmations; not for validation errors. |
+| A query failed | `query-error-state` | Standard error block with retry. |
+| Slide-over panel | `sheet` | **Restricted**: never for admin entity detail (see Detail And Edit). |
+
+Compose these instead of building bespoke overlays. If a needed variant is
+missing, add it to the owned component, not to a page.
+
 ## Copy And I18n
 
 All user-visible strings go through Paraglide messages:
@@ -193,3 +480,9 @@ These patterns must not be copied:
 - `window.confirm`.
 - `hover:bg-gray-50` on interactive rows.
 - Raw semantic Tailwind colors for status states.
+- Raw `<button>` icon actions in rows. Use `row-action` components.
+- `delete-confirm-button`. Use `inline-delete-confirm`.
+- Inline `style={{ borderColor }}` to color a border. Use a `border-*` utility.
+- An unlayered `* { border-color }` or `@utility` override. Keep the reset in
+  `@layer base` (see Borders And Cascade Layers).
+- Hand-picked icon colors for row actions. Use the action tone system.

--- a/klai-portal/frontend/docs/ui-standards.md
+++ b/klai-portal/frontend/docs/ui-standards.md
@@ -40,9 +40,12 @@ Build pages from these; never hand-roll a raw `<button>`, `<input>`,
 | `button` | All buttons (variants: default/secondary/ghost/outline/destructive; sizes: default/sm/icon) | Yes |
 | `badge` | Inline status labels (secondary/success/warning/destructive/outline) | Yes |
 | `input` `select` `textarea` `label` `checkbox` | Form controls | Yes |
+| `search-input` | Text input with a leading search icon (`SearchInput`) | Yes |
 | `row-action` | List/table row actions: `RowActionIconButton`, `RowActionButton`, `RowActionGroup` + the action→tone system | Yes |
-| `list` | List primitives: `ListFrame`, `ListRow`, `ListRowContent`, `ListRowTitle`, `ListRowDescription`, `ListRowActions`, `ListRowIcon` | Yes |
+| `list` | List primitives: `ListFrame`, `ListRow`, `ListRowContent`, `ListRowTitle`, `ListRowDescription`, `ListRowActions`, `ListRowIcon`, `ListRowChevron` | Yes |
 | `inline-delete-confirm` | Inline destructive confirmation inside a row (no layout shift) | Yes |
+| `inline-edit` | Click-to-edit text in place (with save/cancel) | Yes |
+| `radio-card-group` | Selectable radio option cards (`RadioCardGroup`) | Yes |
 | `step-indicator` | Wizard step progress (`StepIndicator`) | Yes |
 | `alert-dialog` | Centered confirm dialog for destructive actions outside rows | Yes |
 | `dialog` | Generic modal | Yes |
@@ -218,6 +221,28 @@ import {
 - `ListRowActions` is the trailing action cell; put a `RowActionGroup` or
   loose `RowActionIconButton`s inside.
 
+### Navigation list
+
+A list whose rows navigate somewhere (the `/app` tool launcher) is the same
+primitives with the row as a link and a trailing `ListRowChevron` instead of
+actions. Do not hand-roll this — reuse the primitives so the icon/title/
+description rhythm stays identical to other lists.
+
+```tsx
+<ListFrame>
+  <ListRow asChild interactive>
+    <a href={tool.href}>
+      <ListRowIcon><tool.icon className="h-4 w-4" /></ListRowIcon>
+      <ListRowContent>
+        <ListRowTitle>{tool.title}</ListRowTitle>
+        <ListRowDescription>{tool.description}</ListRowDescription>
+      </ListRowContent>
+      <ListRowChevron />
+    </a>
+  </ListRow>
+</ListFrame>
+```
+
 ## Inline Delete Confirmation
 
 Destructive actions inside a row use `InlineDeleteConfirm` — the canonical
@@ -251,6 +276,13 @@ Rules:
 
 - Use this for row-level deletes. It is controlled — you own the
   `confirmDeleteId` / pending state.
+- **Tint the row while confirming.** The confirm overlay paints
+  `bg-[var(--color-hover)]` so it can cover the meta text behind it. The row
+  it sits in MUST get the SAME background while confirming, or a hard seam
+  shows where the overlay meets the untinted row. `ListRow confirming` does
+  this for you; a raw `<tr>`/`<div>` row must add
+  `bg-[var(--color-hover)]` on the confirming branch (see
+  `TranscriptionTable`, `SourceRow`).
 - The confirm button is destructive-filled with the action label; cancel is a
   ghost `X`. Both come from the component — do not restyle.
 - For destructive actions that are NOT in a row (e.g. a whole page or card),
@@ -346,6 +378,31 @@ Every field needs `Label` plus matching `id`/`htmlFor`.
 </div>
 ```
 
+- **Search fields** use `SearchInput` (leading magnifier icon), never a bare
+  `Input` with a hand-placed icon.
+- **`Select`** renders a custom chevron; its right padding is symmetric with
+  the left text padding. Do not re-add a native arrow or a second icon.
+- **Inline value edits** (rename in a row) use `InlineEdit` with a green
+  save + ghost cancel control. The amber edit trigger is a bordered action
+  icon (`border border-current`), matching the row-action look.
+
+### Selectable cards
+
+A single-choice list where each option needs a label + description (role
+picker, plan picker) uses `RadioCardGroup`. The selected card gets a dark
+border + subtle fill (no amber on active states per the v1 spine).
+
+```tsx
+<RadioCardGroup
+  options={options}            // { value, label, description }[]
+  value={value}
+  onChange={setValue}
+  aria-label="Profiel"
+/>
+```
+
+`ProfilePicker` is the role-ladder specialization of this pattern.
+
 ## Cards
 
 Cards are individual repeated items, stats, or genuinely framed blocks. Do not
@@ -406,6 +463,26 @@ Do not use raw Tailwind semantic colors such as `text-green-*`, `text-red-*`,
 
 For row/action coloring, do not pick colors by hand — use the action tone
 system (see Row Actions And Action Tones).
+
+### Semantic badges
+
+Status badges use the `Badge` component with a semantic variant. The semantic
+variants (`info`, `success`, `warning`, `destructive`) derive from the SAME
+primary tokens as the action tones — same hue, same meaning — kept soft via a
+10% tint background with the solid token as text:
+
+```
+success  → bg var(--color-success)/10   text var(--color-success)
+warning  → bg var(--color-warning)/10   text var(--color-warning)
+destructive → bg var(--color-destructive)/10 text var(--color-destructive)
+info     → bg var(--color-info)/10      text var(--color-info)
+```
+
+So a green status badge and a green sync icon are the same green, just softer.
+Structural (non-semantic) variants stay neutral: `secondary` (gray fill),
+`outline`, `default`/`accent` (dark). Do not hand-roll status pills with ad-hoc
+`/10` tints — use `Badge`. (The transcribe `StatusBadge` is the remaining
+hand-rolled one; migrate it to `Badge` on touch.)
 
 ## Borders And Cascade Layers
 
@@ -486,3 +563,6 @@ These patterns must not be copied:
 - An unlayered `* { border-color }` or `@utility` override. Keep the reset in
   `@layer base` (see Borders And Cascade Layers).
 - Hand-picked icon colors for row actions. Use the action tone system.
+- Hand-rolled search inputs (`Input` + manually placed icon). Use `SearchInput`.
+- Hand-rolled status pills with ad-hoc `/10` tints. Use `Badge` semantic variants.
+- A delete-confirm overlay on an untinted row. Tint the row while confirming.

--- a/klai-portal/frontend/src/components/ui/badge.tsx
+++ b/klai-portal/frontend/src/components/ui/badge.tsx
@@ -5,7 +5,11 @@ import { cn } from '@/lib/utils'
 // Portal v1 spine (SPEC-PORTAL-REDESIGN-002):
 // - rounded-full (same as buttons)
 // - default/accent use neutral gray (polish-1 decides amber reintroduction)
-// - semantic states (success/warning/destructive) use CSS tokens
+// - Semantic states derive from the SAME primary tokens as the row-action
+//   tones (var(--color-success|warning|destructive|info)), kept soft via a
+//   10% tint background — same hue and meaning as the solid action icons,
+//   just softer. This is the single source of the semantic badge palette;
+//   do not hand-roll status pills with ad-hoc /10 tints.
 const badgeVariants = cva(
   'inline-flex w-fit items-center rounded-full border px-2 py-0.5 text-xs font-medium transition-colors',
   {
@@ -20,11 +24,13 @@ const badgeVariants = cva(
         outline:
           'border-gray-200 text-gray-700',
         success:
-          'border-transparent bg-[var(--color-success-bg)] text-[var(--color-success-text)]',
+          'border-transparent bg-[var(--color-success)]/10 text-[var(--color-success)]',
         warning:
-          'border-transparent bg-[var(--color-warning-subtle)] text-[var(--color-warning-text)]',
+          'border-transparent bg-[var(--color-warning)]/10 text-[var(--color-warning)]',
         destructive:
-          'border-transparent bg-[var(--color-destructive-bg)] text-[var(--color-destructive-text)]',
+          'border-transparent bg-[var(--color-destructive)]/10 text-[var(--color-destructive)]',
+        info:
+          'border-transparent bg-[var(--color-info)]/10 text-[var(--color-info)]',
       },
     },
     defaultVariants: {

--- a/klai-portal/frontend/src/components/ui/inline-delete-confirm.tsx
+++ b/klai-portal/frontend/src/components/ui/inline-delete-confirm.tsx
@@ -28,9 +28,10 @@ interface InlineDeleteConfirmProps {
  *     onConfirm={() => deleteMutation.mutate(row.id)}
  *     onCancel={() => setConfirmDeleteId(null)}
  *   >
- *     <div className="flex items-center justify-end gap-1">
- *       <button onClick={() => setConfirmDeleteId(row.id)}><Trash2 /></button>
- *     </div>
+ *     <RowActionGroup>
+ *       <RowActionIconButton label="Verwijderen" action="delete"
+ *         onClick={() => setConfirmDeleteId(row.id)} />
+ *     </RowActionGroup>
  *   </InlineDeleteConfirm>
  */
 export function InlineDeleteConfirm({

--- a/klai-portal/frontend/src/components/ui/inline-edit-row.tsx
+++ b/klai-portal/frontend/src/components/ui/inline-edit-row.tsx
@@ -1,0 +1,209 @@
+import { useEffect, useRef, useState, type KeyboardEvent, type ReactNode } from 'react'
+import { Check, Loader2, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+export interface InlineEditRowSubmit {
+  name: string
+  description: string
+}
+
+export interface InlineEditRowProps {
+  /** True while this row is in edit mode. Parent owns the singleton so only one row edits at a time. */
+  isEditing: boolean
+  /**
+   * Current name. Seeds the edit buffer on the false → true edit transition
+   * and is shown as the title in view mode.
+   */
+  value: string
+  /**
+   * Current description. Seeds the description buffer; rendered under the
+   * title (and made editable when `withDescription`).
+   */
+  description?: string
+  /** Make the second (description) field editable — the "subtest" case. */
+  withDescription?: boolean
+  /** Disables inputs + save while a mutation is in flight, shows a spinner on save. */
+  isSaving?: boolean
+  namePlaceholder?: string
+  descriptionPlaceholder?: string
+  saveLabel: string
+  cancelLabel: string
+  onSubmit: (next: InlineEditRowSubmit) => void
+  onCancel: () => void
+  /**
+   * Right-side cluster rendered in VIEW mode only (edit/delete icons, a badge,
+   * a delete-confirm overlay, …). Hidden automatically while editing, where it
+   * is replaced by the Save/Cancel cluster.
+   */
+  actions?: ReactNode
+}
+
+/**
+ * Canonical inline edit for list rows — multi-field, zero layout shift.
+ *
+ * Layout contract:
+ *   - The row is a single flex line, `items-center`, so the action cluster
+ *     (icons in view / Save+Cancel in edit) is always vertically centred
+ *     against the FULL content block, regardless of how many lines it has.
+ *   - Each editable field (name, optional description) uses the ghost +
+ *     absolute-overlay technique: the view text stays in the DOM (turned
+ *     `invisible` while editing) so it always defines the box height, and
+ *     the `<input>` is painted `absolute inset-0` on top. Toggling edit can
+ *     therefore NEVER change the row height — zero vertical shift, which is
+ *     the property the old single-field overlay had and the naive flex
+ *     rewrite lost.
+ *   - The content block is `flex-1` and the action cluster `shrink-0`, so the
+ *     wider Save/Cancel pair (vs the two icons) makes the inputs shrink
+ *     horizontally instead of overlapping the buttons.
+ *
+ * Buffer state (`name`, `description`) is seeded ONLY on the false → true
+ * `isEditing` transition via a `useRef` guard, so a TanStack Query refetch
+ * (window-focus, mutation invalidation) cannot wipe the user's typed input
+ * mid-edit. Ported from the production `CoverageNodeRow`.
+ *
+ * Enter submits, Escape cancels.
+ */
+export function InlineEditRow({
+  isEditing,
+  value,
+  description,
+  withDescription = false,
+  isSaving = false,
+  namePlaceholder,
+  descriptionPlaceholder,
+  saveLabel,
+  cancelLabel,
+  onSubmit,
+  onCancel,
+  actions,
+}: InlineEditRowProps) {
+  const [name, setName] = useState(value)
+  const [desc, setDesc] = useState(description ?? '')
+
+  // Seed buffers on the false → true edit transition only — not on every
+  // re-render while editing. Prevents query-refetch object-ref churn from
+  // overwriting typed input (same regression class fixed in CoverageNodeRow).
+  const prevIsEditing = useRef(false)
+  useEffect(() => {
+    if (isEditing && !prevIsEditing.current) {
+      setName(value)
+      setDesc(description ?? '')
+    }
+    prevIsEditing.current = isEditing
+    // Deliberately omit value/description from deps — see comment above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isEditing])
+
+  function submit() {
+    const trimmed = name.trim()
+    if (trimmed) onSubmit({ name: trimmed, description: desc.trim() })
+  }
+
+  function handleKeyDown(e: KeyboardEvent) {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      submit()
+    }
+    if (e.key === 'Escape') onCancel()
+  }
+
+  // Amber rounded affordance via `ring` (not `border`) so it adds no box
+  // width — the overlay stays exactly the size of its ghost text.
+  const overlayInput = cn(
+    'absolute inset-0 w-full rounded-md px-1',
+    'bg-[var(--color-card)] text-[var(--color-foreground)]',
+    'border-0 outline-none ring-1 ring-[var(--color-accent)]',
+    'disabled:opacity-50',
+  )
+
+  const showDescriptionField = withDescription || Boolean(description)
+
+  return (
+    <div className="flex min-w-0 flex-1 items-center gap-2">
+      <div className="min-w-0 flex-1">
+        {/* Name field — ghost holds height, input overlays exactly. */}
+        <div className="relative">
+          <span
+            className={cn(
+              'block truncate text-[15px] font-display text-gray-900',
+              isEditing && 'invisible',
+            )}
+          >
+            {value}
+          </span>
+          {isEditing ? (
+            <input
+              autoFocus
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onKeyDown={handleKeyDown}
+              disabled={isSaving}
+              placeholder={namePlaceholder}
+              aria-label={namePlaceholder ?? value}
+              className={cn(overlayInput, 'text-[15px] font-display')}
+            />
+          ) : null}
+        </div>
+
+        {/* Description field — same ghost+overlay so the second line never
+            disappears (the layout-shift the user flagged). */}
+        {showDescriptionField ? (
+          <div className="relative mt-1">
+            <p
+              className={cn(
+                'block truncate text-sm text-gray-400',
+                isEditing && withDescription && 'invisible',
+              )}
+            >
+              {description || ' '}
+            </p>
+            {isEditing && withDescription ? (
+              <input
+                value={desc}
+                onChange={(e) => setDesc(e.target.value)}
+                onKeyDown={handleKeyDown}
+                disabled={isSaving}
+                placeholder={descriptionPlaceholder}
+                aria-label={descriptionPlaceholder ?? 'Beschrijving'}
+                className={cn(overlayInput, 'text-sm')}
+              />
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+
+      {/* Action cluster: centred against the whole block via the row's
+          items-center. Save/Cancel use the app-standard inline-row button
+          size (matches InlineDeleteConfirm exactly). */}
+      <div className="flex shrink-0 items-center gap-1">
+        {isEditing ? (
+          <>
+            <Button
+              type="button"
+              size="sm"
+              disabled={isSaving || !name.trim()}
+              onClick={submit}
+              className="h-6 gap-1 px-2 text-[10px] [&_svg]:size-2.5 bg-[var(--color-success)] text-white hover:opacity-70"
+            >
+              {isSaving ? <Loader2 className="animate-spin" /> : <Check />}
+              {saveLabel}
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              onClick={onCancel}
+              className="h-6 gap-1 px-2 text-[10px] [&_svg]:size-2.5"
+            >
+              <X />
+              {cancelLabel}
+            </Button>
+          </>
+        ) : (
+          actions
+        )}
+      </div>
+    </div>
+  )
+}

--- a/klai-portal/frontend/src/components/ui/list.tsx
+++ b/klai-portal/frontend/src/components/ui/list.tsx
@@ -1,0 +1,94 @@
+import * as React from 'react'
+import { Slot } from '@radix-ui/react-slot'
+import { cn } from '@/lib/utils'
+
+interface ListFrameProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+function ListFrame({ className, ...props }: ListFrameProps) {
+  return (
+    <div
+      className={cn('divide-y divide-gray-200 border-y border-gray-200', className)}
+      {...props}
+    />
+  )
+}
+
+interface ListRowProps extends React.HTMLAttributes<HTMLDivElement> {
+  asChild?: boolean
+  interactive?: boolean
+  confirming?: boolean
+}
+
+const ListRow = React.forwardRef<HTMLDivElement, ListRowProps>(
+  ({ asChild = false, interactive = false, confirming = false, className, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'div'
+    return (
+      <Comp
+        ref={ref}
+        className={cn(
+          'group flex items-start gap-4 px-2 py-3.5 transition-colors',
+          interactive && 'cursor-pointer klai-hover',
+          confirming && 'bg-[var(--color-hover)]',
+          className,
+        )}
+        {...props}
+      />
+    )
+  },
+)
+ListRow.displayName = 'ListRow'
+
+interface ListRowIconProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+function ListRowIcon({ className, ...props }: ListRowIconProps) {
+  return (
+    <div
+      className={cn('flex h-8 w-8 shrink-0 items-center justify-center text-gray-400', className)}
+      {...props}
+    />
+  )
+}
+
+interface ListRowContentProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+function ListRowContent({ className, ...props }: ListRowContentProps) {
+  return <div className={cn('min-w-0 flex-1', className)} {...props} />
+}
+
+interface ListRowTitleProps extends React.HTMLAttributes<HTMLSpanElement> {}
+
+function ListRowTitle({ className, ...props }: ListRowTitleProps) {
+  return (
+    <span
+      className={cn('truncate text-[15px] font-display text-gray-900', className)}
+      {...props}
+    />
+  )
+}
+
+interface ListRowDescriptionProps extends React.HTMLAttributes<HTMLParagraphElement> {}
+
+function ListRowDescription({ className, ...props }: ListRowDescriptionProps) {
+  return <p className={cn('mt-1 truncate text-sm text-gray-400', className)} {...props} />
+}
+
+interface ListRowActionsProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+function ListRowActions({ className, ...props }: ListRowActionsProps) {
+  return (
+    <div
+      className={cn('flex shrink-0 items-center justify-end gap-1', className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  ListFrame,
+  ListRow,
+  ListRowIcon,
+  ListRowContent,
+  ListRowTitle,
+  ListRowDescription,
+  ListRowActions,
+}

--- a/klai-portal/frontend/src/components/ui/list.tsx
+++ b/klai-portal/frontend/src/components/ui/list.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { Slot } from '@radix-ui/react-slot'
+import { ChevronRight } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 interface ListFrameProps extends React.HTMLAttributes<HTMLDivElement> {}
@@ -83,6 +84,17 @@ function ListRowActions({ className, ...props }: ListRowActionsProps) {
   )
 }
 
+interface ListRowChevronProps extends React.HTMLAttributes<HTMLSpanElement> {}
+
+/** Trailing chevron for navigation rows (a row that links somewhere). */
+function ListRowChevron({ className, ...props }: ListRowChevronProps) {
+  return (
+    <span className={cn('shrink-0 self-center text-gray-300', className)} {...props}>
+      <ChevronRight className="h-4 w-4" />
+    </span>
+  )
+}
+
 export {
   ListFrame,
   ListRow,
@@ -91,4 +103,5 @@ export {
   ListRowTitle,
   ListRowDescription,
   ListRowActions,
+  ListRowChevron,
 }

--- a/klai-portal/frontend/src/components/ui/radio-card-group.tsx
+++ b/klai-portal/frontend/src/components/ui/radio-card-group.tsx
@@ -1,0 +1,84 @@
+import { useId } from 'react'
+import { cn } from '@/lib/utils'
+
+export interface RadioCardOption {
+  value: string
+  label: string
+  description?: string
+  disabled?: boolean
+}
+
+interface RadioCardGroupProps {
+  options: RadioCardOption[]
+  value: string
+  onChange: (value: string) => void
+  /** Group-wide disable. Individual options can also set `disabled`. */
+  disabled?: boolean
+  /** Compact rendering: tighter padding, no description. */
+  compact?: boolean
+  'aria-label'?: string
+  className?: string
+}
+
+/**
+ * Selectable radio cards: a vertical stack of bordered option cards with a
+ * native radio, a title and an optional description. The selected card gets a
+ * dark border + subtle fill (no amber on active states per the v1 spine).
+ *
+ * Generic version of the profile picker pattern. Controlled — the caller owns
+ * `value` and persistence.
+ */
+export function RadioCardGroup({
+  options,
+  value,
+  onChange,
+  disabled = false,
+  compact = false,
+  'aria-label': ariaLabel,
+  className,
+}: RadioCardGroupProps) {
+  // Unique radio-group name so multiple groups on one page never share state.
+  const name = useId()
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label={ariaLabel}
+      className={cn(compact ? 'space-y-1.5' : 'space-y-2', className)}
+    >
+      {options.map((option) => {
+        const isSelected = value === option.value
+        const isDisabled = disabled || option.disabled
+        return (
+          <label
+            key={option.value}
+            className={cn(
+              'flex items-start gap-3 rounded-lg border cursor-pointer transition-colors',
+              compact ? 'p-2' : 'p-3',
+              isSelected ? 'border-gray-900 bg-black/[0.06]' : 'border-gray-200 klai-hover',
+              isDisabled && 'opacity-50 cursor-not-allowed',
+            )}
+          >
+            <input
+              type="radio"
+              name={name}
+              value={option.value}
+              checked={isSelected}
+              disabled={isDisabled}
+              onChange={() => {
+                if (!isDisabled) onChange(option.value)
+              }}
+              className="mt-0.5 accent-gray-900"
+            />
+            <div className="space-y-0.5">
+              <p className="text-sm font-medium text-gray-900">{option.label}</p>
+              {!compact && option.description && (
+                <p className="text-xs text-gray-400">{option.description}</p>
+              )}
+            </div>
+          </label>
+        )
+      })}
+    </div>
+  )
+}

--- a/klai-portal/frontend/src/components/ui/row-action.tsx
+++ b/klai-portal/frontend/src/components/ui/row-action.tsx
@@ -33,7 +33,7 @@ import { Tooltip } from '@/components/ui/tooltip'
 
 const rowActionToneByAction = {
   add: 'primary',
-  edit: 'neutral',
+  edit: 'warning',
   rename: 'neutral',
   configure: 'neutral',
   open: 'neutral',

--- a/klai-portal/frontend/src/components/ui/row-action.tsx
+++ b/klai-portal/frontend/src/components/ui/row-action.tsx
@@ -1,0 +1,268 @@
+import * as React from 'react'
+import { Slot } from '@radix-ui/react-slot'
+import {
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Copy,
+  Download,
+  ExternalLink,
+  Eye,
+  Info,
+  Link as LinkIcon,
+  Loader2,
+  LogOut,
+  MoreHorizontal,
+  Pencil,
+  Play,
+  Plus,
+  RefreshCw,
+  RotateCcw,
+  Search,
+  Send,
+  Settings,
+  Square,
+  Trash2,
+  Upload,
+  UserX,
+  X,
+} from 'lucide-react'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
+import { Tooltip } from '@/components/ui/tooltip'
+
+const rowActionToneByAction = {
+  add: 'primary',
+  edit: 'neutral',
+  rename: 'neutral',
+  configure: 'neutral',
+  open: 'neutral',
+  external: 'neutral',
+  sync: 'success',
+  retry: 'warning',
+  copy: 'neutral',
+  reauth: 'neutral',
+  send: 'primary',
+  view: 'neutral',
+  download: 'neutral',
+  upload: 'neutral',
+  search: 'neutral',
+  save: 'success',
+  delete: 'danger',
+  stop: 'danger',
+  cancel: 'neutral',
+  more: 'neutral',
+  expand: 'neutral',
+  collapse: 'neutral',
+  suspend: 'warning',
+  reactivate: 'success',
+  leave: 'danger',
+  offboard: 'danger',
+  info: 'info',
+} as const
+
+const rowActionIcons = {
+  add: Plus,
+  edit: Pencil,
+  rename: Pencil,
+  configure: Settings,
+  open: ExternalLink,
+  external: ExternalLink,
+  sync: RefreshCw,
+  retry: RotateCcw,
+  copy: Copy,
+  reauth: LinkIcon,
+  send: Send,
+  view: Eye,
+  download: Download,
+  upload: Upload,
+  search: Search,
+  save: Check,
+  delete: Trash2,
+  stop: Square,
+  cancel: X,
+  more: MoreHorizontal,
+  expand: ChevronRight,
+  collapse: ChevronDown,
+  suspend: Square,
+  reactivate: Play,
+  leave: LogOut,
+  offboard: UserX,
+  info: Info,
+} as const
+
+export type RowActionKind = keyof typeof rowActionIcons
+export type RowActionTone = (typeof rowActionToneByAction)[RowActionKind]
+export type RowActionIcon = React.ComponentType<{ className?: string }>
+
+const rowActionIconButtonVariants = cva(
+  'inline-flex h-8 w-8 items-center justify-center rounded-md transition-opacity hover:opacity-70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)] disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:h-4 [&_svg]:w-4 [&_svg]:shrink-0',
+  {
+    variants: {
+      tone: {
+        neutral: 'text-gray-400',
+        primary: 'text-[var(--color-primary)]',
+        info: 'text-[var(--color-info-text)]',
+        danger: 'text-[var(--color-destructive)]',
+        success: 'text-[var(--color-success)]',
+        warning: 'text-[var(--color-warning)]',
+      },
+    },
+    defaultVariants: {
+      tone: 'neutral',
+    },
+  },
+)
+
+const rowActionButtonVariants = cva(
+  'inline-flex h-8 items-center justify-center gap-1.5 whitespace-nowrap rounded-md px-2 text-xs font-medium transition-opacity hover:opacity-70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)] disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:h-3.5 [&_svg]:w-3.5 [&_svg]:shrink-0',
+  {
+    variants: {
+      tone: {
+        neutral: 'text-gray-500',
+        primary: 'text-[var(--color-primary)]',
+        info: 'text-[var(--color-info-text)]',
+        danger: 'text-[var(--color-destructive)]',
+        success: 'text-[var(--color-success)]',
+        warning: 'text-[var(--color-warning)]',
+      },
+    },
+    defaultVariants: {
+      tone: 'neutral',
+    },
+  },
+)
+
+function toneForAction(action?: RowActionKind, tone?: RowActionTone | null): RowActionTone {
+  return tone ?? (action ? rowActionToneByAction[action] : 'neutral')
+}
+
+function iconForAction(action?: RowActionKind, icon?: RowActionIcon): RowActionIcon | undefined {
+  return icon ?? (action ? rowActionIcons[action] : undefined)
+}
+
+function renderActionIcon(action?: RowActionKind, icon?: RowActionIcon) {
+  const actionIcon = iconForAction(action, icon)
+  return actionIcon ? React.createElement(actionIcon) : null
+}
+
+interface RowActionTooltipProps {
+  label: string
+  tooltip?: boolean
+  children: React.ReactNode
+}
+
+function RowActionTooltip({ label, tooltip = true, children }: RowActionTooltipProps) {
+  if (!tooltip) return children
+  return <Tooltip label={label}>{children}</Tooltip>
+}
+
+export interface RowActionIconButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof rowActionIconButtonVariants> {
+  label: string
+  action?: RowActionKind
+  icon?: RowActionIcon
+  asChild?: boolean
+  tooltip?: boolean
+  spinner?: React.ReactNode
+}
+
+const RowActionIconButton = React.forwardRef<HTMLButtonElement, RowActionIconButtonProps>(
+  (
+    {
+      label,
+      action,
+      icon,
+      tone,
+      asChild = false,
+      tooltip = true,
+      spinner,
+      className,
+      children,
+      type = 'button',
+      ...props
+    },
+    ref,
+  ) => {
+    const Comp = asChild ? Slot : 'button'
+    return (
+      <RowActionTooltip label={label} tooltip={tooltip}>
+        <Comp
+          ref={ref}
+          type={asChild ? undefined : type}
+          aria-label={label}
+          className={cn(rowActionIconButtonVariants({ tone: toneForAction(action, tone) }), className)}
+          {...props}
+        >
+          {spinner ?? children ?? renderActionIcon(action, icon)}
+        </Comp>
+      </RowActionTooltip>
+    )
+  },
+)
+RowActionIconButton.displayName = 'RowActionIconButton'
+
+export interface RowActionButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof rowActionButtonVariants> {
+  label: string
+  action?: RowActionKind
+  icon?: RowActionIcon
+  asChild?: boolean
+  tooltip?: boolean
+  spinner?: React.ReactNode
+}
+
+const RowActionButton = React.forwardRef<HTMLButtonElement, RowActionButtonProps>(
+  (
+    {
+      label,
+      action,
+      icon,
+      tone,
+      asChild = false,
+      tooltip = true,
+      spinner,
+      className,
+      children,
+      type = 'button',
+      ...props
+    },
+    ref,
+  ) => {
+    const Comp = asChild ? Slot : 'button'
+    return (
+      <RowActionTooltip label={label} tooltip={tooltip}>
+        <Comp
+          ref={ref}
+          type={asChild ? undefined : type}
+          aria-label={label}
+          className={cn(rowActionButtonVariants({ tone: toneForAction(action, tone) }), className)}
+          {...props}
+        >
+          {spinner ?? renderActionIcon(action, icon)}
+          {children ?? label}
+        </Comp>
+      </RowActionTooltip>
+    )
+  },
+)
+RowActionButton.displayName = 'RowActionButton'
+
+interface RowActionGroupProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+function RowActionGroup({ className, ...props }: RowActionGroupProps) {
+  return <div className={cn('flex items-center justify-end gap-1', className)} {...props} />
+}
+
+export {
+  RowActionButton,
+  RowActionGroup,
+  RowActionIconButton,
+  rowActionButtonVariants,
+  rowActionIconButtonVariants,
+  rowActionIcons,
+  rowActionToneByAction,
+  Loader2 as RowActionLoaderIcon,
+}

--- a/klai-portal/frontend/src/components/ui/search-input.tsx
+++ b/klai-portal/frontend/src/components/ui/search-input.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react'
+import { Search } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Input } from '@/components/ui/input'
+
+export interface SearchInputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+/**
+ * Text input with a leading search icon. Standardizes the
+ * relative-wrapper + absolute icon + `pl-10` pattern that was hand-rolled
+ * across list/overview screens (knowledge, users, transcribe, ...).
+ */
+const SearchInput = React.forwardRef<HTMLInputElement, SearchInputProps>(
+  ({ className, type = 'text', ...props }, ref) => {
+    return (
+      <div className="relative w-full">
+        <Search
+          className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
+          aria-hidden="true"
+        />
+        <Input ref={ref} type={type} className={cn('pl-10', className)} {...props} />
+      </div>
+    )
+  },
+)
+SearchInput.displayName = 'SearchInput'
+
+export { SearchInput }

--- a/klai-portal/frontend/src/components/ui/select.tsx
+++ b/klai-portal/frontend/src/components/ui/select.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { ChevronDown } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 export interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {}
@@ -7,23 +8,33 @@ export interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElemen
 // - rounded-lg (was rounded-md)
 // - border-gray-200 (Tailwind literal)
 // - focus ring amber (preserved via --color-ring)
+//
+// The native dropdown arrow is replaced by a custom chevron so its right
+// padding is symmetric with the left text padding (both 0.75rem / px-3),
+// instead of the browser-default arrow inset which reads as misaligned.
 const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
   ({ className, children, ...props }, ref) => {
     return (
-      <select
-        ref={ref}
-        className={cn(
-          'w-full rounded-lg border border-gray-200 bg-transparent px-3 py-2 text-sm text-gray-900 outline-none transition-colors',
-          'focus:ring-2 focus:ring-[var(--color-ring)]',
-          'disabled:cursor-not-allowed disabled:opacity-50',
-          className
-        )}
-        {...props}
-      >
-        {children}
-      </select>
+      <div className="relative w-full">
+        <select
+          ref={ref}
+          className={cn(
+            'w-full appearance-none rounded-lg border border-gray-200 bg-transparent pl-3 pr-9 py-2 text-sm text-gray-900 outline-none transition-colors',
+            'focus:ring-2 focus:ring-[var(--color-ring)]',
+            'disabled:cursor-not-allowed disabled:opacity-50',
+            className,
+          )}
+          {...props}
+        >
+          {children}
+        </select>
+        <ChevronDown
+          className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
+          aria-hidden="true"
+        />
+      </div>
     )
-  }
+  },
 )
 Select.displayName = 'Select'
 

--- a/klai-portal/frontend/src/index.css
+++ b/klai-portal/frontend/src/index.css
@@ -58,7 +58,8 @@
   --color-sidebar:                    #f5f4ef;
   --color-sidebar-foreground:         #191918;
   --color-sidebar-border:             #e3e2d8;
-  --color-hover:                      #f3f2e7;
+  --color-hover:                      #ffffff;
+  --color-active:                     #ffffff;
   --color-sidebar-accent:             var(--color-hover);
   --color-sidebar-accent-foreground:  #191918;
   --color-sidebar-muted-foreground:   #19191866;

--- a/klai-portal/frontend/src/index.css
+++ b/klai-portal/frontend/src/index.css
@@ -43,6 +43,9 @@
   --color-success:              #27AE60;
   --color-success-bg:           #D1FAE5;
   --color-success-text:         #065F46;
+  --color-info:                 #2563EB;
+  --color-info-bg:              #EFF6FF;
+  --color-info-text:            #1D4ED8;
   --color-warning:              #D97706;
   --color-warning-bg:           #FFFBEB;
   --color-warning-subtle:       #FEF3C7;

--- a/klai-portal/frontend/src/index.css
+++ b/klai-portal/frontend/src/index.css
@@ -82,9 +82,15 @@
   box-sizing: border-box;
 }
 
-* {
-  border-color: var(--color-border);
-  outline-color: var(--color-ring);
+/* Default border/outline color, placed in @layer base so Tailwind's
+   utilities layer (e.g. border-[var(--color-destructive)], border-current)
+   can override it. Unlayered, this rule would win over every utility
+   because unlayered declarations rank after all explicit cascade layers. */
+@layer base {
+  * {
+    border-color: var(--color-border);
+    outline-color: var(--color-ring);
+  }
 }
 
 body {

--- a/klai-portal/frontend/src/routeTree.gen.ts
+++ b/klai-portal/frontend/src/routeTree.gen.ts
@@ -31,6 +31,7 @@ import { Route as Setup2faRouteImport } from './routes/setup/2fa'
 import { Route as PasswordSetRouteImport } from './routes/password/set'
 import { Route as PasswordForgotRouteImport } from './routes/password/forgot'
 import { Route as JoinRequestSentRouteImport } from './routes/join-request/sent'
+import { Route as DevUiRouteImport } from './routes/dev/ui'
 import { Route as BotWidgetIdRouteImport } from './routes/bot/$widgetId'
 import { Route as AppScribeRouteImport } from './routes/app/scribe'
 import { Route as AppIntegrationsRouteImport } from './routes/app/integrations'
@@ -219,6 +220,11 @@ const JoinRequestSentRoute = JoinRequestSentRouteImport.update({
   id: '/sent',
   path: '/sent',
   getParentRoute: () => JoinRequestRoute,
+} as any)
+const DevUiRoute = DevUiRouteImport.update({
+  id: '/dev/ui',
+  path: '/dev/ui',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const BotWidgetIdRoute = BotWidgetIdRouteImport.update({
   id: '/bot/$widgetId',
@@ -662,6 +668,7 @@ export interface FileRoutesByFullPath {
   '/app/integrations': typeof AppIntegrationsRoute
   '/app/scribe': typeof AppScribeRoute
   '/bot/$widgetId': typeof BotWidgetIdRoute
+  '/dev/ui': typeof DevUiRoute
   '/join-request/sent': typeof JoinRequestSentRoute
   '/password/forgot': typeof PasswordForgotRoute
   '/password/set': typeof PasswordSetRoute
@@ -761,6 +768,7 @@ export interface FileRoutesByTo {
   '/app/integrations': typeof AppIntegrationsRoute
   '/app/scribe': typeof AppScribeRoute
   '/bot/$widgetId': typeof BotWidgetIdRoute
+  '/dev/ui': typeof DevUiRoute
   '/join-request/sent': typeof JoinRequestSentRoute
   '/password/forgot': typeof PasswordForgotRoute
   '/password/set': typeof PasswordSetRoute
@@ -862,6 +870,7 @@ export interface FileRoutesById {
   '/app/integrations': typeof AppIntegrationsRoute
   '/app/scribe': typeof AppScribeRoute
   '/bot/$widgetId': typeof BotWidgetIdRoute
+  '/dev/ui': typeof DevUiRoute
   '/join-request/sent': typeof JoinRequestSentRoute
   '/password/forgot': typeof PasswordForgotRoute
   '/password/set': typeof PasswordSetRoute
@@ -966,6 +975,7 @@ export interface FileRouteTypes {
     | '/app/integrations'
     | '/app/scribe'
     | '/bot/$widgetId'
+    | '/dev/ui'
     | '/join-request/sent'
     | '/password/forgot'
     | '/password/set'
@@ -1065,6 +1075,7 @@ export interface FileRouteTypes {
     | '/app/integrations'
     | '/app/scribe'
     | '/bot/$widgetId'
+    | '/dev/ui'
     | '/join-request/sent'
     | '/password/forgot'
     | '/password/set'
@@ -1165,6 +1176,7 @@ export interface FileRouteTypes {
     | '/app/integrations'
     | '/app/scribe'
     | '/bot/$widgetId'
+    | '/dev/ui'
     | '/join-request/sent'
     | '/password/forgot'
     | '/password/set'
@@ -1257,6 +1269,7 @@ export interface RootRouteChildren {
   VerifyRoute: typeof VerifyRoute
   WidgetTestRoute: typeof WidgetTestRoute
   BotWidgetIdRoute: typeof BotWidgetIdRoute
+  DevUiRoute: typeof DevUiRoute
   PasswordForgotRoute: typeof PasswordForgotRoute
   PasswordSetRoute: typeof PasswordSetRoute
   Setup2faRoute: typeof Setup2faRoute
@@ -1418,6 +1431,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/join-request/sent'
       preLoaderRoute: typeof JoinRequestSentRouteImport
       parentRoute: typeof JoinRequestRoute
+    }
+    '/dev/ui': {
+      id: '/dev/ui'
+      path: '/dev/ui'
+      fullPath: '/dev/ui'
+      preLoaderRoute: typeof DevUiRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/bot/$widgetId': {
       id: '/bot/$widgetId'
@@ -2228,6 +2248,7 @@ const rootRouteChildren: RootRouteChildren = {
   VerifyRoute: VerifyRoute,
   WidgetTestRoute: WidgetTestRoute,
   BotWidgetIdRoute: BotWidgetIdRoute,
+  DevUiRoute: DevUiRoute,
   PasswordForgotRoute: PasswordForgotRoute,
   PasswordSetRoute: PasswordSetRoute,
   Setup2faRoute: Setup2faRoute,

--- a/klai-portal/frontend/src/routes/admin/widgets/index.tsx
+++ b/klai-portal/frontend/src/routes/admin/widgets/index.tsx
@@ -2,15 +2,13 @@ import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { useState } from 'react'
 import {
   Plus,
-  Pencil,
-  ExternalLink,
-  Trash2,
   MessageSquare,
 } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { InlineDeleteConfirm } from '@/components/ui/inline-delete-confirm'
 import { QueryErrorState } from '@/components/ui/query-error-state'
+import { RowActionGroup, RowActionIconButton } from '@/components/ui/row-action'
 import * as m from '@/paraglide/messages'
 import { useWidgets, useDeleteWidget } from './-hooks'
 import type { WidgetResponse } from './-types'
@@ -141,8 +139,8 @@ function WidgetsPage() {
                   }}
                   onCancel={() => setConfirmDeleteId(null)}
                 >
-                  <div className="flex items-center justify-end gap-1">
-                    <Button
+                  <RowActionGroup>
+                    <RowActionIconButton
                       type="button"
                       onClick={() =>
                         window.open(
@@ -152,36 +150,28 @@ function WidgetsPage() {
                         )
                       }
                       aria-label={`Open ${w.name}`}
-                      title="Open bot in nieuw tabblad"
-                      variant="ghost"
-                      size="icon"
-                      className="h-8 w-8 rounded-md text-gray-400 hover:text-gray-900"
-                    >
-                      <ExternalLink className="h-4 w-4" />
-                    </Button>
-                    <Button
+                      label="Open bot in nieuw tabblad"
+                      action="open"
+                      tone="neutral"
+                    />
+                    <RowActionIconButton
                       type="button"
                       onClick={goToDetail}
                       aria-label={`Bewerk ${w.name}`}
-                      title="Bewerken"
-                      variant="ghost"
-                      size="icon"
-                      className="h-8 w-8 rounded-md text-gray-400 hover:text-gray-900"
-                    >
-                      <Pencil className="h-4 w-4" />
-                    </Button>
-                    <Button
+                      label="Bewerken"
+                      action="edit"
+                      tone="neutral"
+                    />
+                    <RowActionIconButton
                       type="button"
                       onClick={() => setConfirmDeleteId(String(w.id))}
                       aria-label={`Verwijder ${w.name}`}
-                      title="Verwijderen"
-                      variant="ghost"
-                      size="icon"
-                      className="h-8 w-8 rounded-md text-gray-400 hover:text-[var(--color-destructive)]"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  </div>
+                      label="Verwijderen"
+                      action="delete"
+                      tone="neutral"
+                      className="text-gray-400 hover:text-[var(--color-destructive)]"
+                    />
+                  </RowActionGroup>
                 </InlineDeleteConfirm>
                 </div>
               </div>

--- a/klai-portal/frontend/src/routes/app/transcribe/_components/TranscriptionTable.tsx
+++ b/klai-portal/frontend/src/routes/app/transcribe/_components/TranscriptionTable.tsx
@@ -265,7 +265,9 @@ export function TranscriptionTable({
               return (
                 <tr
                   key={`${item.source}-${item.id}`}
-                  className="border-b border-gray-200 last:border-b-0"
+                  className={`border-b border-gray-200 last:border-b-0 ${
+                    isConfirmingDelete ? 'bg-[var(--color-hover)]' : ''
+                  }`}
                 >
                   {/* Source icon */}
                   <td className="py-4 pr-2 align-top w-6">

--- a/klai-portal/frontend/src/routes/dev/ui.tsx
+++ b/klai-portal/frontend/src/routes/dev/ui.tsx
@@ -2,14 +2,12 @@ import { createFileRoute } from '@tanstack/react-router'
 import type { ComponentProps, ReactNode } from 'react'
 import { useState } from 'react'
 import {
-  Check,
   FileText,
   Loader2,
   MessageSquare,
   Mic,
   Settings,
   Sparkles,
-  X,
 } from 'lucide-react'
 import { toast } from 'sonner'
 import {
@@ -53,7 +51,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { InlineDeleteConfirm } from '@/components/ui/inline-delete-confirm'
-import { InlineEdit } from '@/components/ui/inline-edit'
+import { InlineEditRow } from '@/components/ui/inline-edit-row'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { MultiSelect } from '@/components/ui/multi-select'
@@ -239,8 +237,20 @@ function UiCatalogPage() {
   const [wizardStep, setWizardStep] = useState(1)
   const [activeTab, setActiveTab] = useState('Details')
   const [multiValue, setMultiValue] = useState<string[]>(['kb'])
-  const [inlineEditing, setInlineEditing] = useState(false)
-  const [inlineValue, setInlineValue] = useState('Klai component')
+  // Inline edit catalog: a "component" row (name only) and a "subtest" row
+  // (name + description), each with its own edit + delete-confirm state.
+  const [compEditing, setCompEditing] = useState(false)
+  const [compName, setCompName] = useState('Klai component')
+  const [compDescription, setCompDescription] = useState(
+    'Bewerk de naam of verwijder — alles inline, geen overlap.',
+  )
+  const [compDeleteConfirm, setCompDeleteConfirm] = useState(false)
+  const [subEditing, setSubEditing] = useState(false)
+  const [subName, setSubName] = useState('Toon van de afzender')
+  const [subDescription, setSubDescription] = useState(
+    'Controleert of het antwoord de juiste tone of voice aanhoudt.',
+  )
+  const [subDeleteConfirm, setSubDeleteConfirm] = useState(false)
   const [searchValue, setSearchValue] = useState('')
   const [radioValue, setRadioValue] = useState('personal')
 
@@ -406,8 +416,13 @@ function UiCatalogPage() {
 
       <Section title="Navigation list">
         <ListFrame>
-          {navListItems.map((item) => (
-            <ListRow key={item.title} asChild interactive>
+          {navListItems.map((item, index) => (
+            <ListRow
+              key={item.title}
+              asChild
+              interactive
+              className={index === 0 ? 'bg-[var(--color-active)]' : undefined}
+            >
               <a href="#">
                 <ListRowIcon>
                   <item.icon className="h-4 w-4" />
@@ -653,46 +668,112 @@ function UiCatalogPage() {
         />
       </Section>
 
-      <Section title="Inline edit">
-        <div className="flex items-center gap-3">
-          <InlineEdit
-            isEditing={inlineEditing}
-            value={inlineValue}
-            onValueChange={setInlineValue}
-            onSave={() => setInlineEditing(false)}
-            onCancel={() => setInlineEditing(false)}
-            inputClassName="text-sm font-medium"
-          >
-            <span className="text-sm font-medium text-gray-900">{inlineValue}</span>
-          </InlineEdit>
-          {inlineEditing ? (
-            <div className="flex items-center gap-1 whitespace-nowrap">
-              <Button
-                size="sm"
-                className="h-6 gap-1 px-2 text-[10px] [&_svg]:size-2.5 bg-[var(--color-success)] text-white hover:opacity-70"
-                onClick={() => setInlineEditing(false)}
-              >
-                <Check />
-                Opslaan
-              </Button>
-              <Button
-                size="sm"
-                variant="ghost"
-                className="h-6 gap-1 px-2 text-[10px] [&_svg]:size-2.5"
-                onClick={() => setInlineEditing(false)}
-              >
-                <X />
-                Annuleren
-              </Button>
-            </div>
-          ) : (
-            <BorderedRowActionIconButton
-              label="Naam bewerken"
-              action="edit"
-              onClick={() => setInlineEditing(true)}
+      <Section title="Inline edit and delete">
+        {/* Canonical inline edit: the InlineEditRow primitive puts the input
+            (flex-1) and Save/Cancel (shrink-0) in the same flex row, so they
+            can never overlap regardless of how narrow the action cluster is.
+            Two cases: a "component" row (name only) and a "subtest" row
+            (name + description). Ported from the production CoverageNodeRow
+            ("Categorieën & Dekking"). */}
+        <ListFrame>
+          {/* Component: edit the name, or delete — all inline, rounded fields. */}
+          <ListRow confirming={compDeleteConfirm}>
+            <InlineEditRow
+              isEditing={compEditing}
+              value={compName}
+              description={compDescription}
+              withDescription
+              namePlaceholder="Componentnaam"
+              descriptionPlaceholder="Korte omschrijving van het component"
+              saveLabel="Opslaan"
+              cancelLabel="Annuleren"
+              onSubmit={({ name, description }) => {
+                setCompName(name)
+                setCompDescription(description)
+                setCompEditing(false)
+              }}
+              onCancel={() => setCompEditing(false)}
+              actions={
+                <InlineDeleteConfirm
+                  isConfirming={compDeleteConfirm}
+                  isPending={false}
+                  label="Verwijderen"
+                  cancelLabel="Annuleren"
+                  onConfirm={() => setCompDeleteConfirm(false)}
+                  onCancel={() => setCompDeleteConfirm(false)}
+                >
+                  <RowActionGroup>
+                    <BorderedRowActionIconButton
+                      label="Bewerken"
+                      action="edit"
+                      onClick={() => {
+                        setCompDeleteConfirm(false)
+                        setCompEditing(true)
+                      }}
+                    />
+                    <BorderedRowActionIconButton
+                      label="Verwijderen"
+                      action="delete"
+                      onClick={() => {
+                        setCompEditing(false)
+                        setCompDeleteConfirm(true)
+                      }}
+                    />
+                  </RowActionGroup>
+                </InlineDeleteConfirm>
+              }
             />
-          )}
-        </div>
+          </ListRow>
+
+          {/* Subtest: edit the name AND the description (the second field). */}
+          <ListRow confirming={subDeleteConfirm}>
+            <InlineEditRow
+              isEditing={subEditing}
+              value={subName}
+              description={subDescription}
+              withDescription
+              namePlaceholder="Naam van de subtest"
+              descriptionPlaceholder="Wat controleert deze subtest?"
+              saveLabel="Opslaan"
+              cancelLabel="Annuleren"
+              onSubmit={({ name, description }) => {
+                setSubName(name)
+                setSubDescription(description)
+                setSubEditing(false)
+              }}
+              onCancel={() => setSubEditing(false)}
+              actions={
+                <InlineDeleteConfirm
+                  isConfirming={subDeleteConfirm}
+                  isPending={false}
+                  label="Verwijderen"
+                  cancelLabel="Annuleren"
+                  onConfirm={() => setSubDeleteConfirm(false)}
+                  onCancel={() => setSubDeleteConfirm(false)}
+                >
+                  <RowActionGroup>
+                    <BorderedRowActionIconButton
+                      label="Bewerken"
+                      action="edit"
+                      onClick={() => {
+                        setSubDeleteConfirm(false)
+                        setSubEditing(true)
+                      }}
+                    />
+                    <BorderedRowActionIconButton
+                      label="Verwijderen"
+                      action="delete"
+                      onClick={() => {
+                        setSubEditing(false)
+                        setSubDeleteConfirm(true)
+                      }}
+                    />
+                  </RowActionGroup>
+                </InlineDeleteConfirm>
+              }
+            />
+          </ListRow>
+        </ListFrame>
       </Section>
 
       <Section title="Feedback">

--- a/klai-portal/frontend/src/routes/dev/ui.tsx
+++ b/klai-portal/frontend/src/routes/dev/ui.tsx
@@ -138,7 +138,7 @@ function BorderedRowActionIconButton({
       action={action}
       tone={tone}
       className={[
-        'h-7 w-7 border [border-color:currentColor] bg-transparent [&_svg]:h-3.5 [&_svg]:w-3.5',
+        'h-7 w-7 border border-current bg-transparent [&_svg]:h-3.5 [&_svg]:w-3.5',
         className,
       ].filter(Boolean).join(' ')}
       {...props}

--- a/klai-portal/frontend/src/routes/dev/ui.tsx
+++ b/klai-portal/frontend/src/routes/dev/ui.tsx
@@ -7,12 +7,54 @@ import {
   Settings,
   Sparkles,
 } from 'lucide-react'
+import { toast } from 'sonner'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
 import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import { InlineDeleteConfirm } from '@/components/ui/inline-delete-confirm'
+import { InlineEdit } from '@/components/ui/inline-edit'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { MultiSelect } from '@/components/ui/multi-select'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { QueryErrorState } from '@/components/ui/query-error-state'
 import {
   ListFrame,
   ListRow,
@@ -29,6 +71,7 @@ import {
   type RowActionTone,
 } from '@/components/ui/row-action'
 import { Select } from '@/components/ui/select'
+import { StepIndicator } from '@/components/ui/step-indicator'
 import { Textarea } from '@/components/ui/textarea'
 
 export const Route = createFileRoute('/dev/ui')({
@@ -161,9 +204,25 @@ function Section({
   )
 }
 
+const wizardSteps = ['Details', 'Bron', 'Bevestigen']
+const tabItems = ['Details', 'Activiteit', 'Instellingen']
+const badgeVariants = ['default', 'secondary', 'accent', 'outline', 'success', 'warning', 'destructive'] as const
+const multiSelectOptions = [
+  { value: 'kb', label: 'Kennisbank' },
+  { value: 'chat', label: 'Chat' },
+  { value: 'connectors', label: 'Connectors' },
+  { value: 'widgets', label: 'Widgets' },
+]
+const commandItems = ['Kennisbank', 'Chat', 'Connectors', 'Widgets', 'Instellingen']
+
 function UiCatalogPage() {
   const [confirming, setConfirming] = useState(false)
   const [checked, setChecked] = useState(true)
+  const [wizardStep, setWizardStep] = useState(1)
+  const [activeTab, setActiveTab] = useState('Details')
+  const [multiValue, setMultiValue] = useState<string[]>(['kb'])
+  const [inlineEditing, setInlineEditing] = useState(false)
+  const [inlineValue, setInlineValue] = useState('Klai component')
 
   if (!import.meta.env.DEV) {
     return (
@@ -353,6 +412,57 @@ function UiCatalogPage() {
         </table>
       </Section>
 
+      <Section title="Wizard steps">
+        <div className="space-y-4">
+          <StepIndicator
+            steps={wizardSteps.map((label, i) => ({
+              label,
+              onClick: i < wizardStep ? () => setWizardStep(i) : undefined,
+            }))}
+            currentIndex={wizardStep}
+          />
+          <div className="flex gap-2">
+            <Button
+              variant="secondary"
+              size="sm"
+              disabled={wizardStep === 0}
+              onClick={() => setWizardStep((s) => Math.max(0, s - 1))}
+            >
+              Vorige
+            </Button>
+            <Button
+              size="sm"
+              disabled={wizardStep === wizardSteps.length - 1}
+              onClick={() => setWizardStep((s) => Math.min(wizardSteps.length - 1, s + 1))}
+            >
+              Volgende
+            </Button>
+          </div>
+        </div>
+      </Section>
+
+      <Section title="Tabs">
+        <div className="space-y-4">
+          <div className="flex gap-6 border-b border-gray-200">
+            {tabItems.map((tab) => (
+              <button
+                key={tab}
+                type="button"
+                onClick={() => setActiveTab(tab)}
+                className={
+                  activeTab === tab
+                    ? 'border-b-2 border-gray-900 pb-2 text-sm font-medium text-gray-900'
+                    : 'border-b-2 border-transparent pb-2 text-sm text-gray-400 hover:text-gray-900'
+                }
+              >
+                {tab}
+              </button>
+            ))}
+          </div>
+          <p className="text-sm text-gray-500">Actieve tab: {activeTab}</p>
+        </div>
+      </Section>
+
       <Section title="Form controls">
         <div className="grid gap-4 sm:grid-cols-2">
           <div className="space-y-1.5">
@@ -374,6 +484,152 @@ function UiCatalogPage() {
             <Checkbox checked={checked} onChange={(event) => setChecked(event.currentTarget.checked)} />
             Subtiele kleur voor herkenning
           </label>
+        </div>
+      </Section>
+
+      <Section title="Badges">
+        <div className="flex flex-wrap items-center gap-2">
+          {badgeVariants.map((variant) => (
+            <Badge key={variant} variant={variant}>
+              {variant}
+            </Badge>
+          ))}
+        </div>
+      </Section>
+
+      <Section title="Cards">
+        <Card className="max-w-sm">
+          <CardHeader>
+            <CardTitle>Kennisbank</CardTitle>
+            <CardDescription>Rustig omkaderd blok voor herhaalde items of stats.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-gray-500">12 bronnen, laatst gesynct 2 uur geleden.</p>
+          </CardContent>
+          <CardFooter>
+            <Button variant="secondary" size="sm">Openen</Button>
+          </CardFooter>
+        </Card>
+      </Section>
+
+      <Section title="Overlays and menus">
+        <div className="flex flex-wrap items-center gap-3">
+          <Dialog>
+            <DialogTrigger asChild>
+              <Button variant="secondary">Dialog</Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Voorbeeld dialog</DialogTitle>
+                <DialogDescription>Generieke modal voor een formulier of detail.</DialogDescription>
+              </DialogHeader>
+              <DialogFooter>
+                <Button>Opslaan</Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button variant="destructive">Alert dialog</Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Item verwijderen?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  Bevestiging voor een destructieve actie buiten een rij.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Annuleren</AlertDialogCancel>
+                <AlertDialogAction>Verwijderen</AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline">Dropdown menu</Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+              <DropdownMenuLabel>Acties</DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem>Bewerken</DropdownMenuItem>
+              <DropdownMenuItem>Dupliceren</DropdownMenuItem>
+              <DropdownMenuItem className="text-[var(--color-destructive)]">Verwijderen</DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button variant="ghost">Popover</Button>
+            </PopoverTrigger>
+            <PopoverContent>
+              <p className="text-sm text-gray-500">Zwevend paneel op een trigger.</p>
+            </PopoverContent>
+          </Popover>
+        </div>
+      </Section>
+
+      <Section title="Selection inputs">
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label>Multi-select</Label>
+            <MultiSelect options={multiSelectOptions} value={multiValue} onChange={setMultiValue} />
+          </div>
+          <div className="space-y-1.5">
+            <Label>Command</Label>
+            <Command className="rounded-md border border-gray-200">
+              <CommandInput placeholder="Zoeken..." />
+              <CommandList>
+                <CommandEmpty>Geen resultaten.</CommandEmpty>
+                <CommandGroup>
+                  {commandItems.map((item) => (
+                    <CommandItem key={item}>{item}</CommandItem>
+                  ))}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </div>
+        </div>
+      </Section>
+
+      <Section title="Inline edit">
+        <div className="flex items-center gap-3">
+          <InlineEdit
+            isEditing={inlineEditing}
+            value={inlineValue}
+            onValueChange={setInlineValue}
+            onSave={() => setInlineEditing(false)}
+            onCancel={() => setInlineEditing(false)}
+            inputClassName="text-sm font-medium"
+          >
+            <span className="text-sm font-medium text-gray-900">{inlineValue}</span>
+          </InlineEdit>
+          <RowActionIconButton
+            label="Naam bewerken"
+            action="edit"
+            onClick={() => setInlineEditing((v) => !v)}
+          />
+        </div>
+      </Section>
+
+      <Section title="Feedback">
+        <div className="space-y-4">
+          <div className="flex flex-wrap gap-2">
+            <Button variant="secondary" size="sm" onClick={() => toast.success('Opgeslagen')}>
+              Toast success
+            </Button>
+            <Button variant="secondary" size="sm" onClick={() => toast.error('Er ging iets mis')}>
+              Toast error
+            </Button>
+          </div>
+          <div className="rounded-md border border-gray-200">
+            <QueryErrorState
+              error={new Error('Kon de lijst niet laden.')}
+              onRetry={() => toast('Opnieuw proberen...')}
+            />
+          </div>
         </div>
       </Section>
     </main>

--- a/klai-portal/frontend/src/routes/dev/ui.tsx
+++ b/klai-portal/frontend/src/routes/dev/ui.tsx
@@ -197,7 +197,7 @@ function Section({
   children: ReactNode
 }) {
   return (
-    <section className="space-y-4">
+    <section className="space-y-4 py-10 first:pt-0 last:pb-0">
       <h2 className="text-sm font-semibold text-gray-900">{title}</h2>
       {children}
     </section>
@@ -243,6 +243,7 @@ function UiCatalogPage() {
         </p>
       </div>
 
+      <div className="divide-y divide-gray-200">
       <Section title="Buttons">
         <div className="flex flex-wrap items-center gap-3">
           <Button>Default</Button>
@@ -632,6 +633,7 @@ function UiCatalogPage() {
           </div>
         </div>
       </Section>
+      </div>
     </main>
   )
 }

--- a/klai-portal/frontend/src/routes/dev/ui.tsx
+++ b/klai-portal/frontend/src/routes/dev/ui.tsx
@@ -1,0 +1,381 @@
+import { createFileRoute } from '@tanstack/react-router'
+import type { ComponentProps, ReactNode } from 'react'
+import { useState } from 'react'
+import {
+  FileText,
+  Loader2,
+  Settings,
+  Sparkles,
+} from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import { InlineDeleteConfirm } from '@/components/ui/inline-delete-confirm'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  ListFrame,
+  ListRow,
+  ListRowActions,
+  ListRowContent,
+  ListRowDescription,
+  ListRowTitle,
+} from '@/components/ui/list'
+import {
+  RowActionButton,
+  RowActionGroup,
+  RowActionIconButton,
+  type RowActionKind,
+  type RowActionTone,
+} from '@/components/ui/row-action'
+import { Select } from '@/components/ui/select'
+import { Textarea } from '@/components/ui/textarea'
+
+export const Route = createFileRoute('/dev/ui')({
+  component: UiCatalogPage,
+})
+
+const actionKinds: RowActionKind[] = [
+  'add',
+  'edit',
+  'rename',
+  'configure',
+  'open',
+  'external',
+  'sync',
+  'retry',
+  'copy',
+  'reauth',
+  'send',
+  'view',
+  'download',
+  'upload',
+  'search',
+  'save',
+  'delete',
+  'stop',
+  'cancel',
+  'more',
+  'expand',
+  'collapse',
+  'suspend',
+  'reactivate',
+  'leave',
+  'offboard',
+  'info',
+]
+
+const tones: RowActionTone[] = ['neutral', 'primary', 'info', 'success', 'warning', 'danger']
+
+const toneSampleActions: Record<RowActionTone, RowActionKind> = {
+  neutral: 'edit',
+  primary: 'save',
+  info: 'info',
+  success: 'sync',
+  warning: 'suspend',
+  danger: 'delete',
+}
+
+const actionColorSemantics: Array<{
+  tone: RowActionTone
+  label: string
+  meaning: string
+  examples: string
+  swatchClassName: string
+}> = [
+  {
+    tone: 'neutral',
+    label: 'Neutral',
+    meaning: 'Utility, navigation and low-risk changes',
+    examples: 'edit, rename, configure, view, copy, more',
+    swatchClassName: 'bg-gray-500',
+  },
+  {
+    tone: 'primary',
+    label: 'Primary',
+    meaning: 'Primary create, submit or send action',
+    examples: 'add, send',
+    swatchClassName: 'bg-[var(--color-primary)]',
+  },
+  {
+    tone: 'info',
+    label: 'Information',
+    meaning: 'Information, progress or system context',
+    examples: 'info',
+    swatchClassName: 'bg-[var(--color-info)]',
+  },
+  {
+    tone: 'success',
+    label: 'Success',
+    meaning: 'Positive status change or recovery',
+    examples: 'save, sync, reactivate',
+    swatchClassName: 'bg-[var(--color-success)]',
+  },
+  {
+    tone: 'warning',
+    label: 'Warning',
+    meaning: 'Caution, security attention or risky reversible action',
+    examples: 'suspend, retry',
+    swatchClassName: 'bg-[var(--color-warning)]',
+  },
+  {
+    tone: 'danger',
+    label: 'Danger',
+    meaning: 'Destructive or high-impact action',
+    examples: 'delete, stop, leave, offboard',
+    swatchClassName: 'bg-[var(--color-destructive)]',
+  },
+]
+
+function BorderedRowActionIconButton({
+  action,
+  tone,
+  className,
+  ...props
+}: ComponentProps<typeof RowActionIconButton>) {
+  return (
+    <RowActionIconButton
+      action={action}
+      tone={tone}
+      className={[
+        'h-7 w-7 border [border-color:currentColor] bg-transparent [&_svg]:h-3.5 [&_svg]:w-3.5',
+        className,
+      ].filter(Boolean).join(' ')}
+      {...props}
+    />
+  )
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string
+  children: ReactNode
+}) {
+  return (
+    <section className="space-y-4">
+      <h2 className="text-sm font-semibold text-gray-900">{title}</h2>
+      {children}
+    </section>
+  )
+}
+
+function UiCatalogPage() {
+  const [confirming, setConfirming] = useState(false)
+  const [checked, setChecked] = useState(true)
+
+  if (!import.meta.env.DEV) {
+    return (
+      <div className="mx-auto max-w-3xl px-6 py-10">
+        <p className="text-sm text-gray-400">UI catalog is alleen lokaal beschikbaar.</p>
+      </div>
+    )
+  }
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-10 space-y-10">
+      <div className="space-y-1">
+        <h1 className="page-title text-[26px] font-display-bold text-gray-900">
+          UI catalog
+        </h1>
+        <p className="text-sm text-gray-400">
+          Lokale referentie voor list rows, row actions en basiscomponenten.
+        </p>
+      </div>
+
+      <Section title="Buttons">
+        <div className="flex flex-wrap items-center gap-3">
+          <Button>Default</Button>
+          <Button variant="secondary">Secondary</Button>
+          <Button variant="ghost">Ghost</Button>
+          <Button variant="outline">Outline</Button>
+          <Button variant="destructive">Destructive</Button>
+          <Button size="sm">
+            <Sparkles />
+            Small
+          </Button>
+          <Button size="icon" aria-label="Icon button">
+            <Settings />
+          </Button>
+        </div>
+      </Section>
+
+      <Section title="Action color semantics">
+        <div className="divide-y divide-gray-200 border-y border-gray-200">
+          {actionColorSemantics.map((item) => (
+            <div key={item.tone} className="grid gap-3 px-2 py-3 sm:grid-cols-[160px_1fr_180px] sm:items-center">
+              <div className="flex items-center gap-2">
+                <span className={`h-2.5 w-2.5 rounded-full ${item.swatchClassName}`} />
+                <RowActionIconButton
+                  label={`${item.label} action`}
+                  action={toneSampleActions[item.tone]}
+                  tone={item.tone}
+                  tooltip={false}
+                  className="h-7 w-7 [&_svg]:h-3.5 [&_svg]:w-3.5"
+                />
+                <span className="text-sm font-medium text-gray-900">{item.label}</span>
+              </div>
+              <p className="text-sm text-gray-500">{item.meaning}</p>
+              <p className="text-xs text-gray-400 sm:text-right">{item.examples}</p>
+            </div>
+          ))}
+        </div>
+      </Section>
+
+      <Section title="Row actions">
+        <div className="space-y-4">
+          <RowActionGroup className="justify-start">
+            {tones.map((tone) => (
+              <RowActionIconButton
+                key={tone}
+                label={`${tone} action`}
+                action={toneSampleActions[tone]}
+                tone={tone}
+              />
+            ))}
+            <RowActionIconButton
+              label="Loading action"
+              action="sync"
+              disabled
+              spinner={<Loader2 className="animate-spin" />}
+            />
+          </RowActionGroup>
+
+          <div className="flex flex-wrap gap-2">
+            {actionKinds.map((action) => (
+              <div key={action} className="flex items-center gap-1 rounded-md border border-gray-200 px-2 py-1">
+                <RowActionIconButton label={action} action={action} />
+                <span className="text-xs text-gray-400">{action}</span>
+              </div>
+            ))}
+          </div>
+
+          <RowActionGroup className="justify-start flex-wrap">
+            <RowActionButton label="Re-authenticate" action="reauth">
+              Re-authenticate
+            </RowActionButton>
+            <RowActionButton label="Save changes" action="save">
+              Save changes
+            </RowActionButton>
+            <RowActionButton label="Remove item" action="delete">
+              Remove item
+            </RowActionButton>
+          </RowActionGroup>
+        </div>
+      </Section>
+
+      <Section title="Divider lists">
+        <ListFrame>
+          <ListRow interactive>
+            <ListRowContent>
+              <div className="flex items-center gap-2">
+                <ListRowTitle className="text-sm font-sans font-medium">Kennisbank bronnen</ListRowTitle>
+                <Badge variant="secondary">12 bronnen</Badge>
+              </div>
+              <ListRowDescription>Rustige lijst met links padding en compacte acties.</ListRowDescription>
+            </ListRowContent>
+            <ListRowActions className="self-center">
+              <BorderedRowActionIconButton label="Bewerken" action="edit" />
+              <BorderedRowActionIconButton label="Openen" action="open" />
+              <BorderedRowActionIconButton label="Verwijderen" action="delete" />
+            </ListRowActions>
+          </ListRow>
+
+          <ListRow interactive>
+            <ListRowContent>
+              <div className="flex items-center gap-2">
+                <ListRowTitle className="text-sm font-sans font-medium">Persoonlijke kennis</ListRowTitle>
+                <Badge variant="success">Gesynct</Badge>
+              </div>
+              <ListRowDescription>Meta-informatie blijft subtiel en truncatet op een regel.</ListRowDescription>
+            </ListRowContent>
+            <ListRowActions className="self-center">
+              <BorderedRowActionIconButton label="Synchroniseren" action="sync" />
+              <BorderedRowActionIconButton label="Configureren" action="configure" />
+              <BorderedRowActionIconButton label="Meer acties" action="more" />
+            </ListRowActions>
+          </ListRow>
+
+          <ListRow confirming={confirming}>
+            <ListRowContent>
+              <div className="flex items-center gap-2">
+                <FileText className="h-4 w-4 shrink-0 text-gray-400" />
+                <ListRowTitle className="text-sm font-sans font-medium">Inline delete confirm</ListRowTitle>
+              </div>
+              <ListRowDescription>De overlay houdt dezelfde action-cell breedte.</ListRowDescription>
+            </ListRowContent>
+            <ListRowActions className="self-center">
+              <InlineDeleteConfirm
+                isConfirming={confirming}
+                isPending={false}
+                label="Verwijderen"
+                cancelLabel="Annuleren"
+                onConfirm={() => setConfirming(false)}
+                onCancel={() => setConfirming(false)}
+              >
+                <RowActionGroup>
+                  <BorderedRowActionIconButton label="Bewerken" action="edit" />
+                  <BorderedRowActionIconButton label="Verwijderen" action="delete" onClick={() => setConfirming(true)} />
+                </RowActionGroup>
+              </InlineDeleteConfirm>
+            </ListRowActions>
+          </ListRow>
+        </ListFrame>
+      </Section>
+
+      <Section title="Table spacing">
+        <table className="w-full border-y border-gray-200 text-sm">
+          <thead>
+            <tr className="border-b border-gray-200">
+              <th className="px-2 py-3 text-left text-xs font-medium text-gray-400">Naam</th>
+              <th className="px-2 py-3 text-left text-xs font-medium text-gray-400">Status</th>
+              <th className="px-2 py-3 text-right text-xs font-medium text-gray-400">Acties</th>
+            </tr>
+          </thead>
+          <tbody>
+            {['Admin users', 'Widgets', 'Sources'].map((name) => (
+              <tr key={name} className="border-b border-gray-200 last:border-b-0 klai-hover">
+                <td className="px-2 py-4 font-medium text-gray-900">{name}</td>
+                <td className="px-2 py-4">
+                  <Badge variant="secondary">Actief</Badge>
+                </td>
+                <td className="px-2 py-4">
+                  <RowActionGroup>
+                    <BorderedRowActionIconButton label="Bewerken" action="edit" />
+                    <BorderedRowActionIconButton label="Verwijderen" action="delete" />
+                    <BorderedRowActionIconButton label="Meer acties" action="more" />
+                  </RowActionGroup>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </Section>
+
+      <Section title="Form controls">
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="catalog-name">Naam</Label>
+            <Input id="catalog-name" defaultValue="Klai component" />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="catalog-type">Type</Label>
+            <Select id="catalog-type" defaultValue="list">
+              <option value="list">List</option>
+              <option value="table">Table</option>
+            </Select>
+          </div>
+          <div className="space-y-1.5 sm:col-span-2">
+            <Label htmlFor="catalog-description">Beschrijving</Label>
+            <Textarea id="catalog-description" defaultValue="Compacte portal UI met rustige padding." />
+          </div>
+          <label className="flex items-center gap-2 text-sm text-gray-900">
+            <Checkbox checked={checked} onChange={(event) => setChecked(event.currentTarget.checked)} />
+            Subtiele kleur voor herkenning
+          </label>
+        </div>
+      </Section>
+    </main>
+  )
+}

--- a/klai-portal/frontend/src/routes/dev/ui.tsx
+++ b/klai-portal/frontend/src/routes/dev/ui.tsx
@@ -2,10 +2,14 @@ import { createFileRoute } from '@tanstack/react-router'
 import type { ComponentProps, ReactNode } from 'react'
 import { useState } from 'react'
 import {
+  Check,
   FileText,
   Loader2,
+  MessageSquare,
+  Mic,
   Settings,
   Sparkles,
+  X,
 } from 'lucide-react'
 import { toast } from 'sonner'
 import {
@@ -59,10 +63,13 @@ import {
   ListFrame,
   ListRow,
   ListRowActions,
+  ListRowChevron,
   ListRowContent,
   ListRowDescription,
+  ListRowIcon,
   ListRowTitle,
 } from '@/components/ui/list'
+import { RadioCardGroup } from '@/components/ui/radio-card-group'
 import {
   RowActionButton,
   RowActionGroup,
@@ -70,6 +77,7 @@ import {
   type RowActionKind,
   type RowActionTone,
 } from '@/components/ui/row-action'
+import { SearchInput } from '@/components/ui/search-input'
 import { Select } from '@/components/ui/select'
 import { StepIndicator } from '@/components/ui/step-indicator'
 import { Textarea } from '@/components/ui/textarea'
@@ -206,7 +214,17 @@ function Section({
 
 const wizardSteps = ['Details', 'Bron', 'Bevestigen']
 const tabItems = ['Details', 'Activiteit', 'Instellingen']
-const badgeVariants = ['default', 'secondary', 'accent', 'outline', 'success', 'warning', 'destructive'] as const
+const badgeVariants = ['default', 'secondary', 'accent', 'outline', 'info', 'success', 'warning', 'destructive'] as const
+const navListItems = [
+  { icon: MessageSquare, title: 'Chat', description: 'Privé AI-gesprekken op Europese servers' },
+  { icon: Settings, title: 'Instructies', description: 'Beheer instructies die je in chats kunt aanzetten.' },
+  { icon: Mic, title: 'Scribe', description: 'Audio, video en vergaderingen omzetten naar tekst' },
+]
+const radioCardOptions = [
+  { value: 'personal', label: 'Persoonlijke chat', description: 'Privé-kennis: upload documenten en chat met je eigen kennisbank.' },
+  { value: 'company', label: 'Bedrijfschat', description: 'Alles van Persoonlijke chat, plus toegang tot bedrijfskennis.' },
+  { value: 'manager', label: 'Kennisbeheerder', description: 'Beheer connectoren en bedrijfskennisbanken.' },
+]
 const multiSelectOptions = [
   { value: 'kb', label: 'Kennisbank' },
   { value: 'chat', label: 'Chat' },
@@ -223,6 +241,8 @@ function UiCatalogPage() {
   const [multiValue, setMultiValue] = useState<string[]>(['kb'])
   const [inlineEditing, setInlineEditing] = useState(false)
   const [inlineValue, setInlineValue] = useState('Klai component')
+  const [searchValue, setSearchValue] = useState('')
+  const [radioValue, setRadioValue] = useState('personal')
 
   if (!import.meta.env.DEV) {
     return (
@@ -384,6 +404,25 @@ function UiCatalogPage() {
         </ListFrame>
       </Section>
 
+      <Section title="Navigation list">
+        <ListFrame>
+          {navListItems.map((item) => (
+            <ListRow key={item.title} asChild interactive>
+              <a href="#">
+                <ListRowIcon>
+                  <item.icon className="h-4 w-4" />
+                </ListRowIcon>
+                <ListRowContent>
+                  <ListRowTitle>{item.title}</ListRowTitle>
+                  <ListRowDescription>{item.description}</ListRowDescription>
+                </ListRowContent>
+                <ListRowChevron />
+              </a>
+            </ListRow>
+          ))}
+        </ListFrame>
+      </Section>
+
       <Section title="Table spacing">
         <table className="w-full border-y border-gray-200 text-sm">
           <thead>
@@ -476,6 +515,15 @@ function UiCatalogPage() {
               <option value="list">List</option>
               <option value="table">Table</option>
             </Select>
+          </div>
+          <div className="space-y-1.5 sm:col-span-2">
+            <Label htmlFor="catalog-search">Zoeken</Label>
+            <SearchInput
+              id="catalog-search"
+              value={searchValue}
+              onChange={(e) => setSearchValue(e.target.value)}
+              placeholder="Zoek kennisbanken..."
+            />
           </div>
           <div className="space-y-1.5 sm:col-span-2">
             <Label htmlFor="catalog-description">Beschrijving</Label>
@@ -595,6 +643,16 @@ function UiCatalogPage() {
         </div>
       </Section>
 
+      <Section title="Radio cards">
+        <RadioCardGroup
+          options={radioCardOptions}
+          value={radioValue}
+          onChange={setRadioValue}
+          aria-label="Profiel"
+          className="max-w-md"
+        />
+      </Section>
+
       <Section title="Inline edit">
         <div className="flex items-center gap-3">
           <InlineEdit
@@ -607,11 +665,33 @@ function UiCatalogPage() {
           >
             <span className="text-sm font-medium text-gray-900">{inlineValue}</span>
           </InlineEdit>
-          <RowActionIconButton
-            label="Naam bewerken"
-            action="edit"
-            onClick={() => setInlineEditing((v) => !v)}
-          />
+          {inlineEditing ? (
+            <div className="flex items-center gap-1 whitespace-nowrap">
+              <Button
+                size="sm"
+                className="h-6 gap-1 px-2 text-[10px] [&_svg]:size-2.5 bg-[var(--color-success)] text-white hover:opacity-70"
+                onClick={() => setInlineEditing(false)}
+              >
+                <Check />
+                Opslaan
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-6 gap-1 px-2 text-[10px] [&_svg]:size-2.5"
+                onClick={() => setInlineEditing(false)}
+              >
+                <X />
+                Annuleren
+              </Button>
+            </div>
+          ) : (
+            <BorderedRowActionIconButton
+              label="Naam bewerken"
+              action="edit"
+              onClick={() => setInlineEditing(true)}
+            />
+          )}
         </div>
       </Section>
 


### PR DESCRIPTION
## Summary
- change the shared portal hover and active list state to a near-white lift
- show the active navigation-list state in the local UI catalog without a side indicator
- add the InlineEditRow catalog primitive for inline edit/delete row examples

## Validation
- npm run lint -- src/routes/dev/ui.tsx
- git diff --check